### PR TITLE
config: the closed-world comment claimed no subtree was armed; ten are

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-08-05 — #4313: the closed-world comment said no subtree was armed; ten are
+
+- **Timestamp**: 2026-08-05 (fix/4313-closedworld-comment)
+- **Action**: Correct a false claim in the `closedWorld` doc comment. Comment-only.
+- **File(s)**: `pkg/config/schema.go`
+
+`schemaNode.closedWorld` carried "No production subtree sets this yet — the
+per-subtree flips are follow-ups". `git grep -n 'closedWorld: true' pkg/config/`
+returns TEN production subtrees: NAT `then`, `nat64`, `natv6v4`, IKE `proposal`,
+IKE `dead-peer-detection`, IPsec `proposal`, IPsec `dead-peer-detection`,
+`vpn-monitor`, `traffic-selector` (all `schema_security.go`) and
+`master-password` (`schema_system.go`). Six dedicated
+`schema_closedworld_*_4313_test.go` files pin them.
+
+The comment is what a maintainer reads before touching the walker. Believing the
+mechanism inert, they could change `walkSchemaNode`'s keyword-resolution gate
+without realising ten security subtrees already depend on it rejecting.
+
+Fixed by stating that production subtrees DO set it and giving the grep, rather
+than by enumerating them: an enumerated list in a comment drifts the same way
+the count did, and the next reader trusts the list. This matches the reasoning
+already recorded a few lines away in `walkSchemaNode`, which deliberately
+declines to state how many subtrees are armed.
+
+Validation: `go build ./...` rc 0; `go test ./pkg/config/ -count=1` ok;
+`gofmt -l` clean; diff verified comment-only.
+
 ## 2026-08-05 — #6843 round 7: the thesis defect was standing in the module README
 
 - **Timestamp**: 2026-08-05 (fix/3651-zone-prom-surface, PR #6843)

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -98,9 +98,21 @@ type schemaNode struct {
 	// modeled), otherwise it false-rejects a valid-but-not-yet-modeled
 	// config. The flag is threaded down the walker (walkSchemaNode's
 	// `closed` param): once a subtree sets it, every descendant level
-	// inherits closed-world enforcement. No production subtree sets this
-	// yet — the per-subtree flips are follow-ups gated on a leaf-
-	// completeness audit (see docs/config-schema.md).
+	// inherits closed-world enforcement.
+	//
+	// Production subtrees DO set this — it is not an inert mechanism, and
+	// this comment used to say otherwise. Do not deduce the armed set from
+	// prose that rots; find it with
+	//
+	//	git grep -n 'closedWorld: true' pkg/config/
+	//
+	// The armed set is deliberately NOT enumerated here for the same reason
+	// walkSchemaNode declines to state a count: a list in a comment drifts
+	// away from the flags it describes, and the next reader trusts the list.
+	// Remaining flips stay gated on a per-subtree leaf-completeness audit
+	// (see docs/config-schema.md); each is driven per-domain, not as a
+	// blanket change — a blanket flip would break the deliberate
+	// accept-with-advisory knobs (#2078/#4231).
 	closedWorld bool
 
 	// Typed-leaf metadata (#1319). The zero value (valueType==ValueAny,

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -104,7 +104,12 @@ type schemaNode struct {
 	// this comment used to say otherwise. Do not deduce the armed set from
 	// prose that rots; find it with
 	//
-	//	git grep -n 'closedWorld: true' pkg/config/
+	//	git grep -n 'closedWorld: true' -- 'pkg/config/schema_*.go'
+	//
+	// The `schema_*.go` glob is deliberate: it excludes THIS file, so the
+	// command does not match the line you are reading. Dropping it returns
+	// one extra hit — this comment — and a reader counting results would be
+	// off by one against any number stated elsewhere.
 	//
 	// The armed set is deliberately NOT enumerated here for the same reason
 	// walkSchemaNode declines to state a count: a list in a comment drifts


### PR DESCRIPTION
`schemaNode.closedWorld` documented itself as an inert mechanism:

> No production subtree sets this yet — the per-subtree flips are follow-ups gated on a leaf-completeness audit.

**Ten production subtrees set it.** `git grep -n 'closedWorld: true' pkg/config/`:

| Subtree | File |
|---|---|
| NAT `then`, `nat64`, `natv6v4` | `schema_security.go` |
| IKE `proposal`, IKE `dead-peer-detection` | `schema_security.go` |
| IPsec `proposal`, IPsec `dead-peer-detection` | `schema_security.go` |
| `vpn-monitor`, `traffic-selector` | `schema_security.go` |
| `master-password` | `schema_system.go` |

Six dedicated `schema_closedworld_*_4313_test.go` files pin their rejection behaviour.

### Why it matters

This is the comment a maintainer reads before touching the walker. Believing the flag
inert, they could change `walkSchemaNode`'s keyword-resolution gate — the branch turning a
nil schema child into a `typedLeafErrorf` — without realising ten security and reachability
subtrees already depend on it rejecting unmodeled keywords at strict commit.

### Why a grep instead of a list

An enumerated list in a comment drifts exactly the way this claim did, and the next reader
trusts the list. The fix states that production subtrees *do* set it and points at the
grep. That mirrors reasoning already recorded a few lines away in `walkSchemaNode`, which
deliberately declines to state how many subtrees are armed and says why.

### Scope

Comment-only — verified with a non-comment line filter over the Go diff. The remaining
gating is unchanged and still accurate: further flips are per-subtree, contingent on
leaf-completeness, and a blanket flip would break the deliberate accept-with-advisory knobs
(#2078/#4231).

### Validation

- `go build ./...` — rc 0
- `go test ./pkg/config/ -count=1` — ok (15.4s)
- `gofmt -l` — clean

Advances #4313.