### PR TITLE
cluster: keep heartbeat anti-replay state across a heartbeat restart (#5086)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -65633,3 +65633,21 @@ break — `go vet` confirmed passing under every revert.
   pkg/cluster/heartbeat_auth_test.go,
   pkg/cluster/controllink_auth_status_4484_test.go, pkg/cluster/README.md,
   _Log.md
+
+- **Timestamp**: 2026-08-01 01:55
+- **Action**: #6642 review fold — correct the anti-replay ring's stated unit
+  (peer SESSION, not daemon incarnation) in both the code comments and the
+  cluster README, and give `heartbeatReceiver.peerAuthenticated()` a caller
+  again. Both findings were raised independently by the hostile Claude review
+  (MINOR-1, MINOR-2) and by Codex (finding 2), which converged on the doc
+  defect. A session id is minted per `heartbeatSender`, so a peer heartbeat
+  restart (VRF rebind, HA comms restart) mints one without a daemon boot: the
+  `heartbeatReplaySessions`+1 churn bound is 65 recorded SESSIONS, cheaper to
+  harvest than 65 daemon boots, and routine peer restarts now consume ring
+  slots permanently because the ring outlives a local restart. Neither is a
+  regression — pre-#5086 any local restart wiped the ring entirely, so this
+  worst case is a strict subset. `readLoop` now reaches the sticky flag through
+  `r.peerAuthenticated()` instead of `r.auth.peerAuthenticated()`, so the
+  accessor the PR orphaned has one caller and one definition again.
+  Docs-and-wiring only: no runtime behaviour change.
+- **File(s)**: pkg/cluster/heartbeat.go, pkg/cluster/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -65606,3 +65606,30 @@ break — `go vet` confirmed passing under every revert.
 - **File(s)**: pkg/refactoraudit/audit_canary_test.go, pkg/refactoraudit/doc.go,
   docs/refactoring-audit-current.txt, docs/refactoring-audit.md,
   scripts/refactoring-audit.sh, Makefile, _Log.md
+
+- **Timestamp**: 2026-08-01
+- **Action**: #5086 — anchor heartbeat anti-replay state to the Manager so a
+  heartbeat restart cannot reset it. #5477 gave the receiver a bounded set of
+  retired-session watermarks, but the tracker was a `heartbeatReceiver` field
+  and every `StartHeartbeat` builds a new receiver — including
+  `RestartHeartbeat` on a DHCP-triggered VRF rebind and the HA comms restart,
+  both routine. The replacement receiver started EMPTY, so captured
+  authenticated frames from retired peer incarnations were all re-admitted as
+  never-seen, refreshing peer liveness and applying stale election state; a
+  dead peer kept looking alive and the survivor never took over. Measured
+  pre-fix: 20/60 replayed frames admitted per restart (~4 s of forged liveness
+  vs the ~1 s peer-dead window), fresh on every restart. Moved the replay ring
+  + sticky `peerAuthSeen` into `Manager.hbAuth` (`heartbeatAuthState`, its own
+  mutex now that it outlives one readLoop); receivers hold a pointer.
+  `HeartbeatPeerAuthSeen` reads it directly, closing the mirror hole where
+  `StopHeartbeat` nil'd `m.hbReceiver` and silently disarmed the gRPC fabric
+  downgrade-guard for the restart window (~5 s on a VRF-rebind bind retry).
+  Memory bound unchanged and restart-independent: one fixed 64 x 16 B ring per
+  Manager. No wire change, no added failover latency. Residual (in-memory
+  state is still lost on a full daemon restart, and the >=65-recording ring
+  churn) needs the signed boot-epoch — #6169.
+- **File(s)**: pkg/cluster/heartbeat.go, pkg/cluster/manager.go,
+  pkg/cluster/peer_state.go, pkg/cluster/heartbeat_replay_restart_5086_test.go,
+  pkg/cluster/heartbeat_auth_test.go,
+  pkg/cluster/controllink_auth_status_4484_test.go, pkg/cluster/README.md,
+  _Log.md

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -228,7 +228,7 @@ peer liveness (`lastSeen`) or drive election.
   **Retired-session replays are rejected (#5477).** The pre-#5477 tracker
   held exactly ONE `(session, counter)` and RE-ANCHORED on ANY session
   change, so an on-link attacker who recorded authenticated frames from
-  two incarnations A and B could alternate A→B→A→B indefinitely — each
+  two sessions A and B could alternate A→B→A→B indefinitely — each
   switch reset the single watermark and re-admitted the SAME recorded A
   frames, refreshing peer liveness and applying their stale role/priority
   before `handlePeerHeartbeat`. HMAC blocks forging a NEW session but not
@@ -237,18 +237,26 @@ peer liveness (`lastSeen`) or drive election.
   the highest the genuine peer ever signed). Session ids are RANDOM
   (unordered), so a strictly-newer test like `fullSetSeqGuard` cannot be
   used — a bounded per-session watermark is the mechanism that separates a
-  real reboot (new id) from a replay of a retired incarnation (known id,
+  real reboot (new id) from a replay of a retired session (known id,
   no counter advance). **Bound safety and its honest limit:** the ring
-  RAISES the on-link replay attacker's cost — from 2 recorded incarnations
+  RAISES the on-link replay attacker's cost — from 2 recorded sessions
   (the pre-#5477 A→B→A loop) to `heartbeatReplaySessions`+1 — but is NOT an
   absolute bar. Eviction is FIFO and is triggered by ANY never-seen session,
   INCLUDING a REPLAYED old frame whose session is not currently in the ring:
   admit() treats it as never-seen, re-records it, and evicts the oldest.
   FIFO always leaves exactly one just-evicted session to replay back in as
   never-seen, so an attacker who captured `heartbeatReplaySessions`+1 (= 65)
-  or more distinct incarnations can churn the ring by REPLAY ALONE (no
+  or more distinct sessions can churn the ring by REPLAY ALONE (no
   reboot, no minting) and SUSTAIN the replay indefinitely; with fewer than
-  65 recordings every retired-session replay is rejected. A complete fix
+  65 recordings every retired-session replay is rejected.
+  **The unit is a peer SESSION, not a peer daemon boot.** A session id is
+  minted per `heartbeatSender`, so every peer heartbeat restart (VRF rebind,
+  HA comms restart) mints a fresh one with no reboot involved. So the 65 above
+  is 65 recorded heartbeat sessions — cheaper to harvest than 65 daemon
+  incarnations — and routine peer restarts consume ring slots permanently now
+  that the ring outlives a local restart. Neither is a regression: before
+  #5086 any local heartbeat restart wiped the ring entirely, so this worst
+  case is a strict subset of the previous one. A complete fix
   needs a boot-epoch / monotonic-across-reboot counter carried in the frame
   (a wire change) — tracked as a follow-up (#6169). The map still causes NO
   genuine-peer lockout (an evicted live watermark just makes the peer's next
@@ -263,11 +271,11 @@ peer liveness (`lastSeen`) or drive election.
   (`daemon_ha_sync.go`), both routine. While the tracker was a receiver
   field, each of those DISCARDED every retired-session watermark, so the
   #5477 protection lasted only as long as one UDP socket: after a restart
-  an attacker replaying captured frames from a retired incarnation hit an
+  an attacker replaying captured frames from a retired session hit an
   EMPTY tracker, every frame looked never-seen, and the whole captured run
   was re-admitted — refreshing peer liveness and applying stale
   role/priority for its full length. Measured on the pre-fix code: a
-  10-frame capture from each of two incarnations yields 20 admitted frames
+  10-frame capture from each of two sessions yields 20 admitted frames
   (~4 s of forged liveness at the 200 ms interval, i.e. 4× the ~1 s
   peer-dead window) per heartbeat restart, and a fresh 20 on every
   subsequent restart. A peer that looks alive while dead is the failure
@@ -276,7 +284,7 @@ peer liveness (`lastSeen`) or drive election.
   now under a mutex taken ~5×/s) and does not change the memory bound —
   one fixed ring per `Manager` (64 × 16 B = 1 KiB) plus a mutex and an
   atomic, allocated once, never growing with restart count, uptime, or the
-  number of peer incarnations observed. It also fixes the mirror-image
+  number of peer sessions observed. It also fixes the mirror-image
   hole in `Manager.HeartbeatPeerAuthSeen`, which read the flag off
   `m.hbReceiver`: `StopHeartbeat` nils that field, so every restart
   silently DISARMED the gRPC fabric listener's downgrade-guard for the

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -250,9 +250,45 @@ peer liveness (`lastSeen`) or drive election.
   reboot, no minting) and SUSTAIN the replay indefinitely; with fewer than
   65 recordings every retired-session replay is rejected. A complete fix
   needs a boot-epoch / monotonic-across-reboot counter carried in the frame
-  (a wire change) — tracked as a follow-up. The map still causes NO
+  (a wire change) — tracked as a follow-up (#6169). The map still causes NO
   genuine-peer lockout (an evicted live watermark just makes the peer's next
   frame never-seen → admitted) and cannot grow memory (fixed 64 slots).
+- **The tracker's LIFETIME is the process, not the heartbeat (#5086).**
+  The watermarks and the sticky `peerAuthSeen` flag live in
+  `Manager.hbAuth` (`heartbeatAuthState`); a `heartbeatReceiver` holds a
+  POINTER to it. This is load-bearing, not a refactor. Every
+  `StartHeartbeat` builds a brand-new receiver, and it runs on far more
+  than a daemon boot — `RestartHeartbeat` on a DHCP-triggered VRF rebind
+  (`daemon_apply_dataplane.go`) and the HA comms (re)start
+  (`daemon_ha_sync.go`), both routine. While the tracker was a receiver
+  field, each of those DISCARDED every retired-session watermark, so the
+  #5477 protection lasted only as long as one UDP socket: after a restart
+  an attacker replaying captured frames from a retired incarnation hit an
+  EMPTY tracker, every frame looked never-seen, and the whole captured run
+  was re-admitted — refreshing peer liveness and applying stale
+  role/priority for its full length. Measured on the pre-fix code: a
+  10-frame capture from each of two incarnations yields 20 admitted frames
+  (~4 s of forged liveness at the 200 ms interval, i.e. 4× the ~1 s
+  peer-dead window) per heartbeat restart, and a fresh 20 on every
+  subsequent restart. A peer that looks alive while dead is the failure
+  that matters here: the survivor never takes over. Anchoring the state to
+  the `Manager` costs nothing on the failover path (the same integer scan,
+  now under a mutex taken ~5×/s) and does not change the memory bound —
+  one fixed ring per `Manager` (64 × 16 B = 1 KiB) plus a mutex and an
+  atomic, allocated once, never growing with restart count, uptime, or the
+  number of peer incarnations observed. It also fixes the mirror-image
+  hole in `Manager.HeartbeatPeerAuthSeen`, which read the flag off
+  `m.hbReceiver`: `StopHeartbeat` nils that field, so every restart
+  silently DISARMED the gRPC fabric listener's downgrade-guard for the
+  restart window (a VRF-rebind restart retries the bind for up to ~5 s)
+  and an unsigned fabric RPC was accepted from a peer already known to
+  hold the key. It now reads the process-lifetime state.
+  **Residual, unchanged by #5086:** the state is in memory, so a full
+  daemon restart or reboot still starts with an empty tracker and a
+  captured run replays once against the restarted node. Closing that
+  needs the same signed boot-epoch as the ≥65-recording churn — both are
+  #6169. #5086 removes the vectors an attacker can reach without the
+  survivor restarting its whole daemon.
 - **Dual-accept (rolling upgrade), `heartbeatAuthDecision`.** Mirrors
   the #4126 VRRP-checksum dual-accept migration:
   - No local key → accept everything (this node cannot verify; may be
@@ -301,8 +337,9 @@ package's dual-accept posture (`fabricAuthDecision` mirrors
 The fabric downgrade-guard arms off the heartbeat, not just the fabric
 channel. This package exposes `Manager.HeartbeatPeerAuthSeen()` — true
 once the receiver accepts a valid authed heartbeat from the peer (the
-sticky `heartbeatReceiver.peerAuthSeen`, now an `atomic.Bool` because it
-is read cross-goroutine). The gRPC interceptor rejects a tokenless fabric
+sticky `peerAuthSeen` in `Manager.hbAuth`, an `atomic.Bool` because it is
+read cross-goroutine; it hangs off the Manager rather than the receiver so
+a heartbeat restart cannot disarm the guard — #5086). The gRPC interceptor rejects a tokenless fabric
 call when EITHER a prior valid fabric token OR the heartbeat has armed
 enforcement. Rationale: nothing periodically dials the fabric listener,
 so arming only off an on-demand fabric RPC would leave a window after
@@ -632,7 +669,9 @@ posture; it does not tell you whether an existing session-sync connection
 predates the key.
 
 **Rolling BACK is not symmetric.** `peerAuthSeen` is sticky in memory and
-clears only on restart, so a node that has seen its peer authenticate will
+clears only on an **xpfd restart** — since #5086 it lives on the `Manager`,
+so restarting the heartbeat (VRF rebind, comms restart) no longer clears it
+— so a node that has seen its peer authenticate will
 reject that peer's unsigned heartbeats. Returning one node to an unkeyed
 config or an older binary while the other stays armed produces the same
 split-brain described under rotation.

--- a/pkg/cluster/controllink_auth_status_4484_test.go
+++ b/pkg/cluster/controllink_auth_status_4484_test.go
@@ -45,9 +45,9 @@ func TestControlLinkAuthStatus(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			m := &Manager{controlAuthKey: tc.key}
-			r := &heartbeatReceiver{mgr: m}
+			r := &heartbeatReceiver{mgr: m, auth: m.heartbeatAuthState()}
 			m.hbReceiver = r
-			r.peerAuthSeen.Store(tc.peerAuthSeen)
+			r.auth.peerAuthSeen.Store(tc.peerAuthSeen)
 
 			got := m.controlLinkAuthStatus()
 			engaged := strings.HasPrefix(got, "engaged")
@@ -73,9 +73,9 @@ func TestControlLinkAuthStatus(t *testing.T) {
 // helper. RED-on-revert: dropping the Authentication line makes this fail.
 func TestFormatControlPlaneStatisticsIncludesAuth(t *testing.T) {
 	m := &Manager{controlAuthKey: []byte("shared-psk-16byte")}
-	r := &heartbeatReceiver{mgr: m}
+	r := &heartbeatReceiver{mgr: m, auth: m.heartbeatAuthState()}
 	m.hbReceiver = r
-	r.peerAuthSeen.Store(true)
+	r.auth.peerAuthSeen.Store(true)
 
 	out := m.FormatControlPlaneStatistics()
 	if !strings.Contains(out, "Authentication:") {

--- a/pkg/cluster/heartbeat.go
+++ b/pkg/cluster/heartbeat.go
@@ -582,6 +582,78 @@ func (a *heartbeatAuthReplay) admit(session, counter uint64) bool {
 	return true
 }
 
+// heartbeatAuthState is the per-PEER control-channel authentication state:
+// the anti-replay watermarks and the sticky "peer has authenticated" flag.
+//
+// #5086: this state lives on the Manager (process lifetime), NOT on the
+// heartbeatReceiver (heartbeat lifetime). Every StartHeartbeat builds a brand
+// new heartbeatReceiver, and StartHeartbeat runs on far more than a daemon
+// boot — RestartHeartbeat on a DHCP-triggered VRF rebind
+// (daemon_apply_dataplane.go), and the HA comms (re)start
+// (daemon_ha_sync.go). While the tracker was a receiver field, each of those
+// routine events discarded every retired-session watermark, so the #5477
+// A->B->A rollback re-opened in full: an attacker holding captured
+// authenticated frames from retired peer incarnations replays them into the
+// empty tracker and each one is "never-seen" -> admitted, refreshing peer
+// liveness and applying stale election state for the whole captured run. A
+// heartbeat restart is exactly the moment the local node is least able to
+// afford a peer it wrongly believes is alive.
+//
+// Anchoring the state to the Manager makes the retired-session memory span the
+// process instead of the socket. The bound is unchanged and does not grow with
+// restart count, uptime, or the number of peer incarnations observed: one
+// fixed heartbeatAuthReplay ring (heartbeatReplaySessions * 16 B = 1 KiB) plus
+// a mutex and an atomic, allocated once per Manager.
+//
+// The mutex is required now that the ring outlives a single readLoop: the
+// StartHeartbeat stop-then-start sequence joins the previous readLoop before
+// the next one runs, but the tracker is no longer confined to one goroutine's
+// lifetime and must not depend on that ordering to stay race-free.
+type heartbeatAuthState struct {
+	mu     sync.Mutex
+	replay heartbeatAuthReplay
+
+	// peerAuthSeen is sticky and READ cross-goroutine
+	// (Manager.HeartbeatPeerAuthSeen, consumed by the gRPC fabric listener to
+	// arm its downgrade-guard off the fast-arming heartbeat instead of the
+	// lazily-arming on-demand fabric RPCs), so it is an atomic rather than
+	// mu-guarded.
+	peerAuthSeen atomic.Bool
+}
+
+// admit forwards to the anti-replay tracker under the state lock. Callers must
+// invoke it only after the MAC has verified — an unauthenticated caller must
+// never mutate replay state.
+func (s *heartbeatAuthState) admit(session, counter uint64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.replay.admit(session, counter)
+}
+
+// peerAuthenticated reports whether the peer has ever sent a valid
+// HMAC-authenticated heartbeat (sticky for the life of the process).
+func (s *heartbeatAuthState) peerAuthenticated() bool {
+	return s.peerAuthSeen.Load()
+}
+
+// notePeerAuthenticated records that the peer proved it holds the PSK. From
+// then on an unauthenticated frame from it is a downgrade attack.
+func (s *heartbeatAuthState) notePeerAuthenticated() {
+	s.peerAuthSeen.Store(true)
+}
+
+// heartbeatAuthState returns the Manager's process-lifetime control-channel
+// auth state — the state a new heartbeatReceiver binds to so a restart does
+// not reset anti-replay (#5086). A nil Manager (unit tests constructing a
+// standalone receiver) gets a fresh private state rather than a nil deref, so
+// a test receiver behaves exactly like a never-restarted production one.
+func (m *Manager) heartbeatAuthState() *heartbeatAuthState {
+	if m == nil {
+		return &heartbeatAuthState{}
+	}
+	return &m.hbAuth
+}
+
 // heartbeatAuthDecision applies the #4107 dual-accept policy for one received
 // heartbeat and returns whether to accept it (and, when rejected, a short
 // reason for logging — never the key or packet bytes).
@@ -671,13 +743,13 @@ type heartbeatReceiver struct {
 	recvErrors atomic.Uint64
 	startedAt  time.Time // when receiver started (for initial peer-lost detection)
 
-	// #4107 control-channel auth state. authReplay is touched only from
-	// readLoop. peerAuthSeen is written from readLoop but READ cross-goroutine
-	// (Manager.HeartbeatPeerAuthSeen, consumed by the gRPC fabric listener to
-	// arm its downgrade-guard off the fast-arming heartbeat instead of the
-	// lazily-arming on-demand fabric RPCs), so it is an atomic.
-	authReplay   heartbeatAuthReplay // per-peer anti-replay watermark
-	peerAuthSeen atomic.Bool         // sticky: peer has sent a valid authed HB
+	// auth is the #4107 control-channel auth state (anti-replay watermarks +
+	// the sticky peer-authenticated flag). It is a POINTER to state owned by
+	// the Manager, not an embedded value: the tracker must outlive this
+	// receiver so a heartbeat restart cannot discard the retired-session
+	// memory and re-open the #5086 replay. newHeartbeatReceiver always sets
+	// it; it is never nil.
+	auth *heartbeatAuthState
 }
 
 // peerAuthenticated reports whether the peer has ever sent a valid
@@ -686,7 +758,7 @@ type heartbeatReceiver struct {
 // listener reuses so its downgrade-guard engages within ~one heartbeat
 // interval of the peer coming up, not on the next on-demand fabric RPC.
 func (r *heartbeatReceiver) peerAuthenticated() bool {
-	return r.peerAuthSeen.Load()
+	return r.auth.peerAuthenticated()
 }
 
 func newHeartbeatSender(mgr *Manager, conn *net.UDPConn, peerAddr *net.UDPAddr, interval time.Duration) *heartbeatSender {
@@ -756,6 +828,14 @@ func newHeartbeatReceiver(mgr *Manager, conn *net.UDPConn, threshold int, interv
 		threshold: threshold,
 		interval:  interval,
 		stopCh:    make(chan struct{}),
+		// #5086: bind to the Manager's process-lifetime auth state so a
+		// heartbeat restart (VRF rebind, comms restart) keeps every retired
+		// peer-session watermark instead of starting from an empty tracker
+		// that re-admits captured frames. mgr is nil only in unit tests that
+		// exercise a standalone receiver; those get their own state, which is
+		// exactly the pre-#5086 per-receiver scope and is safe because such a
+		// receiver is never restarted.
+		auth: mgr.heartbeatAuthState(),
 	}
 	return r
 }
@@ -829,8 +909,8 @@ func (r *heartbeatReceiver) readLoop() {
 		key := r.mgr.controlLinkAuthKey()
 		session, counter, present := heartbeatAuthTrailer(buf[:n])
 		macOK := present && len(key) > 0 && verifyHeartbeatMAC(buf[:n], key)
-		nonceFresh := macOK && r.authReplay.admit(session, counter)
-		accept, reason := heartbeatAuthDecision(len(key) > 0, present, macOK, nonceFresh, r.peerAuthSeen.Load())
+		nonceFresh := macOK && r.auth.admit(session, counter)
+		accept, reason := heartbeatAuthDecision(len(key) > 0, present, macOK, nonceFresh, r.auth.peerAuthenticated())
 		if !accept {
 			r.recvErrors.Add(1)
 			slog.Warn("cluster: heartbeat auth rejected",
@@ -842,7 +922,7 @@ func (r *heartbeatReceiver) readLoop() {
 			// unauthenticated frame from it is a downgrade attack. This also
 			// arms the gRPC fabric listener's downgrade-guard (via
 			// Manager.HeartbeatPeerAuthSeen).
-			r.peerAuthSeen.Store(true)
+			r.auth.notePeerAuthenticated()
 		}
 
 		r.received.Add(1)

--- a/pkg/cluster/heartbeat.go
+++ b/pkg/cluster/heartbeat.go
@@ -509,7 +509,18 @@ func verifyHeartbeatMAC(data, authKey []byte) bool {
 // never-seen -> admitted) and cannot grow memory (fixed 64-slot array).
 //
 // 64 slots (64*16 = 1 KiB) bounds memory while forcing an attacker to have
-// captured 65+ distinct daemon incarnations before any replay is sustainable.
+// captured 65+ distinct peer SESSIONS before any replay is sustainable.
+//
+// The unit is a session id, not a daemon boot, and the two are not the same:
+// a session id is minted per heartbeatSender (see authSession below), so every
+// peer heartbeat RESTART — a DHCP-triggered VRF rebind, an HA comms restart —
+// mints a new one without the peer rebooting. Two consequences, both of which
+// only became relevant once #5086 made this ring outlive a local restart:
+// routine peer restarts now permanently consume slots, so the ring reaches
+// eviction pressure from legitimate traffic alone; and the attacker's capture
+// cost for the churn above is 65 sessions, which are cheaper to harvest than
+// 65 daemon boots. Neither is a regression — before #5086 any local restart
+// wiped the whole ring, so this worst case is a strict subset of that one.
 const heartbeatReplaySessions = 64
 
 // replaySessionMark is one remembered (session, high-water counter) pair.
@@ -723,9 +734,12 @@ type heartbeatSender struct {
 	sent       atomic.Uint64
 	sendErrors atomic.Uint64
 
-	// #4107 anti-replay: a random per-process session id plus a monotonic
+	// #4107 anti-replay: a random per-SENDER session id plus a monotonic
 	// per-session counter. A new sender (StartHeartbeat/RestartHeartbeat)
 	// re-seeds authSession so the receiver re-anchors after a restart/reboot.
+	// Per-sender, NOT per-process: a heartbeat restart mints a fresh session
+	// without a daemon boot, which is what makes heartbeatReplaySessions a
+	// bound on peer SESSIONS rather than on peer daemon incarnations.
 	authSession uint64
 	authCounter atomic.Uint64
 }
@@ -910,7 +924,7 @@ func (r *heartbeatReceiver) readLoop() {
 		session, counter, present := heartbeatAuthTrailer(buf[:n])
 		macOK := present && len(key) > 0 && verifyHeartbeatMAC(buf[:n], key)
 		nonceFresh := macOK && r.auth.admit(session, counter)
-		accept, reason := heartbeatAuthDecision(len(key) > 0, present, macOK, nonceFresh, r.auth.peerAuthenticated())
+		accept, reason := heartbeatAuthDecision(len(key) > 0, present, macOK, nonceFresh, r.peerAuthenticated())
 		if !accept {
 			r.recvErrors.Add(1)
 			slog.Warn("cluster: heartbeat auth rejected",

--- a/pkg/cluster/heartbeat_auth_test.go
+++ b/pkg/cluster/heartbeat_auth_test.go
@@ -303,7 +303,7 @@ func TestHeartbeatAuthReplay_BoundedRing(t *testing.T) {
 // ACCEPTS. It reconstructs the exact readLoop gate —
 //
 //	macOK      := present && len(key) > 0 && verifyHeartbeatMAC(frame, key)
-//	nonceFresh := macOK && r.authReplay.admit(session, counter)
+//	nonceFresh := macOK && r.auth.admit(session, counter)
 //	accept, _  := heartbeatAuthDecision(len(key) > 0, present, macOK, nonceFresh, peerAuthSeen)
 //
 // over real signed frames, and asserts that a #5477 A->B->A replay yields
@@ -313,7 +313,7 @@ func TestHeartbeatAuthReplay_BoundedRing(t *testing.T) {
 // would refresh liveness / drive a bogus election.
 func TestHeartbeatReplayGatesLivenessRefresh(t *testing.T) {
 	key := []byte("cluster-shared-secret")
-	r := &heartbeatReceiver{}
+	r := &heartbeatReceiver{auth: &heartbeatAuthState{}}
 
 	const (
 		sessA = 0xA11CE
@@ -325,10 +325,10 @@ func TestHeartbeatReplayGatesLivenessRefresh(t *testing.T) {
 	gate := func(frame []byte) bool {
 		session, counter, present := heartbeatAuthTrailer(frame)
 		macOK := present && len(key) > 0 && verifyHeartbeatMAC(frame, key)
-		nonceFresh := macOK && r.authReplay.admit(session, counter)
-		accept, _ := heartbeatAuthDecision(len(key) > 0, present, macOK, nonceFresh, r.peerAuthSeen.Load())
+		nonceFresh := macOK && r.auth.admit(session, counter)
+		accept, _ := heartbeatAuthDecision(len(key) > 0, present, macOK, nonceFresh, r.auth.peerAuthenticated())
 		if macOK {
-			r.peerAuthSeen.Store(true)
+			r.auth.notePeerAuthenticated()
 		}
 		return accept
 	}
@@ -428,22 +428,37 @@ func TestHeartbeatAuthDecision_ForgedFrameRejected(t *testing.T) {
 }
 
 // TestManagerHeartbeatPeerAuthSeen pins the #4107 arming wire the gRPC fabric
-// listener reads to close its post-restart downgrade window: nil receiver (no
-// heartbeat path) and an unarmed receiver report false; a receiver whose sticky
-// flag is set (a verified authed heartbeat arrived) reports true.
+// listener reads to close its post-restart downgrade window: an unarmed
+// manager reports false; once a verified authed heartbeat has arrived it
+// reports true. #5086 additionally pins that the flag is sticky for the life
+// of the PROCESS, not the life of a heartbeat — tearing the receiver down (as
+// StopHeartbeat/RestartHeartbeat do) must not disarm the guard.
 func TestManagerHeartbeatPeerAuthSeen(t *testing.T) {
 	m := &Manager{}
 	if m.HeartbeatPeerAuthSeen() {
-		t.Error("no receiver wired: expected false")
+		t.Error("no heartbeat started: expected false")
 	}
-	r := &heartbeatReceiver{mgr: m}
+	r := &heartbeatReceiver{mgr: m, auth: m.heartbeatAuthState()}
 	m.hbReceiver = r
 	if m.HeartbeatPeerAuthSeen() {
 		t.Error("receiver unarmed (peer not yet authenticated): expected false")
 	}
 	// A verified authed heartbeat arms the sticky flag (readLoop does this).
-	r.peerAuthSeen.Store(true)
+	r.auth.notePeerAuthenticated()
 	if !m.HeartbeatPeerAuthSeen() {
 		t.Error("receiver armed: expected true")
+	}
+
+	// #5086: a heartbeat restart drops the receiver and installs a new one.
+	// The peer has already PROVEN it holds the PSK, so the downgrade-guard
+	// must stay armed across the whole restart window (a VRF-rebind restart
+	// retries the bind for up to ~5s).
+	m.hbReceiver = nil
+	if !m.HeartbeatPeerAuthSeen() {
+		t.Error("#5086: tearing down the receiver must NOT disarm the downgrade-guard")
+	}
+	m.hbReceiver = &heartbeatReceiver{mgr: m, auth: m.heartbeatAuthState()}
+	if !m.HeartbeatPeerAuthSeen() {
+		t.Error("#5086: a freshly installed receiver must inherit the armed guard")
 	}
 }

--- a/pkg/cluster/heartbeat_replay_restart_5086_test.go
+++ b/pkg/cluster/heartbeat_replay_restart_5086_test.go
@@ -1,0 +1,292 @@
+package cluster
+
+import (
+	"testing"
+	"time"
+)
+
+// #5086: the heartbeat anti-replay tracker must not be reset by a heartbeat
+// restart.
+//
+// #5477 gave the receiver a bounded set of retired-session watermarks so a
+// captured A->B->A alternation is rejected. That tracker lived on the
+// heartbeatReceiver, and EVERY StartHeartbeat builds a new receiver —
+// including RestartHeartbeat on a DHCP-triggered VRF rebind and the HA
+// comms (re)start, both routine runtime events. The replacement receiver
+// therefore began with an EMPTY tracker, so every captured frame from a
+// retired peer incarnation looked never-seen and was admitted again,
+// refreshing peer liveness for the whole captured run. The fix anchors the
+// state to the Manager (process lifetime).
+//
+// The tests below drive the REAL readLoop auth gate and the REAL liveness
+// machinery (r.lastSeen -> checkTimeout -> handlePeerTimeout).
+
+// replay5086Env is one node's view: a Manager plus whichever heartbeat
+// receiver is currently installed.
+type replay5086Env struct {
+	t   *testing.T
+	m   *Manager
+	r   *heartbeatReceiver
+	key []byte
+}
+
+func newReplay5086Env(t *testing.T) *replay5086Env {
+	t.Helper()
+	m := NewManager(0, 42)
+	e := &replay5086Env{t: t, m: m, key: []byte("cluster-shared-secret")}
+	e.restartHeartbeat()
+	return e
+}
+
+// restartHeartbeat models what StartHeartbeat/RestartHeartbeat do to the
+// receiver: the old one is dropped and a brand-new one is built by
+// newHeartbeatReceiver and installed on the Manager. The sockets are not
+// created (no goroutines are started); this test drives the read path
+// directly.
+func (e *replay5086Env) restartHeartbeat() {
+	e.t.Helper()
+	e.r = newHeartbeatReceiver(e.m, nil, DefaultHeartbeatThreshold, DefaultHeartbeatInterval)
+	// start() would set this; back-date it past the cold-boot grace so
+	// peer-lost decisions are not suppressed by the #4386 startup floor.
+	e.r.startedAt = time.Now().Add(-2 * heartbeatStartupGrace)
+	e.m.mu.Lock()
+	e.m.hbReceiver = e.r
+	e.m.mu.Unlock()
+}
+
+// feed pushes one raw frame through the exact gate readLoop applies, and
+// applies the exact consequences readLoop applies on accept: refresh peer
+// liveness (lastSeen) and drive election (handlePeerHeartbeat). It reports
+// whether the frame was accepted.
+func (e *replay5086Env) feed(frame []byte) bool {
+	e.t.Helper()
+	pkt, err := UnmarshalHeartbeat(frame)
+	if err != nil {
+		e.t.Fatalf("unmarshal: %v", err)
+	}
+	session, counter, present := heartbeatAuthTrailer(frame)
+	macOK := present && len(e.key) > 0 && verifyHeartbeatMAC(frame, e.key)
+	nonceFresh := macOK && e.r.auth.admit(session, counter)
+	accept, _ := heartbeatAuthDecision(len(e.key) > 0, present, macOK, nonceFresh, e.r.auth.peerAuthenticated())
+	if !accept {
+		return false
+	}
+	if macOK {
+		e.r.auth.notePeerAuthenticated()
+	}
+	e.r.lastSeen.Store(MonotonicNanos())
+	e.m.handlePeerHeartbeat(pkt)
+	return true
+}
+
+// capture builds the authenticated frames an on-link attacker records off the
+// wire for one peer incarnation (session) — a run of n heartbeats.
+func (e *replay5086Env) capture(session uint64, n int) [][]byte {
+	e.t.Helper()
+	frames := make([][]byte, 0, n)
+	for c := 1; c <= n; c++ {
+		frames = append(frames, MarshalHeartbeatAuth(samplePkt(), e.key, session, uint64(c)))
+	}
+	return frames
+}
+
+// peerDiedAgo rewrites lastSeen so the last GENUINE heartbeat is `age` old,
+// modelling a peer that stopped transmitting `age` ago.
+func (e *replay5086Env) peerDiedAgo(age time.Duration) {
+	e.r.lastSeen.Store(MonotonicNanos() - age.Nanoseconds())
+}
+
+// TestHeartbeatReplayRejectedAfterHeartbeatRestart_5086 is the #5086
+// fail-on-revert gate. An attacker records authenticated heartbeats from two
+// retired peer incarnations A and B. The peer then DIES. A routine heartbeat
+// restart happens on the surviving node (VRF rebind / comms restart). The
+// attacker replays A->B->A->B... into the new receiver.
+//
+// Every replayed frame must be REJECTED, none may refresh peer liveness, and
+// the peer must still be declared dead on the normal schedule
+// (threshold * interval).
+//
+// RED-on-revert: the fix is binding the receiver's auth state to the Manager
+// (heartbeat.go newHeartbeatReceiver `auth: mgr.heartbeatAuthState()` +
+// Manager.hbAuth). Reverting it to a per-receiver tracker — e.g.
+// `auth: &heartbeatAuthState{}` in newHeartbeatReceiver — makes the restarted
+// receiver start empty, every replayed frame is admitted as never-seen,
+// lastSeen is refreshed, and the peer is NEVER declared dead.
+func TestHeartbeatReplayRejectedAfterHeartbeatRestart_5086(t *testing.T) {
+	e := newReplay5086Env(t)
+
+	const (
+		sessA = 0xA11CE
+		sessB = 0xB0B
+	)
+	capturedA := e.capture(sessA, 10)
+	capturedB := e.capture(sessB, 10)
+
+	// Phase 1 — the genuine peer runs incarnation A, reboots into B. The
+	// attacker records both runs off the wire; this node accepts them.
+	for _, f := range capturedA {
+		if !e.feed(f) {
+			t.Fatal("genuine incarnation A must be accepted")
+		}
+	}
+	for _, f := range capturedB {
+		if !e.feed(f) {
+			t.Fatal("genuine reboot into incarnation B must be accepted")
+		}
+	}
+	if !e.m.PeerAlive() {
+		t.Fatal("peer must be alive after genuine heartbeats")
+	}
+
+	// Phase 2 — the peer DIES. Two full timeout windows pass with no genuine
+	// traffic, then a routine heartbeat restart installs a new receiver.
+	timeout := time.Duration(DefaultHeartbeatThreshold) * DefaultHeartbeatInterval
+	e.peerDiedAgo(2 * timeout)
+	lastSeenAtDeath := e.r.lastSeen.Load()
+
+	e.restartHeartbeat()
+	e.r.lastSeen.Store(lastSeenAtDeath) // liveness carries across the restart
+
+	// Phase 3 — the attacker replays the captured A->B->A alternation.
+	admitted := 0
+	for round := 0; round < 3; round++ {
+		for i := range capturedA {
+			if e.feed(capturedA[i]) {
+				admitted++
+			}
+			if e.feed(capturedB[i]) {
+				admitted++
+			}
+		}
+	}
+	if admitted != 0 {
+		t.Errorf("#5086: %d/%d replayed heartbeats were ADMITTED after a heartbeat restart; "+
+			"a heartbeat restart must not reset the retired-session anti-replay state",
+			admitted, 3*2*len(capturedA))
+	}
+	if got := e.r.lastSeen.Load(); got != lastSeenAtDeath {
+		t.Errorf("#5086: replayed heartbeats refreshed peer liveness across a restart "+
+			"(lastSeen %d -> %d); a replay must never refresh lastSeen", lastSeenAtDeath, got)
+	}
+
+	// Phase 4 — the peer is dead and nothing genuine has arrived, so the
+	// normal peer-dead schedule must fire.
+	e.r.checkTimeout()
+	if e.m.PeerAlive() {
+		t.Error("#5086: peer still reported ALIVE after a replay-only window — " +
+			"a dead peer kept alive by replay defeats failover; the survivor never takes over")
+	}
+}
+
+// TestHeartbeatRestartStillAcceptsGenuinePeer_5086 is the NEGATIVE CONTROL.
+// Preserving anti-replay state across a heartbeat restart must not make the
+// guard reject genuine traffic — that would convert a security bug into an
+// availability bug (a peer wrongly declared dead is a split-brain risk).
+//
+// Three genuine post-restart cases must all still be accepted:
+//
+//	a) the peer never restarted and simply keeps counting (the common case);
+//	b) the peer genuinely rebooted into a brand-new session;
+//	c) that new session's counter restarts at 1, far BELOW the retired
+//	   session's watermark — proving the guard keys on (session, counter) and
+//	   not on a global monotonic counter that a real reboot would violate.
+func TestHeartbeatRestartStillAcceptsGenuinePeer_5086(t *testing.T) {
+	const (
+		sessOld = 0xD00D
+		sessNew = 0xFEED
+	)
+
+	// (a) live peer keeps counting across OUR heartbeat restart.
+	t.Run("live peer continues across restart", func(t *testing.T) {
+		e := newReplay5086Env(t)
+		for _, f := range e.capture(sessOld, 50) {
+			if !e.feed(f) {
+				t.Fatal("genuine heartbeat must be accepted")
+			}
+		}
+		e.restartHeartbeat()
+
+		// The peer is alive and unaware we restarted: it keeps advancing the
+		// SAME session past the watermark we remember.
+		for c := 51; c <= 60; c++ {
+			f := MarshalHeartbeatAuth(samplePkt(), e.key, sessOld, uint64(c))
+			if !e.feed(f) {
+				t.Fatalf("#5086 negative control: live peer's heartbeat (session %#x counter %d) "+
+					"was REJECTED after a local heartbeat restart — preserved anti-replay state "+
+					"must not lock out a peer that never restarted", uint64(sessOld), c)
+			}
+		}
+		e.r.checkTimeout()
+		if !e.m.PeerAlive() {
+			t.Error("#5086 negative control: a live peer must stay ALIVE across a local heartbeat restart")
+		}
+	})
+
+	// (b)+(c) genuine peer reboot after our restart: new session, counter
+	// restarts at 1 — below the retired session's watermark.
+	t.Run("genuine peer reboot after restart", func(t *testing.T) {
+		e := newReplay5086Env(t)
+		for _, f := range e.capture(sessOld, 50) {
+			if !e.feed(f) {
+				t.Fatal("genuine heartbeat must be accepted")
+			}
+		}
+		e.restartHeartbeat()
+
+		// The peer really rebooted: fresh random session, counter back to 1.
+		first := MarshalHeartbeatAuth(samplePkt(), e.key, sessNew, 1)
+		if !e.feed(first) {
+			t.Fatal("#5086 negative control: a genuine peer REBOOT (new session, counter 1) " +
+				"must be accepted on its FIRST frame after a local heartbeat restart — " +
+				"rejecting it would wedge failover")
+		}
+		for c := 2; c <= 10; c++ {
+			if !e.feed(MarshalHeartbeatAuth(samplePkt(), e.key, sessNew, uint64(c))) {
+				t.Fatalf("#5086 negative control: rebooted peer counter %d must be accepted", c)
+			}
+		}
+		e.r.checkTimeout()
+		if !e.m.PeerAlive() {
+			t.Error("#5086 negative control: a genuinely rebooted peer must be ALIVE")
+		}
+	})
+}
+
+// TestHeartbeatAuthStateOutlivesReceiver_5086 pins the structural invariant
+// directly at the fix site: successive receivers built by newHeartbeatReceiver
+// for the same Manager share ONE auth state, and its memory is a fixed
+// per-Manager allocation that does not grow with restart count.
+func TestHeartbeatAuthStateOutlivesReceiver_5086(t *testing.T) {
+	m := NewManager(0, 42)
+
+	first := newHeartbeatReceiver(m, nil, DefaultHeartbeatThreshold, DefaultHeartbeatInterval)
+	if first.auth == nil {
+		t.Fatal("receiver auth state must never be nil")
+	}
+	// Record a peer session on the first receiver.
+	if !first.auth.admit(0x1234, 7) {
+		t.Fatal("first sighting of a session must be admitted")
+	}
+	first.auth.notePeerAuthenticated()
+
+	// 100 heartbeat restarts.
+	var last *heartbeatReceiver
+	for i := 0; i < 100; i++ {
+		last = newHeartbeatReceiver(m, nil, DefaultHeartbeatThreshold, DefaultHeartbeatInterval)
+		if last.auth != first.auth {
+			t.Fatalf("restart %d: receiver must share the Manager's auth state, not a fresh one", i)
+		}
+	}
+
+	// The retired-session watermark survived every restart.
+	if last.auth.admit(0x1234, 7) {
+		t.Error("#5086: a replayed (session, counter) must stay rejected across heartbeat restarts")
+	}
+	if !last.auth.peerAuthenticated() {
+		t.Error("#5086: the sticky peer-authenticated flag must survive heartbeat restarts")
+	}
+	// Memory bound: one fixed ring per Manager regardless of restart count.
+	if got := len(m.hbAuth.replay.marks); got != heartbeatReplaySessions {
+		t.Errorf("replay ring = %d marks, want the fixed %d", got, heartbeatReplaySessions)
+	}
+}

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -183,6 +183,16 @@ type Manager struct {
 	hbSender   *heartbeatSender
 	hbReceiver *heartbeatReceiver
 
+	// hbAuth is the #4107 control-channel authentication state for the peer:
+	// the anti-replay watermarks plus the sticky peer-authenticated flag. It
+	// deliberately hangs off the Manager rather than the heartbeatReceiver so
+	// it survives every StartHeartbeat/RestartHeartbeat — a heartbeat restart
+	// must not hand an attacker a fresh, empty replay tracker that re-admits
+	// captured heartbeats from retired peer incarnations (#5086). Fixed size
+	// (~1 KiB), allocated once, never reset for the life of the process. Its
+	// own locking makes it safe to touch without m.mu.
+	hbAuth heartbeatAuthState
+
 	// hbStartMu serializes StartHeartbeat's stop-previous + socket-create +
 	// install sequence so two concurrent StartHeartbeat calls (e.g. a
 	// comms-restart bind-retry goroutine racing RestartHeartbeat) cannot

--- a/pkg/cluster/peer_state.go
+++ b/pkg/cluster/peer_state.go
@@ -32,19 +32,22 @@ func (m *Manager) peerHeartbeatFreshLocked() bool {
 // downgrade-guard: heartbeats flow continuously (~200ms), so this arms within
 // one interval of a keyed peer coming up — closing the post-restart window
 // where nothing had yet dialed the fabric listener on-demand to arm its own
-// sticky flag. Returns false when no heartbeat receiver is wired (standalone /
-// heartbeat not started) or the peer has not authenticated, so a node with no
-// PSK, or a rolling upgrade where the peer is not yet signing, keeps the
-// dual-accept grace. Reads m.hbReceiver under the manager lock (it may be
-// swapped by RestartHeartbeat); the flag itself is an atomic.
+// sticky flag. Returns false when the peer has never authenticated (a node
+// with no PSK, or a rolling upgrade where the peer is not yet signing), so
+// those keep the dual-accept grace.
+//
+// #5086: this reads the Manager's process-lifetime auth state, NOT the current
+// heartbeatReceiver. The flag must be sticky for the life of the process, and
+// reading it off the receiver made it sticky only for the life of a heartbeat:
+// StopHeartbeat nils m.hbReceiver and StartHeartbeat installs a fresh one, so
+// every RestartHeartbeat (a DHCP-triggered VRF rebind retries the bind for up
+// to ~5s) silently disarmed the fabric listener's downgrade-guard and re-armed
+// it only after the next authenticated heartbeat landed. An unsigned fabric
+// RPC inside that window was accepted from a peer already known to hold the
+// key. The state now outlives the socket, so the guard cannot be reset by
+// restarting the heartbeat.
 func (m *Manager) HeartbeatPeerAuthSeen() bool {
-	m.mu.RLock()
-	r := m.hbReceiver
-	m.mu.RUnlock()
-	if r == nil {
-		return false
-	}
-	return r.peerAuthenticated()
+	return m.heartbeatAuthState().peerAuthenticated()
 }
 
 // PeerNodeID returns the peer's node ID (valid only when PeerAlive is true).


### PR DESCRIPTION
Advances #5086.

## STEP 0 — what is actually still broken on master

The literal defect text in #5086 ("re-anchors on any session-id change and keeps
no memory of retired sessions") was fixed by #5477 (merged as #6167): `admit`
now keeps a bounded ring of retired-session watermarks. But that ring lives on
the **`heartbeatReceiver`**, and every `StartHeartbeat` builds a brand-new
receiver — including `RestartHeartbeat` on a DHCP-triggered VRF rebind
(`daemon_apply_dataplane.go:435`) and the HA comms (re)start
(`daemon_ha_sync.go:1333`). Neither is a daemon boot; both are routine.

So the #5477 protection lasts exactly as long as one UDP socket. I measured
this on `origin/master` before writing any fix, driving the real readLoop auth
gate over real signed frames:

| scenario | replayed frames admitted |
|---|---|
| receiver that was live during capture, A→B→A | **0 / 40** — #5477 works |
| same captures, same node, **after a heartbeat restart** | **40 / 40** |
| ONE captured incarnation, after a heartbeat restart | **300 / 300** (= 60 s of forged liveness at 200 ms) |
| 64 incarnations, no restart | 0 / 320 |
| 65 incarnations, no restart | 325 / 325 (the known #6169 churn) |

The interesting result is row 3: the attacker does **not** need 65 recordings,
which is how #6169 frames the residual. One recording plus a restart is enough,
and the forged-liveness duration is just the length of the capture.

## The fix

Anchor the anti-replay watermarks and the sticky `peerAuthSeen` flag to
`Manager.hbAuth` (a new `heartbeatAuthState`); `heartbeatReceiver` holds a
pointer. The retired-session memory now spans the **process**, not the socket.
The state carries its own mutex because it outlives a single `readLoop` and can
no longer rely on that goroutine's lifetime for confinement.

`Manager.HeartbeatPeerAuthSeen` read the same sticky flag off `m.hbReceiver`,
which `StopHeartbeat` nils — the mirror image of the same defect. Every restart
silently disarmed the gRPC fabric listener's PSK downgrade-guard for the whole
restart window (a VRF-rebind restart retries the bind for up to ~5 s), so an
unsigned fabric RPC was accepted from a peer already known to hold the key. It
now reads the process-lifetime state.

**Memory bound:** one fixed ring per `Manager` — `heartbeatReplaySessions` × 16 B
= **1 KiB** — plus a mutex and an atomic, allocated once. It does not grow with
restart count, uptime, or the number of peer incarnations observed. Unchanged
from master; only its lifetime changed.

**Failover timing:** unaffected. No handshake, no round trip, no wire change, no
persistence, no I/O. Same integer scan on the receive path, now under a mutex
taken ~5×/s at the shipped 200 ms interval.

## What remains (please do not auto-close #5086)

This does **not** fully close #5086, which is why the body says *advances*:

- The state is in memory, so a **full daemon restart or reboot** still presents
  an empty tracker and a captured run replays once against the restarted node.
- The **≥65-recording FIFO ring churn** is untouched.

Both need the same thing — a signed monotonic boot-epoch in the frame — and both
are **#6169**. This PR removes the vectors an attacker can reach *without* the
survivor restarting its whole daemon. I have added the row-3 measurement to
#6169, since it shows the attacker cost there is 1 recording, not 65.

I deliberately did not attempt the boot-epoch here: #6370 tried it and was
closed with two structural criticals (rolling-upgrade split of a keyed cluster;
the epoch check ordered *after* the ring insert, making it bypassable), and you
routed #6169 to `/research` for a coherent redesign. Re-treading that as a
drive-by would repeat the rejection. This change composes with whatever that
redesign lands — it changes the state's owner, not the wire.

## Does #6624's mandatory PSK narrow this?

**Barely, and not in the direction that matters.** The PSK stops an attacker
*minting* a frame for a session never seen on the wire, and it is what makes
`admit()` reachable at all (replay state is only mutated post-MAC-verify). It
does nothing about a **captured authentic frame**, which replays exactly as well
as a forged one — the HMAC over `(body, session, counter)` is still valid
forever. What #6624 changed is the population: now that every shipped config is
keyed, the anti-replay path is the *only* thing standing between a recorded
heartbeat and a refreshed `lastSeen`, so a hole in it is no longer masked by
"most clusters run unkeyed anyway". Net: #6624 narrows the attacker to an
on-link recorder, and this issue is precisely about an on-link recorder.

## Composition with the adjacent issues

- **#5081** (PSK/heartbeat-timing not in the transport restart key): composes,
  and this PR is a prerequisite for it. #5081's fix is to restart comms on a PSK
  or timing change — i.e. it *adds* `StartHeartbeat` triggers. On master each new
  trigger would be a new anti-replay reset; after this PR they are free.
- **#5639** (`HeartbeatPeerAuthSeen` is a replaceable sync-auth owner): this
  fixes the heartbeat half of it — the repro "recreate heartbeat/full comms with
  the peer silent, inject an unsigned heartbeat" no longer disarms the sticky
  flag. I have not audited the first-sync-frame half, so #5639 should stay open.
- **#6630** (no key-rotation overlap): no collision. Rotation breaks on
  present-but-invalid HMAC, rejected before the replay tracker is consulted. One
  doc consequence: the rotation procedure's "restart xpfd to clear the sticky
  `peerAuthSeen`" is now the *only* way to clear it — a heartbeat restart no
  longer does it incidentally. README updated to say so.

## Deliberately not done: source-address pinning

#5086's fix direction also suggests validating the peer source address
(`readLoop` discards it). I did not, and I think it should not be done: the
control link is a point-to-point L2 segment where an on-link attacker — the only
attacker this issue contemplates — can spoof the source trivially, so it adds no
security against the modelled adversary, while adding a real lockout risk if the
peer's control-link address is changed or misconfigured. The HMAC already binds
frame authenticity. Happy to be overruled.

## Gate evidence

**1. Test that fails on master.** `TestHeartbeatReplayRejectedAfterHeartbeatRestart_5086`
drives the real readLoop auth gate and the real liveness machinery
(`lastSeen` → `checkTimeout` → `handlePeerTimeout`): the peer runs incarnation A,
reboots into B, then dies; a routine heartbeat restart happens; the attacker
replays the A→B→A alternation. Asserts zero admitted, `lastSeen` never
refreshed, and the peer **declared dead on the normal `threshold × interval`
schedule**.

**2. Mutation proof.** Fix reverted to a per-receiver tracker
(`auth: &heartbeatAuthState{}` in `newHeartbeatReceiver`), test untouched.
`go build ./...` → exit 0, `go vet ./pkg/cluster/` → exit 0 (no build break):

```
--- FAIL: TestHeartbeatReplayRejectedAfterHeartbeatRestart_5086 (0.00s)
    heartbeat_replay_restart_5086_test.go:163: #5086: 20/60 replayed heartbeats were ADMITTED after a heartbeat restart; a heartbeat restart must not reset the retired-session anti-replay state
    heartbeat_replay_restart_5086_test.go:168: #5086: replayed heartbeats refreshed peer liveness across a restart (lastSeen 2794034010621370 -> 2794035010705560); a replay must never refresh lastSeen
    heartbeat_replay_restart_5086_test.go:176: #5086: peer still reported ALIVE after a replay-only window — a dead peer kept alive by replay defeats failover; the survivor never takes over
--- FAIL: TestHeartbeatAuthStateOutlivesReceiver_5086 (0.00s)
    heartbeat_replay_restart_5086_test.go:277: restart 0: receiver must share the Manager's auth state, not a fresh one
```

(20/60 rather than 60/60 because the first replay round re-records the
watermarks; 20 frames is still ~4 s of forged liveness against a ~1 s peer-dead
window, renewed on every restart.)

**3. Negative control.** `TestHeartbeatRestartStillAcceptsGenuinePeer_5086`
covers (a) a live peer that never restarted continuing the same session past the
remembered watermark, and (b) a genuine peer reboot whose new session restarts at
**counter 1 — far below the retired session's watermark**. Both accepted on the
first frame, peer stays/returns ALIVE. **This test passes both with and without
the fix** (note it is absent from the mutation FAIL list above), which is what
makes it a real control: the guard cannot be passing by rejecting every session
transition.

**4. Suites.** `go test ./pkg/cluster/ ./pkg/daemon/ -count=1` green;
`./pkg/grpcapi/` green (it consumes `HeartbeatPeerAuthSeen`); `./pkg/cluster/`
also green under `-race`.

**5. Docs.** `pkg/cluster/README.md` updated: the tracker's lifetime is now part
of the documented contract, with the measured pre-fix numbers, the unchanged
memory bound, the `HeartbeatPeerAuthSeen` consequence, and the explicit residual
pointing at #6169. Two stale statements corrected (`heartbeatReceiver.peerAuthSeen`
→ `Manager.hbAuth`; "clears only on restart" → "clears only on an xpfd restart").

## Smoke

**Cluster smoke required before merge** — this touches the HA heartbeat receive
path. Not run: the loss userspace cluster is shared and lock-managed, and you
schedule it. `make test-failover` is the relevant target; the negative-control
behaviour (peer reboot accepted immediately after a local heartbeat restart) is
what it exercises on real hardware.
