### PR TITLE
test/incus: make the post-deploy primary reassert fail closed (#6591)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-08-21 — #6591 post-deploy primary reassert is fail-closed
+
+- **Timestamp**: 2026-08-21
+- **Action**: The issue text was STALE — the transfer step it asks for
+  (`failover redundancy-group $rg node 0`) already exists. The live
+  defect is that the reassert FAILS OPEN: an unreadable
+  `show chassis cluster status` right after a deploy makes it iterate
+  zero RGs, warn, and return SUCCESS, so `DEPLOY_RC=0` with the cluster
+  inverted (node0 pri 200 secondary behind node1 pri 100 under
+  preempt=no). It also never verified the resulting role. Observed twice
+  firsthand on the shared gate as `FO_RC=2` at test-failover's preflight.
+  Moved the body into `deploy-lib.sh` so the existing mocked-incus
+  selftest can drive it; added a bounded retry on the status read (the
+  measured discriminator was settle time), a per-RG trailing reset, and
+  a fail-closed VERIFY that dies unless node0 reads `primary` for EVERY
+  RG. The verifier rejects an empty status — that is the fail-open cell.
+  Extended the selftest mock with `cli -c` (scripted status queue +
+  command log); the read index is FILE-backed because
+  `status=$(incus exec ...)` is a subshell and a variable increment
+  there is discarded.
+  Mutation matrix 7/7 RED: W1 fail-open restore, W2 no verification,
+  W3 empty status accepted, W4 some-RG-not-every-RG, W5 no transfer
+  (the original report), W6 no settle retry, W7 wiring reverted.
+  W6 initially GREEN because the first cell mutated a DEFAULT the
+  fixture overrides — re-cut against the loop itself.
+  NOT run on the cluster (shared; lead serializes).
+- **File(s)**: test/incus/deploy-lib.sh, test/incus/cluster-setup.sh,
+  test/incus/deploy-lib-selftest.sh, docs/testing.md
+
 ## 2026-08-21 — #6534 port-mirroring: dropped instances stop rendering as armed
 
 - **Timestamp**: 2026-08-21

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -503,6 +503,39 @@ make cluster-create  # launch xpf-fw0, xpf-fw1, cluster-lan-host
 make cluster-deploy  # build + push to both VMs
 ```
 
+**Post-deploy node0-primary reassert (#4009, fail-closed in #6591).** Every
+deploy path ends in `reassert_primary_node0`, which leaves node0 the primary
+for EVERY redundancy group so downstream smoke (`apply-cos-config.sh`,
+`test-failover`) starts from the documented steady state. It matters because
+the loss userspace cluster runs `preempt=no`: if node1 holds a group when the
+deploy finishes, nothing corrects it on its own, and node0 sits secondary at
+priority 200 behind node1 at 100.
+
+Per RG, on node0: **reset → transfer → reset**. `failover reset` alone clears
+the manual-failover flag and never MOVES ownership — only
+`request chassis cluster failover redundancy-group <rg> node 0` does. The
+trailing reset clears the flag the transfer itself sets, which would otherwise
+block the peer from electing during a later reboot leg.
+
+**It is fail-closed and dies rather than warning.** It retries the status read
+across the post-deploy settle window (the daemon is still coming up; a reassert
+issued ~20s after a deploy was measured not to take while the identical command
+later did), then VERIFIES that node0 reads `primary` for every group and aborts
+the deploy loudly if not. Before #6591 an unreadable status made it iterate
+zero groups, warn, and return SUCCESS — so `DEPLOY_RC=0` with the cluster left
+inverted, and the failure surfaced minutes later inside an unrelated smoke
+target's preflight (`FATAL: fw0 is not primary`), where the natural first
+hypothesis is that the change under test broke HA. That misdiagnosis cost two
+gate cycles.
+
+If a deploy aborts here, the cluster is left in whatever state the transfer
+produced: read `show chassis cluster status` on both nodes before re-running,
+and do NOT read the next smoke's failure as an HA regression.
+
+The logic lives in `deploy-lib.sh` (`deploy_reassert_primary_node0`,
+`deploy_reassert_node0_primary_ok`) so `make test-deploy-lib` covers it against
+a mocked incus — no cluster required.
+
 ### VRRP State Verification
 ```bash
 # Both nodes should agree: fw0=MASTER, fw1=BACKUP for all groups

--- a/test/incus/cluster-setup.sh
+++ b/test/incus/cluster-setup.sh
@@ -718,21 +718,16 @@ rolling_detect_secondary() {
 # after a rolling deploy, so downstream smoke (apply-cos-config, test-failover)
 # starts from the documented node0-primary steady state regardless of preempt
 # config — removing the force-node0-primary workaround the HA batch scripts
-# needed (#4009). Best-effort: a failed request is logged, never fatal.
+# needed (#4009).
+#
+# #6591: the body moved into deploy-lib.sh so the self-test can drive it
+# against the mocked incus, and it is FAIL-CLOSED — it dies rather than
+# warning. It used to swallow an unreadable status, do nothing, and return
+# success; the un-reasserted cluster was then discovered minutes later by an
+# unrelated smoke target's preflight, where the first hypothesis is that the
+# change under test broke HA.
 reassert_primary_node0() {
-	local status rg did=0
-	status=$(incus exec "$(r "$VM0")" -- cli -c "show chassis cluster status" 2>/dev/null || true)
-	while read -r rg; do
-		[[ -n "$rg" ]] || continue
-		incus exec "$(r "$VM0")" -- cli -c "request chassis cluster failover reset redundancy-group $rg" >/dev/null 2>&1 || true
-		incus exec "$(r "$VM0")" -- cli -c "request chassis cluster failover redundancy-group $rg node 0" >/dev/null 2>&1 || true
-		did=1
-	done < <(printf '%s\n' "$status" | deploy_rolling_rg_ids)
-	if [[ "$did" == 1 ]]; then
-		info "Re-asserted node0 primary for all redundancy groups (post-deploy)."
-	else
-		warn "Post-deploy primary reassert skipped — could not read cluster status from node0."
-	fi
+	deploy_reassert_primary_node0 "$(r "$VM0")"
 }
 
 # deploy_rolling_deb sequences the deb cut across both nodes (secondary

--- a/test/incus/deploy-lib-selftest.sh
+++ b/test/incus/deploy-lib-selftest.sh
@@ -113,6 +113,24 @@ _fake_exec() {
 	#   systemctl show -p ExecStart --value xpfd  (via bash -c "... sed ...")
 	#   sha256sum <path>
 	case "$1" in
+	cli)
+		# #6591: `cli -c "<command>"`. Every invocation is appended to
+		# $CLI_LOG so a test can assert the ISSUED SEQUENCE (reset ->
+		# transfer -> reset), and `show chassis cluster status` is answered
+		# from $CLI_STATUS_QUEUE — one line-delimited response per read, the
+		# last one repeating. That models the real failure: the first reads
+		# after a deploy fail while the daemon settles, later ones succeed.
+		shift
+		[[ "$1" == "-c" ]] && shift
+		local cmd="$1"
+		printf '%s\n' "$cmd" >>"$CLI_LOG"
+		if [[ "$cmd" == "show chassis cluster status" ]]; then
+			_fake_cli_status
+			return $?
+		fi
+		# request ... : succeed silently unless a test says otherwise.
+		return "${CLI_REQUEST_RC:-0}"
+		;;
 	test)
 		shift
 		# test -f <path>  /  used by deploy_reconcile_stale_pin
@@ -214,6 +232,46 @@ _fake_remote_bash() {
 		return 0
 	fi
 	return 0
+}
+
+# ── #6591 cli mock state ──────────────────────────────────────────────
+# CLI_STATUS_RESPONSES is an array of status payloads consumed one per
+# `show chassis cluster status`; the LAST entry repeats once exhausted.
+# An empty string models an unreadable status (daemon still starting).
+# The read index is FILE-BACKED, not a shell variable. `status=$(incus exec
+# ...)` is a command substitution, i.e. a subshell, so a variable increment
+# inside it is discarded — the counter would stick at 0 and every read would
+# return the same response. That would have made the retry test below
+# unfailable in one direction and permanently red in the other; it is exactly
+# the kind of fixture defect that produces a confident wrong answer.
+CLI_LOG=""
+CLI_IDX_FILE=""
+CLI_REQUEST_RC=0
+declare -a CLI_STATUS_RESPONSES=()
+
+_fake_cli_status() {
+	local n=${#CLI_STATUS_RESPONSES[@]}
+	(( n == 0 )) && return 1
+	local i
+	i=$(<"$CLI_IDX_FILE")
+	printf '%s' "$(( i + 1 ))" >"$CLI_IDX_FILE"
+	(( i >= n )) && i=$(( n - 1 ))
+	local body="${CLI_STATUS_RESPONSES[$i]}"
+	[[ -z "$body" ]] && return 1
+	printf '%s\n' "$body"
+}
+
+reset_cli_mock() {
+	CLI_LOG=$(mktemp)
+	CLI_IDX_FILE=$(mktemp)
+	printf '0' >"$CLI_IDX_FILE"
+	CLI_REQUEST_RC=0
+	CLI_STATUS_RESPONSES=()
+	# No sleeping in the self-test; the retry COUNTS are what is under test.
+	DEPLOY_REASSERT_READ_DELAY=0
+	DEPLOY_REASSERT_VERIFY_DELAY=0
+	DEPLOY_REASSERT_READ_TRIES=3
+	DEPLOY_REASSERT_VERIFY_TRIES=3
 }
 
 # ── Fixtures ──────────────────────────────────────────────────────────
@@ -642,6 +700,173 @@ test_rolling_rg_ids() {
 	fi
 }
 
+# ── #6591 post-deploy reassert: fail-closed ──────────────────────────
+# The pre-fix reassert read `show chassis cluster status`, and if the read
+# failed it iterated ZERO redundancy groups, warned, and returned SUCCESS. The
+# deploy then reported DEPLOY_RC=0 with the cluster left inverted relative to
+# its configured priorities (node0 at priority 200 sitting secondary behind
+# node1 at 100 — preempt=no means nothing corrects it), and the next HA smoke
+# died in its own preflight where the natural first hypothesis is that the
+# change under test broke HA. Measured twice on the shared gate.
+#
+# It also never verified the resulting role, so even a status read that
+# SUCCEEDED could leave the cluster un-reasserted and still report success.
+
+STATUS_BOTH_RG_NODE0_PRIMARY="Redundancy group: 0 , Failover count: 0
+node0   200       primary        no       no       None
+node1   100       secondary      no       no       None
+
+Redundancy group: 1 , Failover count: 0
+node0   200       primary        no       no       None
+node1   100       secondary      no       no       None
+"
+
+# The state the lead actually observed after a deploy that reported success.
+STATUS_INVERTED_RG0="Redundancy group: 0 , Failover count: 0
+node0   200       secondary      no       no       None
+node1   100       primary        no       no       None
+"
+
+# The partial case a per-RG loop can produce and a `grep node0.*primary`
+# cannot see: RG0 reasserted, RG1 still inverted.
+STATUS_RG0_OK_RG1_INVERTED="Redundancy group: 0 , Failover count: 0
+node0   200       primary        no       no       None
+node1   100       secondary      no       no       None
+
+Redundancy group: 1 , Failover count: 0
+node0   200       secondary      no       no       None
+node1   100       primary        no       no       None
+"
+
+test_reassert_verifier_accepts_all_primary() {
+	if printf '%s' "$STATUS_BOTH_RG_NODE0_PRIMARY" | deploy_reassert_node0_primary_ok; then
+		ok "reassert verify: node0 primary for every RG -> accept"
+	else
+		bad "reassert verify: rejected a fully reasserted cluster"
+	fi
+}
+
+test_reassert_verifier_rejects_inverted() {
+	if printf '%s' "$STATUS_INVERTED_RG0" | deploy_reassert_node0_primary_ok; then
+		bad "reassert verify: accepted node0=secondary/node1=primary — the exact state a deploy reported success on"
+	else
+		ok "reassert verify: inverted RG0 -> reject"
+	fi
+}
+
+test_reassert_verifier_rejects_partial() {
+	if printf '%s' "$STATUS_RG0_OK_RG1_INVERTED" | deploy_reassert_node0_primary_ok; then
+		bad "reassert verify: accepted RG0-ok/RG1-inverted — the property is EVERY RG, which a per-line grep cannot express"
+	else
+		ok "reassert verify: partial reassert (RG1 inverted) -> reject"
+	fi
+}
+
+test_reassert_verifier_rejects_empty() {
+	# THE FAIL-OPEN CELL. An unreadable status must not read as "nothing to
+	# check, therefore fine".
+	if printf '%s' "" | deploy_reassert_node0_primary_ok; then
+		bad "reassert verify: accepted an EMPTY status — an unreadable cluster status must FAIL, not pass vacuously (#6591)"
+	else
+		ok "reassert verify: empty/unreadable status -> reject"
+	fi
+}
+
+test_reassert_dies_when_status_never_readable() {
+	reset_cli_mock
+	CLI_STATUS_RESPONSES=("")   # every read fails, for all retries
+	local rc=0
+	( deploy_reassert_primary_node0 "fake:vm0" ) >/dev/null 2>&1 || rc=$?
+	if (( rc != 0 )); then
+		ok "reassert: unreadable status -> DIES (rc=$rc), deploy cannot report success"
+	else
+		bad "reassert: unreadable status returned SUCCESS — this is the #6591 fail-open that cost two gate cycles"
+	fi
+}
+
+test_reassert_retries_status_read_until_settled() {
+	reset_cli_mock
+	# Two failed reads (daemon still settling ~20s post-deploy), then good.
+	CLI_STATUS_RESPONSES=("" "$STATUS_BOTH_RG_NODE0_PRIMARY" "$STATUS_BOTH_RG_NODE0_PRIMARY")
+	local rc=0
+	( deploy_reassert_primary_node0 "fake:vm0" ) >/dev/null 2>&1 || rc=$?
+	if (( rc == 0 )); then
+		ok "reassert: retries the status read across the post-deploy settle window"
+	else
+		bad "reassert: gave up on a transient unreadable status (rc=$rc) — the measured failure was a read that succeeded moments later"
+	fi
+}
+
+test_reassert_dies_when_role_not_achieved() {
+	reset_cli_mock
+	# Status is readable throughout, but node0 never becomes primary: the
+	# transfer was accepted and did not land. Only a verify can tell these
+	# apart, which is why the exit code of the request is not the verdict.
+	CLI_STATUS_RESPONSES=("$STATUS_INVERTED_RG0")
+	local rc=0
+	( deploy_reassert_primary_node0 "fake:vm0" ) >/dev/null 2>&1 || rc=$?
+	if (( rc != 0 )); then
+		ok "reassert: role not achieved -> DIES (rc=$rc) instead of handing the next smoke an inverted cluster"
+	else
+		bad "reassert: reported success while node0 stayed SECONDARY for RG0"
+	fi
+}
+
+test_reassert_issues_reset_transfer_reset_per_rg() {
+	reset_cli_mock
+	CLI_STATUS_RESPONSES=("$STATUS_BOTH_RG_NODE0_PRIMARY")
+	( deploy_reassert_primary_node0 "fake:vm0" ) >/dev/null 2>&1 || true
+	local seq
+	seq=$(grep -v '^show chassis cluster status$' "$CLI_LOG" | tr '\n' '|')
+	local want="request chassis cluster failover reset redundancy-group 0|request chassis cluster failover redundancy-group 0 node 0|request chassis cluster failover reset redundancy-group 0|request chassis cluster failover reset redundancy-group 1|request chassis cluster failover redundancy-group 1 node 0|request chassis cluster failover reset redundancy-group 1|"
+	if [[ "$seq" == "$want" ]]; then
+		ok "reassert: issues reset -> TRANSFER -> reset for every RG"
+	else
+		bad "reassert: wrong command sequence.
+  got:  $seq
+  want: $want
+(the original #6591 report was that only 'failover reset' was issued — that clears the manual flag and never MOVES ownership)"
+	fi
+}
+
+test_reassert_transfer_rc_is_not_the_verdict() {
+	reset_cli_mock
+	# Every request returns non-zero, but the cluster ends up correct. The
+	# verdict is the OBSERVED ROLE, so this must succeed — otherwise a noisy
+	# but harmless CLI rc would fail an otherwise good deploy.
+	CLI_REQUEST_RC=1
+	CLI_STATUS_RESPONSES=("$STATUS_BOTH_RG_NODE0_PRIMARY")
+	local rc=0
+	( deploy_reassert_primary_node0 "fake:vm0" ) >/dev/null 2>&1 || rc=$?
+	if (( rc == 0 )); then
+		ok "reassert: a failing request rc with the correct end state still passes (role is the verdict)"
+	else
+		bad "reassert: failed on a request rc despite node0 being primary everywhere (rc=$rc)"
+	fi
+}
+
+# The WIRING. Every test above drives deploy_reassert_primary_node0 directly,
+# so all of them stay green if cluster-setup.sh stops calling it — which is the
+# mutation that actually matters, because the function only ever runs from
+# there. It is also asserted to run after BOTH deploy paths (rolling and
+# rolling-deb), since a reassert wired into one of them leaves the other
+# handing the next smoke an un-reasserted cluster.
+test_reassert_is_wired_into_both_deploy_paths() {
+	local f="${SCRIPT_DIR}/cluster-setup.sh"
+	local lib call n
+	lib=$(_first_line_matching "$f" '^[[:space:]]*deploy_reassert_primary_node0 ')
+	n=$(grep -c '^[[:space:]]*reassert_primary_node0$' "$f" || true)
+	if [[ -z "$lib" ]]; then
+		bad "wiring: cluster-setup.sh never calls deploy_reassert_primary_node0 — the fail-closed reassert exists but nothing invokes it, so a deploy reasserts nothing and still reports success (#6591)"
+		return
+	fi
+	if (( n < 2 )); then
+		bad "wiring: reassert_primary_node0 is called $n time(s); expected both deploy paths (deploy_rolling and deploy_rolling_deb)"
+		return
+	fi
+	ok "wiring: reassert routed through the lib at :$lib and called from $n deploy paths"
+}
+
 # ── Run ───────────────────────────────────────────────────────────────
 test_rolling_secondary_node0_primary
 test_rolling_secondary_node0_secondary
@@ -661,6 +886,16 @@ test_reconcile_dangling_sbin_keeps_valid
 test_verify_running_match
 test_verify_running_stale_pin_hardfails
 test_verify_running_stale_binary_hardfails
+test_reassert_verifier_accepts_all_primary
+test_reassert_verifier_rejects_inverted
+test_reassert_verifier_rejects_partial
+test_reassert_verifier_rejects_empty
+test_reassert_dies_when_status_never_readable
+test_reassert_retries_status_read_until_settled
+test_reassert_dies_when_role_not_achieved
+test_reassert_issues_reset_transfer_reset_per_rg
+test_reassert_transfer_rc_is_not_the_verdict
+test_reassert_is_wired_into_both_deploy_paths
 test_preflight_pass_proceeds
 test_preflight_reject_hardfails
 test_preflight_reject_touches_nothing

--- a/test/incus/deploy-lib.sh
+++ b/test/incus/deploy-lib.sh
@@ -222,6 +222,110 @@ deploy_rolling_rg_ids() {
 	awk '/^Redundancy group:[[:space:]]/ { print $3 }' | sort -n -u
 }
 
+# ── Post-deploy node0-primary reassert (#4009, fail-closed in #6591) ──
+#
+# deploy_reassert_node0_primary_ok reads `show chassis cluster status` on stdin
+# and succeeds ONLY IF at least one redundancy group is present AND node0 reads
+# exactly `primary` for EVERY one of them.
+#
+# The "at least one" clause is the #6591 fix, not a formality. The pre-fix
+# reassert treated an unreadable status as "no redundancy groups to iterate",
+# did nothing, warned, and returned SUCCESS — so a deploy that reasserted
+# NOTHING was indistinguishable from one that succeeded, and the failure
+# surfaced minutes later in an unrelated smoke target's preflight where the
+# natural first hypothesis is that the change under test broke HA. An empty or
+# unparseable status must therefore FAIL here.
+#
+# The comparison is `$3 == "primary"`, exact and scoped to the node0 row of the
+# CURRENT group — not a `grep "node0.*primary"`. A grep cannot express "every
+# RG", which is the property that matters: the reassert loops all groups, so a
+# check satisfied by any single group would pass while the others stayed
+# inverted.
+deploy_reassert_node0_primary_ok() {
+	awk '
+		/^Redundancy group:[[:space:]]/ { rg = $3; seen[rg] = 1; next }
+		/^node0[[:space:]]/ { if (rg != "" && $3 == "primary") { ok[rg] = 1 } }
+		END {
+			n = 0
+			for (g in seen) { n++; if (!(g in ok)) { exit 1 } }
+			if (n == 0) { exit 1 }
+			exit 0
+		}
+	'
+}
+
+# Bounded retries for the two reads. Overridable so the self-test does not
+# sleep. The status read needs them because the daemon is still coming up right
+# after a deploy: the measured failure was a reassert issued ~20s post-deploy
+# that did not take, while the identical command issued later did.
+DEPLOY_REASSERT_READ_TRIES="${DEPLOY_REASSERT_READ_TRIES:-30}"
+DEPLOY_REASSERT_READ_DELAY="${DEPLOY_REASSERT_READ_DELAY:-2}"
+DEPLOY_REASSERT_VERIFY_TRIES="${DEPLOY_REASSERT_VERIFY_TRIES:-15}"
+DEPLOY_REASSERT_VERIFY_DELAY="${DEPLOY_REASSERT_VERIFY_DELAY:-2}"
+
+# deploy_reassert_primary_node0 leaves node0 the primary for EVERY redundancy
+# group after a deploy, so downstream smoke (apply-cos-config, test-failover)
+# starts from the documented node0-primary steady state regardless of preempt
+# config.
+#
+# It is NO LONGER best-effort (#6591). It dies if it cannot establish that
+# state, because the alternative — the pre-fix behaviour — is a preflight that
+# fails OPEN, and a preflight that fails open is how a real HA regression gets
+# laundered as an infrastructure hiccup. The deploy returning 0 while the
+# cluster is left inverted relative to its configured priorities (node0 at
+# priority 200 sitting secondary behind node1 at 100, because preempt=no means
+# nothing corrects it) cost two misdiagnosed gate cycles.
+#
+# Sequence per RG, on node0: reset -> transfer -> reset.
+#   - the leading reset clears a stale manual-failover flag that would
+#     otherwise refuse the transfer;
+#   - the transfer is what actually MOVES ownership (`failover reset` alone
+#     never did — that was the original #6591 report);
+#   - the trailing reset clears the flag the transfer itself sets, which
+#     otherwise blocks the peer from electing during a later reboot leg.
+#
+# The trailing reset is safe to add precisely BECAUSE the verify below is
+# fail-closed: if clearing the flag ever moved ownership back, this dies loudly
+# instead of handing the next smoke an inverted cluster.
+deploy_reassert_primary_node0() {
+	local rinst="$1"
+	local status rgs rg try
+
+	status=""
+	rgs=""
+	for (( try = 0; try < DEPLOY_REASSERT_READ_TRIES; try++ )); do
+		status=$(incus exec "$rinst" -- cli -c "show chassis cluster status" 2>/dev/null || true)
+		rgs=$(printf '%s\n' "$status" | deploy_rolling_rg_ids)
+		[[ -n "$rgs" ]] && break
+		sleep "$DEPLOY_REASSERT_READ_DELAY"
+	done
+	if [[ -z "$rgs" ]]; then
+		die "post-deploy primary reassert: could not read cluster status from $rinst after ${DEPLOY_REASSERT_READ_TRIES} attempts. NOT continuing: the pre-#6591 code warned and returned success here, leaving the next HA smoke to discover an un-reasserted cluster in its own preflight."
+	fi
+
+	while read -r rg; do
+		[[ -n "$rg" ]] || continue
+		incus exec "$rinst" -- cli -c "request chassis cluster failover reset redundancy-group $rg" >/dev/null 2>&1 || true
+		incus exec "$rinst" -- cli -c "request chassis cluster failover redundancy-group $rg node 0" >/dev/null 2>&1 || true
+		incus exec "$rinst" -- cli -c "request chassis cluster failover reset redundancy-group $rg" >/dev/null 2>&1 || true
+	done <<<"$rgs"
+
+	# Individual requests are tolerated (|| true) because the VERDICT is the
+	# observed role, not the exit code of any one CLI call. A transfer that
+	# returns non-zero but lands is fine; one that returns zero and does not
+	# land is not — and only this read can tell them apart.
+	for (( try = 0; try < DEPLOY_REASSERT_VERIFY_TRIES; try++ )); do
+		status=$(incus exec "$rinst" -- cli -c "show chassis cluster status" 2>/dev/null || true)
+		if printf '%s\n' "$status" | deploy_reassert_node0_primary_ok; then
+			info "Re-asserted node0 primary for all redundancy groups (post-deploy, verified)."
+			return 0
+		fi
+		sleep "$DEPLOY_REASSERT_VERIFY_DELAY"
+	done
+	die "post-deploy primary reassert FAILED: node0 is not primary for every redundancy group after ${DEPLOY_REASSERT_VERIFY_TRIES} verification attempts. The cluster is left in whatever state the transfer produced; do NOT run an HA smoke against it and read the failure as an HA regression. Last status from $rinst:
+${status}"
+}
+
 # ── #1864 verify-dataplane pre-flight (#6493) ────────────────────────
 # The embedded AF_XDP shim object in a freshly built xpfd can be REJECTED by
 # the target box's BPF verifier (a drifted `make generate` toolchain, or simply


### PR DESCRIPTION
Closes #6591

## The issue text is stale — and the correction changes what the fix is

#6591 reports that `reassert_primary_node0` issues only `request chassis cluster failover reset redundancy-group $rg`, which clears the manual-failover flag and never **moves** ownership. That was true when it was filed. **The transfer step is already there today.**

What is still live is worse, and matches the two gate cycles lost to it: **the reassert fails open.**

```bash
status=$(incus exec ... "show chassis cluster status" || true)
while read -r rg; do ... done < <(... deploy_rolling_rg_ids)
if [[ "$did" == 1 ]]; then info "Re-asserted ..." else warn "skipped" fi
```

Right after a deploy the daemon is still coming up, so the status read returns nothing → `deploy_rolling_rg_ids` yields no groups → the loop body never runs → `did` stays 0 → **the function warns and returns success.** The deploy reports `DEPLOY_RC=0` having reasserted nothing.

Because the cluster runs `preempt=no`, nothing corrects that: node0 sits **secondary at priority 200** behind node1 at 100. The failure then surfaces minutes later inside an unrelated smoke target's preflight — `FATAL: fw0 is not primary`, `FO_RC=2` — where the first hypothesis is that the change under test broke HA.

**Measured discriminator:** the same reassert issued ~20s after a deploy did not take; the identical command issued later did. Settle time, not a wrong command.

And even a status read that *succeeded* proved nothing, because the function never checked the resulting role. **A preflight that fails open is how a real HA regression gets laundered as an infrastructure hiccup.**

## Fix

The body moves into `deploy-lib.sh` so the existing mocked-incus self-test can drive it — the #4009 precedent for putting deploy decisions in the tested lib — and gains:

- a **bounded retry** on the status read, addressing the settle-time root cause rather than working around it;
- a per-RG **trailing reset**, making the sequence `reset → transfer → reset`. The transfer sets a manual-failover flag that would otherwise block the peer from electing during a later reboot leg. Safe to add *precisely because* the verify is fail-closed — if clearing the flag ever moved ownership back, the deploy dies loudly instead of handing the next smoke an inverted cluster;
- a **verify** that dies unless node0 reads `primary` for **every** redundancy group.

The verifier is an exact `$3 == "primary"` scoped to the node0 row of the current group, not a `grep "node0.*primary"`. **A grep cannot express "every RG"** — the reassert loops all groups, so a check satisfied by any single group passes while the others stay inverted. It also **rejects an empty status**: "could not read" must not mean "nothing to check, therefore fine". That is the fail-open, restated as an assertion.

Individual CLI requests stay tolerated (`|| true`) on purpose: **the verdict is the observed role, not the exit code of any one call.** A transfer that returns non-zero but lands is fine; one that returns zero and does not land is not; only the read distinguishes them. A cell pins that.

## Self-test

The mock gains `cli -c` support — a scripted queue of status responses (an empty entry models an unreadable read) plus a command log, so the issued `reset → transfer → reset` sequence is asserted directly.

The read index is **file-backed, not a shell variable**: `status=$(incus exec ...)` is a command substitution, i.e. a subshell, so an increment inside it is discarded and the counter would stick at 0 — which would have made the retry cell unfailable in one direction and permanently red in the other.

## Validation

`bash -n` clean on all three scripts. `make test-deploy-lib` → **37 passed, 0 failed**. **Not run against the cluster** — it is shared and serialized centrally.

### Mutation matrix — one mutation per cell

| cell | mutation | result |
|---|---|---|
| W1 | restore the warn + return-0 fail-open | die cell RED |
| W2 | drop the verification entirely | role-not-achieved RED |
| W3 | verifier accepts an empty status | fail-open cell RED |
| W4 | verifier accepts SOME rg, not EVERY | inverted + partial RED |
| W5 | drop the transfer, leaving only resets (**the original #6591 report**) | sequence cell RED |
| W6 | single-shot status read, no retry | settle cell RED |
| W7 | `cluster-setup.sh` stops calling it | **wiring cell RED** |

**W6 was green on its first cut** — that cell mutated the *default* retry count, which the fixture overrides. A mutation the test cannot see measures nothing, so it was re-cut against the loop itself.

**W7 is the cell that matters:** every other test drives the lib function directly, so all of them stay green if `cluster-setup.sh` stops calling it — and the function only ever runs from there. It additionally requires **both** deploy paths to call it, since a reassert wired into one leaves the other handing the next smoke an un-reasserted cluster.

## Docs

`docs/testing.md` gains the post-deploy reassert contract under the cluster prerequisites: why it exists (`preempt=no`), the `reset → transfer → reset` sequence and why `failover reset` alone was never enough, the fail-closed behaviour, and — for whoever hits the abort — that the cluster is left mid-transfer and the next smoke's failure must not be read as an HA regression. `_Log.md` entry added.

> `_Log.md`-only merge conflict on sync; union-resolved with a structural heading count (1816 = 1815 + 1815 − 1814 base). No fold, no re-gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAsT5gCGP7k2vhdZ1sDuRi