### PR TITLE
docs(ddns): state where a credential may be placed in a URL (#7406)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,21 @@
+## 2026-08-22 — #7406: operator note on where a credential may live in a URL
+
+- **Timestamp**: 2026-08-22
+- **Action**: Documented the hostname/path residual in `pkg/ddns/README.md`,
+  placed directly after the paragraph that already enumerates userinfo and
+  query as the slots an operator may embed a credential in — so the reader
+  learns what IS stripped and what is NOT in one place.
+  Framed deliberately as CURRENT BEHAVIOUR ("is rendered verbatim by every
+  surface that redacts these leaves today") rather than as policy ("this is
+  the supported way to configure a credential"). The former stays true
+  whichever way #7406 is resolved; the latter would presume the
+  accept-and-document resolution over the explicit-secret-marking one, and
+  would have to be retracted if the grammar option lands. Does NOT close
+  #7406 — the grammar decision is still open and belongs to the config-schema
+  owner.
+  Docs-only; no code, no behaviour change.
+- **File(s)**: `pkg/ddns/README.md`
+
 ## 2026-08-22 — #6709/#7009: the pkg/ddns full-package flake, both mechanisms
 
 - **Timestamp**: 2026-08-22

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -72,6 +72,34 @@ diagnostics (#2781). A construction failure
 already fired) — fail-open, matching the rfc2136 posture. Live-provider verify
 is the deferred lab gate; the mock-server tests are the merge gate.
 
+### Where a credential may be placed in a URL (#7406)
+
+The two slots named above — the **userinfo** (`user:pass@host`) and the **query
+string** (`?token=...`) — are the slots `config.RedactURL` strips, along with
+the fragment and an authority that cannot be a `host:port` (#6609).
+
+A credential placed in the URL's **hostname** or **path** is rendered
+**verbatim** by every surface that redacts these leaves today — the package's
+own error and log lines, the commit-time warnings, the `show` output, and the
+REST config-read routes:
+
+    https://SECRET.dyn.example.com/nic/update     <-- rendered verbatim
+    https://example.com/nic/SECRET/update         <-- rendered verbatim
+
+This is not an oversight that a better redactor closes.
+`https://SECRET.dyn.example.com/upd` and `https://api.example.com/upd` are
+indistinguishable strings, so any rule that redacts the first redacts every
+host — which would remove the scheme/host/path that make a redacted URL worth
+printing at all.
+
+**Put credentials in the userinfo or the query string, where they are
+redacted.** Some providers do issue a token as a hostname label or a path
+segment; a provider configured that way has its token rendered in cleartext on
+the surfaces above.
+
+Tracked in #7406, which also records the two ways the residual could be closed
+(explicit operator marking of a leaf as secret, or accepting and documenting it).
+
 ### `server` / URL rendering in errors — parse first, then redact (#6545, #6606)
 
 Two rules, and the split between them is the whole discipline:


### PR DESCRIPTION
Docs only. No code, no behaviour change.

`pkg/ddns/README.md` already tells an operator that the `generic` backend lets a credential be embedded in the `url-template`, and that `RedactURL` strips userinfo and the query string. It did not say what happens to a credential placed anywhere **else** — so an operator whose provider issues a token as a hostname label had no way to know that token renders in cleartext.

This adds that, directly after the existing paragraph so the reader learns what is stripped and what is not in one place:

```
https://SECRET.dyn.example.com/nic/update     <-- rendered verbatim
https://example.com/nic/SECRET/update         <-- rendered verbatim
```

It also says **why**, because the reason is what stops this being read as a bug to file: `https://SECRET.dyn.example.com/upd` and `https://api.example.com/upd` are indistinguishable strings, so any rule redacting the first redacts *every* host — which would remove the scheme/host/path that make a redacted URL worth printing at all.

## Framing: current behaviour, not policy

Written deliberately as a statement of **what happens today**, not as a recommendation about intended design.

#7406 records two possible resolutions — explicit operator marking of a leaf as secret (a config-grammar change), or accepting and documenting the residual. That decision belongs to the config-schema owner and is still open.

- *"Credentials in the hostname or path are rendered verbatim today; put them in the userinfo or the query, where they are redacted"* — true now, and stays true whichever resolution lands.
- *"This is the supported way to configure a credential"* — would presume the accept-and-document resolution, and would have to be retracted if explicit marking lands.

This PR writes the former.

## Scope

**Does not close #7406.** The tracking issue stays open for the grammar decision. This is the half that is useful regardless and was at risk of being lost between the two.

Kept as its own small PR rather than folded into #7403 (a test-only flake fix) or #7410 (the #6703 redaction fix), so neither diff carries unrelated prose.

Refs #7406