### PR TITLE
configstore: record first-commit-ness instead of deriving it from nil

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -100351,3 +100351,22 @@ prose edit above them added. No diff falls in the new test body.
   scripts/refactoring-audit-classify.sh,
   docs/refactoring-audit-accepted.txt (new), docs/refactoring-audit.md,
   docs/engineering-style.md, Makefile, _Log.md
+
+- **Timestamp**: 2026-08-21
+- **Action**: #6538 — stop overloading `confirmPrevCfg == nil`. New
+  `Store.confirmPrevFirst` records first-commit-ness where it is known (arm
+  site: pre-promotion `s.compiled`; recovery site: the persisted
+  `rec.FirstCommit`), and both consumers — `PromoteRollback`'s
+  `firstCommitRollback` and the `firstCommit` bit `writeConfirmState`
+  persists — read the flag instead of re-deriving it, so a rollback target
+  that failed the lenient compile no longer persists `committed=0` over a real
+  config. Separately, the expired-during-downtime recovery branch now returns
+  an `ErrConfigCompile`-tagged error (propagated by `Load`) instead of warning
+  and shipping a nil compiled config with `everCommitted=true`, so the daemon
+  fails closed into the #1922 bootstrap/lifeline state rather than a NORMAL
+  boot with no policy. Four one-at-a-time mutations each red exactly one test.
+- **File(s)**: pkg/configstore/store.go, pkg/configstore/store_commit.go,
+  pkg/configstore/store_persist.go,
+  pkg/configstore/confirm_recovery_uncompilable_target_6538_test.go,
+  pkg/daemon/daemon_apply_commit.go, pkg/configstore/README.md,
+  pkg/daemon/README.md, _Log.md

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -424,8 +424,9 @@ per-path:
   `confirm.json` in `.configdb` holding the absolute **deadline**, the
   **rollback-target tree** (`confirmPrevTree` — the ORIGINAL
   last-confirmed tree for a nested re-arm), and the **first-commit**
-  flag (`confirmPrevCfg == nil`, the #1922 Item 1b never-committed
-  case). It is written durably (temp+fsync+rename+dir-fsync),
+  flag (`confirmPrevFirst`, the #1922 Item 1b never-committed case —
+  see the #6538 note below; it used to be re-derived as
+  `confirmPrevCfg == nil` at each consumer). It is written durably (temp+fsync+rename+dir-fsync),
   encrypted with the same master-password machinery as `active.json`
   (the target tree may carry secret leaves), 0600, AFTER the successful
   `writeActive`+promote (a failed commit-confirmed never leaves a
@@ -707,17 +708,60 @@ non-daemon embedders) the timer falls back to the self-contained
 `performAutoRollback`, which promotes store state but does not re-apply
 a dataplane it has no handle on.
 
-The `prevCfg == nil` first-commit rollback target (#1922 Item 1b) is now
-implemented: on a FRESH-store first `commit confirmed` timeout
-`PromoteRollback` reverts the store to the empty bootstrap tree, persists
-the **never-committed marker** (committed=0, NOT an empty *committed*
-tree — see step-0 marker below), clears the in-memory `everCommitted`
-flag, and returns `(nil, true)`. The daemon executor detects the nil
-`prevCfg` and calls `enterBootstrapMode` (interface/FRR/dataplane takeover
-cleanup, keeping the management lifeline) instead of applying an empty
-config to the dataplane. A subsequent restart therefore re-classifies into
-bootstrap (the marker disambiguates never-committed from
-operator-committed-empty).
+The first-commit rollback target (#1922 Item 1b) is now implemented: on a
+FRESH-store first `commit confirmed` timeout `PromoteRollback` reverts the
+store to the empty bootstrap tree, persists the **never-committed marker**
+(committed=0, NOT an empty *committed* tree — see step-0 marker below),
+clears the in-memory `everCommitted` flag, and returns `(nil, true)`. The
+daemon executor detects the nil `prevCfg` and calls `enterBootstrapMode`
+(interface/FRR/dataplane takeover cleanup, keeping the management lifeline)
+instead of applying an empty config to the dataplane. A subsequent restart
+therefore re-classifies into bootstrap (the marker disambiguates
+never-committed from operator-committed-empty).
+
+**First-commit-ness is RECORDED, not re-derived from the nil (#6538).**
+`confirmPrevCfg == nil` carries two unrelated meanings, and the action taken
+on one of them is destructive for the other:
+
+1. *there was no compiled config to stash* — this genuinely is the first
+   commit on a fresh store; and
+2. *the recovered rollback target failed even the LENIENT compile* —
+   `recoverPendingConfirmLocked` re-arming a window that was still open at
+   boot. `Store.Load` repairs the tree it reads from `active.json`
+   (`rewriteRetiredDataplaneType`, `SanitizeTreeControlChars`) but never the
+   `PrevTree` carried inside `confirm.json`, so a target committed on an
+   older build — `system dataplane-type ebpf` is the concrete case — reaches
+   the recovery uncompilable.
+
+`Store.confirmPrevFirst` records the fact where it is known (the arm site
+reads the PRE-promotion `s.compiled`; the recovery site reads the persisted
+`rec.FirstCommit`) and both consumers read the flag: `PromoteRollback`'s
+`firstCommitRollback`, and the `firstCommit` bit `writeConfirmState`
+persists on a nested re-arm. Deriving them from the nil made meaning (2)
+persist `committed=0` **over a real config**, so the next restart
+re-classified a production box into bootstrap (day-0 / claim-all) — and a
+nested arm wrote `FirstCommit=true` into `confirm.json`, making that
+mislabelling durable across the reboot after it.
+
+The **runtime** action on a nil `prevCfg` is deliberately unchanged and
+unbranched: with no compiled config to apply, `enterBootstrapMode`'s
+lifeline safe state is exactly what #1960 prescribes for a
+present-but-uncompilable committed config, and the next boot re-derives that
+state from disk through the main `Load` path. Only the PERSISTENCE differs
+between the two provenances.
+
+**The expired-during-downtime branch fails closed (#6538).** When that
+branch cannot compile its rollback target it still performs the rollback —
+reverting the unconfirmed config is the safety property, and the reverted
+tree must stay reachable for `configure` / `show | compare` / `rollback` —
+but `recoverPendingConfirmLocked` now RETURNS an `ErrConfigCompile`-tagged
+error, which `Load` propagates. Previously it warned, assigned the nil into
+`s.compiled`, set `everCommitted = true`, and `Load` returned success: the
+daemon then saw `ActiveConfig() == nil` + `everCommitted` and resolved to a
+NORMAL boot with **no compiled policy**, running the positional claim-all
+interface rename. That is precisely the shape #1960 fails closed on, and the
+tagged error routes it through the same `classifyLoadError` →
+`loadCompileFailed` → #1922 bootstrap/lifeline path.
 
 ### Config lock: shared/private vs. exclusive holders (#3979)
 

--- a/pkg/configstore/confirm_recovery_uncompilable_target_6538_test.go
+++ b/pkg/configstore/confirm_recovery_uncompilable_target_6538_test.go
@@ -1,0 +1,267 @@
+package configstore
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// uncompilableTree returns a tree that a previously-committed config could
+// plausibly hold and that the LENIENT compile still rejects.
+//
+// `system dataplane-type ebpf` is the concrete production trigger, not a
+// contrived one: it was a legal committed value before the #1373 retirement,
+// and Store.Load repairs it (rewriteRetiredDataplaneType) only on the tree it
+// reads out of active.json — never on the PrevTree carried inside confirm.json.
+// A node that armed `commit confirmed` on an older build and reboots into a
+// current one therefore reaches recoverPendingConfirmLocked with exactly this
+// rollback target.
+func uncompilableTree(t *testing.T) *config.ConfigTree {
+	t.Helper()
+	s := newTestStoreAt(t, filepath.Join(t.TempDir(), "probe"))
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetFromInput("system dataplane-type ebpf"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	tree := s.candidate.Clone()
+	s.ExitConfigure()
+	if _, err := s.compileTreeLenient(tree); err == nil {
+		t.Fatal("premise broken: the probe tree compiles leniently; it cannot " +
+			"stand in for an uncompilable rollback target")
+	}
+	return tree
+}
+
+// rearmWithUncompilableTarget takes a store armed by armedConfirmStore and
+// rewrites its persisted confirm record so the ROLLBACK TARGET no longer
+// compiles, leaving everything else (GuardedHash, FirstCommit=false) intact.
+// deadline selects the expired vs still-in-window recovery branch.
+func rearmWithUncompilableTarget(t *testing.T, path string, deadline time.Time) {
+	t.Helper()
+	s0 := newTestStoreAt(t, path)
+	rec, err := s0.db.ReadConfirm()
+	if err != nil || rec == nil {
+		t.Fatalf("ReadConfirm: rec=%v err=%v", rec, err)
+	}
+	if rec.FirstCommit {
+		t.Fatal("premise broken: the armed record claims FirstCommit; this test " +
+			"is about a REAL previously-committed rollback target")
+	}
+	rec.PrevTree = uncompilableTree(t)
+	rec.Deadline = deadline
+	if err := s0.db.WriteConfirm(rec); err != nil {
+		t.Fatalf("WriteConfirm: %v", err)
+	}
+}
+
+// TestConfirmRecoveryExpiredUncompilableTargetFailsClosed is part 1 of #6538.
+//
+// The expired-during-downtime branch of recoverPendingConfirmLocked compiles
+// the rollback target leniently, warns if that fails, and then assigns the
+// result — nil — into s.compiled while setting everCommitted/persistMarker
+// true. recoverPendingConfirmLocked returns void and runs inside Load, so
+// Load's success return is already fixed by then.
+//
+// The daemon reads that as a NORMAL boot with no compiled policy: #1960 exists
+// precisely so a present-but-uncompilable committed config yields
+// ErrConfigCompile and the #1922 bootstrap/lifeline safe state instead of
+// positional claim-all with an empty policy. This branch bypassed it.
+func TestConfirmRecoveryExpiredUncompilableTargetFailsClosed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	_ = armedConfirmStore(t, path, 10)
+	rearmWithUncompilableTarget(t, path, time.Now().Add(-2*time.Minute))
+
+	s := newTestStoreAt(t, path)
+	err := s.Load()
+
+	if s.ActiveConfig() != nil {
+		t.Fatalf("premise broken: the rollback target compiled after all (%v)", s.ActiveConfig())
+	}
+	if err == nil {
+		t.Fatalf("Load reported SUCCESS while writing a nil compiled config: "+
+			"ActiveConfig()=nil, EverCommitted()=%v. The daemon resolves that to a "+
+			"NORMAL boot with no policy (#6538 part 1)", s.EverCommitted())
+	}
+	if !errors.Is(err, ErrConfigCompile) {
+		t.Fatalf("Load error = %v, want one tagged ErrConfigCompile so "+
+			"classifyLoadError routes it to the #1922 bootstrap/lifeline safe "+
+			"state rather than the generic warn-and-continue path", err)
+	}
+	// The reverted tree must still be reachable so the operator can fix it
+	// from the CLI — the same recovery shape the #1960 Load path leaves.
+	if s.ActiveTree() == nil {
+		t.Fatal("active tree is nil after the fail-closed recovery; the operator " +
+			"has nothing to `show | compare` or roll back from")
+	}
+}
+
+// TestConfirmRecoveryInWindowRollbackDoesNotPersistNeverCommitted is part 2 of
+// #6538 — the durable half.
+//
+// The still-in-window branch re-arms the timer and sets confirmPrevCfg from the
+// lenient compile of the rollback target: nil when that compile fails. Two
+// consumers then DERIVE "this was the first commit on a fresh store" from that
+// nil — PromoteRollback's firstCommitRollback, and the firstCommit bit
+// writeConfirmState persists. "Nil because it genuinely was the first commit"
+// and "nil because the rollback target failed to compile" are different facts,
+// and the action taken on the first is destructive for the second: committed=0
+// persisted over a real config, so a later restart re-classifies the box into
+// bootstrap (day-0 / claim-all).
+func TestConfirmRecoveryInWindowRollbackDoesNotPersistNeverCommitted(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	_ = armedConfirmStore(t, path, 10)
+	rearmWithUncompilableTarget(t, path, time.Now().Add(30*time.Minute))
+
+	s := newTestStoreAt(t, path)
+	if err := s.Load(); err != nil {
+		t.Fatalf("Load (still in window): %v", err)
+	}
+	if !s.IsConfirmPending() {
+		t.Fatal("premise broken: the still-in-window record did not re-arm")
+	}
+	if !s.EverCommitted() {
+		t.Fatal("premise broken: the store must be everCommitted before the rollback")
+	}
+
+	type markerWrite struct{ committed bool }
+	var markerWrites []markerWrite
+	var plainWrites int
+	s.SetWriteActiveMarkerForTesting(func(_ *config.ConfigTree, committed bool) error {
+		markerWrites = append(markerWrites, markerWrite{committed: committed})
+		return nil
+	})
+	s.SetWriteActiveForTesting(func(*config.ConfigTree) error {
+		plainWrites++
+		return nil
+	})
+
+	s.InvokeRollbackTimerForTesting(s.ConfirmGenForTesting())
+
+	for _, w := range markerWrites {
+		if !w.committed {
+			t.Fatalf("the auto-rollback persisted the NEVER-COMMITTED marker "+
+				"(committed=0) over a real previously-committed config: it derived "+
+				"\"first commit on a fresh store\" from confirmPrevCfg==nil, which "+
+				"here means \"the rollback target failed to compile\". The next "+
+				"restart re-classifies this box into bootstrap (#6538 part 2)")
+		}
+	}
+	if plainWrites == 0 {
+		t.Fatalf("the rollback wrote no ordinary active config (marker writes=%v); "+
+			"a real rollback target must be persisted as committed", markerWrites)
+	}
+	if !s.EverCommitted() {
+		t.Fatal("everCommitted was cleared by a rollback to a REAL committed config; " +
+			"the in-memory boot predicate now reads never-committed (#6538 part 2)")
+	}
+}
+
+// TestConfirmRecoveryInWindowNestedArmKeepsFirstCommitFalse is the second
+// consumer of the same overloaded nil: the firstCommit bit persisted into
+// confirm.json by a NESTED commit-confirmed. A nested arm preserves the
+// recovered rollback target, so it re-persists the record with
+// `s.confirmPrevCfg == nil` as its firstCommit value — durably mislabelling a
+// real config as the empty bootstrap tree. The NEXT boot past the deadline then
+// takes the rec.FirstCommit branch and writes committed=0.
+func TestConfirmRecoveryInWindowNestedArmKeepsFirstCommitFalse(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	_ = armedConfirmStore(t, path, 10)
+	rearmWithUncompilableTarget(t, path, time.Now().Add(30*time.Minute))
+
+	s := newTestStoreAt(t, path)
+	if err := s.Load(); err != nil {
+		t.Fatalf("Load (still in window): %v", err)
+	}
+
+	// A nested commit-confirmed while the recovered window is still pending.
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetFromInput("system host-name Nested"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.CommitConfirmed(10); err != nil {
+		t.Fatalf("nested CommitConfirmed: %v", err)
+	}
+
+	rec, err := s.db.ReadConfirm()
+	if err != nil || rec == nil {
+		t.Fatalf("ReadConfirm after nested arm: rec=%v err=%v", rec, err)
+	}
+	if rec.FirstCommit {
+		t.Fatal("the nested arm persisted FirstCommit=true for a rollback target " +
+			"that is a REAL previously-committed config — it derived the bit from " +
+			"confirmPrevCfg==nil, which here means the target failed to compile. " +
+			"The next boot past the deadline writes committed=0 over that config " +
+			"and the restart after it classifies bootstrap (#6538 part 2)")
+	}
+}
+
+// TestConfirmRecoveryInWindowGenuineFirstCommitStillWritesNeverCommitted is the
+// OTHER side of the #6538 discriminator, on the same recovery path.
+//
+// The fix must not become a blanket "never write the never-committed marker".
+// A genuine first commit confirmed on a fresh store still has to persist
+// committed=0 and clear everCommitted on rollback (#1922 Item 1b) — otherwise
+// the restart after it classifies committed-empty => NORMAL and takes over
+// interfaces on an empty config. Recovering that record across a restart must
+// preserve the bit, since confirmPrevCfg is legitimately nil here too. This row
+// and the one above differ ONLY in the persisted FirstCommit bit, so a fix that
+// hard-coded either answer reds one of them.
+func TestConfirmRecoveryInWindowGenuineFirstCommitStillWritesNeverCommitted(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+
+	// A FIRST commit confirmed on a fresh store — no prior Commit.
+	s0 := newTestStoreAt(t, path)
+	if err := s0.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s0.SetFromInput("system host-name FirstEver"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s0.CommitConfirmed(10); err != nil {
+		t.Fatalf("CommitConfirmed: %v", err)
+	}
+	rec, err := s0.db.ReadConfirm()
+	if err != nil || rec == nil {
+		t.Fatalf("ReadConfirm: rec=%v err=%v", rec, err)
+	}
+	if !rec.FirstCommit {
+		t.Fatal("premise broken: a first commit confirmed on a fresh store must " +
+			"persist FirstCommit=true")
+	}
+
+	// Restart inside the window, then let the re-armed timer fire.
+	s := newTestStoreAt(t, path)
+	if err := s.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !s.IsConfirmPending() {
+		t.Fatal("premise broken: the record did not re-arm")
+	}
+
+	var sawNeverCommitted bool
+	s.SetWriteActiveMarkerForTesting(func(_ *config.ConfigTree, committed bool) error {
+		if !committed {
+			sawNeverCommitted = true
+		}
+		return nil
+	})
+
+	s.InvokeRollbackTimerForTesting(s.ConfirmGenForTesting())
+
+	if !sawNeverCommitted {
+		t.Fatal("a GENUINE first-commit rollback did not persist the never-committed " +
+			"marker (committed=0). The next restart reads committed-empty => NORMAL " +
+			"and takes over interfaces on an empty config (#1922 Item 1b)")
+	}
+	if s.EverCommitted() {
+		t.Fatal("everCommitted still true after a genuine first-commit rollback; the " +
+			"in-memory boot predicate reads operator-committed (#1922 Item 1b)")
+	}
+}

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -177,6 +177,22 @@ type Store struct {
 	confirmTimer    *time.Timer
 	confirmPrevTree *config.ConfigTree // active tree before confirmed commit
 	confirmPrevCfg  *config.Config     // compiled config before confirmed commit
+	// confirmPrevFirst records whether confirmPrevTree is the EMPTY BOOTSTRAP
+	// TREE — i.e. the pending commit-confirmed was the first commit on a fresh
+	// store, so its rollback must re-enter never-committed state (#1922 Item
+	// 1b: committed=0 marker, everCommitted cleared).
+	//
+	// #6538: this used to be DERIVED from `confirmPrevCfg == nil` at each
+	// consumer. That nil carries two unrelated meanings — "there was no
+	// compiled config to stash because this genuinely is the first commit" and
+	// "the recovered rollback target failed even the lenient compile"
+	// (recoverPendingConfirmLocked) — and the action taken on the first is
+	// destructive for the second: committed=0 persisted over a REAL config, so
+	// the next restart re-classifies the box into bootstrap (day-0 /
+	// claim-all). Recording the fact at the moment it is known, instead of
+	// inferring it later from a value that means two things, is what makes the
+	// two states distinguishable to every consumer.
+	confirmPrevFirst bool
 
 	// rollbackExecutor is the daemon-registered transaction that owns
 	// the WHOLE commit-confirmed timeout rollback (#1922 Item 1a). When

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -476,6 +476,14 @@ func (s *Store) commitConfirmedLocked(minutes int) (*config.Config, error) {
 		// Save current active state for potential rollback.
 		s.confirmPrevTree = s.active.Clone()
 		s.confirmPrevCfg = s.compiled
+		// #6538: record first-commit-ness HERE, where it is known, instead of
+		// re-deriving it later from confirmPrevCfg==nil. s.compiled is still
+		// the PRE-promotion compiled active config at this point, so a nil
+		// here means this store had no compiled active config before this
+		// commit — the #1922 Item 1b fresh-store case. A nil that shows up
+		// later for a different reason (a recovered rollback target that would
+		// not compile) must not be read as this.
+		s.confirmPrevFirst = s.compiled == nil
 	}
 
 	// Push current active to history
@@ -517,11 +525,14 @@ func (s *Store) commitConfirmedLocked(minutes int) (*config.Config, error) {
 	// successful writeActive+promote so a FAILED commit-confirmed never leaves
 	// a confirm.json (persist-before-promote already returned above on
 	// failure). PrevTree is confirmPrevTree — the ORIGINAL last-confirmed tree
-	// for a nested re-arm; firstCommit mirrors the confirmPrevCfg==nil #1922
-	// Item 1b path. A residual crash window remains between the writeActive
-	// syscall and this write (microseconds vs. the whole multi-minute window
-	// before this fix).
-	s.writeConfirmState(s.confirmPrevTree, deadline, s.confirmPrevCfg == nil)
+	// for a nested re-arm; firstCommit is the recorded confirmPrevFirst, NOT a
+	// re-derivation from confirmPrevCfg==nil (#6538: a nested arm preserves a
+	// recovered rollback target, so that nil can mean "the target failed to
+	// compile" and persisting it as firstCommit durably mislabels a real config
+	// as the empty bootstrap tree). A residual crash window remains between the
+	// writeActive syscall and this write (microseconds vs. the whole
+	// multi-minute window before this fix).
+	s.writeConfirmState(s.confirmPrevTree, deadline, s.confirmPrevFirst)
 
 	slog.Info("commit confirmed started", "timeout_minutes", minutes)
 	return compiled, nil
@@ -723,6 +734,7 @@ func (s *Store) cancelPendingConfirmTimerLocked() bool {
 	s.confirmTimer = nil
 	s.confirmPrevTree = nil
 	s.confirmPrevCfg = nil
+	s.confirmPrevFirst = false
 	return true
 }
 
@@ -881,7 +893,13 @@ func (s *Store) PromoteRollback(gen uint64) (prevCfg *config.Config, ok bool) {
 	// back via enterBootstrapMode rather than applying an empty config.
 	prevCfg = s.confirmPrevCfg
 	s.confirmPrevCfg = nil
-	firstCommitRollback := prevCfg == nil
+	// #6538: the recorded flag, not `prevCfg == nil`. A nil prevCfg ALSO
+	// happens when recoverPendingConfirmLocked could not compile the recovered
+	// rollback target, and treating that as a first commit persists
+	// committed=0 over a real config — which durably re-classifies the next
+	// boot into bootstrap.
+	firstCommitRollback := s.confirmPrevFirst
+	s.confirmPrevFirst = false
 
 	// Persist reverted config to disk. Option B (#1799): the rollback
 	// ALWAYS proceeds in memory — reverting the running config is the

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -110,8 +110,10 @@ func (s *Store) Load() error {
 	s.active = tree
 	s.compiled = compiled
 	s.loadRollbackHistory()
-	s.recoverPendingConfirmLocked()
-	return nil
+	// #6538: the recovery can leave the store with a nil compiled config (its
+	// rollback target failed even the lenient compile). Load MUST NOT report
+	// success in that state — see recoverPendingConfirmLocked.
+	return s.recoverPendingConfirmLocked()
 }
 
 // recoverPendingConfirmLocked restores a commit-confirmed window that was
@@ -133,18 +135,33 @@ func (s *Store) Load() error {
 //   - deadline still in the future -> re-arm the timer for the REMAINING
 //     duration so the original auto-rollback still fires; a clean restart
 //     inside the window therefore also keeps the hatch.
-func (s *Store) recoverPendingConfirmLocked() {
+//
+// #6538: it returns an error so Load can FAIL CLOSED when the recovery leaves
+// no compiled config. The rollback target here is a previously-committed
+// config, and Load repairs the tree it reads from active.json
+// (rewriteRetiredDataplaneType, SanitizeTreeControlChars) but never the
+// PrevTree carried inside confirm.json — so a target committed on an older
+// build can fail even the LENIENT compile. Warning and continuing assigned the
+// nil into s.compiled while marking everCommitted, which the daemon resolves
+// to a NORMAL boot with NO policy: positional claim-all interface naming on a
+// box with no compiled configuration. The returned error is tagged
+// ErrConfigCompile so classifyLoadError routes it to the same #1922
+// bootstrap/lifeline safe state the #1960 main-path compile failure gets. The
+// rollback itself still runs to completion first — reverting the unconfirmed
+// config is the safety property, and the operator needs the reverted tree
+// reachable to fix it from the CLI.
+func (s *Store) recoverPendingConfirmLocked() error {
 	if s.db == nil {
-		return
+		return nil
 	}
 	rec, err := s.db.ReadConfirm()
 	if err != nil {
 		slog.Warn("failed to read persisted commit-confirmed state; cannot restore the "+
 			"pending auto-rollback window", "err", err, "issue", "#4577")
-		return
+		return nil
 	}
 	if rec == nil {
-		return
+		return nil
 	}
 	// #5835: a stale record must not resurrect a rollback of an unrelated,
 	// already-confirmed generation. GuardedHash binds the record to the
@@ -161,7 +178,7 @@ func (s *Store) recoverPendingConfirmLocked() {
 			"that is no longer active (a later commit/confirm superseded it); not resurrecting its "+
 			"rollback", "issue", "#5835")
 		s.resolveConfirmRemovalLocked("stale_confirm_recovery")
-		return
+		return nil
 	}
 	prevTree := rec.PrevTree
 	if prevTree == nil {
@@ -174,6 +191,10 @@ func (s *Store) recoverPendingConfirmLocked() {
 		// with the same persistence semantics as PromoteRollback.
 		s.active = prevTree
 		var perr error
+		// recoverErr is the #6538 fail-closed signal, returned at the end of
+		// this branch so the rollback's persistence/journal/record-removal all
+		// still run first.
+		var recoverErr error
 		if rec.FirstCommit {
 			// #1922 Item 1b: the rollback target is the empty bootstrap tree;
 			// persist committed=0 and clear everCommitted so a later restart
@@ -185,8 +206,22 @@ func (s *Store) recoverPendingConfirmLocked() {
 		} else {
 			compiled, cerr := s.compileTreeLenient(prevTree)
 			if cerr != nil {
-				slog.Warn("recovered commit-confirmed rollback target failed to compile; "+
-					"continuing with the reverted tree", "err", cerr, "issue", "#4577")
+				// #6538: s.compiled is about to become nil while everCommitted
+				// stays true — the exact (ActiveConfig()==nil, everCommitted)
+				// shape #1960 fails closed on. Record it so Load returns an
+				// ErrConfigCompile-tagged error at the end of this branch
+				// instead of reporting success; the daemon then enters the
+				// #1922 bootstrap/lifeline safe state rather than a NORMAL
+				// boot with no policy. The rollback below still completes:
+				// reverting the unconfirmed config is the safety property, and
+				// the reverted tree must stay reachable so the operator can
+				// fix it from the CLI.
+				slog.Error("recovered commit-confirmed rollback target failed to compile; "+
+					"reverting to it anyway and refusing config-driven takeover — fix the "+
+					"configuration from the CLI or roll back",
+					"err", cerr, "issue", "#6538")
+				recoverErr = fmt.Errorf("compile commit-confirmed rollback target: %w: %w",
+					ErrConfigCompile, cerr)
 			}
 			s.compiled = compiled
 			s.persistMarkerCommitted = true
@@ -225,7 +260,7 @@ func (s *Store) recoverPendingConfirmLocked() {
 		})
 		slog.Warn("commit-confirmed window expired while the daemon was down; configuration "+
 			"rolled back to the pre-confirm state on boot", "issue", "#4577")
-		return
+		return recoverErr
 	}
 
 	// Still within the window: re-arm the timer for the remaining duration so
@@ -236,13 +271,26 @@ func (s *Store) recoverPendingConfirmLocked() {
 	// is resolved.
 	remaining := time.Until(rec.Deadline)
 	s.confirmPrevTree = prevTree
+	// #6538: first-commit-ness comes from the PERSISTED record, which is the
+	// only authority on whether PrevTree is the empty bootstrap tree. It must
+	// NOT be re-derived from confirmPrevCfg below, which goes nil on a compile
+	// failure too.
+	s.confirmPrevFirst = rec.FirstCommit
 	if rec.FirstCommit {
 		s.confirmPrevCfg = nil
 	} else {
 		compiled, cerr := s.compileTreeLenient(prevTree)
 		if cerr != nil {
-			slog.Warn("recovered commit-confirmed rollback target failed to compile; the "+
-				"pending auto-rollback will revert store state only", "err", cerr, "issue", "#4577")
+			// The window's rollback can still revert store state and the
+			// on-disk tree, but there is no compiled config to re-apply, so
+			// the daemon will fall back to the bootstrap/lifeline safe state
+			// if the timer fires. confirmPrevFirst stays false, so the
+			// rollback persists the target as COMMITTED (#6538) rather than
+			// writing the never-committed marker over a real config.
+			slog.Error("recovered commit-confirmed rollback target failed to compile; the "+
+				"pending auto-rollback will revert store state and disk only, and the "+
+				"daemon will drop to the bootstrap/lifeline safe state if it fires",
+				"err", cerr, "issue", "#6538")
 		}
 		s.confirmPrevCfg = compiled
 	}
@@ -253,6 +301,7 @@ func (s *Store) recoverPendingConfirmLocked() {
 	})
 	slog.Info("restored pending commit-confirmed window after restart; auto-rollback re-armed",
 		"remaining", remaining.String(), "issue", "#4577")
+	return nil
 }
 
 // Save persists the active configuration to disk.

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -1022,6 +1022,21 @@ never lock an operator out of a remote box it manages.
   in-band. A daemon hard-exit is deliberately NOT used (it would also strand
   mgmt). Distinct from `ErrConfigDBUnreadable` (#1917 D1, which IS a fatal exit
   because the bytes themselves cannot be read).
+  - **The boot commit-confirmed recovery reaches the same guard (#6538).** A
+    `commit confirmed` window that expired while the daemon was down is
+    resolved inside `Store.Load` by `recoverPendingConfirmLocked`, which
+    reverts to the record's `PrevTree`. That tree is a previously-committed
+    config, but `Load`'s tree repairs (`rewriteRetiredDataplaneType`,
+    `SanitizeTreeControlChars`) run only on `active.json`, never on the
+    `PrevTree` inside `confirm.json` — so a target committed on an older build
+    (`system dataplane-type ebpf` is the concrete case) can fail even the
+    lenient compile. That branch used to warn, assign the nil into
+    `s.compiled`, set `everCommitted = true`, and let `Load` return SUCCESS —
+    reconstructing the exact dangerous tuple above and bypassing this guard.
+    It now returns an `ErrConfigCompile`-tagged error, so the recovery lands in
+    `loadCompileFailed` like any other uncompilable committed config. The
+    rollback itself still completes first: the unconfirmed config must not
+    stand, and the reverted tree has to stay reachable for in-band recovery.
   - **Why mgmt stays reachable — freeze in last-known-good, not a wipe.** This
     path does NOT run the `enterBootstrapMode()` teardown (which removes the
     `10-xpf-*` `.network`/`.link` files, clears the FRR managed section, and

--- a/pkg/daemon/daemon_apply_commit.go
+++ b/pkg/daemon/daemon_apply_commit.go
@@ -672,8 +672,23 @@ func (d *Daemon) executeConfirmedRollback(gen uint64) {
 		// clean up the takeover artifacts (networkd files, FRR managed
 		// section, dataplane attach) the failed first commit created, except
 		// the management lifeline. Runs under d.applySem (held above).
-		slog.Warn("commit confirmed (first commit) timed out; rolling back to BOOTSTRAP mode " +
-			"(removing interface/FRR/dataplane takeover, keeping the management lifeline)")
+		//
+		// #6538: a nil prevCfg has a SECOND provenance — a window recovered by
+		// recoverPendingConfirmLocked whose rollback target failed even the
+		// lenient compile (so confirmPrevCfg was nil at re-arm time). The
+		// runtime action is deliberately the SAME, and not branched: with no
+		// compiled config to apply, the bootstrap/lifeline safe state is
+		// exactly what #1960 prescribes for a present-but-uncompilable
+		// committed config, and the next boot re-derives it from disk through
+		// the main Load path. What DOES differ is the persistence, and the
+		// store now decides that from the recorded confirmPrevFirst flag
+		// rather than from this nil: the second provenance persists the target
+		// as COMMITTED, so the box is not durably re-classified into
+		// bootstrap. The log below therefore names both cases.
+		slog.Warn("commit confirmed timed out with no compiled rollback target (first commit " +
+			"on a fresh store, or a recovered rollback target that no longer compiles); " +
+			"rolling back to BOOTSTRAP mode (removing interface/FRR/dataplane takeover, " +
+			"keeping the management lifeline)")
 		// #5868: enterBootstrapMode now attempts every teardown step best-effort
 		// but returns an aggregated error (and has already logged each failed
 		// step + the DEGRADED summary at ERROR) if any step did not converge.


### PR DESCRIPTION
## Problem

A pending `commit confirmed` recovered at boot could **durably mark a real, previously-committed configuration as never-committed**, and an expired window could hand the daemon a **nil compiled config while `Store.Load` reported success**.

Two defects, one overloaded value.

### 1 — `confirmPrevCfg == nil` meant two different things

It means *"there was no compiled config to stash, because this genuinely is the first commit on a fresh store"* (#1922 Item 1b) — and it **also** means *"the rollback target recovered from `confirm.json` failed even the LENIENT compile"*.

That second case is not hypothetical. `Load` repairs the tree it reads out of `active.json` (`rewriteRetiredDataplaneType`, `SanitizeTreeControlChars`) but **never** the `PrevTree` carried inside `confirm.json`, so a target committed on an older build reaches `recoverPendingConfirmLocked` uncompilable. `system dataplane-type ebpf` is the concrete case, and it still fails `compileTreeLenient` today:

```
system dataplane-type ebpf   compileTreeLenient err=the legacy eBPF dataplane
                             backend has been retired ... (see #1373)
```

Two consumers derived first-commit-ness from that nil, and the action on the first meaning is destructive for the second:

- `PromoteRollback`'s `firstCommitRollback` wrote the **never-committed marker (committed=0) over a real config** and cleared `everCommitted`;
- `writeConfirmState` persisted `FirstCommit=true` on a nested re-arm, carrying the mislabelling across the next reboot — where the `rec.FirstCommit` branch writes `committed=0` again, so the restart after that **re-classifies a production box into bootstrap** (day-0 / claim-all).

### 2 — the expired-during-downtime branch reported success with no policy

It warned on the failed compile, assigned the nil into `s.compiled` and set `everCommitted = true`. `recoverPendingConfirmLocked` returned void from inside `Load`, so `Load`'s success return was already fixed: the daemon saw `ActiveConfig()==nil` + `EverCommitted()==true` and resolved to a **NORMAL boot with no compiled policy** — the positional claim-all rename on a box whose intended config is unknown, which is exactly the tuple #1960 fails closed on.

## Reproduced at `origin/master`

All three shapes, through the real entry points (`Store.Load`, the rollback timer, a nested `CommitConfirmed`):

```
--- FAIL: TestConfirmRecoveryExpiredUncompilableTargetFailsClosed
    Load reported SUCCESS while writing a nil compiled config:
    ActiveConfig()=nil, EverCommitted()=true.
--- FAIL: TestConfirmRecoveryInWindowRollbackDoesNotPersistNeverCommitted
    the auto-rollback persisted the NEVER-COMMITTED marker (committed=0) over a
    real previously-committed config...
--- FAIL: TestConfirmRecoveryInWindowNestedArmKeepsFirstCommitFalse
    the nested arm persisted FirstCommit=true for a rollback target that is a
    REAL previously-committed config...
```

## Fix

`Store.confirmPrevFirst` records the fact **where it is known** — the arm site reads the PRE-promotion `s.compiled` (so its meaning is unchanged there), and the recovery site reads the persisted `rec.FirstCommit`, which is the only authority on whether `PrevTree` is the empty bootstrap tree. Both consumers read the flag rather than re-deriving it.

`recoverPendingConfirmLocked` now returns an error and `Load` propagates it, tagged `ErrConfigCompile` so `classifyLoadError` routes it to `loadCompileFailed` and the #1922 bootstrap/lifeline safe state. The rollback still completes first — reverting the unconfirmed config is the safety property, and the reverted tree must stay reachable so the operator can fix it from the CLI.

The **runtime** action on a nil `prevCfg` is deliberately left **unbranched**. With no compiled config to apply, `enterBootstrapMode`'s lifeline safe state is what #1960 prescribes for a present-but-uncompilable committed config, and the next boot re-derives it from disk through the main `Load` path. Only the *persistence* differed between the two provenances, so adding a daemon branch whose two sides did the same thing would be churn, not a fix. The daemon's comment and log line now name both provenances.

## Acceptance criteria

- [x] A rollback target that fails the lenient compile does not yield `everCommitted=true` with `compiled==nil` — `Load` fails closed with `ErrConfigCompile` instead.
- [x] A real rollback never persists `committed=0`.
- [x] Fail-on-revert tests for both branches (the issue notes zero prior coverage; four tests added).

## Validation

`go vet ./pkg/configstore ./pkg/daemon` clean; `go build ./...` clean. `go test -count=1` green for `pkg/configstore` (9.1s), `pkg/daemon` (38.4s), `pkg/cluster`, `pkg/cli`, `pkg/grpcapi`, `pkg/api`.

RUN-line count proving the mutation filter is non-vacuous: the 5-name filter selects **5** `=== RUN` lines.

Four mutations, applied **one at a time**, `go vet` clean before each (so every red is an assertion, not a build break), exit code read from `$?` directly:

| # | mutation | vet | rc | reds | stays green |
|---|---|---|---|---|---|
| A | drop the `ErrConfigCompile` signal (part 1) | 0 | 1 | `ExpiredUncompilableTargetFailsClosed` | other 4 |
| B | `PromoteRollback` derives from `prevCfg == nil` | 0 | 1 | `InWindowRollbackDoesNotPersistNeverCommitted` | other 4 |
| C | `writeConfirmState` derives from `confirmPrevCfg == nil` | 0 | 1 | `InWindowNestedArmKeepsFirstCommitFalse` | other 4 |
| D | recovery stops recording `rec.FirstCommit` | 0 | 1 | `InWindowGenuineFirstCommitStillWritesNeverCommitted` | other 4 |

Rows B and D are the **discriminator**: a fix that hard-coded either answer for first-commit-ness reds one of them. The pre-existing `TestFirstCommitRollbackWritesNeverCommittedMarker` (#1922 Item 1b) stays green under all four, so the genuine first-commit behaviour is not reverted. After each mutation the file was restored and `md5sum -c` confirmed byte-identity; `go test` rc returned to 0.

Reaching production paths for the mutated sites:

- `Run` -> `daemon_run_bringup.go:283` `d.store.Load()` -> `recoverPendingConfirmLocked` — every daemon boot with a `confirm.json` present;
- the confirm timer -> `fireConfirmTimer` -> `executeConfirmedRollback` -> `Store.PromoteRollback` (or `performAutoRollback` with no executor);
- `CommitConfirmed`/`CommitConfirmedGen` -> `commitConfirmedLocked` -> `writeConfirmState`.

## Cluster

**Go control plane only.** No Rust helper change, no shim `.o`, no wire/protocol change. It does not touch session sync, VRRP, failover or fabric forwarding. `Store.SyncApply` (the HA config-sync ingress) is untouched — the changed sites are `Load`, `CommitConfirmed`'s arm, and `PromoteRollback`. My read is that it does **not** owe cluster time; flagging explicitly because commit-confirmed interacts with HA config sync at the *confirmation* sites, which are unchanged here.

## Docs

- `pkg/configstore/README.md`: the `confirm.json` description now names `confirmPrevFirst`, plus two new sections — "First-commit-ness is RECORDED, not re-derived from the nil (#6538)" and "The expired-during-downtime branch fails closed (#6538)".
- `pkg/daemon/README.md`: the #1960 fail-closed section gains "The boot commit-confirmed recovery reaches the same guard (#6538)".

Closes #6538