### PR TITLE
upgrade: make a kernel-promote gate refusal survive the boot (#6622)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,49 @@
+## 2026-08-21 — #6622 kernel promote gate: a refusal now leaves a durable record
+
+- **Timestamp**: 2026-08-21
+- **Action**: The boot gate exits 0 on every path (deliberately — a non-zero
+  exit trips the unit's `OnFailure=` and reboots the box over what may be a
+  transient packaging window) and the unit is `Type=oneshot` +
+  `RemainAfterExit=yes`, so `systemctl status xpf-kernel-promote` read SUCCESS
+  and stayed active even when the gate REFUSED and the armed candidate was
+  running unverified. The only signal was a journald line, which journal
+  rotation removes.
+
+  `refuse()` now writes `/var/lib/xpf/kernel-promote-refusal`, one `key=value`
+  per line, carrying the discovery-snapshot facts the DECISION was made on
+  (`LoadState`, `MainPID`, `ControlGroup`, raw `ExecStart`), the journal bit,
+  the cause, the branch-specific advice, a timestamp and the boot id. Read by
+  `upgrade.ReadRefusalRecord` and surfaced through `ChannelStatus` /
+  `RenderChannelStatus`, so `show system kernel-upgrade`, the console CLI, the
+  remote `cli` and the status RPC all get it without touching `pkg/cli` or
+  `pkg/grpcapi`. The unit still exits 0 and still does not trip `OnFailure=`;
+  a test asserts that rather than assuming it.
+
+  The indeterminate-journal WARNING writes one too, as
+  `disposition=indeterminate`. That is what makes the record's ABSENCE
+  meaningful: if only `refuse()` wrote one, "no record" could not distinguish
+  a clean boot from a boot the gate skipped for the other reason. The quiet
+  "nothing to promote" branch and the post-exec `rc` paths deliberately write
+  nothing — the first is the ordinary boot, the second is where the Go half
+  already owns the durable state.
+
+  The record does NOT duplicate the candidate version: the gate reads the JSON
+  journal for one bit and never for a value, so the candidate is joined in Go
+  by `ReadChannelStatus`, which is accurate because a refusal never transitions
+  the journal.
+
+  Tightened `ReadRefusalRecord` while writing its test: counting `=`-bearing
+  lines rather than RECOGNISED keys let a file whose only fields are unknown
+  parse as a refusal with every field empty, rendering a REFUSED banner made
+  entirely of dashes. The first draft of the test could not see it — its own
+  fixture text contained the literal "key=value".
+- **File(s)**: `scripts/image/xpf-kernel-promote`,
+  `scripts/image/test_kernel_promote_explicit_path.py`,
+  `pkg/upgrade/kernel_promote_refusal.go` (new),
+  `pkg/upgrade/kernel_promote_refusal_6622_test.go` (new),
+  `pkg/upgrade/kernel_status.go`, `pkg/upgrade/kernel_run.go`,
+  `pkg/upgrade/kernel_arm_record.go`, `docs/in-place-upgrade.md`, `_Log.md`
+
 ## 2026-08-21 — #6618 `any-service` protocol breadth: decided KEEP, bound by a verdict lock
 
 - **Timestamp**: 2026-08-21

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -1296,10 +1296,77 @@ window, whereas an un-promoted candidate is already safe — the firmware
 cleared `BootNext`, so the next plain reboot falls back to the known-good
 slot.
 
-**The refusal carries the facts, not just the policy.** Because `exit 0`
-keeps the unit `active` — `systemctl status xpf-kernel-promote` reads
-SUCCESS — that journal line is the *only* operator-visible signal, so it
-echoes what systemd actually returned (`LoadState=[…] MainPID=[…]
+**A refusal leaves a durable record (#6622).** `exit 0` keeps the unit
+`active` and `systemctl status xpf-kernel-promote` reads SUCCESS, so
+before this the journal line was the only signal — and journal rotation
+takes it away. An operator who armed a candidate, rebooted and came back
+later saw a box running the old kernel and a promote unit reporting
+success, with nothing saying the gate had declined or why.
+
+That mattered more after the refusal became a real outcome rather than a
+theoretical one: this gate used to fall back to a compiled default and
+would usually run *something*. **A state that is now reachable needs to
+be observable.**
+
+The gate therefore writes `/var/lib/xpf/kernel-promote-refusal`, beside
+the journal and the arm record and sharing their lifetime — it is
+removed with the journal and rewritten by the next arm, so a refusal can
+never be read as a verdict on a candidate that is no longer in flight.
+`show system kernel-upgrade`, the console CLI and the remote `cli` all
+render it through `upgrade.RenderChannelStatus`, and the status RPC
+reads it through `upgrade.ReadChannelStatus`.
+
+- **The unit still exits 0 and still does not trip `OnFailure=`.** That
+  was deliberately avoided as the fix, and a test asserts it rather than
+  assuming it.
+- **Written only where the gate never ran `xpfd` at all**: every
+  `refuse()`, plus the indeterminate-journal `WARNING`. Including the
+  second is what makes the record's *absence* meaningful — if only
+  `refuse()` wrote one, "no record" could not distinguish a clean boot
+  from a boot the gate skipped for the other reason. It is **not**
+  written by the quiet `nothing to promote` branch (that is the ordinary
+  boot, and a file rewritten every boot buries the signal it carries) nor
+  by the post-exec `rc` paths (there the gate *did* run `xpfd`, and the
+  Go half owns the journal, the promotion marker and the last-roll
+  record for those — a second writer would be a second source).
+- **It carries the resolution facts** — the `LoadState`, `MainPID`,
+  `ControlGroup` and raw `ExecStart` from the discovery snapshot the
+  decision was made on, plus the journal bit, the cause, the
+  branch-specific advice, a timestamp and the boot id. The status
+  surface renders the snapshot rather than re-querying systemd: a
+  re-query days later would describe a different system.
+- **The boot id earns its place** because an early-boot clock can be
+  wrong — no RTC, no NTP yet — so the timestamp alone cannot answer *was
+  this THIS boot?*.
+- **It does not duplicate the candidate version**, and that is a design
+  choice rather than a gap. The gate is POSIX `sh` and the journal is
+  JSON, so it reads that file for **one bit and never for a value**. The
+  candidate is joined in by `ReadChannelStatus`, which has already
+  parsed the journal in Go — and it is still accurate, because a refusal
+  never transitions the journal, so the record and the `ARMED` candidate
+  it declined are read from one consistent state.
+- **Best-effort, always.** Every step of the write is suppressed and the
+  writer always returns success. This runs on a candidate boot whose
+  whole problem may be that the filesystem is not what the gate expected,
+  and a gate that changed its exit path because it could not write a
+  *diagnostic* would convert an observability gap into an availability
+  one. A test plants a directory where the record goes and asserts the
+  exit path is unchanged.
+- **One line per field, `key=value`.** POSIX `sh` writes it and Go reads
+  it, so the same *a value may legally contain the delimiter* hazard as
+  the `ExecStart` parse applies in reverse: a systemd rendering can
+  legally contain newlines (multiple entries render one per line), and an
+  unflattened value would forge extra fields. Values are flattened; Go
+  splits on the **first** `=` so a value containing one survives; unknown
+  keys are ignored so a newer gate can add fields. A record present but
+  carrying no *recognised* field is an **error**, never a silent "no
+  refusal" — the same rule `ReadArmRecord` applies, for the same reason:
+  "absent" is acted on as a positive statement. The path is pinned
+  against Go by `TestPromoteScriptRefusalRecordPathMatchesGo_6622`.
+
+**The refusal message carries the facts too, not just the policy.** The
+journal line remains the immediate signal, so it echoes what systemd
+actually returned (`LoadState=[…] MainPID=[…]
 ControlGroup=[…] ExecStart=[…]`) and branches its advice on which cause
 fired — `systemctl` unreachable, unit not-found, or unit known — because
 telling an operator to fix `ExecStart` when `systemctl` could not be

--- a/pkg/upgrade/kernel_arm_record.go
+++ b/pkg/upgrade/kernel_arm_record.go
@@ -86,6 +86,18 @@ func (r *KernelRunner) recordPromoteBinary(j *KernelJournal) error {
 		return fmt.Errorf("%w: persist arm record %s: %v",
 			ErrKernelPromoteBinaryUnresolvable, path, err)
 	}
+	// A refusal from a PRIOR candidate must not be read as a verdict on this
+	// one (#6622). Cleared here, at the point the new arm record is written,
+	// rather than at the top of Arm: an arm that fails preflight leaves the
+	// previous refusal intact, which is what an operator diagnosing that
+	// failure needs on screen.
+	//
+	// Best-effort. Failing to remove a diagnostic must not refuse an arm that
+	// has already passed preflight and installed a candidate — the fail-closed
+	// rule above is about the arm RECORD, whose absence would strand the
+	// candidate unverifiable, and a stale refusal costs only a confusing line
+	// that carries its own timestamp and boot id.
+	_ = r.clearRefusalRecord()
 	return nil
 }
 

--- a/pkg/upgrade/kernel_promote_refusal.go
+++ b/pkg/upgrade/kernel_promote_refusal.go
@@ -1,0 +1,244 @@
+package upgrade
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ── the boot gate's refusal leaves a durable trace (#6622) ──────────────
+//
+// scripts/image/xpf-kernel-promote exits 0 on EVERY path, deliberately: a
+// non-zero exit trips the unit's OnFailure= and reboots the box over what may
+// be a transient packaging window, and the firmware has already cleared
+// BootNext so the next plain reboot falls back to known-good on its own.
+//
+// The cost of that correct decision is that the unit is Type=oneshot with
+// RemainAfterExit=yes, so `systemctl status xpf-kernel-promote` reads SUCCESS
+// and the unit stays active even when the gate REFUSED and the armed candidate
+// is running unverified. Before this, the only signal was a journald line —
+// time-limited by journal rotation. An operator who armed a candidate,
+// rebooted, and came back later saw a box running the old kernel and a promote
+// unit reporting success, with nothing that said the gate declined or why.
+//
+// #6601 is what made this worth fixing rather than theoretical: it converted
+// "maybe run a stale binary" into "refuse", which is the right trade, but it
+// also made refusal a REACHABLE outcome rather than a hypothetical one. A state
+// that is now reachable needs to be observable.
+//
+// WHAT THIS DELIBERATELY DOES NOT DO. It does not make the unit fail. That was
+// avoided on purpose so a refusal cannot cascade into an OnFailure= chain
+// during boot, and nothing here changes it.
+
+// refusalRecordName is the sidecar the boot gate writes when it declines to
+// run. It lives beside the journal and the arm record so all three share one
+// directory and one lifetime.
+const refusalRecordName = "kernel-promote-refusal"
+
+// RefusalRecordPath returns the refusal-record path for a given kernel journal
+// path, exactly as ArmRecordPath does for the arm record.
+func RefusalRecordPath(journalPath string) string {
+	return filepath.Join(filepath.Dir(journalPath), refusalRecordName)
+}
+
+// refusalTimeLayout is what the gate's `date -u` writes.
+const refusalTimeLayout = "2006-01-02T15:04:05Z"
+
+// PromoteRefusal is the parsed record. It answers the question an operator
+// actually has — "the gate did not promote my candidate; why?" — with the facts
+// the DECISION was made on rather than a re-read of current state.
+type PromoteRefusal struct {
+	// Recorded is false when no record exists, which is the ordinary case: the
+	// gate writes one only on the paths where it never ran xpfd at all.
+	Recorded bool
+
+	// Disposition is "refused" (a loud decline) or "indeterminate" (the journal
+	// could not be read, so the gate could not establish whether anything was
+	// armed). They are different events and are not folded together: a refusal
+	// names a condition the operator can fix, an indeterminate says the gate
+	// could not even tell.
+	Disposition string
+
+	// At is the gate's timestamp, zero when absent or unparseable. AtRaw keeps
+	// the original text so an unparseable value is still shown rather than
+	// silently becoming "no time" — a wrong clock is itself a finding.
+	At    time.Time
+	AtRaw string
+
+	// BootID is /proc/sys/kernel/random/boot_id at the time of the refusal.
+	// An early-boot clock can be wrong (no RTC, no NTP yet), so the timestamp
+	// alone cannot answer "was this THIS boot?". This can.
+	BootID string
+
+	// JournalState is the one bit the gate reads out of the journal: absent,
+	// not-armed, armed, or indeterminate.
+	JournalState string
+
+	// The systemd discovery snapshot the decision was made on. Not re-read
+	// here: the whole point of #6601 r7's snapshot is that what is reported is
+	// what was decided on, and a status command re-querying systemd days later
+	// would describe a different system.
+	Unit         string
+	LoadState    string
+	MainPID      string
+	ControlGroup string
+	ExecStart    string
+
+	// Reason is what happened; Cause is the gate's diagnosis; Advice is the
+	// branch-specific next step. Kept as three fields because the gate branches
+	// its advice, and flattening them would lose which branch it took.
+	Reason string
+	Cause  string
+	Advice string
+}
+
+// ReadRefusalRecord parses the record beside journalPath.
+//
+// An absent record returns a zero PromoteRefusal and a NIL error: "the gate did
+// not decline" is the overwhelmingly common state and must not read as a
+// failure. Anything else — unreadable, or present but with no recognisable
+// fields — is an ERROR, never a silent empty answer, for the same reason
+// ReadArmRecord treats a malformed record as an error: "absent" is acted on as
+// a positive statement, so it must not be reachable by mis-parsing a file that
+// is present.
+//
+// Unknown keys are ignored so a newer gate can add fields without breaking an
+// older reader. The value is split on the FIRST '=' only, because a systemd
+// ExecStart rendering contains several.
+func ReadRefusalRecord(journalPath string) (PromoteRefusal, error) {
+	path := RefusalRecordPath(journalPath)
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return PromoteRefusal{}, nil
+		}
+		return PromoteRefusal{}, fmt.Errorf("read promote-refusal record %s: %w", path, err)
+	}
+	defer f.Close()
+
+	rec := PromoteRefusal{}
+	seen := 0
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimRight(sc.Text(), "\r")
+		if line == "" {
+			continue
+		}
+		key, val, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		// Counted per RECOGNISED key, not per '='-bearing line. Counting the
+		// latter would let any file that happens to contain one '=' parse as a
+		// refusal with every field empty, which renders as a REFUSED banner
+		// made entirely of dashes — worse than the error it displaced.
+		// Unknown keys are still tolerated, so a newer gate adding fields keeps
+		// working with an older reader: it emits the recognised ones too.
+		switch key {
+		case "disposition":
+			rec.Disposition = val
+		case "refused_at":
+			rec.AtRaw = val
+			if t, terr := time.Parse(refusalTimeLayout, val); terr == nil {
+				rec.At = t
+			}
+		case "boot_id":
+			rec.BootID = val
+		case "journal_state":
+			rec.JournalState = val
+		case "unit":
+			rec.Unit = val
+		case "load_state":
+			rec.LoadState = val
+		case "main_pid":
+			rec.MainPID = val
+		case "control_group":
+			rec.ControlGroup = val
+		case "exec_start":
+			rec.ExecStart = val
+		case "reason":
+			rec.Reason = val
+		case "cause":
+			rec.Cause = val
+		case "advice":
+			rec.Advice = val
+		default:
+			continue
+		}
+		seen++
+	}
+	if serr := sc.Err(); serr != nil {
+		return PromoteRefusal{}, fmt.Errorf("read promote-refusal record %s: %w", path, serr)
+	}
+	if seen == 0 {
+		return PromoteRefusal{}, fmt.Errorf("promote-refusal record %s is present but "+
+			"carries no recognised fields; refusing to report it as 'no refusal'", path)
+	}
+	rec.Recorded = true
+	if rec.Disposition == "" {
+		rec.Disposition = "refused"
+	}
+	return rec, nil
+}
+
+// clearRefusalRecord removes the record. Called wherever the arm record is
+// cleared, so the two share a lifetime: a refusal describes a specific armed
+// candidate, and one that outlived its journal would accuse the next boot of a
+// decline that happened to a candidate no longer in flight.
+func (r *KernelRunner) clearRefusalRecord() error {
+	if err := os.Remove(RefusalRecordPath(r.cfg.JournalPath)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove promote-refusal record: %w", err)
+	}
+	return nil
+}
+
+// renderRefusal writes the operator-facing rendering. Split out of
+// RenderChannelStatus so the record can be asserted on directly.
+//
+// It renders on EVERY disposition rather than only "refused": an indeterminate
+// is also a boot where the gate did not run, and an operator told nothing there
+// is in exactly the position this issue is about.
+func renderRefusal(w io.Writer, rec PromoteRefusal) {
+	if !rec.Recorded {
+		return
+	}
+	fmt.Fprintln(w, "")
+	switch rec.Disposition {
+	case "indeterminate":
+		fmt.Fprintln(w, "  Promotion gate: did NOT run — the channel state could not be read")
+	default:
+		fmt.Fprintln(w, "  Promotion gate: REFUSED to promote on a previous boot")
+	}
+	when := rec.AtRaw
+	if when == "" {
+		when = "-"
+	}
+	fmt.Fprintf(w, "    At:            %s\n", when)
+	if rec.BootID != "" {
+		fmt.Fprintf(w, "    Boot ID:       %s\n", rec.BootID)
+	}
+	if rec.JournalState != "" {
+		fmt.Fprintf(w, "    Journal state: %s\n", rec.JournalState)
+	}
+	if rec.Reason != "" {
+		fmt.Fprintf(w, "    Reason:        %s\n", rec.Reason)
+	}
+	if rec.Cause != "" {
+		fmt.Fprintf(w, "    Cause:         %s\n", rec.Cause)
+	}
+	// The resolution facts the decision was made on. Printed even when empty
+	// so "systemctl answered nothing" is visible as such rather than as a
+	// missing line the reader has to notice the absence of.
+	fmt.Fprintf(w, "    Unit:          %s\n", dashIfEmpty(rec.Unit))
+	fmt.Fprintf(w, "      LoadState:   %s\n", dashIfEmpty(rec.LoadState))
+	fmt.Fprintf(w, "      MainPID:     %s\n", dashIfEmpty(rec.MainPID))
+	fmt.Fprintf(w, "      ControlGroup:%s\n", " "+dashIfEmpty(rec.ControlGroup))
+	fmt.Fprintf(w, "      ExecStart:   %s\n", dashIfEmpty(rec.ExecStart))
+	if rec.Advice != "" {
+		fmt.Fprintf(w, "    Next step:     %s\n", rec.Advice)
+	}
+}

--- a/pkg/upgrade/kernel_promote_refusal_6622_test.go
+++ b/pkg/upgrade/kernel_promote_refusal_6622_test.go
@@ -1,0 +1,349 @@
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// #6622: a kernel-promote gate refusal left no durable record.
+//
+// The gate exits 0 on every path (deliberately — a non-zero exit trips
+// OnFailure= and reboots the box over what may be a transient packaging
+// window), and the unit is Type=oneshot with RemainAfterExit=yes. So
+// `systemctl status xpf-kernel-promote` reads SUCCESS and stays active even
+// when the gate REFUSED and the armed candidate is running unverified. The only
+// signal was a journald line, time-limited by rotation.
+//
+// #6601 is what made it worth closing: it converted "maybe run a stale binary"
+// into "refuse", which is right, but it made refusal a REACHABLE outcome rather
+// than a hypothetical one.
+//
+// FAIL-ON-REVERT: delete the record_refusal call from the gate's refuse() and
+// the python harness's refusal-record tests fail; delete the ReadRefusalRecord
+// call from ReadChannelStatus and TestChannelStatusSurfacesTheRefusal_6622
+// fails as an assertion.
+
+var refusalRecordPathRE = regexp.MustCompile(`(?m)^REFUSAL_RECORD="([^"]+)"`)
+
+// TestPromoteScriptRefusalRecordPathMatchesGo is the CROSS-LANGUAGE canary,
+// the sibling of TestPromoteScriptArmRecordPathMatchesGo.
+//
+// The gate is POSIX sh and hardcodes the path; Go derives it from the journal
+// path. If they drift, the gate writes a record nothing reads and
+// `show system kernel-upgrade` reports no refusal on a box that refused —
+// which is the exact failure this issue is about, reintroduced through the
+// back door.
+func TestPromoteScriptRefusalRecordPathMatchesGo_6622(t *testing.T) {
+	data, err := os.ReadFile(promoteScriptPath(t))
+	if err != nil {
+		t.Fatalf("read promote script: %v", err)
+	}
+	m := refusalRecordPathRE.FindSubmatch(data)
+	if m == nil {
+		t.Fatal(`no REFUSAL_RECORD="..." assignment in the promote script; the ` +
+			"refusal record's location is no longer assertable from Go (#6622)")
+	}
+	got, want := string(m[1]), RefusalRecordPath(DefaultKernelJournalPath)
+	if got != want {
+		t.Fatalf("the gate writes its refusal record to %q but Go reads it from "+
+			"%q. A refusal would leave a trace nothing surfaces.", got, want)
+	}
+}
+
+// writeRefusal writes a record beside journal, the way the gate does.
+func writeRefusal(t *testing.T, journal, body string) string {
+	t.Helper()
+	p := RefusalRecordPath(journal)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write refusal record: %v", err)
+	}
+	return p
+}
+
+// TestReadRefusalRecordAbsentIsNotAnError: no record is the ordinary state.
+// Reporting it as an error would make every healthy box's status carry a
+// WARNING line, which trains an operator to ignore the line that matters.
+func TestReadRefusalRecordAbsentIsNotAnError_6622(t *testing.T) {
+	rec, err := ReadRefusalRecord(filepath.Join(t.TempDir(), "kernel-upgrade.state"))
+	if err != nil {
+		t.Fatalf("absent record reported an error: %v", err)
+	}
+	if rec.Recorded {
+		t.Fatal("absent record reported Recorded=true")
+	}
+}
+
+// TestReadRefusalRecordCarriesTheResolutionFacts is the issue's central
+// acceptance criterion: "the record carries the resolution facts, not just
+// 'refused'".
+//
+// The ExecStart value deliberately contains BOTH a '=' and a ';' — that is what
+// systemd's rendering looks like, and a parser that split on every '=' or
+// stopped at the first would mangle exactly the field an operator needs to see
+// to diagnose a stale unit.
+func TestReadRefusalRecordCarriesTheResolutionFacts_6622(t *testing.T) {
+	journal := filepath.Join(t.TempDir(), "kernel-upgrade.state")
+	execStart := "{ path=/opt/relocated live/xpfd ; argv[]=/opt/relocated live/xpfd ; ignore_errors=no }"
+	writeRefusal(t, journal, strings.Join([]string{
+		"version=1",
+		"disposition=refused",
+		"refused_at=2026-08-21T04:05:06Z",
+		"boot_id=1f2e3d4c-0000-1111-2222-333344445555",
+		"journal_state=armed",
+		"unit=xpfd.service",
+		"load_state=loaded",
+		"main_pid=0",
+		"control_group=/system.slice/xpfd.service",
+		"exec_start=" + execStart,
+		"reason=the arming recorded /a/xpfd but the unit resolves /b/xpfd",
+		"cause=xpfd.service IS known to systemd",
+		"advice=Fix xpfd.service so its ExecStart names the live xpfd",
+		"unknown_future_key=ignored",
+	}, "\n")+"\n")
+
+	rec, err := ReadRefusalRecord(journal)
+	if err != nil {
+		t.Fatalf("ReadRefusalRecord: %v", err)
+	}
+	if !rec.Recorded {
+		t.Fatal("a present record read as Recorded=false")
+	}
+	for _, tc := range []struct{ field, got, want string }{
+		{"Disposition", rec.Disposition, "refused"},
+		{"JournalState", rec.JournalState, "armed"},
+		{"Unit", rec.Unit, "xpfd.service"},
+		{"LoadState", rec.LoadState, "loaded"},
+		{"MainPID", rec.MainPID, "0"},
+		{"ControlGroup", rec.ControlGroup, "/system.slice/xpfd.service"},
+		{"ExecStart", rec.ExecStart, execStart},
+		{"BootID", rec.BootID, "1f2e3d4c-0000-1111-2222-333344445555"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.field, tc.got, tc.want)
+		}
+	}
+	if rec.At.IsZero() {
+		t.Errorf("refused_at %q did not parse; the record's timestamp is the "+
+			"thing that survives journal rotation", rec.AtRaw)
+	}
+	if rec.At.UTC().Format(refusalTimeLayout) != "2026-08-21T04:05:06Z" {
+		t.Errorf("At = %v, want 2026-08-21T04:05:06Z", rec.At)
+	}
+	if !strings.Contains(rec.Reason, "/b/xpfd") || rec.Cause == "" || rec.Advice == "" {
+		t.Errorf("reason/cause/advice not all populated: %+v", rec)
+	}
+}
+
+// TestReadRefusalRecordUnparseableTimeStillReports: an early-boot clock can be
+// wrong or unset, and a record whose timestamp cannot be parsed must still be
+// REPORTED. Dropping it would hide a refusal because of a clock — and the bad
+// clock is itself worth seeing.
+func TestReadRefusalRecordUnparseableTimeStillReports_6622(t *testing.T) {
+	journal := filepath.Join(t.TempDir(), "kernel-upgrade.state")
+	writeRefusal(t, journal, "disposition=refused\nrefused_at=not-a-time\nreason=x\n")
+
+	rec, err := ReadRefusalRecord(journal)
+	if err != nil {
+		t.Fatalf("ReadRefusalRecord: %v", err)
+	}
+	if !rec.Recorded {
+		t.Fatal("an unparseable timestamp suppressed the whole record")
+	}
+	if rec.AtRaw != "not-a-time" {
+		t.Errorf("AtRaw = %q, want the original text preserved", rec.AtRaw)
+	}
+	if !rec.At.IsZero() {
+		t.Errorf("At = %v, want zero for an unparseable value", rec.At)
+	}
+}
+
+// TestReadRefusalRecordFieldlessFileIsAnError: "absent" is acted on as a
+// positive statement ("the gate did not decline"), so it must not be reachable
+// by mis-parsing a file that is PRESENT. Same rule ReadArmRecord applies.
+//
+// Two shapes, because they fail differently. The first has no separator at all.
+// The second is the one that actually caught a defect while this was written:
+// a file whose only '=' lines carry keys the reader does not know. Counting
+// '='-bearing lines rather than RECOGNISED ones let that parse as a refusal
+// with every field empty, rendering a REFUSED banner made entirely of dashes —
+// worse than the error it displaced. (The first draft of this test could not
+// see it: its own fixture text contained the literal "key=value".)
+func TestReadRefusalRecordFieldlessFileIsAnError_6622(t *testing.T) {
+	for _, tc := range []struct{ name, body string }{
+		{"no separator at all", "this file has no recognisable fields\n"},
+		{"only unknown keys", "colour=blue\nshape=round\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			journal := filepath.Join(t.TempDir(), "kernel-upgrade.state")
+			writeRefusal(t, journal, tc.body)
+
+			rec, err := ReadRefusalRecord(journal)
+			if err == nil {
+				t.Fatalf("a present-but-unparseable record read as %+v with no "+
+					"error; a refusal would silently report as 'no refusal' (#6622)", rec)
+			}
+			if rec.Recorded {
+				t.Error("Recorded=true alongside an error")
+			}
+		})
+	}
+}
+
+// TestReadRefusalRecordToleratesUnknownKeysAlongsideKnownOnes is the
+// companion over-reach guard: the tightening above must reject a file with ONLY
+// unknown keys without rejecting a NEWER gate that adds fields to a record
+// still carrying the ones this reader knows.
+func TestReadRefusalRecordToleratesUnknownKeysAlongsideKnownOnes_6622(t *testing.T) {
+	journal := filepath.Join(t.TempDir(), "kernel-upgrade.state")
+	writeRefusal(t, journal,
+		"disposition=refused\nsome_field_from_a_newer_gate=x\nreason=y\n")
+
+	rec, err := ReadRefusalRecord(journal)
+	if err != nil {
+		t.Fatalf("a record carrying an unknown field alongside known ones was "+
+			"rejected: %v — an older reader must not refuse a newer gate's "+
+			"record", err)
+	}
+	if !rec.Recorded || rec.Reason != "y" {
+		t.Fatalf("known fields lost: %+v", rec)
+	}
+}
+
+// TestChannelStatusSurfacesTheRefusal is the WIRING assertion, and it is the
+// one that matters: the reader existing is worth nothing if the status surface
+// never calls it.
+//
+// `show system kernel-upgrade`, the console CLI and the remote `cli` all render
+// through RenderChannelStatus, and pkg/daemon's status RPC reads through
+// ReadChannelStatus, so asserting here covers all of them without this package
+// reaching into pkg/cli or pkg/grpcapi.
+func TestChannelStatusSurfacesTheRefusal_6622(t *testing.T) {
+	journal := filepath.Join(t.TempDir(), "kernel-upgrade.state")
+	writeRefusal(t, journal, strings.Join([]string{
+		"disposition=refused",
+		"refused_at=2026-08-21T04:05:06Z",
+		"journal_state=armed",
+		"unit=xpfd.service",
+		"load_state=not-found",
+		"main_pid=0",
+		"exec_start=",
+		"reason=the arm record is ABSENT but a candidate is ARMED",
+		"advice=Re-arm from the live xpfd",
+	}, "\n")+"\n")
+
+	st := ReadChannelStatus(journal, nil)
+	if st.ReadErr != nil {
+		t.Fatalf("ReadChannelStatus: %v", st.ReadErr)
+	}
+	if !st.Refusal.Recorded {
+		t.Fatal("ReadChannelStatus did not pick up the refusal record — the " +
+			"operator surface still reports nothing after a gate refusal (#6622)")
+	}
+
+	var b strings.Builder
+	RenderChannelStatus(&b, st)
+	out := b.String()
+	for _, want := range []string{
+		"REFUSED",
+		"2026-08-21T04:05:06Z",
+		"the arm record is ABSENT but a candidate is ARMED",
+		"not-found",
+		"Re-arm from the live xpfd",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered status omits %q — an operator reading it still "+
+				"cannot tell the gate declined or why.\n%s", want, out)
+		}
+	}
+	// A field systemd could not answer must render as "-" rather than as a
+	// blank an operator reads as "nothing wrong here".
+	if !strings.Contains(out, "ExecStart:   -") {
+		t.Errorf("an empty ExecStart did not render as '-':\n%s", out)
+	}
+}
+
+// TestChannelStatusDistinguishesIndeterminateFromRefused: they are different
+// events. A refusal names a condition the operator can fix; an indeterminate
+// says the gate could not even establish whether anything was armed. Folding
+// them would tell an operator to fix a unit when the problem is an unreadable
+// journal.
+func TestChannelStatusDistinguishesIndeterminateFromRefused_6622(t *testing.T) {
+	journal := filepath.Join(t.TempDir(), "kernel-upgrade.state")
+	writeRefusal(t, journal, "disposition=indeterminate\nreason=journal unreadable\n")
+
+	var b strings.Builder
+	RenderChannelStatus(&b, ReadChannelStatus(journal, nil))
+	out := b.String()
+	if strings.Contains(out, "REFUSED") {
+		t.Errorf("an indeterminate record rendered as a REFUSAL:\n%s", out)
+	}
+	if !strings.Contains(out, "did NOT run") {
+		t.Errorf("an indeterminate record did not say the gate did not run:\n%s", out)
+	}
+}
+
+// TestNoRefusalRendersNothing is the ANTI-NOISE control. The record is only
+// useful if a healthy box is silent about it — a status that always printed a
+// refusal section would teach an operator to skip it.
+func TestNoRefusalRendersNothing_6622(t *testing.T) {
+	var b strings.Builder
+	RenderChannelStatus(&b, ReadChannelStatus(filepath.Join(t.TempDir(), "k.state"), nil))
+	out := b.String()
+	for _, unwanted := range []string{"REFUSED", "Promotion gate:"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("a box with no refusal record printed %q:\n%s", unwanted, out)
+		}
+	}
+}
+
+// TestRefusalRecordSharesTheArmRecordsLifetime: a refusal describes a specific
+// armed candidate. One that outlived its journal would accuse the next boot of
+// a decline that happened to a candidate no longer in flight — the same reason
+// the arm record is cleared with the journal.
+func TestRefusalRecordSharesTheArmRecordsLifetime_6622(t *testing.T) {
+	f := newFakeKernelSystem()
+	r := newKernelRunner(t, f)
+	journal := r.cfg.JournalPath
+	if err := os.MkdirAll(filepath.Dir(journal), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := writeRefusal(t, journal, "disposition=refused\nreason=x\n")
+
+	if err := r.clearKernelJournal(); err != nil {
+		t.Fatalf("clearKernelJournal: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("the refusal record survived the journal clear (stat err %v). "+
+			"It would be reported against whatever is armed next.", err)
+	}
+}
+
+// TestArmingClearsAPriorRefusal: a refusal from a PRIOR candidate must not read
+// as a verdict on the one just armed.
+//
+// Cleared where the new arm record is WRITTEN rather than at the top of Arm, so
+// an arm that fails preflight leaves the previous refusal intact — which is
+// exactly what an operator diagnosing that failure needs on screen.
+func TestArmingClearsAPriorRefusal_6622(t *testing.T) {
+	f := newFakeKernelSystem()
+	r := newKernelRunner(t, f)
+	journal := r.cfg.JournalPath
+	if err := os.MkdirAll(filepath.Dir(journal), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := writeRefusal(t, journal, "disposition=refused\nreason=a prior candidate\n")
+
+	if err := r.Arm("6.18.5-12-generic"); err != nil {
+		t.Fatalf("Arm: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("a prior refusal survived a successful arm (stat err %v); it "+
+			"would be rendered against the candidate just armed", err)
+	}
+}

--- a/pkg/upgrade/kernel_run.go
+++ b/pkg/upgrade/kernel_run.go
@@ -58,6 +58,12 @@ func (r *KernelRunner) clearKernelJournal() error {
 	// gate treats an absent record as a definitive "nothing to promote", so a
 	// record surviving a cleared journal would make it refuse on every
 	// subsequent ordinary boot (#6601 r6).
+	// Same lifetime as the arm record (#6622): a refusal describes a specific
+	// armed candidate, so one that outlived its journal would accuse the next
+	// boot of a decline that happened to a candidate no longer in flight.
+	// Best-effort, and deliberately not fatal: failing to remove a DIAGNOSTIC
+	// must not fail the terminal transition that clears the journal.
+	_ = r.clearRefusalRecord()
 	if err := r.clearArmRecord(); err != nil {
 		return err
 	}

--- a/pkg/upgrade/kernel_status.go
+++ b/pkg/upgrade/kernel_status.go
@@ -56,6 +56,21 @@ type ChannelStatus struct {
 	// literal import cycle, since pkg/upgrade's tests already import
 	// pkg/cluster.
 	HoldReason string
+	// Refusal is the boot gate's durable did-not-run record (#6622), when one
+	// exists. The gate exits 0 on every path so `systemctl status` reads
+	// SUCCESS even after a refusal; this is what makes the decline visible
+	// somewhere an operator looks, and it survives journal rotation.
+	//
+	// It carries the resolution FACTS the gate decided on. It does NOT carry
+	// which candidate was armed, and that is deliberate rather than a gap: the
+	// gate is POSIX sh and the journal is JSON, so it reads that file for one
+	// bit and never for a value. The candidate is joined in here instead, from
+	// Journal.CandidateVersion, which this function has already parsed in Go —
+	// and it is still accurate, because a refusal never transitions the
+	// journal, so the record and the ARMED candidate it declined are read from
+	// one consistent state.
+	Refusal PromoteRefusal
+
 	// ReadErr records a failure to read the durable state. The status still
 	// renders — a channel whose state cannot be read is itself the finding, and
 	// refusing to print anything would leave the operator with strictly less
@@ -81,6 +96,17 @@ func ReadChannelStatus(journalPath string, sys KernelSystem) ChannelStatus {
 		st.Journal = *j
 		st.Armed = j.State.atLeast(KernelStateArmed) &&
 			j.State != KernelStatePromoted && j.State != KernelStateReverted
+	}
+	// The gate's did-not-run record (#6622). Read before the sys-backed
+	// lookups because it needs no KernelSystem: a box whose sys is nil (or
+	// whose probes fail) is exactly the box whose gate most likely declined,
+	// and the refusal is the most useful thing on the screen there.
+	if rec, rerr := ReadRefusalRecord(journalPath); rerr != nil {
+		if st.ReadErr == nil {
+			st.ReadErr = rerr
+		}
+	} else {
+		st.Refusal = rec
 	}
 	if sys == nil {
 		return st
@@ -194,6 +220,14 @@ func RenderChannelStatus(w io.Writer, st ChannelStatus) {
 	} else {
 		fmt.Fprintln(w, "  Last roll:       none recorded")
 	}
+
+	// ── boot-gate refusal (#6622) ──
+	//
+	// Rendered AFTER the armed/marker/last-roll block so the candidate it
+	// declined is already on screen above it: the record deliberately does not
+	// duplicate the candidate version, and this ordering is what joins the two
+	// for the reader.
+	renderRefusal(w, st.Refusal)
 
 	// ── cluster election hold ──
 	if st.HoldReason != "" {

--- a/scripts/image/test_kernel_promote_explicit_path.py
+++ b/scripts/image/test_kernel_promote_explicit_path.py
@@ -94,6 +94,12 @@ ARM_RECORD = "/var/lib/xpf/kernel-promote-binary"
 # The kernel-channel journal. The gate reads ONE BIT out of it (is a candidate
 # ARMED) and never a path. Pinned against Go by TestPromoteScriptJournalMatchesGo.
 KERNEL_JOURNAL = "/var/lib/xpf/kernel-upgrade.state"
+# The durable did-not-run record (#6622). The gate exits 0 on every path and the
+# unit is Type=oneshot + RemainAfterExit=yes, so `systemctl status` reads SUCCESS
+# even after a refusal; this file is what makes the decline outlive journal
+# rotation. Its path is pinned against Go by
+# TestPromoteScriptRefusalRecordPathMatchesGo_6622 (pkg/upgrade).
+REFUSAL_RECORD = "/var/lib/xpf/kernel-promote-refusal"
 VERSIONED = "/var/lib/xpf/versions/current/xpfd"
 
 
@@ -483,6 +489,7 @@ class _GateBase(unittest.TestCase):
         text = text.replace(SBIN, str(self.fake_root) + SBIN)
         text = text.replace(ARM_RECORD, str(self.fake_root) + ARM_RECORD)
         text = text.replace(KERNEL_JOURNAL, str(self.fake_root) + KERNEL_JOURNAL)
+        text = text.replace(REFUSAL_RECORD, str(self.fake_root) + REFUSAL_RECORD)
         self.script_copy.write_text(text)
         self.script_copy.chmod(0o755)
 
@@ -713,6 +720,64 @@ class _GateBase(unittest.TestCase):
             f"the gate did not run the recorded xpfd ({why}): {res.stderr}",
         )
         self._assert_no_path_fallback(res, why)
+
+    def _refusal_path(self) -> Path:
+        return Path(str(self.fake_root) + REFUSAL_RECORD)
+
+    def _read_refusal(self) -> dict:
+        """Parse the durable did-not-run record the way Go does (#6622).
+
+        Splits on the FIRST '=' only: a systemd ExecStart rendering contains
+        several, and a parser that split on every one would mangle the field an
+        operator most needs. Returns {} when no record exists.
+        """
+        p = self._refusal_path()
+        if not p.is_file():
+            return {}
+        out = {}
+        for line in p.read_text().splitlines():
+            if "=" in line:
+                k, v = line.split("=", 1)
+                out[k] = v
+        return out
+
+    def _assert_recorded(self, disposition: str, why: str) -> dict:
+        """The did-not-run outcome left a durable, parseable record."""
+        rec = self._read_refusal()
+        self.assertTrue(
+            rec,
+            f"no durable record at {self._refusal_path()} ({why}). The gate "
+            f"exits 0 and the unit is RemainAfterExit=yes, so `systemctl "
+            f"status` reads SUCCESS — without this file the operator has only "
+            f"a journald line, which journal rotation takes away (#6622)",
+        )
+        self.assertEqual(
+            rec.get("disposition"),
+            disposition,
+            f"disposition={rec.get('disposition')!r}, want {disposition!r} "
+            f"({why}). A refusal names a condition the operator can fix; an "
+            f"indeterminate says the gate could not even tell — folding them "
+            f"sends the operator to the wrong subsystem",
+        )
+        # ONE LINE PER FIELD is the format contract: the shell writes it and Go
+        # reads it, so a value carrying a newline would forge extra records.
+        raw = self._refusal_path().read_text()
+        self.assertEqual(
+            len(raw.splitlines()),
+            len([k for k in rec]),
+            f"the record has lines that are not key=value fields ({why}):\n{raw}",
+        )
+        return rec
+
+    def _assert_no_record(self, why: str):
+        self.assertEqual(
+            self._read_refusal(),
+            {},
+            f"a durable did-not-run record was written ({why}). It is written "
+            f"only where the gate never ran xpfd at all; writing it on an "
+            f"ordinary boot would rewrite the file every boot and bury the "
+            f"signal it exists to carry (#6622)",
+        )
 
     def _spawn_fake_daemon(self, subdir: str, basename: str = "xpfd", unlink: bool = False):
         """Run a real process from a real file; return (proc, path, cgroup)."""
@@ -1809,6 +1874,194 @@ class TestRefusalCarriesFacts(_GateBase):
         self.assertNotIn("Fix xpfd.service so its ExecStart", res.stderr)
 
 
+class TestRefusalLeavesADurableRecord(_GateBase):
+    """#6622 — a did-not-run outcome must survive the boot and journal rotation.
+
+    The gate exits 0 on EVERY path, deliberately: a non-zero exit trips the
+    unit's OnFailure= and reboots the box over what may be a transient
+    packaging window, and the firmware already cleared BootNext so the next
+    plain reboot falls back to known-good on its own. The unit is Type=oneshot
+    with RemainAfterExit=yes, so the cost of that correct decision is that
+    `systemctl status xpf-kernel-promote` reads SUCCESS and stays active even
+    when the gate REFUSED and the armed candidate is running unverified.
+
+    Before this the only signal was a journald line. An operator who armed a
+    candidate, rebooted, and came back later saw a box on the old kernel and a
+    promote unit reporting success, with nothing saying the gate declined or
+    why.
+
+    #6601 is what made it worth closing rather than theoretical: it converted
+    "maybe run a stale binary" into "refuse", which is the right trade, but it
+    made refusal a REACHABLE outcome. A state that is now reachable needs to be
+    observable.
+
+    The record does NOT make the unit fail, and one test below asserts that
+    explicitly — the exit-0 contract is load-bearing and this must not erode it.
+    """
+
+    def test_a_refusal_leaves_a_durable_record_with_the_facts(self):
+        # The strongest refusal: a candidate IS armed and the gate cannot run.
+        self.arm_explicitly_absent = True
+        self.journal = self.journal_body("ARMED")
+        self.stub_loadstate = "loaded"
+        self.stub_mainpid = "0"
+        self.stub_execstart = "{ path=/usr/local/sbin/xpfd ; argv[]=/usr/local/sbin/xpfd ; ignore_errors=no }"
+
+        res = self._run()
+        self._assert_refused(res, "journal ARMED, record absent")
+        rec = self._assert_recorded("refused", "journal ARMED, record absent")
+
+        # The RESOLUTION FACTS, not just "refused" — the issue's central
+        # criterion. These are the snapshot values the DECISION was made on, so
+        # an operator reading them days later is not looking at a re-query of a
+        # system that has since changed.
+        self.assertEqual(rec.get("load_state"), "loaded")
+        self.assertEqual(rec.get("main_pid"), "0")
+        self.assertEqual(rec.get("exec_start"), self.stub_execstart)
+        self.assertEqual(rec.get("unit"), "xpfd.service")
+        # The journal bit that made this a refusal rather than a quiet skip.
+        self.assertEqual(rec.get("journal_state"), "armed")
+        # Enough to say WHAT happened and WHAT to do about it.
+        self.assertIn("ARMED", rec.get("reason", ""))
+        self.assertTrue(rec.get("cause"), f"no cause recorded: {rec}")
+        self.assertTrue(rec.get("advice"), f"no advice recorded: {rec}")
+        # A wrong early-boot clock must not leave the event unattributable.
+        self.assertTrue(rec.get("boot_id"), f"no boot id recorded: {rec}")
+
+    def test_the_record_does_not_make_the_unit_fail(self):
+        # The exit-0 contract is why this issue exists at all, and closing the
+        # observability gap must not close it by breaking that. Asserted as its
+        # own test rather than only inside _assert_refused, because this is the
+        # constraint the fix was most likely to violate.
+        self.arm_explicitly_absent = True
+        self.journal = self.journal_body("ARMED")
+        res = self._run()
+        self.assertEqual(
+            res.returncode,
+            0,
+            "the gate exited non-zero after writing the record; that trips the "
+            "unit's OnFailure= and reboots the box on the boot path (#6622 "
+            "explicitly rules this out as the fix)",
+        )
+        self.assertTrue(self._read_refusal(), "no record was written")
+        self.assertFalse(
+            self.systemctl_ran.exists(),
+            "the gate rebooted after recording a refusal",
+        )
+
+    def test_advice_branch_is_recorded_not_just_logged(self):
+        # set_cause_advice BRANCHES: telling an operator to fix an ExecStart
+        # when systemctl could not be consulted at all points at the wrong
+        # system. The record must preserve WHICH branch was taken, or it
+        # reproduces that mistake one rotation later.
+        self.arm_explicitly_absent = True
+        self.journal = self.journal_body("ARMED")
+        self.stub_show_fail = "1"
+
+        res = self._run()
+        self._assert_refused(res, "systemctl unreachable")
+        rec = self._assert_recorded("refused", "systemctl unreachable")
+        self.assertIn("systemd-availability", rec.get("advice", ""))
+        self.assertIn("systemctl could not be consulted", rec.get("cause", ""))
+        # And the facts must say the query failed rather than reporting an
+        # empty value that reads like "systemd answered, with nothing".
+        self.assertEqual(rec.get("load_state"), "<systemctl failed>")
+
+    def test_a_multiline_execstart_cannot_forge_extra_fields(self):
+        # systemd renders multiple ExecStart entries one per LINE. The record is
+        # one line per field, so an unflattened value would turn a single field
+        # into several bogus records -- the same "a value may legally contain
+        # the delimiter" class as the ExecStart parse itself, in reverse.
+        self.armed = str(self.tmp / "nope" / "xpfd")  # unusable -> refusal
+        self.stub_loadstate = "loaded"
+        self.stub_execstart = (
+            "{ path=/a/xpfd ; argv[]=/a/xpfd ; ignore_errors=no }\n"
+            "reason=FORGED\n"
+            "{ path=/b/xpfd ; argv[]=/b/xpfd ; ignore_errors=no }"
+        )
+
+        res = self._run()
+        self._assert_refused(res, "recorded binary missing")
+        rec = self._assert_recorded("refused", "recorded binary missing")
+        # Assert on the RAW file, not on the parsed dict. The forged line lands
+        # BEFORE the real `reason=`, so a last-key-wins parse (which is what
+        # both this helper and Go's reader do) silently discards it and a
+        # dict-based assertion here could never fire -- it would read as the
+        # load-bearing check while being dead. The raw text is where the
+        # forgery is visible.
+        raw = self._refusal_path().read_text()
+        self.assertNotIn(
+            "\nreason=FORGED",
+            raw,
+            "a newline inside ExecStart forged a `reason` field; the value was "
+            f"not flattened (#6622):\n{raw}",
+        )
+        self.assertNotIn(
+            "\n",
+            rec.get("exec_start", ""),
+            "the ExecStart value kept a newline",
+        )
+        # And the real reason survived intact.
+        self.assertIn("not an executable regular file", rec.get("reason", ""))
+
+    def test_an_indeterminate_journal_is_recorded_as_such(self):
+        # Not a refusal, but the same operator problem: a candidate may be
+        # armed, the gate did not run, and nothing durable said so. Recording
+        # it is what makes the record's ABSENCE meaningful -- if only refuse()
+        # wrote one, "no record" could not distinguish a clean boot from a boot
+        # the gate skipped for this reason.
+        self.arm_explicitly_absent = True
+        journal = self._journal_path()
+        journal.parent.mkdir(parents=True, exist_ok=True)
+        journal.mkdir()  # a DIRECTORY: present, unreadable as a journal
+
+        res = self._run()
+        self.assertEqual(res.returncode, 0, res.stderr)
+        self.assertIn("cannot establish whether", res.stderr)
+        rec = self._assert_recorded("indeterminate", "journal is a directory")
+        self.assertEqual(rec.get("journal_state"), "indeterminate")
+        self.assertNotIn("REFUSING", res.stderr)
+
+    def test_an_ordinary_boot_leaves_no_record(self):
+        # The ANTI-NOISE control. A file rewritten on every boot is not a
+        # signal; and a stale record from a prior candidate would be read as a
+        # verdict on the current one.
+        self.arm_explicitly_absent = True  # nothing armed, no journal
+        res = self._run()
+        self._assert_nothing_armed(res, "nothing armed")
+        self._assert_no_record("ordinary boot, nothing armed")
+
+    def test_a_successful_promotion_leaves_no_record(self):
+        # The gate RAN. From here the Go half owns the durable state (journal,
+        # promotion marker, last-roll), so a second writer here would be a
+        # second source for the same question.
+        self._seed_runtime_layout()
+        _live, ran = self._arm_a_live_binary()
+        res = self._run()
+        self._assert_ran(res, ran, "healthy armed box")
+        self._assert_no_record("the gate ran the recorded binary")
+
+    def test_an_unwritable_state_dir_does_not_change_the_exit_path(self):
+        # This runs on a candidate boot whose whole problem may be that the
+        # filesystem is not what the gate expected. A gate that changed its
+        # exit path because it could not write a DIAGNOSTIC would convert an
+        # observability gap into an availability one -- it would reboot the box.
+        self.arm_explicitly_absent = True
+        self.journal = self.journal_body("ARMED")
+        res_dir = Path(str(self.fake_root) + REFUSAL_RECORD).parent
+        res_dir.mkdir(parents=True, exist_ok=True)
+        # Plant a DIRECTORY where the record goes: mkdir -p succeeds, the
+        # rename cannot.
+        self._refusal_path().mkdir(parents=True, exist_ok=True)
+
+        res = self._run()
+        self._assert_refused(res, "record unwritable")
+        self.assertFalse(
+            self.systemctl_ran.exists(),
+            "an unwritable record rebooted the box",
+        )
+
+
 class TestBusyboxParity(_GateBase):
     """NIT-1 (#6601 r5) — the portability claim was asserted but never bound.
 
@@ -1902,6 +2155,26 @@ class TestBusyboxParity(_GateBase):
         res = self._run()
         self._assert_refused(res, "busybox sh, journal ARMED, record absent")
         self.assertIn("UNVERIFIED", res.stderr)
+
+    def test_refusal_record_is_written_under_busybox(self):
+        # The record writer uses `tr`, `date`, `mv` and a redirection into a
+        # command group. The busybox leg swaps the SHELL, not the utilities, so
+        # what this binds is the SHELL's handling of the group redirect and the
+        # command substitutions inside it -- the parts a non-dash sh could
+        # differ on. Without it the whole #6622 mechanism is asserted only
+        # under /bin/sh, on a script whose entire portability claim is that it
+        # runs under both.
+        self.arm_explicitly_absent = True
+        self.journal = self.journal_body("ARMED")
+        self.stub_loadstate = "loaded"
+        self.stub_execstart = "{ path=/a/xpfd ; argv[]=/a/xpfd ; ignore_errors=no }"
+
+        res = self._run()
+        self._assert_refused(res, "busybox, journal ARMED, record absent")
+        rec = self._assert_recorded("refused", "busybox")
+        self.assertEqual(rec.get("exec_start"), self.stub_execstart)
+        self.assertEqual(rec.get("journal_state"), "armed")
+        self.assertTrue(rec.get("reason"), f"no reason recorded under busybox: {rec}")
 
     def test_arming_state_is_not_a_trial_under_busybox(self):
         # The other side of the same glob: ARMING must NOT match, or busybox

--- a/scripts/image/xpf-kernel-promote
+++ b/scripts/image/xpf-kernel-promote
@@ -61,6 +61,52 @@ ARM_RECORD="/var/lib/xpf/kernel-promote-binary"
 KERNEL_JOURNAL="/var/lib/xpf/kernel-upgrade.state"
 JOURNAL_ARMED_STATE="ARMED"
 
+# The DURABLE TRACE a did-not-run outcome leaves behind (#6622).
+#
+# This gate exits 0 on every path, deliberately: a non-zero exit trips the
+# unit's OnFailure= and reboots the box over what may be a transient packaging
+# window. Combined with Type=oneshot + RemainAfterExit=yes, that means
+# `systemctl status xpf-kernel-promote` reads SUCCESS and the unit stays active
+# even when the gate REFUSED and the armed candidate is running unverified. The
+# only signal was a journald line, which is time-limited by journal rotation --
+# so an operator who armed a candidate, rebooted, and came back the next day saw
+# a box on the old kernel and a promote unit reporting success, with nothing
+# saying the gate declined or why.
+#
+# WHICH PATHS WRITE IT, and why that boundary and not another. It is written by
+# exactly the paths where THE GATE NEVER RAN xpfd AT ALL:
+#
+#   * every refuse() -- the loud declines;
+#   * the indeterminate-journal WARNING, which is not a refusal but is the same
+#     operator problem (a candidate may be armed, the gate did not run, nothing
+#     durable said so).
+#
+# Including the second is not scope creep, it is what makes the record's
+# ABSENCE meaningful: if only refuse() wrote one, "no record" would not
+# distinguish a clean boot from a boot the gate skipped for the other reason.
+#
+# It is deliberately NOT written by:
+#
+#   * the quiet "nothing to promote" branch -- that is the ORDINARY boot, where
+#     not running IS the correct outcome, and a file rewritten on every boot is
+#     noise that would bury the signal;
+#   * the post-exec rc paths -- there the gate DID run xpfd, and the Go half
+#     owns its own durable state for those (the journal, the promotion marker
+#     and the last-roll record), so a second writer would be a second source.
+#
+# Format is key=value, ONE LINE PER FIELD, values flattened by one_line: this is
+# POSIX sh writing a file Go reads, and the same "a value may legally contain
+# the delimiter" hazard that governs the ExecStart parse applies in reverse. A
+# systemd ExecStart rendering can legally contain newlines (multiple entries
+# render one per line), and an unflattened value would turn one field into
+# several bogus records. Go splits on the FIRST '=' so a value containing '='
+# survives, and unknown keys are ignored so a newer gate can add fields.
+#
+# Its path is derived from the journal's directory by ArmRecordPath's sibling
+# in Go (RefusalRecordPath) and pinned equal to this literal by a cross-language
+# canary (TestPromoteScriptRefusalRecordPathMatchesGo, pkg/upgrade).
+REFUSAL_RECORD="/var/lib/xpf/kernel-promote-refusal"
+
 # PROMOTE_UNIT is the systemd unit the record is CROSS-CHECKED against. It is no
 # longer where the binary comes from; it is a second opinion, and an absent
 # second opinion is not evidence against the record.
@@ -254,8 +300,60 @@ set_cause_advice() {
 # OnFailure= and reboots the box over what may be a transient packaging window,
 # and the firmware already cleared BootNext, so the next plain reboot falls back
 # to known-good on its own.
+# one_line flattens a value onto a single line so it cannot forge extra fields
+# in the key=value record. Newlines are the real case (a multi-entry ExecStart
+# renders one per line); tabs and CRs are folded for the same reason at no extra
+# cost. `tr` is a distribution binary on the unit's pinned PATH, like systemctl.
+one_line() {
+    printf '%s' "$1" | tr '\n\r\t' '   '
+}
+
+# record_refusal writes the durable trace. $1 is the disposition, the rest is
+# the human reason.
+#
+# BEST-EFFORT, ALWAYS. Every step is suppressed and the function always returns
+# success: this runs on a candidate boot whose whole problem may be that the
+# filesystem is not what the gate expected, and a gate that changed its exit
+# path because it could not write a DIAGNOSTIC would convert an observability
+# gap into an availability one. The caller's exit 0 must be reached either way.
+#
+# Written to a temp file and renamed so a reader never sees a half-written
+# record; the rename is within one directory, so it is atomic.
+record_refusal() {
+    rr_disposition=$1
+    shift
+    rr_dir=${REFUSAL_RECORD%/*}
+    mkdir -p "$rr_dir" 2>/dev/null || return 0
+    rr_tmp="$REFUSAL_RECORD.tmp"
+    {
+        printf 'version=1\n'
+        printf 'disposition=%s\n' "$rr_disposition"
+        printf 'refused_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)"
+        # The boot this happened on. An early-boot clock can be wrong (no RTC,
+        # no NTP yet), so the timestamp alone cannot answer "was this THIS
+        # boot?"; the boot id can, and it costs one read of a kernel file.
+        printf 'boot_id=%s\n' "$(cat /proc/sys/kernel/random/boot_id 2>/dev/null)"
+        printf 'journal_state=%s\n' "$(journal_state)"
+        printf 'unit=%s\n' "$PROMOTE_UNIT"
+        printf 'load_state=%s\n' "$(one_line "$SNAP_LOADSTATE_SHOW")"
+        printf 'main_pid=%s\n' "$(one_line "$SNAP_MAINPID_SHOW")"
+        printf 'control_group=%s\n' "$(one_line "$SNAP_CONTROLGROUP_SHOW")"
+        printf 'exec_start=%s\n' "$(one_line "$SNAP_EXECSTART_SHOW")"
+        printf 'reason=%s\n' "$(one_line "$*")"
+        # CAUSE and ADVICE are set by set_cause_advice on the refuse() path and
+        # empty elsewhere. They are separate fields rather than appended to the
+        # reason so a reader can render the diagnosis apart from the event, and
+        # so the branch the advice took stays legible.
+        printf 'cause=%s\n' "$(one_line "$CAUSE")"
+        printf 'advice=%s\n' "$(one_line "$ADVICE")"
+    } > "$rr_tmp" 2>/dev/null || { rm -f "$rr_tmp" 2>/dev/null; return 0; }
+    mv -f "$rr_tmp" "$REFUSAL_RECORD" 2>/dev/null || rm -f "$rr_tmp" 2>/dev/null
+    return 0
+}
+
 refuse() {
     set_cause_advice
+    record_refusal refused "$*"
     log "ERROR: $* REFUSING to promote: this gate does NOT fall back to" \
         "inferring which xpfd is live, because a runtime left behind by" \
         "--versions-dir/--sbin-dir relocation or a unit switch is" \
@@ -578,6 +676,9 @@ if [ ! -e "$ARM_RECORD" ]; then
                 "or an interrupted clear."
             ;;
         indeterminate)
+            record_refusal indeterminate "the arm record $ARM_RECORD is absent" \
+                "and $KERNEL_JOURNAL exists but cannot be read as a journal, so" \
+                "this gate could not establish whether a candidate kernel is armed"
             log "WARNING: the promotion gate did NOT run. The arm record" \
                 "$ARM_RECORD is absent, and $KERNEL_JOURNAL exists but cannot" \
                 "be read as a journal, so this gate cannot establish whether a" \


### PR DESCRIPTION
Closes #6622

## The defect

The boot gate exits 0 on **every** path, deliberately — a non-zero exit trips the unit's `OnFailure=` and reboots the box over what may be a transient packaging window, and the firmware already cleared `BootNext` so the next plain reboot falls back to known-good on its own. The unit is `Type=oneshot` with `RemainAfterExit=yes`.

The cost of that correct decision: `systemctl status xpf-kernel-promote` reads **SUCCESS** and stays `active` even when the gate **REFUSED** and the armed candidate is running unverified. The only signal was a journald line, and journal rotation takes it away.

An operator who armed a candidate, rebooted, and came back later saw a box running the old kernel and a promote unit reporting success, with **nothing** that said the gate declined or why.

**#6601 is what makes this worth closing rather than theoretical.** Before it, the gate could fall back to a compiled default and would usually run *something*. It now converts "maybe run a stale binary" into "refuse" — the right trade — which makes refusal a **reachable** outcome. A state that is now reachable needs to be observable.

## I checked the adjacency you flagged: `KernelUpgradeHoldReason` does not cover any of this

Same family, disjoint mechanism. That reason lives in `pkg/cluster` and answers *why is this node held SECONDARY* — the **election** question. The gate refusal happens in POSIX `sh`, in `scripts/image/xpf-kernel-promote`, **before `xpfd` is ever exec'd**, so no Go reason string is produced at all. Nothing to reuse.

What **is** reused is `upgrade.ChannelStatus` / `RenderChannelStatus`, which `show system kernel-upgrade`, the console CLI, the remote `cli` and the status RPC already all render through — so the record reaches every operator surface without this change touching `pkg/cli/` or `pkg/grpcapi/`.

## The fix

`refuse()` writes `/var/lib/xpf/kernel-promote-refusal`, beside the journal and the arm record.

**The unit still exits 0 and still does not trip `OnFailure=`.** The issue rules that out explicitly as the fix, and a dedicated test asserts it rather than leaving it to `_assert_refused` — it is the constraint this change was most likely to violate.

**Which paths write it, and why that boundary.** Only where the gate **never ran `xpfd` at all**: every `refuse()`, plus the indeterminate-journal `WARNING`.

Including the second is not scope creep — it is what makes the record's *absence* meaningful. If only `refuse()` wrote one, "no record" could not distinguish a clean boot from a boot the gate skipped for the other reason, and the operator would be back to guessing.

It is deliberately **not** written by the quiet `nothing to promote` branch (that is the *ordinary* boot; a file rewritten every boot buries the signal it carries) nor by the post-exec `rc` paths (there the gate **did** run `xpfd`, and the Go half already owns the journal, the promotion marker and the last-roll record — a second writer would be a second source).

## One acceptance criterion satisfied differently — stated, not substituted quietly

The issue asks the record to carry **"which candidate was armed"**. It does not, and that is a design choice rather than a gap.

The gate is POSIX `sh` and the journal is JSON. The script carries an explicit invariant that it reads that file **for one bit and never for a value** — *"A BOOLEAN, NEVER A PATH … This function must never grow a path extraction."* Extracting a version out of JSON in `sh` to duplicate it into a second file would breach the rule that exists because a value may legally contain the delimiter.

So the candidate is **joined in Go** by `ReadChannelStatus`, which has already parsed the journal into a struct. That is strictly better than duplicating, and it is accurate rather than merely convenient: **a refusal never transitions the journal**, so it still reads `ARMED` with `CandidateVersion` intact when the operator looks — the record and the candidate it declined come from one consistent state. The render orders the refusal block *after* the armed block for exactly this reason.

Everything else the criterion names — refused, timestamp, and the resolution facts (`MainPID`, `LoadState`, raw `ExecStart`) — is in the record, from the **discovery snapshot the decision was made on**. The status surface renders that snapshot rather than re-querying systemd: a re-query days later would describe a different system, which is the #6601 r7 mistake one rotation later.

A `boot_id` is included because an early-boot clock can be wrong (no RTC, no NTP yet), so the timestamp alone cannot answer *was this THIS boot?*.

## Format is a contract, in both directions

POSIX `sh` writes it and Go reads it, so the *a value may legally contain the delimiter* hazard that governs the `ExecStart` parse applies **in reverse**: a systemd rendering can legally contain newlines (multiple entries render one per line), and an unflattened value would forge extra fields. Values are flattened; Go splits on the **first** `=`; unknown keys are ignored so a newer gate can add fields.

A record present but carrying no **recognised** field is an **error**, never a silent "no refusal" — the rule `ReadArmRecord` already applies, because "absent" is acted on as a positive statement.

**That rule caught a real defect while the test was being written.** The reader first counted `=`-bearing *lines*, so a file whose only fields were unknown parsed as a refusal with every field empty — rendering a `REFUSED` banner made entirely of dashes, worse than the error it displaced. The first draft of the test could not see it: **its own fixture text contained the literal `key=value`**. Both are fixed, and there is now a companion over-reach test proving the tightening does not reject a newer gate's record that carries unknown fields *alongside* known ones.

## Lifetime

Cleared with the journal and rewritten by the next arm, so a refusal can never be read as a verdict on a candidate no longer in flight. It is cleared where the **new arm record is written** rather than at the top of `Arm`, so an arm that fails preflight leaves the previous refusal intact — which is what an operator diagnosing *that* failure needs on screen.

## Mutation matrix

Nine mutations across both halves, each with `go vet` **and** `sh -n` clean at the mutated state, each restored and confirmed byte-identical, and the **firing assertion identified per red** rather than just the failing test.

Production call path: `xpf-kernel-promote.service` → `/usr/local/sbin/xpf-kernel-promote` → `refuse()` (4 call sites) / the indeterminate branch. On the read side: `show system kernel-upgrade` (`pkg/cli/cli_show_system.go:271`, `pkg/grpcapi/server_show.go:524`) and the status RPC (`pkg/daemon/kernel_upgrade_status.go:33`) → `upgrade.ReadChannelStatus` → `ReadRefusalRecord`.

| cell | P1 no refuse() record | P2 no indeterminate record | P3 ExecStart unflattened | P4 refuse() exits 1 | P5 unwire reader | P6 render with no record | P7 loose field count | P8 no clear | P9 shell path drifts |
|---|---|---|---|---|---|---|---|---|---|
| `sh` refusal carries the facts | **RED** | 0 | 0 | **RED** | 0 | 0 | 0 | 0 | **RED** |
| `sh` record does not make the unit fail | **RED** | 0 | 0 | **RED** | 0 | 0 | 0 | 0 | **RED** |
| `sh` advice branch is recorded | **RED** | 0 | 0 | **RED** | 0 | 0 | 0 | 0 | **RED** |
| `sh` multiline ExecStart cannot forge fields | **RED** | 0 | **RED** | **RED** | 0 | 0 | 0 | 0 | **RED** |
| `sh` indeterminate recorded as such | 0 | **RED** | 0 | 0 | 0 | 0 | 0 | 0 | **RED** |
| `sh` ordinary boot leaves no record *(control)* | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| `sh` unwritable dir does not change the exit path | 0 | 0 | 0 | **RED** | 0 | 0 | 0 | 0 | 0 |
| `go` cross-language path canary | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | **RED** |
| `go` ChannelStatus surfaces the refusal | 0 | 0 | 0 | 0 | **RED** | 0 | 0 | 0 | 0 |
| `go` no refusal renders nothing *(control)* | 0 | 0 | 0 | 0 | 0 | **RED** | 0 | 0 | 0 |
| `go` fieldless record is an error | 0 | 0 | 0 | 0 | 0 | 0 | **RED** | 0 | 0 |
| `go` unknown keys tolerated *(control)* | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| `go` record shares the arm record's lifetime | 0 | 0 | 0 | 0 | 0 | 0 | 0 | **RED** | 0 |

P1 is what shipped (no recording at all). P4 exists to prove the exit-0 assertion is not vacuous. P6 is the anti-noise control: a healthy box must stay silent, or an operator learns to skip the section.

**A dead assertion found and fixed by the matrix.** P3's cell reded, but at the *line-count* check rather than at the `reason=FORGED` check written for it. The forged line lands **before** the real `reason=`, and both this harness and Go's reader are last-key-wins, so the dict-based assertion could never fire — it read as the load-bearing check while being dead. It now asserts on the **raw** file, where the forgery is actually visible, and reds there.

## Verification needs

**No live bake or A/B-capable box, and the reason is specific rather than a hedge.** The shell half is driven end to end by the existing hermetic harness — the **real** script under both `/bin/sh` and `busybox sh`, against a re-rooted fake filesystem with a stubbed `systemctl`, so every refusal branch, the exit code, the unwritable-directory path and the flattening are exercised as shipped. The Go half is exercised through `ReadChannelStatus`/`RenderChannelStatus`, the same functions the CLI and gRPC surfaces call.

What a real Tier-1 run would add is only that a live systemd produces snapshot values in the shape the stub emits — and that shape is separately pinned by the pre-existing `TestRefusalCarriesFacts` and `ExecStart`-parsing tests. **No cluster smoke owed**: no dataplane, shim `.o`, HA, VRRP or session-sync involvement.

`scripts/run-selftests.sh` stays at **61 passed / 0 skipped / 0 failed**; the promote harness goes 66 → **74** tests.

## Docs

`docs/in-place-upgrade.md` gains the record's contract next to the exit-0 rationale it exists because of: which paths write it and which deliberately do not, why the boundary is "the gate never ran `xpfd`", the format rules in both directions, the lifetime, the best-effort rule, and the explicit statement that the candidate version is joined in Go rather than duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cz2czGK3aA5MsMhkNkjHXX
