### PR TITLE
validate: make scenario e assert what the daemon actually contracts

### DIFF
--- a/scripts/image/validate.py
+++ b/scripts/image/validate.py
@@ -583,7 +583,26 @@ class Harness:
         e = self.iname("e")   # run-namespaced instance name (#4905-D)
         conf = os.path.join(self.work, "day0-node1.conf")
         with open(conf, "w") as f:
+            # The `chassis cluster` stanza is REQUIRED, not decoration.
+            # /etc/xpf/node-id does NOT select cluster naming: the daemon reads
+            # clusterMode from the committed config
+            # (namingParamsFromConfig -> cfg.Chassis.Cluster != nil), and
+            # hasNodeIDFile() feeds only computeBootClass (bootstrap vs
+            # normal). A node-id box with a cluster-less config runs STANDALONE
+            # naming by design (#4179). Without this stanza the daemon
+            # correctly produces fxp0 + ge-0-0-X and the em0 assertion below
+            # can never pass (#7129).
+            #
+            # authentication-key is mandatory for a cluster stanza to survive
+            # the real commit-check gate — the control channel fails OPEN
+            # without a PSK. It is a throwaway literal: this VM never peers
+            # with anything, and the scenario asserts naming only.
             f.write("system {\n    host-name xpf-node1;\n}\n"
+                    "chassis {\n    cluster {\n        node 1;\n"
+                    "        peer-address 10.99.12.1;\n"
+                    "        authentication-key "
+                    "\"xpf-image-validate-scenario-e-not-a-real-key\";\n"
+                    "    }\n}\n"
                     "interfaces {\n    fxp0 {\n        unit 0 {\n"
                     "            family inet {\n                dhcp;\n"
                     "            }\n        }\n    }\n}\n")
@@ -593,7 +612,7 @@ class Harness:
         iso = make_config_drive.build_config_drive(
             conf, os.path.join(self.work, "day0-node1.iso"), node_id=1,
             validate=False)
-        # Two extra NICs so the namer has em0 (idx 1) and ge-7/0/0 (idx 2).
+        # Two extra NICs so the namer has em0 (idx 1) and ge-7-0-0 (idx 2).
         self.launch(e, iso, extra_nics=2)
         self.wait_xpfd(e)
         if guest(e, "test", "-e", "/etc/xpf/.day0-config-applied",
@@ -611,10 +630,14 @@ class Harness:
         if not guest_sh(e, 'ip link show em0 >/dev/null 2>&1'):
             fail("em0 not present — daemon did not enter cluster naming mode "
                  "for a node-id-present image")
-        if not guest_sh(e, 'ip link show ge-7/0/0 >/dev/null 2>&1'):
-            fail("ge-7/0/0 not present — node-1 FPC-7 positional naming did not "
-                 "run (a node-0 image would name it ge-0/0/0)")
-        info("Scenario E PASS (node-id=1 persisted, cluster em0 + ge-7/0/N naming)")
+        # KERNEL link name, not the Junos display name: the namer assigns
+        # ge-{FPC}-0-{idx-2}, so `ip link show ge-7/0/0` could never match
+        # whatever the daemon did (#7129). `show interfaces terse` is where
+        # the slashes live.
+        if not guest_sh(e, 'ip link show ge-7-0-0 >/dev/null 2>&1'):
+            fail("ge-7-0-0 not present — node-1 FPC-7 positional naming did not "
+                 "run (a node-0 image would name it ge-0-0-0)")
+        info("Scenario E PASS (node-id=1 persisted, cluster em0 + ge-7-0-N naming)")
         self.drop(e)
 
     def scenario_qemu(self):


### PR DESCRIPTION
Follow-on to #7127. With the device-add failure fixed there, scenario `e`
finally launches — and immediately fails two of its own assertions. Both are
the scenario's, not the daemon's.

```
FAIL: em0 not present — daemon did not enter cluster naming mode for a
node-id-present image
```

## 1. `/etc/xpf/node-id` does not select cluster naming

The scenario wrote a day-0 config with **no `chassis cluster` stanza** and then
asserted that the node-id file alone makes the daemon assign `em0` +
`ge-7/0/N`. It does not, and is not meant to:

- `namingParamsFromConfig` → `clusterMode = cfg.Chassis.Cluster != nil`
- `hasNodeIDFile()` feeds only `computeBootClass` (bootstrap vs normal)
- the #4179 comment in `daemon_run_bringup.go` states it outright: a node-id
  node with a cluster-less config runs **STANDALONE** naming and re-names when
  the real cluster config arrives

So the daemon was right — `fxp0`, `ge-0-0-0`, `ge-0-0-1`, no `em0` — and the
scenario was asserting something nothing promises.

The config now carries a cluster stanza. `authentication-key` is part of the
minimum, not decoration: the cluster control channel fails OPEN without a PSK,
so a stanza without one is rejected by the real commit-check gate. Verified
against that gate:

```
$ xpfd check-config -node-id 1 scenE.conf      # no authentication-key
FAIL … chassis cluster: no authentication-key configured …
rc 2
$ xpfd check-config -node-id 1 scenE.conf      # with it
PASS (strict commit-check: parse + schema + compile + device-map preflight)
rc 0
```

The key is a throwaway literal — the VM peers with nothing and the scenario
asserts naming only.

## 2. `ip link show ge-7/0/0` can never match

Kernel link names use dashes: `enumerateAndRenameInterfaces` assigns
`ge-{FPC}-0-{idx-2}`, i.e. `ge-7-0-0`. `ge-7/0/0` is what
`show interfaces terse` prints, not what the kernel calls the link. This
assertion would have failed even after fix 1.

## Why neither had ever executed

The bake has aborted before scenario `e` since mid-June — on the three defects
fixed in #7113, then on #7114's scenario `a`, then on #7124. Scenario `e`
(#4209 H-9) has, as far as the record shows, never run against a real baked
image.

## Validation

- `scripts/run-selftests.sh` exit 0 — 50 passed, 0 skipped, 0 failed.
- The cluster stanza checked against the real commit-check gate, both
  directions, as above.
- End-to-end bake evidence is reported on #7114's PR, which is where the full
  Tier-1 gate result lives (this PR is one of the three needed for a green
  gate).

Closes #7129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJg8SoArRkkHRa7CZpHGGD
