### PR TITLE
test(session-glue): red on a reverted reverse-materialize session id

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -97280,3 +97280,33 @@ prose edit above them added. No diff falls in the new test body.
   pkg/config/wireguard_multiport_warning_1434_test.go,
   pkg/dataplane/userspace/wireguard_steering_advisory_1434_test.go,
   docs/wireguard-interop.md, _Log.md
+
+- **Timestamp**: 2026-08-21
+- **Action**: Added the missing fail-on-revert test for the #5212 session-id
+  adoption on the reverse-materialize path (#6313). `materialize_shared_session_hit`
+  (`userspace-dp/src/afxdp/session_glue/mod.rs`) reinstalls a shared-map hit
+  into the worker-local table with `session_id: replica.session_id`, so a
+  reverse-direction packet that lands on a peer-synced entry keeps the
+  originating node's RT_FLOW correlation id. Reverting that argument to
+  `session_id: 0` reddened NO test: all 48 `session_id` occurrences in
+  `session_glue/tests.rs` were `session_id: 0,` compile-fills (census, not an
+  empty grep).
+
+  The new `reverse_materialized_shared_hit_adopts_replica_session_id_6313`
+  publishes a peer-synced REVERSE companion (`is_reverse: true`) carrying a
+  worker-9 peer id into the shared session map, pins the local table to worker
+  4, drives `resolve_flow_session_decision` with the reverse 5-tuple under an
+  ACTIVE owner RG (so the hit materializes rather than staying transient), and
+  asserts the materialized entry carries the peer id verbatim. A paired
+  negative control (a legacy peer sending id 0) asserts the fallback is a
+  fresh, non-zero, worker-4-namespaced local id.
+
+  Mutation-verified, exit codes read from `$?`, never through a pipe: reverting
+  the production line to `session_id: 0,` -> `cargo check --all-targets` rc=0
+  (an ASSERTION red, not a build break) and the new test rc=101, panicking on
+  the property assertion with left=0x0004000000000001 (a fresh worker-4 alloc)
+  vs right=the worker-9 peer id. Restored -> rc=0.
+
+  Test-only: no production source changed, so no helper binary movement and no
+  cluster smoke owed.
+- **File(s)**: userspace-dp/src/afxdp/session_glue/tests.rs, _Log.md

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -4313,6 +4313,145 @@ fn synced_session_hit_recomputes_local_resolution_after_failover() {
     assert_eq!(resolved.decision.resolution.tx_ifindex, 11);
 }
 
+// #6313 RED-on-revert: a reverse-direction packet whose 5-tuple hits a
+// peer-synced entry in the SHARED session map is materialized into this
+// worker's local table by `materialize_shared_session_hit`, and that
+// materialize must ADOPT the shared replica's stable session id rather than
+// mint a fresh node-local one (#5212). The reverse companion of a synced
+// session carries the SAME RT_FLOW correlation id as its forward half, so a
+// session that opens on the primary and closes on the standby after a
+// failover emits SESSION_CREATE / SESSION_CLOSE under one correlatable id in
+// BOTH directions.
+//
+// The wire-level adoption in `upsert_synced_with_origin` is covered by
+// `synced_import_adopts_peer_session_id_5212` (session/tests.rs); this test
+// covers the session_glue CALLER — reverting the `session_id: replica.session_id`
+// argument in `materialize_shared_session_hit` back to `session_id: 0` makes
+// the install fall through to `alloc_session_id()` and reddens the first
+// assertion below. The local table is pinned to worker 4 and the peer id is
+// minted in worker 9's namespace so a fresh local alloc can never coincide
+// with the adopted value (the id space carries no node discriminator — #6311).
+#[test]
+fn reverse_materialized_shared_hit_adopts_replica_session_id_6313() {
+    let mut sessions = SessionTable::new();
+    sessions.set_worker_id(4);
+
+    let forward = test_key();
+    // The reverse companion: server -> client, ports swapped.
+    let reverse = SessionKey {
+        addr_family: forward.addr_family,
+        protocol: forward.protocol,
+        src_ip: forward.dst_ip,
+        dst_ip: forward.src_ip,
+        src_port: forward.dst_port,
+        dst_port: forward.src_port,
+    };
+    // A second reverse companion (different client port) for the negative
+    // control below.
+    let reverse_legacy = SessionKey {
+        src_port: forward.dst_port,
+        dst_port: forward.src_port + 1,
+        ..reverse.clone()
+    };
+
+    let peer_session_id: u64 = (9u64 << 48) | 0x5212;
+    let mut reverse_metadata = test_metadata();
+    reverse_metadata.is_reverse = true;
+
+    let forwarding = test_forwarding_state();
+    let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+    for (key, session_id) in [
+        (reverse.clone(), peer_session_id),
+        // Control: a legacy peer that predates the #5212 wire field sends 0.
+        (reverse_legacy.clone(), 0u64),
+    ] {
+        publish_shared_session(
+            &shared_sessions,
+            &shared_nat_sessions,
+            &shared_forward_wire_sessions,
+            &shared_owner_rg_indexes,
+            &SyncedSessionEntry {
+                key,
+                decision: test_decision(),
+                metadata: reverse_metadata.clone(),
+                origin: SessionOrigin::SyncImport,
+                protocol: PROTO_TCP,
+                tcp_flags: TCP_FLAG_ACK,
+                // #2170 test fixture: no peer install generation.
+                generation: 0,
+                session_id,
+            },
+        );
+    }
+
+    let peer_worker_commands = Vec::new();
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+    let now_secs = monotonic_nanos() / 1_000_000_000;
+    // RG 1 (the reverse companion's owner) is locally active, so the shared hit
+    // is NOT held transient and takes the materialize path.
+    let ha_state = BTreeMap::from([(1, active_ha_runtime(now_secs))]);
+
+    for key in [&reverse, &reverse_legacy] {
+        resolve_flow_session_decision(
+            &mut sessions,
+            -1,
+            &shared_sessions,
+            &shared_nat_sessions,
+            &shared_forward_wire_sessions,
+            &shared_owner_rg_indexes,
+            &peer_worker_commands,
+            &forwarding,
+            &ha_state,
+            &dynamic_neighbors,
+            &SessionFlow {
+                src_ip: key.src_ip,
+                dst_ip: key.dst_ip,
+                forward_key: key.clone(),
+            },
+            1_000_000,
+            now_secs,
+            PROTO_TCP,
+            TCP_FLAG_ACK,
+            5,
+            false,
+            0,
+            0,
+        )
+        .expect("the reverse shared-session hit should resolve");
+    }
+
+    // THE PROPERTY (#6313): the reverse-materialized entry carries the
+    // replica's id verbatim. Reverting `materialize_shared_session_hit` to
+    // `session_id: 0` reds here with a worker-4 local alloc.
+    assert_eq!(
+        sessions.session_id_for(&reverse),
+        peer_session_id,
+        "a reverse-materialized shared-session hit must ADOPT the replica's \
+         session id so both directions correlate across HA nodes (#5212/#6313)"
+    );
+
+    // NEGATIVE CONTROL (passes with and without the revert): a replica with no
+    // wire id still gets a fresh, non-zero, node-local id — the materialize
+    // path must never leave a session unstamped.
+    let control_id = sessions.session_id_for(&reverse_legacy);
+    assert_ne!(
+        control_id, 0,
+        "a zero replica id must fall back to a fresh local alloc, not 0"
+    );
+    assert_eq!(
+        control_id >> 48,
+        4,
+        "the fallback id must be namespaced to THIS node's worker (4)"
+    );
+    assert_ne!(
+        control_id, peer_session_id,
+        "the fallback must be a fresh LOCAL id, never the adopted peer id"
+    );
+}
+
 // === #1346 dispatcher order-pin + dedup test =================================
 //
 // Round-2 Codex review required two test additions:


### PR DESCRIPTION
## Summary

Closes #6313

`materialize_shared_session_hit` (`userspace-dp/src/afxdp/session_glue/mod.rs:1238`,
adoption at `:1258`) reinstalls a shared session-map hit into the worker-local
table with `session_id: replica.session_id`, so a reverse-direction packet that
lands on a peer-synced entry adopts the originating node's RT_FLOW correlation
id (#5212) rather than minting a fresh node-local one. Reverting that argument
to `session_id: 0` reddened **no** test: all 48 `session_id` occurrences in
`session_glue/tests.rs` were `session_id: 0,` compile-fills (established by
census — `git grep -n 'session_id' -- .../session_glue/tests.rs | grep -v 'session_id: 0,'`
returns empty — not by an empty grep). Only the wire-level adoption inside
`upsert_synced_with_origin` was bound, by `synced_import_adopts_peer_session_id_5212`
in `session/tests.rs`; the session_glue **caller** was uncovered.

## The test

`reverse_materialized_shared_hit_adopts_replica_session_id_6313`:

- publishes a peer-synced **reverse companion** (`is_reverse: true`, keyed by
  the reversed 5-tuple) carrying a worker-9 peer id into the shared session map;
- pins the local table to worker 4 with `set_worker_id`, so a fresh local alloc
  can never coincide with the adopted value (the id namespace carries no node
  discriminator — #6311);
- drives `resolve_flow_session_decision` with the reverse key under an **active**
  owner RG, so the hit takes the materialize path instead of being held
  transient;
- asserts the materialized local entry carries the peer id verbatim.

A paired **negative control** in the same test publishes a second reverse
companion with a zero id (a legacy peer predating the #5212 wire field) and
asserts the fallback is a fresh, non-zero id in this node's worker-4 namespace,
never the peer's. It passes with and without the revert and is labelled as such
in the test.

## Validation

Exit codes read from `$?` directly, never through a pipe.

| step | result |
|---|---|
| new test at HEAD | `rc=0` |
| revert `session_id: replica.session_id` -> `session_id: 0`, `cargo check --all-targets` | `rc=0` (so the red is an ASSERTION, not a build break) |
| revert, run the new test | `rc=101`, panics on the property assertion: `left: 1125899906842625` (`0x0004000000000001`, a fresh worker-4 alloc) vs `right: 2533274790416914` (the worker-9 peer id) |
| restore | `rc=0` |
| `cargo test --manifest-path userspace-dp/Cargo.toml -- --test-threads=1` | `rc=0`, 4447 passed / 0 failed |

## Smoke

**Test-only** — no production source changed, so the helper binary does not move
and no cluster smoke is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126EmRvxtxzSUPiZD9XBrAT