### PR TITLE
config: state the VRF-overlap limitation, do not promise a fix

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -68448,3 +68448,41 @@ break — `go vet` confirmed passing under every revert.
 - **File(s)**: pkg/daemon/cluster_transport_key_5078_test.go,
   pkg/cluster/sync_auth_test.go, pkg/cluster/sync_auth.go,
   pkg/cluster/README.md, _Log.md
+
+## 2026-08-06 — #2387: state what the VRF-overlap tests actually enforce
+
+- **Timestamp**: 2026-08-06
+- **Action**: correct two high-level comments that overclaimed the guard (comment-only)
+- **File(s)**: `pkg/config/compiler_validate_vrf_overlap.go`,
+  `pkg/config/compiler_validate_vrf_overlap_2387_test.go`
+
+A Codex gate and a hostile Claude gate reached the same finding by different
+routes: the DETAILED blocklist comments are honest about being incomplete, but
+the two HIGH-LEVEL summaries above them claim a semantic guarantee the tests do
+not provide.
+
+Codex measured the escape set rather than arguing it. Nine distinct foreclosing
+sentences and nine distinct promising sentences, none using a listed spelling,
+were each spliced before the status tail in both warning arms; all eighteen left
+`go test ./pkg/config` GREEN. Mechanism by shape, measured:
+
+| shape | suffix pin | token lists |
+|---|---|---|
+| APPEND after the tail | always catches | also, if listed |
+| REWORD inside the tail | always catches | also, if listed |
+| SPLICE before the tail | BLIND | listed spellings only |
+| PREPEND at the front | BLIND | listed spellings only |
+
+So the test-file header's "(5) ... with no forecast in EITHER direction before
+it" and the production comment's "keeps forward-looking wording out of BOTH
+format strings" both overstate. Corrected to state the split: the tail is pinned
+verbatim so nothing can be appended, reworded or dropped there; mid-message
+wording is caught only in spellings someone listed. The shipped text is neutral
+because it was written to be, not because the test would stop an author.
+
+Neither list is grown — that is the completeness trap the file's own doctrine
+note refuses, and growing it would trade a disclosed limit for a hidden one.
+
+Comment-only: every changed line is `//` or blank, verified by stripping the
+diff markers and filtering. `gofmt -l` clean, `go vet ./pkg/config/` 0,
+`go test ./pkg/config -run TestVRFOverlap -count=1` 0.

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,64 @@
+## 2026-08-06 — #6902 round 5: the neutrality contract was guarded in one direction
+
+- **Timestamp**: 2026-08-06 (fix/2387-a1-warning-wording, PR #6902)
+- **Action**: Fold two findings from the hostile review leg, plus a precision
+  correction to the round-4 comment. Test-file-only; production warning strings
+  still byte-identical to round 1, `cmp`-verified after every cell below.
+- **File(s)**: `pkg/config/compiler_validate_vrf_overlap_2387_test.go`,
+  `_Log.md`
+
+**ADD-1 — the reverse direction had NO guard.** The contract at
+`compiler_validate_vrf_overlap.go:58-59` is symmetric: the text "must not promise
+a fix, nor rule one out". All 31 blocklist entries were forward-looking, so
+appending `". #2387 is closed wontfix; this is by design and permanent"` passed
+the whole suite while foreclosing an outcome that is still the maintainer's to
+decide. That is the more dangerous half: an operator who reads "by design" stops
+treating an overlapping-VRF topology as a hazard to revisit.
+
+Added `vrfOverlapForeclosingTokens` and widened the test to scan both groups.
+Adding a DIRECTION is not the same act as growing a list — one covers an axis
+with zero coverage, the other chases an infinite tail — and the comment now says
+so, so the two do not get confused later.
+
+**ADD-2 — helper doc.** Already folded in round 4: `vrf2387Warnings` now
+documents that it selects on the diagnosis phrase, deliberately not on `#2387`.
+
+**Correction to round 4's own comment.** It said the control defends against
+"wholesale" deletion being caught elsewhere; the reviewer's framing is sharper
+and the round-4 text was imprecise in the other direction — it asserted the gut
+"reds only this test", which is false. Measured below: the gut also reds
+`TestVRFOverlapWarnsOnOverlappingRIs`, because that gut drops "NOT
+session-isolated". The cell where the control is the ONLY red in the file is the
+discriminator-clause strip. The comment now states exactly that.
+
+| Mutation | subs | Promise | Substance | 6 pre-existing |
+|---|---|---|---|---|
+| baseline | 0 | GREEN | GREEN | ALL GREEN |
+| APPEND foreclosing (wontfix/by design/permanent) | 2 | RED `wontfix` | GREEN | ALL GREEN |
+| SPLICE foreclosing BEFORE the tail | 2 | RED `by design` | GREEN | ALL GREEN |
+| SPLICE forward-looking BEFORE the tail | 2 | RED `planned` | GREEN | ALL GREEN |
+| APPEND the disclosed-escape wording | 2 | RED (suffix) | GREEN | ALL GREEN |
+| SPLICE the disclosed-escape wording before the tail | 2 | GREEN | GREEN | ALL GREEN |
+| GUT to a bare issue reference | 2 | GREEN | RED | 1 RED |
+| WHOLESALE delete the advisory | 2 | RED (helper) | RED (helper) | 2 RED |
+| literal FULL revert of both arms to master | 2 | RED `until` | RED | ALL GREEN |
+| strip every `#2387`, diagnosis intact | 4 | RED (suffix) | GREEN | ALL GREEN |
+| round-4 cells R4a-R4e, re-run | 2 ea | unchanged | unchanged | ALL GREEN |
+
+The two mid-message SPLICE cells are what prove each blocklist load-bearing in
+the span the suffix pin cannot reach; both fire naming a token from the intended
+group. Negative control for the prescribed addition: with
+`vrfOverlapForeclosingTokens` emptied, the foreclosing splice goes GREEN — so the
+new group, not something incidental, is what catches it.
+
+Two rows are honest limits rather than wins. Splicing the disclosed-escape
+wording (`the VRF-aware session key fixes this`) BEFORE the tail leaves both
+tests GREEN — that is the blocklist incompleteness the test file already
+discloses, and the suffix pin only reaches the append form of it. And the
+`#2387`-strip cell now fires at the suffix assertion rather than at the old
+issue-reference check; the defect did not move and the round-3 filter change
+stays.
+
 ## 2026-08-06 — #6902 round 4: the assertions bound VOCABULARY, not the CLAIM
 
 - **Timestamp**: 2026-08-06 (fix/2387-a1-warning-wording, PR #6902)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,49 @@
+## 2026-08-05 — #2387 A.1: the warning promised an outcome #2387 has not decided
+
+- **Timestamp**: 2026-08-05 (fix/2387-a1-warning-wording)
+- **Action**: Reword the `validateVRFOverlap` commit warning so it states the
+  CURRENT limitation and points at #2387, instead of promising that the session
+  identity becomes VRF-aware. Add two tests that keep forward-looking wording
+  out of both format strings without letting the diagnostic be gutted.
+- **File(s)**: `pkg/config/compiler_validate_vrf_overlap.go`,
+  `pkg/config/compiler_validate_vrf_overlap_2387_test.go`,
+  `pkg/config/compiler_tailgates.go`,
+  `docs/research/2387-vrf-flow-identity/plan.md`,
+  `userspace-dp/src/afxdp/forwarding/README.md`
+
+The shipped text said colliding 5-tuples may cross-forward "until the session
+identity is VRF-aware". #2387 is held on a maintainer risk-appetite call and
+neither candidate end-state — the hard-reject posture, or the VRF-aware session
+key (Track B) — is decided, so that clause asserted an outcome that may never
+arrive. It was also circular: the #2387 plan cited the warning text back as
+evidence that the widening was already settled, while the warning had been
+written from the plan's assumption. Both sides are now decoupled; the plan
+bullet that leaned on the warning records that the argument is retired and is
+evidence for neither branch.
+
+Mutation proof (a guard is worthless until watched to fail), 2x2, orthogonal:
+
+| Mutation | StatesStatusNotPromise | KeepsDiagnosticSubstance |
+|---|---|---|
+| baseline | GREEN | GREEN |
+| restore "until…VRF-aware" in both format strings | RED (both arms) | GREEN |
+| strip diagnostic substance, keep no-promise wording | GREEN | RED |
+
+The second row is the negative control: without it, the no-promise test is
+satisfied just as well by deleting the warning text wholesale. The fixture
+helper asserts each arm was actually reached (`both carry` vs `carry
+overlapping L3`) before asserting on it — a single fixture binds one match arm,
+so a "both format strings" claim made from one fixture would be vacuous.
+
+A first mutation attempt was a no-op: the substitution anchored on the wrong
+tab depth, matched nothing, and the suite stayed green — which is
+indistinguishable from a passing guard. Counting the applied substitutions
+before reading the result is what caught it.
+
+Validation: `go test ./pkg/config/ -count=1` ok (15.9s); `go vet ./pkg/config/`
+clean; `gofmt -l` clean on all three Go files; post-mutation restore verified
+byte-identical with `cmp`.
+
 ## 2026-08-05 — #6843 round 7: the thesis defect was standing in the module README
 
 - **Timestamp**: 2026-08-05 (fix/3651-zone-prom-surface, PR #6843)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,69 @@
+## 2026-08-05 — #6902 round 3: the identity assertions bound PRESENCE, not ASSOCIATION
+
+- **Timestamp**: 2026-08-05 (fix/2387-a1-warning-wording, PR #6902)
+- **Action**: Fold four re-gate findings. Test-file-only — production warning
+  strings byte-identical to rounds 1 and 2.
+- **File(s)**: `pkg/config/compiler_validate_vrf_overlap_2387_test.go`
+
+**F3 — the finding worth the round.** Round 2 added per-form identity
+assertions, but as a LIST OF TOKENS. Presence and association are different
+properties and only the second is useful: every identifier stays in the string
+while attached to the WRONG object. Both format strings are 6-argument Sprintf
+calls carrying three (name, origin, prefix) triples — precisely where a
+transposition happens — and `go vet` cannot see it, because every argument is a
+string or Stringer feeding %q/%s.
+
+Measured on the round-2 form: swapping the two origins, the two RI names, or the
+two prefixes each left `go test ./pkg/config/ -count=1` fully GREEN and
+`go vet ./pkg/config/` silent, while the operator was sent to the wrong
+interface or told the wrong prefix sits on the wrong instance — the same
+"told the hazard but not where" failure round 2 was written to prevent, one
+level down. Replaced with ORDERED PAIRINGS held as one contiguous substring. A
+strict replacement, not an addition: a strip breaks the pairing too.
+
+| Mutation (arg transposition in the Sprintf) | substance test |
+|---|---|
+| baseline | GREEN |
+| equal arm, origins swapped | RED |
+| equal arm, RI names swapped | RED |
+| unequal arm, origins swapped | RED |
+| unequal arm, prefixes swapped | RED |
+
+**F4 — an assertion that could not fail.** The `#2387` check was unreachable:
+the helper pre-filtered on the same substring, so every warning reaching it had
+already been selected for containing it. Dropping #2387 failed the fixture's
+COUNT assertion instead, with a message about the wrong thing. The helper now
+filters on the diagnosis phrase ("overlapping L3 across routing-instances"),
+which both arms carry and no other warning does. Verified: removing BOTH #2387
+occurrences from the unequal arm now fires the intended assertion with the
+intended message. (One occurrence is not enough — the tail carries a second.)
+
+**F2 — one of my unmeasured guesses was off-target.** Round 2 added six sibling
+tokens on top of four measured escapes. "work is under way" fires only on that
+exact four-word spelling and misses "underway" and "in progress" — the phrasing
+actually measured. "temporarily" was a good add ("temporary" is not a substring
+of it). Added the eleven still-escaping spellings the review measured, and kept
+"work is under way" with a comment recording it as the worked example of
+reaching for an imagined phrase instead of an observed one.
+
+**F5 — not folded, recorded here instead.** The round-1 COMMIT MESSAGE says "No
+runtime behaviour changes". The operator-facing warning TEXT changed, which is
+runtime output — it is the entire PR. The clause after the dash is right; only
+the headline overstates. The commit is pushed and rewriting it would move the
+PR head for a prose fix, so the correction lives here and in the PR body: the
+accurate statement is "no behaviour change beyond the warning text".
+
+**F6 — validation record was incomplete, not wrong.** Rounds 1-2 claimed only Go
+legs. `userspace-dp/tests/vrf_session_identity_doc_guard.rs` asserts on BOTH
+docs round 1 edited, including plan anchors on the very bullets it rewrote, and
+`make test` runs both legs (#4006). Ran it: `cargo test --test
+vrf_session_identity_doc_guard` -> ok, 2 passed, 0 failed. No defect; the record
+just never named the leg the diff put at risk.
+
+Validation: `go test ./pkg/config/ -count=1` ok (15.6s); `go vet ./pkg/config/`
+clean; `gofmt -l` clean; `cargo test --test vrf_session_identity_doc_guard` ok
+(2 passed); every restore verified byte-identical with `cmp`.
+
 ## 2026-08-05 — #6902 round 2: the mutation recipe in the shipping comment was false
 
 - **Timestamp**: 2026-08-05 (fix/2387-a1-warning-wording, PR #6902)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,53 @@
+## 2026-08-05 — #6902 round 2: the mutation recipe in the shipping comment was false
+
+- **Timestamp**: 2026-08-05 (fix/2387-a1-warning-wording, PR #6902)
+- **Action**: Fold three hostile-review findings. Test-only — the production
+  warning strings are byte-identical to round 1.
+- **File(s)**: `pkg/config/compiler_validate_vrf_overlap_2387_test.go`
+
+**F1 — the recipe did not do what it said.** The header comment claimed that
+"restoring the old …until the session identity is VRF-aware wording" reds the
+promise test while the substance test stays GREEN. Reproduced firsthand: a
+LITERAL revert to the pre-PR string reds BOTH. The old string also lacked the
+"no routing-instance discriminator" clause, so reverting changes two things at
+once — re-adds the promise AND removes the diagnosis. The isolating mutation is
+a TAIL-ONLY substitution that keeps the discriminator clause; the comment now
+prescribes exactly that and warns not to read a both-red result as "the tests do
+not separate". Worth keeping: that the old text trips the substance test proves
+the replacement is strictly more informative than what it replaced.
+
+**F2 — the blocklist was a guess, and the review measured the escapes.** Four
+spellings reintroduced a promise while the test stayed GREEN: "not yet",
+"pending", "temporary", "in a later release". Added those plus siblings
+("temporarily", "for now", "interim", "to be addressed", "work is under way",
+"soon"), each re-verified RED after injection. The list comment now states
+plainly that a blocklist is incomplete by construction — green means "contains
+none of these", NOT "contains no promise" — and that any addition must be shown
+green before being listed.
+
+**F3 — the diagnosis was identified by nobody.** The substance test asserted
+only the explanatory prose, so the RI names, the config origins and the prefixes
+were all strippable with `pkg/config` fully green: an operator would be told a
+cross-forwarding hazard exists but not where. Added per-form identity
+assertions, including BOTH prefixes on the unequal-overlap arm — printing only
+one loses the overlap that arm exists to report.
+
+Mutation matrix, each dimension binding independently:
+
+| Mutation | promise test | substance test |
+|---|---|---|
+| baseline | GREEN | GREEN |
+| tail-only promise restore (the isolating one) | RED | GREEN |
+| blank the RI name, equal-prefix arm | GREEN | RED |
+| duplicate the prefix, unequal-overlap arm | GREEN | RED |
+| literal full revert | RED | RED (expected — two changes) |
+
+Each of the four F2 escapes verified RED after being listed. All arg-count-
+preserving mutations, so every red is an assertion and not a build break.
+
+Validation: `go test ./pkg/config/ -count=1` ok (15.6s); `go vet ./pkg/config/`
+clean; `gofmt -l` clean; restores verified byte-identical with `cmp`.
+
 ## 2026-08-05 — #2387 A.1: the warning promised an outcome #2387 has not decided
 
 - **Timestamp**: 2026-08-05 (fix/2387-a1-warning-wording)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,80 @@
+## 2026-08-06 — #6902 round 4: the assertions bound VOCABULARY, not the CLAIM
+
+- **Timestamp**: 2026-08-06 (fix/2387-a1-warning-wording, PR #6902)
+- **Action**: Fold three test-contract findings plus two comment corrections.
+  Test-file-only — the production warning strings are byte-identical to rounds
+  1 through 3, verified with `cmp` against a pristine copy after every
+  mutation cell below.
+- **File(s)**: `pkg/config/compiler_validate_vrf_overlap_2387_test.go`,
+  `_Log.md`
+
+**F1a — the substance test was polarity-insensitive.** It asserted the bare
+noun `"cross-forward"`. Rewriting `may cross-forward` to `cannot cross-forward`
+inverts the diagnosis — the operator is told the topology IS session-isolated,
+so the hazard reads as a reassurance — and both tests stayed GREEN. Verified
+firsthand at HEAD 690dba2c8 before the fix. A bare noun cannot carry polarity;
+the assertions now hold the claim as contiguous spans: `"the session identity
+carries no routing-instance discriminator"` and `"colliding 5-tuples may
+cross-forward"` (subject + modality + verb).
+
+**F1b — the promise test was a token blocklist, and only a blocklist.**
+Appending `"A fix is guaranteed."` to both arms reintroduces an explicit promise
+that no listed spelling matches; both tests stayed GREEN. Growing the list is
+the trap the list itself documents, so the fix is structural: a new
+`vrfOverlapStatusTail` constant that both arms must END with, verbatim. One
+suffix comparison forbids appending, truncating, and rewording the tail at once.
+The blocklist is retained as the secondary layer and its doc now says what it
+still uniquely covers — a promise spliced into the span BEFORE the tail — and
+that it must not be grown.
+
+**F2 — the PR's own new sentence was unpinned.** The assertion checked only for
+the presence of any `#2387`, and the message carried a `(#2387)` before this PR.
+Deleting the entire new tail — `"See #2387 for the status of this limitation"` —
+left the earlier reference in place and both tests GREEN. The deliverable, going
+unbound. `vrfOverlapStatusTail` pins the sentence, not the reference.
+
+| Mutation (production warning strings) | subs | StatesStatusNotPromise | KeepsDiagnosticSubstance |
+|---|---|---|---|
+| baseline | 0 | GREEN | GREEN |
+| `may cross-forward` -> `cannot cross-forward` | 2 | RED | RED |
+| append `A fix is guaranteed.` | 2 | RED | GREEN |
+| delete the `See #2387 …limitation` tail, keep earlier `(#2387)` | 2 | RED | GREEN |
+| restore `until the session identity is VRF-aware` (tail only) | 2 | RED | GREEN |
+| strip the `no routing-instance discriminator` clause, keep tail | 2 | GREEN | RED |
+| wholesale-delete the advisory text (F3 probe) | 2 | RED (helper) | RED (helper) |
+
+Every cell reports the substitutions APPLIED before its result was read: a
+pattern that silently matches nothing is a no-op wearing a passing guard, and it
+bit this exact matrix once — the clause-strip regex matched only the unequal arm
+(1 of 2) because the word "session" falls on a different concatenation line in
+each arm. Both isolating cells fire on BOTH arms. Every RED is an assertion
+message, never a build break; production restored from a pristine copy and
+`cmp`-verified after each cell. The first three rows were re-run against the
+pre-fix test file and measured GREEN/GREEN, which is what makes them findings
+rather than hypotheses.
+
+**F3 — a false claim in the test's own comment, endorsed in my brief.** The
+comment said that without the substance control, the promise test "is satisfied
+just as well by deleting the warning text wholesale". It is not:
+`vrfOverlapBothFormStrings` requires the diagnosis selector to match, exactly one
+warning per fixture, and both arm markers, so wholesale deletion reds the promise
+test at the helper first. Measured — the F3 probe row above fails at
+`compiler_validate_vrf_overlap_2387_test.go:311`, the fixture-count assertion, in
+BOTH tests. The control's real value is against PARTIAL stripping: text that
+still passes the selector and still ends with the exact tail but has lost the
+cause, the consequence, or the pairing. The comment now says that.
+
+**F4 — two stale comments.** The `vrf2387Warnings` doc still said it "returns
+the compile warnings that mention #2387"; it has filtered on the diagnosis
+phrase since round 3 (deliberately — filtering on `#2387` made the tracking-issue
+assertion unreachable). And the arg-count claim corrected in the round-3 entry
+above.
+
+No production behaviour change: the warning fires on the same configurations,
+with the same severity, and still commits. No module doc needs updating — this
+round changes test assertions and comments only, and the operator-visible
+warning text is unchanged from round 1, whose doc updates already landed.
+
 ## 2026-08-05 — #6902 round 3: the identity assertions bound PRESENCE, not ASSOCIATION
 
 - **Timestamp**: 2026-08-05 (fix/2387-a1-warning-wording, PR #6902)
@@ -8,10 +85,14 @@
 **F3 — the finding worth the round.** Round 2 added per-form identity
 assertions, but as a LIST OF TOKENS. Presence and association are different
 properties and only the second is useful: every identifier stays in the string
-while attached to the WRONG object. Both format strings are 6-argument Sprintf
-calls carrying three (name, origin, prefix) triples — precisely where a
-transposition happens — and `go vet` cannot see it, because every argument is a
-string or Stringer feeding %q/%s.
+while attached to the WRONG object. Both format strings interleave the two
+instances' identifiers — the equal-prefix arm substitutes FIVE arguments (two
+name/origin pairs plus the single prefix they share), the unequal arm SIX (a
+full (name, origin, prefix) triple each) — precisely where a transposition
+happens, and `go vet` cannot see it, because every argument is a string or
+Stringer feeding %q/%s. (Round 4 correction: this paragraph originally called
+both arms "6-argument Sprintf calls carrying three (name, origin, prefix)
+triples", which is wrong on both counts for the equal-prefix arm.)
 
 Measured on the round-2 form: swapping the two origins, the two RI names, or the
 two prefixes each left `go test ./pkg/config/ -count=1` fully GREEN and

--- a/docs/research/2387-vrf-flow-identity/plan.md
+++ b/docs/research/2387-vrf-flow-identity/plan.md
@@ -160,9 +160,13 @@ practice. The remaining decision is only §0b's table:
 - **DENY** is small and Rust-only, but it is *not* Junos semantics (a Junos
   session table is per-routing-instance; identical 5-tuples in two instances
   coexist), and it hands a tenant a denial primitive against a co-tenant that
-  guesses/observes its 5-tuple. It also contradicts the already-shipped A.1
-  warning text, which promises the operator cross-forwarding "until the session
-  identity is VRF-aware" — i.e. it points at ISOLATE.
+  guesses/observes its 5-tuple. (This bullet used to add a third argument: that
+  the already-shipped A.1 warning text promised the operator cross-forwarding
+  "until the session identity is VRF-aware", and so pointed at ISOLATE. That
+  argument is retired — the warning was reworded to state the limitation and
+  point at #2387 without promising or excluding either end-state, precisely so
+  the shipped operator text does not pre-commit this decision. It is now
+  evidence for neither branch.)
 - **ISOLATE** is the issue's literal ask, is vendor-parity, and — with §0a —
   no longer carries the wire flag-day that drove the v4 deferral. Its residual
   cost is mechanical: `SessionKey` grows one `u32` (≈300 struct-literal sites in
@@ -407,8 +411,12 @@ Two tracks. The decision between them is a **product-scope call** (see §11 Q1).
   static routes) to two different routing-instances reachable via PBR `then
   routing-instance`, emit a **commit warning** naming both interfaces/instances:
   "overlapping L3 across routing-instances is forwarded via PBR but is NOT
-  session-isolated (#2387) — colliding 5-tuples may cross-forward until the
-  session identity is VRF-aware." **A warning, not a reject** — AGY r1 Attack 4
+  session-isolated (#2387) — the session identity carries no routing-instance
+  discriminator, so colliding 5-tuples may cross-forward. See #2387 for the
+  status of this limitation." (As originally prescribed here the sentence ended
+  "…may cross-forward until the session identity is VRF-aware"; that promised an
+  outcome this plan has not settled, so the shipped text states the limitation
+  and points at the issue instead.) **A warning, not a reject** — AGY r1 Attack 4
   correctly notes that overlapping-subnet PBR VRF is a *legitimate, working*
   multi-tenant design, so hard-rejecting it breaks a valid deployment to work
   around a fast-path bug. A hard reject is only appropriate if the maintainer's

--- a/pkg/config/compiler_tailgates.go
+++ b/pkg/config/compiler_tailgates.go
@@ -101,9 +101,10 @@ func runTailGates(cfg *Config, opts compileOpts) error {
 	// PBR table override, so a second colliding flow inherits the first's cached
 	// egress / NAT / policy). A WARNING, never a reject: overlapping-subnet
 	// multi-tenant VRF via PBR is a legitimate working design; the config still
-	// commits, the operator is told it is not session-isolated. The VRF-aware
-	// session key is the deferred real fix (Track B — SessionKey widening + HA
-	// wire bump).
+	// commits, the operator is told it is not session-isolated. Whether to widen
+	// the session identity (Track B — a routing-domain id in SessionKey) is an
+	// OPEN #2387 decision, so the warning states the limitation and points at
+	// the issue rather than promising a fix.
 	cfg.Warnings = append(cfg.Warnings, validateVRFOverlap(cfg)...)
 
 	// #2173: static-NAT / NAT64 host-mask gate. #2132 made the Rust

--- a/pkg/config/compiler_validate_vrf_overlap.go
+++ b/pkg/config/compiler_validate_vrf_overlap.go
@@ -60,8 +60,15 @@ const (
 // say colliding 5-tuples may cross-forward "until the session identity is
 // VRF-aware", which asserted an outcome the open decision may never produce —
 // and which the #2387 plan then cited back as evidence for that same outcome.
-// TestVRFOverlapWarningStatesStatusNotPromise keeps forward-looking wording out
-// of BOTH format strings below.
+// TestVRFOverlapWarningStatesStatusNotPromise enforces that in BOTH format
+// strings below — but enforces it PARTIALLY, and the difference matters if you
+// are editing this text. It pins the closing status sentence verbatim, so
+// nothing can be appended, reworded or dropped there. Wording spliced into the
+// MIDDLE of the message is caught only if it uses a spelling on that test's
+// token lists, which are blocklists and incomplete by construction. A forecast
+// in either direction, phrased in a way nobody listed, will commit green. The
+// text is neutral today because it was written to be, not because the test
+// would stop you.
 //
 // Detection builds routing-instance -> set-of-prefixes from two sources:
 //  1. native RI membership — each member interface unit's configured addresses

--- a/pkg/config/compiler_validate_vrf_overlap.go
+++ b/pkg/config/compiler_validate_vrf_overlap.go
@@ -62,8 +62,11 @@ const (
 // and which the #2387 plan then cited back as evidence for that same outcome.
 // TestVRFOverlapWarningStatesStatusNotPromise enforces that in BOTH format
 // strings below — but enforces it PARTIALLY, and the difference matters if you
-// are editing this text. It pins the closing status sentence verbatim, so
-// nothing can be appended, reworded or dropped there. Wording spliced into the
+// are editing this text. It pins the closing status sentence verbatim, so the
+// tail cannot be reworded or dropped, and nothing can be appended after it
+// EXCEPT text that itself re-terminates with the tail verbatim — a contrived
+// escape, recorded so nobody reasons from "appends are impossible". Wording
+// spliced into the
 // MIDDLE of the message is caught only if it uses a spelling on that test's
 // token lists, which are blocklists and incomplete by construction. A forecast
 // in either direction, phrased in a way nobody listed, will commit green. The

--- a/pkg/config/compiler_validate_vrf_overlap.go
+++ b/pkg/config/compiler_validate_vrf_overlap.go
@@ -48,11 +48,20 @@ const (
 // A WARNING, not a reject: overlapping-subnet multi-tenant VRF via PBR is a
 // legitimate, working forwarding design, so hard-rejecting it would break a
 // valid deployment to work around a fast-path bug. The operator is told the
-// topology is not session-isolated; the config still commits. The hard-reject
-// variant (for a "no overlapping subnets at all" product posture) is a future
-// maintainer-gated follow-up, not this pass. The VRF-aware session key itself
-// (a symmetric routing-domain id in SessionKey + the HA wire bump) is the
-// deferred real fix (Track B).
+// topology is not session-isolated; the config still commits. Neither of the
+// two candidate end-states is decided: the hard-reject variant (a "no
+// overlapping subnets at all" product posture) and the VRF-aware session key
+// (a symmetric routing-domain id in SessionKey, Track B) both remain open on
+// #2387, which is held on a maintainer risk-appetite call rather than on
+// further engineering.
+//
+// The warning text below therefore states the CURRENT limitation and points at
+// the tracking issue; it must not promise a fix, nor rule one out. It used to
+// say colliding 5-tuples may cross-forward "until the session identity is
+// VRF-aware", which asserted an outcome the open decision may never produce —
+// and which the #2387 plan then cited back as evidence for that same outcome.
+// TestVRFOverlapWarningStatesStatusNotPromise keeps forward-looking wording out
+// of BOTH format strings below.
 //
 // Detection builds routing-instance -> set-of-prefixes from two sources:
 //  1. native RI membership — each member interface unit's configured addresses
@@ -211,17 +220,19 @@ Scan:
 						warnings = append(warnings, fmt.Sprintf(
 							"routing-instance %q (%s) and %q (%s) both carry %s: "+
 								"overlapping L3 across routing-instances is forwarded via "+
-								"PBR but is NOT session-isolated (#2387) — colliding "+
-								"5-tuples may cross-forward until the session identity is "+
-								"VRF-aware",
+								"PBR but is NOT session-isolated (#2387) — the session "+
+								"identity carries no routing-instance discriminator, so "+
+								"colliding 5-tuples may cross-forward. See #2387 for the "+
+								"status of this limitation",
 							riA, a.origin, riB, b.origin, a.prefix))
 					} else {
 						warnings = append(warnings, fmt.Sprintf(
 							"routing-instance %q (%s, %s) and %q (%s, %s) carry "+
 								"overlapping L3: overlapping L3 across routing-instances is "+
-								"forwarded via PBR but is NOT session-isolated (#2387) — "+
-								"colliding 5-tuples may cross-forward until the session "+
-								"identity is VRF-aware",
+								"forwarded via PBR but is NOT session-isolated (#2387) — the "+
+								"session identity carries no routing-instance discriminator, "+
+								"so colliding 5-tuples may cross-forward. See #2387 for the "+
+								"status of this limitation",
 							riA, a.origin, a.prefix, riB, b.origin, b.prefix))
 					}
 				}

--- a/pkg/config/compiler_validate_vrf_overlap_2387_test.go
+++ b/pkg/config/compiler_validate_vrf_overlap_2387_test.go
@@ -28,9 +28,13 @@ import (
 // blocklist is incomplete by construction. Nine distinct foreclosing sentences
 // and nine distinct promising sentences, none using a listed spelling, were
 // each spliced before the tail and left the whole package suite GREEN. So what
-// is enforced is "no forecast in any spelling we listed, anywhere, plus no
-// tampering with the tail at all" — not "no forecast". Do not grow the lists
-// toward completeness; see the doctrine note at the blocklist itself.
+// is enforced is purely LEXICAL: "none of the listed spellings appears anywhere,
+// plus no tampering with the tail at all" — not "no forecast", and not even "no
+// forecast in a listed spelling". The check cannot see meaning in either
+// direction. It misses a forecast phrased in a spelling nobody listed, and it
+// rejects accurate neutral prose that happens to contain one — eight such
+// sentences were measured tripping the lists. Do not grow the lists toward
+// completeness; see the doctrine note at the blocklist itself.
 //
 // "Either direction" is load-bearing in (5). The contract on validateVRFOverlap
 // is that the text must not promise a fix "nor rule one out", and until now only
@@ -378,12 +382,16 @@ func vrfOverlapBothFormStrings(t *testing.T) (equal, unequal string) {
 	return eq[0], un[0]
 }
 
-// TestVRFOverlapWarningStatesStatusNotPromise pins two properties of BOTH format
-// strings: the message ENDS with vrfOverlapStatusTail verbatim, and the message
-// carries none of the KNOWN forecasting spellings — forward or backward —
-// anywhere. Despite the name, "NotPromise" is shorthand for "neither promises nor
-// forecloses": the contract on validateVRFOverlap is symmetric, so the test is
-// too.
+// TestVRFOverlapWarningStatesStatusNotPromise pins two LEXICAL properties of
+// BOTH format strings: the message ENDS with vrfOverlapStatusTail verbatim, and
+// the message contains none of the listed spellings — from either list —
+// anywhere. It compares text. It does not and cannot evaluate meaning.
+//
+// The NAME is aspirational, not a description of what runs. "NotPromise" is
+// shorthand for the CONTRACT on validateVRFOverlap, which is symmetric —
+// "neither promises nor forecloses". The test approximates that contract with
+// two substring checks, and the gap between the contract and the approximation
+// is the subject of the next paragraph. Do not read the name as the guarantee.
 //
 // What that does NOT amount to is "the text cannot forecast either outcome". The
 // suffix compare is absolute but reaches only the tail; everything before it is

--- a/pkg/config/compiler_validate_vrf_overlap_2387_test.go
+++ b/pkg/config/compiler_validate_vrf_overlap_2387_test.go
@@ -17,13 +17,20 @@ import (
 // do NOT warn (no false positive); (3) a single RI / no RI does NOT warn;
 // (4) the PBR-term source (`then routing-instance`) also feeds the overlap set;
 // (5) the warning ENDS with the exact status sentence, verbatim, so nothing can
-// be appended after it, the tail cannot be reworded, and the status sentence
-// itself cannot be dropped; and (6) losing the promise did not cost the
-// diagnostic any of its substance, polarity included.
+// be appended after it that does not ITSELF re-terminate with the tail, the tail
+// cannot be reworded, and the status sentence itself cannot be dropped; and
+// (6) losing the promise did not cost the diagnostic any of its substance,
+// polarity included.
 //
 // (5) is deliberately NOT "no forecast in either direction". Measured: the
 // suffix pin catches APPEND-after-tail and REWORD-inside-tail in both
-// directions, always. It is BLIND to a forecast SPLICED before the tail or
+// directions, with one contrived exception — an append that duplicates the whole
+// 84-character tail at its end satisfies `HasSuffix` again, so
+// "…limitation. A fix is guaranteed. Meanwhile, <tail verbatim>" passes, and
+// "guaranteed" is on neither list. That is defeating the guard, not stumbling
+// past it, and every SIMPLE append is caught; it is recorded so nobody reasons
+// from "appends are impossible" when deciding a spelling is not worth listing.
+// The pin is BLIND to a forecast SPLICED before the tail or
 // PREPENDED at the front — there, the token lists are the only defence, and a
 // blocklist is incomplete by construction. Nine distinct foreclosing sentences
 // and nine distinct promising sentences, none using a listed spelling, were
@@ -202,8 +209,12 @@ func TestVRFOverlapV6NoCrossFamilyFalsePositive(t *testing.T) {
 // the message carries a second "#2387". And no token list can forbid text being
 // APPENDED after the sentence: "…status of this limitation. A fix is
 // guaranteed." reintroduces an explicit promise while matching every token
-// check. One suffix comparison forbids appending, truncating, and rewording the
-// tail at once, and needs no maintenance as new promise spellings are invented.
+// check. One suffix comparison forbids truncating and rewording the tail
+// outright, and forbids appending anything that does not re-terminate with the
+// tail verbatim — and it needs no maintenance as new promise spellings are
+// invented. Re-terminating is the one hole: repeating the whole tail after an
+// appended promise satisfies `HasSuffix` again. It takes deliberate effort, so
+// treat it as a limit on what the pin PROVES rather than a gap to plug.
 //
 // It deliberately starts AFTER the "…discriminator, so " clause. That makes the
 // two tests SEPARABLE — not orthogonal, and the difference is measured. Deleting
@@ -443,7 +454,8 @@ func TestVRFOverlapWarningStatesStatusNotPromise(t *testing.T) {
 		if !strings.HasSuffix(tc.warn, vrfOverlapStatusTail) {
 			t.Errorf("%s form does not END with the status sentence %q — the advisory must close "+
 				"by stating the consequence and pointing at the open decision, with nothing "+
-				"appended after it: %s",
+				"appended after it (an append that re-terminates with the tail verbatim would "+
+				"satisfy this check; do not do that): %s",
 				tc.form, vrfOverlapStatusTail, tc.warn)
 		}
 	}

--- a/pkg/config/compiler_validate_vrf_overlap_2387_test.go
+++ b/pkg/config/compiler_validate_vrf_overlap_2387_test.go
@@ -212,8 +212,10 @@ func TestVRFOverlapV6NoCrossFamilyFalsePositive(t *testing.T) {
 const vrfOverlapStatusTail = "colliding 5-tuples may cross-forward. " +
 	"See #2387 for the status of this limitation"
 
-// vrfOverlapForwardLookingTokens are the wordings that turn the advisory from a
-// statement of the CURRENT limitation into a promise about a future one. #2387
+// vrfOverlapForwardLookingTokens are SPELLINGS that commonly appear when an
+// advisory stops stating the CURRENT limitation and starts promising a future
+// one. They are not themselves promises, and the check that uses them cannot
+// tell the difference — see the both-directions note below. #2387
 // is held on a maintainer risk-appetite call: neither candidate end-state (the
 // hard-reject posture, or the VRF-aware session key) is decided, so the warning
 // must not assert that either one arrives. The original text said colliding
@@ -232,6 +234,22 @@ const vrfOverlapStatusTail = "colliding 5-tuples may cross-forward. " +
 // documents. The entries below the first group were each added after a review
 // demonstrated it passing the test while reintroducing a promise, so treat any
 // addition the same way: prove it green first, then add it.
+//
+// It is WRONG IN BOTH DIRECTIONS, and the second direction is easy to miss.
+// These are substring matches, so a hit proves a spelling APPEARS — never that
+// the sentence containing it forecasts anything. Eight accurate, deliberately
+// non-forecasting sentences were measured tripping this list: "#2387 leaves
+// both future end-states open" (via "future"), "the #2387 roadmap records no
+// selected end-state" (via "roadmap"), "operators must never infer either
+// end-state from this warning" (via "never"), and five more. Every one of them
+// is exactly the neutrality the contract asks for, and every one is rejected.
+//
+// That direction is fail-SAFE — it blocks correct text rather than admitting
+// wrong text — but it is not free: the pressure it puts on an author is toward
+// vaguer operator wording, which costs the diagnostic the substance
+// TestVRFOverlapWarningKeepsDiagnosticSubstance exists to protect. If you hit a
+// false red, reword around the spelling. Do not carve an exception into the
+// list, and do not water down the message to get past it.
 //
 // Adding a whole DIRECTION is a different act from growing this list, and
 // vrfOverlapForeclosingTokens below is that: not one more spelling of a covered
@@ -282,8 +300,11 @@ var vrfOverlapForwardLookingTokens = []string{
 	"tracked for",
 }
 
-// vrfOverlapForeclosingTokens are the mirror image: wordings that rule a fix
-// OUT. The contract on validateVRFOverlap is symmetric — the text "must not
+// vrfOverlapForeclosingTokens are the mirror image: spellings that commonly
+// appear when a text rules a fix OUT. The same both-directions caveat applies —
+// a hit proves the spelling is present, not that an outcome was foreclosed;
+// "operators must never infer either end-state from this warning" trips "never"
+// while foreclosing nothing. The contract on validateVRFOverlap is symmetric — the text "must not
 // promise a fix, nor rule one out" — because #2387 is held on a maintainer
 // risk-appetite call whose two candidate end-states are BOTH still open. A
 // warning saying the collision is permanent and by design is exactly as wrong as
@@ -392,13 +413,21 @@ func TestVRFOverlapWarningStatesStatusNotPromise(t *testing.T) {
 			verb   string
 			tokens []string
 		}{
-			{"promises a fix", vrfOverlapForwardLookingTokens},
-			{"rules a fix OUT", vrfOverlapForeclosingTokens},
+			{"forward-looking", vrfOverlapForwardLookingTokens},
+			{"foreclosing", vrfOverlapForeclosingTokens},
 		} {
 			for _, tok := range grp.tokens {
 				if strings.Contains(lower, tok) {
-					t.Errorf("%s form %s via %q; #2387 is an open decision, so the warning must state the "+
-						"limitation and point at the issue without forecasting EITHER outcome: %s",
+					// Report the SPELLING, not a verdict about meaning. This is a
+					// substring test: a hit proves %q appears, NOT that the sentence
+					// containing it forecasts anything. Accurate neutral prose can
+					// trip it — "#2387 leaves both future end-states open" is caught
+					// by "future" while forecasting nothing. Saying "this promises a
+					// fix" would be a claim the check cannot support.
+					t.Errorf("%s form contains the %s spelling %q. #2387 is an open decision, so the "+
+						"warning must state the limitation and point at the issue without forecasting "+
+						"either outcome. If this text IS neutral, reword to avoid the spelling — do not "+
+						"add an exception to the list: %s",
 						tc.form, grp.verb, tok, tc.warn)
 				}
 			}

--- a/pkg/config/compiler_validate_vrf_overlap_2387_test.go
+++ b/pkg/config/compiler_validate_vrf_overlap_2387_test.go
@@ -330,9 +330,10 @@ var vrfOverlapForwardLookingTokens = []string{
 // This axis had NO guard until now. Every one of the 31 entries above is
 // forward-looking, so appending ". #2387 is closed wontfix; this is by design
 // and permanent" passed the whole suite while foreclosing the outcome the
-// comment forbids foreclosing. vrfOverlapStatusTail now reds any APPEND in
-// either direction; these tokens cover the same span the forward list does — the
-// message BEFORE the tail — and inherit the same disclosed incompleteness.
+// comment forbids foreclosing. vrfOverlapStatusTail now reds that append — and
+// any other that does not itself re-terminate with the tail — in either
+// direction; these tokens cover the same span the forward list does, the message
+// BEFORE the tail, and inherit the same disclosed incompleteness.
 //
 // The entries are checked against the shipped text: none is a substring of the
 // current warning, so this list starts from a real green.

--- a/pkg/config/compiler_validate_vrf_overlap_2387_test.go
+++ b/pkg/config/compiler_validate_vrf_overlap_2387_test.go
@@ -201,10 +201,14 @@ func TestVRFOverlapV6NoCrossFamilyFalsePositive(t *testing.T) {
 // check. One suffix comparison forbids appending, truncating, and rewording the
 // tail at once, and needs no maintenance as new promise spellings are invented.
 //
-// It deliberately starts AFTER the "…discriminator, so " clause. That keeps this
-// test scoped to the PROMISE dimension: stripping the diagnosis has to red
-// TestVRFOverlapWarningKeepsDiagnosticSubstance and only that test, which is
-// what makes the two tests separable rather than two spellings of one check.
+// It deliberately starts AFTER the "…discriminator, so " clause. That makes the
+// two tests SEPARABLE — not orthogonal, and the difference is measured. Deleting
+// the diagnosis reds TestVRFOverlapWarningKeepsDiagnosticSubstance and only that
+// test, so the substance check is not a second spelling of this one. The converse
+// does NOT hold: the tail carries the substantive polarity word ("may"), so
+// flipping it to "cannot" reds BOTH — this test on the suffix compare, the
+// substance test on its own phrase list. So read a red here as "the tail changed",
+// not as "someone made a promise"; a polarity edit lands in both columns at once.
 const vrfOverlapStatusTail = "colliding 5-tuples may cross-forward. " +
 	"See #2387 for the status of this limitation"
 
@@ -353,13 +357,21 @@ func vrfOverlapBothFormStrings(t *testing.T) (equal, unequal string) {
 	return eq[0], un[0]
 }
 
-// TestVRFOverlapWarningStatesStatusNotPromise pins that BOTH format strings
-// describe the current limitation and point at the tracking issue, without
-// forecasting EITHER outcome. Despite the name, "NotPromise" is shorthand for
-// "neither promises nor forecloses": the contract on validateVRFOverlap is
-// symmetric, so the test is too. Two layers, in order of strength: the message
-// must END with vrfOverlapStatusTail verbatim, and the message must carry none
-// of the known forecasting spellings — forward or backward — anywhere.
+// TestVRFOverlapWarningStatesStatusNotPromise pins two properties of BOTH format
+// strings: the message ENDS with vrfOverlapStatusTail verbatim, and the message
+// carries none of the KNOWN forecasting spellings — forward or backward —
+// anywhere. Despite the name, "NotPromise" is shorthand for "neither promises nor
+// forecloses": the contract on validateVRFOverlap is symmetric, so the test is
+// too.
+//
+// What that does NOT amount to is "the text cannot forecast either outcome". The
+// suffix compare is absolute but reaches only the tail; everything before it is
+// governed by two token BLOCKLISTS, which are incomplete by construction. Nine
+// foreclosing and nine promising sentences, each spliced before the tail in a
+// spelling nobody listed, left the whole package suite GREEN. Treat a green as
+// "the tail is intact and no listed spelling appears" — not as a proof of
+// neutrality. Do not respond by growing the lists; see the doctrine note at the
+// blocklist itself.
 //
 // Restoring the old "…may cross-forward until the session identity is VRF-aware"
 // wording reds this twice over: the suffix no longer matches, and "until" is on

--- a/pkg/config/compiler_validate_vrf_overlap_2387_test.go
+++ b/pkg/config/compiler_validate_vrf_overlap_2387_test.go
@@ -16,10 +16,21 @@ import (
 // interface units WARN, naming both RIs + the prefix; (2) non-overlapping RIs
 // do NOT warn (no false positive); (3) a single RI / no RI does NOT warn;
 // (4) the PBR-term source (`then routing-instance`) also feeds the overlap set;
-// (5) the warning ENDS with the exact status sentence — stating the current
-// limitation and pointing at the tracking issue, with no forecast in EITHER
-// direction before it and nothing appended after it — and (6) losing the promise
-// did not cost the diagnostic any of its substance, polarity included.
+// (5) the warning ENDS with the exact status sentence, verbatim, so nothing can
+// be appended after it, the tail cannot be reworded, and the status sentence
+// itself cannot be dropped; and (6) losing the promise did not cost the
+// diagnostic any of its substance, polarity included.
+//
+// (5) is deliberately NOT "no forecast in either direction". Measured: the
+// suffix pin catches APPEND-after-tail and REWORD-inside-tail in both
+// directions, always. It is BLIND to a forecast SPLICED before the tail or
+// PREPENDED at the front — there, the token lists are the only defence, and a
+// blocklist is incomplete by construction. Nine distinct foreclosing sentences
+// and nine distinct promising sentences, none using a listed spelling, were
+// each spliced before the tail and left the whole package suite GREEN. So what
+// is enforced is "no forecast in any spelling we listed, anywhere, plus no
+// tampering with the tail at all" — not "no forecast". Do not grow the lists
+// toward completeness; see the doctrine note at the blocklist itself.
 //
 // "Either direction" is load-bearing in (5). The contract on validateVRFOverlap
 // is that the text must not promise a fix "nor rule one out", and until now only

--- a/pkg/config/compiler_validate_vrf_overlap_2387_test.go
+++ b/pkg/config/compiler_validate_vrf_overlap_2387_test.go
@@ -17,9 +17,15 @@ import (
 // do NOT warn (no false positive); (3) a single RI / no RI does NOT warn;
 // (4) the PBR-term source (`then routing-instance`) also feeds the overlap set;
 // (5) the warning ENDS with the exact status sentence — stating the current
-// limitation and pointing at the tracking issue, with no promise before it and
-// nothing appended after it — and (6) losing the promise did not cost the
-// diagnostic any of its substance, polarity included.
+// limitation and pointing at the tracking issue, with no forecast in EITHER
+// direction before it and nothing appended after it — and (6) losing the promise
+// did not cost the diagnostic any of its substance, polarity included.
+//
+// "Either direction" is load-bearing in (5). The contract on validateVRFOverlap
+// is that the text must not promise a fix "nor rule one out", and until now only
+// the promise half was guarded: appending ". #2387 is closed wontfix; this is by
+// design and permanent" passed the whole suite while foreclosing an outcome that
+// is still the maintainer's to decide. See vrfOverlapForeclosingTokens.
 //
 // fail-on-revert: removing the validateVRFOverlap call (or its detection body)
 // drops the warning, so TestVRFOverlapWarnsOnOverlappingRIs goes RED.
@@ -211,6 +217,10 @@ const vrfOverlapStatusTail = "colliding 5-tuples may cross-forward. " +
 // documents. The entries below the first group were each added after a review
 // demonstrated it passing the test while reintroducing a promise, so treat any
 // addition the same way: prove it green first, then add it.
+//
+// Adding a whole DIRECTION is a different act from growing this list, and
+// vrfOverlapForeclosingTokens below is that: not one more spelling of a covered
+// axis, but the first coverage of an axis that had none.
 var vrfOverlapForwardLookingTokens = []string{
 	"until",
 	"will be",
@@ -255,6 +265,38 @@ var vrfOverlapForwardLookingTokens = []string{
 	"next release",
 	"targeted for",
 	"tracked for",
+}
+
+// vrfOverlapForeclosingTokens are the mirror image: wordings that rule a fix
+// OUT. The contract on validateVRFOverlap is symmetric — the text "must not
+// promise a fix, nor rule one out" — because #2387 is held on a maintainer
+// risk-appetite call whose two candidate end-states are BOTH still open. A
+// warning saying the collision is permanent and by design is exactly as wrong as
+// one saying a fix is coming, and it is the more dangerous error of the two: an
+// operator who reads "by design" stops treating an overlapping-VRF topology as a
+// hazard to revisit.
+//
+// This axis had NO guard until now. Every one of the 31 entries above is
+// forward-looking, so appending ". #2387 is closed wontfix; this is by design
+// and permanent" passed the whole suite while foreclosing the outcome the
+// comment forbids foreclosing. vrfOverlapStatusTail now reds any APPEND in
+// either direction; these tokens cover the same span the forward list does — the
+// message BEFORE the tail — and inherit the same disclosed incompleteness.
+//
+// The entries are checked against the shipped text: none is a substring of the
+// current warning, so this list starts from a real green.
+var vrfOverlapForeclosingTokens = []string{
+	"wontfix",
+	"won't fix",
+	"will not",
+	"never",
+	"by design",
+	"as designed",
+	"working as intended",
+	"permanent",
+	"closed as",
+	"not going to",
+	"no fix",
 }
 
 // vrfOverlapBothFormStrings returns one warning from EACH of the two format
@@ -302,11 +344,17 @@ func vrfOverlapBothFormStrings(t *testing.T) (equal, unequal string) {
 
 // TestVRFOverlapWarningStatesStatusNotPromise pins that BOTH format strings
 // describe the current limitation and point at the tracking issue, without
-// asserting that any particular fix arrives. Two layers, in order of strength:
-// the message must END with vrfOverlapStatusTail verbatim, and the message must
-// carry none of the known promise spellings anywhere. Restoring the old "…may
-// cross-forward until the session identity is VRF-aware" wording reds both — the
-// suffix no longer matches, and "until" is on the list.
+// forecasting EITHER outcome. Despite the name, "NotPromise" is shorthand for
+// "neither promises nor forecloses": the contract on validateVRFOverlap is
+// symmetric, so the test is too. Two layers, in order of strength: the message
+// must END with vrfOverlapStatusTail verbatim, and the message must carry none
+// of the known forecasting spellings — forward or backward — anywhere.
+//
+// Restoring the old "…may cross-forward until the session identity is VRF-aware"
+// wording reds this twice over: the suffix no longer matches, and "until" is on
+// the forward list. Appending ". #2387 is closed wontfix; this is by design and
+// permanent" reds it on the suffix; splicing the same text BEFORE the tail reds
+// it on the foreclosing list, which is the span the suffix cannot reach.
 func TestVRFOverlapWarningStatesStatusNotPromise(t *testing.T) {
 	equal, unequal := vrfOverlapBothFormStrings(t)
 	for _, tc := range []struct {
@@ -317,10 +365,19 @@ func TestVRFOverlapWarningStatesStatusNotPromise(t *testing.T) {
 		{"unequal-overlap", unequal},
 	} {
 		lower := strings.ToLower(tc.warn)
-		for _, tok := range vrfOverlapForwardLookingTokens {
-			if strings.Contains(lower, tok) {
-				t.Errorf("%s form promises a fix via %q; #2387 is an open decision, so the warning must state the limitation and point at the issue: %s",
-					tc.form, tok, tc.warn)
+		for _, grp := range []struct {
+			verb   string
+			tokens []string
+		}{
+			{"promises a fix", vrfOverlapForwardLookingTokens},
+			{"rules a fix OUT", vrfOverlapForeclosingTokens},
+		} {
+			for _, tok := range grp.tokens {
+				if strings.Contains(lower, tok) {
+					t.Errorf("%s form %s via %q; #2387 is an open decision, so the warning must state the "+
+						"limitation and point at the issue without forecasting EITHER outcome: %s",
+						tc.form, grp.verb, tok, tc.warn)
+				}
 			}
 		}
 		if !strings.HasSuffix(tc.warn, vrfOverlapStatusTail) {
@@ -338,14 +395,25 @@ func TestVRFOverlapWarningStatesStatusNotPromise(t *testing.T) {
 // (no routing-instance discriminator in the session identity) and WHAT follows
 // from it (colliding 5-tuples MAY cross-forward).
 //
-// What this control actually defends against is PARTIAL diagnostic stripping —
-// text that still passes the helper's selector and still ends with the exact
-// status tail, but has lost the cause, the consequence, or the pairing that says
-// which instance sits on which source and prefix. It is NOT what stops wholesale
-// deletion of the warning text: that reds StatesStatusNotPromise first, because
-// vrfOverlapBothFormStrings requires the diagnosis selector to match, exactly one
-// warning per fixture, and both arm markers before any assertion here is reached.
-// An earlier revision of this comment claimed the opposite; it was wrong.
+// What this control actually defends against is GUTTING the warning down to a
+// bare issue reference — text that still passes the helper's selector, still
+// carries both arm markers, and still ends with the exact status tail, but has
+// lost the cause, the consequence, or the pairing that says which instance sits
+// on which source and prefix. Measured on such a gut:
+// TestVRFOverlapWarningStatesStatusNotPromise stays GREEN and this test reds. Be
+// precise about how much that proves — TestVRFOverlapWarnsOnOverlappingRIs also
+// reds there, because that particular gut drops "NOT session-isolated", which it
+// asserts too. The cell where this control is the ONLY red in the file is
+// stripping the "…carries no routing-instance discriminator, so " clause while
+// leaving the tail intact: promise GREEN, six pre-existing GREEN, this one RED.
+// That is the measurement that makes it load-bearing rather than duplicative.
+//
+// An earlier revision of this comment said the promise test "is satisfied just as
+// well by deleting the warning text wholesale". The word doing the damage is
+// "wholesale": a WHOLESALE delete does red the promise test, at
+// vrfOverlapBothFormStrings' one-warning-per-fixture Fatalf, because the
+// diagnosis selector no longer matches anything. It is the skeleton-preserving
+// gut, not the wholesale delete, that this control alone catches.
 func TestVRFOverlapWarningKeepsDiagnosticSubstance(t *testing.T) {
 	equal, unequal := vrfOverlapBothFormStrings(t)
 	for _, tc := range []struct {

--- a/pkg/config/compiler_validate_vrf_overlap_2387_test.go
+++ b/pkg/config/compiler_validate_vrf_overlap_2387_test.go
@@ -16,9 +16,10 @@ import (
 // interface units WARN, naming both RIs + the prefix; (2) non-overlapping RIs
 // do NOT warn (no false positive); (3) a single RI / no RI does NOT warn;
 // (4) the PBR-term source (`then routing-instance`) also feeds the overlap set;
-// (5) the warning states the CURRENT limitation and points at the tracking
-// issue instead of promising a fix, and (6) losing the promise did not cost the
-// diagnostic any of its substance.
+// (5) the warning ENDS with the exact status sentence — stating the current
+// limitation and pointing at the tracking issue, with no promise before it and
+// nothing appended after it — and (6) losing the promise did not cost the
+// diagnostic any of its substance, polarity included.
 //
 // fail-on-revert: removing the validateVRFOverlap call (or its detection body)
 // drops the warning, so TestVRFOverlapWarnsOnOverlappingRIs goes RED.
@@ -27,9 +28,12 @@ import (
 // replace "…may cross-forward. See #2387 for the status of this limitation"
 // with "…may cross-forward until the session identity is VRF-aware", KEEPING
 // the "the session identity carries no routing-instance discriminator, so"
-// clause. That reds TestVRFOverlapWarningStatesStatusNotPromise on the "until"
-// token while TestVRFOverlapWarningKeepsDiagnosticSubstance stays GREEN, which
-// is what distinguishes "the promise is gone" from "the diagnostic is gone".
+// clause. That reds TestVRFOverlapWarningStatesStatusNotPromise twice over — the
+// message no longer ends with vrfOverlapStatusTail, and "until" is on the
+// blocklist — while TestVRFOverlapWarningKeepsDiagnosticSubstance stays GREEN,
+// which is what distinguishes "the promise is gone" from "the diagnostic is
+// gone". The converse isolation is stripping the "…carries no routing-instance
+// discriminator, so " clause and keeping the tail: substance RED, promise GREEN.
 //
 // A LITERAL revert to the pre-PR string reds BOTH, and that is correct, not a
 // failure of the pair: the old string ALSO lacked the discriminator clause, so
@@ -39,7 +43,10 @@ import (
 // the substance test at all is the useful part: the replacement is strictly
 // more informative than what it replaced, and this test is what pins that.)
 
-// vrf2387Warnings returns the compile warnings that mention #2387.
+// vrf2387Warnings returns the compile warnings carrying the cross-VRF overlap
+// diagnosis. It selects on the diagnosis phrase, NOT on "#2387" — see the
+// comment on the filter below for why the issue reference cannot be the
+// selector.
 func vrf2387Warnings(t *testing.T, cmds []string) []string {
 	t.Helper()
 	tree := buildTree(t, cmds)
@@ -50,13 +57,14 @@ func vrf2387Warnings(t *testing.T, cmds []string) []string {
 	var out []string
 	for _, w := range cfg.Warnings {
 		// Filter on the DIAGNOSIS, not on "#2387". Filtering on the issue
-		// reference made the "points at the tracking issue" assertion below
-		// unreachable: every warning reaching it had already been selected for
-		// containing the very substring it then checked for. Dropping #2387
-		// from a format string failed the fixture's count assertion instead,
-		// with a message about the wrong thing. This phrase is carried by both
-		// overlap format strings and by neither the truncation notice nor any
-		// other warning, so the selection stays arm-neutral.
+		// reference made the status-sentence assertion below unreachable: every
+		// warning reaching it had already been selected for containing the very
+		// substring the sentence ends with. Dropping #2387 from a format string
+		// failed the fixture's count assertion instead, with a message about the
+		// wrong thing. This phrase is carried by both overlap format strings and
+		// by neither the truncation notice nor any other warning, so the
+		// selection stays arm-neutral, and it appears nowhere inside
+		// vrfOverlapStatusTail, so it cannot pre-satisfy that assertion either.
 		if strings.Contains(w, "overlapping L3 across routing-instances") {
 			out = append(out, w)
 		}
@@ -162,6 +170,27 @@ func TestVRFOverlapV6NoCrossFamilyFalsePositive(t *testing.T) {
 	}
 }
 
+// vrfOverlapStatusTail is the exact wording BOTH overlap format strings must
+// END with. It is this PR's actual deliverable: the sentence that replaced the
+// old "until the session identity is VRF-aware" promise with a pointer to the
+// still-open decision.
+//
+// Asserted as an exact TERMINAL substring, not as tokens, because every weaker
+// form measured GREEN while the deliverable was gone. A bare `Contains("#2387")`
+// passed with this whole sentence deleted, since the diagnosis clause earlier in
+// the message carries a second "#2387". And no token list can forbid text being
+// APPENDED after the sentence: "…status of this limitation. A fix is
+// guaranteed." reintroduces an explicit promise while matching every token
+// check. One suffix comparison forbids appending, truncating, and rewording the
+// tail at once, and needs no maintenance as new promise spellings are invented.
+//
+// It deliberately starts AFTER the "…discriminator, so " clause. That keeps this
+// test scoped to the PROMISE dimension: stripping the diagnosis has to red
+// TestVRFOverlapWarningKeepsDiagnosticSubstance and only that test, which is
+// what makes the two tests separable rather than two spellings of one check.
+const vrfOverlapStatusTail = "colliding 5-tuples may cross-forward. " +
+	"See #2387 for the status of this limitation"
+
 // vrfOverlapForwardLookingTokens are the wordings that turn the advisory from a
 // statement of the CURRENT limitation into a promise about a future one. #2387
 // is held on a maintainer risk-appetite call: neither candidate end-state (the
@@ -170,13 +199,18 @@ func TestVRFOverlapV6NoCrossFamilyFalsePositive(t *testing.T) {
 // 5-tuples may cross-forward "until the session identity is VRF-aware", and the
 // #2387 plan then cited that sentence back as evidence the widening was already
 // settled — a promise the open decision may never keep.
-// This list is a BLOCKLIST and is therefore incomplete by construction: it
-// catches the spellings someone thought of, and a future author can always
-// phrase a promise a way it does not match. Do not read a green result as
-// "the warning contains no promise" — read it as "the warning contains none of
-// these". The entries below the first group were added after a review
-// demonstrated each one passing the test while reintroducing a promise, so
-// treat any addition the same way: prove it green first, then add it.
+//
+// This list is the SECONDARY layer, and it is a BLOCKLIST: incomplete by
+// construction. vrfOverlapStatusTail above is the primary binding and pins the
+// message from "colliding 5-tuples" to its last character exactly, so the only
+// region where these tokens are the sole defence is the span BEFORE the tail — a
+// promise spliced between "NOT session-isolated (#2387) —" and the diagnosis
+// clause. Do not read a green result as "the warning contains no promise"; read
+// it as "the tail is exactly right and the head contains none of these
+// spellings". Do not grow this list toward completeness — that is the trap it
+// documents. The entries below the first group were each added after a review
+// demonstrated it passing the test while reintroducing a promise, so treat any
+// addition the same way: prove it green first, then add it.
 var vrfOverlapForwardLookingTokens = []string{
 	"until",
 	"will be",
@@ -268,9 +302,11 @@ func vrfOverlapBothFormStrings(t *testing.T) (equal, unequal string) {
 
 // TestVRFOverlapWarningStatesStatusNotPromise pins that BOTH format strings
 // describe the current limitation and point at the tracking issue, without
-// asserting that any particular fix arrives. Restoring the old "…may
-// cross-forward until the session identity is VRF-aware" wording reds this on
-// the "until" token.
+// asserting that any particular fix arrives. Two layers, in order of strength:
+// the message must END with vrfOverlapStatusTail verbatim, and the message must
+// carry none of the known promise spellings anywhere. Restoring the old "…may
+// cross-forward until the session identity is VRF-aware" wording reds both — the
+// suffix no longer matches, and "until" is on the list.
 func TestVRFOverlapWarningStatesStatusNotPromise(t *testing.T) {
 	equal, unequal := vrfOverlapBothFormStrings(t)
 	for _, tc := range []struct {
@@ -287,8 +323,11 @@ func TestVRFOverlapWarningStatesStatusNotPromise(t *testing.T) {
 					tc.form, tok, tc.warn)
 			}
 		}
-		if !strings.Contains(tc.warn, "#2387") {
-			t.Errorf("%s form does not point at the tracking issue: %s", tc.form, tc.warn)
+		if !strings.HasSuffix(tc.warn, vrfOverlapStatusTail) {
+			t.Errorf("%s form does not END with the status sentence %q — the advisory must close "+
+				"by stating the consequence and pointing at the open decision, with nothing "+
+				"appended after it: %s",
+				tc.form, vrfOverlapStatusTail, tc.warn)
 		}
 	}
 }
@@ -296,10 +335,17 @@ func TestVRFOverlapWarningStatesStatusNotPromise(t *testing.T) {
 // TestVRFOverlapWarningKeepsDiagnosticSubstance is the negative control for
 // TestVRFOverlapWarningStatesStatusNotPromise. Dropping the promise must not
 // cost the operator the diagnosis: the warning still has to say WHAT is wrong
-// (no routing-instance discriminator in the session identity) and WHAT the
-// consequence is (colliding 5-tuples may cross-forward). Without this pair, the
-// forward-looking-token test above is satisfied just as well by deleting the
-// warning text wholesale.
+// (no routing-instance discriminator in the session identity) and WHAT follows
+// from it (colliding 5-tuples MAY cross-forward).
+//
+// What this control actually defends against is PARTIAL diagnostic stripping —
+// text that still passes the helper's selector and still ends with the exact
+// status tail, but has lost the cause, the consequence, or the pairing that says
+// which instance sits on which source and prefix. It is NOT what stops wholesale
+// deletion of the warning text: that reds StatesStatusNotPromise first, because
+// vrfOverlapBothFormStrings requires the diagnosis selector to match, exactly one
+// warning per fixture, and both arm markers before any assertion here is reached.
+// An earlier revision of this comment claimed the opposite; it was wrong.
 func TestVRFOverlapWarningKeepsDiagnosticSubstance(t *testing.T) {
 	equal, unequal := vrfOverlapBothFormStrings(t)
 	for _, tc := range []struct {
@@ -312,9 +358,11 @@ func TestVRFOverlapWarningKeepsDiagnosticSubstance(t *testing.T) {
 		// list of tokens to find somewhere in the message. Presence and
 		// association are different properties, and only the second is useful:
 		// a token list is satisfied while every identifier is attached to the
-		// WRONG object. Both format strings are 6-argument Sprintf calls
-		// carrying three (name, origin, prefix) triples, which is exactly where
-		// an argument transposition happens — and `go vet` cannot see it,
+		// WRONG object. Both format strings interleave the two instances'
+		// identifiers — the equal-prefix arm substitutes FIVE arguments (two
+		// name/origin pairs plus the single prefix they share), the unequal arm
+		// SIX (a full (name, origin, prefix) triple each) — which is exactly
+		// where an argument transposition happens, and `go vet` cannot see it,
 		// because every argument is a string or Stringer feeding %q/%s, so the
 		// printf checker reports nothing.
 		//
@@ -349,11 +397,17 @@ func TestVRFOverlapWarningKeepsDiagnosticSubstance(t *testing.T) {
 			},
 		},
 	} {
-		// The explanation: what is wrong and what follows from it.
+		// The explanation: what is wrong and what follows from it. Each entry
+		// carries its own POLARITY, because a bare noun does not. "cross-forward"
+		// alone was satisfied by "colliding 5-tuples CANNOT cross-forward", which
+		// tells the operator the exact opposite of the truth — the hazard reads as
+		// a reassurance and the topology looks safe. Assert the claim, not the
+		// vocabulary: subject + modality + verb as one contiguous span, and the
+		// cause with the "no" that makes it a cause.
 		for _, want := range []string{
 			"NOT session-isolated",
-			"no routing-instance discriminator",
-			"cross-forward",
+			"the session identity carries no routing-instance discriminator",
+			"colliding 5-tuples may cross-forward",
 		} {
 			if !strings.Contains(tc.warn, want) {
 				t.Errorf("%s form lost diagnostic substance %q: %s", tc.form, want, tc.warn)

--- a/pkg/config/compiler_validate_vrf_overlap_2387_test.go
+++ b/pkg/config/compiler_validate_vrf_overlap_2387_test.go
@@ -21,11 +21,23 @@ import (
 // diagnostic any of its substance.
 //
 // fail-on-revert: removing the validateVRFOverlap call (or its detection body)
-// drops the warning, so TestVRFOverlapWarnsOnOverlappingRIs goes RED. Restoring
-// the old "…may cross-forward until the session identity is VRF-aware" wording
-// reds TestVRFOverlapWarningStatesStatusNotPromise on the "until" token, while
-// TestVRFOverlapWarningKeepsDiagnosticSubstance stays GREEN — that pair is what
-// distinguishes "the promise is gone" from "the diagnostic is gone".
+// drops the warning, so TestVRFOverlapWarnsOnOverlappingRIs goes RED.
+//
+// The mutation that ISOLATES the promise dimension is a TAIL-ONLY substitution:
+// replace "…may cross-forward. See #2387 for the status of this limitation"
+// with "…may cross-forward until the session identity is VRF-aware", KEEPING
+// the "the session identity carries no routing-instance discriminator, so"
+// clause. That reds TestVRFOverlapWarningStatesStatusNotPromise on the "until"
+// token while TestVRFOverlapWarningKeepsDiagnosticSubstance stays GREEN, which
+// is what distinguishes "the promise is gone" from "the diagnostic is gone".
+//
+// A LITERAL revert to the pre-PR string reds BOTH, and that is correct, not a
+// failure of the pair: the old string ALSO lacked the discriminator clause, so
+// reverting changes two things at once — it re-adds the promise AND removes the
+// diagnosis. Do not read a both-red result as "the tests do not separate"; run
+// the tail-only mutation above to see them separate. (That the old text trips
+// the substance test at all is the useful part: the replacement is strictly
+// more informative than what it replaced, and this test is what pins that.)
 
 // vrf2387Warnings returns the compile warnings that mention #2387.
 func vrf2387Warnings(t *testing.T, cmds []string) []string {
@@ -150,6 +162,13 @@ func TestVRFOverlapV6NoCrossFamilyFalsePositive(t *testing.T) {
 // 5-tuples may cross-forward "until the session identity is VRF-aware", and the
 // #2387 plan then cited that sentence back as evidence the widening was already
 // settled — a promise the open decision may never keep.
+// This list is a BLOCKLIST and is therefore incomplete by construction: it
+// catches the spellings someone thought of, and a future author can always
+// phrase a promise a way it does not match. Do not read a green result as
+// "the warning contains no promise" — read it as "the warning contains none of
+// these". The entries below the first group were added after a review
+// demonstrated each one passing the test while reintroducing a promise, so
+// treat any addition the same way: prove it green first, then add it.
 var vrfOverlapForwardLookingTokens = []string{
 	"until",
 	"will be",
@@ -160,6 +179,18 @@ var vrfOverlapForwardLookingTokens = []string{
 	"roadmap",
 	"once the session",
 	"when the session",
+	// Measured escapes — each of these was inserted into the warning and
+	// observed to leave the test GREEN before it was listed here.
+	"not yet",
+	"pending",
+	"temporary",
+	"temporarily",
+	"in a later release",
+	"for now",
+	"interim",
+	"to be addressed",
+	"work is under way",
+	"soon",
 }
 
 // vrfOverlapBothFormStrings returns one warning from EACH of the two format
@@ -244,10 +275,35 @@ func TestVRFOverlapWarningKeepsDiagnosticSubstance(t *testing.T) {
 	for _, tc := range []struct {
 		form string
 		warn string
+		// ident is the WHICH of the diagnosis: which routing-instances, reached
+		// through which config source, over which prefix. Asserting only the
+		// explanatory prose leaves every one of these strippable with the whole
+		// package still green — an operator would be told a cross-forwarding
+		// hazard exists but not where, which is not a usable diagnostic.
+		ident []string
 	}{
-		{"equal-prefix", equal},
-		{"unequal-overlap", unequal},
+		{
+			form: "equal-prefix",
+			warn: equal,
+			ident: []string{
+				`"RI-A"`, `"RI-B"`,
+				`interface "ge-0/0/1.0"`, `interface "ge-0/0/2.0"`,
+				"10.0.0.0/24",
+			},
+		},
+		{
+			form: "unequal-overlap",
+			warn: unequal,
+			ident: []string{
+				`"RI-A"`, `"RI-B"`,
+				`interface "ge-0/0/1.0"`, `interface "ge-0/0/2.0"`,
+				// BOTH prefixes: the unequal form's whole reason to exist is
+				// that the two differ, so printing only one loses the overlap.
+				"10.0.0.0/24", "10.0.0.0/25",
+			},
+		},
 	} {
+		// The explanation: what is wrong and what follows from it.
 		for _, want := range []string{
 			"NOT session-isolated",
 			"no routing-instance discriminator",
@@ -255,6 +311,14 @@ func TestVRFOverlapWarningKeepsDiagnosticSubstance(t *testing.T) {
 		} {
 			if !strings.Contains(tc.warn, want) {
 				t.Errorf("%s form lost diagnostic substance %q: %s", tc.form, want, tc.warn)
+			}
+		}
+		// The identification: which objects the explanation is about.
+		for _, want := range tc.ident {
+			if !strings.Contains(tc.warn, want) {
+				t.Errorf("%s form no longer identifies %q — the warning explains the hazard "+
+					"but not which routing-instances, source or prefix it concerns: %s",
+					tc.form, want, tc.warn)
 			}
 		}
 	}

--- a/pkg/config/compiler_validate_vrf_overlap_2387_test.go
+++ b/pkg/config/compiler_validate_vrf_overlap_2387_test.go
@@ -49,7 +49,15 @@ func vrf2387Warnings(t *testing.T, cmds []string) []string {
 	}
 	var out []string
 	for _, w := range cfg.Warnings {
-		if strings.Contains(w, "#2387") {
+		// Filter on the DIAGNOSIS, not on "#2387". Filtering on the issue
+		// reference made the "points at the tracking issue" assertion below
+		// unreachable: every warning reaching it had already been selected for
+		// containing the very substring it then checked for. Dropping #2387
+		// from a format string failed the fixture's count assertion instead,
+		// with a message about the wrong thing. This phrase is carried by both
+		// overlap format strings and by neither the truncation notice nor any
+		// other warning, so the selection stays arm-neutral.
+		if strings.Contains(w, "overlapping L3 across routing-instances") {
 			out = append(out, w)
 		}
 	}
@@ -179,8 +187,18 @@ var vrfOverlapForwardLookingTokens = []string{
 	"roadmap",
 	"once the session",
 	"when the session",
-	// Measured escapes — each of these was inserted into the warning and
-	// observed to leave the test GREEN before it was listed here.
+	// Measured escapes — each was inserted into the warning and observed to
+	// leave the test GREEN before it was listed here.
+	//
+	// "temporarily" earns its own entry: it does NOT contain "temporary" as a
+	// substring, so the shorter token does not cover it.
+	//
+	// A cautionary one, kept as a worked example rather than removed: an
+	// earlier round added "work is under way", which fires only on that exact
+	// four-word spelling and does NOT match "work is underway" or "work is in
+	// progress" — the phrasing actually measured. Reaching for a phrase you
+	// imagined instead of the one you observed buys nothing. "in progress"
+	// below is the token that does the work.
 	"not yet",
 	"pending",
 	"temporary",
@@ -190,7 +208,19 @@ var vrfOverlapForwardLookingTokens = []string{
 	"interim",
 	"to be addressed",
 	"work is under way",
+	"underway",
+	"in progress",
 	"soon",
+	"shortly",
+	"eventually",
+	"plan to",
+	"will gain",
+	"is expected to",
+	"shall",
+	"going to",
+	"next release",
+	"targeted for",
+	"tracked for",
 }
 
 // vrfOverlapBothFormStrings returns one warning from EACH of the two format
@@ -276,30 +306,46 @@ func TestVRFOverlapWarningKeepsDiagnosticSubstance(t *testing.T) {
 		form string
 		warn string
 		// ident is the WHICH of the diagnosis: which routing-instances, reached
-		// through which config source, over which prefix. Asserting only the
-		// explanatory prose leaves every one of these strippable with the whole
-		// package still green — an operator would be told a cross-forwarding
-		// hazard exists but not where, which is not a usable diagnostic.
+		// through which config source, over which prefix.
+		//
+		// These are ORDERED PAIRINGS held as one contiguous substring, not a
+		// list of tokens to find somewhere in the message. Presence and
+		// association are different properties, and only the second is useful:
+		// a token list is satisfied while every identifier is attached to the
+		// WRONG object. Both format strings are 6-argument Sprintf calls
+		// carrying three (name, origin, prefix) triples, which is exactly where
+		// an argument transposition happens — and `go vet` cannot see it,
+		// because every argument is a string or Stringer feeding %q/%s, so the
+		// printf checker reports nothing.
+		//
+		// Measured on the token-list version: swapping the two origins, or the
+		// two RI names, or the two prefixes, left `go test ./pkg/config/
+		// -count=1` fully green and `go vet ./pkg/config/` silent, while the
+		// operator was sent to the wrong interface or told the wrong prefix
+		// sits on the wrong instance. Fixture truth is
+		// RI-A <- ge-0/0/1.0 @ 10.0.0.0/24 and RI-B <- ge-0/0/2.0 @ 10.0.0.0/25.
+		//
+		// The pairing form is a strict replacement, not an addition: a strip
+		// breaks the contiguous substring too, so it still catches everything
+		// the token list caught.
 		ident []string
 	}{
 		{
 			form: "equal-prefix",
 			warn: equal,
 			ident: []string{
-				`"RI-A"`, `"RI-B"`,
-				`interface "ge-0/0/1.0"`, `interface "ge-0/0/2.0"`,
-				"10.0.0.0/24",
+				`"RI-A" (interface "ge-0/0/1.0") and "RI-B" (interface "ge-0/0/2.0") both carry 10.0.0.0/24`,
 			},
 		},
 		{
 			form: "unequal-overlap",
 			warn: unequal,
+			// One pairing per instance: this arm's whole reason to exist is
+			// that the two prefixes DIFFER, so each must stay bound to its own
+			// instance and origin.
 			ident: []string{
-				`"RI-A"`, `"RI-B"`,
-				`interface "ge-0/0/1.0"`, `interface "ge-0/0/2.0"`,
-				// BOTH prefixes: the unequal form's whole reason to exist is
-				// that the two differ, so printing only one loses the overlap.
-				"10.0.0.0/24", "10.0.0.0/25",
+				`"RI-A" (interface "ge-0/0/1.0", 10.0.0.0/24)`,
+				`"RI-B" (interface "ge-0/0/2.0", 10.0.0.0/25)`,
 			},
 		},
 	} {
@@ -316,8 +362,8 @@ func TestVRFOverlapWarningKeepsDiagnosticSubstance(t *testing.T) {
 		// The identification: which objects the explanation is about.
 		for _, want := range tc.ident {
 			if !strings.Contains(tc.warn, want) {
-				t.Errorf("%s form no longer identifies %q — the warning explains the hazard "+
-					"but not which routing-instances, source or prefix it concerns: %s",
+				t.Errorf("%s form no longer states the pairing %q — the warning explains the hazard "+
+					"but not which routing-instance sits on which source and prefix: %s",
 					tc.form, want, tc.warn)
 			}
 		}

--- a/pkg/config/compiler_validate_vrf_overlap_2387_test.go
+++ b/pkg/config/compiler_validate_vrf_overlap_2387_test.go
@@ -15,10 +15,17 @@ import (
 // These tests pin: (1) two RIs with overlapping addresses on their member
 // interface units WARN, naming both RIs + the prefix; (2) non-overlapping RIs
 // do NOT warn (no false positive); (3) a single RI / no RI does NOT warn;
-// (4) the PBR-term source (`then routing-instance`) also feeds the overlap set.
+// (4) the PBR-term source (`then routing-instance`) also feeds the overlap set;
+// (5) the warning states the CURRENT limitation and points at the tracking
+// issue instead of promising a fix, and (6) losing the promise did not cost the
+// diagnostic any of its substance.
 //
 // fail-on-revert: removing the validateVRFOverlap call (or its detection body)
-// drops the warning, so TestVRFOverlapWarnsOnOverlappingRIs goes RED.
+// drops the warning, so TestVRFOverlapWarnsOnOverlappingRIs goes RED. Restoring
+// the old "…may cross-forward until the session identity is VRF-aware" wording
+// reds TestVRFOverlapWarningStatesStatusNotPromise on the "until" token, while
+// TestVRFOverlapWarningKeepsDiagnosticSubstance stays GREEN — that pair is what
+// distinguishes "the promise is gone" from "the diagnostic is gone".
 
 // vrf2387Warnings returns the compile warnings that mention #2387.
 func vrf2387Warnings(t *testing.T, cmds []string) []string {
@@ -132,5 +139,123 @@ func TestVRFOverlapV6NoCrossFamilyFalsePositive(t *testing.T) {
 	})
 	if len(warns) != 0 {
 		t.Fatalf("cross-family (v4 vs v6) must not warn, got: %v", warns)
+	}
+}
+
+// vrfOverlapForwardLookingTokens are the wordings that turn the advisory from a
+// statement of the CURRENT limitation into a promise about a future one. #2387
+// is held on a maintainer risk-appetite call: neither candidate end-state (the
+// hard-reject posture, or the VRF-aware session key) is decided, so the warning
+// must not assert that either one arrives. The original text said colliding
+// 5-tuples may cross-forward "until the session identity is VRF-aware", and the
+// #2387 plan then cited that sentence back as evidence the widening was already
+// settled — a promise the open decision may never keep.
+var vrfOverlapForwardLookingTokens = []string{
+	"until",
+	"will be",
+	"planned",
+	"future",
+	"deferred",
+	"upcoming",
+	"roadmap",
+	"once the session",
+	"when the session",
+}
+
+// vrfOverlapBothFormStrings returns one warning from EACH of the two format
+// strings in validateVRFOverlap: the equal-prefix form (both RIs carry the
+// identical prefix) and the unequal-overlap form (the prefixes overlap without
+// being equal). A fixture that hits only one arm leaves the other's wording
+// unbound, so every wording assertion below runs against both.
+func vrfOverlapBothFormStrings(t *testing.T) (equal, unequal string) {
+	t.Helper()
+
+	eq := vrf2387Warnings(t, []string{
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/2 unit 0 family inet address 10.0.0.2/24",
+		"set routing-instances RI-A instance-type virtual-router",
+		"set routing-instances RI-A interface ge-0/0/1.0",
+		"set routing-instances RI-B instance-type virtual-router",
+		"set routing-instances RI-B interface ge-0/0/2.0",
+	})
+	if len(eq) != 1 {
+		t.Fatalf("equal-prefix fixture: want 1 warning, got %d: %v", len(eq), eq)
+	}
+	// 10.0.0.0/24 vs 10.0.0.0/25 overlap but are not equal, so this reaches the
+	// second format string. Assert the arm separation actually held rather than
+	// trusting the fixture: if both fixtures produced the same form, every
+	// "both format strings" claim below would be vacuous.
+	un := vrf2387Warnings(t, []string{
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/2 unit 0 family inet address 10.0.0.2/25",
+		"set routing-instances RI-A instance-type virtual-router",
+		"set routing-instances RI-A interface ge-0/0/1.0",
+		"set routing-instances RI-B instance-type virtual-router",
+		"set routing-instances RI-B interface ge-0/0/2.0",
+	})
+	if len(un) != 1 {
+		t.Fatalf("unequal-overlap fixture: want 1 warning, got %d: %v", len(un), un)
+	}
+	if !strings.Contains(eq[0], "both carry") {
+		t.Fatalf("equal-prefix fixture did not reach the equal-prefix format string: %s", eq[0])
+	}
+	if !strings.Contains(un[0], "carry overlapping L3") {
+		t.Fatalf("unequal fixture did not reach the unequal-overlap format string: %s", un[0])
+	}
+	return eq[0], un[0]
+}
+
+// TestVRFOverlapWarningStatesStatusNotPromise pins that BOTH format strings
+// describe the current limitation and point at the tracking issue, without
+// asserting that any particular fix arrives. Restoring the old "…may
+// cross-forward until the session identity is VRF-aware" wording reds this on
+// the "until" token.
+func TestVRFOverlapWarningStatesStatusNotPromise(t *testing.T) {
+	equal, unequal := vrfOverlapBothFormStrings(t)
+	for _, tc := range []struct {
+		form string
+		warn string
+	}{
+		{"equal-prefix", equal},
+		{"unequal-overlap", unequal},
+	} {
+		lower := strings.ToLower(tc.warn)
+		for _, tok := range vrfOverlapForwardLookingTokens {
+			if strings.Contains(lower, tok) {
+				t.Errorf("%s form promises a fix via %q; #2387 is an open decision, so the warning must state the limitation and point at the issue: %s",
+					tc.form, tok, tc.warn)
+			}
+		}
+		if !strings.Contains(tc.warn, "#2387") {
+			t.Errorf("%s form does not point at the tracking issue: %s", tc.form, tc.warn)
+		}
+	}
+}
+
+// TestVRFOverlapWarningKeepsDiagnosticSubstance is the negative control for
+// TestVRFOverlapWarningStatesStatusNotPromise. Dropping the promise must not
+// cost the operator the diagnosis: the warning still has to say WHAT is wrong
+// (no routing-instance discriminator in the session identity) and WHAT the
+// consequence is (colliding 5-tuples may cross-forward). Without this pair, the
+// forward-looking-token test above is satisfied just as well by deleting the
+// warning text wholesale.
+func TestVRFOverlapWarningKeepsDiagnosticSubstance(t *testing.T) {
+	equal, unequal := vrfOverlapBothFormStrings(t)
+	for _, tc := range []struct {
+		form string
+		warn string
+	}{
+		{"equal-prefix", equal},
+		{"unequal-overlap", unequal},
+	} {
+		for _, want := range []string{
+			"NOT session-isolated",
+			"no routing-instance discriminator",
+			"cross-forward",
+		} {
+			if !strings.Contains(tc.warn, want) {
+				t.Errorf("%s form lost diagnostic substance %q: %s", tc.form, want, tc.warn)
+			}
+		}
 	}
 }

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -341,15 +341,19 @@ limitation, tracked by #2387.
   used to alias too; it is keyed on the LOGICAL (VLAN unit) ingress ifindex
   since `42bc6bc88`, so two units of one parent no longer share a cache
   entry. Only the ifindex-less conntrack table remains.
-- **Interim mitigation + deferred real fix.** The Go compiler emits a
-  commit WARNING (`validateVRFOverlap`, `pkg/config`) when two distinct
-  routing-instances carry overlapping L3 address space, so the operator is
-  told the topology is not session-isolated (the config still commits — an
-  overlapping-subnet PBR VRF is a legitimate working design). The real fix
-  (Track B) adds a **symmetric routing-domain id** to `SessionKey` +
-  `FlowCacheLookup` + the reverse-key transforms — the discriminator MUST
-  be the routing-domain id (symmetric across forward/reply), NOT zone or
-  ingress-ifindex (asymmetric → breaks conntrack reverse matching).
+- **Interim mitigation + candidate real fix (UNDECIDED).** The Go compiler
+  emits a commit WARNING (`validateVRFOverlap`, `pkg/config`) when two
+  distinct routing-instances carry overlapping L3 address space, so the
+  operator is told the topology is not session-isolated (the config still
+  commits — an overlapping-subnet PBR VRF is a legitimate working design).
+  That warning states the limitation and points at #2387; it deliberately
+  does NOT promise a fix, because none is committed to. The candidate fix
+  (Track B) *would* add a **symmetric routing-domain id** to `SessionKey` +
+  `FlowCacheLookup` + the reverse-key transforms — if taken, the
+  discriminator MUST be the routing-domain id (symmetric across
+  forward/reply), NOT zone or ingress-ifindex (asymmetric → breaks conntrack
+  reverse matching). Whether to take it is an open maintainer decision on
+  #2387, not a scheduled change.
 - **The HA session-sync wire does NOT need a version bump** (corrected in
   plan v5 §0a; the plan's own §4d said otherwise). The domain does not have
   to live in the fixed-width wire KEY block — it rides as a length-gated


### PR DESCRIPTION
The `validateVRFOverlap` commit warning told the operator that colliding
5-tuples may cross-forward "until the session identity is VRF-aware". That
asserted an outcome #2387 has not settled — the issue is held on a maintainer
risk-appetite call, and neither candidate end-state (the hard-reject "no
overlapping subnets at all" posture, or the VRF-aware session key) is decided.

It was also **circular**: the #2387 research plan cited the warning text as
evidence that the widening was already the chosen direction, while the warning
itself had been written from the plan's assumption. Neither document
independently supported the conclusion both rested on. This decouples them.

### Scope

Wording only. The warning fires on exactly the same configurations, with the
same severity, and still commits. No runtime behaviour changes.

### Both format strings

`validateVRFOverlap` has two — the equal-prefix form and the unequal-overlap
form. The fixture helper asserts each arm was actually reached (`both carry` vs
`carry overlapping L3`) before asserting on its text: one fixture binds one
match arm, so a "both format strings" claim made from a single fixture would be
vacuous.

### The tests are a pair, not a duplicate

`TestVRFOverlapWarningStatesStatusNotPromise` keeps forward-looking wording out.
`TestVRFOverlapWarningKeepsDiagnosticSubstance` is its **negative control** —
without it, the first test is satisfied just as well by deleting the warning
text wholesale.

### Mutation proof

| Mutation | StatesStatusNotPromise | KeepsDiagnosticSubstance |
|---|---|---|
| baseline | GREEN | GREEN |
| restore `until…VRF-aware` in both format strings | **RED (both arms)** | GREEN |
| strip diagnostic substance, keep no-promise wording | GREEN | **RED** |

Orthogonal both ways — each test binds its own dimension.

A first mutation attempt was a **no-op**: the substitution anchored on the wrong
tab depth, matched nothing, and the suite stayed green — indistinguishable from
a passing guard. Counting applied substitutions before reading the result is
what caught it.

### Validation

- `go test ./pkg/config/ -count=1` — ok (15.9s)
- `go vet ./pkg/config/` — clean
- `gofmt -l` — clean on all three Go files
- post-mutation restore verified byte-identical with `cmp`

Advances #2387 (does not close it — the risk-appetite decision is unchanged and
still the maintainer's call).