### PR TITLE
dataplane: stop discarding the recompile FIB generation bump

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -97954,3 +97954,32 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: pkg/config/schema_slot_escape_gate_test.go,
   pkg/config/schema_slot_escape_fixtures_test.go, docs/config-schema.md,
   _Log.md
+
+## 2026-08-21 — #7149 dataplane: recompile FIB generation bump error no longer discarded
+
+- **Timestamp**: 2026-08-21
+- **Action**: Split #7149 out of #4960 and fixed it. `CompileConfig` ended a
+  recompile with a bare `dp.BumpFIBGeneration()`, dropping both results.
+  Diffing every `dp.<Method>` the compiler calls against
+  `userspaceShimCompileDataplane`'s override set shows only three are NOT
+  overridden as no-ops — `IsLoaded` and `GetPersistentNAT` (pre-mutation, no
+  error) and `BumpFIBGeneration`, which promotes to the embedded `*Manager` and
+  performs a real bpffs map write. Driving the production shim returns
+  `dataplane not armed: fib_gen_map`, and `(*Manager).BumpFIBGeneration`'s
+  not-armed branch logs nothing. `userspace/manager_compile.go` then builds the
+  snapshot with `m.readFIBGeneration()` off that same map, so a failed bump
+  publishes the PREVIOUS generation and established flows keep a cached
+  next-hop the recompile may have invalidated, apply reporting success.
+  Reported rather than returned: the site is post-`compileZones`, so
+  propagating would manufacture the #4960 half-applied shape.
+
+  Validation: `go test -count=1 ./pkg/dataplane/...` exit 0, `go vet
+  ./pkg/dataplane/...` exit 0. Mutation matrix, one mutation per cell, exit
+  codes captured from `$?`: revert the call site to the bare call → exit 1,
+  source walk only; gut the helper to `_, _ =` → exit 1, both guards; warn
+  unconditionally → exit 1, success control only; delete the only production
+  call → exit 1 on the floor. Go-only diff, no shim `.o` or protocol movement,
+  so no cluster smoke is owed.
+- **File(s)**: pkg/dataplane/compiler.go, pkg/dataplane/compiler_fibgen.go,
+  pkg/dataplane/compiler_fibgen_7149_test.go, pkg/dataplane/dataplane.go,
+  _Log.md

--- a/pkg/dataplane/compiler.go
+++ b/pkg/dataplane/compiler.go
@@ -373,8 +373,15 @@ func CompileConfig(dp DataPlane, cfg *config.Config, isRecompile bool) (*Compile
 	// bpf_fib_lookup with potentially changed interface indices or MAC
 	// addresses. BPF checks session.fib_gen != fib_gen_map[0] and
 	// treats cached entries as stale — no session write-back needed.
+	//
+	// #7149 (split from #4960): this was a bare `dp.BumpFIBGeneration()`,
+	// dropping both results. On the live userspace path it is the only
+	// compiler dataplane call that is NOT a shim no-op, so it is the only one
+	// that can really fail, and a failure silently leaves the snapshot the
+	// helper is about to receive on the previous generation. See
+	// compiler_fibgen.go for why the error is reported rather than returned.
 	if isRecompile {
-		dp.BumpFIBGeneration()
+		bumpFIBGenerationAfterRecompile(dp)
 	}
 
 	slog.Info("config compiled to dataplane",

--- a/pkg/dataplane/compiler_fibgen.go
+++ b/pkg/dataplane/compiler_fibgen.go
@@ -1,0 +1,53 @@
+package dataplane
+
+import "log/slog"
+
+// bumpFIBGenerationAfterRecompile performs CompileConfig's post-recompile FIB
+// generation bump and REPORTS a failure instead of discarding it (#7149,
+// split from #4960).
+//
+// Why the error matters here. On the live userspace path CompileConfig runs
+// against userspaceShimCompileDataplane (loader.go), whose ~55 DataPlane
+// overrides are all no-ops -- TestPrePassFakeIsNoMorePermissiveThanProduction_4960
+// asserts exactly that. BumpFIBGeneration is one of only three methods the
+// compiler calls that the shim does NOT override (the other two, IsLoaded and
+// GetPersistentNAT, run before any mutation and return no error), so it
+// promotes to the embedded *Manager and performs a real bpffs map write. It is
+// therefore the ONE compiler dataplane call on that path that can genuinely
+// fail.
+//
+// And a failure is not cosmetic. userspace/manager_compile.go builds the
+// snapshot it is about to hand the helper with m.readFIBGeneration(), which
+// re-reads the same fib_gen_map this bump writes. A failed bump leaves the map
+// at its old value, so the published snapshot carries the OLD generation, the
+// helper's session.fib_gen comparison still matches, and established flows keep
+// the cached next-hop (ifindex + DMAC/SMAC) that the recompile may have just
+// invalidated -- until they age out, with the apply reporting success
+// throughout. (*Manager).BumpFIBGeneration warns on two of its three failure
+// branches; the registryFresh / not-armed branch returns ErrDataplaneNotArmed
+// with no log at all, so without this the whole thing is silent.
+//
+// It deliberately does NOT return the error. This runs AFTER compileZones has
+// mutated the host and BEFORE the new snapshot is published, so propagating it
+// would manufacture a fresh instance of the exact half-applied shape #4960
+// exists to prevent: VLANs created and addresses reconciled, the apply aborted,
+// the helper left on the old snapshot. Making an apply fail CLOSED after the
+// dataplane has been asked is the apply-transaction half of #4960
+// (research/4960-apply-txn), not this. The other two production callers each
+// pick the treatment their own path can support -- the ip-monitoring actuator
+// retries via pendingFIBBump (#1844/#3757 H3), the route-leak commit tail fails
+// the commit closed because it has no retry owner (#5696 M19) -- and neither is
+// available here.
+//
+// The message wording is deliberately NOT asserted by any test; what is bound
+// is that the error is not discarded (TestCompilerNeverDiscardsTheFIBBumpError_7149,
+// a source walk) and that a failing bump produces a WARN carrying it
+// (TestFailedFIBBumpIsReported_7149).
+func bumpFIBGenerationAfterRecompile(dp DataPlane) {
+	if _, err := dp.BumpFIBGeneration(); err != nil {
+		slog.Warn("compile: FIB generation bump failed — the snapshot about to be "+
+			"published carries the previous generation, so established flows keep "+
+			"their cached next-hop until they age out",
+			"err", err)
+	}
+}

--- a/pkg/dataplane/compiler_fibgen_7149_test.go
+++ b/pkg/dataplane/compiler_fibgen_7149_test.go
@@ -1,0 +1,225 @@
+package dataplane
+
+// #7149 (split from #4960): CompileConfig's post-recompile FIB generation bump
+// used to be a bare `dp.BumpFIBGeneration()`, discarding both results.
+//
+// Two guards, because neither subsumes the other and each catches an escape the
+// other is blind to:
+//
+//   - TestFailedFIBBumpIsReported_7149 binds the BEHAVIOUR: a failing bump
+//     produces a WARN carrying the error. Gutting the body to a bare call reds
+//     it. It cannot see the CALL SITE — replacing
+//     `bumpFIBGenerationAfterRecompile(dp)` in CompileConfig with the old
+//     `dp.BumpFIBGeneration()` leaves it green, because the helper is still
+//     there and still correct.
+//   - TestCompilerNeverDiscardsTheFIBBumpError_7149 binds the SITE, as a source
+//     property rather than as a call trace: no production file in this package
+//     may call BumpFIBGeneration and drop its error. That is what reds on the
+//     revert. It cannot see whether the error is then USEFULLY handled — an
+//     `if err != nil {}` with an empty body satisfies it — which is what the
+//     behavioural half is for.
+//
+// The call site itself cannot be driven from a unit test: CompileConfig reaches
+// the bump only after compileZones completes, and compileZones' tail
+// (stripUnmanagedInterfaces) does netlink.LinkDel / LinkSetDown on every
+// unmanaged link on the host. Every other CompileConfig test in this package
+// stops on the errStopBeforeHostReconcile tripwire for that reason. A source
+// property is what remains available, so it is used deliberately and its limit
+// is stated rather than papered over.
+//
+// The WARN's wording is deliberately NOT asserted. Recording that the prose must
+// contain a phrase is what produced wrong-but-green rounds elsewhere in this
+// package; what is asserted is the LEVEL and that the injected error VALUE
+// reaches the record.
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// fibBumpDP answers BumpFIBGeneration with a scripted result and counts calls.
+// It embeds a NIL DataPlane on purpose: any other method the code under test
+// reaches panics instead of silently succeeding.
+type fibBumpDP struct {
+	DataPlane
+	err   error
+	calls int
+}
+
+func (d *fibBumpDP) BumpFIBGeneration() (uint32, error) {
+	d.calls++
+	return 7, d.err
+}
+
+func TestFailedFIBBumpIsReported_7149(t *testing.T) {
+	sentinel := errors.New("xpf-7149-sentinel: fib_gen_map write refused")
+
+	t.Run("failure is reported", func(t *testing.T) {
+		buf := captureWarnSlog(t)
+		dp := &fibBumpDP{err: sentinel}
+
+		bumpFIBGenerationAfterRecompile(dp)
+
+		if dp.calls != 1 {
+			t.Fatalf("want exactly 1 BumpFIBGeneration call, got %d — the helper "+
+				"no longer performs the bump at all", dp.calls)
+		}
+		warns := warnLines(buf)
+		if len(warns) == 0 {
+			t.Fatalf("a FAILED FIB generation bump produced no WARN record.\n\n"+
+				"captured log:\n%s\n\n"+
+				"The bump is the only compiler dataplane call that is not a shim "+
+				"no-op on the live userspace path, and (*Manager).BumpFIBGeneration's "+
+				"not-armed branch returns ErrDataplaneNotArmed WITHOUT logging. If "+
+				"this site drops it too, a recompile publishes a snapshot carrying "+
+				"the previous FIB generation and established flows keep a stale "+
+				"next-hop, with nothing in the journal saying so (#7149).", buf.String())
+		}
+		// The error VALUE must reach the record — a WARN that announces trouble
+		// without carrying which failure it was is not a report.
+		joined := strings.Join(warns, "\n")
+		if !strings.Contains(joined, "xpf-7149-sentinel") {
+			t.Errorf("the WARN does not carry the bump error.\ngot:\n%s", joined)
+		}
+	})
+
+	// Control. Without this the assertion above is satisfied by a helper that
+	// warns unconditionally, which would be a false alarm on every successful
+	// recompile — CLAUDE.md's logging rules exist precisely against that.
+	t.Run("success is silent", func(t *testing.T) {
+		buf := captureWarnSlog(t)
+		dp := &fibBumpDP{err: nil}
+
+		bumpFIBGenerationAfterRecompile(dp)
+
+		if dp.calls != 1 {
+			t.Fatalf("want exactly 1 BumpFIBGeneration call, got %d", dp.calls)
+		}
+		if warns := warnLines(buf); len(warns) != 0 {
+			t.Errorf("a SUCCESSFUL FIB generation bump emitted %d WARN record(s); "+
+				"the helper warns unconditionally:\n%s", len(warns), strings.Join(warns, "\n"))
+		}
+	})
+}
+
+// captureWarnSlog redirects the default logger into a buffer at WARN level for
+// the duration of the test. Same idiom as captureSlog in
+// compiler_prepass_logging_4960_test.go, narrowed to WARN so an unrelated INFO
+// record cannot be mistaken for a report.
+func captureWarnSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	})))
+	t.Cleanup(func() { slog.SetDefault(old) })
+	return &buf
+}
+
+func warnLines(buf *bytes.Buffer) []string {
+	var out []string
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(line, "level=WARN") {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// TestCompilerNeverDiscardsTheFIBBumpError_7149 walks this package's production
+// source and fails on any call to BumpFIBGeneration that drops its error —
+// either as a bare expression statement (`dp.BumpFIBGeneration()`, the exact
+// pre-#7149 shape) or as an assignment that blanks the error slot
+// (`_, _ = dp.BumpFIBGeneration()`, the shape a bare-statement-only check would
+// wave through).
+//
+// Scoped to pkg/dataplane, non-recursively: pkg/dataplane/userspace has its own
+// deliberate discards, documented at (*Manager).BumpFIBGeneration's error
+// contract in manager_generation.go, and this guard has no business ruling on
+// them.
+func TestCompilerNeverDiscardsTheFIBBumpError_7149(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("parse pkg/dataplane: %v", err)
+	}
+
+	var (
+		calls    int
+		offences []string
+	)
+	for _, pkg := range pkgs {
+		for path, file := range pkg.Files {
+			ast.Inspect(file, func(n ast.Node) bool {
+				switch stmt := n.(type) {
+				case *ast.ExprStmt:
+					if isFIBBumpCall(stmt.X) {
+						calls++
+						offences = append(offences, fmt.Sprintf(
+							"%s:%d: result discarded (bare call statement)",
+							path, fset.Position(stmt.Pos()).Line))
+					}
+				case *ast.AssignStmt:
+					if len(stmt.Rhs) != 1 || !isFIBBumpCall(stmt.Rhs[0]) {
+						return true
+					}
+					calls++
+					// The error is the LAST result.
+					if len(stmt.Lhs) == 0 {
+						return true
+					}
+					if id, ok := stmt.Lhs[len(stmt.Lhs)-1].(*ast.Ident); ok && id.Name == "_" {
+						offences = append(offences, fmt.Sprintf(
+							"%s:%d: error assigned to _",
+							path, fset.Position(stmt.Pos()).Line))
+					}
+				}
+				return true
+			})
+		}
+	}
+
+	// FLOOR. Without it a rename, a file move, or a broken walk empties the
+	// scan and this passes having proven nothing.
+	if calls == 0 {
+		t.Fatalf("the walk found NO call to BumpFIBGeneration in pkg/dataplane's " +
+			"production source. CompileConfig is supposed to make one on recompile, " +
+			"so either the bump was removed outright or this guard has stopped " +
+			"reaching the source it is meant to police.")
+	}
+
+	if len(offences) > 0 {
+		t.Errorf("BumpFIBGeneration's error is discarded at:\n  %s\n\n"+
+			"On the live userspace path this is the only compiler dataplane call "+
+			"that is not a shim no-op, so it is the only one that can really fail, "+
+			"and (*Manager).BumpFIBGeneration's not-armed branch returns "+
+			"ErrDataplaneNotArmed without logging. Dropping it publishes a snapshot "+
+			"carrying the PREVIOUS FIB generation — the helper's session.fib_gen "+
+			"comparison still matches and established flows keep a next-hop the "+
+			"recompile may have just invalidated, with the apply reporting success "+
+			"(#7149, #4960).\n\nReport it (see bumpFIBGenerationAfterRecompile); do "+
+			"NOT return it — this site runs after compileZones has mutated the host, "+
+			"so propagating manufactures the half-applied shape #4960 exists to "+
+			"prevent.", strings.Join(offences, "\n  "))
+	}
+}
+
+func isFIBBumpCall(e ast.Expr) bool {
+	call, ok := e.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && sel.Sel != nil && sel.Sel.Name == "BumpFIBGeneration"
+}

--- a/pkg/dataplane/compiler_validate_4960.go
+++ b/pkg/dataplane/compiler_validate_4960.go
@@ -259,13 +259,21 @@ func (discardingDataPlane) GetPersistentNAT() *PersistentNATTable {
 // and closing it needs the interface-resolution soft skips addressed first
 //
 // One more site sits outside BOTH the table and the exclusion prose above:
-// `dp.BumpFIBGeneration()` (compiler.go), which returns an error the caller
-// deliberately discards under the fire-and-forget contract documented at
-// dataplane.go. It is listed here only so a reader auditing coverage does not
-// have to rediscover that it is neither covered nor an omission -- it cannot
-// produce a returned CompileConfig error, so it is out of scope by construction
-// rather than by choice
+// the post-recompile FIB generation bump (compiler.go ->
+// bumpFIBGenerationAfterRecompile, compiler_fibgen.go). It is listed here only
+// so a reader auditing coverage does not have to rediscover that it is neither
+// covered nor an omission -- it cannot produce a returned CompileConfig error,
+// so it is out of scope by construction rather than by choice
 // (#6893).
+//
+// Do not read that as "so the error does not matter" -- an earlier revision of
+// this paragraph said the caller "deliberately discards" it under a
+// fire-and-forget contract, and that was the justification for a real defect
+// (#7149). Out of scope FOR THE PRE-PASS is not the same as harmless: the bump
+// is the only compiler dataplane call that is not a shim no-op on the live
+// userspace path, and a silent failure publishes a snapshot carrying the
+// previous FIB generation. It is now reported at the call site; what stays true
+// here is only that the pre-pass cannot and need not cover it.
 //
 // The double compile is safe with respect to ID assignment:
 // TestPrePassDoesNotPerturbIDAssignment_4960 measures that two passes with a

--- a/pkg/dataplane/dataplane.go
+++ b/pkg/dataplane/dataplane.go
@@ -391,7 +391,19 @@ type DataPlane interface {
 	// BumpFIBGeneration invalidates cached per-session FIB entries.
 	// #1844: returns the bump error so callers with retry semantics
 	// (the ip-monitoring routes-only actuator's pendingFIBBump) can
-	// see a failed bump; fire-and-forget callers may ignore it.
+	// see a failed bump.
+	//
+	// #7149: no production caller ignores it any more, and the phrase
+	// that used to sit here -- "fire-and-forget callers may ignore it"
+	// -- named exactly one caller, CompileConfig, which is the one it
+	// was wrong for. Each of the three picks the treatment its own path
+	// supports: the ip-monitoring actuator retries (pendingFIBBump), the
+	// route-leak commit tail fails the commit closed for want of a retry
+	// owner (#5696 M19), and the compiler REPORTS -- it runs after
+	// compileZones has mutated the host, so returning the error there
+	// would manufacture the half-applied apply #4960 exists to prevent.
+	// A new caller must choose one of the three; silently dropping it
+	// publishes a snapshot carrying the previous generation.
 	BumpFIBGeneration() (uint32, error)
 	// StartFIBSync is a no-op on every in-tree backend: eBPF resolves
 	// FIB queries via bpf_fib_lookup in-kernel and the userspace


### PR DESCRIPTION
`CompileConfig` ended a recompile with a bare `dp.BumpFIBGeneration()`,
dropping both results. On the live userspace path that is not a harmless
discard.

## Why this call in particular

`CompileUserspaceShim` compiles against `userspaceShimCompileDataplane`
(`pkg/dataplane/loader.go`), whose ~55 `DataPlane` overrides are all no-ops —
`TestPrePassFakeIsNoMorePermissiveThanProduction_4960` asserts exactly that.
Diffing every `dp.<Method>` the compiler calls against that override set leaves
three that are NOT overridden and therefore promote to the embedded `*Manager`:

| method | consequence |
|---|---|
| `IsLoaded` | runs before any mutation, cannot report a mid-apply failure |
| `GetPersistentNAT` | returns a pointer, no error |
| `BumpFIBGeneration` | **real bpffs map write — the only compiler dataplane call on this path that can genuinely fail** |

Measured, driving the production shim directly:

```go
dp := userspaceShimCompileDataplane{Manager: &Manager{}}
gen, err := dp.BumpFIBGeneration()
// -> gen=0 err="dataplane not armed: fib_gen_map"
```

`(*Manager).BumpFIBGeneration` warns on two of its three failure branches; the
`registryFresh` / not-armed branch returns `ErrDataplaneNotArmed` with **no log
at all**. So on that branch the failure was completely silent.

## Why it matters

`userspace/manager_compile.go` builds the snapshot it is about to hand the
helper with `m.readFIBGeneration()`, which re-reads the very `fib_gen_map` this
bump writes. A failed bump leaves the map at its old value → the published
snapshot carries the OLD FIB generation → the helper's `session.fib_gen`
comparison still matches → **established flows keep the cached next-hop
(ifindex + DMAC/SMAC) that the recompile may have just invalidated**, until they
age out, with the apply reporting success throughout.

## Why it is reported, not returned

This site runs *after* `compileZones` has mutated the host and *before* the new
snapshot is published. Propagating would manufacture a fresh instance of the
exact half-applied shape #4960 exists to prevent. The other two production
callers each pick the treatment their own path supports — the ip-monitoring
actuator retries via `pendingFIBBump` (#1844/#3757 H3), the route-leak commit
tail fails the commit closed for want of a retry owner (#5696 M19) — and neither
is available here. Failing an apply closed *after* the dataplane has been asked
is the apply-transaction half of #4960 (`research/4960-apply-txn`, twice
PLAN-NEEDS-MAJOR), not this change.

## Guards

Two, and neither subsumes the other:

- **behavioural** — drives the helper with a failing and a succeeding dataplane;
  binds that a failure produces a WARN carrying the error VALUE and that a
  success is silent. Blind to the call site.
- **source walk** — no production file in `pkg/dataplane` may call
  `BumpFIBGeneration` and drop its error, as a bare statement or by blanking the
  error slot; carries a floor so a rename or a broken walk cannot pass
  vacuously. Blind to whether the error is usefully handled.

The call site cannot be driven from a unit test — `CompileConfig` reaches the
bump only after `compileZones` completes, and its tail `stripUnmanagedInterfaces`
does `netlink.LinkDel` / `LinkSetDown` on every unmanaged link on the host, which
is why every other `CompileConfig` test in this package stops on the
`errStopBeforeHostReconcile` tripwire. The source property is what remains
available; its limit is stated in the test file rather than papered over.

The WARN wording is deliberately unasserted.

## Docs

`DataPlane.BumpFIBGeneration`'s contract said "fire-and-forget callers may
ignore it" — a phrase that named exactly one caller, and the one it was wrong
for. It now states what each of the three callers does and that a new caller
must pick one. `compiler_validate_4960.go` also told a coverage auditor the
error was "deliberately discard[ed] under the fire-and-forget contract"; that
sentence was the justification a reader would have found for leaving this alone,
so it is replaced rather than merely refreshed.

## Validation

```
go test -count=1 ./pkg/dataplane/...        exit 0
go test -count=1 ./pkg/daemon/              exit 0
go vet ./pkg/dataplane/...                  exit 0
go build ./...                              exit 0
```

Mutation matrix — one mutation per cell, exit codes read from `$?`:

| mutation | exit | reds |
|---|---|---|
| revert call site to `dp.BumpFIBGeneration()` | 1 | source walk ONLY (behavioural stays green, as documented) |
| gut helper to `_, _ = dp.BumpFIBGeneration()` | 1 | BOTH guards |
| warn unconditionally | 1 | `success_is_silent` control ONLY |
| delete the only production call | 1 | the floor ("the walk found NO call…") |

Go-only diff; no shim `.o`, protocol version or wire-format movement, so no
cluster smoke is owed.

Closes #7149
