### PR TITLE
upgrade: re-stamp the kernel arm record on an in-place cut (#6639)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -102146,3 +102146,19 @@ prose edit above them added. No diff falls in the new test body.
     pkg/config/compiler_validate_strict_application.go,
     pkg/config/dangling_term_keyword_6564_test.go,
     pkg/config/testdata/golden_4406.json, docs/config-schema.md
+
+## 2026-08-22 — #6639 cut re-stamps the kernel arm record
+- **Timestamp**: 2026-08-22
+- **Action**: An in-place binary cut repoints `current`, the sbin links and the
+  unit ExecStart but left the kernel arm record naming the OLD binary, so a
+  candidate boot refused. The refusal fires in the POSIX-sh OUTER hop (before it
+  execs anything), so the SIDECAR is what had to move — a Go-only change could
+  not fix it. Added step 6d inside `flip()` (after 6c, so a crash leaves today's
+  safe refusing state), gated on an ARMED journal, writing sidecar + journal
+  field from one value with `fsatomic.WriteFileDurable`, fail-closed. Left
+  `VerifyPromoteBinaryMatchesRecord` and the shell untouched: relaxing the
+  comparison would re-admit the stale leftover #6601 exists to eliminate.
+  Consequence was worse than filed — the journal is never cleared, so the gate
+  re-refuses every boot and an HA node holds SECONDARY indefinitely.
+- **File(s)**: pkg/upgrade/flip.go, pkg/upgrade/kernel.go,
+  pkg/upgrade/kernel_arm_restamp_6639_test.go (new), _Log.md

--- a/pkg/upgrade/flip.go
+++ b/pkg/upgrade/flip.go
@@ -52,8 +52,102 @@ func (r *Runner) flip(ver string) error {
 	if err := r.cfg.Sys.DaemonReload(); err != nil {
 		return fmt.Errorf("daemon-reload after unit template: %w", err)
 	}
+	// 6d (#6639): if a kernel candidate is ARMED, re-stamp the arm record at
+	// the binary this cut just made live.
+	//
+	// LAST, deliberately. The record must never name a binary the unit does not
+	// yet point at, so a crash between 6c and here leaves the OLD record — which
+	// is today's behaviour: safe, refusing, and repaired by re-running the cut.
+	if err := r.restampKernelArmRecord(ver); err != nil {
+		return fmt.Errorf("re-stamp kernel arm record: %w", err)
+	}
 	return nil
 }
+
+// restampKernelArmRecord points the kernel channel's arm record at the xpfd
+// this cut just made live (#6639).
+//
+// THE DEFECT. `xpfd upgrade kernel arm` records the arming binary's resolved
+// path — `/var/lib/xpf/versions/<A>/xpfd` — into both the journal's
+// `PromoteBinary` field and the `kernel-promote-binary` sidecar. An in-place
+// binary cut then repoints `current`, the sbin links and the unit's ExecStart at
+// version B and touches neither record. On the candidate boot the POSIX-sh outer
+// hop compares the recorded path against what the unit independently resolves,
+// finds two genuinely different files, and refuses.
+//
+// It is the SIDECAR that has to move. The refusal fires in the shell, before it
+// execs anything, so the Go-side cross-check (VerifyPromoteBinaryMatchesRecord)
+// is never reached — a Go-only change could not fix this.
+//
+// WHY RE-STAMP RATHER THAN RELAX THE COMPARISON. What #6601 built is the
+// property that the promotion gate executes the LIVE xpfd and never a stale
+// leftover, because a stale verifier's PASS permanently promotes a kernel
+// nothing actually validated. Making the comparison version-aware or
+// identity-aware would re-admit `versions/<OLD>/xpfd` — a retained, valid,
+// executable binary — which is exactly the stale leftover that design
+// eliminates. The recorded path is a PROXY for "live", established by
+// authority-of-construction at arm time; a cut has that same authority, because
+// it CREATED the new binary and repointed `current`, the sbin link and
+// ExecStart at it. "Which xpfd is live" is not inferred here — it is this
+// function's own output. So the proxy is updated by a party entitled to update
+// it, and both gates stay byte-identical.
+//
+// The consequence of leaving it is worse than a lost candidate. The shell
+// refuses BEFORE exec'ing xpfd, so Promote() never runs and the journal is never
+// cleared: the gate re-refuses on every subsequent boot from a unit that reports
+// success, and on an HA node `reconcileKernelUpgradeHold` releases the SECONDARY
+// hold only when a promotion marker names the running kernel — a marker that
+// will never be written — so the node holds SECONDARY indefinitely.
+//
+// A no-op unless a candidate is ARMED: with nothing armed there is no record to
+// re-stamp and none is created, so a cut on a box that never used the kernel
+// channel is byte-identical to before.
+//
+// FAILS CLOSED. A half-updated record naming a binary that may not exist is
+// strictly worse than an untouched one, so the sidecar and the journal field are
+// written from ONE resolved value and any failure fails the cut. Leaving the old
+// record intact degrades to exactly this issue, which is the safe fallback.
+func (r *Runner) restampKernelArmRecord(ver string) error {
+	// The struct is built directly rather than through NewKernelRunner, which
+	// requires a KernelSystem. Nothing here touches the system: this is a
+	// journal read, a path join and two durable writes. Demanding a Sys would
+	// mean the binary channel constructing UEFI/apt/systemd plumbing it never
+	// uses, purely to read a file.
+	kr := &KernelRunner{cfg: KernelConfig{JournalPath: kernelArmRestampJournalPath}}
+	j, err := kr.loadKernelJournal()
+	if err != nil {
+		// An unreadable journal is NOT "nothing armed" — it may be an armed one
+		// this cut is about to invalidate. Refuse rather than cut past it.
+		return fmt.Errorf("read kernel journal: %w", err)
+	}
+	if !j.State.atLeast(KernelStateArmed) ||
+		j.State == KernelStatePromoted || j.State == KernelStateReverted {
+		return nil // nothing armed — no record exists to re-stamp
+	}
+	bin := filepath.Join(r.cfg.VersionsDir, ver, "xpfd")
+	if err := validateGateBin(bin); err != nil {
+		return fmt.Errorf("cut target %s is not usable as the promotion gate: %w", bin, err)
+	}
+	j.PromoteBinary = bin
+	if err := kr.saveKernelJournal(j); err != nil {
+		return err
+	}
+	path := ArmRecordPath(kr.cfg.JournalPath)
+	if err := fsatomic.MkdirAllDurable(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create arm-record dir: %w", err)
+	}
+	return fsatomic.WriteFileDurable(path, []byte(bin+"\n"), 0o644)
+}
+
+// kernelArmRestampJournalPath is the kernel journal the cut re-stamps against.
+//
+// A package var seeded from the production default, matching bootGateJournalPath
+// (kernel_arm_journal_path.go): a unit test that drives flip() over a t.TempDir()
+// layout must not write to the real /var/lib/xpf, and nothing outside this
+// package can reach it, so production is structurally incapable of pointing it
+// elsewhere. #6631 already refuses to ARM against a non-default journal, so
+// there is exactly one path this can legitimately be.
+var kernelArmRestampJournalPath = DefaultKernelJournalPath
 
 // repointSymlink atomically points linkPath at a RELATIVE target (basename
 // within the same dir, e.g. current -> <ver>). Atomic via temp+rename.

--- a/pkg/upgrade/kernel.go
+++ b/pkg/upgrade/kernel.go
@@ -179,9 +179,21 @@ type KernelJournal struct {
 	// os.Executable() names the live binary by construction, and it knows that
 	// at the moment it arms. Recording it converts the question from "which
 	// xpfd is live?" (unanswerable from ambient state) into "which xpfd armed
-	// this candidate?" (a fact). The record cannot drift from the arming
-	// because re-arming rewrites it and there is exactly one gate run per
-	// arming, and it is cleared with the journal on promote/revert.
+	// this candidate?" (a fact). It is cleared with the journal on
+	// promote/revert.
+	//
+	// EXACTLY TWO parties may write it, and both establish the value by
+	// CONSTRUCTION rather than by inference: `arm`, which resolves the binary
+	// executing it; and (#6639) an in-place binary cut, which re-stamps it
+	// because the cut CREATED the new xpfd and repointed `current`, the sbin
+	// link and the unit ExecStart at it. Before #6639 only the first existed,
+	// so a cut while a candidate was armed left the record naming a binary the
+	// unit no longer pointed at, and the outer hop refused the promotion on
+	// every subsequent boot.
+	//
+	// The verifying binary may therefore be a different BUILD from the arming
+	// one. That is deliberate: the property being protected is "the gate runs
+	// the LIVE xpfd, never a stale leftover", not "the same build throughout".
 	//
 	// The gate REFUSES when this is present but unusable, and never falls back
 	// to inference. See armRecordPath / the outer hop's sidecar.

--- a/pkg/upgrade/kernel_arm_restamp_6639_test.go
+++ b/pkg/upgrade/kernel_arm_restamp_6639_test.go
@@ -1,0 +1,214 @@
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// useTempKernelJournal6639 points the cut's re-stamp seam at a temp journal.
+//
+// Without it a unit test driving flip() would read — and, once a candidate is
+// armed, WRITE — the real /var/lib/xpf/kernel-upgrade.state and its sidecar on
+// the developer's box.
+func useTempKernelJournal6639(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	jp := filepath.Join(dir, "kernel-upgrade.state")
+	orig := kernelArmRestampJournalPath
+	kernelArmRestampJournalPath = jp
+	t.Cleanup(func() { kernelArmRestampJournalPath = orig })
+	return jp
+}
+
+// armKernelCandidate6639 writes an ARMED journal + sidecar naming binPath, the
+// state `xpfd upgrade kernel arm` leaves behind.
+func armKernelCandidate6639(t *testing.T, journalPath, binPath string) {
+	t.Helper()
+	kr := &KernelRunner{cfg: KernelConfig{JournalPath: journalPath}}
+	j := &KernelJournal{
+		State:            KernelStateArmed,
+		CandidateVersion: "6.19.0-1-generic",
+		KnownGoodVersion: "6.18.4-11-generic",
+		PromoteBinary:    binPath,
+	}
+	if err := kr.saveKernelJournal(j); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ArmRecordPath(journalPath), []byte(binPath+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readArmSidecar6639(t *testing.T, journalPath string) string {
+	t.Helper()
+	b, err := os.ReadFile(ArmRecordPath(journalPath))
+	if err != nil {
+		t.Fatalf("read arm sidecar: %v", err)
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// TestFlipRestampsTheKernelArmRecord_6639 is the fail-on-revert gate.
+//
+// `xpfd upgrade kernel arm` records the arming binary's resolved path into the
+// journal AND the `kernel-promote-binary` sidecar. An in-place binary cut then
+// repoints `current`, the sbin links and the unit's ExecStart at a NEW version
+// and used to touch neither record. On the candidate boot the POSIX-sh outer hop
+// compares the recorded path against what the unit independently resolves, finds
+// two genuinely different files, and refuses — so the candidate is never
+// promoted.
+//
+// The SIDECAR is what matters: the refusal fires in the shell, before it execs
+// anything, so the Go-side cross-check is never reached and a Go-only fix could
+// not have closed this.
+func TestFlipRestampsTheKernelArmRecord_6639(t *testing.T) {
+	jp := useTempKernelJournal6639(t)
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	seedInitialCurrent(t, r, cfg, "1.0.0")
+
+	oldBin := filepath.Join(cfg.VersionsDir, "1.0.0", "xpfd")
+	newBin := filepath.Join(cfg.VersionsDir, "2.0.0", "xpfd")
+	for _, b := range managedBins {
+		writeFakeBin(t, filepath.Join(cfg.VersionsDir, "2.0.0", b), "binary-"+b+"-2.0.0")
+	}
+	armKernelCandidate6639(t, jp, oldBin)
+
+	if err := r.flip("2.0.0"); err != nil {
+		t.Fatalf("flip: %v", err)
+	}
+
+	if got := readArmSidecar6639(t, jp); got != newBin {
+		t.Fatalf("arm sidecar = %q, want %q — the shell outer hop reads THIS file, so a "+
+			"stale value here makes the candidate boot refuse and the kernel candidate is "+
+			"lost", got, newBin)
+	}
+	kr := &KernelRunner{cfg: KernelConfig{JournalPath: jp}}
+	j, err := kr.loadKernelJournal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j.PromoteBinary != newBin {
+		t.Fatalf("journal PromoteBinary = %q, want %q — it must stay equal to the sidecar; "+
+			"the Go cross-check reads this half", j.PromoteBinary, newBin)
+	}
+	// The candidate itself must be untouched: the cut re-points which xpfd
+	// verifies, it does not re-arm or cancel the trial.
+	if j.CandidateVersion != "6.19.0-1-generic" || j.State != KernelStateArmed {
+		t.Fatalf("the cut altered the kernel trial itself: state=%s candidate=%s",
+			j.State, j.CandidateVersion)
+	}
+}
+
+// TestFlipDoesNotCreateAnArmRecordWhenNothingIsArmed_6639 is the negative
+// control the issue asks for by name.
+//
+// A cut on a box that never used the kernel channel must be byte-identical to
+// before: no journal created, no sidecar created. A re-stamp that ran
+// unconditionally would mint an arm record with nothing armed, and the boot gate
+// treats a record's PRESENCE as meaningful — it would start refusing on a box
+// with no kernel trial at all.
+func TestFlipDoesNotCreateAnArmRecordWhenNothingIsArmed_6639(t *testing.T) {
+	jp := useTempKernelJournal6639(t)
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	seedInitialCurrent(t, r, cfg, "1.0.0")
+	for _, b := range managedBins {
+		writeFakeBin(t, filepath.Join(cfg.VersionsDir, "2.0.0", b), "binary-"+b+"-2.0.0")
+	}
+
+	if err := r.flip("2.0.0"); err != nil {
+		t.Fatalf("flip with nothing armed must succeed: %v", err)
+	}
+	if _, err := os.Stat(ArmRecordPath(jp)); !os.IsNotExist(err) {
+		t.Fatalf("the cut created an arm record with nothing armed (err=%v) — the boot gate "+
+			"treats a record's presence as meaningful and would begin refusing", err)
+	}
+	if _, err := os.Stat(jp); !os.IsNotExist(err) {
+		t.Fatalf("the cut created a kernel journal with nothing armed (err=%v)", err)
+	}
+}
+
+// TestFlipRestampIsNoOpForATerminalKernelState_6639 pins the other half of the
+// armed predicate. A journal left at PROMOTED or REVERTED is not an in-flight
+// trial, and its record has already been cleared; re-stamping would recreate one.
+func TestFlipRestampIsNoOpForATerminalKernelState_6639(t *testing.T) {
+	for _, st := range []KernelState{KernelStatePromoted, KernelStateReverted} {
+		t.Run(string(st), func(t *testing.T) {
+			jp := useTempKernelJournal6639(t)
+			fs := newFakeSystem(t, "2.0.0")
+			r, cfg := testEnv(t, fs)
+			seedInitialCurrent(t, r, cfg, "1.0.0")
+			for _, b := range managedBins {
+				writeFakeBin(t, filepath.Join(cfg.VersionsDir, "2.0.0", b), "binary-"+b+"-2.0.0")
+			}
+			kr := &KernelRunner{cfg: KernelConfig{JournalPath: jp}}
+			if err := kr.saveKernelJournal(&KernelJournal{State: st}); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := r.flip("2.0.0"); err != nil {
+				t.Fatalf("flip: %v", err)
+			}
+			if _, err := os.Stat(ArmRecordPath(jp)); !os.IsNotExist(err) {
+				t.Fatalf("a %s journal is not an in-flight trial; the cut must not mint an "+
+					"arm record (err=%v)", st, err)
+			}
+		})
+	}
+}
+
+// TestFlipRestampFailsClosed_6639 pins the atomicity requirement the issue
+// states: a half-updated record naming a binary that may not exist is strictly
+// worse than an untouched one.
+//
+// The cut target's xpfd is absent, so the re-stamp cannot validate it. The cut
+// must FAIL, and the OLD record must survive intact — degrading to exactly the
+// pre-fix behaviour, which is safe and refusing.
+func TestFlipRestampFailsClosed_6639(t *testing.T) {
+	jp := useTempKernelJournal6639(t)
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	seedInitialCurrent(t, r, cfg, "1.0.0")
+
+	oldBin := filepath.Join(cfg.VersionsDir, "1.0.0", "xpfd")
+	armKernelCandidate6639(t, jp, oldBin)
+	// Every managed binary EXCEPT xpfd, so 6a-6c succeed and only the re-stamp's
+	// validation fails — otherwise the case would prove nothing about 6d.
+	for _, b := range managedBins {
+		if b == "xpfd" {
+			continue
+		}
+		writeFakeBin(t, filepath.Join(cfg.VersionsDir, "2.0.0", b), "binary-"+b+"-2.0.0")
+	}
+
+	err := r.flip("2.0.0")
+	if err == nil {
+		t.Fatal("flip must FAIL when the cut target cannot serve as the promotion gate; " +
+			"silently leaving the old record is a cut that reports success while the kernel " +
+			"candidate is already lost")
+	}
+	if !strings.Contains(err.Error(), "re-stamp kernel arm record") {
+		t.Fatalf("the failure must name the re-stamp so it is diagnosable, got: %v", err)
+	}
+	if got := readArmSidecar6639(t, jp); got != oldBin {
+		t.Fatalf("arm sidecar = %q after a failed re-stamp, want the OLD value %q intact — "+
+			"a half-updated record naming a nonexistent binary is worse than an untouched one",
+			got, oldBin)
+	}
+}
+
+// TestRestampSeamIsTheProductionDefault_6639 pins the seam's value, mirroring
+// TestBootGateJournalPathIsTheProductionDefault.
+//
+// The seam exists only so tests do not write to the real /var/lib/xpf. A leaked
+// override would make every case above pass against a journal production never
+// reads — the guard would be vacuous and the defect would ship.
+func TestRestampSeamIsTheProductionDefault_6639(t *testing.T) {
+	if kernelArmRestampJournalPath != DefaultKernelJournalPath {
+		t.Fatalf("kernelArmRestampJournalPath = %q, want the production default %q",
+			kernelArmRestampJournalPath, DefaultKernelJournalPath)
+	}
+}


### PR DESCRIPTION
Closes #6639

## The defect

`xpfd upgrade kernel arm` records the arming binary's resolved path — `/var/lib/xpf/versions/<A>/xpfd` — into **both** the kernel journal's `PromoteBinary` field and the `kernel-promote-binary` sidecar. An in-place binary cut then repoints `current`, the sbin symlinks and the unit's `ExecStart` at version B and touched neither record. On the candidate boot the gate compares, finds two genuinely different files, and refuses. The armed candidate is never promoted.

## Two corrections to the issue, both load-bearing

**1. The sidecar is what had to move — a Go-only fix could not have worked.** The refusal fires in the POSIX-sh **outer hop**'s `same_file "$CROSS" "$RECORDED"` check, *before* it execs anything, so Gate 2b (`VerifyPromoteBinaryMatchesRecord`) is never reached. The shell never reads Go.

**2. The consequence is worse than "annoying and discoverable".** Because the shell refuses before exec'ing xpfd, `Promote()` never runs — so the journal is never cleared and no roll outcome is recorded. Therefore:

- the gate **re-refuses on every subsequent boot**, from a unit that reports **success** (the `exit 0` is deliberate, so a refusal cannot cascade into an `OnFailure=` chain on the boot path);
- `xpfd upgrade kernel status` keeps reporting `ARMED` with the old candidate forever;
- **on an HA node the node holds SECONDARY indefinitely** — `reconcileKernelUpgradeHold` releases only when a promotion marker names the running kernel, and that marker will never be written. Halved cluster capacity until an operator re-arms or hand-deletes two files. Reachable via `xpfd upgrade --rolling`, the only sanctioned cut on a clustered node.

## Re-stamp, do not relax the comparison

What #6601 built is the property that **the promotion gate executes the LIVE xpfd, never a stale leftover** — because a stale verifier's PASS permanently promotes a kernel nothing actually validated.

Making Gate 2b version-aware or identity-aware would re-admit `versions/<OLD>/xpfd` — a retained, valid, executable binary of a valid version — which is byte-for-byte the stale leftover that design spent five revisions eliminating, and would red the shell tests encoding it (`test_unit_disagreeing_with_the_record_refuses_rather_than_picking`, `test_a_single_surviving_default_is_never_executed`). **`VerifyPromoteBinaryMatchesRecord` and the shell are untouched.**

The recorded path is a *proxy* for "live", established at arm time by authority of construction. **A cut has that same authority:** it created the new binary and repointed `current`, the sbin link and `ExecStart` at it. "Which xpfd is live" is not inferred here — it is this function's own output. So the proxy is updated by a party entitled to update it, and both gates stay byte-identical in code.

## Placement details that are load-bearing

- **6d runs LAST**, after the daemon-reload. The record must never name a binary the unit does not yet point at, so a crash between 6c and 6d leaves the OLD record — today's behaviour: safe, refusing, repaired by re-running the cut.
- **Inside `flip()`, not at the cutover call site.** `flip()` is also how `rollback` re-flips to `PreviousVersion`; a call-site fix would leave the rollback direction stale.
- **No-op unless ARMED**, with terminal `PROMOTED`/`REVERTED` counting as not-armed. The boot gate treats a record's *presence* as meaningful, so minting one on a box with no kernel trial would make it start refusing.
- **Fails closed.** A half-updated record naming a binary that may not exist is strictly worse than an untouched one, so the sidecar and journal field are written from **one validated value** and any failure fails the cut.

No new package boundary (`flip.go` and the kernel channel are both `package upgrade`) and no new lock — every `flip()` call site already holds `/run/xpf/upgrade.lock`, whose own doc names *"a binary cut vs `xpfd upgrade kernel arm`"* as a motivating case. The `KernelRunner` is built directly rather than via `NewKernelRunner` because nothing here touches the system; demanding a `Sys` would mean constructing UEFI/apt/systemd plumbing to read a file.

## Validation

- `go test ./pkg/upgrade/ ./cmd/xpfd/ ./pkg/daemon/ -count=1` — green, **including every pre-existing cut/flip test**, which now exercises the nothing-armed no-op path.
- `go build ./...` clean.

**Mutation matrix — four mutations, each on a COMPILING tree:**

| Mutation | Cases that red |
|---|---|
| Remove the 6d call (pre-fix bytes) | the main case + fail-closed |
| Write the sidecar but not the journal field | the sidecar/journal equality assertion |
| Drop `validateGateBin` | fail-closed |
| **Re-stamp UNCONDITIONALLY — a tightening, not a removal** | the nothing-armed control **and** both terminal-state cases |

The journal path is a package var seeded from the production default (mirroring `bootGateJournalPath`), and `TestRestampSeamIsTheProductionDefault_6639` pins its value — a leaked override would make every case above pass against a journal production never reads.

No cluster smoke owed: control-plane only, no `userspace-dp` helper or shim `.o` movement.

## Docs

`pkg/upgrade/kernel.go` — the `PromoteBinary` doc claimed *"the record cannot drift from the arming because re-arming rewrites it and there is exactly one gate run per arming"*. That is now false and is amended in the same change: there are exactly **two** writers, both establishing the value by construction, and the verifying binary may be a different **build** from the arming one — deliberate, since the protected property is "live, not stale", not "same build throughout".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdWuT1UffSkr1spw8sjNTE
