### PR TITLE
daemon: derive the pre-rename kernel name from the kernel, not arithmetic (#6677)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,38 @@
+## 2026-08-22 — #6677: derive the pre-rename kernel name from the kernel, not from PCI arithmetic
+
+- **Timestamp**: 2026-08-22
+- **Action**: Established the reference behaviour firsthand before writing
+  anything, on a host with 38 ARI-enabled netdevs, and it INVERTED the issue.
+  `udevadm test-builtin net_id` (systemd 261) shows systemd does NOT produce
+  an ARI-combined name for any netdev here: every ARI netdev is either at slot
+  0 (`slot<<3 == 0`, ARI a no-op) or an SR-IOV VF, where net_id's VF path
+  takes precedence and names it from the PHYSICAL function's address plus the
+  VF index (`0000:b7:02.0` -> `enp183s0f0v0`, physfn `0000:b7:00.0`). So the
+  issue named the one divergence I could not observe and missed two I could —
+  VF naming and the `npN` port suffix.
+  That killed the prescribed fix (`func += slot << 3`): implementing it would
+  have addressed the unobservable third of the problem while leaving the two
+  demonstrable ones, and closed the issue. Filed the ARI case as #7415 with
+  the hardware that would discriminate it, rather than guessing.
+  Then found the real answer in the kernel: altnames already carry every
+  candidate systemd computed (`eno5v0` carries `enp183s0f0v0`;
+  `ix0` carries `eno5np0`, `enp183s0f0np0`, `enx...`), they are stable across
+  renames, and `ensureRethLinkOriginalName` has used the mechanism in
+  production all along. `deriveKernelName` now asks for altnames first in
+  systemd's NamePolicy order and keeps the PCI derivation as a documented
+  best-effort fallback. Single-sourced the duplicated altname walk out of
+  `ensureRethLinkOriginalName` — a divergence between the two would always be
+  a bug — keeping `eth` as a last resort so that path's prior behaviour is
+  preserved rather than silently altered.
+  Rejected reading `ID_NET_NAME`/`INTERFACE` from the udev database after
+  measuring it: on an xpf-managed NIC those reflect xpf's own rename, so it
+  would return the LOGICAL name — the same defect as #6678.
+  Mutation matrix M1-M4 all RED with real assertions, vet clean at each,
+  RUN=10 matching the control; M5 re-ran the FULL package under M1.
+- **File(s)**: `pkg/daemon/daemon_reth.go`,
+  `pkg/daemon/derive_kernel_name_6677_test.go` (new),
+  `docs/critical-patterns.md`
+
 ## 2026-08-22 — #7406: operator note on where a credential may live in a URL
 
 - **Timestamp**: 2026-08-22

--- a/docs/critical-patterns.md
+++ b/docs/critical-patterns.md
@@ -71,6 +71,26 @@ non-trivial code. This page is the quick-reference gotcha list.
     MAC alternates between physical (boot) and virtual (daemon), so
     `MACAddress=` is unreliable. `ensureRethLinkOriginalName()`
     auto-fixes stale files.
+  - **The pre-rename name comes from the KERNEL, not from arithmetic
+    (#6677).** `deriveKernelName()` asks for the interface's kernel
+    ALTERNATIVE names first and only falls back to deriving one from the
+    sysfs PCI address. Altnames are the candidate set udev itself computed
+    and are stable across renames, so they stay correct after xpf has
+    renamed the interface — which is exactly when the pre-rename name has
+    to be recovered.
+    Re-deriving from the address cannot match systemd, which has at least
+    three inputs the address string does not carry (all measured on real
+    hardware, systemd 261): **ARI** folds slot and function into one 8-bit
+    function number; an **SR-IOV VF** is named from its *physical*
+    function's address plus the VF index (`0000:b7:02.0`, physfn
+    `0000:b7:00.0`, is `enp183s0f0v0` — the address-only derivation says
+    `enp183s2f0`); and a multi-port NIC carries an **`npN` port suffix**
+    (`enp183s0f0np0`). Altname selection follows systemd's default
+    `NamePolicy` order — onboard (`eno`), slot (`ens`), path (`enp`) —
+    because a device commonly carries several at once and the first the
+    policy resolves is the one udev assigns. `eth` is accepted last only,
+    and a MAC-based `enx` name never. #7415 tracks the one divergence that
+    could not be reproduced on available hardware.
   - **Collision-safe positional rename (#4178).** The positional loop
     (`renamePositional`) is two-pass, like device-map mode: it captures
     every NIC's `OriginalName=` from the existing `.link` set BEFORE

--- a/pkg/daemon/daemon_reth.go
+++ b/pkg/daemon/daemon_reth.go
@@ -46,22 +46,13 @@ func ensureRethLinkOriginalName(ifName string) {
 	if !strings.Contains(content, "MACAddress=") {
 		return // already uses OriginalName= or other match
 	}
-	// Derive kernel name from altnames or sysfs
-	link, err := netlink.LinkByName(ifName)
-	if err != nil {
-		return
-	}
-	var kernelName string
-	for _, alt := range link.Attrs().AltNames {
-		if strings.HasPrefix(alt, "enp") || strings.HasPrefix(alt, "eno") ||
-			strings.HasPrefix(alt, "ens") || strings.HasPrefix(alt, "eth") {
-			kernelName = alt
-			break
-		}
-	}
-	if kernelName == "" {
-		kernelName = deriveKernelName(ifName)
-	}
+	// Derive the kernel name. deriveKernelName consults the SAME altnames this
+	// used to walk inline, in systemd's NamePolicy order, and falls back to the
+	// sysfs PCI derivation — so the two paths cannot disagree about what a
+	// NIC's pre-rename name is. A divergence between them would always be a
+	// bug, which is why this is one implementation rather than two kept in
+	// agreement.
+	kernelName := deriveKernelName(ifName)
 	if kernelName == "" {
 		return
 	}
@@ -70,11 +61,89 @@ func ensureRethLinkOriginalName(ifName string) {
 	fixRethLinkFile(ifName, kernelName)
 }
 
+// altNameCandidatesFn returns an interface's kernel ALTERNATIVE names. It is a
+// seam so tests can supply a device's real altname set without netlink.
+var altNameCandidatesFn = func(ifName string) []string {
+	link, err := netlink.LinkByName(ifName)
+	if err != nil {
+		return nil
+	}
+	return link.Attrs().AltNames
+}
+
+// altNamePrefixOrder is systemd's default NamePolicy order, restricted to the
+// prefixes a predictable name can carry: onboard (eno), hotplug slot (ens),
+// then PCI path (enp). See 99-default.link's
+// "NamePolicy=keep kernel database onboard slot path".
+//
+// The order matters: a device commonly carries SEVERAL candidate altnames
+// (measured on a real host, ix0 carries eno5np0, enp183s0f0np0 and
+// enx3cecef6aa8bc at once), and the one udev actually assigns is the first
+// its policy resolves — onboard before path. Picking the first altname the
+// kernel happens to list would be a coin flip between them.
+//
+// "eth" is kept as a LAST resort only. It is the pre-predictable-naming kernel
+// default rather than a policy output, so it must never outrank a real
+// predictable name — but ensureRethLinkOriginalName accepted it before this
+// change, and dropping it would silently alter which name a RETH member
+// records. Ordering it last preserves that behaviour without letting it win
+// over eno/ens/enp.
+//
+// A MAC-based name (enx…) is deliberately NOT accepted: it is last in the
+// default policy and is not a name udev assigns unless the others are
+// unavailable.
+var altNamePrefixOrder = []string{"eno", "ens", "enp", "eth"}
+
+// kernelNameFromAltNames returns the predictable name udev would assign, taken
+// from the interface's kernel alternative names (#6677).
+//
+// This is the AUTHORITATIVE source and is preferred over re-deriving a name
+// from the PCI address, because the kernel and udev have already computed
+// every candidate and kept them as altnames. Re-deriving cannot match it:
+// systemd's naming has at least three inputs a PCI address string does not
+// carry, all of them measured on real hardware —
+//
+//   - ARI: with ari_enabled the slot and function fields are ONE 8-bit
+//     function number (net_id does "func += slot * 8"), which a helper reading
+//     the address alone cannot know;
+//   - SR-IOV: a virtual function is named from its PHYSICAL function's address
+//     plus the VF index, so the VF's own slot/function never appears — a VF at
+//     0000:b7:02.0 is named enp183s0f0v0, from its physfn at 0000:b7:00.0;
+//   - the port suffix: a multi-port NIC carries npN (enp183s0f0np0), which
+//     comes from device properties the address does not contain.
+//
+// Altnames are stable across renames — they are the candidate set, not the
+// current name — so this stays correct after xpf has renamed the interface to
+// its logical name, which is exactly when the pre-rename name must be
+// recovered. ensureRethLinkOriginalName has used the same mechanism in
+// production since before this change.
+func kernelNameFromAltNames(ifName string) string {
+	alts := altNameCandidatesFn(ifName)
+	for _, want := range altNamePrefixOrder {
+		for _, alt := range alts {
+			if strings.HasPrefix(alt, want) {
+				return alt
+			}
+		}
+	}
+	return ""
+}
+
 // deriveKernelName returns the predictable kernel name (e.g. enp8s0) for an
-// interface by examining its sysfs device path. Handles both PCI-direct
-// devices (device → 0000:09:00.0) and virtio-over-PCI (device → virtioN,
-// parent → 0000:08:00.0).
+// interface.
+//
+// It asks the kernel first (kernelNameFromAltNames) and only falls back to
+// deriving a name from the sysfs PCI address when no altname is available —
+// early boot before udev has settled, or a container. The fallback is
+// best-effort by construction: it reproduces the plain domain/bus/slot/function
+// spelling and is blind to ARI, SR-IOV VF parentage and the port suffix (see
+// kernelNameFromAltNames). #7415 records the one of those three that could not
+// be reproduced on available hardware and names the device that would settle
+// it; the other two are what motivated preferring the kernel's answer.
 func deriveKernelName(ifName string) string {
+	if name := kernelNameFromAltNames(ifName); name != "" {
+		return name
+	}
 	devPath, err := filepath.EvalSymlinks(fmt.Sprintf("/sys/class/net/%s/device", ifName))
 	if err != nil {
 		return ""

--- a/pkg/daemon/derive_kernel_name_6677_test.go
+++ b/pkg/daemon/derive_kernel_name_6677_test.go
@@ -1,0 +1,134 @@
+package daemon
+
+import (
+	"testing"
+)
+
+// #6677. deriveKernelName re-derived a predictable name from the PCI address
+// alone. That derivation cannot match systemd's, which has at least three
+// inputs the address string does not carry — all measured on real hardware
+// (systemd 261):
+//
+//	ARI          ari_enabled folds slot and function into ONE 8-bit function
+//	             number (net_id: "func += slot * 8")
+//	SR-IOV VF    a VF is named from its PHYSICAL function's address plus the VF
+//	             index; the VF's own slot/function never appears. Measured:
+//	             0000:b7:02.0 (physfn 0000:b7:00.0) -> enp183s0f0v0, where the
+//	             address-only derivation yields enp183s2f0
+//	port suffix  a multi-port NIC carries npN (enp183s0f0np0)
+//
+// The fix stops re-deriving and asks the kernel, which has already computed
+// every candidate and kept them as altnames. These tests use altname sets
+// captured verbatim from a real host.
+
+func withAltNames(t *testing.T, alts map[string][]string) {
+	t.Helper()
+	saved := altNameCandidatesFn
+	altNameCandidatesFn = func(ifName string) []string { return alts[ifName] }
+	t.Cleanup(func() { altNameCandidatesFn = saved })
+}
+
+// TestDeriveKernelNamePrefersAltNames_6677 is the fail-on-revert: each case is
+// a real device whose correct name the address-only derivation cannot produce.
+func TestDeriveKernelNamePrefersAltNames_6677(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		iface string
+		alts  []string
+		want  string
+		why   string
+	}{
+		{
+			name:  "SR-IOV VF is named from its physical function",
+			iface: "ge-0-0-3",
+			alts:  []string{"enp183s0f0v0"},
+			want:  "enp183s0f0v0",
+			why:   "VF at 0000:b7:02.0; address-only derivation would say enp183s2f0",
+		},
+		{
+			name:  "multi-port NIC keeps its npN port suffix",
+			iface: "ge-0-0-4",
+			alts:  []string{"eno5np0", "enp183s0f0np0", "enx3cecef6aa8bc"},
+			want:  "eno5np0",
+			why:   "onboard outranks path in the default NamePolicy",
+		},
+		{
+			name:  "path name when no onboard name exists",
+			iface: "ge-0-0-5",
+			alts:  []string{"enp103s0f1", "enx3cecef6aa385"},
+			want:  "enp103s0f1",
+			why:   "enx is a MAC name and is never selected",
+		},
+		{
+			name:  "hotplug slot name outranks path",
+			iface: "ge-0-0-6",
+			alts:  []string{"enp5s0", "ens3"},
+			want:  "ens3",
+			why:   "NamePolicy is onboard, then slot, then path",
+		},
+		{
+			name:  "eth is accepted only as a last resort",
+			iface: "ge-0-0-7",
+			alts:  []string{"eth0"},
+			want:  "eth0",
+			why:   "preserves ensureRethLinkOriginalName's prior behaviour",
+		},
+		{
+			name:  "a real predictable name outranks eth",
+			iface: "ge-0-0-8",
+			alts:  []string{"eth0", "enp9s0"},
+			want:  "enp9s0",
+			why:   "eth is the pre-predictable kernel default, not a policy output",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withAltNames(t, map[string][]string{tc.iface: tc.alts})
+			got := deriveKernelName(tc.iface)
+			if got != tc.want {
+				t.Fatalf("deriveKernelName(%q) = %q, want %q (%s)", tc.iface, got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+// TestDeriveKernelNameRejectsMACAltName_6677 is the negative half. A MAC-based
+// altname is always present alongside the others, so accepting it would look
+// like success while recording a name udev does not assign under the default
+// policy.
+func TestDeriveKernelNameRejectsMACAltName_6677(t *testing.T) {
+	withAltNames(t, map[string][]string{"ge-0-0-9": {"enx3cecef6aa8bc"}})
+	// No usable altname and no sysfs device for this fake name, so the
+	// fallback finds nothing either: the result must be empty, NOT the enx name.
+	if got := deriveKernelName("ge-0-0-9"); got == "enx3cecef6aa8bc" {
+		t.Fatalf("a MAC-based altname must never be selected, got %q", got)
+	}
+}
+
+// TestDeriveKernelNameFallsBackWhenNoAltNames_6677 pins that the PCI fallback
+// is still reachable — early boot before udev has settled, or a container.
+// Without this, removing the fallback entirely would go unnoticed.
+func TestDeriveKernelNameFallsBackWhenNoAltNames_6677(t *testing.T) {
+	withAltNames(t, map[string][]string{}) // no altnames for anything
+	// A name with no sysfs device yields "" from the fallback rather than a
+	// panic or a fabricated name.
+	if got := deriveKernelName("definitely-not-a-real-iface"); got != "" {
+		t.Fatalf("with no altnames and no sysfs device the result must be empty, got %q", got)
+	}
+}
+
+// TestAltNamePrefixOrderMatchesNamePolicy_6677 pins the ORDER itself. A device
+// commonly carries several candidates at once, so the order is what decides
+// which name is recorded; a reordering would silently change that on every
+// multi-candidate NIC.
+func TestAltNamePrefixOrderMatchesNamePolicy_6677(t *testing.T) {
+	want := []string{"eno", "ens", "enp", "eth"}
+	if len(altNamePrefixOrder) != len(want) {
+		t.Fatalf("altNamePrefixOrder = %v, want %v", altNamePrefixOrder, want)
+	}
+	for i := range want {
+		if altNamePrefixOrder[i] != want[i] {
+			t.Fatalf("altNamePrefixOrder = %v, want %v (systemd: onboard, slot, path; eth last)",
+				altNamePrefixOrder, want)
+		}
+	}
+}


### PR DESCRIPTION
`deriveKernelName` rebuilt a predictable interface name from the PCI address alone. That derivation cannot match what systemd assigns, so the RETH member `.link` `OriginalName=` it feeds could name an interface udev never presents — and the NIC would be neither renamed nor bound.

## The reference behaviour was established firsthand, and it inverted the issue

Measured on a host with **38 ARI-enabled network devices**, `udevadm test-builtin net_id`, systemd 261:

```
eno5v0  0000:b7:02.0  ari=1  VF   -> ID_NET_NAME_PATH=enp183s0f0v0
ix0     0000:b7:00.0  ari=1  PF   -> ID_NET_NAME_PATH=enp183s0f0np0
eno2    0000:67:00.1  ari=1  slot0-> ID_NET_NAME_PATH=enp103s0f1
```

**systemd produces no ARI-combined name for any netdev here.** Every ARI netdev is either at slot 0 — where the fold adds zero and ARI is a no-op — or is an SR-IOV VF, where net_id's VF path takes precedence and names the device from its **physical function's** address plus the VF index. `0000:b7:02.0`, whose `physfn` is `0000:b7:00.0`, is named `enp183s0f0v0`; the address-only derivation says `enp183s2f0`. The VF's own slot and function never appear.

So the address string is missing at least **three** inputs, two of them demonstrable here:

| divergence | observable? |
|---|---|
| SR-IOV VF parentage | **yes** — measured above |
| `npN` port suffix (`enp183s0f0np0`) | **yes** — measured above |
| ARI slot/function fold | **no** — see #7415 |

Implementing the originally suggested `func += slot << 3` would have fixed the one case that **could not be reproduced on available hardware** while leaving both observable ones broken — and closed the issue while doing it. That case is filed as **#7415**, which names the device that would discriminate it (an ARI-enabled *non-VF* network function at a non-zero slot), rather than being implemented on a guess.

## The fix: ask the kernel

Every candidate name udev computed is already kept as an interface **alternative name**:

```
eno5v0  -> altname enp183s0f0v0
ix0     -> altname eno5np0, enp183s0f0np0, enx3cecef6aa8bc
eno2    -> altname enp103s0f1, enx3cecef6aa385
```

Altnames are the *candidate set*, not the current name, so they stay correct **after** xpf has renamed the interface to its logical name — which is precisely when the pre-rename name has to be recovered. `ensureRethLinkOriginalName` has relied on this mechanism in production all along.

Selection follows systemd's default `NamePolicy` order: **onboard (`eno`), slot (`ens`), path (`enp`)**. The order is load-bearing — a device commonly carries several candidates at once, and the one udev assigns is the first its policy resolves; taking whichever altname the kernel happened to list first would be a coin flip between `eno5np0` and `enp183s0f0np0`. A MAC-based `enx` name is never selected. `eth` is accepted **last only**, so `ensureRethLinkOriginalName`'s prior behaviour is preserved rather than silently altered.

That function's inline altname walk is now the **same implementation** rather than a second copy: both want the same thing, so a divergence between them would always be a bug.

### An alternative measured and rejected

Reading `ID_NET_NAME` or `INTERFACE` from the udev database looks equivalent and is not. On an xpf-managed NIC both reflect **xpf's own rename** (`ID_NET_NAME=ix0`, `ID_NET_LINK_FILE=…`), so they would hand back the logical name — the same defect #6678 fixes. The policy-derived properties and the altnames are rename-stable; the assigned name is not.

The PCI derivation stays as a **documented best-effort fallback** for early boot before udev has settled, and for containers.

## Validation

Full `pkg/daemon` suite `-count=1` clean. **No hardware needed** — the altname lookup is behind a seam, and the fixtures use altname sets captured verbatim from real hardware, including the VF and multi-port cases the old derivation gets wrong.

| mutation | vet | result |
|---|---|---|
| skip altnames (revert to address-only) | 0 | **RED** — `deriveKernelName("ge-0-0-3") = "", want "enp183s0f0v0"` |
| reverse NamePolicy order (path before onboard) | 0 | **RED** — `= "enp183s0f0np0", want "eno5np0"` |
| promote `eth` to first | 0 | **RED** — `= "eth0", want "enp9s0"` |
| accept `enx` (MAC) names | 0 | **RED** — `a MAC-based altname must never be selected` |

RUN count matched the control (10) at every cell; the first was re-run against the **full package**. A fallback-reachability test pins that removing the PCI path entirely would not go unnoticed.

## Relationship to #6678

Separate defect, separate fix, no shared code change — this is *the derivation returns a confidently wrong name*; #6678 is *the caller manufactures a name when derivation admits it has none*.

They interact in the reassuring direction: this makes an empty derivation **rarer**, so it cannot make #6678 worse. Worth recording the counterfactual — had this instead been made to *fail closed* on an underivable name, a tempting and superficially safer shape, it would have made #6678's **latent** bug **live**, converting a wrong-name bug into a wrong-name bug by a different route.

Does not reach the Rust helper binary.

Closes #6677