### PR TITLE
dataplane: route the policy hit-count clear through the helper (#6566 member 2)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -102686,3 +102686,15 @@ prose edit above them added. No diff falls in the new test body.
     starvation — and reds on a revert to `while !stop`.
   - **File(s)**: userspace-dp/src/afxdp/wg/engine_tests.rs,
     docs/engineering-style.md
+
+## 2026-08-22 — #6566 member 2: clear policy hit-counts reaches the helper
+- **Timestamp**: 2026-08-22
+- **Action**: `LegacyDataPlaneAdapter` had no `ClearPolicyCounters`, so the
+  operator clear promoted to the embedded bpfShim and zeroed the RETIRED eBPF
+  `policy_counters` array while the live helper `PolicyCounterStore` — the one
+  the display reads — was untouched, both surfaces printing success. Added the
+  6-line override mirroring `ClearZoneCounters` (#3651). The READ half of that
+  cohort row was already fixed by the `ReadAllPolicyCounters` override; only
+  the CLEAR half was live.
+- **File(s)**: pkg/dataplane/userspace/legacy_dataplane.go,
+  pkg/dataplane/userspace/clear_policy_counters_6566_test.go (new), _Log.md

--- a/pkg/dataplane/userspace/clear_policy_counters_6566_test.go
+++ b/pkg/dataplane/userspace/clear_policy_counters_6566_test.go
@@ -1,0 +1,164 @@
+package userspace
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// #6566 member 2: `clear security policies hit-count` must reach the HELPER,
+// not the retired-eBPF array.
+//
+// `LegacyDataPlaneAdapter` had no ClearPolicyCounters method, so the embedded
+// dataplane.DataPlane (= bpfShim) was PROMOTED and its ClearPolicyCounters
+// zeroed the retired `policy_counters` per-CPU array — 4096 slots nothing has
+// incremented since the eBPF dataplane was retired (#1373/#1476). It returned
+// nil, so both operator surfaces printed "policy hit counters cleared" while
+// the counters the display actually READS (the helper's live
+// PolicyCounterStore, reached via the ReadAllPolicyCounters override) were
+// untouched.
+//
+// The operator-visible symptom is an asymmetry on ONE box: `clear security
+// counters` DOES reset policy hit counts (it routes through the
+// ClearAllCounters override), while `clear security policies hit-count` does
+// NOT. Same counters, two commands, opposite outcomes, both reporting success.
+//
+// NOTE on the issue text: the READ half of that cohort row ("per-policy hit
+// counts read the retired eBPF array on all 5 surfaces") was already FIXED by
+// the ReadAllPolicyCounters adapter override before this sweep, and canary
+// tests enforce the bulk reader on every display site. The CLEAR half is the
+// live defect, and it is the one this test binds.
+//
+// FAIL-ON-REVERT: delete the adapter's ClearPolicyCounters method and the call
+// promotes to bpfShim again — no clear_policy_counters IPC is sent and the
+// assertion below fails. That is the WIRING, not the function it calls:
+// Manager.ClearPolicyCounters is unchanged and keeps working either way, which
+// is exactly why the defect survived.
+
+func TestAdapterClearPolicyCountersReachesTheHelper(t *testing.T) {
+	dir := t.TempDir()
+	controlSock := filepath.Join(dir, "control.sock")
+	ln, err := net.Listen("unix", controlSock)
+	if err != nil {
+		t.Fatalf("listen control socket: %v", err)
+	}
+	defer ln.Close()
+
+	reqCh := make(chan string, 8)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			var req ControlRequest
+			if err := json.NewDecoder(conn).Decode(&req); err != nil {
+				conn.Close()
+				return
+			}
+			reqCh <- req.Type
+			_ = json.NewEncoder(conn).Encode(ControlResponse{
+				OK:     true,
+				Status: &ProcessStatus{},
+			})
+			conn.Close()
+		}
+	}()
+
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("FindProcess: %v", err)
+	}
+	m := New()
+	m.proc = &exec.Cmd{Process: proc}
+	m.cfg.ControlSocket = controlSock
+
+	// Drive the ADAPTER, which is what the operator surfaces hold
+	// (pkg/cli/cli_clear.go and pkg/grpcapi/server_diag_system_action.go both
+	// call ClearPolicyCounters on the dataplane.DataPlane interface).
+	adapter := &LegacyDataPlaneAdapter{manager: m}
+	// The returned error is IGNORED on purpose. Manager.ClearPolicyCounters
+	// calls the bpfShim leg first and JOINS its error, and in a unit test no
+	// BPF map is loaded, so it always reports "dataplane not armed:
+	// policy_counters". That leg is not the property under test — the helper
+	// IPC is, and it is sent unconditionally afterwards. Asserting err == nil
+	// here would make the test fail for a reason unrelated to the defect.
+	_ = adapter.ClearPolicyCounters()
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case got := <-reqCh:
+			if got == "clear_policy_counters" {
+				return // the property
+			}
+		case <-deadline:
+			t.Fatal("the helper never received a clear_policy_counters IPC — " +
+				"the clear was promoted to the retired-eBPF bpfShim array, so " +
+				"the live PolicyCounterStore the display reads is untouched " +
+				"while the operator is told the counters were cleared")
+		}
+	}
+}
+
+// TestAdapterClearAllCountersAlsoClearsPolicyCounters pins the OTHER half of
+// the asymmetry, so a future change cannot fix one command by breaking the
+// other. Both commands must reach the helper.
+func TestAdapterClearAllCountersAlsoClearsPolicyCounters(t *testing.T) {
+	dir := t.TempDir()
+	controlSock := filepath.Join(dir, "control.sock")
+	ln, err := net.Listen("unix", controlSock)
+	if err != nil {
+		t.Fatalf("listen control socket: %v", err)
+	}
+	defer ln.Close()
+
+	reqCh := make(chan string, 16)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			var req ControlRequest
+			if err := json.NewDecoder(conn).Decode(&req); err != nil {
+				conn.Close()
+				return
+			}
+			reqCh <- req.Type
+			_ = json.NewEncoder(conn).Encode(ControlResponse{
+				OK:     true,
+				Status: &ProcessStatus{},
+			})
+			conn.Close()
+		}
+	}()
+
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("FindProcess: %v", err)
+	}
+	m := New()
+	m.proc = &exec.Cmd{Process: proc}
+	m.cfg.ControlSocket = controlSock
+
+	adapter := &LegacyDataPlaneAdapter{manager: m}
+	// Ignored for the same reason as above: the unarmed bpfShim leg is joined
+	// into the error and is not the property under test.
+	_ = adapter.ClearAllCounters()
+
+	seen := map[string]bool{}
+	deadline := time.After(5 * time.Second)
+	for !seen["clear_policy_counters"] {
+		select {
+		case got := <-reqCh:
+			seen[got] = true
+		case <-deadline:
+			t.Fatalf("clear-all never sent clear_policy_counters; saw %v", seen)
+		}
+	}
+}

--- a/pkg/dataplane/userspace/legacy_dataplane.go
+++ b/pkg/dataplane/userspace/legacy_dataplane.go
@@ -342,6 +342,37 @@ func (a *LegacyDataPlaneAdapter) ClearZoneCounters() error {
 	return m.ClearZoneCounters()
 }
 
+// ClearPolicyCounters routes the operator per-policy hit-count clear through
+// the userspace Manager override rather than the embedded bpfShim method
+// (#6566 member 2).
+//
+// Without this method the embedded dataplane.DataPlane (= bpfShim) is PROMOTED
+// here, and its ClearPolicyCounters zeroes the retired-eBPF `policy_counters`
+// per-CPU array — 4096 slots that nothing has incremented since the eBPF
+// dataplane was retired (#1373/#1476). It returns nil, so both operator
+// surfaces print "policy hit counters cleared" while the counters the display
+// actually READS — the helper's live PolicyCounterStore, via the
+// ReadAllPolicyCounters override — are untouched.
+//
+// The operator-visible symptom is an asymmetry on one box: `clear security
+// counters` DOES reset policy hit counts (it routes through the ClearAllCounters
+// override, which reaches clearHelperPolicyCountersLocked), while `clear
+// security policies hit-count` does NOT. Same counters, two commands, opposite
+// outcomes, both reporting success — which also silently breaks the
+// clear-and-watch baseline an operator relies on during incident response.
+//
+// This is the same defect #3651 fixed for ClearZoneCounters and #2218 for
+// ClearAllCounters; natcounters.go names it outright ("Clearing requires TWO
+// actions, exactly mirroring ClearPolicyCounters") while the mirror was never
+// installed on the adapter.
+func (a *LegacyDataPlaneAdapter) ClearPolicyCounters() error {
+	m, err := a.managerOrErr()
+	if err != nil {
+		return err
+	}
+	return m.ClearPolicyCounters()
+}
+
 // ClearAllCounters routes the operator clear-all through the userspace Manager
 // override (#2218) so the helper NAT translation hit store is reset alongside
 // the BPF maps; otherwise the per-rule NAT totals snap back on the next poll.


### PR DESCRIPTION
## Problem

`LegacyDataPlaneAdapter` had **no** `ClearPolicyCounters` method (`grep -c` → 0), so the embedded `dataplane.DataPlane` (= bpfShim) was promoted and its implementation zeroed the retired-eBPF `policy_counters` per-CPU array — 4096 slots nothing has incremented since the eBPF dataplane was retired (#1373/#1476). It returns nil, so both operator surfaces print `policy hit counters cleared` while the counters the display actually reads — the helper's live `PolicyCounterStore`, reached via the `ReadAllPolicyCounters` override — are untouched.

**The operator-visible symptom is an asymmetry on one box:**

| Command | Reaches the helper? | Reports |
|---|---|---|
| `clear security counters` | **yes** (routes through the `ClearAllCounters` override) | success |
| `clear security policies hit-count` | **no** | success |

Same counters, two commands, opposite outcomes, both reporting success. It also silently breaks the clear-and-watch baseline an operator relies on during incident response.

This is the same defect #3651 fixed for `ClearZoneCounters` and #2218 for `ClearAllCounters` — and `natcounters.go:13` names it outright, *"Clearing requires TWO actions, exactly mirroring ClearPolicyCounters"*, while the mirror was never installed on the adapter.

## Correction to the cohort row as filed

The row also claims the per-policy hit-count **READ** path hits the retired array on all five surfaces. **That half was already FIXED** before this sweep, by the `ReadAllPolicyCounters` adapter override, with canary tests enforcing the bulk reader on every display site. Only the **clear** half was live. Recorded rather than fixed as filed, so the disposition is accurate.

## Fix

The missing 6-line override, byte-identical in shape to `ClearZoneCounters`.

## Validation

`go test ./pkg/dataplane/... ./pkg/cli/ ./pkg/grpcapi/ -count=1` green.

| Cell | Mutation | rc | Reds |
|---|---|---|---|
| M1 | delete the adapter override (verbatim pre-fix state) | 1 | the wiring test only |
| CONTROL | none | 0 | — |

**The mutation targets the WIRING, not the function it calls.** `Manager.ClearPolicyCounters` is unchanged and keeps working either way — which is precisely why this defect survived. The `ClearAllCounters` control stays green under M1, pinning the other half of the asymmetry so a future change cannot fix one command by breaking the other.

Both tests deliberately ignore the returned error, and say so: the Manager calls the bpfShim leg first and joins its error, and in a unit test no BPF map is loaded so it always reports `dataplane not armed`. Asserting `err == nil` would fail for a reason unrelated to the defect.

Go control plane only — no `userspace-dp` binary or shim `.o` movement.

Refs #6566