### PR TITLE
host-inbound: drop VRF-enslaved netdevs from the junos-host iifname scope (+ #6564 member 8: coverage, not existence)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,44 @@
+## 2026-08-22 — #6619 + #6564 member 8: VRF-enslaved iifname scope, and coverage vs existence
+
+- **Timestamp**: 2026-08-22
+- **Action**: Established the kernel fact firsthand before building
+  anything (private userns+netns, real nf_tables over netlink, inet base
+  chain at hook input priority 10 — the exact hook xpf_hostinbound
+  installs): for a packet arriving on a VRF-enslaved netdev, `meta
+  iifname` at LOCAL_IN is the VRF MASTER —
+  `c_slave(veth1)=0 c_master(vrf-t)=3 c_any=3`. The `c_any=3` row is
+  what closes the argument: the hook runs exactly once, so the zero is
+  "it does not happen" rather than "a second pass was missed". Then
+  verified — measured, not inferred, per the explicit ask — that the
+  #4168 suppression really does read the resolved netdev set: a zone
+  whose only candidate is cross-zone-ambiguous resolves to none and its
+  deny warns. The same measurement caught #6564 member 8 live in the
+  neighbouring zone: it had resolved SOME of its candidates, emitted a
+  rule scoped to the survivors, and suppressed its warning. Fixed both
+  in one change because the VRF filter ENLARGES the partially-resolved
+  population. Rejected the lead's suggested shape (make a partially
+  resolved zone non-enforceable) after enumerating the cost: it would
+  withdraw a kernel deny that works. Split the single `enforceable`
+  boolean instead — `emitsRules` (any candidate resolved) still gates
+  emission, `fullyScoped` (no OWN candidate unresolved) now gates
+  suppression — so NO packet changes verdict and the only behaviour
+  change is warnings that were previously suppressed. Refined the
+  coverage predicate after an existing test went red and turned out to
+  be RIGHT: a dropped PARENT superset candidate is not a coverage gap
+  (a plain 802.1Q subunit's frames are demuxed to its own netdev), and
+  counting it would have warned on every trunk with an untagged unit-0
+  in one zone and tagged subunits in others. Only an OWN netdev counts.
+  Three one-line mutations, each `go vet` clean at the mutated state,
+  each localising: recording no netdev as enslaved reds exactly the four
+  VRF rows; reverting the coverage predicate to existence semantics reds
+  exactly the three partial-coverage rows; counting a parent candidate
+  as own reds exactly the over-warning guard row AND the shipped
+  `TestJunosHostCrossZoneAmbiguousTrunkKeepsWarning`, two independent
+  tests agreeing on that line.
+- **File(s)**: `pkg/config/junos_host_deny.go`,
+  `pkg/dataplane/userspace/junos_host_vrf_scope_6619_test.go` (new),
+  `docs/host-inbound-service-matrix.md`
+
 ## 2026-08-21 — #6612 junos-host residual: audited the claim, found it false, locked what holds
 
 - **Timestamp**: 2026-08-21

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -1603,6 +1603,73 @@ helper never sees it, so a helper crash cannot lock management out).
   slice below); it never replaces it. Because the scope is the ingress netdev, a
   destination-scoped deny on a data zone can never suppress management ingress on
   a lifeline, whichever firewall address it names.
+- **An l3mdev VRF netdev cannot be an `iifname` scope (#6619).** The daemon
+  enslaves every interface member of every routing instance whose
+  `instance-type` is not `forwarding` to `vrf-<name>`
+  (`pkg/daemon/daemon_apply_interfaces.go` → `BindInterfaceToVRF` →
+  `LinkSetMaster`). At the netfilter LOCAL_IN hook the l3mdev receive handler has
+  already replaced `skb->dev` with the VRF device, so `meta iifname` names the
+  **master**, never the enslaved interface, and `iifname "ge-0-0-1" … drop`
+  matches nothing. Measured firsthand at the exact hook and priority
+  `xpf_hostinbound` installs (inet base chain, hook `input`, priority 10) on the
+  kernel floor this project targets: `c_slave(veth1)=0  c_master(vrf-t)=3
+  c_any=3` — and `c_any=3` for three packets proves the hook runs **exactly
+  once**, so the zero is "it does not happen", not "a second pass was missed".
+  Such a netdev is therefore dropped from the scope. Before #6619 it was kept:
+  the zone emitted a representable program whose rules never matched AND, being
+  representable, suppressed its own #4168 warning — config commits clean, rules
+  present in the ruleset, nothing enforced.
+
+  **Not the same finding as #4455 Component A**, which is PLAN-KILLed. That
+  proposed to ADD a first-ever `iifname` predicate for *multicast admission*, and
+  was killed on reachability plus three attribution fragilities —
+  RETH→physical-member resolution, guess-on-malformed input, an address-lazy
+  interface source. l3mdev/VRF is in none of them, and this is a gate that
+  already shipped (#4932/#4146) on a different feature.
+
+  **Do not "fix" this by scoping on the VRF master name instead.** That rule
+  would match every interface in the VRF, including unzoned ones and any lifeline
+  bound to the same VRF — management stranding of the #7284 shape, where lifeline
+  exclusion is by INTERFACE and not by address value. Making it safe would need
+  full VRF-membership attribution including tunnel interfaces bound through
+  `pkg/routing/tunnel.go`'s `tc.RoutingInstance`, which is the fragile-attribution
+  territory #4455 Component A died in. Enforcement under VRF, if ever wanted,
+  needs its own design with that as the acceptance gate.
+
+- **Scope resolution is a COVERAGE question, not an existence one (#6564
+  member 8).** Two decisions come out of the resolved scope and they are
+  deliberately not one boolean:
+
+  - **Emit rules** when at least one candidate resolved. Protection that works is
+    never withdrawn — a zone that resolved some of its ingress netdevs still gets
+    a kernel deny on those.
+  - **Suppress the #4168 warning** only when every OWN candidate resolved. A zone
+    that resolved *some* is not enforcing the policy on every ingress path, and
+    `len(netdevs) > 0` cannot tell that from full coverage — it reported such a
+    zone as fully enforced.
+
+  A zone with NO candidates at all (lifeline-only, or no interfaces) is a third
+  state and must stay distinct: there is nothing to enforce, so it must not block
+  suppression. The distinction is exactly `len(Unscopable) > 0` — the zone HAD
+  candidates and could not use them all.
+
+  **Only an OWN netdev counts toward the gap.** A VLAN subunit contributes its
+  physical parent as an extra candidate for the bondless-RETH case where frames
+  may ride the member. On a plain 802.1Q trunk the parent is never where the
+  subunit's frames arrive, so losing it costs that zone nothing. Counting a
+  dropped parent as a coverage gap would warn on every trunk carrying an untagged
+  unit-0 in one zone and tagged subunits in others — an ordinary correct config,
+  and an advisory that fires on those stops being read at all.
+  `TestJunosHostCrossZoneAmbiguousTrunkKeepsWarning` (pkg/config) and the
+  parent-superset row of
+  `pkg/dataplane/userspace/junos_host_vrf_scope_6619_test.go` both hold this
+  line.
+
+  **No packet changes verdict.** Dropping an enslaved netdev removes only rules
+  that provably never matched, and partially-resolved zones keep every rule they
+  had. The whole behaviour change is commit-time warnings that were previously
+  suppressed.
+
 - **Coarse-then-fine order (`pkg/daemon/daemon_nft.go`).** The fine DROP runs after
   ESP/AH accept + the firewall-originated reply-direction established accept, but
   BEFORE the ND/PMTUD accepts and the residual full established accept, so a denied

--- a/pkg/config/junos_host_deny.go
+++ b/pkg/config/junos_host_deny.go
@@ -196,10 +196,14 @@ func BuildJunosHostDenyProjection(cfg *Config) JunosHostDenyProjection {
 	}
 	feedBound := junosHostFeedBoundNames(cfg)
 	lifelines := HostInboundLifelineSet(cfg)
-	// Per-zone kernel netdev iifname scope. A zone whose every non-lifeline
-	// netdev is cross-zone-ambiguous resolves to an EMPTY set here — it emits no
-	// kernel rule, so its denies must NOT be suppressed from the #4168 warning.
-	netdevsByZone := JunosHostZoneIngressNetdevs(cfg)
+	// Per-zone kernel netdev iifname scope, WITH what could not be scoped
+	// (#6564 member 8). A zone that resolved only SOME of its candidates still
+	// emits rules for the survivors — protection that works is never withdrawn —
+	// but the policy is not enforced on every ingress path of the zone, so its
+	// #4168 warning must not be suppressed. A non-empty check cannot tell that
+	// apart from full coverage, which is why the projection reads the coverage
+	// and not the netdev list.
+	coverageByZone := junosHostZoneNetdevCoverageMap(cfg)
 
 	// Per-policy-key bookkeeping to decide rendered-vs-warned (§3.3): a policy is
 	// rendered (warning suppressed) iff it is a DENY that applies to >=1
@@ -227,12 +231,23 @@ func BuildJunosHostDenyProjection(cfg *Config) JunosHostDenyProjection {
 			continue
 		}
 		ifaceRefs := junosHostNonLifelineRefs(zone, lifelines)
-		netdevs := netdevsByZone[zoneName]
-		// A deny suppresses its #4168 warning ONLY if it produces a rendered
-		// kernel rule, which requires >=1 unambiguous non-lifeline netdev to scope
-		// the DROP by iifname — NOT merely a non-lifeline interface REF (a ref
-		// whose only netdev is a cross-zone-ambiguous shared parent emits nothing).
-		enforceable := len(netdevs) > 0
+		cov := coverageByZone[zoneName]
+		netdevs := cov.Scoped
+		// TWO decisions, deliberately not one boolean (#6564 member 8).
+		//
+		// emitsRules gates kernel emission: a DROP needs >=1 usable netdev to
+		// scope it by iifname. Unchanged.
+		//
+		// fullyScoped gates the #4168 warning SUPPRESSION, and it is a COVERAGE
+		// question, not an existence one. A zone that had candidates and could
+		// not use all of them is not enforcing the policy on every ingress path,
+		// whether it salvaged some of them or none. Note the two cases are not
+		// the same predicate: a zone with NO candidates at all (lifeline-only, or
+		// no interfaces) has nothing to enforce and must NOT block suppression —
+		// which is exactly what distinguishes it from a zone whose candidates all
+		// turned out to be unscopable.
+		emitsRules := len(netdevs) > 0
+		fullyScoped := len(cov.Unscopable) == 0
 		representable := true
 		for _, t := range terms {
 			if !t.representable {
@@ -247,7 +262,7 @@ func BuildJunosHostDenyProjection(cfg *Config) JunosHostDenyProjection {
 			representable = false
 		}
 		var prog JunosHostDenyProgram
-		if enforceable && representable {
+		if emitsRules && representable {
 			// A cross-dimension permit/deny overlap (a narrow-application or
 			// source-excluded permit ahead of a deny) cannot be cleanly rendered
 			// as a `saddr !=` subtraction — the whole program is un-representable
@@ -272,16 +287,23 @@ func BuildJunosHostDenyProjection(cfg *Config) JunosHostDenyProjection {
 		}
 		// Bookkeeping for the warning.
 		for _, t := range terms {
-			if !enforceable {
+			actionByKey[t.key] = t.action
+			// A zone that tried to scope and could not use every candidate blocks
+			// suppression even when it emitted nothing at all — the policy is
+			// unenforced on that zone's ingress either way, and saying so is the
+			// whole job of the #4168 advisory.
+			if !fullyScoped {
+				blockedByUnrep[t.key] = true
+			}
+			if !emitsRules {
 				continue
 			}
 			appliesEnforceable[t.key]++
-			actionByKey[t.key] = t.action
 			if !representable {
 				blockedByUnrep[t.key] = true
 			}
 		}
-		if !enforceable || !representable {
+		if !emitsRules || !representable {
 			out.Programs = append(out.Programs, JunosHostDenyProgram{
 				Zone:          zoneName,
 				InterfaceRefs: ifaceRefs,
@@ -1103,38 +1125,159 @@ func junosHostZoneExemptNetdevs(cfg *Config, zoneName string, zone *ZoneConfig, 
 	return ikeNetdevs, identNetdevs
 }
 
+// Reasons a zone's candidate ingress netdev cannot be used as an iifname scope.
+const (
+	// junosHostNetdevAmbiguous: the netdev is claimed by MORE THAN ONE zone (a
+	// shared physical parent — a zone on a trunk's untagged unit-0 while the
+	// SAME parent carries another zone's tagged VLAN subunits). Scoping a deny
+	// by it would over-fire on the other zone's ingress.
+	junosHostNetdevAmbiguous = "cross-zone-ambiguous"
+	// junosHostNetdevVRFEnslaved (#6619): the netdev is enslaved to an l3mdev
+	// VRF master by the routing-instance bind in pkg/daemon
+	// (applyVRFReconcile -> BindInterfaceToVRF -> LinkSetMaster). At the
+	// netfilter LOCAL_IN hook the l3mdev rcv handler has already replaced
+	// skb->dev with the VRF device, so `meta iifname` reports the MASTER and an
+	// `iifname "<enslaved>"` rule matches nothing. Measured on the kernel floor
+	// this project targets, at the exact hook and priority xpf_hostinbound
+	// installs: 0 hits on the enslaved name, 3 on the master, and 3 on an
+	// unconditional counter — the hook runs exactly once, so there is no second
+	// pass carrying the enslaved name.
+	junosHostNetdevVRFEnslaved = "vrf-enslaved"
+)
+
+// junosHostUnscopableNetdev is one candidate ingress netdev that cannot serve as
+// an iifname scope, with the reason.
+type junosHostUnscopableNetdev struct {
+	Netdev string
+	Reason string
+}
+
+// junosHostZoneNetdevCoverage is one zone's iifname-scope resolution.
+//
+// The three states are NOT interchangeable and the projection reads them
+// differently (#6564 member 8):
+//
+//   - No candidates at all (both fields empty) — a lifeline-only zone, or one
+//     with no interfaces. There is NOTHING to enforce, so this must not block a
+//     policy's warning suppression.
+//   - Scoped non-empty, Unscopable empty — fully resolved. Rules are emitted and
+//     the policy is genuinely enforced on every ingress path of the zone.
+//   - Unscopable non-empty — the zone HAD candidates and at least one of its OWN
+//     ingress netdevs could not be used. Whatever survived is still emitted
+//     (never withdraw protection that works), but the policy is NOT enforced on
+//     every ingress path of the zone, so its warning must not be suppressed.
+//     This covers both "some resolved" and "none resolved"; the difference
+//     between them is only whether any rule is emitted, not whether the policy
+//     is fully enforced.
+//
+// Only an OWN netdev counts toward Unscopable. A dropped PARENT superset
+// candidate does not: a VLAN subunit contributes its physical parent as an extra
+// candidate for the bondless-RETH case, and on a plain 802.1Q trunk that parent
+// is never where the subunit's frames arrive, so its loss is not a gap. Counting
+// it would warn on every trunk carrying an untagged unit-0 in one zone and
+// tagged subunits in others — an ordinary correct config, and the population an
+// advisory must not fire on if operators are to keep reading it.
+type junosHostZoneNetdevCoverage struct {
+	Scoped     []string
+	Unscopable []junosHostUnscopableNetdev
+}
+
 // JunosHostZoneIngressNetdevs returns, per security zone, the sorted set of
 // kernel netdev names a host-bound packet on that zone arrives with — the
 // iifname scope for the zone's #4146 junos-host DROP rules. It EXCLUDES
-// lifelines and any netdev claimed by MORE THAN ONE zone (an ambiguous shared
+// lifelines, any netdev claimed by MORE THAN ONE zone (an ambiguous shared
 // physical parent — e.g. a zone on a trunk's untagged unit-0 while the SAME
-// parent carries other zones' tagged VLAN subunits), so a zone's deny can never
-// over-fire on another zone's ingress.
+// parent carries other zones' tagged VLAN subunits) so a zone's deny can never
+// over-fire on another zone's ingress, and any netdev enslaved to an l3mdev VRF
+// (#6619) because `iifname` at LOCAL_IN names the VRF master, not the enslaved
+// device, so such a rule matches nothing.
 //
 // It is the SSOT for the iifname scope: the dataplane BuildJunosHostPrograms
 // consumes JunosHostDenyProgram.IngressNetdevs (populated from this) for kernel
-// emission, AND BuildJunosHostDenyProjection gates a deny's warning-suppression
-// on a NON-EMPTY result here — so the #4168 warning can never be suppressed for
-// a deny that produced no kernel rule (the F1 fix; §8 inv-1/12). The
-// netdev-name resolution mirrors the dataplane interface-snapshot LinuxName
-// (userspace.snapshotLinuxName) exactly, pinned byte-for-byte by
-// TestJunosHostZoneNetdevsMatchSnapshot so the two planes cannot drift.
+// emission. Warning suppression is gated on the richer
+// junosHostZoneNetdevCoverage below, NOT on this result being non-empty: a zone
+// that resolved SOME of its candidates emits rules while still not enforcing the
+// policy on every ingress path, and a non-empty check cannot tell that from full
+// coverage (#6564 member 8). The netdev-name resolution mirrors the dataplane
+// interface-snapshot LinuxName (userspace.snapshotLinuxName) exactly, pinned
+// byte-for-byte by TestJunosHostZoneNetdevsMatchSnapshot so the two planes
+// cannot drift.
 func JunosHostZoneIngressNetdevs(cfg *Config) map[string][]string {
+	cov := junosHostZoneNetdevCoverageMap(cfg)
+	if len(cov) == 0 {
+		return nil
+	}
+	out := map[string][]string{}
+	for zone, c := range cov {
+		if len(c.Scoped) > 0 {
+			out[zone] = c.Scoped
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// junosHostVRFEnslavedNetdevs returns the set of kernel netdev names the daemon
+// binds to an l3mdev VRF master. It mirrors applyVRFReconcile
+// (pkg/daemon/daemon_apply_interfaces.go) exactly: every interface member of
+// every routing instance whose instance-type is not `forwarding` (a forwarding
+// instance creates no VRF device and enslaves nothing).
+//
+// Members are resolved through netdevByRef — the SAME ref->netdev map the
+// candidate walk builds — so a bare physical member (`ge-0/0/1`) and its
+// untagged unit-0, which share one netdev, are both covered by a single entry,
+// and a member naming no configured interface contributes nothing (it cannot be
+// a zone candidate either). A VLAN subunit is a distinct kernel device with its
+// own master, so enslaving the parent does NOT enslave the subunit — keying on
+// the netdev rather than the ref gets that right without a special case.
+func junosHostVRFEnslavedNetdevs(cfg *Config, netdevByRef map[string]string) map[string]bool {
+	out := map[string]bool{}
+	for _, ri := range cfg.RoutingInstances {
+		if ri == nil || ri.InstanceType == "forwarding" {
+			continue
+		}
+		for _, member := range ri.Interfaces {
+			if member == "" {
+				continue
+			}
+			if nd := netdevByRef[CanonicalInterfaceUnitRef(member)]; nd != "" {
+				out[nd] = true
+			}
+		}
+	}
+	return out
+}
+
+// junosHostZoneNetdevCoverageMap resolves every zone's iifname scope and records
+// what it could NOT use, so the projection can distinguish "nothing to enforce"
+// from "could not fully enforce".
+func junosHostZoneNetdevCoverageMap(cfg *Config) map[string]junosHostZoneNetdevCoverage {
 	if cfg == nil || len(cfg.Security.Zones) == 0 || len(cfg.Interfaces.Interfaces) == 0 {
 		return nil
 	}
 	lifelines := HostInboundLifelineSet(cfg)
 	zoneByIface := junosHostZoneByInterface(cfg)
-	cand := map[string]map[string]bool{}   // zone -> netdev set
+	// cand[zone][netdev] records whether the netdev is the zone's OWN ingress
+	// device (true) or only a conservative PARENT superset candidate (false).
+	// The distinction decides whether losing it is a coverage GAP: a subunit's
+	// own netdev is where its frames actually arrive, whereas the physical
+	// parent is added for the bondless-RETH case where they may ride the member
+	// instead. Losing a parent candidate costs a plain 802.1Q zone nothing —
+	// tagged frames are demuxed to the subunit netdev — so treating it as a gap
+	// would warn on every trunk that carries an untagged unit-0 in one zone and
+	// tagged subunits in others, which is an ordinary correct config.
+	cand := map[string]map[string]bool{}   // zone -> netdev -> isOwn
 	claims := map[string]map[string]bool{} // netdev -> zone set
-	addCand := func(zone, nd string) {
+	addCand := func(zone, nd string, own bool) {
 		if zone == "" || nd == "" {
 			return
 		}
 		if cand[zone] == nil {
 			cand[zone] = map[string]bool{}
 		}
-		cand[zone][nd] = true
+		cand[zone][nd] = cand[zone][nd] || own
 		if claims[nd] == nil {
 			claims[nd] = map[string]bool{}
 		}
@@ -1151,9 +1294,9 @@ func JunosHostZoneIngressNetdevs(cfg *Config) map[string][]string {
 		if zone == "" {
 			return
 		}
-		addCand(zone, own)
+		addCand(zone, own, true)
 		if vlan != 0 && parent != "" {
-			addCand(zone, parent)
+			addCand(zone, parent, false)
 		}
 	}
 	ifNames := make([]string, 0, len(cfg.Interfaces.Interfaces))
@@ -1161,6 +1304,25 @@ func JunosHostZoneIngressNetdevs(cfg *Config) map[string][]string {
 		ifNames = append(ifNames, n)
 	}
 	sort.Strings(ifNames)
+	// Pass 1: ref -> netdev for every physical and unit row, so the VRF member
+	// list resolves through the SAME name rule the candidates use.
+	netdevByRef := map[string]string{}
+	for _, ifName := range ifNames {
+		iface := cfg.Interfaces.Interfaces[ifName]
+		if iface == nil {
+			continue
+		}
+		netdevByRef[ifName] = junosHostLinuxName(cfg, ifName, nil)
+		for un, unit := range iface.Units {
+			if unit == nil {
+				continue
+			}
+			netdevByRef[fmt.Sprintf("%s.%d", ifName, un)] = junosHostLinuxName(cfg, ifName, unit)
+		}
+	}
+	enslaved := junosHostVRFEnslavedNetdevs(cfg, netdevByRef)
+	// Pass 2: the candidate walk. One "row" per physical interface + one per
+	// unit, mirroring the dataplane interface snapshot.
 	for _, ifName := range ifNames {
 		iface := cfg.Interfaces.Interfaces[ifName]
 		if iface == nil {
@@ -1182,18 +1344,38 @@ func JunosHostZoneIngressNetdevs(cfg *Config) map[string][]string {
 				junosHostLinuxName(cfg, ifName, nil), unit.VlanID)
 		}
 	}
-	out := map[string][]string{}
+	out := map[string]junosHostZoneNetdevCoverage{}
 	for zone, nds := range cand {
-		var keep []string
+		var c junosHostZoneNetdevCoverage
+		names := make([]string, 0, len(nds))
 		for nd := range nds {
-			if len(claims[nd]) == 1 { // unambiguous: only this zone claims nd
-				keep = append(keep, nd)
+			names = append(names, nd)
+		}
+		sort.Strings(names)
+		for _, nd := range names {
+			reason := ""
+			switch {
+			// Ambiguity is reported first: it is the pre-existing reason and the
+			// one an operator resolves by re-zoning, whereas an enslaved netdev
+			// is not scopable by any zoning change.
+			case len(claims[nd]) != 1:
+				reason = junosHostNetdevAmbiguous
+			case enslaved[nd]:
+				reason = junosHostNetdevVRFEnslaved
+			}
+			if reason == "" {
+				c.Scoped = append(c.Scoped, nd)
+				continue
+			}
+			// Only an OWN netdev that could not be scoped is a coverage gap. A
+			// dropped PARENT superset candidate is not: the subunit's own netdev
+			// still covers where its frames arrive.
+			if nds[nd] {
+				c.Unscopable = append(c.Unscopable,
+					junosHostUnscopableNetdev{Netdev: nd, Reason: reason})
 			}
 		}
-		if len(keep) > 0 {
-			sort.Strings(keep)
-			out[zone] = keep
-		}
+		out[zone] = c
 	}
 	return out
 }

--- a/pkg/dataplane/userspace/junos_host_vrf_scope_6619_test.go
+++ b/pkg/dataplane/userspace/junos_host_vrf_scope_6619_test.go
@@ -1,0 +1,296 @@
+package userspace
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// junos_host_vrf_scope_6619_test.go locks two coupled properties of the #4146
+// junos-host DENY projection's iifname scope.
+//
+// #6619 — an interface enslaved to an l3mdev VRF cannot be scoped by its own
+// name. The daemon binds every member of every non-`forwarding` routing instance
+// to `vrf-<name>` (pkg/daemon/daemon_apply_interfaces.go, applyVRFReconcile ->
+// BindInterfaceToVRF -> LinkSetMaster), and at the netfilter LOCAL_IN hook the
+// l3mdev rcv handler has already replaced skb->dev with the VRF device. Measured
+// firsthand at the exact hook and priority xpf_hostinbound installs (inet base
+// chain, hook input, priority 10), on the kernel floor this project targets:
+//
+//	c_slave(veth1)=0  c_master(vrf-t)=3  c_any=3
+//
+// Zero hits on the enslaved name, three on the master — and `c_any=3` for three
+// packets proves the hook runs EXACTLY ONCE, so `c_slave=0` is "it does not
+// happen", not "we missed a second pass". Before this fix such a zone emitted a
+// representable program whose rules matched nothing, and because the program WAS
+// representable it also SUPPRESSED its own #4168 warning: config commits clean,
+// rules present in the ruleset, nothing enforced.
+//
+// #6564 member 8 — `enforceable := len(netdevs) > 0` asked an EXISTENCE question
+// where COVERAGE was required. A zone that resolved only SOME of its ingress
+// netdevs emitted a rule covering the survivors and suppressed its warning,
+// reporting as fully enforced. The projection now reads a coverage record, and
+// the two decisions are separated: rules are emitted whenever anything resolved
+// (protection that works is never withdrawn), while the warning is suppressed
+// only when every OWN ingress netdev resolved.
+//
+// The two are one change because the VRF filter ENLARGES the population of
+// partially-resolved zones — fixing #6619 alone would have grown the set of
+// configs hitting member 8.
+//
+// Rows assert BOTH halves in ONE cell — the resolved scope, whether a kernel
+// rule was emitted, AND the warning count. Two tests, one per half, could drift
+// apart in exactly the way the projection and the advisory already had.
+
+// vrfScopeBase is the interface/zone scaffolding. `trust` exists so the config
+// always has a second, untouched zone: a row that accidentally emptied every
+// zone's scope would otherwise look the same as one that emptied the zone under
+// test.
+var vrfScopeBase = []string{
+	"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
+	"set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.1/24",
+	"set interfaces ge-0/0/1 unit 50 vlan-id 50",
+	"set interfaces ge-0/0/1 unit 50 family inet address 10.0.50.1/24",
+	"set interfaces ge-0/0/2 unit 0 family inet address 10.0.2.1/24",
+	"set security zones security-zone trust interfaces ge-0/0/0.0",
+	"set security address-book global address bad-host 10.0.0.5/32",
+}
+
+// vrfScopeDeny is a plainly representable junos-host deny — source-scoped,
+// destination any, application any — so a row that renders nothing renders
+// nothing because of the SCOPE, not because the policy was un-representable.
+func vrfScopeDeny(fromZone, name string) []string {
+	p := fmt.Sprintf("set security policies from-zone %s to-zone junos-host policy %s ", fromZone, name)
+	return []string{
+		p + "match source-address bad-host",
+		p + "match destination-address any",
+		p + "match application any",
+		p + "then deny",
+	}
+}
+
+func vrfScopeProgram(t *testing.T, cfg *config.Config, zone string) (JunosHostProgram, bool) {
+	t.Helper()
+	for _, p := range BuildJunosHostPrograms(cfg) {
+		if p.Zone == zone {
+			return p, true
+		}
+	}
+	return JunosHostProgram{}, false
+}
+
+// TestJunosHostIngressScopeCoverage6619 walks the scope-resolution states.
+func TestJunosHostIngressScopeCoverage6619(t *testing.T) {
+	rows := []struct {
+		name string
+		// zone / policyName are explicit rather than derived: a heuristic that
+		// picks the subject from the expected values makes the row's assertions
+		// depend on the answer they are checking.
+		zone       string
+		policyName string
+		cmds       []string
+		// wantScoped is the zone's resolved iifname set, asserted exactly: a
+		// count would pass for the right number of wrong netdevs, and the whole
+		// defect is that a rule names a netdev traffic never arrives on.
+		wantScoped []string
+		// wantRules is whether a kernel DROP rule is emitted at all.
+		wantRules bool
+		// wantWarn is the #4168 warning count for the zone's deny.
+		wantWarn int
+	}{
+		{
+			// CONTROL. Without a row that resolves fully, emits a rule and stays
+			// silent, every assertion below is satisfiable by a projection that
+			// resolved nothing and warned about everything.
+			name:       "fully scoped — rule emitted, warning suppressed",
+			zone:       "zoneA",
+			policyName: "denyA",
+			cmds: concat(vrfScopeBase,
+				[]string{"set security zones security-zone zoneA interfaces ge-0/0/1.0"},
+				vrfScopeDeny("zoneA", "denyA")),
+			wantScoped: []string{"ge-0-0-1"},
+			wantRules:  true,
+			wantWarn:   0,
+		},
+		{
+			// #6619, resolved-NONE. The zone's only ingress netdev is enslaved,
+			// so nothing can be scoped and the deny is unenforceable on the
+			// direct host-bound path. Before the fix this emitted a rule on
+			// `ge-0-0-1` — which LOCAL_IN never reports — and suppressed the
+			// warning.
+			name:       "VRF-enslaved, only interface — nothing scoped, warning fires",
+			zone:       "zoneA",
+			policyName: "denyA",
+			cmds: concat(vrfScopeBase,
+				[]string{
+					"set security zones security-zone zoneA interfaces ge-0/0/1.0",
+					"set routing-instances vrA instance-type virtual-router",
+					"set routing-instances vrA interface ge-0/0/1.0",
+				},
+				vrfScopeDeny("zoneA", "denyA")),
+			wantScoped: nil,
+			wantRules:  false,
+			wantWarn:   1,
+		},
+		{
+			// #6619 + member 8, resolved-SOME. This is the state the coverage
+			// predicate exists for: the rule that CAN be scoped is still emitted
+			// (protection that works is never withdrawn) AND the warning fires,
+			// because the deny is not enforced on ge-0-0-1's ingress. An
+			// existence check reports this zone as fully enforced.
+			name:       "VRF-enslaved plus a sibling — partial scope, rule AND warning",
+			zone:       "zoneA",
+			policyName: "denyA",
+			cmds: concat(vrfScopeBase,
+				[]string{
+					"set security zones security-zone zoneA interfaces ge-0/0/1.0",
+					"set security zones security-zone zoneA interfaces ge-0/0/2.0",
+					"set routing-instances vrA instance-type virtual-router",
+					"set routing-instances vrA interface ge-0/0/1.0",
+				},
+				vrfScopeDeny("zoneA", "denyA")),
+			wantScoped: []string{"ge-0-0-2"},
+			wantRules:  true,
+			wantWarn:   1,
+		},
+		{
+			// The enslavement predicate keys on the NETDEV, not the config ref.
+			// A bare physical member enslaves the device that unit 0 also
+			// resolves to, so a zone holding `ge-0/0/1.0` is covered by a
+			// routing instance naming `ge-0/0/1`. Keying on the ref would miss
+			// this and leave the original defect intact for the commoner spelling.
+			name:       "routing instance names the bare physical — unit 0 shares that netdev",
+			zone:       "zoneA",
+			policyName: "denyA",
+			cmds: concat(vrfScopeBase,
+				[]string{
+					"set security zones security-zone zoneA interfaces ge-0/0/1.0",
+					"set routing-instances vrA instance-type virtual-router",
+					"set routing-instances vrA interface ge-0/0/1",
+				},
+				vrfScopeDeny("zoneA", "denyA")),
+			wantScoped: nil,
+			wantRules:  false,
+			wantWarn:   1,
+		},
+		{
+			// `instance-type forwarding` creates NO VRF device and enslaves
+			// nothing (applyVRFReconcile skips it), so its members stay scopable.
+			// Without this row the fix would read as "any routing-instance
+			// membership breaks the scope", which is a different and wrong rule.
+			name:       "instance-type forwarding is not a VRF — scope intact",
+			zone:       "zoneA",
+			policyName: "denyA",
+			cmds: concat(vrfScopeBase,
+				[]string{
+					"set security zones security-zone zoneA interfaces ge-0/0/1.0",
+					"set routing-instances fwd instance-type forwarding",
+					"set routing-instances fwd interface ge-0/0/1.0",
+				},
+				vrfScopeDeny("zoneA", "denyA")),
+			wantScoped: []string{"ge-0-0-1"},
+			wantRules:  true,
+			wantWarn:   0,
+		},
+		{
+			// member 8 via AMBIGUITY on an OWN netdev, no VRF involved. zoneA
+			// owns the untagged unit-0 (its own netdev ge-0-0-1) and ge-0/0/2.0;
+			// zoneB's tagged subunit nominates ge-0-0-1 as a parent candidate and
+			// makes it ambiguous. zoneA loses one of its OWN ingress paths and
+			// keeps the other.
+			name:       "own netdev lost to cross-zone ambiguity — partial scope, rule AND warning",
+			zone:       "zoneA",
+			policyName: "denyA",
+			cmds: concat(vrfScopeBase,
+				[]string{
+					"set security zones security-zone zoneA interfaces ge-0/0/1.0",
+					"set security zones security-zone zoneA interfaces ge-0/0/2.0",
+					"set security zones security-zone zoneB interfaces ge-0/0/1.50",
+				},
+				vrfScopeDeny("zoneA", "denyA")),
+			wantScoped: []string{"ge-0-0-2"},
+			wantRules:  true,
+			wantWarn:   1,
+		},
+		{
+			// THE OVER-WARNING GUARD. zoneB holds only the tagged subunit. Its
+			// physical parent is contributed as a conservative superset candidate
+			// (the bondless-RETH case) and is dropped here — but a plain 802.1Q
+			// subunit's frames are demuxed to ge-0-0-1.50, so losing the parent
+			// costs zoneB nothing and must NOT warn. Counting a dropped parent as
+			// a coverage gap would fire on every trunk carrying an untagged
+			// unit-0 in one zone and tagged subunits in others: an ordinary
+			// correct config, and an advisory that fires on those stops being
+			// read at all.
+			name:       "parent superset candidate dropped — not a gap, no warning",
+			zone:       "zoneB",
+			policyName: "denyB",
+			cmds: concat(vrfScopeBase,
+				[]string{
+					"set security zones security-zone zoneA interfaces ge-0/0/1.0",
+					"set security zones security-zone zoneB interfaces ge-0/0/1.50",
+				},
+				vrfScopeDeny("zoneB", "denyB")),
+			wantScoped: []string{"ge-0-0-1.50"},
+			wantRules:  true,
+			wantWarn:   0,
+		},
+		{
+			// A VLAN subunit is a distinct kernel device with its own master, so
+			// enslaving the PARENT does not enslave the subunit: ge-0-0-1.50 stays
+			// scopable and the rule is still emitted on it.
+			//
+			// The warning nonetheless fires, and that is correct rather than
+			// incidental. `junosHostZoneByInterface` back-fills the BARE physical
+			// to the zone of a subunit when no other zone claims it, so zoneB owns
+			// ge-0-0-1 as an OWN candidate here — and that candidate is enslaved.
+			// The zone really does have an ingress path the deny cannot cover, and
+			// the row asserts the pair: keep what is scopable, announce what is not.
+			name:       "parent enslaved, subunit is not — subunit stays scopable, gap announced",
+			zone:       "zoneB",
+			policyName: "denyB",
+			cmds: concat(vrfScopeBase,
+				[]string{
+					"set security zones security-zone zoneB interfaces ge-0/0/1.50",
+					"set routing-instances vrA instance-type virtual-router",
+					"set routing-instances vrA interface ge-0/0/1",
+				},
+				vrfScopeDeny("zoneB", "denyB")),
+			wantScoped: []string{"ge-0-0-1.50"},
+			wantRules:  true,
+			wantWarn:   1,
+		},
+	}
+
+	for _, row := range rows {
+		t.Run(row.name, func(t *testing.T) {
+			zone, policyName := row.zone, row.policyName
+			cfg := residualCfg(t, row.cmds)
+
+			if got := config.JunosHostZoneIngressNetdevs(cfg)[zone]; !slices.Equal(got, row.wantScoped) {
+				t.Errorf("scope for %s = %v, want %v — the iifname set is the mechanism; a rule naming a netdev LOCAL_IN never reports enforces nothing",
+					zone, got, row.wantScoped)
+			}
+			prog, ok := vrfScopeProgram(t, cfg, zone)
+			rules := 0
+			if ok {
+				rules = len(prog.RulesV4) + len(prog.RulesV6)
+			}
+			if row.wantRules && rules == 0 {
+				t.Errorf("no kernel DROP rule emitted for %s; a partially-resolved zone must keep the protection that DOES work", zone)
+			}
+			if !row.wantRules && rules != 0 {
+				t.Errorf("%d kernel DROP rule(s) emitted for %s with nothing scopable", rules, zone)
+			}
+			if ok && !slices.Equal(prog.IngressIfnames, row.wantScoped) {
+				t.Errorf("program iifnames = %v, want %v", prog.IngressIfnames, row.wantScoped)
+			}
+			if got := residualWarnings(cfg, policyName); len(got) != row.wantWarn {
+				t.Errorf("#4168 warnings naming %q = %d, want %d — a deny that is not enforced on every ingress path of its zone must say so, and one that IS must stay quiet; got %v",
+					policyName, len(got), row.wantWarn, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The kernel fact, measured before anything was built

#6619's acceptance criterion 1 is "establish firsthand what `state->in` is at LOCAL_IN for a packet arriving on a VRF-enslaved interface, on the kernel floor this project targets." Done, in a private user+network namespace against real nf_tables over netlink (no `nft` binary), on an **inet base chain at hook `input`, priority 10** — the exact hook and priority `xpf_hostinbound` installs:

```
PROBE-RESULT kernel=7.0.13+deb14-amd64  c_slave(veth1)=0  c_master(vrf-t)=3  c_any=3
```

`meta iifname` at LOCAL_IN is the **VRF master**, never the enslaved netdev. The unconditional counter is what closes the argument: three hits for three packets means the hook runs **exactly once**, so `c_slave=0` is "it does not happen", not "a second pass was missed". Reading the code could not have settled that — a reader can always suppose a second pass.

Live in this codebase: `pkg/daemon/daemon_apply_interfaces.go:232` enslaves every `cfg.RoutingInstances[].Interfaces` member (any `instance-type` except `forwarding`) via `LinkSetMaster`, while `config.JunosHostZoneIngressNetdevs` computed the scope from interface names with **no VRF dimension**. Such a zone emitted a representable program whose rules matched nothing and — being representable — **suppressed its own #4168 warning**. Config commits clean, rules present in the ruleset, nothing enforced.

## Not #4455 Component A restated

Worth stating in the body because the next reader will make the same guess. #4455-A proposed to **ADD** a first-ever `iifname` predicate for *multicast admission*, and was PLAN-KILLed on reachability plus exactly three attribution fragilities — RETH→physical-member resolution, guess-on-malformed input, an address-lazy interface source. **l3mdev/VRF is in none of them.** #6619 is about a gate that already shipped (#4932/#4146) on a different feature, against a kernel fact that kill never reached. Different feature, different mechanism, so the kill does not transfer.

## The option deliberately rejected

**Scoping on the VRF master name instead.** It looks obviously correct and is not: the rule would match **every** interface in the VRF, including unzoned ones and any lifeline bound to the same VRF — management stranding of exactly the #7284 shape, where lifeline exclusion is by INTERFACE and not by address value. Making it safe needs full VRF-membership attribution including tunnel interfaces bound through `pkg/routing/tunnel.go`'s `tc.RoutingInstance`, which is the fragile-attribution territory Component A died in. The doc records this so it is not "simplified" back in later.

## #6564 member 8, in the same change

The two are one change: dropping enslaved netdevs **enlarges** the population of zones whose scope resolves only partially, which is precisely where `enforceable := len(netdevs) > 0` gives the wrong answer. Fixing #6619 alone would have grown the set of configs hitting member 8.

The same measurement caught it live. In a shared-trunk config the neighbouring zone had resolved **some** of its candidates, emitted a rule scoped to the survivors, and **suppressed its warning** — reporting as fully enforced.

**The boolean is split, not tightened.** The suggested shape — make a partially-resolved zone non-enforceable — was rejected after enumerating its cost: it withdraws a kernel deny that works. Instead:

- `emitsRules` (any candidate resolved) gates **emission** — unchanged.
- `fullyScoped` (no **OWN** candidate unresolved) gates **suppression** — new.

So a partially-resolved zone keeps every rule it had *and* gets its warning. A zone with **no candidates at all** (lifeline-only, or no interfaces) stays a distinct third state: nothing to enforce, so it must not block suppression. That distinction is exactly `len(Unscopable) > 0` — the zone had candidates and could not use them all.

**No packet changes verdict.** Dropping an enslaved netdev removes only rules that provably never matched; partially-resolved zones keep every rule. The entire behaviour change is commit-time warnings that were previously suppressed. That is the narrowing enumeration asked for: there is none.

## A correction the first cut needed

The first version counted **any** dropped candidate as a coverage gap. The shipped `TestJunosHostCrossZoneAmbiguousTrunkKeepsWarning` went red — and the test was **right**. A VLAN subunit contributes its physical parent as an extra candidate for the bondless-RETH case; on a plain 802.1Q trunk that parent is never where its frames arrive, so losing it costs the zone nothing. Counting it would have warned on every trunk carrying an untagged unit-0 in one zone and tagged subunits in others — an ordinary correct config, and an advisory that fires on those stops being read. Only an **OWN** netdev counts now.

## Validation

`pkg/config`, `pkg/dataplane/userspace`, `pkg/daemon`, `pkg/nftables` green with `-count=1`; `gofmt` and `go vet` clean. 9 `=== RUN` on the new lock.

The lock walks all three resolution states — **including the partial one**, which is where the bug lives and which a table of only all-resolved and none-resolved rows would pass straight over. Each row asserts the resolved scope, whether a rule was emitted, **and** the warning count in one cell, so the projection and the advisory cannot drift apart the way they already had. It also carries a fully-scoped control (without it, a projection that resolved nothing and warned about everything satisfies every other row) and the over-warning guard.

Three one-line mutations, each `go vet` clean **at the mutated state**, each restored with the tree clean and rc back to 0, each localising:

| Mutation (`pkg/config/junos_host_deny.go`) | Red |
|---|---|
| `junosHostVRFEnslavedNetdevs`: `out[nd] = true` → `false` (no netdev is enslaved) | exactly the **four VRF rows**; control, `forwarding`, ambiguity and parent-superset rows all stay green |
| `fullyScoped := len(cov.Unscopable) == 0` → `>= 0` (existence semantics restored) | exactly the **three partial-coverage rows** |
| `addCand(zone, parent, false)` → `true` (parent counted as own) | exactly the **over-warning guard row**, and independently the shipped `TestJunosHostCrossZoneAmbiguousTrunkKeepsWarning` |

Production call path: `pkg/daemon` → `dpuserspace.BuildJunosHostPrograms` → `config.BuildJunosHostDenyProjection` → `junosHostZoneNetdevCoverageMap`, and `config.ValidateConfig` → `validateJunosHostDirectDeliveryWarnings` → the same projection for `RenderedPolicyKeys`.

**Reaches the Rust helper binary: no** — no `.o` movement, no protocol change, so no smoke is owed.

Closes #6619

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cz2czGK3aA5MsMhkNkjHXX
