### PR TITLE
image: record what the image ships in the signed traceability record

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-08-22 — #6500 signed image inventory (guest kernel + package set)
+
+- **Timestamp**: 2026-08-22
+- **Action**: The bake now writes `/etc/xpf/image-inventory` inside the
+  image as its last virt-customize step and reads it back OFFLINE with
+  `virt-cat` (no boot), emitting `dist/xpf-<ver>.pkgs` under the signed
+  SHA256SUMS. `build_manifest_text` takes `guest_kernel` as a REQUIRED
+  keyword so a caller cannot silently omit the field the publish gate
+  needs, and `gate_provenance` gains a third fail-closed leg refusing a
+  missing guest_kernel, an absent or uncovered `.pkgs`, a hollow
+  inventory, or a kernel disagreement between the two authenticated
+  records. The record format is single-sourced in
+  `scripts/dist/image_inventory.py` — bake writes it, publish reads it,
+  and a divergence there is always a bug, so it is one definition
+  rather than two bound by a canary. Three pre-existing fixtures set
+  the OLD gate input and were carried forward rather than left to pass
+  vacuously, and the provenance negatives now assert WHICH check fired
+  instead of only that SystemExit was raised.
+- **File(s)**: scripts/image/bake.py, scripts/dist/publish.py,
+  scripts/dist/image_inventory.py, scripts/dist/selftest.sh,
+  scripts/dist/test_image_inventory_6500.py,
+  scripts/dist/test_publish_provenance.py,
+  scripts/image/test_bake_base_pin.py, docs/install-images.md,
+  docs/distribution.md
+
 ## 2026-08-22 — #6521 RFC 6052 citation correction (§2.2 → §3.1)
 
 - **Timestamp**: 2026-08-22

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -119,6 +119,11 @@ publisher isolates suites in its own database and is unaffected. `selftest.sh`
   expire the repo between releases — keep it long for a manual cadence, or run
   an automated re-sign job.
 - Images: `latest.json` (signed) names the current version per channel.
+- Each version's signed `xpf-<ver>.SHA256SUMS` covers the qcow2, the incus
+  metadata, the `.manifest` provenance sidecar, AND the `xpf-<ver>.pkgs`
+  image inventory (guest kernel + installed package versions, #6500), so
+  the traceability record is authenticated by the same signature as the
+  bytes it describes. `publish.py` refuses a release missing any of them.
   `xpf-deploy.py fetch` records a best-effort monotonic watermark at
   `${XDG_STATE_HOME:-~/.local/state}/xpf/image-watermark.json` (per
   `--channel`, default `stable`) and REFUSES a version older than the recorded

--- a/docs/install-images.md
+++ b/docs/install-images.md
@@ -178,6 +178,35 @@ sessions across the mixed-base window or must replace both nodes at once.
 See `docs/in-place-upgrade.md` (Kernel / OS upgrade lanes) for the full
 LANE-1/2/3 decision rule and the state-carry contract.
 
+**What the image SHIPS (#6500).** `bake_host_kernel` above is the BUILD
+HOST's kernel (`os.uname().release`) and answers a different question
+from "what does this image carry". Two additional records close that:
+
+- `guest_kernel:` in the `.manifest` — the kernel the IMAGE runs, i.e.
+  the exact artifact the #1930 LANE-1 channel promotes.
+- `dist/xpf-<ver>.pkgs` — the full installed package inventory
+  (`name=version`, one per line, plus the guest kernel), **covered by the
+  signed `xpf-<ver>.SHA256SUMS`** exactly like the `.manifest` sidecar
+  (#5042), so it is authenticated the moment the manifest signature
+  verifies.
+
+The bake writes the same record INSIDE the image at
+`/etc/xpf/image-inventory` and reads it back out **offline with
+`virt-cat`** — no boot — so "does release X ship openssl 3.x.y
+(CVE-YYYY)?" and "which kernel does image X carry, so I can plan a
+LANE-1 arm?" are answered from the dist tree, and the copy that stays in
+the image answers them on the box too.
+
+Both are **fail-closed at publish**: `publish.py gate_provenance` refuses
+a release whose manifest has no `guest_kernel`, whose `.pkgs` sidecar is
+missing or not covered by the signed manifest, whose inventory is HOLLOW
+(a present-but-empty record satisfies a presence check and answers
+nothing), or whose two authenticated records disagree about the kernel —
+alongside the existing `validated` / `base_image_pinned` refusals. The
+format lives in `scripts/dist/image_inventory.py`, single-sourced because
+bake.py writes it and publish.py reads it and a divergence between those
+is always a bug.
+
 Full first-boot matrix (run after a bake, or standalone):
 
 ```bash

--- a/scripts/dist/image_inventory.py
+++ b/scripts/dist/image_inventory.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""The image inventory format (#6500) — ONE definition, two readers.
+
+The bake signs a per-version manifest that `docs/install-images.md` calls "the
+traceability record", but it recorded only the BUILD HOST's kernel
+(`bake_host_kernel`) and nothing about what the image actually SHIPS: not the
+guest kernel the #1930 LANE-1 channel promotes, and none of the apt package
+versions `virt-customize` installed from a floating mirror. Two bakes from the
+same git commit on different days produce different images, and nothing signed
+recorded the difference — so "does release X ship openssl 3.x.y (CVE-YYYY)?"
+and "which kernel does image X carry, so I can plan a LANE-1 arm?" both
+required booting or mounting the image.
+
+The inventory closes that. `bake.py` writes it INSIDE the image (so the running
+appliance carries its own record too), reads it back out offline with
+`virt-cat`, and emits it as the `xpf-<ver>.pkgs` sidecar covered by the signed
+`xpf-<ver>.SHA256SUMS` — the #5042 pattern, so it is authenticated the moment
+the manifest signature verifies. `publish.py` refuses a release without it,
+fail-closed, alongside `validated` and `base_image_pinned`.
+
+WHY THIS IS ITS OWN MODULE. bake.py WRITES the format and publish.py READS it.
+A divergence between those two is ALWAYS a bug — never a legitimate difference
+— so the format is single-sourced here rather than duplicated and bound by a
+canary. Both scripts already put `scripts/dist` on sys.path for `sign`, so
+neither needed a new import path.
+
+Format (line-oriented, no parser dependency — the guest half is POSIX sh):
+
+    # xpf appliance image inventory
+    guest_kernel: 7.0.0-15-generic
+    packages:
+    adduser=3.152
+    apt=3.1.5
+    ...
+"""
+
+from __future__ import annotations
+
+# Where bake.py's virt-customize step writes the inventory inside the image.
+# It stays in the shipped image on purpose: an operator on the box can answer
+# the same CVE question without the dist tree.
+INVENTORY_GUEST_PATH = "/etc/xpf/image-inventory"
+
+# A bake of the appliance's runtime set installs several hundred packages. A
+# floor well below that catches a collapsed enumeration — the failure mode that
+# aborted every bake twice during #1926, when bake.py's apt-mark hold fragment
+# produced an empty list from an unexpanded ${Package} and then from
+# dpkg-query returning never-installed names — without pinning a number that
+# ordinary package churn would move.
+MIN_PACKAGES = 50
+
+HEADER = "# xpf appliance image inventory"
+KERNEL_KEY = "guest_kernel"
+PACKAGES_KEY = "packages:"
+
+
+class InventoryError(ValueError):
+    """A malformed, empty, or absent image inventory."""
+
+
+def sidecar_name(ver):
+    """The dist-tree basename for a version's inventory sidecar."""
+    return f"xpf-{ver}.pkgs"
+
+
+# The in-guest writer, run by bake.py's virt-customize. POSIX sh, `set -e`, and
+# it FAILS THE BAKE rather than shipping an empty or kernel-less inventory: a
+# traceability record that records nothing is worse than an absent one, because
+# it satisfies a presence check.
+#
+# `${db:Status-Status}` filters to genuinely INSTALLED packages — `dpkg-query
+# -W` matches every package dpkg knows OF, including purged and
+# never-installed names that are only somebody else's dependency. The format
+# string is SINGLE-quoted so the guest's `sh -c` (virt-customize's one and only
+# shell layer) passes `${...}` through to dpkg-query literally. bake.py's
+# neighbouring hold fragment escapes `\${...}` instead because it double-quotes;
+# both reach dpkg-query with the same bytes, and getting this wrong collapses
+# the format to a bare newline and the inventory to nothing (#1926).
+#
+# The count is taken with awk, not `grep -c`: `grep -c` exits 1 on zero
+# matches, and under `set -e` that would abort with dpkg's exit status standing
+# in for "the inventory is empty", losing the diagnosis.
+WRITE_CMD = (
+    "set -e; mkdir -p /etc/xpf; "
+    "kv=$(ls /lib/modules | sort -V | tail -1); "
+    '[ -n "$kv" ] || { echo "FATAL: no kernel in /lib/modules — cannot record '
+    'the guest kernel in the image inventory" >&2; exit 1; }; '
+    "{ "
+    f'echo "{HEADER}"; '
+    f'echo "{KERNEL_KEY}: $kv"; '
+    f'echo "{PACKAGES_KEY}"; '
+    "dpkg-query -W -f='${db:Status-Status} ${Package}=${Version}\\n' "
+    "| awk '$1==\"installed\"{print $2}' | sort; "
+    f"}} > {INVENTORY_GUEST_PATH}; "
+    f"chmod 0644 {INVENTORY_GUEST_PATH}; "
+    f"n=$(awk -F= 'NF>1{{c++}} END{{print c+0}}' {INVENTORY_GUEST_PATH}); "
+    f'[ "$n" -ge {MIN_PACKAGES} ] || {{ echo "FATAL: image inventory recorded '
+    f'only $n packages (expected >= {MIN_PACKAGES}) — the dpkg enumeration '
+    'collapsed" >&2; exit 1; }; '
+    'echo "#6500: recorded image inventory ($n packages, guest kernel $kv)"'
+)
+
+
+def parse(text):
+    """Parse an inventory into (guest_kernel, [name=version, ...]).
+
+    Raises InventoryError with an actionable message on anything that would
+    make the record useless: no kernel line, an empty kernel, or fewer than
+    MIN_PACKAGES entries. Callers get a REFUSAL rather than a hollow record —
+    a present-but-empty inventory passes a presence check and answers no
+    question, which is strictly worse than an absent one.
+    """
+    if not text or not text.strip():
+        raise InventoryError("image inventory is empty")
+    kernel = None
+    pkgs = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith(KERNEL_KEY + ":"):
+            kernel = line.split(":", 1)[1].strip()
+            continue
+        if line == PACKAGES_KEY:
+            continue
+        if "=" in line:
+            name, _, ver = line.partition("=")
+            if name.strip() and ver.strip():
+                pkgs.append(line)
+    if not kernel:
+        raise InventoryError(
+            f"image inventory records no {KERNEL_KEY} — the guest kernel is "
+            "the exact artifact the #1930 LANE-1 channel promotes, so an "
+            "inventory without it cannot answer the question it exists for")
+    if len(pkgs) < MIN_PACKAGES:
+        raise InventoryError(
+            f"image inventory lists only {len(pkgs)} packages (expected >= "
+            f"{MIN_PACKAGES}) — the dpkg enumeration collapsed, so this record "
+            "cannot answer a CVE-triage question. Refusing to treat it as an "
+            "inventory")
+    return kernel, pkgs
+
+
+def guest_kernel(text):
+    """The guest kernel recorded in an inventory. Raises InventoryError."""
+    return parse(text)[0]

--- a/scripts/dist/publish.py
+++ b/scripts/dist/publish.py
@@ -64,6 +64,7 @@ import time
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(os.path.dirname(HERE))
 sys.path.insert(0, HERE)
+import image_inventory  # noqa: E402  (#6500 inventory format)
 import sign  # noqa: E402
 
 
@@ -108,15 +109,18 @@ def _is_allowed_publish_file(name, at_top):
         anywhere in the tree;
       - top-level bake outputs: `install.sh` (its minisign signature is
         verified in gate_images), `xpf-image.pub` (the pinned pubkey convenience
-        copy), and `xpf-<ver>.manifest` (build metadata read by
-        `xpf-deploy image-roll`);
+        copy), `xpf-<ver>.manifest` (build metadata read by
+        `xpf-deploy image-roll`), and `xpf-<ver>.pkgs` (the #6500 image
+        inventory — guest kernel + installed package versions — covered by the
+        signed SHA256SUMS and REQUIRED by gate_provenance);
       - a per-channel `latest.json` in a channel subdir — gate_latest verifies
         its signature.
     """
     if name.endswith((".minisig", ".SHA256SUMS")):
         return True
     if at_top:
-        return name in ("install.sh", "xpf-image.pub") or name.endswith(".manifest")
+        return (name in ("install.sh", "xpf-image.pub")
+                or name.endswith((".manifest", ".pkgs")))
     return name == "latest.json"
 
 
@@ -638,6 +642,13 @@ def gate_provenance(dist, versions, pub):
     image cannot be released via the normal path. There is deliberately no
     override — a signed unpinned image is not releasable.
 
+    #6500 adds the third leg: the signed record must say what the image
+    actually SHIPS. The manifest must carry `guest_kernel` (the kernel the
+    IMAGE runs, not `bake_host_kernel`), and the version must carry an
+    `xpf-<ver>.pkgs` inventory sidecar — covered by the same signed SHA256SUMS
+    — that parses as a real inventory and agrees with the manifest about the
+    kernel. A hollow inventory is refused, not accepted as best-effort.
+
     Fail-CLOSED: every version MUST carry a provenance sidecar that is (a) listed
     in — and hash-matches — the signed manifest, (b) says validated: true, AND
     (c) says base_image_pinned: true. A missing sidecar, an unsigned/mismatched
@@ -689,7 +700,57 @@ def gate_provenance(dist, versions, pub):
                 "a release signature: a signed dev/unpinned bake is not "
                 "releasable. Re-bake against a PINNED_BASE_SHA256 base WITHOUT "
                 "XPF_ALLOW_UNPINNED_BASE.")
-        info(f"image set {ver}: provenance validated=true base_image_pinned=true")
+        # #6500: the traceability record must actually say what the image
+        # ships. `bake_host_kernel` names the BUILD HOST's kernel and answers a
+        # different question; without guest_kernel + the package inventory,
+        # "does release X ship openssl 3.x.y (CVE-YYYY)?" and "which kernel
+        # does X carry, so I can plan a LANE-1 arm?" both require booting or
+        # mounting the image. Fail-CLOSED, exactly like validated /
+        # base_image_pinned: a missing field, a missing sidecar, a sidecar not
+        # covered by the signed manifest, or a HOLLOW one all refuse.
+        #
+        # A hollow record is refused deliberately, not tolerated as
+        # best-effort: a present-but-empty inventory satisfies a presence check
+        # and answers nothing, which is strictly worse than an absent one
+        # because it argues against anyone re-examining it.
+        gkern = fields.get("guest_kernel")
+        if not gkern:
+            die(f"image set {ver} provenance records no guest_kernel — the "
+                "signed manifest cannot say which kernel the image ships (the "
+                "exact artifact the #1930 LANE-1 channel promotes; "
+                "bake_host_kernel is the BUILD HOST's and answers a different "
+                "question). Refusing to publish an image whose traceability "
+                "record cannot describe it. Re-bake (#6500).")
+        pkgs_name = image_inventory.sidecar_name(ver)
+        pkgs_path = os.path.join(dist, pkgs_name)
+        if not os.path.isfile(pkgs_path):
+            die(f"image set {ver} has no inventory sidecar {pkgs_name} in "
+                f"{dist} — the signed record cannot list the package versions "
+                "the image ships, so a CVE-triage question needs the image "
+                "booted or mounted. Refusing to publish (the sidecar is "
+                "written + signed by scripts/image/bake.py; re-bake).")
+        try:
+            pkgs_data = sign.verify_listed_artifact_bytes(pkgs_path, sums, sig, pub)
+        except sign.SignError as e:
+            die(f"inventory sidecar {pkgs_name} failed verify against the "
+                f"signed manifest {os.path.basename(sums)}: {e}")
+        try:
+            inv_kern, inv_pkgs = image_inventory.parse(
+                pkgs_data.decode("utf-8", "replace"))
+        except image_inventory.InventoryError as e:
+            die(f"inventory sidecar {pkgs_name} is not a usable inventory: {e}. "
+                "Refusing to publish.")
+        # The two authenticated records must AGREE about the kernel. They are
+        # written from the same in-guest read, so a divergence means one of
+        # them was edited after the bake — and both are inside the signature,
+        # so it means the whole signed set was re-assembled.
+        if inv_kern != gkern:
+            die(f"image set {ver}: the manifest says guest_kernel={gkern!r} but "
+                f"the inventory sidecar says {inv_kern!r}. Both are covered by "
+                "the same signature, so these cannot disagree on an untampered "
+                "bake. Refusing to publish.")
+        info(f"image set {ver}: provenance validated=true base_image_pinned=true "
+             f"guest_kernel={gkern} inventory={len(inv_pkgs)} packages")
 
 
 def _gate_one_latest(dist, channel, pub, require_present):

--- a/scripts/dist/selftest.sh
+++ b/scripts/dist/selftest.sh
@@ -57,10 +57,39 @@ MANIFEST="$OUT/xpf-$VER.SHA256SUMS"
 # baseline signed set so the positive publish cases below exercise the real
 # shape (validated:false is exercised as a negative in section 8i).
 SIDECAR="$OUT/xpf-$VER.manifest"
-printf 'version: %s\nbase_image_pinned: true\nvalidated: true\n' "$VER" > "$SIDECAR"
+# #6500: the signed record must also say what the image SHIPS — the manifest's
+# `guest_kernel` (the IMAGE's kernel, not the build host's bake_host_kernel)
+# and an xpf-<ver>.pkgs inventory sidecar covered by the same SHA256SUMS.
+# gate_provenance requires both, fail-closed, so the baseline signed set below
+# must carry them or every POSITIVE publish case would fail for the wrong
+# reason. The negatives are exercised in section 8j.
+GUEST_KERNEL="7.0.0-15-generic"
+# prov_sidecar <path> <validated> [guest_kernel; "-" omits the line]
+prov_sidecar() {
+    _gk=${3:-$GUEST_KERNEL}
+    printf 'version: %s\nbase_image_pinned: true\nvalidated: %s\n' "$VER" "$2" > "$1"
+    [ "$_gk" = "-" ] || printf 'guest_kernel: %s\n' "$_gk" >> "$1"
+}
+# make_pkgs <path> [package count] — an inventory in the real format. The
+# default count clears image_inventory.MIN_PACKAGES; a small count models the
+# HOLLOW record the gate must refuse.
+make_pkgs() {
+    _n=${2:-60}
+    {
+        echo "# xpf appliance image inventory"
+        echo "guest_kernel: ${3:-$GUEST_KERNEL}"
+        echo "packages:"
+        _i=0
+        while [ "$_i" -lt "$_n" ]; do echo "pkg$_i=1.0-$_i"; _i=$((_i + 1)); done
+    } > "$1"
+}
+PKGS="$OUT/xpf-$VER.pkgs"
+prov_sidecar "$SIDECAR" true
+make_pkgs "$PKGS"
 XPF_IMAGE_PUBKEY="$WORK/img.pub" \
   $PY "$DIST/sign.py" sign-manifest --manifest "$MANIFEST" \
-      --seckey "$WORK/img.sec" --comment "selftest" "$QCOW" "$META" "$SIDECAR" >/dev/null
+      --seckey "$WORK/img.sec" --comment "selftest" "$QCOW" "$META" "$SIDECAR" \
+      "$PKGS" >/dev/null
 [ -f "$MANIFEST.minisig" ] && ok "manifest signed" || bad "manifest not signed"
 
 verify() {  # verify <file> with pubkey; prints OK/err, returns rc
@@ -207,7 +236,7 @@ fi
 
 # Orphan image artifact NOT covered by any manifest (Codex-r2-1).
 PGO="$WORK/pgorphan"; mkdir -p "$PGO"
-cp "$QCOW" "$META" "$SIDECAR" "$MANIFEST" "$MANIFEST.minisig" "$PGO/"
+cp "$QCOW" "$META" "$SIDECAR" "$PKGS" "$MANIFEST" "$MANIFEST.minisig" "$PGO/"
 head -c 64 /dev/urandom > "$PGO/xpf-9.9.9.qcow2"   # orphan, no manifest covers it
 if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/publish.py" \
      --dist "$PGO" --channel stable --no-apt >/dev/null 2>&1; then
@@ -218,7 +247,7 @@ fi
 
 # Symlink under the image publish root (Codex-r4).
 PGS="$WORK/pgsym"; mkdir -p "$PGS"
-cp "$QCOW" "$META" "$SIDECAR" "$MANIFEST" "$MANIFEST.minisig" "$PGS/"
+cp "$QCOW" "$META" "$SIDECAR" "$PKGS" "$MANIFEST" "$MANIFEST.minisig" "$PGS/"
 ln -s /etc/passwd "$PGS/sneaky.qcow2"
 if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/publish.py" \
      --dist "$PGS" --channel stable --no-apt >/dev/null 2>&1; then
@@ -412,7 +441,7 @@ rm -f "$WORK/pwned"
 # ── 8. publish gate: install.sh mandatory + stamped + signed ────────────────
 info "8. publish gate — install.sh mandatory, stamped, signed"
 GD="$WORK/gate"; mkdir -p "$GD"
-cp "$QCOW" "$META" "$SIDECAR" "$MANIFEST" "$MANIFEST.minisig" "$GD/"
+cp "$QCOW" "$META" "$SIDECAR" "$PKGS" "$MANIFEST" "$MANIFEST.minisig" "$GD/"
 XPF_SIGN_SECKEY="$WORK/img.sec" $PY "$DIST/publish.py" make-latest \
     --channel stable --version "$VER" --dist "$GD" >/dev/null 2>&1
 # 8a. install.sh MISSING -> refuse (mandatory).
@@ -473,7 +502,7 @@ fi
 # ── 8g. HB165 H-5: default-deny sweep refuses a stray non-image file ────────
 info "8g. publish default-deny sweep refuses a stray file under dist/ (HB165 H-5)"
 GOOD="$WORK/hb165"; mkdir -p "$GOOD"
-cp "$QCOW" "$META" "$SIDECAR" "$MANIFEST" "$MANIFEST.minisig" "$GOOD/"
+cp "$QCOW" "$META" "$SIDECAR" "$PKGS" "$MANIFEST" "$MANIFEST.minisig" "$GOOD/"
 XPF_SIGN_SECKEY="$WORK/img.sec" $PY "$DIST/publish.py" make-latest \
     --channel stable --version "$VER" --dist "$GOOD" >/dev/null 2>&1
 $PY "$DIST/publish.py" stamp-installer --out "$GOOD/install.sh" \
@@ -530,12 +559,16 @@ PROV="$WORK/prov"; mkdir -p "$PROV"
 cp "$QCOW" "$META" "$PROV/"
 # A signed image set that is byte-shape-identical to a release but whose signed
 # provenance sidecar says validated:false (a --skip-validate bake).
-printf 'version: %s\nbase_image_pinned: true\nvalidated: false\n' "$VER" \
-    > "$PROV/xpf-$VER.manifest"
+# It carries a COMPLETE #6500 inventory on purpose: this leg must be refused
+# for validated:false, not for a missing inventory. A negative that can be
+# satisfied by the wrong cause stops testing what it names.
+prov_sidecar "$PROV/xpf-$VER.manifest" false
+make_pkgs "$PROV/xpf-$VER.pkgs"
 XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/sign.py" sign-manifest \
     --manifest "$PROV/xpf-$VER.SHA256SUMS" --seckey "$WORK/img.sec" \
     --comment "selftest-skipvalidate" "$PROV/xpf-$VER.qcow2" \
-    "$PROV/xpf-$VER.incus-metadata.tar.gz" "$PROV/xpf-$VER.manifest" >/dev/null
+    "$PROV/xpf-$VER.incus-metadata.tar.gz" "$PROV/xpf-$VER.manifest" \
+    "$PROV/xpf-$VER.pkgs" >/dev/null
 XPF_SIGN_SECKEY="$WORK/img.sec" $PY "$DIST/publish.py" make-latest \
     --channel stable --version "$VER" --dist "$PROV" >/dev/null 2>&1
 $PY "$DIST/publish.py" stamp-installer --out "$PROV/install.sh" \
@@ -550,17 +583,102 @@ else
     ok "publish refuses a validated:false (--skip-validate) image (#4904 A)"
 fi
 # Positive control: flip validated -> true, re-sign the same set -> PASSES.
-printf 'version: %s\nbase_image_pinned: true\nvalidated: true\n' "$VER" \
-    > "$PROV/xpf-$VER.manifest"
+prov_sidecar "$PROV/xpf-$VER.manifest" true
 XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/sign.py" sign-manifest \
     --manifest "$PROV/xpf-$VER.SHA256SUMS" --seckey "$WORK/img.sec" \
     --comment "selftest-validated" "$PROV/xpf-$VER.qcow2" \
-    "$PROV/xpf-$VER.incus-metadata.tar.gz" "$PROV/xpf-$VER.manifest" >/dev/null
+    "$PROV/xpf-$VER.incus-metadata.tar.gz" "$PROV/xpf-$VER.manifest" \
+    "$PROV/xpf-$VER.pkgs" >/dev/null
 if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/publish.py" \
      --dist "$PROV" --channel stable --no-apt >/dev/null 2>&1; then
     ok "publish passes the same set once validated:true (#4904 A control)"
 else
     bad "publish MUST pass a validated:true image but FAILED (#4904 A control)"
+fi
+
+# ── 8j. #6500: the signed record must say what the image SHIPS ──────────────
+# Four refusals, each with the OTHER three inputs intact, so a leg cannot be
+# satisfied by the wrong cause; then one positive control proving the whole
+# set publishes once every input is right.
+info "8j. publish inventory gate — guest_kernel + xpf-<ver>.pkgs are required (#6500)"
+INV="$WORK/inv"; mkdir -p "$INV"
+# resign_inv <extra-artifacts...> — rebuild + sign INV's manifest.
+resign_inv() {
+    XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/sign.py" sign-manifest \
+        --manifest "$INV/xpf-$VER.SHA256SUMS" --seckey "$WORK/img.sec" \
+        --comment "selftest-inventory" "$INV/xpf-$VER.qcow2" \
+        "$INV/xpf-$VER.incus-metadata.tar.gz" "$INV/xpf-$VER.manifest" \
+        "$@" >/dev/null
+}
+inv_publish() {
+    XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/publish.py" \
+        --dist "$INV" --channel stable --no-apt >/dev/null 2>&1
+}
+inv_reset() {
+    rm -rf "$INV"; mkdir -p "$INV"
+    cp "$QCOW" "$META" "$INV/"
+    prov_sidecar "$INV/xpf-$VER.manifest" true
+    make_pkgs "$INV/xpf-$VER.pkgs"
+    # make-latest requires the version's SHA256SUMS to exist, so sign the
+    # complete set first; each case below re-signs after mutating one input.
+    resign_inv "$INV/xpf-$VER.pkgs"
+    XPF_SIGN_SECKEY="$WORK/img.sec" $PY "$DIST/publish.py" make-latest \
+        --channel stable --version "$VER" --dist "$INV" >/dev/null 2>&1
+    $PY "$DIST/publish.py" stamp-installer --out "$INV/install.sh" \
+        --archive-key "$AKEY" --apt-base-url "https://dl.selftest.invalid/apt" \
+        --channel stable >/dev/null 2>&1
+    minisign -S -W -s "$WORK/img.sec" -m "$INV/install.sh" \
+        -x "$INV/install.sh.minisig" >/dev/null 2>&1
+}
+
+# 8j-1: manifest with NO guest_kernel (an older bake) — inventory sidecar present.
+inv_reset
+prov_sidecar "$INV/xpf-$VER.manifest" true -
+resign_inv "$INV/xpf-$VER.pkgs"
+if inv_publish; then
+    bad "publish MUST refuse a manifest with no guest_kernel but PASSED (#6500)"
+else
+    ok "publish refuses a manifest with no guest_kernel (#6500)"
+fi
+
+# 8j-2: guest_kernel present, inventory sidecar ABSENT.
+inv_reset
+rm -f "$INV/xpf-$VER.pkgs"
+resign_inv
+if inv_publish; then
+    bad "publish MUST refuse a set with no xpf-<ver>.pkgs but PASSED (#6500)"
+else
+    ok "publish refuses a set with no inventory sidecar (#6500)"
+fi
+
+# 8j-3: sidecar present and signed but HOLLOW (below the package floor). A
+# present-but-empty record satisfies a presence check and answers nothing.
+inv_reset
+make_pkgs "$INV/xpf-$VER.pkgs" 3
+resign_inv "$INV/xpf-$VER.pkgs"
+if inv_publish; then
+    bad "publish MUST refuse a HOLLOW inventory but PASSED (#6500)"
+else
+    ok "publish refuses a hollow inventory (below the package floor) (#6500)"
+fi
+
+# 8j-4: the two authenticated records DISAGREE about the kernel.
+inv_reset
+make_pkgs "$INV/xpf-$VER.pkgs" 60 "9.9.9-other"
+resign_inv "$INV/xpf-$VER.pkgs"
+if inv_publish; then
+    bad "publish MUST refuse a manifest/inventory kernel mismatch but PASSED (#6500)"
+else
+    ok "publish refuses a manifest/inventory guest_kernel mismatch (#6500)"
+fi
+
+# 8j-5: positive control — every input right, the same tree publishes.
+inv_reset
+resign_inv "$INV/xpf-$VER.pkgs"
+if inv_publish; then
+    ok "publish passes a complete inventory set (#6500 control)"
+else
+    bad "publish MUST pass a complete inventory set but FAILED (#6500 control)"
 fi
 
 # ── 9. install.sh H-16: validate-before-mutate + cleanup-on-failure ─────────

--- a/scripts/dist/test_image_inventory_6500.py
+++ b/scripts/dist/test_image_inventory_6500.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Hermetic tests for the #6500 image-inventory format.
+
+`scripts/dist/image_inventory.py` is the ONE definition of a format with two
+readers: bake.py WRITES it (in-guest, POSIX sh, then reads it back out with
+virt-cat) and publish.py READS it to gate a release. A divergence between
+those is always a bug, which is why the format is single-sourced rather than
+duplicated — and why the writer is tested by RUNNING it, not by inspecting its
+text. A writer whose quoting is wrong produces a valid-looking empty file:
+bake.py's neighbouring apt-mark fragment aborted every bake twice during #1926
+for exactly that, once from an unexpanded `${Package}` and once from
+`dpkg-query -W` returning never-installed names.
+
+The parser's job is to REFUSE a hollow record rather than return one. A
+present-but-empty inventory satisfies a presence check and answers no
+question — strictly worse than an absent one, because it argues against
+anyone re-examining it.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _HERE)
+import image_inventory as inv  # noqa: E402
+
+KVER = "7.0.0-15-generic"
+
+
+def _record(kernel=KVER, npkgs=inv.MIN_PACKAGES, header=True, packages_line=True):
+    lines = []
+    if header:
+        lines.append(inv.HEADER)
+    if kernel is not None:
+        lines.append(f"{inv.KERNEL_KEY}: {kernel}")
+    if packages_line:
+        lines.append(inv.PACKAGES_KEY)
+    lines += [f"pkg{i}=1.0-{i}" for i in range(npkgs)]
+    return "\n".join(lines) + "\n"
+
+
+class ParseTests(unittest.TestCase):
+    def test_a_well_formed_record_round_trips(self):
+        kern, pkgs = inv.parse(_record())
+        self.assertEqual(kern, KVER)
+        self.assertEqual(len(pkgs), inv.MIN_PACKAGES)
+        self.assertIn("pkg0=1.0-0", pkgs)
+
+    def test_empty_text_is_refused(self):
+        with self.assertRaises(inv.InventoryError):
+            inv.parse("")
+        with self.assertRaises(inv.InventoryError):
+            inv.parse("   \n\n")
+
+    def test_no_kernel_line_is_refused(self):
+        with self.assertRaises(inv.InventoryError) as c:
+            inv.parse(_record(kernel=None))
+        self.assertIn(inv.KERNEL_KEY, str(c.exception))
+
+    def test_blank_kernel_value_is_refused(self):
+        with self.assertRaises(inv.InventoryError):
+            inv.parse(_record(kernel=""))
+
+    def test_a_hollow_package_list_is_refused(self):
+        # The record exists, names a kernel, and answers nothing about
+        # packages. It must NOT parse as an inventory.
+        with self.assertRaises(inv.InventoryError) as c:
+            inv.parse(_record(npkgs=3))
+        self.assertIn("collapsed", str(c.exception))
+
+    def test_exactly_the_floor_passes(self):
+        _, pkgs = inv.parse(_record(npkgs=inv.MIN_PACKAGES))
+        self.assertEqual(len(pkgs), inv.MIN_PACKAGES)
+
+    def test_one_below_the_floor_is_refused(self):
+        with self.assertRaises(inv.InventoryError):
+            inv.parse(_record(npkgs=inv.MIN_PACKAGES - 1))
+
+    def test_malformed_package_lines_do_not_count(self):
+        # A line with an empty name or empty version is not a package record;
+        # counting it would let a corrupt file clear the floor.
+        text = (f"{inv.HEADER}\n{inv.KERNEL_KEY}: {KVER}\n{inv.PACKAGES_KEY}\n"
+                + "=1.0\n" * 200)
+        with self.assertRaises(inv.InventoryError):
+            inv.parse(text)
+
+    def test_comments_and_blank_lines_are_ignored(self):
+        text = _record().replace(inv.PACKAGES_KEY,
+                                 f"# a comment\n\n{inv.PACKAGES_KEY}")
+        kern, pkgs = inv.parse(text)
+        self.assertEqual(kern, KVER)
+        self.assertEqual(len(pkgs), inv.MIN_PACKAGES)
+
+    def test_guest_kernel_helper_agrees_with_parse(self):
+        self.assertEqual(inv.guest_kernel(_record()), inv.parse(_record())[0])
+
+    def test_sidecar_name(self):
+        self.assertEqual(inv.sidecar_name("1.2.3"), "xpf-1.2.3.pkgs")
+
+
+@unittest.skipUnless(shutil.which("dpkg-query"),
+                     "dpkg-query not available (non-Debian host)")
+class WriteCommandTests(unittest.TestCase):
+    """RUN the in-guest writer and parse what it produced.
+
+    virt-customize hands `--run-command` to the guest's `sh -c` — exactly one
+    shell layer — so running the same string through a local `sh -c` has the
+    same quoting semantics. Only the two absolute paths are re-rooted; the
+    dpkg-query format string, the installed-only filter, and the non-vacuity
+    check are the shipped bytes.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="xpf-inv-write."))
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        (self.tmp / "etc" / "xpf").mkdir(parents=True)
+        (self.tmp / "lib" / "modules" / KVER).mkdir(parents=True)
+
+    def _run(self):
+        cmd = (inv.WRITE_CMD
+               .replace("/etc/xpf", f"{self.tmp}/etc/xpf")
+               .replace("ls /lib/modules", f"ls {self.tmp}/lib/modules"))
+        return subprocess.run(["sh", "-c", cmd], capture_output=True, text=True)
+
+    def test_the_writer_produces_a_record_the_parser_accepts(self):
+        res = self._run()
+        self.assertEqual(res.returncode, 0, res.stderr)
+        body = (self.tmp / "etc" / "xpf" / "image-inventory").read_text()
+        kern, pkgs = inv.parse(body)
+        self.assertEqual(kern, KVER)
+        # A real dpkg database has far more than the floor; this is the
+        # assertion the quoting bug would break (a bad format string yields a
+        # file of blank lines, which parses to zero packages).
+        self.assertGreater(len(pkgs), inv.MIN_PACKAGES)
+        self.assertTrue(all("=" in p for p in pkgs))
+
+    def test_every_recorded_package_is_actually_installed(self):
+        # The ${db:Status-Status} filter: dpkg-query -W matches every package
+        # dpkg knows OF, including purged and never-installed names.
+        self._run()
+        body = (self.tmp / "etc" / "xpf" / "image-inventory").read_text()
+        _, pkgs = inv.parse(body)
+        installed = subprocess.run(
+            ["dpkg-query", "-W", "-f=${db:Status-Status} ${Package}\n"],
+            capture_output=True, text=True).stdout
+        real = {ln.split()[1] for ln in installed.splitlines()
+                if ln.startswith("installed ")}
+        recorded = {p.split("=", 1)[0] for p in pkgs}
+        self.assertEqual(recorded - real, set(),
+                         "the writer recorded packages that are not installed "
+                         "— the ${db:Status-Status} filter is not applied")
+
+    def test_no_kernel_in_lib_modules_fails_the_bake(self):
+        shutil.rmtree(self.tmp / "lib" / "modules" / KVER)
+        res = self._run()
+        self.assertNotEqual(res.returncode, 0)
+        self.assertIn("no kernel in /lib/modules", res.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/dist/test_publish_provenance.py
+++ b/scripts/dist/test_publish_provenance.py
@@ -31,10 +31,12 @@ assert _SPEC.loader is not None
 _SPEC.loader.exec_module(publish)
 
 # sign.py sits beside publish.py; publish already puts _DIST on sys.path.
+import image_inventory  # noqa: E402  (#6500 sidecar name)
 import sign  # noqa: E402
 
 _HAVE_MINISIGN = shutil.which("minisign") is not None
 VER = "0.0.0-provtest"
+KVER = "7.0.0-15-generic"
 
 
 @unittest.skipUnless(_HAVE_MINISIGN, "minisign not installed")
@@ -53,22 +55,52 @@ class GateProvenanceTests(unittest.TestCase):
         Path(self.meta).write_bytes(b"\x00fake-meta\x00")
         self.sidecar = os.path.join(self.dir, f"xpf-{VER}.manifest")
         self.sums = os.path.join(self.dir, f"xpf-{VER}.SHA256SUMS")
+        self.pkgs = os.path.join(self.dir, image_inventory.sidecar_name(VER))
 
-    def _sign_set(self, validated, base_pinned=True):
-        """(Re)write the provenance sidecar with the given validated /
-        base_image_pinned flags and sign a manifest covering qcow + meta +
-        sidecar (mirrors a real bake).
+    def _sign_set(self, validated, base_pinned=True, guest_kernel=KVER,
+                  inventory=KVER, npkgs=60):
+        """(Re)write the provenance sidecar + the #6500 inventory sidecar and
+        sign a manifest covering qcow + meta + both sidecars (mirrors a bake).
 
         `base_pinned=None` omits the base_image_pinned line entirely, modelling
         an old/tampered sidecar that never asserts pinning (#5815 fail-closed
-        missing-key case)."""
+        missing-key case). `guest_kernel=None` likewise omits guest_kernel (an
+        older bake predating #6500). `inventory=None` writes NO xpf-<ver>.pkgs
+        at all; otherwise it is the kernel the inventory records, so a value
+        different from `guest_kernel` models two authenticated records that
+        disagree. `npkgs` below the floor models a HOLLOW inventory.
+
+        Every DEFAULT is a valid input, so a negative case that varies ONE of
+        them is refused for the reason it names — a fixture that left several
+        inputs broken at once could not tell which check fired."""
         text = f"version: {VER}\n"
         if base_pinned is not None:
             text += f"base_image_pinned: {'true' if base_pinned else 'false'}\n"
         text += f"validated: {'true' if validated else 'false'}\n"
+        if guest_kernel is not None:
+            text += f"guest_kernel: {guest_kernel}\n"
         Path(self.sidecar).write_text(text)
-        sign.write_manifest(self.sums, [self.qcow, self.meta, self.sidecar])
+        artifacts = [self.qcow, self.meta, self.sidecar]
+        if inventory is not None:
+            body = ["# xpf appliance image inventory",
+                    f"guest_kernel: {inventory}", "packages:"]
+            body += [f"pkg{i}=1.0-{i}" for i in range(npkgs)]
+            Path(self.pkgs).write_text("\n".join(body) + "\n")
+            artifacts.append(self.pkgs)
+        elif os.path.exists(self.pkgs):
+            os.remove(self.pkgs)
+        sign.write_manifest(self.sums, artifacts)
         sign.sign_manifest(self.sums, self.sec, comment="provtest")
+
+    def _refused(self, needle):
+        """gate_provenance must refuse, and its message must name the property
+        under test. Asserting only `SystemExit != 0` cannot distinguish WHICH
+        check fired, so a reordered or newly-added gate would silently satisfy
+        every negative for the wrong reason."""
+        with self.assertRaises(SystemExit) as ctx:
+            publish.gate_provenance(self.dir, {VER: self.sums}, self.pub)
+        self.assertNotEqual(ctx.exception.code, 0)
+        self.assertIn(needle, str(ctx.exception.code))
 
     def test_validated_true_passes(self):
         # Regression guard: a fully-pinned validated bake still publishes
@@ -83,32 +115,24 @@ class GateProvenanceTests(unittest.TestCase):
         # must NOT publish. RED on revert: drop the base_image_pinned check ->
         # no SystemExit here.
         self._sign_set(validated=True, base_pinned=False)
-        with self.assertRaises(SystemExit) as ctx:
-            publish.gate_provenance(self.dir, {VER: self.sums}, self.pub)
-        self.assertNotEqual(ctx.exception.code, 0)
+        self._refused("base_image_pinned")
 
     def test_base_pinned_missing_refused(self):
         # #5815 fail-closed: a signed sidecar that never asserts base_image_pinned
         # (old/tampered manifest) is NOT publishable — a sidecar that does not
         # assert pinning must not default-allow.
         self._sign_set(validated=True, base_pinned=None)
-        with self.assertRaises(SystemExit) as ctx:
-            publish.gate_provenance(self.dir, {VER: self.sums}, self.pub)
-        self.assertNotEqual(ctx.exception.code, 0)
+        self._refused("base_image_pinned")
 
     def test_validated_false_refused(self):
         self._sign_set(validated=False)
         # RED on revert: gate_provenance gone -> no SystemExit here.
-        with self.assertRaises(SystemExit) as ctx:
-            publish.gate_provenance(self.dir, {VER: self.sums}, self.pub)
-        self.assertNotEqual(ctx.exception.code, 0)
+        self._refused("validated=")
 
     def test_missing_sidecar_refused(self):
         self._sign_set(validated=True)
         os.remove(self.sidecar)
-        with self.assertRaises(SystemExit) as ctx:
-            publish.gate_provenance(self.dir, {VER: self.sums}, self.pub)
-        self.assertNotEqual(ctx.exception.code, 0)
+        self._refused("no provenance sidecar")
 
     def test_unsigned_tampered_sidecar_refused(self):
         # Sidecar hash-covered by the signed manifest, then swapped on disk to
@@ -116,10 +140,58 @@ class GateProvenanceTests(unittest.TestCase):
         # hash mismatch (TOCTOU-safe), so a post-sign flip cannot slip through.
         self._sign_set(validated=False)
         Path(self.sidecar).write_text(
-            f"version: {VER}\nbase_image_pinned: true\nvalidated: true\n")
-        with self.assertRaises(SystemExit) as ctx:
-            publish.gate_provenance(self.dir, {VER: self.sums}, self.pub)
-        self.assertNotEqual(ctx.exception.code, 0)
+            f"version: {VER}\nbase_image_pinned: true\nvalidated: true\n"
+            f"guest_kernel: {KVER}\n")
+        self._refused("failed verify")
+
+
+    # ── #6500: the record must say what the image SHIPS ──────────────
+    def test_missing_guest_kernel_refused(self):
+        # An older bake predating #6500: fully validated and pinned, with a
+        # complete inventory sidecar — refused solely for the absent field.
+        self._sign_set(validated=True, guest_kernel=None)
+        self._refused("no guest_kernel")
+
+    def test_missing_inventory_sidecar_refused(self):
+        self._sign_set(validated=True, inventory=None)
+        self._refused("no inventory sidecar")
+
+    def test_hollow_inventory_refused(self):
+        # Present, signed, and answering nothing. A presence check would pass
+        # it — which is why the gate parses rather than stats.
+        self._sign_set(validated=True, npkgs=3)
+        self._refused("not a usable inventory")
+
+    def test_inventory_without_a_kernel_line_refused(self):
+        self._sign_set(validated=True)
+        body = Path(self.pkgs).read_text().replace(f"guest_kernel: {KVER}\n", "")
+        Path(self.pkgs).write_text(body)
+        sign.write_manifest(self.sums, [self.qcow, self.meta, self.sidecar, self.pkgs])
+        sign.sign_manifest(self.sums, self.sec, comment="provtest")
+        self._refused("not a usable inventory")
+
+    def test_kernel_disagreement_between_the_two_signed_records_refused(self):
+        # Both records are inside the SAME signature, so they cannot disagree
+        # on an untampered bake — a divergence means the signed set was
+        # re-assembled.
+        self._sign_set(validated=True, guest_kernel=KVER, inventory="9.9.9-other")
+        self._refused("cannot disagree")
+
+    def test_unsigned_inventory_sidecar_refused(self):
+        # Covered by the signed manifest, then swapped on disk: the hash check
+        # must reject it rather than parse whatever is there now.
+        self._sign_set(validated=True)
+        Path(self.pkgs).write_text(
+            "# xpf appliance image inventory\n"
+            f"guest_kernel: {KVER}\npackages:\n"
+            + "".join(f"evil{i}=1.0\n" for i in range(60)))
+        self._refused("failed verify")
+
+    def test_complete_set_publishes(self):
+        # The positive control for all of the above: nothing here refuses a
+        # good bake.
+        self._sign_set(validated=True)
+        publish.gate_provenance(self.dir, {VER: self.sums}, self.pub)
 
 
 class ParseManifestFieldsTests(unittest.TestCase):

--- a/scripts/image/bake.py
+++ b/scripts/image/bake.py
@@ -52,6 +52,7 @@ ROOT = os.path.dirname(os.path.dirname(HERE))
 
 # Signed-distribution helpers (#1924) live under scripts/dist.
 sys.path.insert(0, os.path.join(ROOT, "scripts", "dist"))
+import image_inventory  # noqa: E402  (#6500 inventory format)
 import sign  # noqa: E402
 
 # Runtime dependency set installed explicitly into the image. This is the
@@ -615,6 +616,15 @@ def virt_customize(work_qcow, xpf_deb):
         "--run-command", "update-grub",
         "--write", f"/etc/ssh/sshd_config.d/10-xpf-factory.conf:{SSHD_DROPIN}",
         "--run-command", "passwd -d root",
+        # #6500: record what this image actually SHIPS — the guest kernel and
+        # the full installed package set — INSIDE the image, as the last step
+        # so the enumeration is the final one (after every install, purge and
+        # autoremove above). bake.py reads it back out offline with virt-cat
+        # and emits it as the signed xpf-<ver>.pkgs sidecar; the in-image copy
+        # stays so an operator on the box can answer the same CVE-triage
+        # question without the dist tree. The fragment FAILS THE BAKE on an
+        # empty enumeration rather than shipping a hollow record.
+        "--run-command", image_inventory.WRITE_CMD,
         "--run-command", "/usr/local/sbin/xpfd version",
     ]
     run(argv)
@@ -693,7 +703,7 @@ def finalize_artifacts(*, validate_step, sign_step):
 
 def build_manifest_text(*, ver, commit, base_url, base_img, rel, base_sha,
                         base_pinned, validated, bake_date, kernel,
-                        proto_lines=""):
+                        guest_kernel, proto_lines=""):
     """Assemble the xpf-<ver>.manifest sidecar text (key: value lines).
 
     Pure + unit-testable so the supply-chain PROVENANCE fields are asserted
@@ -705,6 +715,13 @@ def build_manifest_text(*, ver, commit, base_url, base_img, rel, base_sha,
       - `base_image_pinned` (#4904 B): whether the Ubuntu base was authenticated
         against the repo-pinned trust-anchor digest (bound alongside the base
         digest + source URL already recorded here).
+      - `guest_kernel` (#6500): the kernel the IMAGE ships — the exact artifact
+        the #1930 LANE-1 channel promotes. `kernel` above is the BUILD HOST's
+        (`os.uname().release`, honestly named `bake_host_kernel`) and answers a
+        different question entirely. It is a REQUIRED keyword, not a defaulted
+        one, so a caller cannot silently omit the field the publish gate
+        requires. The full package inventory is too large for this sidecar and
+        rides in xpf-<ver>.pkgs, covered by the same signed SHA256SUMS.
 
     The sidecar is covered by the signed xpf-<ver>.SHA256SUMS (#5042), so these
     fields are authenticated once the manifest signature verifies.
@@ -719,6 +736,7 @@ def build_manifest_text(*, ver, commit, base_url, base_img, rel, base_sha,
         f"validated: {'true' if validated else 'false'}\n"
         f"bake_date: {bake_date}\n"
         f"bake_host_kernel: {kernel}\n"
+        f"guest_kernel: {guest_kernel}\n"
         + proto_lines
     )
 
@@ -743,6 +761,7 @@ def main():
                     ("virt-sysprep", "apt-get install libguestfs-tools"),
                     ("virt-sparsify", "apt-get install libguestfs-tools"),
                     ("virt-filesystems", "apt-get install libguestfs-tools"),
+                    ("virt-cat", "apt-get install libguestfs-tools"),
                     ("curl", "apt-get install curl")]:
         require(t, hint)
     if not (os.access("/dev/kvm", os.R_OK) and os.access("/dev/kvm", os.W_OK)):
@@ -822,6 +841,23 @@ def main():
         # 4. customize
         info("customizing image offline (packages, kernel >= 6.18, xpf install)...")
         virt_customize(work_qcow, xpf_deb)
+
+        # 4b. read the #6500 inventory back OUT of the image, offline.
+        # virt-cat, not a boot: the whole point is that the record is
+        # extractable without running the appliance. A parse failure ABORTS the
+        # bake — an image whose traceability record is missing or hollow is not
+        # publishable anyway (publish.py's gate refuses it), so failing here
+        # gives the operator the real cause instead of a refusal three steps
+        # later against an artifact that already exists.
+        info("reading the image inventory (guest kernel + installed packages)...")
+        inventory_text = out_text(
+            ["virt-cat", "-a", work_qcow, image_inventory.INVENTORY_GUEST_PATH])
+        try:
+            guest_kernel, inventory_pkgs = image_inventory.parse(inventory_text)
+        except image_inventory.InventoryError as e:
+            die(f"the baked image carries no usable inventory at "
+                f"{image_inventory.INVENTORY_GUEST_PATH}: {e}")
+        info(f"guest kernel {guest_kernel}, {len(inventory_pkgs)} packages recorded")
 
         # 5. seal
         info("sealing image (virt-sysprep)...")
@@ -913,7 +949,8 @@ def main():
                 rel=rel, base_sha=base_sha, base_pinned=base_pinned,
                 validated=not a.skip_validate,
                 bake_date=time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
-                kernel=os.uname().release, proto_lines=proto_lines))
+                kernel=os.uname().release, guest_kernel=guest_kernel,
+                proto_lines=proto_lines))
         info(f"manifest: {manifest}")
 
         # Per-version, version-named checksum manifest (#1924 §5.1): each bake
@@ -925,8 +962,19 @@ def main():
         # `xpf-deploy image-roll` verifies it against this SHA256SUMS before
         # parsing the ha-protocol / session-sync fields. The .minisig over this
         # manifest is produced only AFTER the validation gate (finalize_artifacts).
+        # #6500: the package inventory sidecar. Its own file rather than more
+        # manifest lines — a full dpkg list is hundreds of entries and the
+        # .manifest is parsed line-by-line by the deployer's mixed-base gate.
+        # It joins the signed SHA256SUMS below, so it is authenticated exactly
+        # like the .manifest sidecar is (#5042).
+        pkgs_out = os.path.join(a.out, image_inventory.sidecar_name(ver))
+        with open(pkgs_out, "w") as f:
+            f.write(inventory_text if inventory_text.endswith("\n")
+                    else inventory_text + "\n")
+        info(f"inventory: {pkgs_out}")
+
         sums = os.path.join(a.out, f"xpf-{ver}.SHA256SUMS")
-        sign.write_manifest(sums, [qcow_out, meta_out, manifest])
+        sign.write_manifest(sums, [qcow_out, meta_out, manifest, pkgs_out])
         info("checksums:")
         print(open(sums).read(), end="")
 

--- a/scripts/image/test_bake_base_pin.py
+++ b/scripts/image/test_bake_base_pin.py
@@ -133,13 +133,32 @@ class ManifestProvenanceBindingTests(_EnvGuard):
             base_url="https://mirror.invalid/rel", base_img="ubuntu.img",
             rel="26.04", base_sha=FAKE, base_pinned=base_pinned,
             validated=validated, bake_date="2026-01-01T00:00:00Z",
-            kernel="6.18.0-test")
+            kernel="6.18.0-test", guest_kernel="7.0.0-15-generic")
 
     def test_base_digest_and_pin_bound(self):
         t = self._text(base_pinned=True, validated=True)
         self.assertIn(f"base_image_sha256: {FAKE}\n", t)
         self.assertIn("base_image_pinned: true\n", t)
         self.assertIn("base_image: https://mirror.invalid/rel/ubuntu.img\n", t)
+
+    def test_guest_kernel_is_bound_and_distinct_from_the_build_host(self):
+        # #6500: `bake_host_kernel` is os.uname().release on the BUILD HOST and
+        # answers a different question from "what does this image ship". Both
+        # must be present and they must not be conflated.
+        t = self._text(base_pinned=True, validated=True)
+        self.assertIn("guest_kernel: 7.0.0-15-generic\n", t)
+        self.assertIn("bake_host_kernel: 6.18.0-test\n", t)
+
+    def test_guest_kernel_is_a_required_keyword(self):
+        # Not defaulted: a caller that forgets it must fail at the call site,
+        # not ship a manifest the publish gate then refuses three steps later.
+        with self.assertRaises(TypeError):
+            bake.build_manifest_text(
+                ver="9.9.9-test", commit="deadbeef",
+                base_url="https://mirror.invalid/rel", base_img="ubuntu.img",
+                rel="26.04", base_sha=FAKE, base_pinned=True,
+                validated=True, bake_date="2026-01-01T00:00:00Z",
+                kernel="6.18.0-test")
 
     def test_validated_true_and_false(self):
         self.assertIn("validated: true\n",
@@ -148,6 +167,39 @@ class ManifestProvenanceBindingTests(_EnvGuard):
                       self._text(base_pinned=True, validated=False))
         self.assertIn("base_image_pinned: false\n",
                       self._text(base_pinned=False, validated=True))
+
+
+class InventoryWiringTests(unittest.TestCase):
+    """#6500: the pure pieces are unit-tested, but a bake main() that never
+    CALLS them records nothing. main() itself needs libguestfs and a real base
+    image, so these pin the call sites in source — deleting one reds here
+    instead of silently shipping an image with no traceability record."""
+
+    SRC = Path(__file__).resolve().parent.joinpath("bake.py").read_text(
+        encoding="utf-8")
+
+    def test_virt_customize_runs_the_inventory_writer(self):
+        self.assertIn("image_inventory.WRITE_CMD", self.SRC)
+
+    def test_the_inventory_is_read_back_offline_with_virt_cat(self):
+        # virt-cat, not a boot: the record must be extractable without running
+        # the appliance, which is the point of recording it at all.
+        self.assertIn('"virt-cat", "-a", work_qcow', self.SRC)
+        self.assertIn('("virt-cat", "apt-get install libguestfs-tools")',
+                      self.SRC)
+
+    def test_the_pkgs_sidecar_joins_the_SIGNED_checksum_set(self):
+        # Outside the signed set it is unauthenticated metadata — exactly the
+        # gap #5042 closed for the .manifest sidecar.
+        self.assertIn(
+            "sign.write_manifest(sums, [qcow_out, meta_out, manifest, pkgs_out])",
+            self.SRC)
+
+    def test_a_bad_inventory_aborts_the_bake(self):
+        self.assertIn("image_inventory.InventoryError", self.SRC)
+
+    def test_main_passes_the_guest_kernel_into_the_manifest(self):
+        self.assertIn("guest_kernel=guest_kernel", self.SRC)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`docs/install-images.md` calls the signed per-version manifest **"the traceability record"** — but it recorded only the BUILD HOST's kernel (`bake_host_kernel` = `os.uname().release`) and nothing about what the image actually carries: not the guest kernel (the exact artifact the #1930 LANE-1 channel promotes), and none of the apt package versions `virt-customize` installed from a floating mirror. Two bakes from the same git commit on different days produce different images and nothing signed recorded the difference, so both routine day-zero questions —

- *"does release X ship openssl 3.x.y (CVE-YYYY)?"*
- *"which kernel does image X carry, so I can plan a LANE-1 arm?"*

— required booting or mounting the image.

## What landed

The bake writes an inventory **inside** the image at `/etc/xpf/image-inventory` as the last `virt-customize` step (after every install, purge and autoremove, so the enumeration is the final set), reads it back **offline with `virt-cat`** — no boot, which is the point — and emits it as `dist/xpf-<ver>.pkgs`, **covered by the signed `xpf-<ver>.SHA256SUMS`** exactly like the `.manifest` sidecar (#5042). The in-image copy stays so an operator on the box can answer the same question without the dist tree.

The manifest gains `guest_kernel`, a **required** keyword of `build_manifest_text` rather than a defaulted one, so a caller cannot silently omit the field the publish gate requires.

`publish.py gate_provenance` gains the third fail-closed leg alongside `validated` / `base_image_pinned`. It refuses a release whose manifest has no `guest_kernel`, whose `.pkgs` sidecar is absent or not covered by the signed manifest, whose inventory is **hollow**, or whose two authenticated records **disagree** about the kernel. A hollow record is refused deliberately rather than tolerated as best-effort: a present-but-empty inventory satisfies a presence check and answers nothing, which is worse than an absent one because it argues against re-examining it. Both records live inside the same signature, so a kernel disagreement means the signed set was re-assembled.

The format is **single-sourced** in `scripts/dist/image_inventory.py` because bake.py *writes* it and publish.py *reads* it, and a divergence between those is always a bug — never a legitimate difference. Both scripts already put `scripts/dist` on `sys.path` for `sign`, so neither needed a new import path.

## Fixtures that set the old gate inputs

Three existing suites had to be brought **forward**, not left to pass over an emptier set:

- the dist roundtrip's baseline signed set and its four copied dist trees now carry the inventory;
- the #4904 `validated:false` negative carries a **complete** inventory on purpose, so it is still refused for `validated:false` and not for a missing one — a negative satisfiable by the wrong cause stops testing what it names;
- `test_publish_provenance`'s negatives now assert **which** check fired instead of only `SystemExit != 0`. A reordered or newly-added gate would otherwise satisfy every one of them for the wrong reason.

## Validation

- `make selftest`: **53 passed / 0 skipped / 0 failed** (was 52). Dist roundtrip: **47 passed / 0 failed** (was 42), with five new legs including a positive control.
- **The in-guest writer was executed by a real shell against live `dpkg`** — 1829 packages, round-tripped through the parser. The format contract is observed output, not assumed. `virt-customize` hands `--run-command` to the guest's `sh -c` (exactly one shell layer), so a local `sh -c` has the same quoting semantics.
- **Fourteen one-line mutations**, each confirmed to import/parse at the mutated state first, each red, each with the full test count collected:

| mutation | red |
|---|---|
| drop the `guest_kernel` requirement | 1 |
| drop the `.pkgs` presence check | 1 |
| stat the sidecar instead of PARSING it | 3 |
| drop the two-records-agree check | 1 |
| revert the `.pkgs` publish allowlist | 6 dist legs |
| drop the parser non-vacuity floor | 3 |
| drop the missing-kernel refusal | 2 |
| count malformed lines as packages | 1 |
| restore the `\$`-escaping bug in the dpkg-query format | 2 |
| drop the installed-only filter | 1 |
| make `guest_kernel` optional | 1 |
| stop binding it into the manifest | 1 |
| stop running the writer in `virt_customize` | 1 |
| leave the sidecar out of the signed set | 1 |

Tree clean and rc back to 0 after each.

## Scope and what is NOT claimed

- **Rust helper binary: not reached.** Python + shell + Markdown only.
- **Needs a live bake to verify end to end: yes, one part.** The `virt-customize` → `virt-cat` round trip against a real baked image needs libguestfs and an Ubuntu base. That half is **not** claimed. What is proven: the writer (run for real against live dpkg), the parser and its refusals, the publish gate (5 refusals + a control, hermetically and through the dist roundtrip), and the bake call sites (source-level wiring assertions, each mutation-proved).
- Docs: `docs/install-images.md` gains a "What the image SHIPS" section; `docs/distribution.md`'s artifact list names the inventory in the signed set.

Closes #6500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cz2czGK3aA5MsMhkNkjHXX