### PR TITLE
config: declare strict-vip-ownership and bind the RG SSOTs (#6663)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -102423,3 +102423,18 @@ prose edit above them added. No diff falls in the new test body.
     controlLinkAuthKey now REDs). Residual closed: readLoop's CALL to admitFrame
     was still unbound — severing it left every 5086 test green.
   - **File(s)**: pkg/cluster/heartbeat_replay_restart_5086_test.go
+
+## 2026-08-22 — #6663 redundancy-group schema/compiler SSOT agreement
+- **Timestamp**: 2026-08-22
+- **Action**: `compileChassis` compiles `strict-vip-ownership` (via the
+  `redundancyGroupStatements` dispatch table) but `setSchema` did not declare
+  it. Not a commit rejection — the RG subtree is open-world, so it committed
+  and took effect — a COMPLETION gap: `redundancy-group 1 ?` never offered it.
+  Declared the leaf, and bound the two SSOTs with an agreement test in ONE
+  direction (compiler ⇒ schema always a bug; schema ⇒ compiler is the
+  documented accepted-only posture). The sweep was provable rather than
+  eyeballed because both sides are enumerable: dispatch-table keys vs schema
+  children, exactly one missing.
+- **File(s)**: pkg/config/schema_chassis.go,
+  pkg/config/rg_schema_compiler_agreement_6663_test.go (new),
+  docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2769,6 +2769,31 @@ whether or not it reads the node — and
 `TestRedundancyGroupNoArgStatementsAreRegistered_6588` keeps it from naming a
 statement the dispatch table does not have.
 
+**The dispatch table and `setSchema` are two SSOTs for one grammar, and they
+had drifted (#6663).** `redundancyGroupStatements` is what `compileChassis`
+actually compiles; `setSchema` is what config-mode completion and `?` help
+read. `strict-vip-ownership` was in the first and missing from the second.
+
+It was **not** a commit rejection — the redundancy-group subtree is
+open-world (`schema_walk.go`), so the statement committed and took effect. It
+was a COMPLETION gap: `set chassis cluster redundancy-group 1 ?` never offered
+a knob the compiler implements, so it was discoverable only by reading the
+compiler.
+
+`TestRedundancyGroupCompilerAndSchemaAgree_6663` now binds them, and it
+deliberately asserts **one direction only**:
+
+- **compiler ⇒ schema** is checked. A statement the compiler honours while the
+  schema omits it is always a defect, for the reason above.
+- **schema ⇒ compiler** is NOT checked. A leaf declared but not yet compiled is
+  the documented accepted-only posture (#2078/#4231/#5804): advertised,
+  committing, with an advisory saying it is inert. Asserting that direction
+  would red every deliberate use of it.
+
+A second test pins that `strict-vip-ownership` is both declared AND still
+compiles — otherwise the agreement test could be satisfied by deleting the
+compiler entry, which is a feature removal wearing the shape of a fix.
+
 **The packing recurses: an INSTANCE can carry its whole body on its own Keys
 too.** Everything above is about a statement inside a named instance's body.
 The instance line itself packs the same way:

--- a/pkg/config/rg_schema_compiler_agreement_6663_test.go
+++ b/pkg/config/rg_schema_compiler_agreement_6663_test.go
@@ -1,0 +1,121 @@
+package config
+
+import (
+	"sort"
+	"testing"
+)
+
+// rgSchemaChildren returns the declared `chassis cluster redundancy-group <n>`
+// child keywords from setSchema.
+func rgSchemaChildren(t *testing.T) map[string]*schemaNode {
+	t.Helper()
+	chassis, ok := setSchema.children["chassis"]
+	if !ok {
+		t.Fatal("setSchema has no `chassis` node")
+	}
+	cluster, ok := chassis.children["cluster"]
+	if !ok {
+		t.Fatal("setSchema has no `chassis cluster` node")
+	}
+	rg, ok := cluster.children["redundancy-group"]
+	if !ok {
+		t.Fatal("setSchema has no `chassis cluster redundancy-group` node")
+	}
+	return rg.children
+}
+
+// TestRedundancyGroupCompilerAndSchemaAgree_6663 binds the two SSOTs for the
+// redundancy-group grammar.
+//
+// `redundancyGroupStatements` is what compileChassis actually compiles;
+// `setSchema` is the documented single source of truth for the config-mode
+// `set`/`delete` grammar (CLAUDE.md, docs/config-schema.md) and is what drives
+// completion and `?` help. #6663 found them disagreeing:
+// `strict-vip-ownership` was compiled but undeclared.
+//
+// THE DIRECTION MATTERS, and this asserts only one of the two.
+//
+// compiler-implies-schema is checked, because a statement the compiler honours
+// while the schema omits it is ALWAYS a defect: the redundancy-group subtree is
+// open-world, so it commits and takes effect, but `set chassis cluster
+// redundancy-group 1 ?` never offers it and an operator cannot discover from the
+// CLI a knob that works. Silent, and only findable by reading the compiler.
+//
+// schema-implies-compiler is deliberately NOT checked. A leaf declared but not
+// yet compiled is the project's documented accepted-only posture (#2078/#4231/
+// #5804): the statement is advertised, commits, and an advisory says it is
+// inert. Asserting that direction would red every deliberate use of it.
+//
+// Adding an entry to `redundancyGroupStatements` without declaring it in
+// setSchema reds this test.
+func TestRedundancyGroupCompilerAndSchemaAgree_6663(t *testing.T) {
+	declared := rgSchemaChildren(t)
+
+	var missing []string
+	for kw := range redundancyGroupStatements {
+		if _, ok := declared[kw]; !ok {
+			missing = append(missing, kw)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Fatalf("compileChassis compiles redundancy-group statement(s) %v that setSchema does "+
+			"not declare. They COMMIT and take effect (the subtree is open-world), but config-mode "+
+			"completion never offers them, so an operator cannot discover from the CLI a knob the "+
+			"compiler implements. Declare each in pkg/config/schema_chassis.go beside `preempt`.",
+			missing)
+	}
+
+	// Non-vacuity: this walk must actually be looking at the real grammar. If a
+	// refactor renamed the path or emptied the table, an empty-vs-empty compare
+	// would pass while checking nothing.
+	if len(redundancyGroupStatements) == 0 {
+		t.Fatal("redundancyGroupStatements is EMPTY — the compiler dispatch table this test " +
+			"compares against is not being reached")
+	}
+	if len(declared) < len(redundancyGroupStatements) {
+		t.Fatalf("setSchema declares %d redundancy-group children but the compiler has %d "+
+			"statements; the schema lookup is probably reaching the wrong node",
+			len(declared), len(redundancyGroupStatements))
+	}
+}
+
+// TestStrictVIPOwnershipIsDeclaredAndCompiles_6663 is the specific #6663 case,
+// asserted end-to-end rather than only through the table comparison above.
+//
+// The agreement test would go green if someone deleted the compiler entry
+// instead of adding the schema leaf — a "fix" that removes the feature. This
+// pins that the statement is BOTH declared and still compiles to its effect.
+func TestStrictVIPOwnershipIsDeclaredAndCompiles_6663(t *testing.T) {
+	if _, ok := rgSchemaChildren(t)["strict-vip-ownership"]; !ok {
+		t.Fatal("setSchema does not declare `strict-vip-ownership` under redundancy-group, so " +
+			"`set chassis cluster redundancy-group 1 ?` cannot offer it")
+	}
+	if _, ok := redundancyGroupStatements["strict-vip-ownership"]; !ok {
+		t.Fatal("the compiler no longer handles `strict-vip-ownership` — declaring it in the " +
+			"schema while dropping the compiler is not a fix, it is a feature removal")
+	}
+
+	// And it still takes effect. A valueless flag, same shape as `preempt`.
+	rg := &RedundancyGroup{}
+	redundancyGroupStatements["strict-vip-ownership"](rg, &Node{Keys: []string{"strict-vip-ownership"}})
+	if !rg.StrictVIPOwnership {
+		t.Fatal("`strict-vip-ownership` no longer sets RedundancyGroup.StrictVIPOwnership")
+	}
+}
+
+// TestRedundancyGroupSchemaLeavesAreCompleteEnoughToComplete_6663 pins that
+// every declared child is usable by the completion path — a leaf with no desc
+// renders an empty `?` line, which is a completion gap of a different shape.
+func TestRedundancyGroupSchemaLeavesAreCompleteEnoughToComplete_6663(t *testing.T) {
+	for kw, node := range rgSchemaChildren(t) {
+		if node == nil {
+			t.Errorf("redundancy-group child %q is a nil schemaNode", kw)
+			continue
+		}
+		if node.desc == "" {
+			t.Errorf("redundancy-group child %q has an empty desc, so `?` help renders a blank "+
+				"line for a statement that exists", kw)
+		}
+	}
+}

--- a/pkg/config/schema_chassis.go
+++ b/pkg/config/schema_chassis.go
@@ -222,6 +222,15 @@ var schemaChassis = &schemaNode{desc: "Chassis configuration", children: map[str
 				children:      nil,
 			},
 			"preempt": {desc: "Allow a higher-priority node to preempt the primary role", children: nil},
+			// #6663: declared here because compileChassis has always
+			// compiled it (redundancyGroupStatements -> compileRGStrictVIPOwnership).
+			// The gap was NOT a commit rejection — the redundancy-group subtree
+			// is open-world, so the statement committed and took effect — it was
+			// a COMPLETION gap: `set chassis cluster redundancy-group 1 ?` never
+			// offered it, so an operator could not discover from the CLI a knob
+			// the compiler implements. Valueless flag, same shape as `preempt`
+			// above, which it sits beside in the dispatch table.
+			"strict-vip-ownership": {desc: "Only the VRRP master may hold the redundancy group's VIPs", children: nil},
 			// interface-monitor weight is NOT typed here: the
 			// `<ifname> weight <n>` tokens pack inline into one leaf
 			// (children==nil here); typing the weight would require a


### PR DESCRIPTION
Closes #6663

## The gap

`compileChassis` has always compiled `strict-vip-ownership` under `chassis cluster redundancy-group <n>` — it is registered in the `redundancyGroupStatements` dispatch table, beside `preempt`, and sets `RedundancyGroup.StrictVIPOwnership`. `setSchema` did not declare it.

**Not a commit rejection**, and that was checked rather than assumed: the redundancy-group subtree is open-world (`schema_walk.go`), so a statement absent from `setSchema` still passes `SchemaValidate`. The config commits and takes effect today.

What was lost is **completion**. `set chassis cluster redundancy-group 1 ?` never offered the statement, so a knob the compiler implements was discoverable only by reading the compiler.

## The sweep was provable, not eyeballed

The issue asks whether any *other* `compileChassis` arm is missing. Both sides are enumerable — the dispatch table's keys against the schema node's children — so that question has an actual answer rather than an impression:

| dispatch table | declared in `setSchema`? |
|---|---|
| `node` | ✅ |
| `gratuitous-arp-count` | ✅ |
| `preempt` | ✅ |
| `interface-monitor` | ✅ |
| `ip-monitoring` | ✅ |
| **`strict-vip-ownership`** | **❌ — the single omission** |

## The durable half asserts ONE direction, deliberately

Declaring the leaf is the smaller half; the next divergence would otherwise be just as silent. But the two directions are not symmetric:

- **compiler ⇒ schema is checked.** A statement the compiler honours while the schema omits it is *always* a defect, for the reason above — it works, it commits, and nothing offers it.
- **schema ⇒ compiler is NOT checked.** A leaf declared but not yet compiled is the project's documented **accepted-only** posture (#2078/#4231/#5804): advertised, committing, with an advisory saying it is inert. Asserting that direction would red every deliberate use of it.

That asymmetry is also why this is an agreement test rather than single-sourcing the two: collapsing them would erase a distinction the project uses on purpose.

**A second test pins that `strict-vip-ownership` is both declared AND still compiles.** Without it, the agreement test could be satisfied by deleting the compiler entry — a feature removal wearing the shape of a fix. The mutation matrix confirms that cell.

## Validation

- `go test ./pkg/config/ ./pkg/cli/ -count=1` — green.
- `go build ./...` clean.

**Mutation matrix — three mutations, each on a COMPILING tree:**

| Mutation | Cases that red |
|---|---|
| Remove the schema leaf (pre-fix bytes) | the agreement test **and** the specific test |
| **Drop the COMPILER entry instead** (feature removal) | **only the specific test** — which is the point of having it |
| Empty the dispatch table (vacuity) | both, via the non-vacuity floor — an empty-vs-empty comparison cannot pass while checking nothing |

A third test asserts every declared child has a non-empty `desc`, since a leaf that renders a blank `?` line is a completion gap of a different shape.

No cluster smoke owed: control-plane only, no `userspace-dp` helper or shim `.o` movement.

## Docs

`docs/config-schema.md` — the packed-statement section now records that the dispatch table and `setSchema` are two SSOTs for one grammar, that they had drifted, why it was a completion gap rather than a rejection, and why only one direction is asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdWuT1UffSkr1spw8sjNTE
