### PR TITLE
config: stop rendering a secret leaf value in validator errors (#6625)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -101993,3 +101993,19 @@ prose edit above them added. No diff falls in the new test body.
     pkg/config/compiler_validate_strict_application.go,
     pkg/config/dangling_term_keyword_6564_test.go,
     pkg/config/testdata/golden_4406.json, docs/config-schema.md
+
+## 2026-08-22 — #6625 secret value rendered by the #1798 control-char validators
+- **Timestamp**: 2026-08-22
+- **Action**: The #1798 control-character validator rendered the offending
+  leaf's VALUE into its error, and for a Secret leaf the secret appeared TWICE
+  (quoted as the value, and as a component of the rendered path). Reproduced
+  byte-for-byte against master before editing. Fixed by masking through the
+  SHARED `secretIndices` set (ast_redact.go) rather than a second list, and
+  reporting the offending byte + offset instead of the value. The sweep the
+  issue demanded found a SECOND leaking surface: the lenient twin
+  `sanitizeNodesControlChars` returns the same value-bearing path for the caller
+  to log, on Store.Load at boot and Store.SyncApply on HA peer-sync — so a
+  persisted key was re-published every boot. Both fixed.
+- **File(s)**: pkg/config/freetext.go,
+  pkg/config/secret_value_in_validator_error_6625_test.go (new),
+  docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -9193,6 +9193,32 @@ CLAUDE.md dual-shape rule). The masked render is byte-identical to the
 cleartext render except at the secret tokens and stays structurally valid
 (the placeholder is quoted where needed).
 
+**The #1798 control-character validators use the SAME set (#6625).** They are
+not display paths, but they render a config path and, on the strict side, the
+offending VALUE — and for a secret leaf the value IS the secret, appearing
+twice: quoted as the value, and again as a component of the path that names it
+(`chassis cluster authentication-key <PSK>`). The trigger is routine rather than
+exotic: a PSK pasted from a password manager, a terminal or a file commonly
+carries a leading or trailing tab or CR, so the operator does the ordinary thing
+and the refusal publishes the key to commit output, the daemon log and the audit
+journal at once.
+
+Both surfaces now mask through `renderNodePath`, and the strict one reports the
+offending byte and its offset instead of the value — `contains a control
+character (0x09 at offset 0)`, which is enough to correct the input without
+disclosing it. That is the same trade `checkKey`
+(`compiler_validate_strict_routing.go`) already made for typed `Secret` fields,
+and the same one `urlParseCause` makes in `pkg/ddns`: name the reason, never the
+input. A NON-secret leaf still renders its value, because for a description or a
+hostname that value is exactly the diagnostic.
+
+Fixing only the strict validator would have been the failure this project keeps
+hitting — one of several symmetric surfaces repaired while its twin keeps
+leaking. The LENIENT twin (`sanitizeNodesControlChars`, used by `Store.Load` at
+boot and `Store.SyncApply` on HA peer-sync) returned the same value-bearing path
+for the caller to log, so an already-persisted key with a stray tab was
+re-published on every single boot. Both are fixed together.
+
 **Secret-leaf set = #2053's `config.Secret` field set** resolved to AST
 keyword signatures (verified against the compiler's `Secret(...)` sites):
 distinctive keywords `pre-shared-key` (keeps the `ascii-text`/`hexadecimal`

--- a/pkg/config/freetext.go
+++ b/pkg/config/freetext.go
@@ -172,26 +172,118 @@ func joinNodePath(prefix string, keys []string) string {
 	return prefix + " " + joined
 }
 
+// renderNodePath builds the same human-readable path from a FLATTENED key path,
+// with every secret VALUE token masked (#6625).
+//
+// The path is where the first half of the leak lived: for a leaf like `chassis
+// cluster authentication-key <PSK>` the secret is not only the offending value,
+// it is also a component of the path that names it. Sanitizing control
+// characters made it printable; it did not make it safe.
+//
+// The secret set comes from secretIndices (ast_redact.go) — the SAME resolution
+// the raw-AST display paths use, not a second list. A validator that decided
+// for itself which leaves are secret would drift from the renderer the moment
+// either gained a keyword, and the drift would be silent in the direction that
+// matters.
+func renderNodePath(fp []string) string {
+	clean := make([]string, len(fp))
+	for i, k := range fp {
+		clean[i] = sanitizeControlChars(k)
+	}
+	for _, idx := range secretIndices(fp) {
+		if idx >= 0 && idx < len(clean) {
+			clean[idx] = SecretDataPlaceholder
+		}
+	}
+	return strings.Join(clean, " ")
+}
+
+// controlCharDetail describes the FIRST control character in s without echoing
+// any of it: the byte value and its offset (#6625).
+//
+// That is enough to fix the input — an operator who pasted a PSK with a
+// trailing tab is told "0x09 at offset 15" and can see it — without publishing
+// the value to commit output, the daemon log and the audit journal. It is the
+// same trade urlParseCause makes in pkg/ddns: name the reason, never the input.
+func controlCharDetail(s string) string {
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 || s[i] == 0x7f {
+			return fmt.Sprintf("0x%02x at offset %d", s[i], i)
+		}
+	}
+	return "none"
+}
+
+// isSecretIndex reports whether position idx of the flattened key path fp is a
+// secret VALUE token.
+func isSecretIndex(fp []string, idx int) bool {
+	for _, i := range secretIndices(fp) {
+		if i == idx {
+			return true
+		}
+	}
+	return false
+}
+
 // validateNodesControlChars walks the (group-expanded) AST and returns
 // an error for the first value or annotation containing a control
 // character, or the first annotation containing a `*/`/`/*` comment
 // delimiter (#3900). Strict commit-path only — see the package comment
 // above.
 func validateNodesControlChars(nodes []*Node, prefix string) error {
+	return validateNodesControlCharsAt(nodes, splitNodePathPrefix(prefix))
+}
+
+// splitNodePathPrefix recovers the flattened key path from the joined string
+// form the exported entry point still accepts. An empty prefix is the root.
+func splitNodePathPrefix(prefix string) []string {
+	if prefix == "" {
+		return nil
+	}
+	return strings.Split(prefix, " ")
+}
+
+// validateNodesControlCharsAt is the recursion, carrying the path as a SLICE
+// rather than a joined string (#6625).
+//
+// The slice is what makes the secret masking possible at all: secretIndices
+// resolves a keyword to the positions of its value tokens, so it needs the
+// components, not a rendered line. Carrying the joined string and re-splitting
+// per level would also have worked, but it would re-split a string built from
+// sanitized components — and a sanitized token can contain the space that split
+// on, silently shifting every index after it.
+func validateNodesControlCharsAt(nodes []*Node, base []string) error {
 	for _, n := range nodes {
-		nodePath := joinNodePath(prefix, n.Keys)
-		for _, k := range n.Keys {
-			if hasControlChars(k) {
-				return fmt.Errorf("%s: value %q contains control characters (newlines and other control characters are not allowed in configuration values)", nodePath, k)
+		fp := append(append([]string(nil), base...), n.Keys...)
+		nodePath := renderNodePath(fp)
+		for i, k := range n.Keys {
+			if !hasControlChars(k) {
+				continue
 			}
+			// #6625: a SECRET leaf's value must not be echoed. The path (with
+			// the secret itself masked) plus the offending byte and its offset
+			// says everything an operator needs to correct the input.
+			//
+			// The trigger is not exotic: a PSK pasted from a password manager,
+			// a terminal or a file routinely carries a leading or trailing tab
+			// or CR. The operator does the ordinary thing, the commit is
+			// refused, and the refusal published the key they were setting —
+			// to the CLI, the daemon log and the audit journal at once.
+			if isSecretIndex(fp, len(base)+i) {
+				return fmt.Errorf("%s: value contains a control character (%s) — the value is withheld because this leaf is secret; remove the control character and re-enter it", nodePath, controlCharDetail(k))
+			}
+			return fmt.Errorf("%s: value %q contains control characters (newlines and other control characters are not allowed in configuration values)", nodePath, k)
 		}
+		// An annotation is operator prose attached to a node, never the secret
+		// value itself, so it keeps rendering — losing that diagnostic would be
+		// a real cost for no gain.
 		if hasControlChars(n.Annotation) {
 			return fmt.Errorf("%s: annotation %q contains control characters (newlines and other control characters are not allowed in annotations)", nodePath, n.Annotation)
 		}
 		if hasCommentDelim(n.Annotation) {
 			return fmt.Errorf("%s: annotation %q contains a comment delimiter (the sequences '*/' and '/*' are not allowed in annotations — they would close the comment and inject the remaining text as configuration on reload)", nodePath, n.Annotation)
 		}
-		if err := validateNodesControlChars(n.Children, nodePath); err != nil {
+		if err := validateNodesControlCharsAt(n.Children, fp); err != nil {
 			return err
 		}
 	}
@@ -204,6 +296,27 @@ func validateNodesControlChars(nodes []*Node, prefix string) error {
 // human-readable config path per modified node. Lenient-path
 // counterpart of validateNodesControlChars.
 func sanitizeNodesControlChars(nodes []*Node, prefix string) []string {
+	return sanitizeNodesControlCharsAt(nodes, splitNodePathPrefix(prefix))
+}
+
+// sanitizeNodesControlCharsAt is the recursion, carrying the path as a slice so
+// the returned warning path can mask secret VALUE tokens (#6625).
+//
+// This is the LENIENT twin of validateNodesControlCharsAt and it leaked the same
+// secret — the caller logs each returned path as
+// `sanitized control characters in configuration value at %q`, and the path is
+// built from n.Keys, which for `authentication-key <PSK>` INCLUDES the PSK.
+// Sanitizing the control characters made it printable, not safe.
+//
+// It is the worse of the two surfaces in one respect: the strict validator fires
+// once, on the operator's commit, while this runs on Store.Load at BOOT and on
+// Store.SyncApply for every HA peer-sync. An already-persisted key with a
+// stray tab was therefore re-published to the log on every single boot.
+//
+// Fixing only the strict side would have been the exact failure this project
+// keeps hitting — one of several symmetric surfaces repaired while its twin
+// keeps leaking.
+func sanitizeNodesControlCharsAt(nodes []*Node, base []string) []string {
 	var warnings []string
 	for _, n := range nodes {
 		changed := false
@@ -221,11 +334,14 @@ func sanitizeNodesControlChars(nodes []*Node, prefix string) []string {
 			n.Annotation = sanitizeCommentDelim(n.Annotation)
 			changed = true
 		}
-		nodePath := joinNodePath(prefix, n.Keys)
+		// The recursion carries the UNMASKED path so each level resolves
+		// secretIndices against the real keywords; masking happens only at
+		// render.
+		fp := append(append([]string(nil), base...), n.Keys...)
 		if changed {
-			warnings = append(warnings, nodePath)
+			warnings = append(warnings, renderNodePath(fp))
 		}
-		warnings = append(warnings, sanitizeNodesControlChars(n.Children, nodePath)...)
+		warnings = append(warnings, sanitizeNodesControlCharsAt(n.Children, fp)...)
 	}
 	return warnings
 }

--- a/pkg/config/secret_value_in_validator_error_6625_test.go
+++ b/pkg/config/secret_value_in_validator_error_6625_test.go
@@ -1,0 +1,185 @@
+package config
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// sentinel6625 is the secret every case plants. One distinctive token so the
+// assertion can be "the error does not contain this" — the only shape a partial
+// redaction cannot satisfy by looking tidy.
+const sentinel6625 = "MY-CLUSTER-PSK-SENTINEL"
+
+// leafChain6625 builds a nested single-key chain ending in a leaf whose LAST
+// key is the value. This is the AST shape the validators walk; ParseSetCommand
+// cannot be used because the lexer treats a tab as whitespace and strips the
+// very byte under test.
+func leafChain6625(keys ...string) []*Node {
+	var head, cur *Node
+	for _, k := range keys {
+		n := &Node{Keys: []string{k}}
+		if head == nil {
+			head = n
+		} else {
+			cur.Children = []*Node{n}
+		}
+		cur = n
+	}
+	cur.IsLeaf = true
+	return []*Node{head}
+}
+
+// secretLeaf6625 is one secret leaf shape, with the sentinel carrying a leading
+// tab — the realistic trigger: a value pasted from a password manager, a
+// terminal or a file.
+func secretLeaf6625(path ...string) []string {
+	return append(append([]string(nil), path...), "\t"+sentinel6625)
+}
+
+// secretLeafCases6625 covers every disambiguation class in secretIndices, not
+// just one keyword: distinctive keywords, the format-qualifier case, and all
+// three CONTEXT-gated generic keywords. A single-case test would pass while the
+// generic keywords — the ones whose secrecy depends on ancestor context — kept
+// leaking.
+func secretLeafCases6625() map[string][]string {
+	return map[string][]string{
+		"authentication-key (distinctive keyword)": secretLeaf6625("chassis", "cluster", "authentication-key"),
+		"pre-shared-key with a format qualifier":   secretLeaf6625("security", "ike", "policy", "p1", "pre-shared-key", "ascii-text"),
+		"tsig-secret":                              secretLeaf6625("system", "services", "dynamic-dns", "provider", "p1", "tsig-secret"),
+		"private-key (wireguard)":                  secretLeaf6625("interfaces", "wg0", "unit", "0", "private-key"),
+		"password under dynamic-dns (context)":     secretLeaf6625("system", "services", "dynamic-dns", "provider", "p1", "password"),
+		"key under authentication md5 (context)":   secretLeaf6625("protocols", "ospf", "area", "0", "interface", "ge-0/0/0", "authentication", "md5", "1", "key"),
+		"community under snmp (context)":           secretLeaf6625("system", "snmp", "community"),
+	}
+}
+
+// TestSecretLeafValueNeverRendered_6625 is the fail-on-revert gate for the
+// STRICT commit path.
+//
+// The #1798 control-character validator rendered the offending leaf's VALUE
+// into its error — and for a Secret leaf that published the key to commit
+// output, the daemon log and the audit journal at once. It appeared TWICE: once
+// quoted as the value, and once as a component of the rendered path, because
+// for `authentication-key <PSK>` the secret IS part of the path that names it.
+//
+// The trigger is narrow but entirely routine: a PSK pasted with a leading or
+// trailing tab or CR. The operator does the ordinary thing and the refusal
+// message discloses the key they were trying to set.
+func TestSecretLeafValueNeverRendered_6625(t *testing.T) {
+	for name, keys := range secretLeafCases6625() {
+		t.Run(name, func(t *testing.T) {
+			err := validateNodesControlChars(leafChain6625(keys...), "")
+			if err == nil {
+				t.Fatal("expected the control character to be rejected; if it is now ACCEPTED " +
+					"this case no longer exercises an error render and must be re-chosen")
+			}
+			if strings.Contains(err.Error(), sentinel6625) {
+				t.Fatalf("the secret reached the error string:\n%v", err)
+			}
+			// The diagnostic must still be USABLE: an operator has to be able to
+			// find the byte without being shown the value.
+			if !strings.Contains(err.Error(), "0x09") {
+				t.Fatalf("the error must name the offending byte class so the input can be "+
+					"corrected without echoing it, got:\n%v", err)
+			}
+		})
+	}
+}
+
+// TestSecretLeafValueNeverRenderedLenient_6625 is the same gate for the LENIENT
+// twin, and it is not redundant.
+//
+// `sanitizeNodesControlChars` returns a path per modified node and the caller
+// logs it. That path is built from `n.Keys`, which for a secret leaf INCLUDES
+// the secret. Sanitizing the control characters made it printable, not safe.
+//
+// This surface is worse in one respect: the strict validator fires once, on the
+// operator's commit, while this one runs on `Store.Load` at BOOT and on
+// `Store.SyncApply` for every HA peer-sync — so an already-persisted key with a
+// stray tab was re-published to the log on every single boot. Fixing only the
+// strict side is the "one of several symmetric surfaces" failure this project
+// keeps hitting.
+func TestSecretLeafValueNeverRenderedLenient_6625(t *testing.T) {
+	for name, keys := range secretLeafCases6625() {
+		t.Run(name, func(t *testing.T) {
+			tree := &ConfigTree{Children: leafChain6625(keys...)}
+			got := SanitizeTreeControlChars(tree)
+			if len(got) == 0 {
+				t.Fatal("expected a sanitize warning; if nothing was sanitized this case no " +
+					"longer exercises a path render and must be re-chosen")
+			}
+			for _, p := range got {
+				if strings.Contains(p, sentinel6625) {
+					t.Fatalf("the secret reached a logged sanitize path: %q", p)
+				}
+			}
+		})
+	}
+}
+
+// TestNonSecretLeafStillRendersValue_6625 is the over-reach guard the issue
+// asks for by name. A validator that stopped echoing EVERY value would satisfy
+// both tests above completely, and would destroy a genuinely useful diagnostic:
+// for a description or a hostname the offending value is exactly what the
+// operator needs to see.
+func TestNonSecretLeafStillRendersValue_6625(t *testing.T) {
+	const plain = "PLAIN-DESCRIPTION-VALUE"
+	err := validateNodesControlChars(
+		leafChain6625("interfaces", "ge-0/0/0", "description", "\t"+plain), "")
+	if err == nil {
+		t.Fatal("expected the control character to be rejected")
+	}
+	// Assert on the QUOTED form, not a bare substring. The rendered PATH also
+	// contains the value (sanitized, tab -> space), so `Contains(plain)` is
+	// satisfied whether or not the value branch ran — it passed against a
+	// mutation that withheld EVERY value. Only the %q value render produces the
+	// escaped, quoted spelling.
+	if want := strconv.Quote("\t" + plain); !strings.Contains(err.Error(), want) {
+		t.Fatalf("a NON-secret leaf must still render its value as %s — blanket suppression "+
+			"is not a fix, it is a lost diagnostic. got:\n%v", want, err)
+	}
+
+	tree := &ConfigTree{Children: leafChain6625("interfaces", "ge-0/0/0", "description", "\t"+plain)}
+	got := SanitizeTreeControlChars(tree)
+	if len(got) != 1 || !strings.Contains(got[0], plain) {
+		t.Fatalf("the lenient path must still name a NON-secret value: %q", got)
+	}
+}
+
+// TestSecretRedactionUsesTheSharedSecretSet_6625 pins that the validator's
+// notion of "secret" is the SAME one the raw-AST display paths use.
+//
+// A validator that carried its own list would drift from the renderer the
+// moment either gained a keyword, and the drift would be silent in the
+// direction that matters — a leaf redacted in `show configuration` but echoed
+// by a commit error.
+func TestSecretRedactionUsesTheSharedSecretSet_6625(t *testing.T) {
+	for name, keys := range secretLeafCases6625() {
+		t.Run(name, func(t *testing.T) {
+			// The shared resolver must mark the LAST token (the value) secret.
+			if !isSecretIndex(keys, len(keys)-1) {
+				t.Fatalf("secretIndices does not mark the value token of %v as secret; the "+
+					"validator and the display redactor disagree about this leaf", keys)
+			}
+			if got := renderNodePath(keys); strings.Contains(got, sentinel6625) {
+				t.Fatalf("renderNodePath leaked the secret: %q", got)
+			}
+		})
+	}
+}
+
+// TestControlCharDetail_6625 covers the detail renderer directly: it must name
+// the byte and offset and carry no input.
+func TestControlCharDetail_6625(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"\tSECRET", "0x09 at offset 0"},
+		{"SECRET\n", "0x0a at offset 6"},
+		{"SEC\x7fRET", "0x7f at offset 3"},
+		{"clean", "none"},
+	} {
+		if got := controlCharDetail(tc.in); got != tc.want {
+			t.Fatalf("controlCharDetail(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #6625

## The defect, reproduced before any edit

The #1798 control-character gate rendered the offending leaf's **value** into its error. For a `Secret`-typed leaf that publishes the secret to everything consuming the error — commit output on the CLI, the daemon log, the audit journal.

The secret appeared **twice**:

```
chassis cluster authentication-key  MY-CLUSTER-PSK : value "\tMY-CLUSTER-PSK\t" contains control characters ...
```

once quoted as the value, and once as a component of the rendered **path** — because for `authentication-key <PSK>` the secret *is* part of the path that names it. Sanitizing the control characters made that path printable; it did not make it safe.

**Trigger is routine, not exotic.** A PSK pasted from a password manager, a terminal or a file commonly carries a leading/trailing tab or CR. The operator does the ordinary thing, the commit is refused, and the refusal discloses the key. It gets worse with #6611 merged, where the control-link PSK becomes a leaf operators are expected to type and rotate.

## The sweep found a second leaking surface

The issue asked for one, warning that *"fixing one of several symmetric surfaces is the failure mode this project keeps hitting"* — and it was right.

`sanitizeNodesControlChars`, the **lenient twin**, returns one path per modified node for the caller to log, built from `n.Keys` — which for a secret leaf includes the secret. **It is the worse of the two:** the strict validator fires once, on the operator's commit; the lenient one runs on `Store.Load` at **boot** and `Store.SyncApply` for every **HA peer-sync**, so an already-persisted key with a stray tab was re-published to the log on *every single boot*. Both are fixed together.

The rest of the sweep came back clean and is worth recording: `checkKey` (`compiler_validate_strict_routing.go`) already reports a byte **offset** for typed `Secret` fields, and the VRRP sites were hand-guarded by #5195 F10 with an explicit `vrrpGroupIDKeys` truncation. The AST-walking `freetext.go` pair was the outlier — which makes sense, it is the only one with no type information.

## Using the shared secret set, not a second list

The secret set comes from `secretIndices` (`ast_redact.go`) — the **same** resolution the raw-AST display paths use. A validator with its own list would drift from the renderer the moment either gained a keyword, and the drift would be silent in the direction that matters: a leaf redacted in `show configuration` but echoed by a commit error.

It also covers the three **context-gated generic keywords** a hand-written list would very likely have missed — `password` under api-auth/dynamic-dns, `key` under `authentication md5`, `community` under `snmp`. The test matrix exercises all of them.

## What replaces the value

`contains a control character (0x09 at offset 0)` — enough to correct the input without disclosing it. Same trade the project already makes: `checkKey` reports a byte offset for a typed `Secret`, and `pkg/ddns`'s `urlParseCause` names the reason and never the input.

**A non-secret leaf still renders its value.** For a description or a hostname that value is exactly the diagnostic; blanket suppression would be a lost diagnostic, not a fix.

## One non-cosmetic implementation note

Both recursions now carry the path as a **slice** rather than a joined string. `secretIndices` resolves a keyword to the positions of its value tokens, so it needs components — and re-splitting the joined form would split a string built from *sanitized* components, where a sanitized token can contain the space being split on, silently shifting every index after it.

## Validation

- `go test ./pkg/config/ ./pkg/configstore/ -count=1` — green.
- `go build ./...` clean.
- The production `CompileConfig` path was driven end-to-end and returns the redacted error, so the wiring is bound, not just the helper.

**Mutation matrix — four mutations, each on a COMPILING tree:**

| Mutation | Cases that red |
|---|---|
| Delete the secret branch (pre-fix bytes) | the strict test |
| Stop masking secrets in the path render | strict, **lenient**, and the shared-set test |
| Revert the lenient twin to `joinNodePath` | the lenient test |
| **Withhold EVERY value — a TIGHTENING, not a removal** | the over-reach guard |

**That last cell caught a defect in the guard itself.** The over-reach assertion was a bare `Contains(value)` — which the *sanitized path* also satisfies — so it passed against a mutation that withheld every value. It now asserts the `strconv.Quote` form, which only the `%q` value render produces. A matrix of delete-the-guard cells alone could not have seen this.

No cluster smoke owed: control-plane only, no `userspace-dp` helper or shim `.o` movement.

## Docs

`docs/config-schema.md` — the secret-redaction section now records that the #1798 validators use the same set, why the byte-offset form replaces the value, and that the lenient twin leaked on every boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdWuT1UffSkr1spw8sjNTE
