### PR TITLE
config: host-inbound interface stanza replaces the zone stanza

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -100554,3 +100554,49 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: pkg/cluster/manager.go, pkg/cluster/heartbeat_manager.go,
   pkg/daemon/daemon_ha_sync.go,
   pkg/cluster/heartbeat_start_stop_race_7257_test.go (new), pkg/cluster/README.md
+
+## 2026-08-21 — #6515: host-inbound interface stanza REPLACES the zone stanza
+- **Timestamp**: 2026-08-21
+- **Action**: The zone-level and per-interface `host-inbound-traffic` sets were
+  UNIONed and asserted in-tree as "Junos additive semantics", so an interface
+  stanza could only ever WIDEN admission. Junos replaces
+  ("Interface configuration overrides that of the zone"). Added
+  `config.EffectiveHostInboundTokens` as the SSOT for the zone↔interface choice
+  (presence of the stanza, not emptiness — an explicit empty stanza is a
+  deny-all override) and routed all four resolvers through it: the display view
+  (`InterfaceHostInboundEffective`), the dataplane/nft builder
+  (`effectiveHostInboundTokens`, renamed from `unionHostInboundTokens`), the
+  #3718 duplicate-address commit gate (`effectiveHostInboundSigLocal`), and the
+  remote CLI projection. `UnionHostInboundTokens` is retained for the
+  WITHIN-level merges (#3720 physical∪unit, #4544 repeated blocks). Added the
+  migration advisory `validateHostInboundOverrideReplaceWarnings` naming every
+  (zone, interface, lost token) triple at commit-check, and corrected every
+  in-tree comment/doc asserting the union, including the .proto (regenerated).
+- **File(s)**: pkg/config/host_inbound_view.go, pkg/config/types_security.go,
+  pkg/config/schema_security.go, pkg/config/dup_host_local_address.go,
+  pkg/config/compiler_validate_warn.go,
+  pkg/config/compiler_validate_warn_host_inbound.go,
+  pkg/dataplane/userspace/zones_override.go,
+  pkg/dataplane/userspace/zones_host_inbound.go,
+  pkg/dataplane/userspace/interfaces.go,
+  pkg/dataplane/userspace/host_inbound_classify.go,
+  pkg/dataplane/userspace/protocol.go, pkg/cli/cli_show_interfaces.go,
+  pkg/api/types.go, pkg/api/README.md, pkg/policymatch/policymatch.go,
+  cmd/cli/show_security.go, proto/xpf/v1/xpf.proto,
+  pkg/grpcapi/xpfv1/xpf.pb.go (regenerated),
+  userspace-dp/src/afxdp/forwarding/host_inbound.rs,
+  userspace-dp/src/afxdp/forwarding/host_inbound_tests.rs,
+  userspace-dp/src/afxdp/forwarding/README.md,
+  userspace-dp/src/afxdp/forwarding_build/interfaces.rs,
+  userspace-dp/src/afxdp/types/forwarding.rs,
+  docs/host-inbound-service-matrix.md, docs/host-inbound-multicast.md,
+  docs/junos-cli-reference.md, docs/config-schema.md,
+  pkg/config/host_inbound_replace_6515_test.go (new),
+  pkg/dataplane/userspace/host_inbound_replace_6515_test.go (new),
+  cmd/cli/zone_hostinbound_replace_6515_test.go (new),
+  pkg/config/host_inbound_view_3654_test.go,
+  pkg/config/host_inbound_fulladmit_warn_3226_test.go,
+  pkg/dataplane/userspace/host_inbound_per_iface_3362_test.go,
+  pkg/dataplane/userspace/host_inbound_baseunit0_5699_test.go,
+  pkg/dataplane/userspace/host_inbound_view_grouping_3721_test.go,
+  pkg/dataplane/userspace/host_inbound_classify_iface_5579_test.go

--- a/cmd/cli/show_security.go
+++ b/cmd/cli/show_security.go
@@ -193,13 +193,18 @@ func zoneHostInboundView(z *pb.ZoneInfo) config.HostInboundView {
 		// host-inbound deny" line as the local and gRPC-text surfaces.
 		LifelineInterfaces: z.GetLifelineInterfaces(),
 	}
+	// #6515: an interface that declares a host-inbound-traffic stanza REPLACES the
+	// zone-level set, so the effective set for each of these rows is the row's own
+	// tokens. Every element of InterfaceHostInbound is by construction a ref that
+	// declares one (the server projects SortedInterfaceHostInboundRefs), which is
+	// why `overridden` is unconditionally true here.
 	for _, ih := range z.GetInterfaceHostInbound() {
 		v.Interfaces = append(v.Interfaces, config.InterfaceHostInboundView{
 			Interface:               ih.GetInterface(),
 			SystemServices:          ih.GetSystemServices(),
 			Protocols:               ih.GetProtocols(),
-			EffectiveSystemServices: config.UnionHostInboundTokens(z.GetHostInboundSystemServices(), ih.GetSystemServices()),
-			EffectiveProtocols:      config.UnionHostInboundTokens(z.GetHostInboundProtocols(), ih.GetProtocols()),
+			EffectiveSystemServices: config.EffectiveHostInboundTokens(z.GetHostInboundSystemServices(), ih.GetSystemServices(), true),
+			EffectiveProtocols:      config.EffectiveHostInboundTokens(z.GetHostInboundProtocols(), ih.GetProtocols(), true),
 		})
 	}
 	return v

--- a/cmd/cli/zone_hostinbound_replace_6515_test.go
+++ b/cmd/cli/zone_hostinbound_replace_6515_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// TestZoneHostInboundViewReplacesZoneSet_6515 binds the REMOTE CLI's projection
+// to the same zone↔interface rule the local CLI, the gRPC text surface and the
+// enforcement path use (#6515): a per-interface `host-inbound-traffic` stanza
+// REPLACES the zone-level stanza on that interface.
+//
+// The remote CLI is the one surface that cannot ask the config — it re-derives
+// the effective set client-side from the structured GetZones response, so it is
+// also the one surface a change to the resolver can silently leave behind. It
+// did before this test existed: reverting this call site to a union kept every
+// cmd/cli test green. An operator reading `show security zones` over the remote
+// CLI would then be told SSH is admitted on an interface the firewall drops it
+// on — worse than no output at all.
+//
+// Every element of InterfaceHostInbound is by construction a ref that declares a
+// stanza (the server projects SortedInterfaceHostInboundRefs), which is why the
+// projection passes overridden=true unconditionally.
+func TestZoneHostInboundViewReplacesZoneSet_6515(t *testing.T) {
+	z := &pb.ZoneInfo{
+		Name:                      "trust",
+		HostInboundSystemServices: []string{"ssh", "ping"},
+		HostInboundProtocols:      []string{"ospf"},
+		InterfaceHostInbound: []*pb.InterfaceHostInbound{{
+			Interface:      "ge-0/0/9.0",
+			Configured:     true,
+			SystemServices: []string{"https"},
+		}},
+	}
+	v := zoneHostInboundView(z)
+	if len(v.Interfaces) != 1 {
+		t.Fatalf("projected %d interface rows, want 1", len(v.Interfaces))
+	}
+	row := v.Interfaces[0]
+	if got := strings.Join(row.EffectiveSystemServices, ","); got != "https" {
+		t.Errorf("effective system-services = %q, want %q: the interface stanza REPLACES the "+
+			"zone's [ssh ping] (#6515), it does not add to it", got, "https")
+	}
+	if len(row.EffectiveProtocols) != 0 {
+		t.Errorf("effective protocols = %v, want none: the WHOLE zone stanza is replaced, so "+
+			"the zone's `ospf` does not reach an interface that declares its own "+
+			"host-inbound-traffic (#6515 granularity)", row.EffectiveProtocols)
+	}
+	// The zone-level lines are unchanged: they still govern every interface that
+	// declares no stanza. Without this the test would also pass for a projection
+	// that had simply stopped carrying the zone set at all.
+	if got := strings.Join(v.ZoneSystemServices, ","); got != "ssh,ping" {
+		t.Errorf("zone system-services = %q, want %q", got, "ssh,ping")
+	}
+}

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -7194,9 +7194,10 @@ reserved for whole-dataplane selection where a rewrite shim
   the pre-#4544 read). Flat-set `SetPath` and `load merge` (FormatSet round-trip)
   both merge two same-key lines onto ONE node, so — like every entry in this
   cluster — the fail-open was reachable ONLY via the hierarchical `NewParser` /
-  `LoadOverride` shape. Distinct from the #3362/#3720 union, which merges
-  host-inbound authored at DIFFERENT granularities (zone ∪ physical ∪ unit);
-  #4544 merges repeated blocks at the SAME granularity. Regression coverage:
+  `LoadOverride` shape. Distinct from the #3362/#3720/#6515 resolution, which
+  combines host-inbound authored at DIFFERENT granularities (`physical ∪ unit`,
+  then REPLACING the zone level); #4544 merges repeated blocks at the SAME
+  granularity. Regression coverage:
   `pkg/config/host_inbound_dup_block_4544_test.go` (zone + interface two-block
   merge, cross-block dedup, single-block byte-identical guard — built with
   `NewParser` for the `LoadOverride` shape); operator doc:

--- a/docs/host-inbound-multicast.md
+++ b/docs/host-inbound-multicast.md
@@ -75,8 +75,9 @@ each routing-instance) against each interface's zone's effective
 explicit. Zone attribution reuses the dataplane's `buildInterfaceZoneMap`
 semantics (`zoneIfaceLogicalKeys`: a bare zone member `reth0` claims every
 configured unit `reth0.10`), and the effective admission set reuses
-`ZoneConfig.InterfaceHostInboundEffective` (zone-level ∪ per-interface override
-with #3720 physical-parent inheritance for logical units, `all`-expanded) — so
+`ZoneConfig.InterfaceHostInboundEffective` (the per-interface override where one
+is declared — it REPLACES the zone-level set, #6515 — with #3720 physical-parent
+inheritance for logical units, `all`-expanded) — so
 the advisory matches runtime enforcement exactly (no missed or false warnings
 on unit interfaces). Same WARN-only,
 zero-dataplane-surface doctrine (the Component A per-zone `iifname` DROP

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -1024,23 +1024,105 @@ Two observability surfaces consume it (mirroring #3698):
   aggregate — this per-interface series is strictly more sensitive and is exported
   alongside it, not in place of it.
 
-## Per-interface override precedence (#3362, #3720)
+## Per-interface override precedence (#3362, #3720, #6515)
 
-Host-inbound-traffic can be authored at three granularities, and the EFFECTIVE
-admission set for a logical unit is the **UNION** of all three (Junos
-host-inbound is additive — an interface admits a service listed at ANY level):
+Host-inbound-traffic can be authored at three granularities:
 
 1. **zone-level** — `security zones <z> host-inbound-traffic { ... }`, applies to
-   every interface in the zone;
+   every interface in the zone **that does not declare its own stanza**;
 2. **physical-interface-level** — `security zones <z> interfaces <ifN>
    host-inbound-traffic { ... }` (a bare interface ref), applies to every
    configured unit of that physical interface;
 3. **unit-level** — `security zones <z> interfaces <ifN.M>
    host-inbound-traffic { ... }`, applies only to that logical unit.
 
-So for unit `ifN.M`: `effective = zone ∪ physical(ifN) ∪ unit(ifN.M)`. A
-more-specific unit override never *replaces* a physical override — they are
-merged. Before #3720 the resolver
+Levels 2 and 3 are both the **interface level** and they UNION with each other.
+The interface level as a whole **REPLACES** the zone level:
+
+```
+effective(ifN.M) = physical(ifN) ∪ unit(ifN.M)     if either is declared
+                 = zone                             otherwise
+```
+
+`config.EffectiveHostInboundTokens` is the SSOT for that outer choice and
+`config.UnionHostInboundTokens` for the inner merge; every surface that resolves
+an interface's admission routes through the former — the kernel nft view builder
+(`BuildZoneHostInboundViews`), the per-interface classifier
+(`ClassifyHostInboundForInterface`), the commit-time advisories, the
+duplicate-host-address gate, and all six display surfaces.
+
+### Replace, not union (#6515) — UPGRADE NOTE
+
+> **This is an admission NARROWING. Read it before upgrading if any of your
+> configs author a per-interface `host-inbound-traffic` stanza.**
+
+Junos, [Security Zones](https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-zone-configuration.html):
+"You can configure these parameters at the zone level, in which case they affect
+all interfaces of the zone, or at the interface level. **(Interface configuration
+overrides that of the zone.)**"
+
+Before #6515 xpf UNIONed the two levels and asserted "Junos additive semantics"
+in-tree, so an interface stanza could only ever WIDEN admission and never narrow
+it: a zone admitting `protocols ospf` with an interface stanza admitting only
+`ping` still admitted OSPF on that interface, where Junos denies it. #6515 makes
+the interface stanza replace the zone stanza on the interfaces that declare one.
+
+**Presence, not emptiness.** An explicit `host-inbound-traffic { }` on an
+interface is a **deny-all** override, not a fallback to the zone set.
+`parseHostInboundNode` compiles a present-but-empty stanza to a non-nil empty
+struct precisely so the two are distinguishable.
+
+**The WHOLE stanza replaces, not each leaf.** An interface stanza that declares
+only `protocols` also drops the zone's `system-services`. That is the literal
+reading of the sentence above, and the community consensus states it the same way
+("if you configure anything under specific interface level, then zone-specific
+configuration doesn't apply to this interface anymore"). No vendor text was found
+describing a per-leaf inheritance, so none is implemented — a per-leaf rule would
+be a guess, and a guess that silently widens admission.
+
+**Junos's own narrowing idiom is `except`, which xpf does not implement.** The
+worked example in the Juniper topic narrows a second interface with
+`system-services all` plus `ftp except` / `http except`. xpf's schema has no
+`except` keyword, so the only way to narrow an interface here is to author the
+narrower token list directly. That is a separate parity gap, not a consequence of
+this change.
+
+**What upgrading takes away.** For every interface that declares a stanza, the
+lost set is the zone-level tokens the interface stanza does not repeat (after
+`all`-expansion). The services most likely to disappear are exactly the ones that
+hurt: `ssh`, `https`/webmgmt, `ike` (ESP/AH keep their global accept, but IKE
+udp/500,4500 is token-gated, so tunnels stop rekeying), and unicast `bgp`/`ospf`
+to the interface address.
+
+**It is not only new connections.** The #5566 conntrack reconcile
+(`buildHostInboundConntrackFlushFilter`) rebuilds its admit set from these same
+views and DELETES established kernel conntrack entries to a covered
+firewall-local address that the new set no longer admits. A narrowing commit
+therefore drops LIVE sessions to a removed service, not merely refuses new ones.
+
+**What is structurally out of scope.** Lifeline interfaces (`fxp0` / `em0` /
+`fab*` and the configured control + fabric links) are excluded from host-inbound
+deny scoping by INTERFACE, so management over `fxp0` and the HA control plane are
+unaffected by this flip. That exclusion is by interface, not by address value —
+a management address also configured on a zoned interface is NOT exempt (see
+"Lifeline exclusion is by INTERFACE, not by address value"). VRRP advertisements
+are unaffected because the views scope drops to unicast interface addresses plus
+VRRP VIPs only, and 224.0.0.18 is never in that scope.
+
+**Migration.** `validateHostInboundOverrideReplaceWarnings`
+(`pkg/config/compiler_validate_warn_host_inbound.go`) emits a commit-time
+advisory naming every `(zone, interface, lost tokens)` triple, so `commit check`
+shows the loss BEFORE the commit that would cause it. The remedy is mechanical:
+repeat the zone-level tokens in the interface stanza. It is WARN-only — the new
+behaviour is the Junos behaviour, and rejecting the config would refuse something
+Junos accepts. Lifeline interfaces and effective sets that full-admit
+(`any-service`) are skipped: nothing is lost there, and an advisory that fires on
+configs losing nothing is one operators learn to ignore.
+
+### Physical∪unit merge (#3720)
+
+A more-specific unit override never *replaces* a physical override — they are
+merged, because both are interface-level statements. Before #3720 the resolver
 (`buildInterfaceHostInboundMap`, `pkg/dataplane/userspace/zones.go`) walked refs
 in sorted order and wrote each key first-writer-wins; a bare physical ref sorts
 before (is a prefix of) its units, so it filled `out["ifN.M"]` first and the
@@ -1073,8 +1155,9 @@ enforce the owner predicate `zoneByIface[ref] == zn`:
 **Presentation parity (#3720 H05).** `ZoneConfig.InterfaceHostInboundEffective`
 (`pkg/config/host_inbound_view.go`) — used by `show interfaces <unit>`, `show
 security zones`, and the gRPC interface diagnostic — folds the physical-parent
-override into a unit ref's effective set with the same additive rule, so the
-operator diagnostic agrees with what the dataplane admits. Before #3720 it read
+override into a unit ref's effective set with the same within-level union rule
+(and then replaces the zone level with it, #6515), so the operator diagnostic
+agrees with what the dataplane admits. Before #3720 it read
 only the exact ref and reported "no override / default-deny" for a unit that in
 fact inherited a physical override.
 
@@ -1094,8 +1177,9 @@ false-deny (the base view's narrower set drops a service the unit-0 override
 opened). The fix skips the base (physical) snapshot's host-inbound address
 contribution when unit 0 is configured: unit 0's snapshot is the authoritative
 carrier (its merged override matches enforcement and `InterfaceHostInboundEffective`),
-so the address resolves to ONE view carrying the additive `zone ∪ physical ∪
-unit-0` admit set. The skip is gated on the ACTUAL same-netdev collapse
+so the address resolves to ONE view carrying the `physical ∪ unit-0` admit set
+(which post-#6515 replaces the zone level; before #6515 it was `zone ∪ physical ∪
+unit-0`). The skip is gated on the ACTUAL same-netdev collapse
 (`snapshotLinuxName(base, unit0) == snapshotLinuxName(base, nil)`), NOT merely
 "unit 0 exists": a VLAN unit 0 (`VlanID > 0` → Linux `<base>.<vlan>`) or a
 tunnel-mapped unit 0 resolves to a DISTINCT netdev, so the base and unit-0
@@ -1109,8 +1193,12 @@ address is never dropped from the deny scope.
 **Gate alignment.** The commit-time duplicate-address gate
 (`buildHostInboundOverrideMapLocal` +
 `validateDuplicateHostLocalAddressStrict`, `pkg/config/dup_host_local_address.go`)
-mirrors the same additive resolution and quarantine, so the
+mirrors the same resolution and quarantine — `effectiveHostInboundSigLocal`
+delegates to `EffectiveHostInboundTokens` — so the
 `CanonicalHostInboundTokenSig` it compares equals the runtime's effective set.
+That matters here specifically: the gate rejects two zones claiming one
+firewall-local address with DIFFERING admission, so a signature built from a
+different combination rule than enforcement uses would compare the wrong sets.
 
 ## Multi-member bracket body applies to every member (#6391) — UPGRADE NOTE
 
@@ -1236,9 +1324,10 @@ unchanged, with no dedup, so a single block keeps its exact token multiset;
 dedup applies only when a second block is actually merged. RED-on-revert guards:
 `pkg/config/host_inbound_dup_block_4544_test.go`.
 
-This is orthogonal to the "Per-interface override precedence (#3362, #3720)"
-union above, which merges host-inbound authored at DIFFERENT granularities
-(zone ∪ physical ∪ unit). #4544 merges repeated blocks at the SAME granularity.
+This is orthogonal to the "Per-interface override precedence (#3362, #3720,
+#6515)" section above, which resolves host-inbound authored at DIFFERENT
+granularities (`physical ∪ unit`, then REPLACING the zone level). #4544 merges
+repeated blocks at the SAME granularity.
 
 **#4818 extends this merge one level UP.** #4544 merges repeated
 `host-inbound-traffic {}` blocks *within one* `security-zone <name> {}`
@@ -1407,7 +1496,8 @@ helper never sees it, so a helper crash cannot lock management out).
   shield must carve TCP/113 out (`HostInboundServiceTokenExpansion`).
   - **Per-interface scope of the IKE / ident shield (#5565).** The shield is
     scoped to the SPECIFIC netdevs whose EFFECTIVE per-interface host-inbound set
-    (`InterfaceHostInboundEffective`, zone-level ∪ interface override) admits the
+    (`InterfaceHostInboundEffective`: the interface override where declared,
+    else the zone-level set — #6515) admits the
     exemption — `JunosHostDenyProgram.IKEExemptNetdevs` / `IdentResetNetdevs`,
     each a subset of the program's `IngressNetdevs`. A per-INTERFACE `ike` /
     `ident-reset` override therefore shields only the interface(s) that configured

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -716,8 +716,11 @@ From zone: guest, To zone: lan
     the zone) AND the interface level (`set security zones security-zone <z>
     interfaces <if> host-inbound-traffic ...`, applies only to that interface).
     xpf now supports the interface-level stanza; the EFFECTIVE admission set for
-    an interface is the UNION of the zone-level set and its interface-level
-    override (Junos additive semantics). A zone is host-inbound-ENFORCING when it
+    an interface is its interface-level stanza when it declares one, otherwise
+    the zone-level set — the interface stanza REPLACES the zone stanza (#6515;
+    Junos: "Interface configuration overrides that of the zone"), and an
+    explicitly EMPTY interface stanza is a deny-all override, not a fallback.
+    A zone is host-inbound-ENFORCING when it
     declares a zone-level stanza OR any interface-level override — so an operator
     can expose a service (e.g. `ssh`) on one interface of a zone while denying it
     on the others by setting the override only on the exposed interface and
@@ -1059,7 +1062,8 @@ and report on the FIRST admitting view, so it certified a zone-wide
 DENIES — a false-admission diagnosis. Two changes remove it:
 
 - `ingress-interface <if>` scopes the host-inbound classification to ONE
-  interface's EFFECTIVE view (zone-level ∪ that interface's override), so the
+  interface's EFFECTIVE view (that interface's override where declared, which
+  REPLACES the zone-level set — #6515 — else the zone-level set), so the
   reported admission is that interface's TRUE posture (admit vs deny), not a
   zone-wide fold. The ref must name an interface assigned to `from-zone`; an
   unknown, zone-mismatched, or management/cluster lifeline (fxp0/em0/fab*) ref is

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -193,8 +193,8 @@ liveness/readiness. Prometheus metrics endpoint. SSE event streams.
     deny-all; kept split so a system-service such as ssh/ping/dhcp is
     distinguishable from a routing protocol such as ospf/bgp), plus any
     `interface_host_inbound` per-interface override (#3362, omitted when
-    none; the effective set for an interface is the union of the zone-level
-    set and its override). The legacy flattened `host_inbound_services`
+    none; the effective set for such an interface IS the override — it REPLACES
+    the zone-level set, #6515). The legacy flattened `host_inbound_services`
     (services + protocols concatenated) is retained as a back-compat alias.
     Before #3653 the bit was re-derived from config shape and reported
     `false` for a no-stanza zone — the pre-#3405 "false = admit-all"

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -148,7 +148,7 @@ type ZoneInfo struct {
 	// InterfaceHostInbound (#3328, #3362) carries per-interface host-inbound
 	// overrides. An entry exists only for an interface that declares its own
 	// `host-inbound-traffic` stanza; the effective admission set for that
-	// interface is the UNION of the zone-level set above and the override.
+	// interface IS the override — it REPLACES the zone-level set above (#6515).
 	// Omitted when no interface declares an override.
 	InterfaceHostInbound []ZoneInterfaceHostInbound `json:"interface_host_inbound,omitempty"`
 	IngressPackets       uint64                     `json:"ingress_packets"`

--- a/pkg/cli/cli_show_interfaces.go
+++ b/pkg/cli/cli_show_interfaces.go
@@ -350,10 +350,11 @@ func (c *CLI) showInterfaces(args []string) error {
 			fmt.Printf("    Security: Zone: %s\n", li.zoneName)
 
 			// Host-inbound traffic services (#3654 H05/M03): show the EFFECTIVE
-			// admitted set for THIS logical interface — the UNION of the zone
-			// set and any per-interface override — flag an interface-local
-			// override, and print an explicit default-deny posture line so a
-			// blank section is never misread as "not enforced".
+			// admitted set for THIS logical interface — its per-interface
+			// override where one is declared (which REPLACES the zone set,
+			// #6515), else the zone set — flag an interface-local override, and
+			// print an explicit default-deny posture line so a blank section is
+			// never misread as "not enforced".
 			if li.zone != nil {
 				svc, proto, overridden := li.zone.InterfaceHostInboundEffective(li.ifaceRef)
 				// #3682: a management / cluster-control lifeline interface is

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -521,13 +521,13 @@ func ValidateConfig(cfg *Config) []string {
 			}
 		}
 		// #3226 fold: every advisory below reasons about the EFFECTIVE token
-		// set — the zone-level list UNION the per-interface override, via the
-		// shared UnionHostInboundTokens — because that is what enforcement acts
-		// on (Junos host-inbound is additive across the two levels). Reasoning
-		// per RAW STANZA made the advisories contradict enforcement AND each
-		// other: a zone `any-service` with a per-interface `rpm` warned that rpm
-		// was DENIED when the union full-admits it. Sharing the union removes
-		// the whole class rather than special-casing each pair.
+		// set — via the shared EffectiveHostInboundTokens — because that is what
+		// enforcement acts on. Reasoning per RAW STANZA made the advisories
+		// contradict enforcement AND each other: a zone `any-service` with a
+		// per-interface `rpm` warned that rpm was DENIED when the effective set
+		// admits everything. Sharing the resolver removes the whole class rather
+		// than special-casing each pair. Post-#6515 that resolver REPLACES the
+		// zone level with a declared interface stanza rather than unioning them.
 		var zoneSvcs []string
 		if zone.HostInboundTraffic != nil {
 			zoneSvcs = zone.HostInboundTraffic.SystemServices
@@ -544,15 +544,20 @@ func ValidateConfig(cfg *Config) []string {
 			}
 			return false
 		}
-		// The zone-level stanza governs every interface that does NOT override.
-		// If EVERY interface in the zone overrides with a full-admit, the
-		// zone-level narrowing is unobservable and its advisories are moot too.
+		// The zone-level stanza governs every interface that does NOT declare its
+		// own host-inbound-traffic stanza. #6515: an interface that declares one
+		// REPLACES the zone set, so if EVERY interface in the zone declares one,
+		// the zone-level tokens reach nothing and their advisories are moot.
+		// (Before #6515 the levels unioned, so only a full-admit override could
+		// make the zone-level narrowing unobservable — a strictly narrower
+		// condition.) The lookup is the exact ref, so a unit that merely INHERITS
+		// a physical-parent override is not counted here and the advisory is still
+		// emitted: erring toward showing an advisory, never toward hiding one.
 		zoneObservable := !effectiveFullAdmits(zoneSvcs)
 		if zoneObservable && len(zone.Interfaces) > 0 {
 			allCovered := true
 			for _, ifRef := range zone.Interfaces {
-				hi := zone.InterfaceHostInbound[CanonicalInterfaceUnitRef(ifRef)]
-				if hi == nil || !effectiveFullAdmits(hi.SystemServices) {
+				if zone.InterfaceHostInbound[CanonicalInterfaceUnitRef(ifRef)] == nil {
 					allCovered = false
 					break
 				}
@@ -579,8 +584,9 @@ func ValidateConfig(cfg *Config) []string {
 			}
 			where := fmt.Sprintf("zone %q interface %q host-inbound-traffic", name, ifRef)
 			// The EFFECTIVE set for this interface, exactly as the dataplane
-			// enforcement view builder computes it.
-			effective := UnionHostInboundTokens(zoneSvcs, hi.SystemServices)
+			// enforcement view builder computes it — post-#6515 the override
+			// REPLACES the zone-level set rather than adding to it.
+			effective := EffectiveHostInboundTokens(zoneSvcs, hi.SystemServices, true)
 			// The full-admit notice stays keyed on the OVERRIDE's own tokens: it
 			// reports what this stanza declares, and a zone-level `any-service`
 			// already drew its own notice at the zone level.
@@ -1888,6 +1894,7 @@ func ValidateConfig(cfg *Config) []string {
 	// host-bound multicast PACKET-WIDE (not scoped to the zone's ingress
 	// interface). Surface that Junos-parity/hardening gap at commit; the per-zone
 	// iifname enforcement remains deferred.
+	warnings = append(warnings, validateHostInboundOverrideReplaceWarnings(cfg)...)
 	warnings = append(warnings, validateHostInboundMulticastWarnings(cfg)...)
 	warnings = append(warnings, validateHostInboundManagedRoutingMismatch(cfg)...)
 

--- a/pkg/config/compiler_validate_warn_host_inbound.go
+++ b/pkg/config/compiler_validate_warn_host_inbound.go
@@ -101,7 +101,8 @@ func hostInboundAdmitsRoutingProtocol(protocols []string, token string) bool {
 // commit-time WARN advisory: a managed FRR routing protocol — OSPFv2, OSPFv3, or
 // RIP, which xpf renders into FRR (pkg/frr/policy_render.go) — is enabled on an
 // interface whose security zone's EFFECTIVE `host-inbound-traffic protocols` set
-// (zone-level ∪ per-interface override, #3362 additive; `all`-expanded) OMITS
+// (the per-interface override where declared, which REPLACES the zone-level set
+// — #6515, #3362; `all`-expanded) OMITS
 // the matching token (ospf/ospf3/rip).
 //
 // This surfaces the ACTUAL silent multicast fail-open that the shipped
@@ -221,9 +222,10 @@ func validateHostInboundManagedRoutingMismatch(cfg *Config) []string {
 			if z == nil {
 				continue
 			}
-			// EFFECTIVE host-inbound protocols for this interface: zone-level ∪ the
-			// per-interface override WITH #3720 physical-parent inheritance for a
-			// logical unit — reuse the InterfaceHostInboundEffective SSOT so the
+			// EFFECTIVE host-inbound protocols for this interface: the
+			// per-interface override where declared (it REPLACES the zone-level
+			// set, #6515) WITH #3720 physical-parent inheritance for a logical
+			// unit — reuse the InterfaceHostInboundEffective SSOT so the
 			// advisory matches the dataplane's admission resolution exactly (a
 			// parent `reth0` override admitting ospf must cover unit `reth0.10`,
 			// else this warns falsely).
@@ -536,4 +538,181 @@ func validatePreIDDefaultPolicyLogWarnings(cfg *Config) []string {
 			"pre-identification session-admit path exists to emit the "+
 			"RT_FLOW session log)",
 		strings.Join(modes, "/"))}
+}
+
+// hostInboundTokenExpansion expands one host-inbound token to the set of NAMED
+// tokens it stands for, so a coverage comparison is made on what is actually
+// admitted rather than on the spelling. `all` is the only expanding token, and
+// it expands differently per kind (HostInboundAllExpansionServices vs
+// HostInboundAllExpansionProtocols), which is why the kind is a parameter rather
+// than the caller picking a helper. Returned tokens are lower-cased, matching
+// how the dataplane keys them.
+func hostInboundTokenExpansion(token string, protocols bool) []string {
+	t := strings.ToLower(strings.TrimSpace(token))
+	if t == "" {
+		return nil
+	}
+	if protocols {
+		if t == "all" {
+			out := make([]string, 0, len(HostInboundAllExpansionProtocols()))
+			for _, p := range HostInboundAllExpansionProtocols() {
+				out = append(out, strings.ToLower(p))
+			}
+			return out
+		}
+		return []string{t}
+	}
+	exp := HostInboundServiceTokenExpansion(t)
+	out := make([]string, 0, len(exp))
+	for _, e := range exp {
+		out = append(out, strings.ToLower(strings.TrimSpace(e)))
+	}
+	return out
+}
+
+// hostInboundLostTokens returns the tokens from zoneToks that the interface's
+// EFFECTIVE set no longer admits, in their authored order. A zone token is
+// "kept" only when EVERY token it expands to is admitted by the effective set,
+// so `all` at the zone level with a narrow interface stanza is reported (it is
+// genuinely narrowed) while `ssh` at the zone level with `all` on the interface
+// is not (the expansion covers it).
+func hostInboundLostTokens(zoneToks, effToks []string, protocols bool) []string {
+	if len(zoneToks) == 0 {
+		return nil
+	}
+	admitted := make(map[string]bool, len(effToks)*2)
+	for _, t := range effToks {
+		for _, e := range hostInboundTokenExpansion(t, protocols) {
+			admitted[e] = true
+		}
+	}
+	var lost []string
+	for _, zt := range zoneToks {
+		exp := hostInboundTokenExpansion(zt, protocols)
+		if len(exp) == 0 {
+			continue
+		}
+		covered := true
+		for _, e := range exp {
+			if !admitted[e] {
+				covered = false
+				break
+			}
+		}
+		if !covered {
+			lost = append(lost, zt)
+		}
+	}
+	return lost
+}
+
+// validateHostInboundOverrideReplaceWarnings emits the #6515 MIGRATION advisory:
+// one warning per zone interface whose per-interface `host-inbound-traffic`
+// stanza REPLACES a zone-level stanza that admitted more than it does.
+//
+// #6515 changed the zone↔interface combination from a union to a replace, to
+// match Junos ("You can configure these parameters at the zone level, in which
+// case they affect all interfaces of the zone, or at the interface level.
+// (Interface configuration overrides that of the zone.)"). That is a NARROWING
+// for any config authored against the previous additive behaviour: an interface
+// stanza that was written to ADD `protocols ospf` to a zone admitting `ssh` now
+// admits ospf and NOTHING ELSE on that interface. The services most likely to
+// disappear are exactly the ones an operator cannot afford to lose silently —
+// ssh, https/webmgmt, ike (ESP/AH are globally accepted but IKE udp/500,4500 is
+// token-gated, so tunnels stop rekeying), and unicast bgp/ospf to the interface
+// address.
+//
+// It is worse than "new connections are refused": the #5566 reconcile rebuilds
+// its admit set from the same views and DELETES established kernel conntrack
+// entries to a covered firewall-local address the new set no longer admits, so a
+// narrowing commit drops the operator's LIVE session to a removed service. This
+// advisory therefore names every lost token at `commit check`, BEFORE the commit
+// that would remove it, and tells the operator the mechanical remedy: repeat the
+// zone tokens in the interface stanza.
+//
+// WARN-only, never a reject: the config is valid Junos and the new behaviour IS
+// the Junos behaviour. Rejecting it would refuse a config Junos accepts.
+//
+// Scope. Emitted per ZONE INTERFACE rather than per authored stanza, because a
+// unit that merely INHERITS a physical-parent override (#3720) also loses the
+// zone tokens and the operator needs to see the interface whose admission
+// actually changed. Lifeline interfaces (fxp0 / em0 / fab* / the configured
+// control + fabric links) are skipped: they are excluded from host-inbound deny
+// scoping entirely, so nothing is lost on them and an advisory would be a false
+// alarm. An effective set that full-admits (`any-service`) loses nothing and is
+// skipped for the same reason.
+func validateHostInboundOverrideReplaceWarnings(cfg *Config) []string {
+	if cfg == nil || cfg.Security.Zones == nil {
+		return nil
+	}
+	lifelines := HostInboundLifelineSet(cfg)
+	names := make([]string, 0, len(cfg.Security.Zones))
+	for name := range cfg.Security.Zones {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var warnings []string
+	for _, name := range names {
+		zone := cfg.Security.Zones[name]
+		if zone == nil || zone.HostInboundTraffic == nil {
+			continue // no zone-level stanza => nothing an override can replace
+		}
+		zoneSvc := zone.HostInboundTraffic.SystemServices
+		zoneProto := zone.HostInboundTraffic.Protocols
+		if len(zoneSvc) == 0 && len(zoneProto) == 0 {
+			continue
+		}
+		refs := make([]string, 0, len(zone.Interfaces))
+		seen := make(map[string]bool, len(zone.Interfaces))
+		for _, ref := range zone.Interfaces {
+			if ref == "" || seen[ref] {
+				continue
+			}
+			seen[ref] = true
+			refs = append(refs, ref)
+		}
+		sort.Strings(refs)
+		for _, ref := range refs {
+			if HostInboundLifelineInterface(ref, lifelines) {
+				continue
+			}
+			effSvc, effProto, overridden := zone.InterfaceHostInboundEffective(ref)
+			if !overridden {
+				continue
+			}
+			fullAdmit := false
+			for _, s := range effSvc {
+				if HostInboundFullAdmitService(s) {
+					fullAdmit = true
+					break
+				}
+			}
+			if fullAdmit {
+				continue
+			}
+			lostSvc := hostInboundLostTokens(zoneSvc, effSvc, false)
+			lostProto := hostInboundLostTokens(zoneProto, effProto, true)
+			if len(lostSvc) == 0 && len(lostProto) == 0 {
+				continue
+			}
+			var lost []string
+			if len(lostSvc) > 0 {
+				lost = append(lost, "system-services ["+strings.Join(lostSvc, " ")+"]")
+			}
+			if len(lostProto) > 0 {
+				lost = append(lost, "protocols ["+strings.Join(lostProto, " ")+"]")
+			}
+			warnings = append(warnings, fmt.Sprintf(
+				"zone %q interface %q: the per-interface host-inbound-traffic "+
+					"stanza REPLACES the zone-level stanza on this interface "+
+					"(Junos: \"Interface configuration overrides that of the "+
+					"zone\"), so host-bound %s admitted by zone %q is DENIED "+
+					"here. Repeat those tokens in the interface stanza to keep "+
+					"admitting them. Established sessions to a removed service "+
+					"are flushed at commit, not merely refused for new "+
+					"connections (#6515, #5566).",
+				name, ref, strings.Join(lost, " and "), name))
+		}
+	}
+	return warnings
 }

--- a/pkg/config/dup_host_local_address.go
+++ b/pkg/config/dup_host_local_address.go
@@ -194,7 +194,8 @@ func mergeHostInboundOverrideLocal(a, b *HostInboundTraffic) *HostInboundTraffic
 // override is expanded onto each of its configured units (skipping a unit owned
 // by a DIFFERENT zone — #3720 M01) and MERGED (unioned) with any unit-level
 // override rather than the sorted-first physical ref shadowing the unit (the
-// #3720 first-writer-wins bug). Rebuilt locally because pkg/config cannot import
+// #3720 first-writer-wins bug) — both are interface-level statements, so they
+// union with each other even though the result REPLACES the zone level (#6515). Rebuilt locally because pkg/config cannot import
 // pkg/dataplane; the effective set it produces per unit therefore matches the
 // runtime builder exactly, so the commit gate and the runtime reporter classify
 // the same unit identically.
@@ -226,7 +227,8 @@ func buildHostInboundOverrideMapLocal(cfg *Config) map[string]*HostInboundTraffi
 			}
 			if strings.Contains(ref, ".") {
 				// Logical unit ref: most specific — merge onto any physical-
-				// inherited set (Junos additive), exact match only.
+				// inherited set (both are INTERFACE-level statements and union
+				// with each other, #3720), exact match only.
 				out[ref] = mergeHostInboundOverrideLocal(out[ref], hib)
 				continue
 			}
@@ -248,22 +250,29 @@ func buildHostInboundOverrideMapLocal(cfg *Config) map[string]*HostInboundTraffi
 }
 
 // effectiveHostInboundSigLocal returns the canonical signature of the EFFECTIVE
-// host-inbound admission set for one interface unit: the zone-level set UNION
-// the per-interface override (#3362, Junos additive), canonicalized. It mirrors
-// pkg/dataplane/userspace.unionHostInboundTokens feeding
-// CanonicalHostInboundTokenSig, so the commit gate and the runtime reporter
-// classify the same unit identically.
+// host-inbound admission set for one interface unit: the per-interface override
+// when the unit declares one, else the zone-level set (#3362; #6515 replace
+// semantics). It mirrors pkg/dataplane/userspace.effectiveHostInboundTokens
+// feeding CanonicalHostInboundTokenSig, so the commit gate and the runtime
+// reporter classify the same unit identically — the whole point of this gate is
+// that two zones claiming one firewall-local address with DIFFERING admission is
+// rejected, and a signature computed from a different combination rule than
+// enforcement uses would compare the wrong sets.
 func effectiveHostInboundSigLocal(zone *ZoneConfig, override *HostInboundTraffic) string {
-	var svc, proto []string
+	var zoneSvc, zoneProto []string
 	if zone != nil && zone.HostInboundTraffic != nil {
-		svc = append(svc, zone.HostInboundTraffic.SystemServices...)
-		proto = append(proto, zone.HostInboundTraffic.Protocols...)
+		zoneSvc = zone.HostInboundTraffic.SystemServices
+		zoneProto = zone.HostInboundTraffic.Protocols
 	}
+	var ovSvc, ovProto []string
 	if override != nil {
-		svc = append(svc, override.SystemServices...)
-		proto = append(proto, override.Protocols...)
+		ovSvc = override.SystemServices
+		ovProto = override.Protocols
 	}
-	return CanonicalHostInboundTokenSig(svc, proto)
+	overridden := override != nil
+	return CanonicalHostInboundTokenSig(
+		EffectiveHostInboundTokens(zoneSvc, ovSvc, overridden),
+		EffectiveHostInboundTokens(zoneProto, ovProto, overridden))
 }
 
 // validateDuplicateHostLocalAddressStrict implements the #3718 Option B

--- a/pkg/config/host_inbound_fulladmit_warn_3226_test.go
+++ b/pkg/config/host_inbound_fulladmit_warn_3226_test.go
@@ -532,23 +532,32 @@ func TestHostInboundMatrixDocDoesNotAdviseTheRefutedRemedy(t *testing.T) {
 // Test_3226_AdvisoriesReasonAboutTheEffectiveTokenSet pins the STRUCTURAL fix
 // for a family of self-contradicting advisory pairs.
 //
-// Junos host-inbound is ADDITIVE across the zone and interface levels: an
-// interface admits a service when EITHER level lists it, and the dataplane
-// enforcement view is built from that union. The commit advisories used to run
+// The commit advisories must reason about the same EFFECTIVE token set the
+// dataplane enforcement view is built from (post-#6515: the interface stanza
+// where one is declared, else the zone stanza). They used to run
 // per RAW STANZA, so they reasoned about a different object than the enforcer
 // and emitted advice that contradicted it — and contradicted each other in the
 // same commit output. Three shapes, all closed here:
 //
 //	any-service + all in ONE stanza      -> "everything is admitted" together
 //	                                        with "ports are now DENIED".
-//	zone any-service + interface rpm     -> "rpm is DENIED, add any-service"
-//	                                        when the union already full-admits.
-//	zone rpm + interface any-service     -> same, in the other direction.
+//	zone rpm + interface any-service     -> "rpm is DENIED, add any-service"
+//	                                        when the effective set already
+//	                                        full-admits.
 //
 // Fixing those case by case would have left the two views diverging, so the
-// advisories now consume config.UnionHostInboundTokens — the same union the
-// dataplane builder uses — and suppress the scoping / unported notices whenever
-// the EFFECTIVE set full-admits.
+// advisories now consume config.EffectiveHostInboundTokens — the same resolver
+// the dataplane builder uses — and suppress the scoping / unported notices
+// whenever the EFFECTIVE set full-admits.
+//
+// #6515 retired the third shape (zone any-service + interface rpm). Under the
+// old ADDITIVE combination that interface's effective set was
+// zone{any-service} ∪ iface{rpm}, a full-admit, so the "rpm is DENIED" notice
+// contradicted it. Under REPLACE the interface is described entirely by its own
+// stanza, so the effective set really is {rpm} and rpm really IS denied there —
+// the advisory is now correct and must fire. That subtest is kept and inverted
+// rather than deleted: it is the case that distinguishes the two combination
+// rules, so it is the one worth pinning.
 //
 // FAIL-ON-REVERT: drop the effectiveFullAdmits gates, or go back to passing the
 // raw per-stanza token lists, and the contradicting pair reappears.
@@ -587,10 +596,22 @@ func Test_3226_AdvisoriesReasonAboutTheEffectiveTokenSet(t *testing.T) {
 			"set security zones security-zone wan interfaces ge-0/0/0.0",
 			"set security zones security-zone wan host-inbound-traffic system-services any-service",
 			"set security zones security-zone wan interfaces ge-0/0/0.0 host-inbound-traffic system-services rpm")
-		if got := hostInboundUnportedWarnings(cfg); len(got) != 0 {
-			t.Errorf("the interface's EFFECTIVE set is zone{any-service} + iface{rpm}, which "+
-				"full-admits — rpm traffic is NOT denied there, so the unported advisory must "+
-				"not fire, got: %v", got)
+		// #6515 INVERSION. The interface declares its own stanza, so its
+		// effective set is {rpm} — the zone's any-service is REPLACED, not
+		// added to. rpm has no platform default port, so it genuinely IS
+		// denied on this interface and the unported advisory is telling the
+		// truth. Before #6515 the effective set was the union (a full-admit)
+		// and the same advisory was a contradiction. Asserting the advisory
+		// FIRES here is what makes this subtest discriminate replace from
+		// union at all; asserting it stays silent would pass under both.
+		got := hostInboundUnportedWarnings(cfg)
+		if len(got) != 1 {
+			t.Fatalf("the interface's EFFECTIVE set is iface{rpm} (the zone's any-service is "+
+				"REPLACED, #6515), so rpm IS denied there and the unported advisory must "+
+				"fire exactly once, got %d: %v", len(got), got)
+		}
+		if !strings.Contains(got[0], "ge-0/0/0.0") {
+			t.Errorf("the unported advisory must name the interface whose stanza denies rpm, got: %v", got)
 		}
 	})
 
@@ -642,25 +663,34 @@ func Test_3226_AdvisoriesReasonAboutTheEffectiveTokenSet(t *testing.T) {
 // because the two computed it separately; a shared helper only removes the class
 // while it actually stays shared.
 //
-// config.UnionHostInboundTokens is the SSOT. The dataplane builder
-// (pkg/dataplane/userspace unionHostInboundTokens) delegates to it, differing
-// only by lower-casing for map keying — which cannot change MEMBERSHIP, because
-// every predicate the advisories apply to the union is case-insensitive.
+// The SSOT is config.EffectiveHostInboundTokens for the zone↔interface
+// combination, and config.UnionHostInboundTokens for merging tokens authored at
+// the SAME level (the #3720 physical→unit resolution, #4544 repeated blocks).
+// The dataplane builder (pkg/dataplane/userspace effectiveHostInboundTokens)
+// delegates to the former, differing only by lower-casing for map keying — which
+// cannot change MEMBERSHIP, because every predicate the advisories apply is
+// case-insensitive.
 //
-// FAIL-ON-REVERT: give either side its own union and the additive/order/dedup
-// properties asserted here stop matching.
+// The table below is the within-level UNION. #6515: it is NOT the zone↔interface
+// rule any more, so a case here named "additive across levels" would be a false
+// claim about a real behaviour — the cases are named for what they are, merges of
+// two same-level lists. The zone↔interface rule has its own table in
+// host_inbound_replace_6515_test.go.
+//
+// FAIL-ON-REVERT: give either side its own merge and the order/dedup properties
+// asserted here stop matching.
 func Test_3226_AdvisoryUnionIsTheEnforcementUnion(t *testing.T) {
 	cases := []struct {
 		name        string
 		zone, iface []string
 		want        []string
 	}{
-		{"additive across levels", []string{"ssh"}, []string{"rpm"}, []string{"ssh", "rpm"}},
-		{"zone tokens keep authored order first", []string{"ping", "ssh"}, []string{"rpm"}, []string{"ping", "ssh", "rpm"}},
+		{"both lists merge", []string{"ssh"}, []string{"rpm"}, []string{"ssh", "rpm"}},
+		{"first list keeps authored order first", []string{"ping", "ssh"}, []string{"rpm"}, []string{"ping", "ssh", "rpm"}},
 		{"exact duplicates collapse", []string{"ssh"}, []string{"ssh", "rpm"}, []string{"ssh", "rpm"}},
 		{"empties skipped", []string{"ssh", ""}, []string{" "}, []string{"ssh"}},
-		{"nil override is the zone set", []string{"ssh"}, nil, []string{"ssh"}},
-		{"nil zone is the override set", nil, []string{"rpm"}, []string{"rpm"}},
+		{"nil second list is the first", []string{"ssh"}, nil, []string{"ssh"}},
+		{"nil first list is the second", nil, []string{"rpm"}, []string{"rpm"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -676,23 +706,34 @@ func Test_3226_AdvisoryUnionIsTheEnforcementUnion(t *testing.T) {
 			}
 		})
 	}
-	// The property the advisories actually depend on: a full-admit token
-	// anywhere in EITHER level is a full-admit in the union, whatever its case.
-	for _, tc := range []struct{ zone, iface []string }{
-		{[]string{"any-service"}, []string{"rpm"}},
-		{[]string{"rpm"}, []string{"any-service"}},
-		{[]string{"rpm"}, []string{"ANY-SERVICE"}},
+	// The property the advisories actually depend on, stated against the
+	// zone↔interface resolver rather than the union: whether the EFFECTIVE set
+	// full-admits, whatever the token's case. #6515 moved two of these three
+	// cases — a full-admit at the ZONE level no longer survives an interface
+	// stanza, because that stanza replaces it.
+	for _, tc := range []struct {
+		zone, iface []string
+		overridden  bool
+		wantFull    bool
+	}{
+		{[]string{"any-service"}, nil, false, true},
+		{[]string{"rpm"}, []string{"any-service"}, true, true},
+		{[]string{"rpm"}, []string{"ANY-SERVICE"}, true, true},
+		// #6515: the zone full-admit does NOT reach an interface that declares
+		// its own stanza. This case is the one that separates replace from
+		// union, so it is asserted in both directions.
+		{[]string{"any-service"}, []string{"rpm"}, true, false},
 	} {
 		full := false
-		for _, svc := range UnionHostInboundTokens(tc.zone, tc.iface) {
+		for _, svc := range EffectiveHostInboundTokens(tc.zone, tc.iface, tc.overridden) {
 			if HostInboundFullAdmitService(svc) {
 				full = true
 			}
 		}
-		if !full {
-			t.Errorf("union of zone %v + iface %v must be recognized as full-admit — the "+
+		if full != tc.wantFull {
+			t.Errorf("effective set of zone %v + iface %v (overridden=%v) full-admit = %v, want %v — the "+
 				"advisory suppression and the dataplane short-circuit both key on this",
-				tc.zone, tc.iface)
+				tc.zone, tc.iface, tc.overridden, full, tc.wantFull)
 		}
 	}
 }

--- a/pkg/config/host_inbound_replace_6515_test.go
+++ b/pkg/config/host_inbound_replace_6515_test.go
@@ -1,0 +1,219 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6515: the zone-level `host-inbound-traffic` stanza and a per-interface one do
+// not COMBINE — the interface stanza REPLACES the zone stanza for that
+// interface. Juniper, Security Zones (security-zone-configuration): "You can
+// configure these parameters at the zone level, in which case they affect all
+// interfaces of the zone, or at the interface level. (Interface configuration
+// overrides that of the zone.)"
+//
+// Before #6515 the two were UNIONed and the in-tree comments asserted "Junos
+// additive semantics", so an interface stanza could only ever WIDEN admission.
+
+// TestEffectiveHostInboundTokens_6515 is the resolver table. The `overridden`
+// column is the whole point: it is stanza PRESENCE, not emptiness, so an
+// explicit `host-inbound-traffic { }` on an interface is a deny-all override and
+// must not fall back to the zone set.
+func TestEffectiveHostInboundTokens_6515(t *testing.T) {
+	cases := []struct {
+		name        string
+		zone, iface []string
+		overridden  bool
+		want        []string
+	}{
+		{"no override falls back to the zone set", []string{"ssh", "ping"}, nil, false, []string{"ssh", "ping"}},
+		{"override replaces the zone set", []string{"ssh", "ping"}, []string{"https"}, true, []string{"https"}},
+		{"override does not inherit unlisted zone tokens", []string{"ssh"}, []string{"ospf"}, true, []string{"ospf"}},
+		{"empty override is deny-all, not a fallback", []string{"ssh"}, nil, true, nil},
+		{"empty override with empty zone stays empty", nil, nil, true, nil},
+		{"no override and no zone set is empty", nil, nil, false, nil},
+		{"override is normalized (trim, dedup, drop empties)", []string{"ssh"}, []string{"https", " https ", ""}, true, []string{"https"}},
+		{"zone set is normalized when it is the answer", []string{"ssh", "ssh", " "}, nil, false, []string{"ssh"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EffectiveHostInboundTokens(tc.zone, tc.iface, tc.overridden)
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Fatalf("EffectiveHostInboundTokens(%v, %v, %v) = %v, want %v",
+					tc.zone, tc.iface, tc.overridden, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestInterfaceHostInboundEffectiveReplacesZoneNotInterfaceLevels_6515 pins the
+// two rules apart. #6515 replaced the ZONE level; it did not touch how a
+// physical-interface override and a unit-level override combine WITH EACH OTHER
+// (#3720) — both are interface-level statements and still union.
+//
+// Written as one fixture carrying all three levels so a regression in either
+// direction is visible: collapsing the physical∪unit union would drop `ping`,
+// and reverting the zone replace would add `ssh`.
+func TestInterfaceHostInboundEffectiveReplacesZoneNotInterfaceLevels_6515(t *testing.T) {
+	z := &ZoneConfig{
+		HostInboundTraffic: &HostInboundTraffic{SystemServices: []string{"ssh"}},
+		InterfaceHostInbound: map[string]*HostInboundTraffic{
+			"ge-0/0/9":   {SystemServices: []string{"ping"}},
+			"ge-0/0/9.0": {SystemServices: []string{"https"}},
+		},
+	}
+	svc, _, overridden := z.InterfaceHostInboundEffective("ge-0/0/9.0")
+	if !overridden {
+		t.Fatal("ge-0/0/9.0 declares an override (and inherits its physical parent's)")
+	}
+	got := strings.Join(svc, ",")
+	if got != "ping,https" {
+		t.Fatalf("effective svc = %v, want [ping https]: the physical and unit overrides are "+
+			"both INTERFACE-level and still union (#3720), while the zone's `ssh` is "+
+			"REPLACED (#6515)", svc)
+	}
+	for _, s := range svc {
+		if s == "ssh" {
+			t.Fatalf("effective svc = %v: the zone-level `ssh` must not survive on an "+
+				"interface that declares its own host-inbound-traffic (#6515)", svc)
+		}
+	}
+}
+
+// TestHostInboundOverrideReplaceAdvisory_6515 covers the migration advisory that
+// ships with the flip: it must name every zone token an interface stanza takes
+// away, and must stay silent where nothing is actually lost — a warning that
+// fires on configs losing nothing is one operators learn to ignore.
+func TestHostInboundOverrideReplaceAdvisory_6515(t *testing.T) {
+	build := func(zoneSvc, zoneProto []string, ifSvc, ifProto []string, ifRef string) *Config {
+		cfg := &Config{}
+		cfg.Security.Zones = map[string]*ZoneConfig{
+			"trust": {
+				Name:               "trust",
+				Interfaces:         []string{ifRef, "ge-0/0/8.0"},
+				HostInboundTraffic: &HostInboundTraffic{SystemServices: zoneSvc, Protocols: zoneProto},
+				InterfaceHostInbound: map[string]*HostInboundTraffic{
+					ifRef: {SystemServices: ifSvc, Protocols: ifProto},
+				},
+			},
+		}
+		return cfg
+	}
+
+	t.Run("names the lost services and protocols", func(t *testing.T) {
+		cfg := build([]string{"ssh", "https"}, []string{"ospf"}, []string{"ping"}, nil, "ge-0/0/9.0")
+		got := validateHostInboundOverrideReplaceWarnings(cfg)
+		if len(got) != 1 {
+			t.Fatalf("want exactly one advisory, got %d: %v", len(got), got)
+		}
+		for _, want := range []string{`"trust"`, `"ge-0/0/9.0"`, "ssh", "https", "ospf", "REPLACES"} {
+			if !strings.Contains(got[0], want) {
+				t.Errorf("advisory must mention %q so the operator can act on it, got: %s", want, got[0])
+			}
+		}
+		if strings.Contains(got[0], "ge-0/0/8.0") {
+			t.Errorf("the sibling interface declares no stanza and loses nothing; it must not "+
+				"be named, got: %s", got[0])
+		}
+	})
+
+	t.Run("silent when the override is a superset", func(t *testing.T) {
+		cfg := build([]string{"ssh"}, nil, []string{"ssh", "ping"}, nil, "ge-0/0/9.0")
+		if got := validateHostInboundOverrideReplaceWarnings(cfg); len(got) != 0 {
+			t.Fatalf("an override repeating every zone token loses nothing; want no advisory, got: %v", got)
+		}
+	})
+
+	t.Run("silent when the override full-admits", func(t *testing.T) {
+		cfg := build([]string{"ssh"}, []string{"ospf"}, []string{"any-service"}, nil, "ge-0/0/9.0")
+		if got := validateHostInboundOverrideReplaceWarnings(cfg); len(got) != 0 {
+			t.Fatalf("an `any-service` override admits everything the zone did; want no advisory, got: %v", got)
+		}
+	})
+
+	t.Run("silent when the override `all` covers the zone token", func(t *testing.T) {
+		cfg := build([]string{"ssh"}, nil, []string{"all"}, nil, "ge-0/0/9.0")
+		if got := validateHostInboundOverrideReplaceWarnings(cfg); len(got) != 0 {
+			t.Fatalf("`all` expands to a union including ssh, so nothing is lost; got: %v", got)
+		}
+	})
+
+	t.Run("fires when the zone `all` is narrowed by the override", func(t *testing.T) {
+		cfg := build([]string{"all"}, nil, []string{"ssh"}, nil, "ge-0/0/9.0")
+		got := validateHostInboundOverrideReplaceWarnings(cfg)
+		if len(got) != 1 {
+			t.Fatalf("a zone `all` narrowed to `ssh` loses most of the expansion; want one advisory, got %d: %v", len(got), got)
+		}
+	})
+
+	t.Run("silent on a lifeline interface", func(t *testing.T) {
+		cfg := build([]string{"ssh"}, nil, []string{"ping"}, nil, "fxp0.0")
+		if got := validateHostInboundOverrideReplaceWarnings(cfg); len(got) != 0 {
+			t.Fatalf("fxp0 is excluded from host-inbound deny scoping, so nothing is lost there "+
+				"and an advisory would be a false alarm; got: %v", got)
+		}
+	})
+
+	t.Run("silent when the zone declares no stanza", func(t *testing.T) {
+		cfg := build(nil, nil, []string{"ping"}, nil, "ge-0/0/9.0")
+		cfg.Security.Zones["trust"].HostInboundTraffic = nil
+		if got := validateHostInboundOverrideReplaceWarnings(cfg); len(got) != 0 {
+			t.Fatalf("with no zone-level stanza there is nothing for the override to replace; got: %v", got)
+		}
+	})
+}
+
+// TestDuplicateHostLocalAddressGateUsesReplaceSemantics_6515 binds the #3718
+// commit gate to the same resolver enforcement uses. The gate rejects a
+// firewall-local address reachable from two zones with DIFFERING effective
+// host-inbound sets, so it compares SIGNATURES — and a signature built from a
+// different combination rule than the kernel chain uses compares the wrong sets.
+// Reverting effectiveHostInboundSigLocal to a union left every other test in
+// pkg/config green, which is what this test exists to stop.
+//
+// Fixture: 10.0.0.1 lives on ge-0/0/0.0 in zone `a` and on ge-0/0/1.0 in zone
+// `b` (the #3718 shared-address topology). Zone `a` admits ssh with no
+// interface stanza; zone `b` admits ping at the zone level but its interface
+// declares `ssh`. Under REPLACE both sides resolve to {ssh} — one policy for the
+// address, so the commit is accepted. Under a UNION zone `b` resolves to
+// {ping, ssh} and the gate rejects a config that is in fact unambiguous.
+func TestDuplicateHostLocalAddressGateUsesReplaceSemantics_6515(t *testing.T) {
+	build := func(bIfaceSvc []string) *Config {
+		cfg := &Config{}
+		cfg.Interfaces.Interfaces = map[string]*InterfaceConfig{
+			"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*InterfaceUnit{
+				0: {Number: 0, Addresses: []string{"10.0.0.1/24"}},
+			}},
+			"ge-0/0/1": {Name: "ge-0/0/1", Units: map[int]*InterfaceUnit{
+				0: {Number: 0, Addresses: []string{"10.0.0.1/24"}},
+			}},
+		}
+		cfg.Security.Zones = map[string]*ZoneConfig{
+			"a": {
+				Name:               "a",
+				Interfaces:         []string{"ge-0/0/0.0"},
+				HostInboundTraffic: &HostInboundTraffic{SystemServices: []string{"ssh"}},
+			},
+			"b": {
+				Name:               "b",
+				Interfaces:         []string{"ge-0/0/1.0"},
+				HostInboundTraffic: &HostInboundTraffic{SystemServices: []string{"ping"}},
+				InterfaceHostInbound: map[string]*HostInboundTraffic{
+					"ge-0/0/1.0": {SystemServices: bIfaceSvc},
+				},
+			},
+		}
+		return cfg
+	}
+
+	if err := validateDuplicateHostLocalAddressStrict(build([]string{"ssh"})); err != nil {
+		t.Fatalf("both zones resolve 10.0.0.1 to {ssh} under replace semantics, so the address "+
+			"has ONE host-inbound policy and the commit must be accepted; got: %v", err)
+	}
+	// Anti-vacuity: the gate must still fire when the two sides genuinely differ,
+	// or the assertion above would be satisfied by a gate that never rejects.
+	if err := validateDuplicateHostLocalAddressStrict(build([]string{"https"})); err == nil {
+		t.Fatal("zone a resolves 10.0.0.1 to {ssh} and zone b to {https}: the address IS " +
+			"host-inbound-ambiguous and the #3718 gate must reject it")
+	}
+}

--- a/pkg/config/host_inbound_view.go
+++ b/pkg/config/host_inbound_view.go
@@ -15,29 +15,28 @@ import (
 // (#3405). Routing all six through this one presenter keeps them from drifting
 // again and mirrors the structured REST/gRPC contract (#3328/#3405/#3653):
 // every configured zone is host-inbound ENFORCING, and the EFFECTIVE admission
-// set for an interface is the UNION of the zone-level set and its interface
-// override (Junos additive semantics).
+// set for an interface is its interface-level `host-inbound-traffic` stanza when
+// it declares one, otherwise the zone-level set (#6515 — Junos REPLACE
+// semantics; see EffectiveHostInboundTokens).
 
-// UnionHostInboundTokens returns the effective host-inbound token set for the
-// combination of a zone-level list and a per-interface override list: the
-// zone-level tokens first in their authored order, then any override-only
-// tokens, with empties skipped and exact-duplicate tokens collapsed. This is
-// the display-side peer of the dataplane's unionHostInboundTokens
-// (dataplane/userspace/zones_override.go); it preserves the authored token case
-// so the text surfaces show tokens exactly as the structured API does (the
-// dataplane path lower-cases for map keying, a concern that does not apply to
-// display — every membership predicate that consumes this, notably
-// HostInboundFullAdmitService, is case-insensitive).
+// UnionHostInboundTokens returns the order-preserving union of two host-inbound
+// token lists: a's tokens first in their authored order, then any of b's not
+// already present, with empties skipped and exact-duplicate tokens collapsed. It
+// preserves the authored token case so the text surfaces show tokens exactly as
+// the structured API does (the dataplane path lower-cases for map keying, a
+// concern that does not apply to display — every membership predicate that
+// consumes this, notably HostInboundFullAdmitService, is case-insensitive).
+// Called with a nil second argument it is a normalizer (trim + dedup).
 //
-// #3226 fold: the COMMIT-TIME ADVISORIES (compiler_validate_warn.go) also
-// consume this. Junos host-inbound is ADDITIVE across the zone and interface
-// levels, so this union — not the raw stanza — is the object enforcement acts
-// on, and an advisory that reasons about anything else will contradict it. It
-// did: a zone-level `any-service` with a per-interface `rpm` warned that rpm
-// traffic was DENIED even though the union full-admits it, and `any-service`
-// alongside `all` in one stanza emitted "everything is admitted" and "ports are
-// now denied" together. Those were symptoms of the two views diverging, so the
-// fix is to share the union rather than special-case each pair.
+// SCOPE (#6515). This unions tokens authored at the SAME level. It is NOT how
+// the zone level and the interface level combine: an interface stanza REPLACES
+// the zone stanza — see EffectiveHostInboundTokens, which every zone-to-interface
+// resolution must route through. Two live callers union within one level:
+//   - the #3720 physical→unit resolution in InterfaceHostInboundEffective and in
+//     the dataplane's buildInterfaceHostInboundMap, where a physical-interface
+//     override and a unit-level override on the same unit are both
+//     "interface-level" statements;
+//   - #4544 repeated `host-inbound-traffic { }` blocks under one stanza.
 func UnionHostInboundTokens(zone, iface []string) []string {
 	seen := make(map[string]bool, len(zone)+len(iface))
 	out := make([]string, 0, len(zone)+len(iface))
@@ -54,6 +53,48 @@ func UnionHostInboundTokens(zone, iface []string) []string {
 	add(zone)
 	add(iface)
 	return out
+}
+
+// EffectiveHostInboundTokens returns the EFFECTIVE host-inbound token set for one
+// interface, given the zone-level list, that interface's own list, and whether
+// the interface declares a `host-inbound-traffic` stanza at all. It is the SSOT
+// for the zone↔interface combination; every surface that resolves an interface's
+// admission — the kernel nft enforcement view builder, the per-interface
+// classifier, the commit-time advisories, the duplicate-host-address commit gate,
+// and all six display surfaces — must route through it or through a wrapper that
+// delegates to it, or they will describe different firewalls.
+//
+// REPLACE, not union (#6515). Junos: "You can configure these parameters at the
+// zone level, in which case they affect all interfaces of the zone, or at the
+// interface level. (Interface configuration overrides that of the zone.)"
+// — Security Zones, security-zone-configuration. So the zone-level stanza governs
+// exactly the interfaces that declare NO stanza of their own; an interface that
+// declares one is described entirely by it, and the zone's tokens do not reach it.
+//
+// The flag is presence, NOT emptiness: an explicit `host-inbound-traffic { }` on
+// an interface is a deny-all override and must not fall back to the zone set.
+// parseHostInboundNode already distinguishes the two (a present-but-empty stanza
+// compiles to a non-nil empty struct, an absent one to nil).
+//
+// GRANULARITY. The whole stanza replaces, not each leaf: an interface stanza that
+// declares only `protocols` also drops the zone's `system-services`. That is the
+// literal reading of the sentence above, and the community consensus states it
+// the same way ("if you configure anything under specific interface level, then
+// zone-specific configuration doesn't apply to this interface anymore"). No
+// vendor text was found describing a per-leaf inheritance, so none is invented
+// here — see docs/host-inbound-service-matrix.md.
+//
+// Before #6515 this combination was a UNION, asserted in-tree as "Junos additive
+// semantics". An interface stanza could then only WIDEN admission and never
+// narrow it: a zone admitting `protocols ospf` with an interface stanza admitting
+// only `ping` still admitted OSPF on that interface, where Junos denies it. The
+// migration this flip imposes on configs that relied on the union is named at
+// commit by validateHostInboundOverrideReplaceWarnings.
+func EffectiveHostInboundTokens(zone, iface []string, overridden bool) []string {
+	if overridden {
+		return UnionHostInboundTokens(iface, nil)
+	}
+	return UnionHostInboundTokens(zone, nil)
 }
 
 // HostInboundDenyReason returns the parenthetical explaining WHY a zone or
@@ -74,12 +115,13 @@ func HostInboundDenyReason(overridden, zoneConfigured bool) string {
 }
 
 // InterfaceHostInboundEffective returns the EFFECTIVE host-inbound admission set
-// for a single interface ref in the zone: the UNION of the zone-level set and
-// the per-interface override for ref (if any). overridden reports whether ref
-// declares its own host-inbound-traffic stanza (#3362). Used by the
-// interface-scoped surfaces (`show interfaces`, `test security-zone interface`,
-// gRPC interface diagnostic) which must show the effective set for ONE
-// interface rather than iterate the whole zone.
+// for a single interface ref in the zone: the per-interface override for ref when
+// ref declares one (#6515 replace semantics — see EffectiveHostInboundTokens),
+// otherwise the zone-level set. overridden reports whether ref declares its own
+// host-inbound-traffic stanza (#3362). Used by the interface-scoped surfaces
+// (`show interfaces`, `test security-zone interface`, gRPC interface diagnostic)
+// which must show the effective set for ONE interface rather than iterate the
+// whole zone.
 func (z *ZoneConfig) InterfaceHostInboundEffective(ref string) (svc, proto []string, overridden bool) {
 	var zoneSvc, zoneProto []string
 	if z != nil && z.HostInboundTraffic != nil {
@@ -89,9 +131,11 @@ func (z *ZoneConfig) InterfaceHostInboundEffective(ref string) (svc, proto []str
 	if z == nil {
 		return UnionHostInboundTokens(zoneSvc, nil), UnionHostInboundTokens(zoneProto, nil), false
 	}
-	// #3720 (H05): the per-interface override is ADDITIVE across the physical and
-	// the unit level, exactly as the dataplane resolves it in
-	// buildInterfaceHostInboundMap. For a logical-unit ref (contains "."), a
+	// #3720 (H05): the physical and the unit level are BOTH "interface level", so
+	// the override for a unit is the UNION of the two, exactly as the dataplane
+	// resolves it in buildInterfaceHostInboundMap. (#6515 replaces the ZONE level
+	// with this result; it does not change how the two interface-level statements
+	// combine with each other.) For a logical-unit ref (contains "."), a
 	// physical-interface-level override on its parent IN THIS ZONE also applies,
 	// so the diagnostic must UNION it. Before #3720 this read only the exact ref,
 	// so `show interfaces <unit>` reported "no override / default-deny" while the
@@ -113,13 +157,14 @@ func (z *ZoneConfig) InterfaceHostInboundEffective(ref string) (svc, proto []str
 	if !overridden {
 		return UnionHostInboundTokens(zoneSvc, nil), UnionHostInboundTokens(zoneProto, nil), false
 	}
-	return UnionHostInboundTokens(zoneSvc, ovSvc), UnionHostInboundTokens(zoneProto, ovProto), true
+	return EffectiveHostInboundTokens(zoneSvc, ovSvc, true),
+		EffectiveHostInboundTokens(zoneProto, ovProto, true), true
 }
 
 // InterfaceHostInboundView is a single per-interface host-inbound override
 // (#3362) projected for display: the interface-local override tokens plus the
-// EFFECTIVE (zone-level UNION override) admitted set that actually reaches the
-// host on that interface.
+// EFFECTIVE admitted set that actually reaches the host on that interface —
+// which post-#6515 IS the override, the zone-level set having been replaced.
 type InterfaceHostInboundView struct {
 	Interface               string
 	SystemServices          []string
@@ -203,8 +248,9 @@ func (z *ZoneConfig) hostInboundViewBase() HostInboundView {
 		}
 		// SystemServices/Protocols show the tokens authored on THIS ref; the
 		// effective set is resolved through InterfaceHostInboundEffective so a
-		// unit ref also folds in a physical-parent override (#3720 H05) — the
-		// same additive resolution the dataplane enforces.
+		// unit ref also folds in a physical-parent override (#3720 H05) and the
+		// zone level is then REPLACED by the result (#6515) — the same
+		// resolution the dataplane enforces.
 		effSvc, effProto, _ := z.InterfaceHostInboundEffective(ref)
 		v.Interfaces = append(v.Interfaces, InterfaceHostInboundView{
 			Interface:               ref,
@@ -221,8 +267,10 @@ func (z *ZoneConfig) hostInboundViewBase() HostInboundView {
 // ONE interface ref in the zone (#3654 H06/H08 — the per-interface admission
 // diagnostic), one line per slice element with NO trailing newline. It shows
 // the zone-level admitted set and, when ref declares its own
-// host-inbound-traffic override, both a marker and the EFFECTIVE (zone UNION
-// interface) admitted set for that interface. A default-deny posture line is
+// host-inbound-traffic override, both a marker and the EFFECTIVE admitted set for
+// that interface (post-#6515 the override REPLACES the zone-level set, so the
+// effective set can be NARROWER than the zone line printed above it). A
+// default-deny posture line is
 // emitted when the effective set is empty, so a blank section cannot be misread
 // as "not enforced".
 //

--- a/pkg/config/host_inbound_view_3654_test.go
+++ b/pkg/config/host_inbound_view_3654_test.go
@@ -47,16 +47,23 @@ func TestInterfaceHostInboundEffective3654(t *testing.T) {
 			"ge-0/0/9.0": {SystemServices: []string{"https", "ssh"}},
 		},
 	}
-	// Overridden interface: effective = zone UNION override.
+	// Overridden interface: effective = the OVERRIDE, which REPLACES the
+	// zone-level stanza (#6515). The fixture is deliberately asymmetric — the
+	// override declares only system-services — so it also pins the granularity:
+	// the whole zone stanza is replaced, so the zone's `protocols ospf` does NOT
+	// survive on this interface either. A per-leaf inheritance rule would leave
+	// ospf here, and no vendor text describes one.
 	svc, proto, overridden := z.InterfaceHostInboundEffective("ge-0/0/9.0")
 	if !overridden {
 		t.Fatal("expected overridden=true for ge-0/0/9.0")
 	}
-	if strings.Join(svc, ",") != "ssh,https" {
-		t.Fatalf("effective svc = %v, want [ssh https]", svc)
+	if strings.Join(svc, ",") != "https,ssh" {
+		t.Fatalf("effective svc = %v, want [https ssh] (the override REPLACES the zone stanza, #6515)", svc)
 	}
-	if strings.Join(proto, ",") != "ospf" {
-		t.Fatalf("effective proto = %v, want [ospf]", proto)
+	if len(proto) != 0 {
+		t.Fatalf("effective proto = %v, want none: the whole zone stanza is replaced, so the "+
+			"zone's `protocols ospf` does not reach an interface that declares its own "+
+			"host-inbound-traffic (#6515 granularity)", proto)
 	}
 	// Non-overridden interface: effective = zone-level only, overridden=false.
 	svc, _, overridden = z.InterfaceHostInboundEffective("ge-0/0/0.0")
@@ -84,11 +91,20 @@ func TestHostInboundViewRender3654(t *testing.T) {
 		"Host-inbound interface overrides:",
 		"ge-0/0/9.0:",
 		"override system-services: https",
-		"effective system-services: ssh, https",
+		// #6515: the override REPLACES the zone stanza on this interface, so
+		// the effective line is the override alone. The zone-level line above
+		// still reads `ssh` — it governs every interface that does NOT declare
+		// a stanza, which is exactly why both lines are asserted here: an
+		// operator reading only one of them would misjudge the posture.
+		"effective system-services: https",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("populated+override render missing %q\n%s", want, out)
 		}
+	}
+	if strings.Contains(out, "effective system-services: ssh") {
+		t.Errorf("the effective line must NOT carry the zone's `ssh` on an overridden "+
+			"interface — the interface stanza replaces it (#6515)\n%s", out)
 	}
 
 	// No-stanza zone: explicit default-deny posture line.
@@ -186,7 +202,8 @@ func TestRenderInterfaceHostInbound3654(t *testing.T) {
 	for _, want := range []string{
 		"Host-inbound services: ssh",
 		"Host-inbound interface override on ge-0/0/9.0:",
-		"effective host-inbound services: ssh, https",
+		// #6515: effective = the override, the zone's ssh having been replaced.
+		"effective host-inbound services: https",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("override diagnostic missing %q\n%s", want, out)

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -173,9 +173,11 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 			// / protocols as untyped containers — tokens validated by
 			// validateHostInboundTokensStrict, not the schema). A bare
 			// `interfaces <if>` (no body) stays valid (zone membership only). The
-			// effective admission set for an interface is the UNION of the
-			// zone-level set and this interface-level set (Junos additive
-			// semantics).
+			// effective admission set for an interface is THIS interface-level
+			// set when the stanza is present — it REPLACES the zone-level stanza
+			// below rather than adding to it (#6515; Junos: "Interface
+			// configuration overrides that of the zone"). A present-but-EMPTY
+			// body is a deny-all override, not a fallback to the zone set.
 			"interfaces": {desc: "Interfaces in this zone", wildcard: &schemaNode{
 				desc: "Interface name", valueHint: ValueHintInterfaceName, placeholder: "<interface-name>",
 				children: map[string]*schemaNode{

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -307,8 +307,12 @@ type ZoneConfig struct {
 	// `security zones security-zone <z> interfaces <ref>` (e.g. "ge-0/0/0.0").
 	// Junos models host-inbound-traffic at BOTH the zone level (HostInboundTraffic
 	// above, applies to every interface in the zone) and the interface level
-	// (here, applies only to that interface); the EFFECTIVE admission set for an
-	// interface is the UNION of the two (Junos additive semantics). A zone is
+	// (here, applies only to that interface). An interface that declares an
+	// interface-level stanza is described ENTIRELY by it: the stanza REPLACES the
+	// zone-level one for that interface (#6515; Junos: "Interface configuration
+	// overrides that of the zone"), and a present-but-EMPTY stanza is a deny-all
+	// override rather than a fallback to the zone set. The resolution SSOT is
+	// config.EffectiveHostInboundTokens. A zone is
 	// host-inbound-ENFORCING if it declares a zone-level stanza OR carries any
 	// interface-level override here — so an operator can expose a service
 	// (e.g. ssh) on one interface of a zone while denying it on the others by

--- a/pkg/dataplane/userspace/host_inbound_baseunit0_5699_test.go
+++ b/pkg/dataplane/userspace/host_inbound_baseunit0_5699_test.go
@@ -50,9 +50,11 @@ func TestHostInboundBaseUnit0NoConflict_5699(t *testing.T) {
 			0: {Number: 0, Addresses: []string{"10.0.1.10/24"}},
 		}},
 	}
-	// Zone trust admits `ping` at the zone level; the unit-0 ref adds `ssh` via a
-	// per-interface host-inbound override — so base sig (ping) != unit-0 sig
-	// (ping+ssh).
+	// Zone trust admits `ping` at the zone level; the unit-0 ref declares a
+	// per-interface host-inbound override of `ssh`, which REPLACES the zone set
+	// on that unit (#6515) — so base sig (ping, no base-level override) !=
+	// unit-0 sig (ssh). The signatures differing is what this test needs; #6515
+	// changed WHICH sets differ, not that they do.
 	cfg.Security.Zones = map[string]*config.ZoneConfig{
 		"trust": {
 			Name:               "trust",
@@ -78,12 +80,22 @@ func TestHostInboundBaseUnit0NoConflict_5699(t *testing.T) {
 		t.Fatalf("live address 10.0.1.10 appears in %d host-inbound views, want exactly 1 "+
 			"(the #5699 base-vs-unit-0 conflict); views carrying it: %+v", len(carrying), carrying)
 	}
-	// Precedence: the single view must carry the unit-0-authoritative merged
-	// admit set (zone ping ∪ unit-0 ssh), NOT the base-only (ping) set.
+	// Precedence: the single view must carry the unit-0-authoritative admit set
+	// (the unit-0 override `ssh`, which replaces the zone-level `ping`, #6515),
+	// NOT the base ref's zone-level-only (ping) set. Asserting the ABSENCE of
+	// `ping` as well as the presence of `ssh` is what pins precedence: a view
+	// carrying both would mean the base contributed after all.
 	got := carrying[0]
-	if !containsAll(got.SystemServices, []string{"ping", "ssh"}) {
-		t.Fatalf("winning view services = %v, want the unit-0 merged set [ping ssh] "+
-			"(unit-0 override must win, not the base-only ping)", got.SystemServices)
+	if !containsAll(got.SystemServices, []string{"ssh"}) {
+		t.Fatalf("winning view services = %v, want the unit-0 override set [ssh] "+
+			"(unit-0 override must win, not the base ref's zone-level ping)", got.SystemServices)
+	}
+	for _, s := range got.SystemServices {
+		if s == "ping" {
+			t.Fatalf("winning view services = %v: the base ref's zone-level `ping` must not "+
+				"appear — the unit-0 stanza replaces the zone set (#6515) and the base's "+
+				"redundant contribution is skipped (#5699)", got.SystemServices)
+		}
 	}
 }
 

--- a/pkg/dataplane/userspace/host_inbound_classify.go
+++ b/pkg/dataplane/userspace/host_inbound_classify.go
@@ -227,9 +227,10 @@ func verdictFor(v ZoneHostInboundView, a HostInboundAdmission) HostInboundViewVe
 // ClassifyHostInboundForInterface classifies the host-inbound admission for a
 // SINGLE ingress interface's EFFECTIVE host-inbound view (#5579). Unlike
 // ClassifyHostInbound — which folds every view in the zone with a first-admit OR
-// — it evaluates ONLY ifaceRef's effective token set (zone-level ∪ the
-// per-interface override, #3362, with the same physical→unit inheritance the
-// enforcement view builder uses), so a mixed zone reports the interface's TRUE
+// — it evaluates ONLY ifaceRef's effective token set (its per-interface
+// override where declared, which REPLACES the zone-level set — #6515, #3362 —
+// with the same physical→unit inheritance the enforcement view builder uses),
+// so a mixed zone reports the interface's TRUE
 // posture (admit vs deny) instead of a zone-wide first-admit fold. ifaceRef is
 // expected to be a caller-validated interface assigned to fromZone (see
 // ResolveHostInboundIngressInterface); an unresolved zone/interface yields
@@ -243,13 +244,14 @@ func ClassifyHostInboundForInterface(cfg *config.Config, fromZone, ifaceRef stri
 		return HostInboundAdmission{Status: HostInboundNotComputed}
 	}
 	// Resolve THIS interface's effective host-inbound token set with the same SSOT
-	// the enforcement view builder uses (unionHostInboundTokens over the zone-level
-	// stanza and the per-interface override, physical→unit inheritance included),
-	// then classify that single view.
+	// the enforcement view builder uses (effectiveHostInboundTokens over the
+	// zone-level stanza and the per-interface override — the override REPLACES the
+	// zone set when present, #6515 — physical→unit inheritance included), then
+	// classify that single view.
 	// #5878 phase 2: look the override up on the ref's canonical logical-unit
 	// identity so a query for ge-0/0/0.01 finds an override authored as
 	// ge-0/0/0.1 (buildInterfaceHostInboundMap now keys by the canonical unit).
-	svc, prot := unionHostInboundTokens(zone.HostInboundTraffic, buildInterfaceHostInboundMap(cfg)[config.CanonicalInterfaceUnitRef(ifaceRef)])
+	svc, prot := effectiveHostInboundTokens(zone.HostInboundTraffic, buildInterfaceHostInboundMap(cfg)[config.CanonicalInterfaceUnitRef(ifaceRef)])
 	v := ZoneHostInboundView{Zone: fromZone, Interfaces: []string{ifaceRef}, SystemServices: svc, Protocols: prot}
 	return classifyOneView(v, proto, hasProto, dstPort, icmpType, family)
 }

--- a/pkg/dataplane/userspace/host_inbound_classify_iface_5579_test.go
+++ b/pkg/dataplane/userspace/host_inbound_classify_iface_5579_test.go
@@ -92,24 +92,38 @@ func Test_5579_IngressInterfaceScopesToTruePosture(t *testing.T) {
 	}
 }
 
-// Test_5579_IngressInterfaceUnionWithZoneLevel asserts the interface-scoped
-// classifier honors the zone-level ∪ per-interface UNION (Junos additive
-// semantics): a zone-level `ping` plus reth0.50's `ssh` override admits ssh on
-// reth0.50, while reth1.0 admits only the zone-level ping and denies ssh.
-func Test_5579_IngressInterfaceUnionWithZoneLevel(t *testing.T) {
+// Test_5579_IngressInterfaceReplacesZoneLevel asserts the interface-scoped
+// classifier resolves the zone↔interface levels the way enforcement does: a
+// zone-level `ping` with reth0.50's `ssh` override admits ssh and DENIES ping on
+// reth0.50, while reth1.0 — which declares no stanza — admits the zone-level ping
+// and denies ssh.
+//
+// #6515: this asserted the UNION before, and the ping-on-reth0.50 case was the
+// one it never sampled — the old body claimed in a comment that reth0.50 "admits
+// ssh AND ping" but only ever queried tcp/22 there. A fixture that varies the
+// right axis and samples only the passing point cannot discriminate the two
+// combination rules, so it passed unchanged when the semantics flipped under it.
+// All four (interface × service) cells are queried now.
+func Test_5579_IngressInterfaceReplacesZoneLevel(t *testing.T) {
 	cfg := hostInboundCfg3362()
 	cfg.Security.Zones["wan"].HostInboundTraffic = &config.HostInboundTraffic{SystemServices: []string{"ping"}}
 
-	// reth1.0 admits the zone-level ping (icmp echo type 8) but denies ssh.
+	// reth1.0 declares no stanza: it admits the zone-level ping (icmp echo
+	// type 8) and denies ssh.
 	if a := ClassifyHostInboundForInterface(cfg, "wan", "reth1.0", uint8(1), true, 0, u8ptr(8), "ip"); a.Status != HostInboundTokenAdmit || a.Token != "ping" {
 		t.Errorf("reth1.0 icmp echo = %v/%q, want token-admit/ping (zone-level)", a.Status, a.Token)
 	}
 	if a := ClassifyHostInboundForInterface(cfg, "wan", "reth1.0", hi5579TCP, true, 22, nil, "ip"); a.Status != HostInboundDenied {
 		t.Errorf("reth1.0 tcp/22 = %v, want denied (ssh only on reth0.50)", a.Status)
 	}
-	// reth0.50 admits ssh (override) AND ping (zone-level union).
+	// reth0.50 declares `ssh`: it admits ssh and NO LONGER inherits the zone's
+	// ping, because its stanza replaces the zone stanza (#6515).
 	if a := ClassifyHostInboundForInterface(cfg, "wan", "reth0.50", hi5579TCP, true, 22, nil, "ip"); a.Status != HostInboundTokenAdmit || a.Token != "ssh" {
 		t.Errorf("reth0.50 tcp/22 = %v/%q, want token-admit/ssh", a.Status, a.Token)
+	}
+	if a := ClassifyHostInboundForInterface(cfg, "wan", "reth0.50", uint8(1), true, 0, u8ptr(8), "ip"); a.Status != HostInboundDenied {
+		t.Errorf("reth0.50 icmp echo = %v/%q, want DENIED: the interface stanza lists only "+
+			"ssh and REPLACES the zone-level ping (#6515)", a.Status, a.Token)
 	}
 }
 

--- a/pkg/dataplane/userspace/host_inbound_per_iface_3362_test.go
+++ b/pkg/dataplane/userspace/host_inbound_per_iface_3362_test.go
@@ -75,11 +75,18 @@ func Test_3362_PerInterfaceViewsScopeOverride(t *testing.T) {
 	}
 }
 
-// Test_3362_UnionWithZoneLevel asserts the effective per-interface set is the
-// UNION of the zone-level set and the interface override (Junos additive
-// semantics): a zone-level `ping` plus an interface `ssh` yields {ping, ssh} on
-// the overridden interface and {ping} on the others.
-func Test_3362_UnionWithZoneLevel(t *testing.T) {
+// Test_3362_ReplaceZoneLevel asserts the effective per-interface set is the
+// interface override where one is declared and the zone-level set everywhere
+// else (#6515 Junos REPLACE semantics): a zone-level `ping` with an interface
+// `ssh` yields {ssh} on the overridden interface and {ping} on the others.
+//
+// Both halves matter. The second is what makes the first meaningful: replace
+// narrows ONE interface, it does not turn the zone-level stanza off. A test that
+// only asserted the overridden interface would still pass if the zone stanza
+// had stopped being applied at all.
+//
+// Before #6515 this asserted the union, {ping, ssh}.
+func Test_3362_ReplaceZoneLevel(t *testing.T) {
 	cfg := hostInboundCfg3362()
 	cfg.Security.Zones["wan"].HostInboundTraffic = &config.HostInboundTraffic{SystemServices: []string{"ping"}}
 
@@ -90,18 +97,21 @@ func Test_3362_UnionWithZoneLevel(t *testing.T) {
 			got[v.V4Addrs[0]] = v.SystemServices
 		}
 	}
-	if !eqStr(got["172.16.50.8"], []string{"ping", "ssh"}) {
-		t.Errorf("overridden iface services = %v, want [ping ssh] (union)", got["172.16.50.8"])
+	if !eqStr(got["172.16.50.8"], []string{"ssh"}) {
+		t.Errorf("overridden iface services = %v, want [ssh]: the interface stanza REPLACES "+
+			"the zone-level `ping` (#6515), it does not add to it", got["172.16.50.8"])
 	}
 	if !eqStr(got["10.0.61.1"], []string{"ping"}) {
-		t.Errorf("non-overridden iface services = %v, want [ping] (zone-level only)", got["10.0.61.1"])
+		t.Errorf("non-overridden iface services = %v, want [ping] (zone-level only) — replace "+
+			"must narrow only the interface that declares a stanza", got["10.0.61.1"])
 	}
 }
 
 // Test_3362_WireCarriesEffectiveOverride asserts the per-interface OVERRIDE
 // reaches the dataplane wire: the overridden unit's InterfaceSnapshot is marked
-// host-inbound-configured with the EFFECTIVE union token set, while the
-// non-overridden unit carries none (Rust falls back to the zone-keyed check).
+// host-inbound-configured with the EFFECTIVE token set — which post-#6515 is the
+// override alone — while the non-overridden unit carries none (Rust falls back to
+// the zone-keyed check).
 func Test_3362_WireCarriesEffectiveOverride(t *testing.T) {
 	cfg := hostInboundCfg3362()
 	cfg.Security.Zones["wan"].HostInboundTraffic = &config.HostInboundTraffic{SystemServices: []string{"ping"}}
@@ -116,8 +126,10 @@ func Test_3362_WireCarriesEffectiveOverride(t *testing.T) {
 	if !over.HostInboundConfigured {
 		t.Fatal("overridden interface reth0.50 must carry host_inbound_configured=true on the wire")
 	}
-	if !eqStr(over.HostInboundSystemServices, []string{"ping", "ssh"}) {
-		t.Errorf("wire effective services = %v, want [ping ssh] (zone ∪ interface)", over.HostInboundSystemServices)
+	if !eqStr(over.HostInboundSystemServices, []string{"ssh"}) {
+		t.Errorf("wire effective services = %v, want [ssh]: the interface stanza replaces the "+
+			"zone-level `ping` (#6515), and the wire must carry what enforcement uses",
+			over.HostInboundSystemServices)
 	}
 
 	plain := byName["reth1.0"]

--- a/pkg/dataplane/userspace/host_inbound_replace_6515_test.go
+++ b/pkg/dataplane/userspace/host_inbound_replace_6515_test.go
@@ -1,0 +1,117 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6515: the ENFORCEMENT side of the union→replace flip. A per-interface
+// `host-inbound-traffic` stanza describes that interface entirely; the
+// zone-level stanza governs only the interfaces that declare none.
+//
+// Test_3362_ReplaceZoneLevel already pins the ordinary narrowing on the kernel
+// nft view builder. This file covers the two cases nothing else reaches: the
+// EMPTY-stanza deny-all override (which distinguishes stanza presence from token
+// emptiness) and the per-interface classifier that answers operator queries.
+
+// hostInboundReplaceCfg6515 builds a zone admitting ssh AND ping at the zone
+// level over two addressed units, with only the first declaring an override.
+// override==nil leaves the first unit un-overridden.
+func hostInboundReplaceCfg6515(override *config.HostInboundTraffic) *config.Config {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.0.1/24"}},
+		}},
+		"ge-0/0/1": {Name: "ge-0/0/1", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.1.1/24"}},
+		}},
+	}
+	zone := &config.ZoneConfig{
+		Name:               "trust",
+		Interfaces:         []string{"ge-0/0/0.0", "ge-0/0/1.0"},
+		HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ssh", "ping"}},
+	}
+	if override != nil {
+		zone.InterfaceHostInbound = map[string]*config.HostInboundTraffic{"ge-0/0/0.0": override}
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{"trust": zone}
+	return cfg
+}
+
+// servicesByAddr6515 maps each firewall-local address to the admitted
+// system-services of the view that scopes it.
+func servicesByAddr6515(cfg *config.Config) map[string][]string {
+	out := map[string][]string{}
+	for _, v := range BuildZoneHostInboundViews(cfg) {
+		for _, a := range v.V4Addrs {
+			out[a] = v.SystemServices
+		}
+	}
+	return out
+}
+
+// TestEmptyInterfaceStanzaIsDenyAllNotFallback_6515 is the discriminator between
+// "the interface declares a stanza" and "the interface's token list is
+// non-empty". An explicit `host-inbound-traffic { }` on an interface is a
+// deny-all override in Junos; resolving on emptiness instead of presence would
+// silently fall back to the zone set and admit ssh on an interface the operator
+// closed. parseHostInboundNode already compiles a present-but-empty stanza to a
+// non-nil empty struct, which is exactly what this fixture supplies.
+func TestEmptyInterfaceStanzaIsDenyAllNotFallback_6515(t *testing.T) {
+	got := servicesByAddr6515(hostInboundReplaceCfg6515(&config.HostInboundTraffic{}))
+	if n := len(got["10.0.0.1"]); n != 0 {
+		t.Fatalf("overridden address admits %v, want nothing: an explicit empty interface "+
+			"host-inbound-traffic stanza is a deny-all override, never a fallback to the "+
+			"zone set (#6515)", got["10.0.0.1"])
+	}
+	// Control: the sibling with no stanza still gets the zone set, so the test
+	// above cannot be satisfied by the zone stanza having stopped applying.
+	if !eqStr(got["10.0.1.1"], []string{"ssh", "ping"}) {
+		t.Fatalf("non-overridden sibling admits %v, want the zone set [ssh ping]", got["10.0.1.1"])
+	}
+}
+
+// TestNoInterfaceStanzaKeepsZoneSet_6515 is the other half of the discriminator:
+// with no override at all, both addresses carry the zone set. Without it, an
+// implementation that simply dropped the zone-level stanza from every view would
+// pass every replace assertion in this package.
+func TestNoInterfaceStanzaKeepsZoneSet_6515(t *testing.T) {
+	got := servicesByAddr6515(hostInboundReplaceCfg6515(nil))
+	for _, addr := range []string{"10.0.0.1", "10.0.1.1"} {
+		if !eqStr(got[addr], []string{"ssh", "ping"}) {
+			t.Fatalf("addr %s admits %v, want the zone set [ssh ping]: replace narrows only "+
+				"interfaces that DECLARE a stanza", addr, got[addr])
+		}
+	}
+}
+
+// TestClassifyHostInboundForInterfaceReplaces_6515 binds the operator-facing
+// per-interface diagnostic to the same rule enforcement uses. A diagnostic that
+// reported the union while the kernel enforced the replace would tell the
+// operator their SSH is admitted on an interface the firewall drops it on —
+// worse than no diagnostic. Both directions are asserted on ONE config so the
+// test says which interface disagreed.
+func TestClassifyHostInboundForInterfaceReplaces_6515(t *testing.T) {
+	cfg := hostInboundReplaceCfg6515(&config.HostInboundTraffic{SystemServices: []string{"https"}})
+
+	// ssh (tcp/22) on the OVERRIDDEN interface: the override lists only https,
+	// so the zone's ssh no longer reaches it.
+	if a := ClassifyHostInboundForInterface(cfg, "trust", "ge-0/0/0.0",
+		config.HostInboundProtoTCP, true, 22, nil, "ip"); a.Status != HostInboundDenied {
+		t.Fatalf("ssh on the overridden interface = %+v, want denied: the interface stanza "+
+			"lists only https, replacing the zone's ssh (#6515)", a)
+	}
+	// https (tcp/443) on the same interface is admitted by its own stanza.
+	if a := ClassifyHostInboundForInterface(cfg, "trust", "ge-0/0/0.0",
+		config.HostInboundProtoTCP, true, 443, nil, "ip"); a.Status != HostInboundTokenAdmit {
+		t.Fatalf("https on the overridden interface = %+v, want token-admit via its own stanza", a)
+	}
+	// ssh on the NON-overridden sibling is still admitted by the zone stanza.
+	if a := ClassifyHostInboundForInterface(cfg, "trust", "ge-0/0/1.0",
+		config.HostInboundProtoTCP, true, 22, nil, "ip"); a.Status != HostInboundTokenAdmit {
+		t.Fatalf("ssh on the non-overridden sibling = %+v, want token-admit: the zone stanza "+
+			"still governs interfaces that declare none", a)
+	}
+}

--- a/pkg/dataplane/userspace/host_inbound_view_grouping_3721_test.go
+++ b/pkg/dataplane/userspace/host_inbound_view_grouping_3721_test.go
@@ -111,9 +111,14 @@ func Test_3721_DistinctSetsStaySeparate(t *testing.T) {
 // Test_3721_EnforcementPreserved is the behavior-preserving assertion: for every
 // firewall-local address, the CANONICAL effective admitted set produced by
 // BuildZoneHostInboundViews equals the set computed independently per interface
-// (unionHostInboundTokens), regardless of how the grouping collapses. The
+// (effectiveHostInboundTokens), regardless of how the grouping collapses. The
 // grouping is an optimization over WHICH view carries an address, never over
 // what that address admits.
+//
+// #6515 changed the per-interface effective set from zone ∪ override to the
+// override alone; the grouping property under test is unchanged, and the fixture
+// still exercises it — two interfaces with the SAME effective set collapse into
+// one view, a third with a different set stays separate.
 func Test_3721_EnforcementPreserved(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
@@ -133,17 +138,19 @@ func Test_3721_EnforcementPreserved(t *testing.T) {
 			Interfaces:         []string{"ge-0/0/0.0", "ge-0/0/1.0", "ge-0/0/2.0"},
 			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ping"}},
 			InterfaceHostInbound: map[string]*config.HostInboundTraffic{
-				"ge-0/0/0.0": {SystemServices: []string{"ssh"}},          // eff {ping, ssh}
-				"ge-0/0/1.0": {SystemServices: []string{"ssh"}},          // eff {ping, ssh} (merges with ge-0/0/0.0)
-				"ge-0/0/2.0": {SystemServices: []string{"https", "ssh"}}, // eff {ping, https, ssh}
+				"ge-0/0/0.0": {SystemServices: []string{"ssh"}},          // eff {ssh}
+				"ge-0/0/1.0": {SystemServices: []string{"ssh"}},          // eff {ssh} (merges with ge-0/0/0.0)
+				"ge-0/0/2.0": {SystemServices: []string{"https", "ssh"}}, // eff {https, ssh}
 			},
 		},
 	}
 
+	// #6515: each interface declares its own stanza, so the zone-level `ping`
+	// reaches none of them.
 	want := map[string]string{
-		"10.0.0.1": canonSet([]string{"ping", "ssh"}),
-		"10.0.1.1": canonSet([]string{"ping", "ssh"}),
-		"10.0.2.1": canonSet([]string{"ping", "https", "ssh"}),
+		"10.0.0.1": canonSet([]string{"ssh"}),
+		"10.0.1.1": canonSet([]string{"ssh"}),
+		"10.0.2.1": canonSet([]string{"https", "ssh"}),
 	}
 	got := map[string]string{}
 	for _, v := range BuildZoneHostInboundViews(cfg) {
@@ -156,8 +163,8 @@ func Test_3721_EnforcementPreserved(t *testing.T) {
 			t.Errorf("addr %s effective set = %s, want %s", addr, got[addr], wantSet)
 		}
 	}
-	// The two {ping, ssh} interfaces collapse to one view; {ping, https, ssh}
-	// stays separate — two address-bearing views for the zone.
+	// The two {ssh} interfaces collapse to one view; {https, ssh} stays
+	// separate — two address-bearing views for the zone.
 	if n := len(countAddrViews(BuildZoneHostInboundViews(cfg), "trunk")); n != 2 {
 		t.Errorf("address-bearing views = %d, want 2 (the two identical sets merged)", n)
 	}

--- a/pkg/dataplane/userspace/interfaces.go
+++ b/pkg/dataplane/userspace/interfaces.go
@@ -526,9 +526,10 @@ func buildInterfaceSnapshotsFrom(cfg *config.Config, liveXfrm map[string]bool) [
 	// interface. Carried only for an interface that declared an interface-level
 	// stanza and is NOT a management/cluster-control lifeline (matching the nft
 	// primary path, which excludes lifeline addresses from host-inbound deny
-	// scoping). The carried set is the EFFECTIVE union of the zone-level set and
-	// the override, so the Rust side enforces it as-is without re-deriving the
-	// union. HostInboundConfigured marks a present override (even an empty one →
+	// scoping). The carried set is the EFFECTIVE set — the override, which
+	// REPLACES the zone-level set (#6515) — so the Rust side enforces it as-is
+	// without re-deriving it.
+	// HostInboundConfigured marks a present override (even an empty one →
 	// fail-closed) so an old Go binary that omits the field is distinguishable.
 	if overrideByIface := buildInterfaceHostInboundMap(cfg); len(overrideByIface) > 0 {
 		lifelines := hostInboundLifelineSet(cfg)
@@ -539,7 +540,7 @@ func buildInterfaceSnapshotsFrom(cfg *config.Config, liveXfrm map[string]bool) [
 				hostInboundLifelineInterface(out[i].Name, lifelines) {
 				continue
 			}
-			svc, proto := unionHostInboundTokens(zone.HostInboundTraffic, ovr)
+			svc, proto := effectiveHostInboundTokens(zone.HostInboundTraffic, ovr)
 			out[i].HostInboundConfigured = true
 			out[i].HostInboundSystemServices = svc
 			out[i].HostInboundProtocols = proto

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -513,9 +513,10 @@ type InterfaceSnapshot struct {
 	CoSPriorityLowMinShareBytes uint64 `json:"cos_priority_low_min_share_bytes,omitempty"`
 	// HostInbound* carry the per-interface host-inbound-traffic OVERRIDE
 	// (#3362). Junos models host-inbound at both the zone level (ZoneSnapshot
-	// above) and the interface level; the EFFECTIVE admission set for an
-	// interface is the UNION of the zone-level set and any interface-level
-	// override. These fields carry that already-unioned effective set and are
+	// above) and the interface level; an interface that declares an
+	// interface-level stanza is described ENTIRELY by it — the zone-level set is
+	// REPLACED, not unioned (#6515). These fields carry that already-resolved
+	// effective set and are
 	// populated ONLY for an interface that declared an interface-level stanza
 	// (and is not a management/cluster-control lifeline). When present the Rust
 	// dataplane keys the host-inbound admission check by ingress interface

--- a/pkg/dataplane/userspace/zones_host_inbound.go
+++ b/pkg/dataplane/userspace/zones_host_inbound.go
@@ -26,7 +26,8 @@ import (
 type ZoneHostInboundView struct {
 	Zone string
 	// Interfaces lists the interface refs whose EFFECTIVE host-inbound token
-	// set (zone-level ∪ interface-level override, #3362) equals this view's
+	// set (the interface-level override when one is declared, else the
+	// zone-level set — #6515 replace semantics, #3362) equals this view's
 	// SystemServices/Protocols. A zone with no per-interface override yields a
 	// single view per zone covering all its interfaces (pre-#3362 shape); a zone
 	// with an override yields one view per distinct effective token set, each
@@ -92,8 +93,9 @@ func BuildZoneHostInboundViews(cfg *config.Config) []ZoneHostInboundView {
 	// traffic is never denied (#3277).
 	lifelines := hostInboundLifelineSet(cfg)
 	// #3362: per-interface host-inbound override lookup (ref → override, with
-	// physical→unit expansion). The EFFECTIVE token set for an interface is the
-	// UNION of its zone-level set and this override; interfaces in the same zone
+	// physical→unit expansion). An interface that declares an override is
+	// described ENTIRELY by it — the zone-level set is REPLACED, not unioned
+	// (#6515); interfaces in the same zone
 	// with the SAME effective set share one view (one nft address set), so a zone
 	// with NO override produces exactly one view per zone (pre-#3362 shape).
 	overrideByIface := buildInterfaceHostInboundMap(cfg)
@@ -192,7 +194,7 @@ func BuildZoneHostInboundViews(cfg *config.Config) []ZoneHostInboundView {
 		if !configured(zone) {
 			continue
 		}
-		svc, proto := unionHostInboundTokens(zone.HostInboundTraffic, nil)
+		svc, proto := effectiveHostInboundTokens(zone.HostInboundTraffic, nil)
 		getGroup(name, svc, proto, "")
 	}
 
@@ -236,7 +238,7 @@ func BuildZoneHostInboundViews(cfg *config.Config) []ZoneHostInboundView {
 		if !configured(zone) {
 			continue
 		}
-		svc, proto := unionHostInboundTokens(zone.HostInboundTraffic, overrideByIface[snap.Name])
+		svc, proto := effectiveHostInboundTokens(zone.HostInboundTraffic, overrideByIface[snap.Name])
 		var g *group
 		for _, a := range snap.Addresses {
 			host := hostIPFromCIDR(a.Address)
@@ -298,7 +300,7 @@ func BuildZoneHostInboundViews(cfg *config.Config) []ZoneHostInboundView {
 			if !configured(zone) {
 				continue
 			}
-			svc, proto := unionHostInboundTokens(zone.HostInboundTraffic, overrideByIface[unitName])
+			svc, proto := effectiveHostInboundTokens(zone.HostInboundTraffic, overrideByIface[unitName])
 			vgKeys := make([]string, 0, len(unit.VRRPGroups))
 			for k := range unit.VRRPGroups {
 				vgKeys = append(vgKeys, k)

--- a/pkg/dataplane/userspace/zones_override.go
+++ b/pkg/dataplane/userspace/zones_override.go
@@ -8,21 +8,28 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 )
 
-// unionHostInboundTokens returns the EFFECTIVE host-inbound system-service and
-// protocol token sets for an interface (#3362): the zone-level set UNION the
-// per-interface override, lower-cased, trimmed, and de-duplicated, with
-// zone-level tokens kept first in their original order and override-only tokens
-// appended. Either argument may be nil. Junos host-inbound is additive across
-// the two levels, so an interface admits a service when EITHER level lists it.
-// #3226 fold: the union itself is now config.UnionHostInboundTokens, shared with
-// the commit-time advisories. Before that this file owned the only union and the
-// advisories computed their own per-RAW-STANZA view, so the two reasoned about
-// DIFFERENT objects and the advice contradicted enforcement (a zone-level
-// `any-service` with a per-interface `rpm` warned rpm was DENIED while this
-// builder full-admitted it). This wrapper keeps the lower-casing the dataplane
-// needs for map keying — config's shared union preserves authored case for the
-// display surfaces — and keeps the local name its callers already use.
-func unionHostInboundTokens(zoneHI, ifaceHI *config.HostInboundTraffic) (svc, proto []string) {
+// effectiveHostInboundTokens returns the EFFECTIVE host-inbound system-service
+// and protocol token sets for an interface (#3362), lower-cased, trimmed and
+// de-duplicated for map keying. Either argument may be nil.
+//
+// #6515: an interface that declares a `host-inbound-traffic` stanza is described
+// ENTIRELY by it — the zone-level set is REPLACED, not unioned ("Interface
+// configuration overrides that of the zone", Junos Security Zones). Presence of
+// the stanza, not emptiness, is the discriminator: ifaceHI non-nil means the
+// operator authored one, and an explicitly empty one is a deny-all override. The
+// decision itself is config.EffectiveHostInboundTokens, shared with the display
+// surfaces, the commit-time advisories and the duplicate-host-address gate, so
+// enforcement and every description of it act on ONE object. Before #3226 this
+// file owned its own combination and the advisories computed a per-RAW-STANZA
+// view, so the two reasoned about DIFFERENT objects and the advice contradicted
+// enforcement (a zone-level `any-service` with a per-interface `rpm` warned rpm
+// was DENIED while this builder admitted it). This wrapper keeps the lower-casing
+// the dataplane needs for map keying — the shared config helper preserves
+// authored case for the display surfaces.
+//
+// Before #6515 this was a UNION (unionHostInboundTokens), so an interface stanza
+// could only ever WIDEN admission relative to the zone.
+func effectiveHostInboundTokens(zoneHI, ifaceHI *config.HostInboundTraffic) (svc, proto []string) {
 	var zs, zp, is, ip []string
 	if zoneHI != nil {
 		zs, zp = zoneHI.SystemServices, zoneHI.Protocols
@@ -30,12 +37,13 @@ func unionHostInboundTokens(zoneHI, ifaceHI *config.HostInboundTraffic) (svc, pr
 	if ifaceHI != nil {
 		is, ip = ifaceHI.SystemServices, ifaceHI.Protocols
 	}
-	return lowerDedup(config.UnionHostInboundTokens(zs, is)),
-		lowerDedup(config.UnionHostInboundTokens(zp, ip))
+	overridden := ifaceHI != nil
+	return lowerDedup(config.EffectiveHostInboundTokens(zs, is, overridden)),
+		lowerDedup(config.EffectiveHostInboundTokens(zp, ip, overridden))
 }
 
 // lowerDedup lower-cases, trims and de-duplicates in one pass, preserving first
-// -seen order. The shared config union dedups on the AUTHORED token (it
+// -seen order. The shared config helper dedups on the AUTHORED token (it
 // preserves case for the display surfaces), so `SSH` and `ssh` both survive it
 // and would collapse to a duplicate `ssh` here. Plain lowerTokens does not
 // dedup, so it would leak that duplicate into the dataplane view — harmless for
@@ -64,11 +72,12 @@ func lowerDedup(in []string) []string {
 
 // mergeHostInboundTraffic returns a NEW *config.HostInboundTraffic whose token
 // lists are the order-preserving UNION of a and b (a's tokens first, then any of
-// b's not already present, exact-string dedup). It underpins the #3720 additive
+// b's not already present, exact-string dedup). It underpins the #3720
 // physical→unit override resolution: a physical-interface override and a
-// more-specific unit-level override on the same unit are UNIONed (Junos
-// host-inbound is additive across levels) rather than the sorted-first physical
-// ref silently shadowing the unit ref (the #3720 first-writer-wins bug). Returns
+// more-specific unit-level override on the same unit are UNIONed (both are
+// INTERFACE-level statements) rather than the sorted-first physical ref silently
+// shadowing the unit ref (the #3720 first-writer-wins bug). #6515 changed how the
+// RESULT combines with the zone level — it replaces it — not this merge. Returns
 // nil only when BOTH inputs are nil; a fresh struct is always allocated so the
 // shared config-owned override objects are never mutated in place.
 func mergeHostInboundTraffic(a, b *config.HostInboundTraffic) *config.HostInboundTraffic {
@@ -105,11 +114,13 @@ func mergeHostInboundTraffic(a, b *config.HostInboundTraffic) *config.HostInboun
 // (#3362) keyed by the interface ref as it appears on a resolved interface
 // snapshot (InterfaceSnapshot.Name).
 //
-// Precedence / merge rule (#3720). Junos host-inbound is ADDITIVE across the
-// override levels, so the EFFECTIVE override for a unit is the UNION of any
-// physical-interface-level override that applies to it and its own unit-level
-// override — never the less-specific physical ref shadowing the more-specific
-// unit ref:
+// Precedence / merge rule (#3720). A physical-interface override and a
+// unit-level override are BOTH interface-level statements, so the EFFECTIVE
+// override for a unit is the UNION of any physical-interface-level override that
+// applies to it and its own unit-level override — never the less-specific
+// physical ref shadowing the more-specific unit ref. (#6515 changed how this
+// result combines with the ZONE level — it REPLACES it — and did not change this
+// within-level union.):
 //   - A ref naming a logical unit (contains ".") is the MOST specific override.
 //     It maps ONLY itself — never a sibling unit — and is MERGED (unioned) onto
 //     whatever physical-inherited set already sits on that unit key, BUT only

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -2127,7 +2127,7 @@ type ZoneInfo struct {
 	// interface_host_inbound (#3328, #3362) carries per-interface host-inbound
 	// overrides. An entry exists only for an interface that declares its own
 	// `host-inbound-traffic` stanza; the effective admission set for that
-	// interface is the UNION of the zone-level set above and its override.
+	// interface IS the override — it REPLACES the zone-level set above (#6515).
 	InterfaceHostInbound []*InterfaceHostInbound `protobuf:"bytes,15,rep,name=interface_host_inbound,json=interfaceHostInbound,proto3" json:"interface_host_inbound,omitempty"`
 	// lifeline_interfaces (#3682) lists the zone's interfaces that are
 	// management / cluster-control LIFELINES (fxp0 / em0 / fab* / configured
@@ -6674,7 +6674,8 @@ type MatchPoliciesRequest struct {
 	// ingress interface's effective host-inbound view (#5579). A zone can carry
 	// multiple per-interface host-inbound views (#3362); without this selector the
 	// classifier reports "ambiguous" when they disagree. With it, only this
-	// interface's effective view (zone-level ∪ per-interface override) is
+	// interface's effective view (its per-interface override where declared,
+	// which REPLACES the zone-level set — #6515 — else the zone-level set) is
 	// classified, so an operator can certify one interface's TRUE host-inbound
 	// posture (admit vs deny) instead of a zone-wide first-admit fold. The ref must
 	// name an interface assigned to from_zone; an unknown / zone-mismatched /

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -252,7 +252,8 @@ type Query struct {
 	// A zone can carry multiple per-interface host-inbound effective views
 	// (#3362); without this selector the classifier reports HostInboundAmbiguous
 	// when they disagree. With it, the classifier evaluates ONLY this interface's
-	// effective view (zone-level ∪ per-interface override), so an operator can
+	// effective view (its per-interface override where declared, which REPLACES
+	// the zone-level set — #6515 — else the zone-level set), so an operator can
 	// certify one interface's TRUE host-inbound posture (admit vs deny) instead of
 	// a zone-wide fold. The ref must name an interface assigned to FromZone; a
 	// caller validates it via dataplane/userspace.ResolveHostInboundIngressInterface

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -252,7 +252,7 @@ message ZoneInfo {
   // interface_host_inbound (#3328, #3362) carries per-interface host-inbound
   // overrides. An entry exists only for an interface that declares its own
   // `host-inbound-traffic` stanza; the effective admission set for that
-  // interface is the UNION of the zone-level set above and its override.
+  // interface IS the override — it REPLACES the zone-level set above (#6515).
   repeated InterfaceHostInbound interface_host_inbound = 15;
   // lifeline_interfaces (#3682) lists the zone's interfaces that are
   // management / cluster-control LIFELINES (fxp0 / em0 / fab* / configured
@@ -783,7 +783,8 @@ message MatchPoliciesRequest {
   // ingress interface's effective host-inbound view (#5579). A zone can carry
   // multiple per-interface host-inbound views (#3362); without this selector the
   // classifier reports "ambiguous" when they disagree. With it, only this
-  // interface's effective view (zone-level ∪ per-interface override) is
+  // interface's effective view (its per-interface override where declared,
+  // which REPLACES the zone-level set — #6515 — else the zone-level set) is
   // classified, so an operator can certify one interface's TRUE host-inbound
   // posture (admit vs deny) instead of a zone-wide first-admit fold. The ref must
   // name an interface assigned to from_zone; an unknown / zone-mismatched /

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -432,9 +432,10 @@ validated zone id and stores it in `ForwardingState::zone_host_inbound`.
 
 **Per-interface override (#3362).** Junos also models `host-inbound-traffic`
 at the INTERFACE level (`security zones <z> interfaces <if>
-host-inbound-traffic { ... }`); the effective admission set for an interface
-is the UNION of the zone-level set and its interface-level override. The Go
-control plane computes that effective union and carries it on
+host-inbound-traffic { ... }`); the effective admission set for an interface is
+its interface-level stanza when it declares one, which REPLACES the zone-level
+set (#6515), otherwise the zone-level set. The Go
+control plane computes that effective set and carries it on
 `InterfaceSnapshot` (`host_inbound_configured` +
 `host_inbound_system_services` / `host_inbound_protocols`), populated only for
 an interface that declared an interface-level stanza and is not a

--- a/userspace-dp/src/afxdp/forwarding/host_inbound.rs
+++ b/userspace-dp/src/afxdp/forwarding/host_inbound.rs
@@ -67,8 +67,8 @@ pub(in crate::afxdp) fn zone_host_inbound_from_snapshot(zone: &ZoneSnapshot) -> 
 /// Shared by the zone-level path ([`zone_host_inbound_from_snapshot`]) and the
 /// per-interface OVERRIDE path (`InterfaceSnapshot.host_inbound_*`), so the two
 /// classify identically. The interface-level token set carried on the wire is
-/// already the EFFECTIVE union (zone ∪ interface) computed in Go, so this just
-/// classifies it as-is.
+/// already the EFFECTIVE set computed in Go — the interface stanza REPLACES the
+/// zone one (#6515) — so this just classifies it as-is.
 pub(in crate::afxdp) fn zone_host_inbound_from_tokens(
     services: &[String],
     protocols: &[String],
@@ -719,7 +719,8 @@ pub(in crate::afxdp) fn host_inbound_admits(
 /// #3362: per-packet host-inbound admit keyed by INGRESS INTERFACE first. When
 /// the ingress interface carries a per-interface host-inbound OVERRIDE
 /// (`state.ifindex_host_inbound`), the packet is matched against that interface's
-/// EFFECTIVE admission set (zone ∪ interface, pre-unioned in Go); otherwise it
+/// EFFECTIVE admission set (resolved in Go: the interface stanza REPLACES the
+/// zone one, #6515); otherwise it
 /// falls back to the zone-keyed [`host_inbound_admits`]. The global
 /// ICMP/PMTUD/ND accept (#3171) is applied first in BOTH branches so error / ND
 /// delivery is never broken by a scoped override. This is the entry point the

--- a/userspace-dp/src/afxdp/forwarding/host_inbound_tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/host_inbound_tests.rs
@@ -178,7 +178,7 @@ fn per_interface_override_keys_by_ifindex() {
 
     // Uplink (override present): admits ssh, denies https, and does NOT
     // inherit the zone's ping (the override REPLACES the zone set on this
-    // interface — its set is the Go-side effective union).
+    // interface — #6515 — and the carried set is already resolved in Go).
     assert!(
         host_inbound_admits_iface(&state, IFINDEX_UPLINK, ZONE, TCP, 22, false, 0),
         "uplink override must admit ssh (tcp/22)",

--- a/userspace-dp/src/afxdp/forwarding_build/interfaces.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/interfaces.rs
@@ -231,7 +231,8 @@ pub(super) fn populate_interfaces(
         }
         // #3362: per-interface host-inbound OVERRIDE. When the control plane
         // marked this interface host-inbound-configured, classify its EFFECTIVE
-        // (zone ∪ interface) token set and key it by ifindex so the
+        // token set — resolved in Go, where the interface stanza REPLACES the
+        // zone one (#6515) — and key it by ifindex so the
         // local-delivery admit path prefers it over the from-zone's set. A
         // present-but-empty override classifies to an empty ZoneHostInbound =
         // fail-closed deny-all (matching the zone-level semantics and the nft

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -202,7 +202,8 @@ pub(in crate::afxdp) struct ForwardingState {
     /// #3362: per-INTERFACE host-inbound-traffic OVERRIDE admission set, keyed by
     /// ingress ifindex. Populated only for an interface that declared an
     /// interface-level `host-inbound-traffic` stanza (and is not a lifeline); the
-    /// carried set is the EFFECTIVE union (zone ∪ interface) computed in Go. When
+    /// carried set is the EFFECTIVE set computed in Go, where the interface stanza
+    /// REPLACES the zone-level one (#6515). When
     /// a packet's ingress ifindex is present here the local-delivery admit path
     /// uses THIS set instead of the from-zone's `zone_host_inbound` entry, so a
     /// service exposed on one interface of a zone is admitted there while the


### PR DESCRIPTION
Closes #6515

> **This is an admission NARROWING.** Read "Narrowing analysis" below before merging. Blast radius in-repo is zero, but it can remove management admission on an operator config.

## The defect

Juniper, [Security Zones](https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-zone-configuration.html), fetched today:

> "You can configure these parameters at the zone level, in which case they affect all interfaces of the zone, or at the interface level. **(Interface configuration overrides that of the zone.)**"

xpf combined the two levels with a UNION and asserted "Junos additive semantics" in-tree, so a per-interface `host-inbound-traffic` stanza could only ever WIDEN admission and never narrow it. A zone admitting `protocols ospf` with an interface stanza admitting only `ping` still admitted OSPF on that interface, where Junos denies it. A Junos operator porting a deliberately narrow interface stanza silently got the wide zone set — a fail-open on the management plane.

### Two caveats I am not hiding

- The **worked example** the issue cites narrows a second interface using Junos's `<service> except` keyword, which xpf does not implement. That example is evidence of intent, not of the replace rule; the rule rests on the parenthetical sentence above. `except` is a separate parity gap, noted in the docs.
- I found **no vendor text** settling whether an interface stanza declaring only `protocols` also wipes the zone's `system-services`. This implements **whole-stanza** replace — the literal reading, and the community consensus states it the same way ("if you configure anything under specific interface level, then zone-specific configuration doesn't apply to this interface anymore"). A per-leaf rule would be a guess, and a guess that silently widens admission. The choice and its absence of evidence are documented rather than buried.

## The fix

`config.EffectiveHostInboundTokens` becomes the SSOT for the zone↔interface choice, and **all four** resolvers route through it:

| site | before |
|---|---|
| `ZoneConfig.InterfaceHostInboundEffective` (six display surfaces) | union |
| `effectiveHostInboundTokens` (kernel nft view builder + classifier + wire snapshot) — renamed from `unionHostInboundTokens` | union |
| `effectiveHostInboundSigLocal` (#3718 duplicate-host-address commit gate) | union |
| `cmd/cli` client-side projection over gRPC | union |

The last two were **unbound by any test** — reverting either to a union left its whole package green. Each now has a test that reds only on that site.

Two properties the resolver pins:

- **Presence, not emptiness.** An explicit `host-inbound-traffic { }` on an interface is a deny-all override, never a fallback to the zone set. `parseHostInboundNode` already compiles a present-but-empty stanza to a non-nil empty struct precisely so the two are distinguishable.
- **The whole stanza replaces**, per the caveat above.

`UnionHostInboundTokens` is retained, narrowed in its doc to what it actually is: a merge of tokens authored at the SAME level. Two live callers need it — the #3720 physical∪unit resolution (both are interface-level statements) and the #4544 repeated-block merge.

## Narrowing analysis

**Lost set** = the zone-level tokens an interface stanza does not repeat (after `all`-expansion), for every interface that declares a stanza. At risk: `ssh` (management), `ike` (ESP/AH keep their global accept, but IKE udp/500,4500 is token-gated, so tunnels stop rekeying), `https`/webmgmt, unicast `bgp`/`ospf` to the interface address.

**It is not only new connections — this is the #1960 headline.** The #5566 reconcile (`buildHostInboundConntrackFlushFilter`) rebuilds its admit set from these same `ZoneHostInboundView`s and DELETES established kernel conntrack entries to a covered firewall-local address the new set no longer admits. A narrowing commit drops the operator's **live** session, it does not merely refuse the next one.

**Structurally out of scope.** Lifeline interfaces (`fxp0` / `em0` / `fab*` and the configured control + fabric links) are excluded from host-inbound deny scoping by INTERFACE, so management over `fxp0` and the HA control plane (heartbeat, session sync, config sync over `em0`) are unaffected. VRRP advertisements are unaffected: the views scope drops to unicast interface addresses plus VRRP VIPs only, and 224.0.0.18 is never in that scope. Per #7284 the lifeline exclusion is by interface, **not** by address value — a management address also configured on a zoned interface is not exempt, and this flip widens that existing exposure.

**Measured blast radius in-repo: zero.** Not one config in the tree authors an interface-level override — `test/incus/*.conf`, `docs/ha-cluster*.conf` and `docs/ha-cluster-userspace.conf` are all zone-level only. The discriminator (`ifaceHI != nil`) does vary in the Go fixtures, which is why the flip is testable, but it has no instance in any shipped or documented config.

### Why a straight correction and not a config knob

1. It is a fail-OPEN parity defect on the management plane.
2. The precedent on this exact plane is a straight flip: #3405 (no-stanza zone: admit-all → default-deny) and #4420 (unzoned addresses: accept → drop), both relying on the same lifeline exclusion as the net.
3. A compatibility knob would itself be non-Junos syntax and would leave the wrong behaviour as the permanent default.
4. The advisory below makes the migration mechanical and visible at `commit check` — strictly better than the issue's proposed prior-release advisory, since it names the loss at the moment it would happen rather than in a version the operator may skip.

## Migration advisory (ships in this commit)

`validateHostInboundOverrideReplaceWarnings` emits one warning per zone interface whose stanza takes admission away, naming every `(zone, interface, lost token)` triple and the remedy: repeat the zone tokens in the interface stanza. WARN-only — the new behaviour IS the Junos behaviour, and rejecting the config would refuse something Junos accepts. It is emitted per zone INTERFACE rather than per authored stanza, so a unit that merely INHERITS a physical-parent override (#3720) is also named. Lifeline interfaces and effective sets that full-admit are skipped: nothing is lost there, and an advisory firing on configs that lose nothing is one operators learn to ignore.

## Existing fixtures

Eight fixtures encoded the union and were updated **with the reason**, not deleted. One is worth calling out: `Test_5579_IngressInterfaceUnionWithZoneLevel` claimed in a comment that the overridden interface "admits ssh AND ping" but only ever queried tcp/22 there — it varied the right axis and sampled only the passing point, so it passed unchanged when the semantics flipped under it. It now queries all four (interface × service) cells and reds under the revert.

The `Test_3226_AdvisoriesReasonAboutTheEffectiveTokenSet/zone any-service with interface rpm` subtest is **inverted** rather than removed: under replace the interface's effective set really is `{rpm}`, rpm really is denied there, and the advisory is now telling the truth. That subtest is the one that distinguishes the two combination rules, so it is the one worth pinning.

## Validation

- `go vet ./...` clean **before** the mutation runs, so a red is an assertion and not a build break.
- Full `go test -count=1 ./...` green — 63 packages, rc 0.
- `cargo check --all-targets` on `userspace-dp` clean. The Rust diff is **comments only** (verified: the only non-comment lines in `git diff userspace-dp/` are in a `.md`), so no compiled artifact moved.

### Mutation matrix — one line per cell, each restored and the file re-verified byte-identical

| # | mutated line | red | green |
|---|---|---|---|
| MA | `EffectiveHostInboundTokens` → return the union | 19 tests across `pkg/config` + `pkg/dataplane/userspace` (incl. the repaired 5579 test) | `NoInterfaceStanzaKeepsZoneSet_6515` (union(zone,nil) == zone) |
| MB | `overridden := ifaceHI != nil` → emptiness test | `TestEmptyInterfaceStanzaIsDenyAllNotFallback_6515` only | rest of package |
| MC | advisory full-admit gate → `&& false` | `silent when the override full-admits` only | 7 sibling subtests |
| MD | advisory lifeline gate → `&& false` | `silent on a lifeline interface` only | 7 sibling subtests |
| ME | advisory admitted-side stops expanding `all` | ``silent when the override `all` covers the zone token`` only | 7 sibling subtests |
| MG | `effectiveHostInboundSigLocal` → union | **nothing** (before the new test) → `TestDuplicateHostLocalAddressGateUsesReplaceSemantics_6515` (after) | — |
| MH | `cmd/cli` projection → union | **nothing** (before the new test) → `TestZoneHostInboundViewReplacesZoneSet_6515` (after) | — |

MC/MD were first written as `if false {`, which broke the build (`fullAdmit` / `lifelines` unused) — a build break is not an assertion red, so they were re-run as `&& false` to keep the package compiling.

Production call paths for the mutated sites: `EffectiveHostInboundTokens` ← `BuildZoneHostInboundViews` (the kernel `xpf_hostinbound` chain), `ClassifyHostInboundForInterface` (REST/gRPC/CLI `match-policies`), `buildInterfaceSnapshots` (the AF_XDP wire snapshot), `ValidateConfig` (commit / commit-check), and the six zone display surfaces.

## Cluster time

No HA or cluster code is touched, so this does **not** owe `make test-failover`. It does change how the kernel host-inbound chain's admit set is computed, but the loss userspace cluster config authors zone-level stanzas only, so the computed set there is bit-identical — a smoke would exercise nothing new. Say the word if you want one anyway.

## Docs

`docs/host-inbound-service-matrix.md` gains "Replace, not union (#6515) — UPGRADE NOTE" (vendor quote, presence-vs-emptiness, granularity and why no per-leaf rule, the `except` gap, what upgrading takes away, the #5566 live-session flush, what is structurally out of scope, and the advisory). Every in-tree claim that the two levels union was corrected — `types_security.go`, `schema_security.go`, `protocol.go`, `api/types.go`, `api/README.md`, `policymatch.go`, `cli_show_interfaces.go`, the Rust comments and `forwarding/README.md`, `docs/junos-cli-reference.md`, `docs/host-inbound-multicast.md`, `docs/config-schema.md`, and the `.proto` (regenerated; the pb.go diff is the two comments and nothing else). `_Log.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cz2czGK3aA5MsMhkNkjHXX