### PR TITLE
refactor(cos): split the waterfill selector into three named phases (#4408 B′ 3a+3b)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -69932,3 +69932,58 @@ no wording changed. Zero `afxdp/ha.rs` citations remain in the file. No
   `nm` at 0x1eb and the Tier-1 diff reports the new edge — the gate is
   watched failing, not assumed.
 - **File(s)**: userspace-dp/src/afxdp/cos/queue_service/mod.rs, _Log.md
+
+## 2026-08-06 — #4408 increment 3b: split the waterfill's two selection walks
+
+- **Timestamp**: 2026-08-06
+- **Action**: Extract the Phase-1 ascending walk and the Phase-2
+  descending residual walk into `waterfill_phase1_select` /
+  `waterfill_phase2_select`, both `#[inline(always)]` and same-module,
+  leaving `select_exact_cos_guarantee_queue_waterfill` a 59-line
+  orchestrator (from 432) over refill -> Phase 1 -> Phase 2 -> wrap
+  tail. Pure motion: 175 + 108 moved lines diff clean against master's
+  `:1094-1268` and `:1280-1387` after stripping leading whitespace.
+  `Option` is a faithful encoding, not an invented protocol — every
+  non-selecting exit of each walk already converged on the same
+  successor in the original body.
+- **Finding (the reason this took a second pass)**: the plan's §7.2
+  mutation grid caught that `waterfill_phase2_select` was **completely
+  unbound**. Both prescribed cells — M5 "Phase 2 ignores the honored
+  bitset" and M6 "Phase 2 resets the cursor on each entry" — left the
+  full waterfill + refund suite GREEN. Every pre-existing fixture enters
+  Phase 2 with the largest class UN-honored (Phase 1 walks ascending and
+  runs out of budget before reaching it), so the descending walk lands
+  on an eligible queue at cursor 0 and neither the honored-skip nor the
+  cursor arithmetic is ever exercised. Two tests now bind it, built on a
+  fixture that honors the LARGEST class first by emptying the two small
+  queues so Phase 1 skips them, then refilling them so the next call
+  breaks into Phase 2 with ordinal bit 2 set.
+- **Validation**: 6-of-6 mutation grid, each cell a NAMED failing test
+  with an ASSERTION (never a build break), plus a negative control.
+  M1 (drop the `epoch_boundary` gate) REDs
+  `waterfill_exact_fit_honor_does_not_livelock_phase1`; M2 (reset the
+  cursor in the refill) REDs
+  `waterfill_exhausted_refill_does_not_reset_phase2_cursor` — "the
+  exhausted refill path must PRESERVE the Phase-2 cursor"; M3 (drop the
+  honored-bit set) REDs 8 tests incl. the #1732 distribution test; M4
+  (charge `send_budget` not `phase1_cost`) REDs 5 incl.
+  `waterfill_phase1_honor_charge_is_configured_quantum_not_tokens`;
+  M5 REDs both new Phase-2 tests; M6 REDs ONLY
+  `waterfill_phase2_cursor_resumes_instead_of_restarting_at_the_largest`
+  — "Phase 2 must RESUME the descending walk from the stored cursor",
+  left 1 right 0 — so the two new tests discriminate rather than
+  restate each other. The negative control (hoisting the
+  `waterfill_epochs` bump earlier inside the same block, semantically
+  null) stays GREEN, so the grid measures the code rather than
+  reporting "everything fails".
+- **Codegen**: raw zero-normalisation Tier-1 call-edge sets unchanged on
+  `service_exact_guarantee_queue_direct_with_info` (32 edges) and on the
+  untouched `enqueue_pending_forwards` control (51 edges).
+  `service_exact_guarantee_queue_direct_with_info` grows 0x619b ->
+  0x61cf (+52 B, +0.21%) with an identical call-edge set — scheduling
+  drift, not a new or lost callee. Negative control fires for all three
+  helpers. Three whole-binary residuals in modules this PR does not
+  open are classified in the PR body.
+- **File(s)**: userspace-dp/src/afxdp/cos/queue_service/mod.rs,
+  userspace-dp/src/afxdp/cos/queue_service/tests/waterfill.rs,
+  docs/cos-validation-notes.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -69899,3 +69899,36 @@ no wording changed. Zero `afxdp/ha.rs` citations remain in the file. No
   pkg/cluster/sync_conn_gen.go, pkg/cluster/sync_conn_read.go,
   pkg/cluster/sync_config_gen_reset_race_5084_test.go,
   pkg/cluster/README.md, docs/sync-protocol.md, _Log.md
+
+## 2026-08-06 — #4408 increment 3a: lift the waterfill epoch refill (Option B')
+
+- **Timestamp**: 2026-08-06
+- **Action**: Extract the Phase-1 epoch refill out of
+  `select_exact_cos_guarantee_queue_waterfill` into
+  `refill_waterfill_epoch(root, now_ns)`, `#[inline(always)]`, same
+  module. Pure motion: the 74 moved lines diff clean against master's
+  `:1000-1073` once leading whitespace is stripped, and the only
+  non-motion edit is the doc comment de-indenting from `    //` to `//`
+  as it becomes the helper's header. The block stays ATOMIC — the order
+  of the `waterfill_epochs` bump, the `epoch_boundary`-gated
+  honored-bitset clear, and `waterfill_epoch_wrap_pending = false` is
+  the #1743 r3 livelock fix, and the helper's header says so.
+- **Scope honesty**: this does NOT move the committed modularity metric.
+  `docs/refactoring-audit-current.txt` gates on file set and tier;
+  `queue_service/mod.rs` was 2166 `[REFACTOR]` and stays above the 2000
+  floor, so the tier is unchanged and `TestHeatmapNotStale` neither
+  fires nor needs a regenerated artifact (`go test
+  ./pkg/refactoraudit/...` ok). The value is reviewability of a state
+  machine, and nothing else.
+- **Validation**: call-edge baseline REGENERATED at this head, not
+  inherited from the plan (`docs/research/4408-hotpath-split/plan.md`
+  §2's artifacts are from `dd23119aa`). Raw, zero-normalisation Tier 1
+  on `service_exact_guarantee_queue_direct_with_info` (the symbol the
+  waterfill inlines into) — 32 edges, diff exit 0; on the untouched
+  `enqueue_pending_forwards` control — 51 edges, diff exit 0. `nm`:
+  neither the waterfill nor `refill_waterfill_epoch` is present, and
+  `service_exact_guarantee_queue_direct_with_info` holds at 0x619b.
+  Negative control: flipping the helper to `#[inline(never)]` puts it in
+  `nm` at 0x1eb and the Tier-1 diff reports the new edge — the gate is
+  watched failing, not assumed.
+- **File(s)**: userspace-dp/src/afxdp/cos/queue_service/mod.rs, _Log.md

--- a/docs/cos-validation-notes.md
+++ b/docs/cos-validation-notes.md
@@ -514,6 +514,23 @@ queue-ownership fragmentation + the Phase-1/Phase-2 split — empirically
 visible. They are **diagnostic only**: the scheduler reads none of them,
 and they are zero on the default Proportional (legacy RR) path.
 
+Since #4408 that selector is an orchestrator over three named phases in
+`userspace-dp/src/afxdp/cos/queue_service/mod.rs`, which is where each
+counter below is actually bumped:
+
+| Phase fn | Counters it bumps |
+|---|---|
+| `refill_waterfill_epoch` | `epochs` |
+| `waterfill_phase1_select` | `phase1_admit`, `phase1_budget_breaks`, and the Phase-1 half of `eligible_visits` |
+| `waterfill_phase2_select` | `phase2_admit` and the Phase-2 half of `eligible_visits` |
+
+`phase1_no_progress` belongs to none of the three: it is bumped — and
+`phase1_admit` correspondingly decremented — by
+`apply_phase1_waterfill_honor_refund`, which
+`service_exact_guarantee_queue_direct_with_info` invokes after a Phase-1
+honor that transmitted zero bytes. The #4408 split was pure motion; no
+counter semantics changed.
+
 ```
 show class-of-service interface reth0.80
   ...

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -980,26 +980,87 @@ fn select_exact_cos_guarantee_queue_waterfill(
     // epoch-boundary gate on the honored bitset, and the #1743 r2/r3
     // ordering hazard that keeps that block atomic.
     refill_waterfill_epoch(root, now_ns);
-    // Phase 1: ascending-rate walk. Pick the first runnable queue
-    // whose secondary_budget ≤ pass1_remaining that has NOT already been
-    // honored this epoch.
-    //
-    // #1732: the honored set is the persistent `waterfill_honored_epoch_bits`
-    // on `root`, keyed by the ASCENDING-VEC ORDINAL `i` (NOT `queue_idx`).
-    // It is read by BOTH phases and cleared at the epoch refill above, so
-    // each queue is honored at most once per epoch: without the Phase-1 skip
-    // the smallest-rate queue would be re-honored on every selector call and
-    // monopolise the Phase-1 budget (the lowest-rate skew this fix targets).
-    // Iterating by index over the persistent vec avoids the per-call heap
-    // clone the old code used solely to dodge the `&mut root.queues` borrow
-    // conflict; `queue_idx` is copied out (a `Copy` `usize`) before the
-    // `&mut` borrow, so borrow-split holds with no allocation.
     let ascending_len = root.exact_queues_by_rate_ascending.len();
     debug_assert!(
         ascending_len <= 64,
         "waterfill honored bitset is u64; >64 exact guarantee queues on one \
          interface is unsupported (ordinal bit range overflow)"
     );
+    // Phase 1: ascending-rate walk (#4408 Increment 3b). `None` means
+    // "budget exhausted or nothing eligible" — both of the original body's
+    // non-selecting Phase-1 exits — and falls through to Phase 2.
+    if let Some(selection) = waterfill_phase1_select(
+        root,
+        queue_fast_path,
+        now_ns,
+        lease_telemetry,
+        queue_count,
+        ascending_len,
+    ) {
+        return Some(selection);
+    }
+    // Phase 2: descending-rate residual walk (#4408 Increment 3b). `None`
+    // means the descending cycle serviced nothing, which is the genuine
+    // Phase-2 WRAP handled by the tail below.
+    if let Some(selection) = waterfill_phase2_select(
+        root,
+        queue_fast_path,
+        now_ns,
+        lease_telemetry,
+        queue_count,
+        ascending_len,
+    ) {
+        return Some(selection);
+    }
+    // Genuine Phase-2 WRAP: a full descending cycle serviced nothing, so the
+    // epoch is fully consumed. Reset the Phase-1 budget and the cursor for
+    // the next call, and arm `epoch_wrap_pending` so the refill above clears
+    // the honored bitset (a true epoch boundary). #1743 (Codex r3): this is
+    // the ONLY place that arms the honored-bits clear besides the time tick —
+    // a bare mid-walk `pass1 == 0` does not, which avoids the all-min-quantum
+    // re-honor livelock.
+    root.waterfill_pass1_remaining_bytes = 0;
+    root.waterfill_phase2_cursor = 0;
+    root.waterfill_epoch_wrap_pending = true;
+    None
+}
+
+// Phase 1: ascending-rate walk. Pick the first runnable queue
+// whose secondary_budget ≤ pass1_remaining that has NOT already been
+// honored this epoch.
+//
+// #1732: the honored set is the persistent `waterfill_honored_epoch_bits`
+// on `root`, keyed by the ASCENDING-VEC ORDINAL `i` (NOT `queue_idx`).
+// It is read by BOTH phases and cleared at the epoch refill above, so
+// each queue is honored at most once per epoch: without the Phase-1 skip
+// the smallest-rate queue would be re-honored on every selector call and
+// monopolise the Phase-1 budget (the lowest-rate skew this fix targets).
+// Iterating by index over the persistent vec avoids the per-call heap
+// clone the old code used solely to dodge the `&mut root.queues` borrow
+// conflict; `queue_idx` is copied out (a `Copy` `usize`) before the
+// `&mut` borrow, so borrow-split holds with no allocation.
+//
+// #4408 Increment 3b: lifted verbatim out of
+// `select_exact_cos_guarantee_queue_waterfill`. Every non-selecting exit of
+// this walk — the `break` and loop exhaustion alike — already converged on
+// the SAME successor in the original body, so `None` encodes them faithfully
+// rather than inventing an outcome protocol. `#[inline(always)]` +
+// same-module keeps the post-inline IR the shape it was (plan §2d); no
+// coldness claim is made or needed.
+//
+// The interior of this walk is NOT further decomposable: `queue`'s `&mut`
+// borrow of `root.queues` coexists with reads of the disjoint `root.tokens`
+// and then ends so `count_park_reason`/`park_cos_queue` can take `&mut root`
+// whole. That is NLL-precise; splitting inside would have to re-derive it.
+#[inline(always)]
+fn waterfill_phase1_select(
+    root: &mut CoSInterfaceRuntime,
+    queue_fast_path: &[WorkerCoSQueueFastPath],
+    now_ns: u64,
+    lease_telemetry: &mut CoSQueueLeaseAcquireTelemetry,
+    queue_count: usize,
+    ascending_len: usize,
+) -> Option<ExactCoSQueueSelection> {
     for i in 0..ascending_len {
         let queue_idx = root.exact_queues_by_rate_ascending[i];
         // #1732: at-most-once Phase-1 honor per epoch. Skip a queue already
@@ -1175,17 +1236,37 @@ fn select_exact_cos_guarantee_queue_waterfill(
             }),
         });
     }
-    // Phase 2: descending-rate walk over queues NOT honored in Phase 1
-    // this epoch.
-    //
-    // #1732: this reads the SAME persistent `waterfill_honored_epoch_bits`
-    // that Phase 1 sets, keyed by the ascending-vec ORDINAL `pos_from_end`,
-    // so it correctly skips queues that already took their Phase-1 guarantee
-    // this epoch and serves the residual to the larger un-honored queues —
-    // the documented descending-residual intent. (Previously this checked an
-    // empty function-local `honored_mask`, which is why the old comment here
-    // admitted it only "approximated".) Iterating `exact_queues_by_rate_
-    // ascending` by index avoids the heap clone the old code used.
+    None
+}
+
+// Phase 2: descending-rate walk over queues NOT honored in Phase 1
+// this epoch.
+//
+// #1732: this reads the SAME persistent `waterfill_honored_epoch_bits`
+// that Phase 1 sets, keyed by the ascending-vec ORDINAL `pos_from_end`,
+// so it correctly skips queues that already took their Phase-1 guarantee
+// this epoch and serves the residual to the larger un-honored queues —
+// the documented descending-residual intent. (Previously this checked an
+// empty function-local `honored_mask`, which is why the old comment here
+// admitted it only "approximated".) Iterating `exact_queues_by_rate_
+// ascending` by index avoids the heap clone the old code used.
+//
+// #4408 Increment 3b: lifted verbatim out of
+// `select_exact_cos_guarantee_queue_waterfill`. Every non-selecting exit of
+// this walk — the `break` and loop exhaustion alike — already converged on
+// the SAME successor in the original body, so `None` encodes them faithfully
+// rather than inventing an outcome protocol. `#[inline(always)]` +
+// same-module keeps the post-inline IR the shape it was (plan §2d); no
+// coldness claim is made or needed.
+#[inline(always)]
+fn waterfill_phase2_select(
+    root: &mut CoSInterfaceRuntime,
+    queue_fast_path: &[WorkerCoSQueueFastPath],
+    now_ns: u64,
+    lease_telemetry: &mut CoSQueueLeaseAcquireTelemetry,
+    queue_count: usize,
+    ascending_len: usize,
+) -> Option<ExactCoSQueueSelection> {
     let mut phase2_idx = root.waterfill_phase2_cursor;
     if phase2_idx >= ascending_len {
         phase2_idx = 0;
@@ -1294,16 +1375,6 @@ fn select_exact_cos_guarantee_queue_waterfill(
             phase1_honor: None,
         });
     }
-    // Genuine Phase-2 WRAP: a full descending cycle serviced nothing, so the
-    // epoch is fully consumed. Reset the Phase-1 budget and the cursor for
-    // the next call, and arm `epoch_wrap_pending` so the refill above clears
-    // the honored bitset (a true epoch boundary). #1743 (Codex r3): this is
-    // the ONLY place that arms the honored-bits clear besides the time tick —
-    // a bare mid-walk `pass1 == 0` does not, which avoids the all-min-quantum
-    // re-honor livelock.
-    root.waterfill_pass1_remaining_bytes = 0;
-    root.waterfill_phase2_cursor = 0;
-    root.waterfill_epoch_wrap_pending = true;
     None
 }
 

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -975,102 +975,11 @@ fn select_exact_cos_guarantee_queue_waterfill(
     if queue_count == 0 || root.exact_queues_by_rate_ascending.is_empty() {
         return None;
     }
-    // Phase 1 epoch refill. The BUDGET is refilled on two triggers:
-    //   (a) `pass1 == 0` — budget spent. Covers both the genuine Phase-2
-    //       wrap (the `None` path zeroes pass1 and arms wrap-pending) and a
-    //       mid-walk Phase-1 exact-fit honor that subtracted the last bytes.
-    //       Also the first-call path (pass1 seeds to 0 in the builder).
-    //   (b) #1743 time-based: `elapsed >= COS_GUARANTEE_VISIT_NS` since the
-    //       last refill. Phase-2 selections do NOT decrement `pass1`, so
-    //       under saturation `pass1` freezes at a small non-zero value below
-    //       every remaining quantum and small classes stop being honored;
-    //       the time tick refreshes the budget once per 200µs window.
-    //
-    // The honored BITSET, however, is cleared (allowing re-honoring) ONLY on
-    // a genuine epoch boundary: the time tick OR a Phase-2 WRAP
-    // (`waterfill_epoch_wrap_pending`). #1743 r3: a bare mid-walk `pass1 == 0`
-    // refills the budget but must NOT clear the bits, else an all-min-quantum
-    // exact-fit config livelocks Phase 1 on q0 and never reaches Phase 2.
-    //
-    // CRITICAL: NEITHER refill path resets `waterfill_phase2_cursor`
-    // (#1743 r2 — only the genuine Phase-2 wrap at the end-of-function `None`
-    // path does) so the descending RR walk advances through ALL large classes
-    // across epochs rather than restarting at the largest (the
-    // residual-starvation regression #1630 r4 caught).
-    let elapsed_since_refresh = now_ns.saturating_sub(root.waterfill_epoch_start_ns);
-    let time_refresh = elapsed_since_refresh >= COS_GUARANTEE_VISIT_NS;
-    let exhausted = root.waterfill_pass1_remaining_bytes == 0;
-    if time_refresh || exhausted {
-        // fraction is clamped 0.0..1.0 at config-apply time; the
-        // dispatch gate also requires fraction > 0. We use f64 → u64
-        // with a floor + saturating cast guarded by the multiplication.
-        let frac = root.oversubscription_guarantee_fraction;
-        let raw_pass1 = if root.shaping_rate_bytes == 0 {
-            // Transparent (unshaped) root: there is no shaper-delivered
-            // cap to anchor against, so fall back to the legacy
-            // `quantum_sum × fraction` over the current eligible set.
-            // The result fits in u64 because quantum_sum ≤ 512 KB ×
-            // N_queues and fraction ≤ 1.0.
-            let mut quantum_sum: u64 = 0;
-            for &qi in &root.exact_queues_by_rate_ascending {
-                quantum_sum =
-                    quantum_sum.saturating_add(cos_guarantee_quantum_bytes(&root.queues[qi]));
-            }
-            ((quantum_sum as f64) * frac).floor() as u64
-        } else {
-            // #1743 Hunk A: anchor pass1 to the shaper-delivered bytes
-            // per epoch × fraction — the documented contract "fraction ×
-            // cap" where cap = shaper × VISIT_NS (docs/fairness-regimes.md).
-            // The legacy `quantum_sum × fraction` over-provisioned pass1
-            // by ~4× for any oversubscribed config (Σ R_i > shaper), so
-            // Phase 2 never fired and the selector degenerated to
-            // ascending RR over all classes. shaping_rate_bytes is
-            // bytes/sec; the u128 product is overflow-safe.
-            let cap_per_epoch = ((root.shaping_rate_bytes as u128)
-                * (COS_GUARANTEE_VISIT_NS as u128)
-                / 1_000_000_000u128) as u64;
-            ((cap_per_epoch as f64) * frac).floor() as u64
-        };
-        // AGY RISK-1 (Codex code-r1 #2): a tiny-positive fraction floors
-        // `raw_pass1` to 0 on EITHER branch — the dispatch gate admits any
-        // `fraction > 0`, including transparent + tiny-fraction. A zero
-        // budget makes `exhausted` true on every selector call → refill +
-        // cursor-reset thrash → Phase-2 starves from index 0. Clamp BOTH
-        // branches to at least one min-quantum so the smallest class is
-        // honorable and the exhausted path can't fire every call. (The
-        // clamp is a no-op for normal fractions where raw_pass1 already
-        // exceeds the smallest quantum.)
-        let pass1 = raw_pass1.max(COS_GUARANTEE_QUANTUM_MIN_BYTES);
-        root.waterfill_pass1_remaining_bytes = pass1;
-        root.waterfill_epoch_start_ns = now_ns;
-        // #1743 (Codex code-r3): clear the persistent honored bitset ONLY on
-        // a genuine epoch boundary — the time tick OR a Phase-2 WRAP
-        // (`waterfill_epoch_wrap_pending`, set by the end-of-function `None`
-        // path). A bare `exhausted` (pass1 == 0) that did NOT come from a
-        // wrap — e.g. a Phase-1 exact-fit honor that subtracted the last
-        // bytes mid-walk — must NOT clear the bits: clearing there re-enabled
-        // a degenerate all-min-quantum livelock where q0 is honored, pass1
-        // hits 0, the next call clears its bit, q0 is re-honored, and Phase 2
-        // is never reached. With the bits intact, the already-honored small
-        // queue is skipped (the `i < 64` check below), so the walk advances
-        // to the next queue or breaks to Phase 2 — guaranteeing forward
-        // progress. The budget is still refilled on a bare `exhausted` so
-        // Phase 1 can resume against the un-honored queues.
-        let epoch_boundary = time_refresh || root.waterfill_epoch_wrap_pending;
-        if epoch_boundary {
-            root.waterfill_honored_epoch_bits = 0;
-        }
-        root.waterfill_epoch_wrap_pending = false;
-        // #1743 (Codex code-r2): the refill never resets the Phase-2 cursor.
-        // The cursor's ONLY reset is the genuine Phase-2 WRAP at the
-        // end-of-function `None` path (which also re-arms epoch_wrap_pending),
-        // so the descending walk advances continuously across epochs — the
-        // #1630 r4 continuity invariant.
-        //
-        // #1628 site 1: completed-epoch / Phase-1-refill counter. Bumped
-        // here (no `queue` borrowed yet) on every refill, either trigger.
-        root.waterfill_epochs = root.waterfill_epochs.wrapping_add(1);
-    }
+    // Phase 1 epoch refill (#4408 Increment 3a). See
+    // `refill_waterfill_epoch` for the two refill triggers, the
+    // epoch-boundary gate on the honored bitset, and the #1743 r2/r3
+    // ordering hazard that keeps that block atomic.
+    refill_waterfill_epoch(root, now_ns);
     // Phase 1: ascending-rate walk. Pick the first runnable queue
     // whose secondary_budget ≤ pass1_remaining that has NOT already been
     // honored this epoch.
@@ -1396,6 +1305,118 @@ fn select_exact_cos_guarantee_queue_waterfill(
     root.waterfill_phase2_cursor = 0;
     root.waterfill_epoch_wrap_pending = true;
     None
+}
+
+// Phase 1 epoch refill. The BUDGET is refilled on two triggers:
+//   (a) `pass1 == 0` — budget spent. Covers both the genuine Phase-2
+//       wrap (the `None` path zeroes pass1 and arms wrap-pending) and a
+//       mid-walk Phase-1 exact-fit honor that subtracted the last bytes.
+//       Also the first-call path (pass1 seeds to 0 in the builder).
+//   (b) #1743 time-based: `elapsed >= COS_GUARANTEE_VISIT_NS` since the
+//       last refill. Phase-2 selections do NOT decrement `pass1`, so
+//       under saturation `pass1` freezes at a small non-zero value below
+//       every remaining quantum and small classes stop being honored;
+//       the time tick refreshes the budget once per 200µs window.
+//
+// The honored BITSET, however, is cleared (allowing re-honoring) ONLY on
+// a genuine epoch boundary: the time tick OR a Phase-2 WRAP
+// (`waterfill_epoch_wrap_pending`). #1743 r3: a bare mid-walk `pass1 == 0`
+// refills the budget but must NOT clear the bits, else an all-min-quantum
+// exact-fit config livelocks Phase 1 on q0 and never reaches Phase 2.
+//
+// CRITICAL: NEITHER refill path resets `waterfill_phase2_cursor`
+// (#1743 r2 — only the genuine Phase-2 wrap at the end-of-function `None`
+// path does) so the descending RR walk advances through ALL large classes
+// across epochs rather than restarting at the largest (the
+// residual-starvation regression #1630 r4 caught).
+//
+// #4408 Increment 3a: lifted verbatim out of
+// `select_exact_cos_guarantee_queue_waterfill` so the selector reads as
+// three named phases rather than one 432-line body. This block MUST stay
+// atomic: the order of the `waterfill_epochs` bump, the
+// `epoch_boundary`-gated honored-bitset clear, and the
+// `waterfill_epoch_wrap_pending = false` reset IS the #1743 r3 livelock
+// fix. Do not split it further into "compute budget" + "clear bits".
+//
+// `#[inline(always)]` + same-module is deliberate: the post-inline IR is
+// by construction the shape it was before the split, so no coldness claim
+// is made or needed (plan §2d).
+#[inline(always)]
+fn refill_waterfill_epoch(root: &mut CoSInterfaceRuntime, now_ns: u64) {
+    let elapsed_since_refresh = now_ns.saturating_sub(root.waterfill_epoch_start_ns);
+    let time_refresh = elapsed_since_refresh >= COS_GUARANTEE_VISIT_NS;
+    let exhausted = root.waterfill_pass1_remaining_bytes == 0;
+    if time_refresh || exhausted {
+        // fraction is clamped 0.0..1.0 at config-apply time; the
+        // dispatch gate also requires fraction > 0. We use f64 → u64
+        // with a floor + saturating cast guarded by the multiplication.
+        let frac = root.oversubscription_guarantee_fraction;
+        let raw_pass1 = if root.shaping_rate_bytes == 0 {
+            // Transparent (unshaped) root: there is no shaper-delivered
+            // cap to anchor against, so fall back to the legacy
+            // `quantum_sum × fraction` over the current eligible set.
+            // The result fits in u64 because quantum_sum ≤ 512 KB ×
+            // N_queues and fraction ≤ 1.0.
+            let mut quantum_sum: u64 = 0;
+            for &qi in &root.exact_queues_by_rate_ascending {
+                quantum_sum =
+                    quantum_sum.saturating_add(cos_guarantee_quantum_bytes(&root.queues[qi]));
+            }
+            ((quantum_sum as f64) * frac).floor() as u64
+        } else {
+            // #1743 Hunk A: anchor pass1 to the shaper-delivered bytes
+            // per epoch × fraction — the documented contract "fraction ×
+            // cap" where cap = shaper × VISIT_NS (docs/fairness-regimes.md).
+            // The legacy `quantum_sum × fraction` over-provisioned pass1
+            // by ~4× for any oversubscribed config (Σ R_i > shaper), so
+            // Phase 2 never fired and the selector degenerated to
+            // ascending RR over all classes. shaping_rate_bytes is
+            // bytes/sec; the u128 product is overflow-safe.
+            let cap_per_epoch = ((root.shaping_rate_bytes as u128)
+                * (COS_GUARANTEE_VISIT_NS as u128)
+                / 1_000_000_000u128) as u64;
+            ((cap_per_epoch as f64) * frac).floor() as u64
+        };
+        // AGY RISK-1 (Codex code-r1 #2): a tiny-positive fraction floors
+        // `raw_pass1` to 0 on EITHER branch — the dispatch gate admits any
+        // `fraction > 0`, including transparent + tiny-fraction. A zero
+        // budget makes `exhausted` true on every selector call → refill +
+        // cursor-reset thrash → Phase-2 starves from index 0. Clamp BOTH
+        // branches to at least one min-quantum so the smallest class is
+        // honorable and the exhausted path can't fire every call. (The
+        // clamp is a no-op for normal fractions where raw_pass1 already
+        // exceeds the smallest quantum.)
+        let pass1 = raw_pass1.max(COS_GUARANTEE_QUANTUM_MIN_BYTES);
+        root.waterfill_pass1_remaining_bytes = pass1;
+        root.waterfill_epoch_start_ns = now_ns;
+        // #1743 (Codex code-r3): clear the persistent honored bitset ONLY on
+        // a genuine epoch boundary — the time tick OR a Phase-2 WRAP
+        // (`waterfill_epoch_wrap_pending`, set by the end-of-function `None`
+        // path). A bare `exhausted` (pass1 == 0) that did NOT come from a
+        // wrap — e.g. a Phase-1 exact-fit honor that subtracted the last
+        // bytes mid-walk — must NOT clear the bits: clearing there re-enabled
+        // a degenerate all-min-quantum livelock where q0 is honored, pass1
+        // hits 0, the next call clears its bit, q0 is re-honored, and Phase 2
+        // is never reached. With the bits intact, the already-honored small
+        // queue is skipped (the `i < 64` check below), so the walk advances
+        // to the next queue or breaks to Phase 2 — guaranteeing forward
+        // progress. The budget is still refilled on a bare `exhausted` so
+        // Phase 1 can resume against the un-honored queues.
+        let epoch_boundary = time_refresh || root.waterfill_epoch_wrap_pending;
+        if epoch_boundary {
+            root.waterfill_honored_epoch_bits = 0;
+        }
+        root.waterfill_epoch_wrap_pending = false;
+        // #1743 (Codex code-r2): the refill never resets the Phase-2 cursor.
+        // The cursor's ONLY reset is the genuine Phase-2 WRAP at the
+        // end-of-function `None` path (which also re-arms epoch_wrap_pending),
+        // so the descending walk advances continuously across epochs — the
+        // #1630 r4 continuity invariant.
+        //
+        // #1628 site 1: completed-epoch / Phase-1-refill counter. Bumped
+        // here (no `queue` borrowed yet) on every refill, either trigger.
+        root.waterfill_epochs = root.waterfill_epochs.wrapping_add(1);
+    }
 }
 
 // Selects the next non-exact guarantee queue for service. Rotates

--- a/userspace-dp/src/afxdp/cos/queue_service/tests/waterfill.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests/waterfill.rs
@@ -787,3 +787,128 @@ fn waterfill_exact_fit_honor_does_not_livelock_phase1() {
     );
 }
 
+
+/// Drives Phase 2 to a state the pre-#4408 suite never reached: a
+/// descending walk whose FIRST candidate is a queue Phase 1 already
+/// honored this epoch.
+///
+/// Every prior waterfill fixture enters Phase 2 with the largest class
+/// un-honored (Phase 1 walks ascending and runs out of budget before it),
+/// so the cursor starts at 0, lands on the largest, and selects it —
+/// Phase 2's honored-skip and its cursor arithmetic are never exercised.
+/// The #4408 mutation grid caught that: removing Phase 2's honored check
+/// and forcing its cursor to 0 both left the whole suite GREEN.
+///
+/// The trick is to honor the LARGEST class first by making the two small
+/// ones momentarily empty, then refill them:
+///   - fraction 0.7 over quantum_sum 37500 -> Phase-1 budget 26250
+///   - q0/q1 empty, so Phase 1 skips both and honors q2 (cost 25000),
+///     leaving 1250 and ordinal bit 2 set
+///   - refill q0/q1; the next call cannot honor q0 (2500 > 1250), so
+///     Phase 1 breaks and Phase 2 runs with the largest class HONORED
+///
+/// Same tick throughout (`now_ns = 1`), so no time refresh clears the
+/// bitset and no bare-exhausted refill fires (1250 != 0).
+fn waterfill_phase2_root_with_largest_honored() -> (CoSInterfaceRuntime, CoSQueueLeaseAcquireTelemetry)
+{
+    let mut root = waterfill_three_unequal_exact_root(0.7);
+    let mut tel = CoSQueueLeaseAcquireTelemetry::default();
+
+    for idx in [0usize, 1usize] {
+        root.queues[idx].hot.items.clear();
+        root.queues[idx].hot.queued_bytes = 0;
+    }
+
+    let first = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel)
+        .expect("Phase 1 honors the only backlogged class");
+    assert_eq!(
+        first.queue_idx, 2,
+        "precondition: with q0/q1 empty, Phase 1 must honor the LARGEST class"
+    );
+    assert_eq!(
+        root.waterfill_honored_epoch_bits & 0b100,
+        0b100,
+        "precondition: ordinal 2 is marked Phase-1-honored"
+    );
+    assert_eq!(
+        root.waterfill_pass1_remaining_bytes, 1250,
+        "precondition: 26250 - 25000 leaves less than q0's 2500 quantum, so \
+         the next call breaks Phase 1 into Phase 2"
+    );
+
+    for idx in [0usize, 1usize] {
+        for _ in 0..8 {
+            root.queues[idx].hot.items.push_back(test_cos_item(1500));
+        }
+        root.queues[idx].hot.queued_bytes = 8 * 1500;
+    }
+    (root, tel)
+}
+
+#[test]
+fn waterfill_phase2_skips_a_queue_honored_in_phase1() {
+    // #1732 via #4408: Phase 2 reads the SAME persistent honored bitset
+    // Phase 1 sets, so a class that already took its Phase-1 guarantee this
+    // epoch must NOT also collect the descending residual. The walk starts
+    // at the largest (cursor 0 -> pos_from_end 2 -> q2), which IS honored,
+    // so the correct selection is the next un-honored class down, q1.
+    let (mut root, mut tel) = waterfill_phase2_root_with_largest_honored();
+
+    let second = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel)
+        .expect("Phase 2 residual selection");
+
+    assert_eq!(
+        second.queue_idx, 1,
+        "Phase 2 must SKIP the Phase-1-honored largest class and serve the \
+         next un-honored class down; selecting q2 again would hand it both \
+         its guarantee and the residual in one epoch"
+    );
+    assert_eq!(
+        root.queues[2].telemetry.waterfill_counters.phase2_admissions, 0,
+        "the honored class must take NO Phase-2 admission this epoch"
+    );
+    assert_eq!(
+        root.queues[1].telemetry.waterfill_counters.phase2_admissions, 1,
+        "the residual goes to the largest UN-honored class"
+    );
+}
+
+#[test]
+fn waterfill_phase2_cursor_resumes_instead_of_restarting_at_the_largest() {
+    // #1630 r4 via #4408: `waterfill_phase2_cursor` is seeded from `root`
+    // and written back on selection precisely so the descending walk
+    // advances through ALL large classes across calls instead of
+    // restarting at the largest every time. Re-entering Phase 2 must
+    // resume where it stopped.
+    //
+    // This is a DISTINCT assertion from the refill-side cursor test
+    // (`waterfill_exhausted_refill_does_not_reset_phase2_cursor`), which
+    // pins that the refill leaves the cursor alone; this one pins that
+    // Phase 2 itself consumes the cursor rather than ignoring it.
+    let (mut root, mut tel) = waterfill_phase2_root_with_largest_honored();
+
+    let second = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel)
+        .expect("Phase 2 residual selection 1");
+    assert_eq!(second.queue_idx, 1, "precondition: first residual is q1");
+    assert_eq!(
+        root.waterfill_phase2_cursor, 2,
+        "precondition: the cursor advanced past the honored q2 and the \
+         selected q1"
+    );
+
+    let third = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel)
+        .expect("Phase 2 residual selection 2");
+
+    assert_eq!(
+        third.queue_idx, 0,
+        "Phase 2 must RESUME the descending walk from the stored cursor and \
+         reach the smallest un-honored class; restarting at the largest \
+         would re-serve q1 forever and starve q0 (the #1630 r4 residual \
+         starvation)"
+    );
+    assert_eq!(
+        root.queues[1].telemetry.waterfill_counters.phase2_admissions, 1,
+        "q1 took exactly one residual — the walk moved on rather than \
+         re-serving it"
+    );
+}


### PR DESCRIPTION
#4408 Option B′ — increments 3a + 3b from
`docs/research/4408-hotpath-split/plan.md`. The dispatch half is not
here; it moved to #6922.

`select_exact_cos_guarantee_queue_waterfill` becomes a **59-line
orchestrator over three named phases**:

| fn | LOC | |
|---|---|---|
| `select_exact_cos_guarantee_queue_waterfill` (orchestrator) | **59** | was 432 |
| `refill_waterfill_epoch` | 76 | new |
| `waterfill_phase1_select` | 185 | new |
| `waterfill_phase2_select` | 118 | new |

Pure motion — 357 moved lines diff clean against master after stripping
leading whitespace. All three helpers are `#[inline(always)]` and
same-module. **No path is claimed cold anywhere**, so no coldness claim
can be wrong (the failure mode that killed #1697-v1 / #4409(b) / #4404).

## What this does NOT buy — read this before the diff

**It does not move the modularity audit, and this PR does not claim it
does.** `docs/refactoring-audit-current.txt` gates on file set and tier
(1500 audit floor / 2000 `[REFACTOR]` floor). `queue_service/mod.rs` was
2166 `[REFACTOR]` and is 2258 `[REFACTOR]` after this — same tier, same
file set, so `TestHeatmapNotStale` neither fires nor needs a regenerated
artifact (`go test ./pkg/refactoraudit/...` → ok). A split does not
shrink a file; it **grew** this one by 92 lines.

The value is reviewability of a state machine: three phases a reviewer
can hold in their head instead of one 432-line body. That is the whole
claim.

**And it partly breaks the rule it invokes.** At 185 and 118 lines the
two new helpers are themselves over `docs/engineering-style.md`'s
100-line god-function cue. They are one walk each; Phase 1's interior in
particular cannot be cut further without re-deriving NLL borrow-end
points (`queue`'s `&mut root.queues` borrow coexists with reads of the
disjoint `root.tokens`, then must end so `count_park_reason` /
`park_cos_queue` can take `&mut root` whole). Flagging it rather than
letting a reviewer find it.

## The mutation grid found a real gap, and it is now closed

The plan's §7.2 grid is not a formality here — it caught that
**`waterfill_phase2_select` was completely unbound**. Both of its
prescribed mutations left the entire waterfill + refund suite GREEN.

The cause: every pre-existing fixture enters Phase 2 with the largest
class **un-honored** — Phase 1 walks ascending and exhausts its budget
before reaching it — so the descending walk starts at cursor 0, lands on
an eligible queue immediately, and neither the honored-skip nor the
cursor arithmetic is ever exercised.

Two new tests reach that state by honoring the **largest** class first:
empty the two small queues so Phase 1 skips them and honors q2 (cost
25000 of a 26250 budget), then refill them so the next call cannot
afford q0's 2500 and breaks into Phase 2 with ordinal bit 2 set.

Final grid — **6 of 6**, every cell a NAMED failing test failing on an
ASSERTION, never a build break:

| Cell | Verdict | Named failure |
|---|---|---|
| M1 refill: drop the `epoch_boundary` gate | RED | `waterfill_exact_fit_honor_does_not_livelock_phase1` (#1743 r3) |
| M2 refill: reset `waterfill_phase2_cursor` | RED | `waterfill_exhausted_refill_does_not_reset_phase2_cursor` — *"the exhausted refill path must PRESERVE the Phase-2 cursor"*, left 0 right 1 |
| M3 phase1: drop the honored-bit set | RED | 8 tests incl. `waterfill_persistent_honored_set_distributes_phase1_across_queues` (#1732) |
| M4 phase1: charge `send_budget` not `phase1_cost` | RED | 5 tests incl. `waterfill_phase1_honor_charge_is_configured_quantum_not_tokens` (#1743 Hunk B) |
| M5 phase2: ignore the honored bitset | RED **(was GREEN)** | both new tests; `…skips_a_queue_honored_in_phase1` |
| M6 phase2: reset the cursor each entry | RED **(was GREEN)** | **only** `waterfill_phase2_cursor_resumes_instead_of_restarting_at_the_largest` — *"Phase 2 must RESUME the descending walk from the stored cursor"*, left 1 right 0 |
| **NC** negative control: hoist the `waterfill_epochs` bump earlier inside the same block (semantically null) | **GREEN** | — |

M5 REDs both new tests, M6 REDs only the cursor one, so the pair
**discriminates** rather than restating one assertion twice. The
negative control staying green is what makes the table evidence rather
than "everything fails".

## Codegen equivalence

**The baseline was regenerated at this head, not inherited — and that
mattered.** The plan's checked-in `callgraph-baseline-dd23119aa.txt`
already differs from this head by a `.llvm.<N>` CGU hash on
`nat64_v6_translation_ineligible`, in a file this PR never opens.
Inheriting §2's numbers would have produced a false failure on the first
run. §12.5 predicted exactly this; it is now measured, not predicted.

**Primary gate — per-symbol Tier 1, raw, zero normalisation:**

```
ADDR=$(nm xpf-userspace-dp | grep -E " [tT] _ZN.*<sym>17h[0-9a-f]+E$" | awk '{print $1}')
objdump -d --no-show-raw-insn xpf-userspace-dp \
 | awk -v a="^$ADDR <" '$0 ~ a {f=1} f&&/^$/{if(seen)exit} f{seen=1;print}' \
 | grep -oP 'call\s+[0-9a-f]+ <\K[^>]+' | sed 's/+0x.*//' | sort -u
```

| Symbol | Edges | `diff` exit |
|---|---|---|
| `service_exact_guarantee_queue_direct_with_info` — the symbol the waterfill inlines into | 32 | **0** |
| `enqueue_pending_forwards` — untouched control | 51 | **0** |

`nm` shows **none** of `select_exact_cos_guarantee_queue_waterfill`,
`refill_waterfill_epoch`, `waterfill_phase1_select`,
`waterfill_phase2_select` — inlining preserved.
`service_exact_guarantee_queue_direct_with_info` grows **0x619b →
0x61cf (+52 B, +0.21%)** with an *identical* callee set: instruction
scheduling, not a new or lost call. That is the second-order residual
plan §2d admits and does not argue away.

**The normalisation is instance-aware** — the §8a F8 defect (a strip
that collapsed three distinct `VecDeque::grow` monomorphisations into
one identity, and would therefore have passed a real instantiation swap)
does not apply:

| Rule | distinct `VecDeque::grow` keys |
|---|---|
| Tier 1 (mine — no normalisation) | **3** |
| Tier 2a (strip only `.llvm.<N>`) | **3** |
| the r2 rule the plan flagged | 1 ← over-collapse |

**Negative control — the gate is watched failing, per helper.** Flipping
each helper to `#[inline(never)]` in turn puts it in `nm` and makes the
Tier-1 diff report it:

| Helper | `nm` size when outlined | Tier-1 diff |
|---|---|---|
| `refill_waterfill_epoch` | 0x1eb | new edge reported |
| `waterfill_phase1_select` | 0x7b7 | new edge reported **and `park_cos_queue` lost** (the gate sees removals too) |
| `waterfill_phase2_select` | 0x4e2 | new edge reported |

## Whole-binary comparison, and its noise floor

I also ran a whole-binary caller→callee map (17,533 edges), which is
stronger than the plan's per-symbol gate. Reporting it honestly rather
than only the gate that passes cleanly.

Three controls establish what the instrument can and cannot see:

| Control | raw whole-binary diff | Tier-2a residual | per-symbol Tier 1 |
|---|---|---|---|
| **D** rebuild identical source | **0** | 0 | clean |
| **N** one added comment line | 204 | **0** | clean |
| **M** move an existing fn to end of file (plan §2c-bis P2 class) | 204 | **0** | clean |
| **this PR** | 2507 | **4** | clean |

So the *raw* whole-binary map has a ~204-line noise floor from CGU
relabelling and is unusable as a primary gate; the build itself is
deterministic (D). After Tier-2a the noise vanishes for both controls,
leaving three residuals from this PR — **all in modules this PR does not
open**, all caused by rustc re-partitioning CGUs when items are added to
`queue_service`:

1. `nat64_v6_translation_ineligible` inside `enqueue_pending_forwards` —
   `.llvm.<N>` relabel. Same rustc item, same instantiation hash
   `17h45dae7fd1de716f1`; only the CGU-internalisation label differs.
2. `SessionWheel::new` — a **CGU-local duplicate copy** of
   `RawVec::grow_one` was eliminated. Proven, not asserted: both symbols
   in the pre-split binary are 0x64 bytes, **byte-identical over all 39
   instructions** after address normalisation, and call the same
   `finish_grow17h3401c95a27232e8a`. The one that disappeared carried a
   `.llvm.` suffix marking it the internal copy. Net −100 bytes, zero
   semantic content.
3. `Copied<I>::try_fold` — `fabric_link_superseded_by_snapshots` became
   inlined instead of called. The callee is still present out-of-line in
   `nm` and still called from `snapshot_refresh`; only this one call site
   changed. Inlining decisions are per-CGU in a non-LTO build.

None changes a callee **path** in the changed code. Per the plan, Tier 2
is never an auto-pass — these are written up for a reviewer to sign off,
not waved through.

## Docs

`docs/cos-validation-notes.md` names
`select_exact_cos_guarantee_queue_waterfill` and explains the trace
counters, so it gains the counter-to-phase map — an operator tracing
`epochs` / `phase1_admit` / `phase2_admit` / `eligible_visits` /
`phase1_budget_breaks` now lands in the right function. It also records
that `phase1_no_progress` belongs to **none** of the three phases: it is
bumped, and `phase1_admit` correspondingly decremented, by
`apply_phase1_waterfill_honor_refund` from
`service_exact_guarantee_queue_direct_with_info`.

*(The plan's §10 concluded no doc change was needed, but its survey
covered only `pkg/dataplane/README.md` and `docs/fairness-regimes.md`;
it did not check `cos-validation-notes.md`, which names the function
directly.)*

## Test results

| Leg | Exit |
|---|---|
| `make test-go` | **0** (zero `FAIL` lines) |
| `make test-rust` run 1 | **2** — one failure, see below |
| `make test-rust` run 2, identical tree/commit/command | **0** (4253 passed, 0 failed) |
| `go test ./pkg/refactoraudit/...` | **0** |

**The run-1 failure is a pre-existing scheduling flake, not this
change** — evidenced, not asserted:

```
afxdp::wg::engine::engine_internal_tests::install_session_serializes_with_reconcile_removal
panicked at src/afxdp/wg/engine_tests.rs:872:5:
  reconcile loop must have completed at least one full add/remove cycle
```

1. **This branch does not touch the WireGuard engine at all.**
   `git diff origin/master...HEAD --stat -- userspace-dp/src/afxdp/wg/`
   is empty; 0 `wg/` files changed. The failing test and the code it
   exercises are byte-identical to master's.
2. **The assertion is a thread-liveness race, visible in the source.**
   Thread A installs sessions and then sets `stop`; thread B loops
   `reconcile_peers` until `stop`. `reconcile_iters >= 1` requires B to
   be scheduled at least once before A finishes. Under CPU contention
   (the box was running several parallel release builds) B can be
   starved to zero iterations.
3. **Re-running the identical command on the identical tree at the same
   commit `153fdea4b` passes, exit 0.** Same source in, different
   outcome — that is non-determinism by definition.
4. 20/20 isolated runs of that single test pass at this head.

*Caveat on the proof, stated rather than hidden:* the standing rule is
to prove a pre-existing failure by rebuilding at the master SHA in a
detached worktree. I did **not** do that — `/` is at **100% (3.6 G
free)** and a second full release+test tree is ~5 GB, which would risk
filling the disk and faking a red for every other agent building on
this box. Points 1–4 above are the substitute, and point 1 makes the
master build largely redundant: the code under test *is* master's.
Filed separately as a test-infrastructure flake.

## Not done

**Throughput smoke was not run** — the brief for this lane explicitly
excluded cluster/incus tooling, and plan §7.5 assigns that leg to the
leader. It is the leg that covers the residual register-allocation /
stack-frame risk §2d admits, and the +52 B size delta is exactly the
class it would cover. It is owed before merge.

## Reviewer: attack this first

1. **The `Option` correspondence.** §1a claims every non-selecting exit
   of each walk already converged on the same successor. Re-derive it
   from the diff rather than trusting the claim — that is the one place
   a behaviour change could hide in a pure-motion diff.
2. **The two new tests' fixture.** It empties and refills queues
   mid-epoch to force an ordering the production selector reaches only
   under specific backlog. Check the preconditions it asserts (budget
   1250, ordinal bit 2 set) are producible in production, not just in
   the fixture.
3. **The +52 B growth** on `service_exact_guarantee_queue_direct_with_info`
   with an identical call-edge set.

Closes #4408.
