### PR TITLE
docs: describe the reviewed base-image pin the bake actually enforces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,8 +284,9 @@ selftest:
 	sh scripts/run-selftests.sh
 
 # Bake the distributable appliance image (#1879 Path C): one
-# offline-built bootable root disk (LATEST Ubuntu server cloudimg base
-# discovered at bake time — XPF_BASE_RELEASE pins; linux-generic
+# offline-built bootable root disk (REVIEWED-PIN Ubuntu server cloudimg
+# base — PINNED_BASE_RELEASE + PINNED_BASE_SHA256 in bake.py, not
+# auto-latest; XPF_BASE_RELEASE overrides one run; linux-generic
 # kernel >= 6.18, xpfd + cli + xpf-userspace-dp + day-0 config-drive
 # loader), exported as a qcow2 for libvirt/KVM AND as an incus VM
 # image (metadata tarball + the same qcow2). Includes the in-guest

--- a/docs/install-images.md
+++ b/docs/install-images.md
@@ -1,10 +1,11 @@
 # xpf appliance images (#1879 Path C)
 
 vSRX-style prebuilt-image distribution: one bootable root disk, built
-offline, carrying everything xpf needs — the LATEST Ubuntu release
-(operator policy: always the newest — 26.04 today, discovered at bake
-time), a >= 6.18 kernel (the AF_XDP shim's verifier floor; 26.04 ships
-7.0), FRR, strongSwan, Kea, chrony, systemd-networkd, and the xpf
+offline, carrying everything xpf needs — a REVIEWED-PIN Ubuntu base
+(`PINNED_BASE_RELEASE` in `bake.py`, 26.04 LTS today; bumping it is a
+deliberate, reviewed commit, **not** auto-latest — #1943), a >= 6.18
+kernel (the AF_XDP shim's verifier floor; 26.04 ships 7.0), FRR,
+strongSwan, Kea, chrony, systemd-networkd, and the xpf
 binaries (`xpfd`, `cli`, `xpf-userspace-dp`) with their systemd units.
 There is no dependency matrix to install and no kernel hunt: the image
 IS the dependency closure.
@@ -67,10 +68,12 @@ Pipeline (offline — the image is never booted to provision it):
    binaries into the `xpf` Debian package (binary set staged under
    `/usr/local/share/xpf/staged`). The bake installs that `.deb` instead
    of copying raw binaries.
-2. Discover the LATEST Ubuntu release from the upstream listing
-   (`XPF_BASE_RELEASE` pins one), then fetch + SHA256-verify the
-   official Ubuntu *server cloudimg*. Upstream owns partitioning and
-   the UEFI/BIOS bootloader.
+2. Resolve the base release from the **reviewed pin**
+   (`PINNED_BASE_RELEASE = "26.04"`, `bake.py`), then fetch the official
+   Ubuntu *server cloudimg* and authenticate it against
+   `PINNED_BASE_SHA256` — a trust anchor the mirror does not control.
+   An unpinned base is **refused**; see "Base-image pin policy" below.
+   Upstream owns partitioning and the UEFI/BIOS bootloader.
 3. `virt-resize` the root partition into an 8 GiB work disk
    (`XPF_IMAGE_DISK_SIZE` overrides). This is the *floor* size: an
    operator who provisions a larger root disk gets the extra space
@@ -166,9 +169,9 @@ Pipeline (offline — the image is never booted to provision it):
 
 Each bake also writes `dist/xpf-<ver>.manifest` recording the exact
 inputs (base image URL + release + verified SHA256, git commit, bake
-date/host kernel). Bakes are not bit-reproducible (the base tracks
-the newest upstream release unless `XPF_BASE_RELEASE` pins one); the
-manifest is the traceability record. The manifest ALSO records the
+date/host kernel). Bakes are not bit-reproducible even at a fixed
+base release — the mirror's package versions move between bakes — so
+the manifest is the traceability record. The manifest ALSO records the
 staged binary's compile-time protocol versions (`ha_protocol_version`,
 `ha_protocol_min_compat`, `session_sync_protocol_version`,
 `configdb_*_version`, from `xpfd protocol-versions`); the #1930 LANE-2
@@ -177,6 +180,53 @@ without booting the image — whether a rolling image-replace can preserve
 sessions across the mixed-base window or must replace both nodes at once.
 See `docs/in-place-upgrade.md` (Kernel / OS upgrade lanes) for the full
 LANE-1/2/3 decision rule and the state-carry contract.
+
+### Base-image pin policy (#1943 / #4904-B)
+
+The base is a **reviewed pin**, not mirror-latest. Two constants in
+`scripts/image/bake.py` are the contract:
+
+| Constant | What it pins | How it moves |
+|---|---|---|
+| `PINNED_BASE_RELEASE` | the Ubuntu release (`"26.04"`) | a reviewed commit (a PR), never automatically |
+| `PINNED_BASE_SHA256` | that release's base-image digest | a reviewed commit, after re-verifying Canonical's GPG-signed `SHA256SUMS` against the UEC signing key `D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81` |
+
+The old default scraped `cloud-images.ubuntu.com` and took the
+highest-numbered listing, which silently selects whatever the mirror
+calls newest — a non-LTS (26.10), or the *previous* release (25.10) when
+an LTS image lags publication. That drift is what the pin forbids.
+
+The digest pin is a supply-chain **trust anchor**, not a convenience: the
+image and its `SHA256SUMS` come from the same configurable mirror
+endpoint, so a same-endpoint checksum authenticates nothing against a
+compromised mirror or a TLS/DNS/CA compromise — the mirror can serve
+matching malicious bytes *and* hash, and xpf would then sign the result
+with its RELEASE key.
+
+**Refusals you can expect** (all `die()`, non-zero exit):
+
+- the downloaded base digest does not match `PINNED_BASE_SHA256` — a
+  wrong/compromised mirror, or a stale pin after a Canonical respin
+  (re-verify the GPG-signed `SHA256SUMS`, then bump the pin in a
+  reviewed commit);
+- the resolved release has **no** pin entry and no `XPF_BASE_SHA256` —
+  the bake refuses rather than trusting a same-endpoint checksum.
+
+**Opt-in overrides** (all one-off, none of them the default):
+
+| Env var | Effect |
+|---|---|
+| `XPF_BASE_RELEASE=<rel>` | use `<rel>` instead of `PINNED_BASE_RELEASE` for this run |
+| `XPF_BASE_SHA256=<digest>` | supply the trust anchor for this run (e.g. a point respin between reviewed bumps); wins over the repo constant |
+| `XPF_UBUNTU_AUTODISCOVER=1` | opt back into mirror-latest discovery — off by default |
+| `XPF_ALLOW_UNPINNED_BASE=1` | proceed with an unauthenticated base. The bake warns loudly and the manifest records `base_image_pinned: false` |
+
+An `XPF_ALLOW_UNPINNED_BASE=1` bake is **not publishable**:
+`publish.py`'s `gate_provenance` refuses `base_image_pinned != true`
+fail-closed (#5815), with no override — a signed unpinned image is not
+releasable. The test VM follows the same policy: `test/incus/setup.sh`
+tracks whatever release production was last baked at, deliberately,
+rather than the newest Ubuntu on the day you run `make test-vm`.
 
 Full first-boot matrix (run after a bake, or standalone):
 

--- a/scripts/test_base_pin_docs_6501.py
+++ b/scripts/test_base_pin_docs_6501.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Guard: the install surface describes the base-image pin contract the code
+actually enforces (#6501).
+
+`docs/install-images.md` promised mirror-latest Ubuntu discovery long after
+#1943 pinned the base and #4904-B added the SHA256 trust anchor. An operator
+following it expected the newest upstream release with no pin enforcement and
+was surprised by the bake aborting on a `PINNED_BASE_SHA256` mismatch or on an
+unpinned release.
+
+A claim fix owes TWO proofs, and this file asserts both.
+
+LANDED — the false claims are gone. Matching is WRAP-INSENSITIVE: comment and
+markdown markers are stripped and all whitespace is collapsed before the
+search, because a claim that wraps across two lines is invisible to a
+line-oriented `grep -F`. That blind spot is not hypothetical here: the fourth
+site this issue's fix had to correct — `Makefile:287-288`, "LATEST Ubuntu
+server cloudimg base / discovered at bake time" — is split across two comment
+lines and is not named in the issue at all. A line-based sweep would have
+shipped it.
+
+The banned fragments are complete ASSERTING clauses, not bare keywords,
+because a claim-guard keyed to keywords is defeated by NEGATION rather than by
+paraphrase: the corrected text and `bake.py` both say "not auto-latest" and
+"opts back into mirror-latest discovery", which a keyword ban would red on
+while the actual false claim walked past.
+
+TRUE — the replacement text matches the code. The doc must name the real
+constants, must carry the SAME pinned release value `bake.py` compiles in, and
+must not name a bake override `bake.py` does not read. A base bump that
+updates the code and forgets the doc reds here, which is the failure mode that
+produced this issue in the first place.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DOC = ROOT / "docs" / "install-images.md"
+MAKEFILE = ROOT / "Makefile"
+BAKE = ROOT / "scripts" / "image" / "bake.py"
+
+# The install-surface files that describe bake behaviour to an operator.
+SURFACE = (DOC, MAKEFILE)
+
+# Complete asserting clauses that were FALSE. Each is normalized the same way
+# the surface is, so a re-wrap cannot smuggle one back in.
+BANNED = (
+    "the latest ubuntu release (operator policy: always the newest",
+    "discover the latest ubuntu release from the upstream listing",
+    "the base tracks the newest upstream release",
+    "latest ubuntu server cloudimg base discovered at bake time",
+    "discovered at bake time), a >= 6.18 kernel",
+)
+
+# Every environment variable the doc is allowed to present as a bake override
+# must be one bake.py actually reads.
+DOC_ENV_RE = re.compile(r"XPF_[A-Z0-9_]+")
+
+
+def pin_policy_section(normalized=False):
+    """The base-image pin-policy section of the doc, or "" if its heading is
+    gone. Returning "" rather than raising keeps a lost anchor a readable test
+    FAILURE instead of a collection error that reports no tests at all."""
+    raw = DOC.read_text(encoding="utf-8")
+    try:
+        start = raw.index("### Base-image pin policy")
+        end = raw.index("Full first-boot matrix", start)
+    except ValueError:
+        return ""
+    section = raw[start:end]
+    return normalize(section) if normalized else section
+
+
+def normalize(text):
+    """Strip comment/markdown markers and collapse all whitespace, so a claim
+    that wraps across lines reads as one string."""
+    stripped = [re.sub(r"^\s*(#+|//+|\*|>|\||-|\d+\.)\s?", " ", ln)
+                for ln in text.splitlines()]
+    return re.sub(r"\s+", " ", " ".join(stripped)).lower()
+
+
+class MatcherVacuityTests(unittest.TestCase):
+    """A guard whose matcher cannot see the thing it bans passes vacuously —
+    and a vacuous green argues against anyone re-examining the property."""
+
+    def test_the_normalizer_finds_a_claim_that_wraps_across_lines(self):
+        wrapped = ("# offline-built bootable root disk (LATEST Ubuntu server\n"
+                   "# cloudimg base discovered at bake time — XPF_BASE_RELEASE\n")
+        self.assertIn("latest ubuntu server cloudimg base discovered at bake time",
+                      normalize(wrapped))
+
+    def test_a_line_oriented_search_would_MISS_that_same_claim(self):
+        # The reason this file normalizes at all, asserted rather than assumed.
+        wrapped = ("# offline-built bootable root disk (LATEST Ubuntu server\n"
+                   "# cloudimg base discovered at bake time\n")
+        self.assertFalse(any(
+            "latest ubuntu server cloudimg base discovered at bake time" in ln.lower()
+            for ln in wrapped.splitlines()))
+
+    def test_the_normalizer_strips_markdown_and_comment_markers(self):
+        self.assertIn("a b", normalize("# a\n> b"))
+        self.assertIn("c d", normalize("- c\n  d"))
+
+    def test_the_pin_policy_section_is_non_trivial(self):
+        # Every scoped assertion below would pass over an empty slice.
+        self.assertGreater(
+            len(TrueTests.SECTION), 800,
+            "the pin-policy section is missing or nearly empty — its heading "
+            "moved, or the section was gutted. Every scoped assertion below "
+            "would pass over an empty slice.")
+
+    def test_the_surface_files_are_non_trivial(self):
+        # If a path stopped resolving, every ban below would pass over an empty
+        # string.
+        for p in SURFACE:
+            self.assertTrue(p.is_file(), f"{p} missing")
+            self.assertGreater(len(normalize(p.read_text(encoding="utf-8"))), 500,
+                               f"{p} normalized to almost nothing")
+
+
+class LandedTests(unittest.TestCase):
+    def test_no_auto_latest_claim_survives_on_the_install_surface(self):
+        for p in SURFACE:
+            n = normalize(p.read_text(encoding="utf-8"))
+            for claim in BANNED:
+                self.assertNotIn(
+                    claim, n,
+                    f"{p.relative_to(ROOT)} still asserts the retired "
+                    f"auto-latest contract: {claim!r}. The base is a REVIEWED "
+                    "PIN (PINNED_BASE_RELEASE / PINNED_BASE_SHA256, #1943 / "
+                    "#4904-B); autodiscovery is opt-in and an unpinned base is "
+                    "refused.")
+
+
+class TrueTests(unittest.TestCase):
+    """The replacement text has to be right, not merely different."""
+
+    DOCN = normalize(DOC.read_text(encoding="utf-8"))
+    BAKESRC = BAKE.read_text(encoding="utf-8")
+
+    # The pin-policy section, isolated. Content assertions are scoped HERE, not
+    # to the whole document: a doc-wide `assertIn("not publishable", ...)` is
+    # satisfied by pipeline step 8's unrelated sentence about --skip-validate
+    # artifacts, so deleting the pin section's own statement left it green.
+    # Caught by mutating exactly that sentence and watching the test pass.
+    # Resolved DEFENSIVELY: a renamed heading must produce a clear FAILURE
+    # from the non-trivial guard below, not a collection-time crash that
+    # reports zero tests.
+    SECTION = pin_policy_section(normalized=True)
+
+    def _bake_const(self, name):
+        m = re.search(rf'^{name} = "([^"]+)"', self.BAKESRC, re.MULTILINE)
+        self.assertIsNotNone(m, f"{name} not found in bake.py")
+        return m.group(1)
+
+    def test_the_doc_names_the_real_constants(self):
+        for c in ("pinned_base_release", "pinned_base_sha256"):
+            self.assertIn(c, self.DOCN,
+                          f"the doc does not name {c.upper()}, the constant the "
+                          "bake actually enforces")
+
+    def test_the_doc_carries_the_SAME_pinned_release_as_the_code(self):
+        # A base bump that edits bake.py and forgets the doc reds here — the
+        # exact drift that produced #6501.
+        rel = self._bake_const("PINNED_BASE_RELEASE")
+        self.assertIn(rel, self.DOCN,
+                      f"bake.py pins Ubuntu {rel} but the doc does not say so")
+
+    def test_the_doc_states_the_reviewed_bump_policy(self):
+        self.assertTrue(
+            "reviewed commit" in self.SECTION or "reviewed pin" in self.SECTION,
+            "the pin-policy section does not say a base bump is a reviewed "
+            "commit")
+
+    def test_the_doc_states_the_unpinned_bake_is_refused_and_unpublishable(self):
+        self.assertIn("not publishable", self.SECTION)
+        self.assertIn("refuse", self.SECTION)
+
+    def test_the_doc_presents_autodiscovery_as_OPT_IN(self):
+        self.assertIn("xpf_ubuntu_autodiscover", self.SECTION)
+        self.assertIn("opt back into mirror-latest discovery", self.SECTION)
+
+    def test_every_bake_override_the_doc_names_is_one_bake_py_reads(self):
+        # The doc must not invent a knob. Restricted to the pin-policy section
+        # so unrelated XPF_* names elsewhere in the doc are out of scope.
+        named = {v for v in DOC_ENV_RE.findall(pin_policy_section())}
+        self.assertTrue(named, "no XPF_* override documented — vacuous")
+        for var in sorted(named):
+            self.assertIn(
+                f'"{var}"', self.BAKESRC,
+                f"the doc presents {var} as a bake override but bake.py never "
+                "reads it")
+
+    def test_the_doc_cites_the_same_gpg_fingerprint_as_the_code(self):
+        m = re.search(r"([0-9A-F]{40})", self.BAKESRC)
+        self.assertIsNotNone(m)
+        self.assertIn(m.group(1).lower(), self.DOCN,
+                      "the doc cites a different Canonical signing key than "
+                      "bake.py's provenance comment")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`docs/install-images.md` still promised mirror-latest Ubuntu discovery long after #1943 pinned the base and #4904-B added the SHA256 trust anchor. An operator following it expected the newest upstream release with no pin enforcement, and met a bake aborting on a `PINNED_BASE_SHA256` mismatch or refusing an unpinned release.

## Four sites, not three

The issue names three (`install-images.md:4-6`, `:70-71`, `:169-170`). There is a fourth:

```make
# offline-built bootable root disk (LATEST Ubuntu server cloudimg base
# discovered at bake time — XPF_BASE_RELEASE pins; linux-generic
```

`Makefile:287-288`. The claim **wraps across two comment lines**, so it is invisible to a line-oriented `grep -F` — and the file has no extension, so an extension-filtered sweep never opens it. Both of those had to fail for it to hide, and both did.

It was found by a **wrap-insensitive sweep over every tracked file**: strip comment/markdown markers, collapse all whitespace, then match. That same sweep confirms the remaining hits — in `bake.py`, `CLAUDE.md`, `test/incus/setup.sh` — are all **negations** ("not auto-latest", "opts back into mirror-latest discovery") and correct as they stand.

## The replacement

A new **"Base-image pin policy (#1943 / #4904-B)"** section states the contract the code enforces: `PINNED_BASE_RELEASE` and `PINNED_BASE_SHA256` as reviewed constants with how each moves; why the digest is a **trust anchor** rather than a convenience (image and `SHA256SUMS` come from the same configurable endpoint, so a same-endpoint checksum authenticates nothing against a compromised mirror — it can serve matching malicious bytes *and* hash); the two refusals an operator can expect; the four opt-in overrides; and the fact that an `XPF_ALLOW_UNPINNED_BASE=1` bake is **not publishable** because `gate_provenance` refuses `base_image_pinned != true` with no override (#5815).

## A claim fix owes two proofs

**LANDED.** The banned fragments are complete **asserting clauses**, normalized the same way the surface is — not bare keywords. A claim-guard keyed to keywords is defeated by **negation**, not paraphrase: "not auto-latest" and "opts back into mirror-latest discovery" are the *correct* text, and a keyword ban would red on them while the real false claim walked past. Two matcher self-tests assert the normalizer **sees** a claim that wraps across lines *and* that a line-oriented search **misses** that same claim, so the reason this guard normalizes is asserted rather than assumed.

**TRUE.** The doc must carry the **same** pinned release value `bake.py` compiles in, must name the real constants, must cite the same Canonical signing fingerprint, must present autodiscovery as opt-in, and must not present an override `bake.py` never reads. A base bump that edits the code and forgets the doc reds here — the exact drift that produced this issue.

## A weak assertion caught mid-review

The content assertions are scoped to the pin-policy **section**, not the whole document. A doc-wide `assertIn("not publishable", ...)` was satisfied by pipeline step 8's unrelated sentence about `--skip-validate` artifacts, so deleting the pin section's own statement left the test **green**. Caught by mutating exactly that sentence and watching the test pass, then re-scoping and confirming the red. Reported rather than quietly fixed, because it is the failure mode this kind of guard is most prone to.

## Validation

- `make selftest`: **56 passed / 0 skipped / 0 failed** (55 at this base — the count moved because #7298 and #7299 merged; no leg lost).
- **Eleven one-line mutations, ten red** with 13 tests collected each:

| mutation | red |
|---|---|
| restore the opening auto-latest claim | LANDED guard |
| restore the pipeline step-2 claim | LANDED guard |
| restore the reproducibility claim | LANDED guard |
| restore the **wrapped Makefile** claim (the 4th site) | LANDED guard |
| bump `PINNED_BASE_RELEASE` without touching the doc | code↔doc agreement |
| invent an override `bake.py` does not read | override check |
| drop the not-publishable statement | scoped content (the re-scoped one) |
| present autodiscovery as the default | opt-in check |
| rename the section heading | 5 tests, incl. the vacuity guard |
| collapse the section | 5 tests, incl. the vacuity guard |

The eleventh — rewording one sentence of the reviewed-pin statement — is **discarded, not reported as a hole**: the section's table still says a bump is "a reviewed commit (a PR), never automatically", so the asserted property genuinely survives it, and a single-line mutation cannot remove a property the section states twice. Tree clean and rc back to 0 after each.

## Scope

- **Rust helper binary: not reached.** Markdown + a Makefile comment + one new test.
- **Needs a live bake/boot: no.** No code path changes — the guard reads source and docs.
- `docs/image-validation.md:46-51` already described the pin correctly and is untouched; the contradiction was confined to the install surface.

Closes #6501

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cz2czGK3aA5MsMhkNkjHXX