### PR TITLE
daemon: let an appliance factory boot claim its fxp0 lifeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,7 +284,19 @@ in git history; `git log -- bpf/xdp/ bpf/tc/` walks the deleted source.
   - `KeepConfiguration=static` on RETH interfaces preserves VRRP VIPs across `networkctl reload`
 - Stale files are auto-removed; `networkctl reload` called only when files actually change
 - **DHCP interfaces**: daemon's DHCP client manages the address; address reconciliation is skipped
-- **Bootstrap**: daemon's `enumerateAndRenameInterfaces()` runs at startup, writes `.link` files + bootstrap fxp0 DHCP `.network`
+- **Bootstrap (#1922 lifeline, #7114 appliance gate)**: on a NORMAL boot the
+  daemon's `enumerateAndRenameInterfaces()` runs at startup and writes the
+  `.link` files. On a BOOTSTRAP boot (nothing ever committed) the full rename
+  loop is suppressed: `setupBootstrapLifeline` identifies the mgmt NIC by the
+  active default route and, only if that NIC is enumeration index 0, renames
+  just it to fxp0 and writes the bootstrap fxp0 DHCP `.network`. With no default
+  route it claims NOTHING (console-only) — that guard keeps a foreign host
+  reachable on its own config. The appliance image has no such config (the bake
+  purges cloud-init/netplan), so `scripts/image/bake.py` writes
+  `/etc/xpf/appliance`; with that marker present AND `EverCommitted()` false the
+  lifeline falls back to the first enumerated NIC, restoring the image's
+  vNIC#1 -> fxp0 factory contract on that artifact only (`isApplianceFactoryBoot`
+  / `chooseBootstrapLifeline`, `docs/install-images.md`)
 - DHCP-learned default routes get admin distance 200 in FRR (lower priority than static routes)
 - **Device-map mode (#1956, bare metal)**: an opt-in `set chassis device-map`
   stanza replaces positional naming with a STABLE-IDENTITY managed allowlist.

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,61 @@
+## 2026-08-21 — #7114: a factory boot of the appliance image claimed no NIC, so no bake could sign
+
+- **Timestamp**: 2026-08-21 (fix/7114-appliance-factory-bootstrap)
+- **Action**: Fixed the last known blocker to a clean appliance bake. Tier-1
+  scenario `a` (factory boot, no day-0 drive) failed on every baked image:
+  the NIC stayed DOWN and unrenamed — no `fxp0`, no DHCP — and because that
+  gate is fatal the bake wrote artifacts but never signed them.
+
+  Reproduced firsthand at `70d2d819f` against the previously baked
+  `xpf-userspace-forwarding-ok-…-gf93215641` qcow2 (`validate.py a --keep`):
+  `FAIL: fxp0 has no IPv4 DHCP address after 90s`; in the kept guest
+  `ip -br link` showed `enp5s0 DOWN`, `/etc/systemd/network/` EMPTY,
+  `/etc/netplan` absent, no default route, and the journal's
+  `bootstrap lifeline: no IPv4/IPv6 default route found` warning.
+
+  **Which of scenario-vs-code is wrong — decided (b), the CODE.** The
+  scenario is not stale: PR #1906 (the image PR, merged 2026-06-13) recorded
+  `==> Scenario A PASS (fxp0 10.199.99.183/24)` on a real baked image, states
+  the shipped contract as "invalid/missing medium -> loud journal log +
+  factory bootstrap (fxp0 DHCP)", and says in as many words that "the no-config
+  boot is the existing, proven fxp0-DHCP bootstrap. M1b remains the right fix
+  for foreign-host installs (M1a deb), **not for the appliance image**". Issue
+  #1922 (M1b) says the same: the appliance image "relies on the existing
+  fxp0-DHCP factory bootstrap" and the PCI-keyed lifeline is "needed for
+  foreign-host installs, not the pinned image". #1922 nevertheless replaced
+  the unconditional `writeBootstrapFxp0Network()` with a default-route-gated
+  lifeline (`79941ada7`, 2026-06-16) and regressed exactly the case it
+  promised not to touch. Three docs still assert the pre-#1922 behaviour
+  (`docs/install-images.md` vSRX-parity table, `docs/image-validation.md`
+  scenario a, `CLAUDE.md`).
+
+  **Fix**: one missing discriminator. `scripts/image/bake.py` writes
+  `/etc/xpf/appliance`; the daemon falls back to the FIRST ENUMERATED NIC only
+  when that marker is present AND `EverCommitted()` is false. Both halves are
+  load-bearing — the marker keeps the #1922 console-only refusal for
+  foreign-host `.deb` installs (the postinst never writes it), and
+  `!everCommitted` keeps it for the #1960 fail-closed boot, where a
+  previously-configured box (possibly with a `chassis device-map` that wants
+  no auto-`fxp0`) is in bootstrap because its config stopped compiling.
+  #1956 §9.6 is untouched: device-map mode needs `DeviceMap.Active()`, hence a
+  committed config, so it can never be in force on this boot.
+
+  **Mutation-verified, three separate one-line mutations, each localised**:
+  dropping the chooser's appliance branch reds
+  `TestChooseBootstrapLifeline/appliance_factory_boot,_no_route` AND the wiring
+  test; dropping the `!everCommitted` half reds only
+  `TestIsApplianceFactoryBoot/marker_but_already_committed`; severing the
+  production call site (`applianceFactory := false`) reds only the wiring test
+  — so the mutation lands at a site the production path actually reaches, not
+  merely at the pure helper.
+
+  **Gates**: `go build ./...` 0; `go test -count=1 ./pkg/daemon/` 0;
+  `scripts/run-selftests.sh` 0 (50 passed / 0 skipped / 0 failed).
+- **File(s)**: pkg/daemon/bootstrap.go,
+  pkg/daemon/bootstrap_appliance_factory_7114_test.go,
+  scripts/image/bake.py, scripts/image/validate.py, pkg/daemon/README.md,
+  docs/install-images.md, docs/image-validation.md, CLAUDE.md, _Log.md
+
 ## 2026-08-21 — #6981 drive-to-merge: master merge + first hostile gate; the holder mask does NOT close #6522
 
 - **Timestamp**: 2026-08-21 (fix/6876-f2-holders, PR #6981)

--- a/docs/image-validation.md
+++ b/docs/image-validation.md
@@ -104,7 +104,7 @@ Scenarios:
 
 | Scenario | Proves |
 |---|---|
-| **a** no config drive | factory boot; kernel ≥6.18 + `-generic` flavor; `linux-modules-extra` present (checked via the Mellanox driver dir as the sentinel — the broader mlx5/i40e set rides with it); exactly one kernel; `init_on_alloc=0` on the booted cmdline; **in-guest `xpfd verify-dataplane` PASS**; `fxp0` DHCP; sshd listening with `PermitRootLogin prohibit-password` + `PermitEmptyPasswords no`; no stray `/etc/xpf/xpf.conf` or stamp |
+| **a** no config drive | factory boot; kernel ≥6.18 + `-generic` flavor; `linux-modules-extra` present (checked via the Mellanox driver dir as the sentinel — the broader mlx5/i40e set rides with it); exactly one kernel; `init_on_alloc=0` on the booted cmdline; **in-guest `xpfd verify-dataplane` PASS**; the `/etc/xpf/appliance` marker present (#7114 — it is what re-enables the factory bootstrap; asserted before the DHCP wait so a bake that stopped writing it fails with its own cause); `fxp0` DHCP; sshd listening with `PermitRootLogin prohibit-password` + `PermitEmptyPasswords no`; no stray `/etc/xpf/xpf.conf` or stamp |
 | **b** valid day-0 drive | config validated + installed + committed (hostname applied, CLI shows it); reboot does **not** re-apply (stamp honored). *(The loader installs the config `0600`; the scenario asserts it exists and is non-empty, not the mode.)* |
 | **c** invalid day-0 drive | commit-check REJECT logged, nothing installed, no stamp, factory bootstrap still reachable |
 | **d** resized disk (#1925) | first-boot root auto-grow fills a 20 GiB root disk — root **partition** + ext4 fs both grow past the 8 GiB bake floor, `/etc/xpf/.root-grown` stamped, idempotent across a reboot, ESP still mounted, `verify-dataplane` still PASS; a control instance at the exact bake size proves the grow is a clean no-op (`growpart` NOCHANGE) |
@@ -313,13 +313,16 @@ i40e-PF for a performance number), and Tier 3 / HA from an image.
 Two defects observed during the run, tracked separately — neither affects
 the result above:
 
-- Tier-1 scenario **a** fails on this image: on a factory boot with no
-  config drive, nothing brings the NIC up (the bake purges cloud-init and
-  netplan), so xpfd's bootstrap lifeline finds no default route, declines
-  to identify a management NIC, and leaves the port down and unrenamed —
-  no `fxp0`, no DHCP. Tier 2 is unaffected because it supplies a day-0
-  config, which takes xpfd out of bootstrap and into full interface
-  takeover.
+- Tier-1 scenario **a** failed on this image (#7114, FIXED): on a factory
+  boot with no config drive, nothing brought the NIC up (the bake purges
+  cloud-init and netplan), so xpfd's bootstrap lifeline found no default
+  route, declined to identify a management NIC, and left the port down and
+  unrenamed — no `fxp0`, no DHCP. Tier 2 was unaffected because it supplies
+  a day-0 config, which takes xpfd out of bootstrap and into full interface
+  takeover. The fix adds the bake-written `/etc/xpf/appliance` marker, which
+  (AND-ed with "nothing ever committed") lets the lifeline claim the first
+  enumerated NIC on this artifact while keeping the console-only refusal for
+  foreign-host installs — see `docs/install-images.md`.
 - `show security flow session` lists the ICMP sessions but omits TCP ones,
   while `show security flow statistics` counts them (`Current sessions:
   10` against a rendered `Total sessions: 2`). A display-path gap, not a

--- a/docs/install-images.md
+++ b/docs/install-images.md
@@ -258,7 +258,7 @@ each VM its own copy-on-write overlay. Put the verified image there with
 | vSRX | xpf image |
 |---|---|
 | First vNIC is fxp0 (OOB mgmt), rest map to ge-0/0/N in attach order | Identical: `enumerateAndRenameInterfaces()` assigns fxp0 / em0 (cluster) / ge-X-0-N by PCI bus order |
-| Factory default: fxp0 DHCP, root console login, no password | Identical: fxp0 DHCP bootstrap; root login on the hypervisor console with empty password; sshd refuses empty/root-password auth |
+| Factory default: fxp0 DHCP, root console login, no password | Identical: fxp0 DHCP bootstrap (gated on the `/etc/xpf/appliance` marker — see below); root login on the hypervisor console with empty password; sshd refuses empty/root-password auth |
 | Day-0 config: ISO with `juniper.conf` at the root, attached as CD-ROM | ISO (or any volume labeled `xpf-config`) with `xpf.conf` at the root — `juniper.conf` accepted as an alias; optional `node-id` file (`0`/`1`) for cluster members |
 | Bad day-0 config: boots factory-default | Identical, but stricter: the config is validated with the REAL commit-check gate (`xpfd check-config`) BEFORE install; a REJECT logs loudly and the system stays factory-default |
 | Day-0 applied once | Applied at most once: stamped after success; never clobbers an existing config (a COMMITTED `.configdb/active.json` or a preseeded `xpf.conf`). A REJECTED medium does not stamp — fix the config and reboot to retry while the system is still factory-default |
@@ -285,6 +285,38 @@ Day-0 loader specifics (`scripts/image/xpf-day0-config`, oneshot unit
   make a box that booted once (empty `.configdb` present) permanently
   skip the probe, killing the fix-and-reboot retry above. A box in
   factory bootstrap has no `active.json`, so the loader re-probes.
+
+### The `/etc/xpf/appliance` marker (#7114)
+
+The bake writes `/etc/xpf/appliance` into the image. It is what makes the
+factory `fxp0` DHCP bootstrap above happen at all.
+
+xpfd's #1922 bootstrap lifeline identifies the management NIC by the ACTIVE
+DEFAULT ROUTE, and refuses to rename or bring up anything when it cannot find
+one — the right call on a **foreign host** where xpf was installed from the
+`.deb` and the operator's own network configuration is the lifeline. The
+appliance has no such configuration: the bake purges cloud-init and deletes
+every netplan / `interfaces.d` file, so a factory boot with no day-0 drive has
+no route, no address, and nothing to preserve. Without the marker that boot
+leaves every port DOWN and unrenamed — reachable only from the hypervisor
+console.
+
+With the marker present AND nothing ever committed on the box, xpfd claims the
+first enumerated NIC as `fxp0` and DHCPs it, which is the image's vNIC#1 →
+fxp0 contract. Both conditions are required:
+
+- The `.deb` postinst never writes the marker, so a foreign-host install keeps
+  the console-only refusal.
+- A box that HAS been configured is excluded even when it boots into bootstrap
+  mode via the #1960 fail-closed path (a committed config that no longer
+  compiles): its intended interface bindings are real and unknown — possibly a
+  `chassis device-map` that wants no auto-`fxp0` at all — so claiming NIC 0
+  there would be exactly the mis-binding #1960 refuses to perform.
+
+Deleting the marker on a running appliance gives that box the foreign-host
+posture. A factory reset does not remove it (the reset erases an exact,
+xpf-owned allowlist of config artifacts), so a zeroized appliance comes back up
+in the factory `fxp0`-DHCP posture — which is the vSRX behaviour.
 
 Build a config drive:
 

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -945,6 +945,24 @@ never lock an operator out of a remote box it manages.
   PCI, survives rename/restart/rollback), and — only if that NIC is
   enumeration index 0 — renames just it to fxp0 and snapshots its addressing
   into the bootstrap `.network`.
+  - **Appliance factory boot (#7114).** The default-route signal does not
+    exist on the appliance image: `scripts/image/bake.py` purges cloud-init
+    and deletes every netplan / `interfaces.d` file, so a factory boot (no
+    day-0 drive) has no route, no address, and no `.network` anywhere — and
+    the refusal above left every port DOWN and unrenamed, console-only, which
+    contradicts the image's shipped vNIC#1 → fxp0 factory contract
+    (`docs/install-images.md`, PR #1906). One discriminator resolves it: the
+    bake writes `/etc/xpf/appliance`, and the daemon (`isApplianceFactoryBoot`)
+    falls back to the FIRST ENUMERATED NIC only when that marker is present
+    **and** `EverCommitted()` is false. Selection itself is the pure
+    `chooseBootstrapLifeline` — a default route always wins; the fallback
+    applies only when there is no route at all. Both halves of the gate are
+    load-bearing: the marker keeps the #1922 refusal intact for foreign-host
+    `.deb` installs (the postinst never writes it), and `!everCommitted` keeps
+    it intact for the #1960 fail-closed boot, where a box that HAS been
+    configured (possibly with a device-map that wants no auto-fxp0) is in
+    bootstrap because its committed config stopped compiling. Steps 2-4 above
+    are unchanged and run identically for either provenance.
 - **Protected set** (`resolveProtectedInterfaces` →
   `dataplane.SetProtectedInterfaceResolver`): fxp0 + the lifeline NIC + an
   explicit `system management-interface` leaf are NEVER marked Unmanaged /

--- a/pkg/daemon/bootstrap.go
+++ b/pkg/daemon/bootstrap.go
@@ -91,6 +91,70 @@ const lifelineRecordFile = "/etc/xpf/lifeline-interface"
 // valve).
 const defaultMgmtInterface = "fxp0"
 
+// applianceMarkerFile marks a host that was PROVISIONED FROM THE XPF APPLIANCE
+// IMAGE. `scripts/image/bake.py` writes it into the baked root filesystem; the
+// .deb postinst NEVER does, so a foreign host that merely has the package
+// installed can never carry it, and neither can a `xpf-deploy` push.
+//
+// It is the discriminator the #1922 bootstrap lifeline was missing (#7114).
+// The lifeline refuses to touch any NIC when it cannot identify a management
+// interface, and on a FOREIGN host that refusal is right: xpf is a guest there
+// and the operator's own network configuration is the thing keeping the box
+// reachable. On the appliance image xpf is the ONLY network manager — the bake
+// purges cloud-init and deletes every netplan / interfaces.d file — so at a
+// factory boot there is no default route, no address, and no `.network` file
+// anywhere: there is nothing to preserve, and refusing leaves every NIC down
+// and unrenamed, reachable only from the hypervisor console. The image's
+// vNIC#1 -> fxp0 factory contract (docs/install-images.md; PR #1906) makes
+// mgmt-is-enumeration-index-0 a property of the ARTIFACT, so on this host —
+// and only on this host — the first enumerated NIC is a safe lifeline.
+//
+// A var, not a const, so tests can repoint the probe at a scratch tree.
+var applianceMarkerFile = "/etc/xpf/appliance"
+
+// Lifeline provenance strings, used for logging and as the chooser's verdict
+// discriminator.
+const (
+	lifelineSourceDefaultRoute     = "default-route"
+	lifelineSourceApplianceFactory = "appliance-factory-boot"
+)
+
+// isApplianceFactoryBoot is the pure gate for the #7114 appliance factory
+// bootstrap. BOTH conditions are load-bearing:
+//
+//   - markerPresent: the host was provisioned from the xpf appliance image, so
+//     xpf owns every NIC on it (see applianceMarkerFile). Without this a
+//     foreign-host .deb install would claim the operator's NICs — the exact
+//     lockout #1922 closed.
+//   - !everCommitted: this is a genuinely FACTORY box — no configuration has
+//     ever been committed on it. A box that HAS been configured can also be in
+//     bootstrap mode, via the #1960 fail-closed path (a committed config that
+//     no longer compiles). There the operator's intended interface bindings are
+//     unknown-but-real — possibly a device-map that never wants an auto-fxp0 —
+//     and claiming NIC 0 as fxp0 would be precisely the mis-binding #1960
+//     refuses to perform. The Item-1b first-commit rollback leaves
+//     everCommitted false, which is correct: that box is factory-equivalent.
+func isApplianceFactoryBoot(markerPresent, everCommitted bool) bool {
+	return markerPresent && !everCommitted
+}
+
+// chooseBootstrapLifeline is the pure NIC-selection core of
+// setupBootstrapLifeline (#7114). The default route wins whenever one exists —
+// including on the appliance, where a committed-then-rolled-back box may still
+// carry addressing — because it is the direct evidence of where the operator
+// actually reaches the box. The appliance factory fallback applies only when
+// there is no default route at all. Anything else selects nothing, which is
+// the #1922 console-only refusal.
+func chooseBootstrapLifeline(routeIface, firstNIC string, applianceFactory bool) (name, source string, ok bool) {
+	if routeIface != "" {
+		return routeIface, lifelineSourceDefaultRoute, true
+	}
+	if applianceFactory && firstNIC != "" {
+		return firstNIC, lifelineSourceApplianceFactory, true
+	}
+	return "", "", false
+}
+
 // userspaceShimLinkPinDir carries the pinned XDP links that survive a daemon
 // restart. Pins are a CHEAP PRE-FILTER ONLY (#1993 review): their presence
 // proves "an XDP link is attached", NOT "forwarding is live". On a graceful
@@ -692,6 +756,27 @@ func readLifelineRecordAt(path string) (lifelineRecord, bool) {
 // once a config exists; the genuinely-fresh box has no leaf yet, so the
 // default-route signal is the only config-independent option.
 //
+// detectLifelineInterfaceFn / enumeratePCINICsFn are injectable seams for the
+// world-reading half of setupBootstrapLifeline, so the #7114 selection wiring
+// is testable without a live netlink/sysfs stack. Production leaves them
+// pointing at the real detectors.
+var (
+	detectLifelineInterfaceFn = detectLifelineInterface
+	enumeratePCINICsFn        = enumeratePCINICs
+)
+
+// applianceFactoryBoot reports whether this bootstrap boot is a FACTORY boot of
+// an xpf appliance image: the bake-written marker is present AND nothing has
+// ever been committed on this box. See isApplianceFactoryBoot for why both
+// halves are required. Called only from the bootstrap naming path, after
+// Store.Load has resolved, so EverCommitted() is stable.
+func (d *Daemon) applianceFactoryBoot() bool {
+	if _, err := os.Stat(applianceMarkerFile); err != nil {
+		return false
+	}
+	return d.store != nil && isApplianceFactoryBoot(true, d.store.EverCommitted())
+}
+
 // Returns the current kernel name of the lifeline NIC and ok=false when no
 // default route exists.
 func detectLifelineInterface() (name string, ok bool) {
@@ -840,13 +925,43 @@ func protectedInterfacesWith(mgmtLeaf, lifeline string) map[string]bool {
 //     re-wire or set `system management-interface` + commit.
 //
 // No other NIC is renamed, cycled, or reconfigured in bootstrap mode.
+//
+// #7114 amends step 1: when there is no default route AND this host is a
+// factory boot of the xpf appliance image (isApplianceFactoryBoot), the first
+// enumerated NIC is selected instead of refusing. Steps 2-4 are unchanged and
+// run identically for either provenance.
 func (d *Daemon) setupBootstrapLifeline() {
-	lifeline, ok := detectLifelineInterface()
+	routeIface, _ := detectLifelineInterfaceFn()
+
+	// #7114: the appliance image's factory boot has no default route to find —
+	// the bake purges cloud-init and netplan, so nothing but xpfd ever brings a
+	// NIC up. Enumerate a fallback there, and ONLY there.
+	firstNIC := ""
+	applianceFactory := routeIface == "" && d.applianceFactoryBoot()
+	if applianceFactory {
+		nics, err := enumeratePCINICsFn()
+		if err != nil {
+			slog.Warn("bootstrap lifeline: appliance factory boot, but NIC enumeration "+
+				"failed; no interface claimed", "err", err)
+			applianceFactory = false
+		} else if len(nics) > 0 {
+			firstNIC = nics[0].name
+		}
+	}
+
+	lifeline, source, ok := chooseBootstrapLifeline(routeIface, firstNIC, applianceFactory)
 	if !ok {
 		slog.Warn("bootstrap lifeline: no IPv4/IPv6 default route found; cannot identify a " +
 			"management NIC. Staying in bootstrap with NO interface changes — reach the box " +
 			"via its hypervisor/physical console and 'commit confirmed' a config.")
 		return
+	}
+	if source == lifelineSourceApplianceFactory {
+		slog.Info("bootstrap lifeline: no default route, but this host carries the xpf "+
+			"appliance-image marker and has never committed a configuration; claiming the "+
+			"first enumerated NIC as the fxp0 factory management interface (DHCP), per the "+
+			"image's vNIC#1 -> fxp0 contract",
+			"interface", lifeline, "marker", applianceMarkerFile)
 	}
 
 	// Record PCI identity (keyed by PCI, MAC tiebreaker) so the protected
@@ -867,7 +982,7 @@ func (d *Daemon) setupBootstrapLifeline() {
 	// Determine the enumeration index of the lifeline NIC. Only index 0
 	// becomes fxp0; renaming a higher-index NIC would not match the mgmt
 	// convention and risks cutting off management.
-	nics, err := enumeratePCINICs()
+	nics, err := enumeratePCINICsFn()
 	if err != nil {
 		slog.Warn("bootstrap lifeline: NIC enumeration failed; no rename performed", "err", err)
 		return
@@ -899,14 +1014,14 @@ func (d *Daemon) setupBootstrapLifeline() {
 	original := recoverOriginalName(lifeline)
 	_ = writeLinkFile(defaultMgmtInterface, original)
 	if lifeline != defaultMgmtInterface {
-		if err := renameInterface(lifeline, defaultMgmtInterface); err != nil {
+		if err := renameInterfaceFn(lifeline, defaultMgmtInterface); err != nil {
 			slog.Warn("bootstrap lifeline: rename to fxp0 failed; mgmt stays on original name",
 				"from", lifeline, "err", err)
 		} else {
 			slog.Info("bootstrap lifeline: renamed management NIC to fxp0", "from", lifeline)
 		}
 	}
-	if err := networkctlReload(); err != nil {
+	if err := networkctlReloadFn(); err != nil {
 		slog.Warn("bootstrap lifeline: networkctl reload failed", "err", err)
 	}
 }

--- a/pkg/daemon/bootstrap_appliance_factory_7114_test.go
+++ b/pkg/daemon/bootstrap_appliance_factory_7114_test.go
@@ -1,0 +1,263 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #7114: a factory boot of the xpf APPLIANCE IMAGE left every NIC down and
+// unrenamed — no fxp0, no DHCP, reachable only from the hypervisor console.
+//
+// Mechanism: the bake purges cloud-init and deletes every netplan /
+// interfaces.d file, so on a no-config-drive boot nothing but xpfd ever
+// configures a NIC. xpfd enters #1922 bootstrap mode; setupBootstrapLifeline
+// identifies the management NIC by the ACTIVE DEFAULT ROUTE; with every port
+// down there is no route; so it declined to touch anything. That refusal is
+// right on a FOREIGN host (xpf is a guest there and the operator's own network
+// config is the lifeline) but wrong on the appliance, where the image's
+// vNIC#1 -> fxp0 factory contract (PR #1906, docs/install-images.md) is the
+// shipped behaviour and there is provably nothing to preserve.
+//
+// The fix adds ONE discriminator — the bake-written /etc/xpf/appliance marker,
+// AND-ed with "never committed" — and falls back to the first enumerated NIC
+// only when both hold.
+//
+// FAIL-ON-REVERT: dropping the appliance branch from chooseBootstrapLifeline
+// reds TestChooseBootstrapLifeline/appliance_factory_boot_no_route AND the
+// wiring test below (no .network is written). Dropping the everCommitted half
+// of the gate reds TestIsApplianceFactoryBoot/marker_but_already_committed.
+
+func TestIsApplianceFactoryBoot(t *testing.T) {
+	tests := []struct {
+		name          string
+		markerPresent bool
+		everCommitted bool
+		want          bool
+	}{
+		{
+			// The #7114 case: a baked appliance that has never been
+			// configured. This is the ONLY combination that may claim a NIC.
+			name:          "marker present and never committed",
+			markerPresent: true,
+			everCommitted: false,
+			want:          true,
+		},
+		{
+			// #1960 fail-closed: a box whose committed config no longer
+			// compiles is ALSO in bootstrap mode, but its operator-intended
+			// interface bindings are real and unknown (possibly a device-map
+			// that never wants an auto-fxp0). Claiming NIC 0 there is the
+			// mis-binding #1960 exists to refuse.
+			name:          "marker but already committed (#1960 fail-closed boot)",
+			markerPresent: true,
+			everCommitted: true,
+			want:          false,
+		},
+		{
+			// A foreign host with the .deb installed: no marker, so the
+			// #1922 console-only refusal stands even on a fresh box.
+			name:          "no marker, never committed (foreign .deb install)",
+			markerPresent: false,
+			everCommitted: false,
+			want:          false,
+		},
+		{
+			name:          "no marker, already committed",
+			markerPresent: false,
+			everCommitted: true,
+			want:          false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isApplianceFactoryBoot(tt.markerPresent, tt.everCommitted); got != tt.want {
+				t.Fatalf("isApplianceFactoryBoot(%v, %v) = %v, want %v",
+					tt.markerPresent, tt.everCommitted, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChooseBootstrapLifeline(t *testing.T) {
+	tests := []struct {
+		name             string
+		routeIface       string
+		firstNIC         string
+		applianceFactory bool
+		wantName         string
+		wantSource       string
+		wantOK           bool
+	}{
+		{
+			// Unchanged #1922 behaviour: a default route is direct evidence
+			// of where the operator reaches the box.
+			name:       "default route selects the route interface",
+			routeIface: "enp5s0",
+			firstNIC:   "enp1s0",
+			wantName:   "enp5s0",
+			wantSource: lifelineSourceDefaultRoute,
+			wantOK:     true,
+		},
+		{
+			// The default route still wins on the appliance — the fallback is
+			// for the case where there is no evidence at all, not a general
+			// override of the route signal.
+			name:             "default route wins over the appliance fallback",
+			routeIface:       "enp5s0",
+			firstNIC:         "enp1s0",
+			applianceFactory: true,
+			wantName:         "enp5s0",
+			wantSource:       lifelineSourceDefaultRoute,
+			wantOK:           true,
+		},
+		{
+			// The #7114 fix.
+			name:             "appliance factory boot, no route",
+			firstNIC:         "enp5s0",
+			applianceFactory: true,
+			wantName:         "enp5s0",
+			wantSource:       lifelineSourceApplianceFactory,
+			wantOK:           true,
+		},
+		{
+			// The #1922 refusal, preserved for every non-appliance host.
+			name:     "no route, not an appliance factory boot",
+			firstNIC: "enp5s0",
+			wantOK:   false,
+		},
+		{
+			// A diskless/NIC-less enumeration must not select the empty
+			// string as an interface name.
+			name:             "appliance factory boot with no NICs enumerated",
+			applianceFactory: true,
+			wantOK:           false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, source, ok := chooseBootstrapLifeline(tt.routeIface, tt.firstNIC, tt.applianceFactory)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				if name != "" || source != "" {
+					t.Fatalf("refusal must select nothing, got name=%q source=%q", name, source)
+				}
+				return
+			}
+			if name != tt.wantName {
+				t.Fatalf("name = %q, want %q", name, tt.wantName)
+			}
+			if source != tt.wantSource {
+				t.Fatalf("source = %q, want %q", source, tt.wantSource)
+			}
+		})
+	}
+}
+
+// TestSetupBootstrapLifelineAppliance binds the WIRING, not just the pure
+// cores: it drives the real setupBootstrapLifeline with the world-readers
+// faked (no default route, one enumerated NIC already named fxp0 so no rename
+// is attempted) and asserts the observable outcome the image gate checks —
+// the bootstrap fxp0 DHCP .network exists. A revert of the production call
+// site (however the pure helpers behave) leaves the directory empty.
+func TestSetupBootstrapLifelineAppliance(t *testing.T) {
+	tests := []struct {
+		name        string
+		writeMarker bool
+		wantNetwork bool
+	}{
+		{
+			name:        "appliance factory boot writes the bootstrap fxp0 .network",
+			writeMarker: true,
+			wantNetwork: true,
+		},
+		{
+			// The #1922 guard, intact: no marker means no NIC is claimed even
+			// though the enumeration and the (absent) route are identical.
+			name:        "foreign host with no marker claims nothing",
+			writeMarker: false,
+			wantNetwork: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Repoint every path/effect this code path can reach.
+			oldLinkDir := linkDir
+			linkDir = filepath.Join(dir, "network")
+			if err := os.MkdirAll(linkDir, 0o755); err != nil {
+				t.Fatalf("mkdir linkDir: %v", err)
+			}
+			oldMarker := applianceMarkerFile
+			applianceMarkerFile = filepath.Join(dir, "appliance")
+			oldRecord := lifelineRecordFileForTest
+			lifelineRecordFileForTest = filepath.Join(dir, "lifeline-interface")
+			oldDetect := detectLifelineInterfaceFn
+			oldEnum := enumeratePCINICsFn
+			oldRename := renameInterfaceFn
+			oldReload := networkctlReloadFn
+			t.Cleanup(func() {
+				linkDir = oldLinkDir
+				applianceMarkerFile = oldMarker
+				lifelineRecordFileForTest = oldRecord
+				detectLifelineInterfaceFn = oldDetect
+				enumeratePCINICsFn = oldEnum
+				renameInterfaceFn = oldRename
+				networkctlReloadFn = oldReload
+			})
+
+			// No default route — the #7114 precondition.
+			detectLifelineInterfaceFn = func() (string, bool) { return "", false }
+			// One NIC, already wearing the target name so the rename is a
+			// no-op and the test needs no netlink.
+			enumeratePCINICsFn = func() ([]pciNIC, error) {
+				return []pciNIC{{sortKey: 0, busAddr: "0000:05:00.0", name: defaultMgmtInterface}}, nil
+			}
+			renamed := false
+			renameInterfaceFn = func(_, _ string) error { renamed = true; return nil }
+			reloaded := false
+			networkctlReloadFn = func() error { reloaded = true; return nil }
+
+			if tt.writeMarker {
+				if err := os.WriteFile(applianceMarkerFile, []byte("appliance\n"), 0o644); err != nil {
+					t.Fatalf("write marker: %v", err)
+				}
+			}
+
+			d := &Daemon{store: newConfigStore(t, filepath.Join(dir, "xpf.conf"))}
+			if d.store.EverCommitted() {
+				t.Fatal("precondition: a fresh store must report EverCommitted()==false")
+			}
+			d.setupBootstrapLifeline()
+
+			netPath := filepath.Join(linkDir, linkPrefix+"fxp0.network")
+			data, err := os.ReadFile(netPath)
+			switch {
+			case tt.wantNetwork && err != nil:
+				t.Fatalf("expected the bootstrap fxp0 .network at %s: %v", netPath, err)
+			case !tt.wantNetwork && err == nil:
+				t.Fatalf("no NIC may be claimed without the marker, but %s was written:\n%s",
+					netPath, data)
+			}
+			if !tt.wantNetwork {
+				if reloaded {
+					t.Fatal("networkctl reload ran on a host that claims nothing")
+				}
+				return
+			}
+			if got := string(data); !strings.Contains(got, "DHCP=yes") || !strings.Contains(got, "Name=fxp0") {
+				t.Fatalf("bootstrap .network is not an fxp0 DHCP config:\n%s", got)
+			}
+			if renamed {
+				t.Fatal("the enumerated NIC already wears the fxp0 name; no rename expected")
+			}
+			if !reloaded {
+				t.Fatal("networkd was never reloaded, so the new .network never takes effect")
+			}
+		})
+	}
+}

--- a/scripts/image/bake.py
+++ b/scripts/image/bake.py
@@ -370,6 +370,26 @@ def virt_customize(work_qcow, xpf_deb):
         "--run-command", "chmod 0755 /usr/lib/systemd/incus-agent-setup",
         "--write", f"/etc/sysctl.d/99-xpf.conf:{SYSCTL_CONF}",
         "--run-command", "mkdir -p /etc/xpf && chmod 0750 /etc/xpf",
+        # #7114: the appliance-image marker. xpfd's #1922 bootstrap lifeline
+        # refuses to rename or bring up ANY NIC when it cannot identify a
+        # management interface from an active default route — the right call on
+        # a foreign host, where xpf is a guest and the operator's own network
+        # configuration is the lifeline. This image has no such configuration:
+        # cloud-init is purged and every netplan / interfaces.d file is deleted
+        # below, so on a factory boot (no day-0 drive) there is no route, no
+        # address, and nothing to preserve. Without this marker that boot leaves
+        # every port DOWN and unrenamed — console-only, no fxp0, no DHCP.
+        # Its presence, AND-ed in the daemon with "never committed", re-enables
+        # the image's vNIC#1 -> fxp0 factory contract on THIS artifact only. The
+        # .deb postinst must never write it.
+        "--write",
+        "/etc/xpf/appliance:"
+        "# xpf (#7114) appliance-image marker — written by scripts/image/bake.py.\n"
+        "# Presence means: this root filesystem IS the xpf appliance, so xpfd owns\n"
+        "# every NIC on it. On a FACTORY boot (nothing ever committed) the daemon\n"
+        "# claims the first enumerated NIC as fxp0 and DHCPs it, instead of the\n"
+        "# console-only bootstrap refusal it applies to foreign-host installs.\n"
+        "# Delete it to get the foreign-host posture on this box.\n",
         "--run-command", f"export DEBIAN_FRONTEND=noninteractive && {APT_UPDATE}",
         "--run-command", f"export DEBIAN_FRONTEND=noninteractive && "
                          f"apt-get install -y -qq -o Acquire::Retries=5 {pkgs}",

--- a/scripts/image/validate.py
+++ b/scripts/image/validate.py
@@ -336,6 +336,17 @@ class Harness:
         if guest(a, "nice", "-n", "19", "/usr/local/sbin/xpfd", "verify-dataplane",
                  check=False).returncode != 0:
             fail("in-guest verify-dataplane REJECTED — image must not ship")
+        # #7114: the appliance marker is what re-enables the factory
+        # fxp0-DHCP bootstrap on this artifact. The bake purges cloud-init and
+        # netplan, so on a no-config-drive boot xpfd's #1922 lifeline finds no
+        # default route; without the marker it declines to touch any NIC and
+        # the port below stays DOWN and unrenamed. Assert the marker FIRST so a
+        # bake that stopped writing it fails with its own cause instead of as
+        # the downstream "fxp0 has no address" timeout.
+        if not guest_sh(a, 'test -f /etc/xpf/appliance'):
+            fail("/etc/xpf/appliance missing — the bake did not write the #7114 "
+                 "appliance-image marker; xpfd will hold the factory boot in the "
+                 "console-only bootstrap state (no fxp0, no DHCP)")
         self.wait_fxp0_dhcp(a)
         # #4172: frr-pythontools (/usr/lib/frr/frr-reload.py) MUST be present
         # or every FRR reload silently degrades to the additive `vtysh -f`


### PR DESCRIPTION
A factory boot of the appliance image — no day-0 config drive — left every NIC
**DOWN and unrenamed**: no `fxp0`, no DHCP, reachable only from the hypervisor
console. Tier-1 validation scenario `a` fails on it, and because that gate is
fatal the bake writes artifacts but never signs them.

Reproduced firsthand at `70d2d819f` against the previously baked
`…-gf93215641` qcow2 (`validate.py a --keep`):

```
FAIL: xpf-image-def6c510-a: fxp0 has no IPv4 DHCP address after 90s

$ incus exec … -- ip -br link
lo      UNKNOWN  …
enp5s0  DOWN     10:66:6a:03:e4:96 <BROADCAST,MULTICAST>
$ … ls -A /etc/systemd/network/ ; ls -A /etc/netplan ; ip route show default
(empty)                          (empty)             (nothing)
$ … journalctl -u xpfd -b
WARN "bootstrap lifeline: no IPv4/IPv6 default route found; cannot identify a
      management NIC. Staying in bootstrap with NO interface changes …"
```

## Which is wrong — the scenario, or the code?

**The code.** The scenario is not stale, and this is not a design call:

- **PR #1906** (the image PR, merged 2026-06-13) recorded
  `==> Scenario A PASS (fxp0 10.199.99.183/24)` on a real baked image, states
  the shipped contract as *"invalid/missing medium → loud journal log +
  factory bootstrap (fxp0 DHCP)"*, and says in as many words:
  *"the no-config boot is the existing, proven fxp0-DHCP bootstrap. M1b
  remains the right fix for foreign-host installs (M1a deb), **not for the
  appliance image**."*
- **Issue #1922** (M1b, the lifeline itself) opens with *"The appliance image
  relies on the existing fxp0-DHCP factory bootstrap"* and scopes the
  PCI-keyed lifeline as *"needed for foreign-host installs, **not the pinned
  image**"*.
- `79941ada7` (#1922, 2026-06-16) nevertheless replaced the unconditional
  `writeBootstrapFxp0Network()` with the default-route-gated lifeline, and so
  regressed exactly the case it promised not to touch. Three docs still assert
  the pre-#1922 behaviour.

The guard itself is right and stays. On a **foreign** host xpf is a guest,
installed from the `.deb`, and the operator's own network configuration is what
keeps the box reachable — refusing to touch a NIC is correct there. The
appliance has no such configuration: the bake purges cloud-init and deletes
every netplan / `interfaces.d` file, so a factory boot has no route, no
address, and no `.network` anywhere. There is nothing to preserve, and
refusing leaves the box dark.

## The fix: one missing discriminator

`bake.py` writes `/etc/xpf/appliance`; the daemon falls back to the **first
enumerated NIC** only when that marker is present **and** `EverCommitted()` is
false. Everything downstream — the PCI identity record, the index-0 check, the
`.network` snapshot, the rename, the reload — is unchanged and runs identically
for either provenance.

Both halves of the gate are load-bearing:

- **The marker** keeps the #1922 refusal intact for foreign-host installs.
  `debian/xpf.postinst` never writes it, and neither does `xpf-deploy`. Note
  the `xpf-appliance` **metapackage** is the operator-facing
  `apt install xpf-appliance` path — i.e. a foreign host — so it must not
  write it either, and does not; the bake installs the `xpf` binary package
  plus the runtime set explicitly, never that metapackage.
- **`!everCommitted`** keeps it intact for the #1960 fail-closed boot. A box
  whose committed config no longer compiles is *also* in bootstrap mode, but
  its operator-intended interface bindings are real and unknown — possibly a
  `chassis device-map` that wants no auto-`fxp0` at all — so claiming NIC 0 as
  `fxp0` there would be precisely the mis-binding #1960 exists to refuse. The
  Item-1b first-commit rollback leaves `everCommitted` false, which is correct:
  that box is factory-equivalent.

**#1956 §9.6 ("no auto-fxp0 / no bootstrap DHCP in device-map mode") is not
weakened.** Device-map mode is gated on `cfg.Chassis.DeviceMap.Active()`, which
requires a committed config, so it can never be in force on the boot this
change affects.

The first enumerated NIC is not a guess: `enumeratePCINICs()` is the same
enumeration the normal rename loop uses, where `idx 0 → fxp0` in both
standalone and cluster mode. And the `system management-interface` escape valve
still works — `protectedInterfacesWith`'s `narrowFxp0` removes `fxp0` from
**both** the default contribution and the lifeline-record union, and the
recorded lifeline resolves to `fxp0` after the rename.

Implementation follows the file's existing discipline — a pure decision core
plus a thin world-reading wrapper: `isApplianceFactoryBoot` is the gate,
`chooseBootstrapLifeline` the selection (a default route always wins; the
fallback applies only when there is no route at all).

## Validation

**The real acceptance — a full bake, scenario `a` on a real image:**

```
==> ── Scenario A: first boot, NO config drive ──
==> guest kernel: 7.0.0-30-generic
==> in-guest verify-dataplane (the bake gate, image kernel)...
==> Scenario A PASS
==> Scenario B PASS
==> Scenario C PASS (reject survived, fix+reboot applied — retry contract)
==> Scenario D PASS
```

Unit gates:

- Three separate one-line mutations red, each localised — dropping the
  chooser's appliance branch reds the chooser case **and** the wiring test;
  dropping the `!everCommitted` half reds only the #1960 gate case; severing
  the production call site (`applianceFactory := false`) reds only the wiring
  test. That third one matters: it proves the mutation lands at a site the
  production path actually reaches, not merely at a pure helper.
- `go build ./...` exit 0; `go test -count=1 ./pkg/daemon/` exit 0.
- `scripts/run-selftests.sh` exit 0 (50 passed / 0 skipped / 0 failed).

## Docs

`docs/install-images.md` (new section on the marker, both gate halves, and
what a factory reset does to it), `docs/image-validation.md` (scenario `a`
row; the Tier-2 run's open-defect note now records this as fixed),
`pkg/daemon/README.md` (the #1922 lifeline bullet), and `CLAUDE.md` — whose
"Bootstrap" bullet had been stale since #1922, still claiming the full
`enumerateAndRenameInterfaces()` rename runs at bootstrap.

## What this does NOT unblock on its own

Scenario `a` is fixed, but the gate runs `a b c d e q`, and reaching a signed
artifact needs two further PRs found by running it: **#7127** (merged — stale
base-pin self-test, scenario `e` device-add refusal, leaked VM) and **#7130**
(scenario `e` asserting cluster naming from `/etc/xpf/node-id` alone, and
checking Junos display names the kernel never uses). All three are independent
causes.

Closes #7114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJg8SoArRkkHRa7CZpHGGD
