### PR TITLE
image: pin the day-0 config's credential posture in the Tier-1 gate

### DIFF
--- a/docs/image-validation.md
+++ b/docs/image-validation.md
@@ -105,7 +105,7 @@ Scenarios:
 | Scenario | Proves |
 |---|---|
 | **a** no config drive | factory boot; kernel ≥6.18 + `-generic` flavor; `linux-modules-extra` present (checked via the Mellanox driver dir as the sentinel — the broader mlx5/i40e set rides with it); exactly one kernel; `init_on_alloc=0` on the booted cmdline; **in-guest `xpfd verify-dataplane` PASS**; the `/etc/xpf/appliance` marker present (#7114 — it is what re-enables the factory bootstrap; asserted before the DHCP wait so a bake that stopped writing it fails with its own cause); `fxp0` DHCP; sshd listening with `PermitRootLogin prohibit-password` + `PermitEmptyPasswords no`; no stray `/etc/xpf/xpf.conf` or stamp; **#1930 LANE-1 A/B kernel channel live in-guest** (#6494 — both `xpf-A`/`xpf-B` registered exactly once with their own `\EFI\<slot>\shimx64.efi` loader and reachable in BootOrder, `xpf-uefi-slots.service` and `xpf-kernel-promote.service` both ran with `ExecMainStatus=0`, and the promote gate logged its ordinary-boot path); **both slot ESP dirs fully staged with selectors seeded at the running kernel** and **every installed kernel package still held** (#6498); **guest booted under UEFI Secure Boot** (#6497 — the `SecureBoot` EFI variable, corroborated by `mokutil --sb-state` when present and `/sys/kernel/security/lockdown`) |
-| **b** valid day-0 drive | config validated + installed + committed (hostname applied, CLI shows it); reboot does **not** re-apply (stamp honored). *(The loader installs the config `0600`; the scenario asserts it exists and is non-empty, not the mode.)* |
+| **b** valid day-0 drive | config validated + installed + committed (hostname applied, CLI shows it); reboot does **not** re-apply (stamp honored). *(The loader installs the config `0600` because it may carry credential material; the scenario now asserts that posture — root-owned **regular file**, mode exactly `0600` — #6503.)* |
 | **c** invalid day-0 drive | commit-check REJECT logged, nothing installed, no stamp, factory bootstrap still reachable |
 | **d** resized disk (#1925) | first-boot root auto-grow fills a 20 GiB root disk — root **partition** + ext4 fs both grow past the 8 GiB bake floor, `/etc/xpf/.root-grown` stamped, idempotent across a reboot, ESP still mounted, `verify-dataplane` still PASS; a control instance at the exact bake size proves the grow is a clean no-op (`growpart` NOCHANGE) |
 
@@ -248,6 +248,43 @@ never-installed names).
 captured command output, unit-tested (with the bake-agreement canaries and the
 call-site wiring assertions) in
 `scripts/image/test_validate_ab_substrate_6498.py`, run by `make selftest`.
+
+### The day-0 config's credential posture (#6503)
+
+The loader installs `/etc/xpf/xpf.conf` with `install -o root -g root -m 0600`
+because it "may carry credential material (root-authentication
+encrypted-password, IKE PSKs)". Until #6503 the gate asserted the file exists
+and is non-empty and **nothing about the mode** — this document said so in as
+many words — so a regression to `0644` would ship world-readable IKE PSKs and
+password hashes inside a *signed* image and pass Tier 1 green. It is pinned now
+for the same reason scenario A pins the sshd posture.
+
+Asserted in **every** scenario that installs a config — B (valid drive), C's
+retry leg, and E (node-id drive) — because they all reach the same `install`
+call and a regression there would ship from any of them.
+
+Two details a naive version of this check gets wrong:
+
+- **The mode is compared as an octal value, not the string `"600"`** — for
+  rendering independence, not because a string compare would let a bad mode
+  through. GNU `stat -c %a` emits `600` unpadded, so `!= "600"` rejects `4600`
+  exactly as `!= 0o600` does; what the value compare buys is that a zero-padded
+  `0600` from a non-GNU `stat` is the same mode and is not a false red.
+- **The probe does not pass `stat -L`.** For a symlink, `stat -c '%a %U:%G %F'`
+  reports the *link* (`777 … symbolic link`); `stat -L` reports the *target*
+  (`644 … regular file`). A check that followed the link would read the
+  target's mode while the file an attacker controls is the link — a `0600`
+  target behind a world-writable link would PASS on mode alone. The file type
+  is therefore part of the verdict, and `_DAY0_CONF_STAT` is asserted to carry
+  no `-L`.
+
+**Not** asserted: `/etc/xpf`'s own directory mode. The loader sets it
+best-effort (`chmod 0750 … || true`) and the directory comes from the `.deb` on
+a real appliance, so it is not the loader's contract to pin here.
+
+`_conf_mode_verdict` is a pure function over the captured `stat` output,
+unit-tested (with the call-site wiring assertions) in
+`scripts/image/test_validate_day0_perms_6503.py` and run by `make selftest`.
 
 ---
 

--- a/scripts/image/test_validate_day0_perms_6503.py
+++ b/scripts/image/test_validate_day0_perms_6503.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Hermetic unit tests for the #6503 day-0 config permission assertion.
+
+The day-0 loader installs `/etc/xpf/xpf.conf` mode 0600 because it "may carry
+credential material (root-authentication encrypted-password, IKE PSKs)"
+(`scripts/image/xpf-day0-config`). Scenario B of the Tier-1 gate asserted the
+file EXISTS and is non-empty (`test -s`) and nothing about the mode —
+`docs/image-validation.md` said so in as many words — so a regression to 0644
+would ship world-readable IKE PSKs and password hashes inside a signed image
+and pass the gate green.
+
+Two details worth stating, because a naive version of this check has both bugs:
+
+  * THE MODE IS COMPARED AS AN OCTAL VALUE, not as the string "600" — for
+    RENDERING independence, not because a string compare would let a bad mode
+    through. GNU `stat -c %a` emits "600" unpadded, so `!= "600"` rejects
+    "4600" exactly as `!= 0o600` does; the string-compare mutation is only
+    distinguishable because a zero-padded "0600" is the same mode and must not
+    be a false red. (An earlier draft of this file claimed a string compare
+    "silently accepts 4600". That is FALSE, and the mutation matrix is what
+    caught it: the string-compare mutation did not red.)
+
+  * THE PROBE DOES NOT PASS `stat -L`. Verified on a real filesystem: for a
+    symlink, `stat -c '%a %U:%G %F'` reports the LINK (`777 ... symbolic
+    link`), while `stat -L` reports the TARGET (`644 ... regular file`). A
+    check that followed the link would read the target's mode while the file
+    an attacker controls is the link — so a 0600 target behind a
+    world-writable link would PASS. The file type is therefore part of the
+    verdict, not an afterthought.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_SPEC = importlib.util.spec_from_file_location("validate", _HERE / "validate.py")
+validate = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(validate)
+
+GOOD = "600 root:root regular file"
+
+
+class ConfModeVerdictTests(unittest.TestCase):
+    def test_root_owned_regular_file_mode_600_passes(self):
+        ok, reason = validate._conf_mode_verdict(GOOD)
+        self.assertTrue(ok, reason)
+
+    def test_trailing_newline_and_padding_are_tolerated(self):
+        ok, reason = validate._conf_mode_verdict("  600 root:root regular file \n")
+        self.assertTrue(ok, reason)
+
+    def test_world_readable_0644_fails(self):
+        # THE regression this exists for.
+        ok, reason = validate._conf_mode_verdict("644 root:root regular file")
+        self.assertFalse(ok)
+        self.assertIn("644", reason)
+
+    def test_group_readable_0640_fails(self):
+        ok, _ = validate._conf_mode_verdict("640 root:root regular file")
+        self.assertFalse(ok)
+
+    def test_world_writable_0666_fails(self):
+        ok, _ = validate._conf_mode_verdict("666 root:root regular file")
+        self.assertFalse(ok)
+
+    def test_setuid_bit_on_an_otherwise_correct_mode_fails(self):
+        ok, reason = validate._conf_mode_verdict("4600 root:root regular file")
+        self.assertFalse(ok)
+        self.assertIn("4600", reason)
+
+    def test_a_zero_padded_rendering_of_the_same_mode_passes(self):
+        # The actual reason the comparison is over the octal VALUE: "0600" and
+        # "600" are the same mode, and a verdict that rejected one rendering
+        # would be a false red, not a caught regression. This is the ONLY
+        # assertion a string compare against "600" fails, which is why it is
+        # written out rather than left implicit.
+        ok, reason = validate._conf_mode_verdict("0600 root:root regular file")
+        self.assertTrue(ok, reason)
+
+    def test_non_root_owner_fails(self):
+        ok, reason = validate._conf_mode_verdict("600 nobody:nogroup regular file")
+        self.assertFalse(ok)
+        self.assertIn("nobody:nogroup", reason)
+
+    def test_root_owner_wrong_group_fails(self):
+        ok, _ = validate._conf_mode_verdict("600 root:staff regular file")
+        self.assertFalse(ok)
+
+    def test_a_symlink_fails_even_though_its_own_mode_is_irrelevant(self):
+        # `stat` without -L reports the LINK: 777 symbolic link. Both the type
+        # and the mode are wrong here, but the TYPE is the load-bearing half —
+        # see the class below.
+        ok, reason = validate._conf_mode_verdict("777 root:root symbolic link")
+        self.assertFalse(ok)
+        self.assertIn("symbolic link", reason)
+
+    def test_a_symlink_whose_mode_LOOKS_right_still_fails(self):
+        # The case that makes the type check load-bearing rather than
+        # decorative: if the probe had used `stat -L`, a 0600 TARGET behind an
+        # attacker-controlled link would report exactly this and PASS on mode
+        # alone. Only the file-type field rejects it.
+        ok, reason = validate._conf_mode_verdict("600 root:root symbolic link")
+        self.assertFalse(ok)
+        self.assertIn("symbolic link", reason)
+
+    def test_a_directory_fails(self):
+        ok, _ = validate._conf_mode_verdict("600 root:root directory")
+        self.assertFalse(ok)
+
+    def test_empty_output_fails_rather_than_passing_vacuously(self):
+        # An absent file or a failed probe leaves the property UNOBSERVED,
+        # which is not the same as satisfied.
+        ok, reason = validate._conf_mode_verdict("")
+        self.assertFalse(ok)
+        self.assertIn("unobserved", reason)
+
+    def test_truncated_output_fails(self):
+        ok, _ = validate._conf_mode_verdict("600 root:root")
+        self.assertFalse(ok)
+
+    def test_unparseable_mode_fails(self):
+        ok, reason = validate._conf_mode_verdict("rw------- root:root regular file")
+        self.assertFalse(ok)
+        self.assertIn("unparseable", reason)
+
+    def test_all_three_problems_are_reported_together(self):
+        ok, reason = validate._conf_mode_verdict("777 nobody:nogroup symbolic link")
+        self.assertFalse(ok)
+        for needle in ("symbolic link", "777", "nobody:nogroup"):
+            self.assertIn(needle, reason)
+
+
+class ProbeShapeTests(unittest.TestCase):
+    def test_the_probe_does_not_follow_symlinks(self):
+        # If -L is ever added, the verdict starts reading the target and the
+        # symlink cases above become unreachable in production while still
+        # passing here.
+        self.assertNotIn("-L", validate._DAY0_CONF_STAT)
+
+    def test_the_probe_asks_for_exactly_the_three_fields_the_verdict_parses(self):
+        self.assertIn("%a", validate._DAY0_CONF_STAT)
+        self.assertIn("%U:%G", validate._DAY0_CONF_STAT)
+        self.assertIn("%F", validate._DAY0_CONF_STAT)
+
+    def test_the_probe_targets_the_installed_config(self):
+        self.assertIn("/etc/xpf/xpf.conf", validate._DAY0_CONF_STAT)
+
+
+class WiringTests(unittest.TestCase):
+    """A verdict nothing calls asserts nothing. The loader reaches the same
+    `install -o root -g root -m 0600` from every scenario that installs a
+    config, so all three pin it."""
+
+    SRC = (_HERE / "validate.py").read_text(encoding="utf-8")
+
+    def _body(self, name):
+        return self.SRC.split(f"def {name}(self", 1)[1].split("\n    def ", 1)[0]
+
+    def test_scenario_b_asserts_the_config_permissions(self):
+        self.assertIn("self.assert_day0_conf_perms(", self._body("scenario_b"))
+
+    def test_scenario_c_retry_leg_asserts_them_too(self):
+        self.assertIn("self.assert_day0_conf_perms(", self._body("scenario_c"))
+
+    def test_scenario_e_node_id_drive_asserts_them_too(self):
+        self.assertIn("self.assert_day0_conf_perms(", self._body("scenario_e"))
+
+    def test_the_assertion_uses_the_verdict(self):
+        self.assertIn("_conf_mode_verdict(", self._body("assert_day0_conf_perms"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/image/validate.py
+++ b/scripts/image/validate.py
@@ -548,6 +548,73 @@ def _oneshot_clean_verdict(name, exec_main_status, active_state, result):
     return True, f"{name} ran clean (ExecMainStatus=0)"
 
 
+# ── day-0 config permissions (#6503) ──────────────────────────────────
+# The day-0 loader installs /etc/xpf/xpf.conf mode 0600 because it "may carry
+# credential material (root-authentication encrypted-password, IKE PSKs)"
+# (scripts/image/xpf-day0-config). Scenario B asserted the file EXISTS and is
+# non-empty (`test -s`) and nothing about the mode — docs/image-validation.md
+# said so in as many words — so a regression to 0644 would ship
+# world-readable IKE PSKs and password hashes in a signed image and pass the
+# Tier-1 gate.
+#
+# The probe reads three fields from ONE `stat`, because a mode check alone has
+# a hole: `stat` follows a symlink only with -L, so without it a symlinked
+# xpf.conf reports the LINK's 0777 — but a naive check that ran `stat -L`
+# would report the TARGET's mode while the file an attacker controls is the
+# link. A credential file must be a regular file, owned by root, mode exactly
+# 0600.
+_DAY0_CONF = "/etc/xpf/xpf.conf"
+_DAY0_CONF_STAT = f"stat -c '%a %U:%G %F' {_DAY0_CONF} 2>/dev/null"
+
+
+def _conf_mode_verdict(stat_out, want_mode=0o600, want_owner="root:root"):
+    """Pure verdict over `stat -c '%a %U:%G %F'` for the installed day-0
+    config: is it a root-owned regular file with exactly mode 0600?
+    Returns (ok, reason).
+
+    The mode is compared as an OCTAL VALUE, not as a string. This is
+    ROBUSTNESS, not a caught bug: GNU `stat -c %a` emits "600" unpadded, so a
+    string compare against "600" rejects "4600" (a setuid bit) just as an int
+    compare does. What the value compare buys is independence from the
+    RENDERING — a zero-padded "0600" from a non-GNU stat is the same mode and
+    must not be a false red, while every extra bit is still rejected because
+    0o4600 != 0o600. Said plainly because the reverse claim (that a string
+    compare would let 4600 through) is FALSE and was in an earlier draft of
+    this comment; the mutation matrix caught it.
+
+    Unreadable / absent output is a FAIL, not a pass. A gate that cannot
+    observe the property it exists to assert has not asserted it.
+    """
+    fields = (stat_out or "").strip().split(None, 2)
+    if len(fields) < 3:
+        return False, (
+            f"could not stat {_DAY0_CONF} in the guest (got {stat_out!r}) — "
+            "the day-0 config is missing, or the probe failed; either way the "
+            "permission is unobserved, which is not the same as satisfied")
+    mode_s, owner, ftype = fields
+    try:
+        mode = int(mode_s, 8)
+    except ValueError:
+        return False, f"{_DAY0_CONF}: unparseable mode {mode_s!r}"
+
+    problems = []
+    if ftype != "regular file":
+        problems.append(
+            f"is a {ftype!r}, not a regular file — a symlinked config puts the "
+            "bytes xpfd reads outside the mode this gate checks")
+    if mode != want_mode:
+        problems.append(
+            f"has mode {mode_s} (0o{mode:o}), not {want_mode:04o} — a day-0 "
+            "config may carry root-authentication encrypted-password and IKE "
+            "PSKs, so any extra bit makes them readable to every local user "
+            "on the appliance")
+    if owner != want_owner:
+        problems.append(f"is owned by {owner}, not {want_owner}")
+    if problems:
+        return False, f"{_DAY0_CONF} " + "; ".join(problems)
+    return True, f"{_DAY0_CONF} is a root:root regular file, mode {mode_s}"
+
+
 def _find_first(candidates):
     for p in candidates:
         if os.path.isfile(p):
@@ -881,6 +948,31 @@ class Harness:
             fail("#1930 INC-0 kernel hold assertion FAILED: " + reason)
         info(f"kernel hold: {reason}")
 
+    def assert_day0_conf_perms(self, inst):
+        """Assert the installed day-0 config's credential posture (#6503).
+
+        Called from every scenario where the loader actually INSTALLS a config
+        — B (valid drive), C's retry leg (fix + reboot applies), and E
+        (node-id drive) — because they all reach the same `install -o root -g
+        root -m 0600` and a regression there would ship in a signed image from
+        any of them.
+
+        Deliberately NOT asserted: /etc/xpf's own directory mode. The loader
+        sets it best-effort (`chmod 0750 ... || true`) and the directory comes
+        from the .deb on a real appliance, so it is not the loader's contract
+        to pin here.
+        """
+        out = guest(inst, "sh", "-c", _DAY0_CONF_STAT,
+                    check=False, capture=True).stdout
+        ok, reason = _conf_mode_verdict(out)
+        if not ok:
+            fail("day-0 config permission assertion FAILED: " + reason +
+                 "\n  The loader installs it 0600 precisely because it may "
+                 "carry credential material (scripts/image/xpf-day0-config); "
+                 "the Tier-1 gate has to pin that, exactly as scenario A pins "
+                 "the sshd posture.")
+        info(f"day-0 config perms: {reason}")
+
     def assert_secure_boot(self, inst):
         """Assert the guest actually booted under UEFI Secure Boot (#6497).
 
@@ -1027,6 +1119,7 @@ class Harness:
             fail("day-0 stamp missing")
         if guest(b, "test", "-s", "/etc/xpf/xpf.conf", check=False).returncode != 0:
             fail("/etc/xpf/xpf.conf missing")
+        self.assert_day0_conf_perms(b)
         if not guest_sh(b,
                         'journalctl -u xpf-day0-config -b --no-pager | grep -q "day-0 config installed"'):
             fail("day-0 loader did not log the install")
@@ -1103,6 +1196,7 @@ class Harness:
                         'journalctl -u xpf-day0-config -b --no-pager | grep -q '
                         '"day-0 config installed"'):
             fail("retry: day-0 loader did not install the fixed config on reboot")
+        self.assert_day0_conf_perms(c)
         self._wait(c,
                    lambda: guest_sh(c, '[ "$(hostname)" = xpf-day0-c-fixed ]'),
                    20, 3, "retry: fixed hostname xpf-day0-c-fixed not applied")
@@ -1250,6 +1344,7 @@ class Harness:
         if nid != "1":
             fail(f"/etc/xpf/node-id is '{nid}', expected '1' — node-id not "
                  "persisted from the day-0 drive")
+        self.assert_day0_conf_perms(e)
         # Cluster-mode naming: node 1 uses FPC 7. em0 is assigned only in
         # cluster mode (position 2); ge-7/0/0 proves the node-1 FPC branch.
         if not guest_sh(e, 'ip link show em0 >/dev/null 2>&1'):


### PR DESCRIPTION
The day-0 loader installs `/etc/xpf/xpf.conf` with `install -o root -g root -m 0600` because it *"may carry credential material (root-authentication encrypted-password, IKE PSKs)"*. Scenario B asserted the file exists and is non-empty (`test -s`) and **nothing about the mode** — `docs/image-validation.md:108` said so in as many words. A regression to `0644` would ship world-readable IKE PSKs and password hashes inside a **signed** image and pass Tier 1 green.

Pinned now for the same reason scenario A pins the sshd posture.

## Where it is asserted

**Every** scenario that installs a config — **B** (valid drive), **C**'s retry leg (fix + reboot applies), and **E** (node-id drive). They all reach the same `install` call, so a regression would ship from any of them. The issue names only scenario B; the other two are the same property at the same call site and cost one line each.

## `stat -L` is deliberately absent, and that is load-bearing

Verified on a real filesystem rather than reasoned about:

```
stat -c    '%a %U:%G %F' link  ->  777 ps:ps symbolic link
stat -L -c '%a %U:%G %F' link  ->  644 ps:ps regular file     <- the TARGET
```

A check that followed the link would read the target's mode while the file an attacker controls is the link — so a `0600` target behind a world-writable link would **pass on mode alone**. The file type is therefore part of the verdict, and a unit test asserts the probe carries no `-L`.

**Not** asserted: `/etc/xpf`'s own directory mode. The loader sets it best-effort (`chmod 0750 … || true`) and the directory comes from the `.deb` on a real appliance, so it is not the loader's contract to pin.

## One claim the mutation matrix corrected

An earlier draft said the mode is compared as an octal value because *"a string compare silently accepts `4600`"*. **That is false.** GNU `stat -c %a` emits `600` unpadded, so `!= "600"` rejects `4600` exactly as `!= 0o600` does.

It surfaced because the string-compare mutation **did not red** — no test could distinguish the two, because there was nothing to distinguish. The value compare's real benefit is independence from the **rendering**, so the comment, the test docstring and the doc now say that, and a test binds it: a zero-padded `0600` is the same mode and must not be a false red. That is the one assertion a string compare fails, and the mutation now reds on it. Reported rather than quietly adjusted.

## Validation

- 23 hermetic unit tests. `make selftest`: **58 passed / 0 skipped / 0 failed** (57 at this base; no leg lost).
- **Nine one-line mutations**, each confirmed to **import** at the mutated state first, each red with 23 tests collected:

| mutation | red |
|---|---|
| drop the mode comparison | 5 |
| compare the mode as a string | 1 (only after the correction above) |
| drop the file-type check | 4 |
| drop the owner check | 3 |
| treat unreadable `stat` output as a pass | 2 (as errors — the mutated function raises instead of returning a verdict) |
| add `-L` to the probe | probe-shape test |
| unwire the assertion from scenario B | wiring |
| unwire it from scenario C's retry leg | wiring |
| unwire it from scenario E | wiring |

Tree clean and rc back to 0 after each.

## Scope

- **Rust helper binary: not reached.** Python + Markdown only.
- **Needs a live bake/boot: yes, for the scenario assertions themselves** — they execute only during a real Tier-1 run (a bake plus an incus VM). That half is **not** claimed. The verdict, the probe shape, and the three call sites are what is proven.
- Docs: the scenario-B row's "not the mode" caveat is replaced by what it now asserts, plus a subsection covering the three call sites, the `-L` reasoning, and what is deliberately left unasserted.

Closes #6503

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cz2czGK3aA5MsMhkNkjHXX