### PR TITLE
docs(api): re-measure the serveBound drain cells and state both

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -97280,3 +97280,32 @@ prose edit above them added. No diff falls in the new test body.
   pkg/config/wireguard_multiport_warning_1434_test.go,
   pkg/dataplane/userspace/wireguard_steering_advisory_1434_test.go,
   docs/wireguard-interop.md, _Log.md
+
+## #7046 — pkg/api README's "reds only …" cell was false at the head that ships it
+
+- **Timestamp**: 2026-08-21
+- **Action**: Re-measured both mutation cells for the HTTPS `drainLeg` in
+  `Server.serveBound` and rewrote the paragraph to state what was observed, at
+  the head it was observed at. Baseline `go test ./pkg/api/ -count=1` at
+  f8e720c3e rc=0 (42.9s), so both reds below are attributable. (A) DELETING the
+  HTTPS `drainLeg` reds TWO: `TestRunGracefulShutdownClosesBothListeners`
+  (10.02s, `server_run_leak_5058_test.go:152`, "Run did not return after ctx
+  cancellation") and `TestServeBoundSeversInFlightResponses_6827` (30.01s,
+  `tls_stale_cert_6827_test.go:1393`, "serveBound did not return after ctx
+  cancellation"); rc=1. Both fail on the JOIN — with no `Shutdown` the HTTPS
+  `Serve` goroutine is never unblocked and `wg.Wait()` never returns — so
+  neither reaches a severing assertion. (B) REVERTING it to a bare `Shutdown`
+  (deadline, no `Close`) reds ONE, `TestServeBoundSeversInFlightResponses_6827`
+  alone (3.56s, `tls_stale_cert_6827_test.go:1404`, HTTPS connection "still
+  OPEN 3s later"), with `TestRunGracefulShutdownClosesBothListeners` PASSING;
+  rc=1. So the "listener CLOSES vs response SEVERED" distinction the paragraph
+  drew is real but was attached to the wrong mutation — it is cell B that
+  isolates severing. The pre-round-11 claims are kept, in the past tense, as
+  what they were: measurements of a tree in which the cell passed `nil` for
+  `httpsLn`. Also recorded why this class of claim rots: a "reds only X"
+  statement is about the rest of the suite and no test can assert it, so the
+  mutation + head + cells must be written down instead of a bare count.
+  Markdown only — `pkg/api/server.go` was mutated for the measurement and
+  restored byte-identical (`git status` clean before commit); no runtime
+  change, nothing reaches the helper binary, no smoke owed.
+- **File(s)**: pkg/api/README.md, _Log.md

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -1088,12 +1088,39 @@ under the daemon's errgroup. Nothing else imports this package.
       fixing it cheap rather than optional: narrowing the invariant instead would
       have left the shape in the tree for the next reader to copy. Bound by
       `TestServeBoundSeversInFlightResponses_6827`, which runs BOTH legs with a
-      stream held on each (#6827 round 11). It used to pass `nil` for `httpsLn`,
-      so it never entered the `if s.httpsServer != nil` branch and reverting
-      THAT statement alone to a bare `Shutdown` left `pkg/api` and `pkg/daemon`
-      green — deleting it reds only
-      `TestRunGracefulShutdownClosesBothListeners`, which asserts the listener
-      CLOSES, not that a response is SEVERED. Round 10's own revert mutation
+      stream held on each (#6827 round 11). BEFORE round 11 that cell passed
+      `nil` for `httpsLn`, so it never entered the `if s.httpsServer != nil`
+      branch and the HTTPS statement was unbound: against THAT tree, reverting
+      it alone to a bare `Shutdown` left `pkg/api` and `pkg/daemon` green, and
+      deleting it redded only `TestRunGracefulShutdownClosesBothListeners`.
+      Neither cell was re-measured when round 11 bound the HTTPS leg, and the
+      second stopped being true (#7046). Re-measured on the SHIPPED tree — head
+      `f8e720c3e`, `pkg/api` green at baseline, exit codes read from `$?`:
+
+      - **Deleting** the HTTPS `drainLeg` reds TWO, not one:
+        `TestRunGracefulShutdownClosesBothListeners`
+        (`server_run_leak_5058_test.go:152`, "Run did not return after ctx
+        cancellation") and `TestServeBoundSeversInFlightResponses_6827`
+        (`tls_stale_cert_6827_test.go:1393`, "serveBound did not return after
+        ctx cancellation"). Both fail on the SAME observable and neither
+        reaches its severing assertion: with no `Shutdown` at all the HTTPS
+        `Serve` goroutine is never unblocked, so `wg.Wait()` never joins.
+      - **Reverting** it to a bare `Shutdown` (deadline, no `Close`) reds ONE:
+        `TestServeBoundSeversInFlightResponses_6827` alone
+        (`tls_stale_cert_6827_test.go:1404` — the HTTPS connection "was still
+        OPEN 3s later"), with `TestRunGracefulShutdownClosesBothListeners`
+        PASSING.
+
+      So "the listener CLOSES, not a response SEVERED" is the right distinction
+      attached to the wrong mutation. It is the BARE-SHUTDOWN cell that isolates
+      severing, because a `Shutdown` still unblocks `Serve` and both tests get
+      their join; the DELETE cell is coarser — it breaks the join, which any
+      test that cancels and waits can see. Note also what cannot be fixed by
+      testing harder: a "reds only X" claim is a statement about the rest of the
+      suite, and no test can assert it. State the mutation, the head it was
+      measured at, and the observed cells — a bare count silently goes stale the
+      next time a fixture grows a leg, which is exactly what happened here.
+      Round 10's own revert mutation
       flipped both statements together, and the bound HTTP leg redded the cell
       and masked the unbound HTTPS one: a compound mutation cannot localise. The
       cell also ASSERTS the returned error now — `drainLeg` grew a return value


### PR DESCRIPTION
`pkg/api/README.md` told the next reader that deleting the HTTPS `drainLeg` from `Server.serveBound` **"reds only `TestRunGracefulShutdownClosesBothListeners`"**. At the head that sentence ships in, it reds **two**. The paragraph is three clauses in mixed tense about two different trees, and the present-tense one describes the tree that existed *before* round 11 bound the HTTPS leg.

## What was measured

Both cells re-run on the shipped tree (`f8e720c3e`). `go test ./pkg/api/ -count=1` is **green at baseline** (rc=0, 42.9s), so both reds are attributable. Exit codes read from `$?`, never through a pipe.

| mutation | rc | reds |
|---|---|---|
| **A. Delete** the HTTPS `drainLeg` | 1 | `TestRunGracefulShutdownClosesBothListeners` (10.02s, `server_run_leak_5058_test.go:152`, "Run did not return after ctx cancellation") **and** `TestServeBoundSeversInFlightResponses_6827` (30.01s, `tls_stale_cert_6827_test.go:1393`, "serveBound did not return after ctx cancellation") |
| **B. Revert** it to a bare `Shutdown` (deadline, no `Close`) | 1 | `TestServeBoundSeversInFlightResponses_6827` **alone** (3.56s, `tls_stale_cert_6827_test.go:1404`, HTTPS connection "still OPEN 3s later"); `TestRunGracefulShutdownClosesBothListeners` **passes** |

## What that actually means

The "listener CLOSES vs response SEVERED" distinction is real, but it belongs to **cell B**, not cell A. A bare `Shutdown` still unblocks `Serve`, so both tests get their join and only the round-11 cell — which holds an active stream on each leg — can see the missing `Close`. Deleting the statement outright is coarser: with no `Shutdown` at all the HTTPS `Serve` goroutine is never unblocked, `wg.Wait()` never joins, and both tests fail on that single observable without reaching any severing assertion.

The pre-round-11 claims are kept as history, in the past tense, named as measurements of the tree where the cell passed `nil` for `httpsLn`.

## Why it went stale, recorded in place

A "reds only X" claim is a statement about *the rest of the suite*, and no test can assert it — which is why round 11 could bind the HTTPS leg and leave the sentence about it standing. The paragraph now says to record the mutation, the head, and the observed cells rather than a bare count.

## Validation

Markdown only. `go build ./...` rc=0 · `go vet ./pkg/api/` rc=0 · the green `pkg/api` baseline above is this branch's base. `pkg/api/server.go` was mutated twice for the measurements and restored byte-identical (the diff is one file).

**No runtime change, nothing reaches the helper binary, no cluster smoke owed.**

Closes #7046