### PR TITLE
ddns: re-run the error-tree bound where a custom As installs a subtree (#6635)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-08-21 — #6635 ddns: the error-tree bound follows a caller-supplied `As`
+
+- **Timestamp**: 2026-08-21
+- **Action**: `errTreeWithinBound` ran ONCE, at the two public scrubber entry
+  points, validating the `Unwrap` tree AS PRESENTED there — which is not the
+  tree the stdlib ends up walking. `errors.As` dispatches to an `As(any) bool`
+  method the CALLER defines, and that method returns a value of the caller's
+  choosing: an error with a one-node tree (guard passes) can install a fresh
+  `*url.Error` whose `Err` self-unwraps, and the next `errors.As` spins forever.
+  REPRODUCED AT MY HEAD before fixing: the entry guard returned true and
+  `scrubURLError` did not return in 5s.
+  The guard now runs at every entry to `scrubURLErrorAt` / `scrubInnerErrorAt`,
+  which is where a caller-supplied subtree can first appear; the public wrappers
+  become thin delegates. Cost is a re-walk per level, at most maxUnwrapDepth^2
+  Unwrap calls on an error path that runs once per reconcile tick.
+  NOT CLOSED, deliberately and stated: a caller-supplied `Error()`/`Unwrap()`
+  that BLOCKS. No placement of the guard fixes that — it needs a watchdog
+  goroutine per render — and the reason to decline is not only cost: a blocking
+  `Error()` hangs ANY fmt render of that error anywhere in the daemon, so
+  bounding it inside one package's scrubber buys nothing.
+  REACHABILITY, checked rather than assumed: caller-supplied, in-process only.
+  Production builds its own client; the only caller passing one is the Surface A
+  reconcile path passing its own. A provider chooses BYTES over the wire, not a
+  Go type. Robustness, NOT a live DoS, and the PR says so.
+- **File(s)**: `pkg/ddns/backend_http.go`,
+  `pkg/ddns/errtree_bound_after_as_6635_test.go` (new), `pkg/ddns/README.md`
+
 ## 2026-08-21 — #6618 `any-service` protocol breadth: decided KEEP, bound by a verdict lock
 
 - **Timestamp**: 2026-08-21

--- a/_Log.md
+++ b/_Log.md
@@ -22,6 +22,14 @@
   Production builds its own client; the only caller passing one is the Surface A
   reconcile path passing its own. A provider chooses BYTES over the wire, not a
   Go type. Robustness, NOT a live DoS, and the PR says so.
+  MATRIX FINDING, kept rather than tuned away: narrowing the `scrubURLErrorAt`
+  guard to `depth == 0` stays GREEN, because the only depth>0 caller hands over
+  a value `errors.As` already resolved to a `*url.Error`, matched at node 0
+  without walking. That is a reachability argument about a caller, which this
+  package does not build invariants on, so the guard stays unconditional and
+  the redundancy is documented instead of removed. Removing it ENTIRELY hangs
+  the pre-existing `TestSelfUnwrappingErrorTerminates` — a red only the FULL
+  suite shows, not `-run 6635`.
 - **File(s)**: `pkg/ddns/backend_http.go`,
   `pkg/ddns/errtree_bound_after_as_6635_test.go` (new), `pkg/ddns/README.md`
 

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -405,14 +405,60 @@ Two further consequences:
   error that unwraps to itself hangs them and an `Unwrap() []error` self-cycle
   overflows the stack; `errTreeWithinBound` walks the tree under a node budget
   before the first `errors.As` and withholds when it blows.
-  **What that bounds, precisely:** the `Unwrap` tree as presented at entry. It
-  does NOT bound a caller's other methods. A custom `As` can install a fresh
-  subtree that was never prewalked, and an `Error()` that blocks or recurses
-  hangs at the first render regardless of tree shape — neither is reachable
-  without a caller-supplied hostile error, and no production caller supplies
-  one, but the bound is not total and should not be read as such. The diagnostic cost — `net/http`'s internal prose, the failing
-  address, the unknown-error type name — is accepted: an unrecognised error is
-  exactly the case where we cannot say what it contains.
+  **What that bounds, precisely (#6635).** The guard used to run ONCE, at the
+  two public entry points, validating the `Unwrap` tree *as presented there* —
+  which is not the tree the stdlib ends up walking. `errors.As` dispatches to an
+  `As(any) bool` method the CALLER defines, and that method hands back a value
+  of the caller's choosing:
+
+  ```go
+  func (e hostile) As(target any) bool {
+      *target.(**url.Error) = &url.Error{Err: selfUnwrappingError{}}
+      return true
+  }
+  ```
+
+  The tree at entry is a single node, so the guard passed; the subtree the `As`
+  installed was never walked, and `scrubURLErrorAt` descended straight into it
+  and spun forever inside the next `errors.As`. Reproduced before the fix: the
+  entry guard returned true and the scrubber did not return.
+
+  The guard now runs at **every entry to the depth-carrying functions**, which
+  is where a caller-supplied subtree can first appear, and the public wrappers
+  are thin delegates. Cost is a re-walk per level — at most
+  `maxUnwrapDepth`² `Unwrap` calls, on an error path that runs at most once per
+  reconcile tick and only for trees that are already pathological; a legitimate
+  error walks one or two levels.
+
+  **Still NOT bounded, deliberately.** A caller-supplied `Error()` or `Unwrap()`
+  that BLOCKS hangs the first render or the guard itself, and no placement of
+  the guard fixes that — it would need a watchdog goroutine per render. The
+  reason for not doing it is not only cost: a blocking `Error()` hangs *any*
+  `fmt` render of that error anywhere in the daemon, so bounding it inside one
+  package's scrubber buys nothing while adding a goroutine to a path that must
+  stay cheap.
+
+  **Reachability, so this is not read as a live DoS.** The bypass needs a Go
+  error VALUE with hostile methods. Production builds its own client
+  (`newProviderHTTPClient` → `newHTTPClientBound`); `ensureProviderHTTPClient`
+  accepts a caller-supplied `*http.Client`, but the only production caller is
+  the Surface A reconcile path passing its own cached client, and every error on
+  these paths originates in `net/http` or the stdlib. A provider chooses BYTES,
+  not a Go type. This is robustness and model consistency, not a reachable
+  denial of service.
+
+  Gates: `errtree_bound_after_as_6635_test.go`. The failure mode is a HANG, so
+  every cell runs the scrubber on a goroutine with a deadline and the test
+  RETURNING is the signal — a direct call would wedge the package run instead of
+  failing. Each cell first asserts the presented tree PASSES `errTreeWithinBound`,
+  which is what makes it a test of the installed subtree rather than a re-test of
+  the round-11 guard; one cell enters the bypass one level down so a fix that
+  guarded only the first entry fails. `TestOrdinaryErrorsStillClassifyNormally_6635`
+  is the over-reach guard — withholding everything satisfies every hang cell and
+  destroys the classification this package exists to produce. The diagnostic
+  cost — `net/http`'s internal prose, the failing address, the unknown-error
+  type name — is accepted: an unrecognised error is exactly the case where we
+  cannot say what it contains.
 - **`guardRedirect`'s refusals name no provider-supplied host at all.** The
   grammar (`refusalHost`/`safeScheme`) bounds a host's character SET — zone ids,
   raw non-ASCII and anything that is not a plain reg-name are withheld — but it

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -430,6 +430,17 @@ Two further consequences:
   reconcile tick and only for trees that are already pathological; a legitimate
   error walks one or two levels.
 
+  The guard in `scrubURLErrorAt` is **unconditional rather than `depth == 0`**,
+  and the mutation matrix is explicit about the trade. Removing it hangs
+  `TestSelfUnwrappingErrorTerminates` — with the wrapper reduced to a delegate,
+  depth 0 IS the public entry and round 12's property lives there. Narrowing it
+  to depth 0 alone stays green, because today the only depth>0 caller is
+  `scrubInnerErrorAt` handing over a value `errors.As` already resolved to a
+  `*url.Error`, which the next `errors.As` matches at node 0 without walking
+  anything. That is a reachability argument about a caller, and this package
+  does not build invariants on those — the same stance the dyndns2 endpoint
+  scrub takes. It is kept total.
+
   **Still NOT bounded, deliberately.** A caller-supplied `Error()` or `Unwrap()`
   that BLOCKS hangs the first render or the guard itself, and no placement of
   the guard fixes that — it would need a watchdog goroutine per render. The

--- a/pkg/ddns/backend_http.go
+++ b/pkg/ddns/backend_http.go
@@ -792,6 +792,20 @@ func scrubURLErrorAt(err error, depth int) string {
 	// RE-GUARD AT EVERY ENTRY, not only at the public one (#6635). See
 	// errTreeWithinBound's own comment for why the guard has to precede the
 	// first errors.As; this is about which TREE it is applied to.
+	//
+	// UNCONDITIONAL, not `depth == 0 &&`, and the mutation matrix says why that
+	// matters. Removing this entirely hangs TestSelfUnwrappingErrorTerminates —
+	// scrubURLError is now a thin delegate, so depth 0 IS the public entry and
+	// round 12's property lives here. Narrowing it to depth 0 alone stays green,
+	// because today the only depth>0 caller is scrubInnerErrorAt handing over a
+	// value errors.As already resolved to a *url.Error, which the errors.As
+	// below then matches at node 0 without walking anything.
+	//
+	// That is a REACHABILITY argument about a caller, and this package does not
+	// build invariants on those — the same stance the dyndns2 endpoint scrub
+	// takes about resolveDyndns2Endpoint having already parsed. A future caller
+	// reaching this function with an unresolved tree would silently lose the
+	// bound. The guard costs a walk of an already-small tree; keep it total.
 	if !errTreeWithinBound(err) {
 		return string(transportWithheld)
 	}

--- a/pkg/ddns/backend_http.go
+++ b/pkg/ddns/backend_http.go
@@ -701,6 +701,38 @@ func doRequest(ctx context.Context, client *http.Client, req *http.Request) (int
 // for identity panics when the dynamic type is not comparable. A budget is
 // sufficient anyway -- a cycle exhausts it, and so does a nest deep enough to
 // overflow. Recursion here is self-limiting because every call spends budget.
+//
+// #6635 MOVED THE CALL SITES. Round 11's guard ran once, at the two PUBLIC
+// entry points, and validated the tree AS PRESENTED THERE. That is not the tree
+// the stdlib ends up walking, because errors.As dispatches to an As(any) bool
+// method the caller defines, and that method hands back a value of the caller's
+// choosing:
+//
+//	func (e hostile) As(target any) bool {
+//	    *target.(**url.Error) = &url.Error{Err: selfUnwrappingError{}}
+//	    return true
+//	}
+//
+// The tree at entry is a single node, so the guard passes; the SUBTREE the As
+// installs was never walked, and scrubURLErrorAt descends straight into it and
+// spins forever inside the next errors.As. Reproduced before the fix: the entry
+// guard returned true and the scrubber did not return.
+//
+// So the guard now runs at every entry to the depth-carrying functions, which
+// is where a caller-supplied subtree can first appear. The cost is a re-walk
+// per level -- at most maxUnwrapDepth^2 Unwrap calls, on an error path that
+// runs at most once per reconcile tick, and only for trees that are already
+// pathological. A legitimate error walks one or two levels.
+//
+// WHAT IS STILL NOT BOUNDED, stated rather than implied. A caller-supplied
+// Error() or Unwrap() that BLOCKS or never returns hangs the first render or
+// the guard itself, and no placement of this function fixes that. Bounding it
+// would need a watchdog goroutine per render. That is deliberately not done,
+// and the reason is not only cost: a blocking Error() hangs ANY fmt render of
+// that error anywhere in the daemon, so bounding it inside one package's
+// scrubber buys nothing while adding a goroutine to a path that must stay
+// cheap. Neither is reachable in production -- errors on these paths come from
+// net/http and the stdlib, and a provider can choose BYTES but not a Go type.
 func errTreeWithinBound(err error) bool {
 	budget := maxUnwrapDepth
 	var walk func(error) bool
@@ -743,9 +775,6 @@ func errTreeWithinBound(err error) bool {
 }
 
 func scrubURLError(err error) string {
-	if !errTreeWithinBound(err) {
-		return string(transportWithheld)
-	}
 	return scrubURLErrorAt(err, 0)
 }
 
@@ -758,6 +787,12 @@ func scrubURLError(err error) string {
 // budgeted for. A deep non-cyclic nest did the same.
 func scrubURLErrorAt(err error, depth int) string {
 	if depth >= maxUnwrapDepth {
+		return string(transportWithheld)
+	}
+	// RE-GUARD AT EVERY ENTRY, not only at the public one (#6635). See
+	// errTreeWithinBound's own comment for why the guard has to precede the
+	// first errors.As; this is about which TREE it is applied to.
+	if !errTreeWithinBound(err) {
 		return string(transportWithheld)
 	}
 	var ue *url.Error
@@ -1048,12 +1083,8 @@ const (
 // prose, the failing address, and the unknown-error type name are all gone. An
 // unrecognised error is exactly the case where we cannot say what it contains.
 func scrubInnerError(err error) string {
-	// Same stdlib-traversal guard as scrubURLError: this is an entry point for
-	// a caller-supplied error, and everything below it (errors.Is, errors.As,
-	// classifyTransportError) walks the tree with the caller's own Unwrap.
-	if !errTreeWithinBound(err) {
-		return string(transportWithheld)
-	}
+	// The stdlib-traversal guard lives in scrubInnerErrorAt now, so it applies
+	// to every entry rather than only this one (#6635).
 	return scrubInnerErrorAt(err, 0)
 }
 
@@ -1065,6 +1096,13 @@ func scrubInnerErrorAt(err error, depth int) string {
 	}
 	if err == nil {
 		return string(transportNil)
+	}
+	// RE-GUARD (#6635). Everything below — findRedirectRefusal aside, which
+	// walks with its own bounded loop — hands this tree to the stdlib:
+	// errors.As here, and errors.Is/errors.As throughout
+	// classifyTransportError. Each dispatches to the caller's own Unwrap.
+	if !errTreeWithinBound(err) {
+		return string(transportWithheld)
 	}
 	// Our own typed refusal, found by assertion over the chain.
 	if r := findRedirectRefusal(err); r != nil {

--- a/pkg/ddns/errtree_bound_after_as_6635_test.go
+++ b/pkg/ddns/errtree_bound_after_as_6635_test.go
@@ -1,0 +1,254 @@
+package ddns
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// errtree_bound_after_as_6635_test.go: #6635. errTreeWithinBound validated the
+// error tree AS PRESENTED at the public entry point, and that is not the tree
+// the stdlib ends up walking. errors.As dispatches to an As(any) bool method the
+// CALLER defines, and that method hands back a value of the caller's choosing —
+// so an error with a one-node tree (guard passes) can install a fresh
+// *url.Error whose Err self-unwraps, and the very next errors.As spins forever.
+//
+// THE FAILURE MODE IS A HANG, so the test RETURNING is the signal. Every cell
+// runs the scrubber on a goroutine with a deadline: without the fix the cell
+// times out; with it, it returns. A plain call would wedge the whole package
+// run instead of failing, which is why none of these call the scrubber directly.
+//
+// REACHABILITY, stated so nobody reads this as a live DoS. The bypass needs a Go
+// error VALUE with hostile methods. Production builds its own client
+// (newProviderHTTPClient → newHTTPClientBound); ensureProviderHTTPClient does
+// accept a caller-supplied *http.Client, but the only production caller is the
+// Surface A reconcile path passing its own cached client, and every error on
+// these paths originates in net/http or the stdlib. A provider can choose BYTES
+// over the wire; it cannot choose a Go type. This is robustness and
+// model-consistency, not a reachable denial of service.
+
+// scrubDeadline is generous: the cells that pass return in microseconds, and the
+// ones that would fail do not return at all, so a large value costs nothing on a
+// green run and only bounds how long a red takes to report.
+const scrubDeadline = 5 * time.Second
+
+// selfUnwrapping's Unwrap returns ITSELF, which makes any stdlib traversal
+// (errors.Is, errors.As, errors.Unwrap in a loop) spin forever.
+type selfUnwrapping struct{}
+
+func (selfUnwrapping) Error() string   { return "self-unwrapping" }
+func (s selfUnwrapping) Unwrap() error { return s }
+
+// selfCycleMulti is the Unwrap() []error form: it recurses until the STACK
+// overflows, which is a `fatal error` recover() cannot catch — strictly worse
+// than a hang.
+type selfCycleMulti struct{}
+
+func (selfCycleMulti) Error() string     { return "self-cycle-multi" }
+func (s selfCycleMulti) Unwrap() []error { return []error{s} }
+
+// asInstallsHostileSubtree has a benign tree AS PRESENTED — one node, no Unwrap
+// at all — so the entry guard passes. Its As then installs a *url.Error whose
+// Err is a subtree that was never walked. This is the exact bypass #6635
+// describes.
+type asInstallsHostileSubtree struct{ inner error }
+
+func (asInstallsHostileSubtree) Error() string { return "as-installer" }
+func (a asInstallsHostileSubtree) As(target any) bool {
+	if p, isURLErr := target.(**url.Error); isURLErr {
+		*p = &url.Error{Op: "Get", URL: "https://prov.example/upd", Err: a.inner}
+		return true
+	}
+	return false
+}
+
+// runWithDeadline runs f on a goroutine and reports whether it returned in time.
+// The goroutine is deliberately NOT waited on when it times out: it may never
+// return, which is the defect.
+func runWithDeadline(t *testing.T, f func() string) (string, bool) {
+	t.Helper()
+	done := make(chan string, 1)
+	go func() { done <- f() }()
+	select {
+	case s := <-done:
+		return s, true
+	case <-time.After(scrubDeadline):
+		return "", false
+	}
+}
+
+func TestScrubbersBoundASubtreeInstalledByACustomAs_6635(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		inner error
+		// via is the public entry point under test. Both are exercised: the
+		// bypass is reachable through either, because scrubInnerErrorAt and
+		// scrubURLErrorAt are mutually recursive.
+		via func(error) string
+	}{
+		{
+			name:  "self_unwrapping_via_scrubURLError",
+			inner: selfUnwrapping{},
+			via:   scrubURLError,
+		},
+		{
+			name:  "self_unwrapping_via_scrubInnerError",
+			inner: selfUnwrapping{},
+			via:   scrubInnerError,
+		},
+		{
+			name:  "unwrap_slice_cycle_via_scrubURLError",
+			inner: selfCycleMulti{},
+			via:   scrubURLError,
+		},
+		{
+			name:  "unwrap_slice_cycle_via_scrubInnerError",
+			inner: selfCycleMulti{},
+			via:   scrubInnerError,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hostile := asInstallsHostileSubtree{inner: tc.inner}
+
+			// THE PRECONDITION that makes this a bypass and not a re-test of the
+			// round-11 guard. If the entry guard rejected this tree the cell
+			// would prove nothing about what a custom As installs.
+			if !errTreeWithinBound(hostile) {
+				t.Fatal("the tree AS PRESENTED must pass the entry guard — it is a single node " +
+					"with no Unwrap. If it does not, this cell is testing the old guard, not " +
+					"the subtree a custom As installs.")
+			}
+
+			got, returned := runWithDeadline(t, func() string { return tc.via(hostile) })
+			if !returned {
+				t.Fatalf("HUNG: the scrubber did not return within %s. A custom As installed a "+
+					"subtree the entry guard never walked, and the next stdlib traversal spins "+
+					"on it. Re-run errTreeWithinBound at every entry to the depth-carrying "+
+					"scrubbers, not only at the public one.", scrubDeadline)
+			}
+			// WHAT IT BECAME. Returning is necessary but not sufficient: a
+			// scrubber that returned the caller's own text would also "return".
+			//
+			// CONTAINS, not equality, and the difference is the point. On the
+			// scrubURLError path the As hands back a *url.Error whose URL field
+			// it also chose, and that field is still rendered — through
+			// safeURLTarget's closed grammar, which reduces it to
+			// scheme://host and drops the path. So the expected result is the
+			// safe target PLUS a withheld inner cause, not a bare constant.
+			// Requiring equality would have been an assertion about the round-8
+			// URL grammar, not about this fix.
+			if !strings.Contains(got, string(transportWithheld)) {
+				t.Errorf("the unbounded subtree must be WITHHELD, not rendered; got %q, want it "+
+					"to contain %q", got, string(transportWithheld))
+			}
+			// And nothing from the hostile subtree's own Error() may appear.
+			if strings.Contains(got, tc.inner.Error()) {
+				t.Errorf("the hostile subtree's own text reached the render: %q", got)
+			}
+		})
+	}
+}
+
+// TestNestedHostileSubtreeIsBoundAtDepth_6635 pushes the installed subtree one
+// level deeper — a *url.Error wrapping the installer — so the bypass is entered
+// through the recursive path rather than at depth 0. A fix that guarded only the
+// public entry point, or only the first level, passes the cells above and fails
+// here.
+func TestNestedHostileSubtreeIsBoundAtDepth_6635(t *testing.T) {
+	hostile := &url.Error{
+		Op:  "Get",
+		URL: "https://prov.example/upd",
+		Err: asInstallsHostileSubtree{inner: selfUnwrapping{}},
+	}
+	if !errTreeWithinBound(hostile) {
+		t.Fatal("the presented tree is two nodes and must pass the entry guard")
+	}
+	got, returned := runWithDeadline(t, func() string { return scrubURLError(hostile) })
+	if !returned {
+		t.Fatalf("HUNG at depth: the guard must run at EVERY entry to the depth-carrying "+
+			"scrubbers, not only the first. (%s deadline)", scrubDeadline)
+	}
+	if !strings.Contains(got, string(transportWithheld)) {
+		t.Errorf("the unbounded subtree must be withheld somewhere in the render; got %q", got)
+	}
+}
+
+// TestOrdinaryErrorsStillClassifyNormally_6635 is the over-reach guard. Adding a
+// guard at every recursion entry must not start withholding ordinary errors:
+// this package's whole diagnostic value is the transport classification, and a
+// fix that withheld everything would satisfy every hang test above.
+func TestOrdinaryErrorsStillClassifyNormally_6635(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "wrapped_connection_refused",
+			err: &url.Error{Op: "Get", URL: "https://prov.example/upd",
+				Err: syscall.ECONNREFUSED},
+			want: string(transportConnRefused),
+		},
+		{
+			name: "deeply_but_finitely_wrapped",
+			// Ten ordinary %w layers: well inside the budget, and the shape a
+			// real error actually has.
+			err:  wrapN(&url.Error{Op: "Get", URL: "https://prov.example/upd", Err: syscall.ECONNRESET}, 10),
+			want: string(transportConnReset),
+		},
+		{
+			name: "plain_transport_error",
+			err:  syscall.ETIMEDOUT,
+			want: string(transportConnTimedOut),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, returned := runWithDeadline(t, func() string { return scrubURLError(tc.err) })
+			if !returned {
+				t.Fatalf("an ORDINARY error must not hang the scrubber (%s deadline)", scrubDeadline)
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("the transport classification must survive the re-guard — withholding "+
+					"everything passes every hang test and destroys the diagnostic.\n"+
+					"  got:  %q\n  want to contain: %q", got, tc.want)
+			}
+			if strings.Contains(got, string(transportWithheld)) {
+				t.Errorf("an ordinary error must NOT be withheld; got %q", got)
+			}
+		})
+	}
+}
+
+// wrapN wraps err in n ordinary fmt-style layers.
+func wrapN(err error, n int) error {
+	for i := 0; i < n; i++ {
+		err = &wrapped{err}
+	}
+	return err
+}
+
+type wrapped struct{ err error }
+
+func (w *wrapped) Error() string { return "layer: " + w.err.Error() }
+func (w *wrapped) Unwrap() error { return w.err }
+
+// TestErrTreeBoundStillRejectsAPresentedCycle_6635 keeps the round-11 property
+// from silently regressing while the call sites move: the guard must still
+// reject a cycle presented DIRECTLY, not only one installed behind an As.
+func TestErrTreeBoundStillRejectsAPresentedCycle_6635(t *testing.T) {
+	if errTreeWithinBound(selfUnwrapping{}) {
+		t.Error("a directly-presented Unwrap() self-cycle must still be rejected")
+	}
+	if errTreeWithinBound(selfCycleMulti{}) {
+		t.Error("a directly-presented Unwrap() []error self-cycle must still be rejected")
+	}
+	if !errTreeWithinBound(errors.New("plain")) {
+		t.Error("a plain error must pass the bound")
+	}
+	if !errTreeWithinBound(wrapN(errors.New("plain"), 10)) {
+		t.Error("an ordinary ten-layer wrap must pass the bound")
+	}
+}


### PR DESCRIPTION
Closes #6635

## Reproduced at my head before writing anything

`errTreeWithinBound` ran **once**, at the two public scrubber entry points, validating the `Unwrap` tree **as presented there**. That is not the tree the stdlib ends up walking. `errors.As` dispatches to an `As(any) bool` method the CALLER defines, and that method hands back a value of the caller's choosing:

```go
func (e hostile) As(target any) bool {
    *target.(**url.Error) = &url.Error{Err: selfUnwrappingError{}}
    return true
}
```

The tree at entry is a single node, so `errTreeWithinBound` returns **true**; the subtree the `As` installs was never walked, and `scrubURLErrorAt` descends straight into it and spins forever inside the next `errors.As`.

Scratch repro on `origin/master`: the entry guard returned true and `scrubURLError` **did not return in five seconds**. Not taken from the issue text — measured.

## The fix (the issue's option 1)

The guard now runs at every entry to the depth-carrying functions `scrubURLErrorAt` and `scrubInnerErrorAt`, which is where a caller-supplied subtree can first appear. The public wrappers become thin delegates.

Cost is a re-walk per level — at most `maxUnwrapDepth`² `Unwrap` calls, on an error path that runs at most once per reconcile tick and only for trees that are already pathological. A legitimate error walks one or two levels.

## Reachability — checked, not inherited from the issue. This is NOT a live DoS.

The bypass needs a Go error **VALUE with hostile methods**. Production builds its own client (`newProviderHTTPClient` → `newHTTPClientBound`). `ensureProviderHTTPClient` does accept a caller-supplied `*http.Client`, but the only production caller is the Surface A reconcile path passing its own cached client, and every error on these paths originates in `net/http` or the stdlib. **A provider can choose BYTES over the wire; it cannot choose a Go type.**

So this is robustness and model consistency, not a reachable denial of service, and the code, the README and this PR all say so rather than letting a reader infer otherwise.

## What is still NOT bounded, deliberately

A caller-supplied `Error()` or `Unwrap()` that **blocks** hangs the first render or the guard itself. No placement of the guard fixes that — it needs a watchdog goroutine per render.

The reason for declining is not only cost: **a blocking `Error()` hangs any `fmt` render of that error anywhere in the daemon**, so bounding it inside one package's scrubber buys nothing while adding a goroutine to a path that must stay cheap. The issue's option 2 is left on the table with that reasoning recorded, not silently skipped.

## Tests: the failure mode is a HANG, so returning is the signal

Every cell in `errtree_bound_after_as_6635_test.go` runs the scrubber **on a goroutine with a deadline**. A direct call would wedge the whole package run instead of failing.

Each cell first asserts the **presented** tree PASSES `errTreeWithinBound` — that precondition is what makes it a test of the subtree a custom `As` installs, rather than a re-test of the round-11 guard. `TestNestedHostileSubtreeIsBoundAtDepth_6635` enters the bypass one level down, so a fix guarding only the first entry still fails. `TestOrdinaryErrorsStillClassifyNormally_6635` is the over-reach guard: withholding everything satisfies every hang cell and destroys the classification this package exists to produce.

One assertion is deliberately `Contains`, not equality, and the difference is the point: on the `scrubURLError` path the hostile `As` also chooses `ue.URL`, which is still rendered through `safeURLTarget`'s closed grammar (reduced to `scheme://host`). Requiring equality would have been an assertion about the round-8 URL grammar, not about this fix.

## Mutation matrix — 6 one-line mutations, re-run at the merged head

`go vet ./pkg/ddns/` rc=0 at every mutated state, `-count=1`, rc read from `$?` directly, tree confirmed clean after each restore, rc back to 0 at the end. **Run against the FULL package, not `-run 6635`** — see M1.

| # | one-line mutation | result |
|---|---|---|
| M1 | drop the re-guard in `scrubURLErrorAt` | **RED** — hangs `TestSelfUnwrappingErrorTerminates` (2m timeout) |
| M2 | drop the re-guard in `scrubInnerErrorAt` | **RED** — hangs the same test |
| M3 | narrow it to `depth == 0 &&` | **GREEN — a finding, kept and documented, see below** |
| M4 | withhold everything instead of classifying | **RED** — the over-reach guard + pre-existing `TestBoundedChainStillClassifies` |
| M5 | `budget := 1 << 30` (the bound never rejects) | **RED** — hang |
| M6 | refund budget for nil `Unwrap() []error` slots | **RED** — pre-existing `TestNilFanoutSpendsBudget` |

**M1 is why the filter matters.** Under `-run 6635` it came back GREEN. The red lives in `TestSelfUnwrappingErrorTerminates`, a pre-existing round-12 test the filter excluded. With the wrapper reduced to a delegate, depth 0 IS the public entry, so round 12's property now lives inside `scrubURLErrorAt` — and a matrix run under a narrow filter would have reported a redundant guard where there is a load-bearing one.

**M3 stays green, and I kept the code rather than tuning the guard down.** Today the only `depth > 0` caller is `scrubInnerErrorAt` handing over a value `errors.As` has already resolved to a `*url.Error`, which the next `errors.As` matches at node 0 without walking anything. That is a **reachability argument about a caller**, and this package does not build invariants on those — the dyndns2 endpoint scrub takes the same stance about `resolveDyndns2Endpoint` having already parsed. A future caller reaching this function with an unresolved tree would silently lose the bound; the guard costs a walk of an already-small tree. It stays total, with the redundancy documented at the site instead of removed.

M6's run also showed `TestOwnedRecordViews` failing alongside. Re-checked in isolation: it passes under M6 and at the restored head. That was the known `pkg/ddns` port-bind flake (#7009), not the mutation.

## Validation

`go build ./...` and `go vet ./pkg/ddns/` clean. `go test -count=1 ./pkg/ddns/` green. `origin/master` merged in (not rebased); `_Log.md` union-resolved with a structural heading count and an anchored marker sweep; everything re-verified at the merged head.

**Does not reach the Rust helper binary.** Go control plane only; no `.o` movement, no shim ABI change, no cluster smoke owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cz2czGK3aA5MsMhkNkjHXX
