### PR TITLE
cluster: key the HA failover fence barrier by request (#6177 items 2+3)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -97879,3 +97879,58 @@ prose edit above them added. No diff falls in the new test body.
   pkg/daemon/daemon_ha_actuation_6371_test.go,
   pkg/cluster/sync_failover_fence_verdict_6371_test.go,
   docs/session-sync-architecture.md, _Log.md
+- **Timestamp**: 2026-08-21
+- **Action**: Fixed #6177 items 2 and 3 — the HA failover fence barrier is now
+  keyed by the peer's REQUEST id, not by the redundancy group alone, and its
+  arm/disarm/wait/timeout lifecycle has direct tests. Item 1 (the RETH VIP
+  removal window) stays OPEN: it is a VRRP state-machine design change, not a
+  barrier fix, and the issue keeps it.
+
+  Item 2. `disarmFailoverActuation` deleted `failoverActuateWait[rgID]` by KEY,
+  with no check that the entry was still the barrier the caller armed, and
+  `waitFailoverActuated`'s expiry called it. The responder handles every
+  `syncMsgFailover` on its own goroutine (`go s.handleRemoteFailover`, sync_conn_read.go),
+  so two transfer-out cycles for one RG can overlap: an older request's expiry
+  then deleted the slot a newer request had just armed, the newer wait found
+  nothing, `waitFailoverActuated` returned nil — "actuated" — and the node
+  replied `failoverAckApplied` for a demotion it had not performed. That is the
+  two-owner window #5640 exists to close, reached through the bookkeeping
+  instead of through the ack.
+
+  The map is now keyed by `failoverActuationKey{rgID, reqID}`;
+  `armFailoverActuation(rgID, reqID)` returns the barrier it stored and
+  `disarmFailoverActuation(rgID, reqID, b)` removes the entry only while it is
+  still that barrier, so a superseded handle — a duplicate request message
+  re-using one request id — cannot evict a live one either. reqID reaches the
+  wait through `SessionSync.WaitFailoverApplied`/`WaitFailoverAppliedBatch`,
+  whose signatures gain the request id that `OnRemoteFailover` already received
+  (no wire change; the id is already on the wire). The demotion event carries no
+  request id — it reports that this node finished demoting the RG — so
+  `resolveFailoverActuation` fans its verdict out over every request in flight
+  for that RG.
+
+  Item 3. `daemon_ha_actuation_6371_test.go` (added by #7118) covers the verdict
+  legs — success, dataplane rejection, a parked waiter, an unarmed RG — but
+  nothing covered the barrier's own lifecycle. Seven new tests in
+  `daemon_ha_actuation_barrier_6177_test.go` drive arm/disarm/wait/timeout
+  directly: the bounded-wait expiry returns a failure and drops the stranded
+  barrier, an expired request leaves a concurrent request armed, a stale handle
+  cannot disarm a re-armed request, the verdict fans out across requests, a
+  disarmed request returns immediately, the batch wait takes the first failure,
+  and concurrent resolves never double-close.
+
+  Validation: `go test -count=1 ./pkg/daemon/ ./pkg/cluster/` exit 0;
+  `go test -count=1 -race -run FailoverActuation ./pkg/daemon/` exit 0;
+  `go vet ./...` and `go build ./...` exit 0. Mutation matrix, 7/7 RED on the
+  intended assertion: key by RG only; disarm without the identity check; wait
+  returning nil on timeout; timeout leaving the barrier stranded; resolve
+  stopping at the first request; and both fence hooks called with reqID 0.
+  HA/failover code — `make test-failover` is owed before merge (not run here:
+  the loss cluster is shared and lock-protected).
+- **File(s)**: pkg/daemon/daemon_ha.go, pkg/daemon/daemon.go,
+  pkg/daemon/daemon_ha_sync.go, pkg/cluster/sync.go,
+  pkg/cluster/sync_failover.go, pkg/cluster/sync_test.go,
+  pkg/cluster/sync_failover_fence_verdict_6371_test.go,
+  pkg/daemon/daemon_ha_actuation_6371_test.go,
+  pkg/daemon/daemon_ha_actuation_barrier_6177_test.go,
+  docs/session-sync-architecture.md, _Log.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -1639,6 +1639,14 @@ event channel (`sendEvent`) before returning. The actual fence — `ResignRG`
 by the daemon's `watchClusterEvents` consumer, not synchronously inside
 `ManualFailover`.
 
+On the RETH-VRRP path `ResignRG` itself is only half-synchronous: it drops the
+instance priority to 0 under the instance lock and then does a **non-blocking**
+send on `resignCh`. The priority-0 adverts and the `becomeBackup` VIP removal
+run on the VRRP instance's own loop, so "resigned" below means *resignation
+signalled and priority driven to 0*, not *VIPs off the wire* (#6177 item 1).
+Direct-VIP mode (`no-reth-vrrp`) has no such gap — `reconcileDirectVIPOwnership`
+removes the addresses inline on the event goroutine.
+
 `handleRemoteFailover` (`pkg/cluster/sync_failover.go`) therefore must **not**
 reply `failoverAckApplied` the instant `OnRemoteFailover` returns: the sender
 treats that ack as authorization to run `commitRequestedPeerFailover` and become
@@ -1650,15 +1658,25 @@ ownership / traffic).
 The fix gates the applied-ack on a fence-completion barrier:
 
 1. The daemon `OnRemoteFailover`/`OnRemoteFailoverBatch` closures call
-   `armFailoverActuation(rgID)` — registering a per-RG barrier — **before**
-   `ManualFailover` enqueues the demotion event, so the actuation signal can
-   never be missed. A `ManualFailover` error disarms the barrier.
+   `armFailoverActuation(rgID, reqID)` — registering a barrier keyed by
+   **(RG, peer request id)** — **before** `ManualFailover` enqueues the demotion
+   event, so the actuation signal can never be missed. A `ManualFailover` error
+   disarms the barrier, passing back the handle `arm` returned so the disarm can
+   only ever remove *that* barrier (#6177 item 2). Keying on the request rather
+   than on the RG alone is what keeps one transfer-out cycle from disturbing
+   another: the responder handles each `syncMsgFailover` on its own goroutine, so
+   before #6177 an older request's expiry could delete the slot a newer request
+   had just armed — the newer wait then found nothing, returned "actuated", and
+   the node acked `failoverAckApplied` for a demotion it had not performed.
 2. `handleRemoteFailover` calls the `WaitFailoverApplied` hook (wired to
    `waitFailoverActuated`) after `OnRemoteFailover` succeeds and before sending
    `failoverAckApplied`. It blocks on the barrier.
 3. `handleClusterEvent` (the per-event body of `watchClusterEvents`), at the end
    of the demotion (non-primary) branch — after `ResignRG` / direct-VIP
    reconcile / `rg_active` clear — resolves the barrier and releases the ack.
+   The demotion event carries no request id — it reports that *this node*
+   finished demoting the RG — so `resolveFailoverActuation` fans the verdict out
+   across every request in flight for that RG.
 4. The barrier carries a **verdict**, not just a completion (#6371). The
    demotion branch tracks whether the dataplane accepted the `rg_active` write:
    on success it calls `signalFailoverActuated(rgID)` (verdict `nil`), and on a
@@ -1679,7 +1697,21 @@ The fix gates the applied-ack on a fence-completion barrier:
    unchanged.
 
 The batch path (`handleRemoteFailoverBatch` / `WaitFailoverAppliedBatch`) applies
-the same per-RG barrier across the whole set.
+the same barrier across the whole set, all members armed under the one batch
+request id; the first non-nil verdict fails the batch ack.
+
+**Residual (#6177 item 1, open).** On the RETH-VRRP path the barrier releases
+once resignation has been *signalled* (priority 0 set synchronously) and
+`rg_active` is cleared — not once `becomeBackup` has physically removed the
+VIPs. A sub-millisecond window therefore remains in which the peer may promote
+while the old owner's VIPs are still on the interface. It is safe-direction
+rather than benign-by-luck: priority-0 is set synchronously so the resigning
+node cannot win a re-election, and the demotion preflight
+(`tryPrepareUserspaceRGDemotion`) has already shifted the flow cache to
+`FabricRedirect`, so transit traffic reaching the old owner is forwarded over
+the fabric rather than dropped. Closing it means gating the barrier release on a
+`becomeBackup` completion signal from the VRRP instance loop, which is a change
+to the VRRP state machine rather than to this barrier.
 
 Once the RG is marked standby, each worker processes a
 `WorkerCommand::DemoteOwnerRGS` on its packet thread

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -433,19 +433,27 @@ type SessionSync struct {
 	// WaitFailoverApplied, if set, blocks until the local node has ACTUATED
 	// the transfer-out just requested via OnRemoteFailover for one RG — i.e.
 	// the async demotion event has been consumed and the old owner fenced
-	// (VRRP resigned to priority-0 / VIPs removed / rg_active cleared). It
-	// gates the failoverAckApplied reply so the peer cannot promote while this
-	// node still externally owns the RG. OnRemoteFailover only ENQUEUES the
-	// demotion event and returns; acking before this barrier opened a
-	// two-owner window (duplicate GARP / VIP ownership / traffic) — #5640. A
-	// non-nil error (fence not actuated within the daemon's bounded timeout)
-	// downgrades the ack to failoverAckFailed so the peer holds instead of
-	// promoting into the two-owner window.
-	WaitFailoverApplied func(rgID int) error
+	// (VRRP resignation signalled and priority driven to 0, or direct VIP
+	// ownership reconciled away, plus rg_active cleared). On the RETH-VRRP
+	// path the physical VIP removal runs on the VRRP instance's own loop and
+	// is NOT waited for here (#6177 item 1). It gates the failoverAckApplied
+	// reply so the peer cannot promote while this node still externally owns
+	// the RG. OnRemoteFailover only ENQUEUES the demotion event and returns;
+	// acking before this barrier opened a two-owner window (duplicate GARP /
+	// VIP ownership / traffic) — #5640. A non-nil error (fence not actuated
+	// within the daemon's bounded timeout) downgrades the ack to
+	// failoverAckFailed so the peer holds instead of promoting into the
+	// two-owner window.
+	//
+	// reqID is the same request identifier passed to OnRemoteFailover, so the
+	// daemon can wait on the barrier THAT request armed rather than on
+	// whatever barrier the RG happens to hold (#6177).
+	WaitFailoverApplied func(rgID int, reqID uint64) error
 	// WaitFailoverAppliedBatch is the multi-RG counterpart of
 	// WaitFailoverApplied: it blocks until every RG in the batch has been
-	// fenced before the batch failoverAckApplied reply is sent (#5640).
-	WaitFailoverAppliedBatch func(rgIDs []int) error
+	// fenced before the batch failoverAckApplied reply is sent (#5640). reqID
+	// identifies the batch request whose barriers are being waited on (#6177).
+	WaitFailoverAppliedBatch func(rgIDs []int, reqID uint64) error
 	// OnFenceReceived requests this node to disable all RGs.
 	OnFenceReceived func()
 	// OnPrepareActivation asks the peer to pre-warm neighbors for the given RG.

--- a/pkg/cluster/sync_failover.go
+++ b/pkg/cluster/sync_failover.go
@@ -441,7 +441,7 @@ func (s *SessionSync) handleRemoteFailover(conn net.Conn, rgID int, reqID uint64
 	// actuate within the bounded timeout, downgrade to failed so the peer
 	// holds rather than joining a split-brain.
 	if s.WaitFailoverApplied != nil {
-		if err := s.WaitFailoverApplied(rgID); err != nil {
+		if err := s.WaitFailoverApplied(rgID, reqID); err != nil {
 			slog.Warn("cluster sync: remote failover fence barrier failed", "rg", rgID, "req_id", reqID, "err", err)
 			s.sendFailoverResult(conn, syncMsgFailoverAck, rgID, reqID, failoverAckFailed, err.Error())
 			return
@@ -466,7 +466,7 @@ func (s *SessionSync) handleRemoteFailoverBatch(conn net.Conn, rgIDs []int, reqI
 	// handleRemoteFailover for the two-owner rationale — a batch handoff that
 	// acks before actuation opens the same window across the whole set.
 	if s.WaitFailoverAppliedBatch != nil {
-		if err := s.WaitFailoverAppliedBatch(rgIDs); err != nil {
+		if err := s.WaitFailoverAppliedBatch(rgIDs, reqID); err != nil {
 			slog.Warn("cluster sync: remote batch failover fence barrier failed", "rgs", rgIDs, "req_id", reqID, "err", err)
 			s.sendFailoverBatchResult(conn, syncMsgFailoverBatchAck, rgIDs, reqID, failoverAckFailed, err.Error())
 			return

--- a/pkg/cluster/sync_failover_fence_verdict_6371_test.go
+++ b/pkg/cluster/sync_failover_fence_verdict_6371_test.go
@@ -28,7 +28,7 @@ func TestHandleRemoteFailoverFailedFenceDowngradesAck(t *testing.T) {
 
 	ss.OnRemoteFailover = func(int, uint64) error { return nil }
 	fenceErr := errors.New("redundancy group 7 rg_active=false not applied on demotion")
-	ss.WaitFailoverApplied = func(int) error { return fenceErr }
+	ss.WaitFailoverApplied = func(int, uint64) error { return fenceErr }
 
 	frames := make(chan syncFrame, 4)
 	readFramesInto(peer, frames)

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -3729,9 +3729,15 @@ func TestHandleRemoteFailoverWithholdsAckUntilFenced(t *testing.T) {
 	// watchClusterEvents actuates the demotion.
 	fenced := make(chan struct{})
 	waitEntered := make(chan struct{}, 1)
-	ss.WaitFailoverApplied = func(rgID int) error {
+	ss.WaitFailoverApplied = func(rgID int, reqID uint64) error {
 		if rgID != 7 {
 			return fmt.Errorf("unexpected rg %d", rgID)
+		}
+		// #6177: the fence must be waited on for the SAME request the
+		// handler armed. A mismatch would leave the wait reading a barrier
+		// that belongs to another cycle (or none at all).
+		if reqID != 42 {
+			return fmt.Errorf("fence waited on request %d, want 42", reqID)
 		}
 		select {
 		case waitEntered <- struct{}{}:
@@ -3803,7 +3809,14 @@ func TestHandleRemoteFailoverBatchWithholdsAckUntilFenced(t *testing.T) {
 
 	fenced := make(chan struct{})
 	waitEntered := make(chan struct{}, 1)
-	ss.WaitFailoverAppliedBatch = func([]int) error {
+	ss.WaitFailoverAppliedBatch = func(gotRGs []int, reqID uint64) error {
+		// #6177: same-request binding as the single-RG case above.
+		if reqID != 43 {
+			return fmt.Errorf("batch fence waited on request %d, want 43", reqID)
+		}
+		if len(gotRGs) != 2 {
+			return fmt.Errorf("batch fence waited on %v, want 2 RGs", gotRGs)
+		}
 		select {
 		case waitEntered <- struct{}{}:
 		default:

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -946,8 +946,10 @@ type Daemon struct {
 	// carries a verdict, not just a completion: a demotion whose rg_active
 	// clear was REJECTED by the dataplane resolves with that error so the ack
 	// is downgraded rather than reported applied (#6371).
-	failoverActuateMu   sync.Mutex
-	failoverActuateWait map[int]*failoverActuation
+	failoverActuateMu sync.Mutex
+	// The map is keyed by (RG, peer request id) so a stale request's disarm
+	// or expired wait can never evict a newer request's barrier (#6177).
+	failoverActuateWait map[failoverActuationKey]*failoverActuation
 	// failoverActuateTimeout bounds waitFailoverActuated so a demotion event
 	// that is never actuated (superseded reset, event-channel drop) downgrades
 	// the ack to failed instead of hanging the peer's failover request.
@@ -1260,7 +1262,7 @@ func New(opts Options) (*Daemon, error) {
 		localFailoverCommitReady:   make(map[int]bool),
 		localFailoverCommitTimeout: 3 * time.Second,
 		localFailoverCommitDelay:   200 * time.Millisecond,
-		failoverActuateWait:        make(map[int]*failoverActuation),
+		failoverActuateWait:        make(map[failoverActuationKey]*failoverActuation),
 		failoverActuateTimeout:     3 * time.Second,
 		userspaceDemotionPrepUntil: make(map[int]time.Time),
 		applySem:                   semaphore.NewWeighted(1),

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -139,7 +139,7 @@ func (d *Daemon) waitLocalFailoverCommitReady(rgIDs []int) error {
 	}
 }
 
-// failoverActuation is the per-RG fence-completion barrier armed before a
+// failoverActuation is the fence-completion barrier armed before a
 // remote-requested transfer-out. done is closed exactly once, when the local
 // demotion has been RESOLVED; err is the verdict (nil = the demotion actually
 // actuated, non-nil = it did not) and is written under failoverActuateMu before
@@ -150,29 +150,59 @@ type failoverActuation struct {
 	err      error
 }
 
-// armFailoverActuation registers a fence-completion barrier for rgID before a
-// remote-requested transfer-out enqueues its async demotion event. It MUST be
-// called before cluster.ManualFailover so the demotion actuation
-// (watchClusterEvents → signalFailoverActuated) cannot close-and-forget the
-// barrier before waitFailoverActuated observes it. Concurrent same-RG remote
-// failovers are excluded upstream (cluster.failoverInProgress + the sync-layer
-// failover waiters), so a single channel per RG is sufficient (#5640).
-func (d *Daemon) armFailoverActuation(rgID int) {
+// failoverActuationKey identifies ONE transfer-out request: the redundancy
+// group plus the request id the peer minted for it (SessionSync.failoverSeq).
+// Keying the barrier map on the REQUEST rather than on the RG alone is what
+// makes a stale cycle harmless — an older request's disarm, or the disarm its
+// expired wait performs, can only ever remove its own entry and never the
+// barrier a newer request for the same RG is about to block on (#6177).
+// A peer that sends no request id supplies 0, which degrades to exactly the
+// pre-#6177 one-slot-per-RG behaviour rather than failing.
+type failoverActuationKey struct {
+	rgID  int
+	reqID uint64
+}
+
+// armFailoverActuation registers a fence-completion barrier for (rgID, reqID)
+// before a remote-requested transfer-out enqueues its async demotion event. It
+// MUST be called before cluster.ManualFailover so the demotion actuation
+// (watchClusterEvents -> signalFailoverActuated) cannot close-and-forget the
+// barrier before waitFailoverActuated observes it. It returns the barrier so
+// the caller can hand the same instance back to disarmFailoverActuation: the
+// map slot is the request's, but the identity check is what keeps a superseded
+// handle from evicting a live one (#6177).
+func (d *Daemon) armFailoverActuation(rgID int, reqID uint64) *failoverActuation {
+	b := &failoverActuation{done: make(chan struct{})}
 	d.failoverActuateMu.Lock()
 	if d.failoverActuateWait == nil {
-		d.failoverActuateWait = make(map[int]*failoverActuation)
+		d.failoverActuateWait = make(map[failoverActuationKey]*failoverActuation)
 	}
-	d.failoverActuateWait[rgID] = &failoverActuation{done: make(chan struct{})}
+	d.failoverActuateWait[failoverActuationKey{rgID: rgID, reqID: reqID}] = b
 	d.failoverActuateMu.Unlock()
+	return b
 }
 
 // disarmFailoverActuation drops a barrier that will never be actuated — used
-// when ManualFailover fails to enqueue the demotion (no event will ever fire).
-// It does NOT close the channel: no waiter can be blocked on it because the
-// applied-ack path is not reached on a ManualFailover error.
-func (d *Daemon) disarmFailoverActuation(rgID int) {
+// when ManualFailover fails to enqueue the demotion (no event will ever fire),
+// and by waitFailoverActuated when its bounded wait expires. It does NOT close
+// the channel: on the ManualFailover-error path no waiter can be blocked on it
+// because the applied-ack path is not reached, and on the timeout path the
+// waiter has already given up.
+//
+// b is the barrier the caller armed. The entry is removed only when it is
+// still THAT barrier: a handle that has already been superseded by a re-arm
+// must not evict the live one, which would leave the newer request's wait
+// reading an empty slot and reporting the fence as actuated when it was not
+// (#6177). A nil handle disarms nothing.
+func (d *Daemon) disarmFailoverActuation(rgID int, reqID uint64, b *failoverActuation) {
+	if b == nil {
+		return
+	}
+	key := failoverActuationKey{rgID: rgID, reqID: reqID}
 	d.failoverActuateMu.Lock()
-	delete(d.failoverActuateWait, rgID)
+	if d.failoverActuateWait[key] == b {
+		delete(d.failoverActuateWait, key)
+	}
 	d.failoverActuateMu.Unlock()
 }
 
@@ -197,41 +227,48 @@ func (d *Daemon) signalFailoverActuationFailed(rgID int, cause error) {
 	d.resolveFailoverActuation(rgID, cause)
 }
 
-// resolveFailoverActuation completes rgID's barrier exactly once with verdict
-// cause (nil = actuated). It is idempotent: the resolved flag is set under the
-// lock, so a second demotion event for the same RG is a no-op and never
+// resolveFailoverActuation completes every armed barrier for rgID exactly once
+// with verdict cause (nil = actuated). The demotion event carries no request
+// id, and the fact it reports — this node finished demoting rgID — answers the
+// question every in-flight request for that RG is asking, so the verdict fans
+// out across the RG's entries. It is idempotent: the resolved flag is set under
+// the lock, so a second demotion event for the same RG is a no-op and never
 // double-closes. The verdict is written BEFORE the close, so any goroutine that
 // observes the close also observes the verdict.
 //
-// The barrier is left in the map rather than deleted — waitFailoverActuated
+// A resolved barrier is left in the map rather than deleted — waitFailoverActuated
 // consumes it. Deleting here would make a resolution that lands before the
 // waiter arrives read as "never armed", i.e. success, which would throw away
-// exactly the failure verdict this path exists to deliver (#6371). A re-arm
-// replaces the entry, so the map stays bounded by the RG count.
+// exactly the failure verdict this path exists to deliver (#6371).
 func (d *Daemon) resolveFailoverActuation(rgID int, cause error) {
 	d.failoverActuateMu.Lock()
-	b := d.failoverActuateWait[rgID]
-	if b == nil || b.resolved {
-		d.failoverActuateMu.Unlock()
-		return
+	var resolved []*failoverActuation
+	for key, b := range d.failoverActuateWait {
+		if key.rgID != rgID || b == nil || b.resolved {
+			continue
+		}
+		b.resolved = true
+		b.err = cause
+		resolved = append(resolved, b)
 	}
-	b.resolved = true
-	b.err = cause
 	d.failoverActuateMu.Unlock()
-	close(b.done)
+	for _, b := range resolved {
+		close(b.done)
+	}
 }
 
-// waitFailoverActuated blocks until the local demotion for rgID has been
-// resolved (barrier closed by signalFailoverActuated / -Failed) or the bounded
-// timeout elapses. A nil barrier means the RG was never armed (or an earlier
-// waiter already consumed the verdict) — return immediately. It returns nil
-// only when the demotion actually actuated: a failed actuation surfaces its
-// cause (#6371) and a barrier that never resolves surfaces a timeout. This
-// gates the remote-failover applied-ack so the peer never promotes into a
-// two-owner window (#5640).
-func (d *Daemon) waitFailoverActuated(rgID int) error {
+// waitFailoverActuated blocks until the local demotion for the (rgID, reqID)
+// transfer-out has been resolved (barrier closed by signalFailoverActuated /
+// -Failed) or the bounded timeout elapses. A nil barrier means the request was
+// never armed (or an earlier waiter already consumed the verdict) — return
+// immediately. It returns nil only when the demotion actually actuated: a
+// failed actuation surfaces its cause (#6371) and a barrier that never resolves
+// surfaces a timeout. This gates the remote-failover applied-ack so the peer
+// never promotes into a two-owner window (#5640).
+func (d *Daemon) waitFailoverActuated(rgID int, reqID uint64) error {
+	key := failoverActuationKey{rgID: rgID, reqID: reqID}
 	d.failoverActuateMu.Lock()
-	b := d.failoverActuateWait[rgID]
+	b := d.failoverActuateWait[key]
 	d.failoverActuateMu.Unlock()
 	if b == nil {
 		return nil
@@ -248,24 +285,25 @@ func (d *Daemon) waitFailoverActuated(rgID int) error {
 		// leaving it behind would let a later wait re-read a stale one.
 		d.failoverActuateMu.Lock()
 		err := b.err
-		if d.failoverActuateWait[rgID] == b {
-			delete(d.failoverActuateWait, rgID)
+		if d.failoverActuateWait[key] == b {
+			delete(d.failoverActuateWait, key)
 		}
 		d.failoverActuateMu.Unlock()
 		return err
 	case <-timer.C:
 		// Drop the stranded barrier so a later actuation event does not
-		// close an orphaned channel that no one reads.
-		d.disarmFailoverActuation(rgID)
+		// close an orphaned channel that no one reads. Identity-checked, so
+		// this expiry cannot disturb another request's live barrier (#6177).
+		d.disarmFailoverActuation(rgID, reqID, b)
 		return fmt.Errorf("timed out waiting for local fence actuation of redundancy group %d", rgID)
 	}
 }
 
-// waitFailoverActuatedBatch blocks until every RG in the batch has been fenced,
-// or returns the first RG's timeout (#5640).
-func (d *Daemon) waitFailoverActuatedBatch(rgIDs []int) error {
+// waitFailoverActuatedBatch blocks until every RG in the batch transfer-out
+// reqID has been fenced, or returns the first RG's failure verdict (#5640).
+func (d *Daemon) waitFailoverActuatedBatch(rgIDs []int, reqID uint64) error {
 	for _, rgID := range rgIDs {
-		if err := d.waitFailoverActuated(rgID); err != nil {
+		if err := d.waitFailoverActuated(rgID, reqID); err != nil {
 			return err
 		}
 	}

--- a/pkg/daemon/daemon_ha_actuation_6371_test.go
+++ b/pkg/daemon/daemon_ha_actuation_6371_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/psaab/xpf/pkg/vrrp"
 )
 
+// actuationReqID is the peer request id these tests transfer RG1 under. The
+// barrier is keyed by (RG, request), so arm and wait must name the same one
+// (#6177).
+const actuationReqID uint64 = 42
+
 // errRGActiveRejected models the dataplane refusing an rg_active write — the
 // helper is down, the control socket errored, the RG is unknown.
 var errRGActiveRejected = errors.New("helper rejected rg_active write")
@@ -95,7 +100,7 @@ func newActuationDaemon(t *testing.T, ha *actuationHA) *Daemon {
 		cluster:                    cm,
 		vrrpMgr:                    vrrp.NewManager(),
 		rgStates:                   make(map[int]*rgStateMachine),
-		failoverActuateWait:        make(map[int]*failoverActuation),
+		failoverActuateWait:        make(map[failoverActuationKey]*failoverActuation),
 		failoverActuateTimeout:     2 * time.Second,
 		userspaceDemotionPrepUntil: make(map[int]time.Time),
 	}
@@ -165,7 +170,7 @@ func TestFailoverActuation_FailedRGActiveClearDoesNotAck(t *testing.T) {
 	d := newActuationDaemon(t, ha)
 	primeRG1Primary(t, d)
 
-	d.armFailoverActuation(1)
+	d.armFailoverActuation(1, actuationReqID)
 	demoteRG1(t, d)
 
 	// Positive control: the demotion really reached the rg_active write with
@@ -177,7 +182,7 @@ func TestFailoverActuation_FailedRGActiveClearDoesNotAck(t *testing.T) {
 		t.Fatalf("SetRGActive wrote active=%v, want false (a demotion clears rg_active)", active)
 	}
 
-	err := d.waitFailoverActuated(1)
+	err := d.waitFailoverActuated(1, actuationReqID)
 	if err == nil {
 		t.Fatal("waitFailoverActuated returned nil after a FAILED rg_active clear: " +
 			"the applied-ack would tell the peer to promote while this node may still forward (#6371)")
@@ -200,13 +205,13 @@ func TestFailoverActuation_SucceededRGActiveClearAcks(t *testing.T) {
 	d := newActuationDaemon(t, ha)
 	primeRG1Primary(t, d)
 
-	d.armFailoverActuation(1)
+	d.armFailoverActuation(1, actuationReqID)
 	demoteRG1(t, d)
 
 	if got := ha.writeCount(); got != 1 {
 		t.Fatalf("SetRGActive call count = %d, want 1", got)
 	}
-	if err := d.waitFailoverActuated(1); err != nil {
+	if err := d.waitFailoverActuated(1, actuationReqID); err != nil {
 		t.Fatalf("waitFailoverActuated = %v, want nil after a successful clear", err)
 	}
 }
@@ -220,9 +225,9 @@ func TestFailoverActuation_ParkedWaiterSeesFailure(t *testing.T) {
 	d := newActuationDaemon(t, ha)
 	primeRG1Primary(t, d)
 
-	d.armFailoverActuation(1)
+	d.armFailoverActuation(1, actuationReqID)
 	errCh := make(chan error, 1)
-	go func() { errCh <- d.waitFailoverActuated(1) }()
+	go func() { errCh <- d.waitFailoverActuated(1, actuationReqID) }()
 	// Give the waiter time to park on the barrier. The assertion holds for
 	// either ordering — a waiter that has not parked yet takes the
 	// consume-after-resolution path and reads the same verdict.
@@ -254,7 +259,7 @@ func TestFailoverActuation_UnarmedRGIsNoop(t *testing.T) {
 	// No armFailoverActuation: this is an ordinary local demotion.
 	demoteRG1(t, d)
 
-	if err := d.waitFailoverActuated(1); err != nil {
+	if err := d.waitFailoverActuated(1, actuationReqID); err != nil {
 		t.Fatalf("waitFailoverActuated on an unarmed RG = %v, want nil", err)
 	}
 }

--- a/pkg/daemon/daemon_ha_actuation_barrier_6177_test.go
+++ b/pkg/daemon/daemon_ha_actuation_barrier_6177_test.go
@@ -1,0 +1,280 @@
+package daemon
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// This file covers the failover fence barrier's OWN arm/disarm/wait/timeout
+// bookkeeping (#6177). The sibling daemon_ha_actuation_6371_test.go drives the
+// barrier through handleClusterEvent and pins the VERDICT the demotion
+// delivers; nothing pinned the barrier's lifecycle itself — the timeout leg,
+// the disarm leg, the map cleanup, and the request-identity rules that keep one
+// transfer-out cycle from disturbing another.
+//
+// The barrier is a self-contained mutex+map on Daemon, so these drive it
+// directly: a bare Daemon reaches every branch and cannot pass for an unrelated
+// reason.
+
+// newBarrierDaemon builds the minimum Daemon the barrier API needs.
+func newBarrierDaemon(timeout time.Duration) *Daemon {
+	return &Daemon{
+		failoverActuateWait:    make(map[failoverActuationKey]*failoverActuation),
+		failoverActuateTimeout: timeout,
+	}
+}
+
+// armedBarriers reports how many barriers are still held. Every arm must be
+// released by exactly one wait or disarm, so a test that finishes with a
+// non-zero count has leaked a channel no one will ever close or read.
+func armedBarriers(d *Daemon) int {
+	d.failoverActuateMu.Lock()
+	defer d.failoverActuateMu.Unlock()
+	return len(d.failoverActuateWait)
+}
+
+// errFenceRejected stands in for the dataplane refusing the demotion write —
+// the verdict signalFailoverActuationFailed carries.
+var errFenceRejected = errors.New("rg_active clear rejected")
+
+// TestFailoverActuationBarrier_TimeoutReportsFailureAndDropsBarrier covers the
+// leg the #6371 tests do not reach: a demotion event that never arrives. The
+// wait must expire with a NON-nil verdict (a nil would ack the transfer as
+// applied and let the peer promote against a node that never demoted), and it
+// must leave nothing behind — a stranded barrier would be closed later by a
+// demotion event with no reader.
+//
+// Fail-on-revert: return nil from the `case <-timer.C` branch of
+// waitFailoverActuated and the first assertion reds; drop the
+// disarmFailoverActuation call in that branch and the leak assertion reds.
+func TestFailoverActuationBarrier_TimeoutReportsFailureAndDropsBarrier(t *testing.T) {
+	d := newBarrierDaemon(40 * time.Millisecond)
+	d.armFailoverActuation(1, 7)
+
+	start := time.Now()
+	err := d.waitFailoverActuated(1, 7)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("waitFailoverActuated returned nil for a demotion that never actuated: " +
+			"the applied-ack would tell the peer to promote against a node that never demoted")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("verdict = %v, want the bounded-wait timeout", err)
+	}
+	// Positive control: the wait really parked on the barrier. An instant
+	// return would mean the barrier was never armed and the assertion above
+	// passed for the wrong reason.
+	if elapsed < 40*time.Millisecond {
+		t.Fatalf("wait returned after %v, want at least the %v timeout", elapsed, 40*time.Millisecond)
+	}
+	if n := armedBarriers(d); n != 0 {
+		t.Fatalf("armed barriers after an expired wait = %d, want 0: the expiry must drop "+
+			"the stranded barrier so a late demotion event has nothing to close", n)
+	}
+	// A late demotion event for the RG must be a harmless no-op, not a close
+	// of an already-abandoned channel.
+	d.signalFailoverActuated(1)
+	if n := armedBarriers(d); n != 0 {
+		t.Fatalf("armed barriers after a late actuation = %d, want 0", n)
+	}
+}
+
+// TestFailoverActuationBarrier_ExpiredRequestKeepsNewerRequestArmed is the
+// #6177 item-2 regression. An expired wait disarms — and before the barrier map
+// was keyed by request, that disarm deleted the RG's slot outright. A newer
+// transfer-out for the same RG that had already armed lost its barrier, so its
+// wait found nothing, returned nil, and the node acked APPLIED for a demotion
+// it had not performed: the two-owner window #5640 exists to prevent.
+//
+// Fail-on-revert: key failoverActuateWait by rgID alone (or drop reqID from the
+// key), and the newer request's barrier is deleted by the older one's expiry —
+// the wait below returns nil and this reds on a clean assertion.
+func TestFailoverActuationBarrier_ExpiredRequestKeepsNewerRequestArmed(t *testing.T) {
+	d := newBarrierDaemon(40 * time.Millisecond)
+
+	d.armFailoverActuation(1, 1) // older cycle, its demotion event never lands
+	expired := make(chan error, 1)
+	go func() { expired <- d.waitFailoverActuated(1, 1) }()
+
+	d.armFailoverActuation(1, 2) // newer cycle for the same RG
+
+	select {
+	case err := <-expired:
+		if err == nil {
+			t.Fatal("the older request's wait must expire with a failure verdict")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the older request's wait never expired")
+	}
+
+	// The newer request must still be armed: its demotion verdict has to reach
+	// its waiter. Resolving with a FAILURE makes the difference observable —
+	// a barrier the expiry wrongly deleted resolves to nothing and its wait
+	// reports success.
+	d.signalFailoverActuationFailed(1, errFenceRejected)
+	err := d.waitFailoverActuated(1, 2)
+	if err == nil {
+		t.Fatal("the newer request's wait returned nil: an older request's expiry deleted " +
+			"its barrier, so a REJECTED demotion would be acked as applied (#6177)")
+	}
+	if !errors.Is(err, errFenceRejected) {
+		t.Fatalf("verdict = %v, want the demotion rejection", err)
+	}
+	if n := armedBarriers(d); n != 0 {
+		t.Fatalf("armed barriers after both requests released = %d, want 0", n)
+	}
+}
+
+// TestFailoverActuationBarrier_StaleHandleCannotDisarmARearmedRequest pins the
+// other half of item 2: identity, not just the key. A duplicate transfer-out
+// message re-uses the peer's request id, so two handler goroutines can hold
+// handles for the SAME key. The one that finishes first must not evict the
+// barrier the other one armed.
+//
+// Fail-on-revert: drop the `d.failoverActuateWait[key] == b` guard in
+// disarmFailoverActuation and the stale handle deletes the live barrier — the
+// wait below returns nil and this reds.
+func TestFailoverActuationBarrier_StaleHandleCannotDisarmARearmedRequest(t *testing.T) {
+	d := newBarrierDaemon(time.Second)
+
+	stale := d.armFailoverActuation(1, 9)
+	d.disarmFailoverActuation(1, 9, stale) // this request's ManualFailover failed
+	if n := armedBarriers(d); n != 0 {
+		t.Fatalf("armed barriers after a matching disarm = %d, want 0", n)
+	}
+
+	d.armFailoverActuation(1, 9)           // re-armed under the same request id
+	d.disarmFailoverActuation(1, 9, stale) // the superseded handle must be inert
+	if n := armedBarriers(d); n != 1 {
+		t.Fatalf("armed barriers after a stale disarm = %d, want the live barrier to survive", n)
+	}
+
+	d.signalFailoverActuationFailed(1, errFenceRejected)
+	err := d.waitFailoverActuated(1, 9)
+	if err == nil {
+		t.Fatal("wait returned nil: a superseded handle evicted the live barrier, so a " +
+			"REJECTED demotion would be acked as applied (#6177)")
+	}
+	if !errors.Is(err, errFenceRejected) {
+		t.Fatalf("verdict = %v, want the demotion rejection", err)
+	}
+}
+
+// TestFailoverActuationBarrier_VerdictFansOutAcrossRequests pins the resolve
+// side. The demotion event carries no request id — it reports that this node
+// finished demoting the RG — so it must resolve EVERY request in flight for
+// that RG. Resolving only one would leave the other waiting out its full
+// timeout and downgrading a handoff that actually completed.
+//
+// Fail-on-revert: stop the resolve loop at the first match and the second wait
+// below expires with a timeout instead of the demotion verdict.
+func TestFailoverActuationBarrier_VerdictFansOutAcrossRequests(t *testing.T) {
+	d := newBarrierDaemon(150 * time.Millisecond)
+	d.armFailoverActuation(1, 1)
+	d.armFailoverActuation(1, 2)
+	d.armFailoverActuation(2, 1) // a different RG must be untouched
+
+	d.signalFailoverActuationFailed(1, errFenceRejected)
+
+	for _, reqID := range []uint64{1, 2} {
+		err := d.waitFailoverActuated(1, reqID)
+		if !errors.Is(err, errFenceRejected) {
+			t.Fatalf("request %d verdict = %v, want the demotion rejection delivered to "+
+				"every request in flight for the RG", reqID, err)
+		}
+	}
+	// RG2's barrier is still armed — the RG1 event said nothing about it.
+	if n := armedBarriers(d); n != 1 {
+		t.Fatalf("armed barriers after RG1 resolved = %d, want 1 (RG2 untouched)", n)
+	}
+	d.disarmFailoverActuation(2, 1, nil) // a nil handle disarms nothing
+	if n := armedBarriers(d); n != 1 {
+		t.Fatalf("armed barriers after a nil-handle disarm = %d, want 1", n)
+	}
+}
+
+// TestFailoverActuationBarrier_DisarmedRequestReportsNoFence pins the
+// ManualFailover-error contract: the demotion was never enqueued, so no event
+// will ever fire. The disarm must leave the wait free to return immediately
+// rather than burning the full timeout — the handler is not on the ack path
+// here, but a leaked barrier would be closed later by an unrelated event.
+func TestFailoverActuationBarrier_DisarmedRequestReportsNoFence(t *testing.T) {
+	d := newBarrierDaemon(2 * time.Second)
+	b := d.armFailoverActuation(3, 11)
+	d.disarmFailoverActuation(3, 11, b)
+
+	start := time.Now()
+	if err := d.waitFailoverActuated(3, 11); err != nil {
+		t.Fatalf("wait on a disarmed request = %v, want nil", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("wait on a disarmed request took %v, want an immediate return", elapsed)
+	}
+	if n := armedBarriers(d); n != 0 {
+		t.Fatalf("armed barriers after disarm = %d, want 0", n)
+	}
+}
+
+// TestFailoverActuationBarrier_BatchTakesTheFirstFailure pins the batch wait:
+// one request id, one barrier per RG, and a single RG whose demotion did not
+// actuate must fail the whole batch ack — a partially fenced batch handed to
+// the peer as applied is a two-owner window on the RGs that did not demote.
+func TestFailoverActuationBarrier_BatchTakesTheFirstFailure(t *testing.T) {
+	d := newBarrierDaemon(150 * time.Millisecond)
+	for _, rgID := range []int{1, 2} {
+		d.armFailoverActuation(rgID, 5)
+	}
+	d.signalFailoverActuated(1)
+	d.signalFailoverActuationFailed(2, errFenceRejected)
+
+	err := d.waitFailoverActuatedBatch([]int{1, 2}, 5)
+	if !errors.Is(err, errFenceRejected) {
+		t.Fatalf("batch verdict = %v, want the failing member's rejection", err)
+	}
+
+	// All-actuated control: the batch must still ack applied, or every planned
+	// batch failover would stall.
+	for _, rgID := range []int{1, 2} {
+		d.armFailoverActuation(rgID, 6)
+		d.signalFailoverActuated(rgID)
+	}
+	if err := d.waitFailoverActuatedBatch([]int{1, 2}, 6); err != nil {
+		t.Fatalf("batch verdict = %v, want nil when every member actuated", err)
+	}
+}
+
+// TestFailoverActuationBarrier_ResolveIsIdempotentUnderConcurrency drives the
+// double-close path the demotion handler can reach when two events for one RG
+// land back to back, and lets -race see the arm/resolve/wait interleaving. A
+// second resolve must be a no-op: a double close panics and takes the daemon
+// down mid-failover.
+func TestFailoverActuationBarrier_ResolveIsIdempotentUnderConcurrency(t *testing.T) {
+	d := newBarrierDaemon(2 * time.Second)
+	d.armFailoverActuation(4, 21)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				d.signalFailoverActuated(4)
+				return
+			}
+			d.signalFailoverActuationFailed(4, errFenceRejected)
+		}(i)
+	}
+	wg.Wait()
+
+	// Whichever verdict won, exactly one was published and the wait consumes it.
+	if err := d.waitFailoverActuated(4, 21); err != nil && !errors.Is(err, errFenceRejected) {
+		t.Fatalf("verdict = %v, want either the success or the rejection", err)
+	}
+	if n := armedBarriers(d); n != 0 {
+		t.Fatalf("armed barriers after the wait consumed the verdict = %d, want 0", n)
+	}
+}

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -1017,9 +1017,9 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 				// enqueues the async demotion event, so watchClusterEvents
 				// cannot actuate-and-forget before WaitFailoverApplied observes
 				// it. The applied-ack (sync layer) then waits on this barrier.
-				d.armFailoverActuation(rgID)
+				barrier := d.armFailoverActuation(rgID, reqID)
 				if err := d.cluster.ManualFailover(rgID); err != nil {
-					d.disarmFailoverActuation(rgID)
+					d.disarmFailoverActuation(rgID, reqID, barrier)
 					slog.Warn("cluster: remote failover failed", "rg", rgID, "err", err)
 					return err
 				}
@@ -1040,12 +1040,13 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 				slog.Info("cluster: remote batch failover request from peer", "rgs", rgIDs, "req_id", reqID)
 				// #5640: arm every member's fence barrier before the batch
 				// demotion enqueues its per-RG events.
+				barriers := make(map[int]*failoverActuation, len(rgIDs))
 				for _, rgID := range rgIDs {
-					d.armFailoverActuation(rgID)
+					barriers[rgID] = d.armFailoverActuation(rgID, reqID)
 				}
 				if err := d.cluster.ManualFailoverBatch(rgIDs); err != nil {
 					for _, rgID := range rgIDs {
-						d.disarmFailoverActuation(rgID)
+						d.disarmFailoverActuation(rgID, reqID, barriers[rgID])
 					}
 					slog.Warn("cluster: remote batch failover failed", "rgs", rgIDs, "err", err)
 					return err


### PR DESCRIPTION
Addresses **#6177** items 2 and 3. **Item 1 stays open** — see below — so this
PR deliberately does not carry a close keyword.

## Item 2 — barrier bookkeeping was delete-by-key (fixed)

The barrier that gates a remote-failover applied-ack on the local demotion
actually actuating (#5640; verdict-carrying since #7118/#6371) was one slot per
redundancy group. `disarmFailoverActuation` deleted `failoverActuateWait[rgID]`
by key with no check that the entry was still the barrier the caller armed, and
`waitFailoverActuated`'s expiry called it.

The responder handles every failover request on its own goroutine
(`go s.handleRemoteFailover`, `pkg/cluster/sync_conn_read.go:410`), so two
transfer-out cycles for one RG can overlap. An older request's expiry then
deleted the slot a newer request had just armed → the newer wait found no
barrier → `waitFailoverActuated` returned `nil`, which encodes "the fence
actuated" → the node replied `failoverAckApplied` for a demotion it had not
performed. That is the two-owner window #5640 exists to close, reached through
the bookkeeping rather than through the ack path. (The issue predicted a
spurious `failoverAckFailed`; at HEAD the missing-barrier case reads as
SUCCESS, so the consequence is the unsafe direction, not the safe one.)

Fix: key the map by `failoverActuationKey{rgID, reqID}`. The request id is the
peer's own `SessionSync.failoverSeq` value — already on the wire, already handed
to `OnRemoteFailover` for the #5079 lease — and now also reaches the wait, so
`WaitFailoverApplied` / `WaitFailoverAppliedBatch` gain a `reqID` parameter.
**No wire change.** A peer that sends no request id supplies 0 and degrades to
exactly the previous one-slot-per-RG behaviour.

Identity is checked as well as the key: `armFailoverActuation` returns the
barrier it stored and `disarmFailoverActuation` removes the entry only while it
is still that barrier, so a superseded handle (a duplicate request message
re-using one request id) cannot evict a live one either.

The demotion event carries no request id — it reports that *this node* finished
demoting the RG, which is what every in-flight request for that RG is asking —
so `resolveFailoverActuation` fans its verdict out across the RG's entries.

## Item 3 — barrier lifecycle had no direct test (fixed)

#7118 added `daemon_ha_actuation_6371_test.go`, which covers the VERDICT legs
(success / dataplane rejection / parked waiter / unarmed RG) through
`handleClusterEvent`. It does not touch the lifecycle: the bounded-wait expiry,
the disarm path, the map cleanup, the batch wait, or double-resolve. Seven new
tests in `daemon_ha_actuation_barrier_6177_test.go` drive the barrier API
directly and cover exactly those.

## Item 1 — RETH VIP-removal window: STILL LIVE, left open

Re-measured at HEAD; unchanged by #7118, which changed *what verdict* is
delivered, not *when*:

- `pkg/daemon/daemon_ha.go:509-511` resolves the barrier at the end of the
  demotion branch;
- `pkg/vrrp/manager.go:721` `ResignRG` sets `cfg.Priority = 0` under the
  instance lock (synchronous) and then calls `triggerResign`;
- `pkg/vrrp/instance.go:375` `triggerResign` is a non-blocking
  `select { case resignCh <- struct{}{}: default: }`;
- `pkg/vrrp/instance.go:1009` the run loop consumes `resignCh` and calls
  `becomeBackup` (`:1365`), whose `removeVIPs` is where the VIPs actually leave.

So the ack still releases on *resignation signalled + priority 0*, not *VIPs off
the wire*. It is a design call — closing it means a `becomeBackup` completion
signal out of the VRRP instance loop, with a fallback for an instance that is
already BACKUP or whose loop is wedged, and it interacts with the ~60ms failover
budget and the 3s actuate timeout. Per the assignment, not chosen here. The
architecture doc and the `WaitFailoverApplied` godoc no longer claim the fence
includes VIP removal, and record what closing it would take.

## Validation

- `go test -count=1 ./pkg/daemon/ ./pkg/cluster/` → exit 0
- `go test -count=1 -race -run FailoverActuation ./pkg/daemon/` → exit 0
- `go vet ./...`, `go build ./...` → exit 0
- Mutation matrix, 7/7 RED on the intended assertion (restore verified against
  pre-mutation copies): key by RG only; disarm without the identity check; wait
  returns nil on timeout; timeout leaves the barrier stranded; resolve stops at
  the first request; `WaitFailoverApplied` called with reqID 0; same for the
  batch hook.

**`make test-failover` is owed before merge** — HA/failover code. Not run here:
the loss cluster is shared and lock-protected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015n9E5wfBQav1UWp4FcTvxu