### PR TITLE
docs: state the arming precondition on the cluster read-only gate

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -97280,3 +97280,31 @@ prose edit above them added. No diff falls in the new test body.
   pkg/config/wireguard_multiport_warning_1434_test.go,
   pkg/dataplane/userspace/wireguard_steering_advisory_1434_test.go,
   docs/wireguard-interop.md, _Log.md
+
+## #6896 — three docs asserted a cluster-secondary read-only gate that arming does not universally give
+
+- **Timestamp**: 2026-08-21
+- **Action**: Replaced the categorical claim ("the secondary is read-only",
+  "Secondary nodes operate in read-only mode, rejecting all config mutations",
+  "Configure mode protection: blocked on secondary cluster nodes", REST has
+  "full gRPC parity") with the mechanism plus its precondition, in the three
+  doc trees #6865 did not touch. Verified at `origin/master` f8e720c3e:
+  `SetClusterReadOnly` has exactly two production call sites, both inside
+  `applyRG0OwnershipTransition` (`pkg/daemon/daemon_ha.go:445,477`), driven by
+  an RG0 **transition** event; there is no startup arming and no reconcile that
+  re-derives the flag; `Store.clusterReadOnly` is a plain bool with no
+  constructor initialisation in `configstore.New`, so it starts `false`; and
+  `pkg/api/config.go` reaches `EnterConfigureSession` with no RG0 check where
+  `pkg/grpcapi/server_config.go:76` guards on `IsLocalPrimary(0)` and
+  `pkg/cli/cli_dispatch.go:380` has its own. A node that cold-starts, seats as
+  RG0 secondary and never transitions therefore has a WRITABLE store — the gap
+  filed as #6890 (#6889 is the dropped-event variant), both still OPEN.
+  `pkg/cluster/README.md` already carries the corrected model from #6865 and is
+  the wording these three now match. Pinned the precondition itself with
+  `TestClusterReadOnly_ZeroValueStoreIsWritable_6896`, which uses NO
+  `SetClusterReadOnly` call: mutating `configstore.New` to construct with
+  `clusterReadOnly: true` reds it (rc=1, read from `$?`), so the claim the docs
+  now make is checked rather than asserted. Docs + one test only — no runtime
+  behaviour change, nothing reaches the helper binary, no smoke owed.
+- **File(s)**: pkg/configstore/README.md, docs/feature-coverage.md,
+  docs/phases.md, pkg/configstore/cluster_readonly_3893_test.go, _Log.md

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -387,12 +387,21 @@ the userspace dataplane admission boundary is in
 - **Remote CLI**: `cli` binary connects via gRPC with full tab/`?` parity.
 - **gRPC API**: 48+ RPCs (config, sessions, stats, routes, IPsec, DHCP,
   cluster).
-- **REST API**: HTTP on port 8080 (health, Prometheus, config, full gRPC
-  parity).
+- **REST API**: HTTP on port 8080 (health, Prometheus, config). Broad
+  surface parity with gRPC, but NOT parity of the cluster guards: the
+  configure-mode entry point (`pkg/api/config.go`) has no RG0 check,
+  where gRPC guards on `IsLocalPrimary(0)` and the interactive CLI has
+  its own check (#6890).
 - **Config management**: candidate/active with commit model, 50 rollback
   slots, `load override`/`load merge`, `show | display set`.
-- **Configure mode protection**: blocked on secondary cluster nodes (RG0
-  primary is config authority).
+- **Configure mode protection**: the RG0 primary is the intended config
+  authority, and on a secondary **whose read-only gate is armed** the
+  configstore rejects every user mutation (`ErrClusterReadOnly`) at every
+  entry point. Arming happens only on an RG0 transition
+  (`applyRG0OwnershipTransition`) and `clusterReadOnly` starts `false`,
+  so a node that cold-starts as secondary and never transitions is NOT
+  gated — see `pkg/configstore/README.md` "Cluster read-only gate" and
+  #6890 (#6889 is the dropped-event variant).
 - **DHCP server**: Kea integration with lease display; static / fixed /
   reserved host bindings (`static-binding <mac> { fixed-address; host-name; }`
   under `dhcp-local-server`/`dhcpv6-local-server` → Kea per-subnet

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -993,7 +993,7 @@ Gap audit: `docs/archived/userspace-forwarding-and-failover-gap-audit.md` (PR #3
 ## Sprint CC-9: Config Sync (Primary→Secondary)
 
 ### Overview
-Configuration synchronization between chassis cluster nodes. Primary node pushes full config text to secondary after each commit. Secondary nodes operate in read-only mode, rejecting all config mutations.
+Configuration synchronization between chassis cluster nodes. Primary node pushes full config text to secondary after each commit. A secondary **whose read-only gate is armed** rejects every user config mutation. Arming is not universal (#6896): `SetClusterReadOnly(true)` is reached only from the RG0 **transition** handler (see the CC-9 store section below) and `clusterReadOnly` starts `false`, so a node that cold-starts as secondary and never transitions is not gated — tracked as #6890, with #6889 the dropped-event variant. Read this as the design intent, not as a property every secondary has.
 
 ### Config Sync Protocol (pkg/cluster/sync.go)
 - **New message type:** `syncMsgConfig = 8` — full config text sync from primary to secondary

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -806,13 +806,32 @@ entrant; that is tracked separately.
 
 ### Cluster read-only gate (#3893)
 
-On an HA chassis cluster the RG0 primary is the sole config authority;
-the secondary is read-only and receives config only via `SyncApply`
-(peer sync from the primary). The daemon toggles the store's read-only
-mode on the RG0 primary↔secondary transition:
+On an HA chassis cluster the RG0 primary is the INTENDED sole config
+authority: on a secondary **whose gate is armed** the store is read-only
+and receives config only via `SyncApply` (peer sync from the primary).
+The daemon arms and disarms that mode from the RG0
+primary↔secondary TRANSITION handler — `applyRG0OwnershipTransition`
+(`pkg/daemon/daemon_ha.go`) — and from nowhere else:
 `SetClusterReadOnly(true)` when this node becomes secondary,
-`SetClusterReadOnly(false)` when it is promoted to primary
-(`pkg/daemon/daemon_ha.go`).
+`SetClusterReadOnly(false)` when it is promoted to primary.
+
+**Arming is not universal — do not read the heading as unconditional
+(#6896).** That transition handler is the only production caller of
+`SetClusterReadOnly` (`git grep -n SetClusterReadOnly -- '*.go'` returns
+the setter plus its two lines in `daemon_ha.go`); there is no startup
+arming and no reconcile that re-derives the flag, and
+`Store.clusterReadOnly` is a plain `bool` with no constructor
+initialisation, so it starts `false` (pinned by
+`TestClusterReadOnly_ZeroValueStoreIsWritable_6896`). A node that
+cold-starts, seats as RG0 secondary and never transitions therefore has
+a **writable** store — and `pkg/api/config.go` enters a configure
+session with no RG0 check of its own, where gRPC guards on
+`IsLocalPrimary(0)` (`pkg/grpcapi/server_config.go`) and the interactive
+CLI has its own check (`pkg/cli/cli_dispatch.go`). That gap is
+**#6890**; the dropped-transition-event variant — the manager reaches
+primary while the store stays read-only — is **#6889**. Both are OPEN.
+Everything below describes what the gate does ONCE ARMED; it is the
+design intent, not a property every secondary has.
 
 `clusterReadOnly` was originally checked ONLY at the `EnterConfigure*`
 gate. That left two holes: a config session **opened before** the node
@@ -839,7 +858,8 @@ config authored by the primary. `SyncApply` (HA peer-sync ingress) and
 `active`/`compiled` state **directly** and never route through the gated
 `Set`/`Commit`/`Load`/`Rollback` methods, so they are unaffected by this
 gate — exactly the distinction between a user-driven mutation (blocked
-on a secondary) and an internal convergence apply (must proceed).
+on a secondary whose gate is armed) and an internal convergence apply
+(must proceed).
 Boot-time `bootstrapFromFile` enters config mode first, so it too is
 governed by the same gate (a no-op there because `clusterReadOnly` is
 `false` at boot, before any RG0 transition).

--- a/pkg/configstore/cluster_readonly_3893_test.go
+++ b/pkg/configstore/cluster_readonly_3893_test.go
@@ -152,3 +152,43 @@ func TestClusterReadOnly_PromotedNodeCanCommit(t *testing.T) {
 		t.Fatalf("Commit (promoted primary): %v", err)
 	}
 }
+
+// TestClusterReadOnly_ZeroValueStoreIsWritable_6896 pins the PRECONDITION the
+// three docs corrected in #6896 now state: the gate is not a property a
+// secondary has, it is a property a secondary is GIVEN by an RG0 transition.
+//
+// `clusterReadOnly` is a plain bool with no constructor initialisation and
+// `SetClusterReadOnly` is reached only from applyRG0OwnershipTransition
+// (pkg/daemon/daemon_ha.go), so a node that cold-starts, seats as RG0
+// secondary and never transitions has a WRITABLE store. Three docs asserted
+// the conclusion ("the secondary is read-only", "rejecting all config
+// mutations", "blocked on secondary cluster nodes") without the precondition;
+// a reader who trusted them would stop looking for #6890.
+//
+// This asserts the default, not the gate: an unarmed store enters config mode
+// and commits. It is deliberately NOT an assertion that the hole is
+// acceptable — when #6890 closes by arming the gate at startup (or by adding
+// the missing RG0 check on the REST path), this test is the place the change
+// becomes visible, and the docs above must move with it.
+func TestClusterReadOnly_ZeroValueStoreIsWritable_6896(t *testing.T) {
+	s := newTestStore(t)
+
+	// No SetClusterReadOnly call anywhere in this test — this is exactly the
+	// cold-start standby that never saw an RG0 transition event.
+	if s.ClusterReadOnly() {
+		t.Fatalf("a freshly constructed Store reports ClusterReadOnly()=true; " +
+			"the docs' arming precondition (#6896) assumes the zero value is " +
+			"false. If this is now armed by construction, #6890 may be closed " +
+			"and pkg/configstore/README.md, docs/feature-coverage.md and " +
+			"docs/phases.md must be re-stated")
+	}
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure on an unarmed store: %v", err)
+	}
+	if err := s.SetFromInput("system host-name cold-start-standby"); err != nil {
+		t.Fatalf("Set on an unarmed store: %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("Commit on an unarmed store: %v", err)
+	}
+}


### PR DESCRIPTION
Three docs outside `pkg/cluster` assert, categorically, that a chassis cluster secondary cannot be configured. That is the design INTENT and holds wherever the configstore read-only gate is armed — but arming is not universal.

## What the code actually guarantees (origin/master f8e720c3e)

- `SetClusterReadOnly` has exactly two production call sites, both inside `applyRG0OwnershipTransition` (`pkg/daemon/daemon_ha.go:445,477`), driven by an RG0 ownership **transition** event. No startup arming, no reconcile that re-derives the flag.
- `Store.clusterReadOnly` (`pkg/configstore/store.go:205`) is a plain `bool` with no initialisation in `configstore.New` — it starts `false`.
- `pkg/api/config.go` enters a configure session with **no** RG0 check, where `pkg/grpcapi/server_config.go:76` guards on `IsLocalPrimary(0)` and `pkg/cli/cli_dispatch.go:380` has its own.

So the guarantee is conditional: **once armed**, the gate covers every user mutation at every entry point. A node that cold-starts, seats as RG0 secondary and never transitions has a **writable** store — #6890, with #6889 the dropped-event variant. Both open.

## What the old text claimed

| site | claim |
|---|---|
| `pkg/configstore/README.md` | "the secondary is read-only and receives config only via `SyncApply`" |
| `docs/feature-coverage.md` | REST has "full gRPC parity", eight lines above "Configure mode protection: blocked on secondary cluster nodes" — both halves cannot be true |
| `docs/phases.md` | "Secondary nodes operate in read-only mode, rejecting all config mutations" |

Each now states the mechanism **with its precondition** and names the hole rather than asserting it away. `pkg/cluster/README.md` already carries this model from #6865 and is the wording these were brought to.

Searched as a CLAIM, not a symbol (a symbol grep finds none of them); that sweep also caught a fourth restatement inside the corrected section ("blocked on a secondary" in the internal-sync bypass paragraph), fixed here.

## Binding

`TestClusterReadOnly_ZeroValueStoreIsWritable_6896` pins the precondition: it never calls `SetClusterReadOnly` and asserts a fresh store is writable. Mutating `configstore.New` to construct with `clusterReadOnly: true` **reds it** (rc=1 from `$?`) — a check on the production constructor, not on a literal.

## Validation

`go build ./...` rc=0 · `go vet ./pkg/configstore/` rc=0 · `go test -count=1 ./pkg/configstore/` rc=0.

Docs + one test. **No runtime behaviour change, nothing reaches the helper binary, no cluster smoke owed.**

Closes #6896