### PR TITLE
fix(ha): recover poison on the synced-session generation-guard reads

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -65606,3 +65606,40 @@ break — `go vet` confirmed passing under every revert.
 - **File(s)**: pkg/refactoraudit/audit_canary_test.go, pkg/refactoraudit/doc.go,
   docs/refactoring-audit-current.txt, docs/refactoring-audit.md,
   scripts/refactoring-audit.sh, Makefile, _Log.md
+
+- **Timestamp**: 2026-08-01
+- **Action**: "#5154 — make the HA session-import poison policy symmetric. The
+  #2170 generation guards in `upsert_synced_session` /
+  `delete_synced_session_gen` read `sessions.synced` with `.lock().ok()`, and
+  the #5674 admission bound read its length with
+  `.lock().map(..).unwrap_or(0)`. After a CONTAINED worker panic (#925
+  supervisor) poisoned that mutex, all three reads yielded 'nothing stored,
+  empty map', so every guard fell through — while the WRITE half
+  (`publish_shared_session` / `remove_shared_session`) commits through
+  `lock_shared_recover`, which `clear_poison()`s and mutates anyway.
+  Validation and mutation applied OPPOSITE poison policies, so a stale-
+  generation install regressed the stored generation, a stale delete removed
+  a NEWER live entry, and an over-ceiling import bypassed the aggregate bound
+  — a fail-OPEN on an ordering guard, reached by a path the system is designed
+  to survive. Fixed by RECOVERING the reads (the established #2402/#1807
+  module policy) rather than refusing the writes: `lock_shared_recover` clears
+  poison, so a refuse-on-poison write would fire nondeterministically
+  depending on which thread locked first, and would wedge HA session sync
+  after a panic the supervisor already contained. `upsert_synced_session` now
+  takes its stored-entry and length reads under ONE guard, which also closes a
+  real TOCTOU (they were separate locks, so the ceiling could be evaluated
+  against a map that had changed between them). Validation: 3 new tests
+  (stale install refused, stale delete refused, negative control that a
+  current-generation install/delete still applies across poisoning);
+  two-stage mutation proof — reverting ONLY the upsert read reds ONLY the
+  install test (`left: Some(1)` right `Some(2)`, the generation regressed),
+  reverting ONLY the delete read reds ONLY the delete test (`left: None`
+  right `Some(2)`, the live entry was removed), both with `cargo build
+  --release` clean (0 errors). Full `cargo test --release --bins --tests --
+  --test-threads=1` green (4354 passed / 0 failed). Filed #6641: the
+  `SHARED_SESSION_POISON_RECOVERIES` counter is still not exported as a
+  Prometheus metric, unlike its #1807 twin. HA cluster smoke required
+  (session-sync path) — scheduled by the team lead, not run here."
+- **File(s)**: userspace-dp/src/afxdp/ha/session_import.rs,
+  userspace-dp/src/afxdp/ha_tests.rs, userspace-dp/src/afxdp/README.md,
+  _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -65643,3 +65643,33 @@ break — `go vet` confirmed passing under every revert.
 - **File(s)**: userspace-dp/src/afxdp/ha/session_import.rs,
   userspace-dp/src/afxdp/ha_tests.rs, userspace-dp/src/afxdp/README.md,
   _Log.md
+
+- **Timestamp**: 2026-08-01
+- **Action**: "#5154 review fold (PR #6643). (1) The #5674 ceiling read was
+  repaired but NOT test-bound — the pre-existing ceiling test
+  (`upsert_synced_session_rejects_over_ceiling_import_and_does_not_fan_out`)
+  runs on a HEALTHY mutex, so reverting the `synced_len` read alone left all
+  27 HA tests green and a future cleanup could have silently undone it. Added
+  `over_ceiling_import_rejected_on_poisoned_shared_mutex`: fills the shared
+  map to the entry cap, poisons the mutex, and asserts a new over-ceiling
+  forward is still refused, counted in `synced_import_cap_drops`, and NOT
+  fanned out to the worker queue. Mutation proof — reverting ONLY the length
+  read to `.lock().map(|s| s.len()).unwrap_or(0)`, ORDERED BEFORE the
+  recovering read, reds ONLY the new test as an assertion with the build
+  clean at 0 errors; the ordering is load-bearing because
+  `lock_shared_recover` calls `clear_poison()`, so a swallowing read placed
+  AFTER it observes a healthy mutex and the mutation is invisible. Under the
+  full origin/master form (all three reads swallowing) the new ceiling test
+  and the stale-install test both red. (2) Narrowed the afxdp README: the
+  #5154 subsection now states explicitly that it establishes the policy for
+  the three reads in `ha/session_import.rs` only, and tabulates the three
+  remaining non-recovering accessors verified firsthand —
+  `snapshot_shared_session_entries` `.unwrap_or_default()` (#6652), the
+  teardown + `SharedSessionOwnerRgIndexes::clear` `if let Ok(..)` skips
+  (#6653), and `snapshot_all_sessions_export` refusing on poison (#6654).
+  Also scoped the pre-existing #2402 paragraph's 'replaces all of them' to
+  the `shared_ops.rs` helpers it actually swept. Those three sites are
+  pre-existing and filed; NOT fixed here. Full `cargo test --release --
+  --test-threads=1` green (4355 passed / 0 failed). No cluster smoke run."
+- **File(s)**: userspace-dp/src/afxdp/ha_tests.rs,
+  userspace-dp/src/afxdp/README.md, _Log.md

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -1046,7 +1046,8 @@ The old access patterns SWALLOWED that poison and lost the data:
   work (a missed demotion, a dropped publish/remove, a spurious lookup
   miss) on poison.
 
-`shared_ops::lock_shared_recover` replaces all of them with poison
+`shared_ops::lock_shared_recover` replaces those `shared_ops.rs` helpers
+with poison
 RECOVERY — `into_inner()` to keep the committed map, `clear_poison()` to
 restore the fast path, and a bump of `SHARED_SESSION_POISON_RECOVERIES`
 plus a sparse journald line so operators see the underlying worker panic.
@@ -1078,10 +1079,29 @@ removed a newer live entry, and an over-ceiling import bypassed the
 admission bound. A fail-OPEN on an ordering guard, reached by a path the
 #925 supervisor is designed to survive.
 
-All three reads now use `lock_shared_recover`, and `upsert_synced_session`
-takes its stored-entry and length reads under ONE guard (they were two
-separate locks, so the ceiling could be evaluated against a map that had
-changed between them).
+Those three reads in `ha/session_import.rs` now use `lock_shared_recover`,
+and `upsert_synced_session` takes its stored-entry and length reads under
+ONE guard (they were two separate locks, so the ceiling could be evaluated
+against a map that had changed between them). Each of the three is pinned
+by a test that poisons the mutex and asserts the guard still refuses —
+including the #5674 ceiling, which the pre-existing ceiling test could not
+cover because it runs on a healthy mutex.
+
+**Scope — this is not a module-wide guarantee.** What #5154 establishes is
+narrow: the three guard reads named above. Direct accesses to these maps
+OUTSIDE `shared_ops.rs` and `ha/session_import.rs` still swallow or refuse
+poison, so the shared-session surface as a whole does NOT yet recover
+uniformly. Known remaining sites, all pre-existing and filed separately:
+
+| Site | Pattern | Consequence | Issue |
+|---|---|---|---|
+| `coordinator/mod.rs` `snapshot_shared_session_entries` | `.unwrap_or_default()` | a reconcile crossing a poisoned mutex replays ZERO sessions | #6652 |
+| `coordinator/mod.rs` teardown + `types/mod.rs` `SharedSessionOwnerRgIndexes::clear` | `if let Ok(..)` | teardown skips poisoned maps/indexes, leaving torn state that still consumes the #5674 ceiling | #6653 |
+| `ha/export.rs` `snapshot_all_sessions_export` | `.map_err(..)` — refuses | the refusal fires by lock order, not by any property of the data | #6654 |
+
+Treat the section above as describing the policy `shared_ops.rs` and
+`ha/session_import.rs` implement, not a property every accessor of
+`sessions.synced` currently has.
 
 **Direction of the fix — recover the read, do not refuse the write.**
 Refusing to mutate on poison is not a coherent alternative here:

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -1057,6 +1057,49 @@ status reads in `state_writer.rs` / `slowpath.rs` keep
 `.lock().map(..).unwrap_or_default()` deliberately (a momentary
 default-mode status read is harmless and not on the session path).
 
+### The policy binds READS that gate a refusal, not just writes (#5154)
+
+The #2402 sweep covered `shared_ops.rs`, but the coordinator's HA
+session-import path (`ha/session_import.rs`) kept three swallowing reads —
+`upsert_synced_session` read the stored entry with `.lock().ok()` and the
+map length with `.lock().map(..).unwrap_or(0)`, and
+`delete_synced_session_gen` read with `.lock().ok()`. Each of those reads
+gates a REFUSAL: the #2170 install/delete generation guards and the #5674
+aggregate admission bound. Their writes, however, commit through
+`publish_shared_session` / `remove_shared_session`, i.e. through
+`lock_shared_recover`.
+
+So validation and mutation applied OPPOSITE poison policies. After a
+contained worker panic poisoned `sessions.synced`, the reads yielded
+"nothing stored, empty map", every guard fell through, and the recovering
+write committed the exact operation the guard exists to refuse — a
+stale-generation install regressed the stored generation, a stale delete
+removed a newer live entry, and an over-ceiling import bypassed the
+admission bound. A fail-OPEN on an ordering guard, reached by a path the
+#925 supervisor is designed to survive.
+
+All three reads now use `lock_shared_recover`, and `upsert_synced_session`
+takes its stored-entry and length reads under ONE guard (they were two
+separate locks, so the ceiling could be evaluated against a map that had
+changed between them).
+
+**Direction of the fix — recover the read, do not refuse the write.**
+Refusing to mutate on poison is not a coherent alternative here:
+`lock_shared_recover` CLEARS poison, so the poisoned window closes the
+instant any other shared-session path (publish, lookup, remove, prewarm)
+touches the mutex. A refuse-on-poison write would therefore fire or not
+fire depending on which thread locked first — a nondeterministic refusal
+of legitimate HA session sync — and would wedge session sync on an HA pair
+after a panic the supervisor already contained, which is its own outage.
+A safety property cannot rest on a flag another thread erases.
+
+Recovering also makes the panic MORE observable at these sites, not less:
+`lock_shared_recover` bumps `SHARED_SESSION_POISON_RECOVERIES` and emits
+the journald line, whereas the old `.ok()` reads recovered nothing and
+logged nothing. Note that counter is still not exported as a Prometheus
+metric, unlike its #1807 twin
+(`xpf_userspace_worker_command_queue_poison_recoveries_total`) — see #6641.
+
 ## RG-activation prewarm dedup is O(N+M) (#4069)
 
 `prewarm_reverse_synced_sessions_for_owner_rgs` runs on RG activation —

--- a/userspace-dp/src/afxdp/ha/session_import.rs
+++ b/userspace-dp/src/afxdp/ha/session_import.rs
@@ -39,11 +39,35 @@ impl crate::afxdp::Coordinator {
     pub fn upsert_synced_session(&self, entry: SyncedSessionEntry) {
         let now_secs = monotonic_nanos() / 1_000_000_000;
         let ha_state = self.ha.rg_runtime.load();
-        let previous_entry = self
-            .sessions.synced
-            .lock()
-            .ok()
-            .and_then(|sessions| sessions.get(&entry.key).cloned());
+        // #5154: read the stored entry AND the map length under ONE RECOVERED
+        // critical section. Both reads feed a REFUSAL decision (the #2170
+        // generation guard and the #5674 admission bound), and every write
+        // below commits through `lock_shared_recover`. Reading with
+        // `.lock().ok()` / `.lock().map(..).unwrap_or(0)` applied the OPPOSITE
+        // poison policy to the validation half: after a contained worker panic
+        // (#925 supervisor) poisoned this mutex, the stored entry read as None
+        // and the length read as 0, so BOTH guards silently evaluated
+        // "no previous entry, empty map" and fell through — while the
+        // recovering write then committed the very install they exist to
+        // refuse. A stale-generation import regressed the stored generation and
+        // an over-ceiling import bypassed the aggregate bound, on a code path
+        // the system is explicitly designed to SURVIVE. Recovering here (the
+        // #2402 / #1807 module policy, `lock_shared_recover`: keep the
+        // committed map, clear the poison, count + log the recovery) makes
+        // validation and mutation agree. Refusing the WRITE on poison instead
+        // is not a coherent alternative: `lock_shared_recover` CLEARS poison,
+        // so the poisoned window closes the instant any other shared-session
+        // path (publish, lookup, remove, prewarm) touches this mutex — a
+        // refuse-on-poison write would fire or not fire depending on which
+        // thread locked first, and would wedge HA session sync after a panic
+        // the supervisor already contained. Folding the two reads into one
+        // guard also removes a real TOCTOU: they were separate locks, so the
+        // ceiling could be evaluated against a map that changed (including one
+        // that had gained this very key) between them.
+        let (previous_entry, synced_len) = {
+            let sessions = lock_shared_recover(&self.sessions.synced);
+            (sessions.get(&entry.key).cloned(), sessions.len())
+        };
         // #2170 install-side guard (SMR C3): refuse a strictly-older-
         // generation install so the per-key stored generation never
         // regresses (closes the delayed-stale-install variant on the
@@ -90,12 +114,6 @@ impl crate::afxdp::Coordinator {
         // transient window never rejects legitimate imports.
         if previous_entry.is_none() && !entry.metadata.is_reverse {
             let synced_cap = self.synced_import_cap();
-            let synced_len = self
-                .sessions
-                .synced
-                .lock()
-                .map(|sessions| sessions.len())
-                .unwrap_or(0);
             if synced_cap != 0 && synced_len >= synced_cap {
                 SYNCED_IMPORT_CAP_DROPS.fetch_add(1, Ordering::Relaxed);
                 return;
@@ -241,11 +259,17 @@ impl crate::afxdp::Coordinator {
     /// generation-aware deletes. A delete_gen of 0, or a stored generation of
     /// 0, falls back to unconditional delete (rolling-upgrade safe).
     pub fn delete_synced_session_gen(&self, key: SessionKey, delete_gen: u64) {
-        let removed_entry = self
-            .sessions.synced
-            .lock()
-            .ok()
-            .and_then(|sessions| sessions.get(&key).cloned());
+        // #5154: RECOVER the poison on this read (same policy as the write
+        // below, which reaches the map through `remove_shared_session` ->
+        // `lock_shared_recover`). With `.lock().ok()` a poisoned mutex read as
+        // None, so the delete-side generation guard never evaluated — and the
+        // recovering `remove_shared_session` then deleted the entry anyway.
+        // That is a stale delete killing a NEWER same-key replacement the
+        // helper had already mirrored: exactly the outcome this guard exists
+        // to prevent, reachable via a contained worker panic.
+        let removed_entry = lock_shared_recover(&self.sessions.synced)
+            .get(&key)
+            .cloned();
         if let Some(entry) = removed_entry.as_ref()
             && entry.generation != 0
             && delete_gen != 0

--- a/userspace-dp/src/afxdp/ha_tests.rs
+++ b/userspace-dp/src/afxdp/ha_tests.rs
@@ -852,6 +852,81 @@ fn upsert_synced_session_rejects_over_ceiling_import_and_does_not_fan_out() {
     );
 }
 
+// #5154: the #5674 ceiling read must RECOVER poison too. The test above
+// exercises the ceiling on a HEALTHY mutex, so it cannot see the fail-open:
+// `upsert_synced_session` read the map length with
+// `.lock().map(|s| s.len()).unwrap_or(0)`, which on a poisoned mutex yields
+// 0 — and `0 >= synced_cap` is false for ANY nonzero cap, so the aggregate
+// admission bound was skipped entirely and the over-ceiling import was
+// admitted AND fanned out to every worker queue. Identical fail-open shape to
+// the two generation guards, in the same critical section, reached by the
+// same contained worker panic.
+//
+// PARENT-RED recipe: revert ONLY the length read to
+// `.lock().map(|s| s.len()).unwrap_or(0)`, ORDERED BEFORE the recovered
+// stored-entry read. The ordering is load-bearing: `lock_shared_recover`
+// calls `clear_poison()`, so a swallowing read placed AFTER it observes a
+// healthy mutex and the mutation is invisible. Target-count = 1 read site.
+#[test]
+fn over_ceiling_import_rejected_on_poisoned_shared_mutex() {
+    let mut coordinator = Coordinator::new();
+    const LOGICAL_CEILING: u16 = 3;
+    coordinator.synced_import_cap_override = LOGICAL_CEILING as usize;
+    let commands = Arc::new(Mutex::new(VecDeque::new()));
+    coordinator.workers.records.insert(
+        0,
+        WorkerRuntimeRecord::for_test(test_worker_handle(commands.clone())),
+    );
+
+    // Fill to the ENTRY cap (2×LOGICAL_CEILING): each admitted forward
+    // publishes a forward key AND a synthesized reverse companion.
+    for i in 0..LOGICAL_CEILING {
+        let entry = synced_entry_port(1000 + i, 0);
+        let key = entry.key.clone();
+        coordinator.upsert_synced_session(entry);
+        assert!(
+            synced_generation_recovered(&coordinator, &key).is_some(),
+            "setup: forward logical session {i} within the ceiling must be \
+             admitted before the map is at its entry cap"
+        );
+    }
+
+    let before = coordinator.synced_import_cap_drops_total();
+
+    poison_shared_synced(&coordinator);
+
+    // A NEW forward key beyond the ceiling, arriving while the mutex is
+    // poisoned, must still be drop-newest REJECTED.
+    let rejected = synced_entry_port(2000, 0);
+    let rejected_key = rejected.key.clone();
+    coordinator.upsert_synced_session(rejected);
+
+    assert!(
+        synced_generation_recovered(&coordinator, &rejected_key).is_none(),
+        "a poisoned shared mutex let an over-ceiling synced import through — \
+         the #5674 admission bound read the map length as 0 via the \
+         non-recovering read, so the ceiling never evaluated while the \
+         recovering write published the entry anyway"
+    );
+    assert_eq!(
+        coordinator.synced_import_cap_drops_total(),
+        before + 1,
+        "the over-ceiling import must be REFUSED and counted on a poisoned \
+         mutex, exactly as on a healthy one"
+    );
+
+    // And it must not reach any worker queue — the #5674 per-worker
+    // multiplication bound has to hold on the poisoned path too.
+    let pending = commands.lock().expect("commands");
+    assert!(
+        !pending.iter().any(|cmd| {
+            matches!(cmd, WorkerCommand::UpsertSynced(entry) if entry.key == rejected_key)
+        }),
+        "a rejected over-ceiling import must not be fanned out to any worker \
+         command queue, even when the shared mutex was poisoned"
+    );
+}
+
 // An equal- or newer-generation upsert must apply (equality is NOT refusal).
 #[test]
 fn upsert_synced_session_applies_equal_and_newer_generation() {

--- a/userspace-dp/src/afxdp/ha_tests.rs
+++ b/userspace-dp/src/afxdp/ha_tests.rs
@@ -923,6 +923,178 @@ fn delete_synced_session_zero_generation_is_unconditional() {
     );
 }
 
+// ── #5154: the generation guards must survive a poisoned shared mutex ──
+//
+// `upsert_synced_session` read the stored entry with `.lock().ok()` and the
+// map length with `.lock().map(..).unwrap_or(0)`;
+// `delete_synced_session_gen` read with `.lock().ok()`. After a CONTAINED
+// worker panic (#925 supervisor) poisoned `sessions.synced`, all three reads
+// silently yielded "nothing stored / empty map" — so the #2170 generation
+// guards never evaluated — while the WRITE half (`publish_shared_session` /
+// `remove_shared_session`) went through `lock_shared_recover`, which
+// `clear_poison()`s and mutates anyway. Validation and mutation applied
+// OPPOSITE poison policies, so a delayed stale-generation install regressed
+// the stored generation and a stale delete removed a newer live entry.
+//
+// The fix makes the reads RECOVER too (the #2402 / #1807 module policy), so
+// the guards always evaluate against the committed map.
+//
+// PARENT-RED recipe: restore either read to its swallowing form — e.g.
+// `let (previous_entry, synced_len) = self.sessions.synced.lock().ok()
+//  .map(|s| (s.get(&entry.key).cloned(), s.len())).unwrap_or((None, 0));`
+// in `upsert_synced_session`, or `.lock().ok().and_then(|s|
+// s.get(&key).cloned())` in `delete_synced_session_gen`
+// (userspace-dp/src/afxdp/ha/session_import.rs). Target-count = 2 read sites.
+
+// Poison `sessions.synced` deterministically: a scoped thread panics while
+// holding the lock and `join()` observes the panic (the panic is CONTAINED —
+// it never unwinds into the test thread), mirroring a worker panic under the
+// #925 supervisor. Every `lock_shared_recover` CLEARS poison, so each
+// operation under test must be freshly poisoned.
+fn poison_shared_synced(coordinator: &Coordinator) {
+    let to_poison = coordinator.sessions.synced.clone();
+    let poisoner = std::thread::spawn(move || {
+        let _guard = to_poison.lock().expect("lock before poisoning");
+        panic!("poison shared session mutex");
+    })
+    .join();
+    assert!(poisoner.is_err(), "poisoning thread must panic");
+    assert!(
+        coordinator.sessions.synced.lock().is_err(),
+        "shared session mutex must be poisoned"
+    );
+}
+
+// Read the stored generation WITHOUT `expect()` so a still-poisoned mutex
+// yields a clean assertion failure below rather than a panic in the reader.
+fn synced_generation_recovered(coordinator: &Coordinator, key: &SessionKey) -> Option<u64> {
+    coordinator
+        .sessions
+        .synced
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(key)
+        .map(|entry| entry.generation)
+}
+
+#[test]
+fn stale_generation_install_refused_on_poisoned_shared_mutex() {
+    let coordinator = Coordinator::new();
+    let key = test_key();
+    let before = coordinator.session_install_stale_ignored_total();
+
+    coordinator.upsert_synced_session(synced_entry_with_generation(2));
+    assert_eq!(synced_generation_recovered(&coordinator, &key), Some(2));
+
+    poison_shared_synced(&coordinator);
+
+    // Delayed stale install (gen=1) against stored gen=2. Pre-fix the poisoned
+    // read returned None, the guard was skipped, and `publish_shared_session`
+    // recovered the poison and OVERWROTE the entry — rolling the stored
+    // generation back to 1.
+    coordinator.upsert_synced_session(synced_entry_with_generation(1));
+    assert_eq!(
+        synced_generation_recovered(&coordinator, &key),
+        Some(2),
+        "a poisoned shared mutex let a stale-generation install roll the \
+         stored generation back — the #2170 guard was skipped by the \
+         non-recovering read while the recovering write committed it"
+    );
+    assert_eq!(
+        coordinator.session_install_stale_ignored_total(),
+        before + 1,
+        "the stale install must be REFUSED and counted, not silently applied"
+    );
+}
+
+#[test]
+fn stale_generation_delete_refused_on_poisoned_shared_mutex() {
+    let coordinator = Coordinator::new();
+    let key = test_key();
+    let before = coordinator.session_delete_stale_ignored_total();
+
+    coordinator.upsert_synced_session(synced_entry_with_generation(2));
+    assert_eq!(synced_generation_recovered(&coordinator, &key), Some(2));
+
+    poison_shared_synced(&coordinator);
+
+    // Stale delete (gen=1) against stored gen=2. Pre-fix the poisoned read
+    // returned None, so the delete-side guard never evaluated and
+    // `remove_shared_session` recovered the poison and removed the entry —
+    // a stale delete killing a newer same-key replacement.
+    coordinator.delete_synced_session_gen(key.clone(), 1);
+    assert_eq!(
+        synced_generation_recovered(&coordinator, &key),
+        Some(2),
+        "a poisoned shared mutex let a stale-generation delete remove a \
+         NEWER live entry — the #2170 delete guard was skipped by the \
+         non-recovering read while the recovering remove committed it"
+    );
+    assert_eq!(
+        coordinator.session_delete_stale_ignored_total(),
+        before + 1,
+        "the stale delete must be REFUSED and counted, not silently applied"
+    );
+}
+
+// NEGATIVE CONTROL: the fix must RECOVER the poison and keep evaluating the
+// guard — not refuse everything it sees on a poisoned mutex. A current/newer
+// install and an equal-generation delete must still APPLY across poisoning,
+// so HA session sync keeps working after a contained worker panic. (This is
+// also what rules out the "refuse the write on poison" alternative: it would
+// fail every assertion here.)
+#[test]
+fn current_generation_install_and_delete_still_apply_on_poisoned_shared_mutex() {
+    let coordinator = Coordinator::new();
+    let key = test_key();
+    let stale_installs_before = coordinator.session_install_stale_ignored_total();
+    let stale_deletes_before = coordinator.session_delete_stale_ignored_total();
+    let recoveries_before =
+        super::shared_ops::SHARED_SESSION_POISON_RECOVERIES.load(Ordering::Relaxed);
+
+    coordinator.upsert_synced_session(synced_entry_with_generation(2));
+
+    // Newer-generation install on a poisoned mutex — must APPLY.
+    poison_shared_synced(&coordinator);
+    coordinator.upsert_synced_session(synced_entry_with_generation(3));
+    assert_eq!(
+        synced_generation_recovered(&coordinator, &key),
+        Some(3),
+        "a newer-generation install must still apply after poison recovery"
+    );
+
+    // Equal-generation delete on a (re-)poisoned mutex — must APPLY.
+    poison_shared_synced(&coordinator);
+    coordinator.delete_synced_session_gen(key.clone(), 3);
+    assert!(
+        synced_generation_recovered(&coordinator, &key).is_none(),
+        "an equal-generation delete must still remove the entry after \
+         poison recovery"
+    );
+
+    // Neither legitimate operation was counted as a stale refusal.
+    assert_eq!(
+        coordinator.session_install_stale_ignored_total(),
+        stale_installs_before,
+        "a legitimate install must not be counted as a stale refusal"
+    );
+    assert_eq!(
+        coordinator.session_delete_stale_ignored_total(),
+        stale_deletes_before,
+        "a legitimate delete must not be counted as a stale refusal"
+    );
+
+    // The panic that poisoned the mutex is OBSERVABLE: each recovery bumps
+    // the shared counter and emits a journald line. Pre-fix the two guard
+    // reads recovered nothing and logged nothing.
+    assert!(
+        super::shared_ops::SHARED_SESSION_POISON_RECOVERIES.load(Ordering::Relaxed)
+            > recoveries_before,
+        "poison recoveries must be counted so the underlying worker panic \
+         is not silently self-healed"
+    );
+}
+
 // --- #4393 peer-synced SNAT reverse-NAT dnat_table publish/delete wiring ----
 
 fn synced_snat_entry() -> SyncedSessionEntry {


### PR DESCRIPTION
Closes #5154

## The defect

`upsert_synced_session` and `delete_synced_session_gen` **validated with one
poison policy and mutated with the opposite one.**

Both #2170 generation guards read the shared `sessions.synced` map with
`.lock().ok()`, and the #5674 aggregate admission bound read its length with
`.lock().map(..).unwrap_or(0)`. On a poisoned mutex those yield `None` / `0`,
so all three guards silently evaluated *"nothing stored, empty map"* and fell
through. The write half of the same functions commits through
`publish_shared_session` / `remove_shared_session` — i.e. through
`lock_shared_recover`, which `clear_poison()`s and mutates regardless.

So after a **contained** worker panic (#925 supervisor) poisoned that mutex:

| operation | pre-fix outcome |
|---|---|
| delayed strictly-older-generation install | stored per-key generation **regressed** (2 → 1) |
| stale-generation delete | removed a **newer** same-key replacement the helper had already mirrored |
| over-ceiling peer import | bypassed the #5674 aggregate admission bound |

A fail-**open** on a guard whose entire job is ordering, reached by a path the
system is explicitly designed to survive. Same bug class as #2402, at call
sites that sweep missed because they live in the coordinator's `ha/` tree
rather than in `shared_ops.rs`.

**The issue named two `.ok()` sites; there is a third fail-open in the same
critical section** — the `synced_len` read one branch below. Fixing only the
two named sites would have left a fail-open in the same function.

## (a) or (b): I chose (a) — recover the READ

Not just because it matches the module's documented #2402/#1807 policy, but
because **(b) is not a coherent safety property here.**

`lock_shared_recover` calls `clear_poison()`. The poisoned window therefore
closes the instant *any* other shared-session path — publish, lookup, remove,
prewarm — touches that mutex. A refuse-on-poison write would fire or not fire
depending on which thread happened to lock first: a **nondeterministic
refusal of legitimate HA session sync**. You cannot build a safety property on
a flag another thread erases.

(b) also carries the cost you named: wedging session sync on an HA pair after
one contained panic is its own outage, and the #925 supervisor exists
precisely so a contained worker panic does *not* take down forwarding.

The negative-control test below is what discriminates the two directions — it
fails under (b).

`upsert_synced_session` now also takes its stored-entry and length reads under
**one** guard. They were two separate locks, so the ceiling could be evaluated
against a map that had changed — including one that had gained this very key —
between them.

## Is the panic observable?

**Partly, and this fix strictly improves it.** Pre-fix, a poisoned read at
these two sites was *completely* silent: `.ok()` → `None`, no counter, no log,
no evidence that anything had been skipped. Post-fix every such read goes
through `lock_shared_recover`, which bumps `SHARED_SESSION_POISON_RECOVERIES`
and emits a journald line.

**But that counter is never exported as a metric.** Its doc comment says it is
"kept for tests and future status wiring", and its only non-test reader is
`ha_tests.rs`. Its direct twin *is* exported —
`xpf_userspace_worker_command_queue_poison_recoveries_total` (#1807) — with
full Rust→Go→Prometheus plumbing. So a contained worker panic that poisoned
shared session state remains invisible to monitoring, with only a journald
line to show for it.

I filed that as **#6641** rather than folding it in: the wiring spans 8+ files
across the Rust helper and the Go control plane and drags in fixture
regeneration, which would bury a security guard fix.

## Gate evidence

**1. Tests** (`userspace-dp/src/afxdp/ha_tests.rs`) — poison is re-established
before *each* operation, since every recovery clears it:

- `stale_generation_install_refused_on_poisoned_shared_mutex`
- `stale_generation_delete_refused_on_poisoned_shared_mutex`
- `current_generation_install_and_delete_still_apply_on_poisoned_shared_mutex` — **negative control**

**2. Mutation proof — two stages, so each read site is proven to bind its own
test.** Both stages `cargo build --release` clean at **0 errors**.

Stage 1, revert *only* the upsert read → *only* the install test reds:

```
thread '...stale_generation_install_refused_on_poisoned_shared_mutex' panicked at ha_tests.rs:996:5:
assertion `left == right` failed: a poisoned shared mutex let a stale-generation install roll the
stored generation back — the #2170 guard was skipped by the non-recovering read while the
recovering write committed it
  left: Some(1)
 right: Some(2)
test result: FAILED. 2 passed; 1 failed
```

Stage 2, revert *only* the delete read → *only* the delete test reds:

```
thread '...stale_generation_delete_refused_on_poisoned_shared_mutex' panicked at ha_tests.rs:1026:5:
assertion `left == right` failed: a poisoned shared mutex let a stale-generation delete remove a
NEWER live entry — the #2170 delete guard was skipped by the non-recovering read while the
recovering remove committed it
  left: None
 right: Some(2)
test result: FAILED. 2 passed; 1 failed
```

`left: Some(1)` is the generation regressing 2→1; `left: None` is the live
newer entry being deleted. Both are assertion failures, not build breaks.

**3. Negative control** — passes on master *and* with the fix, by design: its
job is to prove the fix is not blanket refusal (and to rule out direction (b)),
not to red on master. It asserts a newer-generation install and an
equal-generation delete still apply across poisoning, that neither is counted
as a stale refusal, and that the recovery is counted.

**4. Full suite**, exactly `make test-rust`'s form:

```
TMPDIR=/tmp CARGO_TARGET_DIR=/dev/shm/cargo-5154 \
  cargo test --release --bins --tests -- --test-threads=1
EXIT=0 — 4354 passed; 0 failed; 2 ignored
```

**5. Docs** — `userspace-dp/src/afxdp/README.md` gains a subsection under the
existing "Shared-session map poison policy (#2402)" recording that the policy
binds reads that gate a refusal (not just writes), why recovering the read is
correct and refusing the write is not, and the #6641 observability gap.

## Smoke

This touches HA session sync, so an **HA cluster smoke is required before
merge**. Not run here — flagged for the team lead to schedule.
