### PR TITLE
userspace-dp: carry the RT_FLOW session id on the JSON resync leg

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -97543,3 +97543,46 @@ prose edit above them added. No diff falls in the new test body.
   Both fire on the wrap-accept assertion itself (Repeat vs Accept). Full Rust
   suite `cargo test -p userspace-dp -- --test-threads=1` exit 0.
 - **File(s)**: userspace-dp/src/afxdp/wg/session.rs, _Log.md
+- **Timestamp**: 2026-08-21
+- **Action**: Fixed #6312 sub-item 1 — the JSON session-resync leg now carries
+  the #5212 stable RT_FLOW session id. The Rust JSON `SessionDeltaInfo`
+  (`protocol/binding.rs`) had no session-id field at all and the internal
+  delta -> JSON conversion never copied `delta.session_id`, so every session
+  recovered through the `drain_session_deltas` polling fallback or the owner-RG
+  resync export imported id 0 and the peer minted a fresh local id. The
+  originating node's SESSION_CREATE and the peer's post-failover SESSION_CLOSE
+  then carried different ids — the cross-node correlation #5212 exists to
+  provide, absent exactly in the full-resync recovery window.
+
+  Added `#[serde(rename = "rt_flow_session_id", default)] pub
+  rt_flow_session_id: u64` and populated it from `delta.session_id`. The Go
+  consumer field already existed for the binary leg
+  (`SessionDeltaInfo.RTFlowSessionID`, `json:"rt_flow_session_id"`), so nothing
+  changed downstream. NO protocol-version bump: `ProtocolVersion` (8) governs
+  the CONFIG-SNAPSHOT contract (`apply_snapshot` / `bump_fib_generation`
+  equality + the `ensureRequiredSnapshotProtocolLocked` gates), not this control
+  RPC; and the addition degrades in both directions to 0, the pre-existing
+  "no id carried" sentinel that is the pre-#6312 behaviour of this leg.
+
+  The delta -> JSON conversion was extracted from `flush_session_deltas` as
+  `afxdp::session_delta_info` (pure movement): the parent needs live BPF map
+  fds, per-binding shared state and an event-stream handle, so nothing could
+  test what this leg puts on the wire. Sub-item 2 (the overstated
+  `emit_open_delta_with_origin` comment) was already fixed on master and is now
+  re-tightened to say BOTH legs carry the id.
+
+  Validation: 3 new Rust tests (value carried, wire KEY, zero sentinel) + 1 Go
+  test parsing the Rust `serde(rename)` and asserting the Go decoder agrees.
+  Full Rust suite `cargo test -- --test-threads=1` exit 0 (4452 + 124 passed);
+  `go test -count=1 ./pkg/dataplane/... ./pkg/daemon/ ./pkg/cluster/` exit 0;
+  `cargo check --all-targets` and `go vet` exit 0. Wire fixture regenerated
+  (one additive key). Reaches the helper binary — a cluster smoke is owed.
+- **File(s)**: userspace-dp/src/protocol/binding.rs,
+  userspace-dp/src/afxdp/session_delta.rs, userspace-dp/src/afxdp/mod.rs,
+  userspace-dp/src/afxdp/tests_session_delta_json.rs,
+  userspace-dp/src/session/install.rs, userspace-dp/src/session/README.md,
+  userspace-dp/tests/fixtures/protocol_wire_v1.json,
+  pkg/dataplane/userspace/protocol_ha.go,
+  pkg/dataplane/userspace/wire_verdict_keys_6691_test.go,
+  pkg/dataplane/userspace/session_delta_rt_flow_session_id_key_6312_test.go,
+  _Log.md

--- a/pkg/dataplane/userspace/protocol_ha.go
+++ b/pkg/dataplane/userspace/protocol_ha.go
@@ -181,11 +181,18 @@ type SessionDeltaInfo struct {
 	Nat64       bool   `json:"nat64,omitempty"`
 	Nat64SnatV4 string `json:"nat64_snat_v4,omitempty"`
 	// #5212: the ORIGINATING node's stable RT_FLOW session id, decoded from the
-	// trailing u64 of the binary open frame (after the #4565 snat_v4). Stamped
-	// onto the synced SessionValue{,V6}.RTFlowSessionID by daemon_ha_userspace.go
-	// so the cluster sync wire and the peer helper carry it, letting a
-	// peer-synced session adopt the originating node's id (SESSION_CREATE/CLOSE
-	// correlate across HA nodes). Absent on an old helper => 0, the standby
-	// allocs a fresh local id (pre-#5212 behavior, rolling-upgrade safe).
+	// trailing u64 of the binary open frame (after the #4565 snat_v4) AND —
+	// since #6312 — from the JSON RPC-fallback delta, whose Rust producer
+	// declares `#[serde(rename = "rt_flow_session_id")]` on
+	// SessionDeltaInfo.rt_flow_session_id. The two spellings are held in
+	// agreement by TestSessionDeltaRTFlowSessionIDWireKeyLockstepWithRust6312;
+	// before #6312 the JSON leg carried no id at all, so a session recovered
+	// through the drain_session_deltas polling fallback or the owner-RG resync
+	// export lost its cross-node correlation. Stamped onto the synced
+	// SessionValue{,V6}.RTFlowSessionID by daemon_ha_userspace.go so the cluster
+	// sync wire and the peer helper carry it, letting a peer-synced session adopt
+	// the originating node's id (SESSION_CREATE/CLOSE correlate across HA nodes).
+	// Absent on an old helper => 0, the standby allocs a fresh local id
+	// (pre-#5212 behavior, rolling-upgrade safe).
 	RTFlowSessionID uint64 `json:"rt_flow_session_id,omitempty"`
 }

--- a/pkg/dataplane/userspace/session_delta_rt_flow_session_id_key_6312_test.go
+++ b/pkg/dataplane/userspace/session_delta_rt_flow_session_id_key_6312_test.go
@@ -1,0 +1,67 @@
+package userspace
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+// TestSessionDeltaRTFlowSessionIDWireKeyLockstepWithRust6312 pins the Go
+// DECODER's JSON key for SessionDeltaInfo.RTFlowSessionID to the key the Rust
+// producer actually emits.
+//
+// #6312 made the JSON session-delta leg carry the #5212 stable RT_FLOW session
+// id, which the binary event-stream open frame had carried since #5212 while
+// this leg silently dropped it. The Rust side declares the key with
+// `#[serde(rename = ...)]` on `SessionDeltaInfo.rt_flow_session_id`
+// (userspace-dp/src/protocol/binding.rs); this side reads it through a struct
+// tag. Those are two spellings of one contract, and a mismatch is SILENT on both
+// planes: the field is simply absent from the decoded struct, Go leaves it 0,
+// and 0 is a legitimate value ("no id carried" — the peer allocates a fresh
+// local id). That is exactly the pre-#6312 behaviour, so the fix would look
+// applied and do nothing.
+//
+// The key is therefore parsed out of the Rust source rather than restated here:
+// a constant written down twice is two constants. Reverting either side's
+// spelling reds this.
+func TestSessionDeltaRTFlowSessionIDWireKeyLockstepWithRust6312(t *testing.T) {
+	// Test cwd is pkg/dataplane/userspace.
+	rustKey := rustSerdeRenameIn(t,
+		filepath.Join("..", "..", "..", "userspace-dp", "src", "protocol", "binding.rs"),
+		"rt_flow_session_id")
+
+	const want = uint64(7)<<48 | 0x1234_5678
+	doc := fmt.Sprintf(`{"event":"open","addr_family":2,"protocol":6,`+
+		`"src_ip":"10.0.61.102","dst_ip":"172.16.80.200","src_port":12345,"dst_port":5201,`+
+		`%q:%d}`, rustKey, want)
+
+	var info SessionDeltaInfo
+	if err := json.Unmarshal([]byte(doc), &info); err != nil {
+		t.Fatalf("unmarshal %s: %v", doc, err)
+	}
+	if info.RTFlowSessionID != want {
+		t.Fatalf("RTFlowSessionID = %#x, want %#x. userspace-dp emits the id under the key %q "+
+			"(`#[serde(rename = ...)]` in protocol/binding.rs); a Go struct tag that spells it "+
+			"differently drops the id back to 0 on the JSON resync leg — the #6312 defect, "+
+			"restored silently and with no version to notice it",
+			info.RTFlowSessionID, want, rustKey)
+	}
+	// The tuple decoded too, so the assertion above is about the id key and not
+	// about a document the decoder rejected wholesale.
+	if info.SrcPort != 12345 || info.Event != "open" {
+		t.Fatalf("delta decoded as %+v, want the seeded open tuple", info)
+	}
+
+	// An old helper omits the key entirely. That must leave the pre-existing
+	// "no id carried" sentinel rather than failing the decode, which is what
+	// makes the addition rolling-upgrade safe in the helper-older direction.
+	var legacy SessionDeltaInfo
+	if err := json.Unmarshal([]byte(`{"event":"open","src_port":12345}`), &legacy); err != nil {
+		t.Fatalf("unmarshal legacy delta: %v", err)
+	}
+	if legacy.RTFlowSessionID != 0 {
+		t.Fatalf("legacy delta RTFlowSessionID = %#x, want 0 (the no-id sentinel)",
+			legacy.RTFlowSessionID)
+	}
+}

--- a/pkg/dataplane/userspace/wire_verdict_keys_6691_test.go
+++ b/pkg/dataplane/userspace/wire_verdict_keys_6691_test.go
@@ -21,7 +21,17 @@ import (
 func rustSnapshotSerdeRename(t *testing.T, rustField string) string {
 	t.Helper()
 	// Test cwd is pkg/dataplane/userspace.
-	path := filepath.Join("..", "..", "..", "userspace-dp", "src", "protocol", "snapshot.rs")
+	return rustSerdeRenameIn(t,
+		filepath.Join("..", "..", "..", "userspace-dp", "src", "protocol", "snapshot.rs"),
+		rustField)
+}
+
+// rustSerdeRenameIn is rustSnapshotSerdeRename against an arbitrary Rust wire
+// module, so a sibling key-agreement guard over another protocol struct
+// (session_delta_rt_flow_session_id_key_6312_test.go) parses the declaration
+// with the SAME regex instead of writing a second one that could drift.
+func rustSerdeRenameIn(t *testing.T, path, rustField string) string {
+	t.Helper()
 	src, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read %s: %v (the Go/Rust wire-key lockstep guard cannot run)", path, err)

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -542,6 +542,9 @@ mod tests_policy_inbound_nat;
 #[cfg(test)]
 #[path = "tests_fragment.rs"]
 mod tests_fragment;
+#[cfg(test)]
+#[path = "tests_session_delta_json.rs"]
+mod tests_session_delta_json;
 #[path = "worker/mod.rs"]
 mod worker;
 // #1807: shared poison-recovery helpers (lock_recover /

--- a/userspace-dp/src/afxdp/session_delta.rs
+++ b/userspace-dp/src/afxdp/session_delta.rs
@@ -104,6 +104,118 @@ pub(super) fn purge_queued_flows_for_closed_deltas(
     }
 }
 
+/// Convert one internal `SessionDelta` into the JSON `SessionDeltaInfo` the
+/// control-plane RPC legs carry: the `drain_session_deltas` polling fallback
+/// used while the binary event stream is down, and the owner-RG resync export.
+///
+/// Split out of `flush_session_deltas` so the field-by-field wire mapping is
+/// reachable on its own — that function needs live BPF map fds, per-binding
+/// shared state and an event-stream handle, so nothing could test what this
+/// leg actually puts on the wire (#6312).
+pub(in crate::afxdp) fn session_delta_info(
+    ident: &BindingIdentity,
+    delta: &SessionDelta,
+    zone_id_to_name: &FastMap<u16, String>,
+) -> SessionDeltaInfo {
+    // #919/#922: emit both the resolved zone NAMES (legacy field,
+    // empty when the ID is unknown) and the u16 IDs. New daemons
+    // prefer the IDs; older daemons read the names. The previous
+    // code wrote `metadata.ingress_zone.to_string()` here, which
+    // produced "1"/"2" string literals that broke `zoneIDs[name]`
+    // on the Go side.
+    let ingress_name = zone_id_to_name
+        .get(&delta.metadata.ingress_zone)
+        .cloned()
+        .unwrap_or_default();
+    let egress_name = zone_id_to_name
+        .get(&delta.metadata.egress_zone)
+        .cloned()
+        .unwrap_or_default();
+    SessionDeltaInfo {
+        timestamp: Utc::now(),
+        slot: ident.slot,
+        queue_id: ident.queue_id,
+        worker_id: ident.worker_id,
+        interface: ident.interface.to_string(),
+        ifindex: ident.ifindex,
+        event: session_delta_event(delta.kind).to_string(),
+        addr_family: delta.key.addr_family,
+        protocol: delta.key.protocol,
+        src_ip: delta.key.src_ip.to_string(),
+        dst_ip: delta.key.dst_ip.to_string(),
+        src_port: delta.key.src_port,
+        dst_port: delta.key.dst_port,
+        ingress_zone: ingress_name,
+        egress_zone: egress_name,
+        ingress_zone_id: delta.metadata.ingress_zone,
+        egress_zone_id: delta.metadata.egress_zone,
+        owner_rg_id: delta.metadata.owner_rg_id,
+        disposition: match delta.decision.resolution.disposition {
+            ForwardingDisposition::ForwardCandidate => "forward_candidate",
+            ForwardingDisposition::LocalDelivery => "local_delivery",
+            ForwardingDisposition::NoRoute => "no_route",
+            ForwardingDisposition::MissingNeighbor => "missing_neighbor",
+            ForwardingDisposition::PolicyDenied => "policy_denied",
+            ForwardingDisposition::FabricRedirect => "fabric_redirect",
+            ForwardingDisposition::HAInactive => "ha_inactive",
+            ForwardingDisposition::DiscardRoute => "discard_route",
+            ForwardingDisposition::NextTableUnsupported => "next_table_unsupported",
+        }
+        .to_string(),
+        origin: delta.origin.as_str().to_string(),
+        egress_ifindex: delta.decision.resolution.egress_ifindex,
+        tx_ifindex: delta.decision.resolution.tx_ifindex,
+        tunnel_endpoint_id: delta.decision.resolution.tunnel_endpoint_id,
+        tx_vlan_id: delta.decision.resolution.tx_vlan_id,
+        next_hop: delta
+            .decision
+            .resolution
+            .next_hop
+            .map(|ip| ip.to_string())
+            .unwrap_or_default(),
+        neighbor_mac: delta
+            .decision
+            .resolution
+            .neighbor_mac
+            .map(format_mac)
+            .unwrap_or_default(),
+        src_mac: delta
+            .decision
+            .resolution
+            .src_mac
+            .map(format_mac)
+            .unwrap_or_default(),
+        nat_src_ip: delta
+            .decision
+            .nat
+            .rewrite_src
+            .map(|ip| ip.to_string())
+            .unwrap_or_default(),
+        nat_dst_ip: delta
+            .decision
+            .nat
+            .rewrite_dst
+            .map(|ip| ip.to_string())
+            .unwrap_or_default(),
+        nat_src_port: delta.decision.nat.rewrite_src_port.unwrap_or(0),
+        nat_dst_port: delta.decision.nat.rewrite_dst_port.unwrap_or(0),
+        fabric_redirect: delta.fabric_redirect_sync
+            || delta.decision.resolution.disposition == ForwardingDisposition::FabricRedirect,
+        fabric_ingress: delta.metadata.fabric_ingress,
+        // #2785: carry the per-policy log selection on the JSON fallback
+        // delta so the synced session logs identically after failover.
+        log_session_init: delta.metadata.log_session_init,
+        log_session_close: delta.metadata.log_session_close,
+        // #6312: carry the ORIGINATING node's stable RT_FLOW session id on the
+        // JSON leg too. `SessionDelta.session_id` is the same value the binary
+        // open frame's trailing u64 carries (#5212); before this the JSON leg
+        // dropped it and a session recovered through a full resync lost its
+        // cross-node correlation. 0 (a synthesized delta with no backing entry)
+        // keeps the legacy "peer allocates a fresh local id" behaviour.
+        rt_flow_session_id: delta.session_id,
+    }
+}
+
 // #2669: `live` is `Option` because a drain cycle can coincide with an
 // empty `bindings` slice (XSK sockets admin-down / unconfigured during a
 // reload or transaction while the session table is still aging entries
@@ -183,96 +295,7 @@ pub(super) fn flush_session_deltas(
     // worker-loop wait stays ~1 budget regardless of the owned-session count K.
     let mut event_stream_out_of_sync = *worker_lossless_wedged;
     for delta in deltas {
-        // #919/#922: emit both the resolved zone NAMES (legacy field,
-        // empty when the ID is unknown) and the u16 IDs. New daemons
-        // prefer the IDs; older daemons read the names. The previous
-        // code wrote `metadata.ingress_zone.to_string()` here, which
-        // produced "1"/"2" string literals that broke `zoneIDs[name]`
-        // on the Go side.
-        let ingress_name = zone_id_to_name
-            .get(&delta.metadata.ingress_zone)
-            .cloned()
-            .unwrap_or_default();
-        let egress_name = zone_id_to_name
-            .get(&delta.metadata.egress_zone)
-            .cloned()
-            .unwrap_or_default();
-        let info = SessionDeltaInfo {
-            timestamp: Utc::now(),
-            slot: ident.slot,
-            queue_id: ident.queue_id,
-            worker_id: ident.worker_id,
-            interface: ident.interface.to_string(),
-            ifindex: ident.ifindex,
-            event: session_delta_event(delta.kind).to_string(),
-            addr_family: delta.key.addr_family,
-            protocol: delta.key.protocol,
-            src_ip: delta.key.src_ip.to_string(),
-            dst_ip: delta.key.dst_ip.to_string(),
-            src_port: delta.key.src_port,
-            dst_port: delta.key.dst_port,
-            ingress_zone: ingress_name,
-            egress_zone: egress_name,
-            ingress_zone_id: delta.metadata.ingress_zone,
-            egress_zone_id: delta.metadata.egress_zone,
-            owner_rg_id: delta.metadata.owner_rg_id,
-            disposition: match delta.decision.resolution.disposition {
-                ForwardingDisposition::ForwardCandidate => "forward_candidate",
-                ForwardingDisposition::LocalDelivery => "local_delivery",
-                ForwardingDisposition::NoRoute => "no_route",
-                ForwardingDisposition::MissingNeighbor => "missing_neighbor",
-                ForwardingDisposition::PolicyDenied => "policy_denied",
-                ForwardingDisposition::FabricRedirect => "fabric_redirect",
-                ForwardingDisposition::HAInactive => "ha_inactive",
-                ForwardingDisposition::DiscardRoute => "discard_route",
-                ForwardingDisposition::NextTableUnsupported => "next_table_unsupported",
-            }
-            .to_string(),
-            origin: delta.origin.as_str().to_string(),
-            egress_ifindex: delta.decision.resolution.egress_ifindex,
-            tx_ifindex: delta.decision.resolution.tx_ifindex,
-            tunnel_endpoint_id: delta.decision.resolution.tunnel_endpoint_id,
-            tx_vlan_id: delta.decision.resolution.tx_vlan_id,
-            next_hop: delta
-                .decision
-                .resolution
-                .next_hop
-                .map(|ip| ip.to_string())
-                .unwrap_or_default(),
-            neighbor_mac: delta
-                .decision
-                .resolution
-                .neighbor_mac
-                .map(format_mac)
-                .unwrap_or_default(),
-            src_mac: delta
-                .decision
-                .resolution
-                .src_mac
-                .map(format_mac)
-                .unwrap_or_default(),
-            nat_src_ip: delta
-                .decision
-                .nat
-                .rewrite_src
-                .map(|ip| ip.to_string())
-                .unwrap_or_default(),
-            nat_dst_ip: delta
-                .decision
-                .nat
-                .rewrite_dst
-                .map(|ip| ip.to_string())
-                .unwrap_or_default(),
-            nat_src_port: delta.decision.nat.rewrite_src_port.unwrap_or(0),
-            nat_dst_port: delta.decision.nat.rewrite_dst_port.unwrap_or(0),
-            fabric_redirect: delta.fabric_redirect_sync
-                || delta.decision.resolution.disposition == ForwardingDisposition::FabricRedirect,
-            fabric_ingress: delta.metadata.fabric_ingress,
-            // #2785: carry the per-policy log selection on the JSON fallback
-            // delta so the synced session logs identically after failover.
-            log_session_init: delta.metadata.log_session_init,
-            log_session_close: delta.metadata.log_session_close,
-        };
+        let info = session_delta_info(ident, delta, zone_id_to_name);
         // #2669: per-binding RPC fallback push is the ONLY binding-dependent
         // step. Skipped when no binding exists; every consumer below is
         // binding-independent and runs regardless.

--- a/userspace-dp/src/afxdp/tests_session_delta_json.rs
+++ b/userspace-dp/src/afxdp/tests_session_delta_json.rs
@@ -1,0 +1,157 @@
+// #6312: the JSON leg of the session-delta wire must carry the #5212 stable
+// RT_FLOW session id, at parity with the binary event-stream open frame.
+//
+// The JSON `SessionDeltaInfo` is what the `drain_session_deltas` polling
+// fallback (used whenever the binary event stream is down) and the owner-RG
+// resync export put on the control-plane RPC. Before this it had no session-id
+// field at all, so every session recovered through that leg imported id 0 and
+// the peer minted a fresh local one — the originating node's SESSION_CREATE and
+// the peer's post-failover SESSION_CLOSE no longer shared an id.
+//
+// Sibling `#[path]` test module loaded from afxdp/mod.rs, mirroring the #4840
+// split.
+#![allow(unused_imports)]
+
+use super::session_delta::session_delta_info;
+use super::*;
+use crate::nat::NatDecision;
+use crate::session::{
+    SessionCounters, SessionDecision, SessionDelta, SessionDeltaKind, SessionKey, SessionMetadata,
+    SessionOrigin,
+};
+use std::net::{IpAddr, Ipv4Addr};
+
+fn delta_with_session_id(session_id: u64) -> SessionDelta {
+    SessionDelta {
+        kind: SessionDeltaKind::Open,
+        key: SessionKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: 6,
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+            src_port: 12345,
+            dst_port: 5201,
+        },
+        decision: SessionDecision {
+            resolution: ForwardingResolution {
+                disposition: ForwardingDisposition::ForwardCandidate,
+                local_ifindex: 2,
+                egress_ifindex: 3,
+                tx_ifindex: 3,
+                tunnel_endpoint_id: 0,
+                next_hop: None,
+                neighbor_mac: None,
+                src_mac: None,
+                tx_vlan_id: 0,
+            },
+            nat: NatDecision::default(),
+        },
+        metadata: SessionMetadata {
+            ingress_zone: 1,
+            egress_zone: 2,
+            ingress_ifindex: 0,
+            ingress_vlan_id: 0,
+            owner_rg_id: 1,
+            fabric_ingress: false,
+            is_reverse: false,
+            nat64_reverse: None,
+            log_session_init: false,
+            log_session_close: false,
+            policy_id: 0,
+            inactivity_timeout_ns: None,
+            policy_counter_idx: 0,
+            policy_counter: None,
+        },
+        origin: SessionOrigin::ForwardFlow,
+        fabric_redirect_sync: false,
+        created_ns: 0,
+        last_seen_ns: 0,
+        counters: SessionCounters::default(),
+        observed_tos: 0,
+        observed_tcp_flags: 0,
+        session_id,
+    }
+}
+
+fn test_binding_identity() -> BindingIdentity {
+    BindingIdentity {
+        slot: 0,
+        queue_id: 0,
+        worker_id: 7,
+        interface: Arc::from("ge-0-0-1"),
+        ifindex: 12,
+    }
+}
+
+fn zone_names() -> FastMap<u16, String> {
+    let mut m: FastMap<u16, String> = FastMap::default();
+    m.insert(1, "lan".to_string());
+    m.insert(2, "wan".to_string());
+    m
+}
+
+/// Fail-on-revert: drop `rt_flow_session_id: delta.session_id` from
+/// `session_delta_info` and the id arrives as 0, so the peer allocates a fresh
+/// local id and the cross-node correlation is lost.
+#[test]
+fn session_delta_info_carries_rt_flow_session_id_6312() {
+    let want = 7u64 << 48 | 0x1234_5678;
+    let info = session_delta_info(
+        &test_binding_identity(),
+        &delta_with_session_id(want),
+        &zone_names(),
+    );
+    assert_eq!(
+        info.rt_flow_session_id, want,
+        "the JSON resync leg must carry the originating node's stable RT_FLOW \
+         session id, like the binary open frame does (#6312)"
+    );
+    // Positive control: this really is the delta -> JSON conversion, so a
+    // mismatch above cannot be a wrongly-built fixture.
+    assert_eq!(info.src_port, 12345, "conversion produced the delta's tuple");
+    assert_eq!(info.ingress_zone, "lan", "conversion resolved zone names");
+}
+
+/// The wire KEY is the cross-language contract: the Go consumer decodes this
+/// field as `SessionDeltaInfo.RTFlowSessionID` with `json:"rt_flow_session_id"`
+/// (pkg/dataplane/userspace/protocol_ha.go). A rename on this side would ship a
+/// key the Go decoder ignores — the field would be present and the id still
+/// silently lost, which the struct-level assertion above cannot see.
+#[test]
+fn session_delta_info_rt_flow_session_id_wire_key_6312() {
+    let want = 0x0BAD_F00D_u64;
+    let info = session_delta_info(
+        &test_binding_identity(),
+        &delta_with_session_id(want),
+        &zone_names(),
+    );
+    let v: serde_json::Value = serde_json::to_value(&info).expect("serialize SessionDeltaInfo");
+    let on_wire = v
+        .get("rt_flow_session_id")
+        .unwrap_or_else(|| panic!("no `rt_flow_session_id` key on the wire: {v}"));
+    assert_eq!(
+        on_wire.as_u64(),
+        Some(want),
+        "`rt_flow_session_id` must carry the id verbatim: {v}"
+    );
+}
+
+/// A delta with no backing entry (`session_id == 0`) must still emit the key
+/// carrying 0 — the pre-existing "no id" sentinel the peer maps to a fresh local
+/// allocation. This is the rolling-upgrade fallback, so it must not become an
+/// absent key or a synthesized non-zero value.
+#[test]
+fn session_delta_info_zero_session_id_is_the_no_id_sentinel_6312() {
+    let info = session_delta_info(
+        &test_binding_identity(),
+        &delta_with_session_id(0),
+        &zone_names(),
+    );
+    assert_eq!(info.rt_flow_session_id, 0);
+    let v: serde_json::Value = serde_json::to_value(&info).expect("serialize SessionDeltaInfo");
+    assert_eq!(
+        v.get("rt_flow_session_id").and_then(|x| x.as_u64()),
+        Some(0),
+        "the zero sentinel must still ride the wire: {v}"
+    );
+}

--- a/userspace-dp/src/protocol/binding.rs
+++ b/userspace-dp/src/protocol/binding.rs
@@ -1233,5 +1233,23 @@ pub(crate) struct SessionDeltaInfo {
     pub log_session_init: bool,
     #[serde(rename = "log_session_close", default)]
     pub log_session_close: bool,
+    /// #6312: the ORIGINATING node's STABLE RT_FLOW session id, mirrored from
+    /// `SessionDelta.session_id` — the same value the binary open frame carries
+    /// in its trailing u64 (#5212, `event_stream/codec/session_sync.rs`) — onto
+    /// the JSON RPC-fallback delta. Without it a session recovered through the
+    /// JSON leg (`drain_session_deltas` polling while the event stream is down,
+    /// and the owner-RG resync export) imported id 0 and the peer minted a fresh
+    /// local id, so its SESSION_CLOSE no longer correlated with the originating
+    /// node's SESSION_CREATE.
+    ///
+    /// The Go consumer field already existed for the binary leg
+    /// (`SessionDeltaInfo.RTFlowSessionID`, `json:"rt_flow_session_id"`); the
+    /// rename below MUST match that tag. Additive and rolling-upgrade safe in
+    /// both directions: an old helper omits the key and `default` decodes 0, an
+    /// old daemon ignores a key it does not know, and 0 is the pre-existing
+    /// "no id carried" sentinel that falls back to a fresh local id — i.e. the
+    /// exact pre-#6312 behaviour of this leg.
+    #[serde(rename = "rt_flow_session_id", default)]
+    pub rt_flow_session_id: u64,
 }
 

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -1479,7 +1479,11 @@ closed on the standby after a failover carried different ids on the two nodes.
 #5212 carries the originating node's id on the HA session-sync wire as a
 length-gated trailing field (both sides, mirroring the #4565/#5274 discipline):
 `SessionDelta.session_id` → the MSG_SESSION_OPEN frame's trailing `session_id`
-u64 (`encode_session_open`) → Go `SessionDeltaInfo.RTFlowSessionID` →
+u64 (`encode_session_open`) — and, since #6312, the JSON RPC-fallback delta's
+`rt_flow_session_id` key (`afxdp::session_delta_info`), so a session recovered
+through the `drain_session_deltas` polling leg or the owner-RG resync export
+carries the id at parity with the binary frame instead of importing 0 →
+Go `SessionDeltaInfo.RTFlowSessionID` →
 `SessionValue{,V6}.RTFlowSessionID` → the cluster sync wire (a length-gated
 trailing u64 in `encodeSessionV{4,6}Payload`, after the #5274 `ConfigEpoch`) →
 `SessionSyncRequest.session_id` → `build_synced_session_entry`. On import,

--- a/userspace-dp/src/session/install.rs
+++ b/userspace-dp/src/session/install.rs
@@ -466,9 +466,10 @@ impl SessionTable {
         // table — so look it up by key and carry it on the wire, letting the
         // peer adopt the same id it will emit its own RT_FLOW records under
         // (`session_id_for` returns 0 if the key is somehow absent, the safe
-        // fallback-to-local-alloc sentinel). NB: only the event-stream leg of
-        // this owner-RG export carries the id; the JSON resync leg still drops
-        // it (#6312).
+        // fallback-to-local-alloc sentinel). BOTH legs of this owner-RG export
+        // carry the id since #6312: the binary event-stream frame's trailing u64
+        // (`encode_session_open`) and the JSON `SessionDeltaInfo`
+        // (`rt_flow_session_id`, populated by `afxdp::session_delta_info`).
         let session_id = self.session_id_for(&key);
         self.push_delta(SessionDelta {
             kind: SessionDeltaKind::Open,

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -1044,6 +1044,7 @@
     "owner_rg_id": 0,
     "protocol": 0,
     "queue_id": 0,
+    "rt_flow_session_id": 0,
     "slot": 0,
     "src_ip": "",
     "src_mac": "",


### PR DESCRIPTION
## The defect

The #5212 stable RT_FLOW session id rode the two BINARY sync paths — the
incremental event-stream open frame and `ExportAllSessionsViaEventStream` — but
not the JSON one. `SessionDeltaInfo` (`userspace-dp/src/protocol/binding.rs`)
had no session-id field at all, and the internal delta→JSON conversion never
copied `delta.session_id`. So every session recovered through the
`drain_session_deltas` polling fallback (used whenever the binary event stream
is down) or the owner-RG resync export imported id 0, and the peer minted a
fresh local id: the originating node's SESSION_CREATE and the peer's
post-failover SESSION_CLOSE carried different ids — exactly the cross-node
correlation #5212 exists to provide, absent precisely in the full-resync
recovery window.

## The fix

`#[serde(rename = "rt_flow_session_id", default)] rt_flow_session_id: u64`,
populated from `delta.session_id`. The **Go consumer field already existed** for
the binary leg (`SessionDeltaInfo.RTFlowSessionID`, `json:"rt_flow_session_id"`),
so nothing downstream changes: the id flows on into
`SessionValue{,V6}.RTFlowSessionID` → the cluster sync wire →
`build_synced_session_entry` as it already did from the binary frame.

The delta→JSON conversion is extracted from `flush_session_deltas` as
`afxdp::session_delta_info` — pure movement. That function needs live BPF map
fds, per-binding shared state and an event-stream handle, so nothing could test
what this leg actually puts on the wire.

## No protocol-version bump — and why

`ProtocolVersion` (8) is the **config-snapshot** contract: `apply_snapshot` and
`bump_fib_generation` gate on exact equality, and every required-protocol gate
dispatched from `ensureRequiredSnapshotProtocolLocked`
(`ErrScopedGlobalZoneSet…`, `ErrEgressZone…`, `ErrSecureTunnel…`, …) is a
snapshot feature. This field is on the `drain_session_deltas` control RPC, which
that version does not govern.

Against the v4/#5488 rule — an additive field needs the bump when a peer that
IGNORES it behaves differently in a way that matters — this one degrades in
**both** directions to 0: an older helper omits the key and `serde(default)`
decodes 0; an older daemon ignores a key it does not know. 0 is the pre-existing
"no id carried" sentinel that falls back to a fresh local allocation, i.e. the
pre-#6312 behaviour of this leg. No coverage change, no fail-open. This is the
same reasoning the sibling `SessionSyncRequest.session_id` field already carries
in tree from #5212.

## Scope

Sub-item 1 of the issue only. Sub-item 2 — the `emit_open_delta_with_origin`
comment that overstated the owner-RG path — was already tightened on master; it
is re-tightened here to say BOTH legs carry the id, because this change makes
the previous wording false.

## Validation

Three Rust tests (the value is carried; the WIRE KEY is `rt_flow_session_id`;
a 0 id still emits the sentinel) plus a Go test that **parses** the Rust
`serde(rename)` out of `binding.rs` and asserts the Go decoder's struct tag
agrees — following the #6691 `rustSnapshotSerdeRename` pattern, now generalized
to `rustSerdeRenameIn` so both guards share one parser. A key mismatch is silent
on both planes (the field just decodes to 0, and 0 is legitimate), which is why
the value assertion alone is not enough.

Mutation-verified RED four ways, each with `cargo check` / `go vet` exit 0 so
every red is an assertion and not a build break:

| # | Mutation | Result |
|---|---|---|
| M1 | `rt_flow_session_id: 0` (drop the copy — the pre-#6312 leg) | RED — value + wire-key tests (sentinel test stays GREEN) |
| M2 | rename the RUST key to `rtFlowSessionId` | RED on BOTH planes — Rust wire-key + sentinel, and the Go lockstep test (the value test stays GREEN, so the key test is not redundant) |
| M3 | rename the GO struct tag to `rtflow_session_id` | RED — Go lockstep test |
| M4 | `skip_serializing_if = u64_is_zero` (drop the zero sentinel from the wire) | RED — sentinel test |

Full Rust suite `cargo test -- --test-threads=1` exit 0 (4452 + 124 passed).
`go test -count=1 ./pkg/dataplane/... ./pkg/daemon/ ./pkg/cluster/` exit 0.
`cargo check --all-targets` and `go vet` exit 0. `protocol_wire_v1.json`
regenerated — the diff is one additive key.

**Reaches the helper binary**, so a cluster smoke is owed before merge. Docs
updated: `userspace-dp/src/session/README.md` (#5212 id path), the
`emit_open_delta_with_origin` comment, and the Go field comment.

Closes #6312
