### PR TITLE
cluster/daemon: guarantee one cold sync after the dataplane is ready (#82)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -97219,3 +97219,24 @@ prose edit above them added. No diff falls in the new test body.
 
   `docs/refactoring-audit-current.txt` regenerated after the merge.
 - **File(s)**: _Log.md
+
+## #82 — HA startup race: cold-prime bulk owed after late runtime wiring
+
+- **Timestamp**: 2026-08-21
+- **Action**: Reproduced #82 at `e344c9df5` and fixed it. `startClusterComms`
+  called `ss.Start(commsCtx)` — which spawns the accept/dial goroutines that run
+  the authoritative cold-prime bulk on the first connection — BEFORE
+  `ss.SetRuntime(rt)`. A peer connecting in that window drove `BulkSync` against
+  a nil session store; it returns `session store not ready` before writing a
+  byte, so no `handleDisconnect` follows, and both existing `needColdPrime`
+  consumers (`installConn` on reconnect, `handleDisconnect`'s survivor re-drive)
+  are disconnect-edge triggered. The obligation stayed armed with no consumer for
+  the life of the connection, and the incremental sweep cannot substitute:
+  `StartSyncSweep` seeds `lastSweepTime` to "now" and only queues sessions with
+  `Created >= threshold`, so every pre-startup session is permanently invisible
+  to it. Fix is two parts — `syncSweep` re-drives an owed cold prime on the live
+  connection (`else if` on the `forceResync` consume, sharing
+  `bulkRedriveInFlight`), and the daemon wires the runtime before `Start`.
+- **File(s)**: pkg/cluster/sync_conn_sweep.go,
+  pkg/cluster/sync_cold_prime_late_runtime_82_test.go,
+  pkg/daemon/daemon_ha_sync.go, docs/session-sync-architecture.md, _Log.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -672,6 +672,31 @@ discharged) do not re-bulk.
 where a newer full-disconnect epoch's arm is cleared by an older epoch's success
 self-heals via `forceResync` / the #4090 survivor re-drive / the next reconnect.
 
+**The connected sweep is the third consumer (#82).** Both consumers above are
+disconnect-edge triggered — `installConn` on a reconnect, `handleDisconnect` on
+a survivor fabric. A cold-prime bulk that fails WITHOUT dropping the connection
+therefore left the obligation armed with no consumer for the life of that
+connection. `BulkSync`'s own preconditions produce exactly that shape: it
+returns `session store not ready` (nil `s.sessions`) or `no peer connection`
+before it writes a byte, so no `handleDisconnect` follows. The startup window is
+the real trigger — `startClusterComms` used to call `ss.Start()` (which spawns
+the accept/dial goroutines) and only then `ss.SetRuntime(rt)`, so a peer that
+connected in between drove the cold prime against a nil session store.
+
+The incremental sweep cannot cover for it: `StartSyncSweep` seeds
+`lastSweepTime` to "now" and the sweep only queues sessions with
+`Created >= threshold`, so every session that existed before the sweep started
+is permanently invisible to it — and only a `BulkStart -> BulkEnd` window drives
+the peer's authoritative `reconcileStaleSessions`. `syncSweep` therefore
+re-drives an owed cold prime on the live connection, past its `s.sessions == nil`
+guard so the store is known wired, discharging on success and leaving the arm in
+place on failure so the next tick retries. It is an `else if` on the
+`forceResync` consume (a forced resync sends the same authoritative snapshot, so
+at most one bulk leaves per tick) and shares `bulkRedriveInFlight` with the
+survivor re-drive so the two cannot stack. The daemon also now wires the runtime
+BEFORE `ss.Start()`, which removes the trigger and gives the `SetRuntime` writes
+a happens-before edge over the goroutines `Start` spawns.
+
 ## Incremental Sweep and Delete Journal
 
 ### Background Sweep

--- a/pkg/cluster/sync_cold_prime_late_runtime_82_test.go
+++ b/pkg/cluster/sync_cold_prime_late_runtime_82_test.go
@@ -1,0 +1,134 @@
+package cluster
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// TestColdPrimeOwedWhenRuntimeWiredAfterConnect is the #82 startup-race repro.
+//
+// The daemon starts session sync (ss.Start -> accept/dial goroutines) BEFORE it
+// wires the runtime (ss.SetRuntime), so a peer that connects inside that window
+// drives the cold-prime bulk against a SessionSync whose session store is still
+// nil. BulkSync returns "session store not ready" without touching the
+// connection (no disconnect), the needColdPrime obligation stays armed, and
+// nothing re-drives it while the connection stays up: the reconnect consumer
+// lives in installConn and the survivor re-drive lives in handleDisconnect.
+//
+// The incremental sweep cannot cover for it. StartSyncSweep seeds lastSweepTime
+// to "now", and the sweep only queues sessions with Created >= threshold, so
+// every session that existed before the sweep started is invisible to it
+// forever. Those are exactly the sessions the cold-prime bulk exists to
+// replicate, and they are also the only thing that drives the peer's
+// authoritative reconcileStaleSessions window.
+//
+// RED at the pre-fix HEAD: BulkSyncs stays 0 across every post-wire sweep tick
+// and the pre-existing session never reaches the standby.
+func TestColdPrimeOwedWhenRuntimeWiredAfterConnect(t *testing.T) {
+	const zone = uint16(2)
+	// Created=0 — a session that already existed when the daemon came up, i.e.
+	// strictly older than any sweep threshold.
+	preExisting := dataplane.SessionKey{SrcIP: [4]byte{10, 0, 7, 1}, DstIP: [4]byte{10, 0, 8, 1}, Protocol: 6, SrcPort: 1200, DstPort: 80}
+
+	primDP := &mockSweepDP{
+		v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{
+			preExisting: {IsReverse: 0, IngressZone: zone, Created: 0},
+		},
+		sessionCounter: 1,
+	}
+
+	// Runtime NOT wired: this is the state of `ss` between ss.Start() and
+	// ss.SetRuntime(rt) in startClusterComms.
+	prim := NewSessionSync(":0", "10.0.0.2:4785", nil)
+	if prim.sessions != nil {
+		t.Fatal("precondition: session store must be nil before the runtime is wired")
+	}
+
+	cap := newBulkCaptureConn()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		cap.Close()
+	}()
+
+	// The peer connects inside the wiring window. Unkeyed, so the handshake is
+	// a no-op and handleNewConnection runs the real cold-prime path.
+	prim.handleNewConnection(ctx, 0, cap)
+
+	if got := prim.stats.BulkSyncs.Load(); got != 0 {
+		t.Fatalf("precondition: bulk must have failed with a nil session store, got %d completed bulks", got)
+	}
+	if !prim.needColdPrime.Load() {
+		t.Fatal("precondition: the failed cold prime must leave the obligation armed")
+	}
+	// sendClockSync already wrote a clock frame; assert only that no bulk
+	// window opened.
+	if starts, ends := countBulkMarkers(t, cap.bytes()); starts != 0 || ends != 0 {
+		t.Fatalf("precondition: no bulk window should have opened, got starts=%d ends=%d", starts, ends)
+	}
+
+	// The dataplane becomes ready and the daemon wires it, exactly as
+	// startClusterComms does after Start returns.
+	prim.SetRuntime(primDP)
+	prim.IsPrimaryFn = func() bool { return true }
+	// StartSyncSweep seeds the threshold to "now" — the pre-existing session is
+	// already older than this, so the incremental path can never carry it.
+	prim.lastSweepTime = monotonicSeconds()
+
+	// The connection stays up. Tick the sweep as the 1s loop would.
+	for i := 0; i < 3; i++ {
+		prim.syncSweep()
+	}
+
+	if prim.needColdPrime.Load() {
+		t.Error("#82: the cold-prime obligation is still armed after the runtime became ready — no path re-drives it while the connection stays up")
+	}
+	if got := prim.stats.BulkSyncs.Load(); got != 1 {
+		t.Fatalf("#82: expected exactly one authoritative bulk after the runtime was wired, got %d", got)
+	}
+
+	standbyDP := &mockSweepDP{
+		v4sessions:     map[dataplane.SessionKey]dataplane.SessionValue{},
+		sessionCounter: 1,
+	}
+	standby := NewSessionSync(":0", "10.0.0.1:4785", standbyDP)
+	standby.IsPrimaryFn = func() bool { return false }
+	standby.IsPrimaryForRGFn = func(int) bool { return false }
+	standby.SetZoneRGMap(map[uint16]int{zone: 2})
+
+	starts, ends := replayBulkFrames(t, standby, cap.bytes())
+	if starts != 1 || ends != 1 {
+		t.Fatalf("#82: expected exactly one BulkStart/BulkEnd window on the wire, got starts=%d ends=%d", starts, ends)
+	}
+	if _, ok := standbyDP.v4sessions[preExisting]; !ok {
+		t.Fatal("#82: the session that existed before startup was never replicated to the standby")
+	}
+}
+
+// countBulkMarkers counts BulkStart/BulkEnd frames in a captured stream without
+// replaying them into a standby.
+func countBulkMarkers(t *testing.T, buf []byte) (starts, ends int) {
+	t.Helper()
+	for len(buf) > 0 {
+		if len(buf) < syncHeaderSize {
+			t.Fatalf("truncated frame header: %d bytes left", len(buf))
+		}
+		typ := buf[4]
+		n := binary.LittleEndian.Uint32(buf[8:12])
+		buf = buf[syncHeaderSize:]
+		if uint32(len(buf)) < n {
+			t.Fatalf("truncated payload: want %d, have %d", n, len(buf))
+		}
+		buf = buf[n:]
+		switch typ {
+		case syncMsgBulkStart:
+			starts++
+		case syncMsgBulkEnd:
+			ends++
+		}
+	}
+	return starts, ends
+}

--- a/pkg/cluster/sync_conn_sweep.go
+++ b/pkg/cluster/sync_conn_sweep.go
@@ -121,6 +121,44 @@ func (s *SessionSync) syncSweep() int {
 			s.forceResync.Store(true)
 			slog.Warn("cluster sync: forced resync bulk failed, will retry", "err", err)
 		}
+	} else if s.needColdPrime.Load() && s.bulkRedriveInFlight.CompareAndSwap(false, true) {
+		// #82: an OWED cold prime had exactly two consumers — installConn (a
+		// reconnect) and handleDisconnect's survivor re-drive. Both are
+		// disconnect-edge triggered, so a first bulk that failed WITHOUT
+		// dropping the connection left the obligation armed with no consumer
+		// for the life of that connection.
+		//
+		// BulkSync's own preconditions produce exactly that shape: it returns
+		// "session store not ready" (nil s.sessions) or "no peer connection"
+		// BEFORE it writes a byte, so no handleDisconnect follows. The startup
+		// window is the real trigger — the daemon starts session sync and only
+		// then wires the dataplane runtime, so a peer that connects in between
+		// drives the cold prime against a nil session store.
+		//
+		// The incremental path below cannot cover for it. StartSyncSweep seeds
+		// lastSweepTime to "now" and the sweep only queues sessions with
+		// Created >= threshold, so every session that existed before the sweep
+		// started is permanently invisible to it — and only a BulkStart ->
+		// BulkEnd window drives the peer's authoritative
+		// reconcileStaleSessions. Re-drive here, past the s.sessions nil guard
+		// above so the store is known wired, discharging on success and
+		// leaving the arm in place on failure so the next tick retries.
+		//
+		// else-if, not a second independent block: a forced resync sends the
+		// same authoritative snapshot, so at most one bulk leaves per tick.
+		//
+		// Share bulkRedriveInFlight with the survivor-fabric re-drive so the
+		// two cannot stack a second bulk on top of an in-flight one; the CAS
+		// simply skips this tick when that re-drive owns the flag, and the arm
+		// it is still holding brings us back on the next one.
+		slog.Warn("cluster sync: re-driving owed cold-prime bulk on the live connection (first attempt did not complete)")
+		err := s.doBulkSync()
+		s.bulkRedriveInFlight.Store(false)
+		if err != nil {
+			slog.Warn("cluster sync: owed cold-prime re-drive failed, will retry", "err", err)
+		} else {
+			s.needColdPrime.Store(false)
+		}
 	}
 	if s.lastSweepEmpty && !s.syncBackfillNeeded.Load() {
 		if s.telemetry != nil {

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -1148,6 +1148,36 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			// Retry sync start: the VRF device and address binding may not
 			// be ready during daemon startup (networkd race).
 			for i := 0; i < 30; i++ {
+				// #82: wire the runtime and the ownership predicates BEFORE
+				// Start opens the listeners and dialers, not after it returns.
+				//
+				// Start spawns the accept/connect goroutines, and the first
+				// connection they establish runs the authoritative cold-prime
+				// bulk inside handleNewConnection. Wiring afterwards left a
+				// window in which that bulk ran against a nil session store:
+				// BulkSync returns "session store not ready" before it writes a
+				// byte, so no disconnect follows and — before the sweep
+				// re-drive added alongside this — nothing re-drove the owed
+				// prime for the life of that connection. It also made
+				// SetRuntime an unsynchronized write to fields the goroutines
+				// Start had already spawned were reading. Assigning before the
+				// goroutines exist gives the writes a happens-before edge and
+				// removes the race outright.
+				//
+				// ONE snapshot of the published dataplane per iteration feeds
+				// both this wiring and the post-Start sweep launch, so a
+				// setDataplane(nil) landing mid-retry cannot be seen as non-nil
+				// by one site and nil by the other (#2114 / #6743 rule).
+				rt := d.dataplane()
+				if rt != nil {
+					ss.SetRuntime(rt)
+					ss.IsPrimaryFn = func() bool {
+						return d.cluster != nil && d.cluster.IsLocalPrimary(0)
+					}
+					ss.IsPrimaryForRGFn = func(rgID int) bool {
+						return d.cluster != nil && d.cluster.IsLocalPrimary(rgID)
+					}
+				}
 				if err := ss.Start(commsCtx); err != nil {
 					if i < 5 {
 						slog.Info("cluster: sync bind not ready, retrying",
@@ -1166,23 +1196,16 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 				slog.Info("cluster session sync started",
 					"local", syncLocal, "peer", syncPeer, "vrf", vrfDevice)
 
-				// Wire dataplane into session sync and start the sweep.
-				// Must happen here (not in Run) because the session-sync
-				// object `ss` is created asynchronously in this goroutine. The
-				// published dataplane is a dataplane.RuntimeDataPlane; both the
-				// legacy *Manager and
-				// the userspace LegacyDataPlaneAdapter implement
-				// Sessions()/Telemetry() so they satisfy the cluster
-				// package's narrow clusterRuntime contract directly
-				// (#1518).
-				if rt := d.dataplane(); rt != nil {
-					ss.SetRuntime(rt)
-					ss.IsPrimaryFn = func() bool {
-						return d.cluster != nil && d.cluster.IsLocalPrimary(0)
-					}
-					ss.IsPrimaryForRGFn = func(rgID int) bool {
-						return d.cluster != nil && d.cluster.IsLocalPrimary(rgID)
-					}
+				// Start the sweep and the event-stream drain now that the
+				// listeners are up. The runtime itself was wired above, before
+				// Start (#82). All of it must happen here (not in Run) because
+				// the session-sync object `ss` is created asynchronously in
+				// this goroutine. The published dataplane is a
+				// dataplane.RuntimeDataPlane; both the legacy *Manager and the
+				// userspace LegacyDataPlaneAdapter implement
+				// Sessions()/Telemetry() so they satisfy the cluster package's
+				// narrow clusterRuntime contract directly (#1518).
+				if rt != nil {
 					ss.StartSyncSweep(commsCtx)
 					if wiredStream != nil {
 						go d.eventStreamFallbackLoop(commsCtx, wiredStream)


### PR DESCRIPTION
## What

Two commits closing the #82 HA startup race.

1. **`cluster:`** `syncSweep` now re-drives an owed cold prime on the live
   connection.
2. **`daemon:`** `startClusterComms` wires the session-sync runtime *before*
   `ss.Start()` instead of after it.

## The defect, reproduced

`startClusterComms` called `ss.Start(commsCtx)` — which spawns the accept and
dial goroutines, and the first connection they establish runs the authoritative
cold-prime bulk inside `handleNewConnection` — and only *then*
`ss.SetRuntime(rt)` (`pkg/daemon/daemon_ha_sync.go:1151` / `:1179` at
`e344c9df5`).

A peer connecting inside that window drives `BulkSync` against a nil session
store. `BulkSync` returns `session store not ready` **before it writes a byte**
(`pkg/cluster/sync_bulk.go:57-59`), so no `handleDisconnect` follows — and both
existing `needColdPrime` consumers are disconnect-edge triggered:

| consumer | site | trigger |
|---|---|---|
| reconnect re-prime | `sync_conn.go:441` (`installConn` -> `handleNewConnection`) | a new connection installed |
| survivor re-drive  | `sync_conn.go:1009` (`handleDisconnect`)                    | a fabric dropping |

So the obligation stays armed with **no consumer for the life of that
connection**.

The incremental sweep cannot substitute. `StartSyncSweep` seeds `lastSweepTime`
to "now" (`sync_conn_sweep.go:12`) and the sweep only queues sessions with
`Created >= threshold` (`:146`, `:166`), so every session that existed before the
sweep started is permanently below the threshold. Those are exactly the sessions
the cold prime exists to replicate — and only a `BulkStart -> BulkEnd` window
drives the peer's authoritative `reconcileStaleSessions`. The standby ends up
holding none of them and blackholes those flows on the next failover to it.

## Fix

**Cluster side** — `syncSweep` re-drives the owed prime, past its
`s.sessions == nil` guard so the store is known wired. It is an `else if` on the
`forceResync` consume (a forced resync sends the same authoritative snapshot, so
at most one bulk leaves per tick) and shares `bulkRedriveInFlight` with the
survivor re-drive so the two cannot stack. Success discharges the arm; failure
leaves it in place so the next tick retries.

**Daemon side** — wire `SetRuntime` + `IsPrimaryFn` / `IsPrimaryForRGFn` before
`Start`. This removes the trigger, and it also removes a genuine data race:
`SetRuntime` is a plain field assignment with no lock or atomic, so writing it
after `Start` was an unsynchronized write to fields the spawned goroutines were
already reading. Assigning before those goroutines exist gives the writes a
happens-before edge. The published dataplane is read ONCE per retry iteration and
feeds both the pre-`Start` wiring and the post-`Start` sweep launch, so a
`setDataplane(nil)` landing mid-retry cannot be seen as non-nil by one site and
nil by the other (#2114 / #6743). The read stays *inside* the loop rather than
hoisted, because the loop can run for up to 60s and must not wire a dataplane the
daemon has since disowned.

## Validation

`TestColdPrimeOwedWhenRuntimeWiredAfterConnect`
(`pkg/cluster/sync_cold_prime_late_runtime_82_test.go`) drives the **real**
`handleNewConnection` cold-prime path against a nil runtime, asserts the
preconditions (zero completed bulks, obligation armed, no bulk window on the
wire), then wires the runtime and ticks the sweep — and asserts the pre-existing
session reaches a standby through exactly one `BulkStart`/`BulkEnd` window.

Mutation-checked: with `pkg/cluster/sync_conn_sweep.go` reverted to `e344c9df5`
and everything else in place, the test FAILS (`obligation is still armed`, `got 0`
bulks, rc=1); restored, it passes (rc=0).

```
go test ./pkg/cluster/ -count=1                  ok   17.4s
go test ./pkg/daemon/  -count=1                  ok   37.4s
go test ./pkg/cluster/ ./pkg/daemon/ -count=1 -race   ok  (20.2s / 62.4s)
```

Docs: `docs/session-sync-architecture.md` gains "The connected sweep is the third
consumer (#82)" under the `needColdPrime` section.

Not smoke-tested on the loss cluster — this lane is forbidden from touching it.
The change is on the HA session-sync path, so a `make test-failover` before merge
is warranted.

Closes #82