### PR TITLE
image: bump the 26.04 base pin to Canonical's 2026-08 respin

### DIFF
--- a/scripts/image/bake.py
+++ b/scripts/image/bake.py
@@ -232,7 +232,7 @@ PINNED_BASE_RELEASE = "26.04"
 PINNED_BASE_SHA256 = {
     # ubuntu-26.04-server-cloudimg-amd64.img — Canonical-GPG-verified
     # (UEC signing key D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81).
-    "26.04": "3ee4f67f322abb2d1d1f0fffc957f7411404ad6635dd35b026c8ff05ac6e534c",
+    "26.04": "9dc7c5363c0146a08ba0c9aa834d82c2c6dfbb1c471ad9a2f0aba1189e21be05",
 }
 
 


### PR DESCRIPTION
Canonical respun `ubuntu-26.04-server-cloudimg-amd64.img`, so the pinned digest
no longer matches what the mirror serves and **every bake refuses the base**:

```
digest 9dc7c536... does NOT match pinned 3ee4f67f...
```

That refusal is the gate working as designed — `bake.py` treats
`PINNED_BASE_SHA256` as a trust anchor and will not build on bytes nobody
reviewed. Bumping it is therefore a deliberate reviewed act, which is why this is
its own PR rather than a rider on an image fix.

## Provenance — verified independently, not taken from a report

| | |
|---|---|
| old | `3ee4f67f322abb2d1d1f0fffc957f7411404ad6635dd35b026c8ff05ac6e534c` |
| new | `9dc7c5363c0146a08ba0c9aa834d82c2c6dfbb1c471ad9a2f0aba1189e21be05` |

```
gpg: Signature made Tue 04 Aug 2026 01:46:14 PM PDT
gpg:                using RSA key D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81
gpg: Good signature from "UEC Image Automatic Signing Key <cdimage@ubuntu.com>"

$ grep server-cloudimg-amd64.img SHA256SUMS
9dc7c5363c0146a08ba0c9aa834d82c2c6dfbb1c471ad9a2f0aba1189e21be05 *ubuntu-26.04-server-cloudimg-amd64.img
```

The locally cached base hashes to that same digest.

## A gotcha worth recording for the next person doing this

`https://cloud-images.ubuntu.com/releases/26.04/release/SHA256SUMS` **302-redirects**
to the codename path (`resolute`). Fetching without following redirects yields a
342-byte HTML error page, and `gpg --verify` then reports *"no valid OpenPGP data
found"* rather than a signature failure. Use the codename URL or follow redirects,
and treat a suspiciously short download as a redirect rather than a bad signature.

## Scope

One line. No behaviour change beyond which base bytes are accepted. The #1926
Tier-2 forwarding measurement was produced with `XPF_BASE_SHA256` — the reviewed
one-off override `bake.py` documents for exactly this situation — so this PR
simply makes that override unnecessary.

Related: #1926 (closed on the Tier-2 measurement), #7114 (a clean signed bake is
still blocked by Tier-1 scenario `a`).