### PR TITLE
test/incus: make the failover smoke name which failure it hit (#7368)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,27 @@
+## 2026-08-22 — #7368 failover smoke names which failure it hit
+
+- **Timestamp**: 2026-08-22
+- **Action**: Cross-referenced the two independent checks
+  `test-failover.sh` already performed. Primacy is read from a
+  self-reported field; the session count is a real measurement; they
+  were never compared, so #6656's ownership divergence surfaced as a
+  session-count shortfall blamed on the change under test. Added the
+  pure, selftested `failover_ownership_verdict` (ok / diverged /
+  nostream) and split the exit codes: `FATAL[PRECONDITION]` 2,
+  `FATAL[DIVERGENCE]` 3. Replaced the preflight's unscoped
+  `grep -q "node0.*primary"` with the per-RG
+  `deploy_reassert_node0_primary_ok` from #6591 — measured: `secondary`
+  does NOT contain `primary`, so the grep was not loose in the way it
+  looks; it was UNSCOPED, and accepted node0 secondary for RG0 while
+  primary for RG1.
+  Mutation matrix 6/6 RED after fixing the wiring cells: V4 and V6 were
+  GREEN because my wiring greps matched the COMMENTS that mention the
+  function names — the guard was reading its own documentation. Now
+  strips whole-line comments first.
+  NOT run on the cluster (shared; lead serializes).
+- **File(s)**: test/incus/test-failover.sh, test/incus/deploy-lib.sh,
+  test/incus/deploy-lib-selftest.sh, docs/testing.md
+
 ## 2026-08-22 — #6587 prefix-length validators + provenance-aware RA floor
 
 - **Timestamp**: 2026-08-22

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -536,6 +536,35 @@ The logic lives in `deploy-lib.sh` (`deploy_reassert_primary_node0`,
 `deploy_reassert_node0_primary_ok`) so `make test-deploy-lib` covers it against
 a mocked incus — no cluster required.
 
+**The failover smoke names WHICH failure it hit (#7368).**
+`test-failover.sh` used one exit code (2) for three different outcomes, so
+`FO_RC=2` was read as "failover broke" when it meant "the cluster was never in
+a testable state". The three are now distinct:
+
+| outcome | signal |
+|---|---|
+| precondition not met | `FATAL[PRECONDITION]`, exit 2 |
+| ownership and forwarding disagree | `FATAL[DIVERGENCE]`, exit 3 |
+| a real assertion failed | the usual `FAIL` tally, exit 1 |
+
+Two changes make that possible. The preflight primacy check now uses
+`deploy_reassert_node0_primary_ok` — the same per-RG predicate the deploy
+reassert uses — instead of `grep -q "node0.*primary"` over the whole status
+output. Measured: `secondary` contains no `primary` substring, so that grep
+was not wrong in the way it looks; it was **unscoped**, so a cluster with
+node0 SECONDARY for RG0 and primary for RG1 satisfied it.
+
+And the session assertion now cross-references the two independent checks the
+script already performed. Primacy is read from a field the node reports about
+ITSELF; the session count is a real measurement; they were never compared. In
+#6656 that meant a genuine ownership divergence (node0 primary with 1 session,
+node1 carrying 33) surfaced as a session-count shortfall and was attributed to
+the change under test. The peer count is read on the shortfall path only, and
+`failover_ownership_verdict` (pure, in `deploy-lib.sh`, selftested) decides
+between `diverged` and `nostream`. "The peer has sessions" is deliberately NOT
+the discriminator — session sync means the peer legitimately holds some, so the
+peer must be above `MIN_SESSIONS` while the reported primary is below it.
+
 ### VRRP State Verification
 ```bash
 # Both nodes should agree: fw0=MASTER, fw1=BACKUP for all groups

--- a/test/incus/deploy-lib-selftest.sh
+++ b/test/incus/deploy-lib-selftest.sh
@@ -867,6 +867,126 @@ test_reassert_is_wired_into_both_deploy_paths() {
 	ok "wiring: reassert routed through the lib at :$lib and called from $n deploy paths"
 }
 
+# ── #7368 ownership-vs-forwarding cross-reference ────────────────────
+# test-failover.sh asserted primacy with a grep over `show chassis cluster
+# status` — a field the node reports about ITSELF — and separately asserted
+# that the same node carries sessions, which is a real measurement. The two
+# were never compared.
+#
+# #6656 is what that costs: node0 reported primary for every RG with 1 session
+# while node1 carried 33. The session assertion DID fail, but reported a
+# session-count shortfall, so the run read as "the streams did not establish"
+# — attributed to whatever change was under test — when the actual failure was
+# that ownership and forwarding disagreed.
+#
+# So the property is not "add an oracle"; the oracle was already there. It is
+# "decide WHICH failure this is, and say so distinctly".
+
+test_ownership_verdict_ok() {
+	local got; got=$(failover_ownership_verdict 25 24 4)
+	if [[ "$got" == "ok" ]]; then
+		ok "ownership: primary carries the traffic -> ok"
+	else
+		bad "ownership: healthy run -> expected 'ok', got '$got'"
+	fi
+}
+
+test_ownership_verdict_diverged() {
+	# The #6656 shape exactly.
+	local got; got=$(failover_ownership_verdict 1 33 4)
+	if [[ "$got" == "diverged" ]]; then
+		ok "ownership: reported-primary carries 1, peer carries 33 -> diverged"
+	else
+		bad "ownership: the #6656 divergence -> expected 'diverged', got '$got' (it would be reported as a session-count shortfall and blamed on the change under test)"
+	fi
+}
+
+test_ownership_verdict_nostream() {
+	# Neither node carries traffic: a real establishment failure, and a
+	# DIFFERENT bug with a different fix. Reporting it as a divergence would
+	# be the same conflation in the other direction.
+	local got; got=$(failover_ownership_verdict 0 0 4)
+	if [[ "$got" == "nostream" ]]; then
+		ok "ownership: neither node carries traffic -> nostream (not a divergence)"
+	else
+		bad "ownership: no traffic anywhere -> expected 'nostream', got '$got'"
+	fi
+}
+
+test_ownership_verdict_boundary_is_inclusive() {
+	# Exactly at the minimum is HEALTHY. An exclusive boundary would report a
+	# cluster meeting the documented threshold as diverged.
+	local got; got=$(failover_ownership_verdict 4 4 4)
+	if [[ "$got" == "ok" ]]; then
+		ok "ownership: primary exactly at MIN_SESSIONS -> ok (inclusive)"
+	else
+		bad "ownership: primary at the minimum -> expected 'ok', got '$got'"
+	fi
+}
+
+test_ownership_verdict_peer_below_min_is_not_divergence() {
+	# The peer carrying a FEW synced sessions while the primary carries none is
+	# still an establishment failure — session sync means the peer legitimately
+	# holds sessions, so "peer has some" cannot be the discriminator.
+	local got; got=$(failover_ownership_verdict 0 2 4)
+	if [[ "$got" == "nostream" ]]; then
+		ok "ownership: peer below the minimum -> nostream, not diverged"
+	else
+		bad "ownership: peer with 2 sessions -> expected 'nostream', got '$got' (session sync means the peer always holds some; 'peer has any' is not a divergence signal)"
+	fi
+}
+
+# The WIRING. Every cell above calls the verdict directly, so all of them stay
+# green if test-failover.sh stops consulting it — and the script is the only
+# caller. Also asserts the three failure paths carry DISTINCT exit codes: a
+# gate that exits 2 for a precondition abort, a failover regression AND a
+# divergence teaches people to re-run it instead of reading it.
+test_failover_script_wires_the_crossref() {
+	local f="${SCRIPT_DIR}/test-failover.sh"
+	local missing=() code
+	# CODE ONLY. A first version grepped the raw file and both wiring cells
+	# stayed GREEN under mutation, because the names it searched for also
+	# appear in the COMMENTS explaining them — the guard was reading its own
+	# documentation. Strip whole-line comments before matching.
+	code=$(grep -v '^[[:space:]]*#' "$f")
+	grep -q 'failover_ownership_verdict' <<<"$code" || missing+=("failover_ownership_verdict call")
+	grep -q 'deploy_reassert_node0_primary_ok' <<<"$code" || missing+=("per-RG primacy predicate")
+	grep -q 'die_divergence' <<<"$code" || missing+=("die_divergence")
+	grep -q 'exit 3' <<<"$code" || missing+=("distinct divergence exit code")
+	grep -q 'source .*deploy-lib.sh' <<<"$code" || missing+=("deploy-lib.sh source")
+	if (( ${#missing[@]} == 0 )); then
+		ok "wiring: test-failover.sh sources the lib, uses the per-RG predicate, cross-references, and exits distinctly"
+	else
+		bad "wiring: test-failover.sh is missing: ${missing[*]} — the verdict is selftested but nothing calls it (#7368)"
+	fi
+}
+
+# The primacy predicate must be SCOPED per redundancy group. The retired grep
+# was `node0.*primary` over the whole status output: `secondary` does not
+# contain `primary`, so that part was sound, but the match is not scoped to an
+# RG — a cluster with node0 SECONDARY for RG0 and primary for RG1 satisfied it.
+test_primacy_predicate_is_scoped_per_rg() {
+	local mixed="Redundancy group: 0 , Failover count: 0
+node0   200       secondary      no       no       None
+node1   100       primary        no       no       None
+
+Redundancy group: 1 , Failover count: 0
+node0   200       primary        no       no       None
+node1   100       secondary      no       no       None
+"
+	if printf '%s' "$mixed" | grep -q "node0.*primary"; then
+		: # the retired grep DOES match this -- that is the point
+	else
+		bad "primacy: fixture no longer reproduces the retired grep's false accept"
+		return
+	fi
+	if printf '%s' "$mixed" | deploy_reassert_node0_primary_ok; then
+		bad "primacy: node0 is SECONDARY for RG0 and the predicate accepted it — the preflight would run a failover test against a cluster that is not in the asserted state (#7368)"
+	else
+		ok "primacy: node0 secondary for RG0 -> rejected (the retired whole-output grep accepted it)"
+	fi
+}
+
 # ── Run ───────────────────────────────────────────────────────────────
 test_rolling_secondary_node0_primary
 test_rolling_secondary_node0_secondary
@@ -896,6 +1016,13 @@ test_reassert_dies_when_role_not_achieved
 test_reassert_issues_reset_transfer_reset_per_rg
 test_reassert_transfer_rc_is_not_the_verdict
 test_reassert_is_wired_into_both_deploy_paths
+test_ownership_verdict_ok
+test_ownership_verdict_diverged
+test_ownership_verdict_nostream
+test_ownership_verdict_boundary_is_inclusive
+test_ownership_verdict_peer_below_min_is_not_divergence
+test_failover_script_wires_the_crossref
+test_primacy_predicate_is_scoped_per_rg
 test_preflight_pass_proceeds
 test_preflight_reject_hardfails
 test_preflight_reject_touches_nothing

--- a/test/incus/deploy-lib.sh
+++ b/test/incus/deploy-lib.sh
@@ -254,6 +254,41 @@ deploy_reassert_node0_primary_ok() {
 	'
 }
 
+# failover_ownership_verdict cross-references the two independent checks
+# test-failover.sh already performs, and is the #7368 half of the #6591 fix.
+#
+# The smoke asserts primacy by reading `show chassis cluster status` — a field
+# the node reports about ITSELF — and separately asserts that the same node
+# carries established sessions, which is a real measurement. The two are never
+# compared. #6656 showed what that costs: node0 reported primary for every RG
+# with 1 session while node1 carried 33, and the smoke's session assertion
+# caught it only INCIDENTALLY, reporting a session-count shortfall on a run
+# whose actual failure was ownership/forwarding divergence.
+#
+# Arguments: sessions on the node REPORTED primary, sessions on its peer, and
+# the minimum a healthy primary must carry. Echoes one of:
+#
+#   ok        the reported primary carries the traffic
+#   diverged  the reported primary carries almost nothing while the PEER does
+#             — ownership and forwarding disagree
+#   nostream  neither node carries traffic — the iperf streams did not
+#             establish, which is a different failure with a different fix
+#
+# Split out here so deploy-lib-selftest.sh can drive every combination without
+# a cluster; the caller only formats the message.
+failover_ownership_verdict() {
+	local primary_sessions="$1" peer_sessions="$2" min_sessions="$3"
+	if [[ "$primary_sessions" -ge "$min_sessions" ]]; then
+		printf 'ok\n'
+		return 0
+	fi
+	if [[ "$peer_sessions" -ge "$min_sessions" ]]; then
+		printf 'diverged\n'
+		return 0
+	fi
+	printf 'nostream\n'
+}
+
 # Bounded retries for the two reads. Overridable so the self-test does not
 # sleep. The status read needs them because the daemon is still coming up right
 # after a deploy: the measured failure was a reassert issued ~20s post-deploy

--- a/test/incus/test-failover.sh
+++ b/test/incus/test-failover.sh
@@ -32,6 +32,11 @@ xpf_enter_destructive_cluster_cell "test-failover $*" "$0" "$@"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=test/incus/cluster-env.sh
 source "${SCRIPT_DIR}/cluster-env.sh"
+# #7368: deploy_reassert_node0_primary_ok (the per-RG primacy predicate #6591
+# added) and failover_ownership_verdict, both covered by
+# `make test-deploy-lib` against a mocked incus.
+# shellcheck source=test/incus/deploy-lib.sh
+source "${SCRIPT_DIR}/deploy-lib.sh"
 
 IPERF_TARGET="${IPERF_TARGET:-$IPERF_TARGET4}"
 IPERF_DURATION=120      # seconds — long enough to span retries + reboot + failback
@@ -50,6 +55,12 @@ pass()  { echo "  PASS  $*"; PASS=$((PASS + 1)); }
 fail()  { echo "  FAIL  $*"; FAIL=$((FAIL + 1)); ERRORS+=("$*"); }
 
 die() { echo "FATAL: $*" >&2; exit 2; }
+# #7368: a PRECONDITION failure is not a failover regression, and neither is an
+# ownership/forwarding divergence. All three used to exit 2, so `FO_RC=2` was
+# read as "failover broke" when it meant "the cluster was not in a state to
+# test" — twice, on the shared gate, against changes that were not at fault.
+die_precondition() { echo "FATAL[PRECONDITION]: $*" >&2; exit 2; }
+die_divergence()   { echo "FATAL[DIVERGENCE]: $*" >&2; exit 3; }
 
 instance_running() {
 	local status
@@ -85,12 +96,22 @@ for rg in 0 1 2; do
 done
 sleep 2
 
-# Verify fw0 is primary
+# Verify fw0 is primary for EVERY redundancy group.
+#
+# #7368: this was `grep -q "node0.*primary"` over the whole status output.
+# `secondary` does not contain `primary`, so that part was sound — but the grep
+# is not scoped to a redundancy group, so a cluster with node0 SECONDARY for
+# RG0 and primary for RG1 satisfied it. The reassert makes node0 primary for
+# all RGs, and the post-failover phase below already asserts all three, so the
+# precondition should be the same shape. deploy_reassert_node0_primary_ok is
+# the predicate #6591 added and `make test-deploy-lib` covers; reusing it keeps
+# one definition of "node0 is primary" rather than a second grep that can drift.
 fw0_status=$(incus exec "$FW0" -- cli -c 'show chassis cluster status' 2>/dev/null)
-if echo "$fw0_status" | grep -q "node0.*primary"; then
-	pass "fw0 is primary"
+if printf '%s\n' "$fw0_status" | deploy_reassert_node0_primary_ok; then
+	pass "fw0 is primary for every redundancy group"
 else
-	die "fw0 is not primary — cannot run failover test"
+	die_precondition "fw0 is not primary for every redundancy group — cannot run the failover test. This is a PRECONDITION failure, NOT a failover regression: the cluster was not in a testable state before the change under test ran. Check the post-deploy reassert (#6591) and re-read the state directly:
+$fw0_status"
 fi
 
 # Verify iperf target reachable
@@ -180,10 +201,33 @@ for _ in $(seq 1 20); do
 	[[ "$fw0_sessions" -ge "$MIN_SESSIONS" ]] && break
 	sleep 0.5
 done
+# #7368: cross-reference the two independent checks this script already
+# performs before deciding WHICH failure this is.
+#
+# Primacy is read from `show chassis cluster status` — a field the node reports
+# about itself, with no oracle. The session count is a real measurement. They
+# were never compared, so #6656's divergence (node0 primary with 1 session,
+# node1 carrying 33) surfaced here as "streams did not establish" — a shortfall
+# attributed to whatever change was under test, when the actual failure was
+# that ownership and forwarding disagreed.
+#
+# The peer count is read ONLY on the shortfall path, so the healthy run pays
+# nothing. failover_ownership_verdict is pure and selftested.
 if [[ "$fw0_sessions" -ge "$MIN_SESSIONS" ]]; then
 	pass "fw0 has $fw0_sessions established sessions"
 else
-	fail "fw0 has only $fw0_sessions established sessions (expected >= $MIN_SESSIONS)"
+	fw1_probe=$(incus exec "$FW1" -- cli -c \
+		"show security flow session destination-prefix ${IPERF_TARGET}" 2>/dev/null | grep -c "Session State: Valid" || true)
+	case "$(failover_ownership_verdict "$fw0_sessions" "$fw1_probe" "$MIN_SESSIONS")" in
+	diverged)
+		die_divergence "OWNERSHIP AND FORWARDING DISAGREE. fw0 reports PRIMARY for every redundancy group but carries only $fw0_sessions session(s), while fw1 — reported secondary — carries $fw1_probe. The cluster-state field and the traffic disagree, so neither 'failover is broken' nor 'the streams did not establish' is the right reading; see #6656. Read both nodes directly before re-running:
+  incus exec $FW0 -- cli -c 'show chassis cluster status'
+  incus exec $FW1 -- cli -c 'show chassis cluster status'"
+		;;
+	*)
+		fail "fw0 has only $fw0_sessions established sessions (expected >= $MIN_SESSIONS); fw1 carries $fw1_probe, so this is an establishment failure rather than an ownership/forwarding divergence"
+		;;
+	esac
 fi
 
 # ── Phase 2: Wait for session sync ──────────────────────────────────


### PR DESCRIPTION
Closes #7368

## Problem

`test-failover.sh` asserted primacy by grepping `show chassis cluster status` — a field the node reports **about itself**, with no oracle — and separately asserted that the same node carries established sessions, which is a real measurement. **The two were never compared.**

#6656 is what that costs. node0 reported PRIMARY for every redundancy group while carrying **1 session**; node1 carried **33**. The session assertion *did* fail — but it reported a session-count shortfall, so the run read as "the iperf streams did not establish" and was attributed to whatever change was under test. The oracle was already present; what was missing was deciding **which** failure this is.

And the gate used **one exit code for three outcomes**. `FO_RC=2` meant a precondition abort, a failover regression, *or* a divergence — so it was twice read as "failover broke" when the cluster had simply never been in a testable state. A gate that fails three ways under one code teaches people to re-run it instead of reading it.

| outcome | signal |
|---|---|
| precondition not met | `FATAL[PRECONDITION]`, exit 2 |
| ownership and forwarding disagree | `FATAL[DIVERGENCE]`, exit 3 |
| a real assertion failed | the usual `FAIL` tally, exit 1 |

## A measured correction to the concern as filed

The preflight grep was `node0.*primary`, and the worry was that it also matches a `secondary` row. **It does not** — `secondary` contains no `primary` substring, checked rather than assumed.

The real defect is that the grep is **not scoped to a redundancy group**: a cluster with node0 SECONDARY for RG0 and primary for RG1 satisfies it. A self-test fixture now reproduces exactly that false accept. It is replaced with `deploy_reassert_node0_primary_ok` — the per-RG predicate #6591 added — so there is **one** definition of "node0 is primary" rather than a second grep that can drift from it.

## The cross-reference

Read on the **shortfall path only**, so a healthy run pays nothing.

**"The peer has sessions" is deliberately not the discriminator.** Session sync means the peer legitimately holds some, so the peer must be above `MIN_SESSIONS` while the reported primary is below it. A cell pins that: a peer with 2 synced sessions and a primary with 0 is an *establishment* failure, not a divergence — calling it one would be the same conflation in the other direction.

The verdict is a pure function in `deploy-lib.sh`, so `make test-deploy-lib` drives every combination against a mocked incus.

## Validation

`bash -n` clean on all three scripts. `make test-deploy-lib` → **44 passed, 0 failed**. **Not run against the cluster** — it is shared and serialized centrally.

### Mutation matrix

| cell | mutation | result |
|---|---|---|
| V1 | verdict never reports divergence (the shipped behaviour) | #6656-shape cell RED |
| V2 | **any** peer session reads as divergence | synced-peer cell RED |
| V3 | exclusive boundary at `MIN_SESSIONS` | at-minimum cell RED |
| V4 | script stops cross-referencing | wiring cell RED |
| V5 | divergence shares the preflight exit code again | wiring cell RED |
| V6 | preflight reverts to the unscoped grep | wiring cell RED |

**V4 and V6 were green on the first run, for one cause worth naming:** the wiring cell grepped the **raw file** for the function names, and those names also appear in the **comments** explaining them. The guard was reading its own documentation and could not see the call disappear. It now strips whole-line comments before matching. That is the third time this campaign a guard has matched prose rather than code.

## Note on the follow-up commit

The docs hunk is a second commit because its anchor is #6591's paragraph, which was not in this worktree's base and only arrived with the `origin/master` merge. The edit asserted on the anchor rather than appending blindly, so it failed loudly instead of landing in the wrong place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAsT5gCGP7k2vhdZ1sDuRi