### PR TITLE
config: compile fab0 members from every AST shape

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -950,6 +950,25 @@ allowed-ips folds are covered by the `security-nat-static-multi-zone` and
 `interfaces-wireguard-allowed-ips-multi` dual-AST fixtures plus
 `TestWireguardAllowedIPsBracketList{FlatSet,Hierarchical}`.
 
+**A leaf whose flat-set bracket list lands on a CHILD's Keys needs more than
+`firewallMatchValues` (#6694).** The SSOT helper reads `Keys[1:]` of the node
+plus `Keys[0]` of each child, which covers every leaf whose flat-set path
+absorbs the list onto the node itself. `interfaces fab0 fabric-options
+member-interfaces` does not: its schema node is a plain `children: nil` leaf
+with no `args` and no `multi`, so `SetPath` files the whole bracket list as ONE
+child carrying every name on that child's Keys — and `firewallMatchValues`
+would keep only the first. `fabricMemberValues` (`compiler_interfaces.go`)
+therefore descends the subtree and takes EVERY key. The same read is now driven
+through `FindChildren("member-interfaces")` rather than `FindChild`, because
+repeated hierarchical statements land as sibling nodes. Before the fold the
+hierarchical bracket spelling and the plain single-value spelling
+(`member-interfaces ge-0/0/7;`) both compiled to an EMPTY fabric member list —
+a chassis-cluster fabric that cannot form, silent at commit. Widening the read
+also ARMS the existing fab0/fab1 shared-member overlap check in
+`compiler_validate_warn.go`, which previously saw nothing to compare for
+bracket-authored fabrics; that check emits a warning, not a rejection, so no
+config that committed before is rejected now.
+
 **Widening a multi-value READ requires widening its VALIDATOR in the same
 change (#6659).** Adopting the accumulating reader at a site changes what a
 malformed value DOES. Before, a bad value in slot 2 was discarded at compile and

--- a/pkg/config/compiler_fabric_members_6694_test.go
+++ b/pkg/config/compiler_fabric_members_6694_test.go
@@ -1,0 +1,142 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6694: `interfaces { fab0 { fabric-options { member-interfaces [ a b ]; } } }`
+// compiled an EMPTY member list. The compiler descended miNode.Children only,
+// and the hierarchical bracket spelling carries every name on the node's own
+// Keys with no children at all.
+//
+// The same Children-only descent also emptied the plain single-value
+// hierarchical spelling `member-interfaces ge-0/0/7;`, which the issue did not
+// describe: a one-member fab0 authored in a config FILE (load merge, day-0
+// import, rescue config) lost its member too.
+//
+// fab0 is the chassis-cluster fabric — session sync, config sync, IPsec SA
+// sync and the cross-chassis forwarding path that keeps TCP alive across a
+// VRRP failback all ride it. A fabric with zero compiled members cannot form,
+// and the failure is silent at commit.
+
+func fabricMembersFromBlock(t *testing.T, body string) []string {
+	t.Helper()
+	p := NewParser(body)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse %q: %v", body, errs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig %q: %v", body, err)
+	}
+	ifc := cfg.Interfaces.Interfaces["fab0"]
+	if ifc == nil {
+		t.Fatalf("fab0 absent from compiled config for %q", body)
+	}
+	return ifc.FabricMembers
+}
+
+// fabricMembersFromSet drives the flat-set path the way CLAUDE.md requires —
+// ParseSetCommand + SetPath, never NewParser.
+func fabricMembersFromSet(t *testing.T, cmds ...string) []string {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	ifc := cfg.Interfaces.Interfaces["fab0"]
+	if ifc == nil {
+		t.Fatal("fab0 absent from compiled config")
+	}
+	return ifc.FabricMembers
+}
+
+func assertFabricMembers6694(t *testing.T, spelling string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) || strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("%s: FabricMembers = %v, want %v", spelling, got, want)
+	}
+}
+
+// Test_6694_FabricMembersEveryHierarchicalSpelling covers the brace-parsed
+// spellings. The bracket list and the repeated-statement form both compiled
+// to an empty slice.
+func Test_6694_FabricMembersEveryHierarchicalSpelling(t *testing.T) {
+	want := []string{"ge-0/0/7", "ge-7/0/7"}
+
+	assertFabricMembers6694(t, "nested block `member-interfaces { a; b; }`",
+		fabricMembersFromBlock(t,
+			`interfaces { fab0 { fabric-options { member-interfaces { ge-0/0/7; ge-7/0/7; } } } }`), want)
+
+	assertFabricMembers6694(t, "bracket list `member-interfaces [ a b ];`",
+		fabricMembersFromBlock(t,
+			`interfaces { fab0 { fabric-options { member-interfaces [ ge-0/0/7 ge-7/0/7 ]; } } }`), want)
+
+	// Repeated hierarchical statements land as SIBLING member-interfaces
+	// nodes; the old FindChild read only the first.
+	assertFabricMembers6694(t, "repeated `member-interfaces a; member-interfaces b;`",
+		fabricMembersFromBlock(t,
+			`interfaces { fab0 { fabric-options { member-interfaces ge-0/0/7; member-interfaces ge-7/0/7; } } }`), want)
+}
+
+// Test_6694_FabricMembersSingleHierarchicalMember is the case the issue did
+// not describe: one member, authored in a config file, compiled to ZERO.
+func Test_6694_FabricMembersSingleHierarchicalMember(t *testing.T) {
+	assertFabricMembers6694(t, "single `member-interfaces a;`",
+		fabricMembersFromBlock(t,
+			`interfaces { fab0 { fabric-options { member-interfaces ge-0/0/7; } } }`),
+		[]string{"ge-0/0/7"})
+}
+
+// Test_6694_FabricMembersEveryFlatSetSpelling covers the flat-set path. The
+// bracket list keeps every name on ONE child node's Keys, which is why the
+// firewallMatchValues SSOT (Keys[0] of each child) does not close this leaf.
+func Test_6694_FabricMembersEveryFlatSetSpelling(t *testing.T) {
+	want := []string{"ge-0/0/7", "ge-7/0/7"}
+
+	assertFabricMembers6694(t, "flat-set repeated",
+		fabricMembersFromSet(t,
+			"set interfaces fab0 fabric-options member-interfaces ge-0/0/7",
+			"set interfaces fab0 fabric-options member-interfaces ge-7/0/7"), want)
+
+	assertFabricMembers6694(t, "flat-set bracket list",
+		fabricMembersFromSet(t,
+			"set interfaces fab0 fabric-options member-interfaces [ ge-0/0/7 ge-7/0/7 ]"), want)
+
+	// A three-member list keeps all three, so the fix is not a two-element
+	// special case.
+	assertFabricMembers6694(t, "flat-set bracket list, three members",
+		fabricMembersFromSet(t,
+			"set interfaces fab0 fabric-options member-interfaces [ ge-0/0/7 ge-7/0/7 ge-1/0/1 ]"),
+		[]string{"ge-0/0/7", "ge-7/0/7", "ge-1/0/1"})
+}
+
+// Test_6694_FabricMembersDriveBondMode pins the downstream consequence: the
+// `len(FabricMembers) > 0` branch that sets BondMode never fired for the
+// broken spellings, so the compiled fab0 was not even marked as a bond.
+func Test_6694_FabricMembersDriveBondMode(t *testing.T) {
+	p := NewParser(`interfaces { fab0 { fabric-options { member-interfaces [ ge-0/0/7 ge-7/0/7 ]; } } }`)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if got := cfg.Interfaces.Interfaces["fab0"].BondMode; got != "active-backup" {
+		t.Errorf("fab0 BondMode = %q, want %q", got, "active-backup")
+	}
+}

--- a/pkg/config/compiler_interfaces.go
+++ b/pkg/config/compiler_interfaces.go
@@ -142,12 +142,19 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig, opts compileOpts, w
 			}
 		}
 
-		// Check for fabric-options member-interfaces
+		// Check for fabric-options member-interfaces.
+		//
+		// #6694: read the member names out of EVERY AST shape, not just
+		// miNode.Children. The `Children`-only descent compiled an EMPTY
+		// member list for the two hierarchical spellings that carry the names
+		// on the node's own Keys — the idiomatic bracket list
+		// `member-interfaces [ ge-0/0/0 ge-0/0/1 ];` and the plain single
+		// `member-interfaces ge-0/0/0;`. FindChildren, not FindChild, because
+		// repeated hierarchical statements land as SIBLING nodes and only the
+		// first was ever consulted.
 		if foNode := child.FindChild("fabric-options"); foNode != nil {
-			if miNode := foNode.FindChild("member-interfaces"); miNode != nil {
-				for _, m := range miNode.Children {
-					ifc.FabricMembers = append(ifc.FabricMembers, m.Name())
-				}
+			for _, miNode := range foNode.FindChildren("member-interfaces") {
+				ifc.FabricMembers = append(ifc.FabricMembers, fabricMemberValues(miNode)...)
 			}
 			if len(ifc.FabricMembers) > 0 {
 				ifc.BondMode = "active-backup"
@@ -1344,4 +1351,55 @@ func compileInterfaceDynamicDNS(afNode *Node) *InterfaceDynamicDNSConfig {
 		return nil
 	}
 	return d
+}
+
+// fabricMemberValues returns every member interface name carried by one
+// `fabric-options member-interfaces` node.
+//
+// The names reach the compiler on the node's own Keys, on its children's Keys,
+// or both, depending on how the config was authored (#6694 / the #2419
+// multi-value-leaf class):
+//
+//   - hierarchical block      `member-interfaces { a; b; }`
+//     → Keys=["member-interfaces"], one leaf child per name
+//   - hierarchical bracket    `member-interfaces [ a b ];`
+//     → Keys=["member-interfaces","a","b"], no children
+//   - hierarchical single     `member-interfaces a;`
+//     → Keys=["member-interfaces","a"], no children
+//   - flat-set repeated       `set ... member-interfaces a` (x2)
+//     → Keys=["member-interfaces"], one leaf child per name
+//   - flat-set bracket        `set ... member-interfaces [ a b ]`
+//     → Keys=["member-interfaces"], ONE child whose Keys hold every name
+//
+// The last shape is why firewallMatchValues is not enough here: it reads only
+// Keys[0] of each child, so it would keep the first name of a flat-set bracket
+// list and drop the rest. Descend the whole subtree and take every key.
+//
+// `member-interfaces` has no per-member option keywords in Junos, so unlike
+// the NTP server list there is no trailing-token ambiguity to resolve — every
+// non-empty token below the node is a member name.
+func fabricMemberValues(n *Node) []string {
+	if n == nil {
+		return nil
+	}
+	var members []string
+	add := func(tokens []string) {
+		for _, tok := range tokens {
+			if tok != "" {
+				members = append(members, tok)
+			}
+		}
+	}
+	if len(n.Keys) > 1 {
+		add(n.Keys[1:])
+	}
+	var walk func(*Node)
+	walk = func(parent *Node) {
+		for _, c := range parent.Children {
+			add(c.Keys)
+			walk(c)
+		}
+	}
+	walk(n)
+	return members
 }


### PR DESCRIPTION
## Problem

`interfaces { fab0 { fabric-options { member-interfaces [ ge-0/0/0 ge-0/0/1 ]; } } }`
compiled an **empty** member list. `compiler_interfaces.go` descended `miNode.Children`
only, and the hierarchical bracket spelling — the idiomatic Junos one for a two-member
fabric — carries every name on the node's own `Keys` with no children at all.

`fab0` is the chassis-cluster fabric: session sync, config sync, IPsec SA sync and the
cross-chassis forwarding path that keeps TCP alive across a VRRP failback all ride it. A
fabric with zero compiled members cannot form, the commit is green, and the symptom appears
only under HA.

## Finding the issue did NOT describe

The same `Children`-only descent also emptied the plain single-value hierarchical spelling
`member-interfaces ge-0/0/7;`. A **one-member fab0 authored in a config FILE** (load merge,
day-0 import, rescue config) lost its member too. Flat `set` is unaffected in that shape,
which is why the existing flat-set cluster tests never caught it. Same site, same one-line
fix, so it is folded in here rather than filed separately.

## Enumeration — six spellings, measured

| spelling | before | after |
|---|---|---|
| `member-interfaces { a; b; }` | `[a b]` | `[a b]` |
| `member-interfaces [ a b ];` | `[]` | `[a b]` |
| `member-interfaces a;` | `[]` | `[a]` |
| `member-interfaces a; member-interfaces b;` | `[]` | `[a b]` |
| `set ... member-interfaces <a>` (x2) | `[a b]` | `[a b]` |
| `set ... member-interfaces [ a b ]` | `[a]` | `[a b]` |

Four of six spellings were broken.

## Why not `firewallMatchValues`

The SSOT helper reads `Keys[1:]` of the node plus **`Keys[0]` of each child**. The
flat-set bracket list for this leaf files every name on **one child's Keys**, so
`firewallMatchValues` would still have dropped all but the first. That difference exists
because the schema node is a plain `children: nil` leaf with no `args` and no `multi`,
unlike the leaves the SSOT helper was written for. `fabricMemberValues` descends the whole
subtree and takes every non-empty key; the caller now iterates `FindChildren` rather than
`FindChild` because repeated hierarchical statements land as sibling nodes.

## Validator obligation (docs/config-schema.md #6659 rule)

Widening a multi-value read cannot turn a previously clean commit into a rejection here:
the only validator that reads `FabricMembers` is the fab0/fab1 shared-member overlap check
in `compiler_validate_warn.go`, and it appends a **warning**. That check was previously
vacuous for bracket-authored fabrics — nothing to compare — so this fold **arms** it rather
than tightening it.

## Deliberately NOT done

The issue suggests rejecting a `fab0` with zero compiled members at commit. That is a
design change, not a bug fix: the `chassis cluster fabric-interface` path can name a fabric
whose members are derived rather than authored (`compiler_derivations.go` auto-populates
`FabricInterface`/`Fabric1Interface` from whichever fab has a local member), so a blanket
zero-member rejection risks refusing configs that work today. Left for a separate decision.

## Mutation proof

Production change reverted, tests kept:

```
MUT_BUILD_RC=0
MUT_VET_RC=0
MUT_TEST_RC=1
  compiler_fabric_members_6694_test.go:83:  bracket list `member-interfaces [ a b ];`: FabricMembers = [], want [ge-0/0/7 ge-7/0/7]
  compiler_fabric_members_6694_test.go:89:  repeated `member-interfaces a; member-interfaces b;`: FabricMembers = [], want [ge-0/0/7 ge-7/0/7]
  compiler_fabric_members_6694_test.go:97:  single `member-interfaces a;`: FabricMembers = [], want [ge-0/0/7]
  compiler_fabric_members_6694_test.go:114: flat-set bracket list: FabricMembers = [ge-0/0/7], want [ge-0/0/7 ge-7/0/7]
  compiler_fabric_members_6694_test.go:120: flat-set bracket list, three members: FabricMembers = [ge-0/0/7], want [ge-0/0/7 ge-7/0/7 ge-1/0/1]
  compiler_fabric_members_6694_test.go:140: fab0 BondMode = "", want "active-backup"
```

Build and vet stay clean under the mutation, so this is an **assertion** red, not a build
break. Restored: `POST_RESTORE_RC=0`.

## Validation

- `go build ./...` clean, `go vet ./pkg/config/` clean
- `go test -count=1 ./pkg/config/` -> `ok ... 14.530s` (rc=0)
- `go test -count=1 ./pkg/frr/ ./pkg/cluster/` -> both `ok` (rc=0) — the FabricMembers
  consumers

Docs: `docs/config-schema.md` records why this leaf needs a reader of its own rather than
`firewallMatchValues`.

Go-only change in `pkg/config`; nothing reaches the Rust helper binary, so **no cluster
smoke is owed**.

Closes #6694