### PR TITLE
config: redact URL-bearing leaves on the config-read surfaces (#6703)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,46 @@
+## 2026-08-22 — #6703: URL-bearing config leaves leaked on every config-read surface
+
+- **Timestamp**: 2026-08-22
+- **Action**: Measured the defect before designing, and the measurement moved
+  the fix. The framing in the issue (and in the brief) was that `RedactURL`
+  has a gap; the live defect was that the config-READ surfaces call **no
+  redactor at all**. Proof: `GET /api/v1/config` leaked a *userinfo*
+  credential — a case `RedactURL` has stripped since #2781 and
+  `DDNSProvider.String()` has applied all along — which is only possible if
+  neither is on the path. Confirmed on all three routes named in the
+  acceptance criteria. A fix aimed at `RedactURL` would have been invisible to
+  every one of them.
+  Fixed at the two render boundaries instead: `MarshalJSON` on `DDNSProvider`
+  and `FeedServer` (alias-copy so a field added later is still marshalled and
+  cannot be silently dropped), and a TRANSFORM pass in `redactNodes` for the
+  AST display path. URL leaves are transformed rather than masked because a
+  credential-free URL must render unchanged and the host must stay visible —
+  both explicit acceptance criteria, and a placeholder would violate both.
+  Keyed the AST rule on the LEAF NAME rather than a list of locations, so a
+  future `url` leaf inherits redaction; that also caught two leaves the issue
+  never listed — `system license autoupdate url` and `services rpm probe ...
+  target url` — both measured leaking. Gated `server`/`update-server` on a
+  `dynamic-dns` ancestor since `server` is also an NTP leaf; the gate is
+  pinned by a direct unit test because a render-level test cannot discriminate
+  (RedactURL is a no-op on a bare NTP address, so a wrongly-ungated `server`
+  would still render unchanged and pass for the wrong reason).
+  Added the symmetric commit-ingest guard the redaction creates a need for: a
+  redacted URL still LOOKS valid, so re-applying a redacted export would
+  silently install a broken endpoint instead of failing at commit. Verified it
+  is display-only — `ExportJSON` has zero non-test callers, persistence
+  marshals the AST tree (untouched), and `redactNodes` runs only from
+  `RedactedClone`.
+  Deliberately did NOT change `RedactURL`: 18 call sites across 6 packages, 9
+  of which need the host in their output (the three `show security
+  dynamic-address` surfaces, the commit warnings that name the offending
+  value, the feed-fetch logs that say which server is down).
+  Mutation matrix M1-M6 all RED with real assertions, vet clean at every
+  mutated state, RUN=17 at every cell matching the control.
+- **File(s)**: `pkg/config/ast_redact.go`, `pkg/config/types_system.go`,
+  `pkg/config/types_security.go`, `pkg/config/url_redaction_6703_test.go` (new),
+  `pkg/api/config_url_redaction_6703_test.go` (new),
+  `docs/junos-config-display-reference.md`
+
 ## 2026-08-22 — #6709/#7009: the pkg/ddns full-package flake, both mechanisms
 
 - **Timestamp**: 2026-08-22

--- a/docs/junos-config-display-reference.md
+++ b/docs/junos-config-display-reference.md
@@ -1138,6 +1138,38 @@ save`; to restore, load from that archive/rescue or re-enter the secret in
 cleartext. (The cleartext SSOT still backs HA config sync, the DR archive and
 on-disk persistence — only the display surfaces redact.)
 
+**xpf URL redaction (#6703):** a URL is secret-*bearing* without being a
+secret — the credential lives in the userinfo, query or fragment, while the
+scheme, host and path are the diagnostic payload an operator needs. So
+URL-bearing leaves are **transformed**, not masked: `config.RedactURL` strips
+userinfo, query and fragment (and an authority that cannot be a `host:port`,
+#6609) and leaves everything else intact. A URL with no credential-bearing
+component renders **unchanged**.
+
+This applies on the typed-struct render (`GET /api/v1/config`, via
+`MarshalJSON` on `DDNSProvider` and `FeedServer`) and on the raw-AST display
+surfaces (`show` / `export`, via `urlLeafIndices` in `ast_redact.go`). Before
+#6703 neither surface reached any redactor at all, so these leaves rendered
+verbatim — including a `user:pass@` credential that `RedactURL` has stripped
+since #2781.
+
+The AST rule is keyed on the **leaf name**, so a `url` leaf inherits redaction
+in every context and a future one needs no extra step. `url-template` and
+`checkip-url` are distinctive enough to match unqualified; `server` and
+`update-server` are gated on a `dynamic-dns` ancestor because `server` is also
+an NTP leaf.
+
+A redacted URL still looks like a valid URL, so re-applying a redacted export
+would silently install a broken endpoint rather than failing loudly. xpf
+therefore **rejects a URL leaf containing `<redacted>` on commit-ingest**, the
+same way it rejects `##SECRET-DATA##`.
+
+**Not covered:** a credential embedded in the URL's *hostname* or *path*
+(`https://SECRET.dyn.example.com/upd`) is indistinguishable from an ordinary
+hostname, so no string rule can redact it without redacting every host. Put
+credentials in the userinfo or the query, where they are redacted. Tracked in
+#7406.
+
 ### 7.2 `{ ... }` Collapse in max-depth
 
 When `display max-depth` truncates children, it uses `{ ... }` notation.

--- a/pkg/api/config_url_redaction_6703_test.go
+++ b/pkg/api/config_url_redaction_6703_test.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #6703 end-to-end leak regression for the config-READ surfaces.
+//
+// This is the layer the defect actually lived at. RedactURL has stripped
+// userinfo since #2781 and DDNSProvider.String() has applied it since then, yet
+// GET /api/v1/config still rendered a userinfo credential VERBATIM — because
+// that route json-encodes the compiled *config.Config and called neither. The
+// export/show routes render the raw AST, whose keyword-based redaction had no
+// url/server/url-template entry. So the mechanism was "no redactor is reached",
+// not "the redactor has a gap", and a fix aimed at RedactURL would have been
+// invisible here.
+//
+// Each sentinel is unique so a single leaking field is identifiable, and each
+// sits in a DIFFERENT credential-bearing component (userinfo / query) so the
+// test does not accidentally prove only one rule.
+var urlSecretSentinels6703 = []string{
+	"LEAK-SERVER-USERINFO",   // DDNSProvider.Server, credential in userinfo
+	"LEAK-URLTEMPLATE-QUERY", // DDNSProvider.URLTemplate, token in query
+	"LEAK-CHECKIP-QUERY",     // DDNSProvider.CheckIPURL, key in query
+	"LEAK-FEED-QUERY",        // FeedServer.URL, subscription token in query
+}
+
+// urlCleanValues must render UNCHANGED on every route. Without this half the
+// test cannot distinguish working redaction from blanket over-redaction, which
+// for these leaves would destroy the diagnosability #6703 requires be kept.
+var urlCleanValues6703 = []string{
+	"https://checkip-plain.example/",  // credential-free checkip-url
+	"https://feeds.example/plain.txt", // credential-free feed url
+	"ns1.example.com:53",              // plain host:port update-server
+}
+
+func stageURLSecretConfig6703(t *testing.T) *Server {
+	t.Helper()
+	cmds := []string{
+		"set system services dynamic-dns provider p1 backend generic",
+		"set system services dynamic-dns provider p1 update-server ns1.example.com:53",
+		`set system services dynamic-dns provider p1 server "https://user:LEAK-SERVER-USERINFO@dyn.example/upd"`,
+		`set system services dynamic-dns provider p1 url-template "https://tmpl.example/upd?token=LEAK-URLTEMPLATE-QUERY&host=%h"`,
+		`set system services dynamic-dns provider p1 checkip-url "https://checkip.example/?k=LEAK-CHECKIP-QUERY"`,
+		"set system services dynamic-dns provider p2 backend generic",
+		`set system services dynamic-dns provider p2 checkip-url "https://checkip-plain.example/"`,
+		`set security dynamic-address feed-server threat url "https://feeds.example/list.txt?key=LEAK-FEED-QUERY"`,
+		`set security dynamic-address feed-server clean url "https://feeds.example/plain.txt"`,
+	}
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if _, err := store.LoadSet(strings.Join(cmds, "\n")); err != nil {
+		t.Fatalf("LoadSet() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return &Server{store: store}
+}
+
+// TestConfigReadSurfacesRedactURLSecrets_6703 drives the three routes named in
+// #6703's acceptance criteria and asserts both halves on each.
+func TestConfigReadSurfacesRedactURLSecrets_6703(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		target string
+	}{
+		{"GET /api/v1/config", "/api/v1/config"},
+		{"GET /api/v1/config/export", "/api/v1/config/export?format=set"},
+		{"GET /api/v1/config/show", "/api/v1/config/show"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := stageURLSecretConfig6703(t)
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", tc.target, nil)
+			switch {
+			case strings.Contains(tc.target, "/export"):
+				s.configExportHandler(rr, req)
+			case strings.Contains(tc.target, "/show"):
+				s.configShowHandler(rr, req)
+			default:
+				s.configHandler(rr, req)
+			}
+			if rr.Code != 200 {
+				t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+			}
+			body := rr.Body.String()
+
+			for _, leak := range urlSecretSentinels6703 {
+				if strings.Contains(body, leak) {
+					t.Errorf("%s leaked cleartext URL credential %q", tc.target, leak)
+				}
+			}
+			for _, keep := range urlCleanValues6703 {
+				if !strings.Contains(body, keep) {
+					t.Errorf("%s over-redacted: credential-free value %q must render unchanged\nbody: %s",
+						tc.target, keep, body)
+				}
+			}
+			// The host survives on a REDACTED value too — #6703 requires the
+			// field stay diagnosable, so redaction must not swallow the authority.
+			if !strings.Contains(body, "dyn.example") {
+				t.Errorf("%s dropped the host of a redacted URL; the field must stay diagnosable\nbody: %s",
+					tc.target, body)
+			}
+		})
+	}
+}
+
+// TestRedactedURLExportIsNotRestorable_6703 pins the round-trip guard on its
+// REAL production path — Store.Commit -> SchemaValidateWithDefinitions
+// (schema_walk.go) -> checkRedactionPlaceholder — rather than by calling the
+// guard directly.
+//
+// This matters more for URLs than for secrets. The secret placeholder
+// ("##SECRET-DATA##") is obviously not a password, but a redacted URL still
+// LOOKS like a valid URL, so without the guard an operator re-applying a
+// redacted export would silently commit a DDNS provider that publishes to
+// "https://dyn.example/upd?<redacted>" — a broken endpoint that fails at
+// runtime rather than at commit.
+func TestRedactedURLExportIsNotRestorable_6703(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if _, err := store.LoadSet(
+		`set system services dynamic-dns provider p1 server "https://dyn.example/upd?<redacted>"`); err != nil {
+		t.Fatalf("LoadSet() error = %v", err)
+	}
+	_, err := store.Commit()
+	if err == nil {
+		t.Fatal("committing a redacted export must fail — it is a display render, not a restorable config")
+	}
+	if !strings.Contains(err.Error(), "redacted URL") {
+		t.Errorf("the refusal must name the cause, got %v", err)
+	}
+
+	// The same commit with a cleartext URL must succeed, so the guard is not a
+	// blanket ban on URLs that merely resemble a redacted one.
+	ok := newConfigStore(t, filepath.Join(t.TempDir(), "xpf2.conf"))
+	if err := ok.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if _, err := ok.LoadSet(
+		`set system services dynamic-dns provider p1 server "https://dyn.example/upd?token=real"`); err != nil {
+		t.Fatalf("LoadSet() error = %v", err)
+	}
+	if _, err := ok.Commit(); err != nil {
+		t.Fatalf("a cleartext URL must commit cleanly, got %v", err)
+	}
+}

--- a/pkg/config/ast_redact.go
+++ b/pkg/config/ast_redact.go
@@ -88,6 +88,15 @@ func redactNodes(nodes []*Node, base []string) {
 				n.Keys[idx-len(base)] = SecretDataPlaceholder
 			}
 		}
+		// #6703: URL-bearing leaves are TRANSFORMED, not masked — see
+		// urlLeafIndices. RedactURL strips userinfo/query/fragment (and an
+		// implausible authority, #6609) while keeping scheme/host/path, so a
+		// credential-free URL renders unchanged.
+		for _, idx := range urlLeafIndices(full) {
+			if idx >= len(base) && idx < len(full) {
+				n.Keys[idx-len(base)] = RedactURL(n.Keys[idx-len(base)])
+			}
+		}
 		if !n.IsLeaf {
 			redactNodes(n.Children, full)
 		}
@@ -151,6 +160,46 @@ func secretIndices(fp []string) []int {
 	return out
 }
 
+// urlLeafIndices returns the indices into the flattened key path fp that hold a
+// URL-BEARING leaf value. These are redacted by TRANSFORM (RedactURL) rather
+// than by replacement with SecretDataPlaceholder, because a URL is
+// secret-BEARING without being a secret (#6703): the credential lives in the
+// userinfo, query or fragment, while the scheme/host/path are the diagnostic
+// payload an operator needs to keep seeing. Masking the whole token would make
+// a credential-free URL — the overwhelmingly common case — unreadable.
+//
+// KEYED ON THE LEAF NAME, not on a list of config locations. `url` is matched
+// in EVERY context, so a future url-bearing leaf inherits redaction with no
+// extra step; that is deliberate, and it is why this does not repeat the
+// hand-scoped mistake that produced #6703 in the first place. Applying
+// RedactURL universally is safe precisely because it is a no-op on a URL with
+// no credential-bearing component.
+//
+// The two DDNS leaves that are URLs without being named `url`
+// (`url-template`, `checkip-url`) are distinctive enough to match unqualified.
+// `server` and `update-server` are NOT — `server` is also an NTP leaf
+// (schema_system.go) — so both are gated on a `dynamic-dns` ancestor, the same
+// context-gate doctrine secretIndices uses for the generic `password` keyword.
+func urlLeafIndices(fp []string) []int {
+	var out []int
+	for i, k := range fp {
+		switch k {
+		case "url", "url-template", "checkip-url":
+			for j := i + 1; j < len(fp); j++ {
+				out = append(out, j)
+			}
+		case "server", "update-server":
+			// Generic keywords — a URL only under a DDNS provider.
+			if containsAnyOf(fp[:i], "dynamic-dns") {
+				for j := i + 1; j < len(fp); j++ {
+					out = append(out, j)
+				}
+			}
+		}
+	}
+	return out
+}
+
 // containsAnyOf reports whether seq contains any of names.
 func containsAnyOf(seq []string, names ...string) bool {
 	for _, s := range seq {
@@ -185,6 +234,20 @@ var errRedactionPlaceholderIngest = errors.New(
 		"restorable config; restore from the DR archive (request system " +
 		"configuration rescue) or re-enter the secret in cleartext")
 
+// errRedactedURLIngest is the URL-leaf sibling of errRedactionPlaceholderIngest
+// (#6703). RedactURL rewrites a credential-bearing URL leaf to contain the
+// typed sentinel ("<redacted>") on the display paths, and unlike the secret
+// placeholder the result still LOOKS like a valid URL — so re-committing a
+// redacted export would silently install a broken endpoint (a DDNS provider
+// publishing to "https://host/upd?<redacted>", a feed fetched from a mangled
+// URL) instead of failing loudly. That is a worse failure than the secret case,
+// which is why the ingest guard is symmetric rather than optional.
+var errRedactedURLIngest = errors.New(
+	"config contains a redacted URL value (" + SecretRedacted + ") — this is a " +
+		"redacted export (REST show/export / gRPC ShowConfig), not a restorable " +
+		"config; restore from the DR archive (request system configuration " +
+		"rescue) or re-enter the URL in cleartext")
+
 // checkRedactionPlaceholder rejects a tree whose SECRET leaf value is exactly
 // SecretDataPlaceholder ("##SECRET-DATA##"). It is invoked by the commit-ingest
 // schema gate (SchemaValidateWithDefinitions), so on the strict operator commit
@@ -205,7 +268,36 @@ func checkRedactionPlaceholder(t *ConfigTree) error {
 	if path := findRedactionPlaceholder(t.Children, nil); path != "" {
 		return fmt.Errorf("%w (at %q)", errRedactionPlaceholderIngest, path)
 	}
+	if path := findRedactedURL(t.Children, nil); path != "" {
+		return fmt.Errorf("%w (at %q)", errRedactedURLIngest, path)
+	}
 	return nil
+}
+
+// findRedactedURL is the URL-leaf mirror of findRedactionPlaceholder (#6703).
+// Its scope is exactly what redactNodes TRANSFORMS — the same urlLeafIndices
+// set is used to detect the sentinel that produced it — so detection stays
+// symmetric with masking under either AST shape.
+//
+// It tests CONTAINS rather than equals: RedactURL embeds the sentinel inside an
+// otherwise-intact URL ("https://host/upd?<redacted>"), so an equality test
+// would miss every real case. A non-URL leaf carrying that literal is not
+// inspected at all, mirroring the placeholder guard's deliberate narrowness.
+func findRedactedURL(nodes []*Node, base []string) string {
+	for _, n := range nodes {
+		full := append(append([]string(nil), base...), n.Keys...)
+		for _, idx := range urlLeafIndices(full) {
+			if idx >= len(base) && idx < len(full) && strings.Contains(n.Keys[idx-len(base)], SecretRedacted) {
+				return strings.Join(full[:idx+1], " ")
+			}
+		}
+		if !n.IsLeaf {
+			if hit := findRedactedURL(n.Children, full); hit != "" {
+				return hit
+			}
+		}
+	}
+	return ""
 }
 
 // findRedactionPlaceholder walks nodes maintaining the flattened key path of all

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"slices"
 	"sort"
 	"strings"
@@ -68,6 +69,25 @@ type FeedServer struct {
 	HoldInterval   int         // seconds; 0/unset = retain last-good forever on failure, >0 = drop to empty after N seconds (#2050)
 	FeedName       string      // single feed-name (backward compat, no path)
 	FeedEntries    []FeedEntry // named feeds with per-feed paths
+}
+
+// MarshalJSON redacts the feed URL on every JSON render (#6703). A threat-feed
+// URL routinely carries the subscription token in its query string, and the
+// REST config-read surface json-encodes the compiled *Config directly, so the
+// plain string field marshalled VERBATIM — while the `show security
+// dynamic-address` surfaces have rendered it through RedactURL all along. This
+// makes the two agree.
+//
+// The alias type sheds this method to avoid recursion while preserving every
+// field, so a field added to FeedServer later is still marshalled.
+func (f *FeedServer) MarshalJSON() ([]byte, error) {
+	if f == nil {
+		return []byte("null"), nil
+	}
+	type alias FeedServer
+	v := alias(*f)
+	v.URL = RedactURL(v.URL)
+	return json.Marshal(v)
 }
 
 // FeedEntry is a named feed within a feed-server, with an optional path.

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -374,6 +374,34 @@ func (p *DDNSProvider) String() string {
 		p.AWSRegion, p.HostedZoneID, RedactURL(p.CheckIPURL), p.CheckIPAllowlist)
 }
 
+// MarshalJSON redacts the URL-bearing leaves on every JSON render of a
+// provider (#6703). The Secret-typed credentials (TSIGSecret, Password,
+// APIToken, AWSSecretAccessKey) are already handled by Secret.MarshalJSON, and
+// String() has redacted these same URL fields since #2781 — but the REST
+// config-read surface does neither: GET /api/v1/config json-encodes the
+// compiled *Config directly, so a plain string field marshalled VERBATIM. That
+// route leaked even a userinfo credential, which RedactURL has always stripped,
+// because nothing on the path ever called it.
+//
+// The alias type sheds this method (so json.Marshal does not recurse) while
+// keeping every field and tag identical, and the copy is redacted in place —
+// so a field added to DDNSProvider later is still marshalled, and only these
+// four are rewritten. A hand-built object literal would silently drop new
+// fields, which is the failure mode that makes hand-maintained render lists
+// unsafe.
+func (p *DDNSProvider) MarshalJSON() ([]byte, error) {
+	if p == nil {
+		return []byte("null"), nil
+	}
+	type alias DDNSProvider
+	v := alias(*p)
+	v.UpdateServer = RedactURL(v.UpdateServer)
+	v.Server = RedactURL(v.Server)
+	v.URLTemplate = RedactURL(v.URLTemplate)
+	v.CheckIPURL = RedactURL(v.CheckIPURL)
+	return json.Marshal(v)
+}
+
 // SSHServiceConfig holds SSH service settings.
 type SSHServiceConfig struct {
 	RootLogin   string   // "allow", "deny", "deny-password"

--- a/pkg/config/url_redaction_6703_test.go
+++ b/pkg/config/url_redaction_6703_test.go
@@ -1,0 +1,219 @@
+package config
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// #6703. The config-READ surfaces rendered URL-bearing leaves with no redaction
+// at all — they leaked even a userinfo credential, which RedactURL has stripped
+// since #2781, because nothing on those paths ever called it. These tests pin
+// both halves of the property: a credential-bearing URL is redacted, AND a
+// credential-free one renders UNCHANGED. Only asserting the first cannot detect
+// over-redaction, which for these leaves would destroy the diagnostic value the
+// #6703 acceptance criteria explicitly require be kept.
+
+// TestURLLeafIndicesGatesGenericKeywords_6703 pins the context gate directly.
+// `server` is also an NTP leaf (schema_system.go) and `url` is not, so the two
+// keywords must be scoped differently. A render-level test cannot discriminate
+// here: RedactURL is a no-op on a bare NTP address, so a wrongly-ungated
+// `server` would still render unchanged and the test would pass for the wrong
+// reason.
+func TestURLLeafIndicesGatesGenericKeywords_6703(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path []string
+		want []int
+	}{
+		{"ddns server is a url leaf",
+			[]string{"system", "services", "dynamic-dns", "provider", "p1", "server", "VALUE"}, []int{6}},
+		{"ddns update-server is a url leaf",
+			[]string{"system", "services", "dynamic-dns", "provider", "p1", "update-server", "VALUE"}, []int{6}},
+		{"NTP server is NOT a url leaf",
+			[]string{"system", "ntp", "server", "VALUE"}, nil},
+		{"url matches in every context — feed",
+			[]string{"security", "dynamic-address", "feed-server", "f1", "url", "VALUE"}, []int{5}},
+		{"url matches in every context — license autoupdate",
+			[]string{"system", "license", "autoupdate", "url", "VALUE"}, []int{4}},
+		{"url-template is distinctive, no gate needed",
+			[]string{"system", "services", "dynamic-dns", "provider", "p1", "url-template", "VALUE"}, []int{6}},
+		{"checkip-url is distinctive, no gate needed",
+			[]string{"system", "services", "dynamic-dns", "provider", "p1", "checkip-url", "VALUE"}, []int{6}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := urlLeafIndices(tc.path)
+			if len(got) != len(tc.want) {
+				t.Fatalf("urlLeafIndices(%v) = %v, want %v", tc.path, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("urlLeafIndices(%v) = %v, want %v", tc.path, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// TestDDNSProviderMarshalJSONRedactsURLs_6703 asserts the JSON render both
+// redacts and preserves. GET /api/v1/config json-encodes the compiled *Config,
+// so this marshaller is the whole fix for that route.
+func TestDDNSProviderMarshalJSONRedactsURLs_6703(t *testing.T) {
+	p := &DDNSProvider{
+		Name:         "p1",
+		Backend:      "generic",
+		UpdateServer: "ns1.example.com:53",
+		Server:       "https://user:SUPERSECRET@dyn.example/upd",
+		URLTemplate:  "https://tmpl.example/upd?token=TOKENSECRET&host=%h",
+		CheckIPURL:   "https://checkip.example/plain",
+		Username:     "operator",
+		Password:     Secret("PASSWORDSECRET"),
+		OKResponse:   "good",
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	out := string(b)
+
+	for _, leak := range []string{"SUPERSECRET", "TOKENSECRET", "PASSWORDSECRET"} {
+		if strings.Contains(out, leak) {
+			t.Errorf("marshalled provider leaked %q: %s", leak, out)
+		}
+	}
+	// Assert what the values BECAME, not merely that they changed.
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if want := "https://<redacted>@dyn.example/upd"; got["Server"] != want {
+		t.Errorf("Server = %q, want %q", got["Server"], want)
+	}
+	if want := "https://tmpl.example/upd?<redacted>"; got["URLTemplate"] != want {
+		t.Errorf("URLTemplate = %q, want %q", got["URLTemplate"], want)
+	}
+	// NO credential -> UNCHANGED. This half is what detects over-redaction.
+	if want := "https://checkip.example/plain"; got["CheckIPURL"] != want {
+		t.Errorf("credential-free CheckIPURL = %q, want it rendered unchanged as %q", got["CheckIPURL"], want)
+	}
+	if want := "ns1.example.com:53"; got["UpdateServer"] != want {
+		t.Errorf("plain host:port UpdateServer = %q, want it rendered unchanged as %q", got["UpdateServer"], want)
+	}
+	// Non-URL fields must survive: the alias-copy exists so a field added to
+	// DDNSProvider later is still marshalled rather than silently dropped.
+	if got["Username"] != "operator" || got["OKResponse"] != "good" || got["Backend"] != "generic" {
+		t.Errorf("marshaller dropped or altered a non-URL field: %s", out)
+	}
+}
+
+// TestFeedServerMarshalJSONRedactsURL_6703 is the same property for the feed
+// leaf, whose token conventionally rides in the query string.
+func TestFeedServerMarshalJSONRedactsURL_6703(t *testing.T) {
+	withTok := &FeedServer{Name: "threat", URL: "https://feeds.example/list.txt?key=FEEDSECRET", UpdateInterval: 900}
+	b, err := json.Marshal(withTok)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if strings.Contains(string(b), "FEEDSECRET") {
+		t.Errorf("feed URL leaked its token: %s", b)
+	}
+	if want := "https://feeds.example/list.txt?<redacted>"; got["URL"] != want {
+		t.Errorf("URL = %q, want %q", got["URL"], want)
+	}
+	if got["UpdateInterval"] != float64(900) {
+		t.Errorf("marshaller dropped a non-URL field: %s", b)
+	}
+
+	clean := &FeedServer{Name: "threat", URL: "https://feeds.example/list.txt"}
+	cb, err := json.Marshal(clean)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := json.Unmarshal(cb, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if want := "https://feeds.example/list.txt"; got["URL"] != want {
+		t.Errorf("credential-free feed URL = %q, want it rendered unchanged as %q", got["URL"], want)
+	}
+}
+
+// TestRedactedCloneTransformsURLLeaves_6703 covers the AST render path backing
+// /config/export and /config/show. Unlike a secret leaf, a URL leaf is
+// TRANSFORMED rather than masked, so scheme/host/path stay visible.
+func TestRedactedCloneTransformsURLLeaves_6703(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, cmd := range []string{
+		`set system services dynamic-dns provider p1 server "https://user:ASTSECRET@dyn.example/upd"`,
+		`set security dynamic-address feed-server threat url "https://feeds.example/list.txt?key=ASTFEEDSECRET"`,
+		`set security dynamic-address feed-server clean url "https://feeds.example/plain.txt"`,
+		`set system ntp server 192.0.2.1`,
+	} {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	out := tree.RedactedClone().FormatSet()
+
+	for _, leak := range []string{"ASTSECRET", "ASTFEEDSECRET"} {
+		if strings.Contains(out, leak) {
+			t.Errorf("redacted AST render leaked %q:\n%s", leak, out)
+		}
+	}
+	if !strings.Contains(out, "https://<redacted>@dyn.example/upd") {
+		t.Errorf("ddns server not transformed as expected:\n%s", out)
+	}
+	if !strings.Contains(out, "https://feeds.example/list.txt?<redacted>") {
+		t.Errorf("feed url not transformed as expected:\n%s", out)
+	}
+	// Both no-op halves: a credential-free URL and a non-URL `server` leaf.
+	if !strings.Contains(out, "https://feeds.example/plain.txt") {
+		t.Errorf("credential-free feed url must render UNCHANGED:\n%s", out)
+	}
+	if !strings.Contains(out, "192.0.2.1") {
+		t.Errorf("NTP server must be untouched by URL redaction:\n%s", out)
+	}
+	// The live tree is never mutated — RedactedClone is display-only.
+	if !strings.Contains(tree.FormatSet(), "ASTSECRET") {
+		t.Error("RedactedClone mutated the live tree; the cleartext SSOT backs HA sync and persistence")
+	}
+}
+
+// TestRedactedURLIngestIsRefused_6703 pins the round-trip guard. Redacting a
+// URL leaf produces something that still LOOKS like a valid URL, so without
+// this an operator re-applying a redacted export would silently install a
+// broken endpoint instead of failing loudly.
+func TestRedactedURLIngestIsRefused_6703(t *testing.T) {
+	tree := &ConfigTree{}
+	path, err := ParseSetCommand(`set system services dynamic-dns provider p1 server "https://dyn.example/upd?<redacted>"`)
+	if err != nil {
+		t.Fatalf("ParseSetCommand: %v", err)
+	}
+	if err := tree.SetPath(path); err != nil {
+		t.Fatalf("SetPath: %v", err)
+	}
+	err = checkRedactionPlaceholder(tree)
+	if err == nil {
+		t.Fatal("a redacted URL value must be refused on commit-ingest")
+	}
+	if !strings.Contains(err.Error(), "redacted URL") {
+		t.Errorf("error must identify the cause, got %v", err)
+	}
+
+	// A cleartext URL must still ingest cleanly — the guard is not a blanket ban.
+	clean := &ConfigTree{}
+	p2, _ := ParseSetCommand(`set system services dynamic-dns provider p1 server "https://dyn.example/upd"`)
+	if err := clean.SetPath(p2); err != nil {
+		t.Fatalf("SetPath: %v", err)
+	}
+	if err := checkRedactionPlaceholder(clean); err != nil {
+		t.Errorf("a cleartext URL must ingest cleanly, got %v", err)
+	}
+}


### PR DESCRIPTION
`GET /api/v1/config`, `/config/export` and `/config/show` rendered the URL-bearing config leaves in cleartext — the DDNS provider's `server`, `url-template` and `checkip-url`, and a dynamic-address `feed-server url`. Those are the ordinary way both features are configured: dyndns2 uses HTTP Basic by protocol, and a threat feed carries its subscription token in the query string.

Measured before and after, one sentinel per field, driving the live handlers:

| route | before | after |
|---|---|---|
| `GET /api/v1/config` | all 4 leaked verbatim | none |
| `GET /api/v1/config/export?format=set` | all 4 leaked verbatim | none |
| `GET /api/v1/config/show` | all 4 leaked verbatim | none |

## The defect was not where it looked

`RedactURL` has stripped userinfo since #2781, and `DDNSProvider.String()` has applied it to these same fields all along — yet the JSON route still rendered a `user:pass@` credential **verbatim**. That is only possible if neither is on the path, and neither is: `configHandler` json-encodes the compiled `*Config` directly with no `MarshalJSON` on either struct, while the AST display path is keyword-driven and `secretIndices` had no `url`, `server` or `url-template` entry.

So the mechanism is **"no redactor is reached"**, not "the redactor has a gap". A change aimed at `RedactURL` would have been invisible to all three routes and closed nothing.

## Acceptance criteria are satisfied by this change alone

- **no userinfo, no credential query parameter on any of the three routes** — measured above.
- **scheme, host and path remain visible** — URL leaves are *transformed*, not masked. Asserted directly: the host survives on a redacted value.
- **a URL without credentials renders unchanged** — asserted on every route with credential-free values (a plain `checkip-url`, a plain feed `url`, a bare `ns1.example.com:53`). Without this half the tests could not distinguish working redaction from blanket over-redaction.
- **the leaf set is derived, not hand-enumerated** — the AST rule is keyed on the **leaf name**, so `url` matches in *every* context and a future url-bearing leaf inherits redaction with no extra step. That caught two leaves the issue never listed: `system license autoupdate url` and `services rpm probe … target url`, both measured leaking.

Rows covered: userinfo, query, fragment, and the implausible-authority case #6609 added. The **hostname/path** row is deliberately out of scope and unfixable by any string rule — see #7406 — not missed.

## What this change does NOT touch

`RedactURL` is unchanged. It has **18 call sites across 6 packages**, and 9 of them need the host in their output:

- the three `show security dynamic-address` surfaces (`pkg/api/show_text.go:194`, `pkg/grpcapi/server_show_security_text.go:897`, `pkg/cli/cli_show_security_objects.go:264`) — commands whose *purpose* is displaying the configured URL
- the commit-time warnings that name the offending value (`compiler_validate_warn_ddns.go:351,396`, `compiler_system.go:642`, `compiler_validate_strict_observability.go:229`)
- the feed-fetch failure logs that say which server is down (`feeds.go:210,379`)

All keep their current behaviour, and #6609's extension stays the last word on the authority rules.

The render change is **display-only**: `redactNodes` runs solely from `RedactedClone`, persistence marshals the AST tree (untouched), and `ExportJSON` has no non-test callers — so the cleartext SSOT backing HA sync, the DR archive and rollback is unaffected.

## Design notes

**Transform, not mask.** A URL is secret-*bearing* without being a secret. Masking the whole token with `##SECRET-DATA##` would make a credential-free URL unreadable and drop the host, violating two acceptance criteria outright.

**Alias-copy marshallers.** Each `MarshalJSON` copies through an alias type that sheds the method (no recursion) while keeping every field and tag, then redacts in place — so a field added to either struct later is still marshalled. A hand-built object literal would silently drop it, which is the same class of mistake that produced this defect.

**Gating.** `url-template` and `checkip-url` are distinctive enough to match unqualified; `server` and `update-server` are gated on a `dynamic-dns` ancestor because `server` is also an NTP leaf. That gate is pinned by a **direct unit test**, not a render test — `RedactURL` is a no-op on a bare NTP address, so a wrongly-ungated `server` would still render unchanged and the test would pass for the wrong reason.

**Round-trip guard.** Redaction creates a hazard that the secret placeholder does not: a redacted URL still *looks* like a valid URL, so re-applying a redacted export would silently install a provider publishing to `https://dyn.example/upd?<redacted>` instead of failing at commit. A URL leaf containing the sentinel is now refused on commit-ingest, using the same leaf set that produced it, and pinned on its real production path (`Store.Commit` → `SchemaValidateWithDefinitions` → `checkRedactionPlaceholder`).

## Validation

Full Go suite `-count=1`: **FULL_RC=0, zero FAIL**. (An initial `pkg/daemon` red was my harness — unix-socket paths exceeding the sockaddr limit under a long `TMPDIR`; green with a short one, and unrelated to this change.)

### Mutation matrix

One line each, rc from `$?`, `go vet` clean at every mutated state, RUN count matching the control (17) at every cell.

| mutation | vet | result |
|---|---|---|
| `DDNSProvider.MarshalJSON` stops redacting `Server` | 0 | **RED** — `leaked "SUPERSECRET"` |
| `FeedServer.MarshalJSON` stops redacting `URL` | 0 | **RED** — `feed URL leaked its token` |
| AST walk stops transforming url leaves | 0 | **RED** — `redacted AST render leaked "ASTSECRET"` |
| drop the `dynamic-dns` gate on `server` (over-redaction) | 0 | **RED** — `urlLeafIndices([system ntp server VALUE]) = [3], want []` |
| remove the ingest guard | 0 | **RED** — `a redacted URL value must be refused on commit-ingest` |
| narrow `url` to `feed-server` only (the hand-scoped shape) | 0 | **RED** — `urlLeafIndices([system license autoupdate url VALUE]) = []` |

Does not reach the Rust helper binary. No hardware needed.

## Known residual

`system license autoupdate url` and `services rpm probe … target url` are now redacted on the **export/show** routes (they fell out of the leaf-name rule) but still render verbatim on **`GET /api/v1/config`**, because they live on structs outside this change's scope and would need their own marshallers. Measured, not assumed. Reported separately rather than widened into here.

Closes #6703