### PR TITLE
ddns: bound and shape-filter provider response text in errors (#6634)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,39 @@
+## 2026-08-21 — #6634 ddns: provider RESPONSE TEXT is bounded and shape-filtered
+
+- **Timestamp**: 2026-08-21
+- **Action**: Four backends rendered text from the PROVIDER'S response BODY
+  straight into a returned error the daemon logs and retains as `lastErr`:
+  Cloudflare `Errors[].Message`, Route 53 decoded `Code`/`Message`, and the
+  unrecognized first response line on dyndns2 and DuckDNS — plus three
+  Cloudflare `json.Unmarshal` sites rendering the decoder error with `%w`.
+  No hostile transport is needed, only an API that echoes the request back;
+  DuckDNS carries its token in the QUERY STRING, so the echo IS the credential.
+  MEASURED FIRST, and it changed the fix: two thirds of the issue's surface was
+  already closed elsewhere. `termsafe.SanitizeForDisplay` covers both `show
+  services ddns` surfaces (#6468) and the daemon's `slog.TextHandler`
+  `strconv.Quote`s any non-printable byte, so control-character forgery cannot
+  split a journal line. What neither closes is a CREDENTIAL in the bytes or
+  64 KiB of them. So the fix is a bound plus a URL/userinfo shape filter, NOT
+  an escape.
+  `scrubProviderText` is total on LENGTH (`maxProviderTextBytes`, plus a COUNT
+  bound on the Cloudflare envelope — a per-message cap is not a bound when the
+  provider picks the array length) and partial on SHAPE, and says so: a
+  credential echoed as bare prose is indistinguishable from a word. Filter
+  BEFORE bounding, since the other order splits a URL at the cap and leaves
+  `https://user:PA` rendered. Route 53's returned code/message are NOT scrubbed
+  — `r53DeleteAlreadyGone` classifies delete-idempotency on the raw text, so
+  scrubbing the value would change a control decision; only the render goes
+  through the scrubber.
+  The class gate gained `json.Unmarshal`, FILE-SCOPED: it decodes a provider
+  body in `backend_*.go` and this daemon's own state file in `state.go`. The
+  scope is a predicate, not a site list, so a new backend file is covered
+  automatically.
+- **File(s)**: `pkg/ddns/backend_http.go`, `pkg/ddns/backend_cloudflare.go`,
+  `pkg/ddns/backend_route53.go`, `pkg/ddns/backend_dyndns2.go`,
+  `pkg/ddns/backend_duckdns.go`,
+  `pkg/ddns/provider_response_text_6634_test.go` (new),
+  `pkg/ddns/url_render_class_6545_test.go`, `pkg/ddns/README.md`
+
 ## 2026-08-21 — #6534 port-mirroring: dropped instances stop rendering as armed
 
 - **Timestamp**: 2026-08-21

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -460,6 +460,87 @@ refuse every keyed endpoint. Its userinfo cases are what make it a real guard
 (`url.Parse` rejects `<redacted>@host` with "invalid userinfo"); a query-only
 case would be vacuous, since `?<redacted>` parses fine as a raw query.
 
+#### The other direction: provider RESPONSE TEXT (#6634)
+
+Everything above bounds error VALUES that carry a REQUEST URL. #6634 is the
+opposite flow: text the **provider** put in its response BODY, which four
+backends rendered straight into a returned error the daemon logs and retains as
+the provider's `lastErr` — Cloudflare's `Errors[].Message`, Route 53's decoded
+`Code`/`Message`, and the unrecognized first response line on dyndns2 and
+DuckDNS, plus three Cloudflare `json.Unmarshal` sites that rendered the decoder
+error with `%w` (Go's decoder quotes the offending input back).
+
+The provider is the untrusted party, and **no hostile transport is needed** —
+only an API that answers "your request was invalid: `<the request>`" and echoes
+our own update URL back. DuckDNS makes that concrete: its token travels in the
+QUERY STRING of the update URL, so the echo IS the credential.
+
+**Two thirds of the surface was already closed, elsewhere, and the fix does not
+duplicate it.** Control-character forgery at the terminal is closed by
+`termsafe.SanitizeForDisplay` on both `show services ddns` surfaces (#6468,
+whose own source comment names these exact sites); control characters in the
+journal are closed by the daemon's `slog.TextHandler`, which `strconv.Quote`s
+any value carrying a byte outside printable ASCII, so an embedded newline cannot
+split a log line. What NEITHER closes is a credential in the bytes, or 64 KiB of
+them (`readCappedBody` admits `httpMaxResponseBody`), logged on every reconcile
+tick of a persistent failure.
+
+So `scrubProviderText` bounds two things and is explicit about the third:
+
+1. **LENGTH — a proof.** Nothing provider-chosen exceeds `maxProviderTextBytes`
+   plus a fixed `[truncated]` marker. The Cloudflare envelope additionally
+   bounds the error COUNT: a per-message cap is not a bound when the provider
+   picks how many messages the array carries.
+2. **URL AND USERINFO SHAPES.** A whitespace-delimited token carrying `://`, a
+   userinfo-shaped `user:pass@host`, or a `%XX` escape is replaced whole. A bare
+   `user@host` is NOT withheld — no secret in it, and withholding it would eat
+   `contact support@example.com` from a legitimate message.
+3. **NOT a proof against a provider that WANTS to leak.** A credential echoed as
+   bare prose ("your token abc123 is invalid") is indistinguishable from a word,
+   and no filter recovers it. That residual is accepted rather than papered
+   over: withholding provider text wholesale, as the transport path does for its
+   own errors, costs the operator their single most useful diagnostic ("token
+   invalid", "zone not found", "rate limited") and does not actually close a
+   provider deliberately exfiltrating a credential it was already given.
+
+The order matters: **filter, then bound**. The other order splits a URL at the
+cap and leaves its prefix — `https://user:PA` — rendered.
+
+**Why not the code-mapping option** the issue leaned toward: mapping known
+provider error codes onto our own constants gives a closed output, but only for
+codes we already know, and the unmapped case is exactly the one an operator is
+debugging. Route 53 also classifies delete-idempotency on the RAW message text
+(`r53DeleteAlreadyGone` matches "but it was not found"), so the VALUE must keep
+flowing to the classifier untouched — only the RENDER goes through the scrubber.
+The Cloudflare decode sites are the exception and follow the Route 53 XML
+precedent instead: a decoder's own text has no diagnostic worth preserving, so
+it is withheld outright via `scrubInnerError`.
+
+The class gate gained `json.Unmarshal`, **file-scoped** via `producerFileScope`.
+That call decodes two different things here: in a `backend_*.go` file it decodes
+a provider response body, so the decoder quotes bytes an untrusted party chose;
+in `state.go` it decodes the ownership state file this daemon wrote itself, at a
+root-owned path, where the decoder's detail is the whole diagnostic for
+repairing a corrupt store. The scope is a PREDICATE, not a list of sites, so any
+new backend file is covered automatically — the direction a scope has to fail.
+It is a scope, not an exemption: it says where a call can carry foreign input,
+not that a known-unsafe site is tolerated.
+`TestProviderDecodeScopeIsLoadBearing_6634` pins both halves, and re-walks
+`state.go` under a lied-about filename to prove the scope actually excludes a
+site that would otherwise fail the gate.
+
+Gates: `provider_response_text_6634_test.go`. Every cell drives the REAL backend
+through a real `httptest` server and asserts the request was SERVED before
+asserting anything about the message — a unit test on the scrubber alone would
+pass whether or not any backend called it, and "the credential is absent" is
+satisfied just as well by an input that never arrived. Three axes per backend:
+the leak (what the message BECAME, a `[url withheld]` marker, not merely absence),
+the NEGATIVE CONTROL (ordinary prose must survive, or the fix is blanket
+suppression), and the BOUND. The bound cells size their payload to fit UNDER
+`readCappedBody` deliberately: a message at the full 64 KiB makes the enclosing
+JSON/XML exceed the read cap, the body arrives truncated, the decode fails, and
+the cell never reaches the render site it exists to test.
+
 ### Withdraw (DeleteLease) semantics per backend (#2772)
 
 A withdraw is triggered when a Surface A scope shrinks, a binding is removed, or

--- a/pkg/ddns/backend_cloudflare.go
+++ b/pkg/ddns/backend_cloudflare.go
@@ -117,15 +117,39 @@ type cfRecord struct {
 	TTL     int    `json:"ttl"`
 }
 
-// cfErrors formats the envelope errors WITHOUT leaking the token (which is only
-// ever in the request header, never echoed by Cloudflare).
+// maxCFErrors bounds how many envelope errors are rendered. The array length is
+// PROVIDER-CHOSEN, so without this the per-message cap is defeated by repetition
+// (#6634): a body carrying ten thousand short errors is still an unbounded log
+// line. Four is more than any real Cloudflare failure returns.
+const maxCFErrors = 4
+
+// cfErrors formats the envelope errors.
+//
+// The Cloudflare API token is only ever in the request header and is never
+// echoed by Cloudflare, so it is not the exposure here. The MESSAGE is: it is
+// chosen by the provider, and it was rendered verbatim with %s into an error the
+// daemon logs and retains as the provider's lastErr. An API that answers "your
+// request was invalid: <the request>" echoes our own update URL back, so the
+// text is scrubbed and bounded on the way out (#6634), and the COUNT is bounded
+// too — a per-item cap is not a bound when the provider picks the item count.
+//
+// The numeric Code is rendered as-is: an int cannot carry text.
 func cfErrors(env cfEnvelope) string {
 	if len(env.Errors) == 0 {
 		return "unknown error"
 	}
-	parts := make([]string, 0, len(env.Errors))
-	for _, e := range env.Errors {
-		parts = append(parts, fmt.Sprintf("%d:%s", e.Code, e.Message))
+	shown := env.Errors
+	extra := 0
+	if len(shown) > maxCFErrors {
+		extra = len(shown) - maxCFErrors
+		shown = shown[:maxCFErrors]
+	}
+	parts := make([]string, 0, len(shown)+1)
+	for _, e := range shown {
+		parts = append(parts, fmt.Sprintf("%d:%s", e.Code, scrubProviderText(e.Message)))
+	}
+	if extra > 0 {
+		parts = append(parts, fmt.Sprintf("[+%d more]", extra))
 	}
 	return strings.Join(parts, "; ")
 }
@@ -161,7 +185,14 @@ func (b *cloudflareBackend) do(ctx context.Context, method, path string, body an
 	}
 	var env cfEnvelope
 	if err := json.Unmarshal(raw, &env); err != nil {
-		return cfEnvelope{}, fmt.Errorf("ddns cloudflare: %s: decode response: %w", b.name, err)
+		// SECURITY (#6634): `raw` is a provider-chosen response body, and Go's
+		// JSON decoder QUOTES the offending input back — an overflowing numeric
+		// field yields "json: cannot unmarshal number 9876543210…" with the
+		// complete provider-selected token in it. Withhold the decoder's text
+		// the same way the Route 53 XML decode does; the prefix already says
+		// which call failed.
+		return cfEnvelope{}, fmt.Errorf("ddns cloudflare: %s: decode response: %s",
+			b.name, scrubInnerError(err))
 	}
 	if !env.Success {
 		return env, fmt.Errorf("ddns cloudflare: %s: API error: %s", b.name, cfErrors(env))
@@ -179,7 +210,10 @@ func (b *cloudflareBackend) resolveZoneID(ctx context.Context) (string, error) {
 	}
 	var zones []cfZone
 	if err := json.Unmarshal(env.Result, &zones); err != nil {
-		return "", fmt.Errorf("ddns cloudflare: %s: decode zones: %w", b.name, err)
+		// SECURITY (#6634): as in do() — the decoder quotes provider-chosen
+		// input back, and env.Result came off the wire.
+		return "", fmt.Errorf("ddns cloudflare: %s: decode zones: %s",
+			b.name, scrubInnerError(err))
 	}
 	for _, z := range zones {
 		if strings.EqualFold(z.Name, b.zone) {
@@ -219,7 +253,10 @@ func (b *cloudflareBackend) listRecords(ctx context.Context, zoneID, rtype, fqdn
 		}
 		var recs []cfRecord
 		if err := json.Unmarshal(env.Result, &recs); err != nil {
-			return nil, fmt.Errorf("ddns cloudflare: %s: decode records: %w", b.name, err)
+			// SECURITY (#6634): as in do() — the decoder quotes provider-chosen
+			// input back, and env.Result came off the wire.
+			return nil, fmt.Errorf("ddns cloudflare: %s: decode records: %s",
+				b.name, scrubInnerError(err))
 		}
 		all = append(all, recs...)
 		// Stop when the API reports the last page. Fall back to a short-page

--- a/pkg/ddns/backend_duckdns.go
+++ b/pkg/ddns/backend_duckdns.go
@@ -246,6 +246,11 @@ func parseDuckDNSResponse(body, name string) error {
 		return fmt.Errorf("ddns duckdns: %s: response %q (bad token or unknown domain): %w",
 			name, keyword, errHTTPAuth)
 	default:
-		return fmt.Errorf("ddns duckdns: %s: unrecognized response %q", name, first)
+		// SECURITY (#6634): as on the dyndns2 path — `first` is up to
+		// httpMaxResponseBody (64 KiB) of provider-chosen bytes. DuckDNS carries
+		// its token in the QUERY STRING of the update URL, so an endpoint that
+		// echoes the request back echoes the token itself; %q neutralizes
+		// control characters and nothing else.
+		return fmt.Errorf("ddns duckdns: %s: unrecognized response %q", name, scrubProviderText(first))
 	}
 }

--- a/pkg/ddns/backend_dyndns2.go
+++ b/pkg/ddns/backend_dyndns2.go
@@ -272,6 +272,13 @@ func parseDyndns2Response(body, name string) error {
 	case "nohost", "notfqdn", "numhost", "nofqdn", "badagent":
 		return fmt.Errorf("ddns dyndns2: %s: response %q (hostname/request rejected)", name, keyword)
 	default:
-		return fmt.Errorf("ddns dyndns2: %s: unrecognized response %q", name, first)
+		// SECURITY (#6634): `first` is the provider's own first response line,
+		// up to httpMaxResponseBody (64 KiB) of provider-chosen bytes, rendered
+		// into an error the daemon logs every reconcile tick of a persistent
+		// failure and retains as the provider's lastErr. %q already neutralizes
+		// control characters; what it does not neutralize is a credential — the
+		// dyndns2 `server` leaf can carry userinfo, so an endpoint that echoes
+		// the request back echoes the credential — or 64 KiB of anything.
+		return fmt.Errorf("ddns dyndns2: %s: unrecognized response %q", name, scrubProviderText(first))
 	}
 }

--- a/pkg/ddns/backend_http.go
+++ b/pkg/ddns/backend_http.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	"unicode/utf8"
 
 	"github.com/psaab/xpf/pkg/config"
 )
@@ -1268,4 +1269,139 @@ func classifyHTTPStatus(code int) error {
 	default:
 		return fmt.Errorf("ddns http: unexpected status %d", code)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Provider-CHOSEN text (#6634)
+// ---------------------------------------------------------------------------
+
+// The scrubbers above bound error VALUES that carry a request URL. This is the
+// other direction: text the PROVIDER put in its response BODY and that four
+// backends render into a returned error the daemon logs — Cloudflare's
+// Errors[].Message, Route 53's decoded Code/Message, and the unrecognized first
+// response line on dyndns2 and DuckDNS.
+//
+// THE PROVIDER IS THE UNTRUSTED PARTY HERE. No hostile transport is needed: a
+// "your request was invalid: <the request>" style API echoes our own update URL
+// back, and a DuckDNS-shaped endpoint carries its token in the QUERY, so the
+// echo is the credential. The same body is also the DoS surface — readCappedBody
+// admits httpMaxResponseBody (64 KiB), and every byte of it was reaching a
+// journal line on every reconcile tick of a persistent failure, plus the
+// provider's retained lastErr.
+//
+// WHAT THE SINKS ALREADY DO, so this does not duplicate them. Control-character
+// forgery is closed twice over and neither fix belongs here: the daemon's
+// slog.TextHandler (cmd/xpfd/main.go) strconv.Quote-s any value carrying a byte
+// outside printable ASCII, so an embedded newline cannot split a journal line;
+// and `show services ddns` renders LastError through termsafe.SanitizeForDisplay
+// on both the CLI and gRPC surfaces (#6468). What NO sink can undo is a
+// credential in the bytes, or 64 KiB of them.
+//
+// SO THIS BOUNDS TWO THINGS AND IS HONEST ABOUT THE THIRD:
+//
+//  1. LENGTH — hard cap, total. This half is a proof: nothing provider-chosen
+//     can exceed maxProviderTextBytes plus a fixed marker.
+//  2. URL AND USERINFO SHAPES — a whitespace-delimited token carrying "://", a
+//     userinfo-shaped "user:pass@host", or a percent-escape is replaced whole.
+//     This closes the ECHO threat the issue describes, where the secret arrives
+//     inside a well-formed URL.
+//  3. NOT a proof against a provider that WANTS to leak. A credential echoed as
+//     bare prose ("your token abc123 is invalid") is indistinguishable from a
+//     word, and no filter recovers it. That residual is accepted rather than
+//     papered over, because the alternative — withholding provider text
+//     wholesale, as the transport path does for its own errors — costs the
+//     operator the single most useful diagnostic they get ("token invalid",
+//     "zone not found", "rate limited") in exchange for a threat model
+//     (a provider deliberately exfiltrating a credential it was ALREADY GIVEN)
+//     that withholding does not actually close either.
+//
+// WHY NOT THE CODE-MAPPING OPTION. Mapping known provider error codes onto our
+// own constants, the transportReason discipline, would give a closed output —
+// but only for codes we already know. The unmapped case is exactly the case an
+// operator is debugging, and it would render as a constant saying nothing. Route
+// 53 also classifies delete-idempotency on the raw message text
+// (r53DeleteAlreadyGone), so the VALUE must keep flowing to the classifier
+// untouched; only the RENDER goes through here.
+//
+// FILTER FIRST, THEN BOUND. The other order splits a URL at the cap and leaves
+// its prefix — "https://user:PA" — rendered, which is a partial credential.
+
+const (
+	// maxProviderTextBytes caps any provider-chosen string rendered into an
+	// error. Generous for real provider prose (Route 53's InvalidChangeBatch
+	// "…but it was not found" sentence is under 100 bytes), three orders of
+	// magnitude under the 64 KiB body cap.
+	maxProviderTextBytes = 200
+
+	// providerTextTruncated marks a bounded render. Fixed text, so it cannot
+	// itself carry anything provider-chosen.
+	providerTextTruncated = "[truncated]"
+
+	// providerURLWithheld replaces one URL-shaped or userinfo-shaped token.
+	providerURLWithheld = "[url withheld]"
+
+	// providerTextEmpty distinguishes "the provider said nothing" from "the
+	// provider's text was withheld", which are different diagnoses.
+	providerTextEmpty = "[no text]"
+)
+
+// scrubProviderText renders a provider-supplied string under the bound above.
+// Whitespace runs collapse to a single space: it costs nothing diagnostically,
+// and it means a body that is 64 KiB of newlines cannot dominate the budget.
+func scrubProviderText(s string) string {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return providerTextEmpty
+	}
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if providerTokenCarriesURL(f) {
+			f = providerURLWithheld
+		}
+		out = append(out, f)
+	}
+	joined := strings.Join(out, " ")
+	if len(joined) > maxProviderTextBytes {
+		// Cut on a byte boundary that cannot split a multi-byte rune: back off
+		// to the last boundary at or before the cap. A rune split would emit a
+		// lone continuation byte, which is exactly the invalid-UTF-8 shape the
+		// display sanitizer then has to escape.
+		cut := maxProviderTextBytes
+		for cut > 0 && !utf8.RuneStart(joined[cut]) {
+			cut--
+		}
+		joined = joined[:cut] + providerTextTruncated
+	}
+	return joined
+}
+
+// providerTokenCarriesURL reports whether one whitespace-delimited token is
+// shaped like something that can carry a credential.
+//
+// Three shapes, deliberately narrow so ordinary prose survives:
+//
+//   - a scheme separator "://" — any URL, whatever the scheme;
+//   - USERINFO WITH A PASSWORD: a ':' before an '@'. A bare "user@host" is NOT
+//     withheld — there is no secret in it, and withholding it would eat
+//     "contact support@example.com" from a legitimate provider message;
+//   - a PERCENT-ESCAPE "%XX" — the encoded form of the two above, which is what
+//     a URL echoed through a provider's own escaping looks like. Two hex digits
+//     are required, so "80% of quota" survives.
+func providerTokenCarriesURL(tok string) bool {
+	if strings.Contains(tok, "://") {
+		return true
+	}
+	if at := strings.IndexByte(tok, '@'); at > 0 && strings.IndexByte(tok[:at], ':') >= 0 {
+		return true
+	}
+	for i := 0; i+2 < len(tok); i++ {
+		if tok[i] == '%' && isHexDigit(tok[i+1]) && isHexDigit(tok[i+2]) {
+			return true
+		}
+	}
+	return false
+}
+
+func isHexDigit(c byte) bool {
+	return c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F'
 }

--- a/pkg/ddns/backend_route53.go
+++ b/pkg/ddns/backend_route53.go
@@ -194,7 +194,13 @@ func (b *route53Backend) listRRSet(ctx context.Context, name, rtype string) (r53
 	if cerr := classifyHTTPStatus(code); cerr != nil {
 		var e r53ErrorXML
 		if xml.Unmarshal(raw, &e) == nil && e.Error.Code != "" {
-			return r53LiveRRSet{}, fmt.Errorf("ddns route53: %s: %s: %s: %w", b.name, e.Error.Code, e.Error.Message, cerr)
+			// SECURITY (#6634): Code and Message are decoded from a
+			// PROVIDER-CHOSEN response body and were rendered verbatim with %s
+			// into an error the daemon logs and retains as lastErr. Scrub and
+			// bound both; an API that echoes the request back would otherwise
+			// put our own credentialed update URL in the journal.
+			return r53LiveRRSet{}, fmt.Errorf("ddns route53: %s: %s: %s: %w", b.name,
+				scrubProviderText(e.Error.Code), scrubProviderText(e.Error.Message), cerr)
 		}
 		return r53LiveRRSet{}, fmt.Errorf("ddns route53: %s: %w", b.name, cerr)
 	}
@@ -288,7 +294,14 @@ func (b *route53Backend) change(ctx context.Context, action, name, rtype string,
 		// Surface the Route 53 error code/message when present (never the creds).
 		var e r53ErrorXML
 		if xml.Unmarshal(raw, &e) == nil && e.Error.Code != "" {
-			return e.Error.Code, e.Error.Message, fmt.Errorf("ddns route53: %s: %s: %s: %w", b.name, e.Error.Code, e.Error.Message, cerr)
+			// SECURITY (#6634): the RENDER is scrubbed and bounded, the RETURNED
+			// values are not. r53DeleteAlreadyGone classifies delete-idempotency
+			// on the raw code/message ("but it was not found"), so scrubbing the
+			// values would change a control decision, not just a log line — a
+			// withheld token could turn an idempotent delete into a permanent
+			// retry. Only what reaches the error text goes through the scrubber.
+			return e.Error.Code, e.Error.Message, fmt.Errorf("ddns route53: %s: %s: %s: %w",
+				b.name, scrubProviderText(e.Error.Code), scrubProviderText(e.Error.Message), cerr)
 		}
 		return "", "", fmt.Errorf("ddns route53: %s: %w", b.name, cerr)
 	}

--- a/pkg/ddns/provider_response_text_6634_test.go
+++ b/pkg/ddns/provider_response_text_6634_test.go
@@ -62,6 +62,13 @@ func hostileBody(shape string) string {
 	return strings.Replace(shape, "%ECHO%", providerProse+": "+providerEchoURL, 1)
 }
 
+// decodeSentinel is the leak vector for the DECODE sites, which is a different
+// shape from the render sites. Go's JSON decoder does not quote a mismatched
+// STRING back — it names the type — but it does quote a mismatched NUMBER in
+// full, and the number is provider-chosen and arbitrarily long. So the decode
+// cells plant a long digit run and assert none of it survives.
+const decodeSentinel = "9876543210123456789012345678901234567890"
+
 // serveOnce answers every request with the given status + body and records that
 // it was reached, so a cell cannot pass because nothing was requested.
 type recordingProvider struct {
@@ -452,5 +459,246 @@ func TestProviderDecodeScopeIsLoadBearing_6634(t *testing.T) {
 		t.Error("state.go no longer has an unscrubbed json.Unmarshal render, so the file scope " +
 			"excludes nothing and should be DELETED rather than left standing — a scope that " +
 			"covers no site silently exempts whatever moves into it next")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Staged providers: the SECOND surface of a two-call backend.
+//
+// A single always-fail fake reaches only the FIRST call a backend makes, and
+// this issue is precisely a one-of-N-surfaces class — Route 53 renders provider
+// text in listRRSet AND in change(), and Cloudflare decodes a provider body in
+// do(), resolveZoneID() AND listRecords(). A fake that answers everything with
+// an error never gets past listRRSet or past do(), so those later sites would
+// have been "covered" by a cell that never executed them.
+// ---------------------------------------------------------------------------
+
+// stagedProvider answers each request from a per-request script, so a cell can
+// let the first call succeed and fail the one it is actually testing. It records
+// how many requests were served, which the cells assert on: reaching the second
+// site requires TWO round trips, and a cell that saw only one never got there.
+type stagedProvider struct {
+	t      *testing.T
+	served int
+	// stages are consumed in order; the last one repeats.
+	stages []stagedResponse
+	srv    *httptest.Server
+}
+
+type stagedResponse struct {
+	status int
+	body   string
+}
+
+func newStagedProvider(t *testing.T, stages ...stagedResponse) *stagedProvider {
+	t.Helper()
+	p := &stagedProvider{t: t, stages: stages}
+	p.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		st := p.stages[len(p.stages)-1]
+		if p.served < len(p.stages) {
+			st = p.stages[p.served]
+		}
+		p.served++
+		w.WriteHeader(st.status)
+		_, _ = w.Write([]byte(st.body))
+	}))
+	t.Cleanup(p.srv.Close)
+	return p
+}
+
+// TestProviderResponseTextSecondSurfaces_6634 covers the render and decode sites
+// a single-response fake cannot reach. Each cell asserts the request COUNT, so
+// it fails loudly if the backend short-circuits before the site under test
+// rather than passing on an assertion that never ran.
+func TestProviderResponseTextSecondSurfaces_6634(t *testing.T) {
+	echo := providerProse + ": " + providerEchoURL
+
+	for _, tc := range []struct {
+		name string
+		// stages script the responses; the site under test is driven by the last.
+		stages []stagedResponse
+		run    func(t *testing.T, u string) error
+		// wantServed is how many round trips reaching the site requires.
+		wantServed int
+		// sentinel is what must not survive.
+		sentinel string
+	}{
+		{
+			// Route 53 change(): the GET rrset list must SUCCEED so UpsertLease
+			// proceeds to the POST, which is the site that renders Code/Message.
+			name: "route53_change_error_message",
+			stages: []stagedResponse{
+				{http.StatusOK, `<?xml version="1.0"?><ListResourceRecordSetsResponse>` +
+					`<ResourceRecordSets></ResourceRecordSets></ListResourceRecordSetsResponse>`},
+				{http.StatusBadRequest, `<?xml version="1.0"?><ErrorResponse><Error>` +
+					`<Code>InvalidChangeBatch</Code><Message>` + echo +
+					`</Message></Error></ErrorResponse>`},
+			},
+			run:        runRoute53,
+			wantServed: 2,
+			sentinel:   providerEchoSecret,
+		},
+		{
+			// Cloudflare resolveZoneID(): the envelope must decode so the flow
+			// reaches the SECOND json.Unmarshal, over env.Result.
+			name: "cloudflare_decode_zones",
+			stages: []stagedResponse{
+				{http.StatusOK, `{"success":true,"errors":[],"result":` + decodeSentinel + `}`},
+			},
+			run:        runCloudflare,
+			wantServed: 1,
+			sentinel:   decodeSentinel,
+		},
+		{
+			// Cloudflare listRecords(): zones must resolve first, so this needs
+			// two round trips to reach the THIRD json.Unmarshal.
+			name: "cloudflare_decode_records",
+			stages: []stagedResponse{
+				{http.StatusOK, `{"success":true,"errors":[],` +
+					`"result":[{"id":"ZONEID1","name":"example.net"}]}`},
+				{http.StatusOK, `{"success":true,"errors":[],"result":` + decodeSentinel + `}`},
+			},
+			run:        runCloudflare,
+			wantServed: 2,
+			sentinel:   decodeSentinel,
+		},
+		{
+			// Cloudflare do(): the envelope itself does not decode.
+			name: "cloudflare_decode_response",
+			stages: []stagedResponse{
+				{http.StatusOK, `{"success":true,"errors":[],"result":` + decodeSentinel},
+			},
+			run:        runCloudflare,
+			wantServed: 1,
+			sentinel:   decodeSentinel,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newStagedProvider(t, tc.stages...)
+			err := tc.run(t, p.srv.URL)
+
+			if p.served != tc.wantServed {
+				t.Fatalf("this cell needs %d round trips to REACH the site under test; the "+
+					"backend made %d. The assertions below would be measuring a different "+
+					"site, or none.", tc.wantServed, p.served)
+			}
+			if err == nil {
+				t.Fatal("the staged failure must produce a non-nil error; got nil, so every " +
+					"assertion below would be vacuous")
+			}
+			msg := err.Error()
+			if strings.Contains(msg, tc.sentinel) {
+				t.Errorf("provider-chosen bytes reached the returned error:\n  error = %s\n"+
+					"Render provider text through scrubProviderText, and a decoder's own error "+
+					"through scrubInnerError.", msg)
+			}
+			if len(msg) > maxProviderTextBytes+256 {
+				t.Errorf("the error is %d bytes; a provider-chosen render must stay O(%d), "+
+					"not O(%d):\n  %s", len(msg), maxProviderTextBytes, httpMaxResponseBody, msg)
+			}
+			if !strings.Contains(msg, "ddns ") {
+				t.Errorf("the error must still name the backend; got:\n  %s", msg)
+			}
+		})
+	}
+}
+
+// TestScrubProviderTextRules_6634 is the per-RULE table. The end-to-end cells
+// above prove the BACKENDS call the scrubber; this proves each rule inside it
+// does its own work. Without it a mutation that disabled exactly one of the
+// three shapes would still be caught by a cell whose payload happens to trip
+// two of them, and the matrix would report a red that localises nothing.
+//
+// Each row therefore trips ONE rule and only one. The echo URL used end to end
+// carries both a scheme separator and userinfo, which is realistic but useless
+// for localisation.
+func TestScrubProviderTextRules_6634(t *testing.T) {
+	const secret = "S3CR3T-RULE-6634"
+
+	for _, tc := range []struct {
+		name string
+		in   string
+		// wantWithheld is true when the sentinel-bearing token must be replaced.
+		wantWithheld bool
+		// note says which rule the row exercises, so a failure names it.
+		note string
+	}{
+		{
+			name:         "scheme_separator_only",
+			in:           "invalid request https://prov.example/update?token=" + secret,
+			wantWithheld: true,
+			note:         `the "://" rule — a URL with no userinfo, which is the DuckDNS echo shape`,
+		},
+		{
+			name:         "userinfo_only_no_scheme",
+			in:           "rejected credentials user:" + secret + "@prov.example",
+			wantWithheld: true,
+			note:         "the userinfo rule — a ':' before an '@', with no scheme to trip the first rule",
+		},
+		{
+			name:         "percent_encoded_only",
+			in:           "bad target https%3A%2F%2Fuser%3A" + secret + "%40prov.example",
+			wantWithheld: true,
+			note:         "the %XX rule — the encoded form, which trips neither of the other two",
+		},
+		{
+			name:         "bare_email_survives",
+			in:           "quota exceeded, contact support@prov.example",
+			wantWithheld: false,
+			note:         "a bare user@host carries no secret; withholding it would eat legitimate prose",
+		},
+		{
+			name:         "percentage_survives",
+			in:           "you are at 80% of quota",
+			wantWithheld: false,
+			note:         "a '%' not followed by two hex digits is not an escape",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scrubProviderText(tc.in)
+
+			// NON-VACUITY: the input must have carried something to withhold, and
+			// the surrounding prose must survive either way — a row that passes
+			// because everything was withheld is not testing a rule.
+			firstWord := strings.Fields(tc.in)[0]
+			if !strings.Contains(got, firstWord) {
+				t.Fatalf("the leading prose %q must survive; scrubbing everything makes this "+
+					"row pass for the wrong reason.\n  in:  %q\n  got: %q", firstWord, tc.in, got)
+			}
+
+			if tc.wantWithheld {
+				if strings.Contains(got, secret) {
+					t.Errorf("%s: the credential-bearing token was rendered.\n  in:  %q\n  got: %q",
+						tc.note, tc.in, got)
+				}
+				if !strings.Contains(got, providerURLWithheld) {
+					t.Errorf("%s: the token must be REPLACED by %q, not merely dropped — the "+
+						"operator has to see that something was withheld.\n  got: %q",
+						tc.note, providerURLWithheld, got)
+				}
+				return
+			}
+			if got != tc.in {
+				t.Errorf("%s: this text carries no credential and must pass through unchanged.\n"+
+					"  in:  %q\n  got: %q", tc.note, tc.in, got)
+			}
+		})
+	}
+}
+
+// TestScrubProviderTextEmptyIsDistinguishable_6634 keeps "the provider said
+// nothing" separable from "the provider's text was withheld". They are different
+// diagnoses — one means an empty body, the other means the body was a URL — and
+// collapsing them would send an operator looking in the wrong place.
+func TestScrubProviderTextEmptyIsDistinguishable_6634(t *testing.T) {
+	if got := scrubProviderText(""); got != providerTextEmpty {
+		t.Errorf("empty provider text must render %q; got %q", providerTextEmpty, got)
+	}
+	if got := scrubProviderText("   \n\t "); got != providerTextEmpty {
+		t.Errorf("whitespace-only provider text must render %q; got %q", providerTextEmpty, got)
+	}
+	if got := scrubProviderText("https://user:pw@h/"); got == providerTextEmpty {
+		t.Errorf("a withheld URL must NOT render as %q — that reads as an empty response",
+			providerTextEmpty)
 	}
 }

--- a/pkg/ddns/provider_response_text_6634_test.go
+++ b/pkg/ddns/provider_response_text_6634_test.go
@@ -1,0 +1,456 @@
+package ddns
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// provider_response_text_6634_test.go: #6634. Four backends rendered text taken
+// from the PROVIDER'S HTTP RESPONSE BODY straight into a returned error the
+// daemon logs and retains as the provider's lastErr. The provider is the
+// untrusted party: no hostile transport is needed, only an API that answers
+// "your request was invalid: <the request>" and echoes our own update URL back.
+// DuckDNS makes that concrete — its token travels in the QUERY STRING, so the
+// echo IS the credential.
+//
+// EVERY CELL DRIVES THE REAL BACKEND THROUGH A REAL httptest SERVER. That is
+// deliberate: a unit test on the scrubber alone would pass whether or not any
+// backend called it, and "the credential is absent" is satisfied just as well by
+// an input that never reached the function. Each cell therefore asserts the
+// request was actually SERVED, that the returned error is non-nil, and that the
+// message still carries the provider's ordinary prose — before asserting the
+// credential is gone.
+//
+// WHAT IS ACTUALLY BEING FIXED, since two thirds of this issue's surface turned
+// out to be closed already and the tests should not claim otherwise:
+//
+//   - control-character forgery at the TERMINAL is closed by
+//     termsafe.SanitizeForDisplay on both `show services ddns` surfaces (#6468);
+//   - control characters in the JOURNAL are closed by slog's TextHandler, which
+//     strconv.Quote-s any value carrying a byte outside printable ASCII;
+//   - what NEITHER closes is a CREDENTIAL in the bytes, or 64 KiB of them
+//     (httpMaxResponseBody), logged on every reconcile tick of a persistent
+//     failure and retained in lastErr.
+//
+// So the assertions here are about the credential and the bound, not escaping.
+
+const (
+	// providerEchoURL is the shape a credential arrives in when a provider
+	// echoes our own request back. The sentinel is inside the userinfo.
+	providerEchoSecret = "S3CR3T-PROVIDER-6634"
+	providerEchoURL    = "https://user:" + providerEchoSecret + "@prov.example/update?token=" +
+		providerEchoSecret
+
+	// providerProse is ordinary, useful provider text. The negative controls
+	// require it to SURVIVE — a fix that withheld everything would pass every
+	// leak assertion above and destroy the one diagnostic an operator gets.
+	providerProse = "zone not found for this token"
+)
+
+// hostileBody is a provider response whose error text echoes our credentialed
+// request URL back, wrapped in prose exactly as a real API would.
+func hostileBody(shape string) string {
+	return strings.Replace(shape, "%ECHO%", providerProse+": "+providerEchoURL, 1)
+}
+
+// serveOnce answers every request with the given status + body and records that
+// it was reached, so a cell cannot pass because nothing was requested.
+type recordingProvider struct {
+	served int
+	status int
+	body   string
+	srv    *httptest.Server
+}
+
+func newRecordingProvider(t *testing.T, status int, body string) *recordingProvider {
+	t.Helper()
+	p := &recordingProvider{status: status, body: body}
+	p.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p.served++
+		w.WriteHeader(p.status)
+		_, _ = w.Write([]byte(p.body))
+	}))
+	t.Cleanup(p.srv.Close)
+	return p
+}
+
+func testRec() LeaseDNSRecord {
+	return LeaseDNSRecord{
+		FQDN:        "wan.example.net",
+		Addr:        netip.MustParseAddr("203.0.113.7"),
+		ForwardType: "A",
+		TTL:         60,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The four render sites, each driven end to end.
+// ---------------------------------------------------------------------------
+
+func TestProviderResponseTextDoesNotLeakCredential_6634(t *testing.T) {
+	echo := providerProse + ": " + providerEchoURL
+
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+		run    func(t *testing.T, u string) error
+	}{
+		{
+			name:   "cloudflare_envelope_message",
+			status: http.StatusOK,
+			body:   `{"success":false,"errors":[{"code":1001,"message":"` + echo + `"}],"result":null}`,
+			run:    runCloudflare,
+		},
+		{
+			name:   "cloudflare_decode_error",
+			status: http.StatusOK,
+			// Not JSON at all: the decoder quotes the offending input back.
+			body: echo,
+			run:  runCloudflare,
+		},
+		{
+			name:   "route53_error_message",
+			status: http.StatusBadRequest,
+			body: `<?xml version="1.0"?><ErrorResponse><Error><Code>InvalidInput</Code>` +
+				`<Message>` + echo + `</Message></Error></ErrorResponse>`,
+			run: runRoute53,
+		},
+		{
+			name:   "dyndns2_unrecognized_response",
+			status: http.StatusOK,
+			body:   echo,
+			run:    runDyndns2,
+		},
+		{
+			name:   "duckdns_unrecognized_response",
+			status: http.StatusOK,
+			body:   echo,
+			run:    runDuckDNS,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newRecordingProvider(t, tc.status, tc.body)
+			err := tc.run(t, p.srv.URL)
+
+			// NON-VACUITY. The request must actually have been served and the
+			// operation must actually have failed; otherwise "the sentinel is
+			// absent" is true for the wrong reason.
+			if p.served == 0 {
+				t.Fatal("the fake provider was never reached; this cell must drive the REAL " +
+					"backend through a round trip, not assert on a helper in isolation")
+			}
+			if err == nil {
+				t.Fatal("a provider error response must produce a non-nil error; got nil, so " +
+					"every assertion below would be vacuous")
+			}
+			msg := err.Error()
+
+			// THE LEAK.
+			if strings.Contains(msg, providerEchoSecret) {
+				t.Errorf("provider-supplied response text carried the credential into the "+
+					"returned error:\n  error = %s\n"+
+					"This error is logged by the daemon and retained as the provider's "+
+					"lastErr. Render provider-chosen text through scrubProviderText.", msg)
+			}
+			// WHAT IT BECAME. Absence alone would also be satisfied by an empty
+			// error, by a typo in the sentinel, or by a body that never reached
+			// the render site.
+			if !strings.Contains(msg, providerURLWithheld) &&
+				!strings.Contains(msg, string(transportWithheld)) {
+				t.Errorf("the URL-shaped token must be REPLACED by a marker (%q), or the whole "+
+					"text withheld (%q) on the decode path — not merely absent; got:\n  %s",
+					providerURLWithheld, string(transportWithheld), msg)
+			}
+			// The message must stay attributable.
+			if !strings.Contains(msg, "ddns ") {
+				t.Errorf("the error must still name the backend; got:\n  %s", msg)
+			}
+		})
+	}
+}
+
+// TestProviderResponseTextKeepsOrdinaryProse_6634 is the NEGATIVE CONTROL the
+// issue asks for, and it is the half that stops this fix from being blanket
+// suppression. "token invalid" / "zone not found" / "rate limited" is the single
+// most useful thing an operator gets out of a failing provider; a fix that
+// withheld it would satisfy every leak assertion above and be a regression.
+func TestProviderResponseTextKeepsOrdinaryProse_6634(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+		run    func(t *testing.T, u string) error
+	}{
+		{
+			name:   "cloudflare_envelope_message",
+			status: http.StatusOK,
+			body:   `{"success":false,"errors":[{"code":1001,"message":"` + providerProse + `"}],"result":null}`,
+			run:    runCloudflare,
+		},
+		{
+			name:   "route53_error_message",
+			status: http.StatusBadRequest,
+			body: `<?xml version="1.0"?><ErrorResponse><Error><Code>InvalidInput</Code>` +
+				`<Message>` + providerProse + `</Message></Error></ErrorResponse>`,
+			run: runRoute53,
+		},
+		{
+			name:   "dyndns2_unrecognized_response",
+			status: http.StatusOK,
+			body:   providerProse,
+			run:    runDyndns2,
+		},
+		{
+			name:   "duckdns_unrecognized_response",
+			status: http.StatusOK,
+			body:   providerProse,
+			run:    runDuckDNS,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newRecordingProvider(t, tc.status, tc.body)
+			err := tc.run(t, p.srv.URL)
+			if p.served == 0 {
+				t.Fatal("the fake provider was never reached")
+			}
+			if err == nil {
+				t.Fatal("a provider error response must produce a non-nil error")
+			}
+			if msg := err.Error(); !strings.Contains(msg, providerProse) {
+				t.Errorf("ordinary provider prose must SURVIVE — it is the diagnostic the "+
+					"operator is reading. Withholding it wholesale passes every leak test and "+
+					"is a regression.\n  want to contain: %q\n  got: %s", providerProse, msg)
+			}
+		})
+	}
+}
+
+// TestProviderResponseTextIsBounded_6634 pins the half of this fix that IS a
+// proof. readCappedBody admits httpMaxResponseBody (64 KiB), and every byte of a
+// provider-chosen message was reaching a journal line on every reconcile tick of
+// a persistent failure, plus the retained lastErr. The bound is on the RENDER,
+// so it holds whatever the provider sends.
+func TestProviderResponseTextIsBounded_6634(t *testing.T) {
+	// A single enormous whitespace-free token, so nothing but the cap can
+	// shorten it, and one that is NOT URL-shaped, so it is not withheld for a
+	// different reason and the cell keeps testing the bound.
+	//
+	// SIZED TO FIT UNDER readCappedBody, deliberately. A message at
+	// httpMaxResponseBody makes the enclosing JSON/XML document itself exceed
+	// the read cap, so the body arrives truncated, the decode fails, and the
+	// cell never reaches the render site it exists to test — a green that
+	// measures nothing. 8 KiB is 40x the render bound and comfortably inside the
+	// 64 KiB read cap, so the ONLY thing that can shorten it is this fix. The
+	// read cap is a real second layer, but it bounds the BODY at 64 KiB, which
+	// is three orders of magnitude past what belongs in a log line.
+	huge := strings.Repeat("A", 8<<10)
+
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+		run    func(t *testing.T, u string) error
+	}{
+		{
+			name:   "cloudflare_envelope_message",
+			status: http.StatusOK,
+			body:   `{"success":false,"errors":[{"code":1001,"message":"` + huge + `"}],"result":null}`,
+			run:    runCloudflare,
+		},
+		{
+			name:   "route53_error_message",
+			status: http.StatusBadRequest,
+			body: `<?xml version="1.0"?><ErrorResponse><Error><Code>InvalidInput</Code>` +
+				`<Message>` + huge + `</Message></Error></ErrorResponse>`,
+			run: runRoute53,
+		},
+		{
+			name:   "dyndns2_unrecognized_response",
+			status: http.StatusOK,
+			body:   huge,
+			run:    runDyndns2,
+		},
+		{
+			name:   "duckdns_unrecognized_response",
+			status: http.StatusOK,
+			body:   huge,
+			run:    runDuckDNS,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newRecordingProvider(t, tc.status, tc.body)
+			err := tc.run(t, p.srv.URL)
+			if p.served == 0 {
+				t.Fatal("the fake provider was never reached")
+			}
+			if err == nil {
+				t.Fatal("a provider error response must produce a non-nil error")
+			}
+			msg := err.Error()
+			// A generous ceiling: the bound plus this package's own fixed prefix
+			// prose. The point is that it is O(maxProviderTextBytes), not
+			// O(httpMaxResponseBody).
+			const ceiling = maxProviderTextBytes + 256
+			if len(msg) > ceiling {
+				t.Errorf("a provider-chosen message reached the error at %d bytes, want at most "+
+					"%d. readCappedBody admits %d, and this error is logged every reconcile "+
+					"tick of a persistent failure and retained as lastErr.",
+					len(msg), ceiling, httpMaxResponseBody)
+			}
+			if !strings.Contains(msg, providerTextTruncated) {
+				t.Errorf("a bounded render must SAY it was truncated (%q), otherwise the "+
+					"operator reads a silently-cut message as the whole one; got %d bytes:\n  %s",
+					providerTextTruncated, len(msg), msg)
+			}
+		})
+	}
+}
+
+// TestCloudflareErrorCountIsBounded_6634 closes the repetition bypass. The
+// per-message cap is not a bound when the PROVIDER chooses how many messages the
+// envelope carries: ten thousand short errors is still an unbounded log line.
+func TestCloudflareErrorCountIsBounded_6634(t *testing.T) {
+	var items []string
+	const n = 500
+	for i := 0; i < n; i++ {
+		items = append(items, `{"code":1001,"message":"`+providerProse+`"}`)
+	}
+	body := `{"success":false,"errors":[` + strings.Join(items, ",") + `],"result":null}`
+
+	p := newRecordingProvider(t, http.StatusOK, body)
+	err := runCloudflare(t, p.srv.URL)
+	if p.served == 0 {
+		t.Fatal("the fake provider was never reached")
+	}
+	if err == nil {
+		t.Fatal("a success:false envelope must produce a non-nil error")
+	}
+	msg := err.Error()
+	const ceiling = maxCFErrors*(maxProviderTextBytes+64) + 256
+	if len(msg) > ceiling {
+		t.Errorf("a %d-error envelope rendered %d bytes, want at most %d: the per-message cap "+
+			"is defeated by repetition when the provider picks the COUNT", n, len(msg), ceiling)
+	}
+	if !strings.Contains(msg, "more]") {
+		t.Errorf("a count-bounded render must say how many errors were dropped; got:\n  %s", msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Backend drivers. Each builds the REAL backend against the fake provider and
+// runs the operation whose failure path renders provider text.
+// ---------------------------------------------------------------------------
+
+func runCloudflare(t *testing.T, u string) error {
+	t.Helper()
+	b, err := newCloudflareBackend(&config.DDNSProvider{
+		Name: "cf", Backend: "cloudflare", Zone: "example.net",
+		APIToken: config.Secret("cf-token"), Server: u,
+	}, &http.Client{})
+	if err != nil {
+		t.Fatalf("build cloudflare backend: %v", err)
+	}
+	return b.UpsertLease(context.Background(), testRec())
+}
+
+func runRoute53(t *testing.T, u string) error {
+	t.Helper()
+	b, err := newRoute53Backend(&config.DDNSProvider{
+		Name: "r53", Backend: "route53", HostedZoneID: "Z123",
+		AWSAccessKeyID: "AKID", AWSSecretAccessKey: config.Secret("aws-secret"),
+		Server: u,
+	}, &http.Client{})
+	if err != nil {
+		t.Fatalf("build route53 backend: %v", err)
+	}
+	return b.UpsertLease(context.Background(), testRec())
+}
+
+func runDyndns2(t *testing.T, u string) error {
+	t.Helper()
+	b, err := newDyndns2Backend(&config.DDNSProvider{
+		Name: "dd2", Backend: "dyndns2", Server: u,
+		Username: "u", Password: config.Secret("p"),
+	}, &http.Client{})
+	if err != nil {
+		t.Fatalf("build dyndns2 backend: %v", err)
+	}
+	return b.UpsertLease(context.Background(), testRec())
+}
+
+func runDuckDNS(t *testing.T, u string) error {
+	t.Helper()
+	b, err := newDuckDNSBackend(&config.DDNSProvider{
+		Name: "duck", Backend: "duckdns", APIToken: config.Secret("duck-token"),
+		Server: u,
+	}, &http.Client{})
+	if err != nil {
+		t.Fatalf("build duckdns backend: %v", err)
+	}
+	return b.UpsertLease(context.Background(), testRec())
+}
+
+// TestProviderDecodeScopeIsLoadBearing_6634 proves the file scope on
+// json.Unmarshal is doing work in BOTH directions, because a scope that is
+// vacuous either way is worse than none: one that never excludes anything is
+// noise, and one that never includes anything is a gate that passes on nothing.
+//
+// The second half is the important one. It re-walks state.go while LYING about
+// its filename, so the scope does not apply — and asserts the walk finds an
+// unscrubbed json.Unmarshal render there. That is the direct evidence the scope
+// is load-bearing rather than decorative: without it, adding json.Unmarshal to
+// urlErrorProducers would have turned the class gate red on a site that decodes
+// a file this daemon wrote itself.
+func TestProviderDecodeScopeIsLoadBearing_6634(t *testing.T) {
+	if !producerFileScope("json.Unmarshal", "backend_cloudflare.go") {
+		t.Error("json.Unmarshal MUST be a producer in a backend file — that is where it " +
+			"decodes a provider-chosen response body, which is the whole point of the entry")
+	}
+	if producerFileScope("json.Unmarshal", "state.go") {
+		t.Error("json.Unmarshal must NOT be a producer in state.go, which decodes the " +
+			"ownership state file this daemon wrote itself")
+	}
+	// Every other producer is unscoped.
+	if !producerFileScope("url.Parse", "state.go") {
+		t.Error("the scope must apply to json.Unmarshal ONLY; url.Parse is unscoped")
+	}
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "state.go", nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse state.go: %v", err)
+	}
+	aliases := importAliases(file)
+	unscrubbed := 0
+	for _, decl := range file.Decls {
+		fn, isFunc := decl.(*ast.FuncDecl)
+		if !isFunc || fn.Body == nil {
+			continue
+		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			// Pretend state.go is a backend file, which disables the scope.
+			for _, site := range urlErrorHandlers(n, "backend_pretend.go", aliases) {
+				if site.producer != "json.Unmarshal" {
+					continue
+				}
+				unscrubbed += len(unscrubbedUses(fset, site.stmts, site.errVar, aliases))
+			}
+			return true
+		})
+	}
+	if unscrubbed == 0 {
+		t.Error("state.go no longer has an unscrubbed json.Unmarshal render, so the file scope " +
+			"excludes nothing and should be DELETED rather than left standing — a scope that " +
+			"covers no site silently exempts whatever moves into it next")
+	}
+}

--- a/pkg/ddns/provider_response_text_6634_test.go
+++ b/pkg/ddns/provider_response_text_6634_test.go
@@ -63,10 +63,21 @@ func hostileBody(shape string) string {
 }
 
 // decodeSentinel is the leak vector for the DECODE sites, which is a different
-// shape from the render sites. Go's JSON decoder does not quote a mismatched
-// STRING back — it names the type — but it does quote a mismatched NUMBER in
-// full, and the number is provider-chosen and arbitrarily long. So the decode
-// cells plant a long digit run and assert none of it survives.
+// shape from the render sites and NARROWER than the issue implies. Measured
+// against Go's decoder rather than assumed:
+//
+//	number into a slice   -> "cannot unmarshal number into Go value of type []ddns.cfZone"
+//	number into a string  -> "cannot unmarshal number into Go struct field cfZone.id of type string"
+//	number OVERFLOWING an int field
+//	                      -> "cannot unmarshal number 98765…7890 into Go struct field cfRecord.ttl of type int"
+//	syntax error          -> "invalid character '9' looking for beginning of object key string"
+//
+// So the literal is quoted in exactly ONE case: a numeric overflow into an int
+// field. A syntax error quotes a single character. That matters for what each
+// cell below can honestly assert, and it is why two of them assert the render
+// SHAPE rather than sentinel absence — a cell whose payload cannot produce a
+// literal would pass whether or not the site was scrubbed at all, which is how
+// the first version of this test let two mutations through.
 const decodeSentinel = "9876543210123456789012345678901234567890"
 
 // serveOnce answers every request with the given status + body and records that
@@ -520,8 +531,14 @@ func TestProviderResponseTextSecondSurfaces_6634(t *testing.T) {
 		run    func(t *testing.T, u string) error
 		// wantServed is how many round trips reaching the site requires.
 		wantServed int
-		// sentinel is what must not survive.
+		// sentinel is what must not survive. Empty when the payload cannot
+		// produce a provider-chosen literal at all (see decodeSentinel) — those
+		// cells rely on wantMarker instead.
 		sentinel string
+		// wantMarker is a fixed string the scrubbed render must CONTAIN. It is
+		// what makes a cell an assertion about the render rather than about the
+		// payload: a decode site rendered raw does not produce it.
+		wantMarker string
 	}{
 		{
 			// Route 53 change(): the GET rrset list must SUCCEED so UpsertLease
@@ -537,40 +554,59 @@ func TestProviderResponseTextSecondSurfaces_6634(t *testing.T) {
 			run:        runRoute53,
 			wantServed: 2,
 			sentinel:   providerEchoSecret,
+			wantMarker: providerURLWithheld,
 		},
 		{
 			// Cloudflare resolveZoneID(): the envelope must decode so the flow
 			// reaches the SECOND json.Unmarshal, over env.Result.
+			//
+			// NO SENTINEL IS POSSIBLE HERE, and saying so is the point. cfZone
+			// has only string fields, so no provider-chosen literal can reach
+			// this decoder's error — a number yields "cannot unmarshal number
+			// into Go value of type []ddns.cfZone" with no value in it. The scrub
+			// at this site is UNIFORMITY, not a closed leak, so the cell asserts
+			// the render SHAPE. Asserting sentinel-absence here would pass
+			// whether or not the site was scrubbed, which is a green that
+			// measures nothing.
 			name: "cloudflare_decode_zones",
 			stages: []stagedResponse{
 				{http.StatusOK, `{"success":true,"errors":[],"result":` + decodeSentinel + `}`},
 			},
 			run:        runCloudflare,
 			wantServed: 1,
-			sentinel:   decodeSentinel,
+			wantMarker: string(transportWithheld),
 		},
 		{
 			// Cloudflare listRecords(): zones must resolve first, so this needs
 			// two round trips to reach the THIRD json.Unmarshal.
+			// cfRecord DOES carry an int field (ttl), so an overflowing ttl is a
+			// real literal-bearing payload here — the one decode shape that
+			// quotes provider-chosen bytes back in full.
 			name: "cloudflare_decode_records",
 			stages: []stagedResponse{
 				{http.StatusOK, `{"success":true,"errors":[],` +
 					`"result":[{"id":"ZONEID1","name":"example.net"}]}`},
-				{http.StatusOK, `{"success":true,"errors":[],"result":` + decodeSentinel + `}`},
+				{http.StatusOK, `{"success":true,"errors":[],"result":` +
+					`[{"id":"a","type":"A","name":"n","content":"c","ttl":` + decodeSentinel + `}]}`},
 			},
 			run:        runCloudflare,
 			wantServed: 2,
 			sentinel:   decodeSentinel,
+			wantMarker: string(transportWithheld),
 		},
 		{
-			// Cloudflare do(): the envelope itself does not decode.
+			// Cloudflare do(): the ENVELOPE decode. result_info.page is an int, so
+			// an overflowing page is a literal-bearing payload — this is the
+			// issue's own reproduction, reproduced rather than taken on trust.
 			name: "cloudflare_decode_response",
 			stages: []stagedResponse{
-				{http.StatusOK, `{"success":true,"errors":[],"result":` + decodeSentinel},
+				{http.StatusOK, `{"success":true,"errors":[],"result":[],` +
+					`"result_info":{"page":` + decodeSentinel + `}}`},
 			},
 			run:        runCloudflare,
 			wantServed: 1,
 			sentinel:   decodeSentinel,
+			wantMarker: string(transportWithheld),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -587,10 +623,17 @@ func TestProviderResponseTextSecondSurfaces_6634(t *testing.T) {
 					"assertion below would be vacuous")
 			}
 			msg := err.Error()
-			if strings.Contains(msg, tc.sentinel) {
+			if tc.sentinel != "" && strings.Contains(msg, tc.sentinel) {
 				t.Errorf("provider-chosen bytes reached the returned error:\n  error = %s\n"+
 					"Render provider text through scrubProviderText, and a decoder's own error "+
 					"through scrubInnerError.", msg)
+			}
+			// WHAT IT BECAME. This is the assertion that binds the RENDER rather
+			// than the payload, and it is what catches a site restored to a raw
+			// render whose particular error text happens to carry no literal.
+			if !strings.Contains(msg, tc.wantMarker) {
+				t.Errorf("the render must go through the scrubber, observable as %q in the "+
+					"message; got:\n  %s", tc.wantMarker, msg)
 			}
 			if len(msg) > maxProviderTextBytes+256 {
 				t.Errorf("the error is %d bytes; a provider-chosen render must stay O(%d), "+

--- a/pkg/ddns/url_render_class_6545_test.go
+++ b/pkg/ddns/url_render_class_6545_test.go
@@ -1023,6 +1023,12 @@ var urlErrorProducers = map[string]bool{
 	// chooses that string outright. It rendered with %w at
 	// backend_route53.go:203.
 	"xml.Unmarshal": true,
+	// json.Unmarshal was the gap at #6634, and it is FILE-SCOPED — see
+	// producerFileScope below. Go's JSON decoder quotes the offending input
+	// back ("json: cannot unmarshal number 9876543210… into Go struct field"),
+	// and the Cloudflare backend decodes a PROVIDER-CHOSEN response body, so
+	// that string is attacker-selected. Three sites rendered it with %w.
+	"json.Unmarshal": true,
 	// readCappedBody was the gap this list had at round 10. doRequest has TWO
 	// adjacent error returns; .Do covered the first, and the second — four
 	// lines below it — rendered readCappedBody's error with %w and no producer
@@ -1110,7 +1116,7 @@ func TestDDNSURLErrorRendersGoThroughScrubber(t *testing.T) {
 			}
 			aliases := importAliases(file)
 			ast.Inspect(fn.Body, func(n ast.Node) bool {
-				for _, site := range urlErrorHandlers(n, aliases) {
+				for _, site := range urlErrorHandlers(n, name, aliases) {
 					sites++
 					bad := unscrubbedUses(fset, site.stmts, site.errVar, aliases)
 					if len(bad) > 0 && name == issue6606Exemption.file &&
@@ -1270,13 +1276,13 @@ type handlerSite struct {
 //	if err != nil { return fmt.Errorf("...: %w", err) }
 //
 // from reading as a leak.
-func urlErrorHandlers(n ast.Node, aliases map[string]string) []handlerSite {
+func urlErrorHandlers(n ast.Node, file string, aliases map[string]string) []handlerSite {
 	switch node := n.(type) {
 	case *ast.BlockStmt:
 		// Shape 1: the assignment is a preceding statement in the same block.
 		var sites []handlerSite
 		for i := 0; i+1 < len(node.List); i++ {
-			errVar, producer := producedErrVar(node.List[i], aliases)
+			errVar, producer := producedErrVar(node.List[i], file, aliases)
 			if errVar == "" {
 				continue
 			}
@@ -1297,7 +1303,7 @@ func urlErrorHandlers(n ast.Node, aliases map[string]string) []handlerSite {
 		if node.Init == nil {
 			return nil
 		}
-		errVar, producer := producedErrVar(node.Init, aliases)
+		errVar, producer := producedErrVar(node.Init, file, aliases)
 		if errVar == "" || !testsErrVar(node.Cond, errVar) {
 			return nil
 		}
@@ -1306,9 +1312,34 @@ func urlErrorHandlers(n ast.Node, aliases map[string]string) []handlerSite {
 	return nil
 }
 
+// producerFileScope narrows a producer to the files where its error can carry
+// FOREIGN bytes. Only json.Unmarshal needs it, and the scope is a PREDICATE, not
+// a list of sites: an entry naming individual files would go stale the moment a
+// backend was added, and would fail OPEN in exactly the direction that matters.
+//
+// json.Unmarshal decodes two completely different things in this package. In a
+// `backend_*.go` file it decodes a PROVIDER RESPONSE BODY, so the decoder quotes
+// bytes an untrusted party chose. In state.go it decodes the ownership state
+// file this daemon wrote itself, at a root-owned path — an attacker who can
+// choose those bytes already has root, and the decoder's detail ("invalid
+// character '}' after object key") is the whole diagnostic an operator gets when
+// repairing a corrupt store. Scrubbing that would cost a real capability and
+// close nothing.
+//
+// This is a SCOPE, not an exemption: it says where a call can carry foreign
+// input, not that a known-unsafe site is tolerated. Any NEW backend file is
+// covered automatically, which is the direction a scope has to fail.
+// TestProviderDecodeScopeIsLoadBearing_6634 pins both halves.
+func producerFileScope(callee, file string) bool {
+	if callee == "json.Unmarshal" {
+		return strings.HasPrefix(file, "backend_")
+	}
+	return true
+}
+
 // producedErrVar returns the name of the error variable assigned from a
 // URL-bearing call, or "" if the statement is not such an assignment.
-func producedErrVar(stmt ast.Stmt, aliases map[string]string) (errVar, producer string) {
+func producedErrVar(stmt ast.Stmt, file string, aliases map[string]string) (errVar, producer string) {
 	assign, isAssign := stmt.(*ast.AssignStmt)
 	if !isAssign || len(assign.Rhs) != 1 || len(assign.Lhs) == 0 {
 		return "", ""
@@ -1318,7 +1349,7 @@ func producedErrVar(stmt ast.Stmt, aliases map[string]string) (errVar, producer 
 		return "", ""
 	}
 	callee := calleeName(call.Fun, aliases)
-	if !urlErrorProducers[callee] {
+	if !urlErrorProducers[callee] || !producerFileScope(callee, file) {
 		return "", ""
 	}
 	last, isIdent := assign.Lhs[len(assign.Lhs)-1].(*ast.Ident)


### PR DESCRIPTION
Closes #6634

## The issue's framing needed one correction, and it changed the fix

Four backends render provider **response body** text into an error the daemon logs and retains as the provider's `lastErr`. The issue proposes an escape/filter; before writing one I established **where the text actually lands**, and two thirds of the surface turned out to be closed already — elsewhere, by work that predates this issue.

| sink | state | by what |
|---|---|---|
| operator terminal (`show services ddns`) | **already closed** | `termsafe.SanitizeForDisplay` on BOTH surfaces — `pkg/cli/show_services_ddns.go:104`, `pkg/grpcapi/server_show_dhcp_lldp_snmp.go:421` (#6468, whose own source comment names these exact render sites) |
| journal | **already closed for control characters** | `cmd/xpfd/main.go:486` installs `slog.NewTextHandler`, which `strconv.Quote`s any value carrying a byte outside printable ASCII — an embedded newline cannot split a log line |
| journal + retained `lastErr` | **OPEN** | a **credential** in the bytes, and **64 KiB** of them (`readCappedBody` admits `httpMaxResponseBody`), on every reconcile tick of a persistent failure |

So this PR is a **bound plus a shape filter**, not an escape. Adding escaping would have been a third layer over two that already work.

## The render sites — the issue's list is a floor, so every backend was checked

Fixed: `cfErrors` (`backend_cloudflare.go`), three Cloudflare `json.Unmarshal` sites, Route 53's `Code`/`Message` in **both** `listRRSet` and `change`, dyndns2 `:275`, DuckDNS `:249`.

Confirmed NOT affected: generic (renders `b.okTokens`, our own config, never the body), rfc2136 (`dns.RcodeToString` map + `fmt.Sprintf("rcode%d")`, both bounded), checkip (renders no body text on any path), bind.

DuckDNS makes the threat concrete rather than theoretical: `base.Set("token", b.token)` puts the token in the **query string** of the update URL, so a provider that echoes the request back echoes the token itself. No hostile transport needed.

## `scrubProviderText` — total on one axis, partial on another, and it says which

1. **LENGTH — a proof.** Nothing provider-chosen exceeds `maxProviderTextBytes` plus a fixed `[truncated]` marker. The Cloudflare envelope additionally bounds the **count**: a per-message cap is not a bound when the provider picks how many messages the array carries.
2. **URL/USERINFO SHAPES.** A whitespace-delimited token carrying `://`, a userinfo-shaped `user:pass@host`, or a `%XX` escape is replaced whole. Narrow enough that `contact support@example.com` and `80% of quota` pass through unchanged.
3. **NOT a proof against a provider that wants to leak.** A credential echoed as bare prose is indistinguishable from a word. That residual is stated in the code, the README and here rather than papered over — withholding provider text wholesale costs the operator their single most useful diagnostic and does not close that case either.

**Filter, then bound.** The other order splits a URL at the cap and leaves `https://user:PA` rendered.

## Two deliberate non-changes

- **Route 53's RETURNED code/message stay raw.** `r53DeleteAlreadyGone` (`backend_route53.go:469`) classifies delete-idempotency on that text. Scrubbing the value would change a **control decision**, not a log line — a withheld token turns an idempotent delete into a permanent retry. Only the render goes through the scrubber.
- **The code-mapping option (the issue's preference) was not taken.** It gives a closed output only for codes we already know, and the unmapped case is exactly the one an operator is debugging. The Cloudflare **decode** sites are the exception and follow the existing Route 53 XML precedent instead — a decoder's own text has no diagnostic worth preserving, so it is withheld outright via `scrubInnerError`.

## The class gate gains `json.Unmarshal`, file-scoped

That call decodes two different things here: a **provider response body** in a `backend_*.go` file, and this daemon's **own ownership state file** in `state.go`, at a root-owned path, where the decoder's detail is the whole diagnostic for repairing a corrupt store. `producerFileScope` is a **predicate, not a list of sites**, so any new backend file is covered automatically — the direction a scope has to fail.

This is a **scope, not an exemption** — it says where a call can carry foreign input, not that a known-unsafe site is tolerated. #6606 (PR #7366, already merged into this branch) removed the last exemption from this gate; nothing is re-added. `TestProviderDecodeScopeIsLoadBearing_6634` pins both halves and re-walks `state.go` under a lied-about filename to prove the scope actually excludes a site that would otherwise fail the gate.

## The tests are end-to-end on purpose

Every cell drives the **real backend through a real `httptest` server** and asserts the request was **SERVED** before asserting anything about the message. A unit test on the scrubber alone passes whether or not any backend calls it, and "the credential is absent" is satisfied just as well by an input that never arrived.

A **staged provider** covers the second surface of each two-call backend. A fake that answers everything with an error never gets past Route 53's `listRRSet` or Cloudflare's `do()`, so `change()` and two of the three decode sites would have been "covered" by cells that never executed them — which is exactly the one-of-N-surfaces failure this issue exists to avoid. Each staged cell asserts the request **count**.

**Two mutations initially did not red, and the defect was in the test.** Measured against Go's decoder rather than assumed:

```
number into a slice              -> "cannot unmarshal number into Go value of type []ddns.cfZone"
number OVERFLOWING an int field  -> "cannot unmarshal number 98765…7890 into Go struct field cfRecord.ttl of type int"
syntax error                     -> "invalid character '9' looking for beginning of object key string"
```

The literal is quoted in exactly **one** case. So the envelope cell now overflows `result_info.page` (the issue's own repro, reproduced rather than trusted), the records cell overflows `cfRecord.ttl`, and the zones cell carries **no sentinel at all** — `cfZone` has only string fields, so no provider-chosen literal can reach that error and the scrub there is uniformity, not a closed leak. Every decode cell also asserts what the message **became**, which binds the render rather than the payload.

## Validation

`go build ./...`, `go vet ./...` clean. `go test -count=1` green for `./pkg/ddns/`, `./pkg/daemon/`, `./pkg/config/`, `./pkg/cli/`, `./pkg/grpcapi/`. `origin/master` merged in (not rebased) and everything re-verified at the merged head.

**Mutation matrix — 14 one-line mutations, re-run at the merged head. All 14 red. `go vet ./pkg/ddns/` rc=0 at every mutated state, `-count=1` throughout, rc read from `$?` directly, tree confirmed clean after each restore, rc back to 0 at the end.**

| # | one-line mutation | what reds |
|---|---|---|
| M1 | `cfErrors` renders `e.Message` raw | leak/cloudflare_envelope_message + bound/cloudflare |
| M2 | `shown = shown[:len(shown)]` (drop the count cap) | `TestCloudflareErrorCountIsBounded_6634` |
| M3 | `do()` decode renders `err` | leak/cloudflare_decode_error + second/cloudflare_decode_response |
| M4 | `resolveZoneID` decode renders `err` | second/cloudflare_decode_zones |
| M5 | `listRecords` decode renders `err` | second/cloudflare_decode_records |
| M6 | `listRRSet` renders Code/Message raw | leak/route53 + bound/route53 |
| M7 | `change()` renders Code/Message raw | second/route53_change_error_message |
| M8 | dyndns2 renders `first` raw | leak/dyndns2 + bound/dyndns2 |
| M9 | DuckDNS renders `first` raw | leak/duckdns + bound/duckdns |
| M10 | drop the truncation cut | all four bound cells |
| M11 | disable the `://` rule | 5 e2e cells + rules/scheme_separator_only |
| M12 | disable the userinfo rule | rules/userinfo_only_no_scheme |
| M13 | disable the `%XX` rule | rules/percent_encoded_only |
| M14 | `producerFileScope` returns `true` | `TestDDNSURLErrorRendersGoThroughScrubber` + `TestProviderDecodeScopeIsLoadBearing_6634` |

M11-M13 exist because the end-to-end echo URL trips two rules at once, which is realistic but useless for localisation — a per-rule table makes each mutation name the rule it broke.

Production call path for every fixed site: Surface A reconcile → `surface_a.go:605 newSurfaceABackend` → the backend's `UpsertLease`/`DeleteLease` → the render → `slog.Warn(..., "err", err)` and `rt.lastErr` (`surface_a.go:1153`, `:1955`).

**Does not reach the Rust helper binary.** Go control plane only; no `.o` movement, no shim ABI change, no cluster smoke owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cz2czGK3aA5MsMhkNkjHXX
