### PR TITLE
ipsec: carry a failed SA terminate as teardown debt (#6542)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -100645,3 +100645,16 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: pkg/cluster/manager.go, pkg/cluster/heartbeat_manager.go,
   pkg/daemon/daemon_ha_sync.go,
   pkg/cluster/heartbeat_start_stop_race_7257_test.go (new), pkg/cluster/README.md
+
+## 2026-08-21 — #6542: IPsec teardown debt for a failed terminate
+- **Timestamp**: 2026-08-21
+- **Action**: `terminateRemovedConns` was fire-and-forget while
+  `promoteConnNames` advanced `prevConnNames` first, so a failed
+  `swanctl --terminate` lost the teardown debt permanently and `Apply` still
+  returned nil — a deleted/unrenderable VPN kept forwarding under its stale
+  child SA. The failed subset is now carried in `pendingTerminate`, unioned
+  into the next apply's removed set (filtered by the loaded names so a
+  re-added VPN is never torn down), and returned as an `Apply`/`Clear` error.
+  Debt discharges when the SA is no longer live, so it cannot latch.
+- **File(s)**: pkg/ipsec/manager.go, pkg/ipsec/delete_terminate_3941_test.go,
+  pkg/ipsec/terminate_debt_6542_test.go (new), pkg/ipsec/README.md, _Log.md

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -32,10 +32,15 @@ the apply path pays no fsync (the file is regenerated on every apply).
   reported success). Promotion of `prevConnNames` and removed-SA termination are
   gated on reload SUCCESS — a failed reload leaves the OLD config effective, so
   the applied-name set is preserved and no SA is torn down, letting the next
-  successful Apply/Clear retry the diff + teardown.
+  successful Apply/Clear retry the diff + teardown. **A FAILED terminate is
+  also load-bearing (#6542):** the failed subset becomes teardown DEBT
+  (`pendingTerminate`) that the next Apply folds back into its removed set,
+  and Apply RETURNS the failure instead of reporting success over a stale SA
+  that is still forwarding.
 - `Clear() error` — `manager.go`. Remove the xpf snippet, reload, and
   terminate every previously-applied connection's live SAs (#3941). Like Apply,
-  a reload failure is returned and skips promotion/termination (#4898).
+  a reload failure is returned and skips promotion/termination (#4898), and a
+  failed terminate is carried as debt and returned (#6542).
 - `SAStatus`, `TerminateAllSAs`, `InitiateConnection`, `GetSAStatus`,
   `ActiveConnectionNames` — `ike.go`.
 - `PrepareConfig(cfg *config.Config) *config.IPsecConfig` — `policy.go`.
@@ -102,6 +107,38 @@ all files stay in `package ipsec`, so the public API is unchanged.
   departures are torn down. All swanctl shell-outs route through the `sc`
   seam so the diff→terminate path is unit-tested against recording doubles
   (`delete_terminate_3941_test.go`, `manager_reload_ordering_4898_test.go`).
+
+- **A FAILED terminate is teardown DEBT, not a log line (#6542).**
+  `promoteConnNames` advances `prevConnNames` to the newly-loaded set the
+  moment the reload succeeds, so a departed name is gone from the only record
+  of "what was loaded" after exactly ONE apply. `terminateRemovedConns` was
+  fire-and-forget: a `swanctl --terminate` that errored was logged at WARN and
+  dropped, `Apply` still returned nil, and no later reconcile ever retried —
+  the departed VPN kept forwarding under its stale child SA until rekey /
+  lifetime expiry while the commit reported success. This is the
+  "advance-then-act, lose the debt" family: the marker advanced on a path that
+  was not verified-success.
+
+  The failed subset is now recorded in `pendingTerminate` and UNIONED into the
+  next apply's removed set by `promoteConnNames`, so the teardown is retried
+  every reconcile until it succeeds. `Apply`/`Clear` return the failure
+  (`recordTerminateDebt`), which the commit path joins into its tail result the
+  same way it joins a failed reload (#4433) — the operator sees the degraded
+  IPsec state instead of a false success.
+
+  Two properties keep the debt from latching or misfiring:
+  - It **discharges** when the departed connection is no longer live —
+    `terminateRemovedConns` only terminates (and only charges debt for) a
+    removed name that `--list-sas` actually reports, so an SA that died on its
+    own clears the debt silently rather than failing every future commit. The
+    ambiguous `--list-sas`-failed fallback (unconditional terminate, where a
+    "no matching SA" error is indistinguishable from a real failure) is
+    likewise self-clearing: the next apply enumerates and discharges.
+  - It **never terminates a LOADED connection** — both halves of the removed
+    set are filtered by the newly-loaded names, so an operator re-adding the
+    VPN discharges the debt instead of tearing the restored tunnel down.
+
+  Covered by `terminate_debt_6542_test.go`.
 
 - **The diff keys off the RENDERED set, not the raw VPN name (#5494 —
   FLIPS the prior #3941 name-keyed behavior).** `renderConfig` returns the

--- a/pkg/ipsec/delete_terminate_3941_test.go
+++ b/pkg/ipsec/delete_terminate_3941_test.go
@@ -23,12 +23,22 @@ type swanctlRecorder struct {
 	calls   [][]string
 	listSAs string // body returned for `swanctl --list-sas`
 	listErr error  // error returned for `swanctl --list-sas` (nil = ok)
+	// terminateErr programs a per-connection failure for
+	// `swanctl --terminate --ike <name>`; a name absent from the map (the
+	// zero value, nil map) terminates successfully. Used by the #6542
+	// teardown-debt tests.
+	terminateErr map[string]error
 }
 
 func (r *swanctlRecorder) run(args ...string) ([]byte, error) {
 	r.calls = append(r.calls, args)
 	if len(args) > 0 && args[0] == "--list-sas" {
 		return []byte(r.listSAs), r.listErr
+	}
+	if len(args) == 3 && args[0] == "--terminate" && args[1] == "--ike" {
+		if err := r.terminateErr[args[2]]; err != nil {
+			return []byte("terminate failed"), err
+		}
 	}
 	return nil, nil
 }

--- a/pkg/ipsec/manager.go
+++ b/pkg/ipsec/manager.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -57,6 +59,25 @@ type Manager struct {
 	// config's connection set yields the connections an operator DELETED, so
 	// their live SAs can be torn down (#3941). nil until the first Apply.
 	prevConnNames map[string]bool
+
+	// pendingTerminate carries the TEARDOWN DEBT of connections whose
+	// `swanctl --terminate` failed on a previous apply (#6542).
+	//
+	// prevConnNames advances to the newly-loaded set as soon as the reload
+	// succeeds, so a name that departed the loaded set is gone from it
+	// forever after that single apply. Before #6542 a failed terminate was
+	// logged and dropped on the floor: the departed connection's live child
+	// SA kept forwarding under stale selectors/credentials and no later
+	// reconcile ever retried the teardown, because the only record of what
+	// departed had already been overwritten. Carrying the failed subset here
+	// re-derives it into the NEXT apply's removed set, so the teardown is
+	// retried until it succeeds or the SA is observed gone.
+	//
+	// A debt entry is NEVER a licence to terminate a loaded connection:
+	// promoteConnNames folds the debt into `removed` only for names absent
+	// from the newly-loaded set, so an operator re-adding the VPN discharges
+	// the debt instead of tearing the restored tunnel down.
+	pendingTerminate map[string]bool
 
 	// swanctl is the exec seam for shelling out to swanctl. Nil in
 	// production and directly-constructed test Managers; sc() falls back to
@@ -148,9 +169,17 @@ func (m *Manager) Apply(ipsecCfg *config.IPsecConfig) error {
 	// while we tear it down. Terminate is idempotent: a departed VPN with no
 	// active SA is a clean no-op (no --terminate is issued because it never
 	// shows up in --list-sas).
+	//
+	// #6542: a terminate that FAILS is not swallowed. promoteConnNames has
+	// already advanced prevConnNames past the departed names, so a dropped
+	// failure would lose the teardown debt permanently and leave the stale SA
+	// forwarding while Apply reported success. The failed subset is recorded
+	// as debt (retried on the next apply) AND surfaced as an Apply error, so
+	// the commit result shows the degraded IPsec state — the same posture
+	// #4433 established for a failed reload.
 	removed := m.promoteConnNames(loadedNames)
-	m.terminateRemovedConns(removed)
-	return nil
+	failed := m.terminateRemovedConns(removed)
+	return m.recordTerminateDebt(failed)
 }
 
 // Clear removes the xpf config and reloads strongSwan, terminating the live
@@ -163,8 +192,8 @@ func (m *Manager) Clear() error {
 		return err
 	}
 	removed := m.promoteConnNames(nil)
-	m.terminateRemovedConns(removed)
-	return nil
+	failed := m.terminateRemovedConns(removed)
+	return m.recordTerminateDebt(failed)
 }
 
 // applyConfig renders + atomically writes the swanctl snippet and reloads.
@@ -241,28 +270,77 @@ func (m *Manager) reload() error {
 // reflects the last config strongSwan actually loaded — never a config whose
 // reload failed. The name/removed diff and the prevConnNames advance stay
 // atomic under mu.
+//
+// #6542: the returned set is the union of the departed-this-apply names AND
+// any outstanding teardown debt (pendingTerminate) — connections whose
+// terminate failed on an earlier apply and whose stale SA may therefore still
+// be forwarding. Both halves are filtered by the newly-loaded set, so a name
+// that came back (operator re-added the VPN, or it became renderable again)
+// is never torn down. The debt is cleared here and re-derived from THIS
+// apply's teardown outcome by recordTerminateDebt.
 func (m *Manager) promoteConnNames(newNames map[string]bool) []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	var removed []string
+	seen := make(map[string]bool, len(m.prevConnNames))
 	for name := range m.prevConnNames {
 		if !newNames[name] {
+			removed = append(removed, name)
+			seen[name] = true
+		}
+	}
+	for name := range m.pendingTerminate {
+		if !newNames[name] && !seen[name] {
 			removed = append(removed, name)
 		}
 	}
 	m.prevConnNames = newNames
+	m.pendingTerminate = nil
 	return removed
 }
 
+// recordTerminateDebt records the connections whose teardown failed on this
+// apply so the next reconcile retries them, and returns the error Apply/Clear
+// reports to the caller. An empty failed set discharges cleanly (nil error).
+//
+// The debt is UNIONED into whatever pendingTerminate currently holds rather
+// than replacing it: promoteConnNames releases mu before the terminates run,
+// so a concurrent Apply (the ordered commit path and the DHCP-rebind
+// re-render both call Apply) could otherwise clobber the other's debt. A
+// stale union member is harmless — promoteConnNames filters the debt by the
+// loaded set before any terminate is issued.
+func (m *Manager) recordTerminateDebt(failed []string) error {
+	if len(failed) == 0 {
+		return nil
+	}
+	m.mu.Lock()
+	if m.pendingTerminate == nil {
+		m.pendingTerminate = make(map[string]bool, len(failed))
+	}
+	for _, name := range failed {
+		m.pendingTerminate[name] = true
+	}
+	m.mu.Unlock()
+	sort.Strings(failed)
+	return fmt.Errorf("terminate stale IPsec SAs for removed connection(s) "+
+		"%s: teardown retried on next commit", strings.Join(failed, ", "))
+}
+
 // terminateRemovedConns tears down the live IKE/child SAs of the deleted
-// connections. It queries live SAs and only terminates a removed connection
-// that actually has an SA, so a deletion of a VPN that was never up issues no
-// swanctl call. A terminate failure is logged but never fails the apply — the
-// config reload already unloaded the connection, and the SA may simply have
-// been down already (#3941).
-func (m *Manager) terminateRemovedConns(removed []string) {
+// connections and returns the subset whose terminate FAILED. It queries live
+// SAs and only terminates a removed connection that actually has an SA, so a
+// deletion of a VPN that was never up issues no swanctl call (#3941).
+//
+// #6542: the failed subset is returned rather than only logged. A departed
+// connection that is observed LIVE and whose terminate errors is still
+// forwarding under an unloaded configuration — the exact fail-open this
+// teardown exists to close — so it becomes teardown debt the caller retries.
+// A removed connection that is NOT live is a clean no-op and owes nothing,
+// which is what lets the debt discharge once the SA is actually gone instead
+// of failing every subsequent commit forever.
+func (m *Manager) terminateRemovedConns(removed []string) []string {
 	if len(removed) == 0 {
-		return
+		return nil
 	}
 
 	removedSet := make(map[string]bool, len(removed))
@@ -270,37 +348,52 @@ func (m *Manager) terminateRemovedConns(removed []string) {
 		removedSet[name] = true
 	}
 
+	var failed []string
+
 	live, err := m.liveConnNames()
 	if err != nil {
 		// Could not enumerate live SAs (charon down / vici error). Fall back
 		// to an unconditional, idempotent terminate of each removed name so a
 		// straggler SA is not left forwarding; swanctl no-ops when nothing
 		// matches.
+		//
+		// #6542: a failure here is ambiguous — it may be a genuine teardown
+		// failure or merely "no matching SA" for a connection that was never
+		// up. It is still carried as debt: the NEXT apply enumerates live SAs
+		// and discharges the debt silently if the name is not live, so an
+		// ambiguous failure self-clears in one reconcile instead of latching.
 		slog.Warn("could not list SAs before terminating removed IPsec "+
 			"connections; terminating unconditionally", "err", err)
 		for _, name := range removed {
-			m.terminateIKE(name)
+			if !m.terminateIKE(name) {
+				failed = append(failed, name)
+			}
 		}
-		return
+		return failed
 	}
 
 	for name := range live {
-		if removedSet[name] {
-			m.terminateIKE(name)
+		if removedSet[name] && !m.terminateIKE(name) {
+			failed = append(failed, name)
 		}
 	}
+	return failed
 }
 
 // terminateIKE issues `swanctl --terminate --ike <name>` for a single
-// connection, logging (but not propagating) any error.
-func (m *Manager) terminateIKE(name string) {
+// connection and reports whether it succeeded. The error is logged here and
+// converted to a false return so the caller can carry the teardown debt
+// (#6542); it is deliberately not wrapped and propagated, because a single
+// failure must not abort the teardown of the OTHER removed connections.
+func (m *Manager) terminateIKE(name string) bool {
 	if out, err := m.sc("--terminate", "--ike", name); err != nil {
 		slog.Warn("swanctl terminate for deleted IPsec VPN failed "+
-			"(SA may already be down)", "ike", name, "err", err,
-			"output", string(out))
-		return
+			"(SA may already be down); teardown retried on next commit",
+			"ike", name, "err", err, "output", string(out))
+		return false
 	}
 	slog.Info("terminated live SAs for deleted IPsec VPN", "ike", name)
+	return true
 }
 
 // liveConnNames returns the set of connection (IKE SA) names strongSwan

--- a/pkg/ipsec/terminate_debt_6542_test.go
+++ b/pkg/ipsec/terminate_debt_6542_test.go
@@ -1,0 +1,175 @@
+package ipsec
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// #6542: a FAILED `swanctl --terminate` for a departed connection must not
+// vanish.
+//
+// promoteConnNames advances prevConnNames to the newly-loaded set the moment
+// the reload succeeds, so a departed name is gone from the only record of
+// "what was loaded" after exactly one apply. Before this fix,
+// terminateRemovedConns was fire-and-forget: a terminate that errored was
+// logged at WARN and dropped, Apply still returned nil, and no later
+// reconcile ever retried the teardown — the deleted VPN kept forwarding under
+// its stale child SA until rekey/lifetime expiry while the commit reported
+// success.
+//
+// These tests drive Manager.Apply against the recording swanctl seam with a
+// programmed terminate failure and assert the three properties the fix owes:
+// Apply REPORTS the failure, the debt is RETRIED on the next apply, and the
+// debt DISCHARGES (rather than latching forever) once the SA is gone or the
+// connection comes back into the loaded set.
+
+var errTerminate = errors.New("swanctl: terminate failed")
+
+// applyTwoThenDeleteA loads site-a + site-b, then deletes site-a with both
+// SAs live and site-a's terminate programmed to fail. It returns the error
+// the delete-Apply reported.
+func applyTwoThenDeleteA(t *testing.T, rec *swanctlRecorder) (*Manager, error) {
+	t.Helper()
+	m := newRecordingManager(t, rec)
+	if err := m.Apply(vpnCfg("site-a", "site-b")); err != nil {
+		t.Fatalf("initial Apply: %v", err)
+	}
+	rec.listSAs = liveSA("site-a", "site-b")
+	rec.terminateErr = map[string]error{"site-a": errTerminate}
+	return m, m.Apply(vpnCfg("site-b"))
+}
+
+// TestFailedTerminateIsReported is the first RED-on-revert: restoring the
+// pre-fix `m.terminateRemovedConns(removed); return nil` tail makes Apply
+// return nil here.
+func TestFailedTerminateIsReported(t *testing.T) {
+	rec := &swanctlRecorder{}
+	_, err := applyTwoThenDeleteA(t, rec)
+	if err == nil {
+		t.Fatal("Apply returned nil after the terminate of the departed " +
+			"connection site-a FAILED — the stale SA is still forwarding " +
+			"and the commit reported success")
+	}
+	if !strings.Contains(err.Error(), "site-a") {
+		t.Fatalf("Apply error must name the connection whose teardown "+
+			"failed, got %q", err)
+	}
+	// The surviving connection must not be implicated.
+	if strings.Contains(err.Error(), "site-b") {
+		t.Fatalf("Apply error names the SURVIVING connection site-b: %q", err)
+	}
+}
+
+// TestFailedTerminateIsRetriedOnNextApply is the second RED-on-revert: the
+// departed name is gone from prevConnNames after the first apply, so without
+// the debt set the next apply re-derives an EMPTY removed set and never
+// retries — terminateCalls stays at 1.
+func TestFailedTerminateIsRetriedOnNextApply(t *testing.T) {
+	rec := &swanctlRecorder{}
+	m, err := applyTwoThenDeleteA(t, rec)
+	if err == nil {
+		t.Fatal("delete Apply must report the failed terminate")
+	}
+	if got := rec.terminateCalls(); len(got) != 1 || got[0] != "site-a" {
+		t.Fatalf("delete Apply: want one terminate for site-a, got %v", got)
+	}
+
+	// Same config re-applied (a later, unrelated commit). site-a's SA is
+	// still live, so the teardown debt must be retried.
+	if err := m.Apply(vpnCfg("site-b")); err == nil {
+		t.Fatal("second Apply returned nil while site-a's stale SA is " +
+			"still live and its terminate still fails")
+	}
+	got := rec.terminateCalls()
+	if len(got) != 2 || got[1] != "site-a" {
+		t.Fatalf("teardown debt was not retried on the next Apply: "+
+			"terminate calls %v", got)
+	}
+
+	// Third apply, terminate now succeeds: the debt discharges and Apply
+	// reports success.
+	rec.terminateErr = nil
+	if err := m.Apply(vpnCfg("site-b")); err != nil {
+		t.Fatalf("third Apply after a SUCCESSFUL retry must succeed: %v", err)
+	}
+	if got := rec.terminateCalls(); len(got) != 3 || got[2] != "site-a" {
+		t.Fatalf("third Apply must have retried site-a once more, got %v", got)
+	}
+
+	// Fourth apply: the debt is discharged, so no further terminate.
+	if err := m.Apply(vpnCfg("site-b")); err != nil {
+		t.Fatalf("fourth Apply: %v", err)
+	}
+	if got := rec.terminateCalls(); len(got) != 3 {
+		t.Fatalf("discharged debt must not be retried again, got %v", got)
+	}
+}
+
+// TestTerminateDebtDischargesWhenSAIsGone: the debt must not latch. Once the
+// departed connection no longer appears in --list-sas the fail-open is closed
+// (by expiry, by charon restart, by anything) and further commits must report
+// success rather than failing forever on a dead name.
+func TestTerminateDebtDischargesWhenSAIsGone(t *testing.T) {
+	rec := &swanctlRecorder{}
+	m, err := applyTwoThenDeleteA(t, rec)
+	if err == nil {
+		t.Fatal("delete Apply must report the failed terminate")
+	}
+
+	// site-a's SA is gone; site-b's remains.
+	rec.listSAs = liveSA("site-b")
+	if err := m.Apply(vpnCfg("site-b")); err != nil {
+		t.Fatalf("Apply must succeed once the stale SA is gone: %v", err)
+	}
+	if got := rec.terminateCalls(); len(got) != 1 {
+		t.Fatalf("a departed connection with no live SA owes no terminate, "+
+			"got %v", got)
+	}
+}
+
+// TestTerminateDebtDischargesWhenConnReloaded: a debt entry is never a licence
+// to tear down a LOADED connection. Re-adding the VPN puts site-a back in the
+// rendered+loaded set, so strongSwan is enforcing it again and the teardown
+// debt must be dropped rather than killing the restored tunnel.
+func TestTerminateDebtDischargesWhenConnReloaded(t *testing.T) {
+	rec := &swanctlRecorder{}
+	m, err := applyTwoThenDeleteA(t, rec)
+	if err == nil {
+		t.Fatal("delete Apply must report the failed terminate")
+	}
+	before := len(rec.terminateCalls())
+
+	// Operator re-adds site-a. Its terminate would still fail if issued.
+	if err := m.Apply(vpnCfg("site-a", "site-b")); err != nil {
+		t.Fatalf("re-adding the VPN must succeed: %v", err)
+	}
+	got := rec.terminateCalls()
+	if len(got) != before {
+		t.Fatalf("re-added (loaded) connection must not be torn down by a "+
+			"stale teardown debt, terminate calls %v", got)
+	}
+}
+
+// TestClearReportsFailedTerminate covers the Clear()/empty-config path, which
+// has its own promote+terminate tail.
+func TestClearReportsFailedTerminate(t *testing.T) {
+	rec := &swanctlRecorder{}
+	m := newRecordingManager(t, rec)
+	if err := m.Apply(vpnCfg("site-a")); err != nil {
+		t.Fatalf("initial Apply: %v", err)
+	}
+	rec.listSAs = liveSA("site-a")
+	rec.terminateErr = map[string]error{"site-a": errTerminate}
+
+	if err := m.Apply(nil); err == nil {
+		t.Fatal("clear Apply returned nil after site-a's terminate FAILED")
+	}
+	// The debt survives into the next reconcile on the clear path too.
+	if err := m.Clear(); err == nil {
+		t.Fatal("Clear returned nil while site-a's stale SA is still live")
+	}
+	if got := rec.terminateCalls(); len(got) != 2 {
+		t.Fatalf("clear-path teardown debt was not retried, got %v", got)
+	}
+}


### PR DESCRIPTION
## Problem

`Manager.Apply` advanced `prevConnNames` to the newly-loaded connection set and then called `terminateRemovedConns` fire-and-forget:

```go
removed := m.promoteConnNames(loadedNames)
m.terminateRemovedConns(removed)
return nil
```

A departed name is gone from the only record of "what was loaded" after exactly one apply. So a `swanctl --terminate` that failed was logged at WARN, dropped, and never retried — while `Apply` returned nil. The deleted (or unrenderable, #5494) VPN kept forwarding under its stale child SA until rekey/lifetime expiry, and the commit reported success.

This is the advance-then-act, lose-the-debt shape: the marker advances on a path that is not verified-success.

## Fix

- The failed subset is recorded in a new `pendingTerminate` set and **unioned into the next apply's removed set** by `promoteConnNames`, so the teardown is retried on every subsequent reconcile until it succeeds.
- `Apply`/`Clear` **return** the failure (`recordTerminateDebt`). The commit path already joins an IPsec error into its tail result (the #4433 posture), so the operator sees the degraded state rather than a false success.

Two properties keep the debt from latching or misfiring:

1. **It discharges when the SA is gone.** `terminateRemovedConns` only terminates — and only charges debt for — a removed name that `--list-sas` actually reports. An SA that expired on its own clears the debt silently instead of failing every future commit. The ambiguous `--list-sas`-failed fallback (unconditional terminate, where "no matching SA" is indistinguishable from a real failure) self-clears on the next enumerating apply.
2. **It never terminates a LOADED connection.** Both halves of the removed set are filtered by the newly-loaded names, so re-adding the VPN discharges the debt rather than killing the restored tunnel.

`pendingTerminate` is a separate set rather than a retained `prevConnNames` entry so `prevConnNames` keeps meaning exactly "what strongSwan has loaded". `recordTerminateDebt` unions rather than replaces, because `promoteConnNames` releases `mu` before the terminates run and both the ordered commit path and the DHCP-rebind re-render can be in `Apply`.

## Tests

`pkg/ipsec/terminate_debt_6542_test.go` (new, 5 tests):

- `TestFailedTerminateIsReported` — `Apply` errors and names the failed conn, not the survivor.
- `TestFailedTerminateIsRetriedOnNextApply` — the retry is re-issued, succeeds on the third apply, and is not re-issued after discharge.
- `TestTerminateDebtDischargesWhenSAIsGone` — no latch.
- `TestTerminateDebtDischargesWhenConnReloaded` — a re-added VPN is not torn down.
- `TestClearReportsFailedTerminate` — the `Clear()`/empty-config tail.

## Validation

`go test ./pkg/ipsec/ ./pkg/daemon/ ./pkg/cli/ -count=1` green.

Mutation matrix (one line per cell, restore + rebuild between cells, rc read from a file):

| Cell | Mutation | rc | Reds |
|---|---|---|---|
| M1 | Apply tail `return nil` (pre-fix report leg) | 1 | 5 tests |
| M2 | delete the `pendingTerminate` fold from `promoteConnNames` wiring | 1 | both retry tests |
| M3 | delete the debt-store assignment in `recordTerminateDebt` | 1 | both retry tests |
| CONTROL | none | 0 | — |

No dataplane/cluster code touched: Go control plane only, no `userspace-dp` binary or shim `.o` movement, so no cluster gate is owed.

Closes #6542