### PR TITLE
test(ddns): remove the two ephemeral-port flakes in the full-package run (#6709)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-08-22 — #6709/#7009: the pkg/ddns full-package flake, both mechanisms
+
+- **Timestamp**: 2026-08-22
+- **Action**: Reproduced the flake before touching anything (2/30 full-package
+  runs, ~7%, a DIFFERENT test each time) and established that it is TWO
+  mechanisms sharing ONE root resource — the ephemeral port — rather than the
+  single port race #7009 describes. Killed the obvious third hypothesis first:
+  `slog.SetDefault` is process-global and would produce the identical
+  empty-log symptom under parallelism, but the package has ZERO `t.Parallel()`
+  calls, so tests run sequentially and SetDefault can never be clobbered.
+  (a) `unsignedUpdateWarned` is a process-global `sync.Map` keyed by server
+  host:port that is never reset; ephemeral ports are recycled within one test
+  binary (measured with a standalone probe: 1 reuse per 552 binds), so a test
+  can draw a port an earlier test already warned for and observe zero warns.
+  Proved this causally rather than by inference — a probe that pre-poisons the
+  key reproduces `warns=0 log=""`, byte-identical to the reported symptom.
+  (b) `newFakeDNSServer` bound UDP on :0 then assumed that port number was also
+  free for TCP; the same probe measured the UDP-assigned port already held for
+  TCP host-wide at 1/552, which is ~8% per run and matches the observed rate.
+  Fixed (a) by having the asserting test seed-then-clear its own key, and (b)
+  with a bounded RESAMPLE (`listenDNSPair`) that redraws a fresh port on
+  conflict — explicitly not the retry-the-same-port loop #7009 rejects.
+  Validated against #7009's own binder: six concurrent instances of the package,
+  OLD 6/30 instances failed vs NEW 0/30, then 0/60 at parallelism 10 (120 clean
+  post-fix runs total). Mutation matrix M1/M2/M4/M5 all RED with real
+  assertions; M3 (the negative-assertion vacuity guard) GREEN and kept as
+  defence in depth after a separate cell proved that subtest DOES detect a real
+  regression, so the guard removes a ~8%/run blind spot rather than decorating.
+  Caught and DELETED one test of my own that could not red: it re-implemented
+  `realDNSPairAttempt` instead of calling it, and removing that function's
+  `pc.Close()` left it green with vet clean. Also corrected two rows of the
+  brief's `RedactURL` table by measuring it: a bracketed `[SECRET]` authority
+  survives as an IPv6 literal (not "unparseable"), and a secret in the PATH is a
+  fifth verbatim row nobody had listed.
+- **File(s)**: `pkg/ddns/backend_rfc2136_test.go`,
+  `pkg/ddns/fake_dns_portpair_6709_test.go` (new), `pkg/ddns/README.md`
+
 ## 2026-08-22 — #6619 + #6564 member 8: VRF-enslaved iifname scope, and coverage vs existence
 
 - **Timestamp**: 2026-08-22

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -787,6 +787,46 @@ no change in those packages:
 | `NewProductionManager(parser, nodeID)` | `NewProductionDDNSManager(nodeID)` (wires `keaLeaseParser`) |
 | `NewManagerForTesting(...)` | `NewDDNSManagerForTesting(...)` (wires `keaLeaseParser`) |
 
+## Test fixture discipline — the in-process DNS server (#6709/#7009)
+
+`newFakeDNSServer` binds a real miekg/dns server on 127.0.0.1 for both UDP and
+TCP. Two properties of that fixture are load-bearing, and both were sources of a
+package-wide flake that failed ~7% of full-package runs (20% with six concurrent
+instances) on a DIFFERENT, randomly-chosen test each time.
+
+**One port, two namespaces — resample, never assume.** The server must answer on
+ONE host:port for both protocols, because the updater is configured with a
+single address and the truncation -> TCP-retry path has to reach the same
+server. UDP and TCP are INDEPENDENT port namespaces: a port the kernel hands out
+as a free UDP port says nothing about whether that number is free for TCP, where
+any other process on the host may hold it. Binding UDP once and asserting the
+TCP bind succeeds is therefore wrong, and failed with `bind: address already in
+use`.
+
+`listenDNSPair` draws a candidate port, tries to complete the pair, and DRAWS
+AGAIN on conflict (bounded by `dnsPairAttempts`). Each attempt uses a fresh
+port, so attempts are independent — this is not a retry against a contended
+port, which would convert a fast deterministic failure into a slow flaky one.
+`dnsPairAttempt` is an injectable seam so the resample is pinned by a
+deterministic test (`Test...ResamplesPastAConflictingPort_6709`) instead of by
+occupying a slice of the host's real ephemeral range, which would manufacture
+this very flake for every other test process on the box.
+
+**Process-global warn dedup must be reset by the test that asserts on it.**
+`unsignedUpdateWarned` (`backend_rfc2136.go`) dedups the #4483 unsigned-UPDATE
+warning per update server, keyed by host:port, and it is never reset for the
+life of the process. Ephemeral ports ARE recycled inside a single test binary
+(measured: ~1 reuse per 550 binds), so a test asserting on that warning could
+draw a port an EARLIER test had already warned for, observe zero warnings
+against an empty log, and fail — while passing in isolation.
+
+Any test that asserts on this warning must clear its own key first. The
+positive assertion seeds the poisoned state explicitly and then clears it, so
+dropping the reset fails every run rather than rarely. The NEGATIVE assertion
+("a TSIG-signed updater does not warn") clears it too: a stale key would silence
+the warning and make that test pass VACUOUSLY — green even if the TSIG gate
+regressed.
+
 ## Invariants preserved (do not weaken)
 
 - **Never delete a record xpf did not create** — the state store is the sole

--- a/pkg/ddns/backend_rfc2136_test.go
+++ b/pkg/ddns/backend_rfc2136_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/netip"
@@ -73,6 +74,56 @@ type fakeDNSServer struct {
 	tsig    map[string]string
 }
 
+// listenDNSPair returns a UDP PacketConn and a TCP Listener bound to the SAME
+// 127.0.0.1 ephemeral port, which is what a real DNS server looks like and what
+// the truncation→TCP-retry path needs to reach one address for both.
+//
+// UDP and TCP are independent port namespaces, so there is no portable way to
+// reserve a port number in both at once; the only sound approach is to draw a
+// candidate, try to complete the pair, and DRAW AGAIN on conflict (#6709).
+// Every attempt uses a fresh port, so attempts are independent rather than a
+// retry against a busy port.
+func listenDNSPair() (net.PacketConn, net.Listener, error) {
+	var lastErr error
+	for i := 0; i < dnsPairAttempts; i++ {
+		pc, l, err := dnsPairAttempt()
+		if err == nil {
+			return pc, l, nil
+		}
+		lastErr = err
+	}
+	return nil, nil, fmt.Errorf("no free udp+tcp port pair after %d attempts: %w", dnsPairAttempts, lastErr)
+}
+
+// dnsPairAttempts bounds the resample. Attempts are INDEPENDENT (each draws a
+// fresh port), so the residual failure probability is the per-attempt collision
+// rate raised to this power — at a measured ~0.2% that is ~1e-22.
+const dnsPairAttempts = 8
+
+// dnsPairAttempt draws ONE candidate ephemeral port and tries to complete the
+// UDP+TCP pair on it. It is indirected through a var so the resample loop can
+// be tested against a CONFLICTING candidate deterministically. The alternative
+// — occupying a large slice of the host's real ephemeral TCP range to force a
+// collision — would manufacture, for every other test process on this box,
+// exactly the flake #6709/#7009 exist to remove.
+var dnsPairAttempt = realDNSPairAttempt
+
+func realDNSPairAttempt() (net.PacketConn, net.Listener, error) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		return nil, nil, fmt.Errorf("udp listen: %w", err)
+	}
+	l, err := net.Listen("tcp", pc.LocalAddr().String())
+	if err != nil {
+		// That port number is taken on TCP by something else on the host.
+		// Release the UDP side so the next attempt draws a different port.
+		addr := pc.LocalAddr()
+		_ = pc.Close()
+		return nil, nil, fmt.Errorf("tcp listen on udp-assigned %s: %w", addr, err)
+	}
+	return pc, l, nil
+}
+
 func newFakeDNSServer(t *testing.T, tsig map[string]string) *fakeDNSServer {
 	t.Helper()
 	s := &fakeDNSServer{t: t, rcodeForZone: map[string]int{}, tsig: tsig}
@@ -82,18 +133,29 @@ func newFakeDNSServer(t *testing.T, tsig map[string]string) *fakeDNSServer {
 	// UPDATE opcode unless a handler is registered for the exact zone name).
 	handler := dns.HandlerFunc(s.handle)
 
-	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("udp listen: %v", err)
-	}
 	// Bind TCP on the SAME host:port the UDP socket got (UDP and TCP are
 	// independent port namespaces), so a client that retries-over-TCP against
 	// the single configured server address reaches this server's TCP listener
 	// too — mirroring a real DNS server (UDP+TCP on :53). This makes the
 	// truncation→TCP-retry path testable end to end.
-	l, err := net.Listen("tcp", pc.LocalAddr().String())
+	//
+	// #6709/#7009: because the two namespaces are independent, the kernel
+	// handing out a free UDP port says NOTHING about whether that port number
+	// is free for TCP — another process on the host (a second `go test`, of
+	// which this repo routinely runs a dozen) may hold it. Binding UDP once and
+	// then asserting the TCP bind succeeds therefore failed ~7% of full-package
+	// runs with "bind: address already in use", on a RANDOM test each time.
+	//
+	// RESAMPLE the pair rather than retrying a contended port. Each attempt
+	// draws a FRESH ephemeral port, so this is not the retry-on-EADDRINUSE loop
+	// #7009 rejects — that one re-attempts the SAME port and converts a fast
+	// deterministic failure into a slow flaky one. Redrawing makes attempts
+	// independent: at a measured ~0.2% per-attempt collision rate, 8 attempts
+	// leave a residual around 1e-22, and the loop still fails FAST and loudly
+	// if the host genuinely cannot supply a dual-stack port pair.
+	pc, l, err := listenDNSPair()
 	if err != nil {
-		t.Fatalf("tcp listen: %v", err)
+		t.Fatalf("listen udp+tcp pair: %v", err)
 	}
 	s.addrUDP = pc.LocalAddr().String()
 	s.addrTCP = l.Addr().String()
@@ -1074,6 +1136,21 @@ func TestRFC2136UnsignedUpdateWarnsOncePerProvider(t *testing.T) {
 			t.Fatalf("precondition: updater must have no TSIG key, got %q", u.tsigKeyName)
 		}
 
+		// #6709: unsignedUpdateWarned is a PROCESS-GLOBAL dedup keyed by server
+		// host:port, and ephemeral ports ARE recycled inside a single test
+		// binary (measured: ~1 reuse per 550 binds, so ~8% of full-package
+		// runs). If an earlier test warned for the port this server happens to
+		// draw, LoadOrStore reports "already warned", warnUnsignedOnce returns
+		// silently, and this assertion observes ZERO warns with an EMPTY log —
+		// the exact reported symptom, on a test that passes in isolation.
+		//
+		// SEED the poisoned state explicitly, then clear it. Seeding makes the
+		// hostile precondition deterministic instead of an ~8% lottery: without
+		// the Delete below this subtest fails EVERY run rather than rarely, so
+		// the reset is pinned by a mutation that reds reliably.
+		unsignedUpdateWarned.LoadOrStore(u.server, struct{}{})
+		unsignedUpdateWarned.Delete(u.server)
+
 		var buf bytes.Buffer
 		prev := slog.Default()
 		slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
@@ -1113,6 +1190,13 @@ func TestRFC2136UnsignedUpdateWarnsOncePerProvider(t *testing.T) {
 		if u.tsigKeyName == "" {
 			t.Fatal("precondition: updater must have a TSIG key")
 		}
+
+		// #6709: this is a NEGATIVE assertion, so a stale global dedup entry
+		// for this server's address would silence warnUnsignedOnce and make it
+		// pass VACUOUSLY — green even if the TSIG gate regressed and the signed
+		// path started warning. Clear the slot so the only reason no warn
+		// appears is the TSIG gate itself.
+		unsignedUpdateWarned.Delete(u.server)
 
 		var buf bytes.Buffer
 		prev := slog.Default()

--- a/pkg/ddns/fake_dns_portpair_6709_test.go
+++ b/pkg/ddns/fake_dns_portpair_6709_test.go
@@ -1,0 +1,85 @@
+package ddns
+
+// #6709/#7009 regression: the in-process fake DNS server binds UDP and TCP on
+// ONE ephemeral port, but UDP and TCP are independent port namespaces — a port
+// the kernel reports free for UDP may be held for TCP by any other process on
+// the host. Binding UDP once and asserting the TCP bind succeeds failed ~7% of
+// full-package runs (20% with six concurrent instances of this package) with
+// "bind: address already in use", on a DIFFERENT test each time.
+//
+// listenDNSPair RESAMPLES: each attempt draws a fresh port, so attempts are
+// independent. These tests pin that behaviour deterministically, without
+// occupying real host ports to force a collision.
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// TestListenDNSPairResamplesPastAConflictingPort_6709 is the fail-on-revert
+// proof for the resample loop: with the first attempts failing EADDRINUSE and a
+// later one succeeding, listenDNSPair must still return a usable pair. A
+// single-attempt implementation returns the first error instead.
+func TestListenDNSPairResamplesPastAConflictingPort_6709(t *testing.T) {
+	for _, conflicts := range []int{1, 3, dnsPairAttempts - 1} {
+		calls := 0
+		prev := dnsPairAttempt
+		dnsPairAttempt = func() (net.PacketConn, net.Listener, error) {
+			calls++
+			if calls <= conflicts {
+				return nil, nil, &net.OpError{Op: "listen", Net: "tcp", Err: syscall.EADDRINUSE}
+			}
+			return realDNSPairAttempt()
+		}
+		pc, l, err := listenDNSPair()
+		dnsPairAttempt = prev
+
+		if err != nil {
+			t.Fatalf("conflicts=%d: listenDNSPair must resample past a busy port, got %v", conflicts, err)
+		}
+		if calls != conflicts+1 {
+			t.Fatalf("conflicts=%d: want %d attempts, got %d", conflicts, conflicts+1, calls)
+		}
+		// The pair must be on ONE port — that is the whole point of pairing.
+		_, up, _ := net.SplitHostPort(pc.LocalAddr().String())
+		_, tp, _ := net.SplitHostPort(l.Addr().String())
+		if up != tp {
+			t.Fatalf("conflicts=%d: udp port %s != tcp port %s", conflicts, up, tp)
+		}
+		_ = pc.Close()
+		_ = l.Close()
+	}
+}
+
+// TestListenDNSPairGivesUpLoudly_6709 pins the other half: the loop is BOUNDED
+// and reports the underlying cause. A retry loop that spun forever would turn a
+// fast failure into a hang, which is the outcome #7009 warns against.
+func TestListenDNSPairGivesUpLoudly_6709(t *testing.T) {
+	calls := 0
+	sentinel := &net.OpError{Op: "listen", Net: "tcp", Err: syscall.EADDRINUSE}
+	prev := dnsPairAttempt
+	dnsPairAttempt = func() (net.PacketConn, net.Listener, error) {
+		calls++
+		return nil, nil, sentinel
+	}
+	pc, l, err := listenDNSPair()
+	dnsPairAttempt = prev
+
+	if err == nil {
+		_ = pc.Close()
+		_ = l.Close()
+		t.Fatal("listenDNSPair must fail when every attempt conflicts")
+	}
+	if calls != dnsPairAttempts {
+		t.Fatalf("want exactly %d bounded attempts, got %d", dnsPairAttempts, calls)
+	}
+	if !errors.Is(err, syscall.EADDRINUSE) {
+		t.Fatalf("the give-up error must carry the underlying cause, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "8 attempts") {
+		t.Fatalf("the give-up error must say how many attempts were made, got %v", err)
+	}
+}


### PR DESCRIPTION
`pkg/ddns` failed ~7% of full-package runs — 20% with six concurrent instances — on a **different randomly-chosen test each time**, and passed in isolation. Both mechanisms are test-local; **no production behaviour changes**, and this does not reach the Rust helper binary.

## Two distinct flakes, one shared root resource

They share the ephemeral port but need different fixes, so they are fixed separately rather than folded.

A third hypothesis was eliminated first: `slog.SetDefault` is process-global and a concurrent clobber produces the *identical* empty-log symptom. The package has **zero `t.Parallel()` calls**, so its tests run sequentially and `SetDefault` can never be clobbered — leaving sequential global-state carryover as the only candidate.

### (b) Port pairing — the dominant flake, and the same one as #7009

`newFakeDNSServer` must answer on ONE host:port for both UDP and TCP (the updater has a single configured address, and the truncation→TCP-retry path must reach the same server). It bound UDP on `:0` and then assumed that port number was also free for TCP. The namespaces are independent: a free UDP port says nothing about the TCP port of the same number, which any other process may hold — this repo routinely runs a dozen concurrent test binaries.

A standalone probe measured the UDP-assigned port already held for TCP host-wide at **1 per 552 binds** ≈ 8% per run across the 46 fake servers a run creates, matching the observed rate.

`listenDNSPair` now draws a candidate, tries to complete the pair, and **draws again** on conflict, bounded by `dnsPairAttempts`. Every attempt uses a fresh port, so attempts are independent — deliberately **not** the retry-against-a-contended-port loop #7009 rejects, which trades a fast deterministic failure for a slow flaky one. The single attempt sits behind the `dnsPairAttempt` seam so the resample is pinned deterministically, rather than by occupying a slice of the host's real ephemeral range — which would manufacture this very flake for every other test process on the box.

### (a) Warn dedup — a *separate* flake #7009 does not describe

`unsignedUpdateWarned` is a process-global `sync.Map` keyed by server `host:port`, never reset for the life of the process. Ephemeral ports **are** recycled within one test binary (same probe: 1 reuse per 552 binds), so the test asserting "exactly one unsigned-update WARN" could draw a port an earlier test had already warned for and observe zero warns against an empty log.

Established causally, not inferred: a probe that pre-poisons the key reproduces `warns=0 log=""` **byte-identically** to the report.

The positive assertion now seeds that poisoned state explicitly and then clears it, so dropping the reset fails **every** run instead of rarely. The sibling negative assertion clears the key too — a stale entry would silence the warning and let "a TSIG-signed updater does not warn" pass **vacuously**, green even if the TSIG gate regressed.

## Validation

Against #7009's own binder (the package passing while another instance runs concurrently):

| | sequential | 6 concurrent | 10 concurrent |
|---|---|---|---|
| before | 2/30 failed | **6/30 failed** | — |
| after | 0/30 | 0/30 | 0/60 |

120 clean post-fix runs against a measured 20% pre-fix rate; 0/24 re-confirmed at the merged head. Full package `-count=1`: **505 RUN, 505 PASS**. `go vet` and `go build` clean repo-wide.

### Mutation matrix

One line per mutation, rc read directly from `$?`, `go vet` clean at every mutated state, validated against the full package.

| mutation | vet | result |
|---|---|---|
| drop the dedup reset (mechanism a) | 0 | **RED** — `want exactly one unsigned-update WARN ..., got 0; log=""`, the exact reported message |
| resample loop → single attempt | 0 | **RED** — `must resample past a busy port` |
| attempts bound 8 → 3 | 0 | **RED** — same assertion at `conflicts=3` |
| bypass the seam (pre-fix shape) | 0 | **RED** — `want 2 attempts, got 0` |
| drop the negative subtest's vacuity guard | 0 | GREEN — see below |

The last is a **finding, not a gap**: the guard is kept as defence in depth. A separate cell that makes the TSIG-signed path warn shows that subtest *does* detect a real regression, so the guard removes a ~8%/run blind spot rather than decorating one.

An earlier `-run` filter in the harness was `_6709\$` — a literal `$` matching nothing — which returned rc=0 with **zero tests run**. Caught by counting `=== RUN` lines; the matrix above was re-run with a working filter and a printed RUN count.

## One test deleted rather than shipped

A third test written during this work re-implemented `realDNSPairAttempt` instead of calling it. Deleting that function's `pc.Close()` left it **green with vet clean**, so it certified nothing. Removed. The fd-release on the conflict branch is consequently unpinned by any test — stated rather than papered over, since driving that branch requires controlling which port the kernel hands out.

## Docs

`pkg/ddns/README.md` gains a "Test fixture discipline" section covering both invariants; `_Log.md` entry added (union-resolved against `origin/master` with a structural entry count: 1834 + 1 = 1835).

Closes #6709

## Independent corroboration — #7331 (closed into #6709)

#7331 reached the same conclusion from the other direction, on an **untouched base commit** (`73b2ce98d`), which is what rules out "some branch broke it": **5 runs, 1 red / 4 green**, with the failing test *moving between runs*.

| where | test that failed | mechanism here |
|---|---|---|
| untouched base `73b2ce98d` | `TestPartialDualStackTeardownKeepsSharedDHCID` | (b) port pairing |
| worktree, unrelated changes | `TestRFC2136UnsignedUpdateWarnsOncePerProvider` | **(a) warn dedup** |
| worktree, unrelated changes | `TestManagerPTRNotAuthCountedNotFailed` | (b) port pairing |

A flake that moves between tests points at shared state rather than one bad test — that observation and the mechanisms measured here are two independent routes to the same answer.

Every test #7331 names is accounted for: both (b) cases call `newFakeDNSServer` (verified — `spine_fixes_test.go` and `manager_inc2_test.go` both use it), and the third is the warn-dedup assertion.

**This also answers #7331's three open questions:**

- *"whether it is the #7009 port-bind race widened, or independent"* — **both.** #7009's mechanism is wider than #7009 records: it reaches all **46** `newFakeDNSServer` call sites across five files, not only the tests listed there. And there is a **second, independent** mechanism (a) that produces no bind error at all.
- *"whether it is order-dependent"* — mechanism (a) is, strictly: it requires an earlier test in the same binary to have warned for a recycled port. Mechanism (b) is not order-dependent; it races against other processes on the host.
- *"whether `-count=1` vs a warm cache changes the rate"* — no. All measurements here used a precompiled test binary run directly, which bypasses the result cache entirely.

**One correction to #7331.** It attributes an earlier `surface_a_rfc2136_test.go:259: bind: address already in use` to "a hardcoded-port listener race". That line is `newFakeDNSServer(t, nil)`, not a hardcoded port, and a sweep finds **zero** hardcoded ports in the package's tests — every listener already binds `:0`. So #7009's fallback advice ("where a fixed port is genuinely required, serialise those cases") has nothing to apply to; the whole defect was the UDP→TCP pairing assumption.
