### PR TITLE
selftest: cover the boot-firmware registrar and guard the lint list

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-08-22 — #6499 boot-firmware self-tests + lint-list drift guard
+
+- **Timestamp**: 2026-08-22
+- **Action**: Added 17 hermetic functional tests driving the real
+  `xpf-uefi-slots` under `/bin/sh` with a mock efibootmgr that models
+  NVRAM as state files, covering the four destructive classes
+  (wrong-loader-path deletion, duplicate dedup, promoted-slot BootOrder
+  preservation, empty-BootOrder no-write). Added a coverage guard over
+  `SH_SCRIPTS` catching drift in both directions — a shipped
+  `scripts/image/xpf-*` missing from the lint list, and a listed path
+  that no longer exists (which `:103`'s `|| continue` would drop
+  silently). Two of the issue's three acceptance criteria were already
+  satisfied at master (`xpf-kernel-promote` is in SH_SCRIPTS as of
+  de74cc2db, and its rc contract is covered by
+  test_kernel_promote_explicit_path.py); confirmed rather than
+  re-implemented. Tests are Python so the `run-selftests.sh:139` glob
+  discovers them — a shell self-test would not be run (#7296).
+- **File(s)**: scripts/image/xpf-uefi-slots,
+  scripts/image/test_uefi_slots_6499.py,
+  scripts/test_selftest_lint_coverage_6499.py,
+  docs/install-images.md
+
 ## 2026-08-22 — #6521 RFC 6052 citation correction (§2.2 → §3.1)
 
 - **Timestamp**: 2026-08-22

--- a/docs/install-images.md
+++ b/docs/install-images.md
@@ -506,9 +506,36 @@ external tool is missing SKIPs rather than fails, so the runner is green
 on a minimal host and only goes RED on a genuine regression. It covers:
 
 - shell parse-check (`sh`/`bash -n`) + `shellcheck` over the image/dist
-  shell scripts (`xpf-day0-config`, `xpf-grow-root`, `selftest.sh`, …);
+  shell scripts (`xpf-day0-config`, `xpf-grow-root`, `xpf-uefi-slots`,
+  `xpf-kernel-promote`, `selftest.sh`, …). That list is a HAND enumeration,
+  so `scripts/test_selftest_lint_coverage_6499.py` guards it both ways:
+  every shipped `scripts/image/xpf-*` shell script must be listed (a
+  shipped production script with no parse check at all — #6499), and
+  every listed path must still exist (`run-selftests.sh:103` skips a
+  missing path silently, so a rename deletes a lint leg without a word
+  in the output);
 - `scripts/image/test-grow-root.sh` — grow-root device resolution + stamp
   discipline (#1925);
+- `scripts/image/test_uefi_slots_6499.py` — the **boot-firmware**
+  registrar's destructive paths (#6499). `xpf-uefi-slots` mutates firmware
+  NVRAM on every boot of every shipped appliance — it deletes boot
+  entries, dedups them, and rewrites BootOrder — and `sh -n` +
+  `shellcheck` cannot see that a logic change wipes a customer box's
+  PXE/recovery entries or undoes a promoted kernel slot. The real script
+  runs under a real `/bin/sh` with a mock `efibootmgr` modelling NVRAM as
+  state files, so the four classes a reviewer caught during #1930 are
+  regression fixtures: wrong-loader-path deletion, duplicate dedup,
+  promoted-slot BootOrder preservation, and the empty-BootOrder no-write
+  guard (a reseed built from an unreadable BootOrder would emit
+  `--bootorder <A>,<B>` and wipe everything else). `[ -b "$ESP_DISK" ]` is
+  not relaxed by a test hook — the mock names a partition of a real host
+  block device — and only two path roots are overridable
+  (`XPF_UEFI_SLOTS_EFIVARS`, `XPF_UEFI_SLOTS_ESP`), the same pattern
+  `xpf-grow-root` uses;
+- `scripts/image/test_kernel_promote_explicit_path.py` — the promotion
+  gate's authority model AND its rc contract (`0` → continue, `3` →
+  reboot to known-good and still exit 0, `1`/other → infra error, do NOT
+  reboot into a bounce loop);
 - `scripts/image/test_bake_sign_ordering.py` — VALIDATE-before-SIGN
   ordering (#4017) + frr-pythontools presence;
 - `scripts/image/test_validate_scenarios.py` — the `validate.py` scenario

--- a/scripts/image/test_uefi_slots_6499.py
+++ b/scripts/image/test_uefi_slots_6499.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Hermetic functional self-test for scripts/image/xpf-uefi-slots (#6499).
+
+`xpf-uefi-slots` MUTATES FIRMWARE NVRAM on every boot of every shipped
+appliance: it deletes boot entries, dedups them, and rewrites BootOrder. Until
+this file it was covered by `sh -n` and `shellcheck` alone — a parse check and
+a style check, neither of which can see that a logic change wipes a customer
+box's PXE/recovery entries or undoes a promoted kernel slot.
+
+Three of the guards below exist because a reviewer caught the corresponding
+destructive class DURING #1930, so they are regression fixtures, not
+hypotheticals:
+
+  * wrong-path deletion — an entry that merely shares the LABEL but points
+    somewhere else must be deleted, or the slot chainloads the wrong loader
+    and poisons BootNext (r1/r2 Codex High);
+  * duplicate dedup — the original label guard was anchored at `$`, missed the
+    TAB-then-loader-path shape, and created duplicate slots live. A duplicated
+    slot makes BootNext ambiguous;
+  * promoted-slot preservation — a self-heal that re-seeded "A first"
+    UNDID a promotion to B (r1 Codex High);
+  * empty-BootOrder no-write — a reseed built from an unreadable BootOrder
+    would emit `--bootorder <A>,<B>`, WIPING every other entry: PXE, recovery,
+    the firmware's own (r1 AGY destructive-wipe).
+
+Method: the REAL script, run by a REAL /bin/sh, with PATH shadowed by a mock
+`efibootmgr` that models NVRAM as two state files and a mock `findmnt` — the
+`test-grow-root.sh` pattern, moved to Python so `run-selftests.sh:139` picks it
+up by glob (the shell self-test list at :146-160 is hand-enumerated; #7296).
+
+Non-tautological by construction: every assertion reads the mock's NVRAM state
+or its recorded argv AFTER the real script ran. Nothing here re-implements the
+script's logic.
+
+`[ -b "$ESP_DISK" ]` is NOT relaxed by a test hook — the mock `findmnt` names a
+partition of a REAL host block device, so the script's own device sanity check
+is exercised rather than bypassed.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE / "xpf-uefi-slots"
+
+UBUNTU = "0000|ubuntu|\\EFI\\ubuntu\\shimx64.efi"
+PXE = "0001|UEFI PXEv4|PciRoot(0x0)/Pci(0x2,0x0)/MAC(001122334455,1)"
+
+MOCK_EFIBOOTMGR = r"""#!/bin/sh
+# Mock efibootmgr modelling NVRAM as $MOCK_NVRAM/{entries,order}.
+#   entries: one "ID|LABEL|LOADER" per line
+#   order:   a bare comma list
+# Every invocation's argv is appended to $MOCK_NVRAM/calls.
+NV="$MOCK_NVRAM"
+printf '%s\n' "$*" >> "$NV/calls"
+[ -n "${MOCK_EFIBOOTMGR_RC:-}" ] && exit "$MOCK_EFIBOOTMGR_RC"
+
+mode=render; del_id=""; label=""; loader=""; neworder=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --quiet) ;;
+    -b) del_id="$2"; shift ;;
+    -B) mode=delete ;;
+    --create) mode=create ;;
+    --disk|--part) shift ;;
+    --label) label="$2"; shift ;;
+    --loader) loader="$2"; shift ;;
+    --bootorder) mode=order; neworder="$2"; shift ;;
+    esac
+    shift
+done
+
+drop_from_order() {
+    o=$(cat "$NV/order" 2>/dev/null)
+    printf '%s' "$o" | tr ',' '\n' | grep -vxF "$1" | paste -sd, - > "$NV/order.new"
+    mv "$NV/order.new" "$NV/order"
+}
+
+case "$mode" in
+delete)
+    grep -v "^${del_id}|" "$NV/entries" > "$NV/entries.new" 2>/dev/null || true
+    mv "$NV/entries.new" "$NV/entries"
+    drop_from_order "$del_id"
+    ;;
+create)
+    [ -n "${MOCK_CREATE_RC:-}" ] && exit "$MOCK_CREATE_RC"
+    n=$(cat "$NV/nextid" 2>/dev/null || echo 16)
+    id=$(printf '%04X' "$n")
+    echo "$((n + 1))" > "$NV/nextid"
+    printf '%s|%s|%s\n' "$id" "$label" "$loader" >> "$NV/entries"
+    # Real efibootmgr PREPENDS a new entry to BootOrder.
+    o=$(cat "$NV/order" 2>/dev/null)
+    if [ -n "$o" ]; then printf '%s,%s' "$id" "$o" > "$NV/order"
+    else printf '%s' "$id" > "$NV/order"; fi
+    ;;
+order)
+    printf '%s' "$neworder" > "$NV/order"
+    ;;
+render)
+    echo "BootCurrent: 0000"
+    echo "Timeout: 0 seconds"
+    if [ -z "${MOCK_HIDE_BOOTORDER:-}" ]; then
+        o=$(cat "$NV/order" 2>/dev/null)
+        [ -n "$o" ] && printf 'BootOrder: %s\n' "$o"
+    fi
+    while IFS='|' read -r id lbl ldr; do
+        [ -n "$id" ] || continue
+        printf 'Boot%s* %s\t HD(1,GPT,1234)/File(%s)\n' "$id" "$lbl" "$ldr"
+    done < "$NV/entries"
+    ;;
+esac
+exit 0
+"""
+
+MOCK_FINDMNT = """#!/bin/sh
+# Only `findmnt -no SOURCE <esp>` is used by the script.
+printf '%s\\n' "${MOCK_ESP_SRC:-}"
+"""
+
+
+def _real_block_device():
+    """A REAL host block device, so `[ -b "$ESP_DISK" ]` is exercised for real.
+
+    Returns (esp_src, esp_disk). The partition suffix mirrors the kernel's own
+    naming — `p1` when the device name ends in a digit (nvme0n1p1, loop0p1),
+    plain `1` otherwise (sda1) — which is exactly the shape the script's
+    `s/p?[0-9]+$//` parse handles.
+    """
+    try:
+        names = sorted(os.listdir("/dev"))
+    except OSError:
+        return None, None
+    for name in names:
+        p = os.path.join("/dev", name)
+        try:
+            if not stat.S_ISBLK(os.stat(p).st_mode):
+                continue
+        except OSError:
+            continue
+        return p + ("p1" if name[-1].isdigit() else "1"), p
+    return None, None
+
+
+class _SlotsBase(unittest.TestCase):
+    def setUp(self):
+        self.assertTrue(SCRIPT.is_file(), f"{SCRIPT} missing")
+        esp_src, esp_disk = _real_block_device()
+        if not esp_src:
+            self.skipTest("no host block device to name as the ESP source")
+        self.esp_src, self.esp_disk = esp_src, esp_disk
+
+        self.tmp = Path(tempfile.mkdtemp(prefix="xpf-uefi-slots-test."))
+        self.addCleanup(lambda: subprocess.run(["rm", "-rf", str(self.tmp)]))
+
+        self.bin = self.tmp / "bin"
+        self.bin.mkdir()
+        for name, body in (("efibootmgr", MOCK_EFIBOOTMGR), ("findmnt", MOCK_FINDMNT)):
+            f = self.bin / name
+            f.write_text(body)
+            f.chmod(0o755)
+
+        self.nvram = self.tmp / "nvram"
+        self.nvram.mkdir()
+        (self.nvram / "entries").write_text("")
+        (self.nvram / "order").write_text("")
+
+        # Synthetic efivars dir + ESP. Both slots staged by default; a test
+        # that models an unstaged slot removes one.
+        self.efivars = self.tmp / "efivars"
+        self.efivars.mkdir()
+        self.esp = self.tmp / "esp"
+        for slot in ("xpf-A", "xpf-B"):
+            d = self.esp / "EFI" / slot
+            d.mkdir(parents=True)
+            (d / "shimx64.efi").write_text("shim")
+            (d / "grubx64.efi").write_text("grub")
+
+        self.env_extra = {}
+
+    # ── NVRAM helpers ──
+    def seed(self, entries, order):
+        (self.nvram / "entries").write_text(
+            "".join(e + "\n" for e in entries))
+        (self.nvram / "order").write_text(order)
+
+    def entries(self):
+        """[(id, label, loader)] currently in the mock NVRAM."""
+        out = []
+        for line in (self.nvram / "entries").read_text().splitlines():
+            if line.strip():
+                out.append(tuple(line.split("|", 2)))
+        return out
+
+    def order(self):
+        return [x for x in (self.nvram / "order").read_text().split(",") if x]
+
+    def ids_for(self, label):
+        return [i for i, l, _ in self.entries() if l == label]
+
+    def calls(self):
+        p = self.nvram / "calls"
+        return p.read_text().splitlines() if p.exists() else []
+
+    def run_slots(self):
+        env = dict(os.environ)
+        env.update({
+            "PATH": f"{self.bin}:{env.get('PATH', '')}",
+            "MOCK_NVRAM": str(self.nvram),
+            "MOCK_ESP_SRC": self.esp_src,
+            "XPF_UEFI_SLOTS_EFIVARS": str(self.efivars),
+            "XPF_UEFI_SLOTS_ESP": str(self.esp),
+        })
+        env.update(self.env_extra)
+        res = subprocess.run(["/bin/sh", str(SCRIPT)], env=env,
+                             capture_output=True, text=True)
+        # The script's whole contract is "degraded, not bricked": it must never
+        # fail the boot, on any path.
+        self.assertEqual(res.returncode, 0,
+                         f"the slot registrar must always exit 0: {res.stderr}")
+        return res
+
+
+class FreshBoxTests(_SlotsBase):
+    def test_fresh_box_registers_both_slots_with_their_own_shim(self):
+        self.seed([UBUNTU, PXE], "0000,0001")
+        self.run_slots()
+        got = {l: ldr for _, l, ldr in self.entries()}
+        self.assertEqual(got.get("xpf-A"), "\\EFI\\xpf-A\\shimx64.efi")
+        self.assertEqual(got.get("xpf-B"), "\\EFI\\xpf-B\\shimx64.efi")
+
+    def test_fresh_box_seeds_a_first_then_b_and_keeps_the_other_entries(self):
+        # efibootmgr --create PREPENDS, so creating A then B would leave B in
+        # front without the explicit seed (caught live during #1930).
+        self.seed([UBUNTU, PXE], "0000,0001")
+        self.run_slots()
+        a = self.ids_for("xpf-A")[0]
+        b = self.ids_for("xpf-B")[0]
+        self.assertEqual(self.order()[:2], [a, b])
+        # Non-destructive: every pre-existing entry survives, in order.
+        self.assertEqual(self.order()[2:], ["0000", "0001"])
+
+    def test_rerun_is_idempotent_and_creates_no_duplicates(self):
+        self.seed([UBUNTU, PXE], "0000,0001")
+        self.run_slots()
+        first = sorted(self.entries())
+        self.run_slots()
+        self.assertEqual(sorted(self.entries()), first,
+                         "a second boot changed NVRAM — the registrar is not "
+                         "idempotent")
+
+    def test_unstaged_slot_is_skipped_without_failing_the_boot(self):
+        (self.esp / "EFI" / "xpf-B" / "shimx64.efi").unlink()
+        self.seed([UBUNTU], "0000")
+        res = self.run_slots()
+        self.assertEqual(self.ids_for("xpf-B"), [])
+        self.assertIn("ESP dir not staged", res.stderr)
+        self.assertEqual(len(self.ids_for("xpf-A")), 1)
+
+
+class WrongPathAndDuplicateTests(_SlotsBase):
+    def test_entry_sharing_the_label_but_not_the_loader_is_deleted(self):
+        # A stale/foreign label collision would chainload the wrong loader and
+        # poison BootNext (r1/r2 Codex High).
+        self.seed(["0007|xpf-A|\\EFI\\ubuntu\\shimx64.efi", UBUNTU],
+                  "0007,0000")
+        res = self.run_slots()
+        self.assertIn("deleting WRONG-path entry Boot0007", res.stderr)
+        self.assertNotIn("0007", [i for i, _, _ in self.entries()])
+        ids = self.ids_for("xpf-A")
+        self.assertEqual(len(ids), 1)
+        self.assertEqual(
+            [ldr for i, l, ldr in self.entries() if i == ids[0]][0],
+            "\\EFI\\xpf-A\\shimx64.efi")
+
+    def test_duplicate_correct_entries_are_deduped_to_exactly_one(self):
+        # The original label guard was anchored at `$` and missed the
+        # TAB-then-path shape, so every boot created another slot.
+        self.seed(["0007|xpf-A|\\EFI\\xpf-A\\shimx64.efi",
+                   "0008|xpf-A|\\EFI\\xpf-A\\shimx64.efi", UBUNTU],
+                  "0007,0008,0000")
+        res = self.run_slots()
+        self.assertIn("deleting duplicate correct entry", res.stderr)
+        self.assertEqual(len(self.ids_for("xpf-A")), 1,
+                         "a duplicated slot makes BootNext ambiguous")
+        # The FIRST correct one is kept, and no new entry was created for A.
+        self.assertEqual(self.ids_for("xpf-A"), ["0007"])
+
+    def test_a_wrong_path_duplicate_pair_leaves_one_correct_entry(self):
+        # Both classes at once: one correct, one label-colliding.
+        self.seed(["0007|xpf-A|\\EFI\\xpf-A\\shimx64.efi",
+                   "0008|xpf-A|\\EFI\\foreign\\shimx64.efi", UBUNTU],
+                  "0007,0008,0000")
+        self.run_slots()
+        self.assertEqual(self.ids_for("xpf-A"), ["0007"])
+
+    def test_loader_path_match_is_case_insensitive(self):
+        # efibootmgr renders firmware paths in whatever case the entry holds;
+        # the shell guard matches case-insensitively, so an upper-case render
+        # must NOT be treated as a wrong-path entry and deleted.
+        self.seed(["0007|xpf-A|\\EFI\\XPF-A\\SHIMX64.EFI", UBUNTU], "0007,0000")
+        res = self.run_slots()
+        self.assertNotIn("deleting WRONG-path entry Boot0007", res.stderr)
+        self.assertEqual(self.ids_for("xpf-A"), ["0007"])
+
+
+class BootOrderTests(_SlotsBase):
+    def test_promoted_slot_b_stays_in_front_and_is_not_reseeded_to_a(self):
+        # The kernel channel promoted B. A self-heal that forced "A first"
+        # would UNDO that promotion (r1 Codex High) — silently, on the next
+        # ordinary boot.
+        self.seed(["0007|xpf-A|\\EFI\\xpf-A\\shimx64.efi",
+                   "0008|xpf-B|\\EFI\\xpf-B\\shimx64.efi", UBUNTU],
+                  "0008,0007,0000")
+        self.run_slots()
+        self.assertEqual(self.order()[0], "0008",
+                         "the promoted slot lost the BootOrder front")
+
+    def test_promoted_b_is_preserved_even_when_slot_a_must_be_recreated(self):
+        # B promoted, A's entry lost (a firmware reset that took one entry).
+        # The self-heal recreates A — and --create PREPENDS — so the promoted
+        # default must be re-asserted, not left wherever the create put it.
+        self.seed(["0008|xpf-B|\\EFI\\xpf-B\\shimx64.efi", UBUNTU], "0008,0000")
+        self.run_slots()
+        self.assertEqual(self.order()[0], "0008")
+        self.assertEqual(len(self.ids_for("xpf-A")), 1)
+
+    def test_unreadable_bootorder_writes_no_bootorder_at_all(self):
+        # A reseed built from an EMPTY $ORDER would emit `--bootorder <A>,<B>`
+        # and WIPE every other entry — PXE, recovery, the firmware's own. The
+        # guard must leave NVRAM's order untouched instead.
+        self.seed(["0007|xpf-A|\\EFI\\xpf-A\\shimx64.efi",
+                   "0008|xpf-B|\\EFI\\xpf-B\\shimx64.efi", UBUNTU, PXE],
+                  "0007,0008,0000,0001")
+        self.env_extra["MOCK_HIDE_BOOTORDER"] = "1"
+        res = self.run_slots()
+        self.assertIn("could not read BootOrder", res.stderr)
+        self.assertEqual(
+            [c for c in self.calls() if "--bootorder" in c], [],
+            "the registrar wrote a BootOrder it could not read first — that "
+            "reseed wipes PXE/recovery/firmware entries")
+        self.assertEqual(self.order(), ["0007", "0008", "0000", "0001"],
+                         "the pre-existing BootOrder was not left intact")
+
+    def test_no_xpf_slot_id_leaves_bootorder_unchanged(self):
+        # Nothing staged at all: no slot can be registered, so there is no
+        # xpf-A id to seed with and BootOrder must be left alone.
+        for slot in ("xpf-A", "xpf-B"):
+            (self.esp / "EFI" / slot / "shimx64.efi").unlink()
+        self.seed([UBUNTU, PXE], "0000,0001")
+        res = self.run_slots()
+        self.assertIn("no xpf-A slot id", res.stderr)
+        self.assertEqual(self.order(), ["0000", "0001"])
+        self.assertEqual([c for c in self.calls() if "--bootorder" in c], [])
+
+
+class NonFatalDegradeTests(_SlotsBase):
+    def test_efibootmgr_that_cannot_read_nvram_skips_without_touching_state(self):
+        self.seed([UBUNTU, PXE], "0000,0001")
+        self.env_extra["MOCK_EFIBOOTMGR_RC"] = "1"
+        res = self.run_slots()
+        self.assertIn("cannot read NVRAM", res.stderr)
+        self.assertEqual(self.entries(), [("0000", "ubuntu", UBUNTU.split("|", 2)[2]),
+                                          ("0001", "UEFI PXEv4", PXE.split("|", 2)[2])])
+        self.assertEqual(self.order(), ["0000", "0001"])
+
+    def test_no_efivars_directory_skips(self):
+        for f in self.efivars.iterdir():
+            f.unlink()
+        self.efivars.rmdir()
+        res = self.run_slots()
+        self.assertIn("not a UEFI boot", res.stderr)
+        self.assertEqual(self.calls(), [])
+
+    def test_no_esp_mounted_skips(self):
+        self.env_extra["MOCK_ESP_SRC"] = ""
+        res = self.run_slots()
+        self.assertIn("no ESP mounted", res.stderr)
+
+    def test_unparseable_esp_source_skips(self):
+        # A source with no trailing partition number, or whose disk half is
+        # not a block device, must not reach efibootmgr --create with garbage.
+        self.env_extra["MOCK_ESP_SRC"] = "/dev/does-not-exist9"
+        res = self.run_slots()
+        self.assertIn("could not parse ESP disk/part", res.stderr)
+        self.assertEqual([c for c in self.calls() if "--create" in c], [])
+
+    def test_a_failing_create_is_non_fatal_and_does_not_write_bootorder(self):
+        self.seed([UBUNTU], "0000")
+        self.env_extra["MOCK_CREATE_RC"] = "1"
+        res = self.run_slots()
+        self.assertIn("failed to register slot", res.stderr)
+        self.assertEqual(self.order(), ["0000"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/image/xpf-uefi-slots
+++ b/scripts/image/xpf-uefi-slots
@@ -34,8 +34,24 @@ export LC_ALL=C LANG=C
 
 log() { echo "xpf-uefi-slots: $*" >&2; }
 
+# The efivars directory and the ESP mountpoint are overridable for the
+# self-test (scripts/image/test_uefi_slots_6499.py) only; in production they
+# are the real kernel/ESP paths. This script MUTATES firmware NVRAM and can
+# delete boot entries, so its destructive paths need hermetic coverage — and
+# they cannot be reached at all without pointing these two roots at a
+# synthetic tree (same pattern as xpf-grow-root's XPF_GROW_ROOT_SYSFS /
+# XPF_GROW_ROOT_STAMP). Everything else — efibootmgr, findmnt — is resolved
+# from PATH, which the self-test shadows with mocks, and the `-b "$ESP_DISK"`
+# sanity check below is NOT relaxed: the self-test hands the parse a REAL host
+# block device so that check is exercised rather than bypassed.
+#
+# The UEFI LOADER path (\EFI\<slot>\shimx64.efi) is deliberately NOT derived
+# from these: it is a firmware path interpreted by the firmware, not a mount.
+EFIVARS_DIR="${XPF_UEFI_SLOTS_EFIVARS:-/sys/firmware/efi/efivars}"
+ESP_ROOT="${XPF_UEFI_SLOTS_ESP:-/boot/efi}"
+
 # --- capability gate: UEFI + efibootmgr + writable efivars (all non-fatal) ---
-if [ ! -d /sys/firmware/efi/efivars ]; then
+if [ ! -d "$EFIVARS_DIR" ]; then
     log "not a UEFI boot (no efivars); LANE-1 kernel channel unavailable — skipping"
     exit 0
 fi
@@ -49,9 +65,9 @@ if ! efibootmgr >/dev/null 2>&1; then
 fi
 
 # --- discover the ESP block device + partition for --disk/--part ---
-ESP_SRC=$(findmnt -no SOURCE /boot/efi 2>/dev/null || true)
+ESP_SRC=$(findmnt -no SOURCE "$ESP_ROOT" 2>/dev/null || true)
 if [ -z "$ESP_SRC" ]; then
-    log "no ESP mounted at /boot/efi; skipping"
+    log "no ESP mounted at $ESP_ROOT; skipping"
     exit 0
 fi
 # /dev/sda1 -> disk=/dev/sda part=1 ; /dev/nvme0n1p1 -> disk=/dev/nvme0n1 part=1
@@ -102,7 +118,7 @@ register_slot() {
         return 0
     fi
     # the slot's ESP dir must exist (bake/INC-1 staged shim+grub there)
-    if [ ! -f "/boot/efi/EFI/${slot}/shimx64.efi" ]; then
+    if [ ! -f "$ESP_ROOT/EFI/${slot}/shimx64.efi" ]; then
         log "slot ${slot} ESP dir not staged (no shimx64.efi); skipping ${slot}"
         return 1
     fi

--- a/scripts/test_selftest_lint_coverage_6499.py
+++ b/scripts/test_selftest_lint_coverage_6499.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Guard: `run-selftests.sh`'s shell-lint list covers every shipped
+`scripts/image/xpf-*` shell script (#6499).
+
+`scripts/run-selftests.sh:12` says the runner "DISCOVERS and runs every
+hermetic self-test", but its shell-syntax lint (`SH_SCRIPTS`, :90-100) is a
+HAND ENUMERATION. A hand enumeration drifts silently: a script gets added to
+the image surface, nobody remembers the list, and a shipped production
+script — one the bake installs and enables — never gets so much as a parse
+check. `xpf-kernel-promote` was exactly that for a while: installed and enabled
+by `bake.py:501-507`, with an exit-3 path that REBOOTS the appliance, and
+absent from the list. (It is in the list now, so this guard is what keeps the
+next one from repeating it rather than a fix for that instance.)
+
+Two directions, because the list can rot both ways:
+
+  * a shipped script MISSING from the list — the #6499 defect: no lint at all;
+  * a listed path that no longer EXISTS — `run-selftests.sh:103` does
+    `[ -f "$s" ] || continue`, so a renamed or deleted script makes its lint
+    leg silently vanish. That is the same drift wearing the other face, and it
+    is invisible in the summary line (the PASS count just quietly drops).
+
+SCOPE — SHELL scripts only. The runner picks its interpreter from each
+script's shebang (`*bash*` -> bash, everything else -> sh), so a hypothetical
+`scripts/image/xpf-*` written in Python does not belong in a shell-lint list
+and is deliberately not required here. The membership test is therefore
+"shebang names a shell", not "the filename matches".
+
+This is NOT #7296. That issue is about the runner's *execution* discovery:
+`:139` globs Python self-tests over four directories while `:146-160`
+hand-enumerates the SHELL self-tests, so a hermetic `.sh` self-test can exist
+and never RUN. Different list, different failure mode (an unrun test vs an
+unlinted script), different fix. This guard touches only `SH_SCRIPTS`.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+RUNNER = ROOT / "scripts" / "run-selftests.sh"
+IMAGE_DIR = ROOT / "scripts" / "image"
+
+
+def _sh_scripts():
+    """The paths listed in run-selftests.sh's SH_SCRIPTS block."""
+    text = RUNNER.read_text(encoding="utf-8")
+    m = re.search(r'^SH_SCRIPTS="\n(.*?)\n"$', text, re.MULTILINE | re.DOTALL)
+    assert m, "could not locate the SH_SCRIPTS block in run-selftests.sh"
+    return [ln.strip() for ln in m.group(1).splitlines() if ln.strip()]
+
+
+def _shipped_image_shell_scripts():
+    """Every `scripts/image/xpf-*` regular file whose shebang names a shell."""
+    out = []
+    for p in sorted(IMAGE_DIR.glob("xpf-*")):
+        if not p.is_file():
+            continue
+        try:
+            with p.open("rb") as fh:
+                first = fh.readline().decode("utf-8", "replace")
+        except OSError:
+            continue
+        if not first.startswith("#!"):
+            continue
+        if not re.search(r"\b(ba|da|k|z)?sh\b", first):
+            continue
+        out.append(p.relative_to(ROOT).as_posix())
+    return out
+
+
+class LintListCoverageTests(unittest.TestCase):
+    def test_the_sh_scripts_block_is_parseable(self):
+        # A guard that cannot find the list would pass vacuously over an empty
+        # set — the worst outcome, since it argues against re-examining it.
+        listed = _sh_scripts()
+        self.assertGreater(len(listed), 5,
+                           "SH_SCRIPTS parsed to almost nothing — the guard is "
+                           "reading the wrong thing and would pass vacuously")
+
+    def test_the_shipped_script_scan_is_not_empty(self):
+        found = _shipped_image_shell_scripts()
+        self.assertGreaterEqual(
+            len(found), 4,
+            "scripts/image/xpf-* scan found almost nothing — the guard would "
+            f"pass vacuously over an empty set (got {found})")
+
+    def test_every_shipped_image_shell_script_is_linted(self):
+        listed = set(_sh_scripts())
+        missing = [p for p in _shipped_image_shell_scripts() if p not in listed]
+        self.assertEqual(
+            missing, [],
+            "these shipped scripts/image/xpf-* shell scripts are NOT in "
+            "run-selftests.sh's SH_SCRIPTS lint list, so `make selftest` never "
+            f"parse-checks them: {missing}. Add them to the list at "
+            "scripts/run-selftests.sh:90.")
+
+    def test_every_listed_script_still_exists(self):
+        # run-selftests.sh:103 skips a missing path silently, so a rename
+        # deletes a lint leg without a single word in the output.
+        gone = [p for p in _sh_scripts() if not (ROOT / p).is_file()]
+        self.assertEqual(
+            gone, [],
+            "these paths are in SH_SCRIPTS but do not exist, so their lint "
+            f"legs silently vanish (run-selftests.sh:103 `|| continue`): {gone}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`scripts/image/xpf-uefi-slots` **mutates firmware NVRAM on every boot of every shipped appliance** — it deletes boot entries, dedups them, and rewrites BootOrder. Its only coverage was `sh -n` and `shellcheck`: a parse check and a style check, neither of which can see that a logic change wipes a customer box's PXE/recovery entries or undoes a promoted kernel slot.

Three of the destructive classes it guards against were caught **by review during #1930**, so they belong in a suite rather than in comments. The fourth is the empty-BootOrder guard. All four are now regression fixtures:

| class | what a regression does |
|---|---|
| wrong-loader-path deletion | an entry sharing only the LABEL chainloads the wrong loader and poisons BootNext |
| duplicate dedup | the original label guard was anchored at `$`, missed the TAB-then-path shape, and created duplicate slots **live** |
| promoted-slot preservation | a self-heal that re-seeds "A first" silently **undoes a promotion to B** on the next ordinary boot |
| empty-BootOrder no-write | a reseed built from an unreadable BootOrder emits `--bootorder <A>,<B>` and **wipes PXE, recovery, and the firmware's own entries** |

## Method

`test_uefi_slots_6499.py` runs the **real script** under a real `/bin/sh`, PATH shadowed by a mock `efibootmgr` that models NVRAM as two state files and records every argv, plus a mock `findmnt` — the `test-grow-root.sh` pattern. Every assertion reads the mock's state or its recorded calls **after** the script ran; nothing re-implements the script's logic.

Written in **Python, not shell**, so `run-selftests.sh:139` picks it up by glob. The shell self-test list at `:146-160` is hand-enumerated and would not have run a `.sh` version — that asymmetry is #7296's, and this PR deliberately does not touch it.

Reaching those paths needs the efivars dir and the ESP mountpoint redirectable, so both gain an env override in the same documented style `xpf-grow-root` already uses (`XPF_GROW_ROOT_SYSFS` / `XPF_GROW_ROOT_STAMP`). **Nothing else is relaxed** — `[ -b "$ESP_DISK" ]` still runs, because the mock `findmnt` names a partition of a **real host block device**, so the device sanity check is exercised rather than bypassed. The UEFI loader path stays hardcoded: it is a firmware path, not a mount.

## The lint list

`run-selftests.sh:12` claims to "DISCOVER and run every hermetic self-test", but `SH_SCRIPTS` is a hand enumeration that drifts **both ways**: a shipped script can be missing from it (no parse check at all — the #6499 defect), and a listed path that no longer exists makes its lint leg vanish without a word, because `:103` does `[ -f "$s" ] || continue`. `test_selftest_lint_coverage_6499.py` guards both, with two **non-vacuity** assertions so a renamed or emptied list reds loudly instead of passing over nothing. Membership is decided by the **shebang naming a shell**, not the filename — the runner picks its interpreter from the shebang, so a Python `xpf-*` script would not belong in a shell lint list.

## Two acceptance criteria were already satisfied at master

Not re-implemented, and confirmed rather than assumed:

- **`xpf-kernel-promote` is already in the lint list** — `run-selftests.sh:94`, added by `de74cc2db`.
- **Its rc contract is already covered** by `test_kernel_promote_explicit_path.py` (65 tests, green): rc 0 → exit 0 via `_assert_ran`, rc 1 → exit 0 **without** reboot via `test_infra_error_does_not_reboot`, rc 3 → reboot issued **and** exit 0 via `test_revert_exit_3_still_reboots`. Ran the filter and confirmed it selected 2 tests, both passing, before concluding this.

## Validation

- 17 + 4 new hermetic tests. `make selftest`: **54 passed / 0 skipped / 0 failed** (was 52). `shellcheck -S warning` and `sh -n` still clean on the edited script.
- **Ten one-line mutations**, each confirmed to **parse** at the mutated state before the test run, each red, each with the full test count collected:

| mutation | red |
|---|---|
| revert the wrong-loader-path deletion | 2 |
| revert the duplicate dedup | 1 |
| revert the promoted-slot preservation | 2 |
| revert the empty-BootOrder no-write guard | 1 |
| restore the `$`-anchored label guard (the #1930 live bug) | 6 |
| drop the case-insensitive loader match | 1 |
| drop `xpf-kernel-promote` from `SH_SCRIPTS` | coverage guard |
| leave a stale path in `SH_SCRIPTS` | existence guard |
| drop a different script from the list | coverage guard |
| empty the list / rename it out from under the guard | vacuity guards (2 / 3) |

Tree clean and rc back to 0 after each.

## Scope

- **Rust helper binary: not reached.** Shell + Python + Markdown only.
- **Needs a live bake/boot: no.** Everything here is hermetic — no root, no incus, no network, no real NVRAM.
- The only production change is two env-overridable path roots in `xpf-uefi-slots`; production behaviour is byte-identical when neither is set.
- Docs: `docs/install-images.md`'s `make selftest` inventory now names both new legs, the drift guard, and the promote gate's rc contract.

Closes #6499

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cz2czGK3aA5MsMhkNkjHXX