### PR TITLE
cluster: record why the config-epoch reverse direction has no cheap fix (#6419)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -100645,3 +100645,11 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: pkg/cluster/manager.go, pkg/cluster/heartbeat_manager.go,
   pkg/daemon/daemon_ha_sync.go,
   pkg/cluster/heartbeat_start_stop_race_7257_test.go (new), pkg/cluster/README.md
+
+- **Timestamp**: 2026-08-21
+  - **Action**: #6419 — evaluated and closed the "reuse the authority's config-gen
+    namespace" shortcut for the active/active reverse direction; recorded the
+    structural reason in code + docs and armed the RG0-primary config-sync
+    rejection pin (previously a vacuous green).
+  - **File(s)**: pkg/cluster/sync_conn_gen.go (comment only),
+    docs/session-sync-architecture.md, pkg/daemon/config_sync_test.go

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -498,31 +498,47 @@ and let A threshold on its own `configGenCounter`" — and closed it as
 unworkable. Recorded here because it has been re-derived more than once; the
 three reasons are structural, not implementation detail:
 
-- **The two counters are frozen on opposite sides of one predicate.**
-  `configGenCounter` advances only through `nextConfigGen` ← `QueueConfig`,
-  whose only callers (`syncConfigToPeer`, `reconcileConfigSyncToPeer`) are gated
-  on `rg0ConfigSyncAuthority` = `IsLocalPrimary(0)`. `lastAppliedConfigGen`
+- **The two counters are never simultaneously live on one node, so the shortcut
+  cannot be expressed role-free.** `configGenCounter` advances only through
+  `nextConfigGen` ← `QueueConfig`, whose only production callers
+  (`syncConfigToPeer`, `reconcileConfigSyncToPeer`) are gated on
+  `rg0ConfigSyncAuthority` = `IsLocalPrimary(0)`. `lastAppliedConfigGen`
   advances only through `recordAppliedConfigGen` on a nil `OnConfigReceived`,
   and `handleConfigSync` returns `errConfigSyncRejectedPrimary` whenever
   `IsLocalPrimary(0)`. So a node's send counter is frozen for its whole
-  non-authority tenure and its applied mark is frozen for its whole authority
-  tenure. After the first RG0 transition the new authority thresholds on a value
-  frozen since its last tenure while the new non-authority stamps one frozen
-  since its last tenure — a permanent mismatch, not a transient one, because
-  nothing advances either counter back into agreement.
-- **The handover disambiguation needs the wire field the shortcut avoids.** The
-  proposed remedy — treat the epoch as 0 (the documented disable value) for a
-  session stamped under a different authority incarnation than the receiver's
-  current one — requires the receiver to know a stamp's authority incarnation.
-  `SessionValue.ConfigEpoch` is a bare `uint64` (`pkg/dataplane/types.go`)
-  written as eight raw LE bytes with no companion tag
+  non-authority tenure and its applied mark for its whole authority tenure, and
+  the shortcut must therefore branch on `IsLocalPrimary(0)` at BOTH the stamp
+  site and the threshold site. A role-FREE formulation is not available as a way
+  out: coalescing with `max(configGenCounter, lastAppliedConfigGen)` chooses
+  between two independent `MonotonicNanos()` boot seeds (`initGenState`), so
+  which side wins is a function of relative node uptime rather than of config
+  order.
+
+  To be precise about what this does *not* claim: the role-branched mismatch
+  that follows an RG0 handover **self-heals**. `reconcileConfigSyncToPeer` runs
+  on the `"rg0-promotion"` trigger, so once the new authority has pushed and the
+  new non-authority has applied, both counters are back in one namespace. The
+  hazard is not the steady state after a handover — it is the window *during*
+  one, which the next point covers.
+- **The handover window needs the wire field the shortcut avoids.** RG0 role is
+  not learned atomically by both nodes: each side updates on its own
+  heartbeat/VRRP timing, so there is necessarily a skew window in which the old
+  authority still believes it is the authority while the new one already does.
+  Dual-active is not theoretical either — the election code has an explicit
+  DUAL-ACTIVE branch (`pkg/cluster/election.go`) that detects both nodes primary
+  for one RG and resolves it by effective priority then node ID, which takes a
+  heartbeat round to converge. Throughout that window BOTH nodes stamp and
+  threshold on `configGenCounter`, i.e. on two independent `MonotonicNanos()`
+  boot seeds compared directly, so whether the guard is inert or refuses *every*
+  inbound synced session is decided by relative uptime. The issue's own proposed
+  remedy — treat the epoch as 0 (the documented disable value) for a session
+  stamped under a different authority incarnation than the receiver's current
+  one — is what would close this, and it requires the receiver to know a stamp's
+  authority incarnation. `SessionValue.ConfigEpoch` is a bare `uint64`
+  (`pkg/dataplane/types.go`) written as eight raw LE bytes with no companion tag
   (`encodeSessionV4Payload` / `encodeSessionV6Payload`), and nothing else on the
-  session wire identifies the minting authority. It cannot be derived locally
-  either: RG0 role propagates per node on its own timing and the cluster has a
-  documented transient dual-primary window, in which BOTH nodes stamp and
-  threshold on `configGenCounter` — two independent `MonotonicNanos()` boot
-  seeds compared directly, so which one is larger is a function of relative
-  uptime alone.
+  session wire identifies the minting authority — so the remedy is exactly the
+  wire field the shortcut set out to avoid.
 - **It converts a self-healing failure into total reverse-direction loss.** A
   config apply that does not take effect on the non-authority (compile/promote
   failure, or the RG0-primary rejection above — counted by

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -482,15 +482,64 @@ it refuses on epoch alone — and deliberately does NOT record the per-key
 generation, so the peer's next re-sync of that key is admitted rather than
 refused as stale.
 
-**Item 1 (deferred, documented residual).** The guard still covers only the
+**Item 1 (accepted residual — #6419 closed).** The guard covers only the
 config-authority → peer direction (the primary that admits the session is also
 the RG0 config-sync authority). A non-authority's sessions carry the
 authority-independent seed epoch, so the guard is inert for the reverse
-direction in an active/active deployment (fail-OPEN). Closing it requires a
-bidirectional config-generation namespace that #5274 deliberately scoped out (a
-design-heavy change, not part of #6284 item 2). #6284's residual-COVERAGE gap
-is closed (item 2 by #6366, item 1 by #6418); the substantive hardening of this
-inert direction is tracked separately as a future enhancement on #6419.
+direction in an active/active deployment (fail-OPEN). #6284's residual-COVERAGE
+gap is closed (item 2 by #6366, item 1 by #6418).
+
+Closing the reverse direction itself requires a bidirectional
+config-generation namespace that #5274 deliberately scoped out. #6419 evaluated
+the one shortcut that appeared to avoid building a second namespace — "the
+authority A's generations are already a name both nodes can say, so let the
+non-authority B stamp `B.lastAppliedConfigGen` (the A-generation B is running)
+and let A threshold on its own `configGenCounter`" — and closed it as
+unworkable. Recorded here because it has been re-derived more than once; the
+three reasons are structural, not implementation detail:
+
+- **The two counters are frozen on opposite sides of one predicate.**
+  `configGenCounter` advances only through `nextConfigGen` ← `QueueConfig`,
+  whose only callers (`syncConfigToPeer`, `reconcileConfigSyncToPeer`) are gated
+  on `rg0ConfigSyncAuthority` = `IsLocalPrimary(0)`. `lastAppliedConfigGen`
+  advances only through `recordAppliedConfigGen` on a nil `OnConfigReceived`,
+  and `handleConfigSync` returns `errConfigSyncRejectedPrimary` whenever
+  `IsLocalPrimary(0)`. So a node's send counter is frozen for its whole
+  non-authority tenure and its applied mark is frozen for its whole authority
+  tenure. After the first RG0 transition the new authority thresholds on a value
+  frozen since its last tenure while the new non-authority stamps one frozen
+  since its last tenure — a permanent mismatch, not a transient one, because
+  nothing advances either counter back into agreement.
+- **The handover disambiguation needs the wire field the shortcut avoids.** The
+  proposed remedy — treat the epoch as 0 (the documented disable value) for a
+  session stamped under a different authority incarnation than the receiver's
+  current one — requires the receiver to know a stamp's authority incarnation.
+  `SessionValue.ConfigEpoch` is a bare `uint64` (`pkg/dataplane/types.go`)
+  written as eight raw LE bytes with no companion tag
+  (`encodeSessionV4Payload` / `encodeSessionV6Payload`), and nothing else on the
+  session wire identifies the minting authority. It cannot be derived locally
+  either: RG0 role propagates per node on its own timing and the cluster has a
+  documented transient dual-primary window, in which BOTH nodes stamp and
+  threshold on `configGenCounter` — two independent `MonotonicNanos()` boot
+  seeds compared directly, so which one is larger is a function of relative
+  uptime alone.
+- **It converts a self-healing failure into total reverse-direction loss.** A
+  config apply that does not take effect on the non-authority (compile/promote
+  failure, or the RG0-primary rejection above — counted by
+  `ConfigsApplyFailed`) deliberately leaves `lastAppliedConfigGen` pinned so the
+  authority's re-push re-converges (M-2/#4151). With the applied mark as the
+  stamp source, that same condition pins the non-authority's stamp while the
+  authority's threshold keeps climbing on every push, so the authority refuses
+  EVERY reverse-direction session for as long as the apply keeps failing.
+  `resetRecvGen` compounds it: it stores `lastAppliedConfigGen = 0` on each peer
+  bulk re-prime, so the stamp would be 0 — the disable value — through cold
+  prime, which is exactly when bulk sessions flow.
+
+Reopening the reverse direction therefore starts from the namespace design
+(a wire field carrying each node's applied-config generation, or an authority
+tag alongside `ConfigEpoch` plus a defined ordering across an RG0 authority
+change), which is a `ProtocolVersion` bump and an explicit owner decision — not
+a bounded increment.
 
 Both halves of this directional correctness are regression-pinned by
 `sync_config_epoch_active_active_6284_test.go`: the SAME frozen non-authority

--- a/pkg/cluster/sync_conn_gen.go
+++ b/pkg/cluster/sync_conn_gen.go
@@ -124,9 +124,24 @@ func (s *SessionSync) stampInstallGenV4(key dataplane.SessionKey, val *dataplane
 	// table when it is queued has survived this node's own config-apply
 	// clearSessionsForDeletedPolicies sweep, so it is admitted under the
 	// current config; the receiver refuses it only once IT applies a strictly
-	// newer config (lastAppliedConfigGen advances past this epoch). configGen
-	// and lastAppliedConfigGen are the SAME sender→receiver namespace, so the
-	// comparison is meaningful across the HA boundary.
+	// newer config (lastAppliedConfigGen advances past this epoch).
+	//
+	// The namespace claim holds in ONE direction only. configGenCounter and the
+	// receiver's lastAppliedConfigGen are the same sender→receiver namespace
+	// when the SENDER is the RG0 config-sync authority — the authority mints the
+	// generation and the peer records the one it applied. In the reverse
+	// (non-authority → authority) direction, reachable only active/active, the
+	// stamp is the sender's frozen boot seed and the authority's high-water
+	// never advances, so the guard is inert: fail-OPEN, no false reject. That
+	// residual is deliberate (#5274 scope-out), regression-pinned by
+	// sync_config_epoch_active_active_6284_test.go, and #6419 closed it as
+	// not-cheaply-fixable — the "stamp lastAppliedConfigGen and threshold on
+	// configGenCounter" shortcut fails because each counter is FROZEN for
+	// exactly the tenure in which the shortcut needs it live (a node pushes
+	// config only while IsLocalPrimary(0), and handleConfigSync rejects every
+	// peer config while IsLocalPrimary(0)), and telling the two namespaces apart
+	// across an RG0 handover needs an authority tag that ConfigEpoch, a bare
+	// uint64 on the wire, does not carry. See docs/session-sync-architecture.md.
 	val.ConfigEpoch = s.configGenCounter.Load()
 	s.genSentMu.Lock()
 	if s.genSentV4 == nil {

--- a/pkg/daemon/config_sync_test.go
+++ b/pkg/daemon/config_sync_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -35,13 +36,36 @@ func newClusterManager(primary bool) *cluster.Manager {
 
 // TestHandleConfigSync_RejectsWhenPrimary verifies that the RG0 primary
 // rejects incoming config sync (prevents secondary from overwriting).
+//
+// The returned ERROR is load-bearing, not incidental. `configApplyLoop`
+// advances the config high-water (`recordAppliedConfigGen`) ONLY on a nil
+// `OnConfigReceived` return (M-2/#4151), so a short-circuit that returned nil
+// here would advance `lastAppliedConfigGen` past a config this node never
+// applied — the primary's re-push of that same generation would then be
+// dropped by `shouldApplyConfigGen` as stale and the node would sit silently
+// diverged. Asserting only "it did not panic on the nil store" cannot see that:
+// verified by mutation at `daemon_ha_sync.go`'s rejection arm — replacing
+// `return errConfigSyncRejectedPrimary` with `return nil` left the pre-#6419
+// form of this test GREEN. The `errors.Is` assertion below is what reds it.
+//
+// #6419: this rejection is also half of the reason the "reuse the authority's
+// own config-generation namespace" shortcut cannot close the active/active
+// reverse direction — see the `stampInstallGenV4` comment and
+// docs/session-sync-architecture.md. A node applies no peer config for the
+// whole of its RG0-authority tenure, so its `lastAppliedConfigGen` is frozen
+// exactly while its `configGenCounter` is the live counter, and vice versa.
 func TestHandleConfigSync_RejectsWhenPrimary(t *testing.T) {
 	d := &Daemon{
 		cluster: newClusterManager(true),
 	}
-	// If the guard doesn't work, handleConfigSync would panic accessing
-	// d.store (nil). A successful return means the guard rejected the config.
-	d.handleConfigSync("set system host-name bad-config")
+	// A nil store would panic if the guard let the call through, so reaching
+	// the assertion at all proves the short-circuit fired; the assertion then
+	// proves it short-circuited as a REJECTION rather than a silent success.
+	err := d.handleConfigSync("set system host-name bad-config")
+	if !errors.Is(err, errConfigSyncRejectedPrimary) {
+		t.Fatalf("RG0 primary must REJECT a peer config push with errConfigSyncRejectedPrimary "+
+			"so configApplyLoop leaves the config high-water pinned (M-2/#4151); got err = %v", err)
+	}
 }
 
 // TestHandleConfigSync_AcceptsWhenSecondary verifies that a secondary node

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -395,10 +395,19 @@ func (d *Daemon) syncConfigToPeer() {
 	d.pushConfigToPeer()
 }
 
-// pushConfigToPeer sends the active config to the cluster peer unconditionally
-// (does not check primary/secondary status). Used both by normal commit sync
-// and by the peer-reconnect path where the stable node pushes its config
-// regardless of whether it was preempted.
+// pushConfigToPeer sends the active config to the cluster peer. The FUNCTION
+// itself does not check primary/secondary status — the gate lives at the call
+// site.
+//
+// Its only production caller is syncConfigToPeer, which gates on
+// rg0ConfigSyncAuthority. The peer-reconnect path no longer arrives here: since
+// #5863 it runs through reconcileConfigSyncToPeer, which is RG0-primary-gated
+// too (so a reconnecting SECONDARY never overwrites the authoritative primary's
+// config — #2239/#4385) and calls QueueConfig directly. Those two are the ONLY
+// production QueueConfig sites, which is why configGenCounter advances solely
+// on the RG0 config-sync authority — the property the #5274 config-epoch guard
+// and the #6419 disposition both rest on. Adding an ungated push here would
+// silently break both.
 func (d *Daemon) pushConfigToPeer() {
 	ss := d.getSessionSync()
 	if ss == nil {


### PR DESCRIPTION
Closes #6419

## What this decides

#6419 asked for the bidirectional config-generation namespace that would close
the active/active **non-authority → authority** direction of the #5274
config-epoch guard. A comment on the issue proposed a shortcut that appeared to
avoid building a second namespace, and asked for it to be evaluated before
anyone built one. This PR is that evaluation, and the answer is no.

**The shortcut.** Config sync is unidirectional from the RG0 authority A, so A's
generations are already a name both nodes can say. Let the non-authority B stamp
`B.lastAppliedConfigGen` (the A-generation B is running) instead of its frozen
`configGenCounter`, and let A threshold on its own `configGenCounter` instead of
its never-advancing `lastAppliedConfigGen`. One changed stamp source, one changed
threshold source, no new counter, no wire field.

**Why it cannot work.** Three structural reasons, all verified against the tree:

1. **The two counters are never simultaneously live on one node, so the shortcut
   cannot be expressed role-free.** `configGenCounter` advances only via
   `nextConfigGen` ← `QueueConfig`, whose only production callers
   (`syncConfigToPeer`, `reconcileConfigSyncToPeer`) are gated on
   `rg0ConfigSyncAuthority` = `IsLocalPrimary(0)`. `lastAppliedConfigGen`
   advances only via `recordAppliedConfigGen` on a nil `OnConfigReceived`, and
   `handleConfigSync` returns `errConfigSyncRejectedPrimary` whenever
   `IsLocalPrimary(0)`. A node's send counter is therefore frozen for its whole
   non-authority tenure and its applied mark for its whole authority tenure, so
   the shortcut must branch on `IsLocalPrimary(0)` at **both** the stamp site and
   the threshold site. A role-free `max(configGenCounter, lastAppliedConfigGen)`
   coalescing is not an escape: it chooses between two independent
   `MonotonicNanos()` boot seeds, so the winner is decided by relative uptime
   rather than config order.

   *Explicitly not claimed:* that the post-handover mismatch is permanent. It
   self-heals — `reconcileConfigSyncToPeer` runs on the `"rg0-promotion"`
   trigger, so once the new authority has pushed and the new non-authority has
   applied, both counters are back in one namespace. (An earlier revision of this
   PR asserted permanence; that was wrong and is corrected in `195ec89cb`, which
   also records the correction of the first commit message's wording.)

2. **The handover *window* needs the wire field the shortcut avoids — this is
   the load-bearing kill.** RG0 role is not learned atomically by both nodes;
   each updates on its own heartbeat/VRRP timing, so a skew window always exists
   in which the old authority still believes it is the authority while the new
   one already does. Dual-active is not theoretical: `pkg/cluster/election.go`
   has an explicit **DUAL-ACTIVE** branch that detects both nodes primary for one
   RG and resolves it by effective priority then node ID, which takes a heartbeat
   round to converge. Throughout that window **both** nodes stamp and threshold
   on `configGenCounter` — two independent `MonotonicNanos()` boot seeds compared
   directly — so whether the guard sits inert or refuses **every** inbound synced
   session is decided by relative uptime. The issue's own proposed remedy (treat
   the epoch as 0 for a session stamped under a different authority incarnation)
   is what would close this, and it requires the receiver to know a stamp's
   authority incarnation. `SessionValue.ConfigEpoch` is a bare `uint64` written
   as eight raw LE bytes with no companion tag (`encodeSessionV4Payload` /
   `encodeSessionV6Payload`), and nothing else on the session wire identifies the
   minting authority — so the remedy is exactly the wire field the shortcut set
   out to avoid.

3. **It converts a self-healing failure into total reverse-direction loss.** An
   apply that does not take effect on the non-authority (compile/promote failure,
   or the RG0-primary rejection above — counted by `ConfigsApplyFailed`)
   deliberately leaves `lastAppliedConfigGen` pinned so the authority's re-push
   re-converges (M-2/#4151). With the applied mark as the stamp source, that same
   condition pins the stamp while the authority's threshold keeps climbing on
   every push, refusing **every** reverse-direction session for as long as the
   apply keeps failing. `resetRecvGen` compounds it: it stores
   `lastAppliedConfigGen = 0` on each peer bulk re-prime, so the stamp would be
   0 — the documented *disable* value — through cold prime, which is exactly when
   bulk sessions flow.

Today's behaviour is safe fail-OPEN, documented, and regression-pinned by
`sync_config_epoch_active_active_6284_test.go`. It is unchanged by this PR.

## What actually changes

Production bytes in this diff are **Go comments only**. No behaviour change.

- `pkg/cluster/sync_conn_gen.go` — comment. The `stampInstallGenV4` comment
  asserted "configGen and lastAppliedConfigGen are the SAME sender→receiver
  namespace" without naming the direction that holds in. That sentence is false
  in the reverse direction, which is the whole of #6419. Now qualified.
- `pkg/daemon/daemon_ha_sync.go` — comment. `pushConfigToPeer`'s doc claimed it
  is used by "the peer-reconnect path"; false since #5863, which routes that path
  through the RG0-gated `reconcileConfigSyncToPeer`. Left as written it reads as
  evidence that an ungated push path exists — the opposite of the property
  reason 1 rests on.
- `docs/session-sync-architecture.md` — records the three reasons so the shortcut
  is not re-derived a fourth time, plus what reopening actually starts from (a
  `ProtocolVersion` bump and an owner decision, not a bounded increment).
- `pkg/daemon/config_sync_test.go` — arms a pin that was a vacuous green.

## The test defect this uncovered (independent of the above)

`TestHandleConfigSync_RejectsWhenPrimary` discarded `handleConfigSync`'s return
value and inferred success from "it did not panic on the nil store". The
**error** is load-bearing: `configApplyLoop` advances the config high-water only
on a nil `OnConfigReceived` return, so a short-circuit returning `nil` there
would advance `lastAppliedConfigGen` past a config the node never applied, and
the primary's re-push of that same generation would then be dropped by
`shouldApplyConfigGen` as stale — leaving the node silently diverged.

**Mutation matrix** (one mutation per line, production file restored verbatim
from a pre-mutation copy between cells, `git diff` empty after each restore):

| # | Mutation (production) | Pre-PR test | Post-PR test |
|---|---|---|---|
| A | `return errConfigSyncRejectedPrimary` → `return nil` | **GREEN (vacuous)** | **RED** — `got err = <nil>` |
| B | delete the whole `if d.cluster != nil && d.cluster.IsLocalPrimary(0) { … }` block | RED (panic) | RED (panic) |

Cell A is the one that matters: it is the exact silent-divergence shape, and the
pre-PR assertion could not see it.

## Validation

- `go build ./...` clean; `go vet ./pkg/daemon ./pkg/cluster` clean.
- `go test -count=1 ./pkg/cluster/` — ok, 17.3s.
- `go test -count=1 ./pkg/daemon/` — ok, 38.7s (re-run after the comment change).
- Baseline established green before any mutation.
- Cites re-verified at `origin/master` `17e5569c1` after master advanced.

**No cluster smoke is owed.** The only production-file bytes in this diff are Go
comments; the rest is a test and a doc. No behaviour change, no protocol change,
no dataplane artifact movement.

**Merge note:** this branch conflicts with master on `_Log.md` **only** — no
`.go` conflict (`git merge-tree` reports exactly one conflicted path). Per the
campaign convention that is resolved at merge time, not folded here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gcdxy5mCofwyVWHUKzhU9F
