### PR TITLE
cluster: encrypt the config-sync payload so the PSK stops leaking (#6629)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -102545,3 +102545,27 @@ prose edit above them added. No diff falls in the new test body.
     controlLinkAuthKey now REDs). Residual closed: readLoop's CALL to admitFrame
     was still unbound — severing it left every 5086 test green.
   - **File(s)**: pkg/cluster/heartbeat_replay_restart_5086_test.go
+
+- **Timestamp**: 2026-08-22
+  - **Action**: #6629 — config sync shipped the ACTIVE TREE unredacted, so the
+    control-link PSK crossed the fabric in cleartext on the very link it
+    authenticates, at the one moment that link is guaranteed unauthenticated
+    (session-sync auth is fixed per connection at handshake time and a key
+    commit does not restart comms, so the carrying connection is by
+    construction one handshaked while both ends were unkeyed). Sealed the
+    config payload under a per-connection ephemeral X25519 + HKDF-SHA256 +
+    AES-256-GCM key (`syncMsgConfigKeyExchange` 30 / `syncMsgConfigEncrypted`
+    31, both additive, no wire-version bump). Chose this over excluding the
+    leaf: `SyncApply` promotes the received tree wholesale under a LENIENT
+    compile, so a stripped leaf makes the standby lose its own key and revert
+    to fail-open — and a new primary would drive an old standby unkeyed on a
+    rolling upgrade, where encryption's fallback is only "no worse than today".
+    Mutation matrix 8/9 RED; C7 (the nil-key guard) GREEN BY DESIGN and
+    annotated in place — removing it is unobservable because openConfigPayload
+    fails closed on a nil key; the safety property is bound by C9.
+    Also recorded the three-way incompatibility (#6629 vs the #5078 no-restart
+    pin vs the read-only secondary) in pkg/cluster/README.md.
+  - **File(s)**: pkg/cluster/{sync_config_crypto.go,sync_config_crypto_6629_test.go,
+    sync.go,sync_conn.go,sync_conn_config.go,sync_conn_read.go,
+    sync_capabilities_6650_test.go,README.md},
+    docs/session-sync-architecture.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -216,6 +216,76 @@ deterministic side initiates per fabric. `TCP_NODELAY` is enabled.
 | 13 | Barrier | Primary -> Secondary | Ordered demotion marker |
 | 14 | BarrierAck | Secondary -> Primary | Barrier acknowledgement |
 | 15 | BulkAck | Secondary -> Primary | Bulk acknowledgement |
+| 30 | ConfigKeyExchange | Bidirectional | Ephemeral X25519 public key for config-payload encryption (#6629) |
+| 31 | ConfigEncrypted | Primary -> Secondary | Type 8's payload, sealed (#6629) |
+
+(Types 16-29 are listed in `pkg/cluster/sync.go`; the two above are called out
+here because they change how type 8 travels.)
+
+### Config-Payload Confidentiality (#6629)
+
+The config text a primary pushes is the ACTIVE TREE rendered unredacted —
+`ShowActive()` goes through `ConfigTree.Format()`, which does not redact,
+deliberately, because the same render backs persistence, rollback, the DR
+archive and the on-box CLI, "none of which may lose the real secret"
+(`pkg/configstore/store_format.go`). So every `config.Secret` leaf crosses the
+fabric inside a type-8 payload, including `chassis cluster
+authentication-key` — the PSK that authenticates this very link.
+
+The exposure is circular. Session-sync authentication is fixed PER CONNECTION
+at handshake time, and committing a key does not restart cluster comms
+(`clusterTransportKey` excludes it, pinned by
+`TestAuthKeyChangeDoesNotRestartClusterComms_5078`), so the connection that
+carries the PSK to the peer is by construction the one handshaked while BOTH
+ends were unkeyed: neither authenticated nor confidential. A passive observer
+learns the key as it is introduced, and every subsequent HMAC on the link is
+then forgeable by them. The rollout defeats itself on first use.
+
+**Mechanism.** `installConn` generates a fresh ephemeral X25519 keypair per
+connection; `handleNewConnection` advertises the public half beside
+`sendCapabilities` (type 30). On receipt each end derives an AES-256 key with
+HKDF-SHA256 over the ECDH shared secret, salted with the two public keys in
+canonical order so neither end needs to know which dialled. `QueueConfig` then
+seals the type-8 payload — byte-identical plaintext, generation trailer
+included — and sends it as type 31. The receiver decrypts and hands the
+plaintext to the same `handleConfigPayload` the cleartext arm uses, so the two
+cannot diverge on ordering, generation accounting or apply admission.
+
+**Forward secrecy.** The keypair is per connection and `handleDisconnect`
+drops it, so a reconnect derives a different key and a key recovered later
+cannot open a capture taken on an earlier connection
+(`TestConfigCryptoReconnectDerivesFreshKey6629`).
+
+**What it does NOT close.** An ACTIVE man-in-the-middle. The ephemeral
+exchange on an unkeyed link is itself unauthenticated — there is nothing to
+authenticate it WITH, which is the bootstrap problem — so an attacker who can
+rewrite frames can substitute their own public keys and read the payload. That
+concedes nothing already conceded: on an unkeyed control segment an active
+attacker can already drive failover, call the allowlisted fabric RPCs and
+inject sessions, which is #6611's own rationale for requiring a key. This is
+not a confidential channel; it removes the passive-capture class from one
+message type.
+
+**Mixed version.** A peer that predates this never sends type 30, so no key is
+derived and the push falls back to cleartext type 8 — exactly today's
+behaviour — after a bounded wait that latches, so the cost is one wait per
+connection rather than one per push. The fallback logs a WARNING naming the
+exposure and whether a control-link key is configured (never the key). Both
+types are additive with NO `SessionSyncWireVersion` bump: the receive switch
+has no default arm, so an old peer ignores them, and bumping would make the
+#1930 INC-3 mixed-base gate refuse SESSION sync across the very rolling
+upgrade this must survive.
+
+**Why not exclude the leaf from the payload.** `Store.SyncApply` promotes the
+received tree WHOLESALE and its compile is lenient
+(`compileTreeLenient` -> `lenientClusterAuthKey`), so #6611's validator warns
+rather than rejects on that path: a payload with the leaf stripped makes the
+standby's active config LOSE its own key, and every control channel there
+silently reverts to fail-open dual-accept. On a rolling upgrade a new primary
+would drive an old standby unkeyed. Encryption's mixed-version fallback is "no
+worse than today" instead. Excluding the leaf and provisioning the PSK out of
+band remains the eventual posture, but it lands as ONE design with #6628 and
+#6630 — see "The three-way incompatibility" in `pkg/cluster/README.md`.
 
 ## Bulk Sync
 

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -2159,9 +2159,82 @@ unattended strict paths.
 The `authentication-key` leaf is `config.Secret`-typed and is redacted in the
 ordinary show/log/JSON render paths (`ast_redact.go`), so it is not exposed to
 routine operator output or diagnostics. That is not an absolute guarantee: a
-sufficiently privileged CLI class can still render cleartext configuration,
-and config-sync transmits it in the clear (#6629). Keep the authoritative copy
-in your own secret store.
+sufficiently privileged CLI class can still render cleartext configuration.
+Keep the authoritative copy in your own secret store.
+
+Config sync used to transmit it in the clear as well (#6629). It no longer
+does against a peer of the same vintage — see below — but the qualifier
+matters.
+
+### Config sync and the PSK (#6629)
+
+Config sync ships the ACTIVE TREE rendered unredacted, so the PSK travelled
+inside a `syncMsgConfig` payload, on the link it authenticates, at the one
+moment that link is guaranteed unauthenticated: session-sync auth is fixed per
+connection at handshake time, and committing a key does not restart cluster
+comms, so the carrying connection is by construction one handshaked while both
+ends were unkeyed. A passive observer learned the key as it was introduced and
+could forge every subsequent HMAC on the link. The rollout defeated itself on
+first use.
+
+The payload is now sealed under a key derived from a fresh ephemeral X25519
+exchange performed on every connection (`syncMsgConfigKeyExchange` /
+`syncMsgConfigEncrypted`; mechanism and wire format in
+`docs/session-sync-architecture.md` -> "Config-Payload Confidentiality").
+
+Read the scope literally:
+
+- It defeats a PASSIVE observer, including one holding a full historical
+  capture — the keypair is per connection, so there is forward secrecy across
+  reconnects.
+- It does NOT defeat an ACTIVE man-in-the-middle. The exchange on an unkeyed
+  link is unauthenticated because there is nothing yet to authenticate it
+  with. An active attacker on an unkeyed control segment can already drive
+  election, call the allowlisted fabric RPCs and inject sessions — that is the
+  argument for keying at all — so nothing new is conceded, but do not read
+  this as a confidential channel.
+- Against a peer that predates #6629 the push falls back to CLEARTEXT, with a
+  warning. During a mixed-version window the old behaviour applies in full.
+- **A capture taken before the upgrade is not retired by the upgrade.** Rotate
+  the PSK after both nodes are on a #6629-capable build, for the same reason
+  the #6169 note above gives: no code change invalidates frames an attacker
+  already holds.
+
+### The three-way incompatibility (#6628 / #6629 / #6630)
+
+Three shipped positions cannot all hold, and every fix in this area has to
+declare which one it moves:
+
+1. **#6629**: the PSK must not cross the control link in cleartext.
+2. **`TestAuthKeyChangeDoesNotRestartClusterComms_5078`** pins the exact
+   opposite of #6628's fix, and its failure message states the reason —
+   "committing it would restart cluster comms and drop the very connection
+   that must carry the key to the read-only secondary."
+3. **`sync_auth.go`'s `syncAuthDecision` comment**: an RG0 secondary whose
+   read-only gate is armed returns `ErrClusterReadOnly` from
+   `EnterConfigureSession`, so config-sync is that node's ONLY writer. In-band
+   carriage of the PSK is not incidental — it is the documented live-keying
+   procedure.
+
+Consequences to hold on to:
+
+- **#6628 landed alone bricks the live-keying rollout.** The instant the
+  primary commits the key the connection drops, re-handshakes, and
+  `syncAuthDecision(keyConfigured=true, peerKeyed=false)` REJECTS the
+  still-unkeyed secondary — which can then never be keyed at all, because it
+  is read-only. A self-inflicted permanent partition.
+- **The eventual posture** is that the PSK becomes provisioning-time
+  node-local state that config-sync neither carries nor overwrites (the
+  per-node day-0 config drive already provisions `xpf.conf` alongside
+  `node-id`, and `sync_auth.go` already recommends "keying at provisioning,
+  before either node seats as secondary"). #5078's pin is inverted as PART of
+  that change, never on its own.
+- **#6630's rotation is then FORCED, not preferred.** With no in-band
+  coordination channel left, accepting the previous key for a bounded overlap
+  window is the only rotation that keeps heartbeat liveness.
+- Payload encryption (#6629, above) deliberately does NOT untie this knot. It
+  closes the disclosure without touching carriage, so the three can be
+  resolved as one design later rather than under time pressure.
 
 ## IPsec SA sync
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -126,6 +126,31 @@ const (
 	// Payload: {config_snapshot_protocol_version: u16 LE}, with the #2170
 	// trailing-field discipline so the record can grow.
 	syncMsgPeerCapabilities = 29
+
+	// syncMsgConfigKeyExchange carries the SENDER's ephemeral X25519 public
+	// key for config-payload encryption (#6629). Sent once per installed
+	// connection, right beside the capabilities advertisement.
+	//
+	// Payload: {version: u8, x25519_public_key: [32]byte}, with the #2170
+	// trailing-field discipline so the record can grow.
+	syncMsgConfigKeyExchange = 30
+
+	// syncMsgConfigEncrypted is a syncMsgConfig payload sealed under the key
+	// derived from that exchange (#6629). Its plaintext is byte-identical to
+	// the syncMsgConfig payload — the same encodeConfigPayload framing,
+	// generation trailer included — so the receive path is shared and cannot
+	// drift between the two.
+	//
+	// Payload: {version: u8, nonce: [12]byte, AES-256-GCM(ciphertext||tag)}.
+	//
+	// BOTH are ADDITIVE and version-bump-free on the #2239/#6650 precedent
+	// above: the receive switch has no default arm, so a peer that predates
+	// them ignores the exchange, never derives a key, and is sent cleartext
+	// syncMsgConfig exactly as today — with a loud warning naming the
+	// exposure. Bumping CurrentHAProtocolVersion / SessionSyncWireVersion
+	// would make the #1930 INC-3 mixed-base gate falsely refuse SESSION sync
+	// across the very rolling upgrade this must survive.
+	syncMsgConfigEncrypted = 31
 )
 
 // syncHeader is the wire header for each sync message.
@@ -360,6 +385,14 @@ type SessionSync struct {
 	mu        sync.Mutex
 	conn0     net.Conn
 	conn1     net.Conn
+	// configCrypto0/configCrypto1 hold the per-connection ephemeral X25519
+	// state that encrypts the config-sync payload (#6629). They sit here,
+	// beside the conn they belong to and under the same mu, because their
+	// lifetime is exactly a connection's: installConn replaces the slot's
+	// state with a freshly generated keypair and handleDisconnect clears it,
+	// which is what makes a reconnect derive a different key.
+	configCrypto0 *configCryptoState
+	configCrypto1 *configCryptoState
 	// peerIncarnation identifies which run of the peer process the currently
 	// installed connections belong to, and conn0Gen/conn1Gen record the
 	// incarnation each slot's connection was installed under. All three are

--- a/pkg/cluster/sync_capabilities_6650_test.go
+++ b/pkg/cluster/sync_capabilities_6650_test.go
@@ -113,30 +113,7 @@ func TestCapabilityAdvertisedOnConnectionInstall6650(t *testing.T) {
 // type instead would have them MISPARSE it as real traffic.
 func TestPeerCapabilitiesMessageTypeIsUnique6650(t *testing.T) {
 	t.Parallel()
-	// A SLICE, not a map: syncMsgAuthHello and syncMsgConfigApplyNack both hold
-	// 27 (phase-separated -- pre-install handshake vs post-install), and a map
-	// literal with duplicate constant keys does not compile. Enumerating pairs
-	// keeps every live name in the guard instead of silently dropping one.
-	live := []struct {
-		v    int
-		name string
-	}{
-		{syncMsgSessionV4, "SessionV4"}, {syncMsgSessionV6, "SessionV6"},
-		{syncMsgDeleteV4, "DeleteV4"}, {syncMsgDeleteV6, "DeleteV6"},
-		{syncMsgBulkStart, "BulkStart"}, {syncMsgBulkEnd, "BulkEnd"},
-		{syncMsgHeartbeat, "Heartbeat"}, {syncMsgConfig, "Config"},
-		{syncMsgIPsecSA, "IPsecSA"}, {syncMsgFailover, "Failover"},
-		{syncMsgFence, "Fence"}, {syncMsgClockSync, "ClockSync"},
-		{syncMsgBarrier, "Barrier"}, {syncMsgBarrierAck, "BarrierAck"},
-		{syncMsgBulkAck, "BulkAck"}, {syncMsgFailoverAck, "FailoverAck"},
-		{syncMsgFailoverCommit, "FailoverCommit"}, {syncMsgFailoverCommitAck, "FailoverCommitAck"},
-		{syncMsgPrepareActivation, "PrepareActivation"}, {syncMsgFailoverBatch, "FailoverBatch"},
-		{syncMsgFailoverBatchAck, "FailoverBatchAck"}, {syncMsgFailoverBatchCommit, "FailoverBatchCommit"},
-		{syncMsgFailoverBatchCommitAck, "FailoverBatchCommitAck"}, {syncMsgHeartbeatAck, "HeartbeatAck"},
-		{syncMsgDHCPLeaseV4, "DHCPLeaseV4"}, {syncMsgDHCPLeaseV6, "DHCPLeaseV6"},
-		{syncMsgAuthHello, "AuthHello"}, {syncMsgAuthProof, "AuthProof"},
-		{syncMsgConfigApplyNack, "ConfigApplyNack"},
-	}
+	live := liveSyncMessageTypesExcept(syncMsgPeerCapabilities)
 	for _, m := range live {
 		if m.v == syncMsgPeerCapabilities {
 			t.Fatalf("syncMsgPeerCapabilities (%d) collides with %s. An old peer ignores an "+
@@ -145,7 +122,7 @@ func TestPeerCapabilitiesMessageTypeIsUnique6650(t *testing.T) {
 				syncMsgPeerCapabilities, m.name)
 		}
 	}
-	if len(live) < 25 {
+	if len(live) < 31 {
 		t.Fatalf("the live-type list holds only %d entries — it has fallen behind "+
 			"sync.go and can no longer certify uniqueness", len(live))
 	}
@@ -197,4 +174,58 @@ func readClusterSource(t *testing.T, name string) string {
 		t.Fatalf("parse %s: %v", name, err)
 	}
 	return mustReadClusterFile(t, name)
+}
+
+// syncMessageType names one live syncMsg* constant for the uniqueness guards.
+type syncMessageType struct {
+	v    int
+	name string
+}
+
+// liveSyncMessageTypesExcept enumerates every live syncMsg* constant except
+// the one under test.
+//
+// A SLICE, not a map: syncMsgAuthHello and syncMsgConfigApplyNack both hold 27
+// (phase-separated -- pre-install handshake vs post-install), and a map literal
+// with duplicate constant keys does not compile. Enumerating pairs keeps every
+// live name in the guard instead of silently dropping one.
+//
+// The exclusion is BY VALUE, so passing 27 would drop both AuthHello and
+// ConfigApplyNack. No caller does; a future one that needs 27 must exclude by
+// name instead.
+//
+// SINGLE-SOURCED across the #6650 and #6629 uniqueness guards deliberately: two
+// copies of this census would drift, and a census that has fallen behind
+// sync.go certifies nothing. Each caller excludes its own constant, so the same
+// list serves both. The length floor in each caller catches the list falling
+// behind.
+func liveSyncMessageTypesExcept(under int) []syncMessageType {
+	all := []syncMessageType{
+		{syncMsgSessionV4, "SessionV4"}, {syncMsgSessionV6, "SessionV6"},
+		{syncMsgDeleteV4, "DeleteV4"}, {syncMsgDeleteV6, "DeleteV6"},
+		{syncMsgBulkStart, "BulkStart"}, {syncMsgBulkEnd, "BulkEnd"},
+		{syncMsgHeartbeat, "Heartbeat"}, {syncMsgConfig, "Config"},
+		{syncMsgIPsecSA, "IPsecSA"}, {syncMsgFailover, "Failover"},
+		{syncMsgFence, "Fence"}, {syncMsgClockSync, "ClockSync"},
+		{syncMsgBarrier, "Barrier"}, {syncMsgBarrierAck, "BarrierAck"},
+		{syncMsgBulkAck, "BulkAck"}, {syncMsgFailoverAck, "FailoverAck"},
+		{syncMsgFailoverCommit, "FailoverCommit"}, {syncMsgFailoverCommitAck, "FailoverCommitAck"},
+		{syncMsgPrepareActivation, "PrepareActivation"}, {syncMsgFailoverBatch, "FailoverBatch"},
+		{syncMsgFailoverBatchAck, "FailoverBatchAck"}, {syncMsgFailoverBatchCommit, "FailoverBatchCommit"},
+		{syncMsgFailoverBatchCommitAck, "FailoverBatchCommitAck"}, {syncMsgHeartbeatAck, "HeartbeatAck"},
+		{syncMsgDHCPLeaseV4, "DHCPLeaseV4"}, {syncMsgDHCPLeaseV6, "DHCPLeaseV6"},
+		{syncMsgAuthHello, "AuthHello"}, {syncMsgAuthProof, "AuthProof"},
+		{syncMsgConfigApplyNack, "ConfigApplyNack"},
+		{syncMsgPeerCapabilities, "PeerCapabilities"},
+		{syncMsgConfigKeyExchange, "ConfigKeyExchange"},
+		{syncMsgConfigEncrypted, "ConfigEncrypted"},
+	}
+	out := make([]syncMessageType, 0, len(all))
+	for _, m := range all {
+		if m.v == under {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
 }

--- a/pkg/cluster/sync_config_crypto.go
+++ b/pkg/cluster/sync_config_crypto.go
@@ -1,0 +1,401 @@
+package cluster
+
+// Confidentiality for the config-sync payload (#6629).
+//
+// THE DEFECT. The control-link PSK is an ordinary config leaf
+// (`set chassis cluster authentication-key <key>`, compiled to
+// `Chassis.Cluster.ControlLinkAuthKey`), and config sync ships the ACTIVE
+// CONFIG TEXT: `d.store.ShowActive()` renders through `ConfigTree.Format()`,
+// which does not redact, so the PSK crosses the fabric in cleartext inside a
+// `syncMsgConfig` payload. Rendered both ways, the key is present in
+// `Format()` and absent from `RedactedClone().Format()` — the cleartext render
+// is deliberate (pkg/configstore/store_format.go: the Show* siblings back HA
+// config sync, the DR archive, persistence and the on-box CLI, "none of which
+// may lose the real secret"), and its security consequence was simply never
+// followed through.
+//
+// The exposure is circular. Session-sync authentication is fixed PER
+// CONNECTION at handshake time (`performSyncHandshake` returns immediately
+// when this node holds no key), and committing a key does NOT restart cluster
+// comms — the restart decision compares `clusterTransportKey`, which excludes
+// the auth key, pinned by TestAuthKeyChangeDoesNotRestartClusterComms_5078.
+// So the connection that carries the PSK to the peer is, by construction, the
+// one that was handshaked while BOTH ends were unkeyed: neither authenticated
+// nor confidential. A passive observer on the control segment learns the key
+// AT THE MOMENT IT IS INTRODUCED, and every subsequent HMAC on that link —
+// heartbeat, fabric gRPC bearer token, session-sync frame MAC — is forgeable
+// by them. The rollout defeats itself on first use.
+//
+// WHAT THIS CLOSES, AND WHAT IT DOES NOT.
+//
+// It closes a PASSIVE observer. The config payload is sealed under a key
+// derived from an ephemeral X25519 exchange performed fresh on every
+// connection, so a sniffer holding a full capture of the control segment
+// recovers nothing, and a capture taken before a later key compromise stays
+// unreadable (forward secrecy).
+//
+// It does NOT stop an ACTIVE man-in-the-middle. The ephemeral exchange on an
+// unkeyed link is itself unauthenticated — there is nothing to authenticate it
+// WITH, which is the whole point of the bootstrap problem — so an attacker who
+// can intercept and rewrite frames can substitute their own public keys and
+// read the payload. That concedes nothing that is not already conceded: on an
+// unkeyed control segment an active attacker can drive failover, call the
+// allowlisted fabric RPCs, and inject sessions today. That is #6611's own
+// stated rationale for requiring a key at all. Do not read this file as
+// providing a confidential channel; it removes the passive-capture class from
+// one message type.
+//
+// It is deliberately NOT a change to the frame seal. `sealFrame`
+// (sync_auth.go) still provides the HMAC and anti-replay for authenticated
+// connections, unchanged. This adds confidentiality to ONE message type; it
+// does not replace the authentication scheme.
+//
+// WHY NOT EXCLUDE THE LEAF FROM THE PAYLOAD. Three shipped positions are
+// mutually incompatible, and excluding the leaf resolves the knot in the
+// direction that can leave a node FAIL-OPEN:
+//
+//   - #6629 says the PSK must not cross in cleartext.
+//   - TestAuthKeyChangeDoesNotRestartClusterComms_5078 pins the opposite of
+//     #6628's fix, because the established connection "must carry the key to
+//     the read-only secondary".
+//   - sync_auth.go's syncAuthDecision comment records that an RG0 secondary
+//     with the read-only gate armed returns ErrClusterReadOnly, so config-sync
+//     is that node's ONLY writer.
+//
+// `Store.SyncApply` promotes the received tree WHOLESALE and its compile is
+// lenient (`compileTreeLenient` -> `lenientClusterAuthKey`), so #6611's
+// validator warns rather than rejects on that path: a payload with the leaf
+// removed makes the standby's active config LOSE its own key, and every
+// control channel there silently reverts to fail-open dual-accept. Worse
+// still on a rolling upgrade, where a new primary would drive an old standby
+// unkeyed. Payload encryption's mixed-version fallback is "no worse than
+// today" instead. Exclusion-plus-provisioning remains the eventual posture,
+// but it lands as ONE design with #6628 and #6630 — never alone.
+//
+// See docs/session-sync-architecture.md and pkg/cluster/README.md.
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdh"
+	"crypto/hkdf"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"time"
+)
+
+const (
+	// syncConfigCryptoVersion is the key-exchange wire version. A receiver
+	// that does not recognise the version treats the peer as incapable and
+	// falls back to cleartext with the warning below, rather than failing the
+	// connection: config sync is load-bearing for HA convergence and must
+	// never be taken down by an advisory confidentiality layer.
+	syncConfigCryptoVersion = 1
+
+	// syncConfigECDHPubSize is the marshalled X25519 public key length.
+	syncConfigECDHPubSize = 32
+
+	// syncConfigNonceSize is the AES-GCM nonce length.
+	syncConfigNonceSize = 12
+
+	// syncConfigKeyLen is the derived AEAD key length (AES-256).
+	syncConfigKeyLen = 32
+)
+
+// syncConfigKeyWait bounds how long a config push waits for the peer's
+// ephemeral public key before giving up and sending cleartext.
+//
+// Both ends send their key exchange from installConn, before the
+// OnPeerConnected callback that drives the first push is even dispatched, so on
+// a new<->new pair the key is already present and this wait never runs. It
+// exists for the ordering edge, not the common case. Against a peer that
+// predates this it expires once per connection (the legacy latch below then
+// suppresses further waits), which costs one bounded stall on the first push
+// rather than on every push.
+//
+// A var, not a const, so a test can exercise the mixed-version fallback
+// without spending the real timeout.
+var syncConfigKeyWait = 2 * time.Second
+
+// syncConfigKeyInfo is the HKDF info string binding the derived key to this
+// purpose. Changing it changes the key, so a peer on a different string
+// produces a decrypt failure rather than a silently mismatched key.
+const syncConfigKeyInfo = "xpf cluster config-sync payload v1"
+
+// errConfigDecrypt is returned when a sealed config payload cannot be opened.
+var errConfigDecrypt = errors.New("cluster sync: config payload decrypt failed")
+
+// configCryptoState is the per-CONNECTION ephemeral key-exchange state for
+// config-payload encryption.
+//
+// It lives per fabric slot, alongside conn0/conn1 and their conn0Gen/conn1Gen
+// incarnation stamps, and is guarded by the same SessionSync.mu. installConn
+// REPLACES it with a freshly generated keypair on every install and
+// handleDisconnect clears the slot's state, so:
+//
+//   - a reconnect derives a DIFFERENT key (no reuse across connections), and
+//   - a key compromised later cannot open a capture taken on an earlier
+//     connection.
+//
+// Both properties are asserted by
+// TestConfigCryptoReconnectDerivesFreshKey_6629.
+type configCryptoState struct {
+	priv *ecdh.PrivateKey
+	pub  []byte
+
+	// key is the derived AEAD key, non-nil only once the peer's public key has
+	// arrived and the exchange completed.
+	key []byte
+
+	// ready is closed when key becomes non-nil. A push waiting for the peer's
+	// key selects on it so the common case costs nothing.
+	ready chan struct{}
+
+	// legacy latches once a push has already waited out syncConfigKeyWait on
+	// this connection, so a peer that never sends a key exchange costs ONE
+	// bounded wait per connection rather than one per push.
+	legacy bool
+}
+
+// newConfigCryptoState generates this connection's ephemeral X25519 keypair.
+// A generation failure returns nil, which degrades that connection to
+// cleartext with the fallback warning — never to a dropped fabric.
+func newConfigCryptoState() *configCryptoState {
+	priv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		slog.Error("cluster sync: could not generate config-sync ephemeral key; "+
+			"config payloads on this connection will be sent in CLEARTEXT (#6629)", "err", err)
+		return nil
+	}
+	return &configCryptoState{
+		priv:  priv,
+		pub:   priv.PublicKey().Bytes(),
+		ready: make(chan struct{}),
+	}
+}
+
+// deriveConfigKey completes the exchange against the peer's public key.
+//
+// The HKDF salt is the two public keys in a CANONICAL order (the numerically
+// smaller byte string first), so both ends derive the same key without either
+// needing to know which of them dialled. Mirrors syncDeriveFrameKey's ordering
+// of the handshake nonces.
+func (c *configCryptoState) deriveConfigKey(peerPub []byte) error {
+	if c == nil || c.priv == nil {
+		return errors.New("cluster sync: no local ephemeral key")
+	}
+	pk, err := ecdh.X25519().NewPublicKey(peerPub)
+	if err != nil {
+		return fmt.Errorf("cluster sync: bad peer ephemeral key: %w", err)
+	}
+	shared, err := c.priv.ECDH(pk)
+	if err != nil {
+		return fmt.Errorf("cluster sync: config-sync ECDH failed: %w", err)
+	}
+	lo, hi := c.pub, peerPub
+	if string(lo) > string(hi) {
+		lo, hi = hi, lo
+	}
+	salt := make([]byte, 0, len(lo)+len(hi))
+	salt = append(salt, lo...)
+	salt = append(salt, hi...)
+	key, err := hkdf.Key(sha256.New, shared, salt, syncConfigKeyInfo, syncConfigKeyLen)
+	if err != nil {
+		return fmt.Errorf("cluster sync: config-sync HKDF failed: %w", err)
+	}
+	c.key = key
+	return nil
+}
+
+// sealConfigPayload encrypts plaintext under key, returning
+// {version, nonce, ciphertext||tag}.
+func sealConfigPayload(key, plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, syncConfigNonceSize)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	out := make([]byte, 0, 1+len(nonce)+len(plaintext)+aead.Overhead())
+	out = append(out, syncConfigCryptoVersion)
+	out = append(out, nonce...)
+	// The version byte is authenticated as additional data so a downgrade to a
+	// future weaker version cannot be forged onto an existing ciphertext.
+	out = aead.Seal(out, nonce, plaintext, out[:1])
+	return out, nil
+}
+
+// openConfigPayload reverses sealConfigPayload.
+func openConfigPayload(key, payload []byte) ([]byte, error) {
+	if len(payload) < 1+syncConfigNonceSize {
+		return nil, errConfigDecrypt
+	}
+	if payload[0] != syncConfigCryptoVersion {
+		return nil, fmt.Errorf("%w: unsupported version %d", errConfigDecrypt, payload[0])
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := payload[1 : 1+syncConfigNonceSize]
+	plaintext, err := aead.Open(nil, nonce, payload[1+syncConfigNonceSize:], payload[:1])
+	if err != nil {
+		return nil, errConfigDecrypt
+	}
+	return plaintext, nil
+}
+
+// configCryptoForConnLocked returns the ephemeral state belonging to the slot
+// that currently holds conn. Nil for a stale connection the slots no longer
+// reference — a payload arriving on one is not decryptable and must not be
+// opened with another connection's key.
+//
+// Caller holds s.mu.
+func (s *SessionSync) configCryptoForConnLocked(conn net.Conn) *configCryptoState {
+	switch {
+	case conn != nil && s.conn0 == conn:
+		return s.configCrypto0
+	case conn != nil && s.conn1 == conn:
+		return s.configCrypto1
+	}
+	return nil
+}
+
+// configCryptoForConn is configCryptoForConnLocked with the lock taken.
+func (s *SessionSync) configCryptoForConn(conn net.Conn) *configCryptoState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.configCryptoForConnLocked(conn)
+}
+
+// configKeyForConn returns the derived AEAD key for conn's connection, or nil
+// when the exchange has not completed (or conn is stale). Read under s.mu:
+// the key is published by a receive-loop goroutine and consumed by a push on
+// the commit path.
+func (s *SessionSync) configKeyForConn(conn net.Conn) []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	c := s.configCryptoForConnLocked(conn)
+	if c == nil {
+		return nil
+	}
+	return c.key
+}
+
+// sendConfigKeyExchange advertises this connection's ephemeral public key.
+// Called once per installed connection, right beside sendCapabilities.
+//
+// ADDITIVE and version-bump-free on the #2239/#6650 precedent: the receive
+// switch has no default arm, so a peer that predates this ignores the frame
+// and the sender falls back to cleartext with a warning. Bumping
+// SessionSyncWireVersion instead would make the #1930 INC-3 mixed-base gate
+// refuse SESSION sync across exactly the rolling upgrade this must survive.
+//
+// A send failure is logged and NOT escalated to handleDisconnect, matching
+// sendCapabilities: dropping a live fabric because an advisory frame did not
+// fit would trade a confidentiality gap for a sync outage.
+func (s *SessionSync) sendConfigKeyExchange(conn net.Conn) {
+	c := s.configCryptoForConn(conn)
+	if c == nil || len(c.pub) != syncConfigECDHPubSize {
+		return
+	}
+	payload := make([]byte, 0, 1+syncConfigECDHPubSize)
+	payload = append(payload, syncConfigCryptoVersion)
+	payload = append(payload, c.pub...)
+	s.writeMu.Lock()
+	err := writeMsg(conn, syncMsgConfigKeyExchange, payload)
+	s.writeMu.Unlock()
+	if err != nil {
+		slog.Warn("cluster sync: failed to send config-sync key exchange; config payloads "+
+			"on this connection will be sent in CLEARTEXT (#6629)", "err", err)
+	}
+}
+
+// handleConfigKeyExchange completes the exchange for the slot that holds conn.
+//
+// Idempotent per connection: a second key exchange on the same connection is
+// IGNORED rather than re-deriving. Re-deriving would let a peer (or an
+// on-path attacker who can inject one frame) roll the key of a live connection
+// at will, and there is no legitimate reason to: the keypair is per
+// connection, and a reconnect installs a fresh one.
+func (s *SessionSync) handleConfigKeyExchange(conn net.Conn, payload []byte) {
+	if len(payload) < 1+syncConfigECDHPubSize {
+		slog.Warn("cluster sync: config-sync key exchange too short", "len", len(payload))
+		return
+	}
+	if payload[0] != syncConfigCryptoVersion {
+		slog.Warn("cluster sync: unsupported config-sync key-exchange version; config payloads "+
+			"from this node will be sent in CLEARTEXT (#6629)", "version", payload[0])
+		return
+	}
+	peerPub := payload[1 : 1+syncConfigECDHPubSize]
+	s.mu.Lock()
+	c := s.configCryptoForConnLocked(conn)
+	if c == nil || c.key != nil {
+		s.mu.Unlock()
+		return
+	}
+	err := c.deriveConfigKey(peerPub)
+	ready := c.ready
+	derived := c.key != nil
+	s.mu.Unlock()
+	if err != nil || !derived {
+		slog.Warn("cluster sync: config-sync key exchange failed; config payloads on this "+
+			"connection will be sent in CLEARTEXT (#6629)", "err", err)
+		return
+	}
+	close(ready)
+	slog.Info("cluster sync: config-sync payload encryption negotiated on this connection (#6629)",
+		"remote", connRemoteAddrString(conn))
+}
+
+// awaitConfigKey returns the AEAD key for conn's connection, waiting up to
+// syncConfigKeyWait for the peer's key exchange to land.
+//
+// It returns nil when the peer does not speak the exchange, which is the
+// mixed-version case: the caller then sends cleartext AND WARNS. The warning
+// is not decoration. An operator running a mixed-version pair while first
+// keying the cluster is standing in precisely the exposed window, and the
+// first push on that connection is the moment the information is actionable.
+func (s *SessionSync) awaitConfigKey(conn net.Conn) []byte {
+	c := s.configCryptoForConn(conn)
+	if c == nil {
+		return nil
+	}
+	s.mu.Lock()
+	key, ready, legacy := c.key, c.ready, c.legacy
+	s.mu.Unlock()
+	if key != nil {
+		return key
+	}
+	if legacy {
+		return nil
+	}
+	timer := time.NewTimer(syncConfigKeyWait)
+	defer timer.Stop()
+	select {
+	case <-ready:
+	case <-timer.C:
+	}
+	s.mu.Lock()
+	key = c.key
+	if key == nil {
+		c.legacy = true
+	}
+	s.mu.Unlock()
+	return key
+}

--- a/pkg/cluster/sync_config_crypto_6629_test.go
+++ b/pkg/cluster/sync_config_crypto_6629_test.go
@@ -1,0 +1,501 @@
+package cluster
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// testPSK is the value that must never be readable on the wire. It is a
+// distinctive literal so a substring search over the raw frame is meaningful:
+// a partial or transformed leak still contains it, and a false negative would
+// need the bytes to be genuinely absent.
+const testPSK = "PSK-6629-must-never-cross-in-cleartext"
+
+// configWithPSK is the shape ShowActive() renders: the full active tree,
+// unredacted, with the control-link PSK as an ordinary leaf.
+func configWithPSK() string {
+	return "chassis {\n    cluster {\n        authentication-key \"" + testPSK +
+		"\";\n        config-synchronization;\n    }\n}\n"
+}
+
+// keyExchangePayload builds the wire form of a syncMsgConfigKeyExchange body.
+func keyExchangePayload(pub []byte) []byte {
+	out := make([]byte, 0, 1+len(pub))
+	out = append(out, syncConfigCryptoVersion)
+	return append(out, pub...)
+}
+
+// readOneFrame reads a single length-framed sync message off conn and returns
+// the message type, the payload, and the COMPLETE frame bytes (header
+// included) — the last is what a passive observer on the control segment
+// actually sees, so it is what the leak assertion searches.
+func readOneFrame(t *testing.T, conn net.Conn) (uint8, []byte, []byte) {
+	t.Helper()
+	hdr := make([]byte, syncHeaderSize)
+	if _, err := io.ReadFull(conn, hdr); err != nil {
+		t.Fatalf("read frame header: %v", err)
+	}
+	length := binary.LittleEndian.Uint32(hdr[8:12])
+	body := make([]byte, length)
+	if length > 0 {
+		if _, err := io.ReadFull(conn, body); err != nil {
+			t.Fatalf("read frame body: %v", err)
+		}
+	}
+	return hdr[4], body, append(append([]byte{}, hdr...), body...)
+}
+
+// completeExchange wires two SessionSyncs' ephemeral states together through
+// the REAL handler, exactly as two receive loops would.
+func completeExchange(t *testing.T, a *SessionSync, aConn net.Conn, b *SessionSync, bConn net.Conn) {
+	t.Helper()
+	aState := a.configCryptoForConn(aConn)
+	bState := b.configCryptoForConn(bConn)
+	if aState == nil || bState == nil {
+		t.Fatal("both connections must carry ephemeral state after install")
+	}
+	a.handleConfigKeyExchange(aConn, keyExchangePayload(bState.pub))
+	b.handleConfigKeyExchange(bConn, keyExchangePayload(aState.pub))
+}
+
+// TestConfigSyncPayloadDoesNotCarryThePSKInCleartext6629 is the primary gate,
+// and it asserts BOTH directions in one trajectory.
+//
+// POSITIVE: the control-link PSK must not appear anywhere in the bytes a
+// passive observer on the control segment sees for a config push.
+//
+// CONTROL: the standby must still receive that config, intact, PSK included.
+// Without the control half an "encryption" that garbled or dropped the payload
+// would pass the positive cell trivially — and so would one that simply
+// stopped sending the config at all.
+//
+// FAIL-ON-REVERT: drop the seal in QueueConfig (send syncMsgConfig with the
+// plaintext payload) and the positive half reds on the substring search. Break
+// the decrypt (open with a different key) and the control half reds on the
+// delivered text.
+func TestConfigSyncPayloadDoesNotCarryThePSKInCleartext6629(t *testing.T) {
+	sender := NewSessionSync(":0", "10.0.0.2:4785", &mockSweepDP{})
+	receiver := NewSessionSync(":0", "10.0.0.1:4785", &mockSweepDP{})
+	senderConn, receiverConn := net.Pipe()
+	defer senderConn.Close()
+	defer receiverConn.Close()
+
+	sender.mu.Lock()
+	sender.conn0 = senderConn
+	sender.configCrypto0 = newConfigCryptoState()
+	sender.mu.Unlock()
+	receiver.mu.Lock()
+	receiver.conn0 = receiverConn
+	receiver.configCrypto0 = newConfigCryptoState()
+	receiver.mu.Unlock()
+
+	completeExchange(t, sender, senderConn, receiver, receiverConn)
+
+	cfg := configWithPSK()
+	go sender.QueueConfig(cfg)
+
+	if err := receiverConn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	msgType, payload, raw := readOneFrame(t, receiverConn)
+
+	if msgType != syncMsgConfigEncrypted {
+		t.Fatalf("config push must be sealed: got message type %d, want syncMsgConfigEncrypted (%d). "+
+			"An unsealed push puts the control-link PSK on the wire in cleartext, on the very "+
+			"link it authenticates (#6629)", msgType, syncMsgConfigEncrypted)
+	}
+	if strings.Contains(string(raw), testPSK) {
+		t.Fatal("the control-link PSK is present in the bytes a passive observer sees for a " +
+			"config-sync push (#6629): every subsequent HMAC on this link — heartbeat, fabric " +
+			"gRPC bearer token, session-sync frame MAC — is forgeable by anyone who captured it")
+	}
+
+	// CONTROL: the standby must still get the real config, PSK and all.
+	got := make(chan string, 1)
+	receiver.OnConfigReceived = func(text string) error {
+		got <- text
+		return nil
+	}
+	receiver.handleMessage(receiverConn, msgType, payload)
+	select {
+	case item := <-receiver.configApplyCh:
+		if item.text != cfg {
+			t.Fatalf("the decrypted config must be byte-identical to what was pushed.\n got: %q\nwant: %q",
+				item.text, cfg)
+		}
+		if !strings.Contains(item.text, testPSK) {
+			t.Fatal("the decrypted config lost the PSK — config sync must not lose the real " +
+				"secret (pkg/configstore/store_format.go); an encryption that drops it trades " +
+				"a disclosure for a broken standby")
+		}
+		if item.gen == 0 {
+			t.Fatal("the generation trailer must survive the seal: the plaintext is the " +
+				"encodeConfigPayload framing, so gen travels inside the ciphertext")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the receiver did not enqueue the decrypted config")
+	}
+}
+
+// TestConfigCryptoMixedVersionFallsBackToCleartext6629 pins the accepted
+// fallback and its bound.
+//
+// A peer that predates #6629 never sends a key exchange. Refusing to push
+// would break the rolling upgrade — an unconverged standby is worse than a
+// readable payload — so the push proceeds in the clear, exactly as it does
+// today. That is "no worse than today", which is the property that made
+// payload encryption preferable to excluding the leaf: excluding it would have
+// driven an old standby UNKEYED, i.e. fail-open.
+//
+// The bound matters as much as the fallback: the wait must expire and the push
+// must still happen. A fallback that blocked forever would convert a
+// confidentiality gap into a config-sync outage.
+func TestConfigCryptoMixedVersionFallsBackToCleartext6629(t *testing.T) {
+	prev := syncConfigKeyWait
+	syncConfigKeyWait = 50 * time.Millisecond
+	defer func() { syncConfigKeyWait = prev }()
+
+	sender := NewSessionSync(":0", "10.0.0.2:4785", &mockSweepDP{})
+	senderConn, peerConn := net.Pipe()
+	defer senderConn.Close()
+	defer peerConn.Close()
+
+	sender.mu.Lock()
+	sender.conn0 = senderConn
+	sender.configCrypto0 = newConfigCryptoState()
+	sender.mu.Unlock()
+
+	// No key exchange from the peer — a pre-#6629 build.
+	cfg := configWithPSK()
+	go sender.QueueConfig(cfg)
+
+	if err := peerConn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	msgType, payload, _ := readOneFrame(t, peerConn)
+	if msgType != syncMsgConfig {
+		t.Fatalf("a peer that never negotiated must be sent the legacy cleartext message: "+
+			"got type %d, want syncMsgConfig (%d)", msgType, syncMsgConfig)
+	}
+	text, _ := decodeConfigPayload(payload)
+	if text != cfg {
+		t.Fatalf("the cleartext fallback must be byte-identical to today's push.\n got: %q\nwant: %q",
+			text, cfg)
+	}
+
+	// The legacy latch must be armed so the NEXT push does not pay the wait
+	// again — a per-push stall on the control path is exactly the kind of
+	// shared-socket cost CLAUDE.md forbids adding.
+	sender.mu.Lock()
+	legacy := sender.configCrypto0.legacy
+	sender.mu.Unlock()
+	if !legacy {
+		t.Fatal("the first expired wait must latch the peer as legacy, so a peer that never " +
+			"negotiates costs ONE bounded wait per connection rather than one per push")
+	}
+}
+
+// TestConfigCryptoReconnectDerivesFreshKey6629 binds forward secrecy across
+// connections: the ephemeral keypair is per CONNECTION, so a key recovered
+// later cannot open a capture taken on an earlier one.
+//
+// The two halves are separated so each has a SINGLE-mutation red. A test that
+// disconnected between the installs would need BOTH the install-replaces and
+// the disconnect-clears behaviours removed before it changed colour, and a
+// compound cell localises nothing.
+//
+//   - Phase 1/2 supersede the slot WITHOUT a disconnect (installConn on an
+//     occupied slot — the real supersession path), so the fresh-key assertions
+//     are bound to installConn's replacement alone. Guard it with
+//     `if s.configCrypto0 == nil` and this reds.
+//   - Phase 3 disconnects and checks the slot is cleared, bound to
+//     handleDisconnect's clear alone. Drop that line and this reds.
+func TestConfigCryptoReconnectDerivesFreshKey6629(t *testing.T) {
+	s := NewSessionSync(":0", "10.0.0.2:4785", &mockSweepDP{})
+	peer := newConfigCryptoState()
+	if peer == nil {
+		t.Fatal("could not generate the peer's ephemeral key")
+	}
+
+	install := func() ([]byte, []byte, net.Conn) {
+		local, remote := net.Pipe()
+		t.Cleanup(func() { local.Close(); remote.Close() })
+		s.installConn(0, local)
+		s.handleConfigKeyExchange(local, keyExchangePayload(peer.pub))
+		s.mu.Lock()
+		pub := append([]byte{}, s.configCrypto0.pub...)
+		key := append([]byte{}, s.configCrypto0.key...)
+		s.mu.Unlock()
+		return pub, key, local
+	}
+
+	pub1, key1, _ := install()
+	pub2, key2, conn2 := install()
+
+	if len(key1) != syncConfigKeyLen || len(key2) != syncConfigKeyLen {
+		t.Fatalf("both connections must derive a full-length key (got %d and %d)", len(key1), len(key2))
+	}
+	if string(pub1) == string(pub2) {
+		t.Fatal("installing a connection must produce a FRESH ephemeral keypair; reusing it " +
+			"means one compromise opens every capture ever taken on this pair (#6629)")
+	}
+	if string(key1) == string(key2) {
+		t.Fatal("a new connection must derive a DIFFERENT config key; an identical key across " +
+			"connections is the absence of forward secrecy, whatever the keypair did")
+	}
+
+	// handleDisconnect must drop the state with the connection, or a key
+	// outlives the exchange that produced it and a later frame on a stale
+	// connection could still be opened.
+	s.handleDisconnect(conn2)
+	s.mu.Lock()
+	residual := s.configCrypto0
+	s.mu.Unlock()
+	if residual != nil {
+		t.Fatal("handleDisconnect must drop the connection's ephemeral state with the connection")
+	}
+}
+
+// TestConfigCryptoBothEndsDeriveTheSameKey6629 pins the canonical ordering of
+// the HKDF salt. Each end sees the two public keys in the opposite order, so
+// an implementation that concatenated them as (mine, theirs) would derive two
+// different keys and every push would fail to open — a bug that only shows up
+// against a real peer, never in a single-sided unit test.
+func TestConfigCryptoBothEndsDeriveTheSameKey6629(t *testing.T) {
+	a, b := newConfigCryptoState(), newConfigCryptoState()
+	if a == nil || b == nil {
+		t.Fatal("could not generate ephemeral keys")
+	}
+	if err := a.deriveConfigKey(b.pub); err != nil {
+		t.Fatalf("a.derive: %v", err)
+	}
+	if err := b.deriveConfigKey(a.pub); err != nil {
+		t.Fatalf("b.derive: %v", err)
+	}
+	if string(a.key) != string(b.key) {
+		t.Fatal("both ends must derive the same key: the HKDF salt orders the two public keys " +
+			"canonically so neither end needs to know which of them dialled")
+	}
+
+	// And the key really is a key: a roundtrip through the AEAD must recover
+	// the plaintext, and the ciphertext must not contain it.
+	plain := []byte(configWithPSK())
+	sealed, err := sealConfigPayload(a.key, plain)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if strings.Contains(string(sealed), testPSK) {
+		t.Fatal("the sealed payload still contains the PSK")
+	}
+	opened, err := openConfigPayload(b.key, sealed)
+	if err != nil {
+		t.Fatalf("open with the peer's independently-derived key: %v", err)
+	}
+	if string(opened) != string(plain) {
+		t.Fatal("the roundtrip must be lossless")
+	}
+}
+
+// TestConfigCryptoRejectsSealedPayloadWithNoKey6629: a sealed payload arriving
+// on a connection that never negotiated must be DROPPED, not opened with some
+// other connection's key and not decoded as cleartext.
+//
+// Decoding it as cleartext is the dangerous failure: decodeConfigPayload
+// accepts any bytes (a payload without the generation magic is treated as
+// legacy raw config text), so a ciphertext would sail through as a config and
+// be handed to the apply path as garbage.
+func TestConfigCryptoRejectsSealedPayloadWithNoKey6629(t *testing.T) {
+	s := NewSessionSync(":0", "10.0.0.2:4785", &mockSweepDP{})
+	local, remote := net.Pipe()
+	defer local.Close()
+	defer remote.Close()
+	s.mu.Lock()
+	s.conn0 = local
+	s.configCrypto0 = newConfigCryptoState()
+	s.mu.Unlock()
+
+	other := newConfigCryptoState()
+	if other == nil {
+		t.Fatal("could not generate an unrelated key")
+	}
+	if err := other.deriveConfigKey(newConfigCryptoState().pub); err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	sealed, err := sealConfigPayload(other.key, encodeConfigPayload(configWithPSK(), 7))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+
+	s.handleMessage(local, syncMsgConfigEncrypted, sealed)
+	select {
+	case item := <-s.configApplyCh:
+		t.Fatalf("an unopenable sealed payload must be dropped, not enqueued: got %q", item.text)
+	default:
+	}
+}
+
+// TestConfigCryptoDropsUndecryptablePayload6629 covers the OTHER unopenable
+// case: the connection DID negotiate a key, but the ciphertext does not open
+// under it — a corrupted frame, or one sealed by something that is not the
+// peer.
+//
+// It is a separate test from the no-key case above because the two are guarded
+// by different branches, and a single test reaches only the first of them: with
+// no key the nil-key guard returns before openConfigPayload is ever called, so
+// that test cannot see whether a decrypt FAILURE is handled at all. The
+// mutation matrix found exactly that — neutering the decrypt-error branch left
+// the no-key test green.
+//
+// Dropping is the only safe answer. decodeConfigPayload accepts ANY bytes (a
+// payload without the generation magic is treated as a legacy sender's raw
+// config text), so a ciphertext that reached it would sail through as a
+// "config" and be handed to the apply path as garbage.
+func TestConfigCryptoDropsUndecryptablePayload6629(t *testing.T) {
+	s := NewSessionSync(":0", "10.0.0.2:4785", &mockSweepDP{})
+	local, remote := net.Pipe()
+	defer local.Close()
+	defer remote.Close()
+
+	peer := newConfigCryptoState()
+	if peer == nil {
+		t.Fatal("could not generate the peer's ephemeral key")
+	}
+	s.mu.Lock()
+	s.conn0 = local
+	s.configCrypto0 = newConfigCryptoState()
+	s.mu.Unlock()
+	s.handleConfigKeyExchange(local, keyExchangePayload(peer.pub))
+	if s.configKeyForConn(local) == nil {
+		t.Fatal("the exchange must complete, or this test degenerates into the no-key case")
+	}
+
+	// Sealed under an unrelated key — a corrupt frame or a forgery.
+	stranger := newConfigCryptoState()
+	other := newConfigCryptoState()
+	if stranger == nil || other == nil {
+		t.Fatal("could not generate unrelated keys")
+	}
+	if err := stranger.deriveConfigKey(other.pub); err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	sealed, err := sealConfigPayload(stranger.key, encodeConfigPayload(configWithPSK(), 9))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+
+	s.handleMessage(local, syncMsgConfigEncrypted, sealed)
+	select {
+	case item := <-s.configApplyCh:
+		t.Fatalf("a payload that failed to decrypt must be dropped, not decoded as config: "+
+			"got %q (gen %d). decodeConfigPayload accepts any bytes, so an un-dropped "+
+			"ciphertext reaches the apply path as garbage", item.text, item.gen)
+	default:
+	}
+}
+
+// TestConfigCryptoMessageTypesAreUnique6629 mirrors the #6650 guard for the
+// two types this adds. An old peer ignores an UNKNOWN type via the receive
+// switch's missing default arm — that is the whole no-version-bump argument —
+// but it MISPARSES a known one.
+func TestConfigCryptoMessageTypesAreUnique6629(t *testing.T) {
+	t.Parallel()
+	for _, under := range []struct {
+		v    int
+		name string
+	}{
+		{syncMsgConfigKeyExchange, "syncMsgConfigKeyExchange"},
+		{syncMsgConfigEncrypted, "syncMsgConfigEncrypted"},
+	} {
+		live := liveSyncMessageTypesExcept(under.v)
+		if len(live) < 31 {
+			t.Fatalf("the live-type census holds only %d entries — it has fallen behind "+
+				"sync.go and can no longer certify uniqueness", len(live))
+		}
+		for _, m := range live {
+			if m.v == under.v {
+				t.Fatalf("%s (%d) collides with %s", under.name, under.v, m.name)
+			}
+		}
+	}
+}
+
+// TestConfigKeyExchangeSentOnConnectionInstall6629 binds the SEND WIRING
+// behaviourally, by driving the real connection-install path and reading the
+// frame off the wire — not by looking for the call in the source.
+//
+// This is the assertion the rest of the suite cannot make. Every other test
+// here drives handleConfigKeyExchange directly, so deleting
+// `s.sendConfigKeyExchange(conn)` from handleNewConnection leaves all of them
+// green while no pair ever negotiates in production: both ends fall back to
+// cleartext, the warning fires on every connection, and #6629 is silently
+// reopened with a full green board.
+//
+// A source-text guard would not do: sourceContainsFlat does not strip
+// comments, so a comment naming the call satisfies it.
+//
+// FAIL-ON-REVERT: delete the sendConfigKeyExchange call from
+// handleNewConnection and this reds on the deadline.
+func TestConfigKeyExchangeSentOnConnectionInstall6629(t *testing.T) {
+	// Unkeyed node: performSyncHandshake returns immediately, so the install
+	// path runs with no handshake in the way — which is also exactly the
+	// posture of the connection that carries the PSK across during first
+	// keying, the one #6629 is about.
+	s := NewSessionSync(":0", "10.0.0.2:4785", &mockSweepDP{})
+	cli, srv := net.Pipe()
+	defer cli.Close()
+	defer srv.Close()
+
+	if !s.beginSetup(srv, true) {
+		t.Fatal("beginSetup should admit the first inbound connection")
+	}
+	go s.handleNewConnection(context.Background(), 0, srv)
+
+	if err := cli.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	// The install path emits several advisory frames (clock sync, capabilities,
+	// key exchange). Scan for ours rather than pinning the order, which is not
+	// the property under test.
+	found := false
+	for i := 0; i < 8 && !found; i++ {
+		msgType, payload, _ := readOneFrame(t, cli)
+		if msgType != syncMsgConfigKeyExchange {
+			continue
+		}
+		found = true
+		if len(payload) != 1+syncConfigECDHPubSize {
+			t.Fatalf("key-exchange payload is %d bytes, want %d (version + X25519 public key)",
+				len(payload), 1+syncConfigECDHPubSize)
+		}
+		if payload[0] != syncConfigCryptoVersion {
+			t.Fatalf("key-exchange version byte is %d, want %d", payload[0], syncConfigCryptoVersion)
+		}
+		// It must be THIS connection's public key, not a fresh or shared one:
+		// the peer encrypts to it, and only this connection's private half can
+		// open the result. Look it up through the INSTALLED connection —
+		// handleNewConnection wraps the raw conn in an *authConn before
+		// installConn, and every per-slot lookup (send, receive, push,
+		// disconnect) keys off that wrapper.
+		s.mu.Lock()
+		installed := s.conn0
+		s.mu.Unlock()
+		st := s.configCryptoForConn(installed)
+		if st == nil {
+			t.Fatal("the installed connection carries no ephemeral state")
+		}
+		if string(payload[1:]) != string(st.pub) {
+			t.Fatal("the advertised public key is not the installed connection's own; the " +
+				"peer would encrypt to a key this connection cannot open")
+		}
+	}
+	if !found {
+		t.Fatal("the connection-install path never sent a config-sync key exchange, so no " +
+			"pair ever negotiates payload encryption: every config push falls back to " +
+			"cleartext and #6629 is reopened with the rest of this suite still green")
+	}
+}

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -387,6 +387,13 @@ func (s *SessionSync) handleNewConnection(ctx context.Context, fabricIdx int, co
 	// node cannot represent. Beside the clock sync because it has the same
 	// lifetime: per-incarnation, cleared on full disconnect.
 	s.sendCapabilities(conn)
+	// #6629: advertise this connection's ephemeral public key so the peer can
+	// encrypt the config payload to us. Beside sendCapabilities because it has
+	// the same lifetime (per installed connection) and the same failure
+	// posture: advisory, never escalated to a disconnect. Sent BEFORE the
+	// OnPeerConnected dispatch below, which is what drives the first config
+	// push, so the common case never reaches awaitConfigKey's timeout.
+	s.sendConfigKeyExchange(conn)
 	coldStart := !s.bulkEverCompleted.Load()
 	if d.shouldColdPrime {
 		slog.Info("cluster sync: driving authoritative cold-prime bulk on active connection", "fabric", fabricIdx, "remote", connRemoteAddrString(conn), "cold_start", coldStart, "was_disconnected", d.wasDisconnected)
@@ -532,12 +539,18 @@ func (s *SessionSync) installConn(fabricIdx int, conn net.Conn) connColdPrimeDec
 			s.conn0.Close()
 		}
 		s.conn0 = conn
+		// #6629: a FRESH ephemeral keypair per install. Replacing (never
+		// reusing) the slot's state is what gives the config payload forward
+		// secrecy across reconnects — the superseded connection's key is
+		// dropped here with its connection.
+		s.configCrypto0 = newConfigCryptoState()
 	case 1:
 		if s.conn1 != nil {
 			supersededCurrent = s.conn1Gen == s.peerIncarnation
 			s.conn1.Close()
 		}
 		s.conn1 = conn
+		s.configCrypto1 = newConfigCryptoState()
 	}
 	s.stats.Connected.Store(true)
 	s.lastPeerRxMono.Store(MonotonicNanos())
@@ -830,6 +843,10 @@ func (s *SessionSync) handleDisconnect(conn net.Conn) {
 	case s.conn0 != nil && s.conn0 == conn:
 		s.conn0.Close()
 		s.conn0 = nil
+		// #6629: drop the connection's ephemeral config key with the
+		// connection. Nothing may seal or open a payload with a key that
+		// outlived the exchange that produced it.
+		s.configCrypto0 = nil
 		// #5718 fold F1b: retire the slot's incarnation stamp with the
 		// connection it described. The nil slot already makes
 		// connIsCurrentIncarnationLocked reject, so this is hygiene — it keeps
@@ -840,6 +857,7 @@ func (s *SessionSync) handleDisconnect(conn net.Conn) {
 	case s.conn1 != nil && s.conn1 == conn:
 		s.conn1.Close()
 		s.conn1 = nil
+		s.configCrypto1 = nil
 		s.conn1Gen = 0
 		slog.Info("cluster sync: fabric 1 disconnected")
 	default:

--- a/pkg/cluster/sync_conn_config.go
+++ b/pkg/cluster/sync_conn_config.go
@@ -239,8 +239,47 @@ func (s *SessionSync) QueueConfig(configText string) {
 	}
 	gen := s.nextConfigGen()
 	payload := encodeConfigPayload(configText, gen)
+	// #6629: the config text is the ACTIVE TREE, rendered unredacted — it
+	// carries every Secret leaf, including `chassis cluster
+	// authentication-key`, the PSK this very link authenticates with. Seal it
+	// under the connection's ephemeral key so a passive observer on the
+	// control segment cannot read it. The plaintext is the payload built
+	// above, byte for byte, so the receiver's decode path is identical.
+	msgType := uint8(syncMsgConfig)
+	encrypted := false
+	if key := s.awaitConfigKey(conn); key != nil {
+		sealed, serr := sealConfigPayload(key, payload)
+		if serr != nil {
+			// Never fail the push on a seal error: config sync is how the
+			// standby converges, and an unconverged standby is a worse
+			// outcome than a readable payload. Fall through to cleartext with
+			// the same warning the mixed-version path emits.
+			slog.Error("cluster sync: could not encrypt config payload; sending CLEARTEXT (#6629)",
+				"err", serr)
+		} else {
+			payload, msgType, encrypted = sealed, uint8(syncMsgConfigEncrypted), true
+		}
+	}
+	if !encrypted {
+		// The mixed-version case, and the one moment the operator can act on
+		// this: a peer that predates #6629 never sends a key exchange, so the
+		// config crosses in the clear exactly as it does today. That is the
+		// correct fallback — refusing would break the rolling upgrade — but it
+		// must not be silent, because an operator running a mixed-version pair
+		// WHILE FIRST KEYING THE CLUSTER is standing in the exposed window.
+		// The key's presence is reported, never the key (config.Secret exists
+		// so it never reaches a log).
+		slog.Warn("cluster sync: sending the config to the peer IN CLEARTEXT — the peer did "+
+			"not negotiate config-payload encryption (older build). Every secret in the "+
+			"active configuration, including the control-link PSK when one is set, is "+
+			"readable by anything that can observe the control segment; upgrade the peer, "+
+			"and rotate the PSK afterwards because any capture taken now still verifies "+
+			"(#6629)",
+			"control_link_key_configured", len(s.authKey()) > 0,
+			"remote", connRemoteAddrString(conn), "gen", gen, "size", len(configText))
+	}
 	s.writeMu.Lock()
-	err := writeMsg(conn, syncMsgConfig, payload)
+	err := writeMsg(conn, msgType, payload)
 	s.writeMu.Unlock()
 	if err != nil {
 		slog.Warn("cluster sync: config send error", "err", err)
@@ -254,7 +293,8 @@ func (s *SessionSync) QueueConfig(configText string) {
 	// reconnect bumps the connection epoch and re-pushes on its own.
 	s.lastSentConfigGen.Store(gen)
 	s.stats.ConfigsSent.Add(1)
-	slog.Info("cluster sync: config sent to peer", "size", len(configText), "gen", gen)
+	slog.Info("cluster sync: config sent to peer", "size", len(configText), "gen", gen,
+		"encrypted", encrypted)
 }
 
 // sendConfigApplyNack tells the SENDER that this node did not apply the config

--- a/pkg/cluster/sync_conn_read.go
+++ b/pkg/cluster/sync_conn_read.go
@@ -323,42 +323,46 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 		// speak for the current one. See noteHeartbeatAck (sync_conn.go).
 		s.noteHeartbeatAck(conn)
 	case syncMsgConfig:
-		s.stats.ConfigsReceived.Add(1)
-		s.stats.LastConfigSyncTime.Store(time.Now().UnixNano())
-		configText, gen := decodeConfigPayload(payload)
-		s.stats.LastConfigSyncSize.Store(uint64(len(configText)))
-		slog.Info("cluster sync: config received from peer", "size", len(configText), "gen", gen)
-		// #5563: advance the received-config high-water BEFORE enqueue. This is
-		// the receiver's view of the peer's current committed generation and
-		// gates manual-failover readiness against lastAppliedConfigGen. Record it
-		// even if the enqueue below drops the payload (queue full) so the standby
-		// stays flagged config-stale until the apply actually lands on a re-push.
-		// It stays a monotonic max so a reordered older frame cannot pull it
-		// down. #5084: the load/compare/store moved into recordRecvConfigGen and
-		// is taken under configGenMu — the prior justification here ("the
-		// receiveLoop is single-threaded per connection, so the load/store pair
-		// needs no CAS") holds per connection but there are TWO receive loops,
-		// so a raise driven by one fabric raced resetRecvGen's clear driven by
-		// the other and could re-raise the mark that clear had just zeroed.
-		s.recordRecvConfigGen(gen)
-		// #3931: enqueue onto the single-consumer ordered apply queue instead
-		// of spawning a racing `go OnConfigReceived`. The receiveLoop is
-		// single-threaded per connection, so this preserves receive order;
-		// configApplyLoop then applies only strictly-newer generations. The
-		// enqueue is non-blocking so a slow apply never stalls session sync /
-		// heartbeats on this connection.
-		if s.configApplyCh != nil {
-			select {
-			case s.configApplyCh <- configApplyItem{gen: gen, text: configText}:
-			default:
-				// Ordered apply queue full — practically impossible (commits
-				// are seconds apart, apply is sub-second). Drop with an alarm;
-				// the next commit / reconnect re-push (fresh higher gen)
-				// re-converges the standby.
-				s.stats.Errors.Add(1)
-				slog.Error("cluster sync: config apply queue full, dropping config (will re-converge on next push)", "gen", gen, "size", len(configText))
-			}
+		s.handleConfigPayload(payload)
+	case syncMsgConfigEncrypted:
+		// #6629: same payload, sealed under this connection's ephemeral key.
+		// Decrypt, then hand the plaintext to the SAME handler — the two arms
+		// must never diverge in ordering, generation accounting or apply
+		// admission, and a divergence there would always be a bug, so there is
+		// one implementation rather than two kept in agreement.
+		key := s.configKeyForConn(conn)
+		if key == nil {
+			// A sealed payload arrived on a connection with no derived key:
+			// either the exchange never completed or this is a stale
+			// connection the slots no longer reference. Either way it cannot
+			// be opened, and it must NOT be opened with another connection's
+			// key. Drop it; the sender re-pushes on the next reconcile tick.
+			//
+			// NOT BOUND BY A TEST, and deliberately recorded as such: removing
+			// this branch changes nothing observable, because
+			// openConfigPayload fails closed on a nil key (aes.NewCipher(nil)
+			// errors) and the decrypt-failure branch below drops the payload
+			// anyway. It is kept for the DIAGNOSTIC — "we never negotiated"
+			// and "it did not decrypt" send an operator to entirely different
+			// places — and as defence in depth if openConfigPayload ever grows
+			// a path that tolerates a short key. The safety property (an
+			// unopenable payload never reaches the apply path) is bound by
+			// TestConfigCryptoDropsUndecryptablePayload6629.
+			s.stats.Errors.Add(1)
+			slog.Error("cluster sync: encrypted config received but no key was negotiated on "+
+				"this connection — dropping (#6629)", "remote", connRemoteAddrString(conn))
+			return
 		}
+		plaintext, err := openConfigPayload(key, payload)
+		if err != nil {
+			s.stats.Errors.Add(1)
+			slog.Error("cluster sync: could not decrypt config payload — dropping (#6629)",
+				"err", err, "remote", connRemoteAddrString(conn))
+			return
+		}
+		s.handleConfigPayload(plaintext)
+	case syncMsgConfigKeyExchange:
+		s.handleConfigKeyExchange(conn, payload)
 	case syncMsgIPsecSA:
 		s.stats.IPsecSAReceived.Add(1)
 		// #5706: split off the (incarnation, seq) ordering trailer and admit
@@ -565,5 +569,50 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 		}
 		s.stats.LastFenceAckAt.Store(time.Now().UnixNano())
 		s.completeBarrierWait(seq)
+	}
+}
+
+// handleConfigPayload processes a decoded config-sync payload, whether it
+// arrived in the clear (syncMsgConfig) or sealed (syncMsgConfigEncrypted,
+// #6629). Both arms funnel here because the receiver-side ordering, the
+// generation high-water accounting and the apply-queue admission must be
+// identical for the two — a divergence between them is always a bug, so the
+// behaviour is single-sourced rather than duplicated and kept in agreement.
+func (s *SessionSync) handleConfigPayload(payload []byte) {
+	s.stats.ConfigsReceived.Add(1)
+	s.stats.LastConfigSyncTime.Store(time.Now().UnixNano())
+	configText, gen := decodeConfigPayload(payload)
+	s.stats.LastConfigSyncSize.Store(uint64(len(configText)))
+	slog.Info("cluster sync: config received from peer", "size", len(configText), "gen", gen)
+	// #5563: advance the received-config high-water BEFORE enqueue. This is
+	// the receiver's view of the peer's current committed generation and
+	// gates manual-failover readiness against lastAppliedConfigGen. Record it
+	// even if the enqueue below drops the payload (queue full) so the standby
+	// stays flagged config-stale until the apply actually lands on a re-push.
+	// It stays a monotonic max so a reordered older frame cannot pull it
+	// down. #5084: the load/compare/store moved into recordRecvConfigGen and
+	// is taken under configGenMu — the prior justification here ("the
+	// receiveLoop is single-threaded per connection, so the load/store pair
+	// needs no CAS") holds per connection but there are TWO receive loops,
+	// so a raise driven by one fabric raced resetRecvGen's clear driven by
+	// the other and could re-raise the mark that clear had just zeroed.
+	s.recordRecvConfigGen(gen)
+	// #3931: enqueue onto the single-consumer ordered apply queue instead
+	// of spawning a racing `go OnConfigReceived`. The receiveLoop is
+	// single-threaded per connection, so this preserves receive order;
+	// configApplyLoop then applies only strictly-newer generations. The
+	// enqueue is non-blocking so a slow apply never stalls session sync /
+	// heartbeats on this connection.
+	if s.configApplyCh != nil {
+		select {
+		case s.configApplyCh <- configApplyItem{gen: gen, text: configText}:
+		default:
+			// Ordered apply queue full — practically impossible (commits
+			// are seconds apart, apply is sub-second). Drop with an alarm;
+			// the next commit / reconnect re-push (fresh higher gen)
+			// re-converges the standby.
+			s.stats.Errors.Add(1)
+			slog.Error("cluster sync: config apply queue full, dropping config (will re-converge on next push)", "gen", gen, "size", len(configText))
+		}
 	}
 }


### PR DESCRIPTION
Closes #6629.

## The defect, verified firsthand

`d.store.ShowActive()` renders through `ConfigTree.Format()`, which does **not**
redact. Rendered both ways, `authentication-key` is **present** in `Format()` and
**absent** from `RedactedClone().Format()`. So the control-link PSK crosses the
fabric in cleartext inside a `syncMsgConfig` payload.

The cleartext render is deliberate, not a missing call: `store_format.go:305-310`
says the `Show*` siblings back HA config sync, the DR archive, persistence and the
on-box CLI, *"none of which may lose the real secret."* The security consequence
was simply never followed through.

**The exposure is circular.** Session-sync authentication is fixed per connection
at handshake time (`performSyncHandshake` returns immediately when this node holds
no key), and committing a key does not restart cluster comms —
`clusterTransportKey` excludes it, pinned by
`TestAuthKeyChangeDoesNotRestartClusterComms_5078`. So the connection that carries
the PSK is, by construction, the one handshaked while **both** ends were unkeyed:
neither authenticated nor confidential. A passive observer learns the key *as it is
introduced*, and every subsequent HMAC on that link — heartbeat, fabric gRPC bearer
token, session-sync frame MAC — is forgeable by them. **The rollout defeats itself
on first use.**

Bounded to the provisioning moment; not remote-exploitable by an off-path attacker.

## What ships

`installConn` generates a fresh ephemeral X25519 keypair per connection;
`handleNewConnection` advertises the public half beside `sendCapabilities`
(`syncMsgConfigKeyExchange`, type 30). Each end derives an AES-256 key with
HKDF-SHA256 over the ECDH shared secret, salted with both public keys in canonical
order. `QueueConfig` seals the type-8 payload — byte-identical plaintext, generation
trailer included — as `syncMsgConfigEncrypted` (type 31). The receiver decrypts and
hands the plaintext to the **same** `handleConfigPayload` the cleartext arm uses, so
the two cannot diverge on ordering, generation accounting or apply admission.

`sealFrame` is untouched. This adds confidentiality to one message type; it does not
replace the authentication scheme.

## Scope — stated, not left to inference

- **Closes** a passive observer, including one holding a full historical capture.
  Forward secrecy: the keypair is per connection and `handleDisconnect` drops it, so
  a reconnect derives a different key.
- **Does NOT close** an active man-in-the-middle. The exchange on an unkeyed link is
  itself unauthenticated, because there is nothing yet to authenticate it *with*.
  That concedes nothing already conceded — an active attacker on an unkeyed control
  segment can already drive election, call the allowlisted fabric RPCs and inject
  sessions, which is #6611's own rationale — but this is **not** a confidential
  channel and must not be read as one.
- **A capture taken before the upgrade is not retired by it.** Rotate the PSK once
  both nodes are on a #6629-capable build.

## Mixed version

A peer that predates this never sends type 30, so no key is derived and the push
falls back to cleartext exactly as today, after a bounded wait that latches (one wait
per connection, not per push). The fallback **WARNS**, naming the exposure and whether
a control-link key is configured — never the key. An operator running a mixed-version
pair while first keying the cluster is standing in the exposed window, and that is the
one moment the information is actionable.

Both types are additive with **no** `SessionSyncWireVersion` bump, on the #2239/#6650
precedent: the receive switch has no default arm, and bumping would make the #1930
INC-3 mixed-base gate refuse SESSION sync across the very rolling upgrade this must
survive.

## Why not exclude the leaf from the payload (the issue's proposal)

`Store.SyncApply` promotes the received tree **wholesale**, and its compile is lenient
(`compileTreeLenient` → `lenientClusterAuthKey`), so #6611's validator warns rather
than rejects there. A stripped payload therefore makes the standby's active config
**lose its own key**, silently reverting every control channel to fail-open
dual-accept. On a rolling upgrade a new primary would drive an old standby unkeyed —
and capability-gating the strip preserves the leak in exactly the first-keying
scenario that matters most, so the gate cannot rescue it. Payload encryption's
mixed-version fallback is "no worse than today". A fix whose upgrade path can leave a
node fail-open loses to one whose upgrade path degrades to the status quo.

The issue's option 3 (redact `Secret` as a class) is worse still, and it was checked
rather than assumed: it ships `<secret>` placeholders for IPsec PSKs, BGP MD5, SNMP
and DDNS tokens, and `checkRedactionPlaceholder` (`ast_redact.go:201`) means the peer
likely refuses the push outright. The "safe" option breaks config sync entirely rather
than degrading it. The next person will propose it again; that is why it is written
down.

## The three-way incompatibility (now recorded in `pkg/cluster/README.md`)

Three shipped positions cannot all hold:

1. **#6629** — the PSK must not cross in cleartext.
2. **`TestAuthKeyChangeDoesNotRestartClusterComms_5078`** pins the exact opposite of
   #6628's fix; its failure message states why: *"committing it would restart cluster
   comms and drop the very connection that must carry the key to the read-only
   secondary."*
3. **`sync_auth.go:326-337`** — an RG0 secondary with the read-only gate armed returns
   `ErrClusterReadOnly` from `EnterConfigureSession`, so **config-sync is that node's
   only writer**. In-band carriage is not incidental; it is the documented live-keying
   procedure.

**#6628 landed alone bricks the live-keying rollout**: the connection drops,
re-handshakes, and `syncAuthDecision(keyConfigured=true, peerKeyed=false)` rejects a
secondary that can then never be keyed because it is read-only — a self-inflicted
permanent partition. The eventual posture is exclusion plus provisioning-time
node-local keying (the per-node day-0 drive already provisions `xpf.conf` alongside
`node-id`, and `sync_auth.go` already recommends keying at provisioning), landing as
**one** design with #6628 and #6630, with #5078's pin inverted as part of it. And
**#6630's bounded dual-key overlap becomes forced, not preferred**, since that design
leaves no in-band coordination channel. This PR deliberately does not untie that knot.

## Mutation matrix — 9 cells, one mutation each, all compiling

| Cell | Mutation | Verdict |
|---|---|---|
| C1 | `QueueConfig` sends cleartext (pre-#6629 wire) | **RED** — `got message type 8, want 31` |
| C2 | decrypted payload never reaches the apply path | **RED** — receiver enqueued nothing |
| C3 | `installConn` reuses the slot's ephemeral state | **RED** — same keypair across connections |
| C4 | `handleDisconnect` leaves the state behind | **RED** — residual state after disconnect |
| C5 | HKDF salt not canonically ordered | **RED** — the two ends derive different keys |
| C6 | the legacy latch never arms | **RED** — a stall on every push, not one per connection |
| C7 | sealed payload accepted with no negotiated key | **GREEN — by design, see below** |
| C9 | a failed decrypt is not dropped | **RED** — ciphertext decoded as config (`""`, gen 0) |
| C8 | the install path never sends the key exchange | **RED** — read deadline |

Pre- and post-control both green; working tree verified identical after the matrix.

**C7 is green and that is reported, not hidden.** Removing the nil-key guard changes
nothing observable: `openConfigPayload` fails closed on a nil key (`aes.NewCipher(nil)`
errors) and the decrypt-failure branch drops the payload anyway. The guard is kept for
the **diagnostic** — "we never negotiated" and "it did not decrypt" send an operator to
entirely different places — and the safety property it looks like it provides is bound
by C9. Annotated in place so a future reader does not mistake it for load-bearing.

C7's first form was a genuine miss the matrix caught: the no-key test could not reach
`openConfigPayload` at all, so the decrypt-error branch was **unbound** until
`TestConfigCryptoDropsUndecryptablePayload6629` (C9) was added for it.

## Both directions of the gate

`TestConfigSyncPayloadDoesNotCarryThePSKInCleartext6629` asserts both on one
trajectory: the PSK is **absent** from the raw frame bytes a passive observer sees,
**and** the standby still receives that config intact, PSK included, generation
preserved. Without the control half, an "encryption" that garbled or dropped the
payload — or one that simply stopped sending the config — would pass the positive
cell trivially.

`TestConfigKeyExchangeSentOnConnectionInstall6629` binds the **send wiring**
behaviourally, by driving `handleNewConnection` and reading the frame off the wire.
Every other test drives `handleConfigKeyExchange` directly, so deleting the call would
leave them all green while no pair ever negotiates in production. A source-text guard
would not do here: `sourceContainsFlat` does not strip comments, so a comment naming
the call satisfies it.

The #6650 message-type census is now single-sourced
(`liveSyncMessageTypesExcept`) and shared by both uniqueness guards, with the length
floor raised, rather than copied and left to drift.

## Docs

- `pkg/cluster/README.md` — "Config sync and the PSK (#6629)" and "The three-way
  incompatibility (#6628 / #6629 / #6630)". The stale sentence *"config-sync transmits
  it in the clear (#6629)"* is replaced.
- `docs/session-sync-architecture.md` — the two message types plus
  "Config-Payload Confidentiality (#6629)": mechanism, wire format, forward secrecy,
  what it does not close, mixed-version behaviour.

## Validation

- `go test ./pkg/cluster/ ./pkg/daemon/ ./pkg/configstore/ ./pkg/config/ -count=1` — all green.
- `go test -race ./pkg/cluster/ -run '6629' -count=2` — green; the existing #6550
  cluster race leg green at this head.
- `go vet ./pkg/cluster/` clean, `gofmt` clean, `go build ./...` clean.

**Gating note for the reviewer:** this touches cluster session-sync and changes what
goes on the fabric wire, so it is a protocol change even though no `.o` moved and no
version was bumped — per the campaign's own rule that a protocol bump owes a cluster
smoke, this wants one before merge. I have not run any cluster target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAsT5gCGP7k2vhdZ1sDuRi
