### PR TITLE
fix(config): compile packed redundancy-group interface-monitor / ip-monitoring (#6588)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,51 @@
+## 2026-08-01 — #6588 round 3: the same drop ONE LEVEL UP (redundancy-group instance)
+
+- **Timestamp**: 2026-08-01 (fix/6588-interface-monitor-packed-leaf, PR #6658)
+- **Action**: Round-3 review found a third shape, verified firsthand at the
+  round-2 head before writing: `redundancy-group 1 <statement>;` written on the
+  INSTANCE line compiles to an empty group. namedInstances resolves the name
+  across both shapes (Keys[1]) but returns the node with the body still on
+  Keys, so compileChassis's `range rgInst.node.Children` saw nothing. All four
+  statements confirmed lost with NO error: interface-monitor, ip-monitoring,
+  preempt, and — the severe one — `node 0 priority 200`, the redundancy-group
+  ELECTION PRIORITY. Dropped, the cluster elects on defaults and the wrong node
+  can hold the group, which is a superset of "never demotes".
+  Fixed with redundancyGroupBody = packedStatementProps(rgNode, 2,
+  isRedundancyGroupStatement), so a multi-statement line
+  (`node 0 priority 200 preempt gratuitous-arp-count 8;`) splits at statement
+  keywords instead of folding into the first. Applied at ALL FOUR readers of
+  the RG body — compileChassis plus validateMonitorWeightTokensAST,
+  validateChassisClusterIdentitiesAST and validateGratuitousARPCountAST —
+  because a compiler that sees a shape its gates cannot would admit, through
+  the packed instance line only, exactly what round 2 closed elsewhere.
+- **Rejected fix direction, with evidence**: the reviewer's preferred option was
+  to make namedInstances itself synthesize the packed tail as a child, fixing
+  all ~130 callers at once. Tried it. It breaks callers that already handle the
+  tail: 24 sites read inst.node.Keys directly, and compileStaticRoutes branches
+  on `len(Children)==0` to DETECT the packed shape, so a synthetic child
+  disables its packed path. The experiment turned TestDHCPRelayOverrides_* red
+  (override tokens swallowed into Interfaces) and
+  TestVRRPTrackInterface_KeysPackedDuplicateStrictReject red (lenient
+  first-wins gave an empty TrackInterface). One prediction was wrong and is
+  recorded as such: the packed static route itself SURVIVED the experiment
+  (its next-hop arrives as a real child either way).
+- **Audit answer — other namedInstances callers are NOT all safe**: measured by
+  direct compile, `system login class ops permissions view;` yields a class with
+  empty permissions, `system login user bob class ops;` a user with no class,
+  and `system syslog host 10.0.0.9 any;` a host with zero facilities. Same root
+  cause, different stanzas. Reported as follow-up work rather than claimed safe.
+- **Validation**: mutation D — redundancyGroupBody returns rgNode.Children —
+  build+vet CLEAN, 2 top-level FAILs (PackedBody, PackedBodyReachesGates), 13
+  assertions each naming the lost statement; the container-form control stayed
+  GREEN. Restored: build+vet clean, `go test ./...` exit 0 across 59 packages,
+  85 passing 6588 subtests.
+- **File(s)**: `pkg/config/compiler_system.go`,
+  `pkg/config/compiler_chassis_monitor_weight.go`,
+  `pkg/config/compiler_chassis_identity.go`,
+  `pkg/config/compiler_chassis_garp_count.go`,
+  `pkg/config/compiler_chassis_packed_monitor_6588_test.go`,
+  `docs/config-schema.md`, `_Log.md`
+
 ## 2026-08-01 — #6588 round 2: three MAJORs inside the round-1 fix
 
 - **Timestamp**: 2026-08-01 (fix/6588-interface-monitor-packed-leaf, PR #6658)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,51 @@
+## 2026-08-01 — #6588 config/cluster: packed interface-monitor / ip-monitoring compiled to nothing
+
+- **Timestamp**: 2026-08-01 (fix/6588-interface-monitor-packed-leaf)
+- **Action**: Fixed a chassis-cluster failover FAIL-OPEN. A redundancy-group
+  monitor authored in the PACKED hierarchical spelling — one statement
+  directly under `redundancy-group`, no nested block — compiled to NOTHING.
+  The parser yields a single leaf
+  (`Keys=[interface-monitor ge-0/0/0 weight 255]`, no children) while
+  `compileChassis` enumerated monitors by iterating `child.Children` only,
+  so the operator got `rgs=1, monitors=0`: link tracking configured, commit
+  clean, and a redundancy group that never demoted on link-down.
+  Swept the whole `compileChassis` switch (6 arms) and found the same drop
+  at TWO more sites in the same loop, both fixed here: packed `ip-monitoring`
+  (`ip-monitoring global-weight 255;`, `ip-monitoring family inet <addr>
+  weight <n>;`) dropped its global weights and every probe target — the same
+  RG-demotion debt path — and a packed `family inet <addr> weight <n>;` leaf
+  written INSIDE an `ip-monitoring { ... }` block dropped the target too.
+  The `node` / `gratuitous-arp-count` / `preempt` / `strict-vip-ownership`
+  arms already handled both shapes (verified by direct compile, not by
+  reading). A third sub-shape surfaced from the new test rather than the
+  issue: `interface-monitor ge-0/0/0 { weight 255; }` packed the NAME onto
+  the statement while the attributes arrived as children, so the old reader
+  minted a monitor for an interface literally called `weight`.
+  New shared reader `packedOrContainerEntries(cfgNode, skip)` normalises all
+  shapes; its rule is EITHER/OR (an inline tail means the statement IS one
+  entry, so its children are that entry's properties) — the same rule
+  `namedInstances` already applies, and deliberately NOT the accumulate rule
+  the #2419 multi-value contract uses, since accumulating is what mints the
+  bogus `weight` monitor. `findNamedNode` is its slice-shaped `FindChild`.
+  Second-order: because the packed shape now reaches the compiled `*Config`,
+  the #6549 weight range gate (which runs on the compiled int) covers it for
+  free — a packed `weight -100` is now rejected at commit instead of
+  silently accepted.
+- **Validation**: fail-on-revert with `compiler_system.go` restored verbatim
+  from `origin/master` (test kept): `go build ./...` + `go vet ./...` CLEAN,
+  every Packed subtest RED as an assertion naming the missing monitor /
+  target, and the FlatSet / ContainerHierarchical / Control* subtests GREEN
+  as controls. Full `pkg/config` suite under mutation: 7 top-level FAILs, all
+  `*_6588`, zero others. Restored: full `go test ./...` exit 0.
+- **Scope left out**: `services ip-monitoring` (#1827, `compiler_services.go`)
+  drops its packed `then preferred-route ...;` too, but that is fail-CLOSED —
+  a policy with zero compiled routes is a hard commit error ("at least one
+  then preferred-route route is required"), verified by direct compile. It is
+  a different stanza with a loud failure, so it stays out of this PR.
+- **File(s)**: `pkg/config/compiler_system.go`,
+  `pkg/config/compiler_chassis_packed_monitor_6588_test.go` (new),
+  `docs/config-schema.md`, `_Log.md`
+
 ## 2026-07-31 — #6611 review round 2: guard scoped narrower than its claim
 
 - **Timestamp**: 2026-07-31 (fix/6611-control-channel-auth, PR #6624)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-08-01 — #6588 round 3b: drift guard on the isRedundancyGroupStatement list
+
+- **Timestamp**: 2026-08-01 (fix/6588-interface-monitor-packed-leaf, PR #6658)
+- **Action**: Round 3 introduced a HAND-WRITTEN token list
+  (isRedundancyGroupStatement) that redundancyGroupBody splits a packed instance
+  tail at. A token missing from that list is not a loud failure — the
+  statement's tokens append to whichever statement precedes it on the line, so
+  it silently does nothing. Same defect class as the bug, better camouflaged.
+  Checked the list against both sources of truth rather than re-reading it:
+  it equals compileChassis's switch arms EXACTLY (node, gratuitous-arp-count,
+  preempt, strict-vip-ownership, interface-monitor, ip-monitoring), and is a
+  strict SUPERSET of setSchema's redundancy-group children — setSchema is
+  missing `strict-vip-ownership`, which the compiler DOES handle. That schema
+  gap is pre-existing and unrelated (it costs config-mode completion for that
+  leaf, not compilation); reported, not fixed here.
+  Correct today is not the property worth having, so the list is no longer
+  trusted by inspection: TestRedundancyGroupStatementPredicateCoversCompiler_6588
+  parses compileChassis's OWN source (go/ast), extracts every `case "..."` of
+  the `switch child.Name()` dispatch, and requires the predicate to accept each.
+  Adding an arm without extending the predicate now fails with the token named.
+  The guard fails loudly if it cannot find the function or the switch, and has a
+  floor of 6 arms, so it cannot silently verify an empty set.
+- **Validation**: proved the guard FIRES in both drift directions, build+vet
+  CLEAN under each. (E1) drop "preempt" from the predicate -> RED naming
+  "preempt". (E2) add `case "hold-down-interval":` to compileChassis and forget
+  the predicate — the realistic drift — -> RED naming "hold-down-interval".
+  Restored: build+vet clean, `go test ./...` exit 0 across 59 packages, 86
+  passing 6588 subtests.
+- **File(s)**: `pkg/config/compiler_chassis_packed_monitor_6588_test.go`, `_Log.md`
+
 ## 2026-08-01 — #6588 round 3: the same drop ONE LEVEL UP (redundancy-group instance)
 
 - **Timestamp**: 2026-08-01 (fix/6588-interface-monitor-packed-leaf, PR #6658)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,20 @@
+## 2026-08-01 — #6588 round 6c: put the two-of-three characterization in the comment
+
+- **Timestamp**: 2026-08-01 (fix/6588-interface-monitor-packed-leaf, PR #6658)
+- **Action**: Round 6b corrected the overstated invariant but left the comment
+  merely accurate, not useful: it said the invariant is not enforced without
+  saying WHY the table is still worth having. Reviewer asked for the fuller
+  characterization in the comment itself. Now states, in the artifact that
+  ships: two of the three routes are closed BY CONSTRUCTION (a named-constant
+  KEY registers exactly like a literal one; no switch remains to nest another
+  inside), the third is demoted not eliminated, and what changed for it is which
+  act is natural — adding a `case` used to be the idiomatic way to add a
+  statement and diverged silently, whereas diverging now means ad-hoc dispatch
+  beside a five-line loop whose only other content is the table lookup.
+  docs/config-schema.md carried the same qualification without saying which
+  routes close; matched.
+- **File(s)**: `pkg/config/compiler_system.go`, `docs/config-schema.md`, `_Log.md`
+
 ## 2026-08-01 — #6588 round 6b: correct an overstated invariant in the table comment
 
 - **Timestamp**: 2026-08-01 (fix/6588-interface-monitor-packed-leaf, PR #6658)

--- a/_Log.md
+++ b/_Log.md
@@ -65958,3 +65958,50 @@ break — `go vet` confirmed passing under every revert.
   accessor the PR orphaned has one caller and one definition again.
   Docs-and-wiring only: no runtime behaviour change.
 - **File(s)**: pkg/cluster/heartbeat.go, pkg/cluster/README.md, _Log.md
+
+- **Timestamp**: 2026-08-01 03:20
+- **Action**: #6658 review fold — assert monitor WEIGHTS, not just names, on
+  bracketed lists. `assertMonitors`'s weight arm was dead code: its only caller
+  was an `assertMonitorNames` shim passing nil, so every bracketed-list case in
+  the #6588 suite ran weight-less and the apply-to-all rule in
+  `monitorEntryNodes` was unguarded. Reverting that function to the round-4
+  positional attachment left build, vet and the whole suite green. The shim is
+  deleted and weights are mandatory; name-only callers pass explicit zeros,
+  which asserts the documented #6549 default instead of skipping the check.
+  Also corrected the `redundancyGroupStatements` enumeration, which claimed
+  three drift routes (all of them the table under-covering the compiler) when a
+  probe found a fourth of the opposite shape: the splitter matches a registered
+  keyword in VALUE position, so `interface-monitor preempt weight 255` steals
+  `preempt` and the packed and container spellings disagree. Unreachable from a
+  real config (no Junos interface name collides), so documented rather than
+  fixed; splitting position-aware is #6665.
+- **File(s)**: pkg/config/compiler_chassis_packed_monitor_6588_test.go,
+  pkg/config/compiler_system.go, docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-08-01 04:05
+- **Action**: #6658 review fold round 2 — close two silent-no-effect holes the
+  Codex xhigh review found, and restore the regression coverage the
+  dispatch-table refactor (b3158d315) deleted. (1) `ip-monitoring`'s
+  `global-weight` / `global-threshold` bypassed every gate: the weight gate
+  walked only ENTRY lists, so `global-weight nope`, `global-weight;` and
+  `global-weight 100 global-weight 200` all committed clean at a compiled 0 —
+  zero demotion debt for the WHOLE group, so no number of failing probes
+  demotes it. Now checked by the same missing-value / non-integer / duplicate
+  rules through a shared `checkTokens`, reading the globals with
+  `ipMonitoringGlobalTokens` over the same `packedStatementProps` result the
+  compiler dispatches from. (2) `preempt` and `strict-vip-ownership` compile to
+  a bool and never read the node, so `preempt delay 5` — real Junos syntax xpf
+  does not implement — was accepted and discarded silently; new
+  `validateRGNoArgStatementsAST` rejects trailing tokens and block bodies,
+  strict at commit and warning on the tolerant load path (#1960). (3)
+  `TestRedundancyGroupStatementsSurvivePackedLine_6588` was placeholder-vacuous:
+  an entry keyed `review-placeholder` with sample text `preempt` passed while
+  its handler was never dispatched. Samples must now begin with their own
+  keyword, and the dispatch table is instrumented so a case that never reaches
+  its handler fails. (4) Restored `TestChassisRedundancyGroupBareContainerShape_6588`
+  and the bracket out-of-range / ambiguous-weight cases that b3158d315 dropped.
+- **File(s)**: pkg/config/compiler_chassis_monitor_weight.go,
+  pkg/config/compiler_chassis_rg_arity.go, pkg/config/compiler_system.go,
+  pkg/config/compiler_prewalk.go, pkg/config/compiler_opts.go,
+  pkg/config/compiler_chassis_packed_monitor_6588_test.go,
+  docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,21 @@
+## 2026-08-01 — #6588 round 6b: correct an overstated invariant in the table comment
+
+- **Timestamp**: 2026-08-01 (fix/6588-interface-monitor-packed-leaf, PR #6658)
+- **Action**: The redundancyGroupStatements comment claimed a statement not in
+  the table "is not compiled either — so the two cannot disagree". Review tested
+  that rather than accepting it: dispatch injected inside the loop but outside
+  the table lookup reproduces the original divergence (container form honors the
+  statement, packed multi-statement line drops it). Same m4' result I reported
+  in round 6 — but the CODE COMMENT still carried the overstatement, which is
+  where the next person reads it, so the honest version in the PR body did not
+  fix anything. Reworded to state the real property: the invariant is "all
+  dispatch goes through this table", and the table being the only dispatch path
+  present makes the correct thing the easy thing — it is NOT enforced.
+  Fixed the identical overstatement in docs/config-schema.md, which also carried
+  "so the two cannot disagree" and then contradicted itself a paragraph later.
+  An overstated invariant is how the next person concludes they need not think.
+- **File(s)**: `pkg/config/compiler_system.go`, `docs/config-schema.md`, `_Log.md`
+
 ## 2026-08-01 — #6588 round 6: replace the source-modelling drift guard with a dispatch table
 
 - **Timestamp**: 2026-08-01 (fix/6588-interface-monitor-packed-leaf, PR #6658)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,46 @@
+## 2026-08-01 — #6588 round 5: a regression this PR introduced, plus a second RG node shape
+
+- **Timestamp**: 2026-08-01 (fix/6588-interface-monitor-packed-leaf, PR #6658)
+- **Action**: Re-review at e25cc5d0c found two MAJORs; both reproduced firsthand
+  before writing.
+  (MAJOR-A, a REGRESSION vs master) `interface-monitor [ ge-0/0/0 ge-0/0/1 ]
+  weight 255` compiled ge-0/0/0 at weight ZERO. The round-3 splitter attached a
+  weight token to the entry immediately preceding it. Master compiled ONE
+  monitor at 255; this branch compiled two, N-1 of them inert — monitored,
+  shown, deducting nothing on link-down. Worse than master, and it contradicted
+  this PR's own children-block path, where `[ a b ] { weight 255; }` already
+  applied 255 to both. Fixed by making the attribute run CANDIDATE-scoped: names
+  and `weight` tokens are separated, then every name gets the full run.
+  Apply-to-all is the fail-safe direction and is strictly better than master
+  here (no member dropped, no weight lost). Two inline weights in one bracketed
+  statement are now REJECTED as ambiguous, consistent with the round-2
+  duplicate gate — master silently took the last and dropped the rest.
+  Root cause of it shipping: assertMonitorNames compared only
+  InterfaceMonitors[i].Interface and never .Weight, so the whole bracket suite
+  was blind to weight distribution. Replaced with assertMonitors(names,
+  weights); the name-only entry point now delegates, and the helper documents
+  why a name-only assertion is not enough.
+  (MAJOR-B) redundancyGroupBody used a fixed skip of 2, correct for only ONE of
+  namedInstances' two return shapes. For a bare `redundancy-group { 1 ...; }`
+  wrapper it returns a CHILD whose Keys[0] IS the id, so skip must be 1; with 2
+  the statement keyword was swallowed and the tail opened a node named after a
+  value, matching no switch arm — every statement dropped, election priority
+  included, through all four redundancyGroupBody readers. Keys[0] is an exact
+  discriminator (shape 1 is always reached via FindChildren("redundancy-group")).
+  Fixed rather than documented despite lower reachability: the guard covers all
+  four readers, so leaving it would make the three AST gates blind here while
+  LOOKING like they covered it.
+- **Validation**: two mutation proofs, build+vet CLEAN under each. (F) attach the
+  inline weight to the last entry only -> 2 top-level FAILs, assertions naming
+  the zero-weight monitor; the three MAJOR-A controls (children-block,
+  single-name, weight-less) stayed GREEN. (G) pin skip back to 2 -> 1 FAIL, 4
+  assertions naming the lost statement; both MAJOR-B controls (bare-wrapper
+  nested block, ordinary instance shape) stayed GREEN. Restored: build+vet
+  clean, `go test ./...` exit 0 across 59 packages, 104 passing 6588 subtests.
+- **File(s)**: `pkg/config/compiler_system.go`,
+  `pkg/config/compiler_chassis_packed_monitor_6588_test.go`,
+  `docs/config-schema.md`, `_Log.md`
+
 ## 2026-08-01 — #6588 round 3b: drift guard on the isRedundancyGroupStatement list
 
 - **Timestamp**: 2026-08-01 (fix/6588-interface-monitor-packed-leaf, PR #6658)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,60 @@
+## 2026-08-01 — #6588 round 2: three MAJORs inside the round-1 fix
+
+- **Timestamp**: 2026-08-01 (fix/6588-interface-monitor-packed-leaf, PR #6658)
+- **Action**: Hostile review returned DO-NOT-MERGE with three MAJORs, all
+  inside the code round 1 touched. Each premise was re-verified by direct
+  compile before writing, and one needed correcting.
+  (MAJOR 1) ip-monitoring 0..255 was ungated for the PACKED spelling. The
+  review framed it as "the packed path bypasses the validation the container
+  path gets"; direct compile shows the real shape is narrower and the fix is
+  wider — `SchemaValidate` is called from pkg/configstore, not CompileConfig,
+  and it walks setSchema, so the PACKED statement sits below the depth it
+  reaches for BOTH ip-monitoring and interface-monitor. The typed leaf covers
+  flat-set and container; nothing covered packed. Harmless while packed
+  compiled to nothing — but round 1 made it compile. Fix: extend the #6549
+  compiled-int gate in validateChassisClusterStrict to global-weight,
+  global-threshold and per-target weight, the one layer all three spellings
+  pass through. Pinned that reasoning with a test asserting SchemaValidate
+  returns nil for a config the compiled-int gate rejects.
+  (MAJOR 2) A bracketed `interface-monitor [ a b c ]` compiled ONE monitor.
+  Confirmed pre-existing in ALL THREE spellings, not introduced by round 1 —
+  the lexer strips the brackets (#2419) so N names land on one node's Keys
+  everywhere. The round-1 helper synthesised exactly one entry from the tail,
+  so it inherited the drop. Replaced with monitorEntryNodes, which splits each
+  candidate's Keys at entry boundaries with a reserved value slot after
+  `weight` (the #6524 rule). Kept the EITHER/OR tail-vs-children rule for
+  entry lists — accumulating there mints a monitor for an interface literally
+  named `weight` — and added packedStatementProps for the ip-monitoring
+  property body, where the two ARE siblings.
+  (MAJOR 4) `weight nope` committed clean with Weight=0, so the monitor
+  deducted nothing on link-down. The compiled struct cannot express it (a
+  failed Atoi is indistinguishable from `weight 0`), so this is a new AST gate,
+  validateMonitorWeightTokensAST, deriving its entries from the same readers
+  the compiler uses. Strict at commit, warn on the tolerant path
+  (lenientChassisMonitorWeight, #1960 no-brick).
+  Duplicates were shape-dependent (`weight 100 weight 200` inline -> 200;
+  `{ weight 100; weight 200; }` -> 100). The compiler is now uniformly
+  first-wins via monitorWeightTokens and the gate rejects the duplicate, so the
+  answer no longer depends on spelling.
+- **Validation**: three separate mutation proofs, each with build+vet CLEAN
+  first so the red is an assertion. (A) drop the ip-monitoring range block ->
+  2 top-level FAILs, both MAJOR-1 tests; in-range control GREEN. (B) make
+  monitorEntryNodes return the candidate unsplit -> 2 FAILs, both bracket
+  tests; the single-non-bracketed-entry control GREEN in full. (C) unwire the
+  weight gate from runPreWalkGates -> 3 FAILs (malformed, tolerant-warn,
+  duplicate); the valid-weight control GREEN. Restored: build+vet clean,
+  `go test ./...` exit 0 across 59 packages, 69 passing 6588 subtests.
+- **Scope refused**: the review also enumerated 14 other one-sided arms across
+  pkg/config with the same nodeVal root cause. Left alone and filed separately
+  by the reviewer — #6658 stays about redundancy-group monitors.
+- **File(s)**: `pkg/config/compiler_system.go`,
+  `pkg/config/compiler_chassis_monitor_weight.go` (new),
+  `pkg/config/compiler_validate_strict_chassis.go`,
+  `pkg/config/compiler_prewalk.go`, `pkg/config/compiler_opts.go`,
+  `pkg/config/schema_chassis.go` (stale comment),
+  `pkg/config/compiler_chassis_packed_monitor_6588_test.go`,
+  `docs/config-schema.md`, `_Log.md`
+
 ## 2026-08-01 — #6588 config/cluster: packed interface-monitor / ip-monitoring compiled to nothing
 
 - **Timestamp**: 2026-08-01 (fix/6588-interface-monitor-packed-leaf)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,49 @@
+## 2026-08-01 — #6588 round 6: replace the source-modelling drift guard with a dispatch table
+
+- **Timestamp**: 2026-08-01 (fix/6588-interface-monitor-packed-leaf, PR #6658)
+- **Action**: MAJOR-C — the round-4 drift guard PASSED while a 7th
+  redundancy-group statement was still dropped from a packed multi-statement
+  line, three different ways. Verified all three firsthand at 84f660259 before
+  writing (each: build CLEAN, guard PASS, statement DROPPED):
+    m3 `case rgHoldDownKeyword:` (a named constant, not a string literal) — the
+       guard `continue`d the non-BasicLit case silently, so len(arms) stayed 6
+       and even the `< 6` floor passed. This is the idiom THIS PR introduced
+       with `const monitorWeightKeyword = "weight"`.
+    m4 statement handled by a helper called from the loop, outside the switch —
+       the guard modelled ONE switch.
+    m7 nested `switch child.Name()` inside a `default:` arm — ast.Inspect
+       returned false after matching the outer switch so it never descended.
+  Camouflage that makes it worse than a gap: the same statement ALONE on a line
+  still works (packedStatementProps opens the first node regardless of the
+  predicate), so a developer sees three greens and ships the fold bug.
+  Took the reviewer's fix rather than hardening the guard:
+  redundancyGroupStatements, a map[string]func(*RedundancyGroup, *Node), is now
+  BOTH the compiler's dispatch and the splitter's token set;
+  isRedundancyGroupStatement is derived from it. The six switch arms were
+  extracted VERBATIM into named functions (body-identity verified
+  statement-by-statement against the pre-refactor arms: 22/5/1/1/23/49
+  statements, all identical modulo indentation; no top-level continue/break in
+  any extracted body, so leaving the switch/for changed no control flow).
+  Deleted the source-parsing guard rather than leaving a tautology, and replaced
+  it with TestRedundancyGroupStatementsSurvivePackedLine_6588, which DERIVES its
+  cases from the table: every registered statement is paired with every other on
+  one packed line, in both orders, and a table entry with no sample fails the
+  completeness check. Nothing to update when the table grows.
+- **Honest limit, not claimed closed**: re-ran all three against the table.
+  m3' (named-constant KEY) and m7' (ordinary entry — no switch remains to nest
+  inside) are now HONORED. m4' still DROPS: an ad-hoc `if` in the loop that
+  compiles a statement without registering it. The table makes the idiomatic
+  path correct by construction and converts m4 from invisible to a visible
+  deviation beside a five-line loop; it does not make it impossible, and Go
+  offers no way to. Reported as such rather than claiming three-of-three.
+- **Blast radius**: contained to compileChassis in compiler_system.go. All six
+  arms needed only (rg, child) — no arm touched ch, clusterNode or rgInst — so
+  the extraction is mechanical. No other caller. Full suite exit 0 across 59
+  packages, 116 passing 6588 subtests.
+- **File(s)**: `pkg/config/compiler_system.go`,
+  `pkg/config/compiler_chassis_packed_monitor_6588_test.go`,
+  `docs/config-schema.md`, `_Log.md`
+
 ## 2026-08-01 — #6588 round 5: a regression this PR introduced, plus a second RG node shape
 
 - **Timestamp**: 2026-08-01 (fix/6588-interface-monitor-packed-leaf, PR #6658)

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1239,6 +1239,47 @@ first). The compiler is now uniformly first-wins via `monitorWeightTokens`, and
 a duplicate is rejected outright, so no operator is relying on which form they
 happened to write.
 
+**A gate that walks ENTRY LISTS will miss the statement's own PROPERTIES.** The
+weight gate above was first written around `monitorEntryNodes`, which produces
+entries — interface names, `family inet` addresses. `ip-monitoring`'s
+`global-weight` and `global-threshold` are properties of the statement, not
+entries of a list, so nothing looked at them and
+`ip-monitoring global-weight nope;` committed clean at a compiled 0. That is the
+WORST instance of the class rather than a lesser one: a malformed per-target
+weight costs the group one target's demotion debt, whereas an unusable global
+weight is zero debt for the entire group, so no number of failing probes demotes
+it and failover never happens. `validateMonitorWeightTokensAST` now applies the
+same missing-value / non-integer / duplicate rules to both globals, through one
+shared `checkTokens` rather than a second copy. The globals' reader is
+`ipMonitoringGlobalTokens`, which walks the same `packedStatementProps` result
+the compiler dispatches from — `nodeVal(findNamedNode(props, name))` is
+`ipMonitoringGlobalTokens(props, name)[0]` whenever the property is present, so
+the gate cannot validate a token the compiler does not use. Pinned by
+`TestIPMonitoringGlobalTokensMatchesCompilerRead_6588`.
+
+**A statement that takes NO argument still needs its arity checked.** `preempt`
+and `strict-vip-ownership` compile to a bool and never read the node, so
+anything else written on them is discarded in silence:
+
+```
+redundancy-group 1 preempt weight 255;      # Preempt=true, `weight 255` gone
+redundancy-group 1 preempt delay 5;         # Preempt=true, `delay 5` gone
+redundancy-group 1 preempt { delay 5; }     # Preempt=true, the block gone
+```
+
+Unlike the value-position collision described later, this needs no implausible
+input — a stray token is ordinary typing, and `preempt delay`/`limit`/`period`
+are real Junos SRX options xpf does not implement, so accepting them silently
+tells the operator they configured a preempt delay that does not exist.
+`SchemaValidate` accepts all three (measured), and a bool has nowhere to record
+what was dropped, so `validateRGNoArgStatementsAST`
+(`compiler_chassis_rg_arity.go`) checks it on the AST through the same
+`redundancyGroupBody` splitter. The flag set is written by hand — arity is not
+recoverable from a handler's type, since every handler has the same signature
+whether or not it reads the node — and
+`TestRedundancyGroupNoArgStatementsAreRegistered_6588` keeps it from naming a
+statement the dispatch table does not have.
+
 **The packing recurses: an INSTANCE can carry its whole body on its own Keys
 too.** Everything above is about a statement inside a named instance's body.
 The instance line itself packs the same way:
@@ -1356,6 +1397,24 @@ container/flat-set and single-entry cases as green controls. Its `assertMonitors
 helper requires a weight for every name — there is no name-only variant, because
 having one meant every bracketed-list case in that file ran weight-less and the
 apply-to-all rule above was unguarded.
+
+**Two things that file learned the hard way, both worth keeping.** First, a
+refactor can delete regression coverage for a bug that is still fixed, and
+nothing goes red: the dispatch-table change dropped the bracket-inline-weight
+and bare-`redundancy-group { <id> ... }` suites along with the source-parsing
+drift guard it was deliberately replacing, leaving the apply-to-all rule and the
+`Keys[0]` offset discrimination unguarded while both behaviours still worked.
+When a refactor removes tests, account for each one: replaced, or restored.
+
+Second, a completeness check that only asserts a sample EXISTS proves nothing. A
+table entry keyed `review-placeholder` whose sample text was `preempt`, with a
+`Preempt` assertion, satisfied every check in
+`TestRedundancyGroupStatementsSurvivePackedLine_6588` while `review-placeholder`
+never appeared in the input and its handler was never dispatched. The typed
+assertions cannot catch this, because `preempt` sets `rg.Preempt` no matter
+which key the sample is filed under. The test now requires each sample to begin
+with its own statement keyword AND instruments the dispatch table so a case that
+never reaches the handler it is filed under fails.
 
 **`multi: true` ALSO prevents single-value REPLACE for repeated keyed-list
 leaves (#3984).** The `#2419` discussion above is about ONE statement with a

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1196,6 +1196,23 @@ after it starts a new entry. The value-slot reservation is the same rule the
 #6524 application walk needs, and for the same reason: `weight` consumes exactly
 one following token even when that token spells something else.
 
+**An inline attribute on a bracketed list is CANDIDATE-scoped, not positional.**
+`interface-monitor [ ge-0/0/0 ge-0/0/1 ] weight 255` applies 255 to BOTH names.
+Attaching the weight to the entry that precedes it — the obvious reading — left
+`ge-0/0/0` at weight ZERO: monitored, present in `show`, and deducting nothing
+when its link fails, so the group did not demote. With N names, N-1 monitors
+were inert. That is worse than reading only the first name (which at least
+protected `ge-0/0/0` at 255), and it contradicted the children-block spelling
+`[ a b ] { weight 255; }`, which already applied the weight to both. Apply-to-all
+makes the two spellings agree and is the fail-safe direction. Two inline weights
+in one bracketed statement are ambiguous about which member each belongs to and
+are REJECTED, consistent with the duplicate-weight gate.
+
+Assert compiled WEIGHTS, not just names, when testing this. A name-only
+assertion is blind to precisely the failure that matters: a monitor that exists
+with weight 0 is indistinguishable at runtime from no monitor at all, and the
+regression above shipped past a full bracket-list suite for exactly that reason.
+
 Note the two rules pull in opposite directions and both are needed:
 
 | | tail vs children | why |
@@ -1243,7 +1260,14 @@ elects on defaults, so the WRONG NODE can hold the group — strictly worse than
 
 `redundancyGroupBody` (`compiler_system.go`) undoes it for the chassis-cluster
 surface, splitting the tail at redundancy-group statement keywords so a
-multi-statement line yields one node each. All FOUR readers of that body use it
+multi-statement line yields one node each. It must also pick the right offset
+for the shape it is handed: `namedInstances` returns EITHER the
+`redundancy-group <id>` node itself (`Keys[0]` is the keyword, body starts at
+`Keys[2]`) OR, for a bare `redundancy-group { ... }` wrapper, a child whose
+`Keys[0]` IS the id (body starts at `Keys[1]`). `Keys[0]` discriminates them
+exactly. A fixed offset of 2 swallowed the statement keyword on the second
+shape and opened a node named after a value, matching no switch arm — the same
+silent-nothing outcome, election priority included. All FOUR readers of that body use it
 — `compileChassis` plus the three AST gates (`validateMonitorWeightTokensAST`,
 `validateChassisClusterIdentitiesAST`, `validateGratuitousARPCountAST`) — because
 teaching the compiler to see a shape the gates cannot admits, through the packed

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1260,7 +1260,28 @@ elects on defaults, so the WRONG NODE can hold the group — strictly worse than
 
 `redundancyGroupBody` (`compiler_system.go`) undoes it for the chassis-cluster
 surface, splitting the tail at redundancy-group statement keywords so a
-multi-statement line yields one node each. It must also pick the right offset
+multi-statement line yields one node each. Those keywords come from
+`redundancyGroupStatements`, a `map[string]func(*RedundancyGroup, *Node)` that
+is BOTH the compiler's dispatch table and the splitter's token set — adding a
+statement means adding one entry, and a statement not in the table is not
+compiled either, so the two cannot disagree.
+
+That is deliberately not a checked hand-written list. It was one: a test parsed
+`compileChassis`'s source and extracted the `case "..."` literals of its switch.
+The guard PASSED while a 7th statement was still dropped from a packed
+multi-statement line in three ways — a `case` on a named CONSTANT rather than a
+string literal (the idiom this same file uses for `monitorWeightKeyword`), a
+statement handled by a helper called outside the switch, and a nested `switch`
+inside a `default:` arm. Worse, the failure is camouflaged: the same statement
+ALONE on a line still works, because the splitter opens the first node
+regardless of the predicate. A developer adds the statement, checks the packed
+spelling, sees green, and ships the fold bug. **Modelling another program's
+source text is the wrong tool for keeping two things in step; derive both from
+one table instead.** Registering a statement the ordinary way is now correct by
+construction; compiling one WITHOUT registering it is still possible, but it
+means adding ad-hoc dispatch beside a five-line loop whose only other content is
+the table lookup — a visible deviation rather than the idiomatic path it used to
+be. It must also pick the right offset
 for the shape it is handed: `namedInstances` returns EITHER the
 `redundancy-group <id>` node itself (`Keys[0]` is the keyword, body starts at
 `Keys[2]`) OR, for a bare `redundancy-group { ... }` wrapper, a child whose

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1222,9 +1222,58 @@ first). The compiler is now uniformly first-wins via `monitorWeightTokens`, and
 a duplicate is rejected outright, so no operator is relying on which form they
 happened to write.
 
+**The packing recurses: an INSTANCE can carry its whole body on its own Keys
+too.** Everything above is about a statement inside a named instance's body.
+The instance line itself packs the same way:
+
+```
+redundancy-group 1 { interface-monitor ge-0/0/0 weight 255; }   # container
+redundancy-group 1 interface-monitor ge-0/0/0 weight 255;       # PACKED instance
+redundancy-group 1 node 0 priority 200 preempt;                 # PACKED, several statements
+```
+
+`namedInstances` (`compiler_protocols.go`) resolves the instance NAME across
+both shapes — it reads `Keys[1]` — but hands the node back with the body still
+on `Keys`, so a caller that then walks `.Children` sees an **empty instance**.
+Every statement compiled to nothing while `commit` succeeded. For a
+redundancy group that includes `node <id> priority <p>`, the election priority
+itself: the operator sets it, `show configuration` echoes it, and the cluster
+elects on defaults, so the WRONG NODE can hold the group — strictly worse than
+"the group never demotes".
+
+`redundancyGroupBody` (`compiler_system.go`) undoes it for the chassis-cluster
+surface, splitting the tail at redundancy-group statement keywords so a
+multi-statement line yields one node each. All FOUR readers of that body use it
+— `compileChassis` plus the three AST gates (`validateMonitorWeightTokensAST`,
+`validateChassisClusterIdentitiesAST`, `validateGratuitousARPCountAST`) — because
+teaching the compiler to see a shape the gates cannot admits, through the packed
+instance line only, exactly what those gates exist to reject.
+
+**Why this is NOT fixed inside `namedInstances`.** Making the helper synthesize
+the packed tail as a child would fix every caller at once, and it is tempting
+for that reason. It also breaks callers that already handle the tail
+themselves. `namedInstances` has ~130 call sites and 24 of them read
+`inst.node.Keys` directly; synthesizing a child double-feeds those readers, and
+`compileStaticRoutes` additionally branches on `len(node.Children) == 0` to
+detect the packed shape, so a synthetic child silently disables its packed
+path. Measured, not assumed — the experiment turns
+`TestDHCPRelayOverrides_*` red (the override tokens get swallowed into
+`Interfaces`) and `TestVRRPTrackInterface_KeysPackedDuplicateStrictReject` red
+(lenient first-wins yields an empty `TrackInterface`). A future central fix
+needs the 24 inline readers migrated first; that is its own change.
+
+**Other `namedInstances` callers are NOT all safe, and that is tracked
+separately.** Measured by direct compile: `system login class ops permissions
+view;` compiles a class with EMPTY permissions, `system login user bob class
+ops;` compiles a user with no class, and `system syslog host 10.0.0.9 any;`
+compiles a host with zero facilities. Same root cause, different stanzas, no
+security-boundary equivalence to the RG election — they are follow-up work, not
+a claim of safety.
+
 Covered by `pkg/config/compiler_chassis_packed_monitor_6588_test.go`, which
 pins all three interface-monitor spellings against each other, covers the
-bracketed / malformed / duplicate cases in each, and keeps the
+bracketed / malformed / duplicate cases in each, adds the packed-instance
+spelling for every redundancy-group statement, and keeps the
 container/flat-set and single-entry cases as green controls.
 
 **`multi: true` ALSO prevents single-value REPLACE for repeated keyed-list

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1285,18 +1285,47 @@ to nest another inside. The third is demoted, not eliminated: compiling a
 statement WITHOUT registering it still folds it, but that now means ad-hoc
 dispatch beside a five-line loop whose only other content is the table lookup —
 obvious in review, where adding a `case` to an existing switch was the
-idiomatic act and diverged silently. It must also pick the right offset
-for the shape it is handed: `namedInstances` returns EITHER the
-`redundancy-group <id>` node itself (`Keys[0]` is the keyword, body starts at
-`Keys[2]`) OR, for a bare `redundancy-group { ... }` wrapper, a child whose
-`Keys[0]` IS the id (body starts at `Keys[1]`). `Keys[0]` discriminates them
-exactly. A fixed offset of 2 swallowed the statement keyword on the second
-shape and opened a node named after a value, matching no switch arm — the same
-silent-nothing outcome, election priority included. All FOUR readers of that body use it
-— `compileChassis` plus the three AST gates (`validateMonitorWeightTokensAST`,
-`validateChassisClusterIdentitiesAST`, `validateGratuitousARPCountAST`) — because
-teaching the compiler to see a shape the gates cannot admits, through the packed
-instance line only, exactly what those gates exist to reject.
+idiomatic act and diverged silently.
+
+**Those three routes are all the table UNDER-covering the compiler; there is a
+fourth of the opposite shape.** The splitter matches a registered keyword
+wherever the token appears in the tail, including where the token is a VALUE
+rather than a statement keyword, so a value spelled like a statement is stolen
+and compiled as that statement. Measured:
+
+```
+redundancy-group 1 interface-monitor preempt weight 255;        # InterfaceMonitors=[]              Preempt=true
+redundancy-group 1 { interface-monitor preempt weight 255; }    # InterfaceMonitors=[{preempt 255}] Preempt=false
+```
+
+The two spellings disagree — exactly what splitting the packed line exists to
+prevent. It is not fixed, because the stolen token must sit in entry-NAME
+position and no legal Junos interface name or IP address collides with a
+registered keyword (`ge-*`/`xe-*`/`et-*`, `reth*`, `fxp*`, `em*`, `lo0`, `st0`,
+`ae*`, `fab*`, `irb`, `vlan`), so it is unreachable from a real config rather
+than merely unlikely. There is deliberately no test pinning the divergence —
+that would assert the wrong answer is correct — and none asserting "keyword is
+not an interface name" either, because the project has no canonical
+interface-name predicate and inventing one in a test repeats the
+source-modelling mistake described above. What is guarded is the EDIT that would
+make the route reachable: registering a statement trips the completeness check
+in `TestRedundancyGroupStatementsSurvivePackedLine_6588`, which is where the
+collision question has to be asked. A real fix means splitting position-aware —
+a keyword opens a statement only where a statement may begin — which changes the
+splitter contract.
+
+The splitter must also pick the right offset for the shape it is handed:
+`namedInstances` returns EITHER the `redundancy-group <id>` node itself
+(`Keys[0]` is the keyword, body starts at `Keys[2]`) OR, for a bare
+`redundancy-group { ... }` wrapper, a child whose `Keys[0]` IS the id (body
+starts at `Keys[1]`). `Keys[0]` discriminates them exactly. A fixed offset of 2
+swallowed the statement keyword on the second shape and opened a node named
+after a value, matching no switch arm — the same silent-nothing outcome,
+election priority included. All FOUR readers of that body use it —
+`compileChassis` plus the three AST gates (`validateMonitorWeightTokensAST`,
+`validateChassisClusterIdentitiesAST`, `validateGratuitousARPCountAST`) —
+because teaching the compiler to see a shape the gates cannot admits, through
+the packed instance line only, exactly what those gates exist to reject.
 
 **Why this is NOT fixed inside `namedInstances`.** Making the helper synthesize
 the packed tail as a child would fix every caller at once, and it is tempting
@@ -1323,7 +1352,10 @@ Covered by `pkg/config/compiler_chassis_packed_monitor_6588_test.go`, which
 pins all three interface-monitor spellings against each other, covers the
 bracketed / malformed / duplicate cases in each, adds the packed-instance
 spelling for every redundancy-group statement, and keeps the
-container/flat-set and single-entry cases as green controls.
+container/flat-set and single-entry cases as green controls. Its `assertMonitors`
+helper requires a weight for every name — there is no name-only variant, because
+having one meant every bracketed-list case in that file ran weight-less and the
+apply-to-all rule above was unguarded.
 
 **`multi: true` ALSO prevents single-value REPLACE for repeated keyed-list
 leaves (#3984).** The `#2419` discussion above is about ONE statement with a

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1279,10 +1279,13 @@ regardless of the predicate. A developer adds the statement, checks the packed
 spelling, sees green, and ships the fold bug. **Modelling another program's
 source text is the wrong tool for keeping two things in step; derive both from
 one table instead.** Registering a statement the ordinary way is now correct by
-construction; compiling one WITHOUT registering it is still possible, but it
-means adding ad-hoc dispatch beside a five-line loop whose only other content is
-the table lookup — a visible deviation rather than the idiomatic path it used to
-be. It must also pick the right offset
+construction, which closes two of the three routes above outright — a
+named-constant KEY registers exactly like a literal one, and no switch remains
+to nest another inside. The third is demoted, not eliminated: compiling a
+statement WITHOUT registering it still folds it, but that now means ad-hoc
+dispatch beside a five-line loop whose only other content is the table lookup —
+obvious in review, where adding a `case` to an existing switch was the
+idiomatic act and diverged silently. It must also pick the right offset
 for the shape it is handed: `namedInstances` returns EITHER the
 `redundancy-group <id>` node itself (`Keys[0]` is the keyword, body starts at
 `Keys[2]`) OR, for a bare `redundancy-group { ... }` wrapper, a child whose

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1123,6 +1123,64 @@ the same divergence class #3606 calls out for ports. Covered by
 `pkg/config/compiler_application_chained_leaves_6524_test.go` and the
 policy-OUTCOME suite `pkg/policymatch/app_chained_leaves_6524_test.go`.
 
+**A PACKED hierarchical statement carries its entries on its OWN Keys — the
+fourth collapse pattern, and the only one the flat-set path never produces
+(#6588).** The three patterns above are all `SetPath` artifacts. This one comes
+from the *hierarchical* parser and therefore reaches the compiler only through a
+hand-authored config file, `load merge` / `load override`, or a peer config
+sync — never through a `set` command. A statement that groups entries can be
+written three ways, and they do NOT produce the same AST:
+
+```
+interface-monitor { ge-0/0/0 weight 255; }   # CONTAINER: Keys=[interface-monitor], one child per entry
+interface-monitor ge-0/0/0 weight 255;       # PACKED:    Keys=[interface-monitor ge-0/0/0 weight 255], NO children
+interface-monitor ge-0/0/0 { weight 255; }   # PACKED + body: Keys=[interface-monitor ge-0/0/0], children are that ENTRY's attributes
+set ... interface-monitor ge-0/0/0 weight 255   # flat-set: SetPath yields the CONTAINER shape
+```
+
+A compiler that enumerates entries by iterating the statement's `Children`
+alone sees NOTHING in the packed shape. That was the #6588 fail-open: a packed
+`chassis cluster redundancy-group <n> interface-monitor <if> weight <w>`
+compiled to ZERO interface monitors and a packed `ip-monitoring` to zero
+targets, while `commit` succeeded with no error and no warning — the operator
+had link and probe tracking configured and a redundancy group that never
+demoted on failure. The third spelling was worse than a drop: the entry name
+packs onto the statement while the attributes arrive as children, so reading
+`Children` minted a monitor for an interface literally named `weight`.
+
+`packedOrContainerEntries(cfgNode, skip)` (`compiler_system.go`) is the
+canonical reader — `skip` is how many leading Keys name the statement itself.
+Note its rule is **EITHER/OR, not accumulate**, which is the opposite of the
+`#2419` multi-value contract above and the distinction to get right: a
+multi-value leaf spreads values across Keys AND children of the same kind, so
+`firewallMatchValues` must sum both; a grouping statement with an inline tail IS
+one entry, so its children are that entry's properties, not sibling entries.
+Accumulating there mints the bogus `weight` monitor. `namedInstances`
+(`compiler_protocols.go`) already applies the same either/or rule to named
+instances. Only the outermost level is unpacked — one tail is one entry, which
+is what Junos renders (one statement per line).
+
+Consequences worth knowing when adding a reader:
+
+- **The schema walker does not see this shape at all.** `SchemaValidate` walks
+  the AST from `setSchema`, and a packed tail sits below the depth it reaches,
+  so a typed leaf's `validator` never fires on it. A range/arity gate that must
+  cover the packed spelling has to run on the COMPILED struct
+  (`validateChassisClusterStrict`), not on the schema — which is only true once
+  the packed shape actually compiles.
+- **Silently compiling to nothing is the worst of the three options.** A
+  statement whose packed spelling is genuinely unsupported must be REJECTED at
+  commit with an actionable error. `services ip-monitoring` (a different
+  stanza, `compiler_services.go`) is the fail-CLOSED example: its packed
+  `then preferred-route ...;` is likewise dropped, but a policy with zero
+  compiled routes is a hard commit error ("at least one then preferred-route
+  route is required"), so the operator is told rather than left with a silent
+  no-op.
+
+Covered by `pkg/config/compiler_chassis_packed_monitor_6588_test.go`, which
+pins all three interface-monitor spellings against each other and keeps the
+container/flat-set cases as green controls.
+
 **`multi: true` ALSO prevents single-value REPLACE for repeated keyed-list
 leaves (#3984).** The `#2419` discussion above is about ONE statement with a
 bracket list. The SAME `multi: true` marker fixes a second, distinct shape:
@@ -3578,11 +3636,16 @@ reserved for whole-dataplane selection where a rewrite shim
   same way #4434/#4880 gate the RG id and node priority: on the COMPILED
   `*Config` in `validateChassisClusterStrict`, `0..255`, strict-reject at
   commit / warn on the tolerant load / peer-sync path. Running on the
-  compiled int covers the flat-set and container-hierarchical shapes with
-  one gate (the PACKED one-liner `interface-monitor <if> weight <n>;`
-  written directly under `redundancy-group` is a separate matter — it
-  compiles to ZERO monitors, so the gate never sees it and no debt is
-  installed either; tracked as **#6588**). It is a wire-width gate like
+  compiled int covers ALL THREE spellings with one gate — flat-set,
+  container-hierarchical, and (since **#6588**) the PACKED one-liner
+  `interface-monitor <if> weight <n>;` written directly under
+  `redundancy-group`. The packed spelling used to compile to ZERO monitors,
+  so the gate never saw it and no debt was installed either; now that it
+  compiles like the other two, the gate covers it for free. Note the
+  coverage claim holds BECAUSE the gate reads the compiled int: a typed
+  schema leaf would still miss the packed shape, which sits below the depth
+  `SchemaValidate` reaches (see "A PACKED hierarchical statement carries its
+  entries on its OWN Keys"). It is a wire-width gate like
   its siblings: the weight is the debt subtracted from the RG weight,
   which the heartbeat advertises through a single byte
   (`HeartbeatGroup.Weight`, `uint8(rg.Weight)`) while the local election

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1177,9 +1177,55 @@ Consequences worth knowing when adding a reader:
   route is required"), so the operator is told rather than left with a silent
   no-op.
 
+**The two collapses COMPOSE, and a monitor statement hits both.** The packed
+collapse above is orthogonal to the `#2419` bracket collapse at the top of this
+section, and `interface-monitor` is subject to each independently:
+
+```
+interface-monitor [ ge-0/0/0 ge-0/0/1 ];    # PACKED *and* bracketed
+```
+
+The lexer strips the brackets, so N interface names land on ONE node's Keys — in
+the packed statement, in a hierarchical container child, and in the flat-set
+child alike. Unpacking the statement but then treating its whole tail as a
+single entry compiles the FIRST name and silently discards the rest: the same
+failover fail-open as dropping the statement, one monitor at a time. So
+`monitorEntryNodes` splits each candidate's Keys at entry boundaries — a token
+that is neither the `weight` keyword nor the value slot reserved immediately
+after it starts a new entry. The value-slot reservation is the same rule the
+#6524 application walk needs, and for the same reason: `weight` consumes exactly
+one following token even when that token spells something else.
+
+Note the two rules pull in opposite directions and both are needed:
+
+| | tail vs children | why |
+|---|---|---|
+| **entry list** (`interface-monitor`, ip-monitoring `inet` addresses) | EITHER/OR | a tail means the statement IS one entry, so children are that entry's ATTRIBUTES — accumulating mints a monitor for an interface literally named `weight` |
+| **property body** (`ip-monitoring` itself) | BOTH | properties are siblings at the same level, so a packed tail and a real block body lose nothing when combined; the tail is split only at recognized property keywords (`packedStatementProps`) so `global-weight 255` is not shredded into two |
+
+**A value that is present but UNUSABLE needs an AST gate — the compiled struct
+cannot express it.** `compileChassis` parses a monitor weight with
+`strconv.Atoi` and leaves the 0 default on failure, so by the time the
+compiled-int range gate runs, `weight nope`, `weight 0`, and no weight at all
+are indistinguishable. `interface-monitor ge-0/0/0 weight nope;` therefore
+committed clean and installed a monitor that deducts NOTHING on link-down —
+the same silent-nothing class as the dropped statement. It is rejected by
+`validateMonitorWeightTokensAST` (`compiler_chassis_monitor_weight.go`), which
+derives its entries from `monitorEntryNodes` / `monitorWeightTokens` so the gate
+and the compiler can never disagree about which token is a weight or which entry
+owns it. Strict at commit, warn on the tolerant load / peer-sync path (#1960).
+
+That gate also settles a spelling-dependent answer: a DUPLICATE weight used to
+compile to 200 inline (`weight 100 weight 200` — the inline scan overwrote) but
+to 100 in a block (`{ weight 100; weight 200; }` — `FindChild` returns the
+first). The compiler is now uniformly first-wins via `monitorWeightTokens`, and
+a duplicate is rejected outright, so no operator is relying on which form they
+happened to write.
+
 Covered by `pkg/config/compiler_chassis_packed_monitor_6588_test.go`, which
-pins all three interface-monitor spellings against each other and keeps the
-container/flat-set cases as green controls.
+pins all three interface-monitor spellings against each other, covers the
+bracketed / malformed / duplicate cases in each, and keeps the
+container/flat-set and single-entry cases as green controls.
 
 **`multi: true` ALSO prevents single-value REPLACE for repeated keyed-list
 leaves (#3984).** The `#2419` discussion above is about ONE statement with a
@@ -3645,7 +3691,12 @@ reserved for whole-dataplane selection where a rewrite shim
   coverage claim holds BECAUSE the gate reads the compiled int: a typed
   schema leaf would still miss the packed shape, which sits below the depth
   `SchemaValidate` reaches (see "A PACKED hierarchical statement carries its
-  entries on its OWN Keys"). It is a wire-width gate like
+  entries on its OWN Keys"). #6588 extended the SAME compiled-int gate to the
+  ip-monitoring `global-weight` / `global-threshold` / per-target `weight`,
+  which #6549 had left to their typed schema leaves: those leaves are real, but
+  the schema walker cannot reach the packed spelling for them either, so once
+  the packed shape compiled they needed the compiled-int layer too. It is a
+  wire-width gate like
   its siblings: the weight is the debt subtracted from the RG weight,
   which the heartbeat advertises through a single byte
   (`HeartbeatGroup.Weight`, `uint8(rg.Weight)`) while the local election

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1263,8 +1263,9 @@ surface, splitting the tail at redundancy-group statement keywords so a
 multi-statement line yields one node each. Those keywords come from
 `redundancyGroupStatements`, a `map[string]func(*RedundancyGroup, *Node)` that
 is BOTH the compiler's dispatch table and the splitter's token set — adding a
-statement means adding one entry, and a statement not in the table is not
-compiled either, so the two cannot disagree.
+statement means adding one entry, which registers it with the splitter in the
+same edit. The invariant is "all dispatch goes through the table", and it is
+made natural rather than enforced: see the qualification below.
 
 That is deliberately not a checked hand-written list. It was one: a test parsed
 `compileChassis`'s source and extracted the `case "..."` literals of its switch.

--- a/pkg/config/compiler_chassis_garp_count.go
+++ b/pkg/config/compiler_chassis_garp_count.go
@@ -37,7 +37,8 @@ func validateGratuitousARPCountAST(nodes []*Node) []string {
 	_ = forEachChild(nodes, "chassis", func(chassis *Node) error {
 		return forEachChild(chassis.Children, "cluster", func(cluster *Node) error {
 			for _, rgInst := range namedInstances(cluster.FindChildren("redundancy-group")) {
-				gc := rgInst.node.FindChild("gratuitous-arp-count")
+				// #6588: the body may be packed onto the RG instance's own Keys.
+				gc := findNamedNode(redundancyGroupBody(rgInst.node), "gratuitous-arp-count")
 				if gc == nil {
 					continue
 				}

--- a/pkg/config/compiler_chassis_identity.go
+++ b/pkg/config/compiler_chassis_identity.go
@@ -84,7 +84,8 @@ func validateChassisClusterIdentitiesAST(nodes []*Node, lenient bool) ([]string,
 				// The RG-scoped `node <id>` identity (nested `node { ... }` or
 				// the packed one-liner `node 0 priority <v>`; compileChassis
 				// reads both via nodeVal(child) on a `node` CHILD).
-				for _, child := range rgInst.node.Children {
+				// #6588: the body may be packed onto the RG instance's own Keys.
+				for _, child := range redundancyGroupBody(rgInst.node) {
 					if child.Name() != "node" {
 						continue
 					}

--- a/pkg/config/compiler_chassis_monitor_weight.go
+++ b/pkg/config/compiler_chassis_monitor_weight.go
@@ -1,0 +1,169 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// compiler_chassis_monitor_weight.go carries the #6588 commit-side gate for a
+// redundancy-group monitor weight that is present but UNUSABLE — malformed, or
+// specified twice with different values.
+//
+// Why an AST pre-walk rather than a typed schema leaf or a compiled-struct
+// check:
+//
+//   - The typed-leaf route is closed. `interface-monitor` packs
+//     `<ifname> weight <n>` onto ONE node key, so schema_chassis.go declares it
+//     `children: nil` (typing the weight would need a children/wildcard map,
+//     which flips SetPath's replace-vs-container grouping). SchemaValidate
+//     therefore never reaches the weight token at all — and for the PACKED
+//     spelling it does not reach the ip-monitoring weights either, which sit
+//     below the depth its walk descends.
+//
+//   - The compiled struct cannot tell these cases apart. compileChassis parses
+//     the weight with strconv.Atoi and, on failure, leaves the pre-existing 0
+//     default. `weight nope` and `weight 0` and no weight at all are all
+//     Weight==0 by the time validateChassisClusterStrict sees them, so the
+//     #6549 range gate — which is otherwise the right layer, and which #6588
+//     extended to ip-monitoring — structurally cannot flag a parse failure.
+//
+// Both problems are the same class as the packed-statement drop this file's
+// issue is about: the operator configures a monitor, `commit` succeeds with no
+// error and no warning, and the redundancy group carries LESS demotion debt
+// than was written — `interface-monitor ge-0/0/0 weight nope;` installs a
+// monitor whose weight is 0, so the link going down demotes the group by
+// nothing and failover does not happen.
+//
+// Duplicates were additionally SHAPE-DEPENDENT before this gate:
+// `weight 100 weight 200` inline compiled to 200 (the inline scan overwrote)
+// while `{ weight 100; weight 200; }` compiled to 100 (FindChild returns the
+// first). The compiler is now uniformly first-wins via monitorWeightTokens, and
+// this gate rejects the duplicate outright so the operator is never relying on
+// which spelling they happened to use.
+//
+// Strictness follows the sibling chassis gates: hard-reject at commit /
+// commit-check, downgrade to a cfg.Warnings entry on the tolerant load /
+// peer-sync paths (#1960 no-brick) — an already-persisted or peer-pushed config
+// an older binary accepted must still BOOT. The compiled 0 default is what the
+// tolerant path keeps, now flagged rather than silent.
+
+// validateMonitorWeightTokensAST walks the chassis cluster subtree and reports
+// every redundancy-group monitor weight that is present but unusable. It runs
+// on the group-expanded tree so an apply-groups-inherited weight is covered.
+//
+// It derives its entries from monitorEntryNodes / monitorWeightTokens — the
+// same readers compileChassis uses — so the gate and the compiler cannot drift
+// apart about which token is a weight, which entry it belongs to, or how a
+// bracketed list splits.
+//
+// Returns (warnings, nil) when lenient, (nil, error) on the first offender when
+// strict.
+func validateMonitorWeightTokensAST(nodes []*Node, lenient bool) ([]string, error) {
+	var warnings []string
+
+	emit := func(format string, args ...interface{}) error {
+		msg := fmt.Sprintf(format, args...)
+		if lenient {
+			warnings = append(warnings, msg)
+			return nil
+		}
+		return fmt.Errorf("%s", msg)
+	}
+
+	// checkEntries validates every entry of one monitor statement. what names
+	// the statement for the operator (e.g. `interface-monitor`), and label
+	// renders the entry's identity within the redundancy group.
+	checkEntries := func(rgName, what string, entries []*Node) error {
+		for _, entry := range entries {
+			toks := monitorWeightTokens(entry)
+			if len(toks) == 0 {
+				continue // No weight at all: the documented 0 default (#6549).
+			}
+			if len(toks) > 1 {
+				distinct := false
+				for _, t := range toks[1:] {
+					if t != toks[0] {
+						distinct = true
+						break
+					}
+				}
+				if distinct {
+					if err := emit("chassis cluster redundancy-group %s %s %s: weight "+
+						"specified %d times with different values %q — the compiled weight "+
+						"would depend on the spelling; specify exactly one weight",
+						rgName, what, entry.Name(), len(toks), toks); err != nil {
+						return err
+					}
+					continue
+				}
+				if err := emit("chassis cluster redundancy-group %s %s %s: weight "+
+					"specified %d times; specify exactly one weight",
+					rgName, what, entry.Name(), len(toks)); err != nil {
+					return err
+				}
+				continue
+			}
+			if _, err := strconv.Atoi(toks[0]); err != nil {
+				if err := emit("chassis cluster redundancy-group %s %s %s: weight %q is not "+
+					"an integer — it compiles to the 0 default, so the monitor going down "+
+					"deducts NO weight and the redundancy group never demotes; set a weight "+
+					"in %d..%d",
+					rgName, what, entry.Name(), toks[0],
+					MinInterfaceMonitorWeight, MaxInterfaceMonitorWeight); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+
+	walkErr := forEachChild(nodes, "chassis", func(chassis *Node) error {
+		return forEachChild(chassis.Children, "cluster", func(cluster *Node) error {
+			for _, rgInst := range namedInstances(cluster.FindChildren("redundancy-group")) {
+				for _, child := range rgInst.node.Children {
+					switch child.Name() {
+					case "interface-monitor":
+						if err := checkEntries(rgInst.name, "interface-monitor",
+							monitorEntryNodes(child, 1)); err != nil {
+							return err
+						}
+					case "ip-monitoring":
+						for _, familyNode := range packedStatementProps(child, 1, isIPMonitoringProp) {
+							if familyNode.Name() != "family" {
+								continue
+							}
+							inetNode, inetSkip := ipMonitoringInetNode(familyNode)
+							if inetNode == nil {
+								continue
+							}
+							if err := checkEntries(rgInst.name, "ip-monitoring family inet",
+								monitorEntryNodes(inetNode, inetSkip)); err != nil {
+								return err
+							}
+						}
+					}
+				}
+			}
+			return nil
+		})
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return warnings, nil
+}
+
+// ipMonitoringInetNode resolves the node holding the monitored IPv4 addresses
+// of an ip-monitoring `family` property, and how many of its leading Keys name
+// the node itself rather than an address. The compound spelling
+// (`family inet ...`, Keys[1]=="inet") and the nested one
+// (`family { inet { ... } }`) differ by exactly one identity token, and getting
+// that offset wrong silently shifts which token is read as an address — so both
+// compileChassis and validateMonitorWeightTokensAST resolve it here rather than
+// each open-coding the branch.
+func ipMonitoringInetNode(familyNode *Node) (*Node, int) {
+	if len(familyNode.Keys) >= 2 && familyNode.Keys[1] == "inet" {
+		return familyNode, 2
+	}
+	return familyNode.FindChild("inet"), 1
+}

--- a/pkg/config/compiler_chassis_monitor_weight.go
+++ b/pkg/config/compiler_chassis_monitor_weight.go
@@ -120,7 +120,7 @@ func validateMonitorWeightTokensAST(nodes []*Node, lenient bool) ([]string, erro
 	walkErr := forEachChild(nodes, "chassis", func(chassis *Node) error {
 		return forEachChild(chassis.Children, "cluster", func(cluster *Node) error {
 			for _, rgInst := range namedInstances(cluster.FindChildren("redundancy-group")) {
-				for _, child := range rgInst.node.Children {
+				for _, child := range redundancyGroupBody(rgInst.node) {
 					switch child.Name() {
 					case "interface-monitor":
 						if err := checkEntries(rgInst.name, "interface-monitor",

--- a/pkg/config/compiler_chassis_monitor_weight.go
+++ b/pkg/config/compiler_chassis_monitor_weight.go
@@ -70,48 +70,85 @@ func validateMonitorWeightTokensAST(nodes []*Node, lenient bool) ([]string, erro
 		return fmt.Errorf("%s", msg)
 	}
 
+	// checkTokens applies the missing-value / non-integer / duplicate rules to
+	// the value tokens of ONE weight-like field. Every field this gate covers
+	// shares those rules because every one of them reaches the compiler through
+	// the same Atoi-then-keep-0 coercion, so they are implemented once here
+	// rather than per field.
+	//
+	// where identifies the offending field, already scoped to its redundancy
+	// group (`redundancy-group 1 interface-monitor ge-0/0/0`). subject names
+	// what was specified — `weight` for a monitored entry, `global-weight` /
+	// `global-threshold` for an ip-monitoring global — and consequence spells
+	// out the runtime effect, which differs between a per-entry weight and a
+	// group-wide global.
+	//
+	// An empty token list means the field is absent, which is legal: the
+	// documented 0 default (#6549). A PRESENT keyword with no value yields one
+	// empty-string token from the readers below, so it is reported as malformed
+	// rather than mistaken for absent.
+	checkTokens := func(where, subject, consequence string, toks []string) error {
+		if len(toks) == 0 {
+			return nil
+		}
+		if len(toks) > 1 {
+			distinct := false
+			for _, t := range toks[1:] {
+				if t != toks[0] {
+					distinct = true
+					break
+				}
+			}
+			if distinct {
+				return emit("chassis cluster %s: %s specified %d times with different "+
+					"values %q — the compiled value would depend on the spelling; specify "+
+					"exactly one %s", where, subject, len(toks), toks, subject)
+			}
+			return emit("chassis cluster %s: %s specified %d times; specify exactly one %s",
+				where, subject, len(toks), subject)
+		}
+		if _, err := strconv.Atoi(toks[0]); err != nil {
+			return emit("chassis cluster %s: %s %q is not an integer — it compiles to the 0 "+
+				"default, so %s; set a %s in %d..%d",
+				where, subject, toks[0], consequence, subject,
+				MinInterfaceMonitorWeight, MaxInterfaceMonitorWeight)
+		}
+		return nil
+	}
+
 	// checkEntries validates every entry of one monitor statement. what names
-	// the statement for the operator (e.g. `interface-monitor`), and label
-	// renders the entry's identity within the redundancy group.
+	// the statement for the operator (e.g. `interface-monitor`).
 	checkEntries := func(rgName, what string, entries []*Node) error {
 		for _, entry := range entries {
-			toks := monitorWeightTokens(entry)
-			if len(toks) == 0 {
-				continue // No weight at all: the documented 0 default (#6549).
+			if err := checkTokens(
+				fmt.Sprintf("redundancy-group %s %s %s", rgName, what, entry.Name()),
+				monitorWeightKeyword,
+				"the monitor going down deducts NO weight and the redundancy group never demotes",
+				monitorWeightTokens(entry)); err != nil {
+				return err
 			}
-			if len(toks) > 1 {
-				distinct := false
-				for _, t := range toks[1:] {
-					if t != toks[0] {
-						distinct = true
-						break
-					}
-				}
-				if distinct {
-					if err := emit("chassis cluster redundancy-group %s %s %s: weight "+
-						"specified %d times with different values %q — the compiled weight "+
-						"would depend on the spelling; specify exactly one weight",
-						rgName, what, entry.Name(), len(toks), toks); err != nil {
-						return err
-					}
-					continue
-				}
-				if err := emit("chassis cluster redundancy-group %s %s %s: weight "+
-					"specified %d times; specify exactly one weight",
-					rgName, what, entry.Name(), len(toks)); err != nil {
-					return err
-				}
-				continue
-			}
-			if _, err := strconv.Atoi(toks[0]); err != nil {
-				if err := emit("chassis cluster redundancy-group %s %s %s: weight %q is not "+
-					"an integer — it compiles to the 0 default, so the monitor going down "+
-					"deducts NO weight and the redundancy group never demotes; set a weight "+
-					"in %d..%d",
-					rgName, what, entry.Name(), toks[0],
-					MinInterfaceMonitorWeight, MaxInterfaceMonitorWeight); err != nil {
-					return err
-				}
+		}
+		return nil
+	}
+
+	// checkIPMonitoringGlobals validates the two group-wide ip-monitoring
+	// values. They were missed when this gate was first written because it
+	// walked only the ENTRY lists (interface-monitor names, family inet
+	// addresses), and the globals are properties of the ip-monitoring statement
+	// rather than entries of a list. The consequence is at least as bad: an
+	// unusable global-weight is zero demotion debt for the WHOLE group, so no
+	// number of failing probes demotes it. A typo'd weight is ordinary operator
+	// input, so this is reachable in a way the value-position collision
+	// documented on redundancyGroupStatements is not.
+	checkIPMonitoringGlobals := func(rgName string, props []*Node) error {
+		for _, subject := range []string{"global-weight", "global-threshold"} {
+			if err := checkTokens(
+				fmt.Sprintf("redundancy-group %s ip-monitoring", rgName),
+				subject,
+				"the redundancy group accrues NO demotion debt when its monitored "+
+					"targets fail and never demotes",
+				ipMonitoringGlobalTokens(props, subject)); err != nil {
+				return err
 			}
 		}
 		return nil
@@ -128,7 +165,15 @@ func validateMonitorWeightTokensAST(nodes []*Node, lenient bool) ([]string, erro
 							return err
 						}
 					case "ip-monitoring":
-						for _, familyNode := range packedStatementProps(child, 1, isIPMonitoringProp) {
+						// One packedStatementProps result feeds both the
+						// globals and the family walk, so the gate sees
+						// exactly the node set compileRGIPMonitoring compiles
+						// from.
+						ipmProps := packedStatementProps(child, 1, isIPMonitoringProp)
+						if err := checkIPMonitoringGlobals(rgInst.name, ipmProps); err != nil {
+							return err
+						}
+						for _, familyNode := range ipmProps {
 							if familyNode.Name() != "family" {
 								continue
 							}

--- a/pkg/config/compiler_chassis_packed_monitor_6588_test.go
+++ b/pkg/config/compiler_chassis_packed_monitor_6588_test.go
@@ -550,6 +550,34 @@ func TestChassisInterfaceMonitorBracketListWeight_6588(t *testing.T) {
 			pair, []int{255, 255})
 	})
 
+	t.Run("FlatSetInlineThreeNames", func(t *testing.T) {
+		cfg, err := CompileConfig(flatMonitorTree(t,
+			"set chassis cluster redundancy-group 1 interface-monitor [ ge-0/0/0 ge-0/0/1 ge-0/0/2 ] weight 100"))
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		assertMonitors(t, onlyRG6588(t, cfg),
+			[]string{"ge-0/0/0", "ge-0/0/1", "ge-0/0/2"}, []int{100, 100, 100})
+	})
+
+	// The range gate must see EVERY member, not just the one the weight was
+	// written next to. Under the positional regression ge-0/0/0 carries weight
+	// 0 and the offending 300 reaches only the last member, so the error names
+	// the wrong interface.
+	t.Run("OutOfRangeRejectedForAllMembers", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedMonitorConfig(
+			"            interface-monitor [ ge-0/0/0 ge-0/0/1 ] weight 300;")),
+			"interface-monitor ge-0/0/0 weight 300 is out of range 0..255")
+	})
+	// Two inline weights inside one bracketed statement are ambiguous about
+	// which member each belongs to. Rejecting matches the duplicate-weight gate
+	// rather than silently picking one.
+	t.Run("AmbiguousPerMemberWeightsRejected", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedMonitorConfig(
+			"            interface-monitor [ ge-0/0/0 weight 100 ge-0/0/1 weight 200 ];")),
+			"weight specified 2 times with different values")
+	})
+
 	// CONTROL: the children-block spelling. The weight is candidate-scoped by
 	// construction here, so this stays green under the positional regression;
 	// it pins that the block and inline spellings agree.
@@ -562,6 +590,92 @@ func TestChassisInterfaceMonitorBracketListWeight_6588(t *testing.T) {
 		assertMonitors(t, compileMonitorText(t, packedMonitorConfig(
 			"            interface-monitor {\n                [ ge-0/0/0 ge-0/0/1 ] {\n                    weight 255;\n                }\n            }")),
 			pair, []int{255, 255})
+	})
+	// CONTROL: a single name with an inline weight is unaffected by how the
+	// attribute is scoped. Green in both worlds.
+	t.Run("ControlSingleNameInlineWeight", func(t *testing.T) {
+		assertMonitors(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor ge-0/0/0 weight 255;")),
+			[]string{"ge-0/0/0"}, []int{255})
+	})
+}
+
+// TestChassisRedundancyGroupBareContainerShape_6588 pins the SECOND node shape
+// namedInstances returns.
+//
+// namedInstances yields either the `redundancy-group <id>` node itself
+// (Keys[0]=="redundancy-group", so the body starts at Keys[2]) or, for a bare
+// `redundancy-group { ... }` wrapper, a CHILD whose Keys[0] IS the instance id
+// (so the body starts at Keys[1]). redundancyGroupBody used a fixed skip of 2,
+// which on the second shape swallowed the statement KEYWORD and opened a node
+// named after a value — matching no dispatch entry, so every statement was
+// dropped, election priority included.
+//
+// Reachability through the shipped parser is lower than the packed-instance
+// shape (no Junos output and no SetPath path emits a bare wrapper), but the
+// discrimination is fixed rather than documented: all four redundancyGroupBody
+// readers depend on it, so leaving it would make the AST gates blind here while
+// LOOKING like they covered it.
+//
+// This suite was deleted by the b3158d315 dispatch-table refactor along with
+// the bracket-inline-weight coverage above, and is restored rather than
+// rewritten — the `Keys[0]` discrimination it guards is untouched by that
+// refactor and was left unguarded by its removal.
+//
+// FAIL-ON-REVERT: pin skip back to 2 in redundancyGroupBody and every subtest
+// below fails naming the lost statement.
+func TestChassisRedundancyGroupBareContainerShape_6588(t *testing.T) {
+	t.Run("PackedInterfaceMonitor", func(t *testing.T) {
+		assertMonitors(t, compileRGText(t, packedRGConfig(
+			"        redundancy-group {\n            1 interface-monitor ge-0/0/0 weight 255;\n        }")),
+			[]string{"ge-0/0/0"}, []int{255})
+	})
+	t.Run("PackedNodePriority", func(t *testing.T) {
+		rg := compileRGText(t, packedRGConfig(
+			"        redundancy-group {\n            1 node 0 priority 200;\n        }"))
+		if got, ok := rg.NodePriorities[0]; !ok || got != 200 {
+			t.Fatalf("bare `redundancy-group { 1 node 0 priority 200; }` lost the election "+
+				"priority: NodePriorities = %v", rg.NodePriorities)
+		}
+	})
+	t.Run("PackedPreempt", func(t *testing.T) {
+		rg := compileRGText(t, packedRGConfig(
+			"        redundancy-group {\n            1 preempt;\n        }"))
+		if !rg.Preempt {
+			t.Fatal("bare `redundancy-group { 1 preempt; }` lost `preempt`")
+		}
+	})
+	t.Run("GatesStillReachIt", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedRGConfig(
+			"        redundancy-group {\n            1 interface-monitor ge-0/0/0 weight nope;\n        }")),
+			`weight "nope" is not an integer`)
+	})
+	// The gates added after the refactor must reach this shape too, or the
+	// bare wrapper becomes the one spelling that admits what they reject.
+	t.Run("IPMonitoringGlobalGateStillReachesIt", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedRGConfig(
+			"        redundancy-group {\n            1 ip-monitoring global-weight nope;\n        }")),
+			`global-weight "nope" is not an integer`)
+	})
+	t.Run("NoArgArityGateStillReachesIt", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedRGConfig(
+			"        redundancy-group {\n            1 preempt delay 5;\n        }")),
+			"preempt: takes no argument")
+	})
+	// NEGATIVE CONTROL: the nested-block form under a bare wrapper already
+	// worked (its body arrives as real children) and must be unchanged. Green
+	// with and without the fix.
+	t.Run("ControlBareWrapperNestedBlock", func(t *testing.T) {
+		assertMonitors(t, compileRGText(t, packedRGConfig(
+			"        redundancy-group {\n            1 {\n                interface-monitor ge-0/0/0 weight 255;\n            }\n        }")),
+			[]string{"ge-0/0/0"}, []int{255})
+	})
+	// NEGATIVE CONTROL: the ordinary `redundancy-group <id>` shape still uses
+	// skip 2. Green in both worlds.
+	t.Run("ControlOrdinaryInstanceShape", func(t *testing.T) {
+		assertMonitors(t, compileRGText(t, packedRGConfig(
+			"        redundancy-group 1 interface-monitor ge-0/0/0 weight 255;")),
+			[]string{"ge-0/0/0"}, []int{255})
 	})
 }
 
@@ -748,6 +862,301 @@ func TestChassisMonitorWeightDuplicateRejected_6588(t *testing.T) {
 			t.Fatalf("error %q claims differing values for an identical repeat", err)
 		}
 	})
+}
+
+// ip-monitoring GLOBALS ------------------------------------------------------
+
+// TestChassisIPMonitoringGlobalWeightUnusableRejected_6588 pins the gate on the
+// two GROUP-WIDE ip-monitoring values.
+//
+// The original #6588 weight gate walked only the ENTRY lists —
+// interface-monitor names and `family inet` addresses — because those are what
+// monitorEntryNodes produces. global-weight and global-threshold are properties
+// of the ip-monitoring statement, not entries of a list, so nothing looked at
+// them: `ip-monitoring global-weight nope;` committed clean and compiled to 0.
+//
+// That is the worst instance of the class, not a lesser one. A malformed
+// PER-TARGET weight costs the group that one target's demotion debt; a
+// malformed GLOBAL weight is zero debt for the whole group, so no number of
+// failing probes demotes it and failover never happens. And unlike the
+// value-position collision documented on redundancyGroupStatements, a typo'd
+// weight is ordinary operator input.
+func TestChassisIPMonitoringGlobalWeightUnusableRejected_6588(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{"MalformedGlobalWeightPacked", "            ip-monitoring global-weight nope;",
+			`global-weight "nope" is not an integer`},
+		{"MalformedGlobalThresholdPacked", "            ip-monitoring global-threshold nope;",
+			`global-threshold "nope" is not an integer`},
+		{"MalformedGlobalWeightBlock",
+			"            ip-monitoring {\n                global-weight nope;\n            }",
+			`global-weight "nope" is not an integer`},
+		// A keyword with no value at all must be reported as malformed, not
+		// mistaken for the legal "property absent" case.
+		{"GlobalWeightWithNoValue", "            ip-monitoring global-weight;",
+			`global-weight "" is not an integer`},
+		{"DuplicateGlobalWeightPacked",
+			"            ip-monitoring global-weight 100 global-weight 200;",
+			"global-weight specified 2 times with different values"},
+		{"DuplicateGlobalWeightBlock",
+			"            ip-monitoring {\n                global-weight 100;\n                global-weight 200;\n            }",
+			"global-weight specified 2 times with different values"},
+		{"DuplicateGlobalThresholdPacked",
+			"            ip-monitoring global-threshold 1 global-threshold 2;",
+			"global-threshold specified 2 times with different values"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assertErrContains(t, compileMonitorTextErr(t, packedMonitorConfig(tc.body)), tc.want)
+		})
+	}
+
+	// An identical repeat is still ambiguous authoring, but the message must
+	// not claim a value conflict that does not exist.
+	t.Run("IdenticalRepeatNotCalledAConflict", func(t *testing.T) {
+		err := compileMonitorTextErr(t, packedMonitorConfig(
+			"            ip-monitoring global-weight 100 global-weight 100;"))
+		assertErrContains(t, err, "global-weight specified 2 times")
+		if err != nil && strings.Contains(err.Error(), "different values") {
+			t.Fatalf("error %q claims differing values for an identical repeat", err)
+		}
+	})
+
+	// The gate must reach the packed instance line too, or that one spelling
+	// admits what every other rejects.
+	t.Run("PackedRedundancyGroupBody", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedRGConfig(
+			"        redundancy-group 1 ip-monitoring global-weight nope;")),
+			`global-weight "nope" is not an integer`)
+	})
+}
+
+// TestChassisIPMonitoringGlobalsValidStillCommit_6588 is the negative control:
+// every legal global still commits and compiles verbatim, including both
+// boundaries and the absent case. Green with and without the gate.
+func TestChassisIPMonitoringGlobalsValidStillCommit_6588(t *testing.T) {
+	for _, w := range []int{0, 1, 128, 255} {
+		t.Run(fmt.Sprintf("weight_%d", w), func(t *testing.T) {
+			rg := compileMonitorText(t, packedMonitorConfig(fmt.Sprintf(
+				"            ip-monitoring global-weight %d global-threshold %d;", w, w)))
+			if rg.IPMonitoring == nil {
+				t.Fatal("redundancy group carries no compiled ip-monitoring")
+			}
+			if rg.IPMonitoring.GlobalWeight != w || rg.IPMonitoring.GlobalThreshold != w {
+				t.Fatalf("global-weight/threshold = %d/%d, want %d/%d",
+					rg.IPMonitoring.GlobalWeight, rg.IPMonitoring.GlobalThreshold, w, w)
+			}
+		})
+	}
+	t.Run("GlobalsAbsent", func(t *testing.T) {
+		rg := compileMonitorText(t, packedMonitorConfig(
+			"            ip-monitoring family inet 10.0.1.1 weight 100;"))
+		if rg.IPMonitoring == nil {
+			t.Fatal("redundancy group carries no compiled ip-monitoring")
+		}
+		if rg.IPMonitoring.GlobalWeight != 0 || rg.IPMonitoring.GlobalThreshold != 0 {
+			t.Fatalf("absent globals must stay at the 0 default, got %d/%d",
+				rg.IPMonitoring.GlobalWeight, rg.IPMonitoring.GlobalThreshold)
+		}
+	})
+}
+
+// TestChassisIPMonitoringGlobalMalformedTolerantNoBrick_6588 pins the #1960
+// posture for the new gate: an already-persisted or peer-synced config carrying
+// a malformed global must still BOOT, with a warning, keeping the 0 default.
+func TestChassisIPMonitoringGlobalMalformedTolerantNoBrick_6588(t *testing.T) {
+	p := NewParser(packedMonitorConfig("            ip-monitoring global-weight nope;"))
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile must not reject a malformed ip-monitoring global (no-brick), got %v", err)
+	}
+	if !warningsContain(cfg.Warnings, `global-weight "nope" is not an integer`) {
+		t.Fatalf("lenient compile should have warned; warnings=%v", cfg.Warnings)
+	}
+	rg := onlyRG6588(t, cfg)
+	if rg.IPMonitoring == nil || rg.IPMonitoring.GlobalWeight != 0 {
+		t.Fatalf("lenient compile must keep the 0 default, got %+v", rg.IPMonitoring)
+	}
+}
+
+// TestIPMonitoringGlobalTokensMatchesCompilerRead_6588 pins the claim that
+// makes the gate trustworthy: it reads the SAME token the compiler does.
+//
+// compileRGIPMonitoring picks a global with findNamedNode + nodeVal (first
+// wins); the gate collects every value with ipMonitoringGlobalTokens. If those
+// two ever disagreed about which token is the value, the gate could pass a
+// string the compiler never parses — or reject one it does. Asserting the
+// correspondence directly is cheaper than hoping the two stay aligned, and it
+// is not a tautology: they are separate traversals with separate call sites.
+func TestIPMonitoringGlobalTokensMatchesCompilerRead_6588(t *testing.T) {
+	for _, body := range []string{
+		"            ip-monitoring global-weight 255;",
+		"            ip-monitoring global-weight 255 global-threshold 2;",
+		"            ip-monitoring {\n                global-weight 255;\n                global-threshold 2;\n            }",
+		"            ip-monitoring global-weight 100 global-weight 200;",
+		"            ip-monitoring global-weight;",
+		"            ip-monitoring family inet 10.0.1.1 weight 100;",
+	} {
+		t.Run(strings.TrimSpace(body), func(t *testing.T) {
+			p := NewParser(packedMonitorConfig(body))
+			tree, perrs := p.Parse()
+			if len(perrs) > 0 {
+				t.Fatalf("parse: %v", perrs)
+			}
+			var checked int
+			for _, chassis := range tree.Children {
+				if chassis.Name() != "chassis" {
+					continue
+				}
+				for _, cluster := range chassis.Children {
+					if cluster.Name() != "cluster" {
+						continue
+					}
+					for _, rgInst := range namedInstances(cluster.FindChildren("redundancy-group")) {
+						for _, child := range redundancyGroupBody(rgInst.node) {
+							if child.Name() != "ip-monitoring" {
+								continue
+							}
+							props := packedStatementProps(child, 1, isIPMonitoringProp)
+							for _, name := range []string{"global-weight", "global-threshold"} {
+								toks := ipMonitoringGlobalTokens(props, name)
+								node := findNamedNode(props, name)
+								if len(toks) == 0 {
+									if node != nil {
+										t.Fatalf("%s: gate sees no tokens but the compiler found a node", name)
+									}
+									continue
+								}
+								if node == nil {
+									t.Fatalf("%s: gate sees %q but the compiler found no node", name, toks)
+								}
+								if got := nodeVal(node); got != toks[0] {
+									t.Fatalf("%s: compiler reads %q, gate's first token is %q — "+
+										"the gate would validate a value the compiler never uses",
+										name, got, toks[0])
+								}
+								checked++
+							}
+						}
+					}
+				}
+			}
+			if checked == 0 && strings.Contains(body, "global-") {
+				t.Fatal("this case reached no global comparison — it verifies nothing")
+			}
+		})
+	}
+}
+
+// no-argument statement arity --------------------------------------------
+
+// TestChassisRGNoArgStatementTrailingTokensRejected_6588 pins the arity gate on
+// the two FLAG statements.
+//
+// compileRGPreempt / compileRGStrictVIPOwnership set a bool and never read the
+// node, so anything else written on the statement was discarded in silence.
+// Reachable by ordinary typing, and `preempt delay <n>` / `limit` / `period`
+// are real Junos SRX options xpf does not implement — accepting them silently
+// tells the operator they configured a preempt delay that does not exist.
+// SchemaValidate accepts all of these (pinned below), so the AST gate is the
+// only layer that sees them.
+func TestChassisRGNoArgStatementTrailingTokensRejected_6588(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		text string
+		want string
+	}{
+		{"PreemptTrailingTokensPacked",
+			"        redundancy-group 1 preempt weight 255;", "preempt: takes no argument"},
+		{"PreemptJunosDelayPacked",
+			"        redundancy-group 1 preempt delay 5;", "preempt: takes no argument"},
+		{"StrictVIPOwnershipTrailingToken",
+			"        redundancy-group 1 strict-vip-ownership bogus;",
+			"strict-vip-ownership: takes no argument"},
+		{"PreemptBlockBody",
+			"        redundancy-group 1 {\n            preempt {\n                delay 5;\n            }\n        }",
+			"preempt: takes no argument but carries a"},
+		{"PreemptTrailingTokensContainer",
+			"        redundancy-group 1 {\n            preempt delay 5;\n        }",
+			"preempt: takes no argument"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assertErrContains(t, compileMonitorTextErr(t, packedRGConfig(tc.text)), tc.want)
+		})
+	}
+
+	// The schema walker does not see any of this — evidence for why the gate
+	// runs on the AST rather than as a typed leaf.
+	t.Run("SchemaValidateCannotSeeIt", func(t *testing.T) {
+		tree := flatMonitorTree(t, "set chassis cluster redundancy-group 1 preempt delay 5")
+		if err := SchemaValidate(tree, nil); err != nil {
+			t.Fatalf("SchemaValidate unexpectedly rejected it (%v) — if the schema now covers "+
+				"this, the AST gate's rationale needs revisiting", err)
+		}
+		if _, err := CompileConfig(tree); err == nil {
+			t.Fatal("the AST gate must reject what SchemaValidate cannot see")
+		}
+	})
+}
+
+// TestChassisRGNoArgStatementCleanStillCommits_6588 is the arity negative
+// control: the bare flags, alone and packed alongside other statements, must
+// still commit. Green with and without the gate.
+func TestChassisRGNoArgStatementCleanStillCommits_6588(t *testing.T) {
+	t.Run("PreemptAlone", func(t *testing.T) {
+		if rg := compileRGText(t, packedRGConfig("        redundancy-group 1 preempt;")); !rg.Preempt {
+			t.Fatal("preempt lost")
+		}
+	})
+	t.Run("BothFlagsPackedWithNeighbours", func(t *testing.T) {
+		rg := compileRGText(t, packedRGConfig(
+			"        redundancy-group 1 node 0 priority 200 preempt strict-vip-ownership gratuitous-arp-count 8;"))
+		if !rg.Preempt || !rg.StrictVIPOwnership {
+			t.Fatalf("preempt=%v strict-vip-ownership=%v, want both true", rg.Preempt, rg.StrictVIPOwnership)
+		}
+		if rg.GratuitousARPCount != 8 {
+			t.Fatalf("gratuitous-arp-count = %d, want 8", rg.GratuitousARPCount)
+		}
+	})
+	t.Run("FlatSet", func(t *testing.T) {
+		cfg, err := CompileConfig(flatMonitorTree(t,
+			"set chassis cluster redundancy-group 1 preempt",
+			"set chassis cluster redundancy-group 1 strict-vip-ownership"))
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		rg := onlyRG6588(t, cfg)
+		if !rg.Preempt || !rg.StrictVIPOwnership {
+			t.Fatalf("preempt=%v strict-vip-ownership=%v, want both true", rg.Preempt, rg.StrictVIPOwnership)
+		}
+	})
+}
+
+// TestChassisRGNoArgTolerantNoBrick_6588 pins the #1960 posture for the arity
+// gate: a persisted config with a stray token still BOOTS, with a warning, and
+// the flag still compiles.
+func TestChassisRGNoArgTolerantNoBrick_6588(t *testing.T) {
+	p := NewParser(packedRGConfig("        redundancy-group 1 preempt delay 5;"))
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile must not reject a stray token on a flag statement (no-brick), got %v", err)
+	}
+	if !warningsContain(cfg.Warnings, "preempt: takes no argument") {
+		t.Fatalf("lenient compile should have warned; warnings=%v", cfg.Warnings)
+	}
+	if rg := onlyRG6588(t, cfg); !rg.Preempt {
+		t.Fatal("lenient compile must still set Preempt")
+	}
 }
 
 func assertErrContains(t *testing.T, err error, want string) {
@@ -1136,6 +1545,22 @@ func TestRedundancyGroupStatementsSurvivePackedLine_6588(t *testing.T) {
 		}
 	}
 
+	// Requiring a sample to EXIST is not enough: it must be a sample OF the
+	// statement it is filed under. Without this, an entry could be satisfied by
+	// text that compiles some other statement entirely — a placeholder keyed
+	// `review-placeholder` whose text is `preempt`, with a Preempt assertion,
+	// passed every check in this test while `review-placeholder` never appeared
+	// in the input and its handler was never dispatched. The completeness check
+	// then guarantees nothing, which is worse than not having it, because the
+	// next person reads a green test as coverage.
+	for stmt, s := range samples {
+		if s.text != stmt && !strings.HasPrefix(s.text, stmt+" ") {
+			t.Errorf("sample for %q is %q, which does not begin with the statement keyword — "+
+				"the case compiles some OTHER statement while appearing to cover %q",
+				stmt, s.text, stmt)
+		}
+	}
+
 	// Pair every statement with a DIFFERENT one on the same packed line, in both
 	// orders. A statement the splitter does not know folds into its neighbour,
 	// and only the multi-statement spelling exposes that.
@@ -1148,11 +1573,66 @@ func TestRedundancyGroupStatementsSurvivePackedLine_6588(t *testing.T) {
 				continue
 			}
 			t.Run(a+"_then_"+b, func(t *testing.T) {
+				dispatched := instrumentRGDispatch(t)
 				rg := compileRGText(t, packedRGConfig(
 					"        redundancy-group 1 "+sa.text+" "+sb.text+";"))
 				sa.assert(t, rg)
 				sb.assert(t, rg)
+				// The typed assertions above can be satisfied by the WRONG
+				// statement — `preempt` sets rg.Preempt no matter which key
+				// the sample is filed under. Requiring the handler registered
+				// under each key to have actually run is what ties the case to
+				// its table entry.
+				for _, stmt := range []string{a, b} {
+					if !dispatched(stmt) {
+						t.Errorf("compiling this packed line never dispatched the handler "+
+							"registered under %q, so the case does not exercise the statement "+
+							"it is filed under", stmt)
+					}
+				}
 			})
+		}
+	}
+}
+
+// instrumentRGDispatch wraps every redundancyGroupStatements handler so a test
+// can ask which ones a compile actually reached, and restores the table when
+// the test ends.
+//
+// Wrapping preserves the table's KEYS, so isRedundancyGroupStatement and the
+// packed-line splitter behave identically while instrumented — the test
+// observes dispatch without changing what is dispatched.
+func instrumentRGDispatch(t *testing.T) func(stmt string) bool {
+	t.Helper()
+	orig := make(map[string]func(*RedundancyGroup, *Node), len(redundancyGroupStatements))
+	fired := make(map[string]bool, len(redundancyGroupStatements))
+	for name, fn := range redundancyGroupStatements {
+		orig[name] = fn
+		name, fn := name, fn
+		redundancyGroupStatements[name] = func(rg *RedundancyGroup, child *Node) {
+			fired[name] = true
+			fn(rg, child)
+		}
+	}
+	t.Cleanup(func() {
+		for name, fn := range orig {
+			redundancyGroupStatements[name] = fn
+		}
+	})
+	return func(stmt string) bool { return fired[stmt] }
+}
+
+// TestRedundancyGroupNoArgStatementsAreRegistered_6588 keeps
+// redundancyGroupNoArgStatements in step with the dispatch table. Arity cannot
+// be derived from a handler's type, so the flag set is written by hand; a name
+// in it that is not a registered statement means the arity gate is guarding a
+// statement the compiler does not have.
+func TestRedundancyGroupNoArgStatementsAreRegistered_6588(t *testing.T) {
+	for stmt := range redundancyGroupNoArgStatements {
+		if _, ok := redundancyGroupStatements[stmt]; !ok {
+			t.Errorf("redundancyGroupNoArgStatements lists %q but redundancyGroupStatements "+
+				"does not register it — the arity gate guards a statement that is never "+
+				"compiled", stmt)
 		}
 	}
 }

--- a/pkg/config/compiler_chassis_packed_monitor_6588_test.go
+++ b/pkg/config/compiler_chassis_packed_monitor_6588_test.go
@@ -681,6 +681,21 @@ func assertErrContains(t *testing.T, err error, want string) {
 
 func assertMonitorNames(t *testing.T, rg *RedundancyGroup, want []string) {
 	t.Helper()
+	assertMonitors(t, rg, want, nil)
+}
+
+// assertMonitors compares the compiled monitors by NAME and, when wantWeights
+// is non-nil, by WEIGHT.
+//
+// The weight arm exists because its absence hid a regression: the original
+// name-only helper let `interface-monitor [ ge-0/0/0 ge-0/0/1 ] weight 255`
+// compile to ge-0/0/0=0, ge-0/0/1=255 with every bracket test green. A monitor
+// that exists with weight 0 deducts nothing when its link fails, so the group
+// does not demote — the same runtime outcome as no monitor at all, which is
+// exactly what these tests are supposed to be watching for. Never assert a
+// monitor list by name alone.
+func assertMonitors(t *testing.T, rg *RedundancyGroup, want []string, wantWeights []int) {
+	t.Helper()
 	if len(rg.InterfaceMonitors) != len(want) {
 		t.Fatalf("expected %d interface-monitors %v, got %d: %s — a bracketed list must "+
 			"compile to one monitor per name, not one monitor for the first name",
@@ -690,6 +705,15 @@ func assertMonitorNames(t *testing.T, rg *RedundancyGroup, want []string) {
 		if rg.InterfaceMonitors[i].Interface != w {
 			t.Fatalf("monitor[%d] = %q, want %q (got %s)",
 				i, rg.InterfaceMonitors[i].Interface, w, describeMonitors(rg.InterfaceMonitors))
+		}
+	}
+	for i := range wantWeights {
+		if got := rg.InterfaceMonitors[i].Weight; got != wantWeights[i] {
+			t.Fatalf("monitor %s weight = %d, want %d (got %s) — a monitor compiled at "+
+				"weight 0 deducts NOTHING when its link fails, so the redundancy group "+
+				"does not demote",
+				rg.InterfaceMonitors[i].Interface, got, wantWeights[i],
+				describeMonitors(rg.InterfaceMonitors))
 		}
 	}
 }
@@ -993,4 +1017,172 @@ func TestRedundancyGroupStatementPredicateCoversCompiler_6588(t *testing.T) {
 				arm, arm, arm)
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// #6588 review round 5 — a regression this branch introduced, and a second
+// namedInstances node shape the fixed skip did not cover.
+// ---------------------------------------------------------------------------
+
+// TestChassisInterfaceMonitorBracketInlineWeight_6588 pins MAJOR-A: a trailing
+// inline weight on a bracketed list applies to EVERY member.
+//
+// The entry splitter originally attached a `weight` token to the entry
+// immediately preceding it, which is the obvious reading and is wrong here:
+// `[ ge-0/0/0 ge-0/0/1 ] weight 255` compiled ge-0/0/0 at weight ZERO. That is
+// WORSE than master, which compiled one monitor at 255 and dropped the rest —
+// master at least protected ge-0/0/0. With N names, N-1 monitors were inert:
+// present in `show`, deducting nothing on link-down, group never demotes.
+//
+// The chosen semantics is apply-to-all, matching the children-block spelling
+// `[ a b ] { weight 255; }` (which already applied 255 to both) and the
+// fail-safe rule monitorEntryNodes documents. It is also strictly better than
+// master on this input: no member is dropped and no weight is lost.
+//
+// FAIL-ON-REVERT: attach the weight to split[len(split)-1] again and every
+// subtest below fails naming the zero-weight monitor.
+func TestChassisInterfaceMonitorBracketInlineWeight_6588(t *testing.T) {
+	t.Run("FlatSetTwoNames", func(t *testing.T) {
+		cfg, err := CompileConfig(flatMonitorTree(t,
+			"set chassis cluster redundancy-group 1 interface-monitor [ ge-0/0/0 ge-0/0/1 ] weight 255"))
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		assertMonitors(t, onlyRG6588(t, cfg),
+			[]string{"ge-0/0/0", "ge-0/0/1"}, []int{255, 255})
+	})
+	t.Run("FlatSetThreeNames", func(t *testing.T) {
+		cfg, err := CompileConfig(flatMonitorTree(t,
+			"set chassis cluster redundancy-group 1 interface-monitor [ ge-0/0/0 ge-0/0/1 ge-0/0/2 ] weight 100"))
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		assertMonitors(t, onlyRG6588(t, cfg),
+			[]string{"ge-0/0/0", "ge-0/0/1", "ge-0/0/2"}, []int{100, 100, 100})
+	})
+	t.Run("ContainerHierarchical", func(t *testing.T) {
+		assertMonitors(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor [ ge-0/0/0 ge-0/0/1 ] weight 255;")),
+			[]string{"ge-0/0/0", "ge-0/0/1"}, []int{255, 255})
+	})
+	t.Run("PackedInstanceLine", func(t *testing.T) {
+		assertMonitors(t, compileRGText(t, packedRGConfig(
+			"        redundancy-group 1 interface-monitor [ ge-0/0/0 ge-0/0/1 ] weight 255;")),
+			[]string{"ge-0/0/0", "ge-0/0/1"}, []int{255, 255})
+	})
+
+	// NEGATIVE CONTROL: the children-block spelling already applied the weight
+	// to every member and must keep doing so. Green with and without the fix.
+	t.Run("ControlChildrenBlockWeight", func(t *testing.T) {
+		assertMonitors(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor [ ge-0/0/0 ge-0/0/1 ] {\n                weight 255;\n            }")),
+			[]string{"ge-0/0/0", "ge-0/0/1"}, []int{255, 255})
+	})
+	// NEGATIVE CONTROL: a single name with an inline weight is unaffected by
+	// how the attribute is scoped. Green in both worlds.
+	t.Run("ControlSingleNameInlineWeight", func(t *testing.T) {
+		assertMonitors(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor ge-0/0/0 weight 255;")),
+			[]string{"ge-0/0/0"}, []int{255})
+	})
+	// A weight-less list still compiles every member at the documented 0
+	// default — apply-to-all must not invent a weight.
+	t.Run("ControlNoWeightStaysZero", func(t *testing.T) {
+		assertMonitors(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor [ ge-0/0/0 ge-0/0/1 ];")),
+			[]string{"ge-0/0/0", "ge-0/0/1"}, []int{0, 0})
+	})
+	// The out-of-range gate sees every member, not just the last.
+	t.Run("OutOfRangeRejectedForAllMembers", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedMonitorConfig(
+			"            interface-monitor [ ge-0/0/0 ge-0/0/1 ] weight 300;")),
+			"interface-monitor ge-0/0/0 weight 300 is out of range 0..255")
+	})
+	// Two inline weights in one bracketed statement are ambiguous about which
+	// member each belongs to. Master silently took the LAST and dropped every
+	// member but the first; rejecting is loud and matches the round-2
+	// duplicate-weight gate.
+	t.Run("AmbiguousPerMemberWeightsRejected", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedMonitorConfig(
+			"            interface-monitor [ ge-0/0/0 weight 100 ge-0/0/1 weight 200 ];")),
+			"weight specified 2 times with different values")
+	})
+}
+
+// TestChassisIPMonitoringBracketInlineWeight_6588 pins the same semantics on
+// the ip-monitoring target list, which shares monitorEntryNodes.
+func TestChassisIPMonitoringBracketInlineWeight_6588(t *testing.T) {
+	rg := compileMonitorText(t, packedMonitorConfig(
+		"            ip-monitoring family inet [ 10.0.1.1 10.0.2.1 ] weight 100;"))
+	if rg.IPMonitoring == nil || len(rg.IPMonitoring.Targets) != 2 {
+		t.Fatalf("expected 2 ip-monitoring targets, got %+v", rg.IPMonitoring)
+	}
+	for _, tgt := range rg.IPMonitoring.Targets {
+		if tgt.Weight != 100 {
+			t.Fatalf("target %s weight = %d, want 100 — a target compiled at weight 0 "+
+				"deducts nothing when the probe fails", tgt.Address, tgt.Weight)
+		}
+	}
+}
+
+// TestChassisRedundancyGroupBareContainerShape_6588 pins MAJOR-B: the SECOND
+// node shape namedInstances returns.
+//
+// namedInstances yields either the `redundancy-group <id>` node itself
+// (Keys[0]=="redundancy-group", so the body starts at Keys[2]) or, for a bare
+// `redundancy-group { ... }` wrapper, a CHILD whose Keys[0] IS the instance id
+// (so the body starts at Keys[1]). redundancyGroupBody used a fixed skip of 2,
+// which on the second shape swallowed the statement KEYWORD and opened a node
+// named after a value — matching no switch arm, so every statement was dropped
+// exactly as in round 1, election priority included.
+//
+// Reachability through the shipped parser is lower than the round-1 shape (no
+// Junos output and no SetPath path emits a bare wrapper), but this is fixed
+// rather than documented: the guard covers all four redundancyGroupBody
+// readers, so leaving it would make the three AST gates blind here while
+// LOOKING like they covered it.
+//
+// FAIL-ON-REVERT: pin skip back to 2 and every subtest fails naming the lost
+// statement.
+func TestChassisRedundancyGroupBareContainerShape_6588(t *testing.T) {
+	t.Run("PackedInterfaceMonitor", func(t *testing.T) {
+		assertMonitors(t, compileRGText(t, packedRGConfig(
+			"        redundancy-group {\n            1 interface-monitor ge-0/0/0 weight 255;\n        }")),
+			[]string{"ge-0/0/0"}, []int{255})
+	})
+	t.Run("PackedNodePriority", func(t *testing.T) {
+		rg := compileRGText(t, packedRGConfig(
+			"        redundancy-group {\n            1 node 0 priority 200;\n        }"))
+		if got, ok := rg.NodePriorities[0]; !ok || got != 200 {
+			t.Fatalf("bare `redundancy-group { 1 node 0 priority 200; }` lost the election "+
+				"priority: NodePriorities = %v", rg.NodePriorities)
+		}
+	})
+	t.Run("PackedPreempt", func(t *testing.T) {
+		rg := compileRGText(t, packedRGConfig(
+			"        redundancy-group {\n            1 preempt;\n        }"))
+		if !rg.Preempt {
+			t.Fatal("bare `redundancy-group { 1 preempt; }` lost `preempt`")
+		}
+	})
+	t.Run("GatesStillReachIt", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedRGConfig(
+			"        redundancy-group {\n            1 interface-monitor ge-0/0/0 weight nope;\n        }")),
+			`weight "nope" is not an integer`)
+	})
+	// NEGATIVE CONTROL: the nested-block form under a bare wrapper already
+	// worked (its body arrives as real children) and must be unchanged. Green
+	// with and without the fix.
+	t.Run("ControlBareWrapperNestedBlock", func(t *testing.T) {
+		assertMonitors(t, compileRGText(t, packedRGConfig(
+			"        redundancy-group {\n            1 {\n                interface-monitor ge-0/0/0 weight 255;\n            }\n        }")),
+			[]string{"ge-0/0/0"}, []int{255})
+	})
+	// NEGATIVE CONTROL: the ordinary `redundancy-group <id>` shape still uses
+	// skip 2. Green in both worlds.
+	t.Run("ControlOrdinaryInstanceShape", func(t *testing.T) {
+		assertMonitors(t, compileRGText(t, packedRGConfig(
+			"        redundancy-group 1 interface-monitor ge-0/0/0 weight 255;")),
+			[]string{"ge-0/0/0"}, []int{255})
+	})
 }

--- a/pkg/config/compiler_chassis_packed_monitor_6588_test.go
+++ b/pkg/config/compiler_chassis_packed_monitor_6588_test.go
@@ -465,6 +465,10 @@ func TestChassisPackedShapeBypassesSchemaWalk_6588(t *testing.T) {
 // failover fail-open as dropping the statement, one monitor at a time.
 func TestChassisInterfaceMonitorBracketList_6588(t *testing.T) {
 	want := []string{"ge-0/0/0", "ge-0/0/1", "ge-0/0/2"}
+	// No weight anywhere on these lines, so every monitor must carry the
+	// documented #6549 default. Asserted explicitly rather than skipped — see
+	// assertMonitors.
+	zeros := []int{0, 0, 0}
 
 	t.Run("FlatSet", func(t *testing.T) {
 		cfg, err := CompileConfig(flatMonitorTree(t,
@@ -472,45 +476,126 @@ func TestChassisInterfaceMonitorBracketList_6588(t *testing.T) {
 		if err != nil {
 			t.Fatalf("compile: %v", err)
 		}
-		assertMonitorNames(t, onlyRG6588(t, cfg), want)
+		assertMonitors(t, onlyRG6588(t, cfg), want, zeros)
 	})
 	t.Run("ContainerHierarchical", func(t *testing.T) {
-		assertMonitorNames(t, compileMonitorText(t, packedMonitorConfig(
-			"            interface-monitor {\n                [ ge-0/0/0 ge-0/0/1 ge-0/0/2 ];\n            }")), want)
+		assertMonitors(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor {\n                [ ge-0/0/0 ge-0/0/1 ge-0/0/2 ];\n            }")), want, zeros)
 	})
 	t.Run("Packed", func(t *testing.T) {
-		assertMonitorNames(t, compileMonitorText(t, packedMonitorConfig(
-			"            interface-monitor [ ge-0/0/0 ge-0/0/1 ge-0/0/2 ];")), want)
+		assertMonitors(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor [ ge-0/0/0 ge-0/0/1 ge-0/0/2 ];")), want, zeros)
 	})
 	// A weight-less bracketed list must still yield one monitor per name.
 	t.Run("PackedNoWeight", func(t *testing.T) {
-		assertMonitorNames(t, compileMonitorText(t, packedMonitorConfig(
-			"            interface-monitor [ ge-0/0/0 ge-0/0/1 ];")), []string{"ge-0/0/0", "ge-0/0/1"})
+		assertMonitors(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor [ ge-0/0/0 ge-0/0/1 ];")),
+			[]string{"ge-0/0/0", "ge-0/0/1"}, []int{0, 0})
+	})
+}
+
+// TestChassisInterfaceMonitorBracketListWeight_6588 pins WHICH monitors a
+// bracketed list's weight lands on — the half of the bracket contract the
+// name-only assertions above cannot see.
+//
+// A weight written after a bracketed list applies to EVERY member. The obvious
+// implementation attaches it to the PRECEDING name only, which leaves
+// `[ ge-0/0/0 ge-0/0/1 ] weight 255` compiled as ge-0/0/0=0, ge-0/0/1=255: the
+// first link is monitored but deducts nothing when it fails, so the group does
+// not demote. That is a failover fail-open, and it is WORSE than the master
+// behaviour this PR replaced (which compiled one monitor at 255 and dropped the
+// rest) because the operator sees both interfaces echoed back by `show
+// configuration` and by `show chassis cluster status`.
+//
+// FAIL-ON-REVERT: restore the positional attachment in monitorEntryNodes
+// (append the `weight` tokens to the last name started, instead of collecting
+// them candidate-scoped) and every subtest marked BINDING below fails naming
+// the zero weight. The two CONTROL subtests carry the weight in a children
+// block, where it is candidate-scoped in both implementations — they are green
+// either way and are here to pin that the two spellings agree, not to catch the
+// positional regression.
+func TestChassisInterfaceMonitorBracketListWeight_6588(t *testing.T) {
+	pair := []string{"ge-0/0/0", "ge-0/0/1"}
+
+	// BINDING: inline weight after a bracketed list, in every spelling that
+	// reaches monitorEntryNodes.
+	t.Run("PackedInline", func(t *testing.T) {
+		assertMonitors(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor [ ge-0/0/0 ge-0/0/1 ] weight 255;")),
+			pair, []int{255, 255})
+	})
+	t.Run("PackedInlineThreeMembers", func(t *testing.T) {
+		assertMonitors(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor [ ge-0/0/0 ge-0/0/1 ge-0/0/2 ] weight 100;")),
+			[]string{"ge-0/0/0", "ge-0/0/1", "ge-0/0/2"}, []int{100, 100, 100})
+	})
+	t.Run("ContainerHierarchicalInline", func(t *testing.T) {
+		assertMonitors(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor {\n                [ ge-0/0/0 ge-0/0/1 ] weight 255;\n            }")),
+			pair, []int{255, 255})
+	})
+	t.Run("FlatSetInline", func(t *testing.T) {
+		cfg, err := CompileConfig(flatMonitorTree(t,
+			"set chassis cluster redundancy-group 1 interface-monitor [ ge-0/0/0 ge-0/0/1 ] weight 255"))
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		assertMonitors(t, onlyRG6588(t, cfg), pair, []int{255, 255})
+	})
+	// BINDING, one level up: the whole redundancy-group body packed onto the
+	// instance line still splits the list AND spreads the weight.
+	t.Run("PackedRedundancyGroupBodyInline", func(t *testing.T) {
+		assertMonitors(t, compileRGText(t, packedRGConfig(
+			"        redundancy-group 1 interface-monitor [ ge-0/0/0 ge-0/0/1 ] weight 255;")),
+			pair, []int{255, 255})
+	})
+
+	// CONTROL: the children-block spelling. The weight is candidate-scoped by
+	// construction here, so this stays green under the positional regression;
+	// it pins that the block and inline spellings agree.
+	t.Run("PackedChildrenBlock", func(t *testing.T) {
+		assertMonitors(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor [ ge-0/0/0 ge-0/0/1 ] {\n                weight 255;\n            }")),
+			pair, []int{255, 255})
+	})
+	t.Run("ContainerHierarchicalChildrenBlock", func(t *testing.T) {
+		assertMonitors(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor {\n                [ ge-0/0/0 ge-0/0/1 ] {\n                    weight 255;\n                }\n            }")),
+			pair, []int{255, 255})
 	})
 }
 
 // TestChassisIPMonitoringBracketTargets_6588 covers the same collapse on the
 // ip-monitoring target list.
 func TestChassisIPMonitoringBracketTargets_6588(t *testing.T) {
-	rg := compileMonitorText(t, packedMonitorConfig(
-		"            ip-monitoring family inet [ 10.0.1.1 10.0.2.1 10.0.3.1 ];"))
-	if rg.IPMonitoring == nil {
-		t.Fatal("redundancy group carries no compiled ip-monitoring")
-	}
-	var got []string
-	for _, tg := range rg.IPMonitoring.Targets {
-		got = append(got, tg.Address)
-	}
-	want := []string{"10.0.1.1", "10.0.2.1", "10.0.3.1"}
-	if len(got) != len(want) {
-		t.Fatalf("ip-monitoring targets = %v, want %v — a bracketed list must compile to one "+
-			"target per address", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("ip-monitoring targets = %v, want %v", got, want)
-		}
-	}
+	t.Run("NoWeight", func(t *testing.T) {
+		assertIPMonTargets(t, compileMonitorText(t, packedMonitorConfig(
+			"            ip-monitoring family inet [ 10.0.1.1 10.0.2.1 10.0.3.1 ];")),
+			[]string{"10.0.1.1", "10.0.2.1", "10.0.3.1"}, []int{0, 0, 0})
+	})
+	// BINDING, same shape as the interface-monitor case: ip-monitoring targets
+	// are split by the SAME monitorEntryNodes, so a positional weight
+	// attachment leaves the first probe target deducting nothing on failure.
+	t.Run("InlineWeight", func(t *testing.T) {
+		assertIPMonTargets(t, compileMonitorText(t, packedMonitorConfig(
+			"            ip-monitoring family inet [ 10.0.1.1 10.0.2.1 ] weight 100;")),
+			[]string{"10.0.1.1", "10.0.2.1"}, []int{100, 100})
+	})
+	t.Run("InlineWeightThreeTargets", func(t *testing.T) {
+		assertIPMonTargets(t, compileMonitorText(t, packedMonitorConfig(
+			"            ip-monitoring family inet [ 10.0.1.1 10.0.2.1 10.0.3.1 ] weight 200;")),
+			[]string{"10.0.1.1", "10.0.2.1", "10.0.3.1"}, []int{200, 200, 200})
+	})
+	t.Run("InlineWeightInsideFamilyBlock", func(t *testing.T) {
+		assertIPMonTargets(t, compileMonitorText(t, packedMonitorConfig(
+			"            ip-monitoring {\n                family inet {\n                    [ 10.0.1.1 10.0.2.1 ] weight 100;\n                }\n            }")),
+			[]string{"10.0.1.1", "10.0.2.1"}, []int{100, 100})
+	})
+	t.Run("PackedRedundancyGroupBodyInlineWeight", func(t *testing.T) {
+		assertIPMonTargets(t, compileRGText(t, packedRGConfig(
+			"        redundancy-group 1 ip-monitoring family inet [ 10.0.1.1 10.0.2.1 ] weight 100;")),
+			[]string{"10.0.1.1", "10.0.2.1"}, []int{100, 100})
+	})
 }
 
 // TestChassisInterfaceMonitorSingleEntryNotSplit_6588 is the MAJOR-2 negative
@@ -675,23 +760,32 @@ func assertErrContains(t *testing.T, err error, want string) {
 	}
 }
 
-func assertMonitorNames(t *testing.T, rg *RedundancyGroup, want []string) {
-	t.Helper()
-	assertMonitors(t, rg, want, nil)
-}
-
-// assertMonitors compares the compiled monitors by NAME and, when wantWeights
-// is non-nil, by WEIGHT.
+// assertMonitors compares the compiled monitors by NAME **and** by WEIGHT.
 //
-// The weight arm exists because its absence hid a regression: the original
-// name-only helper let `interface-monitor [ ge-0/0/0 ge-0/0/1 ] weight 255`
-// compile to ge-0/0/0=0, ge-0/0/1=255 with every bracket test green. A monitor
-// that exists with weight 0 deducts nothing when its link fails, so the group
-// does not demote — the same runtime outcome as no monitor at all, which is
-// exactly what these tests are supposed to be watching for. Never assert a
-// monitor list by name alone.
+// Both arms are MANDATORY, and there is deliberately no name-only wrapper.
+// This helper used to have an optional weight arm reached through an
+// `assertMonitorNames(t, rg, want)` shim that passed nil, and every caller in
+// this file went through that shim — so the weight arm was dead code and every
+// bracketed-list case here was weight-less. That is not a hypothetical gap: it
+// let `interface-monitor [ ge-0/0/0 ge-0/0/1 ] weight 255` compile to
+// ge-0/0/0=0, ge-0/0/1=255 with the whole bracket suite green. A monitor that
+// exists with weight 0 deducts nothing when its link fails, so the group does
+// not demote — the same runtime outcome as no monitor at all, which is exactly
+// what these tests exist to watch for.
+//
+// A caller that genuinely expects the weight-less default says so by passing
+// explicit zeros. That is an assertion (the documented #6549 default), not a
+// skip, and it cannot rot into one.
 func assertMonitors(t *testing.T, rg *RedundancyGroup, want []string, wantWeights []int) {
 	t.Helper()
+	// Refuse a silently-partial check: a short wantWeights would leave the
+	// tail of the monitor list unasserted, which is how the weight arm went
+	// dead in the first place.
+	if len(wantWeights) != len(want) {
+		t.Fatalf("assertMonitors misuse: %d names %v but %d weights %v — every monitor "+
+			"must be asserted by weight as well as by name",
+			len(want), want, len(wantWeights), wantWeights)
+	}
 	if len(rg.InterfaceMonitors) != len(want) {
 		t.Fatalf("expected %d interface-monitors %v, got %d: %s — a bracketed list must "+
 			"compile to one monitor per name, not one monitor for the first name",
@@ -703,13 +797,52 @@ func assertMonitors(t *testing.T, rg *RedundancyGroup, want []string, wantWeight
 				i, rg.InterfaceMonitors[i].Interface, w, describeMonitors(rg.InterfaceMonitors))
 		}
 	}
-	for i := range wantWeights {
+	for i := range want {
 		if got := rg.InterfaceMonitors[i].Weight; got != wantWeights[i] {
 			t.Fatalf("monitor %s weight = %d, want %d (got %s) — a monitor compiled at "+
 				"weight 0 deducts NOTHING when its link fails, so the redundancy group "+
 				"does not demote",
 				rg.InterfaceMonitors[i].Interface, got, wantWeights[i],
 				describeMonitors(rg.InterfaceMonitors))
+		}
+	}
+}
+
+// assertIPMonTargets is the ip-monitoring counterpart, and exists for the same
+// reason: the target list is built by the SAME monitorEntryNodes splitter, so a
+// weight-less address assertion leaves the identical hole.
+func assertIPMonTargets(t *testing.T, rg *RedundancyGroup, want []string, wantWeights []int) {
+	t.Helper()
+	if len(wantWeights) != len(want) {
+		t.Fatalf("assertIPMonTargets misuse: %d addresses %v but %d weights %v",
+			len(want), want, len(wantWeights), wantWeights)
+	}
+	if rg.IPMonitoring == nil {
+		t.Fatal("redundancy group carries no compiled ip-monitoring")
+	}
+	got := rg.IPMonitoring.Targets
+	describe := func() string {
+		if len(got) == 0 {
+			return "<none>"
+		}
+		parts := make([]string, 0, len(got))
+		for _, tg := range got {
+			parts = append(parts, fmt.Sprintf("%s weight %d", tg.Address, tg.Weight))
+		}
+		return strings.Join(parts, ", ")
+	}
+	if len(got) != len(want) {
+		t.Fatalf("ip-monitoring targets = %s, want %v — a bracketed list must compile to "+
+			"one target per address", describe(), want)
+	}
+	for i := range want {
+		if got[i].Address != want[i] {
+			t.Fatalf("target[%d] = %q, want %q (got %s)", i, got[i].Address, want[i], describe())
+		}
+		if got[i].Weight != wantWeights[i] {
+			t.Fatalf("target %s weight = %d, want %d (got %s) — a target compiled at weight 0 "+
+				"deducts NOTHING when its probe fails, so the redundancy group does not demote",
+				got[i].Address, got[i].Weight, wantWeights[i], describe())
 		}
 	}
 }
@@ -897,9 +1030,14 @@ func TestChassisRedundancyGroupPackedBodyReachesGates_6588(t *testing.T) {
 			"weight specified 2 times with different values")
 	})
 	t.Run("BracketListStillSplits", func(t *testing.T) {
-		assertMonitorNames(t, compileRGText(t, packedRGConfig(
+		assertMonitors(t, compileRGText(t, packedRGConfig(
 			"        redundancy-group 1 interface-monitor [ ge-0/0/0 ge-0/0/1 ];")),
-			[]string{"ge-0/0/0", "ge-0/0/1"})
+			[]string{"ge-0/0/0", "ge-0/0/1"}, []int{0, 0})
+	})
+	t.Run("BracketListWeightReachesEveryMember", func(t *testing.T) {
+		assertMonitors(t, compileRGText(t, packedRGConfig(
+			"        redundancy-group 1 interface-monitor [ ge-0/0/0 ge-0/0/1 ] weight 255;")),
+			[]string{"ge-0/0/0", "ge-0/0/1"}, []int{255, 255})
 	})
 	t.Run("IPMonitoringRangeStillGated", func(t *testing.T) {
 		assertErrContains(t, compileMonitorTextErr(t, packedRGConfig(
@@ -981,6 +1119,16 @@ func TestRedundancyGroupStatementsSurvivePackedLine_6588(t *testing.T) {
 		}},
 	}
 
+	// This completeness check is also the trip-wire for the splitter's
+	// over-match route (see redundancyGroupStatements' doc comment): the
+	// splitter matches a registered keyword wherever the token appears in a
+	// packed tail, including in entry-NAME position, so a keyword that can also
+	// spell an interface name or an IP address would be STOLEN from the
+	// statement it belongs to and the packed and container spellings would
+	// disagree. No current keyword can (names are ge-*/xe-*, reth*, fxp*, em*,
+	// lo0, st0, ae*, fab*, irb, vlan). Registering a new statement fails here
+	// until a sample is added — that is the moment to check the new keyword
+	// against those shapes.
 	for stmt := range redundancyGroupStatements {
 		if _, ok := samples[stmt]; !ok {
 			t.Errorf("redundancyGroupStatements registers %q but this test has no sample for "+

--- a/pkg/config/compiler_chassis_packed_monitor_6588_test.go
+++ b/pkg/config/compiler_chassis_packed_monitor_6588_test.go
@@ -689,3 +689,204 @@ func assertMonitorNames(t *testing.T, rg *RedundancyGroup, want []string) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// #6588 review round 3 — the same Children-only bug ONE LEVEL UP.
+// ---------------------------------------------------------------------------
+
+// packedRGConfig returns hierarchical config text carrying clusterBody directly
+// under `cluster`, so the redundancy-group statement itself can be written in
+// the packed form. Everything here is driven through the REAL parser
+// (NewParser -> CompileConfig): a hand-built AST would let the test assume the
+// node shape instead of observing it, which is exactly the mistake that let
+// this shape survive two review rounds.
+func packedRGConfig(clusterBody string) string {
+	return `chassis {
+    cluster {
+        authentication-key test-cluster-psk-6588;
+        cluster-id 1;
+` + clusterBody + `
+    }
+}`
+}
+
+func compileRGText(t *testing.T, text string) *RedundancyGroup {
+	t.Helper()
+	p := NewParser(text)
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return onlyRG6588(t, cfg)
+}
+
+// TestChassisRedundancyGroupPackedBody_6588 pins the one-level-up packed
+// spelling: the whole redundancy-group body written on the instance line.
+//
+//	redundancy-group 1 interface-monitor ge-0/0/0 weight 255;
+//
+// namedInstances resolves the instance NAME across both shapes (it reads
+// Keys[1]) but returns the node with the body still on Keys, so a caller
+// walking `.Children` saw an EMPTY group and compiled every statement to
+// nothing — with no error.
+//
+// The `node <id> priority <p>` case is the severe one: it is the redundancy-
+// group election priority. Dropped, the operator sets a priority, sees it
+// echoed by `show configuration`, and the cluster elects on defaults — so the
+// WRONG NODE can hold the group, a superset of "the group never demotes".
+//
+// FAIL-ON-REVERT: change redundancyGroupBody back to rgNode.Children and every
+// Packed subtest below fails with an assertion naming the lost statement.
+func TestChassisRedundancyGroupPackedBody_6588(t *testing.T) {
+	t.Run("InterfaceMonitor", func(t *testing.T) {
+		rg := compileRGText(t, packedRGConfig(
+			"        redundancy-group 1 interface-monitor ge-0/0/0 weight 255;"))
+		if len(rg.InterfaceMonitors) != 1 {
+			t.Fatalf("packed redundancy-group body lost `interface-monitor ge-0/0/0 weight 255`: "+
+				"got %d monitors (%s)", len(rg.InterfaceMonitors), describeMonitors(rg.InterfaceMonitors))
+		}
+		if rg.InterfaceMonitors[0].Interface != "ge-0/0/0" || rg.InterfaceMonitors[0].Weight != 255 {
+			t.Fatalf("monitor = %s, want ge-0/0/0 weight 255", describeMonitors(rg.InterfaceMonitors))
+		}
+	})
+
+	t.Run("NodePriority", func(t *testing.T) {
+		rg := compileRGText(t, packedRGConfig(
+			"        redundancy-group 1 node 0 priority 200;"))
+		if got, ok := rg.NodePriorities[0]; !ok || got != 200 {
+			t.Fatalf("packed redundancy-group body lost `node 0 priority 200`: NodePriorities = %v — "+
+				"a dropped election priority means the cluster elects on defaults and the WRONG "+
+				"node can hold the group", rg.NodePriorities)
+		}
+	})
+
+	t.Run("Preempt", func(t *testing.T) {
+		rg := compileRGText(t, packedRGConfig("        redundancy-group 1 preempt;"))
+		if !rg.Preempt {
+			t.Fatal("packed redundancy-group body lost `preempt`: Preempt = false")
+		}
+	})
+
+	t.Run("StrictVIPOwnership", func(t *testing.T) {
+		rg := compileRGText(t, packedRGConfig("        redundancy-group 1 strict-vip-ownership;"))
+		if !rg.StrictVIPOwnership {
+			t.Fatal("packed redundancy-group body lost `strict-vip-ownership`")
+		}
+	})
+
+	t.Run("GratuitousARPCount", func(t *testing.T) {
+		rg := compileRGText(t, packedRGConfig("        redundancy-group 1 gratuitous-arp-count 8;"))
+		if rg.GratuitousARPCount != 8 {
+			t.Fatalf("packed redundancy-group body lost `gratuitous-arp-count 8`: got %d",
+				rg.GratuitousARPCount)
+		}
+	})
+
+	t.Run("IPMonitoring", func(t *testing.T) {
+		rg := compileRGText(t, packedRGConfig(
+			"        redundancy-group 1 ip-monitoring global-weight 255;"))
+		if rg.IPMonitoring == nil {
+			t.Fatal("packed redundancy-group body lost `ip-monitoring global-weight 255`: IPMonitoring is nil")
+		}
+		if rg.IPMonitoring.GlobalWeight != 255 {
+			t.Fatalf("global-weight = %d, want 255", rg.IPMonitoring.GlobalWeight)
+		}
+	})
+
+	// Several statements on one instance line must each survive — the tail is
+	// split at redundancy-group statement keywords, not folded into the first.
+	t.Run("MultipleStatementsOnOneLine", func(t *testing.T) {
+		rg := compileRGText(t, packedRGConfig(
+			"        redundancy-group 1 node 0 priority 200 preempt gratuitous-arp-count 8;"))
+		if got, ok := rg.NodePriorities[0]; !ok || got != 200 {
+			t.Fatalf("lost `node 0 priority 200` from a multi-statement packed body: %v", rg.NodePriorities)
+		}
+		if !rg.Preempt {
+			t.Fatal("lost `preempt` from a multi-statement packed body")
+		}
+		if rg.GratuitousARPCount != 8 {
+			t.Fatalf("lost `gratuitous-arp-count 8` from a multi-statement packed body: got %d",
+				rg.GratuitousARPCount)
+		}
+	})
+}
+
+// TestChassisRedundancyGroupContainerBodyUnchanged_6588 is the round-3 negative
+// control: the already-working container form must compile exactly as before,
+// every statement intact. It passes with and without redundancyGroupBody.
+func TestChassisRedundancyGroupContainerBodyUnchanged_6588(t *testing.T) {
+	rg := compileRGText(t, packedRGConfig(
+		"        redundancy-group 1 {\n"+
+			"            node 0 priority 200;\n"+
+			"            node 1 priority 100;\n"+
+			"            preempt;\n"+
+			"            strict-vip-ownership;\n"+
+			"            gratuitous-arp-count 8;\n"+
+			"            interface-monitor ge-0/0/0 weight 255;\n"+
+			"            ip-monitoring {\n"+
+			"                global-weight 200;\n"+
+			"                family inet {\n"+
+			"                    10.0.1.1 weight 100;\n"+
+			"                }\n"+
+			"            }\n"+
+			"        }"))
+	if rg.NodePriorities[0] != 200 || rg.NodePriorities[1] != 100 {
+		t.Fatalf("NodePriorities = %v, want {0:200, 1:100}", rg.NodePriorities)
+	}
+	if !rg.Preempt || !rg.StrictVIPOwnership {
+		t.Fatalf("preempt=%v strict-vip-ownership=%v, want both true", rg.Preempt, rg.StrictVIPOwnership)
+	}
+	if rg.GratuitousARPCount != 8 {
+		t.Fatalf("gratuitous-arp-count = %d, want 8", rg.GratuitousARPCount)
+	}
+	if len(rg.InterfaceMonitors) != 1 || rg.InterfaceMonitors[0].Weight != 255 {
+		t.Fatalf("monitors = %s, want one ge-0/0/0 weight 255", describeMonitors(rg.InterfaceMonitors))
+	}
+	if rg.IPMonitoring == nil || rg.IPMonitoring.GlobalWeight != 200 ||
+		len(rg.IPMonitoring.Targets) != 1 || rg.IPMonitoring.Targets[0].Weight != 100 {
+		t.Fatalf("ip-monitoring = %+v, want global-weight 200 with one target weight 100", rg.IPMonitoring)
+	}
+}
+
+// TestChassisRedundancyGroupPackedBodyReachesGates_6588 pins that the round-2
+// gates see the one-level-up packed shape too. Making the body compile without
+// bringing the gates along would admit, through the packed instance line
+// only, exactly what round 2 closed everywhere else.
+func TestChassisRedundancyGroupPackedBodyReachesGates_6588(t *testing.T) {
+	t.Run("MalformedWeightStillRejected", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedRGConfig(
+			"        redundancy-group 1 interface-monitor ge-0/0/0 weight nope;")),
+			`weight "nope" is not an integer`)
+	})
+	t.Run("OutOfRangeWeightStillRejected", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedRGConfig(
+			"        redundancy-group 1 interface-monitor ge-0/0/0 weight 300;")),
+			"weight 300 is out of range 0..255")
+	})
+	t.Run("DuplicateWeightStillRejected", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedRGConfig(
+			"        redundancy-group 1 interface-monitor ge-0/0/0 weight 100 weight 200;")),
+			"weight specified 2 times with different values")
+	})
+	t.Run("BracketListStillSplits", func(t *testing.T) {
+		assertMonitorNames(t, compileRGText(t, packedRGConfig(
+			"        redundancy-group 1 interface-monitor [ ge-0/0/0 ge-0/0/1 ];")),
+			[]string{"ge-0/0/0", "ge-0/0/1"})
+	})
+	t.Run("IPMonitoringRangeStillGated", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedRGConfig(
+			"        redundancy-group 1 ip-monitoring global-weight 300;")),
+			"global-weight 300 is out of range 0..255")
+	})
+	// #5694 identity gate: a malformed RG-scoped node id must still be caught
+	// when the whole body is packed onto the instance line.
+	t.Run("MalformedNodeIDStillRejected", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedRGConfig(
+			"        redundancy-group 1 node bogus priority 200;")),
+			"redundancy-group node")
+	})
+}

--- a/pkg/config/compiler_chassis_packed_monitor_6588_test.go
+++ b/pkg/config/compiler_chassis_packed_monitor_6588_test.go
@@ -327,3 +327,365 @@ func TestChassisIPMonitoringFullyPacked_6588(t *testing.T) {
 		}
 	})
 }
+
+// ---------------------------------------------------------------------------
+// #6588 review round 2 — three MAJORs found inside the code this PR touched.
+// ---------------------------------------------------------------------------
+
+// compileMonitorTextErr is compileMonitorText's counterpart for configs that
+// must be REJECTED at strict commit.
+func compileMonitorTextErr(t *testing.T, text string) error {
+	t.Helper()
+	p := NewParser(text)
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	_, err := CompileConfig(tree)
+	return err
+}
+
+func flatMonitorTree(t *testing.T, extra ...string) *ConfigTree {
+	t.Helper()
+	return buildTree(t, append([]string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster authentication-key test-cluster-psk-6588",
+		"set chassis cluster redundancy-group 1 node 0 priority 200",
+	}, extra...))
+}
+
+// MAJOR 1 -------------------------------------------------------------------
+
+// TestChassisIPMonitoringWeightRangeGated_6588 pins that the ip-monitoring
+// weights are range-gated in ALL THREE spellings.
+//
+// #6549 deliberately left these to their typed schema leaves
+// (ValidateInteger(0,255)) instead of the compiled-int gate it added for
+// interface-monitor. That was sound while the packed spelling compiled to
+// nothing — but SchemaValidate walks the AST from setSchema and a packed
+// statement sits BELOW the depth it reaches (pinned by
+// TestChassisPackedShapeBypassesSchemaWalk_6588), so once #6588 made the packed
+// shape compile, an out-of-range packed weight would have reached the runtime
+// with no commit-side gate on any path. The gate now lives on the compiled int
+// beside its interface-monitor sibling, which is the only layer all three
+// spellings pass through.
+func TestChassisIPMonitoringWeightRangeGated_6588(t *testing.T) {
+	for _, bad := range []struct {
+		what  string
+		want  string
+		flat  string
+		cont  string
+		packd string
+	}{
+		{
+			what: "global-weight", want: "global-weight 300 is out of range 0..255",
+			flat: "set chassis cluster redundancy-group 1 ip-monitoring global-weight 300",
+			cont: "            ip-monitoring {\n                global-weight 300;\n            }",
+			packd: "            ip-monitoring global-weight 300;",
+		},
+		{
+			what: "global-threshold", want: "global-threshold 256 is out of range 0..255",
+			flat: "set chassis cluster redundancy-group 1 ip-monitoring global-threshold 256",
+			cont: "            ip-monitoring {\n                global-threshold 256;\n            }",
+			packd: "            ip-monitoring global-threshold 256;",
+		},
+		{
+			what: "target weight", want: "family inet 10.0.1.1 weight -100 is out of range 0..255",
+			flat: "set chassis cluster redundancy-group 1 ip-monitoring family inet 10.0.1.1 weight -100",
+			cont: "            ip-monitoring {\n                family {\n                    inet {\n                        10.0.1.1 weight -100;\n                    }\n                }\n            }",
+			packd: "            ip-monitoring family inet 10.0.1.1 weight -100;",
+		},
+	} {
+		t.Run(bad.what+"/FlatSet", func(t *testing.T) {
+			_, err := CompileConfig(flatMonitorTree(t, bad.flat))
+			assertErrContains(t, err, bad.want)
+		})
+		t.Run(bad.what+"/ContainerHierarchical", func(t *testing.T) {
+			assertErrContains(t, compileMonitorTextErr(t, packedMonitorConfig(bad.cont)), bad.want)
+		})
+		t.Run(bad.what+"/Packed", func(t *testing.T) {
+			assertErrContains(t, compileMonitorTextErr(t, packedMonitorConfig(bad.packd)), bad.want)
+		})
+	}
+}
+
+// TestChassisIPMonitoringInRangeStillCommits_6588 is the MAJOR-1 negative
+// control: every legal ip-monitoring value, including both boundaries, must
+// still commit AND compile verbatim. It passes with and without the gate.
+func TestChassisIPMonitoringInRangeStillCommits_6588(t *testing.T) {
+	for _, w := range []int{0, 1, 128, 254, 255} {
+		t.Run(fmt.Sprintf("weight_%d", w), func(t *testing.T) {
+			rg := compileMonitorText(t, packedMonitorConfig(fmt.Sprintf(
+				"            ip-monitoring {\n"+
+					"                global-weight %d;\n"+
+					"                global-threshold %d;\n"+
+					"                family inet {\n"+
+					"                    10.0.1.1 weight %d;\n"+
+					"                }\n"+
+					"            }", w, w, w)))
+			if rg.IPMonitoring == nil {
+				t.Fatal("redundancy group carries no compiled ip-monitoring")
+			}
+			if rg.IPMonitoring.GlobalWeight != w || rg.IPMonitoring.GlobalThreshold != w {
+				t.Fatalf("global-weight/threshold = %d/%d, want %d/%d (the gate must not alter an in-range value)",
+					rg.IPMonitoring.GlobalWeight, rg.IPMonitoring.GlobalThreshold, w, w)
+			}
+			if len(rg.IPMonitoring.Targets) != 1 || rg.IPMonitoring.Targets[0].Weight != w {
+				t.Fatalf("targets = %+v, want one target with weight %d", rg.IPMonitoring.Targets, w)
+			}
+		})
+	}
+}
+
+// TestChassisPackedShapeBypassesSchemaWalk_6588 is the load-bearing evidence
+// for WHERE the MAJOR-1 gate had to go: the typed-leaf gate cannot see a packed
+// statement, so a schema validator can never cover it. SchemaValidate accepts
+// an ip-monitoring weight the compiled-int gate rejects.
+func TestChassisPackedShapeBypassesSchemaWalk_6588(t *testing.T) {
+	p := NewParser(packedMonitorConfig("            ip-monitoring family inet 10.0.1.1 weight -100;"))
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	if err := SchemaValidate(tree, nil); err != nil {
+		t.Fatalf("SchemaValidate unexpectedly saw the packed statement (%v) — if the typed "+
+			"leaf now reaches it, the compiled-int gate's rationale needs revisiting", err)
+	}
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("the compiled-int gate must reject what SchemaValidate cannot see")
+	}
+}
+
+// MAJOR 2 -------------------------------------------------------------------
+
+// TestChassisInterfaceMonitorBracketList_6588 pins the #2419 bracketed-list
+// collapse for monitors. The lexer strips `[`/`]`, so
+// `interface-monitor [ ge-0/0/0 ge-0/0/1 ge-0/0/2 ]` lands as N names on ONE
+// node's Keys in EVERY spelling. Compiling only the first name is the same
+// failover fail-open as dropping the statement, one monitor at a time.
+func TestChassisInterfaceMonitorBracketList_6588(t *testing.T) {
+	want := []string{"ge-0/0/0", "ge-0/0/1", "ge-0/0/2"}
+
+	t.Run("FlatSet", func(t *testing.T) {
+		cfg, err := CompileConfig(flatMonitorTree(t,
+			"set chassis cluster redundancy-group 1 interface-monitor [ ge-0/0/0 ge-0/0/1 ge-0/0/2 ]"))
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		assertMonitorNames(t, onlyRG6588(t, cfg), want)
+	})
+	t.Run("ContainerHierarchical", func(t *testing.T) {
+		assertMonitorNames(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor {\n                [ ge-0/0/0 ge-0/0/1 ge-0/0/2 ];\n            }")), want)
+	})
+	t.Run("Packed", func(t *testing.T) {
+		assertMonitorNames(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor [ ge-0/0/0 ge-0/0/1 ge-0/0/2 ];")), want)
+	})
+	// A weight-less bracketed list must still yield one monitor per name.
+	t.Run("PackedNoWeight", func(t *testing.T) {
+		assertMonitorNames(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor [ ge-0/0/0 ge-0/0/1 ];")), []string{"ge-0/0/0", "ge-0/0/1"})
+	})
+}
+
+// TestChassisIPMonitoringBracketTargets_6588 covers the same collapse on the
+// ip-monitoring target list.
+func TestChassisIPMonitoringBracketTargets_6588(t *testing.T) {
+	rg := compileMonitorText(t, packedMonitorConfig(
+		"            ip-monitoring family inet [ 10.0.1.1 10.0.2.1 10.0.3.1 ];"))
+	if rg.IPMonitoring == nil {
+		t.Fatal("redundancy group carries no compiled ip-monitoring")
+	}
+	var got []string
+	for _, tg := range rg.IPMonitoring.Targets {
+		got = append(got, tg.Address)
+	}
+	want := []string{"10.0.1.1", "10.0.2.1", "10.0.3.1"}
+	if len(got) != len(want) {
+		t.Fatalf("ip-monitoring targets = %v, want %v — a bracketed list must compile to one "+
+			"target per address", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ip-monitoring targets = %v, want %v", got, want)
+		}
+	}
+}
+
+// TestChassisInterfaceMonitorSingleEntryNotSplit_6588 is the MAJOR-2 negative
+// control the review asked for: a single NON-bracketed packed monitor must
+// still compile to exactly ONE entry, with its weight intact. The splitter must
+// not shred `ge-0/0/0 weight 255` into an entry per token. Passes with and
+// without the split.
+func TestChassisInterfaceMonitorSingleEntryNotSplit_6588(t *testing.T) {
+	t.Run("PackedWithWeight", func(t *testing.T) {
+		assertSingleMonitor(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor ge-0/0/0 weight 255;")), "ge-0/0/0", 255)
+	})
+	t.Run("ContainerWithWeight", func(t *testing.T) {
+		assertSingleMonitor(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor {\n                ge-0/0/0 weight 255;\n            }")), "ge-0/0/0", 255)
+	})
+	t.Run("PackedNestedWeightBlock", func(t *testing.T) {
+		assertSingleMonitor(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor ge-0/0/0 {\n                weight 255;\n            }")), "ge-0/0/0", 255)
+	})
+	t.Run("FlatSetWithWeight", func(t *testing.T) {
+		cfg, err := CompileConfig(flatMonitorTree(t,
+			"set chassis cluster redundancy-group 1 interface-monitor ge-0/0/0 weight 255"))
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		assertSingleMonitor(t, onlyRG6588(t, cfg), "ge-0/0/0", 255)
+	})
+	t.Run("SingleIPMonitorTarget", func(t *testing.T) {
+		rg := compileMonitorText(t, packedMonitorConfig(
+			"            ip-monitoring family inet 10.0.1.1 weight 100;"))
+		if rg.IPMonitoring == nil || len(rg.IPMonitoring.Targets) != 1 {
+			t.Fatalf("expected exactly 1 ip-monitoring target, got %+v", rg.IPMonitoring)
+		}
+		if got := rg.IPMonitoring.Targets[0]; got.Address != "10.0.1.1" || got.Weight != 100 {
+			t.Fatalf("target = %s weight %d, want 10.0.1.1 weight 100", got.Address, got.Weight)
+		}
+	})
+}
+
+// MAJOR 4 -------------------------------------------------------------------
+
+// TestChassisMonitorWeightMalformedRejected_6588 pins that a weight which is
+// PRESENT but not an integer is rejected at commit in every spelling. Before
+// the gate it compiled to the 0 default: the operator configured link tracking,
+// commit succeeded, and the monitor going down deducted NOTHING — the same
+// silent-nothing class as the packed-statement drop this PR fixes. The compiled
+// struct cannot express it (a failed Atoi is indistinguishable from `weight 0`),
+// so the check runs on the AST.
+func TestChassisMonitorWeightMalformedRejected_6588(t *testing.T) {
+	const want = `weight "nope" is not an integer`
+
+	t.Run("InterfaceMonitor/FlatSet", func(t *testing.T) {
+		_, err := CompileConfig(flatMonitorTree(t,
+			"set chassis cluster redundancy-group 1 interface-monitor ge-0/0/0 weight nope"))
+		assertErrContains(t, err, want)
+	})
+	t.Run("InterfaceMonitor/ContainerHierarchical", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedMonitorConfig(
+			"            interface-monitor {\n                ge-0/0/0 weight nope;\n            }")), want)
+	})
+	t.Run("InterfaceMonitor/Packed", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedMonitorConfig(
+			"            interface-monitor ge-0/0/0 weight nope;")), want)
+	})
+	t.Run("InterfaceMonitor/PackedNestedWeightBlock", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedMonitorConfig(
+			"            interface-monitor ge-0/0/0 {\n                weight nope;\n            }")), want)
+	})
+	t.Run("InterfaceMonitor/WeightWithNoValue", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedMonitorConfig(
+			"            interface-monitor ge-0/0/0 weight;")), `weight "" is not an integer`)
+	})
+	t.Run("IPMonitoringTarget/Packed", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedMonitorConfig(
+			"            ip-monitoring family inet 10.0.1.1 weight nope;")), want)
+	})
+	t.Run("IPMonitoringTarget/ContainerHierarchical", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedMonitorConfig(
+			"            ip-monitoring {\n                family inet {\n                    10.0.1.1 weight nope;\n                }\n            }")), want)
+	})
+}
+
+// TestChassisMonitorWeightMalformedTolerantNoBrick_6588 pins the #1960 posture:
+// an already-persisted or peer-synced config carrying a malformed weight must
+// still BOOT, with a warning.
+func TestChassisMonitorWeightMalformedTolerantNoBrick_6588(t *testing.T) {
+	p := NewParser(packedMonitorConfig("            interface-monitor ge-0/0/0 weight nope;"))
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile must not reject a malformed monitor weight (no-brick), got %v", err)
+	}
+	if !warningsContain(cfg.Warnings, `weight "nope" is not an integer`) {
+		t.Fatalf("lenient compile should have warned; warnings=%v", cfg.Warnings)
+	}
+	// The monitor itself still compiles, with the documented 0 default.
+	assertSingleMonitor(t, onlyRG6588(t, cfg), "ge-0/0/0", 0)
+}
+
+// TestChassisMonitorWeightValidStillCommits_6588 is the MAJOR-4 negative
+// control: a well-formed weight — and a monitor with no weight at all, the
+// documented 0 default from #6549 — must still commit. Passes with and without
+// the gate.
+func TestChassisMonitorWeightValidStillCommits_6588(t *testing.T) {
+	for _, w := range []int{0, 1, 128, 255} {
+		t.Run(fmt.Sprintf("weight_%d", w), func(t *testing.T) {
+			assertSingleMonitor(t, compileMonitorText(t, packedMonitorConfig(fmt.Sprintf(
+				"            interface-monitor ge-0/0/0 weight %d;", w))), "ge-0/0/0", w)
+		})
+	}
+	t.Run("NoWeightAtAll", func(t *testing.T) {
+		assertSingleMonitor(t, compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor ge-0/0/0;")), "ge-0/0/0", 0)
+	})
+}
+
+// Duplicates ----------------------------------------------------------------
+
+// TestChassisMonitorWeightDuplicateRejected_6588 pins that a duplicate weight
+// is rejected rather than resolved differently per spelling. Before the gate,
+// `weight 100 weight 200` inline compiled to 200 (the inline scan overwrote)
+// while `{ weight 100; weight 200; }` compiled to 100 (FindChild returns the
+// first) — the answer depended on how the operator happened to write it.
+func TestChassisMonitorWeightDuplicateRejected_6588(t *testing.T) {
+	const want = "weight specified 2 times with different values"
+
+	t.Run("InlineTail", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedMonitorConfig(
+			"            interface-monitor ge-0/0/0 weight 100 weight 200;")), want)
+	})
+	t.Run("NestedBlock", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedMonitorConfig(
+			"            interface-monitor ge-0/0/0 {\n                weight 100;\n                weight 200;\n            }")), want)
+	})
+	t.Run("InlineAndNested", func(t *testing.T) {
+		assertErrContains(t, compileMonitorTextErr(t, packedMonitorConfig(
+			"            interface-monitor ge-0/0/0 weight 100 {\n                weight 200;\n            }")), want)
+	})
+	t.Run("IdenticalRepeat", func(t *testing.T) {
+		// Same value twice is still ambiguous authoring, but the message must
+		// not claim a value conflict that does not exist.
+		err := compileMonitorTextErr(t, packedMonitorConfig(
+			"            interface-monitor ge-0/0/0 weight 100 weight 100;"))
+		assertErrContains(t, err, "weight specified 2 times")
+		if err != nil && strings.Contains(err.Error(), "different values") {
+			t.Fatalf("error %q claims differing values for an identical repeat", err)
+		}
+	})
+}
+
+func assertErrContains(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected commit to be rejected with %q, got nil error", want)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error %q does not contain %q", err, want)
+	}
+}
+
+func assertMonitorNames(t *testing.T, rg *RedundancyGroup, want []string) {
+	t.Helper()
+	if len(rg.InterfaceMonitors) != len(want) {
+		t.Fatalf("expected %d interface-monitors %v, got %d: %s — a bracketed list must "+
+			"compile to one monitor per name, not one monitor for the first name",
+			len(want), want, len(rg.InterfaceMonitors), describeMonitors(rg.InterfaceMonitors))
+	}
+	for i, w := range want {
+		if rg.InterfaceMonitors[i].Interface != w {
+			t.Fatalf("monitor[%d] = %q, want %q (got %s)",
+				i, rg.InterfaceMonitors[i].Interface, w, describeMonitors(rg.InterfaceMonitors))
+		}
+	}
+}

--- a/pkg/config/compiler_chassis_packed_monitor_6588_test.go
+++ b/pkg/config/compiler_chassis_packed_monitor_6588_test.go
@@ -1,0 +1,329 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// #6588: a chassis-cluster redundancy-group monitor authored in the PACKED
+// hierarchical spelling — one statement directly under `redundancy-group`, no
+// nested block — compiled to NOTHING.
+//
+//	redundancy-group 1 {
+//	    interface-monitor ge-0/0/0 weight 255;   <- packed
+//	}
+//
+// The parser produces ONE leaf with Keys=["interface-monitor","ge-0/0/0",
+// "weight","255"] and NO children, while compileChassis enumerated monitors by
+// iterating child.Children only. Result: rgs=1, monitors=0. `commit` succeeded
+// with no error and no warning, so the operator had link tracking configured
+// and a redundancy group that never demoted on link-down — a failover
+// FAIL-OPEN. The same drop hit `ip-monitoring` (packed global-weight /
+// global-threshold, and a packed `family inet <addr> weight <n>` target), which
+// installs demotion debt through the very same election path.
+//
+// This is the chassis-cluster instance of the #2419 / #3843 dual-shape class:
+// a compiler reading a statement that may pack inline MUST read the node's own
+// Keys tail as well as its Children.
+//
+// FAIL-ON-REVERT: restore the `range child.Children` enumeration in
+// compileChassis and every Packed subtest below fails with an assertion naming
+// the missing monitor / target. The Hierarchical and FlatSet subtests are the
+// negative control — they exercise only the shapes that already worked and
+// stay GREEN with and without the fix.
+
+// packedIfMonConfig returns a hierarchical config text whose redundancy group
+// carries rgBody verbatim.
+func packedMonitorConfig(rgBody string) string {
+	return `chassis {
+    cluster {
+        authentication-key test-cluster-psk-6588;
+        cluster-id 1;
+        redundancy-group 1 {
+            node 0 priority 200;
+` + rgBody + `
+        }
+    }
+}`
+}
+
+// compileMonitorText parses hierarchical config text and returns the single
+// compiled redundancy group.
+func compileMonitorText(t *testing.T, text string) *RedundancyGroup {
+	t.Helper()
+	p := NewParser(text)
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return onlyRG6588(t, cfg)
+}
+
+func onlyRG6588(t *testing.T, cfg *Config) *RedundancyGroup {
+	t.Helper()
+	if cfg == nil || cfg.Chassis.Cluster == nil {
+		t.Fatal("compiled config carries no chassis cluster")
+	}
+	rgs := cfg.Chassis.Cluster.RedundancyGroups
+	if len(rgs) != 1 {
+		t.Fatalf("expected 1 redundancy-group, got %d", len(rgs))
+	}
+	return rgs[0]
+}
+
+func describeMonitors(mons []*InterfaceMonitor) string {
+	if len(mons) == 0 {
+		return "<none>"
+	}
+	parts := make([]string, 0, len(mons))
+	for _, m := range mons {
+		parts = append(parts, fmt.Sprintf("%s weight %d", m.Interface, m.Weight))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// TestChassisInterfaceMonitorAllThreeSpellings_6588 pins that the flat-set,
+// container-hierarchical and packed-hierarchical spellings of the SAME
+// interface-monitor all compile to the SAME typed monitor.
+func TestChassisInterfaceMonitorAllThreeSpellings_6588(t *testing.T) {
+	// Negative control: the two shapes that already worked before the fix.
+	t.Run("FlatSet", func(t *testing.T) {
+		tree := buildTree(t, []string{
+			"set chassis cluster cluster-id 1",
+			"set chassis cluster authentication-key test-cluster-psk-6588",
+			"set chassis cluster redundancy-group 1 node 0 priority 200",
+			"set chassis cluster redundancy-group 1 interface-monitor ge-0/0/0 weight 255",
+		})
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		assertSingleMonitor(t, onlyRG6588(t, cfg), "ge-0/0/0", 255)
+	})
+	t.Run("ContainerHierarchical", func(t *testing.T) {
+		rg := compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor {\n                ge-0/0/0 weight 255;\n            }"))
+		assertSingleMonitor(t, rg, "ge-0/0/0", 255)
+	})
+
+	// The #6588 defect: the packed one-liner.
+	t.Run("Packed", func(t *testing.T) {
+		rg := compileMonitorText(t, packedMonitorConfig(
+			"            interface-monitor ge-0/0/0 weight 255;"))
+		assertSingleMonitor(t, rg, "ge-0/0/0", 255)
+	})
+}
+
+func assertSingleMonitor(t *testing.T, rg *RedundancyGroup, iface string, weight int) {
+	t.Helper()
+	if len(rg.InterfaceMonitors) != 1 {
+		t.Fatalf("expected exactly 1 interface-monitor (%s weight %d), got %d: %s — "+
+			"a redundancy group with zero compiled monitors never demotes on link-down",
+			iface, weight, len(rg.InterfaceMonitors), describeMonitors(rg.InterfaceMonitors))
+	}
+	m := rg.InterfaceMonitors[0]
+	if m.Interface != iface || m.Weight != weight {
+		t.Fatalf("monitor = %s weight %d, want %s weight %d",
+			m.Interface, m.Weight, iface, weight)
+	}
+}
+
+// TestChassisInterfaceMonitorPackedMultiple_6588 pins that several packed
+// one-liners under the same redundancy group each produce their own monitor —
+// the shape a hand-written config uses for a multi-link group.
+func TestChassisInterfaceMonitorPackedMultiple_6588(t *testing.T) {
+	rg := compileMonitorText(t, packedMonitorConfig(
+		"            interface-monitor ge-0/0/0 weight 255;\n"+
+			"            interface-monitor ge-0/0/1 weight 100;"))
+	if len(rg.InterfaceMonitors) != 2 {
+		t.Fatalf("expected 2 interface-monitors, got %d: %s",
+			len(rg.InterfaceMonitors), describeMonitors(rg.InterfaceMonitors))
+	}
+	want := map[string]int{"ge-0/0/0": 255, "ge-0/0/1": 100}
+	for _, m := range rg.InterfaceMonitors {
+		w, ok := want[m.Interface]
+		if !ok {
+			t.Fatalf("unexpected monitor %s in %s", m.Interface, describeMonitors(rg.InterfaceMonitors))
+		}
+		if m.Weight != w {
+			t.Fatalf("monitor %s weight = %d, want %d", m.Interface, m.Weight, w)
+		}
+		delete(want, m.Interface)
+	}
+	if len(want) != 0 {
+		t.Fatalf("monitors missing from the compiled group: %v (got %s)",
+			want, describeMonitors(rg.InterfaceMonitors))
+	}
+}
+
+// TestChassisInterfaceMonitorPackedNoWeight_6588 pins the weight-less packed
+// spelling: it must still produce a monitor (with the pre-existing 0 default),
+// not vanish.
+func TestChassisInterfaceMonitorPackedNoWeight_6588(t *testing.T) {
+	rg := compileMonitorText(t, packedMonitorConfig(
+		"            interface-monitor ge-0/0/0;"))
+	assertSingleMonitor(t, rg, "ge-0/0/0", 0)
+}
+
+// TestChassisInterfaceMonitorPackedNestedWeight_6588 pins the packed instance
+// with a nested weight block — `interface-monitor ge-0/0/0 { weight 255; }`.
+// The interface name packs onto the statement keys while the weight arrives as
+// a child, so both halves must be read.
+func TestChassisInterfaceMonitorPackedNestedWeight_6588(t *testing.T) {
+	rg := compileMonitorText(t, packedMonitorConfig(
+		"            interface-monitor ge-0/0/0 {\n                weight 255;\n            }"))
+	assertSingleMonitor(t, rg, "ge-0/0/0", 255)
+}
+
+// TestChassisInterfaceMonitorPackedWeightRangeGated_6588 pins the issue's
+// second-order consequence: because the packed shape compiled to zero
+// monitors, the #6549 weight range gate — which runs on the COMPILED int —
+// never saw a packed weight, so an out-of-range one was accepted at commit.
+// Now that the packed shape compiles, the existing gate covers it for free.
+func TestChassisInterfaceMonitorPackedWeightRangeGated_6588(t *testing.T) {
+	for _, weight := range []int{-100, -1, 256, 1000} {
+		t.Run(fmt.Sprintf("weight_%d", weight), func(t *testing.T) {
+			text := packedMonitorConfig(fmt.Sprintf(
+				"            interface-monitor ge-0/0/0 weight %d;", weight))
+			p := NewParser(text)
+			tree, perrs := p.Parse()
+			if len(perrs) > 0 {
+				t.Fatalf("parse: %v", perrs)
+			}
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("expected commit to reject the packed out-of-range "+
+					"interface-monitor weight %d (#6549 gates the compiled int), got nil error",
+					weight)
+			}
+			if !strings.Contains(err.Error(), "interface-monitor ge-0/0/0") {
+				t.Fatalf("error %q does not name the offending interface-monitor", err)
+			}
+			if !strings.Contains(err.Error(), "out of range 0..255") {
+				t.Fatalf("error %q does not state the admitted range", err)
+			}
+		})
+	}
+}
+
+// TestChassisIPMonitoringPackedShapes_6588 covers the sibling site: the same
+// Children-only enumeration dropped a packed `ip-monitoring` statement and a
+// packed `family inet <addr> weight <n>` target. ip-monitoring installs
+// redundancy-group demotion debt through the same election path as
+// interface-monitor, so the fail-open is identical in kind.
+func TestChassisIPMonitoringPackedShapes_6588(t *testing.T) {
+	tests := []struct {
+		name       string
+		rgBody     string
+		wantWeight int
+		wantThresh int
+		wantAddr   string
+		wantTgtWgt int
+	}{
+		// Negative control: the fully-hierarchical shapes that already worked.
+		{
+			name: "ControlNestedFamilyBlock",
+			rgBody: "            ip-monitoring {\n" +
+				"                global-weight 255;\n" +
+				"                global-threshold 2;\n" +
+				"                family {\n" +
+				"                    inet {\n" +
+				"                        10.0.1.1 weight 100;\n" +
+				"                    }\n" +
+				"                }\n" +
+				"            }",
+			wantWeight: 255, wantThresh: 2, wantAddr: "10.0.1.1", wantTgtWgt: 100,
+		},
+		{
+			name: "ControlCompoundFamilyBlock",
+			rgBody: "            ip-monitoring {\n" +
+				"                global-weight 255;\n" +
+				"                global-threshold 2;\n" +
+				"                family inet {\n" +
+				"                    10.0.1.1 weight 100;\n" +
+				"                }\n" +
+				"            }",
+			wantWeight: 255, wantThresh: 2, wantAddr: "10.0.1.1", wantTgtWgt: 100,
+		},
+		// #6588: packed spellings.
+		{
+			name: "PackedFamilyLeafInsideBlock",
+			rgBody: "            ip-monitoring {\n" +
+				"                global-weight 255;\n" +
+				"                global-threshold 2;\n" +
+				"                family inet 10.0.1.1 weight 100;\n" +
+				"            }",
+			wantWeight: 255, wantThresh: 2, wantAddr: "10.0.1.1", wantTgtWgt: 100,
+		},
+		{
+			name: "PackedInetLeafInsideFamilyBlock",
+			rgBody: "            ip-monitoring {\n" +
+				"                global-weight 255;\n" +
+				"                global-threshold 2;\n" +
+				"                family {\n" +
+				"                    inet 10.0.1.1 weight 100;\n" +
+				"                }\n" +
+				"            }",
+			wantWeight: 255, wantThresh: 2, wantAddr: "10.0.1.1", wantTgtWgt: 100,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rg := compileMonitorText(t, packedMonitorConfig(tc.rgBody))
+			if rg.IPMonitoring == nil {
+				t.Fatal("redundancy group carries no compiled ip-monitoring — " +
+					"a dropped stanza never demotes the group on probe failure")
+			}
+			if rg.IPMonitoring.GlobalWeight != tc.wantWeight {
+				t.Fatalf("global-weight = %d, want %d", rg.IPMonitoring.GlobalWeight, tc.wantWeight)
+			}
+			if rg.IPMonitoring.GlobalThreshold != tc.wantThresh {
+				t.Fatalf("global-threshold = %d, want %d", rg.IPMonitoring.GlobalThreshold, tc.wantThresh)
+			}
+			if len(rg.IPMonitoring.Targets) != 1 {
+				t.Fatalf("expected exactly 1 ip-monitoring target (%s weight %d), got %d",
+					tc.wantAddr, tc.wantTgtWgt, len(rg.IPMonitoring.Targets))
+			}
+			got := rg.IPMonitoring.Targets[0]
+			if got.Address != tc.wantAddr || got.Weight != tc.wantTgtWgt {
+				t.Fatalf("target = %s weight %d, want %s weight %d",
+					got.Address, got.Weight, tc.wantAddr, tc.wantTgtWgt)
+			}
+		})
+	}
+}
+
+// TestChassisIPMonitoringFullyPacked_6588 covers the one-liner form where the
+// whole ip-monitoring statement packs onto a single line.
+func TestChassisIPMonitoringFullyPacked_6588(t *testing.T) {
+	t.Run("GlobalWeightOnly", func(t *testing.T) {
+		rg := compileMonitorText(t, packedMonitorConfig(
+			"            ip-monitoring global-weight 255;"))
+		if rg.IPMonitoring == nil {
+			t.Fatal("redundancy group carries no compiled ip-monitoring")
+		}
+		if rg.IPMonitoring.GlobalWeight != 255 {
+			t.Fatalf("global-weight = %d, want 255", rg.IPMonitoring.GlobalWeight)
+		}
+	})
+	t.Run("FamilyTargetOnly", func(t *testing.T) {
+		rg := compileMonitorText(t, packedMonitorConfig(
+			"            ip-monitoring family inet 10.0.1.1 weight 100;"))
+		if rg.IPMonitoring == nil {
+			t.Fatal("redundancy group carries no compiled ip-monitoring")
+		}
+		if len(rg.IPMonitoring.Targets) != 1 {
+			t.Fatalf("expected exactly 1 ip-monitoring target, got %d",
+				len(rg.IPMonitoring.Targets))
+		}
+		got := rg.IPMonitoring.Targets[0]
+		if got.Address != "10.0.1.1" || got.Weight != 100 {
+			t.Fatalf("target = %s weight %d, want 10.0.1.1 weight 100", got.Address, got.Weight)
+		}
+	})
+}

--- a/pkg/config/compiler_chassis_packed_monitor_6588_test.go
+++ b/pkg/config/compiler_chassis_packed_monitor_6588_test.go
@@ -2,10 +2,6 @@ package config
 
 import (
 	"fmt"
-	"go/ast"
-	"go/parser"
-	"go/token"
-	"strconv"
 	"strings"
 	"testing"
 )
@@ -383,20 +379,20 @@ func TestChassisIPMonitoringWeightRangeGated_6588(t *testing.T) {
 	}{
 		{
 			what: "global-weight", want: "global-weight 300 is out of range 0..255",
-			flat: "set chassis cluster redundancy-group 1 ip-monitoring global-weight 300",
-			cont: "            ip-monitoring {\n                global-weight 300;\n            }",
+			flat:  "set chassis cluster redundancy-group 1 ip-monitoring global-weight 300",
+			cont:  "            ip-monitoring {\n                global-weight 300;\n            }",
 			packd: "            ip-monitoring global-weight 300;",
 		},
 		{
 			what: "global-threshold", want: "global-threshold 256 is out of range 0..255",
-			flat: "set chassis cluster redundancy-group 1 ip-monitoring global-threshold 256",
-			cont: "            ip-monitoring {\n                global-threshold 256;\n            }",
+			flat:  "set chassis cluster redundancy-group 1 ip-monitoring global-threshold 256",
+			cont:  "            ip-monitoring {\n                global-threshold 256;\n            }",
 			packd: "            ip-monitoring global-threshold 256;",
 		},
 		{
 			what: "target weight", want: "family inet 10.0.1.1 weight -100 is out of range 0..255",
-			flat: "set chassis cluster redundancy-group 1 ip-monitoring family inet 10.0.1.1 weight -100",
-			cont: "            ip-monitoring {\n                family {\n                    inet {\n                        10.0.1.1 weight -100;\n                    }\n                }\n            }",
+			flat:  "set chassis cluster redundancy-group 1 ip-monitoring family inet 10.0.1.1 weight -100",
+			cont:  "            ip-monitoring {\n                family {\n                    inet {\n                        10.0.1.1 weight -100;\n                    }\n                }\n            }",
 			packd: "            ip-monitoring family inet 10.0.1.1 weight -100;",
 		},
 	} {
@@ -919,270 +915,96 @@ func TestChassisRedundancyGroupPackedBodyReachesGates_6588(t *testing.T) {
 	})
 }
 
-// TestRedundancyGroupStatementPredicateCoversCompiler_6588 is a DRIFT GUARD on
-// the hand-written isRedundancyGroupStatement token list.
+// TestRedundancyGroupStatementsSurvivePackedLine_6588 replaces the deleted
+// source-parsing drift guard.
 //
-// redundancyGroupBody splits a packed instance tail at that list. A token
-// missing from it is not a loud failure: the statement's tokens are appended to
-// whichever statement precedes it on the line, so it silently does nothing —
-// the exact class of defect this whole issue is about, with better camouflage.
-// A list that merely LOOKS complete today also drifts the moment someone adds a
-// `case` to compileChassis without touching the predicate.
+// That guard modelled compileChassis's source text — it extracted the `case
+// "..."` literals of one switch — and passed while a 7th statement was still
+// dropped from a packed multi-statement line in three ways: a case on a named
+// CONSTANT rather than a literal, a statement handled by a helper called
+// outside the switch, and a nested switch in a `default:` arm. Both consumers
+// now derive from redundancyGroupStatements, so the drift it was watching for
+// cannot occur and re-asserting it would prove a tautology.
 //
-// So the set is not re-asserted by hand here. It is DERIVED from the compiler
-// itself: this parses compileChassis's own source, extracts every `case "..."`
-// of the switch that dispatches redundancy-group body statements, and requires
-// the predicate to accept each one. Adding an arm without extending the
-// predicate fails this test with the missing token named.
+// What is still worth pinning is the PROPERTY the drift mattered for, and this
+// derives its cases from the table rather than restating them: every registered
+// statement must survive being written on a packed line ALONGSIDE another
+// statement. That is the spelling the fold bug hides in — the same statement
+// ALONE on a line works even when the splitter does not know it, which is what
+// let a developer see it work and ship the bug.
 //
-// If the parse cannot find the switch the test FAILS rather than silently
-// passing on an empty set — a guard that can quietly verify nothing is worse
-// than no guard.
-func TestRedundancyGroupStatementPredicateCoversCompiler_6588(t *testing.T) {
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "compiler_system.go", nil, 0)
-	if err != nil {
-		t.Fatalf("parse compiler_system.go: %v", err)
+// Because the cases come from the table, a statement added later is covered the
+// moment it is registered, with no list here to update.
+func TestRedundancyGroupStatementsSurvivePackedLine_6588(t *testing.T) {
+	if len(redundancyGroupStatements) < 6 {
+		t.Fatalf("redundancyGroupStatements has %d entries, expected at least the 6 known "+
+			"statements — this test derives its cases from that table and would otherwise "+
+			"verify almost nothing", len(redundancyGroupStatements))
 	}
 
-	var fn *ast.FuncDecl
-	for _, d := range file.Decls {
-		if f, ok := d.(*ast.FuncDecl); ok && f.Name.Name == "compileChassis" {
-			fn = f
-			break
-		}
-	}
-	if fn == nil {
-		t.Fatal("compileChassis not found in compiler_system.go — this guard cannot verify " +
-			"the statement list; fix the guard rather than deleting it")
+	// One well-formed instance of each statement, keyed by table entry. A new
+	// table entry with no sample here fails the completeness check below rather
+	// than being skipped silently.
+	samples := map[string]struct {
+		text   string
+		assert func(t *testing.T, rg *RedundancyGroup)
+	}{
+		"node": {"node 0 priority 200", func(t *testing.T, rg *RedundancyGroup) {
+			if got, ok := rg.NodePriorities[0]; !ok || got != 200 {
+				t.Fatalf("node priority lost: %v", rg.NodePriorities)
+			}
+		}},
+		"gratuitous-arp-count": {"gratuitous-arp-count 8", func(t *testing.T, rg *RedundancyGroup) {
+			if rg.GratuitousARPCount != 8 {
+				t.Fatalf("gratuitous-arp-count = %d, want 8", rg.GratuitousARPCount)
+			}
+		}},
+		"preempt": {"preempt", func(t *testing.T, rg *RedundancyGroup) {
+			if !rg.Preempt {
+				t.Fatal("preempt lost")
+			}
+		}},
+		"strict-vip-ownership": {"strict-vip-ownership", func(t *testing.T, rg *RedundancyGroup) {
+			if !rg.StrictVIPOwnership {
+				t.Fatal("strict-vip-ownership lost")
+			}
+		}},
+		"interface-monitor": {"interface-monitor ge-0/0/0 weight 255", func(t *testing.T, rg *RedundancyGroup) {
+			if len(rg.InterfaceMonitors) != 1 || rg.InterfaceMonitors[0].Weight != 255 {
+				t.Fatalf("interface-monitor lost: %s", describeMonitors(rg.InterfaceMonitors))
+			}
+		}},
+		"ip-monitoring": {"ip-monitoring global-weight 255", func(t *testing.T, rg *RedundancyGroup) {
+			if rg.IPMonitoring == nil || rg.IPMonitoring.GlobalWeight != 255 {
+				t.Fatalf("ip-monitoring lost: %+v", rg.IPMonitoring)
+			}
+		}},
 	}
 
-	// Find the switch whose tag is `child.Name()` — the redundancy-group body
-	// dispatch. Keyed on the tag rather than on position so reordering the
-	// function does not silently blind the guard.
-	var arms []string
-	ast.Inspect(fn, func(n ast.Node) bool {
-		sw, ok := n.(*ast.SwitchStmt)
-		if !ok || sw.Tag == nil {
-			return true
+	for stmt := range redundancyGroupStatements {
+		if _, ok := samples[stmt]; !ok {
+			t.Errorf("redundancyGroupStatements registers %q but this test has no sample for "+
+				"it, so its packed-line behaviour is unverified — add one", stmt)
 		}
-		call, ok := sw.Tag.(*ast.CallExpr)
-		if !ok {
-			return true
+	}
+
+	// Pair every statement with a DIFFERENT one on the same packed line, in both
+	// orders. A statement the splitter does not know folds into its neighbour,
+	// and only the multi-statement spelling exposes that.
+	for a, sa := range samples {
+		if _, ok := redundancyGroupStatements[a]; !ok {
+			continue
 		}
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || sel.Sel.Name != "Name" {
-			return true
-		}
-		if ident, ok := sel.X.(*ast.Ident); !ok || ident.Name != "child" {
-			return true
-		}
-		for _, stmt := range sw.Body.List {
-			cc, ok := stmt.(*ast.CaseClause)
-			if !ok {
+		for b, sb := range samples {
+			if b == a {
 				continue
 			}
-			for _, e := range cc.List {
-				lit, ok := e.(*ast.BasicLit)
-				if !ok || lit.Kind != token.STRING {
-					continue
-				}
-				v, err := strconv.Unquote(lit.Value)
-				if err != nil {
-					t.Fatalf("unquote case literal %s: %v", lit.Value, err)
-				}
-				arms = append(arms, v)
-			}
-		}
-		return false
-	})
-
-	if len(arms) == 0 {
-		t.Fatal("found no `case \"...\"` arms on compileChassis's `switch child.Name()` — " +
-			"the guard has lost track of the compiler and is verifying nothing; fix it")
-	}
-	// Sanity floor: the arms known at the time this guard was written. Guards
-	// against the Inspect above latching onto some other, smaller switch.
-	if len(arms) < 6 {
-		t.Fatalf("found only %d redundancy-group statement arms %v — expected at least the 6 "+
-			"known ones; the guard is probably reading the wrong switch", len(arms), arms)
-	}
-
-	for _, arm := range arms {
-		if !isRedundancyGroupStatement(arm) {
-			t.Errorf("compileChassis handles redundancy-group statement %q but "+
-				"isRedundancyGroupStatement does not list it — a packed instance line carrying "+
-				"it (`redundancy-group 1 ... %s ...;`) folds its tokens into the PRECEDING "+
-				"statement and silently does nothing. Add %q to isRedundancyGroupStatement.",
-				arm, arm, arm)
+			t.Run(a+"_then_"+b, func(t *testing.T) {
+				rg := compileRGText(t, packedRGConfig(
+					"        redundancy-group 1 "+sa.text+" "+sb.text+";"))
+				sa.assert(t, rg)
+				sb.assert(t, rg)
+			})
 		}
 	}
-}
-
-// ---------------------------------------------------------------------------
-// #6588 review round 5 — a regression this branch introduced, and a second
-// namedInstances node shape the fixed skip did not cover.
-// ---------------------------------------------------------------------------
-
-// TestChassisInterfaceMonitorBracketInlineWeight_6588 pins MAJOR-A: a trailing
-// inline weight on a bracketed list applies to EVERY member.
-//
-// The entry splitter originally attached a `weight` token to the entry
-// immediately preceding it, which is the obvious reading and is wrong here:
-// `[ ge-0/0/0 ge-0/0/1 ] weight 255` compiled ge-0/0/0 at weight ZERO. That is
-// WORSE than master, which compiled one monitor at 255 and dropped the rest —
-// master at least protected ge-0/0/0. With N names, N-1 monitors were inert:
-// present in `show`, deducting nothing on link-down, group never demotes.
-//
-// The chosen semantics is apply-to-all, matching the children-block spelling
-// `[ a b ] { weight 255; }` (which already applied 255 to both) and the
-// fail-safe rule monitorEntryNodes documents. It is also strictly better than
-// master on this input: no member is dropped and no weight is lost.
-//
-// FAIL-ON-REVERT: attach the weight to split[len(split)-1] again and every
-// subtest below fails naming the zero-weight monitor.
-func TestChassisInterfaceMonitorBracketInlineWeight_6588(t *testing.T) {
-	t.Run("FlatSetTwoNames", func(t *testing.T) {
-		cfg, err := CompileConfig(flatMonitorTree(t,
-			"set chassis cluster redundancy-group 1 interface-monitor [ ge-0/0/0 ge-0/0/1 ] weight 255"))
-		if err != nil {
-			t.Fatalf("compile: %v", err)
-		}
-		assertMonitors(t, onlyRG6588(t, cfg),
-			[]string{"ge-0/0/0", "ge-0/0/1"}, []int{255, 255})
-	})
-	t.Run("FlatSetThreeNames", func(t *testing.T) {
-		cfg, err := CompileConfig(flatMonitorTree(t,
-			"set chassis cluster redundancy-group 1 interface-monitor [ ge-0/0/0 ge-0/0/1 ge-0/0/2 ] weight 100"))
-		if err != nil {
-			t.Fatalf("compile: %v", err)
-		}
-		assertMonitors(t, onlyRG6588(t, cfg),
-			[]string{"ge-0/0/0", "ge-0/0/1", "ge-0/0/2"}, []int{100, 100, 100})
-	})
-	t.Run("ContainerHierarchical", func(t *testing.T) {
-		assertMonitors(t, compileMonitorText(t, packedMonitorConfig(
-			"            interface-monitor [ ge-0/0/0 ge-0/0/1 ] weight 255;")),
-			[]string{"ge-0/0/0", "ge-0/0/1"}, []int{255, 255})
-	})
-	t.Run("PackedInstanceLine", func(t *testing.T) {
-		assertMonitors(t, compileRGText(t, packedRGConfig(
-			"        redundancy-group 1 interface-monitor [ ge-0/0/0 ge-0/0/1 ] weight 255;")),
-			[]string{"ge-0/0/0", "ge-0/0/1"}, []int{255, 255})
-	})
-
-	// NEGATIVE CONTROL: the children-block spelling already applied the weight
-	// to every member and must keep doing so. Green with and without the fix.
-	t.Run("ControlChildrenBlockWeight", func(t *testing.T) {
-		assertMonitors(t, compileMonitorText(t, packedMonitorConfig(
-			"            interface-monitor [ ge-0/0/0 ge-0/0/1 ] {\n                weight 255;\n            }")),
-			[]string{"ge-0/0/0", "ge-0/0/1"}, []int{255, 255})
-	})
-	// NEGATIVE CONTROL: a single name with an inline weight is unaffected by
-	// how the attribute is scoped. Green in both worlds.
-	t.Run("ControlSingleNameInlineWeight", func(t *testing.T) {
-		assertMonitors(t, compileMonitorText(t, packedMonitorConfig(
-			"            interface-monitor ge-0/0/0 weight 255;")),
-			[]string{"ge-0/0/0"}, []int{255})
-	})
-	// A weight-less list still compiles every member at the documented 0
-	// default — apply-to-all must not invent a weight.
-	t.Run("ControlNoWeightStaysZero", func(t *testing.T) {
-		assertMonitors(t, compileMonitorText(t, packedMonitorConfig(
-			"            interface-monitor [ ge-0/0/0 ge-0/0/1 ];")),
-			[]string{"ge-0/0/0", "ge-0/0/1"}, []int{0, 0})
-	})
-	// The out-of-range gate sees every member, not just the last.
-	t.Run("OutOfRangeRejectedForAllMembers", func(t *testing.T) {
-		assertErrContains(t, compileMonitorTextErr(t, packedMonitorConfig(
-			"            interface-monitor [ ge-0/0/0 ge-0/0/1 ] weight 300;")),
-			"interface-monitor ge-0/0/0 weight 300 is out of range 0..255")
-	})
-	// Two inline weights in one bracketed statement are ambiguous about which
-	// member each belongs to. Master silently took the LAST and dropped every
-	// member but the first; rejecting is loud and matches the round-2
-	// duplicate-weight gate.
-	t.Run("AmbiguousPerMemberWeightsRejected", func(t *testing.T) {
-		assertErrContains(t, compileMonitorTextErr(t, packedMonitorConfig(
-			"            interface-monitor [ ge-0/0/0 weight 100 ge-0/0/1 weight 200 ];")),
-			"weight specified 2 times with different values")
-	})
-}
-
-// TestChassisIPMonitoringBracketInlineWeight_6588 pins the same semantics on
-// the ip-monitoring target list, which shares monitorEntryNodes.
-func TestChassisIPMonitoringBracketInlineWeight_6588(t *testing.T) {
-	rg := compileMonitorText(t, packedMonitorConfig(
-		"            ip-monitoring family inet [ 10.0.1.1 10.0.2.1 ] weight 100;"))
-	if rg.IPMonitoring == nil || len(rg.IPMonitoring.Targets) != 2 {
-		t.Fatalf("expected 2 ip-monitoring targets, got %+v", rg.IPMonitoring)
-	}
-	for _, tgt := range rg.IPMonitoring.Targets {
-		if tgt.Weight != 100 {
-			t.Fatalf("target %s weight = %d, want 100 — a target compiled at weight 0 "+
-				"deducts nothing when the probe fails", tgt.Address, tgt.Weight)
-		}
-	}
-}
-
-// TestChassisRedundancyGroupBareContainerShape_6588 pins MAJOR-B: the SECOND
-// node shape namedInstances returns.
-//
-// namedInstances yields either the `redundancy-group <id>` node itself
-// (Keys[0]=="redundancy-group", so the body starts at Keys[2]) or, for a bare
-// `redundancy-group { ... }` wrapper, a CHILD whose Keys[0] IS the instance id
-// (so the body starts at Keys[1]). redundancyGroupBody used a fixed skip of 2,
-// which on the second shape swallowed the statement KEYWORD and opened a node
-// named after a value — matching no switch arm, so every statement was dropped
-// exactly as in round 1, election priority included.
-//
-// Reachability through the shipped parser is lower than the round-1 shape (no
-// Junos output and no SetPath path emits a bare wrapper), but this is fixed
-// rather than documented: the guard covers all four redundancyGroupBody
-// readers, so leaving it would make the three AST gates blind here while
-// LOOKING like they covered it.
-//
-// FAIL-ON-REVERT: pin skip back to 2 and every subtest fails naming the lost
-// statement.
-func TestChassisRedundancyGroupBareContainerShape_6588(t *testing.T) {
-	t.Run("PackedInterfaceMonitor", func(t *testing.T) {
-		assertMonitors(t, compileRGText(t, packedRGConfig(
-			"        redundancy-group {\n            1 interface-monitor ge-0/0/0 weight 255;\n        }")),
-			[]string{"ge-0/0/0"}, []int{255})
-	})
-	t.Run("PackedNodePriority", func(t *testing.T) {
-		rg := compileRGText(t, packedRGConfig(
-			"        redundancy-group {\n            1 node 0 priority 200;\n        }"))
-		if got, ok := rg.NodePriorities[0]; !ok || got != 200 {
-			t.Fatalf("bare `redundancy-group { 1 node 0 priority 200; }` lost the election "+
-				"priority: NodePriorities = %v", rg.NodePriorities)
-		}
-	})
-	t.Run("PackedPreempt", func(t *testing.T) {
-		rg := compileRGText(t, packedRGConfig(
-			"        redundancy-group {\n            1 preempt;\n        }"))
-		if !rg.Preempt {
-			t.Fatal("bare `redundancy-group { 1 preempt; }` lost `preempt`")
-		}
-	})
-	t.Run("GatesStillReachIt", func(t *testing.T) {
-		assertErrContains(t, compileMonitorTextErr(t, packedRGConfig(
-			"        redundancy-group {\n            1 interface-monitor ge-0/0/0 weight nope;\n        }")),
-			`weight "nope" is not an integer`)
-	})
-	// NEGATIVE CONTROL: the nested-block form under a bare wrapper already
-	// worked (its body arrives as real children) and must be unchanged. Green
-	// with and without the fix.
-	t.Run("ControlBareWrapperNestedBlock", func(t *testing.T) {
-		assertMonitors(t, compileRGText(t, packedRGConfig(
-			"        redundancy-group {\n            1 {\n                interface-monitor ge-0/0/0 weight 255;\n            }\n        }")),
-			[]string{"ge-0/0/0"}, []int{255})
-	})
-	// NEGATIVE CONTROL: the ordinary `redundancy-group <id>` shape still uses
-	// skip 2. Green in both worlds.
-	t.Run("ControlOrdinaryInstanceShape", func(t *testing.T) {
-		assertMonitors(t, compileRGText(t, packedRGConfig(
-			"        redundancy-group 1 interface-monitor ge-0/0/0 weight 255;")),
-			[]string{"ge-0/0/0"}, []int{255})
-	})
 }

--- a/pkg/config/compiler_chassis_packed_monitor_6588_test.go
+++ b/pkg/config/compiler_chassis_packed_monitor_6588_test.go
@@ -2,6 +2,10 @@ package config
 
 import (
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -889,4 +893,104 @@ func TestChassisRedundancyGroupPackedBodyReachesGates_6588(t *testing.T) {
 			"        redundancy-group 1 node bogus priority 200;")),
 			"redundancy-group node")
 	})
+}
+
+// TestRedundancyGroupStatementPredicateCoversCompiler_6588 is a DRIFT GUARD on
+// the hand-written isRedundancyGroupStatement token list.
+//
+// redundancyGroupBody splits a packed instance tail at that list. A token
+// missing from it is not a loud failure: the statement's tokens are appended to
+// whichever statement precedes it on the line, so it silently does nothing —
+// the exact class of defect this whole issue is about, with better camouflage.
+// A list that merely LOOKS complete today also drifts the moment someone adds a
+// `case` to compileChassis without touching the predicate.
+//
+// So the set is not re-asserted by hand here. It is DERIVED from the compiler
+// itself: this parses compileChassis's own source, extracts every `case "..."`
+// of the switch that dispatches redundancy-group body statements, and requires
+// the predicate to accept each one. Adding an arm without extending the
+// predicate fails this test with the missing token named.
+//
+// If the parse cannot find the switch the test FAILS rather than silently
+// passing on an empty set — a guard that can quietly verify nothing is worse
+// than no guard.
+func TestRedundancyGroupStatementPredicateCoversCompiler_6588(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "compiler_system.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse compiler_system.go: %v", err)
+	}
+
+	var fn *ast.FuncDecl
+	for _, d := range file.Decls {
+		if f, ok := d.(*ast.FuncDecl); ok && f.Name.Name == "compileChassis" {
+			fn = f
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatal("compileChassis not found in compiler_system.go — this guard cannot verify " +
+			"the statement list; fix the guard rather than deleting it")
+	}
+
+	// Find the switch whose tag is `child.Name()` — the redundancy-group body
+	// dispatch. Keyed on the tag rather than on position so reordering the
+	// function does not silently blind the guard.
+	var arms []string
+	ast.Inspect(fn, func(n ast.Node) bool {
+		sw, ok := n.(*ast.SwitchStmt)
+		if !ok || sw.Tag == nil {
+			return true
+		}
+		call, ok := sw.Tag.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Name" {
+			return true
+		}
+		if ident, ok := sel.X.(*ast.Ident); !ok || ident.Name != "child" {
+			return true
+		}
+		for _, stmt := range sw.Body.List {
+			cc, ok := stmt.(*ast.CaseClause)
+			if !ok {
+				continue
+			}
+			for _, e := range cc.List {
+				lit, ok := e.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				v, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					t.Fatalf("unquote case literal %s: %v", lit.Value, err)
+				}
+				arms = append(arms, v)
+			}
+		}
+		return false
+	})
+
+	if len(arms) == 0 {
+		t.Fatal("found no `case \"...\"` arms on compileChassis's `switch child.Name()` — " +
+			"the guard has lost track of the compiler and is verifying nothing; fix it")
+	}
+	// Sanity floor: the arms known at the time this guard was written. Guards
+	// against the Inspect above latching onto some other, smaller switch.
+	if len(arms) < 6 {
+		t.Fatalf("found only %d redundancy-group statement arms %v — expected at least the 6 "+
+			"known ones; the guard is probably reading the wrong switch", len(arms), arms)
+	}
+
+	for _, arm := range arms {
+		if !isRedundancyGroupStatement(arm) {
+			t.Errorf("compileChassis handles redundancy-group statement %q but "+
+				"isRedundancyGroupStatement does not list it — a packed instance line carrying "+
+				"it (`redundancy-group 1 ... %s ...;`) folds its tokens into the PRECEDING "+
+				"statement and silently does nothing. Add %q to isRedundancyGroupStatement.",
+				arm, arm, arm)
+		}
+	}
 }

--- a/pkg/config/compiler_chassis_rg_arity.go
+++ b/pkg/config/compiler_chassis_rg_arity.go
@@ -1,0 +1,111 @@
+package config
+
+import "fmt"
+
+// compiler_chassis_rg_arity.go carries the #6588 commit-side gate for tokens
+// attached to a redundancy-group statement that TAKES NO ARGUMENT.
+//
+// `preempt` and `strict-vip-ownership` are flags: their compilers
+// (compileRGPreempt / compileRGStrictVIPOwnership) set a bool and never look at
+// the node beyond its name. Anything else written on the statement is therefore
+// discarded in silence:
+//
+//	redundancy-group 1 preempt weight 255;      -> Preempt=true, `weight 255` gone
+//	redundancy-group 1 preempt delay 5;         -> Preempt=true, `delay 5` gone
+//	redundancy-group 1 preempt { delay 5; }     -> Preempt=true, the block gone
+//
+// This is the same silent-no-effect class as the packed-statement drop #6588
+// fixes, and unlike the value-position collision documented on
+// redundancyGroupStatements it needs no implausible input — a stray token or a
+// half-remembered Junos option is ordinary operator typing. `preempt delay`,
+// `preempt limit` and `preempt period` in particular are real Junos SRX syntax
+// that xpf does not implement, so accepting them silently tells the operator
+// they configured a preempt delay when nothing of the sort exists.
+//
+// Neither path caught it before this gate: SchemaValidate accepts
+// `set chassis cluster redundancy-group 1 preempt delay 5` (measured), and the
+// compiled struct is a plain bool with nowhere to record the discarded tokens,
+// so the check has to run on the AST.
+//
+// Strictness follows the sibling chassis gates: hard-reject at commit /
+// commit-check, downgrade to a cfg.Warnings entry on the tolerant load /
+// peer-sync paths (#1960 no-brick).
+
+// redundancyGroupNoArgStatements lists the redundancy-group statements that
+// carry no argument.
+//
+// It is a SEPARATE set from redundancyGroupStatements rather than derived from
+// it, because arity is not recoverable from a func value — every handler has
+// the same signature whether or not it reads the node. The two are kept in step
+// by TestRedundancyGroupNoArgStatementsAreRegistered_6588, which fails if a name
+// here is not a registered statement.
+//
+// Adding a flag statement means adding it here as well as to the dispatch
+// table. Leaving it out is not silent in the way a missing dispatch entry is —
+// the statement still compiles — it only means its trailing tokens keep being
+// ignored quietly.
+var redundancyGroupNoArgStatements = map[string]bool{
+	"preempt":              true,
+	"strict-vip-ownership": true,
+}
+
+// validateRGNoArgStatementsAST walks the chassis cluster subtree and reports
+// every no-argument redundancy-group statement that carries tokens or a body.
+//
+// It reads the statement nodes through redundancyGroupBody, the same splitter
+// compileChassis dispatches from, so the gate sees exactly the nodes the
+// compiler sees — including the packed instance line and the bare
+// `redundancy-group { <id> ... }` wrapper.
+//
+// Returns (warnings, nil) when lenient, (nil, error) on the first offender when
+// strict.
+func validateRGNoArgStatementsAST(nodes []*Node, lenient bool) ([]string, error) {
+	var warnings []string
+
+	emit := func(format string, args ...interface{}) error {
+		msg := fmt.Sprintf(format, args...)
+		if lenient {
+			warnings = append(warnings, msg)
+			return nil
+		}
+		return fmt.Errorf("%s", msg)
+	}
+
+	walkErr := forEachChild(nodes, "chassis", func(chassis *Node) error {
+		return forEachChild(chassis.Children, "cluster", func(cluster *Node) error {
+			for _, rgInst := range namedInstances(cluster.FindChildren("redundancy-group")) {
+				for _, child := range redundancyGroupBody(rgInst.node) {
+					name := child.Name()
+					if !redundancyGroupNoArgStatements[name] {
+						continue
+					}
+					// Keys[0] is the statement itself; anything after it was
+					// written as an inline argument. Children are a block body.
+					// Both are discarded by the compiler, so both are reported.
+					if len(child.Keys) > 1 {
+						if err := emit("chassis cluster redundancy-group %s %s: takes no "+
+							"argument but carries %q — those tokens are silently discarded, so "+
+							"the configuration does not do what it reads as; remove them",
+							rgInst.name, name, child.Keys[1:]); err != nil {
+							return err
+						}
+						continue
+					}
+					if len(child.Children) > 0 {
+						if err := emit("chassis cluster redundancy-group %s %s: takes no "+
+							"argument but carries a %q block — it is silently discarded, so the "+
+							"configuration does not do what it reads as; remove it",
+							rgInst.name, name, child.Children[0].Name()); err != nil {
+							return err
+						}
+					}
+				}
+			}
+			return nil
+		})
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return warnings, nil
+}

--- a/pkg/config/compiler_opts.go
+++ b/pkg/config/compiler_opts.go
@@ -363,6 +363,20 @@ type compileOpts struct {
 	// lenientChassisClusterIdentities.
 	lenientChassisMonitorWeight bool
 
+	// lenientChassisRGStatementArity (#6588) downgrades the redundancy-group
+	// no-argument statement gate (validateRGNoArgStatementsAST) from a hard
+	// compile error to a cfg.Warnings entry on the tolerant load / peer-sync
+	// paths. `preempt` and `strict-vip-ownership` compile to a bool and never
+	// read the node, so trailing tokens or a block body — including the real
+	// Junos `preempt delay <n>` that xpf does not implement — are discarded in
+	// silence and the operator believes they configured something that does not
+	// exist. Commit / commit-check stay strict so a new operator edit is
+	// rejected; an already-persisted or peer-synced config an older binary
+	// accepted must still BOOT (warn) per the #1960 fail-closed-on-load
+	// doctrine — the flag itself still compiles, now with the discarded tokens
+	// flagged. Same doctrine as lenientChassisMonitorWeight.
+	lenientChassisRGStatementArity bool
+
 	// lenientIPsecProposalProtocol (#4298, V-2) downgrades the IPsec
 	// proposal `protocol ah` reject (validateIPsecProposalProtocolStrict)
 	// from a hard error to a warning on the tolerant load / peer-sync paths.
@@ -2035,6 +2049,7 @@ func lenientCompileOpts() compileOpts {
 		lenientReservedProposalSetNames:        true,
 		lenientChassisClusterIdentities:        true,
 		lenientChassisMonitorWeight:            true,
+		lenientChassisRGStatementArity:         true,
 		lenientIPsecProposalProtocol:           true,
 		lenientIPsecManualKey:                  true,
 		lenientLogProfileStreamRef:             true,

--- a/pkg/config/compiler_opts.go
+++ b/pkg/config/compiler_opts.go
@@ -348,6 +348,21 @@ type compileOpts struct {
 	// Same doctrine as lenientReservedProposalSetNames.
 	lenientChassisClusterIdentities bool
 
+	// lenientChassisMonitorWeight (#6588) downgrades the redundancy-group
+	// monitor weight gate (validateMonitorWeightTokensAST) from a hard compile
+	// error to a cfg.Warnings entry on the tolerant load / peer-sync paths. A
+	// weight that is malformed (`weight nope`) or specified twice with
+	// different values compiles to the 0 default / a spelling-dependent pick,
+	// so the monitored link going down deducts NO weight (or the wrong one) and
+	// the redundancy group does not demote — the same silent-nothing class as
+	// the packed-statement drop #6588 fixes. Commit / commit-check stay strict
+	// so a new operator edit is rejected; an already-persisted or peer-synced
+	// config an older binary accepted must still BOOT (warn) per the #1960
+	// fail-closed-on-load doctrine — compileChassis keeps the stable
+	// first-wins / 0-default coercion, now flagged. Same doctrine as
+	// lenientChassisClusterIdentities.
+	lenientChassisMonitorWeight bool
+
 	// lenientIPsecProposalProtocol (#4298, V-2) downgrades the IPsec
 	// proposal `protocol ah` reject (validateIPsecProposalProtocolStrict)
 	// from a hard error to a warning on the tolerant load / peer-sync paths.
@@ -2019,6 +2034,7 @@ func lenientCompileOpts() compileOpts {
 		lenientIPsecTrafficSelectors:           true,
 		lenientReservedProposalSetNames:        true,
 		lenientChassisClusterIdentities:        true,
+		lenientChassisMonitorWeight:            true,
 		lenientIPsecProposalProtocol:           true,
 		lenientIPsecManualKey:                  true,
 		lenientLogProfileStreamRef:             true,

--- a/pkg/config/compiler_prewalk.go
+++ b/pkg/config/compiler_prewalk.go
@@ -482,6 +482,18 @@ func runPreWalkGates(tree *ConfigTree, opts compileOpts) ([]string, error) {
 	// (pkg/vrrp sendGARP, pkg/daemon directSendGARPs) is the primary fix.
 	garpCountWarnings := validateGratuitousARPCountAST(tree.Children)
 
+	// #6588: a redundancy-group monitor weight that is present but UNUSABLE —
+	// non-integer, or specified twice with different values. The compiled
+	// struct cannot express it (a failed Atoi is indistinguishable from
+	// `weight 0` by the time validateChassisClusterStrict runs) and the schema
+	// walker never reaches the token, so it is checked on the AST. Strict at
+	// commit / commit-check; warn on the tolerant load / peer-sync path.
+	monitorWeightWarnings, err := validateMonitorWeightTokensAST(
+		tree.Children, opts.lenientChassisMonitorWeight)
+	if err != nil {
+		return nil, err
+	}
+
 	var warnings []string
 	warnings = append(warnings, ctrlCharWarnings...)
 	warnings = append(warnings, trackWarnings...)
@@ -508,6 +520,7 @@ func runPreWalkGates(tree *ConfigTree, opts compileOpts) ([]string, error) {
 	warnings = append(warnings, dnatToScopeWarnings...)
 	warnings = append(warnings, natMixedScopeWarnings...)
 	warnings = append(warnings, chassisIdentityWarnings...)
+	warnings = append(warnings, monitorWeightWarnings...)
 	warnings = append(warnings, garpCountWarnings...)
 	return warnings, nil
 }

--- a/pkg/config/compiler_prewalk.go
+++ b/pkg/config/compiler_prewalk.go
@@ -494,6 +494,20 @@ func runPreWalkGates(tree *ConfigTree, opts compileOpts) ([]string, error) {
 		return nil, err
 	}
 
+	// #6588: a redundancy-group FLAG statement (`preempt`,
+	// `strict-vip-ownership`) that carries trailing tokens or a block body. The
+	// compilers set a bool and never read the node, so the extra tokens are
+	// discarded silently — including `preempt delay 5`, which is real Junos
+	// syntax xpf does not implement. The compiled bool has nowhere to record
+	// what was dropped and the schema walker accepts it, so it is checked on
+	// the AST. Strict at commit / commit-check; warn on the tolerant load /
+	// peer-sync path.
+	rgArityWarnings, err := validateRGNoArgStatementsAST(
+		tree.Children, opts.lenientChassisRGStatementArity)
+	if err != nil {
+		return nil, err
+	}
+
 	var warnings []string
 	warnings = append(warnings, ctrlCharWarnings...)
 	warnings = append(warnings, trackWarnings...)
@@ -521,6 +535,7 @@ func runPreWalkGates(tree *ConfigTree, opts compileOpts) ([]string, error) {
 	warnings = append(warnings, natMixedScopeWarnings...)
 	warnings = append(warnings, chassisIdentityWarnings...)
 	warnings = append(warnings, monitorWeightWarnings...)
+	warnings = append(warnings, rgArityWarnings...)
 	warnings = append(warnings, garpCountWarnings...)
 	return warnings, nil
 }

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -2214,6 +2214,46 @@ func redundancyGroupBody(rgNode *Node) []*Node {
 // loop whose only other content is this lookup — obvious in review rather than
 // invisible. Demoted, not eliminated; Go offers no construct that would
 // eliminate it.
+//
+// FOURTH ROUTE, opposite direction — the splitter OVER-matches. All three routes
+// above are the table under-covering what the compiler honours: a statement is
+// compiled but not registered, so its tokens fold into the neighbour. There is
+// one more of the other shape, and an earlier version of this comment enumerated
+// "three" as if that were the whole space. The splitter matches a registered
+// keyword wherever the token appears in the tail, including where the token is a
+// VALUE rather than a statement keyword, so a value spelled like a statement is
+// STOLEN and compiled as that statement:
+//
+//	packed:    redundancy-group 1 interface-monitor preempt weight 255;
+//	             -> InterfaceMonitors=[]  Preempt=true
+//	container: redundancy-group 1 { interface-monitor preempt weight 255; }
+//	             -> InterfaceMonitors=[{preempt 255}]  Preempt=false
+//
+// The two spellings disagree — precisely what splitting the packed line exists
+// to prevent. (Measured, not reasoned: both lines above were compiled.)
+//
+// NOT fixed here. The stolen token has to sit in entry-NAME position, and no
+// legal Junos interface name or IP address collides with any keyword registered
+// below — names are ge-*/xe-*/et-*, reth*, fxp*, em*, lo0, st0, ae*, fab*, irb,
+// vlan. So the input is unreachable from a real config, and the runtime
+// materiality is nil.
+//
+// Note what is and is not guarded, since the paragraph above is the kind of
+// claim that rots. There is deliberately NO test asserting the divergence: it
+// would pin the wrong answer as correct and would have to be deleted by whoever
+// fixes this. There is also no test asserting "keyword is not a legal interface
+// name" — the project has no canonical interface-name predicate, so such a test
+// would have to invent the grammar, and inventing a model of something that
+// lives nowhere in code is the same mistake as the source-parsing drift guard
+// this table replaced. What IS guarded is the EDIT that would make the route
+// reachable: registering a statement here trips the completeness check in
+// TestRedundancyGroupStatementsSurvivePackedLine_6588, which fails until a human
+// adds a sample for the new keyword. That is the moment to ask whether the new
+// keyword can also spell an entry name.
+//
+// Fixing it properly means splitting position-aware — a keyword opens a
+// statement only where a statement may begin — which changes the splitter
+// contract and does not belong in a fix for the drop bug.
 var redundancyGroupStatements = map[string]func(rg *RedundancyGroup, child *Node){
 	"node":                 compileRGNodePriority,
 	"gratuitous-arp-count": compileRGGratuitousARPCount,

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -1926,115 +1926,13 @@ func compileChassis(node *Node, ch *ChassisConfig) error {
 
 		// #6588: redundancyGroupBody, not .Children — the whole body may be
 		// packed onto the instance's own Keys.
+		// Dispatch through redundancyGroupStatements — the same table
+		// isRedundancyGroupStatement is derived from, so the set of statements
+		// compiled here and the set redundancyGroupBody splits a packed line at
+		// are one thing rather than two that must be kept in step.
 		for _, child := range redundancyGroupBody(rgInst.node) {
-			switch child.Name() {
-			case "node":
-				// node <id> priority <value>
-				nodeID := 0
-				if v := nodeVal(child); v != "" {
-					if n, err := strconv.Atoi(v); err == nil {
-						nodeID = n
-					}
-				}
-				// Look for "priority" in inline keys or children
-				for i := 2; i < len(child.Keys)-1; i++ {
-					if child.Keys[i] == "priority" {
-						if n, err := strconv.Atoi(child.Keys[i+1]); err == nil {
-							rg.NodePriorities[nodeID] = n
-						}
-					}
-				}
-				if priNode := child.FindChild("priority"); priNode != nil {
-					if v := nodeVal(priNode); v != "" {
-						if n, err := strconv.Atoi(v); err == nil {
-							rg.NodePriorities[nodeID] = n
-						}
-					}
-				}
-			case "gratuitous-arp-count":
-				if v := nodeVal(child); v != "" {
-					if n, err := strconv.Atoi(v); err == nil {
-						rg.GratuitousARPCount = n
-					}
-				}
-			case "preempt":
-				rg.Preempt = true
-			case "strict-vip-ownership":
-				rg.StrictVIPOwnership = true
-			case "interface-monitor":
-				// monitorEntryNodes (#6588): the packed one-liner
-				// `interface-monitor ge-0/0/0 weight 255;` carries the monitor
-				// on the statement's OWN Keys and has no children at all, and a
-				// bracketed `[ ge-0/0/0 ge-0/0/1 ]` collapses N monitors onto
-				// one node's Keys in EVERY spelling.
-				for _, ifChild := range monitorEntryNodes(child, 1) {
-					im := &InterfaceMonitor{
-						Interface: ifChild.Name(),
-					}
-					// monitorWeightTokens reads both value locations
-					// (`ge-0/0/0 weight 255` and `ge-0/0/0 { weight 255; }`)
-					// and is FIRST-WINS, so the compiled weight no longer
-					// depends on the spelling. A malformed or duplicated
-					// weight is rejected/warned by
-					// validateMonitorWeightTokensAST; here it leaves the
-					// pre-existing 0 default.
-					if toks := monitorWeightTokens(ifChild); len(toks) > 0 {
-						if n, err := strconv.Atoi(toks[0]); err == nil {
-							im.Weight = n
-						}
-					}
-					rg.InterfaceMonitors = append(rg.InterfaceMonitors, im)
-				}
-			case "ip-monitoring":
-				ipm := &IPMonitoring{}
-				// #6588: ip-monitoring installs redundancy-group demotion debt
-				// through the same election path as interface-monitor, and it
-				// packs the same way — `ip-monitoring global-weight 255;` and
-				// `ip-monitoring family inet 10.0.1.1 weight 100;` are leaves
-				// with no children.
-				ipmEntries := packedStatementProps(child, 1, isIPMonitoringProp)
-				if gwNode := findNamedNode(ipmEntries, "global-weight"); gwNode != nil {
-					if v := nodeVal(gwNode); v != "" {
-						if n, err := strconv.Atoi(v); err == nil {
-							ipm.GlobalWeight = n
-						}
-					}
-				}
-				if gtNode := findNamedNode(ipmEntries, "global-threshold"); gtNode != nil {
-					if v := nodeVal(gtNode); v != "" {
-						if n, err := strconv.Atoi(v); err == nil {
-							ipm.GlobalThreshold = n
-						}
-					}
-				}
-				for _, familyNode := range ipmEntries {
-					if familyNode.Name() != "family" {
-						continue
-					}
-					// Compound key "family inet" vs nested family { inet { } }.
-					// inetSkip is how many of inetNode's leading Keys name the
-					// node itself rather than a monitored address, so a packed
-					// target (`family inet 10.0.1.1 weight 100;`) is unpacked
-					// from the right offset. Shared with the #6588 weight gate.
-					inetNode, inetSkip := ipMonitoringInetNode(familyNode)
-					if inetNode == nil {
-						continue
-					}
-					for _, addrChild := range monitorEntryNodes(inetNode, inetSkip) {
-						target := &IPMonitorTarget{
-							Address: addrChild.Name(),
-						}
-						// Same FIRST-WINS dual-location weight read as the
-						// interface-monitor arm above.
-						if toks := monitorWeightTokens(addrChild); len(toks) > 0 {
-							if n, err := strconv.Atoi(toks[0]); err == nil {
-								target.Weight = n
-							}
-						}
-						ipm.Targets = append(ipm.Targets, target)
-					}
-				}
-				rg.IPMonitoring = ipm
+			if compile, ok := redundancyGroupStatements[child.Name()]; ok {
+				compile(rg, child)
 			}
 		}
 
@@ -2277,16 +2175,181 @@ func redundancyGroupBody(rgNode *Node) []*Node {
 	return packedStatementProps(rgNode, skip, isRedundancyGroupStatement)
 }
 
+// redundancyGroupStatements is the SINGLE SOURCE OF TRUTH for what a
+// `redundancy-group` body may contain: it is both the compiler's dispatch
+// table and the token set redundancyGroupBody splits a packed instance line
+// at (#6588).
+//
+// The two MUST agree. A statement the compiler honours but the splitter does
+// not know is not a loud failure — on a packed line carrying more than one
+// statement its tokens are appended to whichever statement precedes it, so it
+// silently does nothing, while the SAME statement alone on a line still works.
+// A developer therefore sees it work, and ships the fold bug.
+//
+// This was previously a hand-written token list checked by a test that parsed
+// compileChassis's source and extracted its `case "..."` literals. That guard
+// passed while the statement was still dropped in three ways: a case on a
+// named CONSTANT rather than a string literal (the idiom this very file uses
+// for monitorWeightKeyword), a statement handled by a helper called outside
+// the switch, and a nested switch inside a `default:` arm. Modelling another
+// program's source text is the wrong tool; deriving both consumers from one
+// table removes the divergence by construction instead.
+//
+// Adding a statement means adding an entry here. Doing so registers it with
+// the splitter in the same edit, and a statement NOT registered here is not
+// compiled either — so the two cannot disagree.
+var redundancyGroupStatements = map[string]func(rg *RedundancyGroup, child *Node){
+	"node":                 compileRGNodePriority,
+	"gratuitous-arp-count": compileRGGratuitousARPCount,
+	"preempt":              compileRGPreempt,
+	"strict-vip-ownership": compileRGStrictVIPOwnership,
+	"interface-monitor":    compileRGInterfaceMonitors,
+	"ip-monitoring":        compileRGIPMonitoring,
+}
+
 // isRedundancyGroupStatement reports whether tok opens a statement in a
-// `redundancy-group` body. It must list every keyword compileChassis switches
-// on, or a packed tail carrying that statement is folded into its predecessor.
+// `redundancy-group` body. Derived from the dispatch table, so it can never
+// fall behind what compileChassis actually compiles.
 func isRedundancyGroupStatement(tok string) bool {
-	switch tok {
-	case "node", "gratuitous-arp-count", "preempt", "strict-vip-ownership",
-		"interface-monitor", "ip-monitoring":
-		return true
+	_, ok := redundancyGroupStatements[tok]
+	return ok
+}
+
+// compileRGNodePriority compiles a `node` statement of a redundancy-group body.
+// Registered in redundancyGroupStatements; body moved VERBATIM from the
+// switch arm it replaced (#6588).
+func compileRGNodePriority(rg *RedundancyGroup, child *Node) {
+	// node <id> priority <value>
+	nodeID := 0
+	if v := nodeVal(child); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			nodeID = n
+		}
 	}
-	return false
+	// Look for "priority" in inline keys or children
+	for i := 2; i < len(child.Keys)-1; i++ {
+		if child.Keys[i] == "priority" {
+			if n, err := strconv.Atoi(child.Keys[i+1]); err == nil {
+				rg.NodePriorities[nodeID] = n
+			}
+		}
+	}
+	if priNode := child.FindChild("priority"); priNode != nil {
+		if v := nodeVal(priNode); v != "" {
+			if n, err := strconv.Atoi(v); err == nil {
+				rg.NodePriorities[nodeID] = n
+			}
+		}
+	}
+}
+
+// compileRGGratuitousARPCount compiles a `gratuitous-arp-count` statement of a redundancy-group body.
+// Registered in redundancyGroupStatements; body moved VERBATIM from the
+// switch arm it replaced (#6588).
+func compileRGGratuitousARPCount(rg *RedundancyGroup, child *Node) {
+	if v := nodeVal(child); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			rg.GratuitousARPCount = n
+		}
+	}
+}
+
+// compileRGPreempt compiles a `preempt` statement of a redundancy-group body.
+// Registered in redundancyGroupStatements; body moved VERBATIM from the
+// switch arm it replaced (#6588).
+func compileRGPreempt(rg *RedundancyGroup, child *Node) {
+	rg.Preempt = true
+}
+
+// compileRGStrictVIPOwnership compiles a `strict-vip-ownership` statement of a redundancy-group body.
+// Registered in redundancyGroupStatements; body moved VERBATIM from the
+// switch arm it replaced (#6588).
+func compileRGStrictVIPOwnership(rg *RedundancyGroup, child *Node) {
+	rg.StrictVIPOwnership = true
+}
+
+// compileRGInterfaceMonitors compiles a `interface-monitor` statement of a redundancy-group body.
+// Registered in redundancyGroupStatements; body moved VERBATIM from the
+// switch arm it replaced (#6588).
+func compileRGInterfaceMonitors(rg *RedundancyGroup, child *Node) {
+	// monitorEntryNodes (#6588): the packed one-liner
+	// `interface-monitor ge-0/0/0 weight 255;` carries the monitor
+	// on the statement's OWN Keys and has no children at all, and a
+	// bracketed `[ ge-0/0/0 ge-0/0/1 ]` collapses N monitors onto
+	// one node's Keys in EVERY spelling.
+	for _, ifChild := range monitorEntryNodes(child, 1) {
+		im := &InterfaceMonitor{
+			Interface: ifChild.Name(),
+		}
+		// monitorWeightTokens reads both value locations
+		// (`ge-0/0/0 weight 255` and `ge-0/0/0 { weight 255; }`)
+		// and is FIRST-WINS, so the compiled weight no longer
+		// depends on the spelling. A malformed or duplicated
+		// weight is rejected/warned by
+		// validateMonitorWeightTokensAST; here it leaves the
+		// pre-existing 0 default.
+		if toks := monitorWeightTokens(ifChild); len(toks) > 0 {
+			if n, err := strconv.Atoi(toks[0]); err == nil {
+				im.Weight = n
+			}
+		}
+		rg.InterfaceMonitors = append(rg.InterfaceMonitors, im)
+	}
+}
+
+// compileRGIPMonitoring compiles a `ip-monitoring` statement of a redundancy-group body.
+// Registered in redundancyGroupStatements; body moved VERBATIM from the
+// switch arm it replaced (#6588).
+func compileRGIPMonitoring(rg *RedundancyGroup, child *Node) {
+	ipm := &IPMonitoring{}
+	// #6588: ip-monitoring installs redundancy-group demotion debt
+	// through the same election path as interface-monitor, and it
+	// packs the same way — `ip-monitoring global-weight 255;` and
+	// `ip-monitoring family inet 10.0.1.1 weight 100;` are leaves
+	// with no children.
+	ipmEntries := packedStatementProps(child, 1, isIPMonitoringProp)
+	if gwNode := findNamedNode(ipmEntries, "global-weight"); gwNode != nil {
+		if v := nodeVal(gwNode); v != "" {
+			if n, err := strconv.Atoi(v); err == nil {
+				ipm.GlobalWeight = n
+			}
+		}
+	}
+	if gtNode := findNamedNode(ipmEntries, "global-threshold"); gtNode != nil {
+		if v := nodeVal(gtNode); v != "" {
+			if n, err := strconv.Atoi(v); err == nil {
+				ipm.GlobalThreshold = n
+			}
+		}
+	}
+	for _, familyNode := range ipmEntries {
+		if familyNode.Name() != "family" {
+			continue
+		}
+		// Compound key "family inet" vs nested family { inet { } }.
+		// inetSkip is how many of inetNode's leading Keys name the
+		// node itself rather than a monitored address, so a packed
+		// target (`family inet 10.0.1.1 weight 100;`) is unpacked
+		// from the right offset. Shared with the #6588 weight gate.
+		inetNode, inetSkip := ipMonitoringInetNode(familyNode)
+		if inetNode == nil {
+			continue
+		}
+		for _, addrChild := range monitorEntryNodes(inetNode, inetSkip) {
+			target := &IPMonitorTarget{
+				Address: addrChild.Name(),
+			}
+			// Same FIRST-WINS dual-location weight read as the
+			// interface-monitor arm above.
+			if toks := monitorWeightTokens(addrChild); len(toks) > 0 {
+				if n, err := strconv.Atoi(toks[0]); err == nil {
+					target.Weight = n
+				}
+			}
+			ipm.Targets = append(ipm.Targets, target)
+		}
+	}
+	rg.IPMonitoring = ipm
 }
 
 // isIPMonitoringProp reports whether tok opens an `ip-monitoring` property.

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -2196,12 +2196,24 @@ func redundancyGroupBody(rgNode *Node) []*Node {
 // table removes the divergence by construction instead.
 //
 // Adding a statement means adding an entry here, which registers it with the
-// splitter in the same edit. Note what that does and does NOT guarantee: the
-// invariant is "all dispatch goes through this table", and the table being the
-// only dispatch path present is what makes the correct thing the easy thing —
-// it is not enforced. Compiling a statement from ad-hoc code beside the lookup
-// instead of from an entry here re-opens the fold bug exactly as before
-// (verified, not assumed).
+// splitter in the same edit.
+//
+// Be precise about what that does and does not guarantee, because an overstated
+// invariant is how the next person concludes they need not think about it. The
+// invariant is "ALL dispatch goes through this table", and it is made natural
+// rather than enforced. Two of the three routes above are now closed by
+// construction: a named-constant KEY registers exactly like a literal one, and
+// there is no switch left to nest another inside. The third is not. Compiling a
+// statement from ad-hoc code beside the lookup — without an entry here — still
+// re-opens the fold bug (verified, not assumed).
+//
+// What changed for that third route is which act is the natural one. With the
+// switch, adding a `case` WAS the idiomatic way to add a statement, and it
+// diverged silently. Now the idiomatic way is a table entry, which is correct by
+// construction, and diverging means putting ad-hoc dispatch beside a five-line
+// loop whose only other content is this lookup — obvious in review rather than
+// invisible. Demoted, not eliminated; Go offers no construct that would
+// eliminate it.
 var redundancyGroupStatements = map[string]func(rg *RedundancyGroup, child *Node){
 	"node":                 compileRGNodePriority,
 	"gratuitous-arp-count": compileRGGratuitousARPCount,

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -2195,9 +2195,13 @@ func redundancyGroupBody(rgNode *Node) []*Node {
 // program's source text is the wrong tool; deriving both consumers from one
 // table removes the divergence by construction instead.
 //
-// Adding a statement means adding an entry here. Doing so registers it with
-// the splitter in the same edit, and a statement NOT registered here is not
-// compiled either — so the two cannot disagree.
+// Adding a statement means adding an entry here, which registers it with the
+// splitter in the same edit. Note what that does and does NOT guarantee: the
+// invariant is "all dispatch goes through this table", and the table being the
+// only dispatch path present is what makes the correct thing the easy thing —
+// it is not enforced. Compiling a statement from ad-hoc code beside the lookup
+// instead of from an entry here re-opens the fold bug exactly as before
+// (verified, not assumed).
 var redundancyGroupStatements = map[string]func(rg *RedundancyGroup, child *Node){
 	"node":                 compileRGNodePriority,
 	"gratuitous-arp-count": compileRGGratuitousARPCount,

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -1924,7 +1924,9 @@ func compileChassis(node *Node, ch *ChassisConfig) error {
 			NodePriorities: make(map[int]int),
 		}
 
-		for _, child := range rgInst.node.Children {
+		// #6588: redundancyGroupBody, not .Children — the whole body may be
+		// packed onto the instance's own Keys.
+		for _, child := range redundancyGroupBody(rgInst.node) {
 			switch child.Name() {
 			case "node":
 				// node <id> priority <value>
@@ -2203,6 +2205,55 @@ func packedStatementProps(cfgNode *Node, skip int, isProp func(string) bool) []*
 		}
 	}
 	return append(props, cfgNode.Children...)
+}
+
+// redundancyGroupBody returns the body statements of one `redundancy-group`
+// instance across both spellings (#6588). It is the ONE-LEVEL-UP twin of the
+// packing this file already undoes inside the body:
+//
+//	redundancy-group 1 { interface-monitor ge-0/0/0 weight 255; }
+//	  -> Keys=["redundancy-group","1"], one child per statement
+//	redundancy-group 1 interface-monitor ge-0/0/0 weight 255;
+//	  -> Keys=["redundancy-group","1","interface-monitor","ge-0/0/0","weight","255"],
+//	     NO children — the whole body is packed onto the instance's own Keys
+//
+// namedInstances resolves the instance NAME across both shapes (it reads
+// Keys[1]), but hands back the node with the body still on Keys, so a caller
+// that then walks `.Children` sees an EMPTY redundancy group. Every statement
+// was silently dropped while `commit` succeeded: not just the monitors, but
+// `node <id> priority <p>` — the election priority itself. The operator sets a
+// priority, `show configuration` echoes it, and the cluster elects on defaults,
+// so the WRONG NODE can hold the group. That is a superset of "the group never
+// demotes".
+//
+// The split is at recognized redundancy-group statement keywords, so a tail
+// carrying several statements (`node 0 priority 200 preempt;`) yields one node
+// each rather than swallowing the trailing ones. Both a packed tail and real
+// children are returned: RG statements are siblings, so nothing is lost if a
+// config somehow carries both.
+//
+// Deliberately NOT fixed inside namedInstances itself. That helper has 130 call
+// sites, and 24 of them already read the packed tail off `inst.node.Keys`
+// themselves; synthesizing a child there double-feeds those readers. Measured,
+// not assumed — making namedInstances synthesize breaks
+// TestDHCPRelayOverrides_* (the override tokens get swallowed into Interfaces)
+// and TestVRRPTrackInterface_KeysPackedDuplicateStrictReject (lenient
+// first-wins yields an empty TrackInterface). See the #6588 PR body for the
+// experiment. Other one-sided namedInstances callers are tracked separately.
+func redundancyGroupBody(rgNode *Node) []*Node {
+	return packedStatementProps(rgNode, 2, isRedundancyGroupStatement)
+}
+
+// isRedundancyGroupStatement reports whether tok opens a statement in a
+// `redundancy-group` body. It must list every keyword compileChassis switches
+// on, or a packed tail carrying that statement is folded into its predecessor.
+func isRedundancyGroupStatement(tok string) bool {
+	switch tok {
+	case "node", "gratuitous-arp-count", "preempt", "strict-vip-ownership",
+		"interface-monitor", "ip-monitoring":
+		return true
+	}
+	return false
 }
 
 // isIPMonitoringProp reports whether tok opens an `ip-monitoring` property.

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -2224,13 +2224,21 @@ func redundancyGroupBody(rgNode *Node) []*Node {
 // VALUE rather than a statement keyword, so a value spelled like a statement is
 // STOLEN and compiled as that statement:
 //
-//	packed:    redundancy-group 1 interface-monitor preempt weight 255;
-//	             -> InterfaceMonitors=[]  Preempt=true
-//	container: redundancy-group 1 { interface-monitor preempt weight 255; }
-//	             -> InterfaceMonitors=[{preempt 255}]  Preempt=false
+//	packed:    redundancy-group 1 interface-monitor ip-monitoring weight 255;
+//	             -> InterfaceMonitors=[]  IPMonitoring=&{GlobalWeight:0 GlobalThreshold:0 Targets:[]}
+//	container: redundancy-group 1 { interface-monitor ip-monitoring weight 255; }
+//	             -> InterfaceMonitors=[{ip-monitoring 255}]  IPMonitoring=nil
 //
 // The two spellings disagree — precisely what splitting the packed line exists
-// to prevent. (Measured, not reasoned: both lines above were compiled.)
+// to prevent. (Measured, not reasoned: both lines above were compiled at THIS
+// head. The example deliberately uses ip-monitoring, which still reaches no
+// gate. An earlier version of this comment used `preempt`, and that spelling is
+// now REJECTED at commit by the arity gate added later in this same PR —
+// "preempt: takes no argument but carries [weight 255]" — so quoting it here
+// would show output the compiler no longer produces. `node` is likewise caught,
+// by the #5694 identity gate. Re-measure this block if either gate moves;
+// a stale "measured" claim is how the next reader concludes the analysis was
+// already done and stops checking.)
 //
 // NOT fixed here. The stolen token has to sit in entry-NAME position, and no
 // legal Junos interface name or IP address collides with any keyword registered

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -2417,6 +2417,38 @@ func isIPMonitoringProp(tok string) bool {
 	return false
 }
 
+// ipMonitoringGlobalTokens returns every VALUE carried by the named
+// `ip-monitoring` global property (`global-weight` / `global-threshold`) in a
+// packedStatementProps result, in source order.
+//
+// This is the globals' counterpart to monitorWeightTokens, and exists for the
+// same reason (#6588): compileRGIPMonitoring reads a global with
+// findNamedNode + nodeVal, which is FIRST-WINS and silently leaves the 0
+// default when the value is missing or fails Atoi. A malformed or duplicated
+// global is therefore indistinguishable from `global-weight 0` in the compiled
+// struct, so it has to be caught on the AST — and the gate must read the same
+// token the compiler does or the two can disagree about which value won.
+//
+// That correspondence is exact rather than parallel: over the same props slice
+// this walks the same nodes with the same name predicate in the same order and
+// reads them with the same nodeVal, so
+//
+//	nodeVal(findNamedNode(props, name)) == ipMonitoringGlobalTokens(props, name)[0]
+//
+// whenever the property is present at all. The gate rejects len > 1, so where
+// the compiler's first-wins pick is observable there is exactly one token and
+// the two readers cannot pick differently. Pinned by
+// TestIPMonitoringGlobalTokensMatchesCompilerRead_6588.
+func ipMonitoringGlobalTokens(props []*Node, name string) []string {
+	var out []string
+	for _, n := range props {
+		if len(n.Keys) > 0 && n.Keys[0] == name {
+			out = append(out, nodeVal(n))
+		}
+	}
+	return out
+}
+
 // findNamedNode returns the first node in nodes whose first key is name — the
 // slice equivalent of Node.FindChild, for callers that must search a
 // packedStatementProps result rather than a node's raw Children.

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -1960,26 +1960,25 @@ func compileChassis(node *Node, ch *ChassisConfig) error {
 			case "strict-vip-ownership":
 				rg.StrictVIPOwnership = true
 			case "interface-monitor":
-				// packedOrContainerEntries (#6588): the packed one-liner
+				// monitorEntryNodes (#6588): the packed one-liner
 				// `interface-monitor ge-0/0/0 weight 255;` carries the monitor
-				// on the statement's OWN Keys and has no children at all.
-				for _, ifChild := range packedOrContainerEntries(child, 1) {
+				// on the statement's OWN Keys and has no children at all, and a
+				// bracketed `[ ge-0/0/0 ge-0/0/1 ]` collapses N monitors onto
+				// one node's Keys in EVERY spelling.
+				for _, ifChild := range monitorEntryNodes(child, 1) {
 					im := &InterfaceMonitor{
 						Interface: ifChild.Name(),
 					}
-					// weight is typically inline: "ge-0/0/0 weight 255"
-					for i := 1; i < len(ifChild.Keys)-1; i++ {
-						if ifChild.Keys[i] == "weight" {
-							if n, err := strconv.Atoi(ifChild.Keys[i+1]); err == nil {
-								im.Weight = n
-							}
-						}
-					}
-					if wNode := ifChild.FindChild("weight"); wNode != nil {
-						if v := nodeVal(wNode); v != "" {
-							if n, err := strconv.Atoi(v); err == nil {
-								im.Weight = n
-							}
+					// monitorWeightTokens reads both value locations
+					// (`ge-0/0/0 weight 255` and `ge-0/0/0 { weight 255; }`)
+					// and is FIRST-WINS, so the compiled weight no longer
+					// depends on the spelling. A malformed or duplicated
+					// weight is rejected/warned by
+					// validateMonitorWeightTokensAST; here it leaves the
+					// pre-existing 0 default.
+					if toks := monitorWeightTokens(ifChild); len(toks) > 0 {
+						if n, err := strconv.Atoi(toks[0]); err == nil {
+							im.Weight = n
 						}
 					}
 					rg.InterfaceMonitors = append(rg.InterfaceMonitors, im)
@@ -1991,7 +1990,7 @@ func compileChassis(node *Node, ch *ChassisConfig) error {
 				// packs the same way — `ip-monitoring global-weight 255;` and
 				// `ip-monitoring family inet 10.0.1.1 weight 100;` are leaves
 				// with no children.
-				ipmEntries := packedOrContainerEntries(child, 1)
+				ipmEntries := packedStatementProps(child, 1, isIPMonitoringProp)
 				if gwNode := findNamedNode(ipmEntries, "global-weight"); gwNode != nil {
 					if v := nodeVal(gwNode); v != "" {
 						if n, err := strconv.Atoi(v); err == nil {
@@ -2010,39 +2009,24 @@ func compileChassis(node *Node, ch *ChassisConfig) error {
 					if familyNode.Name() != "family" {
 						continue
 					}
-					// Determine inet node: compound key "family inet" vs nested family { inet { } }
-					var inetNode *Node
+					// Compound key "family inet" vs nested family { inet { } }.
 					// inetSkip is how many of inetNode's leading Keys name the
 					// node itself rather than a monitored address, so a packed
 					// target (`family inet 10.0.1.1 weight 100;`) is unpacked
-					// from the right offset.
-					inetSkip := 2
-					if len(familyNode.Keys) >= 2 && familyNode.Keys[1] == "inet" {
-						inetNode = familyNode
-					} else {
-						inetNode = familyNode.FindChild("inet")
-						inetSkip = 1
-					}
+					// from the right offset. Shared with the #6588 weight gate.
+					inetNode, inetSkip := ipMonitoringInetNode(familyNode)
 					if inetNode == nil {
 						continue
 					}
-					for _, addrChild := range packedOrContainerEntries(inetNode, inetSkip) {
+					for _, addrChild := range monitorEntryNodes(inetNode, inetSkip) {
 						target := &IPMonitorTarget{
 							Address: addrChild.Name(),
 						}
-						// weight inline: "10.0.1.1 weight 100"
-						for i := 1; i < len(addrChild.Keys)-1; i++ {
-							if addrChild.Keys[i] == "weight" {
-								if n, err := strconv.Atoi(addrChild.Keys[i+1]); err == nil {
-									target.Weight = n
-								}
-							}
-						}
-						if wNode := addrChild.FindChild("weight"); wNode != nil {
-							if v := nodeVal(wNode); v != "" {
-								if n, err := strconv.Atoi(v); err == nil {
-									target.Weight = n
-								}
+						// Same FIRST-WINS dual-location weight read as the
+						// interface-monitor arm above.
+						if toks := monitorWeightTokens(addrChild); len(toks) > 0 {
+							if n, err := strconv.Atoi(toks[0]); err == nil {
+								target.Weight = n
 							}
 						}
 						ipm.Targets = append(ipm.Targets, target)
@@ -2058,63 +2042,181 @@ func compileChassis(node *Node, ch *ChassisConfig) error {
 	return nil
 }
 
-// packedOrContainerEntries returns one node per entry carried by cfgNode,
-// across every hierarchical spelling of a Junos statement that groups entries
-// (#6588 — the chassis-cluster instance of the #2419 / #3843 dual-AST-shape
-// class). `skip` is the number of leading Keys that name the statement itself
-// rather than an entry.
+// monitorEntryNodes returns one node per MONITORED ENTRY carried by cfgNode —
+// a redundancy-group `interface-monitor` statement or an ip-monitoring
+// `inet` address list — across every spelling (#6588). `skip` is the number of
+// leading Keys that name the statement itself rather than an entry.
 //
-//   - CONTAINER block   `interface-monitor { ge-0/0/0 weight 255; }`
-//     → Keys=["interface-monitor"], one child node per entry. The entries are
-//     the children; returned unchanged.
-//   - PACKED one-liner  `interface-monitor ge-0/0/0 weight 255;`
-//     → Keys=["interface-monitor","ge-0/0/0","weight","255"], NO children. The
-//     statement itself is a single entry; it is returned as one synthetic node
-//     carrying the Keys tail.
-//   - PACKED with block `interface-monitor ge-0/0/0 { weight 255; }`
-//     → Keys=["interface-monitor","ge-0/0/0"], children are that entry's
-//     ATTRIBUTES. The synthetic node keeps them so a nested `weight` is still
-//     found by the caller's FindChild.
-//   - flat set command  `set ... interface-monitor ge-0/0/0 weight 255`
-//     → SetPath yields the CONTAINER shape (the statement keyword becomes the
-//     node, the remaining tokens one child leaf), so it needs no unpacking.
+// Two independent collapses have to be undone, and they compose:
 //
-// The inline tail and the children are EITHER/OR rather than accumulated —
-// exactly the rule namedInstances already applies to named instances. A tail
-// means the statement IS one entry, so its children are that entry's
-// properties, not sibling entries. Accumulating instead would mint a bogus
-// second entry named after the first attribute (`interface-monitor ge-0/0/0 {
-// weight 255; }` would compile a monitor for an interface literally called
-// "weight").
+//  1. PACKED statement. `interface-monitor ge-0/0/0 weight 255;` yields
+//     Keys=["interface-monitor","ge-0/0/0","weight","255"] and NO children,
+//     while `interface-monitor { ge-0/0/0 weight 255; }` yields
+//     Keys=["interface-monitor"] with one child per entry. A flat `set` command
+//     produces the CONTAINER shape. Reading only Children dropped the packed
+//     spelling entirely — the original #6588 fail-open.
 //
-// Before #6588 the callers iterated cfgNode.Children only, so every PACKED
-// spelling was SILENTLY DROPPED: a hand-authored or `load merge`d config
-// compiled to ZERO interface monitors and ZERO ip-monitoring targets while
-// `commit` succeeded with no error and no warning. The operator had link and
-// probe tracking configured and a redundancy group that never demoted — a
-// failover fail-open. Since the monitors now reach the compiled *Config, the
-// #6549 weight range gate in validateChassisClusterStrict (which runs on the
-// compiled int) covers the packed spelling too.
+//     Tail and children are EITHER/OR here, not accumulated — the rule
+//     namedInstances already applies. A tail means the statement IS one entry,
+//     so its children are that entry's ATTRIBUTES:
+//     `interface-monitor ge-0/0/0 { weight 255; }` must compile ONE monitor for
+//     ge-0/0/0, not a second one named after its first attribute. (Accumulating
+//     there mints a monitor for an interface literally called "weight".)
 //
-// Only the outermost level is unpacked: the tail becomes ONE entry, which is
-// the shape Junos renders (one statement per line). A tail packing two sibling
-// statements onto a single line is not a Junos spelling and is not split here.
-func packedOrContainerEntries(cfgNode *Node, skip int) []*Node {
+//  2. BRACKETED list. The lexer strips `[`/`]` (#2419), so
+//     `interface-monitor [ ge-0/0/0 ge-0/0/1 ]` collapses N names onto ONE
+//     node's Keys in EVERY spelling — packed, hierarchical container child, and
+//     flat-set child alike. Taking only Keys[skip] compiled the FIRST name and
+//     silently discarded the rest, which is the same failover fail-open one
+//     monitor at a time. Each candidate's Keys are therefore SPLIT at entry
+//     boundaries: a token that is not the `weight` keyword (or the value slot
+//     reserved immediately after it) starts a new entry.
+//
+// The value slot reservation matters for the same reason it does in the #6524
+// application walk: `weight` consumes exactly one following token even when
+// that token spells something else, so a malformed `weight weight` cannot
+// silently split into two entries. A malformed or duplicated weight is
+// reported by validateMonitorWeightTokensAST, which derives its entries from
+// THIS function so the gate and the compiler can never disagree.
+//
+// A candidate's children are attributes of every entry it produces. That is
+// exact for the N==1 case (the only shape Junos renders) and lossless for the
+// invented `[ a b ] { weight 255; }` — over-applying a weight adds demotion
+// debt, the fail-SAFE direction, whereas dropping it silently is the failure
+// mode this whole change exists to remove.
+func monitorEntryNodes(cfgNode *Node, skip int) []*Node {
+	var candidates []*Node
 	if len(cfgNode.Keys) > skip {
-		return []*Node{{
-			Keys:     append([]string(nil), cfgNode.Keys[skip:]...),
+		candidates = []*Node{{
+			Keys:     cfgNode.Keys[skip:],
 			Children: cfgNode.Children,
 			IsLeaf:   cfgNode.IsLeaf,
 			Line:     cfgNode.Line,
 			Column:   cfgNode.Column,
 		}}
+	} else {
+		candidates = cfgNode.Children
 	}
-	return cfgNode.Children
+
+	var entries []*Node
+	for _, cand := range candidates {
+		var split []*Node
+		for i := 0; i < len(cand.Keys); {
+			tok := cand.Keys[i]
+			if tok == monitorWeightKeyword && len(split) > 0 {
+				// Attribute of the entry opened above; reserve its value slot.
+				cur := split[len(split)-1]
+				cur.Keys = append(cur.Keys, tok)
+				if i+1 < len(cand.Keys) {
+					cur.Keys = append(cur.Keys, cand.Keys[i+1])
+					i += 2
+					continue
+				}
+				i++
+				continue
+			}
+			split = append(split, &Node{
+				Keys:   []string{tok},
+				IsLeaf: cand.IsLeaf,
+				Line:   cand.Line,
+				Column: cand.Column,
+			})
+			i++
+		}
+		for _, e := range split {
+			e.Children = cand.Children
+		}
+		entries = append(entries, split...)
+	}
+	return entries
+}
+
+// monitorWeightKeyword is the only attribute a monitored entry carries. It is
+// named so monitorEntryNodes and validateMonitorWeightTokensAST cannot drift
+// apart from the compiler's reader.
+const monitorWeightKeyword = "weight"
+
+// monitorWeightTokens returns every `weight` VALUE an entry carries, across
+// both locations the value can occupy (#6588):
+//
+//   - inline on the entry's own Keys — `ge-0/0/0 weight 255`
+//   - as a child leaf              — `ge-0/0/0 { weight 255; }`
+//
+// Callers take the FIRST token, so the compiled weight is the same regardless
+// of spelling. Before #6588 the two locations disagreed on which duplicate
+// won: the inline scan overwrote (last wins) while FindChild returned the
+// first, so `weight 100 weight 200` compiled to 200 inline but 100 in a block.
+// Returning every token also lets the AST gate REJECT a duplicate rather than
+// silently pick one, which is what makes the answer spelling-independent.
+//
+// A `weight` keyword with no following token yields an empty-string entry, so
+// the gate reports it as malformed rather than the caller treating it as absent.
+func monitorWeightTokens(entry *Node) []string {
+	var out []string
+	for i := 1; i < len(entry.Keys); i++ {
+		if entry.Keys[i] != monitorWeightKeyword {
+			continue
+		}
+		if i+1 < len(entry.Keys) {
+			out = append(out, entry.Keys[i+1])
+			i++
+			continue
+		}
+		out = append(out, "")
+	}
+	for _, c := range entry.Children {
+		if len(c.Keys) > 0 && c.Keys[0] == monitorWeightKeyword {
+			out = append(out, nodeVal(c))
+		}
+	}
+	return out
+}
+
+// packedStatementProps returns one node per PROPERTY carried by a statement
+// whose body is a set of named properties rather than a list of monitored
+// entries — `ip-monitoring` (#6588). `skip` names the statement itself and
+// isProp reports whether a token opens a new property.
+//
+//	ip-monitoring { global-weight 255; family inet 10.0.1.1 weight 100; }
+//	  -> Keys=["ip-monitoring"], one child per property (returned as-is)
+//	ip-monitoring global-weight 255;
+//	  -> Keys=["ip-monitoring","global-weight","255"], no children
+//	     -> one synthetic property node ["global-weight","255"]
+//
+// This is deliberately NOT monitorEntryNodes: there every non-attribute token
+// opens an entry, which would shred `global-weight 255` into two. Here the tail
+// is split only at recognized property keywords, so a property's value tokens
+// stay with it. Both a packed tail and real children are returned when both
+// exist — properties are siblings, so nothing is lost either way (unlike a
+// monitored entry, where children are that entry's attributes).
+func packedStatementProps(cfgNode *Node, skip int, isProp func(string) bool) []*Node {
+	var props []*Node
+	if len(cfgNode.Keys) > skip {
+		var cur *Node
+		for _, tok := range cfgNode.Keys[skip:] {
+			if cur == nil || isProp(tok) {
+				cur = &Node{Keys: []string{tok}, Line: cfgNode.Line, Column: cfgNode.Column}
+				props = append(props, cur)
+				continue
+			}
+			cur.Keys = append(cur.Keys, tok)
+		}
+	}
+	return append(props, cfgNode.Children...)
+}
+
+// isIPMonitoringProp reports whether tok opens an `ip-monitoring` property.
+func isIPMonitoringProp(tok string) bool {
+	switch tok {
+	case "global-weight", "global-threshold", "family":
+		return true
+	}
+	return false
 }
 
 // findNamedNode returns the first node in nodes whose first key is name — the
-// slice equivalent of Node.FindChild, for callers that must search the
-// packedOrContainerEntries result rather than a node's raw Children.
+// slice equivalent of Node.FindChild, for callers that must search a
+// packedStatementProps result rather than a node's raw Children.
 func findNamedNode(nodes []*Node, name string) *Node {
 	for _, n := range nodes {
 		if len(n.Keys) > 0 && n.Keys[0] == name {

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -2102,33 +2102,47 @@ func monitorEntryNodes(cfgNode *Node, skip int) []*Node {
 
 	var entries []*Node
 	for _, cand := range candidates {
-		var split []*Node
+		// Separate the entry NAMES from the `weight <n>` attribute tokens, then
+		// give every name the candidate's full attribute run. The attributes are
+		// candidate-scoped, NOT positional: a bracketed list with a trailing
+		// inline weight applies that weight to every member, matching the
+		// children-block spelling `[ a b ] { weight 255; }` and the fail-safe
+		// rule documented above. Attaching it to the preceding name only (the
+		// obvious reading, and what this function did when it was first written)
+		// left `[ ge-0/0/0 ge-0/0/1 ] weight 255` with ge-0/0/0 at weight ZERO —
+		// monitored but deducting nothing, so its link going down did not demote
+		// the group. That was WORSE than master, which compiled one monitor at
+		// 255 and dropped the rest.
+		var names, attrs []string
 		for i := 0; i < len(cand.Keys); {
 			tok := cand.Keys[i]
-			if tok == monitorWeightKeyword && len(split) > 0 {
-				// Attribute of the entry opened above; reserve its value slot.
-				cur := split[len(split)-1]
-				cur.Keys = append(cur.Keys, tok)
+			if tok == monitorWeightKeyword && len(names) > 0 {
+				// Reserve the value slot: `weight` consumes exactly one
+				// following token even when that token spells a name.
+				attrs = append(attrs, tok)
 				if i+1 < len(cand.Keys) {
-					cur.Keys = append(cur.Keys, cand.Keys[i+1])
+					attrs = append(attrs, cand.Keys[i+1])
 					i += 2
 					continue
 				}
 				i++
 				continue
 			}
-			split = append(split, &Node{
-				Keys:   []string{tok},
-				IsLeaf: cand.IsLeaf,
-				Line:   cand.Line,
-				Column: cand.Column,
-			})
+			names = append(names, tok)
 			i++
 		}
-		for _, e := range split {
-			e.Children = cand.Children
+		for _, name := range names {
+			keys := make([]string, 0, 1+len(attrs))
+			keys = append(keys, name)
+			keys = append(keys, attrs...)
+			entries = append(entries, &Node{
+				Keys:     keys,
+				Children: cand.Children,
+				IsLeaf:   cand.IsLeaf,
+				Line:     cand.Line,
+				Column:   cand.Column,
+			})
 		}
-		entries = append(entries, split...)
 	}
 	return entries
 }
@@ -2241,7 +2255,26 @@ func packedStatementProps(cfgNode *Node, skip int, isProp func(string) bool) []*
 // first-wins yields an empty TrackInterface). See the #6588 PR body for the
 // experiment. Other one-sided namedInstances callers are tracked separately.
 func redundancyGroupBody(rgNode *Node) []*Node {
-	return packedStatementProps(rgNode, 2, isRedundancyGroupStatement)
+	// namedInstances returns TWO different node shapes, and the number of
+	// leading identity Keys differs between them:
+	//
+	//   len(child.Keys) >= 2  -> the node ITSELF, Keys[0]=="redundancy-group",
+	//                            Keys[1]==<id>                        -> skip 2
+	//   otherwise             -> a `sub` CHILD of a bare `redundancy-group { }`
+	//                            container, whose Keys[0] IS the <id>  -> skip 1
+	//
+	// Keys[0] is an exact discriminator: the first shape is always reached
+	// through FindChildren("redundancy-group"), so its Keys[0] is that keyword;
+	// the second is a child of that container, so its Keys[0] is the instance
+	// name and never the keyword. Using a fixed skip of 2 swallowed the
+	// STATEMENT keyword on the second shape and opened a node named after a
+	// value, which no switch arm matches — the same silent-nothing outcome,
+	// including the dropped election priority, that this function exists to fix.
+	skip := 1
+	if rgNode.Name() == "redundancy-group" {
+		skip = 2
+	}
+	return packedStatementProps(rgNode, skip, isRedundancyGroupStatement)
 }
 
 // isRedundancyGroupStatement reports whether tok opens a statement in a

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -1960,7 +1960,10 @@ func compileChassis(node *Node, ch *ChassisConfig) error {
 			case "strict-vip-ownership":
 				rg.StrictVIPOwnership = true
 			case "interface-monitor":
-				for _, ifChild := range child.Children {
+				// packedOrContainerEntries (#6588): the packed one-liner
+				// `interface-monitor ge-0/0/0 weight 255;` carries the monitor
+				// on the statement's OWN Keys and has no children at all.
+				for _, ifChild := range packedOrContainerEntries(child, 1) {
 					im := &InterfaceMonitor{
 						Interface: ifChild.Name(),
 					}
@@ -1983,35 +1986,47 @@ func compileChassis(node *Node, ch *ChassisConfig) error {
 				}
 			case "ip-monitoring":
 				ipm := &IPMonitoring{}
-				if gwNode := child.FindChild("global-weight"); gwNode != nil {
+				// #6588: ip-monitoring installs redundancy-group demotion debt
+				// through the same election path as interface-monitor, and it
+				// packs the same way — `ip-monitoring global-weight 255;` and
+				// `ip-monitoring family inet 10.0.1.1 weight 100;` are leaves
+				// with no children.
+				ipmEntries := packedOrContainerEntries(child, 1)
+				if gwNode := findNamedNode(ipmEntries, "global-weight"); gwNode != nil {
 					if v := nodeVal(gwNode); v != "" {
 						if n, err := strconv.Atoi(v); err == nil {
 							ipm.GlobalWeight = n
 						}
 					}
 				}
-				if gtNode := child.FindChild("global-threshold"); gtNode != nil {
+				if gtNode := findNamedNode(ipmEntries, "global-threshold"); gtNode != nil {
 					if v := nodeVal(gtNode); v != "" {
 						if n, err := strconv.Atoi(v); err == nil {
 							ipm.GlobalThreshold = n
 						}
 					}
 				}
-				for _, familyNode := range child.Children {
+				for _, familyNode := range ipmEntries {
 					if familyNode.Name() != "family" {
 						continue
 					}
 					// Determine inet node: compound key "family inet" vs nested family { inet { } }
 					var inetNode *Node
+					// inetSkip is how many of inetNode's leading Keys name the
+					// node itself rather than a monitored address, so a packed
+					// target (`family inet 10.0.1.1 weight 100;`) is unpacked
+					// from the right offset.
+					inetSkip := 2
 					if len(familyNode.Keys) >= 2 && familyNode.Keys[1] == "inet" {
 						inetNode = familyNode
 					} else {
 						inetNode = familyNode.FindChild("inet")
+						inetSkip = 1
 					}
 					if inetNode == nil {
 						continue
 					}
-					for _, addrChild := range inetNode.Children {
+					for _, addrChild := range packedOrContainerEntries(inetNode, inetSkip) {
 						target := &IPMonitorTarget{
 							Address: addrChild.Name(),
 						}
@@ -2040,6 +2055,72 @@ func compileChassis(node *Node, ch *ChassisConfig) error {
 		ch.Cluster.RedundancyGroups = append(ch.Cluster.RedundancyGroups, rg)
 	}
 
+	return nil
+}
+
+// packedOrContainerEntries returns one node per entry carried by cfgNode,
+// across every hierarchical spelling of a Junos statement that groups entries
+// (#6588 — the chassis-cluster instance of the #2419 / #3843 dual-AST-shape
+// class). `skip` is the number of leading Keys that name the statement itself
+// rather than an entry.
+//
+//   - CONTAINER block   `interface-monitor { ge-0/0/0 weight 255; }`
+//     → Keys=["interface-monitor"], one child node per entry. The entries are
+//     the children; returned unchanged.
+//   - PACKED one-liner  `interface-monitor ge-0/0/0 weight 255;`
+//     → Keys=["interface-monitor","ge-0/0/0","weight","255"], NO children. The
+//     statement itself is a single entry; it is returned as one synthetic node
+//     carrying the Keys tail.
+//   - PACKED with block `interface-monitor ge-0/0/0 { weight 255; }`
+//     → Keys=["interface-monitor","ge-0/0/0"], children are that entry's
+//     ATTRIBUTES. The synthetic node keeps them so a nested `weight` is still
+//     found by the caller's FindChild.
+//   - flat set command  `set ... interface-monitor ge-0/0/0 weight 255`
+//     → SetPath yields the CONTAINER shape (the statement keyword becomes the
+//     node, the remaining tokens one child leaf), so it needs no unpacking.
+//
+// The inline tail and the children are EITHER/OR rather than accumulated —
+// exactly the rule namedInstances already applies to named instances. A tail
+// means the statement IS one entry, so its children are that entry's
+// properties, not sibling entries. Accumulating instead would mint a bogus
+// second entry named after the first attribute (`interface-monitor ge-0/0/0 {
+// weight 255; }` would compile a monitor for an interface literally called
+// "weight").
+//
+// Before #6588 the callers iterated cfgNode.Children only, so every PACKED
+// spelling was SILENTLY DROPPED: a hand-authored or `load merge`d config
+// compiled to ZERO interface monitors and ZERO ip-monitoring targets while
+// `commit` succeeded with no error and no warning. The operator had link and
+// probe tracking configured and a redundancy group that never demoted — a
+// failover fail-open. Since the monitors now reach the compiled *Config, the
+// #6549 weight range gate in validateChassisClusterStrict (which runs on the
+// compiled int) covers the packed spelling too.
+//
+// Only the outermost level is unpacked: the tail becomes ONE entry, which is
+// the shape Junos renders (one statement per line). A tail packing two sibling
+// statements onto a single line is not a Junos spelling and is not split here.
+func packedOrContainerEntries(cfgNode *Node, skip int) []*Node {
+	if len(cfgNode.Keys) > skip {
+		return []*Node{{
+			Keys:     append([]string(nil), cfgNode.Keys[skip:]...),
+			Children: cfgNode.Children,
+			IsLeaf:   cfgNode.IsLeaf,
+			Line:     cfgNode.Line,
+			Column:   cfgNode.Column,
+		}}
+	}
+	return cfgNode.Children
+}
+
+// findNamedNode returns the first node in nodes whose first key is name — the
+// slice equivalent of Node.FindChild, for callers that must search the
+// packedOrContainerEntries result rather than a node's raw Children.
+func findNamedNode(nodes []*Node, name string) *Node {
+	for _, n := range nodes {
+		if len(n.Keys) > 0 && n.Keys[0] == name {
+			return n
+		}
+	}
 	return nil
 }
 

--- a/pkg/config/compiler_validate_strict_chassis.go
+++ b/pkg/config/compiler_validate_strict_chassis.go
@@ -107,8 +107,9 @@ func ClampInterfaceMonitorWeight(w int) (int, bool) {
 // chassis-cluster config whose redundancy-group cardinality or ids exceed
 // what the HA heartbeat wire format can encode (#4434, codex-172 C172-H02),
 // whose per-RG node priority is out of the VRRP range (#4880), or whose
-// interface-monitor weight is out of the [0,255] heartbeat weight domain
-// (#6549).
+// interface-monitor weight (#6549) or ip-monitoring global-weight /
+// global-threshold / per-target weight (#6588) is out of the [0,255] heartbeat
+// weight domain.
 //
 // The heartbeat count byte and per-group id byte are both uint8. There is
 // no schema-level value validation on the `redundancy-group <id>` instance
@@ -220,6 +221,66 @@ func validateChassisClusterStrict(cfg *Config) error {
 					rg.ID, im.Interface, im.Weight,
 					MinInterfaceMonitorWeight, MaxInterfaceMonitorWeight,
 					MinInterfaceMonitorWeight, MaxInterfaceMonitorWeight)
+			}
+		}
+
+		// #6588: the SAME compiled-int gate for the ip-monitoring weights.
+		// They carry a typed schema leaf (schema_chassis.go
+		// ValidateInteger(0,255)), which is why #6549 left them to it — but
+		// SchemaValidate walks the AST from setSchema and a PACKED statement
+		// (`ip-monitoring family inet 10.0.1.1 weight -100;`) sits BELOW the
+		// depth that walk reaches, so the typed leaf never fires on it. Before
+		// #6588 that was harmless because the packed spelling compiled to
+		// nothing at all; now that it compiles, an out-of-range packed weight
+		// would reach the runtime with no commit-side gate on ANY path.
+		// Asserting the range here — on the compiled int, exactly where the
+		// interface-monitor gate above lives — makes all three spellings
+		// (flat-set, container-hierarchical, packed) converge on one answer.
+		//
+		// The domain is the same one and for the same reason: an ip-monitoring
+		// weight is demotion DEBT subtracted from the redundancy-group weight,
+		// which the heartbeat advertises through a single wire byte while the
+		// local election reads the raw int. A negative weight is worse here
+		// than for interface-monitor: in global-threshold mode it SUBTRACTS
+		// from the cumulative failure sum, so a second genuinely unreachable
+		// target pushes the sum back BELOW the threshold and drops the debt the
+		// first failure installed — more failures produce LESS demotion.
+		if ipm := rg.IPMonitoring; ipm != nil {
+			if ipm.GlobalWeight < MinInterfaceMonitorWeight || ipm.GlobalWeight > MaxInterfaceMonitorWeight {
+				return fmt.Errorf("chassis cluster: redundancy-group %d ip-monitoring "+
+					"global-weight %d is out of range %d..%d (the weight is subtracted from "+
+					"the redundancy-group weight, which the heartbeat advertises through a "+
+					"single wire byte while the local election reads the raw value) — set a "+
+					"global-weight in %d..%d",
+					rg.ID, ipm.GlobalWeight,
+					MinInterfaceMonitorWeight, MaxInterfaceMonitorWeight,
+					MinInterfaceMonitorWeight, MaxInterfaceMonitorWeight)
+			}
+			if ipm.GlobalThreshold < MinInterfaceMonitorWeight || ipm.GlobalThreshold > MaxInterfaceMonitorWeight {
+				return fmt.Errorf("chassis cluster: redundancy-group %d ip-monitoring "+
+					"global-threshold %d is out of range %d..%d (the threshold is compared "+
+					"against the cumulative failure weight, which shares the single-byte "+
+					"heartbeat weight domain) — set a global-threshold in %d..%d",
+					rg.ID, ipm.GlobalThreshold,
+					MinInterfaceMonitorWeight, MaxInterfaceMonitorWeight,
+					MinInterfaceMonitorWeight, MaxInterfaceMonitorWeight)
+			}
+			// Targets is an AST-order slice, so the first-error message is
+			// already deterministic without sorting.
+			for _, tgt := range ipm.Targets {
+				if tgt == nil { // tolerant/HA-sync path may carry a nil entry (#3494).
+					continue
+				}
+				if tgt.Weight < MinInterfaceMonitorWeight || tgt.Weight > MaxInterfaceMonitorWeight {
+					return fmt.Errorf("chassis cluster: redundancy-group %d ip-monitoring "+
+						"family inet %s weight %d is out of range %d..%d (the weight is "+
+						"subtracted from the redundancy-group weight, and in global-threshold "+
+						"mode a negative weight cancels a sibling target's real failure so more "+
+						"failures produce LESS demotion) — set a weight in %d..%d",
+						rg.ID, tgt.Address, tgt.Weight,
+						MinInterfaceMonitorWeight, MaxInterfaceMonitorWeight,
+						MinInterfaceMonitorWeight, MaxInterfaceMonitorWeight)
+				}
 			}
 		}
 	}

--- a/pkg/config/schema_chassis.go
+++ b/pkg/config/schema_chassis.go
@@ -242,13 +242,22 @@ var schemaChassis = &schemaNode{desc: "Chassis configuration", children: map[str
 				// SetMonitorWeight election.go:324); heartbeat monitor
 				// entries carry weight as uint8.
 				//
-				// #6549: unlike interface-monitor weight, these leaves
-				// have NO compiled-int gate in
-				// validateChassisClusterStrict — this ValidateInteger is
-				// their only commit-side defense, and compileTreeLenient
-				// downgrades it to a warning on Store.Load /
-				// Store.SyncApply (#1960 no-brick). An out-of-range value
-				// therefore REACHES runtime, where pkg/cluster bounds it:
+				// #6549 left these leaves to this ValidateInteger alone,
+				// on the reasoning that a typed leaf covers them. #6588
+				// showed that is only true for the shapes the schema
+				// WALKER reaches: SchemaValidate descends setSchema, so a
+				// PACKED statement (`ip-monitoring family inet 10.0.1.1
+				// weight -100;`, written directly under redundancy-group)
+				// sits below its depth and no validator fires. That was
+				// harmless while the packed spelling compiled to nothing;
+				// once #6588 made it compile, these leaves gained the same
+				// compiled-int gate their interface-monitor sibling has, in
+				// validateChassisClusterStrict — the one layer all three
+				// spellings pass through. This ValidateInteger remains the
+				// earlier, better-worded rejection for the flat-set path.
+				// Both are downgraded on the tolerant load / peer-sync
+				// paths (#1960 no-brick), so an out-of-range value can
+				// still REACH runtime, where pkg/cluster bounds it:
 				// Monitor.ipTargetWeight and the aggregate branch of
 				// desiredRGIPDebts (which also protects the cumulative
 				// global-threshold sum a negative weight would otherwise


### PR DESCRIPTION
Closes #6588

## The defect

A chassis-cluster redundancy-group monitor authored in the **packed hierarchical**
spelling — one statement directly under `redundancy-group`, no nested block —
compiled to **nothing**:

```
redundancy-group 1 {
    interface-monitor ge-0/0/0 weight 255;    ->  rgs=1, monitors=0
}
```

The hierarchical parser emits one leaf with `Keys=["interface-monitor","ge-0/0/0","weight","255"]`
and **no children**, while `compileChassis` (`pkg/config/compiler_system.go:1962`)
enumerated monitors by iterating `child.Children` alone.

That is a failover **fail-open**: `commit` succeeds with no error and no warning,
`show configuration` echoes the operator's intent back verbatim, and the
redundancy group never demotes when the monitored link goes down.

The shape reaches the compiler only from a hand-authored config file, `load merge` /
`load override`, or a peer config sync — a `set` command produces the container
shape, which is why the flat-set path always worked and this stayed hidden.

## Search scope for sibling sites

Stated explicitly rather than as "sweep complete".

**Scope 1 — every switch arm in `compileChassis`, the function the issue names (6 arms).**
Each was checked by *direct compile*, not by reading:

| arm | packed shape | verdict |
|---|---|---|
| `node` | `node 0 priority 200;` | already dual-shape (inline `Keys[2:]` loop + `FindChild`) — **no change** |
| `gratuitous-arp-count` | `gratuitous-arp-count 8;` | `nodeVal` reads `Keys[1]` or `Children[0]` — **no change** |
| `preempt` | presence flag | no value to drop — **no change** |
| `strict-vip-ownership` | presence flag | no value to drop — **no change** |
| `interface-monitor` | `interface-monitor ge-0/0/0 weight 255;` | **DEFECTIVE → 0 monitors — fixed** |
| `ip-monitoring` | `ip-monitoring global-weight 255;` / `ip-monitoring family inet 10.0.1.1 weight 100;` | **DEFECTIVE → 0 weights, 0 targets — fixed** |

`ip-monitoring` is included because it is the *same* bug in the *same* loop feeding
the *same* redundancy-group demotion debt. A third sub-shape inside it —
`ip-monitoring { family inet 10.0.1.1 weight 100; }`, packed family leaf inside a
real block — dropped the target too, and is also fixed.

**Scope 2 — every other Go reader of these AST tokens.**
`grep -rn '"interface-monitor"\|"ip-monitoring"' --include=*.go . | grep -v _test.go`
→ `compiler_system.go` is the **only** file that compiles the chassis-cluster
`interface-monitor` / `ip-monitoring` AST. Every other hit is cmdtree / CLI display /
runtime reading the already-compiled struct, or the unrelated `services ip-monitoring`
stanza. Also checked the two other chassis-subtree AST readers:
- `collectDeviceMapProps` (`compiler_chassis.go`) already walks `Keys` at every depth — not defective.
- `validateChassisClusterIdentitiesAST` (`compiler_chassis_identity.go`) iterates the RG's
  own children looking for `node`, which is a direct child in every spelling — not defective.

**Scope 3 — deliberately left out, with the reason.**
`services ip-monitoring` (#1827, `compiler_services.go`) drops its packed
`then preferred-route ...;` the same way. It is **genuinely different: fail-CLOSED**.
Verified by direct compile — a policy with zero compiled routes is a hard commit error:

```
container:              policy p1 probe="WAN" routes=1
                            route 0.0.0.0/0 nh=10.0.0.1 metric=5
packed-then:            COMPILE ERROR services ip-monitoring policy "p1": at least one then preferred-route route is required
packed-preferred-route: COMPILE ERROR services ip-monitoring policy "p1": at least one then preferred-route route is required
```

The operator is told, rather than left with a silent no-op, so it does not belong in
this fix. The class-wide population is larger still — `grep -rn "range .*\.Children" pkg/config/compiler_*.go`
finds **267 loops across 36 files**. Generalizing to all of them is a separate campaign,
not this PR; what is claimed here is the chassis-cluster subtree, swept exhaustively.

## A third sub-shape the issue did not name

Surfaced by the new test, not by the bug report:

```
interface-monitor ge-0/0/0 { weight 255; }
```

packs the interface **name** onto the statement while the attributes arrive as
children. The old reader took `Children[0].Name()` and compiled a monitor for an
interface literally called **`weight`** — worse than a drop. This is why the new
helper's rule is **EITHER/OR, not accumulate**: an inline tail means the statement
IS one entry, so its children are that entry's properties, not sibling entries. That
is the rule `namedInstances` already applies, and it is deliberately the *opposite*
of the #2419 multi-value contract — accumulating is exactly what mints the bogus monitor.

## Second-order effect (issue's own note)

Because the packed spelling now reaches the compiled `*Config`, the #6549 weight range
gate — which runs on the compiled int rather than on the AST — covers it for free. A
packed `weight -100`, previously accepted at commit because no monitor existed for the
gate to inspect, is now rejected. Pinned by
`TestChassisInterfaceMonitorPackedWeightRangeGated_6588`.

## Mutation proof

`compiler_system.go` restored **verbatim** from `origin/master`, the new test kept.

### Step 1 — the revert is exact, and build + vet are CLEAN (a build break would be a FALSE red)

```
$ git show origin/master:pkg/config/compiler_system.go > pkg/config/compiler_system.go
$ git diff --stat origin/master -- pkg/config/compiler_system.go
                                          <- empty: byte-identical to master
$ go build ./...
BUILD CLEAN
$ go vet ./pkg/config/
VET CLEAN
```

### Step 2 — the new test reds as an ASSERTION naming what is missing

```
=== RUN   TestChassisInterfaceMonitorAllThreeSpellings_6588/Packed
compiler_chassis_packed_monitor_6588_test.go:118: expected exactly 1 interface-monitor (ge-0/0/0 weight 255), got 0: <none> — a redundancy group with zero compiled monitors never demotes on link-down
--- FAIL: TestChassisInterfaceMonitorAllThreeSpellings_6588 (0.00s)
--- PASS: TestChassisInterfaceMonitorAllThreeSpellings_6588/FlatSet (0.00s)
--- PASS: TestChassisInterfaceMonitorAllThreeSpellings_6588/ContainerHierarchical (0.00s)
--- FAIL: TestChassisInterfaceMonitorAllThreeSpellings_6588/Packed (0.00s)
=== RUN   TestChassisInterfaceMonitorPackedMultiple_6588
compiler_chassis_packed_monitor_6588_test.go:144: expected 2 interface-monitors, got 0: <none>
--- FAIL: TestChassisInterfaceMonitorPackedMultiple_6588 (0.00s)
=== RUN   TestChassisInterfaceMonitorPackedNoWeight_6588
compiler_chassis_packed_monitor_6588_test.go:170: expected exactly 1 interface-monitor (ge-0/0/0 weight 0), got 0: <none> — a redundancy group with zero compiled monitors never demotes on link-down
--- FAIL: TestChassisInterfaceMonitorPackedNoWeight_6588 (0.00s)
=== RUN   TestChassisInterfaceMonitorPackedNestedWeight_6588
compiler_chassis_packed_monitor_6588_test.go:180: monitor = weight weight 0, want ge-0/0/0 weight 255
--- FAIL: TestChassisInterfaceMonitorPackedNestedWeight_6588 (0.00s)
=== RUN   TestChassisInterfaceMonitorPackedWeightRangeGated_6588/weight_-100
compiler_chassis_packed_monitor_6588_test.go:200: expected commit to reject the packed out-of-range interface-monitor weight -100 (#6549 gates the compiled int), got nil error
=== RUN   TestChassisInterfaceMonitorPackedWeightRangeGated_6588/weight_-1
compiler_chassis_packed_monitor_6588_test.go:200: expected commit to reject the packed out-of-range interface-monitor weight -1 (#6549 gates the compiled int), got nil error
=== RUN   TestChassisInterfaceMonitorPackedWeightRangeGated_6588/weight_256
compiler_chassis_packed_monitor_6588_test.go:200: expected commit to reject the packed out-of-range interface-monitor weight 256 (#6549 gates the compiled int), got nil error
=== RUN   TestChassisInterfaceMonitorPackedWeightRangeGated_6588/weight_1000
compiler_chassis_packed_monitor_6588_test.go:200: expected commit to reject the packed out-of-range interface-monitor weight 1000 (#6549 gates the compiled int), got nil error
--- FAIL: TestChassisInterfaceMonitorPackedWeightRangeGated_6588 (0.00s)
=== RUN   TestChassisIPMonitoringPackedShapes_6588/PackedFamilyLeafInsideBlock
compiler_chassis_packed_monitor_6588_test.go:289: expected exactly 1 ip-monitoring target (10.0.1.1 weight 100), got 0
=== RUN   TestChassisIPMonitoringPackedShapes_6588/PackedInetLeafInsideFamilyBlock
compiler_chassis_packed_monitor_6588_test.go:289: expected exactly 1 ip-monitoring target (10.0.1.1 weight 100), got 0
--- FAIL: TestChassisIPMonitoringPackedShapes_6588 (0.00s)
--- PASS: TestChassisIPMonitoringPackedShapes_6588/ControlNestedFamilyBlock (0.00s)
--- PASS: TestChassisIPMonitoringPackedShapes_6588/ControlCompoundFamilyBlock (0.00s)
--- FAIL: TestChassisIPMonitoringPackedShapes_6588/PackedFamilyLeafInsideBlock (0.00s)
--- FAIL: TestChassisIPMonitoringPackedShapes_6588/PackedInetLeafInsideFamilyBlock (0.00s)
=== RUN   TestChassisIPMonitoringFullyPacked_6588/GlobalWeightOnly
compiler_chassis_packed_monitor_6588_test.go:311: global-weight = 0, want 255
=== RUN   TestChassisIPMonitoringFullyPacked_6588/FamilyTargetOnly
compiler_chassis_packed_monitor_6588_test.go:321: expected exactly 1 ip-monitoring target, got 0
--- FAIL: TestChassisIPMonitoringFullyPacked_6588 (0.00s)
FAIL	github.com/psaab/xpf/pkg/config	0.008s
```

### Step 2b — unrelated tests stay green under the mutation

```
$ go test ./pkg/config/ -v 2>&1 | grep -E "^--- FAIL" | sort | uniq -c
      1 --- FAIL: TestChassisInterfaceMonitorAllThreeSpellings_6588 (0.00s)
      1 --- FAIL: TestChassisInterfaceMonitorPackedMultiple_6588 (0.00s)
      1 --- FAIL: TestChassisInterfaceMonitorPackedNestedWeight_6588 (0.00s)
      1 --- FAIL: TestChassisInterfaceMonitorPackedNoWeight_6588 (0.00s)
      1 --- FAIL: TestChassisInterfaceMonitorPackedWeightRangeGated_6588 (0.00s)
      1 --- FAIL: TestChassisIPMonitoringFullyPacked_6588 (0.00s)
      1 --- FAIL: TestChassisIPMonitoringPackedShapes_6588 (0.00s)

$ go test ./pkg/config/ -v 2>&1 | grep -E "^--- FAIL" | grep -v "_6588" | wc -l
0
```

Every failure is a `*_6588` test. Zero others.

### Step 3 — restore, confirm green

```
$ go build ./...
BUILD CLEAN
$ go vet ./...
VET CLEAN
--- PASS: TestChassisInterfaceMonitorAllThreeSpellings_6588 (0.00s)
--- PASS: TestChassisInterfaceMonitorAllThreeSpellings_6588/FlatSet (0.00s)
--- PASS: TestChassisInterfaceMonitorAllThreeSpellings_6588/ContainerHierarchical (0.00s)
--- PASS: TestChassisInterfaceMonitorAllThreeSpellings_6588/Packed (0.00s)
--- PASS: TestChassisInterfaceMonitorPackedMultiple_6588 (0.00s)
--- PASS: TestChassisInterfaceMonitorPackedNoWeight_6588 (0.00s)
--- PASS: TestChassisInterfaceMonitorPackedNestedWeight_6588 (0.00s)
--- PASS: TestChassisInterfaceMonitorPackedWeightRangeGated_6588 (0.00s)
--- PASS: TestChassisInterfaceMonitorPackedWeightRangeGated_6588/weight_-100 (0.00s)
--- PASS: TestChassisInterfaceMonitorPackedWeightRangeGated_6588/weight_-1 (0.00s)
--- PASS: TestChassisInterfaceMonitorPackedWeightRangeGated_6588/weight_256 (0.00s)
--- PASS: TestChassisInterfaceMonitorPackedWeightRangeGated_6588/weight_1000 (0.00s)
--- PASS: TestChassisIPMonitoringPackedShapes_6588 (0.00s)
--- PASS: TestChassisIPMonitoringPackedShapes_6588/ControlNestedFamilyBlock (0.00s)
--- PASS: TestChassisIPMonitoringPackedShapes_6588/ControlCompoundFamilyBlock (0.00s)
--- PASS: TestChassisIPMonitoringPackedShapes_6588/PackedFamilyLeafInsideBlock (0.00s)
--- PASS: TestChassisIPMonitoringPackedShapes_6588/PackedInetLeafInsideFamilyBlock (0.00s)
--- PASS: TestChassisIPMonitoringFullyPacked_6588 (0.00s)
--- PASS: TestChassisIPMonitoringFullyPacked_6588/GlobalWeightOnly (0.00s)
--- PASS: TestChassisIPMonitoringFullyPacked_6588/FamilyTargetOnly (0.00s)
ok  	github.com/psaab/xpf/pkg/config	0.020s
```

### Step 4 — negative controls

The controls are **separate subtests that never touch a packed shape**, so they are
controls rather than co-signers. They pass **with and without** the fix (see the
`--- PASS` lines interleaved in the Step 2 mutation output above):

- `TestChassisInterfaceMonitorAllThreeSpellings_6588/FlatSet` — the `ParseSetCommand` + `SetPath` path
- `TestChassisInterfaceMonitorAllThreeSpellings_6588/ContainerHierarchical` — `interface-monitor { ge-0/0/0 weight 255; }`
- `TestChassisIPMonitoringPackedShapes_6588/ControlNestedFamilyBlock` — `family { inet { 10.0.1.1 weight 100; } }`
- `TestChassisIPMonitoringPackedShapes_6588/ControlCompoundFamilyBlock` — `family inet { 10.0.1.1 weight 100; }`

### Full suite on the shipped tree

```
$ go build ./... && go vet ./... && go test ./...
FULL SUITE EXIT=0
59      packages ok, 0 failures
```

The flat-set tests use `ParseSetCommand()` + `tree.SetPath()` via the shared
`buildTree` helper, never `NewParser` (CLAUDE.md "Testing flat set syntax").

## Docs

- `docs/config-schema.md` — the packed shape is documented as the **fourth collapse
  pattern**, and the first one that comes from the hierarchical parser rather than
  from `SetPath`. Covers the either/or-vs-accumulate distinction against #2419, why a
  typed schema leaf cannot cover it (a packed tail sits below the depth `SchemaValidate`
  reaches, so a range gate must run on the compiled struct), and the "silently
  compiling to nothing is the worst of three options" rule with `services ip-monitoring`
  as the fail-closed counter-example.
- `docs/config-schema.md` #6549 passage — corrected. It previously named the packed
  form as an open gap ("compiles to ZERO monitors, so the gate never sees it"); it now
  states the compiled-int gating covers all three spellings, which is the issue's third
  acceptance criterion.
- `_Log.md` — entry appended.

## Acceptance criteria

- [x] The packed form compiles to a working monitor; it does not silently yield zero monitors.
- [x] Fail-on-revert test covering all THREE spellings (flat-set, container-hierarchical, packed) — `TestChassisInterfaceMonitorAllThreeSpellings_6588`.
- [x] `docs/config-schema.md` states which spellings the compiled-int gating covers.

## Not validated

No cluster smoke was run (`make test-failover` / `cluster-deploy`): the change is
confined to `pkg/config` AST-to-struct compilation with no runtime, wire-format, or
dataplane surface, and the HA cluster is a shared resource. The behavior change is
that configs which previously compiled to zero monitors now compile to the monitors
the operator wrote — exercised by unit tests across all spellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi

---

# Round 2 — three MAJORs from hostile review (head `c9481b87`)

All three were inside the code round 1 touched. Each premise was re-verified by direct compile before writing.

## MAJOR 1 — ip-monitoring 0..255 had no gate the packed spelling reaches

**Correction to the review's framing, because it changes the fix.** The finding was stated as "the packed path reaches the compiled struct without going through the range validation the container path gets." Tracing it: `SchemaValidate` is invoked from `pkg/configstore/store.go`, not from `CompileConfig`, and it walks `setSchema` — so a PACKED statement written directly under `redundancy-group` sits **below the depth it descends, for ip-monitoring exactly as for interface-monitor**. The typed leaves cover flat-set and container-hierarchical; *nothing* covered packed. So this is not a packed-only path repair — the gate has to move to the layer all three spellings share.

That layer is where #6549 put the interface-monitor gate: the compiled int in `validateChassisClusterStrict`. `global-weight`, `global-threshold` and per-target `weight` are now bounded to the same `[0,255]` heartbeat domain there. Before / after, by direct compile:

```
                                        BEFORE                    AFTER
M1 flat-set target weight -100          ACCEPT [10.0.1.1 w=-100]  STRICT-REJECT
M1 flat-set global-weight 300           ACCEPT gw=300             STRICT-REJECT
M1 container target weight -100         ACCEPT [10.0.1.1 w=-100]  STRICT-REJECT
M1 container global-weight 300          ACCEPT gw=300             STRICT-REJECT
M1 packed target weight -100            ACCEPT [10.0.1.1 w=-100]  STRICT-REJECT
M1 packed global-weight 300             ACCEPT gw=300             STRICT-REJECT
```

A negative *target* weight is worse than the interface-monitor case: in global-threshold mode it SUBTRACTS from the cumulative failure sum, so a second genuinely unreachable target pushes the sum back below the threshold and drops the debt the first failure installed — more failures producing less demotion. That is in the error text.

`TestChassisPackedShapeBypassesSchemaWalk_6588` pins the rationale directly: `SchemaValidate` returns nil for a config the compiled-int gate rejects. If a future change makes the walker reach packed statements, that test fails and the gate's justification gets revisited.

## MAJOR 2 — bracketed monitors compiled as ONE entry

Confirmed, and confirmed **pre-existing in all three spellings** rather than introduced by round 1 — the lexer strips the brackets (#2419), so N names land on one node's Keys in the packed statement, the hierarchical container child, and the flat-set child alike. Round 1's helper synthesized exactly one entry from the tail and inherited the drop.

```
                                        BEFORE                    AFTER
M2 packed    [ ge-0/0/0 ge-0/0/1 ]      mons=1 [ge-0/0/0]         mons=2 [ge-0/0/0] [ge-0/0/1]
M2 flat-set  [ ge-0/0/0 ge-0/0/1 ]      mons=1 [ge-0/0/0]         mons=2 [ge-0/0/0] [ge-0/0/1]
M2 container [ ge-0/0/0 ge-0/0/1 ]      mons=1 [ge-0/0/0]         mons=2 [ge-0/0/0] [ge-0/0/1]
M2 ipmon family inet [ .1.1 .2.1 ]      targets=1 [10.0.1.1]      targets=2 [10.0.1.1] [10.0.2.1]
```

`monitorEntryNodes` now splits each candidate's Keys at entry boundaries: a token that is neither the `weight` keyword nor the value slot reserved immediately after it starts a new entry. The value-slot reservation is the #6524 rule — `weight` consumes exactly one following token even when that token spells something else.

**The two collapse rules pull in opposite directions and both are needed:**

| statement kind | tail vs children | why |
|---|---|---|
| entry list (`interface-monitor`, ip-monitoring `inet`) | EITHER/OR | a tail means the statement IS one entry, so children are its ATTRIBUTES; accumulating mints a monitor for an interface literally named `weight` — the third sub-shape round 1 found |
| property body (`ip-monitoring`) | BOTH | properties are siblings, so nothing is lost combining them; `packedStatementProps` splits that tail only at recognized property keywords so `global-weight 255` is not shredded into two |

## MAJOR 4 — malformed weight not fail-closed, and duplicates were spelling-dependent

```
                                        BEFORE                    AFTER
M4 packed    weight nope                ACCEPT [ge-0/0/0 w=0]     STRICT-REJECT
M4 container weight nope                ACCEPT [ge-0/0/0 w=0]     STRICT-REJECT
M4 flat-set  weight nope                ACCEPT [ge-0/0/0 w=0]     STRICT-REJECT
DUP inline   weight 100 weight 200      ACCEPT w=200              STRICT-REJECT
DUP block    { weight 100; weight 200 } ACCEPT w=100              STRICT-REJECT
```

The compiled struct structurally cannot flag the malformed case — `compileChassis` leaves the 0 default on a failed `Atoi`, so `weight nope`, `weight 0`, and no weight at all are identical by the time the range gate runs. Hence a new AST pre-walk, `validateMonitorWeightTokensAST`, which derives its entries from `monitorEntryNodes` / `monitorWeightTokens` — the same readers the compiler uses — so the gate and the compiler cannot disagree about which token is a weight or which entry owns it. Strict at commit, warn on the tolerant load / peer-sync path (`lenientChassisMonitorWeight`, #1960 no-brick), pinned by `TestChassisMonitorWeightMalformedTolerantNoBrick_6588`.

On duplicates, the review asked to pick one or reject: **both**. The compiler is now uniformly first-wins via `monitorWeightTokens` (so the tolerant path is also spelling-independent), and the gate rejects the duplicate outright so no operator relies on the pick. An identical repeat gets a message that does not claim a value conflict.

The bounds themselves are confirmed sound and unchanged: 255 parses and passes, 256 is rejected, no compiler-side uint8 truncation.

## Round-2 mutation proofs

Three separate mutations, each with build + vet CLEAN **first** so the red is an assertion, not a build break.

### A — drop the MAJOR-1 ip-monitoring range block

```
BUILD CLEAN
VET CLEAN
compiler_chassis_packed_monitor_6588_test.go:401: expected commit to be rejected with "global-weight 300 is out of range 0..255", got nil error
compiler_chassis_packed_monitor_6588_test.go:404: expected commit to be rejected with "global-weight 300 is out of range 0..255", got nil error
compiler_chassis_packed_monitor_6588_test.go:407: expected commit to be rejected with "global-weight 300 is out of range 0..255", got nil error
compiler_chassis_packed_monitor_6588_test.go:401: expected commit to be rejected with "global-threshold 256 is out of range 0..255", got nil error
compiler_chassis_packed_monitor_6588_test.go:404: expected commit to be rejected with "global-threshold 256 is out of range 0..255", got nil error
compiler_chassis_packed_monitor_6588_test.go:407: expected commit to be rejected with "global-threshold 256 is out of range 0..255", got nil error
compiler_chassis_packed_monitor_6588_test.go:401: expected commit to be rejected with "family inet 10.0.1.1 weight -100 is out of range 0..255", got nil error
compiler_chassis_packed_monitor_6588_test.go:404: expected commit to be rejected with "family inet 10.0.1.1 weight -100 is out of range 0..255", got nil error
compiler_chassis_packed_monitor_6588_test.go:407: expected commit to be rejected with "family inet 10.0.1.1 weight -100 is out of range 0..255", got nil error
compiler_chassis_packed_monitor_6588_test.go:455: the compiled-int gate must reject what SchemaValidate cannot see

$ go test ./pkg/config/ -v | grep -E "^--- FAIL" | sort | uniq -c
      1 --- FAIL: TestChassisIPMonitoringWeightRangeGated_6588 (0.00s)
      1 --- FAIL: TestChassisPackedShapeBypassesSchemaWalk_6588 (0.00s)
```

Negative control `TestChassisIPMonitoringInRangeStillCommits_6588` (every legal value, both boundaries, compiled verbatim) is absent from the FAIL list — green in both worlds.

### B — make `monitorEntryNodes` return the candidate unsplit

```
BUILD CLEAN
VET CLEAN
compiler_chassis_packed_monitor_6588_test.go:475: expected 3 interface-monitors [ge-0/0/0 ge-0/0/1 ge-0/0/2], got 1: ge-0/0/0 weight 0 — a bracketed list must compile to one monitor per name, not one monitor for the first name
compiler_chassis_packed_monitor_6588_test.go:478: expected 3 interface-monitors [ge-0/0/0 ge-0/0/1 ge-0/0/2], got 1: ge-0/0/0 weight 0 — a bracketed list must compile to one monitor per name, not one monitor for the first name
compiler_chassis_packed_monitor_6588_test.go:482: expected 3 interface-monitors [ge-0/0/0 ge-0/0/1 ge-0/0/2], got 1: ge-0/0/0 weight 0 — a bracketed list must compile to one monitor per name, not one monitor for the first name
compiler_chassis_packed_monitor_6588_test.go:501: ip-monitoring targets = [10.0.1.1], want [10.0.1.1 10.0.2.1 10.0.3.1] — a bracketed list must compile to one target per address

$ go test ./pkg/config/ -v | grep -E "^--- FAIL" | sort | uniq -c
      1 --- FAIL: TestChassisInterfaceMonitorBracketList_6588 (0.00s)
      1 --- FAIL: TestChassisIPMonitoringBracketTargets_6588 (0.00s)
```

Negative control — the single non-bracketed packed monitor the review asked for — **passes in full under the mutation**:

```
--- PASS: TestChassisInterfaceMonitorSingleEntryNotSplit_6588 (0.00s)
--- PASS: TestChassisInterfaceMonitorSingleEntryNotSplit_6588/PackedWithWeight (0.00s)
--- PASS: TestChassisInterfaceMonitorSingleEntryNotSplit_6588/ContainerWithWeight (0.00s)
--- PASS: TestChassisInterfaceMonitorSingleEntryNotSplit_6588/PackedNestedWeightBlock (0.00s)
--- PASS: TestChassisInterfaceMonitorSingleEntryNotSplit_6588/FlatSetWithWeight (0.00s)
--- PASS: TestChassisInterfaceMonitorSingleEntryNotSplit_6588/SingleIPMonitorTarget (0.00s)
--- PASS: TestChassisMonitorWeightValidStillCommits_6588 (0.00s)
```

### C — unwire the MAJOR-4 weight gate from `runPreWalkGates`

```
BUILD CLEAN
VET CLEAN
compiler_chassis_packed_monitor_6588_test.go:569: expected commit to be rejected with "weight \"nope\" is not an integer", got nil error
compiler_chassis_packed_monitor_6588_test.go:572: expected commit to be rejected with "weight \"nope\" is not an integer", got nil error
compiler_chassis_packed_monitor_6588_test.go:576: expected commit to be rejected with "weight \"nope\" is not an integer", got nil error
compiler_chassis_packed_monitor_6588_test.go:580: expected commit to be rejected with "weight \"nope\" is not an integer", got nil error
compiler_chassis_packed_monitor_6588_test.go:584: expected commit to be rejected with "weight \"\" is not an integer", got nil error
compiler_chassis_packed_monitor_6588_test.go:588: expected commit to be rejected with "weight \"nope\" is not an integer", got nil error
compiler_chassis_packed_monitor_6588_test.go:592: expected commit to be rejected with "weight \"nope\" is not an integer", got nil error
compiler_chassis_packed_monitor_6588_test.go:611: lenient compile should have warned; warnings=[]
compiler_chassis_packed_monitor_6588_test.go:645: expected commit to be rejected with "weight specified 2 times with different values", got nil error
compiler_chassis_packed_monitor_6588_test.go:649: expected commit to be rejected with "weight specified 2 times with different values", got nil error
compiler_chassis_packed_monitor_6588_test.go:653: expected commit to be rejected with "weight specified 2 times with different values", got nil error
compiler_chassis_packed_monitor_6588_test.go:661: expected commit to be rejected with "weight specified 2 times", got nil error

$ go test ./pkg/config/ -v | grep -E "^--- FAIL" | sort | uniq -c
      1 --- FAIL: TestChassisMonitorWeightDuplicateRejected_6588 (0.00s)
      1 --- FAIL: TestChassisMonitorWeightMalformedRejected_6588 (0.00s)
      1 --- FAIL: TestChassisMonitorWeightMalformedTolerantNoBrick_6588 (0.00s)
```

Negative control `TestChassisMonitorWeightValidStillCommits_6588` (weights 0/1/128/255 and no-weight-at-all) passes in full under the mutation.

### Restore

```
$ go build ./... && go vet ./... && go test ./...
BUILD CLEAN
VET CLEAN
FULL SUITE EXIT=0
59      packages ok, 0 failures
69      passing *_6588 subtests
```

## Round-2 scope

The 14 other one-sided arms across `pkg/config` sharing the `nodeVal` root cause are **not** touched — pre-existing, in stanzas this branch does not modify, filed separately. #6658 stays about redundancy-group monitors.

## Round-2 docs

- `docs/config-schema.md` — the composing-collapses case (a monitor statement is subject to the packed AND the bracket collapse independently), the either/or-vs-both table, and why an unusable-but-present value needs an AST gate rather than a compiled-struct check.
- Two code comments this change made stale are corrected: the `validateChassisClusterStrict` header, and the `schema_chassis.go` comment asserting the ip-monitoring leaves have no compiled-int gate.

---

# Round 3 — packed redundancy-group INSTANCE body (head `f8b3883ab`)

Verified firsthand at the round-2 head before writing anything. All four forms compiled the group (`rgID=1`) with an **empty body** and **no error**:

```
redundancy-group 1 interface-monitor ge-0/0/0 weight 255;  -> mons=0 nodePrio=map[] preempt=false ipmon=false
redundancy-group 1 node 0 priority 200;                    -> mons=0 nodePrio=map[] preempt=false ipmon=false
redundancy-group 1 preempt;                                -> mons=0 nodePrio=map[] preempt=false ipmon=false
redundancy-group 1 ip-monitoring global-weight 255;        -> mons=0 nodePrio=map[] preempt=false ipmon=false
CONTROL container form                                     -> mons=1 [ge-0/0/0 w=255] nodePrio=map[0:200] preempt=true
```

`namedInstances` resolves the instance NAME across both spellings (it reads `Keys[1]`) but hands the node back with the body still on `Keys`, so `range rgInst.node.Children` sees nothing.

**Agreed on severity.** `node <id> priority <p>` is the election priority — dropped, the cluster elects on defaults and the wrong node can hold the group, strictly worse than "never demotes".

## Fix

`redundancyGroupBody` splits the instance tail at redundancy-group statement keywords, so a multi-statement line yields one node each. Container spelling untouched (no tail → returns `Children` unchanged).

Applied at **all four** readers of that body — `compileChassis` plus the three AST gates (`validateMonitorWeightTokensAST`, `validateChassisClusterIdentitiesAST`, `validateGratuitousARPCountAST`). Teaching the compiler a shape the gates cannot see would admit, through the packed instance line only, exactly what round 2 closed everywhere else. After:

```
packed ifmon           mons=1 [ge-0/0/0]
packed node prio       nodePrio=map[0:200]
packed preempt         preempt=true
packed ip-monitoring   ipmon=true
packed garp            garp=8
packed multi-stmt      nodePrio=map[0:200] preempt=true      <- `node 0 priority 200 preempt;`
packed bad weight      STRICT-REJECT: weight "nope" is not an integer
packed oor weight      STRICT-REJECT: weight 300 is out of range 0..255
CONTROL container      mons=1 [ge-0/0/0] nodePrio=map[0:200] preempt=true garp=8
```

## Fix direction — option (a) was tried and rejected on evidence

You offered: fix `namedInstances` centrally, or fix the loop and state the audit. I tried (a) first because you're right that it's the better shape if it works. It doesn't.

`namedInstances` has **~130 call sites**, and **24 read `inst.node.Keys` directly** — they already handle the packed tail themselves, so a synthesized child double-feeds them. `compileStaticRoutes` additionally branches on `len(node.Children) == 0` to *detect* the packed shape, which a synthetic child silently disables.

Applied the synthesis as an experiment. Build clean, then:

```
--- FAIL: TestDHCPRelayOverrides_MergedKeys_NotSwallowed
    compiler_dhcp_relay_overrides_test.go:169: AlwaysBroadcast = false, want true (merged-Keys overrides swallowed)
    compiler_dhcp_relay_overrides_test.go:175: Interfaces = [ge-0/0/0.0 overrides always-broadcast], want [ge-0/0/0.0]
--- FAIL: TestDHCPRelayOverrides_MergedKeys_OverridesBeforeInterface
--- FAIL: TestDHCPRelayOverrides_4309_MergedKeysHopCountValue
--- FAIL: TestDHCPRelayOverrides_5414_TrustOption82_MergedAndBlock
--- FAIL: TestDHCPRelayOverrides_5670_PacketRate_MergedAndBlock
--- FAIL: TestVRRPTrackInterface_KeysPackedDuplicateStrictReject
    vrrp_track_test.go:437: lenient first-wins: TrackInterface = "", want ge-0/0/2
```

Six guarded regressions. A central fix needs those 24 inline readers migrated first — its own change, not this PR.

**One prediction I got wrong, recorded as such:** I expected the packed static route to break, since `compileStaticRoutes` branches on `len(Children)==0`. It **survived** — its next-hop arrives as a real child either way. The DHCP-relay and VRRP failures are the real evidence; the static-route one was my error.

## Audit: the other `namedInstances` callers are NOT all safe

You asked me to state which I checked and why they're safe. I checked the three you named, and they are **not** safe — measured by direct compile, not reasoned:

```
system login class ops permissions view;   -> class ops compiles with EMPTY permissions
system login user bob class ops;           -> user bob compiles with NO class
system syslog host 10.0.0.9 any;           -> host 10.0.0.9 compiles with ZERO facilities
```

Same root cause, different stanzas. I am not claiming safety I did not verify, and I am not silently fixing them here — they need their own issue (distinct from #6659, which is the `nodeVal` arms). Flag if you want me to file it.

## Round-3 mutation proof

`redundancyGroupBody` reverted to `return rgNode.Children`. Build + vet CLEAN first.

```
BUILD CLEAN
VET CLEAN

compiler_chassis_packed_monitor_6588_test.go:749: packed redundancy-group body lost `interface-monitor ge-0/0/0 weight 255`: got 0 monitors (<none>)
compiler_chassis_packed_monitor_6588_test.go:761: packed redundancy-group body lost `node 0 priority 200`: NodePriorities = map[] — a dropped election priority means the cluster elects on defaults and the WRONG node can hold the group
compiler_chassis_packed_monitor_6588_test.go:770: packed redundancy-group body lost `preempt`: Preempt = false
compiler_chassis_packed_monitor_6588_test.go:777: packed redundancy-group body lost `strict-vip-ownership`
compiler_chassis_packed_monitor_6588_test.go:784: packed redundancy-group body lost `gratuitous-arp-count 8`: got 0
compiler_chassis_packed_monitor_6588_test.go:793: packed redundancy-group body lost `ip-monitoring global-weight 255`: IPMonitoring is nil
compiler_chassis_packed_monitor_6588_test.go:806: lost `node 0 priority 200` from a multi-statement packed body: map[]
compiler_chassis_packed_monitor_6588_test.go:861: expected commit to be rejected with "weight \"nope\" is not an integer", got nil error
compiler_chassis_packed_monitor_6588_test.go:866: expected commit to be rejected with "weight 300 is out of range 0..255", got nil error
compiler_chassis_packed_monitor_6588_test.go:871: expected commit to be rejected with "weight specified 2 times with different values", got nil error
compiler_chassis_packed_monitor_6588_test.go:876: expected 2 interface-monitors [ge-0/0/0 ge-0/0/1], got 0: <none>
compiler_chassis_packed_monitor_6588_test.go:881: expected commit to be rejected with "global-weight 300 is out of range 0..255", got nil error
compiler_chassis_packed_monitor_6588_test.go:888: expected commit to be rejected with "redundancy-group node", got nil error

$ go test ./pkg/config/ -v | grep -E "^--- FAIL" | sort | uniq -c
      1 --- FAIL: TestChassisRedundancyGroupPackedBody_6588 (0.00s)
      1 --- FAIL: TestChassisRedundancyGroupPackedBodyReachesGates_6588 (0.00s)
```

Negative control — the already-working container form, asserting **every** statement of a full hierarchical group (both node priorities, preempt, strict-vip-ownership, gratuitous-arp-count, the monitor, and ip-monitoring with a target) — GREEN under the mutation:

```
--- PASS: TestChassisRedundancyGroupContainerBodyUnchanged_6588 (0.00s)
```

Restore:

```
$ go build ./... && go vet ./... && go test ./...
BUILD CLEAN
VET CLEAN
FULL SUITE EXIT=0
59      packages ok, 0 failures
85      passing *_6588 subtests
```

Tests drive the real `NewParser` → `CompileConfig` path on hierarchical source, per your instruction — no hand-built ASTs.

## Round-3 docs

`docs/config-schema.md` gains the recursion (an instance packs the same way a statement does), why `namedInstances` is not the fix site with the measured regressions, and the honest audit result for the `class` / `user` / `host` callers.

---

# Round 3b — drift guard on the statement list (head `e25cc5d0c`)

Not requested; done because the reviewer is probing exactly this and it is my predicate. If it is wrong, I would rather find it than have it found.

## The list is correct today

Derived from both sources of truth rather than re-read:

```
setSchema redundancy-group children:   node, gratuitous-arp-count, preempt, interface-monitor, ip-monitoring
compileChassis switch arms:            node, gratuitous-arp-count, preempt, strict-vip-ownership, interface-monitor, ip-monitoring
isRedundancyGroupStatement:            node, gratuitous-arp-count, preempt, strict-vip-ownership, interface-monitor, ip-monitoring
```

The predicate **equals the compiler's arms exactly** and is a strict superset of the schema's children. `compileChassis` is the right reference: those are the statements that actually do something in an RG body.

**Pre-existing gap found while checking, not fixed here:** `setSchema` is missing `strict-vip-ownership` even though the compiler handles it. That costs config-mode completion for that leaf, not compilation — unrelated to this PR, reported rather than folded in.

## But correct-today is not the property worth having

A token missing from the list does not fail loudly — the statement's tokens append to whichever statement precedes it on the line, so it silently does nothing. Same defect class as the bug, better camouflaged. And the list drifts the moment someone adds a `case` to `compileChassis` without touching the predicate.

`TestRedundancyGroupStatementPredicateCoversCompiler_6588` parses `compileChassis`'s **own source** with `go/ast`, extracts every `case "..."` of the `switch child.Name()` dispatch, and requires the predicate to accept each one.

Written to fail rather than pass when it loses track of what it checks: fails if `compileChassis` is not found, if the switch is not found, if zero arms are extracted, or if fewer than the six known arms are seen (it would have latched onto a different switch). Keys on the switch **tag** rather than position, so reordering the function does not blind it.

## Guard proven to fire — both drift directions

Build + vet CLEAN under each.

**E1 — drop a token from the predicate:**
```
BUILD CLEAN
VET CLEAN
compiler_chassis_packed_monitor_6588_test.go:989: compileChassis handles redundancy-group statement "preempt" but isRedundancyGroupStatement does not list it — a packed instance line carrying it (`redundancy-group 1 ... preempt ...;`) folds its tokens into the PRECEDING statement and silently does nothing. Add "preempt" to isRedundancyGroupStatement.
--- FAIL: TestRedundancyGroupStatementPredicateCoversCompiler_6588 (0.00s)
```

**E2 — add a compiler arm and forget the predicate (the realistic drift):**
```
BUILD CLEAN
VET CLEAN
compiler_chassis_packed_monitor_6588_test.go:989: compileChassis handles redundancy-group statement "hold-down-interval" but isRedundancyGroupStatement does not list it — a packed instance line carrying it (`redundancy-group 1 ... hold-down-interval ...;`) folds its tokens into the PRECEDING statement and silently does nothing. Add "hold-down-interval" to isRedundancyGroupStatement.
--- FAIL: TestRedundancyGroupStatementPredicateCoversCompiler_6588 (0.00s)
```

Restored: `go build ./... && go vet ./... && go test ./...` exit 0, 59 packages, **86** passing `*_6588` subtests.

---

# Round 5 — a regression this PR introduced, plus a second RG node shape (head `84f660259`)

Both reproduced firsthand before touching anything.

## MAJOR-A — regression vs master. Taken first.

Confirmed exactly as reported, and the control makes it worse than a plain bug — my own children path already did the right thing:

```
                                        BEFORE (this PR)              AFTER
A flat-set [ a b ] weight 255           [ge-0/0/0=0] [ge-0/0/1=255]   [ge-0/0/0=255] [ge-0/0/1=255]
A flat-set [ a b c ] weight 100         [=0] [=0] [ge-0/0/2=100]      [=100] [=100] [=100]
A hier packed [ a b ] weight 255        [ge-0/0/0=0] [ge-0/0/1=255]   [ge-0/0/0=255] [ge-0/0/1=255]
A CONTROL children-block weight         [ge-0/0/0=255] [ge-0/0/1=255] unchanged
```

Master gave `mon=1 [ge-0/0/0=255]`. So ge-0/0/0 went from protected-at-255 to monitored-at-zero — present in `show`, deducting nothing on link-down. With N names, N-1 monitors inert.

**Fix: apply-to-all**, per your first option and my own documented reasoning. The attribute run is now candidate-scoped rather than positional — names and `weight` tokens separated in one pass, then every name receives the full run. This makes the inline and children-block spellings agree, and on this input it is strictly better than master: no member dropped, no weight lost. Rejecting instead would have hard-rejected a config master compiled.

Two inline weights in one bracketed statement (`[ a weight 100 b weight 200 ]`) are ambiguous about ownership and are now **rejected**, consistent with the round-2 duplicate gate. Master silently took the last and dropped the rest.

**Why it shipped, which is the part worth fixing properly.** `assertMonitorNames` compared `InterfaceMonitors[i].Interface` and never `.Weight`, and the bracket tests used weight-less lists — so weight distribution was unexamined in both directions, exactly as you said. Replaced with `assertMonitors(names, weights)`; the name-only entry point delegates to it, and the helper carries the reason:

> a monitor compiled at weight 0 deducts NOTHING when its link fails, so the redundancy group does not demote. Never assert a monitor list by name alone.

## MAJOR-B — fixed, not documented

Confirmed:

```
redundancy-group { 1 interface-monitor ge-0/0/0 weight 255; }  -> rgs=1 mons=0 <none>
redundancy-group { 1 node 0 priority 200; }                    -> rgs=1 prio=map[]
redundancy-group { 1 { interface-monitor ...; } }  (control)   -> mons=1 [ge-0/0/0=255] OK
```

`Keys[0]` is an exact discriminator between `namedInstances`' two shapes: shape 1 is always reached through `FindChildren("redundancy-group")`, so its `Keys[0]` is that keyword; shape 2 is a child of that container, so its `Keys[0]` is the id and never the keyword. `redundancyGroupBody` now derives skip from it.

I did not take the enumeration option. You are right about the zone-pair precedent, the fix is three lines, and the argument against documenting is stronger than reachability: the guard covers all four `redundancyGroupBody` readers, so leaving the shape broken would make the three AST gates blind here **while looking like they covered it**. `GatesStillReachIt` pins that a malformed weight is still rejected in this shape.

After: `mons=1 [ge-0/0/0=255]`, `prio=map[0:200]`, preempt honoured.

## Mutation proofs

Build + vet CLEAN under each.

### F — attach the inline weight to the last entry only

```
BUILD CLEAN
VET CLEAN
compiler_chassis_packed_monitor_6588_test.go:1051: monitor ge-0/0/0 weight = 0, want 255 (got ge-0/0/0 weight 0, ge-0/0/1 weight 255) — a monitor compiled at weight 0 deducts NOTHING when its link fails, so the redundancy group does not demote
compiler_chassis_packed_monitor_6588_test.go:1060: monitor ge-0/0/0 weight = 0, want 100 (got ge-0/0/0 weight 0, ge-0/0/1 weight 0, ge-0/0/2 weight 100) — ...
compiler_chassis_packed_monitor_6588_test.go:1064: monitor ge-0/0/0 weight = 0, want 255 — ...
compiler_chassis_packed_monitor_6588_test.go:1069: monitor ge-0/0/0 weight = 0, want 255 — ...
compiler_chassis_packed_monitor_6588_test.go:1097: error "...interface-monitor ge-0/0/1 weight 300 is out of range..." does not contain "interface-monitor ge-0/0/0 weight 300 is out of range 0..255"
compiler_chassis_packed_monitor_6588_test.go:1122: target 10.0.1.1 weight = 0, want 100 — a target compiled at weight 0 deducts nothing when the probe fails

$ go test ./pkg/config/ -v | grep -E "^--- FAIL" | sort | uniq -c
      1 --- FAIL: TestChassisInterfaceMonitorBracketInlineWeight_6588 (0.00s)
      1 --- FAIL: TestChassisIPMonitoringBracketInlineWeight_6588 (0.00s)
```

Controls GREEN under the mutation — including the children-block one you specified:

```
--- PASS: .../ControlChildrenBlockWeight (0.00s)
--- PASS: .../ControlSingleNameInlineWeight (0.00s)
--- PASS: .../ControlNoWeightStaysZero (0.00s)
```

### G — pin skip back to a fixed 2

```
BUILD CLEAN
VET CLEAN
compiler_chassis_packed_monitor_6588_test.go:1149: expected 1 interface-monitors [ge-0/0/0], got 0: <none>
compiler_chassis_packed_monitor_6588_test.go:1157: bare `redundancy-group { 1 node 0 priority 200; }` lost the election priority: NodePriorities = map[]
compiler_chassis_packed_monitor_6588_test.go:1165: bare `redundancy-group { 1 preempt; }` lost `preempt`
compiler_chassis_packed_monitor_6588_test.go:1169: expected commit to be rejected with "weight \"nope\" is not an integer", got nil error

$ go test ./pkg/config/ -v | grep -E "^--- FAIL" | sort | uniq -c
      1 --- FAIL: TestChassisRedundancyGroupBareContainerShape_6588 (0.00s)

--- PASS: .../ControlBareWrapperNestedBlock (0.00s)
--- PASS: .../ControlOrdinaryInstanceShape (0.00s)
```

### Restore

```
$ go build ./... && go vet ./... && go test ./...
BUILD+VET CLEAN
FULL EXIT=0
59      packages ok, 0 failures
104     passing *_6588 subtests
```

## Round-5 docs

`docs/config-schema.md` gains the candidate-scoped-attribute rule with the zero-weight consequence spelled out, the instruction to assert compiled weights rather than names, and the two-shape skip derivation.

---

# Round 6 — dispatch table replaces the source-modelling guard (head `b3158d315`)

Took the table. It was not larger than it looks — blast radius below.

## MAJOR-C reproduced, all three routes

Verified at `84f660259` before writing. Each: build CLEAN, guard **PASS**, statement **DROPPED**.

```
m3 — case on a named constant (the idiom THIS PR introduced)
     build: CLEAN   drift guard: PASS   packed multi-statement line: hold-down-interval=DROPPED
m4 — helper called from the loop, outside the switch
     build: CLEAN   drift guard: PASS   packed multi-statement line: hold-down-interval=DROPPED
m7 — nested switch inside a default: arm
     build: CLEAN   drift guard: PASS   packed multi-statement line: hold-down-interval=DROPPED
```

Your diagnosis of each cause was right, and m3 is the one that stings — `const monitorWeightKeyword = "weight"` at `compiler_system.go` is mine, added with the rationale that naming the token stops readers drifting. The next person following that precedent for an RG statement disarms the guard.

## The fix: one table, both consumers

```go
var redundancyGroupStatements = map[string]func(rg *RedundancyGroup, child *Node){
	"node":                 compileRGNodePriority,
	"gratuitous-arp-count": compileRGGratuitousARPCount,
	"preempt":              compileRGPreempt,
	"strict-vip-ownership": compileRGStrictVIPOwnership,
	"interface-monitor":    compileRGInterfaceMonitors,
	"ip-monitoring":        compileRGIPMonitoring,
}

func isRedundancyGroupStatement(tok string) bool {
	_, ok := redundancyGroupStatements[tok]
	return ok
}
```

The loop is now the whole dispatch:

```go
for _, child := range redundancyGroupBody(rgInst.node) {
	if compile, ok := redundancyGroupStatements[child.Name()]; ok {
		compile(rg, child)
	}
}
```

## Blast radius — contained, and equivalence checked not assumed

Confined to `compileChassis` in `compiler_system.go`. Every arm needed only `(rg, child)` — none touched `ch`, `clusterNode` or `rgInst` — so the extraction is mechanical. No other caller.

Bodies moved **verbatim**, verified statement-for-statement against the pre-refactor arms:

```
  node                   -> compileRGNodePriority          statements= 22  body-identical: True
  gratuitous-arp-count   -> compileRGGratuitousARPCount    statements=  5  body-identical: True
  preempt                -> compileRGPreempt               statements=  1  body-identical: True
  strict-vip-ownership   -> compileRGStrictVIPOwnership    statements=  1  body-identical: True
  interface-monitor      -> compileRGInterfaceMonitors     statements= 23  body-identical: True
  ip-monitoring          -> compileRGIPMonitoring          statements= 49  body-identical: True
ALL BODIES IDENTICAL (modulo indentation): True
```

No extracted body contains a top-level `continue` or `break`, so leaving the enclosing switch and for-loop changed no control flow.

## Guard deleted, replaced by a table-derived property test

The source-parsing guard is gone — with the table it proves a tautology. `TestRedundancyGroupStatementsSurvivePackedLine_6588` pins the property the drift actually mattered for: every registered statement must survive being written on a packed line **alongside another statement**, in both orders. That is the spelling the fold bug hides in, since a statement alone on a line works even when the splitter does not know it.

Its cases are **derived from the table**, so a statement added later is covered the moment it is registered, and a table entry with no sample fails a completeness check rather than being skipped. No list in the test to keep updated.

## Re-run of m3/m4/m7 against the table — two closed, one demoted, stated honestly

```
m3' — registered under a NAMED CONSTANT key      -> hold-down-interval=honored
m7' — ordinary table entry (no switch to nest in) -> hold-down-interval=honored
m4' — ad-hoc `if` in the loop, NOT registered     -> hold-down-interval=DROPPED
```

**m4 is not closed by the table, and I am not going to claim it is.** A statement compiled without a table entry still folds. What changed is which path is idiomatic: with the switch, adding a `case` was the natural thing to do and silently diverged; now the natural thing is a table entry, which is correct by construction, and compiling without registering means adding ad-hoc dispatch beside a five-line loop whose only other content is the table lookup — a visible deviation in review. Two of three closed structurally, the third demoted from invisible to obvious. Go offers no construct that would close it outright.

## Validation

```
$ go build ./... && go vet ./... && go test ./...
BUILD+VET CLEAN
FULL EXIT=0
59      packages ok, 0 failures
116     passing *_6588 subtests
```

`gofmt` clean on every file this PR touches. Three pre-existing unformatted test files in `pkg/config` were confirmed unformatted on `origin/master` and left alone.

---

# Round 6b — invariant stated accurately (head `3e341b8ab`)

Your probe is right and the correction is in. The comment said a statement not in the table "is not compiled either — so the two cannot disagree". That is false, exactly as your injected dispatch shows.

The finding itself was already reported when the table landed (m4′ still drops) — but it lived in **this PR body while the code comment kept the overstatement**, and the comment is where the next person reads it. The honest version elsewhere fixed nothing. That is the part worth recording.

Now:

> Adding a statement means adding an entry here, which registers it with the splitter in the same edit. Note what that does and does NOT guarantee: the invariant is "all dispatch goes through this table", and the table being the only dispatch path present is what makes the correct thing the easy thing — it is not enforced. Compiling a statement from ad-hoc code beside the lookup instead of from an entry here re-opens the fold bug exactly as before (verified, not assumed).

`docs/config-schema.md` carried the identical sentence and then qualified it a paragraph later, so it contradicted itself. Both now agree.

Comment and doc only — no behaviour change. `go build ./...`, `go vet`, and `go test ./pkg/config/` clean; the full matrix was not re-run, per instruction.

---

# Round 6c — the characterization lives in the comment now (head `d6fa06b27`)

Round 6b made the comment *accurate* but not *useful*: it said the invariant is made natural rather than enforced, without saying why the table is worth having anyway. A reader who takes only that away learns the guard is weak, not that the failure mode changed shape.

The comment now carries the full statement, in the artifact that ships rather than in this PR body:

> Be precise about what that does and does not guarantee, because an overstated invariant is how the next person concludes they need not think about it. The invariant is "ALL dispatch goes through this table", and it is made natural rather than enforced. Two of the three routes above are now closed by construction: a named-constant KEY registers exactly like a literal one, and there is no switch left to nest another inside. The third is not. Compiling a statement from ad-hoc code beside the lookup — without an entry here — still re-opens the fold bug (verified, not assumed).
>
> What changed for that third route is which act is the natural one. With the switch, adding a `case` WAS the idiomatic way to add a statement, and it diverged silently. Now the idiomatic way is a table entry, which is correct by construction, and diverging means putting ad-hoc dispatch beside a five-line loop whose only other content is this lookup — obvious in review rather than invisible. Demoted, not eliminated; Go offers no construct that would eliminate it.

`docs/config-schema.md` carried the same qualification without naming which routes close; matched.

Comment and doc only, no behaviour change. Build, vet, `gofmt`, and the `*_6588` suite clean.
