### PR TITLE
config: validate every vlan-id-list value, not slot 0 alone

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1039,12 +1039,29 @@ control so an ACCEPT only counts beside a REJECT of the same token:
 |---|---|---|---|
 | CoS `code-points` | hierarchical BLOCK (`{ totally-bogus; }`) | bracket `[ totally-bogus ]` — *"is not a valid DSCP alias or 0..63 value"* | #6697 |
 | `system archival archive-sites` | bracket `[ "scp://a/b" "-oProxyCommand=id" ]` | single value AND block — *"must not begin with '-'"* (#4589 A7 F-02, CWE-88) | #6692 |
-| `bridge-domains vlan-id-list` | BOTH bracket and block | single value — *"out of range (1-4094)"* / *"invalid vlan-id-list value"* | #6687 |
+| `bridge-domains vlan-id-list` | BOTH bracket and block | single value — *"out of range (1-4094)"* / *"invalid vlan-id-list value"* | #6687 — **CLOSED**, see below |
 
 Note the first two escape in OPPOSITE directions — `collectCoSDSCPCodePoints`
 reads `child.Keys[1:]` plus the inline tail and never `child.Children`, while
 the archive-sites loop reads children and only slot 1 of the tail. "Which shape
 escapes" is a property of the individual reader; do not generalise from one.
+
+**Closing a gate escape owes a SEVERITY SPLIT, not just a widened read
+(#6687).** `vlan-id-list` is now read with `multiLeafAuthoredValues` and every
+authored id runs the parse and range checks, so `[ 10 99999 ]` is rejected
+exactly as `vlan-id-list 99999` always was. But the values it now examines are
+values the OLD gate accepted: a config carrying a bad id in slot 1 committed
+clean, persisted, and would refuse to BOOT after the upgrade if the widened
+check kept its old severity on every path. So the check is split the way every
+other AST-level gate in this compiler is split (`compiler_opts.go`): strict
+(commit / commit-check) hard-rejects naming the value, lenient (tolerant load /
+peer-sync, `lenientBridgeDomainVlanID`) warns and drops that one id. The
+leniently-loaded config therefore carries exactly the VLAN set master compiled —
+the bad id was never installed on either build — and only the warning is new.
+The check stays in the compiler rather than moving to a typed `validator` in
+`setSchema` for a second reason: a strict schema gate firing FIRST would mask
+whether the compiler's own loop ever widened, so the regression test could not
+tell a fix from a no-op.
 
 **And an escape can become live when someone else fixes the value-drop.** The
 archive-sites escape is inert TODAY only because the value is also dropped. A
@@ -1075,8 +1092,9 @@ empty command, so an empty entry never reaches a checker and the remediation
 batch is unaffected by it. Its entry is kept because the compiled list is
 observable in its own right (below), not because anything gates on it.
 
-**SIX leaf families, SEVEN read sites — the category table above has FOUR rows
-and is not the inventory.** The four rows classify EMPTY-VALUE semantics, and
+**SIX leaf families, SEVEN read sites AT #6673 — the category table above has
+FOUR rows and is not the inventory.** (The table is appended to as later fixes
+land; row 8 is #6687's, and the counts in this sentence describe #6673 only.) The four rows classify EMPTY-VALUE semantics, and
 its `Reader` column names four reader mechanisms because two of them serve two
 leaves each. Counting rows (or readers) undercounts what this change had to
 widen. The inventory is:
@@ -1090,6 +1108,7 @@ widen. The inventory is:
 | 5 | `security nat proxy-arp … address` | `compiler_nat_source.go` `compileNAT` | `proxyARPAddressValues` | yes |
 | 6 | `event-options … attributes-match` | `compiler_services.go` `eventAttributesMatchExprs` | `eventMultiWordLeafValues` (tail + each child) | yes |
 | 7 | `event-options … then change-configuration commands` | `compiler_services.go` `eventChangeConfigCommands` | `eventMultiWordLeafValues` (tail + each child) | yes |
+| 8 | `bridge-domains <bd> vlan-id-list` | `compiler_services.go` `compileBridgeDomains` | `multiLeafAuthoredValues` | yes (added by #6687, after this inventory was written) |
 
 Family 3 has TWO read sites, and that is the whole reason the count differs from
 the family count: the `flag` leaf is read once by the compiler and once by the
@@ -1106,7 +1125,6 @@ bundled, because each needs its own value-domain gate widened in the same change
 |---|---|---|
 | CoS DSCP / IEEE classifier `code-points` | reads tail, never `Children` | #6697 |
 | `system archival archive-sites` (+ four sibling system leaves) | reads `Children` and only slot 1 of the tail | #6692 |
-| `bridge-domains vlan-id-list` | validated at slot 0 only | #6687 |
 | nested-bracket tails, proxy-ARP after a range, repeated `commands` leaves | assorted value drops | #6714 |
 
 ### The list above is now enforced by a gate, not maintained by hand

--- a/pkg/config/compiler_bridgedomain_vlanlist_6687_test.go
+++ b/pkg/config/compiler_bridgedomain_vlanlist_6687_test.go
@@ -1,0 +1,285 @@
+package config
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// #6687 — `bridge-domains <bd> vlan-id-list` was read and VALIDATED at slot 0
+// only, so every value past the first was both dropped from the compiled
+// config and never seen by the leaf's only validator. `[ 10 99999 ]` and
+// `[ 10 notanumber ]` committed CLEAN while the identical bad value in slot 0
+// was correctly rejected.
+//
+// These tests pin three separate properties, because a fix can land for one
+// and miss the others:
+//
+//  1. VALUE PARITY. All five authorable spellings compile the SAME id list.
+//  2. GATE COVERAGE. A bad value in slot 1 is rejected by the SAME validator
+//     that rejects it in slot 0 — asserted on the validator's own message, not
+//     on `err != nil`, so a different gate firing cannot be mistaken for this
+//     one having run.
+//  3. SEVERITY SPLIT. The tolerant load / peer-sync path warns and drops the
+//     one bad value instead of refusing the whole config, so a config that
+//     committed clean under the narrower gate still boots after upgrade.
+
+// bdCompile compiles a hierarchical (brace) config on the requested path.
+func bdCompile(t *testing.T, body string, lenient bool) (*Config, error) {
+	t.Helper()
+	p := NewParser(body)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse %q: %v", body, errs)
+	}
+	if lenient {
+		return CompileConfigLenient(tree)
+	}
+	return CompileConfig(tree)
+}
+
+// bdCompileSet compiles a flat-set config on the requested path, going through
+// ParseSetCommand + SetPath exactly as `set` / `load set` / display-set replay
+// does. NewParser must NOT be used for set syntax: it treats newlines as
+// whitespace and merges every line into one node.
+func bdCompileSet(t *testing.T, lenient bool, cmds ...string) (*Config, error) {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, c := range cmds {
+		path, err := ParseSetCommand(c)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", c, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", c, err)
+		}
+	}
+	if lenient {
+		return CompileConfigLenient(tree)
+	}
+	return CompileConfig(tree)
+}
+
+func bdVlanIDs(t *testing.T, cfg *Config, name string) []int {
+	t.Helper()
+	for _, bd := range cfg.BridgeDomains {
+		if bd.Name == name {
+			return bd.VlanIDs
+		}
+	}
+	t.Fatalf("bridge-domain %q not compiled (have %d domains)", name, len(cfg.BridgeDomains))
+	return nil
+}
+
+func bdEqual(got []int, want ...int) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestBridgeDomainVlanIDListEverySpelling is property (1). Before #6687 the
+// three BRACKET/BLOCK spellings compiled [10] while the two REPEATED ones
+// compiled [10 20] — a shape-dependent drop on the leaf whose idiomatic Junos
+// spelling is the bracketed list, i.e. the drop hit the common path.
+func TestBridgeDomainVlanIDListEverySpelling(t *testing.T) {
+	t.Run("A-hier-bracket", func(t *testing.T) {
+		cfg, err := bdCompile(t, `bridge-domains { bd1 { vlan-id-list [ 10 20 ]; } }`, false)
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		if got := bdVlanIDs(t, cfg, "bd1"); !bdEqual(got, 10, 20) {
+			t.Fatalf("VlanIDs = %v, want [10 20]", got)
+		}
+	})
+	t.Run("B-hier-block", func(t *testing.T) {
+		cfg, err := bdCompile(t, `bridge-domains { bd1 { vlan-id-list { 10; 20; } } }`, false)
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		if got := bdVlanIDs(t, cfg, "bd1"); !bdEqual(got, 10, 20) {
+			t.Fatalf("VlanIDs = %v, want [10 20]", got)
+		}
+	})
+	t.Run("C-hier-repeat", func(t *testing.T) {
+		cfg, err := bdCompile(t, `bridge-domains { bd1 { vlan-id-list 10; vlan-id-list 20; } }`, false)
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		if got := bdVlanIDs(t, cfg, "bd1"); !bdEqual(got, 10, 20) {
+			t.Fatalf("VlanIDs = %v, want [10 20]", got)
+		}
+	})
+	t.Run("D-set-bracket", func(t *testing.T) {
+		cfg, err := bdCompileSet(t, false, `set bridge-domains bd1 vlan-id-list [ 10 20 ]`)
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		if got := bdVlanIDs(t, cfg, "bd1"); !bdEqual(got, 10, 20) {
+			t.Fatalf("VlanIDs = %v, want [10 20]", got)
+		}
+	})
+	t.Run("E-set-repeat", func(t *testing.T) {
+		cfg, err := bdCompileSet(t, false,
+			`set bridge-domains bd1 vlan-id-list 10`,
+			`set bridge-domains bd1 vlan-id-list 20`)
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		if got := bdVlanIDs(t, cfg, "bd1"); !bdEqual(got, 10, 20) {
+			t.Fatalf("VlanIDs = %v, want [10 20]", got)
+		}
+	})
+	t.Run("three-values-keeps-the-tail", func(t *testing.T) {
+		cfg, err := bdCompile(t, `bridge-domains { bd1 { vlan-id-list [ 10 20 30 ]; } }`, false)
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		if got := bdVlanIDs(t, cfg, "bd1"); !bdEqual(got, 10, 20, 30) {
+			t.Fatalf("VlanIDs = %v, want [10 20 30]", got)
+		}
+	})
+}
+
+// TestBridgeDomainVlanIDListValidatesEverySlot is property (2). Each case
+// asserts THIS validator's own wording. A bare err != nil would pass even if
+// the widened check never ran and some other gate rejected the config.
+func TestBridgeDomainVlanIDListValidatesEverySlot(t *testing.T) {
+	const rangeMsg = "vlan-id 99999 out of range (1-4094)"
+	const parseMsg = `invalid vlan-id-list value "notanumber"`
+
+	cases := []struct {
+		name string
+		set  []string // flat-set spelling, when non-nil
+		body string   // hierarchical spelling, when set is nil
+		want string
+	}{
+		// Slot 0 — the case that was ALREADY rejected. It is here so a
+		// regression that disables the gate entirely cannot look like a fix.
+		{name: "range/slot0/hier-bracket", body: `bridge-domains { bd1 { vlan-id-list [ 99999 10 ]; } }`, want: rangeMsg},
+		{name: "parse/slot0/hier-bracket", body: `bridge-domains { bd1 { vlan-id-list [ notanumber 10 ]; } }`, want: parseMsg},
+
+		// Slot 1 — the #6687 escape, in every spelling that carries a tail.
+		{name: "range/slot1/hier-bracket", body: `bridge-domains { bd1 { vlan-id-list [ 10 99999 ]; } }`, want: rangeMsg},
+		{name: "range/slot1/hier-block", body: `bridge-domains { bd1 { vlan-id-list { 10; 99999; } } }`, want: rangeMsg},
+		{name: "range/slot1/hier-repeat", body: `bridge-domains { bd1 { vlan-id-list 10; vlan-id-list 99999; } }`, want: rangeMsg},
+		{name: "parse/slot1/hier-bracket", body: `bridge-domains { bd1 { vlan-id-list [ 10 notanumber ]; } }`, want: parseMsg},
+		{name: "parse/slot1/hier-block", body: `bridge-domains { bd1 { vlan-id-list { 10; notanumber; } } }`, want: parseMsg},
+		{name: "range/slot2/hier-bracket", body: `bridge-domains { bd1 { vlan-id-list [ 10 20 99999 ]; } }`, want: rangeMsg},
+		{name: "range/slot1/set-bracket", set: []string{`set bridge-domains bd1 vlan-id-list [ 10 99999 ]`}, want: rangeMsg},
+		{name: "parse/slot1/set-bracket", set: []string{`set bridge-domains bd1 vlan-id-list [ 10 notanumber ]`}, want: parseMsg},
+		{name: "range/slot1/set-repeat", set: []string{
+			`set bridge-domains bd1 vlan-id-list 10`,
+			`set bridge-domains bd1 vlan-id-list 99999`,
+		}, want: rangeMsg},
+
+		// The zero boundary: 0 is out of range at both ends of the list.
+		{name: "range/zero/slot1", body: `bridge-domains { bd1 { vlan-id-list [ 10 0 ]; } }`, want: "vlan-id 0 out of range (1-4094)"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			if tc.set != nil {
+				_, err = bdCompileSet(t, false, tc.set...)
+			} else {
+				_, err = bdCompile(t, tc.body, false)
+			}
+			if err == nil {
+				t.Fatalf("commit accepted an invalid vlan-id-list; want rejection containing %q", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("rejected by the WRONG gate:\n  got  : %v\n  want a message containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// The non-numeric rejection must still WRAP strconv's error, so a caller can
+// classify it with errors.Is rather than by string matching. #6687 moved the
+// check inside a loop; %w had to survive that move.
+func TestBridgeDomainVlanIDListWrapsStrconvError(t *testing.T) {
+	_, err := bdCompile(t, `bridge-domains { bd1 { vlan-id-list [ 10 notanumber ]; } }`, false)
+	if err == nil {
+		t.Fatal("expected a rejection")
+	}
+	if !errors.Is(err, strconv.ErrSyntax) {
+		t.Fatalf("error does not wrap strconv.ErrSyntax: %v", err)
+	}
+}
+
+// TestBridgeDomainVlanIDListLenientDropsAndWarns is property (3). The tolerant
+// load / peer-sync path must not turn a config the OLD gate accepted into a
+// boot failure: it keeps the good ids, drops the bad one, and says so.
+func TestBridgeDomainVlanIDListLenientDropsAndWarns(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    string
+		want    []int
+		warnSub string
+	}{
+		{
+			name:    "range-in-slot1",
+			body:    `bridge-domains { bd1 { vlan-id-list [ 10 99999 20 ]; } }`,
+			want:    []int{10, 20},
+			warnSub: "vlan-id 99999 out of range (1-4094)",
+		},
+		{
+			name:    "parse-in-slot1",
+			body:    `bridge-domains { bd1 { vlan-id-list [ 10 notanumber ]; } }`,
+			want:    []int{10},
+			warnSub: `invalid vlan-id-list value "notanumber"`,
+		},
+		{
+			// Slot 0 too: the tolerant path is uniform across slots, which is
+			// the point — a persisted config must boot regardless of WHERE the
+			// operator put the bad id.
+			name:    "range-in-slot0",
+			body:    `bridge-domains { bd1 { vlan-id-list [ 99999 10 ]; } }`,
+			want:    []int{10},
+			warnSub: "vlan-id 99999 out of range (1-4094)",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := bdCompile(t, tc.body, true)
+			if err != nil {
+				t.Fatalf("tolerant load must not reject a persisted config: %v", err)
+			}
+			if got := bdVlanIDs(t, cfg, "bd1"); !bdEqual(got, tc.want...) {
+				t.Fatalf("VlanIDs = %v, want %v", got, tc.want)
+			}
+			if !warningsContain(cfg.Warnings, tc.warnSub) {
+				t.Fatalf("no downgraded warning naming the dropped value.\n  want substring: %q\n  warnings: %v",
+					tc.warnSub, cfg.Warnings)
+			}
+			if !warningsContain(cfg.Warnings, "ignored: value dropped") {
+				t.Fatalf("warning must say the value was dropped, got: %v", cfg.Warnings)
+			}
+		})
+	}
+}
+
+// An empty value slot is not an id. `vlan-id-list;` carries no value at all and
+// multiLeafAuthoredValues represents that as one EMPTY string — feeding it to
+// strconv.Atoi would manufacture a rejection for a statement master accepted.
+func TestBridgeDomainVlanIDListEmptyValueIsNotRejected(t *testing.T) {
+	for _, body := range []string{
+		`bridge-domains { bd1 { vlan-id-list; } }`,
+		`bridge-domains { bd1 { vlan-id-list [ ]; } }`,
+	} {
+		cfg, err := bdCompile(t, body, false)
+		if err != nil {
+			t.Fatalf("%s: compile: %v", body, err)
+		}
+		if got := bdVlanIDs(t, cfg, "bd1"); len(got) != 0 {
+			t.Fatalf("%s: VlanIDs = %v, want empty", body, got)
+		}
+	}
+}

--- a/pkg/config/compiler_dispatch.go
+++ b/pkg/config/compiler_dispatch.go
@@ -97,7 +97,8 @@ func compileSections(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 				return fmt.Errorf("snmp: %w", err)
 			}
 		case "bridge-domains":
-			if err := compileBridgeDomains(node, &cfg.BridgeDomains); err != nil {
+			if err := compileBridgeDomains(node, &cfg.BridgeDomains,
+				opts.lenientBridgeDomainVlanID, &cfg.Warnings); err != nil {
 				return fmt.Errorf("bridge-domains: %w", err)
 			}
 		}

--- a/pkg/config/compiler_opts.go
+++ b/pkg/config/compiler_opts.go
@@ -2189,6 +2189,24 @@ type compileOpts struct {
 	// statement. See foldLoginClassDenyToRepairableFloor.
 	lenientLoginClassDeny bool
 
+	// lenientBridgeDomainVlanID (#6687) downgrades the bridge-domain
+	// `vlan-id-list` parse / range gate from a hard compile error to a
+	// cfg.Warnings entry plus a dropped value. The strict commit /
+	// commit-check path rejects a non-numeric or out-of-range (not 1-4094)
+	// id in ANY slot of the list; before #6687 only slot 0 was examined, so
+	// `vlan-id-list [ 10 99999 ]` committed clean and compiled as VLAN 10.
+	// Widening the read without this flag would make a config that the old
+	// gate ACCEPTED refuse to boot after an upgrade, which is precisely what
+	// the tolerant load / peer-sync path exists to prevent (#1960). The
+	// dropped value was never installed under the old compiler either, so a
+	// leniently-loaded config carries exactly the VLAN set master compiled —
+	// only the warning is new. This is a per-value decision inside
+	// compileBridgeDomains rather than a declarative typed leaf, so the check
+	// does NOT live in SchemaValidate; putting it there would also mask the
+	// tail, since a strict schema gate firing first hides whether the
+	// compiler's own check ever ran. Same doctrine as lenientSNMPTrapGroup.
+	lenientBridgeDomainVlanID bool
+
 	// nodeAware / stampNodeID (#4329) carry the runtime cluster node
 	// identity (from /etc/xpf/node-id, or `-node-id` on `xpfd
 	// check-config`) into compileExpanded so it can be stamped onto the
@@ -2312,6 +2330,7 @@ func lenientCompileOpts() compileOpts {
 		lenientBGPNeighborPeerAS:               true,
 		lenientRouterID:                        true,
 		lenientSNMPTrapGroup:                   true,
+		lenientBridgeDomainVlanID:              true,
 		lenientDDNSDuration:                    true,
 		lenientPolicyTerminalAction:            true,
 		lenientPolicyLogAction:                 true,

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -2115,8 +2115,17 @@ func compileEventOptions(node *Node, policies *[]*EventPolicy) error {
 	return nil
 }
 
-// compileBridgeDomains parses the bridge-domains AST section into typed BridgeDomainConfig structs.
-func compileBridgeDomains(node *Node, bds *[]*BridgeDomainConfig) error {
+// compileBridgeDomains parses the bridge-domains AST section into typed
+// BridgeDomainConfig structs.
+//
+// #6687: `vlan-id-list` is the leaf's ONLY validator (setSchema declares none
+// for it), and it is read for EVERY authored value rather than slot 0 alone.
+// Strict (commit / commit-check) hard-rejects a non-numeric or out-of-range id
+// in any slot; lenient (tolerant load / peer-sync) warns and skips that one
+// value so a config already persisted under the narrower gate still boots.
+// See the value-reading comment below for why both halves had to change
+// together.
+func compileBridgeDomains(node *Node, bds *[]*BridgeDomainConfig, lenient bool, warnings *[]string) error {
 	for _, child := range node.Children {
 		if child.IsLeaf {
 			continue
@@ -2126,27 +2135,55 @@ func compileBridgeDomains(node *Node, bds *[]*BridgeDomainConfig) error {
 			Name: bdName,
 		}
 
-		// Collect VLAN IDs — multi-value leaf: each "vlan-id-list" child is a separate leaf
-		// #6687 / #6659: nodeVal takes slot 0 only, and the range/parse checks
-		// below are the leaf's ONLY validator (it declares none in setSchema),
-		// so every value past the first is a GATE ESCAPE and not merely a
-		// value-drop: `[ 100 99999 ]` and `{ 100; 99999; }` both commit CLEAN
-		// where a bare `vlan-id-list 99999` is REJECTED "out of range
-		// (1-4094)". Verified through configstore.CheckText. A widened read
-		// MUST run these two checks over every authored value.
+		// Collect VLAN IDs — `vlan-id-list` is a `multi: true` value leaf, so
+		// one node can carry several ids and a bridge domain can carry several
+		// nodes. The range/parse checks here are the leaf's ONLY validator (it
+		// declares none in setSchema), so reading slot 0 alone was both a value
+		// DROP and a GATE ESCAPE (#6687 / #6659): `[ 10 99999 ]`,
+		// `{ 10; 99999; }` and `set ... vlan-id-list [ 10 99999 ]` all committed
+		// CLEAN and compiled VlanIDs=[10], while the identical bad value in slot
+		// 0 was correctly REJECTED "out of range (1-4094)". Measured across all
+		// five spellings; the bracketed list is the idiomatic Junos one, so the
+		// unvalidated path was the COMMON path.
+		//
+		// multiLeafAuthoredValues is the documented reader for a `multi: true`
+		// leaf: it accumulates the node's own Keys[1:] (hierarchical bracket,
+		// and — because the multi flag makes SetPath absorb the tail — the
+		// flat-set bracket too) AND one value per child (hierarchical block,
+		// flat-set repeated). It keeps empty tokens, which a value list must
+		// skip: `vlan-id-list;` carries no id at all and is not a parse error.
+		//
+		// Widening the READ without widening the TOLERANCE would turn a config
+		// that committed clean under the old gate into a boot failure after
+		// upgrade, so the severity is now split the same way every other
+		// AST-level gate in this compiler splits it (see compiler_opts.go):
+		// strict rejects, lenient warns and skips the offending value.
 		for _, vlanNode := range child.FindChildren("vlan-id-list") {
-			valStr := nodeVal(vlanNode)
-			if valStr == "" {
-				continue
+			for _, valStr := range multiLeafAuthoredValues(vlanNode) {
+				if valStr == "" {
+					continue
+				}
+				v, err := strconv.Atoi(valStr)
+				if err != nil {
+					if lenient {
+						*warnings = append(*warnings, fmt.Sprintf(
+							"bridge-domain %s: invalid vlan-id-list value %q: %v (ignored: value dropped)",
+							bdName, valStr, err))
+						continue
+					}
+					return fmt.Errorf("bridge-domain %s: invalid vlan-id-list value %q: %w", bdName, valStr, err)
+				}
+				if v < 1 || v > 4094 {
+					if lenient {
+						*warnings = append(*warnings, fmt.Sprintf(
+							"bridge-domain %s: vlan-id %d out of range (1-4094) (ignored: value dropped)",
+							bdName, v))
+						continue
+					}
+					return fmt.Errorf("bridge-domain %s: vlan-id %d out of range (1-4094)", bdName, v)
+				}
+				bd.VlanIDs = append(bd.VlanIDs, v)
 			}
-			v, err := strconv.Atoi(valStr)
-			if err != nil {
-				return fmt.Errorf("bridge-domain %s: invalid vlan-id-list value %q: %w", bdName, valStr, err)
-			}
-			if v < 1 || v > 4094 {
-				return fmt.Errorf("bridge-domain %s: vlan-id %d out of range (1-4094)", bdName, v)
-			}
-			bd.VlanIDs = append(bd.VlanIDs, v)
 		}
 
 		// Routing interface (e.g. "irb.0")

--- a/pkg/config/schema_spelling_differential_gate_test.go
+++ b/pkg/config/schema_spelling_differential_gate_test.go
@@ -145,9 +145,6 @@ var knownSpellingInconsistencies = map[string]string{
 	"class-of-service rewrite-rules dscp <*> forwarding-class <*> loss-priority <*> code-points":          "#6697",
 	"class-of-service rewrite-rules ieee-802.1 <*> forwarding-class <*> loss-priority <*> code-points":    "#6697",
 
-	// #6687 — vlan-id-list validated/read at slot 0 only.
-	"bridge-domains <*> vlan-id-list": "#6687",
-
 	// #6695 — RA dns-server-address drops every RDNSS server past the first.
 	"protocols router-advertisement interface <*> dns-server-address": "#6695",
 


### PR DESCRIPTION
## The defect

`bridge-domains <bd> vlan-id-list` was read with `nodeVal`, which selects the
first authored value and nothing else. The parse and range checks that follow
that read are the leaf's **only** validator — `setSchema` declares no typed
validator for it — so reading slot 0 alone was not merely a value drop, it was
a **gate escape**:

| authored | committed | compiled |
|---|---|---|
| `vlan-id-list [ 10 99999 ]` | **CLEAN** | `VlanIDs=[10]` |
| `vlan-id-list [ 10 notanumber ]` | **CLEAN** | `VlanIDs=[10]` |
| `vlan-id-list 99999` | REJECTED *"out of range (1-4094)"* | — |

The bracketed list is the idiomatic Junos spelling of this leaf, so the
unvalidated path was the common path.

## Measured, at 22e17c2de, `[ 10 20 ]` in all five spellings

| spelling | compiled `VlanIDs` |
|---|---|
| A hierarchical bracket `vlan-id-list [ 10 20 ];` | **`[10]`** |
| B hierarchical block `vlan-id-list { 10; 20; }` | **`[10]`** |
| C hierarchical repeated | `[10 20]` |
| D flat-set bracket `set … vlan-id-list [ 10 20 ]` | **`[10]`** |
| E flat-set repeated | `[10 20]` |

The leaf is `multi: true`, so the flat-set bracket list is absorbed onto the
node's own `Keys` and the hierarchical block puts one value per child. `nodeVal`
reads neither the tail past slot 1 nor any sibling past the first.

## The fix

The read goes through `multiLeafAuthoredValues`, the documented reader for a
`multi: true` leaf (`Keys[1:]` **and** one value per child). Empty tokens are
skipped by this caller, because `vlan-id-list;` carries no id and is not a parse
error.

**Severity split.** Widening the READ without widening the TOLERANCE would turn
a config the old gate ACCEPTED into a boot failure after upgrade: the bad id is
already persisted in the config DB and the tolerant load path would refuse the
whole config. So the check is split the way every other AST-level gate in this
compiler is split — strict (commit / commit-check) hard-rejects naming the
value, lenient (tolerant load / peer-sync, the new `lenientBridgeDomainVlanID`)
warns and drops that one id. A leniently-loaded config carries exactly the VLAN
set master compiled; only the warning is new.

The check stays in the compiler rather than moving to a typed `validator` in
`setSchema`: a strict schema gate firing first would mask whether the compiler's
own loop ever widened, which is the mask the issue's acceptance criteria call
out.

## Validation

`pkg/config/compiler_bridgedomain_vlanlist_6687_test.go` pins three properties
separately, because a fix can land for one and miss the others: value parity
across all five spellings; gate coverage at slot 0, 1 and 2 asserted on **this**
validator's own message (a bare `err != nil` cannot tell which gate fired); and
the severity split on the tolerant path. It also pins that the strict rejection
still wraps `strconv.ErrSyntax` (`errors.Is`) — the move into a loop had to
preserve `%w`.

**The #2419 spelling-differential gate's allowlist row for this site is removed
in this PR.** A stale row is a hard failure in that gate, so the gate itself
proves the fix landed.

### Mutation proof (each mutation is ONE line; `go vet` clean each time, so
every red is an ASSERTION red, not a build break)

| mutation | `go vet` | targeted tests | what red |
|---|---|---|---|
| `multiLeafAuthoredValues(vlanNode)` → `…[:1]` (exact pre-fix read) | rc=0 | **rc=1**, 19 failures | A/B/D spellings compile `[10]`; every slot-1/slot-2 validation case accepts; lenient cases lose their warning |
| `lenientBridgeDomainVlanID: true` → `false` | rc=0 | **rc=1** | `LenientDropsAndWarns/*`: *"tolerant load must not reject a persisted config"* |
| dispatch passes `true` instead of `opts.lenientBridgeDomainVlanID` (strict becomes tolerant) | rc=0 | **rc=1** | `ValidatesEverySlot/*`: *"commit accepted an invalid vlan-id-list"* |

Under mutation 1 the gate itself also reds, with the allowlist row removed:

```
#2419 class: shape-dependent drop
  siteKey   : "bridge-domains <*> vlan-id-list"
  spellings : A=drop B=drop C=keep D=drop E=keep
```

Note the two REPEATED spellings are controls: they do not red under mutation 1,
because each repeat is its own node whose slot 0 was always validated.

### Suites

- `go test -count=1 -run SchemaSpelling ./pkg/config/` — **green** with the row removed.
- `go test -count=1 ./pkg/config/... ./pkg/configstore/...` — green.
- `go vet ./pkg/config/` clean, `go build ./...` clean.

**No smoke owed.** Go-only, entirely within `pkg/config`. Nothing reaches the
Rust `userspace-dp` helper or the AF_XDP shim and no compiled dataplane artifact
moves.

Closes #6687