### PR TITLE
daemon: fail the HA fence when the rg_active clear fails

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -97543,3 +97543,38 @@ prose edit above them added. No diff falls in the new test body.
   Both fire on the wrap-accept assertion itself (Repeat vs Accept). Full Rust
   suite `cargo test -p userspace-dp -- --test-threads=1` exit 0.
 - **File(s)**: userspace-dp/src/afxdp/wg/session.rs, _Log.md
+- **Timestamp**: 2026-08-21
+- **Action**: Fixed #6371 — a FAILED `rg_active` clear no longer reports the HA
+  fence as actuated. On a peer-requested transfer-out the demotion branch of
+  `watchClusterEvents` called `d.signalFailoverActuated(ev.GroupID)`
+  unconditionally: the `SetRGActive` error path only logged a WARN and fell
+  through to the same close, so `waitFailoverActuated` released the applied-ack
+  and the peer promoted while this node may still have been forwarding for the
+  RG — the exact two-owner window #5640 was written to close.
+
+  The fence barrier now carries a VERDICT rather than bare completion: a new
+  `failoverActuation{done, resolved, err}` replaces the plain `chan struct{}`;
+  the demotion branch records the `SetRGActive` error and resolves via
+  `signalFailoverActuationFailed` instead of `signalFailoverActuated`;
+  `waitFailoverActuated` returns that verdict, so `handleRemoteFailover`
+  downgrades the ack to `failoverAckFailed` and the peer HOLDS. Resolving with
+  a failure (rather than staying silent) also avoids parking the waiter for its
+  full timeout on a fence already known not to have landed. The resolved
+  barrier is left in the map for the waiter to consume — deleting it at
+  resolution time, as the old success-only path did, would make a failure that
+  lands before the waiter arrives read as "never armed", i.e. success.
+
+  The per-event body of `watchClusterEvents` was split out as
+  `handleClusterEvent(ctx, ev, vrrpTimer) *time.Timer` (pure movement; the
+  debounce timer is threaded through the return value) because
+  `cluster.Manager` only exposes a receive-only `Events()`, so the demotion
+  branch was unreachable from a test. Four daemon tests now drive that real
+  path plus one cluster test pinning the verdict's transport.
+
+  Validation: `go test -count=1 ./pkg/daemon/ ./pkg/cluster/` exit 0; `go vet`
+  and `go build ./...` exit 0. HA/failover code — `make test-failover` is owed
+  before merge (not run here: the loss cluster is shared and lock-protected).
+- **File(s)**: pkg/daemon/daemon_ha.go, pkg/daemon/daemon.go,
+  pkg/daemon/daemon_ha_actuation_6371_test.go,
+  pkg/cluster/sync_failover_fence_verdict_6371_test.go,
+  docs/session-sync-architecture.md, _Log.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -1650,16 +1650,28 @@ ownership / traffic).
 The fix gates the applied-ack on a fence-completion barrier:
 
 1. The daemon `OnRemoteFailover`/`OnRemoteFailoverBatch` closures call
-   `armFailoverActuation(rgID)` — registering a per-RG channel — **before**
+   `armFailoverActuation(rgID)` — registering a per-RG barrier — **before**
    `ManualFailover` enqueues the demotion event, so the actuation signal can
    never be missed. A `ManualFailover` error disarms the barrier.
 2. `handleRemoteFailover` calls the `WaitFailoverApplied` hook (wired to
    `waitFailoverActuated`) after `OnRemoteFailover` succeeds and before sending
-   `failoverAckApplied`. It blocks on the barrier channel.
-3. `watchClusterEvents`, at the end of the demotion (non-primary) branch — after
-   `ResignRG` / direct-VIP reconcile / `rg_active` clear — calls
-   `signalFailoverActuated(rgID)`, closing the channel and releasing the ack.
-4. The wait is bounded by `failoverActuateTimeout` (3s default). A demotion that
+   `failoverAckApplied`. It blocks on the barrier.
+3. `handleClusterEvent` (the per-event body of `watchClusterEvents`), at the end
+   of the demotion (non-primary) branch — after `ResignRG` / direct-VIP
+   reconcile / `rg_active` clear — resolves the barrier and releases the ack.
+4. The barrier carries a **verdict**, not just a completion (#6371). The
+   demotion branch tracks whether the dataplane accepted the `rg_active` write:
+   on success it calls `signalFailoverActuated(rgID)` (verdict `nil`), and on a
+   `SetRGActive` error it calls `signalFailoverActuationFailed(rgID, err)`.
+   `waitFailoverActuated` returns that verdict, so a REJECTED clear — this node
+   may still be forwarding for the RG — downgrades the ack to
+   `failoverAckFailed` instead of reporting the fence applied. Failing loudly
+   rather than staying silent also keeps the waiter from burning its whole
+   timeout on a fence already known not to have landed. The resolved barrier is
+   left in the map for `waitFailoverActuated` to consume (a re-arm replaces it):
+   deleting it at resolution time would make a failure that lands before the
+   waiter arrives read as "never armed", i.e. success.
+5. The wait is bounded by `failoverActuateTimeout` (3s default). A demotion that
    never actuates (superseded reset, event-channel drop) downgrades the ack to
    `failoverAckFailed` so the peer **holds** rather than promoting into the
    two-owner window — safety over latency in the race. On the normal path the

--- a/pkg/cluster/sync_failover_fence_verdict_6371_test.go
+++ b/pkg/cluster/sync_failover_fence_verdict_6371_test.go
@@ -1,0 +1,56 @@
+package cluster
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestHandleRemoteFailoverFailedFenceDowngradesAck pins the transport half of
+// the #6371 fix: the daemon's fence barrier now resolves with a FAILURE verdict
+// when the local rg_active clear was rejected, and that verdict must reach the
+// peer as failoverAckFailed — never as failoverAckApplied. An applied-ack on a
+// fence that did not actuate is exactly the two-owner window #5640 closed.
+//
+// Fail-on-revert: drop the error branch on `s.WaitFailoverApplied(rgID)` in
+// handleRemoteFailover and the applied-ack is sent regardless of the verdict.
+func TestHandleRemoteFailoverFailedFenceDowngradesAck(t *testing.T) {
+	ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+	local, peer := net.Pipe()
+	defer local.Close()
+	defer peer.Close()
+
+	ss.mu.Lock()
+	ss.conn0 = local
+	ss.mu.Unlock()
+	ss.stats.Connected.Store(true)
+
+	ss.OnRemoteFailover = func(int, uint64) error { return nil }
+	fenceErr := errors.New("redundancy group 7 rg_active=false not applied on demotion")
+	ss.WaitFailoverApplied = func(int) error { return fenceErr }
+
+	frames := make(chan syncFrame, 4)
+	readFramesInto(peer, frames)
+
+	go ss.handleRemoteFailover(local, 7, 42)
+
+	select {
+	case f := <-frames:
+		if f.typ != syncMsgFailoverAck {
+			t.Fatalf("frame type = %d, want failover ack %d", f.typ, syncMsgFailoverAck)
+		}
+		if len(f.payload) < 2 || f.payload[0] != 7 {
+			t.Fatalf("ack payload = %v, want rg=7", f.payload)
+		}
+		if f.payload[1] == failoverAckApplied {
+			t.Fatal("ack status = applied after a FAILED fence verdict: the peer would " +
+				"promote while this node may still own the RG (#6371)")
+		}
+		if f.payload[1] != failoverAckFailed {
+			t.Fatalf("ack status = %d, want failed %d", f.payload[1], failoverAckFailed)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no failover ack delivered for a failed fence verdict")
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -936,15 +936,18 @@ type Daemon struct {
 	// the bit have a chance to propagate before the peer finalizes demotion.
 	localFailoverCommitDelay time.Duration
 	// failoverActuateMu guards failoverActuateWait. The map holds, per RG, a
-	// channel that watchClusterEvents closes once it has ACTUATED a demotion
-	// (VRRP resign to priority-0 / rg_active clear). armFailoverActuation
-	// registers a fresh channel BEFORE ManualFailover enqueues the demotion
-	// event, so the close can never be missed; waitFailoverActuated blocks the
-	// remote-failover applied-ack on that close. This closes the #5640
-	// two-owner window where the peer promoted off an ack sent before this
-	// (old-owner) node had actually resigned.
+	// barrier that watchClusterEvents resolves once it has finished ACTUATING
+	// a demotion (VRRP resign to priority-0 / rg_active clear).
+	// armFailoverActuation registers a fresh barrier BEFORE ManualFailover
+	// enqueues the demotion event, so the resolution can never be missed;
+	// waitFailoverActuated blocks the remote-failover applied-ack on it. This
+	// closes the #5640 two-owner window where the peer promoted off an ack
+	// sent before this (old-owner) node had actually resigned. The barrier
+	// carries a verdict, not just a completion: a demotion whose rg_active
+	// clear was REJECTED by the dataplane resolves with that error so the ack
+	// is downgraded rather than reported applied (#6371).
 	failoverActuateMu   sync.Mutex
-	failoverActuateWait map[int]chan struct{}
+	failoverActuateWait map[int]*failoverActuation
 	// failoverActuateTimeout bounds waitFailoverActuated so a demotion event
 	// that is never actuated (superseded reset, event-channel drop) downgrades
 	// the ack to failed instead of hanging the peer's failover request.
@@ -1257,7 +1260,7 @@ func New(opts Options) (*Daemon, error) {
 		localFailoverCommitReady:   make(map[int]bool),
 		localFailoverCommitTimeout: 3 * time.Second,
 		localFailoverCommitDelay:   200 * time.Millisecond,
-		failoverActuateWait:        make(map[int]chan struct{}),
+		failoverActuateWait:        make(map[int]*failoverActuation),
 		failoverActuateTimeout:     3 * time.Second,
 		userspaceDemotionPrepUntil: make(map[int]time.Time),
 		applySem:                   semaphore.NewWeighted(1),

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -139,6 +139,17 @@ func (d *Daemon) waitLocalFailoverCommitReady(rgIDs []int) error {
 	}
 }
 
+// failoverActuation is the per-RG fence-completion barrier armed before a
+// remote-requested transfer-out. done is closed exactly once, when the local
+// demotion has been RESOLVED; err is the verdict (nil = the demotion actually
+// actuated, non-nil = it did not) and is written under failoverActuateMu before
+// done is closed, so every observer of the close also observes the verdict.
+type failoverActuation struct {
+	done     chan struct{}
+	resolved bool
+	err      error
+}
+
 // armFailoverActuation registers a fence-completion barrier for rgID before a
 // remote-requested transfer-out enqueues its async demotion event. It MUST be
 // called before cluster.ManualFailover so the demotion actuation
@@ -149,9 +160,9 @@ func (d *Daemon) waitLocalFailoverCommitReady(rgIDs []int) error {
 func (d *Daemon) armFailoverActuation(rgID int) {
 	d.failoverActuateMu.Lock()
 	if d.failoverActuateWait == nil {
-		d.failoverActuateWait = make(map[int]chan struct{})
+		d.failoverActuateWait = make(map[int]*failoverActuation)
 	}
-	d.failoverActuateWait[rgID] = make(chan struct{})
+	d.failoverActuateWait[rgID] = &failoverActuation{done: make(chan struct{})}
 	d.failoverActuateMu.Unlock()
 }
 
@@ -166,30 +177,63 @@ func (d *Daemon) disarmFailoverActuation(rgID int) {
 }
 
 // signalFailoverActuated marks rgID's demotion as actuated (VRRP resigned /
-// rg_active cleared) and releases any waiter. It is idempotent: the channel is
-// deleted under the lock, so a second demotion event for the same RG is a
-// no-op and never double-closes. Safe to call for every non-primary cluster
-// event — an unarmed RG simply has no channel to close.
+// rg_active cleared) and releases any waiter with a success verdict. Safe to
+// call for every non-primary cluster event — an unarmed RG simply has no
+// barrier to resolve.
 func (d *Daemon) signalFailoverActuated(rgID int) {
-	d.failoverActuateMu.Lock()
-	ch := d.failoverActuateWait[rgID]
-	delete(d.failoverActuateWait, rgID)
-	d.failoverActuateMu.Unlock()
-	if ch != nil {
-		close(ch)
+	d.resolveFailoverActuation(rgID, nil)
+}
+
+// signalFailoverActuationFailed releases rgID's barrier with a FAILURE verdict:
+// the demotion side effects did not land (e.g. the dataplane rejected the
+// rg_active clear), so this node may still be forwarding for the RG. The waiter
+// surfaces cause, the sync layer downgrades the applied-ack to failed, and the
+// peer holds instead of promoting into a two-owner window (#6371). cause must
+// be non-nil; a nil cause would be indistinguishable from success.
+func (d *Daemon) signalFailoverActuationFailed(rgID int, cause error) {
+	if cause == nil {
+		cause = fmt.Errorf("redundancy group %d demotion not actuated", rgID)
 	}
+	d.resolveFailoverActuation(rgID, cause)
+}
+
+// resolveFailoverActuation completes rgID's barrier exactly once with verdict
+// cause (nil = actuated). It is idempotent: the resolved flag is set under the
+// lock, so a second demotion event for the same RG is a no-op and never
+// double-closes. The verdict is written BEFORE the close, so any goroutine that
+// observes the close also observes the verdict.
+//
+// The barrier is left in the map rather than deleted — waitFailoverActuated
+// consumes it. Deleting here would make a resolution that lands before the
+// waiter arrives read as "never armed", i.e. success, which would throw away
+// exactly the failure verdict this path exists to deliver (#6371). A re-arm
+// replaces the entry, so the map stays bounded by the RG count.
+func (d *Daemon) resolveFailoverActuation(rgID int, cause error) {
+	d.failoverActuateMu.Lock()
+	b := d.failoverActuateWait[rgID]
+	if b == nil || b.resolved {
+		d.failoverActuateMu.Unlock()
+		return
+	}
+	b.resolved = true
+	b.err = cause
+	d.failoverActuateMu.Unlock()
+	close(b.done)
 }
 
 // waitFailoverActuated blocks until the local demotion for rgID has been
-// actuated (barrier closed by signalFailoverActuated) or the bounded timeout
-// elapses. A nil barrier means the actuation already completed (or was never
-// armed) — return immediately. This gates the remote-failover applied-ack so
-// the peer never promotes into a two-owner window (#5640).
+// resolved (barrier closed by signalFailoverActuated / -Failed) or the bounded
+// timeout elapses. A nil barrier means the RG was never armed (or an earlier
+// waiter already consumed the verdict) — return immediately. It returns nil
+// only when the demotion actually actuated: a failed actuation surfaces its
+// cause (#6371) and a barrier that never resolves surfaces a timeout. This
+// gates the remote-failover applied-ack so the peer never promotes into a
+// two-owner window (#5640).
 func (d *Daemon) waitFailoverActuated(rgID int) error {
 	d.failoverActuateMu.Lock()
-	ch := d.failoverActuateWait[rgID]
+	b := d.failoverActuateWait[rgID]
 	d.failoverActuateMu.Unlock()
-	if ch == nil {
+	if b == nil {
 		return nil
 	}
 	timeout := d.failoverActuateTimeout
@@ -199,8 +243,16 @@ func (d *Daemon) waitFailoverActuated(rgID int) error {
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 	select {
-	case <-ch:
-		return nil
+	case <-b.done:
+		// Consume the resolved barrier: this waiter owns the verdict, and
+		// leaving it behind would let a later wait re-read a stale one.
+		d.failoverActuateMu.Lock()
+		err := b.err
+		if d.failoverActuateWait[rgID] == b {
+			delete(d.failoverActuateWait, rgID)
+		}
+		d.failoverActuateMu.Unlock()
+		return err
 	case <-timer.C:
 		// Drop the stranded barrier so a later actuation event does not
 		// close an orphaned channel that no one reads.
@@ -261,165 +313,197 @@ func (d *Daemon) watchClusterEvents(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case ev := <-d.cluster.Events():
-			noRethVRRP := d.isNoRethVRRP()
-
-			// Dual-active winner reaffirm: no state change but send
-			// GARPs to refresh upstream ARP/NDP caches after split-brain.
-			if ev.DualActiveWin && noRethVRRP {
-				d.scheduleDirectAnnounce(ev.GroupID, "dual-active-win")
-				continue
-			}
-
-			// Update rg_active through unified state machine.
-			//
-			// Both cluster and VRRP events funnel through rgStateMachine
-			// which determines rg_active = clusterPri || anyVrrpMaster.
-			// This prevents the dual-inactive window (both nodes
-			// rg_active=false during failover) and eliminates the race
-			// between the two independent goroutine writers.
-			//
-			// Transition ordering safety:
-			// - Activation: set rg_active FIRST, then remove blackholes,
-			//   then trigger VRRP MASTER (#485). Neighbor readiness is
-			//   maintained continuously in the background.
-			// - Deactivation: run preflight FIRST, then resign VRRP,
-			//   add blackholes, then clear rg_active (#485)
-			isPrimary := ev.NewState == cluster.StatePrimary
-			clusterDemotionEdge := ev.OldState == cluster.StatePrimary && !isPrimary
-			d.setLocalFailoverCommitReady(ev.GroupID, false)
-			s := d.getOrCreateRGState(ev.GroupID)
-			tr := s.SetCluster(isPrimary)
-			if isPrimary {
-				// Activation: enable forwarding first.
-				// Re-read desired state to guard against a
-				// concurrent VRRP goroutine that may have
-				// already superseded this transition.
-				if rt := d.dataplane(); tr.Changed && rt != nil {
-					cur, _ := s.CurrentDesired()
-					if err := rt.HA().SetRGActive(ctx, ev.GroupID, cur); err != nil {
-						slog.Warn("failed to update rg_active from cluster event",
-							"rg", ev.GroupID, "active", cur, "err", err)
-					} else {
-						recordRGActiveAppliedIfCurrentOrStable(s, tr, cur)
-					}
-				}
-				// Only remove blackholes once this node's desired state is
-				// actually active. In strict VIP ownership mode, a cluster
-				// primary event alone does not activate the RG until VRRP
-				// ownership has moved as well.
-				if shouldRemoveBlackholesOnClusterPrimary(s) {
-					d.removeBlackholeRoutes(ev.GroupID)
-				}
-
-				// VRRP priority + ForceRGMaster AFTER rg_active and
-				// blackhole removal (#485).
-				if !noRethVRRP {
-					d.vrrpMgr.UpdateRGPriority(ev.GroupID, 200)
-					// With preempt=false, VRRP won't self-elect even at
-					// higher priority. Force MASTER since cluster state
-					// is authoritative (e.g. after failover reset).
-					// Only do this for intentional promotions (Secondary →
-					// Primary), NOT on initial boot (SecondaryHold → Primary)
-					// where VRRP should follow its own election timer.
-					if ev.OldState == cluster.StateSecondary {
-						d.vrrpMgr.ForceRGMaster(ev.GroupID)
-					}
-				}
-
-				// no-reth-vrrp direct mode: reconcile VIP ownership from
-				// actual cluster local/peer state, not just this rg_active
-				// edge. This prevents stale VIPs from surviving a demotion
-				// when the rg_state machine has already drifted inactive.
-				if noRethVRRP {
-					d.reconcileDirectVIPOwnership(ev.GroupID, "cluster-primary")
-					go d.RefreshFabricFwd()
-				}
-				if noRethVRRP && d.cluster != nil && d.cluster.IsLocalPrimary(ev.GroupID) && (d.dataplane() == nil || !s.NeedsApply()) {
-					d.setLocalFailoverCommitReady(ev.GroupID, true)
-				}
-			} else {
-				// Demotion: run preflight and resign VRRP BEFORE
-				// clearing rg_active (#485). The preflight shifts
-				// userspace flow cache entries to FabricRedirect so
-				// the demoting node forwards via fabric during the
-				// transition window. ResignRG must follow preflight
-				// so traffic is already on the fabric path before
-				// the VRRP BACKUP transition removes VIPs.
-				if clusterDemotionEdge && d.dataplane() != nil {
-					d.tryPrepareUserspaceRGDemotion(ev.GroupID)
-				}
-				if !noRethVRRP {
-					if ev.OldState == cluster.StatePrimary &&
-						(ev.NewState == cluster.StateSecondary || ev.NewState == cluster.StateSecondaryHold) {
-						d.vrrpMgr.ResignRG(ev.GroupID)
-					}
-				}
-				// Deactivation: blackhole routes first (if transitioning
-				// to inactive), then clear rg_active.
-				if tr.Changed && !tr.Active {
-					d.injectBlackholeRoutes(ev.GroupID)
-				}
-				if rt := d.dataplane(); tr.Changed && rt != nil {
-					cur, _ := s.CurrentDesired()
-					if !cur && !clusterDemotionEdge {
-						d.tryPrepareUserspaceRGDemotion(ev.GroupID)
-					}
-					if err := rt.HA().SetRGActive(ctx, ev.GroupID, cur); err != nil {
-						slog.Warn("failed to update rg_active from cluster event",
-							"rg", ev.GroupID, "active", cur, "err", err)
-					} else {
-						recordRGActiveAppliedIfCurrentOrStable(s, tr, cur)
-					}
-				}
-
-				// no-reth-vrrp direct mode: always reconcile actual VIP
-				// ownership on non-primary transitions. Removal must not
-				// depend on a fresh rg_active edge because stale VIPs can
-				// survive a failback if the state machine already drifted.
-				if noRethVRRP {
-					d.reconcileDirectVIPOwnership(ev.GroupID, "cluster-secondary")
-				}
-
-				// #5640: the local demotion is now actuated — VRRP has
-				// resigned to priority-0 (or direct VIP ownership was
-				// reconciled away) and rg_active is cleared. Release any
-				// remote-failover applied-ack that is holding for this fence
-				// so the peer only promotes AFTER this node stopped owning
-				// the RG. Fires for every non-primary edge; unarmed RGs no-op.
-				d.signalFailoverActuated(ev.GroupID)
-			}
-
-			// Strict VIP ownership: suppress GARP on secondary, allow on primary.
-			// Not applicable with no-reth-vrrp (no VRRP instances).
-			if !noRethVRRP && s.IsStrictVIPOwnership() {
-				d.vrrpMgr.SetGARPSuppression(ev.GroupID, !isPrimary)
-			}
-
-			// Debounced VRRP priority update — 500ms coalesce window.
-			// Skipped in no-reth-vrrp mode (no RETH VRRP instances to update).
-			if !noRethVRRP {
-				if vrrpTimer != nil {
-					vrrpTimer.Stop()
-				}
-				vrrpTimer = time.AfterFunc(500*time.Millisecond, func() {
-					if cfg := d.store.ActiveConfig(); cfg != nil {
-						localPri := d.cluster.LocalPriorities()
-						var all []*vrrp.Instance
-						all = append(all, vrrp.CollectInstances(cfg)...)
-						all = append(all, vrrp.CollectRethInstances(cfg, localPri)...)
-						if err := d.vrrpMgr.UpdateInstances(all); err != nil {
-							slog.Warn("cluster: failed to update VRRP instances", "err", err)
-						}
-					}
-				})
-			}
-
-			// RG0-specific: config ownership and IPsec SA re-initiation.
-			if ev.GroupID == 0 {
-				d.applyRG0OwnershipTransition(ev.NewState)
-			}
+			vrrpTimer = d.handleClusterEvent(ctx, ev, vrrpTimer)
 		}
 	}
+}
+
+// handleClusterEvent applies one cluster state-change event: it drives
+// rg_active through the unified rgStateMachine, orders the VRRP and blackhole
+// side effects around that write, and releases the #5640 fence barrier on a
+// demotion.
+//
+// vrrpTimer is the caller's in-flight VRRP-priority debounce timer (nil when
+// none is armed); the possibly re-armed timer is returned so watchClusterEvents
+// keeps exactly one pending update and can stop it on exit. Split out of the
+// select loop so the handling is reachable from a test without an injectable
+// cluster event channel (cluster.Manager only exposes a receive-only Events()).
+func (d *Daemon) handleClusterEvent(ctx context.Context, ev cluster.ClusterEvent, vrrpTimer *time.Timer) *time.Timer {
+	noRethVRRP := d.isNoRethVRRP()
+
+	// Dual-active winner reaffirm: no state change but send
+	// GARPs to refresh upstream ARP/NDP caches after split-brain.
+	if ev.DualActiveWin && noRethVRRP {
+		d.scheduleDirectAnnounce(ev.GroupID, "dual-active-win")
+		return vrrpTimer
+	}
+
+	// Update rg_active through unified state machine.
+	//
+	// Both cluster and VRRP events funnel through rgStateMachine
+	// which determines rg_active = clusterPri || anyVrrpMaster.
+	// This prevents the dual-inactive window (both nodes
+	// rg_active=false during failover) and eliminates the race
+	// between the two independent goroutine writers.
+	//
+	// Transition ordering safety:
+	// - Activation: set rg_active FIRST, then remove blackholes,
+	//   then trigger VRRP MASTER (#485). Neighbor readiness is
+	//   maintained continuously in the background.
+	// - Deactivation: run preflight FIRST, then resign VRRP,
+	//   add blackholes, then clear rg_active (#485)
+	isPrimary := ev.NewState == cluster.StatePrimary
+	clusterDemotionEdge := ev.OldState == cluster.StatePrimary && !isPrimary
+	d.setLocalFailoverCommitReady(ev.GroupID, false)
+	s := d.getOrCreateRGState(ev.GroupID)
+	tr := s.SetCluster(isPrimary)
+	if isPrimary {
+		// Activation: enable forwarding first.
+		// Re-read desired state to guard against a
+		// concurrent VRRP goroutine that may have
+		// already superseded this transition.
+		if rt := d.dataplane(); tr.Changed && rt != nil {
+			cur, _ := s.CurrentDesired()
+			if err := rt.HA().SetRGActive(ctx, ev.GroupID, cur); err != nil {
+				slog.Warn("failed to update rg_active from cluster event",
+					"rg", ev.GroupID, "active", cur, "err", err)
+			} else {
+				recordRGActiveAppliedIfCurrentOrStable(s, tr, cur)
+			}
+		}
+		// Only remove blackholes once this node's desired state is
+		// actually active. In strict VIP ownership mode, a cluster
+		// primary event alone does not activate the RG until VRRP
+		// ownership has moved as well.
+		if shouldRemoveBlackholesOnClusterPrimary(s) {
+			d.removeBlackholeRoutes(ev.GroupID)
+		}
+
+		// VRRP priority + ForceRGMaster AFTER rg_active and
+		// blackhole removal (#485).
+		if !noRethVRRP {
+			d.vrrpMgr.UpdateRGPriority(ev.GroupID, 200)
+			// With preempt=false, VRRP won't self-elect even at
+			// higher priority. Force MASTER since cluster state
+			// is authoritative (e.g. after failover reset).
+			// Only do this for intentional promotions (Secondary →
+			// Primary), NOT on initial boot (SecondaryHold → Primary)
+			// where VRRP should follow its own election timer.
+			if ev.OldState == cluster.StateSecondary {
+				d.vrrpMgr.ForceRGMaster(ev.GroupID)
+			}
+		}
+
+		// no-reth-vrrp direct mode: reconcile VIP ownership from
+		// actual cluster local/peer state, not just this rg_active
+		// edge. This prevents stale VIPs from surviving a demotion
+		// when the rg_state machine has already drifted inactive.
+		if noRethVRRP {
+			d.reconcileDirectVIPOwnership(ev.GroupID, "cluster-primary")
+			go d.RefreshFabricFwd()
+		}
+		if noRethVRRP && d.cluster != nil && d.cluster.IsLocalPrimary(ev.GroupID) && (d.dataplane() == nil || !s.NeedsApply()) {
+			d.setLocalFailoverCommitReady(ev.GroupID, true)
+		}
+	} else {
+		// Demotion: run preflight and resign VRRP BEFORE
+		// clearing rg_active (#485). The preflight shifts
+		// userspace flow cache entries to FabricRedirect so
+		// the demoting node forwards via fabric during the
+		// transition window. ResignRG must follow preflight
+		// so traffic is already on the fabric path before
+		// the VRRP BACKUP transition removes VIPs.
+		if clusterDemotionEdge && d.dataplane() != nil {
+			d.tryPrepareUserspaceRGDemotion(ev.GroupID)
+		}
+		if !noRethVRRP {
+			if ev.OldState == cluster.StatePrimary &&
+				(ev.NewState == cluster.StateSecondary || ev.NewState == cluster.StateSecondaryHold) {
+				d.vrrpMgr.ResignRG(ev.GroupID)
+			}
+		}
+		// Deactivation: blackhole routes first (if transitioning
+		// to inactive), then clear rg_active.
+		if tr.Changed && !tr.Active {
+			d.injectBlackholeRoutes(ev.GroupID)
+		}
+		// #6371: track whether the dataplane accepted the demotion write.
+		// A failed rg_active update means this node may still be forwarding
+		// for the RG, so the fence below must NOT report actuation.
+		var actuateErr error
+		if rt := d.dataplane(); tr.Changed && rt != nil {
+			cur, _ := s.CurrentDesired()
+			if !cur && !clusterDemotionEdge {
+				d.tryPrepareUserspaceRGDemotion(ev.GroupID)
+			}
+			if err := rt.HA().SetRGActive(ctx, ev.GroupID, cur); err != nil {
+				slog.Warn("failed to update rg_active from cluster event",
+					"rg", ev.GroupID, "active", cur, "err", err)
+				actuateErr = fmt.Errorf("redundancy group %d rg_active=%v not applied on demotion: %w",
+					ev.GroupID, cur, err)
+			} else {
+				recordRGActiveAppliedIfCurrentOrStable(s, tr, cur)
+			}
+		}
+
+		// no-reth-vrrp direct mode: always reconcile actual VIP
+		// ownership on non-primary transitions. Removal must not
+		// depend on a fresh rg_active edge because stale VIPs can
+		// survive a failback if the state machine already drifted.
+		if noRethVRRP {
+			d.reconcileDirectVIPOwnership(ev.GroupID, "cluster-secondary")
+		}
+
+		// #5640: the local demotion is now actuated — VRRP has
+		// resigned to priority-0 (or direct VIP ownership was
+		// reconciled away) and rg_active is cleared. Release any
+		// remote-failover applied-ack that is holding for this fence
+		// so the peer only promotes AFTER this node stopped owning
+		// the RG. Fires for every non-primary edge; unarmed RGs no-op.
+		//
+		// #6371: when the rg_active write above FAILED, the fence did not
+		// complete — resolve the barrier with that error instead, so the
+		// applied-ack downgrades to failed and the peer holds rather than
+		// promoting into a two-owner window. Reporting the failure (rather
+		// than staying silent) keeps the waiter from burning its full
+		// timeout on a fence that is already known not to have landed.
+		if actuateErr != nil {
+			d.signalFailoverActuationFailed(ev.GroupID, actuateErr)
+		} else {
+			d.signalFailoverActuated(ev.GroupID)
+		}
+	}
+
+	// Strict VIP ownership: suppress GARP on secondary, allow on primary.
+	// Not applicable with no-reth-vrrp (no VRRP instances).
+	if !noRethVRRP && s.IsStrictVIPOwnership() {
+		d.vrrpMgr.SetGARPSuppression(ev.GroupID, !isPrimary)
+	}
+
+	// Debounced VRRP priority update — 500ms coalesce window.
+	// Skipped in no-reth-vrrp mode (no RETH VRRP instances to update).
+	if !noRethVRRP {
+		if vrrpTimer != nil {
+			vrrpTimer.Stop()
+		}
+		vrrpTimer = time.AfterFunc(500*time.Millisecond, func() {
+			if cfg := d.store.ActiveConfig(); cfg != nil {
+				localPri := d.cluster.LocalPriorities()
+				var all []*vrrp.Instance
+				all = append(all, vrrp.CollectInstances(cfg)...)
+				all = append(all, vrrp.CollectRethInstances(cfg, localPri)...)
+				if err := d.vrrpMgr.UpdateInstances(all); err != nil {
+					slog.Warn("cluster: failed to update VRRP instances", "err", err)
+				}
+			}
+		})
+	}
+
+	// RG0-specific: config ownership and IPsec SA re-initiation.
+	if ev.GroupID == 0 {
+		d.applyRG0OwnershipTransition(ev.NewState)
+	}
+	return vrrpTimer
 }
 
 // applyRG0OwnershipTransition reacts to a RG0 ownership change: it toggles the

--- a/pkg/daemon/daemon_ha_actuation_6371_test.go
+++ b/pkg/daemon/daemon_ha_actuation_6371_test.go
@@ -1,0 +1,260 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	"github.com/psaab/xpf/pkg/vrrp"
+)
+
+// errRGActiveRejected models the dataplane refusing an rg_active write — the
+// helper is down, the control socket errored, the RG is unknown.
+var errRGActiveRejected = errors.New("helper rejected rg_active write")
+
+// actuationHA is an HAController whose SetRGActive verdict the test controls,
+// and which records what it was asked to write.
+type actuationHA struct {
+	mu     sync.Mutex
+	err    error
+	writes []bool // `active` argument of every SetRGActive call
+}
+
+func (h *actuationHA) SetRGActive(_ context.Context, _ int, active bool) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.writes = append(h.writes, active)
+	return h.err
+}
+
+func (h *actuationHA) SetHAWatchdog(_ context.Context, _ int, _ uint64) error { return nil }
+
+func (h *actuationHA) SetFabricForwarding(_ context.Context, _ dataplane.FabricID, _ dataplane.FabricFwdInfo) error {
+	return nil
+}
+
+func (h *actuationHA) SyncFabricState(_ context.Context) error { return nil }
+
+func (h *actuationHA) writeCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.writes)
+}
+
+func (h *actuationHA) lastWrite() (bool, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.writes) == 0 {
+		return false, false
+	}
+	return h.writes[len(h.writes)-1], true
+}
+
+// actuationDP is a RuntimeDataPlane whose only live surface is HA(). The nil
+// embed panics if the demotion path reaches for anything else, which keeps the
+// fake honest.
+type actuationDP struct {
+	dataplane.RuntimeDataPlane
+	ha *actuationHA
+}
+
+func (d *actuationDP) HA() dataplane.HAController { return d.ha }
+
+// Mode makes userspaceDataplaneActive() true so the demotion path takes the
+// userspace early-return in injectBlackholeRoutes instead of issuing netlink
+// route writes — this test is about the fence verdict, not blackholes.
+func (d *actuationDP) Mode() dpuserspace.DataplaneMode { return dpuserspace.ModeUserspaceStrict }
+
+// newActuationDaemon builds the minimum Daemon that can run
+// handleClusterEvent's demotion branch: a committed cluster config, a cluster
+// manager holding RG1, a VRRP manager (unused on the default private-RG-election
+// path but present so the RETH-VRRP branch could not nil-panic), and the
+// caller's HA fake published as the dataplane.
+//
+// Note the config takes the PRODUCTION default: `private-rg-election` is on
+// unless `no-private-rg-election` is set, so isNoRethVRRP() is TRUE here and the
+// demotion runs the direct-VIP-ownership path the loss userspace cluster runs.
+// The fence-barrier release under test is shared by both branches.
+func newActuationDaemon(t *testing.T, ha *actuationHA) *Daemon {
+	t.Helper()
+	cm := cluster.NewManager(0, 1)
+	cm.UpdateConfig(&config.ClusterConfig{
+		RedundancyGroups: []*config.RedundancyGroup{
+			{ID: 0, NodePriorities: map[int]int{0: 200}},
+			{ID: 1, NodePriorities: map[int]int{0: 200}},
+		},
+	})
+	d := &Daemon{
+		store:                      fenceTestStore(t, fenceStartupClusterSet),
+		cluster:                    cm,
+		vrrpMgr:                    vrrp.NewManager(),
+		rgStates:                   make(map[int]*rgStateMachine),
+		failoverActuateWait:        make(map[int]*failoverActuation),
+		failoverActuateTimeout:     2 * time.Second,
+		userspaceDemotionPrepUntil: make(map[int]time.Time),
+	}
+	d.setDataplane(&actuationDP{ha: ha})
+	return d
+}
+
+// primeRG1Primary establishes the pre-demotion posture. UpdateConfig elects a
+// solo node primary for every RG, so this drains those promotion events and
+// tells the daemon's rgStateMachine about the one for RG1 — which makes the
+// demotion below a real rg_active transition (tr.Changed, cur == false) rather
+// than a no-op edge.
+func primeRG1Primary(t *testing.T, d *Daemon) {
+	t.Helper()
+	for drained := true; drained; {
+		select {
+		case <-d.cluster.Events():
+		default:
+			drained = false
+		}
+	}
+	if !d.cluster.IsLocalPrimary(1) {
+		t.Fatal("setup: RG1 must be cluster-primary before the demotion edge")
+	}
+	if tr := d.getOrCreateRGState(1).SetCluster(true); !tr.Active {
+		t.Fatal("setup: RG1 must be desired-active before the demotion edge")
+	}
+}
+
+// demoteRG1 runs the production transfer-out sequence for RG1: cluster
+// ManualFailover (what the daemon's OnRemoteFailover closure calls once the
+// barrier is armed), then the demotion event the manager ACTUALLY emitted is
+// handed to handleClusterEvent — the same value watchClusterEvents would read
+// off Events(). The returned debounce timer is stopped so no background VRRP
+// update fires after the test returns.
+func demoteRG1(t *testing.T, d *Daemon) {
+	t.Helper()
+	if err := d.cluster.ManualFailover(1); err != nil {
+		t.Fatalf("ManualFailover(1): %v", err)
+	}
+	var ev cluster.ClusterEvent
+	select {
+	case ev = <-d.cluster.Events():
+	case <-time.After(2 * time.Second):
+		t.Fatal("cluster manager emitted no demotion event")
+	}
+	if ev.GroupID != 1 || ev.OldState != cluster.StatePrimary || ev.NewState == cluster.StatePrimary {
+		t.Fatalf("unexpected cluster event %+v, want a RG1 primary -> non-primary edge", ev)
+	}
+	if timer := d.handleClusterEvent(context.Background(), ev, nil); timer != nil {
+		timer.Stop()
+	}
+}
+
+// TestFailoverActuation_FailedRGActiveClearDoesNotAck is the #6371 regression
+// guard. On a peer-requested transfer-out, handleClusterEvent clears rg_active
+// and then releases the fence barrier that gates the applied-ack. When the
+// dataplane REJECTS that clear, this node may still be forwarding for the RG —
+// reporting the fence as actuated tells the peer to promote into a two-owner
+// window.
+//
+// Fail-on-revert: restore the unconditional `d.signalFailoverActuated(...)` at
+// the end of the demotion branch and waitFailoverActuated returns nil here,
+// failing RED on a clean assertion.
+func TestFailoverActuation_FailedRGActiveClearDoesNotAck(t *testing.T) {
+	ha := &actuationHA{err: errRGActiveRejected}
+	d := newActuationDaemon(t, ha)
+	primeRG1Primary(t, d)
+
+	d.armFailoverActuation(1)
+	demoteRG1(t, d)
+
+	// Positive control: the demotion really reached the rg_active write with
+	// the clearing value, so the assertion below is not vacuous.
+	if got := ha.writeCount(); got != 1 {
+		t.Fatalf("SetRGActive call count = %d, want 1 (demotion must attempt the clear)", got)
+	}
+	if active, ok := ha.lastWrite(); !ok || active {
+		t.Fatalf("SetRGActive wrote active=%v, want false (a demotion clears rg_active)", active)
+	}
+
+	err := d.waitFailoverActuated(1)
+	if err == nil {
+		t.Fatal("waitFailoverActuated returned nil after a FAILED rg_active clear: " +
+			"the applied-ack would tell the peer to promote while this node may still forward (#6371)")
+	}
+	if !errors.Is(err, errRGActiveRejected) {
+		t.Fatalf("fence verdict = %v, want it to carry the dataplane rejection", err)
+	}
+	// The verdict must arrive from the resolved barrier, not from the wait
+	// timeout — a timeout would delay the peer's failover by the full window.
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("fence verdict = %v, want an immediate failure not a timeout", err)
+	}
+}
+
+// TestFailoverActuation_SucceededRGActiveClearAcks is the negative control: an
+// accepted rg_active clear must still report the fence as actuated, so the fix
+// does not simply refuse every ack (which would break every planned failover).
+func TestFailoverActuation_SucceededRGActiveClearAcks(t *testing.T) {
+	ha := &actuationHA{}
+	d := newActuationDaemon(t, ha)
+	primeRG1Primary(t, d)
+
+	d.armFailoverActuation(1)
+	demoteRG1(t, d)
+
+	if got := ha.writeCount(); got != 1 {
+		t.Fatalf("SetRGActive call count = %d, want 1", got)
+	}
+	if err := d.waitFailoverActuated(1); err != nil {
+		t.Fatalf("waitFailoverActuated = %v, want nil after a successful clear", err)
+	}
+}
+
+// TestFailoverActuation_ParkedWaiterSeesFailure covers the other resolution
+// ordering: the applied-ack waiter is already blocked on the barrier when the
+// demotion fails. It must observe the same failure verdict rather than waking
+// as if the fence had completed.
+func TestFailoverActuation_ParkedWaiterSeesFailure(t *testing.T) {
+	ha := &actuationHA{err: errRGActiveRejected}
+	d := newActuationDaemon(t, ha)
+	primeRG1Primary(t, d)
+
+	d.armFailoverActuation(1)
+	errCh := make(chan error, 1)
+	go func() { errCh <- d.waitFailoverActuated(1) }()
+	// Give the waiter time to park on the barrier. The assertion holds for
+	// either ordering — a waiter that has not parked yet takes the
+	// consume-after-resolution path and reads the same verdict.
+	time.Sleep(20 * time.Millisecond)
+
+	demoteRG1(t, d)
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("parked waiter woke with nil after a FAILED rg_active clear (#6371)")
+		}
+		if !errors.Is(err, errRGActiveRejected) {
+			t.Fatalf("fence verdict = %v, want it to carry the dataplane rejection", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("parked waiter never woke — the barrier must be resolved on failure, not left hanging")
+	}
+}
+
+// TestFailoverActuation_UnarmedRGIsNoop pins the unchanged contract for RGs
+// that never armed a barrier (every ordinary demotion): resolving is a no-op
+// and a wait returns immediately with no error.
+func TestFailoverActuation_UnarmedRGIsNoop(t *testing.T) {
+	ha := &actuationHA{err: errRGActiveRejected}
+	d := newActuationDaemon(t, ha)
+	primeRG1Primary(t, d)
+
+	// No armFailoverActuation: this is an ordinary local demotion.
+	demoteRG1(t, d)
+
+	if err := d.waitFailoverActuated(1); err != nil {
+		t.Fatalf("waitFailoverActuated on an unarmed RG = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## The defect

`watchClusterEvents`' demotion branch cleared `rg_active` and then called
`d.signalFailoverActuated(ev.GroupID)` **unconditionally**. The `SetRGActive`
error path only logged a WARN and fell through to that same call, and
`signalFailoverActuated` consulted no applied state, so `waitFailoverActuated`
released the remote-failover applied-ack **even when the clear had FAILED** —
telling the peer to promote while this node may still have been forwarding for
the redundancy group. That is the two-owner window #5640 was written to close,
reopened by its own error path. `git log -S'signalFailoverActuated' --
pkg/daemon/` returns exactly one commit (`e5c61b59d`, #5640): nothing had
fenced the failure path since it was introduced.

## The fix

The fence barrier now carries a **verdict**, not bare completion.

- `failoverActuation{done, resolved, err}` replaces the plain `chan struct{}`.
  `err` is written under `failoverActuateMu` *before* `done` is closed, so every
  observer of the close also observes the verdict.
- The demotion branch records the `SetRGActive` error and resolves through the
  new `signalFailoverActuationFailed` instead of `signalFailoverActuated`.
- `waitFailoverActuated` returns that verdict, so `handleRemoteFailover`
  downgrades the ack to `failoverAckFailed` (existing code) and the peer
  **holds** instead of joining a split-brain.

Resolving with a failure rather than staying silent is deliberate: silence would
park the waiter for its whole `failoverActuateTimeout` on a fence already known
not to have landed, delaying the peer's failover by seconds for no gain.

A resolved barrier is now **left in the map** for `waitFailoverActuated` to
consume, where the old success-only path deleted it at signal time. With
deletion, a resolution landing before the waiter arrives reads as "never armed",
which `waitFailoverActuated` maps to success — discarding exactly the failure
verdict this path exists to deliver. A re-arm replaces the entry, so the map
stays bounded by the RG count.

## Why the refactor

`cluster.Manager` exposes only a receive-only `Events()`, so the demotion branch
was unreachable from any test — the fix would have been unbindable. The
per-event body is split out as
`handleClusterEvent(ctx, ev, vrrpTimer) *time.Timer`: pure movement, with the
VRRP debounce timer (the only loop-carried state) threaded through the argument
and return value, and the dual-active `continue` becoming `return vrrpTimer`.

## Validation

Five new tests drive the real path. `TestFailoverActuation_*` primes RG1 to
cluster-primary, arms the barrier, calls `cluster.ManualFailover` (what
`OnRemoteFailover` does) and feeds `handleClusterEvent` the demotion event the
manager **actually emitted**, with a dataplane that rejects — and, as a control,
accepts — the `rg_active` write. Both resolution orderings and the unarmed no-op
are covered. `TestHandleRemoteFailoverFailedFenceDowngradesAck` pins the
transport: a failed verdict becomes `failoverAckFailed`, never
`failoverAckApplied`.

Mutation-verified RED three ways, each with `go vet` exit 0 so the red is an
assertion and not a build break:

| # | Mutation | Result |
|---|---|---|
| M1 | restore the unconditional `signalFailoverActuated` | RED — `FailedRGActiveClearDoesNotAck` + `ParkedWaiterSeesFailure` (control + unarmed stay GREEN) |
| M2 | `delete()` the barrier at resolution time (old success-only shape) | RED — `FailedRGActiveClearDoesNotAck` |
| M3 | discard the verdict in `handleRemoteFailover` | RED — `HandleRemoteFailoverFailedFenceDowngradesAck` |

`go test -count=1 ./pkg/daemon/ ./pkg/cluster/` exit 0. `go vet` and
`go build ./...` exit 0. Docs: `docs/session-sync-architecture.md` §"Remote-failover
applied-ack is fenced on local demotion actuation" updated with the verdict
semantics and the retention rationale.

**Smoke owed.** This is HA/failover code, so per the project contract it owes
`make test-failover` on the loss userspace cluster before merge. It was NOT run
here — that cluster is shared and lock-protected. Go control plane only; the
Rust helper binary is untouched.

Closes #6371
