### PR TITLE
sessions: stop rendering policy_id 0 as the first configured policy (#4626)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -66323,3 +66323,98 @@ break — `go vet` confirmed passing under every revert.
   pkg/config/compiler_opts.go,
   pkg/config/compiler_policy_valueless_match_6526_test.go,
   docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-08-05 15:10
+- **Action**: #6851 fold — two MAJORs on the #4626 policy-id-zero guard, both
+  verified firsthand before folding.
+
+  MAJOR 1, the SEVENTH resolver. `EventReader.resolvePolicyName`
+  (`pkg/logging/ringbuf.go`) resolves RT_FLOW record names independently of the
+  six session-row builders and indexed `er.policyNames` directly. It already
+  special-cased `DefaultPolicySentinelID` (#3057) but not
+  `UnattributedPolicyID`, so every host-inbound / fabric / tunnel / pre-#3056 /
+  older-peer record named the FIRST configured policy. This is the surface that
+  matters most: RT_FLOW records go to syslog and ship off-box, so the wrong
+  attribution is durable and lands in what an auditor reads later.
+
+  MAJOR 2, peer fan-out. `fetchPeerSessions` did `resp.Peer = peerResp` — the
+  peer's response attached UNCHANGED, names included. The #4626 guard resolves a
+  name from a raw id for rows THIS node renders; it does not cover a name
+  arriving as DATA from an old peer that resolved it wrongly itself. REST
+  (`writeSessionList` → `pr.GetPeer()`), gRPC clients and the CLI all republish
+  that string, so `fetchPeerSessions` is the single choke point for all three.
+
+  DECISION on MAJOR 2, and why. Override the name for RESERVED ids only; keep
+  the peer's name for everything else. Policy ids are NODE-LOCAL
+  (`compilePolicies` assigns from the local config's rule ordering), so the peer
+  is authoritative for the names of its own sessions and re-resolving an
+  unreserved peer id against the LOCAL map would name whichever local policy
+  occupies that slot — a fresh misattribution firing on every mixed-config
+  cluster, not a fix. The two choices are identical against a same-version peer
+  (it already sends `unattributed`); they differ only for an older peer, which
+  is the population that needs correcting. Pinned by mutation M4.
+
+  STRUCTURE. Added `dataplane.ReservedPolicyName(id) (string, bool)` as the SSOT
+  for "which ids must never reach a name map", and expressed `SessionPolicyName`,
+  the new `PeerSessionPolicyName`, and the logging resolver through it. The
+  logging site keeps its own numeric fallback so it cannot call
+  `SessionPolicyName` directly; an earlier draft probed
+  `SessionPolicyName(nil, id)` for a non-empty result, which works only because
+  a nil map yields "" for unreserved ids — a property nobody is obliged to
+  preserve and whose loss would silently route unreserved ids away from the
+  caller's map. Replaced with the explicit predicate.
+
+  Also FUSED the peer guard with the attach it protects
+  (`attachPeerSessions` sanitizes AND assigns). Two statements at the call site
+  would let a future edit drop the guard and keep the attach — silent and green,
+  the exact failure mode of this PR. Fused, dropping the guard drops the
+  fan-out, which fails loudly.
+
+  ENUMERATION, re-run rather than inherited (the count has grown at every
+  count: briefed 2, previous lane 6, gate 7). Every `policyNames[...]` index in
+  the tree is now: the helper itself, `compilePolicies` building the map, and
+  the logging resolver (fixed). Six routed session builders + logging = SEVEN
+  resolvers; the peer pass-through is the only place a name arrives as data.
+  Checked and CLEARED as carrying no policy name: the other two peer fan-outs
+  (`GetSessionSummaryResponse` is counts only; `GetZonePairSummaryResponse` holds
+  `ZonePairSessionSummary`, which is zone pairs + protocol counts) — verified by
+  enumerating their generated struct fields, not by assuming. Downstream
+  consumers (`pkg/api/sse.go`, `server_show_events.go`,
+  `cli_show_security_log.go`, `monitor.go`, `cmd/cli/show_flow.go`) read an
+  already-resolved string and are fixed transitively.
+
+  MUTATIONS (each restored + re-verified green):
+  - M1 map-first, the shape that looks like a guard: reserved check moved AFTER
+    the map lookup in the logging resolver → RED on
+    `TestResolvePolicyNameZeroIsNotTheFirstPolicy_6851`. Note the
+    no-published-map test stays GREEN under it, which is why the OCCUPIED-map
+    fixture is the load-bearing one.
+  - M2 peer-name-first (trust a non-empty peer string before the reserved
+    check) → 3 RED.
+  - M3 guard dropped, attach kept → 3 RED; the fusion holds.
+  - M4 the REJECTED alternative (discard the peer's name for unreserved ids too,
+    as "re-resolve everything locally" would) → RED on the unreserved control.
+    The decision is pinned, not accidental.
+
+  SUPERSEDED #3057 ASSERTION, called out because the brief did not anticipate
+  it. Routing the logging resolver through the guard broke a PRE-EXISTING test:
+  `TestResolvePolicyNameSentinelRendersDefaultPolicy` asserted "a genuine policy
+  ID 0 still resolves to the first configured policy". That is precisely the
+  claim #4626 retires — the same claim the six session surfaces already stopped
+  making — so the assertion was updated, not the fix weakened. The test's actual
+  #3057 purpose (the sentinel must not alias the first policy) is untouched, and
+  I STRENGTHENED it in the other direction: id 0 must now also not render as
+  `default-policy`, so a "fix" collapsing both reserved ids onto one name would
+  fail rather than pass. The supersession is documented in the test comment.
+  Under mutation M1 that test now reds ALONGSIDE the new one.
+
+  SCOPE LIMIT, stated rather than implied: the tests drive `attachPeerSessions`,
+  so they bind the sanitize-and-attach pair. They do NOT bind
+  `fetchPeerSessions`' call to it — that needs a live `cluster.Manager` with
+  `PeerAlive()` plus an authenticated peer dial, neither reachable from a unit
+  test. Replacing the call with a bare `resp.Peer = peerResp` would not be
+  caught. Recorded in the source next to the function.
+- **File(s)**: pkg/dataplane/policy_display.go, pkg/logging/ringbuf.go,
+  pkg/grpcapi/server_sessions.go, pkg/logging/policy_id_zero_6851_test.go,
+  pkg/grpcapi/peer_policy_name_6851_test.go, docs/junos-cli-reference.md,
+  _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,64 @@
+## 2026-08-05 — #6851 round 3: the on-box CLI bypasses the choke point; the canary could not see it
+
+- **Timestamp**: 2026-08-05 (fix/4626-policy-id-zero, PR #6851)
+- **Action**: MAJOR — `pkg/cli` has its OWN peer dialer. `(c *CLI)
+  fetchPeerSessions` calls `c.dialPeer()` straight to the peer daemon and
+  sets no `IncludePeer`, so it passes through neither the grpcapi fan-out
+  that sanitizes reserved policy ids nor the peer's own fan-out; the
+  response was rendered verbatim. Against a pre-#4626 peer, `show security
+  flow session` in cluster mode printed that peer's first configured policy
+  for every reserved-id session — the defect this branch closes, on the
+  surface an operator actually types. The remote `cli` binary and REST are
+  unaffected.
+  Sanitized at the CLI's own ingress rather than at the render site, so a
+  future render site cannot reintroduce the bypass. Same decision function
+  (`dataplane.PeerSessionPolicyName`) as grpcapi — two call sites, one
+  decision, because the two surfaces reach the peer by different routes.
+  Two SHIPPED claims were falsified by this and are corrected rather than
+  left: `server_sessions.go` said guarding there "covers all three surfaces
+  once" (it covers gRPC and REST), and `docs/junos-cli-reference.md` said
+  cluster peer sessions "carry the same guarantee" (now true, and it names
+  both sanitization points).
+  Canary — my own instrument was the reason this was invisible. The
+  per-FUNCTION rule scoped to the enclosing `FuncDecl`, and both CLI render
+  sites live inside the SAME 557-line `showFlowSession`, in separate
+  `printV4`/`printV6` closures. Either closure's helper call marked the
+  whole function guarded, so reverting exactly one site passed. Narrowed to
+  the innermost function scope: a nested `FuncLit` is its own scope, a
+  parent's helper call does not guard a closure, and one closure does not
+  guard its sibling.
+  Also: the `scanned < 20` floor counted TOTAL files, so it never bound its
+  own dimension — removing `logging` from the package list removed it from
+  the loop entirely, and the floor never ran for it. Replaced with a
+  membership assertion on the list plus a per-package file floor.
+  Scoped honestly rather than fixed: `attachPeerSessions(resp, nil)`
+  compiles, satisfies the structural canary, drops every peer session, and
+  passes the suite — so the "fails loudly" line is an operator-visible
+  claim, not a test-enforced one, and now says so. Map aliasing
+  (`m := policyNames; m[id]`) still defeats the identifier-keyed rule;
+  recorded as a known limit.
+  Correcting my own round-2 report: I wrote that the sentinel-only revert
+  redded "pre-existing behavioural tests". Every failing assertion was
+  authored by this branch —
+  `default_policy_sentinel_3057_test.go` is a pre-existing FUNCTION whose
+  assertion this branch inverted, and the mutation SATISFIES what master
+  asserted. Inverting it was right; describing the result as independent
+  prior coverage was not. A pre-existing file is not a pre-existing
+  assertion.
+- **Validation**: four-mutation matrix, snapshot-and-write-back restore
+  with byte-for-byte verify, every mutant required to compile. All four
+  RED. Two were GREEN on the first run and are the reason two more tests
+  exist: dropping the CLI sanitize CALL (my tests drove the sanitizer
+  directly and left its one call site unbound — the same unit-bound /
+  call-site-unbound gap as #5103), and re-adding the logging carve-out
+  (the per-package floor cannot fire for a package that is no longer in
+  the list). Reverting ONLY the v6 CLI site — measured invisible before
+  the narrowing — now REDs. Full `go test ./pkg/... ./cmd/...` passes.
+- **File(s)**: `pkg/cli/session_filter.go`,
+  `pkg/cli/peer_policy_name_6851_test.go` (new),
+  `pkg/dataplane/policy_display_4626_test.go`,
+  `pkg/grpcapi/server_sessions.go`, `docs/junos-cli-reference.md`, `_Log.md`
+
 ## 2026-08-05 — #6851: close the two gaps the round-2 fix left in its own canary
 
 - **Timestamp**: 2026-08-05 (fix/4626-policy-id-zero, PR #6851)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,53 @@
+## 2026-08-05 — #6851: close the two gaps the round-2 fix left in its own canary
+
+- **Timestamp**: 2026-08-05 (fix/4626-policy-id-zero, PR #6851)
+- **Action**: A concurrent lane had already fixed both review findings on
+  this branch (2e4ec3509) while I was fixing them independently. Theirs is
+  better placed and I dropped mine: the peer guard belongs at
+  `fetchPeerSessions` in grpcapi, where sanitizing the protobuf response
+  in place covers gRPC, the REST `peer` block and the CLI at one choke
+  point. I verified that claim rather than taking the comment's word —
+  `pkg/api` has no independent peer dial, and `writeSessionList` reaches
+  the peer through the same in-process `GetSessions`, so my
+  `sessionEntryFromPB` fix would have been a redundant second helper
+  duplicating theirs. Kept the superseded work on the local branch
+  `backup-mine-14af8e357` rather than deleting it unreviewed.
+  What their commit did NOT update was its own canary, so this adds only
+  that delta. Two gaps:
+  1. `sessionPolicyNameDisplayPackages` still excluded `pkg/logging` with
+     the very reasoning their fix disproved ("the RT_FLOW path owns its
+     own resolver ... folding the two is a separate change"). That
+     exclusion is what let the seventh resolver sit unguarded through
+     round 1. Added `logging`, and replaced the stale comment with why a
+     carve-out needs the same evidence as a fix.
+  2. `attachPeerSessions`' doc names a residual outright — "Replacing this
+     call with a bare `resp.Peer = peerResp` would not be caught here."
+     `TestPeerSessionFanOutGoesThroughAttach_6851` closes it structurally:
+     `fetchPeerSessions` must call the helper and must not assign
+     `resp.Peer` directly. Scoped to that ONE function on purpose — the
+     `resp.Peer` assignments at ~:927 and ~:1039 attach summary responses
+     carrying no per-session policy name, so routing them through a
+     session sanitizer would be wrong, not safer.
+  Fixing (1) surfaced a defect in my own canary rather than in their code:
+  a blanket "no `policyNames[...]` index" rule FALSE-POSITIVED on their
+  resolver, which correctly takes the reserved ids via
+  `ReservedPolicyName` and only then indexes for an unreserved id. There
+  are two legitimate shapes — delegate wholly, or guard-then-index — so
+  the canary now walks per function and reports an index only in a
+  function that never consults a reserved-id helper. Its limits are
+  stated: it does not prove the helper call DOMINATES the index on every
+  path, so a helper in a dead branch would pass.
+- **Validation**: two mutations, snapshot-and-write-back restore with
+  byte-for-byte verify, both required to compile. Reverting the logging
+  resolver to the sentinel-only form goes RED on the canary IN ADDITION
+  to their behavioural tests, which is the coverage the exclusion was
+  costing. Bypassing `attachPeerSessions` with a bare `resp.Peer =
+  peerResp` goes RED on the NEW canary ONLY — nothing else in the suite
+  catches it, which is precisely the residual their comment documented.
+  Full `go test ./pkg/... ./cmd/...` passes.
+- **File(s)**: `pkg/dataplane/policy_display_4626_test.go`,
+  `pkg/grpcapi/peer_fanout_attach_6851_test.go` (new), `_Log.md`
+
 ## 2026-08-05 — #4626 L01: stop rendering `policy_id` 0 as the first configured policy
 
 - **Timestamp**: 2026-08-05 (fix/4626-policy-id-zero)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,54 @@
+## 2026-08-05 — #6851 round 4: delete a comment's false coverage claim, and replace an assertion that could not fail
+
+- **Timestamp**: 2026-08-05 (fix/4626-policy-id-zero, PR #6851)
+- **Action**: Re-gate returned no blocking findings; four comment/assertion
+  items, all folded.
+  **F1** — the CLI call-site canary's SCOPE note claimed it asserts
+  `fetchPeerSessions` "returns no response value that bypasses" the
+  sanitizer. It does not: the body only looks for a CallExpr by name.
+  Measured by the gate — `sanitizePeerSessionPolicyNames(nil)` contains the
+  call, bypasses sanitization, and leaves every package green with the
+  round-3 MAJOR fully restored. Deleted the clause rather than inventing a
+  guard: the residual cell is "call present, argument neutered", the same
+  one already disclosed for `attachPeerSessions`, and the class is covered
+  from two other sides (deleting the call reds this test; gutting the
+  sanitizer reds the behavioural tests). A comment claiming coverage that
+  does not exist is the defect this PR spent three rounds removing.
+  **F3** — an expectation equal to the failure default. The id-0 test
+  asserted `GetPolicyId() != 0` with "the raw wire value must still be
+  surfaced", but the INPUT id is 0, so "want 0" is also the zero value and
+  cannot distinguish preserved from clobbered. Removed it and moved the
+  surfacing claim to the sentinel sibling, where `0xFFFFFFFF` IS
+  distinguishable. Proved the replacement binds rather than assuming:
+  mutating the sanitizer to `e.PolicyId = 0` alongside the name rewrite
+  goes RED with the new assertion and would have gone GREEN under the old
+  one.
+  **F2** — `attachPeerSessions(resp, nil)` does NOT compile standalone
+  (`declared and not used: peerResp`); the substance holds with
+  `_ = peerResp` beside it. Wording corrected, point kept.
+  **F4** — the per-package floor's message cited "pointing it at a path
+  that no longer exists", but a nonexistent root makes WalkDir error and
+  the walk Fatals first. Rescoped to its real domain: directory exists,
+  yields zero production `.go` files.
+  Plus an observation recorded at the source: `PeerSessionPolicyName` has
+  no direct unit test in pkg/dataplane — its reserved-before-peer-name
+  ordering is bound transitively (reversing it reds pkg/cli and
+  pkg/grpcapi). Noted at the function so a future reader does not go
+  looking for the guard in the package that documents it.
+  Watch item checked: `pkg/grpcapi/server_sessions.go` is 1990 lines, ten
+  from the 2000 REFACTOR tier, and this round left it at 1990 — the F2 edit
+  was net-neutral.
+- **Validation**: full `go test ./pkg/... ./cmd/...` passes; gofmt and vet
+  clean. One targeted mutation (clobber `PolicyId` while rewriting the
+  name) confirms the F3 replacement assertion can fail.
+  NOTE for review: this delta is NOT comment-only — F3 removes one
+  assertion and adds another. That is called out rather than folded into a
+  "comment-only" claim.
+- **File(s)**: `pkg/cli/peer_policy_name_6851_test.go`,
+  `pkg/grpcapi/server_sessions.go`,
+  `pkg/dataplane/policy_display.go`,
+  `pkg/dataplane/policy_display_4626_test.go`, `_Log.md`
+
 ## 2026-08-05 — #6851 round 3: the on-box CLI bypasses the choke point; the canary could not see it
 
 - **Timestamp**: 2026-08-05 (fix/4626-policy-id-zero, PR #6851)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,60 @@
+## 2026-08-05 — #4626 L01: stop rendering `policy_id` 0 as the first configured policy
+
+- **Timestamp**: 2026-08-05 (fix/4626-policy-id-zero)
+- **Action**: `policy_id` 0 is overloaded — `compilePolicies` assigns
+  `policySetID*MaxRulesPerPolicy + i`, so the first rule of the first
+  zone-pair really is id 0, while the userspace dataplane stamps 0 on
+  every session no policy admitted (host-inbound, neighbor-seed, fabric,
+  tunnel, all pre-#3056 sessions, and every session synced from an older
+  HA peer during a rolling upgrade — that last one is the peer's whole
+  table). Six session-row render sites indexed
+  `CompileResult.PolicyNames` directly, so all of those sessions were
+  reported as admitted by whichever policy happens to be configured
+  first. Added `dataplane.SessionPolicyName`, which takes both reserved
+  ids (0 and `DefaultPolicySentinelID`) before consulting the map, and
+  routed all six sites through it: `pkg/cli/cli_show_flow.go` printV4 and
+  printV6, `pkg/api/sessions.go` sessionEntryV4/V6, and
+  `pkg/grpcapi/server_sessions.go` sessionEntryV4/V6. The REST and gRPC
+  sites had no numeric fallback at all, so the wrong NAME was emitted
+  unconditionally into a structured field automation reads.
+  Chose a render-side guard over reserving the id space. Reserving is
+  what the issue's L01 text asks for, but it is a cross-plane change
+  (userspace-dp `policy.rs`, the #3056 stamping path, runtime-id
+  assignment, HA wire compatibility) with no approved research plan, and
+  it would NOT repair the case that matters most: an older peer keeps
+  sending a bare 0 through the whole upgrade window, so a render-side
+  guard is required either way and is not made redundant by that work.
+  Rendering 0 as `unattributed` is deliberately an UNDER-claim — the wire
+  value is ambiguous, so every rendering is wrong for one of the two
+  populations, and under-claiming is the safer error on a security
+  surface. It is also the direction the codebase already chose for this
+  identical overload on the behavioral path (`deletedPolicyRuntimeIDs`
+  excludes id 0 as a documented "fail-SAFE under-clear"). The numeric id
+  is still printed beside the name on every surface.
+  Scope note recorded in the code and the PR: this does NOT reserve the
+  id space, so it does not close L01 as the issue words it — it removes
+  the misattribution symptom and leaves the id-space work outstanding.
+- **Validation**: seven-mutation matrix, snapshot-and-write-back restore
+  with byte-for-byte verify, each mutant required to compile so no RED is
+  a build break. All seven RED: reverting the CLI pair, the REST pair,
+  the gRPC pair, and all six at once; rewriting the guard to look the map
+  up FIRST and fall back (the plausible "cleanup" that looks like a guard
+  and guards nothing); dropping the reserved-zero arm; and blanking every
+  policy name (caught by the positive controls). The CLI pair is caught
+  only by the AST canary — those two sites are closures printing to real
+  stdout behind a live dataplane, which is stated as the canary's reason
+  to exist rather than left implicit. Full `pkg/dataplane`, `pkg/api`,
+  `pkg/grpcapi`, `pkg/cli`, `pkg/daemon`, `pkg/logging` and
+  `pkg/refactoraudit` suites pass; no existing golden asserted the old
+  attribution.
+- **File(s)**: `pkg/dataplane/policy_display.go` (new),
+  `pkg/dataplane/policy_display_4626_test.go` (new),
+  `pkg/cli/cli_show_flow.go`, `pkg/api/sessions.go`,
+  `pkg/api/sessions_policy_id_zero_4626_test.go` (new),
+  `pkg/grpcapi/server_sessions.go`,
+  `pkg/grpcapi/server_sessions_policy_id_zero_4626_test.go` (new),
+  `docs/junos-cli-reference.md`, `_Log.md`
+
 ## 2026-08-01 — #6588 round 6c: put the two-of-three characterization in the comment
 
 - **Timestamp**: 2026-08-01 (fix/6588-interface-monitor-packed-leaf, PR #6658)

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -148,6 +148,23 @@ Session ID: 17179902569, Policy name: allow-everything-out-not-logged/270, HA St
   - `HA State: Active|Backup`
   - `Timeout: <seconds>`
   - `Session State: Valid|Invalid`
+- **Two policy indexes are RESERVED and do not name a configured policy**
+  (#4626). The index is always printed, so nothing is hidden:
+  - `unattributed/0` — no configured policy admitted this session.
+    Index `0` is carried by host-inbound, neighbor-seed, fabric and tunnel
+    installs, by any pre-#3056 session, and by every session synced from an
+    older HA peer during a rolling upgrade. It is ALSO the index of the
+    literal first configured policy, so the value is genuinely ambiguous on
+    the wire; the display deliberately under-claims rather than naming a
+    real rule that may never have seen the traffic. Retiring the overload
+    (reserving the id space so real policies start at 1) is the remaining
+    half of #4626.
+  - `default-policy/4294967295` — the implicit `security policies
+    default-policy` verdict admitted or denied this session, not a
+    configured rule (#3057).
+  The same two reserved indexes appear as `policy_name` on the REST
+  `/sessions` and gRPC `GetSessions` surfaces, which carry `policy_id`
+  alongside.
 - **In/Out lines:** Indented 2 spaces.
   - `In: <src_ip>/<src_port> --> <dst_ip>/<dst_port>;<proto>, Conn Tag: 0x0, If: <interface>, Pkts: <N>, Bytes: <N>, `
   - Note the trailing comma+space after Bytes value.

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -164,7 +164,18 @@ Session ID: 17179902569, Policy name: allow-everything-out-not-logged/270, HA St
     configured rule (#3057).
   The same two reserved indexes appear as `policy_name` on the REST
   `/sessions` and gRPC `GetSessions` surfaces, which carry `policy_id`
-  alongside.
+  alongside, and in the `policy-name` field of RT_FLOW syslog records
+  (#6851) — the one surface where the attribution is DURABLE, since those
+  records ship off-box to a collector.
+- **Cluster peer sessions carry the same guarantee** (#6851). An
+  `include_peer` fan-out attaches the peer node's rows, and the peer
+  resolved those names itself; a peer on a pre-#4626 build sent the name
+  of ITS first configured policy for every reserved-index session. The
+  local node overrides the name for RESERVED indexes only. It deliberately
+  does NOT re-resolve an unreserved index against its own policy table:
+  indexes are node-local, so the peer is authoritative for the names of
+  its own sessions, and re-resolving would name whichever local policy
+  happened to occupy that slot.
 - **In/Out lines:** Indented 2 spaces.
   - `In: <src_ip>/<src_port> --> <dst_ip>/<dst_port>;<proto>, Conn Tag: 0x0, If: <interface>, Pkts: <N>, Bytes: <N>, `
   - Note the trailing comma+space after Bytes value.

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -167,11 +167,14 @@ Session ID: 17179902569, Policy name: allow-everything-out-not-logged/270, HA St
   alongside, and in the `policy-name` field of RT_FLOW syslog records
   (#6851) — the one surface where the attribution is DURABLE, since those
   records ship off-box to a collector.
-- **Cluster peer sessions carry the same guarantee** (#6851). An
-  `include_peer` fan-out attaches the peer node's rows, and the peer
-  resolved those names itself; a peer on a pre-#4626 build sent the name
-  of ITS first configured policy for every reserved-index session. The
-  local node overrides the name for RESERVED indexes only. It deliberately
+- **Cluster peer sessions carry the same guarantee** (#6851), on every
+  surface that shows them: the gRPC and REST fan-outs sanitize in
+  `grpcapi fetchPeerSessions`, and the on-box interactive CLI — which dials
+  the peer daemon directly rather than going through that fan-out — does so
+  at its own ingress. The peer resolved those names itself; a peer on a
+  pre-#4626 build sent the name of ITS first configured policy for every
+  reserved-index session. The local node overrides the name for RESERVED
+  indexes only. It deliberately
   does NOT re-resolve an unreserved index against its own policy table:
   indexes are node-local, so the peer is authoritative for the names of
   its own sessions, and re-resolving would name whichever local policy

--- a/pkg/api/sessions.go
+++ b/pkg/api/sessions.go
@@ -1385,14 +1385,15 @@ func sessionEntryV4(key dataplane.SessionKey, val dataplane.SessionValue, now ui
 		outIf = view.zoneNames[val.EgressZone]
 	}
 	se := SessionEntry{
-		SrcAddr:          net.IP(key.SrcIP[:]).String(),
-		DstAddr:          net.IP(key.DstIP[:]).String(),
-		SrcPort:          ntohs(key.SrcPort),
-		DstPort:          ntohs(key.DstPort),
-		Protocol:         protoName(key.Protocol),
-		State:            sessionStateName(val.State),
-		PolicyID:         val.PolicyID,
-		PolicyName:       view.policyNames[val.PolicyID],
+		SrcAddr:  net.IP(key.SrcIP[:]).String(),
+		DstAddr:  net.IP(key.DstIP[:]).String(),
+		SrcPort:  ntohs(key.SrcPort),
+		DstPort:  ntohs(key.DstPort),
+		Protocol: protoName(key.Protocol),
+		State:    sessionStateName(val.State),
+		PolicyID: val.PolicyID,
+		// #4626: reserved ids must not be resolved through the compiled map.
+		PolicyName:       dataplane.SessionPolicyName(view.policyNames, val.PolicyID),
 		IngressZoneName:  view.zoneNames[val.IngressZone],
 		EgressZoneName:   view.zoneNames[val.EgressZone],
 		InZone:           val.IngressZone,
@@ -1439,14 +1440,15 @@ func sessionEntryV6(key dataplane.SessionKeyV6, val dataplane.SessionValueV6, no
 		outIf = view.zoneNames[val.EgressZone]
 	}
 	se := SessionEntry{
-		SrcAddr:          net.IP(key.SrcIP[:]).String(),
-		DstAddr:          net.IP(key.DstIP[:]).String(),
-		SrcPort:          ntohs(key.SrcPort),
-		DstPort:          ntohs(key.DstPort),
-		Protocol:         protoName(key.Protocol),
-		State:            sessionStateName(val.State),
-		PolicyID:         val.PolicyID,
-		PolicyName:       view.policyNames[val.PolicyID],
+		SrcAddr:  net.IP(key.SrcIP[:]).String(),
+		DstAddr:  net.IP(key.DstIP[:]).String(),
+		SrcPort:  ntohs(key.SrcPort),
+		DstPort:  ntohs(key.DstPort),
+		Protocol: protoName(key.Protocol),
+		State:    sessionStateName(val.State),
+		PolicyID: val.PolicyID,
+		// #4626: reserved ids must not be resolved through the compiled map.
+		PolicyName:       dataplane.SessionPolicyName(view.policyNames, val.PolicyID),
 		IngressZoneName:  view.zoneNames[val.IngressZone],
 		EgressZoneName:   view.zoneNames[val.EgressZone],
 		InZone:           val.IngressZone,

--- a/pkg/api/sessions_policy_id_zero_4626_test.go
+++ b/pkg/api/sessions_policy_id_zero_4626_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #4626 L01, REST half. sessionEntryV4/V6 resolved PolicyName by indexing
+// view.policyNames directly, and `policy_id` 0 is BOTH the first configured
+// policy's id and the value stamped on every session no policy admitted
+// (host-inbound, neighbor-seed, fabric, tunnel, pre-#3056, and every session
+// synced from an older HA peer mid-rolling-upgrade). The JSON surface therefore
+// told automation that a specific policy admitted traffic that policy never
+// saw — and unlike the CLI there was no numeric fallback here, so the name was
+// emitted unconditionally.
+//
+// These drive the real entry builders. Re-inlining `view.policyNames[val.PolicyID]`
+// at either site turns them RED.
+
+// policyNamesWithFirstPolicy is the fixture that matters: id 0 is OCCUPIED by a
+// real policy, exactly as compilePolicies emits it. A fixture without an entry
+// at 0 would pass against the unfixed code.
+func policyNamesWithFirstPolicy() map[uint32]string {
+	return map[uint32]string{
+		0:                                 "trust-to-untrust/allow-web",
+		1:                                 "trust-to-untrust/allow-dns",
+		dataplane.DefaultPolicySentinelID: dataplane.DefaultPolicyName,
+	}
+}
+
+func testSessionView() sessionView {
+	return sessionView{
+		zoneNames:    map[uint16]string{1: "trust", 2: "untrust"},
+		policyNames:  policyNamesWithFirstPolicy(),
+		appNames:     map[uint16]string{},
+		zoneIfaces:   map[uint16]string{},
+		egressIfaces: map[sessionEgressKey]string{},
+	}
+}
+
+func TestSessionEntryV4PolicyIDZeroNotFirstPolicy_4626(t *testing.T) {
+	view := testSessionView()
+	val := dataplane.SessionValue{
+		State:       1,
+		PolicyID:    0, // host-inbound / fabric / tunnel / older-peer session
+		IngressZone: 1,
+		EgressZone:  2,
+		Created:     100,
+		LastSeen:    100,
+	}
+
+	se := sessionEntryV4(dataplane.SessionKey{Protocol: 6}, val, 200, view)
+
+	if se.PolicyName == view.policyNames[0] {
+		t.Fatalf("REST session entry reports policy_name=%q for a policy_id 0 session — "+
+			"that is the FIRST configured policy, which never admitted it. Automation "+
+			"reading this attributes host-inbound/fabric/tunnel/older-peer traffic to a "+
+			"real rule (#4626)", se.PolicyName)
+	}
+	if se.PolicyName != dataplane.UnattributedPolicyName {
+		t.Errorf("policy_name = %q, want %q", se.PolicyName, dataplane.UnattributedPolicyName)
+	}
+	// The numeric id is still carried, so nothing is hidden by the substitution.
+	if se.PolicyID != 0 {
+		t.Errorf("policy_id = %d, want 0 — the raw wire value must still be surfaced", se.PolicyID)
+	}
+}
+
+func TestSessionEntryV6PolicyIDZeroNotFirstPolicy_4626(t *testing.T) {
+	view := testSessionView()
+	val := dataplane.SessionValueV6{
+		State:       1,
+		PolicyID:    0,
+		IngressZone: 1,
+		EgressZone:  2,
+		Created:     100,
+		LastSeen:    100,
+	}
+
+	se := sessionEntryV6(dataplane.SessionKeyV6{Protocol: 6}, val, 200, view)
+
+	if se.PolicyName == view.policyNames[0] {
+		t.Fatalf("REST IPv6 session entry reports policy_name=%q for a policy_id 0 session "+
+			"— the first configured policy never admitted it (#4626)", se.PolicyName)
+	}
+	if se.PolicyName != dataplane.UnattributedPolicyName {
+		t.Errorf("policy_name = %q, want %q", se.PolicyName, dataplane.UnattributedPolicyName)
+	}
+}
+
+// Over-rejection guard: a session a real policy DID admit must keep reporting
+// that policy, on both families. A fix that blanked every name would satisfy
+// the tests above and destroy the surface's actual purpose.
+func TestSessionEntryRealPolicyStillResolves_4626(t *testing.T) {
+	view := testSessionView()
+
+	se4 := sessionEntryV4(dataplane.SessionKey{Protocol: 6},
+		dataplane.SessionValue{State: 1, PolicyID: 1, Created: 100, LastSeen: 100}, 200, view)
+	if want := view.policyNames[1]; se4.PolicyName != want {
+		t.Errorf("v4 policy_name = %q, want %q — an admitted session must still name its "+
+			"policy", se4.PolicyName, want)
+	}
+
+	se6 := sessionEntryV6(dataplane.SessionKeyV6{Protocol: 6},
+		dataplane.SessionValueV6{State: 1, PolicyID: 1, Created: 100, LastSeen: 100}, 200, view)
+	if want := view.policyNames[1]; se6.PolicyName != want {
+		t.Errorf("v6 policy_name = %q, want %q", se6.PolicyName, want)
+	}
+
+	// The implicit default-policy sentinel keeps its #3057 rendering.
+	seDef := sessionEntryV4(dataplane.SessionKey{Protocol: 6},
+		dataplane.SessionValue{State: 1, PolicyID: dataplane.DefaultPolicySentinelID,
+			Created: 100, LastSeen: 100}, 200, view)
+	if seDef.PolicyName != dataplane.DefaultPolicyName {
+		t.Errorf("default-sentinel policy_name = %q, want %q (#3057 must not regress)",
+			seDef.PolicyName, dataplane.DefaultPolicyName)
+	}
+}

--- a/pkg/cli/cli_show_flow.go
+++ b/pkg/cli/cli_show_flow.go
@@ -342,7 +342,10 @@ func (c *CLI) showFlowSession(args []string) error {
 			return
 		}
 
-		polName := policyNames[val.PolicyID]
+		// #4626: reserved ids (0 = no policy admitted this session,
+		// DefaultPolicySentinelID = implicit default) must not be resolved
+		// through the compiled map — id 0 IS the first configured policy there.
+		polName := dataplane.SessionPolicyName(policyNames, val.PolicyID)
 		if polName == "" {
 			polName = fmt.Sprintf("%d", val.PolicyID)
 		}
@@ -469,7 +472,10 @@ func (c *CLI) showFlowSession(args []string) error {
 			return
 		}
 
-		polName := policyNames[val.PolicyID]
+		// #4626: reserved ids (0 = no policy admitted this session,
+		// DefaultPolicySentinelID = implicit default) must not be resolved
+		// through the compiled map — id 0 IS the first configured policy there.
+		polName := dataplane.SessionPolicyName(policyNames, val.PolicyID)
 		if polName == "" {
 			polName = fmt.Sprintf("%d", val.PolicyID)
 		}

--- a/pkg/cli/peer_policy_name_6851_test.go
+++ b/pkg/cli/peer_policy_name_6851_test.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"sort"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/dataplane"
@@ -126,18 +127,20 @@ func TestCLISanitizePeerHandlesDegenerateShapes_6851(t *testing.T) {
 // Binding it behaviourally needs a live peer dial through c.dialPeer, so it is
 // bound structurally instead.
 //
-// SCOPE: this asserts only that fetchPeerSessions CONTAINS a call to the
-// sanitizer. It does not prove the call precedes every return, it cannot see a
-// sanitizer that was gutted, and it cannot see the argument — measured:
-// `sanitizePeerSessionPolicyNames(nil)` contains the call, bypasses the
-// sanitization entirely, and leaves every package green with the MAJOR fully
-// restored.
+// It asserts the call is present AND that its argument is the value
+// fetchPeerSessions actually returns. The argument half was added after both
+// review legs measured that `sanitizePeerSessionPolicyNames(nil)` contains the
+// call, bypasses sanitization entirely, and left every package green with the
+// MAJOR fully restored — a guard that cannot fire for an edit restoring the
+// exact defect it exists to prevent. The realistic form is not someone typing
+// `nil`; it is a refactor that builds the response in a different local and
+// sanitizes the wrong one, which the argument check catches and a name-only
+// check does not.
 //
-// That residual cell — "call present, argument neutered" — is the same one
-// disclosed for attachPeerSessions in grpcapi, and it is left uncovered
-// deliberately rather than papered over with a guard invented to satisfy a
-// reviewer. The class is covered from two other sides: deleting the call reds
-// this test, and gutting the sanitizer's body reds the behavioural tests above.
+// SCOPE — two residuals genuinely remain, and neither is cheap to close:
+// this does not prove the call precedes every return, and it cannot see a
+// sanitizer whose BODY was gutted. The behavioural tests above cover the second
+// from the other side.
 func TestCLIPeerFetchCallsSanitizer_6851(t *testing.T) {
 	const (
 		file   = "session_filter.go"
@@ -163,20 +166,67 @@ func TestCLIPeerFetchCallsSanitizer_6851(t *testing.T) {
 			"must bring it along rather than silently disarm it", target, file)
 	}
 
+	// The identifiers fetchPeerSessions actually returns (skipping the `nil`
+	// early-error paths). The sanitizer must be handed one of these — sanitizing
+	// anything else leaves the returned response untouched.
+	returned := map[string]bool{}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		ret, ok := n.(*ast.ReturnStmt)
+		if !ok {
+			return true
+		}
+		for _, r := range ret.Results {
+			if id, ok := r.(*ast.Ident); ok && id.Name != "nil" {
+				returned[id.Name] = true
+			}
+		}
+		return true
+	})
+	if len(returned) == 0 {
+		t.Fatalf("%s returns no named value; this canary keys the sanitizer's argument to "+
+			"what the function returns and cannot check anything otherwise", target)
+	}
+
 	called := false
+	sanitizesReturned := false
 	ast.Inspect(fn.Body, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
 		}
-		if id, ok := call.Fun.(*ast.Ident); ok && id.Name == helper {
-			called = true
+		id, ok := call.Fun.(*ast.Ident)
+		if !ok || id.Name != helper {
+			return true
+		}
+		called = true
+		if len(call.Args) == 1 {
+			if arg, ok := call.Args[0].(*ast.Ident); ok && returned[arg.Name] {
+				sanitizesReturned = true
+			}
 		}
 		return true
 	})
+
 	if !called {
 		t.Errorf("%s no longer calls %s. The on-box CLI dials the peer directly, so this is "+
 			"its ONLY sanitization point — without it a pre-#4626 peer's first configured "+
 			"policy is printed for every reserved-id session (#6851)", target, helper)
+		return
 	}
+	if !sanitizesReturned {
+		t.Errorf("%s calls %s, but not on a value it returns (returns %v). Sanitizing a "+
+			"different local — or nil — leaves the response the caller renders untouched, "+
+			"which restores the #6851 defect while this canary's call check still passes",
+			target, helper, keysOf(returned))
+	}
+}
+
+// keysOf renders a set deterministically for a failure message.
+func keysOf(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/pkg/cli/peer_policy_name_6851_test.go
+++ b/pkg/cli/peer_policy_name_6851_test.go
@@ -1,0 +1,165 @@
+package cli
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #6851: the on-box interactive CLI reaches the cluster peer by its OWN route.
+//
+// (c *CLI) fetchPeerSessions dials the peer daemon directly and sets no
+// IncludePeer, so it passes through neither the grpcapi fan-out that sanitizes
+// reserved policy ids nor the peer's own fan-out. Against a pre-#4626 peer,
+// `show security flow session` in cluster mode therefore printed that peer's
+// FIRST CONFIGURED POLICY as the name for every session stamped with reserved
+// id 0 — the exact defect this branch closes, on the surface an operator
+// actually types, during exactly the mixed-version window
+// PeerSessionPolicyName exists for.
+//
+// The remote `cli` binary is not affected (it sets IncludePeer and arrives
+// through grpcapi), and REST is not affected. This is specifically the on-box
+// path, and before this test it had zero behavioural coverage.
+
+func peerSessionsResp6851(policyID uint32, policyName string) *pb.GetSessionsResponse {
+	return &pb.GetSessionsResponse{
+		Sessions: []*pb.SessionEntry{{
+			SrcAddr:    "10.0.1.5",
+			DstAddr:    "10.0.2.9",
+			Protocol:   "tcp",
+			State:      "established",
+			PolicyId:   policyID,
+			PolicyName: policyName,
+		}},
+	}
+}
+
+// TestCLISanitizesPeerReservedPolicyName_6851 drives the sanitizer the CLI's
+// peer ingress applies. Reverting that call makes the pre-#4626 peer's name
+// survive to the renderer.
+func TestCLISanitizesPeerReservedPolicyName_6851(t *testing.T) {
+	const firstPolicy = "trust-to-untrust/allow-web"
+
+	resp := peerSessionsResp6851(0, firstPolicy)
+	sanitizePeerSessionPolicyNames(resp)
+
+	got := resp.GetSessions()[0].GetPolicyName()
+	if got == firstPolicy {
+		t.Fatalf("the peer's policy_name %q survived for reserved id 0. An older peer "+
+			"resolves id 0 as its first configured policy, and `show security flow "+
+			"session` prints that name for host-inbound, fabric and tunnel sessions no "+
+			"policy admitted (#6851)", got)
+	}
+	if got != dataplane.UnattributedPolicyName {
+		t.Errorf("policy_name = %q, want %q", got, dataplane.UnattributedPolicyName)
+	}
+	if id := resp.GetSessions()[0].GetPolicyId(); id != 0 {
+		t.Errorf("policy_id = %d, want 0 — the raw wire value must still be surfaced", id)
+	}
+}
+
+// The default-policy sentinel is reserved on this path too: a pre-#3057 peer
+// can send its own configured name for it.
+func TestCLISanitizesPeerSentinelPolicyName_6851(t *testing.T) {
+	resp := peerSessionsResp6851(dataplane.DefaultPolicySentinelID, "some-configured-policy")
+	sanitizePeerSessionPolicyNames(resp)
+
+	if got := resp.GetSessions()[0].GetPolicyName(); got != dataplane.DefaultPolicyName {
+		t.Errorf("sentinel policy_name = %q, want %q", got, dataplane.DefaultPolicyName)
+	}
+}
+
+// Over-rejection guard: an ordinary id keeps the name the PEER resolved. Policy
+// ids are node-local, so the peer is authoritative for its own sessions and
+// re-resolving against the local table would name whichever local policy
+// happened to occupy that slot.
+func TestCLIKeepsPeerNameForOrdinaryID_6851(t *testing.T) {
+	const peerName = "dmz-to-untrust/allow-any"
+
+	resp := peerSessionsResp6851(7, peerName)
+	sanitizePeerSessionPolicyNames(resp)
+
+	if got := resp.GetSessions()[0].GetPolicyName(); got != peerName {
+		t.Errorf("policy_name = %q, want the peer's own %q — only RESERVED ids are "+
+			"re-taken", got, peerName)
+	}
+}
+
+// Robustness: nil response, nil entry, and a nested peer response must not
+// panic and must still be sanitized. The CLI does not request a nested fan-out,
+// but the guard should not depend on a peer-version invariant.
+func TestCLISanitizePeerHandlesDegenerateShapes_6851(t *testing.T) {
+	sanitizePeerSessionPolicyNames(nil) // must not panic
+
+	resp := peerSessionsResp6851(0, "first-policy")
+	resp.Sessions = append(resp.Sessions, nil)
+	resp.Peer = peerSessionsResp6851(0, "peer-of-peer-first-policy")
+
+	sanitizePeerSessionPolicyNames(resp)
+
+	if got := resp.GetPeer().GetSessions()[0].GetPolicyName(); got != dataplane.UnattributedPolicyName {
+		t.Errorf("nested peer response was not sanitized: policy_name = %q", got)
+	}
+}
+
+// TestCLIPeerFetchCallsSanitizer_6851 binds the CALL, not just the sanitizer.
+//
+// The tests above drive sanitizePeerSessionPolicyNames directly, so they bind
+// its behaviour and leave its one call site unbound — deleting
+// `sanitizePeerSessionPolicyNames(resp)` from fetchPeerSessions compiles and
+// keeps every one of them green while restoring the MAJOR whole. That was
+// measured, not assumed: the mutation came back GREEN before this test existed.
+//
+// Binding it behaviourally needs a live peer dial through c.dialPeer, so it is
+// bound structurally instead.
+//
+// SCOPE: this asserts fetchPeerSessions contains a call to the sanitizer and
+// returns no response value that bypasses it. It does not prove the call
+// precedes every return, and it cannot see a sanitizer that was gutted — the
+// behavioural tests above cover that half.
+func TestCLIPeerFetchCallsSanitizer_6851(t *testing.T) {
+	const (
+		file   = "session_filter.go"
+		target = "fetchPeerSessions"
+		helper = "sanitizePeerSessionPolicyNames"
+	)
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+
+	var fn *ast.FuncDecl
+	for _, decl := range f.Decls {
+		if fd, ok := decl.(*ast.FuncDecl); ok && fd.Name.Name == target {
+			fn = fd
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatalf("%s not found in %s — this canary is keyed to it by name, so a rename "+
+			"must bring it along rather than silently disarm it", target, file)
+	}
+
+	called := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if id, ok := call.Fun.(*ast.Ident); ok && id.Name == helper {
+			called = true
+		}
+		return true
+	})
+	if !called {
+		t.Errorf("%s no longer calls %s. The on-box CLI dials the peer directly, so this is "+
+			"its ONLY sanitization point — without it a pre-#4626 peer's first configured "+
+			"policy is printed for every reserved-id session (#6851)", target, helper)
+	}
+}

--- a/pkg/cli/peer_policy_name_6851_test.go
+++ b/pkg/cli/peer_policy_name_6851_test.go
@@ -57,9 +57,10 @@ func TestCLISanitizesPeerReservedPolicyName_6851(t *testing.T) {
 	if got != dataplane.UnattributedPolicyName {
 		t.Errorf("policy_name = %q, want %q", got, dataplane.UnattributedPolicyName)
 	}
-	if id := resp.GetSessions()[0].GetPolicyId(); id != 0 {
-		t.Errorf("policy_id = %d, want 0 — the raw wire value must still be surfaced", id)
-	}
+	// NOTE: no policy_id assertion here. The input id IS 0, so "want 0" is also
+	// the zero value and cannot distinguish "preserved" from "zeroed" — an
+	// expectation equal to the failure default. The surfacing claim is asserted
+	// on the sentinel sibling below, where the value would differ.
 }
 
 // The default-policy sentinel is reserved on this path too: a pre-#3057 peer
@@ -70,6 +71,14 @@ func TestCLISanitizesPeerSentinelPolicyName_6851(t *testing.T) {
 
 	if got := resp.GetSessions()[0].GetPolicyName(); got != dataplane.DefaultPolicyName {
 		t.Errorf("sentinel policy_name = %q, want %q", got, dataplane.DefaultPolicyName)
+	}
+	// The raw wire id must SURVIVE the substitution. Asserted here rather than
+	// on the id-0 case because 0xFFFFFFFF is distinguishable from the zero
+	// value, so this assertion can actually fail if the sanitizer clobbers the
+	// id while rewriting the name.
+	if id := resp.GetSessions()[0].GetPolicyId(); id != dataplane.DefaultPolicySentinelID {
+		t.Errorf("policy_id = %d, want %d — the sanitizer rewrites the NAME only; the raw "+
+			"wire value must still be surfaced beside it", id, dataplane.DefaultPolicySentinelID)
 	}
 }
 
@@ -117,10 +126,18 @@ func TestCLISanitizePeerHandlesDegenerateShapes_6851(t *testing.T) {
 // Binding it behaviourally needs a live peer dial through c.dialPeer, so it is
 // bound structurally instead.
 //
-// SCOPE: this asserts fetchPeerSessions contains a call to the sanitizer and
-// returns no response value that bypasses it. It does not prove the call
-// precedes every return, and it cannot see a sanitizer that was gutted — the
-// behavioural tests above cover that half.
+// SCOPE: this asserts only that fetchPeerSessions CONTAINS a call to the
+// sanitizer. It does not prove the call precedes every return, it cannot see a
+// sanitizer that was gutted, and it cannot see the argument — measured:
+// `sanitizePeerSessionPolicyNames(nil)` contains the call, bypasses the
+// sanitization entirely, and leaves every package green with the MAJOR fully
+// restored.
+//
+// That residual cell — "call present, argument neutered" — is the same one
+// disclosed for attachPeerSessions in grpcapi, and it is left uncovered
+// deliberately rather than papered over with a guard invented to satisfy a
+// reviewer. The class is covered from two other sides: deleting the call reds
+// this test, and gutting the sanitizer's body reds the behavioural tests above.
 func TestCLIPeerFetchCallsSanitizer_6851(t *testing.T) {
 	const (
 		file   = "session_filter.go"

--- a/pkg/cli/session_filter.go
+++ b/pkg/cli/session_filter.go
@@ -478,7 +478,45 @@ func (c *CLI) fetchPeerSessions(f sessionFilter) *pb.GetSessionsResponse {
 		slog.Warn("failed to fetch peer sessions", "err", err)
 		return nil
 	}
+	// #6851/#4626: the on-box CLI dials the peer DIRECTLY (dialPeer above), so
+	// it never passes through the grpcapi fan-out that sanitizes reserved
+	// policy ids — and it sets no IncludePeer, so the peer skips its own
+	// fan-out too. Against a pre-#4626 peer the response therefore carries
+	// that peer's FIRST CONFIGURED POLICY as the name for every session
+	// stamped with reserved id 0 (host-inbound, fabric, tunnel, and its whole
+	// table if it is in turn syncing from an older node), and `show security
+	// flow session` printed it verbatim.
+	//
+	// Sanitizing HERE rather than at the render site is deliberate: this is the
+	// CLI's own single ingress for peer sessions, so a future render site
+	// cannot reintroduce the bypass by forgetting to call the helper.
+	sanitizePeerSessionPolicyNames(resp)
 	return resp
+}
+
+// sanitizePeerSessionPolicyNames rewrites the policy name of every peer session
+// carrying a RESERVED id, in place (#6851).
+//
+// It mirrors grpcapi sanitizePeerPolicyNames — the two exist because the two
+// surfaces reach the peer by different routes, not because they disagree. Both
+// delegate the decision to dataplane.PeerSessionPolicyName, which is the single
+// place that knows which ids are reserved; neither re-resolves an unreserved id
+// against the LOCAL map, because the peer's own resolution is authoritative for
+// the peer's sessions.
+func sanitizePeerSessionPolicyNames(resp *pb.GetSessionsResponse) {
+	if resp == nil {
+		return
+	}
+	for _, e := range resp.GetSessions() {
+		if e == nil {
+			continue
+		}
+		e.PolicyName = dataplane.PeerSessionPolicyName(e.GetPolicyName(), e.GetPolicyId())
+	}
+	// A peer that itself fanned out would nest another response here. The CLI
+	// does not request that (no IncludePeer), but guard it rather than rely on
+	// an invariant that holds only for the current peer version.
+	sanitizePeerSessionPolicyNames(resp.GetPeer())
 }
 
 // peerSessionsTotal returns the "Total sessions" count to render for a

--- a/pkg/dataplane/policy_display.go
+++ b/pkg/dataplane/policy_display.go
@@ -1,0 +1,93 @@
+package dataplane
+
+// Session policy-name display resolution.
+//
+// A session row carries the admitting policy as a bare `policy_id` u32
+// (SessionValue.PolicyID, stamped by the userspace dataplane per #3056). Two
+// values in that space are RESERVED and do not name a configured policy;
+// resolving either one through the compiled rule-id -> name map produces a
+// confident, wrong attribution. Every session-row display surface must go
+// through SessionPolicyName rather than indexing the map directly.
+
+// UnattributedPolicyID is the `policy_id` a session carries when no configured
+// security policy admitted it (#4626 L01).
+//
+// It is ZERO, which is also the id of the literal first configured policy
+// (PolicySetID 0, rule index 0 — see compilePolicies' `policySetID*
+// MaxRulesPerPolicy + i`). The value is genuinely OVERLOADED on the wire, and
+// nothing else on the session distinguishes the two readings: SessionValue's
+// flag bits are NAT-only (SessFlagSNAT/DNAT/StaticNAT/NAT64/NPTV6), so there is
+// no host-inbound / fabric / tunnel marker to disambiguate against.
+//
+// Who carries it, and it is not a rare population:
+//
+//   - non-policy-forwarded sessions — host-inbound, neighbor-seed, fabric and
+//     tunnel installs all stamp 0 (userspace-dp publish_conntrack.rs: "`0` stays
+//     the value for non-policy-forwarded sessions");
+//   - every pre-#3056 session, which only ever carried the bare wire scalar;
+//   - every session synced from an OLDER HA peer during a rolling upgrade —
+//     that is the peer's WHOLE table, not a corner case.
+//
+// Retiring the overload means reserving the id space so real policies start at
+// 1, which is a cross-plane change (userspace-dp `policy.rs`, the #3056 stamping
+// path, the runtime-id assignment, HA wire compatibility) tracked as the
+// remaining half of #4626 and deliberately NOT done here. Note that reserving
+// the space would still not repair an old peer's sessions during the upgrade
+// window — it keeps sending a bare 0 — so a render-side guard is required
+// either way and is not made redundant by that work.
+const UnattributedPolicyID uint32 = 0
+
+// UnattributedPolicyName is rendered in place of a policy name for a session
+// carrying UnattributedPolicyID.
+//
+// This is deliberately an UNDER-claim. Because the wire value is ambiguous,
+// every possible rendering is wrong for one of the two populations: naming the
+// first configured policy is wrong for every host-inbound/fabric/tunnel/synced
+// session, and naming this pseudo-policy is wrong for the first policy's own
+// sessions. Under-claiming is the safer error on a security surface — an
+// operator who sees "unattributed" investigates, whereas one who sees a real
+// policy name on a host-inbound session draws a false conclusion about which
+// rule admitted traffic and may leave a policy in place believing it is load
+// bearing. It is also the direction the codebase already chose for this exact
+// overload on the behavioral path: deletedPolicyRuntimeIDs excludes id 0 from
+// the deletion-clear as a documented "fail-SAFE under-clear"
+// (pkg/daemon/daemon_policy_invalidate.go). The display should not claim a
+// precision the wire cannot support while the enforcement path refuses to.
+//
+// The numeric id is still shown beside the name on every surface (the CLI
+// prints `Policy name: <name>/<id>`; REST and gRPC carry PolicyID as its own
+// field), so nothing is hidden by this substitution.
+const UnattributedPolicyName = "unattributed"
+
+// SessionPolicyName resolves a session's PolicyID to the policy name a display
+// surface should render, honouring both reserved ids before consulting the
+// compiled map.
+//
+// policyNames is the compiled rule-id -> name map (CompileResult.PolicyNames);
+// a nil map is fine and is the normal state before the first apply publishes
+// one. Callers keep their own not-found behaviour for an unreserved id that is
+// simply absent — this returns "" for that case exactly as a direct map index
+// did, so the CLI's numeric fallback and REST/gRPC's empty field are unchanged.
+//
+// DefaultPolicySentinelID is handled here as well. compilePolicies seeds the map
+// with it, so on the published path a direct index already resolved it; taking
+// it authoritatively means a session row rendered before any apply (nil map)
+// cannot fall through to a raw "4294967295" either. That is belt-and-braces for
+// the unpublished-map case, not a change to the normal path, and it matches how
+// pkg/logging resolvePolicyName treats the same sentinel for RT_FLOW records
+// (#3057).
+func SessionPolicyName(policyNames map[uint32]string, id uint32) string {
+	switch id {
+	case UnattributedPolicyID:
+		// LOAD-BEARING: this arm must come BEFORE the map lookup, and must not
+		// be "rewritten" as a lookup with a fallback. `policyNames[0]` is
+		// populated — it is the first configured policy — so any form that
+		// consults the map first silently restores the #4626 misattribution
+		// while still looking like a guard.
+		return UnattributedPolicyName
+	case DefaultPolicySentinelID:
+		return DefaultPolicyName
+	default:
+		return policyNames[id]
+	}
+}

--- a/pkg/dataplane/policy_display.go
+++ b/pkg/dataplane/policy_display.go
@@ -77,17 +77,76 @@ const UnattributedPolicyName = "unattributed"
 // pkg/logging resolvePolicyName treats the same sentinel for RT_FLOW records
 // (#3057).
 func SessionPolicyName(policyNames map[uint32]string, id uint32) string {
+	// LOAD-BEARING ORDERING: the reserved check must come BEFORE the map
+	// lookup, and must not be "rewritten" as a lookup with a fallback.
+	// `policyNames[0]` is POPULATED — it is the first configured policy — so
+	// any form that consults the map first silently restores the #4626
+	// misattribution while still looking like a guard.
+	if name, ok := ReservedPolicyName(id); ok {
+		return name
+	}
+	return policyNames[id]
+}
+
+// ReservedPolicyName reports whether `id` is one of the two reserved policy ids
+// and, if so, the fixed pseudo-policy name that must be rendered for it.
+//
+// This is the SSOT for "which ids must never reach a name map", shared by every
+// resolver: the session-row surfaces via SessionPolicyName, the cluster-peer
+// fan-out via PeerSessionPolicyName, and pkg/logging's RT_FLOW record resolver,
+// which keeps its own numeric fallback for an unreserved id and so cannot call
+// SessionPolicyName directly.
+//
+// Expressed as an explicit (name, ok) rather than leaving each caller to
+// re-derive the set: a caller that instead probed `SessionPolicyName(nil, id)`
+// for a non-empty result would get the right answer today only because a nil
+// map yields "" for every unreserved id — a property no one is obliged to
+// preserve, and whose loss would silently route unreserved ids away from the
+// caller's own map.
+func ReservedPolicyName(id uint32) (string, bool) {
 	switch id {
 	case UnattributedPolicyID:
-		// LOAD-BEARING: this arm must come BEFORE the map lookup, and must not
-		// be "rewritten" as a lookup with a fallback. `policyNames[0]` is
-		// populated — it is the first configured policy — so any form that
-		// consults the map first silently restores the #4626 misattribution
-		// while still looking like a guard.
-		return UnattributedPolicyName
+		return UnattributedPolicyName, true
 	case DefaultPolicySentinelID:
-		return DefaultPolicyName
+		return DefaultPolicyName, true
 	default:
-		return policyNames[id]
+		return "", false
 	}
+}
+
+// PeerSessionPolicyName resolves the policy name to render for a session
+// fetched from a CLUSTER PEER, given the name that peer already resolved and
+// the session's raw id.
+//
+// #6851: an include_peer fan-out attaches the peer's response and the peer
+// resolved the name itself. A peer running a pre-#4626 build resolved
+// UnattributedPolicyID through its own compiled map and therefore sent the name
+// of ITS first configured policy — so the local guard, which only covers
+// sessions this node renders, is bypassed entirely by a name arriving as DATA.
+// The wrong attribution is then republished on every local surface (gRPC
+// clients, the REST `peer` block via sessionListFromPB, and the CLI).
+//
+// The choice made here, and WHY it is not "re-resolve everything from the id":
+// policy ids are NODE-LOCAL. `compilePolicies` assigns them from the local
+// config's rule ordering, so the peer's id space is the peer's, and the peer is
+// authoritative for the names of its OWN sessions. Re-resolving an unreserved
+// peer id against the LOCAL policyNames map would name whichever local policy
+// happens to occupy that slot — a fresh misattribution, and one that fires on
+// every mixed-config cluster rather than only on an old peer.
+//
+// So only the RESERVED ids are overridden, and the peer's name is kept for
+// everything else. The two behave identically when the peer is the same
+// version (it already sends `unattributed` / `default-policy` for those ids);
+// they differ only for an older peer, which is exactly the population that
+// needs correcting. An empty peerName for an unreserved id stays empty, so a
+// caller's own not-found handling is unchanged.
+func PeerSessionPolicyName(peerName string, id uint32) string {
+	// Same LOAD-BEARING ordering as SessionPolicyName: the reserved check must
+	// precede any use of peerName. A form that trusts a non-empty peerName
+	// first restores the misattribution for exactly the old-peer population
+	// this exists for, while still looking like a guard.
+	if name, ok := ReservedPolicyName(id); ok {
+		return name
+	}
+	return peerName
 }

--- a/pkg/dataplane/policy_display.go
+++ b/pkg/dataplane/policy_display.go
@@ -140,6 +140,12 @@ func ReservedPolicyName(id uint32) (string, bool) {
 // they differ only for an older peer, which is exactly the population that
 // needs correcting. An empty peerName for an unreserved id stays empty, so a
 // caller's own not-found handling is unchanged.
+//
+// WHERE THIS IS BOUND (#6851 review): there is no direct unit test of this
+// function in pkg/dataplane. The reserved-before-peer-name ordering documented
+// above is bound TRANSITIVELY — reversing it reds pkg/cli and pkg/grpcapi while
+// pkg/dataplane stays green. The property is covered; it is just not covered in
+// the package where it is documented, so do not go looking for the guard here.
 func PeerSessionPolicyName(peerName string, id uint32) string {
 	// Same LOAD-BEARING ordering as SessionPolicyName: the reserved check must
 	// precede any use of peerName. A form that trusts a non-empty peerName

--- a/pkg/dataplane/policy_display_4626_test.go
+++ b/pkg/dataplane/policy_display_4626_test.go
@@ -132,6 +132,58 @@ var reservedPolicyHelpers = []string{
 	"ReservedPolicyName", "SessionPolicyName", "PeerSessionPolicyName",
 }
 
+// scanPolicyNameScope reports unguarded policy-name map indexes inside ONE
+// function scope, then recurses into each nested function literal as its own
+// scope. A helper call in the parent does not guard a closure, and a helper
+// call in one closure does not guard its sibling (#6851).
+func scanPolicyNameScope(owner string, body ast.Node, path string, fset *token.FileSet, violations *[]string) {
+	var indexes []*ast.IndexExpr
+	var nested []*ast.FuncLit
+	guarded := false
+
+	var walk func(n ast.Node) bool
+	walk = func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.FuncLit:
+			if node.Body != body {
+				nested = append(nested, node)
+				return false // its contents belong to ITS scope, not this one
+			}
+		case *ast.CallExpr:
+			for _, h := range reservedPolicyHelpers {
+				if isCallTo(node, h) {
+					guarded = true
+				}
+			}
+		case *ast.IndexExpr:
+			name := ""
+			switch x := node.X.(type) {
+			case *ast.Ident:
+				name = x.Name
+			case *ast.SelectorExpr:
+				name = x.Sel.Name
+			}
+			if name == "policyNames" || name == "PolicyNames" {
+				indexes = append(indexes, node)
+			}
+		}
+		return true
+	}
+	ast.Inspect(body, walk)
+
+	if !guarded {
+		for _, idx := range indexes {
+			*violations = append(*violations, fmt.Sprintf(
+				"%s:%d: %s indexes the policy-name map without consulting %v first",
+				path, fset.Position(idx.Pos()).Line, owner, reservedPolicyHelpers))
+		}
+	}
+	for i, fl := range nested {
+		scanPolicyNameScope(fmt.Sprintf("%s closure #%d", owner, i+1), fl.Body,
+			path, fset, violations)
+	}
+}
+
 // isCallTo reports whether call invokes a function whose (possibly
 // package-qualified) name is fn — `fn(...)`, `pkg.fn(...)` or `x.fn(...)`.
 func isCallTo(call *ast.CallExpr, fn string) bool {
@@ -145,7 +197,7 @@ func isCallTo(call *ast.CallExpr, fn string) bool {
 }
 func TestSessionRowSurfacesUseSessionPolicyName_4626(t *testing.T) {
 	var violations []string
-	scanned := 0
+	perPkg := map[string]int{}
 
 	for _, pkg := range sessionPolicyNameDisplayPackages {
 		root := filepath.Join("..", pkg)
@@ -156,62 +208,40 @@ func TestSessionRowSurfacesUseSessionPolicyName_4626(t *testing.T) {
 			if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 				return nil
 			}
-			scanned++
+			perPkg[pkg]++
 
 			fset := token.NewFileSet()
 			f, perr := parser.ParseFile(fset, path, nil, 0)
 			if perr != nil {
 				t.Fatalf("parse %s: %v", path, perr)
 			}
-			// Walk per FUNCTION, because there are two legitimate shapes and a
-			// blanket "no index" rule rejects one of them:
+			// Walk per innermost FUNCTION SCOPE — a FuncDecl body, or a nested
+			// FuncLit body as its own scope.
+			//
+			// Two legitimate shapes exist and a blanket "no index" rule rejects
+			// one of them:
 			//
 			//   (a) delegate wholly — SessionPolicyName(policyNames, id);
 			//   (b) take the reserved ids first, then index —
 			//       `if n, ok := ReservedPolicyName(id); ok { return n }`.
 			//
 			// (b) is what pkg/logging resolvePolicyName does, and it is correct:
-			// the index is only reached for an id that is not reserved. So an
-			// index is a violation only in a function that never consults a
-			// reserved-id helper at all.
+			// the index is only reached for an id that is not reserved.
+			//
+			// #6851: the scope MUST be the innermost function, not the enclosing
+			// FuncDecl. pkg/cli showFlowSession is 557 lines and contains BOTH
+			// render sites inside separate printV4/printV6 closures, so a
+			// FuncDecl-scoped rule marked the whole function guarded from either
+			// closure's helper call — reverting exactly one site left the
+			// sibling's call satisfying the rule and the canary green. Measured:
+			// reverting only the v6 site passed both this canary and the full
+			// pkg/cli suite. Per-FuncLit, each closure stands on its own.
 			for _, decl := range f.Decls {
 				fn, ok := decl.(*ast.FuncDecl)
 				if !ok || fn.Body == nil {
 					continue
 				}
-				var indexes []*ast.IndexExpr
-				guarded := false
-				ast.Inspect(fn.Body, func(n ast.Node) bool {
-					switch node := n.(type) {
-					case *ast.CallExpr:
-						for _, h := range reservedPolicyHelpers {
-							if isCallTo(node, h) {
-								guarded = true
-							}
-						}
-					case *ast.IndexExpr:
-						name := ""
-						switch x := node.X.(type) {
-						case *ast.Ident:
-							name = x.Name
-						case *ast.SelectorExpr:
-							name = x.Sel.Name
-						}
-						if name == "policyNames" || name == "PolicyNames" {
-							indexes = append(indexes, node)
-						}
-					}
-					return true
-				})
-				if guarded {
-					continue
-				}
-				for _, idx := range indexes {
-					violations = append(violations, fmt.Sprintf(
-						"%s:%d: %s indexes the policy-name map without consulting %v first",
-						path, fset.Position(idx.Pos()).Line, fn.Name.Name,
-						reservedPolicyHelpers))
-				}
+				scanPolicyNameScope(fn.Name.Name, fn.Body, path, fset, &violations)
 			}
 			return nil
 		})
@@ -220,11 +250,39 @@ func TestSessionRowSurfacesUseSessionPolicyName_4626(t *testing.T) {
 		}
 	}
 
-	// Guard the guard: a walk that silently scanned nothing would pass forever.
-	if scanned < 20 {
-		t.Fatalf("canary scanned only %d files across %v; the walk is broken and this test "+
-			"is not checking anything", scanned, sessionPolicyNameDisplayPackages)
+	// Guard the guard, PER PACKAGE (#6851). A total-file floor does not bind
+	// its own dimension: re-adding the pkg/logging carve-out AND reverting
+	// ringbuf.go together kept the total above the threshold, so the very
+	// regression this list exists to prevent went green. Each package must
+	// contribute scanned files of its own.
+	// The list itself is the thing being guarded, so assert MEMBERSHIP before
+	// coverage (#6851). A per-package file floor only fires for a package that
+	// IS listed and scanned nothing — removing "logging" from the list removes
+	// it from the loop, so the floor never runs for it and the carve-out
+	// reinstates silently. Measured: re-adding the carve-out alone went GREEN
+	// against the floor alone.
+	required := map[string]bool{"cli": true, "api": true, "grpcapi": true, "logging": true}
+	for _, pkg := range sessionPolicyNameDisplayPackages {
+		delete(required, pkg)
 	}
+	for pkg := range required {
+		t.Fatalf("pkg/%s was dropped from sessionPolicyNameDisplayPackages. Every one of "+
+			"these packages resolves a policy_id into a NAME on an operator- or "+
+			"automation-visible surface; carving one out is how the seventh resolver "+
+			"survived round 1, and the carve-out that did it was justified by an argument "+
+			"the same change disproved", pkg)
+	}
+
+	for _, pkg := range sessionPolicyNameDisplayPackages {
+		if perPkg[pkg] == 0 {
+			t.Fatalf("canary scanned ZERO files in pkg/%s. Dropping a package from "+
+				"sessionPolicyNameDisplayPackages — or pointing it at a path that no "+
+				"longer exists — silently removes its coverage while the rest of the "+
+				"walk still passes; that is exactly how the seventh resolver survived",
+				pkg)
+		}
+	}
+
 	if len(violations) > 0 {
 		t.Errorf("session-row policy names must resolve through dataplane.SessionPolicyName, "+
 			"which reserves id 0 (no policy admitted the session) and the default-policy "+

--- a/pkg/dataplane/policy_display_4626_test.go
+++ b/pkg/dataplane/policy_display_4626_test.go
@@ -275,11 +275,13 @@ func TestSessionRowSurfacesUseSessionPolicyName_4626(t *testing.T) {
 
 	for _, pkg := range sessionPolicyNameDisplayPackages {
 		if perPkg[pkg] == 0 {
-			t.Fatalf("canary scanned ZERO files in pkg/%s. Dropping a package from "+
-				"sessionPolicyNameDisplayPackages — or pointing it at a path that no "+
-				"longer exists — silently removes its coverage while the rest of the "+
-				"walk still passes; that is exactly how the seventh resolver survived",
-				pkg)
+			t.Fatalf("canary scanned ZERO files in pkg/%s. Its directory exists but "+
+				"yielded no production .go files, so every per-file check below is "+
+				"vacuously satisfied and the package contributes no coverage while the "+
+				"rest of the walk still passes. (A path that does not exist is a "+
+				"different case: WalkDir errors and the Fatalf above fires first.) "+
+				"Membership is asserted separately, because a package REMOVED from the "+
+				"list never reaches this loop at all", pkg)
 		}
 	}
 

--- a/pkg/dataplane/policy_display_4626_test.go
+++ b/pkg/dataplane/policy_display_4626_test.go
@@ -1,0 +1,172 @@
+package dataplane
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #4626 L01. `policy_id` 0 is overloaded: it is both the id of the literal
+// first configured policy (compilePolicies assigns
+// policySetID*MaxRulesPerPolicy + i, so the first rule of the first zone-pair
+// is 0) AND the value stamped on every session no policy admitted —
+// host-inbound, neighbor-seed, fabric, tunnel, every pre-#3056 session, and
+// every session synced from an older HA peer during a rolling upgrade.
+//
+// Resolving it through CompileResult.PolicyNames therefore returns a real
+// policy name for sessions that policy never saw. SessionPolicyName is the
+// guard; these tests pin both the guard and the fact that the six session-row
+// render sites go through it.
+
+// TestSessionPolicyNameReservedIDs_4626 is the guard's own fail-on-revert. The
+// map deliberately CARRIES a name at id 0 — that is the whole defect, and a
+// fixture without it would pass against a broken implementation.
+func TestSessionPolicyNameReservedIDs_4626(t *testing.T) {
+	// A realistic compiled map: id 0 is the first configured policy, exactly
+	// as compilePolicies emits it, plus the seeded default sentinel.
+	names := map[uint32]string{
+		0:                       "trust-to-untrust/allow-web",
+		1:                       "trust-to-untrust/allow-dns",
+		256:                     "dmz-to-untrust/allow-any",
+		DefaultPolicySentinelID: DefaultPolicyName,
+	}
+
+	t.Run("zero never resolves to the first policy", func(t *testing.T) {
+		got := SessionPolicyName(names, 0)
+		if got == names[0] {
+			t.Fatalf("SessionPolicyName(_, 0) = %q — the first configured policy's name. "+
+				"A host-inbound/fabric/tunnel/older-peer session carries id 0 and no policy "+
+				"admitted it; naming a real policy there is a confidently wrong attribution "+
+				"on a security surface (#4626)", got)
+		}
+		if got != UnattributedPolicyName {
+			t.Fatalf("SessionPolicyName(_, 0) = %q, want %q", got, UnattributedPolicyName)
+		}
+	})
+
+	t.Run("zero is unattributed with no policies configured", func(t *testing.T) {
+		if got := SessionPolicyName(map[uint32]string{}, 0); got != UnattributedPolicyName {
+			t.Errorf("empty map: got %q, want %q", got, UnattributedPolicyName)
+		}
+		if got := SessionPolicyName(nil, 0); got != UnattributedPolicyName {
+			t.Errorf("nil map: got %q, want %q", got, UnattributedPolicyName)
+		}
+	})
+
+	t.Run("default sentinel resolves without a published map", func(t *testing.T) {
+		if got := SessionPolicyName(names, DefaultPolicySentinelID); got != DefaultPolicyName {
+			t.Errorf("seeded map: got %q, want %q", got, DefaultPolicyName)
+		}
+		// Before the first apply the map is nil; the sentinel must still not
+		// fall through to a raw numeric render (#3057 parity).
+		if got := SessionPolicyName(nil, DefaultPolicySentinelID); got != DefaultPolicyName {
+			t.Errorf("nil map: got %q, want %q", got, DefaultPolicyName)
+		}
+	})
+
+	// Over-rejection guard: every UNRESERVED id must still resolve exactly as a
+	// direct map index did, including returning "" for an absent id so each
+	// caller's own not-found fallback is unchanged.
+	t.Run("unreserved ids are unchanged", func(t *testing.T) {
+		for _, id := range []uint32{1, 256} {
+			if got, want := SessionPolicyName(names, id), names[id]; got != want {
+				t.Errorf("SessionPolicyName(_, %d) = %q, want %q — the guard must not "+
+					"disturb ordinary policy resolution", id, got, want)
+			}
+		}
+		for _, id := range []uint32{2, 7, 255, 257, 100000, DefaultPolicySentinelID - 1} {
+			if got := SessionPolicyName(names, id); got != "" {
+				t.Errorf("SessionPolicyName(_, %d) = %q, want \"\" — an absent id must stay "+
+					"empty so callers keep their existing numeric/blank fallback", id, got)
+			}
+		}
+	})
+}
+
+// sessionPolicyNameDisplayPackages are the packages that render a SESSION ROW's
+// policy name. pkg/logging is deliberately absent: the RT_FLOW/event path owns
+// its own resolver (EventReader.resolvePolicyName, #3057) over a different map
+// instance, and folding the two is a separate change.
+var sessionPolicyNameDisplayPackages = []string{"cli", "api", "grpcapi"}
+
+// TestSessionRowSurfacesUseSessionPolicyName_4626 is the render-site binding.
+//
+// The behavioural tests in pkg/api and pkg/grpcapi drive four of the six render
+// sites directly. The remaining two are inside printV4/printV6, closures in
+// pkg/cli showFlowSession that fmt.Printf to real stdout behind a live
+// dataplane, so no cheap behavioural test reaches them — and a guard nobody
+// exercises is exactly how #4626 survived #3056 and #3057. This canary covers
+// all six structurally, and any seventh added later, by refusing a direct map
+// index in the display packages.
+//
+// SCOPE, stated rather than implied: it rejects an index expression whose
+// operand is an identifier or field named `policyNames`/`PolicyNames` inside
+// pkg/cli, pkg/api and pkg/grpcapi production files. It does NOT prove those
+// packages resolve policy names correctly in general, and it cannot see a copy
+// of the map stored under another name first. It binds the specific regression
+// shape: re-inlining `policyNames[val.PolicyID]` at a session-row render site.
+func TestSessionRowSurfacesUseSessionPolicyName_4626(t *testing.T) {
+	var violations []string
+	scanned := 0
+
+	for _, pkg := range sessionPolicyNameDisplayPackages {
+		root := filepath.Join("..", pkg)
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			scanned++
+
+			fset := token.NewFileSet()
+			f, perr := parser.ParseFile(fset, path, nil, 0)
+			if perr != nil {
+				t.Fatalf("parse %s: %v", path, perr)
+			}
+			ast.Inspect(f, func(n ast.Node) bool {
+				idx, ok := n.(*ast.IndexExpr)
+				if !ok {
+					return true
+				}
+				name := ""
+				switch x := idx.X.(type) {
+				case *ast.Ident:
+					name = x.Name
+				case *ast.SelectorExpr:
+					name = x.Sel.Name
+				}
+				if name != "policyNames" && name != "PolicyNames" {
+					return true
+				}
+				violations = append(violations, fmt.Sprintf(
+					"%s:%d: direct %s[...] index at a session-row display surface",
+					path, fset.Position(idx.Pos()).Line, name))
+				return true
+			})
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+
+	// Guard the guard: a walk that silently scanned nothing would pass forever.
+	if scanned < 20 {
+		t.Fatalf("canary scanned only %d files across %v; the walk is broken and this test "+
+			"is not checking anything", scanned, sessionPolicyNameDisplayPackages)
+	}
+	if len(violations) > 0 {
+		t.Errorf("session-row policy names must resolve through dataplane.SessionPolicyName, "+
+			"which reserves id 0 (no policy admitted the session) and the default-policy "+
+			"sentinel. A direct map index renders id 0 as the FIRST configured policy — the "+
+			"#4626 misattribution. Offending sites:\n  %s",
+			strings.Join(violations, "\n  "))
+	}
+}

--- a/pkg/dataplane/policy_display_4626_test.go
+++ b/pkg/dataplane/policy_display_4626_test.go
@@ -88,11 +88,20 @@ func TestSessionPolicyNameReservedIDs_4626(t *testing.T) {
 	})
 }
 
-// sessionPolicyNameDisplayPackages are the packages that render a SESSION ROW's
-// policy name. pkg/logging is deliberately absent: the RT_FLOW/event path owns
-// its own resolver (EventReader.resolvePolicyName, #3057) over a different map
-// instance, and folding the two is a separate change.
-var sessionPolicyNameDisplayPackages = []string{"cli", "api", "grpcapi"}
+// sessionPolicyNameDisplayPackages are the packages that turn a policy_id into
+// a policy NAME for an operator- or automation-visible surface.
+//
+// pkg/logging is in the list. An earlier revision excluded it, reasoning that
+// the RT_FLOW/event path "owns its own resolver ... and folding the two is a
+// separate change". That reasoning did not survive #6851: owning a resolver is
+// not exemption from the reserved ids. EventReader.resolvePolicyName took
+// DefaultPolicySentinelID (#3057) and then indexed the map, so id 0 resolved to
+// the first configured policy there too — the SEVENTH instance of the same
+// defect, and the one that matters most, because a log record is durable and
+// ships off-box. The exclusion is what let that site sit unguarded through the
+// first round: a package carved out of a canary is a package nothing checks, so
+// the carve-out needs the same evidence as the fix does.
+var sessionPolicyNameDisplayPackages = []string{"cli", "api", "grpcapi", "logging"}
 
 // TestSessionRowSurfacesUseSessionPolicyName_4626 is the render-site binding.
 //
@@ -104,12 +113,36 @@ var sessionPolicyNameDisplayPackages = []string{"cli", "api", "grpcapi"}
 // all six structurally, and any seventh added later, by refusing a direct map
 // index in the display packages.
 //
-// SCOPE, stated rather than implied: it rejects an index expression whose
-// operand is an identifier or field named `policyNames`/`PolicyNames` inside
-// pkg/cli, pkg/api and pkg/grpcapi production files. It does NOT prove those
-// packages resolve policy names correctly in general, and it cannot see a copy
-// of the map stored under another name first. It binds the specific regression
-// shape: re-inlining `policyNames[val.PolicyID]` at a session-row render site.
+// SCOPE, stated rather than implied. It rejects an index of an identifier or
+// field named `policyNames`/`PolicyNames` inside a production function of
+// pkg/cli, pkg/api, pkg/grpcapi or pkg/logging that never calls a reserved-id
+// helper. Three things it does NOT prove:
+//
+//   - that the helper call DOMINATES the index on every path. A function that
+//     consulted a helper in a dead branch and indexed the map on the live one
+//     would pass. The check is "this function knows about the reserved ids",
+//     not a dataflow proof.
+//   - that those packages resolve policy names correctly in general.
+//   - anything about a copy of the map stored under another name first.
+//
+// It binds the specific regression shape: re-inlining `policyNames[val.PolicyID]`
+// at a site with no reserved-id handling, which is what all seven instances of
+// this defect looked like.
+var reservedPolicyHelpers = []string{
+	"ReservedPolicyName", "SessionPolicyName", "PeerSessionPolicyName",
+}
+
+// isCallTo reports whether call invokes a function whose (possibly
+// package-qualified) name is fn — `fn(...)`, `pkg.fn(...)` or `x.fn(...)`.
+func isCallTo(call *ast.CallExpr, fn string) bool {
+	switch f := call.Fun.(type) {
+	case *ast.Ident:
+		return f.Name == fn
+	case *ast.SelectorExpr:
+		return f.Sel.Name == fn
+	}
+	return false
+}
 func TestSessionRowSurfacesUseSessionPolicyName_4626(t *testing.T) {
 	var violations []string
 	scanned := 0
@@ -130,26 +163,56 @@ func TestSessionRowSurfacesUseSessionPolicyName_4626(t *testing.T) {
 			if perr != nil {
 				t.Fatalf("parse %s: %v", path, perr)
 			}
-			ast.Inspect(f, func(n ast.Node) bool {
-				idx, ok := n.(*ast.IndexExpr)
-				if !ok {
+			// Walk per FUNCTION, because there are two legitimate shapes and a
+			// blanket "no index" rule rejects one of them:
+			//
+			//   (a) delegate wholly — SessionPolicyName(policyNames, id);
+			//   (b) take the reserved ids first, then index —
+			//       `if n, ok := ReservedPolicyName(id); ok { return n }`.
+			//
+			// (b) is what pkg/logging resolvePolicyName does, and it is correct:
+			// the index is only reached for an id that is not reserved. So an
+			// index is a violation only in a function that never consults a
+			// reserved-id helper at all.
+			for _, decl := range f.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					continue
+				}
+				var indexes []*ast.IndexExpr
+				guarded := false
+				ast.Inspect(fn.Body, func(n ast.Node) bool {
+					switch node := n.(type) {
+					case *ast.CallExpr:
+						for _, h := range reservedPolicyHelpers {
+							if isCallTo(node, h) {
+								guarded = true
+							}
+						}
+					case *ast.IndexExpr:
+						name := ""
+						switch x := node.X.(type) {
+						case *ast.Ident:
+							name = x.Name
+						case *ast.SelectorExpr:
+							name = x.Sel.Name
+						}
+						if name == "policyNames" || name == "PolicyNames" {
+							indexes = append(indexes, node)
+						}
+					}
 					return true
+				})
+				if guarded {
+					continue
 				}
-				name := ""
-				switch x := idx.X.(type) {
-				case *ast.Ident:
-					name = x.Name
-				case *ast.SelectorExpr:
-					name = x.Sel.Name
+				for _, idx := range indexes {
+					violations = append(violations, fmt.Sprintf(
+						"%s:%d: %s indexes the policy-name map without consulting %v first",
+						path, fset.Position(idx.Pos()).Line, fn.Name.Name,
+						reservedPolicyHelpers))
 				}
-				if name != "policyNames" && name != "PolicyNames" {
-					return true
-				}
-				violations = append(violations, fmt.Sprintf(
-					"%s:%d: direct %s[...] index at a session-row display surface",
-					path, fset.Position(idx.Pos()).Line, name))
-				return true
-			})
+			}
 			return nil
 		})
 		if err != nil {

--- a/pkg/grpcapi/peer_fanout_attach_6851_test.go
+++ b/pkg/grpcapi/peer_fanout_attach_6851_test.go
@@ -1,0 +1,92 @@
+package grpcapi
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// #6851 residual closure. attachPeerSessions fuses the sanitize with the attach
+// so that dropping the guard also drops the attach and fails loudly — but
+// attachPeerSessions' own doc names what that does NOT cover:
+//
+//	Replacing this call with a bare `resp.Peer = peerResp` would not be caught
+//	here.
+//
+// That is exact: the behavioural tests drive attachPeerSessions, so they bind
+// the pair, but nothing binds fetchPeerSessions' call TO it. Binding it
+// behaviourally needs a live cluster.Manager with PeerAlive() plus a real
+// authenticated peer dial, which a unit test cannot reach. So it is bound
+// structurally instead.
+//
+// SCOPE, stated rather than implied. This checks ONE function, fetchPeerSessions,
+// for two properties: it must call attachPeerSessions, and it must not assign
+// resp.Peer directly. It does not verify the sanitizing is correct (the
+// behavioural tests do that), and it deliberately does not police the other
+// `resp.Peer = peerResp` sites in this file — getSessionSummary at ~:927 and
+// getZonePairSummary at ~:1039 attach AGGREGATE responses that carry no
+// per-session policy name, so routing them through a session sanitizer would be
+// wrong, not safer.
+func TestPeerSessionFanOutGoesThroughAttach_6851(t *testing.T) {
+	const (
+		file   = "server_sessions.go"
+		target = "fetchPeerSessions"
+		helper = "attachPeerSessions"
+	)
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+
+	var fn *ast.FuncDecl
+	for _, decl := range f.Decls {
+		if fd, ok := decl.(*ast.FuncDecl); ok && fd.Name.Name == target {
+			fn = fd
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatalf("%s not found in %s — this canary is keyed to that function by name, so a "+
+			"rename must bring it along rather than silently disarm it", target, file)
+	}
+
+	callsHelper := false
+	var directAssigns []string
+
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.CallExpr:
+			if id, ok := node.Fun.(*ast.Ident); ok && id.Name == helper {
+				callsHelper = true
+			}
+		case *ast.AssignStmt:
+			for _, lhs := range node.Lhs {
+				sel, ok := lhs.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != "Peer" {
+					continue
+				}
+				directAssigns = append(directAssigns,
+					fset.Position(node.Pos()).String())
+			}
+		}
+		return true
+	})
+
+	if !callsHelper {
+		t.Errorf("%s no longer calls %s. The peer fan-out response carries policy names the "+
+			"PEER resolved with its own binary; an older peer renders reserved id 0 as its "+
+			"first configured policy, and attaching that unchanged republishes the "+
+			"misattribution on every local surface — gRPC, the REST `peer` block, and the "+
+			"CLI (#6851/#4626)", target, helper)
+	}
+	if len(directAssigns) > 0 {
+		t.Errorf("%s assigns resp.Peer directly at %s. The attach must go through %s, which "+
+			"sanitizes the reserved ids first — assigning around it is exactly the bypass "+
+			"that function's doc names as uncovered (#6851)",
+			target, strings.Join(directAssigns, ", "), helper)
+	}
+}

--- a/pkg/grpcapi/peer_policy_name_6851_test.go
+++ b/pkg/grpcapi/peer_policy_name_6851_test.go
@@ -1,0 +1,122 @@
+package grpcapi
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #6851 MAJOR 2: a peer-supplied NAME bypasses the #4626 guard.
+//
+// The #4626 guard resolves a policy name from a raw id for rows THIS node
+// renders. An include_peer fan-out is different: the peer resolved the name
+// itself and we attach its response. A peer on a pre-#4626 build resolved
+// reserved id 0 through its own compiled map and sent the name of ITS first
+// configured policy, and that string was republished unchanged on every local
+// surface — gRPC clients, the REST `peer` block via sessionListFromPB, and the
+// CLI.
+//
+// The fixture models exactly that: a peer entry whose PolicyId is 0 and whose
+// PolicyName is already populated with a real policy name. An entry with an
+// empty name would pass against the unfixed code.
+func oldPeerResponse6851() *pb.GetSessionsResponse {
+	return &pb.GetSessionsResponse{
+		Sessions: []*pb.SessionEntry{
+			{
+				// What a pre-#4626 peer sends for a host-inbound / fabric /
+				// tunnel / older-peer-synced session.
+				PolicyId:   0,
+				PolicyName: "trust-to-untrust/allow-web",
+			},
+			{
+				// A session a real policy on the PEER admitted.
+				PolicyId:   7,
+				PolicyName: "peer-only-policy/allow-ssh",
+			},
+			{
+				PolicyId:   dataplane.DefaultPolicySentinelID,
+				PolicyName: "whatever-the-old-peer-said",
+			},
+		},
+	}
+}
+
+func TestAttachPeerSessionsOverridesReservedPolicyName_6851(t *testing.T) {
+	resp := &pb.GetSessionsResponse{}
+	peer := oldPeerResponse6851()
+
+	attachPeerSessions(resp, peer)
+
+	if resp.GetPeer() == nil {
+		t.Fatalf("peer response was not attached — the guard must not drop the fan-out")
+	}
+	got := resp.GetPeer().GetSessions()
+	if len(got) != 3 {
+		t.Fatalf("attached %d peer sessions, want 3", len(got))
+	}
+
+	if got[0].GetPolicyName() == "trust-to-untrust/allow-web" {
+		t.Fatalf("peer session with policy_id 0 still reports %q — the peer's own "+
+			"misattribution was republished unchanged (#6851)", got[0].GetPolicyName())
+	}
+	if want := dataplane.UnattributedPolicyName; got[0].GetPolicyName() != want {
+		t.Errorf("peer policy_id 0 name = %q, want %q", got[0].GetPolicyName(), want)
+	}
+
+	// THE DECISION, pinned: an UNRESERVED peer id keeps the PEER's name. Policy
+	// ids are node-local, so the peer is authoritative for its own sessions;
+	// re-resolving 7 against the LOCAL map would name whichever local policy
+	// occupies that slot — a fresh misattribution on every mixed-config
+	// cluster, not a fix. This assertion is what distinguishes the shipped
+	// choice from "re-resolve everything from the id".
+	if want := "peer-only-policy/allow-ssh"; got[1].GetPolicyName() != want {
+		t.Errorf("unreserved peer id name = %q, want the PEER's own %q — an "+
+			"unreserved id must not be re-resolved locally", got[1].GetPolicyName(), want)
+	}
+
+	// The other reserved id is taken authoritatively too.
+	if want := dataplane.DefaultPolicyName; got[2].GetPolicyName() != want {
+		t.Errorf("peer default-sentinel name = %q, want %q", got[2].GetPolicyName(), want)
+	}
+
+	// The raw id is untouched, so nothing is hidden by the substitution.
+	if got[0].GetPolicyId() != 0 {
+		t.Errorf("policy_id = %d, want 0 — the wire value must still be surfaced",
+			got[0].GetPolicyId())
+	}
+}
+
+// A peer that itself nested a fan-out response must be sanitized too. This
+// should not happen (include_peer is not forwarded, to prevent recursion), but
+// the guard must not depend on a remote node honouring that.
+func TestAttachPeerSessionsSanitizesNestedPeer_6851(t *testing.T) {
+	resp := &pb.GetSessionsResponse{}
+	peer := oldPeerResponse6851()
+	peer.Peer = oldPeerResponse6851()
+
+	attachPeerSessions(resp, peer)
+
+	nested := resp.GetPeer().GetPeer().GetSessions()
+	if len(nested) == 0 {
+		t.Fatalf("nested peer sessions missing")
+	}
+	if want := dataplane.UnattributedPolicyName; nested[0].GetPolicyName() != want {
+		t.Errorf("nested peer policy_id 0 name = %q, want %q", nested[0].GetPolicyName(), want)
+	}
+}
+
+// Degenerate inputs must not panic: a nil response, and a nil entry inside a
+// response, are both reachable from a hostile or version-drifted peer.
+func TestAttachPeerSessionsHandlesNils_6851(t *testing.T) {
+	sanitizePeerPolicyNames(nil)
+
+	resp := &pb.GetSessionsResponse{}
+	attachPeerSessions(resp, &pb.GetSessionsResponse{
+		Sessions: []*pb.SessionEntry{nil, {PolicyId: 0, PolicyName: "x"}},
+	})
+	got := resp.GetPeer().GetSessions()
+	if want := dataplane.UnattributedPolicyName; got[1].GetPolicyName() != want {
+		t.Errorf("entry after a nil = %q, want %q", got[1].GetPolicyName(), want)
+	}
+}

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -1693,14 +1693,15 @@ func sessionEntryV4(key dataplane.SessionKey, val dataplane.SessionValue, now ui
 		outIf = zoneNames[val.EgressZone]
 	}
 	se := &pb.SessionEntry{
-		SrcAddr:          net.IP(key.SrcIP[:]).String(),
-		DstAddr:          net.IP(key.DstIP[:]).String(),
-		SrcPort:          uint32(ntohs(key.SrcPort)),
-		DstPort:          uint32(ntohs(key.DstPort)),
-		Protocol:         protoName(key.Protocol),
-		State:            sessionStateName(val.State),
-		PolicyId:         val.PolicyID,
-		PolicyName:       policyNames[val.PolicyID],
+		SrcAddr:  net.IP(key.SrcIP[:]).String(),
+		DstAddr:  net.IP(key.DstIP[:]).String(),
+		SrcPort:  uint32(ntohs(key.SrcPort)),
+		DstPort:  uint32(ntohs(key.DstPort)),
+		Protocol: protoName(key.Protocol),
+		State:    sessionStateName(val.State),
+		PolicyId: val.PolicyID,
+		// #4626: reserved ids must not be resolved through the compiled map.
+		PolicyName:       dataplane.SessionPolicyName(policyNames, val.PolicyID),
 		IngressZone:      uint32(val.IngressZone),
 		EgressZone:       uint32(val.EgressZone),
 		IngressZoneName:  zoneNames[val.IngressZone],
@@ -1746,14 +1747,15 @@ func sessionEntryV6(key dataplane.SessionKeyV6, val dataplane.SessionValueV6, no
 		outIf = zoneNames[val.EgressZone]
 	}
 	se := &pb.SessionEntry{
-		SrcAddr:          net.IP(key.SrcIP[:]).String(),
-		DstAddr:          net.IP(key.DstIP[:]).String(),
-		SrcPort:          uint32(ntohs(key.SrcPort)),
-		DstPort:          uint32(ntohs(key.DstPort)),
-		Protocol:         protoName(key.Protocol),
-		State:            sessionStateName(val.State),
-		PolicyId:         val.PolicyID,
-		PolicyName:       policyNames[val.PolicyID],
+		SrcAddr:  net.IP(key.SrcIP[:]).String(),
+		DstAddr:  net.IP(key.DstIP[:]).String(),
+		SrcPort:  uint32(ntohs(key.SrcPort)),
+		DstPort:  uint32(ntohs(key.DstPort)),
+		Protocol: protoName(key.Protocol),
+		State:    sessionStateName(val.State),
+		PolicyId: val.PolicyID,
+		// #4626: reserved ids must not be resolved through the compiled map.
+		PolicyName:       dataplane.SessionPolicyName(policyNames, val.PolicyID),
 		IngressZone:      uint32(val.IngressZone),
 		EgressZone:       uint32(val.EgressZone),
 		IngressZoneName:  zoneNames[val.IngressZone],

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -681,8 +681,62 @@ func (s *Server) fetchPeerSessions(ctx context.Context, req *pb.GetSessionsReque
 	if err != nil {
 		slog.Warn("failed to fetch peer sessions", "err", err)
 	} else {
-		resp.Peer = peerResp
+		// #6851/#4626: the peer resolved these policy NAMES itself, so a peer
+		// running a pre-#4626 build sent the name of ITS first configured
+		// policy for every session carrying the reserved id 0 — host-inbound,
+		// fabric, tunnel, and its entire table if IT is in turn syncing from an
+		// older node. The #4626 guard covers rows THIS node renders from a raw
+		// id; it does not cover a name arriving as DATA. Without this, the
+		// misattribution is republished unchanged on every local surface: gRPC
+		// clients, the REST `peer` block (sessionListFromPB), and the CLI.
+		//
+		// Only RESERVED ids are overridden — see PeerSessionPolicyName for why
+		// re-resolving an unreserved peer id against the LOCAL map would be a
+		// fresh misattribution rather than a fix.
+		//
+		// This is the single choke point for the fan-out: REST reaches the peer
+		// through this same in-process response (writeSessionList reads
+		// `pr.GetPeer()`), so guarding here covers all three surfaces once.
+		attachPeerSessions(resp, peerResp)
 	}
+}
+
+// attachPeerSessions sanitizes a fan-out response's policy names and attaches
+// it (#6851).
+//
+// The ATTACH lives inside the sanitizing function deliberately. Keeping them as
+// two statements at the call site would let a future edit drop the guard while
+// leaving the attach — the failure mode this whole PR is about, silent and
+// green. Fused, dropping the guard means dropping the attach, which makes peer
+// sessions vanish from every surface and fails loudly.
+//
+// Residual, stated rather than implied: the tests below drive this function, so
+// they bind the sanitize-and-attach pair. They do NOT bind `fetchPeerSessions`'
+// call TO it — that needs a live cluster.Manager with PeerAlive() plus a real
+// authenticated peer dial, neither of which is reachable from a unit test.
+// Replacing this call with a bare `resp.Peer = peerResp` would not be caught
+// here.
+func attachPeerSessions(resp, peerResp *pb.GetSessionsResponse) {
+	sanitizePeerPolicyNames(peerResp)
+	resp.Peer = peerResp
+}
+
+// sanitizePeerPolicyNames rewrites the policy name of every peer session whose
+// id is reserved, in place.
+func sanitizePeerPolicyNames(peerResp *pb.GetSessionsResponse) {
+	if peerResp == nil {
+		return
+	}
+	for _, e := range peerResp.GetSessions() {
+		if e == nil {
+			continue
+		}
+		e.PolicyName = dataplane.PeerSessionPolicyName(e.GetPolicyName(), e.GetPolicyId())
+	}
+	// A peer that itself fanned out (it should not — include_peer is not
+	// forwarded, precisely to prevent recursion) would nest another response
+	// here. Guard it rather than assume the invariant holds across versions.
+	sanitizePeerPolicyNames(peerResp.GetPeer())
 }
 
 // getSessionsLegacy is the original limit/offset iteration path.

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -694,9 +694,19 @@ func (s *Server) fetchPeerSessions(ctx context.Context, req *pb.GetSessionsReque
 		// re-resolving an unreserved peer id against the LOCAL map would be a
 		// fresh misattribution rather than a fix.
 		//
-		// This is the single choke point for the fan-out: REST reaches the peer
-		// through this same in-process response (writeSessionList reads
-		// `pr.GetPeer()`), so guarding here covers all three surfaces once.
+		// This is the choke point for the gRPC and REST surfaces: REST reaches
+		// the peer through this same in-process response (writeSessionList
+		// reads `pr.GetPeer()`), so guarding here covers both at once.
+		//
+		// It does NOT cover the on-box interactive CLI (#6851). `pkg/cli`
+		// dials the peer daemon itself (session_filter.go dialPeer) and sets no
+		// IncludePeer, so it neither passes through here nor triggers the
+		// peer's own fan-out. That surface sanitizes at its own ingress —
+		// sanitizePeerSessionPolicyNames — for the same reason and via the same
+		// dataplane.PeerSessionPolicyName decision. Two call sites, one
+		// decision function: a third normalization rule is what would rot.
+		// The REMOTE cli binary is not a third case; it sets IncludePeer and
+		// arrives here.
 		attachPeerSessions(resp, peerResp)
 	}
 }
@@ -707,8 +717,13 @@ func (s *Server) fetchPeerSessions(ctx context.Context, req *pb.GetSessionsReque
 // The ATTACH lives inside the sanitizing function deliberately. Keeping them as
 // two statements at the call site would let a future edit drop the guard while
 // leaving the attach — the failure mode this whole PR is about, silent and
-// green. Fused, dropping the guard means dropping the attach, which makes peer
-// sessions vanish from every surface and fails loudly.
+// green. Fused, the two cannot be separated by deleting a line.
+//
+// SCOPED (#6851 review): "fused" is a shape argument, not an enforced one.
+// `attachPeerSessions(resp, nil)` still compiles, still satisfies the
+// structural canary, drops every peer session from all three surfaces, and
+// passes the suite. So this reads as loud to an OPERATOR (peer rows vanish),
+// not to CI. Do not cite it as test-enforced.
 //
 // Residual, stated rather than implied: the tests below drive this function, so
 // they bind the sanitize-and-attach pair. They do NOT bind `fetchPeerSessions`'

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -720,10 +720,10 @@ func (s *Server) fetchPeerSessions(ctx context.Context, req *pb.GetSessionsReque
 // green. Fused, the two cannot be separated by deleting a line.
 //
 // SCOPED (#6851 review): "fused" is a shape argument, not an enforced one.
-// `attachPeerSessions(resp, nil)` still compiles, still satisfies the
-// structural canary, drops every peer session from all three surfaces, and
-// passes the suite. So this reads as loud to an OPERATOR (peer rows vanish),
-// not to CI. Do not cite it as test-enforced.
+// `attachPeerSessions(resp, nil)` on its own does NOT compile — peerResp goes
+// unused — but with `_ = peerResp` beside it the whole suite passes while every
+// peer session is dropped from all three surfaces. So this reads as loud to an
+// OPERATOR (peer rows vanish), not to CI. Do not cite it as test-enforced.
 //
 // Residual, stated rather than implied: the tests below drive this function, so
 // they bind the sanitize-and-attach pair. They do NOT bind `fetchPeerSessions`'

--- a/pkg/grpcapi/server_sessions_policy_id_zero_4626_test.go
+++ b/pkg/grpcapi/server_sessions_policy_id_zero_4626_test.go
@@ -1,0 +1,119 @@
+package grpcapi
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #4626 L01, gRPC half. sessionEntryV4/V6 resolved PolicyName by indexing the
+// compiled policyNames map directly, and `policy_id` 0 is BOTH the first
+// configured policy's id and the value stamped on every session no policy
+// admitted (host-inbound, neighbor-seed, fabric, tunnel, pre-#3056, and every
+// session synced from an older HA peer during a rolling upgrade). Structured
+// consumers of GetSessions were told a specific rule admitted traffic that rule
+// never saw.
+//
+// These drive the real entry builders. Re-inlining `policyNames[val.PolicyID]`
+// at either site turns them RED.
+
+// policyNames4626 is the fixture that matters: id 0 is OCCUPIED by a real
+// policy, exactly as compilePolicies emits it. A fixture without an entry at 0
+// would pass against the unfixed code.
+func policyNames4626() map[uint32]string {
+	return map[uint32]string{
+		0:                                 "trust-to-untrust/allow-web",
+		1:                                 "trust-to-untrust/allow-dns",
+		dataplane.DefaultPolicySentinelID: dataplane.DefaultPolicyName,
+	}
+}
+
+func entryV4_4626(t *testing.T, policyID uint32) *pbSessionEntryShim {
+	t.Helper()
+	se := sessionEntryV4(
+		dataplane.SessionKey{Protocol: 6},
+		dataplane.SessionValue{State: 1, PolicyID: policyID, IngressZone: 1, EgressZone: 2,
+			Created: 100, LastSeen: 100},
+		200,
+		map[uint16]string{1: "trust", 2: "untrust"},
+		policyNames4626(),
+		map[uint16]string{},
+		map[sessionEgressKey]string{},
+		true,
+	)
+	return &pbSessionEntryShim{PolicyName: se.PolicyName, PolicyID: se.PolicyId}
+}
+
+// pbSessionEntryShim narrows the protobuf entry to the two fields under test,
+// so the assertions do not depend on the rest of the generated struct.
+type pbSessionEntryShim struct {
+	PolicyName string
+	PolicyID   uint32
+}
+
+func TestSessionEntryV4PolicyIDZeroNotFirstPolicy_4626(t *testing.T) {
+	names := policyNames4626()
+	got := entryV4_4626(t, 0)
+
+	if got.PolicyName == names[0] {
+		t.Fatalf("gRPC session entry reports policy_name=%q for a policy_id 0 session — that "+
+			"is the FIRST configured policy, which never admitted it. A host-inbound, fabric, "+
+			"tunnel or older-peer-synced session carries id 0 (#4626)", got.PolicyName)
+	}
+	if got.PolicyName != dataplane.UnattributedPolicyName {
+		t.Errorf("policy_name = %q, want %q", got.PolicyName, dataplane.UnattributedPolicyName)
+	}
+	if got.PolicyID != 0 {
+		t.Errorf("policy_id = %d, want 0 — the raw wire value must still be surfaced", got.PolicyID)
+	}
+}
+
+func TestSessionEntryV6PolicyIDZeroNotFirstPolicy_4626(t *testing.T) {
+	names := policyNames4626()
+	se := sessionEntryV6(
+		dataplane.SessionKeyV6{Protocol: 6},
+		dataplane.SessionValueV6{State: 1, PolicyID: 0, IngressZone: 1, EgressZone: 2,
+			Created: 100, LastSeen: 100},
+		200,
+		map[uint16]string{1: "trust", 2: "untrust"},
+		names,
+		map[uint16]string{},
+		map[sessionEgressKey]string{},
+		true,
+	)
+
+	if se.PolicyName == names[0] {
+		t.Fatalf("gRPC IPv6 session entry reports policy_name=%q for a policy_id 0 session — "+
+			"the first configured policy never admitted it (#4626)", se.PolicyName)
+	}
+	if se.PolicyName != dataplane.UnattributedPolicyName {
+		t.Errorf("policy_name = %q, want %q", se.PolicyName, dataplane.UnattributedPolicyName)
+	}
+}
+
+// Over-rejection guard: a session a real policy DID admit must keep reporting
+// that policy, and the #3057 default-policy sentinel must keep its rendering. A
+// fix that blanked every name would pass the tests above and gut the surface.
+func TestSessionEntryRealPolicyStillResolves_4626(t *testing.T) {
+	names := policyNames4626()
+
+	if got := entryV4_4626(t, 1); got.PolicyName != names[1] {
+		t.Errorf("v4 policy_name = %q, want %q — an admitted session must still name its "+
+			"policy", got.PolicyName, names[1])
+	}
+	if got := entryV4_4626(t, dataplane.DefaultPolicySentinelID); got.PolicyName != dataplane.DefaultPolicyName {
+		t.Errorf("default-sentinel policy_name = %q, want %q (#3057 must not regress)",
+			got.PolicyName, dataplane.DefaultPolicyName)
+	}
+
+	se6 := sessionEntryV6(
+		dataplane.SessionKeyV6{Protocol: 6},
+		dataplane.SessionValueV6{State: 1, PolicyID: 1, Created: 100, LastSeen: 100},
+		200,
+		map[uint16]string{}, names, map[uint16]string{},
+		map[sessionEgressKey]string{}, true,
+	)
+	if se6.PolicyName != names[1] {
+		t.Errorf("v6 policy_name = %q, want %q", se6.PolicyName, names[1])
+	}
+}

--- a/pkg/logging/default_policy_sentinel_3057_test.go
+++ b/pkg/logging/default_policy_sentinel_3057_test.go
@@ -20,8 +20,24 @@ import (
 // deny logged with the permit's name — an actively misleading audit trail.
 
 // TestResolvePolicyNameSentinelRendersDefaultPolicy proves the sentinel resolves
-// to "default-policy" and a real policy ID 0 still resolves to the first
-// configured policy's name — the two no longer collide.
+// to "default-policy" and that id 0 resolves to something DISTINCT from it —
+// the two no longer collide, which is the #3057 property.
+//
+// SUPERSEDED IN PART by #4626/#6851. This test originally also asserted that a
+// genuine policy ID 0 "still resolves to the first configured policy". That
+// claim was retired deliberately: id 0 is ALSO the id stamped on every session
+// no policy admitted (host-inbound, neighbour-seed, fabric, tunnel, pre-#3056,
+// and everything synced from an older HA peer), so the wire value is genuinely
+// ambiguous and naming a real rule is the more dangerous of the two possible
+// errors — see dataplane.UnattributedPolicyName. The six session-row surfaces
+// were routed through that guard by #4626; #6851 routed this RT_FLOW resolver
+// through it too, because a syslog record ships off-box and its attribution is
+// durable.
+//
+// The #3057 property this test exists for is UNAFFECTED and is asserted in both
+// directions below: the sentinel must not render as the first policy, and id 0
+// must not render as the default-policy. What changed is only the third value —
+// id 0 now under-claims as "unattributed" instead of naming allow-web.
 func TestResolvePolicyNameSentinelRendersDefaultPolicy(t *testing.T) {
 	er := NewEventReader(nil, NewEventBuffer(16))
 	// The first configured policy is a PERMIT at real runtime ID 0 — exactly
@@ -34,9 +50,19 @@ func TestResolvePolicyNameSentinelRendersDefaultPolicy(t *testing.T) {
 	if got := er.resolvePolicyName(dataplane.DefaultPolicySentinelID); got == "allow-web" {
 		t.Fatalf("sentinel resolved to the first policy name %q — the #3057 collision", got)
 	}
-	// Regression: a genuine policy ID 0 still resolves to the first policy.
-	if got := er.resolvePolicyName(0); got != "allow-web" {
-		t.Fatalf("real policy ID 0 resolved to %q, want \"allow-web\"", got)
+	// #4626/#6851: id 0 under-claims rather than naming the first policy.
+	if got := er.resolvePolicyName(0); got != dataplane.UnattributedPolicyName {
+		t.Fatalf("policy ID 0 resolved to %q, want %q — id 0 is overloaded and must "+
+			"not name the first configured policy (#4626/#6851)",
+			got, dataplane.UnattributedPolicyName)
+	}
+	// The #3057 non-collision, asserted in the OTHER direction too: id 0 must
+	// not be rendered as the implicit default either. A "fix" that collapsed
+	// both reserved ids onto one name would satisfy the assertion above and
+	// re-create exactly the aliasing #3057 removed.
+	if got := er.resolvePolicyName(0); got == dataplane.DefaultPolicyName {
+		t.Fatalf("policy ID 0 resolved to %q — the two RESERVED ids must stay "+
+			"distinct from each other (#3057)", got)
 	}
 }
 

--- a/pkg/logging/policy_id_zero_6851_test.go
+++ b/pkg/logging/policy_id_zero_6851_test.go
@@ -1,0 +1,81 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #6851 MAJOR 1: the SEVENTH policy-name resolver.
+//
+// `EventReader.resolvePolicyName` resolves RT_FLOW record names independently of
+// the six session-row builders #4626 routed through `dataplane.SessionPolicyName`,
+// and it indexed `er.policyNames` directly. Reserved id 0 is also the id of the
+// FIRST configured policy, so every host-inbound / fabric / tunnel / pre-#3056 /
+// older-peer-synced record named that policy.
+//
+// This surface matters more than the interactive ones: RT_FLOW records go to
+// syslog and ship off-box to a collector, so the wrong attribution is DURABLE —
+// it lands in the record an auditor reads months later, not in a row an operator
+// can re-run.
+//
+// FIXTURE NOTE: id 0 must be OCCUPIED by a real policy, exactly as
+// compilePolicies emits it. A fixture with no entry at 0 passes against the
+// unfixed code and proves nothing.
+func policyNamesWithFirstPolicy6851() map[uint32]string {
+	return map[uint32]string{
+		0: "trust-to-untrust/allow-web",
+		1: "trust-to-untrust/allow-dns",
+	}
+}
+
+func TestResolvePolicyNameZeroIsNotTheFirstPolicy_6851(t *testing.T) {
+	er := &EventReader{}
+	er.SetPolicyNames(policyNamesWithFirstPolicy6851())
+
+	got := er.resolvePolicyName(0)
+
+	if got == "trust-to-untrust/allow-web" {
+		t.Fatalf("RT_FLOW record names policy %q for policy_id 0 — that is the FIRST "+
+			"configured policy, which never admitted the session. This record is "+
+			"shipped to a collector, so the misattribution is durable (#6851)", got)
+	}
+	if got != dataplane.UnattributedPolicyName {
+		t.Errorf("resolvePolicyName(0) = %q, want %q", got, dataplane.UnattributedPolicyName)
+	}
+}
+
+// Over-rejection controls. A fix that blanked or reserved everything would pass
+// the test above and destroy the surface.
+func TestResolvePolicyNameUnreservedStillResolves_6851(t *testing.T) {
+	er := &EventReader{}
+	er.SetPolicyNames(policyNamesWithFirstPolicy6851())
+
+	if got, want := er.resolvePolicyName(1), "trust-to-untrust/allow-dns"; got != want {
+		t.Errorf("resolvePolicyName(1) = %q, want %q — a real policy must still name "+
+			"itself on its own records", got, want)
+	}
+
+	// #3057 must not regress: the implicit-default sentinel keeps its name.
+	if got, want := er.resolvePolicyName(dataplane.DefaultPolicySentinelID),
+		dataplane.DefaultPolicyName; got != want {
+		t.Errorf("default sentinel = %q, want %q", got, want)
+	}
+
+	// An unreserved id absent from the map keeps the pre-existing numeric
+	// fallback rather than becoming "unattributed" — the guard must be scoped to
+	// the RESERVED id, not to "anything the map cannot resolve".
+	if got, want := er.resolvePolicyName(4242), "4242"; got != want {
+		t.Errorf("absent unreserved id = %q, want the numeric fallback %q", got, want)
+	}
+}
+
+// The reserved rendering must not depend on a published map: a record emitted
+// before the first apply must still not alias policy 0.
+func TestResolvePolicyNameZeroWithNoPublishedMap_6851(t *testing.T) {
+	er := &EventReader{}
+
+	if got, want := er.resolvePolicyName(0), dataplane.UnattributedPolicyName; got != want {
+		t.Errorf("resolvePolicyName(0) with no policyNames map = %q, want %q", got, want)
+	}
+}

--- a/pkg/logging/ringbuf.go
+++ b/pkg/logging/ringbuf.go
@@ -275,8 +275,22 @@ func (er *EventReader) resolvePolicyName(id uint32) string {
 	// pseudo-policy name authoritatively (even before any policyNames map has
 	// been published) so a default-deny/reject RT_FLOW record never aliases the
 	// first configured policy (real ID 0).
-	if id == dataplane.DefaultPolicySentinelID {
-		return dataplane.DefaultPolicyName
+	//
+	// #6851/#4626: UnattributedPolicyID (0) is reserved for the same reason and
+	// must be handled the SAME way, before the map lookup. This is the seventh
+	// policy-name resolver and the one that matters most: RT_FLOW records are
+	// written to syslog and shipped off-box to a collector, so a wrong
+	// attribution here is DURABLE and lands in the record an auditor reads
+	// later, not just in an interactive row an operator can re-run.
+	//
+	// The under-claim applies here as it does on the session surfaces: a real
+	// policy whose id is 0 now renders `unattributed` on its own deny records.
+	// That is the same tradeoff SessionPolicyName documents — the wire value is
+	// genuinely ambiguous, and naming a specific rule on a host-inbound /
+	// fabric / tunnel / older-peer record is the more dangerous of the two
+	// errors. The numeric id remains in the record's own policy_id field.
+	if name, ok := dataplane.ReservedPolicyName(id); ok {
+		return name
 	}
 	er.policyNamesMu.RLock()
 	name := er.policyNames[id]


### PR DESCRIPTION
## Summary

- `policy_id` 0 is overloaded: `compilePolicies` assigns `policySetID*MaxRulesPerPolicy + i`, so the first rule of the first zone-pair genuinely has id 0 — and the userspace dataplane stamps 0 on every session **no policy admitted**. `publish_conntrack.rs` says so at the stamping site: "`0` stays the value for non-policy-forwarded sessions".
- That population is host-inbound, neighbor-seed, fabric and tunnel installs, every pre-#3056 session, and **every session synced from an older HA peer during a rolling upgrade** — the peer's whole table.
- Six session-row render sites indexed `CompileResult.PolicyNames` directly, where key 0 holds the first configured policy. `show security flow session`, REST `/sessions` and gRPC `GetSessions` therefore all reported that a specific policy admitted traffic it never saw. REST and gRPC had **no** numeric fallback, so the wrong name went unconditionally into a structured field automation consumes.
- Adds `dataplane.SessionPolicyName`, which takes both reserved ids (0 and `DefaultPolicySentinelID`) before consulting the map, and routes all six sites through it. Unreserved ids resolve exactly as a direct index did, including `""` for an absent id, so each caller keeps its existing not-found behaviour.

## Scope — this does not close L01 as the issue words it

#4626 L01 asks to **reserve the id space** so real policies start at 1. That is a cross-plane change (userspace-dp `policy.rs`, the #3056 stamping path, runtime-id assignment, HA wire compatibility), it has no approved research plan, and **it cannot fix the case that matters most**: an older HA peer keeps sending a bare 0 for its entire table throughout the upgrade window regardless of the local id space. A render-side guard is required either way and is not made redundant by that work.

This PR removes the misattribution. The id-space half of L01 stays open.

## Why `unattributed` rather than a policy name

The wire value is ambiguous and nothing else on the session disambiguates it — `SessionValue`'s flag bits are NAT-only (`SessFlagSNAT`/`DNAT`/`StaticNAT`/`NAT64`/`NPTV6`), with no host-inbound, fabric or tunnel marker. So every possible rendering is wrong for one of the two populations.

Under-claiming is the safer error on a security surface: an operator who sees `unattributed` investigates, whereas one who sees a real policy name on a host-inbound session may leave a rule in place believing it is load bearing. It is also the direction already chosen for this identical overload on the **behavioral** path — `deletedPolicyRuntimeIDs` excludes id 0 as a documented "fail-SAFE under-clear". The display should not claim a precision the wire cannot support while the enforcement path refuses to.

The numeric id is still shown beside the name on every surface (`Policy name: unattributed/0`; REST/gRPC carry `policy_id` as its own field), so nothing is hidden.

## Test plan

- [x] `dataplane.SessionPolicyName` unit tests — fixture deliberately **occupies id 0** with a real policy, which is the whole defect; a fixture without it passes against broken code.
- [x] REST `sessionEntryV4`/`V6` and gRPC `sessionEntryV4`/`V6` driven directly (4 of 6 render sites).
- [x] AST canary covering all six sites plus any seventh added later, with its scope stated explicitly.
- [x] Over-rejection controls: an admitted session still names its policy; the #3057 `default-policy` sentinel still renders.
- [x] Full `pkg/dataplane`, `pkg/api`, `pkg/grpcapi`, `pkg/cli`, `pkg/daemon`, `pkg/logging`, `pkg/refactoraudit` suites pass. No existing golden asserted the old attribution.
- [ ] Cluster/smoke not run — display-layer change, and smoke is scheduled centrally.

### Mutation matrix

Snapshot-and-write-back restore with a byte-for-byte verify; every mutant required to **compile** before scoring, so no RED is a build break.

| Mutation | Result |
|---|---|
| Revert the CLI pair (`printV4`/`printV6`) | RED |
| Revert the REST pair | RED |
| Revert the gRPC pair | RED |
| Revert all six at once (= master) | RED |
| Guard consults the map FIRST, falls back to the pseudo-name | RED |
| Drop the reserved-zero arm | RED |
| Blank every policy name | RED |

The map-first mutation is the one worth naming: it still looks like a guard and guards nothing whenever a first policy exists. The `LOAD-BEARING` comment on that arm exists for it.

The two CLI sites are bound **only** by the AST canary — they are closures printing to real stdout behind a live dataplane, so no cheap behavioural test reaches them. That limit is stated in the canary rather than left implicit.

## Refs

Advances #4626 (L01 misattribution half; the id-space reservation remains). Builds on #3056 (policy-id stamping) and #3057 (`DefaultPolicySentinelID`, the precedent this mirrors).