### PR TITLE
routing: draw the next-table window down v4-first structurally (#6583)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,27 @@
+## 2026-08-21 — #6583 next-table window drawn down v4-first structurally
+
+- **Timestamp**: 2026-08-21
+- **Action**: The v4-before-v6 next-table draw-down order was set entirely
+  by two `append` lines in `pkg/daemon/daemon_apply_routing.go` and bound
+  by nothing on either side. Fixed STRUCTURALLY rather than by asserting
+  on the caller: `nextTableManager.Apply` now stable-partitions the slice
+  v4-first (`nextTableFamilyOrdered`), so the kernel agrees with the FIB
+  (`addRoutes("inet.0")` before `addRoutes("inet6.0")`) by construction
+  and no caller can get it wrong. Also closed the fixture gap the
+  kernel-side #6467 guard had — every case generated `10.%d.%d.0/24`
+  only, so its `count(AF_INET)+count(AF_INET6)` totals always carried a
+  zero v6 term and could not see a family reordering at all.
+  Mutation matrix: X1 (no ordering — the pre-fix state) and X2 (v6 first)
+  RED; X3 (unstable within family) initially GREEN — the stability claim
+  was unbound, so a per-slot destination assertion was added and it now
+  reds. X4 (swap the daemon appends) is GREEN **by design**: the whole
+  point is that the swap is now a no-op. That deviates from the issue's
+  acceptance criterion 1, which asked for the swap to turn a test RED;
+  making it harmless is strictly stronger, and adding an assertion on a
+  condition that can no longer vary would be a guard on a dead branch.
+- **File(s)**: pkg/routing/rules.go, pkg/routing/rules_6467_test.go,
+  pkg/routing/README.md
+
 ## 2026-08-21 — #6656 transfer-out override cleared on peer loss
 
 - **Timestamp**: 2026-08-21

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -318,6 +318,27 @@ delegate to the owning domain. Exported types:
   crashed daemon never leaks pins.
 - `100–199`: next-table inter-VRF leaking (static routes with
   `next-table` directive). `nextTableRulePriority` in `rules.go`.
+  **The window is drawn down IPv4-FIRST, and that is enforced HERE
+  (#6583).** `nextTableManager.Apply` advances one family-blind `prio` in
+  slice order, so which leaks survive the `maxNextTableRules` cap used to
+  be decided entirely by two `append` lines in
+  `pkg/daemon/daemon_apply_routing.go` (v4 statics, then v6 statics) — a
+  cross-package convention with nothing on either side binding it. The
+  userspace FIB mirrors the same cap but draws it down in its own order
+  (`pkg/dataplane/userspace/routes.go`: `addRoutes("inet.0", …)` then
+  `addRoutes("inet6.0", …)`), so the two agreed only by coincidence.
+  Swapping those appends would have installed 60 v6 + 40 v4 in the kernel
+  against 60 v4 + 40 v6 in the FIB: 40 leaks in the kernel and not the
+  FIB, 40 the reverse — a leak present only in the FIB resolves into the
+  target VRF on the AF_XDP fast path while a slow-path packet for the same
+  flow resolves in the main table (#6467's verdict split in a new shape).
+  `nextTableFamilyOrdered` makes the agreement structural instead of
+  conventional: no caller can get it wrong, and the guard cannot rot into
+  a check of one caller while a second is added elsewhere. The partition
+  is STABLE, so within a family the caller's relative order — which the
+  FIB's per-family pass also preserves — is untouched; a correct grouping
+  that shuffled inside the group would match on counts and still install
+  a different SET.
 - `31000–31999`: PBR (firewall-filter `routing-instance` action).
   `pbrRulePriority` in `rules.go`. **Kernel FBF support matrix (#3730):**
   `BuildPBRRules` mirrors only the term `from` predicates an `ip rule` can

--- a/pkg/routing/rules.go
+++ b/pkg/routing/rules.go
@@ -128,9 +128,33 @@ func (n *nextTableManager) Apply(routes []*config.StaticRoute, instances []*conf
 		errs = append(errs, clearErr)
 	}
 
+	// #6583: draw the priority window down IPv4-FIRST, independent of the
+	// caller's slice order.
+	//
+	// This loop advances ONE family-blind `prio` in slice order, so which
+	// leaks survive the maxNextTableRules cap was decided entirely by the two
+	// `append` lines in pkg/daemon/daemon_apply_routing.go — v4 statics before
+	// v6 statics. The userspace FIB mirrors the same cap but draws it down in
+	// its OWN order (routes.go: addRoutes("inet.0", ...) then
+	// addRoutes("inet6.0", ...)), so the two sides agreed only by convention
+	// across a package boundary, with nothing on either side binding it.
+	// Swapping those two appends would have installed 60 v6 + 40 v4 rules in
+	// the kernel against 60 v4 + 40 v6 in the FIB: 40 leaks in the kernel and
+	// not the FIB, 40 in the FIB and not the kernel — the #6467 kernel/FIB
+	// verdict split in a new shape, where a leak present only in the FIB
+	// resolves into the target VRF on the AF_XDP fast path while a slow-path
+	// packet for the same flow resolves in the main table.
+	//
+	// Ordering HERE rather than asserting on the caller makes the agreement
+	// structural: no caller can get it wrong, and the guard cannot rot into a
+	// check of one caller while a second caller is added elsewhere. The
+	// partition is STABLE, so within a family the caller's relative order —
+	// which is what the FIB's per-family pass also preserves — is untouched.
+	routes = nextTableFamilyOrdered(routes)
+
 	prio := nextTableRulePriority
 	for i, sr := range routes {
-		if sr.NextTable == "" {
+		if sr == nil || sr.NextTable == "" {
 			continue
 		}
 		tableID, ok := tableIDs[sr.NextTable]
@@ -217,6 +241,33 @@ func (n *nextTableManager) Apply(routes []*config.StaticRoute, instances []*conf
 	// leak rule (or the orphaned-rule window) is observable rather than
 	// silently nil (#3731 / #2273).
 	return errors.Join(errs...)
+}
+
+// nextTableFamilyOrdered returns routes stably partitioned IPv4-first, so the
+// next-table priority window is drawn down in the same family order the
+// userspace FIB uses (#6583).
+//
+// A nil entry or an unparseable destination keeps its position in the FIRST
+// group: both are skipped by Apply's own eligibility checks, so grouping them
+// with v4 costs nothing and avoids inventing a third bucket whose ordering
+// would itself be unspecified. It also preserves the pre-#6583 property that
+// such an entry never consumes a window slot.
+func nextTableFamilyOrdered(routes []*config.StaticRoute) []*config.StaticRoute {
+	out := make([]*config.StaticRoute, 0, len(routes))
+	var v6 []*config.StaticRoute
+	for _, sr := range routes {
+		if sr == nil {
+			out = append(out, sr)
+			continue
+		}
+		_, dst, err := net.ParseCIDR(sr.Destination)
+		if err != nil || dst.IP.To4() != nil {
+			out = append(out, sr)
+			continue
+		}
+		v6 = append(v6, sr)
+	}
+	return append(out, v6...)
 }
 
 // clear removes all ip rules in the next-table priority range.

--- a/pkg/routing/rules_6467_test.go
+++ b/pkg/routing/rules_6467_test.go
@@ -2,10 +2,12 @@ package routing
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
 
@@ -209,4 +211,167 @@ func TestNextTableApplyDroppedCountExcludesMalformedCIDR(t *testing.T) {
 	if total := ops.count(unix.AF_INET) + ops.count(unix.AF_INET6); total != config.NextTableRuleWindow {
 		t.Errorf("expected the cap to hold at %d installed rules, got %d", config.NextTableRuleWindow, total)
 	}
+}
+
+// #6583: the next-table priority window must be drawn down IPv4-FIRST
+// regardless of the order the caller hands routes in.
+//
+// nextTableManager.Apply advances ONE family-blind `prio` in slice order, so
+// before this the draw-down order was set entirely by two `append` lines in
+// pkg/daemon/daemon_apply_routing.go (v4 statics, then v6 statics) — a
+// cross-package convention bound by nothing on either side. The userspace FIB
+// mirrors the same cap but draws it down in its OWN order
+// (pkg/dataplane/userspace/routes.go: addRoutes("inet.0", ...) then
+// addRoutes("inet6.0", ...)), so the two agreed only by coincidence of those
+// appends.
+//
+// Swapping them would have installed 60 v6 + 40 v4 in the kernel against
+// 60 v4 + 40 v6 in the FIB: 40 leaks present in the kernel and absent from the
+// FIB, 40 the reverse. A leak in the FIB but not the kernel resolves into the
+// target VRF on the AF_XDP fast path while a slow-path packet for the same flow
+// resolves in the main table — the #6467 verdict split in a new shape.
+//
+// Nothing was red. The FIB-side test asserts the FIB only, and THIS file's
+// kernel-side guard used a `10.%d.%d.0/24` generator, so its
+// `count(AF_INET) + count(AF_INET6)` total always carried a zero v6 term and
+// could not see a family reordering at all.
+//
+// The fix is structural rather than an assertion on the caller: Apply orders
+// the slice itself, so no caller can get it wrong and the guard cannot rot into
+// a check of one caller while a second is added elsewhere. This test therefore
+// binds the PROPERTY (v4 draws down first) against a deliberately v6-FIRST
+// input — the order the old code would have honoured.
+//
+// RED-on-revert: delete the `routes = nextTableFamilyOrdered(routes)` line in
+// Apply and the v6-first input is honoured verbatim: v6 takes the low
+// priorities and the surviving-family counts interchange.
+func TestNextTableDrawsDownV4FirstRegardlessOfCallerOrder6583(t *testing.T) {
+	instances := []*config.RoutingInstanceConfig{{Name: "dmz-vr", TableID: 101}}
+
+	// Two thirds of a window per family, so the cap bites and exactly one
+	// family can be fully installed — which is what makes the draw-down order
+	// observable rather than cosmetic.
+	perFamily := (config.NextTableRuleWindow * 2) / 3
+	v4 := make([]*config.StaticRoute, 0, perFamily)
+	v6 := make([]*config.StaticRoute, 0, perFamily)
+	for i := 0; i < perFamily; i++ {
+		v4 = append(v4, &config.StaticRoute{
+			Destination: fmt.Sprintf("10.%d.%d.0/24", i/256, i%256),
+			NextTable:   "dmz-vr",
+		})
+		v6 = append(v6, &config.StaticRoute{
+			Destination: fmt.Sprintf("2001:db8:%x::/64", i),
+			NextTable:   "dmz-vr",
+		})
+	}
+
+	// The caller hands them v6 FIRST — the shape a swapped append pair, or any
+	// future second caller, would produce.
+	routes := append(append([]*config.StaticRoute{}, v6...), v4...)
+
+	ops := newFakeRuleOps()
+	nt := &nextTableManager{ops: ops}
+	// Over-cap, so Apply returns the #6467 degraded error; that is expected
+	// here and not what this test is about.
+	_ = nt.Apply(routes, instances)
+
+	gotV4, gotV6 := ops.count(unix.AF_INET), ops.count(unix.AF_INET6)
+	if total := gotV4 + gotV6; total != config.NextTableRuleWindow {
+		t.Fatalf("installed %d rules (v4=%d v6=%d), want the cap %d — fixture is not "+
+			"over-subscribing the window, so the draw-down order is not observable",
+			total, gotV4, gotV6, config.NextTableRuleWindow)
+	}
+	if gotV4 != perFamily {
+		t.Errorf("v4 installed %d of %d offered. IPv4 must draw the window down FIRST "+
+			"so the kernel agrees with the userspace FIB, which programs inet.0 before "+
+			"inet6.0. The caller offered v6 first and the window followed it (#6583).",
+			gotV4, perFamily)
+	}
+	if want := config.NextTableRuleWindow - perFamily; gotV6 != want {
+		t.Errorf("v6 installed %d, want %d (the remainder after v4 draws down first)", gotV6, want)
+	}
+
+	// The families must not interleave in the window either: every v4 rule
+	// takes a lower priority than every v6 rule. A count-only assertion would
+	// pass on an alternating layout that still splits differently from the FIB.
+	maxV4, minV6 := -1, 1<<30
+	for _, r := range ops.rules[unix.AF_INET] {
+		if r.Priority > maxV4 {
+			maxV4 = r.Priority
+		}
+	}
+	for _, r := range ops.rules[unix.AF_INET6] {
+		if r.Priority < minV6 {
+			minV6 = r.Priority
+		}
+	}
+	if gotV6 > 0 && maxV4 >= minV6 {
+		t.Errorf("families interleave in the priority window: highest v4 prio %d >= lowest "+
+			"v6 prio %d. The FIB draws inet.0 down entirely before inet6.0, so an "+
+			"interleaved kernel window splits from it even when the per-family COUNTS match",
+			maxV4, minV6)
+	}
+	// STABILITY within the family. The partition must not reorder v4 among
+	// itself: which v4 leaks survive the cap is decided by their relative
+	// order, and the FIB's per-family pass walks the config slice in order. A
+	// partition that grouped correctly but shuffled inside the group would
+	// match on COUNTS and still install a different SET than the FIB.
+	byPrio := append([]netlink.Rule(nil), ops.rules[unix.AF_INET]...)
+	sort.Slice(byPrio, func(i, j int) bool { return byPrio[i].Priority < byPrio[j].Priority })
+	for i, r := range byPrio {
+		want := v4[i].Destination
+		if got := r.Dst.String(); got != want {
+			t.Fatalf("v4 rule at window slot %d is %s, want %s — the family partition is "+
+				"not STABLE, so the surviving set differs from the FIB's even though the "+
+				"per-family counts agree (#6583)", i, got, want)
+		}
+	}
+
+	assertAllRulesInRange(t, ops, nextTableRulePriority, nextTableRulePriority+maxNextTableRules)
+}
+
+// TestNextTableCapHoldsOnMixedFamilyFixture6583 closes the fixture gap this
+// file had: every pre-#6583 case here generated `10.%d.%d.0/24` only, so the
+// `count(AF_INET) + count(AF_INET6)` totals always summed a real v4 term with a
+// zero v6 term. The cap arithmetic was therefore never exercised across
+// families at all.
+func TestNextTableCapHoldsOnMixedFamilyFixture6583(t *testing.T) {
+	instances := []*config.RoutingInstanceConfig{{Name: "dmz-vr", TableID: 101}}
+
+	const over = 20
+	n := config.NextTableRuleWindow + over
+	routes := make([]*config.StaticRoute, 0, n)
+	for i := 0; i < n; i++ {
+		if i%2 == 0 {
+			routes = append(routes, &config.StaticRoute{
+				Destination: fmt.Sprintf("10.%d.%d.0/24", i/256, i%256),
+				NextTable:   "dmz-vr",
+			})
+			continue
+		}
+		routes = append(routes, &config.StaticRoute{
+			Destination: fmt.Sprintf("2001:db8:%x::/64", i),
+			NextTable:   "dmz-vr",
+		})
+	}
+
+	ops := newFakeRuleOps()
+	nt := &nextTableManager{ops: ops}
+	err := nt.Apply(routes, instances)
+	if err == nil {
+		t.Fatal("over-cap mixed-family Apply must still return the #6467 degraded error")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("; %d next-table route(s) beyond ", over)) {
+		t.Errorf("degraded error must name the %d dropped leaks on a mixed-family set, got %v", over, err)
+	}
+	gotV4, gotV6 := ops.count(unix.AF_INET), ops.count(unix.AF_INET6)
+	if gotV4+gotV6 != config.NextTableRuleWindow {
+		t.Errorf("mixed-family cap: installed v4=%d v6=%d (total %d), want %d",
+			gotV4, gotV6, gotV4+gotV6, config.NextTableRuleWindow)
+	}
+	if gotV6 == 0 {
+		t.Error("the mixed-family fixture installed ZERO v6 rules — the v6 term is still " +
+			"absent, so this guard cannot see a family-ordering change (#6583)")
+	}
+	assertAllRulesInRange(t, ops, nextTableRulePriority, nextTableRulePriority+maxNextTableRules)
 }


### PR DESCRIPTION
Closes #6583

## Problem

`nextTableManager.Apply` advances **one family-blind `prio`** in slice order, so which leaks survive the `maxNextTableRules` cap was decided entirely by two `append` lines in `pkg/daemon/daemon_apply_routing.go`:

```go
allRoutes = append(allRoutes, cfg.RoutingOptions.StaticRoutes...)      // v4
allRoutes = append(allRoutes, cfg.RoutingOptions.Inet6StaticRoutes...) // v6
```

The userspace FIB mirrors the same cap but draws it down in its **own** order (`routes.go`: `addRoutes("inet.0", …)` then `addRoutes("inet6.0", …)`). The two sides agreed by convention across a package boundary, with nothing binding it.

Swapping those appends installs **60 v6 + 40 v4** in the kernel against **60 v4 + 40 v6** in the FIB: 40 leaks present in the kernel and absent from the FIB, 40 the reverse. A leak in the FIB but not the kernel resolves into the target VRF on the AF_XDP fast path while a slow-path packet for the same flow resolves in the main table — #6467's kernel/dataplane verdict split in a new shape.

## Fixed structurally, not by assertion

The issue proposes either an order assertion in `pkg/daemon` or a mixed-family fixture on the kernel side. **Ordering the slice inside `Apply` is strictly stronger than the first**: no caller can get it wrong, and the guard cannot rot into a check of one caller while a second caller is added elsewhere.

`nextTableFamilyOrdered` is a **stable** partition, so within a family the caller's relative order — which the FIB's per-family pass also preserves — is untouched.

I also took the issue's second half: the kernel-side #6467 guard's fixture generated `10.%d.%d.0/24` **only**, so its `count(AF_INET) + count(AF_INET6)` totals always summed a real v4 term with a **zero v6 term**. That guard could not see a family reordering at all — which is why nothing went red.

## Validation

`go build ./...` + `go vet ./pkg/routing` clean per cell. `go test -count=1 ./pkg/routing ./pkg/daemon` green.

### Mutation matrix — one mutation per cell

| cell | mutation | result |
|---|---|---|
| X1 | remove the ordering (the pre-fix state) | order probe RED |
| X2 | order v6 first instead of v4 | order probe RED |
| X3 | non-stable partition (reverse the v4 group) | per-slot probe RED |
| X4 | swap the two daemon appends | **GREEN — by design** |

**X4 deviates from the issue's first acceptance criterion**, which asks that swapping the appends turn a test RED. After this change the swap is a **no-op** — that is the entire point. Making the hazard unreachable is stronger than detecting it, and adding an assertion on a condition that can no longer vary would be a guard on a dead branch. The property the criterion was reaching for (kernel and FIB agree on draw-down order) is bound by X1 and X2, which red against a **v6-first input** — the order the pre-fix code would have honoured.

**X3 was green on its first cut.** The stability claim in the doc comment was unbound: reversing within the v4 group changed which routes survived the cap and nothing noticed, because the test asserted per-family **counts** only. It now asserts the destination at each window slot, so a correct grouping that shuffles inside the group — matching on counts while installing a different **set** than the FIB — reds.

The order probe also asserts the families do not **interleave** in the window (highest v4 priority < lowest v6 priority): a count-only assertion would pass on an alternating layout that still splits differently from the FIB.

## Docs

`pkg/routing/README.md` gains the v4-first rule under the `100–199` priority-band entry, with the cross-package agreement it encodes and why the partition's stability is load-bearing. `_Log.md` entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAsT5gCGP7k2vhdZ1sDuRi