### PR TITLE
config: read every child of a routing-policy from-protocol block

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -928,6 +928,30 @@ Keys=[protocol tcp udp icmp]   IsLeaf=true   (no children)
   `20000`/`to`/`20003` is a sibling keyword), matching the hierarchical
   `Keys=[destination-port 20000 to 20003]`.
 
+**A nested BLOCK is a third shape, and it is not the flat-set chain (#6689).**
+The two shapes above are the ones the bracket-list contract is about. A leaf can
+also be authored as a brace block — `from { protocol { bgp; ospf; static; } }` —
+which leaves the node itself with `Keys=["protocol"]` and files one leaf child
+per value as SIBLINGS. A reader that descends `Children[0]` at each level is
+correct for the flat-set CHAIN (one child deep at every level) and reaches
+exactly one value of a block (N children wide at one level). That was the
+`collectProtocolList` defect: a routing-policy term written to filter three
+protocols compiled to one, and with `then reject` the two dropped protocols were
+silently ACCEPTED and installed — a fail-OPEN route-acceptance widening whose
+authored config renders back intact. Descend EVERY child, not the first, and the
+chain and the block are both covered.
+
+Note this leaf has no per-value option keyword, so every token below the node is
+a value and the full descent carries no promotion hazard. That is a property of
+the leaf, not of the descent — see the `system ntp server` case under
+"A widened read must not PROMOTE a token the old reader discarded" for a leaf
+where it does not hold. The routing-policy `from protocol` value domain is
+UNVALIDATED at commit in every spelling (unlike the firewall-filter leaf of the
+same name, which `filterProtocolResolvable` checks): widening the read makes the
+block spelling behave like the four that already reach `pkg/frr`
+`match source-protocol`, rather than adding a new exposure, but the absent gate
+is tracked separately.
+
 **Compiler contract for multi-value leaves.** Because both shapes now deliver
 the values on `child.Keys[1:]` (with the hierarchical-block-with-children
 shape still possible for nested forms), a compiler reading a multi-value leaf

--- a/pkg/config/compiler_policy_from_protocol_6689_test.go
+++ b/pkg/config/compiler_policy_from_protocol_6689_test.go
@@ -1,0 +1,163 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6689: `from { protocol { bgp; ospf; static; } }` compiled to [bgp] alone.
+// collectProtocolList followed a single-child CHAIN (Children[0] at each
+// level), and the nested-block spelling files one leaf child per protocol as
+// SIBLINGS, so only the first was ever reached.
+//
+// This fails OPEN. With `then reject` the operator's intent is to filter BGP,
+// OSPF and static; the compiled policy filtered BGP alone, so the OSPF and
+// static routes meant to be excluded were accepted and installed. The authored
+// config renders back intact, so there is no diagnostic.
+
+func policyProtocolsFromBlock(t *testing.T, body string) []string {
+	t.Helper()
+	p := NewParser(body)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse %q: %v", body, errs)
+	}
+	return policyProtocolsOf(t, tree)
+}
+
+// policyProtocolsFromSet drives the flat-set path the way CLAUDE.md requires:
+// ParseSetCommand + SetPath, never NewParser.
+func policyProtocolsFromSet(t *testing.T, cmds ...string) []string {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return policyProtocolsOf(t, tree)
+}
+
+func policyProtocolsOf(t *testing.T, tree *ConfigTree) []string {
+	t.Helper()
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	ps := cfg.PolicyOptions.PolicyStatements["p1"]
+	if ps == nil {
+		t.Fatal("policy-statement p1 absent from compiled config")
+	}
+	var got []string
+	for _, term := range ps.Terms {
+		got = append(got, term.FromProtocols...)
+	}
+	return got
+}
+
+func assertProtocols6689(t *testing.T, spelling string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) || strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("%s: FromProtocols = %v, want %v", spelling, got, want)
+	}
+}
+
+// Test_6689_FromProtocolEveryHierarchicalSpelling covers the brace-parsed
+// spellings. The nested block is the one that dropped two of three.
+func Test_6689_FromProtocolEveryHierarchicalSpelling(t *testing.T) {
+	want := []string{"bgp", "ospf", "static"}
+
+	assertProtocols6689(t, "nested block `protocol { bgp; ospf; static; }`",
+		policyProtocolsFromBlock(t,
+			`policy-options { policy-statement p1 { term t1 { from { protocol { bgp; ospf; static; } } then reject; } } }`),
+		want)
+
+	assertProtocols6689(t, "bracket list `protocol [ bgp ospf static ];`",
+		policyProtocolsFromBlock(t,
+			`policy-options { policy-statement p1 { term t1 { from { protocol [ bgp ospf static ]; } then reject; } } }`),
+		want)
+
+	assertProtocols6689(t, "repeated `protocol bgp; protocol ospf; protocol static;`",
+		policyProtocolsFromBlock(t,
+			`policy-options { policy-statement p1 { term t1 { from { protocol bgp; protocol ospf; protocol static; } then reject; } } }`),
+		want)
+}
+
+// Test_6689_FromProtocolEveryFlatSetSpelling pins the flat-set spellings that
+// already worked, so the fold cannot regress them.
+func Test_6689_FromProtocolEveryFlatSetSpelling(t *testing.T) {
+	want := []string{"bgp", "ospf", "static"}
+
+	assertProtocols6689(t, "flat-set bracket list",
+		policyProtocolsFromSet(t,
+			"set policy-options policy-statement p1 term t1 from protocol [ bgp ospf static ]",
+			"set policy-options policy-statement p1 term t1 then reject"),
+		want)
+
+	assertProtocols6689(t, "flat-set repeated",
+		policyProtocolsFromSet(t,
+			"set policy-options policy-statement p1 term t1 from protocol bgp",
+			"set policy-options policy-statement p1 term t1 from protocol ospf",
+			"set policy-options policy-statement p1 term t1 from protocol static",
+			"set policy-options policy-statement p1 term t1 then reject"),
+		want)
+}
+
+// Test_6689_FromProtocolSpellingsAgree binds the AGREEMENT rather than one
+// spelling's value: whatever the compiler makes of a protocol list, every
+// spelling of that same list must make the same thing of it. That is the
+// property the defect violated — four spellings compiled all three protocols
+// while the fifth compiled one — and it is what keeps a future reader of one
+// shape from drifting from the others.
+func Test_6689_FromProtocolSpellingsAgree(t *testing.T) {
+	nested := policyProtocolsFromBlock(t,
+		`policy-options { policy-statement p1 { term t1 { from { protocol { bgp; ospf; static; } } then reject; } } }`)
+	bracket := policyProtocolsFromBlock(t,
+		`policy-options { policy-statement p1 { term t1 { from { protocol [ bgp ospf static ]; } then reject; } } }`)
+	flat := policyProtocolsFromSet(t,
+		"set policy-options policy-statement p1 term t1 from protocol [ bgp ospf static ]",
+		"set policy-options policy-statement p1 term t1 then reject")
+
+	if strings.Join(nested, ",") != strings.Join(bracket, ",") {
+		t.Errorf("nested block %v disagrees with hierarchical bracket %v", nested, bracket)
+	}
+	if strings.Join(nested, ",") != strings.Join(flat, ",") {
+		t.Errorf("nested block %v disagrees with flat-set bracket %v", nested, flat)
+	}
+}
+
+// Test_6689_FromProtocolTwoTermsStayDistinct guards the descent from
+// over-collecting: `protocol` nodes in different terms must not bleed into one
+// another, and a term with no `from protocol` must compile an empty list.
+func Test_6689_FromProtocolTwoTermsStayDistinct(t *testing.T) {
+	p := NewParser(`policy-options { policy-statement p1 {
+		term t1 { from { protocol { bgp; ospf; } } then reject; }
+		term t2 { from { protocol { static; } } then accept; }
+		term t3 { then accept; }
+	} }`)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	ps := cfg.PolicyOptions.PolicyStatements["p1"]
+	if ps == nil {
+		t.Fatal("policy-statement p1 absent")
+	}
+	byName := map[string][]string{}
+	for _, term := range ps.Terms {
+		byName[term.Name] = term.FromProtocols
+	}
+	assertProtocols6689(t, "term t1", byName["t1"], []string{"bgp", "ospf"})
+	assertProtocols6689(t, "term t2", byName["t2"], []string{"static"})
+	if len(byName["t3"]) != 0 {
+		t.Errorf("term t3: FromProtocols = %v, want empty", byName["t3"])
+	}
+}

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -792,20 +792,47 @@ func compilePolicyOptions(node *Node, po *PolicyOptionsConfig) error {
 //     command lands its own leaf (Keys = ["protocol", "<X>"]) as a sibling
 //     under the term's "from" block. The caller iterates those siblings and
 //     calls this helper once per node, which then returns the single protocol.
+//   - block parse, nested block: `from { protocol { bgp; ospf; static; } }`
+//     leaves the node itself with Keys = ["protocol"] and files one LEAF
+//     CHILD PER PROTOCOL as SIBLINGS (#6689).
 //
-// All three shapes (and arbitrarily long lists) are handled by taking
-// Keys[1:] of the protocol node, then appending every key of each descendant
-// in the single-child chain.
+// The fourth shape is why the descent walks every child rather than
+// Children[0]. Following the single-child chain reached only the first
+// sibling, so a term written to filter three protocols compiled to one — and
+// with `then reject`, the two it dropped were silently ACCEPTED and installed.
+// A nested block is not the flat-set chain wearing a different shape; the
+// chain is one child deep at each level, the block is N children wide at one
+// level, and only a full descent covers both.
+//
+// Every token below a protocol node is a protocol name: Junos has no
+// per-protocol option keyword on this leaf, so unlike `system ntp server`
+// (#6690) there is no trailing-token ambiguity and no promotion hazard from
+// reading the whole subtree. Blank tokens are skipped — an empty slot is not
+// a protocol, and every value this helper returns is installed as a
+// `match source-protocol` line.
 func collectProtocolList(protoNode *Node) []string {
+	if protoNode == nil {
+		return nil
+	}
 	var protocols []string
+	add := func(tokens []string) {
+		for _, tok := range tokens {
+			if tok != "" {
+				protocols = append(protocols, tok)
+			}
+		}
+	}
 	if len(protoNode.Keys) >= 2 {
-		protocols = append(protocols, protoNode.Keys[1:]...)
+		add(protoNode.Keys[1:])
 	}
-	for n := protoNode; len(n.Children) > 0; {
-		child := n.Children[0]
-		protocols = append(protocols, child.Keys...)
-		n = child
+	var walk func(*Node)
+	walk = func(parent *Node) {
+		for _, child := range parent.Children {
+			add(child.Keys)
+			walk(child)
+		}
 	}
+	walk(protoNode)
 	return protocols
 }
 


### PR DESCRIPTION
## Problem

`from { protocol { bgp; ospf; static; } }` compiled to **`[bgp]`** alone. A term written
to filter three protocols filtered one.

`collectProtocolList` descended a single-child **chain** — `Children[0]` at each level —
which is the right shape for the flat-set bracket list but not for a brace block. A nested
block leaves the node with `Keys=["protocol"]` and files one leaf child per protocol as
**siblings**, so the chain walk reached the first and stopped. The chain is one child deep
at every level; the block is N children wide at one level.

Fails **OPEN**: with `then reject` the operator meant to exclude BGP, OSPF and static; the
compiled policy excluded BGP alone, so the OSPF and static routes meant to be filtered were
accepted and installed. No diagnostic — `show configuration` renders the authored list back
intact.

## Enumeration — five spellings, measured

| spelling | before | after |
|---|---|---|
| `from { protocol { bgp; ospf; static; } }` | `[bgp]` | `[bgp ospf static]` |
| `from { protocol [ bgp ospf static ]; }` | all three | all three |
| `from { protocol bgp; protocol ospf; ... }` | all three | all three |
| `set ... from protocol [ bgp ospf static ]` | all three | all three |
| `set ... from protocol <X>` (x3) | all three | all three |

## Promotion analysis (docs/config-schema.md #6673 rule)

Every token below a routing-policy `protocol` node is a protocol name — Junos has no
per-protocol option keyword on this leaf — so unlike `system ntp server` (#6690) the full
descent cannot promote an identifier into the value list. Blank tokens are skipped, since
every value returned is installed as an FRR `match source-protocol` line.

## Validator analysis (docs/config-schema.md #6659 rule)

The routing-policy `from protocol` value domain is **unvalidated at commit in every
spelling** — unlike the identically-named firewall-filter leaf, which
`filterProtocolResolvable` checks. There is therefore no one-sided validator to widen
alongside the read.

What the fold does change is that a token authored in the block spelling now reaches the
`pkg/frr` renderer, where the other four spellings already delivered it and where
`sanitizeFRRValue` already applies. So this makes five spellings agree rather than opening
a new path. The absent value-domain gate is filed as **#7121** rather than bundled here,
because adding one is a new commit rejection, not a bug fix.

## Mutation proof

Production change reverted, tests kept:

```
MUT_BUILD_RC=0
MUT_VET_RC=0
MUT_TEST_RC=1
  compiler_policy_from_protocol_6689_test.go:74:  nested block `protocol { bgp; ospf; static; }`: FromProtocols = [bgp], want [bgp ospf static]
  compiler_policy_from_protocol_6689_test.go:126: nested block [bgp] disagrees with hierarchical bracket [bgp ospf static]
  compiler_policy_from_protocol_6689_test.go:129: nested block [bgp] disagrees with flat-set bracket [bgp ospf static]
  compiler_policy_from_protocol_6689_test.go:158: term t1: FromProtocols = [bgp], want [bgp ospf]
```

Build and vet stay clean under the mutation, so this is an **assertion** red, not a build
break. Restored: `POST_RESTORE_RC=0`.

## Tests

Four, and one of them binds the **agreement** rather than a value: whatever the compiler
makes of a protocol list, every spelling of that same list must make the same thing of it.
That is the property the defect violated, and it is what keeps a future reader of one shape
from drifting from the others. A fourth guards the descent from over-collecting across
sibling terms and pins that a term with no `from protocol` still compiles an empty list.

## Validation

- `go build ./...` clean, `go vet ./pkg/config/` clean
- `go test -count=1 ./pkg/config/` -> `ok ... 14.124s` (rc=0)
- `go test -count=1 ./pkg/frr/` -> rc=0 (the FromProtocols consumer)

Docs: `docs/config-schema.md` now records the nested block as a third shape distinct from
the flat-set chain.

Go-only change in `pkg/config`; nothing reaches the Rust helper binary, so **no cluster
smoke is owed**.

Closes #6689