### PR TITLE
config: read every key of every child on two plain value lists

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -993,6 +993,59 @@ also ARMS the existing fab0/fab1 shared-member overlap check in
 bracket-authored fabrics; that check emits a warning, not a rejection, so no
 config that committed before is rejected now.
 
+**That leaf shape is a PREDICATE, not three special cases (#7126).** The
+discriminator is mechanical and worth stating as a rule, because the sites it
+catches all LOOK compliant:
+
+> A leaf declared `children: nil` and **NOT** `multi: true` in `setSchema`, read
+> by a compiler that takes `Keys[0]` / `Name()` of each child, drops every value
+> past the first when the operator authors a bracket list through the flat-set
+> path (`set`, `load set`, the CLI).
+
+`SetPath` files a bracket list differently depending on the flag:
+
+| schema | `set … <leaf> [ v1 v2 ]` becomes |
+|---|---|
+| `multi: true, children: nil` | `Keys=["<leaf>","v1","v2"]`, no children — the tail absorber runs |
+| **`multi: false, children: nil`** | `Keys=["<leaf>"]` with **ONE child** `Keys=["v1","v2"]` |
+
+In the second row every value sits on one child's Keys, so `child.Name()`
+returns `v1` and discards the rest — which is why a reader can obey the
+"`Keys[1:]` AND `Children`" rule above to the letter and still drop. **Reading
+`Children` is not the same as reading every KEY of each child.** The
+hierarchical parser is unaffected (it puts the list on the node's own tail), so
+these sites survive every brace-authored test and bite only the `set` path.
+
+`fabricMemberValues` was the first instance; #7126 found two more —
+`routing-options rib-groups <g> import-rib` and `event-options policy <p>
+events` — so the body now lives once, in `ast.go` as **`plainListValues`**, and
+`fabricMemberValues` is a wrapper that keeps its leaf-specific argument attached
+to its leaf. A divergence between the three would always be a bug, so there is
+one implementation rather than three copies. Use it only where every non-empty
+token below the node is a value: NOT for a leaf with per-value option keywords
+(`ntp server <ip> prefer`, `source-prefix-list <name> except`, `route <prefix>
+discard` — promoting a modifier into the value list is the #6690 hazard), and
+NOT where an EMPTY authored value must survive (`multiLeafAuthoredValues`).
+
+Both new sites also needed `FindChildren`, not `FindChild`: repeated
+hierarchical statements land as SIBLING nodes, and reading only the first drops
+that spelling too even where the flat-set repeated spelling — the same
+configuration, filed as CHILDREN of one node — accumulated correctly. And the
+`import-rib` drop was a GATE ESCAPE as well as a value drop: the #2226
+cross-reference check iterates `ImportRibs`, so an undefined rib named in slot 1
+committed CLEAN while the identical name in slot 0 was rejected. The newly
+visible entries land on #2226's existing tolerant-path downgrade
+(`lenientRibGroupRefs`), so no already-persisted config is turned into a boot
+failure.
+
+The two `import-rib` read sites were byte-identical duplicates in two arms of
+`compileRoutingOptions`, which is the hazard #7126 names: a fix landing in one
+arm leaves the other spelling broken and nothing says so. They now share
+`compileRibGroup`. (Measured: the named-instance arm is INERT at HEAD — it
+selects with `FindChildren("")`, which matches only a child whose first key is
+the empty string, and no parse produces one. The duplication was latent, which
+is precisely why no test could have caught a divergence.)
+
 **Widening a multi-value READ requires widening its VALIDATOR in the same
 change (#6659).** Adopting the accumulating reader at a site changes what a
 malformed value DOES. Before, a bad value in slot 2 was discarded at compile and
@@ -1125,10 +1178,11 @@ dropped(spelling) := compile(spelling, [v1]) == compile(spelling, [v1 v2])
 **Why a gate and not a lint.** There is no single correct reader to lint FOR:
 this package now has at least six accumulating readers, one of which
 (`ntpServerValues`) must additionally skip per-value option KEYWORDS. A rule
-matching "reads `Keys[1]`" would flag compliant code, and would miss the #7126
-sites entirely — both of those read `Keys[1:]` AND `Children` exactly as this
-document instructs, and still drop, because reading `Children` is not the same as
-reading every KEY of each child. A differential asks whether the compiler
+matching "reads `Keys[1]`" would flag compliant code, and would have missed the
+#7126 sites entirely — both of those read `Keys[1:]` AND `Children` exactly as
+this document instructs, and still dropped, because reading `Children` is not the
+same as reading every KEY of each child (both are fixed and their allowlist rows
+removed; the predicate is stated above). A differential asks whether the compiler
 disagrees with ITSELF, which is the actual defect.
 
 **When the gate fails, there are exactly two correct responses**, and picking the

--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -362,6 +362,76 @@ func multiLeafAuthoredValues(n *Node) []string {
 	return vals
 }
 
+// plainListValues returns every value carried by a PLAIN VALUE-LIST leaf — one
+// whose members are bare tokens with no per-value modifier keyword — across all
+// five spellings the Junos grammar admits.
+//
+// The values reach the compiler on the node's own Keys, on its children's Keys,
+// or both, depending on how the config was authored (#6694, #7126 — the #2419
+// multi-value-leaf class):
+//
+//   - hierarchical bracket    `leaf [ a b ];`   → Keys=["leaf","a","b"], no children
+//   - hierarchical block      `leaf { a; b; }`  → Keys=["leaf"], one leaf child per value
+//   - hierarchical single     `leaf a;`         → Keys=["leaf","a"], no children
+//   - flat-set repeated       `set … leaf a` ×2 → Keys=["leaf"], one leaf child per value
+//   - flat-set bracket        `set … leaf [ a b ]`
+//     → Keys=["leaf"], ONE child whose Keys hold EVERY value
+//
+// THE LAST SHAPE IS WHY firewallMatchValues IS NOT ENOUGH, and it is the whole
+// of #7126: firewallMatchValues reads Keys[1:] AND Children — exactly what
+// CLAUDE.md and docs/config-schema.md prescribe — yet still keeps only the
+// first value here, because it takes Keys[0] of each child. Reading Children is
+// not the same as reading every KEY of each child. The shape is produced by
+// SetPath for any leaf setSchema does NOT mark `multi: true`: a multi leaf
+// absorbs the bracket tail onto the node's own Keys (which is why
+// multiLeafAuthoredValues suffices there), a non-multi leaf files it under one
+// child. The hierarchical parser never produces it, which is why these sites
+// survive every brace-authored test and bite only the `set` / `load set` / CLI
+// path.
+//
+// WHEN THIS IS THE WRONG READER. It takes EVERY non-empty token below the node,
+// so it must only be used where every such token is a value:
+//
+//   - NOT for a leaf with per-value option keywords — `ntp server <ip> prefer`,
+//     `source-prefix-list <name> except`, `route <prefix> discard`. Promoting a
+//     modifier into the value list is the hazard #6690 had to avoid; those
+//     leaves keep their own readers.
+//   - NOT for a leaf that must preserve an EMPTY authored value, where a scalar
+//     selects one value and a list only validates it (multiLeafAuthoredValues,
+//     see its comment) — empty tokens are dropped here.
+//
+// The descent reaches grandchildren, which no authorable spelling produces (all
+// five above are depth 1, verified against the parsed ASTs). It is inherited
+// unchanged from #6694's fabricMemberValues rather than narrowed here, so
+// single-sourcing the three call sites changes nothing for the fabric leaf: a
+// hand-written malformed nesting such as `leaf { a { b; } }` contributes `b`
+// today and still does.
+func plainListValues(n *Node) []string {
+	if n == nil {
+		return nil
+	}
+	var vals []string
+	add := func(tokens []string) {
+		for _, tok := range tokens {
+			if tok != "" {
+				vals = append(vals, tok)
+			}
+		}
+	}
+	if len(n.Keys) > 1 {
+		add(n.Keys[1:])
+	}
+	var walk func(*Node)
+	walk = func(parent *Node) {
+		for _, c := range parent.Children {
+			add(c.Keys)
+			walk(c)
+		}
+	}
+	walk(n)
+	return vals
+}
+
 // nonEmptyValues returns the entries of vals that are not empty. Cardinality
 // gates over a multiLeafAuthoredValues list use it so an empty selection slot is
 // not miscounted as an additional authored policy/prefix.

--- a/pkg/config/compiler_flatset_bracket_child_7126_test.go
+++ b/pkg/config/compiler_flatset_bracket_child_7126_test.go
@@ -1,0 +1,409 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #7126 — a compiler that reads a leaf's own Keys[1:] AND its Children, exactly
+// as CLAUDE.md and docs/config-schema.md prescribe, STILL drops every value past
+// the first when the operator authors a bracket list through the flat-set path.
+//
+// The discriminator is mechanical: for a leaf setSchema declares
+// `children: nil` and does NOT mark `multi: true`, SetPath files
+// `set <path> <leaf> [ v1 v2 ]` as ONE child whose Keys are ["v1","v2"], so
+// `child.Name()` (== Keys[0]) returns v1 and discards the rest. Reading
+// Children is not the same as reading every KEY of each child. The
+// hierarchical parser puts the list on the node's own tail instead, which is
+// why these sites survive every brace-authored test.
+//
+// Two sites, and neither is a value the operator can see go missing:
+//
+//   - routing-options rib-groups <g> import-rib — the inter-VRF route-leak
+//     membership list. A rib-group that should pull into two RIBs pulls into
+//     one, so the second table's leak never happens, with no diagnostic, while
+//     `show configuration` renders the full list back.
+//   - event-options policy <p> events — the trigger set of an event policy. A
+//     lost trigger means the automation never fires for part of what was
+//     authored.
+//
+// Every test below runs ALL FIVE spellings the Junos grammar admits, because a
+// fix that lands in one AST arm and not the other is exactly the failure this
+// class is made of.
+
+func ribImports(t *testing.T, cfg *Config, group string) []string {
+	t.Helper()
+	rg, ok := cfg.RoutingOptions.RibGroups[group]
+	if !ok {
+		t.Fatalf("rib-group %q not compiled (have %d groups)", group, len(cfg.RoutingOptions.RibGroups))
+	}
+	return rg.ImportRibs
+}
+
+func policyEvents(t *testing.T, cfg *Config, name string) []string {
+	t.Helper()
+	for _, ep := range cfg.EventOptions {
+		if ep.Name == name {
+			return ep.Events
+		}
+	}
+	t.Fatalf("event policy %q not compiled (have %d policies)", name, len(cfg.EventOptions))
+	return nil
+}
+
+func compileBraceStrict7126(t *testing.T, body string) *Config {
+	t.Helper()
+	p := NewParser(body)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse %q: %v", body, errs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile %q: %v", body, err)
+	}
+	return cfg
+}
+
+// compileSetStrict7126 goes through ParseSetCommand + SetPath, the path `set`,
+// `load set` and display-set replay take. NewParser must NOT be used for set
+// syntax: it treats newlines as whitespace and merges every line into one node,
+// which would hide exactly the shape this test exists for.
+func compileSetStrict7126(t *testing.T, cmds ...string) *Config {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, c := range cmds {
+		path, err := ParseSetCommand(c)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", c, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", c, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return cfg
+}
+
+func wantValues(t *testing.T, what string, got []string, want ...string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s = %v (len %d), want %v", what, got, len(got), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%s = %v, want %v", what, got, want)
+		}
+	}
+}
+
+// ribPreambleBrace / ribPreambleSet define the routing-instances whose ribs the
+// import-rib lists below name. `import-rib` targets are cross-checked at commit
+// (#2226), so a synthetic rib name would make every spelling fail for a reason
+// that has nothing to do with #7126.
+const ribPreambleBrace = `routing-instances { dmz-vr { instance-type virtual-router; } ` +
+	`tunnel-vr { instance-type virtual-router; } } `
+
+var ribPreambleSet = []string{
+	"set routing-instances dmz-vr instance-type virtual-router",
+	"set routing-instances tunnel-vr instance-type virtual-router",
+}
+
+func ribBrace(t *testing.T, body string) *Config {
+	t.Helper()
+	return compileBraceStrict7126(t, ribPreambleBrace+body)
+}
+
+func ribSet(t *testing.T, cmds ...string) *Config {
+	t.Helper()
+	return compileSetStrict7126(t, append(append([]string{}, ribPreambleSet...), cmds...)...)
+}
+
+// Site 1. The flat-set bracket (D) is the spelling that dropped; the other four
+// are controls that must not regress while D is fixed.
+func Test_7126_RibGroupImportRibEverySpelling(t *testing.T) {
+	t.Run("A-hier-bracket", func(t *testing.T) {
+		cfg := ribBrace(t, `routing-options { rib-groups { rg1 { import-rib [ dmz-vr.inet.0 inet.0 ]; } } }`)
+		wantValues(t, "ImportRibs", ribImports(t, cfg, "rg1"), "dmz-vr.inet.0", "inet.0")
+	})
+	t.Run("B-hier-block", func(t *testing.T) {
+		cfg := ribBrace(t, `routing-options { rib-groups { rg1 { import-rib { dmz-vr.inet.0; inet.0; } } } }`)
+		wantValues(t, "ImportRibs", ribImports(t, cfg, "rg1"), "dmz-vr.inet.0", "inet.0")
+	})
+	t.Run("C-hier-repeat", func(t *testing.T) {
+		// Repeated hierarchical statements land as SIBLING nodes. FindChild
+		// returned the first and stopped, so this spelling dropped inet.0 even
+		// though the flat-set repeated spelling below — the same configuration,
+		// filed as CHILDREN of ONE node — accumulated correctly.
+		cfg := ribBrace(t, `routing-options { rib-groups { rg1 { import-rib dmz-vr.inet.0; import-rib inet.0; } } }`)
+		wantValues(t, "ImportRibs", ribImports(t, cfg, "rg1"), "dmz-vr.inet.0", "inet.0")
+	})
+	t.Run("D-set-bracket", func(t *testing.T) {
+		cfg := ribSet(t, `set routing-options rib-groups rg1 import-rib [ dmz-vr.inet.0 inet.0 ]`)
+		wantValues(t, "ImportRibs", ribImports(t, cfg, "rg1"), "dmz-vr.inet.0", "inet.0")
+	})
+	t.Run("E-set-repeat", func(t *testing.T) {
+		cfg := ribSet(t,
+			`set routing-options rib-groups rg1 import-rib dmz-vr.inet.0`,
+			`set routing-options rib-groups rg1 import-rib inet.0`)
+		wantValues(t, "ImportRibs", ribImports(t, cfg, "rg1"), "dmz-vr.inet.0", "inet.0")
+	})
+	t.Run("D-set-bracket-three-ribs", func(t *testing.T) {
+		// Two values can be kept by an off-by-one that still truncates a
+		// longer list; three cannot.
+		cfg := ribSet(t, `set routing-options rib-groups rg1 import-rib [ dmz-vr.inet.0 tunnel-vr.inet.0 inet.0 ]`)
+		wantValues(t, "ImportRibs", ribImports(t, cfg, "rg1"), "dmz-vr.inet.0", "tunnel-vr.inet.0", "inet.0")
+	})
+	t.Run("D-set-bracket-unbracketed-tail", func(t *testing.T) {
+		// `set … import-rib a b` files the identical AST as the bracketed form
+		// (the lexer strips the brackets), so it must compile the same list.
+		cfg := ribSet(t, `set routing-options rib-groups rg1 import-rib dmz-vr.inet.0 inet.0`)
+		wantValues(t, "ImportRibs", ribImports(t, cfg, "rg1"), "dmz-vr.inet.0", "inet.0")
+	})
+}
+
+// The rib-group body is reached by TWO arms in compileRoutingOptions — a
+// named-instance arm and a direct-child arm — which held byte-identical
+// import-rib readers, and #7126 names the hazard that creates: a fix landing in
+// only one arm leaves the defect in the other. They now share compileRibGroup,
+// so this exercises that single body directly, over the five AST shapes, rather
+// than trusting that whichever arm a given config happens to take was the one
+// that got fixed.
+//
+// Measured at 22e17c2de: the named arm is INERT at HEAD. It selects with
+// rgNode.FindChildren(""), which matches only a child whose first key is the
+// empty string, and neither the brace parser nor SetPath produces one — the
+// direct-child arm does all the work. The duplication was therefore latent
+// rather than live, which is exactly why it survived: no test could have caught
+// a divergence between the two.
+func Test_7126_CompileRibGroupBodyEveryShape(t *testing.T) {
+	cases := []struct {
+		name string
+		node *Node
+		want []string
+	}{
+		{
+			name: "hierarchical bracket / packed — tail on the node's own Keys",
+			node: &Node{Keys: []string{"rg1"}, Children: []*Node{
+				{Keys: []string{"import-rib", "inet.0", "inet.2"}},
+			}},
+			want: []string{"inet.0", "inet.2"},
+		},
+		{
+			name: "hierarchical block / flat-set repeated — one child per rib",
+			node: &Node{Keys: []string{"rg1"}, Children: []*Node{
+				{Keys: []string{"import-rib"}, Children: []*Node{
+					{Keys: []string{"inet.0"}}, {Keys: []string{"inet.2"}},
+				}},
+			}},
+			want: []string{"inet.0", "inet.2"},
+		},
+		{
+			// THE #7126 SHAPE.
+			name: "flat-set bracket — every rib on ONE child's Keys",
+			node: &Node{Keys: []string{"rg1"}, Children: []*Node{
+				{Keys: []string{"import-rib"}, Children: []*Node{
+					{Keys: []string{"inet.0", "inet.2"}},
+				}},
+			}},
+			want: []string{"inet.0", "inet.2"},
+		},
+		{
+			name: "repeated hierarchical statements — SIBLING import-rib nodes",
+			node: &Node{Keys: []string{"rg1"}, Children: []*Node{
+				{Keys: []string{"import-rib", "inet.0"}},
+				{Keys: []string{"import-rib", "inet.2"}},
+			}},
+			want: []string{"inet.0", "inet.2"},
+		},
+		{
+			name: "no import-rib at all",
+			node: &Node{Keys: []string{"rg1"}},
+			want: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rg := compileRibGroup("rg1", tc.node)
+			if rg.Name != "rg1" {
+				t.Fatalf("Name = %q, want rg1", rg.Name)
+			}
+			wantValues(t, "ImportRibs", rg.ImportRibs, tc.want...)
+		})
+	}
+}
+
+// A truncated import-rib list is not only a value drop, it is a GATE ESCAPE:
+// the #2226 cross-reference check iterates ImportRibs, so a rib named in a slot
+// the compiler never read could never be rejected. Measured at 22e17c2de,
+// `import-rib [ inet.0 does-not-exist.inet.0 ]` committed CLEAN while the
+// identical name in slot 0 was rejected. Asserted on THAT validator's own
+// wording — a bare err != nil would pass if some other gate rejected the config
+// for an unrelated reason.
+func Test_7126_RibGroupImportRibTailReachesTheRefValidator(t *testing.T) {
+	for _, tc := range []struct{ name, cmd string }{
+		{"slot0", `set routing-options rib-groups rg1 import-rib [ does-not-exist.inet.0 inet.0 ]`},
+		{"slot1", `set routing-options rib-groups rg1 import-rib [ inet.0 does-not-exist.inet.0 ]`},
+		{"slot2", `set routing-options rib-groups rg1 import-rib [ inet.0 dmz-vr.inet.0 does-not-exist.inet.0 ]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := &ConfigTree{}
+			for _, c := range append(append([]string{}, ribPreambleSet...), tc.cmd) {
+				path, err := ParseSetCommand(c)
+				if err != nil {
+					t.Fatalf("ParseSetCommand(%q): %v", c, err)
+				}
+				if err := tree.SetPath(path); err != nil {
+					t.Fatalf("SetPath(%q): %v", c, err)
+				}
+			}
+			_, cerr := CompileConfig(tree)
+			if cerr == nil {
+				t.Fatal("commit accepted an undefined import-rib target")
+			}
+			if !strings.Contains(cerr.Error(), "undefined rib") {
+				t.Fatalf("rejected by the WRONG gate: %v", cerr)
+			}
+
+			// The widened read must not turn an already-persisted config into a
+			// boot failure. #2226 already downgrades this rejection on the
+			// tolerant load / peer-sync path (lenientRibGroupRefs); newly
+			// VISIBLE tail entries have to land on that same downgrade, not
+			// beside it.
+			cfg, lerr := CompileConfigLenient(tree)
+			if lerr != nil {
+				t.Fatalf("tolerant load must boot through an undefined import-rib: %v", lerr)
+			}
+			if !warningsContain(cfg.Warnings, "rib-group import-rib reference") {
+				t.Fatalf("expected a downgraded import-rib-reference warning, got: %v", cfg.Warnings)
+			}
+		})
+	}
+}
+
+// Site 2.
+func Test_7126_EventPolicyEventsEverySpelling(t *testing.T) {
+	t.Run("A-hier-bracket", func(t *testing.T) {
+		cfg := compileBraceStrict7126(t, `event-options { policy p1 { events [ ev_one ev_two ]; } }`)
+		wantValues(t, "Events", policyEvents(t, cfg, "p1"), "ev_one", "ev_two")
+	})
+	t.Run("B-hier-block", func(t *testing.T) {
+		cfg := compileBraceStrict7126(t, `event-options { policy p1 { events { ev_one; ev_two; } } }`)
+		wantValues(t, "Events", policyEvents(t, cfg, "p1"), "ev_one", "ev_two")
+	})
+	t.Run("C-hier-repeat", func(t *testing.T) {
+		cfg := compileBraceStrict7126(t, `event-options { policy p1 { events ev_one; events ev_two; } }`)
+		wantValues(t, "Events", policyEvents(t, cfg, "p1"), "ev_one", "ev_two")
+	})
+	t.Run("D-set-bracket", func(t *testing.T) {
+		cfg := compileSetStrict7126(t, `set event-options policy p1 events [ ev_one ev_two ]`)
+		wantValues(t, "Events", policyEvents(t, cfg, "p1"), "ev_one", "ev_two")
+	})
+	t.Run("E-set-repeat", func(t *testing.T) {
+		cfg := compileSetStrict7126(t,
+			`set event-options policy p1 events ev_one`,
+			`set event-options policy p1 events ev_two`)
+		wantValues(t, "Events", policyEvents(t, cfg, "p1"), "ev_one", "ev_two")
+	})
+	t.Run("D-set-bracket-three-events", func(t *testing.T) {
+		cfg := compileSetStrict7126(t, `set event-options policy p1 events [ ev_one ev_two ev_three ]`)
+		wantValues(t, "Events", policyEvents(t, cfg, "p1"), "ev_one", "ev_two", "ev_three")
+	})
+	t.Run("D-set-bracket-with-a-then-clause", func(t *testing.T) {
+		// The whole point of the trigger set is the remediation it gates, so
+		// pin the drop on a policy that actually has one.
+		cfg := compileSetStrict7126(t,
+			`set event-options policy p1 events [ ev_one ev_two ]`,
+			`set event-options policy p1 then change-configuration commands "set system host-name recovered"`)
+		wantValues(t, "Events", policyEvents(t, cfg, "p1"), "ev_one", "ev_two")
+		ep := cfg.EventOptions[0]
+		if len(ep.ThenCommands) != 1 || ep.ThenCommands[0] != "set system host-name recovered" {
+			t.Fatalf("ThenCommands = %v, want the single authored command", ep.ThenCommands)
+		}
+	})
+}
+
+// The fabric leaf shares the reader after #7126 single-sourced it, so its own
+// five spellings are re-asserted here. #6694's tests already cover it; this
+// exists so a change to plainListValues that only the fabric leaf would notice
+// still reds inside THIS change's test file rather than only next door.
+func Test_7126_SharedReaderKeepsFabricMembersIntact(t *testing.T) {
+	t.Run("hier-bracket", func(t *testing.T) {
+		cfg := compileBraceStrict7126(t, `interfaces { fab0 { fabric-options { member-interfaces [ ge-0/0/0 ge-0/0/1 ]; } } }`)
+		wantValues(t, "FabricMembers", cfg.Interfaces.Interfaces["fab0"].FabricMembers, "ge-0/0/0", "ge-0/0/1")
+	})
+	t.Run("set-bracket", func(t *testing.T) {
+		cfg := compileSetStrict7126(t, `set interfaces fab0 fabric-options member-interfaces [ ge-0/0/0 ge-0/0/1 ]`)
+		wantValues(t, "FabricMembers", cfg.Interfaces.Interfaces["fab0"].FabricMembers, "ge-0/0/0", "ge-0/0/1")
+	})
+}
+
+// plainListValues is the shared body. Pin its contract directly, on hand-built
+// nodes, so a caller-level green cannot hide a reader that happens to be right
+// only for the shapes those callers exercise.
+func Test_7126_PlainListValuesReadsEveryKeyOfEveryChild(t *testing.T) {
+	cases := []struct {
+		name string
+		node *Node
+		want []string
+	}{
+		{
+			name: "tail only (hierarchical bracket / packed)",
+			node: &Node{Keys: []string{"leaf", "a", "b"}},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "one child per value (hierarchical block / flat-set repeated)",
+			node: &Node{Keys: []string{"leaf"}, Children: []*Node{
+				{Keys: []string{"a"}}, {Keys: []string{"b"}},
+			}},
+			want: []string{"a", "b"},
+		},
+		{
+			// THE #7126 SHAPE. One child, every value on its Keys.
+			name: "one child holding every value (flat-set bracket)",
+			node: &Node{Keys: []string{"leaf"}, Children: []*Node{
+				{Keys: []string{"a", "b", "c"}},
+			}},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "tail AND children (mixed authoring merged by the AST)",
+			node: &Node{Keys: []string{"leaf", "a"}, Children: []*Node{
+				{Keys: []string{"b", "c"}},
+			}},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "empty tokens are not values",
+			node: &Node{Keys: []string{"leaf", "", "a"}, Children: []*Node{
+				{Keys: []string{"", "b"}},
+			}},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "no value at all",
+			node: &Node{Keys: []string{"leaf"}},
+			want: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := plainListValues(tc.node)
+			if len(got) != len(tc.want) {
+				t.Fatalf("plainListValues = %v, want %v", got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Fatalf("plainListValues = %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+	if plainListValues(nil) != nil {
+		t.Fatalf("plainListValues(nil) must be nil")
+	}
+}

--- a/pkg/config/compiler_interfaces.go
+++ b/pkg/config/compiler_interfaces.go
@@ -1378,28 +1378,14 @@ func compileInterfaceDynamicDNS(afNode *Node) *InterfaceDynamicDNSConfig {
 // `member-interfaces` has no per-member option keywords in Junos, so unlike
 // the NTP server list there is no trailing-token ambiguity to resolve — every
 // non-empty token below the node is a member name.
+//
+// #7126: the mechanism is not specific to this leaf — `routing-options
+// rib-groups <g> import-rib` and `event-options policy <p> events` are the same
+// plain value list read the same way, and had the same flat-set-bracket drop.
+// The implementation therefore lives in ast.go as plainListValues and is shared
+// by all three; a divergence between them would always be a bug, so there is
+// one body rather than three copies. This wrapper keeps the leaf-specific
+// argument above attached to the leaf it argues about.
 func fabricMemberValues(n *Node) []string {
-	if n == nil {
-		return nil
-	}
-	var members []string
-	add := func(tokens []string) {
-		for _, tok := range tokens {
-			if tok != "" {
-				members = append(members, tok)
-			}
-		}
-	}
-	if len(n.Keys) > 1 {
-		add(n.Keys[1:])
-	}
-	var walk func(*Node)
-	walk = func(parent *Node) {
-		for _, c := range parent.Children {
-			add(c.Keys)
-			walk(c)
-		}
-	}
-	walk(n)
-	return members
+	return plainListValues(n)
 }

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -86,19 +86,7 @@ func compileRoutingOptions(node *Node, ro *RoutingOptionsConfig) error {
 			ro.RibGroups = make(map[string]*RibGroup)
 		}
 		for _, inst := range namedInstances(rgNode.FindChildren("")) {
-			rg := &RibGroup{Name: inst.name}
-			if irNode := inst.node.FindChild("import-rib"); irNode != nil {
-				// import-rib [ rib1 rib2 ... ] or import-rib rib1;
-				for i := 1; i < len(irNode.Keys); i++ {
-					if irNode.Keys[i] == "[" || irNode.Keys[i] == "]" {
-						continue
-					}
-					rg.ImportRibs = append(rg.ImportRibs, irNode.Keys[i])
-				}
-				for _, child := range irNode.Children {
-					rg.ImportRibs = append(rg.ImportRibs, child.Name())
-				}
-			}
+			rg := compileRibGroup(inst.name, inst.node)
 			ro.RibGroups[rg.Name] = rg
 		}
 		// Also handle direct children (non-named instances)
@@ -107,18 +95,7 @@ func compileRoutingOptions(node *Node, ro *RoutingOptionsConfig) error {
 			if _, exists := ro.RibGroups[name]; exists {
 				continue
 			}
-			rg := &RibGroup{Name: name}
-			if irNode := child.FindChild("import-rib"); irNode != nil {
-				for i := 1; i < len(irNode.Keys); i++ {
-					if irNode.Keys[i] == "[" || irNode.Keys[i] == "]" {
-						continue
-					}
-					rg.ImportRibs = append(rg.ImportRibs, irNode.Keys[i])
-				}
-				for _, child := range irNode.Children {
-					rg.ImportRibs = append(rg.ImportRibs, child.Name())
-				}
-			}
+			rg := compileRibGroup(name, child)
 			ro.RibGroups[rg.Name] = rg
 		}
 	}
@@ -1272,6 +1249,48 @@ func parsePolicyTermInlineKeys(term *PolicyTerm, keys []string) {
 // "main" so the commit-time warn and the runtime applier classify a rib-group
 // import the same way (#3876).
 const mainRIBTableID = 254
+
+// compileRibGroup builds one RibGroup from the AST node that carries its body.
+//
+// It exists because compileRoutingOptions reaches a rib-group by TWO arms — the
+// named-instance arm and the direct-child arm — which held byte-identical
+// import-rib readers. #7126 records the hazard that duplication creates: a fix
+// landing in only one arm leaves the defect in the other spelling, and nothing
+// in the compiler would say so. There is now one body, so the two arms cannot
+// disagree.
+//
+// `import-rib` is the inter-VRF route-leak membership list, so a dropped entry
+// is not cosmetic: the rib-group pulls routes into one table instead of two and
+// the second table's leak simply never happens, with no diagnostic, while
+// `show configuration` renders the full list back. Two strict/warning
+// validators also iterate ImportRibs (compiler_validate_warn_routing.go,
+// compiler_validate_strict_routing.go), so a truncated list also narrows what
+// those checks can see.
+//
+// Two reads had to widen together (#7126):
+//
+//   - FindChildren, not FindChild. Repeated hierarchical statements
+//     (`import-rib inet.0; import-rib inet.2;`) land as SIBLING nodes and only
+//     the first was ever consulted, so that spelling dropped every rib past the
+//     first even though the flat-set repeated spelling — which files the same
+//     configuration as CHILDREN of one node — accumulated correctly.
+//   - plainListValues, not Keys[1:] plus each child's Name(). The old read
+//     already covered both sides of the AST exactly as CLAUDE.md prescribes and
+//     still dropped, because `set … import-rib [ inet.0 inet.2 ]` puts EVERY
+//     rib on ONE child's Keys and Name() is Keys[0]. See plainListValues.
+//
+// The old reader also skipped literal "[" / "]" tokens. That guard was
+// unreachable: the lexer strips brackets on both the hierarchical and the
+// flat-set path (verified against the parsed ASTs — `import-rib [ inet.0
+// inet.2 ]` yields Keys=["import-rib","inet.0","inet.2"] with no bracket
+// token), which is why every other #2419 reader in this package omits it.
+func compileRibGroup(name string, node *Node) *RibGroup {
+	rg := &RibGroup{Name: name}
+	for _, irNode := range node.FindChildren("import-rib") {
+		rg.ImportRibs = append(rg.ImportRibs, plainListValues(irNode)...)
+	}
+	return rg
+}
 
 // ribTargetKind classifies a rib-group import-rib name against a source
 // instance for the #3876 per-prefix leak. It mirrors pkg/routing.resolveRibTable

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -2053,16 +2053,20 @@ func compileEventOptions(node *Node, policies *[]*EventPolicy) error {
 		for _, child := range pInst.node.Children {
 			switch child.Name() {
 			case "events":
-				// Hierarchical: events [ evt1 evt2 ]; → Keys = ["events", "evt1", "evt2"]
-				// Hierarchical: events evt1;          → Keys = ["events", "evt1"]
-				// Brackets are stripped by the lexer, so just take Keys[1:]
-				for i := 1; i < len(child.Keys); i++ {
-					ep.Events = append(ep.Events, child.Keys[i])
-				}
-				// Flat set format: children are individual event name nodes
-				for _, evtChild := range child.Children {
-					ep.Events = append(ep.Events, evtChild.Name())
-				}
+				// `events` is the trigger set of the policy, so a lost value is
+				// the fail-SILENT direction: the automation the operator
+				// configured never runs for part of what they asked for.
+				//
+				// The old read covered both sides of the AST — Keys[1:] for the
+				// hierarchical bracket and packed spellings, one value per child
+				// for the block and flat-set-repeated ones — exactly as
+				// CLAUDE.md prescribes, and STILL dropped (#7126). `events` is
+				// not marked `multi: true` in setSchema, so SetPath files
+				// `set … events [ ev_one ev_two ]` as ONE child whose Keys hold
+				// BOTH names; evtChild.Name() is Keys[0] and returned only
+				// ev_one. Reading Children is not reading every KEY of each
+				// child. plainListValues reads both sides AND every key.
+				ep.Events = append(ep.Events, plainListValues(child)...)
 			case "within":
 				w := &EventWithin{}
 				if v := nodeVal(child); v != "" {

--- a/pkg/config/schema_spelling_differential_gate_test.go
+++ b/pkg/config/schema_spelling_differential_gate_test.go
@@ -22,11 +22,12 @@ package config
 //
 // There is no single correct reader to lint FOR. This package now contains at
 // least six accumulating readers — firewallMatchValues, multiLeafAuthoredValues,
-// proxyARPAddressValues, eventMultiWordLeafValues, fabricMemberValues, and
-// ntpServerValues, the last of which must additionally skip per-value option
-// KEYWORDS. A rule matching "reads Keys[1]" would flag compliant code, and would
-// miss the #7126 sites entirely: both of those read Keys[1:] AND Children exactly
-// as CLAUDE.md instructs, and still drop, because reading Children is not the
+// proxyARPAddressValues, eventMultiWordLeafValues, plainListValues (#7126
+// single-sourced #6694's fabricMemberValues into it), and ntpServerValues, the
+// last of which must additionally skip per-value option KEYWORDS. A rule
+// matching "reads Keys[1]" would flag compliant code, and would have missed the
+// #7126 sites entirely: both of those read Keys[1:] AND Children exactly as
+// CLAUDE.md instructs, and still dropped, because reading Children is not the
 // same as reading every KEY of each child. A differential has no such blind
 // spot — it asks whether the compiler disagrees with ITSELF, which is the defect.
 //
@@ -160,11 +161,6 @@ var knownSpellingInconsistencies = map[string]string{
 	// #6688 — source-NAT port range compiles a one-port pool.
 	"security nat source pool <*> port range": "#6688",
 
-	// #7126 — the flat-set bracket list lands on a CHILD's Keys for any leaf
-	// setSchema does not mark multi, so a reader taking Keys[0] of each child
-	// keeps only the first value even though it reads both sides.
-	"routing-options rib-groups <*> import-rib": "#7126",
-	"event-options policy <*> events":           "#7126",
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The predicate, not two special cases

`routing-options rib-groups <g> import-rib` and `event-options policy <p> events`
both read the leaf's own `Keys[1:]` **and** its `Children` — exactly what
`CLAUDE.md` and `docs/config-schema.md` prescribe — and both still dropped every
value past the first when the operator authored a bracket list through the
flat-set path. **Reading `Children` is not the same as reading every KEY of each
child.**

`SetPath` files a bracket list differently depending on the schema flag:

| schema | `set … <leaf> [ v1 v2 ]` becomes |
|---|---|
| `multi: true, children: nil` | `Keys=["<leaf>","v1","v2"]` — the tail absorber runs |
| **`multi: false, children: nil`** | `Keys=["<leaf>"]` with **ONE child** `Keys=["v1","v2"]` |

`child.Name()` is `Keys[0]`, so the second row keeps `v1` and discards the rest.
The hierarchical parser puts the list on the node's own tail instead, which is
why both sites survived every brace-authored test and bit only `set` /
`load set` / the CLI.

## Measured at 22e17c2de, `[ a b ]` in all five spellings

| site | A hier-bracket | B hier-block | C hier-repeat | D set-bracket | E set-repeat |
|---|---|---|---|---|---|
| `import-rib` | `[a b]` | `[a b]` | **`[a]`** | **`[a]`** | `[a b]` |
| `events` | `[a b]` | `[a b]` | `[a b]` | **`[a]`** | `[a b]` |

So `import-rib` needed **two** reads widened, not one — the issue records D, and
C drops as well because repeated hierarchical statements land as SIBLING nodes
and `FindChild` consulted only the first. Both are now `FindChildren` +
`plainListValues`.

Neither drop is one an operator can see: `import-rib` is the inter-VRF
route-leak membership list (the second table's leak simply never happens, and
`show configuration` renders the full list back), and `events` is an event
policy's trigger set (the automation silently never runs for part of what was
authored).

## Not in the issue: the import-rib drop is also a GATE ESCAPE

The #2226 cross-reference check iterates `ImportRibs`, so a rib named in a slot
the compiler never read could never be rejected:

```
set routing-options rib-groups rg1 import-rib [ inet.0 does-not-exist.inet.0 ]   -> committed CLEAN
set routing-options rib-groups rg1 import-rib [ does-not-exist.inet.0 inet.0 ]   -> "references an undefined rib"
```

The newly visible tail entries land on #2226's **existing** tolerant-path
downgrade (`lenientRibGroupRefs`), so no already-persisted config is turned into
a boot failure. Asserted, both legs, at slots 0/1/2.

## Single-sourced, not copied a third time

#6694 solved this shape for `fabric-options member-interfaces`, and the issue
asks for that reader to be generalised. The body now lives once, in `ast.go` as
`plainListValues`; `fabricMemberValues` is a wrapper that keeps its
leaf-specific argument attached to its leaf. A divergence between the three
would always be a bug, so there is one implementation.

The reader's doc states where it must **not** be used: a leaf with per-value
option keywords (`ntp server <ip> prefer`, `source-prefix-list <name> except` —
promoting a modifier into the value list is the #6690 hazard), and a leaf that
must preserve an EMPTY authored value (`multiLeafAuthoredValues`). Its
grandchild descent is inherited from #6694 **unchanged** rather than narrowed
here, so single-sourcing changes nothing for the fabric leaf.

## The duplicated arm

The two `import-rib` read sites were byte-identical duplicates in two arms of
`compileRoutingOptions` — the hazard the issue names. They now share
`compileRibGroup`. **Measured: the named-instance arm is INERT at HEAD** — it
selects with `FindChildren("")`, which matches only a child whose first key is
the empty string, and no parse produces one. The duplication was latent, which
is precisely why no test could have caught a divergence; the arm is left in
place (sharing the body) rather than deleted, since removing dead code is a
separate change. `compileRibGroup` is therefore unit-tested over the five AST
shapes directly.

The old reader also skipped literal `[` / `]` tokens. That guard was
unreachable — the lexer strips brackets on both the hierarchical and the
flat-set path (verified against the parsed ASTs) — which is why no other #2419
reader in this package carries it.

## Validation

`pkg/config/compiler_flatset_bracket_child_7126_test.go`: all five spellings at
both sites, including **three**-value lists (a two-value list can be kept by an
off-by-one that still truncates); the #2226 escape at slots 0/1/2 on that
validator's own wording plus its tolerant-path downgrade; `compileRibGroup` and
`plainListValues` unit-tested on hand-built nodes; and the fabric leaf
re-asserted so a change only it would notice still reds here.

**Both #7126 allowlist rows are removed from the #2419 spelling-differential
gate in this PR.** A stale row is a hard failure there, so the gate proves the
fix landed.

### Mutation proof (each mutation is ONE line; `go vet` rc=0 every time, so every red is an ASSERTION red)

| mutation | `go vet` | `-run _7126_` | gate | what red |
|---|---|---|---|---|
| `plainListValues`: `add(c.Keys)` → `add(c.Keys[:1])` (the exact pre-fix child read) | 0 | **rc=1**, 19 failures | **rc=1** | every D-set-bracket case; gate reports `D=drop` at `import-rib`, `events` **and** `member-interfaces` — the shared reader really does bind all three |
| `compileRibGroup`: `FindChildren` → `FindChild` | 0 | **rc=1**, 4 failures | rc=0 | `C-hier-repeat` + the sibling-node shape. The gate stays green here **by design** — it excludes the repeated spellings for a `multi:false` leaf — which is why the test file asserts C directly |
| `events`: `plainListValues` → `firewallMatchValues` (the "compliant" reader) | 0 | **rc=1**, 4 failures | **rc=1** | every `events` D-set-bracket case; gate `D=drop` |
| `plainListValues`: drop the `Keys[1:]` tail read | 0 | **rc=1**, 15 failures | — | `A-hier-bracket` and `C-hier-repeat`, i.e. the other side of the AST |

### Suites

- `go test -count=1 -run SchemaSpelling ./pkg/config/` — **green** with both rows removed.
- `go test -count=1 ./pkg/config/...` — green.
- `go vet ./pkg/config/` clean, `go build ./...` clean.

**No smoke owed.** Go-only, entirely within `pkg/config`. Nothing reaches the
Rust `userspace-dp` helper or the AF_XDP shim and no compiled dataplane artifact
moves.

Closes #7126