### PR TITLE
test(config): gate the slot-1 validation-escape class

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -97921,3 +97921,36 @@ prose edit above them added. No diff falls in the new test body.
   pkg/config/schema_system.go, pkg/config/schema_validators_system.go,
   pkg/config/value_type.go, pkg/config/control_socket_typed_5839_test.go,
   docs/userspace-dataplane-architecture.md, docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-08-21
+- **Action**: #7143 — gate the slot-1 VALIDATION-escape class. Assert that a
+  value the commit check rejects in slot 0 is also rejected in every later
+  slot, over every multi-value leaf in `setSchema`.
+
+  Four such escapes were confirmed and fixed in one campaign (#7126 import-rib,
+  #6687 vlan-id-list, #6692 archive-sites CWE-88, #6688 source-NAT port range)
+  and two more closed by #7138 (#6697 CoS rewrite-rule code-points) — every one
+  found as a side effect of fixing a READ defect, none by looking for the
+  property. The #2419 spelling-differential gate cannot see it: it compares
+  compiled output across spellings, so a leaf that drops nothing but checks only
+  slot 0 compiles identically in every spelling.
+
+  Two harnesses. `TestSlotEscapeSweep` probes the 43 of 124 multi sites where a
+  synthetic parent path commits clean; `TestSlotEscapeTable` carries hand
+  fixtures for the 45 where it does not (security policies, NAT rule-sets,
+  VRRP, CoS classifiers, BGP import/export, ...) — those are more than a third
+  of the schema, and a harness that silently skips them reports a healthy zero.
+  The remaining 36 reject none of an 81-token pool, so there is no check to
+  escape; that list is logged, never asserted. `TestSlotEscapeCoverage` FAILS if
+  a schema addition lands a multi leaf in none of the three.
+
+  Validation: 0 escapes at 3bbe56f43. Calibration: run unchanged at 22e17c2de,
+  all six historical instances FAIL as named rows. Three independent mutations
+  at three production sites each kill it — `multiLeafAuthoredValues(vlanNode)`
+  narrowed to `[:1]`, a `break` in `validateMultiValueLeaf`'s `Keys[1:]` loop,
+  and `coSCodePointTokens` truncated to one token. `go test -count=1
+  ./pkg/config/` exit 0. Test-only diff — no binary or shim artifact moves, so
+  no cluster smoke is owed.
+- **File(s)**: pkg/config/schema_slot_escape_gate_test.go,
+  pkg/config/schema_slot_escape_fixtures_test.go, docs/config-schema.md,
+  _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1295,6 +1295,61 @@ repeated value is one value, and rejecting it invents a rejection too. See
 "A cardinality gate counts DISTINCT values" below for how each leaf picks its
 identity.
 
+### The ESCAPE half is a second gate, because the differential cannot see it
+
+`TestSlotEscapeSweep` / `TestSlotEscapeTable` / `TestSlotEscapeCoverage`
+(`pkg/config/schema_slot_escape_gate_test.go`, fixtures in
+`schema_slot_escape_fixtures_test.go`) assert the other half of the property in
+the GATE ESCAPE table above: **a value the commit check REJECTS in slot 0 must
+also be rejected in every later slot.**
+
+```
+escape := commit(leaf, [bad]) != nil  &&  commit(leaf, [good bad]) == nil
+```
+
+Neither gate subsumes the other, and the reason is structural rather than a
+matter of thoroughness. The spelling differential compares COMPILED OUTPUT
+across spellings, so a leaf that drops NOTHING but checks only slot 0 compiles
+identically in every spelling and reports agreement. Conversely a leaf can read
+every value and check only the first (#6687, #6692, #6688), or read only the
+first and thereby never check the rest (#7126) — the same defect reached from
+opposite directions, and only one of those two is a value drop.
+
+The escape gate's control is a CLEAN COMMIT, not a compiled string, so it needs
+a parent path the compiler accepts. That splits the schema three ways, and
+`TestSlotEscapeCoverage` re-derives the split on every run rather than stating
+it here:
+
+- sites where a synthetic parent commits clean AND some pool token is rejected
+  are probed automatically by the sweep;
+- sites where every pool token commits clean have no check to escape; the list
+  is LOGGED, never asserted, because a leaf that later GAINS a check must not
+  fail the build for it;
+- sites whose synthetic parent is rejected for reasons unrelated to the leaf —
+  a bare `security policies from-zone ... policy p match source-address` is
+  refused for its two missing criteria — carry no verdict from any automatic
+  probe. Those need a hand fixture supplying a real prerequisite config, and
+  the coverage test FAILS if a schema addition lands one there without a row.
+  That is the anti-rot property: growing the schema without covering the new
+  leaf is a build failure, not a silent hole.
+
+**Calibrate a sweep on defects you have already confirmed.** All six escapes
+that existed at 22e17c2de — #6687, #6688, #6692, #6697 (two CoS rewrite-rule
+families) and #7126 — are pinned as named rows in `slotEscapeHistoricalRows`,
+and the file records that every one of them FAILS there and passes at master.
+Three independent mutations kill it at three separate production sites: narrow
+`multiLeafAuthoredValues(vlanNode)` to `[:1]`, `break` out of
+`validateMultiValueLeaf`'s `Keys[1:]` loop, or truncate `coSCodePointTokens` to
+one token.
+
+**A token the GRAMMAR rejects is not a value the leaf refused.** An earlier
+version of the pool carried `scp://u@h:/p`, which `ParseSetCommand` fails to
+lex. That gave every site a "rejected" token, so every site with any accepted
+token looked probed and the coverage figure came out nearly twice its true
+value. Keep the pool to tokens the grammar accepts; a sweep that counts its own
+parse failure as a leaf's gate over-reports coverage in exactly the direction
+nobody checks.
+
 ### #6692: four system-stanza multi-value leaves, and why only three shared a fix
 
 Four `multi: true` leaves under `system` were read with a single-value accessor,

--- a/pkg/config/schema_slot_escape_fixtures_test.go
+++ b/pkg/config/schema_slot_escape_fixtures_test.go
@@ -1,0 +1,372 @@
+package config
+
+// schema_slot_escape_fixtures_test.go — the hand-authored half of the slot-1
+// validation-escape gate (see schema_slot_escape_gate_test.go for the property
+// and the calibration).
+//
+// A row exists for exactly one reason: its site does NOT commit clean under the
+// synthetic parent path the automatic sweep builds, so the sweep can produce no
+// control and therefore no verdict. Each row supplies a real prerequisite
+// config instead. `site` must be the setSchema site key the row covers —
+// TestSlotEscapeCoverage matches on it, and a row whose site no longer exists
+// is a hard failure rather than a silently inert fixture.
+
+import "strings"
+
+// ---------------------------------------------------------------------------
+// Shared prerequisite configs.
+// ---------------------------------------------------------------------------
+
+const (
+	slotEscWGKeyA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	slotEscWGKeyB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	slotEscWGKeyC = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+)
+
+var slotEscIfaces = []string{
+	"set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24",
+	"set interfaces ge-0/0/1 unit 0 family inet address 10.0.2.1/24",
+}
+
+var slotEscZones = append(append([]string{}, slotEscIfaces...),
+	"set security zones security-zone trust interfaces ge-0/0/0.0",
+	"set security zones security-zone untrust interfaces ge-0/0/1.0",
+)
+
+var slotEscAddrBook = append(append([]string{}, slotEscZones...),
+	"set security address-book global address a1 10.5.0.0/24",
+)
+
+var slotEscApp = []string{
+	"set applications application app1 protocol tcp",
+	"set applications application app1 destination-port 80",
+}
+
+// A zone-pair policy is only valid with all three match criteria present, so
+// each policy row supplies the OTHER two and varies only the leaf under test.
+func slotEscPolicyBase(omit string) []string {
+	out := append([]string{}, slotEscAddrBook...)
+	out = append(out, slotEscApp...)
+	const p = "set security policies from-zone trust to-zone untrust policy p1 "
+	for _, c := range []string{"match source-address any", "match destination-address any", "match application any"} {
+		if omit != "" && strings.HasPrefix(c, omit) {
+			continue
+		}
+		out = append(out, p+c)
+	}
+	return append(out, p+"then permit")
+}
+
+func slotEscGlobalPolicyBase(omit string) []string {
+	out := append([]string{}, slotEscAddrBook...)
+	out = append(out, slotEscApp...)
+	const p = "set security policies global policy g1 "
+	for _, c := range []string{"match source-address any", "match destination-address any", "match application any"} {
+		if omit != "" && strings.HasPrefix(c, omit) {
+			continue
+		}
+		out = append(out, p+c)
+	}
+	return append(out, p+"then permit")
+}
+
+var slotEscNatSrc = append(append([]string{}, slotEscZones...),
+	"set security nat source rule-set RS from zone trust",
+	"set security nat source rule-set RS to zone untrust",
+	"set security nat source rule-set RS rule R1 then source-nat interface",
+)
+
+var slotEscNatDst = append(append([]string{}, slotEscZones...),
+	"set security nat destination rule-set RD from zone untrust",
+	"set security nat destination rule-set RD rule R1 then destination-nat off",
+)
+
+var slotEscNatStatic = append(append([]string{}, slotEscZones...),
+	"set security nat static rule-set RT from zone untrust",
+	"set security nat static rule-set RT rule R1 then static-nat prefix 10.0.9.5/32",
+)
+
+var slotEscPolicyOptions = []string{
+	"set policy-options policy-statement PS term t1 then accept",
+	"set policy-options community C1 members 65000:1",
+}
+
+var slotEscBGP = append(append([]string{}, slotEscPolicyOptions...),
+	"set routing-options autonomous-system 65000",
+	"set protocols bgp group G type external",
+	"set protocols bgp group G peer-as 65001",
+	"set protocols bgp group G neighbor 10.0.2.2",
+)
+
+var slotEscIPsec = []string{
+	"set security ipsec proposal esp-a protocol esp",
+	"set security ipsec proposal esp-a encryption-algorithm aes-256-cbc",
+	"set security ipsec proposal esp-a authentication-algorithm hmac-sha-256-128",
+	"set security ipsec policy pol1 perfect-forward-secrecy keys group14",
+}
+
+var slotEscWG = []string{
+	"set system dataplane-type userspace",
+	"set interfaces wg0 tunnel mode wireguard",
+	"set interfaces wg0 tunnel wireguard listen-port 51820",
+	"set interfaces wg0 tunnel wireguard private-key " + slotEscWGKeyA,
+}
+
+var slotEscCoS = []string{
+	"set class-of-service forwarding-classes queue 0 best-effort",
+	"set class-of-service forwarding-classes queue 1 expedited-forwarding",
+}
+
+var slotEscFilter4 = []string{"set firewall family inet filter F term t1 then accept"}
+var slotEscFilter6 = []string{"set firewall family inet6 filter F6 term t1 then accept"}
+
+var slotEscRibGroup = []string{
+	"set routing-instances blue instance-type virtual-router",
+	"set routing-instances blue interface ge-0/0/1.0",
+	"set interfaces ge-0/0/1 unit 0 family inet address 10.0.2.1/24",
+}
+
+// ---------------------------------------------------------------------------
+// Sites whose leaf has NO check to escape.
+//
+// A row here is NOT a statement that the leaf is correct — only that this gate
+// has nothing to compare, because the probe value it offers is accepted in slot
+// 0 as readily as in slot 1. TestSlotEscapeTable fails if such a site LATER
+// starts rejecting the probe value, which is the direction that matters: the
+// day someone adds the missing check, the row must gain a real verdict rather
+// than stay skipped.
+//
+// Every entry below was measured, not assumed.
+// ---------------------------------------------------------------------------
+var slotEscapeUngated = map[string]string{
+	"security nat source rule-set <*> rule <*> match source-address": "" +
+		"a malformed CIDR (999.1.1.1/24) commits clean, while the destination-NAT " +
+		"and static-NAT `match destination-address` siblings reject one",
+	"security nat source rule-set <*> rule <*> match destination-address": "" +
+		"same: no parse gate on the source rule-set's match addresses",
+	"security nat destination rule-set <*> rule <*> match source-address": "" +
+		"the destination rule-set gates match destination-address but not match source-address",
+	"security nat static rule-set <*> rule <*> match source-address": "" +
+		"the static rule-set gates match destination-address (#37b814d5) but not match source-address",
+	"snmp trap-group <*> categories": "" +
+		"trap categories are an open token set at commit; no domain check exists to escape",
+}
+
+// slotEscapeHistorical pins the instances that motivated this gate. They are
+// listed separately from the coverage rows because their value is different: a
+// coverage row exists so a SITE carries a verdict, whereas these exist so a
+// specific historical defect can never come back unnoticed. Each was measured
+// ESCAPED at 22e17c2de and rejected at the commit that introduced this file.
+func slotEscapeHistoricalRows() []slotEscapeRow {
+	return []slotEscapeRow{
+		{"#6687 bridge-domain vlan-id-list", "bridge-domains <*> vlan-id-list",
+			[]string{"set bridge-domains bd1 domain-type bridge"},
+			"set bridge-domains bd1 vlan-id-list", "10", "99999"},
+		// site is empty: `port range <lo> to <hi>` is an args>1 leaf, which the
+		// shared enumerator excludes by construction (a two-element list is not
+		// meaningful for a compound leaf), so there is no site key to bind to.
+		// The row is a regression pin, not a coverage row.
+		{"#6688 source-NAT pool port range", "",
+			append(append([]string{}, slotEscZones...),
+				"set security nat source pool P1 address 10.9.0.1/32",
+				"set security nat source rule-set RS from zone trust",
+				"set security nat source rule-set RS to zone untrust",
+				"set security nat source rule-set RS rule R1 then source-nat pool P1"),
+			"set security nat source pool P1 port range", "1024", "99999"},
+		{"#6692 archival archive-sites", "system archival configuration archive-sites",
+			[]string{"set system archival configuration transfer-interval 60"},
+			"set system archival configuration archive-sites", `"scp://a/cfg"`, `"-oProxyCommand=id"`},
+		// setSchema models the rewrite-rule leaf as the SINGULAR `code-point`;
+		// `code-points` is an alias the compiler also reads, and it is the
+		// spelling the #6697 escape was authored in. The row probes the alias
+		// and binds to the modeled leaf.
+		{"#6697 cos rewrite-rules dscp code-points", "class-of-service rewrite-rules dscp <*> forwarding-class <*> loss-priority <*> code-point",
+			slotEscCoS,
+			"set class-of-service rewrite-rules dscp r1 forwarding-class best-effort loss-priority low code-points", "ef", "zzbogus"},
+		{"#6697 cos rewrite-rules ieee-802.1 code-points", "class-of-service rewrite-rules ieee-802.1 <*> forwarding-class <*> loss-priority <*> code-point",
+			slotEscCoS,
+			"set class-of-service rewrite-rules ieee-802.1 r2 forwarding-class best-effort loss-priority low code-points", "3", "zzbogus"},
+		{"#7126 rib-group import-rib", "routing-options rib-groups <*> import-rib", slotEscRibGroup,
+			"set routing-options rib-groups RG import-rib", "inet.0", "zz.does-not-exist.inet.0"},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The rows.
+// ---------------------------------------------------------------------------
+
+func slotEscapeRows() []slotEscapeRow {
+	return []slotEscapeRow{
+		// -- security policies ------------------------------------------------
+		{"policies from-zone then log", "security policies from-zone <*> <*> <*> policy <*> then log",
+			slotEscPolicyBase(""),
+			"set security policies from-zone trust to-zone untrust policy p1 then log", "session-init", "zzbogus"},
+		{"policies from-zone then deny log", "security policies from-zone <*> <*> <*> policy <*> then deny log",
+			append(append([]string{}, slotEscAddrBook...),
+				"set security policies from-zone trust to-zone untrust policy p1 match source-address any",
+				"set security policies from-zone trust to-zone untrust policy p1 match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy p1 match application any",
+				"set security policies from-zone trust to-zone untrust policy p1 then deny"),
+			"set security policies from-zone trust to-zone untrust policy p1 then deny log", "session-init", "zzbogus"},
+		{"policies from-zone match source-address", "security policies from-zone <*> <*> <*> policy <*> match source-address",
+			slotEscPolicyBase("match source-address"),
+			"set security policies from-zone trust to-zone untrust policy p1 match source-address", "a1", "zznotdefined"},
+		{"policies from-zone match destination-address", "security policies from-zone <*> <*> <*> policy <*> match destination-address",
+			slotEscPolicyBase("match destination-address"),
+			"set security policies from-zone trust to-zone untrust policy p1 match destination-address", "a1", "zznotdefined"},
+		{"policies from-zone match application", "security policies from-zone <*> <*> <*> policy <*> match application",
+			slotEscPolicyBase("match application"),
+			"set security policies from-zone trust to-zone untrust policy p1 match application", "app1", "zznotdefined"},
+		{"policies global then log", "security policies global policy <*> then log",
+			slotEscGlobalPolicyBase(""),
+			"set security policies global policy g1 then log", "session-init", "zzbogus"},
+		{"policies global then deny log", "security policies global policy <*> then deny log",
+			append(append([]string{}, slotEscAddrBook...),
+				"set security policies global policy g1 match source-address any",
+				"set security policies global policy g1 match destination-address any",
+				"set security policies global policy g1 match application any",
+				"set security policies global policy g1 then deny"),
+			"set security policies global policy g1 then deny log", "session-init", "zzbogus"},
+		{"policies global match source-address", "security policies global policy <*> match source-address",
+			slotEscGlobalPolicyBase("match source-address"),
+			"set security policies global policy g1 match source-address", "a1", "zznotdefined"},
+		{"policies global match destination-address", "security policies global policy <*> match destination-address",
+			slotEscGlobalPolicyBase("match destination-address"),
+			"set security policies global policy g1 match destination-address", "a1", "zznotdefined"},
+		{"policies global match application", "security policies global policy <*> match application",
+			slotEscGlobalPolicyBase("match application"),
+			"set security policies global policy g1 match application", "app1", "zznotdefined"},
+		{"policies global match from-zone", "security policies global policy <*> match from-zone",
+			slotEscGlobalPolicyBase(""),
+			"set security policies global policy g1 match from-zone", "trust", "zznotazone"},
+		{"policies global match to-zone", "security policies global policy <*> match to-zone",
+			slotEscGlobalPolicyBase(""),
+			"set security policies global policy g1 match to-zone", "untrust", "zznotazone"},
+
+		// -- security zones ----------------------------------------------------
+		{"zone iface host-inbound system-services", "security zones security-zone <*> interfaces <*> host-inbound-traffic system-services",
+			slotEscZones,
+			"set security zones security-zone trust interfaces ge-0/0/0.0 host-inbound-traffic system-services", "ssh", "zzbogus"},
+		{"zone iface host-inbound protocols", "security zones security-zone <*> interfaces <*> host-inbound-traffic protocols",
+			slotEscZones,
+			"set security zones security-zone trust interfaces ge-0/0/0.0 host-inbound-traffic protocols", "ospf", "zzbogus"},
+
+		// -- NAT source --------------------------------------------------------
+		{"nat src match source-address", "security nat source rule-set <*> rule <*> match source-address",
+			slotEscNatSrc,
+			"set security nat source rule-set RS rule R1 match source-address", "10.5.0.0/24", "999.1.1.1/24"},
+		{"nat src match destination-address", "security nat source rule-set <*> rule <*> match destination-address",
+			slotEscNatSrc,
+			"set security nat source rule-set RS rule R1 match destination-address", "10.6.0.0/24", "999.1.1.1/24"},
+		{"nat src match source-address-name", "security nat source rule-set <*> rule <*> match source-address-name",
+			append(append([]string{}, slotEscNatSrc...), "set security address-book global address a1 10.5.0.0/24"),
+			"set security nat source rule-set RS rule R1 match source-address-name", "a1", "zznotdefined"},
+		{"nat src match destination-address-name", "security nat source rule-set <*> rule <*> match destination-address-name",
+			append(append([]string{}, slotEscNatSrc...), "set security address-book global address a1 10.5.0.0/24"),
+			"set security nat source rule-set RS rule R1 match destination-address-name", "a1", "zznotdefined"},
+		{"nat src match destination-port", "security nat source rule-set <*> rule <*> match destination-port",
+			slotEscNatSrc,
+			"set security nat source rule-set RS rule R1 match destination-port", "80", "99999"},
+		{"nat src match application", "security nat source rule-set <*> rule <*> match application",
+			append(append([]string{}, slotEscNatSrc...), slotEscApp...),
+			"set security nat source rule-set RS rule R1 match application", "app1", "zznotdefined"},
+
+		// -- NAT destination ----------------------------------------------------
+		{"nat dst match destination-address", "security nat destination rule-set <*> rule <*> match destination-address",
+			slotEscNatDst,
+			"set security nat destination rule-set RD rule R1 match destination-address", "10.6.0.1/32", "999.1.1.1/24"},
+		{"nat dst match source-address", "security nat destination rule-set <*> rule <*> match source-address",
+			slotEscNatDst,
+			"set security nat destination rule-set RD rule R1 match source-address", "10.5.0.0/24", "999.1.1.1/24"},
+		{"nat dst match protocol", "security nat destination rule-set <*> rule <*> match protocol",
+			slotEscNatDst,
+			"set security nat destination rule-set RD rule R1 match protocol", "tcp", "zzbogus"},
+		{"nat dst match destination-port", "security nat destination rule-set <*> rule <*> match destination-port",
+			slotEscNatDst,
+			"set security nat destination rule-set RD rule R1 match destination-port", "80", "99999"},
+		{"nat dst match application", "security nat destination rule-set <*> rule <*> match application",
+			append(append([]string{}, slotEscNatDst...), slotEscApp...),
+			"set security nat destination rule-set RD rule R1 match application", "app1", "zznotdefined"},
+		{"nat dst match source-address-name", "security nat destination rule-set <*> rule <*> match source-address-name",
+			append(append([]string{}, slotEscNatDst...), "set security address-book global address a1 10.5.0.0/24"),
+			"set security nat destination rule-set RD rule R1 match source-address-name", "a1", "zznotdefined"},
+		{"nat dst match destination-address-name", "security nat destination rule-set <*> rule <*> match destination-address-name",
+			append(append([]string{}, slotEscNatDst...), "set security address-book global address a1 10.5.0.0/24"),
+			"set security nat destination rule-set RD rule R1 match destination-address-name", "a1", "zznotdefined"},
+
+		// -- NAT static ----------------------------------------------------------
+		{"nat static match destination-address", "security nat static rule-set <*> rule <*> match destination-address",
+			slotEscNatStatic,
+			"set security nat static rule-set RT rule R1 match destination-address", "10.6.0.1/32", "999.1.1.1/24"},
+		{"nat static match source-address", "security nat static rule-set <*> rule <*> match source-address",
+			slotEscNatStatic,
+			"set security nat static rule-set RT rule R1 match source-address", "10.5.0.0/24", "999.1.1.1/24"},
+
+		// -- routing policy -------------------------------------------------------
+		{"policy-statement from community", "policy-options policy-statement <*> term <*> from community",
+			slotEscPolicyOptions,
+			"set policy-options policy-statement PS term t1 from community", "C1", "zznotdefined"},
+		{"bgp import", "protocols bgp import", slotEscBGP,
+			"set protocols bgp import", "PS", "zznotdefined"},
+		{"bgp group neighbor import", "protocols bgp group <*> neighbor <*> import", slotEscBGP,
+			"set protocols bgp group G neighbor 10.0.2.2 import", "PS", "zznotdefined"},
+		{"bgp group neighbor export", "protocols bgp group <*> neighbor <*> export", slotEscBGP,
+			"set protocols bgp group G neighbor 10.0.2.2 export", "PS", "zznotdefined"},
+		{"forwarding-table export", "routing-options forwarding-table export", slotEscPolicyOptions,
+			"set routing-options forwarding-table export", "PS", "zznotdefined"},
+
+		// -- ipsec ------------------------------------------------------------------
+		{"ipsec policy proposals", "security ipsec policy <*> proposals", slotEscIPsec,
+			"set security ipsec policy pol1 proposals", "esp-a", "zznotdefined"},
+
+		// -- wireguard ---------------------------------------------------------------
+		{"wireguard allowed-ips", "interfaces <*> tunnel wireguard peer <*> allowed-ips",
+			append(append([]string{}, slotEscWG...),
+				"set interfaces wg0 tunnel wireguard peer "+slotEscWGKeyB+" endpoint 10.0.2.2:51820"),
+			"set interfaces wg0 tunnel wireguard peer " + slotEscWGKeyB + " allowed-ips", "10.1.0.0/24", "10.1.0.0/999"},
+		{"wireguard allowed-ips (unit form)", "interfaces <*> unit <*> tunnel wireguard peer <*> allowed-ips",
+			append(append([]string{}, slotEscWG...),
+				"set interfaces wg0 tunnel wireguard peer "+slotEscWGKeyB+" endpoint 10.0.2.2:51820",
+				"set interfaces wg0 tunnel wireguard peer "+slotEscWGKeyB+" allowed-ips 10.1.0.0/24",
+				"set interfaces wg0 unit 0 tunnel wireguard peer "+slotEscWGKeyC+" endpoint 10.0.3.3:51820"),
+			"set interfaces wg0 unit 0 tunnel wireguard peer " + slotEscWGKeyC + " allowed-ips", "10.2.0.0/24", "10.2.0.0/999"},
+
+		// -- CoS -----------------------------------------------------------------------
+		{"cos classifiers dscp code-points", "class-of-service classifiers dscp <*> forwarding-class <*> loss-priority <*> code-points",
+			slotEscCoS,
+			"set class-of-service classifiers dscp c1 forwarding-class best-effort loss-priority low code-points", "ef", "zzbogus"},
+		{"cos classifiers ieee-802.1 code-points", "class-of-service classifiers ieee-802.1 <*> forwarding-class <*> loss-priority <*> code-points",
+			slotEscCoS,
+			"set class-of-service classifiers ieee-802.1 c2 forwarding-class best-effort loss-priority low code-points", "3", "zzbogus"},
+		{"cos classifiers inet-precedence code-points", "class-of-service classifiers inet-precedence <*> forwarding-class <*> loss-priority <*> code-points",
+			slotEscCoS,
+			"set class-of-service classifiers inet-precedence c3 forwarding-class best-effort loss-priority low code-points", "3", "zzbogus"},
+
+		// -- firewall filters -------------------------------------------------------------
+		{"filter inet from icmp-code", "firewall family inet filter <*> term <*> from icmp-code",
+			append(append([]string{}, slotEscFilter4...),
+				"set firewall family inet filter F term t1 from protocol icmp",
+				"set firewall family inet filter F term t1 from icmp-type 3"),
+			"set firewall family inet filter F term t1 from icmp-code", "1", "999"},
+		{"filter inet6 from icmp-code", "firewall family inet6 filter <*> term <*> from icmp-code",
+			append(append([]string{}, slotEscFilter6...),
+				"set firewall family inet6 filter F6 term t1 from next-header icmp6",
+				"set firewall family inet6 filter F6 term t1 from icmp-type 1"),
+			"set firewall family inet6 filter F6 term t1 from icmp-code", "1", "999"},
+
+		// -- VRRP --------------------------------------------------------------------------
+		{"vrrp virtual-address inet", "interfaces <*> unit <*> family inet address <*> vrrp-group <*> virtual-address",
+			[]string{"set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24 vrrp-group 1 priority 100"},
+			"set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24 vrrp-group 1 virtual-address", "10.0.1.254/24", "999.1.1.1/24"},
+		{"vrrp virtual-address inet6", "interfaces <*> unit <*> family inet6 address <*> vrrp-group <*> virtual-address",
+			[]string{"set interfaces ge-0/0/0 unit 0 family inet6 address 2001:db8::1/64 vrrp-group 1 priority 100"},
+			"set interfaces ge-0/0/0 unit 0 family inet6 address 2001:db8::1/64 vrrp-group 1 virtual-address", "2001:db8::254/64", "2001:db8::zzz/64"},
+
+		// -- misc ----------------------------------------------------------------------------
+		{"apply-groups", "apply-groups", []string{"set groups g1 system host-name h1"},
+			"set apply-groups", "g1", "zznotdefined"},
+		{"snmp trap-group categories", "snmp trap-group <*> categories",
+			[]string{"set snmp trap-group tg1 targets 10.0.0.1"},
+			"set snmp trap-group tg1 categories", "link", "zzbogus"},
+	}
+}

--- a/pkg/config/schema_slot_escape_gate_test.go
+++ b/pkg/config/schema_slot_escape_gate_test.go
@@ -1,0 +1,493 @@
+package config
+
+// schema_slot_escape_gate_test.go — the SLOT-1 VALIDATION-ESCAPE gate.
+//
+// WHAT THIS GATE ASSERTS
+//
+// For every value-bearing MULTI leaf in setSchema: a value the commit check
+// REJECTS in slot 0 must also be rejected in every later slot. If
+//
+//	set <path> <leaf> <bad>              -> rejected
+//	set <path> <leaf> [ <good> <bad> ]   -> COMMITS CLEAN
+//
+// then the leaf's check only ever saw slot 0, and every value past the first
+// entered the running configuration unchecked. That is a fail-OPEN: the
+// operator sees a clean commit, `show configuration` renders the list back
+// intact, and the invalid member is either silently dropped by the compiler or
+// carried into the dataplane unvalidated.
+//
+// WHY THIS IS A SEPARATE GATE FROM THE #2419 SPELLING DIFFERENTIAL
+//
+// schema_spelling_differential_gate_test.go compares COMPILED OUTPUT across the
+// five spellings a value list admits. Its primitive is
+//
+//	dropped(spelling) := compile(spelling, [v1]) == compile(spelling, [v1 v2])
+//
+// which detects a compiler DROPPING a value. It is structurally blind to this
+// property: a leaf that drops NOTHING but validates only slot 0 compiles
+// identically in every spelling, so the differential reports agreement. The two
+// gates are complementary and neither subsumes the other — a leaf can read
+// every value and check only the first (#6687 vlan-id-list, #6692 archive-sites,
+// #6688 source-NAT port range), or read only the first and thereby never check
+// the rest (#7126 import-rib).
+//
+// PROVENANCE — the four instances that motivated this gate were all found as a
+// SIDE EFFECT of fixing a read defect, never by looking for them:
+//
+//	#7126  import-rib [ inet.0 does-not-exist.inet.0 ]   committed clean;
+//	       the identical name in slot 0 was rejected "references an undefined rib"
+//	#6687  vlan-id-list [ 10 99999 ] / [ 10 notanumber ] committed clean
+//	#6692  archive-sites: the #4589 leading-dash gate (CWE-88) ran on one
+//	       member only, so a `-oProxyCommand=` past the first was unchecked
+//	#6688  source-NAT `port range 1000 2000`: the endpoints were validated but
+//	       the consumed token count was not, so a pool sized for 1001 ports
+//	       provided ONE and committed clean
+//
+// Four in one campaign, each discovered by accident. Nothing asserted the
+// property, so the class had no floor.
+//
+// CALIBRATION — A SWEEP THAT CANNOT FIND THE BUG YOU ALREADY HAVE REPORTS ZERO
+//
+// Both harnesses below were run unchanged against 22e17c2de (the commit before
+// any of the four fixes landed). Measured there, the table harness reports
+// ESCAPED for all six instances that existed at that commit:
+//
+//	bridge-domain vlan-id-list              #6687
+//	nat src pool port range                 #6688
+//	system archival archive-sites           #6692
+//	rib-group import-rib                    #7126
+//	cos rewrite-rules dscp code-points      #6697 (fixed by #7138)
+//	cos rewrite-rules ieee-802.1 code-points#6697 (fixed by #7138)
+//
+// and the same harnesses report zero at origin/master. That 6-of-6 recall on
+// independently-confirmed defects, against zero at head, is this gate's
+// non-vacuity argument. Re-run it by copying this file into a worktree at
+// 22e17c2de.
+//
+// COVERAGE — HOW THE TWO HARNESSES SPLIT THE SCHEMA
+//
+// TestSlotEscapeCoverage re-derives these numbers on every run and logs them,
+// so they cannot rot into a stale comment. Measured at the commit that
+// introduced this file, over the 124 enumerable multi-value leaf SITES:
+//
+//	43  the sweep probes directly — a pool token commits clean (the control)
+//	    and another is rejected (the value to move into slot 1)
+//	36  no observable gate — every one of the 81 pool tokens commits clean, so
+//	    there is no check to escape and neither harness can carry a verdict.
+//	    TestSlotEscapeCoverage LOGS this list rather than asserting it.
+//	45  no control under a synthetic parent path: `security policies from-zone
+//	    xa20 ...` is rejected for reasons that have nothing to do with the leaf
+//	    under test. This is a harness limitation, not a property of the leaf,
+//	    and it is exactly the class the hand fixtures exist for. All 45 have a
+//	    row; TestSlotEscapeCoverage FAILS if a schema addition lands one here
+//	    without a row, which is the anti-rot property.
+//
+// A NOTE ON THE 36. That number is not a clean bill of health, and one of the
+// four motivating defects would have been invisible to a harness that stopped
+// at "the domain looks open": #6692's archive-sites gate is a leading-dash
+// check, which only a token beginning with '-' can trip. The pool carries one
+// for that reason. A leaf whose domain no pool token violates lands in the 36
+// and is neither cleared nor accused.
+//
+// AN EARLIER VERSION OF THIS COMMENT SAID 79/45 INSTEAD OF 43/36/45, and the
+// error is worth recording because it flatters: the pool at the time contained
+// `scp://u@h:/p`, which ParseSetCommand REJECTS as a syntax error at every
+// site. That gave every site a "rejected" token, so every site with any clean
+// token looked probed. The inflated number was the sweep counting its own
+// parse failure as a leaf's gate. A token that cannot parse is not a value the
+// leaf refused; keep the pool to tokens the grammar accepts.
+//
+// WHAT THIS GATE DOES NOT SEE
+//
+//   - A leaf with NO check at all cannot escape one. Such leaves are recorded
+//     in slotEscapeUngated with the probe value that was accepted in slot 0.
+//     They are NOT assertions that the leaf is correct — only that this gate
+//     has nothing to compare. Several are worth a separate look; see the notes
+//     on individual rows.
+//   - The sweep's verdict depends on the token pool containing both a value the
+//     leaf accepts and one it rejects. A leaf whose domain no pool token
+//     satisfies carries no verdict from the sweep; that is why the pool spans
+//     several domains and why the hand table exists.
+//   - Only the operator commit path is probed. The tolerant load / peer-sync
+//     path (configstore Store.Load / SyncApply) deliberately downgrades these
+//     rejections to warnings so a persisted config still boots (#1960), and
+//     that asymmetry is correct, not a finding.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Shared commit-check primitive.
+//
+// This is the OPERATOR commit path: the schema walk followed by the strict
+// compiler, in the order configstore runs them (schemaValidateExpandedTree then
+// CompileConfig, pkg/configstore/store.go). Using CompileConfigLenient here
+// would silently test the no-brick path instead and never observe a rejection.
+// ---------------------------------------------------------------------------
+
+func slotEscapeCommitSet(cmds []string) error {
+	tree := &ConfigTree{}
+	for _, c := range cmds {
+		p, err := ParseSetCommand(c)
+		if err != nil {
+			return fmt.Errorf("parse %q: %w", c, err)
+		}
+		if err := tree.SetPath(p); err != nil {
+			return fmt.Errorf("setpath %q: %w", c, err)
+		}
+	}
+	if err := SchemaValidate(tree, nil); err != nil {
+		return err
+	}
+	_, err := CompileConfig(tree)
+	return err
+}
+
+func slotEscapeCommitBrace(body string) error {
+	p := NewParser(body)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		return fmt.Errorf("parse: %v", errs)
+	}
+	if err := SchemaValidate(tree, nil); err != nil {
+		return err
+	}
+	_, err := CompileConfig(tree)
+	return err
+}
+
+// slotEscapeRender builds the tree from set commands and renders it as
+// canonical hierarchical brace text. That is the spelling a candidate is
+// PERSISTED and re-read in, so an escape reachable only through the flat-set
+// grammar still has to be probed in the form the box reloads.
+func slotEscapeRender(cmds []string) (string, error) {
+	tree := &ConfigTree{}
+	for _, c := range cmds {
+		p, err := ParseSetCommand(c)
+		if err != nil {
+			return "", err
+		}
+		if err := tree.SetPath(p); err != nil {
+			return "", err
+		}
+	}
+	return tree.Format(), nil
+}
+
+// ---------------------------------------------------------------------------
+// Harness 1 — automatic sweep over the sites a synthetic parent path reaches.
+// ---------------------------------------------------------------------------
+
+// slotEscapeTokens must span the value DOMAINS setSchema's leaves accept, not
+// merely be distinctive strings: the sweep can only judge a leaf for which the
+// pool holds BOTH an accepted and a rejected token. Adding a domain here widens
+// coverage; it cannot manufacture a finding, because a finding still requires a
+// clean control.
+var slotEscapeTokens = []string{
+	"zzqaaa1", "zzqbbb2",
+	"0", "1", "3", "7", "10", "46", "63", "80", "101", "255", "443",
+	"1000", "2000", "99999", "4294967296", "-1",
+	"10.211.212.0/24", "10.211.212.0/32", "10.211.212.0/99", "999.1.1.1/24", "10.211.212.5",
+	"2001:db8::1", "2001:db8::53", "2001:db8::zzz", "2001:db8::/64", "2001:db8::zzz/64",
+	"ge-5/0/7", "ge-5/0/7/9/9",
+	"ef", "af11", "notadscp",
+	"tcp", "bgp", "notaproto", "ospf", "ospf3", "isis", "rip",
+	"-oProxyCommand=id",
+	"aes256-ctr", "hmac-sha2-256", "curve25519-sha256",
+	"session-init", "session-close",
+	"ssh", "ping", "http", "https", "telnet", "snmp",
+	"any", "all", "low", "high", "medium-low",
+	"best-effort", "expedited-forwarding", "assured-forwarding",
+	"syn", "ack", "fin", "echo-request", "unreachable",
+	"basic-datapath", "view", "link",
+	"example.com", "8.8.8.8", "inet.0", "65000:1", "junos-http", "trust",
+	"esp", "aes-256-cbc", "group14", "main", "virtual-router", "discard", "reject",
+}
+
+// slotEscapeForms are the spellings a two-element value list admits. All five
+// are probed: #6687 escaped in the hierarchical bracket and block forms as well
+// as the flat-set one, so restricting to the flat-set grammar would have missed
+// two thirds of that defect's surface.
+type slotEscapeForm struct {
+	name string
+	run  func(g gateLeaf, vals []string) error
+}
+
+func slotEscapeForms() []slotEscapeForm {
+	flatPrefix := func(g gateLeaf) string {
+		return "set " + strings.Join(append(append([]string{}, g.path...), g.leaf), " ")
+	}
+	return []slotEscapeForm{
+		{"A-hier-bracket", func(g gateLeaf, vals []string) error {
+			return slotEscapeCommitBrace(gateBraceConfig(g.path,
+				fmt.Sprintf("%s [ %s ];", g.leaf, strings.Join(vals, " "))))
+		}},
+		{"B-hier-block", func(g gateLeaf, vals []string) error {
+			var b strings.Builder
+			for _, v := range vals {
+				b.WriteString(v)
+				b.WriteString("; ")
+			}
+			return slotEscapeCommitBrace(gateBraceConfig(g.path,
+				fmt.Sprintf("%s { %s}", g.leaf, b.String())))
+		}},
+		{"C-hier-repeat", func(g gateLeaf, vals []string) error {
+			var b strings.Builder
+			for _, v := range vals {
+				b.WriteString(g.leaf)
+				b.WriteString(" ")
+				b.WriteString(v)
+				b.WriteString("; ")
+			}
+			return slotEscapeCommitBrace(gateBraceConfig(g.path, b.String()))
+		}},
+		{"D-set-bracket", func(g gateLeaf, vals []string) error {
+			if len(vals) == 1 {
+				return slotEscapeCommitSet([]string{flatPrefix(g) + " " + vals[0]})
+			}
+			return slotEscapeCommitSet([]string{flatPrefix(g) + " [ " + strings.Join(vals, " ") + " ]"})
+		}},
+		{"E-set-repeat", func(g gateLeaf, vals []string) error {
+			var cmds []string
+			for _, v := range vals {
+				cmds = append(cmds, flatPrefix(g)+" "+v)
+			}
+			return slotEscapeCommitSet(cmds)
+		}},
+	}
+}
+
+// slotEscapeMultiSites returns every enumerable multi-value leaf site. It reuses
+// the #2419 gate's enumerator so the two gates cannot disagree about what the
+// schema contains.
+func slotEscapeMultiSites() []gateLeaf {
+	var out []gateLeaf
+	for _, g := range enumerateGateLeaves() {
+		if g.multi {
+			out = append(out, g)
+		}
+	}
+	return out
+}
+
+// slotEscapeSweepQualifies reports whether a site carries a verdict from the
+// automatic sweep in the given form: at least one pool token commits CLEAN
+// (the control) and at least one is rejected (the thing to move to slot 1).
+func slotEscapeSweepOutcomes(g gateLeaf, form slotEscapeForm) (res []string, ok bool) {
+	res = make([]string, len(slotEscapeTokens))
+	clean, rejected := 0, 0
+	for i, tok := range slotEscapeTokens {
+		e := form.run(g, []string{tok})
+		if e == nil {
+			res[i] = ""
+			clean++
+		} else {
+			res[i] = e.Error()
+			rejected++
+		}
+	}
+	return res, clean > 0 && rejected > 0
+}
+
+func TestSlotEscapeSweep(t *testing.T) {
+	var failures []string
+	for _, form := range slotEscapeForms() {
+		for _, g := range slotEscapeMultiSites() {
+			res, ok := slotEscapeSweepOutcomes(g, form)
+			if !ok {
+				continue
+			}
+			// One control is enough: the property is per-leaf, not per-value
+			// pair, and every additional control multiplies the probe cost by
+			// the pool size for no additional discrimination.
+			good, ctrlIdx := "", -1
+			for i, r := range res {
+				if r == "" {
+					good, ctrlIdx = slotEscapeTokens[i], i
+					break
+				}
+			}
+			_ = ctrlIdx
+			for i, bad := range slotEscapeTokens {
+				if res[i] == "" || bad == good {
+					continue
+				}
+				if err := form.run(g, []string{good, bad}); err == nil {
+					failures = append(failures, fmt.Sprintf(
+						"%s [%s]: %q is REJECTED in slot 0 (%s) but the list [ %s %s ] commits clean",
+						g.siteKey(), form.name, bad, firstLine(res[i]), good, bad))
+				}
+			}
+		}
+	}
+	sort.Strings(failures)
+	for _, f := range failures {
+		t.Errorf("slot-1 validation escape: %s", f)
+	}
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	if len(s) > 140 {
+		s = s[:140] + "..."
+	}
+	return s
+}
+
+// ---------------------------------------------------------------------------
+// Harness 2 — hand-authored fixtures for the sites a synthetic parent cannot
+// reach. Each row supplies a REAL prerequisite config, so the control commits
+// clean and the comparison is meaningful.
+// ---------------------------------------------------------------------------
+
+type slotEscapeRow struct {
+	name string   // human label, used in failure output
+	site string   // the setSchema site this row covers (see TestSlotEscapeCoverage)
+	base []string // prerequisite set commands; must commit clean with `good` alone
+	leaf string   // the `set ...` prefix WITHOUT the value
+	good string   // a value the leaf accepts
+	bad  string   // a value the leaf must reject
+}
+
+func TestSlotEscapeTable(t *testing.T) {
+	for _, r := range append(slotEscapeRows(), slotEscapeHistoricalRows()...) {
+		r := r
+		t.Run(strings.ReplaceAll(r.name, " ", "_"), func(t *testing.T) {
+			with := func(vals ...string) []string {
+				return append(append([]string{}, r.base...), r.leaf+" "+strings.Join(vals, " "))
+			}
+			if err := slotEscapeCommitSet(with(r.good)); err != nil {
+				t.Fatalf("fixture broken: the control (%s %s) must commit clean, got: %v", r.leaf, r.good, err)
+			}
+			e0 := slotEscapeCommitSet(with(r.bad))
+			if e0 == nil {
+				if _, known := slotEscapeUngated[r.site]; known {
+					t.Skipf("no gate on this leaf for %q (recorded in slotEscapeUngated); nothing to escape", r.bad)
+				}
+				t.Fatalf("fixture broken: %q must be REJECTED in slot 0 for this row to mean anything", r.bad)
+			}
+			if _, known := slotEscapeUngated[r.site]; known {
+				t.Fatalf("slotEscapeUngated records this site as having no gate, but %q was rejected in slot 0 (%v) — the row now carries a real verdict, so remove the slotEscapeUngated entry", r.bad, e0)
+			}
+
+			// Slot 1, four ways: flat-set bracket, flat-set repeated, the
+			// canonical hierarchical render the box reloads from, and a
+			// three-element list with the bad value LAST (a check that stops
+			// after two would pass the two-element probe).
+			check := func(label string, err error) {
+				if err == nil {
+					t.Errorf("slot-1 validation escape [%s]: %q is rejected in slot 0 (%s) but the list with it in a later slot commits CLEAN",
+						label, r.bad, firstLine(e0.Error()))
+				}
+			}
+			check("D-set-bracket", slotEscapeCommitSet(with("[", r.good, r.bad, "]")))
+			check("E-set-repeat", slotEscapeCommitSet(append(append([]string{}, r.base...),
+				r.leaf+" "+r.good, r.leaf+" "+r.bad)))
+			check("D-set-bracket-slot2", slotEscapeCommitSet(with("[", r.good, r.good, r.bad, "]")))
+			body, err := slotEscapeRender(with("[", r.good, r.bad, "]"))
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			check("hier-render-roundtrip", slotEscapeCommitBrace(body))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Coverage — every multi site must carry a verdict from one harness or the
+// other, so growing the schema cannot silently grow a hole.
+// ---------------------------------------------------------------------------
+
+func TestSlotEscapeCoverage(t *testing.T) {
+	covered := map[string]bool{}
+	for _, r := range append(slotEscapeRows(), slotEscapeHistoricalRows()...) {
+		if r.site != "" {
+			covered[r.site] = true
+		}
+	}
+
+	// Classify every multi site by what the automatic sweep can observe:
+	//
+	//	verdict     a pool token commits clean AND another is rejected -> the
+	//	            sweep probes this site directly
+	//	no-gate     every pool token commits clean; there is no check to
+	//	            escape, so neither harness can carry a verdict
+	//	no-control  no pool token commits clean, because the SYNTHETIC parent
+	//	            path is rejected for reasons unrelated to the leaf. This is
+	//	            a harness limitation, not a property of the leaf, and it is
+	//	            the class a hand fixture exists to cover.
+	var noGate, needFixture []string
+	verdict := 0
+	for _, g := range slotEscapeMultiSites() {
+		anyVerdict, anyClean := false, false
+		for _, form := range slotEscapeForms() {
+			res, ok := slotEscapeSweepOutcomes(g, form)
+			if ok {
+				anyVerdict = true
+				anyClean = true
+				break
+			}
+			for _, r := range res {
+				if r == "" {
+					anyClean = true
+				}
+			}
+		}
+		switch {
+		case anyVerdict:
+			verdict++
+		case anyClean:
+			noGate = append(noGate, g.siteKey())
+		default:
+			if !covered[g.siteKey()] {
+				needFixture = append(needFixture, g.siteKey())
+			}
+		}
+	}
+
+	sort.Strings(noGate)
+	t.Logf("multi sites=%d  probed by the sweep=%d  no observable gate=%d  hand fixtures=%d",
+		len(slotEscapeMultiSites()), verdict, len(noGate), len(covered))
+	// Logged, not asserted. A leaf that rejects nothing has no gate to escape,
+	// and pinning the list would fail every time a leaf legitimately GAINS a
+	// check — the direction we want. It is printed because it is the honest
+	// inventory of where this gate is silent, and because several entries are
+	// worth a separate look on their own merits.
+	for _, s := range noGate {
+		t.Logf("no observable gate (nothing for this gate to compare): %s", s)
+	}
+
+	sort.Strings(needFixture)
+	for _, s := range needFixture {
+		t.Errorf("multi leaf %q carries NO slot-escape verdict: it does not commit clean under a "+
+			"synthetic parent path, and it has no row in slotEscapeRows. Add one — a prerequisite "+
+			"base config that commits clean, a value the leaf accepts, and one it must reject.", s)
+	}
+
+	// A row whose site is no longer a leaf in setSchema silently stops covering
+	// anything, exactly as a stale allowlist row does in the #2419 gate. Checked
+	// against EVERY enumerated leaf, not only the multi ones: #7126's import-rib
+	// is a multi:false leaf that escaped anyway, and its regression row must not
+	// be deleted just because the coverage half does not reach it.
+	live := map[string]bool{}
+	for _, g := range enumerateGateLeaves() {
+		live[g.siteKey()] = true
+	}
+	for site := range covered {
+		if !live[site] {
+			t.Errorf("a slot-escape row covers %q, which is no longer a leaf in setSchema — "+
+				"update or delete the row", site)
+		}
+	}
+	for site := range slotEscapeUngated {
+		if !live[site] {
+			t.Errorf("slotEscapeUngated records %q, which is no longer a leaf in setSchema", site)
+		}
+	}
+}


### PR DESCRIPTION
A value the commit check REJECTS in slot 0 must also be rejected in every later
slot of a multi-value leaf. Nothing asserted that, so the class had no floor:
six instances were confirmed and fixed inside one campaign and **every one was
found as a side effect of fixing a different (read) defect** — #7126 import-rib,
#6687 vlan-id-list, #6692 archive-sites (CWE-88 argv injection into `scp`),
#6688 source-NAT port range, and the two #6697 CoS rewrite-rule families closed
by #7138.

The #2419 spelling-differential gate cannot see this property. It compares
compiled output across spellings, which detects a compiler *dropping* a value; a
leaf that drops nothing but checks only slot 0 compiles identically in every
spelling and reports agreement. Neither gate subsumes the other.

## What this adds

Two harnesses plus a coverage assertion, over all 124 enumerable multi-value
leaf sites in `setSchema`:

| | sites | how |
|---|---|---|
| `TestSlotEscapeSweep` | 43 | a synthetic parent path commits clean, so the sweep probes automatically |
| `TestSlotEscapeTable` | 45 | no clean control under a synthetic parent (security policies, every NAT rule-set match leaf, VRRP virtual-address, CoS classifiers, BGP import/export, ...) — hand fixtures supply a real prerequisite config |
| logged, not asserted | 36 | reject none of an 81-token pool spanning several value domains: no check to escape |

`TestSlotEscapeCoverage` re-derives the split on every run and FAILS when a
schema addition lands a multi leaf in none of the three, so coverage cannot rot.

## Evidence

**Result at `3bbe56f43`: zero escapes.** That is only meaningful beside the
calibration leg.

**Calibration — 6 of 6.** Run unchanged at `22e17c2de` (before any of the fixes
landed), all six historical instances report ESCAPED, each pinned here as a
named row:

```
--- FAIL: TestSlotEscapeTable/#6687_bridge-domain_vlan-id-list
--- FAIL: TestSlotEscapeTable/#6688_source-NAT_pool_port_range
--- FAIL: TestSlotEscapeTable/#6692_archival_archive-sites
--- FAIL: TestSlotEscapeTable/#6697_cos_rewrite-rules_dscp_code-points
--- FAIL: TestSlotEscapeTable/#6697_cos_rewrite-rules_ieee-802.1_code-points
--- FAIL: TestSlotEscapeTable/#7126_rib-group_import-rib
```

**Mutation — three independent kills at three production sites**, one line each:

| mutation | reds |
|---|---|
| `multiLeafAuthoredValues(vlanNode)` → `[:1]` (`compiler_services.go`) | the bridge-domain site in the sweep, and the #6687 row |
| `break` in `validateMultiValueLeaf`'s `Keys[1:]` loop (`schema_walk.go`) | nine schema-validated sites — name-server, domain-search, ntp server, the three ssh algorithm leaves, RA dns-server-address, both policy log leaves |
| `coSCodePointTokens` truncated to one token (`compiler_class_of_service.go`) | all five CoS rows |

## One harness bug worth reading

An earlier token pool carried `scp://u@h:/p`, which `ParseSetCommand` fails to
lex. That handed *every* site a "rejected" token, so every site with any
accepted token looked probed, and coverage came out at 79 instead of 43 —
nearly double, in the direction nobody checks. A sweep that counts its own parse
failure as a leaf's gate is exactly how a green run becomes worthless, so it is
recorded in the file header rather than only in this description.

## Validation

`go test -count=1 ./pkg/config/` exit 0 (`$?` read directly, not through a
pipe); the new gate adds ~12s. Test-only diff — no binary or shim artifact
moves, so no cluster smoke is owed. `docs/config-schema.md` gains the section
describing the escape half beside the existing differential.

Closes #7143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ha4uXmDpDAJeXe7xQvUYm4
