### PR TITLE
config: refuse a term keyword that carries no value (#6564 member 9)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -101847,3 +101847,13 @@ prose edit above them added. No diff falls in the new test body.
   - **File(s)**: pkg/config/schema_routing.go, pkg/config/schema_security.go,
     pkg/config/schema_validators_network.go,
     pkg/config/silent_drop_strict_6564_test.go, docs/config-schema.md
+
+- **Timestamp**: 2026-08-21
+  - **Action**: #6564 member 9 — a recognized value-taking `term` keyword with no
+    value was silently dropped, widening the application match. Recorded as
+    IncompleteTermLeaves; strict gate rejects, tolerant path warns. Added a
+    source-scanning drift pin binding valueTakingTermLeaves to the switch.
+  - **File(s)**: pkg/config/compiler_applications.go, pkg/config/types_security.go,
+    pkg/config/compiler_validate_strict_application.go,
+    pkg/config/dangling_term_keyword_6564_test.go,
+    pkg/config/testdata/golden_4406.json, docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2256,6 +2256,50 @@ validator must accept **area 0** (the backbone has no `>= 1` floor, unlike a BGP
 cluster-id), and the `autonomous-system` range must stay `1..4294967295` — a
 mutation loosening either is a silent over-acceptance, and both are pinned.
 
+### The dangling-keyword member (#6564 member 9)
+
+`parseApplicationTerms` guards every value-taking arm with
+`if i+1 < len(keys)` and has no `else`, so a RECOGNIZED leaf keyword in the LAST
+position fell through recording nothing at all — and the `default:` arm that
+feeds `UnknownTermLeaves` is unreachable for a keyword the switch recognizes.
+
+The consequence is the exact fail-open the rest of that function exists to stop.
+`default:`'s own comment says it records the token "rather than silently
+dropping the constraint and widening the match", and #3348's says a dropped
+`icmp-type` "would leave the term UNCONSTRAINED ... a fail-open widening". A
+dangling keyword does precisely that: `term t1 protocol tcp destination-port`
+compiled to protocol-only, so an application written to match ONE port matched
+EVERY TCP port, and any policy permitting it widened with it.
+
+**Why the surrounding family missed it.** #3320 (malformed timeout), #3348
+(malformed icmp-type), #3352 (unrecognized leaf) and #6524 (trailing token on
+the application body) each instrument a MALFORMED VALUE. This shape has no value
+to be malformed — the defect is the ABSENCE of one — so none of their gates
+could see it. A cohort built around "instrument the bad value" has a blind spot
+at "there is no value", and that is worth checking for whenever a family of
+value-validators accumulates.
+
+**One guard, not eight `else` branches.** The check runs once before the switch,
+keyed on `valueTakingTermLeaves`. A per-arm `else` would have to be repeated for
+every future value-taking leaf, which is the duplication that drifts.
+
+**The set is pinned to the switch textually.** `valueTakingTermLeaves` is the
+arity contract, and a future leaf added to the switch WITHOUT being added to the
+set silently re-opens the fail-open — while every behavioural test still passes,
+because they can only exercise keywords someone remembered to list.
+`TestValueTakingTermLeavesCoversEveryConsumingArm6564` therefore scans the
+function's own source: every `case "<kw>":` arm whose body reads `keys[i+1]`
+must be a member, and the counts must match in both directions so the set cannot
+accumulate entries for leaves that no longer exist. It fails loudly if its own
+scan pattern stops matching, so it cannot rot into a vacuous pass. Same
+discipline as the #6588 no-arg statement registry.
+
+`IncompleteTermLeaves` is deliberately separate from `UnknownTermLeaves`: the
+keyword IS supported, so calling it an "unknown statement" would send the
+operator hunting a typo that is not there. Posture is the cohort's usual —
+strict on commit / commit-check, warn on the tolerant load / peer-sync path via
+the existing `lenientApplicationSpecs` (#2142) downgrade.
+
 REACHABILITY (honest bound): as with #6525, these compact spellings are
 hierarchical text ingest only — `load override` / `load merge` / the persisted
 config file / HA `SyncApply`. `set` cannot produce them and `display set`

--- a/pkg/config/compiler_applications.go
+++ b/pkg/config/compiler_applications.go
@@ -631,6 +631,11 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 	// a default arm an unknown leaf (and its value) were silently dropped,
 	// widening the term. Record them for the deferred strict gate.
 	var badTermLeaves []string
+	// #6564 member 9: RECOGNIZED value-taking leaves that appeared with NO
+	// value (last token in the term). Distinct from badTermLeaves, which holds
+	// UNRECOGNIZED tokens — the keyword here IS supported, it just has nothing
+	// to constrain with, so the strict gate words the two differently.
+	var incompleteTermLeaves []string
 	// #3348: per normalized-protocol echo-type implied by a junos-ping /
 	// junos-pingv6 alias inside an inline term. normalizeProtocol folds the
 	// alias to "icmp"/"icmpv6" and loses the ping distinction, so capture the
@@ -648,6 +653,27 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 	unconstrainedICMP := map[string]bool{}
 
 	for i := 1; i < len(keys); i++ {
+		// #6564 member 9: a RECOGNIZED value-taking leaf in the LAST position
+		// has no value to consume. Every arm below is guarded by
+		// `if i+1 < len(keys)` with no else, so such a keyword fell through
+		// recording NOTHING — and the `default:` arm that feeds badTermLeaves
+		// is unreachable for a keyword the switch recognizes.
+		//
+		// That is the same fail-open the rest of this function exists to stop:
+		// the constraint is dropped and the term WIDENS. `term t1 protocol tcp
+		// destination-port` compiled to protocol-only, so an application
+		// written to match ONE port matched EVERY TCP port, and any policy
+		// permitting it widened with it. #3320 / #3348 / #3352 / #6524 each
+		// instrument a MALFORMED value; this shape has no value to be
+		// malformed, which is why none of them caught it.
+		//
+		// Checked ONCE here rather than as eight `else` branches: a per-arm
+		// else would have to be repeated for every future value-taking leaf and
+		// is exactly the kind of duplication that drifts.
+		if i+1 >= len(keys) && valueTakingTermLeaves[keys[i]] {
+			incompleteTermLeaves = append(incompleteTermLeaves, keys[i])
+			continue
+		}
 		switch keys[i] {
 		case "protocol":
 			if i+1 < len(keys) {
@@ -789,21 +815,42 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 			it = echoByProto[proto]
 		}
 		result = append(result, &Application{
-			Name:                name,
-			Protocol:            proto,
-			DestinationPort:     dstPort,
-			SourcePort:          srcPort,
-			InactivityTimeout:   timeout,
-			ALG:                 alg,
-			UnknownTimeouts:     badTimeouts,
-			ICMPType:            it,
-			ICMPCode:            icmpCode,
-			UnknownICMP:         badICMP,
-			UnknownTermLeaves:   badTermLeaves,
-			DuplicateTermLeaves: dupTermLeaves,
+			Name:                 name,
+			Protocol:             proto,
+			DestinationPort:      dstPort,
+			SourcePort:           srcPort,
+			InactivityTimeout:    timeout,
+			ALG:                  alg,
+			UnknownTimeouts:      badTimeouts,
+			ICMPType:             it,
+			ICMPCode:             icmpCode,
+			UnknownICMP:          badICMP,
+			UnknownTermLeaves:    badTermLeaves,
+			IncompleteTermLeaves: incompleteTermLeaves,
+			DuplicateTermLeaves:  dupTermLeaves,
 		})
 	}
 	return result
+}
+
+// valueTakingTermLeaves is the set of inline-`term` leaves that REQUIRE a
+// following value token (#6564 member 9). It is the arity contract for
+// parseApplicationTerms' switch: every arm below that consumes `keys[i+1]`
+// must appear here, so a keyword left dangling in the last position is
+// recorded rather than silently dropping its constraint.
+//
+// Adding a value-taking leaf to the switch without adding it here re-opens the
+// fail-open, so the two are pinned together by
+// TestValueTakingTermLeavesCoversEveryConsumingArm6564.
+var valueTakingTermLeaves = map[string]bool{
+	"protocol":           true,
+	"destination-port":   true,
+	"source-port":        true,
+	"icmp-type":          true,
+	"icmp-code":          true,
+	"inactivity-timeout": true,
+	"timeout":            true,
+	"alg":                true,
 }
 
 // aliasEchoICMPType returns the echo-request ICMP / ICMPv6 type implied by a

--- a/pkg/config/compiler_validate_strict_application.go
+++ b/pkg/config/compiler_validate_strict_application.go
@@ -408,6 +408,19 @@ func validateApplicationSyntaxStrict(cfg *Config) error {
 		// UnknownTermLeaves (mirroring UnknownTimeouts / UnknownICMP); reject the
 		// first one so the silent match-widening becomes an operator-visible
 		// commit error.
+		// #6564 member 9: a RECOGNIZED value-taking leaf with NO value. Worded
+		// separately from UnknownTermLeaves above because the keyword IS
+		// supported — calling it an "unknown statement" would send the operator
+		// looking for a typo that is not there. The consequence is the same
+		// fail-open: the constraint is dropped and the term widens.
+		if len(app.IncompleteTermLeaves) > 0 {
+			return fmt.Errorf(
+				"application %q: `term` statement %q is missing its value; the "+
+					"statement is dropped along with the constraint it was meant to "+
+					"impose, widening the term to match more than intended (e.g. "+
+					"`protocol tcp destination-port` with no port matches EVERY TCP port)",
+				name, app.IncompleteTermLeaves[0])
+		}
 		if len(app.UnknownTermLeaves) > 0 {
 			return fmt.Errorf(
 				"application %q: unknown statement %q inside `term`; a custom "+

--- a/pkg/config/dangling_term_keyword_6564_test.go
+++ b/pkg/config/dangling_term_keyword_6564_test.go
@@ -1,0 +1,258 @@
+package config
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// #6564 member 9 — a recognized `term` leaf keyword with NO value.
+//
+// parseApplicationTerms guards every value-taking arm with `if i+1 < len(keys)`
+// and has no `else`. A keyword in the LAST position therefore falls through
+// recording nothing at all: the `default:` arm that feeds UnknownTermLeaves is
+// unreachable for a keyword the switch recognizes.
+//
+// The consequence is the exact fail-open the surrounding family was built to
+// stop. `default:`'s own comment says it records the token "rather than
+// silently dropping the constraint and widening the match", and #3348's says a
+// dropped icmp-type "would leave the term UNCONSTRAINED ... a fail-open
+// widening". A dangling keyword does precisely that and was the one shape none
+// of #3320 / #3348 / #3352 / #6524 caught, because each of those instruments a
+// MALFORMED value and this one has no value to be malformed.
+//
+// `term t1 protocol tcp destination-port` compiles to protocol-only, so an
+// application the operator wrote to match ONE port matches EVERY TCP port —
+// and a policy permitting it widens with it.
+//
+// POSTURE (#1960 no-brick): the repair records the keyword so the EXISTING
+// validateApplicationSpecsStrict gate refuses it on the operator commit path,
+// and the EXISTING lenientApplicationSpecs (#2142) downgrade keeps the tolerant
+// Store.Load / Store.SyncApply path warning-only. Both directions are asserted.
+
+func appTree6564(t *testing.T, cmds ...string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// TestDanglingTermKeywordRejected6564 is the fail-on-revert case: every
+// value-taking leaf, left dangling, must be refused at strict commit.
+//
+// FAIL-ON-REVERT: drop the incomplete-keyword record from parseApplicationTerms
+// (restore the bare `if i+1 < len(keys)` with no else).
+func TestDanglingTermKeywordRejected6564(t *testing.T) {
+	for _, kw := range []string{
+		"protocol",
+		"destination-port",
+		"source-port",
+		"icmp-type",
+		"icmp-code",
+		"inactivity-timeout",
+		"timeout",
+		"alg",
+	} {
+		t.Run(kw, func(t *testing.T) {
+			tree := appTree6564(t,
+				"set applications application appA term t1 protocol tcp "+kw)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("#6564: `term t1 protocol tcp %s` (keyword with NO value) must be "+
+					"REJECTED at strict commit — it records nothing, so the constraint is "+
+					"dropped and the term WIDENS (protocol-only matches every TCP port), which "+
+					"is the same fail-open #3348/#3352 exist to stop", kw)
+			}
+			if !strings.Contains(err.Error(), kw) {
+				t.Fatalf("the rejection must name the dangling keyword %q; got %v", kw, err)
+			}
+			if !strings.Contains(err.Error(), "appA") {
+				t.Fatalf("the rejection must name the application; got %v", err)
+			}
+		})
+	}
+}
+
+// TestCompleteTermStillCompiles6564 is the over-rejection guard.
+//
+// The repair must fire ONLY on a keyword with no value. A well-formed term —
+// and a term whose LAST leaf is a valid keyword/value pair, which is the
+// boundary case the `i+1 < len(keys)` guard is actually about — must still
+// compile and keep its constraints.
+//
+// FAIL-ON-REVERT: make the incomplete-keyword record unconditional (drop the
+// `i+1 >= len(keys)` condition) and this reds immediately.
+func TestCompleteTermStillCompiles6564(t *testing.T) {
+	tree := appTree6564(t,
+		"set applications application appA term t1 protocol tcp destination-port 80",
+		"set applications application appB term t1 protocol udp source-port 53 destination-port 53",
+		"set applications application appC term t1 protocol icmp icmp-type 8 icmp-code 0",
+		"set applications application appD term t1 protocol tcp destination-port 22 inactivity-timeout 1800",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("a well-formed term must still compile; got %v", err)
+	}
+
+	// The trailing constraint must actually be RETAINED, not merely accepted —
+	// a repair that recorded nothing and also parsed nothing would pass a
+	// compile-only assertion.
+	// A term-bearing application is stored as synthesized per-term entries, so
+	// look the constraint up by scanning rather than by guessing the key.
+	findDPort := func(want string) bool {
+		for _, a := range cfg.Applications.Applications {
+			if a.DestinationPort == want {
+				return true
+			}
+		}
+		return false
+	}
+	if !findDPort("80") {
+		t.Fatalf("a well-formed term must RETAIN destination-port 80 — it is the LAST leaf, "+
+			"i.e. exactly the boundary the `i+1 < len(keys)` guard is about, so a repair that "+
+			"mis-ordered the check would drop it; got %+v", cfg.Applications.Applications)
+	}
+	foundICMPCode := false
+	for _, a := range cfg.Applications.Applications {
+		if a.ICMPCode != nil && *a.ICMPCode == 0 && a.ICMPType != nil && *a.ICMPType == 8 {
+			foundICMPCode = true
+		}
+	}
+	if !foundICMPCode {
+		t.Fatalf("a well-formed term must RETAIN icmp-type 8 / icmp-code 0 as its trailing "+
+			"leaf; got %+v", cfg.Applications.Applications)
+	}
+}
+
+// TestDanglingTermKeywordIsWarnOnlyOnTolerantPath6564 is the #1960 no-brick
+// direction.
+//
+// A config an older binary accepted is already persisted and already arriving
+// over HA config-sync. Refusing it on the tolerant path would blackout-boot the
+// node or alarm-loop config sync during an upgrade. The existing
+// lenientApplicationSpecs (#2142) downgrade must still apply to this new
+// record, so the strict gate refuses while the tolerant path warns and
+// continues.
+//
+// FAIL-ON-REVERT: reject the dangling keyword from a path the lenient opts
+// cannot downgrade (e.g. a hard error inside parseApplicationTerms itself).
+func TestDanglingTermKeywordIsWarnOnlyOnTolerantPath6564(t *testing.T) {
+	tree := appTree6564(t, "set applications application appA term t1 protocol tcp destination-port")
+
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("setup: the strict path must reject the dangling keyword")
+	}
+
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("#1960 no-brick: the tolerant load / peer-sync path must still COMPILE a "+
+			"dangling term keyword (warn, not refuse) — a hard failure here blackout-boots a "+
+			"node whose persisted config an older binary accepted; got %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("#1960 no-brick: the tolerant path returned no config")
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "destination-port") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("the tolerant path must WARN about the dropped constraint rather than "+
+			"accepting it in silence — silence is the defect; got warnings %v", cfg.Warnings)
+	}
+}
+
+// TestValueTakingTermLeavesCoversEveryConsumingArm6564 binds the
+// valueTakingTermLeaves set to the switch it describes.
+//
+// The set is the arity contract for parseApplicationTerms: the dangling-keyword
+// guard fires only for keywords listed in it, so a future value-taking leaf
+// added to the switch WITHOUT being added to the set silently re-opens the
+// fail-open — and every behavioural test above would still pass, because they
+// can only exercise keywords someone remembered to list.
+//
+// The two are therefore bound textually, on the source of the function itself:
+// every `case "<kw>":` arm whose body consumes `keys[i+1]` must be a member.
+// This is the same discipline as the #6588 no-arg statement registry, which
+// pins its map against the dispatch table it mirrors.
+//
+// FAIL-ON-REVERT: add a `case "foo":` arm to parseApplicationTerms that reads
+// `keys[i+1]` without adding "foo" to valueTakingTermLeaves.
+func TestValueTakingTermLeavesCoversEveryConsumingArm6564(t *testing.T) {
+	src, err := os.ReadFile("compiler_applications.go")
+	if err != nil {
+		t.Fatalf("read compiler_applications.go: %v", err)
+	}
+	body := string(src)
+
+	start := strings.Index(body, "func parseApplicationTerms")
+	if start < 0 {
+		t.Fatal("parseApplicationTerms not found — this gate is bound to that function " +
+			"by name and must be re-pointed if it is renamed")
+	}
+	// End at the next top-level func so the scan cannot wander into unrelated
+	// switches.
+	rest := body[start+1:]
+	end := strings.Index(rest, "\nfunc ")
+	if end < 0 {
+		t.Fatal("could not find the end of parseApplicationTerms")
+	}
+	fn := rest[:end]
+
+	caseRe := regexp.MustCompile(`(?m)^\s*case ("(?:[^"]+)"(?:, "(?:[^"]+)")*):`)
+	kwRe := regexp.MustCompile(`"([^"]+)"`)
+
+	locs := caseRe.FindAllStringSubmatchIndex(fn, -1)
+	if len(locs) == 0 {
+		t.Fatal("no case arms found in parseApplicationTerms — the scan pattern has rotted, " +
+			"which would make this gate vacuous")
+	}
+
+	checked := 0
+	for i, loc := range locs {
+		labels := fn[loc[2]:loc[3]]
+		armStart := loc[1]
+		armEnd := len(fn)
+		if i+1 < len(locs) {
+			armEnd = locs[i+1][0]
+		}
+		arm := fn[armStart:armEnd]
+		// Only arms that actually consume the NEXT token are value-taking.
+		if !strings.Contains(arm, "i+1 < len(keys)") {
+			continue
+		}
+		for _, m := range kwRe.FindAllStringSubmatch(labels, -1) {
+			kw := m[1]
+			checked++
+			if !valueTakingTermLeaves[kw] {
+				t.Errorf("#6564: parseApplicationTerms has a value-consuming arm for %q "+
+					"(its body reads keys[i+1]) but %q is NOT in valueTakingTermLeaves — a "+
+					"dangling `%s` would fall through recording nothing, dropping the "+
+					"constraint and widening the term, exactly the fail-open member 9 closed",
+					kw, kw, kw)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("the scan matched no value-consuming arms — the pattern has rotted and this " +
+			"gate is vacuous")
+	}
+	// Every member of the set must correspond to a real arm, so the set cannot
+	// accumulate entries for leaves that no longer exist.
+	if checked != len(valueTakingTermLeaves) {
+		t.Errorf("valueTakingTermLeaves has %d entries but %d value-consuming arms were found; "+
+			"the set and the switch have drifted", len(valueTakingTermLeaves), checked)
+	}
+}

--- a/pkg/config/testdata/golden_4406.json
+++ b/pkg/config/testdata/golden_4406.json
@@ -13543,6 +13543,7 @@
             "UnknownTimeouts": null,
             "UnknownICMP": null,
             "UnknownTermLeaves": null,
+            "IncompleteTermLeaves": null,
             "DuplicateTermLeaves": null,
             "DuplicateDirectLeaves": [
               "protocol"
@@ -13820,6 +13821,7 @@
             "UnknownTimeouts": null,
             "UnknownICMP": null,
             "UnknownTermLeaves": null,
+            "IncompleteTermLeaves": null,
             "DuplicateTermLeaves": null,
             "DuplicateDirectLeaves": [
               "protocol"
@@ -14097,6 +14099,7 @@
             "UnknownTimeouts": null,
             "UnknownICMP": null,
             "UnknownTermLeaves": null,
+            "IncompleteTermLeaves": null,
             "DuplicateTermLeaves": null,
             "DuplicateDirectLeaves": [
               "protocol"

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -1298,6 +1298,18 @@ type Application struct {
 	// on the strict commit path / warns on the tolerant load / peer-sync path
 	// (#3352).
 	UnknownTermLeaves []string
+	// IncompleteTermLeaves records RECOGNIZED value-taking leaves inside an
+	// inline `term` that carried NO value — the keyword was the last token, so
+	// there was nothing to consume (#6564 member 9). parseApplicationTerms
+	// guards every consuming arm with `if i+1 < len(keys)` and has no else, and
+	// the `default:` arm that feeds UnknownTermLeaves is unreachable for a
+	// keyword the switch recognizes, so the constraint was dropped in silence
+	// and the term WIDENED — `term t1 protocol tcp destination-port` matched
+	// every TCP port. Distinct from UnknownTermLeaves because the keyword IS
+	// supported; only its value is missing, and the two are worded differently
+	// by validateApplicationSpecsStrict. Strict on commit / commit-check, warn
+	// on the tolerant load / peer-sync path (lenientApplicationSpecs, #2142).
+	IncompleteTermLeaves []string
 	// DuplicateTermLeaves records the names of single-valued (scalar) leaves
 	// (destination-port / source-port / inactivity-timeout / timeout / alg /
 	// icmp-type / icmp-code) that


### PR DESCRIPTION
Refs #6564 — ships **member 9**. With #7365 (shape family) and #7371 (strict family) this leaves only **member 8**, which is scoped to `junos_host_deny.go` and owned by the host-inbound lane.

## The defect

`parseApplicationTerms` guards every value-taking arm with `if i+1 < len(keys)` and has **no `else`**, so a *recognized* leaf keyword in the LAST position fell through recording nothing — and the `default:` arm that feeds `UnknownTermLeaves` is unreachable for a keyword the switch recognizes.

```
set applications application appA term t1 protocol tcp destination-port
```

compiles to **protocol-only**. An application the operator wrote to match ONE port matches **every TCP port**, and any policy permitting it widens with it.

This is the exact fail-open the rest of that function exists to stop — `default:`'s own comment says it records the token *"rather than silently dropping the constraint and widening the match"*, and #3348's says a dropped `icmp-type` *"would leave the term UNCONSTRAINED ... a fail-open widening"*.

## Why the surrounding family missed it

#3320 (malformed timeout), #3348 (malformed icmp-type), #3352 (unrecognized leaf) and #6524 (trailing token on the application body) each instrument a **malformed value**. This shape has no value to be malformed — the defect is the **absence** of one — so none of their gates could see it.

Worth generalising: a cohort built around "instrument the bad value" has a structural blind spot at "there is no value".

## Shape of the fix

**One guard, not eight `else` branches.** The check runs once before the switch, keyed on a new `valueTakingTermLeaves` set. A per-arm `else` would have to be repeated for every future value-taking leaf — the duplication that drifts.

**The set is pinned to the switch textually.** It is the arity contract, and a future leaf added to the switch *without* being added to the set silently re-opens the fail-open — while every behavioural test still passes, because those can only exercise keywords someone remembered to list. `TestValueTakingTermLeavesCoversEveryConsumingArm6564` scans the function's own source: every `case "<kw>":` arm whose body reads `keys[i+1]` must be a member, and the counts must match **in both directions** so the set cannot accumulate stale entries. It fails loudly if its own scan pattern stops matching, so it cannot rot into a vacuous pass. Same discipline as the #6588 no-arg statement registry.

**`IncompleteTermLeaves` is deliberately separate from `UnknownTermLeaves`** — the keyword IS supported, so "unknown statement" would send the operator hunting a typo that is not there.

## Posture

The cohort's usual #1960 no-brick split: **strict** on commit / commit-check, **warn** on the tolerant load / peer-sync path via the *existing* `lenientApplicationSpecs` (#2142) downgrade. No new opts flag was needed. Both directions are asserted.

## Golden baseline

`golden_4406.json` is regenerated for the new struct field. The regeneration was **verified structural-only before being accepted**: 3 keys added, **all `null`**, 0 removed, **0 values changed**. A golden updated without that check is how a real behaviour change gets laundered into a baseline.

## Mutation matrix

One mutation per line, each **verified APPLIED before its run**, production restored verbatim between cells.

| # | Mutation | Result |
|---|---|---|
| M9a | delete the dangling-keyword guard | **RED** |
| M9b | guard fires unconditionally (over-rejects a complete term) | **RED** |
| M9c | delete the strict gate (record kept, never read) | **RED** |
| M9d | drop `alg` from `valueTakingTermLeaves` | **RED** |

**M9b** is the over-rejection direction. **M9d** is the drift direction — and it reds the source-scanning pin *itself*, which is what proves that gate is not vacuous.

M9d also **failed to apply on its first attempt** (`"alg": true,` appears twice in the file) and reported `test=0`. That is a **non-result, not a pass**, so it was redone against a line-verified anchor. Recording it because a silently-unapplied mutation makes a sound fix look unbound.

## Validation

- `go build ./...` clean.
- `go test -count=1 ./pkg/config/` — ok, 46.7s.
- Downstream green: `pkg/configstore`, `pkg/dataplane`, `pkg/daemon`.
- Green baseline before any edit; red-first confirmed across all eight value-taking keywords.

Docs: `docs/config-schema.md` gains a member-9 section covering the blind-spot generalisation, the one-guard rationale, and why the drift pin is textual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gcdxy5mCofwyVWHUKzhU9F
