### PR TITLE
harden all ten live ps-review-042 cohort rows (#5250)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -98242,3 +98242,32 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: userspace-xdp/src/lib.rs, pkg/dataplane/userspace_xdp_bpfel.o,
   pkg/dataplane/userspace_xdp_manifest.json,
   docs/userspace-dataplane-architecture.md, _Log.md
+
+- **Timestamp**: 2026-08-21
+- **Action**: #5250 — sweep the ps-review-042 cohort row by row and fix all ten
+  live items. Each row was re-verified individually against `origin/master`
+  a829e7746 before any code was written; all ten were still live, so the
+  cohort's own "10 of 21" tally held. Ten commits, one per row, each with a
+  test that reds on that row's revert:
+  A9 F3 routeMaskCache Close; A9 F4 within-clause order-independent trigger-on
+  re-arm (a REAL order-dependent defect, not the semantics question the row
+  described); A6-b2 F1 neighbor callback outside the Manager lock; A6-b2 F3 NAT
+  app port ranges without the per-port slice; A7-b1 F1 ethtool -c scanner bound
+  + Err() check; A7-b1 F4 abortable failover commit-ready wait + captured VRRP
+  debounce refs; A7-b2 F2 RX-queue enumeration error distinguished from zero;
+  A8-b2 F3 session totals clamped; A3-b2 F3 host-inbound fabric lifeline
+  narrowed from the `fab` PREFIX to `fab<N>`; A3-b3 F-03 expandAppSet nil guard.
+  Validation: `go build ./...`, `go vet ./pkg/...`, `go test -count=1` over the
+  full Go tree, plus a per-row revert-mutation matrix (one mutation per run).
+  Zero Rust files touched, so the cargo leg is unaffected. `pkg/daemon/
+  daemon_ha.go` is HA/failover code — `make test-failover` is OWED and was not
+  run by this lane.
+- **File(s)**: pkg/config/lifeline.go, pkg/config/predefined.go,
+  pkg/grpcapi/server_sessions.go, pkg/grpcapi/server_helpers.go,
+  pkg/grpcapi/server_nat.go, pkg/dataplane/userspace/manager_neighbor.go,
+  pkg/dataplane/userspace/nat.go, pkg/dataplane/userspace/nat_source.go,
+  pkg/dataplane/userspace/nat_destination.go, pkg/daemon/coalescence.go,
+  pkg/daemon/rss_indirection.go, pkg/daemon/daemon_ha.go,
+  pkg/flowexport/routemask.go, pkg/flowexport/netflow.go,
+  pkg/flowexport/ipfix.go, pkg/eventengine/engine.go, plus the ten new
+  `*_5250_test.go` files and the docs listed in each commit.

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2583,7 +2583,7 @@ The two spellings disagree — exactly what splitting the packed line exists to
 prevent. It is not fixed, because the stolen token must sit in entry-NAME
 position and no legal Junos interface name or IP address collides with a
 registered keyword (`ge-*`/`xe-*`/`et-*`, `reth*`, `fxp*`, `em*`, `lo0`, `st0`,
-`ae*`, `fab*`, `irb`, `vlan`), so it is unreachable from a real config rather
+`ae*`, `fab<N>`, `irb`, `vlan`), so it is unreachable from a real config rather
 than merely unlikely. There is deliberately no test pinning the divergence —
 that would assert the wrong answer is correct — and none asserting "keyword is
 not an interface name" either, because the project has no canonical
@@ -3247,7 +3247,7 @@ address OR VRRP VIP — is host-inbound-reachable from more than one **distinct
 effective host-inbound token set**. It keys on *differing* sets (via the shared
 `config.CanonicalHostInboundTokenSig`), NOT merely ">1 zone", so a deliberate
 duplicate with **identical** service sets across its zones is allowed (no false
-positive), and management/cluster-control lifeline interfaces (fxp0 / em0 / fab*)
+positive), and management/cluster-control lifeline interfaces (fxp0 / em0 / fab<N>)
 are excluded. Lenient downgrade to a `cfg.Warnings` entry on the tolerant load /
 peer-sync path (`lenientDuplicateHostLocalAddress`, #1960 no-brick); the runtime
 `dpuserspace.AmbiguousHostInboundAddresses` reporter + the

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -312,7 +312,7 @@ the source recorded is a strict improvement and is expected.
 |---|---|---|
 | `tcp-encap` | IPsec-in-TCP (Juniper Secure Connect) | Transport is TCP. **Not sourced:** a default listening port. The closest Juniper evidence is the sample output of `show security tcp-encap connection detail`, whose "Local Gateway" (the SRX side) is `10.4.0.2:443` in one session and `10.4.0.2:500` in another — the vendor's own example shows **two** listening ports, and its Output Fields table never documents the port component. `[edit security tcp-encap]` exposes only `profile`/`ssl-profile`/`log`/`traceoptions`; `services ssl termination profile` has no port option and no default either (an earlier revision inferred the port from that profile — withdrawn). TCP/443 is *convention*: the NCP Path Finder **client** guide describes falling back to "TCP encapsulation of IPsec with SSL header (via port 443)", but that is the client vendor describing client behaviour, and Juniper's own Secure Connect guide never mentions 443. A sample plus a third-party convention is not a default. **Operator note:** TCP/443 is already in the `all` union via `https`/`webapi-ssl`, so the observable gap is the non-443 case (e.g. the TCP/500 the same sample shows). |
 | `appqoe` | AppQoE ACTIVE probe | **Not sourced:** transport or port. Juniper describes the active probe only as *"custom packets are sent between spoke and hub points on all the multiple routes"*; `active-probe-params` exposes probe-count, probe-interval, data-fill, data-size, dscp-code-points, enable-sla-export, per-packet-loss-timeout, forwarding-class and loss-priority — no port, no transport — and `show … sla active-probe-statistics` reports addresses and timings with no port column. **Decoy:** udp/36000 is the only port on the AppQoE page and belongs to the *passive* probe; the Limitations section says *"An input firewall filter is required at the non-WAN interfaces to discard UDP packets with UDP destination port 36000."* That is TRANSIT traffic Juniper tells operators to DISCARD — admitting it host-inbound would be doubly wrong. |
-| `high-availability` | Multinode HA (MNHA) inter-node control over the ICL | **Juniper explicitly acknowledges a protocol and port exist and declines to publish them.** The MNHA preparation guidance says the ICL *"path uses (whether the ICL is encrypted or not) IP address, protocol, and port details. You must ensure that this communication is allowed between the nodes if any firewall or other inspection is in place."* That is the entire published statement — no numbers appear anywhere. A sweep of the full Junos High Availability User Guide found 12 config examples using this token and not one port; every TCP/UDP port in the book belongs to the generic BFD chapters, not MNHA. `show chassis high-availability information`/`peer-info` carry peer IP, interface, routing-instance and encryption state — no port field. **Do not attribute udp/500+4500 or ESP here:** those belong to the *optional* `ha-link-encryption` and are admitted through the separate `ike` token Juniper's own examples configure alongside this one. *Mitigation:* xpf does not implement MNHA. Its own inter-node HA control plane (heartbeat on the cluster control interface, session/config sync over the fabric) rides LIFELINE interfaces — `fxp0`, `em0`, `fab*`, plus any configured `control-interface` / `fabric-interface` (`HostInboundLifelineSet`, #3277) — which `BuildZoneHostInboundViews` removes before generating host-inbound deny sets. So an unported `high-availability` cannot break xpf's own HA. **Stated plainly: xpf does not implement the MNHA ICL, so naming this token is a no-op for xpf** — it governs a feature xpf does not have. It bites only an operator porting a Junos MNHA config onto a non-lifeline zone, who gets the commit advisory. |
+| `high-availability` | Multinode HA (MNHA) inter-node control over the ICL | **Juniper explicitly acknowledges a protocol and port exist and declines to publish them.** The MNHA preparation guidance says the ICL *"path uses (whether the ICL is encrypted or not) IP address, protocol, and port details. You must ensure that this communication is allowed between the nodes if any firewall or other inspection is in place."* That is the entire published statement — no numbers appear anywhere. A sweep of the full Junos High Availability User Guide found 12 config examples using this token and not one port; every TCP/UDP port in the book belongs to the generic BFD chapters, not MNHA. `show chassis high-availability information`/`peer-info` carry peer IP, interface, routing-instance and encryption state — no port field. **Do not attribute udp/500+4500 or ESP here:** those belong to the *optional* `ha-link-encryption` and are admitted through the separate `ike` token Juniper's own examples configure alongside this one. *Mitigation:* xpf does not implement MNHA. Its own inter-node HA control plane (heartbeat on the cluster control interface, session/config sync over the fabric) rides LIFELINE interfaces — `fxp0`, `em0`, `fab<N>`, plus any configured `control-interface` / `fabric-interface` (`HostInboundLifelineSet`, #3277) — which `BuildZoneHostInboundViews` removes before generating host-inbound deny sets. So an unported `high-availability` cannot break xpf's own HA. **Stated plainly: xpf does not implement the MNHA ICL, so naming this token is a no-op for xpf** — it governs a feature xpf does not have. It bites only an operator porting a Junos MNHA config onto a non-lifeline zone, who gets the commit advisory. |
 
 #### The only escape is `any-service`
 
@@ -507,8 +507,15 @@ catch-all instead of short-circuiting on the established-accept. Properties:
   because still-permitted flows are kept. A service that stays configured is never
   flushed (no connection-reset regression).
 - **Lifeline-safe.** Only addresses in the covered default-deny set are eligible;
-  management / cluster-control lifelines (fxp0 / em0 / fab*) are excluded from the
-  host-inbound views, so their conntrack is never flushed. Addressed-but-unzoned
+  management / cluster-control lifelines (fxp0 / em0 / fab<N>) are excluded from the
+  host-inbound views, so their conntrack is never flushed. `fab<N>` throughout
+  this document means the literal `fab` followed by DIGITS — `fab0`, `fab1`,
+  `fab10` — and NOT a prefix: #5250 narrowed `HostInboundLifelineInterface`'s
+  unconditional fabric arm from `strings.HasPrefix(base, "fab")`, under which an
+  interface merely NAMED `fab-foo` or `fabric` bought a host-inbound deny
+  bypass. A fabric link under any other name must be DECLARED
+  (`fabric-interface` / `fabric1-interface` / `control-interface`) to be a
+  lifeline, which is the #3277 config-derived path. Addressed-but-unzoned
   addresses (#4420 HI-2) are covered with an empty admit set (fully denied except
   the global exemptions below).
 - **Global exemptions preserved.** ESP/AH (proto 50/51), ICMP ND/PMTUD/error, and
@@ -552,7 +559,7 @@ from `zone_host_inbound` and hit the `None => true` admit-all arm in
 (a management-plane fail-open on the exact tolerant-load / HA-sync path where nil
 zones arise). `None` now means only a genuinely unknown / global ingress zone
 (id 0, never in the table), which keeps the admit default; lifeline interfaces
-(fxp0/em0/fab*) never reach the AF_XDP classifier (#3682).
+(fxp0/em0/fab<N>) never reach the AF_XDP classifier (#3682).
 
 ## Deliberate narrowings & the one cross-surface divergence
 
@@ -618,7 +625,7 @@ same builder that drives the nft payload — so the signal describes the same
 address snapshot, not whether the later nft transaction succeeded. It reports a
 zone iff it has at least one **non-lifeline**
 interface assigned yet resolves no address; zones that are scoped, whose only
-interfaces are management/cluster-control lifelines (fxp0 / em0 / fab*), or that
+interfaces are management/cluster-control lifelines (fxp0 / em0 / fab<N>), or that
 have no interfaces are deliberately NOT reported (low-noise).
 
 Two observability surfaces consume it:
@@ -714,7 +721,7 @@ snapshot produces a zero-drop table shell:
   It carries **no per-service accept and no named counters** — it is strictly the
   real table with every service ACCEPT removed, so during the fence window even a
   `system-services all` zone is denied (maximally fail-closed). The address sets
-  are already lifeline-excluded (fxp0 / em0 / fab* and their addresses are
+  are already lifeline-excluded (fxp0 / em0 / fab<N> and their addresses are
   subtracted by `BuildZoneHostInboundViews` / `BuildUnzonedHostInboundAddrs`), so
   the fence can **never** strand management or break HA.
 - The requested apply still **fails** (`applyHostInboundFilter` returns the
@@ -730,9 +737,9 @@ snapshot produces a zero-drop table shell:
   management-only skip is now gated on the config-derived host-inbound LIFELINE
   set (`config.HostInboundLifelineSet` / `HostInboundLifelineInterface` — the SAME
   authority that lifeline-excludes these address sets), not the broad
-  management-VRF name class (fxp*/fab*/em*). So a zoned NON-lifeline DHCP interface
+  management-VRF name class (fxp*/fab<N>/em*). So a zoned NON-lifeline DHCP interface
   (a standalone `fxp1`) is classified for the full recompile that builds its
-  address-scoped fence; only a true lifeline (fxp0/em0/fab*/configured
+  address-scoped fence; only a true lifeline (fxp0/em0/fab<N>/configured
   control-interface) keeps the management-only fast path. The skip decision and
   this fence now share one classifier and cannot drift.
 - If the fence **also** fails to load (nft itself broken), both errors are joined
@@ -1153,7 +1160,7 @@ This is caught fail-closed at commit and surfaced at runtime:
   zones with different `host-inbound-traffic`, or one zone with differing #3362
   per-interface overrides) is rejected. Covers IPv4 (H01), IPv6 (M02), VRRP VIPs
   (M03), and the cross-zone subset of same-address-across-routing-instances
-  (M04). Management / cluster-control lifeline interfaces (fxp0 / em0 / fab*) are
+  (M04). Management / cluster-control lifeline interfaces (fxp0 / em0 / fab<N>) are
   excluded, mirroring the deny scoping. On the tolerant load / peer-sync path the
   rejection is downgraded to a `cfg.Warnings` entry (`lenientDuplicateHostLocalAddress`)
   so an already-persisted or peer-synced config an older binary accepted still
@@ -1249,7 +1256,7 @@ helper never sees it, so a helper crash cannot lock management out).
 - **Ingress `iifname` scope, never `daddr` as the ZONE scope.** The DROP is scoped
   by the from-zone's kernel netdev names
   (`pkg/dataplane/userspace/BuildJunosHostPrograms`), excluding lifelines
-  (fxp0/em0/fab*) — a daddr-derived zone scope would both under- and over-deny
+  (fxp0/em0/fab<N>) — a daddr-derived zone scope would both under- and over-deny
   across zones. A global-any term renders per ingress zone with that zone's
   netdevs, never unscoped. An EXPLICIT `match destination-address` adds a
   narrowing `daddr` predicate ON TOP of that iifname scope (see the destination

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -427,13 +427,13 @@ From zone: guest, To zone: lan
     enforcement surfaces flip together: the kernel-nft chain scopes a catch-all
     DROP to the zone's addresses, and the Rust AF_XDP classifier inserts the
     zone with an empty admission set. The lifeline interfaces (fxp0 / em0 /
-    fab*) are excluded from the deny address sets and the global ICMP / IPv6 ND
+    fab<N>) are excluded from the deny address sets and the global ICMP / IPv6 ND
     / PMTUD / established-session accepts precede every deny, so the default-deny
     cannot strand management or break HA. (All shipped reference configs already
     declare a `host-inbound-traffic` stanza per zone, so they are unaffected.)
   - **Lifeline-exemption visibility (#3682):** the lifeline exclusion above is
     an IMPLICIT policy exception — a zone-assigned interface whose base name is a
-    lifeline (`fxp0` / `em0` / `fab*`, plus a configured chassis-cluster
+    lifeline (`fxp0` / `em0` / `fab<N>`, plus a configured chassis-cluster
     `control-interface` / `fabric-interface` / secondary fabric) is EXCLUDED from
     that zone's host-inbound deny scoping and always admits host-bound traffic
     regardless of the zone's admission set. Before #3682 no rendered zone view
@@ -448,10 +448,16 @@ From zone: guest, To zone: lan
     (`pkg/config/lifeline.go`), shared by the dataplane deny-scoping path and the
     display presenter so enforcement and audit can never drift. This is a
     VISIBILITY change only — the exemption semantics are unchanged. (Design
-    follow-up: the `em0`/`fab*` match is a base-name PREFIX, so a broader
-    interface literally named `fab-foo`, or a standalone config that merely names
-    an interface `em0`/`fabX` with no configured cluster role, is exempted too;
-    whether this should be an EXACT / role-gated match is tracked on #3682.)
+    follow-up, ANSWERED in #5250: the unconditional fabric match was a base-name
+    PREFIX, so an interface literally named `fab-foo` / `fabric` / `fabX` was
+    exempted with no configured cluster role. It is now `fab` followed by
+    DIGITS — `fab0`, `fab1`, `fab<N>` — which is the only shape the daemon
+    creates (`CleanupFabricIPVLANs`) or the compiler derives. A fabric interface
+    under any other name must be DECLARED as `fabric-interface` /
+    `fabric1-interface` / `control-interface` to stay exempt, which is the #3277
+    config-derived path and is unchanged. The `em0` arm was already EXACT and is
+    unchanged, so a standalone config that names an interface `em0` still gets
+    the historical exception.)
   - **Host-inbound deny accounting (#3326):** a host-bound packet dropped by
     the `host-inbound-traffic` admission gate (a service/protocol not in the
     ingress zone's set) now increments the host-inbound deny counter, surfaced
@@ -703,7 +709,7 @@ From zone: guest, To zone: lan
     Resolving the VIPs from config scopes the deny identically on both nodes
     regardless of mastership; on the master the live address dedups so the rule
     set is byte-identical. Management/cluster-control lifeline interfaces
-    (fxp0/em0/fab*) are still excluded — a VIP on em0 is never scoped — and
+    (fxp0/em0/fab<N>) are still excluded — a VIP on em0 is never scoped — and
     standalone (no-VRRP) zones are unchanged.
   - **Per-interface host-inbound override (#3362):** Junos models
     `host-inbound-traffic` at BOTH the zone level (`set security zones
@@ -757,15 +763,15 @@ From zone: guest, To zone: lan
     (`HostInboundView.Render`), it propagates to all six #3654 surfaces.
   - **Lifeline set derived from cluster config (#3277):** the lifeline
     interfaces excluded from host-inbound deny scoping are no longer a fixed
-    fxp0/em0/fab* hardcode. The set is now `fxp0` (always-mgmt) UNION the
+    fxp0/em0/fab<N> hardcode. The set is now `fxp0` (always-mgmt) UNION the
     configured chassis-cluster `control-interface` and `fabric-interface` /
     `fabric1-interface` names, UNION the backward-compatible defaults em0 and
-    fab*. So a deployment whose control/heartbeat link rides a non-default name
+    fab<N>. So a deployment whose control/heartbeat link rides a non-default name
     (e.g. `set chassis cluster control-interface fxp1`) has that interface
     correctly excluded — its address is never subjected to a host-inbound deny,
     closing a latent HA split-brain (heartbeat drop) gap that would surface once
     the control zone's host-inbound set is scoped rather than full-admit.
-    Canonical em0/fab*-named configs are byte-identical (the defaults still
+    Canonical em0/fab<N>-named configs are byte-identical (the defaults still
     match unconditionally); a standalone config with no chassis-cluster stanza
     keeps fxp0 as its only lifeline (#1960).
   - **Lifeline fail-safe:** enforcement is strictly MATCH-DRIVEN. If NO
@@ -1057,7 +1063,7 @@ DENIES — a false-admission diagnosis. Two changes remove it:
   interface's EFFECTIVE view (zone-level ∪ that interface's override), so the
   reported admission is that interface's TRUE posture (admit vs deny), not a
   zone-wide fold. The ref must name an interface assigned to `from-zone`; an
-  unknown, zone-mismatched, or management/cluster lifeline (fxp0/em0/fab*) ref is
+  unknown, zone-mismatched, or management/cluster lifeline (fxp0/em0/fab<N>) ref is
   rejected fail-closed (the lifeline is served unconditionally, so a
   per-interface verdict would itself be false). Example: `show security
   match-policies from-zone trust to-zone junos-host protocol tcp destination-port

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -5,11 +5,11 @@
 [REFACTOR]   2778  pkg/config/compiler_system.go
 [REFACTOR]   2714  userspace-dp/src/nat/allocator.rs
 [REFACTOR]   2559  userspace-dp/src/nat/source.rs
+[REFACTOR]   2498  pkg/policymatch/policymatch.go
 [REFACTOR]   2490  userspace-dp/src/afxdp/worker/loop_body/mod.rs
-[REFACTOR]   2462  pkg/policymatch/policymatch.go
+[REFACTOR]   2397  pkg/daemon/daemon_system.go
 [REFACTOR]   2373  pkg/config/compiler_opts.go
 [REFACTOR]   2358  pkg/daemon/daemon_nft.go
-[REFACTOR]   2310  pkg/daemon/daemon_system.go
 [REFACTOR]   2310  userspace-dp/src/afxdp/neighbor.rs
 [REFACTOR]   2288  pkg/ddns/surface_a.go
 [REFACTOR]   2258  userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -20,11 +20,11 @@
 [REFACTOR]   2056  userspace-dp/src/afxdp/frame/inspect.rs
 [REFACTOR]   2046  pkg/dataplane/userspace/maps_sync.go
 [REFACTOR]   2034  userspace-dp/src/afxdp/frame/mod.rs
+[REFACTOR]   2005  pkg/daemon/daemon_ha.go
 [WATCH]      1995  pkg/dataplane/compiler.go
-[WATCH]      1990  pkg/grpcapi/server_sessions.go
+[WATCH]      1994  pkg/grpcapi/server_sessions.go
 [WATCH]      1953  pkg/api/metrics_userspace.go
 [WATCH]      1932  pkg/ddns/manager.go
-[WATCH]      1907  pkg/daemon/daemon_ha.go
 [WATCH]      1896  pkg/config/compiler_validate_warn.go
 [WATCH]      1850  userspace-dp/src/afxdp/types/cos.rs
 [WATCH]      1831  userspace-dp/src/afxdp/worker/mod.rs
@@ -43,7 +43,7 @@
 [WATCH]      1586  userspace-dp/src/afxdp/tx/cos_classify.rs
 [WATCH]      1581  pkg/routing/rules.go
 [WATCH]      1547  userspace-dp/src/afxdp/session_glue/mod.rs
+[WATCH]      1539  pkg/daemon/daemon_ha_sync.go
 [WATCH]      1539  pkg/dataplane/userspace/eventstream.go
-[WATCH]      1538  pkg/daemon/daemon_ha_sync.go
-[WATCH]      1512  userspace-xdp/src/lib.rs
+[WATCH]      1531  userspace-xdp/src/lib.rs
 [WATCH]      1502  pkg/config/types_security.go

--- a/docs/userspace-dnat-plan.md
+++ b/docs/userspace-dnat-plan.md
@@ -672,8 +672,27 @@ destination-port range the same way instead of expanding it:
   was already bounded — it parses endpoints with `ParseUint(..,16)`.)
 
 - **Builder compaction (`buildDestinationNATSnapshotsWithFeeds`).** Each term's
-  valid ports are coalesced with `coalescePortRanges` into inclusive `[Low,High]`
-  wire ranges. A single port (`Low==High`, including the `[0,0]` wildcard) keeps
+  valid ports are coalesced into inclusive `[Low,High]` wire ranges.
+
+  **#5250 (A6-b2 F3) — the intermediate per-port slice is gone.** The compaction
+  above bounded what reaches the WIRE, but the builder still built the expanded
+  `[]int` first: three sites read `coalescePortRanges(appPortsFromSpec(spec))`
+  and the DNAT `appTerm` carried the expanded slice all the way into the emit
+  loop, so `destination-port 1-65535` allocated ~65k ints per application and
+  again per application-set member — a commit-time allocation spike on the same
+  goroutine that services the control socket. `appPortRangesFromSpec` (nat.go)
+  emits the range directly: a port spec is a single value or ONE contiguous
+  range, so its coalesced form is always zero or one wire range and there is
+  nothing to merge. `appTerm` now carries `dstRanges []NatPortRangeWire` plus
+  `dstPortsPresent bool` — the latter preserving the one other thing the slice
+  was read for, whether the source list was non-empty BEFORE coalescing, which
+  the #3726/#3857 fail-closed test needs and a coalesced list cannot recover (a
+  spec of `"0"` is present but coalesces away). `appPortsFromSpec` is retained
+  and now shares `appPortSpecBounds` with the range emitter so the two cannot
+  drift; `TestAppPortRangesFromSpecMatchesCoalescedSlice` asserts they AGREE
+  across a spec corpus rather than checking a hand-written expectation table,
+  and `TestAppPortRangesFromSpecDoesNotMaterializeTheRange` reds on an
+  allocation count if the composition comes back. A single port (`Low==High`, including the `[0,0]` wildcard) keeps
   the exact-port `DnatKey` O(1) fast path (`destination_port` set,
   `match_destination_ports` empty — unchanged for the common single-port and
   IP-only rules). A multi-port range is emitted as ONE wildcard-port entry

--- a/pkg/config/expand_appset_nil_5250_test.go
+++ b/pkg/config/expand_appset_nil_5250_test.go
@@ -1,0 +1,31 @@
+package config
+
+import "testing"
+
+// #5250 (A3-b3 F-03). expandAppSet dereferenced its *ApplicationsConfig without
+// a nil check (apps.ApplicationSets, and memberIsNestedSet's two derefs one
+// level down), so ExpandApplicationSet(name, nil) panicked. No production
+// caller passes nil today — every one passes &cfg.Applications, the address of
+// a struct field — so this is defensive hardening in the shape of the #5179 /
+// #5671 present-but-nil VALUE guards beside it, and it goes RED with a panic,
+// not a wrong answer, if the guard is removed.
+func TestExpandApplicationSetNilConfigDoesNotPanic(t *testing.T) {
+	// A predefined bundle needs no user config at all, so a nil
+	// ApplicationsConfig must still expand it rather than erroring.
+	const predefined = "junos-cifs"
+	if _, ok := PredefinedApplicationSets[predefined]; !ok {
+		t.Fatalf("fixture assumes %q is a predefined application-set", predefined)
+	}
+	got, err := ExpandApplicationSet(predefined, nil)
+	if err != nil {
+		t.Fatalf("ExpandApplicationSet(%q, nil) error = %v, want the predefined expansion", predefined, err)
+	}
+	if len(got) == 0 {
+		t.Fatalf("ExpandApplicationSet(%q, nil) expanded to nothing", predefined)
+	}
+
+	// An unknown name is still a deterministic not-found error, not a panic.
+	if _, err := ExpandApplicationSet("no-such-set-anywhere", nil); err == nil {
+		t.Error("ExpandApplicationSet on an unknown name with a nil config must error")
+	}
+}

--- a/pkg/config/lifeline.go
+++ b/pkg/config/lifeline.go
@@ -36,12 +36,15 @@ func LifelineBaseName(name string) string {
 //     a configured `control-interface fxp1` SUBJECT to host-inbound deny scoping
 //     -> potential heartbeat drop -> HA split-brain.
 //
-// em0 (the canonical cluster-control default name) and the fabric prefix fab*
-// stay matched unconditionally in HostInboundLifelineInterface so the canonical
-// default-named configs remain byte-identical (#3070/#3172/#3224 behavior is
-// preserved). A standalone config (no chassis-cluster stanza) contributes no
-// extra names here, so its only lifeline is fxp0 (em0/fab* are no-ops because
-// such interfaces are not present) — #1960.
+// em0 (the canonical cluster-control default name) and the fabric device names
+// fab<N> stay matched unconditionally in HostInboundLifelineInterface so the
+// canonical default-named configs remain byte-identical (#3070/#3172/#3224
+// behavior is preserved). #5250 narrowed that second arm from the `fab` PREFIX
+// to `fab` + digits; a fabric interface under any other name must be DECLARED
+// (`fabric-interface` / `fabric1-interface`) to reach this set, which is the
+// #3277 path and is unaffected. A standalone config (no chassis-cluster stanza)
+// contributes no extra names here, so its only lifeline is fxp0 (em0/fab<N> are
+// no-ops because such interfaces are not present) — #1960.
 func HostInboundLifelineSet(cfg *Config) map[string]bool {
 	set := map[string]bool{"fxp0": true}
 	if cfg != nil && cfg.Chassis.Cluster != nil {
@@ -64,13 +67,23 @@ func HostInboundLifelineSet(cfg *Config) map[string]bool {
 // traffic on these would strand management or break HA. The base name (before
 // the unit suffix) is matched so "fxp0.0" / "em0.0" are caught too.
 //
-// #3682 design note (follow-up): the em0/fab* match is base-name-prefix based,
-// so a broader interface literally named "fab-foo" would also be exempted, and
-// a standalone config that merely happens to name an interface em0/fabX gets a
-// silent exception with no configured management/cluster role. Whether this
-// should be an EXACT / role-gated match rather than a prefix bypass is tracked
-// as a design question on the issue; #3682 changes VISIBILITY only, not the
-// matching semantics.
+// #5250 (A3-b2 F3): the unconditional fabric match is EXACT-SHAPED, not a bare
+// prefix. `strings.HasPrefix(base, "fab")` admitted every name that merely
+// STARTS with "fab" — "fab-foo", "fabric-guest", "fabX" — and admission here is
+// not cosmetic: junosHostNonLifelineRefs (junos_host_deny.go:308) and
+// JunosHostZoneIngressNetdevs (:1147) both SKIP a lifeline, so a host-inbound
+// `deny` policy naming such an interface produced no kernel rule at all. The
+// only fabric devices the daemon ever creates are `fab0` and `fab1`
+// (CleanupFabricIPVLANs, pkg/daemon/daemon_ha_fabric.go:153), and the config
+// form is an interface literally named `fab<N>` carrying `fabric-options
+// member-interfaces` (compiler_derivations.go:131), so `fab` + digits is the
+// whole legitimate population. Anything else is now an ordinary interface and
+// is subject to host-inbound deny like any other.
+//
+// The #3682 design note this replaces recorded the over-broad prefix as an open
+// design question; it is answered here rather than left open. The em0 arm was
+// already exact and is unchanged — a standalone config that names an interface
+// em0 still gets the historical exception (#3070/#3172/#3224 byte-identical).
 func HostInboundLifelineInterface(name string, lifelines map[string]bool) bool {
 	base := LifelineBaseName(name)
 	if base == "" {
@@ -79,5 +92,23 @@ func HostInboundLifelineInterface(name string, lifelines map[string]bool) bool {
 	if lifelines[base] {
 		return true
 	}
-	return base == "em0" || strings.HasPrefix(base, "fab")
+	return base == "em0" || isFabricDeviceName(base)
+}
+
+// isFabricDeviceName reports whether base is a fabric device name in the only
+// shape the daemon creates or the compiler derives: the literal "fab" followed
+// by one or more DIGITS and nothing else ("fab0", "fab1", "fab10"). Written as
+// a scan rather than a regexp so it stays allocation-free on the config-compile
+// path and cannot be defeated by a regexp missing its anchors.
+func isFabricDeviceName(base string) bool {
+	const prefix = "fab"
+	if len(base) <= len(prefix) || base[:len(prefix)] != prefix {
+		return false
+	}
+	for i := len(prefix); i < len(base); i++ {
+		if base[i] < '0' || base[i] > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/config/lifeline_fab_exact_5250_test.go
+++ b/pkg/config/lifeline_fab_exact_5250_test.go
@@ -1,0 +1,114 @@
+package config
+
+import "testing"
+
+// #5250 (A3-b2 F3). HostInboundLifelineInterface's unconditional fabric arm was
+// `strings.HasPrefix(base, "fab")`, so EVERY name starting with "fab" bought an
+// unconditional host-inbound deny exemption. That exemption is enforcement, not
+// display: junosHostNonLifelineRefs and JunosHostZoneIngressNetdevs both SKIP a
+// lifeline, so a `deny` policy toward junos-host on such an interface produced
+// no kernel rule at all.
+//
+// The only fabric devices that exist are fab0/fab1 (the daemon's IPVLANs, and
+// the config interfaces that carry `fabric-options member-interfaces`), so the
+// arm is now `fab` + digits. Anything else must be DECLARED as a
+// chassis-cluster fabric/control interface to stay exempt — the #3277 path,
+// which this test also pins.
+func TestLifelineFabricArmIsExactShaped(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want bool
+		why  string
+	}{
+		{"fab0", true, "the primary fabric IPVLAN"},
+		{"fab1", true, "the secondary fabric IPVLAN (#4038)"},
+		{"fab0.0", true, "unit suffix is stripped before matching"},
+		{"fab10", true, "a multi-digit fabric index is still a fabric device"},
+		{"em0", true, "the em0 arm is exact and unchanged"},
+
+		{"fab-foo", false, "a hyphenated name is not a fabric device"},
+		{"fabric", false, "an interface literally named fabric is an ordinary NIC"},
+		{"fabX", false, "a non-digit suffix is not a fabric index"},
+		{"fab", false, "bare `fab` names no device"},
+		{"fab0x", false, "trailing non-digits are not a fabric index"},
+		{"fab_0", false, "an underscore is not a digit"},
+		{"em1", false, "the em arm never was a prefix"},
+	} {
+		if got := HostInboundLifelineInterface(tc.name, nil); got != tc.want {
+			t.Errorf("HostInboundLifelineInterface(%q) = %v, want %v — %s",
+				tc.name, got, tc.want, tc.why)
+		}
+	}
+}
+
+// A fabric interface under a non-fab<N> name is still exempt when the config
+// DECLARES it, so narrowing the unconditional arm did not regress #3277.
+func TestLifelineDeclaredFabricNameStaysExempt(t *testing.T) {
+	cfg := &Config{}
+	cfg.Chassis.Cluster = &ClusterConfig{
+		ControlInterface: "fxp1",
+		FabricInterface:  "fab-foo",
+	}
+	set := HostInboundLifelineSet(cfg)
+
+	for _, name := range []string{"fab-foo", "fab-foo.0", "fxp1", "fxp1.0"} {
+		if !HostInboundLifelineInterface(name, set) {
+			t.Errorf("%q is a DECLARED chassis-cluster interface and must stay a lifeline", name)
+		}
+	}
+	// The same name with nothing declaring it is NOT a lifeline — that is the
+	// whole delta this fix introduces.
+	if HostInboundLifelineInterface("fab-foo", nil) {
+		t.Error("an UNDECLARED fab-foo must not be a lifeline")
+	}
+}
+
+// The production gate, not just the predicate: a zone whose interface is named
+// fab-guest and carries a junos-host deny must now produce a kernel ingress
+// netdev and a rendered policy. Before the fix the lifeline skip in
+// JunosHostZoneIngressNetdevs/junosHostNonLifelineRefs dropped it silently, so
+// the deny was accepted at commit and enforced nowhere.
+func TestUndeclaredFabNameIsHostInboundEnforced(t *testing.T) {
+	cfg := &Config{}
+	cfg.Interfaces.Interfaces = map[string]*InterfaceConfig{
+		"fab-guest": {Name: "fab-guest", Units: map[int]*InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.9.9.1/24"}},
+		}},
+		"fab0": {Name: "fab0", Units: map[int]*InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.99.0.1/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*ZoneConfig{
+		"guest": {Name: "guest", Interfaces: []string{"fab-guest.0"},
+			HostInboundTraffic: &HostInboundTraffic{SystemServices: []string{"ssh"}}},
+		"fabzone": {Name: "fabzone", Interfaces: []string{"fab0.0"},
+			HostInboundTraffic: &HostInboundTraffic{SystemServices: []string{"ssh"}}},
+	}
+	cfg.Security.AddressBook = &AddressBook{Addresses: map[string]*Address{
+		"bad-net": {Name: "bad-net", Value: "10.0.0.0/8"},
+	}}
+	cfg.Security.Policies = []*ZonePairPolicies{
+		{FromZone: "guest", ToZone: "junos-host", Policies: []*Policy{
+			jhDeny("block-guest", []string{"bad-net"}, []string{"any"})}},
+		{FromZone: "fabzone", ToZone: "junos-host", Policies: []*Policy{
+			jhDeny("block-fab", []string{"bad-net"}, []string{"any"})}},
+	}
+
+	nd := JunosHostZoneIngressNetdevs(cfg)
+	if got := nd["guest"]; len(got) == 0 {
+		t.Fatalf("zone guest on fab-guest.0 must contribute an ingress netdev; got %v — "+
+			"the HasPrefix(\"fab\") lifeline skip is back and the deny enforces nowhere", got)
+	}
+	// fab0 is a real fabric device and keeps its exemption.
+	if got := nd["fabzone"]; len(got) != 0 {
+		t.Errorf("zone fabzone on fab0.0 is a LIFELINE and must contribute no ingress netdev, got %v", got)
+	}
+
+	proj := BuildJunosHostDenyProjection(cfg)
+	if !proj.RenderedPolicyKeys[JunosHostZonePairPolicyKey("guest", "block-guest")] {
+		t.Error("the fab-guest deny must render a kernel rule")
+	}
+	if proj.RenderedPolicyKeys[JunosHostZonePairPolicyKey("fabzone", "block-fab")] {
+		t.Error("the fab0 deny targets a lifeline and must NOT render")
+	}
+}

--- a/pkg/config/predefined.go
+++ b/pkg/config/predefined.go
@@ -261,6 +261,22 @@ func expandAppSet(name string, apps *ApplicationsConfig, depth int) ([]string, e
 	if depth > 3 {
 		return nil, fmt.Errorf("application-set nesting too deep (max 3): %s", name)
 	}
+	// #5250 (A3-b3 F-03): a nil *ApplicationsConfig is substituted with an
+	// EMPTY one rather than rejected. Every production caller passes
+	// &cfg.Applications — the address of a struct field, never nil
+	// (policymatch.go:2021,2197, junos_host_deny.go:813, appid/runtime.go:95) —
+	// so this is defensive hardening, and the same shape as the #5179 /  #5671
+	// present-but-nil VALUE guards in lookupApplicationSet / memberIsNestedSet
+	// one level down. Substituting (rather than erroring) keeps the predefined
+	// Junos bundle table reachable, which is exactly what a caller with no
+	// user-defined applications wants; the three deref sites below
+	// (memberIsNestedSet's two, and lookupApplicationSet's) then see nil MAPS,
+	// which they already handle. Erroring here would instead make
+	// ExpandApplicationSet("junos-cifs", nil) fail on a name that needs no
+	// config at all.
+	if apps == nil {
+		apps = &ApplicationsConfig{}
+	}
 
 	as, ok := lookupApplicationSet(name, apps.ApplicationSets)
 	if !ok {

--- a/pkg/daemon/coalescence.go
+++ b/pkg/daemon/coalescence.go
@@ -189,6 +189,19 @@ func applyCoalescenceOne(iface string, adaptiveEnable bool, rxUsecs, txUsecs int
 // output at least resembled what we expect).
 func parseEthtoolCoalesce(out []byte) (rxUsecs, txUsecs int, adaptRX, adaptTX bool, parsed bool) {
 	scanner := bufio.NewScanner(bytes.NewReader(out))
+	// #5250 (A7-b1 F1): raise the line cap above bufio's 64 KiB default and, at
+	// the bottom, check Err(). A line longer than the cap makes Scan() stop
+	// early with ErrTooLong, which this parser could not see (it checked
+	// neither Err() nor how far it got) — so a truncated read looked like a
+	// complete one and returned parsed=true over a PREFIX of the real settings.
+	// The damage is not the diff-and-rewrite (an unparseable probe already
+	// writes blindly, so a rewrite happens either way) but what a
+	// falsely-complete parse is BELIEVED for: applyCoalescenceOne feeds it to
+	// capture.captureMlx5Coalesce as the operator's pre-xpfd baseline, which
+	// restore-on-disable later writes back to the NIC, and to the MIN1 drift
+	// comparison, which logs a drift warning against values that were never
+	// read.
+	scanner.Buffer(make([]byte, 0, 64*1024), ethtoolCoalesceMaxLine)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
@@ -228,8 +241,24 @@ func parseEthtoolCoalesce(out []byte) (rxUsecs, txUsecs int, adaptRX, adaptTX bo
 			parsed = true
 		}
 	}
+	if err := scanner.Err(); err != nil {
+		// A scan error means the remainder of the output was never examined, so
+		// the values gathered so far describe an unknown prefix of the real
+		// settings. Report NOT-parsed, which is the existing "probe
+		// unparseable" contract: applyCoalescenceOne logs it, writes the
+		// declared config once, and — the point of this arm — records NO
+		// pre-xpfd baseline and raises NO drift warning from values it never
+		// finished reading.
+		return 0, 0, false, false, false
+	}
 	return rxUsecs, txUsecs, adaptRX, adaptTX, parsed
 }
+
+// ethtoolCoalesceMaxLine bounds a single `ethtool -c` output line. Real lines
+// are a label and a small integer (tens of bytes); 1 MiB is far above any
+// plausible driver's output yet still a hard ceiling, so a wedged/garbage
+// driver string cannot make the scanner allocate without bound.
+const ethtoolCoalesceMaxLine = 1 << 20
 
 // parseLabelledInt returns the integer value that follows label in
 // line, or (0, false) if the line doesn't start with label. Tolerates
@@ -269,4 +298,3 @@ func coalescenceMatches(wantAdaptive bool, wantRX, wantTX int,
 	}
 	return true
 }
-

--- a/pkg/daemon/coalescence_scanner_5250_test.go
+++ b/pkg/daemon/coalescence_scanner_5250_test.go
@@ -1,0 +1,75 @@
+package daemon
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// #5250 (A7-b1 F1). parseEthtoolCoalesce scanned with a default bufio.Scanner
+// (64 KiB line cap) and checked neither scanner.Err() nor how far it got. A
+// single over-long line therefore stopped the scan silently and the function
+// still returned parsed=true over the PREFIX it had managed to read.
+//
+// That falsely-complete answer is not merely logged: applyCoalescenceOne feeds
+// it to capture.captureMlx5Coalesce as the operator's pre-xpfd baseline (which
+// restore-on-disable later writes back to the NIC) and to the MIN1 drift
+// comparison. So the harm is a corrupted restore baseline built from values the
+// parser never finished reading.
+func TestParseEthtoolCoalesceOverLongLineIsNotReportedAsParsed(t *testing.T) {
+	// A real prefix, then a line longer than the 1 MiB ceiling (and so also
+	// longer than bufio's 64 KiB default), then the field the parser would
+	// otherwise have picked up.
+	var b bytes.Buffer
+	b.WriteString("Coalesce parameters for ge-0-0-1:\n")
+	b.WriteString("Adaptive RX: off  TX: off\n")
+	b.WriteString("rx-usecs: 8\n")
+	b.WriteString("pkt-rate-low: " + strings.Repeat("9", (1<<20)+4096) + "\n")
+	b.WriteString("tx-usecs: 16\n")
+
+	rx, tx, adaptRX, adaptTX, parsed := parseEthtoolCoalesce(b.Bytes())
+	if parsed {
+		t.Fatalf("an over-long line must not report parsed=true; got rx=%d tx=%d "+
+			"adaptRX=%v adaptTX=%v — the scanner is unbuffered/unchecked again and "+
+			"a PREFIX of the settings is being taken for the whole", rx, tx, adaptRX, adaptTX)
+	}
+	if rx != 0 || tx != 0 || adaptRX || adaptTX {
+		t.Errorf("a not-parsed result must carry zero values, got rx=%d tx=%d adaptRX=%v adaptTX=%v",
+			rx, tx, adaptRX, adaptTX)
+	}
+}
+
+// The raised cap is what lets a long-but-plausible line still parse, so the
+// fix is a bound and not a new failure mode: the same output under the old
+// 64 KiB cap truncated, and now it is read to the end.
+func TestParseEthtoolCoalesceReadsPastTheOldDefaultCap(t *testing.T) {
+	var b bytes.Buffer
+	b.WriteString("Coalesce parameters for ge-0-0-1:\n")
+	b.WriteString("Adaptive RX: on  TX: on\n")
+	// 70 KiB of padding on a COMMENT-shaped line: over the old 64 KiB default,
+	// under the new 1 MiB ceiling.
+	b.WriteString("# " + strings.Repeat("x", 70*1024) + "\n")
+	b.WriteString("rx-usecs: 8\n")
+	b.WriteString("tx-usecs: 16\n")
+
+	rx, tx, adaptRX, adaptTX, parsed := parseEthtoolCoalesce(b.Bytes())
+	if !parsed {
+		t.Fatal("a 70 KiB line is under the raised cap and must parse")
+	}
+	if rx != 8 || tx != 16 || !adaptRX || !adaptTX {
+		t.Fatalf("rx=%d tx=%d adaptRX=%v adaptTX=%v, want 8/16/true/true", rx, tx, adaptRX, adaptTX)
+	}
+}
+
+// Ordinary output is unaffected — the fix must not change the common path.
+func TestParseEthtoolCoalesceNormalOutputUnchanged(t *testing.T) {
+	out := []byte("Coalesce parameters for ge-0-0-1:\n" +
+		"Adaptive RX: off  TX: off\n" +
+		"rx-usecs: 8\n" +
+		"tx-usecs: 16\n")
+	rx, tx, adaptRX, adaptTX, parsed := parseEthtoolCoalesce(out)
+	if !parsed || rx != 8 || tx != 16 || adaptRX || adaptTX {
+		t.Fatalf("parsed=%v rx=%d tx=%d adaptRX=%v adaptTX=%v, want true/8/16/false/false",
+			parsed, rx, tx, adaptRX, adaptTX)
+	}
+}

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -102,6 +102,17 @@ func recordRGActiveAppliedIfCurrentOrStable(s *rgStateMachine, tr rgTransition, 
 	return true
 }
 
+// #5250 (A7-b1 F4): every wait here is ABORTABLE on daemon stop. It used to
+// bare-`time.Sleep` up to localFailoverCommitTimeout (1s) plus the dwell delay
+// with no cancellation, so a `systemctl stop xpfd` landing mid-transfer held
+// shutdown for the rest of that window. The signal is d.applyCancelCtx(), the
+// DAEMON-STOP context (#2926) the archive timer also waits on — NOT d.daemonCtx,
+// which is context.Background in production and never cancelled. Taking it here
+// rather than threading a ctx through SetLocalTransferCommitReadyHook leaves
+// pkg/cluster untouched. A cancelled wait returns an ERROR, the fail-closed
+// direction: cluster.requestPeerFailover responds to non-nil by calling
+// abortRequestedPeerFailover and sending no commit, so the peer stays
+// un-promoted rather than committing a transfer this node can no longer verify.
 func (d *Daemon) waitLocalFailoverCommitReady(rgIDs []int) error {
 	if len(rgIDs) == 0 {
 		return nil
@@ -111,6 +122,26 @@ func (d *Daemon) waitLocalFailoverCommitReady(rgIDs []int) error {
 		timeout = time.Second
 	}
 	delay := d.localFailoverCommitDelay
+	stop := d.applyCancelCtx().Done()
+	// One timer, reset per wait, so a full 1 s of 10 ms polls does not allocate
+	// a hundred of them on the failover path.
+	timer := time.NewTimer(time.Hour)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	defer timer.Stop()
+	wait := func(dur time.Duration) error {
+		timer.Reset(dur)
+		select {
+		case <-stop:
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return fmt.Errorf("daemon stopping while waiting for local failover activation settle for redundancy groups %v", rgIDs)
+		case <-timer.C:
+			return nil
+		}
+	}
 	deadline := time.Now().Add(timeout)
 	dwelled := false
 	for {
@@ -127,7 +158,9 @@ func (d *Daemon) waitLocalFailoverCommitReady(rgIDs []int) error {
 		if ready {
 			if !dwelled && delay > 0 {
 				dwelled = true
-				time.Sleep(delay)
+				if err := wait(delay); err != nil {
+					return err
+				}
 				continue
 			}
 			return nil
@@ -135,7 +168,9 @@ func (d *Daemon) waitLocalFailoverCommitReady(rgIDs []int) error {
 		if time.Now().After(deadline) {
 			return fmt.Errorf("timed out waiting for local failover activation settle for redundancy groups %v", rgIDs)
 		}
-		time.Sleep(10 * time.Millisecond)
+		if err := wait(10 * time.Millisecond); err != nil {
+			return err
+		}
 	}
 }
 
@@ -524,13 +559,38 @@ func (d *Daemon) handleClusterEvent(ctx context.Context, ev cluster.ClusterEvent
 		if vrrpTimer != nil {
 			vrrpTimer.Stop()
 		}
+		// #5250 (A7-b1 F4): the debounce closure CAPTURES the managers it uses
+		// and checks the stop signal before touching them. It used to read
+		// d.store / d.cluster / d.vrrpMgr through the receiver at FIRE time,
+		// 500ms after arming, and the only thing stopping it is
+		// watchClusterEvents' deferred vrrpTimer.Stop() — which for an AfterFunc
+		// timer does not wait for a body that has already begun. So the
+		// last-armed update could run during or after the shutdown that stopped
+		// it, re-reading fields the teardown was tearing down.
+		//
+		// The stop signal is d.applyCancelCtx(), NOT this function's ctx: the
+		// watcher runs as watchClusterEvents(d.daemonCtx) and daemonCtx is
+		// context.Background() in production (see its field comment), so gating
+		// on ctx would be a branch that can never be taken. The channel is read
+		// on the watcher goroutine at ARM time so the field read cannot race
+		// the timer.
+		stopCh := d.applyCancelCtx().Done()
+		clusterRef, storeRef, vrrpRef := d.cluster, d.store, d.vrrpMgr
 		vrrpTimer = time.AfterFunc(500*time.Millisecond, func() {
-			if cfg := d.store.ActiveConfig(); cfg != nil {
-				localPri := d.cluster.LocalPriorities()
+			select {
+			case <-stopCh:
+				return
+			default:
+			}
+			if clusterRef == nil || storeRef == nil || vrrpRef == nil {
+				return
+			}
+			if cfg := storeRef.ActiveConfig(); cfg != nil {
+				localPri := clusterRef.LocalPriorities()
 				var all []*vrrp.Instance
 				all = append(all, vrrp.CollectInstances(cfg)...)
 				all = append(all, vrrp.CollectRethInstances(cfg, localPri)...)
-				if err := d.vrrpMgr.UpdateInstances(all); err != nil {
+				if err := vrrpRef.UpdateInstances(all); err != nil {
 					slog.Warn("cluster: failed to update VRRP instances", "err", err)
 				}
 			}

--- a/pkg/daemon/failover_commit_ready_cancel_5250_test.go
+++ b/pkg/daemon/failover_commit_ready_cancel_5250_test.go
@@ -1,0 +1,100 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #5250 (A7-b1 F4). waitLocalFailoverCommitReady polled with a bare
+// `time.Sleep(10 * time.Millisecond)` and no cancellation of any kind, so a
+// `systemctl stop xpfd` landing while a manual failover transfer was settling
+// held the shutdown for the remainder of localFailoverCommitTimeout (1s by
+// default) plus the dwell delay.
+//
+// The wait now selects on d.applyCancelCtx().Done() — the daemon's DAEMON-STOP
+// context, a child of the SIGTERM/SIGINT signal context (#2926), which is what
+// actually fires on shutdown (d.daemonCtx is context.Background() in production
+// and never cancelled). Reverting either wait to time.Sleep makes this test
+// RED at the deadline.
+func TestWaitLocalFailoverCommitReadyAbortsOnDaemonStop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	d := &Daemon{
+		cluster:                    newClusterManager(true),
+		localFailoverCommitReady:   make(map[int]bool),
+		localFailoverCommitTimeout: 30 * time.Second, // never reached
+		localFailoverCommitDelay:   0,
+		applyCancelContext:         ctx,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- d.waitLocalFailoverCommitReady([]int{0}) }()
+
+	// The RG never becomes ready, so without cancellation this sits for the
+	// full 30s timeout.
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("a cancelled wait must return an ERROR — the caller " +
+				"(cluster.requestPeerFailover) aborts the transfer on a non-nil " +
+				"return, and committing a transfer this node can no longer verify " +
+				"is the fail-OPEN direction")
+		}
+		if !strings.Contains(err.Error(), "daemon stopping") {
+			t.Fatalf("error = %v, want the daemon-stopping reason (a plain timeout "+
+				"here would mean it burned the whole window and never saw the cancel)", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitLocalFailoverCommitReady ignored daemon stop: it is sleeping " +
+			"without a cancellation select again")
+	}
+}
+
+// The dwell delay is abortable too, not just the poll: a wait that has already
+// observed readiness and is dwelling must still yield to shutdown.
+func TestWaitLocalFailoverCommitReadyAbortsDuringTheDwellDelay(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	d := &Daemon{
+		cluster:                    newClusterManager(true),
+		localFailoverCommitReady:   make(map[int]bool),
+		localFailoverCommitTimeout: 30 * time.Second,
+		localFailoverCommitDelay:   30 * time.Second, // the dwell is the long wait
+		applyCancelContext:         ctx,
+	}
+	d.setLocalFailoverCommitReady(0, true) // ready immediately -> straight to dwell
+
+	done := make(chan error, 1)
+	go func() { done <- d.waitLocalFailoverCommitReady([]int{0}) }()
+
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "daemon stopping") {
+			t.Fatalf("error = %v, want the daemon-stopping reason from the dwell wait", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the dwell delay ignored daemon stop: it is a bare time.Sleep again")
+	}
+}
+
+// With no daemon-stop context wired (early boot, and every pre-existing unit
+// test in this file), applyCancelCtx() returns context.Background() — the wait
+// must behave exactly as before.
+func TestWaitLocalFailoverCommitReadyUnwiredContextStillTimesOut(t *testing.T) {
+	d := &Daemon{
+		cluster:                    newClusterManager(true),
+		localFailoverCommitReady:   make(map[int]bool),
+		localFailoverCommitTimeout: 30 * time.Millisecond,
+		localFailoverCommitDelay:   0,
+	}
+	err := d.waitLocalFailoverCommitReady([]int{0})
+	if err == nil || !strings.Contains(err.Error(), "timed out waiting for local failover activation settle") {
+		t.Fatalf("error = %v, want the ordinary settle timeout", err)
+	}
+}

--- a/pkg/daemon/rss_indirection.go
+++ b/pkg/daemon/rss_indirection.go
@@ -59,8 +59,15 @@ type rssExecutor interface {
 	// /sys/class/net/<iface>/device/driver), or "" if not a PCI NIC.
 	readDriver(iface string) string
 	// readQueueCount returns the number of RX queues for iface, as
-	// enumerated from /sys/class/net/<iface>/queues/rx-*.
-	readQueueCount(iface string) int
+	// enumerated from /sys/class/net/<iface>/queues/rx-*, plus the
+	// enumeration error if the directory could not be read at all.
+	//
+	// #5250 (A7-b2 F2): the error is part of the signature because a
+	// FAILED enumeration and a NIC that genuinely reports zero RX queues
+	// are different facts that used to arrive as the same value, 0. The
+	// caller logged the failure as `queues=0 reason="queue count unknown"`,
+	// which reads as a decision made about a real NIC.
+	readQueueCount(iface string) (int, error)
 	// listInterfaces returns the set of netdev names to consider (real
 	// sysfs: basenames of /sys/class/net). Injection point for tests so
 	// the top-level scan path is exercised without touching real netdevs.
@@ -86,10 +93,10 @@ func (realRSSExecutor) readDriver(iface string) string {
 	return filepath.Base(link)
 }
 
-func (realRSSExecutor) readQueueCount(iface string) int {
+func (realRSSExecutor) readQueueCount(iface string) (int, error) {
 	entries, err := os.ReadDir(filepath.Join("/sys/class/net", iface, "queues"))
 	if err != nil {
-		return 0
+		return 0, err
 	}
 	n := 0
 	for _, e := range entries {
@@ -97,7 +104,7 @@ func (realRSSExecutor) readQueueCount(iface string) int {
 			n++
 		}
 	}
-	return n
+	return n, nil
 }
 
 func (realRSSExecutor) listInterfaces() []string {
@@ -253,7 +260,29 @@ func applyRSSIndirectionOne(iface string, workers int, execer rssExecutor) {
 			"iface", iface, "driver", drv)
 		return
 	}
-	queues := execer.readQueueCount(iface)
+	queues, err := execer.readQueueCount(iface)
+	if err != nil {
+		// #5250 (A7-b2 F2): a failed RX-queue enumeration is NOT "this NIC
+		// has zero queues". Returning 0 for both made computeWeightVector
+		// emit `reason="queue count unknown"` at INFO next to `queues=0`,
+		// indistinguishable from a real answer, and then fall through the
+		// `queues > 1` guard so maybeRestoreDefault never ran either.
+		//
+		// No restore is attempted here, and that is deliberate rather than a
+		// gap: the only way ReadDir on /sys/class/net/<iface>/queues fails is
+		// that the netdev is gone (the per-iface driver re-check two lines up
+		// already passed, so the sysfs path existed a moment ago). A netdev
+		// that no longer exists has no indirection table to restore, and the
+		// `ethtool -X` a restore would run fails for the same reason. What was
+		// missing was the operator being able to SEE which of the two happened,
+		// so this logs the error and leaves the table alone.
+		//
+		// reapplyRSSIndirection runs on every config apply, so a transient
+		// failure self-heals on the next commit.
+		slog.Warn("linksetup: rss indirection skipped, cannot enumerate rx queues",
+			"iface", iface, "workers", workers, "err", err)
+		return
+	}
 	weights, reason := computeWeightVector(workers, queues)
 	if weights == nil {
 		slog.Info("linksetup: rss weight reshaping skipped", "iface", iface,

--- a/pkg/daemon/rss_indirection_test.go
+++ b/pkg/daemon/rss_indirection_test.go
@@ -29,6 +29,10 @@ type fakeRSSExecutor struct {
 	drivers map[string]string
 	// Per-iface RX queue count.
 	queues map[string]int
+	// Per-iface sysfs enumeration error (#5250 A7-b2 F2). A key present
+	// here makes readQueueCount FAIL for that iface, which is a different
+	// fact from queues[iface] == 0.
+	queueErrs map[string]error
 	// Scripted ethtool -x <iface> output for idempotency probe.
 	ethtoolX map[string][]byte
 	// Scripted ethtool -c <iface> output for coalescence probe (#801).
@@ -102,8 +106,11 @@ func (f *fakeRSSExecutor) readDriver(iface string) string {
 	return f.drivers[iface]
 }
 
-func (f *fakeRSSExecutor) readQueueCount(iface string) int {
-	return f.queues[iface]
+func (f *fakeRSSExecutor) readQueueCount(iface string) (int, error) {
+	if err, ok := f.queueErrs[iface]; ok {
+		return 0, err
+	}
+	return f.queues[iface], nil
 }
 
 func (f *fakeRSSExecutor) listInterfaces() []string {

--- a/pkg/daemon/rss_queue_count_error_5250_test.go
+++ b/pkg/daemon/rss_queue_count_error_5250_test.go
@@ -1,0 +1,77 @@
+package daemon
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+)
+
+// #5250 (A7-b2 F2). readQueueCount returned a bare int and yielded 0 on a sysfs
+// ReadDir error, so a FAILED enumeration and a NIC that genuinely reports zero
+// RX queues arrived at applyRSSIndirectionOne as the same value. The failure was
+// then logged at INFO as `queues=0 reason="queue count unknown"`, which reads as
+// a decision made about a real NIC, and fell through the `queues > 1` guard so
+// the stale-table restore never ran either.
+//
+// Widening the seam to (int, error) is what makes the two distinguishable. This
+// test pins BOTH sides of the distinction, since a guard that only checks the
+// error case cannot see a fix that swallowed the genuine-zero case with it.
+func TestReadQueueCountErrorIsNotAGenuineZero(t *testing.T) {
+	t.Run("enumeration error touches no ethtool", func(t *testing.T) {
+		f := &fakeRSSExecutor{
+			drivers:   map[string]string{"eth0": "mlx5_core"},
+			queueErrs: map[string]error{"eth0": fs.ErrNotExist},
+			ethtoolX:  map[string][]byte{"eth0": defaultRSSTable6q},
+		}
+		applyRSSIndirectionOne("eth0", 4, f)
+		if len(f.calls) != 0 {
+			t.Fatalf("a failed RX-queue enumeration must not run ethtool at all, got %v", f.calls)
+		}
+	})
+
+	t.Run("genuine zero still takes the skip path", func(t *testing.T) {
+		f := &fakeRSSExecutor{
+			drivers:  map[string]string{"eth0": "mlx5_core"},
+			queues:   map[string]int{"eth0": 0},
+			ethtoolX: map[string][]byte{"eth0": defaultRSSTable6q},
+		}
+		applyRSSIndirectionOne("eth0", 4, f)
+		if len(f.calls) != 0 {
+			t.Fatalf("a genuine zero-queue NIC must not run ethtool either, got %v", f.calls)
+		}
+	})
+
+	t.Run("a real queue count still reshapes", func(t *testing.T) {
+		f := &fakeRSSExecutor{
+			drivers:  map[string]string{"eth0": "mlx5_core"},
+			queues:   map[string]int{"eth0": 6},
+			ethtoolX: map[string][]byte{"eth0": defaultRSSTable6q},
+		}
+		applyRSSIndirectionOne("eth0", 4, f)
+		if len(f.calls) != 2 {
+			t.Fatalf("workers=4 queues=6 must probe then write, got %v", f.calls)
+		}
+	})
+}
+
+// The seam must actually REPORT the error rather than folding it into the
+// count — a (0, nil) return would leave the caller as blind as before.
+func TestFakeExecutorSurfacesTheEnumerationError(t *testing.T) {
+	f := &fakeRSSExecutor{queueErrs: map[string]error{"eth0": fs.ErrNotExist}}
+	n, err := f.readQueueCount("eth0")
+	if err == nil {
+		t.Fatal("readQueueCount must return the enumeration error, not fold it into the count")
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("readQueueCount error = %v, want fs.ErrNotExist", err)
+	}
+	if n != 0 {
+		t.Fatalf("readQueueCount count = %d on error, want 0", n)
+	}
+}
+
+var defaultRSSTable6q = []byte(`RX flow hash indirection table for eth0 with 6 RX ring(s):
+    0:      0     1     2     3     4     5
+    8:      0     1     2     3     4     5
+   16:      0     1     2     3     4     5
+`)

--- a/pkg/dataplane/userspace/app_port_ranges_5250_test.go
+++ b/pkg/dataplane/userspace/app_port_ranges_5250_test.go
@@ -1,0 +1,66 @@
+package userspace
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// appPortSpecCorpus is the spec population both port paths must agree on. It
+// covers each arm of the parse — empty, exact, exact-zero, wide range, reversed
+// range (#3726), zero-anchored range, malformed halves, out-of-u16 values — plus
+// the boundary of the low-side clamp coalescePortRanges applies.
+var appPortSpecCorpus = []string{
+	"", "0", "1", "80", "65535",
+	"0-0", "0-1", "0-65535", "1-1", "1-65535", "20-23", "20000-20003",
+	"200-100", "65535-1",
+	"-", "-80", "80-", "http", "80-http", "http-80",
+	"65536", "1-65536", "70000", "-1", "1-",
+	" 80", "80 ", "8 0",
+}
+
+// #5250 (A6-b2 F3). Three NAT builder sites read
+// coalescePortRanges(appPortsFromSpec(spec)), and the DNAT term carried the
+// expanded []int all the way into the emit loop — so `destination-port 1-65535`
+// materialized ~65k ints per application (and again per application-set member)
+// purely to be collapsed back into one range. appPortRangesFromSpec emits the
+// range directly.
+//
+// This is an AGREEMENT test, not a table of hand-picked expectations: it
+// asserts the new function returns EXACTLY what the composition it replaced
+// returns, for every spec in the corpus. A hand-written expectation table could
+// encode the same mistake twice; this cannot, because the reference side still
+// runs the original code.
+func TestAppPortRangesFromSpecMatchesCoalescedSlice(t *testing.T) {
+	for _, spec := range appPortSpecCorpus {
+		t.Run(fmt.Sprintf("%q", spec), func(t *testing.T) {
+			want := coalescePortRanges(appPortsFromSpec(spec))
+			got := appPortRangesFromSpec(spec)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("appPortRangesFromSpec(%q) = %v, coalescePortRanges(appPortsFromSpec(%q)) = %v",
+					spec, got, spec, want)
+			}
+		})
+	}
+}
+
+// The point of the change: a wide range costs ONE range and no per-port slice.
+// A revert to the materializing path is caught by the allocation count, which
+// scales with the range width and cannot be made to pass by accident.
+func TestAppPortRangesFromSpecDoesNotMaterializeTheRange(t *testing.T) {
+	const wide = "1-65535"
+	got := appPortRangesFromSpec(wide)
+	if len(got) != 1 || got[0].Low != 1 || got[0].High != 65535 {
+		t.Fatalf("appPortRangesFromSpec(%q) = %v, want one [1,65535] range", wide, got)
+	}
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = appPortRangesFromSpec(wide)
+	})
+	// One allocation: the single-element result slice. The old composition
+	// allocated the 65535-int slice (repeatedly, as append grew it) plus the
+	// dedup map plus the uniq slice.
+	if allocs > 2 {
+		t.Fatalf("appPortRangesFromSpec(%q) made %.0f allocations per call — the "+
+			"per-port slice is being materialized again", wide, allocs)
+	}
+}

--- a/pkg/dataplane/userspace/manager_neighbor.go
+++ b/pkg/dataplane/userspace/manager_neighbor.go
@@ -215,15 +215,36 @@ func (m *Manager) rebuildMonitoredIfindexes() {
 // entries (FAILED/INCOMPLETE/none). For force-probe target
 // collection we want only the entries the dataplane is actually
 // using, so we walk neighborIndex (publishable-only).
+// #5250 (A6-b2 F1): fn is invoked AFTER m.mu is released. The previous form
+// held the Manager lock across the callback, so a callback that re-entered any
+// Manager method self-deadlocked (m.mu is a plain sync.Mutex, not reentrant)
+// and any slow callback — the force-probe path issues netlink per target —
+// blocked every control-socket operation that needs m.mu for its whole
+// duration. Snapshotting first bounds the critical section to the map walk.
+//
+// The snapshot is a point-in-time copy: an entry evicted between the walk and
+// the callback is still delivered. That is the same staleness the caller
+// already tolerated (it acted on entries after the walk moved past them) and is
+// harmless for the force-probe consumer, whose worst case is one probe to a
+// neighbor that just left the table.
 func (m *Manager) ForEachSnapshotNeighbor(fn func(ifindex int, ip net.IP)) {
+	type neighborTarget struct {
+		ifindex int
+		ip      net.IP
+	}
 	m.mu.Lock()
-	defer m.mu.Unlock()
+	targets := make([]neighborTarget, 0, len(m.neighborIndex))
 	for k, n := range m.neighborIndex {
 		ip := net.ParseIP(n.IP)
 		if ip == nil {
 			continue
 		}
-		fn(k.ifindex, ip)
+		targets = append(targets, neighborTarget{ifindex: k.ifindex, ip: ip})
+	}
+	m.mu.Unlock()
+
+	for _, t := range targets {
+		fn(t.ifindex, t.ip)
 	}
 }
 

--- a/pkg/dataplane/userspace/nat.go
+++ b/pkg/dataplane/userspace/nat.go
@@ -192,45 +192,94 @@ func coalescePortRanges(ports []int) []NatPortRangeWire {
 	return ranges
 }
 
-// appPortsFromSpec parses a port specification like "80", "1024-65535" into a
-// list of port numbers. Mirrors the logic in pkg/dataplane/compiler.go.
-func appPortsFromSpec(spec string) []int {
-	if spec == "" {
+// appPortRangesFromSpec returns exactly what
+// coalescePortRanges(appPortsFromSpec(spec)) returns, WITHOUT materializing the
+// intermediate per-port slice (#5250, A6-b2 F3).
+//
+// A port spec is a single value or ONE contiguous inclusive range, so its
+// coalesced form is always zero or one wire range — there is nothing for
+// coalescePortRanges to merge. The old path nonetheless appended every port
+// from lo..hi into a []int first, so `destination-port 1-65535` allocated ~65k
+// ints (512 KiB on a 64-bit build) purely to have them collapsed back into one
+// {Low:1,High:65535} entry on the very next line, once per application and
+// again for every member of an application-set — a commit-time allocation
+// spike on the same goroutine that services the control socket.
+//
+// Equivalence with the composition it replaces, arm by arm (pinned by
+// TestAppPortRangesFromSpecMatchesCoalescedSlice, which asserts the two agree
+// across a spec corpus rather than trusting this comment):
+//   - "" / parse failure / reversed range (#3726) -> both yield no range.
+//   - lo == hi -> the slice path yields []int{lo}, which coalesces to
+//     {lo,lo} when lo >= 1 and to nothing when lo == 0.
+//   - lo < hi  -> the slice path yields lo..hi, and coalescePortRanges drops
+//     only the sub-1 values, so the result is {max(lo,1), hi}. hi <= 65535 is
+//     guaranteed by the ParseUint bit width, so no high-side clamp is needed.
+func appPortRangesFromSpec(spec string) []NatPortRangeWire {
+	lo, hi, ok := appPortSpecBounds(spec)
+	if !ok {
 		return nil
+	}
+	// coalescePortRanges skips every value below 1; for a contiguous range that
+	// is exactly a low-side clamp.
+	if lo < 1 {
+		lo = 1
+	}
+	if hi < lo {
+		// Either a single port 0, or a range whose only members were sub-1.
+		return nil
+	}
+	return []NatPortRangeWire{{Low: uint16(lo), High: uint16(hi)}}
+}
+
+// appPortSpecBounds parses a port spec into its inclusive [lo,hi] bounds. ok is
+// false for an empty spec, a malformed number, or a REVERSED range (#3726 —
+// "200-100" can never match, and must not be narrowed to an exact match on the
+// low port). It is the shared parse behind appPortsFromSpec and
+// appPortRangesFromSpec so the two cannot drift.
+func appPortSpecBounds(spec string) (lo, hi uint64, ok bool) {
+	if spec == "" {
+		return 0, 0, false
 	}
 	if strings.Contains(spec, "-") {
 		parts := strings.SplitN(spec, "-", 2)
 		lo, err := strconv.ParseUint(parts[0], 10, 16)
 		if err != nil {
-			return nil
+			return 0, 0, false
 		}
 		hi, err := strconv.ParseUint(parts[1], 10, 16)
 		if err != nil {
-			return nil
-		}
-		if hi > lo {
-			var ports []int
-			for p := lo; p <= hi; p++ {
-				ports = append(ports, int(p))
-			}
-			return ports
+			return 0, 0, false
 		}
 		if hi < lo {
 			// #3726: a REVERSED range ("200-100", lo>hi) is invalid — it can
-			// never match any port. Return nil (not []int{lo}) so the caller
-			// treats it as "configured but unrepresentable" and fails CLOSED
-			// via the never-match sentinel, rather than silently narrowing the
-			// NAT rule to an exact match on the low port. Strict commit already
-			// rejects lo>hi (pkg/config range validation); this hardens the
-			// #1960 tolerant-load / peer-sync backstop. The hi==lo case below
-			// is a legitimate single exact port.
-			return nil
+			// never match any port. Report "no bounds" (not lo..lo) so the
+			// caller treats it as "configured but unrepresentable" and fails
+			// CLOSED via the never-match sentinel, rather than silently
+			// narrowing the NAT rule to an exact match on the low port. Strict
+			// commit already rejects lo>hi (pkg/config range validation); this
+			// hardens the #1960 tolerant-load / peer-sync backstop. hi==lo is a
+			// legitimate single exact port.
+			return 0, 0, false
 		}
-		return []int{int(lo)}
+		return lo, hi, true
 	}
 	p, err := strconv.ParseUint(spec, 10, 16)
 	if err != nil {
+		return 0, 0, false
+	}
+	return p, p, true
+}
+
+// appPortsFromSpec parses a port specification like "80", "1024-65535" into a
+// list of port numbers. Mirrors the logic in pkg/dataplane/compiler.go.
+func appPortsFromSpec(spec string) []int {
+	lo, hi, ok := appPortSpecBounds(spec)
+	if !ok {
 		return nil
 	}
-	return []int{int(p)}
+	ports := make([]int, 0, hi-lo+1)
+	for p := lo; p <= hi; p++ {
+		ports = append(ports, int(p))
+	}
+	return ports
 }

--- a/pkg/dataplane/userspace/nat_destination.go
+++ b/pkg/dataplane/userspace/nat_destination.go
@@ -234,11 +234,22 @@ func buildDestinationNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map
 			//     constraint, carried verbatim (already valid u8s). nil = no ICMP
 			//     type/code constraint (match every type/code of the protocol).
 			type appTerm struct {
-				proto    string
-				ports    []int
-				srcPorts []NatPortRangeWire
-				icmpType *uint8
-				icmpCode *uint8
+				proto string
+				// #5250 (A6-b2 F3): the destination-port axis is carried
+				// ALREADY COALESCED. It used to be a []int of every individual
+				// port, so an application with `destination-port 1-65535`
+				// materialized ~65k ints per term (and again per application-set
+				// member) only for the loop below to collapse them back into one
+				// range. dstPortsPresent preserves the one thing the slice was
+				// also read for: whether the source list was non-empty BEFORE
+				// coalescing, which the #3726/#3857 fail-closed test needs and a
+				// coalesced list cannot recover (a spec of "0" is present but
+				// coalesces away).
+				dstRanges       []NatPortRangeWire
+				dstPortsPresent bool
+				srcPorts        []NatPortRangeWire
+				icmpType        *uint8
+				icmpCode        *uint8
 				// dstPortConfigured records that the application specified a
 				// non-empty destination-port spec, even if it coalesced to no
 				// representable port (all out of 1..65535, or a reversed
@@ -252,7 +263,7 @@ func buildDestinationNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map
 			var appTerms []appTerm
 
 			appTermFor := func(a *config.Application) appTerm {
-				srcPorts := coalescePortRanges(appPortsFromSpec(a.SourcePort))
+				srcPorts := appPortRangesFromSpec(a.SourcePort)
 				if a.SourcePort != "" && len(srcPorts) == 0 {
 					// #3437: a configured source-port that coalesces to nothing
 					// (every value out of 1..65535) fails CLOSED — match no source
@@ -261,7 +272,8 @@ func buildDestinationNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map
 				}
 				return appTerm{
 					proto:             a.Protocol,
-					ports:             appPortsFromSpec(a.DestinationPort),
+					dstRanges:         appPortRangesFromSpec(a.DestinationPort),
+					dstPortsPresent:   a.DestinationPort != "",
 					srcPorts:          srcPorts,
 					icmpType:          a.ICMPType,
 					icmpCode:          a.ICMPCode,
@@ -374,7 +386,11 @@ func buildDestinationNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map
 						protos = []string{""}
 					}
 					for _, proto := range protos {
-						appTerms = append(appTerms, appTerm{proto: proto, ports: rule.Match.DestinationPorts})
+						appTerms = append(appTerms, appTerm{
+							proto:           proto,
+							dstRanges:       coalescePortRanges(rule.Match.DestinationPorts),
+							dstPortsPresent: len(rule.Match.DestinationPorts) > 0,
+						})
 					}
 				}
 			}
@@ -432,13 +448,15 @@ func buildDestinationNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map
 				// when the rule did NOT configure `match destination-port`. On
 				// the no-application explicit-match path term.ports already IS
 				// rule.Match.DestinationPorts, so the override is a no-op there.
-				termPorts := term.ports
+				termRanges := term.dstRanges
+				termPortsPresent := term.dstPortsPresent
 				termDstPortConfigured := term.dstPortConfigured
 				if ruleDstPortConfigured {
-					termPorts = ruleDstPorts
+					termRanges = coalescePortRanges(ruleDstPorts)
+					termPortsPresent = len(ruleDstPorts) > 0
 					termDstPortConfigured = true
 				}
-				portRanges := coalescePortRanges(termPorts)
+				portRanges := termRanges
 				// Did this term CONFIGURE a destination-port at all? A configured
 				// port that survived to no valid value must not become wildcard.
 				// #3726: term.dstPortConfigured is true when the application named
@@ -450,7 +468,7 @@ func buildDestinationNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map
 				// InvalidDestinationPorts). Without this the empty ports slip
 				// through to the wildcard match-any-port default — a fail-open
 				// that widens the DNAT rule to every port.
-				portConfigured := len(termPorts) > 0 || termDstPortConfigured
+				portConfigured := termPortsPresent || termDstPortConfigured
 				if len(portRanges) == 0 {
 					switch {
 					case portConfigured:

--- a/pkg/dataplane/userspace/nat_source.go
+++ b/pkg/dataplane/userspace/nat_source.go
@@ -401,7 +401,7 @@ func buildSourceNATAppTerms(cfg *config.Config, appNames []string) []NatAppTermW
 		if a == nil {
 			return
 		}
-		ports := coalescePortRanges(appPortsFromSpec(a.DestinationPort))
+		ports := appPortRangesFromSpec(a.DestinationPort)
 		if a.DestinationPort != "" && len(ports) == 0 {
 			// #3429: the application carried a destination-port spec but none of
 			// it is representable (out of 1..65535) — fail CLOSED so the term
@@ -416,7 +416,7 @@ func buildSourceNATAppTerms(cfg *config.Config, appNames []string) []NatAppTermW
 		// 1..65535) gets the never-match sentinel rather than widening to any
 		// source port. An app with NO source-port keeps SrcPorts empty (a
 		// legitimate source-port-unconstrained match — the common case).
-		srcPorts := coalescePortRanges(appPortsFromSpec(a.SourcePort))
+		srcPorts := appPortRangesFromSpec(a.SourcePort)
 		if a.SourcePort != "" && len(srcPorts) == 0 {
 			srcPorts = []NatPortRangeWire{natNeverMatchPortRange}
 		}

--- a/pkg/dataplane/userspace/neighbor_callback_lock_5250_test.go
+++ b/pkg/dataplane/userspace/neighbor_callback_lock_5250_test.go
@@ -1,0 +1,78 @@
+package userspace
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// #5250 (A6-b2 F1). ForEachSnapshotNeighbor held m.mu across the callback
+// (`m.mu.Lock(); defer m.mu.Unlock()` around `fn(...)`). m.mu is a plain
+// sync.Mutex, so any callback that re-entered a Manager method that also takes
+// m.mu — SnapshotHasIfindex here, and the force-probe consumer's own path in
+// production — self-deadlocked with no timeout and no error.
+//
+// This test RUNS the re-entrant callback on a goroutine and fails on a
+// deadline. Reverting the walk to invoke fn under the lock makes it hang and
+// therefore RED at the deadline. The deadline is generous (5s) because it
+// bounds a HANG, not a latency: the fixed path completes in microseconds, so
+// the value can never make the test flaky in the passing direction.
+func TestForEachSnapshotNeighborDoesNotHoldTheLockAcrossTheCallback(t *testing.T) {
+	m := &Manager{
+		neighborIndex: map[neighborIndexKey]*NeighborSnapshot{
+			{ifindex: 7, ip: "10.0.0.1"}: {Ifindex: 7, IP: "10.0.0.1"},
+			{ifindex: 7, ip: "10.0.0.2"}: {Ifindex: 7, IP: "10.0.0.2"},
+			{ifindex: 9, ip: "10.0.1.1"}: {Ifindex: 9, IP: "10.0.1.1"},
+		},
+	}
+
+	type visit struct {
+		ifindex int
+		ip      string
+	}
+	done := make(chan []visit, 1)
+	go func() {
+		var seen []visit
+		m.ForEachSnapshotNeighbor(func(ifindex int, ip net.IP) {
+			// Re-enter the Manager from inside the callback. Under the old
+			// lock-across-callback shape this blocks forever on the FIRST
+			// entry, so `seen` never reaches len 3 and `done` never closes.
+			if !m.SnapshotHasIfindex(ifindex) {
+				t.Errorf("SnapshotHasIfindex(%d) = false inside the callback", ifindex)
+			}
+			seen = append(seen, visit{ifindex, ip.String()})
+		})
+		done <- seen
+	}()
+
+	select {
+	case seen := <-done:
+		if len(seen) != 3 {
+			t.Fatalf("visited %d neighbors, want 3: %v", len(seen), seen)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ForEachSnapshotNeighbor DEADLOCKED: a callback that re-enters the " +
+			"Manager blocked, so m.mu is being held across fn() again")
+	}
+}
+
+// An entry whose IP does not parse is skipped, as before — the snapshot copy
+// must not change which neighbors are delivered.
+func TestForEachSnapshotNeighborSkipsUnparseableIP(t *testing.T) {
+	m := &Manager{
+		neighborIndex: map[neighborIndexKey]*NeighborSnapshot{
+			{ifindex: 1, ip: "10.0.0.1"}:  {Ifindex: 1, IP: "10.0.0.1"},
+			{ifindex: 1, ip: "not-an-ip"}: {Ifindex: 1, IP: "not-an-ip"},
+		},
+	}
+	n := 0
+	m.ForEachSnapshotNeighbor(func(_ int, ip net.IP) {
+		n++
+		if ip.String() != "10.0.0.1" {
+			t.Errorf("delivered unexpected ip %q", ip)
+		}
+	})
+	if n != 1 {
+		t.Fatalf("delivered %d neighbors, want 1 (the unparseable entry must be skipped)", n)
+	}
+}

--- a/pkg/eventengine/README.md
+++ b/pkg/eventengine/README.md
@@ -391,11 +391,29 @@ Junos reading in `withinMatches` (`engine.go`):
   `until 1` made the first event `count == 1 >= 1` and NEVER fired, and
   `until N` fired only on events 1..N-1. Regression-locked by
   `TestInclusiveUntil_*_3756`.
-- **Multiple `within` clauses are combined with AND (#4423 M3).**
-  `withinMatches` returns false the moment ANY clause is unsatisfied, so a
-  policy with two `within` clauses fires only when EVERY clause passes for the
-  current event. There is no OR; express an OR-of-conditions as separate
-  policies. Regression-locked by `TestWithinMultipleClausesAreANDed`.
+- **Multiple `within` clauses are combined with AND (#4423 M3).** A policy with
+  two `within` clauses fires only when EVERY clause passes for the current
+  event. There is no OR; express an OR-of-conditions as separate policies.
+  Regression-locked by `TestWithinMultipleClausesAreANDed`.
+- **The verdict does not depend on clause ORDER (#5250, A9 F4).**
+  `withinMatches` is three passes over the clause list — structural validity,
+  then the `trigger on` re-arm/latch, then `trigger until` — rather than one
+  fused loop that returned from the middle of the walk. With the fused loop and
+  two `trigger on` clauses, whichever clause was reached first decided whether
+  the latch was checked or re-armed and the other was never evaluated: a
+  latched policy whose LONG window was still above threshold returned at that
+  clause, so the SHORT clause that had decayed below its own threshold never
+  re-armed the latch. The ANDed condition went false and true again — a real
+  crossing — and the policy stayed silent until the long window decayed. The
+  latch now clears exactly when the ANDed condition is false, i.e. when ANY
+  `trigger on` clause is below its threshold, decided across all of them first.
+  Regression-locked by `TestWithinTriggerOnRearmIsIndependentOfClauseOrder`,
+  which runs the same timeline against both clause orderings and requires them
+  to agree. One deliberate delta: a policy carrying BOTH a structurally invalid
+  clause and a below-threshold `trigger on` clause no longer clears the latch
+  (pass 1 fails closed first). Such a policy fires on no event at all while the
+  invalid clause exists, so the latch value is unobservable until the config is
+  corrected.
 
 ## Audit hardening (#4423)
 

--- a/pkg/eventengine/engine.go
+++ b/pkg/eventengine/engine.go
@@ -1314,12 +1314,21 @@ func policyHasTriggerOn(pol *config.EventPolicy) bool {
 // "within N { trigger on M }" — fires when M events happen within N seconds.
 // "within N { trigger until M }" — fires until M events happen within N seconds, then stops.
 //
-// MULTIPLE within clauses are combined with AND (#4423 M3): the loop below
-// returns false the moment ANY clause is unsatisfied, so the policy fires only
-// when EVERY within clause passes for this event. A policy that wants
+// MULTIPLE within clauses are combined with AND (#4423 M3): the policy fires
+// only when EVERY within clause passes for this event. A policy that wants
 // OR-of-conditions must be written as separate policies. This AND semantics is
 // the documented contract (pkg/eventengine/README.md) and is covered by
 // TestWithinMultipleClausesAreANDed.
+//
+// The body is three passes over the clause list rather than one fused loop, so
+// no verdict depends on the order the operator wrote the clauses in — see the
+// #5250 note on pass 2. One deliberate ordering delta survives: a policy that
+// carries BOTH a structurally invalid clause (rejected by pass 1) and a
+// below-threshold trigger-on clause no longer clears the edge latch, where the
+// fused loop did if the below-threshold clause came first. Such a policy fails
+// closed on every event for as long as the invalid clause exists, so the
+// latch's value is unobservable until the config is corrected — after which the
+// next below-threshold event re-arms it through the normal path.
 func (e *Engine) withinMatches(pol *config.EventPolicy, rt *policyRuntime, eventName string, now time.Time) bool {
 	if len(pol.WithinClauses) == 0 {
 		return true // no temporal filter
@@ -1327,69 +1336,98 @@ func (e *Engine) withinMatches(pol *config.EventPolicy, rt *policyRuntime, event
 
 	timestamps := rt.windows[eventName]
 
+	// PASS 1 — structural validity, over every clause.
+	//
+	// #3751 defense-in-depth: a within clause with no USABLE positive
+	// threshold (both trigger on/until absent or <= 0) — or a non-positive
+	// window — must fail CLOSED, not always-fire. Commit-time validation
+	// (config.validateEventOptionsWithinAST) rejects such a clause outright,
+	// so this belt only fires on a config that slipped through a TOLERANT
+	// load / peer-sync path (an older binary silently coerced a within/
+	// trigger typo to 0). Falling through to `return true` here would treat
+	// that mis-arrived 0 as an unconditional match — turning a threshold-
+	// gated remediation into an ALWAYS-FIRE one, the original fail-open. A
+	// policy with NO within clauses at all is handled above (return true) —
+	// that legitimately means "no temporal filter"; this guard is only for
+	// a within clause that exists but gates nothing.
 	for _, wc := range pol.WithinClauses {
-		// #3751 defense-in-depth: a within clause with no USABLE positive
-		// threshold (both trigger on/until absent or <= 0) — or a non-positive
-		// window — must fail CLOSED, not always-fire. Commit-time validation
-		// (config.validateEventOptionsWithinAST) rejects such a clause outright,
-		// so this belt only fires on a config that slipped through a TOLERANT
-		// load / peer-sync path (an older binary silently coerced a within/
-		// trigger typo to 0). Falling through to `return true` here would treat
-		// that mis-arrived 0 as an unconditional match — turning a threshold-
-		// gated remediation into an ALWAYS-FIRE one, the original fail-open. A
-		// policy with NO within clauses at all is handled above (return true) —
-		// that legitimately means "no temporal filter"; this guard is only for
-		// a within clause that exists but gates nothing.
 		if wc.Seconds <= 0 || (wc.TriggerOn <= 0 && wc.TriggerUntil <= 0) {
 			return false
 		}
+	}
 
+	counts := make([]int, len(pol.WithinClauses))
+	for i, wc := range pol.WithinClauses {
 		window := time.Duration(wc.Seconds) * time.Second
-
-		// Count events within the window
-		count := 0
 		for _, ts := range timestamps {
 			if now.Sub(ts) <= window {
-				count++
+				counts[i]++
 			}
 		}
+	}
 
-		if wc.TriggerOn > 0 {
-			// "trigger on N" is EDGE-triggered (#3756 M1): it fires on the
-			// threshold CROSSING, not on every event while the level stays at
-			// or above N. Junos `trigger on` re-arms only after the count drops
-			// back below N; the 30s cooldown alone only THROTTLES a sustained
-			// level (re-remediating it every cooldown), which is harmful for a
-			// non-idempotent then-batch and spams commit/rollback history.
-			if count < wc.TriggerOn {
-				// Dropped below the threshold: re-arm so the next crossing
-				// fires again.
-				rt.onLatched[eventName] = false
-				return false
-			}
-			if rt.onLatched[eventName] {
-				// Level still at/above N and this crossing already fired:
-				// suppress until the count drops below N (re-arm above).
-				return false
-			}
-			// count >= N and not yet latched: this IS the crossing — pass.
-			// evaluateEvent sets the latch only AFTER the cooldown check
-			// passes, so a cooldown-suppressed crossing is not consumed.
+	// PASS 2 — the "trigger on N" edge latch, decided over EVERY trigger-on
+	// clause before anything returns.
+	//
+	// "trigger on N" is EDGE-triggered (#3756 M1): it fires on the threshold
+	// CROSSING, not on every event while the level stays at or above N. Junos
+	// `trigger on` re-arms only after the count drops back below N; the 30s
+	// cooldown alone only THROTTLES a sustained level (re-remediating it every
+	// cooldown), which is harmful for a non-idempotent then-batch and spams
+	// commit/rollback history.
+	//
+	// #5250 (A9 F4): the re-arm and the latch check are two separate passes
+	// over the clause list, and that separation IS the fix. The single fused
+	// loop this replaces returned false from inside the walk, so with more
+	// than one `within { trigger on N }` clause the outcome depended on the
+	// order the operator wrote them in. Clauses are ANDed (below), so consider
+	// `within 600 { trigger on 10 }` written BEFORE `within 60 { trigger on 3 }`
+	// with the policy already latched: the 600s clause is still at/above 10, so
+	// it hit the latch check and returned — and the 60s clause, which had
+	// dropped below 3 and was the one that should have RE-ARMED the latch, was
+	// never reached. The AND became false and then true again (a real crossing)
+	// and the policy stayed silent until the long window decayed. Written in
+	// the other order the same config re-arms correctly. Deciding the re-arm
+	// across all clauses first makes the result independent of clause order:
+	// the latch clears exactly when the ANDed condition is false, which is
+	// exactly when any trigger-on clause is below its threshold.
+	belowTriggerOn := false
+	hasTriggerOn := false
+	for i, wc := range pol.WithinClauses {
+		if wc.TriggerOn <= 0 {
+			continue
 		}
+		hasTriggerOn = true
+		if counts[i] < wc.TriggerOn {
+			belowTriggerOn = true
+		}
+	}
+	if belowTriggerOn {
+		// Dropped below the threshold: re-arm so the next crossing fires again.
+		rt.onLatched[eventName] = false
+		return false
+	}
+	if hasTriggerOn && rt.onLatched[eventName] {
+		// Level still at/above N on every clause and this crossing already
+		// fired: suppress until some clause's count drops below its threshold
+		// (re-arm above). evaluateEvent sets the latch only AFTER the cooldown
+		// check passes, so a cooldown-suppressed crossing is not consumed.
+		return false
+	}
 
-		if wc.TriggerUntil > 0 {
-			// "trigger until N" fires through the INCLUSIVE N-th event, then
-			// stops (#3756 M2). Junos reads it as "trigger UNTIL the event has
-			// been received N times" — the N-th occurrence is the LAST that
-			// fires. The event is appended to the window BEFORE this check
-			// (evaluateEvent), so the N-th matching event already makes
-			// count==N; using `>=` here made count==N return false, so the N-th
-			// never fired and `until 1` (count==1 on the first event) could
-			// NEVER fire at all — a dead-config bug. `>` fires on 1..N and stops
-			// at N+1.
-			if count > wc.TriggerUntil {
-				return false
-			}
+	// PASS 3 — "trigger until N".
+	//
+	// "trigger until N" fires through the INCLUSIVE N-th event, then stops
+	// (#3756 M2). Junos reads it as "trigger UNTIL the event has been received
+	// N times" — the N-th occurrence is the LAST that fires. The event is
+	// appended to the window BEFORE this check (evaluateEvent), so the N-th
+	// matching event already makes count==N; using `>=` here made count==N
+	// return false, so the N-th never fired and `until 1` (count==1 on the
+	// first event) could NEVER fire at all — a dead-config bug. `>` fires on
+	// 1..N and stops at N+1.
+	for i, wc := range pol.WithinClauses {
+		if wc.TriggerUntil > 0 && counts[i] > wc.TriggerUntil {
+			return false
 		}
 	}
 

--- a/pkg/eventengine/within_clause_order_5250_test.go
+++ b/pkg/eventengine/within_clause_order_5250_test.go
@@ -1,0 +1,138 @@
+package eventengine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/rpm"
+)
+
+// #5250 (A9 F4). The `trigger on N` edge latch is keyed per (policy, event) and
+// was decided INSIDE the single loop that walks the within clauses, which
+// returned false from the middle of that walk. Multiple within clauses are
+// ANDed, so with more than one `trigger on` clause the verdict depended on the
+// ORDER the operator wrote them in: whichever clause was reached first decided
+// whether the latch got checked or re-armed, and the other one was never seen.
+//
+// Concretely, with the LONG window written first and the policy already
+// latched, the long clause was still at/above its threshold, hit the latch
+// check and returned — so the SHORT clause, which had decayed below its own
+// threshold and was the one that should have RE-ARMED the latch, never ran. The
+// ANDed condition went false and then true again — a genuine crossing — and the
+// policy stayed silent until the long window decayed too.
+//
+// The fix decides the re-arm across EVERY trigger-on clause before anything
+// returns, so both orderings agree. This test drives the timeline against both
+// orderings and asserts they produce the SAME sequence, which is the property;
+// it also pins the absolute expectation, so a fix that made both orderings
+// equally wrong cannot pass.
+func TestWithinTriggerOnRearmIsIndependentOfClauseOrder(t *testing.T) {
+	longFirst := []*config.EventWithin{
+		{Seconds: 600, TriggerOn: 3},
+		{Seconds: 60, TriggerOn: 3},
+	}
+	shortFirst := []*config.EventWithin{
+		{Seconds: 60, TriggerOn: 3},
+		{Seconds: 600, TriggerOn: 3},
+	}
+
+	// run drives the timeline and returns the offsets (seconds from base) at
+	// which the policy fired.
+	run := func(clauses []*config.EventWithin) []int {
+		t.Helper()
+		pol := &config.EventPolicy{Name: "p", Events: []string{"e"}, WithinClauses: clauses}
+		e := newTestEngine(t, []*config.EventPolicy{pol})
+		base := time.Unix(1_000_000, 0)
+		var at int
+		e.nowFn = func() time.Time { return base.Add(time.Duration(at) * time.Second) }
+
+		var fired []int
+		// Burst 1 at t=0,1,2 — the third event crosses BOTH thresholds.
+		// Gap to t=100: the 60s window has decayed to empty while the 600s
+		// window still holds all three, so the ANDed condition is false and the
+		// latch must re-arm.
+		// Burst 2 at t=100,101,102 — the third event is a NEW crossing.
+		for _, at = range []int{0, 1, 2, 100, 101, 102} {
+			if n := len(e.evaluateEvent(rpm.Event{Name: "e"})); n > 0 {
+				fired = append(fired, at)
+			}
+		}
+		return fired
+	}
+
+	gotLong := run(longFirst)
+	gotShort := run(shortFirst)
+
+	want := []int{2, 102}
+	eq := func(a, b []int) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i := range a {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	if !eq(gotLong, gotShort) {
+		t.Fatalf("clause ORDER changed the outcome: long-window-first fired at %v, "+
+			"short-window-first fired at %v — the re-arm is being decided inside "+
+			"the walk again", gotLong, gotShort)
+	}
+	if !eq(gotLong, want) {
+		t.Fatalf("fired at %v, want %v: the third event of each burst is a threshold "+
+			"CROSSING and must fire exactly once per burst", gotLong, want)
+	}
+}
+
+// Single-clause edge semantics are unchanged: one fire per crossing, suppressed
+// while the level stays at or above N, re-armed once it drops below.
+func TestWithinSingleTriggerOnKeepsEdgeSemantics(t *testing.T) {
+	pol := &config.EventPolicy{
+		Name:          "p",
+		Events:        []string{"e"},
+		WithinClauses: []*config.EventWithin{{Seconds: 60, TriggerOn: 3}},
+	}
+	e := newTestEngine(t, []*config.EventPolicy{pol})
+	base := time.Unix(2_000_000, 0)
+	var at int
+	e.nowFn = func() time.Time { return base.Add(time.Duration(at) * time.Second) }
+
+	var fired []int
+	// 0,1,2 -> crossing at 2. 3,4 -> level sustained, suppressed. Gap to 200
+	// drains the 60s window; 200,201,202 -> a second crossing at 202.
+	for _, at = range []int{0, 1, 2, 3, 4, 200, 201, 202} {
+		if n := len(e.evaluateEvent(rpm.Event{Name: "e"})); n > 0 {
+			fired = append(fired, at)
+		}
+	}
+	if len(fired) != 2 || fired[0] != 2 || fired[1] != 202 {
+		t.Fatalf("fired at %v, want [2 202] — one fire per crossing", fired)
+	}
+}
+
+// A structurally invalid clause still fails CLOSED regardless of position
+// (#3751), and mixing it with a valid one does not make the policy fire.
+func TestWithinInvalidClauseStillFailsClosedInEitherPosition(t *testing.T) {
+	for name, clauses := range map[string][]*config.EventWithin{
+		"invalid first": {{Seconds: 0, TriggerOn: 1}, {Seconds: 60, TriggerOn: 1}},
+		"invalid last":  {{Seconds: 60, TriggerOn: 1}, {Seconds: 0, TriggerOn: 1}},
+		"no threshold":  {{Seconds: 60}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			pol := &config.EventPolicy{Name: "p", Events: []string{"e"}, WithinClauses: clauses}
+			e := newTestEngine(t, []*config.EventPolicy{pol})
+			base := time.Unix(3_000_000, 0)
+			var at int
+			e.nowFn = func() time.Time { return base.Add(time.Duration(at) * time.Second) }
+			for _, at = range []int{0, 1, 2, 3} {
+				if n := len(e.evaluateEvent(rpm.Event{Name: "e"})); n != 0 {
+					t.Fatalf("a policy with an unusable within clause must never fire, fired %d at t=%d", n, at)
+				}
+			}
+		})
+	}
+}

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -294,6 +294,26 @@ per-entry LRU bookkeeping for a syscall-amortization cache. The bound is
 pinned by `TestRouteMaskCacheBounded` (inserting >cap distinct keys keeps
 `len(entries)` <= cap; removing the bound flips it RED).
 
+**#5250 (A9 F3) — the cache is CLOSABLE.** The background scheduler had no
+stop signal of any kind: no ctx, no Close, and `NewRouteMaskResolver`
+returned only a bare `MaskResolver` closure, so the exporter that owned the
+cache could not have stopped it even if it wanted to — a blocking
+`RTM_GETROUTE` could be *started* after the exporter had been torn down.
+`newRouteMaskCache` now returns the `*routeMaskCache` itself; `NewExporter`
+/ `NewIPFIXExporter` keep it on the exporter (`maskCache`) and `Close()`
+calls `routeMaskCache.Close()`, which the daemon already invokes on every
+flow-export reconcile and at shutdown (`daemon_flowexport.go`). Two
+guarantees, and only the first is absolute: after `Close` returns **no
+further lookup is ever scheduled** (the `closed` flag is taken under `mu`
+in `scheduleLookupLocked`); `Close` also waits for the lookups already
+running, but only up to `routeMaskCloseGrace` (2s), so a netlink socket
+wedged in the kernel cannot hold daemon shutdown open — which would defeat
+the whole point of #3743. `NewRouteMaskResolver` keeps its
+`MaskResolver`-only signature for callers with nothing to shut down.
+Pinned by `TestRouteMaskCacheCloseSchedulesNoFurtherLookups`,
+`TestRouteMaskCacheCloseIsBoundedByTheGrace` and
+`TestExporterCloseStopsTheRouteMaskCache`.
+
 **#3743 — the FIB lookup runs OFF the EventReader callback.** `resolve()`
 is called from `ExportSessionClose`, which runs inside the EventReader
 session-close callback (`daemon_flowexport.go` `flowExportCallback` /

--- a/pkg/flowexport/ipfix.go
+++ b/pkg/flowexport/ipfix.go
@@ -767,6 +767,9 @@ type IPFIXExporter struct {
 	// IPv6 variants IE 29/30) from the FIB. See Exporter.MaskResolver.
 	MaskResolver MaskResolver
 
+	// maskCache: see Exporter.maskCache (#5250, A9 F3).
+	maskCache *routeMaskCache
+
 	batch flowBatch
 
 	exportedFlows atomic.Uint64
@@ -792,12 +795,13 @@ func NewIPFIXExporter(cfg *ExportConfig) (*IPFIXExporter, error) {
 	// compute the same ODID). Also the scope value of the #3748 sampler record.
 	sourceID := stableExporterID("ipfix", cfg.InstanceName, cfg.TemplateName)
 	e := &IPFIXExporter{
-		cfg:          cfg,
-		sourceID:     sourceID,
-		includeDir:   cfg.IncludeFlowDir,
-		templateSet:  encodeIPFIXTemplateSetDir(cfg.IncludeFlowDir),
-		MaskResolver: NewRouteMaskResolver(0),
+		cfg:         cfg,
+		sourceID:    sourceID,
+		includeDir:  cfg.IncludeFlowDir,
+		templateSet: encodeIPFIXTemplateSetDir(cfg.IncludeFlowDir),
 	}
+	e.maskCache = newRouteMaskCache(0)
+	e.MaskResolver = e.maskCache.resolve
 
 	// #3748: advertise the 1-in-N sampling rate via an Options Template +
 	// Options Data Record only when the group is actually sampled (rate > 1),
@@ -955,9 +959,13 @@ func (e *IPFIXExporter) CollectorHealth() []CollectorHealth {
 	return e.conns.health()
 }
 
-// Close shuts down all collector connections.
+// Close shuts down all collector connections and stops the route-mask cache's
+// background FIB lookups (#5250).
 func (e *IPFIXExporter) Close() {
 	e.conns.close()
+	if e.maskCache != nil {
+		e.maskCache.Close()
+	}
 }
 
 func (e *IPFIXExporter) sendTemplates() {

--- a/pkg/flowexport/netflow.go
+++ b/pkg/flowexport/netflow.go
@@ -542,6 +542,12 @@ type Exporter struct {
 	// real matching-route prefix length.
 	MaskResolver MaskResolver
 
+	// maskCache is the routeMaskCache backing MaskResolver when the
+	// constructor built it, so Close can stop its background FIB lookups
+	// (#5250, A9 F3). Nil on a zero-value exporter or when a caller assigned
+	// MaskResolver directly — Close then has nothing to stop, which is correct.
+	maskCache *routeMaskCache
+
 	// Batching: accumulate records, flush periodically
 	batch flowBatch
 
@@ -583,11 +589,12 @@ func NewExporter(cfg *ExportConfig) (*Exporter, error) {
 		// #3740: stable per-group SourceID (RFC 3954 §5.1) derived from the
 		// config identity so two same-collector groups no longer collide on
 		// SourceID=1. HA-symmetric (pure function of config-synced fields).
-		sourceID:     stableExporterID("netflow9", cfg.InstanceName, cfg.TemplateName),
-		fieldsV4:     buildTemplateFieldsV4(cfg.V9TemplateOpts),
-		fieldsV6:     buildTemplateFieldsV6(cfg.V9TemplateOpts),
-		MaskResolver: NewRouteMaskResolver(0),
+		sourceID: stableExporterID("netflow9", cfg.InstanceName, cfg.TemplateName),
+		fieldsV4: buildTemplateFieldsV4(cfg.V9TemplateOpts),
+		fieldsV6: buildTemplateFieldsV6(cfg.V9TemplateOpts),
 	}
+	e.maskCache = newRouteMaskCache(0)
+	e.MaskResolver = e.maskCache.resolve
 	e.recSizeV4 = recordSize(e.fieldsV4)
 	e.recSizeV6 = recordSize(e.fieldsV6)
 	e.templateFlowSet = encodeTemplateFlowSet(cfg.V9TemplateOpts)
@@ -749,9 +756,13 @@ func (e *Exporter) CollectorHealth() []CollectorHealth {
 	return e.conns.health()
 }
 
-// Close shuts down all collector connections.
+// Close shuts down all collector connections and stops the route-mask cache's
+// background FIB lookups (#5250).
 func (e *Exporter) Close() {
 	e.conns.close()
+	if e.maskCache != nil {
+		e.maskCache.Close()
+	}
 }
 
 func (e *Exporter) sendTemplates() {

--- a/pkg/flowexport/routemask.go
+++ b/pkg/flowexport/routemask.go
@@ -88,6 +88,12 @@ type routeMaskCache struct {
 	entries  map[routeMaskKey]routeMaskEntry
 	pending  map[routeMaskKey]struct{} // keys with a background lookup in flight (dedup)
 	inflight int                       // count of background lookups currently running
+	closed   bool                      // Close() called: schedule nothing further (#5250)
+
+	// wg tracks the background lookup goroutines so Close can wait for them
+	// (bounded by routeMaskCloseGrace). Add() happens under mu, next to the
+	// pending/inflight bookkeeping, so it cannot race the closed check.
+	wg sync.WaitGroup
 
 	// afterPopulate, when non-nil, is invoked after each background lookup has
 	// stored its result. Test-only seam for deterministic assertions; nil in
@@ -106,6 +112,14 @@ type routeMaskEntry struct {
 // netlink syscall rate on the hot session-close export path. ttl<=0 selects a
 // sensible default (10s).
 func NewRouteMaskResolver(ttl time.Duration) MaskResolver {
+	return newRouteMaskCache(ttl).resolve
+}
+
+// newRouteMaskCache builds the cache behind NewRouteMaskResolver and returns
+// the cache itself, so an owner (the NetFlow / IPFIX exporters) can Close it on
+// shutdown. NewRouteMaskResolver keeps the MaskResolver-only signature for
+// callers — tests — that have nothing to shut down.
+func newRouteMaskCache(ttl time.Duration) *routeMaskCache {
 	if ttl <= 0 {
 		ttl = 10 * time.Second
 	}
@@ -117,7 +131,7 @@ func NewRouteMaskResolver(ttl time.Duration) MaskResolver {
 		entries:     make(map[routeMaskKey]routeMaskEntry),
 		pending:     make(map[routeMaskKey]struct{}),
 	}
-	return c.resolve
+	return c
 }
 
 // resolve implements MaskResolver with caching. It NEVER issues the netlink
@@ -169,6 +183,14 @@ func (c *routeMaskCache) scheduleLookupLocked(key routeMaskKey, ip16 net.IP, ifi
 	if c.pending == nil {
 		c.pending = make(map[routeMaskKey]struct{})
 	}
+	if c.closed {
+		// #5250 (A9 F3): after Close, a miss resolves to the default and
+		// schedules nothing. Without this the cache had no stop signal of any
+		// kind — no ctx, no Close method — so a blocking RTM_GETROUTE could be
+		// STARTED after the exporter that owns the cache had already shut down,
+		// and each such lookup then wrote into a cache nobody would read again.
+		return
+	}
 	if _, inFlight := c.pending[key]; inFlight {
 		return
 	}
@@ -181,8 +203,48 @@ func (c *routeMaskCache) scheduleLookupLocked(key routeMaskKey, ip16 net.IP, ifi
 	}
 	c.pending[key] = struct{}{}
 	c.inflight++
+	c.wg.Add(1)
 	ipCopy := append(net.IP(nil), ip16...)
 	go c.populate(key, ipCopy, ifindex)
+}
+
+// routeMaskCloseGrace bounds how long Close waits for already-running FIB
+// lookups. A netlink round-trip is normally sub-millisecond; the grace exists
+// so a WEDGED netlink socket cannot hold daemon shutdown open indefinitely,
+// which is the failure this cache's whole background design (#3743) was built
+// to keep off the hot path in the first place.
+const routeMaskCloseGrace = 2 * time.Second
+
+// Close stops the cache. It is idempotent, and safe to call concurrently with
+// resolve.
+//
+// #5250 (A9 F3): two separate guarantees, because only the first is absolute.
+// After Close returns, NO new background lookup will ever be scheduled — that
+// one is unconditional, taken under mu, and is what stops an exporter's netlink
+// work from outliving it indefinitely. Close also WAITS for the lookups already
+// running, but only up to routeMaskCloseGrace; a lookup blocked in the kernel
+// past that is left to finish on its own. It can still write its result into
+// c.entries afterwards, which is harmless (the map outlives the cache only as
+// long as the cache does, and nothing reads it again) and is why this is a
+// bounded wait rather than a join.
+func (c *routeMaskCache) Close() {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.closed = true
+	c.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		c.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(routeMaskCloseGrace):
+	}
 }
 
 // populate runs a single background FIB lookup and stores the result so the
@@ -190,6 +252,7 @@ func (c *routeMaskCache) scheduleLookupLocked(key routeMaskKey, ip16 net.IP, ifi
 // the goroutine body scheduled by scheduleLookupLocked; the netlink round-trip
 // happens here, entirely off the EventReader callback path. #3743.
 func (c *routeMaskCache) populate(key routeMaskKey, ip net.IP, ifindex int) {
+	defer c.wg.Done()
 	mask, ok := c.lookup(ip, ifindex)
 	now := time.Now()
 	c.mu.Lock()

--- a/pkg/flowexport/routemask_close_5250_test.go
+++ b/pkg/flowexport/routemask_close_5250_test.go
@@ -1,0 +1,135 @@
+package flowexport
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// #5250 (A9 F3). routeMaskCache scheduled background netlink FIB lookups from
+// the session-close callback and had NO stop signal of any kind — no ctx, no
+// Close method, and NewRouteMaskResolver returned only a bare closure, so the
+// exporter that owned the cache could not have stopped it even if it wanted to.
+// A blocking RTM_GETROUTE could therefore be STARTED after the exporter had
+// been torn down.
+//
+// The absolute guarantee is the one this test pins: after Close returns, no
+// FURTHER lookup is ever scheduled.
+func TestRouteMaskCacheCloseSchedulesNoFurtherLookups(t *testing.T) {
+	var started atomic.Int64
+	done := make(chan struct{}, 16)
+	c := newRouteMaskCache(time.Hour)
+	c.lookup = func(net.IP, int) (uint8, bool) {
+		started.Add(1)
+		return 24, true
+	}
+	c.afterPopulate = func() { done <- struct{}{} }
+
+	// One pre-Close miss proves the seam is live before we close it — without
+	// this the post-Close assertion would also pass on a cache that never
+	// scheduled anything at all.
+	c.resolve(net.IPv4(198, 51, 100, 1), 3)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("setup: the pre-Close lookup never ran")
+	}
+	if got := started.Load(); got != 1 {
+		t.Fatalf("setup: want 1 lookup before Close, got %d", got)
+	}
+
+	c.Close()
+
+	// Ten distinct keys, so neither the dedup nor the in-flight cap can be
+	// what suppresses them.
+	for i := 0; i < 10; i++ {
+		mask, ok := c.resolve(net.IPv4(198, 51, 100, byte(100+i)), 3)
+		if ok || mask != 0 {
+			t.Fatalf("a post-Close miss must resolve to the default, got %d,%v", mask, ok)
+		}
+	}
+	// Give any wrongly-scheduled goroutine time to run before we read.
+	select {
+	case <-done:
+		t.Fatal("a background lookup ran AFTER Close — the closed flag is gone")
+	case <-time.After(200 * time.Millisecond):
+	}
+	if got := started.Load(); got != 1 {
+		t.Fatalf("%d lookups ran, want 1 (only the pre-Close one) — Close is not "+
+			"stopping the scheduler", got)
+	}
+}
+
+// Close is idempotent and does not hang on a second call.
+func TestRouteMaskCacheCloseIsIdempotent(t *testing.T) {
+	c := newRouteMaskCache(time.Hour)
+	c.lookup = func(net.IP, int) (uint8, bool) { return 0, false }
+	c.Close()
+	c.Close()
+}
+
+// Close waits for an in-flight lookup, but only up to routeMaskCloseGrace — a
+// netlink socket wedged in the kernel must not hold daemon shutdown open.
+func TestRouteMaskCacheCloseIsBoundedByTheGrace(t *testing.T) {
+	release := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	c := newRouteMaskCache(time.Hour)
+	c.lookup = func(net.IP, int) (uint8, bool) {
+		entered <- struct{}{}
+		<-release // never released until after Close has returned
+		return 0, false
+	}
+	c.resolve(net.IPv4(198, 51, 100, 9), 3)
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("setup: the blocking lookup never started")
+	}
+
+	start := time.Now()
+	c.Close()
+	elapsed := time.Since(start)
+	close(release)
+
+	if elapsed < routeMaskCloseGrace {
+		t.Fatalf("Close returned in %v — it did not wait for the in-flight lookup at all", elapsed)
+	}
+	if elapsed > routeMaskCloseGrace+2*time.Second {
+		t.Fatalf("Close blocked for %v on a wedged lookup — the wait is unbounded", elapsed)
+	}
+}
+
+// The exporters own a cache and must stop it: a NewExporter whose Close does
+// not reach the cache leaves the scheduler running for the process lifetime.
+func TestExporterCloseStopsTheRouteMaskCache(t *testing.T) {
+	e, err := NewExporter(&ExportConfig{InstanceName: "t", TemplateName: "t"})
+	if err != nil {
+		t.Fatalf("NewExporter: %v", err)
+	}
+	if e.maskCache == nil {
+		t.Fatal("NewExporter must build a closable route-mask cache")
+	}
+	e.Close()
+	e.maskCache.mu.Lock()
+	closed := e.maskCache.closed
+	e.maskCache.mu.Unlock()
+	if !closed {
+		t.Fatal("Exporter.Close did not close the route-mask cache")
+	}
+
+	ie, err := NewIPFIXExporter(&ExportConfig{InstanceName: "t", TemplateName: "t"})
+	if err != nil {
+		t.Fatalf("NewIPFIXExporter: %v", err)
+	}
+	if ie.maskCache == nil {
+		t.Fatal("NewIPFIXExporter must build a closable route-mask cache")
+	}
+	ie.Close()
+	ie.maskCache.mu.Lock()
+	closed = ie.maskCache.closed
+	ie.maskCache.mu.Unlock()
+	if !closed {
+		t.Fatal("IPFIXExporter.Close did not close the route-mask cache")
+	}
+}

--- a/pkg/grpcapi/server_helpers.go
+++ b/pkg/grpcapi/server_helpers.go
@@ -117,9 +117,14 @@ func (s *Server) telemetry() dataplane.Telemetry {
 
 type natRuleSetKey struct{ from, to string }
 
+// natSessionCounts accumulates in int64 and is CLAMPED at each protobuf
+// assignment (#5250, A8-b2 F3). It used to accumulate directly into int32, so a
+// session table larger than MaxInt32 wrapped the counter negative rather than
+// saturating — the same class #2282 fixed for the NAT port-pool size with
+// clampInt32, which lives one file over and simply was not applied here.
 type natSessionCounts struct {
-	total           int32
-	ruleSetSessions map[natRuleSetKey]int32
+	total           int64
+	ruleSetSessions map[natRuleSetKey]int64
 }
 
 func (s *Server) countSNATSessions(zoneByID map[uint16]string) natSessionCounts {
@@ -132,7 +137,7 @@ func (s *Server) countDNATSessions(zoneByID map[uint16]string) natSessionCounts 
 
 func (s *Server) countNATSessions(flag uint16, zoneByID map[uint16]string) natSessionCounts {
 	counts := natSessionCounts{
-		ruleSetSessions: make(map[natRuleSetKey]int32),
+		ruleSetSessions: make(map[natRuleSetKey]int64),
 	}
 	if !s.dataplaneLoaded() {
 		return counts

--- a/pkg/grpcapi/server_nat.go
+++ b/pkg/grpcapi/server_nat.go
@@ -88,14 +88,14 @@ func (s *Server) GetNATDestination(_ context.Context, _ *pb.GetNATDestinationReq
 			}
 		}
 		counts := s.countDNATSessions(zoneByID)
-		resp.TotalActiveTranslations = counts.total
+		resp.TotalActiveTranslations = clampInt32(counts.total)
 		for _, rs := range cfg.Security.NAT.Destination.RuleSets {
 			key := natRuleSetKey{rs.FromZone, rs.ToZone}
 			if cnt, ok := counts.ruleSetSessions[key]; ok {
 				resp.RuleSetSessions = append(resp.RuleSetSessions, &pb.NATRuleSetSessions{
 					FromZone: rs.FromZone,
 					ToZone:   rs.ToZone,
-					Sessions: cnt,
+					Sessions: clampInt32(cnt),
 				})
 			}
 		}
@@ -176,7 +176,7 @@ func (s *Server) GetNATPoolStats(_ context.Context, _ *pb.GetNATPoolStatsRequest
 		}
 		counts = s.countSNATSessions(zoneByID)
 	}
-	resp.TotalActiveTranslations = counts.total
+	resp.TotalActiveTranslations = clampInt32(counts.total)
 
 	// Interface-mode pools. Each interface-mode rule set must report only
 	// the SNAT sessions that traversed its own from/to zone pair, not the
@@ -190,7 +190,7 @@ func (s *Server) GetNATPoolStats(_ context.Context, _ *pb.GetNATPoolStatsRequest
 				resp.Pools = append(resp.Pools, &pb.NATPoolStats{
 					Name:        fmt.Sprintf("%s->%s", rs.FromZone, rs.ToZone),
 					Address:     "interface",
-					UsedPorts:   counts.ruleSetSessions[natRuleSetKey{rs.FromZone, rs.ToZone}],
+					UsedPorts:   clampInt32(counts.ruleSetSessions[natRuleSetKey{rs.FromZone, rs.ToZone}]),
 					IsInterface: true,
 				})
 			}
@@ -204,7 +204,7 @@ func (s *Server) GetNATPoolStats(_ context.Context, _ *pb.GetNATPoolStatsRequest
 			resp.RuleSetSessions = append(resp.RuleSetSessions, &pb.NATRuleSetSessions{
 				FromZone: rs.FromZone,
 				ToZone:   rs.ToZone,
-				Sessions: cnt,
+				Sessions: clampInt32(cnt),
 			})
 		}
 	}

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -324,7 +324,11 @@ func (s *Server) getSessionsCursor(ctx context.Context, req *pb.GetSessionsReque
 func (s *Server) setSessionsTotal(resp *pb.GetSessionsResponse, f *sessionFilter) error {
 	if !f.hasFilters {
 		v4, v6 := s.dp.SessionCount()
-		resp.Total = int32(v4 + v6)
+		// #5250 (A8-b2 F3): saturate rather than wrap. clampInt32 already
+		// existed in this package (server_nat.go, #2282) and simply was not
+		// applied to the session totals; an int64 that exceeds MaxInt32 turned
+		// into a NEGATIVE "Total sessions" in the CLI/gRPC view.
+		resp.Total = clampInt32(int64(v4) + int64(v6))
 		return nil
 	}
 	total := 0
@@ -344,7 +348,7 @@ func (s *Server) setSessionsTotal(resp *pb.GetSessionsResponse, f *sessionFilter
 	}); err != nil {
 		return status.Errorf(codes.Internal, "v6 session count: %v", err)
 	}
-	resp.Total = int32(total)
+	resp.Total = clampInt32(int64(total))
 	return nil
 }
 

--- a/pkg/grpcapi/session_total_clamp_5250_test.go
+++ b/pkg/grpcapi/session_total_clamp_5250_test.go
@@ -1,0 +1,73 @@
+package grpcapi
+
+import (
+	"math"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// clampTotalsDP reports session counts large enough that their sum overflows
+// int32. It embeds *dataplane.Manager for everything setSessionsTotal does not
+// touch on the no-filter path.
+type clampTotalsDP struct {
+	*dataplane.Manager
+	v4 int
+	v6 int
+}
+
+func (d *clampTotalsDP) IsLoaded() bool           { return true }
+func (d *clampTotalsDP) SessionCount() (int, int) { return d.v4, d.v6 }
+
+// #5250 (A8-b2 F3). setSessionsTotal wrote `int32(v4 + v6)` with no clamp, so a
+// sum past MaxInt32 WRAPPED — the operator-facing "Total sessions" went
+// NEGATIVE. clampInt32 (server_nat.go, added by #2282 for exactly this class on
+// the NAT port-pool size) sat unused one file over. Reverting either call site
+// to a bare int32() conversion makes this test RED with a negative Total.
+func TestSessionsTotalSaturatesInsteadOfWrapping(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		v4, v6 int
+		want   int32
+	}{
+		{"sum below the ceiling is exact", 1000, 2000, 3000},
+		{"sum exactly at the ceiling", math.MaxInt32, 0, math.MaxInt32},
+		{"sum one past the ceiling saturates", math.MaxInt32, 1, math.MaxInt32},
+		{"each half under, sum far over", math.MaxInt32 - 5, 1000, math.MaxInt32},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{dp: &clampTotalsDP{v4: tc.v4, v6: tc.v6}}
+			resp := &pb.GetSessionsResponse{}
+			if err := s.setSessionsTotal(resp, &sessionFilter{}); err != nil {
+				t.Fatalf("setSessionsTotal() error = %v", err)
+			}
+			if resp.Total < 0 {
+				t.Fatalf("Total = %d — a session count wrapped NEGATIVE; the int32 "+
+					"conversion is unclamped again", resp.Total)
+			}
+			if resp.Total != tc.want {
+				t.Fatalf("Total = %d, want %d", resp.Total, tc.want)
+			}
+		})
+	}
+}
+
+// The NAT session counters accumulate in int64 and clamp at the protobuf
+// boundary for the same reason.
+func TestNATSessionCountsClampAtTheWire(t *testing.T) {
+	if got := clampInt32(int64(math.MaxInt32) + 1); got != math.MaxInt32 {
+		t.Fatalf("clampInt32(MaxInt32+1) = %d, want MaxInt32", got)
+	}
+	var counts natSessionCounts
+	counts.total = int64(math.MaxInt32) + 100
+	if got := clampInt32(counts.total); got < 0 {
+		t.Fatalf("natSessionCounts.total clamped to %d — it must saturate, not wrap", got)
+	}
+	// The field must be wide enough to HOLD the over-range value in the first
+	// place: an int32 field would have wrapped at increment time, before any
+	// clamp could see it.
+	if counts.total <= math.MaxInt32 {
+		t.Fatalf("natSessionCounts.total narrowed to %d — the accumulator must be int64", counts.total)
+	}
+}


### PR DESCRIPTION
Closes #5250

Sweeps the ps-review-042 cohort **row by row** and fixes all ten live items. One
commit per row, each with tests that red on that row's revert.

## The count held — but it was verified, not trusted

The issue's summary line claimed "10 of 21 items live (11 fixed)". Every one of
the ten was re-read at `origin/master` a829e7746 before any code was written:

| Row | Site re-verified live |
|---|---|
| A9 F3 | `routemask.go` — still `go c.populate(...)`, no Close/Stop on the type at all |
| A9 F4 | `engine.go` — `onLatched map[string]bool`, still decided inside the clause walk |
| A6-b2 F1 | `manager_neighbor.go` — `fn(k.ifindex, ip)` still under `m.mu` |
| A6-b2 F3 | `nat.go` — still `for p := lo; p <= hi; p++ { ports = append(...) }` |
| A7-b1 F1 | `coalescence.go` — `bufio.NewScanner` with no `Buffer(`/`Err()` in the file |
| A7-b1 F4 | `daemon_ha.go` — still `time.AfterFunc` reading `d.cluster`, still two bare `time.Sleep` |
| A7-b2 F2 | `rss_indirection.go` — `readQueueCount` still `return 0` on ReadDir error |
| A8-b2 F3 | `server_sessions.go` — still `int32(v4 + v6)`; `natSessionCounts.total` still `int32` |
| A3-b2 F3 | `lifeline.go` — still `strings.HasPrefix(base, "fab")` |
| A3-b3 F-03 | `predefined.go` — `expandAppSet` still derefs `apps` unguarded |

**One row was mis-classified in the cohort, in the direction that matters.**
A9 F4 was filed as "a semantics question, not a proven defect — confirm against
Junos escalation semantics before changing it". Reading the code, it is a plain
order-dependent defect, and the test reproduces it exactly (below). The
"low materiality" framing on this cohort was worth looking past.

## The two that are not cosmetic

**A3-b2 F3 — a host-inbound default-deny bypass.** The unconditional fabric
lifeline arm was a bare `HasPrefix(base, "fab")`, and a lifeline is *skipped* by
`junosHostNonLifelineRefs` and `JunosHostZoneIngressNetdevs`. So an interface
named `fab-foo` / `fabric` / `fabX` — operator-chosen names; `schema_interfaces`
accepts a wildcard, and `chassis device-map` names the target directly — could
carry a `deny` toward `junos-host` that commits cleanly and **produces no kernel
rule at all**. Narrowed to `fab` + digits, the only shape the daemon creates
(`CleanupFabricIPVLANs`) or the compiler derives. A fabric/control link under any
other name must be DECLARED (`fabric-interface` / `control-interface`) — the
#3277 path, unchanged. The production-gate test reds on revert with
`zone guest on fab-guest.0 must contribute an ingress netdev; got []`.

**A9 F4 — a remediation policy that stops firing based on clause order.**
`within` clauses are ANDed and the `trigger on N` edge latch was decided from
inside the walk, returning mid-loop. With the LONG window written first and the
policy latched, the long clause was still above threshold, hit the latch check
and returned — so the SHORT clause, which had decayed below its own threshold
and was the one that should have RE-ARMED the latch, was never reached. The AND
went false then true again (a real crossing) and the policy stayed silent. The
test drives one timeline against both clause orderings; on `origin/master` it
prints the defect verbatim:

```
clause ORDER changed the outcome: long-window-first fired at [2],
short-window-first fired at [2 102]
```

Now three passes — validity, re-arm/latch over ALL trigger-on clauses, then
trigger-until — so the latch clears exactly when the ANDed condition is false.

## Revert-mutation matrix

One mutation per run, each restored before the next. Exit codes read from files,
never through a pipe.

| Row | Mutation | Result |
|---|---|---|
| A9 F3 | neuter the `closed` guard | RED — "a background lookup ran AFTER Close" |
| A9 F3 | drop `maskCache.Close()` from `Exporter.Close` | RED — "Exporter.Close did not close the route-mask cache" |
| A9 F4 | restore `engine.go` from master | RED — orderings disagree (above) |
| A6-b2 F1 | restore `manager_neighbor.go` from master | RED at the 5s deadline — "DEADLOCKED" |
| A6-b2 F3 | `appPortRangesFromSpec` → the old composition | RED — 261 allocs/call vs a ceiling of 2 |
| A7-b1 F1 | restore `coalescence.go` from master | RED ×2 — prefix reported `parsed=true`; 70 KiB line truncated |
| A7-b1 F4 | restore `daemon_ha.go` from master | RED ×2 at the 5s deadline vs a 30s configured timeout |
| A7-b2 F2 | narrow `readQueueCount` back to `int` | RED at COMPILE — interface + implementors |
| A8-b2 F3 | `clampInt32(...)` → `int32(v4 + v6)` | RED — `Total = -2147483648` |
| A8-b2 F3 | `natSessionCounts.total` back to `int32` | RED at COMPILE — clampInt32 args |
| A3-b2 F3 | restore `lifeline.go` from master | RED ×3 incl. the production gate |
| A3-b3 F-03 | restore `predefined.go` from master | RED — nil-pointer dereference panic |

Two rows are enforced at compile time rather than by a red test, and both are
seam/type changes where that is the stronger guard, not a weaker one.

**One gap, stated plainly.** The A7-b1 F4 `AfterFunc` capture has **no** unit
test. Its observable is an `UpdateInstances` landing on a torn-down VRRP manager,
which needs a live instance set and a real teardown the daemon fixture cannot
stage. The other half of that row (the ctx-less wait) has three tests, two of
which red on revert.

## Scope notes

- **`nat_destination.go` restructure.** `appTerm.ports []int` → `dstRanges` +
  `dstPortsPresent`. The bool preserves the one other thing the slice was read
  for — whether the source list was non-empty BEFORE coalescing, which the
  #3726/#3857 fail-closed test needs and a coalesced list cannot recover (a spec
  of `"0"` is present but coalesces away). All three construction sites and the
  rule-level override branch were converted together so `portConfigured`
  computes the same value; `portRanges` is only read or reassigned in the emit
  loop, never appended to, so no term can alias another's backing array. The
  existing DNAT fail-closed suite (#3429/#3437/#3726/#3857/#3434) passes.
- **`docs/refactoring-audit-current.txt` regenerated.** The A7-b1 F4 change
  carries `daemon_ha.go` across 2000 LOC (1945 → 2005) into the REFACTOR tier,
  which `make audit-check` gates on. I trimmed ~12 lines of genuinely redundant
  comment prose but stopped there rather than shaving to land at 1999, which
  would be gaming the gate. **Splitting `daemon_ha.go` is a separate work item
  and is deliberately not attempted here.**
- **The Rust `is_host_inbound_lifeline` / `userspaceSkipsIngressInterface`
  `fab` prefixes are NOT changed.** They are a different predicate — which
  netdevs the dataplane binds, not which zones get a deny program — and their
  over-match is documented as leaving an inert sentinel.

## Validation

- `go build ./...`, `go vet ./pkg/...` — exit 0.
- `go test ./... -count=1` over the full Go tree. Two flakes across two full
  runs, each green in isolation and in neither case in a package this PR
  touches: `pkg/ddns` (`bind: address already in use` on a hardcoded port) and
  `pkg/cluster/TestManualFailover_RetryablePreHookRetriesThenSucceeds` (a
  retry-window test that got one attempt in 100ms on a loaded box; passes 5/5
  alone and the whole package passes clean).
- **Zero Rust files touched** (`git diff --stat` shows no `.rs`/`.c`/`.h`), so
  the cargo leg is unaffected and was not run.
- **`pkg/daemon/daemon_ha.go` is HA/failover code — this PR OWES
  `make test-failover`, which this lane did not run.** It touches no
  `pkg/cluster`, `pkg/vrrp`, or session-sync code.

## Docs

`pkg/eventengine/README.md` (clause-order independence + the one deliberate
delta), `pkg/flowexport/README.md` (the closable cache and the two guarantees),
`docs/userspace-dnat-plan.md` (the range emitter), `docs/junos-cli-reference.md`
(the #3682 design question, now ANSWERED rather than left open),
`docs/host-inbound-service-matrix.md` + `docs/config-schema.md` (`fab*` →
`fab<N>`, with the notation defined once). No live module doc describes the
ethtool coalescence parser, the RSS indirection helper, or the failover
commit-ready wait — only archived review files and historical PR plans — so
those three rows carry no doc change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gf7Wu619ZSPt5QvzDZwAJG
