### PR TITLE
cluster: make a clamped monitor weight visible to the operator (#6589)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,31 @@
+## 2026-08-22 — #6589 clamped monitor weights visible to the operator
+
+- **Timestamp**: 2026-08-22
+- **Action**: Carried the clamp signal (`ConfiguredWeight` + `Clamped`)
+  through `InterfaceMonitorInfo` AND `routing.InterfaceMonitorStatus` —
+  the latter is the LIVE path both renderers take, so annotating only
+  the config-only fallback would have left the common case silent — and
+  rendered `N (cfg M)` plus a consequence note in
+  `show chassis cluster interfaces`. Added
+  `Monitor.ClampedIPMonitorWeights` + a render in
+  `FormatIPMonitoringStatus`.
+  CONFIRMED the lead's clamp-precedes-the-gate hypothesis in a sharper
+  form: the clamp happens AT THE RENDER SITE and its boolean is
+  discarded (`w, _ :=`), so the surface prints a plausible 0/255. Also
+  found the ip-monitoring half is WORSE than filed — it reached no
+  surface at all, not even journald.
+  Mutation matrix 7/7 RED after closing three green cells: C4 (the IP
+  RENDER was unbound — the tests called the reporter directly), C5
+  (needed an in-range control), C7 (the first tripwire keyed on the
+  `w, _ :=` SPELLING, but a producer can capture the boolean and still
+  omit it from the struct — re-cut to count `Clamped:` against
+  `InterfaceMonitorInfo{` literals).
+- **File(s)**: pkg/cluster/status.go, pkg/cluster/monitor.go,
+  pkg/routing/monitor.go, pkg/cli/cli_helpers.go,
+  pkg/grpcapi/server_cluster.go,
+  pkg/cluster/clamped_weight_visibility_6589_test.go,
+  pkg/cluster/README.md
+
 ## 2026-08-22 — #6619 + #6564 member 8: VRF-enslaved iifname scope, and coverage vs existence
 
 - **Timestamp**: 2026-08-22

--- a/pkg/cli/cli_helpers.go
+++ b/pkg/cli/cli_helpers.go
@@ -116,10 +116,12 @@ func (c *CLI) buildInterfacesInput() cluster.InterfacesInput {
 		if statuses, ok := monStatuses[rg.ID]; ok {
 			for _, st := range statuses {
 				input.Monitors = append(input.Monitors, cluster.InterfaceMonitorInfo{
-					Interface:       st.Interface,
-					Weight:          st.Weight,
-					Up:              st.Up,
-					RedundancyGroup: rg.ID,
+					Interface:        st.Interface,
+					Weight:           st.Weight,
+					Up:               st.Up,
+					RedundancyGroup:  rg.ID,
+					ConfiguredWeight: st.ConfiguredWeight, // #6589
+					Clamped:          st.Clamped,
 				})
 				localMonMap[st.Interface] = true
 			}
@@ -129,12 +131,14 @@ func (c *CLI) buildInterfacesInput() cluster.InterfacesInput {
 				// raw configured one. An out-of-range weight survives the
 				// tolerant load / peer-sync compile (#1960 no-brick) and the
 				// runtime bounds it to [0,255].
-				w, _ := config.ClampInterfaceMonitorWeight(mon.Weight)
+				w, clamped := config.ClampInterfaceMonitorWeight(mon.Weight)
 				input.Monitors = append(input.Monitors, cluster.InterfaceMonitorInfo{
-					Interface:       mon.Interface,
-					Weight:          w,
-					Up:              true,
-					RedundancyGroup: rg.ID,
+					Interface:        mon.Interface,
+					Weight:           w,
+					Up:               true,
+					RedundancyGroup:  rg.ID,
+					ConfiguredWeight: mon.Weight,
+					Clamped:          clamped, // #6589
 				})
 				localMonMap[mon.Interface] = true
 			}
@@ -158,12 +162,14 @@ func (c *CLI) buildInterfacesInput() cluster.InterfacesInput {
 				}
 				// #6549: the peer bounds this weight the same way we do, so
 				// render the effective value rather than the raw config one.
-				w, _ := config.ClampInterfaceMonitorWeight(mon.Weight)
+				w, clamped := config.ClampInterfaceMonitorWeight(mon.Weight)
 				input.PeerMonitors = append(input.PeerMonitors, cluster.InterfaceMonitorInfo{
-					Interface:       mon.Interface,
-					Weight:          w,
-					Up:              false,
-					RedundancyGroup: rg.ID,
+					Interface:        mon.Interface,
+					Weight:           w,
+					Up:               false,
+					RedundancyGroup:  rg.ID,
+					ConfiguredWeight: mon.Weight,
+					Clamped:          clamped, // #6589
 				})
 			}
 		}

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -2291,6 +2291,57 @@ Gated end-to-end on `set chassis cluster dhcp-lease-synchronization`
 (`config.ClusterConfig.DHCPLeaseSync`); standalone / knob-off renders the Kea
 config bit-identical to pre-#2239 (no control-socket, no hook).
 
+## A clamped monitor weight is visible to the operator (#6589)
+
+An out-of-range `interface-monitor ... weight` is bounded to `[0,255]` by
+`ClampInterfaceMonitorWeight`. That clamp is reachable ONLY from a
+persisted config or an HA config-sync push — the strict commit gate
+rejects an out-of-range weight outright — which is exactly the
+population an operator cannot see by re-reading what they typed.
+
+**The clamp direction is settled and is not the defect.** 0 is retained
+(not 255) because it is an already-legal, operator-reachable state: an
+`interface-monitor` with no `weight` token compiles to exactly 0,
+meaning "monitor this, contribute no debt". Clamping invalid input onto
+an existing semantic is less surprising than clamping it onto
+"maximally fatal", and under clamp-to-255 a typo'd `-100` arriving over
+config-sync would make the RECEIVING node resign its redundancy group
+the moment that link flaps — turning config-sync into a remote HA
+denial of service.
+
+What was wrong is that the clamp was INVISIBLE, and in a specific way:
+every renderer already called the clamp and discarded the signal —
+`w, _ := ...` — so it printed a plausible 0 or 255 indistinguishable
+from an operator-authored one. A diagnostic that fails to a value that
+looks healthy. A monitor clamped to 0 owes no election debt, so its RG
+does not demote when that link fails and the operator finds out during
+a failover that does not happen.
+
+`InterfaceMonitorInfo` (and `routing.InterfaceMonitorStatus`, which
+carries the LIVE path both renderers take — annotating only the
+config-only fallback would have left the common case silent) now carry
+`ConfiguredWeight` + `Clamped`, and `show chassis cluster interfaces`
+renders `N (cfg M)` plus a note stating the consequence. Zero values
+mean "not clamped", so a producer that does not set them renders
+exactly as before.
+
+**The ip-monitoring half was worse than filed.** The interface-monitor
+class at least reaches journald once per config apply
+(`reconcileMonitorDebtsLocked`). The IP class reached NOTHING:
+`ipTargetWeight` and the global-threshold aggregate both discarded the
+signal and no site anywhere logged it, so an out-of-range ip-monitoring
+weight was invisible including in the log. `Monitor.ClampedIPMonitorWeights`
+reports it and `FormatIPMonitoringStatus` renders it. An unset per-target
+weight is deliberately NOT reported: it inherits the global one, which is
+reported on its own line, and reporting it twice would show a per-target
+clamp the operator never configured.
+
+Note on the `SetMonitorWeight` chokepoint: its own clamp-and-warn is
+documented as effectively unreachable, because every producer bounds the
+weight before it gets there. That is deliberate defense-in-depth and the
+code says so — but it does mean a missing warning there must never be
+read as "no out-of-range weight was configured".
+
 ## Interface-monitor link-state detection
 
 `Monitor` (`monitor.go`) is the live carrier-detection loop: a 1-second

--- a/pkg/cluster/clamped_weight_visibility_6589_test.go
+++ b/pkg/cluster/clamped_weight_visibility_6589_test.go
@@ -1,0 +1,336 @@
+// #6589: a clamped (inert) monitor weight was visible only in journald — no
+// operator-facing surface distinguished it from a working monitor.
+//
+// The clamp itself is not the defect and was adjudicated during #6586: 0 is
+// retained because it is an already-legal, operator-reachable state (an
+// interface-monitor with no weight token compiles to exactly 0, "monitor this,
+// contribute no debt"), and because clamping to 255 would let a typo'd -100
+// arriving over the HA config-sync push make the RECEIVING node resign its
+// redundancy group the moment that link flaps — turning config-sync into a
+// remote HA denial of service.
+//
+// What survives is that the clamp is INVISIBLE. And it is invisible in a
+// specific way worth naming: every renderer already called
+// ClampInterfaceMonitorWeight and threw the signal away — `w, _ := ...` —
+// so it printed a plausible 0 or 255 indistinguishable from an
+// operator-authored one. A diagnostic that fails to a value that looks healthy.
+//
+// TWO CLASSES, and they are not equally bad:
+//
+//   - interface-monitor weights DO reach journald, once per config apply, via
+//     reconcileMonitorDebtsLocked. Invisible on every operator surface.
+//   - ip-monitoring weights reached NOTHING. ipTargetWeight and the
+//     global-threshold aggregate both discarded the clamp signal and no site
+//     anywhere logged it, so an out-of-range ip-monitoring weight was invisible
+//     including in the log. That is worse than the case #6589 was filed about.
+//
+// Either way the consequence is the same: a monitor clamped to 0 owes no
+// election debt, so its RG does not demote when that link or probe fails, and
+// the operator discovers it during a failover that does not happen.
+//
+// FAIL-ON-REVERT: restore `w, _ :=` at a producer, or drop the render, and the
+// clamped monitor becomes indistinguishable from a configured one again.
+package cluster
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func TestClampedInterfaceMonitorIsVisibleInStatus6589(t *testing.T) {
+	m := NewManager(0, 1)
+
+	out := m.FormatInterfaces(InterfacesInput{
+		Monitors: []InterfaceMonitorInfo{
+			// Clamped from a typo'd negative: the runtime bounds it to 0, i.e.
+			// "contributes no debt".
+			{Interface: "ge-0/0/1", Weight: 0, Up: true, RedundancyGroup: 1,
+				ConfiguredWeight: -100, Clamped: true},
+			// An ordinary monitor that is legitimately weight 0.
+			{Interface: "ge-0/0/2", Weight: 0, Up: true, RedundancyGroup: 1},
+		},
+	})
+
+	if !strings.Contains(out, "cfg -100") {
+		t.Errorf("the clamped monitor's CONFIGURED weight is not shown, so it is "+
+			"indistinguishable from a monitor legitimately configured at 0:\n%s", out)
+	}
+	if !strings.Contains(out, "CLAMPED") {
+		t.Errorf("no CLAMPED annotation in the output:\n%s", out)
+	}
+	// The note must say what it MEANS. "CLAMPED" alone does not tell an
+	// operator their RG will not demote.
+	if !strings.Contains(out, "NOT demote") {
+		t.Errorf("the note does not state the consequence (the RG will not demote), "+
+			"so an operator cannot tell whether it matters:\n%s", out)
+	}
+}
+
+// The discrimination is the property, so it is asserted directly: two monitors
+// with the SAME effective weight must render differently when one was clamped.
+// A test that only checked "CLAMPED appears" would pass a renderer that
+// annotated every monitor.
+func TestClampedAnnotationDiscriminates6589(t *testing.T) {
+	m := NewManager(0, 1)
+
+	clean := m.FormatInterfaces(InterfacesInput{
+		Monitors: []InterfaceMonitorInfo{
+			{Interface: "ge-0/0/2", Weight: 0, Up: true, RedundancyGroup: 1},
+		},
+	})
+	if strings.Contains(clean, "CLAMPED") || strings.Contains(clean, "cfg ") {
+		t.Fatalf("a monitor that was NOT clamped is annotated as clamped — the "+
+			"annotation carries no information:\n%s", clean)
+	}
+
+	clamped := m.FormatInterfaces(InterfacesInput{
+		Monitors: []InterfaceMonitorInfo{
+			{Interface: "ge-0/0/2", Weight: 0, Up: true, RedundancyGroup: 1,
+				ConfiguredWeight: 900, Clamped: true},
+		},
+	})
+	if !strings.Contains(clamped, "CLAMPED") {
+		t.Fatalf("a clamped monitor is not annotated:\n%s", clamped)
+	}
+	// Same effective weight in both renders — only the provenance differs.
+	if !strings.Contains(clean, "ge-0/0/2") || !strings.Contains(clamped, "ge-0/0/2") {
+		t.Fatal("fixture: both renders must contain the monitor row")
+	}
+}
+
+// TestClampedIPMonitorWeightsAreReported6589 covers the class that reached no
+// surface at all — not even the log.
+func TestClampedIPMonitorWeightsAreReported6589(t *testing.T) {
+	rg := makeRG(2, false, map[int]int{0: 200, 1: 100})
+	rg.IPMonitoring = &config.IPMonitoring{
+		GlobalWeight: 400, // out of range -> clamped to 255
+		Targets: []*config.IPMonitorTarget{
+			{Address: "10.0.0.1", Weight: -5},  // clamped to 0
+			{Address: "10.0.0.2", Weight: 100}, // fine
+			{Address: "10.0.0.3"},              // unset -> inherits global, reported once above
+		},
+	}
+	mon := NewMonitor(NewManager(0, 1), []*config.RedundancyGroup{rg})
+
+	got := mon.ClampedIPMonitorWeights()
+	if len(got) != 2 {
+		t.Fatalf("reported %d clamped ip weights, want 2 (the global-weight and the "+
+			"negative per-target one): %+v", len(got), got)
+	}
+	var sawGlobal, sawTarget bool
+	for _, c := range got {
+		switch c.Target {
+		case "":
+			sawGlobal = true
+			if c.Configured != 400 || c.Effective != 255 {
+				t.Errorf("global: configured=%d effective=%d, want 400/255", c.Configured, c.Effective)
+			}
+		case "10.0.0.1":
+			sawTarget = true
+			if c.Configured != -5 || c.Effective != 0 {
+				t.Errorf("10.0.0.1: configured=%d effective=%d, want -5/0", c.Configured, c.Effective)
+			}
+		default:
+			t.Errorf("unexpected clamped entry %+v — an in-range weight must NOT be "+
+				"reported, or the surface becomes noise operators learn to ignore", c)
+		}
+	}
+	if !sawGlobal || !sawTarget {
+		t.Errorf("missing entries: global=%v target=%v", sawGlobal, sawTarget)
+	}
+}
+
+// The unset-per-target case is the over-reach control: a target with no weight
+// token inherits the global one, which is already reported on its own line.
+// Reporting it again would show the operator a per-target clamp they never
+// configured.
+func TestUnsetIPTargetWeightIsNotReportedAsClamped6589(t *testing.T) {
+	rg := makeRG(3, false, map[int]int{0: 200})
+	// The global is OUT of range, so it is reported on its own line. The unset
+	// target inherits it at election time (ipTargetWeight), and a reporter that
+	// mirrored that inheritance would report the SAME clamp a second time as if
+	// it were a per-target one the operator configured. An in-range global here
+	// would make this control vacuous — nothing would be reported either way.
+	rg.IPMonitoring = &config.IPMonitoring{
+		GlobalWeight: 900, // out of range -> one report, for the global
+		Targets:      []*config.IPMonitorTarget{{Address: "10.0.0.9"}},
+	}
+	mon := NewMonitor(NewManager(0, 1), []*config.RedundancyGroup{rg})
+
+	got := mon.ClampedIPMonitorWeights()
+	if len(got) != 1 {
+		t.Fatalf("want exactly 1 report (the global-weight); an unset per-target weight "+
+			"must not be reported as a per-target clamp the operator never configured. "+
+			"got %d: %+v", len(got), got)
+	}
+	if got[0].Target != "" {
+		t.Errorf("the single report should be the global-weight, got target %q", got[0].Target)
+	}
+}
+
+// TestNoDisplayProducerDiscardsTheClampSignal6589 binds the WIRING, and it is
+// keyed on the exact shape of the defect.
+//
+// Every test above constructs InterfaceMonitorInfo directly, so all of them
+// stay green if a PRODUCER stops carrying the signal — and that is precisely
+// what the bug was. The pre-#6589 code did not fail to clamp; it clamped
+// correctly and wrote `w, _ := config.ClampInterfaceMonitorWeight(...)`,
+// throwing away the one bit that says the operator's value was not the one in
+// effect.
+//
+// So: no display-path producer may use the blank-identifier form. The
+// exemptions are written down, and a stale one fails too.
+func TestNoDisplayProducerDiscardsTheClampSignal6589(t *testing.T) {
+	t.Parallel()
+
+	type exemption struct{ file, why string }
+	// Files allowed to discard the signal, with the reason.
+	allowed := map[string]string{}
+	for _, e := range []exemption{
+		{"../cluster/monitor.go",
+			"ipTargetWeight and desiredRGIPDebts compute an ELECTION weight, not a " +
+				"display value; the display side reads ClampedIPMonitorWeights, which " +
+				"keeps the signal"},
+	} {
+		allowed[e.file] = e.why
+	}
+
+	roots := []string{"../cluster", "../cli", "../grpcapi", "../routing"}
+	var offenders []string
+	found := map[string]bool{}
+	scanned := 0
+
+	for _, dir := range roots {
+		ents, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read %s: %v", dir, err)
+		}
+		for _, e := range ents {
+			name := e.Name()
+			if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			path := filepath.Join(dir, name)
+			src, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			scanned++
+			// Whitespace-collapsed so a gofmt line break between the two
+			// return values cannot hide the discard — the same wrap-blindness
+			// that would have made a line-oriented grep miss the original.
+			flat := strings.Join(strings.Fields(string(src)), "")
+			if !strings.Contains(flat, ",_:=config.ClampInterfaceMonitorWeight(") {
+				continue
+			}
+			if _, ok := allowed[path]; ok {
+				found[path] = true
+				continue
+			}
+			offenders = append(offenders, path)
+		}
+	}
+
+	if scanned < 40 {
+		t.Fatalf("scanned only %d files — the walk is vacuous", scanned)
+	}
+	sort.Strings(offenders)
+	for _, o := range offenders {
+		t.Errorf("%s discards the clamp signal (`w, _ := ClampInterfaceMonitorWeight`).\n"+
+			"  Capture it and carry ConfiguredWeight/Clamped to the display: the clamped\n"+
+			"  value is a plausible 0 or 255, indistinguishable from one the operator\n"+
+			"  configured, and a monitor clamped to 0 means its redundancy group will\n"+
+			"  never demote when that link fails (#6589).", o)
+	}
+	for path, why := range allowed {
+		if !found[path] {
+			t.Errorf("stale exemption: %s no longer discards the clamp signal (%s). "+
+				"Remove it — a stale entry silently widens the next real one.", path, why)
+		}
+	}
+}
+
+// TestClampedIPWeightsReachTheOperatorSurface6589 binds the RENDER for the IP
+// class. The reporter test above proves ClampedIPMonitorWeights computes the
+// right set; it says nothing about whether any operator command prints it, and
+// "computed but never displayed" is the exact defect #6589 is about.
+func TestClampedIPWeightsReachTheOperatorSurface6589(t *testing.T) {
+	m := NewManager(0, 1)
+	rg := makeRG(1, false, map[int]int{0: 200})
+	rg.IPMonitoring = &config.IPMonitoring{
+		GlobalWeight: 700,
+		Targets:      []*config.IPMonitorTarget{{Address: "10.9.9.9", Weight: -3}},
+	}
+	cfg := makeConfig(rg)
+	m.UpdateConfig(cfg)
+	m.monitor = NewMonitor(m, cfg.RedundancyGroups)
+
+	out := m.FormatIPMonitoringStatus()
+
+	for _, want := range []string{"CLAMPED", "700", "10.9.9.9", "NOT demote"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("FormatIPMonitoringStatus does not surface %q. The IP class reached "+
+				"NO surface at all before #6589 — not even journald — so a weight the "+
+				"runtime silently bounded to 0 owed no election debt and the group never "+
+				"demoted on probe failure:\n%s", want, out)
+		}
+	}
+}
+
+// The over-reach control for the render: a fully in-range configuration must
+// produce NO clamp section, or the annotation becomes noise operators learn to
+// skip past.
+func TestInRangeIPWeightsProduceNoClampSection6589(t *testing.T) {
+	m := NewManager(0, 1)
+	rg := makeRG(1, false, map[int]int{0: 200})
+	rg.IPMonitoring = &config.IPMonitoring{
+		GlobalWeight: 100,
+		Targets:      []*config.IPMonitorTarget{{Address: "10.9.9.9", Weight: 50}},
+	}
+	cfg := makeConfig(rg)
+	m.UpdateConfig(cfg)
+	m.monitor = NewMonitor(m, cfg.RedundancyGroups)
+
+	out := m.FormatIPMonitoringStatus()
+	if strings.Contains(out, "CLAMPED") {
+		t.Fatalf("an entirely in-range ip-monitoring config produced a CLAMPED section:\n%s", out)
+	}
+	if got := m.monitor.ClampedIPMonitorWeights(); len(got) != 0 {
+		t.Fatalf("in-range weights reported as clamped: %+v", got)
+	}
+}
+
+// TestEveryMonitorInfoProducerCarriesTheClampFields6589 is the producer-wiring
+// guard, and it keys on the SIGNAL REACHING THE STRUCT rather than on how the
+// clamp call is spelled.
+//
+// A first version searched for the `w, _ :=` discard form. That is the shape
+// the original defect took, but it is not the property: a producer can capture
+// the boolean and still not put it in the struct, and the mutation matrix
+// proved it — a cell that dropped the two fields from a live producer left the
+// discard-form check green.
+func TestEveryMonitorInfoProducerCarriesTheClampFields6589(t *testing.T) {
+	t.Parallel()
+	for _, f := range []string{"../cli/cli_helpers.go", "../grpcapi/server_cluster.go"} {
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		flat := strings.Join(strings.Fields(string(src)), "")
+		literals := strings.Count(flat, "cluster.InterfaceMonitorInfo{")
+		carried := strings.Count(flat, "Clamped:")
+		if literals == 0 {
+			t.Fatalf("%s builds no cluster.InterfaceMonitorInfo — this guard is stale", f)
+		}
+		if carried < literals {
+			t.Errorf("%s builds %d cluster.InterfaceMonitorInfo literal(s) but sets Clamped "+
+				"on only %d. The unset ones render a clamped weight as though the operator "+
+				"configured it (#6589).", f, literals, carried)
+		}
+	}
+}

--- a/pkg/cluster/monitor.go
+++ b/pkg/cluster/monitor.go
@@ -497,7 +497,7 @@ func (mon *Monitor) pollInterfaceMonitors(rg *config.RedundancyGroup, statuses [
 		// can still reach this poll. Deliberately NOT logged here — this loop
 		// runs every poll tick; reconcileMonitorDebtsLocked emits the
 		// config-apply-frequency warning.
-		weight, _ := config.ClampInterfaceMonitorWeight(im.Weight)
+		weight, weightClamped := config.ClampInterfaceMonitorWeight(im.Weight)
 
 		// Translate Junos name (ge-0/0/0) to Linux name (ge-0-0-0).
 		linuxName := config.LinuxIfName(im.Interface)
@@ -529,10 +529,12 @@ func (mon *Monitor) pollInterfaceMonitors(rg *config.RedundancyGroup, statuses [
 
 		// Track local interface status for heartbeat propagation.
 		statuses = append(statuses, InterfaceMonitorInfo{
-			Interface:       im.Interface,
-			Weight:          weight,
-			Up:              up,
-			RedundancyGroup: rg.ID,
+			Interface:        im.Interface,
+			Weight:           weight,
+			Up:               up,
+			RedundancyGroup:  rg.ID,
+			ConfiguredWeight: im.Weight,
+			Clamped:          weightClamped,
 		})
 
 		// #6550: ifaceState is shared with UpdateGroups, which DELETES from it
@@ -682,6 +684,60 @@ launch:
 // never called. Bounding here — the single place both consumers read — is what
 // closes it, and it also keeps the weight reported in the RecordEvent /
 // ipDebts bookkeeping equal to the weight actually applied.
+// ClampedIPWeight is one ip-monitoring weight the runtime bounded (#6589).
+// Target is "" for the per-RG aggregate global-weight.
+type ClampedIPWeight struct {
+	RGID       int
+	Target     string
+	Configured int
+	Effective  int
+}
+
+// ClampedIPMonitorWeights reports every ip-monitoring weight the runtime had to
+// clamp, so an operator-facing surface can show it (#6589).
+//
+// The interface-monitor class at least reaches journald —
+// reconcileMonitorDebtsLocked warns once per config apply. The IP class reached
+// NOTHING: ipTargetWeight and the global-threshold aggregate both discarded the
+// clamp signal, so an out-of-range ip-monitoring weight was invisible on every
+// surface including the log. That is worse than the interface-monitor case
+// #6589 was filed about, and it is the same failure shape: a monitor clamped to
+// 0 owes no election debt, so its RG never demotes when the probe fails.
+func (mon *Monitor) ClampedIPMonitorWeights() []ClampedIPWeight {
+	mon.mu.Lock()
+	groups := mon.groups
+	mon.mu.Unlock()
+
+	var out []ClampedIPWeight
+	for _, rg := range groups {
+		if rg == nil || rg.IPMonitoring == nil {
+			continue
+		}
+		if w, clamped := config.ClampInterfaceMonitorWeight(rg.IPMonitoring.GlobalWeight); clamped {
+			out = append(out, ClampedIPWeight{
+				RGID: rg.ID, Configured: rg.IPMonitoring.GlobalWeight, Effective: w,
+			})
+		}
+		for _, target := range rg.IPMonitoring.Targets {
+			if target == nil {
+				continue
+			}
+			raw := target.Weight
+			if raw == 0 {
+				// Mirrors ipTargetWeight: an unset per-target weight inherits
+				// the global one, which is reported above on its own.
+				continue
+			}
+			if w, clamped := config.ClampInterfaceMonitorWeight(raw); clamped {
+				out = append(out, ClampedIPWeight{
+					RGID: rg.ID, Target: target.Address, Configured: raw, Effective: w,
+				})
+			}
+		}
+	}
+	return out
+}
+
 func (mon *Monitor) ipTargetWeight(rg *config.RedundancyGroup, target *config.IPMonitorTarget) int {
 	raw := target.Weight
 	if raw == 0 {

--- a/pkg/cluster/status.go
+++ b/pkg/cluster/status.go
@@ -700,7 +700,6 @@ func (m *Manager) FormatIPMonitoringStatus() string {
 			}
 		}
 		// Show IP monitor section regardless (config-driven).
-		_ = mon // monitor has the config but we show from state
 		if len(ipFails) > 0 || true {
 			// We always show the section for each RG if any monitors are configured.
 			fmt.Fprintf(&b, "Redundancy group %d:\n", rg.GroupID)
@@ -719,6 +718,27 @@ func (m *Manager) FormatIPMonitoringStatus() string {
 
 	if !hasIP {
 		fmt.Fprintln(&b, "No IP monitoring configured")
+	}
+
+	// #6589: clamped ip-monitoring weights. Unlike the interface-monitor
+	// class, this one reached no surface at all — not even journald — so a
+	// weight the runtime silently bounded to 0 owed no election debt and the
+	// RG never demoted on probe failure.
+	if mon != nil {
+		if clamped := mon.ClampedIPMonitorWeights(); len(clamped) > 0 {
+			fmt.Fprintln(&b)
+			fmt.Fprintln(&b, "Clamped IP monitoring weights:")
+			for _, c := range clamped {
+				what := "global-weight"
+				if c.Target != "" {
+					what = c.Target
+				}
+				fmt.Fprintf(&b, "  Redundancy group %d: %-20s configured %d, effective %d (CLAMPED)\n",
+					c.RGID, what, c.Configured, c.Effective)
+			}
+			fmt.Fprintln(&b, "  A weight clamped to 0 adds no election debt, so the group will")
+			fmt.Fprintln(&b, "  NOT demote when that target fails. Re-commit the weight to fix it.")
+		}
 	}
 
 	// Events.
@@ -745,6 +765,24 @@ type InterfaceMonitorInfo struct {
 	Weight          int
 	Up              bool // physical link state
 	RedundancyGroup int
+	// ConfiguredWeight is the weight as WRITTEN in the config, before
+	// ClampInterfaceMonitorWeight bounded it, and Clamped says whether that
+	// bounding actually happened (#6589).
+	//
+	// Every renderer already called the clamp and threw the signal away
+	// (`w, _ := ...`), so it printed a plausible 0 or 255 that is
+	// indistinguishable from an operator-authored one. A monitor clamped to 0
+	// contributes NO election debt: the RG never demotes when that link fails,
+	// and the operator discovers it during a failover that does not happen.
+	// The clamp itself is reachable only from a persisted config or a peer
+	// push (the strict commit gate rejects an out-of-range weight outright),
+	// which is exactly the population an operator cannot see by re-reading
+	// what they typed.
+	//
+	// Zero values mean "not clamped", so a producer that does not set them
+	// renders exactly as before.
+	ConfiguredWeight int
+	Clamped          bool
 }
 
 // RethInfo holds RETH interface status for display.
@@ -871,6 +909,7 @@ func (m *Manager) FormatInterfaces(input InterfacesInput) string {
 		fmt.Fprintln(&b, "Interface Monitoring:")
 		fmt.Fprintf(&b, "    %-18s%-10s%-26s%s\n", "Interface", "Weight", "Status", "Redundancy-group")
 		fmt.Fprintf(&b, "    %-18s%-10s%s\n", "", "", "(Physical/Monitored)")
+		clampedAny := false
 		for _, mon := range allMonitors {
 			physStatus := "Up"
 			if !mon.Up {
@@ -878,8 +917,23 @@ func (m *Manager) FormatInterfaces(input InterfacesInput) string {
 			}
 			// Physical and monitored status are the same (link-state based).
 			statusStr := fmt.Sprintf("%s  /  %s", physStatus, physStatus)
-			fmt.Fprintf(&b, "    %-18s%-10d%-26s%d\n",
-				mon.Interface, mon.Weight, statusStr, mon.RedundancyGroup)
+			// #6589: a clamped weight renders as "<effective> (cfg <written>)"
+			// so the operator can see the two differ. Printing the effective
+			// weight alone — which is what every renderer did — is correct but
+			// silently indistinguishable from a monitor configured that way.
+			weightCol := fmt.Sprintf("%d", mon.Weight)
+			if mon.Clamped {
+				weightCol = fmt.Sprintf("%d (cfg %d)", mon.Weight, mon.ConfiguredWeight)
+				clampedAny = true
+			}
+			fmt.Fprintf(&b, "    %-18s%-10s%-26s%d\n",
+				mon.Interface, weightCol, statusStr, mon.RedundancyGroup)
+		}
+		if clampedAny {
+			fmt.Fprintln(&b, "    NOTE: a weight shown as \"N (cfg M)\" was CLAMPED to the")
+			fmt.Fprintln(&b, "          [0,255] election domain. A monitor clamped to 0 adds no")
+			fmt.Fprintln(&b, "          election debt, so its redundancy group will NOT demote")
+			fmt.Fprintln(&b, "          when that link fails. Re-commit the weight to fix it.")
 		}
 	}
 

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -75,10 +75,12 @@ func (s *Server) buildInterfacesInput() cluster.InterfacesInput {
 		if statuses, ok := monStatuses[rg.ID]; ok {
 			for _, st := range statuses {
 				input.Monitors = append(input.Monitors, cluster.InterfaceMonitorInfo{
-					Interface:       st.Interface,
-					Weight:          st.Weight,
-					Up:              st.Up,
-					RedundancyGroup: rg.ID,
+					Interface:        st.Interface,
+					Weight:           st.Weight,
+					Up:               st.Up,
+					RedundancyGroup:  rg.ID,
+					ConfiguredWeight: st.ConfiguredWeight, // #6589
+					Clamped:          st.Clamped,
 				})
 				localMonMap[st.Interface] = true
 			}
@@ -98,12 +100,14 @@ func (s *Server) buildInterfacesInput() cluster.InterfacesInput {
 				// runtime bounds it to [0,255]; reporting the raw value here
 				// would be an observability lie on exactly the config where
 				// the operator most needs the truth.
-				w, _ := config.ClampInterfaceMonitorWeight(mon.Weight)
+				w, clamped := config.ClampInterfaceMonitorWeight(mon.Weight)
 				input.Monitors = append(input.Monitors, cluster.InterfaceMonitorInfo{
-					Interface:       mon.Interface,
-					Weight:          w,
-					Up:              false,
-					RedundancyGroup: rg.ID,
+					Interface:        mon.Interface,
+					Weight:           w,
+					Up:               false,
+					RedundancyGroup:  rg.ID,
+					ConfiguredWeight: mon.Weight,
+					Clamped:          clamped, // #6589
 				})
 				localMonMap[mon.Interface] = true
 			}
@@ -129,12 +133,14 @@ func (s *Server) buildInterfacesInput() cluster.InterfacesInput {
 				}
 				// #6549: the peer bounds this weight the same way we do, so
 				// render the effective value rather than the raw config one.
-				w, _ := config.ClampInterfaceMonitorWeight(mon.Weight)
+				w, clamped := config.ClampInterfaceMonitorWeight(mon.Weight)
 				input.PeerMonitors = append(input.PeerMonitors, cluster.InterfaceMonitorInfo{
-					Interface:       mon.Interface,
-					Weight:          w,
-					Up:              false,
-					RedundancyGroup: rg.ID,
+					Interface:        mon.Interface,
+					Weight:           w,
+					Up:               false,
+					RedundancyGroup:  rg.ID,
+					ConfiguredWeight: mon.Weight,
+					Clamped:          clamped, // #6589
 				})
 			}
 		}

--- a/pkg/routing/monitor.go
+++ b/pkg/routing/monitor.go
@@ -14,6 +14,12 @@ type InterfaceMonitorStatus struct {
 	Interface string
 	Weight    int
 	Up        bool // true if link is operationally up
+	// ConfiguredWeight / Clamped carry the #6589 clamp signal to the display.
+	// Weight is what the election APPLIES; these say whether that differs from
+	// what the operator wrote. Zero values mean "not clamped", so a producer
+	// that does not set them renders exactly as before.
+	ConfiguredWeight int
+	Clamped          bool
 }
 
 // monitorManager owns interface-monitor link-state tracking for
@@ -53,7 +59,7 @@ func (mm *monitorManager) Apply(groups []*config.RedundancyGroup) {
 			// it. (Because this clamp runs first, the SetMonitorWeight
 			// chokepoint sees an already-bounded value and stays silent — its
 			// warning fires only for a producer that skipped its own clamp.)
-			weight, _ := config.ClampInterfaceMonitorWeight(mon.Weight)
+			weight, weightClamped := config.ClampInterfaceMonitorWeight(mon.Weight)
 
 			// Translate Junos name (ge-0/0/0) to Linux name (ge-0-0-0).
 			linuxName := config.LinuxIfName(mon.Interface)
@@ -67,6 +73,12 @@ func (mm *monitorManager) Apply(groups []*config.RedundancyGroup) {
 				Interface: mon.Interface,
 				Weight:    weight,
 				Up:        up,
+				// #6589: carry the clamp signal to the display. This is the
+				// LIVE path both `show chassis cluster interfaces` renderers
+				// take; annotating only the config-only fallback would leave
+				// the common case silent.
+				ConfiguredWeight: mon.Weight,
+				Clamped:          weightClamped,
 			})
 			if !up {
 				slog.Warn("interface monitor: link down",


### PR DESCRIPTION
Closes #6589

## The clamp direction is not the defect

Settled in #6586: **0** is retained (not 255) because it is an already-legal, operator-reachable state — an `interface-monitor` with no `weight` token compiles to exactly 0, *"monitor this, contribute no debt"*. And under clamp-to-255, a typo'd `-100` arriving over **config-sync** would make the *receiving* node resign its redundancy group the moment that link flaps — config-sync as a remote HA denial of service.

## What was wrong — and the shape is worth naming

Every renderer already **called** the clamp and threw the signal away:

```go
w, _ := config.ClampInterfaceMonitorWeight(mon.Weight)
```

So it printed a plausible **0 or 255, indistinguishable from an operator-authored one**. A diagnostic that fails to a value that looks healthy. A monitor clamped to 0 owes no election debt, so its RG does not demote when that link fails — and the operator finds out during a failover that does not happen.

The clamp is reachable **only** from a persisted config or an HA config-sync push (the strict commit gate rejects out-of-range outright), which is exactly the population an operator cannot see by re-reading what they typed.

## Fix

`InterfaceMonitorInfo` carries `ConfiguredWeight` + `Clamped`, and **so does `routing.InterfaceMonitorStatus`**. The second matters more than it looks: that is the **live** path both `show chassis cluster interfaces` renderers take, so annotating only the config-only fallback would have left the common case silent while the tests passed. Zero values mean "not clamped", so a producer that does not set them renders exactly as before.

Rendered as `N (cfg M)` plus a note stating the consequence — `CLAMPED` alone does not tell an operator their RG will not demote.

## The ip-monitoring half was worse than filed

The issue says the clamp is *"visible only in journald"*. True for the interface-monitor class (`reconcileMonitorDebtsLocked` warns once per config apply). **The IP class reached nothing**: `ipTargetWeight` and the global-threshold aggregate both discarded the signal and no site anywhere logged it, so an out-of-range ip-monitoring weight was invisible **including in the log**.

`Monitor.ClampedIPMonitorWeights` reports it; `FormatIPMonitoringStatus` renders it. An unset per-target weight is deliberately **not** reported — it inherits the global one, which is reported on its own line, and reporting it twice would show a per-target clamp the operator never configured.

## On "does the clamp precede the gate?"

Yes, and the code already knew: `pkg/routing/monitor.go` says *"Because this clamp runs first, the `SetMonitorWeight` chokepoint sees an already-bounded value and stays silent — its warning fires only for a producer that skipped its own clamp."* That is deliberate defense-in-depth, not a new defect — but it means **a missing warning there must never be read as "no out-of-range weight was configured"**, so the README now says so.

## Validation

`go build ./...` + `go vet` clean per cell. `go test -count=1 ./pkg/cluster ./pkg/cli ./pkg/grpcapi ./pkg/routing ./pkg/daemon` green.

### Mutation matrix

| cell | mutation | result |
|---|---|---|
| C1 | render the effective weight only (shipped state) | 2 tests RED |
| C2 | annotate **every** monitor | discrimination test RED |
| C3 | drop the consequence note | 2 tests RED |
| C4 | remove the IP surface | IP render test RED |
| C5 | IP reporter also reports in-range weights | in-range control RED |
| C6 | IP reporter inherits the global for an unset target | 2 tests RED |
| C7 | a live producer drops the two fields | producer-wiring test RED |

### Three cells were green first time, and each exposed a real gap

- **C4** — the IP tests called `ClampedIPMonitorWeights` directly, so they proved the *set* was computed and said nothing about whether any operator command printed it. "Computed but never displayed" is the exact defect this issue is about.
- **C5** — the control used an in-range **global**, so nothing was reported either way and the assertion could not discriminate.
- **C7** — the first producer tripwire searched for the `w, _ :=` discard spelling. That is the shape the original defect took but **not the property**: a producer can capture the boolean and still omit it from the struct, which is what the cell did. It now counts `Clamped:` against `cluster.InterfaceMonitorInfo{` literals per producer file.

## Docs

`pkg/cluster/README.md` gains a section ahead of the link-state one: why the clamp direction is settled, the discarded-signal shape, why `routing.InterfaceMonitorStatus` had to change too, the ip-monitoring gap, and the caveat about the chokepoint's unreachable warning. `_Log.md` entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAsT5gCGP7k2vhdZ1sDuRi