### PR TITLE
config: scope per-interface host-inbound by node Keys, not children

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -944,54 +944,97 @@ membership (security boundary) loss that also hid the dropped interface from
 the strict `validateZoneInterfaceDefinedStrict` gate. Covered by
 `pkg/config/compiler_zone_interfaces_bracket_5248_test.go`.
 
-**A per-interface `host-inbound-traffic` override is scoped to the SINGLE
-interface it is written under — it NEVER fans out to bracket siblings
-(#6391).** The `zoneInterfaceMembers` flatten above is for zone MEMBERSHIP
-only. Host-inbound is compiled separately and keyed strictly on the direct
-child the stanza hangs under (`iface.Name()` in `compileZones`), never across
-the flattened member set. This matters because the flat-set single-scoped case
-and a hierarchical multi-member `load override` block compile to the SAME AST:
-`interfaces [ ge-0/0/0 ge-0/0/1 ]` followed by
-`interfaces ge-0/0/0 host-inbound-traffic system-services ssh` reuses the FIRST
-member's SetPath container, so the `ge-0/0/0` node carries BOTH the `ge-0/0/1`
-membership leaf AND the host-inbound body — structurally identical to a
-hand-authored `interfaces { ge-0/0/0 { ge-0/0/1; host-inbound-traffic {...} } }`.
-A fanout keyed on the compiled AST alone therefore cannot tell "scope ssh to
-`ge-0/0/0` only" from "apply to every bracket member", so fanning the override
-across `zoneInterfaceMembers` (attempted in PR #6389, closed unmerged) OPENS ssh
-on `ge-0/0/1`, which the operator never configured — an over-permission /
-host-inbound leak.
+**A per-interface `host-inbound-traffic` override is scoped by the KEYS of the
+node it is authored on, never by that node's CHILDREN (#6391).** The
+`zoneInterfaceMembers` flatten above is for zone MEMBERSHIP only — it recurses
+into children. Host-inbound is compiled separately and deliberately does NOT: it
+applies to every name in `iface.Keys` and stops there.
 
-Two properties, do NOT conflate them:
+That distinction exists because the two shapes below are NOT the same AST, which
+is the opposite of what this document asserted before #6391 (it claimed they were
+"structurally identical" and that no AST-keyed fan could separate them — a claim
+disproved by dumping both):
 
-- **Individually-scoped isolation (UNCONDITIONAL invariant).** A service
-  authored under ONE named interface via its own `set` statement
+| authored as | compiled AST | meaning |
+|---|---|---|
+| `interfaces { [ ge-0/0/0 ge-0/0/1 ] { host-inbound-traffic {...} } }` | ONE container `Keys=["ge-0/0/0","ge-0/0/1"]`, **no** membership child | multi-member intent → **both** members |
+| `set ... interfaces [ ge-0/0/0 ge-0/0/1 ]`<br>`set ... interfaces ge-0/0/0 host-inbound-traffic system-services ssh` | container `Keys=["ge-0/0/0"]` with membership **child leaf** `Keys=["ge-0/0/1"]` | ssh scoped to `ge-0/0/0` **only** |
+
+`SetPath` descends the wildcard for the FIRST bracket token and nests the tail
+under it, then the second `set` REUSES that same `ge-0/0/0` container — which is
+why the container ends up carrying both the `ge-0/0/1` membership leaf and the
+host-inbound body even though ssh is single-scoped. Fanning across
+`zoneInterfaceMembers` (children included) is exactly what PR #6389 did, and it
+OPENS ssh on `ge-0/0/1`, which the operator never configured — an over-permission
+/ host-inbound leak (admission is additive, `host_inbound_view.go`). #6389 closed
+unmerged.
+
+**What genuinely IS identical** — and the reason the children-fan leaks so
+broadly — is the flat-set shape above and the hand-authored
+`interfaces { ge-0/0/0 { ge-0/0/1; host-inbound-traffic {...} } }`. The latter is
+the former's SERIALIZATION: `ConfigTree.Format()` (the render `configstore`
+persists through, and the one HA config sync ships via `ShowActive()`) emits
+literally that text, and re-parsing it is byte-identical. So a fan that fires on
+that shape leaks on every RELOAD of an ordinary single-scoped config, and
+first-member-only is the permanently correct answer there — not a compromise.
+
+**Why keying on `Keys` is safe, not merely convenient.** A false positive here
+would re-open the #6389 leak, so the load-bearing property is that **no
+`set`-authored config can produce a multi-key interface container**. That holds by
+schema construction: the interface name is `schemaNode.wildcard` with `args: 0`,
+`multi: false`, `compoundKey: false` (`schema_security.go`), so `SetPath`'s
+`nodeKeyCount = 1 + childSchema.args` is ALWAYS 1 and its container branch stores
+exactly one token. Surplus bracket tokens can only land on a child LEAF, which has
+no `host-inbound-traffic` child and is therefore never read by the fan. The
+multi-key shape is reachable ONLY from a hierarchical parse (`load override`, a
+hand-authored config file). `ExpandGroups` preserves the distinction (an inherited
+multi-key node stays a separate sibling rather than merging into a single-key
+one).
+
+Scope rules that follow:
+
+- **Individually-scoped isolation (UNCONDITIONAL).** A service authored under ONE
+  named interface via its own `set` statement
   (`interfaces ge-0/0/0 host-inbound-traffic system-services ssh`) is
-  single-scoped by definition and must NEVER appear on a sibling — under every
-  design option. This holds today and must keep holding after any future fix.
+  single-scoped and must NEVER appear on a sibling.
+- **Multi-member body applies to every member.** A body authored ON a bracket
+  membership (`interfaces [ ge-0/0/0 ge-0/0/1 ] { host-inbound-traffic { ... } }`)
+  applies to both. This is an admission WIDENING relative to pre-#6391, which
+  applied it to the first member only — see the operator note in
+  `docs/host-inbound-service-matrix.md`.
+- **A nested extra membership is out of scope.**
+  `[ a b ] { c; host-inbound {...} }` fans to `a` and `b` but NOT `c`: `c` is a
+  nested membership statement, not a bracket sibling of the authored node, so it
+  is in the same position as the flat-set `b` leaf. `c` remains a zone MEMBER and
+  falls back to the zone-level host-inbound.
+- **Members do not share a backing store.** `mergeHostInbound` returns `src`
+  unchanged when `dst` is nil, so the fan clones per key (`cloneHostInbound`).
+  Without that, a later single-scoped override merged into one member would
+  mutate the value its bracket siblings point at.
 
-- **Multi-member body (CURRENT fail-safe, pending a design call).** A
-  host-inbound BODY hanging off a bracket membership itself
-  (`interfaces [ ge-0/0/0 ge-0/0/1 ] { host-inbound-traffic { ... } }`, or the
-  `ge-0/0/0 { ge-0/0/1; host-inbound-traffic { ... } }` load-override artifact)
-  currently applies to the first member ONLY. That is the issue's **option 1**
-  (fail-safe): the override stays on the single named interface and a bracketed
-  multi-member intent UNDER-applies (a sibling falls back to the zone-level
-  host-inbound) rather than over-admitting. This is the current default, NOT the
-  final multi-member semantics — making the multi-member intent apply to every
-  member without the flat-set leak needs parse-time scope disambiguation
-  (options 2/3), still an OPEN design call on #6391.
+**Round-trip limitation (#6668, pre-existing, NOT introduced by #6391).** The
+multi-key shape survives `Format()` → `NewParser` (local persistence) and HA
+config sync byte-for-byte, but it does NOT survive `show | display set`:
+`FormatSet()` emits
+`set ... interfaces ge-0/0/0 ge-0/0/1 host-inbound-traffic system-services ssh`,
+which replays into a single garbage leaf
+`Keys=["ge-0/0/1","host-inbound-traffic","system-services","ssh"]` and then fails
+to compile (`zone "trust" references interface "host-inbound-traffic"`). It fails
+CLOSED, but it means the multi-member fan is not durable through a display-set
+round-trip. Tracked separately as #6668.
 
-Both properties are pinned by
+All of the above is pinned by
 `pkg/config/compiler_zone_iface_hostinbound_sibling_6391_test.go`, which asserts
-the FULL per-interface host-inbound map (every interface, both system-services
-AND protocols). Re-introducing the #6389 fanout turns the CONTAINER-SHARING
-cases RED — first-member, three-member, multi-service, protocols, and the two
-hierarchical multi-member-body cases — while the later-member and
-no-shared-backing-store cases stay GREEN CONTROLS (their interfaces do not share
-a SetPath container, so the fanout cannot touch them). The two multi-member-body
-cases assert current option-1 behavior only; an options-2/3 fix intentionally
-updates those two expectations.
+the FULL per-interface host-inbound map (every interface, both system-services AND
+protocols). Re-introducing a children-fan turns the CONTAINER-SHARING cases RED
+(first-member, three-member, multi-service, protocols, and the
+`a { b; host-inbound }` serialization case); reverting the Keys-fan turns
+`TestHostInbound6391HierarchicalBracketBodyFansToAllMembers` RED. The later-member
+and no-shared-backing-store cases stay GREEN CONTROLS (their interfaces do not
+share a SetPath container). `TestHostInbound6391FlatSetNeverYieldsMultiKeyContainer`
+guards the negative direction — a future `SetPath` or schema change that let
+flat-set yield a multi-key container fails there rather than silently widening
+admission.
 
 **Sibling leaves on ONE flat-set line also collapse into a NESTED chain, not
 siblings — the third collapse pattern (#6524).** The two patterns above cover a

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -1044,6 +1044,22 @@ flattens it into a form that fails to compile on reload (it fails closed, with a
 dropping admission). Author multi-member bodies in hierarchical form, or use
 per-interface statements, if you round-trip configs through `display set`.
 
+**Revoking a grant made this way needs care.** A bracket-body grant has no
+targeted `delete`: because the admission was authored on the multi-member node
+rather than on either interface, there is no per-interface path to remove it
+from just one member. The revocation that does work —
+`delete security zones security-zone <z> interfaces [ a b ]` — deletes the
+whole node, which also removes `a` and `b` from the zone entirely. That is
+almost never what an operator wants, and on a zone-based firewall dropping a
+zone membership is a much larger change than dropping a service.
+
+The safe pattern, and the one to prefer when a grant may later need narrowing:
+author per-interface statements instead of a bracket body. Two statements
+granting `ssh` to `a` and to `b` are individually revocable; one bracket body
+granting it to both is not. If you already have a bracket body and need to
+revoke for one member, rewrite it as per-interface statements in the same commit
+as the delete, so the zone membership is never actually lost.
+
 ## Repeated host-inbound-traffic blocks merge (#4544)
 
 Junos MERGES two literal `host-inbound-traffic { ... }` blocks authored under

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -974,6 +974,76 @@ address is never dropped from the deny scope.
 mirrors the same additive resolution and quarantine, so the
 `CanonicalHostInboundTokenSig` it compares equals the runtime's effective set.
 
+## Multi-member bracket body applies to every member (#6391) — UPGRADE NOTE
+
+> **This is an admission WIDENING. Read it before upgrading if any of your
+> configs are hand-authored or loaded with `load override`.**
+
+A per-interface `host-inbound-traffic` body authored ON a bracketed interface
+membership now applies to EVERY member of that bracket. Before #6391 it applied
+to the FIRST member only, and the remaining members silently fell back to the
+zone-level set.
+
+```
+security {
+    zones {
+        security-zone trust {
+            interfaces {
+                [ ge-0/0/0 ge-0/0/1 ] {
+                    host-inbound-traffic {
+                        system-services { ssh; }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+- **Before #6391:** ssh admitted on `ge-0/0/0` only. `ge-0/0/1` fell back to the
+  zone-level host-inbound set.
+- **After #6391:** ssh admitted on `ge-0/0/0` AND `ge-0/0/1` — what the config
+  says.
+
+So on upgrade, an interface that is a non-first member of a bracket carrying a
+host-inbound body **newly admits** the services and protocols in that body. If
+you were relying on the old under-application (deliberately or not), split the
+stanza into per-interface statements before upgrading:
+
+```
+set security zones security-zone trust interfaces [ ge-0/0/0 ge-0/0/1 ]
+set security zones security-zone trust interfaces ge-0/0/0 host-inbound-traffic system-services ssh
+```
+
+That flat-set form is scoped to `ge-0/0/0` alone and is UNAFFECTED by this change
+— see below.
+
+**Who is affected: essentially no one authoring via `set`.** The multi-member
+shape is only reachable from a hierarchical parse — `load override` or a
+hand-edited config file. A `set`-authored bracket list cannot produce it (the
+schema models the interface name as a wildcard container, so `SetPath` nests the
+bracket tail under the first member rather than widening its key). **No config in
+this repository uses the shape**: the `.conf` fixtures under `docs/`,
+`test/incus/` and `examples/deploy/` contain zero bracketed zone memberships.
+
+**What did NOT change — the single-scoped guarantee.** A service authored under
+ONE named interface via its own statement is scoped to that interface and never
+appears on a sibling, including a sibling it shares a bracket with. That
+invariant is unconditional and permanently pinned; PR #6389 broke it and was
+closed unmerged. The two cases are distinguishable in the compiled AST (a
+multi-member body is one container whose `Keys` carry both names; the flat-set
+form is a container keyed on one name with the sibling as a membership CHILD),
+which is what makes applying the body to every member safe here. Full mechanism:
+`docs/config-schema.md`, "A per-interface `host-inbound-traffic` override is
+scoped by the KEYS of the node it is authored on".
+
+**Known limitation (#6668).** The multi-member shape survives config persistence
+and HA config sync, but NOT a `show | display set` round-trip — `display set`
+flattens it into a form that fails to compile on reload (it fails closed, with a
+`references interface "host-inbound-traffic"` error, rather than silently
+dropping admission). Author multi-member bodies in hierarchical form, or use
+per-interface statements, if you round-trip configs through `display set`.
+
 ## Repeated host-inbound-traffic blocks merge (#4544)
 
 Junos MERGES two literal `host-inbound-traffic { ... }` blocks authored under

--- a/pkg/config/compiler_security_zones.go
+++ b/pkg/config/compiler_security_zones.go
@@ -214,7 +214,10 @@ func compileZones(node *Node, sec *SecurityConfig) error {
 						// convenient. The interface name is `schemaNode.wildcard`
 						// with args:0, multi:false, compoundKey:false
 						// (schema_security.go), so SetPath's
-						// `nodeKeyCount = 1 + childSchema.args` is ALWAYS 1 and its
+						// `nodeKeyCount = 1 + childSchema.args` (ast_edit.go:289 —
+						// NOT the same-named local in schema_complete.go,
+						// which is the completion walker and decides
+						// nothing here) is ALWAYS 1 and its
 						// container branch stores exactly one token; surplus bracket
 						// tokens can only land on a child LEAF (which has no
 						// host-inbound child, so it is never read here). A bracket

--- a/pkg/config/compiler_security_zones.go
+++ b/pkg/config/compiler_security_zones.go
@@ -59,6 +59,35 @@ func mergeHostInbound(dst, src *HostInboundTraffic) *HostInboundTraffic {
 	return dst
 }
 
+// cloneHostInbound returns a deep copy of src (fresh backing arrays for both
+// admission dimensions), preserving the exact token multiset and order — a copy
+// is value-identical, it only breaks POINTER identity.
+//
+// Required by the #6391 multi-member fan. mergeHostInbound returns src UNCHANGED
+// when dst is nil (the deliberate #4544 no-copy fast path), so fanning one parsed
+// body across N member names would otherwise store the SAME pointer under N map
+// keys. A later mergeHostInbound into any one of them mutates dst IN PLACE, so a
+// subsequent single-scoped override on one member would silently surface on all
+// the others:
+//
+//	interfaces {
+//	    [ a b ] { host-inbound-traffic { system-services ssh; } }
+//	    a       { host-inbound-traffic { system-services ping; } }
+//	}
+//
+// With a shared pointer, merging `ping` into a mutates the value b also points
+// at, so b wrongly admits ping. Cloning per key keeps the members independent.
+// Pinned by TestHostInbound6391BracketBodyMembersDoNotShareBackingStore.
+func cloneHostInbound(src *HostInboundTraffic) *HostInboundTraffic {
+	if src == nil {
+		return nil
+	}
+	return &HostInboundTraffic{
+		SystemServices: append([]string(nil), src.SystemServices...),
+		Protocols:      append([]string(nil), src.Protocols...),
+	}
+}
+
 // dedupHostInboundTokens returns vals with duplicate entries removed, preserving
 // first-seen order. Used only on the merged (2+ block) host-inbound path (#4544)
 // so a single block keeps its exact token multiset (byte-identical behaviour).
@@ -158,7 +187,59 @@ func compileZones(node *Node, sec *SecurityConfig) error {
 						if zone.InterfaceHostInbound == nil {
 							zone.InterfaceHostInbound = make(map[string]*HostInboundTraffic)
 						}
-						zone.InterfaceHostInbound[iface.Name()] = mergeHostInbound(zone.InterfaceHostInbound[iface.Name()], hib)
+						// #6391: apply the override to every name this member
+						// node's KEYS carry, and NEVER to its CHILDREN. That
+						// distinction is the whole fix; the two shapes it
+						// separates are NOT interchangeable:
+						//
+						//   Keys=[a b], no membership child
+						//       `interfaces { [ a b ] { host-inbound {...} } }`
+						//     A body authored ON a bracket membership — the
+						//     operator's MULTI-MEMBER intent. Both a and b get it.
+						//
+						//   Keys=[a], child leaf Keys=[b]
+						//       `set ... interfaces [ a b ]`
+						//       `set ... interfaces a host-inbound-traffic ... ssh`
+						//     SetPath descends the wildcard for the FIRST token and
+						//     NESTS the bracket tail under it, then the second `set`
+						//     REUSES that same `a` container — so `a` ends up
+						//     carrying both the `b` membership leaf and the
+						//     host-inbound body even though ssh is scoped to `a`
+						//     ALONE. Fanning here is the #6389 regression: it opens
+						//     ssh on `b`, which the operator never configured
+						//     (admission is additive — host_inbound_view.go).
+						//
+						// NO `set`-authored config can reach the multi-key shape,
+						// which is what makes keying on Keys safe rather than merely
+						// convenient. The interface name is `schemaNode.wildcard`
+						// with args:0, multi:false, compoundKey:false
+						// (schema_security.go), so SetPath's
+						// `nodeKeyCount = 1 + childSchema.args` is ALWAYS 1 and its
+						// container branch stores exactly one token; surplus bracket
+						// tokens can only land on a child LEAF (which has no
+						// host-inbound child, so it is never read here). A bracket
+						// list is therefore len(Keys)==1 from `set` and len(Keys)>1
+						// ONLY from a hierarchical parse (`load override`, a
+						// hand-authored config file). Pinned by
+						// TestHostInbound6391FlatSetNeverYieldsMultiKeyContainer.
+						//
+						// A nested extra membership under a bracket body
+						// (`[ a b ] { c; host-inbound {...} }`) fans to a and b but
+						// NOT c: c is a nested membership statement, not a bracket
+						// sibling of the node the body was authored on. Deliberate
+						// (#6391), pinned by
+						// TestHostInbound6391BracketBodyNestedExtraMemberScope.
+						//
+						// cloneHostInbound per key: mergeHostInbound returns src
+						// unchanged when dst is nil, so storing `hib` directly under
+						// several keys would alias ONE value across the members and a
+						// later in-place merge on one would surface on all of them.
+						for _, name := range iface.Keys {
+							if name == "" {
+								continue
+							}
+							zone.InterfaceHostInbound[name] = mergeHostInbound(zone.InterfaceHostInbound[name], cloneHostInbound(hib))
+						}
 					}
 				}
 			case "screen":
@@ -220,8 +301,16 @@ func compileZones(node *Node, sec *SecurityConfig) error {
 // silently dropped the rest (#5248). Recursing the nested chain and reading every
 // key at each level recovers all members. A `host-inbound-traffic` body under a
 // member is NOT an interface name — it is compiled separately (#3362) and skipped
-// here; a bracketed member cannot carry one (Junos: brackets are bare
-// membership), so per-interface host-inbound stays keyed on the direct child.
+// here.
+//
+// This helper is for zone MEMBERSHIP ONLY. Do NOT reuse it to scope a
+// per-interface host-inbound override: it recurses into CHILDREN, and a flat-set
+// `interfaces [ a b ]` puts the sibling `b` in a child of `a` (see the nesting
+// above) while a subsequent `set ... interfaces a host-inbound-traffic ...`
+// reuses that same `a` container. Fanning an override across this member set
+// therefore opens the service on `b` for a config that scoped it to `a` alone —
+// the #6389 regression, closed unmerged. compileZones scopes the override on
+// `iface.Keys` instead, which separates the two shapes (#6391).
 func zoneInterfaceMembers(iface *Node) []string {
 	var names []string
 	for _, k := range iface.Keys {

--- a/pkg/config/compiler_zone_iface_hostinbound_sibling_6391_test.go
+++ b/pkg/config/compiler_zone_iface_hostinbound_sibling_6391_test.go
@@ -17,54 +17,55 @@ import (
 // the SAME `a` container and the host-inbound body becomes a child of the node
 // that also carries the `b` membership leaf.
 //
-// PR #6389 (advances #5609, CLOSED unmerged) tried to make a hierarchical
-// multi-member `load override` block apply the override to every member by
-// fanning the parsed host-inbound across `zoneInterfaceMembers(iface)`. That
-// fanout is UNSOUND: the flat-set single-scoped case and the hierarchical
-// multi-member case compile to the SAME AST, so the fanout cannot tell them
-// apart and OVER-ADMITS — it opens the service on `b` for the common
+// PR #6389 (advances #5609, CLOSED unmerged) tried to make a multi-member
+// `load override` block apply the override to every member by fanning the parsed
+// host-inbound across `zoneInterfaceMembers(iface)` — every name in the node's
+// Keys AND its nested membership children. That fanout OVER-ADMITS: it opens the
+// service on `b` for the common
 //
 //	set security zones security-zone Z interfaces [ a b ]
 //	set security zones security-zone Z interfaces a host-inbound-traffic system-services ssh
 //
-// config that scopes ssh to `a` only. Codex's hostile review of #6389 plus a
-// firsthand repro caught this host-inbound sibling leak; #6389 closed unmerged.
+// config that scopes ssh to `a` only, because SetPath nests the bracket tail under
+// the first member and the second `set` reuses that same container. Codex's
+// hostile review of #6389 plus a firsthand repro caught this host-inbound sibling
+// leak; #6389 closed unmerged.
 //
-// Current master is the fail-SAFE status quo: `compileZones` keys the
-// per-interface override strictly on `iface.Name()` (the direct child the
-// stanza was written under), so a sibling never inherits it. These tests are
-// the RED-on-revert guard that PINS that isolation: re-introducing the #6389
-// `for _, member := range zoneInterfaceMembers(iface)` fanout turns the
-// CONTAINER-SHARING cases RED (a sibling wrongly carries the override) —
-// first-member, three-member, multi-service, protocols, and the two
-// hierarchical multi-member-body cases. The later-member and
-// no-shared-backing-store cases stay GREEN CONTROLS: their interfaces do NOT
-// share a SetPath container (SetPath splits a later-authored member, and two
-// separately-authored top-level interfaces are independent), so the fanout does
-// not touch them — they prove the guard is not a tautology. The guard advances
-// #6391 in the issue's option-1 (fail-safe) direction; see docs/config-schema.md.
+// #6391 REPLACED the fail-safe first-member-only status quo with a fan that keys
+// on the node's KEYS and never on its CHILDREN. The premise #6389 and the original
+// #6391 issue text both worked from — "the flat-set single-scoped case and the
+// hierarchical multi-member case compile to the SAME AST, so no AST-keyed fan can
+// tell them apart" — was TESTED against firsthand AST dumps and is FALSE. The two
+// shapes are distinct:
 //
-// TWO KINDS of assertion below, do NOT conflate them:
+//	`[ a b ] { host-inbound {...} }`  -> ONE container Keys=["a","b"], NO
+//	                                    membership child. Multi-member intent.
+//	`set ... interfaces [ a b ]`      -> container Keys=["a"] with a membership
+//	`set ... interfaces a host-...`      CHILD leaf Keys=["b"]. Single-scoped.
 //
-//   - FLAT-SET, INDIVIDUALLY-SCOPED (the first/later-member, three-member,
-//     multi-service and protocols cases, plus the aliasing guard): a service or
-//     protocol authored under ONE named interface via its OWN `set` statement
-//     (`interfaces a host-inbound-traffic system-services ssh`) must never
-//     appear on a sibling. This is UNCONDITIONALLY correct under every design
-//     option (1/2/3) — an individually-authored per-interface stanza is
-//     single-scoped by definition, so a future parse-time fan (option 2/3) for
-//     the multi-member case must still leave these untouched. Asserted firmly.
+// What IS identical is the flat-set shape and the `a { b; host-inbound {...} }`
+// hierarchical shape — because the latter is the former's SERIALIZATION
+// (`ConfigTree.Format()`, the render configstore persists and HA config sync
+// ships, emits exactly it). That is why fanning on children leaks on every
+// reload, and why first-member-only remains correct for THAT shape permanently.
 //
-//   - MULTI-MEMBER BODY (the two hierarchical cases): a host-inbound BODY
-//     hanging off a bracket-membership / shared container
-//     (`[ a b ] { host-inbound ... }` or the `a { b; host-inbound ... }`
-//     load-override artifact). First-member-only here is the CURRENT option-1
-//     fail-safe outcome, NOT the final multi-member semantics: options 2/3
-//     (parse-time scope disambiguation, still an open DESIGN call on #6391) may
-//     deliberately fan the body to every member. These two cases pin CURRENT
-//     behavior and catch UNINTENDED drift; when option 2/3 lands, its author
-//     updates these two expectations as part of that work. They must NOT be
-//     read as asserting that first-member-only is correct forever.
+// So the assertions below split by SHAPE, not by confidence:
+//
+//   - INDIVIDUALLY-SCOPED / CONTAINER-SHARING (first/later-member, three-member,
+//     multi-service, protocols, the `a { b; ... }` hierarchical case, plus the
+//     aliasing guard): a service or protocol authored under ONE named interface
+//     must NEVER appear on a sibling. UNCONDITIONAL — this is the #6389 leak and
+//     it stays pinned forever. Re-introducing a children-fan turns these RED.
+//
+//   - MULTI-MEMBER BODY (Keys=[a,b], authored ON the bracket membership): applies
+//     to EVERY member. This expectation was INVERTED by #6391 — not a change of
+//     mind about sibling isolation, but the consequence of the two shapes being
+//     different. Reverting the Keys-fan turns this RED.
+//
+//   - NEGATIVE DIRECTION (FlatSetNeverYieldsMultiKeyContainer): no `set`-authored
+//     config may produce a multi-key interface container, or the fan would
+//     re-open the #6389 leak. Schema-guaranteed today; asserted so a future
+//     SetPath / schema refactor cannot silently break it.
 //
 // IMPORTANT (per CLAUDE.md): flat-set syntax is built with ParseSetCommand +
 // tree.SetPath, never NewParser; the hierarchical shape uses parseHierarchical.
@@ -225,17 +226,29 @@ func TestHostInbound6391ProtocolsNoSiblingLeak(t *testing.T) {
 	})
 }
 
-// TestHostInbound6391HierarchicalNestedChildNoSiblingLeak covers the exact
-// load-override AST shape #6389 targeted: a hierarchical block that NESTS the
-// second member under the first alongside a host-inbound body
-// (`interfaces { ge-0/0/0 { ge-0/0/1; host-inbound-traffic { ssh } } }`). This
-// is a MULTI-MEMBER BODY case, NOT an individually-scoped stanza: first-member-
-// only (ssh on ge-0/0/0, nested ge-0/0/1 clean) is the CURRENT option-1 fail-
-// safe outcome, not the final multi-member semantics. An options-2/3 design fix
-// (parse-time scope disambiguation, still open on #6391) may deliberately fan
-// the body to ge-0/0/1 too; when it lands, update this expectation. Today the
-// assertion pins current behavior and the #6389 fanout (which opens ssh on
-// ge-0/0/1 without that design work) turns it RED.
+// TestHostInbound6391HierarchicalNestedChildNoSiblingLeak covers the AST shape
+// #6389 targeted: a hierarchical block that NESTS the second member under the
+// first alongside a host-inbound body
+// (`interfaces { ge-0/0/0 { ge-0/0/1; host-inbound-traffic { ssh } } }`).
+//
+// THIS TEST STAYS GREEN UNDER THE #6391 FIX, and the reason is the whole reason
+// #6389 was unsound. This shape is NOT a multi-member intent that merely
+// resembles the flat-set one — it is the SERIALIZATION of the flat-set one.
+// `ConfigTree.Format()` (what configstore persists through, store_format.go, and
+// what HA config sync ships via d.store.ShowActive()) renders the flat-set
+//
+//	set ... interfaces [ ge-0/0/0 ge-0/0/1 ]
+//	set ... interfaces ge-0/0/0 host-inbound-traffic system-services ssh
+//
+// as EXACTLY this text, and re-parsing it yields a byte-identical AST
+// (Keys=["ge-0/0/0"], child leaf Keys=["ge-0/0/1"], child host-inbound-traffic).
+// So a fan that fired here would leak ssh onto ge-0/0/1 on every RELOAD of an
+// ordinary single-scoped flat-set config — which is precisely the regression
+// #6389 shipped. First-member-only is therefore the CORRECT permanent answer for
+// this shape, not a fail-safe compromise: ssh on ge-0/0/0, nested ge-0/0/1 clean.
+//
+// The genuine multi-member intent is the DISTINCT Keys=[a,b] shape covered by
+// TestHostInbound6391HierarchicalBracketBodyFansToAllMembers.
 func TestHostInbound6391HierarchicalNestedChildNoSiblingLeak(t *testing.T) {
 	tree := parseHierarchical(t, `
 security {
@@ -256,19 +269,37 @@ security {
 	})
 }
 
-// TestHostInbound6391HierarchicalBracketBodyNoSiblingLeak covers the
-// Keys=[a,b] hierarchical bracket-with-body shape
-// (`interfaces { [ ge-0/0/0 ge-0/0/1 ] { host-inbound-traffic { ssh } } }`) —
-// the canonical MULTI-MEMBER BODY: a host-inbound stanza authored ON the bracket
-// membership itself. The lexer strips the brackets so the member node carries
-// both names in its Keys; iface.Name() is the first key, so the CURRENT option-1
-// fail-safe scopes ssh to ge-0/0/0 and leaves ge-0/0/1 clean. This is the
-// under-application #5609-A3.1 / #6391 tracks: first-member-only is the fail-safe
-// default PENDING the options-2/3 design call, NOT the final semantics — an
-// option-2/3 fix that fans the body to every bracket member will intentionally
-// flip this expectation. It is asserted here to pin current behavior, not to
-// declare first-member-only correct forever.
-func TestHostInbound6391HierarchicalBracketBodyNoSiblingLeak(t *testing.T) {
+// TestHostInbound6391HierarchicalBracketBodyFansToAllMembers is the #6391 FIX
+// assertion: the canonical MULTI-MEMBER BODY — a host-inbound stanza authored ON
+// the bracket membership itself — applies to EVERY bracket member.
+//
+// This expectation was INVERTED by #6391 (it previously asserted first-member-
+// only). That was not a change of mind about sibling isolation; it is the
+// consequence of discovering that this shape and the flat-set single-scoped shape
+// are STRUCTURALLY DIFFERENT, which the #6391 issue text and the pre-fix docs both
+// denied. Dumping the compiled AST for each:
+//
+//	`[ a b ] { host-inbound {...} }`   -> ONE container, Keys=["a","b"] (len 2),
+//	                                     NO membership child.
+//	`set ... interfaces [ a b ]`       -> container Keys=["a"] (len 1) with a
+//	`set ... interfaces a host-...`       membership CHILD leaf Keys=["b"].
+//
+// The discriminator is therefore len(Keys)>1, and it is safe in the direction
+// that matters (a false positive would LEAK): no `set`-authored config can
+// produce a multi-key interface container, because the interface name is
+// `schemaNode.wildcard` with args:0 / multi:false / compoundKey:false
+// (schema_security.go), so SetPath's `nodeKeyCount = 1 + args` is always 1.
+// Surplus bracket tokens can only land on a child LEAF. That invariant is pinned
+// independently by TestHostInbound6391FlatSetNeverYieldsMultiKeyContainer so a
+// future schema refactor that broke it fails loudly rather than silently
+// re-opening the #6389 leak.
+//
+// The multi-key shape is reachable only from a hierarchical parse — `load
+// override` or a hand-authored config file. It survives Format()->NewParser
+// (local persistence) and HA config sync byte-for-byte. It does NOT survive a
+// `show | display set` round-trip, which mangles it into an uncompilable leaf —
+// that is a separate pre-existing defect tracked as #6668, NOT introduced here.
+func TestHostInbound6391HierarchicalBracketBodyFansToAllMembers(t *testing.T) {
 	tree := parseHierarchical(t, `
 security {
     zones {
@@ -284,7 +315,196 @@ security {
 	got := compileHostInbound6391(t, tree)
 	assertHostInbound6391(t, got, map[string]hib6391{
 		"ge-0/0/0": {SystemServices: []string{"ssh"}},
+		"ge-0/0/1": {SystemServices: []string{"ssh"}},
 	})
+}
+
+// TestHostInbound6391BracketBodyNestedExtraMemberScope pins the judgement call
+// at the edge of the fan: a bracket body that ALSO nests a further membership
+// statement (`[ a b ] { c; host-inbound {...} }`) applies the override to a and b
+// — the names on the node the body was authored on — but NOT to c.
+//
+// c is a nested membership statement, not a bracket sibling of the authored
+// node, so it is in the same position as the `b` leaf in the flat-set shape:
+// authored separately, therefore not in scope. Deliberate, and asserted so it
+// stays a decision rather than an accident. c is still a zone MEMBER (it appears
+// in zone.Interfaces via zoneInterfaceMembers) — it simply falls back to the
+// zone-level host-inbound, which is the conservative direction.
+func TestHostInbound6391BracketBodyNestedExtraMemberScope(t *testing.T) {
+	tree := parseHierarchical(t, `
+security {
+    zones {
+        security-zone trust {
+            interfaces {
+                [ ge-0/0/0 ge-0/0/1 ] {
+                    ge-0/0/2;
+                    host-inbound-traffic { system-services ssh; }
+                }
+            }
+        }
+    }
+}`)
+	got := compileHostInbound6391(t, tree)
+	assertHostInbound6391(t, got, map[string]hib6391{
+		"ge-0/0/0": {SystemServices: []string{"ssh"}},
+		"ge-0/0/1": {SystemServices: []string{"ssh"}},
+	})
+
+	// c IS a zone member, it just carries no per-interface override.
+	sec := tree.FindChild("security")
+	secCfg := &SecurityConfig{Zones: map[string]*ZoneConfig{}}
+	if err := compileZones(sec.FindChild("zones"), secCfg); err != nil {
+		t.Fatalf("compileZones: %v", err)
+	}
+	if got, want := secCfg.Zones["trust"].Interfaces, []string{"ge-0/0/0", "ge-0/0/1", "ge-0/0/2"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("zone.Interfaces = %q, want %q (the nested member must stay a zone member)", got, want)
+	}
+}
+
+// TestHostInbound6391FlatSetNeverYieldsMultiKeyContainer is the NEGATIVE-direction
+// guard for the #6391 discriminator, and the one that makes the fix durable.
+//
+// The fan keys on len(iface.Keys)>1. A false POSITIVE is the dangerous direction:
+// if any `set`-authored config could produce a multi-key interface container, the
+// fan would re-open the #6389 sibling leak on a config the operator scoped to one
+// interface. Today that is impossible by schema construction (the interface name
+// is a wildcard with args:0 / multi:false / compoundKey:false, so SetPath's
+// nodeKeyCount is always 1) — but that is a fact someone would otherwise have to
+// re-derive from the schema after any SetPath or schema_security.go refactor.
+//
+// This asserts it directly over the flat-set spellings that plausibly stress it:
+// brackets of several widths, both authoring orders, bare multi-name membership,
+// overlapping repeated brackets, and a host-inbound token tail. If a refactor
+// ever makes one of these yield a multi-key container, this fails HERE with the
+// offending Keys rather than silently widening admission.
+func TestHostInbound6391FlatSetNeverYieldsMultiKeyContainer(t *testing.T) {
+	spellings := [][]string{
+		{"set security zones security-zone trust interfaces [ ge-0/0/0 ge-0/0/1 ]"},
+		{"set security zones security-zone trust interfaces [ ge-0/0/0 ge-0/0/1 ge-0/0/2 ge-0/0/3 ]"},
+		{"set security zones security-zone trust interfaces ge-0/0/0 ge-0/0/1"},
+		{"set security zones security-zone trust interfaces ge-0/0/0 ge-0/0/1 host-inbound-traffic system-services ssh"},
+		{
+			"set security zones security-zone trust interfaces [ ge-0/0/0 ge-0/0/1 ]",
+			"set security zones security-zone trust interfaces ge-0/0/0 host-inbound-traffic system-services ssh",
+		},
+		{
+			"set security zones security-zone trust interfaces ge-0/0/0 host-inbound-traffic system-services ssh",
+			"set security zones security-zone trust interfaces [ ge-0/0/0 ge-0/0/1 ]",
+		},
+		{
+			"set security zones security-zone trust interfaces [ ge-0/0/0 ge-0/0/1 ]",
+			"set security zones security-zone trust interfaces ge-0/0/1 host-inbound-traffic system-services ssh",
+		},
+		{
+			"set security zones security-zone trust interfaces [ ge-0/0/0 ge-0/0/1 ]",
+			"set security zones security-zone trust interfaces [ ge-0/0/0 ge-0/0/2 ]",
+			"set security zones security-zone trust interfaces ge-0/0/0 host-inbound-traffic protocols ospf",
+		},
+		{
+			"set security zones security-zone trust interfaces ge-0/0/0",
+			"set security zones security-zone trust interfaces ge-0/0/0 host-inbound-traffic system-services ssh",
+		},
+	}
+
+	for i, cmds := range spellings {
+		tree := &ConfigTree{}
+		for _, cmd := range cmds {
+			path, err := ParseSetCommand(cmd)
+			if err != nil {
+				t.Fatalf("spelling %d: ParseSetCommand(%q): %v", i, cmd, err)
+			}
+			if err := tree.SetPath(path); err != nil {
+				t.Fatalf("spelling %d: SetPath(%q): %v", i, cmd, err)
+			}
+		}
+		sec := tree.FindChild("security")
+		if sec == nil {
+			t.Fatalf("spelling %d: no security node", i)
+		}
+		zones := sec.FindChild("zones")
+		if zones == nil {
+			t.Fatalf("spelling %d: no zones node", i)
+		}
+		for _, zone := range zones.FindChildren("security-zone") {
+			for _, prop := range zone.Children {
+				if prop.Name() != "interfaces" {
+					continue
+				}
+				// Only CONTAINER nodes matter: the fan reads Keys on a node that
+				// carries a host-inbound-traffic child, and a leaf has no
+				// children. Assert on containers at every depth anyway, so a
+				// refactor that starts nesting containers is caught too.
+				var walk func(n *Node)
+				walk = func(n *Node) {
+					if !n.IsLeaf && len(n.Keys) > 1 && n.Name() != "host-inbound-traffic" {
+						t.Fatalf("spelling %d (%q): flat-set produced a MULTI-KEY interface container Keys=%q — "+
+							"the #6391 fan would treat it as a multi-member bracket body and leak the override "+
+							"to every name in Keys (the #6389 regression). Either SetPath or the "+
+							"security-zone interfaces schema changed; re-derive the discriminator before "+
+							"relaxing this assertion.", i, cmds, n.Keys)
+					}
+					for _, c := range n.Children {
+						walk(c)
+					}
+				}
+				for _, iface := range prop.Children {
+					walk(iface)
+				}
+			}
+		}
+	}
+}
+
+// TestHostInbound6391BracketBodyMembersDoNotShareBackingStore guards the aliasing
+// trap the multi-member fan introduces. mergeHostInbound returns src UNCHANGED
+// when dst is nil (the #4544 no-copy fast path), so storing one parsed body under
+// N member keys without cloning would alias ONE value across all N. A later merge
+// mutates dst IN PLACE, so a subsequent single-scoped override on one member
+// would silently surface on its bracket siblings.
+//
+// Here `ping` is authored on ge-0/0/0 ALONE after the bracket body opened `ssh`
+// on both: ge-0/0/0 must end up with ssh+ping and ge-0/0/1 with ssh ONLY. Without
+// cloneHostInbound, ge-0/0/1 wrongly admits ping too.
+func TestHostInbound6391BracketBodyMembersDoNotShareBackingStore(t *testing.T) {
+	tree := parseHierarchical(t, `
+security {
+    zones {
+        security-zone trust {
+            interfaces {
+                [ ge-0/0/0 ge-0/0/1 ] {
+                    host-inbound-traffic { system-services ssh; }
+                }
+                ge-0/0/0 {
+                    host-inbound-traffic { system-services ping; }
+                }
+            }
+        }
+    }
+}`)
+	assertHostInbound6391(t, compileHostInbound6391(t, tree), map[string]hib6391{
+		"ge-0/0/0": {SystemServices: []string{"ping", "ssh"}},
+		"ge-0/0/1": {SystemServices: []string{"ssh"}},
+	})
+
+	// Pointer independence, not just value equality: the two members must not
+	// share a backing array even when they carry equal token sets.
+	sec := tree.FindChild("security")
+	secCfg := &SecurityConfig{Zones: map[string]*ZoneConfig{}}
+	if err := compileZones(sec.FindChild("zones"), secCfg); err != nil {
+		t.Fatalf("compileZones: %v", err)
+	}
+	zone := secCfg.Zones["trust"]
+	a, b := zone.InterfaceHostInbound["ge-0/0/0"], zone.InterfaceHostInbound["ge-0/0/1"]
+	if a == nil || b == nil {
+		t.Fatalf("expected both members to carry an override, got a=%v b=%v", a, b)
+	}
+	if a == b {
+		t.Fatalf("bracket members share the SAME *HostInboundTraffic — a later in-place merge on one leaks to the other")
+	}
+	if len(a.SystemServices) > 0 && len(b.SystemServices) > 0 &&
+		&a.SystemServices[0] == &b.SystemServices[0] {
+		t.Fatalf("bracket members share the SAME SystemServices backing array")
+	}
 }
 
 // TestHostInbound6391NoSharedBackingStoreAcrossInterfaces guards the aliasing

--- a/pkg/config/compiler_zone_iface_hostinbound_sibling_6391_test.go
+++ b/pkg/config/compiler_zone_iface_hostinbound_sibling_6391_test.go
@@ -319,6 +319,40 @@ security {
 	})
 }
 
+// TestHostInbound6391BareMultiMemberBodyFansToAllMembers pins the BRACKET-LESS
+// spelling of the same shape. The lexer discards `[` and `]`, so
+//
+//	[ ge-0/0/0 ge-0/0/1 ] { host-inbound-traffic {...} }
+//	  ge-0/0/0 ge-0/0/1   { host-inbound-traffic {...} }
+//
+// parse to a byte-identical multi-key node and must therefore compile
+// identically. The brackets are cosmetic at this position.
+//
+// Worth pinning separately rather than trusting the equivalence: the whole
+// safety argument for keying on Keys rests on which spellings can produce
+// len(Keys)>1, so "the lexer drops brackets" is load-bearing rather than
+// incidental. If a future lexer change made the two forms diverge, the
+// bracketed test above would keep passing while this one caught it.
+func TestHostInbound6391BareMultiMemberBodyFansToAllMembers(t *testing.T) {
+	tree := parseHierarchical(t, `
+security {
+    zones {
+        security-zone trust {
+            interfaces {
+                ge-0/0/0 ge-0/0/1 {
+                    host-inbound-traffic { system-services ssh; }
+                }
+            }
+        }
+    }
+}`)
+	got := compileHostInbound6391(t, tree)
+	assertHostInbound6391(t, got, map[string]hib6391{
+		"ge-0/0/0": {SystemServices: []string{"ssh"}},
+		"ge-0/0/1": {SystemServices: []string{"ssh"}},
+	})
+}
+
 // TestHostInbound6391BracketBodyNestedExtraMemberScope pins the judgement call
 // at the edge of the fan: a bracket body that ALSO nests a further membership
 // statement (`[ a b ] { c; host-inbound {...} }`) applies the override to a and b


### PR DESCRIPTION
Closes #6391.

## What this changes

A `host-inbound-traffic` body authored on a **bracketed** zone-interface
membership now applies to **every** member of that bracket. It previously applied
to the first member only, so siblings silently fell back to the (usually more
permissive) zone-level set.

`compileZones` scopes the override on the member node's **`Keys`** and never on
its **children**.

## Why #6389's fanout was unsound, and why this one is not

PR #6389 fanned across `zoneInterfaceMembers(iface)`, which recurses into
children. That opens a hole on the common flat-set spelling:

```
set security zones security-zone trust interfaces [ ge-0/0/0 ge-0/0/1 ]
set security zones security-zone trust interfaces ge-0/0/0 host-inbound-traffic system-services ssh
```

`SetPath` nests the bracket tail under the first member and the second `set`
reuses that same `ge-0/0/0` container, so a children-fan admits ssh on
`ge-0/0/1`, which the operator never configured. #6389 closed unmerged.

**The premise both #6389 and this issue worked from is false.** They held that
the flat-set single-scoped shape and a hierarchical multi-member block compile to
the same AST, so no AST-keyed fan could separate them. Dumping both ASTs shows
otherwise:

| authored as | compiled AST |
|---|---|
| `[ a b ] { host-inbound {...} }` | ONE container `Keys=["a","b"]`, **no** membership child |
| `set ... interfaces [ a b ]` + `set ... interfaces a host-inbound-...` | container `Keys=["a"]` with membership **child leaf** `Keys=["b"]` |

What genuinely *is* identical is the flat-set shape and the hand-authored
`a { b; host-inbound {...} }` — because **the latter is the former's
serialization**. `ConfigTree.Format()` (the render `configstore` persists through,
and the one HA config sync ships via `ShowActive()`) emits exactly that text. So a
children-fan leaks on every *reload* of an ordinary single-scoped config, and
first-member-only remains the correct answer for that shape permanently.

## Why keying on `Keys` is safe

The dangerous direction is a **false positive** — a `set`-authored config yielding
a multi-key container would re-open the #6389 leak. That cannot happen: the
interface name is a `schemaNode.wildcard` with `args: 0`, `multi: false`,
`compoundKey: false`, so `SetPath`'s `nodeKeyCount = 1 + args` is always 1 and
surplus bracket tokens can only land on a child **leaf** (which has no
host-inbound child and is never read by the fan). The multi-key shape is reachable
only from a hierarchical parse (`load override`, a hand-authored file), survives
`Format()`→`NewParser` and HA config sync byte-for-byte, and `ExpandGroups` keeps
it distinct.

`TestHostInbound6391FlatSetNeverYieldsMultiKeyContainer` asserts this over nine
flat-set spellings so a future `SetPath` or schema change fails there rather than
silently widening admission.

## Aliasing

The fan clones per key. `mergeHostInbound` returns `src` unchanged when `dst` is
nil (the #4544 no-copy path), so storing one parsed body under N keys would alias
one value across N members, and a later in-place merge on one would surface on all
of them.

## Behaviour change — admission WIDENING

A non-first bracket member carrying a host-inbound body now admits that body's
services and protocols. Documented for upgrading operators in
`docs/host-inbound-service-matrix.md` (with the pre-upgrade workaround: split into
per-interface statements). **No config in this repository uses the shape** — the
`.conf` fixtures under `docs/`, `test/incus/` and `examples/deploy/` contain zero
bracketed zone memberships.

## Docs

- `docs/config-schema.md` stated the impossibility of AST discrimination as fact
  while separately naming the multi-member bracket body as canonical. Corrected,
  with the discriminator and the schema argument spelled out.
- Records the #6668 limitation next to the feature: the multi-key shape does not
  survive `show | display set` (`FormatSet` flattens it into a leaf that fails to
  compile — fail-closed). Pre-existing, not addressed here.

## Testing

`go build ./...` rc=0, `go vet ./...` rc=0, `go test ./...` **rc=0 across 59
packages**.

Both guard directions proven by mutation, each with build and vet rc=0 so the reds
are assertions rather than build breaks:

| mutation | RED | GREEN controls |
|---|---|---|
| revert Keys-fan → `iface.Name()` | 3 multi-member assertions (fans-to-all-members, nested-extra-member scope, shared backing store) | every sibling-isolation guard |
| restore #6389 children-fan | 6 isolation guards with the exact leak (first-member, three-member, multi-service, protocols, `a { b; ... }` serialization, nested-extra-member) | later-member, no-shared-backing-store, never-multi-key |

## Scope decision pinned

`[ a b ] { c; host-inbound {...} }` fans to `a` and `b` but **not** `c` — `c` is a
nested membership statement, not a bracket sibling of the authored node, so it sits
in the same position as the flat-set `b` leaf. `c` stays a zone member and falls
back to the zone-level host-inbound. Asserted so it is a decision rather than an
accident.

Advances #5609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
