### PR TITLE
docs: point the rx_over_1514 mirror at its real doc

### DIFF
--- a/userspace-dp/src/afxdp/worker/loop_body/debug_report.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/debug_report.rs
@@ -89,6 +89,10 @@ pub(super) struct DbgCounters {
     pub(super) fwd_tcp_zero_window: u64,
     pub(super) rx_bytes_total: u64,
     pub(super) tx_bytes_total: u64,
+    /// Mirror of the binding counter. See `afxdp::types::runtime` for what
+    /// this counts and what it does NOT mean: it is a fixed >1514-byte frame
+    /// census, not an MTU-violation count, so tagged full-MTU and jumbo
+    /// frames land in it as ordinary traffic (#5190 A1-b1-F7).
     pub(super) rx_over_1514: u64,
     pub(super) rx_max_frame: u32,
     pub(super) tx_max_frame: u32,


### PR DESCRIPTION
`DbgCounters.rx_over_1514` is a **mirror** of the binding counter. After #5190 the documentation explaining what it counts lives only at the real declaration in `afxdp::types::runtime` — a reader landing on the mirror had no pointer to it, and the name alone invites exactly the wrong reading.

That wrong reading is the whole reason the field was renamed from `rx_oversized`: it is a **fixed >1514-byte frame census, not an MTU-violation count**. It runs in `record_rx_descriptor_telemetry`, *before* the shim metadata is parsed, so there is no per-interface MTU awareness and not even 802.1Q tag presence is known yet. A valid in-band tagged full-MTU frame (1518 bytes) and every jumbo frame land in it. On a VLAN-trunked WAN path it counts **ordinary traffic**, so reading it as an anomaly signal is wrong.

## Provenance

Carried across from **PR #7200**, which had documented the mirror in its own version of the A1-b1-F7 rename. When #7226 landed the rename first, #7200 correctly dropped the whole row — and this pointer would have been lost with it. Its author asked for it to be carried rather than kept for authorship: *"the pointer is the point."*

The two PRs' `debug_report.rs` hunks were measured against each other during that reconciliation: #7200's `@@ -82` added two lines where #7226's added zero, and chasing that two-line delta is what surfaced this as the single genuine casualty of the drop.

## Scope

Four lines, comment-only. No executable code changes, so the helper's `.text` is unaffected even though the object file hash moves — **no cluster smoke owed on artifact grounds**.

## Validation

- `cargo check --bins --tests` → **rc=0**
- `cargo check --bins --tests --features debug-log` → **rc=0**

Both configurations checked because the only reader of this counter is behind `debug-log`. Exit codes read from `$?` directly, never through a pipe.