### PR TITLE
config/nat: correct both false clauses of the 2+-action NAT rejection

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -97280,3 +97280,42 @@ prose edit above them added. No diff falls in the new test body.
   pkg/config/wireguard_multiport_warning_1434_test.go,
   pkg/dataplane/userspace/wireguard_steering_advisory_1434_test.go,
   docs/wireguard-interop.md, _Log.md
+
+## #7034 + #7035 — both false clauses of the NAT 2+-action rejection sentence
+
+- **Timestamp**: 2026-08-21
+- **Action**: Rewrote the two false clauses of the
+  `validateNATTerminalActionCardinalityStrict` 2+-action message. They are one
+  `fmt.Errorf` format string, so they are corrected together. Measured through
+  `CompileConfig` / `CompileConfigLenient` at `origin/master` f8e720c3e.
+  (#7035) "the survivor is not chosen by configuration order" is false in
+  exactly the case that prints it: `compileNATSource` resets `rule.Then` at the
+  top of every `then` container (#3850 last-wins), so the LAST container
+  supplies the counted fields — `{off; pool P}` then `{interface; pool P}`
+  resolves to `{Iface:true Pool:"P"}` and the reverse order to
+  `{Off:true Pool:"P"}`, both printing the identical message. The clause is now
+  scoped to the block and the parenthetical carries the cross-container case.
+  (#7034) "this rejects contradictory actions inside one block" is false for
+  every token-packed spelling: the packed branch reads `t.Keys[1]` alone, so
+  `then { source-nat off pool P; }` → `{Off:true}`,
+  `then { source-nat pool P off; }` and `then { source-nat { pool P off; } }` →
+  `{PoolName:"P"}`, and flat `set … then source-nat pool P off` →
+  `{PoolName:"P"}` — all ACCEPT under strict, DNAT identically. The
+  parenthetical now states the shape it covers and names #7033 for the rest.
+  Also narrowed the same overreach in the function's doc comment ("not by
+  anything the operator wrote"), added the packed-token converse to
+  `natThenTerminalActionCount`'s doc, and updated `docs/config-schema.md`,
+  which carried the #7035 phrase verbatim.
+  Mutation-checked, exit codes from `$?`: (1) restore the old message →
+  `TestNATTerminalActionMessageContent_6820` rc=1 with 4 missing substrings;
+  (2) delete the per-container `rule.Then = NATThen{}` reset →
+  `TestNATTerminalActionContainerOrderPicksSurvivor_7035` rc=1, both orders
+  collapsing to `{Off:true Interface:true}`; (3) make the packed branch also
+  read a trailing `off` (i.e. simulate the #7033 fix) →
+  `TestNATTerminalActionPackedContradictionCommits_7034` rc=1. Message +
+  comments + docs + tests; the compiler's behaviour is unchanged, nothing
+  reaches the helper binary, no smoke owed.
+- **File(s)**: pkg/config/compiler_validate_strict_nat.go,
+  pkg/config/compiler_nat_terminal_action_5628_test.go,
+  pkg/config/compiler_nat_conflict_message_7034_test.go,
+  docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3257,7 +3257,29 @@ rule `off` > `interface` > `pool`. For destination NAT the COMPILER resolves
 looks the pool up, and publishes `PoolAddress: ""`, so "every action is
 published" is false for a DNAT rule; the dataplane's `off` > `pool` branch then
 covers any entry that arrives carrying both. Either way all but one authored
-action is discarded, and the survivor is not chosen by configuration order.
+action is discarded, and *within that block* the survivor is decided by the
+fixed precedence rather than by the order the actions were written.
+
+Scope that to the block and no further (#7035). Across duplicate `then`
+CONTAINERS configuration order DOES decide: `compileNATSource` /
+`compileNATDestination` reset `rule.Then` at the top of every container, so the
+LAST one supplies the fields that get counted — swap
+`then { source-nat { off; pool P; } }` with
+`then { source-nat { interface; pool P; } }` and the surviving action changes
+from `interface` to `off` while the rejection text is identical. Both rows are
+pinned by `TestNATTerminalActionContainerOrderPicksSurvivor_7035`.
+
+And the gate counts RESOLVED FIELDS, not authored tokens, which bounds what it
+can see (#7034). The packed branch of those compilers reads a single key
+(`switch t.Keys[1]`), so a contradiction whose tokens sit on ONE node —
+`then { source-nat off pool P; }`, `then { source-nat pool P off; }`,
+`then { source-nat { pool P off; } }`, or the flat
+`set … then source-nat pool P off` — lowers to a single field, counts as one
+action and COMMITS under strict, with the dropped action silently gone. The
+same holds for `destination-nat`. That is the behaviour gap #7033; the
+rejection message names it rather than claiming the block-level case is
+covered. `TestNATTerminalActionPackedContradictionCommits_7034` pins each
+spelling, so closing #7033 has to update this text too.
 
 *What the tolerant path actually does (#5717).* Only a malformed rule reaches
 the lenient arm — the strict commit path rejects it — but the two arities land

--- a/pkg/config/compiler_nat_conflict_message_7034_test.go
+++ b/pkg/config/compiler_nat_conflict_message_7034_test.go
@@ -1,0 +1,201 @@
+package config
+
+import "testing"
+
+// #7034 / #7035: the 2+-action NAT rejection message made two claims about
+// itself that were false at the head that shipped them. These tests pin the
+// behaviour the corrected message describes, so the message is checked rather
+// than asserted — a claim about a compiler's coverage is exactly the kind that
+// rots silently, because nothing reads it but a human.
+
+// TestNATTerminalActionPackedContradictionCommits_7034 pins the BOUND on the
+// cardinality gate: it counts RESOLVED fields, so a contradiction whose tokens
+// are packed onto one node lowers to a single action and commits under strict.
+//
+// The old parenthetical read "this rejects contradictory actions inside one
+// block", which is a completeness claim over the block-level case. It is false
+// for every packed spelling below: the compiler's packed branch switches on
+// `t.Keys[1]` alone (compileNATSource / compileNATDestination) and drops the
+// rest, so the operator gets a green commit for a rule whose authored `off`
+// exemption was silently discarded, or whose pool was.
+//
+// This test pins a GAP, deliberately. The gap is #7033, and closing it flips
+// every "want accept" here to a rejection — that is the point: the flip has to
+// be a deliberate edit to this file, not a silent divergence from the message.
+func TestNATTerminalActionPackedContradictionCommits_7034(t *testing.T) {
+	snat := func(then string) string {
+		return `
+security {
+    nat {
+        source {
+            pool P { address 203.0.113.5; }
+            rule-set RS {
+                from zone trust;
+                to zone untrust;
+                rule R1 {
+                    match { source-address 10.0.0.0/24; }
+                    ` + then + `
+                }
+            }
+        }
+    }
+}`
+	}
+
+	for _, tc := range []struct {
+		name     string
+		then     string
+		wantOff  bool
+		wantPool string
+	}{
+		// `off` first: the pool is dropped.
+		{"packed off then pool", "then { source-nat off pool P; }", true, ""},
+		// `pool` first: the exemption is dropped — the dangerous direction.
+		{"packed pool then off", "then { source-nat pool P off; }", false, "P"},
+		// Same contradiction one level down, packed onto the child's keys.
+		{"packed child node", "then { source-nat { pool P off; } }", false, "P"},
+	} {
+		cfg, err := compileHier5628(t, snat(tc.then))
+		if err != nil {
+			t.Fatalf("%s: strict CompileConfig REJECTED %q. If #7033 is now fixed, this "+
+				"test and the gate's message (which names #7033 as the open case) must "+
+				"both be updated — do not just delete the case: %v", tc.name, tc.then, err)
+		}
+		got := cfg.Security.NAT.Source[0].Rules[0].Then
+		if got.Off != tc.wantOff || got.PoolName != tc.wantPool {
+			t.Errorf("%s: resolved Then={Off:%v Interface:%v PoolName:%q}, want "+
+				"{Off:%v PoolName:%q} — the packed branch's single-key read is what "+
+				"makes the count one",
+				tc.name, got.Off, got.Interface, got.PoolName, tc.wantOff, tc.wantPool)
+		}
+		if n := natThenTerminalActionCount(got); n != 1 {
+			t.Errorf("%s: natThenTerminalActionCount=%d, want 1 — this test exists "+
+				"because the packed contradiction is counted as ONE action", tc.name, n)
+		}
+	}
+
+	// The flat `set` spelling packs the same way, and is the shape an operator
+	// actually types.
+	flat := buildTree(t, []string{
+		"set security nat source pool P address 203.0.113.5",
+		"set security nat source rule-set RS from zone trust",
+		"set security nat source rule-set RS to zone untrust",
+		"set security nat source rule-set RS rule R1 match source-address 10.0.0.0/24",
+		"set security nat source rule-set RS rule R1 then source-nat pool P off",
+	})
+	cfg, err := CompileConfig(flat)
+	if err != nil {
+		t.Fatalf("flat `then source-nat pool P off`: strict CompileConfig REJECTED it; "+
+			"if #7033 is fixed, update the gate message too: %v", err)
+	}
+	if got := cfg.Security.NAT.Source[0].Rules[0].Then; got.PoolName != "P" || got.Off {
+		t.Errorf("flat packed: Then={Off:%v PoolName:%q}, want {false P}", got.Off, got.PoolName)
+	}
+
+	// Destination NAT packs identically — the corrected message is shared by
+	// both kinds, so the claim it makes has to be true of both.
+	dnat, err := compileHier5628(t, `
+security {
+    nat {
+        destination {
+            pool PD { address 10.0.30.100; }
+            rule-set RD {
+                from zone untrust;
+                rule R1 {
+                    match { destination-address 198.51.100.1/32; }
+                    then { destination-nat pool PD off; }
+                }
+            }
+        }
+    }
+}`)
+	if err != nil {
+		t.Fatalf("packed DNAT contradiction: strict CompileConfig REJECTED it; if #7033 "+
+			"is fixed, update the gate message too: %v", err)
+	}
+	if got := dnat.Security.NAT.Destination.RuleSets[0].Rules[0].Then; got.PoolName != "PD" || got.Off {
+		t.Errorf("packed DNAT: Then={Off:%v PoolName:%q}, want {false PD}", got.Off, got.PoolName)
+	}
+}
+
+// TestNATTerminalActionContainerOrderPicksSurvivor_7035 pins that configuration
+// order DOES choose the survivor across duplicate `then` containers — the case
+// in which the old unscoped clause ("the survivor is not chosen by
+// configuration order") was printed and false.
+//
+// Both fixtures below carry the SAME two containers and differ only in their
+// order. Both are rejected by the strict gate (each container carries two
+// actions, so the count on the winning container is two) and both print the
+// message. On the tolerant path — the one an already-persisted or peer-synced
+// config takes — the #3850 reset makes the LAST container supply the fields, so
+// the surviving action flips between `interface` and `off` with the order.
+func TestNATTerminalActionContainerOrderPicksSurvivor_7035(t *testing.T) {
+	cfgText := func(first, second string) string {
+		return `
+security {
+    nat {
+        source {
+            pool P { address 203.0.113.5; }
+            rule-set RS {
+                from zone trust;
+                to zone untrust;
+                rule R1 {
+                    match { source-address 10.0.0.0/24; }
+                    then { source-nat { ` + first + ` pool P; } }
+                    then { source-nat { ` + second + ` pool P; } }
+                }
+            }
+        }
+    }
+}`
+	}
+
+	for _, tc := range []struct {
+		name          string
+		first, second string
+		wantOff       bool
+		wantInterface bool
+	}{
+		{"off first, interface last", "off;", "interface;", false, true},
+		{"interface first, off last", "interface;", "off;", true, false},
+	} {
+		text := cfgText(tc.first, tc.second)
+
+		// Strict rejects both, with the same message — which is why an unscoped
+		// "not chosen by configuration order" was false in exactly the case that
+		// printed it.
+		p := NewParser(text)
+		tree, perrs := p.Parse()
+		if len(perrs) > 0 {
+			t.Fatalf("%s: Parse: %v", tc.name, perrs)
+		}
+		if _, err := CompileConfig(tree); err == nil {
+			t.Fatalf("%s: strict CompileConfig ACCEPTED a rule whose winning `then` "+
+				"container carries two actions", tc.name)
+		}
+
+		// The tolerant survivor is what container order actually selects.
+		p2 := NewParser(text)
+		tree2, perrs2 := p2.Parse()
+		if len(perrs2) > 0 {
+			t.Fatalf("%s: Parse (lenient): %v", tc.name, perrs2)
+		}
+		cfg, err := CompileConfigLenient(tree2)
+		if err != nil {
+			t.Fatalf("%s: CompileConfigLenient must not brick on a malformed rule "+
+				"(#1960): %v", tc.name, err)
+		}
+		got := cfg.Security.NAT.Source[0].Rules[0].Then
+		if got.Off != tc.wantOff || got.Interface != tc.wantInterface {
+			t.Errorf("%s: resolved Then={Off:%v Interface:%v PoolName:%q}, want "+
+				"{Off:%v Interface:%v} — the LAST container supplies the fields "+
+				"(#3850), so swapping the containers swaps which contradiction, and "+
+				"therefore which surviving action, the operator gets",
+				tc.name, got.Off, got.Interface, got.PoolName, tc.wantOff, tc.wantInterface)
+		}
+		if got.PoolName != "P" {
+			t.Errorf("%s: PoolName=%q, want P (the pool is authored in both containers)",
+				tc.name, got.PoolName)
+		}
+	}
+}

--- a/pkg/config/compiler_nat_terminal_action_5628_test.go
+++ b/pkg/config/compiler_nat_terminal_action_5628_test.go
@@ -102,7 +102,26 @@ func TestNATTerminalActionMessageContent_6820(t *testing.T) {
 		// the wrong one, in a round whose subject was an operator-facing sentence
 		// being false. Assert the exact phrase, because the loose form reads
 		// better and that is precisely where it wins.
-		"the survivor is not chosen by configuration order",
+		//
+		// #7035 narrowed that phrase. The unscoped form ("the survivor is not
+		// chosen by configuration order") was false in exactly the case that
+		// prints it: with duplicate `then` CONTAINERS the #3850 reset makes the
+		// LAST container supply the counted fields, so container order selects
+		// which contradiction — and therefore which survivor — you get. The
+		// clause is now scoped to the block, and the parenthetical carries the
+		// cross-container case. Both halves are asserted, so neither the old
+		// unscoped form nor a silent drop of the scope can return.
+		"WITHIN THIS BLOCK, the survivor is decided by that fixed precedence " +
+			"rather than by the order the actions were written",
+		"container order therefore does decide WHICH contradiction you get here",
+		// #7034: the parenthetical used to end "this rejects contradictory
+		// actions inside one block", which reads as a completeness claim and is
+		// false for every token-packed spelling (`source-nat pool P off` and
+		// friends lower to ONE field and commit — see
+		// TestNATTerminalActionPackedContradictionCommits_7034). It now states
+		// the shape it actually covers and names #7033 for the rest.
+		"a contradiction whose tokens are PACKED onto one node",
+		"#7033",
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("2+-action SNAT rejection missing %q — the message must describe the "+

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -2768,6 +2768,14 @@ func validateStaticNATSingleTargetStrict(cfg *Config) error {
 // carries contradictory actions (e.g. `off` + `pool`, or a single hierarchical
 // `source-nat { interface; pool P; }` node, which #5628's setter change now
 // records as two set fields rather than silently picking one by child order).
+//
+// The converse does NOT hold, and the gate's message must not imply it
+// (#7034): a count of ONE does not mean the block carried one action. A
+// contradiction whose tokens are packed onto a single node —
+// `source-nat pool P off`, `source-nat off pool P`, `source-nat { pool P off; }`
+// — never reaches two fields, because the packed branch of compileNATSource /
+// compileNATDestination reads `t.Keys[1]` alone and drops the rest. Those
+// spellings resolve to one field, count one, and commit. Tracked as #7033.
 func natThenTerminalActionCount(then NATThen) int {
 	n := 0
 	if then.Interface {
@@ -2797,8 +2805,15 @@ func natThenTerminalActionCount(then NATThen) int {
 //
 //   - TWO OR MORE actions (contradictory, mutually-exclusive translations such
 //     as `off` + `pool` or `interface` + `pool` inside ONE block): all but one
-//     authored action is silently discarded, and the survivor is chosen by a
-//     FIXED precedence, not by anything the operator wrote. WHERE that happens
+//     authored action is silently discarded, and WITHIN THAT BLOCK the survivor
+//     is chosen by a FIXED precedence rather than by the order the actions were
+//     written. Scope that to the block and no further (#7035): across duplicate
+//     `then` CONTAINERS configuration order DOES decide, because the reset
+//     below makes the LAST container the one that supplies the fields — swap
+//     `then { source-nat { off; pool P; } }` with
+//     `then { source-nat { interface; pool P; } }` and the surviving action
+//     changes from `interface` to `off` while the message stays the same.
+//     WHERE that happens
 //     differs by kind, and the two do NOT share a mechanism (#6820 round 3):
 //     source NAT publishes every authored field (the #5628 else-if→if setter
 //     change) and the DATAPLANE picks `off` > `interface` > `pool`; destination
@@ -2816,7 +2831,22 @@ func natThenTerminalActionCount(then NATThen) int {
 // CONTAINERS are #3850's intentional last-wins merge (compileNAT resets
 // rule.Then per block, so the count reflects the winning block) and are NOT
 // rejected here — a rule with two `then` blocks each naming one action still
-// commits. Strict on commit / commit-check (hard reject so the malformed rule
+// commits.
+//
+// It counts RESOLVED FIELDS, not authored tokens, and that is a real bound on
+// the gate rather than a restatement of it (#7034). The compiler reads a
+// packed `source-nat`/`destination-nat` node by a SINGLE key —
+// `switch t.Keys[1]` in compileNATSource / compileNATDestination — so every
+// token-packed spelling of a contradiction lowers to ONE field and is counted
+// as one action: `then { source-nat off pool P; }` resolves to `{Off:true}`,
+// `then { source-nat pool P off; }` and `then { source-nat { pool P off; } }`
+// to `{PoolName:"P"}`, and the flat `set … then source-nat pool P off` to
+// `{PoolName:"P"}` — all four COMMIT under strict (measured through
+// CompileConfig at f8e720c3e; the DNAT spellings behave identically). So a
+// count of one does not mean the operator wrote one action, and this gate must
+// not be read as covering the block-level case in general. That gap is the
+// behaviour half, #7033; the message below says so rather than claiming the
+// strong form. Strict on commit / commit-check (hard reject so the malformed rule
 // is operator-visible); the caller downgrades to a warning on the tolerant load
 // / peer-sync path (opts.lenientNATTerminalAction, #1960 no-brick). Only a
 // malformed rule reaches that path — the strict commit path rejects it — but
@@ -2949,10 +2979,16 @@ func validateNATTerminalActionCardinalityStrict(cfg *Config) error {
 					return fmt.Errorf(
 						"%s-nat rule-set %q rule %q: `then` carries %d mutually-exclusive "+
 							"translation actions (expected exactly one of %s); %s, so all but "+
-							"one action is silently discarded and the survivor is not chosen "+
-							"by configuration order. (Duplicate `then` CONTAINERS resolve "+
-							"last-wins per #3850; this rejects contradictory actions inside one "+
-							"block.)",
+							"one action is silently discarded and, WITHIN THIS BLOCK, the "+
+							"survivor is decided by that fixed precedence rather than by the "+
+							"order the actions were written. (Duplicate `then` CONTAINERS "+
+							"resolve last-wins per #3850, so a rule with several containers is "+
+							"counted on the LAST one — container order therefore does decide "+
+							"WHICH contradiction you get here. This gate counts the actions the "+
+							"rule RESOLVED to, so it catches a block that LOWERS two distinct "+
+							"actions; a contradiction whose tokens are PACKED onto one node, as "+
+							"in `pool <p> off`, lowers to a single action, is counted as one and "+
+							"is NOT caught here — tracked as #7033.)",
 						kind, rs.Name, rule.Name, n, actions, mechanism)
 				}
 			}


### PR DESCRIPTION
The #5628 terminal-action-cardinality rejection ends with two claims about itself. Neither is true at the head that ships them. They are two distinct claims but **one `fmt.Errorf` format string** — correcting one without the other leaves a false sentence standing and guarantees a textual conflict — so this PR closes both.

## The old text

> ...so all but one action is silently discarded and **the survivor is not chosen by configuration order**. (Duplicate `then` CONTAINERS resolve last-wins per #3850; **this rejects contradictory actions inside one block**.)

## #7035 — configuration order DOES choose the survivor

`compileNATSource` resets `rule.Then` at the top of every `then` container (#3850 last-wins), so the LAST container supplies the counted fields. Measured at `f8e720c3e`, only the order differing:

```
then { source-nat { off; pool P; } } then { source-nat { interface; pool P; } }
    strict REJECT   tolerant survivor {Interface:true PoolName:"P"}

then { source-nat { interface; pool P; } } then { source-nat { off; pool P; } }
    strict REJECT   tolerant survivor {Off:true PoolName:"P"}
```

Both print the identical message. The precedence claim is true **within a block** and false across containers → clause scoped to the block, parenthetical now carries the cross-container case.

## #7034 — the gate does not reject every contradiction "inside one block"

It counts RESOLVED FIELDS, and the packed branch reads `t.Keys[1]` alone:

```
then { source-nat off pool P; }        ACCEPT {Off:true}     pool dropped
then { source-nat pool P off; }        ACCEPT {Pool:"P"}     off dropped
then { source-nat { pool P off; } }    ACCEPT {Pool:"P"}     off dropped
set … then source-nat pool P off       ACCEPT {Pool:"P"}     off dropped
```

`destination-nat` packs identically. The parenthetical now says it catches a block that **lowers** two distinct actions and names #7033 for the packed case.

Also narrowed: the function doc's "not by anything the operator wrote", `natThenTerminalActionCount`'s doc (added the converse), and `docs/config-schema.md`, which carried the #7035 phrase verbatim.

## Binding — both claims are checkable, so both are pinned

- `TestNATTerminalActionContainerOrderPicksSurvivor_7035` — runs both container orders, asserts the survivor flips.
- `TestNATTerminalActionPackedContradictionCommits_7034` — all four packed spellings plus DNAT; asserts each commits with count 1. **Pins a gap deliberately**: closing #7033 flips every row and the failure message says so.
- `TestNATTerminalActionMessageContent_6820` — now requires the scoped survivor clause, the container-order clause, the packed-node clause and `#7033`.

Mutation-checked, exit codes from `$?`:

| mutation | result |
|---|---|
| restore the old message | `TestNATTerminalActionMessageContent_6820` rc=1, 4 missing substrings |
| delete the per-container `rule.Then = NATThen{}` reset | `…ContainerOrderPicksSurvivor_7035` rc=1, both orders collapse to `{Off:true Interface:true}` |
| packed branch also reads a trailing `off` (simulates the #7033 fix) | `…PackedContradictionCommits_7034` rc=1 |

## Validation

`go build ./...` rc=0 · `go vet ./pkg/config/` rc=0 · `go test -count=1 ./pkg/config/` rc=0 (15.0s) · `go test -count=1 ./pkg/dataplane/userspace/ -run '5717|Contradictory|NATTerminal'` rc=0 (the tolerant path wraps this message into `cfg.Warnings`). No new gofmt offenders.

Message text, comments, docs and tests only — **compiler behaviour unchanged, nothing reaches the helper binary, no cluster smoke owed.**

Closes #7034
Closes #7035