### PR TITLE
deploy: run the #1864 verifier pre-flight on the standalone deploy too

### DIFF
--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -481,7 +481,10 @@ they repeatedly bite:
   - **Never hand-roll binary deploys** (`incus file push` + restart
     loops) to the cluster — they bypass the lock AND the #1864/#1869
     verify-dataplane gate. Deploys go through `cluster-setup.sh
-    deploy` / `make cluster-deploy`.
+    deploy` / `make cluster-deploy`. The same gate now runs on the
+    standalone `setup.sh deploy` path too (#6493), so `make
+    test-deploy` is no longer the one binary-swap route that can put
+    a verifier-rejected shim on a box and report success.
   - **Destructive HA smoke self-locks (#4020).** A `test-failover`
     that reboots a node mid-iperf is FAR more disruptive than a
     deploy, so the reboot/force-stop/failover smoke scripts share the

--- a/docs/test_env.md
+++ b/docs/test_env.md
@@ -625,6 +625,17 @@ Both raw deploy paths (`setup.sh deploy` and `cluster-setup.sh deploy`) now
 reconcile prior #1917 in-place-upgrade residue and HARD-verify the swap, so a
 deploy can no longer silently run OLD code:
 
+- **Verifier pre-flight (#1864 / #1869 / #6493).** BEFORE anything on the box is
+  disturbed, the new xpfd is staged at `/tmp/xpfd.preflight` and run as
+  `verify-dataplane` on the TARGET, so its embedded AF_XDP shim is proven to
+  load against THAT box's kernel. A REJECT aborts the deploy with the old
+  daemon still running and forwarding. This is the one check the other three
+  below cannot substitute for: they compare bytes and process identity, and all
+  pass for a binary whose shim loads nothing — the box then comes up in
+  config-only mode with no dataplane and the failure surfaces later as a
+  forwarding mystery. The walk runs at `nice -19` on the complement of the
+  AF_XDP worker cores (falling back to nice-only if that mask cannot be derived
+  or is unusable) so it does not stall a box that is still in service.
 - **Stale ExecStart pin.** A leftover `xpfd.service.d/10-xpf-version.conf` (from
   a `.deb` dogfood) pins systemd to a concrete versioned binary; a raw
   `incus file push` replaces `/usr/local/sbin/xpfd` but systemd keeps launching
@@ -647,3 +658,11 @@ deploy can no longer silently run OLD code:
 The reconcile/verify logic lives in `test/incus/deploy-lib.sh` (sourced by both
 scripts) and is covered by `test/incus/deploy-lib-selftest.sh`
 (`make test-deploy-lib`), which mocks `incus` against a fake VM rootfs.
+
+The pre-flight is `deploy_verify_dataplane_preflight` in the same file. Its
+correctness is half implementation and half POSITION: the self-test asserts both
+that a REJECT hard-fails without stopping the daemon or pushing into
+`/usr/local/sbin`, and — textually, against the real scripts — that the call in
+each deploy path precedes every destructive step in its function. Moving the
+call below `systemctl stop xpfd` keeps the function correct and makes the gate
+useless, so that ordering is asserted rather than commented.

--- a/test/incus/cluster-setup.sh
+++ b/test/incus/cluster-setup.sh
@@ -813,64 +813,16 @@ deploy_vm() {
 
 	# #1864 pre-flight: verify the NEW binary's embedded shim object
 	# against the node's kernel verifier BEFORE touching the running
-	# daemon. ORDERING INVARIANT: no dataplane stop, cleanup, pkill,
-	# binary replacement, or legacy-name (bpfrxd) migration may run
-	# before this check — the 2026-06-10 incident was exactly a
-	# stop-then-load-fail that left the node in config-only mode. The
-	# check loads anonymous maps only (no pins, no attach), so the
-	# live dataplane is untouched.
+	# daemon. The full ORDERING INVARIANT, CPU contract and rationale live
+	# with the implementation in deploy-lib.sh; the invariant this call site
+	# owns is its POSITION: nothing below it here (bpfrxd migration, pin
+	# reconcile, systemctl stop, pkill, binary push) may be hoisted above it.
+	# The 2026-06-10 incident was exactly a stop-then-load-fail that left the
+	# node in config-only mode.
 	#
-	# CPU contract: the verify walk (~17s of one core on a REJECT)
-	# runs on the complement of the AF_XDP worker cores, derived from
-	# the live xpf-userspace-dp tasks' Cpus_allowed_list. If the
-	# complement is empty or derivation fails, fall back to nice -n 19
-	# on all CPUs (workers pin worker-i -> i-th allowed CPU, so a
-	# dedicated housekeeping core is not guaranteed).
-	info "Pre-flight: verifying new xpfd dataplane object on $vm..."
-	incus file push "$PROJECT_ROOT/xpfd" "${rinst}/tmp/xpfd.preflight" --mode 0755
-	if ! incus exec "$rinst" -- bash -c '
-		set -u
-		free_cpus() {
-			# Worker threads pin themselves to exactly one CPU each
-			# (userspace-dp pin_current_thread); collect the
-			# single-CPU Cpus_allowed_list values (unpinned control
-			# threads report full ranges and are not workers) and
-			# return the complement vs online CPUs.
-			# pidof, not pgrep -x: the process name is 16 chars,
-			# past the 15-char comm truncation pgrep -x matches on.
-			local pid used t v
-			pid=$(pidof -s xpf-userspace-dp 2>/dev/null)
-			[ -n "$pid" ] || return 1
-			used=""
-			for t in /proc/"$pid"/task/*/status; do
-				[ -r "$t" ] || continue
-				v=$(awk -F"\t" "/^Cpus_allowed_list/ {print \$2}" "$t")
-				[[ "$v" =~ ^[0-9]+$ ]] && used="$used $v"
-			done
-			[ -n "${used// /}" ] || return 1
-			seq 0 $(( $(nproc --all) - 1 )) | \
-				awk -v used="$used" "BEGIN{n=split(used,a,\" \"); for(i=1;i<=n;i++) u[a[i]]=1} !(\$0 in u)" | \
-				paste -sd, -
-		}
-		MASK=$(free_cpus 2>/dev/null || true)
-		# Probe the mask before trusting it: the complement is taken
-		# against `nproc --all` (configured CPUs), which can include
-		# offline CPUs — taskset then EINVALs and, because this exec
-		# chain treats any non-zero exit as a verifier REJECT, a bad
-		# mask would false-reject a good binary (observed live on
-		# fw1 during the #1864 deploy smoke). An unusable mask falls
-		# back to the un-pinned nice-only run.
-		if [ -n "$MASK" ] && taskset -c "$MASK" true 2>/dev/null; then
-			exec nice -n 19 taskset -c "$MASK" /tmp/xpfd.preflight verify-dataplane
-		fi
-		exec nice -n 19 /tmp/xpfd.preflight verify-dataplane
-	'; then
-		incus exec "$rinst" -- rm -f /tmp/xpfd.preflight 2>/dev/null || true
-		die "verify-dataplane REJECTED the new binary's embedded shim on $vm — deploy aborted, old daemon untouched.
-  This is the #1864 failure mode. Rebuild with the pinned toolchain (make generate) or restore the tracked object:
-    git checkout -- pkg/dataplane/userspace_xdp_bpfel.o && make build"
-	fi
-	incus exec "$rinst" -- rm -f /tmp/xpfd.preflight 2>/dev/null || true
+	# #6493: extracted from this function into deploy-lib.sh so the standalone
+	# test/incus deploy runs the SAME gate instead of a second hand copy.
+	deploy_verify_dataplane_preflight "$rinst" "$PROJECT_ROOT/xpfd"
 
 	# Migrate from old bpfrxd naming if present.
 	incus exec "$rinst" -- systemctl stop bpfrxd 2>/dev/null || true

--- a/test/incus/deploy-lib-selftest.sh
+++ b/test/incus/deploy-lib-selftest.sh
@@ -32,23 +32,45 @@ bad()  { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
 FAKE_VM=""
 FAKE_MAINPID="0"
 FAKE_EXECSTART="/usr/local/sbin/xpfd"
+# #6493: verdict the fake `xpfd verify-dataplane` probe returns, and an ordered
+# log of every incus call the lib made. The log is what lets a test assert what
+# did NOT happen (no stop, no push to /usr/local/sbin) on the REJECT path — the
+# ordering invariant the pre-flight exists to hold.
+FAKE_VERIFY_RC=0
+# A FILE, not an array: every call under test runs in a subshell (die() exits,
+# so the rc has to be caught), and an array mutated in a subshell is discarded
+# on return. A file survives, so "what did NOT happen" is still assertable
+# after the abort.
+FAKE_CALL_LOG=""
 
 setup_fake_vm() {
 	FAKE_VM=$(mktemp -d)
 	FAKE_MAINPID="0"
 	FAKE_EXECSTART="/usr/local/sbin/xpfd"
+	FAKE_VERIFY_RC=0
+	FAKE_CALL_LOG=$(mktemp)
 	mkdir -p "$FAKE_VM/usr/local/sbin" "$FAKE_VM/etc/systemd/system"
+}
+
+# fake_calls_contain <extended-regex> — did any recorded incus call match?
+fake_calls_contain() {
+	[[ -n "$FAKE_CALL_LOG" ]] && grep -qE "$1" "$FAKE_CALL_LOG" 2>/dev/null
 }
 
 teardown_fake_vm() {
 	[[ -n "$FAKE_VM" && -d "$FAKE_VM" ]] && rm -rf "$FAKE_VM"
 	FAKE_VM=""
+	[[ -n "$FAKE_CALL_LOG" ]] && rm -f "$FAKE_CALL_LOG"
+	FAKE_CALL_LOG=""
 }
 
 # incus mock: supports `incus exec <inst> -- <cmd...>` and
 # `incus file push <local> <inst>/<path> [--mode m]`. <inst> is ignored
 # (single fake VM). All paths resolve under $FAKE_VM.
 incus() {
+	# Record BEFORE dispatch so a call that dies/returns non-zero is still in
+	# the log (the REJECT path's assertions read it).
+	[[ -n "$FAKE_CALL_LOG" ]] && printf '%s\n' "$*" >> "$FAKE_CALL_LOG"
 	local verb="$1"; shift
 	case "$verb" in
 	exec)
@@ -145,6 +167,14 @@ _fake_exec() {
 # _fake_remote_bash interprets the specific bash -c bodies the lib sends.
 _fake_remote_bash() {
 	local body="$1"
+	# #6493 pre-flight probe: the body execs `<staged> verify-dataplane`.
+	# Answer with the configured verdict. Checked FIRST so the generic
+	# fall-through `return 0` at the bottom can never launder a REJECT into a
+	# pass (a mock that silently returns 0 for an unrecognized body inverts the
+	# result of every REJECT test in this file).
+	if [[ "$body" == *"verify-dataplane"* ]]; then
+		return "$FAKE_VERIFY_RC"
+	fi
 	# deploy_verify_running_xpfd: effective ExecStart query (systemctl show
 	# ExecStart | sed path=). Emit the modeled ExecStart through the same sed
 	# the lib applies, so the extraction path is exercised end-to-end.
@@ -349,6 +379,158 @@ test_verify_running_stale_binary_hardfails() {
 	rm -f "$lb"; teardown_fake_vm
 }
 
+# ── #1864 verify-dataplane pre-flight (#6493) ────────────────────────
+# The gate the standalone deploy was missing. Three properties:
+#   1. a REJECT hard-fails (rc != 0) AND touches nothing on the box — no
+#      systemctl stop, no push into /usr/local/sbin. That is the whole point:
+#      the old daemon keeps forwarding while the operator rebuilds.
+#   2. a PASS returns 0 so the deploy proceeds.
+#   3. the staged /tmp/xpfd.preflight is removed on BOTH paths.
+# RED on revert: drop the die() and (1) flips; drop the cleanup call from
+# either path and (3) flips; hoist the call below the stop in setup.sh and the
+# ORDERING test below flips.
+
+test_preflight_pass_proceeds() {
+	setup_fake_vm
+	local lb; lb=$(mktemp); make_local_bin "$lb" "GOOD-SHIM"
+	FAKE_VERIFY_RC=0
+	if ( deploy_verify_dataplane_preflight vm "$lb" ) >/dev/null 2>&1; then
+		ok "preflight: verifier PASS lets the deploy proceed (rc 0)"
+	else
+		bad "preflight: verifier PASS must not abort the deploy"
+	fi
+	rm -f "$lb"; teardown_fake_vm
+}
+
+test_preflight_reject_hardfails() {
+	setup_fake_vm
+	local lb; lb=$(mktemp); make_local_bin "$lb" "BAD-SHIM"
+	FAKE_VERIFY_RC=1
+	if ( deploy_verify_dataplane_preflight vm "$lb" ) >/dev/null 2>&1; then
+		bad "preflight: verifier REJECT MUST hard-fail (this is the #1864 mode)"
+	else
+		ok "preflight: verifier REJECT hard-fails (rc!=0, deploy aborts)"
+	fi
+	rm -f "$lb"; teardown_fake_vm
+}
+
+test_preflight_reject_touches_nothing() {
+	setup_fake_vm
+	local lb; lb=$(mktemp); make_local_bin "$lb" "BAD-SHIM"
+	# The VM is running the OLD binary; a REJECT must leave it exactly there.
+	make_local_bin "$FAKE_VM/usr/local/sbin/xpfd" "OLD-RUNNING"
+	FAKE_VERIFY_RC=1
+	# Subshell for the rc (die() exits); the call log is a file so it survives.
+	local rc=0
+	( deploy_verify_dataplane_preflight vm "$lb" ) >/dev/null 2>&1 || rc=$?
+	if [[ $rc -eq 0 ]]; then
+		bad "preflight: REJECT must not return 0"
+		rm -f "$lb"; teardown_fake_vm; return
+	fi
+	if fake_calls_contain "systemctl stop"; then
+		bad "preflight: REJECT stopped the daemon — the box was taken down to learn the binary is bad"
+	elif fake_calls_contain "vm/usr/local/sbin/xpfd"; then
+		bad "preflight: REJECT pushed into /usr/local/sbin — the bad binary replaced the good one"
+	elif [[ "$(cat "$FAKE_VM/usr/local/sbin/xpfd")" != "OLD-RUNNING" ]]; then
+		bad "preflight: REJECT overwrote the running binary"
+	else
+		ok "preflight: REJECT leaves the old daemon untouched (no stop, no sbin push)"
+	fi
+	rm -f "$lb"; teardown_fake_vm
+}
+
+test_preflight_cleans_up_on_pass() {
+	setup_fake_vm
+	local lb; lb=$(mktemp); make_local_bin "$lb" "GOOD-SHIM"
+	FAKE_VERIFY_RC=0
+	( deploy_verify_dataplane_preflight vm "$lb" ) >/dev/null 2>&1
+	if [[ -e "$FAKE_VM/tmp/xpfd.preflight" ]]; then
+		bad "preflight: staged candidate left behind after PASS"
+	else
+		ok "preflight: staged /tmp/xpfd.preflight removed after PASS"
+	fi
+	rm -f "$lb"; teardown_fake_vm
+}
+
+test_preflight_cleans_up_on_reject() {
+	setup_fake_vm
+	local lb; lb=$(mktemp); make_local_bin "$lb" "BAD-SHIM"
+	FAKE_VERIFY_RC=1
+	( deploy_verify_dataplane_preflight vm "$lb" ) >/dev/null 2>&1
+	if [[ -e "$FAKE_VM/tmp/xpfd.preflight" ]]; then
+		bad "preflight: staged candidate left behind after REJECT (poisons the next probe's diagnosis)"
+	else
+		ok "preflight: staged /tmp/xpfd.preflight removed after REJECT"
+	fi
+	rm -f "$lb"; teardown_fake_vm
+}
+
+test_preflight_missing_local_binary_hardfails() {
+	setup_fake_vm
+	FAKE_VERIFY_RC=0
+	# No local build at all: must fail loudly rather than push nothing and
+	# "pass" a probe of a binary that does not exist.
+	if ( deploy_verify_dataplane_preflight vm /nonexistent/xpfd ) >/dev/null 2>&1; then
+		bad "preflight: absent local xpfd MUST hard-fail"
+	else
+		ok "preflight: absent local xpfd hard-fails before any remote work"
+	fi
+	teardown_fake_vm
+}
+
+# ── ORDERING: the call site position, not the function ───────────────
+# The function can be perfect and the gate still useless if a caller runs it
+# after `systemctl stop xpfd`. These read the real deploy scripts and assert the
+# pre-flight call precedes every destructive step in the same function. Purely
+# textual (no incus), and RED the moment either call is hoisted or removed.
+# _first_line_matching <file> <grep-ere> -> line number of the first matching
+# NON-COMMENT line, or empty.
+#
+# The comment filter is load-bearing, not tidiness: the pre-flight call sites
+# are documented with prose that NAMES the destructive steps ("...runs before
+# `systemctl stop xpfd`..."), so an unanchored sweep matches the explanation of
+# the invariant instead of the code that breaks it — and reports the gate as
+# mis-ordered while it is in fact correct. Caught by this very test on its
+# first run.
+_first_line_matching() {
+	grep -nE "$2" "$1" 2>/dev/null \
+		| awk -F: '{ line = $0; sub(/^[0-9]+:/, "", line); if (line !~ /^[[:space:]]*#/) { print $1; exit } }'
+}
+
+test_preflight_precedes_destructive_steps_standalone() {
+	local f="${SCRIPT_DIR}/setup.sh"
+	local pre stop push
+	pre=$(_first_line_matching "$f" '^[[:space:]]*deploy_verify_dataplane_preflight ')
+	stop=$(_first_line_matching "$f" 'systemctl stop xpfd')
+	push=$(_first_line_matching "$f" 'incus file push .*/usr/local/sbin/xpfd')
+	if [[ -z "$pre" ]]; then
+		bad "ordering(setup.sh): no deploy_verify_dataplane_preflight call — the standalone deploy has NO verifier gate (#6493)"
+	elif [[ -z "$stop" || -z "$push" ]]; then
+		bad "ordering(setup.sh): could not locate the stop/push anchors — test is stale, fix the pattern"
+	elif (( pre < stop && pre < push )); then
+		ok "ordering(setup.sh): pre-flight at :$pre precedes stop(:$stop) and sbin push(:$push)"
+	else
+		bad "ordering(setup.sh): pre-flight at :$pre runs AFTER stop(:$stop)/push(:$push) — the box is already down when the gate fires"
+	fi
+}
+
+test_preflight_precedes_destructive_steps_cluster() {
+	local f="${SCRIPT_DIR}/cluster-setup.sh"
+	local pre stop push
+	pre=$(_first_line_matching "$f" '^[[:space:]]*deploy_verify_dataplane_preflight ')
+	stop=$(_first_line_matching "$f" 'systemctl stop bpfrxd')
+	push=$(_first_line_matching "$f" 'incus file push .*/usr/local/sbin/xpfd')
+	if [[ -z "$pre" ]]; then
+		bad "ordering(cluster-setup.sh): no deploy_verify_dataplane_preflight call — the #1869 gate was lost"
+	elif [[ -z "$stop" || -z "$push" ]]; then
+		bad "ordering(cluster-setup.sh): could not locate the stop/push anchors — test is stale, fix the pattern"
+	elif (( pre < stop && pre < push )); then
+		ok "ordering(cluster-setup.sh): pre-flight at :$pre precedes migration stop(:$stop) and sbin push(:$push)"
+	else
+		bad "ordering(cluster-setup.sh): pre-flight at :$pre runs AFTER stop(:$stop)/push(:$push)"
+	fi
+}
+
 # ── Rolling-deploy node ordering (#4009) ─────────────────────────────
 # Captured `cli -c "show chassis cluster status"` samples (FormatStatus,
 # pkg/cluster/status.go). deploy_rolling_secondary_node must echo the RG0
@@ -479,6 +661,14 @@ test_reconcile_dangling_sbin_keeps_valid
 test_verify_running_match
 test_verify_running_stale_pin_hardfails
 test_verify_running_stale_binary_hardfails
+test_preflight_pass_proceeds
+test_preflight_reject_hardfails
+test_preflight_reject_touches_nothing
+test_preflight_cleans_up_on_pass
+test_preflight_cleans_up_on_reject
+test_preflight_missing_local_binary_hardfails
+test_preflight_precedes_destructive_steps_standalone
+test_preflight_precedes_destructive_steps_cluster
 
 echo "----------------------------------------"
 echo "deploy-lib selftest: $PASS passed, $FAIL failed"

--- a/test/incus/deploy-lib.sh
+++ b/test/incus/deploy-lib.sh
@@ -221,3 +221,109 @@ deploy_rolling_secondary_node() {
 deploy_rolling_rg_ids() {
 	awk '/^Redundancy group:[[:space:]]/ { print $3 }' | sort -n -u
 }
+
+# ── #1864 verify-dataplane pre-flight (#6493) ────────────────────────
+# The embedded AF_XDP shim object in a freshly built xpfd can be REJECTED by
+# the target box's BPF verifier (a drifted `make generate` toolchain, or simply
+# an older kernel on the VM than on the build host). Nothing else in a deploy
+# notices: `incus file push` succeeds, deploy_verify_pushed_sha compares BYTES,
+# and deploy_verify_running_xpfd only proves systemd launched the pushed image.
+# All three pass while the node comes up in config-only mode with NO dataplane,
+# and the failure surfaces later as a forwarding mystery. That is the
+# 2026-06-10 #1864 incident mode exactly.
+#
+# So every path that swaps xpfd on a live box proves the new binary's shim
+# LOADS on THAT box's kernel first. The cluster deploy has done this since
+# #1869; the standalone test/incus deploy did not, which is the venue where
+# shim iteration actually happens (#6493). This is the shared implementation
+# both callers now use.
+
+# Where the candidate binary is staged on the target for the probe. Deliberately
+# NOT /usr/local/sbin/xpfd: the whole point is to decide BEFORE replacing
+# anything the running daemon depends on.
+DEPLOY_PREFLIGHT_PATH="/tmp/xpfd.preflight"
+
+# deploy_verify_dataplane_preflight <rinst> <local_xpfd>
+#
+# ORDERING INVARIANT — the reason this function exists and the thing to protect
+# in review: NO dataplane stop, `xpfd cleanup`, pkill, binary replacement, or
+# legacy-name (bpfrxd) migration may run before this returns. On REJECT it
+# die()s, so the caller aborts with the OLD daemon still running and forwarding.
+# A preflight placed after `systemctl stop xpfd` proves the same fact but has
+# already taken the box down to learn it, which is the bug.
+#
+# The probe loads anonymous maps only — no pins, no attach — so the live
+# dataplane is untouched by a PASS.
+#
+# CPU contract: the verifier walk costs ~17s of one core on a REJECT. Running
+# that on an AF_XDP worker core would stall forwarding on a box that is still
+# in service, so it runs on the COMPLEMENT of the worker cores, derived from the
+# live xpf-userspace-dp tasks' Cpus_allowed_list, at nice -19. If the complement
+# is empty or cannot be derived (no helper running — the standalone case on a
+# box whose daemon is down), it falls back to nice -19 across all CPUs.
+deploy_verify_dataplane_preflight() {
+	local rinst="$1" local_xpfd="$2"
+
+	[[ -f "$local_xpfd" ]] \
+		|| die "verify-dataplane pre-flight: local xpfd not found at $local_xpfd — nothing to verify (build first)"
+
+	info "Pre-flight: verifying new xpfd dataplane object on $rinst..."
+	incus file push "$local_xpfd" "${rinst}${DEPLOY_PREFLIGHT_PATH}" --mode 0755 \
+		|| die "verify-dataplane pre-flight: failed to stage $local_xpfd at ${DEPLOY_PREFLIGHT_PATH} on $rinst — deploy aborted, old daemon untouched"
+
+	if ! incus exec "$rinst" -- bash -c '
+		set -u
+		free_cpus() {
+			# Worker threads pin themselves to exactly one CPU each
+			# (userspace-dp pin_current_thread); collect the
+			# single-CPU Cpus_allowed_list values (unpinned control
+			# threads report full ranges and are not workers) and
+			# return the complement vs online CPUs.
+			# pidof, not pgrep -x: the process name is 16 chars,
+			# past the 15-char comm truncation pgrep -x matches on.
+			local pid used t v
+			pid=$(pidof -s xpf-userspace-dp 2>/dev/null)
+			[ -n "$pid" ] || return 1
+			used=""
+			for t in /proc/"$pid"/task/*/status; do
+				[ -r "$t" ] || continue
+				v=$(awk -F"\t" "/^Cpus_allowed_list/ {print \$2}" "$t")
+				[[ "$v" =~ ^[0-9]+$ ]] && used="$used $v"
+			done
+			[ -n "${used// /}" ] || return 1
+			seq 0 $(( $(nproc --all) - 1 )) | \
+				awk -v used="$used" "BEGIN{n=split(used,a,\" \"); for(i=1;i<=n;i++) u[a[i]]=1} !(\$0 in u)" | \
+				paste -sd, -
+		}
+		MASK=$(free_cpus 2>/dev/null || true)
+		# Probe the mask before trusting it: the complement is taken
+		# against `nproc --all` (configured CPUs), which can include
+		# offline CPUs — taskset then EINVALs and, because this exec
+		# chain treats any non-zero exit as a verifier REJECT, a bad
+		# mask would false-reject a good binary (observed live on
+		# fw1 during the #1864 deploy smoke). An unusable mask falls
+		# back to the un-pinned nice-only run.
+		if [ -n "$MASK" ] && taskset -c "$MASK" true 2>/dev/null; then
+			exec nice -n 19 taskset -c "$MASK" '"$DEPLOY_PREFLIGHT_PATH"' verify-dataplane
+		fi
+		exec nice -n 19 '"$DEPLOY_PREFLIGHT_PATH"' verify-dataplane
+	'; then
+		deploy_preflight_cleanup "$rinst"
+		die "verify-dataplane REJECTED the new binary's embedded shim on $rinst — deploy aborted, old daemon untouched.
+  This is the #1864 failure mode. Rebuild with the pinned toolchain (make generate) or restore the tracked object:
+    git checkout -- pkg/dataplane/userspace_xdp_bpfel.o && make build"
+	fi
+	deploy_preflight_cleanup "$rinst"
+	info "Pre-flight PASS: the new xpfd's embedded shim loads on $rinst's kernel."
+}
+
+# deploy_preflight_cleanup <rinst>
+#
+# Remove the staged candidate. Runs on BOTH the PASS and the REJECT path — a
+# REJECT that leaves a stale /tmp/xpfd.preflight behind seeds the next probe's
+# diagnosis with a binary nobody asked about. Best-effort by design: a failure
+# to unlink must not turn a passing pre-flight into a failed deploy.
+deploy_preflight_cleanup() {
+	local rinst="$1"
+	incus exec "$rinst" -- rm -f "$DEPLOY_PREFLIGHT_PATH" 2>/dev/null || true
+}

--- a/test/incus/setup.sh
+++ b/test/incus/setup.sh
@@ -585,6 +585,22 @@ cmd_deploy() {
 		warn "Rust toolchain not found; skipping xpf-userspace-dp build"
 	fi
 
+	# #1864/#6493 pre-flight: prove the NEW binary's embedded AF_XDP shim is
+	# ACCEPTED by THIS VM's kernel verifier before anything on the box is
+	# disturbed. sha256 equality (deploy_verify_pushed_sha) and "systemd
+	# launched the pushed binary" (deploy_verify_running_xpfd) both pass for a
+	# binary whose shim loads nothing — they verify bytes and process identity,
+	# never verifier acceptance — so without this the standalone deploy reports
+	# success and leaves the VM in config-only mode with no dataplane.
+	#
+	# POSITION IS THE POINT: this runs before the bpfrxd migration, the pin
+	# reconcile, `systemctl stop xpfd`, the pkills and the binary push, so a
+	# REJECT aborts with the old daemon still running. The cluster deploy has
+	# had this gate since #1869; the standalone path — the venue where
+	# `make generate` shim iteration actually happens, against a VM kernel
+	# independent of the build host's — did not (#6493).
+	deploy_verify_dataplane_preflight "$INSTANCE_NAME" "$PROJECT_ROOT/xpfd"
+
 	# Migrate from old bpfrxd naming if present.
 	incus exec "$INSTANCE_NAME" -- systemctl stop bpfrxd 2>/dev/null || true
 	incus exec "$INSTANCE_NAME" -- /usr/local/sbin/bpfrxd cleanup 2>/dev/null || true


### PR DESCRIPTION
Closes #6493

## What was wrong

`grep -rn verify-dataplane test/incus/*.sh` matched **only** `cluster-setup.sh`. The standalone deploy — `make test-deploy` / `test/incus/setup.sh deploy`, the canonical single-VM flow in the README and the CLAUDE.md Quick Start — pushed a new `xpfd` and started it with no proof that its embedded AF_XDP shim is accepted by that VM's BPF verifier.

Nothing else in the deploy can catch it. `incus file push` succeeds; `deploy_verify_pushed_sha` compares **bytes**; `deploy_verify_running_xpfd` proves only that systemd launched the pushed image. All three pass for a binary whose shim loads nothing — the VM comes up config-only with no dataplane, the deploy reports success, and the failure surfaces later as a forwarding mystery. That is the 2026-06-10 #1864 incident mode, and the standalone VM is the *higher*-risk venue for it: it is where `make generate` shim iteration happens, against a VM kernel independent of the build host's.

## What this does

Extracts the #1869 gate from `cluster-setup.sh` into `deploy-lib.sh` as `deploy_verify_dataplane_preflight` (+ `deploy_preflight_cleanup`) and calls it from **both** paths, rather than growing a second hand copy that drifts.

The cluster path's behaviour is unchanged: same staged `/tmp/xpfd.preflight`, same worker-core-complement CPU mask with the `taskset` probe and the nice-only fallback, same abort-before-touching-the-old-daemon on REJECT. The only visible difference is that diagnostics now name the remote-qualified instance (`loss:xpf-userspace-fw0`) rather than the bare VM name.

In `setup.sh` the call sits above the bpfrxd migration, the pin reconcile, `systemctl stop xpfd`, the pkills and the binary push — so a REJECT aborts with the old daemon still running and forwarding.

## Acceptance criteria

- [x] `setup.sh deploy` runs the same `verify-dataplane` preflight (push to /tmp, CPU-complement mask with probe fallback, `nice -19`) **before** `systemctl stop xpfd`, aborting with the old daemon untouched on REJECT.
- [x] Shared logic lives in `test/incus/deploy-lib.sh`; both callers use it. Not a second copy.
- [x] `make test-deploy-lib` covers REJECT-aborts-before-any-stop/push, PASS-proceeds, and preflight-binary-cleanup.

## Validation

`./test/incus/deploy-lib-selftest.sh` (`make test-deploy-lib`) — **27 passed, 0 failed, rc=0** (9 new cases).
`scripts/run-selftests.sh` — **50 passed, 0 skipped, 0 failed, rc=0** (unchanged from baseline).

### Mutation proofs

Exit codes read from `$?`, never through a pipe. One line mutated per run; `git checkout --` restore verified clean (`git status --porcelain` empty) and rc back to 0 between each.

| # | Mutation (one line) | rc | Cell that reddened |
|---|---|---|---|
| M1 | REJECT `die` → `warn` | 1 | `verifier REJECT MUST hard-fail (this is the #1864 mode)` + `REJECT must not return 0` |
| M2 | move the `setup.sh` call below `systemctl stop xpfd` | 1 | `pre-flight at :625 runs AFTER stop(:624)` |
| M3 | drop `deploy_preflight_cleanup` from the REJECT path only | 1 | `staged candidate left behind after REJECT` |
| M4 | delete the `setup.sh` call entirely (the pre-fix state) | 1 | `no deploy_verify_dataplane_preflight call — the standalone deploy has NO verifier gate` |

## A note on the two structural cases

The function can be perfect and the gate still useless if a caller runs it after the daemon is stopped, so two cases read the **real** `setup.sh` / `cluster-setup.sh` and assert the call precedes every destructive step in its function (M2/M4 above).

That check found a defect in its own first draft, which is worth flagging for review: the call sites are documented with prose that *names* the destructive steps ("...runs before `systemctl stop xpfd`..."), so the unanchored sweep matched the **explanation of the invariant** instead of the code that would break it, and reported a correctly-ordered gate as mis-ordered. The comment-skipping line filter in `_first_line_matching` is therefore load-bearing, not tidiness.

## Scope

- **Does not reach the Rust helper.** Shell only; no `userspace-dp`/`userspace-xdp` source, no `.o` movement, no binary artifact.
- **No cluster time used.** Every assertion above is hermetic (the existing fake-incus mock in `deploy-lib-selftest.sh`); the loss cluster was not touched, deployed to, or smoked.

## Docs

`docs/test_env.md` — pre-flight added to the raw-deploy reconciliation list, with why its *position* is asserted rather than commented. `docs/engineering-style.md` — the standalone path is no longer the one binary-swap route that can ship a verifier-rejected shim and report success.

## Follow-up spotted, not fixed here

`deploy-lib-selftest.sh` is fully hermetic (no incus, no cluster, no network) but is **not** discovered by `scripts/run-selftests.sh` — it runs only via `make test-deploy-lib`. Out of scope for this issue; happy to file it separately if wanted.