### PR TITLE
test(ha): scope sync-import refusal counters per Coordinator

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -66375,3 +66375,28 @@ break — `go vet` confirmed passing under every revert.
 - **File(s)**: userspace-dp/src/afxdp/ha_tests.rs,
   userspace-dp/src/afxdp/coordinator/session_manager.rs,
   userspace-dp/src/session/README.md, _Log.md
+- **Timestamp**: 2026-08-05 17:38
+- **Action**: #6819 README — cited the independent cross-PR measurement of the
+  counter flake. While gating #6843, a lane measured parallel `cargo test --
+  afxdp::ha` over 40 iterations: 34/40 FAILED at that PR's HEAD and 34/40 at an
+  `origin/master` CONTROL with the PR's files reverted and its tests confirmed
+  absent. The identical rate with and without the change under review is what
+  identifies the flake as pre-existing and specific to these counters rather
+  than caused by any one PR, and it root-caused the failures to
+  `SESSION_INSTALL_STALE_IGNORED`/`SESSION_DELETE_STALE_IGNORED` being
+  process-global under `assert_eq!(total, before)` — as a family, not one test.
+  That is unmutated evidence from a lane with no stake in #6862, stronger than
+  the mutation numbers already cited. Also recorded the coupling explicitly:
+  the `--test-threads=1` that hides this defect exists to dodge a DIFFERENT one
+  (#6657).
+  NOTE ON THE GATE RUN: `cargo test --release --bins --tests --
+  --test-threads=1` returned rc=101 on this README-only change, failing
+  `afxdp::types::shared_cos_lease::tests::v8_epoch_seqlock_snapshot_never_tears_tag_grace`.
+  That is NOT this change — the diff since the previous green gate is one .md
+  file and no test reads it. Characterized it instead of re-running for green:
+  the test fails 2 of 10 runs ALONE in the process under `--test-threads=1`, so
+  its race is INTERNAL to the test (it spawns its own threads, which
+  `--test-threads=1` does not serialize). That distinguishes it from #6819
+  (cross-test, masked by serial execution) and from the #6657 wg-engine hang.
+  Reported to the #6657 owner.
+- **File(s)**: userspace-dp/src/session/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -66279,8 +66279,16 @@ break — `go vet` confirmed passing under every revert.
   beside the existing per-instance `export_seq`. Every bump site
   (`ha/session_import.rs`) and every read site (`coordinator/status.rs`)
   already held a `&self` Coordinator, and production constructs exactly one
-  Coordinator (`server/lifecycle.rs`), so the gRPC/Prometheus values are
-  unchanged — this is a test-isolation fix with no production behaviour change.
+  Coordinator (`server/lifecycle.rs`), so the exported values are unchanged —
+  this is a test-isolation fix with no production behaviour change.
+  [CORRECTED 2026-08-05 16:10, gate fold: this entry originally said "the
+  gRPC/Prometheus values are unchanged", which was wrong twice. This crate has
+  NO gRPC dependency and none of the three counters is in `proto/`; and only
+  `import_cap_drops` reaches Prometheus (`server/helpers/status.rs` ->
+  `protocol::control` -> the Go status struct ->
+  `xpf_userspace_synced_import_cap_drops_total`). The two stale counters have
+  no wire or metric surface at all — their accessors are reachable only from
+  `ha_tests.rs`.]
   `ha_tests.rs` is untouched: no assertion weakened, no `--test-threads=1`, no
   `#[serial]`. The issue's own suggested fix — "make the assertions
   DELTA-based" — was already in place and is not sufficient: the tests capture
@@ -66335,3 +66343,35 @@ break — `go vet` confirmed passing under every revert.
   ./...` rc=0.
 - **File(s)**: userspace-dp/src/afxdp/ha/session_import.rs,
   userspace-dp/src/afxdp/ha_tests.rs, _Log.md
+- **Timestamp**: 2026-08-05 16:24
+- **Action**: #6819 gate fold round 2 (R3 + doc accuracy). (R3) The gated suite
+  could not detect a regression of the fix. Every assertion on the three
+  counters is a DELTA capture (`before + 1` / `== before`), and `make test-rust`
+  pins `-- --test-threads=1` (Makefile:114-116, adopted to dodge the #6657
+  `__skb_wait_for_more_packets` socket wedge) — under serial execution a
+  process-global satisfies every one of those identically, so reverting any
+  counter to a static shipped GREEN. Added
+  `refusal_counters_are_per_coordinator_not_process_global`: drives one refusal
+  of each kind on a BUSY Coordinator and asserts an IDLE one, live in the same
+  process, saw none of them. It does not depend on interleaving, so it reds at
+  any thread count. Proof under the gate flag: reverting
+  `install_stale_ignored` to its original `metrics.rs` static REDS the new test
+  (ha_tests.rs:738) while the other 29 `ha::` tests run and pass — the
+  pre-existing suite genuinely cannot see the revert. (DOC) Corrected the
+  export-surface claim at three sites: this crate has NO gRPC dependency and
+  none of the three counters is in `proto/`; only `import_cap_drops` reaches
+  Prometheus (`server/helpers/status.rs:102` -> `protocol/control.rs:334` ->
+  `protocol_status.go:279` -> `metrics_userspace.go:672`), and the two stale
+  counters have no wire or metric surface — their accessors are reachable only
+  from `ha_tests.rs`. The earlier 2026-08-05 09:41 entry carries an inline
+  correction. (README) Recorded that the concurrency mechanism is MEASURED
+  (revert reds 24/60 parallel vs 0/12 serial for the cap counter; 43/60 vs 0/5
+  for the stale pair) AND that the sanctioned gate structurally cannot observe
+  it. (NOTE) Documented that per-instance scoping makes every `..._before`
+  capture 0, degenerating three `== before` assertions to `0 == 0` — recorded
+  where those assertions live, with why the family is still bound.
+  Gates: `cargo test --release --bins --tests -- --test-threads=1` rc=0
+  (4235 passed, 0 failed, 2 ignored), `go test ./...` rc=0.
+- **File(s)**: userspace-dp/src/afxdp/ha_tests.rs,
+  userspace-dp/src/afxdp/coordinator/session_manager.rs,
+  userspace-dp/src/session/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -66356,8 +66356,15 @@ break — `go vet` confirmed passing under every revert.
   process, saw none of them. It does not depend on interleaving, so it reds at
   any thread count. Proof under the gate flag: reverting
   `install_stale_ignored` to its original `metrics.rs` static REDS the new test
-  (ha_tests.rs:738) while the other 29 `ha::` tests run and pass — the
-  pre-existing suite genuinely cannot see the revert. (DOC) Corrected the
+  while the other 29 `ha::` tests run and pass — the pre-existing suite
+  genuinely cannot see the revert. WHICH assertion reds depends on the run
+  mode, and the original claim of `ha_tests.rs:738` was only true of the
+  ISOLATED run: libtest orders alphabetically under `--test-threads=1`, so
+  `current_generation_…`/`delete_synced_session_gen_…`/`over_ceiling_import_…`
+  all bump the restored global BEFORE `refusal_counters_…` runs, and the
+  PRECONDITION at the top of the test trips first. Fixed in the 2026-08-05
+  18:05 entry by giving the preconditions the same diagnostic as the payload
+  assertions, so the message is reachable in the mode the gate actually uses. (DOC) Corrected the
   export-surface claim at three sites: this crate has NO gRPC dependency and
   none of the three counters is in `proto/`; only `import_cap_drops` reaches
   Prometheus (`server/helpers/status.rs:102` -> `protocol/control.rs:334` ->
@@ -66400,3 +66407,28 @@ break — `go vet` confirmed passing under every revert.
   (cross-test, masked by serial execution) and from the #6657 wg-engine hang.
   Reported to the #6657 owner.
 - **File(s)**: userspace-dp/src/session/README.md, _Log.md
+- **Timestamp**: 2026-08-05 18:05
+- **Action**: #6819 gate fold round 3 (two MINORs). (M1) The `#6819`
+  diagnostics in `refusal_counters_are_per_coordinator_not_process_global` were
+  UNREACHABLE in the mode the gate actually runs. libtest executes
+  alphabetically under `--test-threads=1`, so `current_generation_…` (c),
+  `delete_synced_session_gen_…` (d) and `over_ceiling_import_…` (o) all bump a
+  restored global BEFORE `refusal_counters_…` (r) runs — the bare
+  `assert_eq!(x, 0)` PRECONDITIONS tripped first and reported `left: 1,
+  right: 0` with no explanation, while the carefully-worded payload assertions
+  forty lines below fired only when the test was run in ISOLATION. Gave the
+  three preconditions the same named diagnostic, so a future engineer who
+  reintroduces the regression reads why in either run mode. Generalisable: a
+  diagnostic is only as good as the run mode that REACHES it — when a test has
+  a precondition and a payload assertion, check which fires under the
+  SANCTIONED invocation, not the filtered one used while developing. (M2)
+  Corrected the `ha_tests.rs:738` line cite: under the conditions stated
+  alongside it (the other 29 `ha::` tests running) the revert reds at the
+  precondition, not 738; 738 is the isolated-run line. Corrected in the
+  2026-08-05 16:24 entry and in the PR body.
+  NOT FOLDED: #6891 — a live cross-test counter flake of exactly the shape this
+  PR's README rule warns about (`GRE_DECAP_CHECKSUM_INVALID_DROPS`, equality
+  assert, 18/60 RED at this branch's HEAD and 16/40 at the merge base — equal
+  rate, so pre-existing). Filed separately; it raises #6891's priority, not
+  this PR's scope.
+- **File(s)**: userspace-dp/src/afxdp/ha_tests.rs, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -66266,3 +66266,35 @@ break — `go vet` confirmed passing under every revert.
   pkg/config/compiler_opts.go,
   pkg/config/compiler_policy_valueless_match_6526_test.go,
   docs/config-schema.md, _Log.md
+- **Timestamp**: 2026-08-05 09:41
+- **Action**: #6819 — five `ha_tests` (in fact SEVEN, on THREE counters) shared
+  process-global `AtomicU64` statics as their before/after baseline, so cargo's
+  in-process parallelism made each test's assertion depend on what every other
+  test happened to do. Measured at pristine `origin/master` ad9591177 with a
+  bounded harness: `FAIL FAIL HUNG FAIL FAIL`, with a #6819 participant failing
+  in 5 of 5 runs. Moved `SESSION_INSTALL_STALE_IGNORED`,
+  `SESSION_DELETE_STALE_IGNORED` (#2170) and `SYNCED_IMPORT_CAP_DROPS` (#5674)
+  out of `bpf_map/metrics.rs` and onto `SessionManager` as per-Coordinator
+  fields (`install_stale_ignored`, `delete_stale_ignored`, `import_cap_drops`),
+  beside the existing per-instance `export_seq`. Every bump site
+  (`ha/session_import.rs`) and every read site (`coordinator/status.rs`)
+  already held a `&self` Coordinator, and production constructs exactly one
+  Coordinator (`server/lifecycle.rs`), so the gRPC/Prometheus values are
+  unchanged — this is a test-isolation fix with no production behaviour change.
+  `ha_tests.rs` is untouched: no assertion weakened, no `--test-threads=1`, no
+  `#[serial]`. The issue's own suggested fix — "make the assertions
+  DELTA-based" — was already in place and is not sufficient: the tests capture
+  `let before = ...` and assert `before + 1`, but a concurrent test's increment
+  lands INSIDE that capture window. Only a per-instance home removes the
+  dependency. After: 10 runs, a #6819 participant failed in 0 of 10. The suite
+  itself is 5 PASS / 2 FAIL / 3 HUNG — every residual failure is #6657
+  (CoS-lease seqlock `v8_epoch_seqlock_snapshot_never_tears_tag_grace`, and an
+  unbounded blocking recv wedging at 7 threads in
+  `__skb_wait_for_more_packets`), a separate defect that this PR does not
+  touch. Red-on-revert: 7 of 7 tests go RED on an assertion when the guard each
+  one covers is reverted.
+- **File(s)**: userspace-dp/src/afxdp/bpf_map/metrics.rs,
+  userspace-dp/src/afxdp/coordinator/session_manager.rs,
+  userspace-dp/src/afxdp/coordinator/status.rs,
+  userspace-dp/src/afxdp/ha/session_import.rs,
+  userspace-dp/src/session/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -66298,3 +66298,40 @@ break — `go vet` confirmed passing under every revert.
   userspace-dp/src/afxdp/coordinator/status.rs,
   userspace-dp/src/afxdp/ha/session_import.rs,
   userspace-dp/src/session/README.md, _Log.md
+- **Timestamp**: 2026-08-05 14:52
+- **Action**: #6819 gate fold (§7 test-acceptance findings). Three findings,
+  each verified against the code before acting. (F1) Both #5674 admission
+  tests set `synced_import_cap_override`, which returns from the `#[cfg(test)]`
+  branch of `synced_import_cap` BEFORE the production expression is evaluated —
+  a test-only seam shadowing the production path, so deleting its trailing
+  `.saturating_mul(2)` left both tests green. Made `synced_import_cap`
+  `pub(super)` (ha_tests is `crate::afxdp::ha::tests`, a SIBLING of
+  `session_import`, so a private fn was unreachable) and added
+  `synced_import_cap_production_formula_is_twice_the_logical_ceiling`, which
+  runs with the override at its default 0 and pins entry-cap == 2x logical
+  ceiling, plus `assert_ne!` against the bare ceiling (what dropping the 2x
+  yields) and a `DEFAULT_MAX_SESSIONS > 0` precondition so `0 == 2*0` cannot
+  make the claim vacuous. (F2) The two non-poison rejection tests accepted a
+  guard that refuses the WHOLE category while counting once, so each now
+  carries its own positive control (newer install applies and does not count;
+  applied equal-generation delete does not count). The two poison rejection
+  tests get scope comments naming the control test that supplies their
+  selectivity. (F3, priority) The poison negative control exercised only
+  NEWER/EQUAL operations with both stale expectations at the per-instance zero
+  baseline, so it accepted DELETING the generation guard outright — a negative
+  control that accepts removal of the thing it controls for. It now also probes
+  the stale direction after recovery (stale install and stale delete each
+  refused and counted exactly once), and the recoveries assertion tightened
+  from `> before` to `>= before + 4` (the poisoning count); kept a LOWER bound,
+  with the reason in the comment, because `SHARED_SESSION_POISON_RECOVERIES`
+  is the one counter still process-global (bumped inside `lock_shared_recover`,
+  which takes only the mutex and has no per-Coordinator home) so a concurrent
+  test can only push it up — `>=` cannot false-FAIL where `==` could.
+  Validation: four-cell mutation matrix, each mutation run against BOTH test
+  generations so a mutation the old tests already caught could not be credited
+  to the new one. Drop-the-2x PASSES both old cap tests and FAILS the new one;
+  delete-the-generation-guard PASSES the old negative control and FAILS the new
+  one. Full `cargo test --release` rc=0 (4234 passed, 0 failed), `go test
+  ./...` rc=0.
+- **File(s)**: userspace-dp/src/afxdp/ha/session_import.rs,
+  userspace-dp/src/afxdp/ha_tests.rs, _Log.md

--- a/userspace-dp/src/afxdp/bpf_map/metrics.rs
+++ b/userspace-dp/src/afxdp/bpf_map/metrics.rs
@@ -272,38 +272,15 @@ pub(in crate::afxdp) static SESSION_PUBLISH_ERRORS_SHARED: AtomicU64 = AtomicU64
 /// `Coordinator::dnat_publish_errors_total()` and surfaced as
 /// `xpf_userspace_dnat_publish_errors_total`.
 pub(in crate::afxdp) static DNAT_PUBLISH_ERRORS_SHARED: AtomicU64 = AtomicU64::new(0);
-/// #2170 HA deferred-delete generation guard observability. These count how
-/// often the helper's in-memory SyncedSessionEntry generation guard refused a
-/// stale-generation install (`upsert_synced_session`, the delayed-stale-install
-/// variant) or a stale-generation delete (`delete_synced_session_gen`,
-/// belt-and-suspenders for any helper-side generation-aware delete). The
-/// authoritative guard lives in the Go cluster apply layer; these helper-side
-/// counters report any divergence/back-stop activity. Surfaced via
-/// `Coordinator::session_install_stale_ignored_total()` /
-/// `session_delete_stale_ignored_total()`.
-pub(in crate::afxdp) static SESSION_INSTALL_STALE_IGNORED: AtomicU64 = AtomicU64::new(0);
-pub(in crate::afxdp) static SESSION_DELETE_STALE_IGNORED: AtomicU64 = AtomicU64::new(0);
-/// #5674: peer-synced session imports REJECTED by the coordinator's aggregate
-/// admission bound (`upsert_synced_session`). Locally-created sessions are
-/// capped per worker at `DEFAULT_MAX_SESSIONS`
-/// (`install_with_protocol_with_origin`), but peer-synced sessions were
-/// imported with NO cap and fanned out to EVERY worker command queue + table,
-/// so a peer under session-table pressure — or a malicious/compromised peer —
-/// could drive this node past its own aggregate session ceiling and multiply
-/// that state across all workers (the availability/DoS root of #5674).
-/// `upsert_synced_session` now bounds the shared synced map (the single
-/// fan-out choke point) at this appliance's OWN aggregate ENTRY ceiling
-/// (`2 * worker_count * DEFAULT_MAX_SESSIONS` — 2× the logical ceiling because
-/// each admitted forward logical session publishes a forward AND a synthesized
-/// reverse companion into the map) and drop-newest-rejects a NEW over-ceiling
-/// FORWARD key here (a REPLACE of an existing key, and a lone reverse import,
-/// never trip the bound — neither grows the forward-keyed count). Surfaced via
-/// `Coordinator::synced_import_cap_drops_total()` and the Prometheus counter
-/// `xpf_userspace_synced_import_cap_drops_total`. A nonzero value means a peer
-/// exceeded its own LOGICAL session ceiling (a malicious/compromised peer); a
-/// legitimate symmetric-pair failover — the peer's full logical set (N logical
-/// → 2N entries) EXACTLY fits the 2N cap — never trips it, at any peer load.
-pub(in crate::afxdp) static SYNCED_IMPORT_CAP_DROPS: AtomicU64 = AtomicU64::new(0);
+// #2170 `SESSION_INSTALL_STALE_IGNORED` / `SESSION_DELETE_STALE_IGNORED` and
+// #5674 `SYNCED_IMPORT_CAP_DROPS` used to live here as process-global statics.
+// They are now PER-COORDINATOR fields on `SessionManager`
+// (`coordinator/session_manager.rs`: `install_stale_ignored`,
+// `delete_stale_ignored`, `import_cap_drops`) — every bump site and every read
+// site already had a `&self` `Coordinator`, and production builds exactly one
+// `Coordinator`, so the emitted metric values are unchanged. As globals they
+// were shared by the one-`Coordinator`-per-`#[test]` suite, which made each
+// test's assertion depend on what every concurrently-running test did (#6819).
 pub(in crate::afxdp) static SESSION_CREATIONS_LOGGED: AtomicU64 = AtomicU64::new(0);
 #[cfg(feature = "debug-log")]
 pub(in crate::afxdp) static ICMPV6_EMBED_LOGGED: AtomicU32 = AtomicU32::new(0);

--- a/userspace-dp/src/afxdp/coordinator/session_manager.rs
+++ b/userspace-dp/src/afxdp/coordinator/session_manager.rs
@@ -9,12 +9,57 @@ use super::*;
 /// session-resolution paths. The `export_seq` counter is the
 /// per-RG ack sequence number that pairs with the export ack
 /// broadcast in HA `export_owner_rg_sessions`.
+///
+/// The three sync-import refusal counters below are PER-INSTANCE
+/// (`AtomicU64` fields, not process-global statics) for the same reason
+/// `Coordinator::last_quiesce_ms` and the `force_worker_*` seams are: a
+/// process-global counter is observable by every other `Coordinator` in the
+/// process. Production builds exactly one `Coordinator` (`server::lifecycle`),
+/// so the Prometheus/gRPC values are unchanged — but the test suite builds one
+/// per `#[test]` and runs them concurrently in a single process, and a global
+/// made every assertion about these counters depend on what every other test
+/// happened to do (#6819).
 pub(in crate::afxdp) struct SessionManager {
     pub(in crate::afxdp) synced: Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
     pub(in crate::afxdp) nat: Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
     pub(in crate::afxdp) forward_wire: Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
     pub(in crate::afxdp) owner_rg_indexes: SharedSessionOwnerRgIndexes,
     pub(in crate::afxdp) export_seq: AtomicU64,
+    /// #2170 HA deferred-delete generation guard observability. These count how
+    /// often the helper's in-memory SyncedSessionEntry generation guard refused
+    /// a stale-generation install (`upsert_synced_session`, the
+    /// delayed-stale-install variant) or a stale-generation delete
+    /// (`delete_synced_session_gen`, belt-and-suspenders for any helper-side
+    /// generation-aware delete). The authoritative guard lives in the Go
+    /// cluster apply layer; these helper-side counters report any
+    /// divergence/back-stop activity. Surfaced via
+    /// `Coordinator::session_install_stale_ignored_total()` /
+    /// `session_delete_stale_ignored_total()`.
+    pub(in crate::afxdp) install_stale_ignored: AtomicU64,
+    pub(in crate::afxdp) delete_stale_ignored: AtomicU64,
+    /// #5674: peer-synced session imports REJECTED by the coordinator's
+    /// aggregate admission bound (`upsert_synced_session`). Locally-created
+    /// sessions are capped per worker at `DEFAULT_MAX_SESSIONS`
+    /// (`install_with_protocol_with_origin`), but peer-synced sessions were
+    /// imported with NO cap and fanned out to EVERY worker command queue +
+    /// table, so a peer under session-table pressure — or a
+    /// malicious/compromised peer — could drive this node past its own
+    /// aggregate session ceiling and multiply that state across all workers
+    /// (the availability/DoS root of #5674). `upsert_synced_session` now bounds
+    /// the shared synced map (the single fan-out choke point) at this
+    /// appliance's OWN aggregate ENTRY ceiling (`2 * worker_count *
+    /// DEFAULT_MAX_SESSIONS` — 2× the logical ceiling because each admitted
+    /// forward logical session publishes a forward AND a synthesized reverse
+    /// companion into the map) and drop-newest-rejects a NEW over-ceiling
+    /// FORWARD key here (a REPLACE of an existing key, and a lone reverse
+    /// import, never trip the bound — neither grows the forward-keyed count).
+    /// Surfaced via `Coordinator::synced_import_cap_drops_total()` and the
+    /// Prometheus counter `xpf_userspace_synced_import_cap_drops_total`. A
+    /// nonzero value means a peer exceeded its own LOGICAL session ceiling (a
+    /// malicious/compromised peer); a legitimate symmetric-pair failover — the
+    /// peer's full logical set (N logical → 2N entries) EXACTLY fits the 2N cap
+    /// — never trips it, at any peer load.
+    pub(in crate::afxdp) import_cap_drops: AtomicU64,
 }
 
 impl SessionManager {
@@ -25,6 +70,9 @@ impl SessionManager {
             forward_wire: Arc::new(Mutex::new(FastMap::default())),
             owner_rg_indexes: SharedSessionOwnerRgIndexes::default(),
             export_seq: AtomicU64::new(0),
+            install_stale_ignored: AtomicU64::new(0),
+            delete_stale_ignored: AtomicU64::new(0),
+            import_cap_drops: AtomicU64::new(0),
         }
     }
 }

--- a/userspace-dp/src/afxdp/coordinator/session_manager.rs
+++ b/userspace-dp/src/afxdp/coordinator/session_manager.rs
@@ -15,10 +15,14 @@ use super::*;
 /// `Coordinator::last_quiesce_ms` and the `force_worker_*` seams are: a
 /// process-global counter is observable by every other `Coordinator` in the
 /// process. Production builds exactly one `Coordinator` (`server::lifecycle`),
-/// so the Prometheus/gRPC values are unchanged — but the test suite builds one
-/// per `#[test]` and runs them concurrently in a single process, and a global
-/// made every assertion about these counters depend on what every other test
-/// happened to do (#6819).
+/// so the exported Prometheus value (`import_cap_drops`, via
+/// `server/helpers/status.rs` -> `protocol::control` -> the Go collector) is
+/// unchanged; the other two have no surface outside this binary at all — their
+/// accessors are called only from `ha_tests.rs`. (None of the three is in
+/// `proto/`: this crate has no gRPC dependency.) The change is observable only
+/// to tests, which build one `Coordinator` per `#[test]` and run them
+/// concurrently in a single process — as globals, every assertion about these
+/// counters depended on what every other test happened to do (#6819).
 pub(in crate::afxdp) struct SessionManager {
     pub(in crate::afxdp) synced: Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
     pub(in crate::afxdp) nat: Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -204,14 +204,14 @@ impl super::Coordinator {
     /// variant). The authoritative guard is in the Go cluster apply layer;
     /// this is the helper-side back-stop counter.
     pub fn session_install_stale_ignored_total(&self) -> u64 {
-        SESSION_INSTALL_STALE_IGNORED.load(Ordering::Relaxed)
+        self.sessions.install_stale_ignored.load(Ordering::Relaxed)
     }
 
     /// #2170: total stale-generation deletes refused by the helper's
     /// in-memory SyncedSessionEntry guard (belt-and-suspenders for any
     /// helper-side generation-aware delete).
     pub fn session_delete_stale_ignored_total(&self) -> u64 {
-        SESSION_DELETE_STALE_IGNORED.load(Ordering::Relaxed)
+        self.sessions.delete_stale_ignored.load(Ordering::Relaxed)
     }
 
     /// #5674: total peer-synced session imports rejected by the coordinator's
@@ -224,7 +224,7 @@ impl super::Coordinator {
     /// DEFAULT_MAX_SESSIONS`); a legitimate symmetric-pair failover never trips
     /// it. Surfaced as `xpf_userspace_synced_import_cap_drops_total`.
     pub fn synced_import_cap_drops_total(&self) -> u64 {
-        SYNCED_IMPORT_CAP_DROPS.load(Ordering::Relaxed)
+        self.sessions.import_cap_drops.load(Ordering::Relaxed)
     }
 
     /// #1760 W3': shared-map NAT reverse-key displacement events — a

--- a/userspace-dp/src/afxdp/ha/session_import.rs
+++ b/userspace-dp/src/afxdp/ha/session_import.rs
@@ -79,7 +79,9 @@ impl crate::afxdp::Coordinator {
             && entry.generation != 0
             && entry.generation < previous.generation
         {
-            SESSION_INSTALL_STALE_IGNORED.fetch_add(1, Ordering::Relaxed);
+            self.sessions
+                .install_stale_ignored
+                .fetch_add(1, Ordering::Relaxed);
             return;
         }
         // #5674: aggregate synced-import admission bound. Locally-created
@@ -115,7 +117,9 @@ impl crate::afxdp::Coordinator {
         if previous_entry.is_none() && !entry.metadata.is_reverse {
             let synced_cap = self.synced_import_cap();
             if synced_cap != 0 && synced_len >= synced_cap {
-                SYNCED_IMPORT_CAP_DROPS.fetch_add(1, Ordering::Relaxed);
+                self.sessions
+                    .import_cap_drops
+                    .fetch_add(1, Ordering::Relaxed);
                 return;
             }
         }
@@ -275,7 +279,9 @@ impl crate::afxdp::Coordinator {
             && delete_gen != 0
             && delete_gen < entry.generation
         {
-            SESSION_DELETE_STALE_IGNORED.fetch_add(1, Ordering::Relaxed);
+            self.sessions
+                .delete_stale_ignored
+                .fetch_add(1, Ordering::Relaxed);
             return;
         }
         let reverse_key = removed_entry.as_ref().and_then(|entry| {

--- a/userspace-dp/src/afxdp/ha/session_import.rs
+++ b/userspace-dp/src/afxdp/ha/session_import.rs
@@ -21,7 +21,14 @@ impl crate::afxdp::Coordinator {
     /// ceiling via the uncapped sync-import fan-out. Zero when no workers are
     /// registered (early boot / teardown) — the caller treats a zero ceiling as
     /// "bound disabled" so a transient window never rejects legitimate imports.
-    fn synced_import_cap(&self) -> usize {
+    /// Visible to `ha::tests` (#6819 §7) so the PRODUCTION arithmetic below can
+    /// be asserted directly. Both admission tests set
+    /// `synced_import_cap_override`, which returns from the `#[cfg(test)]`
+    /// branch BEFORE this function's production expression is ever evaluated —
+    /// a test-only seam shadowing the real formula. With only those tests,
+    /// deleting the trailing `.saturating_mul(2)` here leaves every cap
+    /// assertion green.
+    pub(super) fn synced_import_cap(&self) -> usize {
         #[cfg(test)]
         if self.synced_import_cap_override != 0 {
             // The override expresses a LOGICAL session ceiling; double it to the

--- a/userspace-dp/src/afxdp/ha_tests.rs
+++ b/userspace-dp/src/afxdp/ha_tests.rs
@@ -693,6 +693,26 @@ fn upsert_synced_session_refuses_stale_generation_install() {
         before + 1,
         "stale install should be counted"
     );
+
+    // #6819 §7 positive control. Without this leg the test accepts a guard
+    // that refuses EVERY generation-1 install, or every install whose
+    // generation differs from the stored one — rejecting the whole category
+    // still yields "stored stays 2, counter +1". Pin that the refusal is
+    // SELECTIVE, so the test carries its own control rather than depending on
+    // `upsert_synced_session_applies_equal_and_newer_generation` being read
+    // alongside it.
+    coordinator.upsert_synced_session(synced_entry_with_generation(3));
+    assert_eq!(
+        synced_generation(&coordinator, &key),
+        Some(3),
+        "a NEWER-generation install must still apply — the guard refuses only \
+         strictly-older generations, not every generation change"
+    );
+    assert_eq!(
+        coordinator.session_install_stale_ignored_total(),
+        before + 1,
+        "a legitimate newer install must not bump the stale-refusal counter"
+    );
 }
 
 // ── #5674: synced-import aggregate admission bound (coordinator) ──────
@@ -927,6 +947,73 @@ fn over_ceiling_import_rejected_on_poisoned_shared_mutex() {
     );
 }
 
+// #6819 §7: both admission tests above set `synced_import_cap_override`, which
+// returns from the `#[cfg(test)]` branch of `synced_import_cap` BEFORE the
+// production expression runs. That test-only seam SHADOWS the production
+// formula: with only those two tests, deleting the trailing
+// `.saturating_mul(2)` from the production path leaves every cap assertion
+// green, because no test ever evaluates it. This test leaves the override at
+// its default 0 so the production arithmetic is the thing under test.
+//
+// The 2x is the property being pinned, not an implementation detail: the cap
+// counts ENTRIES while the ceiling it must express is LOGICAL sessions, and
+// each admitted forward publishes a forward key AND a synthesized reverse
+// companion. A cap sized to the logical ceiling rejects ~half of a legitimate
+// full-peer failover import above ~50% peer load (the #5674 dual-entry
+// regression).
+#[test]
+fn synced_import_cap_production_formula_is_twice_the_logical_ceiling() {
+    let mut coordinator = Coordinator::new();
+    assert_eq!(
+        coordinator.synced_import_cap_override, 0,
+        "this test must exercise the PRODUCTION formula — a nonzero override \
+         short-circuits `synced_import_cap` before it is reached"
+    );
+    // A per-worker ceiling of zero would make the 2x assertion below vacuous
+    // (0 == 2*0), so pin that the multiplicand is real first.
+    let per_worker = crate::session::default_max_sessions();
+    assert!(
+        per_worker > 0,
+        "DEFAULT_MAX_SESSIONS must be positive or the ceiling assertions below \
+         cannot distinguish the logical ceiling from twice it"
+    );
+
+    // No workers registered (early boot / teardown): a zero ceiling DISABLES
+    // the bound, so a transient window never rejects legitimate imports.
+    assert_eq!(
+        coordinator.synced_import_cap(),
+        0,
+        "an unregistered-worker coordinator must report a zero (disabled) \
+         ceiling, not a nonzero cap that would reject during early boot"
+    );
+
+    const WORKERS: usize = 3;
+    let commands = Arc::new(Mutex::new(VecDeque::new()));
+    for worker in 0..WORKERS {
+        coordinator.workers.records.insert(
+            worker as u32,
+            WorkerRuntimeRecord::for_test(test_worker_handle(commands.clone())),
+        );
+    }
+
+    let logical_ceiling = WORKERS * per_worker;
+    assert_eq!(
+        coordinator.synced_import_cap(),
+        2 * logical_ceiling,
+        "the production ENTRY cap must be TWICE the logical ceiling \
+         (worker_count * DEFAULT_MAX_SESSIONS), because each admitted forward \
+         logical session publishes a forward key AND a synthesized reverse"
+    );
+    // Stated separately and explicitly: dropping the trailing 2x is the #5674
+    // regression, and it yields exactly the logical ceiling.
+    assert_ne!(
+        coordinator.synced_import_cap(),
+        logical_ceiling,
+        "the ENTRY cap must not equal the LOGICAL ceiling — that is the \
+         pre-#5674 sizing that silently under-syncs a peer above ~50% load"
+    );
+}
+
 // An equal- or newer-generation upsert must apply (equality is NOT refusal).
 #[test]
 fn upsert_synced_session_applies_equal_and_newer_generation() {
@@ -976,11 +1063,21 @@ fn delete_synced_session_gen_refuses_stale_generation() {
         before + 1
     );
 
-    // Equal-generation delete (gen=2) — applies.
+    // Equal-generation delete (gen=2) — applies. This is the positive control:
+    // without it the test accepts a guard that refuses EVERY generation-aware
+    // delete.
     coordinator.delete_synced_session_gen(key.clone(), 2);
     assert!(
         synced_generation(&coordinator, &key).is_none(),
         "equal-generation delete should remove the entry"
+    );
+    // #6819 §7: and the legitimate delete must not be counted either —
+    // otherwise "refuse everything, count once" still satisfies the pair above.
+    assert_eq!(
+        coordinator.session_delete_stale_ignored_total(),
+        before + 1,
+        "an applied equal-generation delete must not bump the stale-refusal \
+         counter"
     );
 }
 
@@ -1080,6 +1177,14 @@ fn stale_generation_install_refused_on_poisoned_shared_mutex() {
         before + 1,
         "the stale install must be REFUSED and counted, not silently applied"
     );
+    // #6819 §7 scope note: this test alone accepts a build that refuses EVERY
+    // nonzero-generation install once the mutex has been poisoned — rejecting
+    // the whole category also leaves the stored generation at 2 with the
+    // counter at +1. The selectivity is controlled by
+    // `current_generation_install_and_delete_still_apply_on_poisoned_shared_mutex`,
+    // which asserts that newer/equal operations still APPLY across poisoning
+    // AND that stale ones are still refused. The two are a pair: deleting that
+    // control silently widens what this test accepts.
 }
 
 #[test]
@@ -1110,6 +1215,11 @@ fn stale_generation_delete_refused_on_poisoned_shared_mutex() {
         before + 1,
         "the stale delete must be REFUSED and counted, not silently applied"
     );
+    // #6819 §7 scope note: as with the install variant, this test alone accepts
+    // a build that refuses EVERY nonzero-generation delete after poisoning. The
+    // selectivity is controlled by
+    // `current_generation_install_and_delete_still_apply_on_poisoned_shared_mutex`;
+    // deleting that control silently widens what this test accepts.
 }
 
 // NEGATIVE CONTROL: the fix must RECOVER the poison and keep evaluating the
@@ -1159,14 +1269,71 @@ fn current_generation_install_and_delete_still_apply_on_poisoned_shared_mutex() 
         "a legitimate delete must not be counted as a stale refusal"
     );
 
+    // #6819 §7: the legs above only exercise NEWER/EQUAL operations, so on
+    // their own they accept DELETING the generation guard outright — a build
+    // that recovers the poison and then applies everything satisfies every
+    // assertion so far, and both stale-counter expectations are just the
+    // per-instance zero baseline. A negative control that accepts the removal
+    // of the thing it is controlling for is not controlling anything, so the
+    // selectivity of the recovery is asserted here directly: recovery must
+    // keep EVALUATING the guard, not bypass it.
+    let stale_key = test_key();
+    coordinator.upsert_synced_session(synced_entry_with_generation(9));
+    assert_eq!(
+        synced_generation_recovered(&coordinator, &stale_key),
+        Some(9),
+        "setup: the re-seeded entry must be stored before the stale probes"
+    );
+
+    poison_shared_synced(&coordinator);
+    coordinator.upsert_synced_session(synced_entry_with_generation(8));
+    assert_eq!(
+        synced_generation_recovered(&coordinator, &stale_key),
+        Some(9),
+        "poison recovery must not turn into accept-everything: a STALE \
+         install is still refused after the mutex is recovered"
+    );
+    assert_eq!(
+        coordinator.session_install_stale_ignored_total(),
+        stale_installs_before + 1,
+        "the stale install refused after recovery must be counted exactly once"
+    );
+
+    poison_shared_synced(&coordinator);
+    coordinator.delete_synced_session_gen(stale_key.clone(), 8);
+    assert_eq!(
+        synced_generation_recovered(&coordinator, &stale_key),
+        Some(9),
+        "poison recovery must not turn into accept-everything: a STALE \
+         delete is still refused after the mutex is recovered"
+    );
+    assert_eq!(
+        coordinator.session_delete_stale_ignored_total(),
+        stale_deletes_before + 1,
+        "the stale delete refused after recovery must be counted exactly once"
+    );
+
     // The panic that poisoned the mutex is OBSERVABLE: each recovery bumps
     // the shared counter and emits a journald line. Pre-fix the two guard
     // reads recovered nothing and logged nothing.
+    //
+    // This bound is >= rather than == on purpose, and it is the ONE assertion
+    // in this file that is still measured against a process-global
+    // (`SHARED_SESSION_POISON_RECOVERIES`, shared_ops.rs — bumped inside
+    // `lock_shared_recover`, which takes only the mutex and so has no
+    // per-Coordinator home to move to under #6819). A concurrent test's
+    // recovery can only push the observed value UP, so a lower bound cannot
+    // false-FAIL; an equality could. It can be satisfied by another test's
+    // bumps, which is why the precise claims above ride on the per-instance
+    // stale counters instead. `+ 4` is the number of poisonings this test
+    // performs: `> before` alone passed even if a single recovery served all
+    // of them.
+    const POISONINGS: u64 = 4;
     assert!(
         super::shared_ops::SHARED_SESSION_POISON_RECOVERIES.load(Ordering::Relaxed)
-            > recoveries_before,
-        "poison recoveries must be counted so the underlying worker panic \
-         is not silently self-healed"
+            >= recoveries_before + POISONINGS,
+        "each poisoning must be recovered and counted so the underlying worker \
+         panic is not silently self-healed"
     );
 }
 

--- a/userspace-dp/src/afxdp/ha_tests.rs
+++ b/userspace-dp/src/afxdp/ha_tests.rs
@@ -694,9 +694,37 @@ fn refusal_counters_are_per_coordinator_not_process_global() {
     // Both instances start clean. (Also the reason the `== before` captures
     // elsewhere in this file are now always `0 == 0` — see the note on
     // `current_generation_install_and_delete_still_apply_on_poisoned_shared_mutex`.)
-    assert_eq!(idle.session_install_stale_ignored_total(), 0);
-    assert_eq!(idle.session_delete_stale_ignored_total(), 0);
-    assert_eq!(idle.synced_import_cap_drops_total(), 0);
+    //
+    // These carry the SAME diagnostic as the payload assertions at the bottom,
+    // because under the sanctioned gate they are what actually fires. libtest
+    // runs alphabetically at `--test-threads=1`, so `current_generation_…` (c),
+    // `delete_synced_session_gen_…` (d) and `over_ceiling_import_…` (o) all
+    // execute BEFORE `refusal_counters_…` (r) and would have already bumped a
+    // restored global. A bare `assert_eq!(x, 0)` here reports `left: 1,
+    // right: 0` with no explanation, forty lines above the sentence that
+    // explains it — and the payload assertions below are reachable only when
+    // this test is run in isolation, which is not how `make test-rust` runs it.
+    assert_eq!(
+        idle.session_install_stale_ignored_total(),
+        0,
+        "precondition: a fresh Coordinator must read zero stale-install \
+         refusals — a nonzero value here means an EARLIER test's refusal leaked \
+         in, i.e. `install_stale_ignored` is process-global again (#6819)"
+    );
+    assert_eq!(
+        idle.session_delete_stale_ignored_total(),
+        0,
+        "precondition: a fresh Coordinator must read zero stale-delete \
+         refusals — a nonzero value here means an EARLIER test's refusal leaked \
+         in, i.e. `delete_stale_ignored` is process-global again (#6819)"
+    );
+    assert_eq!(
+        idle.synced_import_cap_drops_total(),
+        0,
+        "precondition: a fresh Coordinator must read zero cap drops — a nonzero \
+         value here means an EARLIER test's refusal leaked in, i.e. \
+         `import_cap_drops` is process-global again (#6819)"
+    );
 
     // Entry cap = 2 (logical override 1, doubled for the synthesized reverse).
     busy.synced_import_cap_override = 1;

--- a/userspace-dp/src/afxdp/ha_tests.rs
+++ b/userspace-dp/src/afxdp/ha_tests.rs
@@ -669,6 +669,92 @@ fn synced_generation(coordinator: &Coordinator, key: &SessionKey) -> Option<u64>
         .map(|entry| entry.generation)
 }
 
+// #6819 R3: the property the whole counter-scoping change exists to establish,
+// bound DETERMINISTICALLY.
+//
+// Every other assertion on these three counters is a DELTA capture (`let before
+// = ...` then `before + 1` or `== before`). A process-global satisfies every one
+// of them identically whenever tests do not interleave — and the sanctioned gate
+// (`make test-rust`) pins `-- --test-threads=1`, so WITHOUT this test, reverting
+// any of the three fields to a `static` leaves the entire gated suite GREEN.
+// That is measured, not assumed: reverting `import_cap_drops` reds 24 of 60
+// PARALLEL runs and 0 of 12 single-threaded ones; reverting both stale counters
+// reds 43 of 60 parallel and 0 of 5 single-threaded.
+//
+// This test does not depend on interleaving at all, so it reds at ANY thread
+// count including the gate's. It drives one refusal of each kind on a BUSY
+// coordinator and asserts that an IDLE coordinator, alive in the same process,
+// observed none of them. Under a process-global the idle instance reads the busy
+// instance's increments and every assertion in the final block fails.
+#[test]
+fn refusal_counters_are_per_coordinator_not_process_global() {
+    let mut busy = Coordinator::new();
+    let idle = Coordinator::new();
+
+    // Both instances start clean. (Also the reason the `== before` captures
+    // elsewhere in this file are now always `0 == 0` — see the note on
+    // `current_generation_install_and_delete_still_apply_on_poisoned_shared_mutex`.)
+    assert_eq!(idle.session_install_stale_ignored_total(), 0);
+    assert_eq!(idle.session_delete_stale_ignored_total(), 0);
+    assert_eq!(idle.synced_import_cap_drops_total(), 0);
+
+    // Entry cap = 2 (logical override 1, doubled for the synthesized reverse).
+    busy.synced_import_cap_override = 1;
+    let commands = Arc::new(Mutex::new(VecDeque::new()));
+    busy.workers.records.insert(
+        0,
+        WorkerRuntimeRecord::for_test(test_worker_handle(commands.clone())),
+    );
+
+    let key = test_key();
+    busy.upsert_synced_session(synced_entry_with_generation(2));
+    // (a) stale install — refused, counted.
+    busy.upsert_synced_session(synced_entry_with_generation(1));
+    // (b) stale delete — refused, counted; the entry survives.
+    busy.delete_synced_session_gen(key.clone(), 1);
+    // (c) over-ceiling NEW forward — the map already holds the forward + its
+    // synthesized reverse, so it is at the entry cap. Refused, counted.
+    busy.upsert_synced_session(synced_entry_port(2000, 0));
+
+    assert_eq!(
+        busy.session_install_stale_ignored_total(),
+        1,
+        "setup: the busy coordinator must have refused exactly one stale install"
+    );
+    assert_eq!(
+        busy.session_delete_stale_ignored_total(),
+        1,
+        "setup: the busy coordinator must have refused exactly one stale delete"
+    );
+    assert_eq!(
+        busy.synced_import_cap_drops_total(),
+        1,
+        "setup: the busy coordinator must have refused exactly one over-ceiling \
+         import"
+    );
+
+    // THE BINDING ASSERTIONS. A process-global would have leaked all three of
+    // the refusals above into this second, untouched Coordinator.
+    assert_eq!(
+        idle.session_install_stale_ignored_total(),
+        0,
+        "a second Coordinator observed another instance's stale-install \
+         refusal — `install_stale_ignored` is process-global again (#6819)"
+    );
+    assert_eq!(
+        idle.session_delete_stale_ignored_total(),
+        0,
+        "a second Coordinator observed another instance's stale-delete \
+         refusal — `delete_stale_ignored` is process-global again (#6819)"
+    );
+    assert_eq!(
+        idle.synced_import_cap_drops_total(),
+        0,
+        "a second Coordinator observed another instance's over-ceiling import \
+         refusal — `import_cap_drops` is process-global again (#6819)"
+    );
+}
+
 // A stale-generation upsert (gen=1 after gen=2 is stored) must be refused so
 // the per-key stored generation never regresses (the delayed-stale-install
 // variant, SMR C3). Mirrors the Go install guard.
@@ -1258,6 +1344,20 @@ fn current_generation_install_and_delete_still_apply_on_poisoned_shared_mutex() 
     );
 
     // Neither legitimate operation was counted as a stale refusal.
+    //
+    // #6819 note on what the per-instance scoping COST here: `..._before` is now
+    // always 0, because each `#[test]` owns its Coordinator. Under the previous
+    // process-global scheme these were genuine moving-baseline deltas — another
+    // test's refusals could make `stale_installs_before` nonzero — whereas now
+    // the two assertions immediately below are literally `0 == 0`, which is also
+    // what a never-incremented counter reads. Deleting the `fetch_add` bumps
+    // outright leaves THIS test passing in isolation. That is determinism bought
+    // at the cost of these two assertions' independence, and it is an acceptable
+    // trade only because the same mutation reds four other tests in this file
+    // (the two non-poison rejection tests, the two poison ones) plus
+    // `refusal_counters_are_per_coordinator_not_process_global`. The family is
+    // bound; this negative control is individually weak, which is normal for a
+    // negative control but should not be mistaken for coverage.
     assert_eq!(
         coordinator.session_install_stale_ignored_total(),
         stale_installs_before,

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -877,11 +877,29 @@ inside the capture window.
 **That mechanism is measured, and the sanctioned gate cannot see it.** Reverting
 `import_cap_drops` to a static reds 24 of 60 parallel runs and 0 of 12 runs
 under `--test-threads=1`; reverting both stale counters reds 43 of 60 parallel
-and 0 of 5 single-threaded. `make test-rust` pins `-- --test-threads=1` (to dodge
+and 0 of 5 single-threaded.
+
+The strongest evidence is independent of this change and predates it. While
+gating an unrelated PR (#6843), a lane measured parallel
+`cargo test -- afxdp::ha` over 40 iterations and found **34 of 40 runs failing
+at that PR's HEAD — and 34 of 40 at a `origin/master` CONTROL** with the PR's
+own files reverted and its tests confirmed absent. Identical rate with and
+without the change under review, which is what identifies the flake as
+pre-existing and environmental to these counters rather than caused by any one
+PR. It root-caused the failures to exactly `SESSION_INSTALL_STALE_IGNORED` /
+`SESSION_DELETE_STALE_IGNORED` being process-global and asserted with
+`assert_eq!(total, before)`, so *any* concurrently-running test that refuses a
+stale op reds them — and observed it as a whole family
+(`stale_generation_install_refused_…`, `stale_generation_delete_refused_…`,
+`over_ceiling_import_rejected_…`), not a single test. Those are the counters
+this section is about.
+
+`make test-rust` pins `-- --test-threads=1` (to dodge
 an unrelated socket-test wedge in `__skb_wait_for_more_packets`, #6657), so a
-regression of this property would ship **green** through the gate. Delta-capture
-assertions cannot close that hole — under serial execution a process-global
-satisfies `before + 1` identically. The binding test is
+regression of this property would ship **green** through the gate. Note the
+coupling: the flag that hides this defect exists because of a *different* one.
+Delta-capture assertions cannot close that hole — under serial execution a
+process-global satisfies `before + 1` identically. The binding test is
 `refusal_counters_are_per_coordinator_not_process_global`, which asserts one
 `Coordinator`'s refusals are invisible to a second live instance and so reds at
 any thread count. Any new refusal counter needs an equivalent, or it is

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -857,15 +857,35 @@ surfaced via `Coordinator::session_install_stale_ignored_total()` /
 All three sync-import refusal counters (`install_stale_ignored`,
 `delete_stale_ignored`, `import_cap_drops`) are **per-`Coordinator` fields on
 `SessionManager`**, not process-global statics. Production builds exactly one
-`Coordinator`, so the gRPC/Prometheus values are identical either way; the
-distinction is that the test suite builds one `Coordinator` per `#[test]` and
-runs them concurrently in a single process. As globals, a test asserting on
-these counters was measuring every *other* test's stale-install/stale-delete/
-over-ceiling refusals as well as its own, which failed the cargo suite on
-unmodified master (#6819). Keep new refusal counters on `SessionManager` for
-the same reason — a delta capture (`let before = ...; assert_eq!(..., before +
-1)`) does **not** make a process-global safe here, because a concurrent test's
-increment lands inside the capture window.
+`Coordinator`, so the **exported Prometheus value (`import_cap_drops`) is
+unchanged; the other two have no surface outside this binary** — their
+accessors are reachable only from `ha_tests.rs`. Only `import_cap_drops`
+travels the wire, via `server/helpers/status.rs` →
+`protocol::control::…synced_import_cap_drops_total` → the Go status struct →
+`xpf_userspace_synced_import_cap_drops_total`. None of the three appears in
+`proto/`; this crate has no gRPC dependency.
+
+The distinction that matters is therefore purely a test one: the suite builds
+one `Coordinator` per `#[test]` and runs them concurrently in a single
+process. As globals, a test asserting on these counters was measuring every
+*other* test's stale-install/stale-delete/over-ceiling refusals as well as its
+own (#6819). Keep new refusal counters on `SessionManager` for the same reason
+— a delta capture (`let before = ...; assert_eq!(..., before + 1)`) does
+**not** make a process-global safe, because a concurrent test's increment lands
+inside the capture window.
+
+**That mechanism is measured, and the sanctioned gate cannot see it.** Reverting
+`import_cap_drops` to a static reds 24 of 60 parallel runs and 0 of 12 runs
+under `--test-threads=1`; reverting both stale counters reds 43 of 60 parallel
+and 0 of 5 single-threaded. `make test-rust` pins `-- --test-threads=1` (to dodge
+an unrelated socket-test wedge in `__skb_wait_for_more_packets`, #6657), so a
+regression of this property would ship **green** through the gate. Delta-capture
+assertions cannot close that hole — under serial execution a process-global
+satisfies `before + 1` identically. The binding test is
+`refusal_counters_are_per_coordinator_not_process_global`, which asserts one
+`Coordinator`'s refusals are invisible to a second live instance and so reds at
+any thread count. Any new refusal counter needs an equivalent, or it is
+unguarded no matter how many delta assertions surround it.
 
 ### Per-policy log flags on the session-sync wire (#2785)
 

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -788,7 +788,7 @@ cap is meant to prevent). `upsert_synced_session` now bounds the shared
 `synced` map (the single fan-out choke point) at this appliance's OWN
 aggregate **ENTRY** ceiling — `2 * worker_count * DEFAULT_MAX_SESSIONS`
 (`synced_import_cap()`) — and **drop-newest**-rejects a NEW over-ceiling
-FORWARD key: it bumps `SYNCED_IMPORT_CAP_DROPS`
+FORWARD key: it bumps `SessionManager::import_cap_drops`
 (`Coordinator::synced_import_cap_drops_total()`, Prometheus
 `xpf_userspace_synced_import_cap_drops_total`) and returns BEFORE the
 publish + fan-out, so a rejected import is never enqueued to any worker
@@ -842,9 +842,10 @@ halves.
 
 `upsert_synced_session` (`afxdp/ha.rs`) refuses a strictly-older-generation
 install (both generations non-zero) so the helper's stored generation never
-regresses (`SESSION_INSTALL_STALE_IGNORED`), mirroring the Go install guard.
-`delete_synced_session_gen(key, delete_gen)` refuses a strictly-older-generation
-delete (`SESSION_DELETE_STALE_IGNORED`); the plain `delete_synced_session(key)`
+regresses (`SessionManager::install_stale_ignored`), mirroring the Go install
+guard. `delete_synced_session_gen(key, delete_gen)` refuses a
+strictly-older-generation delete (`SessionManager::delete_stale_ignored`); the
+plain `delete_synced_session(key)`
 wrapper passes `delete_gen = 0` so helper-local purges (tunnel-remap, GC) stay
 unconditional. These helper-side guards are **belt-and-suspenders** — the
 authoritative guard lives in the Go cluster apply layer (`deleteClusterSynced*`),
@@ -852,6 +853,19 @@ which short-circuits both the BPF map delete and the helper. The counters are
 surfaced via `Coordinator::session_install_stale_ignored_total()` /
 `session_delete_stale_ignored_total()`. See `docs/sync-protocol.md` and
 `docs/research/2170-ha-deferred-delete/plan.md`.
+
+All three sync-import refusal counters (`install_stale_ignored`,
+`delete_stale_ignored`, `import_cap_drops`) are **per-`Coordinator` fields on
+`SessionManager`**, not process-global statics. Production builds exactly one
+`Coordinator`, so the gRPC/Prometheus values are identical either way; the
+distinction is that the test suite builds one `Coordinator` per `#[test]` and
+runs them concurrently in a single process. As globals, a test asserting on
+these counters was measuring every *other* test's stale-install/stale-delete/
+over-ceiling refusals as well as its own, which failed the cargo suite on
+unmodified master (#6819). Keep new refusal counters on `SessionManager` for
+the same reason — a delta capture (`let before = ...; assert_eq!(..., before +
+1)`) does **not** make a process-global safe here, because a concurrent test's
+increment lands inside the capture window.
 
 ### Per-policy log flags on the session-sync wire (#2785)
 


### PR DESCRIPTION
Closes #6819

## The defect

Seven `#[test]` fns in `userspace-dp/src/afxdp/ha_tests.rs` used **process-global** `AtomicU64` statics as their before/after baseline. Cargo runs tests concurrently in one process, so one test's intentional stale-generation install, stale-generation delete, or over-ceiling import bumped a global another test was asserting had **not** moved.

Measured at pristine `origin/master` ad9591177, full `cargo test --release`, each run bounded at 900 s:

```
SEQUENCE[before]: FAIL FAIL HUNG FAIL FAIL
suite: 0 PASS / 4 FAIL / 1 HUNG
#6819 participant tests failed in 5 of 5 runs
```

That is 5-of-5, not the issue's 3-of-5, because of a scoring detail worth reusing: **the trailing `failures:` block never prints on a wedged run**, so scoring off that block alone counts a wedged run as *clean* — and the run that hung had already failed a #6819 test before wedging. Score off the union of the `failures:` block and the per-test `... FAILED` lines, which survive the wedge. Any harness measuring flake rate against this suite has that bug until it does the same.

## Why the issue's suggested fix wouldn't have worked

The issue offers "make the assertions DELTA-based" as option 2. **They already are** — every one captures `let before = ...` and asserts `before + 1`. That is not sufficient, because a concurrent test's increment lands *inside* the capture window. Recomputing a delta over shared state still observes the other writer. Only a per-instance home removes the dependency, which is the issue's option 3.

## The fix

Three counters move out of `afxdp/bpf_map/metrics.rs` onto `SessionManager`, beside the existing per-instance `export_seq`:

| was (process-global) | now (per-Coordinator) | |
|---|---|---|
| `SESSION_INSTALL_STALE_IGNORED` | `sessions.install_stale_ignored` | #2170 |
| `SESSION_DELETE_STALE_IGNORED` | `sessions.delete_stale_ignored` | #2170 |
| `SYNCED_IMPORT_CAP_DROPS` | `sessions.import_cap_drops` | #5674 |

Every bump site (`ha/session_import.rs:82`, `:118`, `:278`) and every read site (`coordinator/status.rs:207`, `:214`, `:227`) already held a `&self` `Coordinator`, so there are no signature or call-graph changes. This mirrors an existing convention: `Coordinator` already documents three test seams as *"per-instance, NOT a process-global … so parallel tests never race."*

**`ha_tests.rs` is untouched** — no assertion weakened, relaxed or deleted, no `--test-threads=1`, no `#[serial]`, no `>=` tautology.

### The single-Coordinator invariant is load-bearing

"No production behaviour change" rests entirely on production building exactly one `Coordinator`. A second one would silently convert three process-wide sums into three per-instance tallies, so this was established exhaustively rather than by inspecting the obvious site:

- Every `Coordinator::new()` call site enumerated; all but one are under `#[cfg(test)]`. **Two do not live in `*_tests.rs` files and so don't look like tests at a glance**: `coordinator/reconcile/snapshot.rs:801` (inside the `cfg(test)` module opening at `:643`) and `worker/launch.rs:292/301/355` (inside the one opening at `:287`).
- The sole non-test construction is `server/lifecycle.rs:315`, in the one-shot startup initializer of the shared `ServerState` — not in a loop, not in a re-entrant function.
- No `impl Default for Coordinator`, and no struct-literal construction: `Coordinator {` matches only `impl` blocks.
- The `afxdp` field holding it is never reassigned outside tests, so no restart path swaps in a fresh `Coordinator` mid-process.

So the per-instance counters have exactly the lifetime the statics had — created once at startup, never replaced, live until exit. gRPC and Prometheus values are identical.

### Scope note: three counters, not two

`import_cap_drops` is included deliberately rather than deferred. It sits three lines below the other two in the same static block, is asserted in the same `== before + N` form by two tests that **both** bump it (ha_tests.rs:789/806/849/912), and failed in the same measured run. Deferring it would leave the gate red for the identical reason.

## Validation

**After the fix, 10 bounded runs:**
```
SEQUENCE[after]: PASS HUNG FAIL HUNG FAIL PASS HUNG PASS PASS PASS
suite: 5 PASS / 2 FAIL / 3 HUNG
#6819 participant tests failed in 0 of 10 runs
```

`go test ./...` green.

### Isolated measurement: `cargo test --release --bins -- ha::`

The full-suite figure above is the honest system-level number and is the primary one. This second measurement is **narrower** — it exists only to remove the #6657 confound, since none of that issue's legs (wg-engine install/reconcile, CoS-lease seqlock, the blocking-recv wedge) are under `ha::`. 28 tests per run, 10 runs each, same bounded harness:

```
pristine origin/master ad9591177 : FAIL FAIL FAIL FAIL FAIL FAIL FAIL PASS FAIL FAIL   (9 of 10 red)
this branch                      : PASS PASS PASS PASS PASS PASS PASS PASS PASS PASS   (0 of 10 red)
```

Zero HUNGs on either side, confirming the #6657 wedge lives entirely outside this filter.

**The pristine leg is a real control, not a quieter subset.** All seven participants live under `afxdp::ha::tests::`, so the filter keeps every racing partner *inside* it — the race is not separated by construction. Six of the seven were caught failing across those 10 runs:

| times red in 10 | test |
|---|---|
| 9 | `current_generation_install_and_delete_still_apply_on_poisoned_shared_mutex` |
| 1 | `stale_generation_install_refused_on_poisoned_shared_mutex` |
| 1 | `stale_generation_delete_refused_on_poisoned_shared_mutex` |
| 1 | `upsert_synced_session_refuses_stale_generation_install` |
| 1 | `upsert_synced_session_rejects_over_ceiling_import_and_does_not_fan_out` |
| 1 | `over_ceiling_import_rejected_on_poisoned_shared_mutex` |

Only `delete_synced_session_gen_refuses_stale_generation` did not happen to lose a race in this sample. Note that **both** `import_cap_drops` tests appear — independent confirmation that the third counter belonged in this PR rather than deferred.

**The suite is not 10-of-10 green, and this PR does not make it so.** Every residual failure is #6657, a different mechanism:
- both FAILs: `afxdp::types::shared_cos_lease::tests::v8_epoch_seqlock_snapshot_never_tears_tag_grace`
- all 3 HUNGs: an unbounded blocking recv — 7 threads in `__skb_wait_for_more_packets`, 6 in `futex_do_wait`, ~15 s CPU against 900 s wall

### Red-on-revert — 7 of 7 bind on an assertion

Each mutation reverts the production behaviour the test covers; every file was restored **and `touch`ed** so cargo could not re-run a stale binary. `cargo` stayed clean under all seven (no build-break false reds).

| | test | mutation | binding assertion |
|---|---|---|---|
| M1 | `upsert_synced_session_refuses_stale_generation_install` | drop the #2170 install guard | ha_tests.rs:686 "stale-generation install rolled the stored generation back" |
| M2 | `delete_synced_session_gen_refuses_stale_generation` | drop the #2170 delete guard | :970 "stale-generation delete wrongly removed the live entry" |
| M3 | `stale_generation_install_refused_on_poisoned_shared_mutex` | revert the paired read to a poison-swallowing `lock()` | :1071 "a poisoned shared mutex let a stale-generation install roll the stored generation back" — `left: Some(1), right: Some(2)` |
| M4 | `stale_generation_delete_refused_on_poisoned_shared_mutex` | same, delete path | :1108 "…let a stale-generation delete remove a NEWER live entry" — `left: None, right: Some(2)` |
| M5 | `current_generation_install_and_delete_still_apply_on_poisoned_shared_mutex` | refuse-on-poison (the alternative this negative control exists to rule out) | :1145 "a newer-generation install must still apply after poison recovery" — `left: Some(2), right: Some(3)` |
| M6 | `upsert_synced_session_rejects_over_ceiling_import_and_does_not_fan_out` | drop the #5674 admission bound | :800 "an over-ceiling synced FORWARD import must be REJECTED, not admitted past the aggregate cap" |
| M7 | `over_ceiling_import_rejected_on_poisoned_shared_mutex` | revert **only** the ceiling length read, ordered before the recovered read (that test's own parent-RED recipe) | :904 "a poisoned shared mutex let an over-ceiling synced import through" |

**Reviewer trap in the raw logs.** M3/M4/M5/M7 had their evidence lines re-derived from full per-mutation logs. Those four call `poison_shared_synced`, which panics a thread **on purpose**; under `--nocapture` that deliberate panic prints *first*, at `ha_tests.rs:1033: poison shared session mutex`. The first `panicked at` line therefore names the intentional panic, not the failing assertion — the quotes above are the second panic, the real one. The RED verdicts were never in doubt (non-zero rc, no build break, no "1 passed"), but the quoted reasons were wrong until re-derived. In a suite where tests panic by design, "first panic line" is not the failure reason.

## Gate fold — §7 acceptance gaps (commit `8fe6e0f16`)

Three findings about what the tests still *accept*. No runtime change; the counter-scoping fix was sound.

**F1 — the production admission formula was untested.** Both #5674 cap tests set `synced_import_cap_override`, which returns from the `#[cfg(test)]` branch of `synced_import_cap` *before* the production expression is evaluated. Deleting its trailing `.saturating_mul(2)` left both green. `synced_import_cap` is now `pub(super)` (ha_tests is `crate::afxdp::ha::tests`, a **sibling** of `session_import`, so a private fn was unreachable) and a new test runs with the override at 0: zero workers give a disabled (0) ceiling, three workers give exactly `2 * 3 * DEFAULT_MAX_SESSIONS`, plus `assert_ne!` against the bare logical ceiling — which is what dropping the `2x` produces. It pins `DEFAULT_MAX_SESSIONS > 0` first, or `0 == 2*0` makes the claim vacuous.

**F2 — rejecting the whole category still passed.** Refusing *every* generation-1 install also yields "stored unchanged, counter +1". The two non-poison tests now carry their own positive control (newer install applies and does not count; applied equal-generation delete does not count). The two poison tests get scope comments naming the control that supplies their selectivity.

**F3 — the negative control accepted deletion of the guard it controls for.** It exercised only newer/equal operations, so a build that recovers the poison then applies everything satisfied it; both stale expectations are `== before`, the per-instance zero baseline, trivially met when the guard never fires. It now probes the stale direction after recovery — stale install and stale delete each refused and counted exactly once.

The recoveries assertion tightens from `> before` to `>= before + 4` (the poisoning count); one bump serving all of them previously passed. It stays a **lower** bound deliberately: `SHARED_SESSION_POISON_RECOVERIES` is the one counter still process-global, bumped inside `lock_shared_recover`, which takes only the mutex and has no per-`Coordinator` home. A concurrent recovery can only push it up, so `>=` cannot false-fail where `==` could.

### Four-cell mutation matrix

Each mutation is run against **both** test generations — a mutation the old tests already caught would validate nothing.

| mutation | vs OLD tests | vs NEW test |
|---|---|---|
| drop the production `2x` | **PASS** (gap was real) | **FAIL** (gap closed) |
| delete the generation guard | **PASS** (gap was real) | **FAIL** (gap closed) |

New-test failure: *"the production ENTRY cap must be TWICE the logical ceiling"*. New-control failure: *"poison recovery must not turn into accept-everything: a STALE install is still refused after the mutex is recovered"*.

Both PASS cells were re-run one filter at a time — libtest rejects a repeated `--exact` with `Option 'exact' given more than once`, which my first harness scored as inconclusive rather than as a pass.

Full `cargo test --release` rc=**0** (4234 passed, 0 failed, 2 ignored); `go test ./...` rc=**0**.

## Gate fold round 2 — R3 + export-surface accuracy (commit `d857a38be`)

**R3 — the gated suite could not detect a revert of this fix.** Every assertion on the three counters is a delta capture (`before + 1` / `== before`), and `make test-rust` pins `-- --test-threads=1` (`Makefile:114-116`, adopted to dodge the #6657 `__skb_wait_for_more_packets` socket wedge). Under serial execution a process-global satisfies all of them identically, so reverting any counter to a static shipped **green**.

The README's concurrency mechanism is *correct* — measured, reverting the cap counter reds 24/60 parallel runs and 0/12 serial; the stale pair 43/60 vs 0/5 — but the gate structurally cannot observe it. That is a separate problem needing a different test.

`refusal_counters_are_per_coordinator_not_process_global` binds the property directly: drive one stale install, one stale delete and one over-ceiling import on a **busy** `Coordinator`, then assert an **idle** one alive in the same process saw none of them. No dependence on interleaving, so it reds at any thread count.

**Proof, run with the gate's own flag:**

| | result |
|---|---|
| revert `install_stale_ignored` to its `metrics.rs` static → **new test** | **FAIL** — under the sanctioned `--test-threads=1` this reds at the **precondition** (ha_tests.rs:707), *"precondition: a fresh Coordinator must read zero stale-install refusals … `install_stale_ignored` is process-global again (#6819)"*. ha_tests.rs:738 is the line an **isolated** run reaches — libtest orders alphabetically, so c/d/o bump the restored global before r runs. |
| same revert → **other 29 `ha::` tests** | **29 passed, 0 failed** |

The pre-existing suite genuinely cannot see the revert. (The "rest stays green" leg is a real 29-test run, not a green-by-skip: my first attempt mis-parsed a sibling binary's `0 passed` line and was re-measured.)

**Export-surface claim was wrong twice.** "the gRPC/Prometheus values are unchanged" overstated it. This crate has **no gRPC dependency** and none of the three counters is in `proto/`. Only `import_cap_drops` reaches Prometheus — `server/helpers/status.rs:102` → `protocol/control.rs:334` (serde-renamed) → `protocol_status.go:279` → `metrics_userspace.go:672`. The two stale counters have **no wire and no metric surface**; their accessors are reachable only from `ha_tests.rs`. Corrected at `session_manager.rs`, `session/README.md`, and inline on the earlier `_Log.md` entry.

**What the scoping cost, recorded where it applies.** Per-instance counters make every `..._before` capture 0, so three `== before` assertions degenerate to `0 == 0` — which is also what a never-incremented counter reads. Deleting the `fetch_add` bumps leaves that negative control passing *in isolation*. Under the old global scheme those were genuine moving-baseline deltas. Acceptable because the same mutation reds four other tests plus the new one, but the control is individually weaker than it was and the comment now says so.

**Not folded:** `SHARED_SESSION_POISON_RECOVERIES` and the `DNAT_*_ATTEMPTS` pair remain process-global — filed as **#6872**, along with two function-local `static GUARD: Mutex<()>` declarations that serialize nothing.

Gates: `cargo test --release --bins --tests -- --test-threads=1` **rc=0** (4235 passed, 0 failed, 2 ignored); `go test ./...` **rc=0**.

## Gate fold round 3 — reachable diagnostics + commit prefix (`ebc861b28`)

**M1 — the `#6819` diagnostics were unreachable in the mode the gate runs.** libtest executes alphabetically under `--test-threads=1`, so `current_generation_…` (c), `delete_synced_session_gen_…` (d) and `over_ceiling_import_…` (o) all bump a restored global *before* `refusal_counters_…` (r) runs. The bare `assert_eq!(x, 0)` preconditions therefore tripped first and reported `left: 1, right: 0` with no explanation, while the carefully-worded payload assertions forty lines below fired only in an **isolated** run — not how `make test-rust` runs it. All three preconditions now carry the same named diagnostic.

Verified with the revert applied, serial mode: fails at `ha_tests.rs:707` with *"precondition: a fresh Coordinator must read zero stale-install refusals — a nonzero value here means an EARLIER test's refusal leaked in, i.e. `install_stale_ignored` is process-global again (#6819)"*, `left: 1, right: 0`, alongside `29 passed`.

The general lesson outlives the fix: **a diagnostic is only as good as the run mode that reaches it.** When a test has a precondition and a payload assertion, check which fires under the *sanctioned* invocation, not the filtered one used while developing — filtering to a single test hides exactly this.

**M2 — a line cite the stated conditions don't produce.** The claim "reds at ha_tests.rs:738 while the other 29 `ha::` tests run and pass" combined two different runs. The 29-others half reproduces exactly; the line is from the isolated run. Corrected here and in `_Log.md`.

**Commit prefix.** `83df45377` (was `3f8d29a08`) is retitled `test(ha):` → **`fix(ha):`** — it moves production statics into production struct fields, and since this lands via `--merge` the subject survives on master, where `test(ha):` would tell a future bisect to skip the one commit that changed runtime behaviour. History was replayed to retitle it; `git diff` between the pre- and post-rewrite heads is **empty**, so only the subject changed.

Gates on the final head: `cargo test --release --bins --tests -- --test-threads=1` **rc=0** (4235 passed, 0 failed, 2 ignored); `go test ./...` **rc=0**.

## Follow-up, not fixed here

`SHARED_SESSION_POISON_RECOVERIES` (`afxdp/shared_ops.rs:16`) is also a process-global read by tests, but only via `>` comparisons, which are monotone-safe under concurrency. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi




