### PR TITLE
userspace-dp: surface shared-session poison recoveries as a metric (#6641)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -102303,3 +102303,16 @@ prose edit above them added. No diff falls in the new test body.
   re-refuses every boot and an HA node holds SECONDARY indefinitely.
 - **File(s)**: pkg/upgrade/flip.go, pkg/upgrade/kernel.go,
   pkg/upgrade/kernel_arm_restamp_6639_test.go (new), _Log.md
+
+- **Timestamp**: 2026-08-22
+  - **Action**: #6641 — surfaced SHARED_SESSION_POISON_RECOVERIES (#2402) as
+    xpf_userspace_shared_session_poison_recoveries_total, mirroring #1807 end to
+    end. Added a gate binding EVERY Coordinator *_total() accessor to its
+    ProcessStatus assignment — the #1807 precedent's own populate line was
+    unbound too.
+  - **File(s)**: userspace-dp/src/{afxdp/coordinator/status.rs,protocol/control.rs,
+    protocol/tests.rs,server/helpers/status.rs,server/lifecycle.rs},
+    userspace-dp/tests/fixtures/protocol_wire_v1.json,
+    pkg/dataplane/userspace/{protocol_status.go,protocol_test.go},
+    pkg/api/{metrics.go,metrics_userspace.go,metrics_descriptors_userspace_session.go,
+    metrics_descriptor_coverage_test.go,metrics_test.go}

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -422,6 +422,7 @@ type xpfCollector struct {
 	// helper worker panic poisoned a command queue and it was recovered
 	// (committed-prefix + clear_poison policy) instead of going deaf.
 	userspaceWorkerCommandQueuePoisonRecoveries *prometheus.Desc
+	userspaceSharedSessionPoisonRecoveries      *prometheus.Desc
 	// #2315: GRE-decap RFC 6040 §4.2 illegal-combination drops (outer CE
 	// over a Not-ECT inner) — nonzero flags a misbehaving tunnel ingress
 	// that ECT-marked the outer for un-ECN inner traffic on a congested
@@ -839,6 +840,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.userspaceSyncedImportCapDrops
 	ch <- c.userspaceNatReverseKeySharedDisplacements
 	ch <- c.userspaceWorkerCommandQueuePoisonRecoveries
+	ch <- c.userspaceSharedSessionPoisonRecoveries
 	ch <- c.userspaceGreDecapEcnIllegalDrops
 	ch <- c.userspaceWgDecapEcnIllegalDrops
 	ch <- c.userspaceGreEncapDfOversizeDrops

--- a/pkg/api/metrics_descriptor_coverage_test.go
+++ b/pkg/api/metrics_descriptor_coverage_test.go
@@ -560,6 +560,7 @@ func TestCollectorDescriptorCoverage(t *testing.T) {
 		"xpf_userspace_dnat_publish_errors_total",                          // #2244 dnat_table reverse-NAT publish failures
 		"xpf_userspace_session_nat_reverse_key_shared_displacements_total", // #1760 W3' shared displacements
 		"xpf_userspace_worker_command_queue_poison_recoveries_total",       // #1807 poison recoveries
+		"xpf_userspace_shared_session_poison_recoveries_total",             // #2402/#6641 shared-session poison recoveries
 		"xpf_userspace_gre_decap_ecn_illegal_drops_total",                  // #2315 RFC 6040 4.2 decap illegal-combo drops
 		"xpf_userspace_wg_decap_ecn_illegal_drops_total",                   // #2317 WG RFC 6040 4.2 decap illegal-combo drops
 		"xpf_userspace_gre_encap_df_oversize_drops_total",                  // #2331 GRE encap DF-set oversized-outer drops

--- a/pkg/api/metrics_descriptors_userspace_session.go
+++ b/pkg/api/metrics_descriptors_userspace_session.go
@@ -201,4 +201,20 @@ func (c *xpfCollector) initUserspaceSessionDescriptors() {
 			"occurred (#1807, extends #1790).",
 		nil, nil,
 	)
+	c.userspaceSharedSessionPoisonRecoveries = prometheus.NewDesc(
+		"xpf_userspace_shared_session_poison_recoveries_total",
+		"Shared-session mutex poison recoveries across every "+
+			"shared-session and owner-RG-index site (publish, remove, "+
+			"lookups, index maintenance, and the #5154 HA import "+
+			"generation-guard reads). A poisoned mutex means a worker "+
+			"thread panicked while holding the lock; recovery keeps the "+
+			"committed map and clears the poison, so HA promotion "+
+			"proceeds with the EXISTING synced sessions instead of "+
+			"treating the table as empty and dropping every one of them "+
+			"at failover (#2402). A nonzero value indicates a contained "+
+			"worker panic (#925 supervisor) that HA state survived; the "+
+			"recovery is self-healing, so this counter is the only "+
+			"durable record of it (#6641).",
+		nil, nil,
+	)
 }

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -989,6 +989,12 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 			nil,
 			nil,
 		),
+		userspaceSharedSessionPoisonRecoveries: prometheus.NewDesc(
+			"xpf_userspace_shared_session_poison_recoveries_total",
+			"shared-session poison recoveries",
+			nil,
+			nil,
+		),
 		userspaceGreDecapEcnIllegalDrops: prometheus.NewDesc(
 			"xpf_userspace_gre_decap_ecn_illegal_drops_total",
 			"gre decap rfc6040 illegal-combo drops",
@@ -1102,6 +1108,9 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 		NatReverseKeySharedDisplacementsTotal: 4,
 		// #1807: poison-recovery counter emitted unconditionally.
 		WorkerCommandQueuePoisonRecoveries: 2,
+		// #2402/#6641: shared-session poison-recovery counter emitted
+		// unconditionally.
+		SharedSessionPoisonRecoveries: 5,
 		// #2315: GRE-decap RFC 6040 §4.2 illegal-combo drop counter
 		// emitted unconditionally.
 		GreDecapEcnIllegalDropsTotal: 3,
@@ -1190,9 +1199,10 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 	// contention surface (publish call count + publish lock pair +
 	// replication upserts/enqueued/contended + replication queue depth
 	// high-water = 7, plus the depth SUM added when the lifetime max was
-	// demoted to operator context = 8) = 38.
-	if len(got) != 38 {
-		t.Fatalf("emitUserspaceDynamicBufferMetrics: want 38 metrics, got %d", len(got))
+	// demoted to operator context = 8) = 38 + the #2402/#6641
+	// shared-session poison-recovery counter = 39.
+	if len(got) != 39 {
+		t.Fatalf("emitUserspaceDynamicBufferMetrics: want 39 metrics, got %d", len(got))
 	}
 
 	assertGaugeClose(t, got, c.userspaceSessionTableEntries, nil, 77)
@@ -1230,6 +1240,10 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 	assertCounterClose(t, got, c.userspaceNatReverseKeySharedDisplacements, nil, 4)
 	// #1807: poison-recovery counter emitted unconditionally.
 	assertCounterClose(t, got, c.userspaceWorkerCommandQueuePoisonRecoveries, nil, 2)
+	// #2402/#6641: shared-session poison-recovery counter emitted
+	// unconditionally, so a 0 is a real "no worker panic touched HA session
+	// state" signal rather than an absent series.
+	assertCounterClose(t, got, c.userspaceSharedSessionPoisonRecoveries, nil, 5)
 	// #2315: GRE-decap RFC 6040 §4.2 illegal-combo drop counter emitted
 	// unconditionally.
 	assertCounterClose(t, got, c.userspaceGreDecapEcnIllegalDrops, nil, 3)

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -760,6 +760,17 @@ func (c *xpfCollector) emitUserspaceDynamicBufferMetrics(ch chan<- prometheus.Me
 		float64(status.WorkerCommandQueuePoisonRecoveries),
 	)
 
+	// #2402/#6641: shared-session poison recoveries. Emitted
+	// unconditionally for the same reason as its #1807 twin above: a 0 is
+	// a real "no worker panic touched HA session state" signal, and an
+	// absent series would be indistinguishable from a helper that never
+	// reports.
+	ch <- prometheus.MustNewConstMetric(
+		c.userspaceSharedSessionPoisonRecoveries,
+		prometheus.CounterValue,
+		float64(status.SharedSessionPoisonRecoveries),
+	)
+
 	// #2315: GRE-decap RFC 6040 4.2 illegal-combination drops (outer CE
 	// over a Not-ECT inner). Emitted unconditionally so a 0 is a real
 	// "no illegal combinations seen" signal rather than an absent series.

--- a/pkg/dataplane/userspace/protocol_status.go
+++ b/pkg/dataplane/userspace/protocol_status.go
@@ -353,6 +353,16 @@ type ProcessStatus struct {
 	// Omitempty-free on the Rust side (always serialized); plain decode
 	// here defaults to 0 for older helpers.
 	WorkerCommandQueuePoisonRecoveries uint64 `json:"worker_command_queue_poison_recoveries,omitempty"`
+	// #2402/#6641: shared-session mutex poison recoveries (a worker
+	// thread panicked while holding a shared-session or owner-RG-index
+	// mutex; the committed map was recovered and the poison cleared --
+	// afxdp/shared_ops.rs, mirroring the #1807 worker-queue policy).
+	// Nonzero means a worker panic happened and the HA session state
+	// survived it instead of being silently emptied at failover (the
+	// #2402 bug the recovery policy exists to prevent). Surfaced as
+	// xpf_userspace_shared_session_poison_recoveries_total. Decodes to 0
+	// for an older helper that does not send the key.
+	SharedSessionPoisonRecoveries uint64 `json:"shared_session_poison_recoveries,omitempty"`
 	// #2315: GRE-decap frames dropped by the RFC 6040 §4.2 decap-side ECN
 	// combine because the outer header carried a CE mark over an inner
 	// packet that was Not-ECT (the illegal combination — a congested

--- a/pkg/dataplane/userspace/protocol_test.go
+++ b/pkg/dataplane/userspace/protocol_test.go
@@ -1504,6 +1504,48 @@ func TestProcessStatusWorkerCommandQueuePoisonRecoveriesRoundTrip(t *testing.T) 
 // userspace-dp/src/protocol/control.rs; a key rename on either side
 // silently decodes as zero, so pin every tag here and verify the
 // pre-Phase-3 (keys absent) payload defaults to zero.
+// #2402/#6641: wire pin for the shared-session poison-recovery counter.
+// A key rename on either side decodes silently as zero -- and for THIS
+// counter zero reads as "no worker panic ever touched HA session state",
+// which is exactly the reassuring value the missing-metric defect already
+// produced. Pin the tag and the absent-key default on both sides.
+func TestProcessStatusSharedSessionPoisonRecoveriesRoundTrip(t *testing.T) {
+	in := ProcessStatus{
+		SharedSessionPoisonRecoveries: 7,
+	}
+	raw, err := json.Marshal(&in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal obj: %v", err)
+	}
+	if _, ok := obj["shared_session_poison_recoveries"]; !ok {
+		t.Fatalf("wire key %q missing from ProcessStatus JSON: %s",
+			"shared_session_poison_recoveries", string(raw))
+	}
+
+	var back ProcessStatus
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal ProcessStatus: %v", err)
+	}
+	if back.SharedSessionPoisonRecoveries != in.SharedSessionPoisonRecoveries {
+		t.Fatalf("SharedSessionPoisonRecoveries: got %d, want %d",
+			back.SharedSessionPoisonRecoveries, in.SharedSessionPoisonRecoveries)
+	}
+
+	// Pre-#6641 helper payload (key absent) must decode to zero.
+	var legacy ProcessStatus
+	if err := json.Unmarshal([]byte(`{}`), &legacy); err != nil {
+		t.Fatalf("unmarshal legacy ProcessStatus: %v", err)
+	}
+	if legacy.SharedSessionPoisonRecoveries != 0 {
+		t.Fatalf("legacy SharedSessionPoisonRecoveries: got %d, want 0",
+			legacy.SharedSessionPoisonRecoveries)
+	}
+}
+
 func TestProcessStatusNeighborPhase3CountersRoundTrip(t *testing.T) {
 	in := ProcessStatus{
 		NeighborResolverGetBackoffAttemptsTotal: 7,

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -325,6 +325,26 @@ impl super::Coordinator {
         crate::afxdp::worker_queue::WORKER_COMMAND_QUEUE_POISON_RECOVERIES.load(Ordering::Relaxed)
     }
 
+    /// #2402/#6641: total shared-session mutex poison recoveries across
+    /// every shared-session and owner-RG-index site (publish, remove,
+    /// lookups, index maintenance, and the #5154 HA import
+    /// generation-guard reads). Each recovery means a worker thread
+    /// panicked while holding one of those mutexes and the committed map
+    /// was recovered rather than lost — the #2402 policy, which exists
+    /// because substituting an empty table silently dropped every active
+    /// synced session at the moment of failover.
+    ///
+    /// Surfaced as
+    /// `xpf_userspace_shared_session_poison_recoveries_total`. Nonzero
+    /// means a worker panic happened (see #925 supervisor) and HA state
+    /// survived it. The recovery is deliberately self-healing
+    /// (`clear_poison` restores the fast path), so without this counter
+    /// the only record was a sparse journald line — the twin of the
+    /// #1807 counter directly above, which was already surfaced.
+    pub fn shared_session_poison_recoveries_total(&self) -> u64 {
+        crate::afxdp::shared_ops::SHARED_SESSION_POISON_RECOVERIES.load(Ordering::Relaxed)
+    }
+
     /// #2315: GRE-decap frames dropped by the RFC 6040 §4.2 decap-side
     /// ECN combine because the outer header carried a CE mark over an
     /// inner packet that was Not-ECT (the illegal combination — a

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -474,6 +474,17 @@ pub(crate) struct ProcessStatus {
     /// Additive / defaulted for backward compatibility.
     #[serde(rename = "worker_command_queue_poison_recoveries", default)]
     pub worker_command_queue_poison_recoveries: u64,
+    /// #2402/#6641: total shared-session mutex poison recoveries (a
+    /// worker thread panicked while holding a shared-session or
+    /// owner-RG-index mutex; the committed map was recovered and the
+    /// poison cleared — afxdp/shared_ops.rs, mirroring the #1807
+    /// worker-queue policy). Nonzero means a worker panic happened and
+    /// the HA session state survived it instead of being silently
+    /// emptied at failover (the #2402 bug). Surfaced as the Prometheus
+    /// counter `xpf_userspace_shared_session_poison_recoveries_total`.
+    /// Additive / defaulted for backward compatibility.
+    #[serde(rename = "shared_session_poison_recoveries", default)]
+    pub shared_session_poison_recoveries: u64,
     /// #2315: GRE-decap frames dropped by the RFC 6040 §4.2 decap-side
     /// ECN combine because the outer header carried a CE mark over an
     /// inner packet that was Not-ECT (the illegal combination — a

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -308,6 +308,38 @@ fn process_status_worker_command_queue_poison_recoveries_roundtrip() {
     assert_eq!(legacy.worker_command_queue_poison_recoveries, 0);
 }
 
+// #2402/#6641: round-trip + backward-compat pin for the shared-session
+// poison-recovery counter. The wire key feeds
+// pkg/dataplane/userspace/protocol_status.go and the Prometheus counter
+// `xpf_userspace_shared_session_poison_recoveries_total`. A key rename on
+// either side decodes silently as zero, which for THIS counter reads as
+// "no worker panic ever touched HA session state" -- the exact reassuring
+// value the defect already produced, so the tag is pinned on both sides.
+#[test]
+fn process_status_shared_session_poison_recoveries_roundtrip() {
+    let status = ProcessStatus {
+        shared_session_poison_recoveries: 7,
+        ..Default::default()
+    };
+    let value: serde_json::Value =
+        serde_json::to_value(&status).expect("serialize ProcessStatus to Value");
+    assert_eq!(value["shared_session_poison_recoveries"], 7);
+    let back: ProcessStatus = serde_json::from_value(value).expect("deserialize ProcessStatus");
+    assert_eq!(back.shared_session_poison_recoveries, 7);
+
+    // Pre-#6641 payload (key absent) must decode with a zero default.
+    let mut legacy_value =
+        serde_json::to_value(ProcessStatus::default()).expect("serialize default ProcessStatus");
+    legacy_value
+        .as_object_mut()
+        .expect("ProcessStatus serializes to an object")
+        .remove("shared_session_poison_recoveries")
+        .expect("new key present before strip");
+    let legacy: ProcessStatus =
+        serde_json::from_value(legacy_value).expect("pre-#6641 payload decodes");
+    assert_eq!(legacy.shared_session_poison_recoveries, 0);
+}
+
 // #2315: round-trip + backward-compat pin for the GRE-decap RFC 6040
 // §4.2 illegal-combination drop counter. The wire key feeds
 // pkg/dataplane/userspace/protocol.go and the Prometheus counter

--- a/userspace-dp/src/server/helpers/status.rs
+++ b/userspace-dp/src/server/helpers/status.rs
@@ -127,6 +127,8 @@ pub(crate) fn refresh_status(state: &mut ServerState) {
     // panic poisoned a command queue and it was recovered.
     state.status.worker_command_queue_poison_recoveries =
         state.afxdp.worker_command_queue_poison_recoveries_total();
+    state.status.shared_session_poison_recoveries =
+        state.afxdp.shared_session_poison_recoveries_total();
     // #2315: GRE-decap RFC 6040 §4.2 illegal-combination drops (outer CE
     // over a Not-ECT inner). Nonzero = a misbehaving tunnel ingress
     // ECT-marked the outer for un-ECN inner traffic on a congested path.
@@ -455,5 +457,123 @@ pub(crate) fn set_bindings_forwarding_armed(status: &mut ProcessStatus, armed: b
     for binding in &mut status.bindings {
         binding.armed = armed && binding.registered;
         binding.last_change = Some(Utc::now());
+    }
+}
+
+#[cfg(test)]
+mod status_wiring_tests {
+    /// #6641: every Coordinator `*_total()` counter accessor must actually be
+    /// ASSIGNED into `ProcessStatus` by the status refresh above.
+    ///
+    /// This exists because the populate line is the wiring, and nothing bound
+    /// it. Deleting
+    ///
+    ///     state.status.shared_session_poison_recoveries =
+    ///         state.afxdp.shared_session_poison_recoveries_total();
+    ///
+    /// left the ENTIRE suite green: the serde round-trip tests build a
+    /// `ProcessStatus` literal, the Go decode tests parse a literal, and the
+    /// Prometheus test feeds a literal — none of them observes whether the
+    /// helper ever copies the live counter into the status it sends. Verified
+    /// against the #1807 twin as well: deleting ITS populate line was also
+    /// silent, so this was a gap in the pattern, not in one instance of it.
+    ///
+    /// The check is textual because it is a wiring property, not a value
+    /// property: there is no cheap way to stand up a full coordinator here,
+    /// and a behavioural test that did would still only cover the one counter
+    /// it exercised.
+    ///
+    /// ALLOWLIST: counters that deliberately have no status field yet. Each is
+    /// read only by tests today — the same state the #6641 counter was in
+    /// before it was surfaced — so the list is a visible queue rather than a
+    /// permission slip. Adding a counter here means deciding NOT to show it to
+    /// an operator; prefer wiring it.
+    const UNSURFACED: &[&str] = &[
+        "session_delete_stale_ignored_total",
+        "session_install_stale_ignored_total",
+        "synced_import_reserve_refused_total",
+    ];
+
+    fn read(rel: &str) -> String {
+        let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+        std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {}", p.display(), e))
+    }
+
+    /// Strip comment lines before scanning.
+    ///
+    /// Load-bearing, and found the hard way: the doc comment on THIS test
+    /// quotes the very assignment the scan looks for, so with comments
+    /// included the gate stayed green after the real
+    /// `state.status.shared_session_poison_recoveries = ...` line was deleted
+    /// — the documentation satisfied the check on the code's behalf. Any
+    /// source-scanning gate that can be quoted in prose has this failure mode.
+    fn code_only(src: &str) -> String {
+        src.lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Accessor names declared as `pub fn <name>_total(&self) -> u64`.
+    fn accessors(src: &str) -> Vec<String> {
+        let mut out = Vec::new();
+        for line in src.lines() {
+            let t = line.trim();
+            let Some(rest) = t.strip_prefix("pub fn ") else {
+                continue;
+            };
+            let Some(name) = rest.split('(').next() else {
+                continue;
+            };
+            if name.ends_with("_total") && rest.contains("(&self) -> u64") {
+                out.push(name.to_string());
+            }
+        }
+        out.sort();
+        out.dedup();
+        out
+    }
+
+    #[test]
+    fn every_counter_accessor_is_wired_into_process_status() {
+        let coord = code_only(&read("src/afxdp/coordinator/status.rs"));
+        let refresh = code_only(&read("src/server/helpers/status.rs"));
+
+        let accs = accessors(&coord);
+        assert!(
+            accs.len() >= 20,
+            "found only {} `*_total(&self) -> u64` accessors in coordinator/status.rs — the \
+             scan pattern has rotted and this gate would pass vacuously",
+            accs.len()
+        );
+
+        let mut missing = Vec::new();
+        for a in &accs {
+            if UNSURFACED.contains(&a.as_str()) {
+                continue;
+            }
+            if !refresh.contains(&format!("state.afxdp.{}()", a)) {
+                missing.push(a.clone());
+            }
+        }
+        assert!(
+            missing.is_empty(),
+            "#6641: {} Coordinator counter(s) are never assigned into ProcessStatus by the \
+             status refresh, so the helper computes them and an operator never sees them:\n  {}\n\
+             Wire each as `state.status.<field> = state.afxdp.<name>();`, or — only if it is \
+             deliberately not surfaced — add it to UNSURFACED with a reason.",
+            missing.len(),
+            missing.join("\n  ")
+        );
+
+        // The allowlist must not accumulate dead entries.
+        for u in UNSURFACED {
+            assert!(
+                accs.iter().any(|a| a == u),
+                "#6641: UNSURFACED lists {:?}, which is not a Coordinator `*_total()` accessor \
+                 any more — a dead entry hides how many counters are really unsurfaced",
+                u
+            );
+        }
     }
 }

--- a/userspace-dp/src/server/lifecycle.rs
+++ b/userspace-dp/src/server/lifecycle.rs
@@ -239,6 +239,7 @@ pub(crate) fn run() -> Result<(), String> {
             synced_import_cap_drops_total: 0,
             nat_reverse_key_shared_displacements_total: 0,
             worker_command_queue_poison_recoveries: 0,
+            shared_session_poison_recoveries: 0,
             gre_decap_ecn_illegal_drops_total: 0,
             wg_decap_ecn_illegal_drops_total: 0,
             gre_encap_df_oversize_drops_total: 0,

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -930,6 +930,7 @@
     "session_replication_queue_depth_sum": 0,
     "session_replication_upserts_total": 0,
     "session_table_entries": 0,
+    "shared_session_poison_recoveries": 0,
     "shared_session_publish_lock_acquisitions_total": 0,
     "shared_session_publish_lock_contended_total": 0,
     "shared_session_publishes_total": 0,


### PR DESCRIPTION
Closes #6641

## The gap

`SHARED_SESSION_POISON_RECOVERIES` (#2402) counts every recovery of a poisoned shared-session or owner-RG-index mutex — each one meaning a worker thread panicked while holding it and the committed map was recovered rather than lost. That recovery exists because substituting an empty table **silently dropped every active synced session at the moment of failover**.

It was never surfaced. Its own doc said "kept for tests and future status wiring", and the only non-test reader was `ha_tests.rs`. Because the recovery is deliberately self-healing (`clear_poison` restores the fast path), the sole durable record of a contained worker panic touching HA session state was a sparse journald line.

Its twin — the #1807 worker-command-queue poison counter — was already surfaced, so this mirrors that wiring end to end: coordinator accessor → status populate → lifecycle init → `ProcessStatus` field (serde-renamed, defaulted) → Go decode → `xpf_userspace_shared_session_poison_recoveries_total`.

## What mirroring the precedent exposed

**The populate line is the wiring, and nothing bound it.** Deleting

```rust
state.status.shared_session_poison_recoveries =
    state.afxdp.shared_session_poison_recoveries_total();
```

left the **entire suite green**. The serde round-trip tests build a `ProcessStatus` literal, the Go decode test parses a literal, the Prometheus test feeds a literal — none observes whether the helper ever copies the live counter into the status it sends.

I checked the #1807 twin: **deleting its populate line was silent too.** The gap is in the pattern, not in one instance of it — so mirroring the precedent faithfully would have reproduced it.

This adds a gate over the whole family: every Coordinator `*_total(&self) -> u64` accessor must be assigned into `ProcessStatus` by the status refresh.

**It found three more counters in exactly the state this one was in** — read only by tests, never shown to an operator: `session_delete_stale_ignored_total`, `session_install_stale_ignored_total`, `synced_import_reserve_refused_total`. Allowlisted rather than wired (out of scope here); the allowlist rejects dead entries, so it reads as a queue rather than a permission slip.

### The gate needed one non-obvious fix

Its own doc comment **quotes the assignment it greps for**, so with comments included it stayed GREEN after the real line was deleted — the documentation satisfied the check on the code's behalf. It now strips comment lines before scanning.

Any source-scanning gate that can be quoted in prose has this failure mode; worth remembering alongside the other scan-gate hazards.

## Wire fixture

`protocol_wire_v1.json` regenerated, and the diff **classified before accepting it**: exactly one key added (`process_status.shared_session_poison_recoveries = 0`), **zero removed, zero values changed**. Structural-only.

## Mutation matrix

Each verified applied on a compiling tree; restored between cells.

| # | Mutation | Result |
|---|---|---|
| G1 | delete the populate assignment (**the wiring**) | **RED** — was GREEN twice |
| G1b | delete the **#1807 precedent's** populate line | **RED** — was GREEN |
| G2 | rename the Rust serde key | **RED** |
| G3 | rename the Go json tag | **RED** |
| G4 | delete the Prometheus emit | **RED** |
| G5 | dead allowlist entry | **RED** |

G1 is recorded as it actually happened: it passed on the first attempt because the wiring was unbound, and again on the second because the new gate's own comment satisfied it. **Only the third attempt is a real red.**

## Validation

- `cargo test --manifest-path userspace-dp/Cargo.toml -- --test-threads=1` — full suite green.
- `go build ./...` clean; `pkg/api` and `pkg/dataplane/userspace` green with `-count=1`.
- Metric-count guard in `metrics_test.go` bumped 38 → 39 (it caught the addition, as intended).

## ⚠️ Gate owed

**This changes the `userspace-dp` binary, so it owes the cluster smoke.** Not run from this lane — the cluster is serialized centrally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gcdxy5mCofwyVWHUKzhU9F
