### PR TITLE
afxdp: check the idle-regulation poll return in worker_loop

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -99643,3 +99643,12 @@ prose edit above them added. No diff falls in the new test body.
   movement, so no cluster smoke is owed.
 - **File(s)**: pkg/dataplane/userspace/process.go,
   pkg/dataplane/userspace/helper_restart_after_stop_5838_test.go, _Log.md
+
+- **Timestamp**: 2026-08-21
+  - **Action**: #6431 — check the Interrupt-mode idle-regulation `libc::poll`
+    return in `worker_loop`; add `loop_body/idle_poll.rs` classifier
+    (Waited / Interrupted / Degraded) + a substituted 1 ms sleep on the
+    degraded arm; document the idle regulation in the worker README.
+  - **File(s)**: `userspace-dp/src/afxdp/worker/loop_body/idle_poll.rs` (new),
+    `userspace-dp/src/afxdp/worker/loop_body/mod.rs`,
+    `userspace-dp/src/afxdp/worker/README.md`

--- a/userspace-dp/src/afxdp/worker/README.md
+++ b/userspace-dp/src/afxdp/worker/README.md
@@ -41,6 +41,41 @@ Each phase extracted one cluster of fields into a dedicated
 sub-struct so the parent struct stays cache-line-friendly and so
 each cluster has a clear ownership boundary.
 
+## Idle regulation
+
+A tick that did no work increments `idle_iters` and then backs off according
+to `poll_mode`. `BusyPoll` spins for `IDLE_SPIN_ITERS` (256) iterations and
+then sleeps `IDLE_SLEEP_US` (1 us). `Interrupt` spins for the same window —
+firewall-local TCP is ACK-latency-sensitive, so blocking on the first empty
+poll collapses cwnd — and then blocks in `libc::poll` on every binding's
+AF_XDP socket fd with an `INTERRUPT_POLL_TIMEOUT_MS` (1 ms) timeout. When the
+worker has no bindings there is no fd to block on, so it sleeps the same 1 ms
+instead.
+
+That blocking `poll` is the ONLY backoff `Interrupt` mode has past the spin
+window, which is why #6431 made its return a checked value rather than a
+discarded one. `loop_body/idle_poll::classify` splits the return into three
+cases:
+
+| return | classification | caller |
+|--------|----------------|--------|
+| `0` (timeout), or `> 0` with `POLLIN` set on some fd | `Waited` | resume — the wait waited |
+| `-1` with `EINTR` | `Interrupted` | retry; the next pass re-enters the poll, so this costs one work scan and no sleep |
+| `-1` with any other errno, or `> 0` with only `POLLNVAL`/`POLLERR`/`POLLHUP` | `Degraded` | substitute a `INTERRUPT_POLL_TIMEOUT_MS` sleep |
+
+The `Degraded` cases are the ones that matter: both return IMMEDIATELY and
+keep doing so, so without a substituted sleep the 1 ms floor disappears
+entirely and the idle path becomes a hot spin on a pinned core. Measured with
+the production 1 ms timeout: a healthy idle poll yields ~950 loops/s, the same
+loop over a closed fd ~2.96M loops/s — a ~3120x amplification held for as long
+as the condition lasts. `EINTR` is deliberately NOT a `Degraded` case: the
+helper installs a `ctrlc` handler (`server/lifecycle.rs`) and `poll(2)` is one
+of the calls `SA_RESTART` never restarts (signal(7)), so signal-interrupted
+waits are ordinary and must not each buy a sleep. The degraded log is latched
+to one line per worker, because the condition that produces it repeats every
+pass. RX is unaffected either way — the rings are swept on every loop pass;
+`poll` only regulates how long an idle worker waits between sweeps.
+
 ## Files
 
 | File | Purpose |
@@ -50,6 +85,7 @@ each cluster has a clear ownership boundary.
 | `launch.rs` | #6241 — the 5 typed worker-launch bundles (`WorkerLaunchPlan`, `WorkerSharedDataplane`, `WorkerControlChannels`, `WorkerCoSState`, `WorkerPublishedTelemetry`) + 2 nested (`WorkerNeighbors`, `WorkerSharedSessions`) that replace the old 38-parameter positional `worker_loop` protocol. `WorkerSharedDataplane::from_coord` / `WorkerCoSState::from_coord` (coordinator-published state) and the `::new` builders (per-worker slots) are the single named construction sites; `Arc::ptr_eq` wiring tests bind them (fail-on-revert for the session-map and heartbeat/export-ack silent-swap hazards). |
 | `loop_body/setup.rs` | #1776 — one-shot cold setup (`worker_loop_setup`): thread pin via `pin_current_thread` (defined in `afxdp/neighbor.rs`), TSC calibration, binding construction, BPF-map-FD cache; returns `WorkerLoopSetup`. #6245: binding construction now accumulates EXPLICIT per-slot terminal failures (`binding_failures`) + recovered shared-group fallbacks (`recovered_fallbacks`), sorted deterministically and carried through `WorkerLoopSetup` into `WorkerStartupReport` (the failed slot is no longer signalled only by OMISSION from `bindings`). See `coordinator/README.md` #6245. |
 | `loop_body/debug_report.rs` | #1776 — cfg(debug-log)-only `DbgCounters` + per-second verbose report (`emit_periodic_report`) + stall dump (`check_and_dump_stall`). #5189: also the per-binding diagnostics build (`build_binding_summary` — `String` + per-binding `statistics_v2()`/`SO_ERROR` `getsockopt`), which #1776 had left inline and ungated in `loop_body/mod.rs`. Compiled out of release builds. |
+| `loop_body/idle_poll.rs` | #6431 — classification of the Interrupt-mode idle-regulation `poll(2)` return (`classify` -> `Waited` / `Interrupted` / `Degraded`, plus `fault_summary` for the caller's one-shot log). Idle path only, so it is outside the per-tick no-call-boundary constraint. See "Idle regulation" below. |
 | `lifecycle.rs` | `poll_binding` — the per-poll RX/TX orchestrator. The "central function" extracted in Issue 73 step 2. |
 | `cos.rs` | Per-worker CoS runtime helpers + shared-exact threshold (the empirical sustained per-worker exact throughput ceiling — see comment block in the file for the evidence basis). |
 | `cos_state.rs` | `WorkerCos` (#959 Phase 3) — per-binding CoS-engine state. |

--- a/userspace-dp/src/afxdp/worker/loop_body/idle_poll.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/idle_poll.rs
@@ -1,0 +1,237 @@
+// #6431: classification of the Interrupt-mode idle-regulation `poll(2)`
+// return in the AF_XDP worker loop.
+//
+// Interrupt poll-mode has exactly ONE backoff: the blocking `poll()` itself,
+// with an `INTERRUPT_POLL_TIMEOUT_MS` (1 ms) timeout. Discarding its return
+// conflates outcomes that need different handling:
+//
+//   rc == 0                    timeout — the wait waited          -> resume
+//   rc  > 0, POLLIN set        a queue is readable                -> resume
+//   rc == -1, EINTR            a signal cut the wait short        -> retry
+//   rc == -1, any other errno  the call fails and keeps failing   -> BACK OFF
+//   rc  > 0, only error bits   POLLNVAL / POLLERR / POLLHUP       -> BACK OFF
+//
+// The last two rows are the bug. Both return IMMEDIATELY and keep doing so, so
+// the 1 ms floor disappears and the idle path becomes a hot spin on a pinned
+// worker core. Measured on this kernel with the production 1 ms timeout: a
+// healthy idle poll yields ~950 loops/s; the same loop over a closed fd yields
+// ~2.96M loops/s — a ~3120x amplification, held for as long as the condition
+// lasts. `Degraded` therefore tells the caller to substitute its own sleep,
+// which restores exactly the duty cycle the healthy path has.
+//
+// `EINTR` deliberately does NOT back off. A signal-interrupted wait is normal
+// here — the helper installs a `ctrlc` handler (`server/lifecycle.rs`), and
+// `poll(2)` is one of the calls `SA_RESTART` never restarts (signal(7)) — and
+// the caller re-enters the blocking poll on its next pass, so the retry costs
+// one work scan, not a spin. Treating it as an error would add a sleep to
+// ordinary signal delivery; treating it as readiness would busy-loop.
+
+/// What one idle-regulation `poll(2)` return means to the caller.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum IdlePoll {
+    /// The wait actually waited — a timeout, or a descriptor became readable.
+    /// The caller's idle regulation held; nothing more to do.
+    Waited,
+    /// `EINTR`. Retry: the caller re-enters the blocking poll next pass.
+    Interrupted,
+    /// The call returned immediately and will keep returning immediately.
+    /// The caller MUST substitute its own backoff or it will spin.
+    Degraded,
+}
+
+/// Revents bits that report a fault rather than readiness. `poll(2)` sets
+/// these in `revents` regardless of `events`, and each is sticky for as long
+/// as its cause lasts, so a wake carrying only these bits repeats at syscall
+/// rate.
+const FAULT_REVENTS: libc::c_short = libc::POLLNVAL | libc::POLLERR | libc::POLLHUP;
+
+/// Classify one `libc::poll` return.
+///
+/// `rc` is the value the call returned, `errno` the thread's `errno` captured
+/// immediately after it (read only when `rc < 0`), and `fds` the descriptor
+/// slice the call filled in.
+///
+/// `#[inline]` because the caller is the worker loop; this is on the idle path
+/// (the caller is about to make, or has just made, a syscall), so it is not
+/// subject to the per-tick no-call-boundary constraint documented in `mod.rs`,
+/// but there is no reason to leave a call behind either.
+#[inline]
+pub(super) fn classify(rc: libc::c_int, errno: libc::c_int, fds: &[libc::pollfd]) -> IdlePoll {
+    if rc < 0 {
+        return if errno == libc::EINTR {
+            IdlePoll::Interrupted
+        } else {
+            IdlePoll::Degraded
+        };
+    }
+    if rc == 0 {
+        return IdlePoll::Waited;
+    }
+    // rc > 0: at least one descriptor reported something. It is a genuine wake
+    // only if something is actually readable. A revents set carrying nothing
+    // but fault bits — or, defensively, nothing at all — is an immediate,
+    // repeating return, so it takes the fail-safe `Degraded` arm.
+    if fds.iter().any(|pfd| pfd.revents & libc::POLLIN != 0) {
+        IdlePoll::Waited
+    } else {
+        IdlePoll::Degraded
+    }
+}
+
+/// Render the fault bits a degraded wake reported, for the caller's one-shot
+/// log. Returns an empty string when no descriptor carried a fault bit (the
+/// `rc < 0` arm, where the errno is the diagnosis).
+pub(super) fn fault_summary(fds: &[libc::pollfd]) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    for (idx, pfd) in fds.iter().enumerate() {
+        if pfd.revents & FAULT_REVENTS == 0 {
+            continue;
+        }
+        let mut bits: Vec<&str> = Vec::new();
+        if pfd.revents & libc::POLLNVAL != 0 {
+            bits.push("POLLNVAL");
+        }
+        if pfd.revents & libc::POLLERR != 0 {
+            bits.push("POLLERR");
+        }
+        if pfd.revents & libc::POLLHUP != 0 {
+            bits.push("POLLHUP");
+        }
+        parts.push(format!("[{}] fd={} {}", idx, pfd.fd, bits.join("|")));
+    }
+    parts.join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pfd(revents: libc::c_short) -> libc::pollfd {
+        libc::pollfd {
+            fd: 7,
+            events: libc::POLLIN,
+            revents,
+        }
+    }
+
+    #[test]
+    fn timeout_is_a_wait_that_waited() {
+        assert_eq!(
+            classify(0, 0, &[pfd(0)]),
+            IdlePoll::Waited,
+            "rc==0 is the ordinary 1ms timeout — the idle regulation held, so \
+             the caller must NOT add a second sleep on top of it"
+        );
+    }
+
+    #[test]
+    fn readable_descriptor_is_a_wait_that_waited() {
+        assert_eq!(
+            classify(1, 0, &[pfd(libc::POLLIN)]),
+            IdlePoll::Waited,
+            "a POLLIN wake is real work arriving — backing off here would add \
+             latency to the ACK-sensitive path the interrupt spin exists for"
+        );
+    }
+
+    #[test]
+    fn eintr_is_retried_not_treated_as_error_or_readiness() {
+        assert_eq!(
+            classify(-1, libc::EINTR, &[pfd(0)]),
+            IdlePoll::Interrupted,
+            "a signal-interrupted poll must be retried: as Degraded it would \
+             sleep on ordinary signal delivery, as Waited it is indistinguishable \
+             from a timeout and would be fine here but wrong for any caller that \
+             counts completed waits"
+        );
+        assert_ne!(
+            classify(-1, libc::EINTR, &[pfd(0)]),
+            IdlePoll::Degraded,
+            "EINTR must not take the backoff arm"
+        );
+    }
+
+    #[test]
+    fn hard_errno_is_degraded() {
+        for errno in [libc::EINVAL, libc::EFAULT, libc::ENOMEM] {
+            assert_eq!(
+                classify(-1, errno, &[pfd(0)]),
+                IdlePoll::Degraded,
+                "errno {errno} makes poll return immediately and keep doing so; \
+                 without a substituted backoff the idle path spins at syscall rate"
+            );
+        }
+    }
+
+    #[test]
+    fn pollnval_only_is_degraded_not_a_wake() {
+        assert_eq!(
+            classify(1, 0, &[pfd(libc::POLLNVAL)]),
+            IdlePoll::Degraded,
+            "a closed fd sets POLLNVAL and returns rc>0 IMMEDIATELY, forever — \
+             measured ~2.96M loops/s vs ~950/s healthy. Counting rc>0 as a wake \
+             is exactly the unchecked-return bug"
+        );
+        assert_eq!(classify(1, 0, &[pfd(libc::POLLERR)]), IdlePoll::Degraded);
+        assert_eq!(classify(1, 0, &[pfd(libc::POLLHUP)]), IdlePoll::Degraded);
+    }
+
+    #[test]
+    fn readable_wins_over_a_sibling_fault() {
+        assert_eq!(
+            classify(
+                2,
+                0,
+                &[pfd(libc::POLLNVAL), pfd(libc::POLLIN)]
+            ),
+            IdlePoll::Waited,
+            "one bad binding must not make the worker sleep past another \
+             binding's pending RX"
+        );
+    }
+
+    #[test]
+    fn fault_on_the_same_fd_as_readable_still_waits() {
+        assert_eq!(
+            classify(1, 0, &[pfd(libc::POLLIN | libc::POLLHUP)]),
+            IdlePoll::Waited,
+            "POLLHUP alongside POLLIN means drain the readable data first"
+        );
+    }
+
+    #[test]
+    fn positive_return_with_no_revents_fails_safe() {
+        assert_eq!(
+            classify(1, 0, &[pfd(0)]),
+            IdlePoll::Degraded,
+            "rc>0 with nothing set should not happen; if it does it is an \
+             immediate return, so the fail-safe arm is the backoff"
+        );
+    }
+
+    #[test]
+    fn errno_is_ignored_on_a_non_negative_return() {
+        assert_eq!(
+            classify(0, libc::EINTR, &[pfd(0)]),
+            IdlePoll::Waited,
+            "errno is only meaningful when the call failed; a stale EINTR left \
+             in errno by an earlier call must not reclassify a real timeout"
+        );
+    }
+
+    #[test]
+    fn fault_summary_names_the_bits_and_is_empty_when_clean() {
+        let s = fault_summary(&[pfd(libc::POLLIN), pfd(libc::POLLNVAL)]);
+        assert!(s.contains("POLLNVAL"), "summary must name the bit: {s}");
+        assert!(s.contains("[1]"), "summary must name the index: {s}");
+        assert!(
+            !s.contains("POLLERR"),
+            "summary must not report bits that were not set: {s}"
+        );
+        assert!(
+            fault_summary(&[pfd(libc::POLLIN), pfd(0)]).is_empty(),
+            "no fault bits must render as empty, so the errno arm's log is not \
+             padded with a meaningless revents dump"
+        );
+    }
+}

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -44,6 +44,11 @@ mod setup;
 #[cfg(feature = "debug-log")]
 mod debug_report;
 
+// #6431: classification of the Interrupt-mode idle-regulation `poll(2)`
+// return. Idle path only — it does not sit on the per-tick hot path the
+// no-call-boundary note above constrains.
+mod idle_poll;
+
 /// #6592: refresh the worker's per-tick `(validation, forwarding)` view from
 /// ONE `ArcSwap` load, so the two halves can never come from different
 /// generations.
@@ -286,6 +291,11 @@ pub(crate) fn worker_loop(
     }
     const COS_STATUS_INTERVAL_NS: u64 = 100_000_000;
     let mut idle_iters = 0u32;
+    // #6431: one-shot latch for the degraded-idle-poll log. The condition that
+    // sets it (a hard errno, or a fault-only revents set) repeats every pass,
+    // so an unlatched log would itself become the flood the backoff exists to
+    // prevent.
+    let mut idle_poll_degraded = false;
     let mut poll_start = 0usize;
     let mut shared_recycles = Vec::with_capacity((RX_BATCH_SIZE as usize).saturating_mul(2));
     // #5468: per-drain-cycle aggregate lossless-wedge latch. `flush_session_deltas`
@@ -1455,12 +1465,51 @@ pub(crate) fn worker_loop(
                     for pfd in &mut interrupt_poll_fds {
                         pfd.revents = 0;
                     }
-                    unsafe {
+                    let rc = unsafe {
                         libc::poll(
                             interrupt_poll_fds.as_mut_ptr(),
                             interrupt_poll_fds.len() as libc::nfds_t,
                             INTERRUPT_POLL_TIMEOUT_MS,
-                        );
+                        )
+                    };
+                    // #6431: this blocking poll is the ONLY backoff Interrupt
+                    // mode has past the spin window, so discarding its return
+                    // is not a cosmetic omission — a return that came back
+                    // IMMEDIATELY (a hard errno, or a revents set carrying
+                    // only POLLNVAL/POLLERR/POLLHUP) repeats at syscall rate
+                    // and turns the idle wait into a hot spin on a pinned
+                    // core. Capture errno BEFORE anything else can clobber it.
+                    let errno = if rc < 0 {
+                        std::io::Error::last_os_error()
+                            .raw_os_error()
+                            .unwrap_or(0)
+                    } else {
+                        0
+                    };
+                    match idle_poll::classify(rc, errno, &interrupt_poll_fds) {
+                        // Timeout or a readable queue: the wait waited.
+                        idle_poll::IdlePoll::Waited => {}
+                        // EINTR: retry. The next loop pass re-enters the poll,
+                        // so the retry costs one work scan and no sleep.
+                        idle_poll::IdlePoll::Interrupted => {}
+                        idle_poll::IdlePoll::Degraded => {
+                            if !idle_poll_degraded {
+                                idle_poll_degraded = true;
+                                let faults = idle_poll::fault_summary(&interrupt_poll_fds);
+                                eprintln!(
+                                    "xpf-dp: w{worker_id}: idle poll degraded \
+(rc={rc} errno={errno}{}{}) — substituting a {INTERRUPT_POLL_TIMEOUT_MS}ms sleep \
+so the idle path cannot spin; RX is unaffected (the rings are still swept every \
+pass). Logged once per worker.",
+                                    if faults.is_empty() { "" } else { " " },
+                                    faults,
+                                );
+                            }
+                            // Restore the duty cycle the healthy path has.
+                            thread::sleep(Duration::from_millis(
+                                INTERRUPT_POLL_TIMEOUT_MS as u64,
+                            ));
+                        }
                     }
                 } else {
                     wr_state = WorkerRuntimeState::IdleBlock;


### PR DESCRIPTION
## What

Interrupt poll-mode's idle regulation blocks in `libc::poll` on every binding's
AF_XDP socket fd with an `INTERRUPT_POLL_TIMEOUT_MS` (1 ms) timeout, and
discarded the return entirely — the call was not even bound to `_`. This checks
it.

`userspace-dp/src/afxdp/worker/loop_body/mod.rs` (Interrupt arm of the idle
regulation, `worker_loop`), before:

```rust
unsafe {
    libc::poll(
        interrupt_poll_fds.as_mut_ptr(),
        interrupt_poll_fds.len() as libc::nfds_t,
        INTERRUPT_POLL_TIMEOUT_MS,
    );
}
```

That conflates outcomes that need different handling:

| return | meaning | required action |
|---|---|---|
| `0` | timeout — the wait waited | resume |
| `> 0` with `POLLIN` | a queue is readable | resume |
| `-1` / `EINTR` | a signal cut the wait short | retry |
| `-1` / any other errno | the call fails and keeps failing | **back off** |
| `> 0` with only `POLLNVAL`/`POLLERR`/`POLLHUP` | fault-only wake | **back off** |

## Why it matters

That blocking `poll` is the **only** backoff Interrupt mode has past the
`IDLE_SPIN_ITERS` (256) spin window. The two back-off rows both return
*immediately* and keep doing so for as long as their cause lasts, so the 1 ms
floor disappears outright and the idle wait becomes a hot spin on a pinned
worker core.

Measured firsthand with a standalone probe at the production 1 ms timeout,
before the fix was written:

```
A healthy-idle : rc=0 revents=0x0   loops in 200ms = 190     (~950/s)
B closed-fd    : rc=1 revents=0x20 (POLLNVAL)  loops = 592503 (~2962515/s)
C signal(SA_RESTART) during 5000ms poll: rc=-1 errno=4(EINTR) after 20ms
```

~950 loops/s healthy vs ~2.96M loops/s over a closed fd — a **~3120x
amplification**.

Row C is the reason `EINTR` deliberately does *not* back off: the helper
installs a `ctrlc` handler (`server/lifecycle.rs`) and `poll(2)` is one of the
calls `SA_RESTART` never restarts (signal(7)), so signal-interrupted waits are
ordinary here. The caller re-enters the blocking poll on its next pass, so the
retry costs one work scan and no sleep. Classifying `EINTR` as an error would
buy a sleep on every signal delivery; classifying it as readiness would
busy-loop.

**Reachability, stated honestly.** `interrupt_poll_fds` is built once in
`loop_body/setup.rs` from `binding.xsk.device.as_raw_fd()` and never rebuilt,
and `bindings` is never mutated after construction, so `POLLNVAL` is not
reachable through the current ownership structure — it needs a double-close or
fd-reuse bug elsewhere. `EINTR` **is** reachable today and currently costs one
spurious work-scan pass. So this is defensive hardening of an unchecked
syscall, not a fix for a defect firing in the field. The measured consequence
if the condition ever does arise is the 3120x spin above, and the guard is
cheap.

## How

The classification is a pure fn in a new `loop_body/idle_poll.rs`
(`classify` -> `Waited` / `Interrupted` / `Degraded`, plus `fault_summary` for
the log), so it is unit-testable away from the loop. It sits on the idle path
only — the caller is already committed to a syscall — so it is outside the
per-tick no-call-boundary constraint documented at the top of
`loop_body/mod.rs`, and it is `#[inline]` regardless.

- A `POLLIN` on **any** descriptor still counts as a real wake even when a
  sibling descriptor reports a fault, so one bad binding cannot make the worker
  sleep past another binding's pending RX.
- `rc > 0` with no revents at all takes the fail-safe `Degraded` arm.
- The degraded log is latched to one line per worker — the condition repeats
  every pass, so an unlatched log would become the flood the backoff exists to
  prevent.
- RX is unaffected on either arm: the rings are swept on every loop pass;
  `poll` only regulates how long an idle worker waits between sweeps.

Docs: `userspace-dp/src/afxdp/worker/README.md` gains an "Idle regulation"
section (both poll modes, the three-way classification table, the measurement)
and the `loop_body/idle_poll.rs` row in the Files table.

## Validation

- 10 new unit tests, all selected and green:
  `cargo test --manifest-path userspace-dp/Cargo.toml idle_poll -- --test-threads=1`
  -> `10 passed; 0 failed; 4480 filtered out`, rc=0. (Filter confirmed
  non-empty — a filter that selects zero tests also exits 0.)
- Full `userspace-dp` suite green (see comment below).
- `cargo check` clean, no new warnings mentioning `idle_poll`.
- **Mutation matrix** — 5 cells, each one mutation on one line, each an
  ASSERTION red (`cargo test` rc=101 with a named failing assert) on a build
  that compiles (`cargo check` rc=0), source restored and verified `cmp`-equal
  after every cell:

| cell | mutation | check rc | test rc | assertion that fired |
|---|---|---|---|---|
| M1 | EINTR arm folded into `Degraded` | 0 | 101 | `eintr_is_retried_not_treated_as_error_or_readiness` |
| M2 | `rc > 0` always `Waited` (the pre-fix behaviour) | 0 | 101 | `pollnval_only_is_degraded_not_a_wake`, `positive_return_with_no_revents_fails_safe` |
| M3 | `rc == 0` returns `Degraded` | 0 | 101 | `timeout_is_a_wait_that_waited`, `errno_is_ignored_on_a_non_negative_return` |
| M4 | `.any(` -> `.all(` on the POLLIN scan | 0 | 101 | `readable_wins_over_a_sibling_fault` |
| M5 | `fault_summary` drops the POLLNVAL label | 0 | 101 | `fault_summary_names_the_bits_and_is_empty_when_clean` |

## Smoke

**A cluster smoke IS owed** — this changes `userspace-dp/`, so the worker
binary moves. Not run here: the shared loss cluster is held by another session
and this lane was instructed not to touch it. Please serialize it before merge.

Closes #6431
