### PR TITLE
host-inbound: warn on a destination-restricted junos-host permit (#6612's missing clause)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-08-22 — #6612 destination-scoped junos-host permit: the missing advisory clause
+
+- **Timestamp**: 2026-08-22
+- **Action**: Landed the one clause the #6612 audit found missing. A
+  `to-zone junos-host` permit narrowed on DESTINATION (or carrying
+  `destination-address-excluded`) rendered no kernel rule AND produced
+  ZERO warnings of any kind: `junosHostProjectTerm` already refused to
+  render it, while `junosHostPolicyStricterThanCoarseGate` admitted a
+  permit as stricter-than-coarse only through
+  `junosHostPolicySourceScoped`, which inspects the source dimension
+  alone. The advisory now keys on the SAME expression the projection
+  applies (`junosHostAddrScoped(DestinationAddresses) ||
+  DestinationAddressExcluded`) rather than a second copy — a divergence
+  between "the projection refuses to render it" and "the warning says
+  so" is always a bug, which is the discriminator for single-sourcing
+  over binding two copies with an agreement test. Restored the two table
+  rows so each asserts BOTH halves in one cell. Measured, rather than
+  assumed, that a fixture cannot make both halves gate-sensitive at
+  once: the rules half needs a CONCRETE permit source (with
+  `source-address any` the permit sets permitAllV4 and shadows every
+  later deny, so nothing renders with or without the projection gate),
+  while the warning half needs NO concrete source (or it warns through
+  the source predicate and says nothing about the destination
+  dimension). The class is therefore bound by a table row plus the
+  separate widening test, and the doc records why so neither is
+  "simplified" into the other later. Re-shaped the excluded row to
+  `destination-address any` + excluded so the two disjuncts localise
+  independently. Three one-line mutations, each `go vet` clean at the
+  mutated state, each reddening exactly one row: dropping the named
+  disjunct reds only `dst-permit`, dropping the excluded disjunct reds
+  only `dstx-permit`, and dropping the projection gate reds only the
+  widening test's two subtests and none of the table rows — the split
+  the doc describes, confirmed by measurement.
+- **File(s)**: `pkg/config/compiler_validate_warn_host_inbound.go`,
+  `pkg/dataplane/userspace/junos_host_residual_6612_test.go`,
+  `docs/host-inbound-service-matrix.md`
+
 ## 2026-08-21 — #6612 junos-host residual: audited the claim, found it false, locked what holds
 
 - **Timestamp**: 2026-08-21

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -1733,19 +1733,38 @@ way. Covered today: scheduler-gated deny, feed-bound source, feed-bound
 destination, `reject`, `tcp-rst` zone, ALG application, IKE-exempt-tuple
 application, source-restricted permit.
 
-**Open: a destination-scoped `permit` renders nothing AND warns nothing (#6612).**
-Measured, such a policy produces zero warnings of any kind at commit. The
-projection correctly refuses to render it
-(`junosHostProjectTerm`: `p.Action != PolicyDeny && (junosHostAddrScoped(dest) ||
-DestinationAddressExcluded)`), but `junosHostPolicyStricterThanCoarseGate`
-(`pkg/config/compiler_validate_warn_host_inbound.go`) admits a permit as
+A destination-scoped `permit` was silent on BOTH halves until #6612: it rendered
+nothing and produced **zero warnings of any kind**. The projection correctly
+refused to render it (`junosHostProjectTerm`: `p.Action != PolicyDeny &&
+(junosHostAddrScoped(dest) || DestinationAddressExcluded)`), but
+`junosHostPolicyStricterThanCoarseGate`
+(`pkg/config/compiler_validate_warn_host_inbound.go`) admitted a permit as
 stricter-than-coarse only through `junosHostPolicySourceScoped`, which inspects
-the SOURCE dimension alone — so the two halves disagree: the projection knows it
-cannot enforce the policy and the warning never says so. The fix is one clause
-keying the warning on the SAME expression the projection uses, so they cannot
-drift. Until it lands, the rendered-nothing half is locked by
-`TestJunosHostDestinationScopedPermitRendersNothing6612` and the missing half is
-named there.
+the SOURCE dimension alone. One system held both beliefs: the projection knew it
+could not enforce the policy, and the advisory never said so. The warning now
+keys on the SAME expression the projection applies — deliberately not a second
+copy of the condition, because a divergence between the two is always a bug.
+`destination-address-excluded` is covered as its own disjunct, so a config using
+the inverted form is not left with a residual of the bug's own shape.
+
+**Worse than silence — the shape to remember.** A destination-scoped permit
+followed by a deny emitted exactly ONE warning, and it named the **deny**. An
+operator saw output, reasonably concluded the config had been checked, and the
+policy that silently enforced nothing was not the one named. A partial signal
+that points at the wrong policy is more dangerous than no signal, which at least
+invites suspicion.
+
+**Why this class needs two fixtures.** The two halves cannot be made
+gate-sensitive by one config, and the reason is structural. For the RULES half to
+red when the projection's destination gate is removed, the permit needs a
+CONCRETE source — with `source-address any` it sets `permitAllV4` and shadows
+every later deny outright, so nothing renders either way. For the WARNING half to
+red when the advisory clause is removed, the permit must NOT be source-scoped, or
+it warns through the source predicate and proves nothing about the destination
+dimension. The two requirements are mutually exclusive, so the class is bound by a
+table row (source `any`, pinning the advisory clause) plus
+`TestJunosHostDestinationScopedPermitDoesNotWidenALaterDeny6612` (concrete source
+ahead of a deny, pinning the projection gate).
 
 The third dimension, an APPLICATION-scoped permit, has the same silent shape and
 is tracked separately in #7374: it needs a comparison against the zone's

--- a/pkg/config/compiler_validate_warn_host_inbound.go
+++ b/pkg/config/compiler_validate_warn_host_inbound.go
@@ -417,6 +417,22 @@ func junosHostPolicyStricterThanCoarseGate(action PolicyAction, m PolicyMatch) (
 	if junosHostPolicySourceScoped(m) {
 		return true, "source-restricted permit"
 	}
+	// #6612: a permit narrowed on DESTINATION is stricter for the same reason a
+	// source-narrowed one is — the nft chain admits every configured
+	// system-service to EVERY local address in the zone, so each firewall
+	// address the permit does not name falls to the junos-host default deny
+	// under Junos and is admitted here. Before this clause such a permit was
+	// silent on BOTH halves: junosHostProjectTerm already refuses to render it
+	// (a permit is projected only as a `saddr !=` subtraction of later denies,
+	// which cannot express a carve that is also destination-scoped), and this
+	// predicate — asking about the source alone — never said so. The condition
+	// is deliberately the SAME expression junosHostProjectTerm applies, not a
+	// second opinion: a divergence between "the projection refuses to render it"
+	// and "the warning says so" is ALWAYS a bug, so the two must not hold
+	// independent copies of it.
+	if junosHostAddrScoped(m.DestinationAddresses) || m.DestinationAddressExcluded {
+		return true, "destination-restricted permit"
+	}
 	return false, ""
 }
 

--- a/pkg/dataplane/userspace/junos_host_residual_6612_test.go
+++ b/pkg/dataplane/userspace/junos_host_residual_6612_test.go
@@ -227,6 +227,37 @@ func TestJunosHostResidualIsUnrenderedAndWarned6612(t *testing.T) {
 			flipRules: true,
 		},
 		{
+			// #6612: destination-narrowed, source UNSCOPED — the shape that was
+			// silent on BOTH halves before the destination clause landed. Source
+			// `any` is load-bearing: with a concrete source the row would warn
+			// through junosHostPolicySourceScoped and could not tell whether the
+			// destination clause exists.
+			name:       "destination-scoped permit (a carve nft cannot express as a saddr subtraction)",
+			policyName: "dst-permit",
+			cmds:       concat(residualBase, policy("dst-permit", "any", "fw-mgmt", "any", "permit")),
+			flip:       concat(residualBase, policy("dst-permit", "any", "any", "any", "permit")),
+			flipRules:  false,
+		},
+		{
+			// The excluded form must be covered too: a fix catching the named
+			// destination and missing `destination-address-excluded` would leave a
+			// residual with the same shape as the bug, which is the hardest kind
+			// to notice later. The projection gates on both
+			// (`junosHostAddrScoped(dest) || DestinationAddressExcluded`) and so
+			// does the warning.
+			name:       "destination-EXCLUDED permit (same carve, inverted domain)",
+			policyName: "dstx-permit",
+			// `destination-address any` + excluded, NOT a named destination: that
+			// isolates the `DestinationAddressExcluded` disjunct on both the
+			// projection and the advisory. Naming an address here would satisfy
+			// `junosHostAddrScoped` too, and a mutation dropping one disjunct
+			// could not be localised — the other would keep the row green.
+			cmds: concat(residualBase, policy("dstx-permit", "any", "any", "any", "permit"),
+				[]string{"set security policies from-zone untrust to-zone junos-host policy dstx-permit match destination-address-excluded"}),
+			flip:      concat(residualBase, policy("dstx-permit", "any", "any", "any", "permit")),
+			flipRules: false,
+		},
+		{
 			name:       "source-restricted permit (its implied deny-non-permitted half is unenforced)",
 			policyName: "src-permit",
 			cmds:       concat(residualBase, policy("src-permit", "bad-host", "any", "any", "permit")),
@@ -347,52 +378,36 @@ func TestJunosHostMultiTermApplicationIsFullyExpanded6612(t *testing.T) {
 	}
 }
 
-// TestJunosHostDestinationScopedPermitDoesNotWidenALaterDeny6612 locks the half
-// of the destination-scoped-permit contract that HOLDS today, and names the half
-// that does not.
+// TestJunosHostDestinationScopedPermitDoesNotWidenALaterDeny6612 is the
+// mutation anchor for the RULES half of the destination-scoped-permit contract.
+// The table above asserts the conjunction (no rules AND a warning naming the
+// policy) for this class; this pins the half the table's fixture cannot make
+// gate-sensitive.
 //
-// A `to-zone junos-host` permit narrowed on DESTINATION (or carrying
-// `destination-address-excluded`) is un-representable: a permit is projected only
-// as a `saddr !=` SUBTRACTION of later denies, which cannot express a carve that
-// is also destination-scoped. junosHostProjectTerm marks it so, and the whole
-// zone program then emits nothing.
+// The two halves cannot be made load-bearing by ONE fixture, and the reason is
+// structural rather than a shortcut here:
 //
-// The fixture deliberately places a DENY after the permit, because that is the
-// only shape in which the gate changes a packet verdict. A lone
-// destination-scoped permit renders nothing whether or not the gate exists — the
-// projection is DROP-only — so a test built on one would assert a property that
-// holds for an unrelated reason and would stay green with the gate deleted. With
-// a following deny, dropping the gate renders `saddr != <permit source>` on that
-// deny, which stops denying the permitted source to firewall addresses the
-// permit never covered: an under-deny, and exactly the fail-open the gate exists
-// to prevent.
+//   - For the RULES half to red when the projection's destination gate is
+//     deleted, the permit needs a CONCRETE source. With `source-address any` the
+//     permit sets permitAllV4 and shadows every later deny outright, so the
+//     program renders nothing with or without the gate.
+//   - For the WARNING half to red when the advisory's destination clause is
+//     deleted, the permit must NOT be source-scoped, or it warns through
+//     junosHostPolicySourceScoped and proves nothing about the destination
+//     dimension.
 //
-// **The warning half is a KNOWN OPEN DEFECT and is deliberately NOT asserted
-// here.** Measured on this fixture, ValidateConfig emits ZERO warnings of any
-// kind for the permit: junosHostPolicyStricterThanCoarseGate
-// (pkg/config/compiler_validate_warn_host_inbound.go) admits a permit as
-// stricter-than-coarse only through junosHostPolicySourceScoped, which inspects
-// the SOURCE dimension alone, so a destination-narrowed permit never reaches the
-// test. The policy commits clean, renders nothing, and says nothing — the exact
-// silent state #4168 exists to prevent, and the reason #6612's closing claim
-// ("each affected policy emits the #4168 commit warning naming itself") is false
-// as written.
+// A concrete source and no concrete source are mutually exclusive, so the class
+// is covered by the table row (source `any` — pins the warning clause) plus this
+// test (concrete source ahead of a deny — pins the projection gate). Both
+// fixtures assert what they can; neither pretends to bind the other's gate.
 //
-// The fix is one clause, binding the warning to the SAME predicate the
-// projection already uses in junosHostProjectTerm so the two halves cannot drift:
-//
-//	if junosHostAddrScoped(m.DestinationAddresses) || m.DestinationAddressExcluded {
-//	    return true, "destination-restricted permit"
-//	}
-//
-// It lands in pkg/config, outside this lane's file surface, and is tracked on
-// #6612. When it lands, this test folds back into the table above as two rows
-// asserting both halves — they were written and measured, and they pass with
-// that clause.
+// The property this one binds: without the projection gate, the deny that
+// follows renders `saddr != <permit source>` and stops denying that source to
+// every firewall address the permit never covered — an under-deny, and the only
+// shape in which the gate changes a packet verdict.
 //
 // FAIL-ON-REVERT: delete the `p.Action != PolicyDeny && (junosHostAddrScoped(...)
-// || DestinationAddressExcluded)` gate in junosHostProjectTerm and the following
-// deny renders a widened rule — RED here.
+// || DestinationAddressExcluded)` gate in junosHostProjectTerm — RED here.
 func TestJunosHostDestinationScopedPermitDoesNotWidenALaterDeny6612(t *testing.T) {
 	followingDeny := policy("blk", "any", "any", "any", "deny")
 	for _, tc := range []struct {


### PR DESCRIPTION
Completes #6612. PR #7381 shipped the audit and the coverage lock; this is the one clause that lock left red.

## The defect

A `to-zone junos-host` permit narrowed on destination — or carrying `destination-address-excluded` — rendered **no kernel rule AND produced zero warnings of any kind**:

```
dest-scoped permit           : programs=0 rules=0 junos-host-warnings=0
dest-excluded permit         : programs=0 rules=0 junos-host-warnings=0
dest-scoped permit + a deny  : programs=0 rules=0 junos-host-warnings=1   <- names the DENY, not the permit
CONTROL representable deny   : programs=1 rules=1 junos-host-warnings=0   (enforced, correctly suppressed)
```

The middle row is the sharpest one and worth stating plainly: the operator **saw output**, reasonably concluded the config had been checked, and the policy that silently enforced nothing was **not the one named**. A partial signal pointing at the wrong policy is worse than no signal, which at least invites suspicion.

## Root cause — two halves of one mechanism disagreeing

`junosHostProjectTerm` already refuses to render such a permit (a permit is projected only as a `saddr !=` subtraction of later denies, which cannot express a carve that is also destination-scoped). But `junosHostPolicyStricterThanCoarseGate` admitted a permit as stricter-than-coarse only through `junosHostPolicySourceScoped`, which inspects the **source** dimension alone. The projection knew it could not enforce the policy; the advisory never said so.

The fix keys the advisory on the **same expression the projection applies**, deliberately not a second copy:

```go
if junosHostAddrScoped(m.DestinationAddresses) || m.DestinationAddressExcluded {
    return true, "destination-restricted permit"
}
```

A divergence between "the projection refuses to render it" and "the warning says so" is *always* a bug — which is the discriminator for single-sourcing rather than binding two copies with an agreement test. Two independent copies would be free to drift exactly as these two functions already had.

`destination-address-excluded` is carried as its own disjunct, so the inverted form is not left as a residual with the bug's own shape. The excluded row now uses `destination-address any` + excluded rather than a named destination, so the two disjuncts **localise** — a mutation dropping one leaves the other's row green.

## A measured finding: one fixture cannot make both halves gate-sensitive

The lock's design rule is that each residual class asserts both halves — no kernel rule AND a warning naming the policy — in **one cell**, so they cannot drift. That holds here, and the two rows do it. But the two halves cannot both be made *mutation-sensitive* by one fixture, and the reason is structural rather than a shortcut:

- For the **rules** half to red when the projection's destination gate is deleted, the permit needs a **concrete source**. With `source-address any` it sets `permitAllV4` and shadows every later deny outright, so nothing renders with or without the gate.
- For the **warning** half to red when this clause is deleted, the permit must **not** be source-scoped, or it warns through the source predicate and proves nothing about the destination dimension.

Mutually exclusive. So the class is bound by the table row (source `any` — pins this clause) plus `TestJunosHostDestinationScopedPermitDoesNotWidenALaterDeny6612` (concrete source ahead of a deny — pins the projection gate). Both fixtures assert the conjunction; neither pretends to bind the other's gate, and the doc records why so neither is folded into the other later.

This is the same family as PR #7381's fourth mutation: a cell over a case where the mechanism cannot change the outcome passes with the mechanism removed. Here it was caught by asking which shape makes each gate load-bearing *before* writing the cell.

## Validation

`pkg/config`, `pkg/dataplane/userspace`, `pkg/daemon` green with `-count=1`; `gofmt` and `go vet` clean. 16 `=== RUN`.

Three one-line mutations, each `go vet` clean **at the mutated state**, each restored with the tree clean and rc back to 0:

| Mutation | Red |
|---|---|
| Drop the named-destination disjunct (`... \|\| m.DestinationAddressExcluded` → `m.DestinationAddressExcluded`) | **only** the `dst-permit` row — "produced 0 #4168 warnings naming \"dst-permit\"" |
| Drop the excluded disjunct (→ `junosHostAddrScoped(m.DestinationAddresses)`) | **only** the `dstx-permit` row |
| Drop the projection gate in `junosHostProjectTerm` | **only** the widening test's two subtests, and **none** of the table rows — the split described above, confirmed rather than asserted |

Production call path for the first two: `config.ValidateConfig` → `validateJunosHostDirectDeliveryWarnings` → `junosHostPolicyStricterThanCoarseGate`. For the third: `pkg/daemon` → `dpuserspace.BuildJunosHostPrograms` → `config.BuildJunosHostDenyProjection` → `junosHostProjectTerm`.

WARN-only, zero dataplane surface. **Reaches the Rust helper binary: no** — no `.o` movement, no protocol change, so no smoke is owed.

The third dimension (an application-scoped permit) stays out, tracked in #7374: it needs a comparison against the zone's *effective* host-inbound set, or it warns on `match application [ junos-ssh junos-ping ]; then permit;` configs that have no gap at all.

Closes #6612

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cz2czGK3aA5MsMhkNkjHXX
