### PR TITLE
dataplane: bump snapshot protocol to 4 for scoped-global zone sets

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -65647,3 +65647,49 @@ break — `go vet` confirmed passing under every revert.
   pkg/dataplane/userspace/scoped_global_zoneset_protocol_5488_test.go,
   userspace-dp/src/protocol/control.rs,
   docs/userspace-dataplane-architecture.md, docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-08-01
+- **Action**: #5488 review fold (PR #6644, 5 items). **F4 — guard scope narrower
+  than the claim:** `policyScopeIsMultiZone` tests `len(FromZones) > 1 ||
+  len(ToZones) > 1`, but the only test pinning the to-zone half used a zone-pair
+  policy carrying `Match.ToZones` — a shape the compiler never produces
+  (`compiler_security_policy.go` populates the scope only for globals). Added
+  `TestScopedGlobalZoneSetGateCoversBothScopeSides` with REACHABLE rows for a
+  global scoped `from-zone trust; to-zone [ dmz untrust ]` (to-side), the from
+  side, and both sides — each asserting the singular field really is narrowed
+  before asserting the gate fires. The zone-pair row is kept, relabelled as
+  defensive breadth over the emission surface. Re-ran the to-zone-half mutation:
+  the NEW reachable row reds, not just the defensive one. **F7 — ctrl fail-close
+  on a FAILED disarm:** when `disarmSnapshotProtocolFailureLocked` errors the
+  helper stays ARMED on its previous-good snapshot, and on a same-plan refresh
+  the classifier maps were already mutated in place with ctrl enabled — the
+  shim then runs maps a generation ahead of the applied snapshot (the #4959
+  fail-open). Extracted `disarmSnapshotProtocolFailClosedLocked`, which drives
+  `userspace_ctrl` to Enabled=0 via `failClosedUserspaceCtrlMapLocked` on that
+  branch. Scope was set by the codebase's own oracle: `publishSnapshotFailClosedLocked`
+  has exactly TWO callers (Compile with `samePlanRefresh`, `syncSnapshotLocked`
+  with `true`), and BOTH had the identical hazard — so the sibling
+  `process_status.go` site is fixed too rather than shipping a fix narrower
+  than the defect. The other three gate call sites (route overlay, deferred
+  worker arm, HA reconcile) use a bare `requestLocked` and mutate no maps
+  first, so they are correctly out of scope. Every
+  `failClosedUserspaceCtrlMapLocked` return path preserves `cause`, so the
+  sentinel still satisfies `IsRequiredProtocolGateError` and the commit still
+  aborts — asserted explicitly. **F5** — disclosed the node-LOCAL residual
+  (#6650): the version never crosses the cluster heartbeat, so config-sync to a
+  pre-v4 PEER still narrows the deny. **F1/F2/F3** — refreshed the stale
+  two-gate enumerations in `userspace-dp/src/server/README.md`,
+  `docs/userspace-dataplane-gaps.md`, and `pkg/daemon/daemon_apply.go`.
+  Validation: both mutations red as ASSERTIONS with `go build ./...` +
+  `go vet ./...` CLEAN; the F7 scope controls (bootstrap path, successful
+  disarm) and all pre-existing #4959 tests stay green under the F7 mutation.
+  The F7 behavioral test needs memlock privileges (like its #4959 siblings) —
+  verified under `sudo` that all three sub-tests genuinely RUN and pass, not
+  skip. Full `go test ./...` and the Rust cargo suite green.
+- **File(s)**: pkg/dataplane/userspace/manager_compile.go,
+  pkg/dataplane/userspace/process_status.go,
+  pkg/dataplane/userspace/scoped_global_zoneset_protocol_5488_test.go,
+  pkg/dataplane/userspace/scoped_global_zoneset_failclosed_5488_test.go,
+  pkg/daemon/daemon_apply.go, userspace-dp/src/server/README.md,
+  docs/userspace-dataplane-architecture.md, docs/userspace-dataplane-gaps.md,
+  _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -65606,3 +65606,44 @@ break — `go vet` confirmed passing under every revert.
 - **File(s)**: pkg/refactoraudit/audit_canary_test.go, pkg/refactoraudit/doc.go,
   docs/refactoring-audit-current.txt, docs/refactoring-audit.md,
   scripts/refactoring-audit.sh, Makefile, _Log.md
+
+- **Timestamp**: 2026-08-01
+- **Action**: #5488 — bump the config-snapshot protocol version to 4 and gate a
+  multi-zone scoped global policy fail-closed. #4626 gave a scoped global
+  policy a zone-SET scope in the plural `match_from_zones`/`match_to_zones`
+  snapshot fields and made them authoritative, while the singular
+  `match_from_zone`/`match_to_zone` kept only the FIRST element — but left
+  `CONFIG_SNAPSHOT_PROTOCOL_VERSION` at 3, the same value a pre-#4626 helper
+  advertises AND accepts. The version handshake therefore reported agreement
+  while the two sides disagreed about the message: an old helper ignored the
+  plural fields, read the singular one, and NARROWED a global `deny` scoped
+  `[dmz trust] -> untrust` to `dmz -> untrust`, so trust-sourced traffic the
+  operator denied fell through to lower-precedence rules (a rolling-upgrade
+  fail-OPEN). Bumped both constants to 4 in lockstep — both `apply_snapshot`
+  and `bump_fib_generation` gate on EXACT equality, so a pre-v4 helper now
+  refuses the snapshot instead of misreading it. The bump alone is not enough:
+  a refused snapshot leaves that helper ARMED on its previous-good image with
+  the new deny never installed, so it is paired with
+  `ensureScopedGlobalZoneSetProtocolLocked`, a required-protocol gate in the
+  same #2138 class as the policy-scheduler / persistent-source-NAT gates. It
+  fires only when a policy's scope holds MORE THAN ONE zone on a side (a
+  one-element scope emits `singular == the one zone`, never narrowed), disarms
+  the helper, and aborts the commit via
+  `ErrScopedGlobalZoneSetProtocolIncompatible` registered in
+  `requiredProtocolGateSentinels`. The gate is keyed on the multi-zone SHAPE,
+  not the action, so it covers narrowing a `deny`/`reject` (fail-open) and a
+  `permit` (fail-closed correctness break) alike. The #4626 singular emission
+  is deliberately UNCHANGED — the fix is that no reader which would narrow it
+  can receive the snapshot. Validation: new assertion-level parent-RED on both
+  halves independently (version-collision assert and gate assert) with
+  `go build ./...` / `go vet ./...` clean under the revert; negative control
+  (single-zone scoped deny, unscoped global, zone-pair policy) stays green
+  under the revert; full `go test ./...` and the Rust
+  `cargo test --release --bins --tests` suite green. Cluster smoke pending —
+  this changes forwarding admission.
+- **File(s)**: pkg/dataplane/userspace/protocol.go,
+  pkg/dataplane/userspace/manager_compile.go,
+  pkg/dataplane/userspace/manager_capabilities_test.go,
+  pkg/dataplane/userspace/scoped_global_zoneset_protocol_5488_test.go,
+  userspace-dp/src/protocol/control.rs,
+  docs/userspace-dataplane-architecture.md, docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -6322,8 +6322,15 @@ where only `z214` collides **survives** scoped to `[z174]`. Dropping the whole
 rule there would be **fail-open**: surviving-zone (`z174`) traffic would no longer
 hit the deny and would reach a later/default permit while the snapshot publishes
 successfully. After pruning, the singular `MatchFromZone`/`MatchToZone` is
-regenerated from the surviving set (`config.ScopeSingular`) so an old Rust helper
-that reads only the singular field also sees a surviving, non-quarantined zone.
+regenerated from the surviving set (`config.ScopeSingular`) so any reader of the
+singular field sees a surviving, non-quarantined zone rather than the dropped
+one. That regeneration keeps the two shapes CONSISTENT; it is not a
+rolling-upgrade compatibility guarantee. A helper old enough to read only the
+singular field cannot receive the snapshot at all — the config-snapshot protocol
+version is `4` and both mutating verbs gate on exact equality, and a multi-zone
+scope committed against a pre-`4` helper disarms it and aborts the commit
+(`ErrScopedGlobalZoneSetProtocolIncompatible`, #5488; see
+`docs/userspace-dataplane-architecture.md` *Config-snapshot protocol version*).
 The rest of the config still loads (#1960 no-brick).
 The id→name reverse maps resolve a colliding id to the survivor deterministically
 (`config.StableZoneIDOwner`; `pkg/cli/apply.go:syslogZoneNameMap`,

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -919,8 +919,22 @@ from-zone ∈ the from-set AND its to-zone ∈ the to-set. Such a rule keeps the
 `junos-global` sentinel on its structural zones (so it stays classified in the
 `global_indices` tier and the global config order is preserved) and carries its
 context out-of-band on ADDITIVE wire fields. The singular `match_from_zone` /
-`match_to_zone` keep the FIRST zone for rolling-upgrade compatibility with an
-old helper; the plural `match_from_zones` / `match_to_zones` carry the full set.
+`match_to_zone` keep the FIRST zone (`config.ScopeSingular`); the plural
+`match_from_zones` / `match_to_zones` are AUTHORITATIVE and carry the full set.
+
+**The singular field is a display/degradation shape, NOT a rolling-upgrade
+compatibility guarantee (#5488).** #4626 added the plural fields as purely
+ADDITIVE JSON while leaving `CONFIG_SNAPSHOT_PROTOCOL_VERSION` at 3 — the same
+value a pre-#4626 helper advertises and accepts. That made the version handshake
+say "we agree" while the two sides disagreed about what the message meant: an
+old helper ignores the plural fields it does not know, reads only the singular
+one, and NARROWS a global `deny` scoped `[dmz trust] -> untrust` to
+`dmz -> untrust`, so trust-sourced traffic the operator denied falls through to
+lower-precedence rules — a rolling-upgrade fail-OPEN. The version is now **4**
+and the two constants are pinned in lockstep (see *Config-snapshot protocol
+version* below), so a multi-zone scope can never reach a reader that would
+narrow it.
+
 `parse_policy_state` prefers the plural (falling back to `[singular]`) and
 resolves it at snapshot-build time into a `GlobalZoneScope` — `Any` for no
 constraint, `Zones(SmallVec<[u16; 2]>)` for a set of defined zone ids
@@ -1561,6 +1575,70 @@ system {
 - Ensure VM has enough vCPUs: workers + 2 (daemon + kernel headroom)
 - Ensure VM has enough RAM: `workers × bindings × 160 MB + 2 GB` base (at 16384 ring,
   mlx5 driver; 192 MB for virtio_net)
+
+### Config-snapshot protocol version (#5488)
+
+Every `apply_snapshot` and `bump_fib_generation` body carries a `version`
+field. Two constants define it and **MUST be bumped in lockstep**:
+
+- **Go emitter** — `ProtocolVersion` in
+  `pkg/dataplane/userspace/protocol.go`, stamped onto every snapshot the
+  builder produces.
+- **Rust consumer** — `CONFIG_SNAPSHOT_PROTOCOL_VERSION` in
+  `userspace-dp/src/protocol/control.rs`.
+
+Both mutating verbs gate on **EXACT equality**, not `>=`
+(`userspace-dp/src/server/handlers/snapshot.rs`, `apply` and `bump_fib`):
+a helper at any other version refuses the body before touching dataplane
+state, rather than decoding it under its own, narrower contract. The
+lockstep is pinned by `TestSnapshotProtocolVersionLockstepWithRust`,
+which parses the Rust constant rather than mirroring it in a comment.
+
+**What the version means.** It is the meaning of the snapshot message,
+not a feature inventory. Bump it whenever a change makes an older reader
+interpret the SAME bytes differently — in particular whenever a new field
+becomes authoritative over an existing one. A field that is purely
+additive *in meaning* (an old reader that ignores it still enforces
+exactly what it enforced before) does not need a bump; a field that
+changes what a rule COVERS does.
+
+**Why it is at 4.** #4626 gave a scoped global policy a zone-SET scope in
+the plural `match_from_zones`/`match_to_zones` fields, made them
+authoritative, and left the singular `match_from_zone`/`match_to_zone`
+carrying only the FIRST element — but did not bump the version. A
+pre-#4626 helper at the same advertised version 3 therefore accepted the
+snapshot, read only the singular field, and NARROWED a multi-zone global
+`deny` to one zone, letting the dropped zones' traffic reach a
+lower-precedence permit. That is the dangerous direction: a handshake
+that reports agreement while the two sides disagree about the message.
+The invariant #5488 records is that **a compatibility extension which
+changes deny/reject COVERAGE must not be silently ignorable under an
+unchanged protocol version.**
+
+**The bump is paired with a fail-closed gate.** On its own, a bump only
+makes an old helper *refuse* the snapshot — and a refused snapshot leaves
+that helper ARMED on its previous-good image, still forwarding, with the
+newly committed deny never installed. So the version bump is paired with
+`ensureScopedGlobalZoneSetProtocolLocked`
+(`pkg/dataplane/userspace/manager_compile.go`), a required-protocol gate
+in the same class as the policy-scheduler and persistent-source-NAT gates
+(#2138): when the committed config carries a policy whose scope holds
+more than one zone on a side and the running helper reports a
+`ConfigSnapshotProtocolVersion` below `ProtocolVersion`, the daemon
+DISARMS the helper (`set_forwarding_state{armed:false}`) and the commit
+ABORTS with `ErrScopedGlobalZoneSetProtocolIncompatible`, which is
+registered in `requiredProtocolGateSentinels`. The lenient-load doctrine
+(#1960) is unchanged: a boot or peer-sync apply of an already-persisted
+config disarms and logs rather than bricking the node; only the
+operator-facing commit path surfaces the abort.
+
+The gate is keyed on the multi-zone **shape**, not the action, so it
+covers both directions of misrepresentation — narrowing a `deny`/`reject`
+(fail-open) and narrowing a `permit` (a fail-closed correctness break). A
+**single-zone** scope emits `singular == the one zone` and an unscoped
+global emits neither side, so neither can be narrowed by a singular-only
+reader and neither is gated; that keeps the disarm blast radius to
+exactly the misrepresentable population.
 
 ### Control-socket request size cap (#2523, #2744)
 

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -1640,6 +1640,27 @@ global emits neither side, so neither can be narrowed by a singular-only
 reader and neither is gated; that keeps the disarm blast radius to
 exactly the misrepresentable population.
 
+If the disarm ITSELF fails, the helper is still armed on its
+previous-good snapshot — and on a publish path whose classifier BPF maps
+were already mutated in place, the shim would be redirecting transit to
+XSK against maps a generation ahead of what the helper is enforcing. So
+`disarmSnapshotProtocolFailClosedLocked` additionally drives
+`userspace_ctrl` to `Enabled=0` on exactly the two paths that pass
+`mapsMutatedInPlace=true` to `publishSnapshotFailClosedLocked` (Compile's
+`samePlanRefresh` and `syncSnapshotLocked`), dropping transit to the
+kernel-only fail-closed posture. The wrap preserves the gate sentinel, so
+the commit still aborts.
+
+**Residual: this version is node-LOCAL (#6650).** The snapshot protocol
+version governs the daemon↔local-helper socket only; it never crosses the
+cluster heartbeat. In a mixed-version HA pair, node A (v4) commits a
+multi-zone scope, its own gate does not fire because its own helper is
+v4, and `pushCommittedConfigToPeer` ships the config TEXT to node B —
+whose v3 daemon compiles it and narrows the deny against its own v3
+helper. That is the same fail-open relocated from "old helper" to "old
+peer node", and it is NOT closed here: closing it needs a scope signal on
+the config-sync/heartbeat wire. Tracked as #6650.
+
 ### Control-socket request size cap (#2523, #2744)
 
 Each control-socket request is a single newline-delimited JSON body. The

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -264,7 +264,10 @@ There are two distinct fallback boundaries:
      it relies on the helper integrity reject (previous-good retained /
      fresh-boot default-deny) so it never fails open to the kernel.
    - Required-generation protocol gates (policy schedulers, persistent
-     source NAT) that disarm forwarding on a too-old helper are ALSO
+     source NAT, and — since #5488 — a scoped-global policy whose zone scope
+     holds MORE THAN ONE zone on a side, which a pre-v4 helper would NARROW
+     to the first zone by reading only the singular `match_from_zone`/
+     `match_to_zone`) that disarm forwarding on a too-old helper are ALSO
      enforced on the explicit arm path (#5648 / M43b): `SetForwardingArmed(true)`
      re-runs `ensureRequiredSnapshotProtocolLocked` and refuses to arm a
      stale accepted image, so an operator/gRPC arm cannot undo the disarm.

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -178,8 +178,10 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	//
 	// This MUST run before any reconcile step that can abort applyConfigLocked
 	// early — specifically the dataplane apply below, which returns early on a
-	// required userspace protocol-gate error (compileErrorMustAbortApply:
-	// policy-scheduler OR persistent-source-NAT protocol incompatibility, #2138).
+	// required userspace protocol-gate error (compileErrorMustAbortApply, which
+	// delegates to userspace.IsRequiredProtocolGateError — policy-scheduler,
+	// persistent-source-NAT, or multi-zone scoped-global protocol
+	// incompatibility, #2138 / #5488).
 	// Store.Commit() has ALREADY promoted and persisted this compiled config
 	// before applyConfigLocked runs, so the committed authorization is live
 	// regardless of whether the later dataplane apply succeeds. Reconciling

--- a/pkg/dataplane/userspace/manager_capabilities_test.go
+++ b/pkg/dataplane/userspace/manager_capabilities_test.go
@@ -271,6 +271,7 @@ func TestIsRequiredProtocolGateError(t *testing.T) {
 	for _, sentinel := range []error{
 		ErrPolicySchedulerProtocolIncompatible,
 		ErrPersistentSourceNATProtocolIncompatible,
+		ErrScopedGlobalZoneSetProtocolIncompatible,
 	} {
 		if !IsRequiredProtocolGateError(sentinel) {
 			t.Errorf("IsRequiredProtocolGateError(%v) = false, want true (bare sentinel)", sentinel)

--- a/pkg/dataplane/userspace/manager_compile.go
+++ b/pkg/dataplane/userspace/manager_compile.go
@@ -17,6 +17,20 @@ var ErrPolicySchedulerProtocolIncompatible = errors.New("userspace policy schedu
 
 var ErrPersistentSourceNATProtocolIncompatible = errors.New("userspace persistent source NAT snapshot protocol incompatible")
 
+// ErrScopedGlobalZoneSetProtocolIncompatible is the #5488 required-protocol
+// gate sentinel: the committed config carries a policy whose scoped-global zone
+// context holds MORE THAN ONE zone on a side, and the running helper's accepted
+// ConfigSnapshotProtocolVersion predates the v4 contract in which the plural
+// match_from_zones/match_to_zones snapshot fields are AUTHORITATIVE.
+//
+// Such a helper reads only the singular match_from_zone/match_to_zone, which
+// carry the FIRST element (config.ScopeSingular), so it NARROWS the rule to one
+// zone. For a `deny`/`reject` global that is a fail-OPEN — the zones dropped
+// from the scope stop being denied and fall through to lower-precedence rules.
+// For a `permit` it is a fail-closed correctness break. The gate is keyed on
+// the multi-zone SHAPE rather than the action so it covers both directions.
+var ErrScopedGlobalZoneSetProtocolIncompatible = errors.New("userspace scoped-global zone-set snapshot protocol incompatible")
+
 // requiredProtocolGateSentinels enumerates every "this config cannot be
 // committed against the helper's current ConfigSnapshotProtocolVersion"
 // sentinel produced by ensureRequiredSnapshotProtocolLocked. ApplyConfig
@@ -51,6 +65,7 @@ var ErrPersistentSourceNATProtocolIncompatible = errors.New("userspace persisten
 var requiredProtocolGateSentinels = []error{
 	ErrPolicySchedulerProtocolIncompatible,
 	ErrPersistentSourceNATProtocolIncompatible,
+	ErrScopedGlobalZoneSetProtocolIncompatible,
 }
 
 // IsRequiredProtocolGateError reports whether err is (or wraps) any
@@ -668,6 +683,89 @@ func configHasScheduledPolicy(cfg *config.Config) bool {
 	return false
 }
 
+// policyScopeIsMultiZone reports whether a policy's scoped-global zone context
+// (#4626 M03) holds more than one zone on either side — the exact shape the
+// SINGULAR MatchFromZone/MatchToZone snapshot fields cannot represent, because
+// config.ScopeSingular stamps only the first element onto them.
+//
+// A one-element scope is bit-identical in both shapes (singular == the one
+// zone), and an unscoped global has both sides empty, so neither can be
+// narrowed by a reader that ignores the plural fields. Restricting the
+// predicate to len > 1 keeps the #5488 disarm blast radius to exactly the
+// misrepresentable population.
+//
+// A set that CONTAINS the "any" wildcard alongside concrete zones is included
+// conservatively: whether the singular field happens to land on "any" depends
+// on element order, so the shape — not a coincidence of ordering — decides.
+func policyScopeIsMultiZone(pol *config.Policy) bool {
+	if pol == nil {
+		return false
+	}
+	return len(pol.Match.FromZones) > 1 || len(pol.Match.ToZones) > 1
+}
+
+// configHasMultiZoneScopedPolicy scans every policy the snapshot builder lowers
+// through buildOneRuleSnapshot — the global tier AND the zone-pair tier — for a
+// multi-zone scope. Only global policies carry a zone scope today (the compiler
+// never populates Match.FromZones/ToZones for a zone-pair policy), but the
+// emitter stamps MatchFromZone/MatchToZone from the SAME Match fields for every
+// rule, so the gate covers the whole emission surface rather than assuming the
+// compiler's current tier discipline.
+func configHasMultiZoneScopedPolicy(cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, pol := range cfg.Security.GlobalPolicies {
+		if policyScopeIsMultiZone(pol) {
+			return true
+		}
+	}
+	for _, zpp := range cfg.Security.Policies {
+		if zpp == nil {
+			continue
+		}
+		for _, pol := range zpp.Policies {
+			if policyScopeIsMultiZone(pol) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ensureScopedGlobalZoneSetProtocolLocked is the #5488 fail-closed half of the
+// v4 protocol bump. The bump itself makes a pre-v4 helper REFUSE the snapshot
+// (both apply_snapshot and bump_fib_generation gate on exact version equality),
+// which stops it from misreading the scope — but a refused snapshot leaves that
+// helper ARMED on its previous-good image, still forwarding, with the newly
+// committed deny never installed. This gate closes that window the way the
+// project's other required-protocol gates do: the caller
+// (ensureRequiredSnapshotProtocolLocked) disarms the helper and the commit
+// aborts with an operator-visible reason, instead of reporting success against
+// a dataplane running a policy set the helper cannot represent.
+func (m *Manager) ensureScopedGlobalZoneSetProtocolLocked(cfg *config.Config) error {
+	if !configHasMultiZoneScopedPolicy(cfg) {
+		return nil
+	}
+	if m.lastStatus.ConfigSnapshotProtocolVersion >= ProtocolVersion {
+		return nil
+	}
+	var status ProcessStatus
+	if err := m.requestLocked(ControlRequest{Type: "status"}, &status); err == nil {
+		m.recordHelperStatusLocked(&status)
+		if status.ConfigSnapshotProtocolVersion >= ProtocolVersion {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"%w: helper config snapshot protocol version %d < required %d for multi-zone scoped global policies "+
+			"(an older helper reads only the singular match from-zone/to-zone and would NARROW the scope)",
+		ErrScopedGlobalZoneSetProtocolIncompatible,
+		m.lastStatus.ConfigSnapshotProtocolVersion,
+		ProtocolVersion,
+	)
+}
+
 func (m *Manager) ensurePolicySchedulerProtocolLocked(cfg *config.Config) error {
 	if !configHasScheduledPolicy(cfg) {
 		return nil
@@ -716,7 +814,10 @@ func (m *Manager) ensureRequiredSnapshotProtocolLocked(cfg *config.Config) error
 	if err := m.ensurePolicySchedulerProtocolLocked(cfg); err != nil {
 		return err
 	}
-	return m.ensurePersistentSourceNATProtocolLocked(cfg)
+	if err := m.ensurePersistentSourceNATProtocolLocked(cfg); err != nil {
+		return err
+	}
+	return m.ensureScopedGlobalZoneSetProtocolLocked(cfg)
 }
 
 func (m *Manager) disarmSnapshotProtocolFailureLocked(protocolErr error) error {

--- a/pkg/dataplane/userspace/manager_compile.go
+++ b/pkg/dataplane/userspace/manager_compile.go
@@ -325,10 +325,7 @@ func (m *Manager) Compile(cfg *config.Config) (*dataplane.CompileResult, error) 
 		return result, err
 	}
 	if err := m.ensureRequiredSnapshotProtocolLocked(cfg); err != nil {
-		if disarmErr := m.disarmSnapshotProtocolFailureLocked(err); disarmErr != nil {
-			return result, errors.Join(err, disarmErr)
-		}
-		return result, err
+		return result, m.disarmSnapshotProtocolFailClosedLocked(snap, err, samePlanRefresh)
 	}
 	if m.deferWorkers {
 		snap.DeferWorkers = true
@@ -818,6 +815,47 @@ func (m *Manager) ensureRequiredSnapshotProtocolLocked(cfg *config.Config) error
 		return err
 	}
 	return m.ensureScopedGlobalZoneSetProtocolLocked(cfg)
+}
+
+// disarmSnapshotProtocolFailClosedLocked is the shared fail-closed action for a
+// required-protocol gate hit on a publish path (#5488 F7). It disarms the helper
+// — the fail-closed contract of requiredProtocolGateSentinels — and, when the
+// disarm ITSELF fails, additionally drives the userspace_ctrl shim to Enabled=0
+// on the paths whose classifier BPF maps were already mutated IN PLACE.
+//
+// Why the extra step. A failed disarm leaves the helper ARMED on its
+// previous-good Rust snapshot. On a same-plan refresh the ingress/local/
+// interface-NAT classifier maps were already rewritten to the NEW plan with
+// ctrl still enabled (syncUserspaceClassifierMapsFailClosedLocked), so simply
+// returning would leave the XDP shim redirecting transit to XSK against maps a
+// generation AHEAD of the snapshot the helper is enforcing. That is precisely
+// the "fail-OPEN security/availability mismatch" failClosedUserspaceCtrlMapLocked
+// exists to prevent (#4959), and the reason publishSnapshotFailClosedLocked
+// takes the same mapsMutatedInPlace flag. Driving ctrl to 0 drops transit to the
+// kernel-only fail-closed posture until a later good commit re-publishes.
+//
+// mapsMutatedInPlace MUST mirror the flag the caller passes to
+// publishSnapshotFailClosedLocked, which is the codebase's oracle for "the
+// classifier maps are ahead of the applied snapshot": samePlanRefresh in Compile,
+// unconditionally true in syncSnapshotLocked (its only producer of an
+// unpublished lastSnapshot is Compile's pendingXSKStartup branch, which always
+// mutates the maps in place). The bootstrap path already programmed
+// ctrl.Enabled=0, so it needs no extra fail-closed.
+//
+// Every failClosedUserspaceCtrlMapLocked return path PRESERVES cause (returned
+// as-is, or wrapped with errors.Join), so the gate sentinel still satisfies
+// IsRequiredProtocolGateError and the commit still ABORTS. A fail-closed disarm
+// must never be downgraded into a promoted commit (#2138).
+func (m *Manager) disarmSnapshotProtocolFailClosedLocked(snapshot *ConfigSnapshot, protocolErr error, mapsMutatedInPlace bool) error {
+	disarmErr := m.disarmSnapshotProtocolFailureLocked(protocolErr)
+	if disarmErr == nil {
+		return protocolErr
+	}
+	joined := errors.Join(protocolErr, disarmErr)
+	if !mapsMutatedInPlace {
+		return joined
+	}
+	return m.failClosedUserspaceCtrlMapLocked(snapshot, joined)
 }
 
 func (m *Manager) disarmSnapshotProtocolFailureLocked(protocolErr error) error {

--- a/pkg/dataplane/userspace/process_status.go
+++ b/pkg/dataplane/userspace/process_status.go
@@ -2,7 +2,6 @@ package userspace
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -84,11 +83,14 @@ func (m *Manager) syncSnapshotLocked() error {
 	// for parity with update_neighbors path.
 	publishSnap := *m.lastSnapshot
 	publishSnap.Neighbors = filterPublishableNeighbors(m.lastSnapshot.Neighbors)
+	// #5488 (F7): mapsMutatedInPlace is unconditionally true here for the same
+	// reason the publishSnapshotFailClosedLocked call below passes true — the
+	// only producer of an unpublished lastSnapshot is Compile's pendingXSKStartup
+	// branch, which ALWAYS mutated the classifier maps in place first. So a
+	// failed disarm here must also drive ctrl to 0 rather than leave the shim
+	// running maps a generation ahead of the applied snapshot.
 	if err := m.ensureRequiredSnapshotProtocolLocked(publishSnap.Config); err != nil {
-		if disarmErr := m.disarmSnapshotProtocolFailureLocked(err); disarmErr != nil {
-			return errors.Join(err, disarmErr)
-		}
-		return err
+		return m.disarmSnapshotProtocolFailClosedLocked(&publishSnap, err, true)
 	}
 	// #2124: this is the XSK-startup deferred same-plan publish path, which
 	// publishes apply_snapshot independently of Compile(). Disarm before

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -7,7 +7,34 @@ import (
 )
 
 const (
-	ProtocolVersion                  = 3
+	// ProtocolVersion is the config-snapshot wire contract version. It is
+	// the Go mirror of CONFIG_SNAPSHOT_PROTOCOL_VERSION
+	// (userspace-dp/src/protocol/control.rs) and the two MUST be bumped in
+	// lockstep: both apply_snapshot and bump_fib_generation gate on EXACT
+	// equality, so a helper at a different version refuses the snapshot
+	// outright rather than decoding it under the wrong contract.
+	//
+	// v4 (#5488): a scoped GLOBAL policy carries its zone SCOPE as a zone
+	// SET in the plural match_from_zones/match_to_zones fields, and those
+	// fields are AUTHORITATIVE. The singular match_from_zone/match_to_zone
+	// fields carry only the FIRST element (config.ScopeSingular).
+	//
+	// #4626 added the plural fields as purely ADDITIVE JSON without bumping
+	// this constant, which made the version handshake lie: a pre-#4626
+	// helper advertising the same version 3 ignores fields it does not know
+	// and reads ONLY the singular field, so a global `deny` scoped
+	// `[dmz trust] -> untrust` silently NARROWS to `dmz -> untrust` and the
+	// trust-sourced traffic the operator denied is evaluated by lower
+	// precedence rules instead — a rolling-upgrade fail-OPEN. A
+	// compatibility extension that changes deny/reject COVERAGE must not be
+	// silently ignorable under an unchanged protocol version.
+	//
+	// The bump alone only makes an old helper REFUSE the snapshot (it keeps
+	// forwarding its previous-good image), so it is paired with the
+	// ensureScopedGlobalZoneSetProtocolLocked required-protocol gate in
+	// manager_compile.go, which DISARMS the helper and aborts the commit
+	// when the running helper is too old to represent a multi-zone scope.
+	ProtocolVersion                  = 4
 	InjectPacketTupleProtocolVersion = 1
 	TypeUserspace                    = "userspace"
 

--- a/pkg/dataplane/userspace/scoped_global_zoneset_failclosed_5488_test.go
+++ b/pkg/dataplane/userspace/scoped_global_zoneset_failclosed_5488_test.go
@@ -1,0 +1,266 @@
+// #5488 (F7): the required-protocol gate's fail-closed action is to DISARM the
+// helper. When that disarm itself FAILS the helper stays ARMED on its
+// previous-good Rust snapshot — and on the publish paths whose classifier BPF
+// maps were already mutated IN PLACE (Compile's samePlanRefresh,
+// syncSnapshotLocked unconditionally) the XDP shim is then redirecting transit
+// to XSK against maps a generation AHEAD of the snapshot the helper is
+// enforcing. That is the same "fail-OPEN security/availability mismatch"
+// failClosedUserspaceCtrlMapLocked was introduced for in #4959; before this fix
+// nothing drove userspace_ctrl.Enabled to 0 on the gate's disarm-error branch.
+//
+// The #5488 protocol bump is what makes this reachable in practice: every
+// helper built before this PR reports a pre-v4 ConfigSnapshotProtocolVersion,
+// so a multi-zone scoped global commit takes the gate on all of them.
+//
+// FAIL-ON-REVERT: dropping the failClosedUserspaceCtrlMapLocked call from
+// disarmSnapshotProtocolFailClosedLocked (i.e. returning `joined` in both
+// branches) leaves ctrl at Enabled=1 after a failed disarm, so
+// TestSnapshotProtocolDisarmFailureFailsClosed5488/maps_mutated_in_place_disables_ctrl
+// goes RED on its "ctrl.Enabled must be 0" assertion.
+package userspace
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// injectClassifierMaps5488 injects the ingress-iface / local-address /
+// interface-NAT classifier maps that applyHelperStatusLocked reconciles, so a
+// SUCCESSFUL disarm really completes instead of erroring out on a missing map.
+func injectClassifierMaps5488(t *testing.T, m *Manager) {
+	t.Helper()
+	v6KeySize := uint32(unsafe.Sizeof(userspaceLocalV6Key{}))
+	for _, spec := range []struct {
+		name    string
+		keySize uint32
+	}{
+		{mapNameUserspaceIngressIfaces, 4},
+		{mapNameUserspaceLocalV4, 4},
+		{mapNameUserspaceLocalV6, v6KeySize},
+		{mapNameUserspaceInterfaceNATv4, 4},
+		{mapNameUserspaceInterfaceNATv6, v6KeySize},
+	} {
+		bpfMap, err := ebpf.NewMap(&ebpf.MapSpec{
+			Type:       ebpf.Hash,
+			KeySize:    spec.keySize,
+			ValueSize:  1,
+			MaxEntries: 64,
+		})
+		if err != nil {
+			skipIfBPFMapUnavailable(t, "new "+spec.name+" map", err)
+		}
+		t.Cleanup(func() { bpfMap.Close() })
+		injectShimMap(t, m.bpfShim, spec.name, bpfMap)
+	}
+}
+
+// newProtocolGateFailClosedManager5488 builds a Manager wired to a control
+// socket, with a real userspace_ctrl map seeded Enabled=1 — the post-same-plan-
+// refresh state: classifier maps already mutated in place, ctrl left enabled.
+func newProtocolGateFailClosedManager5488(t *testing.T) (*Manager, *ebpf.Map, *ConfigSnapshot, string) {
+	t.Helper()
+	// A SHORT temp-dir prefix (not t.TempDir(), whose long sub-test name would
+	// push the AF_UNIX path past the 108-byte sun_path limit -> "bind: invalid
+	// argument"). Honors TMPDIR (run with TMPDIR=/tmp).
+	dir, err := os.MkdirTemp("", "x5488")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	controlSock := filepath.Join(dir, "control.sock")
+
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+	m.cfg.ControlSocket = controlSock
+	// A pre-v4 helper: the #5488 gate fires for a multi-zone scoped global.
+	m.lastStatus.ConfigSnapshotProtocolVersion = preV4SnapshotProtocolVersion
+
+	ctrlMap, _ := injectCtrlAndBindingMaps(t, m)
+	// applyHelperStatusLocked (run by a SUCCESSFUL disarm) reconciles the whole
+	// classifier map set. Inject all of them, or the "successful disarm" branch
+	// would fail its status sync and take the FAILED-disarm path instead —
+	// silently turning that sub-test into a duplicate of the first one.
+	injectClassifierMaps5488(t, m)
+
+	enabled := userspaceCtrlValue{
+		Enabled:         1,
+		MetadataVersion: userspaceMetadataVersion,
+		Workers:         4,
+		QueueCount:      4,
+	}
+	if err := ctrlMap.Update(uint32(0), enabled, ebpf.UpdateAny); err != nil {
+		t.Fatalf("seed userspace_ctrl Enabled=1: %v", err)
+	}
+
+	cfg := multiZoneScopedGlobalDenyConfig()
+	snap, err := buildSnapshot(cfg, config.UserspaceConfig{ControlSocket: controlSock}, 8, 0)
+	if err != nil {
+		t.Fatalf("buildSnapshot: %v", err)
+	}
+	return m, ctrlMap, snap, controlSock
+}
+
+// gateErr5488 returns the real gate error for a multi-zone scoped global against
+// the manager's (pre-v4) helper, so the test drives the production predicate
+// rather than a hand-rolled stand-in.
+func gateErr5488(t *testing.T, m *Manager) error {
+	t.Helper()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	err := m.ensureRequiredSnapshotProtocolLocked(multiZoneScopedGlobalDenyConfig())
+	if !errors.Is(err, ErrScopedGlobalZoneSetProtocolIncompatible) {
+		t.Fatalf("precondition: gate error = %v, want ErrScopedGlobalZoneSetProtocolIncompatible", err)
+	}
+	return err
+}
+
+func TestSnapshotProtocolDisarmFailureFailsClosed5488(t *testing.T) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("RemoveMemlock: %v", err)
+	}
+
+	// Core contract: gate fires + disarm FAILS + maps were mutated in place
+	// => ctrl must be driven to 0, and the commit must still abort.
+	t.Run("maps_mutated_in_place_disables_ctrl", func(t *testing.T) {
+		m, ctrlMap, snap, controlSock := newProtocolGateFailClosedManager5488(t)
+		gateErr := gateErr5488(t, m)
+		// The helper answers the set_forwarding_state disarm with OK:false, so
+		// disarmSnapshotProtocolFailureLocked returns an error and the helper
+		// stays ARMED on its previous-good snapshot.
+		startArmControlServerReject(t, controlSock, 1)
+
+		if got := readCtrlEnabled4959(t, ctrlMap); got != 1 {
+			t.Fatalf("precondition: ctrl.Enabled = %d, want 1 (running enabled firewall)", got)
+		}
+
+		m.mu.Lock()
+		err := m.disarmSnapshotProtocolFailClosedLocked(snap, gateErr, true /*mapsMutatedInPlace*/)
+		m.mu.Unlock()
+		if err == nil {
+			t.Fatal("disarmSnapshotProtocolFailClosedLocked must return an error when the disarm fails")
+		}
+		if got := readCtrlEnabled4959(t, ctrlMap); got != 0 {
+			t.Fatalf("ctrl.Enabled = %d after a FAILED protocol-gate disarm, want 0 (fail closed); "+
+				"the helper is still armed on its previous-good snapshot while the classifier maps "+
+				"were mutated in place to the new plan, so a still-enabled shim redirects transit "+
+				"to XSK against maps a generation ahead of the applied snapshot (#5488 F7 / #4959 "+
+				"fail-open)", got)
+		}
+		// The fail-closed wrap must NOT swallow the sentinel: a commit that hits
+		// a required-protocol gate must ABORT, never be promoted (#2138).
+		if !IsRequiredProtocolGateError(err) {
+			t.Fatalf("IsRequiredProtocolGateError(%v) = false, want true — the ctrl fail-closed wrap "+
+				"must preserve the gate sentinel so the commit still aborts", err)
+		}
+	})
+
+	// Scope control: the bootstrap path already programmed ctrl.Enabled=0
+	// before the publish, so mapsMutatedInPlace=false must NOT run the
+	// classifier fail-closed. Assert it leaves the (artificially still-enabled)
+	// ctrl untouched, proving the action is specific to the in-place path.
+	t.Run("bootstrap_path_does_not_failclose", func(t *testing.T) {
+		m, ctrlMap, snap, controlSock := newProtocolGateFailClosedManager5488(t)
+		gateErr := gateErr5488(t, m)
+		startArmControlServerReject(t, controlSock, 1)
+
+		m.mu.Lock()
+		err := m.disarmSnapshotProtocolFailClosedLocked(snap, gateErr, false /*mapsMutatedInPlace*/)
+		m.mu.Unlock()
+		if err == nil {
+			t.Fatal("disarmSnapshotProtocolFailClosedLocked must return an error on the bootstrap path too")
+		}
+		if got := readCtrlEnabled4959(t, ctrlMap); got != 1 {
+			t.Fatalf("ctrl.Enabled = %d, want 1 unchanged; the bootstrap path already set "+
+				"ctrl.Enabled=0 before publish and must not run the in-place classifier fail-closed", got)
+		}
+		if !IsRequiredProtocolGateError(err) {
+			t.Fatalf("IsRequiredProtocolGateError(%v) = false, want true", err)
+		}
+	})
+
+	// Branch control: a SUCCESSFUL disarm must return the gate error UNCHANGED —
+	// taking neither the errors.Join branch nor the ctrl fail-closed branch. The
+	// identity comparison is the discriminating assertion: errors.Is would also
+	// hold for a joined error, so it cannot tell the branches apart.
+	//
+	// Note this sub-test deliberately does NOT assert ctrl stays Enabled=1. On a
+	// successful disarm the helper answers with a not-Enabled status and
+	// disarmSnapshotProtocolFailureLocked feeds it to applyHelperStatusLocked,
+	// which independently programs ctrl.Enabled=0. That is the ORDINARY
+	// fail-closed outcome of a disarm, reached through the status sync rather
+	// than through the F7 path — so a ctrl assertion here would pass whether or
+	// not the F7 fix exists and would prove nothing.
+	t.Run("successful_disarm_returns_bare_gate_error", func(t *testing.T) {
+		m, _, snap, controlSock := newProtocolGateFailClosedManager5488(t)
+		gateErr := gateErr5488(t, m)
+		startArmControlServer(t, controlSock, 1) // responds OK:true
+
+		m.mu.Lock()
+		err := m.disarmSnapshotProtocolFailClosedLocked(snap, gateErr, true /*mapsMutatedInPlace*/)
+		m.mu.Unlock()
+		if err != gateErr { //nolint:errorlint // identity IS the assertion
+			t.Fatalf("error = %v (%T), want the SAME error value as the gate returned; a "+
+				"successful disarm must not join or re-wrap it", err, err)
+		}
+		if !IsRequiredProtocolGateError(err) {
+			t.Fatalf("IsRequiredProtocolGateError(%v) = false, want true", err)
+		}
+	})
+}
+
+// TestProtocolGateSitesRouteThroughFailClosedHelper5488 is a source-level guard
+// so a revert cannot re-inline the bare disarm at either publish site and slip
+// past the behavioral test above (which drives the extracted helper directly).
+//
+// The two sites are exactly the two callers of publishSnapshotFailClosedLocked —
+// the codebase's oracle for "the classifier maps are ahead of the applied
+// snapshot" — and each must pass the SAME mapsMutatedInPlace value to both
+// calls, or the fail-closed action and the publish would disagree about whether
+// the maps were mutated.
+func TestProtocolGateSitesRouteThroughFailClosedHelper5488(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		file      string
+		fn        string
+		wantGate  string
+		wantPub   string
+		whyInPlce string
+	}{
+		{
+			file:      "manager_compile.go",
+			fn:        "Compile",
+			wantGate:  "m.disarmSnapshotProtocolFailClosedLocked(snap, err, samePlanRefresh)",
+			wantPub:   "publishSnapshotFailClosedLocked(&publishSnap, &status, samePlanRefresh)",
+			whyInPlce: "samePlanRefresh mutates the classifier maps in place before the publish",
+		},
+		{
+			file:      "process_status.go",
+			fn:        "syncSnapshotLocked",
+			wantGate:  "m.disarmSnapshotProtocolFailClosedLocked(&publishSnap, err, true)",
+			wantPub:   "publishSnapshotFailClosedLocked(&publishSnap, &status, true)",
+			whyInPlce: "its only producer of an unpublished lastSnapshot is Compile's pendingXSKStartup branch, which always mutates the maps in place",
+		},
+	} {
+		t.Run(tc.fn, func(t *testing.T) {
+			src := goFunctionSource(t, tc.file, tc.fn)
+			if !strings.Contains(src, tc.wantGate) {
+				t.Errorf("%s must route the required-protocol gate hit through "+
+					"%s so a FAILED disarm drives ctrl to 0 (#5488 F7) — %s; got:\n%s",
+					tc.fn, tc.wantGate, tc.whyInPlce, src)
+			}
+			if !strings.Contains(src, tc.wantPub) {
+				t.Errorf("%s must publish via %s; the gate fail-closed and the publish "+
+					"fail-closed have to agree on mapsMutatedInPlace", tc.fn, tc.wantPub)
+			}
+		})
+	}
+}

--- a/pkg/dataplane/userspace/scoped_global_zoneset_protocol_5488_test.go
+++ b/pkg/dataplane/userspace/scoped_global_zoneset_protocol_5488_test.go
@@ -249,31 +249,126 @@ func TestScopedGlobalSingleZoneAndUnscopedPolicyNotGated(t *testing.T) {
 	}
 }
 
-// TestScopedGlobalZoneSetGateCoversZonePairTier pins the gate to the whole
-// emission surface. lowerPolicy stamps MatchFromZone/MatchToZone from
-// pol.Match.FromZones/ToZones for EVERY rule, not just the global tier, so a
-// multi-zone scope reaching a zone-pair policy must be gated too.
-func TestScopedGlobalZoneSetGateCoversZonePairTier(t *testing.T) {
-	cfg := &config.Config{Security: config.SecurityConfig{
-		Policies: []*config.ZonePairPolicies{{
-			FromZone: "trust", ToZone: "untrust",
-			Policies: []*config.Policy{{
-				Name: "zp-scoped",
+// TestScopedGlobalZoneSetGateCoversBothScopeSides pins BOTH halves of
+// policyScopeIsMultiZone (`len(FromZones) > 1 || len(ToZones) > 1`) to a
+// reachable config, and the predicate to the whole emission surface.
+//
+// The to-zone half needs its own REACHABLE positive case: an ordinary Junos
+// `global policy p match { from-zone trust; to-zone [ untrust dmz ]; }` is a
+// multi-zone scope on the TO side only, and `ScopeSingular` narrows it to
+// `untrust` exactly as it narrows the from side. Without this row the to-zone
+// half of the predicate would be pinned only by the zone-pair row below, whose
+// shape the compiler never actually produces (`compiler_security_policy.go`
+// populates Match.FromZones/ToZones only for global policies) — a guard scoped
+// narrower than the claim it protects, and one a future cleanup could delete as
+// "tests an unreachable branch".
+func TestScopedGlobalZoneSetGateCoversBothScopeSides(t *testing.T) {
+	globalScoped := func(name string, from, to []string) *config.Config {
+		return &config.Config{Security: config.SecurityConfig{
+			GlobalPolicies: []*config.Policy{{
+				Name: name,
 				Match: config.PolicyMatch{
 					SourceAddresses:      []string{"any"},
 					DestinationAddresses: []string{"any"},
 					Applications:         []string{"any"},
-					ToZones:              []string{"untrust", "dmz"},
+					FromZones:            from,
+					ToZones:              to,
 				},
 				Action: config.PolicyDeny,
 			}},
-		}},
-	}}
-	m := New()
-	m.lastStatus.ConfigSnapshotProtocolVersion = preV4SnapshotProtocolVersion
-	if err := m.ensureScopedGlobalZoneSetProtocolLocked(cfg); !errors.Is(err, ErrScopedGlobalZoneSetProtocolIncompatible) {
-		t.Errorf("zone-pair tier multi-zone scope = %v, want ErrScopedGlobalZoneSetProtocolIncompatible", err)
+		}}
 	}
+
+	cases := []struct {
+		name        string
+		cfg         *config.Config
+		wantSingFrm string
+		wantSingTo  string
+	}{
+		{
+			// The from-side hazard (the shape in the issue report).
+			name:        "global multi-zone FROM side",
+			cfg:         globalScoped("g-from-multi", []string{"dmz", "trust"}, []string{"untrust"}),
+			wantSingFrm: "dmz", wantSingTo: "untrust",
+		},
+		{
+			// The to-side hazard — reachable, ordinary Junos:
+			//   global policy g match { from-zone trust; to-zone [ untrust dmz ]; }
+			name:        "global multi-zone TO side",
+			cfg:         globalScoped("g-to-multi", []string{"trust"}, []string{"dmz", "untrust"}),
+			wantSingFrm: "trust", wantSingTo: "dmz",
+		},
+		{
+			name:        "global multi-zone BOTH sides",
+			cfg:         globalScoped("g-both-multi", []string{"dmz", "trust"}, []string{"untrust", "wan"}),
+			wantSingFrm: "dmz", wantSingTo: "untrust",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The narrowing is real on this shape: the singular field a pre-v4
+			// helper reads resolves a STRICTLY smaller scope than configured.
+			snaps, err := buildPolicySnapshots(tc.cfg)
+			if err != nil {
+				t.Fatalf("buildPolicySnapshots: %v", err)
+			}
+			if len(snaps) != 1 {
+				t.Fatalf("expected 1 lowered rule, got %d", len(snaps))
+			}
+			s := snaps[0]
+			if s.MatchFromZone != tc.wantSingFrm || s.MatchToZone != tc.wantSingTo {
+				t.Errorf("singular scope = %q->%q, want %q->%q",
+					s.MatchFromZone, s.MatchToZone, tc.wantSingFrm, tc.wantSingTo)
+			}
+			narrowed := false
+			if got := preV4HelperEffectiveScope(s.MatchFromZone); len(got) < len(s.effectiveMatchFromZones()) {
+				narrowed = true
+			}
+			if got := preV4HelperEffectiveScope(s.MatchToZone); len(got) < len(s.effectiveMatchToZones()) {
+				narrowed = true
+			}
+			if !narrowed {
+				t.Fatalf("precondition failed: neither side is narrowed by a singular-only reader "+
+					"(from %q->%q, to %q->%q); this row no longer exercises the #5488 fail-open",
+					s.MatchFromZone, s.effectiveMatchFromZones(), s.MatchToZone, s.effectiveMatchToZones())
+			}
+
+			m := New()
+			m.lastStatus.ConfigSnapshotProtocolVersion = preV4SnapshotProtocolVersion
+			if err := m.ensureScopedGlobalZoneSetProtocolLocked(tc.cfg); !errors.Is(err, ErrScopedGlobalZoneSetProtocolIncompatible) {
+				t.Errorf("gate = %v, want ErrScopedGlobalZoneSetProtocolIncompatible", err)
+			}
+		})
+	}
+
+	// Defensive breadth: lowerPolicy stamps the singular fields from the same
+	// Match for EVERY rule, not just the global tier, so the predicate scans the
+	// zone-pair tier too. The compiler does not produce this shape today
+	// (compiler_security_policy.go populates the scope only for globals), so
+	// this row guards the emission surface rather than a reachable config.
+	t.Run("zone-pair tier (defensive, not compiler-reachable)", func(t *testing.T) {
+		cfg := &config.Config{Security: config.SecurityConfig{
+			Policies: []*config.ZonePairPolicies{{
+				FromZone: "trust", ToZone: "untrust",
+				Policies: []*config.Policy{{
+					Name: "zp-scoped",
+					Match: config.PolicyMatch{
+						SourceAddresses:      []string{"any"},
+						DestinationAddresses: []string{"any"},
+						Applications:         []string{"any"},
+						ToZones:              []string{"untrust", "dmz"},
+					},
+					Action: config.PolicyDeny,
+				}},
+			}},
+		}}
+		m := New()
+		m.lastStatus.ConfigSnapshotProtocolVersion = preV4SnapshotProtocolVersion
+		if err := m.ensureScopedGlobalZoneSetProtocolLocked(cfg); !errors.Is(err, ErrScopedGlobalZoneSetProtocolIncompatible) {
+			t.Errorf("zone-pair tier multi-zone scope = %v, want ErrScopedGlobalZoneSetProtocolIncompatible", err)
+		}
+	})
 }
 
 // TestSnapshotProtocolVersionLockstepWithRust guards the failure mode that

--- a/pkg/dataplane/userspace/scoped_global_zoneset_protocol_5488_test.go
+++ b/pkg/dataplane/userspace/scoped_global_zoneset_protocol_5488_test.go
@@ -1,0 +1,329 @@
+package userspace
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// preV4SnapshotProtocolVersion is the version a pre-#4626 helper advertises and
+// accepts — the value CONFIG_SNAPSHOT_PROTOCOL_VERSION held when the plural
+// match_from_zones/match_to_zones fields were added as purely ADDITIVE JSON
+// without a bump. It is deliberately a LITERAL, not `ProtocolVersion - 1`: the
+// point of #5488 is that the current version must no longer collide with the
+// version whose readers cannot see the plural fields, so the test must pin the
+// historical value rather than track the constant it is checking.
+const preV4SnapshotProtocolVersion = 3
+
+// preV4HelperAcceptsSnapshot models the version gate a pre-v4 helper applies.
+// It mirrors the EXACT-equality check both mutating verbs run before touching
+// any dataplane state (userspace-dp/src/server/handlers/snapshot.rs, `apply` and
+// `bump_fib`):
+//
+//	if snapshot.version != CONFIG_SNAPSHOT_PROTOCOL_VERSION { reject }
+//
+// Exact equality (not `<=`) is what makes the bump load-bearing: an old helper
+// refuses a NEWER snapshot outright instead of decoding it under its own,
+// narrower contract.
+func preV4HelperAcceptsSnapshot(version int) bool {
+	return version == preV4SnapshotProtocolVersion
+}
+
+// preV4HelperEffectiveScope models how a pre-#4626 helper resolves a global
+// policy's zone scope: it knows only the SINGULAR match_from_zone /
+// match_to_zone field, so an unknown plural field is dropped by serde's
+// deny-nothing decode and never consulted. An empty singular means "any zone".
+func preV4HelperEffectiveScope(singular string) []string {
+	if singular == "" {
+		return nil
+	}
+	return []string{singular}
+}
+
+func multiZoneScopedGlobalDenyConfig() *config.Config {
+	return &config.Config{
+		Security: config.SecurityConfig{
+			GlobalPolicies: []*config.Policy{
+				{
+					Name: "g-deny-multi",
+					Match: config.PolicyMatch{
+						SourceAddresses:      []string{"any"},
+						DestinationAddresses: []string{"any"},
+						Applications:         []string{"any"},
+						FromZones:            []string{"dmz", "trust"},
+						ToZones:              []string{"untrust"},
+					},
+					Action: config.PolicyDeny,
+				},
+			},
+		},
+	}
+}
+
+// TestScopedGlobalMultiZoneDenyIsNotNarrowableByPreV4Helper is the #5488
+// regression.
+//
+// #4626 lowers a multi-zone scoped global deny with the singular
+// match_from_zone carrying only the FIRST zone (config.ScopeSingular) and the
+// full set in the additive plural match_from_zones. That degradation is only
+// safe if a reader that cannot see the plural field is never handed the
+// snapshot. Before #5488 CONFIG_SNAPSHOT_PROTOCOL_VERSION was still 3 — the
+// same value a pre-#4626 helper advertises and accepts — so the version
+// handshake said "we agree" while the two sides disagreed about what the
+// message meant: the old helper read `dmz` alone and NARROWED a global deny
+// scoped `[dmz trust] -> untrust` to `dmz -> untrust`, letting trust-sourced
+// traffic the operator denied fall through to lower-precedence rules
+// (a rolling-upgrade fail-OPEN).
+func TestScopedGlobalMultiZoneDenyIsNotNarrowableByPreV4Helper(t *testing.T) {
+	cfg := multiZoneScopedGlobalDenyConfig()
+
+	snap, err := buildSnapshotWithSchedulerStateAndNATCounters(
+		cfg, deriveUserspaceConfig(cfg), 1, 0, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("build snapshot: %v", err)
+	}
+	if len(snap.Policies) != 1 {
+		t.Fatalf("expected 1 lowered rule, got %d", len(snap.Policies))
+	}
+	rule := snap.Policies[0]
+
+	// Preconditions: the emission really is narrowable when read singular-only.
+	// This is the hazard the version now fences off — #4626's degradation is
+	// deliberately UNCHANGED by this fix, so if these stop holding the test is
+	// no longer exercising the fail-open it guards.
+	if want := []string{"dmz", "trust"}; !equalStrings(rule.MatchFromZones, want) {
+		t.Fatalf("plural MatchFromZones = %q, want %q", rule.MatchFromZones, want)
+	}
+	preV4Scope := preV4HelperEffectiveScope(rule.MatchFromZone)
+	if len(preV4Scope) >= len(rule.MatchFromZones) {
+		t.Fatalf("precondition failed: singular scope %q is not narrower than the configured set %q; "+
+			"this test no longer exercises the #5488 fail-open", preV4Scope, rule.MatchFromZones)
+	}
+
+	// THE GUARD. The daemon stamps its own ProtocolVersion onto every snapshot.
+	// A pre-v4 helper must REFUSE that snapshot, so it can never reach the
+	// narrowing decode above.
+	if preV4HelperAcceptsSnapshot(snap.Version) {
+		t.Errorf("a pre-#4626 helper ACCEPTS the snapshot at version %d: it reads only the singular "+
+			"match_from_zone %q and narrows the global deny to %q instead of the configured %q "+
+			"(rolling-upgrade fail-OPEN — CONFIG_SNAPSHOT_PROTOCOL_VERSION must not collide with %d)",
+			snap.Version, rule.MatchFromZone, preV4Scope, rule.MatchFromZones, preV4SnapshotProtocolVersion)
+	}
+
+	// The bump alone only makes the old helper refuse the snapshot — it keeps
+	// forwarding its previous-good image with the new deny never installed. The
+	// required-protocol gate turns that into a fail-CLOSED disarm plus an
+	// aborted commit.
+	m := New()
+	m.lastStatus.ConfigSnapshotProtocolVersion = preV4SnapshotProtocolVersion
+	gateErr := m.ensureRequiredSnapshotProtocolLocked(cfg)
+	if !errors.Is(gateErr, ErrScopedGlobalZoneSetProtocolIncompatible) {
+		t.Errorf("ensureRequiredSnapshotProtocolLocked against a pre-v4 helper = %v, "+
+			"want ErrScopedGlobalZoneSetProtocolIncompatible (helper must be disarmed, not fed a "+
+			"snapshot whose multi-zone deny it will narrow)", gateErr)
+	}
+	// #2138: a gate that disarms but is missing from the abort set promotes the
+	// commit against a disarmed dataplane.
+	if !IsRequiredProtocolGateError(gateErr) {
+		t.Errorf("IsRequiredProtocolGateError(%v) = false, want true — the #5488 gate must abort the commit", gateErr)
+	}
+
+	// A helper at the current version is not gated.
+	m2 := New()
+	m2.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
+	if err := m2.ensureRequiredSnapshotProtocolLocked(cfg); err != nil {
+		t.Errorf("current-version helper gated: %v, want nil", err)
+	}
+}
+
+// TestScopedGlobalSingleZoneAndUnscopedPolicyNotGated is the negative control.
+// A one-element scope lowers to singular == the one zone (bit-identical in both
+// shapes, never narrowed), and an unscoped global / ordinary zone-pair policy
+// carries no scope at all. None of them can be misread by a singular-only
+// reader, so none may trip the #5488 gate — otherwise the fix disarms the
+// common case.
+func TestScopedGlobalSingleZoneAndUnscopedPolicyNotGated(t *testing.T) {
+	cases := []struct {
+		name        string
+		cfg         *config.Config
+		wantFrom    []string
+		wantTo      []string
+		wantSingFrm string
+		wantSingTo  string
+	}{
+		{
+			name: "single-zone scoped global deny",
+			cfg: &config.Config{Security: config.SecurityConfig{
+				GlobalPolicies: []*config.Policy{{
+					Name: "g-deny-one",
+					Match: config.PolicyMatch{
+						SourceAddresses:      []string{"any"},
+						DestinationAddresses: []string{"any"},
+						Applications:         []string{"any"},
+						FromZones:            []string{"dmz"},
+						ToZones:              []string{"untrust"},
+					},
+					Action: config.PolicyDeny,
+				}},
+			}},
+			wantFrom: []string{"dmz"}, wantTo: []string{"untrust"},
+			wantSingFrm: "dmz", wantSingTo: "untrust",
+		},
+		{
+			name: "unscoped global permit",
+			cfg: &config.Config{Security: config.SecurityConfig{
+				GlobalPolicies: []*config.Policy{{
+					Name: "g-permit-any",
+					Match: config.PolicyMatch{
+						SourceAddresses:      []string{"any"},
+						DestinationAddresses: []string{"any"},
+						Applications:         []string{"any"},
+					},
+					Action: config.PolicyPermit,
+				}},
+			}},
+			wantFrom: nil, wantTo: nil, wantSingFrm: "", wantSingTo: "",
+		},
+		{
+			name: "ordinary zone-pair permit",
+			cfg: &config.Config{Security: config.SecurityConfig{
+				Policies: []*config.ZonePairPolicies{{
+					FromZone: "trust", ToZone: "untrust",
+					Policies: []*config.Policy{{
+						Name: "zp-permit",
+						Match: config.PolicyMatch{
+							SourceAddresses:      []string{"any"},
+							DestinationAddresses: []string{"any"},
+							Applications:         []string{"any"},
+						},
+						Action: config.PolicyPermit,
+					}},
+				}},
+			}},
+			wantFrom: nil, wantTo: nil, wantSingFrm: "", wantSingTo: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			snaps, err := buildPolicySnapshots(tc.cfg)
+			if err != nil {
+				t.Fatalf("buildPolicySnapshots: %v", err)
+			}
+			if len(snaps) != 1 {
+				t.Fatalf("expected 1 lowered rule, got %d", len(snaps))
+			}
+			s := snaps[0]
+			if !equalStrings(s.MatchFromZones, tc.wantFrom) || !equalStrings(s.MatchToZones, tc.wantTo) {
+				t.Errorf("plural scope = %q->%q, want %q->%q",
+					s.MatchFromZones, s.MatchToZones, tc.wantFrom, tc.wantTo)
+			}
+			if s.MatchFromZone != tc.wantSingFrm || s.MatchToZone != tc.wantSingTo {
+				t.Errorf("singular scope = %q->%q, want %q->%q",
+					s.MatchFromZone, s.MatchToZone, tc.wantSingFrm, tc.wantSingTo)
+			}
+			// A singular-only reader resolves the SAME scope as a plural-aware
+			// one, so there is nothing for the version to fence off.
+			if got := preV4HelperEffectiveScope(s.MatchFromZone); !equalStrings(got, s.effectiveMatchFromZones()) {
+				t.Errorf("pre-v4 from-zone scope %q != effective %q — this shape IS narrowable and must be gated",
+					got, s.effectiveMatchFromZones())
+			}
+			if got := preV4HelperEffectiveScope(s.MatchToZone); !equalStrings(got, s.effectiveMatchToZones()) {
+				t.Errorf("pre-v4 to-zone scope %q != effective %q — this shape IS narrowable and must be gated",
+					got, s.effectiveMatchToZones())
+			}
+
+			// The gate must stay silent even against the oldest helper.
+			m := New()
+			m.lastStatus.ConfigSnapshotProtocolVersion = preV4SnapshotProtocolVersion
+			if err := m.ensureScopedGlobalZoneSetProtocolLocked(tc.cfg); err != nil {
+				t.Errorf("gate fired on a non-narrowable config: %v, want nil", err)
+			}
+		})
+	}
+}
+
+// TestScopedGlobalZoneSetGateCoversZonePairTier pins the gate to the whole
+// emission surface. lowerPolicy stamps MatchFromZone/MatchToZone from
+// pol.Match.FromZones/ToZones for EVERY rule, not just the global tier, so a
+// multi-zone scope reaching a zone-pair policy must be gated too.
+func TestScopedGlobalZoneSetGateCoversZonePairTier(t *testing.T) {
+	cfg := &config.Config{Security: config.SecurityConfig{
+		Policies: []*config.ZonePairPolicies{{
+			FromZone: "trust", ToZone: "untrust",
+			Policies: []*config.Policy{{
+				Name: "zp-scoped",
+				Match: config.PolicyMatch{
+					SourceAddresses:      []string{"any"},
+					DestinationAddresses: []string{"any"},
+					Applications:         []string{"any"},
+					ToZones:              []string{"untrust", "dmz"},
+				},
+				Action: config.PolicyDeny,
+			}},
+		}},
+	}}
+	m := New()
+	m.lastStatus.ConfigSnapshotProtocolVersion = preV4SnapshotProtocolVersion
+	if err := m.ensureScopedGlobalZoneSetProtocolLocked(cfg); !errors.Is(err, ErrScopedGlobalZoneSetProtocolIncompatible) {
+		t.Errorf("zone-pair tier multi-zone scope = %v, want ErrScopedGlobalZoneSetProtocolIncompatible", err)
+	}
+}
+
+// TestSnapshotProtocolVersionLockstepWithRust guards the failure mode that
+// created #5488 in the first place: the Go emitter and the Rust consumer gate
+// on EXACT version equality, so a one-sided change silently breaks every apply.
+// Parse the Rust constant instead of mirroring it in a comment.
+func TestSnapshotProtocolVersionLockstepWithRust(t *testing.T) {
+	// Test cwd is pkg/dataplane/userspace.
+	path := filepath.Join("..", "..", "..", "userspace-dp", "src", "protocol", "control.rs")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v (the Go/Rust snapshot protocol version lockstep guard cannot run)", path, err)
+	}
+	re := regexp.MustCompile(`(?m)^pub\(crate\) const CONFIG_SNAPSHOT_PROTOCOL_VERSION: i32 = (\d+);`)
+	match := re.FindSubmatch(src)
+	if match == nil {
+		t.Fatalf("CONFIG_SNAPSHOT_PROTOCOL_VERSION declaration not found in %s — "+
+			"if it was renamed or moved, update this lockstep guard rather than deleting it", path)
+	}
+	rustVersion, err := strconv.Atoi(string(match[1]))
+	if err != nil {
+		t.Fatalf("parse rust CONFIG_SNAPSHOT_PROTOCOL_VERSION %q: %v", match[1], err)
+	}
+	if rustVersion != ProtocolVersion {
+		t.Fatalf("snapshot protocol version skew: Go ProtocolVersion = %d, Rust "+
+			"CONFIG_SNAPSHOT_PROTOCOL_VERSION = %d. Both apply_snapshot and bump_fib_generation "+
+			"gate on EXACT equality, so the two MUST be bumped together.",
+			ProtocolVersion, rustVersion)
+	}
+	if rustVersion <= preV4SnapshotProtocolVersion {
+		t.Fatalf("snapshot protocol version = %d, must be > %d (#5488): the plural "+
+			"match_from_zones/match_to_zones scope fields changed deny COVERAGE, so the version "+
+			"must not collide with the pre-#4626 value whose readers ignore them",
+			rustVersion, preV4SnapshotProtocolVersion)
+	}
+	// The Rust comment must keep naming the issue so the reason for the value
+	// survives the next bump.
+	if !strings.Contains(string(src), "#5488") {
+		t.Errorf("%s no longer explains the #5488 reason for the version floor", path)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -19,7 +19,26 @@ use super::security::{
 };
 use super::snapshot::{ConfigSnapshot, FabricSnapshot, NeighborSnapshot, UserspaceCapabilities};
 
-pub(crate) const CONFIG_SNAPSHOT_PROTOCOL_VERSION: i32 = 3;
+/// The config-snapshot wire contract version, mirrored on the Go side by
+/// `userspace.ProtocolVersion` (pkg/dataplane/userspace/protocol.go). The two
+/// MUST be bumped in lockstep: both `apply_snapshot` and `bump_fib_generation`
+/// gate on EXACT equality, so a peer at a different version refuses the
+/// snapshot outright instead of decoding it under the wrong contract.
+///
+/// v4 (#5488): a scoped GLOBAL policy carries its zone SCOPE as a zone SET in
+/// the plural `match_from_zones`/`match_to_zones` fields, and those fields are
+/// AUTHORITATIVE (`effective_match_zones` prefers them). The singular
+/// `match_from_zone`/`match_to_zone` fields carry only the FIRST element.
+///
+/// #4626 added the plural fields as purely ADDITIVE JSON without bumping this
+/// constant, which made the version handshake lie: a pre-#4626 helper
+/// advertising the same version 3 ignores fields it does not know and reads
+/// ONLY the singular field, so a global `deny` scoped `[dmz trust] -> untrust`
+/// silently NARROWS to `dmz -> untrust` — a rolling-upgrade fail-OPEN for the
+/// zones dropped from the scope. A compatibility extension that changes
+/// deny/reject COVERAGE must not be silently ignorable under an unchanged
+/// protocol version.
+pub(crate) const CONFIG_SNAPSHOT_PROTOCOL_VERSION: i32 = 4;
 pub(crate) const INJECT_PACKET_TUPLE_PROTOCOL_VERSION: i32 = 1;
 
 /// #3651: one per-zone traffic-volume row inside the `ProcessStatus`-level

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -113,17 +113,36 @@ Go side; **the JSON tags ARE the contract** — changing one without
 updating the other breaks the helper.
 
 `ConfigSnapshot.version` is a compatibility gate, not just documentation.
-The helper accepts only the current snapshot protocol version; this prevents a
-new daemon from publishing fields such as policy-scheduler inactive bits or
-source-NAT persistent-lease settings to a helper that would silently ignore
-them.
+The helper accepts only the current snapshot protocol version — EXACT equality,
+on both mutating verbs (`apply_snapshot` and `bump_fib_generation`). This
+prevents a new daemon from publishing fields such as policy-scheduler inactive
+bits, source-NAT persistent-lease settings, or scoped-global zone SETS to a
+helper that would silently ignore them. Bump `CONFIG_SNAPSHOT_PROTOCOL_VERSION`
+(`protocol/control.rs`) and the Go mirror `ProtocolVersion` TOGETHER whenever a
+change makes an older reader interpret the same bytes differently — in
+particular whenever a new field becomes authoritative over an existing one.
+Leaving the version unchanged for such a field is what caused #5488: the
+plural `match_from_zones`/`match_to_zones` scope became authoritative in #4626
+while the version stayed at 3, so a pre-#4626 helper at the same advertised
+version read only the singular field and NARROWED a multi-zone global deny (a
+rolling-upgrade fail-open).
+
 The helper also reports `config_snapshot_protocol_version` in status so a new
 daemon can fail closed before sending snapshots that require newer runtime
 semantics to an older helper binary that predates the gate. If the daemon
-detects an incompatible helper while scheduled policies or per-pool source-NAT
-`persistent-nat` settings are configured, it sends `set_forwarding_state
-armed=false` before returning the compile/publish error; the old helper must
-not keep forwarding a stale snapshot that ignores those semantics.
+detects an incompatible helper while any of the gated features is configured —
+scheduled policies, per-pool source-NAT `persistent-nat` settings, or a
+scoped-global policy whose zone scope holds MORE THAN ONE zone on a side
+(#5488) — it sends `set_forwarding_state armed=false` before returning the
+compile/publish error; the old helper must not keep forwarding a stale snapshot
+that ignores those semantics. The Go-side gate list is
+`requiredProtocolGateSentinels` in `pkg/dataplane/userspace/manager_compile.go`;
+every gate must be registered there or the commit is promoted against a
+disarmed dataplane (#2138). If that disarm ITSELF fails on a publish path whose
+classifier BPF maps were already mutated in place, the daemon additionally
+drives the `userspace_ctrl` shim to `Enabled=0` so transit falls back to the
+kernel-only fail-closed posture rather than running maps a generation ahead of
+the applied snapshot (#5488 F7, mirroring #4959).
 
 `inject_packet_tuple_protocol_version` is the corresponding status gate for
 `inject_packet` requests that set `emit_on_wire=true`. Those requests must carry


### PR DESCRIPTION
Closes #5488

## The defect

`lowerPolicy` (`pkg/dataplane/userspace/policies_lower.go:259-262`) emits a
scoped global policy's zone scope twice: `MatchFromZone`/`MatchToZone` =
the FIRST zone only (`config.ScopeSingular`, "for backward compatibility")
plus `MatchFromZones`/`MatchToZones` = the full authoritative set. #4626
added the plural fields as purely additive JSON and did **not** bump
`CONFIG_SNAPSHOT_PROTOCOL_VERSION` — it was still `3`, the same value a
pre-#4626 helper advertises **and accepts**.

So the version handshake said "we agree" while the two sides disagreed
about what the message meant. A pre-#4626 helper passes the gate, ignores
the plural fields, reads only the singular one, and **narrows** a global
`deny` scoped `[dmz trust] -> untrust` to `dmz -> untrust`. Traffic from
`trust` that the operator denied then falls through to lower-precedence
rules and can be permitted — a rolling-upgrade **fail-OPEN**.

## Fix shape, and why

Two halves. **Neither is sufficient alone.**

**1. Bump both constants to 4, in lockstep.** Go `ProtocolVersion`
(`pkg/dataplane/userspace/protocol.go`) and Rust
`CONFIG_SNAPSHOT_PROTOCOL_VERSION` (`userspace-dp/src/protocol/control.rs`).
Both mutating verbs — `apply_snapshot` and `bump_fib_generation` — already
gate on **exact equality**, not `>=`, so a pre-v4 helper now refuses the
snapshot outright rather than decoding it under its own narrower contract.
The #4626 singular emission is deliberately **unchanged**; the fix is that
no reader which would narrow it can receive the snapshot.

**2. A fail-closed required-protocol gate.** A bump alone only makes an old
helper *refuse* the snapshot — and a refused snapshot leaves it **armed on
its previous-good image, still forwarding**, with the newly committed deny
never installed. That is the "worse than the bug" outcome, so the bump is
paired with `ensureScopedGlobalZoneSetProtocolLocked`, in the same
required-gate class as the policy-scheduler and persistent-source-NAT gates
(#2138). When the config carries a multi-zone scope and the helper reports
`ConfigSnapshotProtocolVersion < ProtocolVersion`, the daemon **disarms**
the helper (`set_forwarding_state{armed:false}`) and the commit **aborts**
with `ErrScopedGlobalZoneSetProtocolIncompatible`, registered in
`requiredProtocolGateSentinels`. Lenient-load (#1960) is unchanged: boot and
peer-sync applies disarm and log rather than brick the node; only the
operator-facing commit path surfaces the abort.

The gate is keyed on the multi-zone **shape**, not the action, so it covers
both directions — narrowing a `deny`/`reject` (fail-open) and narrowing a
`permit` (fail-closed correctness break). It fires only for `len(scope) > 1`:
a one-element scope emits `singular == the one zone` and an unscoped global
emits neither side, so neither is narrowable and neither is gated. That keeps
the disarm blast radius to exactly the misrepresentable population.

### Considered and rejected: make the singular field unambiguous

- Emitting `""` for a multi-zone scope makes an old reader resolve
  `GlobalZoneScope::Any` — safely *wider* for a `deny`, but a catastrophic
  fail-OPEN for a scoped `permit`. The field is action-agnostic, so no single
  value is safe for both actions.
- Emitting a poison sentinel would depend on the OLD helper having the #3402
  unresolvable-zone fail-closed preflight — i.e. on code in the very binary we
  cannot upgrade or test. That cannot be load-bearing.

For the LOCAL daemon↔helper skew this closes, the version is the only signal
that is load-bearing on code present in every version that has the gate. It is
**not** a signal for the cross-chassis skew — see the residual below.

## Residual: the version is node-LOCAL (#6650)

This closes the daemon↔local-helper skew. It does **not** close the
cross-chassis one, and the claim above should not be read as covering it.

The snapshot protocol version governs the local control socket and never
crosses the cluster heartbeat. In a mixed-version HA pair: node A (v4) commits
a multi-zone scope; A's gate stays silent because A's own helper is v4;
`pushCommittedConfigToPeer` ships the config **text** to node B; B's v3 daemon
compiles it and narrows the deny against its own v3 helper. Same fail-open,
relocated from "old helper" to "old peer node". Closing it needs a scope signal
on the config-sync/heartbeat wire, which is out of scope here and tracked as
**#6650**. Recorded in `docs/userspace-dataplane-architecture.md` alongside the
version contract so the boundary is documented where a reader will look.

## Both-sides grep

The helper snapshot wire has **exactly two parties**:

| Side | Location |
|---|---|
| Go emitter | `pkg/dataplane/userspace/policies_lower.go:259-262` (sole producer); `pkg/dataplane/userspace/zones_quarantine.go:188-198` re-derives the singular from the pruned set on the same struct |
| Rust consumer | `userspace-dp/src/policy.rs:2118,2123` via the plural-preferring `effective_match_zones`; decode at `userspace-dp/src/protocol/security.rs:489-505` |

**No third reader.** `policies_reject.go:172-173` and
`zones_quarantine.go:183-193` read the same in-process struct through
`effectiveMatchFromZones()`, which prefers the plural — they see the
authoritative set and are unaffected.

**A separate wire, out of scope:** gRPC `PolicyRule`
(`pkg/grpcapi/server_show_zones.go:277-280`) and REST
(`pkg/api/security.go:311-314`) carry the same singular+plural pair to *client*
consumers, resolved plural-first by `cmd/cli/show_security.go:581-599`. An old
`cli` against a new daemon would **display** only the first zone — an
observability skew across a client-version skew, not an enforcement change
(the policy simulator `pkg/policymatch` reads `rule.Match.FromZones` from the
config, not these fields). Different protocol, no forwarding impact,
deliberately not in this PR.

## Gate evidence

**1. The test.** `TestScopedGlobalMultiZoneDenyIsNotNarrowableByPreV4Helper`
builds a real snapshot from a multi-zone scoped global **deny**, asserts as a
*precondition* that the singular field really is narrower than the configured
set (so the test keeps exercising the hazard), then asserts the pre-v4 helper
**refuses** that snapshot — modelling the exact-equality gate from
`userspace-dp/src/server/handlers/snapshot.rs` — and that the Go gate returns
the sentinel and is in the commit-abort set.

**2. Mutation proof — assertion-level RED, `go build ./...` and
`go vet ./...` CLEAN under both reverts.**

Full revert of the production change:

```
--- FAIL: TestScopedGlobalMultiZoneDenyIsNotNarrowableByPreV4Helper (0.00s)
    scoped_global_zoneset_protocol_5488_test.go:113: a pre-#4626 helper ACCEPTS the snapshot at version 3: it reads only the singular match_from_zone "dmz" and narrows the global deny to ["dmz"] instead of the configured ["dmz" "trust"] (rolling-upgrade fail-OPEN — CONFIG_SNAPSHOT_PROTOCOL_VERSION must not collide with 3)
    scoped_global_zoneset_protocol_5488_test.go:127: ensureRequiredSnapshotProtocolLocked against a pre-v4 helper = <nil>, want ErrScopedGlobalZoneSetProtocolIncompatible (helper must be disarmed, not fed a snapshot whose multi-zone deny it will narrow)
    scoped_global_zoneset_protocol_5488_test.go:134: IsRequiredProtocolGateError(<nil>) = false, want true — the #5488 gate must abort the commit
--- FAIL: TestScopedGlobalZoneSetGateCoversZonePairTier (0.00s)
    scoped_global_zoneset_protocol_5488_test.go:275: zone-pair tier multi-zone scope = <nil>, want ErrScopedGlobalZoneSetProtocolIncompatible
--- FAIL: TestSnapshotProtocolVersionLockstepWithRust (0.00s)
    scoped_global_zoneset_protocol_5488_test.go:307: snapshot protocol version = 3, must be > 3 (#5488): the plural match_from_zones/match_to_zones scope fields changed deny COVERAGE, so the version must not collide with the pre-#4626 value whose readers ignore them
--- FAIL: TestIsRequiredProtocolGateError (0.00s)
    manager_capabilities_test.go:277: IsRequiredProtocolGateError(userspace scoped-global zone-set snapshot protocol incompatible) = false, want true (bare sentinel)
```

Gate-only revert, **version bump left in** — proves the gate binds
independently of the constant:

```
--- FAIL: TestScopedGlobalMultiZoneDenyIsNotNarrowableByPreV4Helper (0.00s)
    scoped_global_zoneset_protocol_5488_test.go:127: ensureRequiredSnapshotProtocolLocked against a pre-v4 helper = <nil>, want ErrScopedGlobalZoneSetProtocolIncompatible (helper must be disarmed, not fed a snapshot whose multi-zone deny it will narrow)
    scoped_global_zoneset_protocol_5488_test.go:134: IsRequiredProtocolGateError(<nil>) = false, want true — the #5488 gate must abort the commit
```

**3. Negative control.**
`TestScopedGlobalSingleZoneAndUnscopedPolicyNotGated` covers a single-zone
scoped deny, an unscoped global permit, and an ordinary zone-pair permit: each
lowers with the singular and plural shapes agreeing, a singular-only reader
resolves the *same* scope as a plural-aware one, and the gate stays silent even
against the oldest helper. **It stays GREEN under the revert**, as a negative
control must.

**4. Suites.** Full `go test ./...` green (exit 0).
`TMPDIR=/tmp CARGO_TARGET_DIR=/dev/shm/cargo-5488 cargo test --release --bins --tests -- --test-threads=1`
green (exit 0, 7 `test result: ok`, 0 failures).

**5. Docs.** New *Config-snapshot protocol version* section in
`docs/userspace-dataplane-architecture.md` records what the version means, the
exact-equality gate, why it moved to 4, and the paired fail-closed gate. The
stale "for rolling-upgrade compatibility with an old helper" claim is corrected
there and in `docs/config-schema.md`.

## Review fold (second commit)

**F4 — guard scope narrower than the claim.** `policyScopeIsMultiZone` tests
`len(FromZones) > 1 || len(ToZones) > 1`, but the only test pinning the to-zone
half built a **zone-pair** policy carrying `Match.ToZones` — a shape
`compiler_security_policy.go` never produces. The reachable to-side hazard
(`global policy p match { from-zone trust; to-zone [ untrust dmz ]; }`) had no
coverage. Added `TestScopedGlobalZoneSetGateCoversBothScopeSides` with
reachable global rows for the to-side, from-side, and both sides, each
asserting the singular field really is narrower before asserting the gate
fires; the zone-pair row is kept and relabelled as defensive breadth over the
emission surface. Re-ran the to-zone-half mutation — the **new reachable** row
reds, not only the defensive one.

**F7 — ctrl fail-close on a FAILED disarm.** Fixed. Extracted
`disarmSnapshotProtocolFailClosedLocked`, which drives `userspace_ctrl` to
`Enabled=0` via `failClosedUserspaceCtrlMapLocked` when the disarm itself
errors on a path whose classifier maps were mutated in place.

Scope came from the codebase's own oracle rather than the report:
`publishSnapshotFailClosedLocked`'s `mapsMutatedInPlace` flag has **exactly two
call sites** — `Compile` with `samePlanRefresh` and `syncSnapshotLocked` with an
unconditional `true` — and **both** carried the identical hazard. Fixing only
`Compile` would have shipped a fix narrower than the defect (the same shape as
F4), so the sibling `process_status.go` site is fixed too. The other three gate
call sites (route overlay, deferred worker arm, HA desired-state reconcile) use
a bare `requestLocked` and mutate no maps beforehand, so they are correctly
untouched. Every `failClosedUserspaceCtrlMapLocked` return path preserves
`cause`, so the sentinel still satisfies `IsRequiredProtocolGateError` and the
commit still aborts — asserted explicitly.

**F5** — the node-local residual is disclosed above and in the architecture
doc, against #6650.

**F6** — resolved in favour of `Closes #5488`; the contradictory trailing
`Advances #5488.` is removed.

**F1/F2/F3** — refreshed the stale two-gate enumerations in
`userspace-dp/src/server/README.md` (which now also states the bump-in-lockstep
rule and names #5488 as the reason), `docs/userspace-dataplane-gaps.md`, and
`pkg/daemon/daemon_apply.go` (now pointing at the table-driven
`IsRequiredProtocolGateError` rather than naming two sentinels).

### Fold mutation proofs

Both red as **assertions**, `go build ./...` and `go vet ./...` **clean**.

To-zone half of `policyScopeIsMultiZone` reverted — the new reachable row reds:

```
    scoped_global_zoneset_protocol_5488_test.go:340: gate = <nil>, want ErrScopedGlobalZoneSetProtocolIncompatible
--- FAIL: TestScopedGlobalZoneSetGateCoversBothScopeSides/global_multi-zone_TO_side
```

`failClosedUserspaceCtrlMapLocked` call dropped — only the targeted sub-test
reds; both scope controls and all pre-existing #4959 tests stay green:

```
    scoped_global_zoneset_failclosed_5488_test.go:152: ctrl.Enabled = 1 after a FAILED protocol-gate disarm, want 0 (fail closed); ...
--- FAIL: TestSnapshotProtocolDisarmFailureFailsClosed5488/maps_mutated_in_place_disables_ctrl
    --- PASS: .../bootstrap_path_does_not_failclose
    --- PASS: .../successful_disarm_returns_bare_gate_error
--- PASS: TestAddressOnlyCommitRejectedPublishFailsClosed4959 (all 3 sub-tests)
--- PASS: TestDeferredPublishRejectedFailsClosed4959 (both sub-tests)
```

### A note on the F7 test, since it SKIPs unprivileged

Like its #4959 siblings it needs memlock, so it was run under `sudo` to confirm
all three sub-tests genuinely **execute** rather than skip. That surfaced two
harness gaps, fixed rather than papered over:

1. The success path needed the full classifier map set injected — without it
   the status sync failed and the sub-test silently became a duplicate of the
   failure case.
2. Its original ctrl assertion was **wrong**: on a successful disarm
   `applyHelperStatusLocked` independently programs ctrl to 0 from the helper's
   disarmed status. The discriminating assertion is now error **identity**,
   which `errors.Is` could not have distinguished from a join.

## Side effect worth reviewing

The bump also tightens the two pre-existing required-protocol gates, which
compare against the current `ProtocolVersion` rather than a pinned per-feature
floor. Adjudicated as pre-existing coupling (#6648) — but the bump is what
makes it bite, so the disarm radius genuinely widens from "configs using the
new feature" to "configs using any gated feature". Not held against this PR;
recorded there.

Also tracked separately and not folded: the `>=`-vs-`==` gate comparison
(#6649) and the gate's position after the classifier-map write (#6647), both
pre-existing.

## Smoke

**Cluster smoke required and NOT run here** — this changes forwarding
admission. The cluster is shared and lock-managed; smoke is scheduled by the
team lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi

