### PR TITLE
frr: parse IS-IS adjacencies right-anchored so a peer cannot forge columns (#6590)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -102668,3 +102668,11 @@ prose edit above them added. No diff falls in the new test body.
   pkg/daemon/mirror_session_id_adoption_6666_test.go (new),
   pkg/daemon/userspace_sync_test.go, proto/xpf/v1/xpf.proto,
   pkg/cluster/README.md, docs/session-sync-architecture.md, _Log.md
+
+- **Timestamp**: 2026-08-22
+  - **Action**: #6590 — `show isis neighbor` was parsed left-to-right, so a
+    peer-advertised hostname containing spaces shifted every later column and let
+    the neighbour forge its own State/Level/Interface/HoldTime. Now right-anchored
+    against a header-derived trailing width; short/headerless rows dropped.
+  - **File(s)**: pkg/frr/status_parse.go,
+    pkg/frr/isis_positional_forgery_6590_test.go

--- a/pkg/frr/isis_positional_forgery_6590_test.go
+++ b/pkg/frr/isis_positional_forgery_6590_test.go
@@ -1,0 +1,185 @@
+package frr
+
+import (
+	"testing"
+)
+
+// #6590 — a peer-advertised IS-IS hostname containing SPACES must not shift the
+// columns of `show isis neighbor`.
+//
+// The first column is not a system ID: FRR substitutes the hostname the peer
+// advertised in its Dynamic Hostname TLV (RFC 5301, `hostname dynamic`, on by
+// default), and it retains printable ASCII spaces when decoding that TLV. The
+// old parser assigned tokens to columns POSITIONALLY with strings.Fields, so a
+// hostname with N spaces moved every later column N places right and filled
+// State/Level/Interface/HoldTime with peer-chosen bytes.
+//
+// This is NOT the #6468 escape-injection class and #6579's sanitiser cannot fix
+// it. Sanitising keeps a row SAFE TO PRINT while preserving plausible printable
+// text, so a sanitised row can still be materially false — an operator reading
+// `show isis adjacency` to decide whether a neighbour is healthy can be shown a
+// `State` the neighbour chose. Display integrity is a parser property.
+//
+// The fix is right-anchored parsing: only the first column can contain a space,
+// so the trailing columns are taken from the END and the hostname absorbs the
+// surplus. The trailing width is learned from the header rather than hardcoded
+// (note "System Id" is one column spelled with a space).
+
+// isisMgr6590 builds a Manager whose vtysh returns out for `show isis neighbor`,
+// reusing the package's existing fakeExecutor seam rather than adding a second
+// double.
+func isisMgr6590(out string) *Manager {
+	return NewForTest("", &fakeExecutor{
+		vtyshResp: map[string]string{"show isis neighbor": out},
+	})
+}
+
+// isisTable6590 builds a `show isis neighbor` table with the real FRR header.
+func isisTable6590(rows ...string) string {
+	out := "Area 1:\n" +
+		" System Id           Interface   L  State        Holdtime SNPA\n"
+	for _, r := range rows {
+		out += " " + r + "\n"
+	}
+	return out
+}
+
+// TestISISHostnameWithSpacesCannotForgeColumns6590 is the fail-on-revert case.
+//
+// FAIL-ON-REVERT: restore the left-anchored fields[0..4] assignment.
+func TestISISHostnameWithSpacesCannotForgeColumns6590(t *testing.T) {
+	// The attack from the issue: the peer advertises a hostname whose spaces
+	// spell out a complete, plausible set of trailing columns. Positionally
+	// parsed, the operator sees Interface=peer, Level=ge-0-0-1, State=2,
+	// HoldTime=Up — every displayed cell chosen by the neighbour.
+	m := isisMgr6590(isisTable6590(
+		"evil peer ge-0-0-1 2 Up 27 ge-0-0-9 1 Down 99 dead.dead.dead",
+	))
+
+	adjs, err := m.GetISISAdjacency()
+	if err != nil {
+		t.Fatalf("GetISISAdjacency: %v", err)
+	}
+	if len(adjs) != 1 {
+		t.Fatalf("want 1 adjacency, got %d: %+v", len(adjs), adjs)
+	}
+	got := adjs[0]
+
+	// The REAL trailing columns are the last five tokens; everything before
+	// them is the hostname, spaces and all.
+	if got.Interface != "ge-0-0-9" {
+		t.Errorf("#6590: Interface is peer-forged: got %q, want %q — the hostname's "+
+			"spaces shifted the columns", got.Interface, "ge-0-0-9")
+	}
+	if got.Level != "1" {
+		t.Errorf("#6590: Level is peer-forged: got %q, want %q", got.Level, "1")
+	}
+	if got.State != "Down" {
+		t.Errorf("#6590: State is peer-forged: got %q, want %q — an operator deciding "+
+			"whether this neighbour is healthy would be reading a value the neighbour "+
+			"chose", got.State, "Down")
+	}
+	if got.HoldTime != "99" {
+		t.Errorf("#6590: HoldTime is peer-forged: got %q, want %q", got.HoldTime, "99")
+	}
+
+	// And the hostname keeps everything it actually claimed, so the operator
+	// can SEE that the name is absurd rather than having it silently
+	// redistributed into the other cells.
+	const wantName = "evil peer ge-0-0-1 2 Up 27"
+	if got.SystemID != wantName {
+		t.Errorf("#6590: SystemID = %q, want %q — the surplus tokens belong to the "+
+			"hostname, which is the column the peer legitimately controls",
+			got.SystemID, wantName)
+	}
+}
+
+// TestISISOrdinaryRowStillParses6590 is the over-correction guard: a normal row
+// must be unchanged by the fix.
+//
+// FAIL-ON-REVERT: an off-by-one in the right-anchor split reds here.
+func TestISISOrdinaryRowStillParses6590(t *testing.T) {
+	m := isisMgr6590(isisTable6590(
+		"rtr1                ge-0-0-1    2  Up           27       2020.2020.2020",
+		"rtr2                ge-0-0-2    1  Init         9        2020.2020.2021",
+	))
+
+	adjs, err := m.GetISISAdjacency()
+	if err != nil {
+		t.Fatalf("GetISISAdjacency: %v", err)
+	}
+	if len(adjs) != 2 {
+		t.Fatalf("want 2 adjacencies, got %d: %+v", len(adjs), adjs)
+	}
+	for i, want := range []ISISAdjacency{
+		{SystemID: "rtr1", Interface: "ge-0-0-1", Level: "2", State: "Up", HoldTime: "27"},
+		{SystemID: "rtr2", Interface: "ge-0-0-2", Level: "1", State: "Init", HoldTime: "9"},
+	} {
+		if adjs[i] != want {
+			t.Errorf("row %d: got %+v, want %+v", i, adjs[i], want)
+		}
+	}
+}
+
+// TestISISMalformedRowsAreNotRendered6590 pins the "reported rather than
+// rendered" half.
+//
+// A row too short to carry every trailing column cannot be split safely — any
+// assignment would put peer-chosen text under a heading it does not belong to,
+// which is the defect itself. Such a row is dropped, not guessed at.
+//
+// A table with NO header is likewise not parsed: the trailing width is unknown
+// without it, and guessing the width is the same failure in a different place.
+func TestISISMalformedRowsAreNotRendered6590(t *testing.T) {
+	// Short row: fewer fields than the header's trailing width + 1.
+	short := isisMgr6590(isisTable6590("rtr1 ge-0-0-1 2"))
+	adjs, err := short.GetISISAdjacency()
+	if err != nil {
+		t.Fatalf("GetISISAdjacency(short): %v", err)
+	}
+	if len(adjs) != 0 {
+		t.Errorf("#6590: a row too short to carry every trailing column must be dropped, "+
+			"not split by guesswork; got %+v", adjs)
+	}
+
+	// Headerless table: width unknown.
+	headerless := isisMgr6590("Area 1:\n rtr1 ge-0-0-1 2 Up 27 2020.2020.2020\n")
+	adjs, err = headerless.GetISISAdjacency()
+	if err != nil {
+		t.Fatalf("GetISISAdjacency(headerless): %v", err)
+	}
+	if len(adjs) != 0 {
+		t.Errorf("#6590: without the header the trailing width is unknown — parsing anyway "+
+			"reintroduces the positional guess; got %+v", adjs)
+	}
+}
+
+// TestISISTrailingWidthFollowsTheHeader6590 pins that the width is DERIVED.
+//
+// Hardcoding five trailing columns would silently mis-parse an FRR release that
+// adds or drops one. Deriving it from the header means the parser follows the
+// table it was actually given.
+//
+// FAIL-ON-REVERT: replace the header-derived width with a constant.
+func TestISISTrailingWidthFollowsTheHeader6590(t *testing.T) {
+	// A hypothetical FRR that drops the SNPA column: four trailing columns.
+	out := "Area 1:\n" +
+		" System Id           Interface   L  State        Holdtime\n" +
+		" host with spaces ge-0-0-1 2 Up 27\n"
+
+	adjs, err := isisMgr6590(out).GetISISAdjacency()
+	if err != nil {
+		t.Fatalf("GetISISAdjacency: %v", err)
+	}
+	if len(adjs) != 1 {
+		t.Fatalf("want 1 adjacency, got %d: %+v", len(adjs), adjs)
+	}
+	want := ISISAdjacency{
+		SystemID: "host with spaces", Interface: "ge-0-0-1",
+		Level: "2", State: "Up", HoldTime: "27",
+	}
+	if adjs[0] != want {
+		t.Errorf("#6590: the trailing width must follow the header, not a constant; "+
+			"got %+v, want %+v", adjs[0], want)
+	}
+}

--- a/pkg/frr/status_parse.go
+++ b/pkg/frr/status_parse.go
@@ -73,18 +73,24 @@ func (m *Manager) GetRIPRoutes() ([]RIPRouteEntry, error) {
 // (RFC 5301, `hostname dynamic` — on by default) for the dotted system ID
 // whenever that mapping is known, so the first column of `show isis neighbor`
 // is whatever the neighbour called itself. Every OTHER field inherits the same
-// taint: GetISISAdjacency splits the row with strings.Fields, so a hostname
-// containing a SPACE shifts Interface/Level/State/HoldTime one column right and
-// puts peer bytes in each of them. Display sites must sanitize the WHOLE row —
-// see termsafe.SanitizeRowForDisplay.
+// taint in the sense that it is peer-authored text and display sites must
+// sanitize the WHOLE row — see termsafe.SanitizeRowForDisplay.
 //
-// Sanitizing does NOT repair that shift. It keeps the row safe to print; the
-// VALUES remain positionally derived from peer-controlled text, so a shifted
-// row can display a State the peer chose and no display guard can detect it.
-// Fixing that needs this parse to change — FRR's IS-IS JSON output, or
-// right-anchored columns with malformed rows reported rather than rendered.
-// Tracked as #6590. Do not cite the display guard as making this struct
-// trustworthy.
+// The COLUMN SHIFT is fixed (#6590). GetISISAdjacency used to split the row
+// left-to-right with strings.Fields, so a hostname containing a SPACE moved
+// Interface/Level/State/HoldTime one column right and put peer bytes in each
+// of them — and sanitizing could not repair that, because it keeps a row safe
+// to print while preserving plausible printable text, so a shifted row could
+// display a State the peer chose with no display guard able to detect it. The
+// parse is now RIGHT-ANCHORED against a header-derived trailing width: only
+// this first column can contain a space, so the trailing columns are taken
+// from the end and the hostname absorbs the surplus. A row too short to carry
+// every trailing column, or a table with no header to derive the width from,
+// is dropped rather than guessed at.
+//
+// So SystemID remains peer-controlled text that must be sanitized before
+// display, but Interface/Level/State/HoldTime are now FRR's values rather than
+// whatever the peer's hostname spelled.
 type ISISAdjacency struct {
 	SystemID  string
 	Interface string
@@ -105,29 +111,58 @@ func (m *Manager) GetISISAdjacency() ([]ISISAdjacency, error) {
 		return nil, err
 	}
 	var adjs []ISISAdjacency
+	// #6590: trailing-column count, learned from the header row. Only the
+	// FIRST column can contain a space (it is the peer's advertised dynamic
+	// hostname); every other column is FRR-generated and space-free. So the
+	// row is parsed RIGHT-ANCHORED and the hostname absorbs the surplus,
+	// instead of assigning tokens left-to-right and letting a space in the
+	// hostname shift every later column one place right.
+	//
+	// Zero until the header is seen. A table with no header is not parsed:
+	// without it the trailing width is unknown, and guessing is exactly the
+	// failure this fixes.
+	trailing := 0
 	lines := strings.Split(output, "\n")
 	for _, line := range lines {
 		fields := strings.Fields(line)
-		if len(fields) < 4 {
+		if len(fields) == 0 || strings.HasPrefix(line, "Area") {
 			continue
 		}
-		if fields[0] == "System" || strings.HasPrefix(line, "Area") {
+		// Header: "System Id  Interface  L  State  Holdtime  SNPA". Note
+		// "System Id" is ONE column spelled with a space, so the trailing
+		// width is the field count minus those two tokens — derived rather
+		// than hardcoded, so an FRR release that adds or drops a trailing
+		// column is followed rather than silently mis-parsed.
+		if fields[0] == "System" && len(fields) >= 2 && fields[1] == "Id" {
+			trailing = len(fields) - 2
 			continue
 		}
+		if trailing <= 0 {
+			continue
+		}
+		// A row must carry every trailing column plus at least one token of
+		// hostname. Anything shorter is malformed; skipping it is the
+		// "reported rather than rendered" half — a partial row would put
+		// peer-chosen text under the wrong heading, which is the defect.
+		if len(fields) < trailing+1 {
+			continue
+		}
+		split := len(fields) - trailing
 		adj := ISISAdjacency{
-			SystemID: fields[0],
+			SystemID: strings.Join(fields[:split], " "),
 		}
-		if len(fields) >= 2 {
-			adj.Interface = fields[1]
+		rest := fields[split:]
+		if len(rest) >= 1 {
+			adj.Interface = rest[0]
 		}
-		if len(fields) >= 3 {
-			adj.Level = fields[2]
+		if len(rest) >= 2 {
+			adj.Level = rest[1]
 		}
-		if len(fields) >= 4 {
-			adj.State = fields[3]
+		if len(rest) >= 3 {
+			adj.State = rest[2]
 		}
-		if len(fields) >= 5 {
-			adj.HoldTime = fields[4]
+		if len(rest) >= 4 {
+			adj.HoldTime = rest[3]
 		}
 		adjs = append(adjs, adj)
 	}


### PR DESCRIPTION
Closes #6590

## The defect

The first column of `show isis neighbor` is **not a system ID**. FRR substitutes the hostname the peer advertised in its Dynamic Hostname TLV (RFC 5301, `hostname dynamic`, on by default) and retains printable ASCII **spaces** when decoding it. `GetISISAdjacency` assigned tokens left-to-right with `strings.Fields`, so a hostname with N spaces moved every later column N places right:

```
wire row:  evil peer ge-0-0-1 2 Up 27
parsed as: SystemID=evil  Interface=peer  Level=ge-0-0-1  State=2  HoldTime=Up
```

With enough tokens the neighbour controls **every displayed cell**. An operator running `show isis adjacency` to decide whether a neighbour is healthy can be shown a `State` that neighbour chose.

**Not the #6468 escape-injection class, and #6579's sanitizer cannot fix it.** Sanitizing keeps a row *safe to print* while preserving plausible printable text — so a sanitized row can still be **materially false**. Display integrity is a parser property.

## The fix

**Right-anchored parsing.** Only the first column can contain a space; every other column is FRR-generated. So the trailing columns are taken from the **end** and the hostname absorbs the surplus.

**The trailing width is derived from the header, not hardcoded.** Note `System Id` is one column spelled with a space, so the width is the header's field count minus those two tokens. An FRR release that adds or drops a trailing column is then followed rather than silently mis-parsed.

**Two shapes are dropped rather than guessed at** — the "reported rather than rendered" half:

- a row too short to carry every trailing column, because any split would put peer-chosen text under a heading it does not belong to, which *is* the defect;
- every row of a table with **no header**, because without one the trailing width is unknown and guessing it reintroduces the same positional guess somewhere else.

## Why not JSON

`show isis neighbor json` is the established shape here — `GetBGPSummary` moved to JSON in #3942 for a closely related reason (a text table overloading a column and a field-count scraper misparsing footers).

Rejected for **this** change: it depends on the deployed FRR build actually emitting that JSON, and getting it wrong converts a display-integrity bug into **no IS-IS adjacency output at all**. Right-anchoring is self-contained and testable without FRR. If someone later confirms JSON support across the supported FRR range, it remains the better long-term shape.

## Documentation

The struct's doc comment carried this defect as a **known caveat naming #6590**. It now describes the fix, and keeps the half that is still true: `SystemID` remains peer-authored text that display sites must sanitize.

## Mutation matrix

Each verified applied on a compiling tree.

| # | Mutation | Result |
|---|---|---|
| I1 | restore left-anchored positional parsing | **RED** |
| I2 | hardcode the trailing width, ignoring the header | **RED** |
| I3 | off-by-one in the split | **RED** — over-correction |
| I4 | parse headerless tables by guessing the width | **RED** |
| I5 | render short rows anyway | **RED** |

**I3 is the over-correction direction**: a fix that shifted the boundary the other way would satisfy a forgery-only matrix while corrupting ordinary rows.

## Validation

- `go build ./...` clean.
- `pkg/frr` and `pkg/grpcapi` green with `-count=1`. `grpcapi` matters here: it carries the #6468/#6579 display-guard tests that consume this parser, so the existing terminal-safety behaviour is confirmed unchanged.
- The test reuses the package's existing `fakeExecutor` seam rather than adding a second double.

Go control plane only — **no helper binary or shim movement, no cluster smoke owed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gcdxy5mCofwyVWHUKzhU9F
