### PR TITLE
cluster: bind readLoop's installation of the #5086 auth gate (#6646)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -102386,3 +102386,10 @@ prose edit above them added. No diff falls in the new test body.
     pkg/dataplane/userspace/{protocol_status.go,protocol_test.go},
     pkg/api/{metrics.go,metrics_userspace.go,metrics_descriptors_userspace_session.go,
     metrics_descriptor_coverage_test.go,metrics_test.go}
+
+- **Timestamp**: 2026-08-22
+  - **Action**: #6646 — the reconstruction the issue reported was already replaced
+    by single-sourcing on admitFrame (verified: readLoop calls it, and severing
+    controlLinkAuthKey now REDs). Residual closed: readLoop's CALL to admitFrame
+    was still unbound — severing it left every 5086 test green.
+  - **File(s)**: pkg/cluster/heartbeat_replay_restart_5086_test.go

--- a/pkg/cluster/heartbeat_replay_restart_5086_test.go
+++ b/pkg/cluster/heartbeat_replay_restart_5086_test.go
@@ -1,6 +1,8 @@
 package cluster
 
 import (
+	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -279,5 +281,84 @@ func TestHeartbeatAuthStateOutlivesReceiver_5086(t *testing.T) {
 	// Memory bound: one fixed ring per Manager regardless of restart count.
 	if got := len(m.hbAuth.replay.marks); got != heartbeatReplaySessions {
 		t.Errorf("replay ring = %d marks, want the fixed %d", got, heartbeatReplaySessions)
+	}
+}
+
+// TestReadLoopActuallyGatesEveryFrame_5086 binds readLoop's CALL to admitFrame,
+// which the tests above do not.
+//
+// Those tests drive `admitFrame` directly. That is the right shape for the
+// gate's LOGIC — it is the single implementation readLoop also uses, so the
+// accept-side consequences are production's rather than a copy. But it leaves
+// one thing unbound: whether readLoop still routes frames through it at all.
+//
+// Measured, not assumed. Replacing readLoop's
+//
+//	if !r.admitFrame(buf[:n], pkt) {
+//
+// with `if false {` — i.e. a receive path that authenticates nothing and admits
+// every datagram on the wire, i.e. the whole #4107/#5086 guard bypassed — left
+// every 5086 test GREEN, because none of them reaches readLoop.
+//
+// The check is a source scan because the alternative is worse here. Driving the
+// real loop needs a UDP socket plus the two goroutines start() spawns, and the
+// assertions would then be "did lastSeen move / not move" behind a settle
+// deadline — timing in a file that is otherwise fully deterministic. A flaky
+// gate on an anti-replay guard is a gate people learn to re-run.
+//
+// Comment lines are stripped before scanning. Here that is PRECAUTIONARY
+// rather than load-bearing, and the distinction is worth stating: the scan
+// reads heartbeat.go while the comment quoting the call lives in this test
+// file, so today no comment can satisfy it — verified by severing the call
+// with stripping disabled, which still failed. The #6641 gate scanned the same
+// file its own doc comment lived in and DID go green off its explanation, so
+// the habit is kept here against a future comment in heartbeat.go that quotes
+// the call.
+//
+// FAIL-ON-REVERT: delete or bypass the admitFrame call in readLoop.
+func TestReadLoopActuallyGatesEveryFrame_5086(t *testing.T) {
+	src, err := os.ReadFile("heartbeat.go")
+	if err != nil {
+		t.Fatalf("read heartbeat.go: %v", err)
+	}
+
+	var code []string
+	for _, line := range strings.Split(string(src), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue
+		}
+		code = append(code, line)
+	}
+
+	start := -1
+	for i, line := range code {
+		if strings.HasPrefix(line, "func (r *heartbeatReceiver) readLoop()") {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatal("readLoop not found in heartbeat.go — this gate is bound to it by name " +
+			"and must be re-pointed if it is renamed")
+	}
+	end := len(code)
+	for i := start + 1; i < len(code); i++ {
+		if strings.HasPrefix(code[i], "func ") {
+			end = i
+			break
+		}
+	}
+	body := strings.Join(code[start:end], "\n")
+
+	if len(body) < 200 {
+		t.Fatalf("readLoop body scanned to only %d bytes — the scan has rotted and this gate "+
+			"would pass vacuously", len(body))
+	}
+	if !strings.Contains(body, "r.admitFrame(") {
+		t.Fatal("#5086/#6646: readLoop does not call r.admitFrame — every datagram on the wire " +
+			"would be admitted without authentication or replay checking, and the 5086 tests " +
+			"would NOT notice, because they drive admitFrame directly rather than through the " +
+			"receive loop.\n\nThe gate's logic and the gate's INSTALLATION are two properties; " +
+			"this test owns the second.")
 	}
 }


### PR DESCRIPTION
Closes #6646

## The reported defect is already fixed — verified, not assumed

#6646 reported that the #5086 test reconstructed the receive-side auth gate in the test file and drove that reconstruction instead of the real path.

That is fixed at HEAD. The boot-epoch work (`f29e4eb24` / `ae56bebe4` / `9d0d18e5e`) extracted `heartbeatReceiver.admitFrame` as the **single implementation** and pointed **both** `readLoop` (`heartbeat.go`, the `if !r.admitFrame(buf[:n], pkt)` call) and the test's `feed` helper at it. The test now takes its key from `m.controlLinkAuthKey()` rather than a test-local one. Single-sourced, not an agreement test.

**Proved rather than eyeballed.** The issue named its concern precisely — *"a regression in `controlLinkAuthKey()` plumbing would leave the suite green"*. Severing that plumbing now **REDs** `TestHeartbeatReplayRejectedAfterHeartbeatRestart_5086`.

Note the issue's own citations had rotted: its quoted production snippet predates the #6169 boot-epoch handling, and the reconstruction it quotes no longer exists.

## One residual was still open

It is the shape the issue **title** describes, rather than the shape its evidence section describes. Replacing `readLoop`'s

```go
if !r.admitFrame(buf[:n], pkt) {
```

with `if false {` — a receive path that authenticates nothing and admits **every datagram on the wire**, the whole #4107/#5086 guard bypassed — left **every 5086 test green**, because all of them call `admitFrame` directly and none reaches the loop.

**The gate's logic was bound; its installation was not.** `TestReadLoopActuallyGatesEveryFrame_5086` owns that second property.

## Why a source scan rather than a real socket

Driving the real loop needs a UDP socket plus the two goroutines `start()` spawns, and the assertions become *"did `lastSeen` move / not move"* behind a settle deadline — timing in a file that is otherwise fully deterministic. **A flaky gate on an anti-replay guard is one people learn to re-run.** Stated in the test so the trade is visible rather than implied.

## An honest correction about the comment stripping

The scan strips comments, and my first version of the comment claimed that was *load-bearing here*. **It is not**, and the mutation said so: severing the call with stripping disabled still failed, because this gate reads `heartbeat.go` while the quoting comment lives in the test file.

The #6641 gate scanned the same file its own doc comment lived in and **did** go green off its own explanation — so the habit is kept here against a future comment in `heartbeat.go` that quotes the call, and the comment now says precautionary rather than load-bearing.

## Mutation matrix

Each verified applied on a compiling tree.

| # | Mutation | Result |
|---|---|---|
| H1 | sever `controlLinkAuthKey` plumbing | **RED** — the issue's named case |
| H2 | `readLoop` stops calling `admitFrame` | **RED** — was GREEN |
| H3 | rename `readLoop` | **RED** — fails loudly, not silently |
| H4 | scan with comments + call severed | **RED** — hence stripping is precautionary here |

## Validation

- `go build ./...` clean; `go vet ./pkg/cluster` clean.
- `go test -count=1 ./pkg/cluster/` — ok, 19.7s.

Test-only change; no production behaviour, no binary movement, **no cluster smoke owed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gcdxy5mCofwyVWHUKzhU9F
