### PR TITLE
cluster: lock the monitor's dampening maps against UpdateGroups (#6550)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,9 +107,21 @@ test-go: test-race-dp
 # and fails if any test in the declared concurrency-binder files stops
 # matching. Keep the `-run '<pattern>'` single-quoted spelling — that canary
 # reads it.
+#
+# #6550: the pkg/cluster leg. Before it, NO make target ran ./pkg/cluster
+# under -race at all, so the cluster Monitor's concurrent-map fatal (poll
+# goroutine vs UpdateGroups) and the #7257 heartbeat start/stop race were
+# not races CI had failed to catch — they were races CI had no path to
+# observe. The selection is the two packages' race PROBES only (they are
+# ~2s combined at -count=2); pkg/cluster's non-race tests stay on the
+# plain `go test ./...` leg. Keep the `-run '<pattern>'` single-quoted
+# spelling here too: pkg/cluster's TestRaceGateCoversTheClusterProbes6550
+# parses this line, and pkg/daemon's canary reads the FIRST -run line in
+# this recipe, so this leg must stay BELOW the pkg/daemon one.
 test-race-dp:
 	$(GO) test -race ./pkg/daemon/ -run 'DataplaneCell|NATPoolAlarm|ForwardingStatus|BootstrapExit|RuntimeDataplaneNeverBareRootManager|EventStreamFallbackLoop|RunUserspaceEventStream|LiveDataPlane_|GRPCShowBuffers_|SystemAction_|GRPCServer_|RESTServer_|ManagementProbe|ConsoleCLIProbeWiring|FullResync|ReconcilePassUsesOneDataplaneSnapshot|ReconcileBlackholeWrappersStillReloadPerCall' -count=2
 	$(GO) test -race ./pkg/dataplane/ -run 'ArmedGate|PreArm' -count=2
+	$(GO) test -race ./pkg/cluster/ -run 'DoesNotRaceUpdateGroups6550|DoesNotHoldMuAcrossManagerCallback6550|DoesNotRaceStopHeartbeat7257|HeartbeatStartSuperseded' -count=2
 
 # Rust userspace-dp correctness suite (#4006). userspace-dp is a
 # binary-only crate (no [lib] target), so its unit tests live in the bin

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-08-21 — #6550 cluster monitor poll/UpdateGroups map race
+
+- **Timestamp**: 2026-08-21
+- **Action**: Took `mon.mu` around the poll goroutine's mutations of
+  `ifaceState`, `ipState`, `ipDebts` and `ipThresholdState`, which
+  `UpdateGroups` deletes from under that same lock on every cluster
+  config apply — a Go runtime FATAL (`concurrent map read and map
+  write`) reachable from a routine commit, and via config-sync on both
+  nodes. Not one lock around the apply phase: the order is
+  `m.mu -> mon.mu` (`Manager.UpdateConfig` holds `m.mu` and calls
+  `UpdateGroups`), and the poll path calls `SetMonitorWeight`, which
+  takes `m.mu` — holding `mon.mu` across that inverts the order and
+  deadlocks. `reconcileRGIPDebts` now computes its whole diff under the
+  lock into a `[]ipDebtAction` and replays the manager callbacks after
+  releasing it, preserving the removals-then-installs emission order.
+  Added a race probe, a deterministic lock-order probe (new
+  `beforeManagerApplyHook` seam), and a Makefile canary; added the
+  missing `./pkg/cluster/` leg to `test-race-dp` — no make target raced
+  this package at all, so #6550 and #7257 were races CI had no PATH to.
+  Mutation matrix: M1/M2/M3 (each site's lock removed, verbatim pre-fix
+  form) → 5/5/7 DATA RACEs; M4 (lock held across the manager callback)
+  → the lock-order probe reds on timeout; W1 (delete the Makefile leg)
+  and W2 (drop a probe name from its pattern) → the canary reds.
+- **File(s)**: pkg/cluster/monitor.go,
+  pkg/cluster/monitor_poll_update_race_6550_test.go,
+  pkg/cluster/README.md, Makefile
+
 ## 2026-08-22 — #6499 boot-firmware self-tests + lint-list drift guard
 
 - **Timestamp**: 2026-08-22

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -2314,6 +2314,41 @@ removed/changed persisted and stranded a healthy node secondary forever.
 (it runs under the manager lock already held by `UpdateConfig`); the
 manager-side clear happens directly in `reconcileMonitorDebtsLocked`.
 
+**Monitor map locking and the `m.mu -> mon.mu` order (#6550).** The poll
+goroutine and `UpdateGroups` share four maps — `ifaceState`, `ipState`,
+`ipDebts`, `ipThresholdState`. `UpdateGroups` deletes from all four under
+`mon.mu`; the poll cycle used to write all four with no lock at all, which
+is a Go RUNTIME FATAL (`concurrent map read and map write`), not a
+tolerable race, and it is reachable from an ordinary commit — with
+config-sync, on both nodes.
+
+The repair cannot be one lock around the whole apply phase. The lock order
+in this package is **`m.mu` -> `mon.mu`**: `Manager.UpdateConfig` holds
+`m.mu` across its whole body and calls `Monitor.UpdateGroups`, which takes
+`mon.mu`. The poll path calls `mgr.SetMonitorWeight` / `mgr.RecordEvent`,
+which take `m.mu`. Holding `mon.mu` across those callbacks inverts the
+order and deadlocks a commit against a poll — trading a probabilistic
+fatal for a deterministic hang.
+
+So each mutation site takes `mon.mu` for the map access and the dampening
+update it feeds, and releases it before calling the manager.
+`reconcileRGIPDebts` drives its whole bookkeeping to the new value under
+the lock, collects the resulting weight changes into a local
+`[]ipDebtAction`, drops the lock, and only then replays them (removals
+first, then installs — the pre-#6550 emission order). `desiredRGIPDebts`
+therefore requires `mon.mu` held. `Monitor.Stop` is unaffected: it drops
+`mon.mu` before `wg.Wait()`, so a poll blocked on the lock cannot wedge a
+teardown.
+
+Two probes pin this, both in `monitor_poll_update_race_6550_test.go`: a
+race probe (poll cycles bounded, `UpdateGroups` looped, ratio logged) and a
+deterministic lock-order probe that lands an `UpdateGroups` on another
+goroutine exactly at a manager callback and requires it to complete. Both
+assert only under `-race` or a deadlock, so a third test reads the
+Makefile and requires `test-race-dp` to keep its `./pkg/cluster/` leg —
+before #6550 no make target raced this package at all, so these were races
+CI had no path to rather than races CI had missed.
+
 `reconcileMonitorDebtsLocked` reconciles INTERFACE-monitor debt ONLY.
 `monitorWeights` + `MonitorFails` are a SHARED structure that also holds
 IP-MONITORING debts (installed by `SetMonitorWeight` from the ip-monitor

--- a/pkg/cluster/monitor.go
+++ b/pkg/cluster/monitor.go
@@ -151,6 +151,24 @@ type Monitor struct {
 
 	// nowFunc can be overridden for testing time-dependent behavior.
 	nowFunc func() time.Time
+
+	// beforeManagerApplyHook is a test seam fired immediately before the poll
+	// cycle calls out to the Manager (SetMonitorWeight / RecordEvent). nil in
+	// production. It exists so a test can assert that mon.mu is NOT held
+	// across that callback (#6550): the lock order in this package is
+	// m.mu -> mon.mu (Manager.UpdateConfig holds m.mu and calls
+	// Monitor.UpdateGroups), so holding mon.mu while calling into the manager
+	// inverts it and deadlocks a commit against a poll cycle. Called with no
+	// Monitor lock held.
+	beforeManagerApplyHook func()
+}
+
+// beforeManagerApply fires the #6550 lock-order test seam. Production installs
+// no hook, so this is a nil check on the poll path.
+func (mon *Monitor) beforeManagerApply() {
+	if mon.beforeManagerApplyHook != nil {
+		mon.beforeManagerApplyHook()
+	}
 }
 
 // nlLinkGetter abstracts netlink.Handle.LinkByName for testing.
@@ -517,15 +535,25 @@ func (mon *Monitor) pollInterfaceMonitors(rg *config.RedundancyGroup, statuses [
 			RedundancyGroup: rg.ID,
 		})
 
+		// #6550: ifaceState is shared with UpdateGroups, which DELETES from it
+		// under mon.mu on every cluster config apply. The map access and the
+		// dampening update it feeds are one critical section; the manager
+		// callbacks below are deliberately OUTSIDE it (see the lock-order note
+		// on beforeManagerApplyHook).
+		mon.mu.Lock()
 		state := mon.ifaceState[key]
 		if state == nil {
 			state = &monitorState{}
 			mon.ifaceState[key] = state
 		}
+		transitioned := mon.evaluateTransition(state, !up)
+		nowDown := state.down
+		mon.mu.Unlock()
 
-		if mon.evaluateTransition(state, !up) {
-			mon.mgr.SetMonitorWeight(rg.ID, im.Interface, state.down, weight)
-			if state.down {
+		if transitioned {
+			mon.beforeManagerApply()
+			mon.mgr.SetMonitorWeight(rg.ID, im.Interface, nowDown, weight)
+			if nowDown {
 				mon.mgr.RecordEvent(EventMonitor, rg.ID, fmt.Sprintf(
 					"Interface %s state changed to down, weight %d", im.Interface, weight))
 			} else {
@@ -670,12 +698,19 @@ func (mon *Monitor) ipTargetWeight(rg *config.RedundancyGroup, target *config.IP
 // RG/target order.
 func (mon *Monitor) updateIPTargetDampenedState(rg *config.RedundancyGroup, target *config.IPMonitorTarget, reachable bool) {
 	key := ipMonitorKey{rgID: rg.ID, address: target.Address}
+	// #6550: ipState is shared with UpdateGroups, which deletes a removed RG's
+	// targets from it under mon.mu. This body makes no manager call, so the
+	// whole of it can run under the lock.
+	mon.mu.Lock()
 	state := mon.ipState[key]
 	if state == nil {
 		state = &monitorState{}
 		mon.ipState[key] = state
 	}
-	if mon.evaluateTransition(state, !reachable) {
+	transitioned := mon.evaluateTransition(state, !reachable)
+	mon.mu.Unlock()
+
+	if transitioned {
 		slog.Info("cluster monitor: IP probe reachability changed",
 			"rg", rg.ID, "address", target.Address, "reachable", reachable)
 	}
@@ -715,6 +750,9 @@ func isIPMonitorName(iface string) bool {
 //   - ip-monitoring absent: nothing is owed.
 //
 // Returned as monitor-name → weight.
+//
+// Callers must hold mon.mu: this reads mon.ipState, which UpdateGroups deletes
+// from concurrently (#6550).
 func (mon *Monitor) desiredRGIPDebts(rg *config.RedundancyGroup) map[string]int {
 	desired := map[string]int{}
 	if rg.IPMonitoring == nil {
@@ -769,35 +807,45 @@ func (mon *Monitor) desiredRGIPDebts(rg *config.RedundancyGroup) map[string]int 
 //     fire; the full reconcile does.
 //
 // Called for EVERY RG each cycle, including one that has dropped ip-monitoring.
+//
+// #6550: the bookkeeping (ipState, ipDebts, ipThresholdState) is driven to its
+// new value under mon.mu — UpdateGroups deletes from all three under that same
+// lock — and the resulting manager callbacks are replayed AFTER the lock is
+// dropped. They cannot run under it: SetMonitorWeight takes m.mu and
+// Manager.UpdateConfig holds m.mu while calling UpdateGroups, so mon.mu held
+// across the callback inverts the m.mu -> mon.mu order and deadlocks. The
+// emitted sequence is unchanged — all removals, then all installs, in the same
+// (map-iteration, i.e. already unordered) order as before.
 func (mon *Monitor) reconcileRGIPDebts(rg *config.RedundancyGroup) {
+	mon.mu.Lock()
 	desired := mon.desiredRGIPDebts(rg)
 
 	installed := mon.ipDebts[rg.ID]
 	if installed == nil {
 		if len(desired) == 0 {
+			mon.mu.Unlock()
 			return // nothing installed, nothing desired — no-op
 		}
 		installed = make(map[string]int)
 		mon.ipDebts[rg.ID] = installed
 	}
 
+	var pending []ipDebtAction
 	// Remove installed debts that are no longer desired.
 	for name, w := range installed {
 		if _, ok := desired[name]; ok {
 			continue
 		}
-		mon.mgr.SetMonitorWeight(rg.ID, name, false, w)
 		delete(installed, name)
-		mon.recordIPDebtChange(rg.ID, name, false, w)
+		pending = append(pending, ipDebtAction{name: name, weight: w, install: false})
 	}
 	// Install (or reweight) desired debts not already matching.
 	for name, w := range desired {
 		if cur, ok := installed[name]; ok && cur == w {
 			continue
 		}
-		mon.mgr.SetMonitorWeight(rg.ID, name, true, w)
 		installed[name] = w
-		mon.recordIPDebtChange(rg.ID, name, true, w)
+		pending = append(pending, ipDebtAction{name: name, weight: w, install: true})
 	}
 
 	if len(installed) == 0 {
@@ -806,6 +854,33 @@ func (mon *Monitor) reconcileRGIPDebts(rg *config.RedundancyGroup) {
 	// Mirror the aggregate-installed flag for readability/tests.
 	_, aggInstalled := installed[ipAggregateMonitorName]
 	mon.ipThresholdState[rg.ID] = aggInstalled
+	mon.mu.Unlock()
+
+	// Removals first, then installs — the pre-#6550 emission order.
+	for _, act := range pending {
+		if act.install {
+			continue
+		}
+		mon.beforeManagerApply()
+		mon.mgr.SetMonitorWeight(rg.ID, act.name, false, act.weight)
+		mon.recordIPDebtChange(rg.ID, act.name, false, act.weight)
+	}
+	for _, act := range pending {
+		if !act.install {
+			continue
+		}
+		mon.beforeManagerApply()
+		mon.mgr.SetMonitorWeight(rg.ID, act.name, true, act.weight)
+		mon.recordIPDebtChange(rg.ID, act.name, true, act.weight)
+	}
+}
+
+// ipDebtAction is one pending manager-side ip-monitor debt change: computed by
+// reconcileRGIPDebts while it holds mon.mu, applied after it drops it (#6550).
+type ipDebtAction struct {
+	name    string
+	weight  int
+	install bool
 }
 
 // recordIPDebtChange emits the operator event + log for an ip-monitor debt

--- a/pkg/cluster/monitor_poll_update_race_6550_test.go
+++ b/pkg/cluster/monitor_poll_update_race_6550_test.go
@@ -1,0 +1,323 @@
+package cluster
+
+import (
+	"context"
+	"net"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// #6550 — the Monitor's poll goroutine mutated ifaceState, ipState, ipDebts and
+// ipThresholdState with NO mon.mu while UpdateGroups deletes from those same
+// maps under it.
+//
+//	pollCycle:   groups := mon.groups (under mu) ... mu.Unlock()
+//	             -> pollInterfaceMonitors      mon.ifaceState[key] = state   UNLOCKED
+//	             -> updateIPTargetDampenedState mon.ipState[key]   = state   UNLOCKED
+//	             -> reconcileRGIPDebts          mon.ipDebts[...]            UNLOCKED
+//	                                            mon.ipThresholdState[...]   UNLOCKED
+//	UpdateGroups: mon.mu.Lock(); delete(mon.ifaceState, ...) etc.
+//
+// A concurrent map read+write is a Go RUNTIME FATAL ("concurrent map read and
+// map write"), not a recoverable race: the process dies. It is reachable from
+// an ordinary commit — Manager.UpdateConfig calls Monitor.UpdateGroups on every
+// cluster config apply — and HA config-sync pushes that same commit to BOTH
+// nodes.
+//
+// CI had no path to it: make test-go's race gate (test-race-dp) ran -race over
+// ./pkg/daemon and ./pkg/dataplane only. ./pkg/cluster was never raced by any
+// make target. This change adds a pkg/cluster leg to test-race-dp selecting the
+// probe below, so the guard is one a CI run can actually observe.
+
+// raceNlHandle is a mutation-safe nlLinkGetter for the concurrency probes. The
+// shared mockNlHandle in monitor_test.go carries a bare map that the probe's
+// own flapping would race, which would report a race in the TEST rather than
+// in the code under test.
+type raceNlHandle struct {
+	mu   sync.Mutex
+	up   map[string]bool
+	miss map[string]bool
+}
+
+func newRaceNlHandle() *raceNlHandle {
+	return &raceNlHandle{up: make(map[string]bool), miss: make(map[string]bool)}
+}
+
+func (h *raceNlHandle) LinkByName(name string) (netlink.Link, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.miss[name] {
+		return nil, net.UnknownNetworkError("not found: " + name)
+	}
+	var state netlink.LinkOperState = netlink.OperDown
+	if h.up[name] {
+		state = netlink.OperUp
+	}
+	return &mockLink{attrs: netlink.LinkAttrs{Name: name, OperState: state}}, nil
+}
+
+func (h *raceNlHandle) setUp(name string, up bool) {
+	h.mu.Lock()
+	h.up[name] = up
+	h.mu.Unlock()
+}
+
+// race6550Groups builds the two monitored sets the probe alternates between.
+// The second is a strict subset of the first, so every UpdateGroups call in the
+// loop performs real deletes from ifaceState/ipState/ipDebts/ipThresholdState —
+// a same-set update would take mon.mu, find nothing to drop and never touch the
+// maps the poll goroutine is writing.
+func race6550Groups() (full, reduced []*config.RedundancyGroup) {
+	mk := func(id int) *config.RedundancyGroup {
+		rg := makeRG(id, false, map[int]int{0: 200, 1: 100},
+			&config.InterfaceMonitor{Interface: "trust0", Weight: 100},
+			&config.InterfaceMonitor{Interface: "untrust0", Weight: 100},
+		)
+		rg.IPMonitoring = &config.IPMonitoring{
+			GlobalWeight: 100,
+			Targets: []*config.IPMonitorTarget{
+				{Address: "10.0.0.1", Weight: 50},
+				{Address: "10.0.0.2", Weight: 50},
+			},
+		}
+		return rg
+	}
+	return []*config.RedundancyGroup{mk(0), mk(1)}, []*config.RedundancyGroup{mk(0)}
+}
+
+// TestMonitorPollDoesNotRaceUpdateGroups6550 is the race probe.
+//
+// The BOUNDED side is the EXPENSIVE one. A poll cycle walks every RG's
+// interface monitors through netlink, probes every IP target and reconciles the
+// per-RG debt set against the manager (which takes m.mu); UpdateGroups is two
+// short map walks. Bounding the cheap side instead would let it run to
+// completion inside the expensive side's first pass and race the window
+// approximately once. The achieved ratio is logged rather than assumed, so a
+// future change that makes UpdateGroups expensive turns a degenerate probe into
+// a visible one instead of a quiet pass.
+//
+// The assertion is the race detector, so this is only meaningful under -race.
+// RED on revert: drop the mon.mu critical sections from pollInterfaceMonitors /
+// updateIPTargetDampenedState / reconcileRGIPDebts and
+//
+//	go test -race -count=1 -run TestMonitorPollDoesNotRaceUpdateGroups6550 ./pkg/cluster/
+//
+// reports WARNING: DATA RACE on the monitor maps (and, without -race, can trip
+// the runtime's "concurrent map read and map write" fatal outright).
+func TestMonitorPollDoesNotRaceUpdateGroups6550(t *testing.T) {
+	full, reduced := race6550Groups()
+
+	m := NewManager(0, 1)
+	m.UpdateConfig(makeConfig(full...))
+
+	nlh := newRaceNlHandle()
+	nlh.setUp("trust0", true)
+	nlh.setUp("untrust0", true)
+
+	mon := NewMonitor(m, full)
+	mon.nlHandle = nlh
+	setNoDampening(mon)
+
+	// Flap both the link state and the IP reachability so every cycle actually
+	// transitions dampened state and installs/clears debts, rather than
+	// steady-stating into the no-op branch of reconcileRGIPDebts.
+	var tick atomic.Int64
+	mon.probeFn = func(_ context.Context, _ string) (bool, bool) {
+		return tick.Load()%2 == 0, true
+	}
+
+	const pollCycles = 200
+	var polls, updates atomic.Int64
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// BOUNDED, expensive side: a fixed number of poll cycles.
+	go func() {
+		defer wg.Done()
+		defer close(done)
+		for i := 0; i < pollCycles; i++ {
+			tick.Add(1)
+			nlh.setUp("trust0", i%3 != 0)
+			mon.poll()
+			polls.Add(1)
+		}
+	}()
+
+	// LOOPED, cheap side: keep deleting out from under the poll goroutine until
+	// the bounded side signals done.
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			mon.UpdateGroups(reduced)
+			mon.UpdateGroups(full)
+			updates.Add(2)
+		}
+	}()
+
+	wg.Wait()
+
+	got, want := updates.Load(), polls.Load()
+	t.Logf("#6550 race probe: %d poll cycles against %d UpdateGroups calls (%.1f updates/poll)",
+		want, got, float64(got)/float64(want))
+	if got < want {
+		t.Errorf("degenerate probe: %d UpdateGroups calls against %d poll cycles — "+
+			"the looped side must out-run the bounded one or the window is barely raced",
+			got, want)
+	}
+}
+
+// TestMonitorPollDoesNotHoldMuAcrossManagerCallback6550 binds the SHAPE of the
+// fix, and it is the reason the fix is per-mutation critical sections rather
+// than one lock around the whole apply phase.
+//
+// The lock order in this package is m.mu -> mon.mu: Manager.UpdateConfig holds
+// m.mu for its whole body and calls Monitor.UpdateGroups, which takes mon.mu
+// (documented at UpdateGroups — it deliberately does not call the locking
+// SetMonitorWeight for exactly this reason). The poll path calls
+// mgr.SetMonitorWeight, which takes m.mu. So holding mon.mu across that
+// callback inverts the order and deadlocks a routine commit against a poll
+// cycle — the naive "wrap phase 3 in mon.mu" repair for #6550 turns a
+// probabilistic runtime fatal into a deterministic hang.
+//
+// The probe lands an UpdateGroups on a separate goroutine at the instant the
+// poll cycle is about to call into the manager, and requires it to complete.
+// RED on revert: hold mon.mu across mon.mgr.SetMonitorWeight in
+// pollInterfaceMonitors or reconcileRGIPDebts and the UpdateGroups blocks
+// forever, tripping the timeout below.
+func TestMonitorPollDoesNotHoldMuAcrossManagerCallback6550(t *testing.T) {
+	full, reduced := race6550Groups()
+
+	m := NewManager(0, 1)
+	m.UpdateConfig(makeConfig(full...))
+
+	nlh := newRaceNlHandle()
+	nlh.setUp("trust0", false) // down -> guarantees an interface-monitor debt apply
+	nlh.setUp("untrust0", true)
+
+	mon := NewMonitor(m, full)
+	mon.nlHandle = nlh
+	setNoDampening(mon)
+	mon.probeFn = func(_ context.Context, _ string) (bool, bool) {
+		return false, true // unreachable -> guarantees an ip-monitor debt apply
+	}
+
+	var fired atomic.Int64
+	mon.beforeManagerApplyHook = func() {
+		// Only the first crossing needs to be probed; the rest would just add
+		// wall-clock. Every crossing is a place mon.mu must not be held.
+		if fired.Add(1) != 1 {
+			return
+		}
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			mon.UpdateGroups(reduced)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Errorf("UpdateGroups blocked for 5s while the poll cycle was applying a " +
+				"monitor debt: mon.mu must not be held across the mgr.SetMonitorWeight / " +
+				"RecordEvent callback — that inverts the m.mu -> mon.mu order " +
+				"Manager.UpdateConfig relies on and deadlocks a commit against a poll (#6550)")
+		}
+	}
+
+	mon.poll()
+
+	if fired.Load() == 0 {
+		t.Fatal("beforeManagerApplyHook never fired — the probe did not reach a " +
+			"manager callback, so it proves nothing. Check the fixture still " +
+			"produces an interface-monitor or ip-monitor debt transition.")
+	}
+}
+
+// TestRaceGateCoversTheClusterProbes6550 binds the WIRING that makes the two
+// probes above observable.
+//
+// The probes assert through the race detector, so they are inert without
+// -race. Before #6550 no make target ran ./pkg/cluster under -race at all:
+// test-race-dp covered ./pkg/daemon and ./pkg/dataplane only. That is why the
+// Monitor's concurrent-map fatal and the #7257 heartbeat start/stop race are
+// races CI had no PATH to, not races CI merely failed to catch. Adding the
+// probes without adding the leg would have reproduced exactly that.
+//
+// So this reads the real Makefile and requires the pkg/cluster leg to exist AND
+// its -run pattern to still select every probe named below. RED-on-revert:
+// delete the `$(GO) test -race ./pkg/cluster/ ...` line from the test-race-dp
+// recipe (or drop a name from its pattern) and this fails — which is the
+// mutation that matters, because deleting the leg is silent otherwise.
+//
+// Stated residual, same shape as pkg/daemon's #6743 canary: the probe list
+// below is hand-maintained. A new cluster race probe is outside the gate until
+// it is added here. This binds "the gate has not fallen behind these probes",
+// not "these are all the cluster race probes there are".
+func TestRaceGateCoversTheClusterProbes6550(t *testing.T) {
+	t.Parallel()
+
+	wantProbes := []string{
+		"TestMonitorPollDoesNotRaceUpdateGroups6550",
+		"TestMonitorPollDoesNotHoldMuAcrossManagerCallback6550",
+		"TestStartHeartbeatDoesNotRaceStopHeartbeat7257",
+	}
+
+	src, err := os.ReadFile("../../Makefile")
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	var pattern string
+	inRecipe := false
+	for _, line := range strings.Split(string(src), "\n") {
+		if strings.HasPrefix(line, "test-race-dp:") {
+			inRecipe = true
+			continue
+		}
+		if !inRecipe {
+			continue
+		}
+		// The recipe ends at the first non-indented, non-blank line.
+		if line != "" && !strings.HasPrefix(line, "\t") {
+			break
+		}
+		if !strings.Contains(line, "./pkg/cluster/") {
+			continue
+		}
+		m := regexp.MustCompile(`-run\s+'([^']*)'`).FindStringSubmatch(line)
+		if m == nil {
+			t.Fatalf("the test-race-dp pkg/cluster leg has no single-quoted -run pattern: %q", line)
+		}
+		pattern = m[1]
+		break
+	}
+	if pattern == "" {
+		t.Fatal("test-race-dp has no `go test -race ./pkg/cluster/ -run '<pattern>'` leg. " +
+			"The cluster race probes only assert under -race, so without this leg they " +
+			"never run in CI and the #6550 / #7257 races become unobservable again. " +
+			"If the leg was deliberately removed (the whole package now races), delete " +
+			"this canary in the same change and say so.")
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		t.Fatalf("test-race-dp pkg/cluster -run pattern %q does not compile: %v", pattern, err)
+	}
+	for _, name := range wantProbes {
+		if !re.MatchString(name) {
+			t.Errorf("race probe %s is NOT selected by the test-race-dp pkg/cluster pattern %q — "+
+				"it will not run under -race in CI", name, pattern)
+		}
+	}
+}


### PR DESCRIPTION
Closes #6550

## Problem

`Monitor`'s poll goroutine mutated `ifaceState`, `ipState`, `ipDebts` and `ipThresholdState` with **no `mon.mu`**, while `UpdateGroups` deletes from those same four maps under it. A concurrent map read+write is a Go **runtime FATAL**, not a recoverable race — the process dies. It is reachable from an ordinary commit (`Manager.UpdateConfig` → `Monitor.UpdateGroups` on every cluster config apply), and HA config-sync pushes that commit to **both** nodes.

Baseline, before the fix: `go test -race -run TestMonitorPollDoesNotRaceUpdateGroups6550 ./pkg/cluster/` reported **20 DATA RACEs**, `mapassign` in `pollInterfaceMonitors` against `mapIterStart` in `UpdateGroups`.

## Why not just wrap the apply phase

The lock order in this package is **`m.mu` → `mon.mu`**: `UpdateConfig` holds `m.mu` for its whole body and calls `UpdateGroups`, which takes `mon.mu`. The poll path calls `mgr.SetMonitorWeight` / `mgr.RecordEvent`, which take `m.mu`. Holding `mon.mu` across those callbacks **inverts the order and deadlocks** a commit against a poll cycle — trading a probabilistic fatal for a deterministic hang. The naive fix is worse than the bug, so it gets its own probe (M4 below).

Each site therefore takes `mon.mu` for the map access plus the dampening update it feeds, and drops it before calling the manager. `reconcileRGIPDebts` drives its whole bookkeeping under the lock, collects the resulting weight changes into a local `[]ipDebtAction`, releases, then replays them — removals then installs, the pre-change emission order (both loops already ranged a Go map, so order within each half was never defined).

`Monitor.Stop` is unaffected: it drops `mon.mu` before `wg.Wait()`, so a poll blocked on the lock cannot wedge a teardown.

## Class note vs #7257 (PR #7292)

#7292 established that *a comms-scoped goroutine that PUBLISHES state a teardown clears needs a generation gate; a WaitGroup join protects a different property.*

**#6550 needs neither.** `Monitor.Stop` already joins (`mon.wg.Wait()`), so the poll goroutine cannot outlive teardown; and the racing writer is `UpdateGroups`, which is not a teardown and is not ordered against the goroutine's lifecycle at all. What was missing is plain mutual exclusion. Applying the #7257 idiom here would have added a gate against the wrong event.

## CI had no path to this

`test-race-dp` ran `-race` over `./pkg/daemon` and `./pkg/dataplane` only. **No make target raced `./pkg/cluster`** — so neither this race nor #7257's heartbeat race was a race CI failed to catch; both were races CI could not observe. This adds the `./pkg/cluster` leg (selecting both packages' probes, ~2s at `-count=2`) plus a canary that reads the Makefile and reds if the leg or any probe name is dropped, since deleting a Makefile line is otherwise silent.

## Validation

`go build ./...` + `go vet ./pkg/cluster` clean per cell. `go test -count=1 ./pkg/cluster ./pkg/daemon` green. Probes `-race` clean at **318.6 UpdateGroups calls per poll cycle** — logged, so a degenerate probe is visible rather than quietly passing. The bounded side is the *expensive* one (the poll cycle); the cheap `UpdateGroups` loop runs until the bounded side signals done.

### Mutation matrix — one mutation per cell, each restoring the pre-fix form of exactly one site

| cell | mutation | result |
|---|---|---|
| M1 | `pollInterfaceMonitors` unlocked | 5 DATA RACEs, probe RED |
| M2 | `updateIPTargetDampenedState` unlocked | 5 DATA RACEs, probe RED |
| M3 | `reconcileRGIPDebts` unlocked | 7 DATA RACEs, probe RED |
| M4 | `mon.mu` held across the manager callback | lock-order probe RED on its 5s timeout |
| W1 | delete the Makefile `pkg/cluster` leg | canary RED |
| W2 | drop one probe name from its pattern | canary RED, naming it |

M3's cell removes the `Lock` and its two matching `Unlock`s together: a lone `Lock` removal does not compile, so that is the minimum edit restoring the pre-fix unlocked read — not a compound mutation of two properties.

The deterministic lock-order probe lands its `UpdateGroups` through a new `beforeManagerApplyHook` rather than a sleep, and **fails loudly if the hook never fires** — a probe that does not reach a manager callback proves nothing.

## Not run

`make test-failover` (the issue's second acceptance criterion) — the loss cluster is shared and serialized centrally; this is a Go-only control-plane locking change with no dataplane artifact movement.

## Docs

`pkg/cluster/README.md` gains a "Monitor map locking and the `m.mu -> mon.mu` order" section under the #5080 reconcile discussion; `_Log.md` entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAsT5gCGP7k2vhdZ1sDuRi