### PR TITLE
config: stop rendering a credential's value in the control-char error (#6625)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -102021,3 +102021,11 @@ prose edit above them added. No diff falls in the new test body.
     pkg/config/compiler_validate_strict_application.go,
     pkg/config/dangling_term_keyword_6564_test.go,
     pkg/config/testdata/golden_4406.json, docs/config-schema.md
+
+- **Timestamp**: 2026-08-22
+  - **Action**: #6625 — the #1798 control-character gate rendered a credential
+    leaf's VALUE into its error (twice: path + quoted value). Now reports the
+    byte class and offset instead, for credential leaves only. `community` is
+    path-qualified (secret under snmp, a BGP route-target name elsewhere).
+  - **File(s)**: pkg/config/secret.go, pkg/config/freetext.go,
+    pkg/config/secret_in_error_6625_test.go

--- a/pkg/config/freetext.go
+++ b/pkg/config/freetext.go
@@ -179,9 +179,24 @@ func joinNodePath(prefix string, keys []string) string {
 // above.
 func validateNodesControlChars(nodes []*Node, prefix string) error {
 	for _, n := range nodes {
-		nodePath := joinNodePath(prefix, n.Keys)
+		// #6625: a credential leaf must never have its VALUE rendered. The
+		// path is built from the REDACTED keys, because joinNodePath renders
+		// every key — including the value — so an un-redacted path published
+		// the secret a second time, alongside the quoted value below.
+		nodePath := joinNodePath(prefix, redactSecretKeys(prefix, n.Keys))
+		secretLeaf := isSecretLeaf(prefix, n.Keys)
 		for _, k := range n.Keys {
 			if hasControlChars(k) {
+				if secretLeaf {
+					// Report WHERE and WHAT, never the value. The offset plus
+					// the byte is enough to fix the input — a leading tab from
+					// a password manager is offset 0, a trailing CR is the last
+					// offset — and discloses nothing. Rendering it would put the
+					// credential into commit output, the daemon log and the
+					// audit journal, which is exactly what the operator was
+					// trying to set privately.
+					return fmt.Errorf("%s: value contains %s (newlines and other control characters are not allowed in configuration values; the value is not shown because this statement carries a credential)", nodePath, describeControlChar(k))
+				}
 				return fmt.Errorf("%s: value %q contains control characters (newlines and other control characters are not allowed in configuration values)", nodePath, k)
 			}
 		}

--- a/pkg/config/secret.go
+++ b/pkg/config/secret.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -325,4 +326,113 @@ func (s *Secret) UnmarshalYAML(value *yaml.Node) error {
 	}
 	*s = Secret(v)
 	return nil
+}
+
+// secretLeafKeywords is the set of config-grammar leaf keywords whose VALUE is
+// a credential (#6625).
+//
+// It exists because the control-character gate (validateNodesControlChars)
+// runs on the AST, BEFORE compilation, so the compiled `Secret` type is not
+// available to it — and that gate formats the offending value into its error,
+// which for a credential publishes the credential to commit output, the daemon
+// log and the audit journal.
+//
+// Keyed on the leaf KEYWORD (Keys[0]) rather than a full path, because a
+// credential leaf is spelled the same wherever it appears: `authentication-key`
+// is a secret under chassis cluster, VRRP, OSPF, RIP and IS-IS alike, and a
+// path-keyed set would have to enumerate all of them and would silently miss
+// the next one.
+//
+// ERR TOWARD INCLUSION for an UNAMBIGUOUS keyword. A false positive costs one
+// diagnostic detail — the operator is told the byte offset and class instead of
+// the value. A false negative publishes a credential.
+//
+// Membership is pinned against the schema by
+// TestSecretLeafKeywordsExistInSchema (no dead entries) and against the known
+// credential leaves by TestSecretLeafKeywordsCoverKnownCredentials.
+var secretLeafKeywords = map[string]bool{
+	"authentication-key": true,
+	"pre-shared-key":     true,
+	"preshared-key":      true,
+	"private-key":        true,
+	"encrypted-password": true,
+	"password":           true,
+	"tsig-secret":        true,
+	"api-key":            true,
+}
+
+// secretLeafKeywordsByRoot qualifies a DUAL-USE keyword by the top-level
+// stanza it appears under: secret in one place, an ordinary identifier in
+// another.
+//
+// `community` is the worked example and the reason this map exists. Under
+// `snmp` the community string IS the credential; under `policy-options` a
+// community is a BGP route-target name, and #4097's gate exists specifically to
+// show the operator WHICH community member carried a newline. Blanket-keying on
+// the keyword redacted the BGP one and broke that diagnostic — caught by
+// TestFRRPolicyValueControlCharsBlocked_4097, not by inspection.
+//
+// The lesson generalises: keyword-keying is right for a leaf spelled the same
+// wherever it appears, and wrong the moment a spelling is reused for something
+// that is not a credential. Add to THIS map, not the set above, whenever that
+// is true.
+var secretLeafKeywordsByRoot = map[string]map[string]bool{
+	"community": {"snmp": true},
+}
+
+// IsSecretLeafKeyword reports whether an UNAMBIGUOUS config leaf keyword
+// carries a credential as its value. Dual-use keywords are resolved by
+// isSecretLeaf, which also considers the stanza the leaf appears under.
+func IsSecretLeafKeyword(keyword string) bool {
+	return secretLeafKeywords[keyword]
+}
+
+// isSecretLeaf reports whether the leaf named by keys carries a credential,
+// given the path prefix it was found under.
+func isSecretLeaf(prefix string, keys []string) bool {
+	if len(keys) == 0 {
+		return false
+	}
+	kw := keys[0]
+	if secretLeafKeywords[kw] {
+		return true
+	}
+	roots, dualUse := secretLeafKeywordsByRoot[kw]
+	if !dualUse {
+		return false
+	}
+	root := prefix
+	if i := strings.IndexByte(root, ' '); i >= 0 {
+		root = root[:i]
+	}
+	return roots[root]
+}
+
+// describeControlChar names the first control character in s by offset and
+// byte value, WITHOUT reproducing the surrounding value (#6625). That is
+// enough to locate and fix the input — a leading tab from a password manager
+// is offset 0, a trailing CR is the last offset — while disclosing nothing.
+func describeControlChar(s string) string {
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 || s[i] == 0x7f {
+			return fmt.Sprintf("a control character (0x%02x) at byte offset %d", s[i], i)
+		}
+	}
+	return "a control character"
+}
+
+// redactSecretKeys returns keys with every VALUE token replaced by the
+// redaction sentinel when the leaf keyword is a credential (#6625). Keys[0] is
+// the leaf name and is kept — the operator needs to know WHICH statement was
+// rejected.
+func redactSecretKeys(prefix string, keys []string) []string {
+	if !isSecretLeaf(prefix, keys) {
+		return keys
+	}
+	out := make([]string, len(keys))
+	out[0] = keys[0]
+	for i := 1; i < len(keys); i++ {
+		out[i] = SecretRedacted
+	}
+	return out
 }

--- a/pkg/config/secret_in_error_6625_test.go
+++ b/pkg/config/secret_in_error_6625_test.go
@@ -1,0 +1,227 @@
+package config
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// #6625 — the #1798 control-character gate rendered a credential leaf's VALUE
+// into its error.
+//
+// For a leaf whose value is a secret (a cluster PSK, an IKE pre-shared-key, a
+// WireGuard private key, an encrypted password, a TSIG secret, an SNMP
+// community) that put the secret into everything that consumes the error:
+// commit output on the CLI, the daemon log, the audit journal.
+//
+// It fired twice per rejection — once in the rendered PATH (joinNodePath
+// renders every key, and the value IS a key) and once in the quoted value.
+//
+// The trigger is narrow but routine: a PSK pasted from a password manager, a
+// terminal or a file commonly carries a leading or trailing tab or CR. The
+// operator does the ordinary thing, the commit is refused, and the refusal
+// publishes the key they were trying to set privately.
+//
+// The project already treats secret rendering as a hard rule — Secret redacts
+// on String()/marshal, the #4406 golden redacts ControlLinkAuthKey, and
+// pkg/grpcapi carries an AST gate (#6532/#6602) against unwrapping a Secret
+// into a rendered string. This validator bypassed all of it by formatting the
+// raw value.
+
+// controlCharErr runs the strict commit-path control-character gate and returns
+// its error.
+func controlCharErr6625(t *testing.T, keys ...string) error {
+	t.Helper()
+	return controlCharErrUnder6625(t, "", keys...)
+}
+
+// controlCharErrUnder6625 runs the gate with an explicit path prefix, so a
+// DUAL-USE keyword can be exercised under each stanza it appears in.
+func controlCharErrUnder6625(t *testing.T, prefix string, keys ...string) error {
+	t.Helper()
+	return validateNodesControlChars([]*Node{{Keys: keys, IsLeaf: true}}, prefix)
+}
+
+// TestSecretValueNotRenderedInControlCharError6625 is the fail-on-revert case.
+//
+// FAIL-ON-REVERT: drop the secretLeaf branch from validateNodesControlChars, or
+// stop redacting the keys handed to joinNodePath — either alone re-publishes
+// the credential.
+func TestSecretValueNotRenderedInControlCharError6625(t *testing.T) {
+	for _, leaf := range []string{
+		"authentication-key",
+		"pre-shared-key",
+		"preshared-key",
+		"private-key",
+		"encrypted-password",
+		"password",
+		"tsig-secret",
+		"api-key",
+	} {
+		t.Run(leaf, func(t *testing.T) {
+			const secret = "SUPER-SECRET-PSK-VALUE"
+			err := controlCharErr6625(t, leaf, "\t"+secret+"\t")
+			if err == nil {
+				t.Fatalf("setup: a control character in %s must still be REJECTED", leaf)
+			}
+			if strings.Contains(err.Error(), secret) {
+				t.Fatalf("#6625: the %s error PUBLISHES the credential — it reaches commit "+
+					"output, the daemon log and the audit journal, which is precisely what the "+
+					"operator was setting privately.\ngot: %s", leaf, err.Error())
+			}
+			// It must still be actionable: name the statement, and say where
+			// and what the offending byte is.
+			if !strings.Contains(err.Error(), leaf) {
+				t.Fatalf("the error must still name the statement %q; got: %s", leaf, err.Error())
+			}
+			if !strings.Contains(err.Error(), "byte offset") {
+				t.Fatalf("the error must locate the offending byte so the operator can fix the "+
+					"input without seeing it echoed; got: %s", err.Error())
+			}
+			if !strings.Contains(err.Error(), "0x09") {
+				t.Fatalf("the error must name the offending byte class; got: %s", err.Error())
+			}
+		})
+	}
+}
+
+// TestNonSecretValueStillRenderedInControlCharError6625 is the negative
+// control: the fix must not blanket-suppress a genuinely useful diagnostic.
+//
+// For an ordinary leaf the value is exactly what the operator needs to see —
+// which invisible character got pasted into their host-name or description.
+//
+// FAIL-ON-REVERT: make the redaction unconditional (drop the secretLeafKeywords
+// lookup) and this reds.
+func TestNonSecretValueStillRenderedInControlCharError6625(t *testing.T) {
+	for _, leaf := range []string{"host-name", "description", "domain-name"} {
+		t.Run(leaf, func(t *testing.T) {
+			const val = "my\thost"
+			err := controlCharErr6625(t, leaf, val)
+			if err == nil {
+				t.Fatalf("setup: a control character in %s must be REJECTED", leaf)
+			}
+			// %q ESCAPES the tab, so the rendered form is the quoted literal
+			// `"my\thost"`, not a raw tab. Asserting the raw byte would fail
+			// against a correct implementation.
+			if !strings.Contains(err.Error(), strconv.Quote(val)) {
+				t.Fatalf("#6625 over-correction: a NON-secret leaf must still render its value — "+
+					"that diagnostic is the whole point for an ordinary statement; got: %s",
+					err.Error())
+			}
+		})
+	}
+}
+
+// TestSecretLeafKeywordsExistInSchema pins the set against the grammar: every
+// keyword must be a real schema leaf, so the set cannot accumulate entries for
+// statements that no longer exist and quietly look bigger than it is.
+//
+// FAIL-ON-REVERT: add a keyword to secretLeafKeywords that appears nowhere in
+// the schema.
+func TestSecretLeafKeywordsExistInSchema(t *testing.T) {
+	if len(secretLeafKeywords) == 0 {
+		t.Fatal("secretLeafKeywords is EMPTY — every credential value would be rendered, and " +
+			"the redaction tests would pass vacuously against an empty set")
+	}
+	for kw := range secretLeafKeywords {
+		if !schemaHasLeafKeyword(t, kw) {
+			t.Errorf("#6625: secretLeafKeywords contains %q, which is not a leaf keyword anywhere "+
+				"in setSchema — a dead entry makes the set look broader than it is", kw)
+		}
+	}
+}
+
+// TestSecretLeafKeywordsCoverKnownCredentials is the coverage direction, and it
+// is the one that matters: a credential leaf MISSING from the set leaks, while
+// a spurious one merely costs a diagnostic.
+//
+// The list here is deliberately independent of the production set — it is
+// derived from the leaves the compiler wraps in Secret() — so the two must
+// agree rather than one being read off the other.
+//
+// FAIL-ON-REVERT: remove any of these from secretLeafKeywords.
+func TestSecretLeafKeywordsCoverKnownCredentials(t *testing.T) {
+	// Every one of these is wrapped in config.Secret by the compiler:
+	// authentication-key (chassis cluster / VRRP / OSPF / RIP / IS-IS),
+	// pre-shared-key (IKE), preshared-key + private-key (WireGuard),
+	// encrypted-password (system login / root-authentication),
+	// password (web-management auth), tsig-secret (DDNS), api-key (REST auth).
+	for _, kw := range []string{
+		"authentication-key",
+		"pre-shared-key",
+		"preshared-key",
+		"private-key",
+		"encrypted-password",
+		"password",
+		"tsig-secret",
+		"api-key",
+	} {
+		if !secretLeafKeywords[kw] {
+			t.Errorf("#6625: %q is a credential leaf (the compiler wraps it in Secret) but is "+
+				"NOT in secretLeafKeywords, so a control character in it publishes the "+
+				"credential to commit output, the daemon log and the audit journal", kw)
+		}
+	}
+}
+
+// schemaHasLeafKeyword reports whether keyword appears as a leaf name anywhere
+// in setSchema.
+func schemaHasLeafKeyword(t *testing.T, keyword string) bool {
+	t.Helper()
+	seen := map[*schemaNode]bool{}
+	var walk func(n *schemaNode) bool
+	walk = func(n *schemaNode) bool {
+		if n == nil || seen[n] {
+			return false
+		}
+		seen[n] = true
+		for name, child := range n.children {
+			if name == keyword {
+				return true
+			}
+			if walk(child) {
+				return true
+			}
+		}
+		return walk(n.wildcard)
+	}
+	return walk(setSchema)
+}
+
+// TestDualUseCommunityRedactedOnlyUnderSNMP6625 pins BOTH sides of the one
+// keyword whose secrecy depends on where it appears.
+//
+// Under `snmp` the community string IS the credential. Under `policy-options`
+// it is a BGP route-target name, and #4097's gate exists specifically to show
+// the operator WHICH community member carried a newline.
+//
+// An earlier revision of this fix keyed secrecy on the KEYWORD alone and
+// redacted both — which broke that diagnostic and was caught by
+// TestFRRPolicyValueControlCharsBlocked_4097, not by inspection. This test
+// exists so the distinction cannot regress silently in either direction.
+//
+// FAIL-ON-REVERT: move "community" into secretLeafKeywords (the BGP leg reds),
+// or delete secretLeafKeywordsByRoot (the SNMP leg reds).
+func TestDualUseCommunityRedactedOnlyUnderSNMP6625(t *testing.T) {
+	const val = "\tSECRET-COMMUNITY-STRING\t"
+
+	snmpErr := controlCharErrUnder6625(t, "snmp", "community", val)
+	if snmpErr == nil {
+		t.Fatal("setup: a control character in an snmp community must be REJECTED")
+	}
+	if strings.Contains(snmpErr.Error(), "SECRET-COMMUNITY-STRING") {
+		t.Fatalf("#6625: an SNMP community string IS a credential and must not be rendered; "+
+			"got: %s", snmpErr.Error())
+	}
+
+	bgpErr := controlCharErrUnder6625(t, "policy-options", "community", val)
+	if bgpErr == nil {
+		t.Fatal("setup: a control character in a policy-options community must be REJECTED")
+	}
+	if !strings.Contains(bgpErr.Error(), strconv.Quote(val)) {
+		t.Fatalf("#6625 over-correction: a BGP policy-options community is a route-target NAME, "+
+			"not a credential — #4097's gate exists to show WHICH member carried the control "+
+			"character, and redacting it destroys that diagnostic; got: %s", bgpErr.Error())
+	}
+}


### PR DESCRIPTION
Closes #6625

## The leak

The #1798 control-character gate formatted the offending **value** into its error. For a credential leaf that published the credential to everything downstream: commit output on the CLI, the daemon log, the audit journal.

It leaked **twice** per rejection — `joinNodePath` renders every key, and for a leaf statement the value *is* a key:

```
chassis cluster authentication-key  MY-PSK : value "\tMY-PSK\t" contains control characters ...
```

Narrow trigger, routine in practice: a PSK pasted from a password manager, a terminal or a file commonly carries a leading/trailing tab or CR. The operator does the ordinary thing, the commit is refused, and the refusal publishes the key they were setting privately. #6611 makes it worse by turning the control-link PSK into a leaf operators are expected to type and rotate.

The project already treats secret rendering as a hard rule — `Secret` redacts on `String()`/marshal, the #4406 golden redacts `ControlLinkAuthKey`, and `pkg/grpcapi` carries an AST gate (#6532/#6602) against unwrapping a `Secret` into a rendered string. **This validator bypassed all of it.**

## The fix

A credential leaf reports *where* and *what*, never the value:

```
... : value contains a control character (0x09) at byte offset 0 ...
```

Enough to fix the input — a leading tab is offset 0, a trailing CR is the last offset — and it discloses nothing. **Non-credential leaves keep rendering the value**, because for an ordinary statement seeing which invisible character got pasted *is* the diagnostic.

The gate runs on the AST, *before* compilation, so the compiled `Secret` type is unavailable. Secrecy is keyed on the leaf **keyword**: a credential leaf is spelled the same wherever it appears (`authentication-key` is a secret under chassis cluster, VRRP, OSPF, RIP and IS-IS alike), so a path-keyed set would have to enumerate all of them and would silently miss the next one.

## `community` is the exception that shaped the design

Under `snmp` the community string **is** the credential. Under `policy-options` it is a BGP route-target name, and **#4097's gate exists specifically to show the operator which member carried a newline**.

An earlier revision of this fix keyed on the keyword alone and redacted both — which broke that diagnostic. It was caught by `TestFRRPolicyValueControlCharsBlocked_4097`, **not by inspection**; my own "err toward inclusion" reasoning had explicitly considered BGP communities and included the keyword anyway.

Dual-use keywords are now qualified by the stanza they appear under, and the lesson is recorded where the next such keyword will be added: *keyword-keying is right for a leaf spelled the same everywhere, and wrong the moment a spelling is reused for something that is not a credential.* `TestDualUseCommunityRedactedOnlyUnderSNMP6625` pins both sides.

## Mutation matrix

Each verified **applied and compiling** before its run; production restored verbatim between cells.

| # | Mutation | Result |
|---|---|---|
| E1 | secret branch renders the value again | **RED** |
| E2 | stop redacting the **path** (leak via `joinNodePath`) | **RED** |
| E3 | redaction unconditional (over-correct) | **RED** |
| E4 | drop a credential keyword from the set | **RED** |
| E5 | make `community` unconditionally secret | **RED** |

**E3 and E5 are the over-correction directions** — a fix that blanket-suppressed every value would satisfy a leak-only matrix while destroying the diagnostic the gate exists to provide.

**E1's first attempt did not compile**, and a red on a non-compiling tree is void, so it was redone as a compiling mutation rather than counted. Noting it because a build-failure red and an assertion red are indistinguishable in an exit code.

## Validation

- `go build ./...` clean; `go vet` clean.
- `go test -count=1 ./pkg/config/` — ok, 44.5s.
- `pkg/configstore`, `pkg/daemon` green.
- Green baseline before any edit; red-first confirmed on all eight credential leaves.

Two drift pins beyond the behavioural tests: every keyword must exist in the schema (no dead entries), and every leaf the compiler wraps in `Secret()` must be covered — the latter derived independently of the production set, so the two must agree rather than one being read off the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gcdxy5mCofwyVWHUKzhU9F
