### PR TITLE
cluster: stop asserting a sync-ready gate on RG promotion

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -97280,3 +97280,42 @@ prose edit above them added. No diff falls in the new test body.
   pkg/config/wireguard_multiport_warning_1434_test.go,
   pkg/dataplane/userspace/wireguard_steering_advisory_1434_test.go,
   docs/wireguard-interop.md, _Log.md
+
+## #7102 — SetSyncReady's comment guaranteed a promotion gate deleted in 0781f7a60
+
+- **Timestamp**: 2026-08-21
+- **Action**: Corrected three source comments (and one doc section) that told a
+  reader RG promotion is gated on session-sync readiness in private-rg-election
+  mode. It is not, at `origin/master` f8e720c3e. Established firsthand:
+  `m.syncReady` is written and read only inside `pkg/cluster/sync_state.go`;
+  the complete non-test caller list for `IsSyncReady()` is the readiness
+  timeout at `pkg/daemon/daemon_ha_sync.go:45` plus two log fields at `:80` and
+  `:130`; and the readiness conjunction at
+  `pkg/daemon/daemon_ha_userspace_readiness.go:215` is
+  `ifReady && takeoverGateReady && fabricReady && userspaceReady` with no sync
+  term — `takeoverGateReady` in this mode is `checkNoRethTakeoverReadiness` →
+  `checkVIPReadiness`, i.e. VIP ownership alone. `git show 0781f7a60` confirms
+  the gate existed (`vrrpReady = d.cluster.IsSyncReady()`, blocker "session
+  sync not ready") and that the same commit replaced it with the VIP-only
+  check, with an empty commit body — so the rationale is unavailable. Per the
+  work item the gate was NOT restored (that is #110's scope and a behaviour
+  change); the comments now say plainly that promotion is not sync-gated, so a
+  reader is not misled in either direction. Sites: `SetSyncReady` doc
+  (sync_state.go), the `syncReady` field comment (manager.go), the
+  private-rg-election `armSyncReadyTimer` note (daemon_run_bringup.go, which
+  also claimed "without this ... would never become primary"), and a new
+  subsection in docs/session-sync-architecture.md, whose connection-lifecycle
+  list invites the same inference. Binding: the existing
+  `TestTakeoverReadinessForRG_NoRethIgnoresClusterSyncReady` already pinned the
+  behaviour but was uncited and used a fixture with BOTH `no-reth-vrrp` and
+  (by compiler default) `private-rg-election` set, so it could not say which
+  term selected the branch; added
+  `TestTakeoverReadinessForRG_PrivateRGElectionIgnoresClusterSyncReady_7102`
+  with `NoRethVRRP` asserted FALSE, and cited both from the comment. Mutation:
+  restoring the gate in `takeoverReadinessForRG` reds BOTH (rc=1 from `$?`,
+  reason `[session sync not ready]`). Comments, one test and docs — `git diff`
+  shows zero non-comment lines in the production Go files; no runtime change,
+  nothing reaches the helper binary, no smoke owed.
+- **File(s)**: pkg/cluster/sync_state.go, pkg/cluster/manager.go,
+  pkg/daemon/daemon_run_bringup.go, pkg/daemon/vip_readiness_test.go,
+  docs/session-sync-architecture.md, _Log.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -539,6 +539,25 @@ On disconnect:
 - the readiness timeout is invalidated with a generation guard so a stale timer
   callback cannot flip readiness back to true after disconnect
 
+### What cluster sync readiness does NOT do (#7102)
+
+It is not a promotion gate. Nothing in the RG readiness conjunction
+(`ifReady && takeoverGateReady && fabricReady && userspaceReady`,
+`pkg/daemon/daemon_ha_userspace_readiness.go`) reads
+`cluster.Manager.syncReady`; in no-RETH / private-rg-election mode
+`takeoverGateReady` is VIP ownership alone. A node in that mode can take over an
+RG before bulk sync completes. The gate that did read it — `vrrpReady =
+d.cluster.IsSyncReady()`, reporting `session sync not ready` as a takeover
+blocker — was deleted in `0781f7a60` (2026-04-05, empty commit body); whether it
+should return is **#110**, open. Today `IsSyncReady()` has exactly three
+production readers: the readiness timeout in `daemon_ha_sync.go` and two log
+fields.
+
+The **VRRP sync hold** released above is a real preemption suppressor, but it is
+a separate mechanism (`vrrp.Manager.SetSyncHold` / `ReleaseSyncHold`) armed only
+in RETH VRRP mode — do not read the two as one thing because they are released
+on the same edge.
+
 ### Pre-Auth Connection Admission (#5303)
 
 The accept loop admits every inbound connection into a small **pre-auth setup

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -412,10 +412,14 @@ type Manager struct {
 	// once readiness is established.
 	takeoverHoldTime time.Duration
 
-	// syncReady is true once bulk session sync has been received (or timed
-	// out). Used in private-rg-election / no-reth-vrrp mode as the
-	// equivalent of VRRP sync-hold — gates RG promotion until session state
-	// is synchronized from the peer.
+	// syncReady is true once bulk session sync has been received (or the
+	// readiness timeout released the hold). It gates NOTHING: no consumer
+	// reads it to decide RG promotion, in private-rg-election / no-reth-vrrp
+	// mode or any other (#7102). It was the no-RETH equivalent of the VRRP
+	// sync-hold until 0781f7a60 removed that gate; today its only production
+	// readers are the readiness timeout in pkg/daemon/daemon_ha_sync.go and
+	// two log fields. See SetSyncReady in sync_state.go for the full account
+	// and #110 for whether the gate should return.
 	syncReady bool
 
 	// syncTransport records whether session sync uses "fabric" or

--- a/pkg/cluster/sync_state.go
+++ b/pkg/cluster/sync_state.go
@@ -8,8 +8,37 @@ type SyncStatsProvider interface {
 	IsConnected() bool
 }
 
-// SetSyncReady marks session sync as ready (bulk sync received or timed out).
-// In private-rg-election mode this gates RG promotion via the readiness pipeline.
+// SetSyncReady marks session sync as ready (bulk sync received, or the
+// readiness timeout released the hold).
+//
+// It does NOT gate RG promotion, in private-rg-election mode or any other
+// (#7102). Say that plainly, because the opposite belief is the one #110 was
+// filed to prevent and this comment used to assert it: promotion readiness in
+// no-RETH / private-rg-election mode is VIP ownership ALONE
+// (checkNoRethTakeoverReadiness -> checkVIPReadiness, pkg/daemon), and the
+// readiness conjunction that consumes it — ifReady && takeoverGateReady &&
+// fabricReady && userspaceReady, in daemon_ha_userspace_readiness.go — carries
+// no sync term. A node in this mode can therefore take over an RG before bulk
+// session sync has completed.
+//
+// The gate DID exist: reconcileRGState set vrrpReady = d.cluster.IsSyncReady()
+// in no-RETH mode and reported "session sync not ready" as a takeover blocker,
+// until 0781f7a60 (2026-04-05) deleted it. That commit has an empty body, so
+// the rationale for the removal is unavailable and would need re-deriving;
+// whether the gate SHOULD come back is #110, still open. Do not restore it from
+// this comment.
+//
+// Pinned by TestTakeoverReadinessForRG_NoRethIgnoresClusterSyncReady and
+// TestTakeoverReadinessForRG_PrivateRGElectionIgnoresClusterSyncReady_7102
+// (pkg/daemon), which drive a reconcile with sync NOT ready and assert the RG
+// still reaches Ready with no "session sync not ready" reason.
+//
+// What the flag IS for: the readiness timeout in pkg/daemon/daemon_ha_sync.go,
+// which uses it to decide whether to release its own hold, and two log fields
+// on the sync connect/disconnect edges. Those are its only production readers.
+// The real preemption suppressor with a similar name is the VRRP sync-hold
+// (vrrp.Manager.SetSyncHold / ReleaseSyncHold), which is armed only in RETH
+// VRRP mode and is not this flag.
 func (m *Manager) SetSyncReady(ready bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/daemon/daemon_run_bringup.go
+++ b/pkg/daemon/daemon_run_bringup.go
@@ -231,10 +231,18 @@ func (d *Daemon) initManagers(configCompileFailed bool) error {
 		if cc.FabricInterface != "" && cc.FabricPeerAddress != "" && !cc.NoRethVRRP && !cc.PrivateRGElection {
 			d.vrrpMgr.SetSyncHold(30 * time.Second)
 		}
-		// Private-rg-election mode: gate RG promotion on session sync
-		// readiness with a 30s timeout fallback (mirrors VRRP sync-hold).
-		// Without this, standalone nodes or nodes with permanently-down
-		// peers would never become primary.
+		// Private-rg-election mode takes no VRRP sync-hold (the branch
+		// above excludes it), so arm the sync-ready timeout instead. Be
+		// exact about what that buys (#7102): cluster.Manager.syncReady
+		// does NOT gate RG promotion in this mode — takeover readiness
+		// here is VIP ownership alone (checkNoRethTakeoverReadiness) and
+		// the readiness conjunction has no sync term — so this is a bound
+		// on a reported/logged state, not on takeover. It is also not the
+		// only arm: the cold-start branch of onSessionSyncPeerConnected
+		// re-arms the timer (bumping syncReadyTimerGen, which supersedes
+		// this one), and this timer's callback returns early while no sync
+		// peer is connected. Whether promotion SHOULD be sync-gated is
+		// #110; do not read this call as already doing it.
 		if cc.PrivateRGElection && cc.FabricInterface != "" && cc.FabricPeerAddress != "" {
 			d.armSyncReadyTimer()
 		}

--- a/pkg/daemon/vip_readiness_test.go
+++ b/pkg/daemon/vip_readiness_test.go
@@ -342,6 +342,14 @@ func testStoreWithSetConfig(t *testing.T, lines []string) *configstore.Store {
 	return store
 }
 
+// TestTakeoverReadinessForRG_NoRethIgnoresClusterSyncReady pins that in
+// no-reth-vrrp mode the RG takeover gate does NOT consult cluster sync
+// readiness. Together with the private-rg-election sibling below it is the
+// binding for cluster.Manager.SetSyncReady's doc comment, which used to assert
+// the opposite (#7102): the gate that read IsSyncReady() here was deleted in
+// 0781f7a60 and takeover readiness is now VIP ownership alone. #110 tracks
+// whether it should return — if it does, this test and its sibling red, which
+// is the point.
 func TestTakeoverReadinessForRG_NoRethIgnoresClusterSyncReady(t *testing.T) {
 	store := testStoreWithSetConfig(t, []string{
 		"set chassis cluster cluster-id 1",
@@ -384,6 +392,78 @@ func TestTakeoverReadinessForRG_NoRethIgnoresClusterSyncReady(t *testing.T) {
 	for _, reason := range state.ReadinessReasons {
 		if strings.Contains(reason, "session sync not ready") {
 			t.Fatalf("unexpected session sync gating reason: %v", state.ReadinessReasons)
+		}
+	}
+}
+
+// TestTakeoverReadinessForRG_PrivateRGElectionIgnoresClusterSyncReady_7102 is
+// the same property reached through the OTHER spelling of the branch.
+//
+// The sibling above authors `no-reth-vrrp`, and because private-rg-election is
+// the compiler default (compiler_system.go sets PrivateRGElection unless
+// `no-private-rg-election` is present) that fixture has BOTH flags set — so it
+// cannot tell you which one selected the no-RETH takeover path. The comment
+// this binds names private-rg-election specifically, so this fixture sets
+// private-rg-election with NoRethVRRP left FALSE: the branch at
+// daemon_ha.go (`cc.NoRethVRRP || cc.PrivateRGElection`) is then taken solely
+// on the private-rg-election term, and the RG still reaches Ready with session
+// sync NOT ready and no "session sync not ready" reason.
+func TestTakeoverReadinessForRG_PrivateRGElectionIgnoresClusterSyncReady_7102(t *testing.T) {
+	store := testStoreWithSetConfig(t, []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster authentication-key test-cluster-psk-7102",
+		"set chassis cluster node 0",
+		"set chassis cluster private-rg-election",
+		"set chassis cluster redundancy-group 0 node 0 priority 200",
+		"set interfaces reth0 redundant-ether-options redundancy-group 0",
+		"set interfaces reth0 unit 0 family inet address 10.0.1.1/24",
+		"set interfaces ge-0/0/0 gigether-options redundant-parent reth0",
+	})
+
+	cc := store.ActiveConfig().Chassis.Cluster
+	if cc == nil || !cc.PrivateRGElection {
+		t.Fatalf("fixture must compile to PrivateRGElection=true, got %+v", cc)
+	}
+	if cc.NoRethVRRP {
+		t.Fatal("fixture must leave NoRethVRRP false so private-rg-election is the " +
+			"only term selecting the no-RETH takeover path")
+	}
+
+	cm := cluster.NewManager(0, 1)
+	cm.UpdateConfig(cc)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cm.Start(ctx)
+
+	d := &Daemon{
+		rgStates:     make(map[int]*rgStateMachine),
+		cluster:      cm,
+		store:        store,
+		vrrpMgr:      vrrp.NewManager(),
+		linkByNameFn: mockLinkByName(map[string]*testLink{"ge-0-0-0": newTestLink("ge-0-0-0", true)}),
+	}
+
+	if d.cluster.IsSyncReady() {
+		t.Fatal("sync must start NOT ready for this test to mean anything")
+	}
+
+	d.reconcileRGState()
+
+	state := d.cluster.GroupState(0)
+	if state == nil {
+		t.Fatal("expected RG 0 state")
+	}
+	if !state.Ready {
+		t.Fatalf("RG 0 not ready with session sync not ready: %v — promotion in "+
+			"private-rg-election mode is NOT sync-gated at HEAD (the gate was deleted "+
+			"in 0781f7a60). If this now reds because #110 restored the gate, update "+
+			"cluster.SetSyncReady's doc comment, the Manager.syncReady field comment "+
+			"and the daemon_run_bringup.go note with it", state.ReadinessReasons)
+	}
+	for _, reason := range state.ReadinessReasons {
+		if strings.Contains(reason, "session sync not ready") {
+			t.Fatalf("takeover readiness reported a sync reason %q; the readiness "+
+				"conjunction has no sync term (#7102)", state.ReadinessReasons)
 		}
 	}
 }


### PR DESCRIPTION
`cluster.Manager.SetSyncReady`'s doc comment said *"In private-rg-election mode this gates RG promotion via the readiness pipeline."* It does not. The gate existed and was deleted; the comment stayed — so the source asserts the safety property **#110** exists to add, and an auditor reading it could reasonably conclude #110 is already done.

## What the code actually guarantees (origin/master f8e720c3e)

- `m.syncReady` is written and read only inside `pkg/cluster/sync_state.go`.
- The complete non-test caller list for `IsSyncReady()`: the readiness timeout at `pkg/daemon/daemon_ha_sync.go:45` (which uses it to release its **own** hold) and two log fields at `:80`/`:130`.
- The readiness conjunction at `daemon_ha_userspace_readiness.go:215` is `ifReady && takeoverGateReady && fabricReady && userspaceReady` — **no sync term**. In no-RETH / private-rg-election mode `takeoverGateReady` is `checkNoRethTakeoverReadiness` → `checkVIPReadiness`, i.e. VIP ownership alone.

A node in private-rg-election mode can therefore take over an RG before bulk session sync completes.

## How it got this way

`git show 0781f7a60` (2026-04-05) removes exactly the described gate — `vrrpReady = d.cluster.IsSyncReady()` with `"session sync not ready"` as a takeover blocker — and replaces it with the VIP-only check. **Empty commit body**, so the rationale is unavailable.

**The gate is NOT restored here** — that is #110's scope and a behaviour change needing its own review. The comments now say plainly that promotion is *not* sync-gated, so the next reader is misled in neither direction.

## Sites (searched as a claim, not a symbol)

| file | claim |
|---|---|
| `pkg/cluster/sync_state.go` | `SetSyncReady`'s doc |
| `pkg/cluster/manager.go` | the `syncReady` field: "gates RG promotion until session state is synchronized from the peer" |
| `pkg/daemon/daemon_run_bringup.go` | the private-rg-election `armSyncReadyTimer` note, which also claimed "without this … would never become primary" — nothing gates on the flag, so nothing was ever blocked by it |
| `docs/session-sync-architecture.md` | the connection-lifecycle list ends "cluster sync readiness becomes true" and invites the same inference; a new subsection states what it does **not** do and separates it from the VRRP sync hold, which IS a real preemption suppressor released on the same edge |

## Binding

`TestTakeoverReadinessForRG_NoRethIgnoresClusterSyncReady` already pinned the behaviour but was cited by nothing, and its fixture sets `no-reth-vrrp` while private-rg-election is the compiler **default** — both terms of `cc.NoRethVRRP || cc.PrivateRGElection` are true in it, so it cannot say which selected the path. Added `TestTakeoverReadinessForRG_PrivateRGElectionIgnoresClusterSyncReady_7102`, which asserts `NoRethVRRP == false`, drives a reconcile with sync NOT ready, and requires Ready with no `"session sync not ready"` reason. Both are cited from the comment, and both failure messages say a red here means #110 landed and the comments must move with it.

**Mutation:** restoring the gate inside `takeoverReadinessForRG` reds **both** tests — rc=1 from `$?`, reasons `[session sync not ready]`.

## Validation

`go build ./...` rc=0 · `go vet ./pkg/cluster/ ./pkg/daemon/` rc=0 · `go test -count=1 ./pkg/cluster/` rc=0 (17.4s) · `go test -count=1 ./pkg/daemon/` rc=0 (36.9s) · gofmt clean.

`git diff` over the production Go files contains **zero non-comment lines**. Comments, one test, docs. **Nothing reaches the helper binary, no cluster smoke owed.**

Closes #7102