### PR TITLE
Make the appliance bake work again, and record the Tier-2 forwarding pass

### DIFF
--- a/debian/xpf.postinst
+++ b/debian/xpf.postinst
@@ -45,7 +45,8 @@ case "$1" in
         if [ -z "$2" ]; then
             # === #1964 first-install seed (mechanism A) ===
             #
-            # Seed the versioned runtime layout BEFORE #DEBHELPER# starts
+            # Seed the versioned runtime layout BEFORE the debhelper-
+            # generated section (see the token near the end of this file) starts
             # the unit: copy staged/* -> versions/<v>/, set versions/current
             # -> <v>, and repoint /usr/local/sbin/* THROUGH versions/current.
             # This gives the appliance a real, immutable rollback target so

--- a/docs/image-validation.md
+++ b/docs/image-validation.md
@@ -121,28 +121,33 @@ self-contained on one incus host: the appliance is the L3 gateway, the
 LAN/WAN segments are pure L2 bridges, and interface SNAT means the WAN
 endpoint needs no route back.
 
-> **VENUE WARNING (re-confirmed 2026-06-17 live — #1955's "resolved"
-> claim was wrong; #1961).** The AF_XDP userspace dataplane does NOT
-> forward L3 transit over **virtio** NICs in a plain incus VM. The
-> #1927/#1929 fixes did clear the *earlier* failure mode (the `libxdp
-> private bind: Device or resource busy` rebind loop), so the bind now
-> succeeds — but a deeper gap remains: the XDP shim attaches native and
-> redirects, yet the helper's XSK **receives 0 frames** (`show security
-> flow statistics` → `Packets received: 0`, `Sessions created: 0`).
-> Everything up to the control plane works — boot, day-0 install/commit,
-> interface bring-up, and the gateway is pingable (host-inbound) — but
-> **L3 transit forwarding yields 0 sessions**. This was verified on clean
-> master (xpfd `4f453c98`, helper `cb83da9f`) against a virtio
-> trust→untrust path on TWO kernels (6.17 / Ubuntu 25.10 and 6.18 /
-> Debian 13), with BOTH `AUTO` (flags=0) and forced `COPY` bind flags,
-> and with BOTH `busy-poll` and `interrupt` poll modes — none deliver to
-> the XSK. The #1928/#1929 "AUTO bind + HA-gate fix forwards 5000 pps on
-> virtio" claim did NOT reproduce here. Run the *forwarding* assertions
-> only on a venue with a real AF_XDP NIC: **mlx5 SR-IOV VFs** (the loss
-> userspace cluster, proven daily) or **i40e PF passthrough** (the
-> standalone test VM's WAN). On incus/virtio, treat Tier 2 as a
-> **control-plane + day-0 + interface-bring-up** check (steps through
-> "confirm the interface map" below), not a forwarding proof.
+> **VENUE NOTE (measured 2026-08-21 from a baked image; #1926).** Plain
+> **virtio** in an ordinary incus VM IS a valid venue for the Tier-2
+> *functional* forwarding assertions below. The earlier "virtio delivers
+> 0 frames to the XSK" warning here is retired — see
+> "Recorded Tier-2 result" for the run that replaces it.
+>
+> The claim it rested on (#1961) was root-caused to a Go↔Rust snapshot
+> **wire-type** bug for DSCP/code-point lists, fixed in **PR #1976** plus
+> the `NUM_WIDTH` siblings in **#1978**. Its "sustained virtio stall"
+> follow-on was retracted by its own author as a test-environment defect:
+> three firewall VMs were answering the same gateway IPs on the same
+> bridges, so the client's gateway ARP flipped mid-flow. The warning text
+> was written one day BEFORE #1976 landed and was never revisited, so it
+> outlived its evidence by two months.
+>
+> What virtio does NOT give you is a **line-rate** number: the ceiling
+> below is a few Gbit/s on a single flow, an order of magnitude under a
+> real AF_XDP NIC. Performance claims still belong on **mlx5 SR-IOV VFs**
+> (the loss userspace cluster) or **i40e PF passthrough** (the standalone
+> test VM's WAN). Tier 2 does not ask for one — it asks whether the
+> appliance routes and NATs at all.
+>
+> **The one trap to avoid** is the one that caused the #1961
+> misdiagnosis: make sure no other firewall VM answers the same gateway
+> IPs on the same bridges. Run `incus list` first. The private
+> `10.66.1.0/24` / `10.66.2.0/24` segments below exist precisely to keep
+> this run isolated.
 
 ### Topology
 
@@ -162,11 +167,10 @@ endpoint needs no route back.
 NIC order = interface name (positional contract). Names are shown in
 config/CLI slash form (`ge-0/0/0`); the Linux link name is the dash form
 (`ge-0-0-0`) that `assignName()` produces — the config layer translates
-between them. NOTE (per the venue warning above, #1961): on incus/virtio
-the AF_XDP dataplane binds but does NOT deliver to the XSK (transit yields
-0 sessions), so this topology validates control-plane + day-0 + interface
-bring-up, NOT transit forwarding. Run the forwarding assertions on
-mlx5-VF / i40e-PF.
+between them. This topology on plain incus/virtio validates the full
+Tier-2 set: control-plane + day-0 + interface bring-up AND transit
+forwarding/NAT (measured, #1926 — see "Recorded Tier-2 result"). Only
+line-rate numbers need mlx5-VF / i40e-PF.
 
 ### Host networks
 
@@ -259,6 +263,68 @@ incus exec wanhost -- timeout 6 tcpdump -ni eth0 -c3 'src fd66:2::1'    # v6 SNA
 - `show security flow session` shows the forwarded flows with interface SNAT.
 - `wanhost` sees traffic sourced from `10.66.2.1` (v4) AND `fd66:2::1` (v6) — SNAT confirmed for both families, not bridged.
 
+### Recorded Tier-2 result (2026-08-21, #1926)
+
+First recorded pass. Run on ordinary **incus/virtio** on a dev host — no
+SR-IOV, no PF passthrough, no shared-cluster lock.
+
+| | |
+|---|---|
+| Image | `xpf-userspace-forwarding-ok-20260402-bfb00432-10859-gf93215641.qcow2` |
+| `git_commit` | `f93215641` (master `e344c9df5` + the three bake fixes below) |
+| Base | Ubuntu 26.04 cloud image, `9dc7c536…`, Canonical-GPG-verified |
+| Guest kernel | `7.0.0-30-generic` |
+| Venue | incus VM, 3× virtio NIC, `xpf-rtr-{mgmt,lan,wan}` |
+
+Deployed from the baked qcow2 via `xpf-deploy.py` with the day-0 drive —
+**not** pushed binaries. Results:
+
+- **v4 ping** 10.66.1.10 → 10.66.2.10: replies, 0.35–0.43 ms.
+- **v6 ping** fd66:1::10 → fd66:2::10: replies, 0.31–0.33 ms.
+  (The *first* echo of a cold flow is lost in both families while the
+  session installs — `icmp_seq=1` missing, `seq=2,3` fine. A warm flow is
+  0% loss; see the discriminator below.)
+- **iperf3 v4** 2.98 Gbit/s (5 s), **4.29 Gbit/s** sustained over 30 s.
+- **iperf3 v6** 3.94 Gbit/s (5 s), **3.02 Gbit/s** sustained over 30 s.
+- **`show security flow session`**: LAN→WAN flows with interface SNAT —
+  `In: 10.66.1.10 --> 10.66.2.10;icmp / Out: 10.66.2.10 --> 10.66.2.1;icmp`
+  and the `fd66:` equivalent translating to `fd66:2::1`.
+- **`show security flow statistics`**: `Packets received: 3033032`,
+  `Packets dropped: 0` — the direct refutation of the retired warning's
+  `Packets received: 0`.
+- **wanhost tcpdump**: ICMP *and* TCP sourced from `10.66.2.1` /
+  `fd66:2::1`; the LAN host's own address never appears on the WAN
+  segment. SNAT confirmed for both families and both protocols.
+
+**Discriminator — this is the xpf dataplane, not the guest kernel.**
+Interface SNAT alone already rules the kernel out (`nft list ruleset`
+shows no NAT table — only xpf's own RST-suppression and host-inbound
+counters). Made explicit anyway, matching the method that settled #1961:
+with `net.ipv4.ip_forward=0` **and** `net.ipv6.conf.all.forwarding=0` set
+on the appliance, ping stayed at **0% loss** and iperf3 still moved
+**4.29 Gbit/s (v4)** and **3.02 Gbit/s (v6)** over 30 s. Kernel forwarding
+disabled, traffic still crossing: the AF_XDP userspace dataplane carried
+it.
+
+**Not proven by this run**, and deliberately not claimed:
+line rate (virtio ceilings at a few Gbit/s on one flow — use mlx5-VF or
+i40e-PF for a performance number), and Tier 3 / HA from an image.
+
+Two defects observed during the run, tracked separately — neither affects
+the result above:
+
+- Tier-1 scenario **a** fails on this image: on a factory boot with no
+  config drive, nothing brings the NIC up (the bake purges cloud-init and
+  netplan), so xpfd's bootstrap lifeline finds no default route, declines
+  to identify a management NIC, and leaves the port down and unrenamed —
+  no `fxp0`, no DHCP. Tier 2 is unaffected because it supplies a day-0
+  config, which takes xpfd out of bootstrap and into full interface
+  takeover.
+- `show security flow session` lists the ICMP sessions but omits TCP ones,
+  while `show security flow statistics` counts them (`Current sessions:
+  10` against a rendered `Total sessions: 2`). A display-path gap, not a
+  forwarding one — the TCP flows demonstrably forward and SNAT.
+
 ### Cleanup
 ```bash
 incus delete -f xpf-rtr lanhost wanhost
@@ -323,25 +389,28 @@ Delete `fw0`/`fw1` and the five `xpf-ha-*` networks.
 
 ## Honest scope
 
-- **virtio is NOT a forwarding venue (#1961, re-confirmed 2026-06-17).**
-  #1927/#1929 cleared the earlier `Device or resource busy` bind loop, so
-  the helper now binds virtio multi-queue cleanly — but it still does NOT
-  forward transit: the XDP shim attaches native and redirects, yet the
-  helper's XSK receives 0 frames (`Packets received: 0`, `Sessions
-  created: 0`). Re-verified on clean master against a virtio trust→untrust
-  path on kernels 6.17 and 6.18, with both `AUTO` and `COPY` bind flags
-  and both `busy-poll` and `interrupt` poll modes; the #1928/#1929 "AUTO
-  bind forwards 5000 pps on virtio" claim did not reproduce. So Tiers 2–3
-  on virtio validate only boot + day-0 + interface bring-up + control-plane
-  reachability — NOT transit forwarding/NAT/HA. Functional forwarding (and
-  line-rate numbers) require a real AF_XDP NIC: the loss userspace
-  cluster's mlx5 SR-IOV VFs, or i40e PF passthrough on the standalone test
-  VM. The loss SR-IOV smoke matrix (`docs/`) tests the *deployed binaries*;
-  an image-based forwarding test needs the image booted on one of those NIC
-  venues. Tracked in #1961 (reopened from the #1928 "resolved" claim).
-- The image is hardware-agnostic for the control-plane tiers, but transit
-  forwarding is NOT venue-agnostic: `verify-dataplane` and forwarding
-  exercise the real userspace AF_XDP path, which does not deliver on
-  virtio. Local KVM/virtio is a faithful *control-plane* venue only.
+- **virtio IS a functional forwarding venue; it is not a performance one
+  (measured 2026-08-21, #1926).** Tier 2 passes end-to-end on ordinary
+  incus/virtio — v4+v6 ping, iperf3 both families, interface SNAT
+  confirmed on the wire — from a booted baked image, with the guest's own
+  `ip_forward` disabled to prove the AF_XDP dataplane carried it. See
+  "Recorded Tier-2 result". What virtio cannot give you is a line-rate
+  number: it ceilings at a few Gbit/s on a single flow, so performance
+  claims still need the loss cluster's mlx5 SR-IOV VFs or i40e PF
+  passthrough.
+
+  This bullet previously asserted the opposite, on #1961's "XSK receives
+  0 frames" finding. That finding was a Go↔Rust snapshot wire-type bug
+  (fixed in #1976/#1978), and its "sustained stall" follow-on was
+  retracted by its author as a gateway-IP/ARP collision between three
+  firewall VMs. The text was written the day before the fix landed and
+  went unrevisited for two months; treat the dated "re-confirmed" note it
+  carried as a caution about re-confirming against a moving tree, not as
+  evidence.
+- The **image vs. deployed binaries** distinction still matters. The loss
+  SR-IOV smoke matrix exercises binaries pushed onto already-running VMs;
+  it never boots the baked qcow2. The recorded Tier-2 result above is an
+  image-based proof and is the thing that closes that gap — on virtio. An
+  image-based proof *on an SR-IOV venue* is still unrun.
 - None of these tiers touch the shared `loss` cluster; Tier-1 and the
   functional tiers use dedicated throwaway instances + networks.

--- a/scripts/image/bake.py
+++ b/scripts/image/bake.py
@@ -419,11 +419,27 @@ def virt_customize(work_qcow, xpf_deb):
         # then VERIFY every enumerated package is actually in `apt-mark showhold`
         # (per-package, not a count) so neither a partial hold nor a pre-existing
         # unrelated hold can ship an unprotected image.
+        #
+        # Two things this fragment gets wrong easily, both of which aborted
+        # every bake (found by running one, #1926):
+        #   1. The `$` in the dpkg-query format must be ESCAPED. This string is
+        #      handed to the guest's `sh -c`, so an unescaped `${Package}` is
+        #      expanded by that shell as an unset variable, the format collapses
+        #      to a bare `\n`, dpkg-query emits one blank line per package, and
+        #      `$(...)` strips them all -> `pkgs` empty -> the FATAL below.
+        #   2. `dpkg-query -W` matches every package dpkg KNOWS OF, not just the
+        #      installed ones -- purged and never-installed names (e.g.
+        #      `linux-headers-3.0`, `linux-image-fb-generic`, referenced only as
+        #      someone else's dependency) come back too. `apt-mark hold` errors
+        #      on those ("Can't select installed nor candidate version"), which
+        #      `set -e` turns fatal. Filter on `${db:Status-Status}` so only
+        #      genuinely installed packages reach apt-mark.
         "--run-command",
         'set -e; export DEBIAN_FRONTEND=noninteractive; '
-        'pkgs=$(dpkg-query -W -f="${Package}\\n" "linux-image-*" "linux-headers-*" '
-        '"linux-modules-*" "linux-generic" 2>/dev/null | sort -u); '
-        '[ -n "$pkgs" ] || { echo "FATAL: no linux-* packages found to hold" >&2; exit 1; }; '
+        'pkgs=$(dpkg-query -W -f="\\${db:Status-Status} \\${Package}\\n" '
+        '"linux-image-*" "linux-headers-*" "linux-modules-*" "linux-generic" '
+        '2>/dev/null | awk \'$1=="installed"{print $2}\' | sort -u); '
+        '[ -n "$pkgs" ] || { echo "FATAL: no installed linux-* packages found to hold" >&2; exit 1; }; '
         # apt-mark hold failure is fatal (set -e + no output swallow); then
         # verify EACH enumerated package is actually in showhold, so a
         # pre-existing unrelated hold cannot mask a partial/failed hold.

--- a/scripts/image/test_bake_kernel_hold_enumeration.py
+++ b/scripts/image/test_bake_kernel_hold_enumeration.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Regression test for the #1930 kernel-hold enumeration in bake.py.
+
+The bake pins the kernel package set with `apt-mark hold` so a background
+apt cannot drift the kernel out from under the verifier-gated AF_XDP shim
+(#1864/#1930). The package set is enumerated in-guest with:
+
+    pkgs=$(dpkg-query -W -f="${Package}\\n" "linux-image-*" ... | sort -u)
+
+That fragment is handed to the guest's `sh -c`, so the `$` in `${Package}`
+must reach dpkg-query LITERALLY. Unescaped, the guest shell expands
+`${Package}` itself — it is an unset shell variable, so the format string
+collapses to a bare `\\n`, dpkg-query emits one blank line per installed
+kernel package, `$(...)` strips the trailing newlines, and `pkgs` comes out
+EMPTY. The bake then dies at its own guard:
+
+    FATAL: no linux-* packages found to hold
+
+which aborts every bake before the image is ever written. (Introduced
+2026-06-16 by 6948ed0f8, #1930 INC-0; found by running a real bake.)
+
+This test extracts the actual `--run-command` string bake.py emits and runs
+it under a real /bin/sh against a STUB dpkg-query + apt-mark, asserting the
+kernel packages are enumerated and held.
+
+RED on revert: drop the backslash before `${Package}` in bake.py and
+test_enumerates_kernel_packages fails with the FATAL guard message.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "xpf_bake_hold", Path(__file__).with_name("bake.py"))
+bake = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(bake)
+
+# The kernel package set a stubbed guest reports as INSTALLED.
+_INSTALLED = [
+    "linux-generic",
+    "linux-headers-7.0.0-30",
+    "linux-headers-7.0.0-30-generic",
+    "linux-image-7.0.0-30-generic",
+    "linux-modules-7.0.0-30-generic",
+]
+
+# Names dpkg KNOWS OF but which are NOT installed. `dpkg-query -W` returns
+# these alongside the installed set (they are left behind by a purge, or
+# referenced only as some other package's dependency). `apt-mark hold` fails
+# on them with "Can't select installed nor candidate version", and `set -e`
+# turns that into a dead bake -- so they must be filtered out. These two
+# names are the ones a real 26.04 bake actually tripped over.
+_NOT_INSTALLED = [
+    "linux-headers-3.0",
+    "linux-image-fb-generic",
+]
+
+
+def _hold_command() -> str:
+    """Return the single `--run-command` from bake.py that does apt-mark hold."""
+    captured = {}
+
+    def fake_run(argv, **kw):
+        captured["argv"] = argv
+        return None
+
+    real_run = bake.run
+    bake.run = fake_run
+    try:
+        bake.virt_customize("/nonexistent/work.qcow2", "/nonexistent/xpf.deb")
+    finally:
+        bake.run = real_run
+
+    argv = captured["argv"]
+    cmds = [argv[i + 1] for i, a in enumerate(argv[:-1])
+            if a == "--run-command" and "apt-mark hold" in argv[i + 1]]
+    assert len(cmds) == 1, f"expected exactly 1 apt-mark hold command, got {len(cmds)}"
+    return cmds[0]
+
+
+class KernelHoldEnumerationTests(unittest.TestCase):
+    def setUp(self):
+        self.cmd = _hold_command()
+
+    @staticmethod
+    def _stub_guest(tmp: str) -> dict:
+        """Create stub dpkg-query/apt-mark on a private PATH.
+
+        The dpkg-query stub honours `-f`/`--showformat` the way the real one
+        does for the only field bake.py asks for, `${Package}`. It therefore
+        emits blank lines when handed a format with no field reference —
+        exactly the real behaviour the bug depended on.
+        """
+        binv = Path(tmp) / "bin"
+        binv.mkdir()
+        held = Path(tmp) / "held"
+        held.write_text("")
+
+        (binv / "dpkg-query").write_text(
+            "#!/bin/sh\n"
+            "fmt=''\n"
+            "while [ $# -gt 0 ]; do\n"
+            "  case \"$1\" in\n"
+            "    -W) ;;\n"
+            "    -f=*) fmt=${1#-f=} ;;\n"
+            "    -f|--showformat) shift; fmt=$1 ;;\n"
+            "    --showformat=*) fmt=${1#--showformat=} ;;\n"
+            "    *) patterns=\"$patterns $1\" ;;\n"
+            "  esac\n"
+            "  shift\n"
+            "done\n"
+            "emit() {\n"
+            "  st=$1; p=$2\n"
+            "  out=''\n"
+            "  case \"$fmt\" in *'${db:Status-Status}'*) out=\"$st \" ;; esac\n"
+            "  case \"$fmt\" in *'${Package}'*) out=\"$out$p\" ;; esac\n"
+            "  printf '%s\\n' \"$out\"\n"
+            "}\n"
+            "for p in " + " ".join(_INSTALLED) + "; do emit installed \"$p\"; done\n"
+            "for p in " + " ".join(_NOT_INSTALLED) + "; do emit not-installed \"$p\"; done\n"
+        )
+        # `apt-mark hold` on a name that is not installed is an ERROR, exactly
+        # as the real one behaves -- so an unfiltered enumeration kills the
+        # step under `set -e`.
+        (binv / "apt-mark").write_text(
+            "#!/bin/sh\n"
+            f"HELD={held}\n"
+            "case \"$1\" in\n"
+            "  hold) shift; rc=0; for p in \"$@\"; do\n"
+            "      case \" " + " ".join(_NOT_INSTALLED) + " \" in\n"
+            "        *\" $p \"*) echo \"E: Can't select installed nor candidate\"\n"
+            "                   \"version from package '$p' as it has neither\" >&2\n"
+            "                 rc=100; continue ;;\n"
+            "      esac\n"
+            "      echo \"$p\" >> \"$HELD\"\n"
+            "    done; exit $rc ;;\n"
+            "  showhold) sort -u \"$HELD\" ;;\n"
+            "esac\n"
+        )
+        for f in ("dpkg-query", "apt-mark"):
+            os.chmod(binv / f, os.stat(binv / f).st_mode | stat.S_IEXEC)
+        return {"PATH": f"{binv}:{os.environ['PATH']}"}
+
+    def test_enumerates_kernel_packages(self):
+        """The emitted script must enumerate + hold the installed kernel set.
+
+        REDs on the unescaped `${Package}`: the guest shell eats the field
+        reference, pkgs comes out empty, and bake.py's own guard fires.
+
+        Also REDs on an unfiltered enumeration: the stub reports two
+        not-installed names, apt-mark rejects them, and `set -e` kills the
+        step -- the second half of the real bake failure.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            env = self._stub_guest(tmp)
+            r = subprocess.run(["/bin/sh", "-c", self.cmd], env=env,
+                               capture_output=True, text=True)
+            self.assertEqual(
+                r.returncode, 0,
+                f"hold step failed rc={r.returncode}\n"
+                f"stdout={r.stdout}\nstderr={r.stderr}")
+            self.assertNotIn("no linux-* packages found to hold", r.stderr)
+            for pkg in _INSTALLED:
+                self.assertIn(pkg, r.stdout,
+                              f"{pkg} missing from the held set: {r.stdout}")
+            self.assertIn(f"held {len(_INSTALLED)} linux-* packages", r.stdout)
+            for pkg in _NOT_INSTALLED:
+                self.assertNotIn(
+                    pkg, r.stdout,
+                    f"not-installed {pkg} must not be handed to apt-mark hold")
+
+    def test_field_references_are_escaped_for_the_guest_shell(self):
+        """Every dpkg-query field reference must be escaped for `sh -c`.
+
+        A textual companion to the behavioural test above: it pins the
+        MECHANISM (each `$` is backslash-escaped, so the guest shell hands
+        `${...}` to dpkg-query instead of expanding it) so a rewrite that
+        keeps the fragment but drops an escape is caught even if the stub
+        harness drifts.
+        """
+        fmt = _fmt_of(self.cmd)
+        for field in ("${db:Status-Status}", "${Package}"):
+            self.assertIn("\\" + field, fmt,
+                          f"{field} must be backslash-escaped in {fmt!r}")
+        # And nothing unescaped slipped through: strip the escaped forms and
+        # no bare field reference may remain.
+        residue = fmt.replace("\\${db:Status-Status}", "").replace("\\${Package}", "")
+        self.assertNotIn("${", residue,
+                         f"unescaped field reference left in {fmt!r}")
+
+    def test_only_installed_packages_are_enumerated(self):
+        """The enumeration must filter on install state.
+
+        `dpkg-query -W` reports every package dpkg knows of. Holding a
+        not-installed one is an apt-mark error and, under `set -e`, a dead
+        bake. Pin that the status field is both requested and filtered on.
+        """
+        self.assertIn("db:Status-Status", self.cmd)
+        self.assertIn('installed', self.cmd)
+
+
+def _fmt_of(cmd: str) -> str:
+    """Extract the dpkg-query `-f="..."` format as written in the script.
+
+    The format contains spaces, so it cannot be recovered by splitting on
+    whitespace; match the double-quoted argument instead.
+    """
+    m = re.search(r'-f="([^"]*)"', cmd)
+    assert m, f"no -f=\"...\" argument in {cmd!r}"
+    return m.group(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_debhelper_token_placement.py
+++ b/scripts/test_debhelper_token_placement.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Guard the `#DEBHELPER#` token placement in debian/ maintainer scripts.
+
+debhelper substitutes EVERY occurrence of the literal `#DEBHELPER#` in a
+maintainer script with a generated shell snippet. The token therefore has
+to sit alone on its own line, at the point where that snippet belongs. A
+token that appears mid-line — including inside a prose comment — is still
+substituted, so the generated block is spliced into the middle of the
+script and whatever followed the token on that line is left behind as a
+top-level command.
+
+That is exactly what happened in debian/xpf.postinst (#1964, 723427b1e):
+
+    # Seed the versioned runtime layout BEFORE #DEBHELPER# starts
+
+became the dh_installsystemd block followed by a bare line ` starts`, so
+the built package's postinst died on a fresh install with
+
+    /var/lib/dpkg/info/xpf.postinst: 148: starts: not found
+    dpkg: error processing package xpf (--configure):
+     ... postinst maintainer script subprocess failed with exit status 127
+
+which aborted `apt-get install ./xpf_*.deb` and, with it, every appliance
+bake. Found by running a real bake for #1926.
+
+RED on revert: put `#DEBHELPER#` back inside the comment on
+debian/xpf.postinst:48 and test_token_is_alone_on_its_line fails.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+_TOKEN = "#DEBHELPER#"
+_DEBIAN = Path(__file__).resolve().parents[1] / "debian"
+# Maintainer scripts debhelper post-processes. `.debhelper` files are
+# debhelper's own generated fragments, not sources — skip them.
+_SUFFIXES = (".postinst", ".preinst", ".postrm", ".prerm", ".config")
+
+
+def _maintainer_scripts() -> list[Path]:
+    return sorted(
+        p for p in _DEBIAN.iterdir()
+        if p.is_file()
+        and p.suffix in _SUFFIXES
+        and not p.name.endswith(".debhelper")
+    )
+
+
+class DebhelperTokenPlacementTests(unittest.TestCase):
+    def test_scripts_found(self):
+        """Fail loudly rather than pass vacuously if the layout moves."""
+        scripts = _maintainer_scripts()
+        self.assertTrue(scripts, f"no maintainer scripts found under {_DEBIAN}")
+        names = {p.name for p in scripts}
+        self.assertIn("xpf.postinst", names,
+                      f"xpf.postinst missing from {sorted(names)}")
+
+    def test_token_is_alone_on_its_line(self):
+        """Every `#DEBHELPER#` must be the entire (stripped) line.
+
+        Anything else — a prose mention, a trailing word, a leading
+        comment marker — gets substituted in place and corrupts the script.
+        """
+        for path in _maintainer_scripts():
+            for lineno, line in enumerate(path.read_text().splitlines(), 1):
+                if _TOKEN not in line:
+                    continue
+                self.assertEqual(
+                    line.strip(), _TOKEN,
+                    f"{path.name}:{lineno} has {_TOKEN} embedded in a line; "
+                    f"debhelper substitutes it in place and leaves the rest "
+                    f"of the line as executable shell. Line: {line!r}")
+
+    def test_token_present_where_required(self):
+        """postinst/postrm/preinst must still carry exactly one token.
+
+        Guards the inverse mistake: deleting the token to satisfy the
+        placement rule would silently drop the generated systemd handling.
+        """
+        for name in ("xpf.postinst", "xpf.preinst", "xpf.postrm"):
+            path = _DEBIAN / name
+            if not path.is_file():
+                continue
+            n = path.read_text().count(_TOKEN)
+            self.assertEqual(n, 1, f"{name} has {n} {_TOKEN} tokens, want 1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1926

`docs/image-validation.md` Tier 2 has never had a recorded result. The
page blamed the NIC venue — a VENUE WARNING saying the AF_XDP dataplane
delivers 0 frames to the XSK over virtio.

The actual reason turned out to be more mundane: **you could not bake an
appliance image at all.** Three independent defects, each masking the
next, aborted every `python3 scripts/image/bake.py` run since mid-June.
Once they were fixed, the image booted on plain virtio and forwarded.

## The three bake defects

Found by iterating real bakes, not by reading code.

**1 + 2 — `scripts/image/bake.py`, the #1930 kernel-hold step** (both
from `6948ed0f8`, 2026-06-16)

- The dpkg-query format was not escaped for the guest shell. The fragment
  goes to the guest's `sh -c`, which expanded `${Package}` itself as an
  unset variable; the format collapsed to a bare `\n`, dpkg-query emitted
  one blank line per package, `$(...)` stripped them, `pkgs` came out
  empty → `FATAL: no linux-* packages found to hold`.
- Once that was fixed, the second surfaced: `dpkg-query -W` reports every
  package dpkg *knows of*, not just installed ones. On the 26.04 base
  that includes `linux-headers-3.0` and `linux-image-fb-generic`.
  `apt-mark hold` rejects them (`E: Can't select installed nor candidate
  version…`) and `set -e` killed the step — after the 8 real kernel
  packages had already been held.

**3 — `debian/xpf.postinst:48`, a `#DEBHELPER#` token inside prose**
(`723427b1e`, 2026-06-17)

debhelper substitutes *every* occurrence. The generated dh_installsystemd
block was spliced into the first-install branch and the tail of the
comment line — a bare ` starts` — was left as a top-level command:

```
/var/lib/dpkg/info/xpf.postinst: 148: starts: not found
dpkg: error processing package xpf (--configure): … exit status 127
```

**This one is not bake-only.** `apt-get install ./xpf_*.deb` fails on any
fresh install — the #1917 appliance install path. `make test-deploy`
pushes binaries rather than installing the package, which is why nothing
caught it.

## Tests

- `scripts/image/test_bake_kernel_hold_enumeration.py` — captures the argv
  `virt_customize` actually builds, extracts the real `--run-command`, and
  runs it under `/bin/sh` against stub `dpkg-query`/`apt-mark` that
  reproduce both real behaviours (blank lines for a field-less format;
  apt-mark failing on a not-installed name). Two textual tests pin the
  mechanism so a rewrite that drops an escape or the filter is caught even
  if the stub drifts.
- `scripts/test_debhelper_token_placement.py` — sweeps every
  `debian/*.{postinst,preinst,postrm,prerm,config}` and asserts each
  `#DEBHELPER#` is alone on its line, is still present exactly once
  (guards the inverse mistake of deleting it), and that the scripts were
  found at all (no vacuous pass).

Mutations run one defect at a time, never compounded:

| mutation | result |
|---|---|
| escapes removed, filter kept | REDs with the real `FATAL: no linux-* packages found to hold` |
| filter removed, escapes kept | REDs with apt-mark `rc=100`, the real error path |
| prose token restored | REDs 2 of 3 placement tests |

`make selftest`: 48 → **50 passed, 0 skipped, 0 failed**.

## The Tier-2 result

Baked qcow2, booted under ordinary incus on plain virtio, deployed via
`xpf-deploy.py` with its day-0 drive — **not** pushed binaries. Guest
kernel `7.0.0-30-generic`; base Ubuntu 26.04, Canonical-GPG-verified.

- v4 ping 0.35–0.43 ms; v6 ping 0.31–0.33 ms
- iperf3 v4 2.98 Gbit/s (5 s), **4.29 Gbit/s** sustained over 30 s
- iperf3 v6 3.94 Gbit/s (5 s), **3.02 Gbit/s** sustained over 30 s
- `show security flow session`: LAN→WAN flows with interface SNAT
- `show security flow statistics`: `Packets received: 3033032`,
  `Packets dropped: 0` — the direct refutation of the warning's
  `Packets received: 0`
- wanhost tcpdump: ICMP **and** TCP sourced from `10.66.2.1` /
  `fd66:2::1`; the LAN host's address never appears on the WAN segment

**Discriminator.** Interface SNAT already rules the guest kernel out
(`nft list ruleset` has no NAT table, only xpf's own RST-suppression and
host-inbound counters). Made explicit anyway, matching the method that
settled #1961: with `net.ipv4.ip_forward=0` **and**
`net.ipv6.conf.all.forwarding=0` on the appliance, ping stayed at **0%
loss** and iperf3 still moved 4.29 Gbit/s (v4) and 3.02 Gbit/s (v6) over
30 s.

## The doc

This page has flipped on the virtio question four times. `2054f0a8e`
wrote the current warning on 2026-06-17 — one day before #1976 landed the
fix for the very symptom it cites, and reverting `a9d3b7de1`/`c522b4aa3`,
which had flipped it the other way. Nothing revisited it for two months.

So the replacement is written to be falsifiable rather than assertive: it
names the image, commit, kernel, numbers, and discriminator, and keeps the
environment trap that caused the original misdiagnosis (#1961's three
firewall VMs answering the same gateway IPs) as a standing instruction to
run `incus list` first.

Deliberately **not** claimed: line rate (virtio ceilings at a few Gbit/s
on one flow), Tier 3 from an image, and an image-based forwarding proof on
an SR-IOV venue — still unrun. The image-vs-deployed-binaries distinction
is kept and sharpened, since it is the distinction #1926 exists for.

## Out of scope, filed separately

Neither affects the result:

- Tier-1 scenario **a** fails on this image: on a factory boot with no
  config drive nothing brings the NIC up (the bake purges cloud-init and
  netplan), so xpfd's bootstrap lifeline finds no default route and leaves
  the port down and unrenamed — no `fxp0`, no DHCP. Tier 2 is unaffected
  because it supplies a day-0 config.
- `show security flow session` omits TCP sessions that `show security flow
  statistics` counts (`Current sessions: 10` vs a rendered `Total
  sessions: 2`).

Also worth a decision, not changed here: `PINNED_BASE_SHA256` is stale —
Canonical respun the 26.04 image. I verified the new digest against
Canonical's GPG-signed `SHA256SUMS` (UEC key
`D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81`, **Good signature**) and baked
with `XPF_BASE_SHA256`, which bake.py documents as a reviewed one-off
override and which still records `base_image_pinned: true`. Bumping the
repo pin is a deliberate reviewed commit and is left to the owner.

No shared cluster was touched — local incus, private `xpf-rtr-*` networks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9xUEnt5VJUXBJLwR4vf65


Closes #7109
