### PR TITLE
config: warn on the inert syslog file archive block

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -10413,7 +10413,8 @@ enum and rejected (an IP is not a severity).
   switches on the known modifier keywords before the pair fallback. Host
   `source-address`/`port` are captured into `SyslogHostConfig.SourceAddress`
   / `.Port`; `match`/`structured-data`/`explicit-priority`/`log-prefix`/
-  `facility-override`/`archive` are recognized-and-skipped. The
+  `facility-override` are recognized-and-skipped, and `archive` is
+  recognized-recorded-and-warned (see #7146 below). The
   `syslogFacilitySeverity` helper extracts the pair (flat `Keys[0]/Keys[1]`
   or hierarchical `Keys[0]` + child) and returns ok=false for a valueless
   leaf, so a bare/garbage keyword is dropped instead of appended as a
@@ -10428,6 +10429,77 @@ enum and rejected (an IP is not a severity).
   hardcoded 514.
 - **tests** — `pkg/config/compiler_syslog_hostmods_4303_test.go` (facilities
   not polluted, source-address/port captured, strict commit accepts).
+
+## Syslog file `archive` is accepted-but-inert (#7146)
+
+The `archive` sub-statement of `system syslog file <name>` is modeled in
+`setSchema` in full — `files`, `size`, `start-time`, `transfer-interval`,
+`archive-sites` (`multi: true`), `world-readable` / `no-world-readable` — and
+is implemented by **nothing**. The #4303 S-1 work above put `archive` in
+`compileSystem`'s recognized-modifier skip list so it would not be captured as
+a bogus `<facility> <severity>` pair, but no consumer was ever written: the
+whole subtree was read and discarded. Every knob committed clean, rendered back
+in `show configuration`, and produced no rotation, no retention, and no
+off-box transfer. An operator who configured log archival got a clean commit
+and no archiving.
+
+The runtime for a syslog file is `applySyslogFiles` (`pkg/daemon/daemon_system.go`),
+which writes an rsyslog drop-in (`/etc/rsyslog.d/10-xpf-<name>.conf`) directing
+matching facility/severity messages to `/var/log/<name>` — and nothing else.
+There is no rotation, size accounting, schedule, or transfer anywhere in the
+daemon for a syslog file. (The `archiveConfig` / `archiveTransfer` machinery in
+`pkg/daemon` is the **unrelated** `system archival configuration` feature, which
+archives the running **config**, not logs, and does work.)
+
+#7146 keeps the block unimplemented and makes it **loud**, the same
+accept-with-advisory shape as #4316:
+
+- **compiler** — `compileSystem`'s syslog `file` loop switches `archive` out of
+  the skip list into its own case. It sets `SyslogFileConfig.ArchiveConfigured`
+  (presence: a bare `archive;` is archiving-with-defaults in Junos, so presence
+  alone is what the operator asked for) and records the sub-statement
+  **keywords** in `SyslogFileConfig.ArchiveKnobs` (sorted, deduplicated).
+  `syslogArchiveTokens` flattens the subtree depth-first pre-order so ONE walker
+  covers every shape the dual AST produces for the same stanza — the flat block
+  (`Keys=["archive"]` + sibling children), the flat compact form
+  (`archive size 1m files 5` → a NESTED key chain, not siblings), the
+  hierarchical block, and the hierarchical one-line form
+  (`archive size 1m files 5;` → all tokens on `Keys`, no children).
+  `syslogArchiveKnobs` then walks those tokens against the
+  `syslogArchiveKeywordArgs` allowlist, stepping over each keyword's value so an
+  `archive-sites` URL that happens to equal a keyword is not read as one.
+- **keywords only, never values** — an `archive-sites` URL can embed credentials
+  (`scp://user:pass@host/`), and the advisory is printed at commit and pasted
+  into support tickets. This is the same rule `systemInertKnobWarnings` applies
+  to the NTP `authentication-key`.
+- **advisory** — `ValidateConfig` (`compiler_validate_warn.go`) emits one
+  warning per archiving file naming the file, the configured knobs, and the
+  consequence:
+
+  ```
+  system syslog file "f1" archive [archive-sites files size start-time transfer-interval]:
+  accepted for Junos compatibility but NOT implemented — xpf writes /var/log/f1
+  through an rsyslog drop-in and applies no rotation, no size cap, no retention
+  count, no start-time schedule, and no off-box transfer, so this log file is
+  never rotated and its contents are NOT archived anywhere. The configuration is
+  valid and this is expected, not a fault in it; rotate and collect /var/log/f1
+  with the host's own log policy (#7146)
+  ```
+
+- **warn, never reject** — the stanza commits today. A hard reject would fail
+  the tolerant load / peer-sync path on a config an operator already has, which
+  is the #1960 brick-on-upgrade shape.
+- **not a CWE-88** — the #4589 leading-dash gate on `system archival
+  configuration archive-sites` exists because that value is handed to `scp` as a
+  destination (`pkg/daemon/daemon_flow.go`). The syslog leaf has no such gate and
+  does not need one: it reaches no `scp` invocation because it reaches nothing at
+  all. Implementing archival would change that and would then owe the #4589
+  treatment.
+- **tests** — `pkg/config/syslog_archive_inert_7146_test.go`: the advisory fires
+  in all four AST shapes and for a bare `archive`, one per file, never on the
+  common case (a plain facility/severity file, a `host`/`user` destination,
+  `system archival configuration`, or no syslog block), never echoes a value,
+  and the commit still succeeds.
 
 ## Custom system login class (#4304 S-2)
 

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -300,7 +300,12 @@ the userspace dataplane admission boundary is in
 ## Observability
 
 - **Syslog**: facility/severity/category filtering, structured RT_FLOW
-  format, TCP/TLS transport, event mode local file.
+  format, TCP/TLS transport, event mode local file. A `system syslog file`
+  destination is written to `/var/log/<name>` via an rsyslog drop-in; its
+  `archive` block (rotation, retention, `start-time`, `transfer-interval`,
+  `archive-sites`) is accepted for Junos compatibility but **not implemented**
+  and raises a commit advisory saying so (#7146) — xpf does not rotate or
+  archive these files.
 - **NetFlow v9 / IPFIX**: 1-in-N sampling (IPFIX advertises the rate to
   collectors via a sampler Options Template — Set ID 3, template 258,
   `selectorAlgorithm`/`samplingPacketInterval`/`samplingPacketSpace`, scoped by

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -38,9 +38,9 @@ Last updated: 2026-05-24
 | Multi-Tenancy | 4 | 0 | 0 | 4 |
 | Management & Automation | 12 | 2 | 0 | 14 |
 | Interface Enhancements | 1 | 1 | 0 | 2 |
-| System Enhancements | 5 | 0 | 0 | 5 |
+| System Enhancements | 5 | 0 | 1 | 6 |
 | Miscellaneous | 6 | 0 | 0 | 6 |
-| **TOTAL** | **120** | **19** | **0** | **139** |
+| **TOTAL** | **120** | **19** | **1** | **140** |
 
 > The per-section counts and grand total above are a hand-maintained
 > summary and drift by ±1 against a strict machine row-parse of
@@ -825,6 +825,7 @@ xpf has hostname, domain-name, domain-search, timezone, name-servers, NTP, servi
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|
 | **SSH Key Exchange** | `system services ssh key-exchange ...` | Restrict the SSH key-exchange (KEX) algorithms the firewall offers | Medium | Done (H5/#2008 — repeatable leaf rendered to the sshd `KexAlgorithms` drop-in, `pkg/daemon/daemon_system.go`; drop-in lifecycle hardened in #2062 — removing/emptying the ssh stanza removes the `/etc/ssh/sshd_config.d/xpf.conf` drop-in and reloads so sshd reverts to base-image defaults, and a reload failure after a write reverts the drop-in to its prior content/removes it so a bad config never breaks the next sshd restart) |
+| **Syslog File Archive / Rotation** | `system syslog file <name> archive { files <n>; size <bytes>; start-time <t>; transfer-interval <min>; archive-sites <url>; }` | Rotate `/var/log/<name>` at a size threshold, retain N archives, and transfer them off-box on a schedule | Low | Missing — accepted-but-inert with a commit advisory (#7146). The whole block is modeled in `setSchema` and compiled by nothing: #4303 folded `archive` into `compileSystem`'s recognized-modifier skip list, and `applySyslogFiles` writes only an rsyslog drop-in pointing at `/var/log/<name>`. #7146 keeps it unimplemented and makes it LOUD instead of silent — the block is recorded on `SyslogFileConfig` (`ArchiveConfigured` / `ArchiveKnobs`, keywords only) and `ValidateConfig` emits one per-file advisory naming the file and its knobs and stating the logs are NOT archived. Warn, never reject: the stanza commits today and a reject would fail the tolerant load / peer-sync path (#1960). Implementing it needs rotation, size accounting, a transfer schedule, and an `scp` path that would then owe the #4589 leading-dash gate that guards `system archival configuration archive-sites`. See [docs/config-schema.md](config-schema.md) "Syslog file `archive` is accepted-but-inert (#7146)". |
 | **RADIUS Server Config** | `system radius-server ... port ... secret ...` | RADIUS server definitions for AAA (authentication, authorization, accounting) | Medium | Missing |
 | **TACACS+ Server Config** | `system tacplus-server ... port ... secret ...` | TACACS+ server definitions for per-command authorization | Medium | Missing |
 | **Authentication Order** | `system authentication-order [radius tacplus password]` | Control order of authentication methods for management access | Medium | Missing |
@@ -910,6 +911,7 @@ table, so this list count can be higher than the category-level Parse-Only total
 | # | Config Path | Type | Notes |
 |---|------------|------|-------|
 | 1 | `system license autoupdate url` | SystemConfig.LicenseAutoUpdate | No licensing system |
+| 2 | `system syslog file <name> archive { files, size, start-time, transfer-interval, archive-sites, world-readable, no-world-readable }` | SyslogFileConfig.ArchiveConfigured / .ArchiveKnobs | Recorded at compile ONLY so the #7146 commit advisory can name the block; no runtime consumer. No rotation, retention, schedule, or off-box transfer exists for a syslog file — `applySyslogFiles` writes an rsyslog drop-in pointing at `/var/log/<name>` and nothing more. Keywords are recorded, never values (an `archive-sites` URL can embed credentials). |
 
 ## Runtime Follow-Up Features Summary
 

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -345,9 +345,26 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 			}
 			for _, fileInst := range namedInstances(child.FindChildren("file")) {
 				file := &SyslogFileConfig{Name: fileInst.name}
+				archiveKnobs := map[string]bool{}
 				for _, prop := range fileInst.node.Children {
 					switch prop.Name() {
-					case "archive", "match", "match-strings", "structured-data",
+					case "archive":
+						// #7146: the whole `archive` block (files, size,
+						// start-time, transfer-interval, archive-sites,
+						// world/no-world-readable) is modeled in setSchema
+						// and implemented by NOTHING — #4303 folded it into
+						// the recognized-modifier skip list below, so every
+						// knob committed clean and vanished. Record the
+						// container's presence and its sub-statement
+						// KEYWORDS (never their values) so ValidateConfig can
+						// tell the operator their logs are not being
+						// archived. Recording is all this does; no runtime
+						// consumer reads these fields.
+						file.ArchiveConfigured = true
+						for _, knob := range syslogArchiveKnobs(prop) {
+							archiveKnobs[knob] = true
+						}
+					case "match", "match-strings", "structured-data",
 						"explicit-priority", "allow-duplicates":
 						// #4303 S-1: recognized file modifiers, not a
 						// facility/severity pair — do not append as one.
@@ -357,6 +374,13 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 							file.Severity = sev
 						}
 					}
+				}
+				if len(archiveKnobs) > 0 {
+					file.ArchiveKnobs = make([]string, 0, len(archiveKnobs))
+					for knob := range archiveKnobs {
+						file.ArchiveKnobs = append(file.ArchiveKnobs, knob)
+					}
+					sort.Strings(file.ArchiveKnobs)
 				}
 				sys.Syslog.Files = append(sys.Syslog.Files, file)
 			}
@@ -922,6 +946,88 @@ func syslogFacilitySeverity(prop *Node) (facility, severity string, ok bool) {
 		}
 	}
 	return "", "", false
+}
+
+// syslogArchiveKeywordArgs enumerates the `system syslog file <f> archive`
+// sub-statements setSchema models (schema_system.go) and records, for each,
+// whether it is followed by a value token. It is the keyword allowlist the
+// token walker below uses to tell a KEYWORD apart from a VALUE in a flattened
+// token stream, and the arity it uses to step over a value so an
+// `archive-sites` URL that happens to equal a keyword is not mistaken for one
+// (#7146).
+var syslogArchiveKeywordArgs = map[string]bool{
+	"size":              true,
+	"files":             true,
+	"start-time":        true,
+	"transfer-interval": true,
+	"archive-sites":     true,
+	"world-readable":    false,
+	"no-world-readable": false,
+}
+
+// syslogArchiveTokens flattens a syslog-file `archive` subtree into its tokens
+// in source order, depth-first pre-order: a node contributes its own Keys,
+// then each child's subtree. This is what makes ONE walker cover every shape
+// the dual AST produces for the same stanza (#7146):
+//
+//	flat block      `set ... archive files 7` + `set ... archive size 1m`
+//	                -> Keys=["archive"], children ["files","7"] ["size","1m"]
+//	flat compact    `set ... archive size 1m files 5`
+//	                -> Keys=["archive"] -> child ["size","1m"] -> GRANDchild
+//	                   ["files","5"] (a nested chain, not siblings)
+//	hierarchical    `archive { files 7; size 1m; }` -> same as flat block
+//	hier. one-line  `archive size 1m files 5;`
+//	                -> Keys=["archive","size","1m","files","5"], NO children
+//
+// A reader that only walked Children would miss the one-line form entirely;
+// one that only read Keys would miss both block forms.
+func syslogArchiveTokens(n *Node, out []string) []string {
+	if n == nil {
+		return out
+	}
+	out = append(out, n.Keys...)
+	for _, c := range n.Children {
+		out = syslogArchiveTokens(c, out)
+	}
+	return out
+}
+
+// syslogArchiveKnobs returns the sorted, deduplicated archive sub-statement
+// KEYWORDS configured under a syslog-file `archive` node — never their values,
+// because an `archive-sites` URL can carry credentials and the caller feeds
+// this straight into an operator-visible commit advisory (#7146).
+//
+// Unrecognized tokens are skipped rather than reported: the schema already
+// rejects an unknown leaf at commit, and echoing an arbitrary token here would
+// reintroduce the value-leak this function exists to avoid.
+func syslogArchiveKnobs(n *Node) []string {
+	if n == nil {
+		return nil
+	}
+	tokens := syslogArchiveTokens(n, nil)
+	if len(tokens) > 0 {
+		// Drop the leading "archive" keyword itself.
+		tokens = tokens[1:]
+	}
+	seen := map[string]bool{}
+	var knobs []string
+	for i := 0; i < len(tokens); i++ {
+		takesValue, isKeyword := syslogArchiveKeywordArgs[tokens[i]]
+		if !isKeyword {
+			continue
+		}
+		if !seen[tokens[i]] {
+			seen[tokens[i]] = true
+			knobs = append(knobs, tokens[i])
+		}
+		if takesValue {
+			// Step over the value so `archive-sites "size"` records
+			// archive-sites once, not archive-sites AND size.
+			i++
+		}
+	}
+	sort.Strings(knobs)
+	return knobs
 }
 
 // loginClassPermName renders a coarse xpf permission for the advisory.

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -1226,6 +1226,39 @@ func ValidateConfig(cfg *Config) []string {
 		}
 	}
 
+	// #7146: the `system syslog file <f> archive` block — files, size,
+	// start-time, transfer-interval, archive-sites, world/no-world-readable —
+	// is fully modeled in setSchema and implemented by NOTHING. #4303 put
+	// `archive` in compileSystem's recognized-modifier skip list, so every
+	// knob was read and discarded: the stanza committed clean, rendered back
+	// in `show configuration`, and produced no rotation, no retention, and no
+	// off-box transfer. An operator configuring log archival believed they had
+	// it. Make the acceptance LOUD instead of implementing archival (which is
+	// a feature: rotation, size accounting, a transfer schedule, and an scp
+	// path that would then need the #4589 leading-dash treatment).
+	//
+	// WARN, never reject: this stanza commits today, and a hard reject would
+	// fail the tolerant load / peer-sync path on a config an operator already
+	// has, which is the #1960 brick-on-upgrade shape.
+	//
+	// Note this is NOT the `system archival configuration` advisory above:
+	// that feature archives the CONFIG and does run. Keywords only — an
+	// archive-sites URL can embed credentials.
+	if cfg.System.Syslog != nil {
+		for _, f := range cfg.System.Syslog.Files {
+			if f == nil || !f.ArchiveConfigured {
+				continue
+			}
+			knobs := ""
+			if len(f.ArchiveKnobs) > 0 {
+				knobs = fmt.Sprintf(" [%s]", strings.Join(f.ArchiveKnobs, " "))
+			}
+			warnings = append(warnings, fmt.Sprintf(
+				"system syslog file %q archive%s: accepted for Junos compatibility but NOT implemented — xpf writes /var/log/%s through an rsyslog drop-in and applies no rotation, no size cap, no retention count, no start-time schedule, and no off-box transfer, so this log file is never rotated and its contents are NOT archived anywhere. The configuration is valid and this is expected, not a fault in it; rotate and collect /var/log/%s with the host's own log policy (#7146)",
+				f.Name, knobs, f.Name, f.Name))
+		}
+	}
+
 	if cfg.System.Services != nil && cfg.System.Services.DNSProxyConfigured {
 		warnings = append(warnings, "system services dns dns-proxy configured but DNS proxy/forwarder runtime is not implemented")
 	}

--- a/pkg/config/syslog_archive_inert_7146_test.go
+++ b/pkg/config/syslog_archive_inert_7146_test.go
@@ -1,0 +1,305 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #7146: the `system syslog file <f> archive` block is modeled in setSchema
+// (schema_system.go) and compiled by nothing — #4303 folded `archive` into
+// compileSystem's recognized-modifier skip list, so files/size/start-time/
+// transfer-interval/archive-sites all committed clean and did nothing. The
+// fix is accept-with-advisory (#4316 pattern), NOT archival: the block is
+// recorded on the compiled SyslogFileConfig and ValidateConfig names it at
+// commit so an operator knows their logs are not being archived.
+//
+// These tests bind three properties:
+//  1. the advisory FIRES for a file carrying an archive block, in every AST
+//     shape the dual parser produces for it;
+//  2. it does NOT fire for the common case (a plain facility/severity file,
+//     a host/user destination, or no syslog block at all) — a guard that
+//     fires on every config is noise, not a signal;
+//  3. the commit still SUCCEEDS. Rejecting would fail the tolerant load /
+//     peer-sync path on a config an operator already has (#1960).
+
+// buildTree7146 compiles flat `set` lines the only correct way (ParseSetCommand
+// + SetPath); NewParser merges newlines into one node.
+func buildTree7146(t *testing.T, cmds []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// compile7146 compiles and returns the warnings an operator sees at commit.
+// It reads cfg.Warnings — the surface runTailGates folds ValidateConfig into
+// and the CLI prints — not ValidateConfig's return value, so the test fails
+// if the advisory is emitted somewhere the commit path never shows.
+func compile7146(t *testing.T, cmds []string) (*Config, []string) {
+	t.Helper()
+	cfg, err := CompileConfig(buildTree7146(t, cmds))
+	if err != nil {
+		t.Fatalf("CompileConfig returned an error; the archive block must WARN, never reject (#1960 tolerant-load): %v", err)
+	}
+	return cfg, cfg.Warnings
+}
+
+// archiveWarnings returns the subset of warnings that are the #7146 advisory.
+func archiveWarnings(warnings []string) []string {
+	var out []string
+	for _, w := range warnings {
+		if strings.Contains(w, "syslog file") && strings.Contains(w, "archive") {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+// Quoted: the `@` and `:` in a URL are lexer tokens in a bare set value.
+const archiveSiteURL = `"scp://logbot:s3cr3t@backup.example.net/logs"`
+
+func TestSyslogFileArchiveInertWarning(t *testing.T) {
+	cfg, warnings := compile7146(t, []string{
+		"set system syslog file f1 any any",
+		"set system syslog file f1 archive files 7",
+		"set system syslog file f1 archive size 1048576",
+		"set system syslog file f1 archive start-time 03:00",
+		"set system syslog file f1 archive transfer-interval 60",
+		"set system syslog file f1 archive world-readable",
+		"set system syslog file f1 archive archive-sites " + archiveSiteURL,
+	})
+
+	got := archiveWarnings(warnings)
+	if len(got) != 1 {
+		t.Fatalf("want exactly 1 syslog-archive advisory, got %d: %#v (all warnings: %#v)", len(got), got, warnings)
+	}
+	w := got[0]
+
+	// The operator must learn WHICH file, WHICH knobs, and that archival is
+	// not happening — not merely that "something" is unsupported.
+	for _, want := range []string{
+		`"f1"`,
+		"NOT implemented",
+		"NOT archived",
+		"/var/log/f1",
+		"#7146",
+	} {
+		if !strings.Contains(w, want) {
+			t.Errorf("advisory is missing %q:\n%s", want, w)
+		}
+	}
+	for _, knob := range []string{"files", "size", "start-time", "transfer-interval", "archive-sites", "world-readable"} {
+		if !strings.Contains(w, knob) {
+			t.Errorf("advisory does not name the configured knob %q:\n%s", knob, w)
+		}
+	}
+
+	// Keywords only. An archive-sites URL can embed credentials, and this
+	// string is printed at commit and copied into support tickets.
+	if strings.Contains(w, "s3cr3t") || strings.Contains(w, "backup.example.net") {
+		t.Errorf("advisory echoed an archive-sites VALUE (credential leak):\n%s", w)
+	}
+	for _, v := range []string{"1048576", "03:00", "logbot"} {
+		if strings.Contains(w, v) {
+			t.Errorf("advisory echoed the configured value %q; keywords only:\n%s", v, w)
+		}
+	}
+
+	// The record the advisory is built from.
+	files := cfg.System.Syslog.Files
+	if len(files) != 1 {
+		t.Fatalf("want 1 compiled syslog file, got %d", len(files))
+	}
+	if !files[0].ArchiveConfigured {
+		t.Error("ArchiveConfigured false for a file with an archive block")
+	}
+	wantKnobs := "archive-sites files size start-time transfer-interval world-readable"
+	if got := strings.Join(files[0].ArchiveKnobs, " "); got != wantKnobs {
+		t.Errorf("ArchiveKnobs = %q, want %q (sorted + deduplicated)", got, wantKnobs)
+	}
+	// Facility/severity parsing must survive the new `archive` case.
+	if files[0].Facility != "any" || files[0].Severity != "any" {
+		t.Errorf("facility/severity = %q/%q, want any/any", files[0].Facility, files[0].Severity)
+	}
+}
+
+// The dual AST puts the same stanza in four different shapes. A walker that
+// read only Children would miss the hierarchical one-line form; one that read
+// only Keys would miss both block forms; one that read only direct children
+// would miss the flat-compact NESTED chain.
+func TestSyslogFileArchiveInertWarningASTShapes(t *testing.T) {
+	t.Run("flat compact (nested key chain)", func(t *testing.T) {
+		cfg, warnings := compile7146(t, []string{
+			"set system syslog file f2 any any",
+			"set system syslog file f2 archive size 1m files 5",
+		})
+		if got := archiveWarnings(warnings); len(got) != 1 {
+			t.Fatalf("want 1 advisory, got %d: %#v", len(got), got)
+		}
+		if got := strings.Join(cfg.System.Syslog.Files[0].ArchiveKnobs, " "); got != "files size" {
+			t.Errorf("ArchiveKnobs = %q, want %q", got, "files size")
+		}
+	})
+
+	t.Run("hierarchical one-line (all tokens on Keys)", func(t *testing.T) {
+		src := `system {
+    syslog {
+        file f3 {
+            any any;
+            archive size 1m files 5;
+        }
+    }
+}`
+		tree, perrs := NewParser(src).Parse()
+		if len(perrs) > 0 {
+			t.Fatalf("parse: %v", perrs)
+		}
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("CompileConfig: %v", err)
+		}
+		if got := archiveWarnings(cfg.Warnings); len(got) != 1 {
+			t.Fatalf("want 1 advisory for the one-line archive form, got %d: %#v", len(got), cfg.Warnings)
+		}
+		if got := strings.Join(cfg.System.Syslog.Files[0].ArchiveKnobs, " "); got != "files size" {
+			t.Errorf("ArchiveKnobs = %q, want %q", got, "files size")
+		}
+	})
+
+	t.Run("hierarchical block", func(t *testing.T) {
+		src := `system {
+    syslog {
+        file f4 {
+            any any;
+            archive {
+                files 7;
+                no-world-readable;
+            }
+        }
+    }
+}`
+		tree, perrs := NewParser(src).Parse()
+		if len(perrs) > 0 {
+			t.Fatalf("parse: %v", perrs)
+		}
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("CompileConfig: %v", err)
+		}
+		if got := archiveWarnings(cfg.Warnings); len(got) != 1 {
+			t.Fatalf("want 1 advisory, got %d: %#v", len(got), cfg.Warnings)
+		}
+		if got := strings.Join(cfg.System.Syslog.Files[0].ArchiveKnobs, " "); got != "files no-world-readable" {
+			t.Errorf("ArchiveKnobs = %q, want %q", got, "files no-world-readable")
+		}
+	})
+
+	// A bare `archive;` is archiving-with-defaults in Junos, so presence
+	// alone warrants the advisory even with no sub-statement to name.
+	t.Run("bare archive container", func(t *testing.T) {
+		cfg, warnings := compile7146(t, []string{
+			"set system syslog file f5 any any",
+			"set system syslog file f5 archive",
+		})
+		got := archiveWarnings(warnings)
+		if len(got) != 1 {
+			t.Fatalf("want 1 advisory for a bare `archive`, got %d: %#v", len(got), warnings)
+		}
+		if strings.Contains(got[0], "[") {
+			t.Errorf("bare archive advisory should name no knobs, got a knob list:\n%s", got[0])
+		}
+		if !cfg.System.Syslog.Files[0].ArchiveConfigured {
+			t.Error("ArchiveConfigured false for a bare `archive` container")
+		}
+		if len(cfg.System.Syslog.Files[0].ArchiveKnobs) != 0 {
+			t.Errorf("ArchiveKnobs = %#v, want empty", cfg.System.Syslog.Files[0].ArchiveKnobs)
+		}
+	})
+}
+
+// The guard must not fire on the common case. A commit advisory that appears
+// on every syslog config trains operators to ignore it.
+func TestSyslogFileArchiveInertWarningNotOnCommonCase(t *testing.T) {
+	cases := []struct {
+		name string
+		cmds []string
+	}{
+		{"plain file destination", []string{
+			"set system syslog file messages any warning",
+			"set system syslog file security authorization info",
+		}},
+		{"file with non-archive modifiers", []string{
+			"set system syslog file messages any warning",
+			"set system syslog file messages explicit-priority",
+			"set system syslog file messages structured-data",
+		}},
+		{"host and user destinations", []string{
+			"set system syslog host 10.0.0.9 any warning",
+			"set system syslog host 10.0.0.9 source-address 10.0.1.1",
+			"set system syslog host 10.0.0.9 port 5514",
+			"set system syslog user * any emergency",
+		}},
+		{"config archival (a different, implemented feature)", []string{
+			"set system archival configuration transfer-interval 60",
+			"set system archival configuration archive-sites ftp://host/dir",
+		}},
+		{"no syslog block at all", []string{
+			"set system host-name fw0",
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, warnings := compile7146(t, tc.cmds)
+			if got := archiveWarnings(warnings); len(got) != 0 {
+				t.Errorf("syslog-archive advisory fired on the common case %q: %#v", tc.name, got)
+			}
+		})
+	}
+}
+
+// One advisory per FILE: an operator with three archiving files must be told
+// about all three, and a file without the block must not be swept in.
+func TestSyslogFileArchiveInertWarningPerFile(t *testing.T) {
+	_, warnings := compile7146(t, []string{
+		"set system syslog file a any any",
+		"set system syslog file a archive files 3",
+		"set system syslog file b any any",
+		"set system syslog file c any any",
+		"set system syslog file c archive archive-sites " + archiveSiteURL,
+	})
+	got := archiveWarnings(warnings)
+	if len(got) != 2 {
+		t.Fatalf("want 2 advisories (files a and c), got %d: %#v", len(got), got)
+	}
+	joined := strings.Join(got, "\n")
+	if !strings.Contains(joined, `"a"`) || !strings.Contains(joined, `"c"`) {
+		t.Errorf("advisories do not name both archiving files:\n%s", joined)
+	}
+	if strings.Contains(joined, `"b"`) {
+		t.Errorf("advisory named file b, which has no archive block:\n%s", joined)
+	}
+}
+
+// syslogArchiveKnobs must never mistake a VALUE for a keyword. An
+// archive-sites URL is operator-controlled text.
+func TestSyslogArchiveKnobsSkipsValues(t *testing.T) {
+	_, warnings := compile7146(t, []string{
+		"set system syslog file f6 any any",
+		"set system syslog file f6 archive archive-sites size",
+	})
+	got := archiveWarnings(warnings)
+	if len(got) != 1 {
+		t.Fatalf("want 1 advisory, got %d: %#v", len(got), got)
+	}
+	if !strings.Contains(got[0], "[archive-sites]") {
+		t.Errorf("an archive-sites VALUE of \"size\" was read as the size keyword:\n%s", got[0])
+	}
+}

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -456,6 +456,30 @@ type SyslogFileConfig struct {
 	Name     string
 	Facility string
 	Severity string
+	// ArchiveConfigured records that an `archive` container was present
+	// under this syslog file (#7146). In Junos a bare `archive;` enables
+	// archiving with defaults, so PRESENCE alone — not just a populated
+	// sub-statement — is what the operator asked for and what the commit
+	// advisory reports.
+	//
+	// xpf implements NONE of it: applySyslogFiles writes an rsyslog drop-in
+	// that directs matching messages to /var/log/<name> and nothing more.
+	// There is no rotation, size cap, retention count, start-time schedule,
+	// or off-box transfer anywhere in the daemon for a syslog FILE (the
+	// `archive`/`archiveTransfer` machinery in pkg/daemon belongs to the
+	// unrelated `system archival configuration` feature, which archives the
+	// CONFIG, not logs). These two fields exist only so ValidateConfig can
+	// name the inert block at commit — the #4316 accept-with-advisory
+	// pattern — and are read by nothing else.
+	ArchiveConfigured bool
+	// ArchiveKnobs holds the sorted, deduplicated `archive` sub-statement
+	// KEYWORDS found under this file (files, size, start-time,
+	// transfer-interval, archive-sites, world-readable, no-world-readable).
+	// Keywords ONLY, never their values: an `archive-sites` URL can embed
+	// credentials (scp://user:pass@host/), and the advisory echoes this
+	// slice — the same "name the keyword, never the leaf value" rule
+	// systemInertKnobWarnings applies to the NTP authentication-key.
+	ArchiveKnobs []string
 }
 
 // SNMPConfig holds SNMP agent configuration.


### PR DESCRIPTION
## What was measured first

At `bf10c6b7c`, a config carrying the full block:

```
set system syslog file f1 any any
set system syslog file f1 archive files 7
set system syslog file f1 archive size 1048576
set system syslog file f1 archive start-time 03:00
set system syslog file f1 archive transfer-interval 60
set system syslog file f1 archive world-readable
set system syslog file f1 archive archive-sites "scp://user@backup.example.net/logs"
```

compiles with `err == nil` and **zero** warnings on either surface
(`cfg.Warnings` and `ValidateConfig`). The compiled entry is exactly
`SyslogFileConfig{Name:f1 Facility:any Severity:any}`, and the full
compiled-config JSON (3591 bytes) contains **none** of `archive`, `1048576`,
`03:00`, `transfer`, `backup.example.net`, or `world-readable`. Nothing in
`pkg/logging` or `pkg/daemon` reads an archive field for a syslog file:
`applySyslogFiles` writes an rsyslog drop-in pointing at `/var/log/<name>` and
stops there. (The `archiveConfig`/`archiveTransfer` machinery in `pkg/daemon`
is the unrelated `system archival configuration` feature — it archives the
CONFIG, and it does work.)

## The decision

This does **not** implement archival. Archival is a feature — file rotation,
size accounting, a transfer schedule, and an `scp` path that would then
genuinely owe the #4589 leading-dash treatment. The defect worth closing now is
the **silent acceptance**, so the block is made loud through the mechanism this
repo already runs for accepted-but-unenforced knobs (#4316 pattern):

```
system syslog file "f1" archive [archive-sites files size start-time transfer-interval]:
accepted for Junos compatibility but NOT implemented — xpf writes /var/log/f1
through an rsyslog drop-in and applies no rotation, no size cap, no retention
count, no start-time schedule, and no off-box transfer, so this log file is
never rotated and its contents are NOT archived anywhere. The configuration is
valid and this is expected, not a fault in it; rotate and collect /var/log/f1
with the host's own log policy (#7146)
```

**Warn, never reject.** The stanza commits today; a hard reject would fail the
tolerant load / peer-sync path on a config an operator already has — the #1960
brick-on-upgrade shape.

**Keywords only, never values.** An `archive-sites` URL can embed credentials
(`scp://user:pass@host/`) and this string is printed at commit and pasted into
support tickets — the same rule `systemInertKnobWarnings` applies to the NTP
`authentication-key`.

**Functional gap, not a second CWE-88.** The #4589 leading-dash gate is absent
on this leaf, but the leaf reaches no `scp` invocation because it reaches
nothing at all.

## Implementation

- `compileSystem`'s syslog `file` loop switches `archive` out of the #4303
  recognized-modifier skip list into its own case, setting
  `SyslogFileConfig.ArchiveConfigured` (presence — a bare `archive;` is
  archiving-with-defaults in Junos) and recording the sub-statement keywords in
  `SyslogFileConfig.ArchiveKnobs`, sorted and deduplicated.
- `syslogArchiveTokens` flattens the subtree depth-first pre-order so ONE
  walker covers every shape the dual AST produces for the same stanza: flat
  block, flat compact (`archive size 1m files 5` → a **nested key chain**, not
  siblings), hierarchical block, and hierarchical one-line (**all tokens on
  `Keys`, no children**). A reader that only walked `Children` would miss the
  one-line form; one that only read `Keys` would miss both block forms.
- `syslogArchiveKnobs` walks those tokens against the
  `syslogArchiveKeywordArgs` allowlist and steps over each keyword's value, so
  an `archive-sites` URL that happens to equal a keyword is not read as one.
- `ValidateConfig` emits one advisory per archiving file.

## Docs

No doc previously claimed archival worked, so nothing was a false claim — but
`docs/feature-gaps.md`'s Parse-Only summary omitted the feature entirely, which
is the same shape. Corrected:

- `docs/config-schema.md` — new "Syslog file `archive` is accepted-but-inert
  (#7146)" section beside the #4303 S-1 one it amends (whose "`archive` is
  recognized-and-skipped" bullet is updated).
- `docs/feature-gaps.md` — a System Enhancements row and a Parse-Only Features
  Summary row; the hand-maintained counts bumped by the one row added.
- `docs/feature-coverage.md` — the Syslog bullet now states the archive block is
  accepted but not implemented.

## Validation

`go test ./pkg/config/ -count=1` → **ok** (51.5s); `go test ./pkg/daemon/
./pkg/grpcapi/ ./pkg/cli/ ./pkg/configstore/ -count=1` → **ok**; `go vet
./pkg/config/` → **rc=0**. Exit codes read from `$?`, never through a pipe.

Mutation matrix — control green, each cell restored to a clean tree, `go vet`
rc=0 in every cell:

| # | Mutation | test rc | Which cells red |
|---|----------|---------|-----------------|
| control | none | 0 | — (all pass) |
| M1 | delete the `ValidateConfig` emission | **1** | all 8 assertion sites — `got 0` advisories |
| M2 | drop the child recursion in `syslogArchiveTokens` | **1** | flat-compact + hierarchical-block **only**; one-line and bare-`archive` still PASS — the walker's shape coverage localises |
| M3 | drop the value-step in `syslogArchiveKnobs` | **1** | `TestSyslogArchiveKnobsSkipsValues` only — `archive-sites "size"` read as the `size` keyword |
| M4 | `ArchiveConfigured = true` → `false` | **1** | all 8 — nothing recorded, nothing warned |
| M5 | drop the `!f.ArchiveConfigured` guard (anti-vacuity) | **1** | the *negative* cells — the advisory fires on a plain facility/severity file and on file `b`, which has no archive block |

M5 is the one that matters for a guard: without it the test would pass on a
warning that fires for every syslog config, which is noise, not a signal.

## Scope

`pkg/config` + docs only. Nothing reaches the Rust helper binary, no compiled
artifact moves, so **no cluster smoke is owed** — and the shared loss cluster
was not touched.

Closes #7146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cz2czGK3aA5MsMhkNkjHXX
