### PR TITLE
image: unblock the Tier-1 validation gate (base-pin self-test, scenario e multi-NIC, leaked VM)

### DIFF
--- a/scripts/image/test_bake_base_pin.py
+++ b/scripts/image/test_bake_base_pin.py
@@ -63,11 +63,19 @@ class PinnedConstantTests(_EnvGuard):
                          "the pinned base digest must be a bare sha256 hex.")
 
     def test_2604_pin_matches_canonical_gpg_verified_value(self):
-        # The 26.04 pin was authored by verifying Canonical's SHA256SUMS.gpg
+        # The 26.04 pin is authored by verifying Canonical's SHA256SUMS.gpg
         # against the UEC signing key D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81.
+        # Current value is Canonical's 2026-08 respin (bumped in bake.py by
+        # 5fb53d7a1); re-verified here independently:
+        #   gpg: Signature made Tue 04 Aug 2026 01:46:14 PM PDT
+        #   gpg:                using RSA key D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81
+        #   gpg: Good signature from "UEC Image Automatic Signing Key <cdimage@ubuntu.com>"
+        # The constant is duplicated here ON PURPOSE: the trust anchor must not
+        # be able to move without a reviewer seeing it in a diff. Both places
+        # move together, or this test is what says so.
         self.assertEqual(
             bake.PINNED_BASE_SHA256.get("26.04"),
-            "3ee4f67f322abb2d1d1f0fffc957f7411404ad6635dd35b026c8ff05ac6e534c")
+            "9dc7c5363c0146a08ba0c9aa834d82c2c6dfbb1c471ad9a2f0aba1189e21be05")
 
 
 class ResolveBasePinTests(_EnvGuard):

--- a/scripts/image/validate.py
+++ b/scripts/image/validate.py
@@ -173,11 +173,26 @@ class Harness:
 
     # ── lifecycle ──
     def ensure_network(self):
+        # dns.mode=none is REQUIRED, not cosmetic. incus registers one DNS
+        # record per instance per managed network, so a second NIC on the same
+        # network is refused at device-add time:
+        #   Instance DNS name "<inst>" conflict between "extranic0" and "eth0"
+        #   because both are connected to same network
+        # Scenario e needs three NICs on one network to prove the node-1
+        # positional naming (em0 + ge-7/0/N), and scenario d's control leg
+        # needs none of the DNS records. Turning DNS off keeps DHCP — which is
+        # all any scenario consumes — and removes the conflict.
         if incus("network", "show", self.net, check=False, capture=True).returncode != 0:
-            info(f"creating validation network {self.net} (NAT + DHCP)")
+            info(f"creating validation network {self.net} (NAT + DHCP, no DNS)")
             incus("network", "create", self.net, "ipv4.address=10.199.99.1/24",
-                  "ipv4.nat=true", "ipv6.address=none")
+                  "ipv4.nat=true", "ipv6.address=none", "dns.mode=none")
             self.created_net = True
+        else:
+            # A network left behind by an earlier run (or a concurrent bake)
+            # may predate this setting. Idempotent, and harmless to a
+            # concurrent run: no scenario resolves an instance by DNS.
+            incus("network", "set", self.net, "dns.mode=none", check=False,
+                  capture=True)
 
     def verify_signatures(self):
         """Verify the EXACT qcow2 + metadata files against the signed
@@ -240,6 +255,13 @@ class Harness:
         incus("init", self.alias, name, "--vm", "--network", self.net,
               "-c", "limits.cpu=2", "-c", "limits.memory=2GiB",
               "-c", f"user.xpf-owner={self.run_id}", capture=True)
+        # Register for teardown IMMEDIATELY after init, not after the device
+        # adds below. The instance exists and carries this run's ownership tag
+        # from the moment init returns; registering later meant any failure
+        # between here and the end of launch() (a refused device add, a bad
+        # ISO path) left a VM behind that cleanup could not see, because
+        # cleanup only walks self.instances.
+        self.instances.append(name)
         if root_size:
             # Override the instance's root disk to a size LARGER than the
             # image (#1925 Scenario D). `device override root` materializes an
@@ -256,7 +278,6 @@ class Harness:
         if iso:
             incus("config", "device", "add", name, "day0", "disk",
                   f"source={os.path.realpath(iso)}", capture=True)
-        self.instances.append(name)
         incus("start", name)
         self.wait_agent(name)
 


### PR DESCRIPTION
Two `scripts/image` defects that block the Tier-1 validation gate — and
therefore block any signed bake — with unrelated causes but the same effect.
Split into two commits.

## 1. `test_bake_base_pin.py` still asserts the pre-respin digest (#7125)

`5fb53d7a1` bumped `PINNED_BASE_SHA256["26.04"]` to Canonical's 2026-08 respin
but left the self-test's duplicated constant behind, so `make selftest` is RED
at master:

```
FAIL: test_2604_pin_matches_canonical_gpg_verified_value
AssertionError: '9dc7c536…' != '3ee4f67f…'
  passed=49  skipped=0  failed=1
```

The duplication is deliberate — it is what makes a trust-anchor move visible in
a diff — so the fix moves the expectation rather than removing it, and records
the provenance next to it. The digest was **re-verified here, not taken on
trust**: Canonical's `SHA256SUMS` + detached `SHA256SUMS.gpg` for 26.04 verify
against the UEC Image Automatic Signing Key
`D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81` that `bake.py` names —
`gpg --verify` rc 0, signature dated 2026-08-04 — and the entry for
`ubuntu-26.04-server-cloudimg-amd64.img` in that signed list is `9dc7c536…`.

## 2. Scenario `e` cannot launch, and a failed launch leaks a VM (#7124)

Found on the first Tier-1 run in months to get past scenario `a` (that is
#7114, a separate PR). Scenarios **a, b, c, d PASS**; `e` dies before booting:

```
Error: Failed add validation for device "extranic0": Instance DNS name
"xpf-image-<run>-e" conflict between "extranic0" and "eth0" because both are
connected to same network
```

incus registers one DNS record per instance per managed network, so the second
NIC on `xpf-image-net` is refused at device-add time — and scenario `e` needs
three NICs on one network to prove the node-1 positional naming (`em0` +
`ge-7/0/N`). `nictype=bridged parent=xpf-image-net` does **not** dodge it:
incus resolves the parent bridge back to the managed network and refuses
identically (verified by hand).

Fix: create the harness-owned network with `dns.mode=none`, and `set` it on a
network left behind by an earlier run (the name is fixed and outlives runs).
DHCP is unaffected and no scenario resolves an instance by DNS.

The same failure exposed a second defect: `launch()` registered the instance in
`self.instances` only after every `config device add`, and `cleanup()` walks
that list — so the instance that failed the device add survived the run
(`xpf-image-70e311c3-e,STOPPED`). Registration moves to immediately after
`incus init`, where it is also correct: the instance already carries this run's
`user.xpf-owner` tag, so the ownership-gated `_owned_delete` can prove it is
ours.

## Validation

- `scripts/run-selftests.sh` exit 0 — **50 passed, 0 skipped, 0 failed**
  (RED before commit 1: 49/1).
- The incus device-add repro run by hand at incus 7.0.0 before and after
  `dns.mode=none`: rc 1 → rc 0 for both extra NICs.
- Full bake evidence is on #7114's PR, which is where the end-to-end gate
  result lives (both PRs are needed for a green gate).

Closes #7124
Closes #7125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJg8SoArRkkHRa7CZpHGGD
