### PR TITLE
vrrp: drop self-transmitted advertisement frames (#6560)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -101185,3 +101185,19 @@ prose edit above them added. No diff falls in the new test body.
   pkg/config/compiler_multivalue_leaf_failopen_6659_test.go,
   pkg/config/compiler_multivalue_leaf_empty_6673_test.go,
   docs/feature-gaps.md, docs/phases.md, _Log.md
+
+## 2026-08-21 — #6560 VRRP self-frame filter
+- **Timestamp**: 2026-08-21
+- **Action**: VRRP had no PACKET_OUTGOING / multicast-loop self-frame filter;
+  self-filtering rested solely on the deliberately-nilable getLocalIP()
+  snapshot, which is nil for 30ms-1s during the #2528 RETH-MAC flush window,
+  so a MASTER could process its own advert and self-demote via
+  resolveEqualPriorityMaster's nil-localCmp step-down. Confirmed the frame IS
+  delivered by two mechanisms (AF_PACKET ETH_P_ALL TX tap; IP multicast
+  loopback on the fallback raw sockets) — the socket did NOT already filter.
+  Added PACKET_IGNORE_OUTGOING (set before bind, best-effort), an sll_pkttype
+  drop in receiverAfPacket (Recvfrom's sockaddr was being discarded), and
+  IP_MULTICAST_LOOP/IPV6_MULTICAST_LOOP disable on both fallback sockets.
+  TOUCHES VRRP — owes `make test-failover`.
+- **File(s)**: pkg/vrrp/manager.go, pkg/vrrp/instance_receive.go,
+  pkg/vrrp/self_frame_filter_6560_test.go (new), pkg/vrrp/README.md, _Log.md

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -661,6 +661,64 @@ DOWN → set MAC → UP flushes ALL kernel addresses; networkd
 `KeepConfiguration=static` restores them, but with a 30 ms–1 s window
 against the next 30 ms advert), plus a DAD-failed link-local re-add.
 
+#### Self-frame filtering does not depend on the address snapshot (#6560)
+
+The address re-resolution above narrows the stale-source window but
+cannot close it, because `reresolveLocalAddrs` legitimately stores
+**nil** when the interface has no non-VIP address of the family — which
+is exactly what the flush window produces. Every self-check on the
+receive path is written `lip != nil && src.Equal(lip)`, so **a nil
+snapshot means ACCEPT**. Combined with the delivery paths below, a
+MASTER could process its OWN advertisement, land on
+`resolveEqualPriorityMaster`'s equal-priority branch, hit the
+`localCmp == nil` arm, and `becomeBackup` — the "stepping down" log line
+whose comment justifies the step-down by assuming the advert came from a
+peer. In this case the "actively advertising equal-priority peer" is the
+node itself.
+
+Self-adverts really are delivered, by two independent mechanisms, and
+neither was suppressed:
+
+- **The AF_PACKET tap (primary path).** The capture socket is
+  `ETH_P_ALL` — what tcpdump uses, and why tcpdump shows egress
+  traffic. `dev_queue_xmit_nit` clones every outbound frame to each
+  `ptype_all` tap with `skb->pkt_type = PACKET_OUTGOING`, and
+  `packet_rcv` drops only `PACKET_LOOPBACK`. Adverts leave on the raw
+  AF_INET/AF_INET6 sockets, but they egress the very netdev this socket
+  is bound to. The cBPF filter cannot help: every instruction matches
+  ethertype or IP protocol, there is no `SKF_AD_PKTTYPE` ancillary
+  load, and a self-advert satisfies it exactly.
+- **IP multicast loopback (fallback path).** The raw `ip4:112` /
+  `ip6:112` sockets both send and `JoinGroup` 224.0.0.18 / ff02::12,
+  and `IP_MULTICAST_LOOP` defaults to 1 — so the kernel cloned every
+  advert we transmitted back into the socket that sent it.
+
+Three fixes, none of which touch the state machine:
+
+1. `PACKET_IGNORE_OUTGOING` on the AF_PACKET receiver, set **before**
+   bind (an `ETH_P_ALL` socket is already capturing at creation, so
+   setting it after bind would leave a window). Best-effort: it is
+   Linux >= 4.20 and an older kernel logs and continues.
+2. `receiverAfPacket` now keeps the `sockaddr_ll` that `Recvfrom`
+   returns — it used to discard it as `_`, which made `sll_pkttype`
+   structurally unavailable — and drops `PACKET_OUTGOING`. This is the
+   belt that still holds on a kernel without (1).
+3. `IP_MULTICAST_LOOP` / `IPV6_MULTICAST_LOOP` disabled on the fallback
+   raw sockets. Both are per-SENDING-socket, so they suppress only the
+   loopback of our own transmissions; a peer's advert arriving from the
+   wire is unaffected.
+
+An unclassifiable sockaddr **fails open** (treated as not-outgoing).
+Dropping a frame we cannot classify would be a self-inflicted
+master-down, which is strictly worse than the bug being fixed.
+
+**Not addressed here.** `resolveLocalIPv4` selects ONE address (the
+lowest non-VIP), not the interface's address SET, so a self-advert sent
+from address A also bypasses the comparison once the selected source has
+become B. That residual is narrower than it looks now that the two
+delivery paths above are suppressed, and it is tracked separately rather
+than folded in.
+
 The manager now runs a singleton ADDRESS-watcher (`addrwatch.go`,
 `runAddrWatcher`) subscribed via `netlink.AddrSubscribe`. On any address
 add/del whose `LinkIndex` matches an instance's bound `iface.Index`, it

--- a/pkg/vrrp/instance_receive.go
+++ b/pkg/vrrp/instance_receive.go
@@ -258,7 +258,7 @@ func (vi *vrrpInstance) receiverAfPacket() {
 		default:
 		}
 
-		n, _, err := unix.Recvfrom(vi.afPacketFD, buf, 0)
+		n, from, err := afPacketRecvfrom(vi.afPacketFD, buf, 0)
 		if err != nil {
 			select {
 			case <-vi.stopCh:
@@ -270,6 +270,13 @@ func (vi *vrrpInstance) receiverAfPacket() {
 				}
 				continue
 			}
+		}
+
+		// Drop our OWN transmissions (#6560). See afPacketFrameIsOutgoing for
+		// why this is not redundant with PACKET_IGNORE_OUTGOING, and why the
+		// address-snapshot comparison further down cannot cover it.
+		if afPacketFrameIsOutgoing(from) {
+			continue
 		}
 
 		// Need at least 14 bytes to read the ethertype.
@@ -521,4 +528,54 @@ func (vi *vrrpInstance) warnRXDrop() {
 	}
 	slog.Warn("vrrp: rx channel full, dropping advertisements",
 		"key", vi.key(), "total_drops", drops)
+}
+
+// afPacketRecvfrom is the recvfrom(2) entry point used by receiverAfPacket.
+// Package var for the same reason as afPacketSocket in manager.go: it lets a
+// test drive the receive LOOP — including the #6560 self-frame drop, which lives
+// in the loop and not in the parsers — deterministically and without CAP_NET_RAW.
+var afPacketRecvfrom = unix.Recvfrom
+
+// afPacketFrameIsOutgoing reports whether a frame the AF_PACKET capture socket
+// delivered is one this host TRANSMITTED, using the sll_pkttype the kernel
+// reports in the frame's sockaddr_ll (#6560).
+//
+// WHY THIS EXISTS AT ALL. The capture socket is an ETH_P_ALL tap — that is what
+// tcpdump uses and why tcpdump shows egress traffic. dev_queue_xmit_nit clones
+// every outbound frame to each ptype_all tap with skb->pkt_type =
+// PACKET_OUTGOING, and packet_rcv drops only PACKET_LOOPBACK. Adverts leave on
+// the raw AF_INET/AF_INET6 sockets, but they egress the very netdev this socket
+// is bound to, so a MASTER's own advertisement arrives in its own receive queue.
+// The cBPF filter cannot stop it: every instruction matches ethertype or IP
+// protocol, there is no SKF_AD_PKTTYPE ancillary load, and a self-advert
+// satisfies the filter exactly.
+//
+// WHY THE EXISTING SELF-CHECK IS NOT ENOUGH. Self-filtering rested solely on
+// comparing the frame's source against getLocalIP()/getLocalIPv6(), and those
+// are DELIBERATELY nilable: reresolveLocalAddrs stores nil when the interface
+// has no non-VIP address of the family. Every one of those four comparisons is
+// written `lip != nil && src.Equal(lip)`, so a nil snapshot means ACCEPT. During
+// the #2528 RETH-MAC flush window — programRethMAC does link DOWN, set MAC, link
+// UP, and DOWN flushes every kernel address — the snapshot is nil for 30ms-1s.
+// A self-advert already committed to the tap then reaches handleMasterRx, where
+// it necessarily carries our own priority, so resolveEqualPriorityMaster runs;
+// that function re-reads the same nilable snapshot and, on nil, logs "local
+// source unresolved — stepping down" and calls becomeBackup. The comment there
+// justifies the step-down by assuming the advert came from a PEER. In this case
+// the "actively advertising equal-priority peer" is this node itself.
+//
+// WHY IT IS NOT REDUNDANT WITH PACKET_IGNORE_OUTGOING. That socket option is
+// Linux >= 4.20; on an older kernel openAfPacketReceiver logs and continues, and
+// this check is what still holds. Keeping both is the belt-and-braces pair: the
+// option avoids the copy, this avoids acting on it.
+//
+// A sockaddr that is missing or not a link-layer one is treated as NOT outgoing.
+// Failing open here is correct: a frame we cannot classify must still be able to
+// be a peer's advert, and dropping it would be a self-inflicted master-down.
+func afPacketFrameIsOutgoing(from unix.Sockaddr) bool {
+	sll, ok := from.(*unix.SockaddrLinklayer)
+	if !ok || sll == nil {
+		return false
+	}
+	return sll.Pkttype == unix.PACKET_OUTGOING
 }

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -1130,6 +1130,16 @@ func openPerInterfaceSocket(ifName string, iface *net.Interface, isVLAN bool) (*
 		return nil, nil, fmt.Errorf("raw conn: %w", err)
 	}
 
+	// Do not loop our own adverts back to local sockets (#6560). This socket
+	// both sends and receives, and it joins 224.0.0.18 below, so with the
+	// default IP_MULTICAST_LOOP=1 the kernel clones every advert we transmit
+	// back up the local receive path and into this very socket. The option is
+	// per-SENDING-socket, so it suppresses only the loopback of our own
+	// transmissions; a peer's advert arriving from the wire is unaffected.
+	if err := rawConn.SetMulticastLoopback(false); err != nil {
+		slog.Debug("vrrp: disable ipv4 multicast loopback failed", "interface", ifName, "err", err)
+	}
+
 	// Join VRRP multicast group on this interface.
 	group := net.IPv4(224, 0, 0, 18)
 	if err := rawConn.JoinGroup(iface, &net.IPAddr{IP: group}); err != nil {
@@ -1143,6 +1153,12 @@ func openPerInterfaceSocket(ifName string, iface *net.Interface, isVLAN bool) (*
 // It is a package var so tests can intercept the call and assert the type
 // flags (notably SOCK_CLOEXEC) without needing CAP_NET_RAW.
 var afPacketSocket = unix.Socket
+
+// afPacketSetsockoptInt is the setsockopt(2) entry point used by
+// openAfPacketReceiver for PACKET_IGNORE_OUTGOING. Package var for the same
+// reason as afPacketSocket: it lets a test assert the EXACT (level, option,
+// value) the call site uses, deterministically and without CAP_NET_RAW.
+var afPacketSetsockoptInt = unix.SetsockoptInt
 
 // VRRP advertisement multicast destination MACs. IPv4 VRRP adverts go to
 // 224.0.0.18 which maps to the Ethernet multicast MAC 01:00:5e:00:00:12; IPv6
@@ -1268,6 +1284,31 @@ func openAfPacketReceiver(ifIndex int) (int, error) {
 	fd, err := afPacketSocket(unix.AF_PACKET, unix.SOCK_RAW|unix.SOCK_CLOEXEC, int(proto))
 	if err != nil {
 		return -1, fmt.Errorf("af_packet socket: %w", err)
+	}
+
+	// Ask the kernel not to deliver our OWN transmissions to this capture
+	// socket (#6560).
+	//
+	// This socket is an ETH_P_ALL tap, which is what tcpdump uses and why it
+	// shows egress traffic: dev_queue_xmit_nit clones every outbound frame to
+	// each ptype_all tap with skb->pkt_type = PACKET_OUTGOING, and packet_rcv
+	// drops only PACKET_LOOPBACK. Adverts leave on the raw AF_INET/AF_INET6
+	// sockets, but they egress the very netdev this socket is bound to, so a
+	// MASTER's own advertisement lands in its own receive queue -- passing the
+	// cBPF filter, which matches ethertype and IP protocol only and has no
+	// pkttype ancillary load.
+	//
+	// Set BEFORE bind, deliberately. socket(AF_PACKET, SOCK_RAW,
+	// htons(ETH_P_ALL)) with a non-zero protocol is already capturing on every
+	// interface at creation, so setting this after bind would leave a window in
+	// which our own frames could already be queued.
+	//
+	// Best-effort: PACKET_IGNORE_OUTGOING is Linux >= 4.20. An older kernel
+	// returns ENOPROTOOPT and keeps working, because the receive loop's
+	// sll_pkttype check (receiverAfPacket) is the belt this is the braces for.
+	if err := afPacketSetsockoptInt(fd, unix.SOL_PACKET, unix.PACKET_IGNORE_OUTGOING, 1); err != nil {
+		slog.Debug("vrrp: PACKET_IGNORE_OUTGOING unavailable; relying on the sll_pkttype check",
+			"ifindex", ifIndex, "err", err)
 	}
 
 	// Bind to specific interface.
@@ -1396,6 +1437,13 @@ func openIPv6Socket(ifName string, iface *net.Interface, isVLAN bool) (net.Packe
 	if err := sc.Control(func(rawfd uintptr) {
 		// Ignore error — may fail if group already joined.
 		_ = unix.SetsockoptIPv6Mreq(int(rawfd), unix.IPPROTO_IPV6, unix.IPV6_JOIN_GROUP, mreq)
+		// Do not loop our own adverts back to local sockets (#6560) — the v6
+		// twin of the IP_MULTICAST_LOOP disable on the IPv4 raw conn. Same
+		// reasoning: this socket sends AND joins ff02::12, so the default
+		// loopback delivers our own adverts straight back into it.
+		if err := unix.SetsockoptInt(int(rawfd), unix.IPPROTO_IPV6, unix.IPV6_MULTICAST_LOOP, 0); err != nil {
+			slog.Debug("vrrp: disable ipv6 multicast loopback failed", "interface", ifName, "err", err)
+		}
 	}); err != nil {
 		slog.Debug("vrrp: ipv6 join multicast failed", "interface", ifName, "err", err)
 	}

--- a/pkg/vrrp/self_frame_filter_6560_test.go
+++ b/pkg/vrrp/self_frame_filter_6560_test.go
@@ -1,0 +1,216 @@
+package vrrp
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestAfPacketFrameIsOutgoing_6560 pins the classification the receive loop
+// gates on. Before #6560 the sockaddr from Recvfrom was discarded (`n, _, err
+// :=`), so sll_pkttype was structurally unavailable and a self-transmitted
+// advert was indistinguishable from a peer's.
+func TestAfPacketFrameIsOutgoing_6560(t *testing.T) {
+	if !afPacketFrameIsOutgoing(&unix.SockaddrLinklayer{Pkttype: unix.PACKET_OUTGOING}) {
+		t.Fatal("a PACKET_OUTGOING frame is our own transmission and must be dropped")
+	}
+	// Every delivery type a PEER's advert can arrive as must be kept. Getting
+	// this wrong is not a missed optimisation — dropping a peer advert is a
+	// self-inflicted master-down.
+	for name, pt := range map[string]uint8{
+		"multicast": unix.PACKET_MULTICAST,
+		"host":      unix.PACKET_HOST,
+		"broadcast": unix.PACKET_BROADCAST,
+		"otherhost": unix.PACKET_OTHERHOST,
+	} {
+		if afPacketFrameIsOutgoing(&unix.SockaddrLinklayer{Pkttype: pt}) {
+			t.Fatalf("a PACKET_%s frame is a peer's advert and must be kept", name)
+		}
+	}
+	// An unclassifiable sockaddr FAILS OPEN: a frame we cannot classify must
+	// still be able to be a peer's advert.
+	if afPacketFrameIsOutgoing(nil) {
+		t.Fatal("a nil sockaddr must fail open (kept), not be dropped as self")
+	}
+	if afPacketFrameIsOutgoing(&unix.SockaddrInet4{}) {
+		t.Fatal("a non-link-layer sockaddr must fail open (kept), not be dropped as self")
+	}
+	// A typed-nil *SockaddrLinklayer must not panic on the Pkttype deref.
+	var typedNil *unix.SockaddrLinklayer
+	if afPacketFrameIsOutgoing(typedNil) {
+		t.Fatal("a typed-nil link-layer sockaddr must fail open (kept)")
+	}
+}
+
+// TestAfPacketReceiverIgnoresOutgoing_6560 is the WIRING gate for the socket
+// option: openAfPacketReceiver must actually ask the kernel to stop delivering
+// our own transmissions. It intercepts the setsockopt(2) entry point so the
+// exact (level, option, value) at the call site is asserted deterministically,
+// without CAP_NET_RAW.
+//
+// Deleting the afPacketSetsockoptInt call from openAfPacketReceiver makes this
+// go red; the pure classification test above would not catch that.
+func TestAfPacketReceiverIgnoresOutgoing_6560(t *testing.T) {
+	type call struct{ level, opt, value int }
+	var calls []call
+
+	origSock := afPacketSocket
+	origOpt := afPacketSetsockoptInt
+	defer func() {
+		afPacketSocket = origSock
+		afPacketSetsockoptInt = origOpt
+	}()
+
+	// Hand back a real but harmless fd so the function proceeds past socket()
+	// into the setsockopt call. Bind then fails (a link-layer address on an
+	// AF_UNIX socket), which is fine — the option is set BEFORE bind on purpose,
+	// because an ETH_P_ALL socket is already capturing at creation and setting
+	// it after bind would leave a window for our own frames to queue.
+	fd, err := unix.Socket(unix.AF_UNIX, unix.SOCK_DGRAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Skipf("cannot open a stand-in fd: %v", err)
+	}
+	defer unix.Close(fd)
+
+	afPacketSocket = func(_, _, _ int) (int, error) { return fd, nil }
+	afPacketSetsockoptInt = func(_, level, opt, value int) error {
+		calls = append(calls, call{level, opt, value})
+		return unix.ENOPROTOOPT // an old kernel — must be tolerated, not fatal
+	}
+
+	// Bind will fail; that is expected and irrelevant to what is asserted.
+	_, _ = openAfPacketReceiver(1)
+
+	var found bool
+	for _, c := range calls {
+		if c.level == unix.SOL_PACKET && c.opt == unix.PACKET_IGNORE_OUTGOING {
+			found = true
+			if c.value != 1 {
+				t.Fatalf("PACKET_IGNORE_OUTGOING set to %d, want 1", c.value)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("openAfPacketReceiver never set PACKET_IGNORE_OUTGOING; setsockopt calls: %+v", calls)
+	}
+}
+
+// buildSelfAdvertFrame6560 builds a complete, VALID Ethernet + IPv4 + VRRPv3
+// advertisement frame from srcIP, exactly as this node would transmit one. It
+// must be genuinely parseable: a frame the parser would reject for any other
+// reason would make the test below pass for the wrong reason.
+func buildSelfAdvertFrame6560(t *testing.T, srcIP net.IP, vrid, prio uint8) []byte {
+	t.Helper()
+	dstIP := net.IPv4(224, 0, 0, 18).To4()
+	pkt := &VRRPPacket{
+		VRID:         vrid,
+		Priority:     prio,
+		MaxAdvertInt: 3,
+		IPAddresses:  []net.IP{srcIP.To4()},
+	}
+	payload, err := pkt.Marshal(false, srcIP.To4(), dstIP)
+	if err != nil {
+		t.Fatalf("marshal advert: %v", err)
+	}
+
+	frame := make([]byte, 14+20+len(payload))
+	binary.BigEndian.PutUint16(frame[12:14], 0x0800) // ethertype IPv4
+
+	ip := frame[14:]
+	ip[0] = 0x45                                                 // v4, IHL 5
+	binary.BigEndian.PutUint16(ip[2:4], uint16(20+len(payload))) // total length
+	ip[8] = 255                                                  // TTL, RFC 5798 §5.1.1.3
+	ip[9] = 112                                                  // proto VRRP
+	copy(ip[12:16], srcIP.To4())
+	copy(ip[16:20], dstIP)
+	copy(ip[20:], payload)
+	return frame
+}
+
+// TestReceiverAfPacketDropsSelfFrameWithNilSnapshot_6560 is the fail-on-revert
+// gate for the LOOP, and it reproduces the issue's exact scenario.
+//
+// The local-IP snapshot is left NIL — the state reresolveLocalAddrs stores
+// during the #2528 RETH-MAC flush window, when programRethMAC's link DOWN has
+// flushed every kernel address. All four existing self-checks are written
+// `lip != nil && src.Equal(lip)`, so a nil snapshot means ACCEPT: without the
+// sll_pkttype drop this node's OWN advert reaches rxCh, and from there
+// handleMasterRx -> resolveEqualPriorityMaster, which on a nil snapshot logs
+// "local source unresolved — stepping down" and calls becomeBackup. A MASTER
+// demotes itself.
+//
+// Deleting `if afPacketFrameIsOutgoing(from) { continue }` from receiverAfPacket
+// makes this go red. Neither the pure classification test nor the setsockopt
+// wiring test above would catch that deletion.
+func TestReceiverAfPacketDropsSelfFrameWithNilSnapshot_6560(t *testing.T) {
+	const vrid = 42
+	self := net.IPv4(10, 0, 61, 1)
+	peer := net.IPv4(10, 0, 61, 2)
+
+	vi := &vrrpInstance{
+		afPacketFD: 3, // never touched: the recvfrom seam is stubbed
+		rxCh:       make(chan *VRRPPacket, 8),
+		stopCh:     make(chan struct{}),
+	}
+	vi.cfg.GroupID = vrid
+	vi.cfg.Family = "inet"
+	// The flush window: no local address of the family is resolvable.
+	vi.setLocalIP(nil)
+	if vi.getLocalIP() != nil {
+		t.Fatal("setup: the local-IP snapshot must be nil to reproduce the flush window")
+	}
+
+	// Same VRID and the same priority the instance would advertise, so the
+	// frame lands on resolveEqualPriorityMaster's equal-priority branch — the
+	// path that steps a MASTER down.
+	selfFrame := buildSelfAdvertFrame6560(t, self, vrid, 100)
+	peerFrame := buildSelfAdvertFrame6560(t, peer, vrid, 100)
+
+	type delivery struct {
+		frame   []byte
+		pkttype uint8
+	}
+	queue := []delivery{
+		{selfFrame, unix.PACKET_OUTGOING},  // our own transmission, tapped on TX
+		{peerFrame, unix.PACKET_MULTICAST}, // a real peer advert
+	}
+
+	orig := afPacketRecvfrom
+	defer func() { afPacketRecvfrom = orig }()
+	idx := 0
+	afPacketRecvfrom = func(_ int, p []byte, _ int) (int, unix.Sockaddr, error) {
+		if idx >= len(queue) {
+			close(vi.stopCh)
+			return 0, nil, unix.EAGAIN
+		}
+		d := queue[idx]
+		idx++
+		n := copy(p, d.frame)
+		return n, &unix.SockaddrLinklayer{Pkttype: d.pkttype}, nil
+	}
+
+	done := make(chan struct{})
+	go func() { vi.receiverAfPacket(); close(done) }()
+	<-done
+
+	var got []string
+	for {
+		select {
+		case pkt := <-vi.rxCh:
+			got = append(got, pkt.SrcIP.String())
+			continue
+		default:
+		}
+		break
+	}
+
+	// The peer advert MUST have arrived — otherwise the assertion below is
+	// vacuous (a loop that dropped everything would also "drop the self frame").
+	if len(got) != 1 || got[0] != peer.String() {
+		t.Fatalf("received %v; want exactly the peer advert %s — the self-sent "+
+			"PACKET_OUTGOING frame must be dropped and the peer's kept",
+			got, peer.String())
+	}
+}


### PR DESCRIPTION
Closes #6560

> ⚠️ **This is VRRP code — it owes `make test-failover`,** which is run centrally. No cluster target was run from this lane.

## The stale-issue hypothesis was checked, and it is false

The natural first question is whether the AF_PACKET socket already filters outgoing frames, making this issue stale. It does not, and there are **two** independent delivery paths, neither suppressed:

**1. The AF_PACKET TX tap (the primary receive path).** The socket is bound `ETH_P_ALL` — what tcpdump uses, and why tcpdump shows egress traffic. `dev_queue_xmit_nit` clones every outbound frame to each `ptype_all` tap with `skb->pkt_type = PACKET_OUTGOING`, and `packet_rcv` drops only `PACKET_LOOPBACK`. Adverts leave on the raw AF_INET/AF_INET6 sockets, but they egress the very netdev this socket is bound to.

Three things had to line up, and all three did:
- `receiverAfPacket` **discarded** the sockaddr `Recvfrom` returns (`n, _, err :=`), so `sll_pkttype` was structurally unavailable.
- No `PACKET_IGNORE_OUTGOING` setsockopt anywhere (repo-wide grep: zero hits, as for `sll_pkttype`, `IP_MULTICAST_LOOP`, `IPV6_MULTICAST_LOOP`).
- The cBPF filter matches ethertype and IP protocol only — every instruction is `ldh`/`ldb`/`jeq`/`ret`, with no `SKF_AD_PKTTYPE` ancillary load. A self-advert satisfies it exactly. (A classic BPF filter runs inside `packet_rcv`, which is invoked for the outgoing copy too, so it could never exclude `PACKET_OUTGOING` without explicitly loading pkttype.)

**2. IP multicast loopback (the fallback path).** The raw `ip4:112` / `ip6:112` sockets both send **and** `JoinGroup` 224.0.0.18 / ff02::12, with `IP_MULTICAST_LOOP` defaulting to 1 — so the kernel cloned every advert back into the socket that sent it.

The repo already concedes the premise: `pkg/vrrp/addrwatch.go` says *"self-filtering in `handleMasterRx` misclassifies our own adverts as a peer's -> false master conflict / split-brain."* That sentence is only meaningful if self-adverts reach `handleMasterRx`.

## Why the existing self-check cannot cover it

Self-filtering rested entirely on comparing against `getLocalIP()`/`getLocalIPv6()`, which are **deliberately nilable** — `reresolveLocalAddrs` stores nil when the interface has no non-VIP address of the family. All four receive-path checks are written `lip != nil && src.Equal(lip)`, so **a nil snapshot means ACCEPT**.

That is exactly what the #2528 flush window produces (`programRethMAC`: link DOWN → set MAC → UP; DOWN flushes every kernel address, 30 ms–1 s). A self-advert delivered in that window carries our own priority, so `resolveEqualPriorityMaster` runs, re-reads the same nilable snapshot, and on nil logs *"local source unresolved — stepping down"* and calls `becomeBackup`. Its #4376 comment justifies the step-down by assuming the advert came from a **peer**; here the "actively advertising equal-priority peer" is the node itself. A MASTER demotes itself in exactly the window the surrounding code was hardened for.

## The fix — three changes, none touching the state machine

| Change | Note |
|---|---|
| `PACKET_IGNORE_OUTGOING` on the AF_PACKET receiver | Set **before** bind: an `ETH_P_ALL` socket with a non-zero protocol is already capturing at creation, so setting it after bind leaves a window for our own frames to queue. Best-effort — Linux ≥ 4.20; an older kernel logs and continues. |
| `sll_pkttype` drop in `receiverAfPacket` | The loop now keeps the sockaddr. This is the belt the option is the braces for — it still holds on a kernel without (1). |
| `IP_MULTICAST_LOOP` / `IPV6_MULTICAST_LOOP` = 0 on the fallback raw sockets | Per-**sending**-socket, so they suppress only the loopback of our own transmissions; a peer advert from the wire is unaffected. |

**An unclassifiable sockaddr FAILS OPEN** (treated as not-outgoing). Dropping a frame we cannot classify would be a self-inflicted master-down — strictly worse than the bug being fixed.

## Split out, not folded in

`resolveLocalIPv4` selects **one** address (the lowest non-VIP), not the interface's address **set**, so the comparison also fails with a *non-nil* snapshot once the selected source changes — `resolveEqualPriorityMaster` then compares our own old source against our own new one and steps down on a coin flip. With both delivery paths now suppressed that residual is far narrower, but it is still a silent coin flip, so it is filed as **#7334** rather than folded in here. The README's "Not addressed here" paragraph names it.

## Validation

- `go test ./pkg/vrrp/ ./pkg/cluster/ -count=1` — green.
- `go build ./...` clean.
- **`make test-failover` NOT run from this lane** — the loss cluster is serialized centrally. Per `docs/engineering-style.md` step 8, this change must not merge without it.

**Mutation matrix — four mutations, each on a COMPILING tree:**

| Mutation | Test that reds |
|---|---|
| Delete the loop's `afPacketFrameIsOutgoing` drop (**wiring**) | `TestReceiverAfPacketDropsSelfFrameWithNilSnapshot_6560` |
| Classify `PACKET_OUTGOING` as not-outgoing | the classifier **and** the loop test |
| Fail **closed** on an unclassifiable sockaddr | `TestAfPacketFrameIsOutgoing_6560` |
| Delete the `PACKET_IGNORE_OUTGOING` setsockopt (**wiring**) | `TestAfPacketReceiverIgnoresOutgoing_6560` |

The receive-loop test drives the **real loop** through a `recvfrom` seam, with a genuinely parseable Ethernet+IPv4+VRRPv3 advert (TTL 255, correct pseudo-header checksum via `VRRPPacket.Marshal`) and a **nil** local-IP snapshot — the issue's exact scenario. It asserts the peer frame still arrives, so a loop that dropped everything cannot pass it vacuously. The existing `TestAfPacket_SelfSentFiltered` tests could not have caught this: they call a test-local reimplementation of the parser and pass a **non-nil** `localIP`.

## Docs

`pkg/vrrp/README.md` — a new section under the #2528 material explaining both delivery mechanisms, the three fixes and why each is placed where it is, the fail-open posture, and the residual now tracked in #7334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdWuT1UffSkr1spw8sjNTE