### PR TITLE
docs(config-schema): record the bare multi-member spelling and strengthen the nested-child rationale

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -958,6 +958,7 @@ disproved by dumping both):
 | authored as | compiled AST | meaning |
 |---|---|---|
 | `interfaces { [ ge-0/0/0 ge-0/0/1 ] { host-inbound-traffic {...} } }` | ONE container `Keys=["ge-0/0/0","ge-0/0/1"]`, **no** membership child | multi-member intent → **both** members |
+| `interfaces { ge-0/0/0 ge-0/0/1 { host-inbound-traffic {...} } }` — the **bare** spelling | identical to the row above; the lexer discards `[` / `]` (#2419), so the brackets are **cosmetic at this position** | multi-member intent → **both** members |
 | `set ... interfaces [ ge-0/0/0 ge-0/0/1 ]`<br>`set ... interfaces ge-0/0/0 host-inbound-traffic system-services ssh` | container `Keys=["ge-0/0/0"]` with membership **child leaf** `Keys=["ge-0/0/1"]` | ssh scoped to `ge-0/0/0` **only** |
 
 `SetPath` descends the wildcard for the FIRST bracket token and nests the tail
@@ -1003,10 +1004,13 @@ Scope rules that follow:
   applied it to the first member only — see the operator note in
   `docs/host-inbound-service-matrix.md`.
 - **A nested extra membership is out of scope.**
-  `[ a b ] { c; host-inbound {...} }` fans to `a` and `b` but NOT `c`: `c` is a
-  nested membership statement, not a bracket sibling of the authored node, so it
-  is in the same position as the flat-set `b` leaf. `c` remains a zone MEMBER and
-  falls back to the zone-level host-inbound.
+  `[ a b ] { c; host-inbound {...} }` fans to `a` and `b` but NOT `c`. This is
+  forced by the fix's own invariant rather than chosen: `c` is a nested CHILD,
+  not a bracket PEER, and its AST position is indistinguishable from the flat-set
+  membership tail that caused #6389 (`set ... interfaces [ a b ]` nests `b` as
+  exactly this kind of child). Applying the body to `c` would restore the
+  forbidden children-fan and re-open the original leak by another route. `c`
+  remains a zone MEMBER and falls back to the zone-level host-inbound.
 - **Members do not share a backing store.** `mergeHostInbound` returns `src`
   unchanged when `dst` is nil, so the fan clones per key (`cloneHostInbound`).
   Without that, a later single-scoped override merged into one member would

--- a/pkg/config/compiler_zone_iface_hostinbound_sibling_6391_test.go
+++ b/pkg/config/compiler_zone_iface_hostinbound_sibling_6391_test.go
@@ -358,12 +358,18 @@ security {
 // statement (`[ a b ] { c; host-inbound {...} }`) applies the override to a and b
 // — the names on the node the body was authored on — but NOT to c.
 //
-// c is a nested membership statement, not a bracket sibling of the authored
-// node, so it is in the same position as the `b` leaf in the flat-set shape:
-// authored separately, therefore not in scope. Deliberate, and asserted so it
-// stays a decision rather than an accident. c is still a zone MEMBER (it appears
-// in zone.Interfaces via zoneInterfaceMembers) — it simply falls back to the
-// zone-level host-inbound, which is the conservative direction.
+// The reason is stronger than a judgement call, and it is the same reason #6389
+// was unsound: c is a nested CHILD, not a bracket PEER, and its position in the
+// AST is INDISTINGUISHABLE from the flat-set membership tail that caused #6389
+// (`set ... interfaces [ a b ]` nests `b` as exactly this kind of child). So
+// applying the body to c would restore the forbidden children-fan — not merely
+// over-apply in one unusual spelling, but RE-OPEN THE ORIGINAL LEAK by another
+// route. Excluding c is therefore forced by the fix's own invariant rather than
+// chosen.
+//
+// c is still a zone MEMBER (it appears in zone.Interfaces via
+// zoneInterfaceMembers); it simply falls back to the zone-level host-inbound,
+// which is the conservative direction.
 func TestHostInbound6391BracketBodyNestedExtraMemberScope(t *testing.T) {
 	tree := parseHierarchical(t, `
 security {


### PR DESCRIPTION
Two additive documentation/comment follow-ups to #6670, which merged while this
push was in flight — the commit landed on the branch after the merge commit was
cut, so it never reached master. Re-landing it here unchanged.

Neither is a behaviour change; no non-comment compiler line is touched.

## 1. Record the bare spelling in `docs/config-schema.md`

9a2ca316b added the bracket-less **test** but `docs/config-schema.md` — the file
carrying the *mechanism*, as opposed to the operator note in
`docs/host-inbound-service-matrix.md` — still described only the bracketed form.

The lexer discards `[` and `]` (#2419), so

```
interfaces { [ ge-0/0/0 ge-0/0/1 ] { host-inbound-traffic {...} } }
interfaces {   ge-0/0/0 ge-0/0/1   { host-inbound-traffic {...} } }
```

parse to the same multi-key node and fan identically. A reader consulting the AST
shape table to work out **which spellings reach `len(Keys)>1`** — the question the
whole safety argument turns on — would previously have concluded, wrongly, that
brackets were required. The table now carries the bare row.

## 2. Strengthen the rationale for excluding a nested extra membership

Both the doc and the test comment called `[ a b ] { c; host-inbound {...} }`
excluding `c` a *defensible judgement call*. Codex's review of #6670 supplied a
stronger reason, and it is worth recording because a future reader could otherwise
decide the judgement call goes the other way:

> `c` is a nested CHILD, not a bracket PEER, and its AST position is
> indistinguishable from the flat-set membership tail that caused #6389
> (`set ... interfaces [ a b ]` nests `b` as exactly this kind of child).

So applying the body to `c` would restore the forbidden children-fan and re-open
the original leak by another route. The exclusion is **forced by the fix's own
invariant**, not chosen.

## Testing

`go build ./...` rc=0, `go vet ./pkg/config/` rc=0, `go test ./pkg/config/` rc=0
on top of current master.

Advances #6391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
