### PR TITLE
cluster: serialize the config-generation reset against its advances (#5084 partial)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -68224,3 +68224,52 @@ than after, so this does not repeat the defect it corrects. The enclosing
 paragraph was rewrapped to 72 columns because the longer path overflowed;
 no wording changed. Zero `afxdp/ha.rs` citations remain in the file. No
 `.rs` file is touched — this PR stays comment/doc-only.
+
+- **Timestamp**: 2026-08-06
+- **Action**: #5084 SPLIT — the connection-epoch fence is removed from this PR
+  and blocked on #5480. Seven review rounds established that the fence keys on
+  `syncConnID`, a total ORDER over connections, when the predicate it needs is
+  an EQUIVALENCE ("same peer boot?"), because config generations are comparable
+  only within one sender incarnation. A ranking cannot express an equivalence,
+  so the floor has no correct setting: never descending locks out a live
+  same-incarnation sibling that merely connected earlier, and descending
+  re-admits departed older-incarnation connections and makes the floor a mutable
+  target an in-flight `resetRecvGen` can reclaim. The decisive finding is that
+  the fence's drop is a `continue` that skips the generation gate, so a dropped
+  payload's generation never enters the high-water and HEAD ended up applying a
+  stale payload `origin/master` REFUSES; closing that means recording the
+  dropped generation, which is a pre-reboot (higher) value and wedges the
+  standby permanently. One scalar high-water cannot serve two incarnations.
+  What ships instead is the one defect that is real on master with or without
+  the fence: the reconnect RESET of the config-generation marks was not atomic
+  against their ADVANCE. Both marks are advanced by a load/compare/store and
+  cleared to 0 by `resetRecvGen` from a DIFFERENT goroutine — the clear runs on
+  a receive loop, the applied mark advances on `configApplyLoop`, and the
+  received mark advances on a receive loop of which there are TWO. A clear
+  landing inside an advance was LOST and the store re-raised the mark it had
+  just zeroed, leaving a pre-reboot generation that refuses every generation the
+  reconnected peer can produce — silently, permanently, since the marks are
+  monotone-max. New `configGenMu` covers the reset and all four advance sites;
+  readers stay lock-free. Two false contracts corrected at their sites
+  ("called ONLY from the single-consumer configApplyLoop" ignored the clear;
+  "the receiveLoop is single-threaded per connection" is true per connection but
+  there are two of them).
+- **Validation**: 2x2 mutation grid, disjoint cells. M1 (remove `configGenMu`
+  from the advances and the reset) REDs both binders as ASSERTIONS —
+  "the reconnect reset was LOST: the applied config high-water is 1800000000123
+  (the peer's PRE-REBOOT generation) instead of 0.
+  reset_completed_inside_the_advance_window=true" and the received-mark twin —
+  and leaves `TestConfigGenAdvanceStaysMonotone` GREEN. M2 (drop the
+  `gen > current` comparison for a bare Store) REDs only the monotone guard,
+  both subtests ("the applied high-water must never regress: publishing
+  12000000456 after 1800000000123 pulled it down to 12000000456"), and leaves
+  both binders GREEN. Each monotone subtest carries a negative control (a
+  strictly higher generation must still advance), so the assertion pins
+  regression rather than "never moves". `go build ./...` 0,
+  `go vet ./pkg/cluster ./pkg/daemon` 0,
+  `go test ./pkg/cluster ./pkg/daemon -count=1 -race` 0,
+  `go test ./pkg/cluster -run <5084 cohort> -count=5 -race` 0.
+- **File(s)**: pkg/cluster/sync.go, pkg/cluster/sync_conn_config.go,
+  pkg/cluster/sync_conn_gen.go, pkg/cluster/sync_conn_read.go,
+  pkg/cluster/sync_config_gen_reset_race_5084_test.go,
+  pkg/cluster/README.md, docs/sync-protocol.md, _Log.md

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -603,6 +603,30 @@ monotonic counter restarts lower — is accepted instead of refused as stale
 config after a reconnect is always the peer's *current* config
 (`pushConfigToPeer` sends `ShowActive`), so the newest content still wins.
 
+**That reset is atomic against every advance of the marks (#5084).** Both
+high-waters are advanced by a non-atomic read-modify-write — load, compare,
+store — and `resetRecvGen` clears them from a *different* goroutine: the clear
+runs on a receive loop (the `BulkStart` handler), the applied mark is advanced
+by the single `configApplyLoop` consumer, and the received mark is advanced by a
+receive loop, of which there are **two** (`conn0`/`conn1`). Nothing ordered
+them, so a clear landing between an advance's load and its store was simply
+LOST, and the store then re-raised the mark the reset had just zeroed.
+
+That is not a transient. The marks are monotone-max and the whole reason the
+reset exists is that a rebooted peer restarts its counter LOWER, so a surviving
+pre-reboot generation refuses *every* generation the reconnected peer can
+produce: on `lastAppliedConfigGen` the standby silently keeps running the
+pre-reboot config, and on `lastRecvConfigGen` the readiness comparison below
+inverts. Neither self-clears short of another accepted re-prime. `configGenMu`
+now covers the reset and every advance (`recordAppliedConfigGen`,
+`recordRecvConfigGen`, `beginConfigApply`/`endConfigApply`); readers stay
+lock-free, since a reader racing a writer only ever observes one side of a
+single monotone step. Two prior comments stated the contract wrongly and are
+corrected at their sites — the applied advance claimed it is "called ONLY from
+the single-consumer `configApplyLoop`", which ignores the clear, and the
+received advance claimed "the receiveLoop is single-threaded per connection",
+which is true per connection but there are two of them.
+
 **Manual-failover config-staleness gate (#5563).** A second high-water mark,
 `lastRecvConfigGen`, records the highest generation this node has *received*
 from the peer (advanced in the `syncMsgConfig` handler at enqueue, BEFORE

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -1367,7 +1367,25 @@ outside the monitor loop:
   sender→receiver #3931 namespace, so the comparison is meaningful across nodes.
   `epoch == 0` (legacy peer / local-origin) disables the check (rolling-upgrade
   safe); the reconnect `resetRecvGen` zeroes `lastAppliedConfigGen` so a
-  rebooted-peer bulk re-prime is never falsely rejected. **The guard is
+  rebooted-peer bulk re-prime is never falsely rejected. **That zeroing is
+  serialized against every advance of the mark by `configGenMu` (#5084)** — the
+  advance is a load/compare/store and the clear runs on a different goroutine
+  (a receive loop, versus `configApplyLoop` for the applied mark and the *other*
+  receive loop for the received mark), so a clear could land inside an advance
+  and be lost, leaving a pre-reboot generation that refuses every generation the
+  reconnected peer can produce. Writers of the three config-generation marks:
+
+  | writer | mark(s) | goroutine | synchronisation |
+  |---|---|---|---|
+  | `recordAppliedConfigGen` | applied | `configApplyLoop` | `configGenMu` |
+  | `recordRecvConfigGen` | received | receive loop (×2) | `configGenMu` |
+  | `beginConfigApply` / `endConfigApply` | applying fence | `configApplyLoop` | `configGenMu` |
+  | `resetRecvGen` | all three, clear to 0 | receive loop (×2) | `configGenMu` |
+  | `initGenState` | all three | `NewSessionSync` | none — pre-`Start`, no goroutines yet |
+
+  Readers stay lock-free (the marks are atomics and `configEpochStale` runs per
+  synced session install); a reader racing a writer observes one side of a
+  single monotone step, which is the tolerance the marks already had. **The guard is
   Go-cluster-authoritative** — the userspace helper's `config_generation` is a
   *local* commit counter (`Manager.bumpGeneration`) that is not cross-node
   comparable, so the receiver rejects the stale install BEFORE forwarding it to

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -617,6 +617,54 @@ type SessionSync struct {
 	lastRecvConfigGen atomic.Uint64
 	configApplyCh     chan configApplyItem
 
+	// configGenMu makes the reconnect RESET of the three config-generation
+	// marks above atomic with respect to every ADVANCE of them (#5084).
+	//
+	// Each mark is advanced by a non-atomic read-modify-write — load, compare,
+	// store — and each is cleared to 0 by resetRecvGen on a peer bulk re-prime.
+	// Those run on DIFFERENT goroutines: resetRecvGen is called from the
+	// syncMsgBulkStart handler on a receive loop, while the applied mark is
+	// advanced by the single configApplyLoop consumer and the received mark by
+	// a receive loop. Nothing ordered them, so a clear could land between an
+	// advance's load and its store and be lost — the store then re-raises the
+	// mark the reset just cleared.
+	//
+	// That is not benign, which is what the pre-#5084 comments assumed. The
+	// whole point of the reset is that a peer which OS-rebooted restarts its
+	// monotonic configGenCounter LOWER; a pre-reboot generation surviving the
+	// reset means every one of the reconnected peer's CURRENT generations is
+	// refused as stale. On lastAppliedConfigGen that silently strands the
+	// standby on the pre-reboot config; on lastRecvConfigGen it poisons the
+	// readiness comparison (PeerConfigGen > AppliedConfigGen) so the node can
+	// report ready while running the wrong policy. Neither self-clears: the
+	// marks are monotone-max, so only another accepted re-prime or ~1.8e12
+	// commits would move them back down.
+	//
+	// Two prior comments stated the contract wrongly and are corrected at their
+	// sites: recordAppliedConfigGen claimed it is "called ONLY from the
+	// single-consumer configApplyLoop", which ignores resetRecvGen's clear; and
+	// the received-mark raise claimed "the receiveLoop is single-threaded per
+	// connection", which is true per connection but there are TWO of them
+	// (conn0/conn1), so a raise on one fabric races a reset on the other.
+	//
+	// Every WRITER takes this mutex; READERS stay lock-free, because they are on
+	// hot paths (configEpochStale runs per synced session install) and a reader
+	// racing a writer only observes one side of a single monotone step, which is
+	// the same tolerance the marks already had.
+	//
+	// LOCK ORDER: configGenMu is a LEAF. No site takes another lock while
+	// holding it, and resetRecvGen takes it strictly after releasing recvGenMu.
+	configGenMu sync.Mutex
+	// configGenAdvanceBarrierFn is a test injection seam (nil in production,
+	// #5084). recordAppliedConfigGen / recordRecvConfigGen call it after reading
+	// the current mark and before storing the advanced value — the exact window
+	// in which a concurrent clear used to be lost. A lost update cannot be
+	// driven deterministically any other way: without a seam the test would have
+	// to race a sleep against the window and would pass on broken code whenever
+	// it lost that race. A test parks a reset in the window and asserts the
+	// clear survives.
+	configGenAdvanceBarrierFn func()
+
 	// Config-sync APPLY health tracking (#6387). These drive the time-based CF
 	// monitor-failure edge. Unlike the loop-local high-water logic they are NOT
 	// single-goroutine-owned: an independent grace-expiry timer

--- a/pkg/cluster/sync_config_gen_reset_race_5084_test.go
+++ b/pkg/cluster/sync_config_gen_reset_race_5084_test.go
@@ -1,0 +1,217 @@
+package cluster
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// #5084 — the reconnect RESET of the config-generation marks must be atomic with
+// respect to every ADVANCE of them.
+//
+// Both marks are advanced by a non-atomic read-modify-write (load, compare,
+// store) and cleared to 0 by resetRecvGen on a peer bulk re-prime, and those run
+// on DIFFERENT goroutines: resetRecvGen is driven by the syncMsgBulkStart
+// handler on a receive loop, the applied mark is advanced by the single
+// configApplyLoop consumer, and the received mark is advanced by a receive loop
+// (of which there are TWO — conn0 and conn1). Nothing ordered them, so a clear
+// landing between an advance's load and its store was simply LOST.
+//
+// The harm is not a transient: the marks are monotone-max. A peer that
+// OS-rebooted restarts its configGenCounter LOWER, which is the entire reason
+// the reset exists. A pre-reboot generation surviving the reset means every one
+// of the reconnected peer's CURRENT generations is refused as stale — on the
+// applied mark the standby silently keeps running the pre-reboot config, and on
+// the received mark the readiness comparison (PeerConfigGen > AppliedConfigGen)
+// inverts and the node reports READY while running that wrong policy. Neither
+// self-clears short of another accepted re-prime.
+//
+// What binds what:
+//
+//	TestConfigGenResetIsNotLostByAConcurrentAppliedAdvance
+//	TestConfigGenResetIsNotLostByAConcurrentReceivedAdvance
+//	    THE binders. They park an advance inside its own load/store window via
+//	    configGenAdvanceBarrierFn, drive resetRecvGen into that window from
+//	    another goroutine, and assert the clear survives. Reverting the mutex
+//	    leaves the reset free to run inside the window, and the parked store then
+//	    re-raises the mark it just cleared.
+//	TestConfigGenAdvanceStaysMonotone
+//	    Over-reach guard. GREEN with the mutex reverted by design: it pins the
+//	    `gen > current` comparison, which the serialization has nothing to do
+//	    with, so the two cells are disjoint.
+
+// preRebootGen is a realistic pre-reboot magnitude (configGenCounter is seeded
+// from CLOCK_MONOTONIC nanos, so ~30 minutes of uptime stamps ~1.8e12) and
+// postRebootGen is what the same node stamps ~12 seconds after a reboot. The
+// post value being far LOWER is the whole reason the reset exists.
+const (
+	resetRaceGenPreReboot  uint64 = 1_800_000_000_123
+	resetRaceGenPostReboot uint64 = 12_000_000_456
+)
+
+// parkedAdvance drives one advance with its store parked inside the mark's
+// load/store window, runs resetRecvGen from a second goroutine while it is
+// parked, and returns once both have finished. reachedWindow reports whether the
+// advance actually parked (a guard against the test silently becoming a no-op if
+// the advance is skipped by its own comparison), and resetFinishedWhileParked
+// reports whether the reset completed BEFORE the advance was released — which is
+// the observable difference between the serialized and unserialized code.
+func parkedAdvance(t *testing.T, s *SessionSync, advance func()) (reachedWindow, resetFinishedWhileParked bool) {
+	t.Helper()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	s.configGenAdvanceBarrierFn = func() {
+		once.Do(func() { close(entered) })
+		<-release
+	}
+	defer func() { s.configGenAdvanceBarrierFn = nil }()
+
+	advanceDone := make(chan struct{})
+	go func() {
+		defer close(advanceDone)
+		advance()
+	}()
+
+	select {
+	case <-entered:
+		reachedWindow = true
+	case <-time.After(5 * time.Second):
+		close(release)
+		<-advanceDone
+		return false, false
+	}
+
+	// The reconnecting peer's bulk re-prime, driven from another goroutine
+	// exactly as the syncMsgBulkStart handler drives it from a receive loop.
+	resetDone := make(chan struct{})
+	go func() {
+		defer close(resetDone)
+		s.resetRecvGen()
+	}()
+
+	// Give the reset a real chance to run. Serialized, it blocks on configGenMu
+	// and this observation is false; unserialized, it completes here.
+	select {
+	case <-resetDone:
+		resetFinishedWhileParked = true
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	close(release)
+	<-advanceDone
+	select {
+	case <-resetDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("resetRecvGen never completed after the parked advance was released")
+	}
+	return reachedWindow, resetFinishedWhileParked
+}
+
+// TestConfigGenResetIsNotLostByAConcurrentAppliedAdvance binds the APPLIED mark.
+//
+// Harm first: with the clear lost, the standby's high-water stays at the peer's
+// PRE-REBOOT generation, so the reconnected peer's current (lower) config is
+// refused as stale by shouldApplyConfigGen and the standby silently keeps
+// running the pre-reboot configuration.
+func TestConfigGenResetIsNotLostByAConcurrentAppliedAdvance(t *testing.T) {
+	s := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", nil)
+
+	reached, resetRanInsideWindow := parkedAdvance(t, s, func() {
+		s.recordAppliedConfigGen(resetRaceGenPreReboot)
+	})
+	if !reached {
+		t.Fatal("fixture broken: the advance never entered its load/store window, so nothing was parked and this test proves nothing")
+	}
+
+	if got := s.lastAppliedConfigGen.Load(); got != 0 {
+		t.Fatalf("the reconnect reset was LOST: the applied config high-water is %d (the peer's PRE-REBOOT generation) instead of 0. "+
+			"reset_completed_inside_the_advance_window=%v. The standby now refuses every generation the reconnected peer can produce "+
+			"(it restarts its counter LOWER, e.g. %d) and silently keeps running the pre-reboot config",
+			got, resetRanInsideWindow, resetRaceGenPostReboot)
+	}
+
+	// The whole point of the reset: the reconnected peer's LOWER current
+	// generation must now be admitted.
+	if !s.shouldApplyConfigGen(resetRaceGenPostReboot) {
+		t.Fatalf("the reconnected peer's current generation %d must be admitted after the reset; high-water is %d",
+			resetRaceGenPostReboot, s.lastAppliedConfigGen.Load())
+	}
+}
+
+// TestConfigGenResetIsNotLostByAConcurrentReceivedAdvance binds the RECEIVED
+// mark, which has a second receive loop as its racing writer rather than the
+// apply loop, and a different harm.
+//
+// Harm first: TransferReadiness compares PeerConfigGen (this mark) against
+// AppliedConfigGen. With the clear lost, PeerConfigGen stays pinned at the
+// pre-reboot generation while the applied mark is correctly 0, so the node reads
+// as config-stale forever; and once a post-reboot config does apply, the
+// comparison is against a generation the peer can never reach again.
+func TestConfigGenResetIsNotLostByAConcurrentReceivedAdvance(t *testing.T) {
+	s := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", nil)
+
+	reached, resetRanInsideWindow := parkedAdvance(t, s, func() {
+		s.recordRecvConfigGen(resetRaceGenPreReboot)
+	})
+	if !reached {
+		t.Fatal("fixture broken: the advance never entered its load/store window, so nothing was parked and this test proves nothing")
+	}
+
+	if got := s.lastRecvConfigGen.Load(); got != 0 {
+		t.Fatalf("the reconnect reset was LOST: the received config high-water is %d (the peer's PRE-REBOOT generation) instead of 0. "+
+			"reset_completed_inside_the_advance_window=%v. The manual-failover readiness gate compares this against the applied mark, "+
+			"so it is now pinned above every generation the reconnected peer can produce (e.g. %d)",
+			got, resetRanInsideWindow, resetRaceGenPostReboot)
+	}
+}
+
+// --- over-reach guard: GREEN with the serialization reverted ----------------
+
+// The advance is a monotone MAX, and that is a separate property from being
+// serialized against the reset. Pinning it here keeps the mutex from being
+// mistaken for the thing that makes the mark monotone: replacing
+// `gen > current` with a bare Store reds this and leaves both binders above
+// green, so the two cells are disjoint rather than one restating the other.
+func TestConfigGenAdvanceStaysMonotone(t *testing.T) {
+	t.Run("applied mark", func(t *testing.T) {
+		s := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", nil)
+		s.recordAppliedConfigGen(resetRaceGenPreReboot)
+		if got := s.lastAppliedConfigGen.Load(); got != resetRaceGenPreReboot {
+			t.Fatalf("fixture broken: the first advance must take, got %d want %d", got, resetRaceGenPreReboot)
+		}
+		// A reordered older frame, or a delayed publish from a prior
+		// incarnation. It must not pull the mark down.
+		s.recordAppliedConfigGen(resetRaceGenPostReboot)
+		if got := s.lastAppliedConfigGen.Load(); got != resetRaceGenPreReboot {
+			t.Fatalf("the applied high-water must never regress: publishing %d after %d pulled it down to %d",
+				resetRaceGenPostReboot, resetRaceGenPreReboot, got)
+		}
+		// Negative control: a genuinely HIGHER generation must still advance it,
+		// so the assertion above pins regression rather than pinning "never
+		// moves".
+		s.recordAppliedConfigGen(resetRaceGenPreReboot + 1)
+		if got := s.lastAppliedConfigGen.Load(); got != resetRaceGenPreReboot+1 {
+			t.Fatalf("a strictly higher generation must still advance the applied high-water; got %d want %d",
+				got, resetRaceGenPreReboot+1)
+		}
+	})
+
+	t.Run("received mark", func(t *testing.T) {
+		s := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", nil)
+		s.recordRecvConfigGen(resetRaceGenPreReboot)
+		if got := s.lastRecvConfigGen.Load(); got != resetRaceGenPreReboot {
+			t.Fatalf("fixture broken: the first advance must take, got %d want %d", got, resetRaceGenPreReboot)
+		}
+		s.recordRecvConfigGen(resetRaceGenPostReboot)
+		if got := s.lastRecvConfigGen.Load(); got != resetRaceGenPreReboot {
+			t.Fatalf("the received high-water must never regress: recording %d after %d pulled it down to %d",
+				resetRaceGenPostReboot, resetRaceGenPreReboot, got)
+		}
+		s.recordRecvConfigGen(resetRaceGenPreReboot + 1)
+		if got := s.lastRecvConfigGen.Load(); got != resetRaceGenPreReboot+1 {
+			t.Fatalf("a strictly higher generation must still advance the received high-water; got %d want %d",
+				got, resetRaceGenPreReboot+1)
+		}
+	})
+}

--- a/pkg/cluster/sync_conn_config.go
+++ b/pkg/cluster/sync_conn_config.go
@@ -274,15 +274,58 @@ func (s *SessionSync) shouldApplyConfigGen(gen uint64) bool {
 
 // recordAppliedConfigGen advances the config high-water mark after a config of
 // generation gen has been SUCCESSFULLY applied. gen==0 (legacy / unconditional)
-// never advances the mark, mirroring the pre-#3931 behavior. It is called ONLY
-// from the single-consumer configApplyLoop after OnConfigReceived returns nil,
-// so the load/store pair needs no CAS.
+// never advances the mark, mirroring the pre-#3931 behavior.
+//
+// #5084: the load/compare/store is taken under configGenMu. The prior comment
+// here claimed it is "called ONLY from the single-consumer configApplyLoop, so
+// the load/store pair needs no CAS" — that is the wrong contract. The apply
+// loop is indeed the only ADVANCER, but resetRecvGen CLEARS this mark to 0 from
+// a receive-loop goroutine, so the pair had a concurrent writer. A clear landing
+// between the load and the store is LOST, re-raising a pre-reboot generation the
+// reconnect reset had just cleared and refusing every one of the reconnected
+// peer's lower current generations from then on. See the configGenMu doc.
+//
+// The three writers of lastAppliedConfigGen are:
+//
+//	recordAppliedConfigGen  the advance, here — configApplyLoop, under configGenMu
+//	resetRecvGen            the reconnect clear-to-0 — receive loop, under configGenMu
+//	initGenState            NewSessionSync / NewDualSessionSync, before Start
+//	                        spawns any goroutine, so it needs no lock
 func (s *SessionSync) recordAppliedConfigGen(gen uint64) {
 	if gen == 0 {
 		return
 	}
+	s.configGenMu.Lock()
+	defer s.configGenMu.Unlock()
 	if gen > s.lastAppliedConfigGen.Load() {
+		if s.configGenAdvanceBarrierFn != nil {
+			s.configGenAdvanceBarrierFn()
+		}
 		s.lastAppliedConfigGen.Store(gen)
+	}
+}
+
+// recordRecvConfigGen advances the RECEIVED config high-water (#5563) under
+// configGenMu, for the same reason recordAppliedConfigGen does (#5084): the
+// raise is a load/compare/store and resetRecvGen clears the mark from another
+// goroutine. The prior inline comment justified the bare pair with "the
+// receiveLoop is single-threaded per connection" — true per connection, but
+// there are TWO receive loops (conn0/conn1), so a raise driven by one fabric
+// races a reset driven by the other. A lost clear here leaves PeerConfigGen
+// pinned at a pre-reboot generation, which inverts the manual-failover
+// readiness gate (PeerConfigGen > AppliedConfigGen) into reporting READY while
+// the standby runs the pre-reboot policy.
+func (s *SessionSync) recordRecvConfigGen(gen uint64) {
+	if gen == 0 {
+		return
+	}
+	s.configGenMu.Lock()
+	defer s.configGenMu.Unlock()
+	if gen > s.lastRecvConfigGen.Load() {
+		if s.configGenAdvanceBarrierFn != nil {
+			s.configGenAdvanceBarrierFn()
+		}
+		s.lastRecvConfigGen.Store(gen)
 	}
 }
 
@@ -292,8 +335,15 @@ func (s *SessionSync) recordAppliedConfigGen(gen uint64) {
 // sweep — and configEpochStale folds max(fence, high-water) into its refusal
 // threshold. A gen==0 (legacy/unconditional) apply carries no comparable epoch,
 // so the fence stays 0 and no install is refused on its account. Called ONLY
-// from the single-consumer configApplyLoop, so the store needs no CAS.
+// from the single-consumer configApplyLoop. The store takes configGenMu (#5084)
+// so it cannot straddle resetRecvGen's clear of the same field; a stale fence is
+// less harmful than a stale high-water (the next sweep re-sends the transiently
+// refused installs), but the reset clears all three marks as one transaction and
+// leaving one writer outside the lock invites a reader to conclude none is
+// needed.
 func (s *SessionSync) beginConfigApply(gen uint64) {
+	s.configGenMu.Lock()
+	defer s.configGenMu.Unlock()
 	s.applyingConfigGen.Store(gen)
 }
 
@@ -304,8 +354,11 @@ func (s *SessionSync) beginConfigApply(gen uint64) {
 // advance — closing the residual window. On an apply FAILURE the high-water
 // deliberately stays put (M-2/#4151) and the fence is simply dropped, restoring
 // the pre-apply admission posture (the transiently-refused installs are re-sent
-// by the peer's next sweep). Called ONLY from configApplyLoop.
+// by the peer's next sweep). Called ONLY from configApplyLoop, under configGenMu
+// for the reason given on beginConfigApply (#5084).
 func (s *SessionSync) endConfigApply() {
+	s.configGenMu.Lock()
+	defer s.configGenMu.Unlock()
 	s.applyingConfigGen.Store(0)
 }
 

--- a/pkg/cluster/sync_conn_gen.go
+++ b/pkg/cluster/sync_conn_gen.go
@@ -351,20 +351,32 @@ func (s *SessionSync) resetRecvGen() {
 	// 0 makes the next config apply unconditionally; it is always the peer's
 	// CURRENT config (pushConfigToPeer sends ShowActive), so the newest
 	// content still wins.
+	//
+	// #5084: the three clears below are ONE transaction under configGenMu, and
+	// every advance of these marks takes the same lock. Without it a clear could
+	// land between a concurrent advance's load and its store and be LOST, so a
+	// pre-reboot generation survived the reset and refused every one of the
+	// reconnected peer's lower current generations — permanently, since the
+	// marks are monotone-max. The clears run on a receive-loop goroutine and the
+	// applied-mark advance runs on configApplyLoop, so they genuinely race.
+	s.configGenMu.Lock()
 	s.lastAppliedConfigGen.Store(0)
 	// #6284: drop the apply-in-progress fence alongside the high-water so a
 	// concurrent bulk re-prime restores the accept-everything posture the reset
 	// intends. A re-prime admits the rebooted peer's lower-generation set; a
 	// stale fence from an apply that raced the reset would otherwise keep
-	// refusing it. configApplyLoop may re-raise the fence on its next apply —
-	// the same benign race the high-water reset already has with a concurrent
-	// advance — and the re-primed installs are re-sent by the next sweep.
+	// refusing it. configApplyLoop may re-raise the fence on its NEXT apply,
+	// which is benign — the re-primed installs are re-sent by the next sweep.
+	// (The pre-#5084 wording called that "the same benign race the high-water
+	// reset already has with a concurrent advance". The fence half is benign;
+	// the high-water half is not, which is what configGenMu now closes.)
 	s.applyingConfigGen.Store(0)
 	// #5563: reset the received-config high-water alongside the applied mark so
 	// the manual-failover readiness gate's applied<=received invariant holds
 	// across the reset window. The reconnect re-push then re-establishes both
 	// (received on receive, applied on successful apply).
 	s.lastRecvConfigGen.Store(0)
+	s.configGenMu.Unlock()
 	// #5706: reset the full-set (IPsec/DHCP) ordering high-water marks for the
 	// same reason. A reconnecting peer that OS-rebooted restarts its monotonic
 	// incarnation LOWER; without this reset the guard would refuse its fresh

--- a/pkg/cluster/sync_conn_read.go
+++ b/pkg/cluster/sync_conn_read.go
@@ -306,12 +306,14 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 		// gates manual-failover readiness against lastAppliedConfigGen. Record it
 		// even if the enqueue below drops the payload (queue full) so the standby
 		// stays flagged config-stale until the apply actually lands on a re-push.
-		// The receiveLoop is single-threaded per connection, so the load/store
-		// pair needs no CAS; guard on gen>current to keep it a monotonic max
-		// against a reordered older frame.
-		if gen > s.lastRecvConfigGen.Load() {
-			s.lastRecvConfigGen.Store(gen)
-		}
+		// It stays a monotonic max so a reordered older frame cannot pull it
+		// down. #5084: the load/compare/store moved into recordRecvConfigGen and
+		// is taken under configGenMu — the prior justification here ("the
+		// receiveLoop is single-threaded per connection, so the load/store pair
+		// needs no CAS") holds per connection but there are TWO receive loops,
+		// so a raise driven by one fabric raced resetRecvGen's clear driven by
+		// the other and could re-raise the mark that clear had just zeroed.
+		s.recordRecvConfigGen(gen)
 		// #3931: enqueue onto the single-consumer ordered apply queue instead
 		// of spawning a racing `go OnConfigReceived`. The receiveLoop is
 		// single-threaded per connection, so this preserves receive order;


### PR DESCRIPTION
## What this does

Makes the reconnect **reset** of the config-generation high-water marks atomic with respect to every **advance** of them.

Both marks are advanced by a non-atomic read-modify-write (load, compare, store), and `resetRecvGen` clears them to 0 from a **different goroutine** — the clear runs on a receive loop (the `BulkStart` handler), the applied mark advances on the single `configApplyLoop` consumer, and the received mark advances on a receive loop, of which there are **two** (`conn0`/`conn1`). Nothing ordered them, so a clear landing between an advance's load and its store was lost, and the store re-raised the mark the reset had just zeroed.

That is not a transient. The marks are monotone-max and the whole reason the reset exists is that a rebooted peer restarts its `configGenCounter` **lower**, so a surviving pre-reboot generation refuses every generation the reconnected peer can produce — on `lastAppliedConfigGen` the standby silently keeps running the pre-reboot config, and on `lastRecvConfigGen` the manual-failover readiness comparison is pinned against a value the peer can never reach again. Neither self-clears short of another accepted bulk re-prime.

A new `configGenMu` (a leaf lock) covers the reset and all four advance sites. Readers stay lock-free. Two false contracts are corrected where they sit.

## What this deliberately does NOT do

**It does not close #5084.** This PR previously carried a connection-epoch fence (`configNamespaceConnID`) intended to close it. That fence has been **removed**.

Review established that the fence keys on `syncConnID`, a total **order** over connections, when the predicate it needs is an **equivalence** — "were these payloads produced by the same peer boot?" — because generations are comparable only within one sender incarnation. A ranking cannot express an equivalence, and the floor has no correct setting:

- never descending locks out a live same-incarnation sibling that merely connected earlier;
- descending re-admits departed older-incarnation connections and makes the floor a mutable target an in-flight `resetRecvGen` can reclaim.

Decisively: the fence's drop is a `continue` that skips the generation gate, so a dropped payload's generation never enters the high-water, and the fenced build **applied a stale payload that `origin/master` refuses**. Closing that requires recording the dropped generation — a pre-reboot, therefore higher, value — which wedges the standby permanently and silently. One scalar high-water cannot serve two incarnations.

The correct fix is a **peer boot incarnation on the wire**, which is blocked on #5480. The full analysis is posted on #5084.

## Validation

2×2 mutation grid, disjoint cells:

| mutation | binders | monotone guard |
|---|---|---|
| remove `configGenMu` from the advances + the reset | **RED** (assertions) | GREEN |
| replace `gen > current` with a bare `Store` | GREEN | **RED** (both subtests) |

Red-on-revert assertion: `the reconnect reset was LOST: the applied config high-water is 1800000000123 (the peer's PRE-REBOOT generation) instead of 0. reset_completed_inside_the_advance_window=true`

Each monotone subtest carries a negative control (a strictly higher generation must still advance), so the assertion pins regression rather than "never moves".

- `go build ./...` → 0
- `go vet ./pkg/cluster ./pkg/daemon` → 0
- `go test ./pkg/cluster ./pkg/daemon -count=1 -race` → 0
- `go test ./pkg/cluster -run <5084 cohort> -count=5 -race` → 0 (17 distinct tests, zero skips)
- `go test ./pkg/refactoraudit/...` → 0

Advances #5084.
