### PR TITLE
policymatch/cli: fix 2 of 19 codex-181 cohort survivors (C14, C20)

### DIFF
--- a/pkg/cli/cli_request_testcmd.go
+++ b/pkg/cli/cli_request_testcmd.go
@@ -132,6 +132,15 @@ func (c *CLI) testPolicy(args []string) error {
 		// #3285: host-bound traffic — no transit global/default fallback.
 		fmt.Printf("No matching to-zone junos-host policy for %s -> junos-host\n", fromZone)
 		fmt.Printf("  %s\n", policymatch.HostInboundShowLine)
+		// #5649 (C181-C20): name the admitting host-inbound-traffic token (or
+		// report deny/global-accept/indeterminate), mirroring the local `show
+		// security match-policies` renderer (#3627 B1a) — this remote/`request`
+		// path was missing it entirely.
+		if res.HostInbound != nil {
+			if line := res.HostInbound.Describe(); line != "" {
+				fmt.Printf("  host-inbound-traffic (zone %s): %s\n", fromZone, line)
+			}
+		}
 		return nil
 	}
 	// #4373 (E4/H2/H7): a multicast/broadcast/unspecified/loopback destination is
@@ -173,6 +182,16 @@ func (c *CLI) testPolicy(args []string) error {
 	fmt.Printf("  Policy:    %s\n", res.PolicyName)
 	printPolicyMatchIdentity(res)
 	fmt.Printf("  Action:    %s\n", policymatch.ActionString(res.Action))
+	// #5649 (C181-C20): a MATCHED to-zone junos-host fine policy still needs
+	// the coarse host-inbound-traffic admission gate named — LocalDelivery
+	// evaluates BOTH and the fine action alone does not govern the flow.
+	// res.HostInbound is populated only for to-zone junos-host queries
+	// (matchJunosHost), so this is a no-op for an ordinary transit match.
+	if res.HostInbound != nil {
+		if line := res.HostInbound.Describe(); line != "" {
+			fmt.Printf("  Host-inbound: %s\n", line)
+		}
+	}
 	if srcIP != "" {
 		fmt.Printf("  Source:    %s -> ", srcIP)
 	} else {

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -500,6 +500,19 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 	} else {
 		fmt.Printf("    Scope: zone-pair (from-zone: %s, to-zone: %s)\n", res.FromZone, res.ToZone)
 	}
+	// #5649 (C181-C20): a MATCHED to-zone junos-host fine policy still needs
+	// the coarse host-inbound-traffic admission gate (LocalDelivery evaluates
+	// BOTH — the fine policy action never overrides a coarse deny). Without
+	// this line an operator reading a matched permit could believe the fine
+	// action alone governs the flow; mirrors the HostInboundUnmatched branch's
+	// Describe() call above, which already names the gate for the no-match
+	// case (#3627 B1a). res.HostInbound is populated only for to-zone
+	// junos-host queries (matchJunosHost), so this is a no-op for transit.
+	if res.HostInbound != nil {
+		if line := res.HostInbound.Describe(); line != "" {
+			fmt.Printf("    host-inbound-traffic (zone %s): %s\n", fromZone, line)
+		}
+	}
 	if res.Description != "" {
 		fmt.Printf("    Description: %s\n", res.Description)
 	}

--- a/pkg/cli/host_inbound_verdict_render_5649_test.go
+++ b/pkg/cli/host_inbound_verdict_render_5649_test.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #5649 (C181-C20): a MATCHED to-zone junos-host fine policy still needs the
+// coarse host-inbound-traffic admission gate named beside it — LocalDelivery
+// evaluates BOTH (the fine policy action never overrides a coarse deny), and
+// before this fix neither the local `show security match-policies` renderer
+// nor the remote/`request` `test policy` renderer printed
+// Result.HostInbound.Describe() for a MATCHED result; `test policy`'s
+// HostInboundUnmatched branch didn't call it either (`show security
+// match-policies` already did, #3627 B1a).
+//
+// hostInboundJunosHostStore builds a zone "trust" carrying a host-inbound-
+// traffic ssh admission and a `to-zone junos-host` policy that separately
+// permits the same tuple at the fine-policy layer, so a query against it is
+// Matched=true (fine permit) AND res.HostInbound.Status ==
+// HostInboundTokenAdmit (coarse ssh admit) simultaneously.
+func hostInboundJunosHostStore(t *testing.T) *CLI {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust {
+            host-inbound-traffic {
+                system-services { ssh; }
+            }
+        }
+        security-zone untrust {
+            host-inbound-traffic {
+                system-services { ssh; }
+            }
+        }
+    }
+    policies {
+        from-zone trust to-zone junos-host {
+            policy allow-ssh {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return &CLI{store: store}
+}
+
+// TestShowMatchPoliciesMatchedHostInboundDescribe pins the local `show
+// security match-policies` renderer (cli_show_security.go showMatchPolicies).
+//
+// FAIL-ON-REVERT: dropping the `if res.HostInbound != nil { ... Describe() }`
+// block from the matched-verdict branch removes the "host-inbound-traffic"
+// line, failing the Contains assertion below.
+func TestShowMatchPoliciesMatchedHostInboundDescribe(t *testing.T) {
+	c := hostInboundJunosHostStore(t)
+	out := captureStdout(t, func() {
+		if err := c.showMatchPolicies(c.store.ActiveConfig(), []string{
+			"from-zone", "trust", "to-zone", "junos-host",
+			"protocol", "tcp", "destination-port", "22",
+		}); err != nil {
+			t.Fatalf("showMatchPolicies() error = %v", err)
+		}
+	})
+	if !strings.Contains(out, "Matching policy") {
+		t.Fatalf("want a matched fine policy verdict, got: %s", out)
+	}
+	if !strings.Contains(out, "host-inbound-traffic") || !strings.Contains(out, "ssh") {
+		t.Errorf("matched junos-host verdict missing the coarse host-inbound-traffic admission line (#5649); out = %s", out)
+	}
+}
+
+// TestTestPolicyMatchedHostInboundDescribe covers the sibling remote/`request
+// test policy` renderer (cli_request_testcmd.go testPolicy), which was
+// missing Describe() on BOTH its HostInboundUnmatched and matched branches.
+//
+// FAIL-ON-REVERT: dropping either Describe() block reintroduces a matched (or
+// unmatched) junos-host verdict with no host-inbound-traffic context.
+func TestTestPolicyMatchedHostInboundDescribe(t *testing.T) {
+	c := hostInboundJunosHostStore(t)
+	out := captureStdout(t, func() {
+		if err := c.testPolicy([]string{
+			"from-zone", "trust", "to-zone", "junos-host",
+			"protocol", "tcp", "destination-port", "22",
+		}); err != nil {
+			t.Fatalf("testPolicy() error = %v", err)
+		}
+	})
+	if !strings.Contains(out, "Policy match") {
+		t.Fatalf("want a matched fine policy verdict, got: %s", out)
+	}
+	if !strings.Contains(out, "Host-inbound:") || !strings.Contains(out, "ssh") {
+		t.Errorf("matched junos-host verdict missing the coarse host-inbound-traffic admission line (#5649); out = %s", out)
+	}
+}
+
+// TestTestPolicyUnmatchedHostInboundDescribe covers the HostInboundUnmatched
+// branch of testPolicy: "untrust" carries the same ssh host-inbound-traffic
+// admission as "trust" but has NO to-zone junos-host fine policy authored, so
+// the verdict falls straight to the coarse gate.
+func TestTestPolicyUnmatchedHostInboundDescribe(t *testing.T) {
+	c := hostInboundJunosHostStore(t)
+	out := captureStdout(t, func() {
+		if err := c.testPolicy([]string{
+			"from-zone", "untrust", "to-zone", "junos-host",
+			"protocol", "tcp", "destination-port", "22",
+		}); err != nil {
+			t.Fatalf("testPolicy() error = %v", err)
+		}
+	})
+	if !strings.Contains(out, "No matching to-zone junos-host policy") {
+		t.Fatalf("want HostInboundUnmatched (no fine policy authored for untrust), got: %s", out)
+	}
+	if !strings.Contains(out, "host-inbound-traffic") || !strings.Contains(out, "ssh") {
+		t.Errorf("unmatched junos-host verdict missing the host-inbound-traffic admission line (#5649); out = %s", out)
+	}
+}

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -1497,7 +1497,7 @@ func reportedScopeZone(scope []string, flowZone string) string {
 // global / junos-host policies (policy.rs evaluate_policy_result_with_icmp gates
 // the whole transit block on from_id != 0 && to_id != 0; evaluate_junos_host_policy
 // returns None for from_id == 0). A zone is "known" iff it is present in
-// cfg.Security.Zones.
+// cfg.Security.Zones AND is not QUARANTINED (#5649, C181-C14/C20).
 //
 // This mirrors the runtime UNCONDITIONALLY — there is deliberately NO
 // empty-Zones leniency. policy.rs applies the from_id/to_id != 0 gate for every
@@ -1508,9 +1508,45 @@ func reportedScopeZone(scope []string, flowZone string) string {
 // the runtime would never evaluate. A committed production config always
 // populates Zones; a synthetic config without zones now faithfully matches
 // nothing in transit.
+//
+// #5649 (C181-C14/C20): a lenient/HA-loaded config with a StableZoneID
+// collision keeps compiling — the LATER-sorting zone name is QUARANTINED at
+// snapshot build (config.QuarantinedZoneNames / zoneid.go) and dropped from
+// the dataplane: its interfaces are unzoned (fail to id 0) and its policies
+// are scrubbed. Before this fix, zoneKnown consulted only the raw typed
+// cfg.Security.Zones map, which STILL contains the quarantined name (typed
+// config carries the collision; only the built snapshot resolves it), so the
+// simulator reported a quarantined zone as policy-matchable — telling an
+// operator that a policy referencing the DROPPED zone permits or denies a
+// flow, when the runtime never installed that zone at all. Projecting the
+// same collision-quarantine result used by the wire builder keeps the
+// simulator's "known" predicate honest about what the dataplane actually
+// admitted.
 func zoneKnown(cfg *config.Config, zone string) bool {
-	_, ok := cfg.Security.Zones[zone]
-	return ok
+	if _, ok := cfg.Security.Zones[zone]; !ok {
+		return false
+	}
+	if _, quarantined := quarantinedZoneNames(cfg)[zone]; quarantined {
+		return false
+	}
+	return true
+}
+
+// quarantinedZoneNames computes the #3719 StableZoneID collision-quarantine
+// set for cfg's configured zone names — the exact projection zoneKnown needs
+// to treat a runtime-dropped zone as unknown (#5649, C181-C14/C20). This is a
+// cold config-tool path (CLI/REST/gRPC `match-policies`, not per-packet), so
+// recomputing the O(n log n) sort per zoneKnown call is not hot-path work; n
+// is the configured zone count, typically tens of entries.
+func quarantinedZoneNames(cfg *config.Config) map[string]struct{} {
+	if len(cfg.Security.Zones) < 2 {
+		return nil
+	}
+	names := make([]string, 0, len(cfg.Security.Zones))
+	for name := range cfg.Security.Zones {
+		names = append(names, name)
+	}
+	return config.QuarantinedZoneNames(names)
 }
 
 // matchedResult builds the verdict for a concrete policy hit, stamping its zone

--- a/pkg/policymatch/zone_quarantine_5649_test.go
+++ b/pkg/policymatch/zone_quarantine_5649_test.go
@@ -1,0 +1,118 @@
+package policymatch
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// zoneQuarantineCfg builds a config carrying the verified StableZoneID
+// collision pair z174/z214 (also used by
+// pkg/dataplane/userspace/zones_collision_3719_test.go) plus a distinct
+// "trust" zone. z214 is the later-sorting name, so config.QuarantinedZoneNames
+// drops it — exactly what a lenient/HA-loaded config with an unrenamed
+// collision produces at snapshot build (zoneid.go). A permit policy references
+// z214 both as a zone-pair from-zone and as a junos-host from-zone.
+func zoneQuarantineCfg(t *testing.T) *config.Config {
+	t.Helper()
+	if config.StableZoneID("z174") != config.StableZoneID("z214") {
+		t.Fatalf("test premise broken: z174/z214 no longer collide under the frozen fold")
+	}
+	permitAny := func(name string) *config.Policy {
+		return &config.Policy{
+			Name:   name,
+			Action: config.PolicyPermit,
+			Match: config.PolicyMatch{
+				SourceAddresses:      []string{"any"},
+				DestinationAddresses: []string{"any"},
+				Applications:         []string{"any"},
+			},
+		}
+	}
+	return &config.Config{
+		Security: config.SecurityConfig{
+			DefaultPolicy: config.PolicyDeny,
+			Zones:         zones("z174", "z214", "trust"),
+			Policies: []*config.ZonePairPolicies{
+				{FromZone: "z214", ToZone: "trust", Policies: []*config.Policy{permitAny("z214-to-trust")}},
+				{FromZone: "z214", ToZone: JunosHostZone, Policies: []*config.Policy{permitAny("z214-host")}},
+			},
+		},
+		Applications: config.ApplicationsConfig{},
+	}
+}
+
+// TestQuarantinedZoneNoTransitMatch pins #5649 (C181-C14/C20): the simulator
+// must treat a StableZoneID-collision-quarantined zone (z214, dropped from the
+// dataplane by zoneid.go's #3719 runtime quarantine — see
+// zones_collision_3719_test.go) the same way it treats an UNDEFINED zone
+// (#3355) — id 0, ineligible for transit tiers — even though z214 is still
+// present in the raw typed cfg.Security.Zones map. Before the fix, zoneKnown
+// consulted only that raw map and reported z214 as policy-matchable, telling
+// an operator that a policy the runtime never installed permits traffic.
+//
+// FAIL-ON-REVERT: dropping the quarantine check from zoneKnown makes this
+// query match the z214-to-trust permit (Matched=true), failing the
+// want-default-deny assertion.
+func TestQuarantinedZoneNoTransitMatch(t *testing.T) {
+	cfg := zoneQuarantineCfg(t)
+
+	res := Match(cfg, Query{FromZone: "z214", ToZone: "trust", Protocol: "tcp", DstPort: 80})
+	if res.Matched {
+		t.Fatalf("quarantined from-zone z214 matched a transit rule the runtime dropped (#5649); res = %+v", res)
+	}
+	if !res.DefaultUsed || res.Action != config.PolicyDeny {
+		t.Fatalf("want default-policy deny for a quarantined zone, got %+v", res)
+	}
+}
+
+// TestQuarantinedZoneJunosHostUnmatched covers the matchJunosHost sibling
+// path: a quarantined ingress zone must resolve to HostInboundUnmatched, not a
+// matched host rule, mirroring TestUndefinedFromZoneJunosHostUnmatched.
+func TestQuarantinedZoneJunosHostUnmatched(t *testing.T) {
+	cfg := zoneQuarantineCfg(t)
+
+	res := Match(cfg, Query{FromZone: "z214", ToZone: JunosHostZone, Protocol: "tcp", DstPort: 22})
+	if res.Matched {
+		t.Fatalf("quarantined ingress zone matched a junos-host rule (#5649); res = %+v", res)
+	}
+	if !res.HostInboundUnmatched {
+		t.Fatalf("want HostInboundUnmatched for a quarantined ingress zone, got %+v", res)
+	}
+}
+
+// TestSurvivorZoneStillMatches is the positive control: z174 (the
+// sorted-first survivor that OWNS the colliding id) must not be over-blocked
+// by the quarantine projection — only the later-sorting collider is dropped.
+func TestSurvivorZoneStillMatches(t *testing.T) {
+	cfg := zoneQuarantineCfg(t)
+	cfg.Security.Policies = append(cfg.Security.Policies, &config.ZonePairPolicies{
+		FromZone: "z174", ToZone: "trust",
+		Policies: []*config.Policy{{
+			Name:   "z174-to-trust",
+			Action: config.PolicyPermit,
+			Match: config.PolicyMatch{
+				SourceAddresses:      []string{"any"},
+				DestinationAddresses: []string{"any"},
+				Applications:         []string{"any"},
+			},
+		}},
+	})
+
+	res := Match(cfg, Query{FromZone: "z174", ToZone: "trust", Protocol: "tcp", DstPort: 80})
+	if !res.Matched || res.Action != config.PolicyPermit {
+		t.Fatalf("survivor zone z174 over-blocked by the #5649 quarantine guard; res = %+v", res)
+	}
+}
+
+// TestNoCollisionZonesUnaffected proves the quarantine projection is a no-op
+// when no zone name collides: a two-zone config with no id collision must
+// match exactly as before.
+func TestNoCollisionZonesUnaffected(t *testing.T) {
+	cfg := undefinedZoneCfg()
+
+	res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 80})
+	if !res.Matched || res.Action != config.PolicyPermit {
+		t.Fatalf("non-colliding zones affected by the #5649 quarantine projection; res = %+v", res)
+	}
+}


### PR DESCRIPTION
## Summary

A firsthand sweep of all 19 items in #5649 ("[cohort] codex-review-181
low-materiality / bounded-hardening survivors") against `origin/master`
found:

- 6 of 19 already fixed pre-sweep (M18, M22, C09, C10, C11, C13 — each
  explicitly tagged `#5649` in the code that fixed it).
- **2 of 19 fixed by this PR: C14 and C20.**
- 11 of 19 still LIVE, moved to successor issue #7177 (grouped there for
  triage efficiency only, not as one shared cause).

This PR fixes only 2 of the cohort's 19 rows. The other 11 are explicitly
NOT closed by this PR — they're tracked in #7177 so #5649 can close without
losing them.

## What this PR fixes

**C14** — `pkg/policymatch/policymatch.go`'s `zoneKnown` consulted only the
raw typed `cfg.Security.Zones` map, so a StableZoneID-collision-quarantined
zone (dropped from the dataplane at snapshot build, `config.QuarantinedZoneNames`
/ `zoneid.go` #3719) was still reported as policy-matchable by the
`show security match-policies` / `test policy` / REST / gRPC simulator. Fixed
by also rejecting a name in the quarantine set, routing it through the same
"unknown zone" paths an undefined zone already uses (#3355).

**C20** (CLI-rendering half) — a MATCHED to-zone `junos-host` fine policy
printed only the fine action, never the coarse `host-inbound-traffic`
admission context that governs the same query (LocalDelivery enforces both;
the fine action doesn't override the coarse one). `show security
match-policies` already rendered this for the *unmatched* case (#3627 B1a)
but not matched; the remote `request test policy` renderer
(`cli_request_testcmd.go`) didn't render it on either branch. Both now call
`Result.HostInbound.Describe()`.

## Test plan

- [x] `go build ./...` — rc=0
- [x] `go vet ./pkg/policymatch/... ./pkg/cli/...` — rc=0
- [x] `go test -count=1 ./pkg/policymatch/... ./pkg/cli/...` — rc=0, both packages `ok`
- [x] Mutation-proof (C14): reverting `zoneKnown` to its pre-fix body reds
      `TestQuarantinedZoneNoTransitMatch` and
      `TestQuarantinedZoneJunosHostUnmatched` — exit code 1, read directly
      (not through a pipe); restoring returns both to green.
- [x] Mutation-localization (C14): a ONE-LINE mutation isolated to only the
      quarantine gate (`quarantined` -> `quarantined && false`, existence
      check left untouched) reds the two tests above on their FIRST
      assertion — `if res.Matched { t.Fatalf(...) }` at
      `zone_quarantine_5649_test.go:61-62` and `:76-77` — not the z174/z214
      collision-premise guard and not the second (`DefaultUsed`/
      `HostInboundUnmatched`) assertion. The two positive controls
      (`TestSurvivorZoneStillMatches`, `TestNoCollisionZonesUnaffected`)
      stay green under this same mutation, confirming it's scoped to only
      the quarantine gate.
- [x] Mutation-proof (C20): reverting all three print blocks reds
      `TestShowMatchPoliciesMatchedHostInboundDescribe`,
      `TestTestPolicyMatchedHostInboundDescribe`, and
      `TestTestPolicyUnmatchedHostInboundDescribe` — exit code 1, read
      directly; restoring returns all three (and the full `pkg/cli` suite)
      to green.
- [x] Re-verified at the merged head (branch merged `origin/master`, no
      conflicts): `go build ./...` rc=0, `go vet` rc=0,
      `go test -count=1` rc=0 — no fold-introduced regression.

## Production-reachability note (C14 fixture)

`pkg/policymatch/zone_quarantine_5649_test.go` reuses the verified z174/z214
StableZoneID-colliding pair from
`pkg/dataplane/userspace/zones_collision_3719_test.go`. Confirmed the
precondition it builds (both colliding zone names present in
`cfg.Security.Zones`) is real production behavior, not a test-only
construction: `validateZoneIDCollisionAST` (`pkg/config/zoneid.go`) is a
strict/lenient VALIDATOR only — on the lenient path (load / HA peer-sync of
an already-active config) it emits a warning but never strips a zone from
the typed config, and `compileZones` (`pkg/config/compiler_security_zones.go`)
has no collision awareness at all. The quarantine only happens later, at
Rust snapshot build. So a live daemon's `ActiveConfig()` genuinely returns a
`Security.Zones` map carrying both colliding names in this degraded state —
exactly what `pkg/policymatch.Match`/`zoneKnown` (invoked from real CLI/
REST/gRPC `match-policies` handlers) would see.

Closes #5649

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012157LoowVr8rVZaoxU9yGK
