### PR TITLE
config: refuse the values that silently did nothing (#6564 strict family, 3 of 9)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -101745,3 +101745,12 @@ prose edit above them added. No diff falls in the new test body.
   - **File(s)**: pkg/config/compiler_security_alg.go, pkg/config/compiler_routing.go,
     pkg/config/compiler_security_flow.go, pkg/config/compact_leaf_cohort_6564_test.go,
     docs/config-schema.md
+
+- **Timestamp**: 2026-08-21
+  - **Action**: #6564 (strict-reject family, members 2/5/6) — malformed
+    autonomous-system, chained zone `screen` statement, and malformed OSPF area
+    id now REJECT at strict commit and WARN on the tolerant load/peer-sync path
+    (#1960 no-brick, via the #1319 SchemaValidate split). Added ValidateOSPFArea.
+  - **File(s)**: pkg/config/schema_routing.go, pkg/config/schema_security.go,
+    pkg/config/schema_validators_network.go,
+    pkg/config/silent_drop_strict_6564_test.go, docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2217,6 +2217,45 @@ brace and flat-set spellings AGREE with the compact one rather than asserting
 the compact one alone — a test that pinned only the compact shape would not
 notice the two drifting apart again.
 
+### The strict-reject members of the same cohort (#6564)
+
+Three further #6564 members are NOT shape defects and must not be fixed as if
+they were. The statement is structurally readable; its VALUE is malformed, or
+its trailing token is unreachable, and the compiler silently coerced or
+discarded it. There is no correct value to infer, so the only honest repair is
+to refuse it.
+
+| Statement | Silent behaviour before | Repair |
+|---|---|---|
+| `routing-options autonomous-system <bad>` | `strconv.ParseUint`'s error was discarded with no `else` and no record, so `AutonomousSystem` stayed 0, `resolveBGPAutonomousSystem` left `LocalAS` 0, and `pkg/frr` gates `router bgp` on `LocalAS > 0` — **one bad token silently disabled BGP entirely** | `valueType` + `validator`, matching its `local-as` / `peer-as` siblings, which already had both |
+| `security-zone <z> screen <p> <trailing>` | the zone compiler reads `Keys[1]` via `nodeVal` and never the node's children, so a chained statement after the profile name is dropped | `scalar: true`, so the existing `validateScalarValueLeaf` arity gate sees it |
+| `protocols ospf area <bad>` (×4 sites) | no key validator at all, so a malformed id was written **verbatim** into `frr.conf` | `keyValidator: ValidateOSPFArea` |
+
+**Member 2 is a swallowed error, not a Keys-vs-Children defect** — `nodeVal`
+already reads both shapes. A shape-family fix applied there would have looked
+right and changed nothing, which is precisely why each member of a cohort has
+to be diagnosed rather than pattern-matched to the family.
+
+**The posture is asymmetric, and that is the point (#1960 no-brick).** All three
+repairs are schema-level, so they inherit the #1319 PR 2 split for free:
+`SchemaValidate` is STRICT on the operator commit / commit-check path
+(`Store.compileTree`) and DOWNGRADED TO A WARNING on the tolerant
+`Store.Load` / `Store.SyncApply` path (`Store.compileTreeLenient`). A new
+operator edit is refused loudly; a config an older binary already accepted still
+BOOTS after an upgrade. Refusing on both paths would blackout-boot a node or
+alarm-loop HA config sync at the worst possible moment — during an upgrade,
+possibly on the standby of an HA pair mid-ISSU.
+
+`pkg/config/silent_drop_strict_6564_test.go` asserts BOTH directions: the strict
+gate must reject, AND the compiler must still produce a config so the lenient
+wrapper has something to continue with. A strict-only matrix would pass a fix
+that bricks the boot path.
+
+Two further guards worth keeping when this area is edited: the OSPF area
+validator must accept **area 0** (the backbone has no `>= 1` floor, unlike a BGP
+cluster-id), and the `autonomous-system` range must stay `1..4294967295` — a
+mutation loosening either is a silent over-acceptance, and both are pinned.
+
 REACHABILITY (honest bound): as with #6525, these compact spellings are
 hierarchical text ingest only — `load override` / `load merge` / the persisted
 config file / HA `SyncApply`. `set` cannot produce them and `display set`

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -149,7 +149,7 @@ var schemaRoutingOptions = &schemaNode{desc: "Routing options", children: map[st
 			"route": staticRouteNode(),
 		}},
 	}},
-	"autonomous-system": {desc: "Autonomous system number", args: 1, placeholder: "<as-number>", children: nil},
+	"autonomous-system": {desc: "Autonomous system number", args: 1, valueType: ValueInteger, placeholder: "<as-number>", validator: ValidateInteger(1, 4294967295), children: nil},
 	"forwarding-table": {desc: "Forwarding table", children: map[string]*schemaNode{
 		"export": {desc: "Export policy", args: 1, multi: true, placeholder: "<policy>", children: nil},
 	}},
@@ -295,7 +295,7 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 		"reference-bandwidth": {desc: "Reference bandwidth", args: 1, placeholder: "<bandwidth>", children: nil},
 		"passive":             {desc: "Passive mode", children: nil},
 		"export":              {desc: "Export policy", args: 1, multi: true, placeholder: "<policy-name>", children: nil},
-		"area": {desc: "OSPF area", args: 1, placeholder: "<area-id>", children: map[string]*schemaNode{
+		"area": {desc: "OSPF area", args: 1, placeholder: "<area-id>", keyValidator: ValidateOSPFArea, children: map[string]*schemaNode{
 			"interface": {desc: "Interface", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: map[string]*schemaNode{
 				"passive":             {desc: "Passive interface", children: nil},
 				"no-passive":          {desc: "Non-passive interface", children: nil},
@@ -332,7 +332,7 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 	"ospf3": {desc: "OSPFv3 configuration", children: map[string]*schemaNode{
 		"router-id": {desc: "Router ID", args: 1, placeholder: "<address>", children: nil},
 		"export":    {desc: "Export policy", args: 1, multi: true, placeholder: "<policy-name>", children: nil},
-		"area": {desc: "OSPFv3 area", args: 1, placeholder: "<area-id>", children: map[string]*schemaNode{
+		"area": {desc: "OSPFv3 area", args: 1, placeholder: "<area-id>", keyValidator: ValidateOSPFArea, children: map[string]*schemaNode{
 			"interface": {desc: "Interface", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: map[string]*schemaNode{
 				"passive":             {desc: "Passive interface", children: nil},
 				"cost":                {desc: "Interface cost", args: 1, placeholder: "<cost>", children: nil},
@@ -760,7 +760,7 @@ var schemaRoutingInstances = &schemaNode{desc: "Routing instance configuration",
 		"ospf": {desc: "OSPF configuration", children: map[string]*schemaNode{
 			"reference-bandwidth": {desc: "Reference bandwidth", args: 1, placeholder: "<bandwidth>", children: nil},
 			"passive":             {desc: "Passive mode", children: nil},
-			"area": {desc: "OSPF area", args: 1, placeholder: "<area-id>", children: map[string]*schemaNode{
+			"area": {desc: "OSPF area", args: 1, placeholder: "<area-id>", keyValidator: ValidateOSPFArea, children: map[string]*schemaNode{
 				"interface": {desc: "Interface", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: map[string]*schemaNode{
 					"passive":             {desc: "Passive interface", children: nil},
 					"no-passive":          {desc: "Non-passive interface", children: nil},
@@ -797,7 +797,7 @@ var schemaRoutingInstances = &schemaNode{desc: "Routing instance configuration",
 		"ospf3": {desc: "OSPFv3 configuration", children: map[string]*schemaNode{
 			"router-id": {desc: "Router ID", args: 1, placeholder: "<address>", children: nil},
 			"export":    {desc: "Export policy", args: 1, multi: true, placeholder: "<policy-name>", children: nil},
-			"area": {desc: "OSPFv3 area", args: 1, placeholder: "<area-id>", children: map[string]*schemaNode{
+			"area": {desc: "OSPFv3 area", args: 1, placeholder: "<area-id>", keyValidator: ValidateOSPFArea, children: map[string]*schemaNode{
 				"interface": {desc: "Interface", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: map[string]*schemaNode{
 					"passive":             {desc: "Passive interface", children: nil},
 					"cost":                {desc: "Interface cost", args: 1, placeholder: "<cost>", children: nil},

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -185,7 +185,7 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 				},
 			}},
 			"tcp-rst":              {desc: "Send TCP RST for denied traffic", children: nil},
-			"screen":               {desc: "Screen profile name", args: 1, placeholder: "<screen-name>", children: nil},
+			"screen":               {desc: "Screen profile name", args: 1, scalar: true, placeholder: "<screen-name>", children: nil},
 			"host-inbound-traffic": {desc: "Host inbound traffic", children: hostInboundSchemaChildren()},
 			// #3061: zone-local address book. Same entry grammar as the
 			// global book (security address-book global) but attached

--- a/pkg/config/schema_validators_network.go
+++ b/pkg/config/schema_validators_network.go
@@ -185,3 +185,35 @@ func parseCIDRStrict(raw, example string) (net.IP, error) {
 	}
 	return ip, nil
 }
+
+// ValidateOSPFArea accepts an OSPF/OSPFv3 area identifier in either Junos
+// spelling: an IPv4 dotted-quad (0.0.0.0, 10.1.2.3) or a 32-bit unsigned
+// integer (0, 1, 4294967295). Both are legitimate and FRR renders either.
+//
+// #6564: the `area` key carried NO validator, while its siblings `route`
+// (ValidateRouteDestination) and `next-hop` (ValidateStaticNextHop) both do.
+// compileProtocols takes the area name verbatim from Keys[1] via
+// namedInstances and pkg/frr writes it straight into frr.conf (` area %s %s`,
+// ` ip ospf area %s`), so a malformed id reached the routing daemon's config
+// file unexamined. Unlike a BGP cluster-id, area 0 is the BACKBONE and must be
+// accepted — the integer arm therefore has no >= 1 floor.
+func ValidateOSPFArea(raw string, _ *Config) error {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return fmt.Errorf("missing value (expected an OSPF area id: an IPv4 dotted-quad like 0.0.0.0, or an integer 0..4294967295)")
+	}
+	// Dotted-quad form. net.ParseIP rejects a bare integer, so the integer
+	// spelling falls through to the ParseUint arm below.
+	if ip := net.ParseIP(trimmed); ip != nil {
+		if ip.To4() == nil {
+			return fmt.Errorf("invalid area id %q (an IPv6 address is not a valid OSPF area id; use an IPv4 dotted-quad or a 32-bit integer)", raw)
+		}
+		return nil
+	}
+	// 32-bit unsigned integer form. ParseUint with bitSize 32 rejects a value
+	// above 4294967295. Area 0 is the backbone, so there is no lower bound.
+	if _, err := strconv.ParseUint(trimmed, 10, 32); err == nil {
+		return nil
+	}
+	return fmt.Errorf("invalid area id %q (expected an IPv4 dotted-quad like 0.0.0.0, or a 32-bit integer 0..4294967295)", raw)
+}

--- a/pkg/config/silent_drop_strict_6564_test.go
+++ b/pkg/config/silent_drop_strict_6564_test.go
@@ -1,0 +1,193 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6564 — the strict-reject members (2, 5, 6).
+//
+// These three differ from the compact-leaf shape family (#7365): there the
+// operand was DROPPED and the fix makes the statement take effect. Here the
+// statement is structurally readable but its VALUE is malformed or its trailing
+// token is unreachable, and the compiler silently coerced or discarded it. The
+// only honest repair is to refuse it, because there is no correct value to
+// infer.
+//
+//	routing-options autonomous-system <bad>
+//	    strconv.ParseUint's error was discarded with no else and no record, so
+//	    AutonomousSystem stayed 0 and resolveBGPAutonomousSystem left LocalAS
+//	    0 — pkg/frr gates `router bgp` on LocalAS > 0, so a typo in ONE leaf
+//	    silently disabled BGP ENTIRELY.
+//
+//	security-zone <z> screen <p> <trailing>
+//	    the zone compiler reads Keys[1] via nodeVal and never looks at the
+//	    node's children, so a chained statement after the profile name is
+//	    dropped.
+//
+//	protocols ospf area <bad>
+//	    no key validator at all, so a malformed area id was rendered VERBATIM
+//	    into frr.conf — the sibling `route` and `next-hop` keys both carry one.
+//
+// POSTURE (#1960 no-brick, and the #1319 PR 2 split that implements it):
+// SchemaValidate is STRICT on the operator commit / commit-check path
+// (Store.compileTree) and DOWNGRADED TO A WARNING on the tolerant
+// Store.Load / Store.SyncApply path (Store.compileTreeLenient). A config an
+// older binary accepted must still BOOT after an upgrade; only a new operator
+// edit is refused. Both directions are asserted below — a fix that rejected on
+// BOTH paths would pass a strict-only matrix and brick a box on upgrade.
+
+// schemaErr6564 runs the typed-leaf gate the way the strict commit path does.
+func schemaErr6564(t *testing.T, cmds ...string) error {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return SchemaValidate(tree, nil)
+}
+
+// --- Member 2: a malformed autonomous-system silently disables BGP ----------
+
+func TestStrictRejectAutonomousSystem6564(t *testing.T) {
+	for _, bad := range []string{"notanumber", "4294967296", "-1", "65001x"} {
+		t.Run(bad, func(t *testing.T) {
+			err := schemaErr6564(t, "set routing-options autonomous-system "+bad)
+			if err == nil {
+				t.Fatalf("#6564: `autonomous-system %s` must be REJECTED at strict commit — "+
+					"the compiler discards ParseUint's error, leaves AutonomousSystem 0, and "+
+					"pkg/frr then renders NO `router bgp` block at all, so one bad token "+
+					"silently disables BGP entirely", bad)
+			}
+			if !strings.Contains(err.Error(), "autonomous-system") {
+				t.Fatalf("the rejection must name the leaf; got %v", err)
+			}
+		})
+	}
+
+	// A valid AS in both spellings must still pass.
+	for _, ok := range []string{"1", "65001", "4294967295"} {
+		if err := schemaErr6564(t, "set routing-options autonomous-system "+ok); err != nil {
+			t.Fatalf("valid autonomous-system %s must be accepted; got %v", ok, err)
+		}
+	}
+}
+
+// --- Member 5: a chained zone `screen` statement is dropped -----------------
+
+func TestStrictRejectZoneScreenTrailingToken6564(t *testing.T) {
+	err := schemaErr6564(t, "set security zones security-zone untrust screen sc tcp-rst")
+	if err == nil {
+		t.Fatal("#6564: a trailing statement after `screen <profile>` must be REJECTED at " +
+			"strict commit — the zone compiler reads Keys[1] and never the node's children, " +
+			"so the chained statement is silently dropped and the operator believes they " +
+			"configured something that does not exist")
+	}
+	if !strings.Contains(err.Error(), "screen") {
+		t.Fatalf("the rejection must name the leaf; got %v", err)
+	}
+
+	// The bare, correct form must still pass.
+	if err := schemaErr6564(t, "set security zones security-zone untrust screen sc"); err != nil {
+		t.Fatalf("a plain `screen <profile>` must be accepted; got %v", err)
+	}
+}
+
+// --- Member 6: a malformed OSPF area id renders verbatim into FRR -----------
+
+func TestStrictRejectOSPFAreaID6564(t *testing.T) {
+	// All four schema sites: ospf / ospf3, top-level and routing-instance.
+	prefixes := []string{
+		"set protocols ospf area ",
+		"set protocols ospf3 area ",
+		"set routing-instances RI protocols ospf area ",
+		"set routing-instances RI protocols ospf3 area ",
+	}
+	for _, p := range prefixes {
+		for _, bad := range []string{"not-an-area", "999.999.999.999", "4294967296", "0.0.0"} {
+			t.Run(strings.TrimSpace(p)+"/"+bad, func(t *testing.T) {
+				if err := schemaErr6564(t, p+bad); err == nil {
+					t.Fatalf("#6564: `%s%s` must be REJECTED at strict commit — there is no "+
+						"area-id key validator, so the malformed id is rendered VERBATIM into "+
+						"frr.conf (its sibling `route`/`next-hop` keys both validate)", p, bad)
+				}
+			})
+		}
+		// Both legitimate Junos spellings must still pass.
+		for _, ok := range []string{"0", "0.0.0.0", "1", "10.1.2.3", "4294967295"} {
+			if err := schemaErr6564(t, p+ok); err != nil {
+				t.Fatalf("valid area id %q under %q must be accepted; got %v", ok, p, err)
+			}
+		}
+	}
+}
+
+// --- The no-brick direction (#1960): the tolerant path must NOT refuse ------
+
+// TestStrictRejectFamilyIsWarnOnlyOnTolerantPath6564 is the OTHER direction of
+// the posture, and it is the cell a strict-only matrix would miss.
+//
+// A config an older binary accepted is already persisted on disk and already
+// arriving over HA config-sync. If these gates refused on the tolerant path
+// too, the version bump would blackout-boot the node (Store.Load) or
+// alarm-loop config sync (Store.SyncApply) — and it would do so during an
+// upgrade, potentially on the standby of an HA pair mid-ISSU.
+//
+// The split lives in Store.compileTreeLenient, which logs and continues rather
+// than returning the SchemaValidate error. This asserts the compiler itself
+// still COMPILES each offending config, so the tolerant path has something to
+// continue with; a fix that made the COMPILER refuse would brick the same boot
+// the lenient wrapper is there to protect.
+//
+// FAIL-ON-REVERT: make any of the three fixes a hard compiler error rather than
+// a schema-gate rejection.
+func TestStrictRejectFamilyIsWarnOnlyOnTolerantPath6564(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmds []string
+	}{
+		{"autonomous-system", []string{"set routing-options autonomous-system notanumber"}},
+		{"zone-screen-trailing", []string{
+			// The screen profile must EXIST: an undefined reference is a
+			// separate, pre-existing gate, and leaving it undefined would make
+			// this cell pass for the wrong reason.
+			"set security screen ids-option sc icmp ping-death",
+			"set security zones security-zone untrust screen sc tcp-rst",
+		}},
+		{"ospf-area", []string{"set protocols ospf area not-an-area"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := &ConfigTree{}
+			for _, cmd := range tc.cmds {
+				path, err := ParseSetCommand(cmd)
+				if err != nil {
+					t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+				}
+				if err := tree.SetPath(path); err != nil {
+					t.Fatalf("SetPath(%q): %v", cmd, err)
+				}
+			}
+
+			// Strict gate refuses...
+			if err := SchemaValidate(tree, nil); err == nil {
+				t.Fatalf("setup: the strict typed-leaf gate must reject %s", tc.name)
+			}
+
+			// ...but the COMPILER must still produce a config, so
+			// Store.compileTreeLenient can warn and continue rather than
+			// refusing a config that boots today (#1960 no-brick).
+			if _, err := CompileConfig(tree); err != nil {
+				t.Fatalf("#1960 no-brick: the tolerant load / peer-sync path must still COMPILE "+
+					"%s (Store.compileTreeLenient warns on the schema violation and continues). "+
+					"A hard compiler error here blackout-boots a node whose persisted config an "+
+					"older binary accepted; got %v", tc.name, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refs #6564 — ships the **strict-reject family** (members 2, 5, 6) on the posture agreed for this cohort. With #7365 (shape family) this leaves members 8 and 9 outstanding.

## These are not shape defects

The statement is structurally readable; its **value** is malformed, or its trailing token is unreachable, and the compiler silently coerced or discarded it. There is no correct value to infer, so the only honest repair is to refuse it.

| Statement | Silent behaviour before | Repair |
|---|---|---|
| `routing-options autonomous-system <bad>` | `ParseUint`'s error discarded with no `else` → `AutonomousSystem` 0 → `LocalAS` 0 → `pkg/frr` gates `router bgp` on `LocalAS > 0`, so **one bad token silently disabled BGP entirely** | `valueType` + `validator`, matching the `local-as`/`peer-as` siblings that already had both |
| `security-zone <z> screen <p> <trailing>` | zone compiler reads `Keys[1]` via `nodeVal`, never the children → chained statement dropped | `scalar: true`, so the existing `validateScalarValueLeaf` gate is reached |
| `protocols ospf area <bad>` (×4 sites) | no key validator at all → malformed id written **verbatim** into `frr.conf` | `keyValidator: ValidateOSPFArea` |

**Member 2 is a swallowed error, not a Keys-vs-Children defect** — `nodeVal` already reads both shapes. A shape-family fix applied there would have looked right and changed nothing. That is the reason to diagnose each member of a cohort rather than pattern-match it to the family.

## The posture is asymmetric on purpose (#1960 no-brick)

All three repairs are schema-level, so they inherit the **#1319 PR 2** split for free:

- **Strict** on the operator commit / commit-check path (`Store.compileTree`) → **reject**.
- **Tolerant** `Store.Load` / `Store.SyncApply` path (`Store.compileTreeLenient`) → **warn and continue**.

A new operator edit is refused loudly; a config an older binary already accepted still **boots** after an upgrade. Refusing on both paths would blackout-boot a node or alarm-loop HA config sync at the worst moment — during an upgrade, possibly on the standby of an HA pair mid-ISSU.

No new `compileOpts` flag was needed: the existing `SchemaValidate` split already implements exactly this contract.

## Migration, stated plainly

After this change `commit` refuses a malformed `autonomous-system`, a chained zone `screen` statement, and a malformed OSPF `area` id that previous binaries accepted. An existing box **upgrades without refusing its own persisted config** — the tolerant path warns and continues — and the operator's next strict commit is where the stale value surfaces.

## Mutation matrix — both directions

One mutation per line, each **verified APPLIED before the run** (a mutation that silently fails to apply inverts its own result — one cell here did fail to apply on the first attempt and was redone rather than counted). Production restored verbatim between cells.

| # | Mutation | Result |
|---|---|---|
| S2 | drop the `autonomous-system` validator + valueType | **RED** |
| S2b | loosen its range to `(0, 4294967296)` | **RED** — over-accept |
| S5 | drop `scalar: true` from the zone `screen` leaf | **RED** |
| S6 | drop the area `keyValidator` from all four sites | **RED** |
| S6b | make the area validator reject **area 0** (backbone) | **RED** — over-reject |

**S6b is worth a look.** `ValidateOSPFArea` is modelled on `ValidateBGPClusterID`, which has a `>= 1` floor. Area 0 is the OSPF **backbone**, so copying that floor would have refused every backbone area — a fix that reads correct and breaks the most common config in the file. S6b pins it.

And the **no-brick direction is a test cell, not just a claim**: `TestStrictRejectFamilyIsWarnOnlyOnTolerantPath6564` asserts the strict gate rejects **and** the compiler still produces a config, so the lenient wrapper has something to continue with. A strict-only matrix would pass a fix that bricks the boot path.

That cell also caught a real fixture bug in its own first run — the zone case failed on a *pre-existing, unrelated* undefined-screen-profile gate, which would have made the cell pass for the wrong reason. Fixture corrected to define the profile.

## Validation

- `go build ./...` clean.
- `go test -count=1 ./pkg/config/` — ok, 49.9s.
- Downstream green: `pkg/configstore`, `pkg/frr`, `pkg/cmdtree`, `pkg/daemon`.
- Green baseline before any edit; red-first confirmed on all three members across all four area sites.

Docs: `docs/config-schema.md` gains a strict-reject section beside the #6564 shape-family entry, covering the swallowed-error distinction, the asymmetric posture, and the two over-correction guards.

## Remaining on #6564

- **Member 8** — coverage-vs-existence gate in `junos_host_deny.go` (`enforceable := len(netdevs) > 0` is an existence check where coverage is required).
- **Member 9** — missing malformed-value record for an application `term` with no value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gcdxy5mCofwyVWHUKzhU9F
