### PR TITLE
config: reject a security-policy match leaf written with no operand (#6526)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -66238,3 +66238,31 @@ break — `go vet` confirmed passing under every revert.
   pkg/daemon/userspace_sync_session_id_6198_test.go,
   userspace-dp/src/session/mod.rs, userspace-dp/src/session/tests.rs,
   userspace-dp/src/session/README.md, docs/session-sync-architecture.md, _Log.md
+- **Timestamp**: 2026-08-01 09:15
+- **Action**: #6526 — a security-policy `match` leaf written with NO OPERAND
+  satisfied the #3044 required-dimension gate and compiled to the
+  byte-identical empty slice the OMITTED form produces, which the userspace
+  matcher reads as match-ANY; `then permit` therefore permitted every source.
+  Root cause: the gate decided presence from the leaf NAME
+  (`present[m.Name()] = true`) while `firewallMatchValues` — the reader
+  `compilePolicy` actually uses — skips blank tokens so an empty result means
+  "criterion absent". Reachable through the CLI's own `set` path
+  (`ParseSetCommand` + `SetPath`) and the hierarchical parser. Added
+  `policyValuelessMatchDimensions`, which decides presence with the compiler's
+  own value reader, and emitted it as a DISTINCT finding from the SAME walk as
+  #3044 under its own lenient flag (`lenientPolicyValuelessMatch`): strict
+  commit/commit-check hard-rejects, the tolerant load/peer-sync path warns
+  (#1960 no-brick) and additionally poisons the policy to never-match via the
+  #5575 `LenientContentDropped` flag, which the name-based predicate had also
+  let the valueless form bypass. Covers all FIVE value-bearing dimensions —
+  source-address, destination-address, application, and the scoped-global
+  from-zone/to-zone whose empty set collapses a global policy to the all-zones
+  wildcard. `source-address-excluded`/`destination-address-excluded` are
+  excluded (boolean modifiers, valueless by design), and from-zone/to-zone are
+  inspected only under a global policy so the #3113 gate keeps sole ownership
+  of them under a zone-pair policy.
+- **File(s)**: pkg/config/compiler_policy_missing_match.go,
+  pkg/config/compiler_security_policy.go, pkg/config/compiler_prewalk.go,
+  pkg/config/compiler_opts.go,
+  pkg/config/compiler_policy_valueless_match_6526_test.go,
+  docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -918,6 +918,36 @@ allowed-ips folds are covered by the `security-nat-static-multi-zone` and
 `interfaces-wireguard-allowed-ips-multi` dual-AST fixtures plus
 `TestWireguardAllowedIPsBracketList{FlatSet,Hierarchical}`.
 
+**A multi-value leaf can be PRESENT and still carry NOTHING — presence must be
+decided by VALUES, never by the leaf NAME (#6526).** `firewallMatchValues`
+skips blank tokens, and its doc comment states the contract: *an empty result
+means "criterion absent"*. A gate that instead decides presence from the leaf
+name (`present[child.Name()] = true`) is asserting something about VALUES using
+a check on NAMES, and the two disagree for exactly one input — the leaf written
+with **no operand**:
+
+```
+match { source-address; }                                # hierarchical
+set security policies from-zone t to-zone u policy p match source-address
+```
+
+Both shapes yield `Keys=["source-address"]` with no children, so
+`firewallMatchValues` returns nothing and the dimension compiles to the
+**byte-identical empty slice the OMITTED form produces** — which the userspace
+matcher reads as match-ANY. Under `then permit` that is a fail-open: an
+operator who hits enter one token early commits a permit-any policy. Because
+`multi: true` leaves are UNTYPED (no `validator`) and `schema_walk.go`
+deliberately declines minimum arity (see "Trailing-token arity on scalar value
+leaves", #3332 — the arity gate is scoped strictly to EXCESS tokens and only
+runs for `scalar: true` leaves), `SchemaValidate` cannot catch this: in
+`pkg/config` a leaf that opts out of typing opts out of every value check.
+`policyValuelessMatchDimensions` (`compiler_policy_missing_match.go`) closes it
+for the five value-bearing security-policy match dimensions by asking
+`firewallMatchValues` — the SAME reader `compilePolicy` uses — whether the
+dimension carries anything; see the #6526 section below. RULE OF THUMB: when a
+gate's claim is *"this dimension constrains something"*, evaluate it with the
+compiler's own value reader, not with a name lookup.
+
 **Bracketed lists on a WILDCARD container collapse differently — a NESTED
 chain, not `Keys[1:]` (#5248).** The contract above assumes a `multi: true`
 value leaf, whose surplus bracket tokens land on ONE leaf's `Keys`. A
@@ -6585,6 +6615,86 @@ Regression coverage:
 `pkg/dataplane/userspace/policy_global_zone_3148_test.go`, the Rust
 `global_policy_*` tests in `userspace-dp/src/policy_tests.rs`, and
 `pkg/policymatch/scoped_global_zonelocal_test.go` (#3287).
+
+### #6526 — A policy `match` leaf with NO OPERAND widens the dimension to match-ANY
+
+The #3044 required-match gate (`validatePolicyRequiredMatchStrict`) decided
+whether a Junos-mandatory dimension was present from the leaf **name**:
+
+```go
+for _, m := range policyMatchChildren(polNode) { present[m.Name()] = true }
+```
+
+while the reader the compiler actually uses — `firewallMatchValues` — skips
+blank tokens, so *an empty result means "criterion absent"*. A dimension
+written with **no operand** therefore satisfied the gate and compiled to the
+**byte-identical empty slice the OMITTED form produces**, which the userspace
+matcher reads as match-ANY:
+
+| `match` stanza | before #6526 | after #6526 |
+|---|---|---|
+| `source-address 10.0.0.0/8;` | ACCEPTED, `SourceAddresses=[10.0.0.0/8]` | unchanged |
+| `source-address;` (no operand) | **ACCEPTED, `SourceAddresses=[]` → match-ANY** | REJECTED (#6526) |
+| omitted entirely | REJECTED (#3044) | unchanged |
+
+`then permit` on the middle row permits **every** source. It was reachable
+through the CLI's own `set` path — `set security policies from-zone trust
+to-zone untrust policy p1 match source-address` with the value left off — so
+an operator hitting enter one token early shipped a permit-any policy. It also
+bypassed the #5575 `LenientContentDropped` poison, which used the same
+name-based predicate. The schema cannot catch it (see "A multi-value leaf can
+be PRESENT and still carry NOTHING" above): the five match dimensions are
+untyped `args: 1, multi: true` leaves with no `validator`, and minimum arity is
+deliberately out of scope for `schema_walk.go`.
+
+`policyValuelessMatchDimensions(polNode, isGlobal)`
+(`compiler_policy_missing_match.go`) is the shared predicate. It flags a
+dimension that is present by name but whose values, **unioned across every
+`match {}` block** (#3842 parity, via `policyMatchChildren`), are empty —
+precisely the condition under which the compiled slice is empty and the
+dimension widens. All **five** value-bearing dimensions are covered:
+`source-address`, `destination-address`, `application`, plus the scoped-global
+`from-zone` / `to-zone`, whose empty set collapses a global policy to the
+all-zones wildcard (a fix that closed only `source-address` would leave that
+half open). Deliberately excluded: `source-address-excluded` /
+`destination-address-excluded`, which are boolean MODIFIER leaves that
+legitimately carry no operand. `from-zone`/`to-zone` are inspected only under a
+global policy — under a zone-pair policy they are not match siblings at all and
+the #3113 unsupported-leaf gate (which runs first) owns them, so one typo is
+never double-attributed.
+
+Enforcement follows the #1960 no-brick split, and the finding is emitted from
+the SAME walk as #3044 (so the duplicate-block / dual-AST scope coverage can
+never diverge between the two) but with a **distinct message** under a
+**distinct lenient flag** (`lenientPolicyValuelessMatch`), so "you did not
+write the criterion" stays distinguishable from "you wrote it and left the
+value off":
+
+- **Strict (commit / commit-check)** — hard reject, naming the policy scope,
+  the policy, and every valueless dimension. The operator authored this
+  candidate, so surfacing it is the safe choice and matches Junos, where the
+  stanza cannot commit.
+- **Tolerant (`Store.Load` / HA `SyncApply` peer-sync)** — warn and continue,
+  so an already-persisted or peer-synced config an older binary silently
+  accepted still BOOTS instead of blacking out the node or alarm-looping config
+  sync. There the policy is additionally **poisoned to never-match** by
+  `compilePolicy`'s #5575 `LenientContentDropped` flag, so the dataplane
+  publishes the rule with the `__unsupported__` sentinel rather than the
+  widened permit — the warning is not the only protection on that path.
+
+When a policy trips BOTH findings, the omitted-dimension (#3044) message is
+reported first as the more fundamental authoring error.
+
+Regression coverage:
+`pkg/config/compiler_policy_valueless_match_6526_test.go` — all five dimensions
+through BOTH the flat `ParseSetCommand` + `SetPath` path and the hierarchical
+`NewParser` path; a three-way differential (`normal` accepted with its value /
+no-operand rejected by #6526 / omitted rejected by #3044) that asserts each
+gate's OWN message and forbids the other's, so a finding can never be silently
+re-attributed; the lenient warn + `LenientContentDropped` poison; and
+false-positive controls for the `-excluded` modifiers, bracketed lists,
+duplicate match blocks that supply the value, explicit `any`, and a global
+policy that simply omits `from-zone`/`to-zone`.
 
 ### #3075 — Stable zone ids (supersedes the #2391 u8 count cap)
 

--- a/pkg/config/compiler_opts.go
+++ b/pkg/config/compiler_opts.go
@@ -1780,6 +1780,27 @@ type compileOpts struct {
 	// must write `any` for an intentional wildcard (Junos parity). Same
 	// doctrine as lenientPolicyMatchLeaves.
 	lenientPolicyMissingMatch bool
+	// lenientPolicyValuelessMatch (#6526) downgrades the security-policy
+	// VALUELESS-match-dimension gate — the second finding emitted by
+	// validatePolicyRequiredMatchStrict — from a hard compile error to a
+	// cfg.Warnings entry. A `match` dimension written with NO OPERAND
+	// (`source-address;`, or a `set ... match source-address` line with the
+	// value left off) satisfied the #3044 name-based required-dimension gate
+	// yet compiled to the BYTE-IDENTICAL empty slice the omitted form
+	// produces, which the userspace matcher reads as match-ANY: `then permit`
+	// then permits every source, and a scoped-global `match from-zone` /
+	// `to-zone` collapses to the all-zones wildcard. The strict commit /
+	// commit-check path hard-rejects so the typo is operator-visible (naming
+	// the policy scope, the policy, and every valueless dimension); the
+	// tolerant load / peer-sync paths downgrade to a warning so an
+	// already-persisted or peer-synced config an older binary silently
+	// accepted still BOOTS (#1960 fail-closed-on-load class) — and there the
+	// policy is additionally poisoned to never-match by compilePolicy's #5575
+	// LenientContentDropped flag rather than published as a widened permit.
+	// Kept as its own flag (not folded into lenientPolicyMissingMatch) so the
+	// two findings stay independently attributable. Same doctrine as
+	// lenientPolicyMissingMatch.
+	lenientPolicyValuelessMatch bool
 	// lenientPolicyCommunityRef (#2881) downgrades the policy community
 	// cross-reference gate (validatePolicyCommunityReferencesStrict) from a
 	// hard compile error to a cfg.Warnings entry. A policy term's
@@ -2143,6 +2164,7 @@ func lenientCompileOpts() compileOpts {
 		lenientPolicyThenReject:                true,
 		lenientPolicyThenDeny:                  true,
 		lenientPolicyMissingMatch:              true,
+		lenientPolicyValuelessMatch:            true,
 		lenientPolicyCommunityRef:              true,
 		lenientPolicyReservedRedistName:        true,
 		lenientPolicyReservedChainName:         true,

--- a/pkg/config/compiler_opts.go
+++ b/pkg/config/compiler_opts.go
@@ -1795,8 +1795,18 @@ type compileOpts struct {
 	// tolerant load / peer-sync paths downgrade to a warning so an
 	// already-persisted or peer-synced config an older binary silently
 	// accepted still BOOTS (#1960 fail-closed-on-load class) — and there the
-	// policy is additionally poisoned to never-match by compilePolicy's #5575
-	// LenientContentDropped flag rather than published as a widened permit.
+	// policy is additionally poisoned by compilePolicy's #5575
+	// LenientContentDropped flag rather than published as a widened permit —
+	// but ONLY on the userspace dataplane, which is the sole plane that reads
+	// that flag. The kernel host-inbound actuator (junos_host_deny.go ->
+	// daemon_apply_tail.go) does NOT consult it, so a poisoned `junos-host`
+	// policy still projects to nft with an empty source list read as
+	// source-any: it becomes permitAll and suppresses a following deny. That
+	// gap is PRE-EXISTING (the OMITTED spelling reaches it identically on
+	// master) and is tracked as #6705, not introduced here. The runtime
+	// consequences of the snapshot rejection itself — the transit window, HA
+	// divergence, and a poisoned commit-confirmed rollback target — are
+	// likewise pre-existing and tracked as #6707.
 	// Kept as its own flag (not folded into lenientPolicyMissingMatch) so the
 	// two findings stay independently attributable. Same doctrine as
 	// lenientPolicyMissingMatch.

--- a/pkg/config/compiler_policy_missing_match.go
+++ b/pkg/config/compiler_policy_missing_match.go
@@ -70,6 +70,22 @@ import (
 // (#1960 fail-closed-on-load class). The policy keeps its pre-existing
 // match-any-for-missing compilation exactly as before this gate, now
 // flagged. Same doctrine as validatePolicyMatchLeavesStrict.
+//
+// #6526 extends the file to the SECOND way a dimension can fail to constrain
+// anything: a dimension written with NO OPERAND (`source-address;`, or a
+// `set ... match source-address` line with the value left off). The gate above
+// decides presence from the leaf NAME, so a valueless leaf satisfied it while
+// compiling to the byte-identical empty match-ANY slice the omitted form
+// produces — the reject gate protected a claim about VALUES with a check on
+// NAMES. policyValuelessMatchDimensions closes that by asking
+// firewallMatchValues (the SAME reader compilePolicy uses) whether the
+// dimension carries anything, and covers all FIVE value-bearing dimensions:
+// source-address, destination-address, application, plus the scoped-global
+// from-zone / to-zone (whose empty set collapses a global policy to the
+// all-zones wildcard). Same strict-reject / lenient-warn doctrine, and both
+// findings feed compilePolicy's #5575 LenientContentDropped poison so a
+// leniently-loaded valueless policy is published as never-match rather than as
+// a silently widened permit.
 
 // requiredPolicyMatchLeaves are the three Junos-mandatory match dimensions
 // every active security policy must specify. Kept in declaration order so
@@ -110,15 +126,117 @@ func policyMissingRequiredMatchDimensions(polNode *Node) []string {
 	return missing
 }
 
+// valueBearingPolicyMatchLeaves are the security-policy `match` dimensions
+// whose SEMANTICS are carried by their operand(s) — the leaves compilePolicy
+// reads with firewallMatchValues into a match set that the userspace matcher
+// interprets as match-ANY when empty. Kept in declaration order so the #6526
+// error message lists valueless dimensions deterministically.
+//
+// from-zone / to-zone are the scoped-global match context (#3148/#4626 M03)
+// and are value-bearing ONLY under a `security policies global` policy; under
+// a zone-pair policy they are not registered match siblings at all and the
+// #3113 unsupported-match-leaf gate (which runs FIRST in runPreWalkGates)
+// rejects them outright, so policyValuelessMatchDimensions skips them there
+// rather than double-attributing one typo to two gates.
+//
+// Deliberately EXCLUDED: source-address-excluded / destination-address-excluded.
+// Those are boolean MODIFIER leaves that legitimately carry no operand
+// (compilePolicy sets a bool off the leaf name alone), so an emptiness check
+// on them would reject valid Junos.
+var valueBearingPolicyMatchLeaves = []string{
+	"source-address",
+	"destination-address",
+	"application",
+	"from-zone",
+	"to-zone",
+}
+
+// policyValuelessMatchDimensions returns every value-bearing `match` dimension
+// that is PRESENT BY NAME in a policy node's UNION of `match {}` blocks but
+// whose accumulated value set is EMPTY, in declaration order; an empty result
+// means every present dimension actually constrains something. isGlobal marks a
+// `security policies global` policy so the global-only from-zone/to-zone match
+// context is inspected exactly where compilePolicy honours it.
+//
+// #6526 — the defect this closes. policyMissingRequiredMatchDimensions above
+// decides presence from the leaf NAME (`present[m.Name()] = true`), while the
+// reader compilePolicy actually uses — firewallMatchValues
+// (compiler_firewall.go) — SKIPS blank tokens, and its own doc comment states
+// the conflicting definition: "an empty result means criterion absent". A leaf
+// written with NO operand therefore satisfies the #3044 name-based gate and
+// compiles to the BYTE-IDENTICAL empty slice the omitted form produces:
+//
+//	match { source-address; destination-address any; application any; }
+//	set security policies from-zone t to-zone u policy p1 match source-address
+//
+// both yield Match.SourceAddresses == [] (n=0), which the userspace matcher
+// reads as match-ANY — so `then permit` permits EVERY source. The same shape
+// collapses a scoped-global `match from-zone` / `match to-zone` to the
+// all-zones wildcard. Both parser shapes produce it: hierarchically the leaf is
+// Keys=["source-address"] with no children; via ParseSetCommand + SetPath the
+// flat path lands on the same node. The gate protected a claim about VALUES
+// with a check on NAMES; this predicate closes the gap by asking
+// firewallMatchValues — the SAME reader compilePolicy uses — whether the
+// dimension carries anything, so the reject gate and the compiler can never
+// disagree about what "present" means.
+//
+// Union semantics (#3842 parity): a dimension is flagged only when the values
+// accumulated across EVERY `match {}` block are empty — precisely the condition
+// under which the compiled slice is empty and the dimension widens. A policy
+// that writes `source-address;` in one block and `source-address 10.0.0.0/8;`
+// in a duplicate block compiles to [10.0.0.0/8] and is NOT widened, so it is
+// not flagged; that mirrors how policyMissingRequiredMatchDimensions unions
+// presence across blocks.
+func policyValuelessMatchDimensions(polNode *Node, isGlobal bool) []string {
+	children := policyMatchChildren(polNode)
+	var valueless []string
+	for _, leaf := range valueBearingPolicyMatchLeaves {
+		if globalOnlyPolicyMatchLeaves[leaf] && !isGlobal {
+			continue
+		}
+		seen, valued := false, false
+		for _, m := range children {
+			if m.Name() != leaf {
+				continue
+			}
+			seen = true
+			if len(firewallMatchValues(m)) > 0 {
+				valued = true
+			}
+		}
+		if seen && !valued {
+			valueless = append(valueless, leaf)
+		}
+	}
+	return valueless
+}
+
 // validatePolicyRequiredMatchStrict walks the `security policies` subtree of
-// the group-expanded AST and rejects any policy whose `match` clause omits a
-// required dimension (source-address, destination-address, application) or
-// omits the `match` block entirely. Covers both zone-pair and global
-// policies. See the file header for the contract and rationale.
-func validatePolicyRequiredMatchStrict(nodes []*Node, lenient bool) ([]string, error) {
+// the group-expanded AST and rejects any policy whose `match` clause either
+//
+//   - OMITS a required dimension (source-address, destination-address,
+//     application) or omits the `match` block entirely (#3044), or
+//   - writes a value-bearing dimension with NO OPERAND, so the dimension
+//     compiles to the same empty match-ANY set the omitted form produces
+//     (#6526 — see policyValuelessMatchDimensions).
+//
+// Covers both zone-pair and global policies. The two failure modes share ONE
+// walk (so they can never diverge on scope — the duplicate-block and dual-AST
+// coverage below applies to both) but emit DISTINCT messages under DISTINCT
+// lenient flags, so an operator (and a test) can tell "you did not write the
+// criterion" apart from "you wrote it and left the value off". See the file
+// header for the contract and rationale.
+func validatePolicyRequiredMatchStrict(nodes []*Node, lenientMissing, lenientValueless bool) ([]string, error) {
 	var warnings []string
+	report := func(msg string, lenient bool) error {
+		if !lenient {
+			return fmt.Errorf("%s", msg)
+		}
+		warnings = append(warnings, msg)
+		return nil
+	}
 	emit := func(scope, policyName string, missing []string) error {
-		msg := fmt.Sprintf(
+		return report(fmt.Sprintf(
 			"security policies %s policy %q match is missing required "+
 				"criterion %s (Junos requires every security policy to specify "+
 				"source-address, destination-address, AND application; a missing "+
@@ -127,20 +245,43 @@ func validatePolicyRequiredMatchStrict(nodes []*Node, lenient bool) ([]string, e
 				"an over-broad block for deny) — add the missing criterion, using "+
 				"the explicit `any` keyword for an intentional wildcard (#3044)",
 			scope, policyName, strings.Join(quoteAll(missing), ", "),
-		)
-		if !lenient {
-			return fmt.Errorf("%s", msg)
-		}
-		warnings = append(warnings, msg)
-		return nil
+		), lenientMissing)
+	}
+	// emitValueless rejects a match dimension written with NO operand (#6526).
+	// Kept textually distinct from emit above — the two conditions are one
+	// keystroke apart for an operator but have different fixes, and a shared
+	// message would make them indistinguishable to anything asserting on it.
+	emitValueless := func(scope, policyName string, valueless []string) error {
+		return report(fmt.Sprintf(
+			"security policies %s policy %q match criterion %s is present but "+
+				"carries NO value (the leaf was written with no operand, e.g. "+
+				"`source-address;` or a `set ... match source-address` line with "+
+				"the value omitted) — an empty match dimension compiles to the "+
+				"SAME match-ANY as omitting the criterion entirely, silently "+
+				"WIDENING the policy to traffic the operator did not intend (a "+
+				"fail-open for permit, an over-broad block for deny; for a global "+
+				"policy's from-zone/to-zone it collapses the scope to the "+
+				"all-zones wildcard) — supply the intended value, using the "+
+				"explicit `any` keyword for an intentional wildcard (#6526)",
+			scope, policyName, strings.Join(quoteAll(valueless), ", "),
+		), lenientValueless)
 	}
 
-	checkPolicy := func(scope, policyName string, polNode *Node) error {
-		missing := policyMissingRequiredMatchDimensions(polNode)
-		if len(missing) == 0 {
-			return nil
+	checkPolicy := func(scope, policyName string, polNode *Node, isGlobal bool) error {
+		// Missing-entirely is reported first: it is the more fundamental
+		// authoring error, and on the strict path the first finding is the
+		// returned error.
+		if missing := policyMissingRequiredMatchDimensions(polNode); len(missing) > 0 {
+			if err := emit(scope, policyName, missing); err != nil {
+				return err
+			}
 		}
-		return emit(scope, policyName, missing)
+		if valueless := policyValuelessMatchDimensions(polNode, isGlobal); len(valueless) > 0 {
+			if err := emitValueless(scope, policyName, valueless); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
 	// #3562: iterate EVERY top-level `security` node and EVERY `policies`
@@ -159,7 +300,7 @@ func validatePolicyRequiredMatchStrict(nodes []*Node, lenient bool) ([]string, e
 				switch child.Name() {
 				case "global":
 					for _, polInst := range namedInstances(child.FindChildren("policy")) {
-						if err := checkPolicy("global", polInst.name, polInst.node); err != nil {
+						if err := checkPolicy("global", polInst.name, polInst.node, true); err != nil {
 							return err
 						}
 					}
@@ -188,7 +329,7 @@ func validatePolicyRequiredMatchStrict(nodes []*Node, lenient bool) ([]string, e
 					for _, zp := range pairs {
 						scope := fmt.Sprintf("from-zone %s to-zone %s", zp.from, zp.to)
 						for _, polInst := range namedInstances(zp.policyNode.FindChildren("policy")) {
-							if err := checkPolicy(scope, polInst.name, polInst.node); err != nil {
+							if err := checkPolicy(scope, polInst.name, polInst.node, false); err != nil {
 								return err
 							}
 						}

--- a/pkg/config/compiler_policy_valueless_match_6526_test.go
+++ b/pkg/config/compiler_policy_valueless_match_6526_test.go
@@ -1,0 +1,611 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// compiler_policy_valueless_match_6526_test.go is the fail-on-revert guard for
+// the #6526 valueless-match-dimension gate — the second finding emitted by
+// validatePolicyRequiredMatchStrict, backed by policyValuelessMatchDimensions.
+//
+// The defect: a security-policy `match` leaf written with NO OPERAND satisfied
+// the #3044 required-dimension gate (which decided presence from the leaf
+// NAME) and compiled to the BYTE-IDENTICAL empty slice the OMITTED form
+// produces, which the userspace matcher reads as match-ANY. `then permit` then
+// permitted every source; a scoped-global `match from-zone` / `match to-zone`
+// collapsed to the all-zones wildcard. It was reachable through the CLI's own
+// `set` path — `set security policies from-zone trust to-zone untrust policy p
+// match source-address` with the value left off committed cleanly — so an
+// operator hitting enter one token early shipped a permit-any policy. It also
+// bypassed the #5575 LenientContentDropped poison, because that poison used
+// the same name-based predicate.
+//
+// These tests pin THREE DISTINCT outcomes and attribute each to the gate that
+// produced it, asserting the specific gate's OWN message rather than a bare
+// `err != nil` (two gates can reject these probes, so `err != nil` would pass
+// even if the #6526 check never ran):
+//
+//	match stanza                | outcome
+//	----------------------------|------------------------------------------
+//	source-address 10.0.0.0/8;  | ACCEPTED, Match.SourceAddresses=[10.0.0.0/8]
+//	source-address;             | REJECTED by #6526 ("carries NO value")
+//	(omitted entirely)          | REJECTED by #3044 ("missing required criterion")
+//
+// Reverting the fix (make policyValuelessMatchDimensions return nil, or drop
+// the emitValueless call in validatePolicyRequiredMatchStrict) turns the
+// no-operand subtests GREEN on the BAD config — exactly the regression these
+// tests catch.
+
+// Gate fingerprints. Each assertion below requires the EXPECTED gate's marker
+// AND forbids the other gate's marker, so a finding can never be silently
+// re-attributed.
+const (
+	gate3044Marker = "match is missing required criterion"
+	gate3044Tag    = "(#3044)"
+	gate6526Marker = "is present but carries NO value"
+	gate6526Tag    = "(#6526)"
+)
+
+// buildValuelessMatchFlatTree builds a config tree through the CLI's OWN flat
+// `set` path — ParseSetCommand + ConfigTree.SetPath — never NewParser, which
+// treats newlines as whitespace and would merge every set line into one node.
+func buildValuelessMatchFlatTree(t *testing.T, cmds []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// buildValuelessMatchHierTree builds a config tree through the HIERARCHICAL
+// parser (a `load override` / on-disk config), the other AST shape the
+// compiler must handle.
+func buildValuelessMatchHierTree(t *testing.T, body string) *ConfigTree {
+	t.Helper()
+	tree, err := NewParser(body).Parse()
+	if err != nil {
+		t.Fatalf("hierarchical parse of %q: %v", body, err)
+	}
+	return tree
+}
+
+// zonePairHier wraps a `match { ... }` body in a complete zone-pair policy
+// with the referenced zones defined, so the zone-reference gate does not
+// pre-empt the match gates under test.
+func zonePairHier(matchBody string) string {
+	return `security {
+	zones { security-zone trust; security-zone untrust; }
+	policies {
+		from-zone trust to-zone untrust {
+			policy p { match { ` + matchBody + ` } then { permit; } }
+		}
+	}
+}`
+}
+
+// globalHier wraps a `match { ... }` body in a complete global policy.
+func globalHier(matchBody string) string {
+	return `security { policies { global {
+	policy g { match { ` + matchBody + ` } then { permit; } }
+} } }`
+}
+
+// assertRejectedBy6526 asserts the strict compile failed with the #6526
+// valueless-dimension message naming exactly wantDims, and that the #3044
+// missing-dimension gate did NOT produce it.
+func assertRejectedBy6526(t *testing.T, err error, wantDims string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("strict commit ACCEPTED a match dimension written with no operand — " +
+			"the dimension compiles to the empty match-ANY slice and the policy widens (#6526)")
+	}
+	msg := err.Error()
+	want := fmt.Sprintf("match criterion %s is present but carries NO value", wantDims)
+	if !strings.Contains(msg, want) {
+		t.Fatalf("error %q does not carry the #6526 valueless-dimension finding %q", msg, want)
+	}
+	if !strings.Contains(msg, gate6526Tag) {
+		t.Fatalf("error %q is not tagged %s", msg, gate6526Tag)
+	}
+	if strings.Contains(msg, gate3044Marker) {
+		t.Fatalf("error %q was produced by the #3044 missing-dimension gate, not the #6526 "+
+			"valueless-dimension gate — the probe is not attributable", msg)
+	}
+}
+
+// assertRejectedBy3044 asserts the strict compile failed with the ORIGINAL
+// #3044 missing-dimension message naming exactly wantDims, and that the #6526
+// gate did NOT produce it. This is the differential control: the omitted form
+// must stay attributable to the gate that already covered it.
+func assertRejectedBy3044(t *testing.T, err error, wantDims string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("strict commit ACCEPTED a policy with an omitted required match dimension (#3044)")
+	}
+	msg := err.Error()
+	want := fmt.Sprintf("%s %s", gate3044Marker, wantDims)
+	if !strings.Contains(msg, want) {
+		t.Fatalf("error %q does not carry the #3044 missing-dimension finding %q", msg, want)
+	}
+	if !strings.Contains(msg, gate3044Tag) {
+		t.Fatalf("error %q is not tagged %s", msg, gate3044Tag)
+	}
+	if strings.Contains(msg, gate6526Marker) {
+		t.Fatalf("error %q was produced by the #6526 valueless-dimension gate, not the #3044 "+
+			"missing-dimension gate — the probe is not attributable", msg)
+	}
+}
+
+// TestPolicyValuelessMatchDimensionRejectedFlatSet drives the reproduction
+// through the CLI's own `set` path for ALL FIVE value-bearing dimensions:
+// source-address, destination-address, application, and the scoped-global
+// from-zone / to-zone. A fix that closes only source-address is incomplete —
+// the same shape collapses `match from-zone <z>` to the all-zones wildcard.
+func TestPolicyValuelessMatchDimensionRejectedFlatSet(t *testing.T) {
+	zonePair := func(extra ...string) []string {
+		return append([]string{
+			"set security zones security-zone trust",
+			"set security zones security-zone untrust",
+		}, extra...)
+	}
+	cases := []struct {
+		name     string
+		cmds     []string
+		wantDims string
+	}{
+		{
+			name: "source-address with no operand",
+			cmds: zonePair(
+				"set security policies from-zone trust to-zone untrust policy p match source-address",
+				"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy p match application any",
+				"set security policies from-zone trust to-zone untrust policy p then permit",
+			),
+			wantDims: `"source-address"`,
+		},
+		{
+			name: "destination-address with no operand",
+			cmds: zonePair(
+				"set security policies from-zone trust to-zone untrust policy p match source-address any",
+				"set security policies from-zone trust to-zone untrust policy p match destination-address",
+				"set security policies from-zone trust to-zone untrust policy p match application any",
+				"set security policies from-zone trust to-zone untrust policy p then permit",
+			),
+			wantDims: `"destination-address"`,
+		},
+		{
+			name: "application with no operand",
+			cmds: zonePair(
+				"set security policies from-zone trust to-zone untrust policy p match source-address any",
+				"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy p match application",
+				"set security policies from-zone trust to-zone untrust policy p then permit",
+			),
+			wantDims: `"application"`,
+		},
+		{
+			name: "global from-zone with no operand",
+			cmds: []string{
+				"set security policies global policy g match source-address any",
+				"set security policies global policy g match destination-address any",
+				"set security policies global policy g match application any",
+				"set security policies global policy g match from-zone",
+				"set security policies global policy g then permit",
+			},
+			wantDims: `"from-zone"`,
+		},
+		{
+			name: "global to-zone with no operand",
+			cmds: []string{
+				"set security policies global policy g match source-address any",
+				"set security policies global policy g match destination-address any",
+				"set security policies global policy g match application any",
+				"set security policies global policy g match to-zone",
+				"set security policies global policy g then permit",
+			},
+			wantDims: `"to-zone"`,
+		},
+		{
+			name: "global from-zone and to-zone both with no operand",
+			cmds: []string{
+				"set security policies global policy g match source-address any",
+				"set security policies global policy g match destination-address any",
+				"set security policies global policy g match application any",
+				"set security policies global policy g match from-zone",
+				"set security policies global policy g match to-zone",
+				"set security policies global policy g then permit",
+			},
+			wantDims: `"from-zone", "to-zone"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := CompileConfig(buildValuelessMatchFlatTree(t, tc.cmds))
+			assertRejectedBy6526(t, err, tc.wantDims)
+		})
+	}
+}
+
+// TestPolicyValuelessMatchDimensionRejectedHierarchical drives the same
+// reproduction through the HIERARCHICAL parser — the `load override` /
+// on-disk-config shape, where the no-operand leaf is written `source-address;`.
+func TestPolicyValuelessMatchDimensionRejectedHierarchical(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		wantDims string
+	}{
+		{
+			name:     "source-address with no operand",
+			body:     zonePairHier(`source-address; destination-address any; application any;`),
+			wantDims: `"source-address"`,
+		},
+		{
+			name:     "destination-address with no operand",
+			body:     zonePairHier(`source-address any; destination-address; application any;`),
+			wantDims: `"destination-address"`,
+		},
+		{
+			name:     "application with no operand",
+			body:     zonePairHier(`source-address any; destination-address any; application;`),
+			wantDims: `"application"`,
+		},
+		{
+			name:     "global from-zone with no operand",
+			body:     globalHier(`source-address any; destination-address any; application any; from-zone;`),
+			wantDims: `"from-zone"`,
+		},
+		{
+			name:     "global to-zone with no operand",
+			body:     globalHier(`source-address any; destination-address any; application any; to-zone;`),
+			wantDims: `"to-zone"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := CompileConfig(buildValuelessMatchHierTree(t, tc.body))
+			assertRejectedBy6526(t, err, tc.wantDims)
+		})
+	}
+}
+
+// TestPolicyMatchDimensionThreeOutcomesAreDistinct is the differential core of
+// this guard: the SAME dimension, written three ways, must produce THREE
+// DISTINCT results — accepted with the configured value, rejected by the NEW
+// #6526 check, rejected by the ORIGINAL #3044 check. If the no-operand form
+// and the omitted form produced the same message the tests could not tell them
+// apart, and a regression that re-collapsed them would go unnoticed.
+func TestPolicyMatchDimensionThreeOutcomesAreDistinct(t *testing.T) {
+	zonePairCmds := func(srcLine string) []string {
+		cmds := []string{
+			"set security zones security-zone trust",
+			"set security zones security-zone untrust",
+		}
+		if srcLine != "" {
+			cmds = append(cmds, srcLine)
+		}
+		return append(cmds,
+			"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+			"set security policies from-zone trust to-zone untrust policy p match application any",
+			"set security policies from-zone trust to-zone untrust policy p then permit",
+		)
+	}
+
+	t.Run("flat-set", func(t *testing.T) {
+		t.Run("normal value accepted", func(t *testing.T) {
+			cfg, err := CompileConfig(buildValuelessMatchFlatTree(t, zonePairCmds(
+				"set security policies from-zone trust to-zone untrust policy p match source-address 10.0.0.0/8")))
+			if err != nil {
+				t.Fatalf("strict commit rejected a policy with a real source-address value: %v", err)
+			}
+			assertOnlyPolicySources(t, cfg, []string{"10.0.0.0/8"})
+		})
+		t.Run("no operand rejected by 6526", func(t *testing.T) {
+			_, err := CompileConfig(buildValuelessMatchFlatTree(t, zonePairCmds(
+				"set security policies from-zone trust to-zone untrust policy p match source-address")))
+			assertRejectedBy6526(t, err, `"source-address"`)
+		})
+		t.Run("omitted rejected by 3044", func(t *testing.T) {
+			_, err := CompileConfig(buildValuelessMatchFlatTree(t, zonePairCmds("")))
+			assertRejectedBy3044(t, err, `"source-address"`)
+		})
+	})
+
+	t.Run("hierarchical", func(t *testing.T) {
+		t.Run("normal value accepted", func(t *testing.T) {
+			cfg, err := CompileConfig(buildValuelessMatchHierTree(t, zonePairHier(
+				`source-address 10.0.0.0/8; destination-address any; application any;`)))
+			if err != nil {
+				t.Fatalf("strict commit rejected a policy with a real source-address value: %v", err)
+			}
+			assertOnlyPolicySources(t, cfg, []string{"10.0.0.0/8"})
+		})
+		t.Run("no operand rejected by 6526", func(t *testing.T) {
+			_, err := CompileConfig(buildValuelessMatchHierTree(t, zonePairHier(
+				`source-address; destination-address any; application any;`)))
+			assertRejectedBy6526(t, err, `"source-address"`)
+		})
+		t.Run("omitted rejected by 3044", func(t *testing.T) {
+			_, err := CompileConfig(buildValuelessMatchHierTree(t, zonePairHier(
+				`destination-address any; application any;`)))
+			assertRejectedBy3044(t, err, `"source-address"`)
+		})
+	})
+}
+
+// assertOnlyPolicySources asserts the compiled config holds exactly one
+// zone-pair policy whose source-address set is want. It pins the ACCEPTED
+// outcome to a real value, not merely to the absence of an error — an empty
+// slice would otherwise satisfy "accepted" and hide the very widening this
+// gate exists to stop.
+func assertOnlyPolicySources(t *testing.T, cfg *Config, want []string) {
+	t.Helper()
+	var got []string
+	n := 0
+	for _, zp := range cfg.Security.Policies {
+		for _, p := range zp.Policies {
+			n++
+			got = p.Match.SourceAddresses
+			if p.LenientContentDropped {
+				t.Fatalf("policy %q was poisoned (LenientContentDropped) on a clean strict commit", p.Name)
+			}
+		}
+	}
+	if n != 1 {
+		t.Fatalf("expected exactly 1 compiled zone-pair policy, got %d", n)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("Match.SourceAddresses = %v (n=%d), want %v (n=%d)", got, len(got), want, len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Match.SourceAddresses = %v, want %v", got, want)
+		}
+	}
+}
+
+// TestPolicyValuelessMatchLenientWarnsAndPoisons asserts the #1960 no-brick
+// split: on the TOLERANT load / peer-sync path a valueless dimension does NOT
+// fail the compile (an already-persisted or peer-synced config an older binary
+// silently accepted still BOOTS) but IS surfaced as a warning AND poisoned via
+// the #5575 LenientContentDropped flag, so the userspace snapshot builder
+// publishes the rule as never-match instead of as the widened permit. The
+// warning assertion is on the #6526 message specifically, not on the mere
+// presence of some warning.
+func TestPolicyValuelessMatchLenientWarnsAndPoisons(t *testing.T) {
+	cases := []struct {
+		name     string
+		tree     func(t *testing.T) *ConfigTree
+		wantDims string
+		global   bool
+	}{
+		{
+			name: "flat-set source-address",
+			tree: func(t *testing.T) *ConfigTree {
+				return buildValuelessMatchFlatTree(t, []string{
+					"set security zones security-zone trust",
+					"set security zones security-zone untrust",
+					"set security policies from-zone trust to-zone untrust policy p match source-address",
+					"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+					"set security policies from-zone trust to-zone untrust policy p match application any",
+					"set security policies from-zone trust to-zone untrust policy p then permit",
+				})
+			},
+			wantDims: `"source-address"`,
+		},
+		{
+			name: "hierarchical application",
+			tree: func(t *testing.T) *ConfigTree {
+				return buildValuelessMatchHierTree(t, zonePairHier(
+					`source-address any; destination-address any; application;`))
+			},
+			wantDims: `"application"`,
+		},
+		{
+			name: "global from-zone",
+			tree: func(t *testing.T) *ConfigTree {
+				return buildValuelessMatchHierTree(t, globalHier(
+					`source-address any; destination-address any; application any; from-zone;`))
+			},
+			wantDims: `"from-zone"`,
+			global:   true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := CompileConfigLenient(tc.tree(t))
+			if err != nil {
+				t.Fatalf("lenient compile must not brick on a valueless match dimension: %v", err)
+			}
+			want := fmt.Sprintf("match criterion %s is present but carries NO value", tc.wantDims)
+			found := false
+			for _, w := range cfg.Warnings {
+				if strings.Contains(w, want) && strings.Contains(w, gate6526Tag) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("expected a downgraded #6526 valueless-dimension warning %q, got warnings: %v", want, cfg.Warnings)
+			}
+			pols := cfg.Security.GlobalPolicies
+			if !tc.global {
+				pols = nil
+				for _, zp := range cfg.Security.Policies {
+					pols = append(pols, zp.Policies...)
+				}
+			}
+			if len(pols) != 1 {
+				t.Fatalf("expected exactly 1 compiled policy, got %d", len(pols))
+			}
+			if !pols[0].LenientContentDropped {
+				t.Fatalf("policy %q compiled leniently with a valueless match dimension but was NOT "+
+					"poisoned (LenientContentDropped=false) — the widened permit would be published "+
+					"to the dataplane (#5575/#6526)", pols[0].Name)
+			}
+		})
+	}
+}
+
+// TestPolicyValuelessMatchCompilesToSameEmptySetAsOmitted pins the PREMISE the
+// gate rests on: on the tolerant path (the only path that still compiles these
+// configs) a no-operand dimension and an omitted dimension produce the SAME
+// empty match set, which the userspace matcher reads as match-ANY. If a future
+// change made the no-operand form compile to something distinguishable, this
+// documents that the gate's rationale would need revisiting.
+func TestPolicyValuelessMatchCompilesToSameEmptySetAsOmitted(t *testing.T) {
+	srcOf := func(t *testing.T, body string) []string {
+		t.Helper()
+		cfg, err := CompileConfigLenient(buildValuelessMatchHierTree(t, body))
+		if err != nil {
+			t.Fatalf("lenient compile: %v", err)
+		}
+		for _, zp := range cfg.Security.Policies {
+			for _, p := range zp.Policies {
+				return p.Match.SourceAddresses
+			}
+		}
+		t.Fatalf("no compiled policy")
+		return nil
+	}
+	noOperand := srcOf(t, zonePairHier(`source-address; destination-address any; application any;`))
+	omitted := srcOf(t, zonePairHier(`destination-address any; application any;`))
+	if len(noOperand) != 0 || len(omitted) != 0 {
+		t.Fatalf("expected both forms to compile to an EMPTY source set, got no-operand=%v omitted=%v",
+			noOperand, omitted)
+	}
+}
+
+// TestPolicyValuelessMatchDoesNotOverReject is the false-positive control: the
+// gate must fire ONLY on a dimension that actually compiles to an empty set.
+func TestPolicyValuelessMatchDoesNotOverReject(t *testing.T) {
+	cases := []struct {
+		name string
+		tree func(t *testing.T) *ConfigTree
+	}{
+		{
+			// source-address-excluded / destination-address-excluded are
+			// BOOLEAN modifier leaves that legitimately carry no operand.
+			// Flagging them would reject valid Junos.
+			name: "address-excluded modifiers carry no operand by design",
+			tree: func(t *testing.T) *ConfigTree {
+				return buildValuelessMatchHierTree(t, zonePairHier(
+					`source-address any; source-address-excluded; destination-address any; `+
+						`destination-address-excluded; application any;`))
+			},
+		},
+		{
+			// The #2419 bracketed list collapses onto ONE leaf's Keys;
+			// firewallMatchValues sees all three, so the dimension is valued.
+			name: "bracketed list is a valued dimension",
+			tree: func(t *testing.T) *ConfigTree {
+				return buildValuelessMatchHierTree(t, zonePairHier(
+					`source-address [ 10.0.0.0/8 192.168.0.0/16 ]; destination-address any; application any;`))
+			},
+		},
+		{
+			// #3842 union semantics: a duplicate `match {}` block supplies the
+			// value, so the dimension does NOT compile to an empty set and is
+			// not widened — the gate must not fire.
+			name: "duplicate match block supplies the value",
+			tree: func(t *testing.T) *ConfigTree {
+				return buildValuelessMatchHierTree(t, `security {
+	zones { security-zone trust; security-zone untrust; }
+	policies { from-zone trust to-zone untrust { policy p {
+		match { source-address; destination-address any; application any; }
+		match { source-address 10.0.0.0/8; }
+		then { permit; }
+	} } }
+}`)
+			},
+		},
+		{
+			// The explicit wildcard is a VALUE, not an absence — Junos parity.
+			name: "explicit any is a value",
+			tree: func(t *testing.T) *ConfigTree {
+				return buildValuelessMatchHierTree(t, zonePairHier(
+					`source-address any; destination-address any; application any;`))
+			},
+		},
+		{
+			// A global policy that simply OMITS from-zone/to-zone is the
+			// documented all-zones form and must keep committing.
+			name: "global policy without from-zone/to-zone",
+			tree: func(t *testing.T) *ConfigTree {
+				return buildValuelessMatchHierTree(t, globalHier(
+					`source-address any; destination-address any; application any;`))
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := CompileConfig(tc.tree(t)); err != nil {
+				t.Fatalf("strict commit rejected a policy the #6526 gate must not flag: %v", err)
+			}
+		})
+	}
+}
+
+// TestPolicyValuelessAndMissingTogetherReportsMissingFirst pins the documented
+// precedence when a policy trips BOTH findings: the omitted dimension is the
+// more fundamental authoring error and is reported first, so the operator sees
+// a stable, deterministic message rather than one that depends on walk order.
+func TestPolicyValuelessAndMissingTogetherReportsMissingFirst(t *testing.T) {
+	_, err := CompileConfig(buildValuelessMatchHierTree(t, zonePairHier(
+		`source-address; destination-address any;`)))
+	assertRejectedBy3044(t, err, `"application"`)
+}
+
+// TestPolicyValuelessMatchZonePairFromZoneStaysUnsupported guards the scoping
+// choice: from-zone/to-zone are value-bearing ONLY under a global policy.
+// Under a ZONE-PAIR policy they are not match siblings at all, so the #3113
+// unsupported-match-leaf gate — which runs first — owns them, and the #6526
+// gate must not double-attribute the same typo.
+func TestPolicyValuelessMatchZonePairFromZoneStaysUnsupported(t *testing.T) {
+	body := zonePairHier(`source-address any; destination-address any; application any; from-zone;`)
+
+	_, err := CompileConfig(buildValuelessMatchHierTree(t, body))
+	if err == nil {
+		t.Fatalf("strict commit accepted `match from-zone` under a zone-pair policy")
+	}
+	if !strings.Contains(err.Error(), "is not supported") || !strings.Contains(err.Error(), "(#3113)") {
+		t.Fatalf("expected the #3113 unsupported-match-leaf gate to own zone-pair from-zone, got: %v", err)
+	}
+	if strings.Contains(err.Error(), gate6526Marker) {
+		t.Fatalf("the #6526 gate double-attributed a zone-pair from-zone the #3113 gate owns: %v", err)
+	}
+
+	// The strict path returns only the FIRST finding, and #3113 runs before
+	// the #3044/#6526 walk — so the assertion above cannot by itself prove the
+	// global-only scoping. The LENIENT path collects EVERY finding, so it can:
+	// exactly one warning (the #3113 one) must mention this leaf.
+	cfg, lerr := CompileConfigLenient(buildValuelessMatchHierTree(t, body))
+	if lerr != nil {
+		t.Fatalf("lenient compile must not brick: %v", lerr)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, gate6526Marker) {
+			t.Fatalf("the #6526 gate warned about a zone-pair `match from-zone` that the #3113 gate "+
+				"already owns — one typo, two findings: %s", w)
+		}
+	}
+	sawUnsupported := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "(#3113)") && strings.Contains(w, "from-zone") {
+			sawUnsupported = true
+			break
+		}
+	}
+	if !sawUnsupported {
+		t.Fatalf("expected the #3113 unsupported-leaf warning for zone-pair from-zone, got: %v", cfg.Warnings)
+	}
+}

--- a/pkg/config/compiler_prewalk.go
+++ b/pkg/config/compiler_prewalk.go
@@ -403,8 +403,17 @@ func runPreWalkGates(tree *ConfigTree, opts compileOpts) ([]string, error) {
 	// so an already-persisted or peer-synced config still boots (#1960) — the
 	// policy keeps its match-any-for-missing compilation, now flagged. A
 	// missing dimension is distinct from an explicit `any` (Junos parity).
+	//
+	// #6526: the same walk also rejects a value-bearing dimension written
+	// with NO OPERAND (`source-address;`, or a `set ... match source-address`
+	// line with the value omitted). That form satisfied the #3044 name-based
+	// presence check yet compiled to the byte-identical empty match-ANY slice
+	// the omitted form produces — so `then permit` permitted every source and
+	// a scoped-global `match from-zone`/`to-zone` collapsed to the all-zones
+	// wildcard. It is emitted as a DISTINCT message under its own lenient
+	// flag so the two findings stay independently attributable.
 	policyMissingMatchWarnings, err := validatePolicyRequiredMatchStrict(
-		tree.Children, opts.lenientPolicyMissingMatch)
+		tree.Children, opts.lenientPolicyMissingMatch, opts.lenientPolicyValuelessMatch)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/compiler_security_policy.go
+++ b/pkg/config/compiler_security_policy.go
@@ -395,7 +395,17 @@ func compilePolicy(polInst struct {
 	// false) and a DROPPED / MISSING constraint (empty slice, flag true) is made
 	// here on the AST: policyMissingRequiredMatchDimensions treats an omitted
 	// leaf differently from an explicit `any`.
+	//
+	// #6526: policyValuelessMatchDimensions is the third predicate because a
+	// dimension written with NO OPERAND (`source-address;`) compiles to the
+	// BYTE-IDENTICAL empty slice the omitted form produces — it read as
+	// "present" to the name-based predicate above and therefore slipped past
+	// this poison as well as past the strict gate, so a leniently-loaded
+	// valueless permit was published to the dataplane fully widened. It
+	// covers all five value-bearing dimensions, including the scoped-global
+	// from-zone/to-zone whose empty set means "all zones".
 	if len(policyMissingRequiredMatchDimensions(polInst.node)) > 0 ||
+		len(policyValuelessMatchDimensions(polInst.node, isGlobal)) > 0 ||
 		len(policyUnsupportedMatchLeafFindings(polInst.node, isGlobal)) > 0 ||
 		len(policyUnsupportedThenPermitModifiers(polInst.node)) > 0 {
 		pol.LenientContentDropped = true


### PR DESCRIPTION
Closes #6526

## The defect

A security-policy `match` leaf written with **no operand** satisfied the #3044
required-dimension gate and compiled to the **byte-identical empty slice the
OMITTED form produces** — which the userspace matcher reads as match-ANY.
`then permit` therefore permitted every source.

Two components disagreed on what "present" means. The gate
(`policyMissingRequiredMatchDimensions`, `compiler_policy_missing_match.go`)
decided it from the leaf **NAME**:

```go
for _, m := range policyMatchChildren(polNode) { present[m.Name()] = true }
```

while the reader `compilePolicy` actually uses — `firewallMatchValues`
(`compiler_firewall.go`) — skips blank tokens, and its own doc comment states
the conflicting definition: *"Empty / blank tokens are skipped so an empty
result means 'criterion absent'."* The gate protected a claim about **VALUES**
with a check on **NAMES**, and the two disagreed for exactly one input.

### Before / after (measured, `pkg/config`)

| `match` stanza | before: `CompileConfig` | before: `Match.SourceAddresses` | after |
|---|---|---|---|
| `source-address 10.0.0.0/8;` | ACCEPTED | `[10.0.0.0/8]` n=1 | unchanged |
| `source-address;` (no operand) | **ACCEPTED** | **`[]` n=0 → match-ANY** | **REJECTED (#6526)** |
| omitted entirely | REJECTED (#3044) | — | unchanged |

`CompileConfigLenient` also yielded `[]` n=0 with `LenientContentDropped=false`,
so the #5575 lenient fail-closed poison was bypassed too — a leniently loaded
valueless permit was published to the dataplane **fully widened**, not as
never-match.

It was reachable through the CLI's own `set` path (`ParseSetCommand` +
`SetPath`, not `NewParser`):

```
set security policies from-zone trust to-zone untrust policy p1 match source-address
```

was accepted end to end and yielded `src=[] n=0` with `action=permit`. An
operator hitting enter one token early committed a permit-any policy.

The schema cannot catch it: `schema_walk.go` deliberately declines minimum
arity (that gate is scoped strictly to EXCESS trailing tokens and only runs for
`scalar: true` leaves), and the five match dimensions are untyped
`args: 1, multi: true` leaves with no `validator` (`schema_security.go`). In
`pkg/config`, a leaf that opts out of typing opts out of every value check —
every typed validator in the repo already opens with
`if raw == "" { return "missing value..." }`.

## The fix

`policyValuelessMatchDimensions(polNode, isGlobal)` decides presence by asking
`firewallMatchValues` — the **same reader `compilePolicy` uses** — whether the
dimension carries anything, so the gate and the compiler can no longer disagree.
It unions values across every `match {}` block (#3842 parity), so a dimension is
flagged only when the compiled slice is actually empty; a duplicate block that
supplies the value is not widened and is not flagged.

**All FIVE value-bearing dimensions** are covered: `source-address`,
`destination-address`, `application`, plus the scoped-global `from-zone` /
`to-zone`, whose empty set collapses a global policy to the all-zones wildcard.
Closing only `source-address` would have left that half open.

Deliberately excluded: `source-address-excluded` / `destination-address-excluded`
— boolean MODIFIER leaves that legitimately carry no operand. `from-zone` /
`to-zone` are inspected only under a **global** policy, because under a zone-pair
policy they are not match siblings at all and the #3113 unsupported-leaf gate
(which runs first) owns them — one typo, one finding.

The finding is emitted from the **same walk** as #3044, so the two can never
diverge on scope (duplicate `security`/`policies` blocks, both AST shapes), but
with a **distinct message** under a **distinct lenient flag**
(`lenientPolicyValuelessMatch`), so "you did not write the criterion" stays
distinguishable from "you wrote it and left the value off". A policy tripping
both reports the omitted-dimension (#3044) finding first.

### Which path rejects, which warns (#1960 no-brick)

| path | behaviour | why |
|---|---|---|
| **Strict** — `commit` / `commit-check` (`CompileConfig`, `Store.compileTree`) | **hard REJECT**, naming the policy scope, the policy and every valueless dimension | the operator authored this candidate, so surfacing it is the safe choice — and on Junos the stanza cannot commit at all |
| **Tolerant** — `Store.Load` / HA `SyncApply` peer-sync (`CompileConfigLenient`) | **WARN + continue**, and the policy is additionally **poisoned to never-match** via `compilePolicy`'s #5575 `LenientContentDropped` flag | hard-failing would blackout-boot the node or alarm-loop HA config sync over a config an older binary silently accepted. The warning is *not* the only protection on this path: the dataplane publishes the rule with the `__unsupported__` sentinel instead of the widened permit |

## Tests

`pkg/config/compiler_policy_valueless_match_6526_test.go`:

1. **Three distinct outcomes as three distinct results** — normal accepted with
   its value, no-operand rejected by the NEW check, omitted rejected by the
   ORIGINAL #3044 gate.
2. **Every assertion is on the specific gate's own message**, never a bare
   `err != nil`. `assertRejectedBy6526` requires
   `match criterion "<dim>" is present but carries NO value` **and** `(#6526)`,
   **and forbids** `match is missing required criterion`;
   `assertRejectedBy3044` is its mirror image. Two gates can reject these
   probes, so an attribution-blind assertion would pass even if the new check
   never ran.
3. **Both parse paths** — every dimension driven through the flat
   `ParseSetCommand` + `tree.SetPath()` loop **and** through the hierarchical
   `NewParser`.
4. **The lenient path separately** — `CompileConfigLenient` must not brick, must
   carry the #6526 warning, and must set `LenientContentDropped`.
5. **False-positive controls** — `-excluded` modifiers, bracketed lists,
   duplicate match blocks that supply the value, explicit `any`, and a global
   policy that simply omits `from-zone`/`to-zone` all still commit.

## Mutation proof

Every mutation kept `go build ./...` **and** `go vet ./pkg/config/...` at
**rc=0** (verified per mutation before reading test results — a build break or
vet failure is a false red). The first M1 attempt used an early `return nil`
above the live body and tripped `go vet` *unreachable code*; it was **discarded
as a false red** and redone with the body removed.

| mutation | build / vet | reds | assertion text that fired |
|---|---|---|---|
| **M1** — whole predicate reverted (`policyValuelessMatchDimensions` returns nil) | 0 / 0 | 22 | `strict commit ACCEPTED a match dimension written with no operand — the dimension compiles to the empty match-ANY slice and the policy widens (#6526)` and `expected a downgraded #6526 valueless-dimension warning "match criterion \"source-address\" is present but carries NO value", got warnings: []` |
| **M2** — gate never emits (predicate intact) | 0 / 0 | 22 | same two, confirming the reject/warn wiring is what binds, not the predicate alone |
| **M3** — poison site drops the predicate (gate intact) | 0 / 0 | **4, poison only** | `policy "p" compiled leniently with a valueless match dimension but was NOT poisoned (LenientContentDropped=false) — the widened permit would be published to the dataplane (#5575/#6526)` |
| **M4a** — drop `source-address` from the covered set | 0 / 0 | 7, **only** source-address subtests | `strict commit ACCEPTED a match dimension written with no operand …` |
| **M4b** — drop `destination-address` | 0 / 0 | 2, **only** destination-address subtests | same |
| **M4c** — drop `application` | 0 / 0 | 3, **only** application subtests | same |
| **M4d** — drop `from-zone` | 0 / 0 | 4, **only** from-zone subtests (incl. the both-zones case) | same |
| **M4e** — drop `to-zone` | 0 / 0 | 3, **only** to-zone subtests (incl. the both-zones case) | same |
| **M5** — drop the global-only scope skip | 0 / 0 | **1** | `the #6526 gate warned about a zone-pair `match from-zone` that the #3113 gate already owns — one typo, two findings` |

M4a–M4e are the **scope proof**: removing any one dimension reds exactly that
dimension's subtests and nothing else, so the guard scope matches the claim
("all five dimensions"), not just the headline one.

Under **M1 the controls all stayed GREEN**, which is what makes the reds
meaningful: the six #3044 `TestPolicyMissingMatchCriterionFailsCommit` subtests,
`TestPolicyCompleteMatchCommits`,
`TestPolicyMissingMatchLenientDowngradesToWarning`, all five
`TestPolicyValuelessMatchDoesNotOverReject` subtests, and both
`normal_value_accepted` / `omitted_rejected_by_3044` legs of the three-way
differential.

M5 is only provable on the **lenient** path (strict returns the first finding,
and #3113 runs before this walk), so the test asserts it there — where every
finding is collected.

## Validation

- `go build ./...` — **rc=0**
- `go vet ./pkg/config/...` — **rc=0**
- `go test ./...` — **rc=0**, 59 packages ok, 0 FAIL (real exit code, not piped
  through `tail`)

Docs updated (`docs/config-schema.md`): a new `### #6526` section next to the
#3148 global-policy zone-context section, plus a rule-of-thumb paragraph in
"Multi-value leaves and bracketed lists" — the section that documents
`firewallMatchValues` and therefore owns the contract that was violated: *when a
gate's claim is "this dimension constrains something", evaluate it with the
compiler's own value reader, not with a name lookup.*

Not covered: no cluster/dataplane smoke was run — this is a pure `pkg/config`
commit-time gate with no dataplane or wire-format change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
