### PR TITLE
umem: delete the UMEM before unmapping its pages

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,46 @@
+## 2026-08-21 — #5192 item 1: `WorkerUmemInner` unmapped the UMEM before deleting it
+
+- **Timestamp**: 2026-08-21 (fix/5192-umem-drop-order)
+- **Action**: Swapped the `umem` / `area` field declarations in
+  `WorkerUmemInner` so the libxdp UMEM object is destroyed before the mmap
+  region backing it, and pinned the ordering with a test.
+
+  `xsk_ffi::Umem::new` is `unsafe` on one stated precondition — the caller's
+  `area` must "outlive this Umem". `WorkerUmemInner` owns both halves of that
+  pair and declared `area` first, so Rust's declaration-order field destruction
+  ran `munmap` and only then `xsk_umem__delete`: the pages were released while
+  the UMEM object was still registered against them. Latent rather than a live
+  UAF, because `bridge_xsk_umem_delete` -> `xsk_umem__delete` does not read the
+  user area and the kernel pins UMEM pages while the fd is open — but that
+  mitigation is an unpinned external library's implementation detail, and this
+  box now links libxdp 1.6.3 where the original refutation was written against
+  1.6.0. The fix costs two lines and removes the dependence entirely.
+
+  Rust has NO compile-time drop-order assertion — there is no `const` fact to
+  hang a `const _: () = assert!(..)` on — so inventing one would have been
+  fragile. The order is pinned by OBSERVATION instead: a `cfg(test)`-only
+  `crate::drop_order_probe` that both `Drop` impls append to, and
+  `umem/tests/drop_order.rs` asserting the sequence on the REAL
+  `WorkerUmemInner` (via `WorkerUmem::new_for_test`) and on the
+  `WorkerUmemPool` wrapper production actually builds. The probe is
+  allocation-free (fixed thread-local array, `try_with`) because it runs inside
+  `Drop` and this crate installs a counting global allocator under `cfg(test)`
+  that other tests assert against; a `Vec` push would charge an allocation to
+  whatever hot-path test happened to drop a UMEM inside its window.
+
+  Validation: the test was written BEFORE the swap and observed the defect
+  directly — both cases red at `a77d5568c` with `left: [MmapArea, Umem]`,
+  i.e. munmap first. Green after the swap with `[Umem, MmapArea]`. Full
+  `make test-rust` green. No shim, no Go, no compiled-artifact movement, so no
+  cluster smoke is owed. #5192's second item (the XDP shim's aligned metadata
+  store) is NOT in this change — see below.
+- **File(s)**: userspace-dp/src/afxdp/umem/mod.rs,
+  userspace-dp/src/afxdp/umem/mmap.rs,
+  userspace-dp/src/afxdp/umem/tests/mod.rs,
+  userspace-dp/src/afxdp/umem/tests/drop_order.rs,
+  userspace-dp/src/afxdp/umem/README.md, userspace-dp/src/drop_order_probe.rs,
+  userspace-dp/src/main.rs, userspace-dp/src/xsk_ffi.rs, _Log.md
+
 ## 2026-08-21 — #6697: the CoS `code-points` BLOCK spelling lost the whole classifier
 
 - **Timestamp**: 2026-08-21 (fix/6697-cos-code-points-spellings)

--- a/userspace-dp/src/afxdp/umem/README.md
+++ b/userspace-dp/src/afxdp/umem/README.md
@@ -18,7 +18,7 @@ drop-in for xdpilone), and tracks frame budgets per binding.
 | `mod.rs` | `WorkerUmem` / `WorkerUmemInner` / `WorkerUmemPool` — Rc-shared UMEM handle held by the owner worker, plus the free-frame pool. |
 | `mmap.rs` | `MmapArea` — the raw `mmap` region. |
 | `mmap_tests.rs` | Co-located mmap unit tests. |
-| `tests/` | Co-located UMEM unit tests: `mod.rs` + `mmap_area.rs`. The binding-state concern tests moved to `../binding_state/tests/` in #6436 (the #4667 per-concern split maps 1:1 onto the new location). |
+| `tests/` | Co-located UMEM unit tests: `mod.rs` + `drop_order.rs` + `mmap_area.rs`. The binding-state concern tests moved to `../binding_state/tests/` in #6436 (the #4667 per-concern split maps 1:1 onto the new location). |
 
 ## Where it sits
 
@@ -34,6 +34,20 @@ drop-in for xdpilone), and tracks frame budgets per binding.
   descriptor sharing. This is the reason every "rebalance flows
   across workers" design has been plan-killed; see
   `docs/per-5-tuple/state.md` for the formal ceiling.
+- **`WorkerUmemInner` field order is load-bearing (#5192).** `umem`
+  is declared BEFORE `area` because Rust destroys struct fields in
+  declaration order, and `xsk_ffi::Umem::new` is `unsafe` on the
+  precondition that the mmap'd area outlives the `Umem`. Declared the
+  other way round, `munmap` runs while the libxdp UMEM object is still
+  registered against those pages — a latent use-after-free whose only
+  defence is that `xsk_umem__delete` in the linked libxdp happens not
+  to read the user area, which is an unpinned external library's
+  implementation detail rather than an invariant this repo controls.
+  Rust has no compile-time drop-order assertion, so the order is
+  pinned by observation: both destructors record into
+  `crate::drop_order_probe` under `cfg(test)` and
+  `tests/drop_order.rs` asserts `[Umem, MmapArea]`. Swapping the two
+  declarations back reds it.
 - `Rc<WorkerUmemInner>` (not `Arc`) is intentional — UMEM ownership
   doesn't cross thread boundaries within the worker. The cross-binding
   redirect path in `cos/cross_binding.rs` *copies* frames into the

--- a/userspace-dp/src/afxdp/umem/mmap.rs
+++ b/userspace-dp/src/afxdp/umem/mmap.rs
@@ -158,6 +158,11 @@ impl MmapArea {
 
 impl Drop for MmapArea {
     fn drop(&mut self) {
+        // #5192: this `munmap` must not run until the `Umem` registered
+        // against the region is gone — see `WorkerUmemInner`'s field
+        // order and `crate::drop_order_probe`.
+        #[cfg(test)]
+        crate::drop_order_probe::record(crate::drop_order_probe::DropTag::MmapArea);
         let _ = unsafe { libc::munmap(self.ptr.as_ptr().cast::<c_void>(), self.mapped_len) };
     }
 }

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -3,9 +3,25 @@ use super::*;
 mod mmap;
 pub(in crate::afxdp) use mmap::MmapArea;
 
+/// The UMEM region plus the libxdp UMEM object registered against it.
+///
+/// **Field order is load-bearing (#5192).** `xsk_ffi::Umem::new` is
+/// `unsafe` on the precondition that the mmap'd `area` "outlives this
+/// Umem", and Rust destroys struct fields in DECLARATION order — so
+/// `umem` (which calls `xsk_umem__delete`) MUST be declared before
+/// `area` (which calls `munmap`). Reversed, the pages are unmapped
+/// while the UMEM object is still registered against them: a latent
+/// use-after-free whose only defence is that the linked libxdp's
+/// `xsk_umem__delete` happens not to read the user area — an external
+/// library's implementation detail, not an invariant this repo owns.
+///
+/// Rust offers no compile-time drop-order assertion, so the order is
+/// pinned by observation instead: `afxdp::umem::tests::drop_order`
+/// watches both destructors through `crate::drop_order_probe` and reds
+/// if these two lines are ever swapped back.
 pub(super) struct WorkerUmemInner {
-    area: MmapArea,
     umem: Umem,
+    area: MmapArea,
     total_frames: u32,
 }
 
@@ -35,8 +51,8 @@ impl WorkerUmem {
             .map_err(|e| format!("create umem: {e}"))?;
         Ok(Self {
             inner: Rc::new(WorkerUmemInner {
-                area,
                 umem,
+                area,
                 total_frames,
             }),
         })
@@ -58,8 +74,8 @@ impl WorkerUmem {
         let umem = Umem::new_for_test(umem_cfg, area.as_nonnull_slice());
         Ok(Self {
             inner: Rc::new(WorkerUmemInner {
-                area,
                 umem,
+                area,
                 total_frames,
             }),
         })

--- a/userspace-dp/src/afxdp/umem/tests/drop_order.rs
+++ b/userspace-dp/src/afxdp/umem/tests/drop_order.rs
@@ -1,0 +1,68 @@
+// #5192 A1-b6-F6 — `WorkerUmemInner` field destruction order.
+//
+// `xsk_ffi::Umem::new` is `unsafe` on one stated precondition: the
+// caller-supplied `area` must "outlive this Umem". `WorkerUmemInner`
+// owns both halves of that pair, so it is the type that has to honour
+// it, and Rust destroys struct fields in DECLARATION order. Declaring
+// `area` first therefore runs `munmap` while the libxdp UMEM object is
+// still registered against those pages — a latent use-after-free whose
+// only defence today is that `xsk_umem__delete` in the pinned libxdp
+// happens not to read the user area. That is an unpinned external
+// library's implementation detail, not an invariant this repo controls,
+// and this box already runs a different libxdp point release than the
+// one the original refutation was written against.
+//
+// Rust exposes no compile-time drop-order assertion, so the guard is an
+// observation: both destructors record into `crate::drop_order_probe`
+// under `cfg(test)`. Restoring the old field order reds this test.
+
+use super::*;
+use crate::drop_order_probe::{self, DropTag};
+
+#[test]
+fn worker_umem_inner_drops_umem_before_mmap_area() {
+    drop_order_probe::reset();
+
+    let umem = WorkerUmem::new_for_test(4).expect("build hermetic worker umem");
+    assert_eq!(
+        drop_order_probe::recorded(),
+        Vec::<DropTag>::new(),
+        "constructing a WorkerUmem must not destroy either half"
+    );
+
+    drop(umem);
+
+    // The whole point: `Umem` (xsk_umem__delete) strictly before
+    // `MmapArea` (munmap). Reversed, this is the latent UAF.
+    assert_eq!(
+        drop_order_probe::recorded(),
+        vec![DropTag::Umem, DropTag::MmapArea],
+        "WorkerUmemInner must destroy its Umem before the MmapArea backing it; \
+         field declaration order in umem/mod.rs is what fixes this"
+    );
+}
+
+#[test]
+fn worker_umem_pool_preserves_the_same_drop_order() {
+    // `WorkerUmemPool` is the type production actually constructs
+    // (`WorkerUmemPool::new` -> `WorkerUmem::new`), and it wraps the
+    // `WorkerUmem` in a struct of its own. Pin that the extra wrapper
+    // does not reorder the pair: a future field shuffle in
+    // `WorkerUmemPool` cannot change it, but a `Drop` impl added there
+    // could, and this catches that.
+    drop_order_probe::reset();
+
+    let pool = WorkerUmemPool {
+        umem: WorkerUmem::new_for_test(4).expect("build hermetic worker umem"),
+        free_frames: VecDeque::new(),
+    };
+    assert_eq!(drop_order_probe::recorded(), Vec::<DropTag>::new());
+
+    drop(pool);
+
+    assert_eq!(
+        drop_order_probe::recorded(),
+        vec![DropTag::Umem, DropTag::MmapArea],
+        "wrapping a WorkerUmem in WorkerUmemPool must not reorder the UMEM/mmap teardown"
+    );
+}

--- a/userspace-dp/src/afxdp/umem/tests/mod.rs
+++ b/userspace-dp/src/afxdp/umem/tests/mod.rs
@@ -4,8 +4,10 @@
 // per-concern layout maps 1:1 onto the new location).
 //
 // Submodules by concern (see each file):
+//   drop_order  — #5192 UMEM-before-munmap field destruction order
 //   mmap_area
 
 use super::*;
 
+mod drop_order;
 mod mmap_area;

--- a/userspace-dp/src/drop_order_probe.rs
+++ b/userspace-dp/src/drop_order_probe.rs
@@ -1,0 +1,76 @@
+// #5192 A1-b6-F6: test-only drop-order probe for the UMEM lifetime pair.
+//
+// `WorkerUmemInner` owns both a `xsk_ffi::Umem` (whose `Drop` calls
+// `xsk_umem__delete`) and the `MmapArea` that backs it (whose `Drop`
+// calls `munmap`). `Umem::new` documents the unsafe contract that the
+// area must OUTLIVE the `Umem`, so the `Umem` field has to be
+// destroyed first.
+//
+// Rust destroys struct fields in DECLARATION order and offers no
+// compile-time way to assert that order — there is no `const` fact to
+// hang a `const _: () = assert!(..)` on, and a comment is not a gate.
+// So the invariant is pinned by OBSERVATION instead: both `Drop` impls
+// append a tag here under `cfg(test)`, and
+// `afxdp::umem::tests::drop_order` asserts the sequence. Swapping the
+// two field declarations back reds that test.
+//
+// Allocation-free on purpose: `record` runs inside `Drop`, and this
+// crate installs a counting global allocator under `cfg(test)`
+// (`test_alloc::CountingAlloc`) that other tests assert against. A
+// `Vec` push here would charge an allocation to whatever hot-path
+// test happened to drop a UMEM inside its measurement window.
+
+use std::cell::Cell;
+
+/// Which destructor ran.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DropTag {
+    /// `xsk_ffi::Umem::drop` — `xsk_umem__delete`.
+    Umem = 1,
+    /// `afxdp::umem::MmapArea::drop` — `munmap`.
+    MmapArea = 2,
+}
+
+/// Ring capacity. The observed sequences are two events long; the
+/// slack exists so an unexpected extra drop is visible as a length
+/// mismatch rather than being silently discarded.
+const CAP: usize = 8;
+
+thread_local! {
+    static LOG: Cell<(usize, [u8; CAP])> = const { Cell::new((0, [0u8; CAP])) };
+}
+
+/// Append `tag` to this thread's drop log. Silently no-ops once the
+/// log is full, and when TLS is already torn down (`try_with`) — this
+/// runs from `Drop`, including during thread teardown.
+pub(crate) fn record(tag: DropTag) {
+    let _ = LOG.try_with(|cell| {
+        let (n, mut buf) = cell.get();
+        if n < CAP {
+            buf[n] = tag as u8;
+            cell.set((n + 1, buf));
+        }
+    });
+}
+
+/// Clear this thread's drop log. Call at the top of a probing test so
+/// drops from earlier tests on the same thread cannot leak in.
+pub(crate) fn reset() {
+    let _ = LOG.try_with(|cell| cell.set((0, [0u8; CAP])));
+}
+
+/// Snapshot this thread's drop log, oldest first. Allocates — call it
+/// from a test body, never from a `Drop` impl.
+pub(crate) fn recorded() -> Vec<DropTag> {
+    LOG.with(|cell| {
+        let (n, buf) = cell.get();
+        buf[..n]
+            .iter()
+            .map(|&b| match b {
+                1 => DropTag::Umem,
+                2 => DropTag::MmapArea,
+                other => unreachable!("unknown drop tag {other}"),
+            })
+            .collect()
+    })
+}

--- a/userspace-dp/src/main.rs
+++ b/userspace-dp/src/main.rs
@@ -27,6 +27,15 @@ mod tcp_flags;
 #[allow(dead_code)]
 mod xsk_ffi;
 
+// #5192: test-only drop-order probe. `WorkerUmemInner` must destroy
+// its `Umem` (xsk_umem__delete) before the `MmapArea` that backs it
+// (munmap); Rust has no compile-time drop-order assertion, so the two
+// `Drop` impls record here under `cfg(test)` and a umem test asserts
+// the sequence. Production builds compile neither the probe nor the
+// recording calls.
+#[cfg(test)]
+mod drop_order_probe;
+
 // #4971: test-only counting global allocator. Lets the TX hot-path
 // regression tests assert that an expected TX backpressure retry
 // performs ZERO heap allocations per drain pass. Compiled only under

--- a/userspace-dp/src/xsk_ffi.rs
+++ b/userspace-dp/src/xsk_ffi.rs
@@ -469,6 +469,12 @@ impl Umem {
 
 impl Drop for Umem {
     fn drop(&mut self) {
+        // #5192: record BEFORE the null check — the ordering fact under
+        // test is when this destructor runs relative to the backing
+        // `MmapArea`'s, and the hermetic `new_for_test` Umem carries a
+        // null `inner`.
+        #[cfg(test)]
+        crate::drop_order_probe::record(crate::drop_order_probe::DropTag::Umem);
         if !self.inner.is_null() {
             unsafe { bridge_xsk_umem_delete(self.inner) };
         }


### PR DESCRIPTION
`xsk_ffi::Umem::new` is `unsafe` on one stated precondition — the caller's
`area` must be "a valid, page-aligned mmap'd region that **outlives this
Umem**" (`userspace-dp/src/xsk_ffi.rs:387-389`). `WorkerUmemInner`
(`userspace-dp/src/afxdp/umem/mod.rs`) owns both halves of that pair and
declared `area: MmapArea` before `umem: Umem`. Rust destroys struct fields in
DECLARATION order, so teardown ran `munmap` first and `xsk_umem__delete`
second: the pages were released while the libxdp UMEM object was still
registered against them.

Latent rather than a live UAF — `bridge_xsk_umem_delete` -> `xsk_umem__delete`
does not read the user area, and the kernel pins UMEM pages while the fd is
open. But that mitigation is an **unpinned external library's implementation
detail**, not an invariant this repo controls. This box links `libxdp 1.6.3-1`
(`dpkg -l libxdp1`), while the original refutation was reasoned about 1.6.0.
The correct order costs two lines.

## Pinning the order

Rust has **no compile-time drop-order assertion** — there is no `const` fact to
hang a `const _: () = assert!(..)` on, and `ManuallyDrop` + a hand-written
`Drop` would trade a latent bug for two live `unsafe` calls whose only job is to
restate what declaration order already says. Neither was invented; the order is
pinned by **observation** instead.

`crate::drop_order_probe` is a `cfg(test)`-only recorder that both destructors
append to, and `umem/tests/drop_order.rs` asserts the sequence on the **real**
`WorkerUmemInner` (via `WorkerUmem::new_for_test`) and on the `WorkerUmemPool`
wrapper production actually constructs. The recording sites are the production
`Drop` impls, so the test watches the shipped teardown path, not a mirror.

The probe is allocation-free on purpose (fixed thread-local array + `try_with`,
not a `Vec`): it runs inside `Drop`, and this crate installs a counting global
allocator under `cfg(test)` that other tests assert against.

## Validation

The test was written against the **unfixed** field order and observed the defect
directly:

```
left:  [MmapArea, Umem]     <- a77d5568c (origin/master): munmap first
right: [Umem, MmapArea]
```

Both cases red before the swap, green after. `make test-rust` green end to end
(4453 + 60 + 8 + 22 + 31 + 1 + 2 passed, 0 failed, `$?` = 0).
`make build-userspace-dp` clean — the probe compiles to nothing outside
`cfg(test)`.

**No cluster smoke owed.** Rust-only; no Go, no `userspace-xdp` source, and
`pkg/dataplane/userspace_xdp_bpfel.o` is untouched.

## Scope — this does NOT close #5192

Issue #5192 is a two-item cohort. This is **item 1 only**. Item 2 (A1-b11-F3,
the XDP shim's aligned typed metadata store) was implemented and **measured**,
and then reverted: `ptr::write_unaligned` costs **+14,047 verifier processed
insns (773,966 -> 788,013), headroom 22.60% -> 21.20%**, and **+1,152 bytes of
`.text` (+144 BPF insns)** on the per-packet redirect path — LLVM's BPF backend
lowers an unaligned 96-byte store to byte-wise stores. The full measurement is
posted on the issue; #5192 stays open on item 2.

Refs #5192