### PR TITLE
dataplane: guard the helper control-socket stale unlink; type the control-socket leaf

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -97678,3 +97678,45 @@ prose edit above them added. No diff falls in the new test body.
   pkg/daemon/daemon_ha_actuation_6371_test.go,
   pkg/cluster/sync_failover_fence_verdict_6371_test.go,
   docs/session-sync-architecture.md, _Log.md
+- **Timestamp**: 2026-08-21
+- **Action**: #5839 — harden the userspace helper control-socket stale-socket
+  removal and type the `control-socket` leaf. The control-socket half of helper
+  bring-up still did a bare `_ = os.Remove(cfg.ControlSocket)`: the path is
+  operator-supplied and xpfd runs as root, so it deleted whatever object the
+  path named (regular file, symlink, a running helper's live socket) and
+  swallowed the failure when it could not. The sibling EVENT-socket half was
+  hardened in #5273 (`removeStaleEventStreamSocket`); this extracts that logic
+  into `removeStaleUnixSocket` in a new `stale_socket.go` so both halves share
+  ONE implementation (an explicit #5839 invariant), and points the control
+  socket at it. All four checks apply to the control socket: Lstat with
+  not-exists tolerated (and a symlink judged on its own inode), an
+  `os.ModeSocket` gate, a `/proc/net/unix` liveness probe, and a non-ignored
+  `os.Remove`. The sidecar flock is NOT extended to the control socket: xpfd
+  does not bind it (the Rust helper does) so a daemon-side lock would serialize
+  nothing.
+
+  Because `ensureProcessLocked` stops generation N before preparing N+1, the
+  guarded removal alone would have converted "silently delete a regular file and
+  continue" into "tear down forwarding, then fail" — worse for availability. So
+  `preflightHelperPaths` runs the deterministic checks (control/event/state must
+  be distinct; neither socket path may already exist as a non-socket) BEFORE the
+  stop, via `stopForNewGenerationLocked`. The liveness check is deliberately not
+  hoisted: the control socket is live precisely until the helper holding it is
+  stopped.
+
+  `control-socket` also becomes a typed leaf (`ValueUnixSocketPath` /
+  `ValidateUnixSocketPath`): absolute, no `.`/`..`/empty component, no trailing
+  slash, no control characters, within the 107-octet AF_UNIX sun_path limit.
+  No-brick per #1960 — `compileTreeLenient` warns and boots on a stale stored or
+  peer-synced value, so the gate binds strict commits only and the runtime layer
+  is what actually protects bring-up.
+
+  Validation: `go test -count=1 ./...` exit 0. Mutation matrix over the four
+  checks + the preflight + the typed leaf recorded in the PR. Go-only diff — no
+  Rust/shim artifact moves, so no cluster smoke is owed.
+- **File(s)**: pkg/dataplane/userspace/stale_socket.go,
+  pkg/dataplane/userspace/process.go, pkg/dataplane/userspace/eventstream.go,
+  pkg/dataplane/userspace/stale_socket_5839_test.go,
+  pkg/config/schema_system.go, pkg/config/schema_validators_system.go,
+  pkg/config/value_type.go, pkg/config/control_socket_typed_5839_test.go,
+  docs/userspace-dataplane-architecture.md, docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -10251,3 +10251,37 @@ is never echoed into a warning.
   separately (S-3, not this change).
 - **tests** — `pkg/config/compiler_inert_knobs_4306_test.go` (advisories fire,
   no secret echoed).
+
+## `system dataplane control-socket` typed as a socket path (#5839)
+
+`control-socket` was an untyped `{args: 1}` leaf, so any string committed and
+reached the dataplane verbatim. Three shapes are pathological:
+
+- a **relative** path — the daemon dials it and the Rust helper binds it from
+  two separate processes, each resolving it against its own working directory;
+- a `..` **traversal** — the path is handed to the stale-socket unlink at every
+  helper bring-up, so a stored config could aim that unlink outside the runtime
+  directory the path appears to name;
+- a path over the **107-octet AF_UNIX `sun_path` limit** — it can never bind, so
+  it surfaces as an opaque dataplane bring-up failure rather than a commit error.
+
+The leaf is now `valueType: ValueUnixSocketPath` with the
+`ValidateUnixSocketPath` validator (`schema_validators_system.go`): absolute, no
+`.`/`..`/empty component, no trailing `/`, no control characters, within the
+`sun_path` limit. `?`-completion gains the `<socket-path>` placeholder plus an
+example.
+
+Per the #1960 layered-defense doctrine this is **strict-on-commit,
+lenient-on-load**: `compileTreeLenient` warns and keeps booting a stored or
+peer-synced config carrying a stale value, so typing the leaf cannot brick a
+node. The gate is therefore NOT what protects the runtime — the dataplane's
+`removeStaleUnixSocket` re-judges the path defensively at every bring-up
+(refuses a non-socket, refuses a live listener's socket, never discards an
+unlink failure; see `docs/userspace-dataplane-architecture.md` "Socket path
+handling"). That runtime layer is what a value which never passed through a
+strict commit runs into.
+
+- **tests** — `pkg/config/control_socket_typed_5839_test.go` (validator
+  accept/reject table including the exact 107/108-octet boundary, plus the
+  leaf driven through `SchemaValidate` + `CompileConfig` so it is pinned as
+  WIRED, not merely defined).

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -1997,8 +1997,62 @@ system {
 | workers | 1 | Number of AF_XDP worker threads |
 | ring-entries | 1024 | RX/TX/fill/completion ring size per binding |
 | binary | — | Path to Rust binary |
-| control-socket | — | Unix socket for control protocol |
+| control-socket | — | Unix socket for control protocol (typed leaf: absolute, no `.`/`..` component, ≤107 octets — see below) |
 | state-file | — | JSON state persistence path |
+
+### Socket path handling (#5273, #5839)
+
+`control-socket` is operator-supplied and xpfd runs as root, so both helper
+sockets are treated as untrusted paths at every bring-up.
+
+**Commit check.** `control-socket` is a typed leaf
+(`ValueUnixSocketPath` / `ValidateUnixSocketPath`, `pkg/config`): it must be an
+absolute path with no `.`, `..`, or empty component, and must fit the 107-octet
+AF_UNIX `sun_path` limit. This is a STRICT-commit gate only — the tolerant
+load / peer-sync path warns and boots on a stale value (#1960), so the runtime
+never relies on it.
+
+**Runtime.** `removeStaleUnixSocket` (`pkg/dataplane/userspace/stale_socket.go`)
+is the single implementation of stale-socket removal for BOTH the control socket
+and the event socket. Before it unlinks anything it:
+
+1. `Lstat`s the path, tolerating "does not exist" (the normal first boot) and
+   judging a symlink on its own inode rather than following it;
+2. refuses any path that is not a Unix socket — a regular file, directory,
+   FIFO, device, or symlink is preserved, not deleted;
+3. refuses a socket the kernel Unix socket table still lists, i.e. one a LIVE
+   listener holds. Unlinking a live socket does not stop that listener; it makes
+   it unreachable (including to the #1993 boot armed-probe) while a second
+   helper binds a fresh socket at the same name and then fails to claim the
+   AF_XDP queues. An unreadable `/proc/net/unix` is inconclusive and fails
+   closed. The probe is non-invasive by design: DIALING the event socket would
+   make the daemon accept the probe as its new helper and drop the real one;
+4. surfaces an `os.Remove` failure instead of discarding it.
+
+**Known residual (#7139).** Those checks judge a path STRING, and the unlink is
+a separate syscall on that same string. A live socket reached through a
+different spelling of the same file — most plausibly a symlinked parent
+directory — is not matched in `/proc/net/unix` and so reads as stale, and the
+target or its parent can be swapped between the check and the unlink. Closing
+either needs the trusted-directory rework (`openat2` with `RESOLVE_BENEATH`, or
+an inode-keyed liveness decision) that #7139 tracks. The typed `control-socket`
+leaf removes the spelling most likely to be written by hand (a `.`/`..`
+component) from any strict commit, but does not close the alias.
+
+`EventStream.Start` additionally holds a sidecar `flock` across the call, which
+serializes daemon-side owners of the socket it binds. The control socket has no
+such lock because xpfd does not bind it — the Rust helper does
+(`remove_stale_socket` in `userspace-dp/src/server/lifecycle.rs`), and it does
+not participate in the flock protocol.
+
+**Ordering.** `ensureProcessLocked` stops generation N before it prepares
+generation N+1, so `preflightHelperPaths` runs the DETERMINISTIC path checks —
+control/event/state must name distinct paths, and neither socket path may
+already exist as a non-socket — BEFORE the running helper is torn down. A
+config that could never bring up a new generation therefore leaves the previous
+one, and its forwarding, running. The liveness check is deliberately NOT
+hoisted: the control socket is live precisely until the helper holding it is
+stopped.
 
 **Tuning guidelines:**
 - Set `workers` to match NIC RSS queue count (`ethtool -L <dev> combined N`)

--- a/pkg/config/control_socket_typed_5839_test.go
+++ b/pkg/config/control_socket_typed_5839_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5839: `system dataplane control-socket` was an untyped `{args: 1}` leaf, so
+// any string committed and reached the dataplane verbatim — including a
+// relative path (resolved against whatever working directory the daemon and the
+// helper each hold), a `..` traversal (the path is handed to a stale-socket
+// unlink at every bring-up), and a path over the AF_UNIX sun_path limit (which
+// can never bind). Typing it moves those from an opaque runtime bring-up
+// failure to a commit-check error.
+
+func TestValidateUnixSocketPath_5839(t *testing.T) {
+	good := []string{
+		"/run/xpf/userspace-dp.sock",
+		"/tmp/xpf-userspace-dp/control.sock",
+		"/var/run/xpf/dp-0.sock",
+	}
+	for _, raw := range good {
+		if err := ValidateUnixSocketPath(raw, nil); err != nil {
+			t.Errorf("ValidateUnixSocketPath(%q) = %v, want accepted", raw, err)
+		}
+	}
+
+	bad := []struct {
+		raw     string
+		wantSub string
+	}{
+		{"", "missing value"},
+		{"userspace-dp.sock", "must be absolute"},
+		{"run/xpf/dp.sock", "must be absolute"},
+		{"/run/xpf/../../etc/shadow", `".."`},
+		{"/run/./xpf/dp.sock", `"."`},
+		{"/run/xpf/", "not a directory"},
+		{"/", "not a directory"},
+		{"/run//xpf/dp.sock", "empty component"},
+		{"/run/xpf/dp\x00.sock", "control characters"},
+		{"/" + strings.Repeat("a", 107) + "/dp.sock", "sun_path limit"},
+	}
+	for _, tc := range bad {
+		err := ValidateUnixSocketPath(tc.raw, nil)
+		if err == nil {
+			t.Errorf("ValidateUnixSocketPath(%q) = nil, want rejection", tc.raw)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.wantSub) {
+			t.Errorf("ValidateUnixSocketPath(%q) error = %q, want it to mention %q", tc.raw, err, tc.wantSub)
+		}
+	}
+
+	// The boundary is the sun_path limit itself, not an approximation of it:
+	// 107 octets binds, 108 does not.
+	atLimit := "/" + strings.Repeat("a", maxUnixSocketPathLen-1)
+	if got := len(atLimit); got != maxUnixSocketPathLen {
+		t.Fatalf("fixture length = %d, want %d", got, maxUnixSocketPathLen)
+	}
+	if err := ValidateUnixSocketPath(atLimit, nil); err != nil {
+		t.Errorf("ValidateUnixSocketPath(<%d octets>) = %v, want accepted", maxUnixSocketPathLen, err)
+	}
+	if err := ValidateUnixSocketPath(atLimit+"a", nil); err == nil {
+		t.Errorf("ValidateUnixSocketPath(<%d octets>) = nil, want rejection", maxUnixSocketPathLen+1)
+	}
+}
+
+// TestControlSocketTypedLeafGate_5839 drives the value through the same two
+// steps a commit takes — SchemaValidate then the compiler — so the leaf is
+// pinned as WIRED, not merely as a validator that exists.
+func TestControlSocketTypedLeafGate_5839(t *testing.T) {
+	build := func(t *testing.T, value string) *ConfigTree {
+		t.Helper()
+		tree := &ConfigTree{}
+		path, err := ParseSetCommand("set system dataplane control-socket " + value)
+		if err != nil {
+			t.Fatalf("ParseSetCommand: %v", err)
+		}
+		tree.SetPath(path)
+		return tree
+	}
+
+	t.Run("valid path commits and compiles", func(t *testing.T) {
+		tree := build(t, "/run/xpf/userspace-dp.sock")
+		if err := SchemaValidate(tree, nil); err != nil {
+			t.Fatalf("SchemaValidate: %v", err)
+		}
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("CompileConfig: %v", err)
+		}
+		if cfg.System.UserspaceDataplane == nil {
+			t.Fatal("compiled config has no userspace dataplane stanza")
+		}
+		if got := cfg.System.UserspaceDataplane.ControlSocket; got != "/run/xpf/userspace-dp.sock" {
+			t.Fatalf("compiled ControlSocket = %q, want /run/xpf/userspace-dp.sock", got)
+		}
+	})
+
+	for _, bad := range []string{"userspace-dp.sock", "/run/xpf/../../etc/shadow"} {
+		t.Run("rejected: "+bad, func(t *testing.T) {
+			tree := build(t, bad)
+			if err := SchemaValidate(tree, nil); err == nil {
+				t.Fatalf("SchemaValidate accepted control-socket %q, want a commit-check error", bad)
+			}
+		})
+	}
+}

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -294,12 +294,25 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 		// break an existing stanza) but have NO effect; the compiler
 		// emits a per-knob commit warning instead (#1892,
 		// userspaceRetiredKnobWarnings).
-		"cores":          {args: 1, desc: "Legacy DPDK core count (retired, ignored)", children: nil},
-		"memory":         {args: 1, desc: "Legacy DPDK memory allocation (retired, ignored)", children: nil},
-		"socket-mem":     {args: 1, desc: "Legacy DPDK socket memory (retired, ignored)", children: nil},
-		"binary":         {args: 1, desc: "Userspace dataplane helper binary path", children: nil},
-		"control-socket": {args: 1, desc: "Unix control socket path", children: nil},
-		"state-file":     {args: 1, desc: "Helper state file path", children: nil},
+		"cores":      {args: 1, desc: "Legacy DPDK core count (retired, ignored)", children: nil},
+		"memory":     {args: 1, desc: "Legacy DPDK memory allocation (retired, ignored)", children: nil},
+		"socket-mem": {args: 1, desc: "Legacy DPDK socket memory (retired, ignored)", children: nil},
+		"binary":     {args: 1, desc: "Userspace dataplane helper binary path", children: nil},
+		// #5839: typed so a path the dataplane bring-up would have to refuse
+		// — relative, `..`-escaping, or over the AF_UNIX sun_path limit —
+		// fails at commit check instead of at helper start. Strict commits
+		// only; the tolerant load path warns and boots (#1960), and
+		// removeStaleUnixSocket re-judges the path defensively at runtime.
+		"control-socket": {
+			args:          1,
+			desc:          "Unix control socket path",
+			valueType:     ValueUnixSocketPath,
+			valueDesc:     "Absolute path the dataplane helper binds its control socket at",
+			valueExamples: []string{"/run/xpf/userspace-dp.sock"},
+			validator:     ValidateUnixSocketPath,
+			children:      nil,
+		},
+		"state-file": {args: 1, desc: "Helper state file path", children: nil},
 		// #1319 PR 3 typed dataplane knobs. Each compiled with the
 		// Atoi error swallowed (compileUserspaceDataplane), so
 		// garbage silently fell back to the 0 zero-value, which the

--- a/pkg/config/schema_validators_system.go
+++ b/pkg/config/schema_validators_system.go
@@ -365,6 +365,65 @@ var zoneNameSegmentRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_+-]*$`)
 // that still rejects an absurdly long traversal string.
 const maxTimeZoneLen = 64
 
+// maxUnixSocketPathLen bounds a helper socket path. AF_UNIX sun_path is a
+// 108-byte array that must hold a NUL terminator, so 107 octets is the longest
+// path the kernel can bind — a longer one fails at bind() with EINVAL, which
+// surfaces as an opaque dataplane bring-up failure rather than a commit error.
+const maxUnixSocketPathLen = 107
+
+// ValidateUnixSocketPath accepts a `system dataplane control-socket` value: the
+// filesystem path the Rust helper binds its control listener on and the daemon
+// dials (pkg/dataplane/userspace/process.go, process_control.go).
+//
+// It must be an ABSOLUTE, traversal-free path that names a file, because:
+//
+//   - the daemon and the helper are separate processes, so a relative path is
+//     resolved against whatever working directory each happens to hold;
+//   - the path is handed to the stale-socket unlink at every bring-up, so a
+//     `..` component lets a stored config aim that unlink outside the runtime
+//     directory it appears to name (#5839);
+//   - a trailing slash or a bare `/` names no socket at all;
+//   - a path over sun_path's 107 usable octets can never bind.
+//
+// Strict at commit-check (SchemaValidate) only. The tolerant load / peer-sync
+// path keeps booting on a stale value (#1960 no-brick: pkg/configstore
+// compileTreeLenient warns and continues), and the runtime is not relying on
+// this gate — removeStaleUnixSocket re-judges the path defensively at every
+// bring-up, which is what protects a value that never passed through a strict
+// commit at all. Rejecting `.`/`..` here removes the traversal spelling most
+// likely to be written by hand; it does NOT make the runtime path
+// alias-proof — a symlinked parent still aliases (#7139).
+func ValidateUnixSocketPath(raw string, _ *Config) error {
+	if raw == "" {
+		return fmt.Errorf("missing value (expected an absolute socket path, e.g. /run/xpf/userspace-dp.sock)")
+	}
+	if !strings.HasPrefix(raw, "/") {
+		return fmt.Errorf("socket path %q must be absolute (start with '/'): the daemon and the "+
+			"dataplane helper are separate processes and resolve a relative path against "+
+			"their own working directories", raw)
+	}
+	if len(raw) > maxUnixSocketPathLen {
+		return fmt.Errorf("socket path %q is %d octets, over the %d-octet AF_UNIX sun_path limit",
+			raw, len(raw), maxUnixSocketPathLen)
+	}
+	if strings.HasSuffix(raw, "/") {
+		return fmt.Errorf("socket path %q must name a socket file, not a directory (no trailing '/')", raw)
+	}
+	for _, seg := range strings.Split(raw, "/")[1:] {
+		switch seg {
+		case "":
+			return fmt.Errorf("socket path %q must not contain an empty component (doubled '/')", raw)
+		case ".", "..":
+			return fmt.Errorf("socket path %q must not contain a %q component: the path is unlinked "+
+				"at every dataplane bring-up and must not be able to leave the directory it names", raw, seg)
+		}
+		if strings.IndexFunc(seg, func(r rune) bool { return r < 0x20 }) >= 0 {
+			return fmt.Errorf("socket path %q must not contain control characters (including NUL)", raw)
+		}
+	}
+	return nil
+}
+
 // ValidateTimeZone accepts a `system time-zone` value: an IANA tz-database /
 // zoneinfo name such as `UTC`, `America/Los_Angeles`, or `Etc/GMT+5`. The value
 // is rendered into the /etc/localtime symlink target

--- a/pkg/config/value_type.go
+++ b/pkg/config/value_type.go
@@ -104,6 +104,14 @@ const (
 	// commits but silently carries no traffic; the name is rejected at
 	// commit check (#5297).
 	ValueSecureTunnelIf
+	// ValueUnixSocketPath is an absolute filesystem path a Unix-domain
+	// socket is bound at (`system dataplane control-socket`). Validated by
+	// ValidateUnixSocketPath: absolute, no `.`/`..`/empty component, within
+	// the 107-octet AF_UNIX sun_path limit. The path is handed to the
+	// dataplane's stale-socket unlink at every bring-up, so a traversal or a
+	// relative path is rejected at commit rather than resolved at runtime
+	// against a working directory the operator never named (#5839).
+	ValueUnixSocketPath
 )
 
 // Placeholder returns the angle-bracket placeholder name shown in `?`
@@ -150,6 +158,8 @@ func (v ValueType) Placeholder() string {
 		return "<timezone>"
 	case ValueSecureTunnelIf:
 		return "<st-interface>"
+	case ValueUnixSocketPath:
+		return "<socket-path>"
 	}
 	return ""
 }

--- a/pkg/dataplane/userspace/eventstream.go
+++ b/pkg/dataplane/userspace/eventstream.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"net"
 	"os"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -217,7 +216,7 @@ func (es *EventStream) Start(ctx context.Context) error {
 			releaseEventStreamSocketLock(lockFile)
 		}
 	}()
-	if err := removeStaleEventStreamSocket(es.socketPath); err != nil {
+	if err := removeStaleUnixSocket(socketKindEventStream, es.socketPath); err != nil {
 		return err
 	}
 
@@ -257,51 +256,6 @@ func releaseEventStreamSocketLock(f *os.File) {
 	_ = f.Close()
 }
 
-// removeStaleEventStreamSocket removes only a proven stale Unix-stream socket.
-// The caller must hold the sidecar ownership lock. A live listener, a path of a
-// different type, or an inconclusive kernel-table read fails closed and is never
-// unlinked. Inspecting /proc/net/unix is deliberately non-invasive: dialing the
-// event socket as a liveness probe would make the old daemon accept the probe as
-// its new helper and disconnect the real helper.
-func removeStaleEventStreamSocket(socketPath string) error {
-	info, err := os.Lstat(socketPath)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("inspect event stream socket %s: %w", socketPath, err)
-	}
-	if info.Mode()&os.ModeSocket == 0 {
-		return fmt.Errorf("event stream path %s exists and is not a Unix socket", socketPath)
-	}
-
-	active, err := eventStreamSocketActive(socketPath)
-	if err != nil {
-		return err
-	}
-	if active {
-		return fmt.Errorf("event stream socket %s already has a live listener", socketPath)
-	}
-	if err := os.Remove(socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("remove stale event stream socket %s: %w", socketPath, err)
-	}
-	return nil
-}
-
-func eventStreamSocketActive(socketPath string) (bool, error) {
-	data, err := os.ReadFile("/proc/net/unix")
-	if err != nil {
-		return false, fmt.Errorf("inspect kernel Unix socket table for %s: %w", socketPath, err)
-	}
-	for _, line := range strings.Split(string(data), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) >= 8 && strings.Join(fields[7:], " ") == socketPath {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 // ListenerBound reports whether the event-stream listener socket successfully
 // bound (net.Listen in Start() succeeded and Close() has not run). It is TRUE
 // as soon as the daemon can receive the local helper's session deltas,
@@ -330,7 +284,17 @@ func (es *EventStream) Close() {
 	es.connected.Store(false)
 	es.mu.Unlock()
 	if es.ownsSocket {
-		_ = os.Remove(es.socketPath)
+		// Exempt from removeStaleUnixSocket (#5839): ownsSocket is set only
+		// after THIS EventStream bound the path under the sidecar flock, so
+		// ownership is already established and the liveness probe would be
+		// meaningless — the listener it would find is the one just closed
+		// above. The failure is reported rather than discarded so a socket
+		// left behind is diagnosable at the next bring-up, which refuses to
+		// unlink what it cannot prove stale.
+		if err := os.Remove(es.socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			slog.Warn("event stream: removing own socket failed",
+				"path", es.socketPath, "err", err)
+		}
 		es.ownsSocket = false
 	}
 	releaseEventStreamSocketLock(es.socketLock)

--- a/pkg/dataplane/userspace/process.go
+++ b/pkg/dataplane/userspace/process.go
@@ -15,6 +15,83 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 )
 
+// helperEventSocketPath resolves the event-socket path for a helper config: the
+// explicit `event-socket` when the operator set one, else the conventional name
+// beside the control socket. The pre-stop preflight and the listener setup both
+// resolve it through here, so they can never disagree about which path was
+// validated (#5839).
+func helperEventSocketPath(cfg config.UserspaceConfig) string {
+	if cfg.EventSocket != "" {
+		return cfg.EventSocket
+	}
+	return filepath.Join(filepath.Dir(cfg.ControlSocket), "userspace-dp-events.sock")
+}
+
+// preflightHelperPaths rejects a helper path set that bring-up would have to
+// refuse anyway, while the RUNNING generation can still be spared (#5839).
+//
+// ensureProcessLocked stops generation N before it prepares generation N+1, so
+// without a preflight every path fault is paid for with forwarding: the healthy
+// helper is killed, socket preparation then fails, and the node is left with no
+// dataplane at all. The two checks here are exactly the DETERMINISTIC faults —
+// an aliased path, and a path that exists as something other than a Unix socket
+// — neither of which stopping the helper can change. Everything conditional on
+// the running helper is deliberately left to removeStaleUnixSocket after the
+// stop; above all the liveness check, since the control socket is live PRECISELY
+// UNTIL we stop the helper that owns it.
+//
+// It fails only on a certain fault. An Lstat error other than "does not exist"
+// is inconclusive here and is left to the post-stop path rather than turned into
+// a new bring-up failure on a code path that used to have none.
+func preflightHelperPaths(cfg config.UserspaceConfig) error {
+	evtPath := helperEventSocketPath(cfg)
+	// The stale-socket primitive must never be pointed at the state file: a
+	// REGULAR FILE is expected there, so aliasing it onto a socket path would
+	// hand helper state to a socket unlink. Aliasing the two sockets onto each
+	// other is equally unworkable — the daemon's event listener would occupy
+	// the path the helper must bind.
+	for _, pair := range []struct{ aName, a, bName, b string }{
+		{"control-socket", cfg.ControlSocket, "event socket", evtPath},
+		{"control-socket", cfg.ControlSocket, "state-file", cfg.StateFile},
+		{"event socket", evtPath, "state-file", cfg.StateFile},
+	} {
+		if pair.a != "" && pair.a == pair.b {
+			return fmt.Errorf("userspace dataplane %s and %s must name distinct paths (both are %s)",
+				pair.aName, pair.bName, pair.a)
+		}
+	}
+	for _, sock := range []struct{ kind, path string }{
+		{socketKindControl, cfg.ControlSocket},
+		{socketKindEventStream, evtPath},
+	} {
+		if sock.path == "" {
+			continue
+		}
+		info, err := os.Lstat(sock.path)
+		if err != nil {
+			continue
+		}
+		if info.Mode()&os.ModeSocket == 0 {
+			return fmt.Errorf("userspace dataplane %s %s is a %s, not a Unix socket",
+				sock.kind, sock.path, describeFileMode(info.Mode()))
+		}
+	}
+	return nil
+}
+
+// stopForNewGenerationLocked preflights the incoming path set and tears the
+// running helper down only once that preflight passes, so a config that cannot
+// bring up a new generation leaves the previous one — and its forwarding —
+// running (#5839).
+func (m *Manager) stopForNewGenerationLocked(cfg config.UserspaceConfig) error {
+	if err := preflightHelperPaths(cfg); err != nil {
+		return fmt.Errorf("refusing to restart userspace dataplane helper, "+
+			"previous generation left running: %w", err)
+	}
+	m.stopLocked()
+	return nil
+}
+
 func (m *Manager) ensureProcessLocked(cfg config.UserspaceConfig) error {
 	tuneSocketBuffers()
 	if m.proc != nil && m.proc.Process != nil && configEqual(m.cfg, cfg) {
@@ -26,10 +103,14 @@ func (m *Manager) ensureProcessLocked(cfg config.UserspaceConfig) error {
 			return nil
 		}
 		slog.Warn("userspace dataplane helper unhealthy, restarting")
-		m.stopLocked()
+		if err := m.stopForNewGenerationLocked(cfg); err != nil {
+			return err
+		}
 	}
 	if m.proc != nil {
-		m.stopLocked()
+		if err := m.stopForNewGenerationLocked(cfg); err != nil {
+			return err
+		}
 	}
 	m.clearLastStatusLocked()
 	binary, err := findBinary(cfg.Binary)
@@ -42,13 +123,18 @@ func (m *Manager) ensureProcessLocked(cfg config.UserspaceConfig) error {
 	if err := os.MkdirAll(filepath.Dir(cfg.StateFile), 0755); err != nil {
 		return fmt.Errorf("mkdir state dir: %w", err)
 	}
-	_ = os.Remove(cfg.ControlSocket)
+	// The control socket is named by operator configuration and xpfd runs as
+	// root, so the stale-socket unlink is guarded rather than fire-and-forget:
+	// it refuses a path that is not a Unix socket, refuses one a live listener
+	// still holds, and surfaces a removal failure instead of discarding it
+	// (#5839). The helper has not been spawned yet, so failing here costs
+	// nothing beyond the generation that was already stopped.
+	if err := removeStaleUnixSocket(socketKindControl, cfg.ControlSocket); err != nil {
+		return err
+	}
 	// Start the event stream listener before spawning the helper so it
 	// can connect immediately.
-	evtPath := cfg.EventSocket
-	if evtPath == "" {
-		evtPath = filepath.Join(filepath.Dir(cfg.ControlSocket), "userspace-dp-events.sock")
-	}
+	evtPath := helperEventSocketPath(cfg)
 	es := NewEventStream(evtPath)
 	esCtx, esCancel := context.WithCancel(context.Background())
 	// The event socket is the primary push path for post-bootstrap session

--- a/pkg/dataplane/userspace/stale_socket.go
+++ b/pkg/dataplane/userspace/stale_socket.go
@@ -1,0 +1,133 @@
+package userspace
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Socket-kind labels for removeStaleUnixSocket. They appear verbatim in the
+// operator-facing error, so keep them noun phrases that read as the subject of
+// "refusing to unlink <kind> <path>".
+const (
+	socketKindControl     = "control socket"
+	socketKindEventStream = "event stream socket"
+)
+
+// removeStaleUnixSocket removes only a PROVEN STALE Unix socket at path, and is
+// the single implementation of stale-socket removal in this package (#5839).
+//
+// Both helper sockets are named by operator-supplied configuration
+// (`system dataplane control-socket`, and the event socket derived beside it),
+// and xpfd runs as root, so an unconditional os.Remove would silently unlink
+// whatever filesystem object the path happened to name. Four checks stand
+// between the path and the unlink, in this order:
+//
+//  1. Lstat, with "does not exist" tolerated. A first boot has no socket, and
+//     that is the normal case, not an error. Lstat rather than Stat so a
+//     SYMLINK is judged on its own inode: a symlink is not a socket and is
+//     therefore rejected below instead of being followed to its target.
+//  2. os.ModeSocket. A regular file, directory, FIFO, device, or symlink at the
+//     path is refused rather than deleted. This is the data-destruction case.
+//  3. A liveness probe against the kernel Unix socket table. Unlinking the
+//     socket of a LIVE listener does not stop that listener: it keeps serving
+//     the now-unreachable inode while a second process binds a fresh socket at
+//     the same path. For the control socket that means two helpers contending
+//     for the same AF_XDP queues (the second fails to bind, EBUSY) while the
+//     first becomes undialable — including by the #1993 boot armed-probe, which
+//     resolves forwarding state through exactly this path. Fail closed instead:
+//     a live owner is reported, never evicted.
+//  4. A NON-ignored os.Remove. A removal that fails (EACCES, EROFS, an
+//     immutable parent) must fail bring-up rather than let the caller proceed
+//     into a bind that will fail more confusingly. ErrNotExist is tolerated
+//     because a concurrent cleanup racing us to the same unlink reached the
+//     intended end state.
+//
+// Reading /proc/net/unix is deliberately non-invasive: DIALING as a liveness
+// probe would, on the event socket, make the daemon accept the probe as its new
+// helper and disconnect the real one. An unreadable table is inconclusive and
+// fails closed — it is never treated as "not active".
+//
+// The caller is responsible for whatever ownership serialization its socket
+// needs (EventStream.Start holds a sidecar flock across this call). The control
+// socket has no such lock because xpfd does not bind it — the Rust helper does,
+// and it does not participate in the flock protocol.
+//
+// KNOWN RESIDUAL (#7139): checks 1-3 judge a path STRING, and check 4 unlinks
+// that same string in a separate syscall. A live socket reached through a
+// different spelling of the same file — most plausibly a symlinked parent
+// directory — is not matched in /proc/net/unix and so reads as stale, and the
+// target or its parent can be swapped between the check and the unlink. Closing
+// either needs the trusted-directory rework (openat2 with RESOLVE_BENEATH, or
+// an inode-keyed liveness decision) tracked in #7139, not a further string
+// test here.
+func removeStaleUnixSocket(kind, path string) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect %s %s: %w", kind, path, err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("refusing to unlink %s %s: existing path is a %s, not a Unix socket",
+			kind, path, describeFileMode(info.Mode()))
+	}
+
+	active, err := unixSocketPathActive(path)
+	if err != nil {
+		return err
+	}
+	if active {
+		return fmt.Errorf("refusing to unlink %s %s: it already has a live listener", kind, path)
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove stale %s %s: %w", kind, path, err)
+	}
+	return nil
+}
+
+// unixSocketPathActive reports whether the kernel Unix socket table lists a
+// socket bound to path — i.e. some process is still holding it. A table that
+// cannot be read returns an error and never a bare false, so an inconclusive
+// read fails closed at the caller.
+func unixSocketPathActive(path string) (bool, error) {
+	data, err := os.ReadFile("/proc/net/unix")
+	if err != nil {
+		return false, fmt.Errorf("inspect kernel Unix socket table for %s: %w", path, err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		// Columns are fixed through Flags/Type/St/Inode; the path is the
+		// 8th field onward, rejoined because a bound path may contain
+		// spaces.
+		if len(fields) >= 8 && strings.Join(fields[7:], " ") == path {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// describeFileMode names the file type an operator sees at a refused path, so
+// the error says what is actually there rather than only what it is not. It
+// mirrors the helper-side wording in userspace-dp/src/server/lifecycle.rs
+// (describe_file_type).
+func describeFileMode(mode os.FileMode) string {
+	switch {
+	case mode&os.ModeSymlink != 0:
+		return "symlink"
+	case mode&os.ModeDir != 0:
+		return "directory"
+	case mode&os.ModeNamedPipe != 0:
+		return "FIFO"
+	case mode&os.ModeDevice != 0 && mode&os.ModeCharDevice != 0:
+		return "character device"
+	case mode&os.ModeDevice != 0:
+		return "block device"
+	case mode&os.ModeType == 0:
+		return "regular file"
+	default:
+		return "non-socket file"
+	}
+}

--- a/pkg/dataplane/userspace/stale_socket_5839_test.go
+++ b/pkg/dataplane/userspace/stale_socket_5839_test.go
@@ -1,0 +1,405 @@
+package userspace
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5839: the helper control socket was removed with a bare, result-discarding
+// `os.Remove(cfg.ControlSocket)`. The path comes from operator configuration
+// (`system dataplane control-socket`) and xpfd runs as root, so that unlink
+// deleted whatever object the path named — a regular file, a symlink, the live
+// socket of a running helper — and swallowed the failure when it could not.
+// The sibling event-socket half was hardened in #5273; these tests pin the same
+// four checks on the shared primitive both halves now use.
+
+// shortSocketDir returns a scratch directory under /tmp. AF_UNIX sun_path is
+// 108 bytes; a t.TempDir() path (which carries the full test name) can push a
+// bound socket past it and produce "bind: invalid argument" instead of the
+// behaviour under test.
+func shortSocketDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "xpf5839")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// listenUnix binds a real Unix-stream listener at path and returns it.
+func listenUnix(t *testing.T, path string) *net.UnixListener {
+	t.Helper()
+	ln, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	if err != nil {
+		t.Fatalf("ListenUnix(%s): %v", path, err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	return ln
+}
+
+// TestRemoveStaleUnixSocketRefusesNonSocketPaths_5839 covers check 2 (the
+// os.ModeSocket gate) for every non-socket file type the path could name. Each
+// case asserts BOTH halves: the call fails, and the object is still there —
+// "returned an error" alone would pass even if the unlink had already run.
+func TestRemoveStaleUnixSocketRefusesNonSocketPaths_5839(t *testing.T) {
+	cases := []struct {
+		name    string
+		create  func(t *testing.T, path string)
+		wantSub string
+	}{
+		{
+			name: "regular file",
+			create: func(t *testing.T, path string) {
+				if err := os.WriteFile(path, []byte("operator data"), 0600); err != nil {
+					t.Fatalf("WriteFile: %v", err)
+				}
+			},
+			wantSub: "regular file",
+		},
+		{
+			name: "directory",
+			create: func(t *testing.T, path string) {
+				if err := os.Mkdir(path, 0755); err != nil {
+					t.Fatalf("Mkdir: %v", err)
+				}
+			},
+			wantSub: "directory",
+		},
+		{
+			name: "fifo",
+			create: func(t *testing.T, path string) {
+				if err := syscall.Mkfifo(path, 0600); err != nil {
+					t.Fatalf("Mkfifo: %v", err)
+				}
+			},
+			wantSub: "FIFO",
+		},
+		{
+			// Lstat, not Stat: a symlink is judged on its own inode, so a
+			// symlink POINTING AT a socket is still refused rather than
+			// followed into an unlink of the target.
+			name: "symlink to a socket",
+			create: func(t *testing.T, path string) {
+				target := filepath.Join(filepath.Dir(path), "real.sock")
+				ln := listenUnix(t, target)
+				_ = ln
+				if err := os.Symlink(target, path); err != nil {
+					t.Fatalf("Symlink: %v", err)
+				}
+			},
+			wantSub: "symlink",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := shortSocketDir(t)
+			path := filepath.Join(dir, "control.sock")
+			tc.create(t, path)
+
+			err := removeStaleUnixSocket(socketKindControl, path)
+			if err == nil {
+				t.Fatalf("removeStaleUnixSocket(%s) = nil, want refusal for a %s", path, tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error = %q, want it to name the file type %q", err, tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), "refusing to unlink") {
+				t.Errorf("error = %q, want a refusal, not an incidental failure", err)
+			}
+			if _, statErr := os.Lstat(path); statErr != nil {
+				t.Fatalf("%s at %s was destroyed by a refused removal: %v", tc.name, path, statErr)
+			}
+		})
+	}
+}
+
+// TestRemoveStaleUnixSocketRefusesLiveListener_5839 covers check 3, the one
+// that matters most: unlinking the socket of a LIVE listener does not stop that
+// listener, it only makes it unreachable while a second process binds a fresh
+// socket at the same name. The socket must survive the refusal AND still
+// accept a connection.
+func TestRemoveStaleUnixSocketRefusesLiveListener_5839(t *testing.T) {
+	dir := shortSocketDir(t)
+	path := filepath.Join(dir, "control.sock")
+	listenUnix(t, path)
+
+	err := removeStaleUnixSocket(socketKindControl, path)
+	if err == nil {
+		t.Fatal("removeStaleUnixSocket() = nil for a socket with a LIVE listener, want refusal")
+	}
+	if !strings.Contains(err.Error(), "live listener") {
+		t.Errorf("error = %q, want it to name the live listener", err)
+	}
+	if _, statErr := os.Lstat(path); statErr != nil {
+		t.Fatalf("live socket at %s was unlinked by a refused removal: %v", path, statErr)
+	}
+	conn, dialErr := net.DialTimeout("unix", path, 2*time.Second)
+	if dialErr != nil {
+		t.Fatalf("live listener at %s is no longer reachable after the refusal: %v", path, dialErr)
+	}
+	_ = conn.Close()
+}
+
+// TestRemoveStaleUnixSocketRemovesStaleSocket_5839 is the positive control for
+// checks 1 and 4: a crash artifact — a socket file with no listener behind it —
+// is removed, and a path that does not exist at all is not an error.
+func TestRemoveStaleUnixSocketRemovesStaleSocket_5839(t *testing.T) {
+	dir := shortSocketDir(t)
+	path := filepath.Join(dir, "control.sock")
+
+	if err := removeStaleUnixSocket(socketKindControl, path); err != nil {
+		t.Fatalf("removeStaleUnixSocket() on a missing path = %v, want nil", err)
+	}
+
+	ln := listenUnix(t, path)
+	// Leave the socket file behind on close, which is what a SIGKILLed helper
+	// leaves on disk.
+	ln.SetUnlinkOnClose(false)
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+	if _, err := os.Lstat(path); err != nil {
+		t.Fatalf("precondition: stale socket not left on disk: %v", err)
+	}
+
+	if err := removeStaleUnixSocket(socketKindControl, path); err != nil {
+		t.Fatalf("removeStaleUnixSocket() on a stale socket = %v, want removal", err)
+	}
+	if _, err := os.Lstat(path); !os.IsNotExist(err) {
+		t.Fatalf("stale socket still present after removal: err=%v", err)
+	}
+}
+
+// TestRemoveStaleUnixSocketSurfacesRemoveFailure_5839 covers check 4: a removal
+// that FAILS must be reported, not discarded. Pre-#5839 the control-socket call
+// site was `_ = os.Remove(...)`, so an unremovable socket produced a confusing
+// downstream bind failure instead of a diagnosis.
+func TestRemoveStaleUnixSocketSurfacesRemoveFailure_5839(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory write permission; the unlink cannot be made to fail this way")
+	}
+	dir := shortSocketDir(t)
+	path := filepath.Join(dir, "control.sock")
+	ln := listenUnix(t, path)
+	ln.SetUnlinkOnClose(false)
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+	// Deny unlink in the parent directory.
+	if err := os.Chmod(dir, 0555); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0755) })
+
+	err := removeStaleUnixSocket(socketKindControl, path)
+	if err == nil {
+		t.Fatal("removeStaleUnixSocket() = nil when the unlink failed, want the failure surfaced")
+	}
+	if !strings.Contains(err.Error(), "remove stale") {
+		t.Errorf("error = %q, want it to report the failed removal", err)
+	}
+}
+
+// TestEnsureProcessLockedRefusesLiveControlSocket_5839 pins the check through
+// the PRODUCTION path rather than the primitive alone: bring-up must refuse
+// before spawning a helper, and the live socket must still be there and still
+// serving afterwards.
+func TestEnsureProcessLockedRefusesLiveControlSocket_5839(t *testing.T) {
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	dir := shortSocketDir(t)
+	sock := filepath.Join(dir, "control.sock")
+	listenUnix(t, sock)
+
+	m := New()
+	cfg := config.UserspaceConfig{
+		Binary:        testBinary,
+		ControlSocket: sock,
+		StateFile:     filepath.Join(dir, "state.json"),
+	}
+	m.mu.Lock()
+	err = m.ensureProcessLocked(cfg)
+	m.mu.Unlock()
+
+	if err == nil {
+		t.Fatal("ensureProcessLocked() = nil with a LIVE listener on the control socket, want refusal")
+	}
+	if !strings.Contains(err.Error(), "live listener") {
+		t.Errorf("error = %q, want it to name the live listener", err)
+	}
+	if m.proc != nil {
+		t.Errorf("helper spawned despite the refusal: %+v", m.proc)
+	}
+	if _, statErr := os.Lstat(sock); statErr != nil {
+		t.Fatalf("live control socket was unlinked by bring-up: %v", statErr)
+	}
+	conn, dialErr := net.DialTimeout("unix", sock, 2*time.Second)
+	if dialErr != nil {
+		t.Fatalf("live control socket no longer reachable after bring-up refusal: %v", dialErr)
+	}
+	_ = conn.Close()
+}
+
+// TestEnsureProcessLockedRefusesNonSocketControlPath_5839 is the data-loss
+// case through the production path: a regular file at the control-socket path
+// must be preserved and bring-up must fail closed.
+func TestEnsureProcessLockedRefusesNonSocketControlPath_5839(t *testing.T) {
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	dir := shortSocketDir(t)
+	sock := filepath.Join(dir, "control.sock")
+	const payload = "operator data that must survive bring-up"
+	if err := os.WriteFile(sock, []byte(payload), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	m := New()
+	cfg := config.UserspaceConfig{
+		Binary:        testBinary,
+		ControlSocket: sock,
+		StateFile:     filepath.Join(dir, "state.json"),
+	}
+	m.mu.Lock()
+	err = m.ensureProcessLocked(cfg)
+	m.mu.Unlock()
+
+	if err == nil {
+		t.Fatal("ensureProcessLocked() = nil with a regular file at the control socket, want refusal")
+	}
+	if m.proc != nil {
+		t.Errorf("helper spawned despite the refusal: %+v", m.proc)
+	}
+	got, readErr := os.ReadFile(sock)
+	if readErr != nil {
+		t.Fatalf("regular file at the control-socket path was deleted by bring-up: %v", readErr)
+	}
+	if string(got) != payload {
+		t.Errorf("file contents = %q, want %q", got, payload)
+	}
+}
+
+// TestEnsureProcessLockedKeepsRunningHelperOnBadPathSet_5839 pins the ordering
+// half of #5839: ensureProcessLocked stops generation N before it prepares
+// generation N+1, so a path fault used to be paid for with forwarding — the
+// healthy helper was killed and only then did preparation fail, leaving the
+// node with no dataplane at all. A deterministic path fault must be caught
+// while the previous generation is still running.
+func TestEnsureProcessLockedKeepsRunningHelperOnBadPathSet_5839(t *testing.T) {
+	dir := shortSocketDir(t)
+	sock := filepath.Join(dir, "control.sock")
+	if err := os.WriteFile(sock, []byte("not a socket"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// A stand-in for the running helper: ensureProcessLocked only needs a
+	// live *exec.Cmd to decide there is a generation to tear down.
+	running := exec.Command("/bin/sleep", "60")
+	if err := running.Start(); err != nil {
+		t.Fatalf("start stand-in helper: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = running.Process.Kill()
+		_ = running.Wait()
+	})
+
+	m := New()
+	m.proc = running
+	cfg := config.UserspaceConfig{
+		Binary:        "/bin/sleep",
+		ControlSocket: sock,
+		StateFile:     filepath.Join(dir, "state.json"),
+	}
+
+	m.mu.Lock()
+	err := m.ensureProcessLocked(cfg)
+	m.mu.Unlock()
+
+	if err == nil {
+		t.Fatal("ensureProcessLocked() = nil with a non-socket control path, want refusal")
+	}
+	if !strings.Contains(err.Error(), "previous generation left running") {
+		t.Errorf("error = %q, want it to say the previous generation was spared", err)
+	}
+	if m.proc == nil {
+		t.Fatal("running helper was torn down for a config that could never come up")
+	}
+	// Signal 0 probes liveness without delivering anything.
+	if sigErr := m.proc.Process.Signal(syscall.Signal(0)); sigErr != nil {
+		t.Fatalf("running helper process was killed for a config that could never come up: %v", sigErr)
+	}
+}
+
+// TestPreflightHelperPathsRejectsAliasedPaths_5839 pins the aliasing guard: the
+// socket-unlink primitive must never be aimed at the state file, where a
+// REGULAR FILE is the expected object, and the two sockets cannot share a path
+// because the daemon's event listener would occupy the name the helper must
+// bind.
+func TestPreflightHelperPathsRejectsAliasedPaths_5839(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  config.UserspaceConfig
+	}{
+		{
+			name: "control aliases state",
+			cfg: config.UserspaceConfig{
+				ControlSocket: "/run/xpf/dp.sock",
+				StateFile:     "/run/xpf/dp.sock",
+			},
+		},
+		{
+			name: "control aliases event",
+			cfg: config.UserspaceConfig{
+				ControlSocket: "/run/xpf/dp.sock",
+				EventSocket:   "/run/xpf/dp.sock",
+				StateFile:     "/run/xpf/state.json",
+			},
+		},
+		{
+			name: "event aliases state",
+			cfg: config.UserspaceConfig{
+				ControlSocket: "/run/xpf/dp.sock",
+				EventSocket:   "/run/xpf/state.json",
+				StateFile:     "/run/xpf/state.json",
+			},
+		},
+		{
+			name: "derived event socket aliases an explicit control socket",
+			cfg: config.UserspaceConfig{
+				ControlSocket: "/run/xpf/userspace-dp-events.sock",
+				StateFile:     "/run/xpf/state.json",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := preflightHelperPaths(tc.cfg)
+			if err == nil {
+				t.Fatal("preflightHelperPaths() = nil, want a distinct-paths refusal")
+			}
+			if !strings.Contains(err.Error(), "distinct paths") {
+				t.Errorf("error = %q, want a distinct-paths refusal", err)
+			}
+		})
+	}
+
+	ok := config.UserspaceConfig{
+		ControlSocket: "/run/xpf/userspace-dp.sock",
+		StateFile:     "/run/xpf/state.json",
+	}
+	if err := preflightHelperPaths(ok); err != nil {
+		t.Fatalf("preflightHelperPaths() on the default-shaped path set = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
Closes #5839

The control-socket half of userspace helper bring-up still removed its stale
socket with a bare `_ = os.Remove(cfg.ControlSocket)`. The path is
operator-supplied (`system dataplane control-socket`) and xpfd runs as root, so
that unlink deleted whatever filesystem object the path named — a regular file,
a symlink, a directory entry, or the **live socket of a running helper** — and
discarded the failure when it could not.

The sibling EVENT-socket half was hardened in #5273 (`7c00ef1bd`,
`removeStaleEventStreamSocket`). This PR extracts that logic into
`removeStaleUnixSocket` (new `pkg/dataplane/userspace/stale_socket.go`) so
stale-socket removal has ONE implementation — an explicit #5839 invariant — and
points the control socket at it.

## Which of the four checks apply

All four. Assessed individually, not copied:

| Check | Applies to the control socket? | Why |
|---|---|---|
| `Lstat`, not-exists tolerated | **Yes** | A first boot has no socket. `Lstat` rather than `Stat` so a symlink is judged on its own inode instead of being followed into an unlink of its target. |
| `os.ModeSocket` gate | **Yes** | This is the data-destruction case, and the path is operator-supplied. A regular file / directory / FIFO / device / symlink is preserved and refused. |
| `/proc/net/unix` liveness probe | **Yes — this is the one that matters** | Unlinking a live listener's socket does not stop that listener; it keeps serving an unreachable inode while a second process binds a fresh socket at the same name. For the control socket the surviving helper becomes undialable — including by the #1993 boot armed-probe, which resolves forwarding state through exactly this path — while the new helper cannot claim the AF_XDP queues the first still holds. The probe is non-invasive by design: dialing would, on the event socket, make the daemon accept the probe as its new helper and drop the real one. |
| Non-ignored `os.Remove` | **Yes** | A failed unlink (EACCES, EROFS) must fail bring-up rather than proceed into a bind that fails more confusingly. |

**Judged INAPPLICABLE: the sidecar `flock`.** `EventStream.Start` holds one
across its call, which serializes daemon-side *owners* of the socket it binds.
xpfd does not bind the control socket — the Rust helper does
(`remove_stale_socket`, `userspace-dp/src/server/lifecycle.rs`), and it does not
participate in the flock protocol. A daemon-side lock there would serialize
nothing, and making it meaningful would be a cross-binary protocol change (and
would move the Rust binary, owing a smoke). Not attempted.

## Ordering: the guard alone would have been an availability regression

`ensureProcessLocked` stops generation N before it prepares generation N+1. So
the guarded removal **on its own** would have converted "silently delete a
regular file and continue" into "tear down forwarding, then fail" — worse than
the bug for a misconfigured path. `preflightHelperPaths` therefore runs the
DETERMINISTIC checks — control/event/state must name distinct paths, and neither
socket path may already exist as a non-socket — BEFORE the stop, via
`stopForNewGenerationLocked`. A config that could never bring up a new
generation now leaves the previous one, and its forwarding, running.

The liveness check is deliberately NOT hoisted: the control socket is live
precisely until the helper holding it is stopped. An inconclusive `Lstat` in the
preflight is left to the post-stop path rather than turned into a new failure on
a code path that previously had none.

`EventStream.Close` keeps its own unlink — `ownsSocket` is set only after that
EventStream bound the path under the flock, so ownership is already established
and the liveness probe would find the listener just closed above — but it now
logs a failure instead of discarding it.

## Typing `control-socket` (#1960 analysis)

Shipped. `ValueUnixSocketPath` + `ValidateUnixSocketPath`: absolute, no
`.`/`..`/empty component, no trailing `/`, no control characters, within the
107-octet AF_UNIX `sun_path` limit.

It is **no-brick**: the gate binds STRICT commits only. `compileTreeLenient`
(`pkg/configstore/store.go`) warns and keeps booting a stored or peer-synced
config carrying a stale value — the documented #1319/#1960 doctrine — so a
deployment whose committed path this validator would reject still boots and
still forwards, and only the operator's next strict commit rejects it. The
values it rejects are ones that either cannot work at all (over `sun_path`) or
work only by accident (a relative path resolved against each process's cwd).
The runtime does not depend on this gate: `removeStaleUnixSocket` re-judges the
path defensively at every bring-up, which is what protects a value that never
passed through a strict commit.

## Mutation matrix

Every cell: mutation applied to a clean tree in a separate worktree, `go vet`
rc read first so a red is an ASSERTION red and not a compile error, `go test`
exit code read from `$?` (never through a pipe), tree restored before the next
cell. Control cell (unmutated) rc=0.

| # | Mutation | `go vet` | `go test` | Assertion that fired |
|---|---|---|---|---|
| M1 | **liveness check removed** (the required one) | rc=0 | **rc=1** | `removeStaleUnixSocket() = nil for a socket with a LIVE listener` **and**, through the production path, `live control socket was unlinked by bring-up: lstat ...: no such file or directory` — i.e. the mutation reproduces the reported defect exactly (5.02s: bring-up then proceeded to spawn a helper) |
| M2 | `os.ModeSocket` gate removed | rc=0 | **rc=1** | all four file-type subtests: `= nil, want refusal for a regular file` / `directory` / `fifo` / `symlink to a socket` |
| M3 | `os.Remove` failure discarded (`_ = os.Remove`) | rc=0 | **rc=1** | `= nil when the unlink failed, want the failure surfaced` |
| M4 | `Lstat` → `Stat` (symlink followed) | rc=0 | **rc=1** | `= nil, want refusal for a symlink to a socket` — with `Stat` the symlink is followed to a live socket, the liveness probe then matches the SYMLINK path (not the target) in `/proc/net/unix`, reads "stale", and unlinks |
| M5 | pre-stop preflight removed | rc=0 | **rc=1** | `running helper was torn down for a config that could never come up` (2.00s — the duration is the teardown) |
| M6 | `control-socket` leaf untyped again | rc=0 | **rc=1** | `SchemaValidate accepted control-socket "userspace-dp.sock"` and `".../../etc/shadow"` |

## Tests

`pkg/dataplane/userspace/stale_socket_5839_test.go` (8 tests): every non-socket
file type is refused **and still present** afterwards; a live socket is refused,
still present, and still **dialable**; a stale socket (bound then closed with
`SetUnlinkOnClose(false)`, what a SIGKILLed helper leaves) is removed; a missing
path is not an error; a failed unlink is surfaced (skipped as root, which
bypasses directory permissions); a regular file at the control-socket path
survives `ensureProcessLocked` with its contents intact; a bad path set leaves a
running helper **process** alive (probed with signal 0). Socket fixtures use a
short `/tmp` scratch dir — a `t.TempDir()` path can exceed the 108-byte
`sun_path` limit and fail at bind instead of at the behaviour under test.

`pkg/config/control_socket_typed_5839_test.go`: accept/reject table including
the exact 107/108-octet boundary, plus the leaf driven through `SchemaValidate`
**and** `CompileConfig` so it is pinned as WIRED, not merely defined.

## Known residual — filed as #7139, not silently left

The checks judge a path STRING and the unlink is a separate syscall on that
string. A live socket reached through a different spelling of the same file
(most plausibly a symlinked parent) is not matched in `/proc/net/unix` and reads
as stale; and the target can be swapped between check and unlink. Closing either
needs the `openat2(RESOLVE_BENEATH)` trusted-directory rework #5839 names as its
fix direction, or an inode-keyed liveness decision. Documented at the primitive,
in the validator, and in `docs/userspace-dataplane-architecture.md`; tracked in
**#7139**.

## Validation

- `go test -count=1 ./...` — **exit 0** (read from `$?`).
- `go vet ./...` — **exit 0**.
- Docs updated in the same change: `docs/userspace-dataplane-architecture.md`
  (new "Socket path handling" section + the `control-socket` table row),
  `docs/config-schema.md` (typed-leaf section with the #1960 analysis), `_Log.md`.

**No cluster smoke owed.** The diff is Go-only — `git diff --name-only
origin/master...HEAD` matches nothing under `userspace-dp/`, `userspace-xdp/`,
or any `.rs`/`.c`/`.h`/`.o`. No helper binary or shim artifact moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJx3qPFEUzg7Lm5mCSCf44