### PR TITLE
docs: regenerate the refactoring heatmap

### DIFF
--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -1,5 +1,5 @@
 [REFACTOR]   5466  userspace-dp/src/afxdp/poll_descriptor/mod.rs
-[REFACTOR]   4007  pkg/config/compiler_validate_strict_nat.go
+[REFACTOR]   4150  pkg/config/compiler_validate_strict_nat.go
 [REFACTOR]   3926  userspace-dp/src/nat64.rs
 [REFACTOR]   3801  userspace-dp/src/policy.rs
 [REFACTOR]   2884  pkg/config/compiler_system.go
@@ -16,13 +16,13 @@
 [REFACTOR]   2258  userspace-dp/src/afxdp/cos/queue_service/mod.rs
 [REFACTOR]   2227  userspace-dp/src/session/mod.rs
 [REFACTOR]   2225  pkg/config/compiler_services.go
+[REFACTOR]   2197  pkg/grpcapi/server_sessions.go
 [REFACTOR]   2092  userspace-dp/src/afxdp/frame/mod.rs
 [REFACTOR]   2074  pkg/dhcprelay/relay.go
 [REFACTOR]   2056  userspace-dp/src/afxdp/frame/inspect.rs
 [REFACTOR]   2046  pkg/dataplane/userspace/maps_sync.go
 [REFACTOR]   2005  pkg/daemon/daemon_ha.go
 [WATCH]      1995  pkg/dataplane/compiler.go
-[WATCH]      1991  pkg/grpcapi/server_sessions.go
 [WATCH]      1953  pkg/api/metrics_userspace.go
 [WATCH]      1952  pkg/config/compiler_validate_warn.go
 [WATCH]      1932  pkg/ddns/manager.go
@@ -31,12 +31,12 @@
 [WATCH]      1829  pkg/config/compiler_validate_strict_filter.go
 [WATCH]      1823  pkg/snmp/agent.go
 [WATCH]      1795  userspace-dp/src/afxdp/wg/engine.rs
+[WATCH]      1792  pkg/api/sessions.go
 [WATCH]      1776  pkg/config/types_system.go
 [WATCH]      1764  userspace-dp/src/screen/scan.rs
-[WATCH]      1680  pkg/api/server.go
+[WATCH]      1685  pkg/api/server.go
 [WATCH]      1654  pkg/dataplane/compiler_iface.go
 [WATCH]      1652  pkg/cmdtree/tree.go
-[WATCH]      1639  pkg/api/sessions.go
 [WATCH]      1608  userspace-dp/src/afxdp/poll_descriptor/filter.rs
 [WATCH]      1608  userspace-dp/src/afxdp/tx/dispatch/mod.rs
 [WATCH]      1595  pkg/cluster/heartbeat.go
@@ -48,3 +48,4 @@
 [WATCH]      1539  pkg/dataplane/userspace/eventstream.go
 [WATCH]      1531  userspace-xdp/src/lib.rs
 [WATCH]      1528  pkg/config/types_security.go
+[WATCH]      1501  pkg/dataplane/types.go


### PR DESCRIPTION
`pkg/refactoraudit` is red on master again — for two files unrelated to the previous regeneration in #7235.

Measured firsthand at `origin/master` `e5403832e`:

```
entered the audit (now >=1500 LOC):
  [WATCH]    pkg/dataplane/types.go
changed tier (crossed 2000 LOC):
  pkg/grpcapi/server_sessions.go: [WATCH] -> [REFACTOR]
```

I confirmed both sizes independently rather than trusting the assertion text: `pkg/dataplane/types.go` is **1501** lines — it crossed the floor by **exactly one line** — and `pkg/grpcapi/server_sessions.go` is **2197** after `0053f3533` ("filter sessions by the recorded ingress interface", +251/-47) pushed it through 2000. `tcp_segmentation.rs` from #7235 is still correctly present at 1582, so that fix landed and held.

## The second regeneration in an hour is the actual finding

This unblocks `go test ./...`, but it is a treadmill and should be read as one.

The artifact is a generated snapshot of a **repo-global** property, so it is only valid for the tree it was generated from. On a board landing several PRs an hour it can go stale between authoring and merge — #7235 was authored against a head that no longer existed by the time it landed. A PR author who did everything right still lands red, and the file that reds them is usually one they never touched.

`types.go` at **1501** is the sharpest illustration: a one-line addition anywhere in the repo flipped a gate for unrelated authors.

**#6617 already relaxed this gate once for exactly this reason** — from a byte-for-byte compare to an audit-content compare, after measuring master byte-stale in 26 of 40 first-parent commits. The content compare has the same flaw one level up: it is narrower, but any file crossing a threshold anywhere still reds it globally.

Filed separately as a gate-design issue rather than worked around here. The plausible fixes are regenerating at merge time, or letting the gate tolerate a bounded lag — both are decisions for whoever owns the gate, not something to smuggle into a regeneration PR.

## The change

Generated with the committed generator, not edited by hand:

```
bash scripts/refactoring-audit.sh > docs/refactoring-audit-current.txt
```

## Validation

- Failure reproduced first at `origin/master` `e5403832e` with none of this change.
- Both file sizes verified independently (1501, 2197).
- After regeneration: `go test -count=1 ./pkg/refactoraudit/` **rc=0**.

Exit codes read from `$?` directly, never through a pipe.

Docs-only: one generated artifact, no `.go`, no `.rs`, no compiled artifact. No cluster smoke owed.