### PR TITLE
image: assert the #1930 A/B slot registration in the Tier-1 gate

### DIFF
--- a/docs/image-validation.md
+++ b/docs/image-validation.md
@@ -104,13 +104,53 @@ Scenarios:
 
 | Scenario | Proves |
 |---|---|
-| **a** no config drive | factory boot; kernel ≥6.18 + `-generic` flavor; `linux-modules-extra` present (checked via the Mellanox driver dir as the sentinel — the broader mlx5/i40e set rides with it); exactly one kernel; `init_on_alloc=0` on the booted cmdline; **in-guest `xpfd verify-dataplane` PASS**; the `/etc/xpf/appliance` marker present (#7114 — it is what re-enables the factory bootstrap; asserted before the DHCP wait so a bake that stopped writing it fails with its own cause); `fxp0` DHCP; sshd listening with `PermitRootLogin prohibit-password` + `PermitEmptyPasswords no`; no stray `/etc/xpf/xpf.conf` or stamp |
+| **a** no config drive | factory boot; kernel ≥6.18 + `-generic` flavor; `linux-modules-extra` present (checked via the Mellanox driver dir as the sentinel — the broader mlx5/i40e set rides with it); exactly one kernel; `init_on_alloc=0` on the booted cmdline; **in-guest `xpfd verify-dataplane` PASS**; the `/etc/xpf/appliance` marker present (#7114 — it is what re-enables the factory bootstrap; asserted before the DHCP wait so a bake that stopped writing it fails with its own cause); `fxp0` DHCP; sshd listening with `PermitRootLogin prohibit-password` + `PermitEmptyPasswords no`; no stray `/etc/xpf/xpf.conf` or stamp; **#1930 LANE-1 A/B kernel channel live in-guest** (#6494 — both `xpf-A`/`xpf-B` registered exactly once with their own `\EFI\<slot>\shimx64.efi` loader and reachable in BootOrder, `xpf-uefi-slots.service` and `xpf-kernel-promote.service` both ran with `ExecMainStatus=0`, and the promote gate logged its ordinary-boot path) |
 | **b** valid day-0 drive | config validated + installed + committed (hostname applied, CLI shows it); reboot does **not** re-apply (stamp honored). *(The loader installs the config `0600`; the scenario asserts it exists and is non-empty, not the mode.)* |
 | **c** invalid day-0 drive | commit-check REJECT logged, nothing installed, no stamp, factory bootstrap still reachable |
 | **d** resized disk (#1925) | first-boot root auto-grow fills a 20 GiB root disk — root **partition** + ext4 fs both grow past the 8 GiB bake floor, `/etc/xpf/.root-grown` stamped, idempotent across a reboot, ESP still mounted, `verify-dataplane` still PASS; a control instance at the exact bake size proves the grow is a clean no-op (`growpart` NOCHANGE) |
 
 **Pass:** `Validation complete.` with all selected scenarios PASS. Any
 `FAIL:` line blocks the bake.
+
+### Why scenario A asserts the A/B kernel channel (#6494)
+
+The bake stages `/boot/efi/EFI/{xpf-A,xpf-B}` and enables the two #1930
+oneshots, and hard-asserts the signed shim is present. What it cannot assert
+offline is the half that only happens in-guest: UEFI `Boot####` variables live
+in the target's firmware NVRAM, which `virt-customize` cannot write, so
+registration is a first-boot oneshot on the real machine.
+
+That oneshot is deliberately non-fatal on every failure path — a read-only or
+no-efivars platform must still boot ("degraded, not bricked") — and until #6494
+nothing downstream re-read its outcome. So a regression in the ESP disk/part
+parse, the loader-path match, or the `efibootmgr` write shipped a fully
+`validated: true` image whose verify-gated kernel channel was silently
+unavailable. The operator found out when `xpfd upgrade kernel arm` exited 2
+with *"A/B slots not both registered ... the first-boot registration oneshot
+must run first"*.
+
+Note what scenario A does **not** assert about the promotion gate: the
+`promotion gate: clean` journal line. That line is emitted only once the gate
+has exec'd xpfd to run the promote verb. On a factory boot with nothing armed
+the script exits 0 much earlier, logging `no armed kernel candidate recorded`,
+so requiring the former would fail every good image. The gate asserts
+`ExecMainStatus=0` plus that ordinary-boot line, which together prove the unit
+**executed** rather than being skipped by a Condition.
+
+The three slot properties are checked separately because they have three
+different causes: registered *exactly once* (a duplicate makes `BootNext`
+ambiguous — the live #1930 bug, from a label guard anchored at `$`), pointing
+at *its own* `\EFI\<slot>\shimx64.efi` (a label-only match would chainload the
+wrong loader), and present in *BootOrder* (a slot the firmware never reaches is
+not registered in any sense the channel can act on). The verdict functions
+mirror `xpf-uefi-slots`' own shell regexes on purpose: a gate that disagreed
+with the script about what "registered" means would certify a state the script
+would not accept.
+
+Both verdicts are pure functions over captured command output
+(`_efibootmgr_slot_verdict`, `_oneshot_clean_verdict`), unit-tested without a
+hypervisor in `scripts/image/test_validate_ab_slots_6494.py` (run by `make
+selftest`), in the same idiom as `_qemu_img_verdict`.
 
 ---
 

--- a/scripts/image/test_validate_ab_slots_6494.py
+++ b/scripts/image/test_validate_ab_slots_6494.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Hermetic unit tests for the #1930 LANE-1 A/B slot assertions the Tier-1
+gate gained in #6494.
+
+validate.py's scenario A cannot run without a hypervisor and a real baked
+qcow2, but the verdicts it hinges on are pure functions over captured command
+output and ARE testable without one — the _qemu_img_verdict idiom already in
+the file:
+
+  - `_efibootmgr_slot_verdict` — both A/B slots registered exactly once, each
+    with its own signed shim loader, both reachable in BootOrder.
+  - `_oneshot_clean_verdict` — the registration + promotion oneshots RAN and
+    exited 0, with "never ran" distinguished from "ran and failed".
+
+RED on revert: relax any of the three slot properties, or stop distinguishing
+a skipped oneshot from a failed one, and an assertion here flips.
+
+The efibootmgr samples are the real output shape: an entry line is
+"BootXXXX[*]<space>LABEL<TAB>loader-path", where the label is followed by a TAB
+and the path, NOT line-end. Anchoring a label match at $ is the exact miss that
+created duplicate slots live during #1930, so the duplicate case below is a
+regression fixture, not a hypothetical.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_SPEC = importlib.util.spec_from_file_location("validate", _HERE / "validate.py")
+validate = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(validate)
+
+
+def _efibootmgr(order="0003,0004,0000", entries=None):
+    """Render efibootmgr output with a BootOrder and the given entry lines."""
+    if entries is None:
+        entries = [
+            "Boot0003* xpf-A\tHD(1,GPT,1234)/File(\\EFI\\xpf-A\\shimx64.efi)",
+            "Boot0004* xpf-B\tHD(1,GPT,1234)/File(\\EFI\\xpf-B\\shimx64.efi)",
+            "Boot0000* ubuntu\tHD(1,GPT,1234)/File(\\EFI\\ubuntu\\shimx64.efi)",
+        ]
+    head = ["BootCurrent: 0003", "Timeout: 0 seconds", f"BootOrder: {order}"]
+    return "\n".join(head + entries) + "\n"
+
+
+class EfibootmgrSlotVerdictTests(unittest.TestCase):
+    def test_both_slots_registered_once_and_in_bootorder_passes(self):
+        ok, reason = validate._efibootmgr_slot_verdict(_efibootmgr())
+        self.assertTrue(ok, reason)
+
+    def test_missing_slot_fails(self):
+        # The bake staged the ESP dirs but the in-guest oneshot never created
+        # the entry: the whole #6494 failure mode.
+        out = _efibootmgr(entries=[
+            "Boot0003* xpf-A\tHD(1,GPT,1234)/File(\\EFI\\xpf-A\\shimx64.efi)",
+            "Boot0000* ubuntu\tHD(1,GPT,1234)/File(\\EFI\\ubuntu\\shimx64.efi)",
+        ])
+        ok, reason = validate._efibootmgr_slot_verdict(out)
+        self.assertFalse(ok)
+        self.assertIn("xpf-B", reason)
+        self.assertIn("NOT registered", reason)
+
+    def test_neither_slot_registered_fails_naming_both(self):
+        out = _efibootmgr(entries=[
+            "Boot0000* ubuntu\tHD(1,GPT,1234)/File(\\EFI\\ubuntu\\shimx64.efi)",
+        ])
+        ok, reason = validate._efibootmgr_slot_verdict(out)
+        self.assertFalse(ok)
+        self.assertIn("xpf-A", reason)
+        self.assertIn("xpf-B", reason)
+
+    def test_duplicate_slot_fails(self):
+        # The #1930 live bug: a label guard anchored at $ never matched, so
+        # every boot created another entry. A duplicated slot makes BootNext
+        # ambiguous.
+        out = _efibootmgr(order="0003,0005,0004", entries=[
+            "Boot0003* xpf-A\tHD(1,GPT,1234)/File(\\EFI\\xpf-A\\shimx64.efi)",
+            "Boot0005* xpf-A\tHD(1,GPT,1234)/File(\\EFI\\xpf-A\\shimx64.efi)",
+            "Boot0004* xpf-B\tHD(1,GPT,1234)/File(\\EFI\\xpf-B\\shimx64.efi)",
+        ])
+        ok, reason = validate._efibootmgr_slot_verdict(out)
+        self.assertFalse(ok)
+        self.assertIn("registered 2 times", reason)
+
+    def test_right_label_wrong_loader_path_fails(self):
+        # A stale/foreign entry that shares the LABEL but chainloads something
+        # else must NOT count as registered (r1 Codex High on xpf-uefi-slots).
+        out = _efibootmgr(entries=[
+            "Boot0003* xpf-A\tHD(1,GPT,1234)/File(\\EFI\\ubuntu\\shimx64.efi)",
+            "Boot0004* xpf-B\tHD(1,GPT,1234)/File(\\EFI\\xpf-B\\shimx64.efi)",
+        ])
+        ok, reason = validate._efibootmgr_slot_verdict(out)
+        self.assertFalse(ok)
+        self.assertIn("loader path", reason)
+
+    def test_registered_but_absent_from_bootorder_fails(self):
+        # A slot the firmware will never reach is not usable by the channel.
+        out = _efibootmgr(order="0000")
+        ok, reason = validate._efibootmgr_slot_verdict(out)
+        self.assertFalse(ok)
+        self.assertIn("BootOrder", reason)
+
+    def test_no_bootorder_line_fails(self):
+        out = "\n".join([
+            "BootCurrent: 0003",
+            "Boot0003* xpf-A\tHD(1,GPT,1234)/File(\\EFI\\xpf-A\\shimx64.efi)",
+            "Boot0004* xpf-B\tHD(1,GPT,1234)/File(\\EFI\\xpf-B\\shimx64.efi)",
+        ]) + "\n"
+        ok, reason = validate._efibootmgr_slot_verdict(out)
+        self.assertFalse(ok)
+        self.assertIn("BootOrder", reason)
+
+    def test_bare_path_form_without_File_wrapper_passes(self):
+        # efibootmgr renders the loader either as File(\EFI\..) or bare; both
+        # are the same registration, and the shell guard accepts both.
+        out = _efibootmgr(entries=[
+            "Boot0003* xpf-A\tHD(1,GPT,1234)/\\EFI\\xpf-A\\shimx64.efi",
+            "Boot0004* xpf-B\tHD(1,GPT,1234)/\\EFI\\xpf-B\\shimx64.efi",
+        ])
+        ok, reason = validate._efibootmgr_slot_verdict(out)
+        self.assertTrue(ok, reason)
+
+    def test_bootorder_id_case_is_ignored(self):
+        # efibootmgr prints hex ids; firmware/tooling case can differ between
+        # the entry line and the BootOrder list. A case mismatch is not an
+        # unreachable slot, and treating it as one would false-fail a good bake.
+        out = _efibootmgr(order="000a,0000", entries=[
+            "Boot000A* xpf-A\tHD(1,GPT,1234)/File(\\EFI\\xpf-A\\shimx64.efi)",
+            "Boot000B* xpf-B\tHD(1,GPT,1234)/File(\\EFI\\xpf-B\\shimx64.efi)",
+        ])
+        ok, reason = validate._efibootmgr_slot_verdict(out)
+        # xpf-B is genuinely absent from BootOrder here; xpf-A must NOT be.
+        self.assertFalse(ok)
+        self.assertNotIn("xpf-A: registered", reason)
+        self.assertIn("xpf-B", reason)
+
+    def test_empty_output_fails_rather_than_passing_vacuously(self):
+        # An efibootmgr that printed nothing must not read as "all good".
+        ok, _ = validate._efibootmgr_slot_verdict("")
+        self.assertFalse(ok)
+
+
+class OneshotCleanVerdictTests(unittest.TestCase):
+    def test_clean_run_passes(self):
+        ok, reason = validate._oneshot_clean_verdict("u", "0", "active", "success")
+        self.assertTrue(ok, reason)
+
+    def test_nonzero_exit_fails(self):
+        ok, reason = validate._oneshot_clean_verdict("u", "1", "failed", "exit-code")
+        self.assertFalse(ok)
+
+    def test_never_ran_is_distinguished_from_failed(self):
+        # A Condition-skipped unit (never enabled, or ConditionPathExists
+        # /boot/efi did not hold) is a DIFFERENT bake defect from a non-zero
+        # exit, and collapsing them sends the next person to the wrong place.
+        ok, reason = validate._oneshot_clean_verdict("u", "0", "inactive", "")
+        self.assertFalse(ok)
+        self.assertIn("never ran", reason)
+
+        ok, reason = validate._oneshot_clean_verdict("u", "1", "failed", "exit-code")
+        self.assertFalse(ok)
+        self.assertNotIn("never ran", reason)
+
+    def test_timeout_result_fails(self):
+        # TimeoutStartSec=20 tripping is a real, non-hypothetical outcome for
+        # xpf-uefi-slots (a stuck efibootmgr), and it exits with Result=timeout.
+        ok, reason = validate._oneshot_clean_verdict("u", "0", "failed", "timeout")
+        self.assertFalse(ok)
+        self.assertIn("timeout", reason)
+
+
+class ScenarioWiringTests(unittest.TestCase):
+    def test_scenario_a_calls_the_ab_assertion(self):
+        """The verdicts can be perfect and prove nothing if scenario A never
+        calls them. Structural, and RED the moment the call is dropped."""
+        src = (_HERE / "validate.py").read_text()
+        body = src.split("def scenario_a(self):", 1)[1].split("def scenario_b(self):", 1)[0]
+        self.assertIn("self.assert_ab_kernel_channel(", body,
+                      "scenario A does not assert the #1930 A/B kernel channel "
+                      "— the Tier-1 gate would sign a manifest for an image "
+                      "whose kernel can never be upgraded in place (#6494)")
+
+    def test_harness_exposes_the_assertion(self):
+        self.assertTrue(hasattr(validate.Harness, "assert_ab_kernel_channel"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/image/validate.py
+++ b/scripts/image/validate.py
@@ -5,8 +5,11 @@ Boots the baked artifacts under LOCAL incus (instances xpf-image-* —
 never the shared loss cluster) and proves the first-boot contract:
 
   a  no config drive  -> factory bootstrap: boots, xpfd active, fxp0 DHCP,
-     sshd listening, AND in-guest `xpfd verify-dataplane` PASSES against
-     the image's own kernel (the bake gate).
+     sshd listening, in-guest `xpfd verify-dataplane` PASSES against the
+     image's own kernel (the bake gate), AND the #1930 LANE-1 A/B kernel
+     channel actually came up in the guest (#6494): both slots registered
+     with their own signed shim and reachable in BootOrder, and both
+     first-boot oneshots ran clean.
   b  valid day-0 drive -> config validated + installed + committed at first
      boot (hostname applied); a reboot does NOT re-apply (stamp).
   c  invalid day-0 drive -> commit-check REJECT logged, nothing installed,
@@ -33,6 +36,7 @@ Usage:
 import argparse
 import json
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -98,6 +102,140 @@ def _qemu_img_verdict(imginfo, min_bytes):
         return False, (f"virtual-size {vsize} below the {min_bytes}-byte bake floor "
                        "— truncated / incomplete image")
     return True, f"qcow2, virtual-size {vsize / (1024 ** 3):.1f}GiB"
+
+
+# ── #1930 LANE-1 A/B slot registration (#6494) ────────────────────────
+# The bake STAGES /boot/efi/EFI/{xpf-A,xpf-B} and ENABLES xpf-uefi-slots.service
+# + xpf-kernel-promote.service, and hard-asserts the signed shim is there. What
+# it cannot assert offline is the half that only happens in-guest: UEFI Boot####
+# variables live in the target's firmware NVRAM, which virt-customize cannot
+# write, so registration is a first-boot oneshot on the real machine.
+#
+# That oneshot is deliberately NON-FATAL on every failure path ("degraded, not
+# bricked" — a read-only/no-efivars platform must still boot), and nothing
+# downstream re-read its outcome. So a regression in the ESP disk/part parse,
+# the loader-path match, or the efibootmgr write shipped a fully "validated"
+# image whose verify-gated kernel channel was silently unavailable, and the
+# operator discovered it only when `xpfd upgrade kernel arm` exited 2 with "A/B
+# slots not both registered ... the first-boot registration oneshot must run
+# first" (pkg/upgrade/kernel_run.go ErrKernelChannelUnavailable).
+#
+# A gate for a production appliance image should prove the upgrade substrate it
+# ships, not only the files that substrate is made of.
+#
+# The slots the #1930 channel requires. Both must exist; the channel refuses to
+# arm unless BOTH are registered, so one is as unavailable as none.
+_AB_SLOTS = ("xpf-A", "xpf-B")
+
+# An efibootmgr entry line is "BootXXXX[*]<space>LABEL<TAB>loader-path". The
+# label is followed by a TAB and the path, NOT line-end — anchoring at $ is the
+# miss that created duplicate slots live during #1930. Mirrors the shell regex
+# in scripts/image/xpf-uefi-slots register_slot() on purpose: the gate must
+# agree with the script about what "registered" means, or it certifies a state
+# the script would not accept.
+_EFIBOOT_ENTRY_RE = re.compile(
+    r"^Boot([0-9A-Fa-f]{4})\*?[ \t]+(?P<label>\S+)[ \t]+(?P<rest>.*)$")
+_BOOTORDER_RE = re.compile(r"^BootOrder:\s*(?P<order>\S*)\s*$", re.MULTILINE)
+
+
+def _efibootmgr_slot_verdict(out, slots=_AB_SLOTS):
+    """Pure verdict over `efibootmgr` (or `efibootmgr -v`) output: are BOTH
+    #1930 A/B slots registered exactly once, each pointing at its own signed
+    shim, and both reachable in BootOrder? Returns (ok, reason).
+
+    Split out from the scenario so the acceptance criterion is unit-testable
+    without a hypervisor, in the _qemu_img_verdict idiom (#4209 H-9).
+
+    Three separate properties, reported separately, because they have three
+    different causes:
+      - exactly once  -> a duplicate means the registration guard's label match
+                         missed (the #1930 live bug); a duplicate ALSO poisons
+                         BootNext, since which Boot#### the slot means is then
+                         ambiguous.
+      - loader path   -> an entry that merely shares the LABEL but points
+                         elsewhere chainloads the wrong loader.
+      - in BootOrder  -> a slot the firmware will never reach is registered but
+                         unusable, which is not "registered" in any sense the
+                         kernel channel can act on.
+    """
+    ids = {}          # slot -> [Boot#### ids with the RIGHT loader path]
+    wrong_path = {}   # slot -> [rendered lines whose path does not match]
+    for line in out.splitlines():
+        m = _EFIBOOT_ENTRY_RE.match(line.rstrip())
+        if not m:
+            continue
+        label = m.group("label")
+        if label not in slots:
+            continue
+        # efibootmgr prints "...File(\EFI\xpf-A\shimx64.efi)" or the bare
+        # "...\EFI\xpf-A\shimx64.efi". Match the slot's shim path with any
+        # separator between the components and case-insensitively, exactly as
+        # the shell guard does (grep -qiE "EFI.${slot}.shimx64\.efi").
+        want = re.compile(r"EFI.%s.shimx64\.efi" % re.escape(label), re.IGNORECASE)
+        if want.search(m.group("rest")):
+            ids.setdefault(label, []).append(m.group(1))
+        else:
+            wrong_path.setdefault(label, []).append(line.strip())
+
+    problems = []
+    for slot in slots:
+        got = ids.get(slot, [])
+        if not got:
+            bad = wrong_path.get(slot)
+            if bad:
+                problems.append(
+                    f"{slot}: registered but the loader path is NOT "
+                    f"\\EFI\\{slot}\\shimx64.efi ({bad!r}) — it would chainload "
+                    "the wrong loader")
+            else:
+                problems.append(
+                    f"{slot}: NOT registered — the first-boot xpf-uefi-slots "
+                    "oneshot did not create it (LANE-1 kernel channel "
+                    "unavailable on this image)")
+        elif len(got) > 1:
+            problems.append(
+                f"{slot}: registered {len(got)} times ({', '.join(got)}) — a "
+                "duplicated slot makes BootNext ambiguous")
+
+    mo = _BOOTORDER_RE.search(out)
+    if mo is None:
+        problems.append("efibootmgr reported no BootOrder line — cannot prove "
+                        "either slot is reachable by the firmware")
+    else:
+        order = [x for x in mo.group("order").split(",") if x]
+        for slot in slots:
+            got = ids.get(slot, [])
+            if got and not any(i.upper() in (o.upper() for o in order) for i in got):
+                problems.append(
+                    f"{slot}: registered ({got[0]}) but absent from BootOrder "
+                    f"({mo.group('order')!r}) — the firmware would never reach it")
+
+    if problems:
+        return False, "; ".join(problems)
+    return True, ("both A/B slots registered exactly once with the right shim "
+                  "loader and present in BootOrder")
+
+
+def _oneshot_clean_verdict(name, exec_main_status, active_state, result):
+    """Pure verdict over `systemctl show` fields for a first-boot oneshot:
+    did it RUN and exit 0? Returns (ok, reason).
+
+    A oneshot with RemainAfterExit=yes reports ActiveState=active after a clean
+    run. The distinction that matters is "did not run" vs "ran and failed":
+    inactive means a Condition skipped it (the unit was never enabled, or
+    ConditionPathExists=/boot/efi did not hold — an image with no ESP), which
+    is a DIFFERENT bake defect from a non-zero exit, so they are reported
+    separately rather than as one 'not clean'.
+    """
+    if active_state in ("inactive", "") and result in ("", "success"):
+        return False, (f"{name} never ran (ActiveState={active_state!r}) — the "
+                       "bake did not enable it, or its Condition did not hold "
+                       "on this image")
+    if result and result != "success":
+        return False, f"{name} failed (Result={result!r}, ExecMainStatus={exec_main_status!r})"
+    if exec_main_status not in ("0", 0):
+        return False, f"{name} exited {exec_main_status!r}, not 0"
+    return True, f"{name} ran clean (ExecMainStatus=0)"
 
 
 def _find_first(candidates):
@@ -386,6 +524,7 @@ class Harness:
             fail("sshd effective config does not refuse root password auth")
         if not guest_sh(a, '/usr/sbin/sshd -T | grep -qx "permitemptypasswords no"'):
             fail("sshd effective config does not pin PermitEmptyPasswords no")
+        self.assert_ab_kernel_channel(a)
         if guest(a, "test", "-e", "/etc/xpf/xpf.conf", check=False).returncode == 0:
             fail("unexpected /etc/xpf/xpf.conf")
         if guest(a, "test", "-e", "/etc/xpf/.day0-config-applied", check=False).returncode == 0:
@@ -395,6 +534,85 @@ class Harness:
             fail("day-0 loader did not log the no-medium fallback")
         info("Scenario A PASS")
         self.drop(a)
+
+    def _show_unit(self, inst, unit, prop):
+        """One `systemctl show -p <prop> --value <unit>` field from the guest."""
+        return guest(inst, "systemctl", "show", "-p", prop, "--value", unit,
+                     check=False, capture=True).stdout.strip()
+
+    def assert_ab_kernel_channel(self, inst):
+        """Assert the #1930 LANE-1 A/B kernel-channel substrate actually came
+        up IN THE GUEST (#6494) — not merely that the bake staged its files.
+
+        Three things, in the order their failures would be diagnosed:
+          1. the registration oneshot ran clean (it is non-fatal by design, so
+             its own exit is the only place a failure is recorded at all);
+          2. both slots are registered exactly once, with the right shim loader,
+             and reachable in BootOrder — the state `xpfd upgrade kernel arm`
+             refuses to proceed without;
+          3. the promotion gate ran clean on this ordinary boot.
+
+        On (3), note what is NOT asserted: the "promotion gate: clean" line.
+        That line is only emitted once the gate has exec'd xpfd to run the
+        promote verb. On a factory boot with nothing armed the script exits 0
+        much earlier, logging "no armed kernel candidate recorded", so requiring
+        the former here would fail every good image. What IS asserted is that
+        the unit ran and exited 0, plus the ordinary-boot line, which together
+        prove the gate EXECUTED rather than being skipped by a Condition — the
+        thing an operator is relying on when they arm a candidate later.
+        """
+        info("#1930 LANE-1: A/B slot registration + promotion gate...")
+
+        # Both oneshots are WantedBy=multi-user.target and are NOT ordered
+        # Before=xpfd (deliberately — a hanging efibootmgr must never block the
+        # #1922 mgmt lifeline), so xpfd being active does not imply they have
+        # finished. Wait for each to settle rather than racing it.
+        for unit in ("xpf-uefi-slots.service", "xpf-kernel-promote.service"):
+            self._wait(inst,
+                       lambda u=unit: self._show_unit(inst, u, "ActiveState")
+                       not in ("activating", "reloading"),
+                       40, 3, f"{unit} still activating after 120s")
+
+        ok, reason = _oneshot_clean_verdict(
+            "xpf-uefi-slots.service",
+            self._show_unit(inst, "xpf-uefi-slots.service", "ExecMainStatus"),
+            self._show_unit(inst, "xpf-uefi-slots.service", "ActiveState"),
+            self._show_unit(inst, "xpf-uefi-slots.service", "Result"))
+        if not ok:
+            jrn = guest(inst, "journalctl", "-u", "xpf-uefi-slots", "-b",
+                        "--no-pager", check=False, capture=True).stdout
+            fail(f"#1930 A/B slot registration: {reason}\n{jrn[-800:]}")
+
+        got = guest(inst, "efibootmgr", check=False, capture=True)
+        if got.returncode != 0:
+            fail("efibootmgr failed in the guest "
+                 f"(rc={got.returncode}: {(got.stderr or '').strip()!r}) — the "
+                 "#1930 A/B kernel channel needs it to register the slots, so "
+                 "an image where it is absent or cannot read NVRAM ships with "
+                 "LANE-1 permanently unavailable")
+        ok, reason = _efibootmgr_slot_verdict(got.stdout)
+        if not ok:
+            fail("#1930 A/B slot registration FAILED in-guest: " + reason +
+                 "\n--- efibootmgr ---\n" + got.stdout)
+        info(f"  slots OK: {reason}")
+
+        ok, reason = _oneshot_clean_verdict(
+            "xpf-kernel-promote.service",
+            self._show_unit(inst, "xpf-kernel-promote.service", "ExecMainStatus"),
+            self._show_unit(inst, "xpf-kernel-promote.service", "ActiveState"),
+            self._show_unit(inst, "xpf-kernel-promote.service", "Result"))
+        if not ok:
+            jrn = guest(inst, "journalctl", "-u", "xpf-kernel-promote", "-b",
+                        "--no-pager", check=False, capture=True).stdout
+            fail(f"#1930 promotion gate: {reason}\n{jrn[-800:]}")
+        if not guest_sh(inst,
+                        'journalctl -u xpf-kernel-promote -b --no-pager '
+                        '| grep -q "no armed kernel candidate recorded"'):
+            fail("#1930 promotion gate did not log the ordinary-boot path "
+                 "(\"no armed kernel candidate recorded\") — it exited 0 without "
+                 "reaching its decision, so an armed candidate would go "
+                 "unverified on a later boot")
+        info("  promotion gate ran clean on this ordinary boot")
 
     def scenario_b(self):
         info("── Scenario B: first boot WITH valid day-0 config drive ──")


### PR DESCRIPTION
Closes #6494

## What was wrong

`grep -n "efibootmgr\|xpf-A\|xpf-B\|BootOrder\|kernel-promote" scripts/image/validate.py` returned **nothing**. The Tier-1 gate signs `validated: true` into the image manifest without ever checking that the #1930 LANE-1 A/B kernel-slot substrate came up in the guest.

The bake stages `/boot/efi/EFI/{xpf-A,xpf-B}` and enables the two oneshots, and hard-asserts the signed shim is present. What it *cannot* assert offline is the half that only happens in-guest: UEFI `Boot####` variables live in the target's firmware NVRAM, which `virt-customize` cannot write, so registration is a first-boot oneshot on the real machine.

That oneshot is deliberately **non-fatal on every failure path** — a read-only or no-efivars platform must still boot ("degraded, not bricked") — and nothing downstream re-read its outcome. So a regression in the ESP disk/part parse, the loader-path match, or the `efibootmgr` write shipped a fully validated image whose verify-gated kernel channel was silently unavailable, and the operator found out when `xpfd upgrade kernel arm` exited 2 with `ErrKernelChannelUnavailable`.

## What this does

Scenario A now asserts in-guest: both oneshots ran and exited 0; both slots registered exactly once, each pointing at its own `\EFI\<slot>\shimx64.efi`, both reachable in BootOrder; and the promotion gate logged its ordinary-boot path.

The three slot properties are reported **separately** because they have three different causes — exactly-once (a duplicate makes `BootNext` ambiguous: the live #1930 bug, from a label guard anchored at `$`), its-own-loader (a label-only match chainloads the wrong thing), and in-BootOrder (a slot the firmware never reaches is not registered in any sense the channel can act on). The verdict regexes deliberately mirror `xpf-uefi-slots`' own shell regexes: a gate that disagreed with the script about what "registered" means would certify a state the script would not accept.

Both oneshots are `WantedBy=multi-user.target` and deliberately **not** ordered `Before=xpfd` (a hanging `efibootmgr` must never block the #1922 mgmt lifeline), so xpfd being active does not imply they have finished — the assertion waits for each to leave `activating` rather than racing it.

## One correction to the issue's acceptance criteria

> - [ ] Same scenario asserts ... (or the promote journal line "promotion gate: clean").

**That line is unreachable in scenario A.** `promotion gate: clean` (`xpf-kernel-promote:646`) is emitted only after the gate has exec'd xpfd to run the promote verb. On a factory boot with nothing armed the script exits 0 much earlier at `:591`, logging `no armed kernel candidate recorded`. Requiring the former would fail **every good image**.

The gate asserts `ExecMainStatus=0` **plus that ordinary-boot line** instead, which together prove the unit *executed* rather than being skipped by a Condition — which is what an operator is relying on when they arm a candidate later. Flagging it rather than quietly substituting.

## Acceptance criteria

- [x] Asserts `efibootmgr` lists both `xpf-A` and `xpf-B` each exactly once, each pointing at `\EFI\<slot>\shimx64.efi`, and both in BootOrder.
- [x] Asserts both services ran with `ExecMainStatus=0` — with the promote-line substitution above, stated explicitly.
- [x] A deliberately-broken registration FAILS the gate — see M1/M2/M3/M6 below (each fixture is a broken registration).

## Validation

`scripts/run-selftests.sh` — **51 passed, 0 skipped, 0 failed, rc=0** (50 at baseline; the new test file is auto-discovered by the `scripts/image/test_*.py` glob).

Verdicts are pure functions over captured command output, in the existing `_qemu_img_verdict` idiom, so the acceptance criterion is testable without a hypervisor. 16 hermetic cases: missing slot, neither slot, duplicate, right-label/wrong-loader, registered-but-not-in-BootOrder, no BootOrder line, the bare (non-`File()`) loader rendering, hex-id case differences between the entry line and BootOrder, empty output, and never-ran vs ran-and-failed vs timed-out for the oneshot verdict. Two are structural — the verdicts can be perfect and prove nothing if scenario A never calls them.

### Mutation proofs

`python3 -m py_compile` checked green before each run so every red is an assertion, not a syntax error. Exit codes from `$?`. One line per mutation; restore verified (`git status --porcelain` empty, rc back to 0).

| # | Mutation (one line) | py_compile | rc | Cell that reddened |
|---|---|---|---|---|
| M1 | stop requiring the slot be in BootOrder | 0 | 1 | `registered_but_absent_from_bootorder_fails`, `bootorder_id_case_is_ignored` |
| M2 | drop the exactly-once rule | 0 | 1 | `duplicate_slot_fails` |
| M3 | match the label only, ignore the loader path | 0 | 1 | `right_label_wrong_loader_path_fails` |
| M4 | stop distinguishing never-ran from ran-and-failed | 0 | 1 | `never_ran_is_distinguished_from_failed` |
| M5 | drop the `assert_ab_kernel_channel` call from scenario A | 0 | 1 | `scenario_a_calls_the_ab_assertion` |
| M6 | anchor the entry regex at `$` (the live #1930 miss) | 0 | 1 | 5 cells incl. both PASS fixtures |

## What is NOT proven here — please read before merging

**This assertion only executes inside a real incus boot of a baked qcow2.** The verdict *logic* is proven above; "it passes on a genuinely good image" is not, and I am not claiming it. It needs one `bake.py` + `validate.py a` run, which I did not have bake/cluster time for.

Two specific things that run would settle, both one-line fixes if they red:

1. **Is `efibootmgr` present in the image?** It is not in `bake.py`'s `RUNTIME_PACKAGES` and not in `debian/control`'s `xpf-appliance` Depends — it is inherited from the Ubuntu cloud base, which this bake purges cloud-init from and autoremoves. If it is absent, the gate fails with an explicit message. **That would be a correct finding, not a false red**: `xpf-uefi-slots` hard-depends on `efibootmgr`, so an image without it ships with LANE-1 permanently unavailable. Fix would be adding it to `RUNTIME_PACKAGES` (the same reasoning as the `cloud-guest-utils` comment already in that list). I deliberately did **not** make that change here — it is a different defect from "the gate does not assert", and pre-emptively papering over it would hide the answer.
2. **Does the incus VM guest give the oneshot writable efivars?** incus VMs use OVMF with a per-instance NVRAM file, so it should; if not, the guest hits the script's `exit 0` skip and the gate reports `xpf-A: NOT registered`.

## Scope

- **Does not reach the Rust helper.** Python gate + docs only; no `userspace-dp`/`userspace-xdp` source, no `.o`.
- **No cluster time used.** The loss cluster was not touched, deployed to, or smoked; every result above is hermetic.

## Merge ordering — verified

This PR conflicts with **#7274** (#6497): both add a Harness method immediately before `def scenario_b` in `validate.py`, both rewrote the scenario-`a` line of the module docstring, and both edit the same two anchors in `docs/image-validation.md`. All are pure **both-added** conflicts — keep both sides, and merge the two docstring sentences.

(An earlier version of #7274's body claimed these two merged cleanly. They do not; that claim is corrected there.)

Merged locally in that order and resolved: module imports clean, both new `test_*.py` files rc=0, `scripts/run-selftests.sh` **52 passed / 0 failed, rc=0**.

## Docs

`docs/image-validation.md` — the assertion in the scenario A row, plus a section on why the gate asserts the channel at all, what it deliberately does not assert about the promote line and why, and why the three slot properties are separate. `validate.py`'s module docstring updated to match.
