### PR TITLE
docs(2387): land the VRF session-identity decision record; correct the HA-wire cost claim

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -62122,3 +62122,54 @@ break — `go vet` confirmed passing under every revert.
   22.7 Gbps) and needs no re-run for a comment-only change.
 - **File(s)**: pkg/cluster/{election.go,ifmon_weight_daemon_apply_6549_test.go},
     pkg/routing/monitor.go, _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #2387 — land the VRF session-identity decision record on master,
+  correct the shipped README's superseded "HA wire bump" cost claim, and add a
+  guard binding both to the code they describe.
+  `userspace-dp/src/afxdp/forwarding/README.md` documents the #2387
+  single-forwarding-domain session-identity limitation and cites
+  `docs/research/2387-vrf-flow-identity/plan.md` as the decision record for the
+  deferred real fix. That plan lived ONLY on the unmerged
+  `research/2387-vrf-flow-identity` branch, so the shipped citation dangled —
+  the exact failure `pkg/api/zone_counter_doc_ref_test.go` was written to
+  prevent after it happened once for #3643.
+  Landed the plan plus its six reviewer files, and added a v5 §0 addendum
+  recording three first-hand findings that change the deferral calculus:
+  (0a) plan §4d is WRONG that Track B needs an HA wire break — §4d is right
+  that the wire KEY block is fixed-width, but the routing-domain does not have
+  to live there. It rides as a length-gated trailing VALUE field exactly like
+  #2170 Generation / #3301 AppTimeout+PolicyCounterIdx / #4565 Nat64SnatV4 /
+  #5274 ConfigEpoch / #5212 RTFlowSessionID, and the repo states the rule at
+  sync_protocol.go:930 ("does NOT bump SessionSyncWireVersion"); interning
+  domain 0 = the default routing-instance makes a legacy peer's omitted field
+  decode to the default VRF, so CurrentHAProtocolVersion never moves and the
+  #1930 mixed-base ISSU gate is never tripped. This was plan §11 Q5, called
+  there "the single biggest lever on B-min's cost".
+  (0b) "decline the cross-domain hit and fall through to the session-miss path"
+  is NOT a viable cheap middle: install_with_protocol_with_origin opens with an
+  unconditional remove_entry(&key) (session/install.rs:139), so two colliding
+  flows would evict each other per packet (per-packet SNAT re-allocation breaks
+  both). Only DENY (fail-closed drop) and ISOLATE (widened identity) are
+  coherent end-states.
+  (0c) corner inventory the plan lacked: GRE decap is SAFE (gre.rs:760 rebinds
+  the inner ingress_ifindex to the tunnel logical ifindex, so a decapped flow's
+  domain is stable); fabric ingress needs an explicit exemption; the §7
+  inter-VRF route-leaked corner is CHEAP if the ingress+egress domain live in
+  SessionMetadata (which already stores and swaps the zone pair) rather than in
+  the key.
+  Also recorded that Track A is COMPLETE (A.1 #4327, A.2 42bc6bc88, A.3 docs),
+  so the conntrack table is now the SOLE collision surface, and narrowed the
+  open maintainer question from "is overlapping-subnet VRF in scope" to the
+  single binary DENY-vs-ISOLATE choice.
+  No dataplane behaviour change — the #2387 bug itself is untouched and the
+  issue stays open pending that call.
+  Validation: new `userspace-dp/tests/vrf_session_identity_doc_guard.rs` (2
+  tests) green under `cargo test --release`; RED-on-revert proven by mutation in
+  a throwaway detached worktree (see review notes) with the crate still building
+  clean; `cargo fmt --check` and `cargo clippy` clean on the touched test.
+- **File(s)**: docs/research/2387-vrf-flow-identity/{plan.md,agy-plan-r1.md,
+    agy-plan-r2.md,claude-smr-plan-r1.md,claude-smr-plan-r2.md,codex-plan-r1.md,
+    codex-plan-r2.md,reviewer-ids.md},
+    userspace-dp/src/afxdp/forwarding/README.md,
+    userspace-dp/tests/vrf_session_identity_doc_guard.rs, _Log.md

--- a/docs/research/2387-vrf-flow-identity/agy-plan-r1.md
+++ b/docs/research/2387-vrf-flow-identity/agy-plan-r1.md
@@ -1,0 +1,56 @@
+# AGY — adversarial plan review r1 (#2387)
+
+Job `adversarial-review-mr0wcll0-pk94mc`, reviewed plan v1. Verbatim verdict:
+
+---
+
+**Verdict: PLAN-NEEDS-MAJOR-REVISION**
+
+**1. Attack 1: Refuting the Latency Claim (PBR Routing is Fully Functional Today)**
+
+The headline PLAN-DEFER relies on the premise that the collision is latent because
+the forwarding layer cannot isolate VRFs anyway (global `inet.0` + global local
+sets). This premise is incorrect. Under PBR `then routing-instance`, the slow-path
+forwarding layer is fully table-scoped and correctly isolated today:
+`ingress_route_table_override` returns the overridden table
+(`forwarding/mod.rs:1211-1289`); `lookup_forwarding_resolution_v4` is strictly
+table-scoped for static and connected routes (`forwarding/mod.rs:1494-1550`). For
+transit traffic packets never hit the global `local_v4` check. So two routing
+instances reusing a subnet and forwarding transit (differentiated by ingress port
++ PBR table) work correctly on the slow path. But the conntrack lookup
+`lookup_session_across_scopes` (`shared_ops.rs:563-605`) queries by only the bare
+5-tuple `SessionKey` (`session/key.rs:9-17`), so the second flow matches the first
+flow's session and the fast path returns the first flow's cached `SessionDecision`,
+cross-forwarding to the wrong egress. This is a LIVE, active bug today for anyone
+deploying overlapping subnets with PBR-based routing instances. Not latent.
+
+**2. Attack 2: Validating the HA-Wire Hard Break** — §4d is CORRECT. Widening
+`SessionKey` is a hard HA wire break. `encodeSessionV4Payload`
+(`sync_protocol.go:80-171`) serializes the primary key at bytes 0-15 then value
+fields from offset 16; the `ReverseKey` is embedded in the value at offset 136
+(`:136-145`). `decodeSessionV4Payload` (`:315-425`) assumes a fixed 16-byte key at
+offset 0 and reads value fields at fixed offsets. Widening the key shifts every
+subsequent field; an old peer reads wrong bytes → deserialization corruption. Not
+length-gated in a backward-compatible way.
+
+**3. Attack 3: Symmetry of the Discriminator and Inter-VRF Route Leaking** — §7 is
+CORRECT. Reply matching relies on `reverse_wire_key`/`reverse_canonical_key`
+(`session/key.rs:84-138`). Ingress ifindex and ingress zone are asymmetric (reply
+enters on the forward egress). Routing-domain id is symmetric for intra-VRF flows.
+The inter-VRF route-leaked corner is real: a packet leaked VRF-A→VRF-B has forward
+ingress domain VRF-A but reply ingress domain VRF-B; a simple routing-domain id in
+the key breaks reply matching for leaked flows. Track B must store both ingress and
+egress domains or exempt leaked flows.
+
+**4. Attack 4: The Commit-Time Overlap Guard (Track A.1) False Rejections** — Track
+A.1 falsely rejects legitimate, working configurations. Users can legitimately
+reuse subnets across distinct routing-instances via PBR table override + forwarding
+isolation — standard VRF design. A.1 would reject this at compile time to work
+around a fast-path bug, stripping multi-tenant overlapping-subnet support.
+
+**5. Attack 5: Phase Ordering Critique** — the assertion that B-P2 (key widening)
+before B-P1 (per-VRF FIB) is a dead-end is incorrect. PBR table overrides already
+handle table-scoped forwarding on the slow path, so doing B-P2 first would
+immediately resolve fast-path session collisions for PBR-based VRF configs —
+functioning VRF isolation on the fast path without waiting for the larger per-VRF
+default FIB. Phase ordering should prioritize key widening + PBR support.

--- a/docs/research/2387-vrf-flow-identity/agy-plan-r2.md
+++ b/docs/research/2387-vrf-flow-identity/agy-plan-r2.md
@@ -1,0 +1,39 @@
+# AGY — adversarial plan review r2 (convergence) (#2387)
+
+Job `adversarial-review-mr0wp66c-c5nu8h`, reviewed plan v3. Verbatim verdict:
+
+---
+
+**Verdict: PLAN-DEFER**
+
+Round 2 adversarial review of revised plan v3; verified all four findings from
+Round 1.
+
+1. **Attack 1 (PBR makes collision LIVE):** Confirmed the execution order in
+   `poll_descriptor/mod.rs:474` and `poll_descriptor/mod.rs:1208`.
+   `resolve_flow_session_decision` runs before PBR resolution, confirming that
+   identical 5-tuples in VRF-B cache-hit VRF-A's established session.
+2. **Attack 4 (Warning posture):** Verified that softening A.1 to a commit warning
+   avoids breaking legitimate multi-tenant configs where subnets overlap.
+3. **Attack 5 (Separation of B-min and B-ext):** Confirmed that Track B-min
+   (widening key and interning routing-instance names via the dead
+   `meta.routing_table` slot) functions correctly as a minimal fix on PBR
+   configurations without needing the per-VRF default FIB (Track B-ext).
+4. **HA-wire & Route Leaking Invariants:** Verified that the Go sync protocol at
+   `sync_protocol.go:136-145` serializes keys inline, making key widening a hard
+   break requiring a bump of `CurrentHAProtocolVersion` (`heartbeat.go:31`).
+   Checked route recursion at `forwarding/mod.rs:1579-1604` and confirmed that
+   scoping leaked flows to domain-0 in B-min is necessary to avoid reply matching
+   failures.
+
+**We agree with the PLAN-DEFER verdict.** The bug is real and reachable under PBR,
+but resolving it requires a product-level scope decision and introduces a breaking
+change to the HA wire sync format.
+
+Key open decisions for maintainer input:
+1. **Product Scope (§11 Q1):** Do we officially support overlapping-subnet VRFs via
+   PBR? AGY recommends **Option (a)**: support it, ship the Track A.1 warning + A.3
+   docs now, and schedule Track B-min for future implementation.
+2. **Leaked Flow Scoping (§11 Q4):** Confirm that scoping leaked inter-VRF flows to
+   domain-0 is acceptable for the first iteration (B-min) to avoid immediate
+   conntrack reply matching failures.

--- a/docs/research/2387-vrf-flow-identity/claude-smr-plan-r1.md
+++ b/docs/research/2387-vrf-flow-identity/claude-smr-plan-r1.md
@@ -1,0 +1,113 @@
+# Claude SMR — hostile plan review r1 (#2387)
+
+**Reviewing:** `docs/research/2387-vrf-flow-identity/plan.md` v1 @ `c88ff7850`
+**Posture:** HOSTILE. Goal: break the plan's central claim.
+**Verdict:** **PLAN-NEEDS-REVISION** → then PLAN-DEFER (the recommendation
+survives, but the severity framing in §3/§4b is materially wrong and must be
+corrected before convergence).
+
+---
+
+## SHOWSTOPPER S1 — the "unreachable in a forwarding-correct config" claim is FALSE (PBR counterexample)
+
+The plan's load-bearing argument (§3, §4b, §8 PLAN-KILL line) is: the collision
+is latent because the overlapping-subnet trigger "does not forward correctly
+today irrespective of the session key." That is **only true for the default
+(non-PBR) forwarding mode.** It is **false** once PBR `then routing-instance` is
+in play — which is exactly the mechanism the plan itself cites as the "sole
+per-packet table override."
+
+Concrete reachable counterexample, verified against source:
+
+- Two ingress interfaces in two routing-instances, **overlapping client
+  addressing** (e.g. both tenants use `10.0.0.0/24`), each with an interface
+  filter `then routing-instance <ri>` so the destination lookup is steered to
+  the per-VRF table (`foo.inet.0` / `bar.inet.0`). Per-VRF forwarding now
+  **works** — `ingress_route_table_override` returns the per-VRF table
+  (`forwarding/mod.rs:1211`) and the session-miss resolution honors it
+  (`poll_descriptor/mod.rs:1208-1216` → `:1244-1248`).
+- **Ordering proof (the kill shot):** the established-session lookup
+  `resolve_flow_session_decision` runs at `poll_descriptor/mod.rs:474` and
+  short-circuits *before* the PBR override + route resolution at `:1208-1248`
+  (comment at `:503` confirms it "never runs policy"). The session lookup uses
+  the bare 5-tuple (`flow.forward_key`, `shared_ops.rs:563-599`).
+- So: flow 1 (VRF-A) creates a session caching egress-A. Flow 2 (VRF-B), **same
+  5-tuple**, hits flow 1's conntrack session at line 474 and is handed flow 1's
+  cached decision (egress-A, VRF-A's NAT, VRF-A's policy verdict) — its **own**
+  PBR/route/policy is never evaluated. Result: wrong-VRF forwarding + wrong NAT
+  + wrong policy on flow 2. The flow-cache `(SessionKey, physical_ifindex)`
+  discriminator does **not** save it: even on a different physical port, flow 2
+  misses the flow cache but still hits the ifindex-less conntrack table.
+
+This is a **real, reachable, forwarding-correct-config** correctness/isolation
+breach — it is precisely #2387's multi-tenant overlapping-address scenario. The
+bug is therefore **"latent in default mode, LIVE (if niche) in PBR-steered
+overlapping-address multi-VRF mode,"** not purely defensive. The plan must say
+so. (This also retroactively corrects the prior campaign-8 comment, which made
+the same too-strong "doesn't forward correctly today" claim.)
+
+**Impact on recommendation:** PLAN-DEFER still stands (the *complete* fix is
+still Track B; the literal key-widening is still the last phase), but:
+- §3/§4b must be rewritten from "unreachable" to "reachable via PBR; latent only
+  in default forwarding mode."
+- Track A.1's justification flips: it is no longer "reject a config that doesn't
+  forward anyway" but "**reject a config that DOES forward (via PBR) but whose
+  flows we cannot isolate at the session layer** — fail-closed until Track B."
+  That is a stronger, more honest fail-closed posture, and it means A.1 must
+  reject the overlap **even when** a PBR filter is present (Q4 in the plan asked
+  whether A.1 falsely rejects working PBR configs — the answer is it must reject
+  them *deliberately*, because "works" ≠ "isolated").
+- The "PLAN-KILL acceptable if unreachable" line is no longer satisfied on the
+  unreachability prong; PLAN-KILL would now rest only on "churn outweighs the
+  win for a niche config," which is a weaker basis. PLAN-DEFER is the honest
+  verdict.
+
+## M1 — A.2 (flow-cache logical-ifindex key) is a near-no-op for this issue; don't oversell it
+
+Given S1, the conntrack table (no ifindex) is the authoritative collision
+surface; the flow cache already carries the physical ifindex and still doesn't
+prevent the cross-VRF hit. A.2 only stops same-parent-VLAN flow-cache reuse and
+does nothing for the conntrack-level breach. Keep A.2 as a tidy-up
+(logical-ifindex SSOT alignment per #2370/#3021) but stop implying it materially
+mitigates #2387. Re-rank it below A.1 and A.3.
+
+## M2 — Track B-P2 "+4 bytes" is optimistic given the dead `meta.routing_table`
+
+§4e established `routing_table` is dead/always-0. B-P0 can reuse that slot for a
+domain id with **no `UserspaceDpMeta` size change** (good). But the plan should
+state explicitly that the domain id must be a *dense interned u32* (not the
+RI-name hash) so the per-packet key hash cost is a single added u32, and that the
+SessionKey grows by 4 bytes only (not 8). Tighten §5 B-P0 wording.
+
+## m3 — inter-VRF route-leaked reverse-match corner (§7) needs a concrete config path or an explicit "out of scope for B-MVP"
+
+§7 flags that next-table/rib-group leaked flows make the routing-domain id
+asymmetric. The plan should either (a) cite the rib-group/next-table config that
+produces it (`pkg/routing/`) and require storing both ingress+egress domain, or
+(b) explicitly scope leaked flows OUT of B-MVP with a documented
+known-limitation. Leaving it as prose invites an engineer to ship B-P2 and
+silently regress leaked-flow conntrack.
+
+## What the plan gets RIGHT (verified, not rubber-stamped)
+
+- §4a bare-5-tuple key + map inventory: confirmed against `key.rs:9-17`,
+  `session_manager.rs:13-15`, `session/mod.rs:453-457`.
+- §4c #3096 coherence gap: confirmed — NAT scope is computed at create
+  (`nat_scope_ctx_for_flow`, `forwarding/mod.rs:120-145`) and the established
+  path reuses the cached decision without re-checking it
+  (`session_glue/mod.rs:1004-1044`). Real and well-stated.
+- §4d HA-wire hard-break: confirmed against `sync_protocol.go` (key portion
+  fixed-layout, reverse-key embedded in the value, only value-trailing
+  length-gated). This is a genuine correction of campaign-8 and the strongest
+  cost argument for deferring the key widening.
+- §7 symmetric-discriminator-only argument (zone/ingress-ifindex asymmetric
+  across forward/reply via `reverse_wire_key`/`reverse_canonical_key`): correct
+  and is the key design insight that kills the issue's "and/or zone" suggestion.
+
+## Required for r2
+
+1. Rewrite §3/§4b: "reachable via PBR, latent in default mode" (S1).
+2. Reframe A.1 as deliberate fail-closed reject of overlap even with PBR (S1/Q4).
+3. Demote A.2; correct its scope (M1).
+4. Tighten B-P0 to dense-interned-u32 / +4B (M2).
+5. Resolve the leaked-flow corner: in-scope-with-dual-domain or out-of-B-MVP (m3).

--- a/docs/research/2387-vrf-flow-identity/claude-smr-plan-r2.md
+++ b/docs/research/2387-vrf-flow-identity/claude-smr-plan-r2.md
@@ -1,0 +1,71 @@
+# Claude SMR — hostile plan review r2 (convergence) (#2387)
+
+**Reviewing:** `docs/research/2387-vrf-flow-identity/plan.md` v3 @ `a620dc727`
+**Posture:** HOSTILE convergence check — did v3 actually close r1's defects, or
+paper over them?
+**Verdict:** **PLAN-DEFER (research-converged).** Convergent with AGY r1 + Codex
+r1. No remaining blocker. The plan correctly stops at "real reachable bug,
+minimal fix identified, awaiting a maintainer scope decision + /engineer."
+
+---
+
+## r1 defects — disposition check (each must be genuinely fixed, not reworded)
+
+- **S1 / AGY-Attack-1 / Codex-Escalation (PBR reachability):** CLOSED. §3 now
+  states "latent in default mode, LIVE via PBR"; §4b carries the ordering proof
+  (`poll_descriptor/mod.rs:474` short-circuit before `:1208`, conntrack lookup by
+  bare `flow.forward_key` at `shared_ops.rs:563-599`) plus the config-validity
+  citations (`firewall_ri_*_test.go`). This is a real escalation, not a hedge —
+  the verdict basis moved from "unreachable" to "cost/benefit for a niche config."
+- **AGY-Attack-4 (A.1 over-rejects):** CLOSED. A.1 is now a commit *warning* by
+  default, hard-reject only under an explicit "no overlapping subnets" product
+  posture. This is the right call — hard-rejecting a working PBR VRF to paper over
+  a fast-path bug would be a self-inflicted regression. Note it correctly stops
+  citing the NPTv6 *reject* gate as the pattern (that was a category error in v2).
+- **AGY-Attack-5 (phase ordering):** CLOSED, and this is the most important
+  structural improvement. The split into B-min (P0+P2+P3) vs B-ext (per-VRF
+  default FIB) is correct: PBR already supplies per-VRF forwarding, so the key
+  widening delivers PBR-mode isolation *without* B-ext. The §8 architectural-
+  mismatch row was rewritten (the old "B-P2 before B-P1 is the dead-end" claim was
+  itself the dead-end thinking). Good.
+- **Codex citation fixes:** CLOSED. `CurrentHAProtocolVersion` corrected to
+  `heartbeat.go:27-31` (with the `sync.go:36` alias noted); path-shorthand note
+  added for the `src/afxdp/` subtree; upgrade-gate `cluster_cli.go:246-248` cited.
+- **§4c / §4d / §7 (confirmed accurate by all three in r1):** unchanged in
+  substance, wording still holds.
+
+## Residual hostile probes (none rise to a blocker)
+
+- **Is B-min's leaked-flow domain-0 scoping safe?** Yes for B-min: it preserves
+  *today's* behavior for leaked flows (they already get no VRF discrimination),
+  so it cannot regress them — it only declines to *improve* them until B-ext.2.
+  The §7 hard-gate wording ("shipping the key widening without this scoping would
+  silently regress leaked-flow conntrack") is the correct guardrail: an engineer
+  must explicitly exempt leaked flows, not silently key them by ingress-domain.
+- **Does Q5 (additive trailing-domain wire encoding) undercut the §4d
+  hard-break?** No — it sharpens it. The hard-break is real *if* domain rides
+  inside the key block; Q5 raises the legitimate alternative of carrying domain as
+  a trailing length-gated value field with domain-0 implied for old peers
+  (graceful degradation, no corruption). That is a /engineer-time design choice,
+  correctly left open rather than over-committed. It could materially lower
+  B-min's cost — worth flagging to the maintainer as the single biggest lever.
+- **Is the perf claim (+4B key, one FastMap lookup) honest?** Yes — B-P0 reuses
+  the dead `meta.routing_table` slot (no `UserspaceDpMeta` size change), and the
+  domain id is a dense interned u32, not an RI-name hash. The hot-path cost is one
+  added u32 in the key hash + one ingress-time map lookup. Must still be measured
+  (the plan says so in §9).
+- **Did v3 over-rotate toward "ship B-min now"?** No. The recommendation remains
+  PLAN-DEFER pending a product-scope decision (§11 Q1), which is correct for
+  `/research` — the bug is real but the fix carries an HA wire change and a
+  product-support question that the maintainer must answer before /engineer.
+
+## Verdict
+
+**PLAN-DEFER (research-converged).** The plan honestly characterizes a real,
+reachable (PBR-mode) wrong-VRF forwarding/NAT/policy bug; identifies the minimal
+real fix (B-min: domain id + key + HA wire) distinct from the larger optional
+feature (B-ext: per-VRF default FIB); offers a non-regressing interim mitigation
+(A.1 warning + A.3 docs); and lays out the correctness traps (symmetric
+discriminator only; leaked-flow scoping; HA wire). Awaiting the maintainer's
+product-scope call and explicit `/engineer` approval. No code should be written
+until that approval.

--- a/docs/research/2387-vrf-flow-identity/codex-plan-r1.md
+++ b/docs/research/2387-vrf-flow-identity/codex-plan-r1.md
@@ -1,0 +1,73 @@
+# Codex — hostile plan review r1 (#2387)
+
+Reviewed plan v1. Codex ran successfully (NOT infra-blocked). Verbatim verdict:
+
+---
+
+**PLAN-NEEDS-MAJOR-REVISION**
+
+**1. ESCALATION CHECK — CONFIRMED**
+
+A forwarding-correct live path exists via input FBF/PBR, so the plan's "latent
+only" premise is wrong. Valid input `then routing-instance` is explicitly allowed:
+`pkg/config/firewall_ri_output_direction_3432_test.go:59-69` and
+`pkg/config/firewall_ri_conflict_3308_test.go:81-97`. On a session miss, PBR
+produces a per-packet table override: `userspace-dp/src/afxdp/forwarding/mod.rs:1211-1225`,
+evaluates the routing-instance filter at `mod.rs:1239-1251`, returns
+`<ri>.inet.0`/`<ri>.inet6.0` at `mod.rs:1283-1288`. The miss path passes that
+override into FIB lookup at `poll_descriptor/mod.rs:1208-1216`, `1244-1249`.
+Overlapping per-table forwarding works when a table is supplied:
+`forwarding/tests.rs:2455-2460, 2510-2536, 2539-2546, 2602-2626`. Local delivery
+is table-scoped too. The session key is still bare `flow.forward_key` at
+`poll_descriptor/mod.rs:2217-2224`. A later same-5-tuple packet hits session
+lookup **before** DNAT/PBR/policy miss logic at `poll_descriptor/mod.rs:473-493`,
+`session_glue/mod.rs:1037-1044`; that lookup uses only the 5-tuple key at
+`shared_ops.rs:563-604`. Plan citation error: `userspace-dp/src/types/forwarding.rs`
+does not exist; current file is `userspace-dp/src/afxdp/types/forwarding.rs`.
+
+**2. WIRE-BREAK CHECK §4d — CONFIRMED**
+
+The session-sync key block is fixed-width, not length-gated. V4 encodes a fixed
+`keySize := 16` then value bytes: `sync_protocol.go:80-98`. V4 decode requires
+only `len(payload) >= 16`, parses exactly 16 key bytes, treats offset 16 as value
+start: `sync_protocol.go:315-331`. Length-gated fields are value/trailing only:
+`sync_protocol.go:343-344, 368-390, 409-422`. V6 same with a fixed 40-byte key:
+`:180-192, 429-445`. The embedded reverse key is also fixed-width inside the value:
+V4 `:136-145`, V6 `:231-240`. Widening either primary or reverse key shifts later
+fields for old decoders — hard wire break confirmed. Plan citation error:
+`CurrentHAProtocolVersion` is at `pkg/cluster/heartbeat.go:27-31`, not `sync.go:36`.
+The upgrade gate treats mismatched HA protocol versions as non-rolling-compatible
+at `pkg/upgrade/cluster_cli.go:246-248`.
+
+**3. SYMMETRY CHECK §7 — CONFIRMED**
+
+`reply_matches_forward_session` accepts only `reverse_wire_key`/`reverse_canonical_key`:
+`session/key.rs:19-25`; transforms carry identity from the forward key
+`:84-121, 124-138`. `ingress_zone` is asymmetric (`poll_descriptor/mod.rs:2174-2176`
+forward, `:2422-2424` + `shared_ops.rs:658-660` reverse; zone derivation depends on
+ingress+egress ifindex `forwarding/mod.rs:275-292`). Ingress ifindex also asymmetric
+(`forwarding/mod.rs:583-591`). Symmetric: a routing-domain/VRF id keyed by ifindex
+`afxdp/types/forwarding.rs:64-69`. Caveat: route leaking/`next-table` can cross
+domains (recursion `forwarding/mod.rs:1579-1604`), so inter-VRF flows need design
+beyond a single ingress-domain field.
+
+**4. COHERENCE GAP CHECK §4c — CONFIRMED**
+
+Plan path error: `userspace-dp/src/session/session_glue/mod.rs` does not exist;
+correct is `userspace-dp/src/afxdp/session_glue/mod.rs`. NAT scope IS enforced at
+session creation (`nat/mod.rs:34-47`, `nat/source.rs:294-318`,
+`poll_descriptor/nat_exception.rs:43-80`, DNAT `poll_descriptor/mod.rs:953-1002`).
+The established fast path does NOT re-run that scope gate:
+`resolve_flow_session_decision` calls `lookup_session_across_scopes(..., &flow.forward_key, ...)`
+at `session_glue/mod.rs:1037-1044`, reuses `resolved.decision` at `1072-1089`; the
+lookup helper takes no NAT scope / ingress RI / egress RI / zone args at
+`shared_ops.rs:563-570`. The coherence gap is real.
+
+**Final verdict: PLAN-NEEDS-MAJOR-REVISION** — the PLAN-DEFER rationale rested on
+"overlapping-subnet flows cannot be forwarded correctly today regardless of session
+key," which is refuted: valid PBR `then routing-instance` produces table-scoped
+per-miss forwarding that works, and the bare-5-tuple key then causes the second
+VRF's established flows to hit the wrong session entry. Live bug for any operator
+using input firewall filters with `then routing-instance` across overlapping
+subnets. The HA wire-break, symmetry constraint, and NAT-coherence gap assessments
+are confirmed accurate (modulo the path/line citation errors noted).

--- a/docs/research/2387-vrf-flow-identity/codex-plan-r2.md
+++ b/docs/research/2387-vrf-flow-identity/codex-plan-r2.md
@@ -1,0 +1,51 @@
+# Codex — plan review r2 (convergence) (#2387)
+
+Reviewed plan v3. Codex ran successfully (NOT infra-blocked). Verbatim verdict:
+
+---
+
+**PLAN-NEEDS-REVISION** (conditional — converges to PLAN-DEFER after two wording
+fixes, both landed in v4 below).
+
+Two remaining blockers preventing PLAN-DEFER convergence:
+
+**Blocker 1 — §4c stale "latent/non-forwarding" wording.** `plan.md:217-219`
+still said the NAT coherence gap "remains latent only because §4b makes the
+trigger non-forwarding." That contradicts the PBR-live finding. NAT runs inside
+the same PBR-triggered path (`forwarding/mod.rs:211-212` resolves NAT scope;
+`session_glue/mod.rs:1037-1042` looks up `&flow.forward_key`). The sentence needs
+to say latent in default mode and live under PBR.
+
+**Blocker 2 — §A.1 stale "hard reject" wording.** `plan.md:382` and `:400-402`
+described the compile-time check as a "commit error / rejects." The plan's own
+`plan.md:254-265` correctly describes it as a commit-time WARNING. Appendix A.1
+must be aligned.
+
+**Items confirmed:**
+1. **PBR reachability — CONFIRMED.** `poll_descriptor/mod.rs:474` calls
+   `resolve_flow_session_decision` (short-circuits before forwarding), and `:1208`
+   builds `route_table_override` (the PBR override). Plan correctly states
+   default=latent, PBR=live.
+2. **Citation fixes — CONFIRMED.** `pkg/cluster/heartbeat.go:27-31`
+   `CurrentHAProtocolVersion`; `pkg/cluster/sync.go:36` `SessionSyncWireVersion`
+   alias; path-shorthand note for `src/afxdp/` subtree at `plan.md:104-109`. All
+   line numbers verified.
+3. **Phase ordering — CONFIRMED.** B-min (P0/P2/P3) and B-ext (per-VRF default
+   FIB) are split, with explicit "NOT a prerequisite" at `plan.md:293-294`.
+   Logically sound: PBR override at `poll_descriptor/mod.rs:1208-1248` is
+   independent of the default-table globals at `forwarding/mod.rs:12-13`.
+4. **§4d/§7 — CONFIRMED still accurate.** HA wire: `sync_protocol.go:81` 16-byte
+   key, `:136-145` encodes reverse key, `:332-368` decode gates. Reverse-flow
+   domain: `session/key.rs:84`/`:124` reverse key; `forwarding/mod.rs:1579-1604`
+   leaked-flow recursion.
+
+"After those two sentences are corrected, the plan converges and PLAN-DEFER is
+appropriate — the findings are real, B-min is the minimal fix, and it correctly
+identifies the maintainer product-scope decision and HA wire bump as the gate."
+
+---
+
+**Disposition (v4):** both blockers fixed — §4c rewritten to "latent in default
+mode, live under PBR"; the §8 risk-table and §9 test-plan A.1 wording aligned to
+"commit WARNING (not reject)." Per Codex's own statement, the plan now converges:
+**PLAN-DEFER**, 3-of-3 (Claude SMR + AGY + Codex).

--- a/docs/research/2387-vrf-flow-identity/plan.md
+++ b/docs/research/2387-vrf-flow-identity/plan.md
@@ -1,0 +1,617 @@
+# #2387 — VRF/routing-instance awareness in session/flow identity
+
+> **v5 (this revision) — engineering-time addendum. Read §0 FIRST: it
+> CORRECTS §4d, retires two cost objections, and narrows the open maintainer
+> question to a single binary choice. The rest of the document is the
+> converged v4 text, unchanged.**
+
+**Status:** DRAFT v3 — incorporates all three r1 reviews (Claude SMR + AGY +
+Codex; all three independently returned NEEDS-MAJOR-REVISION on the PBR
+reachability escalation, and all three confirmed §4c/§4d/§7 accurate). Codex was
+NOT infra-blocked this round — full 3-of-3.
+
+**v3 changelog (from r1 reviews):**
+- All three reviewers refuted the v1 "unreachable in a forwarding-correct config"
+  claim — the collision IS reachable via PBR `then routing-instance` (per-VRF
+  forwarding works without per-VRF default FIB). §3/§4b rewritten "latent in
+  default mode, LIVE via PBR."
+- **AGY Attack 4:** A.1 hard-reject breaks a *legitimate* overlapping-subnet PBR
+  VRF design → softened to a commit **warning** by default (hard reject only if
+  the product decision is "no overlapping subnets at all").
+- **AGY Attack 5:** the v1/v2 "key widening must be last, after per-VRF FIB"
+  ordering was wrong → split into **Track B-min** (P0+P2+P3, the minimal real fix
+  using PBR as the forwarding mechanism) and **Track B-ext** (per-VRF default FIB
+  — a separate enhancement, NOT a prerequisite).
+- **Codex citation fixes:** corrected `CurrentHAProtocolVersion` location and
+  added a path-shorthand note (`src/afxdp/` subtree).
+- A.2 demoted (does not mitigate the conntrack-level breach); B-P0 tightened to a
+  dense-interned u32 reusing the dead `routing_table` slot; leaked-flow corner
+  resolved (domain-0 scope for B-min, dual-domain for B-ext).
+
+**Branch:** authored on `research/2387-vrf-flow-identity` (docs only — no
+production source); landed on master as the decision record cited by
+`userspace-dp/src/afxdp/forwarding/README.md`.
+
+**Verified against:** origin/master @ `13e3b269e` (campaign-8's prior comment was
+written against `0160fbfb9`; this revision re-verifies every claim against current
+master and corrects two of them — see §4).
+
+---
+
+## 0. v5 engineering-time addendum — the deferred cost objections, re-measured
+
+Verified against origin/master @ `4f9d5b491` (v4 was written against
+`13e3b269e`). v4 deferred on two grounds: (a) an HA-wire **hard break** forcing
+a `CurrentHAProtocolVersion` bump and a non-rolling both-nodes upgrade, and
+(b) an open product-scope call. Ground (a) does not survive re-measurement.
+Everything in §0 is a first-hand code finding, not a re-reading of v4.
+
+### 0a. §4d is WRONG for a VALUE-carried domain: there is NO HA wire break
+
+§4d is right that the session-sync **key block is fixed-width and not
+length-gated**, and that the key is serialized twice (primary + the reverse-key
+embedded in the value). It is wrong to conclude that a routing-domain
+discriminator must therefore ride in that key block. It does not have to.
+
+Both wire surfaces take an additive trailing field with **no version bump**:
+
+- **Cross-chassis byte wire** (`pkg/cluster/sync_protocol.go`). The session
+  payload already carries FIVE length-gated trailing VALUE fields — #2170
+  `Generation`, #3301 `AppTimeout` + `PolicyCounterIdx`, #4565 `Nat64SnatV4`,
+  #5274 `ConfigEpoch`, #5212 `RTFlowSessionID`. The decoder reads each under
+  `if off+N <= len(payload)` and returns `ok=true` regardless
+  (`decodeSessionV4Payload`, and the V6 twin), so an old sender's short payload
+  decodes cleanly with the absent fields zeroed. The repo states the rule
+  explicitly at `sync_protocol.go:930`: *"This is a length-gated trailing field
+  like the #3931 config-gen — it does NOT bump SessionSyncWireVersion."*
+- **Rust↔Go control socket** (`SessionSyncRequest`,
+  `userspace-dp/src/protocol/control.rs:989`). Every field is
+  `#[serde(default)]`; a new field is additive by construction.
+
+The receiver folds the trailing `routing_domain` into the in-memory key it
+reconstructs. Interning **domain 0 = the default routing-instance** (NOT a
+separate "unknown" sentinel) makes an old peer's omitted field decode to the
+default VRF — which is exactly correct for every non-VRF deployment, i.e. the
+overwhelming majority, and makes the mixed-version window bit-identical there.
+In a VRF deployment the mixed-version degradation is bounded and benign: a
+peer-synced session for a non-default VRF lands in domain 0, does not match a
+domain-N packet, and that flow re-establishes after failover. It never
+cross-forwards.
+
+**Consequence:** `CurrentHAProtocolVersion` (`pkg/cluster/heartbeat.go:31`) does
+NOT move, so the #1930 mixed-base ISSU gate (`pkg/upgrade/cluster_cli.go:246`)
+is NOT tripped and the upgrade stays rolling. Delete the "HA mixed-version:
+HIGH" cell from the §8 Track-B risk table and the B-P3 "hard break" framing —
+B-P3 is an append, on the same footing as #3301/#5274/#5212. This was §11 Q5,
+called out there as *"the single biggest lever on B-min's cost"*. It is
+resolved in favour of cheap.
+
+### 0b. "Refuse the hit and fall through to the slow path" is NOT a viable middle
+
+Worth recording because it is the first cheap-looking alternative anyone
+proposes to widening the identity. It does not work.
+`SessionTable::install_with_protocol_with_origin` opens with an unconditional
+`let _previous = self.remove_entry(&key);`
+(`userspace-dp/src/session/install.rs:139`). So if the fast path merely
+*declines* a cross-domain hit and lets the packet take the session-miss path,
+that path re-installs under the same bare 5-tuple and **evicts the incumbent
+VRF's session**. Two colliding flows then evict each other on every packet:
+per-packet SNAT re-allocation (the translated tuple changes mid-flow — the flow
+breaks outright), plus SESSION_CREATE/CLOSE RT_FLOW churn and an HA delta storm.
+
+So there are exactly **two** coherent end-states, and no cheap third one:
+
+| | Behaviour on a cross-VRF 5-tuple collision | Cost |
+|---|---|---|
+| **DENY** | fail-closed DROP of the second VRF's flow + a counter | small, Rust-only, no wire |
+| **ISOLATE** | both flows keep their own session (Junos semantics) | identity widening + an additive wire append |
+
+### 0c. Corner inventory for any domain-aware change (new; v4 flagged only the leak case)
+
+Each is a potential self-DoS if a fail-closed variant misses it. Verified:
+
+- **Tunnel decap — SAFE, no special handling.** `try_native_gre_decap_from_frame`
+  rebinds the inner meta's `ingress_ifindex` to `endpoint.logical_ifindex`
+  (`userspace-dp/src/afxdp/gre.rs:760`), i.e. the TUNNEL logical interface, not
+  the underlay physical port. So a decapped flow presents the same ingress
+  identity on every packet and its domain is stable. v4 did not check this.
+- **Fabric cross-chassis ingress — needs an explicit exemption.** The frame
+  arrives on the fabric link while the session was admitted on the peer's real
+  ingress interface, so the domains legitimately differ.
+  `packet_fabric_ingress` is already threaded into
+  `resolve_flow_session_decision`, so the exemption is a one-line gate.
+- **Peer-synced sessions — carry the domain (§0a) or treat as unknown.** With
+  the additive trailing field they carry it; without it they must not be
+  fail-closed against.
+- **Inter-VRF route-leaked flows (§7's residual) — CHEAPER than v4 assumed.**
+  v4 deferred dual-domain handling to B-ext.2 as expensive, and scoped leaked
+  flows to domain-0 in B-min. It is cheap if the ingress AND egress domain are
+  stored in the session **VALUE** (`SessionMetadata`, which already stores the
+  `ingress_zone`/`egress_zone` pair and already gets swapped for the reverse
+  companion in `build_reverse_session_from_forward_match`). The egress domain is
+  derivable at install from `ForwardingResolution.egress_ifindex`. This lets
+  B-min ship correct leaked-flow reverse matching instead of documenting a
+  known limitation.
+- **Transient/seeded sessions** (neighbor seed, local-delivery, NAT64 companions)
+  — resolve to the default domain or to unknown; must not be fail-closed against.
+
+### 0d. What is already shipped (A-track is COMPLETE)
+
+- **A.1** — commit warning on overlapping L3 across routing-instances:
+  PR #4327 (`408cfc7ee`), `validateVRFOverlap` in `pkg/config`.
+- **A.2** — flow cache keyed on the LOGICAL (VLAN unit) ingress ifindex:
+  `42bc6bc88`. v4 ranked this below A.1; it shipped anyway and it removes the
+  flow-cache half of the collision. The conntrack table is now the **sole**
+  remaining collision surface.
+- **A.3** — the limitation + the #3096 coherence contract are documented in
+  `userspace-dp/src/afxdp/forwarding/README.md`.
+
+Nothing in Track A remains. The issue is now entirely a Track-B question.
+
+### 0e. The open question, narrowed to one binary
+
+v4 asked "is overlapping-subnet multi-tenant VRF in product scope?" — which is
+hard to answer in the abstract. With A.1 shipped as a **warning** rather than a
+reject, the config already commits, so the posture question is settled in
+practice. The remaining decision is only §0b's table:
+
+> **On a cross-VRF 5-tuple collision, do we DENY the second flow or ISOLATE it?**
+
+- **DENY** is small and Rust-only, but it is *not* Junos semantics (a Junos
+  session table is per-routing-instance; identical 5-tuples in two instances
+  coexist), and it hands a tenant a denial primitive against a co-tenant that
+  guesses/observes its 5-tuple. It also contradicts the already-shipped A.1
+  warning text, which promises the operator cross-forwarding "until the session
+  identity is VRF-aware" — i.e. it points at ISOLATE.
+- **ISOLATE** is the issue's literal ask, is vendor-parity, and — with §0a —
+  no longer carries the wire flag-day that drove the v4 deferral. Its residual
+  cost is mechanical: `SessionKey` grows one `u32` (≈300 struct-literal sites in
+  `userspace-dp/src`, the large majority in tests), the reverse-key transforms
+  in `session/key.rs` take the reply domain, and one additive field is appended
+  to each of the two wire surfaces. It requires `make test-failover` on the loss
+  userspace cluster because the identity crosses the cross-chassis wire.
+
+**v5 recommendation: ISOLATE (Track B-min), scheduled as its own PR series.**
+The cost objection that justified PLAN-DEFER has been retired; the semantic
+objection to DENY has not. B-ext (per-VRF default FIB) remains independently
+deferrable and is still NOT a prerequisite.
+
+---
+
+## 1. Status
+
+**CONVERGED v4 — PLAN-DEFER (research-converged), 3-of-3.** This is a `/research`
+pass: it stops at PLAN-READY / PLAN-KILL / PLAN-DEFER and produces a converged
+plan-of-action, no code PR. Convergence: Claude SMR r2 = PLAN-DEFER, AGY r2 =
+PLAN-DEFER, Codex r2 = PLAN-DEFER after two §4c/§A.1 wording fixes (landed in v4;
+`codex-plan-r2.md`). Codex was not infra-blocked in either round.
+
+The headline recommendation is **PLAN-DEFER**: the bug is real and reachable
+(LIVE under PBR `then routing-instance`, latent in default forwarding mode), but
+the real fix (Track B-min) carries an HA wire change and a product-support
+question. Ship the interim A.1 commit warning + A.3 docs now; schedule Track B-min
+(domain id + key widening + HA wire bump) once the maintainer confirms
+overlapping-subnet PBR VRF is supported. Track B-ext (per-VRF default FIB) is a
+separate, independently deferrable enhancement. Awaiting manual `/engineer`
+approval — no code until then.
+
+## 2. Issue framing
+
+#2387 says: the userspace-dp session/flow identity is the bare 5-tuple
+(src ip, dst ip, src port, dst port, protocol) with no VRF / routing-instance
+(or zone) discriminator, so two flows that live in different VRFs but share the
+same 5-tuple collide in the conntrack map — causing wrong-flow forwarding, NAT,
+or policy. The literal ask is "add VRF/routing-instance id (and/or zone) to the
+SessionKey."
+
+## 3. Honest scope / value framing
+
+The bug **mechanism is real and confirmed** (§4). Its reachability is
+**mode-dependent** (corrected in v2 after SMR r1):
+
+- **Default forwarding mode (no PBR): latent.** For two flows to legitimately
+  carry the *same* 5-tuple in two VRFs you need overlapping L3 address space, and
+  the userspace forwarding layer is **not VRF-isolated** by default — the
+  destination FIB lookup for a normal transit packet defaults to the global
+  `inet.0`/`inet6.0` table, and local-delivery uses a single global address set.
+  So an overlapping-subnet multi-VRF topology does not route correctly *in this
+  mode* irrespective of the session key.
+- **PBR mode (`then routing-instance` on the ingress interfaces): LIVE.** PBR is
+  the dataplane's per-packet table override; with a PBR filter steering each
+  ingress interface to its own per-VRF table, overlapping-address multi-VRF
+  **does forward correctly** — and then the bare-5-tuple session key collides: a
+  second flow with the same 5-tuple hits the first flow's conntrack session and
+  inherits its egress / NAT / policy decision (wrong-VRF forwarding). See §4b for
+  the verified ordering proof. This is a real, reachable (if niche)
+  correctness/isolation breach — exactly #2387's multi-tenant scenario.
+
+The session-key collision is the tip of a larger "VRF-aware forwarding +
+conntrack isolation" feature. In default mode it is latent; in PBR mode it is a
+live wrong-forwarding bug on the *second* colliding flow. Either way, the literal
+"widen the key now" ask is the last and most expensive phase of that feature, not
+a standalone fix.
+
+The literal fix the issue asks for (widen the SessionKey) is, by itself:
+- **the most expensive and riskiest phase** of that larger feature (hard HA wire
+  break + version bump + C/Go/Rust/fixture lockstep + conntrack reverse-match
+  correctness — §4, §5, §7), and
+- **delivers zero realized isolation** until the forwarding layer is also made
+  VRF-aware (a separate, larger body of work).
+
+*If reviewers conclude the churn of the full feature is too large for what is a
+niche (overlapping-address + PBR + simultaneous identical-5-tuple) config,
+PLAN-KILL of the literal "widen the key now" ask is acceptable — but the
+fail-closed guard (Track A.1) should ship regardless, because the bug is now
+known to be reachable, not purely theoretical.* The recommended terminal state is
+PLAN-DEFER: ship the cheap fail-closed guard + doc now; schedule the full feature
+only if multi-tenant overlapping-subnet VRF isolation is a declared product goal.
+
+## 4. Confirmed mechanism + what's already shipped (current master `13e3b269e`)
+
+> **Path shorthand:** Rust dataplane citations below are relative to
+> `userspace-dp/src/` and live under the `afxdp/` subtree unless the path already
+> names another (e.g. `session/key.rs`, `nat/`). Full forms: `forwarding/mod.rs`
+> = `userspace-dp/src/afxdp/forwarding/mod.rs`; `types/forwarding.rs` =
+> `userspace-dp/src/afxdp/types/forwarding.rs`; `session_glue/mod.rs` =
+> `userspace-dp/src/afxdp/session_glue/mod.rs`; `shared_ops.rs` =
+> `userspace-dp/src/afxdp/shared_ops.rs`. (Codex r1 flagged the bare `src/types/`
+> / `src/session/session_glue/` forms as non-existent — they are under
+> `src/afxdp/`.)
+
+### 4a. The key is the bare 5-tuple — confirmed
+
+- `SessionKey` = `{ addr_family:u8, protocol:u8, src_ip:IpAddr, dst_ip:IpAddr,
+  src_port:u16, dst_port:u16 }` — `userspace-dp/src/session/key.rs:9-17`. No
+  zone / VRF / ifindex.
+- Built at session-create from the L4 tuple + AF **only** —
+  `parse_session_flow_from_meta` (`userspace-dp/src/afxdp/frame/inspect.rs:1513-1544`)
+  and the frame/byte parsers (`inspect.rs:1220`, `:1451`, `:1546`). None read
+  `meta.ingress_zone`, `meta.routing_table`, `meta.ingress_vlan_id`, or
+  `meta.ingress_ifindex`.
+- Every session map is keyed by `SessionKey` alone: the shared synced / NAT /
+  forward-wire maps (`afxdp/coordinator/session_manager.rs:13-15`), the
+  worker-local conntrack indexes `key_to_handle` / `nat_reverse_index` /
+  `forward_wire_index` / `reverse_translated_index`
+  (`session/mod.rs:453-457`), and the tunnel rate map (`afxdp/tunnel.rs:270`).
+- Lookup uses `flow.forward_key` only — `lookup_session_across_scopes`
+  (`afxdp/shared_ops.rs:563-599`) receives `ingress_ifindex` as a parameter but
+  **does not** put it in the key; `SessionTable::lookup_with_origin`
+  (`session/lookup.rs:28-43`) probes `key_to_handle.get(key)` then
+  `reverse_translated_index`.
+- The session entry stores `ingress_zone:u16` / `egress_zone:u16`
+  (`session/entry.rs:25-26`) but these are read only for the per-zone half-open
+  TCP override (`session/lookup.rs:51-55`), never for key matching. There is **no
+  routing-table / VRF field** on `SessionMetadata` or `SessionEntry`.
+
+**Conclusion:** two flows with identical 5-tuples on any two interfaces share one
+conntrack entry. The flow cache (`FlowCacheEntry`) adds a partial discriminator —
+its key is `(SessionKey, ingress_ifindex)` where `ingress_ifindex` is the **raw
+physical** parent (`flow_cache.rs:149` lookup, `:424` insert), so two flows on
+*different physical ports* don't collide there, but two VLAN sub-units on the
+*same* physical parent still do. The conntrack table (no ifindex at all) is the
+primary collision surface.
+
+### 4b. The forwarding layer is NOT VRF-isolated — confirmed (this is why it's latent)
+
+- Default FIB table is global: `DEFAULT_V4_TABLE="inet.0"` / `inet6.0`
+  (`afxdp/forwarding/mod.rs:12-13`); a transit packet with no PBR override
+  resolves there (`:1131-1133`, `:1174-1176`), and the established-session path
+  passes `table=None` (`session_glue/mod.rs:148-153`).
+- Local-delivery sets are global, single sets: `local_v4` / `local_v6`
+  (`types/forwarding.rs:15-16`), tested at `forwarding/mod.rs:1134` / `:1177`,
+  populated from every interface address into the one set
+  (`forwarding_build/interfaces.rs:153`/`:169`).
+- The **only** per-packet table override is PBR `then routing-instance`
+  (`ingress_route_table_override`, `forwarding/mod.rs:1211`; sole production
+  caller `poll_descriptor/mod.rs:1208-1216`). There is **no** automatic
+  `ifindex → default-table` binding — an interface's native `routing_instance` is
+  used only for connected-route table naming
+  (`connected_route_tables`, `forwarding_build/interfaces.rs:126-127`/`:274-283`)
+  and next-table recursion.
+
+So in **default mode** two routing-instances both owning `10.0.0.10` already
+collide at the global FIB and global `local_v4` layers; the overlapping config
+never forwards correctly there, with or without a wider session key.
+
+**But PBR makes per-VRF forwarding work — and that is where the collision goes
+live (verified ordering proof):**
+
+- Input `then routing-instance` is a valid, tested config
+  (`pkg/config/firewall_ri_output_direction_3432_test.go:59-69`,
+  `pkg/config/firewall_ri_conflict_3308_test.go:81-97`). With it,
+  `ingress_route_table_override` returns the per-VRF table
+  (`forwarding/mod.rs:1211`, builds `<ri>.inet.0`/`inet6.0` at `:1283-1288`), and
+  the **session-miss** resolution honors it (`poll_descriptor/mod.rs:1208-1216`
+  builds the override; `:1244-1248` passes it to
+  `lookup_forwarding_resolution_in_table_with_dynamic`). Table-scoped
+  forwarding+local-delivery under a supplied table is proven in
+  `forwarding/tests.rs:2455-2546`. So overlapping-address multi-VRF *does* forward
+  correctly under PBR.
+- **The established-session fast path runs FIRST and ignores PBR:**
+  `resolve_flow_session_decision` is called at `poll_descriptor/mod.rs:474` and
+  short-circuits before the PBR override at `:1208` (comment at `:503`: it "never
+  runs policy"). It looks up the conntrack session by the bare 5-tuple
+  (`flow.forward_key`, `shared_ops.rs:563-599`).
+- Therefore: flow 1 (VRF-A) creates a session caching egress-A; flow 2 (VRF-B),
+  *same 5-tuple*, hits flow 1's session at line 474 and is handed flow 1's cached
+  decision — its own PBR/route/policy is never evaluated → wrong-VRF forward +
+  wrong NAT + wrong policy. The flow-cache `(SessionKey, physical_ifindex)`
+  discriminator does not save it: flow 2 misses the flow cache (or collides if on
+  the same parent VLAN) but still hits the ifindex-less conntrack table. **The
+  conntrack table is the authoritative collision surface.**
+
+### 4c. NEW since campaign-8 (#3096) — partial VRF awareness landed, but only in NAT *selection*
+
+`#3096` (`ab9c6580e`, merged after `0160fbfb9`) added:
+- `ifindex_to_routing_instance: FastMap<i32, String>` —
+  `types/forwarding.rs:69`, built from `iface.routing_instance` at
+  `forwarding_build/interfaces.rs:56-57`. **This is the P0 building block
+  campaign-8 said "doesn't exist yet."** It now exists (as a name → not yet a
+  compact id).
+- `NatScopeCtx` (`nat/mod.rs:42`) resolved per-flow via `nat_scope_ctx_for_flow`
+  (`forwarding/mod.rs:120-145`) from the ingress/egress ifindex, so NAT
+  rule-*selection* is now routing-instance-scoped at **session create**.
+
+**The coherence gap this introduces (new finding):** the NAT scope is checked
+only when a session is *created* (`match_source_nat` path). On the established
+fast path, `resolve_flow_session_decision` (`session_glue/mod.rs:1004-1044`)
+returns the cached hit's decision via `lookup_session_across_scopes` using
+`flow.forward_key` **without re-running the scope gate**. Because the session
+cache is keyed by the bare 5-tuple, a second flow that collides on the 5-tuple
+would inherit the first flow's NAT/policy/forwarding decision, *defeating
+#3096's scoping for that flow*. The codebase is now partway into VRF-awareness
+(NAT selection) while session identity is still VRF-blind — an internal
+inconsistency. The gap is **latent in default mode** (§4b: the trigger does not
+forward there) but **live under PBR** — NAT runs inside the same PBR-triggered
+session-miss path (`forwarding/mod.rs:211-212` resolves the NAT scope, then
+`session_glue/mod.rs:1037-1042` looks up `&flow.forward_key`), so flow 2's
+established hit reuses flow 1's cached NAT decision without re-checking scope,
+exactly as in §4b. A future per-VRF-FIB phase (B-ext) that makes default mode
+forward would extend the live window to non-PBR configs too.
+
+### 4d. CORRECTION to campaign-8's HA-wire claim (new finding)
+
+Campaign-8 said a VRF-id "appended to the key payload is wire-compatible if
+length-gated." **That is wrong.** On the cross-chassis byte wire
+(`pkg/cluster/sync_protocol.go`), only the *value's trailing* fields are
+length-gated/additive (decoder bails early-but-ok at each boundary,
+`decodeSessionV4Payload:318/332/343/368`). The **key portion is fixed-layout
+little-endian and NOT length-gated**, and the key is serialized *twice* (the
+primary key, plus the embedded `reverse_key` inside the value at
+`sync_protocol.go:136-145`). Widening `SessionKey` shifts the reverse-key block
+and every value field after it, so it is a **hard wire break** requiring a
+bump of `CurrentHAProtocolVersion` (`pkg/cluster/heartbeat.go:27-31`; the
+`SessionSyncWireVersion = uint16(CurrentHAProtocolVersion)` alias is at
+`pkg/cluster/sync.go:36`) and the #1930 mixed-base ISSU gate — the upgrade path
+already treats a mismatched HA protocol version as non-rolling-compatible
+(`pkg/upgrade/cluster_cli.go:246-248`), so a key-wire bump forces a both-nodes
+upgrade. Strictly more expensive than the "additive" estimate.
+
+### 4e. `routing_table` meta field is dead (new finding)
+
+`UserspaceDpMeta.routing_table:u32` (offset 24; `types/mod.rs:111`,
+`userspace-xdp/src/lib.rs:132`) is hard-coded `0` at the shim ingress build
+(`lib.rs:682`) and in the dp default init (`types/mod.rs:195`). The only code
+that ever set it non-zero was C in the legacy BPF zone/filter programs deleted in
+#1476. So it **cannot be repurposed as-is**; a routing-domain id must be computed
+and plumbed fresh.
+
+## 5. Concrete design
+
+Two tracks. The decision between them is a **product-scope call** (see §11 Q1).
+
+### Track A — proportionate hardening now (recommended default; cheap, fail-closed)
+
+- **A.1 — commit-time WARNING (not a hard reject)** (`pkg/config` compiler).
+  When a config assigns overlapping L3 address space (interface addresses or
+  static routes) to two different routing-instances reachable via PBR `then
+  routing-instance`, emit a **commit warning** naming both interfaces/instances:
+  "overlapping L3 across routing-instances is forwarded via PBR but is NOT
+  session-isolated (#2387) — colliding 5-tuples may cross-forward until the
+  session identity is VRF-aware." **A warning, not a reject** — AGY r1 Attack 4
+  correctly notes that overlapping-subnet PBR VRF is a *legitimate, working*
+  multi-tenant design, so hard-rejecting it breaks a valid deployment to work
+  around a fast-path bug. A hard reject is only appropriate if the maintainer's
+  product decision is "we do not support overlapping subnets" at all (§11 Q1) —
+  default to the warning. No wire/HA impact; pure config-layer. Pattern to
+  mirror: the existing config-validation warnings (not the NPTv6 *reject* gate).
+  This is the **interim safety net**; the real fix for the live breach is Track
+  B-min.
+- **A.2 — (de-prioritized) flow-cache logical-ifindex key.** Change
+  `FlowCacheEntry` to key on the **logical** ingress ifindex (resolve
+  `(parent, vlan) → logical` via `resolve_ingress_logical_ifindex`, already
+  called at `flow_cache.rs:373` for the DSCP/L4 coherency check) instead of the
+  raw physical `meta.ingress_ifindex` (`flow_cache.rs:149`, `:424`). **This does
+  NOT mitigate #2387's core breach** — the conntrack table (no ifindex) is the
+  authoritative collision surface (§4b), and the flow cache already carries the
+  physical ifindex yet still doesn't prevent the cross-VRF hit. A.2 is a tidy-up
+  that aligns the flow cache with the logical-ifindex SSOT used elsewhere
+  (#2370/#3021) and stops same-parent-VLAN flow-cache reuse; rank it below A.1
+  and A.3. No wire/HA change.
+- **A.3 — documentation.** Record the single-forwarding-domain limitation in
+  `userspace-dp/src/afxdp/forwarding/README.md` and the VRF docs, note that PBR
+  is the only per-VRF forwarding path and that it is NOT session-isolated, and
+  record the #3096 NAT-scope-vs-session-cache coherence contract.
+
+### Track B-min — the minimal real fix for the LIVE PBR-mode bug (corrected ordering)
+
+**AGY r1 Attack 5 correction:** v1/v2 said the key widening must come *last*,
+after per-VRF default FIB (old B-P1), else it's a dead-end. That is **wrong**.
+PBR `then routing-instance` is *already* the per-VRF forwarding mechanism on the
+slow path (§4b), so widening the key + deriving a domain id alone fixes the
+fast-path collision for PBR-based VRF deployments **without** needing per-VRF
+default FIB. Per-VRF default FIB (now Track B-ext) is a *separate* enhancement
+that makes *non-PBR* configs VRF-isolate — it is NOT a prerequisite for the key
+fix. The minimal fix for the reachable bug is:
+
+- **B-P0 — routing-domain id.** Derive a stable compact `routing_domain:u32`
+  from the existing `ifindex_to_routing_instance` map by **interning the RI name
+  to a dense u32** (domain 0 = default/unscoped) — never hash the RI name on the
+  hot path. For PBR-steered flows the domain is the PBR-resolved
+  routing-instance; for natively-assigned interfaces it is
+  `ifindex_to_routing_instance[ingress_ifindex]`. Reuse the **dead
+  `meta.routing_table` slot** (§4e) to carry it, so there is **no
+  `UserspaceDpMeta` size change** (struct stays size-96 with its mirrored
+  `offset_of!` asserts intact). SessionKey then grows by exactly 4 bytes.
+- **B-P2 — symmetric discriminator in the key.** Add `routing_domain:u32` to
+  `SessionKey`, `FlowCacheLookup`, and the reverse-key transforms
+  (`reverse_wire_key` / `reverse_canonical_key`, `session/key.rs:84-138`). It
+  **must be the routing-domain id, NOT zone or ingress-ifindex** — see §7.
+  Leaked inter-VRF flows are scoped to domain-0 for B-min (the §7 hard gate).
+- **B-P3 — HA wire (hard break).** Bump `CurrentHAProtocolVersion`, change the
+  Go `sync_protocol.go` key encode/decode (primary + embedded reverse-key, V4 +
+  V6), the Rust `SessionSyncRequest` (`protocol/control.rs:868-972`), the C
+  conntrack mirror `session_key`/`session_key_v6`
+  (`bpf/headers/xpf_conntrack.h:7`/`:68`), the Go mirror
+  `dataplane.SessionKey`/`SessionKeyV6` (`pkg/dataplane/types.go:6`/`:87`), and
+  regenerate the golden fixture `userspace-dp/tests/fixtures/protocol_wire_v1.json`.
+  Gate mixed-version interop through the #1930 mixed-base ISSU path.
+
+B-min (P0+P2+P3 + the leaked-flow scoping) is the smallest change that closes the
+reachable #2387 breach. It is still non-trivial (the HA wire hard break + version
+bump dominate the cost), but it is much smaller than the full per-VRF forwarding
+feature.
+
+### Track B-ext — per-VRF default forwarding (separate, deferred; NOT a prerequisite)
+
+- **B-ext.1 — per-VRF forwarding without PBR.** Per-VRF `local_v{4,6}` sets and
+  an ingress-VRF-scoped default FIB table, so an interface's native
+  `routing_instance` selects the destination table for a normal packet *without*
+  requiring a PBR filter. This makes §4b's default mode VRF-isolate too. It is an
+  independent enhancement (a usability/parity improvement over "you must attach a
+  PBR filter"), not needed for the B-min correctness fix.
+- **B-ext.2 — leaked-flow full handling.** Replace B-min's domain-0 scoping of
+  inter-VRF route-leaked flows with dual ingress+egress-domain storage and an
+  egress-domain reverse-key transform (§7).
+- **B-ext.3 — commit validation.** Flip A.1's warning to a "require overlap to
+  live inside distinct routing-instances" model once isolation is real.
+
+## 6. Public API preservation
+
+Track A: no public Rust/Go API signature changes (A.1 is a new compiler check;
+A.2 is internal to `flow_cache.rs`; A.3 is docs). Track B-min (B-P2/B-P3) changes
+the `SessionKey` struct and the HA wire — by definition not preservable; that is
+the cost the version bump exists to manage.
+
+## 7. Hidden invariants the change must preserve
+
+- **Conntrack reverse-match symmetry (the correctness trap).** The reply packet
+  is matched via `reverse_wire_key` / `reverse_canonical_key`. The reply
+  ingresses on the *egress* interface, so **ingress-zone and ingress-ifindex are
+  asymmetric** across forward vs reply — putting either in the key breaks reply
+  matching. The **routing-domain id is symmetric for intra-VRF flows** (forward
+  and reply both stay in the VRF), so the reverse-key transform keeps the same
+  domain and matching holds. **Residual asymmetry:** an **inter-VRF route-leaked
+  flow** (next-table / rib-group) ingresses VRF-A, egresses VRF-B; its reply
+  ingresses VRF-B, so the forward-stored domain differs from the reply's computed
+  domain. **Resolution for B-min:** the config path that produces this is
+  rib-group / `next-table` inter-VRF route leaking (`pkg/routing/`; recursion at
+  `forwarding/mod.rs:1579-1604`). B-min **scopes leaked inter-VRF flows OUT** with
+  a documented known-limitation (leaked flows keep domain-0 / unscoped identity,
+  as today); Track B-ext.2 then stores both ingress and egress domain on the
+  session and uses the egress domain in the reverse-key transform (mirroring NAT's
+  reverse-key handling). Shipping the key widening without this scoping would
+  silently regress leaked-flow conntrack, so the
+  scoping decision is a hard gate, not prose. Campaign-8 did not flag this corner.
+- **HA wire portability / mixed-version.** §4d: key widening is a hard break;
+  ISSU during the upgrade window must not corrupt or silently drop sessions —
+  hence the version bump + mixed-base gate + a version-aware decoder.
+- **`UserspaceDpMeta` size/offset invariant.** The struct is size-96 with
+  `offset_of!`/`const _` asserts mirrored in `types/mod.rs` and
+  `userspace-xdp/src/lib.rs`; B-P0 plumbing must respect the mirror + asserts.
+- **Allocation rules.** Domain-id derivation must be a per-packet *lookup* (an
+  interned u32), never a per-packet `String` clone or hash of the RI name — the
+  key is hashed per packet on the hot path.
+- **#3096 NAT-scope coherence.** Any session-identity change must keep the
+  invariant that a cached fast-path decision is only reused for a flow in the
+  same scope it was admitted under.
+
+## 8. Risk assessment
+
+| Class | Track A | Track B |
+|---|---|---|
+| Behavioral regression | LOW — A.1 emits a commit WARNING (not a reject) on overlapping-L3-across-RI configs, INCLUDING PBR ones that currently forward; the config still commits, the operator is just told it is not session-isolated. (A hard reject is opt-in only, under the "no overlapping subnets" product posture — §11 Q1.) A.2 only changes which entry a same-parent VLAN flow caches under. | HIGH — touches conntrack identity, reply matching, per-VRF FIB; mis-set domain → flows fail to match (self-DoS) or cross-match. |
+| HA mixed-version | NONE (no wire change). | HIGH — hard key-wire break (§4d); requires version bump + #1930 mixed-base ISSU gate + dual-format decoder for the upgrade window. |
+| Wire / struct size | NONE. | MED — SessionKey +4 B (and the C/Go mirrors + golden fixture); `UserspaceDpMeta` already has the dead `routing_table` slot, so no meta size change if reused. |
+| Performance (key hashed per packet) | NONE. | LOW-MED — +4 B in the key hash and per-entry map cost (~1-3%); domain-id derivation is one extra `FastMap` lookup at ingress. Must be measured (smoke + perf). |
+| Architectural mismatch | LOW — A.1/A.3 are the honest contract; A.2 aligns flow-cache with the logical-ifindex SSOT already used elsewhere (#2370/#3021). | LOW-MED — corrected (AGY Attack 5): the key widening (B-min) is NOT a dead-end before per-VRF FIB, because PBR is already the per-VRF forwarding mechanism. Risk is reversed — B-min alone delivers PBR-mode isolation; B-ext (per-VRF default FIB) is the separable enhancement. The real mismatch risk is the HA wire hard break (managed by the version bump + ISSU gate). |
+
+**PLAN-KILL acceptable if:** the churn of Track B outweighs the win for what is a
+niche config (overlapping addresses + PBR + simultaneous identical 5-tuple —
+§4b). Note the collision is **not** unreachable: it is live in PBR mode, only
+latent in default mode. So PLAN-KILL rests solely on the cost/benefit prong, not
+on unreachability. The proportionate immediate response is Track A.1 (commit
+warning for the live breach) + A.3 (docs); the minimal real fix is **Track B-min**
+(key widening + domain id + HA wire bump), scheduled if multi-tenant
+overlapping-subnet VRF is a declared product goal. Track B-ext (per-VRF default
+FIB) is independently deferrable.
+
+## 9. Test plan
+
+- **Track A.1 (RED-on-revert):** `pkg/config` unit test — two routing-instances
+  with overlapping `10.0.0.10/24` on VLAN sub-units of one parent ⇒ commit
+  succeeds with a **warning** naming both interfaces/instances. Reverting the
+  guard (no warning emitted) makes the test go RED. (Under the opt-in hard-reject
+  posture, a separate test asserts the commit is rejected.)
+- **Track A.2:** `flow_cache` unit test — same physical parent, two VLAN units,
+  identical 5-tuple ⇒ distinct flow-cache entries (RED if the key reverts to raw
+  physical ifindex).
+- **Track B-min (the issue's stated regression, RED-on-revert):** construct two
+  flows — same parent ifindex, two VLAN sub-interfaces in different
+  routing-instances each with a PBR `then routing-instance` filter steering to its
+  own table (so each forwards), identical 5-tuples, differing policy/NAT — and
+  assert **no** session or flow-cache reuse across the boundary, plus correct
+  reply-direction match *within* each VRF, plus the inter-VRF route-leaked corner
+  stays domain-0 (§7). Reverting the `routing_domain` field makes it RED (flow 2
+  inherits flow 1's egress).
+- **HA wire round-trip:** Go `sync_protocol.go` encode→decode of the widened key
+  (V4 + V6, primary + reverse-key) round-trips; golden `protocol_wire_v1.json`
+  regenerated and matched; a version-skew decode test proves graceful handling
+  during ISSU.
+- **HA live:** `make test-failover` on the loss userspace cluster (key crosses
+  the cross-chassis wire) — required for any Track-B change touching session sync.
+- **Perf neutrality:** smoke v4 + v6 + per-class CoS on the loss cluster; perf
+  record to confirm the wider key + domain-id lookup is within noise.
+
+## 10. Out of scope (explicitly)
+
+- Per-VRF default FIB / per-VRF local-delivery sets (Track B-ext) — a separate
+  multi-PR enhancement, NOT needed for the B-min correctness fix; #2388 already
+  tracks the connected-route table-naming half.
+- Zone-only flow isolation without overlapping addressing (not reachable; same
+  src IP can't legitimately ingress on two zones without overlap or asymmetric
+  routing).
+- Repurposing `meta.routing_table` for anything other than the B-P0 domain id.
+- Any change to the eBPF retirement posture (the C conntrack header is a
+  parity/mirror artifact only).
+
+## 11. Open questions for adversarial review
+
+1. **Product scope (decides the response level):** Is overlapping-subnet
+   multi-tenant VRF isolation (via PBR) something we support? The bug is now known
+   reachable (live in PBR mode), so the choice is: (a) **support it** → schedule
+   **Track B-min** (the real fix) + ship A.1 warning + A.3 docs as interim; or
+   (b) **explicitly do not support it** → upgrade A.1 from a warning to a hard
+   reject and document the non-support. Either way A.3 (docs) + A.1 (some guard)
+   ship now. "Do nothing" is no longer defensible given reachability.
+2. **[Largely answered by r1]** The §4c #3096 coherence gap is reachable via PBR
+   (all three reviewers confirmed). Remaining sub-question: is there a
+   *non-PBR* forwarding-correct trigger (e.g. asymmetric routing, ECMP across
+   VRFs) that also reaches it? If so, B-ext (per-VRF default FIB) moves up too.
+3. Is the routing-domain id truly the only symmetric discriminator, or is there a
+   cheaper symmetric quantity already on both forward and reply packets? Refute
+   or confirm that zone/ingress-ifindex are unusable (§7).
+4. **[Answered by r1, confirm the scope call]** The inter-VRF route-leaked
+   reverse-match corner (§7) has a config path today (rib-group / next-table). The
+   plan scopes leaked flows to domain-0 in B-min and defers full dual-domain
+   handling to B-ext.2. Do reviewers agree leaked flows can keep today's
+   (domain-0) behavior in B-min, or must dual-domain be in the first cut?
+5. Is the HA-wire hard-break assessment (§4d) correct that the key portion is not
+   length-gated (all three r1 reviewers confirmed it is), or is there a
+   forward-compatible encoding — e.g. a NEW session-sync message type carrying the
+   domain as a trailing value field, with domain-0 implied for old peers — that
+   downgrades B-P3 from "hard break" to "additive"? This is the single biggest
+   lever on B-min's cost and deserves a deliberate design choice at /engineer time.
+6. Is A.2 (flow-cache logical-ifindex key) safe to ship independently of A.1, or
+   does changing the flow-cache key risk a first-packet-latency or
+   cache-thrash regression on the untagged common case?

--- a/docs/research/2387-vrf-flow-identity/reviewer-ids.md
+++ b/docs/research/2387-vrf-flow-identity/reviewer-ids.md
@@ -1,0 +1,24 @@
+# #2387 plan-review reviewer ledger
+
+3-way hostile plan review (Codex + AGY + Claude SMR). Copilot is NOT a research
+reviewer (it joins the quad at `/engineer` on the code PR).
+
+| Round | Reviewer | ID / location | Verdict |
+|---|---|---|---|
+| r1 | Claude SMR | `claude-smr-plan-r1.md` | PLAN-NEEDS-REVISION (caught the PBR reachability defect in my own v1) |
+| r1 | AGY | job `adversarial-review-mr0wcll0-pk94mc` → `agy-plan-r1.md` | PLAN-NEEDS-MAJOR-REVISION |
+| r1 | Codex | rescue agent (NOT infra-blocked) → `codex-plan-r1.md` | PLAN-NEEDS-MAJOR-REVISION |
+| r2 | Claude SMR | `claude-smr-plan-r2.md` | PLAN-DEFER (converged) |
+| r2 | AGY | job `adversarial-review-mr0wp66c-c5nu8h` → `agy-plan-r2.md` | PLAN-DEFER (converged) |
+| r2 | Codex | rescue agent → `codex-plan-r2.md` | PLAN-NEEDS-REVISION → PLAN-DEFER after 2 wording fixes (landed in v4) |
+
+**Convergence:** all three reviewers converge on PLAN-DEFER (Claude SMR + AGY at
+v3; Codex conditionally at v3, unconditionally after the two §4c/§A.1 wording
+fixes landed in v4). Full 3-of-3 — Codex was not infra-blocked in either round.
+
+All three r1 reviewers independently escalated the same finding: the collision is
+LIVE via PBR `then routing-instance`, not latent. All three confirmed §4c (NAT
+coherence gap), §4d (HA-wire hard break), §7 (symmetric discriminator + inter-VRF
+leaked corner) accurate. Codex additionally caught 3 citation errors (fixed in
+v3). Codex ran successfully this round, so the review is full 3-of-3 (not the
+2-of-3 Codex-infra-blocked fallback).

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -337,17 +337,39 @@ limitation, tracked by #2387.
   flow. The invariant the real fix must restore: **a cached fast-path
   decision is only reused for a flow in the same scope it was admitted
   under.**
+- **The conntrack table is now the SOLE collision surface.** The flow cache
+  used to alias too; it is keyed on the LOGICAL (VLAN unit) ingress ifindex
+  since `42bc6bc88`, so two units of one parent no longer share a cache
+  entry. Only the ifindex-less conntrack table remains.
 - **Interim mitigation + deferred real fix.** The Go compiler emits a
   commit WARNING (`validateVRFOverlap`, `pkg/config`) when two distinct
   routing-instances carry overlapping L3 address space, so the operator is
   told the topology is not session-isolated (the config still commits — an
   overlapping-subnet PBR VRF is a legitimate working design). The real fix
   (Track B) adds a **symmetric routing-domain id** to `SessionKey` +
-  `FlowCacheLookup` + the reverse-key transforms, plus the HA session-sync
-  wire bump — the discriminator MUST be the routing-domain id (symmetric
-  across forward/reply), NOT zone or ingress-ifindex (asymmetric → breaks
-  conntrack reverse matching). See
-  `docs/research/2387-vrf-flow-identity/plan.md`.
+  `FlowCacheLookup` + the reverse-key transforms — the discriminator MUST
+  be the routing-domain id (symmetric across forward/reply), NOT zone or
+  ingress-ifindex (asymmetric → breaks conntrack reverse matching).
+- **The HA session-sync wire does NOT need a version bump** (corrected in
+  plan v5 §0a; the plan's own §4d said otherwise). The domain does not have
+  to live in the fixed-width wire KEY block — it rides as a length-gated
+  trailing **value** field, exactly like #2170 `Generation`, #3301
+  `AppTimeout`/`PolicyCounterIdx`, #4565 `Nat64SnatV4`, #5274 `ConfigEpoch`
+  and #5212 `RTFlowSessionID` (`pkg/cluster/sync_protocol.go`; the
+  `SessionSyncRequest` control-socket struct is all `#[serde(default)]`).
+  The receiver folds it into the key it reconstructs. Interning **domain 0
+  = the default routing-instance** makes an old peer's omitted field decode
+  to the default VRF, so a non-VRF cluster is bit-identical across the
+  mixed-version window and `CurrentHAProtocolVersion` never moves.
+- **Do NOT "decline the hit and fall through"** as a cheap mitigation.
+  `install_with_protocol_with_origin` opens with an unconditional
+  `remove_entry(&key)` (`session/install.rs`), so the session-miss path
+  would re-install under the same bare 5-tuple and evict the incumbent
+  VRF's session — the two flows then evict each other per packet
+  (per-packet SNAT re-allocation breaks both). The only coherent
+  end-states are a fail-closed DROP or a widened identity.
+- Decision record: `docs/research/2387-vrf-flow-identity/plan.md` (read §0
+  first — it supersedes §4d and narrows the open call).
 
 ## Where it sits
 

--- a/userspace-dp/tests/vrf_session_identity_doc_guard.rs
+++ b/userspace-dp/tests/vrf_session_identity_doc_guard.rs
@@ -1,0 +1,158 @@
+//! #2387 VRF/routing-instance session-identity decision-record guard.
+//!
+//! `userspace-dp/src/afxdp/forwarding/README.md` documents the single-
+//! forwarding-domain session-identity limitation and cites
+//! `docs/research/2387-vrf-flow-identity/plan.md` as the decision record for
+//! the deferred real fix (Track B). That plan lived ONLY on the unmerged
+//! `research/2387-vrf-flow-identity` branch, so the in-tree citation dangled —
+//! the same failure the #3643/#3651 guard (`pkg/api/zone_counter_doc_ref_test.go`)
+//! exists to prevent, which its own comment records happening once before.
+//!
+//! FAIL-ON-REVERT: deleting the plan doc, dropping its §0 anchors, or restoring
+//! the superseded "the fix needs an HA session-sync wire bump" wording in the
+//! README makes this test go RED.
+//!
+//! The doc claims are also bound to the code they describe, so the decision
+//! record cannot silently drift away from the runtime:
+//!   * `SessionKey` is still the bare 5-tuple (no routing-domain field). When
+//!     Track B lands this assertion fires and the README/plan MUST be updated
+//!     in the same change — that is the point.
+//!   * `install_with_protocol_with_origin` still opens with an unconditional
+//!     `remove_entry(&key)`, which is why "decline the cross-domain hit and
+//!     fall through to the session-miss path" is not a viable cheap mitigation
+//!     (the two colliding flows would evict each other per packet).
+//!   * `pkg/cluster/sync_protocol.go` still uses length-gated trailing VALUE
+//!     fields, which is why the domain can be carried additively with no
+//!     `CurrentHAProtocolVersion` bump (plan §0a, correcting plan §4d).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("userspace-dp should live directly under the repo root")
+        .to_path_buf()
+}
+
+fn read(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_else(|e| panic!("cannot read {}: {}", path.display(), e))
+}
+
+#[test]
+fn vrf_session_identity_decision_record_exists_and_matches_runtime() {
+    let root = repo_root();
+    let plan_rel = "docs/research/2387-vrf-flow-identity/plan.md";
+    let plan_path = root.join(plan_rel);
+    let readme_path = root.join("userspace-dp/src/afxdp/forwarding/README.md");
+
+    let readme = read(&readme_path);
+
+    // The README must still be the citer; if the citation is dropped, this
+    // guard has no subject and should be deleted deliberately, not silently.
+    assert!(
+        readme.contains(plan_rel),
+        "{} must cite the #2387 decision record {plan_rel}",
+        readme_path.display()
+    );
+
+    // The decision record itself must be on master, not stranded on a research
+    // branch. `read` panics with the path when it is missing.
+    let plan = read(&plan_path);
+
+    for anchor in [
+        "## 0. v5 engineering-time addendum",
+        "### 0a.",
+        "does NOT bump SessionSyncWireVersion",
+        "install.rs:139",
+        "**DENY**",
+        "**ISOLATE**",
+    ] {
+        assert!(
+            plan.contains(anchor),
+            "{} must keep the {anchor:?} anchor the #2387 README claims rest on",
+            plan_path.display()
+        );
+    }
+
+    // The superseded cost claim (plan §4d as applied to a VALUE-carried domain)
+    // must not come back into the shipped README: the fix does NOT need an HA
+    // protocol-version bump.
+    assert!(
+        !readme.contains("wire bump"),
+        "{} still carries the superseded \"HA session-sync wire bump\" claim for #2387; \
+         the routing-domain rides as a length-gated trailing VALUE field (plan §0a)",
+        readme_path.display()
+    );
+    for required in [
+        "The HA session-sync wire does NOT need a version bump",
+        "`CurrentHAProtocolVersion` never moves.",
+        "Do NOT \"decline the hit and fall through\"",
+    ] {
+        assert!(
+            readme.contains(required),
+            "{} must document {required:?} (#2387 plan §0)",
+            readme_path.display()
+        );
+    }
+}
+
+#[test]
+fn vrf_session_identity_doc_claims_still_match_the_code() {
+    let root = repo_root();
+
+    // Claim 1: the identity is still the bare 5-tuple. When Track B widens it,
+    // this fires so the decision record is updated in the same change.
+    let key_rs = read(&root.join("userspace-dp/src/session/key.rs"));
+    assert!(
+        !key_rs.contains("routing_domain"),
+        "SessionKey grew a routing-domain discriminator — update the #2387 \
+         decision record (docs/research/2387-vrf-flow-identity/plan.md) and the \
+         \"Session identity is NOT VRF-aware\" section of \
+         userspace-dp/src/afxdp/forwarding/README.md in this change"
+    );
+
+    // Claim 2: session install unconditionally evicts a same-key incumbent,
+    // which is why declining a cross-domain hit and falling through to the
+    // session-miss path is not a viable mitigation.
+    let install_rs = read(&root.join("userspace-dp/src/session/install.rs"));
+    assert!(
+        install_rs.contains("let _previous = self.remove_entry(&key);"),
+        "session install no longer unconditionally evicts a same-key incumbent — \
+         the #2387 README/plan rationale for rejecting \"decline the hit and fall \
+         through\" no longer holds and must be revisited"
+    );
+
+    // Claim 3: the cross-chassis session wire still grows by length-gated
+    // trailing VALUE fields, so a routing-domain is an append, not a flag day.
+    let sync_go = read(&root.join("pkg/cluster/sync_protocol.go"));
+    assert!(
+        sync_go.contains("length-gated trailing field"),
+        "pkg/cluster/sync_protocol.go lost its length-gated trailing-field \
+         contract — the #2387 plan §0a \"no HA protocol-version bump\" finding \
+         must be re-derived"
+    );
+    assert!(
+        sync_go.contains("if off+8 <= len(payload)"),
+        "pkg/cluster/sync_protocol.go lost the bounds-gated trailing-field \
+         decode that makes an absent #2387 routing-domain decode as the default \
+         routing-instance for a legacy peer"
+    );
+
+    // Claim 4: the Rust<->Go control-socket session sync is serde-defaulted, so
+    // the same append is additive there too.
+    let control_rs = read(&root.join("userspace-dp/src/protocol/control.rs"));
+    let sync_req = control_rs
+        .split_once("pub(crate) struct SessionSyncRequest {")
+        .expect("SessionSyncRequest struct should exist in protocol/control.rs")
+        .1;
+    let sync_req_body = sync_req
+        .split_once("\n}")
+        .expect("SessionSyncRequest struct should be brace-terminated")
+        .0;
+    assert!(
+        sync_req_body.contains("serde(default)"),
+        "SessionSyncRequest is no longer serde-defaulted — the #2387 plan §0a \
+         additive control-socket finding must be re-derived"
+    );
+}


### PR DESCRIPTION
Advances #2387. **Does not fix it** — the cross-VRF session-reuse bug is
untouched and the issue stays open pending one maintainer call (see
"Open decision" below). Deliberately not using a close keyword.

## Why

`userspace-dp/src/afxdp/forwarding/README.md` documents the #2387
single-forwarding-domain session-identity limitation and cites
`docs/research/2387-vrf-flow-identity/plan.md` as the decision record for the
deferred real fix. That plan lived ONLY on the unmerged
`research/2387-vrf-flow-identity` branch, so the shipped citation dangled — the
same failure `pkg/api/zone_counter_doc_ref_test.go` was written to prevent
after it happened once for #3643.

Worse, the shipped README asserts the fix requires "the HA session-sync wire
bump". That is **wrong**, and it is the claim that has kept #2387 deferred.

## What

Land the plan + its six reviewer files, and add a v5 §0 addendum with three
first-hand findings verified against current master:

**§0a — there is no HA wire break.** Plan §4d is right that the session-sync
wire KEY block is fixed-width and not length-gated. It is wrong to conclude the
routing-domain must live there. It rides as a length-gated trailing **VALUE**
field exactly like #2170 `Generation`, #3301 `AppTimeout`/`PolicyCounterIdx`,
#4565 `Nat64SnatV4`, #5274 `ConfigEpoch`, #5212 `RTFlowSessionID` — the decoder
reads each under `if off+N <= len(payload)` and still returns ok, and the repo
states the rule outright at `sync_protocol.go:930` ("does NOT bump
`SessionSyncWireVersion`"). `SessionSyncRequest` on the Rust↔Go control socket
is all `#[serde(default)]`, so the same append is additive there too. Interning
**domain 0 = the default routing-instance** makes a legacy peer's omitted field
decode to the default VRF, so a non-VRF cluster is bit-identical across the
mixed-version window, `CurrentHAProtocolVersion` never moves, and the #1930
mixed-base ISSU gate is never tripped. This was plan §11 Q5 — called there
*"the single biggest lever on B-min's cost"*.

**§0b — "decline the hit and fall through" is not a viable cheap middle.**
`install_with_protocol_with_origin` opens with an unconditional
`remove_entry(&key)` (`session/install.rs:139`), so two colliding flows would
evict each other on every packet and per-packet SNAT re-allocation breaks both.
Only a fail-closed DROP or a widened identity are coherent end-states.

**§0c — corner inventory the plan lacked.** GRE decap is SAFE
(`try_native_gre_decap_from_frame` rebinds the inner `ingress_ifindex` to
`endpoint.logical_ifindex`, `gre.rs:760`, so a decapped flow's domain is
stable); fabric cross-chassis ingress needs an explicit exemption; the §7
inter-VRF route-leaked corner is much cheaper than v4 assumed if the ingress
AND egress domain live in `SessionMetadata` (which already stores and swaps the
ingress/egress zone pair) rather than in the key.

Also recorded: **Track A is complete** (A.1 #4327 commit warning, A.2
`42bc6bc88` logical flow-cache key, A.3 docs), so the conntrack table is now
the **sole** collision surface.

## Open decision this unblocks

Narrowed from v4's "is overlapping-subnet multi-tenant VRF in product scope?"
to one binary:

> On a cross-VRF 5-tuple collision, do we **DENY** the second flow
> (fail-closed drop; small, Rust-only, no wire) or **ISOLATE** it (widen the
> identity; Junos semantics)?

Recommendation in the plan is **ISOLATE**: DENY is not Junos semantics (a Junos
session table is per-routing-instance), hands a tenant a denial primitive
against a co-tenant, and contradicts the already-shipped A.1 warning text; and
the cost objection that justified deferring ISOLATE has been retired by §0a.

## Validation

New `userspace-dp/tests/vrf_session_identity_doc_guard.rs` binds the decision
record to the code it describes — the plan must exist with its §0 anchors, the
README must cite it and must not carry the superseded wire-bump wording,
`SessionKey` must still be the bare 5-tuple (so widening it forces a doc update
in the same change), session install must still evict a same-key incumbent, and
the Go/Rust sync surfaces must still be length-gated / serde-defaulted.

RED-on-revert proven by mutation in a throwaway detached worktree, crate
building clean in each case (no false reds):

| mutation | result |
|---|---|
| delete the plan doc | `cannot read .../plan.md: No such file or directory` |
| revert the README to `origin/master` | `still carries the superseded "HA session-sync wire bump" claim` |
| drop the `remove_entry(&key)` token | `session install no longer unconditionally evicts a same-key incumbent` |

Full `cargo test --release --bins --tests` green (4217 + siblings, 0 failed);
`rustfmt --check` and `clippy` clean on the new file. No Go files touched, so
the Go leg is unaffected. No dataplane behaviour change, so no cluster smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
