### PR TITLE
config: one interface-level host-inbound walk, not two

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -100945,3 +100945,17 @@ prose edit above them added. No diff falls in the new test body.
   pkg/config/compiler_device_map_dup_name_6546_test.go (new),
   pkg/daemon/device_map_dup_name_6546_test.go (new),
   docs/bare-metal-device-map.md, _Log.md
+
+## 2026-08-21 — #6519 follow-up: one interface-level host-inbound walk, not two
+- **Timestamp**: 2026-08-21
+- **Action**: #6515 and #6519 landed independently, each carrying its own copy of
+  the #3720 physical∪unit interface-level override walk —
+  `InterfaceHostInboundEffective` inline, and `InterfaceHostInboundOverride` in
+  the #6519 advisory. `InterfaceHostInboundEffective` now CALLS
+  `InterfaceHostInboundOverride`. Single-sourced rather than bound with an
+  agreement test because a divergence would ALWAYS be a bug: the #6519 advisory
+  asks "does the interface's own stanza authorize this?" to decide what the
+  zone-level stanza is answerable for, and must be asking about the set the
+  resolver admits. Behaviour-preserving; no advisory or enforcement change.
+- **File(s)**: pkg/config/host_inbound_view.go,
+  pkg/config/host_inbound_dhcp_scope_6519.go

--- a/pkg/config/host_inbound_dhcp_scope_6519.go
+++ b/pkg/config/host_inbound_dhcp_scope_6519.go
@@ -41,10 +41,11 @@ var hostInboundDHCPExceptionServices = []string{"dhcp", "bootp"}
 // ref's own unit-level override (#3720, both are interface-level statements) —
 // and whether ref declares any interface-level stanza at all.
 //
-// It is the interface-level half of what InterfaceHostInboundEffective resolves,
-// exposed on its own because a caller sometimes needs to know what the INTERFACE
-// authorized as distinct from what the interface ends up admitting. #6519 is
-// that caller: "the zone-level token is what authorizes DHCP here" is precisely
+// It is the interface-level half of what InterfaceHostInboundEffective resolves
+// — that resolver CALLS this, so the #3720 physical∪unit walk exists once and not
+// twice: a divergence between them would always be a bug. It is exposed on its
+// own because a caller sometimes needs to know what the INTERFACE authorized as
+// distinct from what the interface ends up admitting. #6519 is that caller: "the zone-level token is what authorizes DHCP here" is precisely
 // "the effective set admits it and the interface's own stanza does not", and
 // that predicate is correct whether the two levels union or the interface level
 // replaces the zone level.

--- a/pkg/config/host_inbound_view.go
+++ b/pkg/config/host_inbound_view.go
@@ -131,29 +131,23 @@ func (z *ZoneConfig) InterfaceHostInboundEffective(ref string) (svc, proto []str
 	if z == nil {
 		return UnionHostInboundTokens(zoneSvc, nil), UnionHostInboundTokens(zoneProto, nil), false
 	}
-	// #3720 (H05): the physical and the unit level are BOTH "interface level", so
-	// the override for a unit is the UNION of the two, exactly as the dataplane
-	// resolves it in buildInterfaceHostInboundMap. (#6515 replaces the ZONE level
-	// with this result; it does not change how the two interface-level statements
-	// combine with each other.) For a logical-unit ref (contains "."), a
-	// physical-interface-level override on its parent IN THIS ZONE also applies,
-	// so the diagnostic must UNION it. Before #3720 this read only the exact ref,
-	// so `show interfaces <unit>` reported "no override / default-deny" while the
-	// dataplane admitted the inherited physical override — the diagnostic gave the
-	// OPPOSITE answer to enforcement.
+	// The INTERFACE-level half comes from InterfaceHostInboundOverride, which owns
+	// the #3720 (H05) physical∪unit union: the physical and the unit level are
+	// BOTH "interface level", so the override for a unit is the UNION of the two,
+	// exactly as the dataplane resolves it in buildInterfaceHostInboundMap. (#6515
+	// replaces the ZONE level with that result; it does not change how the two
+	// interface-level statements combine with each other.) Before #3720 this read
+	// only the exact ref, so `show interfaces <unit>` reported "no override /
+	// default-deny" while the dataplane admitted the inherited physical override —
+	// the diagnostic gave the OPPOSITE answer to enforcement.
+	//
+	// It is a CALL and not a second copy of that walk because a divergence between
+	// the two would always be a bug: the #6519 advisory asks
+	// InterfaceHostInboundOverride "does the interface's own stanza authorize this
+	// service?" precisely to decide what the ZONE-level stanza is answerable for,
+	// and it has to be asking about the same set this resolver admits.
 	var ovSvc, ovProto []string
-	if base, unit, ok := strings.Cut(ref, "."); ok && unit != "" && base != "" {
-		if phys := z.InterfaceHostInbound[base]; phys != nil {
-			ovSvc = UnionHostInboundTokens(ovSvc, phys.SystemServices)
-			ovProto = UnionHostInboundTokens(ovProto, phys.Protocols)
-			overridden = true
-		}
-	}
-	if exact := z.InterfaceHostInbound[ref]; exact != nil {
-		ovSvc = UnionHostInboundTokens(ovSvc, exact.SystemServices)
-		ovProto = UnionHostInboundTokens(ovProto, exact.Protocols)
-		overridden = true
-	}
+	ovSvc, ovProto, overridden = z.InterfaceHostInboundOverride(ref)
 	if !overridden {
 		return UnionHostInboundTokens(zoneSvc, nil), UnionHostInboundTokens(zoneProto, nil), false
 	}


### PR DESCRIPTION
Follow-up to #7310 (#6515) and #7314 (#6519), both now merged. No issue closed — this is a duplication the two PRs created between them by landing independently.

## What happened

Both PRs needed the #3720 physical∪unit interface-level override walk, and each brought its own copy:

- `ZoneConfig.InterfaceHostInboundEffective` resolves it inline (pre-existing);
- `ZoneConfig.InterfaceHostInboundOverride` (new in #7314) does the same walk, because the #6519 zone-level DHCP advisory needs to ask what the **interface** authorized as distinct from what the interface ends up admitting.

Neither PR could see the other's copy while they were open.

## The fix

`InterfaceHostInboundEffective` now calls `InterfaceHostInboundOverride`.

**Single-sourced rather than bound with an agreement test**, because a divergence between the two would *always* be a bug: the #6519 advisory asks "does this interface's own stanza authorize the service?" precisely to decide what the ZONE-level stanza is answerable for, and it has to be asking about the same set the resolver admits. There is no configuration in which the two should legitimately differ, so binding them with a test would be documenting a divergence that must never happen rather than preventing it.

Behaviour-preserving: no advisory text, no enforcement, no rendered output changes.

## Validation

- `go vet ./...` clean **before** the mutation runs.
- Full `go test -count=1 ./...` green — 63 packages, rc 0.

### Mutation matrix — each restored and the file re-verified byte-identical

| # | mutated line | red |
|---|---|---|
| P1 | physical-parent branch inside the now-shared walk → `&& false` | `TestInterfaceHostInboundOverrideAgreesWithEffective_6519`, **`Test_3720_EffectiveUnitUnionsPhysical`**, **`Test_3720_EffectiveUnitInheritsPhysicalOnly`**, `TestInterfaceHostInboundEffectiveReplacesZoneNotInterfaceLevels_6515` |
| P2 | resolver stops delegating (resolves the exact ref itself) | 12 tests across #3720, #3654, #6515, #6519 |

P1 is the point of the change: **before** it, the same mutation reded only the #6519 agreement test, because the two #3720 tests exercised the other copy. The shared walk is now covered by the older tests as well, which is exactly the coverage the duplication was costing.

## Cluster time

None owed — pure control-plane refactor, no HA/cluster code, no dataplane artifact.

## Docs

`_Log.md` only. The behaviour is unchanged, so `docs/host-inbound-service-matrix.md`'s description of the resolution still holds verbatim; the doc comments on both functions now name each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cz2czGK3aA5MsMhkNkjHXX