### PR TITLE
test(cos): verify the CLI transcript, not the session exit status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,11 @@ make test-deploy     # Build -> push xpfd+cli+helper (each sha256-verified ==
 make test-deploy-lib # Self-test the deploy reconcile/sha-verify helpers (no VM)
 make test-cluster-lock-lib # Self-test the #1875 lock + #4020 destructive-smoke
                      #   lock preamble (no cluster — private lock path, mocked incus)
+make test-cos-apply-lib # Self-test the #6440 CoS-apply CLI-transcript gate:
+                     #   the piped-stdin CLI is a REPL that prints "error: ..."
+                     #   and still exits 0, so apply-cos-config.sh verifies the
+                     #   CLI's success markers, not the session exit status.
+                     #   Hermetic (mocked incus) + the Go marker contract.
 make test-cluster-env-lib # Self-test the cluster-env resolver (#5024): $FW0/
                      #   $FW1/$CLUSTER_LAN_HOST derive from each env's VM0/VM1/
                      #   LAN_HOST and get INCUS_REMOTE-qualified (no cluster)

--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ clean:
 # The standalone instance name defaults to xpf-fw; override it for an
 # ad-hoc/renamed VM with `XPF_INSTANCE=<name> make test-deploy` (#2162). The
 # env var flows through to setup.sh (INSTANCE_NAME=${XPF_INSTANCE:-xpf-fw}).
-.PHONY: test-env-init test-vm standalone-test-vm test-ct test-deploy test-deploy-lib test-cluster-lock-lib test-cluster-env-lib test-ssh test-destroy test-status test-start test-stop test-restart test-logs test-journal
+.PHONY: test-env-init test-vm standalone-test-vm test-ct test-deploy test-deploy-lib test-cluster-lock-lib test-cluster-env-lib test-cos-apply-lib test-ssh test-destroy test-status test-start test-stop test-restart test-logs test-journal
 
 test-env-init:
 	./test/incus/setup.sh init
@@ -350,6 +350,17 @@ test-deploy-lib:
 test-cluster-lock-lib:
 	bash ./test/incus/with-cluster-selftest.sh
 	bash ./test/incus/cluster-cell-selftest.sh
+
+# Self-test the #6440 CoS-apply CLI-transcript gate. `apply-cos-config.sh`
+# drives the Junos CLI by piping a heredoc into it; that form is a REPL that
+# prints "error: ..." for a failed command, continues, and still exits 0 — so
+# the phase gates verify the CLI's own success markers instead of the session
+# exit status. Hermetic: mocked incus, canned transcripts; no cluster, no VM.
+# Run this after touching apply-cos-config.sh or cos-apply-lib.sh. The Go half
+# of the marker contract lives in cmd/cli/cos_apply_markers_6440_test.go.
+test-cos-apply-lib:
+	bash ./test/incus/cos-apply-lib-selftest.sh
+	go test -count=1 -run 6440 ./cmd/cli/
 
 # Self-test the shared cluster-env resolver (#5024): the HA/failover
 # smoke scripts read $FW0/$FW1/$CLUSTER_LAN_HOST, which cluster-env.sh

--- a/_Log.md
+++ b/_Log.md
@@ -99798,3 +99798,20 @@ prose edit above them added. No diff falls in the new test body.
   pkg/grpcapi/session_iface_identity_6960_test.go, pkg/api/sessions.go,
   pkg/api/session_iface_identity_6960_test.go, pkg/dataplane/types.go,
   userspace-dp/src/session/README.md, _Log.md
+
+## 2026-08-21 — #6440 CoS-apply CLI-transcript gate
+
+- **Timestamp**: 2026-08-21
+- **Action**: Diagnosed #6440 (`apply-cos-config.sh` exits 6). Root cause: the
+  piped-stdin CLI is a REPL that prints `error: ...` for a failed command,
+  continues, and exits 0 — so the phase-1/phase-2 exit-status gates could
+  never fire, and a silently-failed `load merge` committed a deletes-only
+  candidate (a CoS wipe) that surfaced only as the phase-3 "no shaper
+  binding" grep. Replaced the exit-status gates with CLI success-marker
+  verification, made every rollback verified, and added a daemon-readiness
+  wait.
+- **File(s)**: `test/incus/cos-apply-lib.sh` (new),
+  `test/incus/cos-apply-lib-selftest.sh` (new),
+  `cmd/cli/cos_apply_markers_6440_test.go` (new),
+  `test/incus/apply-cos-config.sh`, `Makefile`, `CLAUDE.md`,
+  `docs/cos-validation-notes.md`

--- a/cmd/cli/cos_apply_markers_6440_test.go
+++ b/cmd/cli/cos_apply_markers_6440_test.go
@@ -1,0 +1,250 @@
+// Pin the CLI success-marker contract that test/incus/cos-apply-lib.sh depends
+// on (#6440).
+//
+// `apply-cos-config.sh` drives this binary by piping a heredoc into it. That
+// form is a REPL: main's read loop prints "error: %v" for a failed command,
+// CONTINUES to the next line, and the process still exits 0. So the script
+// cannot gate on the session's exit status — it gates on the success markers
+// these handlers print instead.
+//
+// That makes the marker STRINGS a cross-language contract. Reword one here and
+// the shell gate silently stops detecting failures: it would keep looking for
+// text the CLI no longer emits, fail every apply, or — worse for the reverse
+// edit — accept a failed apply. These tests fix both halves of the contract:
+//
+//	(a) on SUCCESS the exact marker is printed, and
+//	(b) on FAILURE it is NOT printed (an error is returned instead).
+//
+// (b) is the load-bearing half. A gate keyed on a marker the CLI prints
+// unconditionally would be vacuous.
+//
+// Keep the constants below in sync with COS_MARKER_* in
+// test/incus/cos-apply-lib.sh.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc"
+)
+
+// The marker strings test/incus/cos-apply-lib.sh greps for.
+const (
+	cosMarkerLoadMerge   = "load merge complete"
+	cosMarkerCommitCheck = "configuration check succeeds"
+	cosMarkerCommit      = "commit complete"
+	cosMarkerRollback    = "configuration rolled back"
+)
+
+// markerClient stubs the four config RPCs the CoS apply path uses. Each can be
+// switched to fail so the same call site is exercised on both paths.
+type markerClient struct {
+	pb.BpfrxServiceClient
+
+	loadErr     error
+	checkErr    error
+	commitErr   error
+	rollbackErr error
+}
+
+func (m *markerClient) Load(_ context.Context, _ *pb.LoadRequest, _ ...grpc.CallOption) (*pb.LoadResponse, error) {
+	if m.loadErr != nil {
+		return nil, m.loadErr
+	}
+	return &pb.LoadResponse{}, nil
+}
+
+func (m *markerClient) CommitCheck(_ context.Context, _ *pb.CommitCheckRequest, _ ...grpc.CallOption) (*pb.CommitCheckResponse, error) {
+	if m.checkErr != nil {
+		return nil, m.checkErr
+	}
+	return &pb.CommitCheckResponse{}, nil
+}
+
+func (m *markerClient) Commit(_ context.Context, _ *pb.CommitRequest, _ ...grpc.CallOption) (*pb.CommitResponse, error) {
+	if m.commitErr != nil {
+		return nil, m.commitErr
+	}
+	return &pb.CommitResponse{}, nil
+}
+
+func (m *markerClient) Rollback(_ context.Context, _ *pb.RollbackRequest, _ ...grpc.CallOption) (*pb.RollbackResponse, error) {
+	if m.rollbackErr != nil {
+		return nil, m.rollbackErr
+	}
+	return &pb.RollbackResponse{}, nil
+}
+
+// GetStatus backs refreshPrompt() on the commit success path.
+func (m *markerClient) GetStatus(_ context.Context, _ *pb.GetStatusRequest, _ ...grpc.CallOption) (*pb.GetStatusResponse, error) {
+	return &pb.GetStatusResponse{}, nil
+}
+
+// captureDispatch runs c.dispatch(line) with stdout redirected, returning what
+// was printed plus the dispatch error.
+func captureDispatch(t *testing.T, c *ctl, line string) (string, error) {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	dispatchErr := c.dispatch(line)
+
+	w.Close()
+	os.Stdout = orig
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("read captured stdout: %v", err)
+	}
+	r.Close()
+	return buf.String(), dispatchErr
+}
+
+// hasMarkerLine mirrors cos_transcript_has_marker: the marker must start a
+// LINE, not merely appear somewhere in the output.
+func hasMarkerLine(out, marker string) bool {
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// A `load merge <file>` that the daemon accepts must print the exact marker.
+func TestLoadMergePrintsMarkerOnSuccess_6440(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "sets")
+	if err != nil {
+		t.Fatalf("temp: %v", err)
+	}
+	if _, err := f.WriteString("set class-of-service interfaces reth0 unit 80 shaping-rate 25g\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f.Close()
+
+	c := configModeCtl(&markerClient{})
+	out, err := captureDispatch(t, c, "load merge "+f.Name())
+	if err != nil {
+		t.Fatalf("load merge must succeed, got: %v", err)
+	}
+	if !hasMarkerLine(out, cosMarkerLoadMerge) {
+		t.Fatalf("load merge success must print %q at line start; got:\n%s", cosMarkerLoadMerge, out)
+	}
+}
+
+// ...and a `load merge` the daemon REJECTS must NOT print it. This is the
+// #6440 case: the REPL prints an error and continues, so the marker's absence
+// is the only in-band signal the shell gate can key on.
+func TestLoadMergeWithholdsMarkerOnFailure_6440(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "sets")
+	if err != nil {
+		t.Fatalf("temp: %v", err)
+	}
+	if _, err := f.WriteString("set class-of-service interfaces reth0 unit 80 shaping-rate 25g\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f.Close()
+
+	c := configModeCtl(&markerClient{loadErr: fmt.Errorf("line 12: not a set/delete command")})
+	out, err := captureDispatch(t, c, "load merge "+f.Name())
+	if err == nil {
+		t.Fatal("a rejected load merge must return an error")
+	}
+	if hasMarkerLine(out, cosMarkerLoadMerge) {
+		t.Fatalf("a FAILED load merge must NOT print %q; got:\n%s", cosMarkerLoadMerge, out)
+	}
+}
+
+func TestCommitCheckMarkerContract_6440(t *testing.T) {
+	c := configModeCtl(&markerClient{})
+	out, err := captureDispatch(t, c, "commit check")
+	if err != nil {
+		t.Fatalf("commit check must succeed, got: %v", err)
+	}
+	if !hasMarkerLine(out, cosMarkerCommitCheck) {
+		t.Fatalf("commit check success must print %q; got:\n%s", cosMarkerCommitCheck, out)
+	}
+
+	c = configModeCtl(&markerClient{checkErr: fmt.Errorf("zone trust references undefined policy")})
+	out, err = captureDispatch(t, c, "commit check")
+	if err == nil {
+		t.Fatal("a failed commit check must return an error")
+	}
+	if hasMarkerLine(out, cosMarkerCommitCheck) {
+		t.Fatalf("a FAILED commit check must NOT print %q; got:\n%s", cosMarkerCommitCheck, out)
+	}
+}
+
+func TestCommitMarkerContract_6440(t *testing.T) {
+	c := configModeCtl(&markerClient{})
+	out, err := captureDispatch(t, c, "commit")
+	if err != nil {
+		t.Fatalf("commit must succeed, got: %v", err)
+	}
+	if !hasMarkerLine(out, cosMarkerCommit) {
+		t.Fatalf("commit success must print %q; got:\n%s", cosMarkerCommit, out)
+	}
+
+	c = configModeCtl(&markerClient{commitErr: fmt.Errorf("dataplane apply failed")})
+	out, err = captureDispatch(t, c, "commit")
+	if err == nil {
+		t.Fatal("a failed commit must return an error")
+	}
+	if hasMarkerLine(out, cosMarkerCommit) {
+		t.Fatalf("a FAILED commit must NOT print %q; got:\n%s", cosMarkerCommit, out)
+	}
+}
+
+func TestRollbackMarkerContract_6440(t *testing.T) {
+	c := configModeCtl(&markerClient{})
+	out, err := captureDispatch(t, c, "rollback 1")
+	if err != nil {
+		t.Fatalf("rollback must succeed, got: %v", err)
+	}
+	if !hasMarkerLine(out, cosMarkerRollback) {
+		t.Fatalf("rollback success must print %q; got:\n%s", cosMarkerRollback, out)
+	}
+
+	c = configModeCtl(&markerClient{rollbackErr: fmt.Errorf("no previous configuration")})
+	out, err = captureDispatch(t, c, "rollback 1")
+	if err == nil {
+		t.Fatal("a failed rollback must return an error")
+	}
+	if hasMarkerLine(out, cosMarkerRollback) {
+		t.Fatalf("a FAILED rollback must NOT print %q; got:\n%s", cosMarkerRollback, out)
+	}
+}
+
+// The shell gate and this file must agree on the literal strings. Read them
+// back out of the library so a one-sided rename fails here instead of silently
+// disarming the gate on the cluster.
+func TestShellGateMarkersMatchCLI_6440(t *testing.T) {
+	data, err := os.ReadFile("../../test/incus/cos-apply-lib.sh")
+	if err != nil {
+		t.Fatalf("read cos-apply-lib.sh: %v", err)
+	}
+	lib := string(data)
+	for _, want := range []struct{ shellVar, marker string }{
+		{"COS_MARKER_LOAD_MERGE", cosMarkerLoadMerge},
+		{"COS_MARKER_COMMIT_CHECK", cosMarkerCommitCheck},
+		{"COS_MARKER_COMMIT", cosMarkerCommit},
+		{"COS_MARKER_ROLLBACK", cosMarkerRollback},
+	} {
+		assign := fmt.Sprintf("%s=%q", want.shellVar, want.marker)
+		if !strings.Contains(lib, assign) {
+			t.Errorf("test/incus/cos-apply-lib.sh must define %s — the CLI prints %q but the shell gate does not grep for it",
+				assign, want.marker)
+		}
+	}
+}

--- a/docs/cos-validation-notes.md
+++ b/docs/cos-validation-notes.md
@@ -989,6 +989,75 @@ than re-running. The accompanying fixture at
 `test/incus/cos-iperf-config.set` covers both `family inet` and
 `family inet6` classifier state.
 
+### How the loader detects a failed apply (#6440)
+
+That strictness could not actually work before #6440, and it is worth
+understanding why, because the same trap catches any script driving this
+CLI.
+
+The loader runs the CLI by piping a heredoc into it:
+
+```bash
+incus exec "$TARGET" -- /usr/local/sbin/cli <<EOF
+configure
+delete class-of-service
+load merge /tmp/cos-iperf-sets.set
+commit check
+...
+```
+
+**That form is a REPL, not a batch runner.** `cmd/cli`'s read loop prints
+`error: <msg>` for a failed command, continues to the NEXT line, and the
+process still exits 0. So gating a phase on the session's exit status
+detects nothing. (`cli -c "<one command>"` is the opposite — it
+`os.Exit(1)`s on a dispatch error. Only the piped-stdin form swallows.)
+
+The failure #6440 recorded: `load merge` failed, leaving a candidate that
+held only the loader's `delete class-of-service ...` lines. Deleting is
+valid, so `commit check` passed and `commit` committed the deletes —
+**wiping CoS instead of applying it**. The first check that noticed
+anything was the post-commit `show class-of-service interface` grep, which
+reported the misleading "no shaper/scheduler binding" and exited 6. Every
+CoS measurement taken after such a run was silently taken against
+un-applied config.
+
+The loader now verifies the CLI's own **success markers** in each captured
+transcript (`test/incus/cos-apply-lib.sh`):
+
+| verb | marker printed only on success |
+|---|---|
+| `load merge` | `load merge complete` |
+| `commit check` | `configuration check succeeds` |
+| `commit` | `commit complete` (or `commit complete: <summary>`) |
+| `rollback N` | `configuration rolled back` |
+
+Positive markers are checked rather than scanning for `error:` lines
+because the loader's delete list is idempotent by design: its `delete`
+lines legitimately error with a path-not-found on a fresh post-deploy box
+where CoS was already wiped. Those benign errors must not fail the apply,
+and they do not disturb the markers.
+
+Two consequences worth knowing:
+
+- **`rollback` is verified too.** Every rollback site previously announced
+  "live state reverted" from the `then` branch of an `if` on the session's
+  exit status — i.e. unconditionally. The loader could report a clean
+  revert over a rollback that never happened. It now says
+  `live state reverted (verified)` only when both markers appear, and
+  escalates to `MANUAL INTERVENTION REQUIRED` otherwise.
+- **Exit 6 now means what it says.** A CLI/daemon reachability failure
+  during the readback exits 6 with an explicit "this is a CLI/daemon
+  reachability failure, NOT a CoS binding failure" line, and a new exit 3
+  covers "xpfd never became reachable" (the loader waits for the gRPC
+  listener before the first commit — a deploy restarts xpfd, and #6440 also
+  recorded a commit-check dying on connection-refused).
+
+`make test-cos-apply-lib` self-tests all of this hermetically (mocked
+incus, canned transcripts — no cluster). The marker strings are a
+cross-language contract; `cmd/cli/cos_apply_markers_6440_test.go` pins
+both halves (printed on success, withheld on failure) and fails if the
+shell library and the CLI ever disagree.
+
 Opt-in injectors layered onto the selected fixture: the
 `--surplus-sharing` flag (#915) and `COS_EQUAL_FLOW=1` (#1831,
 follow-up to #1766/#1745) each append one presence-only scheduler

--- a/test/incus/apply-cos-config.sh
+++ b/test/incus/apply-cos-config.sh
@@ -53,6 +53,12 @@ set -euo pipefail
 _LOCK_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=cluster-lock.sh
 source "${_LOCK_SCRIPT_DIR}/cluster-lock.sh"
+# #6440: CLI-transcript success-marker gate. The piped-stdin CLI is a REPL
+# that prints "error: ..." for a failed command, continues, and still exits
+# 0 — so every phase below must verify the CLI's own success markers rather
+# than the session's exit status.
+# shellcheck source=cos-apply-lib.sh
+source "${_LOCK_SCRIPT_DIR}/cos-apply-lib.sh"
 if ! xpf_cluster_lock_held; then
     exec "${_LOCK_SCRIPT_DIR}/with-cluster.sh" "apply-cos-config $*" \
         -- "${_LOCK_SCRIPT_DIR}/apply-cos-config.sh" "$@"
@@ -207,6 +213,16 @@ incus file push --mode 0644 "$SETS_TMP" "${TARGET}/${REMOTE_SETS}" >/dev/null
 # check` validates the candidate before apply; we invoke it first so a
 # syntactically-bad candidate is caught before anything live changes.
 
+# ---- Phase 0: daemon readiness ----
+# This script normally runs immediately after a deploy, which restarts xpfd.
+# #6440 recorded a run whose commit-check died with connection-refused because
+# the gRPC listener was not up yet. Wait for it before touching config.
+if ! cos_wait_daemon_ready "$TARGET" "${COS_READY_TIMEOUT:-60}"; then
+	echo "error: xpfd on $TARGET did not become reachable within ${COS_READY_TIMEOUT:-60}s" >&2
+	echo "no live state changed (nothing was committed)" >&2
+	exit 3
+fi
+
 # ---- Phase 1: commit check (dry-run validate) ----
 CHECK_OUT=$(mktemp)
 trap "rm -f '$SETS_TMP' '$CHECK_OUT'" EXIT
@@ -231,6 +247,16 @@ then
 	echo "---- cli output ----" >&2
 	cat "$CHECK_OUT" >&2
 	echo "---- end cli output ----" >&2
+	echo "no live state changed (commit check runs on the candidate only)" >&2
+	exit 4
+fi
+# #6440: the exit status above is NOT sufficient — the piped-stdin CLI exits 0
+# even when `load merge` or `commit check` failed. Require BOTH markers: a
+# silently-failed load leaves a candidate holding only this script's deletes,
+# which is a VALID candidate, so `commit check` would pass and phase 2 would
+# commit a CoS wipe.
+if ! cos_require_markers "commit check on $TARGET" "$CHECK_OUT" \
+	"$COS_MARKER_LOAD_MERGE" "$COS_MARKER_COMMIT_CHECK"; then
 	echo "no live state changed (commit check runs on the candidate only)" >&2
 	exit 4
 fi
@@ -270,13 +296,18 @@ then
 	# to roll forward onto the last good committed config — if the
 	# pre-apply state itself was wedged, this will repair it.
 	echo "attempting rollback 1 | commit to restore last-good state..." >&2
-	incus exec "$TARGET" -- /usr/local/sbin/cli <<'EOF' >&2 || true
-configure
-rollback 1
-commit
-exit
-quit
-EOF
+	cos_rollback_one "$TARGET" || true
+	exit 5
+fi
+# #6440: as in phase 1, the exit status alone proves nothing. Require the
+# markers for BOTH verbs that must have landed for CoS to be applied.
+if ! cos_require_markers "commit on $TARGET" "$APPLY_OUT" \
+	"$COS_MARKER_LOAD_MERGE" "$COS_MARKER_COMMIT"; then
+	echo "the CoS apply did NOT land; rolling forward to the last good state..." >&2
+	# `|| true` so a failed rollback does not let `set -e` pre-empt the
+	# phase-specific exit code below; cos_rollback_one has already reported
+	# MANUAL INTERVENTION REQUIRED on that path.
+	cos_rollback_one "$TARGET" || true
 	exit 5
 fi
 
@@ -288,8 +319,21 @@ fi
 # not runtime-live — roll back to the previous good state.
 VERIFY_OUT=$(mktemp)
 trap "rm -f '$SETS_TMP' '$CHECK_OUT' '$APPLY_OUT' '$VERIFY_OUT'" EXIT
-incus exec "$TARGET" -- /usr/local/sbin/cli -c "show class-of-service interface" \
-	> "$VERIFY_OUT" 2>&1 || true
+# NOTE (#6440): do NOT `|| true` this one. Unlike the piped-stdin heredocs
+# above, `cli -c` DOES exit non-zero on a dispatch error or an unreachable
+# xpfd, so its status is meaningful. Swallowing it made an unreachable daemon
+# produce an error transcript that failed the shaper grep below and exited 6
+# blaming a "missing shaper binding" — the misdiagnosis #6440 was filed on.
+if ! incus exec "$TARGET" -- /usr/local/sbin/cli -c "show class-of-service interface" \
+	> "$VERIFY_OUT" 2>&1; then
+	echo "error: 'show class-of-service interface' FAILED on $TARGET (the CLI could not run it)" >&2
+	echo "---- cli output ----" >&2
+	cat "$VERIFY_OUT" >&2
+	echo "---- end cli output ----" >&2
+	echo "this is a CLI/daemon reachability failure, NOT a CoS binding failure" >&2
+	cos_rollback_one "$TARGET" || true
+	exit 6
+fi
 cat "$VERIFY_OUT"
 
 # Look for ANY shaper/scheduler signal. If the show output does not
@@ -298,21 +342,7 @@ cat "$VERIFY_OUT"
 if ! grep -iqE 'shaper|scheduler|traffic-control-profile|output.*traffic' "$VERIFY_OUT"; then
 	echo "error: post-commit verification FAILED — 'show class-of-service interface' output shows no shaper/scheduler binding" >&2
 	echo "rolling forward with 'rollback 1 | commit' to restore the last good state..." >&2
-	ROLLBACK_OUT=$(mktemp)
-	trap "rm -f '$SETS_TMP' '$CHECK_OUT' '$APPLY_OUT' '$VERIFY_OUT' '$ROLLBACK_OUT'" EXIT
-	if incus exec "$TARGET" -- /usr/local/sbin/cli > "$ROLLBACK_OUT" 2>&1 <<'EOF'
-configure
-rollback 1
-commit
-exit
-quit
-EOF
-	then
-		echo "rollback 1 committed — live state reverted" >&2
-	else
-		echo "WARN: rollback commit also failed — MANUAL INTERVENTION REQUIRED" >&2
-		cat "$ROLLBACK_OUT" >&2
-	fi
+	cos_rollback_one "$TARGET" || true
 	exit 6
 fi
 
@@ -340,9 +370,14 @@ fi
 if grep -qE '^set .*oversubscription-policy' "$CONFIG_FILE"; then
 	OVERSUB_OUT=$(mktemp)
 	trap "rm -f '$SETS_TMP' '$CHECK_OUT' '$APPLY_OUT' '$VERIFY_OUT' '$OVERSUB_OUT'" EXIT
-	incus exec "$TARGET" -- /usr/local/sbin/cli -c \
+	if ! incus exec "$TARGET" -- /usr/local/sbin/cli -c \
 		"show configuration class-of-service | display set" \
-		> "$OVERSUB_OUT" 2>&1 || true
+		> "$OVERSUB_OUT" 2>&1; then
+		echo "error: 'show configuration class-of-service | display set' FAILED on $TARGET" >&2
+		cat "$OVERSUB_OUT" >&2
+		cos_rollback_one "$TARGET" || true
+		exit 7
+	fi
 
 	MISSING=0
 	while IFS= read -r want; do
@@ -360,21 +395,7 @@ if grep -qE '^set .*oversubscription-policy' "$CONFIG_FILE"; then
 		cat "$OVERSUB_OUT" >&2
 		echo "---- end show output ----" >&2
 		echo "rolling forward with 'rollback 1 | commit' to restore the last good state..." >&2
-		ROLLBACK_OUT=$(mktemp)
-		trap "rm -f '$SETS_TMP' '$CHECK_OUT' '$APPLY_OUT' '$VERIFY_OUT' '$OVERSUB_OUT' '$ROLLBACK_OUT'" EXIT
-		if incus exec "$TARGET" -- /usr/local/sbin/cli > "$ROLLBACK_OUT" 2>&1 <<'EOF'
-configure
-rollback 1
-commit
-exit
-quit
-EOF
-		then
-			echo "rollback 1 committed — live state reverted" >&2
-		else
-			echo "WARN: rollback commit also failed — MANUAL INTERVENTION REQUIRED" >&2
-			cat "$ROLLBACK_OUT" >&2
-		fi
+		cos_rollback_one "$TARGET" || true
 		exit 7
 	fi
 fi

--- a/test/incus/cos-apply-lib-selftest.sh
+++ b/test/incus/cos-apply-lib-selftest.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+# Self-test for test/incus/cos-apply-lib.sh (#6440).
+#
+# Hermetic: no incus, no cluster, no VM, no network. `incus` is mocked as a
+# shell function that replays a canned CLI transcript, so the marker gate and
+# the verified-rollback helper are exercised end-to-end.
+#
+# The load-bearing pair is "the #6440 failure transcript" vs "the benign
+# transcript": BOTH carry the same path-not-found noise from this script's
+# idempotent `delete` lines, and they differ ONLY in whether the CLI reported
+# its success markers. A gate that keyed on `error:` lines instead of the
+# markers would reject both; a gate that keyed on the session exit status
+# (the pre-fix behavior) would accept both.
+#
+# Usage: ./test/incus/cos-apply-lib-selftest.sh   (rc 0 = all pass)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=cos-apply-lib.sh
+source "${SCRIPT_DIR}/cos-apply-lib.sh"
+
+PASS=0
+FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# ── transcript fixtures ───────────────────────────────────────────────
+# The exact shape apply-cos-config.sh captures. The `error: ... path not
+# found` lines are the NORMAL, benign result of the script's idempotent
+# delete list on a fresh post-deploy box where CoS was already wiped
+# (config.ConfigTree.DeletePath -> ErrPathNotFound).
+BENIGN_NOISE='error: delete: path not found: class-of-service
+error: delete: path not found: firewall family inet filter bandwidth-output'
+
+# A healthy phase-1 (commit check) session.
+transcript_check_ok() {
+	cat <<EOF
+$BENIGN_NOISE
+load merge complete
+configuration check succeeds
+Exiting configuration mode
+EOF
+}
+
+# The #6440 failure: `load merge` failed, so the candidate held ONLY the
+# deletes. That IS a valid candidate, so `commit check` still succeeded. The
+# REPL printed the error and carried on; the session exited 0.
+transcript_check_load_failed() {
+	cat <<EOF
+$BENIGN_NOISE
+error: load merge: line 12: "set class-of-service ..." is not a set/delete/deactivate/activate command
+configuration check succeeds
+Exiting configuration mode
+EOF
+}
+
+# A healthy phase-2 (commit) session.
+transcript_commit_ok() {
+	cat <<EOF
+$BENIGN_NOISE
+load merge complete
+commit complete
+Exiting configuration mode
+EOF
+}
+
+# Phase 2 where the commit itself failed after a good load.
+transcript_commit_failed() {
+	cat <<EOF
+load merge complete
+error: commit failed: rpc error: code = Unavailable desc = connection refused
+Exiting configuration mode
+EOF
+}
+
+# require_on <fixture-fn> <label> <marker>...
+#
+# Materialize <fixture-fn>'s transcript to a temp file and run
+# cos_require_markers against it. The transcript path must land in argument
+# POSITION 2 (cos_require_markers <label> <transcript> <marker>...) — an
+# earlier revision of this harness appended it after the markers instead,
+# which made cos_require_markers stat a marker STRING as its transcript,
+# fail the [[ -f ]] guard, and report every marker missing. Every "must be
+# REJECTED" cell then passed for the wrong reason (a vacuous green) while
+# the "must be ACCEPTED" cells failed. Keep the position explicit.
+require_on() {
+	local fixture="$1" label="$2"; shift 2
+	local t; t=$(mktemp)
+	"$fixture" > "$t"
+	cos_require_markers "$label" "$t" "$@"
+	local rc=$?
+	rm -f "$t"
+	return $rc
+}
+
+# ── cos_transcript_has_marker ─────────────────────────────────────────
+t=$(mktemp); printf 'commit complete\n' > "$t"
+cos_transcript_has_marker "$t" "$COS_MARKER_COMMIT" \
+	&& ok "marker found on its own line" \
+	|| bad "marker found on its own line"
+
+printf 'commit complete: 3 changes\n' > "$t"
+cos_transcript_has_marker "$t" "$COS_MARKER_COMMIT" \
+	&& ok "marker matches the 'commit complete: <summary>' form" \
+	|| bad "marker matches the 'commit complete: <summary>' form"
+
+# Line-anchoring: the marker text appearing INSIDE an error message must not
+# satisfy the assertion. Without the ^ anchor this cell passes wrongly.
+printf 'error: commit failed before commit complete could be reported\n' > "$t"
+cos_transcript_has_marker "$t" "$COS_MARKER_COMMIT" \
+	&& bad "marker must NOT match mid-line inside an error message" \
+	|| ok "marker must NOT match mid-line inside an error message"
+
+printf 'nothing here\n' > "$t"
+cos_transcript_has_marker "$t" "$COS_MARKER_COMMIT" \
+	&& bad "absent marker must not be reported present" \
+	|| ok "absent marker must not be reported present"
+
+cos_transcript_has_marker "/nonexistent/transcript" "$COS_MARKER_COMMIT" \
+	&& bad "a missing transcript file must not satisfy the gate" \
+	|| ok "a missing transcript file must not satisfy the gate"
+rm -f "$t"
+
+# ── cos_require_markers: the load-bearing pair ────────────────────────
+# Benign noise + both markers -> ACCEPT. Proves the gate does not
+# false-positive on the idempotent delete list's path-not-found errors.
+if require_on transcript_check_ok "phase1" \
+	"$COS_MARKER_LOAD_MERGE" "$COS_MARKER_COMMIT_CHECK" 2>/dev/null; then
+	ok "healthy commit-check transcript ACCEPTED despite benign delete errors"
+else
+	bad "healthy commit-check transcript ACCEPTED despite benign delete errors"
+fi
+
+# Same benign noise, `load merge` marker absent -> REJECT. This is the exact
+# #6440 case that the old exit-status gate could not see.
+if require_on transcript_check_load_failed "phase1" \
+	"$COS_MARKER_LOAD_MERGE" "$COS_MARKER_COMMIT_CHECK" 2>/dev/null; then
+	bad "#6440: a silently-failed 'load merge' must be REJECTED even though commit-check passed"
+else
+	ok "#6440: a silently-failed 'load merge' must be REJECTED even though commit-check passed"
+fi
+
+if require_on transcript_commit_ok "phase2" \
+	"$COS_MARKER_LOAD_MERGE" "$COS_MARKER_COMMIT" 2>/dev/null; then
+	ok "healthy commit transcript ACCEPTED"
+else
+	bad "healthy commit transcript ACCEPTED"
+fi
+
+if require_on transcript_commit_failed "phase2" \
+	"$COS_MARKER_LOAD_MERGE" "$COS_MARKER_COMMIT" 2>/dev/null; then
+	bad "a failed commit must be REJECTED"
+else
+	ok "a failed commit must be REJECTED"
+fi
+
+# The failure report must NAME the missing marker, so the operator learns
+# which verb failed instead of chasing the downstream symptom.
+report=$(require_on transcript_check_load_failed "phase1" \
+	"$COS_MARKER_LOAD_MERGE" "$COS_MARKER_COMMIT_CHECK" 2>&1)
+if grep -q "never reported \"load merge complete\"" <<<"$report"; then
+	ok "the failure report names the missing marker (load merge)"
+else
+	bad "the failure report names the missing marker (load merge)"
+fi
+# ...and must NOT accuse the verb that actually succeeded.
+if grep -q "never reported \"configuration check succeeds\"" <<<"$report"; then
+	bad "the failure report must not accuse commit-check, which succeeded"
+else
+	ok "the failure report must not accuse commit-check, which succeeded"
+fi
+
+# ── incus mock for the rollback / readiness helpers ───────────────────
+# MOCK_ROLLBACK_TRANSCRIPT selects what the mocked CLI prints for the
+# rollback session; MOCK_READY_AFTER makes the readiness probe fail N times
+# before succeeding. MOCK_READY_CALLS counts probes.
+MOCK_ROLLBACK_TRANSCRIPT="ok"
+MOCK_READY_AFTER=0
+MOCK_READY_CALLS=0
+
+incus() {
+	# Only `incus exec <inst> -- /usr/local/sbin/cli ...` is used by the lib.
+	if [[ "$*" == *"-c show system uptime"* ]]; then
+		MOCK_READY_CALLS=$((MOCK_READY_CALLS + 1))
+		[[ "$MOCK_READY_CALLS" -gt "$MOCK_READY_AFTER" ]] && return 0
+		return 1
+	fi
+	# The rollback session: consume the heredoc on stdin, emit a transcript.
+	cat >/dev/null
+	case "$MOCK_ROLLBACK_TRANSCRIPT" in
+	ok)
+		echo "configuration rolled back"
+		echo "commit complete"
+		;;
+	rollback_failed)
+		echo "error: rollback: no previous configuration"
+		;;
+	commit_failed)
+		echo "configuration rolled back"
+		echo "error: commit failed: connection refused"
+		;;
+	esac
+	return 0
+}
+# `sleep` is mocked away so the readiness timeout cell runs instantly.
+sleep() { :; }
+
+# ── cos_rollback_one ──────────────────────────────────────────────────
+MOCK_ROLLBACK_TRANSCRIPT="ok"
+if cos_rollback_one "fake:vm" 2>/dev/null; then
+	ok "a rollback that reported BOTH markers is treated as landed"
+else
+	bad "a rollback that reported BOTH markers is treated as landed"
+fi
+
+# The #6440 reassurance: the pre-fix script announced "live state reverted"
+# from the `then` branch of an `if` on the session exit status, which is 0
+# even here. The helper must call this a FAILURE.
+MOCK_ROLLBACK_TRANSCRIPT="rollback_failed"
+if cos_rollback_one "fake:vm" 2>/dev/null; then
+	bad "a rollback whose 'rollback' verb failed must NOT report 'live state reverted'"
+else
+	ok "a rollback whose 'rollback' verb failed must NOT report 'live state reverted'"
+fi
+
+MOCK_ROLLBACK_TRANSCRIPT="commit_failed"
+if cos_rollback_one "fake:vm" 2>/dev/null; then
+	bad "a rollback whose 'commit' verb failed must NOT report 'live state reverted'"
+else
+	ok "a rollback whose 'commit' verb failed must NOT report 'live state reverted'"
+fi
+
+# And the operator-facing text must only claim a revert when it was verified.
+MOCK_ROLLBACK_TRANSCRIPT="rollback_failed"
+msg=$(cos_rollback_one "fake:vm" 2>&1)
+if grep -q "live state reverted" <<<"$msg"; then
+	bad "an unverified rollback must not print 'live state reverted'"
+else
+	ok "an unverified rollback must not print 'live state reverted'"
+fi
+if grep -q "MANUAL INTERVENTION REQUIRED" <<<"$msg"; then
+	ok "an unverified rollback escalates to MANUAL INTERVENTION REQUIRED"
+else
+	bad "an unverified rollback escalates to MANUAL INTERVENTION REQUIRED"
+fi
+
+# ── cos_wait_daemon_ready ─────────────────────────────────────────────
+MOCK_READY_CALLS=0; MOCK_READY_AFTER=0
+if cos_wait_daemon_ready "fake:vm" 10; then
+	ok "readiness returns 0 when xpfd answers immediately"
+else
+	bad "readiness returns 0 when xpfd answers immediately"
+fi
+
+MOCK_READY_CALLS=0; MOCK_READY_AFTER=2
+if cos_wait_daemon_ready "fake:vm" 30; then
+	ok "readiness retries past a not-yet-listening daemon"
+else
+	bad "readiness retries past a not-yet-listening daemon"
+fi
+
+# A daemon that never comes up must TIME OUT rather than spin forever.
+MOCK_READY_CALLS=0; MOCK_READY_AFTER=100000
+if cos_wait_daemon_ready "fake:vm" 6; then
+	bad "readiness times out when xpfd never answers"
+else
+	ok "readiness times out when xpfd never answers"
+fi
+
+# ── wiring: apply-cos-config.sh must actually USE the gate ────────────
+# The helpers above can be perfect and the script still fail open if a phase
+# forgets to call them, or calls them with the wrong marker set. These cells
+# bind the call sites. They are textual on purpose: the phases run only
+# against a live cluster, so this is the only hermetic way to prove the
+# wiring did not regress.
+APPLY="${SCRIPT_DIR}/apply-cos-config.sh"
+
+if grep -q 'source "${_LOCK_SCRIPT_DIR}/cos-apply-lib.sh"' "$APPLY"; then
+	ok "apply-cos-config.sh sources the gate library"
+else
+	bad "apply-cos-config.sh sources the gate library"
+fi
+
+# Phase 1 must require BOTH the load and the commit-check markers. Requiring
+# only commit-check is precisely the #6440 hole: a failed load leaves a
+# deletes-only candidate that checks clean.
+if grep -A2 'cos_require_markers "commit check' "$APPLY" \
+	| grep -q 'COS_MARKER_LOAD_MERGE.*COS_MARKER_COMMIT_CHECK'; then
+	ok "phase 1 requires the load-merge AND commit-check markers"
+else
+	bad "phase 1 requires the load-merge AND commit-check markers"
+fi
+
+if grep -A2 'cos_require_markers "commit on' "$APPLY" \
+	| grep -q 'COS_MARKER_LOAD_MERGE.*COS_MARKER_COMMIT"'; then
+	ok "phase 2 requires the load-merge AND commit markers"
+else
+	bad "phase 2 requires the load-merge AND commit markers"
+fi
+
+# No unverified rollback heredoc may survive: every rollback must go through
+# cos_rollback_one, which checks the markers before claiming a revert.
+if grep -q '^rollback 1$' "$APPLY"; then
+	bad "no raw 'rollback 1' heredoc may remain in apply-cos-config.sh"
+else
+	ok "no raw 'rollback 1' heredoc may remain in apply-cos-config.sh"
+fi
+
+if grep -q 'live state reverted' "$APPLY"; then
+	bad "apply-cos-config.sh must not claim 'live state reverted' itself (cos_rollback_one owns that, verified)"
+else
+	ok "apply-cos-config.sh must not claim 'live state reverted' itself (cos_rollback_one owns that, verified)"
+fi
+
+# The `cli -c` readback exit status must no longer be discarded.
+if grep -q 'show class-of-service interface" \\$' "$APPLY" \
+	&& grep -A1 'show class-of-service interface"' "$APPLY" | grep -q '|| true'; then
+	bad "the 'show class-of-service interface' readback must not discard its exit status"
+else
+	ok "the 'show class-of-service interface' readback must not discard its exit status"
+fi
+
+if grep -q 'cos_wait_daemon_ready "\$TARGET"' "$APPLY"; then
+	ok "apply-cos-config.sh waits for xpfd readiness before the first commit"
+else
+	bad "apply-cos-config.sh waits for xpfd readiness before the first commit"
+fi
+
+echo
+echo "cos-apply-lib-selftest: ${PASS} passed, ${FAIL} failed"
+[[ "$FAIL" -eq 0 ]]

--- a/test/incus/cos-apply-lib.sh
+++ b/test/incus/cos-apply-lib.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Shared CLI-transcript verification helpers for the xpf CoS apply path
+# (#6440).
+#
+# WHY THIS EXISTS
+#
+# `apply-cos-config.sh` drives the Junos-style CLI by piping a heredoc into
+# `/usr/local/sbin/cli`:
+#
+#     if ! incus exec "$TARGET" -- /usr/local/sbin/cli <<EOF
+#     configure
+#     delete class-of-service
+#     load merge /tmp/cos-iperf-sets.set
+#     commit check
+#     ...
+#
+# and gated each phase on that command's EXIT STATUS. That gate is
+# structurally unable to detect a failure, because the stdin form of the CLI
+# is a REPL, not a batch runner. Its read loop (cmd/cli/main.go) is:
+#
+#     err = c.dispatch(line)
+#     if err != nil {
+#         if err == errExit { break }
+#         fmt.Fprintf(os.Stderr, "error: %v\n", err)   // print and CONTINUE
+#     }
+#
+# A failed `load merge` / `commit check` / `commit` prints one `error: ...`
+# line to stderr, the loop moves to the NEXT heredoc line, and `main` returns
+# normally — process exit status 0. (`cli -c "<one command>"` is the opposite:
+# that path DOES `os.Exit(1)` on a dispatch error. Only the piped-stdin form
+# swallows.)
+#
+# The consequence #6440 reported: a `load merge` that failed left a candidate
+# holding ONLY the script's `delete class-of-service ...` lines. Deleting is
+# perfectly valid, so `commit check` passed and `commit` committed the deletes
+# — wiping CoS instead of re-applying it. Neither the phase-1 nor the phase-2
+# gate could fire, so the first thing that noticed anything was the phase-3
+# output grep, which reported the MISLEADING "no shaper/scheduler binding"
+# and exited 6. Every CoS-dependent measurement taken after such a run was
+# silently taken against un-applied config.
+#
+# THE GATE
+#
+# Instead of trusting the exit status, assert the CLI's own SUCCESS MARKERS
+# are present in the captured transcript. Each config verb prints a distinct
+# line to stdout only on success (cmd/cli/main.go, cmd/cli/shared.go):
+#
+#     load merge      -> "load merge complete"
+#     commit check    -> "configuration check succeeds"
+#     commit          -> "commit complete" (or "commit complete: <summary>")
+#     rollback N      -> "configuration rolled back"
+#
+# On failure the marker is NOT printed and an `error: ...` line appears
+# instead. Asserting the positive marker is deliberately preferred over
+# scanning for `error:`: the script's own delete list is idempotent by design
+# and its `delete <path>` lines legitimately error with a path-not-found on a
+# fresh post-deploy box (config.ConfigTree.DeletePath returns ErrPathNotFound;
+# see pkg/config/event_options_4423_test.go). Those benign errors must not
+# fail the apply, and they do not disturb the success markers.
+#
+# The Go-side contract these markers form is pinned by
+# cmd/cli/cos_apply_markers_6440_test.go, so a reworded CLI cannot silently
+# un-arm this gate.
+#
+# These helpers depend on nothing but bash + grep so the self-test
+# (cos-apply-lib-selftest.sh, `make test-cos-apply-lib`) is hermetic.
+
+# The CLI success markers this gate keys on. Each is matched ANCHORED to the
+# start of a line, so a marker appearing inside an error/warning message body
+# cannot satisfy the assertion. Keep in sync with
+# cmd/cli/cos_apply_markers_6440_test.go.
+# shellcheck disable=SC2034  # consumed by apply-cos-config.sh, which sources this file
+COS_MARKER_LOAD_MERGE="load merge complete"
+# shellcheck disable=SC2034  # consumed by apply-cos-config.sh, which sources this file
+COS_MARKER_COMMIT_CHECK="configuration check succeeds"
+COS_MARKER_COMMIT="commit complete"
+COS_MARKER_ROLLBACK="configuration rolled back"
+
+# cos_transcript_has_marker <transcript-file> <marker>
+#
+# True when <marker> appears at the START of some line of the transcript.
+# Line-anchored on purpose: `commit complete` must match both the bare form
+# and `commit complete: <summary>`, but must NOT match a line such as
+# `error: commit failed: ... commit complete ...`.
+cos_transcript_has_marker() {
+	local transcript="$1" marker="$2"
+	[[ -f "$transcript" ]] || return 1
+	grep -q "^${marker}" "$transcript"
+}
+
+# cos_require_markers <label> <transcript-file> <marker>...
+#
+# Assert every supplied marker is present in the transcript. Returns 0 when
+# all are found. On the first miss it reports WHICH marker was missing (that
+# names the verb that actually failed, rather than blaming a downstream
+# symptom) plus the CLI transcript, and returns 1.
+#
+# Callers turn that 1 into the phase-appropriate exit code + rollback.
+cos_require_markers() {
+	local label="$1" transcript="$2"
+	shift 2
+	local marker missing=0
+	for marker in "$@"; do
+		if ! cos_transcript_has_marker "$transcript" "$marker"; then
+			echo "error: ${label}: the CLI never reported \"${marker}\"" >&2
+			missing=1
+		fi
+	done
+	if [[ "$missing" -ne 0 ]]; then
+		echo "error: ${label}: a command inside the CLI session FAILED." >&2
+		echo "  The piped-stdin CLI is a REPL: it prints 'error: ...' for a failed" >&2
+		echo "  command, continues to the next line, and still exits 0 — so the" >&2
+		echo "  session's exit status cannot be trusted (#6440)." >&2
+		echo "---- cli transcript ----" >&2
+		cat "$transcript" >&2
+		echo "---- end cli transcript ----" >&2
+		return 1
+	fi
+	return 0
+}
+
+# cos_wait_daemon_ready <target> [timeout-seconds]
+#
+# Block until xpfd's gRPC endpoint answers on <target>, or the timeout
+# expires. Returns 0 when ready, 1 on timeout.
+#
+# `apply-cos-config.sh` is normally run right after `make cluster-deploy`,
+# which restarts xpfd. #6440 recorded a run whose commit-check failed with
+# connection-refused because the daemon's gRPC listener was not up yet —
+# there was no readiness wait between deploy and the first CLI call.
+#
+# The probe uses `cli -c`, NOT the piped-stdin form: the `-c` path exits
+# non-zero both when xpfd is unreachable (the GetStatus reachability probe)
+# and when the command itself fails, so its exit status is meaningful.
+cos_wait_daemon_ready() {
+	local target="$1" timeout="${2:-60}"
+	local waited=0
+	while [[ "$waited" -lt "$timeout" ]]; do
+		if incus exec "$target" -- /usr/local/sbin/cli -c "show system uptime" \
+			>/dev/null 2>&1; then
+			return 0
+		fi
+		sleep 2
+		waited=$((waited + 2))
+	done
+	return 1
+}
+
+# cos_rollback_one <target>
+#
+# Run `rollback 1 | commit` on <target> and VERIFY it actually landed.
+# Returns 0 only when the CLI reported BOTH "configuration rolled back" and
+# "commit complete".
+#
+# Every rollback site in apply-cos-config.sh previously ran this as
+# `... <<'EOF' || true` and then announced "live state reverted" from the
+# `then` branch of an `if` on the session's exit status — which, being the
+# piped-stdin REPL, is 0 whether or not the rollback worked. So the script
+# could print a clean "live state reverted" over a rollback that never
+# happened, leaving the cluster on the half-applied config the caller
+# believed had been undone. #6440 observed exactly that reassurance.
+cos_rollback_one() {
+	local target="$1"
+	local out
+	out=$(mktemp)
+	incus exec "$target" -- /usr/local/sbin/cli >"$out" 2>&1 <<'CLIEOF' || true
+configure
+rollback 1
+commit
+exit
+quit
+CLIEOF
+	if cos_require_markers "rollback 1 | commit on $target" "$out" \
+		"$COS_MARKER_ROLLBACK" "$COS_MARKER_COMMIT"; then
+		echo "rollback 1 committed — live state reverted (verified)" >&2
+		rm -f "$out"
+		return 0
+	fi
+	echo "WARN: rollback commit did NOT land — MANUAL INTERVENTION REQUIRED" >&2
+	rm -f "$out"
+	return 1
+}


### PR DESCRIPTION
## The defect

`apply-cos-config.sh` exited **6** on `loss:xpf-userspace-fw0` with "no
shaper/scheduler binding" and auto-rolled-back. Because `make cluster-deploy`
wipes CoS and this script is how it gets re-applied, every CoS-dependent
measurement after such a run was silently taken against **un-applied config**.

The script drives the CLI by piping a heredoc into it and gated each phase on
that command's **exit status**. That gate is structurally unable to detect a
failure. The piped-stdin form of the CLI is a **REPL, not a batch runner** —
`cmd/cli/main.go`:

```go
err = c.dispatch(line)
if err != nil {
    if err == errExit { break }
    if err == context.Canceled { continue }
    fmt.Fprintf(os.Stderr, "error: %v\n", err)   // print and CONTINUE
}
```

A failed command prints one line to stderr, the loop moves to the next heredoc
line, and `main` returns normally — **exit status 0**. Only
`cli -c "<one command>"` `os.Exit(1)`s on a dispatch error.

So a `load merge` that failed left a candidate holding ONLY the script's
`delete class-of-service ...` lines. Deleting is a **valid** candidate, so
`commit check` passed and `commit` committed the deletes — wiping CoS instead
of re-applying it. Neither the phase-1 nor the phase-2 gate could fire; the
first check that inspected anything was the phase-3 output grep, which blamed
a missing shaper binding for a failure two phases upstream.

Both the exit-4 ("commit check failed") and exit-5 ("commit failed") paths were
**dead code** for per-command failures.

## Three further defects on the same root cause

1. **The rollback reassurance was unverified.** Every rollback site ran
   `... <<'EOF' || true` and then announced `live state reverted` from the
   `then` branch of an `if` on the session exit status — i.e. unconditionally.
   The script could report a clean revert over a rollback that never happened.
   #6440 recorded exactly that reassurance.
2. **The two `cli -c` readbacks discarded their exit status** with `|| true`.
   That form's status *is* meaningful, so an unreachable xpfd produced an error
   transcript that failed the shaper grep and exited 6 blaming CoS — the
   misdiagnosis this issue was filed on.
3. **No daemon-readiness wait** between a deploy (which restarts xpfd) and the
   first CLI call. The issue's follow-up comment recorded a commit-check dying
   on connection-refused for this reason.

## The fix

Gate on the CLI's own **success markers**, which are printed only on success:

| verb | marker |
|---|---|
| `load merge` | `load merge complete` |
| `commit check` | `configuration check succeeds` |
| `commit` | `commit complete` (or `commit complete: <summary>`) |
| `rollback N` | `configuration rolled back` |

Positive markers are checked rather than scanning for `error:` lines because
the script's delete list is **idempotent by design**: its `delete` lines
legitimately return path-not-found on a fresh post-deploy box
(`ConfigTree.DeletePath` → `ErrPathNotFound`). That benign noise must not fail
the apply, and it does not disturb the markers. The self-test's load-bearing
pair carries *identical* benign noise in both transcripts and differs only in
the markers — an `error:`-scanning gate rejects both; the old exit-status gate
accepts both.

Rollbacks now route through `cos_rollback_one`, which requires both markers
before claiming a revert. A new phase 0 waits for the gRPC listener (exit 3 if
it never arrives), and the readbacks fail with an explicit "reachability
failure, **NOT** a CoS binding failure".

The marker strings are a cross-language contract, so both halves are pinned:
`cmd/cli/cos_apply_markers_6440_test.go` asserts each marker **is** printed on
success and **is not** printed on failure (an always-on marker would make the
gate vacuous), and fails if the shell library and the CLI ever disagree.

## Validation

- `make test-cos-apply-lib` — 26/26 hermetic cells (mocked incus, canned
  transcripts) + 6 Go marker tests, rc 0. Filter confirmed non-vacuous: `-run
  6440` selected 6 named tests, not zero.
- `go build ./...`, `go vet ./cmd/cli/`, `go test -count=1 ./cmd/cli/` — rc 0.
- `bash -n` clean on all three scripts; `shellcheck -S warning` clean on both
  new files (real `$?`, not through a pipe).

### Mutation matrix (one mutation per cell, rc read from `$?`)

| mutation | rc | assertion that fired |
|---|---|---|
| remove the marker line-anchor | 1 | only the mid-line cell |
| `cos_require_markers` always returns 0 | 1 | both REJECT cells + all rollback cells |
| rollback claims success unconditionally | 1 | all four rollback cells |
| phase 1 drops the load-merge marker | 1 | the phase-1 wiring cell only |
| restore the unverified rollback heredoc | 1 | the raw-heredoc + "live state reverted" cells |
| remove the readiness wait | 1 | the readiness wiring cell |
| CLI rewords `load merge complete` | 1 | `load merge success must print ...` |
| CLI prints the marker unconditionally | 1 | `a FAILED load merge must NOT print ...` |
| shell gate greps a marker the CLI never prints | 1 | the cross-language cell |

Post-restore control green.

An earlier revision of the self-test passed the transcript path in the wrong
argument position, which made every "must be REJECTED" cell pass **vacuously**
(`cos_require_markers` stat'd a marker string as its transcript and reported
everything missing). The helper now takes the position explicitly and
documents why.

## Scope

Diagnosed **statically** — no cluster access, no deploy, no smoke, per the
dispatch. Test tooling only: **no daemon, dataplane, or Rust helper code is
touched**, so no shim `.o` moves and no cluster smoke is owed.

A live confirmation run on the loss cluster is still worth doing once it frees,
to observe which verb the new gate names on a real failure. That is a
nice-to-have, not a merge blocker — the gate's behavior is fully covered
hermetically.

Docs updated per the repo contract: `docs/cos-validation-notes.md` gains a "How
the loader detects a failed apply" section (and its stale "intentionally strict
on `load merge` / `commit`" claim is corrected — that strictness could not work
before this change), plus `CLAUDE.md` and the `Makefile` target.

Closes #6440

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cz2czGK3aA5MsMhkNkjHXX