### PR TITLE
config: warn when a second WireGuard port is unsteered

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -97219,3 +97219,44 @@ prose edit above them added. No diff falls in the new test body.
 
   `docs/refactoring-audit-current.txt` regenerated after the merge.
 - **File(s)**: _Log.md
+
+## #1434 — surface the single-steered-WireGuard-port limitation at commit
+
+- **Timestamp**: 2026-08-21
+- **Action**: Added a commit-time WARNING for a config that resolves to more
+  than one distinct WireGuard listen port. The AF_XDP shim's WG-RX steering
+  gate is a single scalar (`UserspaceCtrl.wg_listen_port`, compared in
+  `wg_steer_to_kernel`), fed by `snapshotWgListenPort`, which returns the FIRST
+  configured WireGuard endpoint's port. Two WG tunnels on distinct ports
+  therefore committed clean while the second tunnel received no inbound
+  transport at all — permanently, silently down. The new gate
+  `validateWireguardSingleSteeredPort` names the port that WILL be programmed
+  (with its tunnel ref) and every port that will NOT be.
+
+  Deliberately a warning, not a reject: the config is legal, the first tunnel
+  works exactly as authored, and rejecting would change commit acceptance for
+  configs that commit clean at every released version. It also leaves the
+  premise of `TestWireGuardListenPorts_5582` intact (that test compiles a
+  two-distinct-port config and asserts the port SET) — verified still green.
+
+  No dataplane behaviour change: `userspace-xdp/` untouched, no ABI bump, no
+  multi-port support. #1434 stays open for Increment 2 (the verifier-gated,
+  lab-gated shim change); this removes only the silence.
+
+  The steered port is derived from `config.EmitTunnelEndpointNames`, the same
+  SSOT emitter `buildTunnelEndpointSnapshots` drives, and a cross-package
+  parity test requires the port the warning names to equal what
+  `snapshotWgListenPort` actually programs — so the advisory cannot become a
+  confident lie if either order is ever changed.
+
+  Mutation-checked three ways, exit codes read from `$?`, never through a pipe:
+  (1) delete the `runTailGates` emission -> `pkg/config` rc=1, `pkg/dataplane/
+  userspace` rc=1; (2) pick `refs[len(refs)-1]` as the winner -> rc=1/rc=1;
+  (3) invert the emitter order so the WRONG port is named -> rc=1/rc=1, with
+  the parity test reporting "advisory claims listen-port 51900 is steered, but
+  the dataplane programs 51820".
+- **File(s)**: pkg/config/compiler_validate_wireguard_multiport.go,
+  pkg/config/compiler_tailgates.go,
+  pkg/config/wireguard_multiport_warning_1434_test.go,
+  pkg/dataplane/userspace/wireguard_steering_advisory_1434_test.go,
+  docs/wireguard-interop.md, _Log.md

--- a/docs/wireguard-interop.md
+++ b/docs/wireguard-interop.md
@@ -810,6 +810,46 @@ lands, only the first configured WG listen port is steered, so a second
 tunnel on a different port will not receive inbound transport packets.
 Design of record: `docs/research/1434-multi-tunnel-wireguard/plan.md`.
 
+**The limitation is now SURFACED AT COMMIT.** It used to be silent: a
+config declaring two WireGuard tunnels on distinct listen ports committed
+clean and the second tunnel was simply, permanently dead with no operator
+signal at all. `validateWireguardSingleSteeredPort`
+(`pkg/config/compiler_validate_wireguard_multiport.go`, run from
+`runTailGates`) now emits a commit **warning** whenever the configuration
+resolves to more than one distinct WireGuard listen port. The warning names
+the port that WILL be programmed (with its tunnel ref) and every port that
+will NOT be, e.g.:
+
+```
+wireguard: 2 distinct listen-ports are configured, but the dataplane steers
+inbound WireGuard transport for only ONE of them. listen-port 51820 (wg0) IS
+steered and works. listen-port 51900 (wg1) is NOT steered - no inbound
+WireGuard transport reaches that tunnel, so no handshake ever completes and
+no return traffic arrives: dead while appearing configured. Only one
+WireGuard listen-port can receive inbound transport until multi-port steering
+lands (#1434 Increment 2, deferred); remove or re-point the unsteered
+tunnel(s) rather than leaving them silently down.
+```
+
+It is a WARNING, never a reject — the config is legal, its first tunnel
+works exactly as authored, and rejecting would change commit acceptance for
+configs that commit clean at every released version. The steered port is
+derived from `config.EmitTunnelEndpointNames`, the same SSOT emitter
+`buildTunnelEndpointSnapshots` drives, so the port the warning names is the
+port `snapshotWgListenPort` packs into the shim ctrl block; two WG tunnels
+that SHARE one listen port lose nothing to the steering scalar and draw no
+warning. This removes the silence only — the dataplane behaviour, the shim,
+and the ABI are unchanged, and #1434 stays open for Increment 2.
+
+Fail-on-revert guards: `TestWireGuardDistinctListenPortsWarnsAtCommit_1434`,
+`TestWireGuardSingleListenPortDoesNotWarn_1434`,
+`TestWireGuardSameListenPortDoesNotWarn_1434`,
+`TestWireGuardThreeListenPortsWarnsOnce_1434` (`pkg/config`), and the
+cross-package parity binding
+`TestWireGuardSteeringAdvisoryNamesTheProgrammedPort_1434`
+(`pkg/dataplane/userspace`), which requires the port the warning names to
+equal the port `snapshotWgListenPort` actually programs.
+
 ## Host-inbound admission of the WG listen port (#5582)
 
 The shim steers local-destination UDP on the configured WG listen port to
@@ -864,10 +904,11 @@ hook (`emitHostInboundWireGuardAccept`). Rationale:
 port (the compile-time SSOT), which is also what the shim packs into the
 ctrl block, so kernel filter and shim steering agree. The shim's
 single-port WG-RX steering (S2a) only steers the FIRST configured port
-today (see "Multi-tunnel status" above); the host-inbound filter admits
-ALL configured WG ports, so a second-tunnel rule is currently a no-op at
-the kernel (nothing steers that port up) but is correct-in-intent and
-ready for the deferred multi-tunnel steering (#1434 Increment 2).
+today (see "Multi-tunnel status" above, where that limitation is now
+warned about at commit); the host-inbound filter admits ALL configured WG
+ports, so a second-tunnel rule is currently a no-op at the kernel (nothing
+steers that port up) but is correct-in-intent and ready for the deferred
+multi-tunnel steering (#1434 Increment 2).
 
 Fail-on-revert guards: `TestHostInboundFilterAdmitsWireGuardListenPort`
 and `TestHostInboundFilterWireGuardPayloadParses` (`pkg/daemon`),

--- a/pkg/config/compiler_tailgates.go
+++ b/pkg/config/compiler_tailgates.go
@@ -249,6 +249,17 @@ func runTailGates(cfg *Config, opts compileOpts) error {
 	}
 	cfg.Warnings = append(cfg.Warnings, wgPeerWarnings...)
 
+	// #1434 Increment 2 (deferred): the AF_XDP shim's WG-RX steering gate is a
+	// SINGLE scalar (UserspaceCtrl.wg_listen_port), fed by the FIRST configured
+	// WireGuard endpoint's port (snapshotWgListenPort). A config declaring two
+	// WireGuard tunnels on DISTINCT listen ports therefore commits clean while
+	// the second tunnel receives no inbound transport at all — permanently and
+	// silently down. Warn (never reject): the config is legal, the first tunnel
+	// works exactly as authored, and generalizing the shim to a port SET is a
+	// verifier-gated lab change. This removes the silence; it does not remove
+	// the limitation.
+	cfg.Warnings = append(cfg.Warnings, validateWireguardSingleSteeredPort(cfg)...)
+
 	// #5162: non-WireGuard tunnel outer-family cross-field gate. A GRE/IPIP
 	// tunnel whose OUTER source and destination are different address
 	// families (v4 source + v6 destination, or the reverse) passes per-leaf

--- a/pkg/config/compiler_validate_wireguard_multiport.go
+++ b/pkg/config/compiler_validate_wireguard_multiport.go
@@ -1,0 +1,117 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// validateWireguardSingleSteeredPort emits a commit WARNING (never a hard
+// reject) when the configuration declares WireGuard tunnels on more than one
+// distinct UDP listen port.
+//
+// Why this is a defect worth a commit-time signal: the AF_XDP shim's WG-RX
+// steering gate is a SINGLE scalar. `UserspaceCtrl.wg_listen_port` holds one
+// port, `wg_steer_to_kernel` (userspace-xdp/src/lib.rs) compares
+// `pkt.flow_dst_port` against `ctrl.wg_listen_port & 0xffff`, and the Go side
+// packs that scalar with `snapshotWgListenPort`
+// (pkg/dataplane/userspace/maps_sync.go), which returns the FIRST
+// mode=="wireguard" tunnel endpoint's port and ignores every later one. So a
+// second WireGuard tunnel on a different listen port has its inbound transport
+// UDP left unsteered: the kernel WG control socket never sees it, the tunnel
+// never completes a handshake, and — before this gate — the config committed
+// clean with ZERO operator signal. The tunnel is simply, permanently, silently
+// down.
+//
+// A WARNING, not a reject. The configuration is legal, it is what an operator
+// migrating a multi-tunnel WireGuard deployment would naturally author, and its
+// FIRST tunnel works exactly as configured today. Rejecting would break a
+// partially-working deployment to report a dataplane limitation, and would
+// change commit acceptance for configs that commit clean at every released
+// version. Generalizing the shim to steer a port SET is #1434 Increment 2 — a
+// verifier-gated `userspace-xdp` edit with a documented v6-line-rate
+// sensitivity that must clear the loss cluster before it can merge. Until it
+// lands, the honest thing is to tell the operator exactly which tunnel is dead
+// and why. The warning must therefore describe the CURRENT limitation and name
+// the tracking issue; it must not promise the fix, nor rule it out.
+//
+// Ordering. The winner is computed from EmitTunnelEndpointNames — the same SSOT
+// emitter the snapshot builder (buildTunnelEndpointSnapshots) drives — so
+// "which port wins" here is derived from, not a second guess at, what the
+// dataplane will program. EmitTunnelEndpointNames walks interfaces in sorted
+// name order (units ascending), so the winner is stable across commits and
+// identical on both HA nodes. One residual gap: the builder additionally
+// intersects with the live InterfaceSnapshot rows, so if the winning tunnel's
+// interface is absent at runtime the NEXT WG endpoint is programmed instead.
+// Commit time cannot see that, so the warning names the config-order winner;
+// either way the "more than one port is configured, only one is steered" claim
+// holds, which is the part the operator must act on.
+//
+// A tunnel with WgListenPort == 0 is skipped: the strict WireGuard gate
+// (validateOneWireguardTunnel, #3863) hard-rejects a zero/out-of-range
+// listen-port at commit, so a zero here only arises on a tolerant load, and it
+// contributes no steerable port either way.
+func validateWireguardSingleSteeredPort(cfg *Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	type wgEndpointRef struct {
+		name string
+		port uint16
+	}
+	refs := make([]wgEndpointRef, 0, 2)
+	for _, ep := range EmitTunnelEndpointNames(cfg) {
+		if ep.Tunnel == nil || ep.Tunnel.Mode != "wireguard" || ep.Tunnel.WgListenPort == 0 {
+			continue
+		}
+		refs = append(refs, wgEndpointRef{name: ep.Name, port: ep.Tunnel.WgListenPort})
+	}
+	if len(refs) < 2 {
+		return nil
+	}
+
+	// The first emitted WG endpoint is the one whose port reaches the shim.
+	steered := refs[0]
+	strandedPorts := make([]uint16, 0, len(refs)-1)
+	strandedTunnels := make(map[uint16][]string, len(refs)-1)
+	for _, ref := range refs[1:] {
+		if ref.port == steered.port {
+			// Same port as the steered one: the one steering scalar already
+			// covers it, so nothing is lost to THIS defect. (Two WG tunnels
+			// sharing a port collide on the kernel UDP bind — bind_wg_socket
+			// sets no SO_REUSEPORT — but that is a different failure and not
+			// this gate's subject. This gate fires only on the distinct-port
+			// condition the single steering scalar drops.)
+			continue
+		}
+		if _, seen := strandedTunnels[ref.port]; !seen {
+			strandedPorts = append(strandedPorts, ref.port)
+		}
+		strandedTunnels[ref.port] = append(strandedTunnels[ref.port], ref.name)
+	}
+	if len(strandedPorts) == 0 {
+		return nil
+	}
+	sort.Slice(strandedPorts, func(i, j int) bool { return strandedPorts[i] < strandedPorts[j] })
+
+	stranded := make([]string, 0, len(strandedPorts))
+	for _, port := range strandedPorts {
+		stranded = append(stranded, fmt.Sprintf("%d (%s)", port, strings.Join(strandedTunnels[port], ", ")))
+	}
+	strandedNoun, strandedVerb, strandedSubject := "listen-port", "is", "that tunnel"
+	if len(strandedPorts) > 1 {
+		strandedNoun, strandedVerb, strandedSubject = "listen-ports", "are", "those tunnels"
+	}
+	return []string{fmt.Sprintf(
+		"wireguard: %d distinct listen-ports are configured, but the dataplane "+
+			"steers inbound WireGuard transport for only ONE of them. "+
+			"listen-port %d (%s) IS steered and works. %s %s %s NOT steered — no "+
+			"inbound WireGuard transport reaches %s, so no handshake ever "+
+			"completes and no return traffic arrives: dead while appearing "+
+			"configured. Only one WireGuard listen-port can receive inbound "+
+			"transport until multi-port steering lands (#1434 Increment 2, "+
+			"deferred); remove or re-point the unsteered tunnel(s) rather than "+
+			"leaving them silently down.",
+		len(strandedPorts)+1, steered.port, steered.name,
+		strandedNoun, strings.Join(stranded, ", "), strandedVerb, strandedSubject)}
+}

--- a/pkg/config/wireguard_multiport_warning_1434_test.go
+++ b/pkg/config/wireguard_multiport_warning_1434_test.go
@@ -1,0 +1,184 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// wgSteeringWarnings returns the commit warnings that talk about WireGuard
+// listen-port STEERING. Selection is by the property the operator cares about
+// ("wireguard" + "steered"), not by the exact sentence the current gate emits,
+// so a reworded advisory is still found and a REMOVED advisory still reds.
+func wgSteeringWarnings(cfg *Config) []string {
+	var out []string
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "wireguard") && strings.Contains(w, "steered") {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+// TestWireGuardDistinctListenPortsWarnsAtCommit_1434 is the #1434 silence gate.
+//
+// The defect: the AF_XDP shim's WG-RX steering is a SINGLE scalar
+// (UserspaceCtrl.wg_listen_port, compared in wg_steer_to_kernel), fed by
+// snapshotWgListenPort, which returns the FIRST configured WireGuard endpoint's
+// port. A config with two WireGuard tunnels on DISTINCT listen ports commits
+// clean, but only the first port is ever programmed — the second tunnel never
+// receives inbound transport and is permanently, silently down.
+//
+// This asserts the commit now SAYS so, and says it precisely enough to act on:
+// exactly one advisory, naming BOTH ports, BOTH tunnels, which one survives,
+// which one does not, and the tracking issue.
+//
+// Fail-on-revert: delete the validateWireguardSingleSteeredPort append in
+// runTailGates (or make the gate return nil) and this goes RED — the config
+// commits clean again with zero operator signal, which is the defect.
+func TestWireGuardDistinctListenPortsWarnsAtCommit_1434(t *testing.T) {
+	lines := []string{
+		// wg1 on the HIGHER port, authored FIRST. The dataplane snapshot
+		// emitter walks interfaces in sorted NAME order, so wg0 wins the one
+		// steering slot regardless of authoring order — the advisory must
+		// report the emitter's winner, not the author's first line.
+		"set interfaces wg1 tunnel mode wireguard",
+		"set interfaces wg1 tunnel wireguard listen-port 51900",
+		"set interfaces wg1 tunnel wireguard private-key " + wgKeyA,
+		"set interfaces wg1 tunnel wireguard peer " + wgKeyB + " allowed-ips 10.2.0.0/24",
+		"set interfaces wg0 tunnel mode wireguard",
+		"set interfaces wg0 tunnel wireguard listen-port 51820",
+		"set interfaces wg0 tunnel wireguard private-key " + wgKeyB,
+		"set interfaces wg0 tunnel wireguard peer " + wgKeyA + " allowed-ips 10.1.0.0/24",
+		"set system dataplane-type userspace",
+	}
+	tree := buildTree4953(t, lines)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		// Explicitly NOT a reject: the config is legal and its first tunnel
+		// works. A hard error here would change commit acceptance for a
+		// config that commits clean at every released version.
+		t.Fatalf("two distinct WG listen-ports must still COMMIT (warning, not reject); got error: %v", err)
+	}
+
+	got := wgSteeringWarnings(cfg)
+	if len(got) != 1 {
+		t.Fatalf("want exactly 1 WireGuard steering advisory, got %d: %v (all warnings: %v)",
+			len(got), got, cfg.Warnings)
+	}
+	w := got[0]
+
+	// Both ports and both tunnel refs must appear — an advisory that names
+	// only the dead port leaves the operator guessing which tunnel is live.
+	for _, want := range []string{"51820", "51900", "wg0", "wg1", "#1434"} {
+		if !strings.Contains(w, want) {
+			t.Errorf("advisory does not mention %q: %s", want, w)
+		}
+	}
+
+	// Direction is the whole point: naming the ports without saying WHICH one
+	// survives is no better than silence. Bind the assignment explicitly, so a
+	// gate that picks the wrong winner (authoring order, or the max port)
+	// cannot pass by merely mentioning both numbers.
+	if !strings.Contains(w, "listen-port 51820 (wg0) IS steered") {
+		t.Errorf("advisory does not name 51820/wg0 as the port that IS programmed: %s", w)
+	}
+	if !strings.Contains(w, "listen-port 51900 (wg1) is NOT steered") {
+		t.Errorf("advisory does not name 51900/wg1 as the port that is NOT programmed: %s", w)
+	}
+}
+
+// TestWireGuardSingleListenPortDoesNotWarn_1434 pins the common case shut: one
+// WireGuard tunnel is fully supported today, so it must draw no steering
+// advisory. Without this, a gate that fired on "any WireGuard tunnel" would
+// pass the multi-port test above while crying wolf on every single-tunnel
+// deployment.
+func TestWireGuardSingleListenPortDoesNotWarn_1434(t *testing.T) {
+	lines := []string{
+		"set interfaces wg0 tunnel mode wireguard",
+		"set interfaces wg0 tunnel wireguard listen-port 51820",
+		"set interfaces wg0 tunnel wireguard private-key " + wgKeyB,
+		"set interfaces wg0 tunnel wireguard peer " + wgKeyA + " allowed-ips 10.1.0.0/24",
+		"set system dataplane-type userspace",
+	}
+	tree := buildTree4953(t, lines)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if got := wgSteeringWarnings(cfg); len(got) != 0 {
+		t.Fatalf("single-tunnel WireGuard config must draw no steering advisory, got: %v", got)
+	}
+}
+
+// TestWireGuardSameListenPortDoesNotWarn_1434 binds the DISTINCT qualifier. Two
+// WireGuard tunnels that share one listen port lose nothing to the single
+// steering scalar — that one port is programmed and covers both — so this gate
+// must stay quiet. A naive "more than one WireGuard tunnel" test would fire
+// here and mislabel a different problem (two tunnels on one port collide on the
+// kernel UDP bind; bind_wg_socket sets no SO_REUSEPORT) as a steering loss.
+func TestWireGuardSameListenPortDoesNotWarn_1434(t *testing.T) {
+	lines := []string{
+		"set interfaces wg0 tunnel mode wireguard",
+		"set interfaces wg0 tunnel wireguard listen-port 51820",
+		"set interfaces wg0 tunnel wireguard private-key " + wgKeyB,
+		"set interfaces wg0 tunnel wireguard peer " + wgKeyA + " allowed-ips 10.1.0.0/24",
+		"set interfaces wg1 tunnel mode wireguard",
+		"set interfaces wg1 tunnel wireguard listen-port 51820",
+		"set interfaces wg1 tunnel wireguard private-key " + wgKeyA,
+		"set interfaces wg1 tunnel wireguard peer " + wgKeyB + " allowed-ips 10.2.0.0/24",
+		"set system dataplane-type userspace",
+	}
+	tree := buildTree4953(t, lines)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if got := wgSteeringWarnings(cfg); len(got) != 0 {
+		t.Fatalf("two WG tunnels sharing ONE listen port must draw no steering advisory, got: %v", got)
+	}
+}
+
+// TestWireGuardThreeListenPortsWarnsOnce_1434 covers the >2 case: one advisory
+// listing EVERY stranded port, not one advisory per stranded tunnel (which
+// would bury the signal) and not just the first stranded one (which would
+// under-report the damage).
+func TestWireGuardThreeListenPortsWarnsOnce_1434(t *testing.T) {
+	lines := []string{
+		"set interfaces wg0 tunnel mode wireguard",
+		"set interfaces wg0 tunnel wireguard listen-port 51820",
+		"set interfaces wg0 tunnel wireguard private-key " + wgKeyB,
+		"set interfaces wg0 tunnel wireguard peer " + wgKeyA + " allowed-ips 10.1.0.0/24",
+		"set interfaces wg1 tunnel mode wireguard",
+		"set interfaces wg1 tunnel wireguard listen-port 51900",
+		"set interfaces wg1 tunnel wireguard private-key " + wgKeyA,
+		"set interfaces wg1 tunnel wireguard peer " + wgKeyB + " allowed-ips 10.2.0.0/24",
+		"set interfaces wg2 tunnel mode wireguard",
+		"set interfaces wg2 tunnel wireguard listen-port 51999",
+		"set interfaces wg2 tunnel wireguard private-key " + wgKeyC1434,
+		"set interfaces wg2 tunnel wireguard peer " + wgKeyA + " allowed-ips 10.3.0.0/24",
+		"set system dataplane-type userspace",
+	}
+	tree := buildTree4953(t, lines)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	got := wgSteeringWarnings(cfg)
+	if len(got) != 1 {
+		t.Fatalf("want exactly 1 WireGuard steering advisory for 3 ports, got %d: %v", len(got), got)
+	}
+	w := got[0]
+	if !strings.Contains(w, "3 distinct listen-ports") {
+		t.Errorf("advisory does not report the full port count: %s", w)
+	}
+	for _, want := range []string{"51900 (wg1)", "51999 (wg2)"} {
+		if !strings.Contains(w, want) {
+			t.Errorf("advisory omits stranded port %q: %s", want, w)
+		}
+	}
+	if !strings.Contains(w, "listen-port 51820 (wg0) IS steered") {
+		t.Errorf("advisory does not name 51820/wg0 as the surviving port: %s", w)
+	}
+}
+
+const wgKeyC1434 = "c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"

--- a/pkg/dataplane/userspace/wireguard_steering_advisory_1434_test.go
+++ b/pkg/dataplane/userspace/wireguard_steering_advisory_1434_test.go
@@ -1,0 +1,107 @@
+package userspace
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// steeredPortRe pulls the port the commit advisory tells the operator WILL be
+// programmed out of the warning text the operator actually reads.
+var steeredPortRe = regexp.MustCompile(`listen-port (\d+) \([^)]+\) IS steered`)
+
+// TestWireGuardSteeringAdvisoryNamesTheProgrammedPort_1434 is the cross-package
+// parity binding for the #1434 commit advisory.
+//
+// The advisory (pkg/config, validateWireguardSingleSteeredPort) tells the
+// operator WHICH WireGuard listen port survives the dataplane's single steering
+// scalar. That claim is only worth anything if it agrees with the code that
+// actually fills the scalar — snapshotWgListenPort, whose value the shim
+// compares in wg_steer_to_kernel. Both derive their order from
+// config.EmitTunnelEndpointNames today, but they are different functions in
+// different packages: nothing structural stops one from being re-ordered.
+//
+// So: compile a two-port config, read the port the ADVISORY names, build the
+// dataplane snapshot from the same config, and require snapshotWgListenPort to
+// return exactly that port. If they ever diverge the advisory becomes a
+// confident lie — worse than the silence it replaced — and this reds.
+func TestWireGuardSteeringAdvisoryNamesTheProgrammedPort_1434(t *testing.T) {
+	const (
+		keyA = "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+		keyB = "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+	)
+	// wg1 (higher port) authored first, wg0 (lower port) second — so a gate
+	// that reported authoring order instead of emitter order would name 51900,
+	// and the snapshot would program 51820. That mismatch is what this catches.
+	lines := []string{
+		"set interfaces wg1 tunnel mode wireguard",
+		"set interfaces wg1 tunnel wireguard listen-port 51900",
+		"set interfaces wg1 tunnel wireguard private-key " + keyA,
+		"set interfaces wg1 tunnel wireguard peer " + keyB + " allowed-ips 10.2.0.0/24",
+		"set interfaces wg0 tunnel mode wireguard",
+		"set interfaces wg0 tunnel wireguard listen-port 51820",
+		"set interfaces wg0 tunnel wireguard private-key " + keyB,
+		"set interfaces wg0 tunnel wireguard peer " + keyA + " allowed-ips 10.1.0.0/24",
+		"set system dataplane-type userspace",
+	}
+	tree := &config.ConfigTree{}
+	for _, line := range lines {
+		path, err := config.ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := config.CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+
+	var advisory string
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "wireguard") && strings.Contains(w, "steered") {
+			if advisory != "" {
+				t.Fatalf("more than one WireGuard steering advisory: %v", cfg.Warnings)
+			}
+			advisory = w
+		}
+	}
+	if advisory == "" {
+		t.Fatalf("no WireGuard steering advisory emitted for two distinct listen-ports; warnings: %v", cfg.Warnings)
+	}
+	m := steeredPortRe.FindStringSubmatch(advisory)
+	if m == nil {
+		t.Fatalf("advisory does not name a steered listen-port in the expected form: %s", advisory)
+	}
+	claimed, convErr := strconv.Atoi(m[1])
+	if convErr != nil {
+		t.Fatalf("steered port %q is not numeric: %v", m[1], convErr)
+	}
+
+	// Build the snapshot the way the manager does: emitter refs become the
+	// live interface rows, then buildTunnelEndpointSnapshots + the same
+	// snapshotWgListenPort the ctrl-block writer calls.
+	emitted := config.EmitTunnelEndpointNames(cfg)
+	ifaces := make([]InterfaceSnapshot, 0, len(emitted))
+	for i, ep := range emitted {
+		ifaces = append(ifaces, InterfaceSnapshot{
+			Name:      ep.Name,
+			LinuxName: ep.Name,
+			Ifindex:   100 + i,
+		})
+	}
+	snap := &ConfigSnapshot{TunnelEndpoints: buildTunnelEndpointSnapshots(cfg, ifaces)}
+	programmed := snapshotWgListenPort(snap)
+	if programmed == 0 {
+		t.Fatalf("snapshot programmed no WireGuard port; endpoints: %+v", snap.TunnelEndpoints)
+	}
+	if uint32(claimed) != programmed {
+		t.Fatalf("commit advisory claims listen-port %d is steered, but the dataplane programs %d — the advisory is wrong: %s",
+			claimed, programmed, advisory)
+	}
+}


### PR DESCRIPTION
## The defect

The AF_XDP shim's WireGuard RX steering gate is a **single scalar**. The shim
compares a packet's UDP destination port against `ctrl.wg_listen_port & 0xffff`
(`wg_steer_to_kernel`, `userspace-xdp/src/lib.rs`), and the Go side fills that
scalar with `snapshotWgListenPort` (`pkg/dataplane/userspace/maps_sync.go`),
which returns the **first** configured `mode=="wireguard"` endpoint's port and
ignores every later one.

A configuration declaring two WireGuard tunnels on **distinct** listen ports
therefore committed clean, and the second tunnel then received no inbound
WireGuard transport at all — no handshake ever completed, no return traffic ever
arrived. It showed as configured and was permanently dead, with **zero operator
signal**: not at commit, not at runtime. `docs/wireguard-interop.md` recorded
this as a known deferred limitation, but nothing in the product said it.

## What this changes

`validateWireguardSingleSteeredPort` (new,
`pkg/config/compiler_validate_wireguard_multiport.go`), run from `runTailGates`,
emits a commit **warning** whenever the configuration resolves to more than one
distinct WireGuard listen port. It names the port that *will* be programmed with
its tunnel ref, and every port that will *not* be:

```
wireguard: 2 distinct listen-ports are configured, but the dataplane steers
inbound WireGuard transport for only ONE of them. listen-port 51820 (wg0) IS
steered and works. listen-port 51900 (wg1) is NOT steered — no inbound WireGuard
transport reaches that tunnel, so no handshake ever completes and no return
traffic arrives: dead while appearing configured. Only one WireGuard listen-port
can receive inbound transport until multi-port steering lands (#1434 Increment 2,
deferred); remove or re-point the unsteered tunnel(s) rather than leaving them
silently down.
```

**A warning, never a reject.** The config is legal, it is what an operator
migrating a multi-tunnel WireGuard deployment would naturally author, and its
first tunnel works exactly as configured. Rejecting would break a
partially-working deployment to report a dataplane limitation, and would change
commit acceptance for configs that commit clean at every released version —
including the two-distinct-port config `TestWireGuardListenPorts_5582` compiles.
That test's premise is untouched and it is verified still green.

The steered port is derived from `config.EmitTunnelEndpointNames` — the same
SSOT emitter `buildTunnelEndpointSnapshots` drives — so *which port wins* is read
from, not guessed alongside, what the dataplane programs. Two WireGuard tunnels
that **share** one listen port lose nothing to the single steering scalar and
draw no warning; only the distinct-port condition fires.

## Scope: #1434 stays open

Relates to #1434 without closing it — deliberately no closing keyword anywhere in
this body, not even a negated one (GitHub's parser does not read negation). This
removes the **silence**, not the limitation. `userspace-xdp/`
is untouched, no ABI is bumped, and multi-port steering is not attempted — that
is #1434 Increment 2, a verifier-gated shim edit with a documented v6-line-rate
sensitivity that needs cluster + perf + `make test-failover` work. **#1434 stays
open** and this PR must not be allowed to auto-close it.

Dataplane behaviour is unchanged, so this owes no cluster smoke: no compiled
artifact moves and no protocol version changes.

## Tests

`pkg/config`:
- `TestWireGuardDistinctListenPortsWarnsAtCommit_1434` — two distinct ports still
  COMMIT (not reject), exactly one advisory, naming both ports, both tunnels, the
  tracking issue, and **which** port survives. Authors the higher port first, so a
  gate reporting authoring order rather than emitter order fails.
- `TestWireGuardSingleListenPortDoesNotWarn_1434` — the common case draws no
  advisory (a gate firing on "any WireGuard tunnel" would cry wolf everywhere).
- `TestWireGuardSameListenPortDoesNotWarn_1434` — binds the *distinct* qualifier;
  two tunnels sharing one port stay quiet.
- `TestWireGuardThreeListenPortsWarnsOnce_1434` — one advisory listing every
  stranded port, not one per tunnel and not just the first.

`pkg/dataplane/userspace`:
- `TestWireGuardSteeringAdvisoryNamesTheProgrammedPort_1434` — cross-package
  parity: the port the **warning text** names as steered must equal what
  `snapshotWgListenPort` actually programs. If the two orders ever diverge the
  advisory becomes a confident lie, which is worse than the silence it replaced.

## Validation

Exit codes read from `$?`, never through a pipe.

| command | rc |
|---|---|
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go test -count=1 ./pkg/config/... ./pkg/dataplane/...` | 0 |
| `go test -count=1 ./pkg/daemon/... ./pkg/configstore/... ./pkg/grpcapi/... ./pkg/api/... ./pkg/cli/...` | 0 |

**Mutation checks** (one mutation per run, tree restored and diffed clean between):

| mutation | `pkg/config` | `pkg/dataplane/userspace` |
|---|---|---|
| delete the `runTailGates` emission | rc=**1** | rc=**1** |
| pick `refs[len(refs)-1]` as the winner | rc=**1** | rc=**1** |
| invert emitter order so the WRONG port is named | rc=**1** | rc=**1** |

Under mutation 3 the parity test reports exactly the property it was written for:
`commit advisory claims listen-port 51900 is steered, but the dataplane programs
51820 — the advisory is wrong`. The two negative tests stay green under every
mutation, as over-fire guards must. `TestWireGuardListenPorts_5582` stays green
under mutation 1, confirming it does not depend on the new warning.

## Docs

`docs/wireguard-interop.md` — the "Multi-tunnel status (#1434 scope note)"
section previously described the limitation as silent. It now records that the
limitation is **surfaced at commit**, shows the warning text, states why it is a
warning rather than a reject, and lists the fail-on-revert guards. The #5582
host-inbound section's back-reference is updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPsefKwS8UZRN3XjBBUxu2

