### PR TITLE
config: reject a malformed literal in a NAT rule's match addresses

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -98349,3 +98349,84 @@ prose edit above them added. No diff falls in the new test body.
   pkg/config/compiler_multivalue_leaf_empty_6673_test.go,
   pkg/config/schema_spelling_differential_gate_test.go, docs/config-schema.md,
   _Log.md
+
+- **Timestamp**: 2026-08-21
+- **Action**: #7145 — reject a malformed literal in a NAT rule's `match
+  source-address` / `match destination-address` on the four (kind x leaf) slots
+  that had no parse gate at all.
+
+  MEASURED FIRST, at bf10c6b7c, over the issue's own base config, with BOTH
+  `999.1.1.1/24` and `zznotanaddr` (so this is not a near-miss in the CIDR
+  grammar). Four of the six (NAT kind x match leaf) slots accepted the value;
+  two rejected it — the same operator typo refused in one slot of a rule and
+  accepted in the sibling slot of the SAME rule:
+
+  | kind | match source-address | match destination-address |
+  |---|---|---|
+  | source | ACCEPTED -> reject | ACCEPTED -> reject |
+  | destination | ACCEPTED -> reject | reject (#3228) |
+  | static | ACCEPTED -> reject | reject (#3206) |
+
+  Not inert. The Go snapshot builders copy the list to the wire VERBATIM and
+  each Rust consumer drops per entry what it cannot parse — `parse_match_prefix`
+  (nat/source.rs), `DnatTable::from_snapshots` (nat/destination.rs),
+  `SourceConstraint::from_list` (nat/static_nat.rs) — while the `*_constrained`
+  flag stays set from the non-empty list. A malformed entry NARROWS the rule
+  below what was authored; an all-malformed list leaves it constrained with zero
+  prefixes, matching NOTHING, visible only as a bounded NAT parse-error counter
+  (#4718).
+
+  `validateNATMatchAddressLiteralsStrict` closes the four; the two
+  already-rejecting slots keep their own gates. Scope is the LITERAL leaves
+  only: `*-address-name` is an address-book reference whose unresolvable raw
+  token is appended to the same wire list ON PURPOSE (#2416 fail-closed
+  backstop), so a gate walking the post-resolution list would reject the
+  backstop itself.
+
+  Predicate is `net.ParseCIDR` then `net.ParseIP` (`natMatchPrefixParses`), the
+  exact Rust pair — NOT `netip`. `netip.ParsePrefix` is STRICTER than Rust on
+  the mask text: it rejects a zero-padded prefix length (`1.2.3.4/024`) that
+  Rust's `u8::from_str` reads as 24 and installs. Refusing a value the dataplane
+  installs is the one direction a widened validator must never take.
+
+  Tolerant path (flag `lenientNATMatchAddressLiterals`) warns and KEEPS the
+  value. Dropping it Go-side would empty an all-malformed list, clear
+  `*_constrained` and collapse the rule to MATCH-ANY — a fail-OPEN regression
+  strictly worse than the silent narrowing this closes.
+
+  The four sites were removed from `slotEscapeUngated` (#7143's scout registry,
+  which is where the asymmetry surfaced): their rows now carry a real verdict and
+  run the full slot-1 escape comparison instead of skipping.
+
+  Validation: `go test ./... -count=1` — only pkg/ddns
+  TestSurfaceARealBackendWithdrawOnAddressLoss failed, the known #7009 UDP/TCP
+  port-space flake; green in isolation (exit 0). `go vet` exit 0. Mutation
+  matrix, ONE mutation per cell, exit codes from `$?`, `go vet` clean on every
+  cell (no build breaks): (1) remove the strict gate call site -> exit 1, RED at
+  the "committed CLEAN" assertion on all 8 #7145 cells while both control cells
+  (#3228 / #3206) stayed GREEN; (2) drop `lenientNATMatchAddressLiterals` from
+  `lenientCompileOpts` -> exit 1 at "Store.Load REFUSED" / "SyncApply REJECTED"
+  and at the compiler-level tolerance assertion (the CommitCheck over-reach
+  guard reds at its PRECONDITION, as its own comment records); (3) swap the
+  predicate to `netip` -> exit 1 on exactly the `1.2.3.4/024` cells of the four
+  gated slots, every other value green; (4) make the tolerant path DROP instead
+  of KEEP -> exit 1 at the KEEP assertion in both store ingresses while the
+  over-reach guard stayed green. Go-only, `pkg/config` + a `pkg/configstore`
+  test; nothing reaches the Rust helper or the wire protocol, so no cluster
+  smoke is owed.
+
+  Known residuals, measured, deliberately NOT folded in (a different value class
+  from the issue's malformed CIDR, each in an OLDER gate): an out-of-range mask
+  (`10.0.0.0/33`) is still accepted on destination-NAT `match
+  destination-address`, whose #3228 gate strips the mask and parses only the
+  address part while its own builder uses `net.ParseCIDR` and skips the entry;
+  and a quoted empty value is still accepted on static-NAT `match
+  destination-address`, where an empty slot carries the deliberate #6673
+  "authored blank selection" meaning. Filed as #7215 and #7216.
+- **File(s)**: pkg/config/compiler_validate_strict_nat_match_addr.go,
+  pkg/config/compiler_nat_helpers.go, pkg/config/compiler_opts.go,
+  pkg/config/compiler_uniformgates_nat.go,
+  pkg/config/nat_match_address_literal_7145_test.go,
+  pkg/config/schema_slot_escape_fixtures_test.go,
+  pkg/configstore/nat_match_address_no_brick_7145_test.go,
+  docs/config-schema.md, docs/userspace-dnat-plan.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -9289,6 +9289,65 @@ Strict = hard commit error; lenient = `cfg.Warnings` entry (the Rust
 `from_snapshots` drop remains the lenient/peer-sync backstop). Same exemptions
 apply (NPTv6, `then static-nat inet`).
 
+**#7145 — malformed literal in a NAT `match` address, on the four slots that
+had no gate at all.** #3206 above closed static-NAT `match
+destination-address`; #3228 closed destination-NAT `match destination-address`.
+The other four (NAT kind x match leaf) slots had NO parse gate, so the SAME
+value — `999.1.1.1/24`, or `zznotanaddr`, so this is not a near-miss in the CIDR
+grammar — was refused in one slot of a rule and accepted in the sibling slot of
+the same rule:
+
+| kind | `match source-address` | `match destination-address` |
+|---|---|---|
+| `security nat source` | accepted -> **rejected (#7145)** | accepted -> **rejected (#7145)** |
+| `security nat destination` | accepted -> **rejected (#7145)** | rejected (#3228) |
+| `security nat static` | accepted -> **rejected (#7145)** | rejected (#3206) |
+
+These values are not inert. The Go snapshot builders copy them to the wire
+verbatim and each Rust consumer — `parse_match_prefix`
+(`userspace-dp/src/nat/source.rs`), `DnatTable::from_snapshots`
+(`nat/destination.rs`), `SourceConstraint::from_list` (`nat/static_nat.rs`) —
+drops the entry it cannot parse while the `*_constrained` flag stays set from
+the non-empty list. A malformed entry therefore NARROWS the rule below what was
+authored, and an all-malformed list leaves the rule constrained with zero
+prefixes: it matches NOTHING and stops translating, recorded only as a bounded
+NAT parse-error counter (#4718).
+
+`validateNATMatchAddressLiteralsStrict`
+(`pkg/config/compiler_validate_strict_nat_match_addr.go`, wired into
+`runUniformGatesNAT` immediately after the #3228 sibling) rejects it at strict
+commit / commit-check, naming the NAT kind, rule-set, rule, match leaf, and
+value. Scope is the LITERAL leaves only: `match source-address-name` /
+`destination-address-name` are address-book references whose unresolvable raw
+token is deliberately appended to the same wire list as a fail-closed backstop
+(#2416), so the gate must never walk the post-resolution list.
+
+The acceptance predicate is `net.ParseCIDR` then `net.ParseIP`
+(`natMatchPrefixParses`, `compiler_nat_helpers.go`) — the exact Rust pair,
+NOT the `netip` equivalents. `netip.ParsePrefix` is stricter than Rust on the
+mask text: it rejects a zero-padded prefix length (`1.2.3.4/024`) that Rust's
+`u8::from_str` reads as 24 and installs, and a validator that refuses a value
+the dataplane installs bricks the operator's next commit on a working box.
+
+Lenient (`Store.Load` / HA peer-sync, flag `lenientNATMatchAddressLiterals`):
+warn, do not fail. That value committed clean on every build before this gate,
+so boxes carrying one exist by construction. The tolerant path deliberately
+KEEPS the value in the compiled config: dropping it would empty an
+all-malformed list, clear the Rust `*_constrained` flag and collapse the rule to
+MATCH-ANY — a fail-OPEN regression strictly worse than the silent narrowing this
+gate is about.
+
+Regression coverage: `pkg/config/nat_match_address_literal_7145_test.go` (the
+full 3x2 census at strict, including the two pre-existing gates as controls;
+tolerant warn-and-KEEP with the good value intact and the malformed one authored
+second; an over-rejection guard that pins `0.0.0.0/0`, `::/0`, a bare host, a
+host-bits CIDR and `1.2.3.4/024` still committing) and
+`pkg/configstore/nat_match_address_no_brick_7145_test.go` (the no-brick property
+at the REAL ingresses — `Store.Load` and `Store.SyncApply` — plus a
+`CommitCheck` over-reach guard). The four sites were also removed from
+`slotEscapeUngated` (`schema_slot_escape_fixtures_test.go`), so their #7143
+slot-escape rows now run the full slot-1 comparison instead of skipping.
+
 Regression coverage: `pkg/config/compiler_nat_host_mask_test.go` (bare/​/32/​/128
 accept; v4 + v6 non-host match/prefix reject with asserted message; NPTv6 and
 `inet` exemptions; NAT64 source-pool host vs non-host; strict-reject /

--- a/docs/userspace-dnat-plan.md
+++ b/docs/userspace-dnat-plan.md
@@ -445,6 +445,73 @@ bracket/repeated lists lost every prefix after the first (M02).
   the non-scoped / test wrappers pass `None` (source gate skipped), the
   production scoped callers pass `Some(..)`.
 
+### Malformed literal match prefixes rejected at commit (#7145)
+
+Every mechanism above depends on the operator's literal `match source-address` /
+`match destination-address` values being parseable, because the Go snapshot
+builders copy them to the wire VERBATIM and the Rust consumers drop, per entry,
+whatever they cannot parse:
+
+| kind | Rust parse site |
+|---|---|
+| source NAT | `parse_match_prefix` (`nat/source.rs`) |
+| destination NAT | `DnatTable::from_snapshots` (`nat/destination.rs`) |
+| static NAT | `SourceConstraint::from_list` (`nat/static_nat.rs`) |
+
+All three try `IpNet::from_str`, fall back to `IpAddr::from_str` (bare host ->
+/32 / /128), and drop the entry otherwise while recording a bounded NAT
+parse-error counter (#4718). The `*_constrained` flag is keyed on the SNAPSHOT
+LIST being non-empty, not on how many entries parsed — that is what makes the
+all-malformed case fail CLOSED rather than collapse to match-any.
+
+Fail-closed at runtime was never the complaint. The complaint (#7145) was that
+the operator boundary was SILENT about it in four of the six (kind x match leaf)
+slots, while the other two rejected the identical value. Measured at
+`bf10c6b7c` with `999.1.1.1/24`:
+
+| kind | `match source-address` | `match destination-address` |
+|---|---|---|
+| source | accepted -> **rejected** | accepted -> **rejected** |
+| destination | accepted -> **rejected** | rejected (#3228) |
+| static | accepted -> **rejected** | rejected (#3206) |
+
+`validateNATMatchAddressLiteralsStrict`
+(`pkg/config/compiler_validate_strict_nat_match_addr.go`) closes the four. It
+walks ONLY the literal leaves — `match source-address-name` /
+`destination-address-name` are address-book references whose unresolvable raw
+token is appended to the same wire list ON PURPOSE (#2416, above), so a gate
+that walked the post-resolution list would reject the fail-closed backstop
+itself.
+
+The predicate is `net.ParseCIDR` then `net.ParseIP` (`natMatchPrefixParses`,
+`compiler_nat_helpers.go`), chosen over the `netip` equivalents because
+`netip.ParsePrefix` is STRICTER than Rust on the mask text — it rejects a
+zero-padded prefix length (`1.2.3.4/024`) that Rust's `u8::from_str` reads as
+24 and installs. Rejecting a value the dataplane installs is the one direction
+a widened validator must never take.
+
+Strict on commit / commit-check (hard reject naming the kind, rule-set, rule,
+leaf, and value); lenient on load / peer-sync (warn, flag
+`lenientNATMatchAddressLiterals`, #1960 no-brick — the value COMMITTED CLEAN on
+every build before this, so the population of boxes carrying one is non-empty by
+construction). **The tolerant path KEEPS the malformed value in the compiled
+config.** Dropping it Go-side would empty an all-malformed list, clear
+`*_constrained` and collapse the rule to MATCH-ANY — turning a fail-closed
+silent break into a fail-OPEN one.
+
+Known residuals, measured, NOT closed by #7145 (they are a different value
+class from the issue's malformed CIDR):
+
+- **#7215** — an out-of-range mask (`10.0.0.0/33`) is still accepted on
+  destination-NAT `match destination-address`. That slot's own gate (#3228)
+  strips the mask and parses only the address part, while its Go builder
+  (`dnatDestinationParts`) uses `net.ParseCIDR` and skips the entry — a
+  validator/builder divergence in the OLDER gate.
+- **#7216** — an explicitly quoted empty value (`match destination-address ""`)
+  is still accepted on static-NAT `match destination-address`, where an empty
+  slot carries the deliberate #6673 "authored blank selection" meaning, so
+  closing it needs to separate a machinery-produced blank from a typed one.
+
 ### Static-NAT invalid `match destination-port` fails closed (#5101)
 
 The static-NAT typed `match destination-port` / `mapped-port` leaves are

--- a/pkg/config/compiler_nat_helpers.go
+++ b/pkg/config/compiler_nat_helpers.go
@@ -427,3 +427,40 @@ func applyDeterministicHost(det *DeterministicNATConfig, hostNode *Node) {
 		det.HostAddress = hostNode.Keys[1]
 	}
 }
+
+// natMatchPrefixParses mirrors the Rust NAT match-prefix parser EXACTLY, so
+// "accepted at commit" and "installed at runtime" cannot diverge for a NAT
+// rule's literal `match source-address` / `match destination-address` values.
+//
+// Those values reach the wire VERBATIM — the Go snapshot builders copy the
+// list without filtering (pkg/dataplane/userspace/nat_source.go,
+// nat_destination.go, nat_static.go) — and all three Rust consumers parse each
+// entry the same way:
+//
+//   - source NAT:      parse_match_prefix (userspace-dp/src/nat/source.rs)
+//   - destination NAT: DnatTable::from_snapshots (nat/destination.rs)
+//   - static NAT:      SourceConstraint::from_list (nat/static_nat.rs)
+//
+// Each tries `IpNet::from_str` first (a CIDR, host bits permitted) and falls
+// back to `IpAddr::from_str` (a bare host IP, promoted to /32 or /128). An
+// entry that satisfies neither is DROPPED from the match set.
+//
+// The Go mirror is net.ParseCIDR then net.ParseIP, chosen over the netip
+// equivalents because netip.ParsePrefix is STRICTER than Rust on the mask
+// text: it rejects a zero-padded prefix length (`1.2.3.4/024`) that Rust's
+// `u8::from_str` accepts as 24, so a netip-based gate would reject a value the
+// dataplane installs — the one direction a widened validator must never take
+// (#1960 no-brick). net.ParseIP is likewise the right bare-host mirror because
+// it rejects a zone-suffixed literal (`fe80::1%eth0`) exactly as Rust's
+// `IpAddr::from_str` does, where netip.ParseAddr would accept it.
+//
+// An empty value returns false: an empty entry is not a prefix, it still
+// leaves the match list NON-empty, and the Rust `*_constrained` flag is keyed
+// on list length — so an empty entry narrows the rule (or, alone, makes it
+// match nothing) exactly like any other unparseable one.
+func natMatchPrefixParses(raw string) bool {
+	if _, _, err := net.ParseCIDR(raw); err == nil {
+		return true
+	}
+	return net.ParseIP(raw) != nil
+}

--- a/pkg/config/compiler_opts.go
+++ b/pkg/config/compiler_opts.go
@@ -1422,6 +1422,28 @@ type compileOpts struct {
 	// leniently-loaded bad config is inert. Same doctrine as
 	// lenientPolicyZoneRefs / lenientNATHostMask.
 	lenientDestNATAddresses bool
+	// lenientNATMatchAddressLiterals (#7145) downgrades the NAT match-address
+	// literal gate (validateNATMatchAddressLiteralsStrict) from a hard compile
+	// error to a cfg.Warnings entry. The strict commit / commit-check path
+	// hard-rejects a source / destination / static NAT rule whose literal
+	// `match source-address` (any kind) or `match destination-address` (source
+	// kind) carries a value the dataplane cannot parse. Before #7145 those four
+	// (kind x leaf) slots had NO parse gate at all, while the sibling slot in
+	// the SAME rule — destination-NAT and static-NAT `match
+	// destination-address` — rejected the identical value (#3228 / #3206): one
+	// operator typo, opposite verdicts depending on which slot it landed in.
+	// The values reach the wire verbatim and each Rust consumer drops what it
+	// cannot parse while keeping the rule CONSTRAINED, so a malformed entry
+	// narrows the rule and an all-malformed list makes it match NOTHING —
+	// visible only as a bounded NAT parse-error counter. The tolerant load /
+	// peer-sync paths downgrade to a warning so an already-persisted or
+	// peer-synced config carrying a malformed prefix still BOOTS (#1960
+	// no-brick), and the value is deliberately KEPT in the compiled config on
+	// that path: dropping it Go-side would empty an all-malformed list, clear
+	// the Rust `*_constrained` flag and collapse the rule to MATCH-ANY, turning
+	// a fail-closed break into a fail-open one. Same doctrine as
+	// lenientDestNATAddresses.
+	lenientNATMatchAddressLiterals bool
 	// lenientRPMSourceAddress (#2492) downgrades the RPM test
 	// source-address gate (validateRPMSourceAddressStrict) from a hard
 	// compile error to a cfg.Warnings entry. The strict commit /
@@ -2323,6 +2345,7 @@ func lenientCompileOpts() compileOpts {
 		lenientDuplicateHostLocalAddress:       true,
 		lenientClusterAuthKey:                  true,
 		lenientDestNATAddresses:                true,
+		lenientNATMatchAddressLiterals:         true,
 		lenientRPMSourceAddress:                true,
 		lenientRPMLinkLocalZone:                true,
 		lenientRPMHTTPGetScheme:                true,

--- a/pkg/config/compiler_uniformgates_nat.go
+++ b/pkg/config/compiler_uniformgates_nat.go
@@ -30,6 +30,29 @@ func runUniformGatesNAT(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 		}
 	}
 
+	// #7145 NAT match-address literal gate. The four (NAT kind x match leaf)
+	// slots that had NO parse gate at all — `match source-address` on source /
+	// destination / static NAT, and `match destination-address` on source NAT —
+	// accepted a malformed CIDR (`999.1.1.1/24`) that the sibling slot in the
+	// SAME rule rejected. The values reach the wire verbatim; each Rust consumer
+	// drops the unparseable entry but keeps the rule CONSTRAINED, so the rule
+	// silently narrows and an all-malformed list matches NOTHING. Strict on
+	// commit / commit-check (hard reject); lenient on load / peer-sync
+	// (downgrade to a warning so an already-persisted or peer-synced config
+	// still boots — #1960 no-brick; the value is KEPT so the dataplane's
+	// fail-closed drop still applies rather than collapsing to match-any).
+	// Runs immediately after the sibling destination-address gate so the two
+	// read as one family, and so a rule tripping BOTH reports the older,
+	// narrower message first (no change to an existing config's first error).
+	if err := validateNATMatchAddressLiteralsStrict(cfg); err != nil {
+		if opts.lenientNATMatchAddressLiterals {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("nat match address (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #2396(a)/(3) destination-NAT match-protocol gate. The DNAT `match
 	// protocol <token>` reaches the wire VERBATIM (nodeVal -> rule.Match.Protocol
 	// -> snapshot, with no validation), and the Rust DNAT table drops a token

--- a/pkg/config/compiler_validate_strict_nat_match_addr.go
+++ b/pkg/config/compiler_validate_strict_nat_match_addr.go
@@ -1,0 +1,169 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// validateNATMatchAddressLiteralsStrict (#7145) hard-rejects a NAT rule whose
+// literal `match source-address` / `match destination-address` carries a value
+// the dataplane cannot parse.
+//
+// THE DEFECT IT CLOSES IS AN ASYMMETRY, not a missing check in the abstract.
+// Measured at bf10c6b7c over a base config that commits clean, `999.1.1.1/24`
+// (and `zznotanaddr`, so this is not a near-miss in the CIDR grammar) landed
+// on six (NAT kind x match leaf) slots with four different verdicts:
+//
+//	security nat source      rule-set RS rule R1 match source-address       ACCEPTED
+//	security nat source      rule-set RS rule R1 match destination-address  ACCEPTED
+//	security nat destination rule-set RD rule R1 match source-address       ACCEPTED
+//	security nat destination rule-set RD rule R1 match destination-address  rejected (#3228)
+//	security nat static      rule-set RT rule R1 match source-address       ACCEPTED
+//	security nat static      rule-set RT rule R1 match destination-address  rejected (#3206)
+//
+// The same operator typo was refused in one slot of a rule and accepted in the
+// sibling slot of the SAME rule. This gate covers the four accepting slots; the
+// two already-rejecting slots keep their own (older, differently-worded) gates,
+// which is why this walks only the four — a second complaint about a value
+// already rejected would just reorder which message the operator sees.
+//
+// WHAT THE SILENT ACCEPT COSTS. These values are not inert. The Go snapshot
+// builders copy the configured list to the wire WITHOUT filtering
+// (pkg/dataplane/userspace/nat_source.go, nat_destination.go, nat_static.go)
+// and each Rust consumer parses per entry, dropping what it cannot parse while
+// recording only a bounded NAT parse-error counter (#4718):
+//
+//   - source NAT:      parse_match_prefix       (userspace-dp/src/nat/source.rs)
+//   - destination NAT: DnatTable::from_snapshots (nat/destination.rs)
+//   - static NAT:      SourceConstraint::from_list (nat/static_nat.rs)
+//
+// The `*_constrained` flag is keyed on the SNAPSHOT list being non-empty, not
+// on how many entries parsed. So a malformed entry beside good ones NARROWS the
+// rule below what was authored, and an all-malformed list leaves the rule
+// constrained with zero prefixes — it matches NOTHING and stops translating.
+// That fail-closed runtime posture is correct and is deliberately preserved
+// (see the lenient note below); what was wrong is that the operator boundary was
+// silent about a value the dataplane cannot use, while the sibling slot in the
+// same rule was not.
+//
+// SCOPE: literal values only. `match source-address-name` / `match
+// destination-address-name` are address-BOOK references and are validated by
+// validateNATSourceAddressNameReferencesStrict; the snapshot builders append an
+// unresolvable name's RAW token to the same wire list on purpose, as a
+// fail-closed backstop (appendNATSourceAddressName), so this gate must never
+// walk the post-resolution list — only the config leaf the operator authored.
+//
+// Strict on commit / commit-check (hard reject naming the NAT kind, rule-set,
+// rule, match leaf, and the offending value); lenient on load / peer-sync
+// (warn — #1960 no-brick). The lenient path warns and leaves the value in the
+// compiled config ON PURPOSE. Dropping the entry Go-side would empty an
+// all-malformed list, clear `*_constrained`, and collapse the rule back to
+// MATCH-ANY — turning a fail-closed silent break into a fail-OPEN one (the
+// exact regression the nat_destination.go #2416 comment warns about). Warn,
+// keep the entry, let the dataplane drop it: the leniently-loaded config boots
+// and forwards, and behaves exactly as it did before this gate existed.
+func validateNATMatchAddressLiteralsStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	// Reported deterministically: rule-sets are walked in sorted name order,
+	// rules in their configured order, and within a rule source-address before
+	// destination-address — so the first-reported offender is stable across
+	// runs and across the map-ordered scope expansion. Mirrors
+	// validateDestinationNATAddressesStrict.
+	check := func(kind, ruleSet, rule, leaf string, values []string) error {
+		for _, raw := range values {
+			if natMatchPrefixParses(raw) {
+				continue
+			}
+			axis := "source"
+			if leaf == "destination-address" {
+				axis = "destination"
+			}
+			return fmt.Errorf(
+				"%s rule-set %q rule %q: match %s %q is not a valid IP address or "+
+					"CIDR prefix; the rule would commit but the dataplane cannot parse "+
+					"the value and drops it from the %s match set (recorded only as a "+
+					"NAT parse-error counter), so the rule matches a NARROWER set than "+
+					"authored — and because the match list is still non-empty the rule "+
+					"stays constrained, so a list whose values are ALL malformed matches "+
+					"NOTHING and the rule silently translates no traffic (full list: %s)",
+				kind, ruleSet, rule, leaf, raw, axis, strings.Join(values, ", "))
+		}
+		return nil
+	}
+
+	for _, rs := range sortedNATRuleSetsByName(cfg.Security.NAT.Source) {
+		for _, rule := range rs.Rules {
+			if rule == nil {
+				continue
+			}
+			if err := check("source-nat", rs.Name, rule.Name, "source-address",
+				natMatchValues(rule.Match.SourceAddresses, rule.Match.SourceAddress)); err != nil {
+				return err
+			}
+			if err := check("source-nat", rs.Name, rule.Name, "destination-address",
+				natMatchValues(rule.Match.DestinationAddresses, rule.Match.DestinationAddress)); err != nil {
+				return err
+			}
+		}
+	}
+
+	if cfg.Security.NAT.Destination != nil {
+		for _, rs := range sortedNATRuleSetsByName(cfg.Security.NAT.Destination.RuleSets) {
+			for _, rule := range rs.Rules {
+				if rule == nil {
+					continue
+				}
+				// destination-address on this kind is validateDestination-
+				// NATAddressesStrict's (#3228); only the source side is new.
+				if err := check("destination-nat", rs.Name, rule.Name, "source-address",
+					natMatchValues(rule.Match.SourceAddresses, rule.Match.SourceAddress)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	staticSets := append([]*StaticNATRuleSet(nil), cfg.Security.NAT.Static...)
+	sort.SliceStable(staticSets, func(i, j int) bool {
+		if staticSets[i] == nil || staticSets[j] == nil {
+			return staticSets[i] != nil
+		}
+		return staticSets[i].Name < staticSets[j].Name
+	})
+	for _, rs := range staticSets {
+		if rs == nil {
+			continue
+		}
+		for _, rule := range rs.Rules {
+			if rule == nil {
+				continue
+			}
+			// destination-address on this kind is the #3206 arm of
+			// validateNATHostMaskStrict; only the source side is new.
+			if err := check("static-nat", rs.Name, rule.Name, "source-address",
+				natMatchValues(rule.SourceAddresses, rule.SourceAddress)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// sortedNATRuleSetsByName returns a name-sorted copy of a NAT rule-set slice
+// with the nil entries dropped, so a gate's first-reported offender does not
+// depend on the map-ordered scope expansion that produced the slice. Stable, so
+// the several rule-sets a multi-scope stanza expands into keep their relative
+// order.
+func sortedNATRuleSetsByName(in []*NATRuleSet) []*NATRuleSet {
+	out := make([]*NATRuleSet, 0, len(in))
+	for _, rs := range in {
+		if rs != nil {
+			out = append(out, rs)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}

--- a/pkg/config/nat_match_address_literal_7145_test.go
+++ b/pkg/config/nat_match_address_literal_7145_test.go
@@ -1,0 +1,355 @@
+package config
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// #7145: a malformed CIDR in a NAT rule's `match source-address` committed
+// clean on ALL THREE NAT kinds — and on the source rule-set's `match
+// destination-address` too — while `match destination-address` on the
+// destination and static rule-sets REJECTED the identical value.
+//
+// MEASURED AT bf10c6b7c, over the base config below, with `999.1.1.1/24` (and
+// `zznotanaddr`, so this is not a near-miss in the CIDR grammar):
+//
+//	kind         leaf                  master     here
+//	source       source-address        ACCEPTED   rejected   <- #7145
+//	source       destination-address   ACCEPTED   rejected   <- #7145
+//	destination  source-address        ACCEPTED   rejected   <- #7145
+//	destination  destination-address   rejected   rejected   (#3228, untouched)
+//	static       source-address        ACCEPTED   rejected   <- #7145
+//	static       destination-address   rejected   rejected   (#3206, untouched)
+//
+// The four ACCEPTED slots are what validateNATMatchAddressLiteralsStrict
+// closes. The two already-rejecting slots keep their own gates and are asserted
+// here as CONTROLS — they are in the table so a regression that silently
+// removed one of the OLD gates fails here too, and so the table is a complete
+// (kind x leaf) census rather than a list of the ones this change touched.
+//
+// The accept was not inert. These values reach the wire VERBATIM (the Go
+// snapshot builders copy the list unfiltered) and each Rust consumer drops an
+// entry it cannot parse while keeping the rule CONSTRAINED — so a malformed
+// entry silently NARROWS the rule and an all-malformed list makes it match
+// NOTHING, recorded only as a bounded NAT parse-error counter (#4718).
+//
+// Per CLAUDE.md every flat-set case is built with ParseSetCommand + SetPath,
+// never NewParser (which merges all set lines into one node).
+
+// nat7145Base is the two-interface / two-zone config the issue reproduces over;
+// it commits clean on its own.
+var nat7145Base = []string{
+	"set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24",
+	"set interfaces ge-0/0/1 unit 0 family inet address 10.0.2.1/24",
+	"set security zones security-zone trust interfaces ge-0/0/0.0",
+	"set security zones security-zone untrust interfaces ge-0/0/1.0",
+}
+
+// nat7145Kind describes one NAT kind's complete rule-set scaffolding plus the
+// `set ... match ` prefix that addresses its single rule.
+type nat7145Kind struct {
+	name     string // "source" | "destination" | "static"
+	ruleSet  string
+	scaffold []string
+	// sibling is the OTHER match leaf's valid value, needed because a static /
+	// destination rule with no destination-address at all is out of scope for
+	// the gates that already exist (they skip a rule with no match) — without
+	// it the source-address cases would not be comparable to the base config.
+	sibling map[string][]string
+}
+
+func nat7145Kinds() []nat7145Kind {
+	return []nat7145Kind{
+		{
+			name:    "source",
+			ruleSet: "RS",
+			scaffold: []string{
+				"set security nat source rule-set RS from zone trust",
+				"set security nat source rule-set RS to zone untrust",
+				"set security nat source rule-set RS rule R1 then source-nat interface",
+			},
+		},
+		{
+			name:    "destination",
+			ruleSet: "RD",
+			scaffold: []string{
+				"set security nat destination pool P1 address 10.0.2.5/32",
+				"set security nat destination rule-set RD from zone trust",
+				"set security nat destination rule-set RD rule R1 then destination-nat pool P1",
+			},
+			sibling: map[string][]string{
+				"source-address": {"set security nat destination rule-set RD rule R1 match destination-address 203.0.113.1/32"},
+			},
+		},
+		{
+			name:    "static",
+			ruleSet: "RT",
+			scaffold: []string{
+				"set security nat static rule-set RT from zone trust",
+				"set security nat static rule-set RT rule R1 then static-nat prefix 10.0.1.5/32",
+			},
+			sibling: map[string][]string{
+				"source-address": {"set security nat static rule-set RT rule R1 match destination-address 203.0.113.1/32"},
+			},
+		},
+	}
+}
+
+// nat7145Cmds builds the full flat-set corpus for one (kind, leaf, values) cell.
+func nat7145Cmds(k nat7145Kind, leaf string, values ...string) []string {
+	cmds := append([]string{}, nat7145Base...)
+	cmds = append(cmds, k.scaffold...)
+	cmds = append(cmds, k.sibling[leaf]...)
+	set := "set security nat " + k.name + " rule-set " + k.ruleSet + " rule R1 match " + leaf
+	for _, v := range values {
+		cmds = append(cmds, set+" "+v)
+	}
+	return cmds
+}
+
+func nat7145Tree(t *testing.T, cmds []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		p, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(p); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// nat7145MatchList returns the compiled match list for one (kind, leaf) cell,
+// so a test can assert what the tolerant path actually LOWERED rather than
+// asserting only that it did not error.
+func nat7145MatchList(t *testing.T, cfg *Config, kind, leaf string) []string {
+	t.Helper()
+	switch kind {
+	case "source":
+		if len(cfg.Security.NAT.Source) == 0 || len(cfg.Security.NAT.Source[0].Rules) == 0 {
+			t.Fatalf("source-NAT rule missing from the compiled config: %+v", cfg.Security.NAT.Source)
+		}
+		m := cfg.Security.NAT.Source[0].Rules[0].Match
+		if leaf == "destination-address" {
+			return m.DestinationAddresses
+		}
+		return m.SourceAddresses
+	case "destination":
+		if cfg.Security.NAT.Destination == nil || len(cfg.Security.NAT.Destination.RuleSets) == 0 ||
+			len(cfg.Security.NAT.Destination.RuleSets[0].Rules) == 0 {
+			t.Fatalf("destination-NAT rule missing from the compiled config: %+v", cfg.Security.NAT.Destination)
+		}
+		m := cfg.Security.NAT.Destination.RuleSets[0].Rules[0].Match
+		if leaf == "destination-address" {
+			return m.DestinationAddresses
+		}
+		return m.SourceAddresses
+	case "static":
+		if len(cfg.Security.NAT.Static) == 0 || len(cfg.Security.NAT.Static[0].Rules) == 0 {
+			t.Fatalf("static-NAT rule missing from the compiled config: %+v", cfg.Security.NAT.Static)
+		}
+		r := cfg.Security.NAT.Static[0].Rules[0]
+		if leaf == "destination-address" {
+			return r.MatchAddresses
+		}
+		return r.SourceAddresses
+	}
+	t.Fatalf("unknown NAT kind %q", kind)
+	return nil
+}
+
+// TestNATMatchAddressLiteral7145StrictRejectsEverySlot is the ASYMMETRY guard:
+// the same malformed value must be refused in every (NAT kind x match leaf)
+// slot, and the rejection must NAME the offending value, the rule-set, and the
+// rule so the operator can find it.
+//
+// It is a full 3x2 census on purpose. Two of the six cells are the pre-existing
+// #3228 / #3206 gates; the other four are #7145. Reading the table is how you
+// see that the six now agree — a test that only covered the four would leave
+// "they agree" unbound.
+//
+// RED-on-revert (the four #7145 cells): drop the
+// validateNATMatchAddressLiteralsStrict call from runUniformGatesNAT, or make
+// natMatchPrefixParses return true unconditionally, and this fails at
+// "committed CLEAN".
+func TestNATMatchAddressLiteral7145StrictRejectsEverySlot(t *testing.T) {
+	for _, bad := range []string{"999.1.1.1/24", "zznotanaddr"} {
+		for _, k := range nat7145Kinds() {
+			for _, leaf := range []string{"source-address", "destination-address"} {
+				t.Run(bad+"/"+k.name+"/"+leaf, func(t *testing.T) {
+					tree := nat7145Tree(t, nat7145Cmds(k, leaf, bad))
+					_, err := CompileConfig(tree)
+					if err == nil {
+						t.Fatalf("`security nat %s rule-set %s rule R1 match %s %s` committed CLEAN. "+
+							"The value reaches the dataplane verbatim, which cannot parse it and drops "+
+							"it from the match set while leaving the rule CONSTRAINED — so the rule "+
+							"silently narrows, and with this as its only value it matches NOTHING and "+
+							"stops translating, visible only as a NAT parse-error counter (#7145)",
+							k.name, k.ruleSet, leaf, bad)
+					}
+					msg := err.Error()
+					if !strings.Contains(msg, bad) {
+						t.Errorf("the rejection must NAME the offending value %q so the operator can "+
+							"find it in a long rule-set; got: %v", bad, msg)
+					}
+					if !strings.Contains(msg, k.ruleSet) || !strings.Contains(msg, "R1") {
+						t.Errorf("the rejection must name the rule-set (%q) and rule (\"R1\"); got: %v",
+							k.ruleSet, msg)
+					}
+					if !strings.Contains(msg, leaf) {
+						t.Errorf("the rejection must name the match leaf (%q) — the whole point of "+
+							"#7145 is that the two leaves of one rule disagreed, so a message that "+
+							"does not say WHICH leaf leaves the operator where they started; got: %v",
+							leaf, msg)
+					}
+				})
+			}
+		}
+	}
+}
+
+// TestNATMatchAddressLiteral7145LenientWarnsAndKeeps is the #1960 no-brick half
+// at the compiler: the tolerant path must WARN, not fail — and it must KEEP the
+// malformed value in the lowered list.
+//
+// KEEPING IT IS LOAD-BEARING, not laziness. The Rust `*_constrained` flag is
+// keyed on the snapshot list being NON-EMPTY, not on how many entries parsed
+// (source.rs `source_constrained = !snap.source_addresses.is_empty()`,
+// destination.rs, static_nat.rs `SourceConstraint::from_list`). Dropping an
+// all-malformed list Go-side would clear that flag and collapse the rule to
+// MATCH-ANY — converting a fail-CLOSED silent break into a fail-OPEN one, which
+// is strictly worse than the bug this change fixes. So the tolerant path warns,
+// keeps the value, and lets the dataplane drop it.
+//
+// The good value is asserted intact ALONGSIDE the malformed one, and the
+// malformed value is authored SECOND, so the test also pins that the gate walks
+// the whole bracket list rather than only slot 0.
+//
+// RED-on-revert: remove lenientNATMatchAddressLiterals from
+// lenientCompileOpts() and this fails at "the tolerant path REJECTED".
+func TestNATMatchAddressLiteral7145LenientWarnsAndKeeps(t *testing.T) {
+	const bad = "999.1.1.1/24"
+	// The four slots #7145 closes. The other two are covered by their own
+	// gates' tolerant paths (#3228 / #3206) and word their warnings
+	// differently, so asserting this warning text on them would bind the wrong
+	// gate.
+	for _, tc := range []struct{ kind, leaf, good string }{
+		{"source", "source-address", "10.0.0.0/8"},
+		{"source", "destination-address", "198.51.100.0/24"},
+		{"destination", "source-address", "10.0.0.0/8"},
+		{"static", "source-address", "10.0.0.0/8"},
+	} {
+		t.Run(tc.kind+"/"+tc.leaf, func(t *testing.T) {
+			var k nat7145Kind
+			for _, cand := range nat7145Kinds() {
+				if cand.name == tc.kind {
+					k = cand
+				}
+			}
+			tree := nat7145Tree(t, nat7145Cmds(k, tc.leaf, tc.good, bad))
+
+			// Precondition: the SAME corpus is refused by the strict path.
+			// Without this the tolerant assertion below could pass simply
+			// because the corpus never tripped the gate at all.
+			if _, err := CompileConfig(tree); err == nil {
+				t.Fatalf("precondition: the strict path must REJECT this corpus, else the "+
+					"tolerant assertion is vacuous (kind=%s leaf=%s)", tc.kind, tc.leaf)
+			}
+
+			cfg, err := CompileConfigLenient(tree)
+			if err != nil {
+				t.Fatalf("the tolerant path REJECTED a config carrying a malformed NAT match "+
+					"prefix. A config an older binary committed must still BOOT and still "+
+					"FORWARD (#1960): a compile failure on Store.Load leaves ActiveConfig() nil, "+
+					"which forces the daemon into the bootstrap/lifeline state — a worse outage "+
+					"than the narrowed NAT rule it complains about: %v", err)
+			}
+			if cfg == nil {
+				t.Fatal("the tolerant path returned a nil config; a silent nil is the same brick " +
+					"as an error")
+			}
+
+			var warn string
+			for _, w := range cfg.Warnings {
+				if strings.Contains(w, bad) && strings.Contains(w, tc.leaf) {
+					warn = w
+					break
+				}
+			}
+			if warn == "" {
+				t.Fatalf("the tolerant path must WARN, naming the value and the leaf — a silent "+
+					"tolerate is the pre-#7145 behaviour, which is exactly the defect. warnings: %v",
+					cfg.Warnings)
+			}
+			if !strings.Contains(warn, k.ruleSet) || !strings.Contains(warn, "R1") {
+				t.Errorf("the warning must name the rule-set (%q) and rule (\"R1\"); got: %s",
+					k.ruleSet, warn)
+			}
+
+			got := nat7145MatchList(t, cfg, tc.kind, tc.leaf)
+			want := []string{tc.good, bad}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("tolerant-path match list = %q, want %q. The GOOD value must survive "+
+					"(a tolerant load that lost it would silently widen or break the rule), and "+
+					"the MALFORMED value must survive too: the Rust *_constrained flag is keyed "+
+					"on this list being non-empty, so dropping it here would collapse an "+
+					"all-malformed rule to MATCH-ANY — a fail-OPEN regression worse than #7145",
+					got, want)
+			}
+		})
+	}
+}
+
+// TestNATMatchAddressLiteral7145AcceptsValidPrefixes is the OVER-REJECTION
+// guard, and it is the half that makes the widening safe to ship: a widened
+// validator that rejects a value the dataplane happily installs bricks the next
+// commit on a working box (#1960).
+//
+// Every value here is one the Rust parsers accept, so every one must still
+// commit on every slot:
+//
+//   - `0.0.0.0/0` / `::/0` — the match-any spelling that ships in
+//     docs/ha-cluster-userspace.conf and test/incus/xpf-cluster-fw0.conf today.
+//   - a bare host IP — `IpAddr::from_str` promotes it to /32 / /128.
+//   - a CIDR with host bits set — `IpNet::from_str` permits them.
+//   - `1.2.3.4/024` — a ZERO-PADDED prefix length. Rust's `u8::from_str`
+//     reads "024" as 24 and installs the prefix, and Go's net.ParseCIDR agrees;
+//     netip.ParsePrefix does NOT (it rejects the padding), which is precisely
+//     why natMatchPrefixParses is built on net.ParseCIDR. Swap it to the netip
+//     form and this cell goes RED — that is the point of the cell.
+//
+// The static `match destination-address` slot is excluded per value, not
+// wholesale: static NAT requires a HOST route there (#3206 / #3031), so `/0`,
+// `/24` and `/024` are legitimately rejected by that older gate for a reason
+// that has nothing to do with #7145.
+func TestNATMatchAddressLiteral7145AcceptsValidPrefixes(t *testing.T) {
+	for _, good := range []string{"0.0.0.0/0", "10.0.0.0/8", "192.0.2.5", "192.0.2.5/32", "1.2.3.4/024", "2001:db8::/32", "2001:db8::1"} {
+		for _, k := range nat7145Kinds() {
+			for _, leaf := range []string{"source-address", "destination-address"} {
+				if k.name == "static" && leaf == "destination-address" {
+					// Host-route-only slot; governed by #3206 / #3031, not #7145.
+					continue
+				}
+				if k.name == "static" && strings.HasPrefix(good, "2001:db8:") {
+					// A v6 source-address against a v4 `then static-nat prefix`
+					// is a family mismatch the static gates reject for their
+					// own reasons.
+					continue
+				}
+				t.Run(good+"/"+k.name+"/"+leaf, func(t *testing.T) {
+					tree := nat7145Tree(t, nat7145Cmds(k, leaf, good))
+					if _, err := CompileConfig(tree); err != nil {
+						t.Fatalf("`match %s %s` on %s NAT was REJECTED, but the dataplane parses "+
+							"and installs it. A widened validator that refuses a working value "+
+							"bricks the operator's next commit on a box that was forwarding "+
+							"correctly (#1960): %v", leaf, good, k.name, err)
+					}
+				})
+			}
+		}
+	}
+}

--- a/pkg/config/schema_slot_escape_fixtures_test.go
+++ b/pkg/config/schema_slot_escape_fixtures_test.go
@@ -138,16 +138,21 @@ var slotEscRibGroup = []string{
 //
 // Every entry below was measured, not assumed.
 // ---------------------------------------------------------------------------
+// #7145 CLOSED the four NAT match-address rows this map used to carry:
+//
+//	security nat source      rule-set <*> rule <*> match source-address
+//	security nat source      rule-set <*> rule <*> match destination-address
+//	security nat destination rule-set <*> rule <*> match source-address
+//	security nat static      rule-set <*> rule <*> match source-address
+//
+// They were recorded here because a malformed CIDR (999.1.1.1/24) committed
+// clean in slot 0, while the destination-NAT and static-NAT `match
+// destination-address` siblings rejected the identical value — the asymmetry
+// this scout's inventory surfaced. validateNATMatchAddressLiteralsStrict now
+// gates all four, so their rows carry a REAL verdict and run the full slot-1
+// escape comparison instead of skipping. Removed rather than annotated: an
+// entry here means "this gate has nothing to compare", which is no longer true.
 var slotEscapeUngated = map[string]string{
-	"security nat source rule-set <*> rule <*> match source-address": "" +
-		"a malformed CIDR (999.1.1.1/24) commits clean, while the destination-NAT " +
-		"and static-NAT `match destination-address` siblings reject one",
-	"security nat source rule-set <*> rule <*> match destination-address": "" +
-		"same: no parse gate on the source rule-set's match addresses",
-	"security nat destination rule-set <*> rule <*> match source-address": "" +
-		"the destination rule-set gates match destination-address but not match source-address",
-	"security nat static rule-set <*> rule <*> match source-address": "" +
-		"the static rule-set gates match destination-address (#37b814d5) but not match source-address",
 	"snmp trap-group <*> categories": "" +
 		"trap categories are an open token set at commit; no domain check exists to escape",
 }

--- a/pkg/configstore/nat_match_address_no_brick_7145_test.go
+++ b/pkg/configstore/nat_match_address_no_brick_7145_test.go
@@ -1,0 +1,218 @@
+package configstore
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #7145 no-brick, bound at the REAL ingress.
+//
+// The tolerant-path test in pkg/config drives CompileConfigLenient directly.
+// That binds the compiler's behaviour, not the property: #1960 no-brick is a
+// property of Store.Load / Store.SyncApply, and a change that routed either
+// through the strict compile — or that registered the new gate outside
+// lenientCompileOpts() — would leave every compiler-level test green while an
+// already-persisted config stopped booting and HA config sync alarm-looped.
+// Same argument, and same shape, as ipip_no_brick_4785_test.go.
+//
+// The widening in #7145 is exactly the kind that needs this: a `match
+// source-address 999.1.1.1/24` COMMITTED CLEAN on every xpf build before this
+// change, so the population of boxes whose persisted config carries one is
+// non-empty by construction.
+
+// natMatchBad7145 is the malformed value from the issue. It parses as neither a
+// CIDR nor a bare host IP, so every Rust NAT consumer drops it.
+const natMatchBad7145 = "999.1.1.1/24"
+
+// natMatchPersisted7145 is the hierarchical form of a source-NAT rule whose
+// `match source-address` list carries one good prefix and one malformed one —
+// the shape an older binary persisted, and the shape a peer syncs.
+//
+// The good prefix is FIRST and the malformed one SECOND so the assertions below
+// can tell "the list survived" apart from "the list was truncated at the bad
+// entry".
+const natMatchPersisted7145 = `interfaces {
+    ge-0/0/0 {
+        unit 0 {
+            family inet {
+                address 10.0.1.1/24;
+            }
+        }
+    }
+    ge-0/0/1 {
+        unit 0 {
+            family inet {
+                address 10.0.2.1/24;
+            }
+        }
+    }
+}
+security {
+    zones {
+        security-zone trust {
+            interfaces {
+                ge-0/0/0.0;
+            }
+        }
+        security-zone untrust {
+            interfaces {
+                ge-0/0/1.0;
+            }
+        }
+    }
+    nat {
+        source {
+            rule-set RS {
+                from zone trust;
+                to zone untrust;
+                rule R1 {
+                    match {
+                        source-address [ 10.0.0.0/8 999.1.1.1/24 ];
+                    }
+                    then {
+                        source-nat {
+                            interface;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}`
+
+// natMatchSourceList7145 returns the compiled source-NAT rule's match list.
+func natMatchSourceList7145(t *testing.T, cfg *config.Config) []string {
+	t.Helper()
+	if len(cfg.Security.NAT.Source) == 0 || len(cfg.Security.NAT.Source[0].Rules) == 0 {
+		t.Fatalf("the tolerant ingress dropped the source-NAT rule entirely: %+v",
+			cfg.Security.NAT.Source)
+	}
+	return cfg.Security.NAT.Source[0].Rules[0].Match.SourceAddresses
+}
+
+// assertNATMatch7145Tolerated checks the three things the tolerant ingress owes:
+// it warned, it kept the GOOD prefix, and it kept the MALFORMED one.
+//
+// Keeping the malformed one is load-bearing, not laziness. The Rust
+// `source_constrained` flag is keyed on the snapshot list being NON-EMPTY, not
+// on how many entries parsed (userspace-dp/src/nat/source.rs). Dropping an
+// all-malformed list Go-side would clear it and collapse the rule to MATCH-ANY
+// — a fail-OPEN regression strictly worse than the silent narrowing #7145 is
+// about. So: warn, keep, and let the dataplane drop.
+func assertNATMatch7145Tolerated(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	var warn string
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, natMatchBad7145) && strings.Contains(w, "source-address") {
+			warn = w
+			break
+		}
+	}
+	if warn == "" {
+		t.Errorf("the tolerant ingress must WARN, naming the value and the leaf; a silent "+
+			"tolerate is the pre-#7145 behaviour. warnings: %v", cfg.Warnings)
+	}
+	got := natMatchSourceList7145(t, cfg)
+	if len(got) != 2 || got[0] != "10.0.0.0/8" || got[1] != natMatchBad7145 {
+		t.Fatalf("tolerant-ingress match list = %q, want [10.0.0.0/8 %s]. The GOOD prefix must "+
+			"survive (a boot that lost it forwards differently from the box that committed "+
+			"it), and the MALFORMED one must survive too — the Rust source_constrained flag "+
+			"is keyed on this list being non-empty, so dropping it here collapses an "+
+			"all-malformed rule to MATCH-ANY", got, natMatchBad7145)
+	}
+}
+
+// TestLoadToleratesNATMatchAddress7145 is the DISK-BOOT half: a node whose
+// already-committed config carries a malformed NAT match prefix must still
+// boot, and must still carry the rule.
+//
+// The tree is written straight to active.json with the committed marker set
+// (DB.WriteActiveMarker), NOT through a commit. That models the real scenario —
+// bytes an OLDER binary committed, before this gate existed — and it keeps the
+// persistence step off the lenient compile path, so a mutation that makes the
+// tolerant compile strict lands on THIS test's own Load assertion instead of
+// tripping a borrowed precondition.
+//
+// RED-on-revert: drop lenientNATMatchAddressLiterals from lenientCompileOpts()
+// and this fails at "Store.Load REFUSED a persisted config".
+func TestLoadToleratesNATMatchAddress7145(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	tree, errs := config.NewParser(natMatchPersisted7145).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("precondition: the fixture must parse: %v", errs[0])
+	}
+	if err := newTestStoreAt(t, path).db.WriteActiveMarker(tree, true); err != nil {
+		t.Fatalf("precondition: persisting the stanza must succeed: %v", err)
+	}
+
+	booted := newTestStoreAt(t, path)
+	if err := booted.Load(); err != nil {
+		t.Fatalf("Store.Load REFUSED a persisted config carrying a malformed NAT match "+
+			"prefix. That value COMMITTED CLEAN on every build before #7145, so this is a "+
+			"config real boxes have: a compile failure here leaves ActiveConfig() nil, which "+
+			"forces the daemon into the #1922 bootstrap/lifeline state — the box loses its "+
+			"whole config over one narrowed NAT rule: %v", err)
+	}
+	cfg := booted.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("Store.Load returned no error but left ActiveConfig() nil; the daemon reads " +
+			"that as an uncompiled config and refuses takeover, so a silent nil is the same " +
+			"brick as an error")
+	}
+	assertNATMatch7145Tolerated(t, cfg)
+}
+
+// TestSyncApplyToleratesNATMatchAddress7145 is the HA peer-sync half. A standby
+// that refuses the primary's config alarm-loops and diverges the cluster.
+//
+// RED-on-revert: same mutation, fails at "SyncApply REJECTED".
+func TestSyncApplyToleratesNATMatchAddress7145(t *testing.T) {
+	s := newTestStoreAt(t, filepath.Join(t.TempDir(), "config"))
+	cfg, err := s.SyncApply(natMatchPersisted7145, nil)
+	if err != nil {
+		t.Fatalf("SyncApply REJECTED a config carrying a malformed NAT match prefix. The HA "+
+			"config-sync ingress is TOLERANT by contract (#1960): a standby that refuses the "+
+			"primary's config alarm-loops and diverges the cluster: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("SyncApply returned a nil config on the tolerated path")
+	}
+	assertNATMatch7145Tolerated(t, cfg)
+}
+
+// TestCommitCheckRejectsNATMatchAddress7145 is the OVER-REACH guard on the
+// other side: tolerating the value at ingress must NOT make the operator's next
+// commit accept it. Tolerant ingest and a strict commit are the two halves of
+// #1960, and a "fix" that satisfied the first by weakening the second would
+// delete this change's whole point.
+//
+// It runs against the store's REAL commit-check entry point, not the compiler,
+// because that is where an operator meets the gate.
+//
+// MUTATION NOTE, measured rather than assumed: reverting the TOLERANCE
+// (lenientNATMatchAddressLiterals -> false) turns this test RED at its SyncApply
+// PRECONDITION, not at its CommitCheck assertion. Read a failure here by WHICH
+// line failed — a red at the precondition means the fixture could not be set
+// up, not that a relaxed commit gate was caught.
+func TestCommitCheckRejectsNATMatchAddress7145(t *testing.T) {
+	s := newTestStoreAt(t, filepath.Join(t.TempDir(), "config"))
+	if _, err := s.SyncApply(natMatchPersisted7145, nil); err != nil {
+		t.Fatalf("precondition: the ingress must tolerate the stanza: %v", err)
+	}
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	_, err := s.CommitCheck()
+	if err == nil {
+		t.Fatal("CommitCheck ACCEPTED a malformed NAT match prefix after a tolerated ingest " +
+			"— the strict commit gate must stay strict; tolerating it at ingress is a " +
+			"boot-safety concession, not a relaxation of the gate (#7145 / #1960)")
+	}
+	if !strings.Contains(err.Error(), natMatchBad7145) {
+		t.Errorf("CommitCheck must reject for the #7145 reason and NAME the value, not fail "+
+			"for some unrelated one: %v", err)
+	}
+}


### PR DESCRIPTION
## The asymmetry, measured first

At `bf10c6b7c`, over the issue's own base config, with **both** `999.1.1.1/24`
and `zznotanaddr` — so this is not a near-miss in the CIDR grammar, four of the
six (NAT kind x match leaf) slots simply had **no parse gate at all**:

| kind | `match source-address` | `match destination-address` |
|---|---|---|
| `security nat source` | ACCEPTED -> **rejected** | ACCEPTED -> **rejected** |
| `security nat destination` | ACCEPTED -> **rejected** | rejected (#3228) |
| `security nat static` | ACCEPTED -> **rejected** | rejected (#3206) |

The same operator typo was refused in one slot of a rule and accepted in the
sibling slot of the **same rule**.

## Why it is not inert

The Go snapshot builders copy the configured list to the wire **verbatim**, and
each Rust consumer drops per entry what it cannot parse while recording only a
bounded NAT parse-error counter (#4718):

| kind | Rust parse site |
|---|---|
| source NAT | `parse_match_prefix` (`nat/source.rs`) |
| destination NAT | `DnatTable::from_snapshots` (`nat/destination.rs`) |
| static NAT | `SourceConstraint::from_list` (`nat/static_nat.rs`) |

All three key `*_constrained` on the **snapshot list being non-empty**, not on
how many entries parsed. A malformed entry beside good ones therefore NARROWS
the rule below what was authored; an all-malformed list leaves the rule
constrained with zero prefixes — it matches NOTHING and silently stops
translating. The fail-closed runtime posture is right and is preserved; the
defect was that the operator boundary was silent about it.

## The fix

`validateNATMatchAddressLiteralsStrict` (new file) walks the four
previously-ungated slots and hard-rejects at strict commit / commit-check,
naming NAT kind, rule-set, rule, match leaf, and value. The two already-gated
slots keep their own older gates and appear in the test table as **controls**,
so the census is complete rather than a list of what this PR touched.

**Scope is the literal leaves only.** `match source-address-name` /
`destination-address-name` are address-book references whose unresolvable raw
token is appended to the *same* wire list on purpose (#2416) as the fail-closed
backstop; a gate walking the post-resolution list would reject that backstop.

**Predicate choice is the load-bearing decision.** `natMatchPrefixParses` is
`net.ParseCIDR` then `net.ParseIP` — the exact Rust pair, **not** the `netip`
equivalents. `netip.ParsePrefix` is *stricter* than Rust on the mask text: it
rejects a zero-padded prefix length (`1.2.3.4/024`) that Rust's `u8::from_str`
reads as 24 and installs. Refusing a value the dataplane installs is the one
direction a widened validator must never take. Mutation cell 3 pins this.

## No-brick (#1960)

That value committed clean on every build before this, so appliances carrying
one exist by construction. The tolerant load / peer-sync path warns instead of
failing (`lenientNATMatchAddressLiterals`), and **deliberately keeps the value
in the compiled config**: dropping it Go-side would empty an all-malformed list,
clear the Rust `*_constrained` flag and collapse the rule to MATCH-ANY — a
fail-OPEN regression strictly worse than the bug being fixed.

Verified through the **real** ingresses, not just the compiler:
`Store.Load` (disk boot, tree written straight to `active.json` with the
committed marker — the shape an older binary persisted) and `Store.SyncApply`
(HA peer sync). Both boot, both warn, both keep the good prefix *and* the
malformed one. A `CommitCheck` over-reach guard pins that tolerating at ingress
did not relax the commit gate.

## Slot-escape registry

The four sites are removed from `slotEscapeUngated` — the #7143 scout registry
whose "leaves that reject nothing" inventory is where this surfaced. An entry
there means "this gate has nothing to compare", which is no longer true: those
rows now carry a real verdict and run the full slot-1 escape comparison
(bracket, repeated, slot-2, hierarchical round-trip) instead of skipping.

## Known residuals — measured, deliberately not folded in

A different value class from the issue's malformed CIDR, each inside an **older**
gate; folding them in would change that gate's contract inside a PR about four
ungated slots. Both are recorded in the docs where an operator reads them:

- **#7215** — destination-NAT `match destination-address` still accepts an
  out-of-range mask (`10.0.0.0/33`); its #3228 gate strips the mask and parses
  only the address part, while its own builder uses `net.ParseCIDR` and skips
  the entry.
- **#7216** — static-NAT `match destination-address` still accepts a quoted
  empty value, where an empty slot carries the deliberate #6673 "authored blank
  selection" meaning.

## Validation

`go test ./... -count=1`: the only failure was `pkg/ddns`
`TestSurfaceARealBackendWithdrawOnAddressLoss`, the known #7009 UDP/TCP
port-space flake — green in isolation, exit 0. `go vet` exit 0.

Mutation matrix, **one mutation per cell**, exit codes read from `$?` (never
through a pipe), `go vet` clean on every cell so no red is a build break:

| # | mutation | result |
|---|---|---|
| 1 | remove the strict gate's call site | exit 1, RED at the "committed CLEAN" assertion on all 8 #7145 cells; **both control cells stayed GREEN** |
| 2 | drop `lenientNATMatchAddressLiterals` from `lenientCompileOpts` | exit 1 at "Store.Load REFUSED" / "SyncApply REJECTED" and at the compiler-level tolerance assertion. The `CommitCheck` guard reds at its **precondition**, not its assertion — its own comment records that |
| 3 | swap the predicate to `netip` | exit 1 on exactly the `1.2.3.4/024` cells of the four gated slots; every other value and both control slots green |
| 4 | make the tolerant path DROP instead of KEEP | exit 1 at the KEEP assertion in both store ingresses, over-reach guard green — the KEEP assertion is not vacuous |

## Dataplane reach

Go-only: `pkg/config` plus one `pkg/configstore` test. Nothing touches
`userspace-dp/`, `userspace-xdp/`, the shim `.o`, or the wire protocol — **no
cluster smoke is owed**.

Closes #7145
