### PR TITLE
test(policer): race refill against consume with an advancing clock

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -97280,3 +97280,44 @@ prose edit above them added. No diff falls in the new test body.
   pkg/config/wireguard_multiport_warning_1434_test.go,
   pkg/dataplane/userspace/wireguard_steering_advisory_1434_test.go,
   docs/wireguard-interop.md, _Log.md
+
+- **Timestamp**: 2026-08-21
+- **Action**: Added the missing refill-under-contention race test for the
+  lock-free three-color policer (#6307). The bundled
+  `concurrent_meter_is_lock_free_and_preserves_trTCM_thresholds` pins
+  `now_ns = 0`, so it hammers only the consume `compare_exchange_weak`; the
+  REFILL path — the win-the-window `last_refill_ns` CAS plus the #4261 sub-byte
+  rewind composing across concurrent partial windows — never ran under
+  contention, and that is the actual over-grant hazard of the #5390 design.
+
+  `concurrent_refill_under_contention_neither_over_nor_under_grants_6307` runs
+  8 threads against ONE shared trTCM policer with an ADVANCING clock. Every op
+  claims its timestamp from a single `fetch_add` clock and the threads race
+  until a shared budget is exhausted (a shared-budget loop, NOT equal
+  per-thread iteration counts), so total simulated time is exactly 175 ms no
+  matter how the scheduler interleaves and the ceiling is deterministic:
+  CBS 50_000 B + CIR 1e6 B/s x 0.175 s = 225_000 B. Offered load is ~100x the
+  supply, so the committed bucket never re-saturates and ends holding less than
+  one packet. STEP_NS = 700 accrues 0.7 B per op, so most ops grant nothing and
+  the sub-byte credit must survive across ops (#4261 dust) under contention.
+  The test asserts BOTH directions — admitted <= ceiling (no over-grant) and
+  admitted + 3 packets >= ceiling (no lost refill) — and reports the achieved
+  contention rate (share of ops that observed a foreign clock advance) plus the
+  per-thread op split, so a run that degenerated to serial execution is visible
+  rather than passing silently.
+
+  Production is CORRECT: 5/5 runs admitted EXACTLY 225_000 B at a 99.4-99.7%
+  interleave rate. Mutation-verified with two concurrency-only mutations of
+  `refill_independent_bucket` (the site the trTCM path actually reaches), exit
+  codes read from `$?`, never through a pipe: (A) credit the refill even when
+  the `last_refill_ns` compare_exchange LOSES -> `cargo check --all-targets`
+  rc=0, test rc=101, "over-grant ... admitted 321500 B ... budget is only
+  225000 B"; (B) abandon the credit add when the packed-credits
+  `compare_exchange_weak` loses -> check rc=0, test rc=101, "starved ...
+  admitted only 113000 B". Each mutation reddens ONLY the new test — the other
+  11 `filter::policer` tests, including the now_ns=0 concurrent one, stay green,
+  which is exactly the gap #6307 named.
+
+  Test-only: no production source changed, so no helper binary movement and no
+  cluster smoke owed.
+- **File(s)**: userspace-dp/src/filter/policer.rs (tests module only), _Log.md

--- a/userspace-dp/src/filter/policer.rs
+++ b/userspace-dp/src/filter/policer.rs
@@ -835,6 +835,164 @@ mod tests {
     }
 
     #[test]
+    fn concurrent_refill_under_contention_neither_over_nor_under_grants_6307() {
+        // #6307 fail-on-revert: the bundled
+        // `concurrent_meter_is_lock_free_and_preserves_trTCM_thresholds` pins
+        // `now_ns = 0`, so it exercises only the consume `compare_exchange_weak`
+        // under contention — the REFILL path (the win-the-window timestamp CAS
+        // plus the #4261 sub-byte rewind composing across concurrent partial
+        // windows) never runs there, and that is the actual over-grant hazard
+        // of the lock-free design. This test advances the clock while N threads
+        // meter, so refills and consumes race.
+        //
+        // SHARED-BUDGET LOOP (not equal per-thread iteration counts): every op
+        // claims its timestamp from one `fetch_add` clock and threads race until
+        // the shared budget is exhausted, so a fast thread simply takes more ops
+        // and a descheduled thread cannot shorten the run. Total simulated time
+        // is therefore EXACTLY `T_MAX_NS` no matter how the scheduler
+        // interleaves, which is what makes the ceiling below deterministic.
+        //
+        // Ceiling arithmetic (committed bucket binds; see below):
+        //   CBS = 50_000 B initial burst
+        //   + CIR x T_MAX_NS / 1e9 = 1e6 x 0.175 = 175_000 B refilled
+        //   = 225_000 B of green budget over the whole run.
+        // Offered load is 250_000 x 100 B = 25_000_000 B, i.e. ~100x the supply,
+        // so the committed bucket is drained continuously: it never re-saturates
+        // (a saturated bucket would silently discard grants and blur the
+        // ceiling) and it ends holding less than one packet.
+        //
+        // STEP_NS = 700 with CIR = 1e6 B/s accrues 0.7 B per op, so most ops
+        // grant NOTHING and `compute_refill_add` must carry the sub-byte credit
+        // across ops via its `last_refill_ns` rewind — the #4261 dust path, here
+        // composed across concurrent partial windows.
+        //
+        // The peak bucket never binds: PIR = 1e9 B/s regrants 700 B per 700 ns
+        // step against a 100 B debit, so `peak >= cost` always holds and a
+        // packet is Green exactly when the COMMITTED bucket covers it. Packets
+        // that miss committed fall to Yellow (they are not counted).
+        use std::sync::Barrier;
+
+        const THREADS: usize = 8;
+        const PKT: u64 = 100;
+        const STEP_NS: u64 = 700;
+        const OPS: u64 = 250_000;
+        const T_MAX_NS: u64 = OPS * STEP_NS;
+        const CIR: u64 = 1_000_000;
+        const CBS: u64 = 50_000;
+        const PIR: u64 = 1_000_000_000;
+        const PBS: u64 = 5_000_000;
+
+        let policer = Arc::new(tr_tcm(CIR, CBS, PIR, PBS, true));
+        // Prime both refill clocks at t=0 from ONE thread. Without this the
+        // first thread to reach `refill()` stamps `last_refill_ns` at ITS
+        // timestamp and the window [0, that timestamp) is never granted, which
+        // would make the ceiling scheduler-dependent. Priming also opens PKT
+        // bytes of headroom in the committed bucket so the very first
+        // concurrent refill has somewhere to land (no start-of-run saturation
+        // loss). Its 100 green bytes are counted in the total below.
+        assert_eq!(
+            policer.meter(0, PKT, PacketColor::Green).color,
+            PacketColor::Green,
+            "the priming meter must be Green (the bucket starts at CBS)"
+        );
+
+        let clock = Arc::new(AtomicU64::new(0));
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let mut handles = Vec::new();
+        for _ in 0..THREADS {
+            let p = Arc::clone(&policer);
+            let clock = Arc::clone(&clock);
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                let mut green_bytes = 0u64;
+                let mut ops = 0u64;
+                // How many of this thread's ops saw the shared clock move by
+                // more than its own step since its previous op — i.e. observed
+                // another thread's advance. This is the achieved-contention
+                // RATE, reported below; 0 means the run degenerated to serial
+                // execution and the race was never exercised.
+                let mut interleaved = 0u64;
+                let mut prev_ns = 0u64;
+                barrier.wait();
+                loop {
+                    let now_ns = clock.fetch_add(STEP_NS, Ordering::Relaxed) + STEP_NS;
+                    if now_ns > T_MAX_NS {
+                        break;
+                    }
+                    if ops > 0 && now_ns != prev_ns + STEP_NS {
+                        interleaved += 1;
+                    }
+                    prev_ns = now_ns;
+                    ops += 1;
+                    if p.meter(now_ns, PKT, PacketColor::Green).color == PacketColor::Green {
+                        green_bytes += PKT;
+                    }
+                }
+                (green_bytes, ops, interleaved)
+            }));
+        }
+        let results: Vec<(u64, u64, u64)> =
+            handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let total_green: u64 = PKT + results.iter().map(|r| r.0).sum::<u64>();
+        let total_ops: u64 = results.iter().map(|r| r.1).sum();
+        let interleaved: u64 = results.iter().map(|r| r.2).sum();
+
+        // The shared-budget loop must have consumed exactly the budget — this
+        // pins T_MAX_NS as the real elapsed window the ceiling is computed from.
+        assert_eq!(
+            total_ops, OPS,
+            "the shared timestamp budget must be fully consumed exactly once"
+        );
+        eprintln!(
+            "#6307 refill-under-contention: {total_ops} ops / {THREADS} threads, \
+             per-thread ops {:?}, {interleaved} ops ({:.1}%) observed a foreign \
+             clock advance, {total_green} B green admitted",
+            results.iter().map(|r| r.1).collect::<Vec<_>>(),
+            100.0 * interleaved as f64 / total_ops as f64,
+        );
+
+        let refilled = CIR * T_MAX_NS / 1_000_000_000;
+        let ceiling = CBS + refilled;
+
+        // NO OVER-GRANT. A refill window credited twice (the losing side of the
+        // `last_refill_ns` compare_exchange adding tokens anyway) admits green
+        // bytes the aggregate CIR/CBS contract never issued.
+        assert!(
+            total_green <= ceiling,
+            "over-grant under concurrent refill: admitted {total_green} B green \
+             but the CBS + CIR*T budget is only {ceiling} B \
+             (CBS {CBS} + {refilled} refilled over {T_MAX_NS} ns)"
+        );
+
+        // NO LOST REFILL. Demand is ~100x supply, so a correct meter ends with
+        // less than one packet of committed credit unspent. Slack accounts for
+        // that residue (<PKT), the at-most-one-byte of sub-byte dust still owed
+        // at T_MAX_NS, and one packet of margin. A dropped refill (e.g. the
+        // window winner abandoning its credit add when the packed-credits CAS
+        // loses) starves the policer by far more than this.
+        const SLACK: u64 = 3 * PKT;
+        assert!(
+            total_green + SLACK >= ceiling,
+            "starved under concurrent refill: admitted only {total_green} B \
+             green against a {ceiling} B budget (CBS {CBS} + {refilled} \
+             refilled over {T_MAX_NS} ns) — a refill was lost"
+        );
+
+        // Non-vacuity, checked LAST so a real over/under-grant is reported
+        // first: with 8 threads over 250_000 ops this floor of ONE observed
+        // foreign advance is many orders of magnitude below the measured
+        // 99.4-99.7%, so it fires only if the run degenerated to strictly
+        // serial execution — in which case the two assertions above proved
+        // nothing about the refill race and the result must not read as
+        // covered.
+        assert!(
+            interleaved > 0,
+            "no op observed another thread's clock advance: the threads ran \
+             serially and the refill race was never exercised"
+        );
+    }
+
+    #[test]
     fn meter_hot_path_takes_no_shared_mutex_source_guard() {
         // #5390 fail-on-revert source guard: bind the metered hot path to the
         // lock-free design. A revert to `Mutex<ThreeColorPolicerState>` +


### PR DESCRIPTION
## Summary

Closes #6307

The bundled `concurrent_meter_is_lock_free_and_preserves_trTCM_thresholds`
(`userspace-dp/src/filter/policer.rs:823`) pins `now_ns = 0` on every meter — its
own comment says so — so it exercises only the consume `compare_exchange_weak`
under contention. The **refill** path never runs there: the win-the-window
`last_refill_ns` compare_exchange and the #4261 sub-byte rewind composing across
concurrent partial windows, which is the actual over-grant hazard of the #5390
lock-free design. The only other concurrent test in the file
(`meter_hot_path_takes_no_shared_mutex_source_guard`) is a source guard. A refill
credited twice, or a refill dropped, reddened nothing.

## The test

`concurrent_refill_under_contention_neither_over_nor_under_grants_6307` — 8 threads
meter **one** shared trTCM policer while the clock advances.

**Shared-budget loop, not equal per-thread iteration counts.** Every op claims its
timestamp from a single `fetch_add` clock and the threads race until a shared
budget is exhausted, so a fast thread simply takes more ops and a descheduled
thread cannot shorten the run. (Observed per-thread split on a 16-core box:
`[37874, 24638, 39018, 38540, 22866, 36320, 25400, 25344]`.) Total simulated time
is therefore exactly `T_MAX_NS` however the scheduler interleaves, which is what
makes the ceiling exact:

```
CBS 50_000 B + CIR 1e6 B/s x 0.175 s = 225_000 B of green budget
```

- A single-threaded **priming meter at t=0** stamps both refill clocks, so the
  granted window is exactly `[0, T_MAX_NS]` instead of starting at whichever
  timestamp the first thread happened to hold; it also opens one packet of
  headroom so the first concurrent refill has somewhere to land.
- Offered load is **~100x** the supply, so the committed bucket never
  re-saturates (a saturated bucket discards grants and would blur the ceiling)
  and ends holding less than one packet.
- `STEP_NS = 700` accrues **0.7 B per op**, so most ops grant nothing and the
  sub-byte credit must survive across ops — the #4261 dust path, here composed
  across concurrent partial windows.
- The peak bucket never binds (PIR regrants 700 B per step against a 100 B
  debit), so Green means exactly "the committed bucket covered it".

Both directions are asserted — `admitted <= ceiling` (no over-grant) and
`admitted + 3 packets >= ceiling` (no lost refill) — and the test **reports the
achieved contention rate** (share of ops that observed another thread's clock
advance) plus the per-thread op split, then fails if that rate is zero, so a run
that degenerated to serial execution cannot pass silently as "covered".

## Production is correct

5 consecutive runs admitted **exactly 225_000 B** — the ceiling, to the byte — at a
99.4-99.7% interleave rate. No over-grant, no lost dust, no starvation. There is
no runtime bug here; the gap was purely coverage.

## Mutation verification

Two one-line, **concurrency-only** mutations of `refill_independent_bucket` — the
refill site the trTCM meter path actually reaches. Exit codes read from `$?`,
never through a pipe.

| mutation | `cargo check --all-targets` | test | message |
|---|---|---|---|
| A: credit the refill even when the `last_refill_ns` compare_exchange **loses** (double refill) | `rc=0` | `rc=101` | `over-grant under concurrent refill: admitted 321500 B green but the CBS + CIR*T budget is only 225000 B` |
| B: abandon the credit add when the packed-credits `compare_exchange_weak` loses (lost refill) | `rc=0` | `rc=101` | `starved under concurrent refill: admitted only 113000 B green against a 225000 B budget` |

`check rc=0` in both rows means each red is an **assertion** failure, not a build
break. And **each mutation reddens only the new test** — the other 11
`filter::policer` tests, including the `now_ns = 0` concurrent one, stay green
(`11 passed; 1 failed`). That is precisely the gap #6307 named.

Full suite: `cargo test --manifest-path userspace-dp/Cargo.toml -- --test-threads=1`
→ `rc=0`, 4447 passed / 0 failed. (One earlier run hit the known pre-existing
#7089 `wg framed_handshake` load flake, unrelated to this diff; it reran green
2/2 and the final full run is clean.)

## Smoke

**Test-only** — the change is confined to the `#[cfg(test)] mod tests` block, so
the helper binary does not move and no cluster smoke is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126EmRvxtxzSUPiZD9XBrAT