### PR TITLE
cluster: source the bulk window from table-truth (#6031)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -99519,3 +99519,18 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: `userspace-dp/src/afxdp/mod.rs`,
   `userspace-dp/src/server/helpers/status.rs`,
   `userspace-dp/tests/heartbeat_failclosed_doc_guard.rs` (new)
+
+## 2026-08-21 — #6031: source the cold-prime bulk window from table-truth
+- **Timestamp**: 2026-08-21
+- **Action**: Add `SessionSync.BulkSessionSource` (three-case contract: snapshot /
+  fall-back / abort) so `BulkSync` delimits its authoritative window from the
+  Rust helper's `export_owner_rg_sessions` table-truth walk instead of the
+  best-effort BPF display mirror. Wired in `startClusterComms` to the daemon's
+  `userspaceBulkSessionSnapshot`. The delta -> wire expansion is now a single
+  shared walk (`forEachUserspaceOpenWireSession`) used by both the incremental
+  stream and the bulk snapshot.
+- **File(s)**: pkg/cluster/sync.go, pkg/cluster/sync_bulk.go,
+  pkg/daemon/daemon_ha_userspace_stream.go, pkg/daemon/daemon_ha_sync.go,
+  pkg/cluster/sync_bulk_source_6031_test.go (new),
+  pkg/daemon/userspace_bulk_snapshot_6031_test.go (new),
+  docs/sync-protocol.md, docs/session-sync-architecture.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -239,14 +239,23 @@ the new bulk is sent.
 
 `BulkSync()`:
 
-1. allocates a new monotonically increasing epoch
-2. sends `BulkStart(epoch)`
-3. iterates `sessions_v4` / `sessions_v6`
-4. skips reverse entries
-5. skips sessions not owned by this node for the ingress zone
-6. sends forward entries only
-7. records `pendingBulkAckEpoch` (**before** the `BulkEnd` write)
-8. sends `BulkEnd(epoch)` and then waits for peer acknowledgement
+1. resolves `BulkSessionSource` — the #6031 authoritative, owner-RG-filtered
+   TABLE-TRUTH snapshot (`export_owner_rg_sessions`). This happens BEFORE the
+   epoch is taken, so a source failure aborts without opening a window
+2. allocates a new monotonically increasing epoch
+3. sends `BulkStart(epoch)`
+4. iterates the snapshot when one was supplied, otherwise `sessions_v4` /
+   `sessions_v6` — the best-effort BPF display mirror, which is the fall-back for
+   a runtime with no table-truth export
+5. skips reverse entries
+6. skips sessions not owned by this node for the ingress zone — the store-walk
+   path only; a supplied snapshot is already owner-RG and origin filtered
+7. sends forward entries only
+8. records `pendingBulkAckEpoch` (**before** the `BulkEnd` write)
+9. sends `BulkEnd(epoch)` and then waits for peer acknowledgement
+
+See `docs/sync-protocol.md` "Table-truth bulk source (#6031)" for why the mirror
+is not authoritative and why an export failure aborts rather than falls back.
 
 The sender now treats outbound bulk acknowledgement as first-class state. A
 bulk transfer is not considered fully primed until the peer returns `BulkAck`

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -823,12 +823,52 @@ authoritative snapshot: reconciling against an incomplete set would DELETE live
 peer-owned sessions merely dropped in transit. The override is therefore no
 longer wired in production (`startClusterComms`); `doBulkSync` always ends with
 `BulkSync()`, whose direct writes under `writeMu` are lossless and complete.
-`BulkSync` sources sessions from the shim `sessions`/`sessions_v6` BPF mirror
-maps (owner-RG-filtered by `ShouldSyncZone`); a table-truth source
-(`ExportOwnerRGSessions`) that removes the mirror-drift residual is tracked as a
-follow-up. `BulkSyncOverride` is retained only as a test/extension seam and is
+`BulkSyncOverride` is retained only as a test/extension seam and is
 regression-proof: the trailing `BulkSync()` runs unconditionally, so an override
 can never re-send empty markers.
+
+#### Table-truth bulk source (#6031)
+
+`BulkSync` used to source the window from the local session store, which on the
+userspace dataplane walks the shim `sessions`/`sessions_v6` BPF maps. Those are
+a best-effort DISPLAY MIRROR the Rust helper publishes
+(`publish_bpf_conntrack_entry`) so `show security flow session` can render
+zone/interface information — **not** the helper's authoritative in-process
+`SessionTable`. The mirror can drift from table-truth (publication is gated at
+table cap and on `install_failed`, the periodic refresh lags) and carries no
+per-session ORIGIN, so it also echoes peer-owned imports back at their owner.
+Since #5085 removed the empty-bulk reconcile skip, an under-populated mirror at
+cold-prime is not a missed optimization — the receiver treats every absent key as
+stale and DELETES it.
+
+`SessionSync.BulkSessionSource` (wired in `startClusterComms` to the daemon's
+`userspaceBulkSessionSnapshot`) now supplies the window from the table-truth
+control verb `export_owner_rg_sessions`, filtered to the redundancy groups this
+node is primary for and skipping locally-demoted entries. It is a SOURCE, not an
+override: exactly one `BulkStart → sessions → BulkEnd` window is written, under
+the same epoch, with the same #3912 record-then-send discipline and the same
+#5272 bulk-completion gate. No wire change.
+
+The three-case contract is what makes it safe:
+
+| source returns | BulkSync does |
+|---|---|
+| a snapshot (possibly EMPTY) | frames exactly that set — an empty snapshot is an authoritative "I own nothing", which the peer must reconcile against |
+| `(nil, nil)` | falls back to the session-store walk — no authoritative source exists (no userspace runtime, no committed config), so nothing regresses |
+| `(nil, err)` | ABORTS before writing `BulkStart` |
+
+The abort matters: falling back on an export failure would reconcile the peer
+against exactly the mirror the change decided is not authoritative, and an
+under-populated window deletes live sessions. A skipped bulk is recoverable —
+every `doBulkSync` caller re-arms and retries (`handleNewConnection`'s
+`needColdPrime` latch, the #4090 survivor re-drive, the #82 sweep re-drive).
+
+A supplied snapshot is NOT re-filtered by `ShouldSyncZone`: the source has
+already applied the per-session owner-RG and origin filter, and re-applying the
+zone-level approximation on top would drop sessions the authoritative export says
+this node owns (a zone missing from `zoneRGMap`, a fabric-redirect wire alias) —
+which the peer would then reconcile away. Reverse entries are still skipped on
+both paths.
 
 #### Survivor-fabric cold-start bulk re-drive (#4090)
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -470,6 +470,39 @@ type SessionSync struct {
 	// always ends with the lossless BulkSync window, so an override can never
 	// reintroduce the empty-marker / skipped-reconcile regression.
 	BulkSyncOverride func() error
+	// BulkSessionSource, when set, supplies the AUTHORITATIVE session set that
+	// BulkSync delimits, replacing the walk of the local session store (#6031).
+	//
+	// The store BulkSync otherwise walks is, on the userspace dataplane, the
+	// best-effort BPF conntrack MIRROR the Rust helper publishes for display
+	// (`publish_bpf_conntrack_entry`) — not the helper's authoritative in-process
+	// SessionTable. The mirror can drift from table-truth (publish gating at
+	// table cap / on install_failed, periodic-refresh lag) and carries no
+	// per-session origin, so it can echo peer-owned imports back at their owner.
+	// Since #5085 removed the empty-bulk reconcile skip, reconciling the peer
+	// against an under-populated mirror DELETES live peer-owned sessions.
+	//
+	// Contract, in three cases — the middle one is the reason this is not just
+	// `func() []Session`:
+	//
+	//   (snapshot, nil) → this set IS the window. Sent losslessly under writeMu
+	//                     exactly as the store walk would be.
+	//   (nil, nil)      → no authoritative source is available right now (no
+	//                     userspace runtime, no committed config). Fall back to
+	//                     the store walk — today's posture, unchanged.
+	//   (nil, err)      → the authoritative source FAILED. The bulk is ABORTED.
+	//                     Falling back here would reconcile the peer against
+	//                     exactly the mirror we just decided is not
+	//                     authoritative, which is the unrecoverable direction:
+	//                     an under-populated window deletes live sessions,
+	//                     whereas a skipped bulk is re-armed and retried by
+	//                     every caller (handleNewConnection, the survivor
+	//                     re-drive, and the #82 sweep re-drive).
+	//
+	// An EMPTY non-nil snapshot is authoritative and means exactly that: this
+	// node owns no syncable sessions, so the peer must reconcile away what it
+	// still holds for us.
+	BulkSessionSource func() (*BulkSessionSnapshot, error)
 	// OnBulkSyncAckReceived fires when the peer acknowledges our outbound bulk sync.
 	OnBulkSyncAckReceived func()
 	// OnPeerConnected fires when a peer sync connection is established.

--- a/pkg/cluster/sync_bulk.go
+++ b/pkg/cluster/sync_bulk.go
@@ -47,14 +47,71 @@ func (s *SessionSync) doBulkSync() error {
 	return s.BulkSync()
 }
 
+// resolveBulkSessionSnapshot consults BulkSessionSource, translating its
+// three-case contract (see the field's doc) into (snapshot, err):
+//
+//	non-nil snapshot → send it
+//	nil, nil         → fall back to the local session-store walk
+//	nil, err         → abort the bulk; do NOT fall back to the mirror
+func (s *SessionSync) resolveBulkSessionSnapshot() (*BulkSessionSnapshot, error) {
+	src := s.BulkSessionSource
+	if src == nil {
+		return nil, nil
+	}
+	snapshot, err := src()
+	if err != nil {
+		s.stats.Errors.Add(1)
+		return nil, fmt.Errorf("authoritative bulk session source failed: %w", err)
+	}
+	return snapshot, nil
+}
+
+// BulkSessionSnapshot is a caller-supplied, authoritative set of locally-owned
+// forward sessions for one bulk window (#6031). It exists so the window can be
+// sourced from the dataplane's TABLE-TRUTH export instead of the best-effort
+// BPF display mirror the local session store walks — see BulkSessionSource.
+//
+// A nil-but-returned snapshot and an EMPTY snapshot are different things: empty
+// is an authoritative "I own nothing", which the receiver must reconcile
+// against. Only reverse entries are excluded by construction (the exporter
+// yields forward sessions); BulkSync applies no further filtering to a supplied
+// snapshot, because the source has already applied the owner-RG/origin filter
+// the store walk cannot.
+type BulkSessionSnapshot struct {
+	V4 []dataplane.SessionEntryV4
+	V6 []dataplane.SessionEntryV6
+}
+
+// Len reports the total session count across both families.
+func (b *BulkSessionSnapshot) Len() int {
+	if b == nil {
+		return 0
+	}
+	return len(b.V4) + len(b.V6)
+}
+
 // BulkSync sends all locally-owned forward sessions to the peer inside a
 // BulkStart -> sessions -> BulkEnd window, using lossless direct writes so the
 // receiver reconciles stale peer-owned sessions against the true snapshot.
+//
+// The session set comes from BulkSessionSource when one is installed and
+// yields a snapshot (#6031: the authoritative, owner-RG-filtered table-truth
+// export), and from the local session store otherwise. Either way exactly ONE
+// window is written, under the same epoch, with the same #3912 record-then-send
+// discipline — the source changes where the sessions come from, never the shape
+// of what the receiver reconciles against.
 func (s *SessionSync) BulkSync() error {
 	s.bulkSendMu.Lock()
 	defer s.bulkSendMu.Unlock()
 
-	if s.sessions == nil {
+	// Resolve the source BEFORE the epoch is taken and BulkStart is written: a
+	// source failure must abort without having opened a window the receiver
+	// would otherwise reconcile against an incomplete session set.
+	snapshot, err := s.resolveBulkSessionSnapshot()
+	if err != nil {
+		return err
+	}
+	if snapshot == nil && s.sessions == nil {
 		return fmt.Errorf("session store not ready")
 	}
 	conn := s.getActiveConn()
@@ -80,7 +137,7 @@ func (s *SessionSync) BulkSync() error {
 
 	// Send bulk start marker with epoch.
 	s.writeMu.Lock()
-	err := writeMsg(conn, syncMsgBulkStart, epochBuf[:])
+	err = writeMsg(conn, syncMsgBulkStart, epochBuf[:])
 	s.writeMu.Unlock()
 	if err != nil {
 		s.pendingBulkAckEpoch.Store(0)
@@ -90,24 +147,34 @@ func (s *SessionSync) BulkSync() error {
 	}
 
 	var count, skipped int
-	slog.Info("cluster sync: bulk sync iterating v4", "epoch", epoch)
-	// Send owned v4 forward sessions.
-	err = s.sessions.ForEachV4(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+	source := "session-store"
+	if snapshot != nil {
+		source = "table-truth"
+	}
+	slog.Info("cluster sync: bulk sync iterating v4", "epoch", epoch, "source", source)
+	// sendV4 writes one owned v4 forward session. Shared by both source paths
+	// so the wire framing, the #2170 install-gen stamp, the disconnect handling
+	// and the writeMu yield cadence cannot drift between them. Returns false to
+	// stop the walk on a write failure, exactly as before.
+	sendV4 := func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
 		if val.IsReverse != 0 {
 			return true
 		}
-		if !s.ShouldSyncZone(val.IngressZone) {
+		// A supplied snapshot has already been filtered by the source, which
+		// knows each session's OWNER RG and origin. The store walk has only the
+		// zone-level approximation, so it still applies it.
+		if snapshot == nil && !s.ShouldSyncZone(val.IngressZone) {
 			skipped++
 			return true
 		}
 		s.stampInstallGenV4(key, &val)
 		msg := encodeSessionV4Payload(key, val)
 		s.writeMu.Lock()
-		err := writeMsg(conn, syncMsgSessionV4, msg)
+		werr := writeMsg(conn, syncMsgSessionV4, msg)
 		s.writeMu.Unlock()
-		if err != nil {
+		if werr != nil {
 			s.handleDisconnect(conn)
-			slog.Warn("bulk sync v4 write error", "err", err)
+			slog.Warn("bulk sync v4 write error", "err", werr)
 			return false
 		}
 		count++
@@ -119,11 +186,20 @@ func (s *SessionSync) BulkSync() error {
 			runtime.Gosched()
 		}
 		return true
-	})
-	if err != nil {
-		s.pendingBulkAckEpoch.Store(0)
-		s.pendingBulkAckSince.Store(0)
-		return fmt.Errorf("bulk sync v4 iterate: %w", err)
+	}
+	if snapshot != nil {
+		for _, e := range snapshot.V4 {
+			if !sendV4(e.Key, e.Value) {
+				break
+			}
+		}
+	} else {
+		err = s.sessions.ForEachV4(sendV4)
+		if err != nil {
+			s.pendingBulkAckEpoch.Store(0)
+			s.pendingBulkAckSince.Store(0)
+			return fmt.Errorf("bulk sync v4 iterate: %w", err)
+		}
 	}
 	slog.Info("cluster sync: bulk sync iterated v4",
 		"epoch", epoch,
@@ -131,23 +207,23 @@ func (s *SessionSync) BulkSync() error {
 		"skipped", skipped)
 
 	// Send owned v6 forward sessions.
-	slog.Info("cluster sync: bulk sync iterating v6", "epoch", epoch, "sessions", count, "skipped", skipped)
-	err = s.sessions.ForEachV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+	slog.Info("cluster sync: bulk sync iterating v6", "epoch", epoch, "sessions", count, "skipped", skipped, "source", source)
+	sendV6 := func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
 		if val.IsReverse != 0 {
 			return true
 		}
-		if !s.ShouldSyncZone(val.IngressZone) {
+		if snapshot == nil && !s.ShouldSyncZone(val.IngressZone) {
 			skipped++
 			return true
 		}
 		s.stampInstallGenV6(key, &val)
 		msg := encodeSessionV6Payload(key, val)
 		s.writeMu.Lock()
-		err := writeMsg(conn, syncMsgSessionV6, msg)
+		werr := writeMsg(conn, syncMsgSessionV6, msg)
 		s.writeMu.Unlock()
-		if err != nil {
+		if werr != nil {
 			s.handleDisconnect(conn)
-			slog.Warn("bulk sync v6 write error", "err", err)
+			slog.Warn("bulk sync v6 write error", "err", werr)
 			return false
 		}
 		count++
@@ -155,11 +231,20 @@ func (s *SessionSync) BulkSync() error {
 			runtime.Gosched()
 		}
 		return true
-	})
-	if err != nil {
-		s.pendingBulkAckEpoch.Store(0)
-		s.pendingBulkAckSince.Store(0)
-		return fmt.Errorf("bulk sync v6 iterate: %w", err)
+	}
+	if snapshot != nil {
+		for _, e := range snapshot.V6 {
+			if !sendV6(e.Key, e.Value) {
+				break
+			}
+		}
+	} else {
+		err = s.sessions.ForEachV6(sendV6)
+		if err != nil {
+			s.pendingBulkAckEpoch.Store(0)
+			s.pendingBulkAckSince.Store(0)
+			return fmt.Errorf("bulk sync v6 iterate: %w", err)
+		}
 	}
 	slog.Info("cluster sync: bulk sync iterated v6",
 		"epoch", epoch,
@@ -193,7 +278,7 @@ func (s *SessionSync) BulkSync() error {
 	}
 
 	s.stats.BulkSyncs.Add(1)
-	slog.Info("cluster sync: bulk sync complete", "sessions", count, "skipped", skipped, "epoch", epoch)
+	slog.Info("cluster sync: bulk sync complete", "sessions", count, "skipped", skipped, "epoch", epoch, "source", source)
 	return nil
 }
 

--- a/pkg/cluster/sync_bulk_source_6031_test.go
+++ b/pkg/cluster/sync_bulk_source_6031_test.go
@@ -1,0 +1,331 @@
+package cluster
+
+import (
+	"errors"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #6031 — the cold-prime bulk window must be delimited from TABLE-TRUTH, not
+// from the best-effort BPF display mirror the local session store walks.
+//
+// On the userspace dataplane `s.sessions.ForEachV4/V6` iterates the BPF
+// conntrack maps the Rust helper publishes for `show security flow session`
+// (publish_bpf_conntrack_entry), NOT the helper's authoritative in-process
+// SessionTable. The mirror can be under-populated (publish gating at table cap
+// / on install_failed, periodic-refresh lag). Since #5085 removed the
+// empty-bulk reconcile skip, an under-populated window is not a missed
+// optimisation — the receiver treats every absent key as stale and DELETES it.
+
+func bulkSourceKey(a, b byte, sport uint16) dataplane.SessionKey {
+	return dataplane.SessionKey{
+		SrcIP:    [4]byte{10, 0, 5, a},
+		DstIP:    [4]byte{10, 0, 6, b},
+		Protocol: 6,
+		SrcPort:  sport,
+		DstPort:  80,
+	}
+}
+
+// newBulkSourcePair builds the #5085 primary/standby pair: the sender owns RG5
+// (zone 5), the receiver owns RG1 and holds sessions in both zones.
+func newBulkSourcePair(t *testing.T, senderStore, receiverStore map[dataplane.SessionKey]dataplane.SessionValue) (*SessionSync, *SessionSync, *mockSweepDP) {
+	t.Helper()
+	senderDP := &mockSweepDP{v4sessions: senderStore}
+	senderSS := NewSessionSync(":0", "10.0.0.2:4785", senderDP)
+	senderSS.IsPrimaryFn = func() bool { return true }
+	senderSS.IsPrimaryForRGFn = func(rgID int) bool { return rgID == 5 }
+	senderSS.SetZoneRGMap(map[uint16]int{5: 5})
+
+	receiverDP := &mockSweepDP{v4sessions: receiverStore}
+	receiverSS := NewSessionSync(":0", "10.0.0.3:4785", receiverDP)
+	receiverSS.IsPrimaryFn = func() bool { return false }
+	receiverSS.IsPrimaryForRGFn = func(rgID int) bool { return rgID == 1 }
+	receiverSS.SetZoneRGMap(map[uint16]int{1: 1, 5: 5})
+	return senderSS, receiverSS, receiverDP
+}
+
+// TestBulkSyncSourcesWindowFromTableTruthNotMirror_6031 is the fail-on-revert
+// guard for the residual itself.
+//
+// The primary's helper holds TWO live sessions for its owned RG. Its BPF
+// display mirror — the store BulkSync used to walk — has only one of them:
+// `mirrorOnly`. `tableTruth` is live but was never published (table cap /
+// install_failed / refresh lag). The standby holds BOTH.
+//
+// RED on revert: drop the BulkSessionSource consultation from BulkSync (walk
+// the store as before) and `tableTruth` is absent from the window, so the
+// receiver reconciles a LIVE peer-owned session away.
+func TestBulkSyncSourcesWindowFromTableTruthNotMirror_6031(t *testing.T) {
+	mirrorOnly := bulkSourceKey(1, 1, 1000)
+	tableTruth := bulkSourceKey(2, 2, 2000)
+	localC := dataplane.SessionKey{SrcIP: [4]byte{10, 0, 1, 1}, DstIP: [4]byte{10, 0, 2, 1}, Protocol: 6, SrcPort: 3000, DstPort: 22}
+	live := dataplane.SessionValue{State: dataplane.SessStateEstablished, IngressZone: 5}
+
+	senderSS, receiverSS, receiverDP := newBulkSourcePair(t,
+		// The MIRROR is missing tableTruth — the drift this issue is about.
+		map[dataplane.SessionKey]dataplane.SessionValue{mirrorOnly: live},
+		map[dataplane.SessionKey]dataplane.SessionValue{
+			mirrorOnly: live,
+			tableTruth: live,
+			localC:     {State: dataplane.SessStateEstablished, IngressZone: 1},
+		})
+
+	calls := 0
+	senderSS.BulkSessionSource = func() (*BulkSessionSnapshot, error) {
+		calls++
+		return &BulkSessionSnapshot{V4: []dataplane.SessionEntryV4{
+			{Key: mirrorOnly, Value: live},
+			{Key: tableTruth, Value: live},
+		}}, nil
+	}
+
+	pumpBulk(t, senderSS, receiverSS)
+
+	if calls != 1 {
+		t.Fatalf("BulkSessionSource consulted %d times, want exactly 1 per window", calls)
+	}
+	if _, ok := receiverDP.v4sessions[tableTruth]; !ok {
+		t.Fatal("#6031: a LIVE peer-owned session absent from the primary's BPF display mirror " +
+			"but present in table-truth was reconciled away — the cold-prime window must be " +
+			"sourced from the authoritative export, not the mirror")
+	}
+	if _, ok := receiverDP.v4sessions[mirrorOnly]; !ok {
+		t.Fatal("a live peer-owned session present in the window must survive")
+	}
+	if _, ok := receiverDP.v4sessions[localC]; !ok {
+		t.Fatal("the standby's own session (our RG) must never be reconciled")
+	}
+}
+
+// TestBulkSyncSourceOverridesMirrorPhantom_6031 is the other drift direction: a
+// PHANTOM in the mirror (an entry the helper published but that is no longer in
+// the authoritative table). The window must not carry it, so the standby's copy
+// is reconciled away rather than being kept alive by a stale display record.
+func TestBulkSyncSourceOverridesMirrorPhantom_6031(t *testing.T) {
+	realSession := bulkSourceKey(1, 1, 1000)
+	phantom := bulkSourceKey(3, 3, 3000)
+	live := dataplane.SessionValue{State: dataplane.SessStateEstablished, IngressZone: 5}
+
+	senderSS, receiverSS, receiverDP := newBulkSourcePair(t,
+		map[dataplane.SessionKey]dataplane.SessionValue{realSession: live, phantom: live},
+		map[dataplane.SessionKey]dataplane.SessionValue{realSession: live, phantom: live})
+
+	senderSS.BulkSessionSource = func() (*BulkSessionSnapshot, error) {
+		return &BulkSessionSnapshot{V4: []dataplane.SessionEntryV4{{Key: realSession, Value: live}}}, nil
+	}
+
+	pumpBulk(t, senderSS, receiverSS)
+
+	if _, ok := receiverDP.v4sessions[phantom]; ok {
+		t.Fatal("#6031: a mirror PHANTOM the authoritative table no longer holds must not be " +
+			"framed into the window — the standby kept a session the primary has closed")
+	}
+	if _, ok := receiverDP.v4sessions[realSession]; !ok {
+		t.Fatal("the authoritative session must survive")
+	}
+}
+
+// TestBulkSyncEmptySnapshotIsAuthoritative_6031 pins the distinction the source
+// contract turns on: an EMPTY snapshot is an authoritative "I own nothing", not
+// an absent source. It must produce a real BulkStart/BulkEnd window that
+// reconciles — NOT a silent fall-back to the mirror, which here still holds
+// sessions and would keep the standby's stale copy alive.
+func TestBulkSyncEmptySnapshotIsAuthoritative_6031(t *testing.T) {
+	stale := bulkSourceKey(2, 2, 2000)
+	live := dataplane.SessionValue{State: dataplane.SessStateEstablished, IngressZone: 5}
+
+	senderSS, receiverSS, receiverDP := newBulkSourcePair(t,
+		// The mirror still lists it; table-truth says we own nothing.
+		map[dataplane.SessionKey]dataplane.SessionValue{stale: live},
+		map[dataplane.SessionKey]dataplane.SessionValue{stale: live})
+
+	senderSS.BulkSessionSource = func() (*BulkSessionSnapshot, error) {
+		return &BulkSessionSnapshot{}, nil
+	}
+
+	pumpBulk(t, senderSS, receiverSS)
+
+	if _, ok := receiverDP.v4sessions[stale]; ok {
+		t.Fatal("#6031: an EMPTY authoritative snapshot must reconcile the standby's stale " +
+			"peer-owned sessions away — it was treated as an absent source and the mirror " +
+			"walk kept the session alive")
+	}
+}
+
+// TestBulkSyncNilSnapshotFallsBackToStore_6031 pins the compatibility arm: a
+// source that reports "no authoritative source right now" (nil, nil) — no
+// userspace runtime, no committed config — must leave the pre-#6031 store walk
+// in place rather than sending an empty window that deletes live sessions.
+func TestBulkSyncNilSnapshotFallsBackToStore_6031(t *testing.T) {
+	fromStore := bulkSourceKey(1, 1, 1000)
+	live := dataplane.SessionValue{State: dataplane.SessStateEstablished, IngressZone: 5}
+
+	senderSS, receiverSS, receiverDP := newBulkSourcePair(t,
+		map[dataplane.SessionKey]dataplane.SessionValue{fromStore: live},
+		map[dataplane.SessionKey]dataplane.SessionValue{fromStore: live})
+
+	senderSS.BulkSessionSource = func() (*BulkSessionSnapshot, error) { return nil, nil }
+
+	pumpBulk(t, senderSS, receiverSS)
+
+	if _, ok := receiverDP.v4sessions[fromStore]; !ok {
+		t.Fatal("#6031: a (nil, nil) source means no authoritative snapshot is available and " +
+			"BulkSync must fall back to the session-store walk — instead an empty window " +
+			"reconciled a live session away")
+	}
+}
+
+// TestBulkSyncSourceErrorAbortsWithoutOpeningWindow_6031 pins the error
+// posture, which is the whole reason the contract has three cases rather than
+// two. When the authoritative export FAILS, falling back to the mirror would
+// reconcile the peer against exactly the source this change decided is not
+// authoritative — the unrecoverable direction. BulkSync must abort, and it must
+// abort BEFORE writing BulkStart: a window the receiver has opened but that is
+// never completed with a full session set is the same hazard.
+//
+// Every doBulkSync caller re-arms and retries on error (handleNewConnection's
+// needColdPrime latch, the survivor re-drive, the #82 sweep re-drive), so
+// aborting costs a round, not the reconcile.
+func TestBulkSyncSourceErrorAbortsWithoutOpeningWindow_6031(t *testing.T) {
+	live := dataplane.SessionValue{State: dataplane.SessStateEstablished, IngressZone: 5}
+	senderSS, _, _ := newBulkSourcePair(t,
+		map[dataplane.SessionKey]dataplane.SessionValue{bulkSourceKey(1, 1, 1000): live},
+		nil)
+
+	injected := errors.New("helper control socket refused export_owner_rg_sessions")
+	senderSS.BulkSessionSource = func() (*BulkSessionSnapshot, error) { return nil, injected }
+
+	local, peer := net.Pipe()
+	defer local.Close()
+	defer peer.Close()
+	senderSS.mu.Lock()
+	senderSS.conn0 = local
+	senderSS.mu.Unlock()
+
+	before := senderSS.stats.BulkSyncs.Load()
+	err := senderSS.BulkSync()
+	if err == nil {
+		t.Fatal("#6031: BulkSync succeeded although the authoritative session source FAILED — " +
+			"the window would have been reconciled against the mirror we just distrusted")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("BulkSync error = %v, want it to carry the source failure", err)
+	}
+	if got := senderSS.stats.BulkSyncs.Load(); got != before {
+		t.Fatalf("BulkSyncs counter moved (%d -> %d) on an aborted bulk", before, got)
+	}
+	// Nothing may have been written: a BulkStart the receiver acts on but that
+	// no BulkEnd completes is its own hazard.
+	if err := peer.SetReadDeadline(time.Now().Add(150 * time.Millisecond)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	buf := make([]byte, 1)
+	if n, rerr := peer.Read(buf); rerr == nil || !errors.Is(rerr, os.ErrDeadlineExceeded) {
+		t.Fatalf("#6031: sender wrote %d byte(s) (read err %v) before aborting — the source must "+
+			"be resolved BEFORE the BulkStart marker opens a window", n, rerr)
+	}
+}
+
+// countBulkSessionFrames drives senderSS.BulkSync() over a pipe and returns how
+// many syncMsgSessionV4/V6 frames the window carried. Asserting on the WIRE is
+// the honest question for a filtering rule: it does not depend on what the
+// receiver's fake store chooses to install.
+func countBulkSessionFrames(t *testing.T, senderSS *SessionSync) int {
+	t.Helper()
+	local, peer := net.Pipe()
+	defer local.Close()
+	defer peer.Close()
+	senderSS.mu.Lock()
+	senderSS.conn0 = local
+	senderSS.mu.Unlock()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- senderSS.BulkSync() }()
+
+	sessions := 0
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if err := peer.SetReadDeadline(deadline); err != nil {
+			t.Fatalf("set read deadline: %v", err)
+		}
+		mt, _, err := readSyncFrame(peer)
+		if err != nil {
+			t.Fatalf("reading bulk frame: %v", err)
+		}
+		if mt == syncMsgSessionV4 || mt == syncMsgSessionV6 {
+			sessions++
+		}
+		if mt == syncMsgBulkEnd {
+			break
+		}
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("BulkSync returned error: %v", err)
+	}
+	return sessions
+}
+
+// TestBulkSyncSnapshotSkipsReverseEntries_6031 pins that the shared per-session
+// send path still applies the reverse-entry rule to a SUPPLIED snapshot: only
+// forward sessions belong on the wire. The receiver's reconcile candidate set
+// skips reverse entries too, so a framed reverse entry is an unmatchable key.
+//
+// RED on revert: drop the `val.IsReverse != 0` guard from the snapshot path and
+// the frame count is 2.
+func TestBulkSyncSnapshotSkipsReverseEntries_6031(t *testing.T) {
+	fwd := bulkSourceKey(1, 1, 1000)
+	rev := bulkSourceKey(9, 9, 9000)
+	live := dataplane.SessionValue{State: dataplane.SessStateEstablished, IngressZone: 5}
+
+	senderSS, _, _ := newBulkSourcePair(t, map[dataplane.SessionKey]dataplane.SessionValue{}, nil)
+	senderSS.BulkSessionSource = func() (*BulkSessionSnapshot, error) {
+		return &BulkSessionSnapshot{V4: []dataplane.SessionEntryV4{
+			{Key: fwd, Value: live},
+			{Key: rev, Value: dataplane.SessionValue{State: dataplane.SessStateEstablished, IngressZone: 5, IsReverse: 1}},
+		}}, nil
+	}
+
+	if got := countBulkSessionFrames(t, senderSS); got != 1 {
+		t.Fatalf("bulk window carried %d session frames, want 1 — a REVERSE entry must not be "+
+			"framed from a supplied snapshot", got)
+	}
+}
+
+// TestBulkSyncSnapshotBypassesZoneFilter_6031 pins the deliberate filtering
+// change. The store walk can only approximate ownership with ShouldSyncZone (a
+// zone->RG config map); the source has already applied the per-session OWNER-RG
+// and origin filter the helper's export performs. Re-applying the zone
+// approximation on top would silently drop sessions the authoritative export
+// says we own — a session whose zone is not in this node's zone->RG map (a
+// day-2 zone, a fabric-redirect wire alias) would vanish from the window and be
+// reconciled away on the standby.
+//
+// RED on revert: apply ShouldSyncZone to the snapshot path too and the frame
+// count drops to 0.
+func TestBulkSyncSnapshotBypassesZoneFilter_6031(t *testing.T) {
+	// Zone 77 is NOT in the sender's zone->RG map, so ShouldSyncZone is false
+	// for it: IsPrimaryForRGFn is set, the lookup misses, and the IsPrimaryFn
+	// fallback is only reached when the map has no entry — which is exactly the
+	// shape a day-2 zone has before the map is refreshed.
+	unmapped := bulkSourceKey(4, 4, 4000)
+	senderSS, _, _ := newBulkSourcePair(t, map[dataplane.SessionKey]dataplane.SessionValue{}, nil)
+	senderSS.IsPrimaryFn = func() bool { return false }
+	senderSS.BulkSessionSource = func() (*BulkSessionSnapshot, error) {
+		return &BulkSessionSnapshot{V4: []dataplane.SessionEntryV4{
+			{Key: unmapped, Value: dataplane.SessionValue{State: dataplane.SessStateEstablished, IngressZone: 77}},
+		}}, nil
+	}
+	if !senderSS.ShouldSyncZone(77) == false {
+		t.Fatal("precondition: zone 77 must NOT pass ShouldSyncZone for this test to mean anything")
+	}
+
+	if got := countBulkSessionFrames(t, senderSS); got != 1 {
+		t.Fatalf("bulk window carried %d session frames, want 1 — a supplied snapshot is already "+
+			"owner-RG filtered and must not be re-filtered by the zone approximation", got)
+	}
+}

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -1035,12 +1035,24 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			// sendCh) and then sent an EMPTY BulkStart/BulkEnd, so the receiver
 			// recorded zero session keys and skipped authoritative stale
 			// reconciliation — a stale peer-owned session the standby held
-			// survived cold-prime. Cold-prime now uses the lossless BulkSync
+			// survived cold-prime. Cold-prime uses the lossless BulkSync
 			// direct-write window (doBulkSync), which delimits a COMPLETE
-			// authoritative snapshot the receiver reconciles against. A
-			// table-truth, owner-RG-filtered snapshot via ExportOwnerRGSessions
-			// (eliminating the BulkSync mirror-map drift residual) is tracked as
-			// a follow-up.
+			// authoritative snapshot the receiver reconciles against.
+			//
+			// #6031: and that window is now SOURCED from table-truth. BulkSync
+			// otherwise walks the local session store, which on the userspace
+			// dataplane is the helper's best-effort BPF display MIRROR — it can
+			// drift from the authoritative SessionTable and carries no
+			// per-session origin. Installing the source makes the window come
+			// from ExportOwnerRGSessions (owner-RG filtered, demoted entries
+			// skipped) instead, with a documented fall-back-to-store /
+			// abort-on-error contract. This is a SOURCE, not an override: the
+			// single BulkStart -> sessions -> BulkEnd window, its epoch, the
+			// #3912 record-then-send discipline and the #5272 bulk-completion
+			// gate are all unchanged, which is why it is not wired through
+			// BulkSyncOverride (that runs BEFORE BulkSync, so the mirror-sourced
+			// window would still be the one the receiver reconciled against).
+			ss.BulkSessionSource = d.userspaceBulkSessionSnapshot
 
 			ss.OnPeerDisconnected = func() {
 				d.cluster.RecordEvent(cluster.EventFabric, -1, "Peer disconnected (all fabrics)")

--- a/pkg/daemon/daemon_ha_userspace_stream.go
+++ b/pkg/daemon/daemon_ha_userspace_stream.go
@@ -415,42 +415,18 @@ func (d *Daemon) queueUserspaceSessionDeltas(
 		return 0
 	}
 	queued := 0
+	emitV4 := func(key dataplane.SessionKey, val dataplane.SessionValue) {
+		ss.QueueSessionV4(key, val)
+		queued++
+	}
+	emitV6 := func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) {
+		ss.QueueSessionV6(key, val)
+		queued++
+	}
 	for _, delta := range deltas {
 		switch strings.ToLower(delta.Event) {
 		case "open":
-			switch delta.AddrFamily {
-			case dataplane.AFInet:
-				key, val, ok := userspaceSessionFromDeltaV4(delta, zoneIDs)
-				if !ok {
-					slog.Debug("userspace delta: V4 conversion failed", "src", delta.SrcIP, "dst", delta.DstIP, "disposition", delta.Disposition)
-					continue
-				}
-				if !d.shouldSyncUserspaceDelta(ss, delta, val.IngressZone) {
-					continue
-				}
-				ss.QueueSessionV4(key, val)
-				slog.Debug("userspace delta: queued V4", "src", delta.SrcIP, "dst", delta.DstIP, "ownerRG", delta.OwnerRGID)
-				queued++
-				if delta.FabricRedirect && !delta.FabricIngress {
-					if wireKey, wireVal, ok := userspaceForwardWireAliasV4(key, val, delta); ok {
-						ss.QueueSessionV4(wireKey, wireVal)
-						queued++
-					}
-				}
-			case dataplane.AFInet6:
-				key, val, ok := userspaceSessionFromDeltaV6(delta, zoneIDs)
-				if !ok || !d.shouldSyncUserspaceDelta(ss, delta, val.IngressZone) {
-					continue
-				}
-				ss.QueueSessionV6(key, val)
-				queued++
-				if delta.FabricRedirect && !delta.FabricIngress {
-					if wireKey, wireVal, ok := userspaceForwardWireAliasV6(key, val, delta); ok {
-						ss.QueueSessionV6(wireKey, wireVal)
-						queued++
-					}
-				}
-			}
+			d.forEachUserspaceOpenWireSession(ss, zoneIDs, delta, emitV4, emitV6)
 		case "close":
 			switch delta.AddrFamily {
 			case dataplane.AFInet:
@@ -509,4 +485,161 @@ func (d *Daemon) drainUserspaceSessionDeltasWithConfig(
 		}
 	}
 	return total, nil
+}
+
+// forEachUserspaceOpenWireSession expands ONE "open" session delta into the
+// (key, value) pairs that represent it on the cluster session-sync wire, after
+// applying the sync filter, and hands each to the family-appropriate callback.
+//
+// It is the SINGLE definition of "what does this delta look like on the wire" —
+// the conversion, the owner-RG/zone filter, and the #4090 fabric forward wire
+// alias. Both producers use it: the incremental event-stream path
+// (queueUserspaceSessionDeltas, which queues each pair onto sendCh) and the
+// #6031 authoritative bulk snapshot (userspaceBulkSessionSnapshot, which
+// collects them into the window). A divergence between those two is always a
+// bug — the bulk window is meant to be exactly the set the incremental stream
+// would have delivered — so they share one walk instead of two copies that can
+// drift.
+//
+// Callback-shaped rather than slice-returning so the incremental path, which
+// runs once per session event, allocates nothing per delta: each caller builds
+// its closures once per batch.
+func (d *Daemon) forEachUserspaceOpenWireSession(
+	ss *cluster.SessionSync,
+	zoneIDs map[string]uint16,
+	delta dpuserspace.SessionDeltaInfo,
+	v4 func(dataplane.SessionKey, dataplane.SessionValue),
+	v6 func(dataplane.SessionKeyV6, dataplane.SessionValueV6),
+) {
+	switch delta.AddrFamily {
+	case dataplane.AFInet:
+		key, val, ok := userspaceSessionFromDeltaV4(delta, zoneIDs)
+		if !ok {
+			slog.Debug("userspace delta: V4 conversion failed", "src", delta.SrcIP, "dst", delta.DstIP, "disposition", delta.Disposition)
+			return
+		}
+		if !d.shouldSyncUserspaceDelta(ss, delta, val.IngressZone) {
+			return
+		}
+		v4(key, val)
+		slog.Debug("userspace delta: queued V4", "src", delta.SrcIP, "dst", delta.DstIP, "ownerRG", delta.OwnerRGID)
+		if delta.FabricRedirect && !delta.FabricIngress {
+			if wireKey, wireVal, ok := userspaceForwardWireAliasV4(key, val, delta); ok {
+				v4(wireKey, wireVal)
+			}
+		}
+	case dataplane.AFInet6:
+		key, val, ok := userspaceSessionFromDeltaV6(delta, zoneIDs)
+		if !ok || !d.shouldSyncUserspaceDelta(ss, delta, val.IngressZone) {
+			return
+		}
+		v6(key, val)
+		if delta.FabricRedirect && !delta.FabricIngress {
+			if wireKey, wireVal, ok := userspaceForwardWireAliasV6(key, val, delta); ok {
+				v6(wireKey, wireVal)
+			}
+		}
+	}
+}
+
+// userspaceBulkSessionSnapshot builds the AUTHORITATIVE session set for one
+// cluster bulk window from the userspace dataplane's TABLE-TRUTH export
+// (#6031), and is installed as SessionSync.BulkSessionSource.
+//
+// Before this, BulkSync sourced the window from s.sessions.ForEachV4/V6 — which
+// on the userspace dataplane walks the BPF conntrack maps the Rust helper
+// publishes as a best-effort DISPLAY MIRROR (publish_bpf_conntrack_entry, so
+// `show security flow session` can render zone/interface info), not the helper's
+// authoritative in-process SessionTable. The mirror can drift: publication is
+// gated at table cap and on install_failed, the periodic refresh lags, and the
+// mirror carries no per-session ORIGIN, so it also echoes peer-owned imports
+// back at their owner. Since #5085 removed the empty-bulk reconcile skip, a
+// transiently under-populated mirror at cold-prime reconciles away LIVE
+// peer-owned sessions on the standby.
+//
+// ExportOwnerRGSessions is the table-truth walk (control verb
+// `export_owner_rg_sessions`), filtered to the redundancy groups this node is
+// primary for and skipping locally-demoted entries — so the window is both
+// complete and owner-RG accurate, which the zone-level ShouldSyncZone
+// approximation could not be.
+//
+// Return contract (SessionSync.BulkSessionSource):
+//
+//   - (nil, nil) when there is no authoritative source to consult — no
+//     published runtime, a runtime that is not the userspace exporter, or no
+//     committed config. BulkSync then falls back to the store walk, exactly as
+//     before, so nothing regresses where no table-truth exists.
+//   - (empty, nil) when this node is primary for NO redundancy group. That is
+//     an authoritative "I own nothing to sync", NOT an absent source: the peer
+//     must reconcile away sessions it still holds on our behalf. Returning
+//     (nil, nil) here would silently fall back to the mirror and re-push the
+//     peer's own imports back at it.
+//   - (nil, err) when the export itself failed. BulkSync ABORTS rather than
+//     falling back — see the field doc for why an incomplete window is the
+//     unrecoverable direction.
+func (d *Daemon) userspaceBulkSessionSnapshot() (*cluster.BulkSessionSnapshot, error) {
+	if d.getSessionSync() == nil {
+		return nil, nil
+	}
+	rt := d.dataplane()
+	if rt == nil {
+		return nil, nil
+	}
+	exporter, ok := rt.(userspaceSessionExporter)
+	if !ok {
+		return nil, nil
+	}
+	if d.store == nil {
+		return nil, nil
+	}
+	cfg := d.store.ActiveConfig()
+	if cfg == nil {
+		return nil, nil
+	}
+	// Read the CURRENT active config's RG set on every call, never a startup
+	// snapshot: a day-2 commit can add a redundancy group (#3917) and its
+	// sessions must ride the very next bulk window.
+	return d.buildUserspaceBulkSnapshotWithConfig(exporter, cfg, d.primaryOwnerRGIDs(cfg))
+}
+
+// buildUserspaceBulkSnapshotWithConfig is the config-taking half of
+// userspaceBulkSessionSnapshot, split out so the export -> convert -> filter
+// pipeline is drivable in a unit test without a published runtime. It mirrors
+// exportUserspaceOwnerRGSessionsWithConfig, which does the same walk for the
+// full-resync path but QUEUES onto the lossy sendCh instead of collecting.
+//
+// An empty rgIDs set returns an EMPTY, non-nil snapshot: this node owns no
+// syncable sessions, which is an authoritative statement the peer must
+// reconcile against, not an absent source.
+func (d *Daemon) buildUserspaceBulkSnapshotWithConfig(
+	exporter userspaceSessionExporter,
+	cfg *config.Config,
+	rgIDs []int,
+) (*cluster.BulkSessionSnapshot, error) {
+	snapshot := &cluster.BulkSessionSnapshot{}
+	if exporter == nil || cfg == nil || len(rgIDs) == 0 {
+		return snapshot, nil
+	}
+	deltas, _, err := exporter.ExportOwnerRGSessions(rgIDs, 0)
+	if err != nil {
+		return nil, err
+	}
+	ss := d.getSessionSync()
+	zoneIDs := buildZoneIDs(cfg)
+	appendV4 := func(key dataplane.SessionKey, val dataplane.SessionValue) {
+		snapshot.V4 = append(snapshot.V4, dataplane.SessionEntryV4{Key: key, Value: val})
+	}
+	appendV6 := func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) {
+		snapshot.V6 = append(snapshot.V6, dataplane.SessionEntryV6{Key: key, Value: val})
+	}
+	for _, delta := range deltas {
+		// The export yields the live table, so every record is an "open".
+		// Anything else would be a helper bug; skipping it keeps a stray
+		// close-shaped record from being framed as a live session.
+		if delta.Event != "" && !strings.EqualFold(delta.Event, "open") {
+			continue
+		}
+		d.forEachUserspaceOpenWireSession(ss, zoneIDs, delta, appendV4, appendV6)
+	}
+	return snapshot, nil
 }

--- a/pkg/daemon/userspace_bulk_snapshot_6031_test.go
+++ b/pkg/daemon/userspace_bulk_snapshot_6031_test.go
@@ -1,0 +1,327 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// #6031 — the cold-prime bulk window is sourced from the userspace helper's
+// TABLE-TRUTH export (export_owner_rg_sessions), not from the best-effort BPF
+// display mirror pkg/cluster's BulkSync used to walk.
+
+// errExportRefused models the helper refusing the export — control socket down,
+// unsupported verb, protocol mismatch.
+var errExportRefused = errors.New("helper refused export_owner_rg_sessions")
+
+type failingUserspaceSessionExporter struct{ err error }
+
+func (f *failingUserspaceSessionExporter) ExportOwnerRGSessions(_ []int, _ uint32) ([]dpuserspace.SessionDeltaInfo, dpuserspace.ProcessStatus, error) {
+	return nil, dpuserspace.ProcessStatus{}, f.err
+}
+
+func bulkSnapshotConfig() *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"lan": {Name: "lan"},
+		"wan": {Name: "wan"},
+	}
+	return cfg
+}
+
+func bulkSnapshotDaemon() *Daemon {
+	return &Daemon{
+		sessionSync: &cluster.SessionSync{
+			IsPrimaryFn:      func() bool { return true },
+			IsPrimaryForRGFn: func(rgID int) bool { return rgID == 1 },
+		},
+	}
+}
+
+// TestBuildUserspaceBulkSnapshotCollectsTableTruth_6031 pins the core of the
+// snapshot builder: the export's records become window entries, and a record
+// for a redundancy group this node is NOT primary for is filtered out by the
+// same per-session owner-RG rule the incremental stream applies — the accuracy
+// the zone-level ShouldSyncZone approximation could not deliver.
+func TestBuildUserspaceBulkSnapshotCollectsTableTruth_6031(t *testing.T) {
+	mine := dpuserspace.SessionDeltaInfo{
+		Event: "open", AddrFamily: dataplane.AFInet, Protocol: 6,
+		SrcIP: "10.0.61.102", DstIP: "172.16.80.200", SrcPort: 39906, DstPort: 5201,
+		IngressZone: "lan", EgressZone: "wan", OwnerRGID: 1,
+		EgressIfindex: 12, TXIfindex: 11, NeighborMAC: "aa:bb:cc:dd:ee:ff",
+	}
+	peers := mine
+	peers.SrcPort = 39907
+	peers.OwnerRGID = 2 // this node is primary for RG1 only
+	v6 := dpuserspace.SessionDeltaInfo{
+		Event: "open", AddrFamily: dataplane.AFInet6, Protocol: 6,
+		SrcIP: "2001:559:8585:bf01::102", DstIP: "2001:559:8585:80::200",
+		SrcPort: 40000, DstPort: 5201,
+		IngressZone: "lan", EgressZone: "wan", OwnerRGID: 1,
+		EgressIfindex: 12, TXIfindex: 11, NeighborMAC: "aa:bb:cc:dd:ee:ff",
+	}
+
+	exporter := &fakeUserspaceSessionExporter{deltas: []dpuserspace.SessionDeltaInfo{mine, peers, v6}}
+	d := bulkSnapshotDaemon()
+
+	snap, err := d.buildUserspaceBulkSnapshotWithConfig(exporter, bulkSnapshotConfig(), []int{1})
+	if err != nil {
+		t.Fatalf("buildUserspaceBulkSnapshotWithConfig() error = %v", err)
+	}
+	if exporter.calls != 1 {
+		t.Fatalf("export calls = %d, want exactly 1 per window", exporter.calls)
+	}
+	if got := len(snap.V4); got != 1 {
+		t.Fatalf("snapshot V4 = %d entries, want 1 — a session owned by a redundancy group "+
+			"this node is not primary for must not ride our authoritative window", got)
+	}
+	if got := len(snap.V6); got != 1 {
+		t.Fatalf("snapshot V6 = %d entries, want 1", got)
+	}
+	if got := snap.Len(); got != 2 {
+		t.Fatalf("snapshot Len() = %d, want 2", got)
+	}
+	if snap.V4[0].Value.IngressZone == 0 {
+		t.Fatal("snapshot entry lost its ingress zone — the receiver's reconcile keys on it")
+	}
+}
+
+// TestBuildUserspaceBulkSnapshotCarriesFabricWireAlias_6031 pins that the
+// snapshot expands a fabric-redirected session into BOTH wire keys, exactly as
+// the incremental path does. Dropping the alias would leave the peer's copy
+// absent from the authoritative window on the very next bulk, so the peer would
+// reconcile away a session it is actively forwarding for.
+func TestBuildUserspaceBulkSnapshotCarriesFabricWireAlias_6031(t *testing.T) {
+	exporter := &fakeUserspaceSessionExporter{deltas: []dpuserspace.SessionDeltaInfo{{
+		Event: "open", AddrFamily: dataplane.AFInet, Protocol: 6,
+		SrcIP: "10.0.61.102", DstIP: "172.16.80.200", SrcPort: 39906, DstPort: 5201,
+		IngressZone: "lan", EgressZone: "wan", OwnerRGID: 1,
+		EgressIfindex: 12, TXIfindex: 11, TXVLANID: 80,
+		NeighborMAC: "aa:bb:cc:dd:ee:ff", SrcMAC: "02:bf:72:00:50:08",
+		NATSrcIP: "172.16.80.8", NATSrcPort: 39906,
+		FabricRedirect: true,
+	}}}
+	d := bulkSnapshotDaemon()
+
+	snap, err := d.buildUserspaceBulkSnapshotWithConfig(exporter, bulkSnapshotConfig(), []int{1})
+	if err != nil {
+		t.Fatalf("buildUserspaceBulkSnapshotWithConfig() error = %v", err)
+	}
+	if got := len(snap.V4); got != 2 {
+		t.Fatalf("snapshot V4 = %d entries, want 2 (session + #4090 forward wire alias)", got)
+	}
+	if snap.V4[0].Key == snap.V4[1].Key {
+		t.Fatal("the forward wire alias must be a DISTINCT key from the session it aliases")
+	}
+}
+
+// TestBuildUserspaceBulkSnapshotPropagatesExportError_6031 pins the error
+// posture at the source: a failed export must surface as an error, never as an
+// empty-but-successful snapshot. An empty snapshot is authoritative — it would
+// tell the peer to reconcile away every session we own.
+func TestBuildUserspaceBulkSnapshotPropagatesExportError_6031(t *testing.T) {
+	d := bulkSnapshotDaemon()
+	snap, err := d.buildUserspaceBulkSnapshotWithConfig(
+		&failingUserspaceSessionExporter{err: errExportRefused}, bulkSnapshotConfig(), []int{1})
+	if err == nil {
+		t.Fatal("#6031: a FAILED table-truth export returned no error — an empty snapshot is " +
+			"authoritative and would reconcile away every session this node owns")
+	}
+	if !errors.Is(err, errExportRefused) {
+		t.Fatalf("error = %v, want it to carry the export failure", err)
+	}
+	if snap != nil {
+		t.Fatalf("snapshot = %+v, want nil alongside the error", snap)
+	}
+}
+
+// TestBuildUserspaceBulkSnapshotNoOwnedRGsIsEmptyNotNil_6031 pins the
+// distinction the whole three-case source contract turns on. A node that is
+// primary for NO redundancy group owns nothing to sync — that is an
+// authoritative statement, and returning nil would instead be read as "no
+// source available" and silently fall back to the mirror, re-pushing the peer's
+// own imports back at it.
+func TestBuildUserspaceBulkSnapshotNoOwnedRGsIsEmptyNotNil_6031(t *testing.T) {
+	exporter := &fakeUserspaceSessionExporter{deltas: []dpuserspace.SessionDeltaInfo{{
+		Event: "open", AddrFamily: dataplane.AFInet, Protocol: 6,
+		SrcIP: "10.0.61.102", DstIP: "172.16.80.200", SrcPort: 39906, DstPort: 5201,
+		IngressZone: "lan", EgressZone: "wan", OwnerRGID: 1,
+	}}}
+	d := bulkSnapshotDaemon()
+
+	snap, err := d.buildUserspaceBulkSnapshotWithConfig(exporter, bulkSnapshotConfig(), nil)
+	if err != nil {
+		t.Fatalf("buildUserspaceBulkSnapshotWithConfig() error = %v", err)
+	}
+	if snap == nil {
+		t.Fatal("#6031: a node primary for no redundancy group must return an EMPTY " +
+			"authoritative snapshot, not nil — nil falls back to the display mirror")
+	}
+	if snap.Len() != 0 {
+		t.Fatalf("snapshot Len() = %d, want 0", snap.Len())
+	}
+	if exporter.calls != 0 {
+		t.Fatalf("export calls = %d, want 0 — there is nothing to export", exporter.calls)
+	}
+}
+
+// TestUserspaceBulkSessionSnapshotFallsBackWhenNoRuntime_6031 pins the
+// compatibility arm of the resolver: with no published runtime (or a runtime
+// that is not the userspace exporter) there is no table-truth to consult, so it
+// must report "no source" and leave the pre-#6031 store walk in place rather
+// than sending an empty window that deletes live sessions.
+func TestUserspaceBulkSessionSnapshotFallsBackWhenNoRuntime_6031(t *testing.T) {
+	d := bulkSnapshotDaemon()
+	snap, err := d.userspaceBulkSessionSnapshot()
+	if err != nil {
+		t.Fatalf("userspaceBulkSessionSnapshot() error = %v", err)
+	}
+	if snap != nil {
+		t.Fatalf("snapshot = %+v, want nil (fall back to the session-store walk) with no runtime", snap)
+	}
+}
+
+// TestBuildUserspaceBulkSnapshotSkipsNonOpenRecords_6031 pins that a
+// close-shaped record in a live-table export is not framed as a live session.
+func TestBuildUserspaceBulkSnapshotSkipsNonOpenRecords_6031(t *testing.T) {
+	exporter := &fakeUserspaceSessionExporter{deltas: []dpuserspace.SessionDeltaInfo{{
+		Event: "close", AddrFamily: dataplane.AFInet, Protocol: 6,
+		SrcIP: "10.0.61.102", DstIP: "172.16.80.200", SrcPort: 39906, DstPort: 5201,
+		IngressZone: "lan", EgressZone: "wan", OwnerRGID: 1,
+	}}}
+	d := bulkSnapshotDaemon()
+
+	snap, err := d.buildUserspaceBulkSnapshotWithConfig(exporter, bulkSnapshotConfig(), []int{1})
+	if err != nil {
+		t.Fatalf("buildUserspaceBulkSnapshotWithConfig() error = %v", err)
+	}
+	if snap.Len() != 0 {
+		t.Fatalf("snapshot Len() = %d, want 0 — a close record is not a live session", snap.Len())
+	}
+}
+
+// bulkSourceWiringDP is a RuntimeDataPlane whose only live surface is the
+// table-truth export, so the production-wired source can be invoked for real.
+type bulkSourceWiringDP struct {
+	dataplane.RuntimeDataPlane
+	exporter *fakeUserspaceSessionExporter
+}
+
+func (d *bulkSourceWiringDP) ExportOwnerRGSessions(rgIDs []int, max uint32) ([]dpuserspace.SessionDeltaInfo, dpuserspace.ProcessStatus, error) {
+	return d.exporter.ExportOwnerRGSessions(rgIDs, max)
+}
+
+func (d *bulkSourceWiringDP) Mode() dpuserspace.DataplaneMode { return dpuserspace.ModeUserspaceStrict }
+
+// Sessions/Telemetry are reached by SessionSync.SetRuntime. Nil is the
+// "no store wired" case the sync layer already guards for, which is what this
+// test wants: the assertion is about the SOURCE, not the store walk.
+func (d *bulkSourceWiringDP) Sessions() dataplane.SessionStore { return nil }
+
+func (d *bulkSourceWiringDP) Telemetry() dataplane.Telemetry { return nil }
+
+// TestStartClusterCommsWiresTableTruthBulkSource_6031 is the WIRING guard. The
+// two halves of this change are independently useless: pkg/cluster consults
+// SessionSync.BulkSessionSource, and pkg/daemon can build a table-truth
+// snapshot — but the residual only closes if the production startup actually
+// installs the one into the other. So this drives the real
+// startClusterComms and then INVOKES the source it published, asserting the
+// entry that comes back is the exported one. Asserting merely that the field is
+// non-nil would pass with any function wired there.
+//
+// RED on revert: delete the `ss.BulkSessionSource = d.userspaceBulkSessionSnapshot`
+// line from startClusterComms and the nil-source assertion fires; wire some
+// other producer and the round-trip assertion fires.
+func TestStartClusterCommsWiresTableTruthBulkSource_6031(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "config.db"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	// A clustered active whose sync endpoint RESOLVES: lo carries 127.0.0.1/8,
+	// which selectClusterBindAddr matches against the 127.0.0.2 peer, so the
+	// sync constructor goroutine gets past its address retry loop and reaches
+	// the callback wiring.
+	for _, line := range []string{
+		"chassis cluster cluster-id 1",
+		"chassis cluster node 0",
+		"chassis cluster control-interface lo",
+		"chassis cluster peer-address 127.0.0.2",
+		"chassis cluster redundancy-group 0 node 0 priority 200",
+		"chassis cluster redundancy-group 0 node 1 priority 100",
+		"chassis cluster authentication-key test-cluster-psk-6031",
+		"security zones security-zone lan",
+		"security zones security-zone wan",
+	} {
+		if err := store.SetFromInput(line); err != nil {
+			t.Fatalf("set %q: %v", line, err)
+		}
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	exported := dpuserspace.SessionDeltaInfo{
+		Event: "open", AddrFamily: dataplane.AFInet, Protocol: 6,
+		SrcIP: "10.0.61.102", DstIP: "172.16.80.200", SrcPort: 39906, DstPort: 5201,
+		IngressZone: "lan", EgressZone: "wan", OwnerRGID: 0,
+		EgressIfindex: 12, TXIfindex: 11, NeighborMAC: "aa:bb:cc:dd:ee:ff",
+	}
+	exporter := &fakeUserspaceSessionExporter{deltas: []dpuserspace.SessionDeltaInfo{exported}}
+
+	d := &Daemon{
+		store:    store,
+		opts:     Options{NoDataplane: true},
+		cluster:  newClusterManager(true),
+		rgStates: make(map[int]*rgStateMachine),
+	}
+	// Publish the export-capable runtime BEFORE comms start: startClusterComms
+	// only wires the ownership predicates (IsPrimaryFn / IsPrimaryForRGFn) when
+	// a runtime is published, and the sync filter the snapshot builder applies
+	// consults them.
+	d.setDataplane(&bulkSourceWiringDP{exporter: exporter})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.startClusterComms(ctx)
+	t.Cleanup(d.stopClusterComms)
+
+	var ss *cluster.SessionSync
+	for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); {
+		if ss = d.getSessionSync(); ss != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if ss == nil {
+		t.Fatal("setup: startClusterComms never published a SessionSync")
+	}
+	if ss.BulkSessionSource == nil {
+		t.Fatal("#6031: startClusterComms published a SessionSync with NO BulkSessionSource — " +
+			"the bulk window still comes from the best-effort BPF display mirror")
+	}
+
+	// Invoke the wired source: the snapshot must carry the EXPORTED session,
+	// which identifies the wired function as the table-truth resolver rather
+	// than any other producer that could have been assigned to the field.
+	snap, err := ss.BulkSessionSource()
+	if err != nil {
+		t.Fatalf("wired BulkSessionSource() error = %v", err)
+	}
+	if snap == nil {
+		t.Fatal("#6031: the wired source reported NO authoritative snapshot with an " +
+			"export-capable runtime published — BulkSync would fall back to the mirror")
+	}
+	if exporter.calls != 1 {
+		t.Fatalf("export_owner_rg_sessions calls = %d, want 1 — the wired source is not the "+
+			"table-truth resolver", exporter.calls)
+	}
+	if got := snap.Len(); got != 1 {
+		t.Fatalf("wired source snapshot Len() = %d, want 1 (the exported session)", got)
+	}
+}

--- a/pkg/daemon/userspace_bulk_snapshot_6031_test.go
+++ b/pkg/daemon/userspace_bulk_snapshot_6031_test.go
@@ -248,11 +248,20 @@ func TestStartClusterCommsWiresTableTruthBulkSource_6031(t *testing.T) {
 	// which selectClusterBindAddr matches against the 127.0.0.2 peer, so the
 	// sync constructor goroutine gets past its address retry loop and reaches
 	// the callback wiring.
+	//
+	// The endpoint is the FABRIC transport, not control-link, deliberately:
+	// startClusterComms only starts the heartbeat when control-interface AND
+	// peer-address are both set, and cluster.Manager.StartHeartbeat /
+	// StopHeartbeat race on the manager's heartbeat fields (heartbeat_manager.go
+	// :116 vs :163) — a PRE-EXISTING race this test has no business exposing.
+	// The sync constructor takes the fabric fall-back and reaches the same
+	// wiring block. TestActiveClusterTransportIsMutexGuarded_6290 avoids the
+	// same hazard the same way (it configures no sync endpoint at all).
 	for _, line := range []string{
 		"chassis cluster cluster-id 1",
 		"chassis cluster node 0",
-		"chassis cluster control-interface lo",
-		"chassis cluster peer-address 127.0.0.2",
+		"chassis cluster fabric-interface lo",
+		"chassis cluster fabric-peer-address 127.0.0.2",
 		"chassis cluster redundancy-group 0 node 0 priority 200",
 		"chassis cluster redundancy-group 0 node 1 priority 100",
 		"chassis cluster authentication-key test-cluster-psk-6031",


### PR DESCRIPTION
Closes #6031

## The residual, at HEAD

`BulkSync` delimits the authoritative cold-prime snapshot the peer's
`reconcileStaleSessions` runs against. Since #5085 removed the empty-bulk
reconcile skip, a session merely **absent** from that window is treated as
stale and **deleted**.

But the window was sourced from `s.sessions.ForEachV4/V6` — which on the
userspace dataplane walks the shim `sessions`/`sessions_v6` BPF maps. Those are
a best-effort **display mirror** the Rust helper publishes via
`publish_bpf_conntrack_entry` so `show security flow session` can render
zone/interface info — not the helper's authoritative in-process `SessionTable`.
The mirror can drift:

- publication is gated at table cap and on `install_failed` (`session_glue/mod.rs`),
- the periodic refresh lags,
- and it carries no per-session **origin**, so it also echoes peer-owned imports
  back at their owner (`ShouldSyncZone` is only a zone-level approximation).

A transiently under-populated mirror at cold-prime therefore reconciles **live
peer-owned sessions** away on the standby.

## The fix

`SessionSync.BulkSessionSource`, resolved **before** the epoch is taken so a
failure aborts without opening a window. Three cases — the middle one is why
this is not a plain getter:

| returns | BulkSync does |
|---|---|
| snapshot (possibly **empty**) | frames exactly that set. Empty is an authoritative "I own nothing", which the peer must reconcile against |
| `(nil, nil)` | falls back to the store walk — no authoritative source exists (no userspace runtime, no committed config), so nothing regresses |
| `(nil, err)` | **aborts** |

The abort is the load-bearing choice. Falling back on an export failure would
reconcile the peer against exactly the mirror this change decided is not
authoritative, and an under-populated window deletes live sessions. A skipped
bulk is recoverable: every `doBulkSync` caller re-arms and retries
(`handleNewConnection`'s `needColdPrime` latch, the #4090 survivor re-drive, the
#82 sweep re-drive).

**A source, not an override.** `BulkSyncOverride` runs *before* `BulkSync`, so a
window framed there would still be followed by the mirror-sourced one the
receiver actually reconciles against — which is why the issue's "rewire the
override" sketch would not have closed the residual. Exactly one
`BulkStart → sessions → BulkEnd` window is written, same epoch, same #3912
record-then-send discipline, same #5272 completion gate. **No wire change.**

`startClusterComms` wires it to `userspaceBulkSessionSnapshot`, which reads the
**current** active config's RG set on every call (never a startup snapshot,
#3917) and drives `ExportOwnerRGSessions` — owner-RG filtered, locally-demoted
entries skipped.

A supplied snapshot is deliberately **not** re-filtered by `ShouldSyncZone`: the
source already applied the per-session owner-RG and origin filter, and
re-applying the zone approximation would drop sessions the export says we own (a
zone missing from `zoneRGMap`, a fabric wire alias) and let the peer reconcile
them away.

## One walk, two producers

The delta → wire expansion (convert, filter, #4090 forward wire alias) is now
one shared `forEachUserspaceOpenWireSession`, used by both the incremental
event-stream path and the bulk snapshot. A divergence between those two is
always a bug — the window is meant to be exactly what the incremental stream
would have delivered — so they share one definition rather than two copies.
Callback-shaped so the per-session incremental path still allocates nothing per
delta.

The new code lives in `daemon_ha_userspace_stream.go` (already on the
`pkg/dataplane` legacy-import allowlist) rather than `_export.go`, so the #1451
retirement-boundary canary's allowlist is unchanged.

## Tests — 14 new

**pkg/cluster (7)** drive the real `doBulkSync → handleMessage` seam over
`net.Pipe` (the #5085 harness): a table-truth session missing from the mirror
survives; a mirror **phantom** does not ride the window; empty is authoritative
and reconciles; `(nil,nil)` falls back; an error aborts with **zero bytes**
written; reverse entries skipped from a snapshot; the zone filter bypassed for a
snapshot.

**pkg/daemon (7)** cover the builder (owner-RG filter, fabric wire alias, error
propagation, empty-not-nil, non-open records, no-runtime fall-back) plus a
**wiring** test that drives the real `startClusterComms` on a resolvable sync
endpoint and then **invokes** the source it published, asserting the exported
session comes back — asserting merely non-nil would pass with any function.

### Mutation matrix — 10/10 RED, `go build` + `go vet` clean in every cell

| # | mutation | RED |
|---|---|---|
| M1 | BulkSync ignores the source (pre-fix store walk) | 5 tests |
| M2 | source error falls back to the mirror | `SourceErrorAborts` |
| M3 | `(nil,nil)` treated as an authoritative empty window | `NilSnapshotFallsBackToStore` |
| M4 | re-apply `ShouldSyncZone` to a supplied snapshot | `SnapshotBypassesZoneFilter` |
| M5 | drop the reverse guard on the v4 send path | `SnapshotSkipsReverseEntries` |
| M6 | export error swallowed into an empty snapshot | `PropagatesExportError` |
| M7 | no-owned-RGs returns nil instead of empty | `NoOwnedRGsIsEmptyNotNil` |
| M8 | delete the `ss.BulkSessionSource = …` production wiring | `StartClusterCommsWiresTableTruthBulkSource` |
| M9 | shared walk drops the #4090 forward wire alias | `CarriesFabricWireAlias` |
| M10 | source failure surfaced only AFTER BulkStart opened a window | `SourceErrorAborts` (the zero-bytes assertion) |

`go test -count=1 ./pkg/cluster ./pkg/daemon ./pkg/dataplane` — green, including
the retirement-boundary canary.

## Validation still owed

HA / session-sync change: owes **`make test-failover`** on the loss userspace
cluster. Not run here — the cluster is shared and lock-protected and is
serialised centrally. Worth exercising specifically because the snapshot's
delta-derived keys must match the mirror keys the receiver's reconcile candidate
set is built from; unit tests pin the plumbing, the cluster proves the keys.

## Docs

`docs/sync-protocol.md` gains a "Table-truth bulk source (#6031)" section (the
old text said the table-truth source "is tracked as a follow-up") and
`docs/session-sync-architecture.md`'s `BulkSync()` step list now names the source
resolution and its ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017g5f5Gq1LJGUY7rRNrUnZa
