### PR TITLE
test(wg): cover the wrap accept after a forward-clear (#6118)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -97280,3 +97280,28 @@ prose edit above them added. No diff falls in the new test body.
   pkg/config/wireguard_multiport_warning_1434_test.go,
   pkg/dataplane/userspace/wireguard_steering_advisory_1434_test.go,
   docs/wireguard-interop.md, _Log.md
+
+- **Timestamp**: 2026-08-21
+- **Action**: Added `wrap_accept_after_forward_clear` to the #5168 WireGuard
+  replay tests (#6118). One ring slot+bit is shared by every counter congruent
+  modulo the ring capacity (RING_BLOCKS * BLOCK_BITS = 8192), so a fresh
+  `X + 8192` is decided off the very bit `X` set; it decides correctly only
+  because the forward-clear sweep zeroed `X`'s block as the high-water advanced
+  over it. The pre-existing 14 tests covered the security direction (the bit
+  SURVIVES a forward clear) but not this availability twin, where a false
+  Repeat silently drops authentic traffic after a large counter advance.
+
+  The test seeds X=100, advances to X+8192+64 — far enough that the sweep's
+  `diff` saturates at RING_BLOCKS and wraps back over X's block, near enough
+  that X+8192 is still inside the 8128 window and so takes the bitmap arm — and
+  requires X+8192 to Accept, then its own replay to Repeat. Slot aliasing and
+  the in-window precondition are asserted, not assumed.
+
+  Test-only: no production file touched, helper binary unchanged, no smoke owed.
+  Mutation-verified RED two ways, `cargo check` exit 0 for both so each red is
+  an assertion failure and not a build break, and each leaving the other 13
+  replay tests GREEN: (1) forward-clear sweep body neutered; (2) sweep bound
+  narrowed one block, `current + diff` -> `(current + diff).saturating_sub(1)`.
+  Both fire on the wrap-accept assertion itself (Repeat vs Accept). Full Rust
+  suite `cargo test -p userspace-dp -- --test-threads=1` exit 0.
+- **File(s)**: userspace-dp/src/afxdp/wg/session.rs, _Log.md

--- a/userspace-dp/src/afxdp/wg/session.rs
+++ b/userspace-dp/src/afxdp/wg/session.rs
@@ -512,6 +512,73 @@ mod session_tests {
         );
     }
 
+    // #6118 (#5168 hardening): the anti-false-Repeat WRAP accept — the
+    // availability twin of `ring_preserves_in_window_bit_across_blocks`.
+    //
+    // One ring slot+bit is shared by every counter congruent modulo the ring
+    // capacity (RING_BLOCKS * BLOCK_BITS = 8192), so `X` and `X + 8192` are
+    // indistinguishable to the bitmap read. A FRESH `X + 8192` may therefore be
+    // decided off `X`'s bit, and the only thing that makes it decide correctly
+    // is the forward-clear sweep having zeroed `X`'s block while the high-water
+    // advanced over it. If that sweep is skipped — or stops one block short of
+    // the wrap tail — the fresh counter falsely Repeats and authentic traffic is
+    // dropped after a large counter advance.
+    //
+    // RED-ON-REVERT: neutering the sweep, or narrowing its inclusive bound by
+    // one block (`current + diff` -> `(current + diff).saturating_sub(1)`, which
+    // leaves exactly the seed's block dirty when `diff` saturates at
+    // RING_BLOCKS), turns the wrap accept below into a Repeat. Both mutations
+    // leave the other 13 replay tests GREEN — this case is their sole detector.
+    #[test]
+    fn wrap_accept_after_forward_clear() {
+        // The counters, chosen so the aliasing and the window arm are exact.
+        const RING_SPAN: u64 = RING_BLOCKS as u64 * BLOCK_BITS; // 8192
+        let seed = 100u64;
+        let wrapped = seed + RING_SPAN; // same word, same bit as `seed`
+        // One block PAST `wrapped`: far enough that the advance's `diff`
+        // saturates at RING_BLOCKS (so the sweep wraps all the way back over
+        // the seed's block), yet near enough that `wrapped` is still in window
+        // and so takes the bitmap arm rather than the high-water arm.
+        let advance = wrapped + BLOCK_BITS;
+
+        // The slot aliasing is this test's precondition, not an assumption —
+        // assert it, so a geometry change cannot silently make the case vacuous.
+        let slot = |c: u64| ((c >> BLOCK_BIT_LOG) as usize & BLOCK_MASK, c & BIT_MASK);
+        assert_eq!(
+            slot(seed),
+            slot(wrapped),
+            "precondition: {seed} and {wrapped} must alias ONE ring slot+bit"
+        );
+        assert_ne!(
+            slot(advance),
+            slot(seed),
+            "precondition: the advance must not itself sit on the shared slot"
+        );
+
+        let mut r = ReplayState::default();
+        assert_eq!(r.check_and_update(seed), ReplayDecision::Accept);
+        assert_eq!(r.check_and_update(advance), ReplayDecision::Accept);
+        assert!(
+            !r.definitely_out_of_window(wrapped),
+            "precondition: {wrapped} must be IN window at high-water {advance}, \
+             so the decision is the bitmap read and not the age reject"
+        );
+
+        assert_eq!(
+            r.check_and_update(wrapped),
+            ReplayDecision::Accept,
+            "a fresh counter aliasing a forward-cleared slot must ACCEPT, not \
+             falsely Repeat off the stale bit left by {seed}"
+        );
+        // ...and the accept must have SET the bit, not merely passed the read:
+        // its own replay repeats.
+        assert_eq!(
+            r.check_and_update(wrapped),
+            ReplayDecision::Repeat,
+            "the wrap accept must record {wrapped} as seen"
+        );
+    }
+
     #[test]
     fn reject_after_messages_constant_matches_wireguard_spec() {
         assert_eq!(REJECT_AFTER_MESSAGES, 0xffff_ffff_ffff_dfff);


### PR DESCRIPTION
## What

Adds `wrap_accept_after_forward_clear` to the #5168 WireGuard replay test
set in `userspace-dp/src/afxdp/wg/session.rs`.

## Why

The #5168 port (PR #6117) is a byte-for-byte port of wireguard-go's
`ValidateCounter`, and its 14 tests cover the **security** direction
thoroughly: unseen-accept at ages 64/127/8127/8128, reject at 8129,
replay-Repeat at every in-window age, precheck/commit boundary
agreement, and `ring_preserves_in_window_bit_across_blocks` (the bit
SURVIVES a forward clear).

The **availability** twin was uncovered. One ring slot+bit is shared by
every counter congruent modulo the ring capacity
(`RING_BLOCKS * BLOCK_BITS` = 8192), so a fresh counter `X + 8192` is
decided off the very bit `X` set. It decides correctly *only* because
the forward-clear sweep zeroed `X`'s block while the high-water advanced
over it. Skip that sweep, or stop it one block short of the wrap tail,
and the fresh counter falsely Repeats — authentic traffic dropped after
a large counter advance, with no security signal to show for it.

## How

Seed `X = 100`; advance the high-water to `X + 8192 + 64`. That advance
is chosen on two axes at once:

- far enough that the sweep's `diff` saturates at `RING_BLOCKS` and
  therefore wraps all the way back over `X`'s own block (a sweep never
  clears its starting block otherwise);
- near enough that `X + 8192` is still inside the 8128 window, so it
  takes the **bitmap** arm and not the age-reject arm.

Then require `X + 8192` to `Accept`, and its own replay to `Repeat` (so
the accept is proven to have SET the bit, not merely passed the read).
The slot aliasing and the in-window precondition are **asserted**, not
assumed, so a ring-geometry change cannot quietly make the case vacuous.

## Production behaviour

Verified correct against wireguard-go `replay.go` — no bug found; this
locks the property.

## Binary impact

**Test-only.** No production file is touched, the helper binary is
unchanged, and **no dataplane smoke is owed**.

## Validation

Full Rust suite `cargo test --manifest-path userspace-dp/Cargo.toml --
--test-threads=1` → **exit 0** (4447 passed, 0 failed).

Mutation-verified RED two ways. `cargo check --all-targets` **exit 0**
for both, so each red is an *assertion* failure and not a build break,
and each leaves the other 13 replay tests **green** — this case is their
sole detector:

| # | Mutation | Result |
|---|---|---|
| 1 | forward-clear sweep body neutered | test exit 101, `session.rs:566` `left: Repeat / right: Accept`, 13 passed / 1 failed |
| 2 | sweep bound narrowed one block: `current + diff` → `(current + diff).saturating_sub(1)` (leaves exactly the seed's block dirty when `diff` saturates at `RING_BLOCKS`) | test exit 101, `session.rs:566` `left: Repeat / right: Accept`, 13 passed / 1 failed |

Both reds fire on the wrap-accept assertion itself, not on a
precondition guard.

Closes #6118

🤖 Generated with [Claude Code](https://claude.com/claude-code)