### PR TITLE
userspace-dp/HA: reserve the NAT port before publishing an import (#6600)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -101745,3 +101745,26 @@ prose edit above them added. No diff falls in the new test body.
   - **File(s)**: pkg/config/compiler_security_alg.go, pkg/config/compiler_routing.go,
     pkg/config/compiler_security_flow.go, pkg/config/compact_leaf_cohort_6564_test.go,
     docs/config-schema.md
+
+## 2026-08-22 — #6600 HA import reserves the NAT port before publishing
+- **Timestamp**: 2026-08-22
+- **Action**: `upsert_synced_session` published the shared session entry before
+  enqueueing the worker commands, and the NAT reservation happened only inside
+  the worker-local upsert — so in that window a local flow could claim the port,
+  `reserve_flow` refused to steal it, and the refusal was returned/counted/logged
+  by nothing. Moved the reservation to the coordinator, BEFORE the publish, and
+  refuse the import on failure (counted as `synced_import_reserve_refused`).
+  Made the reserve chains return their verdict (the bool was already computed
+  and discarded). Untracked holder so worker reserves are absorbed; skipped with
+  zero workers; source-NAT rolled back if NAT64 refuses. Zone pair resolved
+  through the SAME helper the worker uses.
+  **MOVES THE userspace-dp HELPER BINARY — cluster smoke owed.**
+- **File(s)**: userspace-dp/src/afxdp/ha/session_import.rs,
+  userspace-dp/src/nat/source.rs, userspace-dp/src/nat/mod.rs,
+  userspace-dp/src/nat64.rs,
+  userspace-dp/src/afxdp/coordinator/session_manager.rs,
+  userspace-dp/src/afxdp/coordinator/status.rs,
+  userspace-dp/src/afxdp/session_glue/mod.rs,
+  userspace-dp/src/afxdp/session_glue/commands/mod.rs,
+  userspace-dp/src/afxdp/session_glue/commands/upsert_synced.rs,
+  userspace-dp/src/afxdp/ha_tests.rs, docs/sync-protocol.md, _Log.md

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -310,6 +310,66 @@ V6}` (drives the real sender enqueue + receiver apply in wire order),
 `TestDeleteGenerationStrictlyGreaterThanInstall{V4,V6}` in
 `pkg/cluster/sync_gen_guard_test.go`.
 
+## NAT-Port Reservation on Import (#6600)
+
+A peer-synced session carries a pre-computed NAT decision, so the importing
+node must RESERVE the translated port it names — the standby never runs the
+allocation path that would otherwise claim it, and after failover a fresh local
+flow could reuse it, putting two flows on one NAT source tuple.
+
+That reservation used to happen ONLY inside the worker-local upsert, which is
+driven by a command enqueued **after** the shared session entry was published.
+`publish_shared_session` makes the entry visible on every packet-path lookup
+surface at once (`synced`, `nat`, `forward_wire`), and
+`materialize_shared_session_hit` forwards on `replica.decision` — including
+`decision.nat` — without reserving anything. A worker that sampled an empty
+command queue just before the coordinator's push proceeds straight into
+`poll_binding` with the entry already live.
+
+In that window a local flow can allocate the same port. `reserve_flow` then
+REFUSES to steal it, which is the right call — but the refusal was returned by
+nothing, counted by nothing and logged by nothing, so the imported session went
+on advertising a translation this node did not own.
+
+**The reservation is now taken by the coordinator, before the publish.** A
+refusal drops the import: no session beats a session naming someone else's
+port, and the peer re-syncs. It is counted as
+`synced_import_reserve_refused_total` — a silent drop would only trade one
+invisible failure for another. A nonzero value means a local flow held the
+translated port at import time, which on a healthy standby (owning RG passive)
+should not happen: look for overlapping pools, an active-active RG pair sharing
+one SNAT pool, or NAT config drift between the nodes.
+
+Three properties that are load-bearing and each pinned by a test:
+
+- **The coordinator's reservation is `Untracked`, so it is ABSORBED rather than
+  doubled.** It contributes no holder bit, so each worker's later reserve finds
+  the identical `(flow, translated)` already live, takes `reserve_flow`'s
+  idempotent early return and ORs its own bit in. The last worker's release
+  still empties the mask and frees the port. Had the coordinator's reservation
+  instead made the workers' REFUSE, no holder bit would ever be recorded and
+  the port would leak.
+- **Skipped when no worker is registered.** Nothing polls, so there is no racing
+  local allocation to guard against, and an `Untracked` reservation no worker
+  adopts has nobody to release it. Same carve-out as the zero-ceiling case.
+- **A half-taken reservation is rolled back.** A NAT64 decision carries both a
+  v4 pool source (source-NAT allocator) and a translated `(pool v4, port)` (the
+  per-prefix allocator), so a session can be admissible to one and not the
+  other. Without the rollback the source-NAT port taken moments before a NAT64
+  refusal is held by nobody — the import is not published, so there is no
+  session to reap.
+
+The zone pair is resolved through the SAME helper the worker-side upsert uses.
+If the two disagreed, the coordinator would reserve in one allocator while the
+workers reserve in another: its check would pass while the port the session
+actually names stayed free.
+
+**Note on the import outcome.** The control RPC's `ControlResponse.ok` is not
+yet driven by this refusal. The reservation now happens early enough that it
+COULD be — which was impossible before, since the worker-side reserve runs long
+after the RPC has answered — but wiring it through the handler, and the
+Prometheus counter for the new metric, are tracked separately.
+
 ## Config-Epoch Guard (#5274)
 
 Distinct from the per-key install generation (#2170), every **session** message

--- a/userspace-dp/src/afxdp/coordinator/session_manager.rs
+++ b/userspace-dp/src/afxdp/coordinator/session_manager.rs
@@ -64,6 +64,28 @@ pub(in crate::afxdp) struct SessionManager {
     /// peer's full logical set (N logical → 2N entries) EXACTLY fits the 2N cap
     /// — never trips it, at any peer load.
     pub(in crate::afxdp) import_cap_drops: AtomicU64,
+    /// #6600: peer-synced imports REFUSED because this node could not reserve
+    /// the translated NAT port the session names.
+    ///
+    /// The import path published the shared session entry BEFORE any worker
+    /// reserved that port, and the reservation — which happens only inside the
+    /// worker-local upsert — REFUSES to steal a port a different live
+    /// allocation already holds. The refusal was returned by nothing, counted
+    /// by nothing and logged by nothing, so in the window between publish and
+    /// worker-apply a local flow could claim the port and the imported session
+    /// went on advertising a translation this node did not own. Any packet
+    /// forwarded on that shared-backed decision used it.
+    ///
+    /// The reservation now happens at the coordinator BEFORE the publish, and a
+    /// refusal drops the import instead. That is the safe direction — no
+    /// session beats a session naming someone else's port, and the peer re-syncs
+    /// — but it is still a DROPPED failover session, so it must be visible: a
+    /// silent drop would trade one invisible failure for another. A nonzero
+    /// value means a local flow held the translated port at import time, which
+    /// on a healthy standby (owning RG passive) should not happen and points at
+    /// overlapping pools, an active-active RG pair sharing one SNAT pool, or
+    /// genuine NAT config drift between the nodes.
+    pub(in crate::afxdp) import_reserve_refused: AtomicU64,
 }
 
 impl SessionManager {
@@ -77,6 +99,7 @@ impl SessionManager {
             install_stale_ignored: AtomicU64::new(0),
             delete_stale_ignored: AtomicU64::new(0),
             import_cap_drops: AtomicU64::new(0),
+            import_reserve_refused: AtomicU64::new(0),
         }
     }
 }

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -289,6 +289,13 @@ impl super::Coordinator {
         self.sessions.import_cap_drops.load(Ordering::Relaxed)
     }
 
+    /// #6600: peer-synced imports refused because this node could not reserve
+    /// the translated NAT port the session names. See
+    /// `SessionManager::import_reserve_refused` for what a nonzero value means.
+    pub fn synced_import_reserve_refused_total(&self) -> u64 {
+        self.sessions.import_reserve_refused.load(Ordering::Relaxed)
+    }
+
     /// #1760 W3': shared-map NAT reverse-key displacement events — a
     /// `publish_shared_session` insert into `shared_nat_sessions`
     /// displaced a DIFFERENT forward session's entry at the same reverse

--- a/userspace-dp/src/afxdp/ha/session_import.rs
+++ b/userspace-dp/src/afxdp/ha/session_import.rs
@@ -43,6 +43,55 @@ impl crate::afxdp::Coordinator {
             .saturating_mul(2)
     }
 
+    /// #6600: take this node's reservation on a peer-synced forward entry's
+    /// translated NAT identity. Returns false when the node cannot own it.
+    ///
+    /// The zone pair is resolved through the SAME helper the worker-side upsert
+    /// uses, so the coordinator and the workers cannot land on different
+    /// allocators — a coordinator that reserved elsewhere would report success
+    /// while the port the session actually names stayed free.
+    ///
+    /// The NAT64 twin is taken second and ROLLED BACK on failure of neither
+    /// half being enough on its own: a NAT64 decision carries both a v4 pool
+    /// source (source-NAT allocator) and a translated `(pool v4, port)` (the
+    /// per-prefix allocator), so a session can be admissible to one and not the
+    /// other. Leaving a half-taken reservation behind would be a leak no worker
+    /// ever releases, because no session gets published to reap.
+    fn reserve_synced_translation(&self, entry: &SyncedSessionEntry) -> bool {
+        let now_ns = monotonic_nanos();
+        let zones = crate::afxdp::session_glue::synced_source_nat_zone_pair(
+            &self.forwarding,
+            &entry.metadata,
+        );
+        if !crate::nat::reserve_synced_source_nat_allocation_untracked(
+            &self.forwarding.source_nat_rules,
+            &entry.key,
+            entry.decision.nat,
+            entry.metadata.is_reverse,
+            zones,
+            now_ns,
+        ) {
+            return false;
+        }
+        if !crate::nat64::reserve_synced_nat64_allocation(
+            &self.forwarding.nat64,
+            &entry.key,
+            entry.decision.nat,
+            entry.metadata.is_reverse,
+            now_ns,
+        ) {
+            crate::nat::release_source_nat_allocation(
+                &self.forwarding.source_nat_rules,
+                &entry.key,
+                entry.decision.nat,
+                entry.metadata.is_reverse,
+                now_ns,
+            );
+            return false;
+        }
+        true
+    }
+
     pub fn upsert_synced_session(&self, entry: SyncedSessionEntry) {
         let now_secs = monotonic_nanos() / 1_000_000_000;
         let ha_state = self.ha.rg_runtime.load();
@@ -164,6 +213,47 @@ impl crate::afxdp::Coordinator {
         } else {
             None
         };
+        // #6600: RESERVE THE TRANSLATED NAT PORT BEFORE PUBLISHING.
+        //
+        // The publish below makes the entry visible on every packet-path lookup
+        // surface at once (`synced`, `nat`, `forward_wire`), and
+        // `materialize_shared_session_hit` forwards on `replica.decision`
+        // — including `decision.nat` — without reserving anything. The
+        // reservation used to happen ONLY inside the worker-local upsert, which
+        // is driven by a command enqueued AFTER this publish; a worker that
+        // sampled an empty queue just before that push proceeds straight into
+        // `poll_binding` with the entry already live. In that window a local
+        // flow can allocate the same port, and `reserve_flow` REFUSES to steal
+        // it — correctly — after which the imported session went on advertising
+        // a translation this node does not own, with the refusal returned by
+        // nothing and counted by nothing.
+        //
+        // Taking the reservation here closes the window at its source rather
+        // than trying to observe it afterwards. It is also the only thing that
+        // COULD make the refusal reachable by the import outcome at all: the
+        // worker-side reserve runs long after the control RPC has answered, so
+        // propagating from there was never possible.
+        //
+        // `Untracked` contributes no holder bit, so the per-worker reservations
+        // that follow are absorbed rather than doubled — `reserve_flow` finds
+        // the identical `(flow, translated)` already live and takes its
+        // idempotent early return, OR-ing each worker's bit in — and the last
+        // worker's release still empties the mask and frees the port.
+        //
+        // Skipped when NO worker is registered: nothing polls, so there is no
+        // racing local allocation to guard against, and an `Untracked`
+        // reservation that no worker ever adopts has no one to release it. Same
+        // shape as the zero-ceiling carve-out above, and for the same reason.
+        if entry.origin.is_peer_synced()
+            && !entry.metadata.is_reverse
+            && !self.workers.records.is_empty()
+            && !self.reserve_synced_translation(&entry)
+        {
+            self.sessions
+                .import_reserve_refused
+                .fetch_add(1, Ordering::Relaxed);
+            return;
+        }
         publish_shared_session(
             &self.sessions.synced,
             &self.sessions.nat,

--- a/userspace-dp/src/afxdp/ha_tests.rs
+++ b/userspace-dp/src/afxdp/ha_tests.rs
@@ -2124,3 +2124,515 @@ fn every_shared_session_lock_in_production_recovers_from_poison_6653() {
         offenders.join("\n  ")
     );
 }
+
+// --- #6600: reserve-before-publish -----------------------------------------
+
+/// A single-address pool source-NAT rule, so a synced translation names a real
+/// pool port that a local flow can contend for.
+fn reserve6600_forwarding() -> ForwardingState {
+    let mut forwarding = ForwardingState::default();
+    forwarding.source_nat_rules = crate::nat::parse_source_nat_rules(&[crate::SourceNATRuleSnapshot {
+        name: "pool-snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "p".to_string(),
+        pool_addresses: vec!["203.0.113.1/32".to_string()],
+        port_low: 1024,
+        port_high: 65535,
+        ..crate::SourceNATRuleSnapshot::default()
+    }]);
+    forwarding
+}
+
+/// A peer-synced forward entry whose NAT decision names `pool_port` on the
+/// single-address pool above.
+fn reserve6600_entry(src_port: u16, pool_port: u16) -> SyncedSessionEntry {
+    SyncedSessionEntry {
+        key: SessionKey {
+            src_port,
+            ..test_key()
+        },
+        decision: SessionDecision {
+            resolution: test_resolution(),
+            nat: NatDecision {
+                rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))),
+                rewrite_src_port: Some(pool_port),
+                ..NatDecision::default()
+            },
+        },
+        metadata: test_metadata(),
+        origin: SessionOrigin::SyncImport,
+        protocol: PROTO_TCP,
+        tcp_flags: 0x10,
+        generation: 0,
+        session_id: 0,
+    }
+}
+
+/// #6600 fail-on-revert gate: an import whose translated NAT port is already
+/// owned by a LOCAL flow must be REFUSED — not published, not fanned out — and
+/// counted.
+///
+/// Before this, `upsert_synced_session` published the shared entry (visible at
+/// once on `synced`, `nat` and `forward_wire`) and only THEN enqueued the worker
+/// commands. The reservation lived solely inside the worker-local upsert, and
+/// `reserve_flow` refuses to steal a port a different live allocation holds —
+/// with the refusal returned by nothing, counted by nothing and logged by
+/// nothing. A worker that sampled an empty command queue just before the push
+/// proceeds into `poll_binding` with the entry already live, and
+/// `materialize_shared_session_hit` forwards on `replica.decision.nat` without
+/// reserving anything. The session then advertised a translation this node did
+/// not own.
+///
+/// Reverting the pre-publish reservation in `upsert_synced_session` makes case
+/// (b) go red: the entry is published and fanned out with the port unreserved.
+#[test]
+fn upsert_synced_session_refuses_import_whose_nat_port_is_locally_owned_6600() {
+    let mut coordinator = Coordinator::new();
+    coordinator.forwarding = reserve6600_forwarding();
+    let commands = Arc::new(Mutex::new(VecDeque::new()));
+    coordinator.workers.records.insert(
+        0,
+        WorkerRuntimeRecord::for_test(test_worker_handle(commands.clone())),
+    );
+
+    // (a) POSITIVE CONTROL FIRST. Without it a coordinator that refused every
+    // import would satisfy (b) completely.
+    let free = reserve6600_entry(40001, 50001);
+    let free_key = free.key.clone();
+    coordinator.upsert_synced_session(free);
+    assert!(
+        synced6600_contains(&coordinator, &free_key),
+        "an import whose translated port is FREE must still be admitted"
+    );
+    assert_eq!(
+        coordinator.synced_import_reserve_refused_total(),
+        0,
+        "an admissible import must not be counted as a reservation refusal"
+    );
+
+    // A LOCAL flow now owns pool port 50000 — the port the next import names.
+    // This is the racing allocation the publish/enqueue window admits.
+    let contended: u16 = 50000;
+    let local_flow = SessionKey {
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 200)),
+        src_port: 44444,
+        ..test_key()
+    };
+    // Occupied through the PUBLIC reservation entry point rather than the
+    // allocator's private mint, so the test drives the same code the production
+    // paths do. A different flow holding the same translated identity is
+    // exactly the "different live allocation" `reserve_flow` refuses to steal
+    // from.
+    assert!(
+        crate::nat::reserve_synced_source_nat_allocation_untracked(
+            &coordinator.forwarding.source_nat_rules,
+            &local_flow,
+            NatDecision {
+                rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))),
+                rewrite_src_port: Some(contended),
+                ..NatDecision::default()
+            },
+            false,
+            None,
+            1_000,
+        ),
+        "setup: the local flow must end up holding the exact port the import names, \
+         or the case below is not exercising the collision at all"
+    );
+
+    let before = coordinator.synced_import_reserve_refused_total();
+
+    // (b) THE CASE. An import naming the locally-owned port must be refused.
+    let clashing = reserve6600_entry(40002, contended);
+    let clashing_key = clashing.key.clone();
+    coordinator.upsert_synced_session(clashing);
+
+    assert!(
+        !synced6600_contains(&coordinator, &clashing_key),
+        "an import whose translated NAT port is owned by a LOCAL flow was PUBLISHED; \
+         every packet forwarded on that shared-backed decision uses a port this node \
+         does not own"
+    );
+    {
+        let pending = commands.lock().expect("commands");
+        assert!(
+            !pending.iter().any(|cmd| matches!(
+                cmd,
+                WorkerCommand::UpsertSynced(entry) if entry.key == clashing_key
+            )),
+            "a refused import must not be fanned out to any worker command queue"
+        );
+    }
+    assert_eq!(
+        coordinator.synced_import_reserve_refused_total(),
+        before + 1,
+        "a refused import must be COUNTED — a silent drop trades one invisible \
+         failure for another"
+    );
+}
+
+/// #6600: with NO worker registered the pre-publish reservation is skipped.
+///
+/// Nothing polls, so there is no racing local allocation to guard against, and
+/// an `Untracked` reservation that no worker ever adopts has no one to release
+/// it. Making the coordinator reserve unconditionally would leak a pool port on
+/// every early-boot / teardown import.
+#[test]
+fn upsert_synced_session_skips_pre_publish_reserve_with_no_workers_6600() {
+    let mut coordinator = Coordinator::new();
+    coordinator.forwarding = reserve6600_forwarding();
+
+    let entry = reserve6600_entry(40003, 50002);
+    let key = entry.key.clone();
+    coordinator.upsert_synced_session(entry);
+
+    assert!(
+        synced6600_contains(&coordinator, &key),
+        "with no workers registered the import must still be admitted"
+    );
+    assert_eq!(
+        coordinator.synced_import_reserve_refused_total(),
+        0,
+        "the zero-worker path must not refuse imports"
+    );
+    // And it must have taken NO reservation. A DIFFERENT flow reserving the
+    // same translated port proves the port is free: had the coordinator
+    // reserved it, the occupancy CAS would refuse this. That is the assertion
+    // that binds the guard — without it, deleting the zero-worker carve-out
+    // leaves every case green while every early-boot import leaks a pool port
+    // with holders == 0 and no worker to release it.
+    let unrelated = SessionKey {
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 210)),
+        src_port: 44446,
+        ..test_key()
+    };
+    assert!(
+        crate::nat::reserve_synced_source_nat_allocation_untracked(
+            &coordinator.forwarding.source_nat_rules,
+            &unrelated,
+            NatDecision {
+                rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))),
+                rewrite_src_port: Some(50002),
+                ..NatDecision::default()
+            },
+            false,
+            None,
+            1_000,
+        ),
+        "the zero-worker path must take NO reservation — the port it would have \
+         held has no worker to release it"
+    );
+}
+
+/// #6600: a half-taken reservation must be ROLLED BACK.
+///
+/// A NAT64 decision carries BOTH a v4 pool source (the source-NAT allocator)
+/// and a translated `(pool v4, port)` (the per-prefix allocator), so a session
+/// can be admissible to one and not the other. Without the rollback, a
+/// source-NAT reservation taken moments before a NAT64 refusal is left behind
+/// holding a pool port that NO worker will ever release — the import is not
+/// published, so there is no session to reap.
+///
+/// Deleting the `release_source_nat_allocation` call in
+/// `reserve_synced_translation` makes this go red.
+#[test]
+fn upsert_synced_session_rolls_back_source_nat_when_nat64_refuses_6600() {
+    let mut coordinator = Coordinator::new();
+    coordinator.forwarding = reserve6600_forwarding();
+    coordinator.forwarding.nat64 = crate::nat64::Nat64State::from_snapshots(&[
+        crate::NAT64RuleSnapshot {
+            name: "nat64-wkp".to_string(),
+            prefix: "64:ff9b::/96".to_string(),
+            pool_addresses: vec!["203.0.113.1".to_string()],
+            no_v6_frag_header: false,
+            ..Default::default()
+        },
+    ]);
+    let commands = Arc::new(Mutex::new(VecDeque::new()));
+    coordinator.workers.records.insert(
+        0,
+        WorkerRuntimeRecord::for_test(test_worker_handle(commands.clone())),
+    );
+
+    // A NAT64 decision naming pool port 51000 on 203.0.113.1.
+    let nat64_port: u16 = 51000;
+    let mk = |src_port: u16| SyncedSessionEntry {
+        key: SessionKey {
+            src_port,
+            ..test_key()
+        },
+        decision: SessionDecision {
+            resolution: test_resolution(),
+            nat: NatDecision {
+                rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))),
+                rewrite_src_port: Some(nat64_port),
+                nat64: true,
+                ..NatDecision::default()
+            },
+        },
+        metadata: test_metadata(),
+        origin: SessionOrigin::SyncImport,
+        protocol: PROTO_TCP,
+        tcp_flags: 0x10,
+        generation: 0,
+        session_id: 0,
+    };
+
+    // Occupy the NAT64 translated identity with a DIFFERENT flow, so the
+    // import's NAT64 leg refuses while its source-NAT leg succeeds.
+    let squatter = mk(40010);
+    assert!(
+        crate::nat64::reserve_synced_nat64_allocation(
+            &coordinator.forwarding.nat64,
+            &squatter.key,
+            squatter.decision.nat,
+            false,
+            1_000,
+        ),
+        "setup: the squatter must take the NAT64 identity"
+    );
+
+    let entry = mk(40011);
+    let key = entry.key.clone();
+    let before = coordinator.synced_import_reserve_refused_total();
+    coordinator.upsert_synced_session(entry);
+
+    assert!(
+        !synced6600_contains(&coordinator, &key),
+        "setup: the import must be refused, or the rollback is not exercised"
+    );
+    assert_eq!(
+        coordinator.synced_import_reserve_refused_total(),
+        before + 1,
+        "setup: the refusal must be counted"
+    );
+
+    // THE ASSERTION: the source-NAT port the refused import briefly held must
+    // be free again. An unrelated flow reserving it proves the rollback ran.
+    let unrelated = SessionKey {
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 211)),
+        src_port: 44447,
+        ..test_key()
+    };
+    assert!(
+        crate::nat::reserve_synced_source_nat_allocation_untracked(
+            &coordinator.forwarding.source_nat_rules,
+            &unrelated,
+            NatDecision {
+                rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))),
+                rewrite_src_port: Some(nat64_port),
+                ..NatDecision::default()
+            },
+            false,
+            None,
+            1_000,
+        ),
+        "the source-NAT reservation taken before the NAT64 refusal was NOT rolled \
+         back — it holds a pool port no worker will ever release, because no \
+         session was published to reap"
+    );
+}
+
+/// #6600: the coordinator's `Untracked` reservation must be ABSORBED by the
+/// per-worker reservations rather than doubling them, so the last worker's
+/// release still frees the port.
+///
+/// This is the composability claim the whole design rests on: `reserve_flow`
+/// finds the identical `(flow, translated)` already live and takes its
+/// idempotent early return, OR-ing the worker's bit into a mask that started
+/// EMPTY (`NatHolder::Untracked` contributes no bit). If the coordinator's
+/// reservation instead made the worker's reserve REFUSE, no holder bit would
+/// ever be recorded and the port would leak.
+#[test]
+fn coordinator_pre_publish_reserve_is_absorbed_by_worker_reserve_6600() {
+    let forwarding = reserve6600_forwarding();
+    let entry = reserve6600_entry(40004, 50003);
+    let now_ns = 1_000;
+
+    assert!(
+        crate::nat::reserve_synced_source_nat_allocation_untracked(
+            &forwarding.source_nat_rules,
+            &entry.key,
+            entry.decision.nat,
+            entry.metadata.is_reverse,
+            None,
+            now_ns,
+        ),
+        "the coordinator's reservation must succeed on a free port"
+    );
+    // Two workers then reserve the SAME translation, exactly as the fan-out
+    // produces. Both must SUCCEED — a refusal here is the failure mode that
+    // would leak the port.
+    for worker_id in 0..2u32 {
+        assert!(
+            crate::nat::reserve_synced_source_nat_allocation_for_worker(
+                &forwarding.source_nat_rules,
+                &entry.key,
+                entry.decision.nat,
+                entry.metadata.is_reverse,
+                None,
+                now_ns,
+                worker_id,
+            ),
+            "worker {worker_id}'s reservation must be ABSORBED by the coordinator's, \
+             not refused — a refusal records no holder bit and the port leaks"
+        );
+    }
+    // The last worker's release frees it: the port is allocatable again by an
+    // unrelated flow.
+    for worker_id in 0..2u32 {
+        crate::nat::release_source_nat_allocation_for_worker(
+            &forwarding.source_nat_rules,
+            &entry.key,
+            entry.decision.nat,
+            entry.metadata.is_reverse,
+            now_ns,
+            worker_id,
+        );
+    }
+    let other = SessionKey {
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 201)),
+        src_port: 44445,
+        ..test_key()
+    };
+    assert!(
+        crate::nat::reserve_synced_source_nat_allocation_untracked(
+            &forwarding.source_nat_rules,
+            &other,
+            entry.decision.nat,
+            false,
+            None,
+            now_ns,
+        ),
+        "after the LAST worker released, the port must be reservable again by an \
+         unrelated flow — an un-absorbed coordinator reservation would hold it forever"
+    );
+}
+
+/// Read through the shared synced map's lock. `sessions.synced` is an
+/// `Arc<Mutex<..>>`, so a bare `contains_key` does not compile.
+fn synced6600_contains(coordinator: &Coordinator, key: &SessionKey) -> bool {
+    coordinator
+        .sessions
+        .synced
+        .lock()
+        .expect("synced map")
+        .contains_key(key)
+}
+
+/// #6600: the coordinator's pre-publish reservation must resolve the synced
+/// zone pair through the SAME helper the worker-side upsert uses.
+///
+/// This matters only when two source-NAT rules share a pool address — the #6211
+/// case. The zone pair narrows PASS 1 to the rule the ACTIVE node actually
+/// matched; without it the reservation falls through to PASS 2, "the first rule
+/// whose pool contains the address", which can be a DIFFERENT allocator. The
+/// coordinator would then reserve a port in one allocator while the workers
+/// reserve in another: the coordinator's check passes, the port the session
+/// actually names stays unreserved, and the defect is back wearing a new shape
+/// — plus a leaked port in the allocator nobody will reap from.
+///
+/// Replacing the shared call with a bare `None` makes this go red.
+#[test]
+fn coordinator_pre_publish_reserve_uses_the_workers_zone_pair_6600() {
+    let mut coordinator = Coordinator::new();
+    // TWO rules over the SAME pool address. Rule 0 is a decoy in a different
+    // zone pair and is what PASS 2 would pick; rule 1 is the one the entry's
+    // metadata names, and is what PASS 1 picks when zones resolve.
+    let mut forwarding = ForwardingState::default();
+    forwarding.source_nat_rules = crate::nat::parse_source_nat_rules(&[
+        crate::SourceNATRuleSnapshot {
+            name: "decoy".to_string(),
+            from_zone: "dmz".to_string(),
+            to_zone: "wan".to_string(),
+            source_addresses: vec!["0.0.0.0/0".to_string()],
+            pool_name: "p-decoy".to_string(),
+            pool_addresses: vec!["203.0.113.1/32".to_string()],
+            port_low: 1024,
+            port_high: 65535,
+            ..crate::SourceNATRuleSnapshot::default()
+        },
+        crate::SourceNATRuleSnapshot {
+            name: "real".to_string(),
+            from_zone: "lan".to_string(),
+            to_zone: "wan".to_string(),
+            source_addresses: vec!["0.0.0.0/0".to_string()],
+            pool_name: "p-real".to_string(),
+            pool_addresses: vec!["203.0.113.1/32".to_string()],
+            port_low: 1024,
+            port_high: 65535,
+            ..crate::SourceNATRuleSnapshot::default()
+        },
+    ]);
+    forwarding
+        .zone_id_to_name
+        .insert(TEST_LAN_ZONE_ID, "lan".to_string());
+    forwarding
+        .zone_id_to_name
+        .insert(TEST_WAN_ZONE_ID, "wan".to_string());
+    coordinator.forwarding = forwarding;
+    let commands = Arc::new(Mutex::new(VecDeque::new()));
+    coordinator.workers.records.insert(
+        0,
+        WorkerRuntimeRecord::for_test(test_worker_handle(commands.clone())),
+    );
+
+    // Non-vacuity: the zone pair must actually RESOLVE, or both the fix and the
+    // mutation see `None` and this test proves nothing.
+    let meta = test_metadata();
+    assert!(
+        crate::afxdp::session_glue::synced_source_nat_zone_pair(&coordinator.forwarding, &meta)
+            .is_some(),
+        "setup: the zone pair must resolve, or the discriminator does not vary"
+    );
+
+    let port: u16 = 52000;
+    let entry = reserve6600_entry(40020, port);
+    let key = entry.key.clone();
+    coordinator.upsert_synced_session(entry);
+    assert!(
+        synced6600_contains(&coordinator, &key),
+        "setup: the import must be admitted"
+    );
+
+    let unrelated = SessionKey {
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 220)),
+        src_port: 44448,
+        ..test_key()
+    };
+    let nat = NatDecision {
+        rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))),
+        rewrite_src_port: Some(port),
+        ..NatDecision::default()
+    };
+    // The ZONE-MATCHED rule's allocator must hold the port.
+    assert!(
+        !crate::nat::reserve_synced_source_nat_allocation_untracked(
+            &coordinator.forwarding.source_nat_rules[1..2],
+            &unrelated,
+            nat,
+            false,
+            None,
+            1_000,
+        ),
+        "the coordinator did not reserve in the ZONE-MATCHED rule's allocator — it \
+         resolved a different zone pair than the worker will, so the port the \
+         session names stays unreserved"
+    );
+    // And the decoy's must NOT — otherwise the coordinator reserved in the
+    // fall-through allocator, leaking a port nobody reaps from.
+    assert!(
+        crate::nat::reserve_synced_source_nat_allocation_untracked(
+            &coordinator.forwarding.source_nat_rules[0..1],
+            &unrelated,
+            nat,
+            false,
+            None,
+            1_000,
+        ),
+        "the coordinator reserved in the DECOY rule's allocator (the PASS 2 \
+         fall-through), which no worker will ever release"
+    );
+}

--- a/userspace-dp/src/afxdp/session_glue/commands/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/commands/mod.rs
@@ -13,7 +13,7 @@ mod delete_synced;
 mod demote_owner_rgs;
 mod export_owner_rg_sessions;
 mod refresh_owner_rgs;
-mod upsert_synced;
+pub(in crate::afxdp) mod upsert_synced;
 
 pub(in crate::afxdp::session_glue) use delete_synced::handle_delete_synced;
 pub(in crate::afxdp::session_glue) use demote_owner_rgs::handle_demote_owner_rgs;

--- a/userspace-dp/src/afxdp/session_glue/commands/upsert_synced.rs
+++ b/userspace-dp/src/afxdp/session_glue/commands/upsert_synced.rs
@@ -18,7 +18,12 @@ use super::super::*;
 /// too rather than assumed: an empty `from_zone` would silently EXCLUDE every
 /// zone-scoped rule instead of leaving the axis unconstrained, which is the one
 /// way this narrowing could pick a worse rule than the pre-#6211 fallback.
-fn synced_source_nat_zone_pair<'a>(
+/// #6600: `pub(in crate::afxdp)` so the COORDINATOR's pre-publish reservation
+/// resolves the zone pair through the SAME function the worker does. If the two
+/// ever disagreed, the coordinator would reserve on one allocator and the worker
+/// on another — the coordinator's check would pass while the port the session
+/// actually names stayed unreserved, which is the defect wearing a new shape.
+pub(in crate::afxdp) fn synced_source_nat_zone_pair<'a>(
     forwarding: &'a ForwardingState,
     metadata: &crate::session::SessionMetadata,
 ) -> crate::nat::SyncedNatZones<'a> {

--- a/userspace-dp/src/afxdp/session_glue/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/mod.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-mod commands;
+pub(in crate::afxdp) mod commands;
 mod promote;
 
 use promote::{
@@ -1545,3 +1545,8 @@ mod tests;
 #[cfg(test)]
 #[path = "newflow_contention_tests.rs"]
 mod newflow_contention_tests;
+
+// #6600: the coordinator's pre-publish NAT reservation resolves the synced zone
+// pair through the SAME helper the worker-side upsert uses, so the two cannot
+// land on different allocators.
+pub(in crate::afxdp) use commands::upsert_synced::synced_source_nat_zone_pair;

--- a/userspace-dp/src/nat/mod.rs
+++ b/userspace-dp/src/nat/mod.rs
@@ -87,15 +87,16 @@ pub(crate) use source::{
     match_source_nat,
     match_source_nat_result, match_source_nat_result_for_tuple, parse_source_nat_rules,
     parse_source_nat_rules_with_previous, release_nat64_pool_port,
-    release_source_nat_allocation_for_worker, reserve_nat64_pool_port,
-    reserve_synced_source_nat_allocation_for_worker, rollback_source_nat_allocation_for_worker,
+    release_source_nat_allocation, release_source_nat_allocation_for_worker,
+    reserve_nat64_pool_port, reserve_synced_source_nat_allocation_for_worker,
+    // #6600: the coordinator's pre-publish reservation and its rollback. NOT
+    // test-only, unlike the untracked entry points below — these are the
+    // production import path.
+    reserve_synced_source_nat_allocation_untracked, rollback_source_nat_allocation_for_worker,
 };
 // #6211 F2: test-only untracked entry points (see their doc comments).
 #[cfg(test)]
-pub(crate) use source::{
-    release_source_nat_allocation, reserve_synced_source_nat_allocation,
-    rollback_source_nat_allocation,
-};
+pub(crate) use source::{reserve_synced_source_nat_allocation, rollback_source_nat_allocation};
 pub(crate) use static_nat::{StaticNatEntry, StaticNatTable};
 pub(crate) use status::source_nat_pool_statuses;
 

--- a/userspace-dp/src/nat/source.rs
+++ b/userspace-dp/src/nat/source.rs
@@ -1244,7 +1244,13 @@ fn source_nat_runtime_compatible(new_rule: &SourceNatRule, old_rule: &SourceNatR
 /// BUILD FAILURE in the non-test profile rather than a silent single-holder
 /// release of a reservation every worker holds. Production uses the
 /// `_for_worker` twin.
-#[cfg(test)]
+///
+/// #6600: one production caller now exists, and it is the exact case the guard
+/// above was written to permit — the ROLLBACK of an `Untracked` reservation the
+/// coordinator took moments earlier and no worker has adopted. There is no
+/// worker_id to thread, because no worker holds it: the reservation is being
+/// withdrawn precisely BECAUSE the import is not going to be published. A
+/// holder-aware release would be the wrong call here, not a safer one.
 pub(crate) fn release_source_nat_allocation(
     rules: &[SourceNatRule],
     key: &crate::session::SessionKey,
@@ -1576,7 +1582,7 @@ pub(crate) fn reserve_synced_source_nat_allocation_for_worker(
     // expiry off a real clock.
     now_ns: u64,
     worker_id: u32,
-) {
+) -> bool {
     reserve_synced_source_nat_allocation_with_holder(
         rules,
         key,
@@ -1585,9 +1591,46 @@ pub(crate) fn reserve_synced_source_nat_allocation_for_worker(
         synced_zones,
         now_ns,
         NatHolder::Worker(worker_id),
-    );
+    )
 }
 
+/// #6600: the COORDINATOR-side reservation, taken BEFORE the shared session
+/// entry is published.
+///
+/// It holds `NatHolder::Untracked`, which contributes no holder bit, so the
+/// per-worker reservations that follow are absorbed rather than doubled:
+/// `reserve_flow` finds the identical `(flow, translated)` already live and
+/// takes its idempotent early-return, OR-ing the worker's bit in. The last
+/// worker's release then empties the mask and frees the port exactly as before.
+pub(crate) fn reserve_synced_source_nat_allocation_untracked(
+    rules: &[SourceNatRule],
+    key: &crate::session::SessionKey,
+    nat: NatDecision,
+    is_reverse: bool,
+    synced_zones: SyncedNatZones<'_>,
+    now_ns: u64,
+) -> bool {
+    reserve_synced_source_nat_allocation_with_holder(
+        rules,
+        key,
+        nat,
+        is_reverse,
+        synced_zones,
+        now_ns,
+        NatHolder::Untracked,
+    )
+}
+
+/// Returns whether the translation is RESERVED on this node — either because a
+/// pass took it, or because there was nothing to reserve (a reverse entry, or a
+/// decision with no `rewrite_src`). `false` means every candidate rule REFUSED,
+/// i.e. a different live allocation already owns the port (#6600).
+///
+/// Before #6600 the bool `reserve_synced_on_first_pool_owner` already computed
+/// was discarded here, and the whole chain up to `handle_upsert_synced` returned
+/// `()` — so a refusal was not returned, not counted and not logged. The
+/// coordinator uses this return to refuse the import outright rather than
+/// publishing a session whose translation names a port this node does not own.
 fn reserve_synced_source_nat_allocation_with_holder(
     rules: &[SourceNatRule],
     key: &crate::session::SessionKey,
@@ -1597,12 +1640,12 @@ fn reserve_synced_source_nat_allocation_with_holder(
     synced_zones: SyncedNatZones<'_>,
     now_ns: u64,
     holder: NatHolder,
-) {
+) -> bool {
     if is_reverse {
-        return;
+        return true;
     }
     let Some(rewrite_src) = nat.rewrite_src else {
-        return;
+        return true;
     };
     let flow = SourceNatFlowKey {
         protocol: key.protocol,
@@ -1643,7 +1686,7 @@ fn reserve_synced_source_nat_allocation_with_holder(
             holder,
         )
     {
-        return;
+        return true;
     }
     // #6211 PASS 2 — the pre-#6211 behaviour, unchanged: the first rule whose
     // pool CONTAINS the translated address, with no zone/tuple narrowing.
@@ -1664,7 +1707,7 @@ fn reserve_synced_source_nat_allocation_with_holder(
         nat.rewrite_src_port,
         now_ns,
         holder,
-    );
+    )
 }
 
 /// #6211: reserve the synced translation on the first rule in `rules` whose

--- a/userspace-dp/src/nat64.rs
+++ b/userspace-dp/src/nat64.rs
@@ -1715,14 +1715,19 @@ pub(crate) fn rollback_nat64_allocation_for_worker(
 /// BUILD FAILURE in the non-test profile rather than a silent single-holder
 /// release of a reservation every worker holds. Production uses the
 /// `_for_worker` twin.
-#[cfg(test)]
+///
+/// #6600: no longer test-only. The COORDINATOR takes an untracked reservation
+/// before publishing a peer-synced import, and the per-worker reservations that
+/// follow are absorbed by `reserve_flow`'s idempotent early return, so the
+/// release semantics the comment above warns about are unchanged — the last
+/// worker still frees.
 pub(crate) fn reserve_synced_nat64_allocation(
     nat64: &Nat64State,
     key: &crate::session::SessionKey,
     nat: NatDecision,
     is_reverse: bool,
     now_ns: u64,
-) {
+) -> bool {
     reserve_synced_nat64_allocation_with_holder(
         nat64,
         key,
@@ -1730,7 +1735,7 @@ pub(crate) fn reserve_synced_nat64_allocation(
         is_reverse,
         now_ns,
         crate::nat::NatHolder::Untracked,
-    );
+    )
 }
 
 /// #6211 F2: reserve a synced NAT64 translation and record `worker_id` as a
@@ -1747,7 +1752,7 @@ pub(crate) fn reserve_synced_nat64_allocation_for_worker(
     // expiry off a real clock.
     now_ns: u64,
     worker_id: u32,
-) {
+) -> bool {
     reserve_synced_nat64_allocation_with_holder(
         nat64,
         key,
@@ -1755,7 +1760,7 @@ pub(crate) fn reserve_synced_nat64_allocation_for_worker(
         is_reverse,
         now_ns,
         crate::nat::NatHolder::Worker(worker_id),
-    );
+    )
 }
 
 fn reserve_synced_nat64_allocation_with_holder(
@@ -1765,15 +1770,20 @@ fn reserve_synced_nat64_allocation_with_holder(
     is_reverse: bool,
     now_ns: u64,
     holder: crate::nat::NatHolder,
-) {
+) -> bool {
+    // #6600: returns whether the translation is RESERVED — true when a prefix
+    // took it, and true when there was nothing to reserve. `false` means every
+    // pool prefix REFUSED, i.e. a different live allocation already owns the
+    // (pool v4, port). The bool `reserve_nat64_pool_port` already computed was
+    // discarded before #6600.
     if is_reverse || !nat.nat64 {
-        return;
+        return true;
     }
     let Some(IpAddr::V4(snat_v4)) = nat.rewrite_src else {
-        return;
+        return true;
     };
     let Some(port) = nat.rewrite_src_port else {
-        return;
+        return true;
     };
     let flow = SourceNatFlowKey {
         protocol: key.protocol,
@@ -1805,9 +1815,14 @@ fn reserve_synced_nat64_allocation_with_holder(
             now_ns,
             holder,
         ) {
-            break;
+            return true;
         }
     }
+    // No prefix owned the address, or every owner refused. Not distinguished on
+    // purpose: from the coordinator's point of view both mean "this node does
+    // not own the translation this session names", and publishing a session for
+    // either is the thing #6600 fixes.
+    false
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #6600

> ⚠️ **This moves the `userspace-dp` helper binary — a cluster smoke is owed and was NOT run from this lane.** It is HA session-sync code.

## The defect

`upsert_synced_session` published the shared session entry **first** and only then enqueued the worker commands. `publish_shared_session` makes the entry visible on every packet-path lookup surface at once — `synced`, `nat`, `forward_wire` — and `materialize_shared_session_hit` forwards on `replica.decision`, `decision.nat` included, **without reserving anything**.

The reservation lived solely inside the worker-local upsert, driven by the command enqueued *after* that publish. A worker that sampled an empty command queue just before the push proceeds straight into `poll_binding` with the entry already live.

In that window a local flow can allocate the same translated port. `reserve_flow` then **refuses to steal it** — the right call — but the refusal was returned by nothing, counted by nothing and logged by nothing: `handle_upsert_synced` returns `()`, both reserve callees return `()`, and the one bool that existed was discarded as a bare statement. The imported session went on advertising a translation this node does not own.

Every cited line number in the issue had rotted; every cited **behaviour** was still present, and one thing was worse than filed — the BPF session-map entry is published in that window too.

**The window widens the exposure but does not create it.** If a local flow legitimately holds the port when the command *is* applied — overlapping pools, an active-active RG pair sharing one SNAT pool — the reserve is refused deterministically and dropped just as silently.

## Why reserve-before-publish, not propagate-the-refusal

These are not alternatives. The worker-side reserve runs on a worker thread long after the control RPC has written its response, so propagating from there could only ever have added a counter — never an outcome. Moving the reservation to the coordinator closes the window at its source **and** is the only thing that makes an import outcome reachable at all (filed as #7377).

A refusal now drops the import. No session beats a session naming someone else's port, and the peer re-syncs. It is **counted** — a silent drop would only trade one invisible failure for another.

## Three load-bearing properties, each pinned

| Property | Why it matters |
|---|---|
| The coordinator's reservation is `Untracked`, so per-worker reservations are **absorbed**, not doubled | Each worker finds the identical `(flow, translated)` already live, takes `reserve_flow`'s idempotent early return and ORs its bit in; the last worker's release still frees the port. **Verified against `reserve_flow` first-hand rather than assumed** — had the coordinator's reservation made the workers' *refuse*, no holder bit would ever be recorded and the port would leak. |
| Skipped with **zero workers** | Nothing polls, so there is no racing allocation to guard against, and an untracked reservation no worker adopts has nobody to release it. Same carve-out as the zero-ceiling case above it. |
| A half-taken reservation is **rolled back** | A NAT64 decision carries both a v4 pool source and a translated `(pool v4, port)` in *different* allocators, so a session can be admissible to one and not the other. Without the rollback, the source-NAT port is held by nobody — no session was published to reap. |

The zone pair is resolved through the **same helper** the worker-side upsert uses (now `pub(in crate::afxdp)` rather than duplicated). If the two disagreed, the coordinator would reserve in one allocator while the workers reserve in another: its check would pass while the port the session actually names stayed free.

## Validation

- `cargo test --release --bins --tests -- --test-threads=1` — **green**, the full Rust gate.
- `go build ./...` clean.

**Mutation matrix — five mutations, each on a COMPILING tree:**

| Mutation | Test that reds |
|---|---|
| Delete the pre-publish reservation (pre-fix ordering) | the collision case |
| Reserve but **ignore** the refusal | the collision case |
| Reserve even with zero workers | the zero-worker case |
| Skip the NAT64 rollback | the rollback case |
| Replace the shared zone-pair call with `None` | the zone case |

**Three cells did not bind on the first pass, and that is worth stating.** The zero-worker guard and the rollback both survived their mutations **green** — no assertion observed the allocator. And the zone-pair test was **vacuous**: its fixture left `zone_id_to_name` empty, so the pair resolved to `None` on *both* sides of the mutation and the discriminator never varied. All three are now bound by assertions that query the allocator directly, and the zone test asserts up front that the pair actually resolves before relying on it.

## Deliberately not in scope

Filed as **#7377**: the refusal does not yet set `ControlResponse.ok = false` (now possible for the first time, since the reservation moved onto the control thread), and the new counter has no Prometheus descriptor. `docs/sync-protocol.md` names both.

## Docs

`docs/sync-protocol.md` — a new "NAT-Port Reservation on Import (#6600)" section covering the window, the drop-and-count posture, the three properties, what a nonzero counter means for an operator, and the two deferred halves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdWuT1UffSkr1spw8sjNTE
