### PR TITLE
config: fold redundancy-group instances by canonical id (#6543)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -100663,3 +100663,19 @@ prose edit above them added. No diff falls in the new test body.
   pkg/dhcpserver/dhcpserver.go, pkg/daemon/dhcp_rg_filter_6520_test.go (new),
   pkg/dhcpserver/kea_filtered_group_selector_6520_test.go (new),
   pkg/daemon/README.md
+
+## 2026-08-21 — #6543: redundancy-group ids folded by canonical value
+- **Timestamp**: 2026-08-21
+- **Action**: `compileChassis` appended one `*RedundancyGroup` per AST
+  instance, so `redundancy-group 1` + `redundancy-group 01` (and a repeated
+  hierarchical block) committed TWO records with `ID=1` — one with an empty
+  `NodePriorities`. `cluster.Manager.UpdateConfig`'s id-keyed last-wins loop
+  then overwrote `LocalPriority` with the map-miss zero and the #4880 gate
+  passed vacuously on the empty record. Instances are now folded by canonical
+  int id and each body is replayed into the single record through the same
+  statement dispatch table (leaf-level last-wins, Junos `set` semantics);
+  first-appearance order preserved.
+- **File(s)**: pkg/config/compiler_system.go,
+  pkg/config/compiler_chassis_rg_id_canonical_6543_test.go (new),
+  pkg/cluster/rg_id_canonical_6543_test.go (new), docs/config-schema.md,
+  pkg/cluster/README.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2776,6 +2776,49 @@ which key the sample is filed under. The test now requires each sample to begin
 with its own statement keyword AND instruments the dispatch table so a case that
 never reaches the handler it is filed under fails.
 
+**A redundancy-group is folded by CANONICAL ID, not by the spelling
+(#6543).** `namedInstances` yields one entry per AST node and
+`compileChassis` parses the instance name with `strconv.Atoi`, which maps `1`,
+`01`, `001` and `+1` to the SAME int. Appending one `*RedundancyGroup` per
+instance therefore committed **two** records sharing `ID=1`:
+
+```
+set chassis cluster redundancy-group 1 node 0 priority 200   # record A: NodePriorities{0:200}
+set chassis cluster redundancy-group 01 preempt              # record B: NodePriorities{} Preempt
+```
+
+The repeated hierarchical block hits the same split for a different reason —
+`SetPath` merges same-name flat-set children, but the hierarchical parser
+leaves `redundancy-group 1 { ... } redundancy-group 1 { ... }` as two nodes.
+
+Everything downstream keys redundancy groups by the **int** id.
+`cluster.Manager.UpdateConfig` (`pkg/cluster/group_state.go`) walks the slice
+into an id-keyed map and does `existing.LocalPriority = rg.NodePriorities[m.nodeID]`,
+so whichever record it visited last won: the empty-map record overwrote the
+configured 200 with the **map-miss zero** and node 0 ran RG 1 at priority 0 —
+it loses an election it was configured to win. The #4880 node-priority range
+gate could not catch it either; it iterated the empty-map record and passed
+**vacuously**, having nothing to range-check. Two silent-failure shapes
+intersecting: an overloaded zero (map-miss `0` indistinguishable from a
+configured `0`) behind a vacuous gate.
+
+`compileChassis` now folds instances into one record per canonical id and
+replays each instance's body into it through the same `redundancyGroupStatements`
+dispatch table, so the merge is **leaf-level last-wins** — ordinary Junos `set`
+semantics — rather than one whole record silently displacing another.
+First-appearance order of the ids is preserved so the compiled slice, and every
+first-error message derived from it, stays deterministic. Merging rather than
+rejecting is deliberate: the repeated-hierarchical-block spelling is legal
+Junos that merges, so a hard reject would newly refuse a config an operator can
+legitimately write.
+
+Covered by `pkg/config/compiler_chassis_rg_id_canonical_6543_test.go` (the
+compile half, including a distinct-ids negative control and the #4880 gate now
+seeing the merged record) and `pkg/cluster/rg_id_canonical_6543_test.go` (the
+runtime half — real set lines through the real compiler into the real
+`Manager`, asserting `LocalPriority` is the configured 200 and is insensitive
+to which spelling came first).
+
 **`multi: true` ALSO prevents single-value REPLACE for repeated keyed-list
 leaves (#3984).** The `#2419` discussion above is about ONE statement with a
 bracket list. The SAME `multi: true` marker fixes a second, distinct shape:

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -83,6 +83,30 @@ locating any symbol below is now a matter of opening the named file.
   invariant answerable by reading one file end-to-end.
 - Readiness gate (`SetRGReady`) — `readiness.go`.
 
+### `UpdateConfig` is id-keyed and last-wins (#6543)
+
+`UpdateConfig` walks `cfg.RedundancyGroups` — a SLICE — into `m.groups`, a
+`map[int]*RedundancyGroupState` keyed by `rg.ID`, doing
+`existing.LocalPriority = rg.NodePriorities[m.nodeID]` on every visit. Two
+compiled records sharing one id are therefore a silent overwrite by whichever
+came last, and a `NodePriorities` MAP MISS is indistinguishable from a
+configured priority of 0.
+
+That was reachable from config: `redundancy-group 1 node 0 priority 200` plus
+`redundancy-group 01 preempt` compiled to two `ID=1` records, one with an empty
+priority map, so node 0 ran RG 1 at priority **0** instead of 200 and lost an
+election it was configured to win. The fix is upstream — `compileChassis` now
+folds redundancy-group instances by CANONICAL int id, so the compiler cannot
+hand `UpdateConfig` two records for one group (see `docs/config-schema.md`,
+"A redundancy-group is folded by CANONICAL ID"). The runtime half of that
+property is pinned in `rg_id_canonical_6543_test.go`, which drives real set
+lines through the real compiler into a real `Manager`.
+
+The last-wins loop itself is unchanged and is still the contract: ONE compiled
+record per redundancy-group id. A future caller that synthesizes
+`ClusterConfig` records directly (peer sync, tests) owes that same invariant —
+`UpdateConfig` does not enforce it.
+
 ### Live vs desired heartbeat timing (#5081)
 
 `Manager.hbInterval` / `Manager.hbThreshold` are the **desired**

--- a/pkg/cluster/rg_id_canonical_6543_test.go
+++ b/pkg/cluster/rg_id_canonical_6543_test.go
@@ -1,0 +1,153 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6543: the runtime half of the canonical-redundancy-group-id property.
+//
+// UpdateConfig walks cfg.RedundancyGroups and keys m.groups by rg.ID, so two
+// compiled records sharing one id are a LAST-WINS overwrite:
+//
+//	existing.LocalPriority = rg.NodePriorities[m.nodeID]
+//
+// Before the compiler folded instances by canonical id, spelling the group
+// two ways (`redundancy-group 1 node 0 priority 200` plus
+// `redundancy-group 01 preempt`) produced a second ID=1 record with an EMPTY
+// NodePriorities map, and this line overwrote the configured 200 with the
+// map-miss ZERO. Node 0 then ran RG 1 at priority 0 — it loses an election it
+// was configured to win, which is a real failover behaviour change that
+// survives commit-check silently.
+//
+// This test drives the REAL compiler (set lines -> CompileConfig) into the
+// REAL Manager rather than hand-building typed records, so it binds the
+// end-to-end path the operator actually travels.
+//
+// FAIL-ON-REVERT: restore the per-instance append in compileChassis and
+// LocalPriority comes back 0 here.
+
+// compileClusterCfg compiles flat-set lines into the typed ClusterConfig.
+func compileClusterCfg(t *testing.T, lines []string) *config.ClusterConfig {
+	t.Helper()
+	tree := &config.ConfigTree{}
+	for _, line := range lines {
+		path, err := config.ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := config.CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("commit rejected: %v", err)
+	}
+	if cfg.Chassis.Cluster == nil {
+		t.Fatal("no chassis cluster compiled")
+	}
+	return cfg.Chassis.Cluster
+}
+
+func localPriority(t *testing.T, m *Manager, rgID int) int {
+	t.Helper()
+	for _, gs := range m.GroupStates() {
+		if gs.GroupID == rgID {
+			return gs.LocalPriority
+		}
+	}
+	t.Fatalf("redundancy group %d not present in GroupStates()", rgID)
+	return 0
+}
+
+func TestTwoSpellingsOfOneRGIDKeepTheConfiguredPriority(t *testing.T) {
+	for _, alt := range []string{"01", "001", "+1"} {
+		t.Run("alt="+alt, func(t *testing.T) {
+			cc := compileClusterCfg(t, []string{
+				"set chassis cluster cluster-id 1",
+				"set chassis cluster authentication-key test-cluster-psk-6543",
+				"set chassis cluster node 0",
+				"set chassis cluster redundancy-group 1 node 0 priority 200",
+				"set chassis cluster redundancy-group 1 node 1 priority 100",
+				"set chassis cluster redundancy-group " + alt + " preempt",
+			})
+
+			m := NewManager(0, 1)
+			m.UpdateConfig(cc)
+			drainEvents(m, 4)
+
+			if got := localPriority(t, m, 1); got != 200 {
+				t.Fatalf("node 0 runs RG 1 at LocalPriority %d, want 200 — a "+
+					"second ID=1 record spelled %q overwrote the configured "+
+					"priority with the map-miss zero, so this node loses an "+
+					"election it was configured to win", got, alt)
+			}
+			// The alternate spelling's own statement must still be in effect.
+			found := false
+			for _, gs := range m.GroupStates() {
+				if gs.GroupID == 1 {
+					found = true
+					if !gs.Preempt {
+						t.Errorf("preempt from spelling %q did not reach the "+
+							"group state", alt)
+					}
+				}
+			}
+			if !found {
+				t.Fatal("redundancy group 1 missing from GroupStates()")
+			}
+		})
+	}
+}
+
+// TestSpellingOrderDoesNotChangeTheOutcome: the split was order-sensitive —
+// whichever record UpdateConfig visited LAST won. The merged record must be
+// insensitive to which spelling the operator wrote first.
+func TestSpellingOrderDoesNotChangeTheOutcome(t *testing.T) {
+	base := []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster authentication-key test-cluster-psk-6543",
+		"set chassis cluster node 0",
+	}
+	orders := [][]string{
+		{"set chassis cluster redundancy-group 1 node 0 priority 200",
+			"set chassis cluster redundancy-group 01 preempt"},
+		{"set chassis cluster redundancy-group 01 preempt",
+			"set chassis cluster redundancy-group 1 node 0 priority 200"},
+	}
+	for i, tail := range orders {
+		m := NewManager(0, 1)
+		m.UpdateConfig(compileClusterCfg(t, append(append([]string{}, base...), tail...)))
+		drainEvents(m, 4)
+		if got := localPriority(t, m, 1); got != 200 {
+			t.Errorf("order %d: LocalPriority %d, want 200", i, got)
+		}
+	}
+}
+
+// TestDistinctRGIDsKeepDistinctPriorities is the negative control: the fold
+// must not collapse genuinely different groups into one.
+func TestDistinctRGIDsKeepDistinctPriorities(t *testing.T) {
+	cc := compileClusterCfg(t, []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster authentication-key test-cluster-psk-6543",
+		"set chassis cluster node 0",
+		"set chassis cluster redundancy-group 0 node 0 priority 200",
+		"set chassis cluster redundancy-group 1 node 0 priority 150",
+		"set chassis cluster redundancy-group 2 node 0 priority 100",
+	})
+	m := NewManager(0, 1)
+	m.UpdateConfig(cc)
+	drainEvents(m, 8)
+
+	for id, want := range map[int]int{0: 200, 1: 150, 2: 100} {
+		if got := localPriority(t, m, id); got != want {
+			t.Errorf("rg %d LocalPriority %d, want %d", id, got, want)
+		}
+	}
+	if n := len(m.GroupStates()); n != 3 {
+		t.Errorf("%d redundancy groups in state, want 3", n)
+	}
+}

--- a/pkg/config/compiler_chassis_rg_id_canonical_6543_test.go
+++ b/pkg/config/compiler_chassis_rg_id_canonical_6543_test.go
@@ -1,0 +1,200 @@
+package config
+
+import "testing"
+
+// #6543: two SPELLINGS of one redundancy-group id must compile to ONE record.
+//
+// `strconv.Atoi` maps `1`, `01`, `001` and `+1` to the same int, but the AST
+// keeps them as distinct instances — and so did the compiler, which appended
+// one *RedundancyGroup per instance. A config carrying
+//
+//	set chassis cluster redundancy-group 1 node 0 priority 200
+//	set chassis cluster redundancy-group 01 preempt
+//
+// committed clean as TWO records with ID=1: one holding the operator's
+// priority map and one holding an EMPTY map. Everything downstream keys
+// redundancy groups by the int id, so cluster.Manager.UpdateConfig's id-keyed
+// last-wins loop overwrote LocalPriority with the map-miss zero and node 0 ran
+// RG 1 at priority 0 instead of 200. The #4880 priority-range gate could not
+// catch it: it iterated the empty-map record and passed vacuously.
+//
+// FAIL-ON-REVERT: restore the per-instance
+// `ch.Cluster.RedundancyGroups = append(ch.Cluster.RedundancyGroups, rg)`
+// (i.e. drop the byID fold in compileChassis) and every "one record" assertion
+// below sees 2.
+//
+// The runtime half of this property — that the merged record is the one
+// cluster.Manager actually elects from — is bound in
+// pkg/cluster/rg_id_canonical_6543_test.go.
+
+func rgSpellingSetLines(spellings ...string) []string {
+	lines := []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster authentication-key test-cluster-psk-6543",
+		"set chassis cluster node 0",
+	}
+	// The FIRST spelling carries the node priorities; every later spelling
+	// carries a different statement, so a record that displaces another is
+	// visibly missing one half.
+	lines = append(lines,
+		"set chassis cluster redundancy-group "+spellings[0]+" node 0 priority 200",
+		"set chassis cluster redundancy-group "+spellings[0]+" node 1 priority 100")
+	for _, s := range spellings[1:] {
+		lines = append(lines, "set chassis cluster redundancy-group "+s+" preempt")
+	}
+	return lines
+}
+
+// compileRGs compiles the set lines and returns the redundancy groups.
+func compileRGs(t *testing.T, lines []string) []*RedundancyGroup {
+	t.Helper()
+	cfg, err := CompileConfig(buildTree(t, lines))
+	if err != nil {
+		t.Fatalf("commit rejected: %v", err)
+	}
+	if cfg.Chassis.Cluster == nil {
+		t.Fatal("no chassis cluster compiled")
+	}
+	return cfg.Chassis.Cluster.RedundancyGroups
+}
+
+// TestTwoSpellingsOfOneRGIDCompileToOneRecord is the core RED-on-revert.
+func TestTwoSpellingsOfOneRGIDCompileToOneRecord(t *testing.T) {
+	for _, alt := range []string{"01", "001", "+1"} {
+		t.Run("alt="+alt, func(t *testing.T) {
+			rgs := compileRGs(t, rgSpellingSetLines("1", alt))
+			if len(rgs) != 1 {
+				ids := make([]int, len(rgs))
+				for i, rg := range rgs {
+					ids[i] = rg.ID
+				}
+				t.Fatalf("spellings 1 and %s compiled to %d redundancy-group "+
+					"records (ids %v) — everything downstream keys by the int "+
+					"id, so the extra record silently displaces the real one",
+					alt, len(rgs), ids)
+			}
+			rg := rgs[0]
+			if rg.ID != 1 {
+				t.Fatalf("merged record has id %d, want 1", rg.ID)
+			}
+			// Both halves survive the merge: the priorities from spelling `1`
+			// AND the preempt from the alternate spelling.
+			if got := rg.NodePriorities[0]; got != 200 {
+				t.Errorf("node 0 priority %d, want 200 — the operator's "+
+					"configured priority was lost in the merge", got)
+			}
+			if got := rg.NodePriorities[1]; got != 100 {
+				t.Errorf("node 1 priority %d, want 100", got)
+			}
+			if !rg.Preempt {
+				t.Errorf("preempt from spelling %q was lost in the merge", alt)
+			}
+		})
+	}
+}
+
+// TestThreeSpellingsOfOneRGIDCompileToOneRecord: the fold is not a
+// two-instance special case.
+func TestThreeSpellingsOfOneRGIDCompileToOneRecord(t *testing.T) {
+	rgs := compileRGs(t, rgSpellingSetLines("1", "01", "001"))
+	if len(rgs) != 1 {
+		t.Fatalf("three spellings of id 1 compiled to %d records", len(rgs))
+	}
+	if rgs[0].NodePriorities[0] != 200 || !rgs[0].Preempt {
+		t.Fatalf("merged record lost a half: %+v", rgs[0])
+	}
+}
+
+// TestRepeatedHierarchicalRGBlockCompilesToOneRecord: the SAME spelling
+// repeated as two hierarchical blocks is two AST nodes too (SetPath merges
+// same-name flat-set children, the hierarchical parser does not), so it hit
+// the identical split. Junos merges repeated blocks; so must this.
+func TestRepeatedHierarchicalRGBlockCompilesToOneRecord(t *testing.T) {
+	src := `chassis {
+    cluster {
+        cluster-id 1;
+        authentication-key test-cluster-psk-6543;
+        node 0;
+        redundancy-group 1 {
+            node 0 priority 200;
+        }
+        redundancy-group 1 {
+            preempt;
+        }
+    }
+}
+`
+	tree, perrs := NewParser(src).Parse()
+	if len(perrs) != 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("commit rejected: %v", err)
+	}
+	rgs := cfg.Chassis.Cluster.RedundancyGroups
+	if len(rgs) != 1 {
+		t.Fatalf("a repeated hierarchical redundancy-group 1 block compiled "+
+			"to %d records", len(rgs))
+	}
+	if rgs[0].NodePriorities[0] != 200 {
+		t.Errorf("node 0 priority %d, want 200", rgs[0].NodePriorities[0])
+	}
+	if !rgs[0].Preempt {
+		t.Errorf("preempt from the second block was lost")
+	}
+}
+
+// TestDistinctRGIDsAreNotMerged is the negative control: the fold must key on
+// the canonical id, not collapse every redundancy-group into one.
+func TestDistinctRGIDsAreNotMerged(t *testing.T) {
+	lines := []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster authentication-key test-cluster-psk-6543",
+		"set chassis cluster node 0",
+		"set chassis cluster redundancy-group 0 node 0 priority 200",
+		"set chassis cluster redundancy-group 1 node 0 priority 150",
+		"set chassis cluster redundancy-group 2 node 0 priority 100",
+	}
+	rgs := compileRGs(t, lines)
+	if len(rgs) != 3 {
+		t.Fatalf("three distinct ids compiled to %d records", len(rgs))
+	}
+	want := map[int]int{0: 200, 1: 150, 2: 100}
+	for _, rg := range rgs {
+		if got := rg.NodePriorities[0]; got != want[rg.ID] {
+			t.Errorf("rg %d node 0 priority %d, want %d", rg.ID, got, want[rg.ID])
+		}
+	}
+	// First-appearance order is preserved so the compiled slice (and every
+	// first-error message derived from it) stays deterministic.
+	for i, rg := range rgs {
+		if rg.ID != i {
+			t.Errorf("record %d has id %d — first-appearance order not preserved", i, rg.ID)
+		}
+	}
+}
+
+// TestPriorityRangeGateSeesTheMergedRecord: the #4880 gate must range-check
+// the priorities the operator actually wrote, even when they were written
+// under a different spelling from the rest of the group's body. Before the
+// merge the out-of-range priority lived on one record while the gate happily
+// passed over the other.
+func TestPriorityRangeGateSeesTheMergedRecord(t *testing.T) {
+	lines := []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster authentication-key test-cluster-psk-6543",
+		"set chassis cluster node 0",
+		"set chassis cluster redundancy-group 01 node 0 priority 255",
+		"set chassis cluster redundancy-group 1 preempt",
+	}
+	_, err := CompileConfig(buildTree(t, lines))
+	if err == nil {
+		t.Fatal("commit accepted an out-of-range node priority (255, the " +
+			"RFC 5798 IP-owner reserved value) written under an alternate " +
+			"spelling of the redundancy-group id")
+	}
+	if !stringContainsAll(err.Error(), "redundancy-group 1", "priority 255", "out of range") {
+		t.Fatalf("error %q does not name the out-of-range priority", err.Error())
+	}
+}

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -2063,15 +2063,43 @@ func compileChassis(node *Node, ch *ChassisConfig) error {
 		}
 	}
 
+	// #6543: redundancy-group instances are folded by CANONICAL id, not by
+	// the spelling the operator wrote. `strconv.Atoi` maps `1`, `01`, `001`
+	// and `+1` to the same int, and the AST keeps them as DISTINCT instances
+	// (namedInstances yields one entry per node, and a repeated hierarchical
+	// `redundancy-group 1 { ... }` block is two nodes as well). Appending one
+	// record per instance therefore committed TWO *RedundancyGroup with
+	// ID=1 — one carrying the operator's `node <n> priority <p>` map and one
+	// with an EMPTY map.
+	//
+	// Everything downstream keys redundancy groups by the int id, so the
+	// split was silently lossy: cluster.Manager.UpdateConfig's id-keyed
+	// last-wins loop overwrote LocalPriority with the map-miss zero from
+	// whichever record came second, so a node configured to win the election
+	// at priority 200 ran RG 1 at priority 0. The #4880 priority-range gate
+	// could not catch it either — it iterated the empty-map record and passed
+	// vacuously, having nothing to range-check.
+	//
+	// Folding by canonical id yields exactly one record per id and replays
+	// every instance's body into it through the same statement table, so the
+	// merge is leaf-level last-wins — Junos `set` semantics — rather than a
+	// whole record silently displacing another. First-appearance order of the
+	// ids is preserved so the compiled slice stays deterministic.
+	byID := make(map[int]*RedundancyGroup)
 	for _, rgInst := range namedInstances(clusterNode.FindChildren("redundancy-group")) {
 		rgID := 0
 		if n, err := strconv.Atoi(rgInst.name); err == nil {
 			rgID = n
 		}
 
-		rg := &RedundancyGroup{
-			ID:             rgID,
-			NodePriorities: make(map[int]int),
+		rg, ok := byID[rgID]
+		if !ok {
+			rg = &RedundancyGroup{
+				ID:             rgID,
+				NodePriorities: make(map[int]int),
+			}
+			byID[rgID] = rg
+			ch.Cluster.RedundancyGroups = append(ch.Cluster.RedundancyGroups, rg)
 		}
 
 		// #6588: redundancyGroupBody, not .Children — the whole body may be
@@ -2085,8 +2113,6 @@ func compileChassis(node *Node, ch *ChassisConfig) error {
 				compile(rg, child)
 			}
 		}
-
-		ch.Cluster.RedundancyGroups = append(ch.Cluster.RedundancyGroups, rg)
 	}
 
 	return nil


### PR DESCRIPTION
## Problem

`compileChassis` appended one `*RedundancyGroup` per AST instance while parsing the instance name with `strconv.Atoi` — which maps `1`, `01`, `001` and `+1` to the same int. Verified firsthand:

```
set chassis cluster redundancy-group 1 node 0 priority 200
set chassis cluster redundancy-group 1 node 1 priority 100
set chassis cluster redundancy-group 01 preempt
```
```
rg[0] ID=1 prio=map[0:200 1:100] preempt=false
rg[1] ID=1 prio=map[]            preempt=true     <-- two records, one id
```

The repeated hierarchical block splits the same way (`SetPath` merges same-name flat-set children; the hierarchical parser does not) — also verified: `redundancy-group 1 { node 0 priority 200; } redundancy-group 1 { preempt; }` → 2 records.

Everything downstream keys redundancy groups by the **int** id. `cluster.Manager.UpdateConfig` (`pkg/cluster/group_state.go:37`) walks the slice into an id-keyed map:

```go
existing.LocalPriority = rg.NodePriorities[m.nodeID]
```

so whichever record it visited last won — the empty-map record overwrote a configured 200 with the **map-miss zero**. Node 0 then ran RG 1 at priority 0 and lost an election it was configured to win, silently, across a clean commit-check.

The #4880 node-priority range gate could not catch it either: it iterated the empty-map record and passed **vacuously**, having nothing to range-check. An overloaded zero behind a vacuous gate.

## Fix

Fold instances into one record per canonical int id, replaying each instance's body into it through the same `redundancyGroupStatements` dispatch table. The merge is therefore **leaf-level last-wins** — ordinary Junos `set` semantics — rather than one whole record silently displacing another. First-appearance order of the ids is preserved so the compiled slice, and every first-error message derived from it, stays deterministic.

**Merging rather than rejecting is deliberate.** The repeated-hierarchical-block spelling is legal Junos that merges, so a hard reject would newly refuse a config an operator can legitimately write. The issue's own fix text offers "reject or normalise"; this normalises.

## Tests

`pkg/config/compiler_chassis_rg_id_canonical_6543_test.go` — the compile half: `01`/`001`/`+1` each merge to one record with BOTH halves intact; three spellings; the repeated hierarchical block; a distinct-ids negative control that also pins first-appearance order; and the #4880 gate now range-checking a priority written under an alternate spelling.

`pkg/cluster/rg_id_canonical_6543_test.go` — the runtime half: real set lines → real `CompileConfig` → real `Manager.UpdateConfig`, asserting `LocalPriority == 200` (not 0) and that the outcome is insensitive to which spelling came first, plus a distinct-ids control.

## Validation

`go test ./pkg/config/ ./pkg/cluster/ ./pkg/daemon/ -count=1` green.

Mutation matrix (one line per cell, restore + rebuild between cells, rc read from a file):

| Cell | Mutation | rc | Reds |
|---|---|---|---|
| M1 | restore the pre-fix per-instance `append` (drop the `byID` fold) | 1 | 3 compile tests + 3 runtime subtests |
| M2 | delete only the `byID[rgID] = rg` registration | 1 | same set |
| CONTROL | none | 0 | — |

`TestPriorityRangeGateSeesTheMergedRecord` is deliberately not a red-on-revert cell: under the split the out-of-range priority still lives on one of the two records, so the gate still fires. It pins the post-merge behaviour, not the bug.

Go control plane only — no `userspace-dp` binary or shim `.o` movement. This touches config compilation feeding the cluster election, so a cluster gate is worth running centrally even though no dataplane artifact moved.

Closes #6543