### PR TITLE
config: gate conflicting inline-term icmp-type/icmp-code repeats (#6766)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,50 @@
+## 2026-08-05 — #6814 fold round 4: correct four claims, quote the leaf assertion
+
+- **Timestamp**: 2026-08-05 (fold/6814-r2, gate at 1314dcb72)
+- **Action**: Text round. The gate found no runtime findings; production code is
+  untouched this round (`compiler_applications.go` and `policymatch.go` are
+  byte-identical to the previous commit).
+    - **A wrong attribution in the fall-through helper.** The comment said the
+      explicit `Matched=false` check rejects `Matched=true, DefaultUsed=false,
+      Action=permit`. It does not — that input fails at the `DefaultUsed` check
+      above and never reaches the `Matched` one. The shape that leg
+      independently binds is `Matched=true, DefaultUsed=true, Action=permit`, a
+      Result claiming BOTH a concrete match and a default fall-through, which is
+      exactly what the round-3 mutation set. Corrected in the test comment and
+      in the round-3 log entry. Worth stating precisely rather than softening:
+      the two legs look redundant, and a reader trimming the "redundant" one
+      would delete the only assertion binding that shape.
+    - **"Names the leaf" was satisfied by boilerplate.** The rejection text ends
+      with a STATIC enumeration of every trackable leaf — `(destination-port /
+      source-port / inactivity-timeout / timeout / alg / icmp-type /
+      icmp-code)` — so a bare `strings.Contains(err, leaf)` is true no matter
+      which leaf actually conflicted. Rather than weaken the claim, made it
+      true: both the strict and tolerant assertions now match the QUOTED form
+      (`conflicting duplicate "icmp-type" inside`), which is the only
+      identifying occurrence. This is the one place this round goes beyond text,
+      and it is one predicate per assertion.
+    - **Two pre-existing false claims in the plan doc**, cheap to fix in place:
+      it said the compiled-struct test "demonstrably enforces" the last type
+      although it drives no matcher (now points at the verdict-level test that
+      does), and it described an `icmp-code 0 icmp-code 0` idempotent control
+      when the fixture is `icmp-type 3 icmp-code 1 icmp-code 1` (verified by
+      reading the fixture before correcting the claim).
+    - Named the environment on the round-3 `FULL_RC=0` line. A sandboxed runner
+      that blocks sockets/netlink exits non-zero on unrelated packages; that is
+      a runner limitation, not a contradiction of a run scored on a box that can
+      open sockets.
+- **Validation**: Swapped-label mutation — the two recorded leaf labels
+  exchanged, so an `icmp-type` conflict records `icmp-code` and vice versa.
+  Build and vet clean under it. The QUOTED assertion goes RED on both tests,
+  naming the wrong-leaf message it received. A throwaway control running the
+  BARE (pre-fix) assertion verbatim PASSED the same mutation (rc=0), so the
+  quoting is what added the discrimination rather than the check merely looking
+  stricter. Restored by pristine-snapshot write-back plus `touch`; GREEN
+  re-confirmed. Gates from real exit codes on this workstation (sockets and
+  netlink permitted): `GATE1_RC=0`, `FULL_RC=0`.
+- **File(s)**: `pkg/policymatch/app_inline_term_icmp_dup_6766_test.go`,
+  `docs/pr/6766-inline-icmp-dup/plan.md`, `_Log.md`
+
 ## 2026-08-05 — #6814 fold round 3: assert the fall-through evidence, bind the recording
 
 - **Timestamp**: 2026-08-05 (fold/6814-r2, gate at 48bb63f54)
@@ -11,19 +58,26 @@
       `Result` that was never populated — a path producing NOTHING looked
       identical to a genuine fall-through. New `assertFellThroughToDefaultPermit`
       helper asserts `DefaultUsed=true` FIRST (the only non-default evidence that
-      the default branch ran), then `Matched=false` explicitly — which also
-      rejects the `Matched=true, DefaultUsed=false, Action=permit` shape, a
-      concrete policy PERMIT rather than a fall-through. The DENY legs gained a
-      matching `DefaultUsed=false` assertion so they cannot be satisfied by a
-      default either.
+      the default branch ran), then `Matched=false` explicitly. The shape that
+      second leg independently binds is `Matched=true, DefaultUsed=true,
+      Action=permit` — a Result claiming BOTH a concrete match and a default
+      fall-through. It does NOT carry `Matched=true, DefaultUsed=false`: that
+      input fails at the `DefaultUsed` check and never reaches the `Matched`
+      one, which is why the leg needed its own mutation to prove. The DENY legs
+      gained a matching `DefaultUsed=false` assertion so they cannot be
+      satisfied by a default either.
     - **The duplicate RECORDING was not bound.** Verified firsthand before
       fixing: with the #6766 tracking removed outright (strict stops rejecting)
       both policymatch tests still PASSED, because the compiled values and every
       verdict are identical whether or not the conflict was recorded. The shared
       `inlineICMPDupCfg` fixture now asserts BOTH halves of the recording — that
-      strict `CompileConfig` rejects and names the leaf, and that the tolerant
-      path emits the warning naming it (the only signal an operator gets on the
-      path that keeps forwarding).
+      strict `CompileConfig` rejects and that the tolerant path emits the
+      warning (the only signal an operator gets on the path that keeps
+      forwarding). Both match the leaf name in its QUOTED form: the message
+      ends with a static enumeration of every trackable leaf, so a bare
+      substring check is satisfied by that boilerplate regardless of which leaf
+      conflicted. Proven by swapping the two recorded labels — the bare shape
+      accepts the swapped message, the quoted shape rejects it.
     - **Scalar-zero override control (gate suggestion, taken).** The
       apply-groups override control now commits `icmp-type 0` — the scalar zero
       of the compiled `uint8`. `assertTermICMP` rejects a nil `ICMPType`
@@ -50,7 +104,10 @@
   Two mutation attempts were discarded as invalid rather than reported: one
   broke the build (`declared and not used`) and one silently applied nothing
   (a 2-occurrence anchor tripped the count assert), whose "PASS" was
-  meaningless. Gates scored from real exit codes: `GATE1_RC=0`, `FULL_RC=0`.
+  meaningless. Gates scored from real exit codes on this workstation (Linux,
+  sockets and netlink permitted): `GATE1_RC=0`, `FULL_RC=0` across 59 packages.
+  A sandboxed runner that blocks sockets/netlink will exit non-zero on
+  unrelated packages; that is a runner limitation, not a contradiction.
 - **File(s)**: `pkg/policymatch/app_inline_term_icmp_dup_6766_test.go`,
   `pkg/config/compiler_application_term_icmp_dup_6766_test.go`, `_Log.md`
 

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,59 @@
+## 2026-08-05 — #6814 fold round 3: assert the fall-through evidence, bind the recording
+
+- **Timestamp**: 2026-08-05 (fold/6814-r2, gate at 48bb63f54)
+- **Action**: Gate returned MERGE-NEEDS-MINOR on one family of defects — the
+  round-2 tests leaned on ZERO VALUES where the non-default evidence is what
+  proves the behaviour. All four items folded; production code is still
+  comment-only.
+    - **Fall-through was never actually asserted.** `config.PolicyPermit` is the
+      zero value of `PolicyAction` (`types_security.go:582`) and `Matched=false`
+      is a zero value too, so the discarded-value subtests were satisfied by a
+      `Result` that was never populated — a path producing NOTHING looked
+      identical to a genuine fall-through. New `assertFellThroughToDefaultPermit`
+      helper asserts `DefaultUsed=true` FIRST (the only non-default evidence that
+      the default branch ran), then `Matched=false` explicitly — which also
+      rejects the `Matched=true, DefaultUsed=false, Action=permit` shape, a
+      concrete policy PERMIT rather than a fall-through. The DENY legs gained a
+      matching `DefaultUsed=false` assertion so they cannot be satisfied by a
+      default either.
+    - **The duplicate RECORDING was not bound.** Verified firsthand before
+      fixing: with the #6766 tracking removed outright (strict stops rejecting)
+      both policymatch tests still PASSED, because the compiled values and every
+      verdict are identical whether or not the conflict was recorded. The shared
+      `inlineICMPDupCfg` fixture now asserts BOTH halves of the recording — that
+      strict `CompileConfig` rejects and names the leaf, and that the tolerant
+      path emits the warning naming it (the only signal an operator gets on the
+      path that keeps forwarding).
+    - **Scalar-zero override control (gate suggestion, taken).** The
+      apply-groups override control now commits `icmp-type 0` — the scalar zero
+      of the compiled `uint8`. `assertTermICMP` rejects a nil `ICMPType`
+      outright, so "committed the local 0" and "compiled nothing" cannot be
+      confused, and the control additionally binds a compiler that treats a
+      committed 0 as unset. Cheaper than reshaping the fixture and it keeps the
+      empirically-verified semantics (local term fully replaces the group's).
+    - Left alone per the gate: the positive controls that expect
+      `ICMPCode=nil`. Their companion non-nil type assertions and the
+      code-bearing controls keep the suite non-vacuous.
+- **Validation**: Four mutations, preflight build+vet clean, each vet-clean
+  under the mutation, each restored by writing back a pristine snapshot and
+  `touch`ing (never `git checkout --`), GREEN re-confirmed after each.
+  (1) Recording removed: both policymatch tests now RED at the strict-reject
+  assertion — they PASSED under this same mutation before the fold.
+  (2) Every default-branch `Result` leaves `DefaultUsed` unset: new assertion
+  RED with `default_used=false matched=false action=0`, and a throwaway
+  negative control running the PRE-fold assertion shape verbatim PASSED the
+  same mutation — the new evidence is what catches it.
+  (3) Default path also claims `Matched=true`: the `Matched` leg fires on its
+  own (it sits behind the `DefaultUsed` check, so it needed its own mutation).
+  (4) Committed `icmp-type 0` dropped as if unset: the override control RED
+  with `ovr-t1 ICMPType = <nil>, want 0` while its sibling subtests stay green.
+  Two mutation attempts were discarded as invalid rather than reported: one
+  broke the build (`declared and not used`) and one silently applied nothing
+  (a 2-occurrence anchor tripped the count assert), whose "PASS" was
+  meaningless. Gates scored from real exit codes: `GATE1_RC=0`, `FULL_RC=0`.
+- **File(s)**: `pkg/policymatch/app_inline_term_icmp_dup_6766_test.go`,
+  `pkg/config/compiler_application_term_icmp_dup_6766_test.go`, `_Log.md`
+
 ## 2026-08-05 — #6814 fold round 2: bind the icmp-code last-writer, add positive controls
 
 - **Timestamp**: 2026-08-05 (fold/6814-r2, PR #6814 head b21c7bd19)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-08-05 — #6814 fold round 5: the same weak leaf assertion in the three pre-existing rejection tests
+
+- **Timestamp**: 2026-08-05 (fold/6814-r2, separate commit on top of 274e24f23)
+- **Action**: Round 4 fixed the bare-substring leaf assertion in the two tests it
+  added. The identical defect was sitting in the THREE pre-existing #5797
+  rejection tests in the same file — `FlatSet_Rejected`,
+  `Hierarchical_Rejected`, `ApplyGroups_Rejected` — all using
+  `strings.Contains(err.Error(), c.leaf)`. Flagged rather than silently widened;
+  the lead scoped it in as a separate commit, on the reasoning that leaving it
+  fixes what bit us rather than the class, and leaves a reader unable to tell
+  which of the two forms in one file is deliberate.
+  All three now match the QUOTED occurrence, with one shared note explaining
+  why: the rejection message ends with a static enumeration of every trackable
+  leaf, so the bare form is satisfied by boilerplate regardless of which leaf
+  conflicted, and only the identifying occurrence is quoted.
+- **Validation**: Same swapped-label mutation as round 4 — the two recorded leaf
+  labels exchanged in `parseApplicationTerms`. Build and vet clean under it.
+  ALL SIX rejection subtests (three tests x icmp-type/icmp-code) go RED; the
+  four positive controls correctly stay GREEN, since they author no conflict and
+  so have no label to swap — which also confirms the mutation is scoped to the
+  rejection path and is not simply breaking the package. Negative control: the
+  three assertions reverted to the BARE form with the mutation still applied
+  PASS (rc=0), so quoting is what added the discrimination in these three too,
+  not a stricter-looking check. Restored both files by pristine-snapshot
+  write-back plus `touch`; production `compiler_applications.go` confirmed
+  byte-identical to HEAD afterwards. Gates from real exit codes on this
+  workstation: `GATE1_RC=0`, `FULL_RC=0`.
+- **File(s)**: `pkg/config/compiler_application_term_icmp_dup_6766_test.go`,
+  `_Log.md`
+
 ## 2026-08-05 — #6814 fold round 4: correct four claims, quote the leaf assertion
 
 - **Timestamp**: 2026-08-05 (fold/6814-r2, gate at 1314dcb72)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,63 @@
+## 2026-08-05 — #6814 fold round 2: bind the icmp-code last-writer, add positive controls
+
+- **Timestamp**: 2026-08-05 (fold/6814-r2, PR #6814 head b21c7bd19)
+- **Action**: Folded the three review findings on the #6766 inline-term ICMP
+  duplicate gate. The production gate itself was confirmed sound and is
+  unchanged; every finding was about what the tests actually bind.
+    - **B1 — the `icmp-code` last-writer was unbound.** Conflicting `icmp-code`
+      was exercised only on strict REJECTION paths, which assert that a
+      conflict is refused but never which value survives when it is TOLERATED.
+      On the tolerant path (boot load / HA SyncApply) the reject is downgraded
+      to a warning and the surviving value is the one enforced, so a production
+      edit retaining the FIRST conflicting code instead of the last changed
+      which ICMP traffic a referenced deny covers while passing the whole file.
+      Verified by mutation: keep-FIRST on `icmp-code` left ALL six pre-existing
+      tests green. Now pinned twice — at the compiled struct
+      (`TestApplicationTermICMPDup_LenientKeepsLastCode`) and at the verdict.
+    - **B2 — a comment claimed more than its test.** The
+      `ReferencedDeny_StrictRejects_LenientNarrows` comment said the term
+      "demonstrably enforces ONLY the last type", but the test asserts on
+      `app.ICMPType` and drives no matcher. Fixed on BOTH sides: the comment now
+      states its real scope (compiled struct, no matcher) and points at the new
+      verdict-level test, and that new test drives `policymatch.Match` for real
+      — asserting the discarded type/code falls through to `default-policy
+      permit-all` while the surviving one hits the deny.
+    - **B3 — no rejection test had a positive control.** All three could not
+      distinguish "rejects the conflicting repeat" from "rejects this shape".
+      Added shape-matched valid cases to each. The apply-groups one gained the
+      CROSS-SOURCE case the originals never reached: a group value restated
+      locally is an apply-groups OVERRIDE, not a duplicate — it must commit,
+      the local value wins, and the group's `icmp-code` must not leak into
+      the merged term (empirically confirmed: the local `term` REPLACES the
+      group's outright rather than merging token streams).
+    - **Non-blocking comment fix.** `compiler_applications.go` claimed the
+      trackers keep each leaf's "first assigned value"; every arm refreshes its
+      comparison value after recording, so the check is "differs from its
+      immediate predecessor" — one record per TRANSITION, so `8, 3, 8` records
+      two where compare-against-first records one. Nothing observable depends on
+      it: acceptance is identical (any multi-value sequence contains a
+      transition) and the gate reports only `DuplicateTermLeaves[0]`, so the
+      extra records never reach the error text. Verified by running `8, 3, 8`
+      through the real gate — the error names `icmp-type` once. The comment now
+      says the slice is a non-empty/empty signal with one representative leaf
+      name, not a conflict tally.
+- **Validation**: Three mutations, each with build+vet clean under the mutation
+  and a preflight-clean build+vet before any of them.
+  (1) keep-FIRST on `icmp-code`: all six pre-existing tests PASS — the B1 gap
+  reproduced — while the two new guards go RED, the verdict one showing the real
+  inversion (code 2 `matched=false default_used=true`, code 1 DENIED).
+  (2) Over-broad gate (record a duplicate on EVERY `icmp-type`, including the
+  first): all four new positive controls FAIL while every rejection subtest still
+  PASSES — the exact blindness B3 described.
+  (3) Matcher ignores ICMP constraints: the new verdict guard FIRES while the
+  old struct-level test still PASSES — B2 proven two-sided.
+  `go test ./pkg/config/... ./pkg/policymatch/...` and the full `go test ./...`
+  both clean. No cluster tooling run.
+- **File(s)**: `pkg/config/compiler_applications.go`,
+  `pkg/config/compiler_application_term_icmp_dup_6766_test.go`,
+  `pkg/config/README.md`,
+  `pkg/policymatch/app_inline_term_icmp_dup_6766_test.go`, `_Log.md`
+
 ## 2026-08-03 — #6766: gate conflicting inline-term icmp-type / icmp-code repeats
 
 - **Timestamp**: 2026-08-03 (fix/6766-inline-icmp-dup, opus-review-001 R23)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-08-03 — #6766: gate conflicting inline-term icmp-type / icmp-code repeats
+
+- **Timestamp**: 2026-08-03 (fix/6766-inline-icmp-dup, opus-review-001 R23)
+- **Action**: The #3366 inline-term duplicate-scalar framework tracked
+  destination-port / source-port / timeout / alg but declared no set flags for
+  the ICMP leaves, so a conflicting `icmp-type` / `icmp-code` repeat inside one
+  inline application `term` overwrote the pointer with no record — the term is
+  opaque to SchemaValidate, and the strict structure gate only sees
+  `Application.DuplicateTermLeaves`, so strict commit accepted the config and a
+  referenced DENY enforced only the LAST type/code (silent narrowing of the
+  deny match). Added `icmpTypeSet` / `icmpCodeSet` first-value tracking in
+  `parseApplicationTerms` mirroring the ports (and the #5574 direct-body ICMP
+  tracking): a conflicting repeat is recorded on `DuplicateTermLeaves`, an
+  idempotent same-value repeat stays accepted, malformed tokens keep the
+  existing `UnknownICMP` path. Strict error text, the
+  `validateApplicationStructureStrict` doc comment, the `DuplicateTermLeaves`
+  field doc, and the pkg/config README #3366 section now enumerate the ICMP
+  leaves. New fail-on-revert tests cover packed flat-set, hierarchical,
+  apply-groups, a referenced deny policy (strict rejects; lenient compiles with
+  only the last type — characterizing the narrowing), same-value idempotent
+  acceptance, and the lenient no-brick downgrade, for both leaves.
+- **File(s)**: `pkg/config/compiler_applications.go`,
+  `pkg/config/compiler_validate_strict_application.go`,
+  `pkg/config/types_security.go`,
+  `pkg/config/compiler_application_term_icmp_dup_6766_test.go`,
+  `pkg/config/README.md`, `docs/pr/6766-inline-icmp-dup/plan.md`, `_Log.md`
+
 ## 2026-08-01 — #6588 round 6c: put the two-of-three characterization in the comment
 
 - **Timestamp**: 2026-08-01 (fix/6588-interface-monitor-packed-leaf, PR #6658)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,50 @@
+## 2026-08-05 — #6814 fold round 6: two bare leaf sites my round-5 grep could not find
+
+- **Timestamp**: 2026-08-05 (fold/6814-r2, on top of a47afa165)
+- **Action**: An AGY leg running the full swapped-label matrix at true head found
+  TWO more bare leaf assertions — in the file THIS PR authored, not the
+  pre-existing ones round 5 swept.
+    - `compiler_application_term_icmp_dup_6766_test.go:277`
+      (`ReferencedDeny_StrictRejects_LenientNarrows`) and `:398`
+      (`Lenient_DowngradesToWarning`). Both now match the QUOTED form.
+    - **Why round 5 missed them, which is the reusable part.** My sweep grepped
+      for `strings.Contains(err.Error(), c.leaf)` — the table-driven form. These
+      two hardcode the literal `"icmp-type"` instead of taking it from a case
+      table, so a grep shaped around the variable form STRUCTURALLY cannot find
+      them. The mutation matrix finds every shape because it does not care how
+      the assertion is spelled. Grep finds what you already know the shape of;
+      the mutation finds what you do not.
+    - **The file header was consequently false.** It claimed the quoted form is
+      used "throughout this file" and that it "reds all three rejection tests".
+      There are FIVE leaf-identity sites: four rejection assertions (the three
+      table-driven ones plus ReferencedDeny, which hardcodes its leaf) and one
+      tolerant-path warning assertion. Header rewritten to state the count —
+      the count is what makes the claim checkable — and to record why the two
+      literal-form sites were quoted a round later than the table-driven ones.
+      Also records that the enumeration beside the identifying occurrence
+      renders UNQUOTED (`%q` of `DuplicateTermLeaves[0]` in
+      `compiler_validate_strict_application.go`), which is what makes quoting
+      discriminate at all.
+- **Validation**: Same swapped-label mutation, preflight build+vet clean, vet
+  clean under it. Full matrix: ALL FIVE leaf-identity sites RED — the six
+  table-driven rejection subtests, `ReferencedDeny`, and
+  `Lenient_DowngradesToWarning`. The four positive controls stay GREEN, as do
+  `Idempotent_Accepted` and `LenientKeepsLastCode` (no conflict authored, so no
+  label to swap, and the latter asserts a VALUE not a leaf name) — which is what
+  shows the mutation is scoped to leaf identity rather than breaking the
+  package. Negative control: `:277` and `:398` reverted to the bare form with
+  the mutation still applied both PASS (rc=0). Restored both files by
+  pristine-snapshot write-back plus `touch`; `compiler_applications.go`
+  confirmed byte-identical to HEAD afterwards. Gates from real exit codes on
+  this workstation: `GATE1_RC=0`, `FULL_RC=0`.
+- **Note**: the stale-SHA Codex verdict relayed for this PR was discarded, not
+  folded — every one of its five findings was already closed at
+  `a47afa165`, proven by grepping each flagged string across `1314dcb72` /
+  `274e24f23` / `a47afa165`. These two AGY findings are from the true head and
+  are unrelated to those five.
+- **File(s)**: `pkg/config/compiler_application_term_icmp_dup_6766_test.go`,
+  `_Log.md`
+
 ## 2026-08-05 — #6814 fold round 5: the same weak leaf assertion in the three pre-existing rejection tests
 
 - **Timestamp**: 2026-08-05 (fold/6814-r2, separate commit on top of 274e24f23)

--- a/_Log.md
+++ b/_Log.md
@@ -2,8 +2,9 @@
 
 - **Timestamp**: 2026-08-05 (fold/6814-r2, on top of a47afa165)
 - **Action**: An AGY leg running the full swapped-label matrix at true head found
-  TWO more bare leaf assertions — in the file THIS PR authored, not the
-  pre-existing ones round 5 swept.
+  TWO more bare leaf assertions — in the same file this PR authored, beyond the
+  three round 5 swept (all of them new in this PR; see the provenance
+  correction in the round-5 entry).
     - `compiler_application_term_icmp_dup_6766_test.go:277`
       (`ReferencedDeny_StrictRejects_LenientNarrows`) and `:398`
       (`Lenient_DowngradesToWarning`). Both now match the QUOTED form.
@@ -45,17 +46,28 @@
 - **File(s)**: `pkg/config/compiler_application_term_icmp_dup_6766_test.go`,
   `_Log.md`
 
-## 2026-08-05 — #6814 fold round 5: the same weak leaf assertion in the three pre-existing rejection tests
+## 2026-08-05 — #6814 fold round 5: the same weak leaf assertion in three more of this file's tests
 
 - **Timestamp**: 2026-08-05 (fold/6814-r2, separate commit on top of 274e24f23)
 - **Action**: Round 4 fixed the bare-substring leaf assertion in the two tests it
-  added. The identical defect was sitting in the THREE pre-existing #5797
-  rejection tests in the same file — `FlatSet_Rejected`,
-  `Hierarchical_Rejected`, `ApplyGroups_Rejected` — all using
-  `strings.Contains(err.Error(), c.leaf)`. Flagged rather than silently widened;
-  the lead scoped it in as a separate commit, on the reasoning that leaving it
-  fixes what bit us rather than the class, and leaves a reader unable to tell
-  which of the two forms in one file is deliberate.
+  added. The identical defect was sitting in three more tests in the SAME file
+  — `FlatSet_Rejected`, `Hierarchical_Rejected`, `ApplyGroups_Rejected` — all
+  using `strings.Contains(err.Error(), c.leaf)`. Flagged rather than silently
+  widened; the lead scoped it in as a separate commit, on the reasoning that
+  leaving it fixes what bit us rather than the class, and leaves a reader unable
+  to tell which of the two forms in one file is deliberate.
+
+  **Provenance correction (#6814).** This entry, its heading, the round-6
+  back-reference below, and the commit message of `a47afa165` all described
+  these three as "pre-existing #5797 rejection tests". That is FALSE.
+  `pkg/config/compiler_application_term_icmp_dup_6766_test.go` does not exist on
+  `origin/master` — `git diff --name-status origin/master...HEAD` reports it as
+  `A` (added), introduced by this PR's own first commit `b21c7bd19`. All three
+  tests are NEW in this PR. The distinction is not cosmetic: "swept a
+  pre-existing defect class inherited from another issue" and "fixed every site
+  in its own new file" are different claims about what the PR did, and only the
+  second is true. The `a47afa165` commit message is immutable and still carries
+  the wrong framing; this note and the PR body are the correction of record.
   All three now match the QUOTED occurrence, with one shared note explaining
   why: the rejection message ends with a static enumeration of every trackable
   leaf, so the bare form is satisfied by boilerplate regardless of which leaf

--- a/docs/pr/6766-inline-icmp-dup/plan.md
+++ b/docs/pr/6766-inline-icmp-dup/plan.md
@@ -20,10 +20,21 @@ Mirror the existing #3366 value-aware duplicate tracking for the two ICMP
 leaves, in the same function, with the same semantics:
 
 1. `pkg/config/compiler_applications.go` `parseApplicationTerms`:
-   - add `icmpTypeSet` / `icmpCodeSet` bools plus first parsed values
+   - add `icmpTypeSet` / `icmpCodeSet` bools plus a companion value
      (`uint8`), exactly like the direct body's `itypeSet`/`icodeSet`;
-   - on a repeat whose parsed value differs from the first, append
-     `"icmp-type"` / `"icmp-code"` to `dupTermLeaves`;
+   - the companion holds the MOST RECENTLY parsed value, not the first —
+     every arm refreshes it after recording — so the check is "differs
+     from its immediate predecessor" and one record is appended per
+     TRANSITION. `icmp-type 8 icmp-type 3 icmp-type 8` therefore records
+     TWO conflicts, where comparing every later value against the first
+     would record one. Nothing observable depends on the difference:
+     acceptance is identical (any sequence carrying more than one
+     distinct value contains at least one transition), and the strict
+     gate reports only `DuplicateTermLeaves[0]`, so the extra records
+     never reach the error text. Treat the slice as a non-empty/empty
+     signal carrying one representative leaf name, NOT a conflict tally;
+   - on such a transition, append `"icmp-type"` / `"icmp-code"` to
+     `dupTermLeaves`;
    - an idempotent same-value repeat stays accepted (no record);
    - a malformed token keeps its current path (`badICMP` → `UnknownICMP` →
      strict specs gate) — duplicate tracking only applies to values that parse,
@@ -54,6 +65,9 @@ previously compiled to a silently narrowed constraint.
 - `pkg/config/compiler_applications.go` (parseApplicationTerms + comment)
 - `pkg/config/compiler_validate_strict_application.go` (error text + doc comment)
 - `pkg/config/compiler_application_term_icmp_dup_6766_test.go` (new tests)
+- `pkg/policymatch/app_inline_term_icmp_dup_6766_test.go` (new tests — the
+  verdict-level half, added in the review fold; referenced below but omitted
+  from this list until #6814)
 - `pkg/config/README.md` (#3366 section: extend the tracked leaf list)
 - `docs/pr/6766-inline-icmp-dup/plan.md` (this file)
 - `_Log.md` (work log entry)

--- a/docs/pr/6766-inline-icmp-dup/plan.md
+++ b/docs/pr/6766-inline-icmp-dup/plan.md
@@ -71,11 +71,17 @@ New fail-on-revert table + guards in
 - **apply-groups**: a group restates the term with a conflicting value; the
   merged config rejects;
 - **deny-policy**: a referenced deny app with a conflicting inline `icmp-type`
-  rejects at strict compile; on the lenient path the compiled term demonstrably
-  enforces ONLY the last type (characterizes the silent narrowing the strict
-  gate prevents);
+  rejects at strict compile; on the lenient path the compiled Application
+  carries ONLY the last type. That test asserts on the compiled STRUCT and
+  drives no matcher, so it does not by itself show the surviving value is what
+  gets ENFORCED; the enforcement claim is proved at the verdict in
+  `pkg/policymatch/app_inline_term_icmp_dup_6766_test.go`, which drives
+  `policymatch.Match` and asserts the discarded type/code falls through to
+  `default-policy permit-all`;
 - **same-value idempotent**: `icmp-type 8 icmp-type 8` and
-  `icmp-code 0 icmp-code 0` commit cleanly;
+  `icmp-type 3 icmp-code 1 icmp-code 1` commit cleanly (the code fixture uses
+  1, not 0 — a committed `icmp-type 0` is used instead as the apply-groups
+  scalar-zero override control);
 - **lenient downgrade**: conflicting repeat downgrades to a warning, no brick.
 
 RED-first: the rejection tests fail against the pre-fix compiler (nothing

--- a/docs/pr/6766-inline-icmp-dup/plan.md
+++ b/docs/pr/6766-inline-icmp-dup/plan.md
@@ -1,0 +1,82 @@
+# Plan: gate conflicting inline-term `icmp-type` / `icmp-code` repeats (#6766)
+
+## Goal
+
+A single-valued `icmp-type` or `icmp-code` leaf repeated with a DIFFERENT value
+inside one inline application `term` is currently last-writer-wins with no
+commit error: `parseApplicationTerms` assigns each repeat straight into the
+`icmpType` / `icmpCode` pointer, the term subtree is opaque to SchemaValidate
+(`schema_security.go` `term` is `args:1, children:nil`), and the strict
+structure gate only sees leaves recorded on `Application.DuplicateTermLeaves` —
+which the inline parser never populates for ICMP. A referenced DENY application
+therefore enforces only the last type/code (a silent narrowing of the deny
+match). The direct-body path (#5574) and the port/timeout/ALG inline leaves
+(#3366) already track first-value/set and record conflicting repeats; ICMP was
+omitted from the #3366 framework.
+
+## Approach
+
+Mirror the existing #3366 value-aware duplicate tracking for the two ICMP
+leaves, in the same function, with the same semantics:
+
+1. `pkg/config/compiler_applications.go` `parseApplicationTerms`:
+   - add `icmpTypeSet` / `icmpCodeSet` bools plus first parsed values
+     (`uint8`), exactly like the direct body's `itypeSet`/`icodeSet`;
+   - on a repeat whose parsed value differs from the first, append
+     `"icmp-type"` / `"icmp-code"` to `dupTermLeaves`;
+   - an idempotent same-value repeat stays accepted (no record);
+   - a malformed token keeps its current path (`badICMP` → `UnknownICMP` →
+     strict specs gate) — duplicate tracking only applies to values that parse,
+     so a `icmp-type 8 icmp-type foo` sequence is still caught by the malformed
+     arm, not the duplicate arm;
+   - update the #3366 comment block to name the ICMP leaves.
+2. `pkg/config/compiler_validate_strict_application.go`:
+   - extend the `DuplicateTermLeaves` error text to enumerate
+     `icmp-type / icmp-code` alongside the existing leaves;
+   - update the `validateApplicationStructureStrict` doc comment (#3366 bullet)
+     to name the ICMP leaves.
+
+No dataplane or Rust change: `capabilities.go` and `policy.rs` consume the
+final compiled constraint; the fix makes the compiler reject a config that
+previously compiled to a silently narrowed constraint.
+
+## Alternatives rejected
+
+- **Schema-typing the term subtree**: the inline term is a single packed
+  statement in both AST shapes; making the schema walk it would be a much
+  larger grammar change and is not how #3352/#3366 solved the same opacity.
+- **Value-blind rejection (any repeat)**: would break the accepted idempotent
+  same-value restate (apply-groups merges can legitimately restate a value);
+  inconsistent with the #3366/#5574 semantics.
+
+## Files touched
+
+- `pkg/config/compiler_applications.go` (parseApplicationTerms + comment)
+- `pkg/config/compiler_validate_strict_application.go` (error text + doc comment)
+- `pkg/config/compiler_application_term_icmp_dup_6766_test.go` (new tests)
+- `pkg/config/README.md` (#3366 section: extend the tracked leaf list)
+- `docs/pr/6766-inline-icmp-dup/plan.md` (this file)
+- `_Log.md` (work log entry)
+
+## Test strategy
+
+New fail-on-revert table + guards in
+`pkg/config/compiler_application_term_icmp_dup_6766_test.go`:
+
+- **packed flat-set** (the `flatTreeFromSets` shape, one `set` line carrying
+  the repeat): `icmp-type 8 icmp-type 0` and `icmp-code 1 icmp-code 2` reject,
+  error names the leaf;
+- **hierarchical** (`hierTree` brace block with sibling repeats): both leaves
+  reject;
+- **apply-groups**: a group restates the term with a conflicting value; the
+  merged config rejects;
+- **deny-policy**: a referenced deny app with a conflicting inline `icmp-type`
+  rejects at strict compile; on the lenient path the compiled term demonstrably
+  enforces ONLY the last type (characterizes the silent narrowing the strict
+  gate prevents);
+- **same-value idempotent**: `icmp-type 8 icmp-type 8` and
+  `icmp-code 0 icmp-code 0` commit cleanly;
+- **lenient downgrade**: conflicting repeat downgrades to a warning, no brick.
+
+RED-first: the rejection tests fail against the pre-fix compiler (nothing
+records the duplicate, strict compile succeeds).

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -1210,11 +1210,16 @@ parent on `cfg.Applications.MixedDirectTermApps` and `validateApplicationStructu
 (`compiler_validate_strict.go`) hard-rejects it at commit (move the direct match
 into its own `term`). The same gate also rejects a single-valued (scalar) term
 leaf — `destination-port` / `source-port` / `inactivity-timeout` / `timeout` /
-`alg` — that appears more than once inside ONE inline term with a CONFLICTING
+`alg`, and since #6766 `icmp-type` / `icmp-code` — that appears more than once
+inside ONE inline term with a CONFLICTING
 value: the inline `term` is opaque to the `SchemaValidate` walk, so a repeat (via
 apply-groups, flat-set ordering, or hand authoring) was last-writer-wins,
 silently overriding the earlier value by token order; `parseApplicationTerms`
-records the offending leaf on `Application.DuplicateTermLeaves`. An IDEMPOTENT
+records the offending leaf on `Application.DuplicateTermLeaves`. (#6766: the
+#3366 framework omitted the ICMP leaves, so a conflicting `icmp-type` /
+`icmp-code` repeat overwrote the pointer with no record and a referenced DENY
+enforced only the LAST type/code — a silent narrowing of the deny match, the
+inline-term analogue of the #5574 direct-body ICMP tracking.) An IDEMPOTENT
 same-value repeat (e.g. the `timeout` / `inactivity-timeout` aliases both set to
 the same number) is harmless and accepted, and a repeated `protocol` is the
 documented multi-protocol-term syntax (one application per unique protocol) and

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -1219,7 +1219,13 @@ records the offending leaf on `Application.DuplicateTermLeaves`. (#6766: the
 #3366 framework omitted the ICMP leaves, so a conflicting `icmp-type` /
 `icmp-code` repeat overwrote the pointer with no record and a referenced DENY
 enforced only the LAST type/code — a silent narrowing of the deny match, the
-inline-term analogue of the #5574 direct-body ICMP tracking.) An IDEMPOTENT
+inline-term analogue of the #5574 direct-body ICMP tracking. On the TOLERANT
+path the conflict is only a warning, so whichever value survives is the one
+actually enforced: that keep-LAST outcome is pinned for both `icmp-type` and
+`icmp-code` at the verdict — the discarded value falling through to
+`default-policy permit-all` — in
+`pkg/policymatch/app_inline_term_icmp_dup_6766_test.go`, and at the compiled
+struct in `compiler_application_term_icmp_dup_6766_test.go`.) An IDEMPOTENT
 same-value repeat (e.g. the `timeout` / `inactivity-timeout` aliases both set to
 the same number) is harmless and accepted, and a repeated `protocol` is the
 documented multi-protocol-term syntax (one application per unique protocol) and

--- a/pkg/config/compiler_application_term_icmp_dup_6766_test.go
+++ b/pkg/config/compiler_application_term_icmp_dup_6766_test.go
@@ -1,0 +1,246 @@
+package config
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// #6766 (opus-review-001 R23): a single-valued `icmp-type` / `icmp-code` leaf
+// repeated with a CONFLICTING value inside one inline application `term` was
+// last-writer-wins with no commit error. parseApplicationTerms tracked
+// conflicting repeats for destination-port / source-port / timeout / alg (the
+// #3366 framework) but declared no set flags for the ICMP leaves, so each
+// repeat silently overwrote the pointer; the term subtree is opaque to
+// SchemaValidate (`term` is args:1, children:nil), and the strict structure
+// gate only sees Application.DuplicateTermLeaves — which the inline parser
+// never populated for ICMP. A referenced DENY application therefore enforced
+// only the LAST type/code: a deny authored `icmp-type 8` then `icmp-type 3`
+// denied only type 3, and echo traffic fell through to a later permit or the
+// default permit (a silent narrowing of the deny match). The direct-body path
+// already tracks ICMP conflicts (#5574); this is the inline-term analogue.
+//
+// Shapes: packed flat-set (flatTreeFromSets — one `set` line carrying the
+// repeat), hierarchical (hierTree — sibling repeats), and apply-groups (a
+// group-authored packed term merged into the stanza). All three reassemble to
+// the same parseApplicationTerms token stream via applicationTermKeys.
+
+// Core fail-on-revert, packed flat-set shape: a conflicting icmp-type /
+// icmp-code repeat inside one inline term must be REJECTED at commit, with the
+// error naming the leaf. Revert the duplicate tracking and the second value
+// silently overwrites the first (last-writer-wins), CompileConfig succeeds, and
+// this assertion goes RED.
+func TestApplicationTermICMPDup_FlatSet_Rejected(t *testing.T) {
+	cases := []struct {
+		name string
+		term string
+		leaf string
+	}{
+		{"icmp-type", "term t1 protocol icmp icmp-type 8 icmp-type 0", "icmp-type"},
+		{"icmp-code", "term t1 protocol icmp icmp-type 3 icmp-code 1 icmp-code 2", "icmp-code"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tree := flatTreeFromSets(t, unrefAppOnly("dup", c.term)...)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("expected commit to REJECT conflicting duplicate %q inside a term", c.leaf)
+			}
+			if !strings.Contains(err.Error(), "duplicate") || !strings.Contains(err.Error(), c.leaf) {
+				t.Fatalf("error should name the duplicate leaf %q, got: %v", c.leaf, err)
+			}
+		})
+	}
+}
+
+// Hierarchical shape: the same conflict authored as sibling statements inside a
+// brace-block term must reject too (the compiler reassembles both AST shapes
+// through applicationTermKeys).
+func TestApplicationTermICMPDup_Hierarchical_Rejected(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		leaf string
+	}{
+		{"icmp-type", "term t1 { protocol icmp; icmp-type 8; icmp-type 0; }", "icmp-type"},
+		{"icmp-code", "term t1 { protocol icmp; icmp-type 3; icmp-code 1; icmp-code 2; }", "icmp-code"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tree := hierTree(t, "applications {\n    application dup {\n        "+c.body+"\n    }\n}\n")
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("expected commit to REJECT conflicting duplicate %q inside a hierarchical term", c.leaf)
+			}
+			if !strings.Contains(err.Error(), "duplicate") || !strings.Contains(err.Error(), c.leaf) {
+				t.Fatalf("error should name the duplicate leaf %q, got: %v", c.leaf, err)
+			}
+		})
+	}
+}
+
+// apply-groups shape: a group-authored term carrying the conflicting repeat is
+// cloned into the applications stanza by ExpandGroups; the merged config must
+// reject exactly like a directly-authored one (apply-groups is one of the load
+// paths that produces duplicate term leaves in practice).
+func TestApplicationTermICMPDup_ApplyGroups_Rejected(t *testing.T) {
+	cases := []struct {
+		name string
+		term string
+		leaf string
+	}{
+		{"icmp-type", "term t1 protocol icmp icmp-type 8 icmp-type 0", "icmp-type"},
+		{"icmp-code", "term t1 protocol icmp icmp-type 3 icmp-code 1 icmp-code 2", "icmp-code"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tree := flatTreeFromSets(t,
+				"set groups g applications application dup "+c.term,
+				"set apply-groups g")
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("expected commit to REJECT an apply-groups term with conflicting %q", c.leaf)
+			}
+			if !strings.Contains(err.Error(), "duplicate") || !strings.Contains(err.Error(), c.leaf) {
+				t.Fatalf("error should name the duplicate leaf %q, got: %v", c.leaf, err)
+			}
+		})
+	}
+}
+
+// Fail-on-revert (security-adjacent): a REFERENCED deny application whose
+// inline term carries conflicting `icmp-type` values must be rejected at
+// commit. Revert the fix and the term silently keeps only the LAST value
+// (type 3), so the deny no longer covers echo (type 8) — that traffic falls
+// through to the default permit. Proven two ways: (1) strict CompileConfig
+// rejects; (2) on the lenient path (which still compiles, downgrading the
+// reject to a warning) the compiled term demonstrably enforces ONLY the last
+// type — the silent narrowing the strict gate exists to prevent.
+func TestApplicationTermICMPDup_ReferencedDeny_StrictRejects_LenientNarrows(t *testing.T) {
+	src := `
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy blockit {
+                match {
+                    source-address any;
+                    destination-address any;
+                    application badapp;
+                }
+                then {
+                    deny;
+                }
+            }
+        }
+        default-policy {
+            permit-all;
+        }
+    }
+}
+applications {
+    application badapp {
+        term t1 {
+            protocol icmp;
+            icmp-type 8;
+            icmp-type 3;
+        }
+    }
+}
+`
+	tree := hierTree(t, src)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatalf("expected commit to REJECT a referenced deny app with a conflicting inline icmp-type")
+	} else if !strings.Contains(err.Error(), "duplicate") || !strings.Contains(err.Error(), "icmp-type") {
+		t.Fatalf("error should flag the conflicting icmp-type duplicate, got: %v", err)
+	}
+
+	// Characterize the underlying keep-last narrowing the gate protects against:
+	// the lenient path still compiles (no-brick), and the compiled term carries
+	// ONLY the last value — echo (type 8) is no longer denied, so it falls
+	// through to the default permit.
+	cfg, lerr := CompileConfigLenient(tree)
+	if lerr != nil {
+		t.Fatalf("lenient path must NOT brick on a conflicting inline icmp-type: %v", lerr)
+	}
+	app := cfg.Applications.Applications["badapp-t1"]
+	if app == nil {
+		t.Fatalf("term application badapp-t1 missing on lenient path; have %v", appNames(cfg))
+	}
+	if app.ICMPType == nil || *app.ICMPType != 3 {
+		got := "nil"
+		if app.ICMPType != nil {
+			got = strconv.Itoa(int(*app.ICMPType))
+		}
+		t.Fatalf("keep-last narrowing characterization: want ICMPType=3 (the silently-retained "+
+			"last value), got %s", got)
+	}
+}
+
+// Guard against over-rejection of the value-aware idempotent path: an ICMP leaf
+// repeated with the SAME value is harmless (no value is silently lost) and must
+// COMMIT — only a CONFLICTING (different-value) repeat is rejected. Flip the
+// duplicate detection to value-blind (reject any repeat regardless of value)
+// and this assertion goes RED.
+func TestApplicationTermICMPDup_Idempotent_Accepted(t *testing.T) {
+	cases := []struct {
+		name     string
+		term     string
+		wantType uint8
+		wantCode *uint8
+	}{
+		{"same-icmp-type", "term t1 protocol icmp icmp-type 8 icmp-type 8", 8, nil},
+		{"same-icmp-code", "term t1 protocol icmp icmp-type 3 icmp-code 1 icmp-code 1", 3, u8p(1)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tree := flatTreeFromSets(t, unrefAppOnly("idem", c.term)...)
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("an idempotent same-value repeat must COMMIT (only a "+
+					"conflicting different-value repeat is rejected), got: %v", err)
+			}
+			app := cfg.Applications.Applications["idem-t1"]
+			if app == nil {
+				t.Fatalf("term application idem-t1 missing; have %v", appNames(cfg))
+			}
+			if app.ICMPType == nil || *app.ICMPType != c.wantType {
+				t.Fatalf("the single icmp-type value must survive, want %d got %v", c.wantType, app.ICMPType)
+			}
+			if c.wantCode == nil {
+				if app.ICMPCode != nil {
+					t.Fatalf("no icmp-code authored, want nil got %d", *app.ICMPCode)
+				}
+			} else if app.ICMPCode == nil || *app.ICMPCode != *c.wantCode {
+				t.Fatalf("the single icmp-code value must survive, want %d got %v", *c.wantCode, app.ICMPCode)
+			}
+		})
+	}
+}
+
+// The tolerant load / peer-sync path (CompileConfigLenient) must NOT brick on a
+// conflicting inline-term ICMP repeat an older binary persisted — it downgrades
+// the reject to a warning so the daemon still boots (#1960 no-brick). Revert
+// the lenient downgrade and this goes RED.
+func TestApplicationTermICMPDup_Lenient_DowngradesToWarning(t *testing.T) {
+	tree := flatTreeFromSets(t, unrefAppOnly("dup",
+		"term t1 protocol icmp icmp-type 8 icmp-type 0")...)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient path must NOT fail on a conflicting inline icmp-type (no-brick): %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "application structure") && strings.Contains(w, "duplicate") &&
+			strings.Contains(w, "icmp-type") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient path must record a downgrade warning naming icmp-type; warnings: %v", cfg.Warnings)
+	}
+}

--- a/pkg/config/compiler_application_term_icmp_dup_6766_test.go
+++ b/pkg/config/compiler_application_term_icmp_dup_6766_test.go
@@ -51,6 +51,33 @@ func TestApplicationTermICMPDup_FlatSet_Rejected(t *testing.T) {
 			}
 		})
 	}
+
+	// Positive control (#6766 fold). A rejection test alone cannot distinguish
+	// "rejects the conflicting repeat" from "rejects this whole shape": a
+	// regression that refused every packed flat-set ICMP term would satisfy
+	// every assertion above. These shape-matched VALID terms — same packed
+	// one-line flat-set form, non-conflicting values — must still commit.
+	t.Run("positive control: valid packed flat-set terms still commit", func(t *testing.T) {
+		for _, c := range []struct {
+			name     string
+			term     string
+			wantType uint8
+			wantCode *uint8
+		}{
+			{"single icmp-type", "term t1 protocol icmp icmp-type 8", 8, nil},
+			{"icmp-type plus icmp-code", "term t1 protocol icmp icmp-type 3 icmp-code 1", 3, u8p(1)},
+		} {
+			t.Run(c.name, func(t *testing.T) {
+				tree := flatTreeFromSets(t, unrefAppOnly("okapp", c.term)...)
+				cfg, err := CompileConfig(tree)
+				if err != nil {
+					t.Fatalf("a NON-conflicting packed flat-set ICMP term must COMMIT — "+
+						"the gate rejects a conflicting repeat, not the shape: %v", err)
+				}
+				assertTermICMP(t, cfg, "okapp-t1", c.wantType, c.wantCode)
+			})
+		}
+	})
 }
 
 // Hierarchical shape: the same conflict authored as sibling statements inside a
@@ -77,6 +104,33 @@ func TestApplicationTermICMPDup_Hierarchical_Rejected(t *testing.T) {
 			}
 		})
 	}
+
+	// Positive control (#6766 fold). Without this, a shape-specific regression
+	// that rejected EVERY brace-block term — e.g. a reassembly change that
+	// mistook each sibling statement for a repeat of its predecessor — would
+	// pass the rejection assertions above while breaking all hierarchical ICMP
+	// terms. The valid sibling forms must still commit.
+	t.Run("positive control: valid hierarchical terms still commit", func(t *testing.T) {
+		for _, c := range []struct {
+			name     string
+			body     string
+			wantType uint8
+			wantCode *uint8
+		}{
+			{"single icmp-type", "term t1 { protocol icmp; icmp-type 8; }", 8, nil},
+			{"icmp-type plus icmp-code", "term t1 { protocol icmp; icmp-type 3; icmp-code 1; }", 3, u8p(1)},
+		} {
+			t.Run(c.name, func(t *testing.T) {
+				tree := hierTree(t, "applications {\n    application okapp {\n        "+c.body+"\n    }\n}\n")
+				cfg, err := CompileConfig(tree)
+				if err != nil {
+					t.Fatalf("a NON-conflicting hierarchical ICMP term must COMMIT — the "+
+						"gate rejects a conflicting repeat, not sibling statements: %v", err)
+				}
+				assertTermICMP(t, cfg, "okapp-t1", c.wantType, c.wantCode)
+			})
+		}
+	})
 }
 
 // apply-groups shape: a group-authored term carrying the conflicting repeat is
@@ -106,16 +160,63 @@ func TestApplicationTermICMPDup_ApplyGroups_Rejected(t *testing.T) {
 			}
 		})
 	}
+
+	// Positive control 1 (#6766 fold): a group-authored term with NO conflict
+	// must still be cloned in and commit. The rejection cases above carry both
+	// conflicting values inside the group, so on their own they cannot tell
+	// "rejects the conflict" from "rejects anything arriving via apply-groups".
+	t.Run("positive control: valid group-authored term still commits", func(t *testing.T) {
+		tree := flatTreeFromSets(t,
+			"set groups g applications application okapp term t1 protocol icmp icmp-type 3 icmp-code 1",
+			"set apply-groups g")
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("a NON-conflicting group-authored ICMP term must COMMIT: %v", err)
+		}
+		assertTermICMP(t, cfg, "okapp-t1", 3, u8p(1))
+	})
+
+	// Positive control 2 (#6766 fold) — the CROSS-SOURCE case the rejection
+	// tests never reach. A group value restated locally is not a duplicate: it
+	// is the documented apply-groups override, where the group supplies a
+	// default and the local stanza wins. The local `term t1` REPLACES the
+	// group's outright, so the group's icmp-code must not leak into the merged
+	// term either. An edit that folded the two sources into one token stream
+	// would both reject this (spurious duplicate) and surface icmp-code 5, and
+	// nothing else in this file would notice.
+	t.Run("positive control: local term overrides a group term without a false duplicate", func(t *testing.T) {
+		tree := flatTreeFromSets(t,
+			"set groups g applications application ovr term t1 protocol icmp icmp-type 8 icmp-code 5",
+			"set apply-groups g",
+			"set applications application ovr term t1 protocol icmp icmp-type 3")
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("a local term restating a group-inherited icmp-type is an apply-groups "+
+				"OVERRIDE, not a conflicting repeat, and must COMMIT: %v", err)
+		}
+		// Local wins; the group's icmp-code does not survive the replacement.
+		assertTermICMP(t, cfg, "ovr-t1", 3, nil)
+	})
 }
 
 // Fail-on-revert (security-adjacent): a REFERENCED deny application whose
 // inline term carries conflicting `icmp-type` values must be rejected at
 // commit. Revert the fix and the term silently keeps only the LAST value
-// (type 3), so the deny no longer covers echo (type 8) — that traffic falls
-// through to the default permit. Proven two ways: (1) strict CompileConfig
-// rejects; (2) on the lenient path (which still compiles, downgrading the
-// reject to a warning) the compiled term demonstrably enforces ONLY the last
-// type — the silent narrowing the strict gate exists to prevent.
+// (type 3), so the deny no longer covers echo (type 8).
+//
+// Scope of what this test proves (#6766 fold): (1) strict CompileConfig
+// rejects; (2) on the lenient path — which still compiles, downgrading the
+// reject to a warning — the compiled Application carries ONLY the last
+// authored value, for icmp-type AND icmp-code.
+//
+// It asserts on the COMPILED STRUCT, not on a policy decision. It does not
+// exercise either matcher, so it cannot by itself show that the surviving
+// value is what gets enforced or that the discarded value escapes the deny.
+// That enforcement claim is proven separately, at the verdict, in
+// pkg/policymatch/app_inline_term_icmp_dup_6766_test.go, which drives
+// policymatch.Match and asserts the discarded type/code falls through to
+// `default-policy permit-all`. Keep this comment's claim and that file's in
+// sync — do not restate the enforcement conclusion here.
 func TestApplicationTermICMPDup_ReferencedDeny_StrictRejects_LenientNarrows(t *testing.T) {
 	src := `
 security {
@@ -177,6 +278,46 @@ applications {
 		}
 		t.Fatalf("keep-last narrowing characterization: want ICMPType=3 (the silently-retained "+
 			"last value), got %s", got)
+	}
+}
+
+// The icmp-CODE analogue of the characterization above (#6766 fold). Before
+// this, conflicting `icmp-code` was exercised ONLY on strict rejection paths:
+// every test asserted that a conflict is refused, none asserted which value
+// survives when it is TOLERATED. A production edit that retained the FIRST
+// conflicting code instead of the last therefore passed the entire file while
+// changing which traffic a referenced deny covers. This pins the surviving
+// value; the matching verdict-level guard is in
+// pkg/policymatch/app_inline_term_icmp_dup_6766_test.go.
+func TestApplicationTermICMPDup_LenientKeepsLastCode(t *testing.T) {
+	tree := flatTreeFromSets(t, unrefAppOnly("dup",
+		"term t1 protocol icmp icmp-type 3 icmp-code 1 icmp-code 2")...)
+
+	// Strict still refuses the conflict.
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatalf("strict commit must REJECT a conflicting inline icmp-code")
+	}
+
+	cfg, lerr := CompileConfigLenient(tree)
+	if lerr != nil {
+		t.Fatalf("lenient path must NOT brick on a conflicting inline icmp-code: %v", lerr)
+	}
+	app := cfg.Applications.Applications["dup-t1"]
+	if app == nil {
+		t.Fatalf("term application dup-t1 missing on lenient path; have %v", appNames(cfg))
+	}
+	if app.ICMPCode == nil || *app.ICMPCode != 2 {
+		got := "nil"
+		if app.ICMPCode != nil {
+			got = strconv.Itoa(int(*app.ICMPCode))
+		}
+		t.Fatalf("keep-last narrowing characterization: want ICMPCode=2 (the silently-retained "+
+			"LAST value), got %s — a keep-FIRST regression reports 1 here and silently "+
+			"changes which ICMP traffic a referenced deny covers", got)
+	}
+	// The type is untouched by the code conflict.
+	if app.ICMPType == nil || *app.ICMPType != 3 {
+		t.Fatalf("ICMPType = %v, want 3 (unaffected by the icmp-code conflict)", app.ICMPType)
 	}
 }
 
@@ -242,5 +383,27 @@ func TestApplicationTermICMPDup_Lenient_DowngradesToWarning(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("lenient path must record a downgrade warning naming icmp-type; warnings: %v", cfg.Warnings)
+	}
+}
+
+// assertTermICMP checks the compiled inline-term application's ICMP constraints.
+// wantCode == nil asserts the term left icmp-code unconstrained.
+func assertTermICMP(t *testing.T, cfg *Config, appName string, wantType uint8, wantCode *uint8) {
+	t.Helper()
+	app := cfg.Applications.Applications[appName]
+	if app == nil {
+		t.Fatalf("term application %s missing; have %v", appName, appNames(cfg))
+	}
+	if app.ICMPType == nil || *app.ICMPType != wantType {
+		t.Fatalf("%s ICMPType = %v, want %d", appName, app.ICMPType, wantType)
+	}
+	if wantCode == nil {
+		if app.ICMPCode != nil {
+			t.Fatalf("%s ICMPCode = %d, want unconstrained (nil)", appName, *app.ICMPCode)
+		}
+		return
+	}
+	if app.ICMPCode == nil || *app.ICMPCode != *wantCode {
+		t.Fatalf("%s ICMPCode = %v, want %d", appName, app.ICMPCode, *wantCode)
 	}
 }

--- a/pkg/config/compiler_application_term_icmp_dup_6766_test.go
+++ b/pkg/config/compiler_application_term_icmp_dup_6766_test.go
@@ -25,6 +25,17 @@ import (
 // group-authored packed term merged into the stanza). All three reassemble to
 // the same parseApplicationTerms token stream via applicationTermKeys.
 
+// #6814: the leaf name is matched in its QUOTED form throughout this file. The
+// rejection message ends with a STATIC enumeration of every trackable leaf —
+// "(destination-port / source-port / inactivity-timeout / timeout / alg /
+// icmp-type / icmp-code)" — so a bare substring check for the leaf name is
+// satisfied by that boilerplate no matter which leaf actually conflicted, and a
+// swapped label sails through. Only the identifying occurrence is quoted
+// (`conflicting duplicate "icmp-type" inside`), so the quotes are what make
+// "the error names the leaf" an assertion rather than a coincidence. Proven by
+// swapping the two recorded labels in parseApplicationTerms: the quoted form
+// reds all three rejection tests, the bare form passes them.
+//
 // Core fail-on-revert, packed flat-set shape: a conflicting icmp-type /
 // icmp-code repeat inside one inline term must be REJECTED at commit, with the
 // error naming the leaf. Revert the duplicate tracking and the second value
@@ -46,7 +57,7 @@ func TestApplicationTermICMPDup_FlatSet_Rejected(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected commit to REJECT conflicting duplicate %q inside a term", c.leaf)
 			}
-			if !strings.Contains(err.Error(), "duplicate") || !strings.Contains(err.Error(), c.leaf) {
+			if !strings.Contains(err.Error(), "duplicate") || !strings.Contains(err.Error(), `"`+c.leaf+`"`) {
 				t.Fatalf("error should name the duplicate leaf %q, got: %v", c.leaf, err)
 			}
 		})
@@ -99,7 +110,7 @@ func TestApplicationTermICMPDup_Hierarchical_Rejected(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected commit to REJECT conflicting duplicate %q inside a hierarchical term", c.leaf)
 			}
-			if !strings.Contains(err.Error(), "duplicate") || !strings.Contains(err.Error(), c.leaf) {
+			if !strings.Contains(err.Error(), "duplicate") || !strings.Contains(err.Error(), `"`+c.leaf+`"`) {
 				t.Fatalf("error should name the duplicate leaf %q, got: %v", c.leaf, err)
 			}
 		})
@@ -155,7 +166,7 @@ func TestApplicationTermICMPDup_ApplyGroups_Rejected(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected commit to REJECT an apply-groups term with conflicting %q", c.leaf)
 			}
-			if !strings.Contains(err.Error(), "duplicate") || !strings.Contains(err.Error(), c.leaf) {
+			if !strings.Contains(err.Error(), "duplicate") || !strings.Contains(err.Error(), `"`+c.leaf+`"`) {
 				t.Fatalf("error should name the duplicate leaf %q, got: %v", c.leaf, err)
 			}
 		})

--- a/pkg/config/compiler_application_term_icmp_dup_6766_test.go
+++ b/pkg/config/compiler_application_term_icmp_dup_6766_test.go
@@ -25,16 +25,32 @@ import (
 // group-authored packed term merged into the stanza). All three reassemble to
 // the same parseApplicationTerms token stream via applicationTermKeys.
 
-// #6814: the leaf name is matched in its QUOTED form throughout this file. The
-// rejection message ends with a STATIC enumeration of every trackable leaf —
-// "(destination-port / source-port / inactivity-timeout / timeout / alg /
-// icmp-type / icmp-code)" — so a bare substring check for the leaf name is
-// satisfied by that boilerplate no matter which leaf actually conflicted, and a
-// swapped label sails through. Only the identifying occurrence is quoted
-// (`conflicting duplicate "icmp-type" inside`), so the quotes are what make
-// "the error names the leaf" an assertion rather than a coincidence. Proven by
-// swapping the two recorded labels in parseApplicationTerms: the quoted form
-// reds all three rejection tests, the bare form passes them.
+// #6814: the leaf name is matched in its QUOTED form at every site in this file
+// that asserts WHICH leaf was flagged. The rejection message ends with a STATIC
+// enumeration of every trackable leaf — "(destination-port / source-port /
+// inactivity-timeout / timeout / alg / icmp-type / icmp-code)" — so a bare
+// substring check for the leaf name is satisfied by that boilerplate no matter
+// which leaf actually conflicted, and a swapped label sails through. Only the
+// identifying occurrence is quoted (`conflicting duplicate "icmp-type" inside`,
+// rendered by the `%q` of DuplicateTermLeaves[0] in
+// compiler_validate_strict_application.go — the enumeration beside it is
+// unquoted), so the quotes are what make "the error names the leaf" an
+// assertion rather than a coincidence.
+//
+// There are FIVE such sites, and the count is stated so this claim stays
+// checkable: four rejection assertions — the three table-driven ones plus
+// ReferencedDeny_StrictRejects_LenientNarrows, which hardcodes its leaf name
+// instead of taking it from a case table — and one tolerant-path warning
+// assertion in Lenient_DowngradesToWarning. The first three were quoted before
+// the other two, because a grep for the table-driven `c.leaf` form structurally
+// cannot find a hardcoded string literal; the swapped-label mutation finds
+// every shape.
+//
+// Proven by swapping the two recorded labels in parseApplicationTerms: with the
+// quoted form all five sites RED, with the bare form all five PASS. The
+// positive controls stay GREEN under that mutation — they author no conflict,
+// so they have no label to swap, which is what shows the mutation is scoped to
+// the leaf-identity path rather than breaking the package.
 //
 // Core fail-on-revert, packed flat-set shape: a conflicting icmp-type /
 // icmp-code repeat inside one inline term must be REJECTED at commit, with the
@@ -274,7 +290,7 @@ applications {
 	tree := hierTree(t, src)
 	if _, err := CompileConfig(tree); err == nil {
 		t.Fatalf("expected commit to REJECT a referenced deny app with a conflicting inline icmp-type")
-	} else if !strings.Contains(err.Error(), "duplicate") || !strings.Contains(err.Error(), "icmp-type") {
+	} else if !strings.Contains(err.Error(), "duplicate") || !strings.Contains(err.Error(), `"icmp-type"`) {
 		t.Fatalf("error should flag the conflicting icmp-type duplicate, got: %v", err)
 	}
 
@@ -395,7 +411,7 @@ func TestApplicationTermICMPDup_Lenient_DowngradesToWarning(t *testing.T) {
 	found := false
 	for _, w := range cfg.Warnings {
 		if strings.Contains(w, "application structure") && strings.Contains(w, "duplicate") &&
-			strings.Contains(w, "icmp-type") {
+			strings.Contains(w, `"icmp-type"`) {
 			found = true
 			break
 		}

--- a/pkg/config/compiler_application_term_icmp_dup_6766_test.go
+++ b/pkg/config/compiler_application_term_icmp_dup_6766_test.go
@@ -239,10 +239,19 @@ func TestApplicationTermICMPDup_ApplyGroups_Rejected(t *testing.T) {
 // commit. Revert the fix and the term silently keeps only the LAST value
 // (type 3), so the deny no longer covers echo (type 8).
 //
-// Scope of what this test proves (#6766 fold): (1) strict CompileConfig
-// rejects; (2) on the lenient path — which still compiles, downgrading the
-// reject to a warning — the compiled Application carries ONLY the last
-// authored value, for icmp-type AND icmp-code.
+// Scope of what this test proves (#6766 fold, narrowed in #6814): (1) strict
+// CompileConfig rejects; (2) on the lenient path — which still compiles,
+// downgrading the reject to a warning — the compiled Application carries ONLY
+// the last authored value.
+//
+// For icmp-TYPE only. This test's config authors a single conflicting leaf
+// (`icmp-type 8` then `icmp-type 3`), so it says nothing about icmp-code; an
+// earlier version of this comment claimed both, which a code-only keep-first
+// edit on the CODE arm would have satisfied. The icmp-code half is bound by
+// TestApplicationTermICMPDup_LenientKeepsLastCode below, and both leaves are
+// bound at the verdict in
+// pkg/policymatch/app_inline_term_icmp_dup_6766_test.go. The property is
+// covered; it is just not covered HERE, which is what the claim got wrong.
 //
 // It asserts on the COMPILED STRUCT, not on a policy decision. It does not
 // exercise either matcher, so it cannot by itself show that the surviving
@@ -296,8 +305,20 @@ applications {
 
 	// Characterize the underlying keep-last narrowing the gate protects against:
 	// the lenient path still compiles (no-brick), and the compiled term carries
-	// ONLY the last value — echo (type 8) is no longer denied, so it falls
-	// through to the default permit.
+	// ONLY the last value.
+	//
+	// #6814: this reads the compiled STRUCT and never invokes a matcher, so it
+	// cannot show what happens to echo (type 8) on the wire. An earlier version
+	// of this comment said echo "falls through to the default permit" — which
+	// contradicted this function's own header two dozen lines up, and the
+	// header was the correct half. A matcher edit that ignored ICMPType
+	// entirely would leave every assertion below green.
+	//
+	// That is worth naming rather than quietly rewording: it is the exact
+	// defect class this PR exists to fix — a claim that a check discriminates
+	// something it never reaches — turned inward on the PR's own test file. The
+	// fall-through IS proven, at the verdict, by
+	// pkg/policymatch/app_inline_term_icmp_dup_6766_test.go.
 	cfg, lerr := CompileConfigLenient(tree)
 	if lerr != nil {
 		t.Fatalf("lenient path must NOT brick on a conflicting inline icmp-type: %v", lerr)

--- a/pkg/config/compiler_application_term_icmp_dup_6766_test.go
+++ b/pkg/config/compiler_application_term_icmp_dup_6766_test.go
@@ -188,14 +188,22 @@ func TestApplicationTermICMPDup_ApplyGroups_Rejected(t *testing.T) {
 		tree := flatTreeFromSets(t,
 			"set groups g applications application ovr term t1 protocol icmp icmp-type 8 icmp-code 5",
 			"set apply-groups g",
-			"set applications application ovr term t1 protocol icmp icmp-type 3")
+			// The local value is deliberately 0 (echo-reply), the SCALAR ZERO of
+			// the compiled uint8 (#6814 gate). assertTermICMP rejects a nil
+			// ICMPType outright, so "committed the local 0" and "compiled
+			// nothing" cannot be confused here — the nil check carries the
+			// weight a non-zero value would otherwise have to. That makes this
+			// control bind the zero value itself: a compiler that dropped the
+			// local statement, or that let the group's 8 win, is caught, and so
+			// is one that treats a committed 0 as "unset".
+			"set applications application ovr term t1 protocol icmp icmp-type 0")
 		cfg, err := CompileConfig(tree)
 		if err != nil {
 			t.Fatalf("a local term restating a group-inherited icmp-type is an apply-groups "+
 				"OVERRIDE, not a conflicting repeat, and must COMMIT: %v", err)
 		}
 		// Local wins; the group's icmp-code does not survive the replacement.
-		assertTermICMP(t, cfg, "ovr-t1", 3, nil)
+		assertTermICMP(t, cfg, "ovr-t1", 0, nil)
 	})
 }
 

--- a/pkg/config/compiler_applications.go
+++ b/pkg/config/compiler_applications.go
@@ -338,7 +338,8 @@ func compileApplications(node *Node, apps *ApplicationsConfig) error {
 		hasDirectBody := false
 		// #5574: value-aware conflict tracking for the DIRECT (scalar) match body,
 		// mirroring the inline-term duplicate detection in parseApplicationTerms
-		// (dstPortSet / srcPortSet / algSet / timeoutSet -> DuplicateTermLeaves). A
+		// (dstPortSet / srcPortSet / algSet / timeoutSet / icmpTypeSet /
+		// icmpCodeSet -> DuplicateTermLeaves). A
 		// direct application stores each scalar leaf into a SINGLE typed field, so
 		// two conflicting sibling leaves (protocol tcp; protocol udp;
 		// destination-port 22; destination-port 53) were last-writer-wins — only
@@ -605,8 +606,15 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 	// the `timeout` / `inactivity-timeout` aliases both set to 1800) is harmless
 	// and accepted. `protocol` is deliberately EXCLUDED — a repeated `protocol` is
 	// the documented multi-protocol-term syntax (one Application per unique
-	// protocol), not a duplicate.
+	// protocol), not a duplicate. #6766: the #3366 framework omitted the ICMP
+	// leaves — a conflicting `icmp-type` / `icmp-code` repeat overwrote the
+	// pointer with no record, so a referenced deny enforced only the LAST
+	// type/code; they are now tracked like the ports (malformed tokens keep the
+	// badICMP / UnknownICMP path — duplicate tracking applies only to values
+	// that parse).
 	dstPortSet, srcPortSet, algSet, timeoutSet := false, false, false, false
+	icmpTypeSet, icmpCodeSet := false, false
+	var icmpTypeVal, icmpCodeVal uint8
 	var dupTermLeaves []string
 	// #3352: tokens inside the inline term that are not a recognized leaf.
 	// The term subtree is opaque to SchemaValidate (children:nil), so without
@@ -650,6 +658,14 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 			if i+1 < len(keys) {
 				i++
 				if t, ok := parseICMPTypeCode(keys[i]); ok {
+					// #6766: value-aware duplicate tracking, mirroring the
+					// ports above — a conflicting repeat is recorded for the
+					// strict structure gate; an idempotent same-value repeat
+					// is accepted.
+					if icmpTypeSet && *t != icmpTypeVal {
+						dupTermLeaves = append(dupTermLeaves, "icmp-type")
+					}
+					icmpTypeSet, icmpTypeVal = true, *t
 					icmpType = t
 				} else {
 					// #3348: a malformed inline-term icmp-type. The schema does
@@ -663,6 +679,10 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 			if i+1 < len(keys) {
 				i++
 				if c, ok := parseICMPTypeCode(keys[i]); ok {
+					if icmpCodeSet && *c != icmpCodeVal {
+						dupTermLeaves = append(dupTermLeaves, "icmp-code")
+					}
+					icmpCodeSet, icmpCodeVal = true, *c
 					icmpCode = c
 				} else {
 					badICMP = append(badICMP, keys[i])

--- a/pkg/config/compiler_applications.go
+++ b/pkg/config/compiler_applications.go
@@ -600,9 +600,19 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 	// DIFFERENT value — via apply-groups, flat-set ordering, or hand authoring —
 	// was last-writer-wins: the loop below overwrote the earlier value with no
 	// validation, silently narrowing (or widening) the term to the final token by
-	// parse order. Track each scalar leaf's first assigned value so a CONFLICTING
-	// repeat (a new value that silently discards the earlier one) is recorded for
-	// the strict structure gate. An idempotent repeat (the same value again, e.g.
+	// parse order. Each scalar leaf carries a companion `<leaf>Set` flag and a
+	// `<leaf>Val` holding the MOST RECENTLY assigned value — not the first: every
+	// arm refreshes its comparison value after recording, so the check is
+	// "differs from its immediate predecessor", i.e. one record per TRANSITION.
+	// `8, 3, 8` therefore records TWO conflicts, where comparing every later value
+	// against the first would record one. Nothing observable depends on that
+	// difference: acceptance is identical (any sequence carrying more than one
+	// distinct value contains at least one transition, so the strict gate rejects
+	// it, and an idempotent run records nothing either way), and the gate reports
+	// only `DuplicateTermLeaves[0]` (compiler_validate_strict_application.go), so
+	// the extra records never reach the error text. Treat the slice as a
+	// non-empty/empty signal carrying one representative leaf name, NOT as a
+	// conflict tally. An idempotent repeat (the same value again, e.g.
 	// the `timeout` / `inactivity-timeout` aliases both set to 1800) is harmless
 	// and accepted. `protocol` is deliberately EXCLUDED — a repeated `protocol` is
 	// the documented multi-protocol-term syntax (one Application per unique

--- a/pkg/config/compiler_validate_strict_application.go
+++ b/pkg/config/compiler_validate_strict_application.go
@@ -524,7 +524,8 @@ func validateApplicationSyntaxStrict(cfg *Config) error {
 //     parent name on cfg.Applications.MixedDirectTermApps.
 //
 //   - #3366 duplicate scalar term leaf: a single-valued leaf (destination-port /
-//     source-port / inactivity-timeout / timeout / alg) repeated with a
+//     source-port / inactivity-timeout / timeout / alg, and — since #6766 —
+//     icmp-type / icmp-code) repeated with a
 //     CONFLICTING value inside one inline term. The term is opaque to the
 //     SchemaValidate walk, so the repeat was last-writer-wins — the earlier value
 //     silently overwritten by parse order, narrowing/widening the term with no
@@ -589,7 +590,7 @@ func validateApplicationStructureStrict(cfg *Config) error {
 				return fmt.Errorf(
 					"application %q: conflicting duplicate %q inside `term`; a single-valued "+
 						"term leaf (destination-port / source-port / inactivity-timeout / "+
-						"timeout / alg) may carry only one value — a repeat with a different "+
+						"timeout / alg / icmp-type / icmp-code) may carry only one value — a repeat with a different "+
 						"value is last-writer-wins and silently overrides the earlier one by "+
 						"token order (use repeated `protocol` only for an intentional "+
 						"multi-protocol term)",

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -1223,7 +1223,8 @@ type Application struct {
 	// (#3352).
 	UnknownTermLeaves []string
 	// DuplicateTermLeaves records the names of single-valued (scalar) leaves
-	// (destination-port / source-port / inactivity-timeout / timeout / alg) that
+	// (destination-port / source-port / inactivity-timeout / timeout / alg /
+	// icmp-type / icmp-code) that
 	// appeared MORE THAN ONCE with a CONFLICTING (different) value inside one
 	// inline `application <a> term <t>`. The inline term is opaque to the
 	// SchemaValidate walk, so a repeated scalar leaf — via apply-groups, flat-set
@@ -1236,7 +1237,9 @@ type Application struct {
 	// multi-protocol-term syntax. Mirroring UnknownTermLeaves, the offending leaf
 	// name is recorded and the deferred gate (validateApplicationStructureStrict)
 	// hard-rejects the first one on the strict commit path / warns on the tolerant
-	// load / peer-sync path (#3366).
+	// load / peer-sync path (#3366; icmp-type / icmp-code added in #6766 — their
+	// omission let a conflicting repeat silently narrow a referenced deny to the
+	// LAST type/code).
 	DuplicateTermLeaves []string
 	// DuplicateDirectLeaves records the names of single-valued (scalar) DIRECT
 	// match leaves (protocol / destination-port / source-port / inactivity-timeout

--- a/pkg/policymatch/app_inline_term_icmp_dup_6766_test.go
+++ b/pkg/policymatch/app_inline_term_icmp_dup_6766_test.go
@@ -74,8 +74,16 @@ func inlineICMPDupCfg(t *testing.T, appLine, leaf string) *config.Config {
 			"the #6766 duplicate recording is gone and the narrowing below is "+
 			"reachable through a green commit", leaf)
 	}
-	if !strings.Contains(serr.Error(), "duplicate") || !strings.Contains(serr.Error(), leaf) {
-		t.Fatalf("strict rejection should name the duplicate leaf %q, got: %v", leaf, serr)
+	// The leaf name is matched in its QUOTED form. The rejection text ends with a
+	// static enumeration of every trackable leaf —
+	// "(destination-port / source-port / ... / icmp-type / icmp-code)" — so a bare
+	// substring check for the leaf is satisfied by that boilerplate no matter
+	// which leaf actually conflicted, and a swapped label would sail through.
+	// Only the identifying occurrence is quoted (`conflicting duplicate
+	// "icmp-type" inside`), so quoting is what makes "names the leaf" true.
+	if !strings.Contains(serr.Error(), "duplicate") || !strings.Contains(serr.Error(), `"`+leaf+`"`) {
+		t.Fatalf("strict rejection should name the duplicate leaf %q (quoted, so the "+
+			"static leaf enumeration in the message cannot satisfy this), got: %v", leaf, serr)
 	}
 
 	cfg, err := config.CompileConfigLenient(tree)
@@ -87,7 +95,8 @@ func inlineICMPDupCfg(t *testing.T, appLine, leaf string) *config.Config {
 	// contract these verdict tests characterize.
 	warned := false
 	for _, w := range cfg.Warnings {
-		if strings.Contains(w, "duplicate") && strings.Contains(w, leaf) {
+		// Quoted, for the same reason as the strict assertion above.
+		if strings.Contains(w, "duplicate") && strings.Contains(w, `"`+leaf+`"`) {
 			warned = true
 			break
 		}
@@ -174,11 +183,17 @@ func TestInlineTermICMPCodeDupNarrowsEnforcement_6766(t *testing.T) {
 // populated at all — a path that produced NOTHING looks identical to a genuine
 // fall-through. `DefaultUsed` is the only field here that carries non-default
 // evidence: it is true ONLY because the default-policy branch actually ran. It
-// is asserted FIRST for that reason, and `Matched=false` is asserted explicitly
-// rather than left implied, which also rejects the
-// `Matched=true, DefaultUsed=false, Action=permit` shape — a concrete policy
-// PERMIT, which is a different (and equally wrong) outcome from falling
-// through.
+// is asserted FIRST for that reason.
+//
+// `Matched=false` is asserted explicitly rather than left implied, and the shape
+// it independently binds is `Matched=true, DefaultUsed=true, Action=permit` — a
+// Result claiming BOTH a concrete policy match and a default fall-through, which
+// is incoherent and would otherwise pass. It does NOT carry
+// `Matched=true, DefaultUsed=false`: that input fails at the `DefaultUsed` check
+// above and never reaches here. Stated precisely because the two legs look
+// redundant and are not — the mutation that proves this one sets Matched on the
+// default-branch Result, and a later reader trimming the "redundant" check would
+// delete the only assertion binding it.
 func assertFellThroughToDefaultPermit(t *testing.T, res Result, what string) {
 	t.Helper()
 	if !res.DefaultUsed {

--- a/pkg/policymatch/app_inline_term_icmp_dup_6766_test.go
+++ b/pkg/policymatch/app_inline_term_icmp_dup_6766_test.go
@@ -1,0 +1,141 @@
+package policymatch
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6766 review fold — the VERDICT-level guard on inline-term ICMP duplicate
+// narrowing.
+//
+// The strict gate rejects a conflicting `icmp-type` / `icmp-code` repeat inside
+// one inline term, but the TOLERANT path (boot load / HA SyncApply) downgrades
+// that reject to a warning and keeps enforcing whatever compiled. So on the
+// path that actually forwards packets, WHICH of the conflicting values survives
+// is an enforcement outcome, not bookkeeping: the surviving value is the only
+// one the deny covers, and every other value falls through to
+// `default-policy permit-all`.
+//
+// The pkg/config tests assert on the compiled Application struct. That binds the
+// compiler but not the matcher, and it left the icmp-CODE last-writer
+// unconstrained entirely: a production edit that retained the FIRST conflicting
+// code instead of the last would satisfy every strict-rejection test, because
+// those only assert that a conflict is refused, never which value wins when it
+// is tolerated. These tests pin the surviving value for type AND code by
+// driving the real matcher, so a keep-first regression flips a concrete
+// permit/deny verdict rather than a struct field.
+//
+// RED-on-revert: drop the #6766 duplicate tracking and the strict gate stops
+// rejecting, but these tests still hold — they characterize the tolerated
+// narrowing, which is the thing the gate exists to prevent. Change the
+// surviving value (keep-first instead of keep-last) and every subtest below
+// inverts: the value expected to be DENIED is permitted and vice versa.
+
+// inlineICMPDupCfg builds a deny policy referencing an application whose single
+// inline term repeats an ICMP leaf with conflicting values, then compiles it on
+// the TOLERANT path (the strict path rejects it by design).
+func inlineICMPDupCfg(t *testing.T, appLine string) *config.Config {
+	t.Helper()
+	tree := &config.ConfigTree{}
+	for _, cmd := range []string{
+		appLine,
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies from-zone trust to-zone untrust policy blockit match source-address any",
+		"set security policies from-zone trust to-zone untrust policy blockit match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy blockit match application badapp",
+		"set security policies from-zone trust to-zone untrust policy blockit then deny",
+		// permit-all is what the narrowed-away traffic escapes into. It is the
+		// reason the narrowing is a fail-OPEN and not merely a lost match.
+		"set security policies default-policy permit-all",
+	} {
+		path, err := config.ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := config.CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must not brick on a conflicting inline ICMP repeat: %v", err)
+	}
+	return cfg
+}
+
+func icmpQuery(icmpType, icmpCode *uint8) Query {
+	return Query{
+		FromZone: "trust", ToZone: "untrust",
+		SrcIP: net.ParseIP("10.0.1.5"), DstIP: net.ParseIP("10.0.2.5"),
+		Protocol: "icmp",
+		ICMPType: icmpType, ICMPCode: icmpCode,
+	}
+}
+
+// TestInlineTermICMPTypeDupNarrowsEnforcement_6766 pins which conflicting
+// icmp-TYPE survives on the tolerant path, at the verdict.
+func TestInlineTermICMPTypeDupNarrowsEnforcement_6766(t *testing.T) {
+	// Authored `icmp-type 8` then `icmp-type 3`: last-writer-wins keeps 3.
+	cfg := inlineICMPDupCfg(t,
+		"set applications application badapp term t1 protocol icmp icmp-type 8 icmp-type 3")
+
+	t.Run("last authored type is the one enforced", func(t *testing.T) {
+		res := Match(cfg, icmpQuery(u8(3), nil))
+		if !res.Matched || res.Action != config.PolicyDeny {
+			t.Fatalf("ICMP type 3 (the LAST authored icmp-type) must hit the deny; "+
+				"got matched=%v action=%v default_used=%v. If type 3 is NOT denied "+
+				"while type 8 IS, the compiler kept the FIRST conflicting value and "+
+				"the last-writer contract these tests pin has inverted",
+				res.Matched, res.Action, res.DefaultUsed)
+		}
+	})
+
+	t.Run("first authored type escapes into default permit-all", func(t *testing.T) {
+		res := Match(cfg, icmpQuery(u8(8), nil))
+		if res.Matched && res.Action == config.PolicyDeny {
+			t.Fatalf("ICMP type 8 (the FIRST authored icmp-type) was DENIED — the term " +
+				"did not narrow to the last value, so this characterization is stale")
+		}
+		if res.Action != config.PolicyPermit {
+			t.Fatalf("ICMP type 8 must fall through to default-policy permit-all "+
+				"(this IS the silent narrowing the strict gate prevents); got action=%v "+
+				"matched=%v default_used=%v", res.Action, res.Matched, res.DefaultUsed)
+		}
+	})
+}
+
+// TestInlineTermICMPCodeDupNarrowsEnforcement_6766 is the icmp-CODE analogue,
+// and is the specific gap the strict-rejection tests left open: nothing
+// anywhere constrained which conflicting CODE survives.
+func TestInlineTermICMPCodeDupNarrowsEnforcement_6766(t *testing.T) {
+	// Authored `icmp-code 1` then `icmp-code 2` under a fixed type 3.
+	cfg := inlineICMPDupCfg(t,
+		"set applications application badapp term t1 protocol icmp icmp-type 3 icmp-code 1 icmp-code 2")
+
+	t.Run("last authored code is the one enforced", func(t *testing.T) {
+		res := Match(cfg, icmpQuery(u8(3), u8(2)))
+		if !res.Matched || res.Action != config.PolicyDeny {
+			t.Fatalf("ICMP type 3 code 2 (the LAST authored icmp-code) must hit the deny; "+
+				"got matched=%v action=%v default_used=%v. A production edit that "+
+				"retained the FIRST conflicting code would land here",
+				res.Matched, res.Action, res.DefaultUsed)
+		}
+	})
+
+	t.Run("first authored code escapes into default permit-all", func(t *testing.T) {
+		res := Match(cfg, icmpQuery(u8(3), u8(1)))
+		if res.Matched && res.Action == config.PolicyDeny {
+			t.Fatalf("ICMP type 3 code 1 (the FIRST authored icmp-code) was DENIED — " +
+				"the surviving code is the first, not the last, inverting the " +
+				"last-writer contract this test pins")
+		}
+		if res.Action != config.PolicyPermit {
+			t.Fatalf("ICMP type 3 code 1 must fall through to default-policy permit-all; "+
+				"got action=%v matched=%v default_used=%v",
+				res.Action, res.Matched, res.DefaultUsed)
+		}
+	})
+}

--- a/pkg/policymatch/app_inline_term_icmp_dup_6766_test.go
+++ b/pkg/policymatch/app_inline_term_icmp_dup_6766_test.go
@@ -2,6 +2,7 @@ package policymatch
 
 import (
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -35,8 +36,15 @@ import (
 
 // inlineICMPDupCfg builds a deny policy referencing an application whose single
 // inline term repeats an ICMP leaf with conflicting values, then compiles it on
-// the TOLERANT path (the strict path rejects it by design).
-func inlineICMPDupCfg(t *testing.T, appLine string) *config.Config {
+// the TOLERANT path.
+//
+// It also BINDS THE DUPLICATE RECORDING (#6814 gate): without the two checks
+// below, deleting the #6766 tracking outright leaves these tests green, because
+// the compiled values — and therefore every verdict — are identical whether or
+// not the conflict was recorded. The recording is what makes strict reject and
+// what puts the operator-visible warning on the tolerant path, so both are
+// asserted here rather than assumed.
+func inlineICMPDupCfg(t *testing.T, appLine, leaf string) *config.Config {
 	t.Helper()
 	tree := &config.ConfigTree{}
 	for _, cmd := range []string{
@@ -59,9 +67,35 @@ func inlineICMPDupCfg(t *testing.T, appLine string) *config.Config {
 			t.Fatalf("SetPath(%q): %v", cmd, err)
 		}
 	}
+	// The conflict must be RECORDED: strict commit refuses it and names the leaf.
+	serr := func() error { _, e := config.CompileConfig(tree); return e }()
+	if serr == nil {
+		t.Fatalf("strict commit must REJECT the conflicting inline %q — if it does not, "+
+			"the #6766 duplicate recording is gone and the narrowing below is "+
+			"reachable through a green commit", leaf)
+	}
+	if !strings.Contains(serr.Error(), "duplicate") || !strings.Contains(serr.Error(), leaf) {
+		t.Fatalf("strict rejection should name the duplicate leaf %q, got: %v", leaf, serr)
+	}
+
 	cfg, err := config.CompileConfigLenient(tree)
 	if err != nil {
 		t.Fatalf("CompileConfigLenient must not brick on a conflicting inline ICMP repeat: %v", err)
+	}
+	// ...and the tolerant path must still SAY so. This is the only signal an
+	// operator gets on the path that keeps forwarding, so it is part of the
+	// contract these verdict tests characterize.
+	warned := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "duplicate") && strings.Contains(w, leaf) {
+			warned = true
+			break
+		}
+	}
+	if !warned {
+		t.Fatalf("tolerant path must record a downgrade warning naming %q — the "+
+			"narrowing asserted below is otherwise completely silent; warnings: %v",
+			leaf, cfg.Warnings)
 	}
 	return cfg
 }
@@ -80,10 +114,14 @@ func icmpQuery(icmpType, icmpCode *uint8) Query {
 func TestInlineTermICMPTypeDupNarrowsEnforcement_6766(t *testing.T) {
 	// Authored `icmp-type 8` then `icmp-type 3`: last-writer-wins keeps 3.
 	cfg := inlineICMPDupCfg(t,
-		"set applications application badapp term t1 protocol icmp icmp-type 8 icmp-type 3")
+		"set applications application badapp term t1 protocol icmp icmp-type 8 icmp-type 3",
+		"icmp-type")
 
 	t.Run("last authored type is the one enforced", func(t *testing.T) {
 		res := Match(cfg, icmpQuery(u8(3), nil))
+		if res.DefaultUsed {
+			t.Fatalf("ICMP type 3 must be denied by the POLICY, not by a default; got default_used=true action=%v", res.Action)
+		}
 		if !res.Matched || res.Action != config.PolicyDeny {
 			t.Fatalf("ICMP type 3 (the LAST authored icmp-type) must hit the deny; "+
 				"got matched=%v action=%v default_used=%v. If type 3 is NOT denied "+
@@ -95,15 +133,7 @@ func TestInlineTermICMPTypeDupNarrowsEnforcement_6766(t *testing.T) {
 
 	t.Run("first authored type escapes into default permit-all", func(t *testing.T) {
 		res := Match(cfg, icmpQuery(u8(8), nil))
-		if res.Matched && res.Action == config.PolicyDeny {
-			t.Fatalf("ICMP type 8 (the FIRST authored icmp-type) was DENIED — the term " +
-				"did not narrow to the last value, so this characterization is stale")
-		}
-		if res.Action != config.PolicyPermit {
-			t.Fatalf("ICMP type 8 must fall through to default-policy permit-all "+
-				"(this IS the silent narrowing the strict gate prevents); got action=%v "+
-				"matched=%v default_used=%v", res.Action, res.Matched, res.DefaultUsed)
-		}
+		assertFellThroughToDefaultPermit(t, res, "ICMP type 8 (the FIRST authored icmp-type)")
 	})
 }
 
@@ -113,10 +143,14 @@ func TestInlineTermICMPTypeDupNarrowsEnforcement_6766(t *testing.T) {
 func TestInlineTermICMPCodeDupNarrowsEnforcement_6766(t *testing.T) {
 	// Authored `icmp-code 1` then `icmp-code 2` under a fixed type 3.
 	cfg := inlineICMPDupCfg(t,
-		"set applications application badapp term t1 protocol icmp icmp-type 3 icmp-code 1 icmp-code 2")
+		"set applications application badapp term t1 protocol icmp icmp-type 3 icmp-code 1 icmp-code 2",
+		"icmp-code")
 
 	t.Run("last authored code is the one enforced", func(t *testing.T) {
 		res := Match(cfg, icmpQuery(u8(3), u8(2)))
+		if res.DefaultUsed {
+			t.Fatalf("ICMP type 3 code 2 must be denied by the POLICY, not by a default; got default_used=true action=%v", res.Action)
+		}
 		if !res.Matched || res.Action != config.PolicyDeny {
 			t.Fatalf("ICMP type 3 code 2 (the LAST authored icmp-code) must hit the deny; "+
 				"got matched=%v action=%v default_used=%v. A production edit that "+
@@ -127,15 +161,39 @@ func TestInlineTermICMPCodeDupNarrowsEnforcement_6766(t *testing.T) {
 
 	t.Run("first authored code escapes into default permit-all", func(t *testing.T) {
 		res := Match(cfg, icmpQuery(u8(3), u8(1)))
-		if res.Matched && res.Action == config.PolicyDeny {
-			t.Fatalf("ICMP type 3 code 1 (the FIRST authored icmp-code) was DENIED — " +
-				"the surviving code is the first, not the last, inverting the " +
-				"last-writer contract this test pins")
-		}
-		if res.Action != config.PolicyPermit {
-			t.Fatalf("ICMP type 3 code 1 must fall through to default-policy permit-all; "+
-				"got action=%v matched=%v default_used=%v",
-				res.Action, res.Matched, res.DefaultUsed)
-		}
+		assertFellThroughToDefaultPermit(t, res, "ICMP type 3 code 1 (the FIRST authored icmp-code)")
 	})
+}
+
+// assertFellThroughToDefaultPermit asserts that a query reached the configured
+// default policy and was permitted there.
+//
+// #6814 gate: `config.PolicyPermit` is the ZERO value of PolicyAction
+// (types_security.go), and so is `Matched=false`. An assertion built only on
+// "action is permit" is therefore satisfied by a Result that was never
+// populated at all — a path that produced NOTHING looks identical to a genuine
+// fall-through. `DefaultUsed` is the only field here that carries non-default
+// evidence: it is true ONLY because the default-policy branch actually ran. It
+// is asserted FIRST for that reason, and `Matched=false` is asserted explicitly
+// rather than left implied, which also rejects the
+// `Matched=true, DefaultUsed=false, Action=permit` shape — a concrete policy
+// PERMIT, which is a different (and equally wrong) outcome from falling
+// through.
+func assertFellThroughToDefaultPermit(t *testing.T, res Result, what string) {
+	t.Helper()
+	if !res.DefaultUsed {
+		t.Fatalf("%s must FALL THROUGH to default-policy permit-all: want DefaultUsed=true, "+
+			"got default_used=false matched=%v action=%v. DefaultUsed is the only "+
+			"non-zero-valued evidence that the default branch ran at all — permit and "+
+			"unmatched are both zero values and prove nothing on their own",
+			what, res.Matched, res.Action)
+	}
+	if res.Matched {
+		t.Fatalf("%s must not match a concrete policy: want Matched=false, got matched=true "+
+			"action=%v (a policy PERMIT is not the same outcome as falling through)",
+			what, res.Action)
+	}
+	if res.Action != config.PolicyPermit {
+		t.Fatalf("%s reached the default policy but was not permitted: action=%v", what, res.Action)
+	}
 }


### PR DESCRIPTION
## Summary

- opus-review-001 R23 (High): `parseApplicationTerms` tracked conflicting
  inline-term repeats for destination-port / source-port / timeout / alg (the
  #3366 framework) but declared no set flags for `icmp-type` / `icmp-code`, so
  a conflicting repeat overwrote the pointer with no record. The term subtree
  is opaque to SchemaValidate (`term` is args:1, children:nil) and the strict
  structure gate only sees `Application.DuplicateTermLeaves`, so strict commit
  accepted the config and a referenced DENY enforced only the LAST type/code —
  a silent narrowing of the deny match (echo authored then overwritten by
  unreachable falls through to a later/default permit).
- Fix: `icmpTypeSet` / `icmpCodeSet` first-value tracking in
  `parseApplicationTerms`, mirroring the ports and the #5574 direct-body ICMP
  tracking. A differing repeat appends the leaf name to `DuplicateTermLeaves`;
  an idempotent same-value repeat stays accepted; malformed tokens keep the
  existing `UnknownICMP` path (duplicate tracking applies only to values that
  parse).
- Strict error text, the `validateApplicationStructureStrict` doc comment, the
  `DuplicateTermLeaves` field doc, and the pkg/config README #3366 section now
  enumerate the ICMP leaves.
- No dataplane or Rust change: `capabilities.go` / `policy.rs` consume the
  final compiled constraint; the compiler now rejects what previously compiled
  to a silently narrowed constraint.

## Hot-path shape

None — config-compile cold path only; two booleans + two uint8s per inline
term, no allocations beyond the (rare, pre-existing pattern) duplicate-record
append.

## Test plan

- [x] New fail-on-revert tests
  `pkg/config/compiler_application_term_icmp_dup_6766_test.go` — RED pre-fix
  (all rejection cases committed silently), GREEN post-fix:
  - packed flat-set shape: conflicting `icmp-type` / `icmp-code` reject, error
    names the leaf
  - hierarchical brace-block shape: both leaves reject
  - apply-groups: a group-authored packed term with the conflict rejects after
    expansion
  - referenced deny policy: strict rejects; the lenient path demonstrably
    compiles to ONLY the last type (ICMPType=3) — characterizes the narrowing
    the gate prevents
  - same-value idempotent repeats commit cleanly with the value intact
  - lenient path downgrades to a warning (no-brick, #1960 doctrine)
- [x] `go test ./pkg/config/... ./pkg/dataplane/userspace/...` — pass
- [x] Full `go test ./...` — pass
- [x] `go vet ./pkg/config/` — clean; touched files gofmt-clean
- [ ] Deploy / cluster smoke — not run: control-plane config-compiler change
  with no dataplane, HA, or apply-path behavior change (per campaign rules,
  cluster smokes are not run by the engineer agent)

## Refs

- Root analysis: opus-review-001 R23 (base ad9591177481)
- Related: #3366 (inline-term port/timeout/ALG duplicate gate), #5574
  (direct-body scalar conflicts, incl. ICMP), #3348 (inline-term ICMP grammar +
  malformed-value gate)

Closes #6766

---

## `a47afa165` — the remaining sites in this PR's own file (separate commit)

> **Provenance correction.** This commit's message, and an earlier version of this
> section, described `FlatSet_Rejected` / `Hierarchical_Rejected` /
> `ApplyGroups_Rejected` as "three pre-existing #5797 rejection tests". **That is
> false.** `pkg/config/compiler_application_term_icmp_dup_6766_test.go` does not
> exist on `origin/master` — `git diff --name-status origin/master...HEAD` reports
> it as `A` (added), introduced by this PR's own first commit `b21c7bd19`. All
> three tests are **new in this PR**. The commit message is immutable and still
> carries the wrong framing; this note is the correction of record.
>
> The distinction matters because it changes what the PR claims to have done:
> "swept a pre-existing defect class inherited from another issue" and "fixed
> every site in its own new file" are different claims, and only the second is
> true.

Round 4 quoted the leaf assertion in two of this file's tests. This commit quoted the remaining table-driven three — `FlatSet_Rejected`, `Hierarchical_Rejected`, `ApplyGroups_Rejected`, all of which used `strings.Contains(err.Error(), c.leaf)`.

Kept as its own commit so it reviews independently. Fixing only the two touched in round 4 would have left the next reader looking at three tests using the weak form beside two using the strong one, with no way to tell which was deliberate.

**The mechanism:** the rejection message ends with a *static enumeration* of every trackable leaf — `(destination-port / source-port / inactivity-timeout / timeout / alg / icmp-type / icmp-code)` — so a bare substring check for the leaf name is satisfied by that boilerplate no matter which leaf actually conflicted, and a swapped label sails through. Only the identifying occurrence is quoted (`conflicting duplicate "icmp-type" inside`), so the quotes are what turn "the error names the leaf" into an assertion rather than a coincidence.

### Proof — four cells

| | quoted (new) | bare (old) |
|---|---|---|
| **labels swapped** | **RED** — all 6 rejection subtests | **PASS** — blind to the swap |
| **unmutated** | GREEN | GREEN |

The four positive controls stay **GREEN** under the mutation, which is load-bearing rather than incidental: they author no conflict, so they have no label to swap, and their staying green confirms the mutation is scoped to the rejection path rather than simply breaking the package.

Build and vet clean under the mutation; both files restored by pristine-snapshot write-back plus `touch`, with `compiler_applications.go` confirmed byte-identical to HEAD afterwards. Gates from real exit codes: `GATE1_RC=0`, `FULL_RC=0` across 59 packages.


---

## `e97915ec1` — the last two bare leaf sites, and the header count

An AGY leg running the full swapped-label matrix at true head found **two more bare leaf assertions in the file this PR authored** (`:277` `ReferencedDeny_StrictRejects_LenientNarrows`, `:398` `Lenient_DowngradesToWarning`). Both are now quoted.

**Why the previous sweep missed them**, recorded because it generalises: that sweep grepped for `strings.Contains(err.Error(), c.leaf)` — the table-driven form. These two hardcode the literal `"icmp-type"` instead of taking it from a case table, so a grep shaped around the *variable* form structurally cannot find them. The mutation matrix finds every shape because it does not care how the assertion is spelled. **Grep finds what you already know the shape of; the mutation finds what you do not.**

The header was consequently false — it claimed the quoted form was used "throughout this file" and reds "all three rejection tests". There are **five** leaf-identity sites: four rejection assertions (the three table-driven plus `ReferencedDeny`, which hardcodes its leaf) and one tolerant-path warning assertion. The header now states that count, because the count is what makes the claim checkable.

Full matrix under the swap: **all five RED**. The four positive controls stay GREEN, as do `Idempotent_Accepted` and `LenientKeepsLastCode` — they author no conflict so have no label to swap, and the latter asserts a *value* rather than a leaf name. That is what shows the mutation is scoped to leaf identity rather than breaking the package. Negative control: both sites reverted to bare, mutation still applied → **both PASS**.

## Acceptance change worth knowing about

`icmpType` / `icmpCode` are single scalars shared across every `Application` a multi-protocol term generates, so this now **hard-fails at strict commit**:

```
set applications application mp term t1 protocol icmp icmp-type 8 protocol icmpv6 icmp-type 128
```

Verified directly: strict returns `conflicting duplicate "icmp-type" inside term`; the tolerant path still commits, producing both `mp-t1-icmp` and `mp-t1-icmpv6`.

**Rejecting is the correct direction.** Because the scalar is shared across the per-protocol expansion, the pre-fix behaviour applied the last-writer value (128) to *both* legs — so the ICMPv4 leg silently matched type 128, which no ICMPv4 packet carries. The old outcome was silently wrong rather than usefully permissive. And because the tolerant path still commits, an already-persisted config or an older peer's sync does not brick the daemon (#1960 no-brick).

An operator who genuinely wants per-protocol ICMP types should author one `term` per protocol.

