### PR TITLE
vrrp: fence the failover ack on RETH VIP release (#6177 item 1)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -99519,3 +99519,19 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: `userspace-dp/src/afxdp/mod.rs`,
   `userspace-dp/src/server/helpers/status.rs`,
   `userspace-dp/tests/heartbeat_failclosed_doc_guard.rs` (new)
+
+## 2026-08-21 — #6177 item 1: fence the remote-failover ack on RETH VIP release
+- **Timestamp**: 2026-08-21
+- **Action**: Close the RETH VIP-removal sub-ms two-owner residual. `vrrp.ResignRG`
+  now returns a `*ResignBarrier` armed on every targeted instance before
+  `triggerResign`; instances report to it from the sites that actually complete a
+  VIP release (`becomeBackup` with the `removeVIPs` verdict, the MASTER-arm
+  shutdown removal, a new BACKUP-arm `resignCh` consumer, and `stop()`).
+  `handleClusterEvent` defers the demotion fence verdict to
+  `awaitRethVIPRelease`, which resolves `signalFailoverActuated` /
+  `signalFailoverActuationFailed` from the release itself, on its own goroutine.
+- **File(s)**: pkg/vrrp/resign_barrier.go (new), pkg/vrrp/instance.go,
+  pkg/vrrp/manager.go, pkg/daemon/daemon.go, pkg/daemon/daemon_ha.go,
+  pkg/vrrp/resign_barrier_6177_test.go (new),
+  pkg/daemon/daemon_ha_reth_vip_fence_6177_test.go (new),
+  docs/session-sync-architecture.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -1668,10 +1668,12 @@ by the daemon's `watchClusterEvents` consumer, not synchronously inside
 On the RETH-VRRP path `ResignRG` itself is only half-synchronous: it drops the
 instance priority to 0 under the instance lock and then does a **non-blocking**
 send on `resignCh`. The priority-0 adverts and the `becomeBackup` VIP removal
-run on the VRRP instance's own loop, so "resigned" below means *resignation
-signalled and priority driven to 0*, not *VIPs off the wire* (#6177 item 1).
+run on the VRRP instance's own loop, so `ResignRG` *returning* means
+*resignation signalled and priority driven to 0*, not *VIPs off the wire*.
 Direct-VIP mode (`no-reth-vrrp`) has no such gap — `reconcileDirectVIPOwnership`
-removes the addresses inline on the event goroutine.
+removes the addresses inline on the event goroutine. `ResignRG` therefore
+returns a `vrrp.ResignBarrier`, and the fence waits on it rather than on the
+call returning (step 5 below, #6177 item 1).
 
 `handleRemoteFailover` (`pkg/cluster/sync_failover.go`) therefore must **not**
 reply `failoverAckApplied` the instant `OnRemoteFailover` returns: the sender
@@ -1715,7 +1717,25 @@ The fix gates the applied-ack on a fence-completion barrier:
    left in the map for `waitFailoverActuated` to consume (a re-arm replaces it):
    deleting it at resolution time would make a failure that lands before the
    waiter arrives read as "never armed", i.e. success.
-5. The wait is bounded by `failoverActuateTimeout` (3s default). A demotion that
+5. On the RETH-VRRP path the verdict is deferred to the **VIP release itself**
+   (#6177 item 1). `ResignRG` returns a `vrrp.ResignBarrier` armed on every
+   targeted instance BEFORE `triggerResign`; each instance reports to it from
+   the site that actually completes a release — `becomeBackup` (with the
+   `removeVIPs` outcome), the MASTER-arm shutdown removal, the BACKUP arm of the
+   run loop consuming a resign token for an instance that was already BACKUP,
+   and `stop()` for a retired instance. `handleClusterEvent` hands the barrier to
+   `awaitRethVIPRelease` **on its own goroutine** — `watchClusterEvents`
+   serialises every cluster event, so blocking there would stall unrelated RGs
+   behind one VIP removal — and that resolves the fence: `signalFailoverActuated`
+   on a clean release, `signalFailoverActuationFailed` when `removeVIPs` failed
+   (a stale VIP is still answering ARP, so it is not a two-owner-safe
+   resignation) or when the release does not report within
+   `rethVIPReleaseTimeout` (500 ms default — far below the 3 s
+   `failoverActuateTimeout` so the verdict NAMES the un-released addresses, and
+   far below the initiator's 20 s ack timeout so the ack is a decision, not a
+   hang). Already-BACKUP and no-instance RGs resolve promptly rather than
+   stalling, so a clean failover is not downgraded to a hold.
+6. The wait is bounded by `failoverActuateTimeout` (3s default). A demotion that
    never actuates (superseded reset, event-channel drop) downgrades the ack to
    `failoverAckFailed` so the peer **holds** rather than promoting into the
    two-owner window — safety over latency in the race. On the normal path the
@@ -1726,18 +1746,17 @@ The batch path (`handleRemoteFailoverBatch` / `WaitFailoverAppliedBatch`) applie
 the same barrier across the whole set, all members armed under the one batch
 request id; the first non-nil verdict fails the batch ack.
 
-**Residual (#6177 item 1, open).** On the RETH-VRRP path the barrier releases
-once resignation has been *signalled* (priority 0 set synchronously) and
-`rg_active` is cleared — not once `becomeBackup` has physically removed the
-VIPs. A sub-millisecond window therefore remains in which the peer may promote
-while the old owner's VIPs are still on the interface. It is safe-direction
-rather than benign-by-luck: priority-0 is set synchronously so the resigning
-node cannot win a re-election, and the demotion preflight
+**Closed (#6177 item 1).** The RETH-VRRP path used to release the barrier once
+resignation had been *signalled* (priority 0 set synchronously) and `rg_active`
+was cleared — not once `becomeBackup` had physically removed the VIPs — leaving
+a sub-millisecond window in which the peer could promote while the old owner's
+VIPs were still on the interface. Step 5 above closes it by gating the release
+on a `becomeBackup` completion signal out of the VRRP instance loop. The
+pre-existing mitigations still stand behind it: priority-0 is set synchronously
+so the resigning node cannot win a re-election, and the demotion preflight
 (`tryPrepareUserspaceRGDemotion`) has already shifted the flow cache to
 `FabricRedirect`, so transit traffic reaching the old owner is forwarded over
-the fabric rather than dropped. Closing it means gating the barrier release on a
-`becomeBackup` completion signal from the VRRP instance loop, which is a change
-to the VRRP state machine rather than to this barrier.
+the fabric rather than dropped.
 
 Once the RG is marked standby, each worker processes a
 `WorkerCommand::DemoteOwnerRGS` on its packet thread

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -969,6 +969,16 @@ type Daemon struct {
 	// that is never actuated (superseded reset, event-channel drop) downgrades
 	// the ack to failed instead of hanging the peer's failover request.
 	failoverActuateTimeout time.Duration
+	// rethVIPReleaseTimeout bounds awaitRethVIPRelease — the #6177 item 1 wait
+	// for the RETH VRRP instances to physically remove their virtual addresses
+	// before the remote-failover applied-ack releases. Zero ⇒ the package
+	// default (rethVIPReleaseTimeout); tests shorten it.
+	rethVIPReleaseTimeout time.Duration
+	// resignRethRGFn overrides the RETH VRRP resignation performed on a
+	// demotion (#6177 item 1). Production leaves it nil and the demotion calls
+	// vrrpMgr.ResignRG directly; unit tests inject a barrier they control so
+	// the deferred fence verdict is drivable without real VRRP instances.
+	resignRethRGFn func(rgID int) vipReleaseBarrier
 	// Test hooks for direct-mode VIP ownership reconciliation.
 	directAddVIPsFn        func(int) int
 	directRemoveVIPsFn     func(int) int

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -334,6 +334,88 @@ func (d *Daemon) waitFailoverActuated(rgID int, reqID uint64) error {
 	}
 }
 
+// vipReleaseBarrier is the completion surface awaitRethVIPRelease waits on:
+// *vrrp.ResignBarrier in production. Taking the interface rather than the
+// concrete type is what lets the deferred-verdict wiring be driven in a unit
+// test without real VRRP instances and live netlink.
+type vipReleaseBarrier interface {
+	// Done closes once every targeted VRRP instance has released its VIPs.
+	Done() <-chan struct{}
+	// Err is the release verdict, valid once Done has closed.
+	Err() error
+}
+
+// resignRethRG drives the RETH VRRP resignation for rgID and returns the
+// barrier that completes when the virtual addresses are actually off the
+// interface (#6177 item 1). A nil return means there is nothing to wait for and
+// the caller resolves its fence immediately — the pre-#6177 behaviour, which is
+// correct only when no RETH VIP tenure exists to release.
+//
+// resignRethRGFn is the unit-test seam; production leaves it nil.
+func (d *Daemon) resignRethRG(rgID int) vipReleaseBarrier {
+	if d.resignRethRGFn != nil {
+		return d.resignRethRGFn(rgID)
+	}
+	if d.vrrpMgr == nil {
+		return nil
+	}
+	return d.vrrpMgr.ResignRG(rgID)
+}
+
+// rethVIPReleaseTimeout bounds awaitRethVIPRelease. VIP removal is a handful of
+// netlink deletes on the VRRP instance goroutine — sub-millisecond in practice,
+// and the whole RETH failover budget is ~60ms — so anything approaching this
+// bound means the run loop is not making progress (wedged, or retired between
+// the arm and the release). It is deliberately far BELOW failoverActuateTimeout
+// (3s) so the peer-facing verdict names the VIP release as the thing that did
+// not happen instead of surfacing as a generic barrier timeout, and far below
+// the initiator's 20s ack timeout so the ack is a decision, not a hang.
+const rethVIPReleaseTimeout = 500 * time.Millisecond
+
+// awaitRethVIPRelease resolves rgID's fence barrier on the ACTUAL removal of the
+// RETH virtual addresses (#6177 item 1).
+//
+// #5640 withheld the remote-failover applied-ack until the local demotion was
+// actuated, but on the RETH-VRRP path "actuated" meant ResignRG had returned:
+// priority-0 written (synchronously — so the resigning node cannot win a
+// re-election) and a non-blocking resignCh send performed. The advert burst and
+// the becomeBackup VIP removal still ran afterwards on the instance goroutine,
+// so the peer could promote — add VIPs, GARP — while this node's addresses were
+// still on the interface. A sub-millisecond two-owner residual, but a real one,
+// and the reason this issue carries the security label. Direct-VIP mode
+// (no-reth-vrrp) never had the gap: reconcileDirectVIPOwnership removes the
+// addresses inline on this goroutine.
+//
+// A failed release, and an expiry, both resolve the barrier with a FAILURE
+// verdict: the sync layer downgrades the applied-ack to failed and the peer
+// HOLDS rather than promoting into a window where both nodes answer for the
+// VIP. That is the safe direction — a held failover is recoverable, a
+// duplicate-address window is not — and it is not the common case: a VRRP
+// instance that is already BACKUP consumes the resign token on its next loop
+// hop and reports a clean release, and an RG with no RETH instances at all
+// yields a barrier that is born complete.
+func (d *Daemon) awaitRethVIPRelease(rgID int, barrier vipReleaseBarrier) {
+	timeout := d.rethVIPReleaseTimeout
+	if timeout <= 0 {
+		timeout = rethVIPReleaseTimeout
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-barrier.Done():
+		if err := barrier.Err(); err != nil {
+			d.signalFailoverActuationFailed(rgID, fmt.Errorf(
+				"redundancy group %d RETH virtual addresses not released on demotion: %w", rgID, err))
+			return
+		}
+		d.signalFailoverActuated(rgID)
+	case <-timer.C:
+		d.signalFailoverActuationFailed(rgID, fmt.Errorf(
+			"timed out after %s waiting for redundancy group %d RETH virtual addresses to be released",
+			timeout, rgID))
+	}
+}
+
 // waitFailoverActuatedBatch blocks until every RG in the batch transfer-out
 // reqID has been fenced, or returns the first RG's failure verdict (#5640).
 func (d *Daemon) waitFailoverActuatedBatch(rgIDs []int, reqID uint64) error {
@@ -489,10 +571,14 @@ func (d *Daemon) handleClusterEvent(ctx context.Context, ev cluster.ClusterEvent
 		if clusterDemotionEdge && d.dataplane() != nil {
 			d.tryPrepareUserspaceRGDemotion(ev.GroupID)
 		}
+		// #6177 item 1: capture the RETH resign barrier so the fence verdict
+		// below can be released on the VIPs actually leaving the interface,
+		// not merely on the resignation having been signalled.
+		var rethResign vipReleaseBarrier
 		if !noRethVRRP {
 			if ev.OldState == cluster.StatePrimary &&
 				(ev.NewState == cluster.StateSecondary || ev.NewState == cluster.StateSecondaryHold) {
-				d.vrrpMgr.ResignRG(ev.GroupID)
+				rethResign = d.resignRethRG(ev.GroupID)
 			}
 		}
 		// Deactivation: blackhole routes first (if transitioning
@@ -540,9 +626,20 @@ func (d *Daemon) handleClusterEvent(ctx context.Context, ev cluster.ClusterEvent
 		// promoting into a two-owner window. Reporting the failure (rather
 		// than staying silent) keeps the waiter from burning its full
 		// timeout on a fence that is already known not to have landed.
-		if actuateErr != nil {
+		//
+		// #6177 item 1: on the RETH-VRRP path the VIP removal runs on the VRRP
+		// instance goroutine, so at this point the resignation is only
+		// SIGNALLED (priority-0 is set synchronously, the addresses are not yet
+		// off the wire). Hand the verdict to awaitRethVIPRelease, which resolves
+		// the barrier from the release itself. It runs on its own goroutine
+		// because handleClusterEvent serialises every cluster event — blocking
+		// here would stall unrelated RGs' state changes behind one VIP removal.
+		switch {
+		case actuateErr != nil:
 			d.signalFailoverActuationFailed(ev.GroupID, actuateErr)
-		} else {
+		case rethResign != nil:
+			go d.awaitRethVIPRelease(ev.GroupID, rethResign)
+		default:
 			d.signalFailoverActuated(ev.GroupID)
 		}
 	}

--- a/pkg/daemon/daemon_ha_reth_vip_fence_6177_test.go
+++ b/pkg/daemon/daemon_ha_reth_vip_fence_6177_test.go
@@ -1,0 +1,227 @@
+package daemon
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/vrrp"
+)
+
+// #6177 item 1 — the remote-failover applied-ack must be fenced on the RETH
+// VIPs actually LEAVING the interface, not on the resignation having been
+// signalled.
+//
+// #5640 withheld the ack until the demotion was "actuated", but on the
+// RETH-VRRP path ResignRG only writes priority-0 synchronously and then does a
+// non-blocking send on resignCh: the advert burst and the becomeBackup VIP
+// removal run afterwards, on the VRRP instance goroutine. The peer therefore
+// received "applied" and promoted — adding VIPs, sending GARP — while this node
+// still owned the virtual address. Sub-millisecond, but a genuine two-owner
+// window, and the reason the issue carries the security label.
+//
+// Direct-VIP mode (`private-rg-election` / `no-reth-vrrp`) never had the gap and
+// is covered unchanged by the #6371 tests, which run on that path.
+
+// fakeVIPRelease is a caller-driven vipReleaseBarrier standing in for
+// *vrrp.ResignBarrier, so this test drives the ORDERING without real VRRP
+// instances or live netlink. pkg/vrrp owns the "the barrier tracks the real VIP
+// removal" half (resign_barrier_6177_test.go); this file owns the "the daemon
+// waits for it" half.
+type fakeVIPRelease struct {
+	done chan struct{}
+	mu   sync.Mutex
+	err  error
+	once sync.Once
+}
+
+func newFakeVIPRelease() *fakeVIPRelease {
+	return &fakeVIPRelease{done: make(chan struct{})}
+}
+
+func (f *fakeVIPRelease) Done() <-chan struct{} { return f.done }
+
+func (f *fakeVIPRelease) Err() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.err
+}
+
+func (f *fakeVIPRelease) release(err error) {
+	f.once.Do(func() {
+		f.mu.Lock()
+		f.err = err
+		f.mu.Unlock()
+		close(f.done)
+	})
+}
+
+// rethFenceClusterSet is fenceStartupClusterSet on the RETH-VRRP path:
+// `no-private-rg-election` turns off the production default so isNoRethVRRP()
+// is FALSE and handleClusterEvent takes the ResignRG branch under test.
+const rethFenceClusterSet = fenceStartupClusterSet +
+	"set chassis cluster no-private-rg-election\n"
+
+// newRethFenceDaemon is newActuationDaemon on the RETH-VRRP path, with the
+// resignation seam pointed at the caller's barrier.
+func newRethFenceDaemon(t *testing.T, ha *actuationHA, barrier vipReleaseBarrier) *Daemon {
+	t.Helper()
+	cm := cluster.NewManager(0, 1)
+	cm.UpdateConfig(&config.ClusterConfig{
+		RedundancyGroups: []*config.RedundancyGroup{
+			{ID: 0, NodePriorities: map[int]int{0: 200}},
+			{ID: 1, NodePriorities: map[int]int{0: 200}},
+		},
+	})
+	d := &Daemon{
+		store:                      fenceTestStore(t, rethFenceClusterSet),
+		cluster:                    cm,
+		vrrpMgr:                    vrrp.NewManager(),
+		rgStates:                   make(map[int]*rgStateMachine),
+		failoverActuateWait:        make(map[failoverActuationKey]*failoverActuation),
+		failoverActuateTimeout:     2 * time.Second,
+		rethVIPReleaseTimeout:      time.Second,
+		userspaceDemotionPrepUntil: make(map[int]time.Time),
+	}
+	d.resignRethRGFn = func(int) vipReleaseBarrier { return barrier }
+	d.setDataplane(&actuationDP{ha: ha})
+	// Precondition: this daemon really is on the RETH-VRRP path. Without it
+	// every assertion below would silently be testing the direct-VIP branch.
+	if d.isNoRethVRRP() {
+		t.Fatal("setup: isNoRethVRRP() is true — the RETH ResignRG branch is not reachable")
+	}
+	return d
+}
+
+// TestRethDemotionFenceWaitsForVIPRelease_6177 is the fail-on-revert guard. The
+// applied-ack waiter must still be BLOCKED after handleClusterEvent has run the
+// whole demotion — priority-0 written, rg_active cleared — and must release only
+// once the VIP removal reports.
+//
+// RED on revert: restore the pre-#6177 `d.signalFailoverActuated(ev.GroupID)`
+// as the unconditional else-branch (or drop the `case rethResign != nil` arm)
+// and waitFailoverActuated returns nil at the first assertion, while the VIPs
+// are demonstrably still on the interface.
+func TestRethDemotionFenceWaitsForVIPRelease_6177(t *testing.T) {
+	ha := &actuationHA{}
+	barrier := newFakeVIPRelease()
+	d := newRethFenceDaemon(t, ha, barrier)
+	primeRG1Primary(t, d)
+
+	d.armFailoverActuation(1, actuationReqID)
+
+	waited := make(chan error, 1)
+	go func() { waited <- d.waitFailoverActuated(1, actuationReqID) }()
+
+	demoteRG1(t, d)
+
+	// Positive control: the demotion really reached the rg_active clear, so a
+	// still-blocked waiter is about the VIP fence and not about a demotion
+	// that never ran.
+	if got := ha.writeCount(); got != 1 {
+		t.Fatalf("SetRGActive call count = %d, want 1 (the demotion must attempt the clear)", got)
+	}
+	if active, ok := ha.lastWrite(); !ok || active {
+		t.Fatalf("SetRGActive wrote active=%v, want false", active)
+	}
+
+	// THE assertion: the VIPs have not been released, so the peer must not
+	// have been told the transfer applied.
+	select {
+	case err := <-waited:
+		t.Fatalf("applied-ack released with err=%v while the RETH virtual addresses were "+
+			"still on the interface — the peer would promote into a two-owner window (#6177 item 1)", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	barrier.release(nil)
+
+	select {
+	case err := <-waited:
+		if err != nil {
+			t.Fatalf("applied-ack verdict = %v, want nil after a clean VIP release", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("applied-ack never released after the VIP release reported — a clean failover " +
+			"must not be downgraded to a hold")
+	}
+}
+
+// TestRethDemotionFenceFailsOnVIPReleaseError_6177 pins the verdict direction
+// when the release itself failed: a stale VIP is still answering ARP, so the
+// ack must be downgraded and the peer must hold.
+func TestRethDemotionFenceFailsOnVIPReleaseError_6177(t *testing.T) {
+	injected := errors.New("netlink AddrDel refused")
+	ha := &actuationHA{}
+	barrier := newFakeVIPRelease()
+	d := newRethFenceDaemon(t, ha, barrier)
+	primeRG1Primary(t, d)
+
+	d.armFailoverActuation(1, actuationReqID)
+	barrier.release(injected)
+	demoteRG1(t, d)
+
+	err := d.waitFailoverActuated(1, actuationReqID)
+	if err == nil {
+		t.Fatal("applied-ack released after the RETH VIP removal FAILED (#6177 item 1)")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("fence verdict = %v, want it to carry the VIP-removal failure", err)
+	}
+}
+
+// TestRethDemotionFenceFailsWhenVIPReleaseStalls_6177 covers the wedged /
+// retired run-loop case: no release signal can arrive. The bounded wait must
+// produce a NAMED failure — so the operator sees which fence did not close —
+// rather than hanging the peer's request or, worse, reporting success.
+func TestRethDemotionFenceFailsWhenVIPReleaseStalls_6177(t *testing.T) {
+	ha := &actuationHA{}
+	barrier := newFakeVIPRelease() // never released
+	d := newRethFenceDaemon(t, ha, barrier)
+	d.rethVIPReleaseTimeout = 50 * time.Millisecond
+	primeRG1Primary(t, d)
+
+	d.armFailoverActuation(1, actuationReqID)
+	demoteRG1(t, d)
+
+	err := d.waitFailoverActuated(1, actuationReqID)
+	if err == nil {
+		t.Fatal("applied-ack released although the RETH VIP release never reported (#6177 item 1)")
+	}
+	if !strings.Contains(err.Error(), "virtual addresses") {
+		t.Fatalf("fence verdict = %q, want it to name the un-released virtual addresses", err)
+	}
+	// The verdict must come from the VIP sub-wait, not from the outer
+	// failoverActuateTimeout — the latter is 2s here and would delay the peer.
+	if strings.Contains(err.Error(), "timed out waiting for local fence actuation") {
+		t.Fatalf("fence verdict = %q, want the VIP release timeout not the outer barrier timeout", err)
+	}
+}
+
+// TestRethDemotionFenceNoVRRPInstancesAcksPromptly_6177 is the negative
+// control: an RG with no RETH VIP tenure to release must not be made to wait.
+// It drives the REAL vrrp.Manager (no seam), so it also pins that ResignRG's
+// production return value is usable as a fence — a nil return there would make
+// every RETH demotion take the immediate branch and silently reopen the window.
+func TestRethDemotionFenceNoVRRPInstancesAcksPromptly_6177(t *testing.T) {
+	ha := &actuationHA{}
+	d := newRethFenceDaemon(t, ha, nil)
+	d.resignRethRGFn = nil // real vrrp.Manager, zero instances
+	primeRG1Primary(t, d)
+
+	d.armFailoverActuation(1, actuationReqID)
+	demoteRG1(t, d)
+
+	start := time.Now()
+	if err := d.waitFailoverActuated(1, actuationReqID); err != nil {
+		t.Fatalf("waitFailoverActuated = %v, want nil for an RG with no RETH VIP tenure", err)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("applied-ack took %s for an RG with nothing to release — the fence must not "+
+			"turn a clean failover into a stall", elapsed)
+	}
+}

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -2,6 +2,7 @@ package vrrp
 
 import (
 	"bytes"
+	"fmt"
 	"log/slog"
 	"net"
 	"strings"
@@ -271,6 +272,24 @@ type vrrpInstance struct {
 	// interface (#2528). Production leaves it nil and interfaceAddrs() queries
 	// vi.iface.Addrs() live on every resolve.
 	addrsFn func() ([]net.Addr, error)
+
+	// resignAckMu guards resignAcks: the set of #6177 ResignBarriers waiting
+	// for THIS instance to finish RELEASING its virtual addresses after a
+	// forced resignation. A barrier is armed by the manager BEFORE
+	// triggerResign, and reported to from the sites that actually complete a
+	// VIP release, so a waiter can never be told "released" by a code path
+	// that only signalled the resignation.
+	//
+	// Arming does NOT shortcut on state: reading "already BACKUP" and
+	// completing the barrier immediately would be wrong exactly when it
+	// matters, because becomeBackup publishes BACKUP (setState) BEFORE it
+	// runs removeVIPs — the VIP can still be on the wire while the state
+	// already reads BACKUP. Instead the BACKUP arm of the run loop consumes
+	// the resign token and reports there, so a genuinely already-resigned
+	// instance completes the barrier on the next loop hop rather than
+	// stalling it.
+	resignAckMu sync.Mutex
+	resignAcks  []*ResignBarrier
 }
 
 func newInstance(cfg Instance, iface *net.Interface, eventCh chan<- VRRPEvent, onEventDrop func()) *vrrpInstance {
@@ -377,6 +396,44 @@ func (vi *vrrpInstance) triggerResign() {
 	case vi.resignCh <- struct{}{}:
 	default:
 	}
+}
+
+// armResignAck registers b as a waiter for this instance's next VIP release.
+// The manager calls it BEFORE triggerResign so the run loop cannot complete the
+// release between the arm and the trigger and leave the waiter unreported.
+func (vi *vrrpInstance) armResignAck(b *ResignBarrier) {
+	if b == nil {
+		return
+	}
+	vi.resignAckMu.Lock()
+	vi.resignAcks = append(vi.resignAcks, b)
+	vi.resignAckMu.Unlock()
+}
+
+// notifyResigned reports outcome err to every barrier armed on this instance
+// and clears the list, so each registration is reported exactly once and a
+// later release cannot double-report an already-completed barrier. err is the
+// VIP-removal outcome: nil means the addresses are off the wire.
+func (vi *vrrpInstance) notifyResigned(err error) {
+	vi.resignAckMu.Lock()
+	waiters := vi.resignAcks
+	vi.resignAcks = nil
+	vi.resignAckMu.Unlock()
+	for _, b := range waiters {
+		b.report(err)
+	}
+}
+
+// staleVIPResignErr converts a lingering VIP divergence (#5482) into a resign
+// verdict. An instance that is already BACKUP has no VIP tenure to tear down —
+// unless a previous removal FAILED and its async reconcile has not yet cleared
+// the address, in which case this node may still be answering ARP for the VIP
+// and must not report a clean release to a two-owner fence (#6177 item 1).
+func (vi *vrrpInstance) staleVIPResignErr() error {
+	if vi.vipDiverged.Load() {
+		return fmt.Errorf("%w: instance %s", ErrStaleVIPOnBackup, vi.key())
+	}
+	return nil
 }
 
 // getPreempt reports the EFFECTIVE preempt mode. It is the configured
@@ -856,6 +913,20 @@ func (vi *vrrpInstance) stepBackup(masterDownTimer, advertTimer, preemptHoldTime
 			stopAndDrainTimer(masterDownTimer)
 			masterDownTimer.Reset(vi.masterDownInterval())
 		}
+	case <-vi.resignCh:
+		// #6177 item 1: a forced resignation arrived while this instance is
+		// ALREADY BACKUP — a cluster demotion for an RG whose VRRP tenure had
+		// already ended (peer preempted us, a link-down demotion landed first,
+		// a reconcile-driven re-resign). There is no MASTER tenure to tear
+		// down, so nothing more will remove VIPs on our behalf and the token
+		// would otherwise sit unread in resignCh forever, stalling the fence
+		// barrier until its timeout and downgrading a clean failover to a hold.
+		//
+		// Consume it here and report the honest verdict: a clean release
+		// unless a PREVIOUS removal failed and its #5482 reconcile has not yet
+		// cleared the address, in which case a VIP may still be answering ARP
+		// and this is not a two-owner-safe resignation.
+		vi.notifyResigned(vi.staleVIPResignErr())
 	case <-vi.configUpdatedCh:
 		// A config update landed (updateConfig) while this BACKUP select was
 		// running (#2900). If a preempt hold-time is armed, the new config may
@@ -996,10 +1067,15 @@ func (vi *vrrpInstance) run() {
 				}
 				// Best-effort at process exit: log a removal failure but do not
 				// schedule a reconcile (stopCh is closed, the run-loop is ending).
-				if err := vi.removeVIPs(); err != nil {
+				err := vi.removeVIPs()
+				if err != nil {
 					slog.Warn("vrrp: VIP removal failed during resignation shutdown",
 						"key", vi.key(), "err", err)
 				}
+				// #6177: the run loop is ending, so this is the last VIP
+				// release it will ever perform. Report it rather than
+				// stranding a barrier armed just before the shutdown.
+				vi.notifyResigned(err)
 				return
 			case pkt := <-vi.rxCh:
 				vi.handleMasterRx(pkt, masterDownTimer, advertTimer)
@@ -1366,7 +1442,8 @@ func (vi *vrrpInstance) becomeBackup(masterDownTimer, advertTimer *time.Timer) {
 	slog.Info("vrrp: transitioning to BACKUP",
 		"key", vi.key())
 	vi.setState(StateBackup)
-	vi.surfaceStaleVIP(vi.removeVIPs(), "becomeBackup")
+	removeErr := vi.removeVIPs()
+	vi.surfaceStaleVIP(removeErr, "becomeBackup")
 	advertTimer.Stop()
 	masterDownTimer.Reset(vi.masterDownInterval())
 	// A MASTER stepping down to a worthy higher/tie-break master begins a
@@ -1377,6 +1454,13 @@ func (vi *vrrpInstance) becomeBackup(masterDownTimer, advertTimer *time.Timer) {
 	vi.skipNextPreemptHold = false
 	vi.mu.Unlock()
 	vi.emitEvent()
+	// #6177 item 1: the VIPs are now physically off the interface (or
+	// removeErr says why they are not). Report to every resign barrier armed
+	// on this instance so a fenced remote failover releases its applied-ack on
+	// VIP REMOVAL, not merely on "resignation signalled + priority 0". This is
+	// the last statement in the function on purpose: a waiter that observes the
+	// completion must not be able to observe it before the removal ran.
+	vi.notifyResigned(removeErr)
 }
 
 // stop signals the instance goroutine to stop and waits for it to finish.
@@ -1389,4 +1473,11 @@ func (vi *vrrpInstance) stop() {
 	// vi.conn and receiverAfPacket()'s vi.afPacketFD reads.
 	vi.closeSocketDescriptors()
 	<-vi.stopped
+	// #6177: the run loop has exited. Anything armed after its final release
+	// (or armed against an instance that was never MASTER) will never be
+	// reported by the loop, so report it here rather than leaving the caller's
+	// fence to burn its timeout. The instance is retired: it holds no VIP
+	// tenure, so a clean verdict is honest unless a removal is known to have
+	// failed and not been reconciled.
+	vi.notifyResigned(vi.staleVIPResignErr())
 }

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -718,22 +718,41 @@ func (m *Manager) UpdateInstances(desired []*Instance) error {
 // re-election before the debounced priority update fires.
 // Used when cluster state transitions from Primary to Secondary
 // (manual failover, weight drop, etc.) in non-preempt mode.
-func (m *Manager) ResignRG(rgID int) {
+//
+// The returned ResignBarrier completes when every targeted instance has
+// physically released its virtual addresses (#6177 item 1). The priority-0
+// write is synchronous, but triggerResign is not: the advert burst and the
+// becomeBackup VIP removal run on each instance's own goroutine, so ResignRG
+// returning means "resignation signalled and priority driven to 0", NOT "the
+// VIPs are off the wire". A caller fencing a remote failover against a
+// two-owner window must wait on the barrier; a caller that only needs the
+// election result (the reconcile safety net) may ignore it. Never nil: an RG
+// with no matching instances yields an already-complete barrier.
+func (m *Manager) ResignRG(rgID int) *ResignBarrier {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	vrid := 100 + rgID
+	var targets []*vrrpInstance
 	for _, vi := range m.instances {
 		if isRethInstance(vi.cfg) && vi.cfg.GroupID == vrid {
-			// Set priority to 0 BEFORE triggering resign. Without this,
-			// the masterDown timer (~97ms) can fire before the debounced
-			// priority update (500ms), causing the instance to re-elect
-			// at the old high priority and knock the peer back to BACKUP.
-			vi.mu.Lock()
-			vi.cfg.Priority = 0
-			vi.mu.Unlock()
-			vi.triggerResign()
+			targets = append(targets, vi)
 		}
 	}
+	barrier := newResignBarrier(len(targets))
+	for _, vi := range targets {
+		// Arm the barrier BEFORE the trigger so the run loop cannot complete
+		// the release in the gap and leave this registration unreported.
+		vi.armResignAck(barrier)
+		// Set priority to 0 BEFORE triggering resign. Without this,
+		// the masterDown timer (~97ms) can fire before the debounced
+		// priority update (500ms), causing the instance to re-elect
+		// at the old high priority and knock the peer back to BACKUP.
+		vi.mu.Lock()
+		vi.cfg.Priority = 0
+		vi.mu.Unlock()
+		vi.triggerResign()
+	}
+	return barrier
 }
 
 // UpdateRGPriority immediately sets the VRRP priority for all instances

--- a/pkg/vrrp/resign_barrier.go
+++ b/pkg/vrrp/resign_barrier.go
@@ -1,0 +1,96 @@
+package vrrp
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+)
+
+// ErrStaleVIPOnBackup is the resign verdict for an instance that is already
+// BACKUP but whose last VIP removal FAILED and has not yet been cleared by the
+// #5482 async reconcile. The address may still be on the wire, so the
+// resignation must not be reported as a clean release (#6177 item 1).
+var ErrStaleVIPOnBackup = errors.New("vrrp: stale VIP still present on BACKUP instance")
+
+// ResignBarrier reports when a forced RG resignation has been ACTUATED on the
+// VRRP run loop — i.e. every targeted instance has physically removed its
+// virtual addresses (or reported why it could not) — as opposed to merely
+// having the resignation signalled.
+//
+// #6177 item 1. ResignRG is only half-synchronous: it drops the instance
+// priority to 0 under the instance lock (synchronous, so the resigning node
+// cannot win a re-election) and then does a NON-BLOCKING send on resignCh. The
+// priority-0 advert burst and the becomeBackup VIP removal run later, on the
+// instance's own goroutine. A caller that treats ResignRG's return as "the VIPs
+// are off the wire" is wrong by the length of one run-loop hop — the sub-ms
+// two-owner residual the #5640 hostile review flagged. ResignBarrier closes that
+// gap by giving the caller something to wait on that is driven FROM the VIP
+// removal itself.
+//
+// The barrier is one-shot and completes exactly once, when the last targeted
+// instance reports. Err reports the first VIP-removal failure observed by any
+// instance (nil when every instance released cleanly) — a failed removal means a
+// stale VIP may still be answering ARP, which is precisely the two-owner hazard
+// the caller is fencing against, so it must not read as a clean resignation.
+//
+// A barrier with no targeted instances is born complete: there is no VRRP VIP
+// tenure to release, so there is nothing to wait for.
+type ResignBarrier struct {
+	remaining atomic.Int32
+	done      chan struct{}
+
+	mu  sync.Mutex
+	err error
+}
+
+// newResignBarrier builds a barrier awaiting n instance reports. n <= 0 yields
+// an already-complete barrier.
+func newResignBarrier(n int) *ResignBarrier {
+	b := &ResignBarrier{done: make(chan struct{})}
+	if n <= 0 {
+		close(b.done)
+		return b
+	}
+	b.remaining.Store(int32(n))
+	return b
+}
+
+// Done returns a channel closed once every targeted instance has reported its
+// VIP-release outcome. Read Err after it closes for the verdict.
+func (b *ResignBarrier) Done() <-chan struct{} {
+	if b == nil {
+		return nil
+	}
+	return b.done
+}
+
+// Err returns the first VIP-removal failure reported by any targeted instance,
+// or nil when all of them released cleanly. Only meaningful once Done is closed.
+func (b *ResignBarrier) Err() error {
+	if b == nil {
+		return nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.err
+}
+
+// report records one instance's VIP-release outcome. The FIRST non-nil error
+// wins so the verdict names the earliest failure rather than the last reporter.
+// The count is decremented after the error is recorded, so a goroutine that
+// observes the close also observes the verdict.
+func (b *ResignBarrier) report(err error) {
+	if b == nil {
+		return
+	}
+	if err != nil {
+		b.mu.Lock()
+		if b.err == nil {
+			b.err = err
+		}
+		b.mu.Unlock()
+	}
+	if b.remaining.Add(-1) == 0 {
+		close(b.done)
+	}
+}

--- a/pkg/vrrp/resign_barrier_6177_test.go
+++ b/pkg/vrrp/resign_barrier_6177_test.go
@@ -1,0 +1,273 @@
+package vrrp
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/vishvananda/netlink"
+)
+
+// #6177 item 1 — the RETH VIP-removal two-owner residual.
+//
+// #5640 withheld the remote-failover applied-ack until the local demotion was
+// "actuated". On the RETH-VRRP path that meant ResignRG had RETURNED: the
+// instance priority was driven to 0 under the instance lock and a NON-BLOCKING
+// send was made on resignCh. The advert burst and the becomeBackup VIP removal
+// still ran afterwards, on the instance's own goroutine — so the peer could be
+// told "go ahead, promote" while this node's virtual addresses were still on
+// the interface. These tests pin the barrier that closes that gap: ResignRG's
+// return value must not complete until a VIP release has actually happened.
+
+// resignBarrierInstance builds a RETH instance (Family == "" is what
+// isRethInstance keys on) for redundancy group 1 — VRID 101 — whose VIP netlink
+// removal is governed by delFn.
+func resignBarrierInstance(t *testing.T, name string, delFn func(*netlink.Addr) error) (*Manager, *vrrpInstance) {
+	t.Helper()
+	m := NewManager()
+	vi := newInstance(Instance{
+		Interface:         name,
+		GroupID:           101,
+		Priority:          200,
+		AdvertiseInterval: 1000,
+		VirtualAddresses:  []string{"10.0.61.1/24"},
+	}, &net.Interface{Name: name}, m.eventCh, nil)
+	vi.linkByNameFn = func(n string) (netlink.Link, error) { return fiveZeroEightTwoLink(n), nil }
+	vi.addrAddFn = func(netlink.Link, *netlink.Addr) error { return nil }
+	vi.addrDelFn = func(_ netlink.Link, a *netlink.Addr) error { return delFn(a) }
+	m.mu.Lock()
+	m.instances = map[instanceKey]*vrrpInstance{{iface: name, groupID: 101}: vi}
+	m.mu.Unlock()
+	t.Cleanup(func() {
+		select {
+		case <-vi.stopCh:
+		default:
+			close(vi.stopCh)
+		}
+	})
+	return m, vi
+}
+
+func barrierDone(b *ResignBarrier) bool {
+	select {
+	case <-b.Done():
+		return true
+	default:
+		return false
+	}
+}
+
+func waitBarrier(t *testing.T, b *ResignBarrier, why string) {
+	t.Helper()
+	select {
+	case <-b.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatalf("resign barrier never completed: %s", why)
+	}
+}
+
+// TestResignRGBarrierNotCompleteUntilVIPRemoved_6177 is the fail-on-revert guard
+// for the residual itself. The window under test is the one between ResignRG
+// returning and the VRRP run loop reaching becomeBackup: in it, the resignation
+// is SIGNALLED and the priority is 0, but the VIP is still on the interface.
+//
+// RED on revert: make ResignRG report completion at trigger time (the pre-fix
+// posture — `return newResignBarrier(0)`, or arm the barrier and report to it
+// inside the ResignRG loop instead of from becomeBackup) and the
+// "barrier completed before the VIP was removed" assertion fires.
+func TestResignRGBarrierNotCompleteUntilVIPRemoved_6177(t *testing.T) {
+	release := make(chan struct{})
+	removed := make(chan struct{}, 1)
+	m, vi := resignBarrierInstance(t, "xpf-6177-a0", func(*netlink.Addr) error {
+		<-release
+		removed <- struct{}{}
+		return nil
+	})
+	vi.setState(StateMaster)
+
+	barrier := m.ResignRG(1)
+	if barrier == nil {
+		t.Fatal("ResignRG returned a nil barrier — a caller cannot fence on it")
+	}
+
+	// Positive controls: the production side effects of ResignRG really did
+	// happen, so the assertion below is about ordering and not about a
+	// no-op ResignRG.
+	if len(vi.resignCh) != 1 {
+		t.Fatalf("resignCh depth = %d, want 1 — ResignRG did not signal the instance", len(vi.resignCh))
+	}
+	vi.mu.RLock()
+	pri := vi.cfg.Priority
+	vi.mu.RUnlock()
+	if pri != 0 {
+		t.Fatalf("priority = %d, want 0 — ResignRG must still drive priority to 0 synchronously", pri)
+	}
+
+	// THE residual: at this instant the VIP delete has not been issued.
+	if barrierDone(barrier) {
+		t.Fatal("resign barrier completed before the VIP was removed — the peer would be " +
+			"told to promote while this node still owns the virtual address (#6177 item 1)")
+	}
+
+	// Now let the run loop's hop happen: becomeBackup is what the MASTER arm of
+	// the loop calls on a resignCh token.
+	go vi.becomeBackup(time.NewTimer(time.Hour), time.NewTimer(time.Hour))
+	// Still blocked inside the netlink delete.
+	time.Sleep(20 * time.Millisecond)
+	if barrierDone(barrier) {
+		t.Fatal("resign barrier completed while the VIP delete was still in flight (#6177 item 1)")
+	}
+
+	close(release)
+	waitBarrier(t, barrier, "becomeBackup finished removing the VIP")
+	select {
+	case <-removed:
+	default:
+		t.Fatal("the barrier completed but the netlink delete never ran")
+	}
+	if err := barrier.Err(); err != nil {
+		t.Fatalf("barrier verdict = %v, want nil after a clean removal", err)
+	}
+}
+
+// TestResignRGBarrierCarriesVIPRemoveFailure_6177 pins the verdict direction: a
+// removal that FAILED leaves the address on the wire, so the barrier must not
+// report a clean release. Reporting nil here would hand the peer the same
+// two-owner promotion the barrier exists to prevent — the difference being that
+// the stale VIP persists until the #5482 async reconcile clears it, not
+// sub-millisecond.
+//
+// RED on revert: report `nil` instead of the removeVIPs outcome from
+// becomeBackup and the Err assertion fires.
+func TestResignRGBarrierCarriesVIPRemoveFailure_6177(t *testing.T) {
+	injected := errors.New("injected netlink AddrDel failure")
+	m, vi := resignBarrierInstance(t, "xpf-6177-b0", func(*netlink.Addr) error { return injected })
+	vi.setState(StateMaster)
+	vi.vipReconcileBackoff = time.Hour // keep the #5482 retry out of this test
+
+	barrier := m.ResignRG(1)
+	vi.becomeBackup(time.NewTimer(time.Hour), time.NewTimer(time.Hour))
+
+	waitBarrier(t, barrier, "becomeBackup ran")
+	err := barrier.Err()
+	if err == nil {
+		t.Fatal("barrier reported a clean release after the VIP removal FAILED — " +
+			"a stale VIP is still answering ARP against the new master (#6177 item 1)")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("barrier verdict = %v, want it to carry the netlink failure", err)
+	}
+}
+
+// TestResignRGBarrierCompletesOnAlreadyBackupInstance_6177 covers the case the
+// design has to get right or every clean failover turns into a hold: an
+// instance that is ALREADY BACKUP when the resignation arrives. Nothing will
+// call becomeBackup for it, so without a consumer the token sits in resignCh
+// forever and the caller burns its whole timeout.
+//
+// RED on revert: delete the `case <-vi.resignCh` arm from stepBackup and this
+// test fails on the barrier timeout.
+func TestResignRGBarrierCompletesOnAlreadyBackupInstance_6177(t *testing.T) {
+	m, vi := resignBarrierInstance(t, "xpf-6177-c0", func(*netlink.Addr) error { return nil })
+	vi.setState(StateBackup)
+
+	barrier := m.ResignRG(1)
+	if barrierDone(barrier) {
+		t.Fatal("barrier completed before the run loop consumed the resignation")
+	}
+
+	// One hop of the BACKUP arm of the run loop.
+	go vi.stepBackup(time.NewTimer(time.Hour), time.NewTimer(time.Hour), time.NewTimer(time.Hour))
+
+	waitBarrier(t, barrier, "an already-BACKUP instance must resolve the resignation, not stall it")
+	if err := barrier.Err(); err != nil {
+		t.Fatalf("barrier verdict = %v, want nil — an already-BACKUP instance holds no VIP tenure", err)
+	}
+	if len(vi.resignCh) != 0 {
+		t.Fatalf("resignCh depth = %d, want 0 — the token must be consumed, not left pending", len(vi.resignCh))
+	}
+}
+
+// TestResignRGBarrierAlreadyBackupWithStaleVIPFails_6177 is the honesty case of
+// the one above: already BACKUP is only a clean release when no PREVIOUS
+// removal failed. With #5482 divergence set the address may still be on the
+// interface, so the resignation must report failure and the peer must hold.
+func TestResignRGBarrierAlreadyBackupWithStaleVIPFails_6177(t *testing.T) {
+	m, vi := resignBarrierInstance(t, "xpf-6177-d0", func(*netlink.Addr) error { return nil })
+	vi.setState(StateBackup)
+	vi.vipDiverged.Store(true)
+
+	barrier := m.ResignRG(1)
+	go vi.stepBackup(time.NewTimer(time.Hour), time.NewTimer(time.Hour), time.NewTimer(time.Hour))
+
+	waitBarrier(t, barrier, "the resignation must resolve even when a stale VIP is flagged")
+	if err := barrier.Err(); !errors.Is(err, ErrStaleVIPOnBackup) {
+		t.Fatalf("barrier verdict = %v, want ErrStaleVIPOnBackup — a diverged VIP is not a clean release", err)
+	}
+}
+
+// TestResignRGBarrierMultiInstanceWaitsForAll_6177 pins that the barrier is a
+// conjunction: a RETH RG has one VRRP instance per member interface, and the
+// fence is only satisfied when EVERY one of them has released. Completing on
+// the first would leave the other member still answering for the VIP.
+func TestResignRGBarrierMultiInstanceWaitsForAll_6177(t *testing.T) {
+	m, vi1 := resignBarrierInstance(t, "xpf-6177-e0", func(*netlink.Addr) error { return nil })
+	vi2 := newInstance(Instance{
+		Interface:         "xpf-6177-e1",
+		GroupID:           101,
+		Priority:          200,
+		AdvertiseInterval: 1000,
+		VirtualAddresses:  []string{"10.0.61.1/24"},
+	}, &net.Interface{Name: "xpf-6177-e1"}, m.eventCh, nil)
+	vi2.linkByNameFn = func(n string) (netlink.Link, error) { return fiveZeroEightTwoLink(n), nil }
+	vi2.addrDelFn = func(netlink.Link, *netlink.Addr) error { return nil }
+	m.mu.Lock()
+	m.instances[instanceKey{iface: "xpf-6177-e1", groupID: 101}] = vi2
+	m.mu.Unlock()
+	t.Cleanup(func() { close(vi2.stopCh) })
+	vi1.setState(StateMaster)
+	vi2.setState(StateMaster)
+
+	barrier := m.ResignRG(1)
+	vi1.becomeBackup(time.NewTimer(time.Hour), time.NewTimer(time.Hour))
+	if barrierDone(barrier) {
+		t.Fatal("barrier completed after ONE of two RETH member instances released its VIP (#6177 item 1)")
+	}
+	vi2.becomeBackup(time.NewTimer(time.Hour), time.NewTimer(time.Hour))
+	waitBarrier(t, barrier, "both member instances released")
+	if err := barrier.Err(); err != nil {
+		t.Fatalf("barrier verdict = %v, want nil", err)
+	}
+}
+
+// TestResignRGBarrierNoInstancesIsBornComplete_6177 pins the no-op contract: an
+// RG with no RETH VRRP instances has no VIP tenure to release, so a caller must
+// not be made to wait out a timeout for a fence that is already satisfied.
+func TestResignRGBarrierNoInstancesIsBornComplete_6177(t *testing.T) {
+	m, _ := resignBarrierInstance(t, "xpf-6177-f0", func(*netlink.Addr) error { return nil })
+	barrier := m.ResignRG(7) // VRID 107 — no instance matches
+	if !barrierDone(barrier) {
+		t.Fatal("barrier for an RG with no RETH instances must be born complete")
+	}
+	if err := barrier.Err(); err != nil {
+		t.Fatalf("barrier verdict = %v, want nil", err)
+	}
+}
+
+// TestResignRGBarrierRetiredInstanceDoesNotStall_6177 covers the remaining way
+// a release signal can fail to arrive: the instance is torn down (config
+// change, shutdown) between the arm and the run loop's next hop. stop() drains
+// the barrier so the caller gets a verdict instead of a hang.
+func TestResignRGBarrierRetiredInstanceDoesNotStall_6177(t *testing.T) {
+	m, vi := resignBarrierInstance(t, "xpf-6177-g0", func(*netlink.Addr) error { return nil })
+	vi.setState(StateBackup)
+	// The run loop is not running in this unit test, so close(stopped)
+	// stands in for it having exited; stop() joins on it.
+	close(vi.stopped)
+
+	barrier := m.ResignRG(1)
+	go vi.stop()
+
+	waitBarrier(t, barrier, "a retired instance must resolve the resignation, not strand it")
+}


### PR DESCRIPTION
Closes #6177

## What was left

Items 2 (barrier delete-by-key) and 3 (barrier unit tests) were discharged by
#7142/#7118. **Item 1 — the RETH VIP-removal two-owner residual — was still
live at `origin/master`**, and it is the reason this issue carries the
`security` label. This PR closes it.

## The defect, at HEAD

`#5640` withheld the remote-failover `failoverAckApplied` until the local
demotion was *actuated*. On the RETH-VRRP path "actuated" meant `ResignRG` had
**returned**, and `ResignRG` is only half-synchronous
(`pkg/vrrp/manager.go:721`):

```go
vi.mu.Lock(); vi.cfg.Priority = 0; vi.mu.Unlock()   // synchronous
vi.triggerResign()                                   // NON-BLOCKING send on resignCh
```

The priority-0 advert burst and the `becomeBackup` → `removeVIPs` netlink
deletes run afterwards, on the VRRP instance's own goroutine. So the peer was
told "applied" — its authorization to run `commitRequestedPeerFailover`, add
VIPs and GARP — while this node's virtual addresses were **still on the
interface**. Sub-millisecond, but a real two-owner window: two nodes answering
ARP for the same address, and an upstream cache that can latch the loser.

Direct-VIP mode (`no-reth-vrrp` / `private-rg-election`) never had the gap —
`reconcileDirectVIPOwnership` removes the addresses inline on the event
goroutine — which is why the existing `#6371` tests, which run on that path,
could not see it.

## The fix

`ResignRG` now returns a `*vrrp.ResignBarrier`, armed on every targeted
instance **before** `triggerResign` so the run loop cannot complete a release
in the gap and leave the registration unreported. Instances report to it only
from sites that **actually complete a release**:

| site | verdict |
|---|---|
| `becomeBackup`, as its last statement | the `removeVIPs` outcome |
| the MASTER arm's shutdown removal | that removal's outcome |
| a **new** BACKUP-arm consumer of `resignCh` | clean, unless `#5482` `vipDiverged` says a stale VIP is still on the wire |
| `stop()` (instance retired between arm and next hop) | same |

Arming deliberately does **not** shortcut on state. `becomeBackup` publishes
`BACKUP` (`setState`) *before* it runs `removeVIPs`, so "already BACKUP" can be
true while the address is still on the wire — exactly when the shortcut would
be wrong.

The already-BACKUP consumer is what keeps the fix from being a regression: a
resign token that lands on a non-MASTER instance is only selected on in the
`StateMaster` arm, so without it the token sits unread forever and **every**
such demotion burns the caller's full timeout, downgrading a clean failover to
a hold. The issue text called this out as the open design question.

`handleClusterEvent` captures the barrier and hands the fence verdict to
`awaitRethVIPRelease` **on its own goroutine** — `watchClusterEvents` serialises
every cluster event, so blocking there would stall unrelated RGs behind one VIP
removal. A clean release → `signalFailoverActuated`. A failed release, or no
report within `rethVIPReleaseTimeout` (500 ms), → `signalFailoverActuationFailed`,
so the peer **holds** rather than promoting into the window. 500 ms sits far
below the 3 s `failoverActuateTimeout` so the verdict *names* the un-released
addresses instead of surfacing as a generic barrier timeout, and far below the
initiator's 20 s ack timeout so the ack is a decision, not a hang.

No wire change. No protocol version bump.

## Tests

**7 new in `pkg/vrrp`** (`resign_barrier_6177_test.go`) pin the barrier against
the *real* VIP removal, driving the `linkByNameFn`/`addrDelFn` seams: not
complete at `ResignRG` return, not complete mid-delete, the removal-failure
verdict, the already-BACKUP and retired-instance resolutions, the multi-member
conjunction (one member released ≠ fence satisfied), the no-instance no-op.

**4 new in `pkg/daemon`** (`daemon_ha_reth_vip_fence_6177_test.go`) pin the
wiring on a `no-private-rg-election` config (asserted in setup, so the test
cannot silently drift onto the direct-VIP branch): the applied-ack still
**blocked** after a full demotion has run and cleared `rg_active`, released on
report, failed on a release error, failed with a NAMED verdict on a stall, and
prompt for an RG with no RETH tenure (this last one drives the **real**
`vrrp.Manager`, no seam).

### Mutation matrix — 7/7 RED, `go build` + `go vet` clean in every cell

| # | mutation (one line, verbatim pre-fix where applicable) | RED |
|---|---|---|
| M1 | restore the pre-fix unconditional `signalFailoverActuated` tail | 3 daemon tests; `WaitsForVIPRelease` reds on the two-owner assertion (`:136`) |
| M2 | delete `vi.armResignAck(barrier)` from `ResignRG` | 6 vrrp tests |
| M3 | delete `vi.notifyResigned(removeErr)` from `becomeBackup` | 3 vrrp tests |
| M4 | `notifyResigned(removeErr)` → `notifyResigned(nil)` | `CarriesVIPRemoveFailure` |
| M5 | delete the `case <-vi.resignCh` arm from `stepBackup` | 2 vrrp tests |
| M6 | timeout leg signals actuated instead of failed | `FailsWhenVIPReleaseStalls` |
| M7 | drop the `barrier.Err()` check on the release leg | `FailsOnVIPReleaseError` |

`go test -count=1 ./pkg/vrrp ./pkg/daemon ./pkg/cluster` — green.

## Validation still owed

This is an HA / VRRP / failover change: it owes **`make test-failover`** on the
loss userspace cluster. Not run here — the cluster is shared and lock-protected
and is serialised centrally.

## Docs

`docs/session-sync-architecture.md`: the "#6177 item 1, open" residual paragraph
is replaced with the closed mechanism, the `ResignRG` half-synchronous paragraph
now points at the barrier, and the fence sequence gains a step 5 describing the
report sites, the goroutine hand-off, and the timeout ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017g5f5Gq1LJGUY7rRNrUnZa
