### PR TITLE
cli,grpcapi,ipsec: escape external-command output before display (#6584)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-08-22 — #6584 command-output + swanctl termsafe guards
+
+- **Timestamp**: 2026-08-22
+- **Action**: Block-sanitized `journalctl`/`tail` on BOTH renderers plus
+  `journalctl --boot` (structurally identical, not named in the issue),
+  and guarded every fork in the multi-fork gRPC functions
+  (`GetSystemInfo` ×4, `showNTP` ×4) so no guarded arm vouches for a raw
+  sibling. CORRECTED the issue's framing for site B: swanctl stdout never
+  reaches a terminal — the PARSED fields do — so it is the #6579
+  parsed-row class and is guarded once at INGEST (`sanitizeSAStatus` in
+  `GetSAStatus`) rather than at ~24 render sites across two renderers.
+  Added the mechanism the research showed was missing entirely: a
+  both-directions tripwire requiring every fork-containing function to
+  apply >= as many termsafe calls as forks, or be allowlisted with a
+  reason.
+  Mutation matrix 6/6 RED after two real fixture defects the matrix
+  itself exposed: (1) the tripwire's first version asked only whether a
+  function "references termsafe", which let one guarded arm vouch for
+  its siblings — four cells that removed a real guard stayed GREEN;
+  (2) after switching to a count, package-scope forks had an EMPTY body
+  so `0 >= 0` waved them through silently — the control run caught that.
+  Both now conservative. Successor #7389 filed for the streaming sites
+  (tcpdump renders attacker packet bytes; traceroute resolves PTR) which
+  need a line-wise writer, plus the low-taint remainder.
+- **File(s)**: pkg/cli/cli_show_system.go, pkg/grpcapi/server_show.go,
+  pkg/grpcapi/server_show_status.go, pkg/grpcapi/server_show_system.go,
+  pkg/ipsec/ike.go, pkg/ipsec/manager.go,
+  pkg/cli/command_output_termsafe_6584_test.go,
+  pkg/ipsec/sa_status_termsafe_6584_test.go, pkg/cli/README.md
+
 ## 2026-08-21 — #6631 kernel arm: refuse a journal path the boot gate cannot read
 
 - **Timestamp**: 2026-08-21

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -217,6 +217,27 @@ presenter's rendered output is byte-identical:
   Escaping LF but passing U+2028 in the field variant would be incoherent: that
   variant is the stricter of the two about line breaks.
 
+  **Command output and swanctl SAs (#6584).** `show log` / `show log <name>`
+  / `show system boot-messages` and their `ShowText` / `GetSystemInfo`
+  mirrors block-sanitize their `journalctl` / `tail` stdout — the syslog
+  stream carries the very DHCP lease hostnames #6468 was filed about, so
+  reading the LOG bypassed the sanitized lease table. The IPsec SA views
+  are the PARSED-ROW class, not the raw-block class the issue assumed
+  (`stdout` never reaches a terminal; the parsed fields do), so they are
+  guarded once at INGEST in `pkg/ipsec` — thirteen fields across four
+  renderers is exactly the width of sweep that ships half-applied.
+
+  `TestEveryCommandOutputDisplaySiteIsSanitizedOrDeclared6584`
+  (`pkg/cli`) is the mechanism that was missing: every function that
+  forks an external command must apply at least as many `termsafe` calls
+  as it makes forks, or appear in `declaredUnsanitizedForks` with a
+  reason. The count is RELATIVE on purpose — deleting a fork lowers the
+  requirement, so it cannot go vacuous the way an absolute count does,
+  while deleting a sanitize still reds. It fails in BOTH directions, so a
+  stale exemption is caught too. Streaming sites (`tcpdump`, `ping`,
+  `traceroute`) are exempted with the reason they need a shape change to
+  a line-wise writer before they can be guarded at all.
+
   **The guard goes on BOTH terminal-facing renderers.** Every one of these
   commands runs on the local CLI *and* the remote `cli`, which prints
   `resp.Output` verbatim (`cmd/cli`: `fmt.Print(resp.Output)`); a fix on one

--- a/pkg/cli/cli_show_system.go
+++ b/pkg/cli/cli_show_system.go
@@ -17,6 +17,8 @@ import (
 	"github.com/psaab/xpf/pkg/sysservices"
 	"github.com/psaab/xpf/pkg/upgrade"
 	"golang.org/x/sys/unix"
+
+	"github.com/psaab/xpf/pkg/termsafe"
 )
 
 // readLinkSpeed reads the link speed in Mbps from sysfs. Returns 0 on error.
@@ -567,10 +569,17 @@ func (c *CLI) showSystemUptime() error {
 // showSystemBootMessages shows recent boot messages via journalctl.
 
 func (c *CLI) showSystemBootMessages() error {
-	cmd := exec.Command("journalctl", "--boot", "-n", "100", "--no-pager")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	// #6584: this is the SAME journald text as `show log`, and it was not
+	// named in the issue — it was found by sweeping the predicate rather than
+	// the two cited sites. It has to be BUFFERED to be guarded at all: wiring
+	// cmd.Stdout straight to os.Stdout leaves no string to sanitize. The
+	// output is bounded at 100 lines, so buffering costs nothing.
+	out, err := exec.Command("journalctl", "--boot", "-n", "100", "--no-pager").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("journalctl --boot: %w", err)
+	}
+	fmt.Print(termsafe.SanitizeBlockForDisplay(string(out)))
+	return nil
 }
 
 // showSystemMemory shows memory usage (like Junos "show system memory").
@@ -928,7 +937,10 @@ func (c *CLI) showDaemonLog(args []string) error {
 			if err != nil {
 				return fmt.Errorf("read %s: %w", logPath, err)
 			}
-			fmt.Print(string(out))
+			// #6584: the syslog stream carries the very DHCP lease hostnames
+			// #6468 was filed about, so reading the LOG bypasses the sanitized
+			// lease table. Block variant: the line structure IS the output.
+			fmt.Print(termsafe.SanitizeBlockForDisplay(string(out)))
 			return nil
 		}
 	}
@@ -939,7 +951,9 @@ func (c *CLI) showDaemonLog(args []string) error {
 	if err != nil {
 		return fmt.Errorf("journalctl: %w", err)
 	}
-	fmt.Print(string(out))
+	// #6584: see the tail branch above — journald re-emits device-originated
+	// text (DHCP hostnames, IKE identities, LLDP) verbatim.
+	fmt.Print(termsafe.SanitizeBlockForDisplay(string(out)))
 	return nil
 }
 

--- a/pkg/cli/command_output_termsafe_6584_test.go
+++ b/pkg/cli/command_output_termsafe_6584_test.go
@@ -1,0 +1,332 @@
+// #6584: raw external-command output reaching an operator terminal unescaped.
+//
+// #6468 established the class — device-originated text printed to a terminal
+// can carry OSC 52 (clipboard write), OSC 8 (hyperlink) and CSI (cursor/erase)
+// sequences the terminal ACTS ON. #6579 covered the vtysh and DDNS surfaces.
+//
+// The two sites the issue names are the largest remaining members, and the log
+// one is the most directly connected to #6468's own threat model: the syslog
+// stream carries the very DHCP lease hostnames #6468 was filed about, so a
+// device that sets its hostname to an escape payload gets it logged and then
+// re-emitted verbatim the moment an operator runs `show log` — the sanitized
+// lease table is bypassed by reading the log instead.
+//
+// THIS FILE'S DURABLE PART IS THE TRIPWIRE, not the two fixes.
+//
+// The research for this issue established that NOTHING in the tree fails when
+// a display site forgets the guard: there is no enumerating table and no
+// source-scanning canary for termsafe, only per-site behavioural binders. That
+// is the same gap #6579's own review recorded from the other side — "reverting
+// all 14 call-site edits left the suite green, because the only test file
+// exercised the primitive" — and the miss it actually shipped was an entire
+// renderer.
+//
+// So every function that forks an external command must either reference
+// termsafe or be written down here with a reason. That is a set difference in
+// BOTH directions: an unguarded fork fails, and a stale exemption whose site no
+// longer exists also fails, so the list cannot rot into a record of things that
+// used to be true.
+package cli
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// forkExemption names one function that forks an external command and does NOT
+// route its output through termsafe.
+type forkExemption struct {
+	pkgDir string
+	file   string
+	fn     string
+	why    string
+}
+
+// declaredUnsanitizedForks is the complete allowlist across the three packages
+// that fork on a display path.
+var declaredUnsanitizedForks = []forkExemption{
+	// ---- no output is consumed at all ----
+	{"../cli", "cli_request_system.go", "handleRequestSystem",
+		"systemctl reboot/halt/poweroff — no output is read"},
+	{"../cli", "cli_request_system.go", "<package-scope>",
+		"deferred power-action goroutine — no output is read"},
+
+	// ---- output is consumed but never reaches a terminal as raw text ----
+	{"../ipsec", "manager.go", "runSwanctl",
+		"generic swanctl runner; its SA-listing caller sanitizes at ingest " +
+			"(sanitizeSAStatus) and its error path escapes the captured output"},
+
+	// ---- STREAMING sites: cannot be guarded without a shape change ----
+	{"../cli", "monitor_traffic.go", "handleMonitorTraffic",
+		"tcpdump wires cmd.Stdout straight to os.Stdout so there is no string " +
+			"to sanitize, and it is unbounded+interactive so buffering would " +
+			"break Ctrl-C and streaming. This is the MOST attacker-controlled " +
+			"surface in the class — tcpdump renders packet bytes as ASCII. " +
+			"Needs a line-wise sanitizing writer; tracked separately"},
+	{"../cli", "cli_request_ping.go", "handlePing",
+		"streams to os.Stdout; same shape change as tcpdump. Tracked separately"},
+	{"../cli", "cli_request_ping.go", "handleTraceroute",
+		"streams to os.Stdout AND resolves PTR records by default, so the bytes " +
+			"come from DNS an attacker may control. Tracked separately"},
+	{"../grpcapi", "server_diag_ping.go", "streamDiagCmd",
+		"the gRPC ping/traceroute streamer — per-line sends, same shape change " +
+			"as the local CLI twins above. Tracked separately"},
+
+	// ---- low-taint, root-controlled text, LOCAL CLI ONLY ----
+	// Each of these is a SINGLE-fork function, so function granularity is exact
+	// for them. Their gRPC mirrors ARE guarded: those functions fork several
+	// binaries each, and leaving any raw would let the guarded sibling vouch
+	// for the rest under this check.
+	{"../cli", "cli_show_system.go", "showSystemConnections",
+		"ss -tnp — numeric; the process column is root-controlled. Tracked separately"},
+	{"../cli", "cli_show_system.go", "showSystemProcesses",
+		"ps aux — argv of root-controlled processes. Tracked separately"},
+	{"../cli", "cli_show_system.go", "showSystemNTP",
+		"chronyc -n / ntpq -pn / timedatectl — numeric-mode NTP status. Tracked separately"},
+	{"../cli", "cli_clear.go", "handleClearArp",
+		"ip -4 neigh flush — output only in an error string. Tracked separately"},
+	{"../cli", "cli_clear.go", "handleClearIPv6",
+		"ip -6 neigh flush — as above. Tracked separately"},
+
+	// ---- the exec plumbing itself ----
+	{"../grpcapi", "exec_timeout.go", "combinedOutputTimeout", "exec helper, not a display site"},
+	{"../grpcapi", "exec_timeout.go", "combinedOutputTimeoutUnlimited", "exec helper"},
+	{"../grpcapi", "exec_timeout.go", "outputTimeout", "exec helper"},
+	{"../grpcapi", "exec_timeout.go", "outputTimeoutUnlimited", "exec helper"},
+	{"../grpcapi", "exec_timeout.go", "runTimeout", "exec helper; discards output"},
+
+	// ---- destructive admin actions, output only in errors ----
+	{"../grpcapi", "server_diag_system_action.go", "SystemAction",
+		"ip neigh flush; output only in an error string. Tracked separately"},
+	{"../grpcapi", "server_diag_zeroize.go", "<package-scope>",
+		"zeroize userdel / passwd -l root. Tracked separately"},
+}
+
+var forkCallees = map[string]bool{
+	"exec.Command": true, "exec.CommandContext": true,
+	"combinedOutputTimeout": true, "outputTimeout": true,
+	"combinedOutputTimeoutUnlimited": true, "outputTimeoutUnlimited": true,
+}
+
+// TestEveryCommandOutputDisplaySiteIsSanitizedOrDeclared6584 is the tripwire.
+//
+// RED-on-revert: drop the termsafe call from showDaemonLog (or its gRPC
+// mirror) and that function is named here, because it forks and no longer
+// references termsafe and is not on the list.
+func TestEveryCommandOutputDisplaySiteIsSanitizedOrDeclared6584(t *testing.T) {
+	t.Parallel()
+
+	allowed := map[string]string{}
+	for _, e := range declaredUnsanitizedForks {
+		allowed[e.pkgDir+"\x00"+e.file+"\x00"+e.fn] = e.why
+	}
+	found := map[string]bool{}
+	var undeclared []string
+	scanned := 0
+
+	for _, dir := range []string{"../cli", "../grpcapi", "../ipsec"} {
+		ents, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read %s: %v", dir, err)
+		}
+		fset := token.NewFileSet()
+		for _, e := range ents {
+			name := e.Name()
+			if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			path := filepath.Join(dir, name)
+			src, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			f, err := parser.ParseFile(fset, path, src, 0)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+			scanned++
+
+			// A function is "guarded" when its FILE references termsafe and
+			// the function body itself mentions it. File-level alone would
+			// let one guarded function in a file vouch for an unguarded
+			// sibling — which is exactly how a half-applied sweep hides.
+			var decls []*ast.FuncDecl
+			for _, d := range f.Decls {
+				if fd, ok := d.(*ast.FuncDecl); ok {
+					decls = append(decls, fd)
+				}
+			}
+			encl := func(p token.Pos) *ast.FuncDecl {
+				for _, fd := range decls {
+					if fd.Pos() <= p && p <= fd.End() {
+						return fd
+					}
+				}
+				return nil
+			}
+
+			ast.Inspect(f, func(nd ast.Node) bool {
+				ce, ok := nd.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				var callee string
+				switch fn := ce.Fun.(type) {
+				case *ast.Ident:
+					callee = fn.Name
+				case *ast.SelectorExpr:
+					if x, ok := fn.X.(*ast.Ident); ok {
+						callee = x.Name + "." + fn.Sel.Name
+					}
+				}
+				if !forkCallees[callee] {
+					return true
+				}
+				fnName := "<package-scope>"
+				body := ""
+				haveBody := false
+				if fd := encl(ce.Pos()); fd != nil {
+					fnName = fd.Name.Name
+					body = string(src[fd.Pos()-f.FileStart : fd.End()-f.FileStart])
+					haveBody = true
+				}
+				// Guarded when the function applies AT LEAST AS MANY termsafe
+				// calls as it makes forks.
+				//
+				// "references termsafe at all" was the first version and it was
+				// too coarse: GetSystemInfo forks four binaries and ShowText
+				// two, so one guarded arm vouched for its unguarded siblings —
+				// the exact half-applied-sweep shape this file exists to catch,
+				// reproduced inside the guard. The mutation matrix found it:
+				// four cells that removed a real guard stayed GREEN.
+				//
+				// A RELATIVE count is safe where an absolute one would rot:
+				// deleting a fork also lowers the requirement, so the guard
+				// cannot go vacuous by the counted call disappearing — which is
+				// the usual failure of count-based checks. Deleting a SANITIZE
+				// while keeping the fork is what reds.
+				// A fork inside a package-level var initializer has no
+				// enclosing FuncDecl, so there is no body to count. Unknown
+				// must mean UNGUARDED and fall through to the allowlist: with
+				// an empty body both counts are 0, and `0 >= 0` would have
+				// waved every package-scope fork through silently. The control
+				// run caught exactly that.
+				if haveBody && strings.Count(body, "termsafe.") >= strings.Count(body, callee+"(") {
+					return true
+				}
+				key := dir + "\x00" + name + "\x00" + fnName
+				if _, ok := allowed[key]; ok {
+					found[key] = true
+					return true
+				}
+				undeclared = append(undeclared,
+					dir+"/"+name+" "+fnName+"() forks "+callee+" and does not sanitize")
+				return true
+			})
+		}
+	}
+
+	if scanned < 30 {
+		t.Fatalf("scanned only %d production files — the walk is vacuous", scanned)
+	}
+	sort.Strings(undeclared)
+	for _, u := range undeclared {
+		t.Errorf("unsanitized command-output site: %s\n"+
+			"  Route the output through termsafe.SanitizeBlockForDisplay (multi-line\n"+
+			"  command stdout) or termsafe.SanitizeForDisplay (a single-line field),\n"+
+			"  on BOTH renderers — or add it to declaredUnsanitizedForks with the\n"+
+			"  reason it cannot be guarded (#6584).", u)
+	}
+	for _, e := range declaredUnsanitizedForks {
+		if !found[e.pkgDir+"\x00"+e.file+"\x00"+e.fn] {
+			t.Errorf("stale exemption: %s/%s %s() no longer forks, or is now guarded (%s).\n"+
+				"  Remove it — a stale allowlist entry silently widens the next real one.",
+				e.pkgDir, e.file, e.fn, e.why)
+		}
+	}
+}
+
+// TestGetSAStatusWiresTheIngestGuard6584 binds the WIRING for site B.
+//
+// The behavioural tests in pkg/ipsec drive parseSAOutput and sanitizeSAStatus
+// directly, because GetSAStatus forks a real swanctl and cannot be driven from
+// a unit test. That means they test the FUNCTION and say nothing about whether
+// anything calls it — and the mutation that matters is deleting the call.
+func TestGetSAStatusWiresTheIngestGuard6584(t *testing.T) {
+	t.Parallel()
+	src, err := os.ReadFile("../ipsec/ike.go")
+	if err != nil {
+		t.Fatalf("read ike.go: %v", err)
+	}
+	flat := strings.Join(strings.Fields(string(src)), "")
+	if !strings.Contains(flat, "sanitizeSAStatus(&sas[i])") {
+		t.Fatal("GetSAStatus does not call sanitizeSAStatus on the parsed records. " +
+			"Every renderer of SAStatus — two local CLI views, two gRPC mirrors — then " +
+			"prints peer-influenced swanctl text raw, and the pkg/ipsec tests stay green " +
+			"throughout because they exercise the sanitizer directly (#6584).")
+	}
+}
+
+// TestMultiLineCommandOutputUsesTheBlockVariant6584 pins the VARIANT at the
+// sites whose output is multi-line command stdout.
+//
+// Picking the wrong one is not a security regression but it is a real defect
+// in the other direction: SanitizeForDisplay escapes LF, so a whole journalctl
+// dump would collapse into one line of \x0a. pkg/cli/README.md states the rule
+// as "pick the variant by the SHAPE of the value" and says the tests assert
+// both directions; for these forked sites there is no seam to assert it
+// behaviourally, so it is asserted structurally.
+func TestMultiLineCommandOutputUsesTheBlockVariant6584(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ file, fn string }{
+		{"../cli/cli_show_system.go", "showDaemonLog"},
+		{"../cli/cli_show_system.go", "showSystemBootMessages"},
+		{"../grpcapi/server_show.go", "ShowText"},
+		{"../grpcapi/server_show_status.go", "GetSystemInfo"},
+	} {
+		src, err := os.ReadFile(tc.file)
+		if err != nil {
+			t.Fatalf("read %s: %v", tc.file, err)
+		}
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, tc.file, src, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", tc.file, err)
+		}
+		var body string
+		for _, d := range f.Decls {
+			if fd, ok := d.(*ast.FuncDecl); ok && fd.Name.Name == tc.fn {
+				body = string(src[fd.Pos()-f.FileStart : fd.End()-f.FileStart])
+			}
+		}
+		if body == "" {
+			t.Fatalf("%s: function %s not found — this guard is stale", tc.file, tc.fn)
+		}
+		// COUNT-relative, for the same reason the tripwire above is: these
+		// functions fork more than once (GetSystemInfo four times, ShowText and
+		// showDaemonLog twice), so `contains Block` lets one correct arm vouch
+		// for a sibling that was switched to the single-line variant. The
+		// mutation matrix caught exactly that.
+		forks := strings.Count(body, "outputTimeout(ctx,") +
+			strings.Count(body, "combinedOutputTimeout(ctx,") +
+			strings.Count(body, "exec.Command(")
+		if got := strings.Count(body, "SanitizeBlockForDisplay"); got < forks {
+			t.Errorf("%s %s() applies SanitizeBlockForDisplay %d time(s) to %d forked "+
+				"command output(s). The shortfall is sanitized with the SINGLE-LINE "+
+				"variant, which escapes LF — so a multi-line log dump collapses into "+
+				"one line of \\x0a. Multi-line command output takes "+
+				"SanitizeBlockForDisplay, which preserves LF/TAB and neutralizes "+
+				"CR/ESC/C0/C1 (#6584).", tc.file, tc.fn, got, forks)
+		}
+		if forks == 0 {
+			t.Errorf("%s %s(): the fork-counting patterns matched nothing, so this "+
+				"guard is vacuous — the call spelling changed", tc.file, tc.fn)
+		}
+	}
+}

--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -11,6 +11,8 @@ import (
 	"github.com/psaab/xpf/pkg/upgrade"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/psaab/xpf/pkg/termsafe"
 )
 
 // --- Operational show RPCs ---
@@ -471,7 +473,10 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 		if err != nil {
 			return nil, diagExecError("journalctl", err)
 		}
-		buf.Write(out)
+		// #6584: the remote `cli` prints resp.Output VERBATIM, so this is the
+		// same terminal reached over a different transport — and it is the
+		// more common operator posture.
+		buf.WriteString(termsafe.SanitizeBlockForDisplay(string(out)))
 
 	case "internet-options":
 		s.showInternetOptions(cfg, &buf)
@@ -572,7 +577,7 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 			if err != nil {
 				return nil, diagExecError("read "+logPath, err)
 			}
-			buf.Write(out)
+			buf.WriteString(termsafe.SanitizeBlockForDisplay(string(out)))
 		} else {
 			return nil, status.Errorf(codes.InvalidArgument, "unknown topic: %s", req.Topic)
 		}

--- a/pkg/grpcapi/server_show_status.go
+++ b/pkg/grpcapi/server_show_status.go
@@ -14,6 +14,8 @@ import (
 	"github.com/vishvananda/netlink"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/psaab/xpf/pkg/termsafe"
 )
 
 func (s *Server) GetStatus(_ context.Context, _ *pb.GetStatusRequest) (*pb.GetStatusResponse, error) {
@@ -200,14 +202,24 @@ func (s *Server) GetSystemInfo(ctx context.Context, req *pb.GetSystemInfoRequest
 		if err != nil {
 			return nil, diagExecError("running ps", err)
 		}
-		buf.Write(out)
+		// #6584: guarded even though this text is root-controlled rather than
+		// device-originated. GetSystemInfo forks FOUR binaries from one
+		// function, so leaving three raw would let the guarded one vouch for
+		// them under any function-granularity check — the half-applied-sweep
+		// shape #6579 shipped.
+		buf.WriteString(termsafe.SanitizeBlockForDisplay(string(out)))
 
 	case "storage":
 		out, err := outputTimeout(ctx, "df", "-h")
 		if err != nil {
 			return nil, diagExecError("running df", err)
 		}
-		buf.Write(out)
+		// #6584: guarded even though this text is root-controlled rather than
+		// device-originated. GetSystemInfo forks FOUR binaries from one
+		// function, so leaving three raw would let the guarded one vouch for
+		// them under any function-granularity check — the half-applied-sweep
+		// shape #6579 shipped.
+		buf.WriteString(termsafe.SanitizeBlockForDisplay(string(out)))
 
 	case "arp":
 		neighbors, err := netlink.NeighList(0, netlink.FAMILY_V4)
@@ -252,14 +264,21 @@ func (s *Server) GetSystemInfo(ctx context.Context, req *pb.GetSystemInfoRequest
 		if err != nil {
 			return nil, diagExecError("running journalctl", err)
 		}
-		buf.Write(out)
+		// #6584 sweep: same journald text as ShowText{log}; not named in the
+		// issue.
+		buf.WriteString(termsafe.SanitizeBlockForDisplay(string(out)))
 
 	case "connections":
 		out, err := outputTimeout(ctx, "ss", "-tnp")
 		if err != nil {
 			return nil, diagExecError("running ss", err)
 		}
-		buf.Write(out)
+		// #6584: guarded even though this text is root-controlled rather than
+		// device-originated. GetSystemInfo forks FOUR binaries from one
+		// function, so leaving three raw would let the guarded one vouch for
+		// them under any function-granularity check — the half-applied-sweep
+		// shape #6579 shipped.
+		buf.WriteString(termsafe.SanitizeBlockForDisplay(string(out)))
 
 	case "users":
 		cfg := s.store.ActiveConfig()

--- a/pkg/grpcapi/server_show_system.go
+++ b/pkg/grpcapi/server_show_system.go
@@ -36,6 +36,8 @@ import (
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/psaab/xpf/pkg/termsafe"
 )
 
 // showVersion renders daemon version, hostname, kernel, and uptime.
@@ -294,14 +296,14 @@ func (s *Server) showNTP(ctx context.Context, buf *strings.Builder) {
 	// step only runs because the previous binary failed, and the
 	// request ctx still cancels the whole chain on client disconnect.
 	if out, err := combinedOutputTimeout(ctx, "chronyc", "tracking"); err == nil {
-		writeChronyTracking(buf, string(out))
+		writeChronyTracking(buf, termsafe.SanitizeBlockForDisplay(string(out)))
 		if src, err := combinedOutputTimeout(ctx, "chronyc", "-n", "sources"); err == nil {
-			fmt.Fprintf(buf, "\nNTP sources:\n%s", string(src))
+			fmt.Fprintf(buf, "\nNTP sources:\n%s", termsafe.SanitizeBlockForDisplay(string(src)))
 		}
 	} else if out, err := combinedOutputTimeout(ctx, "ntpq", "-pn"); err == nil {
-		fmt.Fprintf(buf, "\nNTP peers:\n%s\n", string(out))
+		fmt.Fprintf(buf, "\nNTP peers:\n%s\n", termsafe.SanitizeBlockForDisplay(string(out)))
 	} else if out, err := combinedOutputTimeout(ctx, "timedatectl", "show", "--property=NTPSynchronized", "--value"); err == nil {
-		fmt.Fprintf(buf, "\nNTP synchronized: %s\n", strings.TrimSpace(string(out)))
+		fmt.Fprintf(buf, "\nNTP synchronized: %s\n", termsafe.SanitizeForDisplay(strings.TrimSpace(string(out))))
 	}
 }
 

--- a/pkg/ipsec/ike.go
+++ b/pkg/ipsec/ike.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
+
+	"github.com/psaab/xpf/pkg/termsafe"
 )
 
 // dpdSettings holds the resolved dead-peer-detection parameters for a
@@ -676,7 +678,7 @@ func (m *Manager) ActiveConnectionNames() ([]string, error) {
 // InitiateConnection initiates a single IPsec connection by name.
 func (m *Manager) InitiateConnection(name string) error {
 	if out, err := runSwanctl("--initiate", "--child", name); err != nil {
-		return fmt.Errorf("swanctl --initiate %s: %w: %s", name, err, string(out))
+		return fmt.Errorf("swanctl --initiate %s: %w: %s", name, err, termsafe.SanitizeForDisplay(string(out)))
 	}
 	return nil
 }
@@ -695,10 +697,19 @@ func (m *Manager) GetSAStatus() ([]SAStatus, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("swanctl --list-sas: %w: %s", err, stderr.String())
+		// #6584: the error string reaches a terminal on both renderers
+		// (pkg/cli prints "error: %v", the gRPC status is re-wrapped and
+		// printed by cmd/cli), so raw swanctl stderr is the same class.
+		return nil, fmt.Errorf("swanctl --list-sas: %w: %s", err, termsafe.SanitizeForDisplay(stderr.String()))
 	}
 
-	return parseSAOutput(stdout.String()), nil
+	sas := parseSAOutput(stdout.String())
+	// #6584: sanitize once, here, so every renderer (local CLI, gRPC mirror,
+	// and any future one) is covered by construction.
+	for i := range sas {
+		sanitizeSAStatus(&sas[i])
+	}
+	return sas, nil
 }
 
 // parseSAOutput parses the human-readable output of `swanctl --list-sas`
@@ -725,6 +736,47 @@ func (m *Manager) GetSAStatus() ([]SAStatus, error) {
 // of this parser assumed an "ipsec statusall"-style layout (local: A === B /
 // local_ts = C / bytes_in=N) that swanctl never emits, so every SA field but
 // the name/state came back blank (#3937).
+// sanitizeSAStatus neutralizes terminal control sequences in every field of a
+// parsed swanctl SA record (#6584).
+//
+// It runs at INGEST rather than at each renderer, because the alternative is
+// roughly two dozen guard sites: `show security ipsec security-associations`
+// and its `detail` form print thirteen fields per SA one line at a time, the
+// statistics view prints a width-formatted row, and every one of those has a
+// byte-for-byte gRPC mirror. #6579's own review recorded what happens to a
+// sweep that wide -- "reverting all 14 call-site edits left the suite green,
+// because the only test file exercised the primitive" -- and the miss it
+// actually shipped was an entire renderer. One choke point cannot be
+// half-applied, and it covers a renderer added later for free. The tree
+// already accepts this shape: LLDP is sanitized at ingest for the same reason.
+//
+// SanitizeForDisplay (single-line) is right for every field here: these are
+// FIELDS the callers format into rows, so an embedded LF is itself a forgery
+// vector -- it fakes a row.
+//
+// Guarding the WHOLE record, not the fields believed to be peer-controlled, is
+// the #6579 rule. The parser is strings.Split/Fields-based, so which swanctl
+// column lands in which struct field is a property of the CURRENT strongSwan
+// output format, not an invariant. Today RemoteTS/LocalTS carry the traffic
+// selectors the peer proposed and parseEndpointHost discards the quoted peer
+// IKE identity; neither fact is guaranteed by anything in this repo.
+func sanitizeSAStatus(sa *SAStatus) {
+	sa.Name = termsafe.SanitizeForDisplay(sa.Name)
+	sa.ConnectionName = termsafe.SanitizeForDisplay(sa.ConnectionName)
+	sa.LocalAddr = termsafe.SanitizeForDisplay(sa.LocalAddr)
+	sa.RemoteAddr = termsafe.SanitizeForDisplay(sa.RemoteAddr)
+	sa.State = termsafe.SanitizeForDisplay(sa.State)
+	sa.LocalTS = termsafe.SanitizeForDisplay(sa.LocalTS)
+	sa.RemoteTS = termsafe.SanitizeForDisplay(sa.RemoteTS)
+	sa.InBytes = termsafe.SanitizeForDisplay(sa.InBytes)
+	sa.OutBytes = termsafe.SanitizeForDisplay(sa.OutBytes)
+	sa.InPackets = termsafe.SanitizeForDisplay(sa.InPackets)
+	sa.OutPackets = termsafe.SanitizeForDisplay(sa.OutPackets)
+	sa.SPIIn = termsafe.SanitizeForDisplay(sa.SPIIn)
+	sa.SPIOut = termsafe.SanitizeForDisplay(sa.SPIOut)
+	sa.Rekey = termsafe.SanitizeForDisplay(sa.Rekey)
+}
+
 func parseSAOutput(output string) []SAStatus {
 	var sas []SAStatus
 	var currentConn *SAStatus

--- a/pkg/ipsec/manager.go
+++ b/pkg/ipsec/manager.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/fsatomic"
+
+	"github.com/psaab/xpf/pkg/termsafe"
 )
 
 // swanctlTimeout bounds every swanctl shell-out. reload() runs on the
@@ -403,7 +405,7 @@ func (m *Manager) terminateIKE(name string) bool {
 func (m *Manager) liveConnNames() (map[string]bool, error) {
 	out, err := m.sc("--list-sas")
 	if err != nil {
-		return nil, fmt.Errorf("swanctl --list-sas: %w: %s", err, string(out))
+		return nil, fmt.Errorf("swanctl --list-sas: %w: %s", err, termsafe.SanitizeForDisplay(string(out)))
 	}
 	names := make(map[string]bool)
 	for _, sa := range parseSAOutput(string(out)) {

--- a/pkg/ipsec/sa_status_termsafe_6584_test.go
+++ b/pkg/ipsec/sa_status_termsafe_6584_test.go
@@ -1,0 +1,126 @@
+// #6584 site B: swanctl SA output reaching an operator terminal unescaped.
+//
+// A CORRECTION TO THE ISSUE'S FRAMING, which changes where the fix belongs.
+// The issue calls this "raw swanctl SA output" — the same raw-block class as
+// the journalctl surface. It is not. `stdout.String()` never reaches a
+// terminal: it goes only to parseSAOutput. What reaches the terminal are the
+// PARSED FIELDS, printed a line at a time by
+// `show security ipsec security-associations [detail]`, as a width-formatted
+// row by the statistics view, and again by both of their gRPC mirrors.
+//
+// So this is #6579's PARSED-ROW class, and the guard goes at INGEST rather
+// than at ~24 render sites across two renderers. #6579's own review recorded
+// what a sweep that wide does: "reverting all 14 call-site edits left the
+// suite green, because the only test file exercised the primitive" — and the
+// miss it shipped was an entire renderer. The tree already accepts
+// sanitize-at-ingest for LLDP.
+//
+// Guarding the WHOLE record rather than the fields believed to be
+// peer-controlled is the #6579 rule, and it is load-bearing here: the parser
+// is strings.Split/Fields-based, so which swanctl column lands in which struct
+// field is a property of the current strongSwan output format, not an
+// invariant this repo controls.
+//
+// FAIL-ON-REVERT: drop the sanitizeSAStatus loop from GetSAStatus and the
+// escape survives into every field below.
+package ipsec
+
+import (
+	"strings"
+	"testing"
+)
+
+// hostileSwanctlOutput is shaped like real `swanctl --list-sas` output with an
+// OSC 52 clipboard write, a CSI erase, a CR and a bare LF folded into the
+// peer-influenced traffic-selector fields.
+const hostileSwanctlOutput = "vpn-a: #1, ESTABLISHED, IKEv2, 1111111111111111_i* 2222222222222222_r\n" +
+	"  local  'CN=fw' @ 192.0.2.1[500]\n" +
+	"  remote 'CN=peer' @ 198.51.100.9[500]\n" +
+	"  vpn-a: #2, reqid 1, INSTALLED, TUNNEL, ESP:AES_GCM_16-256\n" +
+	"    installed 42s ago, rekeying in 3358s, expires in 3918s\n" +
+	"    in  c0ffee01,  1234 bytes,    10 packets\n" +
+	"    out deadbeef,  5678 bytes,    20 packets\n" +
+	"    local  10.0.0.0/24\x1b]52;c;cGF5bG9hZA==\x07\n" +
+	"    remote 10.1.0.0/24\x1b[2J\rSPOOFED\n"
+
+// rawTermControl reports control bytes that survived into a rendered value.
+func rawTermControl(s string) []byte {
+	var got []byte
+	for i := 0; i < len(s); i++ {
+		if b := s[i]; b < 0x20 || b == 0x7f {
+			got = append(got, b)
+		}
+	}
+	return got
+}
+
+// TestSAStatusFieldsAreSanitizedAtIngest6584 drives the real parser and the
+// real ingest guard, then checks EVERY field of every record — not just the
+// two the payload happened to land in. A per-field spot check would pass a
+// guard that covered one column.
+func TestSAStatusFieldsAreSanitizedAtIngest6584(t *testing.T) {
+	sas := parseSAOutput(hostileSwanctlOutput)
+	if len(sas) == 0 {
+		t.Fatal("fixture parsed to zero SAs — the payload never reaches a field, so " +
+			"this test would pass against unguarded code")
+	}
+	for i := range sas {
+		sanitizeSAStatus(&sas[i])
+	}
+
+	sawPayload := false
+	for i, sa := range sas {
+		for name, v := range map[string]string{
+			"Name": sa.Name, "ConnectionName": sa.ConnectionName,
+			"LocalAddr": sa.LocalAddr, "RemoteAddr": sa.RemoteAddr,
+			"State": sa.State, "LocalTS": sa.LocalTS, "RemoteTS": sa.RemoteTS,
+			"InBytes": sa.InBytes, "OutBytes": sa.OutBytes,
+			"InPackets": sa.InPackets, "OutPackets": sa.OutPackets,
+			"SPIIn": sa.SPIIn, "SPIOut": sa.SPIOut, "Rekey": sa.Rekey,
+		} {
+			if got := rawTermControl(v); len(got) != 0 {
+				t.Errorf("SA[%d].%s carries raw control bytes %q: %q — an OSC 52 here "+
+					"writes the operator's clipboard the moment the SA table is "+
+					"displayed (#6584)", i, name, got, v)
+			}
+			if strings.Contains(v, `\x1b`) {
+				sawPayload = true
+			}
+		}
+	}
+	if !sawPayload {
+		t.Fatal("no field contains the ESCAPED payload, so the hostile bytes never " +
+			"reached a struct field at all — the fixture does not exercise the guard. " +
+			"Check parseSAOutput still maps the traffic-selector lines.")
+	}
+}
+
+// TestSAStatusSanitizeDoesNotAlterOrdinaryOutput6584 is the over-reach guard.
+// The SA table is read by operators; mangling ordinary values is its own bug.
+func TestSAStatusSanitizeDoesNotAlterOrdinaryOutput6584(t *testing.T) {
+	const clean = "vpn-branch: #7, ESTABLISHED, IKEv2, aaaa_i* bbbb_r\n" +
+		"  local  'CN=fw.example.com' @ 192.0.2.1[500]\n" +
+		"  remote 'CN=branch.example.com' @ 198.51.100.9[4500]\n" +
+		"  vpn-branch: #9, reqid 2, INSTALLED, TUNNEL, ESP:AES_GCM_16-256\n" +
+		"    installed 42s ago, rekeying in 3358s, expires in 3918s\n" +
+		"    in  c0ffee01,  1234 bytes,    10 packets\n" +
+		"    out deadbeef,  5678 bytes,    20 packets\n" +
+		"    local  10.0.0.0/24\n" +
+		"    remote 10.1.0.0/24\n"
+
+	before := parseSAOutput(clean)
+	after := parseSAOutput(clean)
+	for i := range after {
+		sanitizeSAStatus(&after[i])
+	}
+	if len(before) != len(after) || len(before) == 0 {
+		t.Fatalf("fixture parsed to %d/%d SAs", len(before), len(after))
+	}
+	for i := range before {
+		if before[i] != after[i] {
+			t.Errorf("sanitizing altered an ordinary SA record:\n before: %+v\n after:  %+v\n"+
+				"Well-formed swanctl output must pass through byte-identical (#6584)",
+				before[i], after[i])
+		}
+	}
+}


### PR DESCRIPTION
Closes #6584

## Site A — `journalctl` / `tail`

The site most directly connected to #6468's own threat model: **the syslog stream carries the very DHCP lease hostnames #6468 was filed about**, so a device that sets its hostname to an escape payload gets it logged and re-emitted verbatim the moment an operator runs `show log`. The sanitized lease table is bypassed by reading the log instead.

Guarded on **both** renderers — the remote `cli` prints `resp.Output` verbatim and is the more common operator posture, which is precisely the half #6579 initially missed on its own class.

Also guarded: **`show system boot-messages`** and its `GetSystemInfo` mirror. Same journald text, structurally identical, **not named in the issue** — found by sweeping the predicate rather than the two cited sites. The local one had to move from `cmd.Stdout = os.Stdout` to buffered capture to be guardable at all; output is bounded at 100 lines.

## Site B — a correction that changes where the fix belongs

The issue calls this *"raw swanctl SA output"*, i.e. the same raw-block class as site A. **It is not.** `stdout.String()` never reaches a terminal — it goes only to `parseSAOutput`. What reaches the terminal are the **parsed fields**: thirteen of them, printed a line at a time by `show security ipsec security-associations [detail]`, as a width-formatted row by the statistics view, and again by both gRPC mirrors.

So it is #6579's **parsed-row** class, and the guard goes at **ingest** rather than at ~24 render sites. #6579's own review recorded what a sweep that wide does — *"reverting all 14 call-site edits left the suite green, because the only test file exercised the primitive"* — and the miss it shipped was an entire renderer. The tree already accepts sanitize-at-ingest for LLDP.

The **whole record** is guarded, not the fields believed to be peer-controlled: the parser is `strings.Split`/`Fields`-based, so which swanctl column lands in which struct field is a property of the current strongSwan output format, not an invariant this repo controls.

Every fork in the **multi-fork** gRPC functions is guarded (`GetSystemInfo`'s four, `showNTP`'s four), even where the text is root-controlled, because leaving any raw lets the guarded sibling vouch for it under any function-granularity check.

## The durable part is the tripwire

Research established that **nothing in the tree fails when a display site forgets the guard**: there is no enumerating table and no source-scanning canary for termsafe, only per-site behavioural binders. Every fork-containing function must now apply **at least as many `termsafe` calls as it makes forks**, or appear in `declaredUnsanitizedForks` with a reason — and the check fails in **both** directions, so a stale exemption is caught too.

## Validation

`go build ./...` + `go vet` clean per cell. `go test -count=1 ./pkg/cli ./pkg/grpcapi ./pkg/ipsec` green.

### Mutation matrix

| cell | mutation | result |
|---|---|---|
| Z1 | swanctl ingest guard removed | **wiring** test RED |
| Z2 | only one swanctl field guarded | all-fields test RED |
| Z3 | local journalctl raw | tripwire + variant RED |
| Z4 | gRPC log mirror raw | tripwire + variant RED |
| Z5 | block variant swapped for single-line | variant test RED |
| Z6 | stale exemption for a guarded site | tripwire RED |

### Two fixture defects the matrix exposed — both in the guard itself

1. **The tripwire's first version asked only whether a function "references termsafe".** `GetSystemInfo` forks four binaries and `ShowText` two, so one guarded arm vouched for its unguarded siblings — *the exact half-applied-sweep shape the guard exists to catch, reproduced inside the guard.* **Four cells that removed a real guard stayed green.** It is now count-relative. A relative count is safe where an absolute one rots: deleting a fork also lowers the requirement, so it cannot go vacuous by the counted call disappearing, while deleting a sanitize still reds.
2. **After that change, a fork inside a package-level var initializer has no enclosing `FuncDecl`**, so both counts were 0 and `0 >= 0` waved every package-scope fork through silently. **The control run caught it** (two exemptions reported stale). Unknown body now means unguarded.

The variant test needed the same treatment for the same reason.

Site B's behavioural tests drive `parseSAOutput` / `sanitizeSAStatus` directly, because `GetSAStatus` forks a real swanctl — so they test the function and say nothing about whether anything calls it. **Z1 is that gap**, and a separate wiring assertion covers it.

## Deliberately not fixed — successor #7389

`tcpdump` (renders attacker packet bytes straight to the terminal fd — the most attacker-controlled surface in the class) and `ping`/`traceroute` (which resolves PTR records by default). All three wire `cmd.Stdout` to `os.Stdout`, so guarding them needs a **line-wise sanitizing writer** — a design step, not a missing call. **A partial guard would be worse than none**: it invites the reader to assume the class is handled.

The successor also records the full population the sweep found — at least **9 raw-block, 4 parsed-row and 5 error-string** sites across three packages, against the two the issue named — and every one is on the tripwire's allowlist today, so closing each is a matter of deleting its entry and watching the guard go green.

## Docs

`pkg/cli/README.md` gains the #6584 paragraph in the guarded-surfaces section: the two classes, why site B is ingest-guarded, and the tripwire's relative-count and both-directions properties. `_Log.md` entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAsT5gCGP7k2vhdZ1sDuRi