### PR TITLE
config,ra: bound the PD prefix lengths and floor a delegated /0 (#6587)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,37 @@
+## 2026-08-22 — #6587 prefix-length validators + provenance-aware RA floor
+
+- **Timestamp**: 2026-08-22
+- **Action**: Part A: typed `ValidateInteger(0, 128)` on
+  `preferred-prefix-length` and `sub-prefix-length` (both were untyped
+  placeholders behind an Atoi whose error is discarded). CORRECTION to
+  the issue: the impact is NOT symmetric — `sub-prefix-length` is
+  incidentally fail-closed, but `preferred-prefix-length > 128` makes
+  `net.CIDRMask` return nil and the IA_PD hint EGRESSES with wire
+  prefix-length 0.
+  Part B: added `config.RAPrefix.Delegated`, set only by
+  `buildRAConfigs` on the PD path, and a `buildRA` floor refusing
+  `Delegated && Bits()==0`. That supplies the PROVENANCE #6531 said was
+  missing, so an operator-authored `::/0` is untouched. Also added the
+  field to `pkg/ra`'s `configEqual` — it gates whether the PIO is emitted
+  at all, so it is wire-affecting (#4307's lesson).
+  Regenerated `golden_4406.json`: the diff is exclusively
+  `"Delegated": false` additions, verified before regenerating.
+  Repurposed `TestBuildRA_6531_ZeroPrefixWouldBeAdvertised` — its stated
+  premise ("indistinguishable from operator-authored") is no longer true,
+  so it is renamed to `TestBuildRA_6587_ConfiguredZeroPrefixStillAdvertised`
+  and now serves as the over-reach guard.
+  Mutation matrix 8/8 RED after fixing two cells: B4 (daemon stops
+  stamping) was GREEN — the WIRING was unbound, since every pkg/ra test
+  sets the flag itself; B5 was a BAD CELL that neutered PreferredLife
+  instead of Delegated.
+- **File(s)**: pkg/config/schema_interfaces.go, pkg/config/types_routing.go,
+  pkg/config/testdata/golden_4406.json, pkg/daemon/daemon_ra.go,
+  pkg/ra/sender.go, pkg/ra/ra.go,
+  pkg/config/dhcpv6_prefixlen_schema_6587_test.go,
+  pkg/ra/sender_delegated_prefixlen_6587_test.go,
+  pkg/ra/sender_prefixlen_6531_test.go,
+  pkg/daemon/ra_pd_prefixlen_6531_test.go, pkg/dhcp/README.md
+
 ## 2026-08-21 — #6635 ddns: the error-tree bound follows a caller-supplied `As`
 
 - **Timestamp**: 2026-08-21

--- a/pkg/config/dhcpv6_prefixlen_schema_6587_test.go
+++ b/pkg/config/dhcpv6_prefixlen_schema_6587_test.go
@@ -1,0 +1,96 @@
+// #6587 part A: `preferred-prefix-length` and `sub-prefix-length` were BOTH
+// untyped `<length>` placeholders parsed with an unbounded strconv.Atoi whose
+// error is DISCARDED (`, _ =`), so `abc` and `999` alike silently became a
+// value the operator never typed.
+//
+// The issue frames the impact as "fail-closed, not fail-open". That holds for
+// sub-prefix-length only: netip.PrefixFrom(addr, >128) yields an invalid
+// Prefix which daemon_ra.go's IsValid() check rejects — the delegation is
+// silently absent, with no commit-time error.
+//
+// preferred-prefix-length is NOT even that. net.CIDRMask(999, 128) returns
+// nil, and dhcpv6.OptIAPrefix.ToBytes then writes `length, _ := Mask.Size()`
+// = 0 — so the IA_PD hint EGRESSES to the upstream DHCPv6 server with wire
+// prefix-length 0. No panic, no local error, a malformed request on the wire.
+//
+// Either way the guard was incidental: it depended on a downstream validity
+// check noticing, not on the value being rejected where the operator typed it.
+//
+// FAIL-ON-REVERT: drop `valueType`/`validator` from either schema entry in
+// schema_interfaces.go and that leaf's reject cases stop erroring.
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDHCPv6PrefixDelegatingLengthsAreRangeChecked6587(t *testing.T) {
+	const base = "set interfaces ge-0/0/0 unit 0 family inet6 dhcpv6-client prefix-delegating "
+
+	for _, leaf := range []string{"preferred-prefix-length", "sub-prefix-length"} {
+		t.Run(leaf, func(t *testing.T) {
+			// Rejected: above the IPv6 prefix-length domain, negative, and
+			// non-numeric. The Atoi that discarded its error accepted all
+			// three by silently producing 0 or a nonsense length.
+			for _, bad := range []string{"129", "999", "-1", "abc", "64x"} {
+				tree := flatTreeFromSets(t, base+leaf+" "+bad)
+				err := SchemaValidate(tree, nil)
+				if err == nil {
+					t.Errorf("%s %q was ACCEPTED at commit-check; the operator gets no "+
+						"error and the value is silently discarded or egressed malformed "+
+						"(#6587)", leaf, bad)
+					continue
+				}
+				// The operator has to be able to act on the message.
+				if !strings.Contains(err.Error(), bad) {
+					t.Errorf("%s %q: error does not name the offending value: %v", leaf, bad, err)
+				}
+				if !strings.Contains(err.Error(), leaf) {
+					t.Errorf("%s %q: error does not name the leaf: %v", leaf, bad, err)
+				}
+			}
+
+			// Accepted: the whole domain including BOTH boundaries. 0 is the
+			// documented "not set" sentinel both fields already use, so a
+			// validator that rejected it would break every config that omits
+			// the value's effect by setting it explicitly.
+			for _, ok := range []string{"0", "1", "48", "56", "64", "127", "128"} {
+				tree := flatTreeFromSets(t, base+leaf+" "+ok)
+				if err := SchemaValidate(tree, nil); err != nil {
+					t.Errorf("%s %q is in range and must commit clean, got: %v", leaf, ok, err)
+				}
+			}
+		})
+	}
+}
+
+// TestDHCPv6PrefixDelegatingLengthsStillCompile6587 is the over-reach control:
+// the typed schema must not have changed what a VALID config compiles to.
+func TestDHCPv6PrefixDelegatingLengthsStillCompile6587(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set interfaces ge-0/0/0 unit 0 family inet6 dhcpv6-client prefix-delegating preferred-prefix-length 56",
+		"set interfaces ge-0/0/0 unit 0 family inet6 dhcpv6-client prefix-delegating sub-prefix-length 64",
+	)
+	if err := SchemaValidate(tree, nil); err != nil {
+		t.Fatalf("a valid prefix-delegating stanza must pass schema validation: %v", err)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	iface := cfg.Interfaces.Interfaces["ge-0/0/0"]
+	if iface == nil || len(iface.Units) == 0 {
+		t.Fatalf("interface/unit not compiled: %+v", cfg.Interfaces.Interfaces)
+	}
+	dc := iface.Units[0].DHCPv6Client
+	if dc == nil {
+		t.Fatal("DHCPv6Client not compiled")
+	}
+	if dc.PrefixDelegatingPrefixLen != 56 {
+		t.Errorf("PrefixDelegatingPrefixLen = %d, want 56", dc.PrefixDelegatingPrefixLen)
+	}
+	if dc.PrefixDelegatingSubPrefLen != 64 {
+		t.Errorf("PrefixDelegatingSubPrefLen = %d, want 64", dc.PrefixDelegatingSubPrefLen)
+	}
+}

--- a/pkg/config/schema_interfaces.go
+++ b/pkg/config/schema_interfaces.go
@@ -246,8 +246,43 @@ var schemaInterfaces = &schemaNode{desc: "Interface configuration", wildcard: &s
 					"client-type":    {desc: "Client type", args: 1, placeholder: "<type>", children: nil},
 					"client-ia-type": {desc: "Client IA type", args: 1, placeholder: "<type>", children: nil},
 					"prefix-delegating": {desc: "Prefix delegation", children: map[string]*schemaNode{
-						"preferred-prefix-length": {desc: "Preferred prefix length", args: 1, placeholder: "<length>", children: nil},
-						"sub-prefix-length":       {desc: "Sub-prefix length", args: 1, placeholder: "<length>", children: nil},
+						// #6587: both leaves were untyped `<length>` placeholders
+						// parsed with an unbounded strconv.Atoi whose error is
+						// DISCARDED, so `abc` and `999` both silently became a
+						// value the operator never typed.
+						//
+						// sub-prefix-length was incidentally fail-closed —
+						// netip.PrefixFrom(addr, >128) yields an invalid Prefix
+						// that daemon_ra.go's IsValid() check rejects — but the
+						// operator got no commit error, just a silently absent
+						// delegation. preferred-prefix-length is NOT even that:
+						// net.CIDRMask(999, 128) returns nil, and the IA_PD hint
+						// then EGRESSES to the upstream server with wire
+						// prefix-length 0.
+						//
+						// 0..128 is the IPv6 prefix-length domain; 0 is retained
+						// as the documented "not set" sentinel both fields
+						// already use.
+						"preferred-prefix-length": {
+							desc:          "Preferred prefix length",
+							args:          1,
+							placeholder:   "<0..128>",
+							valueType:     ValueInteger,
+							valueDesc:     "Requested IA_PD prefix length (0..128; 0 = not set, send no length hint)",
+							valueExamples: []string{"48", "56", "60"},
+							validator:     ValidateInteger(0, 128),
+							children:      nil,
+						},
+						"sub-prefix-length": {
+							desc:          "Sub-prefix length",
+							args:          1,
+							placeholder:   "<0..128>",
+							valueType:     ValueInteger,
+							valueDesc:     "Length of the sub-prefix derived from the delegation for RA (0..128; 0 = advertise the delegated prefix as-is)",
+							valueExamples: []string{"64"},
+							validator:     ValidateInteger(0, 128),
+							children:      nil,
+						},
 					}},
 					"client-identifier": {desc: "Client identifier", children: map[string]*schemaNode{
 						"duid-type": {desc: "DUID type", args: 1, placeholder: "<type>", children: nil},

--- a/pkg/config/testdata/golden_4406.json
+++ b/pkg/config/testdata/golden_4406.json
@@ -910,7 +910,8 @@
                 "OnLink": true,
                 "Autonomous": true,
                 "ValidLifetime": 0,
-                "PreferredLife": 0
+                "PreferredLife": 0,
+                "Delegated": false
               }
             ],
             "DNSServers": [
@@ -2171,7 +2172,8 @@
                 "OnLink": true,
                 "Autonomous": true,
                 "ValidLifetime": 0,
-                "PreferredLife": 0
+                "PreferredLife": 0,
+                "Delegated": false
               }
             ],
             "DNSServers": [
@@ -3431,7 +3433,8 @@
                 "OnLink": true,
                 "Autonomous": true,
                 "ValidLifetime": 0,
-                "PreferredLife": 0
+                "PreferredLife": 0,
+                "Delegated": false
               }
             ],
             "DNSServers": [
@@ -4691,7 +4694,8 @@
                 "OnLink": true,
                 "Autonomous": true,
                 "ValidLifetime": 0,
-                "PreferredLife": 0
+                "PreferredLife": 0,
+                "Delegated": false
               }
             ],
             "DNSServers": [
@@ -5952,7 +5956,8 @@
                 "OnLink": true,
                 "Autonomous": true,
                 "ValidLifetime": 0,
-                "PreferredLife": 0
+                "PreferredLife": 0,
+                "Delegated": false
               }
             ],
             "DNSServers": [
@@ -7212,7 +7217,8 @@
                 "OnLink": true,
                 "Autonomous": true,
                 "ValidLifetime": 0,
-                "PreferredLife": 0
+                "PreferredLife": 0,
+                "Delegated": false
               }
             ],
             "DNSServers": [
@@ -8289,7 +8295,8 @@
                 "OnLink": true,
                 "Autonomous": true,
                 "ValidLifetime": 0,
-                "PreferredLife": 0
+                "PreferredLife": 0,
+                "Delegated": false
               }
             ],
             "DNSServers": [
@@ -9261,7 +9268,8 @@
                 "OnLink": true,
                 "Autonomous": true,
                 "ValidLifetime": 0,
-                "PreferredLife": 0
+                "PreferredLife": 0,
+                "Delegated": false
               }
             ],
             "DNSServers": [
@@ -10232,7 +10240,8 @@
                 "OnLink": true,
                 "Autonomous": true,
                 "ValidLifetime": 0,
-                "PreferredLife": 0
+                "PreferredLife": 0,
+                "Delegated": false
               }
             ],
             "DNSServers": [
@@ -11203,7 +11212,8 @@
                 "OnLink": true,
                 "Autonomous": true,
                 "ValidLifetime": 0,
-                "PreferredLife": 0
+                "PreferredLife": 0,
+                "Delegated": false
               }
             ],
             "DNSServers": [
@@ -12175,7 +12185,8 @@
                 "OnLink": true,
                 "Autonomous": true,
                 "ValidLifetime": 0,
-                "PreferredLife": 0
+                "PreferredLife": 0,
+                "Delegated": false
               }
             ],
             "DNSServers": [
@@ -13146,7 +13157,8 @@
                 "OnLink": true,
                 "Autonomous": true,
                 "ValidLifetime": 0,
-                "PreferredLife": 0
+                "PreferredLife": 0,
+                "Delegated": false
               }
             ],
             "DNSServers": [

--- a/pkg/config/types_routing.go
+++ b/pkg/config/types_routing.go
@@ -405,6 +405,20 @@ type RAPrefix struct {
 	Autonomous    bool   // SLAAC autonomous flag (default true)
 	ValidLifetime int    // seconds, 0 = default (2592000 = 30 days)
 	PreferredLife int    // seconds, 0 = default (604800 = 7 days)
+	// Delegated marks a prefix DERIVED from a DHCPv6 IA_PD delegation rather
+	// than authored by the operator (#6587).
+	//
+	// It exists because pkg/ra cannot otherwise tell the two apart, and the
+	// right answer differs: a delegated /0 is upstream garbage and must never
+	// be advertised on-link + autonomous to the LAN, while an operator-authored
+	// `::/0` is a legitimate configuration a blanket floor would silently
+	// break. #6581 fixed the same class at the DHCPv6 DECODER for exactly this
+	// reason — by the time a prefix reaches pkg/ra the provenance was gone.
+	//
+	// Set ONLY by buildRAConfigs (pkg/daemon) on the PD path. The compiler
+	// leaves it at the zero value, so operator-authored prefixes stay false by
+	// construction and no compiler change is needed.
+	Delegated bool
 }
 
 // OSPFConfig holds OSPF routing configuration.

--- a/pkg/daemon/daemon_ra.go
+++ b/pkg/daemon/daemon_ra.go
@@ -39,6 +39,9 @@ func (d *Daemon) buildRAConfigs(cfg *config.Config) []*config.RAInterfaceConfig 
 				Prefix:     subPrefix.String(),
 				OnLink:     true,
 				Autonomous: true,
+				// #6587: mark the provenance so pkg/ra can apply a floor to a
+				// DELEGATED prefix without breaking an operator-authored ::/0.
+				Delegated: true,
 			}
 			if mapping.ValidLifetime > 0 {
 				pfx.ValidLifetime = int(mapping.ValidLifetime.Seconds())

--- a/pkg/daemon/ra_pd_prefixlen_6531_test.go
+++ b/pkg/daemon/ra_pd_prefixlen_6531_test.go
@@ -12,7 +12,9 @@ package daemon
 // Both are documentation of the consumer seam and the blast radius, NOT
 // RED-on-revert guards: they are GREEN before and after the pkg/dhcp fix (the
 // first is an over-reach guard; the second pins current unguarded behavior,
-// exactly like pkg/ra's TestBuildRA_6531_ZeroPrefixWouldBeAdvertised). The
+// exactly like pkg/ra's TestBuildRA_6587_ConfiguredZeroPrefixStillAdvertised,
+// renamed from TestBuildRA_6531_ZeroPrefixWouldBeAdvertised when #6587 gave
+// pkg/ra a provenance-scoped floor). The
 // RED-on-revert coverage for the guard itself lives in
 // pkg/dhcp/dhcpv6_iapd_prefixlen_6531_test.go.
 
@@ -102,5 +104,68 @@ func TestBuildRAConfigs_6531_ZeroPrefixSurvivesTheIsValidGuard(t *testing.T) {
 	if !got.OnLink || !got.Autonomous {
 		t.Errorf("OnLink = %v, Autonomous = %v, want both true "+
 			"(this is what makes a /0 a LAN-wide hijack)", got.OnLink, got.Autonomous)
+	}
+}
+
+// TestBuildRAConfigs_6587_StampsDelegatedProvenance binds the WIRING for the
+// #6587 floor.
+//
+// pkg/ra's tests construct config.RAPrefix values directly, so they prove the
+// floor WORKS and say nothing about whether anything sets the flag it keys on.
+// Deleting `Delegated: true` from buildRAConfigs leaves every one of them green
+// while the floor silently stops firing — a delegated /0 reaches the LAN again
+// and the only thing that changed is one struct field nobody asserts.
+//
+// It also asserts the operator-authored side stays FALSE from the same run, so
+// the flag cannot be satisfied by stamping every prefix true.
+func TestBuildRAConfigs_6587_StampsDelegatedProvenance(t *testing.T) {
+	mgr := dhcp.NewManagerForTesting(nil)
+	mgr.SeedDelegatedPrefixesForRATesting("ge-0/0/3", "trust0", []dhcp.DelegatedPrefix{{
+		Interface:         "ge-0/0/3",
+		Prefix:            netip.MustParsePrefix("2001:db8:900d::/64"),
+		PreferredLifetime: 3600 * time.Second,
+		ValidLifetime:     7200 * time.Second,
+	}})
+
+	// An operator-authored prefix on a DIFFERENT interface, present in the
+	// same buildRAConfigs run.
+	cfg := &config.Config{}
+	cfg.Protocols.RouterAdvertisement = []*config.RAInterfaceConfig{{
+		Interface: "dmz0",
+		Prefixes:  []*config.RAPrefix{{Prefix: "2001:db8:dmz::/64", OnLink: true, Autonomous: true}},
+	}}
+
+	d := &Daemon{dhcp: mgr}
+	ras := d.buildRAConfigs(cfg)
+
+	var sawPD, sawConfigured bool
+	for _, ra := range ras {
+		for _, p := range ra.Prefixes {
+			switch ra.Interface {
+			case "trust0":
+				sawPD = true
+				if !p.Delegated {
+					t.Errorf("PD-derived prefix %s on %s has Delegated=false. The #6587 "+
+						"floor keys on this flag, so it never fires and a delegated /0 "+
+						"reaches the LAN — while every pkg/ra test stays green, because "+
+						"they set the flag themselves", p.Prefix, ra.Interface)
+				}
+			case "dmz0":
+				sawConfigured = true
+				if p.Delegated {
+					t.Errorf("operator-authored prefix %s on %s has Delegated=true. The "+
+						"floor would then refuse a legitimate `::/0` — the exact "+
+						"over-reach the provenance exists to prevent", p.Prefix, ra.Interface)
+				}
+			}
+		}
+	}
+	if !sawPD {
+		t.Fatal("no PD-derived prefix in the output — the fixture does not exercise the " +
+			"stamping path, so this test proves nothing")
+	}
+	if !sawConfigured {
+		t.Fatal("no operator-authored prefix in the output — the false-side control is " +
+			"vacuous")
 	}
 }

--- a/pkg/dhcp/README.md
+++ b/pkg/dhcp/README.md
@@ -323,6 +323,35 @@ External only: `github.com/insomniacslk/dhcp`, `github.com/vishvananda/netlink`.
   `/0`); `pkg/ra/sender_prefixlen_6531_test.go` covers `config.RAPrefix` →
   `buildRA` → `ndp.MarshalMessage` and asserts on the RE-PARSED wire bytes,
   pinning the blast radius from the consumer side.
+
+  **#6587 added the defense-in-depth layer #6531 deliberately deferred, and
+  two commit-time range validators.** The decoder remains the primary
+  guard; what changed is that `pkg/ra` can now apply a floor of its own
+  without breaking legitimate configuration. #6531's reasoning for NOT
+  filtering there was that at that point a delegated `/0` is
+  "indistinguishable from an operator-authored
+  `set interfaces <if> ipv6 router-advertisement prefix ::/0`" — so #6587
+  supplied the missing PROVENANCE rather than a blanket floor.
+  `config.RAPrefix.Delegated` is set only by `buildRAConfigs` on the PD
+  path; the compiler leaves it false, so operator-authored prefixes are
+  false BY CONSTRUCTION and no compiler change was needed. `buildRA` then
+  refuses exactly `Delegated && Bits() == 0`. Because that flag decides
+  whether the PIO is emitted at all it is wire-affecting, so it is also
+  compared in `pkg/ra`'s `configEqual` change detector — the #4307 comment
+  there records what omitting a wire-affecting field from that list cost
+  last time.
+
+  Separately, `preferred-prefix-length` and `sub-prefix-length` are now
+  typed `ValidateInteger(0, 128)` leaves. Both were untyped placeholders
+  parsed with an unbounded `strconv.Atoi` whose error is DISCARDED. The
+  impact was NOT symmetric, contrary to the "fail-closed" framing:
+  `sub-prefix-length` was incidentally fail-closed (an invalid
+  `netip.Prefix` is caught by `daemon_ra.go`'s `IsValid()`), but
+  `preferred-prefix-length` was not — `net.CIDRMask(999, 128)` returns
+  nil and `OptIAPrefix.ToBytes` then writes length 0, so the IA_PD hint
+  EGRESSES malformed to the upstream server. Either way the guard was
+  incidental: it depended on a downstream check noticing rather than on
+  the value being rejected where the operator typed it.
 - **RFC 3442 classless static routes (option 121 / legacy 249, #4118).**
   `leaseFromACKv4` parses option 121 (the standard `ClasslessStaticRoute`
   accessor) and falls back to the legacy Microsoft option 249 (raw

--- a/pkg/ra/ra.go
+++ b/pkg/ra/ra.go
@@ -1078,7 +1078,13 @@ func configEqual(a, b *config.RAInterfaceConfig) bool {
 			a.Prefixes[i].OnLink != b.Prefixes[i].OnLink ||
 			a.Prefixes[i].Autonomous != b.Prefixes[i].Autonomous ||
 			a.Prefixes[i].ValidLifetime != b.Prefixes[i].ValidLifetime ||
-			a.Prefixes[i].PreferredLife != b.Prefixes[i].PreferredLife {
+			a.Prefixes[i].PreferredLife != b.Prefixes[i].PreferredLife ||
+			// #6587: Delegated gates whether the PIO is emitted at all
+			// (buildRA drops a delegated /0), so it is WIRE-AFFECTING and
+			// belongs in this change detector. The #4307 comment above
+			// records what omitting a wire-affecting field from this list
+			// cost last time: a stale advertisement.
+			a.Prefixes[i].Delegated != b.Prefixes[i].Delegated {
 			return false
 		}
 	}

--- a/pkg/ra/sender.go
+++ b/pkg/ra/sender.go
@@ -882,6 +882,31 @@ func (s *sender) buildRA() *ndp.RouterAdvertisement {
 			prefLife = validLife
 		}
 
+		// #6587: refuse to advertise a DELEGATED /0.
+		//
+		// #6581 closed this at the DHCPv6 decoder, which is the right primary
+		// place — an IA_PD prefix-length of 0 or >128 is refused before it
+		// becomes a DelegatedPrefix. This is the defense-in-depth layer that
+		// PR deliberately did not add, and the reason it could not add it
+		// naively is recorded in its own test: at this point a delegated /0 is
+		// "indistinguishable from an operator-authored
+		// `set interfaces <if> ipv6 router-advertisement prefix ::/0`", which
+		// is legitimate configuration. RAPrefix.Delegated supplies the
+		// provenance that was missing, so the floor applies to exactly the
+		// population that can never be intentional.
+		//
+		// A /0 here would be advertised on-link AND autonomous to the LAN:
+		// every SLAAC host would treat the entire IPv6 address space as
+		// on-link and stop routing through this firewall.
+		//
+		// Only 0 is reachable: netip.ParsePrefix succeeded above, so Bits() is
+		// in [0,128] and the uint8 conversion below cannot wrap.
+		if pfx.Delegated && prefix.Bits() == 0 {
+			slog.Warn("ra: refusing to advertise a delegated /0 prefix",
+				"prefix", pfx.Prefix, "interface", s.cfg.Interface)
+			continue
+		}
+
 		ra.Options = append(ra.Options, &ndp.PrefixInformation{
 			PrefixLength:                   uint8(prefix.Bits()),
 			OnLink:                         pfx.OnLink,

--- a/pkg/ra/sender_delegated_prefixlen_6587_test.go
+++ b/pkg/ra/sender_delegated_prefixlen_6587_test.go
@@ -1,0 +1,137 @@
+// #6587 part B: pkg/ra had no prefix-length floor of its own, so a DELEGATED
+// /0 that survived the upstream checks was advertised on-link + autonomous to
+// the whole LAN.
+//
+// WHY THIS COULD NOT SIMPLY BE FILTERED, and why #6581 deliberately left it.
+// #6581 closed the same class at the DHCPv6 DECODER (an IA_PD prefix-length of
+// 0 or >128 is refused before it becomes a DelegatedPrefix), and its own test
+// file records the reason it stopped there: by the time a prefix reaches
+// pkg/ra it is "indistinguishable from an operator-authored
+// `set interfaces <if> ipv6 router-advertisement prefix ::/0`" — which is
+// legitimate configuration a naive floor would silently break.
+//
+// So the fix is not a floor, it is PROVENANCE. config.RAPrefix.Delegated is
+// set only by buildRAConfigs on the PD path; the compiler leaves it false, so
+// operator-authored prefixes are false by construction. buildRA then refuses
+// exactly the population that can never be intentional.
+//
+// FAIL-ON-REVERT: delete the `pfx.Delegated && prefix.Bits() == 0` guard from
+// buildRA and the delegated /0 reaches the wire again.
+package ra
+
+import (
+	"testing"
+
+	"github.com/mdlayher/ndp"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// prefixInfosFor returns every PrefixInformation on the wire for the given
+// prefixes, so a test can assert on ABSENCE as well as on content.
+func prefixInfosFor(t *testing.T, prefixes ...*config.RAPrefix) []*ndp.PrefixInformation {
+	t.Helper()
+	s := newTestSender3895(&config.RAInterfaceConfig{
+		Interface: "trust0",
+		Prefixes:  prefixes,
+	})
+	b, err := ndp.MarshalMessage(s.buildRA())
+	if err != nil {
+		t.Fatalf("marshal RA: %v", err)
+	}
+	msg, err := ndp.ParseMessage(b)
+	if err != nil {
+		t.Fatalf("parse RA: %v", err)
+	}
+	ra, ok := msg.(*ndp.RouterAdvertisement)
+	if !ok {
+		t.Fatalf("parsed message is %T, want *ndp.RouterAdvertisement", msg)
+	}
+	var out []*ndp.PrefixInformation
+	for _, o := range ra.Options {
+		if pi, ok := o.(*ndp.PrefixInformation); ok {
+			out = append(out, pi)
+		}
+	}
+	return out
+}
+
+func TestBuildRA_6587_DelegatedZeroPrefixIsRefused(t *testing.T) {
+	got := prefixInfosFor(t, &config.RAPrefix{
+		Prefix:     "::/0",
+		OnLink:     true,
+		Autonomous: true,
+		Delegated:  true,
+	})
+	if len(got) != 0 {
+		t.Fatalf("a DELEGATED /0 was advertised as PrefixLength %d (on-link=%v "+
+			"autonomous=%v). Every SLAAC host on the segment would treat the entire "+
+			"IPv6 address space as on-link and stop routing through this firewall "+
+			"(#6587).", got[0].PrefixLength, got[0].OnLink,
+			got[0].AutonomousAddressConfiguration)
+	}
+}
+
+// The discrimination is the whole point, so it is asserted directly rather
+// than left to two tests in different files. Same prefix, same flags, only the
+// provenance differs — and only one of them is refused.
+func TestBuildRA_6587_ProvenanceIsWhatDiscriminates(t *testing.T) {
+	configured := prefixInfosFor(t, &config.RAPrefix{
+		Prefix: "::/0", OnLink: true, Autonomous: true, Delegated: false,
+	})
+	delegated := prefixInfosFor(t, &config.RAPrefix{
+		Prefix: "::/0", OnLink: true, Autonomous: true, Delegated: true,
+	})
+	if len(configured) != 1 {
+		t.Fatalf("operator-authored ::/0 produced %d PrefixInformation options, want 1 — "+
+			"the floor over-reached onto legitimate configuration", len(configured))
+	}
+	if len(delegated) != 0 {
+		t.Fatalf("delegated ::/0 produced %d PrefixInformation options, want 0", len(delegated))
+	}
+}
+
+// A delegated prefix of a NORMAL length must still be advertised: the floor is
+// scoped to /0, not to delegated prefixes generally. Without this, a fix that
+// dropped every delegated prefix would pass the two tests above.
+func TestBuildRA_6587_DelegatedNormalPrefixStillAdvertised(t *testing.T) {
+	got := prefixInfosFor(t, &config.RAPrefix{
+		Prefix: "2001:db8:1000::/64", OnLink: true, Autonomous: true, Delegated: true,
+	})
+	if len(got) != 1 {
+		t.Fatalf("a delegated /64 produced %d PrefixInformation options, want 1 — "+
+			"the floor is filtering delegated prefixes as a class rather than /0", len(got))
+	}
+	if got[0].PrefixLength != 64 {
+		t.Errorf("PrefixLength = %d, want 64", got[0].PrefixLength)
+	}
+	if !got[0].OnLink || !got[0].AutonomousAddressConfiguration {
+		t.Errorf("OnLink = %v, Autonomous = %v, want both true",
+			got[0].OnLink, got[0].AutonomousAddressConfiguration)
+	}
+}
+
+// TestConfigEqual_6587_DelegatedChangeRestartsTheSender pins the change
+// detector. Delegated decides whether the PIO is emitted AT ALL, so it is
+// wire-affecting; the #4307 comment in ra.go records what omitting a
+// wire-affecting field from configEqual cost last time — a stale
+// advertisement that kept going out after the config changed.
+func TestConfigEqual_6587_DelegatedChangeRestartsTheSender(t *testing.T) {
+	mk := func(delegated bool) *config.RAInterfaceConfig {
+		return &config.RAInterfaceConfig{
+			Interface: "trust0",
+			Prefixes: []*config.RAPrefix{{
+				Prefix: "2001:db8::/64", OnLink: true, Autonomous: true, Delegated: delegated,
+			}},
+		}
+	}
+	if configEqual(mk(false), mk(true)) {
+		t.Fatal("configEqual reports two RA configs equal when only Delegated differs. " +
+			"That field gates whether the prefix is advertised at all, so the sender " +
+			"would keep running with the old decision (#6587)")
+	}
+	if !configEqual(mk(true), mk(true)) {
+		t.Error("configEqual reports two identical configs unequal — the sender would " +
+			"restart on every reconcile")
+	}
+}

--- a/pkg/ra/sender_prefixlen_6531_test.go
+++ b/pkg/ra/sender_prefixlen_6531_test.go
@@ -11,11 +11,19 @@ package ra
 //     autonomous. This is the OVER-REACH guard and must stay GREEN under a
 //     revert of the pkg/dhcp fix.
 //   - A /0 that reaches this far IS advertised as PrefixLength 0. This test
-//     pins the blast radius the pkg/dhcp guard prevents; it documents current
-//     behavior and is GREEN both before and after the fix. It is the reason
-//     the /0 must be refused at the DHCPv6 decoder rather than filtered here:
-//     by this point the prefix is indistinguishable from an operator-authored
-//     `set interfaces <if> ipv6 router-advertisement prefix ::/0`.
+//     pinned the blast radius the pkg/dhcp guard prevents; it documented
+//     current behavior and was GREEN both before and after the #6531 fix.
+//
+//     UPDATED BY #6587. Its stated reason — "by this point the prefix is
+//     indistinguishable from an operator-authored
+//     `set interfaces <if> ipv6 router-advertisement prefix ::/0`" — no
+//     longer holds: config.RAPrefix.Delegated now carries the provenance, and
+//     buildRA refuses a DELEGATED /0 while still emitting a configured one.
+//     So this case has changed meaning rather than becoming stale: it is now
+//     the OVER-REACH guard for the operator-authored ::/0 that the floor must
+//     not break (#6587 acceptance criterion 3), and it is named accordingly
+//     below. The delegated half is covered by
+//     TestBuildRA_6587_DelegatedZeroPrefixIsRefused.
 //
 // This file covers the LAST LEG of the PD → RA chain: config.RAPrefix →
 // buildRA → marshaled bytes. It starts from a statically constructed
@@ -86,15 +94,24 @@ func TestBuildRA_6531_NormalPrefixStillAdvertised(t *testing.T) {
 	}
 }
 
-// The blast radius #6531 prevents: nothing downstream of the DHCPv6 decoder
-// stops a /0 from being advertised on-link + autonomous to the whole LAN.
-func TestBuildRA_6531_ZeroPrefixWouldBeAdvertised(t *testing.T) {
+// An OPERATOR-AUTHORED ::/0 is still advertised (#6587 over-reach guard).
+//
+// This was TestBuildRA_6531_ZeroPrefixWouldBeAdvertised, which recorded that
+// nothing downstream of the DHCPv6 decoder stopped a /0 reaching the LAN. #6587
+// added a floor here — but scoped to DELEGATED prefixes, because
+// `set interfaces <if> ipv6 router-advertisement prefix ::/0` is legitimate
+// configuration and a blanket floor would silently break it. The case therefore
+// survives with its assertion intact and its MEANING inverted: it now proves
+// the floor did not over-reach.
+func TestBuildRA_6587_ConfiguredZeroPrefixStillAdvertised(t *testing.T) {
+	// prefixInfoFor builds a config.RAPrefix with Delegated unset, i.e. the
+	// operator-authored provenance. That is load-bearing, not incidental.
 	pi := prefixInfoFor(t, "::/0")
 
 	if pi.PrefixLength != 0 {
-		t.Fatalf("PrefixLength = %d, want 0 — pkg/ra gained a prefix-length "+
-			"filter; re-check whether the #6531 guard in pkg/dhcp is still the "+
-			"only thing keeping a delegated /0 off the wire", pi.PrefixLength)
+		t.Fatalf("PrefixLength = %d, want 0 — the #6587 delegated-/0 floor has "+
+			"over-reached and is now filtering an OPERATOR-AUTHORED ::/0, which is "+
+			"legitimate configuration", pi.PrefixLength)
 	}
 	if !pi.OnLink || !pi.AutonomousAddressConfiguration {
 		t.Errorf("OnLink = %v, Autonomous = %v, want both true "+


### PR DESCRIPTION
Closes #6587

## Part A — two config leaves took an unbounded prefix length

`preferred-prefix-length` and `sub-prefix-length` were both untyped `<length>` placeholders parsed with `strconv.Atoi` whose error is **discarded**, so `abc` and `999` alike silently became a value the operator never typed. Both are now typed `ValidateInteger(0, 128)` leaves, rejected where the operator typed them.

**A correction to the issue's impact claim.** It says "fail-closed, not fail-open". That holds for `sub-prefix-length` only: `netip.PrefixFrom(addr, >128)` yields an invalid `Prefix` that `daemon_ra.go`'s `IsValid()` rejects — silently absent delegation, no commit error.

**`preferred-prefix-length` is not even that.** `net.CIDRMask(999, 128)` returns **nil**, and `dhcpv6.OptIAPrefix.ToBytes` then writes `length, _ := Mask.Size()` = 0 — so the IA_PD hint **egresses to the upstream DHCPv6 server with wire prefix-length 0**. No panic, no local error, a malformed request on the wire. There is a live defect here, not only a hygiene gap.

`0` stays in range: both fields document it as the "not set" sentinel, so a validator rejecting it would break every config that sets it explicitly. Cell A3 pins that.

## Part B — the floor #6531 deliberately deferred

#6531 closed this class at the DHCPv6 **decoder** and stopped there. Its own test file records why: by the time a prefix reaches `pkg/ra`, a delegated `/0` is *"indistinguishable from an operator-authored `set interfaces <if> ipv6 router-advertisement prefix ::/0`"* — legitimate configuration a naive floor would silently break.

**So the fix is not a floor, it is provenance.** `config.RAPrefix` gains `Delegated`, set **only** by `buildRAConfigs` on the PD path; the compiler leaves it at the zero value, so operator-authored prefixes are false **by construction** and no compiler change is needed. `buildRA` then refuses exactly `Delegated && Bits() == 0`.

A delegated `/0` would otherwise be advertised **on-link and autonomous**, so every SLAAC host on the segment treats the entire IPv6 address space as on-link and stops routing through this firewall.

`Delegated` is also compared in `pkg/ra`'s `configEqual`: it gates whether the PIO is emitted at all, so it is wire-affecting — and the #4307 comment directly above that comparison records what omitting a wire-affecting field from the change detector cost last time (a stale advertisement).

## Collateral — checked, not assumed

- **`golden_4406.json`** changes because the compiled `*config.Config` is serialized to JSON and `RAPrefix` has no json tags. The diff was inspected **before** regenerating and is exclusively `"Delegated": false` additions — every prefix in the golden is operator-authored, so `false` is correct.
- **`raDesiredHash`** marshals the same struct, so the first reconcile after upgrade sees one hash mismatch and performs one redundant RA re-apply. Benign, and stated here rather than discovered later.

## A repurposed test, not a deleted one

`TestBuildRA_6531_ZeroPrefixWouldBeAdvertised` built its `RAPrefix` with `Delegated` unset — i.e. the operator-authored provenance. Its assertion is unchanged and its **meaning is inverted**: it is now the over-reach guard proving the floor did not break a configured `::/0`, which is the issue's third acceptance criterion. Renamed to say so, and its now-false failure message (*"pkg/ra gained a prefix-length filter; re-check whether the #6531 guard is still the only thing…"*) is corrected, because `pkg/ra` now **has** one.

## Validation

`go build ./...` + `go vet` clean per cell. `go test -count=1 ./pkg/config ./pkg/ra ./pkg/daemon ./pkg/dhcp` green.

### Mutation matrix

| cell | mutation | result |
|---|---|---|
| A1 | `preferred-prefix-length` back to untyped | range test RED |
| A2 | `sub-prefix-length` back to untyped | range test RED |
| A3 | range excludes 0 | RED on the documented sentinel |
| B1 | remove the floor (the shipped state) | delegated-`/0` tests RED |
| B2 | floor ignores provenance | operator-authored over-reach control RED |
| B3 | floor drops **all** delegated prefixes | normal-`/64` control RED |
| B4 | daemon stops stamping `Delegated` | **wiring test RED** |
| B5 | `configEqual` loses the comparison | detector test RED |

**B4 was green on its first run and is the cell that mattered.** Every `pkg/ra` test constructs `config.RAPrefix` itself, so they prove the floor *works* and say nothing about whether anything sets the flag it keys on — deleting `Delegated: true` from `buildRAConfigs` left all of them green while the floor silently stopped firing. It now has a test driving the real `buildRAConfigs`, asserting the PD prefix is stamped **true** *and* an operator-authored prefix in the same run stays **false**, so the flag cannot be satisfied by stamping everything.

**B5 was also green, but as a bad cell rather than a gap**: the mutation neutered the `PreferredLife` comparison instead of the `Delegated` one, so it measured nothing. Re-cut against the term under test.

## Docs

`pkg/dhcp/README.md` extends the #6531 section with the defense-in-depth layer, the provenance mechanism and why a blanket floor was wrong, plus the asymmetric Part A impact. `_Log.md` entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAsT5gCGP7k2vhdZ1sDuRi