### PR TITLE
daemon: mint a real identity for the HA-synced session id (#6198)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -65854,3 +65854,34 @@ break — `go vet` confirmed passing under every revert.
   proto/xpf/v1/xpf.proto, pkg/grpcapi/xpfv1/xpf.pb.go,
   userspace-dp/src/session/mod.rs, userspace-dp/src/session/README.md,
   docs/session-sync-architecture.md, _Log.md
+
+- **Timestamp**: 2026-08-01 07:40
+- **Action**: #6198 second review fold (MERGE-NEEDS-MAJOR — both MAJORs were in
+  the seeding added in the previous round). (1) The zero-correction emitted a
+  DUPLICATE: `Add(1) & mask; if counter == 0 { counter = 1 }` corrects only the
+  returned copy, so at the wrap the atomic still holds the masked-zero value and
+  the NEXT call returns the id just handed out — inside the namespace, so nothing
+  downstream looks wrong while uniqueness silently stops holding. Replaced with a
+  CAS advance so the STORED value is the returned one. The wrap is reachable, not
+  theoretical: the seed consumes counter space, so distance to the boundary
+  depends on uptime phase. Kept the ring rather than failing closed — the id is
+  display-only but the conversion carrying it installs an HA-synced session, so
+  refusing to mint would trade a cosmetic alias for lost sessions at failover.
+  (2) The seed was read at SECOND resolution, so two incarnations whose first
+  allocations land in the same integer second got identical seeds and repeated
+  from their first id — the common restart, since `RestartSec=1` lands in the
+  window and the sub-second phase is uniform. Added `daemonMonotonicNanos` and
+  reshifted the seed to `nanos >> 10` (~1.024 us granularity, three orders of
+  magnitude below any real teardown+exec; ~976k ids/s of rate headroom; 9.1-year
+  seed cycle). The previous test only compared `uptime` vs `uptime+1`, so it
+  could not see this — the new test drives 1ms/10ms/100ms/700ms separations
+  inside one second, with a fixture guard that fails if an offset crosses a
+  second boundary and makes the case vacuous. (3) MINOR: the `0xFFFF<<48`
+  reservation was documented but unenforced on the Rust side; added
+  `CONTROL_PLANE_SESSION_ID_WORKER_HI` and a hard `assert!` in `set_worker_id`
+  (not `debug_assert!` — release strips those and `make test-rust` is a release
+  build), plus a `#[should_panic]` guard and a negative control.
+- **File(s)**: pkg/daemon/daemon_ha_userspace_convert.go,
+  pkg/daemon/userspace_sync_session_id_6198_test.go,
+  userspace-dp/src/session/mod.rs, userspace-dp/src/session/tests.rs,
+  userspace-dp/src/session/README.md, docs/session-sync-architecture.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -65801,3 +65801,28 @@ break — `go vet` confirmed passing under every revert.
   accessor the PR orphaned has one caller and one definition again.
   Docs-and-wiring only: no runtime behaviour change.
 - **File(s)**: pkg/cluster/heartbeat.go, pkg/cluster/README.md, _Log.md
+
+- **Timestamp**: 2026-08-01 03:20
+- **Action**: #6198 — mint a real identity for the node-local BPF-ABI SessionID
+  on the HA-synced conversion path. The previous
+  `uint64(now)<<16 | uint64(delta.Slot&0xffff)` was not an identity: `delta.Slot`
+  is the AF_XDP BINDING slot (`BindingIdentity.slot`, a handful per node), the
+  binary event stream that carries the primary delta path never decodes it at
+  all (`decodeSessionEvent` leaves it 0), and `now` is CLOCK_MONOTONIC SECONDS —
+  so every session converted within one second collapsed onto ONE id (the
+  reported `&0xffff` slot aliasing is in fact unreachable; the real defect is
+  far wider). `nextUserspaceSyncedSessionID` replaces it with a monotonic
+  counter in a reserved `0xFFFF<<48` namespace, disjoint from the
+  worker-namespaced ids the Rust helper stamps into the same BPF conntrack
+  mirror field. `userspaceForwardWireAliasFromDelta{V4,V6}` become
+  `userspaceForwardWireAlias{V4,V6}` taking the already-converted base session,
+  so the fabric-redirect alias and its base still share one id instead of
+  minting two. The id stays deliberately node-local — the cross-node
+  correlatable id is the separate `RTFlowSessionID` (#5212). No wire-format
+  change (the field is already u64 on both sides) and no Rust change (the
+  helper never reads this field).
+- **File(s)**: pkg/daemon/daemon_ha_userspace_convert.go,
+  pkg/daemon/daemon_ha_userspace_stream.go, pkg/daemon/userspace_sync_test.go,
+  pkg/daemon/userspace_sync_session_id_6198_test.go, pkg/dataplane/types.go,
+  pkg/cluster/README.md, docs/session-sync-architecture.md,
+  docs/sync-protocol.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -65826,3 +65826,31 @@ break — `go vet` confirmed passing under every revert.
   pkg/daemon/userspace_sync_session_id_6198_test.go, pkg/dataplane/types.go,
   pkg/cluster/README.md, docs/session-sync-architecture.md,
   docs/sync-protocol.md, _Log.md
+
+- **Timestamp**: 2026-08-01 05:10
+- **Action**: #6198 review fold (MERGE-NEEDS-MINOR, four minors). (1) Seed the
+  synced-session id counter from the boot clock
+  (`userspaceSyncedSessionIDSeed`, `monotonic_seconds << 24` masked to 48 bits)
+  — an unseeded counter re-minted 1,2,3… after an xpfd restart and collided
+  with entries the peer's mirror still held from the previous incarnation, a
+  narrow axis on which the old `now<<16|Slot` was actually BETTER (CLOCK_MONOTONIC
+  keeps increasing across a daemon restart). Seeding closes the residual instead
+  of documenting it. (2) `pkg/dataplane/types.go` asserted the opposite of this
+  PR's thesis on BOTH `SessionValue` and `SessionValueV6` — "unique ID, same on
+  both cluster nodes" 87 lines above a comment calling the id node-local;
+  replaced with the node-local semantics. (3) Same false claim was the
+  operator-facing gRPC contract (`proto/xpf/v1/xpf.proto` `session_id`);
+  corrected and REGENERATED `xpf.pb.go` via `make proto` (diff ignoring
+  whitespace is the comment only — the protobuf tag is byte-identical, no wire
+  impact). (4) The `0xFFFF<<48` reservation was documented only on the Go side,
+  which does not have to obey it; recorded it on `SessionTable::set_worker_id`
+  and in `userspace-dp/src/session/README.md`, where a future minter (e.g.
+  #6311, which proposes re-partitioning those high bits) would look. Also took
+  the reviewer's NIT: the id is distinct per CONVERSION, not stable per session
+  (bulk resync re-stamps; the close branch burns one) — now stated in the code
+  comment and the architecture doc rather than implied otherwise.
+- **File(s)**: pkg/daemon/daemon_ha_userspace_convert.go,
+  pkg/daemon/userspace_sync_session_id_6198_test.go, pkg/dataplane/types.go,
+  proto/xpf/v1/xpf.proto, pkg/grpcapi/xpfv1/xpf.pb.go,
+  userspace-dp/src/session/mod.rs, userspace-dp/src/session/README.md,
+  docs/session-sync-architecture.md, _Log.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -378,7 +378,9 @@ never rejects on it. The path is: the Rust dataplane harvests the id onto
 `SessionDelta.session_id` and writes it as the trailing field of the
 `MSG_SESSION_OPEN` event-stream frame; the daemon decodes it into
 `SessionDeltaInfo.RTFlowSessionID` and stamps `SessionValue{,V6}.RTFlowSessionID`
-(distinct from the node-local BPF-ABI `SessionID`, which stays `now<<16|Slot`);
+(distinct from the node-local BPF-ABI `SessionID`, which since #6198 is minted
+per converted session by `nextUserspaceSyncedSessionID` — see "Node-Local
+BPF-ABI Session Id" below);
 `SessionSync` carries it as the trailing wire field; the peer daemon forwards it
 on `SessionSyncRequest.session_id`; and the peer helper's
 `upsert_synced_with_origin` ADOPTS it (stamping the imported `SessionEntry`)
@@ -387,6 +389,47 @@ falls back to `alloc_session_id()` — rolling-upgrade safe. Because the id is
 worker-namespaced, adopting the peer's id verbatim keeps it unique across the
 importing node's shared-nothing worker tables. The standby's SESSION_CLOSE
 RT_FLOW then correlates with the primary's SESSION_CREATE.
+
+### Node-Local BPF-ABI Session Id (#6198)
+
+`SessionValue{,V6}.SessionID` is the *other*, node-local id: the on-map BPF
+conntrack ABI field. It is NOT a lookup key — forwarding matches the 5-tuple
+`SessionKey` — and it is NOT carried to the peer helper (`buildSessionSyncRequest`
+forwards only `RTFlowSessionID`). Its blast radius is display and correlation:
+it rides the session wire, and on the receiving node `SetClusterSyncedSessionV4/V6`
+writes it into the BPF conntrack mirror, where `show security flow session`
+(`flowSessionDisplayID`), the REST session views, and the gRPC session RPCs
+surface it.
+
+Until #6198 the userspace converters synthesized it as
+`uint64(now)<<16 | uint64(delta.Slot&0xffff)`. Both halves were wrong:
+
+- `delta.Slot` is the AF_XDP **binding** slot (`BindingIdentity.slot`, one per
+  interface/queue — a handful per node), not a session-table slot. The `&0xffff`
+  mask was therefore unreachable in practice.
+- The binary event stream that carries the primary delta path never decodes
+  `Slot` at all (`decodeSessionEvent` leaves it `0`), so the low half was a
+  constant.
+- `now` is CLOCK_MONOTONIC **seconds**. Every session converted within one
+  second collapsed onto ONE id, conflating unrelated flows wherever the id is
+  displayed.
+
+`nextUserspaceSyncedSessionID` replaces it with a node-local monotonic counter in
+a reserved namespace: `0xFFFF << 48 | counter48`. The namespace keeps the
+control-plane-minted ids disjoint from the dataplane ids the helper stamps into
+the same mirror field (`(worker_id & 0xFFFF) << 48 | counter48`, worker ids being
+tiny queue indices), so the two writers can never alias. The counter never
+returns `0` — that is the established "unknown id" sentinel that makes
+`flowSessionDisplayID` fall back to the per-row ordinal.
+
+The fabric-redirect forward-wire alias entry (`userspaceForwardWireAliasV4/V6`)
+takes the ALREADY-CONVERTED base session rather than re-converting the delta, so
+the alias and its base — two conntrack keys for one logical session — share one
+id. Re-converting would mint a second.
+
+This id stays deliberately node-local; the cross-node correlatable id is the
+separate `RTFlowSessionID` above. Regression coverage:
+`TestUserspaceSyncedSessionID*6198` in `pkg/daemon`.
 
 ## Sync Readiness and Bulk Priming
 

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -418,9 +418,33 @@ Until #6198 the userspace converters synthesized it as
 a reserved namespace: `0xFFFF << 48 | counter48`. The namespace keeps the
 control-plane-minted ids disjoint from the dataplane ids the helper stamps into
 the same mirror field (`(worker_id & 0xFFFF) << 48 | counter48`, worker ids being
-tiny queue indices), so the two writers can never alias. The counter never
+tiny queue indices), so the two writers can never alias. That reservation is a
+cross-language invariant: it is recorded on the Rust side too, at
+`SessionTable::set_worker_id` and in `userspace-dp/src/session/README.md`, since
+that is the allocator which has to stay out of `0xFFFF`. The counter never
 returns `0` — that is the established "unknown id" sentinel that makes
 `flowSessionDisplayID` fall back to the per-row ordinal.
+
+The counter is **seeded from the boot clock** on first use
+(`userspaceSyncedSessionIDSeed`, `monotonic_seconds << 24` masked to 48 bits).
+Without a seed, an xpfd restart would re-mint `1, 2, 3…` and collide with entries
+the peer's mirror still holds from the previous incarnation — sessions this node
+closed while it was down, whose keys the post-restart bulk re-export never
+overwrites. The old `now<<16|Slot` composition did not have that flaw, because
+CLOCK_MONOTONIC is system uptime and keeps increasing across a daemon restart, so
+seeding is what keeps the change a strict improvement rather than a trade. Each
+second of uptime claims 2^24 ≈ 16.7M ids, so a restarting incarnation starts above
+its predecessor's high-water mark unless that predecessor averaged more than
+~16.7M synced conversions per second — orders of magnitude beyond the dataplane
+(`MAX_SESSIONS` is 10M in total). The seed wraps after ~194 days of uptime, which
+can only alias ids that old.
+
+The id is distinct per **conversion**, not stable per session. A bulk resync
+re-converts live sessions and re-stamps them with fresh ids, and the `close`
+branch of `queueUserspaceSessionDeltas` converts purely to derive the key and
+discards the id it mints. Both are harmless in a 48-bit space, and the old
+composition churned the id the same way — what changed is that concurrent
+sessions no longer *share* one.
 
 The fabric-redirect forward-wire alias entry (`userspaceForwardWireAliasV4/V6`)
 takes the ALREADY-CONVERTED base session rather than re-converting the delta, so

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -458,7 +458,8 @@ id just handed out. The duplicate stays inside the namespace, so nothing downstr
 looks wrong — uniqueness just silently stops holding. The wrap is reachable rather
 than theoretical, because the seed itself consumes counter space and the distance to
 the boundary depends on uptime phase. Ringing is the right behaviour there: a wrap
-re-mints only ids this incarnation issued 2^48 conversions ago, or ids from an
+re-mints only ids this incarnation issued 2^48-1 conversions ago (the ring skips
+the zero counter, so 2^48-1 values are usable, not 2^48), or ids from an
 incarnation whose entries are long gone. Refusing to mint would be worse — the id is
 display-only, but the conversion carrying it installs an HA-synced session, so
 failing it to protect a display field would trade a cosmetic alias for lost sessions

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -419,25 +419,50 @@ a reserved namespace: `0xFFFF << 48 | counter48`. The namespace keeps the
 control-plane-minted ids disjoint from the dataplane ids the helper stamps into
 the same mirror field (`(worker_id & 0xFFFF) << 48 | counter48`, worker ids being
 tiny queue indices), so the two writers can never alias. That reservation is a
-cross-language invariant: it is recorded on the Rust side too, at
-`SessionTable::set_worker_id` and in `userspace-dp/src/session/README.md`, since
-that is the allocator which has to stay out of `0xFFFF`. The counter never
+cross-language invariant, and it is ENFORCED on the Rust side rather than merely
+recorded: `SessionTable::set_worker_id` asserts a worker id never lands on
+`CONTROL_PLANE_SESSION_ID_WORKER_HI`. A hard `assert!`, not `debug_assert!` —
+`make test-rust` and the shipped helper both build `--release`, where a debug
+assertion is stripped and would guard nothing — and worker setup is config time,
+where `docs/engineering-style.md` prefers crash-start over running with a wrong
+invariant. The counter never
 returns `0` — that is the established "unknown id" sentinel that makes
 `flowSessionDisplayID` fall back to the per-row ordinal.
 
 The counter is **seeded from the boot clock** on first use
-(`userspaceSyncedSessionIDSeed`, `monotonic_seconds << 24` masked to 48 bits).
+(`userspaceSyncedSessionIDSeed`, `monotonic_nanos >> 10` masked to 48 bits).
 Without a seed, an xpfd restart would re-mint `1, 2, 3…` and collide with entries
 the peer's mirror still holds from the previous incarnation — sessions this node
 closed while it was down, whose keys the post-restart bulk re-export never
 overwrites. The old `now<<16|Slot` composition did not have that flaw, because
 CLOCK_MONOTONIC is system uptime and keeps increasing across a daemon restart, so
-seeding is what keeps the change a strict improvement rather than a trade. Each
-second of uptime claims 2^24 ≈ 16.7M ids, so a restarting incarnation starts above
-its predecessor's high-water mark unless that predecessor averaged more than
-~16.7M synced conversions per second — orders of magnitude beyond the dataplane
-(`MAX_SESSIONS` is 10M in total). The seed wraps after ~194 days of uptime, which
-can only alias ids that old.
+seeding is what keeps the change a strict improvement rather than a trade.
+
+The seed reads **nanoseconds, not seconds**. A second-resolution read gives two
+incarnations whose first allocations land in the same integer second an identical
+seed, and they then repeat from their very first id — and that is the common
+restart, not the exotic one: systemd's `RestartSec=1` lands inside the window, and
+the sub-second phase is uniform, so on average half of all restarts do. At
+`>> 10` the seed granularity is ~1.024 µs, three orders of magnitude below the
+teardown+exec of any real restart. The seed advances ~976,562 per second of
+uptime, so a restarting incarnation starts above its predecessor's high-water mark
+unless that predecessor *averaged* more than ~976k synced conversions per second.
+The 48-bit seed space covers ~9.1 years of uptime before it cycles, and a cycle can
+only alias ids from an incarnation that old.
+
+The counter advances by **CAS, not a bare `Add`**, so the value stored is the value
+returned. The counter must skip the reserved `0`, and the skip has to be committed:
+`Add(1) & mask; if counter == 0 { counter = 1 }` corrects only the local copy, so at
+the wrap the atomic still holds the masked-zero value and the NEXT call returns the
+id just handed out. The duplicate stays inside the namespace, so nothing downstream
+looks wrong — uniqueness just silently stops holding. The wrap is reachable rather
+than theoretical, because the seed itself consumes counter space and the distance to
+the boundary depends on uptime phase. Ringing is the right behaviour there: a wrap
+re-mints only ids this incarnation issued 2^48 conversions ago, or ids from an
+incarnation whose entries are long gone. Refusing to mint would be worse — the id is
+display-only, but the conversion carrying it installs an HA-synced session, so
+failing it to protect a display field would trade a cosmetic alias for lost sessions
+at failover.
 
 The id is distinct per **conversion**, not stable per session. A bulk resync
 re-converts live sessions and re-stamps them with fresh ids, and the `close`

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -379,7 +379,10 @@ ADOPTS it — the two nodes emit RT_FLOW records for the same session under one 
 `MSG_SESSION_OPEN` event-stream frame's trailing `session_id` u64
 (`encode_session_open`) → Go `SessionDeltaInfo.RTFlowSessionID`
 (`decodeSessionEvent`) → `SessionValue{,V6}.RTFlowSessionID`
-(`userspaceSessionFromDelta*`, distinct from the BPF-ABI `SessionID`) → this
+(`userspaceSessionFromDelta*`, distinct from the node-local BPF-ABI `SessionID`,
+which the same converters mint per session via `nextUserspaceSyncedSessionID`
+since #6198 — see "Node-Local BPF-ABI Session Id" in
+`docs/session-sync-architecture.md`) → this
 length-gated trailing wire field (`encode/decodeSessionV{4,6}Payload`) → the peer
 Go `SessionSyncRequest.session_id` (`buildSessionSyncRequest*`) → the Rust helper
 `build_synced_session_entry` → `SessionInstall::session_id`. On import,

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -1174,7 +1174,8 @@ outside the monitor loop:
   active/active direction stays a documented fail-OPEN residual on #6284 (item 1,
   needs a bidirectional config-gen namespace #5274 scoped out).
 - **RT_FLOW session id (#5212)**: distinct from BOTH the synthesized BPF-ABI
-  `SessionID` (`now<<16|slot`, node-local) AND the per-key install generation,
+  `SessionID` (node-local, minted per converted session by
+  `nextUserspaceSyncedSessionID` since #6198) AND the per-key install generation,
   every session install carries the ORIGINATING node's stable RT_FLOW session id
   (`SessionValue{,V6}.RTFlowSessionID`, the dataplane's
   `SessionTable::alloc_session_id` value) as a length-gated trailing `uint64` on

--- a/pkg/daemon/daemon_ha_userspace_convert.go
+++ b/pkg/daemon/daemon_ha_userspace_convert.go
@@ -67,17 +67,27 @@ const userspaceSyncedSessionIDCounterMask = uint64(0x0000_FFFF_FFFF_FFFF)
 // right to seed the counter. 2^10 ns ≈ 1.024 µs of seed granularity, which sets
 // both properties that matter:
 //
-//   - Two incarnations collide only if their first allocations land within the
-//     same 1.024 µs. A daemon restart is milliseconds at the very least (process
-//     teardown, exec, init), so the window is unreachable by three orders of
-//     magnitude. Seeding at SECOND resolution — the first cut of this fix — left
-//     a window of up to a full second, which systemd's `RestartSec=1` lands
-//     squarely inside.
-//   - The seed advances ~976,562 per second of uptime, so a restarting
-//     incarnation starts above its predecessor's high-water mark unless that
-//     predecessor averaged more than ~976k synced conversions per second. That is
-//     well above what the dataplane produces, and it is an AVERAGE over the
-//     predecessor's whole lifetime, not a peak.
+//   - Two incarnations share the same SEED only if their first allocations land
+//     in the same aligned 1.024 µs bucket. A daemon restart is milliseconds at
+//     the very least (process teardown, exec, init), so that window is
+//     unreachable by three orders of magnitude. Seeding at SECOND resolution —
+//     the first cut of this fix — left a window of up to a full second, which
+//     systemd's `RestartSec=1` lands squarely inside.
+//   - Distinct seeds are necessary but not sufficient: two incarnations can still
+//     overlap by RANGE. The seed advances ~976,562 per second, so a successor
+//     seeded t nanoseconds later starts (t >> 10) values above its predecessor,
+//     and the ranges overlap once the predecessor mints more than that many ids.
+//     At a 1 ms gap that is only ~976 ids. What makes overlap unreachable in
+//     practice is the ratio: sustaining it needs an average above ~976k synced
+//     conversions per second, far above what the dataplane produces.
+//
+// Be precise about the interval that average is taken over. Seeding is LAZY
+// (sync.Once on the first allocation), so both endpoints are FIRST ALLOCATIONS,
+// not process starts — the averaging interval begins when the predecessor first
+// minted an id, not when it booted. An incarnation that idles for a long time
+// and then mints just before being replaced gets only the teardown/restart gap
+// of headroom, not its whole lifetime. Conversely, delay before the successor's
+// first allocation widens the gap.
 //
 // The 48-bit seed space covers 2^58 ns ≈ 9.1 years of uptime before it cycles;
 // a cycle can only alias ids from an incarnation that old.
@@ -135,7 +145,8 @@ var (
 //
 // The wrap itself is reachable, not theoretical: the seed consumes counter space,
 // so the distance to it depends on uptime phase. A wrap only re-mints ids this
-// incarnation issued 2^48 conversions ago, or ids from an incarnation whose
+// incarnation issued 2^48-1 conversions ago (the ring skips the zero counter,
+// so 2^48-1 values are usable, not 2^48), or ids from an incarnation whose
 // entries are long gone — so the ring is the right behaviour. Refusing to mint
 // would be worse: this id is display-only, but the conversion that carries it
 // installs an HA-synced session, and failing that to protect a display field

--- a/pkg/daemon/daemon_ha_userspace_convert.go
+++ b/pkg/daemon/daemon_ha_userspace_convert.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"encoding/binary"
 	"net"
+	"sync"
 	"sync/atomic"
 
 	"golang.org/x/sys/unix"
@@ -52,9 +53,41 @@ const userspaceSyncedSessionIDNamespace = uint64(0xFFFF) << 48
 // that namespace — the same width the dataplane allocator uses.
 const userspaceSyncedSessionIDCounterMask = uint64(0x0000_FFFF_FFFF_FFFF)
 
+// userspaceSyncedSessionIDSeedShift is how far the boot clock is shifted to seed
+// the counter, i.e. how much counter space each SECOND of system uptime claims:
+// 2^24 ≈ 16.7M ids.
+const userspaceSyncedSessionIDSeedShift = 24
+
+// userspaceSyncedSessionIDSeed returns the counter value a daemon incarnation
+// starts from, given the system uptime in seconds at which it began.
+//
+// A bare counter starting at 0 would make ids REPEAT across an xpfd restart: the
+// new incarnation re-mints 1, 2, 3… while entries the peer's conntrack mirror
+// still holds from the previous incarnation (sessions this node closed while it
+// was down, whose keys the post-restart bulk re-export never overwrites) carry
+// exactly those values. The old now<<16|Slot composition did NOT have that flaw,
+// because CLOCK_MONOTONIC is system uptime and keeps increasing across a daemon
+// restart — so seeding is what keeps this change a strict improvement rather than
+// a trade.
+//
+// Seeding from the same boot clock restores the property. Each second of uptime
+// advances the seed by 2^24, so a restarting incarnation starts above its
+// predecessor's high-water mark unless that predecessor averaged more than ~16.7M
+// synced-session conversions PER SECOND — orders of magnitude above what the
+// dataplane can produce (MAX_SESSIONS is 10M in total). The mask bounds the seed
+// to the 48-bit counter space; it wraps after 2^24 seconds (~194 days) of uptime,
+// and a wrap can only alias ids minted ~194 days earlier, long since aged out of
+// any mirror.
+func userspaceSyncedSessionIDSeed(monotonicSeconds uint64) uint64 {
+	return (monotonicSeconds << userspaceSyncedSessionIDSeedShift) & userspaceSyncedSessionIDCounterMask
+}
+
 // userspaceSyncedSessionIDs is the node-local monotonic allocator behind
-// nextUserspaceSyncedSessionID.
-var userspaceSyncedSessionIDs atomic.Uint64
+// nextUserspaceSyncedSessionID, seeded from the boot clock on first use.
+var (
+	userspaceSyncedSessionIDs    atomic.Uint64
+	userspaceSyncedSessionIDOnce sync.Once
+)
 
 // nextUserspaceSyncedSessionID mints the node-local BPF-ABI SessionID stamped on
 // a session converted from a userspace-helper delta (#6198).
@@ -67,18 +100,30 @@ var userspaceSyncedSessionIDs atomic.Uint64
 // (`decodeSessionEvent` in pkg/dataplane/userspace/eventstream.go leaves it 0).
 // Every session converted within the same monotonic SECOND therefore collapsed
 // onto ONE id, conflating unrelated flows in `show security flow session` and in
-// the REST/gRPC session views. A monotonic counter gives every converted session
-// a distinct id for the lifetime of the daemon.
+// the REST/gRPC session views. A monotonic counter gives every CONVERSION a
+// distinct id — see the per-conversion note below.
 //
-// The counter is masked to 48 bits and never returns 0 (`0` is the established
+// The counter is seeded from the boot clock on first use
+// (userspaceSyncedSessionIDSeed) so ids do not repeat across an xpfd restart
+// either. It is masked to 48 bits and never returns 0 (`0` is the established
 // "no id / unknown" sentinel that makes `flowSessionDisplayID` fall back to the
 // per-row ordinal), so even the unreachable wrap case stays well-formed rather
 // than aliasing the namespace bits or emitting the sentinel.
+//
+// The id is per CONVERSION, not stable per session: a bulk resync re-converts
+// live sessions and re-stamps them with fresh ids, and the `close` branch of
+// queueUserspaceSessionDeltas converts purely to derive the key and discards the
+// id it mints. Both are harmless in a 48-bit space, and the old composition
+// churned the id the same way — what changed is that concurrent sessions no
+// longer SHARE one.
 //
 // This id stays NODE-LOCAL by design: the cross-node correlatable id is the
 // separate RTFlowSessionID (#5212), which rides its own wire field and is
 // adopted verbatim by the peer helper. See docs/session-sync-architecture.md.
 func nextUserspaceSyncedSessionID() uint64 {
+	userspaceSyncedSessionIDOnce.Do(func() {
+		userspaceSyncedSessionIDs.Store(userspaceSyncedSessionIDSeed(daemonMonotonicSeconds()))
+	})
 	counter := userspaceSyncedSessionIDs.Add(1) & userspaceSyncedSessionIDCounterMask
 	if counter == 0 {
 		counter = 1

--- a/pkg/daemon/daemon_ha_userspace_convert.go
+++ b/pkg/daemon/daemon_ha_userspace_convert.go
@@ -36,6 +36,16 @@ func daemonMonotonicSeconds() uint64 {
 	return uint64(ts.Sec)
 }
 
+// daemonMonotonicNanos is the full-resolution boot clock. daemonMonotonicSeconds
+// truncates to whole seconds, which is fine for session Created/LastSeen but NOT
+// for seeding an identity: two daemon incarnations whose first allocations land
+// in the same integer second would read the same value.
+func daemonMonotonicNanos() uint64 {
+	var ts unix.Timespec
+	_ = unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
+	return uint64(ts.Sec)*1_000_000_000 + uint64(ts.Nsec)
+}
+
 // userspaceSyncedSessionIDNamespace reserves the high 16 bits of the node-local
 // BPF-ABI SessionID minted for an HA-synced session (#6198).
 //
@@ -53,13 +63,28 @@ const userspaceSyncedSessionIDNamespace = uint64(0xFFFF) << 48
 // that namespace — the same width the dataplane allocator uses.
 const userspaceSyncedSessionIDCounterMask = uint64(0x0000_FFFF_FFFF_FFFF)
 
-// userspaceSyncedSessionIDSeedShift is how far the boot clock is shifted to seed
-// the counter, i.e. how much counter space each SECOND of system uptime claims:
-// 2^24 ≈ 16.7M ids.
-const userspaceSyncedSessionIDSeedShift = 24
+// userspaceSyncedSessionIDSeedShift is how far monotonic NANOSECONDS are shifted
+// right to seed the counter. 2^10 ns ≈ 1.024 µs of seed granularity, which sets
+// both properties that matter:
+//
+//   - Two incarnations collide only if their first allocations land within the
+//     same 1.024 µs. A daemon restart is milliseconds at the very least (process
+//     teardown, exec, init), so the window is unreachable by three orders of
+//     magnitude. Seeding at SECOND resolution — the first cut of this fix — left
+//     a window of up to a full second, which systemd's `RestartSec=1` lands
+//     squarely inside.
+//   - The seed advances ~976,562 per second of uptime, so a restarting
+//     incarnation starts above its predecessor's high-water mark unless that
+//     predecessor averaged more than ~976k synced conversions per second. That is
+//     well above what the dataplane produces, and it is an AVERAGE over the
+//     predecessor's whole lifetime, not a peak.
+//
+// The 48-bit seed space covers 2^58 ns ≈ 9.1 years of uptime before it cycles;
+// a cycle can only alias ids from an incarnation that old.
+const userspaceSyncedSessionIDSeedShift = 10
 
 // userspaceSyncedSessionIDSeed returns the counter value a daemon incarnation
-// starts from, given the system uptime in seconds at which it began.
+// starts from, given the monotonic nanoseconds at which it began.
 //
 // A bare counter starting at 0 would make ids REPEAT across an xpfd restart: the
 // new incarnation re-mints 1, 2, 3… while entries the peer's conntrack mirror
@@ -69,17 +94,8 @@ const userspaceSyncedSessionIDSeedShift = 24
 // because CLOCK_MONOTONIC is system uptime and keeps increasing across a daemon
 // restart — so seeding is what keeps this change a strict improvement rather than
 // a trade.
-//
-// Seeding from the same boot clock restores the property. Each second of uptime
-// advances the seed by 2^24, so a restarting incarnation starts above its
-// predecessor's high-water mark unless that predecessor averaged more than ~16.7M
-// synced-session conversions PER SECOND — orders of magnitude above what the
-// dataplane can produce (MAX_SESSIONS is 10M in total). The mask bounds the seed
-// to the 48-bit counter space; it wraps after 2^24 seconds (~194 days) of uptime,
-// and a wrap can only alias ids minted ~194 days earlier, long since aged out of
-// any mirror.
-func userspaceSyncedSessionIDSeed(monotonicSeconds uint64) uint64 {
-	return (monotonicSeconds << userspaceSyncedSessionIDSeedShift) & userspaceSyncedSessionIDCounterMask
+func userspaceSyncedSessionIDSeed(monotonicNanos uint64) uint64 {
+	return (monotonicNanos >> userspaceSyncedSessionIDSeedShift) & userspaceSyncedSessionIDCounterMask
 }
 
 // userspaceSyncedSessionIDs is the node-local monotonic allocator behind
@@ -105,10 +121,25 @@ var (
 //
 // The counter is seeded from the boot clock on first use
 // (userspaceSyncedSessionIDSeed) so ids do not repeat across an xpfd restart
-// either. It is masked to 48 bits and never returns 0 (`0` is the established
-// "no id / unknown" sentinel that makes `flowSessionDisplayID` fall back to the
-// per-row ordinal), so even the unreachable wrap case stays well-formed rather
-// than aliasing the namespace bits or emitting the sentinel.
+// either.
+//
+// The advance is a CAS rather than a bare Add so the STORED value is the one that
+// was returned. `0` is the "no id / unknown" sentinel that makes
+// `flowSessionDisplayID` fall back to the per-row ordinal, so the counter skips
+// it — and skipping it has to be committed to the atomic. A bare
+// `Add(1) & mask; if counter == 0 { counter = 1 }` corrects only the local copy:
+// at the wrap the atomic still holds the masked-zero value, so the NEXT call
+// reads 1 and returns the id just handed out. That silently breaks the one
+// property this whole change exists to establish, and unlike a plain overflow it
+// leaves the id inside the namespace, so nothing downstream looks wrong.
+//
+// The wrap itself is reachable, not theoretical: the seed consumes counter space,
+// so the distance to it depends on uptime phase. A wrap only re-mints ids this
+// incarnation issued 2^48 conversions ago, or ids from an incarnation whose
+// entries are long gone — so the ring is the right behaviour. Refusing to mint
+// would be worse: this id is display-only, but the conversion that carries it
+// installs an HA-synced session, and failing that to protect a display field
+// would trade a cosmetic alias for lost sessions at failover.
 //
 // The id is per CONVERSION, not stable per session: a bulk resync re-converts
 // live sessions and re-stamps them with fresh ids, and the `close` branch of
@@ -122,13 +153,18 @@ var (
 // adopted verbatim by the peer helper. See docs/session-sync-architecture.md.
 func nextUserspaceSyncedSessionID() uint64 {
 	userspaceSyncedSessionIDOnce.Do(func() {
-		userspaceSyncedSessionIDs.Store(userspaceSyncedSessionIDSeed(daemonMonotonicSeconds()))
+		userspaceSyncedSessionIDs.Store(userspaceSyncedSessionIDSeed(daemonMonotonicNanos()))
 	})
-	counter := userspaceSyncedSessionIDs.Add(1) & userspaceSyncedSessionIDCounterMask
-	if counter == 0 {
-		counter = 1
+	for {
+		cur := userspaceSyncedSessionIDs.Load()
+		next := (cur + 1) & userspaceSyncedSessionIDCounterMask
+		if next == 0 {
+			next = 1
+		}
+		if userspaceSyncedSessionIDs.CompareAndSwap(cur, next) {
+			return userspaceSyncedSessionIDNamespace | next
+		}
 	}
-	return userspaceSyncedSessionIDNamespace | counter
 }
 
 func userspaceSessionTimeout(proto uint8) uint32 {

--- a/pkg/daemon/daemon_ha_userspace_convert.go
+++ b/pkg/daemon/daemon_ha_userspace_convert.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"encoding/binary"
 	"net"
+	"sync/atomic"
 
 	"golang.org/x/sys/unix"
 
@@ -32,6 +33,57 @@ func daemonMonotonicSeconds() uint64 {
 	var ts unix.Timespec
 	_ = unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
 	return uint64(ts.Sec)
+}
+
+// userspaceSyncedSessionIDNamespace reserves the high 16 bits of the node-local
+// BPF-ABI SessionID minted for an HA-synced session (#6198).
+//
+// The Rust dataplane's own stable id (`SessionTable::alloc_session_id`, #4915 —
+// carried across the cluster wire as the DISTINCT RTFlowSessionID, #5212) is
+// `(worker_id & 0xFFFF) << 48 | counter48`, where `worker_id` is a worker/queue
+// index (`set_worker_id`, userspace-dp/src/session/mod.rs). Reserving 0xFFFF for
+// the Go-minted ids keeps the two id spaces disjoint inside the shared BPF
+// conntrack mirror: the helper stamps its own id for sessions it owns, the
+// control plane stamps one of these for a peer-synced session it installs, and
+// neither can ever alias the other.
+const userspaceSyncedSessionIDNamespace = uint64(0xFFFF) << 48
+
+// userspaceSyncedSessionIDCounterMask is the low-48-bit counter space inside
+// that namespace — the same width the dataplane allocator uses.
+const userspaceSyncedSessionIDCounterMask = uint64(0x0000_FFFF_FFFF_FFFF)
+
+// userspaceSyncedSessionIDs is the node-local monotonic allocator behind
+// nextUserspaceSyncedSessionID.
+var userspaceSyncedSessionIDs atomic.Uint64
+
+// nextUserspaceSyncedSessionID mints the node-local BPF-ABI SessionID stamped on
+// a session converted from a userspace-helper delta (#6198).
+//
+// It replaces the previous `uint64(now)<<16 | uint64(delta.Slot&0xffff)`
+// composition, which was NOT an identity at all: `delta.Slot` is the AF_XDP
+// BINDING slot (`BindingIdentity.slot`, userspace-dp/src/afxdp/session_delta.rs
+// — one per interface/queue, a handful per node), and the binary event stream
+// that carries the primary delta path never decodes it at all
+// (`decodeSessionEvent` in pkg/dataplane/userspace/eventstream.go leaves it 0).
+// Every session converted within the same monotonic SECOND therefore collapsed
+// onto ONE id, conflating unrelated flows in `show security flow session` and in
+// the REST/gRPC session views. A monotonic counter gives every converted session
+// a distinct id for the lifetime of the daemon.
+//
+// The counter is masked to 48 bits and never returns 0 (`0` is the established
+// "no id / unknown" sentinel that makes `flowSessionDisplayID` fall back to the
+// per-row ordinal), so even the unreachable wrap case stays well-formed rather
+// than aliasing the namespace bits or emitting the sentinel.
+//
+// This id stays NODE-LOCAL by design: the cross-node correlatable id is the
+// separate RTFlowSessionID (#5212), which rides its own wire field and is
+// adopted verbatim by the peer helper. See docs/session-sync-architecture.md.
+func nextUserspaceSyncedSessionID() uint64 {
+	counter := userspaceSyncedSessionIDs.Add(1) & userspaceSyncedSessionIDCounterMask
+	if counter == 0 {
+		counter = 1
+	}
+	return userspaceSyncedSessionIDNamespace | counter
 }
 
 func userspaceSessionTimeout(proto uint8) uint32 {
@@ -183,8 +235,10 @@ func userspaceSessionFromDeltaV4(delta dpuserspace.SessionDeltaInfo, zoneIDs map
 	now := daemonMonotonicSeconds()
 	val := dataplane.SessionValue{
 		State: 4, // SESS_STATE_ESTABLISHED
-		// SessionID is the BPF-ABI conntrack id (node-local now<<16|Slot).
-		SessionID: uint64(now)<<16 | uint64(delta.Slot&0xffff),
+		// SessionID is the BPF-ABI conntrack id: node-local, and unique per
+		// converted session since #6198 (the previous now<<16|Slot composition
+		// collapsed every session converted in the same second onto one id).
+		SessionID: nextUserspaceSyncedSessionID(),
 		// #5212: the ORIGINATING node's stable RT_FLOW session id (distinct from
 		// SessionID above). Carried across the cluster sync wire so a peer-synced
 		// session adopts it and its SESSION_CREATE/CLOSE records correlate across
@@ -242,11 +296,15 @@ func userspaceSessionFromDeltaV4(delta dpuserspace.SessionDeltaInfo, zoneIDs map
 	return key, val, true
 }
 
-func userspaceForwardWireAliasFromDeltaV4(delta dpuserspace.SessionDeltaInfo, zoneIDs map[string]uint16) (dataplane.SessionKey, dataplane.SessionValue, bool) {
-	key, val, ok := userspaceSessionFromDeltaV4(delta, zoneIDs)
-	if !ok {
-		return dataplane.SessionKey{}, dataplane.SessionValue{}, false
-	}
+// userspaceForwardWireAliasV4 derives the fabric-redirect forward-wire alias
+// entry from an ALREADY-CONVERTED base session.
+//
+// It takes the converted base rather than re-converting the delta because
+// nextUserspaceSyncedSessionID mints a FRESH id per conversion (#6198): a second
+// conversion of the same delta would split one logical session across two
+// SessionIDs, where the alias and its base entry must share one. It also drops a
+// redundant conversion from the delta path.
+func userspaceForwardWireAliasV4(key dataplane.SessionKey, val dataplane.SessionValue, delta dpuserspace.SessionDeltaInfo) (dataplane.SessionKey, dataplane.SessionValue, bool) {
 	wireKey := userspaceForwardWireKeyV4(key, delta)
 	if wireKey == key {
 		return dataplane.SessionKey{}, dataplane.SessionValue{}, false
@@ -284,8 +342,9 @@ func userspaceSessionFromDeltaV6(delta dpuserspace.SessionDeltaInfo, zoneIDs map
 	now := daemonMonotonicSeconds()
 	val := dataplane.SessionValueV6{
 		State: 4, // SESS_STATE_ESTABLISHED
-		// SessionID is the BPF-ABI conntrack id (node-local now<<16|Slot).
-		SessionID: uint64(now)<<16 | uint64(delta.Slot&0xffff),
+		// SessionID is the BPF-ABI conntrack id: node-local, and unique per
+		// converted session since #6198 (see the V4 converter).
+		SessionID: nextUserspaceSyncedSessionID(),
 		// #5212: the ORIGINATING node's stable RT_FLOW session id (see V4) —
 		// adopted by a peer-synced session so its RT_FLOW records correlate
 		// across HA nodes; 0 on a legacy helper => fresh local id on import.
@@ -355,11 +414,9 @@ func userspaceForwardWireKeyV6(key dataplane.SessionKeyV6, delta dpuserspace.Ses
 	return wire
 }
 
-func userspaceForwardWireAliasFromDeltaV6(delta dpuserspace.SessionDeltaInfo, zoneIDs map[string]uint16) (dataplane.SessionKeyV6, dataplane.SessionValueV6, bool) {
-	key, val, ok := userspaceSessionFromDeltaV6(delta, zoneIDs)
-	if !ok {
-		return dataplane.SessionKeyV6{}, dataplane.SessionValueV6{}, false
-	}
+// userspaceForwardWireAliasV6 is the V6 twin of userspaceForwardWireAliasV4 —
+// same reason for taking the already-converted base (#6198).
+func userspaceForwardWireAliasV6(key dataplane.SessionKeyV6, val dataplane.SessionValueV6, delta dpuserspace.SessionDeltaInfo) (dataplane.SessionKeyV6, dataplane.SessionValueV6, bool) {
 	wireKey := userspaceForwardWireKeyV6(key, delta)
 	if wireKey == key {
 		return dataplane.SessionKeyV6{}, dataplane.SessionValueV6{}, false

--- a/pkg/daemon/daemon_ha_userspace_stream.go
+++ b/pkg/daemon/daemon_ha_userspace_stream.go
@@ -371,7 +371,7 @@ func (d *Daemon) queueUserspaceSessionDeltas(
 				slog.Debug("userspace delta: queued V4", "src", delta.SrcIP, "dst", delta.DstIP, "ownerRG", delta.OwnerRGID)
 				queued++
 				if delta.FabricRedirect && !delta.FabricIngress {
-					if wireKey, wireVal, ok := userspaceForwardWireAliasFromDeltaV4(delta, zoneIDs); ok {
+					if wireKey, wireVal, ok := userspaceForwardWireAliasV4(key, val, delta); ok {
 						ss.QueueSessionV4(wireKey, wireVal)
 						queued++
 					}
@@ -384,7 +384,7 @@ func (d *Daemon) queueUserspaceSessionDeltas(
 				ss.QueueSessionV6(key, val)
 				queued++
 				if delta.FabricRedirect && !delta.FabricIngress {
-					if wireKey, wireVal, ok := userspaceForwardWireAliasFromDeltaV6(delta, zoneIDs); ok {
+					if wireKey, wireVal, ok := userspaceForwardWireAliasV6(key, val, delta); ok {
 						ss.QueueSessionV6(wireKey, wireVal)
 						queued++
 					}

--- a/pkg/daemon/userspace_sync_session_id_6198_test.go
+++ b/pkg/daemon/userspace_sync_session_id_6198_test.go
@@ -160,6 +160,59 @@ func TestUserspaceSyncedSessionIDNamespaceDisjointFromDataplane6198(t *testing.T
 	}
 }
 
+// TestUserspaceSyncedSessionIDSeedSurvivesRestart6198 pins the cross-restart
+// anti-reuse property.
+//
+// An unseeded counter would re-mint 1, 2, 3… after an xpfd restart and collide
+// with entries the peer's mirror still holds from the previous incarnation. The
+// old now<<16|Slot composition did NOT have that flaw (CLOCK_MONOTONIC keeps
+// increasing across a daemon restart), so seeding is what keeps this change a
+// strict improvement rather than a trade.
+func TestUserspaceSyncedSessionIDSeedSurvivesRestart6198(t *testing.T) {
+	// Two incarnations one second of uptime apart.
+	const uptime = uint64(1_000_000) // ~11.6 days, well inside the 48-bit space
+	seedA := userspaceSyncedSessionIDSeed(uptime)
+	seedB := userspaceSyncedSessionIDSeed(uptime + 1)
+
+	gap := seedB - seedA
+	if want := uint64(1) << userspaceSyncedSessionIDSeedShift; gap != want {
+		t.Fatalf("one second of uptime advances the seed by %d, want %d", gap, want)
+	}
+
+	// Incarnation A must not reach incarnation B's seed. The bound is A's average
+	// mint rate; 1M conversions/second is already far above what the dataplane can
+	// produce (MAX_SESSIONS is 10M in total).
+	const mintedInThatSecond = uint64(1) << 20
+	if seedA+mintedInThatSecond >= seedB {
+		t.Fatalf("incarnation A minting %d ids/s reaches incarnation B's seed "+
+			"(%#x + %d >= %#x) — ids would repeat across a restart",
+			mintedInThatSecond, seedA, mintedInThatSecond, seedB)
+	}
+
+	// The seed must stay inside the counter space so it can never bleed into the
+	// namespace bits.
+	if seedB&^userspaceSyncedSessionIDCounterMask != 0 {
+		t.Fatalf("seed %#x escapes the 48-bit counter mask", seedB)
+	}
+}
+
+// TestUserspaceSyncedSessionIDIsSeededFromBootClock6198 pins that the allocator
+// actually APPLIES the seed — the property above is worthless if
+// nextUserspaceSyncedSessionID never calls it. An unseeded counter would still be
+// in the low thousands after a whole test binary's worth of mints; a seeded one
+// starts at least one second of uptime (2^24) above zero.
+func TestUserspaceSyncedSessionIDIsSeededFromBootClock6198(t *testing.T) {
+	if daemonMonotonicSeconds() == 0 {
+		t.Skip("system uptime < 1s: the boot-clock seed is 0 and carries no signal")
+	}
+	counter := nextUserspaceSyncedSessionID() &^ userspaceSyncedSessionIDNamespace
+	if floor := uint64(1) << userspaceSyncedSessionIDSeedShift; counter < floor {
+		t.Fatalf("counter %d is below one second of seeded space (%d) — the "+
+			"allocator is not seeded from the boot clock, so ids repeat across a restart",
+			counter, floor)
+	}
+}
+
 // TestUserspaceForwardWireAliasSharesBaseSessionID6198 pins that the
 // fabric-redirect forward-wire alias entry carries the SAME SessionID as its
 // base entry: they are two conntrack keys for ONE logical session. Re-converting

--- a/pkg/daemon/userspace_sync_session_id_6198_test.go
+++ b/pkg/daemon/userspace_sync_session_id_6198_test.go
@@ -160,31 +160,38 @@ func TestUserspaceSyncedSessionIDNamespaceDisjointFromDataplane6198(t *testing.T
 	}
 }
 
+// oneSecondOfUptimeNanos is one second expressed in the units
+// userspaceSyncedSessionIDSeed consumes.
+const oneSecondOfUptimeNanos = uint64(1_000_000_000)
+
 // TestUserspaceSyncedSessionIDSeedSurvivesRestart6198 pins the cross-restart
-// anti-reuse property.
+// anti-reuse property across a WHOLE second of uptime.
 //
 // An unseeded counter would re-mint 1, 2, 3… after an xpfd restart and collide
 // with entries the peer's mirror still holds from the previous incarnation. The
 // old now<<16|Slot composition did NOT have that flaw (CLOCK_MONOTONIC keeps
 // increasing across a daemon restart), so seeding is what keeps this change a
 // strict improvement rather than a trade.
+//
+// This is also the NEGATIVE CONTROL for the sub-second case below: a full second
+// separates two incarnations under a second-resolution seed just as well as under
+// a nanosecond one, so this test passes in both worlds.
 func TestUserspaceSyncedSessionIDSeedSurvivesRestart6198(t *testing.T) {
-	// Two incarnations one second of uptime apart.
-	const uptime = uint64(1_000_000) // ~11.6 days, well inside the 48-bit space
+	// ~11.6 days of uptime, well inside the 48-bit seed space.
+	const uptime = uint64(1_000_000) * oneSecondOfUptimeNanos
 	seedA := userspaceSyncedSessionIDSeed(uptime)
-	seedB := userspaceSyncedSessionIDSeed(uptime + 1)
+	seedB := userspaceSyncedSessionIDSeed(uptime + oneSecondOfUptimeNanos)
 
-	gap := seedB - seedA
-	if want := uint64(1) << userspaceSyncedSessionIDSeedShift; gap != want {
-		t.Fatalf("one second of uptime advances the seed by %d, want %d", gap, want)
+	if seedB <= seedA {
+		t.Fatalf("a later incarnation seeds at %#x, not above the earlier %#x", seedB, seedA)
 	}
 
-	// Incarnation A must not reach incarnation B's seed. The bound is A's average
-	// mint rate; 1M conversions/second is already far above what the dataplane can
-	// produce (MAX_SESSIONS is 10M in total).
-	const mintedInThatSecond = uint64(1) << 20
+	// Incarnation A must not reach incarnation B's seed. The bound is A's AVERAGE
+	// mint rate over that second; 100k conversions/second is already well above
+	// what the dataplane sustains.
+	const mintedInThatSecond = uint64(100_000)
 	if seedA+mintedInThatSecond >= seedB {
-		t.Fatalf("incarnation A minting %d ids/s reaches incarnation B's seed "+
+		t.Fatalf("incarnation A averaging %d ids/s reaches incarnation B's seed "+
 			"(%#x + %d >= %#x) — ids would repeat across a restart",
 			mintedInThatSecond, seedA, mintedInThatSecond, seedB)
 	}
@@ -196,20 +203,147 @@ func TestUserspaceSyncedSessionIDSeedSurvivesRestart6198(t *testing.T) {
 	}
 }
 
+// TestUserspaceSyncedSessionIDSeedDistinctWithinOneSecond6198 drives the case the
+// whole-second test above CANNOT see: two incarnations whose first allocations
+// land inside the SAME integer monotonic second.
+//
+// That is the common restart, not the exotic one — systemd's `RestartSec=1` puts
+// a crash-restart squarely in the window, and the sub-second phase is uniform, so
+// on average half of all restarts land in it. A seed read at second resolution
+// gives both incarnations the SAME value and they repeat from their very first
+// id. Every separation below is far longer than a process teardown+exec, and
+// every one is invisible to a whole-second seed.
+func TestUserspaceSyncedSessionIDSeedDistinctWithinOneSecond6198(t *testing.T) {
+	// Uptime 1e6 s + 0.25 s: mid-second, so every offset below stays inside the
+	// same integer second.
+	const base = uint64(1_000_000)*oneSecondOfUptimeNanos + 250_000_000
+
+	for _, sep := range []struct {
+		name  string
+		nanos uint64
+	}{
+		{"1ms", 1_000_000},
+		{"10ms", 10_000_000},
+		{"100ms", 100_000_000},
+		{"700ms", 700_000_000},
+	} {
+		t.Run(sep.name, func(t *testing.T) {
+			// Guard the fixture: if the offset crossed a second boundary a
+			// second-resolution seed would legitimately differ and the test
+			// would be vacuous.
+			if base/oneSecondOfUptimeNanos != (base+sep.nanos)/oneSecondOfUptimeNanos {
+				t.Fatalf("fixture error: a %s offset from %d ns crosses a second "+
+					"boundary, so this case does not exercise the same-second window",
+					sep.name, base)
+			}
+			seedA := userspaceSyncedSessionIDSeed(base)
+			seedB := userspaceSyncedSessionIDSeed(base + sep.nanos)
+			if seedA == seedB {
+				t.Fatalf("two incarnations %s apart within one monotonic second "+
+					"share seed %#x — the restart re-mints from the same first id, "+
+					"so the new incarnation's ids collide with the previous one's "+
+					"entries still in the peer's mirror", sep.name, seedA)
+			}
+			if seedB <= seedA {
+				t.Fatalf("later incarnation seeds at %#x, not above the earlier %#x", seedB, seedA)
+			}
+		})
+	}
+}
+
 // TestUserspaceSyncedSessionIDIsSeededFromBootClock6198 pins that the allocator
-// actually APPLIES the seed — the property above is worthless if
+// actually APPLIES the seed — the properties above are worthless if
 // nextUserspaceSyncedSessionID never calls it. An unseeded counter would still be
 // in the low thousands after a whole test binary's worth of mints; a seeded one
-// starts at least one second of uptime (2^24) above zero.
+// starts at least one second of uptime above zero.
 func TestUserspaceSyncedSessionIDIsSeededFromBootClock6198(t *testing.T) {
-	if daemonMonotonicSeconds() == 0 {
-		t.Skip("system uptime < 1s: the boot-clock seed is 0 and carries no signal")
+	if daemonMonotonicNanos() < oneSecondOfUptimeNanos {
+		t.Skip("system uptime < 1s: the boot-clock seed carries no signal yet")
 	}
 	counter := nextUserspaceSyncedSessionID() &^ userspaceSyncedSessionIDNamespace
-	if floor := uint64(1) << userspaceSyncedSessionIDSeedShift; counter < floor {
+	if floor := userspaceSyncedSessionIDSeed(oneSecondOfUptimeNanos); counter < floor {
 		t.Fatalf("counter %d is below one second of seeded space (%d) — the "+
 			"allocator is not seeded from the boot clock, so ids repeat across a restart",
 			counter, floor)
+	}
+}
+
+// TestUserspaceSyncedSessionIDWrapEmitsNoDuplicate6198 drives the allocator TO
+// the 48-bit boundary, not near it.
+//
+// The counter must skip the reserved `0` — and the skip has to be COMMITTED to
+// the atomic. Correcting only the returned copy (`Add(1) & mask; if counter == 0
+// { counter = 1 }`) leaves the atomic holding the masked-zero value, so the call
+// AFTER the wrap reads 1 and returns the id just handed out. The duplicate stays
+// inside the namespace, so nothing downstream looks wrong — uniqueness just
+// silently stops holding.
+//
+// The wrap is reachable rather than theoretical: the seed consumes counter space,
+// so the distance to it depends on uptime phase.
+func TestUserspaceSyncedSessionIDWrapEmitsNoDuplicate6198(t *testing.T) {
+	// Let the lazy boot-clock seed fire first, so the Store below is not
+	// overwritten by it, then restore the allocator for any later test.
+	_ = nextUserspaceSyncedSessionID()
+	saved := userspaceSyncedSessionIDs.Load()
+	t.Cleanup(func() { userspaceSyncedSessionIDs.Store(saved) })
+
+	// One short of the last representable counter value.
+	userspaceSyncedSessionIDs.Store(userspaceSyncedSessionIDCounterMask - 1)
+
+	const mints = 4 // last-before-wrap, the wrap itself, and two past it
+	ids := make([]uint64, 0, mints)
+	seen := make(map[uint64]int, mints)
+	for i := 0; i < mints; i++ {
+		id := nextUserspaceSyncedSessionID()
+		if prev, dup := seen[id]; dup {
+			t.Fatalf("mints %d and %d across the 48-bit wrap both returned %#x — "+
+				"the zero-correction was applied to the returned copy but never "+
+				"committed to the atomic, so the id after the wrap repeats",
+				prev, i, id)
+		}
+		seen[id] = i
+		ids = append(ids, id)
+	}
+
+	for i, id := range ids {
+		if id == userspaceSyncedSessionIDNamespace {
+			t.Fatalf("mint %d returned the reserved 0 counter (%#x)", i, id)
+		}
+		if id>>48 != 0xFFFF {
+			t.Fatalf("mint %d left the namespace: %#x", i, id)
+		}
+	}
+
+	// The wrap must land on 1 and then keep climbing, not stall or repeat.
+	if got := ids[1] &^ userspaceSyncedSessionIDNamespace; got != 1 {
+		t.Fatalf("counter after the wrap = %d, want 1", got)
+	}
+	if got := ids[2] &^ userspaceSyncedSessionIDNamespace; got != 2 {
+		t.Fatalf("counter after the wrap+1 = %d, want 2 — the atomic did not "+
+			"retain the corrected value", got)
+	}
+}
+
+// TestUserspaceSyncedSessionIDDistinctAwayFromWrap6198 is the NEGATIVE CONTROL
+// for the wrap test: consecutive mints far from the boundary are distinct under
+// BOTH the CAS advance and the old Add-and-correct, because the correction branch
+// never runs there. A control that also reds would be a co-signer.
+func TestUserspaceSyncedSessionIDDistinctAwayFromWrap6198(t *testing.T) {
+	_ = nextUserspaceSyncedSessionID()
+	saved := userspaceSyncedSessionIDs.Load()
+	t.Cleanup(func() { userspaceSyncedSessionIDs.Store(saved) })
+
+	// Same distance-from-a-boundary shape as the wrap test, but at a point the
+	// counter merely passes through.
+	userspaceSyncedSessionIDs.Store(userspaceSyncedSessionIDCounterMask >> 1)
+
+	seen := make(map[uint64]int, 4)
+	for i := 0; i < 4; i++ {
+		id := nextUserspaceSyncedSessionID()
+		if prev, dup := seen[id]; dup {
+			t.Fatalf("mints %d and %d away from the wrap both returned %#x", prev, i, id)
+		}
+		seen[id] = i
 	}
 }
 

--- a/pkg/daemon/userspace_sync_session_id_6198_test.go
+++ b/pkg/daemon/userspace_sync_session_id_6198_test.go
@@ -1,0 +1,199 @@
+package daemon
+
+import (
+	"testing"
+
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// #6198 regression coverage for the node-local BPF-ABI SessionID minted by the
+// HA-synced session converters.
+//
+// The pre-fix composition was:
+//
+//	SessionID: uint64(now)<<16 | uint64(delta.Slot&0xffff)
+//
+// `now` is CLOCK_MONOTONIC SECONDS and `delta.Slot` is the AF_XDP BINDING slot
+// (`BindingIdentity.slot` — one per interface/queue, a handful per node), which
+// the binary event stream carrying the primary delta path never even decodes
+// (`decodeSessionEvent` leaves it 0). Every session converted within one
+// monotonic second therefore collapsed onto ONE id.
+
+func sessionDeltaV4ForSessionID(srcPort uint16, slot uint32) dpuserspace.SessionDeltaInfo {
+	return dpuserspace.SessionDeltaInfo{
+		Event: "open", AddrFamily: 2, Protocol: 6,
+		SrcIP: "10.0.61.102", DstIP: "172.16.80.200",
+		SrcPort: srcPort, DstPort: 5201,
+		IngressZone: "lan", EgressZone: "wan", EgressIfindex: 12,
+		Slot: slot,
+	}
+}
+
+func sessionDeltaV6ForSessionID(srcPort uint16, slot uint32) dpuserspace.SessionDeltaInfo {
+	return dpuserspace.SessionDeltaInfo{
+		Event: "open", AddrFamily: 10, Protocol: 6,
+		SrcIP: "2001:559:8585:bf01::102", DstIP: "2001:559:8585:80::200",
+		SrcPort: srcPort, DstPort: 5201,
+		IngressZone: "lan", EgressZone: "wan", EgressIfindex: 12,
+		Slot: slot,
+	}
+}
+
+// TestUserspaceSyncedSessionIDDistinctPerSession6198 is the fail-on-revert pin.
+//
+// It converts many DISTINCT sessions that share the binding slot the event
+// stream actually produces (0) and asserts every minted SessionID is unique.
+// Restoring `uint64(now)<<16 | uint64(delta.Slot&0xffff)` makes this RED as an
+// assertion: a few hundred conversions cannot span a monotonic second boundary
+// more than once, so the pre-fix code yields at most two distinct ids.
+func TestUserspaceSyncedSessionIDDistinctPerSession6198(t *testing.T) {
+	zoneIDs := map[string]uint16{"lan": 1, "wan": 2}
+	const sessions = 512
+
+	for _, tc := range []struct {
+		name    string
+		convert func(uint16, uint32) (uint64, bool)
+	}{
+		{
+			name: "v4",
+			convert: func(port uint16, slot uint32) (uint64, bool) {
+				_, val, ok := userspaceSessionFromDeltaV4(sessionDeltaV4ForSessionID(port, slot), zoneIDs)
+				return val.SessionID, ok
+			},
+		},
+		{
+			name: "v6",
+			convert: func(port uint16, slot uint32) (uint64, bool) {
+				_, val, ok := userspaceSessionFromDeltaV6(sessionDeltaV6ForSessionID(port, slot), zoneIDs)
+				return val.SessionID, ok
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			seen := make(map[uint64]uint16, sessions)
+			for i := 0; i < sessions; i++ {
+				port := uint16(30000 + i)
+				id, ok := tc.convert(port, 0)
+				if !ok {
+					t.Fatalf("expected %s delta (src port %d) to convert", tc.name, port)
+				}
+				if prev, dup := seen[id]; dup {
+					t.Fatalf("%s SessionID collision: src ports %d and %d both minted id %#x "+
+						"(%d distinct sessions produced only %d distinct ids) — the synced "+
+						"session id is not an identity",
+						tc.name, prev, port, id, i+1, len(seen))
+				}
+				seen[id] = port
+			}
+			if len(seen) != sessions {
+				t.Fatalf("%s: %d distinct ids for %d sessions", tc.name, len(seen), sessions)
+			}
+		})
+	}
+}
+
+// TestUserspaceSyncedSessionIDSlotBoundary6198 covers the literal aliasing the
+// issue names: slots that differ by a multiple of 65536 are indistinguishable
+// under `Slot & 0xffff`. Slot no longer participates in the identity at all, so
+// these sessions get distinct ids. Restoring the mask makes the 65536/65537
+// pairs collide with 0/1 within a monotonic second.
+func TestUserspaceSyncedSessionIDSlotBoundary6198(t *testing.T) {
+	zoneIDs := map[string]uint16{"lan": 1, "wan": 2}
+	slots := []uint32{0, 1, 65535, 65536, 65537, 131072}
+
+	seen := make(map[uint64]uint32, len(slots))
+	for i, slot := range slots {
+		// Distinct sessions (distinct source ports) that happen to land on
+		// different binding slots — including slots that alias under the old
+		// 16-bit mask.
+		_, val, ok := userspaceSessionFromDeltaV4(sessionDeltaV4ForSessionID(uint16(40000+i), slot), zoneIDs)
+		if !ok {
+			t.Fatalf("expected delta on slot %d to convert", slot)
+		}
+		if prev, dup := seen[val.SessionID]; dup {
+			t.Fatalf("SessionID collision: slots %d and %d both minted id %#x — "+
+				"slot %d aliases slot %d under a 16-bit mask", prev, slot, val.SessionID, slot, prev)
+		}
+		seen[val.SessionID] = slot
+	}
+}
+
+// TestUserspaceSyncedSessionIDDistinctSlotsBelowBoundary6198 is the NEGATIVE
+// CONTROL: it must pass BOTH with and without the fix.
+//
+// Two sessions on distinct binding slots BELOW the 16-bit boundary always got
+// distinct ids, because the pre-fix composition put the slot in the low 16 bits
+// (`now<<16 | slot`), so slots 1 and 2 differ regardless of `now`. A control
+// that also reds on revert would be a co-signer, not a control.
+func TestUserspaceSyncedSessionIDDistinctSlotsBelowBoundary6198(t *testing.T) {
+	zoneIDs := map[string]uint16{"lan": 1, "wan": 2}
+
+	_, valA, ok := userspaceSessionFromDeltaV4(sessionDeltaV4ForSessionID(41000, 1), zoneIDs)
+	if !ok {
+		t.Fatal("expected slot-1 delta to convert")
+	}
+	_, valB, ok := userspaceSessionFromDeltaV4(sessionDeltaV4ForSessionID(41001, 2), zoneIDs)
+	if !ok {
+		t.Fatal("expected slot-2 delta to convert")
+	}
+	if valA.SessionID == valB.SessionID {
+		t.Fatalf("slots 1 and 2 shared SessionID %#x", valA.SessionID)
+	}
+}
+
+// TestUserspaceSyncedSessionIDNamespaceDisjointFromDataplane6198 pins the
+// namespace reservation: a Go-minted id must never be mistakable for a Rust
+// dataplane id (`(worker_id & 0xFFFF) << 48 | counter48`, worker ids being tiny
+// queue indices), because both are written into the same BPF conntrack mirror
+// field. It also pins the "never 0" property — 0 is the sentinel that makes
+// `flowSessionDisplayID` fall back to the per-row ordinal.
+func TestUserspaceSyncedSessionIDNamespaceDisjointFromDataplane6198(t *testing.T) {
+	for i := 0; i < 64; i++ {
+		id := nextUserspaceSyncedSessionID()
+		if id == 0 {
+			t.Fatal("minted the 0 sentinel")
+		}
+		if hi := id >> 48; hi != 0xFFFF {
+			t.Fatalf("minted id %#x has namespace %#x, want %#x — it could alias a "+
+				"dataplane id from worker %d", id, hi, 0xFFFF, hi)
+		}
+	}
+}
+
+// TestUserspaceForwardWireAliasSharesBaseSessionID6198 pins that the
+// fabric-redirect forward-wire alias entry carries the SAME SessionID as its
+// base entry: they are two conntrack keys for ONE logical session. Re-converting
+// the delta for the alias (the pre-#6198 shape) would mint a second id.
+func TestUserspaceForwardWireAliasSharesBaseSessionID6198(t *testing.T) {
+	zoneIDs := map[string]uint16{"lan": 1, "wan": 2}
+
+	deltaV4 := sessionDeltaV4ForSessionID(39906, 0)
+	deltaV4.NATSrcIP = "172.16.80.8"
+	deltaV4.NATSrcPort = 39906
+	baseKeyV4, baseValV4, ok := userspaceSessionFromDeltaV4(deltaV4, zoneIDs)
+	if !ok {
+		t.Fatal("expected v4 delta to convert")
+	}
+	_, aliasValV4, ok := userspaceForwardWireAliasV4(baseKeyV4, baseValV4, deltaV4)
+	if !ok {
+		t.Fatal("expected v4 forward-wire alias")
+	}
+	if aliasValV4.SessionID != baseValV4.SessionID {
+		t.Fatalf("v4 alias SessionID %#x != base %#x", aliasValV4.SessionID, baseValV4.SessionID)
+	}
+
+	deltaV6 := sessionDeltaV6ForSessionID(50952, 0)
+	deltaV6.NATSrcIP = "2001:559:8585:80::8"
+	deltaV6.NATSrcPort = 50952
+	baseKeyV6, baseValV6, ok := userspaceSessionFromDeltaV6(deltaV6, zoneIDs)
+	if !ok {
+		t.Fatal("expected v6 delta to convert")
+	}
+	_, aliasValV6, ok := userspaceForwardWireAliasV6(baseKeyV6, baseValV6, deltaV6)
+	if !ok {
+		t.Fatal("expected v6 forward-wire alias")
+	}
+	if aliasValV6.SessionID != baseValV6.SessionID {
+		t.Fatalf("v6 alias SessionID %#x != base %#x", aliasValV6.SessionID, baseValV6.SessionID)
+	}
+}

--- a/pkg/daemon/userspace_sync_test.go
+++ b/pkg/daemon/userspace_sync_test.go
@@ -197,7 +197,9 @@ func TestUserspaceSessionFromDeltaCarriesRTFlowSessionID5212(t *testing.T) {
 	if valV4.RTFlowSessionID != wantID {
 		t.Fatalf("v4 RTFlowSessionID = %#x, want %#x", valV4.RTFlowSessionID, wantID)
 	}
-	// The BPF-ABI SessionID stays a distinct node-local now<<16|Slot value.
+	// The BPF-ABI SessionID stays a distinct node-local value (#6198: minted by
+	// nextUserspaceSyncedSessionID in its own 0xFFFF<<48 namespace, which the
+	// dataplane's worker-namespaced RTFlowSessionID can never occupy).
 	if valV4.SessionID == wantID {
 		t.Fatal("RTFlowSessionID must be distinct from the BPF-ABI SessionID")
 	}
@@ -477,7 +479,11 @@ func TestUserspaceForwardWireAliasFromDeltaV4UsesNATTuple(t *testing.T) {
 		NATSrcPort:  39906,
 	}
 
-	key, _, ok := userspaceForwardWireAliasFromDeltaV4(delta, zoneIDs)
+	baseKey, baseVal, ok := userspaceSessionFromDeltaV4(delta, zoneIDs)
+	if !ok {
+		t.Fatal("expected v4 delta to convert")
+	}
+	key, _, ok := userspaceForwardWireAliasV4(baseKey, baseVal, delta)
 	if !ok {
 		t.Fatal("expected v4 forward-wire alias")
 	}
@@ -600,7 +606,11 @@ func TestUserspaceForwardWireAliasFromDeltaV6UsesNATTuple(t *testing.T) {
 		NATSrcPort:  50952,
 	}
 
-	key, _, ok := userspaceForwardWireAliasFromDeltaV6(delta, zoneIDs)
+	baseKey, baseVal, ok := userspaceSessionFromDeltaV6(delta, zoneIDs)
+	if !ok {
+		t.Fatal("expected v6 delta to convert")
+	}
+	key, _, ok := userspaceForwardWireAliasV6(baseKey, baseVal, delta)
 	if !ok {
 		t.Fatal("expected v6 forward-wire alias")
 	}

--- a/pkg/dataplane/types.go
+++ b/pkg/dataplane/types.go
@@ -24,7 +24,14 @@ type SessionValue struct {
 	IsReverse  uint8
 	AppTimeout uint32 // per-application inactivity timeout (seconds), 0=use default
 
-	SessionID uint64 // unique ID, same on both cluster nodes
+	// SessionID is the NODE-LOCAL conntrack id. It is a display/correlation
+	// value, never a lookup key — forwarding, installs, and deletes are all
+	// 5-tuple keyed. In userspace mode the control plane mints it per converted
+	// HA-synced session (nextUserspaceSyncedSessionID, #6198); the helper stamps
+	// its own dataplane id for sessions it owns (#4915). The two nodes do NOT
+	// agree on it: the cross-node correlatable id is RTFlowSessionID below.
+	// See "Node-Local BPF-ABI Session Id" in docs/session-sync-architecture.md.
+	SessionID uint64
 
 	Created  uint64
 	LastSeen uint64
@@ -148,7 +155,14 @@ type SessionValueV6 struct {
 	IsReverse  uint8
 	AppTimeout uint32 // per-application inactivity timeout (seconds), 0=use default
 
-	SessionID uint64 // unique ID, same on both cluster nodes
+	// SessionID is the NODE-LOCAL conntrack id. It is a display/correlation
+	// value, never a lookup key — forwarding, installs, and deletes are all
+	// 5-tuple keyed. In userspace mode the control plane mints it per converted
+	// HA-synced session (nextUserspaceSyncedSessionID, #6198); the helper stamps
+	// its own dataplane id for sessions it owns (#4915). The two nodes do NOT
+	// agree on it: the cross-node correlatable id is RTFlowSessionID below.
+	// See "Node-Local BPF-ABI Session Id" in docs/session-sync-architecture.md.
+	SessionID uint64
 
 	Created  uint64
 	LastSeen uint64

--- a/pkg/dataplane/types.go
+++ b/pkg/dataplane/types.go
@@ -114,8 +114,11 @@ type SessionValue struct {
 	// on the primary and closes on the peer after a failover then emits its
 	// SESSION_CREATE and SESSION_CLOSE records under ONE correlatable id across
 	// both nodes. Distinct from the BPF-ABI SessionID above (that is the Go
-	// dataplane's own conntrack id, now<<16|Slot in userspace mode — node-local
-	// by construction). Like Generation/ConfigEpoch this is userspace-sync-only
+	// dataplane's own conntrack id — node-local by construction; in userspace mode
+	// it is minted per converted session by nextUserspaceSyncedSessionID, #6198,
+	// replacing a now<<16|Slot composition that collapsed every session converted
+	// in one second onto a single id). Like Generation/ConfigEpoch this is
+	// userspace-sync-only
 	// HA metadata carried as a length-gated trailing field in the encode*Payload
 	// functions; it is NOT part of the BPF/C conntrack ABI and MUST NOT be added
 	// to it. 0 = "no id carried" (a legacy peer that omits the field, or a
@@ -221,8 +224,11 @@ type SessionValueV6 struct {
 	// on the primary and closes on the peer after a failover then emits its
 	// SESSION_CREATE and SESSION_CLOSE records under ONE correlatable id across
 	// both nodes. Distinct from the BPF-ABI SessionID above (that is the Go
-	// dataplane's own conntrack id, now<<16|Slot in userspace mode — node-local
-	// by construction). Like Generation/ConfigEpoch this is userspace-sync-only
+	// dataplane's own conntrack id — node-local by construction; in userspace mode
+	// it is minted per converted session by nextUserspaceSyncedSessionID, #6198,
+	// replacing a now<<16|Slot composition that collapsed every session converted
+	// in one second onto a single id). Like Generation/ConfigEpoch this is
+	// userspace-sync-only
 	// HA metadata carried as a length-gated trailing field in the encode*Payload
 	// functions; it is NOT part of the BPF/C conntrack ABI and MUST NOT be added
 	// to it. 0 = "no id carried" (a legacy peer that omits the field, or a

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -3017,36 +3017,38 @@ func (x *GetSessionsResponse) GetNextPageToken() string {
 }
 
 type SessionEntry struct {
-	state            protoimpl.MessageState `protogen:"open.v1"`
-	SrcAddr          string                 `protobuf:"bytes,1,opt,name=src_addr,json=srcAddr,proto3" json:"src_addr,omitempty"`
-	DstAddr          string                 `protobuf:"bytes,2,opt,name=dst_addr,json=dstAddr,proto3" json:"dst_addr,omitempty"`
-	SrcPort          uint32                 `protobuf:"varint,3,opt,name=src_port,json=srcPort,proto3" json:"src_port,omitempty"`
-	DstPort          uint32                 `protobuf:"varint,4,opt,name=dst_port,json=dstPort,proto3" json:"dst_port,omitempty"`
-	Protocol         string                 `protobuf:"bytes,5,opt,name=protocol,proto3" json:"protocol,omitempty"`
-	State            string                 `protobuf:"bytes,6,opt,name=state,proto3" json:"state,omitempty"`
-	PolicyId         uint32                 `protobuf:"varint,7,opt,name=policy_id,json=policyId,proto3" json:"policy_id,omitempty"`
-	IngressZone      uint32                 `protobuf:"varint,8,opt,name=ingress_zone,json=ingressZone,proto3" json:"ingress_zone,omitempty"`
-	EgressZone       uint32                 `protobuf:"varint,9,opt,name=egress_zone,json=egressZone,proto3" json:"egress_zone,omitempty"`
-	FwdPackets       uint64                 `protobuf:"varint,10,opt,name=fwd_packets,json=fwdPackets,proto3" json:"fwd_packets,omitempty"`
-	FwdBytes         uint64                 `protobuf:"varint,11,opt,name=fwd_bytes,json=fwdBytes,proto3" json:"fwd_bytes,omitempty"`
-	RevPackets       uint64                 `protobuf:"varint,12,opt,name=rev_packets,json=revPackets,proto3" json:"rev_packets,omitempty"`
-	RevBytes         uint64                 `protobuf:"varint,13,opt,name=rev_bytes,json=revBytes,proto3" json:"rev_bytes,omitempty"`
-	Nat              string                 `protobuf:"bytes,14,opt,name=nat,proto3" json:"nat,omitempty"`
-	AgeSeconds       int64                  `protobuf:"varint,15,opt,name=age_seconds,json=ageSeconds,proto3" json:"age_seconds,omitempty"`
-	TimeoutSeconds   uint32                 `protobuf:"varint,16,opt,name=timeout_seconds,json=timeoutSeconds,proto3" json:"timeout_seconds,omitempty"`
-	IngressZoneName  string                 `protobuf:"bytes,17,opt,name=ingress_zone_name,json=ingressZoneName,proto3" json:"ingress_zone_name,omitempty"`
-	EgressZoneName   string                 `protobuf:"bytes,18,opt,name=egress_zone_name,json=egressZoneName,proto3" json:"egress_zone_name,omitempty"`
-	IdleSeconds      int64                  `protobuf:"varint,19,opt,name=idle_seconds,json=idleSeconds,proto3" json:"idle_seconds,omitempty"`
-	Application      string                 `protobuf:"bytes,20,opt,name=application,proto3" json:"application,omitempty"`                                   // resolved application name
-	PolicyName       string                 `protobuf:"bytes,21,opt,name=policy_name,json=policyName,proto3" json:"policy_name,omitempty"`                   // resolved policy name
-	SessionId        uint64                 `protobuf:"varint,22,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`                     // unique session ID (same on both cluster nodes)
-	IngressInterface string                 `protobuf:"bytes,23,opt,name=ingress_interface,json=ingressInterface,proto3" json:"ingress_interface,omitempty"` // Junos-style interface name for ingress zone
-	EgressInterface  string                 `protobuf:"bytes,24,opt,name=egress_interface,json=egressInterface,proto3" json:"egress_interface,omitempty"`    // Junos-style interface name for egress zone
-	NatSrcAddr       string                 `protobuf:"bytes,25,opt,name=nat_src_addr,json=natSrcAddr,proto3" json:"nat_src_addr,omitempty"`                 // SNAT translated source address
-	NatSrcPort       uint32                 `protobuf:"varint,26,opt,name=nat_src_port,json=natSrcPort,proto3" json:"nat_src_port,omitempty"`                // SNAT translated source port
-	NatDstAddr       string                 `protobuf:"bytes,27,opt,name=nat_dst_addr,json=natDstAddr,proto3" json:"nat_dst_addr,omitempty"`                 // DNAT translated destination address
-	NatDstPort       uint32                 `protobuf:"varint,28,opt,name=nat_dst_port,json=natDstPort,proto3" json:"nat_dst_port,omitempty"`                // DNAT translated destination port
-	HaActive         bool                   `protobuf:"varint,29,opt,name=ha_active,json=haActive,proto3" json:"ha_active,omitempty"`                        // true if session is on HA primary node
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	SrcAddr         string                 `protobuf:"bytes,1,opt,name=src_addr,json=srcAddr,proto3" json:"src_addr,omitempty"`
+	DstAddr         string                 `protobuf:"bytes,2,opt,name=dst_addr,json=dstAddr,proto3" json:"dst_addr,omitempty"`
+	SrcPort         uint32                 `protobuf:"varint,3,opt,name=src_port,json=srcPort,proto3" json:"src_port,omitempty"`
+	DstPort         uint32                 `protobuf:"varint,4,opt,name=dst_port,json=dstPort,proto3" json:"dst_port,omitempty"`
+	Protocol        string                 `protobuf:"bytes,5,opt,name=protocol,proto3" json:"protocol,omitempty"`
+	State           string                 `protobuf:"bytes,6,opt,name=state,proto3" json:"state,omitempty"`
+	PolicyId        uint32                 `protobuf:"varint,7,opt,name=policy_id,json=policyId,proto3" json:"policy_id,omitempty"`
+	IngressZone     uint32                 `protobuf:"varint,8,opt,name=ingress_zone,json=ingressZone,proto3" json:"ingress_zone,omitempty"`
+	EgressZone      uint32                 `protobuf:"varint,9,opt,name=egress_zone,json=egressZone,proto3" json:"egress_zone,omitempty"`
+	FwdPackets      uint64                 `protobuf:"varint,10,opt,name=fwd_packets,json=fwdPackets,proto3" json:"fwd_packets,omitempty"`
+	FwdBytes        uint64                 `protobuf:"varint,11,opt,name=fwd_bytes,json=fwdBytes,proto3" json:"fwd_bytes,omitempty"`
+	RevPackets      uint64                 `protobuf:"varint,12,opt,name=rev_packets,json=revPackets,proto3" json:"rev_packets,omitempty"`
+	RevBytes        uint64                 `protobuf:"varint,13,opt,name=rev_bytes,json=revBytes,proto3" json:"rev_bytes,omitempty"`
+	Nat             string                 `protobuf:"bytes,14,opt,name=nat,proto3" json:"nat,omitempty"`
+	AgeSeconds      int64                  `protobuf:"varint,15,opt,name=age_seconds,json=ageSeconds,proto3" json:"age_seconds,omitempty"`
+	TimeoutSeconds  uint32                 `protobuf:"varint,16,opt,name=timeout_seconds,json=timeoutSeconds,proto3" json:"timeout_seconds,omitempty"`
+	IngressZoneName string                 `protobuf:"bytes,17,opt,name=ingress_zone_name,json=ingressZoneName,proto3" json:"ingress_zone_name,omitempty"`
+	EgressZoneName  string                 `protobuf:"bytes,18,opt,name=egress_zone_name,json=egressZoneName,proto3" json:"egress_zone_name,omitempty"`
+	IdleSeconds     int64                  `protobuf:"varint,19,opt,name=idle_seconds,json=idleSeconds,proto3" json:"idle_seconds,omitempty"`
+	Application     string                 `protobuf:"bytes,20,opt,name=application,proto3" json:"application,omitempty"`                 // resolved application name
+	PolicyName      string                 `protobuf:"bytes,21,opt,name=policy_name,json=policyName,proto3" json:"policy_name,omitempty"` // resolved policy name
+	// Node-local dataplane session id: a display/correlation value, NOT a key,
+	// and NOT the same on both cluster nodes (#6198).
+	SessionId        uint64 `protobuf:"varint,22,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	IngressInterface string `protobuf:"bytes,23,opt,name=ingress_interface,json=ingressInterface,proto3" json:"ingress_interface,omitempty"` // Junos-style interface name for ingress zone
+	EgressInterface  string `protobuf:"bytes,24,opt,name=egress_interface,json=egressInterface,proto3" json:"egress_interface,omitempty"`    // Junos-style interface name for egress zone
+	NatSrcAddr       string `protobuf:"bytes,25,opt,name=nat_src_addr,json=natSrcAddr,proto3" json:"nat_src_addr,omitempty"`                 // SNAT translated source address
+	NatSrcPort       uint32 `protobuf:"varint,26,opt,name=nat_src_port,json=natSrcPort,proto3" json:"nat_src_port,omitempty"`                // SNAT translated source port
+	NatDstAddr       string `protobuf:"bytes,27,opt,name=nat_dst_addr,json=natDstAddr,proto3" json:"nat_dst_addr,omitempty"`                 // DNAT translated destination address
+	NatDstPort       uint32 `protobuf:"varint,28,opt,name=nat_dst_port,json=natDstPort,proto3" json:"nat_dst_port,omitempty"`                // DNAT translated destination port
+	HaActive         bool   `protobuf:"varint,29,opt,name=ha_active,json=haActive,proto3" json:"ha_active,omitempty"`                        // true if session is on HA primary node
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -4093,9 +4093,13 @@ type EventEntry struct {
 	// consuming GetEvents can reproduce the full close record. All are
 	// additive (new field numbers, no renumber). 0 / "" means the event
 	// did not carry the field (e.g. a non-close event, or no NAT applied).
-	NatSrcAddr     string `protobuf:"bytes,21,opt,name=nat_src_addr,json=natSrcAddr,proto3" json:"nat_src_addr,omitempty"`              // post-NAT source "ip:port" ("" = no NAT)
-	NatDstAddr     string `protobuf:"bytes,22,opt,name=nat_dst_addr,json=natDstAddr,proto3" json:"nat_dst_addr,omitempty"`              // post-NAT destination "ip:port"
-	SessionId      uint64 `protobuf:"varint,23,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`                  // unique session identifier
+	NatSrcAddr string `protobuf:"bytes,21,opt,name=nat_src_addr,json=natSrcAddr,proto3" json:"nat_src_addr,omitempty"` // post-NAT source "ip:port" ("" = no NAT)
+	NatDstAddr string `protobuf:"bytes,22,opt,name=nat_dst_addr,json=natDstAddr,proto3" json:"nat_dst_addr,omitempty"` // post-NAT destination "ip:port"
+	// Node-local dataplane session id (the #4915 [152:160] ringbuf slot): unique
+	// within this node, but NOT the same on both cluster nodes (#6198). Use it to
+	// correlate this event with `show security flow session` on THIS node; it is
+	// not a cross-node key.
+	SessionId      uint64 `protobuf:"varint,23,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	ElapsedTime    uint32 `protobuf:"varint,24,opt,name=elapsed_time,json=elapsedTime,proto3" json:"elapsed_time,omitempty"`            // seconds since session creation (CLOSE)
 	Created        uint32 `protobuf:"varint,25,opt,name=created,proto3" json:"created,omitempty"`                                       // absolute session-creation Unix seconds (CLOSE)
 	CreatedNanos   uint32 `protobuf:"varint,26,opt,name=created_nanos,json=createdNanos,proto3" json:"created_nanos,omitempty"`         // sub-second nanosecond remainder of created

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -411,7 +411,9 @@ message SessionEntry {
   int64 idle_seconds = 19;
   string application = 20;        // resolved application name
   string policy_name = 21;        // resolved policy name
-  uint64 session_id = 22;         // unique session ID (same on both cluster nodes)
+  // Node-local dataplane session id: a display/correlation value, NOT a key,
+  // and NOT the same on both cluster nodes (#6198).
+  uint64 session_id = 22;
   string ingress_interface = 23;  // Junos-style interface name for ingress zone
   string egress_interface = 24;   // Junos-style interface name for egress zone
   string nat_src_addr = 25;       // SNAT translated source address

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -538,7 +538,11 @@ message EventEntry {
   // did not carry the field (e.g. a non-close event, or no NAT applied).
   string nat_src_addr = 21;     // post-NAT source "ip:port" ("" = no NAT)
   string nat_dst_addr = 22;     // post-NAT destination "ip:port"
-  uint64 session_id = 23;       // unique session identifier
+  // Node-local dataplane session id (the #4915 [152:160] ringbuf slot): unique
+  // within this node, but NOT the same on both cluster nodes (#6198). Use it to
+  // correlate this event with `show security flow session` on THIS node; it is
+  // not a cross-node key.
+  uint64 session_id = 23;
   uint32 elapsed_time = 24;     // seconds since session creation (CLOSE)
   uint32 created = 25;          // absolute session-creation Unix seconds (CLOSE)
   uint32 created_nanos = 26;    // sub-second nanosecond remainder of created

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -1061,7 +1061,12 @@ to put on the wire.
   namespaces the id so it is unique across the node's shared-nothing per-worker
   `SessionTable`s; the counter is monotonic, so a reused 5-tuple (same worker)
   gets a DISTINCT id. `0` is reserved as the wire "unknown" sentinel — a real id
-  is never 0.
+  is never 0. **Worker id `0xFFFF` is reserved for the Go control plane (#6198)**:
+  `nextUserspaceSyncedSessionID` (`pkg/daemon/daemon_ha_userspace_convert.go`)
+  mints `0xFFFF << 48 | counter48` for the peer-synced sessions the daemon writes
+  into the SAME BPF conntrack mirror field, so the two id spaces stay disjoint.
+  Unreachable today (`binding.worker_id` is bounded by the worker count), but any
+  re-partition of these high bits must preserve it.
 - **Storage** — write-once on `SessionEntry.session_id`, never re-stamped, so a
   session's create and close read the same value.
 - **Wire** — harvested onto the Open/Close `SessionDelta.session_id` and encoded

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -1066,7 +1066,11 @@ to put on the wire.
   mints `0xFFFF << 48 | counter48` for the peer-synced sessions the daemon writes
   into the SAME BPF conntrack mirror field, so the two id spaces stay disjoint.
   Unreachable today (`binding.worker_id` is bounded by the worker count), but any
-  re-partition of these high bits must preserve it.
+  re-partition of these high bits must preserve it — `set_worker_id` ENFORCES the
+  reservation with a hard `assert!` (not `debug_assert!`: the helper and
+  `make test-rust` both build `--release`, where a debug assertion is stripped).
+  Pinned by `session::tests::set_worker_id_rejects_the_control_plane_namespace_6198`
+  and its negative control.
 - **Storage** — write-once on `SessionEntry.session_id`, never re-stamped, so a
   session's create and close read the same value.
 - **Wire** — harvested onto the Open/Close `SessionDelta.session_id` and encoded

--- a/userspace-dp/src/session/mod.rs
+++ b/userspace-dp/src/session/mod.rs
@@ -770,6 +770,17 @@ impl SessionTable {
     /// per-worker monotonic counter. A worker id >= 2^16 is clamped into range
     /// (never happens — a queue index is tiny) so the shift cannot alias the
     /// counter bits.
+    ///
+    /// **RESERVED: worker id `0xFFFF` belongs to the Go control plane (#6198).**
+    /// Both allocators write into the SAME BPF conntrack mirror field: this table
+    /// stamps `session_id` for sessions the helper owns, and
+    /// `nextUserspaceSyncedSessionID` (pkg/daemon/daemon_ha_userspace_convert.go)
+    /// mints `0xFFFF << 48 | counter48` for a peer-synced session the daemon
+    /// installs. Keeping `0xFFFF` out of this half is what makes the two id
+    /// spaces disjoint. It is unreachable today — `binding.worker_id` is bounded
+    /// by the worker count (`replan_bindings_from_candidates`) — but anything
+    /// that re-partitions these high bits (e.g. #6311's proposal to steal a bit
+    /// from the worker field) must preserve the reservation.
     pub fn set_worker_id(&mut self, worker_id: u32) {
         self.session_id_worker_hi = ((worker_id as u64) & 0xFFFF) << 48;
     }

--- a/userspace-dp/src/session/mod.rs
+++ b/userspace-dp/src/session/mod.rs
@@ -510,6 +510,15 @@ struct SessionRecord {
     entry: SessionEntry,
 }
 
+/// The `session_id` high-16 (worker) value RESERVED for the Go control plane
+/// (#6198). `nextUserspaceSyncedSessionID`
+/// (`pkg/daemon/daemon_ha_userspace_convert.go`) mints
+/// `0xFFFF << 48 | counter48` for the peer-synced sessions the daemon installs,
+/// and those land in the SAME BPF conntrack mirror field this table stamps. A
+/// `SessionTable` must never take this as its worker id — see `set_worker_id`,
+/// which enforces it.
+pub(crate) const CONTROL_PLANE_SESSION_ID_WORKER_HI: u64 = 0xFFFF;
+
 pub(crate) struct SessionTable {
     /// #964 Step 1: slab-allocated session storage. Indexed by u32
     /// handle. Replaces the prior `sessions: FxHashMap<Key, Entry>`.
@@ -781,8 +790,24 @@ impl SessionTable {
     /// by the worker count (`replan_bindings_from_candidates`) — but anything
     /// that re-partitions these high bits (e.g. #6311's proposal to steal a bit
     /// from the worker field) must preserve the reservation.
+    ///
+    /// The reservation is ENFORCED, not merely documented: a worker id landing on
+    /// it aborts at worker setup. This is a config-time invariant (called once per
+    /// worker, with a queue index), so per `docs/engineering-style.md` a hard
+    /// failure beats running with ids that silently alias the control plane's. A
+    /// plain `assert!` rather than `debug_assert!` because `make test-rust` and
+    /// the shipped helper both build `--release`, where a debug assertion is
+    /// stripped and would guard nothing.
     pub fn set_worker_id(&mut self, worker_id: u32) {
-        self.session_id_worker_hi = ((worker_id as u64) & 0xFFFF) << 48;
+        let worker_hi = (worker_id as u64) & 0xFFFF;
+        assert_ne!(
+            worker_hi, CONTROL_PLANE_SESSION_ID_WORKER_HI,
+            "worker id {worker_id} maps onto the session-id namespace reserved \
+             for the Go control plane (#6198): nextUserspaceSyncedSessionID mints \
+             {CONTROL_PLANE_SESSION_ID_WORKER_HI:#x} << 48 | counter into the same \
+             BPF conntrack mirror field"
+        );
+        self.session_id_worker_hi = worker_hi << 48;
     }
 
     /// #4915: allocate the next STABLE session id for a freshly-installed entry.

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -379,6 +379,44 @@ fn session_id_namespaces_worker_in_high_bits() {
     );
 }
 
+// #6198: the high-16 value 0xFFFF is RESERVED for the Go control plane, which
+// mints `0xFFFF << 48 | counter48` for peer-synced sessions into the SAME BPF
+// conntrack mirror field this table stamps. Before #6198 that reservation lived
+// only in a Go comment, so nothing on this side stopped a worker id from landing
+// on it. It is unreachable today (`binding.worker_id` is bounded by the worker
+// count), but #6311 proposes re-partitioning exactly these bits — this pins the
+// invariant so such a change has to confront it rather than silently alias.
+//
+// A hard `assert!`, not `debug_assert!`: `make test-rust` and the shipped helper
+// both build `--release`, where a debug assertion is stripped and would guard
+// nothing. Worker setup is config time, where docs/engineering-style.md prefers
+// crash-start over running with a wrong invariant.
+#[test]
+#[should_panic(expected = "reserved for the Go control plane")]
+fn set_worker_id_rejects_the_control_plane_namespace_6198() {
+    let mut table = SessionTable::new();
+    table.set_worker_id(CONTROL_PLANE_SESSION_ID_WORKER_HI as u32);
+}
+
+// The paired NEGATIVE CONTROL: the highest worker id that is NOT reserved is
+// accepted and namespaces normally. This passes with and without the assertion,
+// so it proves the guard is scoped to the reserved value rather than rejecting
+// large worker ids in general.
+#[test]
+fn set_worker_id_accepts_the_value_below_the_reservation_6198() {
+    let mut table = SessionTable::new();
+    table.set_worker_id(CONTROL_PLANE_SESSION_ID_WORKER_HI as u32 - 1);
+    let t0 = 1_000_000_000u64;
+    assert!(table.install_with_protocol(key_v4(), decision(), metadata(), t0, PROTO_TCP, 0));
+    let opens = table.drain_deltas(8);
+    assert_eq!(opens.len(), 1);
+    assert_eq!(
+        opens[0].session_id >> 48,
+        CONTROL_PLANE_SESSION_ID_WORKER_HI - 1,
+        "an unreserved worker id must still namespace normally"
+    );
+}
+
 // #5212 RED-on-revert: a peer-synced import ADOPTS the originating node's stable
 // session id carried on the HA session-sync wire (SessionInstall.session_id)
 // instead of minting a fresh node-local one, so the standby's SESSION_CLOSE


### PR DESCRIPTION
## Summary

- Replace the HA-synced `SessionValue{,V6}.SessionID` composition `uint64(now)<<16 | uint64(delta.Slot&0xffff)` with `nextUserspaceSyncedSessionID()`, a node-local monotonic counter in a reserved `0xFFFF<<48` namespace.
- **The reported truncation is unreachable; the real defect is much wider.** `delta.Slot` is the AF_XDP *binding* slot (~12 on the loss cluster), not a 10M-capacity session-table slot — and the primary delta path never decodes it at all, so the low half was a constant. With `now` in **seconds**, every session converted in the same second collapsed onto **one** id.
- `userspaceForwardWireAliasFromDelta{V4,V6}` → `userspaceForwardWireAlias{V4,V6}`, taking the already-converted base session so the fabric-redirect alias and its base keep one shared id (and one fewer conversion on the delta path).
- Both converter call sites (V4 `:187`, V6 `:288`) fixed — they are symmetric and want the same answer.
- No wire-format change and no Rust change (details below).

## STEP 0 — impact analysis

### 1. Real range of `delta.Slot`

The issue states `delta.Slot` is a session-table slot bounded by `MAX_SESSIONS = 10000000`. **That is not what the field is.**

The Rust helper has exactly one `SessionDeltaInfo` construction site, `userspace-dp/src/afxdp/session_delta.rs:202`:

```rust
slot: ident.slot,          // ident: &BindingIdentity
queue_id: ident.queue_id,
worker_id: ident.worker_id,
```

`BindingIdentity` (`userspace-dp/src/afxdp/types/forwarding.rs:1090`) is the AF_XDP **binding** identity. Slots are handed out densely by `replan_bindings_from_candidates` (`userspace-dp/src/server/helpers/planning.rs:501-513`):

```rust
let queue_count = candidates.iter().map(|(_, rx)| *rx).min().unwrap_or(0);
let mut slot = 0u32;
for queue_id in 0..queue_count {
    for iface in &interfaces {
        binding.slot = slot;   // slot += 1 per (queue, interface)
```

So `max(slot) = min(rx_queues) × af_xdp_interfaces − 1`. On the loss userspace cluster that is 6 RX queues × a couple of AF_XDP interfaces ≈ **12 slots**. Reaching 65536 would require tens of thousands of interfaces or RX queues. **`& 0xffff` never truncated anything in practice — the reported bug is latent-to-unreachable.**

Worse, on the primary path the slot is not merely small, it is *absent*: `decodeSessionEvent` (`pkg/dataplane/userspace/eventstream.go:1281`) builds the `SessionDeltaInfo` without ever writing `Slot`. `grep -n Slot pkg/dataplane/userspace/eventstream.go` returns nothing. `grep Slot pkg/daemon/*.go` (non-test) returns *only* the two buggy lines — nothing in `pkg/daemon` populates it either.

**Therefore `SessionID == uint64(now)<<16` for every event-stream delta, and `now` is CLOCK_MONOTONIC seconds. Every HA-synced session opened in the same second shares one id.** That is the actual defect, and it is far more severe than the filed one: not "two flows whose slots differ by 65536", but *every* flow in a one-second window. The JSON RPC drain path does populate `Slot`, but with ~12 distinct values it fares no better.

### 2. What consumes this `SessionID`

Traced end to end. It is **not** a lookup key and **not** HA identity:

| Consumer | Detail |
|---|---|
| HA wire | `sync_protocol.go:128/243` encode, `:407/535` decode — a plain `uint64` value field |
| Receiving node | `installClusterSyncedV4/V6` → `PutClusterSyncedV4` → `SetClusterSyncedSessionV4` (`manager_ha.go:1112`) → `m.bpfShim.SetSessionV4(key, installVal)` — written into the BPF conntrack mirror |
| Peer helper | **Not carried.** `buildSessionSyncRequest` forwards only `RTFlowSessionID` (`manager_ha.go:1647/1732`); the Rust side never reads this field |
| CLI | `show security flow session` via `flowSessionDisplayID` (`pkg/cli/cli_show_flow.go:101`) |
| REST / gRPC | `pkg/api/sessions.go:1408/1462`, `pkg/grpcapi/server_sessions.go:1715/1768` |

Exactly one consumer gates on its value: `flowSessionDisplayID`'s `!= 0` check, which falls back to the per-row ordinal. Forwarding matches the 5-tuple `SessionKey`; the conntrack GC reads `Created` at byte offset 16, not this field. So a collision is a **forensic/display** defect — an operator sees unrelated flows sharing one session id on the standby — not a misforward.

### 3. Is the `now<<16` half sound?

Enumerating what the composition actually separates:

| Case | Separated? |
|---|---|
| Same slot, different second | Yes |
| Different slot (< 65536), same second | Yes |
| **Same slot, same second** | **No — and this is the common case** |
| Different slots aliasing under `&0xffff` | No (unreachable: max slot ≈ 12) |

The composition can produce at most `#binding_slots` distinct ids per second — and exactly **one** on the event-stream path. It is a *coarse timestamp*, not an identity. Widening the slot field, as the issue suggests, would fix the unreachable case and leave the reachable one untouched.

## Fix

```go
const userspaceSyncedSessionIDNamespace = uint64(0xFFFF) << 48
const userspaceSyncedSessionIDCounterMask = uint64(0x0000_FFFF_FFFF_FFFF)
var userspaceSyncedSessionIDs atomic.Uint64

func nextUserspaceSyncedSessionID() uint64 {
	counter := userspaceSyncedSessionIDs.Add(1) & userspaceSyncedSessionIDCounterMask
	if counter == 0 {
		counter = 1
	}
	return userspaceSyncedSessionIDNamespace | counter
}
```

**Seeded from the boot clock, at nanosecond resolution.** `userspaceSyncedSessionIDSeed` seeds the counter once, on first use, with `monotonic_nanos >> 10` masked to 48 bits. Without a seed, ids repeat across an xpfd restart — the one axis on which the old composition was better, since CLOCK_MONOTONIC keeps increasing across a daemon restart. Nanoseconds rather than seconds because a second-resolution read gives two incarnations starting in the same integer second an identical seed (see MAJOR 2 below). Granularity ~1.024 µs; the seed advances ~976,562 per second of uptime, so a restart starts above its predecessor's high-water mark unless that predecessor *averaged* >976k synced conversions/second; the 48-bit seed space covers ~9.1 years of uptime.

**CAS advance, not a bare `Add`.** The counter skips the reserved `0`, and the skip is committed to the atomic. Correcting only the returned copy emits a duplicate at the wrap (see MAJOR 1 below).

**Per conversion, not per session.** A bulk resync re-converts live sessions and re-stamps them; the `close` branch converts purely to derive the key and discards the id it mints. Both are harmless in a 48-bit space, and the old composition churned the id the same way — what changed is that concurrent sessions no longer *share* one.

**Why the namespace.** Two writers populate that same BPF mirror field: the Rust helper stamps its own stable id for sessions it owns (`(worker_id & 0xFFFF) << 48 | counter48`, `session/mod.rs:773-789`, #4915), and the control plane stamps this one for a peer-synced session it installs. Worker ids are tiny queue indices, so reserving `0xFFFF` makes the two id spaces provably disjoint. The counter never returns 0 — that stays the established "unknown id" sentinel behind the ordinal fallback.

**Why the alias helpers changed.** With a per-conversion counter, the old `userspaceForwardWireAliasFromDeltaV4(delta, zoneIDs)` — which re-converted the delta internally while the caller had *already* converted it — would mint a second id and split one logical session across its two conntrack keys. Taking the converted base keeps them on one id and removes the redundant conversion.

**Scope.** The id stays deliberately node-local; `RTFlowSessionID` (#5212) remains the cross-node correlatable id and is untouched. Whether the standby's mirror id should instead *adopt* that cross-node id is a behaviour question in #5212/#5213's lineage — deliberately not bundled here (see Deferred).

## Rust side

**No Rust behaviour change, and this is not a one-sided widening.**

- The wire field is already `uint64` on both encode and decode (`binary.LittleEndian.PutUint64` / `Uint64` in `sync_protocol.go`) — no width is pinned anywhere, so nothing widened.
- The value never reaches the helper: `buildSessionSyncRequest` carries only `RTFlowSessionID` (JSON `session_id`), a different field.
- The helper only *writes* `session_id` into the mirror (`publish_conntrack.rs`); it never reads the Go-written value back.

The review fold adds two **comment-only** Rust edits (`SessionTable::set_worker_id` and `userspace-dp/src/session/README.md`) recording that worker id `0xFFFF` is reserved for the control plane — see MINOR 3 below. `cargo check --all-targets` is clean; no Rust code changed.

## Test plan

- [x] `GOCACHE=/dev/shm/gc6198 GOTMPDIR=/dev/shm go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` (full Go suite, every package) — clean
- [x] New `pkg/daemon/userspace_sync_session_id_6198_test.go`:
  - `TestUserspaceSyncedSessionIDDistinctPerSession6198` (V4 + V6) — the fail-on-revert pin
  - `TestUserspaceSyncedSessionIDSlotBoundary6198` — slots 0/1/65535/65536/65537/131072
  - `TestUserspaceSyncedSessionIDDistinctSlotsBelowBoundary6198` — negative control
  - `TestUserspaceSyncedSessionIDNamespaceDisjointFromDataplane6198` — namespace + never-0
  - `TestUserspaceForwardWireAliasSharesBaseSessionID6198` — alias shares the base id
- [ ] Cluster smoke — not run (control-plane conversion only, no forwarding path touched; and this PR does not run cluster targets)

### Mutation proof

Reverted **only** the two `SessionID:` call sites to `uint64(now)<<16 | uint64(delta.Slot&0xffff)`, leaving the tests and every import in place. Build and vet stay clean first, so the red is an assertion and not a build break:

```
$ go build ./...   # after reverting only the fix
BUILD CLEAN
$ go vet ./pkg/daemon/...
VET CLEAN
```

```
$ go test ./pkg/daemon/ -run 6198 -v
=== RUN   TestUserspaceSyncedSessionIDDistinctPerSession6198
=== RUN   TestUserspaceSyncedSessionIDDistinctPerSession6198/v4
    userspace_sync_session_id_6198_test.go:81: v4 SessionID collision: src ports 30000 and 30001 both minted id 0x2ac2660000 (2 distinct sessions produced only 1 distinct ids) — the synced session id is not an identity
=== RUN   TestUserspaceSyncedSessionIDDistinctPerSession6198/v6
    userspace_sync_session_id_6198_test.go:81: v6 SessionID collision: src ports 30000 and 30001 both minted id 0x2ac2660000 (2 distinct sessions produced only 1 distinct ids) — the synced session id is not an identity
--- FAIL: TestUserspaceSyncedSessionIDDistinctPerSession6198 (0.00s)
    --- FAIL: TestUserspaceSyncedSessionIDDistinctPerSession6198/v4 (0.00s)
    --- FAIL: TestUserspaceSyncedSessionIDDistinctPerSession6198/v6 (0.00s)
=== RUN   TestUserspaceSyncedSessionIDSlotBoundary6198
    userspace_sync_session_id_6198_test.go:114: SessionID collision: slots 0 and 65536 both minted id 0x2ac2660000 — slot 65536 aliases slot 0 under a 16-bit mask
--- FAIL: TestUserspaceSyncedSessionIDSlotBoundary6198 (0.00s)
=== RUN   TestUserspaceSyncedSessionIDDistinctSlotsBelowBoundary6198
--- PASS: TestUserspaceSyncedSessionIDDistinctSlotsBelowBoundary6198 (0.00s)
=== RUN   TestUserspaceSyncedSessionIDNamespaceDisjointFromDataplane6198
--- PASS: TestUserspaceSyncedSessionIDNamespaceDisjointFromDataplane6198 (0.00s)
=== RUN   TestUserspaceForwardWireAliasSharesBaseSessionID6198
--- PASS: TestUserspaceForwardWireAliasSharesBaseSessionID6198 (0.00s)
FAIL
```

Note `0x2ac2660000` — the low 16 bits are zero. That is the event-stream reality: `now<<16 | 0`.

**Unrelated tests stay green.** Full `pkg/daemon` suite under the mutation — exactly two failures, both new:

```
$ go test ./pkg/daemon/          # mutated
--- FAIL: TestUserspaceSyncedSessionIDDistinctPerSession6198 (0.00s)
--- FAIL: TestUserspaceSyncedSessionIDSlotBoundary6198 (0.00s)
FAIL	github.com/psaab/xpf/pkg/daemon	28.600s
```

**Negative control is a control, not a co-signer.** `TestUserspaceSyncedSessionIDDistinctSlotsBelowBoundary6198` (slots 1 and 2) PASSES in both worlds — the pre-fix composition put the slot in the low 16 bits, so slots 1 and 2 differ regardless of `now`.

**Restored, green again:**

```
$ go build ./... && go vet ./... && go test ./pkg/daemon/
BUILD CLEAN
VET CLEAN
ok  	github.com/psaab/xpf/pkg/daemon	18.319s
```

**Determinism.** The pin does not depend on the monotonic clock: it converts 512 distinct sessions and asserts 512 distinct ids. 512 conversions cannot straddle 511 second boundaries, so the pre-fix code yields at most two distinct ids — the red is deterministic, not probabilistic.

## Docs

- `docs/session-sync-architecture.md` — new "Node-Local BPF-ABI Session Id (#6198)" section covering what the id is, why the old composition was not an identity, the namespace reservation, and the alias-shares-one-id rule; the #5212 section's cross-reference updated.
- `docs/sync-protocol.md` — the #5212 end-to-end path's parenthetical about the distinct BPF-ABI id.
- `pkg/cluster/README.md` — the `now<<16|slot` description in the RT_FLOW session-id bullet.
- `pkg/dataplane/types.go` — the `RTFlowSessionID` doc comments (V4 and V6) that described `SessionID` as `now<<16|Slot`.
- `_Log.md` — entry appended.

## Review fold (MERGE-NEEDS-MINOR — four minors, no MAJOR)

The reviewer independently corroborated the reframing and **disproved** the leading hypothesis it was scoped to hunt: a cross-node id collision causing a wrong delete or overwrite. Every consumer was traced; the id is not a key anywhere, so no node discriminator is needed and #6311 does not block this.

1. **Cross-restart id reuse** — seeded the counter from the boot clock (above). This was a real, if narrow, regression: the old composition did *not* alias across a daemon restart. Closed rather than documented.
2. **`pkg/dataplane/types.go` asserted the opposite of this PR's thesis** — `SessionID uint64 // unique ID, same on both cluster nodes` on *both* `SessionValue` and `SessionValueV6`, 87 lines above this PR's own node-local comment. Replaced with the node-local, display-only, never-a-key semantics.
3. **Same false claim in the operator-facing gRPC contract** — `proto/xpf/v1/xpf.proto` `SessionEntry.session_id`. Corrected and `xpf.pb.go` **regenerated** via `make proto` (not hand-edited). `git diff -w` on the generated file is the comment alone; the protobuf tag is byte-identical, so no wire impact.
4. **The `0xFFFF<<48` reservation was documented only on the side that need not obey it** — the Rust `SessionTable::set_worker_id` masks a worker id into exactly those bits with nothing saying `0xFFFF` is taken. Unreachable today (`binding.worker_id` is bounded by the worker count), but an unguarded cross-language invariant, and #6311 proposes re-partitioning those bits. Recorded on `set_worker_id` and in `userspace-dp/src/session/README.md`.

Also took the reviewer's NIT: the id is per *conversion*, not stable per session — now stated in the code comment and the architecture doc.

### Re-gate after the fold

The original gate still holds: reverting only the two `SessionID:` call sites reds `TestUserspaceSyncedSessionIDDistinctPerSession6198` (V4 and V6) and `TestUserspaceSyncedSessionIDSlotBoundary6198` as assertions, build and vet clean.

The new seeding guard was proven to fire **independently**. Neutralising only the boot-clock seed (seeding from `0` — the `sync.Once` and the helper stay wired, so the build stays clean):

```
$ go build ./... && go vet ./pkg/daemon/...
BUILD CLEAN
VET CLEAN
$ go test ./pkg/daemon/ -run 6198 -v
--- PASS: TestUserspaceSyncedSessionIDDistinctPerSession6198 (0.00s)
--- PASS: TestUserspaceSyncedSessionIDSlotBoundary6198 (0.00s)
--- PASS: TestUserspaceSyncedSessionIDDistinctSlotsBelowBoundary6198 (0.00s)
--- PASS: TestUserspaceSyncedSessionIDNamespaceDisjointFromDataplane6198 (0.00s)
--- PASS: TestUserspaceSyncedSessionIDSeedSurvivesRestart6198 (0.00s)
    userspace_sync_session_id_6198_test.go:210: counter 1097 is below one second of seeded space (16777216) — the allocator is not seeded from the boot clock, so ids repeat across a restart
--- FAIL: TestUserspaceSyncedSessionIDIsSeededFromBootClock6198 (0.00s)
--- PASS: TestUserspaceForwardWireAliasSharesBaseSessionID6198 (0.00s)
```

Exactly one test reds, and it is the one named for seeding — the guard is scoped to seeding, not a co-signer of the main fix. (`...SeedSurvivesRestart6198` correctly stays green: it pins the seed *math*, which M2 leaves intact, while `...IsSeededFromBootClock6198` pins the *wiring*.) Restored: full `go test ./...` green.

## Second review fold (MERGE-NEEDS-MAJOR — both MAJORs in the seeding, no change to the shape of the fix)

Codex's independent consumer audit again found no lookup, delete, generation guard or dedup keyed by `SessionID`, no third minting constructor beyond the V4/V6 pair, and a fresh protobuf generation byte-identical to the tracked `.pb.go`. Both MAJORs were defects in the boot-clock seeding added in the first fold.

**MAJOR 1 — the zero-correction emitted a duplicate.** `Add(1) & mask; if counter == 0 { counter = 1 }` corrects the returned copy but never commits the skip, so at the wrap the atomic still holds the masked-zero value and the *next* call returns the id just handed out. It stays inside the namespace, so nothing downstream looks wrong — uniqueness silently stops holding. Now a CAS, so the stored value is the returned one.

The wrap is reachable, not theoretical: the seed consumes counter space, so the distance to the boundary depends on uptime phase, and `MAX_SESSIONS` does not bound it (it bounds live entries; closes and resyncs also consume ids). Kept the ring rather than failing closed — this id is display-only, but the conversion carrying it installs an HA-synced session, so refusing to mint would trade a cosmetic alias for lost sessions at failover. A wrap only re-mints ids this incarnation issued 2^48 conversions ago, or ids from an incarnation whose entries are long gone.

**MAJOR 2 — rapid restarts repeated ids immediately.** `daemonMonotonicSeconds` discards nanoseconds and seeding is lazy, so two incarnations whose first allocations land in the same integer second got identical seeds and repeated from their very first id. That is the *common* restart: `RestartSec=1` lands inside the window and the sub-second phase is uniform, so on average half of all restarts do. Now `daemonMonotonicNanos` + `>> 10`.

The previous test compared `uptime` against `uptime+1` — it checked that a *different* second yields a different seed and never that the *same* second yields a colliding one, the same shape of gap this PR already corrected once. The new test drives 1 ms / 10 ms / 100 ms / 700 ms separations inside one integer second, with a fixture guard that fails if an offset crosses a second boundary and would make the case vacuous.

**MINOR — the reservation is now enforced, not documented.** `CONTROL_PLANE_SESSION_ID_WORKER_HI` names the reserved `0xFFFF` and `SessionTable::set_worker_id` asserts against it. A hard `assert!`, not `debug_assert!`: `make test-rust` and the shipped helper both build `--release`, where a debug assertion is stripped and would guard nothing. Worker setup is config time, where `docs/engineering-style.md` prefers crash-start over a wrong invariant.

### Mutation proofs — each guard driven to its own failing case, each with a control

| Mutation | Reds | Control that stays green |
|---|---|---|
| Restore `Add`-and-correct-local-copy | `...WrapEmitsNoDuplicate6198`: *"mints 1 and 2 across the 48-bit wrap both returned `0xffff000000000001`"* | `...DistinctAwayFromWrap6198` — same test shape at a point the counter merely passes through |
| Truncate the seed to second resolution | `...SeedDistinctWithinOneSecond6198`, all four sub-second cases: *"two incarnations 1ms apart within one monotonic second share seed `0xe35fa931a0`"* | `...SeedSurvivesRestart6198` — a whole second apart, which separates under both resolutions |
| Remove the Rust `assert!` | `set_worker_id_rejects_the_control_plane_namespace_6198`, in a **release** build | `set_worker_id_accepts_the_value_below_the_reservation_6198` |
| Revert the two `SessionID:` call sites (original gate, re-proven on top of the fold) | `...DistinctPerSession6198`, `...SlotBoundary6198` | every other 6198 test |

Build and vet are clean under each mutation first, so every red is an assertion rather than a break. Restored: `go build ./...`, `go vet ./...`, `go test ./...` clean; `cargo test --release -- --test-threads=1` clean (4233 + 64 tests, 0 failed).

## Deferred

- Whether the standby's conntrack-mirror id should ADOPT the cross-node `RTFlowSessionID` instead of a node-local one. Today the control plane writes a node-local id into the mirror while the helper, once it owns the session, stamps the adopted cross-node id into the same field — so the displayed id can change at promotion. That is a behaviour choice in #5212/#5213's lineage and needs its own issue; deliberately not bundled with this bug fix.

## Refs

Advances #6198. Related: #5212 (cross-node `RTFlowSessionID`), #5213 (`show security flow session` renders the dataplane id), #4915 (dataplane stable session id).


