### PR TITLE
userspace-dp: guard every pre-publish sibling, not one of seven

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -102686,3 +102686,10 @@ prose edit above them added. No diff falls in the new test body.
     starvation — and reds on a revert to `while !stop`.
   - **File(s)**: userspace-dp/src/afxdp/wg/engine_tests.rs,
     docs/engineering-style.md
+
+- **Timestamp**: 2026-08-22
+  - **Action**: #6593 — six of seven pre-publish siblings had no ordering guard and
+    the seventh had a hoist bypass. Added one PrePublishSiblings capture at the
+    store_runtime_view choke point covering all seven, with #6592-style
+    previous-view retention for hoist resistance. cfg(test) only.
+  - **File(s)**: userspace-dp/src/afxdp/coordinator/{cos_state.rs,mod.rs,tests.rs}

--- a/userspace-dp/src/afxdp/coordinator/cos_state.rs
+++ b/userspace-dp/src/afxdp/coordinator/cos_state.rs
@@ -26,3 +26,42 @@ impl SharedCoSState {
         }
     }
 }
+
+/// #6593: the worker-visible sibling structures captured at the exact instant
+/// the runtime view becomes visible, so their publication ORDER can be
+/// asserted rather than assumed.
+///
+/// `refresh_runtime_snapshot` relies on a documented order: every structure
+/// below must be published BEFORE the runtime view, because the view is the
+/// single worker-visible gate and a worker reads it first. Publish one of them
+/// AFTER and a worker can observe new forwarding paired with a stale sibling.
+///
+/// Only ONE of the seven had an ordering assertion, and it had a bypass. The
+/// rest had none at all.
+///
+/// Each field holds the `Arc` that was worker-visible at the capture instant.
+/// The test compares each against the corresponding post-refresh `Arc` with
+/// `Arc::ptr_eq`: SAME means the structure was already published when the view
+/// went out (correct); DIFFERENT means it was published afterwards, which is
+/// exactly the window a worker can land in. A structure this refresh did not
+/// republish compares equal, which is right — there is nothing to order.
+///
+/// `previous_view` makes the capture PROVE ITS OWN POSITION (the #6592
+/// technique): it is the still-visible view at the same instant, and the test
+/// asserts it is NOT the post-publish view. Hoisting the view store above this
+/// capture would otherwise let every `ptr_eq` above pass vacuously by reading
+/// already-published values. It retains an `Arc` rather than a raw pointer
+/// deliberately — dropping it would let the next `Arc::new` reuse the freed
+/// address and fool `ptr_eq`.
+#[cfg(test)]
+#[derive(Clone)]
+pub(crate) struct PrePublishSiblings {
+    pub(crate) cos_owner_worker_by_queue: Arc<BTreeMap<(i32, u8), u32>>,
+    pub(crate) cos_owner_live_by_queue: Arc<BTreeMap<(i32, u8), Arc<BindingLiveState>>>,
+    pub(crate) cos_root_leases: Arc<BTreeMap<i32, Arc<SharedCoSRootLease>>>,
+    pub(crate) cos_exact_backlogs: Arc<BTreeMap<i32, Arc<SharedCoSExactBacklog>>>,
+    pub(crate) cos_queue_leases: Arc<BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>>,
+    pub(crate) cos_queue_vtime_floors: Arc<BTreeMap<(i32, u8), Arc<SharedCoSQueueVtimeFloor>>>,
+    pub(crate) ha_fabrics: Arc<Vec<FabricLink>>,
+    pub(crate) previous_view: Arc<RuntimeView>,
+}

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -42,6 +42,8 @@ use cos_leases::{
     unique_interface_owner_worker_id,
 };
 pub(crate) use cos_state::SharedCoSState;
+#[cfg(test)]
+pub(crate) use cos_state::PrePublishSiblings;
 pub(in crate::afxdp) use ha_state::HaState;
 pub(crate) use neighbor_manager::NeighborManager;
 pub(crate) use neighbor_manager::WarmItem;
@@ -376,6 +378,13 @@ pub struct Coordinator {
     /// Absent from release builds; per-instance so parallel tests never race.
     #[cfg(test)]
     pub(crate) runtime_view_at_publish: Option<(Arc<RuntimeView>, Arc<RuntimeView>)>,
+    /// #6593: every worker-visible sibling structure that MUST be published
+    /// before the runtime view, captured at the instant just before the view
+    /// store. See `PrePublishSiblings` for the invariant and why it retains
+    /// `Arc`s. Absent from release builds; per-instance so parallel tests
+    /// never race.
+    #[cfg(test)]
+    pub(crate) prepublish_siblings: Option<PrePublishSiblings>,
     /// #6244: typed reconcile progress + failure identity. Replaces the
     /// former free-form `String` side-channel; the legacy operator string is
     /// rendered only at the `reconcile_debug` / `debug_reconcile_stage` wire
@@ -445,6 +454,8 @@ impl Coordinator {
             cos_owner_at_forwarding_publish: None,
             #[cfg(test)]
             runtime_view_at_publish: None,
+            #[cfg(test)]
+            prepublish_siblings: None,
             last_reconcile_stage: ReconcileStage::Idle,
             poll_mode: crate::PollMode::BusyPoll,
             event_stream: None,
@@ -1243,6 +1254,19 @@ impl Coordinator {
         #[cfg(test)]
         {
             self.runtime_view_at_publish = Some((view.clone(), self.ha.runtime.load_full()));
+            // #6593: capture EVERY sibling that must already be worker-visible
+            // here, not just the CoS owner map. Taken at the same instant and
+            // from the same choke point, so no publish path can bypass it.
+            self.prepublish_siblings = Some(PrePublishSiblings {
+                cos_owner_worker_by_queue: self.cos.owner_worker_by_queue.load_full(),
+                cos_owner_live_by_queue: self.cos.owner_live_by_queue.load_full(),
+                cos_root_leases: self.cos.root_leases.load_full(),
+                cos_exact_backlogs: self.cos.exact_backlogs.load_full(),
+                cos_queue_leases: self.cos.queue_leases.load_full(),
+                cos_queue_vtime_floors: self.cos.queue_vtime_floors.load_full(),
+                ha_fabrics: self.ha.fabrics.load_full(),
+                previous_view: self.ha.runtime.load_full(),
+            });
         }
         self.ha.runtime.publish(view);
     }

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -6692,3 +6692,172 @@ fn stopped_coordinator_guard_joins_the_neigh_monitor_on_drop_6637() {
         "StoppedCoordinator dropped without joining the neigh-monitor thread"
     );
 }
+
+/// #6593: EVERY pre-publish sibling must already be worker-visible when the
+/// runtime view goes out — not just the CoS owner map.
+///
+/// `refresh_runtime_snapshot` relies on a documented order. The runtime view is
+/// the single worker-visible gate and a worker reads it first, so any structure
+/// published AFTER it opens a window where a worker holds new forwarding paired
+/// with a stale sibling.
+///
+/// Seven structures are in that set: the six CoS maps published by
+/// `refresh_cos_runtime_maps` (owner-by-queue, owner-live, root leases, exact
+/// backlogs, queue leases, queue vtime floors) and `ha.fabrics`. Before this
+/// test exactly ONE of them had an ordering assertion —
+/// `refresh_runtime_snapshot_publishes_cos_owner_map_before_forwarding` — and
+/// that assertion had a hoist bypass. The other six had none.
+///
+/// The invariant is asserted uniformly and without knowing what changed: for
+/// each sibling, the `Arc` that was worker-visible at the capture instant must
+/// be the SAME allocation as the one visible after the refresh. Same means it
+/// was already published when the view went out. Different means it was
+/// published afterwards — the defect. A sibling this refresh did not republish
+/// compares equal, which is correct: there is nothing to order.
+///
+/// Hoist resistance comes from `previous_view` (the #6592 technique): the
+/// capture retains the still-visible view from the same instant and asserts it
+/// is NOT the post-publish view, so the capture proves its own position.
+/// Without it, moving the view store ABOVE the capture would make every
+/// `ptr_eq` above pass vacuously by reading already-published values — which is
+/// precisely the bypass the one pre-existing guard had.
+#[test]
+fn refresh_runtime_snapshot_publishes_every_sibling_before_the_view() {
+    let mut coordinator = Coordinator::new();
+    coordinator.workers.identities.insert(
+        1,
+        BindingIdentity {
+            slot: 1,
+            queue_id: 0,
+            worker_id: 2,
+            interface: "ge-0-0-2".into(),
+            ifindex: 12,
+        },
+    );
+
+    assert!(
+        coordinator.prepublish_siblings.is_none(),
+        "no snapshot applied yet",
+    );
+
+    // A snapshot that actually MOVES the CoS structures: a new shaped
+    // interface with a scheduler map creates queue (80, 0). A snapshot that
+    // changed nothing would make every ptr_eq trivially true and the test
+    // vacuous.
+    let mut snapshot = ConfigSnapshot::default();
+    snapshot.interfaces.push(InterfaceSnapshot {
+        name: "reth0.80".into(),
+        ifindex: 80,
+        parent_ifindex: 12,
+        hardware_addr: "02:00:00:00:00:80".into(),
+        cos_shaping_rate_bytes_per_sec: 1_000_000,
+        cos_scheduler_map: "wan-map".into(),
+        ..Default::default()
+    });
+    snapshot.class_of_service = Some(ClassOfServiceSnapshot {
+        forwarding_classes: vec![CoSForwardingClassSnapshot {
+            name: "best-effort".into(),
+            queue: 0,
+        }],
+        schedulers: vec![],
+        scheduler_maps: vec![CoSSchedulerMapSnapshot {
+            name: "wan-map".into(),
+            entries: vec![CoSSchedulerMapEntrySnapshot {
+                forwarding_class: "best-effort".into(),
+                scheduler: String::new(),
+            }],
+        }],
+        dscp_classifiers: vec![],
+        ieee8021_classifiers: vec![],
+        dscp_rewrite_rules: vec![],
+        inet_precedence_classifiers: vec![],
+    });
+
+    coordinator
+        .refresh_runtime_snapshot(&snapshot)
+        .expect("refresh_runtime_snapshot must succeed");
+
+    let captured = coordinator
+        .prepublish_siblings
+        .clone()
+        .expect("refresh must record the siblings at the view-publish point");
+
+    // Guard against a vacuous run: this snapshot must actually have moved the
+    // CoS owner map, or every assertion below would hold trivially.
+    assert_eq!(
+        captured.cos_owner_worker_by_queue.get(&(80, 0)),
+        Some(&2u32),
+        "setup: the CoS owner map must already own the new queue at publish time — \
+         if this snapshot did not move the CoS structures the ordering assertions \
+         below would pass vacuously",
+    );
+
+    // THE INVARIANT, part 1: every sibling visible at publish time is the same
+    // allocation a worker sees now.
+    for (name, same) in [
+        (
+            "cos.owner_worker_by_queue",
+            Arc::ptr_eq(
+                &captured.cos_owner_worker_by_queue,
+                &coordinator.cos.owner_worker_by_queue.load_full(),
+            ),
+        ),
+        (
+            "cos.owner_live_by_queue",
+            Arc::ptr_eq(
+                &captured.cos_owner_live_by_queue,
+                &coordinator.cos.owner_live_by_queue.load_full(),
+            ),
+        ),
+        (
+            "cos.root_leases",
+            Arc::ptr_eq(
+                &captured.cos_root_leases,
+                &coordinator.cos.root_leases.load_full(),
+            ),
+        ),
+        (
+            "cos.exact_backlogs",
+            Arc::ptr_eq(
+                &captured.cos_exact_backlogs,
+                &coordinator.cos.exact_backlogs.load_full(),
+            ),
+        ),
+        (
+            "cos.queue_leases",
+            Arc::ptr_eq(
+                &captured.cos_queue_leases,
+                &coordinator.cos.queue_leases.load_full(),
+            ),
+        ),
+        (
+            "cos.queue_vtime_floors",
+            Arc::ptr_eq(
+                &captured.cos_queue_vtime_floors,
+                &coordinator.cos.queue_vtime_floors.load_full(),
+            ),
+        ),
+        (
+            "ha.fabrics",
+            Arc::ptr_eq(&captured.ha_fabrics, &coordinator.ha.fabrics.load_full()),
+        ),
+    ] {
+        assert!(
+            same,
+            "#6593: {name} was published AFTER the runtime view. The view is the single \
+             worker-visible gate and a worker reads it first, so a worker can observe this \
+             refresh's forwarding paired with the PREVIOUS {name}. Publish it before \
+             `publish_runtime_view`.",
+        );
+    }
+
+    // THE INVARIANT, part 2 (hoist resistance): the capture sat BEFORE the
+    // view store, so the view it retained is not the one now published.
+    let published_view = coordinator.ha.runtime.load_full();
+    assert!(
+        !Arc::ptr_eq(&captured.previous_view, &published_view),
+        "#6593: the sibling capture ran at or after the view store, so every ptr_eq above \
+         passed vacuously by reading already-published values. Capture before the store — \
+         this is the same bypass the single pre-existing CoS-owner guard had.",
+    );
+}


### PR DESCRIPTION
Closes #6593

`refresh_runtime_snapshot` relies on a documented order: several shared structures must be published BEFORE the runtime view, because the view is the single worker-visible gate and a worker reads it first. Publish one after and a worker can observe this refresh's forwarding paired with the PREVIOUS sibling.

## The population, re-derived at HEAD

Seven, and the issue's count is accurate:

| sibling | site |
|---|---|
| `cos.owner_worker_by_queue` | `cos_leases.rs:135-157` |
| `cos.owner_live_by_queue` | " |
| `cos.root_leases` | " |
| `cos.exact_backlogs` | " |
| `cos.queue_leases` | " |
| `cos.queue_vtime_floors` | " |
| `ha.fabrics` | `snapshot_refresh.rs:455` |

Its **citation** is not, and the drift matters for anyone re-reading it: #6592 replaced the `ha.forwarding.store(...)` gate the issue describes with `publish_runtime_view()` / `store_runtime_view`, and `mod.rs` refers to the old site in the past tense. The ORDER is correct today; what was missing is the guard.

Only one of the seven was guarded, and that guard had the bypass the issue names: its capture proves nothing about its own position, so **hoisting** the view store above it — rather than exchanging two lines in place — leaves it reading an already-published value and passing vacuously.

## One capture, not seven seams

At the `store_runtime_view` choke point (so no publish path can bypass it), `PrePublishSiblings` retains the worker-visible `Arc` of each sibling. The test compares each against the post-refresh `Arc` with `Arc::ptr_eq`: **same** means the sibling was already published when the view went out; **different** means it was published afterwards, which is the window itself. A sibling this refresh did not republish compares equal — correct, there is nothing to order.

The formulation is deliberately content-free: it asserts ORDER without knowing what any sibling contains, so it keeps working as the CoS structures evolve, and adding an eighth sibling to the capture is the only change a future publication needs.

Hoist resistance is #6592's technique applied to all seven at once: the capture also retains the still-visible previous view and asserts it is NOT the post-publish view. Without that, moving the store above the capture makes every `ptr_eq` pass vacuously — exactly the pre-existing bypass. It retains an `Arc` rather than a raw pointer deliberately: dropping it would let the next `Arc::new` reuse the freed address and fool `ptr_eq`.

The test also asserts its own fixture moved the CoS structures. A snapshot that changed nothing would make every `ptr_eq` trivially true and the whole test vacuous.

## Mutation matrix

Each verified APPLIED before its run.

| # | mutation | result |
|---|---|---|
| J1 | move the CoS refresh after `publish_runtime_view` | **RED** (six siblings) |
| J2 | move `ha.fabrics` after `publish_runtime_view` | **RED** |
| J3 | hoist the view store above the capture | **RED** (the bypass) |

J1 failed to apply on its first attempt — the anchor missed a trailing semicolon — and reported `test=0`. That is a non-result, not a pass, so it was redone against a line-verified anchor.

## Validation

Full cargo suite green with `--test-threads=1`; `cargo check` on the default profile clean.

**No cluster gate owed.** The seam and the struct are `#[cfg(test)]`, so the release binary is unchanged — verified by a non-test `cargo check`. No shim `.o`, no helper binary movement, no Go side.