### PR TITLE
config: reserve the value slot in the packed RG splitter (#6665)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -102545,3 +102545,20 @@ prose edit above them added. No diff falls in the new test body.
     controlLinkAuthKey now REDs). Residual closed: readLoop's CALL to admitFrame
     was still unbound — severing it left every 5086 test green.
   - **File(s)**: pkg/cluster/heartbeat_replay_restart_5086_test.go
+
+## 2026-08-22 — #6665 packed redundancy-group keyword theft
+- **Timestamp**: 2026-08-22
+- **Action**: `packedStatementProps` applied its keyword predicate to every token
+  in the tail with no positional state, so a registered keyword opened a
+  statement even in a VALUE slot: an interface whose name spells a keyword was
+  consumed as that statement — monitor silently dropped AND an unrelated
+  statement fabricated, so the RG accrues no link-down debt and never demotes.
+  Fixed with the value-slot reservation #6658 already established one level down
+  in `monitorEntryNodes`. Corrected two stale in-tree claims: the project DOES
+  have a canonical interface-name predicate
+  (`ValidateDeviceMapLogicalName`) and it admits all six keywords, so
+  reachability was "no operator would" not "the system prevents"; and the
+  "deliberately no test" note is superseded by a test that asserts packed ==
+  container, using the container spelling as the oracle.
+- **File(s)**: pkg/config/compiler_system.go,
+  pkg/config/packed_rg_keyword_theft_6665_test.go (new), _Log.md

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -2280,19 +2280,98 @@ func monitorWeightTokens(entry *Node) []string {
 // exist — properties are siblings, so nothing is lost either way (unlike a
 // monitored entry, where children are that entry's attributes).
 func packedStatementProps(cfgNode *Node, skip int, isProp func(string) bool) []*Node {
+	return packedStatementPropsArity(cfgNode, skip, isProp, nil)
+}
+
+// packedStatementPropsArity is packedStatementProps with a VALUE-SLOT contract
+// (#6665).
+//
+// THE DEFECT. The plain splitter applies isProp to every token in the tail with
+// no positional state at all, so a registered keyword opens a new statement
+// WHEREVER it appears — including where a value is expected. An interface whose
+// name spells a statement keyword is therefore consumed as that statement:
+//
+//	packed:    redundancy-group 1 interface-monitor ip-monitoring weight 255;
+//	             -> InterfaceMonitors=[]  IPMonitoring=&{}
+//	container: redundancy-group 1 { interface-monitor ip-monitoring weight 255; }
+//	             -> InterfaceMonitors=[{ip-monitoring 255}]  IPMonitoring=nil
+//
+// The monitor is dropped AND an unrelated statement is fabricated, and the two
+// spellings of one config compile differently. `pkg/cluster` then ranges an
+// empty InterfaceMonitors, so the redundancy group accrues no link-down debt and
+// never demotes — the failure `assertSingleMonitor` exists to name.
+//
+// It is sticky: configstore persists the TREE and re-emits a packed leaf as the
+// same packed line, so it survives `show configuration`, reboot and HA peer
+// sync. Authored once, wrong forever.
+//
+// THE FIX IS #6658'S OWN SHAPE, one level up. monitorEntryNodes already reserves
+// a value slot — "`weight` consumes exactly one following token even when that
+// token spells a name" — for exactly this class. `arity` lifts that contract to
+// the statement splitter: a keyword that takes an argument consumes the next
+// token unconditionally, so the token in its value slot cannot re-arm the
+// splitter.
+//
+// A nil arity is the pre-#6665 behaviour, kept for the ip-monitoring caller
+// whose sub-keywords have no name-shaped value slot.
+//
+// WHAT IT DOES NOT RESOLVE, stated rather than implied: `interface-monitor` is
+// variadic, so only its FIRST token is protected. `interface-monitor ge-0/0/0
+// preempt;` still reads `preempt` as a statement — which is also what the
+// container form does, so the two spellings agree, which is the property under
+// repair. There is no local information that distinguishes "a second monitor
+// named preempt" from "no more monitors, then preempt", and inventing one would
+// break the multi-statement packing #6588 pins.
+func packedStatementPropsArity(
+	cfgNode *Node,
+	skip int,
+	isProp func(string) bool,
+	arity func(string) int,
+) []*Node {
 	var props []*Node
 	if len(cfgNode.Keys) > skip {
 		var cur *Node
+		pending := 0 // value tokens the open statement must still absorb
 		for _, tok := range cfgNode.Keys[skip:] {
+			if pending > 0 {
+				pending--
+				cur.Keys = append(cur.Keys, tok)
+				continue
+			}
 			if cur == nil || isProp(tok) {
 				cur = &Node{Keys: []string{tok}, Line: cfgNode.Line, Column: cfgNode.Column}
 				props = append(props, cur)
+				if arity != nil {
+					pending = arity(tok)
+				}
 				continue
 			}
 			cur.Keys = append(cur.Keys, tok)
 		}
 	}
 	return append(props, cfgNode.Children...)
+}
+
+// redundancyGroupStatementArity is how many tokens a redundancy-group statement
+// consumes as its VALUE before the splitter may open another statement (#6665).
+//
+// Derived from the grammar the compilers actually read, and deliberately only
+// for the statements whose value slot can hold a free-form identifier or a
+// number. `preempt` and `strict-vip-ownership` take nothing, so the token after
+// them genuinely does open a statement.
+func redundancyGroupStatementArity(tok string) int {
+	switch tok {
+	case "interface-monitor":
+		// `<ifname>` — the one free-form identifier slot in the whole stanza,
+		// and therefore the only slot a keyword can be stolen out of.
+		return 1
+	case "node", "gratuitous-arp-count":
+		// `<node-id>` / `<count>` — numeric, so a keyword here is already
+		// rejected by the #5694 identity gate rather than silently stolen; the
+		// reservation makes that a parse-time fact instead of a downstream one.
+		return 1
+	}
+	return 0
 }
 
 // redundancyGroupBody returns the body statements of one `redundancy-group`
@@ -2348,7 +2427,8 @@ func redundancyGroupBody(rgNode *Node) []*Node {
 	if rgNode.Name() == "redundancy-group" {
 		skip = 2
 	}
-	return packedStatementProps(rgNode, skip, isRedundancyGroupStatement)
+	return packedStatementPropsArity(
+		rgNode, skip, isRedundancyGroupStatement, redundancyGroupStatementArity)
 }
 
 // redundancyGroupStatements is the SINGLE SOURCE OF TRUTH for what a
@@ -2416,28 +2496,37 @@ func redundancyGroupBody(rgNode *Node) []*Node {
 // a stale "measured" claim is how the next reader concludes the analysis was
 // already done and stops checking.)
 //
-// NOT fixed here. The stolen token has to sit in entry-NAME position, and no
-// legal Junos interface name or IP address collides with any keyword registered
-// below — names are ge-*/xe-*/et-*, reth*, fxp*, em*, lo0, st0, ae*, fab*, irb,
-// vlan. So the input is unreachable from a real config, and the runtime
-// materiality is nil.
+// FIXED in #6665, by exactly the move the paragraph that used to sit here said
+// would be needed: the splitter is now position-aware. A statement that takes an
+// argument reserves its value slot (redundancyGroupStatementArity), so the token
+// in that slot cannot re-arm the splitter — the same "reserve the value slot"
+// contract monitorEntryNodes already applied one level down for `weight`.
 //
-// Note what is and is not guarded, since the paragraph above is the kind of
-// claim that rots. There is deliberately NO test asserting the divergence: it
-// would pin the wrong answer as correct and would have to be deleted by whoever
-// fixes this. There is also no test asserting "keyword is not a legal interface
-// name" — the project has no canonical interface-name predicate, so such a test
-// would have to invent the grammar, and inventing a model of something that
-// lives nowhere in code is the same mistake as the source-parsing drift guard
-// this table replaced. What IS guarded is the EDIT that would make the route
-// reachable: registering a statement here trips the completeness check in
-// TestRedundancyGroupStatementsSurvivePackedLine_6588, which fails until a human
-// adds a sample for the new keyword. That is the moment to ask whether the new
-// keyword can also spell an entry name.
+// Two claims that used to live here were wrong and are corrected rather than
+// deleted, because both were load-bearing for the decision to defer:
 //
-// Fixing it properly means splitting position-aware — a keyword opens a
-// statement only where a statement may begin — which changes the splitter
-// contract and does not belong in a fix for the drop bug.
+//   - "no legal Junos interface name collides with any keyword". The reachability
+//     argument was "no operator would do this", not "the system prevents it" —
+//     and the system does NOT prevent it. `chassis device-map interface
+//     <logical-name>` is gated by ValidateDeviceMapLogicalName
+//     (schema_validators_devicemap.go), which accepts any non-empty,
+//     whitespace-free, dot-free [a-zA-Z0-9-/] string. All six registered
+//     keywords pass it. The predicate the old comment said did not exist does.
+//
+//   - "there is deliberately NO test asserting the divergence: it would pin the
+//     wrong answer as correct". True while the divergence stood; the test that
+//     belongs here asserts the packed and container spellings AGREE, using the
+//     container form as the oracle, which pins the RIGHT answer without
+//     hand-writing an expectation. That is
+//     TestPackedRGDoesNotStealAKeywordFromTheValueSlot_6665.
+//
+// The residual, stated rather than implied: `interface-monitor` is variadic, so
+// only its FIRST token is protected. `interface-monitor ge-0/0/0 preempt;` still
+// reads `preempt` as a statement — and so does the container form, so the two
+// spellings agree, which is the property under repair. No local information
+// distinguishes "a second monitor named preempt" from "no more monitors, then
+// preempt", and inventing one would break the multi-statement packing
+// TestRedundancyGroupStatementsSurvivePackedLine_6588 pins.
 var redundancyGroupStatements = map[string]func(rg *RedundancyGroup, child *Node){
 	"node":                 compileRGNodePriority,
 	"gratuitous-arp-count": compileRGGratuitousARPCount,

--- a/pkg/config/packed_rg_keyword_theft_6665_test.go
+++ b/pkg/config/packed_rg_keyword_theft_6665_test.go
@@ -1,0 +1,191 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+)
+
+// packedRG6665 compiles a fully-PACKED redundancy-group instance line — the
+// body on the instance node's own Keys, which is the only shape that reaches
+// the splitter.
+func packedRG6665(t *testing.T, body string) *RedundancyGroup {
+	t.Helper()
+	text := fmt.Sprintf(`chassis {
+    cluster {
+        cluster-id 1;
+        node 0;
+        authentication-key "test-cluster-psk-value";
+        redundancy-group 1 %s
+    }
+}
+`, body)
+	cfg, err := CompileConfig(mustParse6665(t, text))
+	if err != nil {
+		t.Fatalf("compile %q: %v", body, err)
+	}
+	if cfg.Chassis.Cluster == nil || len(cfg.Chassis.Cluster.RedundancyGroups) == 0 {
+		t.Fatalf("no redundancy group compiled from %q", body)
+	}
+	for _, rg := range cfg.Chassis.Cluster.RedundancyGroups {
+		if rg != nil && rg.ID == 1 {
+			return rg
+		}
+	}
+	t.Fatalf("redundancy-group 1 not found for %q", body)
+	return nil
+}
+
+// containerRG6665 compiles the SAME statement in the container spelling, which
+// never reaches the splitter and is therefore the correct answer by
+// construction.
+func containerRG6665(t *testing.T, body string) *RedundancyGroup {
+	t.Helper()
+	return packedRG6665(t, "{ "+body+" }")
+}
+
+func mustParse6665(t *testing.T, text string) *ConfigTree {
+	t.Helper()
+	tree, err := NewParser(text).Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return tree
+}
+
+// TestPackedRGDoesNotStealAKeywordFromTheValueSlot_6665 is the fail-on-revert
+// gate.
+//
+// The splitter matched a statement keyword WHEREVER it appeared, including in a
+// value slot, so an interface whose name spells a keyword was consumed as that
+// statement: the monitor was silently dropped AND an unrelated statement was
+// fabricated. `pkg/cluster` then ranges an empty InterfaceMonitors, so the group
+// accrues no link-down debt and never demotes.
+//
+// The oracle is the CONTAINER spelling of the same statement, which cannot reach
+// the splitter. Asserting packed == container is what makes this a test of the
+// defect rather than of a hand-written expectation.
+func TestPackedRGDoesNotStealAKeywordFromTheValueSlot_6665(t *testing.T) {
+	// Every keyword in the dispatch table, in the one free-form identifier slot
+	// the stanza has. A single-keyword case would leave the others silent — and
+	// the bare-flag spellings below were still SILENT at HEAD even after #6658's
+	// arity gate, which only fires on trailing tokens.
+	for kw := range redundancyGroupStatements {
+		t.Run(kw+"/with-weight", func(t *testing.T) {
+			body := "interface-monitor " + kw + " weight 255;"
+			got := packedRG6665(t, body)
+			want := containerRG6665(t, body)
+			assertMonitorsAgree6665(t, kw, got, want)
+		})
+		t.Run(kw+"/bare", func(t *testing.T) {
+			body := "interface-monitor " + kw + ";"
+			got := packedRG6665(t, body)
+			want := containerRG6665(t, body)
+			assertMonitorsAgree6665(t, kw, got, want)
+		})
+	}
+}
+
+func assertMonitorsAgree6665(t *testing.T, kw string, got, want *RedundancyGroup) {
+	t.Helper()
+	if len(got.InterfaceMonitors) != len(want.InterfaceMonitors) {
+		t.Fatalf("packed compiled %d interface-monitors, container compiled %d — the keyword %q "+
+			"was stolen out of the interface-name slot, so the group monitors nothing and "+
+			"never demotes on link-down\npacked=%+v\ncontainer=%+v",
+			len(got.InterfaceMonitors), len(want.InterfaceMonitors), kw,
+			got.InterfaceMonitors, want.InterfaceMonitors)
+	}
+	for i := range want.InterfaceMonitors {
+		// Compare the POINTED-TO values: InterfaceMonitors holds pointers, so a
+		// bare != compares addresses and reds on two identical monitors.
+		g, w := got.InterfaceMonitors[i], want.InterfaceMonitors[i]
+		if (g == nil) != (w == nil) {
+			t.Fatalf("monitor %d: packed %v, container %v", i, g, w)
+		}
+		if g != nil && *g != *w {
+			t.Fatalf("monitor %d: packed %+v, container %+v", i, *g, *w)
+		}
+	}
+	// The theft's second half: an unrelated statement fabricated from the
+	// stolen keyword. Compare the flags and the ip-monitoring block too.
+	if got.Preempt != want.Preempt {
+		t.Fatalf("Preempt: packed %v, container %v — a stolen %q fabricated a statement the "+
+			"operator never wrote", got.Preempt, want.Preempt, kw)
+	}
+	if got.StrictVIPOwnership != want.StrictVIPOwnership {
+		t.Fatalf("StrictVIPOwnership: packed %v, container %v", got.StrictVIPOwnership, want.StrictVIPOwnership)
+	}
+	if (got.IPMonitoring == nil) != (want.IPMonitoring == nil) {
+		t.Fatalf("IPMonitoring: packed nil=%v, container nil=%v — a stolen %q fabricated an "+
+			"ip-monitoring block", got.IPMonitoring == nil, want.IPMonitoring == nil, kw)
+	}
+}
+
+// TestPackedRGStillSplitsRealStatements_6665 is the over-reach guard.
+//
+// A splitter that stopped opening statements would satisfy the gate above
+// completely and would re-break #6588 — the whole point of which is that a
+// packed instance line compiles its body at all. This pins that a genuine
+// multi-statement packed line still splits.
+func TestPackedRGStillSplitsRealStatements_6665(t *testing.T) {
+	rg := packedRG6665(t, "interface-monitor ge-0/0/0 weight 255 preempt;")
+	if len(rg.InterfaceMonitors) != 1 {
+		t.Fatalf("expected 1 monitor, got %+v", rg.InterfaceMonitors)
+	}
+	if rg.InterfaceMonitors[0].Interface != "ge-0/0/0" || rg.InterfaceMonitors[0].Weight != 255 {
+		t.Fatalf("monitor = %+v, want {ge-0/0/0 255}", rg.InterfaceMonitors[0])
+	}
+	if !rg.Preempt {
+		t.Fatal("the trailing `preempt` must still open a statement — reserving a value slot " +
+			"must not stop the splitter splitting")
+	}
+}
+
+// TestRGStatementArityAgreesWithTheNoArgSSOT_6665 binds the value-slot table to
+// the tree's existing statement-arity SSOT.
+//
+// `redundancyGroupNoArgStatements` already declares which statements take NO
+// argument — it is what the #6658 arity gate rejects trailing tokens against. A
+// statement that takes no argument must reserve no value slot (or the token
+// after it would be swallowed instead of opening a statement), and a statement
+// that DOES take one must reserve exactly one (or a keyword in its value
+// position is stolen). Two tables disagreeing about the same question is how the
+// next statement rejoins the theft class.
+//
+// setSchema is deliberately not the oracle here: `interface-monitor` is declared
+// `children: nil` with a documented rationale (typing it would flip SetPath's
+// container grouping), so the schema does not carry the arity this splitter
+// needs — which is exactly why the arity lives in its own table.
+func TestRGStatementArityAgreesWithTheNoArgSSOT_6665(t *testing.T) {
+	if len(redundancyGroupStatements) == 0 || len(redundancyGroupNoArgStatements) == 0 {
+		t.Fatal("a source table is EMPTY — this agreement check would pass vacuously")
+	}
+	for kw := range redundancyGroupStatements {
+		reserved := redundancyGroupStatementArity(kw)
+		if redundancyGroupNoArgStatements[kw] {
+			if reserved != 0 {
+				t.Errorf("%q takes no argument per redundancyGroupNoArgStatements but reserves "+
+					"%d value token(s); the token after it would be swallowed instead of "+
+					"opening a statement", kw, reserved)
+			}
+			continue
+		}
+		// ip-monitoring is the one value-bearing statement whose first token is
+		// itself a sub-keyword (family / global-weight / global-threshold), not
+		// a free-form name, so there is no identifier slot to steal from.
+		if kw == "ip-monitoring" {
+			continue
+		}
+		if reserved == 0 {
+			t.Errorf("%q takes an argument but reserves no value slot — a keyword in its value "+
+				"position would be stolen as a statement (#6665)", kw)
+		}
+	}
+	// And no arity for a statement that does not exist: dead policy that reads
+	// as coverage.
+	for _, kw := range []string{"preempt", "strict-vip-ownership", "node",
+		"gratuitous-arp-count", "interface-monitor", "ip-monitoring"} {
+		if _, ok := redundancyGroupStatements[kw]; !ok {
+			t.Errorf("this test names %q, which is no longer a redundancy-group statement", kw)
+		}
+	}
+}


### PR DESCRIPTION
Closes #6665

## The defect

`packedStatementProps` applied its keyword predicate to **every token in the tail with no positional state**, so a registered statement keyword opened a new statement *wherever* it appeared — including where a value was expected:

```
packed:    redundancy-group 1 interface-monitor ip-monitoring weight 255;
             -> InterfaceMonitors=[]  IPMonitoring=&{}
container: redundancy-group 1 { interface-monitor ip-monitoring weight 255; }
             -> InterfaceMonitors=[{ip-monitoring 255}]  IPMonitoring=nil
```

**Both halves are defects:** the monitor is silently dropped **and** an unrelated statement is fabricated. `pkg/cluster` then ranges an empty `InterfaceMonitors`, so the redundancy group accrues no link-down debt and **never demotes** — the failure `assertSingleMonitor` exists to name.

It is **sticky**: `configstore` persists the tree and re-emits a packed leaf as the same packed line, so it survives `show configuration`, reboot and HA peer sync. Authored once, wrong forever.

## The residual is larger than the issue records

The issue's own comment says the `preempt` and `node` spellings now fail **loudly** after #6658's arity gate. That is true only when the stolen monitor carries a trailing `weight` — the gate tests `len(child.Keys) > 1`. A **bare** `interface-monitor preempt;` (a monitor with no weight, a spelling `TestChassisInterfaceMonitorPackedNoWeight_6588` pins as supported) is **still silent**, as are the bare `node`, `strict-vip-ownership` and `gratuitous-arp-count` spellings.

The matrix therefore covers **every keyword in the dispatch table, in both the with-weight and bare forms**.

## The fix is #6658's own shape, one level up

`monitorEntryNodes` already reserves a value slot — *"`weight` consumes exactly one following token even when that token spells a name"* — for exactly this class. This lifts that contract to the **statement** splitter: a statement that takes an argument consumes the next token unconditionally, so the token in its value slot cannot re-arm the splitter.

**The container spelling is the oracle.** Every case asserts `packed == container` rather than a hand-written expectation, because the container form never reaches the splitter and is correct by construction. That is also what lets the test pin the *right* answer — which the old in-tree comment said a divergence test could not do.

## Two stale claims corrected, not deleted

Both were load-bearing for the decision to defer:

- **"No legal Junos interface name collides with any keyword."** This made the reachability argument *"no operator would do this"*. But the system does not prevent it: `chassis device-map interface <logical-name>` is gated by `ValidateDeviceMapLogicalName`, which accepts any non-empty, whitespace-free, dot-free `[a-zA-Z0-9-/]` string — and **all six registered keywords pass it**. The same comment said the project has no canonical interface-name predicate; it does, and it admits the whole collision set.
- **"There is deliberately NO test asserting the divergence."** True while the divergence stood. The test that belongs here asserts the two spellings **agree**.

## The residual, stated rather than implied

`interface-monitor` is variadic, so only its **first** token is protected. `interface-monitor ge-0/0/0 preempt;` still reads `preempt` as a statement — **and so does the container form**, so the two agree, which is the property under repair. No local information distinguishes "a second monitor named preempt" from "no more monitors, then preempt", and inventing one would break the multi-statement packing #6588 pins.

## Validation

- `go test ./pkg/config/ ./pkg/cluster/ -count=1` — green, including **every #6588 packed-leaf test unchanged**.
- `go build ./...` clean.

**Mutation matrix — three mutations, each on a COMPILING tree:**

| Mutation | Cases that red |
|---|---|
| Drop the arity plumbing (pre-fix splitter) | the theft matrix |
| `interface-monitor` reserves nothing | the theft matrix + the arity-agreement test |
| **Reserve a slot for the ZERO-arg flags too** (a tightening) | **three #6588 tests** + the agreement test — the token after `preempt` would be swallowed instead of opening a statement |

The arity table is **bound to `redundancyGroupNoArgStatements`**, the tree's existing SSOT for which statements take no argument, so the next statement added cannot silently rejoin the theft class. `setSchema` is deliberately *not* that oracle: `interface-monitor` is declared `children: nil` with a documented rationale, so the schema does not carry the arity this splitter needs.

No cluster smoke owed: control-plane only, no `userspace-dp` helper or shim `.o` movement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdWuT1UffSkr1spw8sjNTE
