### PR TITLE
daemon: re-install event-stream callbacks on a replaced standalone stream

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -99614,3 +99614,45 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: `userspace-dp/src/afxdp/mod.rs`,
   `userspace-dp/src/server/helpers/status.rs`,
   `userspace-dp/tests/heartbeat_failclosed_doc_guard.rs` (new)
+
+- **Timestamp**: 2026-08-21 18:52 PDT
+- **Action**: #7017 — standalone daemon re-installs event-stream callbacks on
+  a replaced stream
+
+  On a STANDALONE (no-cluster) daemon the userspace event-stream callbacks were
+  installed once and never re-installed when the helper's `EventStream`
+  instance was REPLACED. The clustered path got the `es != wired` re-install in
+  #6743 r6-F4; `runUserspaceEventStream`'s standalone arm called
+  `wireUserspaceEventStreamCallbacks` — which RETURNS as soon as it installs —
+  and returned with it, never running `eventStreamFallbackLoop`. Stated in-tree
+  as a KNOWN GAP (#6743 r2-N5) and reproduces identically on origin/master, so
+  pre-existing rather than introduced.
+
+  Symptom: a commit-confirmed rollback tears the armed backend's stream down
+  while KEEPING the backend object, and the corrected re-arm constructs a new
+  one; that instance has no `SetOnEvent`/`SetOnFullResync`/dataplane-event
+  callback, so every helper event lands in the callback-not-ready queue and
+  RT_FLOW session records stop reaching `show log`, syslog and the flow
+  exporter for the rest of the process lifetime. Only a restart recovers.
+
+  Fix: `watchUserspaceEventStreamCallbacks` — same 500 ms cadence and
+  first-wire behaviour, but it never returns and applies the fallback loop's
+  instance-IDENTITY re-install every tick. The arm now blocks for the life of
+  ctx where it used to return, and its goroutine is on the run WaitGroup;
+  `runShutdownSequence` calls `stop()` before `wg.Wait()`, so it joins within
+  one tick — that ordering is load-bearing and has its own binder.
+  `wireUserspaceEventStreamCallbacks` is unchanged and still used by
+  `daemon_ha_sync.go`.
+
+  Validation: reproduced firsthand at origin/master `aa3780666` — with
+  callbacks on stream A and the backend then publishing stream B, no ACK ever
+  came back on B (FAIL at the wiring deadline, 85.20s); with the loop the ACK
+  lands on the next tick, 0.50s PASS. Mutation 3/3 RED (revert the arm to
+  wire-once; weaken `es != wired` to `wired == nil`; drop the `ctx.Done()`
+  select arm), `go vet` clean at each with a non-zero exit captured.
+  `go test -count=1 ./pkg/daemon/` exit 0; the two new tests exit 0 under
+  `-race`. Go-only, `pkg/daemon`; nothing reaches the Rust helper binary, so no
+  cluster smoke is owed.
+- **File(s)**: pkg/daemon/daemon_ha_userspace_stream.go,
+  pkg/daemon/daemon_standalone_stream_rewire_7017_test.go,
+  pkg/daemon/README.md, _Log.md

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -47,7 +47,19 @@ usable. Two consequences the code makes explicit:
   for the drainer, which stayed captured at loop entry and kept draining a
   disowned backend at 10 Hz on the fast fallback branch) and re-installs
   its callbacks when a rollback + corrected re-arm replaces the stream
-  instance. `handleEventStreamFullResync` likewise resolves its session
+  instance. #7017: that last clause was true of the CLUSTERED loop only.
+  `runUserspaceEventStream`'s standalone (no-cluster) arm called
+  `wireUserspaceEventStreamCallbacks` and RETURNED with it, so it never ran
+  the `es != wired` re-install and a replacement stream on a standalone
+  daemon got no callbacks at all — its dataplane events accumulated in the
+  callback-not-ready queue, and RT_FLOW records stopped reaching `show
+  log`, syslog and the flow exporter until the daemon restarted. That arm
+  now runs `watchUserspaceEventStreamCallbacks`: the same 500 ms cadence
+  and the same first-wire behaviour, but it never returns and applies the
+  same instance-identity re-install every tick. It is registered on the run
+  WaitGroup, and `runShutdownSequence` calls `stop()` before `wg.Wait()`,
+  so it joins within one tick of shutdown.
+  `handleEventStreamFullResync` likewise resolves its session
   exporter from the cell on every call, so a full resync after a rollback
   + corrected re-arm exports from the CURRENT backend rather than the
   torn-down one (#6743 r2-B8, bound by
@@ -56,7 +68,9 @@ usable. Two consequences the code makes explicit:
   (REST); `daemon_ha_userspace_stream_live_test.go` drives the event-stream
   loop across a `setDataplane(nil)`, across a stream replacement, and —
   on the reconcile-cadence branch, which needs its own connected-stream
-  fixture — across a backend republication (#6743 r2-B3).
+  fixture — across a backend republication (#6743 r2-B3);
+  `daemon_standalone_stream_rewire_7017_test.go` is the standalone twin of
+  the stream-replacement case plus the shutdown join.
 
   The console-CLI site has TWO halves, and neither covers it alone
   (corrected in #6743 r2 — an earlier revision of this paragraph said the

--- a/pkg/daemon/daemon_ha_userspace_stream.go
+++ b/pkg/daemon/daemon_ha_userspace_stream.go
@@ -91,29 +91,29 @@ func (d *Daemon) runUserspaceEventStream(ctx context.Context) {
 		// Standalone: no session sync, so nothing to poll or drain — but
 		// the helper's DATAPLANE events (RT_FLOW records into the event
 		// buffer) still arrive through these callbacks, so they must be
-		// installed. wireUserspaceEventStreamCallbacks re-reads the cell
-		// every 500 ms until a provider with a stream appears, so an empty
-		// cell here is a retry, not a latch.
+		// installed, and they must STAY installed across a stream
+		// replacement.
 		//
-		// KNOWN GAP (#6743 r2-N5), stated because the sentence above is
-		// true of the FIRST wiring only and reads as if the whole path were
-		// self-correcting. wireUserspaceEventStreamCallbacks RETURNS once
-		// it installs, and this arm returns with it. The re-install on a
-		// REPLACED stream instance — the `es != wired` block r6-F4 added —
-		// lives in eventStreamFallbackLoop, which this path never runs. So
-		// on a standalone (no-cluster) daemon, a commit-confirmed rollback
-		// that closes the armed backend's stream followed by a corrected
-		// re-arm that constructs a new one leaves the replacement stream
-		// with no callbacks: its dataplane events accumulate in the
-		// callback-not-ready queue instead of reaching the event buffer,
-		// until the daemon restarts.
+		// #7017: this arm used to call wireUserspaceEventStreamCallbacks
+		// and RETURN. That helper re-reads the #2114 cell every 500 ms
+		// until a provider with a stream appears, so an empty cell at entry
+		// was a retry rather than a latch — but it returns the moment it
+		// installs, and the arm returned with it. The re-install on a
+		// REPLACED stream instance (the `es != wired` block r6-F4 added)
+		// lived only in eventStreamFallbackLoop, which this path never
+		// runs. So on a standalone daemon, a commit-confirmed rollback that
+		// closes the armed backend's stream followed by a corrected re-arm
+		// that constructs a new one left the replacement with no callbacks:
+		// its dataplane events accumulated in the callback-not-ready queue
+		// instead of reaching the event buffer, and RT_FLOW records stopped
+		// reaching `show log`, syslog and the flow exporter for the rest of
+		// the process's life. Only a restart recovered.
 		//
-		// This is PRE-EXISTING in shape — the clustered path had the same
-		// hole before r6-F4 and this arm was never converted — and is left
-		// alone here rather than fixed blind: the fix is either to run a
-		// stream-watch loop on this path too or to hoist the re-install
-		// into the wiring helper, and both want their own binder.
-		d.wireUserspaceEventStreamCallbacks(ctx)
+		// watchUserspaceEventStreamCallbacks keeps the same 500 ms cadence
+		// and the same first-wire behaviour, but never returns: it applies
+		// the fallback loop's `es != wired` re-install on every tick, which
+		// is the asymmetry #7017 names.
+		d.watchUserspaceEventStreamCallbacks(ctx)
 		return
 	}
 
@@ -184,6 +184,47 @@ func (d *Daemon) wireUserspaceEventStreamCallbacks(ctx context.Context) *dpusers
 		select {
 		case <-ctx.Done():
 			return nil
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+// watchUserspaceEventStreamCallbacks keeps the callbacks installed on
+// WHATEVER stream instance the #2114 cell currently publishes, for as long as
+// ctx lives. It is the standalone (no-cluster) counterpart of the
+// eventStreamFallbackLoop re-install: same 500 ms cadence as
+// wireUserspaceEventStreamCallbacks, same `es != wired` predicate as the
+// clustered loop, minus the session-sync drain work there is nothing to do on
+// this path.
+//
+// #7017: the clustered path was fixed for a REPLACED stream in #6743 r6-F4
+// and this arm was never converted, so it wired once and returned. A
+// commit-confirmed rollback tears the armed backend's stream down
+// (pkg/dataplane/userspace/process.go) and the corrected re-arm constructs a
+// NEW one; without this loop that replacement never got SetOnEvent /
+// SetOnFullResync / the dataplane-event callback, and every helper event from
+// that point sat in the callback-not-ready queue.
+//
+// Installing is idempotent per instance: the guard is instance IDENTITY, so a
+// stream that has not been replaced is never re-wired and the callbacks are
+// not reinstalled on every tick.
+func (d *Daemon) watchUserspaceEventStreamCallbacks(ctx context.Context) {
+	var wired *dpuserspace.EventStream
+	for {
+		var es *dpuserspace.EventStream
+		if provider, ok := d.currentEventStreamProvider(); ok {
+			es = provider.EventStream()
+		}
+		if es != nil && es != wired {
+			d.installEventStreamCallbacks(es)
+			if wired != nil {
+				slog.Info("userspace: event stream replaced (rollback/re-arm), callbacks re-installed")
+			}
+			wired = es
+		}
+		select {
+		case <-ctx.Done():
+			return
 		case <-time.After(500 * time.Millisecond):
 		}
 	}

--- a/pkg/daemon/daemon_standalone_stream_rewire_7017_test.go
+++ b/pkg/daemon/daemon_standalone_stream_rewire_7017_test.go
@@ -1,0 +1,130 @@
+// #7017: on a STANDALONE (no-cluster) daemon the userspace event-stream
+// callbacks were installed exactly once and never re-installed when the
+// helper's EventStream instance was REPLACED.
+//
+// The clustered path was fixed for this in #6743 r6-F4 — the
+// `es != wired` re-install inside eventStreamFallbackLoop — but the standalone
+// arm of runUserspaceEventStream called wireUserspaceEventStreamCallbacks and
+// RETURNED with it, and never ran that loop. The asymmetry was stated in-tree
+// as a KNOWN GAP rather than fixed.
+//
+// Failure mode: a commit-confirmed rollback tears down the armed backend's
+// stream (pkg/dataplane/userspace/process.go) and the corrected re-arm
+// constructs a NEW one. On master the replacement got no SetOnEvent /
+// SetOnFullResync / dataplane-event callback, so every helper event from that
+// point landed in the callback-not-ready queue: RT_FLOW session records stopped
+// reaching `show log`, syslog and the flow exporter for the rest of the process
+// lifetime, recoverable only by restarting the daemon.
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// TestRunUserspaceEventStream_StandaloneRewiresReplacementStream is the
+// standalone twin of TestEventStreamFallbackLoop_RewiresReplacementStream, and
+// binds the #7017 hunk and only that hunk.
+//
+// The FIRST ack proves the arm still wires at all (the pre-existing behaviour
+// this must not regress); the SECOND, on a different stream instance the
+// backend publishes afterwards, is the property #7017 adds. On a standalone
+// daemon handleEventStreamDelta takes its "ignored (no cluster/sync)" arm and
+// ACKs, so an ack proves only that the CALLBACK ran — which is exactly the
+// property under test.
+//
+// Fail-on-revert: restore `d.wireUserspaceEventStreamCallbacks(ctx); return`
+// in place of the watch loop and the second ack never comes back. Measured at
+// origin/master aa3780666: the first ack lands, the second times out at the
+// wiring deadline (85s under `-timeout 90s`); with the loop the second ack
+// lands on the next 500 ms tick and the whole test takes 0.5s.
+func TestRunUserspaceEventStream_StandaloneRewiresReplacementStream(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	first, firstPath := startEventStreamForRewireTest(t, ctx, "first.sock")
+	replacement, replacementPath := startEventStreamForRewireTest(t, ctx, "replacement.sock")
+
+	d := &Daemon{store: storeWithActiveConfigForDrainTest(t)}
+	if d.cluster != nil || d.getSessionSync() != nil {
+		t.Fatal("test setup: this must take the STANDALONE arm (no cluster, no session sync)")
+	}
+
+	backend := &replaceableStreamDP{}
+	backend.es.Store(first)
+	d.setDataplane(backend)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.runUserspaceEventStream(ctx)
+	}()
+
+	firstConn, err := dialEventStreamForRewireTest(t, firstPath)
+	if err != nil {
+		t.Fatalf("dial first event stream: %v", err)
+	}
+	defer firstConn.Close()
+	writeEventFrameForWiringTest(t, firstConn, dpuserspace.EventTypeSessionOpen, 1,
+		buildSessionOpenFrameV4PayloadForWiringTest())
+	waitForAckSeqForWiringTest(t, firstConn, 1)
+
+	// The commit-confirmed rollback + corrected re-arm: the published backend
+	// now exposes a DIFFERENT stream instance, with no callbacks on it.
+	backend.es.Store(replacement)
+
+	replacementConn, err := dialEventStreamForRewireTest(t, replacementPath)
+	if err != nil {
+		t.Fatalf("dial replacement event stream: %v", err)
+	}
+	defer replacementConn.Close()
+	writeEventFrameForWiringTest(t, replacementConn, dpuserspace.EventTypeSessionOpen, 1,
+		buildSessionOpenFrameV4PayloadForWiringTest())
+	// SetOnEvent flushes the callback-not-ready queue, so this does not race the
+	// loop's next tick: the ack arrives whenever the re-install lands.
+	waitForAckSeqForWiringTest(t, replacementConn, 1)
+
+	cancel()
+	<-done
+}
+
+// TestRunUserspaceEventStream_StandaloneReturnsOnContextCancel pins the
+// shutdown join. #7017 turns the standalone arm from a function that RETURNED
+// after wiring into one that loops for the life of ctx, and daemon_run.go
+// registers that goroutine on the run WaitGroup. runShutdownSequence calls
+// stop() and only then wg.Wait(), so the loop must observe the cancellation and
+// return — otherwise the daemon would hang in wg.Wait() forever on every stop.
+//
+// Fail-on-revert: drop the `case <-ctx.Done(): return` arm from the select in
+// watchUserspaceEventStreamCallbacks and this test fails on its deadline
+// instead of joining.
+func TestRunUserspaceEventStream_StandaloneReturnsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	es, _ := startEventStreamForRewireTest(t, ctx, "shutdown.sock")
+	d := &Daemon{store: storeWithActiveConfigForDrainTest(t)}
+	backend := &replaceableStreamDP{}
+	backend.es.Store(es)
+	d.setDataplane(backend)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.runUserspaceEventStream(ctx)
+	}()
+
+	// Let it reach the loop and install, so the cancel is observed from inside
+	// the 500 ms select rather than before the first iteration.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("standalone event-stream arm did not return within 5s of ctx cancel; " +
+			"runShutdownSequence's wg.Wait() would hang on every daemon stop (#7017)")
+	}
+}


### PR DESCRIPTION
## Problem

On a **standalone (no-cluster) daemon** the userspace event-stream
callbacks are installed exactly once and never re-installed when the
helper's `EventStream` instance is **replaced**.

The clustered path was fixed for this in `#6743` r6-F4 — the
`es != wired` re-install `eventStreamFallbackLoop` evaluates every tick.
`runUserspaceEventStream`'s standalone arm calls
`wireUserspaceEventStreamCallbacks`, which **returns as soon as it
installs**, and the arm returns with it. It never runs that loop, so
nothing watches for a later instance.

**Pre-existing, not introduced by #6743** — it reproduces identically on
`origin/master`, and #6743 stated it in-tree as a KNOWN GAP (r2-N5)
rather than fixing it blind.

### Failure scenario

1. A `commit confirmed` rollback tears the armed backend's stream down
   (`pkg/dataplane/userspace/process.go`) while deliberately KEEPING the
   backend object; a corrected commit re-arms it via
   `runBootstrapExitStartup`.
2. The re-arm constructs a **new** `*dpuserspace.EventStream`.
3. That instance has no `SetOnEvent` / `SetOnFullResync` /
   dataplane-event callback.

Every event the helper emits from that point lands in the
callback-not-ready queue instead of the daemon's event buffer: **RT_FLOW
session records stop reaching `show log`, syslog and the flow exporter
for the rest of the process lifetime.** Only a daemon restart recovers.

## Fix

Mirror the cluster arm, which is what the issue asks for.
`watchUserspaceEventStreamCallbacks` keeps the 500 ms cadence and the
first-wire behaviour of the helper it replaces, but never returns: it
re-resolves the provider and the stream from the #2114 cell each tick and
re-installs on the same **instance-identity** predicate the fallback loop
uses, so an unreplaced stream is never re-wired.

`wireUserspaceEventStreamCallbacks` is unchanged and still used by
`daemon_ha_sync.go`, where a bounded 5 s wire is followed by
`eventStreamFallbackLoop` taking over the re-install.

### Shutdown join

The arm now blocks for the life of `ctx` where it used to return, and
`daemon_run.go` registers that goroutine on the run WaitGroup.
`runShutdownSequence` calls `stop()` — which cancels that same context —
and only then `wg.Wait()`, so the loop joins within one tick. That
ordering is load-bearing, so it gets its own binder: without the
`ctx.Done()` select arm the daemon would hang in `wg.Wait()` on **every**
stop, and no rewire assertion would catch it.

## Reproduction (firsthand, at `origin/master` aa3780666)

Callbacks installed on stream A, backend then publishes stream B:

```
    zz_repro7017_test.go:39: stream A wired (ack seq=1)
    zz_repro7017_test.go:51: read ack frame: read unix @->.../replacement.sock: i/o timeout
--- FAIL: TestRepro7017StandaloneRewire (85.20s)
```

With the loop, the ack lands on the next tick:

```
--- PASS: TestRepro7017StandaloneRewire (0.50s)
```

## Validation

- **Mutation 3/3 RED**, one mutation per cell, `go vet` clean at each,
  non-zero exit captured from the run:
  | mutation | red at |
  |---|---|
  | arm reverted to `wireUserspaceEventStreamCallbacks(ctx); return` | the SECOND ack (replacement stream); the first still passes, so the red localises |
  | `es != wired` weakened to `wired == nil` | same — proves the predicate, not merely the loop's existence, does the work |
  | `ctx.Done()` arm dropped from the watch select | the shutdown-join assertion |
- `go test -count=1 ./pkg/daemon/` exit 0 (full package); the two new
  tests exit 0 under `-race`.
- The sibling cluster-arm tests
  (`TestEventStreamFallbackLoop_*`, `TestRunUserspaceEventStream_Standalone
  WiresAfterEmptyCellAtEntry`) all still pass.
- **No smoke owed.** Go-only, `pkg/daemon`; nothing under `userspace-dp/`
  or `userspace-xdp/` is touched, so the Rust helper binary and the shim
  `.o` are unchanged.

Closes #7017