### PR TITLE
api: authorize the REST read surface per principal (#6660)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -102485,3 +102485,18 @@ prose edit above them added. No diff falls in the new test body.
     controlLinkAuthKey now REDs). Residual closed: readLoop's CALL to admitFrame
     was still unbound — severing it left every 5086 test green.
   - **File(s)**: pkg/cluster/heartbeat_replay_restart_5086_test.go
+
+## 2026-08-22 — #6660 REST read-surface authorization
+- **Timestamp**: 2026-08-22
+- **Action**: #5561 gated the 19 mutating REST routes and scoped reads out, so
+  any local uid could GET the full running configuration unidentified. Measured
+  what is actually disclosed before designing: the compiled *config.Config is
+  json-encoded, so #2053's Secret marshaller applies and NO secret is rendered
+  in cleartext — this is configuration/topology disclosure, not credential
+  disclosure. Added restReadPermissions (every /api/v1 GET -> PermView) and
+  readAuthz, reusing #5561's machinery. /health + /metrics stay open (harness
+  consumers; swept every in-tree consumer and found nothing else on REST).
+  Safe because PrincipalForUID returns superuser for uid 0 unconditionally, so
+  root-run tooling on a box with no login model is unaffected.
+- **File(s)**: pkg/api/authz.go, pkg/api/read_authz_6660_test.go (new),
+  pkg/api/config_authz_5561_test.go, pkg/api/README.md, _Log.md

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -333,10 +333,10 @@ liveness/readiness. Prometheus metrics endpoint. SSE event streams.
   fidelity for cross-system correlation; the CLI keeps human-friendly
   whole-second output.
 
-## Server-side authorization (#5561)
+## Server-side authorization (#5561, reads #6660)
 
-Every state-changing route is gated on a **server-derived principal** before it
-reaches its handler. `authz.go` owns the route table and the middleware; the
+Every route under `/api/v1` — state-changing **and** read — is gated on a
+**server-derived principal** before it reaches its handler. `authz.go` owns the route table and the middleware; the
 decision itself lives in `pkg/authz` so the gRPC surface reaches the same
 verdict. That gRPC leg has since landed (#5278) — see
 [`pkg/grpcapi/README.md`](../grpcapi/README.md) "Server-side authorization",
@@ -346,6 +346,53 @@ inline (grpc-go calls its accept hook off the accept loop, `http.Server` does
 not), and prices the multiplexed `SystemAction` verb-by-verb because a unary
 interceptor is handed the decoded request that this middleware deliberately
 never reads.
+
+### The read surface (#6660)
+
+#5561 gated the 19 mutating routes and deliberately scoped reads out. That left
+every read route open: any local process could `GET /api/v1/config` without
+being identified, and no login-class permission was consulted. #6660 closes it —
+`restReadPermissions` + `readAuthz`, reusing #5561's identification machinery
+unchanged.
+
+**What was actually disclosed, measured rather than assumed.** `GET
+/api/v1/config` json-encodes the COMPILED `*config.Config`, so #2053's
+`config.Secret` marshaller applies and **no operator secret is rendered in
+cleartext** — verified by marshalling a populated `ControlLinkAuthKey` and
+checking the output. So this was **not** credential disclosure. What it was is
+full CONFIGURATION disclosure: zones, policies, NAT rules, interface addressing,
+routing neighbours — a complete map of the firewall, to any local uid, including
+one with no `system login user` entry at all. On a firewall that is
+reconnaissance.
+
+**Every route is `PermView`**, not a per-route tier. These are all `show`
+verbs, and Junos gates `show` on `view`; inventing finer tiers here would be a
+policy the CLI's own table does not have, and the two would drift. The finer
+question — whether a read should be REDACTED by class rather than denied — is a
+different contract and is left open.
+
+**Why this is not a no-brick problem.** `PrincipalForUID` returns a **superuser**
+principal for uid 0 unconditionally, with no login model required, so root-run
+monitoring and support tooling on a box that never adopted RBAC keeps working
+byte-for-byte. What changes is a NON-root local uid outside the login model —
+exactly the population the issue exists to stop.
+
+**`/health` and `/metrics` stay open** and are not in the table. They carry no
+configuration, `authCheck` already exempts them, and the in-tree incus harnesses
+read `/metrics`. A sweep of every in-tree consumer found those two and nothing
+else touching REST at all, so gating `/api/v1` breaks no shipped tooling.
+
+`readAuthz` serves an UNGUARDED safe route rather than refusing it — the
+opposite of the mutation gate's fail-closed default — precisely so those two
+keep working. The cost is that a NEW read route added without a table entry
+would serve unauthenticated, so `TestEveryReadRouteHasAPermission_6660`
+enumerates the routes `server.go` actually registers and fails on any `/api/v1`
+GET the table does not cover, moving that risk from runtime to the suite.
+
+It adjudicates ONCE, where the mutation gate adjudicates twice. That is a
+difference rather than an omission: the mutation gate drains the body between
+its two passes because a caller owns its body and can hold an authorization open
+for the whole read timeout. A GET has no body to withhold.
 
 **Why the loopback bind was not enough.** The daemon provisions every `system
 login user` a real shell account (`useradd -m -s /bin/bash`), and the CLI's RBAC

--- a/pkg/api/authz.go
+++ b/pkg/api/authz.go
@@ -71,6 +71,89 @@ import (
 // and splitting enforcement between the middleware and the handler to recover
 // that one verb would put half the authorization decision somewhere a future
 // route could forget to make.
+// restReadPermissions is the authorization policy for the SAFE (read) routes
+// under /api/v1 (#6660).
+//
+// #5561 authorized the 19 MUTATING routes and deliberately scoped reads out.
+// The read surface stayed open: any local process could GET /api/v1/config and
+// the rest without being identified, and no login-class permission was
+// consulted.
+//
+// WHAT IS AND IS NOT DISCLOSED, measured rather than assumed. GET
+// /api/v1/config json-encodes the COMPILED *config.Config, so #2053's
+// config.Secret marshaller applies and no operator secret is rendered in
+// cleartext -- verified by marshalling a populated ControlLinkAuthKey and
+// checking the output. So this is NOT credential disclosure. What it is, is
+// full CONFIGURATION disclosure: zones, policies, NAT rules, interface
+// addressing, routing neighbours -- a complete map of the firewall, to any
+// local uid, including one with no `system login user` entry at all. On a
+// firewall that is reconnaissance, which is why every one of these routes is a
+// `show`-equivalent and Junos gates `show` on `view`.
+//
+// EVERY ROUTE IS PermView, deliberately, rather than a per-route tier. These
+// are all show verbs; inventing finer tiers here would be a policy the CLI's
+// own table does not have, and the two would drift. The finer question the
+// issue raises -- whether a read should be REDACTED by class rather than
+// denied -- is a different contract and is left open.
+//
+// /health and /metrics are NOT here and stay open. They carry no configuration,
+// authCheck already exempts them, and the in-tree harnesses read /metrics
+// (test/incus/*.sh) -- a sweep of every in-tree consumer found those two and
+// nothing else touching REST at all, so gating the /api/v1 surface breaks no
+// shipped tooling.
+//
+// WHY THIS IS NOT A NO-BRICK PROBLEM. PrincipalForUID returns a SUPERUSER
+// principal for uid 0 unconditionally, with no login model required, so
+// root-run monitoring and support tooling on a box that never adopted RBAC
+// keeps working byte-for-byte. What changes is a NON-root local uid outside the
+// login model -- which is exactly the population this issue exists to stop
+// reading the configuration.
+var restReadPermissions = map[string]config.LoginClassPermission{
+	// Configuration reads. The disclosure this issue is about.
+	"GET /api/v1/config":               config.PermView,
+	"GET /api/v1/config/compare":       config.PermView,
+	"GET /api/v1/config/export":        config.PermView,
+	"GET /api/v1/config/history":       config.PermView,
+	"GET /api/v1/config/search":        config.PermView,
+	"GET /api/v1/config/show":          config.PermView,
+	"GET /api/v1/config/show-rollback": config.PermView,
+	"GET /api/v1/config/status":        config.PermView,
+	"GET /api/v1/show-text":            config.PermView,
+
+	// Operational state.
+	"GET /api/v1/status":                               config.PermView,
+	"GET /api/v1/system/info":                          config.PermView,
+	"GET /api/v1/system/buffers":                       config.PermView,
+	"GET /api/v1/interfaces":                           config.PermView,
+	"GET /api/v1/interfaces/detail":                    config.PermView,
+	"GET /api/v1/routes":                               config.PermView,
+	"GET /api/v1/routing/bgp":                          config.PermView,
+	"GET /api/v1/routing/ospf":                         config.PermView,
+	"GET /api/v1/dhcp/identifiers":                     config.PermView,
+	"GET /api/v1/dhcp/leases":                          config.PermView,
+	"GET /api/v1/events/stream":                        config.PermView,
+	"GET /api/v1/logs/stream":                          config.PermView,
+	"GET /api/v1/statistics/global":                    config.PermView,
+	"GET /api/v1/statistics/interfaces":                config.PermView,
+	"GET /api/v1/statistics/zones":                     config.PermView,
+	"GET /api/v1/services/flow-exporters":              config.PermView,
+	"GET /api/v1/security/events":                      config.PermView,
+	"GET /api/v1/security/ipsec/sa":                    config.PermView,
+	"GET /api/v1/security/match":                       config.PermView,
+	"GET /api/v1/security/nat/destination":             config.PermView,
+	"GET /api/v1/security/nat/deterministic":           config.PermView,
+	"GET /api/v1/security/nat/pools":                   config.PermView,
+	"GET /api/v1/security/nat/rules":                   config.PermView,
+	"GET /api/v1/security/nat/source":                  config.PermView,
+	"GET /api/v1/security/policies":                    config.PermView,
+	"GET /api/v1/security/screen":                      config.PermView,
+	"GET /api/v1/security/sessions":                    config.PermView,
+	"GET /api/v1/security/sessions/summary":            config.PermView,
+	"GET /api/v1/security/sessions/summary/zone-pairs": config.PermView,
+	"GET /api/v1/security/vrrp":                        config.PermView,
+	"GET /api/v1/security/zones":                       config.PermView,
+}
+
 var restMutationPermissions = map[string]config.LoginClassPermission{
 	// Operational clear verbs.
 	"POST /api/v1/security/sessions/clear": config.PermClear,
@@ -758,10 +841,52 @@ func credentialPrincipalUser(cfg AuthConfig, r *http.Request) (string, bool) {
 
 // mutationAuthzGuard rejects a state-changing request whose caller the server
 // cannot authorize (#5561). Safe methods pass through untouched.
+// readAuthz adjudicates a SAFE (read) request against restReadPermissions
+// (#6660) and either serves it or refuses it.
+//
+// It is deliberately SIMPLER than the mutation path above, and the difference is
+// the point rather than an omission. The mutation gate adjudicates TWICE and
+// drains the body between the two passes, because a caller owns its body and can
+// hold an authorization open for the whole read timeout. A GET has no body to
+// withhold: the handler is entered immediately, so there is no window between
+// the verdict and the action for a revocation to fall into. One pass is the
+// whole decision here.
+//
+// An UNGUARDED safe route is served, not refused -- the opposite of the mutation
+// gate's fail-closed default. That asymmetry is deliberate too. /health and
+// /metrics are safe routes with no entry in the table and must keep serving:
+// authCheck already exempts them, the in-tree incus harnesses read /metrics, and
+// a fail-closed default here would break them at the first request. The cost is
+// that a NEW read route added without a table entry serves unauthenticated --
+// which is why TestEveryReadRouteHasAPermission_6660 enumerates the mux and
+// fails on any /api/v1 GET the table does not cover, moving that risk from
+// runtime to the test suite.
+func (s *Server) readAuthz(w http.ResponseWriter, r *http.Request, next http.Handler) {
+	route := r.Method + " " + r.URL.Path
+	required, known := restReadPermissions[route]
+	if !known {
+		next.ServeHTTP(w, r)
+		return
+	}
+	cfg, p, _ := s.authorizeInputs(r)
+	if err := authz.Authorize(cfg, p, required); err != nil {
+		// Debug, not Warn: caller-driven and reachable unauthenticated, so a
+		// Warn here is a log-amplification lever -- the same reasoning the
+		// mutation denial states.
+		slog.Debug("api: refused unauthorized read",
+			"method", r.Method, "path", r.URL.Path,
+			"principal", p.String(), "source", p.Source.String(),
+			"required", authz.PermissionName(required), "err", err)
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
+	next.ServeHTTP(w, r)
+}
+
 func (s *Server) mutationAuthzGuard(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isSafeHTTPMethod(r.Method) {
-			next.ServeHTTP(w, r)
+			s.readAuthz(w, r, next)
 			return
 		}
 		// Exact match on the registered pattern. The path is NOT cleaned or

--- a/pkg/api/config_authz_5561_test.go
+++ b/pkg/api/config_authz_5561_test.go
@@ -345,10 +345,22 @@ func TestAuthorizedPrincipalStillMutatesConfig_5561(t *testing.T) {
 	}
 }
 
-// TestReadOnlyEndpointsUnaffected_5561 pins the blast radius: with NO
-// establishable principal at all, the read surface — REST GETs, /health and
-// /metrics — behaves exactly as before. The gate must not have turned a
-// monitoring endpoint into a 403.
+// TestReadOnlyEndpointsUnaffected_5561 pins the blast radius of the MUTATION
+// gate on the read surface: with no establishable principal at all, the health
+// and metrics endpoints behave exactly as before. The gate must not have turned
+// a monitoring endpoint into a 403.
+//
+// #6660 NARROWED THIS TEST, and the narrowing is the point rather than a
+// concession. When #5561 shipped, "the read surface is unaffected" was the whole
+// truth, because reads were not authorized at all — which is precisely the gap
+// #6660 closes. The /api/v1 GETs that used to be listed here are now REFUSED for
+// an unattributable caller, and TestUnattributableCallerIsDeniedReads_6660 pins
+// that in the opposite direction.
+//
+// What survives here is the half that must NEVER change: /health and /metrics
+// carry no configuration, are exempt in authCheck, and are read by the in-tree
+// incus harnesses. A gate that took them down would break monitoring on every
+// box, which is the failure this test exists to catch.
 func TestReadOnlyEndpointsUnaffected_5561(t *testing.T) {
 	usePasswdFixture(t)
 	store := authzStore(t, authzTestConfig)
@@ -361,12 +373,6 @@ func TestReadOnlyEndpointsUnaffected_5561(t *testing.T) {
 	for _, path := range []string{
 		"/health",
 		"/metrics",
-		"/api/v1/config",
-		"/api/v1/config/show",
-		"/api/v1/config/status",
-		"/api/v1/status",
-		"/api/v1/interfaces",
-		"/api/v1/security/zones",
 	} {
 		t.Run(path, func(t *testing.T) {
 			resp, err := (&http.Client{Timeout: 10 * time.Second}).Get(base + path)
@@ -376,8 +382,8 @@ func TestReadOnlyEndpointsUnaffected_5561(t *testing.T) {
 			defer resp.Body.Close()
 			if resp.StatusCode == http.StatusForbidden {
 				body, _ := io.ReadAll(resp.Body)
-				t.Fatalf("GET %s returned 403 — the mutation gate is refusing read traffic: %s",
-					path, body)
+				t.Fatalf("GET %s returned 403 — an unauthenticated monitoring endpoint is refusing "+
+					"traffic; /health and /metrics must stay open (#6660): %s", path, body)
 			}
 		})
 	}

--- a/pkg/api/read_authz_6660_test.go
+++ b/pkg/api/read_authz_6660_test.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func get6660(t *testing.T, base, path string) (int, string) {
+	t.Helper()
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Get(base + path)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(b)
+}
+
+// TestUnattributableCallerIsDeniedReads_6660 is the fail-on-revert gate.
+//
+// #5561 authorized the 19 MUTATING routes and scoped reads out, so any local
+// process could GET the full running configuration without being identified and
+// no login-class permission was consulted.
+//
+// The caller here is LOCAL but unattributable — the same fixture #5561 uses for
+// its mutation denials — which is the population that must not be reading a
+// firewall's zones, policies, NAT rules and addressing.
+func TestUnattributableCallerIsDeniedReads_6660(t *testing.T) {
+	usePasswdFixture(t)
+	store := authzStore(t, authzTestConfig)
+	_, base := authzServer(t, Config{
+		Addr:         "127.0.0.1:8080",
+		Store:        store,
+		PeerLookupFn: unattributableLocalPeer(),
+	})
+
+	for _, path := range []string{
+		"/api/v1/config",
+		"/api/v1/config/show",
+		"/api/v1/config/status",
+		"/api/v1/show-text",
+		"/api/v1/status",
+		"/api/v1/interfaces",
+		"/api/v1/security/zones",
+		"/api/v1/security/policies",
+		"/api/v1/security/sessions",
+		"/api/v1/routes",
+	} {
+		t.Run(path, func(t *testing.T) {
+			code, body := get6660(t, base, path)
+			if code != http.StatusForbidden {
+				t.Fatalf("GET %s returned %d, want 403 — an unidentified local caller is "+
+					"reading the firewall's configuration and operational state: %s",
+					path, code, body)
+			}
+		})
+	}
+}
+
+// TestRootStillReadsWithNoLoginModel_6660 is the no-brick guard, and it is the
+// reason this change is safe to make at all.
+//
+// PrincipalForUID returns a SUPERUSER principal for uid 0 unconditionally, with
+// no `system login user` entry required. So root-run monitoring, automation and
+// support tooling on a box that never adopted RBAC keeps working byte-for-byte;
+// what changes is a NON-root local uid outside the login model, which is exactly
+// the population the issue exists to stop.
+//
+// Without this case the change would read as "gate the read surface" with no
+// evidence about who it breaks — and the issue explicitly warns that a read
+// denial can break monitoring that has never needed an identity.
+func TestRootStillReadsWithNoLoginModel_6660(t *testing.T) {
+	usePasswdFixture(t)
+	// A config with NO `system login` stanza at all: the box never adopted RBAC.
+	store := authzStore(t, "system {\n    host-name fw;\n}\n")
+	_, base := authzServer(t, Config{
+		Addr:         "127.0.0.1:8080",
+		Store:        store,
+		PeerLookupFn: fixedPeerUID(0),
+	})
+
+	for _, path := range []string{"/api/v1/config", "/api/v1/status"} {
+		t.Run(path, func(t *testing.T) {
+			if code, body := get6660(t, base, path); code == http.StatusForbidden {
+				t.Fatalf("GET %s returned 403 for ROOT on a box with no login model — this "+
+					"would break every root-run monitor on every deployment that never "+
+					"configured `system login user`: %s", path, body)
+			}
+		})
+	}
+}
+
+// TestHealthAndMetricsStayOpen_6660 pins the two routes that must never be
+// gated: they carry no configuration, authCheck already exempts them, and the
+// in-tree incus harnesses read /metrics. Gating them would break monitoring on
+// every box.
+func TestHealthAndMetricsStayOpen_6660(t *testing.T) {
+	usePasswdFixture(t)
+	store := authzStore(t, authzTestConfig)
+	_, base := authzServer(t, Config{
+		Addr:         "127.0.0.1:8080",
+		Store:        store,
+		PeerLookupFn: unattributableLocalPeer(),
+	})
+	for _, path := range []string{"/health", "/metrics"} {
+		t.Run(path, func(t *testing.T) {
+			if code, body := get6660(t, base, path); code == http.StatusForbidden {
+				t.Fatalf("GET %s returned 403; it must stay open: %s", path, body)
+			}
+		})
+	}
+}
+
+// TestEveryReadRouteHasAPermission_6660 is the completeness gate.
+//
+// readAuthz serves an UNGUARDED safe route rather than refusing it, because
+// /health and /metrics must keep working. The cost of that choice is that a NEW
+// read route added without a table entry would serve unauthenticated — silently.
+// This moves that risk from runtime to the suite: it enumerates the routes the
+// mux actually registers and fails on any /api/v1 GET the table does not cover.
+//
+// It reads the registration source rather than a hand-kept list, so adding a
+// route and forgetting the permission cannot pass.
+func TestEveryReadRouteHasAPermission_6660(t *testing.T) {
+	src := readServerSourceForTest(t)
+	re := regexp.MustCompile(`mux\.HandleFunc\("(GET) (/api/v1/[^"]*)"`)
+	var missing []string
+	found := 0
+	for _, m := range re.FindAllStringSubmatch(src, -1) {
+		route := m[1] + " " + m[2]
+		found++
+		if _, ok := restReadPermissions[route]; !ok {
+			missing = append(missing, route)
+		}
+	}
+	if found == 0 {
+		t.Fatal("the route scan matched NOTHING — the regex or the registration shape changed, " +
+			"and a completeness gate that matches nothing passes vacuously")
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Fatalf("%d registered /api/v1 GET route(s) have no entry in restReadPermissions and "+
+			"therefore serve UNAUTHENTICATED: %v", len(missing), missing)
+	}
+}
+
+// TestReadPermissionTableNamesOnlyRealRoutes_6660 is the other direction: an
+// entry for a route that does not exist is dead policy that reads as coverage.
+func TestReadPermissionTableNamesOnlyRealRoutes_6660(t *testing.T) {
+	src := readServerSourceForTest(t)
+	for route := range restReadPermissions {
+		path := strings.TrimPrefix(route, "GET ")
+		if !strings.Contains(src, `mux.HandleFunc("GET `+path+`"`) {
+			t.Errorf("restReadPermissions names %q, which the mux does not register — dead "+
+				"policy that reads as coverage", route)
+		}
+	}
+}
+
+// TestReadRoutesAreAllViewTier_6660 pins the contract stated in the table's doc:
+// every read is a `show`-equivalent, so every entry is PermView. A finer tier
+// invented here would be a policy the CLI's own table does not have, and the two
+// would drift.
+func TestReadRoutesAreAllViewTier_6660(t *testing.T) {
+	for route, perm := range restReadPermissions {
+		if perm != config.PermView {
+			t.Errorf("read route %q requires %v, want PermView", route, perm)
+		}
+	}
+}
+
+// readServerSourceForTest returns server.go's source, so the route-coverage
+// gates above compare against what is actually REGISTERED rather than a
+// hand-kept list that can fall behind the mux.
+func readServerSourceForTest(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile("server.go")
+	if err != nil {
+		t.Fatalf("read server.go: %v", err)
+	}
+	return string(b)
+}

--- a/pkg/daemon/daemon_dp_escape_rest_test.go
+++ b/pkg/daemon/daemon_dp_escape_rest_test.go
@@ -3,9 +3,14 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"sync"
+
+	"github.com/psaab/xpf/pkg/authz"
 	"testing"
 	"time"
 )
@@ -25,8 +30,46 @@ import (
 
 // startEscapeTestREST runs the production HTTP startup path on an
 // ephemeral loopback port and returns the effective base URL.
+// authorizeEscapeTestREST gives the test process an IDENTIFIED, authorized
+// principal for the REST read surface (#6660).
+//
+// These cases assert what `/api/v1/status` REPORTS about the dataplane; they are
+// not about authorization. Before #6660 the read surface was ungated so any
+// caller reached the handler. Now a read requires PermView, and the test runner
+// (an ordinary uid, not root) is not in the login model — so without this the
+// cases fail at 403 having never exercised their subject.
+//
+// It maps the RUNNING uid to a name and grants that name super-user, rather than
+// hardcoding a uid, so it is correct on any machine and in CI.
+func authorizeEscapeTestREST(t *testing.T, d *Daemon) {
+	t.Helper()
+	const user = "xpf-escape-test"
+	uid := os.Getuid()
+	passwd := filepath.Join(t.TempDir(), "passwd")
+	line := fmt.Sprintf("%s:x:%d:%d::/home/%s:/bin/bash\n", user, uid, uid, user)
+	if err := os.WriteFile(passwd, []byte(line), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(authz.SetPasswdPathForTest(passwd))
+
+	text := fmt.Sprintf(
+		"system {\n    login {\n        user %s {\n            class super-user;\n        }\n    }\n}\n",
+		user)
+	if err := d.store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := d.store.LoadOverride(text); err != nil {
+		t.Fatalf("LoadOverride: %v", err)
+	}
+	if _, err := d.store.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	d.store.ExitConfigure()
+}
+
 func startEscapeTestREST(t *testing.T, d *Daemon) string {
 	t.Helper()
+	authorizeEscapeTestREST(t, d)
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 	d.opts.APIAddr = "127.0.0.1:0"


### PR DESCRIPTION
Closes #6660

## The gap

#5561 gated the 19 **mutating** routes on a server-derived principal and deliberately scoped reads out. The read surface stayed open: any local process could `GET /api/v1/config` and the rest without being identified, and no login-class permission was consulted.

## What is actually disclosed — measured before designing

`GET /api/v1/config` json-encodes the **compiled** `*config.Config`, so #2053's `config.Secret` marshaller applies. Verified by marshalling a populated `ControlLinkAuthKey` and checking the output:

```
PSK PRESENT IN JSON:        false
TOPOLOGY PRESENT (zone):    true
TOPOLOGY PRESENT (iface):   true
```

**So this is not credential disclosure**, and describing it that way would have been wrong. What it *is* is full **configuration** disclosure — zones, policies, NAT rules, interface addressing, routing neighbours: a complete map of the firewall, to any local uid, including one with no `system login user` entry at all. On a firewall that is reconnaissance.

## The fix

Every `/api/v1` read now requires `PermView`, through the identification machinery #5561 already built — this **wires an existing mechanism onto an uncovered path** rather than building one.

**Every route is `PermView`, not a per-route tier.** These are all `show` verbs, and Junos gates `show` on `view`. Inventing finer tiers here would be a policy the CLI's own table does not have, and the two would drift. The finer question the issue raises — whether a read should be **redacted by class** rather than denied — is a different contract and is left open.

## Why this is not a no-brick problem

This was the issue's main worry, so it gets its own test rather than an assurance. `PrincipalForUID` returns a **superuser** principal for **uid 0 unconditionally**, with no login model required — so root-run monitoring, automation and support tooling on a box that never adopted RBAC keeps working byte-for-byte. What changes is a **non-root** local uid outside the login model: exactly the population the issue exists to stop.

## The consumer sweep the issue asked for

Swept every in-tree consumer of every route. Result: **`/metrics` and `/health` (read by the incus harnesses) and nothing else touching REST at all.** So gating `/api/v1` breaks no shipped tooling. Those two stay open and are not in the table.

`readAuthz` **serves** an unguarded safe route rather than refusing it — the opposite of the mutation gate's fail-closed default — precisely so those two keep working. The cost is that a *new* read route added without a table entry would serve unauthenticated, silently. That risk moves from runtime to the suite:

- `TestEveryReadRouteHasAPermission_6660` scans the routes `server.go` actually **registers** and fails on any `/api/v1` GET the table does not cover.
- A companion test fails an entry naming a route the mux does **not** register — dead policy that reads as coverage.

It adjudicates **once** where the mutation gate adjudicates twice. A difference, not an omission: the mutation gate drains the body between its two passes because a caller owns its body and can hold an authorization open for the whole read timeout. A GET has no body to withhold.

## Two tests repaired rather than deleted

**`TestReadOnlyEndpointsUnaffected_5561`** is narrowed. When #5561 shipped, *"the read surface is unaffected"* was the whole truth — because reads were not authorized at all, which is the gap being closed. Its `/api/v1` cases move to the opposite assertion here; what survives is the half that must **never** change: `/health` and `/metrics`.

**Three `pkg/daemon` REST tests** asserted what `/api/v1/status` reports about the dataplane, not authorization. They now map the **running** uid to a login user rather than hardcoding one, so they are correct on any machine and in CI.

## Validation

- `go test ./pkg/api/ ./pkg/daemon/ ./pkg/grpcapi/ -count=1` — green.
- `go build ./...` clean.

**Mutation matrix — four mutations, each on a COMPILING tree:**

| Mutation | Cases that red |
|---|---|
| Restore the pre-fix pass-through for safe methods | the denial test |
| **Remove the guard from the path `Run()` takes** | **the denial test** — the wiring cell; a test calling the authorizer directly would pass while production bypassed it |
| Fail **closed** on an unguarded safe route | both `/health`+`/metrics` gates |
| Drop one route from the table | the denial case **and** the coverage gate |

No cluster smoke owed: control-plane only, no `userspace-dp` helper or shim `.o` movement.

## Docs

`pkg/api/README.md` — a new "The read surface (#6660)" section records what is and is not disclosed (with the measurement), why every route is `PermView`, why `/health` and `/metrics` stay open, why the unguarded default is serve-not-refuse and what pays for it, and the single-vs-double adjudication difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdWuT1UffSkr1spw8sjNTE
