### PR TITLE
docs(vrrp): state the RFC 5798 virtual-MAC deviation and its cost

### DIFF
--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -249,6 +249,31 @@ the userspace dataplane admission boundary is in
   (#5301). `pkg/cluster/monitor.go`.
 - **Bondless RETH**: VRRP on physical member interfaces, per-node virtual
   MAC (`02:bf:72:CC:RR:NN`), no Linux bonding required.
+- **VRRP L2 identity is a deliberate deviation from RFC 5798 (#5091).** The RFC
+  specifies a *shared* virtual-router MAC — `00-00-5E-00-01-{VRID}` for IPv4 and
+  `00-00-5E-00-02-{VRID}` for IPv6 — which both routers use, so the virtual
+  router's L2 identity survives a failover untouched. xpf instead derives a
+  **per-node** locally-administered MAC (`02:bf:72:CC:RR:NN` = cluster, RG,
+  node) and advertises from the physical member interface. Two consequences an
+  operator must plan for:
+  - **Failover changes the L2 identity**, so recovery depends on the
+    gratuitous-ARP burst (IPv4) and unsolicited neighbour advertisements
+    (IPv6) reaching peers and updating switch FDBs, rather than on the MAC
+    simply not moving. That path is engineered rather than best-effort —
+    `becomeMaster` sends GARP asynchronously with a forced burst after a MAC
+    change (#2081) — but it is still an update-the-peers mechanism, not an
+    identity-preserving one.
+  - **xpf cannot form a virtual router with a third-party VRRP speaker.** The
+    protocol is on the wire, but a standards-conformant peer expects the shared
+    MAC. Treat RETH VRRP as an xpf-to-xpf mechanism between the two chassis of
+    one cluster, not as general VRRP interop.
+
+  The reason is not oversight: on this platform both nodes' member interfaces
+  routinely share an L2 domain — SR-IOV VFs from the same PF, or two ports on
+  the same physical switch — and a genuinely shared MAC there produces FDB
+  conflicts and MAC flapping as the switch sees one address on two ports. The
+  per-node MAC trades RFC conformance for a deterministic L2 topology. See
+  `RethMAC` in `pkg/cluster/reth.go`.
 - **Session sync**: incremental 1s sweep + ring buffer + GC delete
   callbacks, TCP on fabric link.
 - **Config sync**: primary → secondary with `${node}` variable expansion,

--- a/pkg/cluster/reth.go
+++ b/pkg/cluster/reth.go
@@ -109,6 +109,25 @@ func (rc *RethController) RethIPs(rethName string) ([]net.IP, error) {
 // nodes' member interfaces are on the same L2 domain (e.g. SR-IOV VFs
 // from the same PF, or same physical switch). VRRP + gratuitous NA handle
 // failover; RA goodbye packets handle IPv6 default gateway transitions.
+//
+// This is a DELIBERATE deviation from RFC 5798 §7.3, which specifies a SHARED
+// virtual-router MAC (00-00-5E-00-01-{VRID} v4 / 00-00-5E-00-02-{VRID} v6) that
+// both routers use, so the virtual router's L2 identity survives a failover
+// untouched. Two consequences follow from not doing that, and both are accepted
+// rather than overlooked (#5091):
+//
+//   - Failover CHANGES the L2 identity, so recovery rides on the GARP/NA burst
+//     updating peer caches and switch FDBs instead of the address never moving.
+//     ReconcileVIPs bumps garpEpoch and forces a burst precisely because the MAC
+//     just changed (#2081) — an update-the-peers mechanism, not an
+//     identity-preserving one.
+//   - xpf cannot form a virtual router with a third-party VRRP speaker, which
+//     expects the shared MAC. RETH VRRP is an xpf-to-xpf mechanism between the
+//     two chassis of one cluster, not general VRRP interop.
+//
+// Do not "fix" this to the RFC MAC without solving the FDB problem first: a
+// shared MAC on two member interfaces in one L2 domain makes the switch see one
+// address on two ports. Operator-facing statement: docs/feature-coverage.md.
 func RethMAC(clusterID, rgID, nodeID int) net.HardwareAddr {
 	return net.HardwareAddr{0x02, 0xbf, 0x72, byte(clusterID), byte(rgID), byte(nodeID)}
 }


### PR DESCRIPTION
Closes #5091.

## What this is

#5091 reports that native VRRP announces node-specific RETH MACs instead of the
RFC 5798 shared virtual-router MAC, and says up front that this is *"a
deliberate, documented tradeoff... may be WONTFIX or resolved by explicitly
labelling a non-interoperable mode."*

This takes the second option. The behaviour is correct for this platform and is
unchanged; what was missing is the statement of the deviation where a reader
would actually stand.

## Why it was worth doing rather than closing WONTFIX

The tradeoff was recorded only half-way. `RethMAC` explained the FDB motivation
but never named the RFC it departs from, and `docs/feature-coverage.md` listed
the per-node MAC as a plain feature bullet with no interop caveat at all. That
leaves two failure modes:

- An undocumented deviation is indistinguishable from a bug — which is how this
  came to be filed in the first place.
- It invites the opposite error: someone "corrects" the MAC to the RFC value and
  reintroduces exactly the FDB conflict the per-node scheme exists to avoid. The
  comment now says explicitly not to do that without solving the FDB problem
  first.

## What is now stated

RFC 5798 §7.3 specifies a **shared** virtual-router MAC
(`00-00-5E-00-01-{VRID}` v4, `00-00-5E-00-02-{VRID}` v6) used by both routers,
so the virtual router's L2 identity survives failover untouched. xpf derives a
**per-node** locally-administered MAC (`02:bf:72:CC:RR:NN`) instead. Two
consequences, both now explicit:

- **Failover changes the L2 identity.** Recovery depends on the gratuitous-ARP
  burst and unsolicited neighbour advertisements reaching peers and updating
  switch FDBs, rather than on the address not moving. That path is engineered
  rather than best-effort — `ReconcileVIPs` bumps `garpEpoch` and forces a burst
  precisely because the MAC just changed (#2081) — but it is an
  update-the-peers mechanism, not an identity-preserving one.
- **No third-party VRRP interop.** A standards-conformant peer expects the
  shared MAC. RETH VRRP is an xpf-to-xpf mechanism between the two chassis of
  one cluster, not general VRRP.

The motivation is recorded alongside the deviation so a future reader can
re-judge the tradeoff rather than merely obey it: on this platform both nodes'
member interfaces routinely share an L2 domain (SR-IOV VFs from the same PF, or
two ports on one switch), where a shared MAC makes the switch see one address on
two ports.

## Scope

Comment and documentation only. **44 insertions, zero deletions**, and no
non-comment Go line changed — verified with
`git diff -- '*.go' | grep -E '^[+-]' | grep -vE '^[+-][+-]' | grep -vE '^[+-]\s*//'`,
which returns empty.

## Validation

| Gate | Result |
|---|---|
| `go build ./...` | rc=0 |
| `go vet ./pkg/cluster/` | rc=0 |
| `gofmt -l pkg/cluster/reth.go` | clean |
| `go test ./pkg/cluster/` | `ok  github.com/psaab/xpf/pkg/cluster  10.504s` (rc=0) |

No mutation proof is offered and none is meaningful here: there is no behaviour
change to bind a guard to. The claim this PR makes is that the prose is accurate,
which is verified by reading it against `RethMAC`, `pkg/cluster/garp.go`, and RFC
5798 §7.3 — not by a test.