### PR TITLE
syslog: scope a host selector to the facility its client emits

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,54 @@
+## 2026-08-21 — #5797: a syslog selector for a facility the client never emits filtered every record it did
+
+- **Timestamp**: 2026-08-21 (fix/5797-syslog-selector-facility)
+- **Action**: Keyed `syslogHostMinSeverity` on the facility code the host's
+  `SyslogClient` actually stamps, so a `<facility> <severity>` selector naming a
+  different facility no longer sets that client's threshold.
+- **File(s)**: `pkg/daemon/daemon_system.go`,
+  `pkg/daemon/syslog_selector_5797_test.go` (new),
+  `pkg/daemon/syslog_severity_5314_test.go`, `pkg/logging/README.md`
+
+  Junos evaluates a host's selectors independently: `daemon info;
+  authorization critical` forwards daemon records at info-or-higher and
+  authorization records at critical-or-higher. xpf folded every selector with
+  `MoreRestrictiveMinSeverity`, so that config filtered the WHOLE destination at
+  critical and dropped the daemon notice/info records the operator had asked for
+  by name. `daemon info; authorization none` was the same defect at full
+  magnitude: `none` outranks everything in `minSeverityRestrictRank`, so one
+  selector naming a facility this client can never emit silenced the destination
+  outright, emergency included.
+
+  The key is the numeric facility CODE, not the authored name, because the code
+  is what appears in the wire PRI. Unmapped Junos names all resolve to local0,
+  so a host that really does stamp local0 stays constrained by them — the
+  selector and the emitted record share a facility on the wire, and pretending
+  otherwise would drop a real restriction. `any` is the wildcard and applies to
+  everything; an exact selector for the stamped facility displaces it
+  (Junos more-specific-wins). Two selectors naming the same facility are a
+  genuine conflict and still fold most-restrictive, which is what
+  `TestSyslogHostMinSeverity_Merge` should have been testing all along — it was
+  asserting the cross-facility fold, i.e. the defect, so it is retargeted rather
+  than deleted.
+
+  Not fixed here, and deliberately: a client carries one facility, so a host
+  naming two mappable facilities can still honor only the one it stamps, and
+  which one that is depends on selector order. Honoring both needs a source
+  facility on the event envelope and per-facility routing.
+
+  Mutation proof, both at production-reachable sites in
+  `syslogHostMinSeverity`:
+  - fold every non-wildcard selector (`case ... == stampedFacility:` ->
+    `default:`, restoring the blind fold) — `go test -count=1 ./pkg/daemon/
+    -run TestSyslogSelector` exit=1, three assertions red including
+    `min severity = SeverityNone: ... silenced the whole destination`;
+  - drop more-specific-wins (`if exactSet {` -> `if exactSet && !wildSet {`) —
+    exit=1, `TestSyslogSelector_ExactWinsOverWildcard` red in BOTH directions,
+    so it is not satisfiable by always taking the permissive threshold.
+
+  Control at HEAD: `go test -count=1 ./pkg/daemon/ ./pkg/logging/` exit=0.
+  `go vet ./pkg/daemon/` clean. Go-only change; no dataplane binary moves, so no
+  cluster smoke is owed.
+
 ## 2026-08-21 — #5192 item 1: `WorkerUmemInner` unmapped the UMEM before deleting it
 
 - **Timestamp**: 2026-08-21 (fix/5192-umem-drop-order)

--- a/_Log.md
+++ b/_Log.md
@@ -45,6 +45,17 @@
     exit=1, `TestSyslogSelector_ExactWinsOverWildcard` red in BOTH directions,
     so it is not satisfiable by always taking the permissive threshold.
 
+  Follow-on in the same change: the correct semantics make an inapplicable
+  selector a SILENT no-op — the operator asked for `authorization critical` and
+  now gets neither the records nor a complaint — so `applySystemSyslog` warns
+  once per apply for every selector that names a facility this host's client
+  does not stamp. This is not the existing unmapped-NAME warning: `kern` is
+  perfectly well-formed and still inapplicable on a daemon-stamping host.
+  Mutations: deleting the warn call reds the positive subtest (exit=1);
+  widening it to every selector reds BOTH controls, `stamped_facility_stays_quiet`
+  and `wildcard_stays_quiet` (exit=1), so it cannot be satisfied by warning
+  unconditionally.
+
   Control at HEAD: `go test -count=1 ./pkg/daemon/ ./pkg/logging/` exit=0.
   `go vet ./pkg/daemon/` clean. Go-only change; no dataplane binary moves, so no
   cluster smoke is owed.

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -1099,6 +1099,30 @@ func (d *Daemon) applySystemSyslog(cfg *config.Config) {
 					"host", host.Address, "facility", raw, "using", "local0")
 			}
 			facility = f
+
+			// #5797: a selector naming a facility OTHER than the one this
+			// client stamps can never match a record it sends, so it no longer
+			// contributes to the threshold (syslogHostMinSeverity). That is the
+			// correct semantics, and it is also a silent no-op the operator has
+			// no way to see — they asked for `authorization critical` and get
+			// neither the records nor a complaint. Say so, once per apply.
+			//
+			// This is not the unmapped-name warning above: the name may be
+			// perfectly well-formed (`kern`, `auth`) and still be inapplicable,
+			// because a client carries ONE facility. Honoring several needs a
+			// source facility on the event envelope, which is the successor
+			// issue's architecture.
+			for _, sel := range host.Facilities {
+				if logging.FacilityIsWildcard(sel.Facility) ||
+					logging.ParseFacility(sel.Facility) == facility {
+					continue
+				}
+				slog.Warn("system syslog: selector names a facility this host's client does not "+
+					"emit, so it selects nothing — every record to this host carries the "+
+					"stamped facility (#5797)",
+					"host", host.Address, "selector", sel.Facility,
+					"severity", sel.Severity, "stamped", facility)
+			}
 		}
 
 		c, err := logging.NewSyslogClientWithSource(host.Address, port, host.SourceAddress)

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -943,11 +943,49 @@ func (d *Daemon) applyTimezone(cfg *config.Config) {
 // applySystemSyslog configures system-level syslog forwarding from
 // system { syslog { host ... } } config. This forwards daemon log
 // messages (Go slog) to remote syslog servers.
-// syslogHostMinSeverity folds the severity of every `<facility> <severity>`
-// pair of one syslog host into a single SyslogClient.MinSeverity threshold —
-// the most restrictive one, since the client carries a single filter. It
-// returns 0 (no filter / send-all) when no entry names a severity, matching
+// syslogHostMinSeverity computes the SyslogClient.MinSeverity threshold for
+// one syslog host from its `<facility> <severity>` selectors. It returns 0
+// (no filter / send-all) when no APPLICABLE entry names a severity, matching
 // the SyslogClient zero value.
+//
+// stampedFacility is the numeric facility code this host's client will stamp
+// into every record it emits (SyslogClient.Facility, chosen by the caller from
+// the authored selector list). It is the key, and it is what makes the
+// selection Junos-shaped rather than a blind fold.
+//
+// #5797 — WHICH SELECTORS APPLY. Junos evaluates `<facility> <severity>`
+// pairs INDEPENDENTLY: `daemon info; authorization critical` forwards daemon
+// records at info-or-higher and authorization records at critical-or-higher.
+// This function previously folded every pair to the single most restrictive
+// severity, so that config filtered the WHOLE destination at critical and
+// silently dropped the daemon notice/info records the operator explicitly
+// asked for. `daemon info; authorization none` was worse: `none` outranks
+// everything, so ONE selector naming a facility this client never emits
+// silenced the entire destination.
+//
+// A selector can only match a record whose facility it names. Every record
+// this client sends carries stampedFacility, so a selector resolving to a
+// DIFFERENT facility code matches nothing this client will ever send and must
+// not constrain it. Only two kinds of selector apply:
+//
+//   - the `any` wildcard (FacilityIsWildcard), which matches every record;
+//   - a selector whose facility resolves to stampedFacility.
+//
+// Resolution is by numeric CODE, not by authored name, because the code is
+// what appears in the wire PRI. Unmapped Junos names all resolve to local0
+// (ParseFacility's fallback, warned about at the call site), so a host that
+// actually stamps local0 is correctly constrained by them — the selector and
+// the emitted record genuinely share a facility on the wire.
+//
+// Junos more-specific-wins: when at least one exact-code selector applies, the
+// `any` wildcard does NOT also constrain the threshold. Two selectors naming
+// the SAME code are a genuine conflict on one facility and still fold to the
+// most restrictive of the two.
+//
+// RESIDUAL (tracked separately, NOT fixed here): a client carries one facility,
+// so a host naming two mappable facilities can still only honor one of them,
+// and which one is stamped depends on selector order. Honoring both needs a
+// source facility on the event envelope and per-facility routing.
 //
 // ParseSeverity maps ALL ten Junos severities (#5314): emergency
 // (SeverityEmergency), alert/critical/error/warning/notice/info/debug (raw
@@ -957,22 +995,44 @@ func (d *Daemon) applyTimezone(cfg *config.Config) {
 // them), so `host H <facility> critical` left MinSeverity at the 0 send-all
 // sentinel and over-forwarded info/warning/error records the operator never
 // authorized.
-func syslogHostMinSeverity(facilities []config.SyslogFacility) int {
-	min := 0 // no filter (send-all) default; also the SyslogClient zero value
-	set := false
+func syslogHostMinSeverity(facilities []config.SyslogFacility, stampedFacility int) int {
+	exact := 0 // fold of selectors naming stampedFacility
+	exactSet := false
+	wild := 0 // fold of `any` selectors
+	wildSet := false
+
 	for _, f := range facilities {
 		if f.Severity == "" {
 			continue
 		}
 		sev := logging.ParseSeverity(f.Severity)
-		if !set {
-			min = sev
-			set = true
-			continue
+		switch {
+		case logging.FacilityIsWildcard(f.Facility):
+			if !wildSet {
+				wild, wildSet = sev, true
+			} else {
+				wild = logging.MoreRestrictiveMinSeverity(wild, sev)
+			}
+		case logging.ParseFacility(f.Facility) == stampedFacility:
+			if !exactSet {
+				exact, exactSet = sev, true
+			} else {
+				exact = logging.MoreRestrictiveMinSeverity(exact, sev)
+			}
 		}
-		min = logging.MoreRestrictiveMinSeverity(min, sev)
+		// Any other selector names a facility this client never emits. It
+		// matches nothing here, so it contributes nothing — that is the whole
+		// #5797 correction.
 	}
-	return min
+
+	// Junos more-specific-wins: an exact selector displaces the wildcard.
+	if exactSet {
+		return exact
+	}
+	if wildSet {
+		return wild
+	}
+	return 0 // no applicable selector named a severity: send-all
 }
 
 func (d *Daemon) applySystemSyslog(cfg *config.Config) {
@@ -1050,7 +1110,10 @@ func (d *Daemon) applySystemSyslog(cfg *config.Config) {
 
 		c.Facility = facility
 		if len(host.Facilities) > 0 {
-			c.MinSeverity = syslogHostMinSeverity(host.Facilities)
+			// #5797: keyed on the facility this client actually stamps, so a
+			// selector naming a DIFFERENT facility cannot restrict (or, with
+			// `none`, silence) records it can never match.
+			c.MinSeverity = syslogHostMinSeverity(host.Facilities, facility)
 		}
 
 		clients = append(clients, c)

--- a/pkg/daemon/syslog_selector_5797_test.go
+++ b/pkg/daemon/syslog_selector_5797_test.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -165,4 +167,61 @@ func TestSyslogSelector_UnmappedNameSharingLocal0Applies(t *testing.T) {
 		t.Errorf("unmapped `authorization critical` on a local0-stamping client = %d, want %d: "+
 			"the selector and the emitted record share local0 on the wire", got, logging.SyslogCritical)
 	}
+}
+
+// TestApplySystemSyslogWarnsOnInapplicableSelector_5797 binds the operator
+// signal for the residual. A selector naming a facility this host's client does
+// not stamp now selects nothing — correct, and invisible. The operator asked
+// for `authorization critical` and gets neither the records nor a complaint, so
+// applySystemSyslog says so once per apply.
+//
+// The negative control matters more than the positive one here: the wildcard
+// and the stamped facility are BOTH applicable and must stay quiet, or a
+// correct single-selector config warns on every commit.
+//
+// RED-on-revert: delete the warn loop in applySystemSyslog and the positive
+// subtest fails; widen it to every selector and the two controls fail.
+func TestApplySystemSyslogWarnsOnInapplicableSelector_5797(t *testing.T) {
+	apply := func(t *testing.T, sel []config.SyslogFacility) string {
+		t.Helper()
+		buf := captureRenderedWarnings(t)
+		d := &Daemon{slogHandler: logging.NewSyslogSlogHandler(slog.Default().Handler())}
+		t.Cleanup(func() { d.slogHandler.SetClients(nil) })
+		cfg := &config.Config{}
+		cfg.System.Syslog = &config.SystemSyslogConfig{
+			Hosts: []*config.SyslogHostConfig{{Address: "192.0.2.10", Facilities: sel}},
+		}
+		d.applySystemSyslog(cfg)
+		return buf.String()
+	}
+
+	const marker = "selects nothing"
+
+	t.Run("foreign facility warns", func(t *testing.T) {
+		got := apply(t, []config.SyslogFacility{
+			{Facility: "daemon", Severity: "info"},
+			{Facility: "kern", Severity: "critical"},
+		})
+		if !strings.Contains(got, marker) {
+			t.Errorf("a `kern critical` selector on a daemon-stamping host selects nothing and "+
+				"said so nowhere; the operator sees neither the records nor a complaint. captured:\n%s", got)
+		}
+		if !strings.Contains(got, "kern") {
+			t.Errorf("the warning must name the inapplicable selector. captured:\n%s", got)
+		}
+	})
+
+	t.Run("stamped facility stays quiet", func(t *testing.T) {
+		if got := apply(t, []config.SyslogFacility{{Facility: "daemon", Severity: "info"}}); strings.Contains(got, marker) {
+			t.Errorf("the selector that supplies the stamped facility IS applicable and must not "+
+				"warn — a correct config would complain on every commit. captured:\n%s", got)
+		}
+	})
+
+	t.Run("wildcard stays quiet", func(t *testing.T) {
+		if got := apply(t, []config.SyslogFacility{{Facility: "any", Severity: "info"}}); strings.Contains(got, marker) {
+			t.Errorf("`any` matches every record and is always applicable; warning about it is a "+
+				"false alarm on the repo's own canonical fixture. captured:\n%s", got)
+		}
+	})
 }

--- a/pkg/daemon/syslog_selector_5797_test.go
+++ b/pkg/daemon/syslog_selector_5797_test.go
@@ -1,0 +1,168 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/logging"
+)
+
+// #5797. A Junos `system syslog host <h>` may carry several independent
+// `<facility> <severity>` selectors, and Junos evaluates them INDEPENDENTLY:
+// each facility keeps its own threshold. xpf folded every selector to the
+// single most restrictive severity, so a selector naming a facility the
+// destination's client never emits still filtered — or, with `none`, silenced —
+// every record it did emit.
+//
+// These tests key on the facility the client actually STAMPS, which is the only
+// facility any record it sends can carry. A selector resolving to a different
+// code matches nothing here and must contribute nothing.
+
+// TestSyslogSelector_ForeignFacilityDoesNotRestrict is the issue's headline
+// example, verbatim:
+//
+//	host 192.0.2.10 { daemon info; authorization critical; }
+//
+// Junos forwards daemon records at info-or-higher. Before this fix the fold
+// took critical (more restrictive than info) and the destination silently lost
+// every daemon notice/info record the operator explicitly requested.
+//
+// RED-on-revert: restore the blind fold (merge every selector with
+// MoreRestrictiveMinSeverity regardless of facility) and min becomes
+// SyslogCritical, failing the threshold assertion, and both info/notice
+// forwarding assertions fail.
+func TestSyslogSelector_ForeignFacilityDoesNotRestrict(t *testing.T) {
+	sel := []config.SyslogFacility{
+		{Facility: "daemon", Severity: "info"},
+		{Facility: "authorization", Severity: "critical"},
+	}
+
+	min := syslogHostMinSeverity(sel, logging.FacilityDaemon)
+	if min != logging.SyslogInfo {
+		t.Fatalf("min severity = %d, want %d (info — the daemon selector's own threshold)",
+			min, logging.SyslogInfo)
+	}
+
+	c := &logging.SyslogClient{Facility: logging.FacilityDaemon, MinSeverity: min}
+	for _, sev := range []int{logging.SyslogInfo, logging.SyslogNotice, logging.SyslogWarning, logging.SyslogCritical} {
+		if !c.ShouldSend(sev) {
+			t.Errorf("`daemon info; authorization critical` must forward severity %d — "+
+				"the authorization selector cannot restrict daemon records", sev)
+		}
+	}
+	if c.ShouldSend(logging.SyslogDebug) {
+		t.Error("`daemon info` must NOT forward debug — the daemon threshold still applies")
+	}
+}
+
+// TestSyslogSelector_ForeignNoneDoesNotSilence is the same defect at its worst
+// magnitude. `none` outranks every other threshold in
+// minSeverityRestrictRank, so under the blind fold ONE `none` selector on a
+// facility this client never emits turned the whole destination off.
+//
+// RED-on-revert: with the blind fold, min == SeverityNone and ShouldSend
+// returns false for every severity, so every forwarding assertion fails.
+func TestSyslogSelector_ForeignNoneDoesNotSilence(t *testing.T) {
+	sel := []config.SyslogFacility{
+		{Facility: "daemon", Severity: "info"},
+		{Facility: "authorization", Severity: "none"},
+	}
+
+	min := syslogHostMinSeverity(sel, logging.FacilityDaemon)
+	if min == logging.SeverityNone {
+		t.Fatalf("min severity = SeverityNone: an `authorization none` selector silenced the "+
+			"whole destination, but this client stamps daemon (%d) and can never emit an "+
+			"authorization record", logging.FacilityDaemon)
+	}
+	if min != logging.SyslogInfo {
+		t.Fatalf("min severity = %d, want %d (info)", min, logging.SyslogInfo)
+	}
+
+	c := &logging.SyslogClient{Facility: logging.FacilityDaemon, MinSeverity: min}
+	if !c.ShouldSend(logging.SyslogInfo) {
+		t.Error("destination silenced: `daemon info` records must still forward")
+	}
+	if !c.ShouldSend(logging.SyslogEmergency) {
+		t.Error("destination silenced: even emergency records stopped forwarding")
+	}
+}
+
+// TestSyslogSelector_OwnFacilityNoneStillSilences is the negative control for
+// the test above, and it is what keeps that fix from being a blanket
+// "ignore none". A `none` naming the facility this client DOES stamp is an
+// operator instruction to stop forwarding, and must be obeyed.
+//
+// Without this control, a fix that simply skipped every `none` would pass
+// TestSyslogSelector_ForeignNoneDoesNotSilence while breaking the operator's
+// actual off switch.
+func TestSyslogSelector_OwnFacilityNoneStillSilences(t *testing.T) {
+	min := syslogHostMinSeverity([]config.SyslogFacility{
+		{Facility: "daemon", Severity: "none"},
+	}, logging.FacilityDaemon)
+	if min != logging.SeverityNone {
+		t.Fatalf("min severity = %d, want SeverityNone (%d): `daemon none` on a daemon-stamping "+
+			"client is the operator's off switch", min, logging.SeverityNone)
+	}
+	c := &logging.SyslogClient{Facility: logging.FacilityDaemon, MinSeverity: min}
+	if c.ShouldSend(logging.SyslogEmergency) {
+		t.Error("`daemon none` must forward nothing, not even emergency")
+	}
+}
+
+// TestSyslogSelector_ExactWinsOverWildcard pins Junos more-specific-wins: when
+// a host names both `any` and the client's own facility, the exact selector
+// supplies the threshold. Otherwise `any critical; daemon info` would keep
+// filtering daemon records at critical.
+func TestSyslogSelector_ExactWinsOverWildcard(t *testing.T) {
+	// Exact more PERMISSIVE than the wildcard — the direction a
+	// most-restrictive fold gets wrong.
+	if got := syslogHostMinSeverity([]config.SyslogFacility{
+		{Facility: "any", Severity: "critical"},
+		{Facility: "daemon", Severity: "info"},
+	}, logging.FacilityDaemon); got != logging.SyslogInfo {
+		t.Errorf("`any critical; daemon info` = %d, want %d (info — exact wins)", got, logging.SyslogInfo)
+	}
+	// Exact more RESTRICTIVE than the wildcard — exact still wins, so this is
+	// not satisfiable by "always take the permissive one".
+	if got := syslogHostMinSeverity([]config.SyslogFacility{
+		{Facility: "any", Severity: "info"},
+		{Facility: "daemon", Severity: "critical"},
+	}, logging.FacilityDaemon); got != logging.SyslogCritical {
+		t.Errorf("`any info; daemon critical` = %d, want %d (critical — exact wins)", got, logging.SyslogCritical)
+	}
+}
+
+// TestSyslogSelector_WildcardAppliesWhenNoExact keeps the #5314 contract: with
+// no selector naming the stamped facility, the `any` wildcard is the threshold.
+// A fix that only honored exact matches would silently restore send-all here.
+func TestSyslogSelector_WildcardAppliesWhenNoExact(t *testing.T) {
+	got := syslogHostMinSeverity([]config.SyslogFacility{
+		{Facility: "any", Severity: "critical"},
+		{Facility: "authorization", Severity: "info"},
+	}, logging.FacilityDaemon)
+	if got != logging.SyslogCritical {
+		t.Errorf("`any critical; authorization info` = %d, want %d (the wildcard applies)",
+			got, logging.SyslogCritical)
+	}
+}
+
+// TestSyslogSelector_UnmappedNameSharingLocal0Applies pins that the key is the
+// numeric facility CODE, not the authored name. Every Junos name xpf's mapper
+// does not know resolves to local0 (ParseFacility's fallback, warned about at
+// the call site). A client that actually stamps local0 therefore DOES emit
+// records those selectors match on the wire, so they must still constrain it.
+//
+// This is the boundary that stops the fix from being "ignore names I do not
+// recognize", which would drop a real operator restriction.
+func TestSyslogSelector_UnmappedNameSharingLocal0Applies(t *testing.T) {
+	if logging.ParseFacility("authorization") != logging.FacilityLocal0 {
+		t.Skip("mapper learned `authorization`; this boundary no longer exists")
+	}
+	got := syslogHostMinSeverity([]config.SyslogFacility{
+		{Facility: "authorization", Severity: "critical"},
+	}, logging.FacilityLocal0)
+	if got != logging.SyslogCritical {
+		t.Errorf("unmapped `authorization critical` on a local0-stamping client = %d, want %d: "+
+			"the selector and the emitted record share local0 on the wire", got, logging.SyslogCritical)
+	}
+}

--- a/pkg/daemon/syslog_severity_5314_test.go
+++ b/pkg/daemon/syslog_severity_5314_test.go
@@ -21,7 +21,8 @@ import (
 func TestSyslogHostMinSeverity_AnyCritical(t *testing.T) {
 	facilities := []config.SyslogFacility{{Facility: "any", Severity: "critical"}}
 
-	min := syslogHostMinSeverity(facilities)
+	// `any` is the wildcard: it applies whatever facility the client stamps.
+	min := syslogHostMinSeverity(facilities, logging.FacilityDaemon)
 	if min != logging.SyslogCritical {
 		t.Fatalf("syslogHostMinSeverity(any critical) = %d, want %d (critical)", min, logging.SyslogCritical)
 	}
@@ -44,7 +45,7 @@ func TestSyslogHostMinSeverity_AnyCritical(t *testing.T) {
 // NOT the send-all sentinel. The old `if sev > 0` guard would also have dropped
 // emergency (its threshold code is negative), leaving MinSeverity at 0.
 func TestSyslogHostMinSeverity_EmergencyNotSendAll(t *testing.T) {
-	min := syslogHostMinSeverity([]config.SyslogFacility{{Facility: "any", Severity: "emergency"}})
+	min := syslogHostMinSeverity([]config.SyslogFacility{{Facility: "any", Severity: "emergency"}}, logging.FacilityDaemon)
 	if min != logging.SeverityEmergency {
 		t.Fatalf("syslogHostMinSeverity(any emergency) = %d, want %d (emergency)", min, logging.SeverityEmergency)
 	}
@@ -57,25 +58,32 @@ func TestSyslogHostMinSeverity_EmergencyNotSendAll(t *testing.T) {
 	}
 }
 
-// TestSyslogHostMinSeverity_Merge folds several facility pairs into the most
-// restrictive client filter, and confirms an unspecified severity defaults to
-// send-all.
-func TestSyslogHostMinSeverity_Merge(t *testing.T) {
-	// Most restrictive of {info, critical, warning} is critical.
+// TestSyslogHostMinSeverity_SameFacilityMerge folds several pairs naming the
+// SAME facility into the most restrictive client filter, and confirms an
+// unspecified severity defaults to send-all.
+//
+// #5797 retarget: this test previously asserted a cross-FACILITY fold —
+// {daemon info, kern critical, auth warning} => critical — which is the defect
+// #5797 names, not a contract. `MoreRestrictiveMinSeverity` is still the merge
+// rule; what changed is the POPULATION it merges, which is now only the
+// selectors that can match a record this client emits. Two selectors naming one
+// facility remain a genuine conflict on that facility and still fold.
+func TestSyslogHostMinSeverity_SameFacilityMerge(t *testing.T) {
+	// Most restrictive of {info, critical, warning} on ONE facility is critical.
 	min := syslogHostMinSeverity([]config.SyslogFacility{
 		{Facility: "daemon", Severity: "info"},
-		{Facility: "kern", Severity: "critical"},
-		{Facility: "auth", Severity: "warning"},
-	})
+		{Facility: "daemon", Severity: "critical"},
+		{Facility: "daemon", Severity: "warning"},
+	}, logging.FacilityDaemon)
 	if min != logging.SyslogCritical {
-		t.Errorf("merge = %d, want %d (critical, most restrictive)", min, logging.SyslogCritical)
+		t.Errorf("same-facility merge = %d, want %d (critical, most restrictive)", min, logging.SyslogCritical)
 	}
 
 	// No facilities / no severity => 0 (send-all) default.
-	if got := syslogHostMinSeverity(nil); got != 0 {
+	if got := syslogHostMinSeverity(nil, logging.FacilityDaemon); got != 0 {
 		t.Errorf("syslogHostMinSeverity(nil) = %d, want 0 (send-all)", got)
 	}
-	if got := syslogHostMinSeverity([]config.SyslogFacility{{Facility: "daemon"}}); got != 0 {
+	if got := syslogHostMinSeverity([]config.SyslogFacility{{Facility: "daemon"}}, logging.FacilityDaemon); got != 0 {
 		t.Errorf("syslogHostMinSeverity(no severity) = %d, want 0 (send-all)", got)
 	}
 }

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -181,8 +181,22 @@ connectionless and exempt:
   send-all sentinel and a security appliance forwarded substantially more
   syslog data than authorized — critical/notice/alert/emergency/debug/none
   all leaked as "no filter". A syslog host that lists several
-  `<facility> <severity>` pairs is folded to one client filter via
-  `MoreRestrictiveMinSeverity` (the most restrictive pair wins).
+  `<facility> <severity>` pairs resolves to one client filter, but only
+  the selectors that can MATCH a record this client emits take part
+  (#5797). A client stamps exactly one facility, so a selector naming a
+  different facility code matches nothing it will ever send and does not
+  constrain it. `daemon info; authorization critical` therefore filters
+  daemon records at **info**, not critical, and `daemon info;
+  authorization none` does not silence the destination — before #5797 a
+  blind `MoreRestrictiveMinSeverity` fold across every pair did both.
+  What still folds via `MoreRestrictiveMinSeverity` is two selectors
+  naming the SAME facility, which is a genuine conflict on one facility.
+  The Junos `any` wildcard matches every record and applies unless an
+  exact selector for the stamped facility is present (more-specific
+  wins). Residual, tracked separately: one client carries one facility,
+  so a host naming two mappable facilities can still honor only the one
+  it stamps, and which one that is depends on selector order — honoring
+  both needs a source facility on the event envelope.
 - **Unmapped facility names are reported, not silent (#5797).**
   `ParseFacility` returns `FacilityLocal0` for any name it does not know,
   which makes an authored `local0` indistinguishable from a name the


### PR DESCRIPTION
Advances #5797 — the bounded, provable half. The architecture half (a source
facility on the event envelope, per-facility routing, the eight design
invariants) is split to a successor; see the close comment on #5797.

## The defect

A Junos `system syslog host <h>` may carry several independent
`<facility> <severity>` selectors, and Junos evaluates them **independently**:
each facility keeps its own threshold. xpf folded every selector of a host into
one `SyslogClient.MinSeverity` with `MoreRestrictiveMinSeverity`, so a selector
naming a facility that destination's client **never emits** still filtered every
record it did.

The issue's own example:

```
host 192.0.2.10 {
    daemon info;
    authorization critical;
}
```

Junos forwards daemon records at info-or-higher. xpf took the more restrictive
of `{info, critical}` and filtered the whole destination at critical — silently
dropping the daemon notice/info records the operator had asked for by name.

`daemon info; authorization none` is the same defect at full magnitude. `none`
outranks everything in `minSeverityRestrictRank`, so **one** selector naming a
facility this client can never emit silenced the destination outright, emergency
included.

## The fix, and why it is keyed on the code

A selector can only match a record whose facility it names, and every record a
client sends carries the one facility it stamps. So the threshold is computed
only from the selectors that can match:

- the `any` wildcard, which matches everything;
- selectors resolving to the stamped facility code.

The key is the numeric **code**, not the authored name, because the code is what
appears in the wire PRI. Every Junos name xpf's mapper does not know resolves to
local0, so a host that really does stamp local0 stays constrained by them — the
selector and the emitted record genuinely share a facility on the wire.
`TestSyslogSelector_UnmappedNameSharingLocal0Applies` pins that boundary, which
is what stops the change from degenerating into "ignore names I do not
recognize" and dropping a real operator restriction.

Junos more-specific-wins: an exact selector for the stamped facility displaces
the wildcard. Two selectors naming the **same** facility are a genuine conflict
on one facility and still fold most-restrictive — that is what
`MoreRestrictiveMinSeverity` is for, and it keeps its job.

## Direction of change

Strictly permissive: this can only widen what a destination forwards, never
narrow it. A `none` naming the client's **own** facility is still the operator's
off switch — `TestSyslogSelector_OwnFacilityNoneStillSilences` is the negative
control that stops a lazier fix ("skip every `none`") from passing while
breaking that.

## Retargeted test

`TestSyslogHostMinSeverity_Merge` asserted `{daemon info, kern critical, auth
warning} => critical` — the cross-facility fold, i.e. the defect itself, which
#5797 names at `syslog_severity_5314_test.go:60-73`. It is retargeted to the
same-facility conflict it should have been pinning, not deleted; the #5314
contract it also carries (send-all defaults) is untouched.

## Not fixed here, deliberately

A client carries one facility, so a host naming two mappable facilities can
still honor only the one it stamps, and which one that is depends on selector
order. Honoring both needs a source facility on the event envelope and
per-facility routing. Stated in the function doc, in `pkg/logging/README.md`,
and on the successor issue.

## Validation

Mutation proof, both at production-reachable sites inside
`syslogHostMinSeverity`:

| mutation | result |
|---|---|
| fold every non-wildcard selector (`case ... == stampedFacility:` → `default:`) — restores the blind fold | **exit=1**, three assertions red incl. `min severity = SeverityNone: ... silenced the whole destination` |
| drop more-specific-wins (`if exactSet {` → `if exactSet && !wildSet {`) | **exit=1**, `TestSyslogSelector_ExactWinsOverWildcard` red in **both** directions, so it is not satisfiable by always taking the permissive threshold |

Control at HEAD:

```
$ go test -count=1 ./pkg/daemon/ ./pkg/logging/
ok  	github.com/psaab/xpf/pkg/daemon	36.458s
ok  	github.com/psaab/xpf/pkg/logging	0.349s
exit=0
$ go vet ./pkg/daemon/     # clean
```

Go-only change; no dataplane binary moves, so **no cluster smoke is owed**.

Docs: `pkg/logging/README.md` stated the most-restrictive fold as the contract
and is corrected, including the residual.
