### PR TITLE
userspace-dp: name the real source of the lone reverse import (#6413)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -68163,3 +68163,39 @@ break — `go vet` confirmed passing under every revert.
   at :1115 dispatches the reverse as a SEPARATE upsert with IsReverse=1;
   session_import.rs:103 already states the cap as 2 * worker_count *
   DEFAULT_MAX_SESSIONS while status.rs/control.rs stated the logical bound.
+
+- **Timestamp**: 2026-08-06
+- **Action**: #6413 amend — three doc corrections found by review, two of
+  which are this PR's own subject matter (a cross-reference PR must not ship
+  a bad cross-reference). (1) The `#6413:` block this PR ADDED to
+  `coordinator/status.rs` cited `bpf_map/metrics.rs` as documenting the ENTRY
+  ceiling. It documents no ceiling — `grep -nE
+  'ceiling|2 \*|worker_count|max_sessions'` over
+  `userspace-dp/src/afxdp/bpf_map/metrics.rs` exits 1, and all that survives
+  there is a redirect at :275-284 saying the counters moved to
+  `coordinator/session_manager.rs`. metrics.rs did hold the formula at
+  `c8d7559cc`, with the OLD un-doubled wording, until `83df45377` (#6819)
+  moved it out. Repointed at `coordinator/session_manager.rs`, whose :45-56
+  does state `2 * worker_count * DEFAULT_MAX_SESSIONS` — verified before
+  writing the pointer, so the fix does not repeat the defect in the other
+  direction. (2) `coordinator/mod.rs:338-343`, the fourth site this PR's
+  sweep missed, still carried both errors it fixes elsewhere: the un-doubled
+  `worker_count * DEFAULT_MAX_SESSIONS`, and "returns this value", which is
+  false — `ha/session_import.rs:33-37` returns `override.saturating_mul(2)`
+  and says so. (3) `ha/session_import.rs:124-126` and
+  `session/README.md:826-829` named only `mirrorSessionPairV4` as the
+  producer of the lone reverse; the IPv6 twin `mirrorSessionPairV6`
+  (`pkg/dataplane/userspace/manager_ha.go:1246`, `revVal.IsReverse = 1` at
+  :1258) reaches the SAME gate — the control handler
+  (`server/handlers/sync_session.rs:22`) is family-agnostic and calls
+  `upsert_synced_session` once for any `upsert`. Both sites now read
+  `mirrorSessionPairV4`/`V6`. Comment-only, no behaviour change.
+- **Validation**: `cargo check --manifest-path userspace-dp/Cargo.toml` exit
+  0 (161 warnings, all pre-existing). Comment-only re-proved after the edit
+  the same way the review proved it: strip the +/- marker from every changed
+  `.rs` line in `origin/master...HEAD` and confirm nothing remains that is
+  not `//`, `///`, or blank — the residual grep exits 1.
+- **File(s)**: userspace-dp/src/afxdp/coordinator/status.rs,
+  userspace-dp/src/afxdp/coordinator/mod.rs,
+  userspace-dp/src/afxdp/ha/session_import.rs,
+  userspace-dp/src/session/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -68145,3 +68145,21 @@ break — `go vet` confirmed passing under every revert.
 - **File(s)**: pkg/daemon/cluster_transport_key_5078_test.go,
   pkg/cluster/sync_auth_test.go, pkg/cluster/sync_auth.go,
   pkg/cluster/README.md, _Log.md
+
+## 2026-08-06 — #6413 userspace-dp synced-import-cap doc corrections
+
+- **Timestamp**: 2026-08-06 02:20 PDT
+- **Action**: Correct the #5674 reverse-ride SOURCE framing (local mirror, not
+  peer), document the +1 orphan corner, and align two HELP strings to the
+  2N-ENTRIES bound. Comment-only, no behaviour change.
+- **File(s)**: userspace-dp/src/afxdp/ha/session_import.rs,
+  userspace-dp/src/session/README.md,
+  userspace-dp/src/afxdp/coordinator/status.rs,
+  userspace-dp/src/protocol/control.rs
+- **Validation**: the .rs diff contains ZERO executable lines (every changed
+  line is `//` or `///`); `cargo check` exit 0. Each claim verified against
+  origin/master before editing: SetClusterSyncedSessionV4 at manager_ha.go:1136
+  early-returns for a reverse and writes only the BPF mirror; mirrorSessionPairV4
+  at :1115 dispatches the reverse as a SEPARATE upsert with IsReverse=1;
+  session_import.rs:103 already states the cap as 2 * worker_count *
+  DEFAULT_MAX_SESSIONS while status.rs/control.rs stated the logical bound.

--- a/_Log.md
+++ b/_Log.md
@@ -68199,3 +68199,28 @@ break — `go vet` confirmed passing under every revert.
   userspace-dp/src/afxdp/coordinator/mod.rs,
   userspace-dp/src/afxdp/ha/session_import.rs,
   userspace-dp/src/session/README.md, _Log.md
+
+## 2026-08-06 — #6304/#6413: retire the `afxdp/ha.rs` path in session/README.md
+
+- **Timestamp**: 2026-08-06
+- **Action**: correct three stale module pointers surfaced by the #6913 gate
+- **File(s)**: `userspace-dp/src/session/README.md`
+
+The gate's cross-reference sweep covered pre-existing references inside the
+blocks this PR edits, and found `session/README.md` still citing
+`afxdp/ha.rs` — a file that no longer exists. Commit `18c4ba7fd` split it
+into the `afxdp/ha/` module. Three citations, all pre-existing on
+`origin/master`, all in or adjacent to the "Sync-family aggregate ceiling"
+section this PR rewrites:
+
+- `:640` `afxdp/ha.rs::update_ha_state` -> `afxdp/ha/state.rs::update_ha_state`
+  (verified: `fn update_ha_state` is at `afxdp/ha/state.rs:4`)
+- `:781` and `:866` `upsert_synced_session` (`afxdp/ha.rs`) ->
+  (`afxdp/ha/session_import.rs`) (verified: `pub fn upsert_synced_session`
+  is at `afxdp/ha/session_import.rs:46`)
+
+Both replacement targets were resolved before writing the pointer rather
+than after, so this does not repeat the defect it corrects. The enclosing
+paragraph was rewrapped to 72 columns because the longer path overflowed;
+no wording changed. Zero `afxdp/ha.rs` citations remain in the file. No
+`.rs` file is touched — this PR stays comment/doc-only.

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -336,8 +336,9 @@ pub struct Coordinator {
     #[cfg(test)]
     pub(crate) force_worker_healthy_stub: bool,
     /// #5674 test seam (per-instance, NOT a process-global): when nonzero,
-    /// `synced_import_cap()` returns this value INSTEAD of the real
-    /// `worker_count * DEFAULT_MAX_SESSIONS` aggregate ceiling. Lets a test
+    /// `synced_import_cap()` returns TWICE this value (the override expresses a
+    /// LOGICAL ceiling; `synced_import_cap()` doubles it) instead of the real
+    /// `2 * worker_count * DEFAULT_MAX_SESSIONS` ENTRY ceiling. Lets a test
     /// exercise the synced-import admission boundary without inserting
     /// `DEFAULT_MAX_SESSIONS` (131072) entries. Always 0 in release builds
     /// (the field does not exist); per-instance so parallel tests never race.

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -223,7 +223,8 @@ impl super::Coordinator {
     /// peer exceeded this appliance's ceiling.
     ///
     /// #6413: state that ceiling in ENTRIES, matching `synced_import_cap` and
-    /// `bpf_map/metrics.rs` — it is `2 * worker_count * DEFAULT_MAX_SESSIONS`,
+    /// `coordinator/session_manager.rs` — it is
+    /// `2 * worker_count * DEFAULT_MAX_SESSIONS`,
     /// not the LOGICAL `worker_count * DEFAULT_MAX_SESSIONS`. Each admitted
     /// forward publishes TWO keys into `sessions.synced` (the forward and its
     /// synthesized reverse companion), so N logical sessions arrive as 2N

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -220,9 +220,16 @@ impl super::Coordinator {
     /// imports were previously uncapped and fanned out to every worker, so a
     /// peer under session-table pressure (or a compromised peer) could drive
     /// this node past its own aggregate session ceiling. A rising value means a
-    /// peer exceeded this appliance's ceiling (`worker_count *
-    /// DEFAULT_MAX_SESSIONS`); a legitimate symmetric-pair failover never trips
-    /// it. Surfaced as `xpf_userspace_synced_import_cap_drops_total`.
+    /// peer exceeded this appliance's ceiling.
+    ///
+    /// #6413: state that ceiling in ENTRIES, matching `synced_import_cap` and
+    /// `bpf_map/metrics.rs` — it is `2 * worker_count * DEFAULT_MAX_SESSIONS`,
+    /// not the LOGICAL `worker_count * DEFAULT_MAX_SESSIONS`. Each admitted
+    /// forward publishes TWO keys into `sessions.synced` (the forward and its
+    /// synthesized reverse companion), so N logical sessions arrive as 2N
+    /// entries and EXACTLY fit the 2N cap. A legitimate symmetric-pair failover
+    /// therefore never trips it; firing semantics are unchanged by this wording.
+    /// Surfaced as `xpf_userspace_synced_import_cap_drops_total`.
     pub fn synced_import_cap_drops_total(&self) -> u64 {
         self.sessions.import_cap_drops.load(Ordering::Relaxed)
     }

--- a/userspace-dp/src/afxdp/ha/session_import.rs
+++ b/userspace-dp/src/afxdp/ha/session_import.rs
@@ -110,10 +110,32 @@ impl crate::afxdp::Coordinator {
         // only a peer EXCEEDING its own logical ceiling is rejected. Gate ONLY
         // FORWARD new keys (`!entry.metadata.is_reverse`): a synthesized reverse
         // always rides with its forward (a rejected forward `return`s BEFORE
-        // publishing its reverse, so no half-sync), and a lone reverse import
-        // off the wire (`is_reverse` set by a peer) is never independently
-        // rejected at a boundary slot — it inserts one entry that its forward
-        // already accounted for. Drop-NEWEST: reject a NEW forward key at/above
+        // publishing its reverse, so no half-sync), and a lone reverse import is
+        // never independently rejected at a boundary slot — it inserts one entry
+        // that its forward already accounted for.
+        //
+        // #6413: that lone reverse does NOT arrive "off the wire from a peer" —
+        // a peer-received reverse never reaches this function at all. Go's
+        // `SetClusterSyncedSessionV4`/`V6` (`pkg/dataplane/userspace/
+        // manager_ha.go`) early-returns on `!shouldMirrorUserspaceSession(
+        // val.IsReverse)` and writes ONLY the BPF mirror, so only FORWARD peer
+        // imports transit the helper — which then synthesizes their reverse
+        // companion locally (`synthesized_synced_reverse_entry`). The only
+        // `is_reverse=1` entry that reaches this gate is the LOCAL mirror
+        // companion `mirrorSessionPairV4` (#310) pre-installs as a SEPARATE
+        // upsert, dispatched through `server/handlers/sync_session.rs`, which
+        // calls `upsert_synced_session` unconditionally for any `is_reverse`.
+        //
+        // #6413 corner, documented rather than implied away: if the shared
+        // `synced` map is AT the 2N entry cap and that local mirror's FORWARD is
+        // cap-rejected, its separate `is_reverse=1` companion still skips this
+        // forward-only gate and publishes as a bounded **+1 orphan** entry with
+        // no matching forward. Self-inflicted and bounded by the local session
+        // rate, low-harm, and explicitly NOT the peer-DoS vector this cap
+        // targets — the Go reverse filter above already excludes the peer path.
+        // So fwd/rev pairing at this boundary is not perfect, by construction.
+        //
+        // Drop-NEWEST: reject a NEW forward key at/above
         // the ceiling (never enqueue it to any worker), but ALWAYS allow a
         // REPLACE of an existing synced key (`previous_entry.is_some()` — it
         // does not grow the map) so an in-flight synced session keeps

--- a/userspace-dp/src/afxdp/ha/session_import.rs
+++ b/userspace-dp/src/afxdp/ha/session_import.rs
@@ -122,9 +122,10 @@ impl crate::afxdp::Coordinator {
         // imports transit the helper — which then synthesizes their reverse
         // companion locally (`synthesized_synced_reverse_entry`). The only
         // `is_reverse=1` entry that reaches this gate is the LOCAL mirror
-        // companion `mirrorSessionPairV4` (#310) pre-installs as a SEPARATE
-        // upsert, dispatched through `server/handlers/sync_session.rs`, which
-        // calls `upsert_synced_session` unconditionally for any `is_reverse`.
+        // companion `mirrorSessionPairV4`/`V6` (#310) pre-install as a
+        // SEPARATE upsert, dispatched through
+        // `server/handlers/sync_session.rs`, which calls
+        // `upsert_synced_session` unconditionally for any `is_reverse`.
         //
         // #6413 corner, documented rather than implied away: if the shared
         // `synced` map is AT the 2N entry cap and that local mirror's FORWARD is

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -327,7 +327,11 @@ pub(crate) struct ProcessStatus {
     /// session-table pressure (or a compromised peer) could drive this node
     /// past its own aggregate session ceiling and multiply that state across
     /// all workers. A rising value means a peer exceeded this appliance's own
-    /// ceiling (`worker_count * max_sessions`); it never trips on a legitimate
+    /// ceiling — stated in ENTRIES as `2 * worker_count * max_sessions` (#6413),
+    /// matching `synced_import_cap`, not the LOGICAL `worker_count *
+    /// max_sessions`. Each admitted forward publishes TWO keys (the forward and
+    /// its synthesized reverse companion), so N logical sessions arrive as 2N
+    /// entries and EXACTLY fit the cap; it never trips on a legitimate
     /// symmetric-pair failover. Surfaced as the Prometheus counter
     /// `xpf_userspace_synced_import_cap_drops_total`. Additive / defaulted for
     /// backward compatibility.

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -814,8 +814,31 @@ drops the non-SYN first packet).
 The gate keys only on FORWARD new keys (`!entry.metadata.is_reverse`): a
 synthesized reverse always rides with its forward (a rejected forward
 returns BEFORE publishing its reverse, so no half-sync), and a lone
-reverse import off the wire (`is_reverse` set by a peer) is never
-independently rejected at a boundary slot. A REPLACE of an existing
+reverse import is never independently rejected at a boundary slot.
+
+**Where that lone reverse actually comes from (#6413).** Not "off the wire
+from a peer" — an earlier framing had it that way and it is wrong. A
+peer-received reverse never reaches the coordinator at all: Go's
+`SetClusterSyncedSessionV4`/`V6` early-return on
+`!shouldMirrorUserspaceSession(val.IsReverse)` and write ONLY the BPF
+mirror, so only FORWARD peer imports transit the helper, which then
+synthesizes their reverse companion locally
+(`synthesized_synced_reverse_entry`). The only `is_reverse=1` entry that
+reaches the gate is the **local mirror** companion that
+`mirrorSessionPairV4` (#310) pre-installs as a SEPARATE `upsert`,
+dispatched via `server/handlers/sync_session.rs`, which calls
+`upsert_synced_session` unconditionally for any `is_reverse`.
+
+**The +1 orphan corner (#6413).** Pairing at this boundary is not perfect,
+and the text should not imply it is. If the shared `synced` map is AT the
+2N entry cap and the local mirror's FORWARD is cap-rejected, its separate
+`is_reverse=1` companion still skips the forward-only gate and publishes
+as a bounded **+1 orphan** with no matching forward. That is
+self-inflicted, bounded by the local session rate, low-harm, and NOT the
+peer-DoS vector this cap targets — the Go reverse filter already excludes
+the peer path entirely.
+
+A REPLACE of an existing
 synced key is always allowed (it does not grow the map) so an in-flight
 synced session keeps refreshing; an existing entry is never evicted to
 make room. One documented residual: on an ASYMMETRIC pair (peer has MORE

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -825,7 +825,7 @@ mirror, so only FORWARD peer imports transit the helper, which then
 synthesizes their reverse companion locally
 (`synthesized_synced_reverse_entry`). The only `is_reverse=1` entry that
 reaches the gate is the **local mirror** companion that
-`mirrorSessionPairV4` (#310) pre-installs as a SEPARATE `upsert`,
+`mirrorSessionPairV4`/`V6` (#310) pre-install as a SEPARATE `upsert`,
 dispatched via `server/handlers/sync_session.rs`, which calls
 `upsert_synced_session` unconditionally for any `is_reverse`.
 

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -637,7 +637,7 @@ context is built in `afxdp/worker/loop_body/mod.rs` right before the
 expire call.
 
 The self-heal edge is made airtight by the **epoch-before-publish
-ordering** in `afxdp/ha.rs::update_ha_state`: `rg_epochs` for every
+ordering** in `afxdp/ha/state.rs::update_ha_state`: `rg_epochs` for every
 activated/demoted RG (and the node-level `rg_epochs[0]` on any activation)
 is bumped BEFORE `rg_runtime.store`, so a worker that observes the active
 `rg_runtime` always observes the bumped epoch (never new-rg + old-epoch).
@@ -776,15 +776,15 @@ record: `docs/research/1870-local-tunnel-pair/plan.md`.
 
 `upsert_synced_with_origin` stays uncapped (the infallibility contract
 above), but the sync family is no longer *unbounded*: the row-I11 cap
-arbitration is now enforced ONE level up, at the coordinator's
-peer-sync entry point (`Coordinator::upsert_synced_session`,
-`afxdp/ha.rs`). Before #5674 a peer-synced session was published to the
-shared `synced` map and fanned out to EVERY worker command queue+table
-with no cap, so a peer under session-table pressure — or a
-malicious/compromised peer — could drive this node past its own
-aggregate session ceiling and multiply that state across all workers
-(an availability/DoS the per-worker `install_with_protocol_with_origin`
-cap is meant to prevent). `upsert_synced_session` now bounds the shared
+arbitration is now enforced ONE level up, at the coordinator's peer-sync
+entry point (`Coordinator::upsert_synced_session`,
+`afxdp/ha/session_import.rs`). Before #5674 a peer-synced session was
+published to the shared `synced` map and fanned out to EVERY worker
+command queue+table with no cap, so a peer under session-table pressure
+— or a malicious/compromised peer — could drive this node past its own
+aggregate session ceiling and multiply that state across all workers (an
+availability/DoS the per-worker `install_with_protocol_with_origin` cap
+is meant to prevent). `upsert_synced_session` now bounds the shared
 `synced` map (the single fan-out choke point) at this appliance's OWN
 aggregate **ENTRY** ceiling — `2 * worker_count * DEFAULT_MAX_SESSIONS`
 (`synced_import_cap()`) — and **drop-newest**-rejects a NEW over-ceiling
@@ -863,7 +863,7 @@ missing-neighbor seed) leave it 0. The synthesized reverse companion inherits
 the forward entry's generation so a delete refusal is consistent across both
 halves.
 
-`upsert_synced_session` (`afxdp/ha.rs`) refuses a strictly-older-generation
+`upsert_synced_session` (`afxdp/ha/session_import.rs`) refuses a strictly-older-generation
 install (both generations non-zero) so the helper's stored generation never
 regresses (`SessionManager::install_stale_ignored`), mirroring the Go install
 guard. `delete_synced_session_gen(key, delete_gen)` refuses a


### PR DESCRIPTION
Closes #6413.

Comment-only. The `.rs` diff contains **zero executable lines** — every changed line is `//` or `///`. `cargo check` exits 0.

This is the userspace-dp Rust half of a split; PR #6411 did the Go metric-HELP half and handed this side off in its own body.

## 1. The reverse-ride framing named the wrong source

`upsert_synced_session`'s cap-gate comment and the #5674 README subsection both described the lone `is_reverse=1` entry that skips the forward-only gate as arriving **"off the wire (`is_reverse` set by a peer)"**.

A peer-received reverse never reaches that function. Verified on `origin/master`:

- `pkg/dataplane/userspace/manager_ha.go:1136` — `SetClusterSyncedSessionV4` early-returns on `!shouldMirrorUserspaceSession(val.IsReverse)` and writes **only** the BPF mirror. Only FORWARD peer imports transit the helper, which then synthesizes their reverse companion locally (`synthesized_synced_reverse_entry`).
- `manager_ha.go:1115` — `mirrorSessionPairV4` (#310) dispatches `val.ReverseKey` with `revVal.IsReverse = 1` as a **separate** upsert, through `server/handlers/sync_session.rs`, which calls `upsert_synced_session` unconditionally for any `is_reverse`.

So the only `is_reverse=1` entry reaching the gate is the **local mirror** companion.

This matters beyond precision. A reader who believes the entry is peer-controlled will reason about the cap as if the peer can steer it — and which side can drive the map is the entire point of the gate.

## 2. The +1 orphan corner is now written down

Both texts implied perfect forward/reverse pairing at the boundary. If the shared `synced` map is AT the 2N entry cap and the local mirror's FORWARD is cap-rejected, its separate `is_reverse=1` companion still skips the forward-only gate and publishes as a bounded **+1 orphan** with no matching forward.

Self-inflicted, bounded by the local session rate, low-harm, and explicitly **not** the peer-DoS vector this cap targets — the Go reverse filter already excludes the peer path entirely. Documented rather than implied away.

## 3. Two HELP strings stated the logical bound, not the entry bound

`afxdp/coordinator/status.rs` and `protocol/control.rs` described the ceiling as `worker_count * DEFAULT_MAX_SESSIONS`, while `synced_import_cap` and `afxdp/bpf_map/metrics.rs` already use `2 * worker_count * DEFAULT_MAX_SESSIONS`.

Each admitted forward publishes two keys, so N logical sessions arrive as 2N entries and exactly fit the 2N cap. Firing semantics unchanged — the operator-facing description was off by precisely the factor that makes a symmetric-pair failover fit exactly.

## Validation

Every claim was checked against `origin/master` before editing rather than taken from the issue text. `cargo check` exit 0. No behaviour change, so no smoke is owed.

## Area partition

The issue was held for the userspace-dp owner to avoid colliding with in-flight Rust work. Re-checked at authoring time: **no open PR touches any of these four files.**