### PR TITLE
upgrade: refuse to arm a kernel against an unreadable journal (#6631)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,49 @@
+## 2026-08-21 — #6631 kernel arm: refuse a journal path the boot gate cannot read
+
+- **Timestamp**: 2026-08-21
+- **Action**: `xpfd upgrade kernel arm --journal <non-default>` produced a
+  STRUCTURALLY UNPROMOTABLE candidate. Go honoured the flag — the journal went
+  to `<path>` and `ArmRecordPath` derived the sidecar from its directory, so
+  both files moved together — while the boot gate hardcodes both locations. It
+  found neither, took its benign "nothing to promote" branch, and exited quiet:
+  the candidate booted, ran UNVERIFIED, was never promoted, and reverted on the
+  next plain reboot behind a log line that reads like an ordinary boot.
+
+  Established the "can never be promoted" claim as UNREACHABLE rather than
+  merely awkward by closing all three channels that could carry a path:
+  `xpf-kernel-promote.service` is `ExecStart=/usr/local/sbin/xpf-kernel-promote`
+  with no operands AND the script parses no argv of its own (no `$1`, `$@` or
+  `getopts` — the only `$1`/`$2` in it are function parameters); neither
+  promote unit mentions a journal in any form; and the gate's inner exec is
+  `"$XPFD" upgrade kernel promote` with no `--journal`. So even an operator
+  drop-in overriding `ExecStart` has nothing to pass to.
+
+  `KernelRunner.Arm` therefore refuses up front with a new
+  `ErrKernelJournalUnpromotable`, before the candidate version is validated and
+  before any system call. Deliberately NOT `ErrKernelChannelUnavailable`: that
+  sentinel exits 2 and the kernel-roll orchestrator reads it as a legitimate
+  LANE-2 fallback, which an operator typo must not look like.
+
+  The seam is a package var `bootGateJournalPath`, so a test that arms against
+  a `t.TempDir()` journal states "this box's gate reads here" rather than
+  switching the check off. Unexported, so cmd/xpfd and pkg/daemon are
+  structurally incapable of relaxing it, and
+  `TestBootGateJournalPathIsTheProductionDefault_6631` pins the compiled-in
+  value so a leaked override cannot make the guard vacuous for the ~30 arm
+  tests that follow.
+
+  Corrected the operator-facing text that PROMISED this did not exist: the
+  `--journal` flag help said "DIAGNOSTIC-ONLY … can never be promoted" and its
+  comment pointed at #6632 ("until then the help text says so"); #6632 was
+  closed as a duplicate of #6631 on 2026-08-07 with no implementing PR.
+- **File(s)**: `pkg/upgrade/kernel_arm_journal_path.go` (new),
+  `pkg/upgrade/kernel_arm_journal_6631_test.go` (new),
+  `pkg/upgrade/kernel_run.go`, `pkg/upgrade/kernel_test.go`,
+  `cmd/xpfd/upgrade_kernel.go`, `docs/in-place-upgrade.md`,
+  `scripts/image/xpf-kernel-promote` (comment cross-reference),
+  `scripts/image/test_kernel_promote_explicit_path.py` (docstring
+  cross-references), `_Log.md`
+
 ## 2026-08-21 — #6656 transfer-out override cleared on peer loss
 
 - **Timestamp**: 2026-08-21

--- a/cmd/xpfd/upgrade_kernel.go
+++ b/cmd/xpfd/upgrade_kernel.go
@@ -33,17 +33,25 @@ func runUpgradeKernelSubcommand(args []string) {
 	}
 	verb := args[0]
 	fs := flag.NewFlagSet("upgrade kernel "+verb, flag.ContinueOnError)
-	// DIAGNOSTIC-ONLY for `arm` (#6601 r8 / #6632). The boot-time promotion
-	// gate is a systemd oneshot with a hardcoded ExecStart and no way to be
-	// told a journal path, so it always reads the compiled-in default — as does
-	// the arm-record sidecar beside it. A candidate armed against a non-default
-	// journal is therefore structurally unpromotable: it boots, runs
-	// unverified, and the next reboot reverts it. #6632 tracks refusing that at
-	// arm time; until then the help text says so.
+	// REFUSED for `arm` since #6631; diagnostic-only for the other kernel verbs.
+	// The boot-time promotion gate is a systemd oneshot with a hardcoded
+	// ExecStart and no way to be told a journal path, so it always reads the
+	// compiled-in default — as does the arm-record sidecar beside it. A
+	// candidate armed against a non-default journal is therefore structurally
+	// unpromotable: it boots, runs unverified, and the next reboot reverts it,
+	// with the gate logging an ordinary boot.
+	//
+	// upgrade.KernelRunner.Arm now REFUSES that rather than accepting it
+	// (ErrKernelJournalUnpromotable), so the failure lands in the operator's
+	// terminal at the moment they ask instead of as a silent non-promotion one
+	// reboot later. The flag stays defined here because the read-only verbs
+	// (status) and the crash-recovery verbs legitimately take one, and because
+	// removing it would break the diagnostic use the tests rely on.
 	journalPath := fs.String("journal", upgrade.DefaultKernelJournalPath,
-		"crash-safe kernel-channel journal path (DIAGNOSTIC-ONLY for `arm`: the "+
-			"boot-time promotion gate always reads "+upgrade.DefaultKernelJournalPath+
-			", so a candidate armed against a different journal can never be promoted)")
+		"crash-safe kernel-channel journal path (`arm` REFUSES a non-default "+
+			"value: the boot-time promotion gate always reads "+
+			upgrade.DefaultKernelJournalPath+", so a candidate armed against a "+
+			"different journal could never be verified or promoted)")
 	strictWatchdog := fs.Bool("strict-watchdog", false,
 		"Path-D1: refuse to arm unless a verified-persistent watchdog is present "+
 			"(default Path-D2: BootNext still closes the boot-loop; an early hang "+

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -1152,15 +1152,41 @@ candidate `ARMED`? — and:
 **`--journal` is not one of those cases**, and must not be cited as this
 check's motivation. Go derives the sidecar from the journal's *directory*,
 so `xpfd upgrade kernel arm --journal <elsewhere>` moves **both** files
-together: the gate finds neither and takes the quiet branch. That is a
-real trap — the boot unit hardcodes
-`ExecStart=/usr/local/sbin/xpf-kernel-promote` with no way to pass a
-journal path, so a candidate armed against a non-default journal is
-*structurally* unpromotable — but it is pre-existing (before this gate
-existed, `xpfd upgrade kernel promote` read the default journal, found
-nothing and no-op'd identically) and orthogonal. **For the kernel
-channel, `--journal` is diagnostic-only**; the arm-time refusal is
-tracked separately as #6632.
+together: the gate would find neither and take the quiet branch, not the
+loud ARMED-without-record branch above. That is a different defect, and
+it is closed at the other end.
+
+**Arming refuses a non-default journal path (#6631).** The boot gate
+cannot be told where to look, and this is worth stating as *unreachable*
+rather than *awkward* — all three channels that could carry a path are
+absent:
+
+| channel | why it does not exist |
+|---|---|
+| argument | `xpf-kernel-promote.service` is `ExecStart=/usr/local/sbin/xpf-kernel-promote` with no operands, and the script parses no argv of its own — no `$1`, no `$@`, no `getopts`. An operator drop-in overriding `ExecStart` has nothing to pass *to*. |
+| environment | neither promote unit mentions a journal in any form; the only `Environment=` is the pinned `PATH`. |
+| the inner exec | the gate runs `"$XPFD" upgrade kernel promote` with **no** `--journal`, so the Go half reads the compiled-in default regardless of what armed the candidate. |
+
+So a candidate armed elsewhere would boot, run **unverified**, never be
+promoted, and revert on the next plain reboot — the safe direction, but
+silent, which is exactly the benign-skip laundering this gate otherwise
+works to eliminate. `KernelRunner.Arm` therefore refuses up front with
+`ErrKernelJournalUnpromotable`, before the candidate version is even
+validated and before any system call: arming is a preflight and is
+retryable, a candidate kernel booting unverified is not. The refusal
+names the path the gate reads, so it is actionable.
+
+The sentinel is deliberately **not** `ErrKernelChannelUnavailable`: that
+one means *use LANE 2 instead* and exits 2, which the kernel-roll
+orchestrator proceeds past. A mistyped flag is exit 1 — fix the command.
+
+**For the kernel channel, `--journal` is therefore accepted only on the
+verbs that cannot strand a candidate** (`status` and the crash-recovery
+verbs). It remains fully usable on the non-kernel `xpfd upgrade` verbs,
+which journal to `/var/lib/xpf/upgrade.state` and have no boot-time gate
+reading a fixed path. The scoping is pinned by
+`TestArmJournalGuardIsScopedToTheKernelArmPath_6631`, which requires the
+guard to have exactly one caller and for that caller to be `Arm`.
 
 `ARMED` **specifically**, not `ARMING`: `ARMING` is prepared intent
 recorded before the firmware one-shot is read back, which is exactly the

--- a/pkg/upgrade/kernel_arm_journal_6631_test.go
+++ b/pkg/upgrade/kernel_arm_journal_6631_test.go
@@ -1,0 +1,258 @@
+package upgrade
+
+import (
+	"errors"
+	"go/ast"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #6631: `xpfd upgrade kernel arm --journal <non-default>` produced a
+// STRUCTURALLY UNPROMOTABLE candidate.
+//
+// The Go side honoured the flag — the journal went to <path> and
+// ArmRecordPath derived the sidecar from its DIRECTORY, so both files landed
+// there. The boot gate hardcodes both locations, found neither, took its
+// benign "nothing to promote" branch, and exited quiet. The candidate booted,
+// ran UNVERIFIED, was never promoted, and reverted on the next plain reboot,
+// with the gate's log reading like an ordinary boot.
+//
+// UNREACHABLE, NOT MERELY AWKWARD. There is no channel by which the path could
+// reach the gate, and all three that would be needed are absent:
+// xpf-kernel-promote.service is `ExecStart=/usr/local/sbin/xpf-kernel-promote`
+// with no operands and the script parses no argv of its own; neither promote
+// unit mentions a journal in any form; and the gate's inner exec is
+// `"$XPFD" upgrade kernel promote` with no --journal, so the Go half reads the
+// compiled-in default regardless. Even an operator drop-in overriding ExecStart
+// has nothing to pass to.
+//
+// So the refusal belongs at ARM time, in the operator's terminal, at the moment
+// they ask. Arming is a preflight and is retryable; a candidate kernel booting
+// unverified is not.
+//
+// FAIL-ON-REVERT: delete the checkArmJournalPromotable call from Arm and
+// TestKernelArmRefusesANonDefaultJournalPath_6631 fails as an assertion.
+
+// newKernelRunnerAtJournal builds a runner at an explicit journal path WITHOUT
+// telling the guard that the boot gate reads it.
+//
+// This is the inverse of newKernelRunner, which models a healthy box by moving
+// the gate's path to match. Here the mismatch IS the fixture, so it must not be
+// papered over.
+func newKernelRunnerAtJournal(t *testing.T, f *fakeKernelSystem, journal string) *KernelRunner {
+	t.Helper()
+	r, err := NewKernelRunner(KernelConfig{
+		JournalPath: journal,
+		Sys:         f,
+		Logf:        func(string, ...any) {},
+	})
+	if err != nil {
+		t.Fatalf("NewKernelRunner: %v", err)
+	}
+	return r
+}
+
+// TestBootGateJournalPathIsTheProductionDefault is the ANTI-VACUITY guard for
+// every other test in the package.
+//
+// newKernelRunner overrides bootGateJournalPath to the test's own temp journal,
+// which is what lets ~30 arm tests keep working. That override is only safe
+// because production cannot perform it: the var is unexported, so cmd/xpfd and
+// pkg/daemon are structurally incapable of relaxing the constraint, and the
+// compiled-in value is the one the boot gate actually reads.
+//
+// If this ever fails, either a test leaked an override past its t.Cleanup or
+// the default drifted — and in the second case every arm on a real appliance
+// would refuse.
+func TestBootGateJournalPathIsTheProductionDefault_6631(t *testing.T) {
+	if bootGateJournalPath != DefaultKernelJournalPath {
+		t.Fatalf("bootGateJournalPath = %q, want the compiled-in default %q. "+
+			"Either an override leaked past a t.Cleanup (making the #6631 guard "+
+			"vacuous for the tests that follow) or the default drifted from the "+
+			"path scripts/image/xpf-kernel-promote hardcodes.",
+			bootGateJournalPath, DefaultKernelJournalPath)
+	}
+	// The shell gate's own constant is pinned equal to this by
+	// TestPromoteScriptJournalMatchesGo, so the guard compares against the path
+	// the gate really reads rather than a second source that could drift.
+	if DefaultKernelJournalPath != "/var/lib/xpf/kernel-upgrade.state" {
+		t.Fatalf("DefaultKernelJournalPath = %q; the boot gate hardcodes "+
+			"/var/lib/xpf/kernel-upgrade.state", DefaultKernelJournalPath)
+	}
+}
+
+// TestKernelArmRefusesANonDefaultJournalPath is the core #6631 assertion.
+//
+// Three things are checked, and they fail for different reasons, so none is
+// redundant: that the arm REFUSED, that it refused for THIS reason rather than
+// tripping some later guard by accident, and that it refused before touching
+// anything.
+func TestKernelArmRefusesANonDefaultJournalPath_6631(t *testing.T) {
+	f := newFakeKernelSystem()
+	journal := filepath.Join(t.TempDir(), "elsewhere", "kernel-upgrade.state")
+	r := newKernelRunnerAtJournal(t, f, journal)
+
+	err := r.Arm("6.18.5-12-generic")
+	if err == nil {
+		t.Fatalf("Arm against %s succeeded. That candidate is structurally "+
+			"unpromotable: the boot gate reads only %s, so it would boot, run "+
+			"UNVERIFIED, and revert on the next plain reboot (#6631)",
+			journal, bootGateJournalPath)
+	}
+
+	// WHICH check fired. Without this the test passes just as happily if the
+	// arm died in preflight for an unrelated reason — a negative test that
+	// passes for the wrong reason is indistinguishable from one that works.
+	if !errors.Is(err, ErrKernelJournalUnpromotable) {
+		t.Fatalf("Arm failed with %v, which is not an ErrKernelJournalUnpromotable "+
+			"refusal — some other guard rejected this, and the #6631 constraint "+
+			"is not the thing being asserted", err)
+	}
+	// The message must name the constraint, not just the outcome: an operator
+	// who is told "refused" without being told the gate reads a fixed path
+	// cannot act.
+	if !strings.Contains(err.Error(), bootGateJournalPath) {
+		t.Errorf("refusal %q does not name %q, the path the boot gate reads — "+
+			"the operator has nothing to act on", err, bootGateJournalPath)
+	}
+
+	// Refused BEFORE any mutation. Arming installs a kernel, writes BootNext
+	// and reboots; a refusal that arrived after some of that would leave the
+	// box in a state nothing cleans up.
+	if len(f.calls) != 0 {
+		t.Errorf("the refusal came AFTER %d system call(s) %v — it must precede "+
+			"every mutation (#6631)", len(f.calls), f.calls)
+	}
+	if f.rebooted {
+		t.Error("Arm rebooted despite refusing")
+	}
+	if _, statErr := os.Stat(journal); !os.IsNotExist(statErr) {
+		t.Errorf("a journal was written at %s despite the refusal (stat err %v)",
+			journal, statErr)
+	}
+	if rec := ArmRecordPath(journal); func() bool { _, e := os.Stat(rec); return e == nil }() {
+		t.Errorf("an arm-record sidecar was written at %s despite the refusal", rec)
+	}
+}
+
+// TestKernelArmJournalRefusalIsNotChannelUnavailable pins the SENTINEL choice,
+// which is an exit-code contract rather than a cosmetic one.
+//
+// cmd/xpfd maps ErrKernelChannelUnavailable to exit 2, which the xpf-deploy
+// kernel-roll orchestrator reads as "this box cannot use LANE 1, fall back to
+// LANE 2" — an outcome it proceeds past. A mistyped flag must not look like
+// that. It is exit 1: fix the command and re-run.
+func TestKernelArmJournalRefusalIsNotChannelUnavailable_6631(t *testing.T) {
+	f := newFakeKernelSystem()
+	r := newKernelRunnerAtJournal(t, f, filepath.Join(t.TempDir(), "k.state"))
+
+	err := r.Arm("6.18.5-12-generic")
+	if err == nil {
+		t.Fatal("Arm succeeded against a non-default journal (#6631)")
+	}
+	if errors.Is(err, ErrKernelChannelUnavailable) {
+		t.Fatalf("the #6631 refusal reports ErrKernelChannelUnavailable (%v), so "+
+			"cmd/xpfd exits 2 and an orchestrator reads an operator input error as "+
+			"a legitimate channel-unavailable fallback", err)
+	}
+}
+
+// TestKernelArmAtTheBootGateJournalStillSucceeds is the ANTI-OVER-REACH
+// control. A guard that refused every arm would be a total outage of the
+// kernel channel and would satisfy every negative test above, so the positive
+// case has to be asserted explicitly.
+func TestKernelArmAtTheBootGateJournalStillSucceeds_6631(t *testing.T) {
+	f := newFakeKernelSystem()
+	r := newKernelRunner(t, f) // models a box whose gate reads the test journal
+
+	if err := r.Arm("6.18.5-12-generic"); err != nil {
+		t.Fatalf("Arm at the gate's own journal path refused: %v — the #6631 "+
+			"guard has over-reached and no kernel can be armed at all", err)
+	}
+	if !f.rebooted {
+		t.Fatal("Arm did not reach the reboot; the guard interrupted the happy path")
+	}
+	if bootGateJournalPath != r.cfg.JournalPath {
+		t.Fatalf("fixture is not modelling the intended box: gate reads %q, "+
+			"runner journals to %q", bootGateJournalPath, r.cfg.JournalPath)
+	}
+}
+
+// TestKernelArmToleratesAnEquivalentSpelling: the comparison is lexical, so it
+// must at least absorb the spellings that occur in practice rather than
+// refusing a path that IS the gate's path written differently.
+//
+// This is where an over-strict guard would bite a real operator: `--journal`
+// typed with a doubled slash or a trailing `/.` names the same file, and
+// refusing it would be a refusal with no defect behind it.
+func TestKernelArmToleratesAnEquivalentSpelling_6631(t *testing.T) {
+	f := newFakeKernelSystem()
+	journal := filepath.Join(t.TempDir(), "kernel-upgrade.state")
+	withBootGateJournal(t, journal)
+
+	dir, base := filepath.Split(journal)
+	spelled := dir + "." + string(filepath.Separator) + base // <dir>/./<base>
+	if filepath.Clean(spelled) != journal {
+		t.Fatalf("fixture error: %q does not clean to %q", spelled, journal)
+	}
+
+	r := newKernelRunnerAtJournal(t, f, spelled)
+	if err := r.Arm("6.18.5-12-generic"); err != nil {
+		t.Fatalf("Arm refused %q, which is the gate's own path written "+
+			"differently: %v", spelled, err)
+	}
+}
+
+// TestArmJournalGuardIsScopedToTheKernelArmPath pins the SCOPE the issue asks
+// for: `--journal` stays legitimate for the read-only kernel verbs and for the
+// non-kernel `xpfd upgrade` verbs, so the guard must have exactly one caller.
+//
+// A behavioural test cannot state this — "no other code path is affected" is a
+// claim about absence, and the binary channel's own journal tests passing only
+// shows that the paths they happen to cover are unaffected. Counting the
+// callers in the source says it directly.
+func TestArmJournalGuardIsScopedToTheKernelArmPath_6631(t *testing.T) {
+	_, files := parseUpgradeTree(t, upgradeTreeRoot(t))
+
+	type site struct{ file, fn string }
+	var sites []site
+	for path, f := range files {
+		for _, d := range f.Decls {
+			fd, ok := d.(*ast.FuncDecl)
+			if !ok || fd.Body == nil {
+				continue
+			}
+			ast.Inspect(fd.Body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if ok && sel.Sel.Name == "checkArmJournalPromotable" {
+					sites = append(sites, site{path, fd.Name.Name})
+				}
+				return true
+			})
+		}
+	}
+
+	if len(sites) != 1 {
+		t.Fatalf("checkArmJournalPromotable has %d callers %v, want exactly 1. "+
+			"The kernel channel's journal constraint must not spread to the "+
+			"read-only verbs or to the non-kernel `xpfd upgrade` journal, where "+
+			"--journal is legitimate (#6631).", len(sites), sites)
+	}
+	if sites[0].fn != "Arm" {
+		t.Fatalf("checkArmJournalPromotable is called from %s, want Arm — the "+
+			"refusal is scoped to arming, not to the flag (#6631)", sites[0].fn)
+	}
+
+	// The two channels journal to different files; conflating them is how a
+	// kernel-scoped constraint would leak onto the binary channel.
+	if DefaultJournalPath == DefaultKernelJournalPath {
+		t.Fatalf("the binary channel and kernel channel share journal path %q",
+			DefaultJournalPath)
+	}
+}

--- a/pkg/upgrade/kernel_arm_journal_path.go
+++ b/pkg/upgrade/kernel_arm_journal_path.go
@@ -1,0 +1,91 @@
+package upgrade
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+)
+
+// ── the kernel channel's journal path is not an operator choice (#6631) ──
+//
+// `--journal` is defined on EVERY `xpfd upgrade kernel` verb, `arm` included
+// (cmd/xpfd/upgrade_kernel.go). For the kernel channel that flag is
+// diagnostic-only, and arming with a non-default value produced a candidate
+// that was STRUCTURALLY UNPROMOTABLE — it booted, ran unverified, and the next
+// plain reboot reverted it, with no signal anywhere.
+//
+// WHY IT CANNOT BE FIXED BY TEACHING THE GATE THE PATH. There is no channel to
+// tell it one. Three would be needed and none exists:
+//
+//   - ARGUMENT: xpf-kernel-promote.service is
+//     `ExecStart=/usr/local/sbin/xpf-kernel-promote` with no operands, and the
+//     script parses no argv of its own — it has no `$1`, no `$@`, no getopts.
+//     So even an operator drop-in overriding ExecStart has nothing to pass to.
+//   - ENVIRONMENT: neither promote unit mentions a journal in any form. The
+//     only Environment= is the pinned PATH.
+//   - THE INNER EXEC: the gate runs `"$XPFD" upgrade kernel promote` with no
+//     --journal, so the Go half reads DefaultKernelJournalPath regardless of
+//     what armed the candidate.
+//
+// And the flag moves BOTH files, not one: ArmRecordPath derives the sidecar
+// from the journal's DIRECTORY, so the gate finds neither file and takes its
+// quiet "nothing to promote" branch rather than the loud ARMED-without-record
+// refusal. That is precisely the benign-skip laundering #6601 otherwise worked
+// to eliminate — a safe failure direction (no promotion) reported as an
+// ordinary boot.
+//
+// So the honest place to fail is the operator's terminal, at the moment they
+// ask. Arming is a preflight and is retryable; a candidate kernel that boots
+// unverified is not. This is the same shape as recordPromoteBinary, which
+// refuses to arm when it cannot establish WHICH xpfd must verify the candidate.
+
+// ErrKernelJournalUnpromotable marks an arm-time refusal: the candidate would
+// be recorded in a journal the boot-time promotion gate does not read, so it
+// could never be verified and never promoted.
+//
+// It is deliberately NOT ErrKernelChannelUnavailable. That sentinel means "use
+// LANE 2 instead" and cmd/xpfd maps it to exit 2, which an orchestrator reads
+// as a legitimate channel-unavailable fallback. This is an operator input
+// error on a channel that is perfectly available — exit 1, fix the command.
+var ErrKernelJournalUnpromotable = errors.New("kernel journal path is not promotable")
+
+// bootGateJournalPath is the journal path the BOOT-TIME promotion gate reads.
+//
+// It is the compiled-in default because that is the literal truth: the gate
+// hardcodes `/var/lib/xpf/kernel-upgrade.state` (scripts/image/xpf-kernel-promote)
+// and TestPromoteScriptJournalMatchesGo pins the shell constant equal to
+// DefaultKernelJournalPath, so this is not a second source that could drift.
+//
+// It is a package VAR, not a const, for one reason: a test that legitimately
+// arms against a t.TempDir() journal is modelling a box whose gate reads THAT
+// path, and saying so is more honest than a boolean that switches the check
+// off. Nothing outside this package can reach it, so production is structurally
+// incapable of relaxing the constraint. TestBootGateJournalPathIsTheProductionDefault
+// pins its value so a leaked override cannot make the guard vacuous.
+var bootGateJournalPath = DefaultKernelJournalPath
+
+// checkArmJournalPromotable refuses an arm whose journal the boot gate will
+// never read.
+//
+// The comparison is lexical (filepath.Clean on both sides) rather than a
+// symlink resolution: EvalSymlinks touches the filesystem and fails on a box
+// where /var/lib/xpf does not exist yet, which would turn a first arm on a
+// fresh install into a refusal. Clean absorbs the spellings that actually
+// occur (`//var/lib/...`, a trailing `/.`) and anything more exotic gets a
+// message naming the exact path required, so it is actionable rather than a
+// brick.
+func (r *KernelRunner) checkArmJournalPromotable() error {
+	if filepath.Clean(r.cfg.JournalPath) == filepath.Clean(bootGateJournalPath) {
+		return nil
+	}
+	return fmt.Errorf("%w: refusing to arm against journal %s. The boot-time "+
+		"promotion gate is a systemd oneshot with a hardcoded ExecStart and no "+
+		"way to be told a journal path, so it always reads %s — and the arm-record "+
+		"sidecar beside it. A candidate armed here would boot, run UNVERIFIED, "+
+		"never be promoted, and revert on the next plain reboot, with the gate "+
+		"reporting an ordinary boot. Re-run without --journal (or with --journal %s). "+
+		"For the kernel channel --journal is diagnostic-only; it remains usable on "+
+		"the read-only verbs and on the non-kernel `xpfd upgrade` verbs",
+		ErrKernelJournalUnpromotable, r.cfg.JournalPath,
+		bootGateJournalPath, bootGateJournalPath)
+}

--- a/pkg/upgrade/kernel_run.go
+++ b/pkg/upgrade/kernel_run.go
@@ -82,6 +82,14 @@ func (r *KernelRunner) ktransition(j *KernelJournal, s KernelState) error {
 // the process dies right after SetBootNext, the firmware clears BootNext on the
 // next boot, so at worst the candidate is tried once and falls back.
 func (r *KernelRunner) Arm(candidateVersion string) error {
+	// FIRST, before the candidate is even looked at (#6631). A journal the boot
+	// gate does not read makes this arm unpromotable no matter what is armed,
+	// so it outranks every per-invocation complaint below: telling an operator
+	// their version string is malformed, when the command could not have worked
+	// with a perfect one, sends them to fix the wrong thing.
+	if err := r.checkArmJournalPromotable(); err != nil {
+		return fmt.Errorf("kernel-upgrade arm: %w", err)
+	}
 	if candidateVersion == "" {
 		return fmt.Errorf("kernel-upgrade: candidate version is required")
 	}

--- a/pkg/upgrade/kernel_test.go
+++ b/pkg/upgrade/kernel_test.go
@@ -216,8 +216,10 @@ func (f *fakeKernelSystem) Now() time.Time { return f.now }
 
 func newKernelRunner(t *testing.T, f *fakeKernelSystem) *KernelRunner {
 	t.Helper()
+	journal := filepath.Join(t.TempDir(), "kernel-upgrade.state")
+	withBootGateJournal(t, journal)
 	r, err := NewKernelRunner(KernelConfig{
-		JournalPath: filepath.Join(t.TempDir(), "kernel-upgrade.state"),
+		JournalPath: journal,
 		Sys:         f,
 		Logf:        func(string, ...any) {},
 	})
@@ -225,6 +227,21 @@ func newKernelRunner(t *testing.T, f *fakeKernelSystem) *KernelRunner {
 		t.Fatalf("NewKernelRunner: %v", err)
 	}
 	return r
+}
+
+// withBootGateJournal models a box whose boot-time promotion gate reads
+// `path`, restoring the production value afterwards.
+//
+// Every test that arms needs this, because Arm refuses a journal the gate does
+// not read (#6631) and every test journal is a t.TempDir(). Stating it that way
+// round — "on this box the gate reads here" — is what keeps the fixtures
+// truthful; a flag that merely switched the check off would let a test assert
+// an arm that production would reject.
+func withBootGateJournal(t *testing.T, path string) {
+	t.Helper()
+	orig := bootGateJournalPath
+	t.Cleanup(func() { bootGateJournalPath = orig })
+	bootGateJournalPath = path
 }
 
 func contains(calls []string, want string) bool {
@@ -477,8 +494,10 @@ func TestKernelArmAbortsForeignDefault(t *testing.T) {
 func TestKernelArmStrictWatchdogAborts(t *testing.T) {
 	f := newFakeKernelSystem()
 	f.wdPersist = false
+	journal := filepath.Join(t.TempDir(), "k.state")
+	withBootGateJournal(t, journal)
 	r, _ := NewKernelRunner(KernelConfig{
-		JournalPath:    filepath.Join(t.TempDir(), "k.state"),
+		JournalPath:    journal,
 		Sys:            f,
 		StrictWatchdog: true,
 	})
@@ -732,8 +751,10 @@ func TestKernelPromoteBootCurrentErrRunningKnownGoodCleansUp(t *testing.T) {
 func TestKernelArmStrictWatchdogArmFailureAborts(t *testing.T) {
 	f := newFakeKernelSystem()
 	f.armWatchdogErr = fmt.Errorf("simulated /dev/watchdog I/O error")
+	journal := filepath.Join(t.TempDir(), "k.state")
+	withBootGateJournal(t, journal)
 	r, _ := NewKernelRunner(KernelConfig{
-		JournalPath:    filepath.Join(t.TempDir(), "k.state"),
+		JournalPath:    journal,
 		Sys:            f,
 		StrictWatchdog: true,
 	})

--- a/scripts/image/test_kernel_promote_explicit_path.py
+++ b/scripts/image/test_kernel_promote_explicit_path.py
@@ -54,7 +54,8 @@ is loud.
 one: Go derives the sidecar from the journal's directory, so that flag moves
 BOTH files together and the gate finds neither. It is a real trap — the boot
 unit hardcodes this script with no way to pass a journal path, so such a
-candidate is structurally unpromotable — but a pre-existing and separate one.)
+candidate is structurally unpromotable — but a separate one, closed at the ARM
+end by #6631 rather than here.)
 
 FAIL-ON-REVERT: restore `command -v xpfd` / bare `xpfd upgrade kernel promote`,
 reintroduce a compiled-default fallback, remove the arm-record check, or make
@@ -1528,9 +1529,10 @@ class TestArmedWithoutARecordIsNotLaundered(_GateBase):
 
     Explicitly NOT one of those: `arm --journal <elsewhere>`. Go derives the
     sidecar from the journal's directory, so that flag moves both files together
-    and the gate finds neither, taking the quiet branch. It is a separate,
-    pre-existing trap (the boot unit hardcodes the script with no journal
-    argument, so such a candidate can never be promoted at all) and must not be
+    and the gate finds neither, taking the quiet branch. It is a separate trap
+    (the boot unit hardcodes the script with no journal argument, so such a
+    candidate can never be promoted at all), closed at the ARM end by #6631 —
+    `KernelRunner.Arm` refuses a non-default journal path — and it must not be
     cited as this check's motivation.
 
     Not promoting is the SAFE direction, so this is availability and honesty

--- a/scripts/image/xpf-kernel-promote
+++ b/scripts/image/xpf-kernel-promote
@@ -538,8 +538,11 @@ same_file() {
 # directory), so the gate finds neither and takes the quiet branch. That is a
 # real trap, but a DIFFERENT one -- the boot unit hardcodes this script with no
 # way to pass a journal path, so a non-default --journal is structurally
-# unpromotable, exactly as it was before this gate existed. It is tracked
-# separately; do not cite it as the motivation for the check below.
+# unpromotable, exactly as it was before this gate existed. Nothing about THIS
+# gate changed: it is closed at the other end, where the ambiguity actually is.
+# `KernelRunner.Arm` REFUSES a non-default journal path outright (#6631,
+# ErrKernelJournalUnpromotable), so the state is no longer reachable from a
+# supported operation. Do not cite it as the motivation for the check below.
 #
 # In the desyncs that ARE reachable, a candidate is armed, the gate silently
 # does not run, the candidate is never promoted, and the next reboot reverts it


### PR DESCRIPTION
Closes #6631

## The defect

`--journal` is defined on **every** `xpfd upgrade kernel` verb, `arm` included (`cmd/xpfd/upgrade_kernel.go`). The Go side honours it: the journal goes to `<path>`, and `ArmRecordPath` derives the arm-record sidecar from the journal's **directory**, so both files land there together.

The boot-time gate hardcodes both:

```sh
ARM_RECORD="/var/lib/xpf/kernel-promote-binary"
KERNEL_JOURNAL="/var/lib/xpf/kernel-upgrade.state"
```

It finds neither, takes the benign **"nothing to promote"** branch, and exits quiet. The candidate boots, runs **UNVERIFIED**, is never promoted, and reverts on the next plain reboot — behind a log line that reads like an ordinary boot.

The failure direction is safe. **The silence is not.** This is precisely the benign-skip laundering the gate otherwise works to eliminate, and #6601's loud ARMED-without-record refusal structurally cannot fire here: that branch needs the journal readable **at the default path** and saying `ARMED`, and here the journal is elsewhere too.

## Reachability verdict — unreachable, not awkward

The issue's phrase "can never be promoted" is a strong claim, so it was established by **closing the channels**, not by failing to find one. Three would be needed; all three are absent:

| channel | evidence |
|---|---|
| **argument** | `xpf-kernel-promote.service` is `ExecStart=/usr/local/sbin/xpf-kernel-promote` with no operands — **and** the script parses no argv of its own. A grep for `$1`/`$@`/`getopts` in `xpf-kernel-promote` returns only *function* parameters inside `usable`, `same_file` and `pid_in_unit_cgroup`, never the script's own. So even an operator drop-in overriding `ExecStart` has nothing to pass **to**. |
| **environment** | neither promote unit contains the string `journal`/`Journal`/`JOURNAL` in any case (grep rc=1). The only `Environment=` is the pinned `PATH`. |
| **the inner exec** | line 641 is `"$XPFD" upgrade kernel promote` with **no** `--journal`, so the Go half reads `DefaultKernelJournalPath` regardless of what armed the candidate. |

Closing it therefore needs a code change either way, which is what makes the arm-time refusal the right shape rather than one of two options.

## The fix

`KernelRunner.Arm` refuses up front with a new `ErrKernelJournalUnpromotable`. Arming is a preflight and is retryable; a candidate kernel booting unverified is not — the same trade `recordPromoteBinary` already makes when it cannot establish *which* xpfd must verify the candidate.

**It runs first, before the candidate version is even validated.** A journal the gate does not read makes the arm unpromotable no matter what is armed, so telling an operator their version string is malformed — when the command could not have worked with a perfect one — sends them to fix the wrong thing. It also precedes every system call, so a refusal cannot leave a half-installed candidate behind.

**The sentinel is deliberately not `ErrKernelChannelUnavailable`.** That one means *use LANE 2 instead*, and cmd/xpfd maps it to **exit 2**, which the xpf-deploy kernel-roll orchestrator reads as a legitimate channel-unavailable fallback and **proceeds past**. An operator typo must not look like that. It is exit 1: fix the command.

**The comparison is lexical**, `filepath.Clean` on both sides, not `EvalSymlinks` — which touches the filesystem and fails on a box where `/var/lib/xpf` does not exist yet, turning a first arm on a fresh install into a refusal. `Clean` absorbs the spellings that occur (`//var/lib/…`, a trailing `/.`), and anything more exotic gets a message naming the exact path required.

## The seam, and why it is a path rather than a boolean

~30 existing tests arm against a `t.TempDir()` journal. The seam is a package var, `bootGateJournalPath`, so `newKernelRunner` says **"on this box the gate reads here"** — which is true of the box being modelled. A boolean that switched the check off would instead let a test assert an arm that production would reject.

It is **unexported**, so `cmd/xpfd` and `pkg/daemon` are *structurally* incapable of relaxing the constraint — a compile-time guarantee rather than a tested one. `TestBootGateJournalPathIsTheProductionDefault_6631` pins the compiled-in value, so a leaked override cannot silently make the guard vacuous for every arm test that follows, and it cross-checks the literal the shell gate hardcodes (already pinned the other way by `TestPromoteScriptJournalMatchesGo`).

## Scope

The issue asks that `--journal` stay legitimate for the read-only kernel verbs and the non-kernel `xpfd upgrade` verbs. That is a claim about **absence**, which a behavioural test cannot state — the binary channel's own journal tests passing shows only that the paths they happen to cover are unaffected. `TestArmJournalGuardIsScopedToTheKernelArmPath_6631` says it directly: the guard must have exactly **one** caller and that caller must be `Arm`.

## Mutation matrix

Six mutations, each on a **compiling** tree with `go vet ./pkg/upgrade/` **clean at the mutated state**, each restored and confirmed byte-identical to its backup. The firing assertion is identified per red rather than just the failing test.

Production call path: `xpfd upgrade kernel arm <ver>` → `runUpgradeKernelSubcommand` (`cmd/xpfd/upgrade_kernel.go:113`) → `KernelRunner.Arm` (`pkg/upgrade/kernel_run.go:84`) → `checkArmJournalPromotable`, first statement.

| cell | N1 no call (shipped) | N2 compare to self | N3 wrong sentinel | N4 always refuse | N5 drop one Clean | N6 var drifts |
|---|---|---|---|---|---|---|
| `…RefusesANonDefaultJournalPath_6631` | **:99** | **:99** | **:109** | 0 | 0 | 0 |
| `…RefusalIsNotChannelUnavailable_6631` | **:153** | **:153** | **:156** | 0 | 0 | 0 |
| `…GuardIsScopedToTheKernelArmPath_6631` | **:242** | 0 | 0 | 0 | 0 | 0 |
| `…BootGateJournalPathIsTheProductionDefault_6631` | 0 | 0 | 0 | 0 | 0 | **:71** |
| `…ArmAtTheBootGateJournalStillSucceeds_6631` *(control)* | 0 | 0 | 0 | **:171** | 0 | 0 |
| `…ArmToleratesAnEquivalentSpelling_6631` *(control)* | 0 | 0 | 0 | **:203** | **:203** | 0 |

N1 restores what shipped (no call at all). N3 reds at `:109` (the `errors.Is(ErrKernelJournalUnpromotable)` assertion) and `:156` (the `errors.Is(ErrKernelChannelUnavailable)` assertion) — the sentinel cells specifically, not the outcome. N4 is the over-reach control: a guard that refused everything satisfies every negative cell above, so the positive case is asserted separately and only it reds.

**A false-RED episode, reported rather than smoothed over.** An earlier pass of N5/N6 produced impossible rows (N6 red in all six cells). Re-running each in isolation **with stderr kept** showed both behaving exactly as designed; the batched rows were contention artefacts from parallel lanes sharing the toolchain, and discarding stderr is what made them undiagnosable. Every row above comes from the re-run that captures and reports the firing assertion.

## Verification needs

**None beyond CI, and this is the half that a live run genuinely cannot add.** The refusal is a pure preflight in the control plane: it executes before any system call, so there is nothing about it that only a real A/B-capable box or a live bake could exercise. What a live box *was* required for is the reachability claim, and that is settled statically above — from the shipped unit files and the shipped script — because the absence of a channel is not something a boot demonstrates.

No cluster smoke owed: no dataplane, shim `.o`, HA, VRRP or session-sync involvement.

## Docs

`docs/in-place-upgrade.md` said "**For the kernel channel, `--journal` is diagnostic-only**; the arm-time refusal is tracked separately as #6632". #6632 was closed as a duplicate of this issue on 2026-08-07 with no implementing PR, so that pointer named work nobody was doing. Rewritten with the three-channel unreachability table, the sentinel/exit-code rationale, and the scoping.

The same stale promise was **in the operator's hands**: the `--journal` flag's own `-help` text read "DIAGNOSTIC-ONLY for `arm` … can never be promoted", and its comment said "#6632 tracks refusing that at arm time; **until then the help text says so**". Both corrected, along with the two cross-references in `scripts/image/xpf-kernel-promote` and its harness that described the trap as merely "tracked separately".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cz2czGK3aA5MsMhkNkjHXX
