### PR TITLE
daemon/device-map: never persist an OriginalName udev cannot present (#6678)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,39 @@
+## 2026-08-22 — #6678: device-map OriginalName= no longer falls back to the logical name
+
+- **Timestamp**: 2026-08-22
+- **Action**: `deviceMapOriginalNameFor` returned the NIC's CURRENT name when
+  the sysfs derivation came back empty; in the recovery branch that matters
+  (`current == logical`) that is the LOGICAL name, which udev never presents,
+  so the written `.link` could never match and boot persistence failed
+  silently. Changed the contract to `(string, bool)` and made the apply path
+  decline to write a `.link` at all when no udev-matchable name exists,
+  reporting it on the same #5842 channel as a `.link` that failed to land.
+  Tracing the call graph found a SECOND manufacturing site the issue does not
+  mention: the write site has its own fallback, `recoverOriginalName`, which
+  also returns the current name when no `.link` records it — so a fix confined
+  to `deviceMapOriginalNameFor` would have been defeated there and looked
+  correct. Both are covered; the end-to-end test would still fail if only the
+  first were fixed.
+  Rejected `original == final` as the discriminator even though it needs no
+  plumbing: it is unsound for a NIC whose real kernel name legitimately equals
+  its logical name, which would then be skipped wrongly. Carried an explicit
+  NUL-prefixed sentinel as a map VALUE instead — `breakNameCollisions` re-keys
+  only KEYS, so the value survives the temp rename with no signature change to
+  a helper the positional path shares.
+  The full package caught what the filter could not:
+  `TestEnumerateAndRenameMapped_BootRecheckAllowsSafeMap_5490` was green ONLY
+  because of this defect — it never stubbed the derivation, so it read the real
+  `/sys` of whatever host ran it, found no `fxp0`, and relied on the fallback.
+  Repaired the fixture to pin its derivation; verified under mutation M5 that
+  the repair made it independent rather than newly dependent.
+  Mutation matrix M1-M4 all RED with real assertions, vet clean at each,
+  RUN=4 matching the control; M5 re-ran the FULL package under M1.
+- **File(s)**: `pkg/daemon/device_map.go`,
+  `pkg/daemon/device_map_original_name_6678_test.go` (new),
+  `pkg/daemon/device_map_test.go`,
+  `pkg/daemon/device_map_preflight_failclosed_5490_test.go`,
+  `docs/bare-metal-device-map.md`
+
 ## 2026-08-22 — #7406: operator note on where a credential may live in a URL
 
 - **Timestamp**: 2026-08-22

--- a/docs/bare-metal-device-map.md
+++ b/docs/bare-metal-device-map.md
@@ -136,6 +136,34 @@ immediately on commit.
   spellings in its error. Only BOUND entries are counted: a duplicate whose
   second entry matches no present NIC is unambiguous and still binds.
 
+### `OriginalName=` must be a name udev will present (#6678)
+
+Each mapped NIC's `.link` records `OriginalName=` — the NIC's **pre-rename
+kernel name** — so systemd can find it again on the next boot and re-apply the
+logical name. That key is load-bearing for RETH members in particular: their MAC
+alternates between physical (at boot) and virtual (once the daemon programs the
+RETH virtual MAC), so `MACAddress=` is unreliable for them and `OriginalName=`
+is the only stable match.
+
+xpf derives that name in one of three ways, in order:
+
+1. an existing `.link` chain already records the true original — use it;
+2. the NIC still wears its own kernel name (`current != logical`, a fresh first
+   map) — that name **is** the original;
+3. the NIC already wears its logical name and its `.link` was lost — derive the
+   kernel name from sysfs.
+
+If (3) comes back empty, xpf **declines to write a `.link` at all** and reports
+it as a rename/reload failure. It does **not** fall back to the NIC's current
+name, because in that branch the current name IS the logical name, which udev
+will never present — the resulting `.link` could not match, so boot-time
+persistence would fail *silently*: the file exists, the name looks plausible,
+and nothing matches on the next boot.
+
+Leaving the NIC under its kernel name is the better failure. It is a state the
+rest of the daemon already understands and reports, and it surfaces at apply
+time rather than hours later on a machine nobody is watching.
+
 ## `unmapped-interface-policy`
 
 - **`leave-alone` (default in device-map mode):** NICs with no entry are

--- a/pkg/daemon/device_map.go
+++ b/pkg/daemon/device_map.go
@@ -118,18 +118,45 @@ func applyStartupNamingPolicy(cfg *config.Config, nodeID int, clusterMode bool,
 //     pre-rename kernel name (e.g. ens3 on a fresh first map). Keep it; do NOT
 //     synthesize an enpXsY name, which would not match udev on next boot
 //     (AGY r3 MAJOR).
-func deviceMapOriginalNameFor(currentNIC, logical string) string {
+//
+// The bool reports whether a udev-matchable name was found. It is FALSE only
+// in the recovery branch when the derivation comes back empty (#6678): there
+// the NIC already wears its logical name, and the logical name is precisely
+// what udev will never present. Returning it — as this did — writes a .link
+// whose OriginalName= cannot match, so boot-time persistence fails SILENTLY:
+// the file exists, the name looks plausible, and nothing matches. Every other
+// consumer of an empty derivation treats it as a clean skip
+// (ensureRethLinkOriginalName returns without rewriting), and this was the one
+// place that converted "I could not derive a name" into "here is a name".
+//
+// The caller must not write a .link for a NIC this reports false for. Leaving
+// the NIC under its kernel name is a state the rest of the daemon understands;
+// a .link that silently never matches is not.
+func deviceMapOriginalNameFor(currentNIC, logical string) (string, bool) {
 	orig := recoverOriginalName(currentNIC)
 	if orig != currentNIC {
-		return orig // an existing .link chain recorded the true original
+		return orig, true // an existing .link chain recorded the true original
 	}
 	if currentNIC == logical {
-		if dk := deriveKernelNameFn(currentNIC); dk != "" {
-			return dk
+		dk := deriveKernelNameFn(currentNIC)
+		if dk == "" {
+			return "", false
 		}
+		return dk, true
 	}
-	return currentNIC
+	return currentNIC, true
 }
+
+// deviceMapOriginalUnknown marks, inside originalByCurrent, a bound NIC whose
+// true pre-rename kernel name could not be derived (#6678).
+//
+// It is carried as a VALUE rather than in a separate set because
+// breakNameCollisions re-keys originalByCurrent across the temp rename and
+// only rewrites KEYS — a sentinel value survives that untouched, so this needs
+// no signature change to a helper the positional rename path shares. The NUL
+// prefix makes it unrepresentable as an interface name, so it can never be
+// confused with one or silently written into a .link.
+const deviceMapOriginalUnknown = "\x00xpf-original-unknown"
 
 // enumerateAndRenameMapped is the device-map-mode replacement for
 // enumerateAndRenameInterfaces. It renames ONLY mapped NICs to their bound
@@ -210,7 +237,11 @@ func enumerateAndRenameMapped(dm *config.DeviceMapConfig, cfg *config.Config, pr
 		switch {
 		case b.Status.Bound():
 			desiredByCurrent[b.CurrentNIC] = b.Logical
-			originalByCurrent[b.CurrentNIC] = deviceMapOriginalNameFor(b.CurrentNIC, b.Logical)
+			if orig, ok := deviceMapOriginalNameFor(b.CurrentNIC, b.Logical); ok {
+				originalByCurrent[b.CurrentNIC] = orig
+			} else {
+				originalByCurrent[b.CurrentNIC] = deviceMapOriginalUnknown
+			}
 			desiredNames[b.Logical] = true
 			slog.Info("device-map: resolved binding",
 				"logical", b.Entry.LogicalName, "current", b.CurrentNIC, "status", b.Status.String())
@@ -266,6 +297,36 @@ func enumerateAndRenameMapped(dm *config.DeviceMapConfig, cfg *config.Config, pr
 		original := originalByCurrent[current]
 		if original == "" {
 			original = recoverOriginalName(current)
+		}
+		if original == deviceMapOriginalUnknown {
+			// #6678: no udev-matchable pre-rename name exists for this NIC.
+			// Writing a .link anyway would record an OriginalName= udev never
+			// presents, so the file would silently never match and this NIC
+			// would come up unnamed on the next boot with nothing to point at.
+			// Decline to write it and report on the SAME channel as a .link
+			// that failed to land (#5842) — the next-boot consequence is
+			// identical, and it must be loud now rather than discovered on a
+			// machine nobody is watching.
+			slog.Error("device-map: cannot determine the pre-rename kernel name for a "+
+				"bound NIC; refusing to write a .link whose OriginalName= could never "+
+				"match. This NIC will come up under its kernel name on the next boot.",
+				"current", current, "logical", final)
+			renameErrs = append(renameErrs,
+				fmt.Errorf("device-map: no udev-matchable OriginalName for %s (logical %s); "+
+					"boot-time persistence not established", current, final))
+			if current == final {
+				continue
+			}
+			if err := renameInterfaceFn(current, final); err != nil {
+				slog.Warn("device-map: rename failed", "from", current, "to", final, "err", err)
+				renameErrs = append(renameErrs,
+					fmt.Errorf("rename %s -> %s: %w", current, final, err))
+			} else {
+				slog.Info("device-map: renamed interface (no .link written)",
+					"from", current, "to", final)
+				changed = true
+			}
+			continue
 		}
 		if current == final {
 			// Ensure a .link exists for boot persistence even when the name

--- a/pkg/daemon/device_map_original_name_6678_test.go
+++ b/pkg/daemon/device_map_original_name_6678_test.go
@@ -1,0 +1,161 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #6678. deviceMapOriginalNameFor fell back to the NIC's CURRENT name when the
+// kernel-name derivation came back empty. In the recovery branch that matters —
+// a NIC already wearing its logical name whose .link was lost — current ==
+// logical, so the LOGICAL name was persisted as OriginalName=. udev never
+// presents that name, so the .link could not match and boot-time persistence
+// failed SILENTLY: the file exists, the name looks plausible, nothing matches.
+//
+// This is why it was latent rather than obvious: every OTHER consumer of an
+// empty derivation treats it as a clean skip (ensureRethLinkOriginalName
+// returns without rewriting the RETH .link), so this was the single non-skip
+// fallback in the call graph.
+//
+// The severity comes from what OriginalName= is load-bearing for. RETH members
+// are PCI-keyed with OriginalName= precisely BECAUSE their MAC alternates —
+// physical at boot, virtual once the daemon programs the RETH virtual MAC — so
+// MACAddress= is unreliable for them. A wrong OriginalName= on a RETH member is
+// not self-correcting at boot.
+
+// stubMappedSeamsWearingLogicalName points the rename seams at a single NIC
+// that ALREADY wears its final logical name (ge-0-0-3), which is the recovery
+// branch: current == logical and no .link exists.
+func stubMappedSeamsWearingLogicalName(t *testing.T, derived string) (linkDirPath string, renameCalls *int) {
+	t.Helper()
+	dir := withTempLinkDir(t)
+
+	savedEnum := enumeratePresentNICsFn
+	enumeratePresentNICsFn = func() ([]presentNIC, error) {
+		return []presentNIC{{Name: "ge-0-0-3", PCIAddr: "0000:09:00.0"}}, nil
+	}
+	t.Cleanup(func() { enumeratePresentNICsFn = savedEnum })
+
+	savedDerive := deriveKernelNameFn
+	deriveKernelNameFn = func(string) string { return derived }
+	t.Cleanup(func() { deriveKernelNameFn = savedDerive })
+
+	var rc int
+	savedRename := renameInterfaceFn
+	renameInterfaceFn = func(from, to string) error { rc++; return nil }
+	t.Cleanup(func() { renameInterfaceFn = savedRename })
+
+	savedReload := networkctlReloadFn
+	networkctlReloadFn = func() error { return nil }
+	t.Cleanup(func() { networkctlReloadFn = savedReload })
+
+	return dir, &rc
+}
+
+func linkFilesIn(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s): %v", dir, err)
+	}
+	var out []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".link") {
+			out = append(out, e.Name())
+		}
+	}
+	return out
+}
+
+// TestDeviceMapOriginalNameForReportsUnderivable_6678 pins the contract change:
+// an empty derivation in the recovery branch reports "no name", it does not
+// hand back the logical name.
+func TestDeviceMapOriginalNameForReportsUnderivable_6678(t *testing.T) {
+	withTempLinkDir(t) // empty link dir => recoverOriginalName returns its input
+	saved := deriveKernelNameFn
+	deriveKernelNameFn = func(string) string { return "" }
+	t.Cleanup(func() { deriveKernelNameFn = saved })
+
+	got, ok := deviceMapOriginalNameFor("ge-0-0-3", "ge-0-0-3")
+	if ok {
+		t.Fatalf("an empty derivation must report NO udev-matchable name, got %q with ok=true", got)
+	}
+	// Assert what the value BECAME, not merely that ok flipped: the logical
+	// name must not be handed back under any guise.
+	if got != "" {
+		t.Fatalf("underivable must yield the empty string, got %q", got)
+	}
+	if got == "ge-0-0-3" {
+		t.Fatal("the LOGICAL name was returned — udev never presents it")
+	}
+}
+
+// TestEnumerateAndRenameMappedSkipsLinkWhenOriginalUnderivable_6678 is the
+// end-to-end half, driving the real apply path. It also covers the second
+// manufacturing site: the write site has its OWN fallback
+// (recoverOriginalName), which likewise returns the current name when no .link
+// records it — so a fix confined to deviceMapOriginalNameFor would be defeated
+// there and this test would still fail.
+func TestEnumerateAndRenameMappedSkipsLinkWhenOriginalUnderivable_6678(t *testing.T) {
+	dir, _ := stubMappedSeamsWearingLogicalName(t, "") // derivation returns nothing
+	dm, cfg := mappedRenameTestConfig()
+
+	err := enumerateAndRenameMapped(dm, cfg, nil)
+
+	if files := linkFilesIn(t, dir); len(files) != 0 {
+		for _, f := range files {
+			b, _ := os.ReadFile(filepath.Join(dir, f))
+			t.Errorf("a .link was written with no derivable OriginalName: %s\n%s", f, b)
+		}
+	}
+	if err == nil {
+		t.Fatal("failing to establish boot persistence must be reported, not silent")
+	}
+	if !strings.Contains(err.Error(), "OriginalName") {
+		t.Errorf("the error must name the cause, got %v", err)
+	}
+}
+
+// TestEnumerateAndRenameMappedWritesLinkWhenOriginalDerivable_6678 is the
+// positive control. Without it the test above could pass because this harness
+// never writes a .link at all — a green that proves nothing.
+func TestEnumerateAndRenameMappedWritesLinkWhenOriginalDerivable_6678(t *testing.T) {
+	dir, _ := stubMappedSeamsWearingLogicalName(t, "enp9s0") // derivation succeeds
+	dm, cfg := mappedRenameTestConfig()
+
+	if err := enumerateAndRenameMapped(dm, cfg, nil); err != nil {
+		t.Fatalf("a derivable OriginalName must apply cleanly, got %v", err)
+	}
+	files := linkFilesIn(t, dir)
+	if len(files) != 1 {
+		t.Fatalf("want exactly one .link written, got %v", files)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, files[0]))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	content := string(b)
+	if !strings.Contains(content, "OriginalName=enp9s0") {
+		t.Errorf("the derived kernel name must be recorded, got:\n%s", content)
+	}
+	if strings.Contains(content, "OriginalName=ge-0-0-3") {
+		t.Errorf("the LOGICAL name must never be recorded as OriginalName:\n%s", content)
+	}
+	if strings.Contains(content, deviceMapOriginalUnknown) {
+		t.Errorf("the sentinel must never reach a .link file:\n%s", content)
+	}
+}
+
+// TestDeviceMapUnknownSentinelIsNotAnInterfaceName_6678 pins the property that
+// makes carrying the sentinel as a map VALUE safe: it can never collide with a
+// real interface name, so it cannot be mistaken for one if it ever escapes.
+func TestDeviceMapUnknownSentinelIsNotAnInterfaceName_6678(t *testing.T) {
+	if !strings.ContainsRune(deviceMapOriginalUnknown, 0) {
+		t.Fatalf("the sentinel must be unrepresentable as an interface name, got %q", deviceMapOriginalUnknown)
+	}
+	if len(deviceMapOriginalUnknown) <= 16 {
+		t.Logf("note: sentinel %q is short enough to fit IFNAMSIZ, but the NUL keeps it unrepresentable", deviceMapOriginalUnknown)
+	}
+}

--- a/pkg/daemon/device_map_preflight_failclosed_5490_test.go
+++ b/pkg/daemon/device_map_preflight_failclosed_5490_test.go
@@ -207,6 +207,21 @@ func TestEnumerateAndRenameMapped_BootRecheckAllowsSafeMap_5490(t *testing.T) {
 	networkctlReloadFn = func() error { return nil }
 	t.Cleanup(func() { networkctlReloadFn = savedReload })
 
+	// fxp0 already wears its logical name, so the OriginalName= comes from the
+	// sysfs derivation. Stub it: unstubbed, this read the REAL /sys of whatever
+	// host ran the test, found no fxp0, and returned "" — which before #6678
+	// silently fell back to the logical name and let this test pass on the
+	// defect. The property under test here is the pre-flight stranding check,
+	// not name derivation, so pin the derivation rather than inherit the host's.
+	savedDerive := deriveKernelNameFn
+	deriveKernelNameFn = func(name string) string {
+		if name == "fxp0" {
+			return "enp5s0" // matches its mapped PCI address 0000:05:00.0
+		}
+		return ""
+	}
+	t.Cleanup(func() { deriveKernelNameFn = savedDerive })
+
 	dm := &config.DeviceMapConfig{
 		Entries: []config.DeviceMapEntry{
 			{LogicalName: "fxp0", PCIAddr: "0000:05:00.0"},

--- a/pkg/daemon/device_map_test.go
+++ b/pkg/daemon/device_map_test.go
@@ -260,7 +260,10 @@ func TestDeviceMapOriginalNameForFreshKernelName(t *testing.T) {
 	deriveKernelNameFn = func(string) string { called = true; return "enp0s3" }
 	t.Cleanup(func() { deriveKernelNameFn = old })
 
-	got := deviceMapOriginalNameFor("ens3", "ge-0-0-3")
+	got, ok := deviceMapOriginalNameFor("ens3", "ge-0-0-3")
+	if !ok {
+		t.Fatal("a real kernel name is udev-matchable; ok must be true")
+	}
 	if got != "ens3" {
 		t.Fatalf("fresh-box OriginalName must be the real kernel name ens3, got %q", got)
 	}
@@ -277,7 +280,10 @@ func TestDeviceMapOriginalNameForDerivesWhenWearingLogicalName(t *testing.T) {
 	deriveKernelNameFn = func(string) string { return "enp9s0" }
 	t.Cleanup(func() { deriveKernelNameFn = old })
 
-	got := deviceMapOriginalNameFor("ge-0-0-3", "ge-0-0-3")
+	got, ok := deviceMapOriginalNameFor("ge-0-0-3", "ge-0-0-3")
+	if !ok {
+		t.Fatal("a successful derivation is udev-matchable; ok must be true")
+	}
 	if got != "enp9s0" {
 		t.Fatalf("when wearing the logical name, OriginalName must derive the kernel name, got %q", got)
 	}


### PR DESCRIPTION
`deviceMapOriginalNameFor` fell back to the NIC's **current** kernel name when the sysfs derivation returned nothing. In the branch where that matters — a NIC already wearing its final logical name whose `.link` was lost — `current` **is** the logical name, so the logical name was written as `OriginalName=`.

udev never presents that name, so the `.link` could not match and boot-time persistence failed **silently**: the file exists, the name looks plausible, and nothing matches on the next boot.

## Why it is latent rather than obvious

Every other consumer of an empty derivation treats it as a clean skip — `ensureRethLinkOriginalName` (`daemon_reth.go:39`) returns without rewriting the RETH `.link`, which is the correct posture. This was the **one non-skip fallback in the call graph**, converting "I could not derive a name" into "here is a name".

## Why it is worth fixing before it bites

The failure is silent and deferred. The bad `.link` is written at apply time; the consequence appears at the *next boot*, on a machine nobody is watching, as a NIC that did not get its name. Correlating that back to an empty derivation hours earlier is expensive.

The name is load-bearing for **RETH members** in particular: their MAC alternates between physical at boot and virtual once the daemon programs the RETH virtual MAC, so `MACAddress=` is unreliable for them and `OriginalName=` is the only stable match. A wrong `OriginalName=` on a RETH member does not self-correct at boot.

## The fix

`deviceMapOriginalNameFor` now returns a second value reporting whether a udev-matchable name was found. The apply path declines to write a `.link` at all when it was not, and reports on the **same channel as a `.link` that failed to land** (#5842) — the next-boot consequence is identical. Leaving the NIC under its kernel name is strictly better: that is a state the rest of the daemon understands and reports.

### A second manufacturing site the issue does not mention

Tracing the call graph found that the **write site has its own fallback**: `original := originalByCurrent[current]; if original == "" { original = recoverOriginalName(current) }`, and `recoverOriginalName` *also* returns the current name when no `.link` records it (`linksetup.go:429`).

So a fix confined to `deviceMapOriginalNameFor` would have been **defeated there while looking correct**. Both are covered, and the end-to-end test fails if only the first is fixed.

### A discriminator deliberately rejected

`original == final` needs no plumbing and is tempting. It is **unsound**: a NIC whose real kernel name legitimately equals its logical name would be skipped wrongly. The signal has to be *"derivation was attempted and produced nothing"*, so that is what is carried — as a NUL-prefixed sentinel value in the existing map.

`breakNameCollisions` re-keys that map across the temp rename but rewrites only **keys**, so a sentinel *value* survives untouched — no signature change to a helper the positional rename path shares.

## A pre-existing test was green only because of this defect

`TestEnumerateAndRenameMapped_BootRecheckAllowsSafeMap_5490` never stubbed the derivation, so it read the real `/sys` of whatever host ran it, found no `fxp0`, and depended on the fallback to write its `.link`. Its actual property is the pre-flight stranding check, so the fixture now pins its derivation instead of inheriting the host's.

This only surfaced because the mutations were validated against the **full package** rather than a `-run` filter.

## Validation

Full `pkg/daemon` suite `-count=1` clean. No hardware needed.

| mutation | vet | result |
|---|---|---|
| restore the logical-name fallback (the original defect) | 0 | **RED** — `an empty derivation must report NO udev-matchable name` |
| caller stops recording the sentinel | 0 | **RED** — `a .link was written with no derivable OriginalName` |
| write site ignores the sentinel | 0 | **RED** — `a .link was written…: 10-xpf-ge-0-0-3.link` |
| underivable no longer reported as an error | 0 | **RED** — `failing to establish boot persistence must be reported, not silent` |

RUN count matched the control (4) at every cell. The first mutation was additionally re-run against the **full package**, confirming nothing else pins the behaviour and that the repaired 5490 fixture is independent rather than newly dependent.

A **positive control** asserts a `.link` IS written when the derivation succeeds, so the skip test cannot pass merely because this harness never writes one.

## Relationship to #6677

Separate defect, separate fix, no shared code change. This is *the caller manufactures a name when derivation admits it has none*; #6677 is *the derivation returns a confidently wrong name*.

They interact in the reassuring direction: #6677's udev-first fix makes an empty derivation **rarer**, so it cannot make this worse. Worth noting the counterfactual — had #6677 instead been made to *fail closed* on an underivable name, a tempting and superficially safer shape, it would have made this latent bug **live**, converting a wrong-name bug into a wrong-name bug by a different route. That is the argument for fixing this regardless of which #6677 shape lands.

Does not reach the Rust helper binary.

Closes #6678