### PR TITLE
dhcpserver: scope cluster DHCP mastership to RG members only

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -100554,3 +100554,21 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: pkg/cluster/manager.go, pkg/cluster/heartbeat_manager.go,
   pkg/daemon/daemon_ha_sync.go,
   pkg/cluster/heartbeat_start_stop_race_7257_test.go (new), pkg/cluster/README.md
+
+## 2026-08-21 — #6520: cluster DHCP RG filter drops node-local members
+- **Timestamp**: 2026-08-21
+- **Action**: `filterDHCPConfigForMasterRGs` built its keep-set only from RETH
+  members of MASTER RGs, so every interface with no redundancy group (the `fxp0`
+  lifeline, any node-local data interface) was removed from every
+  `dhcp-local-server` group on BOTH nodes and a node-local-only group vanished.
+  Mastership now scopes only RG-scoped members; a member in no RG is node-local
+  and always kept. Both sets come from one walker, `rethInterfacesMatchingRG`.
+  Second half: a group the filter SHRANK still carries the removed member's
+  pools, so `dhcpserver.subnetInterface` cross-bound them onto the survivor;
+  the filter now records `DHCPServerGroup.MembersFiltered` (runtime-only,
+  `json:"-"`) and the renderer omits Kea's per-subnet interface selector for
+  such a group, falling back to address-based subnet selection.
+- **File(s)**: pkg/daemon/daemon_ha.go, pkg/config/types_system.go,
+  pkg/dhcpserver/dhcpserver.go, pkg/daemon/dhcp_rg_filter_6520_test.go (new),
+  pkg/dhcpserver/kea_filtered_group_selector_6520_test.go (new),
+  pkg/daemon/README.md

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -1733,6 +1733,30 @@ type DHCPServerGroup struct {
 	Name       string
 	Interfaces []string
 	Pools      []*DHCPPool
+	// MembersFiltered marks a group whose Interfaces list is a RUNTIME-narrowed
+	// subset of what the operator authored — today only the chassis-cluster
+	// master-RG filter (daemon.filterDHCPConfigForMasterRGs) sets it. It is
+	// never set by the config compiler and never appears in a committed config.
+	//
+	// It exists because Interfaces and Pools are independent arrays with NO
+	// semantic edge: nothing records which pool belongs to which member. So once
+	// members are removed, "this group has exactly one interface" no longer
+	// implies "every pool in this group is served on that interface" — the
+	// inference dhcpserver.subnetInterface makes when it emits Kea's per-subnet
+	// interface selector. A mixed `[fxp0.0, reth0.80]` group narrowed to the
+	// surviving RETH member would otherwise bind the fxp0 pool's subnet to the
+	// RETH member (#6520). With this set the renderer omits the selector and
+	// Kea falls back to address-based subnet selection, which is correct for
+	// every group — just less robust than an explicit binding, which is why the
+	// selector is emitted at all.
+	//
+	// It is excluded from every marshal (`json:"-"`, `yaml:"-"`): it describes
+	// this PROCESS's current mastership view, not the operator's configuration,
+	// so it must not appear in the compiled-config dump (GET /api/v1/config),
+	// in the golden compile baseline, or in anything the cluster config-sync
+	// carries to the peer — where it would be read as a committed value the
+	// peer's own filter should not inherit.
+	MembersFiltered bool `json:"-" yaml:"-"`
 }
 
 // DHCPPool defines an address pool for DHCP leases.

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -773,6 +773,68 @@ reconcile passes: an edge pass whose apply fails, a no-transition pass that
 must re-drive it, and a third that must NOT) and
 `TestClaimApplyRetryOnlyAfterAFailedApply`, in
 `dhcp_apply_converger_6535_test.go`.
+
+### Cluster DHCP member scoping: node-local vs RG-scoped (#6520)
+
+`filterDHCPConfigForMasterRGs` decides which members of each
+`dhcp-local-server` / `dhcpv6-local-server` group this node serves. Two
+properties, both wrong before #6520.
+
+**Mastership scopes only RG-scoped members.** The keep-set used to be built
+exclusively from `rethInterfacesForRG` over the currently-MASTER RGs, and that
+function only ever yields members of `reth*` interfaces. Every interface that
+is *not* part of a redundancy group — the `fxp0` management lifeline, and any
+plain node-local data interface — was therefore removed from every group on
+BOTH nodes, and a group made only of such members vanished entirely. Clustering
+a box silently killed the DHCP service its operator had configured on a
+node-local segment. Redundancy-group mastership answers "which node answers for
+this REDUNDANT interface"; it says nothing about an interface with no redundant
+peer, and Junos clusters likewise run `fxp0` services per node. So:
+
+- a member that belongs to NO redundancy group is **node-local** and is kept
+  unconditionally, on both nodes;
+- a member that IS redundancy-group-scoped is kept only while this node masters
+  that RG (unchanged).
+
+Both sets come from ONE walker, `rethInterfacesMatchingRG`, of which
+`rethInterfacesForRG` is now a predicate wrapper. That is deliberate rather than
+stylistic: a divergence between "RG-scoped" and "mastered" is always a bug,
+because the keep rule is exactly *RG-scoped implies mastered*. If one set
+resolved a RETH member to a different name than the other, a node-local
+interface would read as an unmastered RG member (service dropped) or an RG
+member as node-local (both nodes serving DHCP on one redundant segment).
+
+**A narrowed group must not keep Kea's per-subnet interface selector.**
+`config.DHCPServerGroup` carries independent `Interfaces` and `Pools` arrays
+with no semantic edge — nothing records which pool belongs to which member. So
+once this filter removes a member, "the group has exactly one interface" no
+longer implies "every pool in the group is served on that interface", which is
+the inference `dhcpserver.subnetInterface` makes when it emits Kea's per-subnet
+`interface` selector (#1778). A mixed `[fxp0.0, reth0.80]` group narrowed to the
+surviving RETH member would bind the fxp0 pool's subnet to the RETH member.
+
+The filter therefore sets `DHCPServerGroup.MembersFiltered` whenever it actually
+shrinks a group, and `subnetInterface` omits the selector for such a group —
+falling back to Kea address-based subnet selection, the same mechanism every
+multi-interface group already uses. This never changes WHICH subnets are served,
+only how Kea selects among them. `MembersFiltered` is a runtime marker, excluded
+from every marshal (`json:"-"`, `yaml:"-"`) so it cannot reach the
+compiled-config dump, the golden compile baseline, or the peer over cluster
+config-sync.
+
+Dropping the whole group instead was considered and rejected: for a mixed-RG
+group in active/active (say `reth0.80` in RG1 and `reth1.0` in RG2) BOTH nodes
+would drop it and DHCP would stop everywhere.
+
+Guards: `pkg/daemon/dhcp_rg_filter_6520_test.go` (node-local member kept beside
+a mastered RETH member; node-local-only group survives on a node mastering
+nothing; an RG-scoped member of a BACKUP RG is still removed; the flag is set
+exactly when the group shrank) and
+`pkg/dhcpserver/kea_filtered_group_selector_6520_test.go` (the renderer emits no
+per-subnet selector for a narrowed group, and still emits one for an authored
+singleton). The two files name their own side of the agreement so a failure says
+which half broke.
+
 ### Out-of-band `rg_active` writers must re-arm the reconcile retry (#6530)
 
 `rgStateMachine` (`rg_state.go`) tracks a desired `active` value and an

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -1340,12 +1340,27 @@ func (d *Daemon) runStartupGoodbye(rgID int, rgRA []*config.RAInterfaceConfig) {
 // rethInterfacesForRG returns the Linux interface names of RETH interfaces
 // belonging to the given redundancy group.
 func rethInterfacesForRG(cfg *config.Config, rgID int) []string {
+	return rethInterfacesMatchingRG(cfg, func(id int) bool { return id == rgID })
+}
+
+// rethInterfacesMatchingRG returns the Linux interface names of every RETH
+// interface whose redundancy group satisfies want.
+//
+// It is the SINGLE source for both RG-derived interface sets the cluster DHCP
+// filter needs — "which interfaces does THIS node currently master" and "which
+// interfaces are redundancy-group-scoped AT ALL" (#6520). Deriving the two from
+// one walker is not a style preference: a divergence between them is ALWAYS a
+// bug, because the filter's keep rule is exactly "RG-scoped implies mastered".
+// If one set resolved a RETH member differently from the other, a node-local
+// interface would be misread as an unmastered RG member (service dropped) or an
+// RG member as node-local (both nodes serve DHCP on one redundant segment).
+func rethInterfacesMatchingRG(cfg *config.Config, want func(rgID int) bool) []string {
 	var names []string
 	for name, ifc := range cfg.Interfaces.Interfaces {
 		if ifc == nil {
 			continue
 		}
-		if ifc.RedundancyGroup == rgID && strings.HasPrefix(name, "reth") {
+		if want(ifc.RedundancyGroup) && strings.HasPrefix(name, "reth") {
 			// Resolve RETH to physical member for Linux-level operations.
 			resolved := config.LinuxIfName(cfg.ResolveReth(name))
 			for _, unit := range ifc.Units {
@@ -1702,9 +1717,27 @@ func (d *Daemon) reconcileClusterDHCPServices(reason string) {
 	d.dhcpServer.ApplyAsync(desired, "reconcile: "+reason)
 }
 
-// filterDHCPConfigForMasterRGs returns a DHCP config containing only groups
-// whose interfaces belong to RGs that are currently MASTER. Returns nil if
-// no groups match.
+// filterDHCPConfigForMasterRGs returns the DHCP config this node should serve
+// in cluster mode: every group member that is either NODE-LOCAL or belongs to a
+// redundancy group this node currently masters. Returns nil if nothing
+// survives.
+//
+// #6520 (a) — mastership scoping applies ONLY to RG-scoped members. Before this
+// fix the keep-set was built exclusively from `rethInterfacesForRG` over the
+// MASTER RGs, so it could only ever contain RETH members: every interface that
+// is not part of a redundancy group — the `fxp0.0` management lifeline, and any
+// plain node-local data interface — was removed from every group on BOTH nodes,
+// and a group made only of such members disappeared entirely. That silently
+// killed DHCP service the operator configured on a node-local segment the
+// moment the box was clustered. Redundancy-group mastership says which node
+// answers for a REDUNDANT interface; it says nothing about an interface that
+// has no redundant peer, and Junos clusters likewise run `fxp0` services per
+// node. So an interface that belongs to NO redundancy group is kept
+// unconditionally, and only an RG-scoped member is gated on this node holding
+// that RG.
+//
+// The two sets are derived from ONE walker (rethInterfacesMatchingRG) so
+// "RG-scoped" and "mastered" cannot resolve a RETH member differently.
 func (d *Daemon) filterDHCPConfigForMasterRGs(cfg *config.Config) *config.DHCPServerConfig {
 	// Collect all interfaces belonging to master RGs. Normalize the untagged
 	// ".0" suffix (#4647) so the set is keyed by the bare member name that the
@@ -1717,6 +1750,13 @@ func (d *Daemon) filterDHCPConfigForMasterRGs(cfg *config.Config) *config.DHCPSe
 		for _, n := range rethInterfacesForRG(cfg, rgID) {
 			masterIfaces[stripUntaggedUnitSuffix(n)] = true
 		}
+	}
+	// Every interface that IS redundancy-group-scoped, regardless of which node
+	// currently masters it. An interface absent from this set has no redundant
+	// peer and is therefore node-local (#6520).
+	rgScoped := make(map[string]bool)
+	for _, n := range rethInterfacesMatchingRG(cfg, func(int) bool { return true }) {
+		rgScoped[stripUntaggedUnitSuffix(n)] = true
 	}
 
 	dhcpCfg := cfg.System.DHCPServer
@@ -1737,13 +1777,23 @@ func (d *Daemon) filterDHCPConfigForMasterRGs(cfg *config.Config) *config.DHCPSe
 				// "ge-0-0-1.0" is not a device. Tagged units keep their
 				// ".<vlan>" and match only the tagged member.
 				norm := stripUntaggedUnitSuffix(iface)
-				if masterIfaces[norm] {
+				// #6520: node-local members (no redundancy group) are not
+				// mastership-scoped and are always kept; RG-scoped members are
+				// kept only while this node masters their RG.
+				if masterIfaces[norm] || !rgScoped[norm] {
 					kept = append(kept, norm)
 				}
 			}
 			if len(kept) > 0 {
 				cp := *group
 				cp.Interfaces = kept
+				// #6520 (b): DHCPServerGroup carries independent Interfaces and
+				// Pools arrays with no semantic edge, so a group whose member
+				// list SHRANK here no longer describes which pool belongs to
+				// which member. Record that so the Kea renderer suppresses its
+				// per-subnet interface selector instead of cross-binding a
+				// removed member's pool onto a survivor (dhcpserver.subnetInterface).
+				cp.MembersFiltered = len(kept) != len(group.Interfaces)
 				result[name] = &cp
 			}
 		}

--- a/pkg/daemon/dhcp_rg_filter_6520_test.go
+++ b/pkg/daemon/dhcp_rg_filter_6520_test.go
@@ -1,0 +1,158 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6520: the cluster DHCP master-RG filter.
+//
+// (a) Mastership scoping must apply only to RG-scoped members. A node-local
+// interface — the fxp0 management lifeline, or any plain interface with no
+// redundant peer — has no redundancy group to master, so removing it from
+// every group on both nodes silently kills the DHCP service configured on it.
+//
+// (b) When the filter DOES narrow a group, it must record that
+// (DHCPServerGroup.MembersFiltered) so the Kea renderer suppresses its
+// per-subnet interface selector. This file asserts the PRODUCER side of that
+// agreement; pkg/dhcpserver asserts the consumer honours the flag. Each side
+// names itself so a failure says which one broke.
+
+// dhcpClusterMixedConfig builds a two-RG HA config: reth1 (RG1, member
+// ge-0/0/1) and reth2 (RG2, member ge-0/0/2), plus one dhcp-local-server group
+// over the supplied interface refs.
+func dhcpClusterMixedConfig(groupIfaces ...string) *config.Config {
+	return &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"reth1": {
+					Name:            "reth1",
+					RedundancyGroup: 1,
+					Units:           map[int]*config.InterfaceUnit{0: {}},
+				},
+				"ge-0/0/1": {Name: "ge-0/0/1", RedundantParent: "reth1"},
+				"reth2": {
+					Name:            "reth2",
+					RedundancyGroup: 2,
+					Units:           map[int]*config.InterfaceUnit{0: {}},
+				},
+				"ge-0/0/2": {Name: "ge-0/0/2", RedundantParent: "reth2"},
+				"fxp0":     {Name: "fxp0", Units: map[int]*config.InterfaceUnit{0: {}}},
+			},
+		},
+		System: config.SystemConfig{
+			DHCPServer: config.DHCPServerConfig{
+				DHCPLocalServer: &config.DHCPLocalServerConfig{
+					Groups: map[string]*config.DHCPServerGroup{
+						"g1": {Name: "g1", Interfaces: append([]string(nil), groupIfaces...)},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestFilterDHCPConfigForMasterRGs_NodeLocalMemberKeptOnMaster_6520 is the
+// #6520 (a) regression: a group mixing the fxp0 lifeline with a mastered RETH
+// member must keep BOTH members. Before the fix the keep-set was built only
+// from RETH members of master RGs, so fxp0 was dropped even here.
+func TestFilterDHCPConfigForMasterRGs_NodeLocalMemberKeptOnMaster_6520(t *testing.T) {
+	d := newTestDaemon()
+	cfg := dhcpClusterMixedConfig("fxp0.0", "reth1.0")
+	d.getOrCreateRGState(1).SetVRRP("reth1", true)
+
+	got := d.filterDHCPConfigForMasterRGs(cfg)
+	if got == nil || got.DHCPLocalServer == nil {
+		t.Fatal("group with a mastered RETH member must survive the filter; got nil")
+	}
+	g := got.DHCPLocalServer.Groups["g1"]
+	if g == nil {
+		t.Fatal("group g1 dropped by the master-RG filter")
+	}
+	if len(g.Interfaces) != 2 || !contains6520(g.Interfaces, "fxp0") || !contains6520(g.Interfaces, "ge-0-0-1") {
+		t.Fatalf("#6520(a) RED: node-local fxp0 must be kept alongside the mastered RETH member; kept %v, want both [fxp0 ge-0-0-1]", g.Interfaces)
+	}
+}
+
+// TestFilterDHCPConfigForMasterRGs_NodeLocalOnlyGroupSurvivesOnBackup_6520 is
+// the sharper half of #6520 (a): a group made only of node-local members must
+// survive on a node that masters NOTHING. Before the fix the whole group — and
+// with it the DHCP service on the management segment — disappeared on every
+// node that was not the RG master, i.e. permanently on the backup.
+func TestFilterDHCPConfigForMasterRGs_NodeLocalOnlyGroupSurvivesOnBackup_6520(t *testing.T) {
+	d := newTestDaemon()
+	cfg := dhcpClusterMixedConfig("fxp0.0")
+	d.getOrCreateRGState(1).SetVRRP("reth1", false)
+	d.getOrCreateRGState(2).SetVRRP("reth2", false)
+
+	got := d.filterDHCPConfigForMasterRGs(cfg)
+	if got == nil || got.DHCPLocalServer == nil {
+		t.Fatal("#6520(a) RED: a node-local-only DHCP group must survive on a node that masters no RG; the whole config was filtered to nil")
+	}
+	g := got.DHCPLocalServer.Groups["g1"]
+	if g == nil || len(g.Interfaces) != 1 || g.Interfaces[0] != "fxp0" {
+		t.Fatalf("#6520(a) RED: expected the node-local member kept as [fxp0], got %+v", g)
+	}
+}
+
+// TestFilterDHCPConfigForMasterRGs_RGScopedMemberStillGated_6520 pins the
+// property #6520 must NOT weaken: an RG-scoped member is still removed while
+// this node does not master its RG. Without this, "keep what is not mastered"
+// would degenerate into keeping everything and both nodes would serve DHCP on
+// the same redundant segment.
+func TestFilterDHCPConfigForMasterRGs_RGScopedMemberStillGated_6520(t *testing.T) {
+	d := newTestDaemon()
+	cfg := dhcpClusterMixedConfig("reth1.0", "reth2.0")
+	d.getOrCreateRGState(1).SetVRRP("reth1", true)
+	d.getOrCreateRGState(2).SetVRRP("reth2", false)
+
+	got := d.filterDHCPConfigForMasterRGs(cfg)
+	if got == nil || got.DHCPLocalServer == nil {
+		t.Fatal("group with a mastered RETH member must survive the filter; got nil")
+	}
+	g := got.DHCPLocalServer.Groups["g1"]
+	if g == nil || len(g.Interfaces) != 1 || g.Interfaces[0] != "ge-0-0-1" {
+		t.Fatalf("an RG-scoped member of a BACKUP RG must still be removed; kept %+v, want only [ge-0-0-1]", g)
+	}
+}
+
+// TestFilterDHCPConfigForMasterRGs_MarksShrunkGroup_6520 is the PRODUCER half
+// of the #6520 (b) agreement: the active/active mixed-RG group above really
+// does shrink to a singleton, and the filter must record that so the renderer
+// stops emitting a per-subnet selector. Asserting the flag here (rather than
+// only the rendered Kea file) localises a break to the filter.
+func TestFilterDHCPConfigForMasterRGs_MarksShrunkGroup_6520(t *testing.T) {
+	d := newTestDaemon()
+	cfg := dhcpClusterMixedConfig("reth1.0", "reth2.0")
+	d.getOrCreateRGState(1).SetVRRP("reth1", true)
+	d.getOrCreateRGState(2).SetVRRP("reth2", false)
+
+	g := d.filterDHCPConfigForMasterRGs(cfg).DHCPLocalServer.Groups["g1"]
+	if !g.MembersFiltered {
+		t.Fatal("#6520(b) RED (producer side): the filter narrowed g1 from 2 members to 1 but did not set MembersFiltered, so dhcpserver.subnetInterface will cross-bind the removed member's pool onto the survivor")
+	}
+}
+
+// TestFilterDHCPConfigForMasterRGs_UnshrunkGroupNotMarked_6520 is its control:
+// a group the filter did not narrow must NOT be marked, or every
+// operator-authored singleton group would lose the #1778 explicit binding.
+func TestFilterDHCPConfigForMasterRGs_UnshrunkGroupNotMarked_6520(t *testing.T) {
+	d := newTestDaemon()
+	cfg := dhcpClusterMixedConfig("reth1.0")
+	d.getOrCreateRGState(1).SetVRRP("reth1", true)
+
+	g := d.filterDHCPConfigForMasterRGs(cfg).DHCPLocalServer.Groups["g1"]
+	if g.MembersFiltered {
+		t.Fatal("#6520(b) RED (producer side): an unnarrowed group must not be marked MembersFiltered — marking it would strip the #1778 per-subnet selector from every authored singleton group")
+	}
+}
+
+func contains6520(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/dhcpserver/dhcpserver.go
+++ b/pkg/dhcpserver/dhcpserver.go
@@ -775,7 +775,20 @@ func parseLeaseCSVFileInto(path string, now time.Time, acc *leaseCSVAccum) error
 // pre-#1778 renderer silently bound only the first interface,
 // breaking the others. All group interfaces are always listed in
 // interfaces-config, so Kea listens on every one either way.
+//
+// #6520: the single-interface inference is only sound for a group whose member
+// list is what the operator AUTHORED. A group narrowed at runtime by the
+// chassis-cluster master-RG filter can arrive here as a singleton while still
+// carrying the pools of the members that were removed, and binding those pools
+// to the survivor cross-binds a foreign network onto it. There is no
+// pool→member edge in the config model to filter the pools by, so a narrowed
+// group falls back to address-based selection — the same mechanism every
+// multi-interface group already uses, and correct for the pools that DO belong
+// to the survivor.
 func subnetInterface(group *config.DHCPServerGroup) string {
+	if group.MembersFiltered {
+		return ""
+	}
 	if len(group.Interfaces) == 1 {
 		return group.Interfaces[0]
 	}

--- a/pkg/dhcpserver/kea_filtered_group_selector_6520_test.go
+++ b/pkg/dhcpserver/kea_filtered_group_selector_6520_test.go
@@ -1,0 +1,108 @@
+package dhcpserver
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6520 (b): the CONSUMER half of the cluster-filter agreement. A
+// DHCPServerGroup whose member list was narrowed at runtime
+// (config.DHCPServerGroup.MembersFiltered, set by
+// daemon.filterDHCPConfigForMasterRGs) still carries the pools of the members
+// that were removed, because Interfaces and Pools have no semantic edge. Kea's
+// per-subnet `interface` selector must therefore be suppressed for such a
+// group: emitting it binds EVERY pool in the group — including a removed
+// member's network — to the one survivor.
+//
+// The producer half (the filter setting the flag exactly when it shrinks a
+// group) is asserted in pkg/daemon; each test names its own side so a failure
+// says which one broke.
+
+// filteredGroupV4Config renders a group holding two pools — one belonging to a
+// mgmt member, one to a RETH member — as it arrives after the cluster filter
+// removed the mgmt member. filtered selects whether the narrowing is recorded.
+func filteredGroupV4Config(filtered bool) *config.DHCPServerConfig {
+	return &config.DHCPServerConfig{
+		DHCPLocalServer: &config.DHCPLocalServerConfig{
+			Groups: map[string]*config.DHCPServerGroup{
+				"mixed": {
+					Name:            "mixed",
+					Interfaces:      []string{"ge-0-0-1"},
+					MembersFiltered: filtered,
+					Pools: []*config.DHCPPool{
+						{Name: "mgmt", Subnet: "10.99.0.0/24", RangeLow: "10.99.0.10", RangeHigh: "10.99.0.20"},
+						{Name: "lan", Subnet: "10.0.61.0/24", RangeLow: "10.0.61.10", RangeHigh: "10.0.61.20"},
+					},
+				},
+			},
+		},
+	}
+}
+
+// subnetSelectors returns subnet CIDR -> per-subnet `interface` selector for
+// every rendered Dhcp4 subnet (absent selector => "").
+func subnetSelectors(t *testing.T, path string) map[string]string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var outer struct {
+		Dhcp4 struct {
+			Subnet4 []struct {
+				Subnet    string `json:"subnet"`
+				Interface string `json:"interface"`
+			} `json:"subnet4"`
+		} `json:"Dhcp4"`
+	}
+	if err := json.Unmarshal(raw, &outer); err != nil {
+		t.Fatal(err)
+	}
+	out := make(map[string]string, len(outer.Dhcp4.Subnet4))
+	for _, s := range outer.Dhcp4.Subnet4 {
+		out[s.Subnet] = s.Interface
+	}
+	return out
+}
+
+// TestKeaSubnetSelectorBoundForAuthoredSingletonGroup_6520 is the CONTROL: an
+// operator-authored single-interface group is unchanged by #6520 and keeps the
+// explicit #1778 binding on every one of its subnets.
+func TestKeaSubnetSelectorBoundForAuthoredSingletonGroup_6520(t *testing.T) {
+	m, _ := testManager(t, map[string]bool{}, "")
+	if err := m.generateKea4Config(filteredGroupV4Config(false)); err != nil {
+		t.Fatalf("generateKea4Config: %v", err)
+	}
+	got := subnetSelectors(t, m.confPath4)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 rendered subnets, got %d (%v)", len(got), got)
+	}
+	for subnet, sel := range got {
+		if sel != "ge-0-0-1" {
+			t.Fatalf("CONTROL BROKE (producer side is not implicated): authored singleton group must keep its #1778 per-subnet selector; subnet %s got interface %q, want %q", subnet, sel, "ge-0-0-1")
+		}
+	}
+}
+
+// TestKeaSubnetSelectorSuppressedForFilteredGroup_6520 is the #6520 (b)
+// regression: once the cluster filter has narrowed the group, no subnet may
+// carry a per-subnet selector — the removed member's pool would be cross-bound
+// onto the survivor.
+func TestKeaSubnetSelectorSuppressedForFilteredGroup_6520(t *testing.T) {
+	m, _ := testManager(t, map[string]bool{}, "")
+	if err := m.generateKea4Config(filteredGroupV4Config(true)); err != nil {
+		t.Fatalf("generateKea4Config: %v", err)
+	}
+	got := subnetSelectors(t, m.confPath4)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 rendered subnets, got %d (%v)", len(got), got)
+	}
+	for subnet, sel := range got {
+		if sel != "" {
+			t.Fatalf("CONSUMER SIDE BROKE (dhcpserver.subnetInterface ignored MembersFiltered): a runtime-narrowed group must emit NO per-subnet interface selector, else the removed member's pool is cross-bound; subnet %s got interface %q", subnet, sel)
+		}
+	}
+}


### PR DESCRIPTION
Closes #6520

Two coupled defects in the cluster DHCP-serving path, both live on master.

## 1. Node-local members are dropped on both nodes

`filterDHCPConfigForMasterRGs` (`pkg/daemon/daemon_ha.go`) built its keep-set exclusively from `rethInterfacesForRG` over the currently-MASTER redundancy groups. That walker only ever yields members of `reth*` interfaces, so **every interface that is not part of a redundancy group** — the `fxp0` management lifeline, and any plain node-local data interface — was removed from every `dhcp-local-server` / `dhcpv6-local-server` group on **both** nodes, and a group made only of such members disappeared entirely.

This is broader than the issue's "lifeline" framing: clustering a box silently killed the DHCP service configured on any node-local segment, permanently on the backup.

Redundancy-group mastership answers *which node serves a redundant interface*. It says nothing about an interface with no redundant peer, and Junos clusters run `fxp0` services per node. So:

- a member belonging to **no** redundancy group is node-local and kept unconditionally, on both nodes;
- an RG-scoped member is still kept only while this node masters that RG.

Both sets now come from one walker, `rethInterfacesMatchingRG`, of which `rethInterfacesForRG` is a predicate wrapper. That is deliberate rather than stylistic: the keep rule is exactly *RG-scoped implies mastered*, so a divergence between the two sets is always a bug — one resolving a RETH member differently from the other would drop a node-local service, or leave both nodes serving DHCP on one redundant segment.

## 2. A narrowed group cross-binds the removed member's pools

`config.DHCPServerGroup` carries independent `Interfaces` and `Pools` arrays with no semantic edge: nothing records which pool belongs to which member. Once the filter removes a member, "the group has exactly one interface" no longer implies "every pool in the group is served on that interface" — which is the inference `dhcpserver.subnetInterface` makes when it emits Kea's per-subnet `interface` selector (#1778). A mixed `[fxp0.0, reth0.80]` group narrowed to the surviving RETH member bound the fxp0 pool's subnet to the RETH member.

The filter now sets `DHCPServerGroup.MembersFiltered` whenever it actually shrinks a group, and `subnetInterface` omits the selector for such a group — falling back to Kea's address-based subnet selection, the same mechanism every multi-interface group already uses and which `subnetInterface`'s own doc already names as the correct-if-less-robust fallback. **Which subnets are served does not change**, only how Kea selects among them.

`MembersFiltered` is a runtime marker, excluded from every marshal (`json:"-"`, `yaml:"-"`) so it cannot reach the compiled-config dump (`GET /api/v1/config`), the golden compile baseline, or the peer over cluster config-sync.

### Rejected alternative

The issue's direction (b) — drop a group whole when filtering would shrink it — is **wrong** and was not taken. For a mixed-RG group in active/active (`reth0.80` in RG1, `reth1.0` in RG2) both nodes would drop the whole group and DHCP would stop everywhere.

### Discriminator check

Both branches vary in practice. Same-RG groups preserve cardinality and are untouched; a mixed-RG group under active/active shrinks to a singleton, which is exactly the reported defect. The node-local branch is reached by any non-RETH member.

## Validation

- `go vet ./pkg/daemon/... ./pkg/dhcpserver/... ./pkg/config/...` clean **before** the mutation runs, so a red is an assertion and not a build break.
- Full `go test -count=1 ./...` green — 63 packages, rc 0. `TestCompileGolden4406` first caught `MembersFiltered` leaking into the compiled-config JSON, which is why the field is marshal-excluded; it is green now.
- New guards, each naming its own side of the agreement so a failure says which half broke:
  - `pkg/daemon/dhcp_rg_filter_6520_test.go` — node-local member kept beside a mastered RETH member; node-local-only group survives on a node mastering nothing; an RG-scoped member of a BACKUP RG is still removed; the flag is set exactly when the group shrank, and not when it did not.
  - `pkg/dhcpserver/kea_filtered_group_selector_6520_test.go` — a narrowed group renders no per-subnet selector; an authored singleton still renders one (control).

### Mutation matrix — one line per cell, restored and re-verified green after each

| # | mutated line (production path) | red | green |
|---|---|---|---|
| M1 | keep rule → `if masterIfaces[norm] {` | NodeLocalMemberKeptOnMaster, NodeLocalOnlyGroupSurvivesOnBackup | RGScopedMemberStillGated, both flag tests |
| M2 | `cp.MembersFiltered = …` → `= false` | MarksShrunkGroup | all four others |
| M3 | `if group.MembersFiltered {` → `if false {` | SelectorSuppressedForFilteredGroup | SelectorBoundForAuthoredSingletonGroup |
| M4 | keep rule → `if true {` | RGScopedMemberStillGated, MarksShrunkGroup | node-local pair, unshrunk control |
| M5 | walker → `if strings.HasPrefix(name, "reth") {` (predicate dropped) | RGScopedMemberStillGated, MarksShrunkGroup | pre-existing #4647 trio |

Production call paths for the mutated sites: `filterDHCPConfigForMasterRGs` ← `desiredClusterDHCPConfig` ← the commit path (`daemon_apply_routing.go`), both RG-transition edges (`applyRethServicesForRG` / `clearRethServicesForRG`), and the #6535 reconcile converger. `subnetInterface` ← `generateKea4Config` / `generateKea6Config` ← `Manager.apply` ← `Apply` / `ApplyAsync`.

One methodology note worth recording: a first pass used `-run '_6520|_4647'`, and `_4647` matched only the *file* name `daemon_dhcp_filter_4647_test.go`, selecting zero of those three tests while still exiting 0. M5 was re-run as M5b under `-run 'TestFilterDHCPConfigForMasterRGs'` (8 `=== RUN` lines) to actually cover them.

## Cluster time owed

This changes chassis-cluster behaviour and **owes `make test-failover`**. It has **not** been run — this branch was developed without touching the shared loss cluster. Do not read the green unit matrix above as a substitute for it.

## Docs

`pkg/daemon/README.md` gains "Cluster DHCP member scoping: node-local vs RG-scoped (#6520)" beside the #6535 converger section, covering both properties, the single-walker rationale, the rejected whole-group-drop alternative, and the guards. `_Log.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cz2czGK3aA5MsMhkNkjHXX