### PR TITLE
cli: surface the day-0 config-import verdict as `show system bootstrap-import`

### DIFF
--- a/cmd/cli/show_system.go
+++ b/cmd/cli/show_system.go
@@ -135,6 +135,11 @@ func (c *ctl) handleShowSystem(args []string) error {
 		return c.showSystemInfo("boot-messages")
 	case "core-dumps":
 		return c.showText("core-dumps")
+	case "bootstrap-import":
+		// #6496: the day-0 config-import verdict. Rendered daemon-side through
+		// pkg/bootstrapshow — the same implementation the in-process console
+		// CLI uses — so the two clients cannot show different answers.
+		return c.showText("bootstrap-import")
 	default:
 		return fmt.Errorf("unknown show system target: %s", args[0])
 	}

--- a/docs/bare-metal-device-map.md
+++ b/docs/bare-metal-device-map.md
@@ -216,9 +216,11 @@ The SAME pre-flight now runs on the **day-0 / bootstrap paths** (#4183):
 
 ## Day-0 import visibility
 
-A day-0 / bootstrap config-import outcome is recorded at boot and surfaced on
-`/health` (#4184) so "why didn't my config apply" has an in-band answer beyond
-a single journald line:
+A day-0 / bootstrap config-import outcome is recorded at boot and surfaced both
+in the CLI as `show system bootstrap-import` (#6496 — including the failure
+REASON, which `/health` cannot carry) and on `/health` (#4184), so "why didn't
+my config apply" has an in-band answer beyond a single journald line. The full
+day-0 triage walkthrough is in `docs/install-images.md`. The `/health` fields:
 
 - `bootstrap_import_status`: `ok` (imported + committed), `loaded-from-db`
   (an active config was already present), `no-config` (no text config present —
@@ -229,6 +231,14 @@ a single journald line:
   NOT force a 503 (the box is in the lifeline-safe bootstrap state — surfacing
   the cause is the goal, not pulling a still-reachable box from rotation). A
   failed import also emits a `BOOTSTRAP_IMPORT_FAILED` event.
+
+`show system bootstrap-import` renders the same recorded snapshot through
+`pkg/bootstrapshow`, shared by the in-process console CLI and the gRPC
+`ShowText` path the remote `cli` uses, so the console, the remote client and
+the health probe cannot disagree about whether a day-0 config applied. Unlike
+`/health` it prints the error detail: that endpoint is unauthenticated and an
+import error quotes the offending config, which can echo a submitted secret
+(#5031); the CLI path is authenticated.
 
 A factory boot with NO `/etc/xpf/xpf.conf` is the EXPECTED fresh state and is
 logged at Info ("no text config present"), not Warn (#4186) — so an operator

--- a/docs/deploy-quickstart.md
+++ b/docs/deploy-quickstart.md
@@ -207,7 +207,7 @@ The YAML + `xpf.conf` are the deployable artifacts — treat them as code:
 
 | Symptom | Look at |
 |---|---|
-| day-0 config not applied | `journalctl -u xpf-day0-config` — verbatim commit-check rejection; box stays factory-default, fix + reboot |
+| day-0 config not applied | `show system bootstrap-import` from the CLI — the recorded verdict AND the reason (#6496); then `journalctl -u xpf-day0-config` for the verbatim commit-check rejection. Box stays factory-default: fix + reboot. See docs/install-images.md "My day-0 config did not apply" |
 | NIC roles shifted | `cli -c "show interfaces terse"` vs your YAML; an interface added between deploys changes order |
 | VF dataplane dead after host reboot | unpinned VF MAC rotated — set `mac:` on the interface |
 | no mgmt after commit | hypervisor console → `cli` → `rollback 1`, `commit` |

--- a/docs/install-images.md
+++ b/docs/install-images.md
@@ -286,6 +286,46 @@ Day-0 loader specifics (`scripts/image/xpf-day0-config`, oneshot unit
   skip the probe, killing the fix-and-reboot retry above. A box in
   factory bootstrap has no `active.json`, so the loader re-probes.
 
+### "My day-0 config did not apply" — where to look (#4184 / #6496)
+
+The boot-time config-import decision is RECORDED, so this is a question with an
+in-band answer rather than a journald hunt. From the CLI on the box (console or
+ssh, local `cli` or remote):
+
+```
+> show system bootstrap-import
+Bootstrap configuration import:
+  Status:   import-failed
+  Meaning:  a configuration file was present but could NOT be applied — see Error below
+  Recorded: 2026-08-21 14:02:11 UTC
+  Error:    day-0 config REJECTED by commit-check: ...
+
+  The box is in the lifeline-safe bootstrap state; ...
+```
+
+The four statuses are `ok` (imported + committed), `loaded-from-db` (an active
+config was already present, so no file import was attempted — the normal
+steady-state boot), `no-config` (nothing to import: the expected factory boot),
+and `import-failed` (a file was present but could not be read, parsed,
+committed, or survived the device-map strand preflight).
+
+`import-failed` is INFORMATIONAL, not a fault state: the box is in the
+lifeline-safe bootstrap state and still reachable, so neither this command nor
+`/health` treats it as a reason to pull the box. It also emits a
+`BOOTSTRAP_IMPORT_FAILED` event.
+
+The same status is on the loopback REST probe for scripted checks:
+
+```
+curl -s http://127.0.0.1:8080/health | jq '.data | {bootstrap_import_status, bootstrap_import_failed, bootstrap_import_unix}'
+```
+
+Use the CLI when you need the **reason**. `/health` deliberately reports the
+status enum, the failed flag and the timestamp but NOT the error text: that
+endpoint is unauthenticated, and an import error quotes the offending
+configuration, which can echo a submitted secret (#5031). The CLI and gRPC
+paths are authenticated, so they are the only surfaces that can tell you why.
+
 ### The `/etc/xpf/appliance` marker (#7114)
 
 The bake writes `/etc/xpf/appliance` into the image. It is what makes the

--- a/pkg/bootstrapshow/bootstrapshow.go
+++ b/pkg/bootstrapshow/bootstrapshow.go
@@ -1,0 +1,117 @@
+// Package bootstrapshow renders the day-0 / bootstrap config-import outcome
+// (#4184) for the operator-facing show paths, and owns the status vocabulary
+// itself.
+//
+// Background (#6496): the outcome was recorded by the daemon and rendered in
+// exactly one place — the `/health` JSON on the loopback REST API. The
+// operator this feature exists for is standing at a fresh box on day zero
+// with the `cli` prompt open, asking the one question the status answers
+// ("why didn't my day-0 config apply?"), and could not get it from the CLI
+// they were already in: they had to know to leave it and curl
+// 127.0.0.1:8080/health, documented only in the bare-metal device-map doc.
+//
+// This package is a leaf (stdlib only) so BOTH show paths — the in-process
+// CLI (pkg/cli) and the gRPC ShowText path the remote `cli` binary uses
+// (pkg/grpcapi) — render from one implementation, in the pkg/natshow idiom.
+// Two renderings of the same recorded fact that disagree is ALWAYS a bug,
+// never a legitimate difference, so this is single-sourced rather than
+// duplicated-and-cross-checked.
+//
+// The status constants live here too, and pkg/daemon's unexported names are
+// defined as aliases of them, so the recorded vocabulary and the rendered
+// vocabulary cannot drift apart into a status the renderer does not know.
+package bootstrapshow
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+// Status vocabulary for the boot-time config-import decision. pkg/daemon
+// records exactly one of these once per boot (recordBootstrapImport).
+const (
+	// StatusOK: the text config file was imported and committed.
+	StatusOK = "ok"
+	// StatusLoadedDB: an active config was already present in the DB; no file
+	// import was attempted (the normal steady-state boot).
+	StatusLoadedDB = "loaded-from-db"
+	// StatusNoConfig: no text config file present (factory / fresh boot).
+	// Expected — NOT a failure.
+	StatusNoConfig = "no-config"
+	// StatusFailed: a text config file was present but could not be
+	// read/parsed/committed, or was rejected by the device-map preflight.
+	StatusFailed = "import-failed"
+)
+
+// Snapshot is the recorded outcome. It mirrors daemon.BootstrapImport
+// without importing pkg/daemon (which imports both show paths).
+type Snapshot struct {
+	Status  string // a Status* constant; "" when the decision has not been reached yet
+	Error   string // detail when Status == StatusFailed
+	UnixSec int64  // when the outcome was recorded
+	Failed  bool   // true only for StatusFailed
+}
+
+// explain returns the operator-facing meaning of a status. An UNKNOWN status
+// is reported as unknown rather than silently rendered as a bare string: a
+// status this package does not recognise means the daemon started recording a
+// vocabulary the renderer was never taught, and saying so is more useful than
+// printing it as if it were understood.
+func explain(status string) string {
+	switch status {
+	case StatusOK:
+		return "the day-0 / preseeded configuration was imported and committed"
+	case StatusLoadedDB:
+		return "an active configuration was already present; no file import was attempted"
+	case StatusNoConfig:
+		return "no configuration file was present (factory boot) — expected, not a failure"
+	case StatusFailed:
+		return "a configuration file was present but could NOT be applied — see Error below"
+	case "":
+		return "the daemon has not yet reached the boot-time import decision"
+	default:
+		return "unrecognized status — this xpfd records a state this CLI does not know"
+	}
+}
+
+// Render writes the Junos-style rendering of the recorded outcome.
+//
+// Informational by construction (#6496 acceptance): it describes state and
+// never signals failure through its own return, mirroring the deliberate
+// /health posture where import-failed does NOT force a 503 — a reachable box
+// whose day-0 config did not take must not be pulled from rotation over it.
+//
+// Unlike /health, this surface DOES render the error detail. /health withholds
+// it on purpose (#5031): that endpoint is unauthenticated and the raw import
+// error quotes the offending config, which can echo a submitted secret. The
+// CLI and ShowText paths are authenticated, so this is the only surface that
+// can answer "why didn't my config apply" with the actual reason — which is
+// the entire point of the command.
+func Render(w io.Writer, s Snapshot) {
+	fmt.Fprintln(w, "Bootstrap configuration import:")
+	status := s.Status
+	if status == "" {
+		status = "not-recorded"
+	}
+	fmt.Fprintf(w, "  Status:   %s\n", status)
+	fmt.Fprintf(w, "  Meaning:  %s\n", explain(s.Status))
+	if s.UnixSec != 0 {
+		fmt.Fprintf(w, "  Recorded: %s\n",
+			time.Unix(s.UnixSec, 0).UTC().Format("2006-01-02 15:04:05 UTC"))
+	}
+	if s.Error != "" {
+		fmt.Fprintf(w, "  Error:    %s\n", s.Error)
+	}
+	// The remediation hint is gated on Failed, not on Error being non-empty:
+	// a failure whose detail was lost still needs to tell the operator what to
+	// do next, and a non-failure that somehow carries detail must not be
+	// dressed up as one.
+	if s.Failed {
+		fmt.Fprintln(w, "")
+		fmt.Fprintln(w, "  The box is in the lifeline-safe bootstrap state; the running")
+		fmt.Fprintln(w, "  configuration is NOT the one on the day-0 medium. Fix the cause")
+		fmt.Fprintln(w, "  above, then either commit the corrected configuration from this")
+		fmt.Fprintln(w, "  CLI or re-present a corrected day-0 medium and reboot.")
+	}
+}

--- a/pkg/bootstrapshow/bootstrapshow_6496_test.go
+++ b/pkg/bootstrapshow/bootstrapshow_6496_test.go
@@ -1,0 +1,126 @@
+package bootstrapshow
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// render is a test helper: the rendering of one snapshot as a string.
+func render(s Snapshot) string {
+	var b bytes.Buffer
+	Render(&b, s)
+	return b.String()
+}
+
+// The four recorded statuses each render their own status token AND their own
+// meaning. RED on revert: collapse two cases in explain() and the pair that
+// collapsed reports the same meaning line.
+func TestEveryStatusRendersItsOwnMeaning(t *testing.T) {
+	cases := []struct{ status, wantToken string }{
+		{StatusOK, "ok"},
+		{StatusLoadedDB, "loaded-from-db"},
+		{StatusNoConfig, "no-config"},
+		{StatusFailed, "import-failed"},
+	}
+	seen := map[string]string{}
+	for _, c := range cases {
+		out := render(Snapshot{Status: c.status})
+		if !strings.Contains(out, "Status:   "+c.wantToken+"\n") {
+			t.Errorf("status %q: rendered status token missing from:\n%s", c.status, out)
+		}
+		meaning := meaningLine(t, out)
+		if meaning == "" {
+			t.Fatalf("status %q: no Meaning line in:\n%s", c.status, out)
+		}
+		if prev, dup := seen[meaning]; dup {
+			t.Errorf("statuses %q and %q render the SAME meaning %q — an operator "+
+				"cannot tell them apart", prev, c.status, meaning)
+		}
+		seen[meaning] = c.status
+	}
+}
+
+func meaningLine(t *testing.T, out string) string {
+	t.Helper()
+	for _, ln := range strings.Split(out, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(ln), "Meaning:") {
+			return strings.TrimSpace(ln)
+		}
+	}
+	return ""
+}
+
+// A status the renderer does not know must be REPORTED as unrecognized, not
+// printed as though it were understood. This is what makes the daemon-side
+// constant aliasing (pkg/daemon/daemon_health.go) checkable rather than a
+// convention: a divergence surfaces to the operator instead of hiding.
+func TestUnknownStatusIsReportedAsUnrecognized(t *testing.T) {
+	out := render(Snapshot{Status: "some-future-state"})
+	if !strings.Contains(out, "some-future-state") {
+		t.Errorf("the unrecognized status value itself must still be shown:\n%s", out)
+	}
+	if !strings.Contains(out, "unrecognized status") {
+		t.Errorf("an unknown status must be called out as unrecognized:\n%s", out)
+	}
+}
+
+// The empty status (daemon has not reached the decision yet) must not render
+// as an empty field — the operator would read a blank as "nothing wrong".
+func TestUnrecordedStatusIsNamed(t *testing.T) {
+	out := render(Snapshot{})
+	if !strings.Contains(out, "not-recorded") {
+		t.Errorf("an unrecorded outcome must be NAMED, not blank:\n%s", out)
+	}
+	if strings.Contains(out, "Status:   \n") {
+		t.Errorf("blank status field rendered:\n%s", out)
+	}
+}
+
+// The failure REASON is the entire point of the command: /health withholds it
+// (#5031, unauthenticated), so if this surface drops it too the operator has
+// no in-band way to learn why the day-0 config did not apply.
+func TestFailedRendersTheErrorDetailAndRemediation(t *testing.T) {
+	const detail = `parse error at line 12: unknown statement "dataplane-type"`
+	// 1755792000 == 2025-08-21 16:00:00 UTC. Pinned so the rendering is
+	// asserted in UTC regardless of the test host's TZ.
+	out := render(Snapshot{Status: StatusFailed, Error: detail, Failed: true, UnixSec: 1755792000})
+	if !strings.Contains(out, detail) {
+		t.Errorf("import-failed must render the error detail (the whole point of "+
+			"the command; /health cannot carry it):\n%s", out)
+	}
+	if !strings.Contains(out, "lifeline-safe bootstrap state") {
+		t.Errorf("import-failed must tell the operator what state the box is in:\n%s", out)
+	}
+	if !strings.Contains(out, "2025-08-21 16:00:00 UTC") {
+		t.Errorf("a recorded timestamp must be rendered in UTC:\n%s", out)
+	}
+}
+
+// The remediation block is gated on Failed, not on Error being non-empty. A
+// non-failure must never be dressed up as one.
+func TestNonFailureNeverShowsRemediation(t *testing.T) {
+	for _, s := range []Snapshot{
+		{Status: StatusOK, UnixSec: 1755792000},
+		{Status: StatusNoConfig, UnixSec: 1755792000},
+		{Status: StatusLoadedDB, UnixSec: 1755792000},
+	} {
+		out := render(s)
+		if strings.Contains(out, "lifeline-safe bootstrap state") {
+			t.Errorf("status %q is not a failure but rendered the failure "+
+				"remediation:\n%s", s.Status, out)
+		}
+	}
+}
+
+// A snapshot with no recorded time must not render a 1970 timestamp as if the
+// outcome had been recorded at the epoch.
+func TestZeroTimestampIsOmittedNotRenderedAsEpoch(t *testing.T) {
+	out := render(Snapshot{Status: StatusOK})
+	if strings.Contains(out, "1970") {
+		t.Errorf("an unset UnixSec must be omitted, not rendered as the epoch:\n%s", out)
+	}
+	if strings.Contains(out, "Recorded:") {
+		t.Errorf("no Recorded line should appear without a timestamp:\n%s", out)
+	}
+}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/chzyer/readline"
+	"github.com/psaab/xpf/pkg/bootstrapshow"
 	"github.com/psaab/xpf/pkg/cluster"
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/configstore"
@@ -93,11 +94,17 @@ type CLI struct {
 	// / unit test): showSystemServices falls back to the documented loopback
 	// defaults.
 	listenersFn func() sysservices.Listeners
-	hostname    string
-	username    string
-	userClass   string
-	version     string
-	startTime   time.Time
+	// bootstrapImportFn returns the recorded day-0 / bootstrap config-import
+	// outcome for `show system bootstrap-import` (#6496). The daemon wires it
+	// to Daemon.BootstrapImportSnapshot — the SAME snapshot /health and the
+	// gRPC ShowText path read. Nil in a `cli` spawned outside the daemon,
+	// where the command reports that no outcome has been recorded.
+	bootstrapImportFn func() bootstrapshow.Snapshot
+	hostname          string
+	username          string
+	userClass         string
+	version           string
+	startTime         time.Time
 
 	vrrpMgr *vrrp.Manager
 
@@ -283,6 +290,16 @@ func (c *CLI) SetFlowCollectorHealthFn(fn func() []flowexport.ExporterCollectorH
 // showSystemServices on the documented loopback defaults (offline / unit test).
 func (c *CLI) SetListenersFn(fn func() sysservices.Listeners) {
 	c.listenersFn = fn
+}
+
+// SetBootstrapImportFn wires the recorded day-0 / bootstrap config-import
+// outcome for `show system bootstrap-import` (#6496). The daemon passes
+// Daemon.BootstrapImportSnapshot — the SAME snapshot /health and the gRPC
+// ShowText renderer read — so the console, the remote `cli`, and the health
+// probe cannot disagree about whether the day-0 configuration applied. Nil
+// leaves the command reporting an unrecorded outcome (offline / unit test).
+func (c *CLI) SetBootstrapImportFn(fn func() bootstrapshow.Snapshot) {
+	c.bootstrapImportFn = fn
 }
 
 // SetDDNSOwnedRecordsFn sets a callback for retrieving the DHCP

--- a/pkg/cli/cli_show_bootstrap_import_6496_test.go
+++ b/pkg/cli/cli_show_bootstrap_import_6496_test.go
@@ -18,16 +18,18 @@ import (
 // case and handleShowSystem returns "unknown show system target".
 func TestHandleShowSystemDispatchesBootstrapImport(t *testing.T) {
 	const detail = `day-0 config REJECTED: unknown statement "dataplane-type"`
-	c := &CLI{
-		bootstrapImportFn: func() bootstrapshow.Snapshot {
-			return bootstrapshow.Snapshot{
-				Status:  bootstrapshow.StatusFailed,
-				Error:   detail,
-				UnixSec: 1755792000,
-				Failed:  true,
-			}
-		},
-	}
+	// Wired through SetBootstrapImportFn, NOT by assigning the private field:
+	// the setter is the seam the daemon actually uses, and a test that writes
+	// the field directly stays green with the setter's body emptied.
+	c := &CLI{}
+	c.SetBootstrapImportFn(func() bootstrapshow.Snapshot {
+		return bootstrapshow.Snapshot{
+			Status:  bootstrapshow.StatusFailed,
+			Error:   detail,
+			UnixSec: 1755792000,
+			Failed:  true,
+		}
+	})
 	var err error
 	out := captureStdout(t, func() { err = c.handleShowSystem([]string{"bootstrap-import"}) })
 	if err != nil {
@@ -54,7 +56,8 @@ func TestConsoleBootstrapImportMatchesTheSharedRenderer(t *testing.T) {
 		{Status: bootstrapshow.StatusFailed, Error: "boom", UnixSec: 1755792000, Failed: true},
 		{},
 	} {
-		c := &CLI{bootstrapImportFn: func() bootstrapshow.Snapshot { return snap }}
+		c := &CLI{}
+		c.SetBootstrapImportFn(func() bootstrapshow.Snapshot { return snap })
 		out := captureStdout(t, func() { _ = c.handleShowSystem([]string{"bootstrap-import"}) })
 		var want bytes.Buffer
 		bootstrapshow.Render(&want, snap)

--- a/pkg/cli/cli_show_bootstrap_import_6496_test.go
+++ b/pkg/cli/cli_show_bootstrap_import_6496_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/bootstrapshow"
+)
+
+// These drive the console path end-to-end and capture os.Stdout via the
+// package-local captureStdout helper (cluster_failover_test.go).
+
+// #6496: `show system bootstrap-import` on the in-process console CLI.
+//
+// The whole reason this command exists is that the day-0 operator is standing
+// at the console with this prompt open. RED on revert: remove the dispatcher
+// case and handleShowSystem returns "unknown show system target".
+func TestHandleShowSystemDispatchesBootstrapImport(t *testing.T) {
+	const detail = `day-0 config REJECTED: unknown statement "dataplane-type"`
+	c := &CLI{
+		bootstrapImportFn: func() bootstrapshow.Snapshot {
+			return bootstrapshow.Snapshot{
+				Status:  bootstrapshow.StatusFailed,
+				Error:   detail,
+				UnixSec: 1755792000,
+				Failed:  true,
+			}
+		},
+	}
+	var err error
+	out := captureStdout(t, func() { err = c.handleShowSystem([]string{"bootstrap-import"}) })
+	if err != nil {
+		t.Fatalf("handleShowSystem(bootstrap-import) error = %v", err)
+	}
+	if !strings.Contains(out, "import-failed") {
+		t.Errorf("wired status not rendered on the console path:\n%s", out)
+	}
+	if !strings.Contains(out, detail) {
+		t.Errorf("the console path must render the failure REASON — it is the "+
+			"question the operator is asking, and /health cannot carry it "+
+			"(#5031):\n%s", out)
+	}
+}
+
+// The console rendering must be BYTE-IDENTICAL to the shared renderer, which
+// is also what the gRPC ShowText path emits. Two operators looking at the same
+// box through the console and through the remote `cli` must not be told
+// different things about one recorded fact.
+func TestConsoleBootstrapImportMatchesTheSharedRenderer(t *testing.T) {
+	for _, snap := range []bootstrapshow.Snapshot{
+		{Status: bootstrapshow.StatusOK, UnixSec: 1755792000},
+		{Status: bootstrapshow.StatusNoConfig, UnixSec: 1755792000},
+		{Status: bootstrapshow.StatusFailed, Error: "boom", UnixSec: 1755792000, Failed: true},
+		{},
+	} {
+		c := &CLI{bootstrapImportFn: func() bootstrapshow.Snapshot { return snap }}
+		out := captureStdout(t, func() { _ = c.handleShowSystem([]string{"bootstrap-import"}) })
+		var want bytes.Buffer
+		bootstrapshow.Render(&want, snap)
+		if out != want.String() {
+			t.Errorf("status %q: console render diverges from bootstrapshow.Render\n"+
+				"--- console ---\n%s\n--- shared ---\n%s", snap.Status, out, want.String())
+		}
+	}
+}
+
+// A `cli` spawned outside the daemon has no hook. It must still print an
+// explicit unrecorded state rather than nothing, which an operator would read
+// as "no problem here".
+func TestConsoleBootstrapImportWithNoHookStillRenders(t *testing.T) {
+	c := &CLI{}
+	out := captureStdout(t, func() { _ = c.handleShowSystem([]string{"bootstrap-import"}) })
+	if !strings.Contains(out, "not-recorded") {
+		t.Errorf("nil hook must render an explicit not-recorded state:\n%s", out)
+	}
+}

--- a/pkg/cli/cli_show_system.go
+++ b/pkg/cli/cli_show_system.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/psaab/xpf/pkg/bootstrapshow"
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpformat "github.com/psaab/xpf/pkg/dataplane/userspace/format"
@@ -232,6 +233,24 @@ func (c *CLI) showCoreDumps() error {
 	if !found {
 		fmt.Println("No core dumps found")
 	}
+	return nil
+}
+
+// showBootstrapImport renders the day-0 / bootstrap config-import outcome
+// (#4184) recorded at boot — the answer to "why didn't my day-0 config apply?"
+// (#6496).
+//
+// Before this the outcome existed only in the loopback /health JSON, so the
+// operator standing at a fresh box in this very CLI had to know to leave it
+// and curl 127.0.0.1:8080/health. It renders through pkg/bootstrapshow, the
+// same implementation the gRPC ShowText path uses, so the console and the
+// remote `cli` cannot disagree about the same recorded fact.
+func (c *CLI) showBootstrapImport() error {
+	snap := bootstrapshow.Snapshot{}
+	if c.bootstrapImportFn != nil {
+		snap = c.bootstrapImportFn()
+	}
+	bootstrapshow.Render(os.Stdout, snap)
 	return nil
 }
 
@@ -1074,6 +1093,9 @@ func (c *CLI) handleShowSystem(args []string) error {
 
 	case "core-dumps":
 		return c.showCoreDumps()
+
+	case "bootstrap-import":
+		return c.showBootstrapImport()
 
 	case "license":
 		fmt.Println("License: open-source (no license required)")

--- a/pkg/cmdtree/tree.go
+++ b/pkg/cmdtree/tree.go
@@ -687,7 +687,8 @@ var OperationalTree = map[string]*Node{
 			"rollback": {Desc: "Show rolled back configuration", Children: map[string]*Node{
 				"compare": {Desc: "Compare rollback with active config"},
 			}},
-			"backup-router": {Desc: "Show backup router configuration"},
+			"backup-router":    {Desc: "Show backup router configuration"},
+			"bootstrap-import": {Desc: "Show the day-0 / bootstrap configuration import outcome"},
 			"buffers": {Desc: "Show buffer utilization", Children: map[string]*Node{
 				"detail": {Desc: "Show detailed per-map statistics"},
 			}},

--- a/pkg/cmdtree/tree_bootstrap_import_6496_test.go
+++ b/pkg/cmdtree/tree_bootstrap_import_6496_test.go
@@ -1,0 +1,44 @@
+package cmdtree
+
+import "testing"
+
+// #6496: `show system bootstrap-import` must exist in the operational tree.
+//
+// The tree is the single source of truth for tab completion and `?` help
+// across the local CLI, the remote CLI, and gRPC (CLAUDE.md "Command Trees").
+// A dispatcher case with no tree node is reachable only by an operator who
+// already knows the exact string — which is nobody on day zero, when this
+// command is the one they need. RED on revert: delete the node and the lookup
+// below fails while every dispatcher still "works".
+func TestShowSystemBootstrapImportNodeExists(t *testing.T) {
+	show, ok := OperationalTree["show"]
+	if !ok {
+		t.Fatal("no `show` node in the operational tree")
+	}
+	sys, ok := show.Children["system"]
+	if !ok {
+		t.Fatal("no `show system` node in the operational tree")
+	}
+	n, ok := sys.Children["bootstrap-import"]
+	if !ok {
+		t.Fatal("`show system bootstrap-import` missing — the day-0 import " +
+			"verdict is not tab-completable or discoverable via `?` (#6496)")
+	}
+	if n.Desc == "" {
+		t.Error("`show system bootstrap-import` has no description — `?` help " +
+			"would render a blank line")
+	}
+}
+
+// The node must also be OFFERED by the completion walk the CLIs actually call,
+// not merely present in the map. A node reachable only by direct map lookup is
+// still invisible at the prompt.
+func TestShowSystemBootstrapImportIsCompleted(t *testing.T) {
+	got := CompleteFromTree(OperationalTree, []string{"show", "system"}, "bootstrap", nil)
+	for _, c := range got {
+		if c == "bootstrap-import" {
+			return
+		}
+	}
+	t.Fatalf("`show system bootstrap-` does not complete to bootstrap-import; got %v", got)
+}

--- a/pkg/daemon/daemon_bootstrap_import_vocab_6496_test.go
+++ b/pkg/daemon/daemon_bootstrap_import_vocab_6496_test.go
@@ -63,3 +63,34 @@ func TestFailedFlagTracksTheFailedStatusOnly(t *testing.T) {
 		t.Errorf("Error = %q, want the recorded detail", got.Error)
 	}
 }
+
+// bootstrapShowSnapshot is the ONE conversion both wiring sites use (the gRPC
+// server config and the in-process CLI hook). Every field must survive it: a
+// dropped Error is a box that reports import-failed with no reason, and a
+// dropped Failed is one that reports the failure without the remediation
+// block. RED on revert: drop any field from the conversion.
+func TestBootstrapShowSnapshotCarriesEveryField(t *testing.T) {
+	d := &Daemon{}
+	d.recordBootstrapImport(bootstrapImportFailed, "day-0 config REJECTED: bad stanza")
+
+	want := d.BootstrapImportSnapshot()
+	got := d.bootstrapShowSnapshot()
+
+	if got.Status != want.Status {
+		t.Errorf("Status = %q, want %q", got.Status, want.Status)
+	}
+	if got.Error != want.Error {
+		t.Errorf("Error = %q, want %q — an import-failed with no reason is the "+
+			"state this command exists to avoid", got.Error, want.Error)
+	}
+	if got.UnixSec != want.UnixSec {
+		t.Errorf("UnixSec = %d, want %d", got.UnixSec, want.UnixSec)
+	}
+	if got.Failed != want.Failed {
+		t.Errorf("Failed = %v, want %v", got.Failed, want.Failed)
+	}
+	if got.UnixSec == 0 {
+		t.Error("recordBootstrapImport did not stamp a time; the conversion " +
+			"assertion above would pass vacuously")
+	}
+}

--- a/pkg/daemon/daemon_bootstrap_import_vocab_6496_test.go
+++ b/pkg/daemon/daemon_bootstrap_import_vocab_6496_test.go
@@ -1,0 +1,65 @@
+package daemon
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/bootstrapshow"
+)
+
+// #6496: every status this package can RECORD must be one the operator-facing
+// renderer understands.
+//
+// The four constants are aliases of the bootstrapshow vocabulary, so today
+// this holds by construction. The test is here because that construction is
+// exactly what a future change would break: adding a fifth outcome as a bare
+// string literal (the shape the constants had before #6496) compiles, records,
+// reaches /health, and reaches `show system bootstrap-import` — where the
+// operator is told "unrecognized status — this xpfd records a state this CLI
+// does not know". That is a silent-until-the-worst-moment failure on the day-0
+// surface, so it is asserted rather than left to review.
+func TestEveryRecordableStatusIsRenderable(t *testing.T) {
+	// Every status recordBootstrapImport can be called with, by name so a new
+	// constant that is not added here is visible as an omission in review.
+	recordable := []string{
+		bootstrapImportOK,
+		bootstrapImportLoadedDB,
+		bootstrapImportNoConfig,
+		bootstrapImportFailed,
+	}
+	for _, st := range recordable {
+		var b bytes.Buffer
+		bootstrapshow.Render(&b, bootstrapshow.Snapshot{Status: st})
+		if strings.Contains(b.String(), "unrecognized status") {
+			t.Errorf("daemon can record status %q but bootstrapshow does not "+
+				"recognize it — the operator would be told the CLI does not "+
+				"understand its own daemon:\n%s", st, b.String())
+		}
+	}
+}
+
+// The Failed flag and the failure STATUS must agree. /health keys
+// bootstrap_import_failed off Status == bootstrapImportFailed, and the
+// renderer keys its remediation block off Snapshot.Failed; if a caller ever
+// sets one without the other, one surface calls the box healthy while the
+// other calls it broken.
+func TestFailedFlagTracksTheFailedStatusOnly(t *testing.T) {
+	d := &Daemon{}
+	for _, st := range []string{
+		bootstrapImportOK, bootstrapImportLoadedDB, bootstrapImportNoConfig,
+	} {
+		d.recordBootstrapImport(st, "")
+		if got := d.BootstrapImportSnapshot(); got.Failed {
+			t.Errorf("status %q must not report Failed", st)
+		}
+	}
+	d.recordBootstrapImport(bootstrapImportFailed, "boom")
+	got := d.BootstrapImportSnapshot()
+	if !got.Failed {
+		t.Error("import-failed must report Failed")
+	}
+	if got.Error != "boom" {
+		t.Errorf("Error = %q, want the recorded detail", got.Error)
+	}
+}

--- a/pkg/daemon/daemon_health.go
+++ b/pkg/daemon/daemon_health.go
@@ -85,6 +85,23 @@ func (d *Daemon) BootstrapImportSnapshot() BootstrapImport {
 	}
 }
 
+// bootstrapShowSnapshot converts the recorded outcome into the operator-facing
+// shape (#6496). It exists as a named method rather than as a closure at each
+// wiring site because there are TWO sites — the gRPC server config
+// (daemon_run_servers.go) and the in-process CLI hook (daemon_run.go) — and a
+// field silently dropped from one of two hand-copied conversions is exactly the
+// divergence the shared renderer was introduced to prevent. One conversion,
+// directly testable.
+func (d *Daemon) bootstrapShowSnapshot() bootstrapshow.Snapshot {
+	b := d.BootstrapImportSnapshot()
+	return bootstrapshow.Snapshot{
+		Status:  b.Status,
+		Error:   b.Error,
+		UnixSec: b.UnixSec,
+		Failed:  b.Failed,
+	}
+}
+
 // recordCompileFailure tracks a dataplane compile failure and emits an
 // escalating log (#758). The first failure remains a single WARN;
 // every Nth repeat re-emits at ERROR level so an operator tailing the

--- a/pkg/daemon/daemon_health.go
+++ b/pkg/daemon/daemon_health.go
@@ -5,24 +5,33 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/psaab/xpf/pkg/bootstrapshow"
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/logging"
 )
 
 // Bootstrap-import outcome constants (#4184). Recorded once at boot by
-// recordBootstrapImport and surfaced via /health + an event.
+// recordBootstrapImport and surfaced via /health, an event, and (#6496)
+// `show system bootstrap-import` on the CLI + gRPC paths.
+//
+// These are ALIASES of the bootstrapshow vocabulary, not independent literals.
+// The renderer maps each status to an operator-facing explanation and reports
+// anything it does not recognise as unrecognised, so a status recorded here
+// that the renderer was never taught would surface to the operator as
+// "unrecognized status". Defining them as aliases makes that unreachable: the
+// value written and the value rendered are the same constant.
 const (
 	// bootstrapImportOK: the text config file was imported and committed.
-	bootstrapImportOK = "ok"
+	bootstrapImportOK = bootstrapshow.StatusOK
 	// bootstrapImportLoadedDB: an active config was already present in the DB;
 	// no file import was attempted (normal steady-state boot).
-	bootstrapImportLoadedDB = "loaded-from-db"
+	bootstrapImportLoadedDB = bootstrapshow.StatusLoadedDB
 	// bootstrapImportNoConfig: no text config file present (factory/fresh
 	// boot). Expected — NOT a failure and NOT health-degrading.
-	bootstrapImportNoConfig = "no-config"
+	bootstrapImportNoConfig = bootstrapshow.StatusNoConfig
 	// bootstrapImportFailed: a text config file was present but could not be
 	// read/parsed/committed (or was rejected by the device-map preflight).
-	bootstrapImportFailed = "import-failed"
+	bootstrapImportFailed = bootstrapshow.StatusFailed
 )
 
 // BootstrapImport is a snapshot of the day-0 / bootstrap config-import

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -12,7 +12,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/psaab/xpf/pkg/bootstrapshow"
 	"github.com/psaab/xpf/pkg/cli"
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
@@ -653,15 +652,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		// the gRPC ShowText renderer read, so an operator standing at a fresh
 		// box can answer "why didn't my day-0 config apply?" from the CLI they
 		// are already in instead of leaving it to curl the loopback REST API.
-		shell.SetBootstrapImportFn(func() bootstrapshow.Snapshot {
-			b := d.BootstrapImportSnapshot()
-			return bootstrapshow.Snapshot{
-				Status:  b.Status,
-				Error:   b.Error,
-				UnixSec: b.UnixSec,
-				Failed:  b.Failed,
-			}
-		})
+		shell.SetBootstrapImportFn(d.bootstrapShowSnapshot)
 		shell.SetRPMResultsFn(func() []*rpm.ProbeResult {
 			if d.rpm != nil {
 				return d.rpm.Results()

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/psaab/xpf/pkg/bootstrapshow"
 	"github.com/psaab/xpf/pkg/cli"
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
@@ -647,6 +648,20 @@ func (d *Daemon) Run(ctx context.Context) error {
 		// state out-of-band while a concurrent commit / HA-sync / reconcile
 		// re-creates the just-erased .configdb SSOT or re-renders the wiped secrets.
 		shell.SetFactoryResetFn(d.factoryReset)
+		// #6496: the day-0 config-import verdict for `show system
+		// bootstrap-import` on the console. Same recorded snapshot /health and
+		// the gRPC ShowText renderer read, so an operator standing at a fresh
+		// box can answer "why didn't my day-0 config apply?" from the CLI they
+		// are already in instead of leaving it to curl the loopback REST API.
+		shell.SetBootstrapImportFn(func() bootstrapshow.Snapshot {
+			b := d.BootstrapImportSnapshot()
+			return bootstrapshow.Snapshot{
+				Status:  b.Status,
+				Error:   b.Error,
+				UnixSec: b.UnixSec,
+				Failed:  b.Failed,
+			}
+		})
 		shell.SetRPMResultsFn(func() []*rpm.ProbeResult {
 			if d.rpm != nil {
 				return d.rpm.Results()

--- a/pkg/daemon/daemon_run_servers.go
+++ b/pkg/daemon/daemon_run_servers.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/psaab/xpf/pkg/api"
-	"github.com/psaab/xpf/pkg/bootstrapshow"
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/eventengine"
 	"github.com/psaab/xpf/pkg/feeds"
@@ -142,15 +141,7 @@ func (d *Daemon) startGRPCServer(ctx context.Context, wg *sync.WaitGroup, eventB
 		// authenticated, and the failure REASON is the entire point of the
 		// command (#5031 withholds it from /health because that endpoint is
 		// unauthenticated, which is a different question from privilege).
-		BootstrapImportFn: func() bootstrapshow.Snapshot {
-			b := d.BootstrapImportSnapshot()
-			return bootstrapshow.Snapshot{
-				Status:  b.Status,
-				Error:   b.Error,
-				UnixSec: b.UnixSec,
-				Failed:  b.Failed,
-			}
-		},
+		BootstrapImportFn: d.bootstrapShowSnapshot,
 		RPMResultsFn: func() []*rpm.ProbeResult {
 			if d.rpm != nil {
 				return d.rpm.Results()

--- a/pkg/daemon/daemon_run_servers.go
+++ b/pkg/daemon/daemon_run_servers.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/psaab/xpf/pkg/api"
+	"github.com/psaab/xpf/pkg/bootstrapshow"
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/eventengine"
 	"github.com/psaab/xpf/pkg/feeds"
@@ -133,6 +134,23 @@ func (d *Daemon) startGRPCServer(ctx context.Context, wg *sync.WaitGroup, eventB
 		Cluster:    d.cluster,
 		DHCP:       d.dhcp,
 		DHCPServer: d.dhcpServer,
+		// #6496: the day-0 config-import verdict for `show system
+		// bootstrap-import`. Same recorded snapshot /health reports below and
+		// the in-process CLI reads (daemon_run.go SetBootstrapImportFn), so
+		// the three surfaces cannot disagree about whether a day-0 config
+		// applied. Unlike /health this path renders b.Error: it is
+		// authenticated, and the failure REASON is the entire point of the
+		// command (#5031 withholds it from /health because that endpoint is
+		// unauthenticated, which is a different question from privilege).
+		BootstrapImportFn: func() bootstrapshow.Snapshot {
+			b := d.BootstrapImportSnapshot()
+			return bootstrapshow.Snapshot{
+				Status:  b.Status,
+				Error:   b.Error,
+				UnixSec: b.UnixSec,
+				Failed:  b.Failed,
+			}
+		},
 		RPMResultsFn: func() []*rpm.ProbeResult {
 			if d.rpm != nil {
 				return d.rpm.Results()

--- a/pkg/grpcapi/authz_methods.go
+++ b/pkg/grpcapi/authz_methods.go
@@ -304,6 +304,13 @@ var showTextElevatedTopics = map[string]config.LoginClassPermission{
 // (TestEveryShowTextTopicHasAPermission_5278 parses server_show.go), which is
 // what makes it a coverage claim rather than an assertion of good intent. Keys
 // ending in ':' are prefix rules, exactly as above.
+//
+// #6496: "bootstrap-import" sits here at PermView, matching the coarse model
+// the rest of `show` uses (PermView gates every show command) and matching
+// "login" below, which renders login configuration at the same level. Its
+// error detail is withheld from /health because that endpoint is
+// UNAUTHENTICATED (#5031) — a different distinction from privilege level;
+// every caller reaching here has authenticated.
 var showTextViewTopics = map[string]bool{
 	"address-book":                      true,
 	"alarms":                            true,
@@ -312,17 +319,11 @@ var showTextViewTopics = map[string]bool{
 	"applications":                      true,
 	"backup-router":                     true,
 	"bfd-peers":                         true,
-	// #6496: the day-0 config-import verdict. PermView, matching the coarse
-	// model the rest of `show` uses (PermView gates every show command) and
-	// matching "login" above, which renders login configuration at the same
-	// level. The topic's error detail is withheld from /health because that
-	// endpoint is UNAUTHENTICATED (#5031), which is a different distinction
-	// from privilege level — every caller reaching here has authenticated.
-	"bootstrap-import": true,
-	"buffers":          true,
-	"buffers-detail":   true,
-	"chassis":          true,
-	"chassis-cluster":  true,
+	"bootstrap-import":                  true,
+	"buffers":                           true,
+	"buffers-detail":                    true,
+	"chassis":                           true,
+	"chassis-cluster":                   true,
 	"chassis-cluster-control-plane-statistics": true,
 	"chassis-cluster-data-plane-fairness":      true,
 	"chassis-cluster-data-plane-flows":         true,

--- a/pkg/grpcapi/authz_methods.go
+++ b/pkg/grpcapi/authz_methods.go
@@ -312,10 +312,17 @@ var showTextViewTopics = map[string]bool{
 	"applications":                      true,
 	"backup-router":                     true,
 	"bfd-peers":                         true,
-	"buffers":                           true,
-	"buffers-detail":                    true,
-	"chassis":                           true,
-	"chassis-cluster":                   true,
+	// #6496: the day-0 config-import verdict. PermView, matching the coarse
+	// model the rest of `show` uses (PermView gates every show command) and
+	// matching "login" above, which renders login configuration at the same
+	// level. The topic's error detail is withheld from /health because that
+	// endpoint is UNAUTHENTICATED (#5031), which is a different distinction
+	// from privilege level — every caller reaching here has authenticated.
+	"bootstrap-import": true,
+	"buffers":          true,
+	"buffers-detail":   true,
+	"chassis":          true,
+	"chassis-cluster":  true,
 	"chassis-cluster-control-plane-statistics": true,
 	"chassis-cluster-data-plane-fairness":      true,
 	"chassis-cluster-data-plane-flows":         true,

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/psaab/xpf/pkg/authz"
+	"github.com/psaab/xpf/pkg/bootstrapshow"
 	"github.com/psaab/xpf/pkg/cluster"
 	"github.com/psaab/xpf/pkg/clusterfailover"
 	"github.com/psaab/xpf/pkg/config"
@@ -130,6 +131,13 @@ type Config struct {
 	// unit-test / no-daemon build, where showSystemServices falls back to the
 	// documented loopback defaults.
 	ListenersFn func() sysservices.Listeners
+	// BootstrapImportFn returns the recorded day-0 / bootstrap config-import
+	// outcome for `show system bootstrap-import` (#6496). Wired by the daemon
+	// to Daemon.BootstrapImportSnapshot — the SAME recorded snapshot /health
+	// reports, so the two surfaces cannot disagree about whether a day-0
+	// config applied. nil in a unit-test / no-daemon build, where the topic
+	// reports that the daemon has not recorded an outcome.
+	BootstrapImportFn func() bootstrapshow.Snapshot
 	// PeerLookupFn overrides how the primary listener's #5278 authorization
 	// gate learns which local account owns a connection. Production leaves it
 	// nil and the gate calls authz.LookupPeer, which reads the kernel's socket
@@ -179,6 +187,10 @@ type Server struct {
 	// `show system services` (#6385). Wired from Config.ListenersFn; nil in a
 	// no-daemon unit-test build.
 	listenersFn func() sysservices.Listeners
+	// bootstrapImportFn returns the recorded day-0 import outcome for the
+	// `bootstrap-import` ShowText topic (#6496). Wired from
+	// Config.BootstrapImportFn; nil in a no-daemon unit-test build.
+	bootstrapImportFn func() bootstrapshow.Snapshot
 	// requestedAddr is the primary gRPC bind requested at construction
 	// (--grpc-addr). Immutable, so it is read without effMu; it is the fallback
 	// address reported while pre-bind and on a bind failure (#6385/#6401).
@@ -315,6 +327,7 @@ func NewServer(addr string, cfg Config) *Server {
 		fabricPeerAddrFn:      cfg.FabricPeerAddrFn,
 		fabricVRFDevice:       cfg.FabricVRFDevice,
 		listenersFn:           cfg.ListenersFn,
+		bootstrapImportFn:     cfg.BootstrapImportFn,
 		peerLookupFn:          cfg.PeerLookupFn,
 	}
 }

--- a/pkg/grpcapi/server_fabric_secret_render_6532_test.go
+++ b/pkg/grpcapi/server_fabric_secret_render_6532_test.go
@@ -114,7 +114,8 @@ var fabricSecretSentinels = []string{
 // Parameterized (prefix:) topics carry a representative argument.
 var showTextAuditTopics = []string{
 	"address-book", "alarms", "alg", "application-identification-status",
-	"applications", "backup-router", "bfd-peers", "buffers", "buffers-detail",
+	"applications", "backup-router", "bfd-peers", "bootstrap-import",
+	"buffers", "buffers-detail",
 	"chassis", "chassis-cluster", "chassis-cluster-control-plane-statistics",
 	"chassis-cluster-data-plane-fairness", "chassis-cluster-data-plane-flows",
 	"chassis-cluster-data-plane-interfaces", "chassis-cluster-data-plane-statistics",

--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/psaab/xpf/pkg/bootstrapshow"
 	"github.com/psaab/xpf/pkg/config"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 	"google.golang.org/grpc/codes"
@@ -498,6 +499,16 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 
 	case "core-dumps":
 		s.showCoreDumps(cfg, &buf)
+
+	case "bootstrap-import":
+		// #6496: the day-0 config-import verdict, in-band. Renders through the
+		// shared bootstrapshow package so this and the in-process CLI cannot
+		// disagree about the same recorded fact.
+		snap := bootstrapshow.Snapshot{}
+		if s.bootstrapImportFn != nil {
+			snap = s.bootstrapImportFn()
+		}
+		bootstrapshow.Render(&buf, snap)
 
 	case "task":
 		s.showTask(cfg, &buf)

--- a/pkg/grpcapi/server_show_bootstrap_import_6496_test.go
+++ b/pkg/grpcapi/server_show_bootstrap_import_6496_test.go
@@ -26,9 +26,14 @@ import (
 // healthy default for a failed box.
 func TestShowTextBootstrapImportRendersTheWiredSnapshot(t *testing.T) {
 	const detail = `day-0 config REJECTED: unknown statement "dataplane-type"`
-	s := &Server{
-		store: newConfigStore(t, t.TempDir()+"/xpf.conf"),
-		bootstrapImportFn: func() bootstrapshow.Snapshot {
+	// Constructed through NewServer, NOT as a bare &Server{...}: the wiring
+	// under test is Config.BootstrapImportFn -> server.bootstrapImportFn, and a
+	// test that sets the private field directly stays GREEN with that assignment
+	// deleted. It did, on the first draft — the mutation that removed the
+	// NewServer line left this file passing, which is what sent the tests back.
+	s := NewServer("127.0.0.1:0", Config{
+		Store: newConfigStore(t, t.TempDir()+"/xpf.conf"),
+		BootstrapImportFn: func() bootstrapshow.Snapshot {
 			return bootstrapshow.Snapshot{
 				Status:  bootstrapshow.StatusFailed,
 				Error:   detail,
@@ -36,7 +41,7 @@ func TestShowTextBootstrapImportRendersTheWiredSnapshot(t *testing.T) {
 				Failed:  true,
 			}
 		},
-	}
+	})
 	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "bootstrap-import"})
 	if err != nil {
 		t.Fatalf("ShowText(bootstrap-import) error = %v", err)
@@ -62,10 +67,10 @@ func TestShowTextBootstrapImportMatchesTheSharedRenderer(t *testing.T) {
 		{Status: bootstrapshow.StatusFailed, Error: "boom", UnixSec: 1755792000, Failed: true},
 		{},
 	} {
-		s := &Server{
-			store:             newConfigStore(t, t.TempDir()+"/xpf.conf"),
-			bootstrapImportFn: func() bootstrapshow.Snapshot { return snap },
-		}
+		s := NewServer("127.0.0.1:0", Config{
+			Store:             newConfigStore(t, t.TempDir()+"/xpf.conf"),
+			BootstrapImportFn: func() bootstrapshow.Snapshot { return snap },
+		})
 		resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "bootstrap-import"})
 		if err != nil {
 			t.Fatalf("ShowText(%q) error = %v", snap.Status, err)
@@ -84,7 +89,9 @@ func TestShowTextBootstrapImportMatchesTheSharedRenderer(t *testing.T) {
 // unit build) must still get a rendered answer, not an empty body an operator
 // would read as "nothing wrong".
 func TestShowTextBootstrapImportWithNoHookStillRenders(t *testing.T) {
-	s := &Server{store: newConfigStore(t, t.TempDir()+"/xpf.conf")}
+	s := NewServer("127.0.0.1:0", Config{
+		Store: newConfigStore(t, t.TempDir()+"/xpf.conf"),
+	})
 	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "bootstrap-import"})
 	if err != nil {
 		t.Fatalf("ShowText(bootstrap-import) with nil hook error = %v", err)

--- a/pkg/grpcapi/server_show_bootstrap_import_6496_test.go
+++ b/pkg/grpcapi/server_show_bootstrap_import_6496_test.go
@@ -1,0 +1,95 @@
+package grpcapi
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/bootstrapshow"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #6496: `show system bootstrap-import` over the gRPC ShowText path.
+//
+// The recorded day-0 import outcome had exactly one renderer — the /health
+// JSON on the loopback REST API — so an operator at a fresh box could not
+// answer "why didn't my day-0 config apply?" from the CLI they were in. These
+// bind the wiring end-to-end: the topic must be dispatched, it must render the
+// snapshot the DAEMON supplied (not a default), and it must render it through
+// the shared package so this and the in-process CLI cannot diverge.
+
+// The dispatcher must actually consult the wired hook. RED on revert: drop
+// `bootstrapImportFn: cfg.BootstrapImportFn` from NewServer, or stop calling
+// the hook in the dispatcher, and the staged detail disappears from the render
+// while the topic still "works" — the exact shape of a surface that reports a
+// healthy default for a failed box.
+func TestShowTextBootstrapImportRendersTheWiredSnapshot(t *testing.T) {
+	const detail = `day-0 config REJECTED: unknown statement "dataplane-type"`
+	s := &Server{
+		store: newConfigStore(t, t.TempDir()+"/xpf.conf"),
+		bootstrapImportFn: func() bootstrapshow.Snapshot {
+			return bootstrapshow.Snapshot{
+				Status:  bootstrapshow.StatusFailed,
+				Error:   detail,
+				UnixSec: 1755792000,
+				Failed:  true,
+			}
+		},
+	}
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "bootstrap-import"})
+	if err != nil {
+		t.Fatalf("ShowText(bootstrap-import) error = %v", err)
+	}
+	out := resp.GetOutput()
+	if !strings.Contains(out, "import-failed") {
+		t.Errorf("wired status not rendered:\n%s", out)
+	}
+	if !strings.Contains(out, detail) {
+		t.Errorf("wired error detail not rendered — the reason is the whole point "+
+			"of the command, and /health cannot carry it (#5031):\n%s", out)
+	}
+}
+
+// The gRPC render must be BYTE-IDENTICAL to pkg/bootstrapshow's, so the remote
+// `cli`, the in-process console CLI (which calls Render directly) and this path
+// cannot drift into showing different answers for one recorded fact.
+func TestShowTextBootstrapImportMatchesTheSharedRenderer(t *testing.T) {
+	for _, snap := range []bootstrapshow.Snapshot{
+		{Status: bootstrapshow.StatusOK, UnixSec: 1755792000},
+		{Status: bootstrapshow.StatusNoConfig, UnixSec: 1755792000},
+		{Status: bootstrapshow.StatusLoadedDB, UnixSec: 1755792000},
+		{Status: bootstrapshow.StatusFailed, Error: "boom", UnixSec: 1755792000, Failed: true},
+		{},
+	} {
+		s := &Server{
+			store:             newConfigStore(t, t.TempDir()+"/xpf.conf"),
+			bootstrapImportFn: func() bootstrapshow.Snapshot { return snap },
+		}
+		resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "bootstrap-import"})
+		if err != nil {
+			t.Fatalf("ShowText(%q) error = %v", snap.Status, err)
+		}
+		var want bytes.Buffer
+		bootstrapshow.Render(&want, snap)
+		if resp.GetOutput() != want.String() {
+			t.Errorf("status %q: ShowText render diverges from bootstrapshow.Render\n"+
+				"--- ShowText ---\n%s\n--- shared ---\n%s",
+				snap.Status, resp.GetOutput(), want.String())
+		}
+	}
+}
+
+// A `cli` reaching a daemon that never recorded an outcome (or a no-daemon
+// unit build) must still get a rendered answer, not an empty body an operator
+// would read as "nothing wrong".
+func TestShowTextBootstrapImportWithNoHookStillRenders(t *testing.T) {
+	s := &Server{store: newConfigStore(t, t.TempDir()+"/xpf.conf")}
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "bootstrap-import"})
+	if err != nil {
+		t.Fatalf("ShowText(bootstrap-import) with nil hook error = %v", err)
+	}
+	if !strings.Contains(resp.GetOutput(), "not-recorded") {
+		t.Errorf("nil hook must render an explicit not-recorded state:\n%s", resp.GetOutput())
+	}
+}


### PR DESCRIPTION
Closes #6496

## What was wrong

The #4184 work records the boot-time config-import outcome (`ok` / `loaded-from-db` / `no-config` / `import-failed` + error detail) and emits a `BOOTSTRAP_IMPORT_FAILED` event — but rendered it in exactly one place: the `/health` JSON on the loopback REST API. `grep -rn "bootstrap_import_status\|BootstrapImportStatus" pkg/cmdtree pkg/grpcapi proto` returned nothing.

The operator that feature exists for is standing at a fresh box on day zero with the `cli` prompt open, asking the exact question the status answers. They could not get it from the CLI they were in — they had to know to leave it and `curl 127.0.0.1:8080/health`, documented only in the bare-metal device-map doc, not in the general day-0 flow.

## What this does

`show system bootstrap-import` on the operational tree, the in-process console CLI, the gRPC `ShowText` dispatcher, and the remote `cli` client. **No proto change was needed** — `ShowText(topic)` already exists.

```
> show system bootstrap-import
Bootstrap configuration import:
  Status:   import-failed
  Meaning:  a configuration file was present but could NOT be applied — see Error below
  Recorded: 2026-08-21 14:02:11 UTC
  Error:    day-0 config REJECTED by commit-check: ...

  The box is in the lifeline-safe bootstrap state; the running
  configuration is NOT the one on the day-0 medium. ...
```

**Rendering is single-sourced** in a new leaf package `pkg/bootstrapshow`, in the `pkg/natshow` idiom. Two renderings of one recorded fact that disagree is *always* a bug, never a legitimate difference — so this is single-sourced rather than duplicated-and-cross-checked, and both call paths are asserted byte-identical to it.

That package also owns the **status vocabulary**; `pkg/daemon`'s four unexported constants become aliases of it. The renderer maps each status to a meaning and reports anything else as `unrecognized status`, so a status recorded but never taught to the renderer would surface to the day-0 operator as the CLI not understanding its own daemon. Aliasing makes that unreachable, and a test asserts every recordable status renders without the marker.

**The error detail is rendered here, deliberately.** `/health` withholds it (#5031): that endpoint is unauthenticated and an import error quotes the offending config, which can echo a submitted secret. The CLI/gRPC paths are authenticated, so they are the *only* surfaces that can answer "why didn't my config apply" with the reason — the point of the command. Topic sits at `PermView`, matching the coarse model the rest of `show` uses and matching `login`, which renders login configuration at the same level.

## Acceptance criteria

- [x] Renders status, error detail, and timestamp via the gRPC path, matching the /health payload (same recorded snapshot, one conversion).
- [x] `docs/install-images.md` day-0 troubleshooting references the command **and** the /health field.
- [x] `import-failed` remains non-503 on /health (untouched), and the CLI rendering is likewise informational — `Render` has no failure return; a test asserts non-failure statuses never render the remediation block.

## Two of the repo's own gates were load-bearing

`TestEveryShowTextTopicHasAPermission_5278` required the authz entry, and `TestShowTextTopicAuditCoverageIsComplete` required the topic to join the #6532 fabric secret-render sweep. The second is worth a reviewer's attention: **`ShowText` is reachable from the peer chassis over the fabric**, not only from loopback. That is not a new disclosure class here (an HA peer already receives the full config over config-sync), but it is why the topic is *audited* rather than assumed safe.

## Validation

`go test ./... -count=1 -p 2` — **rc=0**, no failures.

> One earlier `./...` run reported `FAIL github.com/psaab/xpf/pkg/daemon 5.221s` with **`signal: killed`** and no `--- FAIL` line — a kernel kill under parallel load on a shared box, not a test failure. `pkg/daemon` passes standalone (rc=0, twice) and the whole suite passes at `-p 2`. Recording it rather than hiding it.

### Mutation proofs

Exit codes from `$?`, never through a pipe. One line per mutation; `git checkout --` restore verified (`git status --porcelain` empty) and rc back to 0 between each.

| # | Mutation (one line) | rc | Cell that reddened |
|---|---|---|---|
| M1 | drop `bootstrapImportFn: cfg.BootstrapImportFn` from `NewServer` | 1 | `RendersTheWiredSnapshot` + `MatchesTheSharedRenderer` |
| M2 | empty the body of `CLI.SetBootstrapImportFn` | 1 | `HandleShowSystemDispatchesBootstrapImport` + `ConsoleBootstrapImportMatchesTheSharedRenderer` |
| M3 | drop `Error` from `Daemon.bootstrapShowSnapshot` | 1 | `BootstrapShowSnapshotCarriesEveryField` |
| M4 | delete the cmdtree node | 1 | `NodeExists` + `IsCompleted` |
| M5 | collapse `loaded-from-db`'s meaning into `ok`'s in `explain()` | 1 | `EveryStatusRendersItsOwnMeaning` |
| M6 | topic dispatches but renders `Snapshot{}` instead of the wired one | 1 | `RendersTheWiredSnapshot` + `MatchesTheSharedRenderer` |
| M7 | rename the case label so the topic is unreachable | 1 | `EveryShowTextTopicHasAPermission_5278`, `ShowTextTopicAuditCoverageIsComplete`, + all three topic tests |

### The first draft's tests were unsound, and the mutations are how that surfaced

M1 originally came back **rc=0**. The tests constructed a bare `&Server{bootstrapImportFn: ...}` and assigned `CLI.bootstrapImportFn` directly, so deleting the line that actually connects `Config.BootstrapImportFn` to the server left the whole file green — a mutation at a site the production path never takes proves nothing.

Second commit (`488a6c2`) drives the real seams instead: `NewServer(addr, Config{...})` and `CLI.SetBootstrapImportFn`. The two hand-copied conversion closures in `daemon_run.go` / `daemon_run_servers.go` also became one named `Daemon.bootstrapShowSnapshot` with a field-by-field test — a field dropped from one of two identical conversions is the same divergence the shared renderer exists to prevent, and nothing covered it.

A `-DISABLED` variant of M6 was also discarded first: deleting the whole `case` block reddened as an **unused-import build failure**, which is not an assertion. M6/M7 as recorded both keep the build green (`go build` rc=0 checked before each).

## Scope

- **Does not reach the Rust helper.** Go control plane + docs only; no `userspace-dp`/`userspace-xdp` source, no `.o`.
- **No cluster time used.** All hermetic `go test`; the loss cluster was not touched, deployed to, or smoked.
- **No proto/protoc regeneration** — the existing `ShowText` topic RPC carries it.

## Merge ordering — verified

This PR conflicts with **#7285** (#6495): both add a `show system <topic>` through the same seams, so they insert at the same anchors in seven files. The full conflict map and resolution are in #7285's body. Two of the seven (`pkg/cli/cli.go`, `pkg/cli/cli_show_system.go`) do **not** survive a blind union merge — both hunks carry a shared trailing region (struct tail fields, and a function's closing brace), so the closer must be restored by hand.

Merged locally in that order and resolved: `go test ./... -count=1 -p 2` rc=0.

## Docs

`docs/install-images.md` — new "My day-0 config did not apply" triage section: the command, the four statuses, the `/health` equivalent for scripted checks, and why only the CLI can show the reason. `docs/deploy-quickstart.md` — troubleshooting row points at it. `docs/bare-metal-device-map.md` — day-0 visibility section names the command alongside the `/health` fields.
