### PR TITLE
config: compile every NTP server, not just Keys[1]

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1122,6 +1122,35 @@ whole value list and the node's own tail is ignored, verbatim master behaviour;
 the tail is read only when there are no children, which is the shape master
 compiled nothing from.**
 
+**CHILDREN WIN is a rule for leaves whose tail is an IDENTIFIER, not a rule for
+every leaf (#6690).** The two `event-options` arms adopt it because in
+`<leaf> <identifier> { <value>; }` the tail names the statement and the children
+are the values, so reading the tail promotes a name into the value list.
+`system ntp server` is the opposite arrangement: the tail is the VALUE (the
+server address) and a child is a per-server OPTION. `server 1.1.1.1 { prefer; }`
+under CHILDREN WIN would compile `prefer` as the NTP server and discard
+`1.1.1.1`. `ntpServerValues` (`compiler_system.go`) therefore reads both sides
+and discriminates by TOKEN NAME instead of by side, skipping the four Junos
+per-server option keywords — `prefer`, `key`, `version`, `routing-instance` —
+together with their argument tokens, and carrying that skip count across the
+`Keys` -> `Children` boundary.
+
+Name-based discrimination is unavoidable for this leaf rather than a stylistic
+choice. Once the lexer has stripped the brackets, `server 1.1.1.1 prefer;` and
+`server [ 1.1.1.1 2.2.2.2 ];` are the SAME AST shape, so no structural rule can
+separate an option from a second server. The schema cannot separate them either:
+the leaf is `args: 1, multi: true`, which makes both `SetPath` and the block
+parser absorb trailing tokens silently, and `prefer` is a syntactically valid
+hostname that `ValidateNTPServer` accepts. Promoting it would render `prefer`
+verbatim into a chrony `server` directive — the injection surface #4902 typed
+the value to close.
+
+Before this fold the nested-block spelling `ntp { server { a; b; } }` compiled
+ZERO servers (the reader tested `len(Keys) >= 2`, which that shape never
+satisfies) and the bracket spelling kept only the first — a green commit with no
+time sync, whose symptoms (certificate validity windows, IPsec rekey scheduling,
+cross-node log correlation) surface far from the cause.
+
 #### The token boundary is a property of the GROUP, not of the tail (#6673)
 
 When a leaf's value is itself a MULTI-WORD string, "how many values does this

--- a/pkg/config/compiler_ntp_multivalue_6690_test.go
+++ b/pkg/config/compiler_ntp_multivalue_6690_test.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6690: `system { ntp { server { a; b; } } }` compiled ZERO NTP servers and
+// the commit was green — the compiler read only ntpChild.Keys[1], which the
+// nested-block spelling never populates. The bracketed spelling kept only the
+// first server for the same reason (#2419 collapses the list onto Keys[1:]).
+//
+// These guards pin the compiled server LIST, not its length, across every
+// spelling the parser can produce, and pin the non-regression that a
+// per-server OPTION keyword is not compiled as an extra server.
+
+// ntpServersFromBlock compiles a hierarchical (brace) config body and returns
+// the compiled NTP server list.
+func ntpServersFromBlock(t *testing.T, body string) []string {
+	t.Helper()
+	p := NewParser(body)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse %q: %v", body, errs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig %q: %v", body, err)
+	}
+	return cfg.System.NTPServers
+}
+
+// ntpServersFromSet applies flat `set` commands and returns the compiled NTP
+// server list. Per CLAUDE.md the flat-set path must be driven through
+// ParseSetCommand + SetPath, never NewParser.
+func ntpServersFromSet(t *testing.T, cmds ...string) []string {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	return cfg.System.NTPServers
+}
+
+func assertServers(t *testing.T, spelling string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) || strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("%s: NTPServers = %v, want %v", spelling, got, want)
+	}
+}
+
+// Test_6690_NTPServerEveryHierarchicalSpelling covers the three brace-parsed
+// spellings. The nested block is the one that compiled to ZERO.
+func Test_6690_NTPServerEveryHierarchicalSpelling(t *testing.T) {
+	want := []string{"1.1.1.1", "2.2.2.2"}
+
+	assertServers(t, "nested block `server { a; b; }`",
+		ntpServersFromBlock(t, `system { ntp { server { 1.1.1.1; 2.2.2.2; } } }`), want)
+
+	assertServers(t, "bracket list `server [ a b ];`",
+		ntpServersFromBlock(t, `system { ntp { server [ 1.1.1.1 2.2.2.2 ]; } }`), want)
+
+	assertServers(t, "repeated leaf `server a; server b;`",
+		ntpServersFromBlock(t, `system { ntp { server 1.1.1.1; server 2.2.2.2; } }`), want)
+}
+
+// Test_6690_NTPServerEveryFlatSetSpelling covers the two flat-set spellings.
+// The bracket list dropped every server past the first.
+func Test_6690_NTPServerEveryFlatSetSpelling(t *testing.T) {
+	want := []string{"1.1.1.1", "2.2.2.2"}
+
+	assertServers(t, "flat-set repeated leaf",
+		ntpServersFromSet(t,
+			"set system ntp server 1.1.1.1",
+			"set system ntp server 2.2.2.2"), want)
+
+	assertServers(t, "flat-set bracket list",
+		ntpServersFromSet(t, "set system ntp server [ 1.1.1.1 2.2.2.2 ]"), want)
+}
+
+// Test_6690_NTPServerOptionTokensAreNotServers is the non-regression half.
+// After the lexer strips brackets, `server 1.1.1.1 prefer` and
+// `server [ 1.1.1.1 2.2.2.2 ]` are the SAME AST shape, so a naive
+// read-every-key fix would compile "prefer" as an NTP server and render it
+// verbatim into a chrony `server` directive. Each option keyword must be
+// skipped together with its argument tokens.
+func Test_6690_NTPServerOptionTokensAreNotServers(t *testing.T) {
+	one := []string{"1.1.1.1"}
+
+	assertServers(t, "`server a prefer;`",
+		ntpServersFromBlock(t, `system { ntp { server 1.1.1.1 prefer; } }`), one)
+
+	assertServers(t, "`server a key 5;`",
+		ntpServersFromBlock(t, `system { ntp { server 1.1.1.1 key 5; } }`), one)
+
+	assertServers(t, "`server a version 4;`",
+		ntpServersFromBlock(t, `system { ntp { server 1.1.1.1 version 4; } }`), one)
+
+	assertServers(t, "`server a routing-instance mgmt;`",
+		ntpServersFromBlock(t, `system { ntp { server 1.1.1.1 routing-instance mgmt; } }`), one)
+
+	// Option carried as a child of the address leaf rather than as a trailing
+	// key: `server 1.1.1.1 { prefer; }` → Keys=["server","1.1.1.1"], child
+	// Keys=["prefer"]. The child walk must skip it too.
+	assertServers(t, "`server a { prefer; }`",
+		ntpServersFromBlock(t, `system { ntp { server 1.1.1.1 { prefer; } } }`), one)
+
+	// An option on a real multi-server statement must not swallow a server.
+	assertServers(t, "`server [ a b ] prefer;`",
+		ntpServersFromBlock(t, `system { ntp { server [ 1.1.1.1 2.2.2.2 ] prefer; } }`),
+		[]string{"1.1.1.1", "2.2.2.2"})
+}

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -64,10 +64,23 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 			// shapes.
 			sys.NameServers = append(sys.NameServers, firewallMatchValues(child)...)
 		case "ntp":
+			// #6690: read EVERY server a `server` node carries, not just
+			// Keys[1]. `system { ntp { server { a; b; } } }` puts one leaf
+			// child per server and leaves the node itself with Keys=["server"]
+			// only, so the old `len(Keys) >= 2` read compiled ZERO servers from
+			// it — a green commit with no time sync at all. The bracketed
+			// spelling `server [ a b ]` collapses onto Keys[1:] (#2419) and
+			// kept only the first.
+			//
+			// This is NOT firewallMatchValues: a `server` node's trailing
+			// tokens are ambiguous. `server 1.1.1.1 prefer;` and
+			// `server [ 1.1.1.1 2.2.2.2 ];` are structurally identical after
+			// the lexer strips the brackets, so the per-server OPTION keywords
+			// have to be recognised by name or `prefer` would be compiled as a
+			// second NTP server and rendered verbatim into a chrony directive
+			// (#4902 types the value for exactly that reason).
 			for _, ntpChild := range child.FindChildren("server") {
-				if len(ntpChild.Keys) >= 2 {
-					sys.NTPServers = append(sys.NTPServers, ntpChild.Keys[1])
-				}
+				sys.NTPServers = append(sys.NTPServers, ntpServerValues(ntpChild)...)
 			}
 			if thNode := child.FindChild("threshold"); thNode != nil {
 				if v := nodeVal(thNode); v != "" {
@@ -2636,4 +2649,73 @@ func validateBackupRouterDst(cfg *Config, lenient bool) ([]string, error) {
 		return append(warnings, msg+" (ignored: backup-router default route not installed until corrected)"), nil
 	}
 	return nil, fmt.Errorf("%s", msg)
+}
+
+// ntpServerOptionArgs maps each Junos per-server option keyword that may
+// follow `system ntp server <address>` to the number of argument tokens it
+// consumes. These are the tokens that can legally appear AFTER the server
+// address on the same statement, so they must never be mistaken for a second
+// server address.
+//
+// The schema types `system ntp server` as a single-argument multi:true leaf
+// (schema_system.go), which means SetPath and the block parser both absorb any
+// trailing tokens onto the node's Keys without complaint — `prefer` is even a
+// syntactically valid hostname, so ValidateNTPServer accepts it. The compiler
+// is therefore the only place the distinction can be drawn.
+var ntpServerOptionArgs = map[string]int{
+	"prefer":           0,
+	"key":              1,
+	"version":          1,
+	"routing-instance": 1,
+}
+
+// ntpServerValues returns every NTP server address carried by one `server`
+// node, across all five spellings the parser can produce (#6690):
+//
+//   - hierarchical block, one leaf child per server
+//     `ntp { server { a; b; } }`  → Keys=["server"], children ["a"], ["b"]
+//   - hierarchical bracket list
+//     `ntp { server [ a b ]; }`   → Keys=["server","a","b"], no children
+//   - hierarchical repeated leaf
+//     `ntp { server a; server b; }` → two sibling nodes, one address each
+//     (the caller's FindChildren("server") loop visits both)
+//   - flat-set repeated leaf       → same as above
+//   - flat-set bracket list
+//     `set system ntp server [ a b ]` → Keys=["server","a","b"]
+//
+// and skips the per-server option tokens in ntpServerOptionArgs together with
+// their arguments, so `server 1.1.1.1 prefer;`, `server 1.1.1.1 key 5;` and
+// `server 1.1.1.1 { prefer; }` still compile to exactly one server.
+//
+// The option skip counter deliberately carries across the Keys→Children
+// boundary: an option whose argument was split onto a child node must not
+// leak that argument into the server list.
+func ntpServerValues(n *Node) []string {
+	if n == nil {
+		return nil
+	}
+	var servers []string
+	skip := 0
+	consume := func(tokens []string) {
+		for _, tok := range tokens {
+			if skip > 0 {
+				skip--
+				continue
+			}
+			if nargs, isOption := ntpServerOptionArgs[tok]; isOption {
+				skip = nargs
+				continue
+			}
+			if tok != "" {
+				servers = append(servers, tok)
+			}
+		}
+	}
+	if len(n.Keys) > 1 {
+		consume(n.Keys[1:])
+	}
+	for _, child := range n.Children {
+		consume(child.Keys)
+	}
+	return servers
 }


### PR DESCRIPTION
## Problem

`system { ntp { server { 1.1.1.1; 2.2.2.2; } } }` compiled **zero** NTP servers and the
commit was green. The nested-block spelling leaves the `server` node with
`Keys=["server"]` and one leaf child per address, so the `len(ntpChild.Keys) >= 2` guard
in `compiler_system.go` never fired. The bracketed spelling `server [ a b ]` collapses the
list onto `Keys[1:]` (#2419) and kept only the first address.

Fails toward silence: `show configuration` renders the servers the operator authored,
chrony is handed none.

## Enumeration — all five spellings, measured

| spelling | before | after |
|---|---|---|
| `ntp { server { a; b; } }` | `[]` | `[a b]` |
| `ntp { server [ a b ]; }` | `[a]` | `[a b]` |
| `ntp { server a; server b; }` | `[a b]` | `[a b]` |
| `set system ntp server <a>` (x2) | `[a b]` | `[a b]` |
| `set system ntp server [ a b ]` | `[a]` | `[a b]` |

Two of five spellings were broken, not one.

## Neither `firewallMatchValues` nor CHILDREN-WIN is correct here

Both established multi-leaf rules misread this leaf, **in opposite directions**:

- **`firewallMatchValues`** (what the adjacent `name-server` arm uses) reads every key.
  After the lexer strips brackets, `server 1.1.1.1 prefer;` and
  `server [ 1.1.1.1 2.2.2.2 ];` are the *same AST shape*, so it would compile `prefer` as
  a second NTP server and render it verbatim into a chrony `server` directive — the
  injection surface #4902 typed the value to close.
- **CHILDREN-WIN** (the #6673 event-options rule: children are the whole value list, the
  tail is ignored) fails the mirror case. In `server 1.1.1.1 { prefer; }` the tail is the
  VALUE and the child is the OPTION, so ignoring the tail would compile `prefer` as the
  server and discard the address. That rule assumes a leaf whose tail is an *identifier*,
  which is true of the event-options arms and false here.

The schema cannot draw the line either: the leaf is `args: 1, multi: true`, so both
`SetPath` and the block parser absorb trailing tokens silently, and `prefer` is a
syntactically valid hostname that `ValidateNTPServer` accepts. `ntpServerValues` therefore
discriminates by **token name**, not by side — skipping `prefer`, `key`, `version`,
`routing-instance` with their arguments, carrying the skip count across the
`Keys` -> `Children` boundary.

## Validator obligation (docs/config-schema.md #6659 rule)

None owed. `server` declares a schema `validator`, and `validateMultiValueLeaf`
(`schema_walk.go`) already walked `Keys[1:]` **and** every child's `Keys[0]` — every value
the widened read now materializes was already checked.

## Neighbourhood check (acceptance criterion 3)

Scoped to the `FindChildren` sites in `compiler_system.go`, **not** claimed as a general
sweep: `ciphers` and `macs` already read every value via `firewallMatchValues`;
`key-exchange` (`nodeVal`) and `api-key` (`nodeVal`) do read slot 0 only, but both are
already tracked by #6692 and are deliberately untouched here.

## Mutation proof

Production change reverted, tests kept:

```
MUT_BUILD_RC=0
MUT_VET_RC=0
MUT_TEST_RC=1
  compiler_ntp_multivalue_6690_test.go:67:  nested block `server { a; b; }`: NTPServers = [], want [1.1.1.1 2.2.2.2]
  compiler_ntp_multivalue_6690_test.go:70:  bracket list `server [ a b ];`: NTPServers = [1.1.1.1], want [1.1.1.1 2.2.2.2]
  compiler_ntp_multivalue_6690_test.go:87:  flat-set bracket list: NTPServers = [1.1.1.1], want [1.1.1.1 2.2.2.2]
  compiler_ntp_multivalue_6690_test.go:119: `server [ a b ] prefer;`: NTPServers = [1.1.1.1], want [1.1.1.1 2.2.2.2]
```

Build and vet stay clean under the mutation, so this is an **assertion** red, not a build
break. Restored: `POST_RESTORE_RC=0`.

## Validation

- `go build ./...` clean, `go vet ./pkg/config/` clean
- `go test -count=1 ./pkg/config/` -> `ok ... 15.414s` (rc=0)
- Option-token non-regressions pinned: `prefer`, `key 5`, `version 4`,
  `routing-instance mgmt`, the `server a { prefer; }` child form, and
  `server [ a b ] prefer;`

Docs: `docs/config-schema.md` now records why CHILDREN-WIN does not generalise to a leaf
whose tail is the value.

Go-only change in `pkg/config`; nothing reaches the Rust helper binary, so **no cluster
smoke is owed**.

Closes #6690