### PR TITLE
docs(io_uring): correct the teardown drop-order guarantee (#6168)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -97280,3 +97280,43 @@ prose edit above them added. No diff falls in the new test body.
   pkg/config/wireguard_multiport_warning_1434_test.go,
   pkg/dataplane/userspace/wireguard_steering_advisory_1434_test.go,
   docs/wireguard-interop.md, _Log.md
+
+- **Timestamp**: 2026-08-21
+- **Action**: Corrected the io_uring teardown drop-order guarantee across five
+  files (#6168). The docstrings claimed that closing the ring fd "makes the
+  kernel cancel and wait for every in-flight op", so `RingWriter`'s field order
+  made the fallback safe outright. Verified against `io_uring/io_uring.c`:
+  `io_uring_release` -> `io_ring_ctx_wait_and_kill` kills the ctx percpu ref and
+  then `queue_work()`s `io_ring_exit_work`, which is what runs the
+  `io_uring_try_cancel_requests` loop. `close()` returns without waiting on it.
+  So the field order buys the START of the kernel teardown before any buffer is
+  freed, not its completion.
+
+  No behaviour change — the code was already structured correctly; the CLAIM was
+  false, which is worse than silence because it invites a future reader to lean
+  on the fallback as a barrier and relax the drain doing the real work. The docs
+  now state exactly what holds (field drop order is deterministic and narrows
+  the window; the cancellation finishing is NOT guaranteed) and name the real
+  proof: the synchronous `drain_for_teardown`, which blocks on each target
+  write's terminal CQE before freeing that buffer.
+
+  Per #6168 task 2 the residual is ACCEPTED, not hardened, and the module doc
+  records why: reaching it needs the drain to fail first (4096 consecutive
+  failed waits, or a fatally dead ring) with a write still mid-io-wq; it is
+  strictly better than pre-#5800, which freed on every retry ceiling with no
+  drain; and closing it would trade a narrow hazard for an unconditional
+  bounded leak of unproven buffers at registry drop. The doc names that leak as
+  the lever to pull if the reachability argument stops holding.
+
+  The issue named three sites; a grep for the claim found ten, all corrected.
+  The "invariant 4" label is dropped everywhere — the numbering implied a proof
+  the code does not have.
+
+  Comments and docs only: every changed Rust line outside the
+  `#[cfg(test)]`-gated `io_uring_write_tests.rs` is a comment, and the one line
+  inside it is an assert message. Helper binary unchanged, no smoke owed.
+  `cargo check --all-targets` exit 0; full Rust suite exit 0.
+- **File(s)**: userspace-dp/src/io_uring_write.rs,
+  userspace-dp/src/io_uring_write_tests.rs, userspace-dp/src/slowpath.rs,
+  userspace-dp/src/state_writer.rs, docs/xdp-io-uring-userspace-dataplane.md,
+  _Log.md

--- a/docs/xdp-io-uring-userspace-dataplane.md
+++ b/docs/xdp-io-uring-userspace-dataplane.md
@@ -453,13 +453,21 @@ also used by the state writer. Its `WriteMode` (`IoUring(RingWriter)` |
   preserves the heap address the SQE points at) and stays owned there. It is
   never freed while an SQE may still reference it. A deferred buffer is released
   only when ONE terminal state is observed: its matching write CQE is reaped
-  (opportunistically at the top of the next write), a teardown drain cancels the
-  op AND observes both the cancel's completion and the target write's terminal
-  CQE, or the ring fd closes (`RingWriter` field order drops the ring — kernel
-  cancel+wait — before the registry frees buffers). The old code returned at the
-  ceiling and let the caller free the buffer with the SQE possibly still in
-  flight (a UAF-class disclosure/corruption); the fix moves ownership instead of
-  weakening lifetime.
+  (opportunistically at the top of the next write), or a teardown drain cancels
+  the op AND observes both the cancel's completion and the target write's
+  terminal CQE. That drain is the SYNCHRONOUS proof and covers every realistic
+  teardown. A straggler it cannot prove terminal — its `MAX_WAIT_RETRIES`
+  ceiling was hit, or the ring is fatally dead — is retained and freed only when
+  the registry drops, which `RingWriter`'s field order puts AFTER the ring fd
+  close. That ordering is a best-effort narrowing of the window, **not** a
+  barrier: closing the fd runs `io_uring_release`, which kills the ctx reference
+  and QUEUES the kernel's `io_ring_exit_work`; the cancel-and-wait happens in
+  that work item, asynchronously, so `close()` does not block on the io-wq drain
+  (#6168). The residual is accepted and bounded: it needs a pathological
+  ceiling-during-teardown storm, and is strictly better than the pre-#5800
+  behaviour. The old code returned at the ceiling and let the caller free the
+  buffer with the SQE possibly still in flight (a UAF-class
+  disclosure/corruption); the fix moves ownership instead of weakening lifetime.
 - **Per-call fallback (#2477).** An io_uring failure that put NOTHING on the TUN
   (`WriteResult::NothingWritten`) hands the owned buffer back and is rescued by a
   synchronous write of the SAME packet — the frame is still deliverable. A
@@ -471,12 +479,12 @@ also used by the state writer. Its `WriteMode` (`IoUring(RingWriter)` |
 - **Runtime demotion (#5172, mirrors state_writer #2958).** A structured
   per-write outcome separates packet-transfer certainty from RING HEALTH. A
   `Deferred { fatal_ring: true }` — the ring fd itself is dead — retires the ring
-  ONCE: dropping the `RingWriter` runs a bounded teardown drain and closes the
-  ring fd (which frees any parked buffer safely), then `WriteMode` flips to
-  `SyncFallback` and reports `mode = "sync"`. Every later packet then takes the
-  sync branch directly instead of retrying the broken ring (which otherwise
-  degrades BGP/OSPF/mgmt/local traffic). The demotion is PERMANENT (no cooldown
-  re-promotion — avoids flapping).
+  ONCE: dropping the `RingWriter` runs a bounded teardown drain (which frees
+  each parked buffer whose terminal CQE it observes) and closes the ring fd,
+  then `WriteMode` flips to `SyncFallback` and reports `mode = "sync"`. Every
+  later packet then takes the sync branch directly instead of retrying the
+  broken ring (which otherwise degrades BGP/OSPF/mgmt/local traffic). The
+  demotion is PERMANENT (no cooldown re-promotion — avoids flapping).
 - **Transient does NOT demote.** A `NothingWritten` the sync fallback rescued, or
   a bare retry-ceiling `Deferred { fatal_ring: false }` (an EINTR storm), keeps
   io_uring live — a momentary blip must not abandon the ring; the parked buffer

--- a/userspace-dp/src/io_uring_write.rs
+++ b/userspace-dp/src/io_uring_write.rs
@@ -46,13 +46,50 @@
 //!     AND the target write's terminal CQE before freeing — cancellation
 //!     SUBMISSION alone is insufficient), or
 //!   * the ring fd is closed: [`RingWriter`]'s field order drops the ring BEFORE
-//!     the registry, so the kernel's ring-exit cancel+wait completes before any
-//!     buffer is freed (invariant 2/4).
+//!     the registry, so the kernel's teardown of the ring is INITIATED before
+//!     any buffer is freed. This last one is a best-effort narrowing of the
+//!     window, NOT a proof — see "What the fd close does and does not buy"
+//!     below and the [`RingWriter`] field-order note.
 //!
 //! Ring-global ids (never restarting per call, [`InflightRegistry::alloc_id`])
 //! close the stale-CQE aliasing hole; the id space is fail-closed on wrap
 //! (invariant 3) — `alloc_id` returns `None` at exhaustion and `write_all`
 //! refuses to submit rather than reuse a possibly-live id.
+//!
+//! ### What the fd close does and does not buy (#6168)
+//!
+//! The PRIMARY release is the SYNCHRONOUS [`InflightRegistry::drain_for_teardown`]:
+//! it blocks in `submit_and_wait` until each target write's terminal CQE is
+//! observed, and only then frees that write's buffer. That covers every
+//! realistic teardown.
+//!
+//! The fd-close fallback is WEAKER than a synchronous barrier, and this comment
+//! used to say otherwise. Closing the ring fd runs the kernel's
+//! `io_uring_release`, which kills the ctx reference (nothing further can be
+//! submitted) and then QUEUES `io_ring_exit_work` on a workqueue; that work item
+//! is what actually cancels and waits for the in-flight ops. `close()` does NOT
+//! block on it. So:
+//!
+//!   * GUARANTEED — Rust drops struct fields in declaration order, so the ring
+//!     fd close (and with it the START of the kernel's cancellation) always
+//!     happens BEFORE any registry buffer is freed. The ordering is
+//!     deterministic and it strictly narrows the window.
+//!   * NOT GUARANTEED — that the cancellation has FINISHED. `io_ring_exit_work`
+//!     runs asynchronously, so a write already executing in io-wq can still be
+//!     dereferencing a buffer at the instant the registry frees it. The fd close
+//!     is not a synchronous io-wq barrier.
+//!
+//! That residual is ACCEPTED, not closed (#6168). Reaching it requires the drain
+//! to fail first — its `MAX_WAIT_RETRIES` ceiling of 4096 consecutive failed
+//! waits, or a fatally dead ring — with a write still mid-io-wq. And even there
+//! it is strictly better than the pre-#5800 code, which freed the buffer on
+//! EVERY retry ceiling with no drain at all.
+//!
+//! Closing the residual completely would mean RETAINING (leaking) an unproven
+//! buffer at registry drop rather than freeing it — trading a narrow, hard-to-
+//! reach lifetime hazard for an unconditional bounded leak on a path that has
+//! already failed. #6168 weighed that and did not take it; if this comment and
+//! the reachability argument above ever stop holding, that is the lever to pull.
 //!
 //! Error classification (two further defects, retained from #2477/#2478):
 //!
@@ -160,9 +197,11 @@ struct InFlightWrite {
 /// Buffers are moved in ([`Self::defer`]) only when [`write_all`] must return
 /// before its op reached a terminal state. They are released — the owned buffer
 /// dropped — only when ONE terminal state is observed: the matching write CQE is
-/// reaped ([`Self::reap_ready`]) or a teardown drain proves no kernel reference
-/// remains ([`Self::drain_for_teardown`], or the ring fd closing before the
-/// registry drops).
+/// reaped ([`Self::reap_ready`]), or a teardown drain PROVES no kernel reference
+/// remains ([`Self::drain_for_teardown`]). If the drain cannot prove it, the
+/// entries survive until the registry itself drops — which [`RingWriter`]'s
+/// field order puts after the ring fd close, a best-effort narrowing rather than
+/// a proof (see the module doc, "What the fd close does and does not buy").
 pub(crate) struct InflightRegistry {
     /// Next `user_data` to hand out. Monotonic from 1; 0 is the stale/uninit
     /// sentinel and is never a valid id. Fail-closed on wrap (invariant 3).
@@ -248,7 +287,10 @@ impl InflightRegistry {
     /// `MAX_WAIT_RETRIES`; if the ceiling is hit, or the ring is fatally dead,
     /// the still-live entries are RETAINED (never freed early) — their buffers
     /// are freed only when the registry itself drops, which for [`RingWriter`]
-    /// happens AFTER the ring fd is closed (invariant 4).
+    /// happens after the ring fd is closed. That ordering narrows the window but
+    /// does not prove the kernel is done (#6168 — the fd close only STARTS an
+    /// asynchronous `io_ring_exit_work`); this drain returning without releasing
+    /// an entry is therefore the accepted residual, not a second proof.
     ///
     /// Returns the number of entries released by this drain (for tests).
     fn drain_for_teardown(&mut self, port: &mut dyn RingPort) -> usize {
@@ -298,9 +340,11 @@ impl InflightRegistry {
                 Err(err) => {
                     if is_permanent(&err) {
                         // The ring fd is dead: no further CQE can surface. Retain
-                        // the remaining entries; they free when the registry
-                        // drops (after the ring fd closes), which is when the
-                        // kernel can no longer reference them.
+                        // the remaining entries — never free one here, where
+                        // nothing has been proven. They free when the registry
+                        // drops, after the ring fd close has started the kernel's
+                        // teardown. That is the accepted best-effort residual,
+                        // not a proof the kernel is done (#6168).
                         break;
                     }
                     std::thread::yield_now();
@@ -372,11 +416,21 @@ impl RingPort for IoUringPort<'_> {
 /// A persistent io_uring plus its in-flight owned-buffer registry (#5800). Both
 /// slow-path callers own one of these across their lifetime.
 ///
-/// **Field order is load-bearing (invariant 4).** `ring` (field 0) drops BEFORE
-/// `inflight` (field 1). Dropping `ring` closes the io_uring fd, which makes the
-/// kernel cancel and wait for every in-flight op; only THEN does `inflight` drop
-/// and free the buffers, by which point no kernel reference can remain. Do not
-/// reorder these fields.
+/// **Field order is load-bearing.** `ring` (field 0) drops BEFORE `inflight`
+/// (field 1) — Rust drops struct fields in declaration order, so the ordering is
+/// deterministic. Dropping `ring` closes the io_uring fd, which starts the
+/// kernel's ring teardown: `io_uring_release` kills the ctx reference (nothing
+/// further can be submitted) and queues `io_ring_exit_work`, the work item that
+/// cancels and waits for the in-flight ops. Only THEN does `inflight` drop and
+/// free any buffer the teardown drain could not prove terminal.
+///
+/// What that buys is a strictly narrowed window, NOT a barrier: `close()` does
+/// not wait for `io_ring_exit_work`, so an op already running in io-wq may still
+/// reference a buffer when `inflight` drops (#6168). The proof lives in the
+/// synchronous [`InflightRegistry::drain_for_teardown`] this type's `Drop` runs
+/// first; the field order is the fallback for the residual where that drain
+/// hits its ceiling or the ring is dead. Do not reorder these fields — the
+/// ordering costs nothing and it is the only thing narrowing that window.
 pub(crate) struct RingWriter {
     ring: IoUring,
     inflight: InflightRegistry,
@@ -411,14 +465,16 @@ impl RingWriter {
 
 impl Drop for RingWriter {
     fn drop(&mut self) {
-        // Best-effort bounded drain: submit cancels and observe the target
-        // writes' terminal CQEs so buffers are freed cleanly. Even if the drain
-        // hits its ceiling (or the ring is fatally dead), correctness holds: the
-        // ring fd closes when `self.ring` drops immediately after this returns,
-        // which makes the kernel cancel+wait every in-flight op, and only THEN
-        // does `self.inflight` drop and free any straggler buffers. Disjoint
-        // field borrows let the drain hold `&mut ring` and `&mut inflight` at
-        // once without moving out of `self`.
+        // The bounded drain is the PROOF path: it submits cancels and blocks on
+        // the target writes' terminal CQEs, so every buffer it releases is
+        // provably unreferenced. If it hits its ceiling (or the ring is fatally
+        // dead) it releases nothing and the stragglers are retained; the ring fd
+        // then closes when `self.ring` drops immediately after this returns,
+        // starting the kernel's ring teardown BEFORE `self.inflight` drops and
+        // frees them. That ordering narrows the window but is not a barrier —
+        // the fd close only queues `io_ring_exit_work` (#6168). Disjoint field
+        // borrows let the drain hold `&mut ring` and `&mut inflight` at once
+        // without moving out of `self`.
         let ring = &mut self.ring;
         let inflight = &mut self.inflight;
         let mut port = IoUringPort { ring, fd: -1 };

--- a/userspace-dp/src/io_uring_write_tests.rs
+++ b/userspace-dp/src/io_uring_write_tests.rs
@@ -163,7 +163,7 @@ impl RingPort for FakeRing {
         // The cancel op is only SUBMITTED — and its completion only reapable — by
         // a later SUCCESSFUL wait. Queue it as pending rather than making it
         // immediately ready, so a fatal ring (every wait errors) never surfaces
-        // it (invariant 4: the parked buffer is retained, not released).
+        // it (the parked buffer is retained, not released).
         self.pending_cqes.push_back(Completion {
             user_data,
             result: 0,
@@ -593,7 +593,7 @@ fn write_all_fails_closed_when_id_space_exhausted() {
 }
 
 // ---------------------------------------------------------------------------
-// #5800 — teardown drain + cancellation (invariant 2/4)
+// #5800 — teardown drain + cancellation (the synchronous proof path)
 // ---------------------------------------------------------------------------
 
 /// #5800: `drain_for_teardown` submits an AsyncCancel for each deferred write id
@@ -678,10 +678,13 @@ fn drain_waits_for_target_cqe_not_just_cancel() {
     assert_eq!(ring.cancel_calls, 1, "the drain cancelled the deferred write");
 }
 
-/// #5800 (invariant 4): a FATAL ring cannot be drained (every wait returns the
-/// permanent error), so `drain_for_teardown` RETAINS the buffer — it is never
-/// freed early. The straggler is freed only when the registry itself drops
-/// (after the ring fd closes).
+/// #5800: a FATAL ring cannot be drained (every wait returns the permanent
+/// error), so `drain_for_teardown` RETAINS the buffer — it is never freed early.
+/// The straggler is freed only when the registry itself drops, which
+/// `RingWriter`'s field order puts after the ring fd close (#6168: a best-effort
+/// narrowing of the window, not a proof the kernel is done). What THIS test
+/// binds is the retain: a fatal ring must never release a buffer it cannot
+/// prove terminal.
 #[test]
 fn fatal_ring_drain_retains_buffer() {
     let mut ring = FakeRing::new(vec![], vec![]).with_repeat_err(libc::EBADF);
@@ -695,7 +698,7 @@ fn fatal_ring_drain_retains_buffer() {
     assert_eq!(
         reg.inflight_len(),
         1,
-        "invariant 4: the buffer is retained until teardown/registry-drop, never freed early"
+        "the buffer is retained until teardown/registry-drop, never freed early"
     );
 }
 

--- a/userspace-dp/src/slowpath.rs
+++ b/userspace-dp/src/slowpath.rs
@@ -729,12 +729,14 @@ fn apply_slowpath_outcome(
 ///
 /// Overwriting `*mode` DROPS the [`RingWriter`], whose `Drop` runs a bounded
 /// teardown drain (submit an AsyncCancel per still-in-flight entry, observe each
-/// target write's terminal CQE) and then closes the ring fd. The fd close makes
-/// the kernel cancel and wait for every outstanding op, and the in-flight
-/// registry — dropped AFTER the ring by field order — frees any straggler buffer
-/// only then, so no kernel reference can outlive a buffer across the demotion
-/// (the #5800 buffer-lifetime invariant, now covering the parked-buffer case the
-/// pre-#5800 code could not). No re-promotion (avoids flapping).
+/// target write's terminal CQE) and then closes the ring fd. The drain is the
+/// synchronous proof: every buffer it releases is provably unreferenced, which
+/// is the parked-buffer case the pre-#5800 code could not cover. A straggler the
+/// drain could NOT prove terminal is retained and freed only when the in-flight
+/// registry drops, which field order puts after the ring fd close — a
+/// best-effort narrowing of the window, not a barrier, because the fd close only
+/// queues the kernel's asynchronous `io_ring_exit_work` (#6168; see the
+/// `io_uring_write` module doc). No re-promotion (avoids flapping).
 fn retire_ring_to_sync(mode: &mut WriteMode) {
     *mode = WriteMode::SyncFallback;
 }

--- a/userspace-dp/src/state_writer.rs
+++ b/userspace-dp/src/state_writer.rs
@@ -316,8 +316,10 @@ fn persist_with_mode(mode: &mut WriteMode, path: &str, data: Vec<u8>) -> Persist
                 // reference it, #5800) and cannot be synchronously retried — the
                 // buffer is no longer ours and the op may be in flight. Fail this
                 // write and demote; dropping the RingWriter on demotion runs the
-                // teardown drain and closes the ring fd, which is what frees the
-                // parked buffer safely.
+                // teardown drain, which frees the parked buffer once it observes
+                // the write's terminal CQE, and then closes the ring fd (#6168:
+                // the fd close narrows, but does not close, the window for a
+                // buffer the drain could not prove terminal).
                 let cause =
                     format!("io_uring write deferred (buffer retained), demoting to sync: {ring_err}");
                 PersistOutcome {


### PR DESCRIPTION
## The false claim

Five files told operators and future readers that closing the io_uring
ring fd *"makes the kernel cancel and wait for every in-flight op"*, and
that `RingWriter`'s field order therefore made the fallback path safe
outright.

That is not what the kernel does. Verified against `io_uring/io_uring.c`:

```c
static int io_uring_release(struct inode *inode, struct file *file)
{
	struct io_ring_ctx *ctx = file->private_data;
	file->private_data = NULL;
	io_ring_ctx_wait_and_kill(ctx);      /* -> queue_work(...exit_work) */
	return 0;
}
```

`io_ring_ctx_wait_and_kill()` kills the ctx percpu ref and then
`queue_work()`s `io_ring_exit_work`. *That work item* is what runs the
`io_uring_try_cancel_requests()` loop. `close()` returns without waiting
for it.

So the field order buys the **start** of the kernel's teardown before
any buffer is freed — not its completion.

## What this PR does

Nothing here changes behaviour; the code was already structured
correctly. What was wrong was the claim — and a false safety claim is
worse than none, because it invites a future reader to lean on the
fallback as a barrier and relax the drain that is doing the real work.

The docs now say exactly what holds:

- **GUARANTEED** — Rust drops struct fields in declaration order, so the
  ring fd close always precedes any registry free. Deterministic, and it
  strictly narrows the window. Do not reorder the fields.
- **NOT GUARANTEED** — that the cancellation has *finished*.
  `io_ring_exit_work` runs asynchronously; the fd close is not a
  synchronous io-wq barrier.

…and name the real proof: the synchronous `drain_for_teardown`, which
blocks on each target write's terminal CQE before freeing that write's
buffer, and covers every realistic teardown.

## Residual: accepted, and the reasoning is recorded (#6168 task 2)

The module doc now records *why* the residual is accepted rather than
hardened:

- reaching it needs the drain to fail first — its `MAX_WAIT_RETRIES`
  ceiling of 4096 consecutive failed waits, or a fatally dead ring —
  with a write still mid-io-wq;
- it is strictly better than the pre-#5800 code, which freed the buffer
  on **every** retry ceiling with no drain at all;
- closing it would trade that narrow hazard for an unconditional bounded
  leak of unproven buffers at registry drop.

The doc names that leak as the lever to pull if the reachability
argument ever stops holding. Filed as #7106 (hardening + a "deferred
buffers retained" gauge + a field-order guard) so the option survives
this issue closing.

**This is a known, already-triaged residual, not a new finding** — it is
the exact non-blocking LOW the #6166 hostile review raised and #6168 was
opened to record. No live use-after-free was found on any realistic
path.

## Site census

The issue named three sites. A grep for the claim found **ten**, all
corrected here:

| File | Site |
|---|---|
| `io_uring_write.rs` | module-doc bullet + new "What the fd close does and does not buy" section |
| `io_uring_write.rs` | `InflightRegistry` struct doc ("proves" covered both arms) |
| `io_uring_write.rs` | `drain_for_teardown` docstring tail |
| `io_uring_write.rs` | fatal-ring retain comment inside `drain_for_teardown` |
| `io_uring_write.rs` | `RingWriter` field-order doc |
| `io_uring_write.rs` | `Drop for RingWriter` comment |
| `slowpath.rs` | `retire_ring_to_sync` doc — the issue cites this under `io_uring_write.rs`; it lives in `slowpath.rs` now |
| `state_writer.rs` | deferred-persist comment |
| `docs/xdp-io-uring-userspace-dataplane.md` | both affected bullets |
| `io_uring_write_tests.rs` | the label "invariant 4" |

The **"invariant 4" label is dropped everywhere**, because the numbering
implied a proof the code does not have.
`fatal_ring_drain_retains_buffer` keeps its test body unchanged and its
docstring now states what it actually binds: a fatal ring must never
*release* a buffer it cannot prove terminal.

## Binary impact

**Comments and docs only — no smoke owed.** Every changed Rust line
outside `io_uring_write_tests.rs` is a comment or doc comment; that file
is `#[cfg(test)]`-gated (`io_uring_write.rs:731`) and its one changed
code line is an assert *message*. The shipped helper binary is
unchanged.

## Validation

- `cargo check --manifest-path userspace-dp/Cargo.toml --all-targets` → **exit 0**, 0 errors
- `cargo test --manifest-path userspace-dp/Cargo.toml -- --test-threads=1` → **exit 0** (4446 passed, 0 failed)

No behavioural test accompanies this change: the corrected claim is
prose about kernel scheduling, and a substring guard over it would be
defeated by paraphrase while false-positiving on the now-accurate
description of what `io_ring_exit_work` does. The testable adjacent
property — that `RingWriter`'s field order is not silently reversed —
is filed in #7106.

Closes #6168

🤖 Generated with [Claude Code](https://claude.com/claude-code)