### PR TITLE
refactoraudit: run the modularity gate uncached, reject duplicate rows (#6626, #6627)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,29 @@ test-go: test-race-dp
 	# code); widen to ./... once those are resolved.
 	$(GO) vet ./pkg/flowexport/...
 	$(GO) test ./...
+	# #6626: pkg/refactoraudit MUST run uncached.
+	#
+	# Its hard gate (TestTouchedFileCrossedModularityThreshold) measures the
+	# branch's own diff against its merge base by shelling out to
+	# scripts/refactoring-audit-touched.sh. Neither the working tree nor that
+	# script is a `go test` cache input, so a REAL threshold crossing changes
+	# nothing the cache hashes and `./...` above returns "ok (cached)" — the
+	# gate passes without running. Reproduced: a new 2004-LOC production file
+	# (a genuine [REFACTOR] crossing, exactly the event this gate exists to
+	# catch) returned "ok (cached)" and FAILED under -count=1.
+	#
+	# #6623 widened the window rather than creating it: under the old
+	# byte-exact artifact compare the tracked artifact churned constantly and
+	# busted the cache by accident, so a stale pass survived one commit instead
+	# of many.
+	#
+	# Scoped to this package, not the whole suite: measured at ~10.7s uncached
+	# against ~0.1s cached, which is noise on a suite that already runs
+	# minutes, whereas -count=1 on ./... would forfeit caching everywhere.
+	# Deliberately NOT narrowed further with -run: a name predicate silently
+	# stops covering the next tree-reading test added here, which is the
+	# #6743 r2-N3 lesson recorded in this package's own doc.go.
+	$(GO) test -count=1 ./pkg/refactoraudit/
 
 # #2114 scoped race gate: the dataplane-cell publication races
 # (bootstrap-exit clear vs sampler/watcher/confirm-timer readers) and the

--- a/_Log.md
+++ b/_Log.md
@@ -102192,3 +102192,10 @@ prose edit above them added. No diff falls in the new test body.
     pkg/config/compiler_validate_strict_application.go,
     pkg/config/dangling_term_keyword_6564_test.go,
     pkg/config/testdata/golden_4406.json, docs/config-schema.md
+
+- **Timestamp**: 2026-08-22
+  - **Action**: #6626 + #6627 — the heatmap hard gate could return "ok (cached)"
+    on a real threshold crossing (working tree is not a go test cache input);
+    make test-go now runs pkg/refactoraudit uncached, guarded by a Makefile
+    wiring test. #6627: a duplicated heatmap row is now rejected explicitly.
+  - **File(s)**: Makefile, pkg/refactoraudit/audit_canary_test.go

--- a/pkg/refactoraudit/audit_canary_test.go
+++ b/pkg/refactoraudit/audit_canary_test.go
@@ -337,6 +337,33 @@ func TestHeatmapArtifactWellFormed(t *testing.T) {
 		}
 	}
 
+	// #6627: each path appears AT MOST ONCE.
+	//
+	// A duplicated row passed every other check here, which is why it needed
+	// its own. The staleness comparison builds a tierByPath map, so a second
+	// row for the same path collapses onto the first and compares equal; the
+	// order check below permits equal-adjacent rows, so a duplicate does not
+	// break ordering; and the band check above passes because the duplicate
+	// carries the same valid LOC and tier.
+	//
+	// This is the existence-vs-coverage shape: every check asked "is there a
+	// row for this path", none asked "how many". The generator cannot produce
+	// a duplicate, so this is a hand-edit detector — the same class the
+	// surrounding tests already cover for retagging, deletion, phantom rows
+	// and reordering, and the one gap in that set.
+	seenPath := make(map[string]int, len(rows))
+	for i, r := range rows {
+		if first, dup := seenPath[r.path]; dup {
+			t.Errorf("#6627: path %s appears twice in the committed heatmap (rows %d and %d) — "+
+				"a duplicate row is invisible to every other check here (tierByPath collapses it, "+
+				"equal-adjacent rows are validly ordered, and the band check sees the same valid "+
+				"LOC and tier), so it must be rejected explicitly",
+				r.path, first+1, i+1)
+			continue
+		}
+		seenPath[r.path] = i
+	}
+
 	// Generator order: LOC descending, path ascending on ties
 	// (LC_ALL=C sort -k2,2nr -k3,3 in scripts/refactoring-audit.sh).
 	for i := 1; i < len(rows); i++ {
@@ -528,5 +555,61 @@ func TestInlineTestBlockNotStripped(t *testing.T) {
 	if got != want {
 		t.Fatalf("audit_loc stripped or miscounted an inline-test fixture: got %q, want %q\n"+
 			"the measurement must count RAW LOC so a stripper cannot erase production code following a test block", got, want)
+	}
+}
+
+// TestMakefileRunsAuditPackageUncached binds the #6626 fix to the wiring that
+// makes it live.
+//
+// The hard gate measures the branch's own diff by shelling out to
+// scripts/refactoring-audit-touched.sh. Neither the working tree nor that
+// script is a `go test` cache input, so a REAL threshold crossing changes
+// nothing the cache hashes and a plain `go test ./...` returns "ok (cached)" —
+// the gate passes without running. Demonstrated on this package: a new
+// 2004-LOC production file (a genuine [REFACTOR] crossing) returned
+// "ok (cached)" and FAILED under -count=1.
+//
+// Nothing inside Go can detect that from within a cached run, so the fix lives
+// in the Makefile and this test guards the Makefile. Without it, deleting the
+// invocation silently restores a gate that can pass without running — and every
+// test in this package would still be green, because they would simply be
+// served from cache.
+//
+// FAIL-ON-REVERT: drop `-count=1` from the pkg/refactoraudit invocation in the
+// test-go target, or delete the invocation.
+func TestMakefileRunsAuditPackageUncached(t *testing.T) {
+	root := repoRoot(t)
+	b, err := os.ReadFile(filepath.Join(root, "Makefile"))
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	mk := string(b)
+
+	// The invocation must exist AND carry -count=1. Matching the two together
+	// is the point: `go test ./pkg/refactoraudit/` without -count=1 is the
+	// cached-pass bug wearing the shape of a fix.
+	want := "$(GO) test -count=1 ./pkg/refactoraudit/"
+	if !strings.Contains(mk, want) {
+		t.Fatalf("#6626: the Makefile must run this package UNCACHED — expected a line "+
+			"containing %q in the test-go target.\n\nWithout it, a real threshold crossing "+
+			"returns \"ok (cached)\" on the path CI and developers actually take, so the "+
+			"modularity gate passes without ever running. Every test in this package stays "+
+			"green in that state, which is exactly why this has to be checked here.", want)
+	}
+
+	// And it must be reachable from test-go, not stranded in some unused target.
+	idx := strings.Index(mk, "test-go:")
+	if idx < 0 {
+		t.Fatal("#6626: no test-go target found in the Makefile — this guard is bound to it " +
+			"by name and must be re-pointed if the target is renamed")
+	}
+	rest := mk[idx:]
+	if end := strings.Index(rest, "\n\n"); end > 0 {
+		rest = rest[:end]
+	}
+	if !strings.Contains(rest, want) {
+		t.Errorf("#6626: the uncached pkg/refactoraudit invocation exists but is NOT inside the "+
+			"test-go target, so `make test-go` — the path CI and developers take — would still "+
+			"serve this package from cache.\n\ntest-go target body:\n%s", rest)
 	}
 }


### PR DESCRIPTION
Closes #6626
Closes #6627

Two defects in the heatmap gate's own reliability, both pre-existing, both filed from the hostile review of #6623.

## #6626 — the gate could pass WITHOUT RUNNING

`TestTouchedFileCrossedModularityThreshold` measures the branch's own diff against its merge base by shelling out to `scripts/refactoring-audit-touched.sh`. **Neither the working tree nor that script is a `go test` cache input**, so a real threshold crossing changes nothing the cache hashes — and `test-go` runs `go test ./...` with no `-count=1`, which is the path CI and developers actually take.

**Reproduced before fixing, as the issue asked.** A new 2004-LOC production file — a genuine `new → [REFACTOR]` crossing, exactly the event this gate exists to catch:

```
-- plain go test:      ok  github.com/psaab/xpf/pkg/refactoraudit  (cached)
-- go test -count=1:   --- FAIL: TestTouchedFileCrossedModularityThreshold
```

#6623 **widened** the window rather than creating it: under the old byte-exact artifact compare the tracked artifact churned constantly and busted the cache by accident, so a stale pass survived one commit instead of many.

### Scope was measured, not guessed

| | time |
|---|---|
| package, uncached | **10.7s** |
| package, cached | 0.1s |
| hard gate only (`-run`), uncached | 0.4s |

Scoped to the package. 10.7s is noise on a suite that already runs minutes, whereas `-count=1` on `./...` would forfeit caching everywhere. **Deliberately not narrowed to the 0.4s `-run` form**: a name predicate silently stops covering the next tree-reading test added here — the #6743 r2-N3 lesson recorded in this package's own `doc.go`.

### The fix is guarded, because nothing in Go can see a cached run from inside one

`TestMakefileRunsAuditPackageUncached` asserts the uncached invocation exists **and** sits inside `test-go` rather than stranded in an unused target. Without it, deleting the line silently restores a gate that passes without running — and **every test in this package stays green in that state, because they are served from cache.**

## #6627 — a duplicated row was invisible to every check

The staleness comparison builds a `tierByPath` map, so a second row for the same path collapses onto the first and compares equal; the sort-order check permits equal-adjacent rows; the band check passes because the duplicate carries the same valid LOC and tier.

Every check asked *"is there a row for this path"*, none asked *"how many"* — the existence-vs-coverage shape. `TestHeatmapArtifactWellFormed` now rejects a repeated path explicitly, closing the one hand-edit shape its siblings did not already cover (they catch retagging, deletion, phantom rows and reordering).

## Mutation matrix

Each verified applied before its run; state restored between cells.

| # | Mutation | Result |
|---|---|---|
| F1 | drop `-count=1` from the Makefile invocation | **RED** |
| F2 | delete the invocation entirely | **RED** |
| F3 | move it **out of** `test-go` (stranded elsewhere) | **RED** |
| F4 | duplicated artifact, #6627 check **removed** | **PASSES** |
| F4b | **same** duplicated artifact, check **restored** | **RED** |

**F4/F4b is one paired cell on identical input** — the artifact is duplicated in both, only the check differs. F4 *passing* is the demonstration that a duplicate really was invisible to every other check in the file; F4b *failing* is the demonstration that this check is what catches it. Necessary and sufficient, rather than merely correlated.

## Validation

- `go build ./...` clean; `go vet ./pkg/refactoraudit` clean.
- Full package green (8.0s) with `-count=1`.
- Artifact byte-restored after the mutations (`git diff` empty).
- The 2004-LOC repro file was removed and the tree verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gcdxy5mCofwyVWHUKzhU9F
