### PR TITLE
config: redact control-char secrets in both AST shapes (#7395)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -102333,3 +102333,18 @@ prose edit above them added. No diff falls in the new test body.
   re-refuses every boot and an HA node holds SECONDARY indefinitely.
 - **File(s)**: pkg/upgrade/flip.go, pkg/upgrade/kernel.go,
   pkg/upgrade/kernel_arm_restamp_6639_test.go (new), _Log.md
+
+## 2026-08-22 — #7395 control-char secret leak: the other three cells
+- **Timestamp**: 2026-08-22
+- **Action**: #6625's merged fix (PR #7387, another lane) covered ONE of four
+  cells. Measured at master: {strict,lenient} x {flat,hierarchical} → only
+  strict/flat redacted. `isSecretLeaf` reads `keys[0]`, which is the keyword in
+  the flat shape and the VALUE in the hierarchical one, so the hierarchical
+  shape defeated it entirely; the lenient sanitizer was never fixed at all and
+  is the worse surface (its caller LOGS every path, on Store.Load at boot and
+  Store.SyncApply per HA peer-sync). Routed both validators through a
+  FLATTENED-path resolution that is shape-independent, taking the UNION of the
+  tree's two secret-leaf lists so neither can under-redact, and bound the two
+  lists to agree.
+- **File(s)**: pkg/config/freetext.go,
+  pkg/config/control_char_secret_shapes_7395_test.go (new), _Log.md

--- a/pkg/config/control_char_secret_shapes_7395_test.go
+++ b/pkg/config/control_char_secret_shapes_7395_test.go
@@ -1,0 +1,211 @@
+package config
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const sentinel7395 = "SENTINEL-CREDENTIAL-VALUE"
+
+// The #1798 validators must behave identically in BOTH AST shapes (CLAUDE.md
+// dual-shape rule):
+//
+//   - FLAT (set syntax): the keyword and its value collapse onto ONE node's Keys.
+//   - HIERARCHICAL (block parse): they are SEPARATE chained nodes.
+//
+// #6625's fix keyed on keys[0], which is the keyword in the flat shape and the
+// VALUE in the hierarchical one — so it covered one shape and left the other
+// publishing the credential twice over (#7395).
+
+func flatLeaf7395(path []string, kw, val string) []*Node {
+	var head, cur *Node
+	for _, k := range path {
+		n := &Node{Keys: []string{k}}
+		if head == nil {
+			head = n
+		} else {
+			cur.Children = []*Node{n}
+		}
+		cur = n
+	}
+	leaf := &Node{Keys: []string{kw, val}, IsLeaf: true}
+	if cur == nil {
+		return []*Node{leaf}
+	}
+	cur.Children = []*Node{leaf}
+	return []*Node{head}
+}
+
+func hierLeaf7395(path []string, kw, val string) []*Node {
+	var head, cur *Node
+	for _, k := range append(append([]string(nil), path...), kw, val) {
+		n := &Node{Keys: []string{k}}
+		if head == nil {
+			head = n
+		} else {
+			cur.Children = []*Node{n}
+		}
+		cur = n
+	}
+	cur.IsLeaf = true
+	return []*Node{head}
+}
+
+// secretLeaves7395 covers every disambiguation class, not one keyword: the
+// unconditional keywords, the format-qualifier case, and all three
+// CONTEXT-gated generic keywords whose secrecy depends on an ancestor.
+func secretLeaves7395() map[string]struct {
+	path []string
+	kw   string
+} {
+	return map[string]struct {
+		path []string
+		kw   string
+	}{
+		"authentication-key":               {[]string{"chassis", "cluster"}, "authentication-key"},
+		"pre-shared-key":                   {[]string{"security", "ike", "policy", "p1"}, "pre-shared-key"},
+		"private-key":                      {[]string{"interfaces", "wg0", "unit", "0"}, "private-key"},
+		"tsig-secret":                      {[]string{"system", "services", "dynamic-dns", "provider", "p1"}, "tsig-secret"},
+		"api-key":                          {[]string{"system", "services", "rest-api"}, "api-key"},
+		"password (context: dynamic-dns)":  {[]string{"system", "services", "dynamic-dns", "provider", "p1"}, "password"},
+		"api-token (context: dynamic-dns)": {[]string{"system", "services", "dynamic-dns", "provider", "p1"}, "api-token"},
+		"community (context: snmp)":        {[]string{"system", "snmp"}, "community"},
+		"key (context: authentication md5)": {[]string{
+			"protocols", "ospf", "area", "0", "interface", "ge-0/0/0", "authentication", "md5", "1",
+		}, "key"},
+	}
+}
+
+// TestControlCharSecretRedactedInBothShapes_7395 is the fail-on-revert gate for
+// all FOUR cells: {strict, lenient} x {flat, hierarchical}.
+//
+// Before this, exactly one of the four redacted. The hierarchical shape defeated
+// the predicate entirely, and the lenient sanitizer was never fixed at all —
+// and that one is the worse surface, because its caller LOGS every path it
+// returns and it runs on Store.Load at BOOT and Store.SyncApply on every HA
+// peer-sync. A persisted key with a stray tab was re-published every boot.
+func TestControlCharSecretRedactedInBothShapes_7395(t *testing.T) {
+	for name, leaf := range secretLeaves7395() {
+		for shape, build := range map[string]func([]string, string, string) []*Node{
+			"flat": flatLeaf7395,
+			"hier": hierLeaf7395,
+		} {
+			t.Run(name+"/"+shape+"/strict", func(t *testing.T) {
+				err := validateNodesControlChars(build(leaf.path, leaf.kw, "\t"+sentinel7395), "")
+				if err == nil {
+					t.Fatal("setup: a control character must still be REJECTED; if it is now " +
+						"accepted this case exercises no error render")
+				}
+				if strings.Contains(err.Error(), sentinel7395) {
+					t.Fatalf("the credential reached the commit error:\n%v", err)
+				}
+			})
+			t.Run(name+"/"+shape+"/lenient", func(t *testing.T) {
+				tree := &ConfigTree{Children: build(leaf.path, leaf.kw, "\t"+sentinel7395)}
+				got := SanitizeTreeControlChars(tree)
+				if len(got) == 0 {
+					t.Fatal("setup: nothing was sanitized; this case exercises no path render")
+				}
+				for _, p := range got {
+					if strings.Contains(p, sentinel7395) {
+						t.Fatalf("the credential reached a LOGGED sanitize path (boot / HA "+
+							"peer-sync): %q", p)
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestNonSecretValueStillRenderedInBothShapes_7395 is the over-reach guard.
+//
+// A validator that stopped echoing EVERY value would satisfy the gate above
+// completely and destroy a real diagnostic: for a description the offending
+// value is exactly what the operator needs to see.
+//
+// It asserts the QUOTED form, not a bare substring — the rendered PATH also
+// contains the value (sanitized), so a Contains() check passes whether or not
+// the value branch ran.
+func TestNonSecretValueStillRenderedInBothShapes_7395(t *testing.T) {
+	const plain = "PLAIN-DESCRIPTION-VALUE"
+	for shape, build := range map[string]func([]string, string, string) []*Node{
+		"flat": flatLeaf7395,
+		"hier": hierLeaf7395,
+	} {
+		t.Run(shape+"/strict", func(t *testing.T) {
+			err := validateNodesControlChars(
+				build([]string{"interfaces", "ge-0/0/0"}, "description", "\t"+plain), "")
+			if err == nil {
+				t.Fatal("expected rejection")
+			}
+			if want := strconv.Quote("\t" + plain); !strings.Contains(err.Error(), want) {
+				t.Fatalf("a NON-secret leaf must still render its value as %s — blanket "+
+					"suppression is a lost diagnostic, not a fix. got:\n%v", want, err)
+			}
+		})
+		t.Run(shape+"/lenient", func(t *testing.T) {
+			tree := &ConfigTree{Children: build([]string{"interfaces", "ge-0/0/0"}, "description", "\t"+plain)}
+			got := SanitizeTreeControlChars(tree)
+			if len(got) != 1 || !strings.Contains(got[0], plain) {
+				t.Fatalf("the lenient path must still NAME a non-secret value: %q", got)
+			}
+		})
+	}
+}
+
+// TestPolicyOptionsCommunityStaysLegible_7395 pins the #4097 diagnostic that
+// motivates root-gating `community`: under snmp it is the credential, under
+// policy-options it is a BGP route-target name and the operator needs to see
+// WHICH member carried the newline. The union of the two secret resolutions
+// must not blanket-redact it.
+func TestPolicyOptionsCommunityStaysLegible_7395(t *testing.T) {
+	const rt = "65000:100"
+	err := validateNodesControlChars(
+		flatLeaf7395([]string{"policy-options"}, "community", "\t"+rt), "")
+	if err == nil {
+		t.Fatal("expected rejection")
+	}
+	if !strings.Contains(err.Error(), rt) {
+		t.Fatalf("a policy-options community is a route target, not a credential, and must "+
+			"stay legible (#4097). got:\n%v", err)
+	}
+}
+
+// TestBothSecretResolutionsAgree_7395 binds the tree's TWO secret-leaf lists
+// together.
+//
+// #6625 added secretLeafKeywords (secret.go) beside the secretIndices
+// resolution the raw-AST display paths already used (ast_redact.go). Two lists
+// answering one question is how the next credential keyword gets added to one
+// and not the other — and the drift is silent in the direction that matters: a
+// leaf redacted in `show configuration` but echoed by a commit error.
+//
+// The validators now take their UNION, so neither list alone can under-redact.
+// This asserts the union actually covers each list, which is what makes that
+// claim true rather than aspirational.
+func TestBothSecretResolutionsAgree_7395(t *testing.T) {
+	for kw := range secretLeafKeywords {
+		fp := []string{"chassis", "cluster", kw, sentinel7395}
+		if !isSecretValueIndex(fp, 3) {
+			t.Errorf("secretLeafKeywords lists %q but the validators' resolution does not "+
+				"mark its value secret — a credential the commit error would publish", kw)
+		}
+	}
+	// And the reverse: everything secretIndices knows must be covered too.
+	for _, tc := range []struct {
+		fp  []string
+		idx int
+	}{
+		{[]string{"system", "snmp", "community", sentinel7395}, 3},
+		{[]string{"protocols", "ospf", "area", "0", "interface", "ge-0/0/0",
+			"authentication", "md5", "1", "key", sentinel7395}, 10},
+		{[]string{"system", "services", "dynamic-dns", "provider", "p1",
+			"aws-secret-key", sentinel7395}, 6},
+	} {
+		if !isSecretValueIndex(tc.fp, tc.idx) {
+			t.Errorf("secretIndices marks %v[%d] secret but the validators' resolution does not",
+				tc.fp, tc.idx)
+		}
+	}
+}

--- a/pkg/config/freetext.go
+++ b/pkg/config/freetext.go
@@ -172,22 +172,117 @@ func joinNodePath(prefix string, keys []string) string {
 	return prefix + " " + joined
 }
 
+// renderNodePathFlat builds the human-readable path from a FLATTENED key path,
+// masking every secret VALUE token (#7395).
+//
+// It resolves secrecy through secretIndices (ast_redact.go) — the SAME
+// resolution the raw-AST display paths use, and the only one in the tree that is
+// AST-SHAPE INDEPENDENT. That is the whole point: `authentication-key <PSK>`
+// arrives either as ONE node whose Keys are ["authentication-key", "<PSK>"]
+// (flat-set) or as TWO chained nodes (hierarchical parse), and a predicate that
+// reads keys[0] matches the keyword in the first shape and the VALUE in the
+// second. secretIndices sees the flattened path, so both shapes resolve
+// identically.
+func renderNodePathFlat(fp []string) string {
+	clean := make([]string, len(fp))
+	for i, k := range fp {
+		clean[i] = sanitizeControlChars(k)
+	}
+	for idx := range secretValueIndicesFlat(fp) {
+		if idx >= 0 && idx < len(clean) {
+			clean[idx] = SecretRedacted
+		}
+	}
+	return strings.Join(clean, " ")
+}
+
+// secretValueIndicesFlat returns the positions of the flattened key path that
+// hold a secret VALUE, as the UNION of the tree's two secret-leaf resolutions.
+//
+// There are two because #6625 added one (secretLeafKeywords / isSecretLeaf, in
+// secret.go) beside the one the raw-AST display paths already used
+// (secretIndices, in ast_redact.go), and they do not agree: `password` is
+// unconditional in the first and gated to `api-auth`/`dynamic-dns` in the
+// second, while the second additionally knows authentication-password,
+// privacy-password, simple-password, api-token, aws-secret-key,
+// `community` under snmp and `key` under `authentication md5`.
+//
+// Taking the union rather than picking one is deliberate. Each list is a claim
+// that something IS a credential; disagreement means one of them has a leaf the
+// other has not learned about yet, and in a redactor the safe resolution of
+// "one says secret" is secret. The cost of over-redacting is a lost diagnostic;
+// the cost of under-redacting is a published credential.
+//
+// It is evaluated over the FLATTENED path, which is what makes it independent
+// of AST shape: `authentication-key <PSK>` arrives either as ONE node whose Keys
+// are ["authentication-key", "<PSK>"] (flat-set) or as TWO chained nodes
+// (hierarchical parse). A predicate reading keys[0] matches the keyword in the
+// first and the VALUE in the second — which is why #6625's fix covered only the
+// flat shape (#7395).
+//
+// Both root-gated cases survive the union intact: a policy-options `community`
+// is a BGP route-target name and stays legible in BOTH resolutions, so #4097's
+// diagnostic is not broken.
+func secretValueIndicesFlat(fp []string) map[int]bool {
+	out := map[int]bool{}
+	for _, i := range secretIndices(fp) {
+		out[i] = true
+	}
+	for i, k := range fp {
+		if !IsSecretLeafKeyword(k) {
+			continue
+		}
+		// Every token after the keyword is its value (covers a multi-token or
+		// bracketed-list value), matching redactSecretKeys' keys[1:] rule.
+		for j := i + 1; j < len(fp); j++ {
+			out[j] = true
+		}
+	}
+	return out
+}
+
+// isSecretValueIndex reports whether position idx of the flattened key path is a
+// secret VALUE token.
+func isSecretValueIndex(fp []string, idx int) bool {
+	return secretValueIndicesFlat(fp)[idx]
+}
+
+// splitNodePathPrefix recovers the flattened key path from the joined string
+// form the exported entry points still accept. Empty prefix is the root.
+func splitNodePathPrefix(prefix string) []string {
+	if prefix == "" {
+		return nil
+	}
+	return strings.Split(prefix, " ")
+}
+
 // validateNodesControlChars walks the (group-expanded) AST and returns
 // an error for the first value or annotation containing a control
 // character, or the first annotation containing a `*/`/`/*` comment
 // delimiter (#3900). Strict commit-path only — see the package comment
 // above.
 func validateNodesControlChars(nodes []*Node, prefix string) error {
+	return validateNodesControlCharsAt(nodes, splitNodePathPrefix(prefix))
+}
+
+// validateNodesControlCharsAt is the recursion, carrying the path as a SLICE.
+//
+// The slice is what makes shape-independent secrecy possible: secretIndices
+// resolves a keyword to the positions of its value tokens, so it needs the
+// components. Re-splitting the joined form per level would also split a string
+// built from SANITIZED components, and a sanitized token can contain the space
+// being split on — silently shifting every index after it.
+func validateNodesControlCharsAt(nodes []*Node, base []string) error {
 	for _, n := range nodes {
-		// #6625: a credential leaf must never have its VALUE rendered. The
-		// path is built from the REDACTED keys, because joinNodePath renders
-		// every key — including the value — so an un-redacted path published
-		// the secret a second time, alongside the quoted value below.
-		nodePath := joinNodePath(prefix, redactSecretKeys(prefix, n.Keys))
-		secretLeaf := isSecretLeaf(prefix, n.Keys)
-		for _, k := range n.Keys {
+		// #6625/#7395: a credential leaf must never have its VALUE rendered,
+		// and the path renders every key — so for `authentication-key <PSK>`
+		// an un-redacted path published the secret a SECOND time, alongside
+		// the quoted value below.
+		fp := append(append([]string(nil), base...), n.Keys...)
+		nodePath := renderNodePathFlat(fp)
+		for i, k := range n.Keys {
 			if hasControlChars(k) {
-				if secretLeaf {
+				if isSecretValueIndex(fp, len(base)+i) {
 					// Report WHERE and WHAT, never the value. The offset plus
 					// the byte is enough to fix the input — a leading tab from
 					// a password manager is offset 0, a trailing CR is the last
@@ -206,7 +301,7 @@ func validateNodesControlChars(nodes []*Node, prefix string) error {
 		if hasCommentDelim(n.Annotation) {
 			return fmt.Errorf("%s: annotation %q contains a comment delimiter (the sequences '*/' and '/*' are not allowed in annotations — they would close the comment and inject the remaining text as configuration on reload)", nodePath, n.Annotation)
 		}
-		if err := validateNodesControlChars(n.Children, nodePath); err != nil {
+		if err := validateNodesControlCharsAt(n.Children, fp); err != nil {
 			return err
 		}
 	}
@@ -219,6 +314,12 @@ func validateNodesControlChars(nodes []*Node, prefix string) error {
 // human-readable config path per modified node. Lenient-path
 // counterpart of validateNodesControlChars.
 func sanitizeNodesControlChars(nodes []*Node, prefix string) []string {
+	return sanitizeNodesControlCharsAt(nodes, splitNodePathPrefix(prefix))
+}
+
+// sanitizeNodesControlCharsAt is the lenient recursion, carrying the path as a
+// slice for the same reason its strict twin does.
+func sanitizeNodesControlCharsAt(nodes []*Node, base []string) []string {
 	var warnings []string
 	for _, n := range nodes {
 		changed := false
@@ -236,11 +337,17 @@ func sanitizeNodesControlChars(nodes []*Node, prefix string) []string {
 			n.Annotation = sanitizeCommentDelim(n.Annotation)
 			changed = true
 		}
-		nodePath := joinNodePath(prefix, n.Keys)
+		// #7395: the same masking, through the same resolution. The caller LOGS
+		// each path this returns, and this walker runs on Store.Load at BOOT and
+		// on Store.SyncApply for every HA peer-sync — so an already-persisted
+		// key with a stray tab was re-published to the daemon log on every
+		// single boot. The strict validator fires once, on a commit; this is the
+		// worse of the two surfaces, and #6625 fixed only the other one.
+		fp := append(append([]string(nil), base...), n.Keys...)
 		if changed {
-			warnings = append(warnings, nodePath)
+			warnings = append(warnings, renderNodePathFlat(fp))
 		}
-		warnings = append(warnings, sanitizeNodesControlChars(n.Children, nodePath)...)
+		warnings = append(warnings, sanitizeNodesControlCharsAt(n.Children, fp)...)
 	}
 	return warnings
 }


### PR DESCRIPTION
Closes #7395

## #6625's fix covered one of four cells

Measured at master before this change, same credential, same leaf:

| | strict validator | lenient sanitizer |
|---|---|---|
| **FLAT** (set syntax, keyword+value on one node) | redacted ✅ | **LEAKS** ❌ |
| **HIERARCHICAL** (separate chained nodes) | **LEAKS TWICE** ❌ | **LEAKS** ❌ |

The hierarchical strict output was the pre-#6625 message verbatim — the secret in the rendered path *and* again in the quoted value:

```
chassis cluster authentication-key  SENTINEL-PSK: value "\tSENTINEL-PSK" contains control characters ...
```

## Two root causes, one per axis

**Shape.** `isSecretLeaf`/`redactSecretKeys` key off `keys[0]`. Per CLAUDE.md's dual-AST rule a leaf arrives either as **one** node whose `Keys` are `["authentication-key", "<PSK>"]` (flat set-syntax) or as **two** chained nodes (hierarchical parse). In the first, `keys[0]` is the keyword; in the second it is the **value**, with the keyword in the prefix — so the predicate never matched.

**Surface.** The lenient sanitizer was not touched at all, and it is the worse of the two. The strict validator fires **once**, on an operator's commit. The lenient walker runs on `Store.Load` at **boot** and on `Store.SyncApply` for **every HA peer-sync**, and its caller *logs* every path it returns. An already-persisted key with a stray tab — exactly the value the #1798 migration helper exists to clean up — was re-published to the daemon log on every single boot, indefinitely, with no operator action.

## The fix

Both validators now resolve secrecy over the **flattened key path**, which is shape-independent by construction, and both recursions carry that path as a **slice**. The slice is not cosmetic: the resolution maps a keyword to the positions of its value tokens, so it needs components — and re-splitting the joined form would split a string built from *sanitized* components, where a sanitized token can contain the space being split on, silently shifting every index after it.

## The union, not a choice

#6625 added `secretLeafKeywords` (`secret.go`) beside the `secretIndices` resolution the raw-AST display paths already used (`ast_redact.go`), and **the two disagree**: `password` is unconditional in the first and gated to `api-auth`/`dynamic-dns` in the second, while the second additionally knows `authentication-password`, `privacy-password`, `simple-password`, `api-token`, `aws-secret-key`, `community` under `snmp`, and `key` under `authentication md5`.

Each list is a *claim that something is a credential*, so a disagreement means one of them has not learned about a leaf yet. In a redactor the safe resolution of "one says secret" is **secret**: over-redaction costs a diagnostic, under-redaction publishes a credential. Picking either alone regresses the other's contract — **both directions are covered by a mutation cell below.**

Both root-gated cases survive intact, so a `policy-options` `community` — a BGP route target, not a credential — stays legible and #4097's diagnostic is not broken. That is pinned by its own test.

The two lists are now **bound to agree by a test** rather than left to drift, because drift here is silent in the direction that matters: a leaf redacted in `show configuration` but echoed by a commit error.

## Validation

- `go test ./pkg/config/ ./pkg/configstore/ -count=1` — green, **including #6625's own tests unchanged**.
- `go build ./...` clean.

**Mutation matrix — five mutations, each on a COMPILING tree:**

| Mutation | Cases that red |
|---|---|
| Revert the lenient path to the unredacted join (pre-fix) | all 9 lenient cells |
| Restore the `keys[0]` predicate | every hierarchical strict cell |
| **Drop the `secretIndices` half of the union** | the agreement test **+ #6625's dual-use community test** |
| **Drop the `secretLeafKeywords` half of the union** | the agreement test **+ #6625's password test** |
| **Mask EVERY value — a tightening, not a removal** | both over-reach guards, mine and #6625's |

**That C/D pair is the point of the union:** each half's removal is caught by the *other* list's test, so neither can be dropped as redundant later.

The over-reach guard asserts the `strconv.Quote` form, not a bare substring — the rendered path also contains the value (sanitized), so a `Contains()` check passes whether or not the value branch ran.

No cluster smoke owed: control-plane only, no `userspace-dp` helper or shim `.o` movement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdWuT1UffSkr1spw8sjNTE
