### PR TITLE
cluster: adopt the cross-node session id in the BPF mirror (#6666)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -102545,3 +102545,20 @@ prose edit above them added. No diff falls in the new test body.
     controlLinkAuthKey now REDs). Residual closed: readLoop's CALL to admitFrame
     was still unbound — severing it left every 5086 test green.
   - **File(s)**: pkg/cluster/heartbeat_replay_restart_5086_test.go
+
+## 2026-08-22 — #6666 mirror adopts the cross-node session id (DECISION)
+- **Timestamp**: 2026-08-22
+- **Action**: Decided #6666 in favour of option 2 (adopt RTFlowSessionID in the
+  BPF conntrack mirror) and implemented it. Evidence: nothing keys on the id
+  (swept every non-test reference — no map key, index, dedup or generation
+  guard); #6311's node discriminator bit makes cross-node collision structurally
+  impossible (already pinned by a test); no BPF ABI change, so the helper binary
+  does NOT move; and the change is two call sites in Go. Option 3a rejected —
+  it grows the conntrack value 144->152 and `validateUserspaceShimLivePins`
+  hard-refuses a ValueSize mismatch, i.e. session loss on upgrade. Folded in
+  option 1's deliverable: the proto comment was BACKWARDS on both halves and
+  pkg/cluster/README still described the removed `now<<16|slot`.
+- **File(s)**: pkg/daemon/daemon_ha_userspace_convert.go,
+  pkg/daemon/mirror_session_id_adoption_6666_test.go (new),
+  pkg/daemon/userspace_sync_test.go, proto/xpf/v1/xpf.proto,
+  pkg/cluster/README.md, docs/session-sync-architecture.md, _Log.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -777,6 +777,46 @@ This id stays deliberately node-local; the cross-node correlatable id is the
 separate `RTFlowSessionID` above. Regression coverage:
 `TestUserspaceSyncedSessionID*6198` in `pkg/daemon`.
 
+### #6666: the mirror now ADOPTS the cross-node id
+
+The section above describes the two ids as independent, and until #6666 they
+were. That independence was the defect, not the design.
+
+**Two writers reach one field.** The control plane writes
+`SessionValue{,V6}.SessionID` on every conversion; the helper writes the entry's
+own stable id whenever a frame drives a local publish for the same key
+(`publish_conntrack.rs`, #5213). They minted from disjoint namespaces, so the id
+an operator saw FLIPPED depending on which wrote last.
+
+**It was not only at promotion.** Because the control-plane id is distinct per
+CONVERSION rather than per session (stated above), every bulk resync re-stamped
+every live synced session with a fresh id. The issue described promotion; the
+churn is wider than that.
+
+**It also made #5213's invariant false.** `cli_show_flow.go` promises the
+displayed id is IDENTICAL to the id RT_FLOW emits for the same session. For a
+peer-synced session it was not: RT_FLOW carried the adopted peer id, the mirror
+carried a local one.
+
+So the mirror adopts the peer's id when it sent one, and mints a node-local id
+only when it did not (a legacy or mid-rolling-upgrade peer). Both surfaces now
+render one id for one session.
+
+**Safe by construction rather than by bookkeeping.** #6311 gave every id a node
+discriminator bit, so an adopted id carries the ORIGINATING node's bit and cannot
+collide with anything this node mints — pinned by
+`adopted_peer_id_cannot_collide_with_a_local_id_6311`. And nothing keys on the
+id: `pkg/dataplane/types.go` states it is "never a lookup key", and a sweep of
+every non-test `SessionID` reference finds no map key, index, dedup or generation
+guard. The blast radius is display-only.
+
+**What it does NOT close**, so the claim is not over-stated: synthesized reverse
+companions still carry `session_id: 0` (they are not displayed — the CLI skips
+reverse rows), and #6965 means an ordinary TRANSIT session has no conntrack row
+at all, so the population this improves is the peer-synced, host-inbound and
+neighbor-seed sets. If #6965 is ever closed, the transit population lands in the
+mirror with helper-minted ids and this two-writer surface widens sharply.
+
 ## Sync Readiness and Bulk Priming
 
 This is the biggest place where older descriptions are wrong or incomplete.

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -2743,8 +2743,7 @@ outside the monitor loop:
   guard still covers only the config-authority → peer direction; the reverse
   active/active direction stays a documented fail-OPEN residual on #6284 (item 1,
   needs a bidirectional config-gen namespace #5274 scoped out).
-- **RT_FLOW session id (#5212)**: distinct from BOTH the synthesized BPF-ABI
-  `SessionID` (`now<<16|slot`, node-local) AND the per-key install generation,
+- **RT_FLOW session id (#5212)**: distinct from the per-key install generation,
   every session install carries the ORIGINATING node's stable RT_FLOW session id
   (`SessionValue{,V6}.RTFlowSessionID`, the dataplane's
   `SessionTable::alloc_session_id` value) as a length-gated trailing `uint64` on
@@ -2773,6 +2772,14 @@ outside the monitor loop:
   transition and prevents spurious failover churn. A nil receiver / unset seam
   reports not-fresh, so the no-receiver call paths behave exactly as before the
   re-check existed.
+
+  **#6198/#6666 correction:** the BPF-ABI `SessionID` was described here as
+  `now<<16|slot` — a composition #6198 removed (it collapsed every session
+  converted in the same second onto one id). Since #6666 the mirror ADOPTS this
+  RT_FLOW id when the peer sent one, so the two are no longer distinct for a
+  peer-synced session; a node-local id is minted only for a legacy peer that
+  sent none. That is what makes `show security flow session` and RT_FLOW render
+  one id for one session.
 
 - **The peer heartbeat-ack capability is peer-INCARNATION scoped, not
   process-sticky (#5718 C01a).** `SessionSync.peerHeartbeatAckEver` latches

--- a/pkg/daemon/daemon_ha_userspace_convert.go
+++ b/pkg/daemon/daemon_ha_userspace_convert.go
@@ -166,6 +166,19 @@ var (
 // This id stays NODE-LOCAL by design: the cross-node correlatable id is the
 // separate RTFlowSessionID (#5212), which rides its own wire field and is
 // adopted verbatim by the peer helper. See docs/session-sync-architecture.md.
+// adoptedOrLocalSyncedSessionID returns the id to stamp into the BPF conntrack
+// mirror for a peer-synced session (#6666).
+//
+// The peer's stable cross-node id when it sent one; a fresh node-local id
+// otherwise. The fallback is what makes this rolling-upgrade safe: a mixed-base
+// peer sends 0, and that path is byte-identical to pre-#6666.
+func adoptedOrLocalSyncedSessionID(rtFlowSessionID uint64) uint64 {
+	if rtFlowSessionID != 0 {
+		return rtFlowSessionID
+	}
+	return nextUserspaceSyncedSessionID()
+}
+
 func nextUserspaceSyncedSessionID() uint64 {
 	userspaceSyncedSessionIDOnce.Do(func() {
 		userspaceSyncedSessionIDs.Store(userspaceSyncedSessionIDSeed(daemonMonotonicNanos()))
@@ -331,10 +344,35 @@ func userspaceSessionFromDeltaV4(delta dpuserspace.SessionDeltaInfo, zoneIDs map
 	now := daemonMonotonicSeconds()
 	val := dataplane.SessionValue{
 		State: 4, // SESS_STATE_ESTABLISHED
-		// SessionID is the BPF-ABI conntrack id: node-local, and unique per
-		// converted session since #6198 (the previous now<<16|Slot composition
-		// collapsed every session converted in the same second onto one id).
-		SessionID: nextUserspaceSyncedSessionID(),
+		// SessionID is the BPF-ABI conntrack id the session VIEWS render --
+		// `show security flow session`, the REST session views, the gRPC session
+		// RPCs. #6666: when the peer sent its stable cross-node id, ADOPT it
+		// here instead of minting a node-local one.
+		//
+		// TWO WRITERS reach this one field. The control plane writes it on every
+		// conversion; the helper writes the entry's own stable id whenever a
+		// frame drives a local publish for the same key. They minted from
+		// disjoint namespaces, so the displayed id FLIPPED depending on which
+		// wrote last -- at promotion, and (worse, and not in the issue) at every
+		// bulk resync, because the control-plane id is distinct per CONVERSION
+		// rather than per session. Adopting makes both writers agree.
+		//
+		// It also makes #5213's stated invariant true. cli_show_flow.go promises
+		// the displayed id is IDENTICAL to the id RT_FLOW emits for the same
+		// session; for a peer-synced session it was not, because RT_FLOW carries
+		// the adopted id while the mirror carried the local one.
+		//
+		// SAFE BY CONSTRUCTION, not by bookkeeping. #6311 gave every id a node
+		// discriminator bit, so an adopted id carries the ORIGINATING node's bit
+		// and cannot collide with anything this node mints -- pinned by
+		// adopted_peer_id_cannot_collide_with_a_local_id_6311. And nothing keys
+		// on it: pkg/dataplane/types.go states it is "never a lookup key", and a
+		// sweep of every non-test SessionID reference finds no map key, index,
+		// dedup or generation guard. The blast radius is display-only.
+		//
+		// 0 means a legacy or rolling-upgrade peer that sent no id; mint as
+		// before, which keeps every #6198 mint test exercising the same path.
+		SessionID: adoptedOrLocalSyncedSessionID(delta.RTFlowSessionID),
 		// #5212: the ORIGINATING node's stable RT_FLOW session id (distinct from
 		// SessionID above). Carried across the cluster sync wire so a peer-synced
 		// session adopts it and its SESSION_CREATE/CLOSE records correlate across
@@ -438,9 +476,9 @@ func userspaceSessionFromDeltaV6(delta dpuserspace.SessionDeltaInfo, zoneIDs map
 	now := daemonMonotonicSeconds()
 	val := dataplane.SessionValueV6{
 		State: 4, // SESS_STATE_ESTABLISHED
-		// SessionID is the BPF-ABI conntrack id: node-local, and unique per
-		// converted session since #6198 (see the V4 converter).
-		SessionID: nextUserspaceSyncedSessionID(),
+		// SessionID: adopted from the peer when it sent one, else minted
+		// node-local (#6666 -- see the V4 converter for the full reasoning).
+		SessionID: adoptedOrLocalSyncedSessionID(delta.RTFlowSessionID),
 		// #5212: the ORIGINATING node's stable RT_FLOW session id (see V4) —
 		// adopted by a peer-synced session so its RT_FLOW records correlate
 		// across HA nodes; 0 on a legacy helper => fresh local id on import.

--- a/pkg/daemon/mirror_session_id_adoption_6666_test.go
+++ b/pkg/daemon/mirror_session_id_adoption_6666_test.go
@@ -1,0 +1,115 @@
+package daemon
+
+import (
+	"testing"
+
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+func delta6666(rtFlowID uint64, v6 bool) dpuserspace.SessionDeltaInfo {
+	d := dpuserspace.SessionDeltaInfo{
+		Event: "open", AddrFamily: 2, Protocol: 6,
+		SrcIP: "10.0.61.102", DstIP: "172.16.80.200", SrcPort: 12345, DstPort: 5201,
+		IngressZone: "lan", EgressZone: "wan", EgressIfindex: 12,
+		RTFlowSessionID: rtFlowID,
+	}
+	if v6 {
+		d.AddrFamily = 10
+		d.SrcIP, d.DstIP = "2001:db8::1", "2001:db8::2"
+	}
+	return d
+}
+
+// TestMirrorAdoptsCrossNodeSessionID_6666 is the fail-on-revert gate for the
+// decision recorded on #6666.
+//
+// The BPF conntrack mirror has TWO writers of one field. The control plane
+// stamped a node-local id on every conversion; the helper stamps the entry's own
+// stable id whenever a frame drives a local publish for the same key. The
+// displayed id therefore flipped depending on which wrote last — at promotion,
+// and at every bulk resync, since the control-plane id was distinct per
+// CONVERSION rather than per session.
+//
+// It also made #5213's stated invariant false: cli_show_flow.go promises the
+// displayed id is identical to the id RT_FLOW emits for the same session, and
+// for a peer-synced session it was not.
+func TestMirrorAdoptsCrossNodeSessionID_6666(t *testing.T) {
+	zoneIDs := map[string]uint16{"lan": 1, "wan": 2}
+	const peerID = uint64(7)<<48 | 0x1234_5678
+
+	t.Run("v4 adopts", func(t *testing.T) {
+		_, val, ok := userspaceSessionFromDeltaV4(delta6666(peerID, false), zoneIDs)
+		if !ok {
+			t.Fatal("expected the delta to convert")
+		}
+		if val.SessionID != peerID {
+			t.Fatalf("SessionID = %#x, want the adopted %#x", val.SessionID, peerID)
+		}
+		if val.RTFlowSessionID != peerID {
+			t.Fatalf("RTFlowSessionID = %#x, want %#x — adoption must not disturb the wire field",
+				val.RTFlowSessionID, peerID)
+		}
+	})
+
+	t.Run("v6 adopts", func(t *testing.T) {
+		_, val, ok := userspaceSessionFromDeltaV6(delta6666(peerID, true), zoneIDs)
+		if !ok {
+			t.Fatal("expected the delta to convert")
+		}
+		if val.SessionID != peerID {
+			t.Fatalf("v6 SessionID = %#x, want the adopted %#x — the v6 converter is a separate "+
+				"site and a fix applied to only one of the two is the symmetric-surface failure",
+				val.SessionID, peerID)
+		}
+	})
+}
+
+// TestLegacyPeerStillMintsALocalID_6666 is the rolling-upgrade guard.
+//
+// A mixed-base peer sends RTFlowSessionID == 0. That path must stay
+// byte-identical to pre-#6666 — a fresh node-local id — or a cluster mid-upgrade
+// stamps every synced session with 0, collapsing every row onto one id.
+func TestLegacyPeerStillMintsALocalID_6666(t *testing.T) {
+	zoneIDs := map[string]uint16{"lan": 1, "wan": 2}
+
+	_, a, ok := userspaceSessionFromDeltaV4(delta6666(0, false), zoneIDs)
+	if !ok {
+		t.Fatal("expected the delta to convert")
+	}
+	_, b, ok := userspaceSessionFromDeltaV4(delta6666(0, false), zoneIDs)
+	if !ok {
+		t.Fatal("expected the delta to convert")
+	}
+	if a.SessionID == 0 || b.SessionID == 0 {
+		t.Fatal("a legacy peer's session was stamped with id 0 — every synced row would " +
+			"collapse onto one id and the display would name none of them")
+	}
+	if a.SessionID == b.SessionID {
+		t.Fatalf("two conversions minted the same node-local id %#x; #6198 requires one per "+
+			"converted session", a.SessionID)
+	}
+}
+
+// TestAdoptedIDIsNotInTheControlPlaneNamespace_6666 pins that adoption really
+// carries the ORIGINATING node's namespace rather than being re-minted.
+//
+// Without it, an implementation that minted a fresh id and happened to return it
+// would satisfy the adoption test only by coincidence of the fixture; this
+// asserts the value is NOT from the control plane's reserved 0xFFFF space, which
+// is the property that makes the two writers agree.
+func TestAdoptedIDIsNotInTheControlPlaneNamespace_6666(t *testing.T) {
+	const peerID = uint64(7)<<48 | 0x1234_5678
+	got := adoptedOrLocalSyncedSessionID(peerID)
+	if got != peerID {
+		t.Fatalf("adoptedOrLocalSyncedSessionID(%#x) = %#x", peerID, got)
+	}
+	if got>>48 == 0xFFFF {
+		t.Fatalf("the adopted id %#x sits in the control plane's reserved 0xFFFF namespace; it "+
+			"must carry the originating node's namespace", got)
+	}
+	// And the fallback DOES use that namespace, which is what keeps the two
+	// mint spaces disjoint for a legacy peer.
+	if minted := adoptedOrLocalSyncedSessionID(0); minted>>48 != 0xFFFF {
+		t.Fatalf("the legacy fallback minted %#x outside the control-plane namespace", minted)
+	}
+}

--- a/pkg/daemon/userspace_sync_test.go
+++ b/pkg/daemon/userspace_sync_test.go
@@ -207,11 +207,15 @@ func TestUserspaceSessionFromDeltaCarriesRTFlowSessionID5212(t *testing.T) {
 	if valV4.RTFlowSessionID != wantID {
 		t.Fatalf("v4 RTFlowSessionID = %#x, want %#x", valV4.RTFlowSessionID, wantID)
 	}
-	// The BPF-ABI SessionID stays a distinct node-local value (#6198: minted by
-	// nextUserspaceSyncedSessionID in its own 0xFFFF<<48 namespace, which the
-	// dataplane's worker-namespaced RTFlowSessionID can never occupy).
-	if valV4.SessionID == wantID {
-		t.Fatal("RTFlowSessionID must be distinct from the BPF-ABI SessionID")
+	// #6666 REVERSED THIS ASSERTION, and the reversal is the decision rather
+	// than a concession. It used to require the BPF-ABI SessionID be DISTINCT
+	// from the cross-node id -- which is exactly the divergence that made the
+	// displayed id flip between the control plane's value and the helper's, and
+	// made #5213's "identical to the id RT_FLOW emits" promise false for every
+	// peer-synced session. The mirror now ADOPTS the peer's id when it sent one.
+	if valV4.SessionID != wantID {
+		t.Fatalf("v4 SessionID = %#x, want the ADOPTED cross-node id %#x — the session views "+
+			"and RT_FLOW must render one id for one session (#6666)", valV4.SessionID, wantID)
 	}
 
 	deltaV6 := dpuserspace.SessionDeltaInfo{

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -554,10 +554,19 @@ message EventEntry {
   // did not carry the field (e.g. a non-close event, or no NAT applied).
   string nat_src_addr = 21;     // post-NAT source "ip:port" ("" = no NAT)
   string nat_dst_addr = 22;     // post-NAT destination "ip:port"
-  // Node-local dataplane session id (the #4915 [152:160] ringbuf slot): unique
-  // within this node, but NOT the same on both cluster nodes (#6198). Use it to
-  // correlate this event with `show security flow session` on THIS node; it is
-  // not a cross-node key.
+  // Dataplane session id (the #4915 [152:160] ringbuf slot).
+  //
+  // CROSS-NODE STABLE (#5212): a peer-synced session ADOPTS the originating
+  // node's id, so this node's SESSION_CLOSE carries the same id as the
+  // originating node's SESSION_CREATE. That is the whole point of #5212 and it
+  // is what a SIEM correlates on across a failover.
+  //
+  // #6666 corrected this comment, which was backwards on BOTH halves: it said
+  // the id was node-local and NOT the same on both nodes (it is the same, since
+  // #5212), and it pointed at `show security flow session` on THIS node as the
+  // correlation target (which rendered a DIFFERENT, control-plane-minted id for
+  // a peer-synced session until #6666 made the mirror adopt this one). Both
+  // surfaces now render this id, so either correlation works.
   uint64 session_id = 23;
   uint32 elapsed_time = 24;     // seconds since session creation (CLOSE)
   uint32 created = 25;          // absolute session-creation Unix seconds (CLOSE)


### PR DESCRIPTION
Closes #6666

## The decision

#6666 asked for a decision, not a patch. Deciding it required knowing what adoption would **cost** — and the cost turned out to be near zero, which is what settles it.

**Option 2 (adopt `RTFlowSessionID` in the mirror) is implemented here.** Option 1 (status quo + document) is folded in as the doc corrections below, because two of those docs were not merely stale but *backwards*. Option 3a (surface both, as a conntrack-ABI field) is rejected on cost — see below.

## The defect is two writers of one field

The control plane writes `SessionValue{,V6}.SessionID` on every conversion; the helper writes the entry's own stable id whenever a frame drives a local publish for the same key (#5213). They minted from disjoint namespaces, so the id an operator saw **flipped depending on which wrote last**.

**It is wider than the issue states.** The control-plane id is distinct per **conversion**, not per session, so *every bulk resync* re-stamped every live synced session with a fresh id. "Changes at promotion" understates what was being accepted.

**It also made #5213's invariant false.** `cli_show_flow.go` promises the displayed id is *identical* to the id RT_FLOW emits for the same session — and for a peer-synced session it was not. That promise lived in a doc comment and in a test that fed a hand-written id and never exercised the peer-synced population.

## Why adoption is cheap

| Concern | Finding |
|---|---|
| Does anything key on the id? | **No.** `pkg/dataplane/types.go` states it is "never a lookup key"; a sweep of every non-test `SessionID` reference finds no map key, index, dedup or generation guard. Blast radius is display-only. |
| Collision with a locally-minted id? | **Structurally impossible.** #6311 gave every id a node discriminator bit, so an adopted id carries the *originating* node's bit — already pinned by `adopted_peer_id_cannot_collide_with_a_local_id_6311`. The obvious per-node-counter worry was checked, not assumed. |
| Does the helper binary move? | **No.** No BPF ABI change; this is two Go call sites. |
| Rolling upgrade? | Preserved by the `0` fallback — a mixed-base peer gets a node-local mint, byte-identical to before, which is why every #6198 mint test still exercises that path unchanged. |

**Why not "surface both":** the conntrack-ABI variant grows the value 144→152 (192→200 for v6), and `validateUserspaceShimLivePins` **hard-refuses** a `ValueSize` mismatch against the live pin — i.e. session loss on upgrade.

## The claim is scoped, not over-stated

Synthesized reverse companions still carry `session_id: 0` (not displayed — the CLI skips reverse rows), and **#6965** means an ordinary **transit** session has no conntrack row at all. So the population this improves is the peer-synced, host-inbound and neighbor-seed sets. If #6965 is ever closed, the transit population lands in the mirror with helper-minted ids and this two-writer surface widens sharply — recorded in the architecture doc.

## Two docs were backwards, not just stale

- `proto/xpf/v1/xpf.proto` told SIEM integrators the event session id was node-local and **NOT** the same on both nodes — it has been the same since #5212 — and pointed at `show security flow session` as the correlation target, which rendered a *different* id until this change.
- `pkg/cluster/README.md` still described the BPF-ABI id as `now<<16|slot`, a composition #6198 removed.

## One test reversed, not deleted

`TestUserspaceSessionFromDeltaCarriesRTFlowSessionID5212` asserted the two ids must **differ**. That is precisely the behaviour under decision, so the assertion is reversed with the reasoning recorded inline.

## Validation

- `go test ./pkg/daemon/ ./pkg/cluster/ ./pkg/cli/ -count=1` — green.
- `go build ./...` clean.

**Mutation matrix — three mutations, each on a COMPILING tree:**

| Mutation | Cases that red |
|---|---|
| Revert **V4** to the node-local mint (pre-fix) | the adoption test + #5212's |
| **Revert only V6** | the adoption test — the symmetric-surface cell; a fix applied to one of two converters is the failure mode this campaign keeps hitting |
| **Adopt unconditionally, dropping the legacy fallback** (a tightening) | the rolling-upgrade guard **and** two #6198 mint tests |

A fourth test pins that the adopted value is genuinely the originating node's namespace and not a coincidentally-returned fresh mint.

No cluster smoke owed: **no BPF ABI change and no `userspace-dp` helper movement** — control-plane Go only.

## Docs

`docs/session-sync-architecture.md` gains a "#6666: the mirror now adopts the cross-node id" section covering the two-writer mechanism, the per-resync churn the issue did not name, the safety argument, and what it explicitly does *not* close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdWuT1UffSkr1spw8sjNTE
