### PR TITLE
frr: stop a peer hostname shifting the IS-IS adjacency columns (#6590)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -102792,3 +102792,20 @@ prose edit above them added. No diff falls in the new test body.
   the CLEAR half was live.
 - **File(s)**: pkg/dataplane/userspace/legacy_dataplane.go,
   pkg/dataplane/userspace/clear_policy_counters_6566_test.go (new), _Log.md
+
+## 2026-08-22 — #6590: IS-IS adjacency column shift
+- **Timestamp**: 2026-08-22
+- **Action**: `GetISISAdjacency` assigned `strings.Fields` tokens to columns
+  POSITIONALLY, and the first column is the peer-advertised Dynamic Hostname
+  TLV, in which FRR retains printable ASCII spaces. A space-bearing hostname
+  shifted every later column, letting the peer forge Interface/Level/State/
+  HoldTime — terminal-safe after #6579 but materially false. The parse now
+  validates the FRR-GENERATED columns (exactly 5 or 6 fields, IS-IS level
+  shape, numeric holdtime) and marks an ambiguous row `Malformed` with the
+  derived fields empty and `Raw` carrying the line; both display sites branch
+  on it. An escape-bearing but space-free hostname stays well-formed so the
+  #6468/#6579 fixtures keep exercising the display guard.
+- **File(s)**: pkg/frr/status_parse.go,
+  pkg/frr/isis_adjacency_shift_6590_test.go (new),
+  pkg/cli/cli_show_routing.go, pkg/grpcapi/server_routing.go,
+  pkg/frr/README.md, _Log.md

--- a/pkg/cli/cli_show_routing.go
+++ b/pkg/cli/cli_show_routing.go
@@ -473,6 +473,14 @@ func (c *CLI) showISIS(args []string) error {
 		fmt.Printf("  %-20s %-14s %-10s %-10s %s\n",
 			"System ID", "Interface", "Level", "State", "Hold Time")
 		for _, a := range adjs {
+			// #6590: an ambiguous row must not be rendered as though its
+			// columns were values — the derived fields are empty and the
+			// peer chose the text. Report it instead.
+			if a.Malformed {
+				fmt.Printf("  %s\n", termsafe.SanitizeForDisplay(
+					"(unparseable adjacency row: "+a.Raw+")"))
+				continue
+			}
 			fmt.Printf("  %-20s %-14s %-10s %-10s %s\n",
 				termsafe.SanitizeRowForDisplay(
 					a.SystemID, a.Interface, a.Level, a.State, a.HoldTime)...)

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -708,6 +708,39 @@ also carries operator content:
   community (set|add) <value>` carries a community VALUE (e.g. `65000:100`),
   not a list reference, and is not validated. Same fail-closed-the-whole-reload
   class as the community-list definition gate above.
+- **A shifted `show isis neighbor` row is REPORTED, not rendered (#6590).**
+  The first column is the hostname the peer advertised in its Dynamic Hostname
+  TLV (RFC 5301, `hostname dynamic`, on by default), and FRR retains printable
+  ASCII **spaces** when decoding it. Assigning tokens to columns by POSITION
+  therefore let a space-bearing hostname shift every later column and put peer
+  bytes in each of them — with enough tokens the peer controlled all five
+  displayed cells, and the operator saw a well-formed adjacency table whose
+  values came from the adjacency's own remote end.
+
+  **This is not the #6468 escape-injection defect and the #6579 display guard
+  does not fix it.** Sanitizing preserves plausible printable text, so it cannot
+  distinguish a genuine `State=Up` from a peer-supplied token: the row can be
+  terminal-safe and still materially false. That is a display INTEGRITY defect
+  and its fix belongs in the parser.
+
+  `GetISISAdjacency` now validates the columns FRR GENERATES rather than
+  trusting position — the row must hold exactly 5 or 6 fields (SNPA optional),
+  its `L` slot must be an IS-IS level, and its `Holdtime` slot must be numeric.
+  A space in the hostname can only ADD tokens, never remove them, so it cannot
+  reach a valid count while also satisfying the shape checks. Note that the
+  count bound alone is NOT sufficient: a one-space hostname on a row without
+  SNPA yields exactly 6 fields, and only the level-shape check rejects it.
+
+  An ambiguous row sets `ISISAdjacency.Malformed`, leaves every derived field
+  EMPTY, and carries the original line in `Raw`. It is neither dropped (that
+  would hide a real adjacency) nor rendered as columns (that would assert values
+  the peer chose). **Display sites MUST branch on `Malformed`** — both
+  `pkg/cli/cli_show_routing.go` and `pkg/grpcapi/server_routing.go` do.
+
+  An escape-bearing but SPACE-FREE hostname stays a well-formed row on purpose:
+  the escape is the display guard's job, and if such a row went `Malformed` the
+  #6468/#6579 regression fixtures would stop exercising the guard they exist
+  for. That orthogonality is pinned by a test.
 - **`GetBGPSummary` parses JSON, not the text table (#3942).**
   `GetBGPSummary` runs `show bgp summary json` and decodes it via
   `parseBGPSummaryJSON` (`status_parse.go`), mirroring the `parseRouteJSON`

--- a/pkg/frr/isis_adjacency_shift_6590_test.go
+++ b/pkg/frr/isis_adjacency_shift_6590_test.go
@@ -1,0 +1,208 @@
+package frr
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6590: a peer-advertised IS-IS hostname containing a SPACE must not shift the
+// adjacency columns and let the peer forge State/Level/Interface/HoldTime.
+//
+// The first column of `show isis neighbor` is the hostname the peer advertised
+// in its Dynamic Hostname TLV (RFC 5301, `hostname dynamic`, on by default),
+// and FRR retains printable ASCII spaces when decoding that TLV. Assigning
+// tokens to columns purely by POSITION therefore let the peer push its own
+// bytes into every later cell:
+//
+//	wire row:  evil peer ge-0-0-1 2 Up 27
+//	parsed as: SystemID=evil Interface=peer Level=ge-0-0-1 State=2 HoldTime=Up
+//
+// With enough space-separated tokens the peer controls all five displayed cells
+// and the operator sees a well-formed table whose values come from the
+// adjacency's own remote end.
+//
+// This is NOT the #6468 escape-injection defect and is not fixed by the #6579
+// display guard: sanitizing preserves plausible printable text, so it cannot
+// distinguish a genuine State=Up from a peer-supplied token. The row can be
+// terminal-safe and still materially false — a display INTEGRITY defect whose
+// fix belongs in the parser.
+//
+// FAIL-ON-REVERT: restore the positional assignment (drop the field-count and
+// level/holdtime shape checks) and the shifted rows below parse as well-formed
+// with peer-chosen values in every cell.
+
+func isisManager(t *testing.T, table string) *Manager {
+	t.Helper()
+	return &Manager{exec: &fakeExecutor{
+		vtyshResp: map[string]string{"show isis neighbor": table},
+	}}
+}
+
+const isisHeader = "Area 1:\n" +
+	" System Id           Interface   L  State        Holdtime SNPA\n"
+
+// TestSpaceBearingHostnameIsNotRenderedAsColumns is the core RED-on-revert.
+func TestSpaceBearingHostnameIsNotRenderedAsColumns(t *testing.T) {
+	cases := []struct {
+		name string
+		row  string
+	}{
+		{
+			// One space: pushes the count to 7 with SNPA present.
+			"one-space-with-snpa",
+			" evil peer           ge-0-0-1    2  Up           27       2020.2020.2020",
+		},
+		{
+			// One space, no SNPA: exactly 6 fields, so the COUNT bound alone
+			// does not catch it — the level slot holds "ge-0-0-1" and the
+			// shape check is what rejects it.
+			"one-space-no-snpa",
+			" evil peer ge-0-0-1 2 Up 27",
+		},
+		{
+			// The full forgery from the issue: the peer supplies every cell.
+			"peer-controls-every-cell",
+			" x ge-0-0-9 2 Down 99   ge-0-0-1    2  Up           27       2020.2020.2020",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			adjs, err := isisManager(t, isisHeader+tc.row+"\n").GetISISAdjacency()
+			if err != nil {
+				t.Fatalf("GetISISAdjacency: %v", err)
+			}
+			if len(adjs) != 1 {
+				t.Fatalf("want 1 adjacency, got %d: %+v", len(adjs), adjs)
+			}
+			a := adjs[0]
+			if !a.Malformed {
+				t.Fatalf("a space-bearing hostname parsed as a well-formed row: "+
+					"SystemID=%q Interface=%q Level=%q State=%q HoldTime=%q — "+
+					"every one of those cells is peer-controlled",
+					a.SystemID, a.Interface, a.Level, a.State, a.HoldTime)
+			}
+			// A malformed row must assert NOTHING. Reporting a neighbour in
+			// state "" is quieter than the forgery but still false.
+			if a.SystemID != "" || a.Interface != "" || a.Level != "" ||
+				a.State != "" || a.HoldTime != "" {
+				t.Errorf("malformed row still carries derived values: %+v", a)
+			}
+			// ...but it must not be DROPPED either: a silently discarded row
+			// hides a real adjacency.
+			if a.Raw == "" {
+				t.Error("malformed row has no Raw text, so the operator cannot " +
+					"see that an adjacency exists at all")
+			}
+		})
+	}
+}
+
+// TestWellFormedRowsStillParse is the negative control. A guard that rejected
+// everything would satisfy the test above while breaking the command.
+func TestWellFormedRowsStillParse(t *testing.T) {
+	cases := []struct {
+		name                             string
+		row                              string
+		sysID, iface, level, state, hold string
+	}{
+		{
+			"with-snpa",
+			" rtr1                ge-0-0-1    2  Up           27       2020.2020.2020",
+			"rtr1", "ge-0-0-1", "2", "Up", "27",
+		},
+		{
+			// SNPA absent (5 fields) is legitimate and must still parse.
+			"without-snpa",
+			" rtr2                ge-0-0-2    1  Up           30",
+			"rtr2", "ge-0-0-2", "1", "Up", "30",
+		},
+		{
+			"level-1-2",
+			" rtr3                ge-0-0-3    1-2  Init       9        2020.2020.2021",
+			"rtr3", "ge-0-0-3", "1-2", "Init", "9",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			adjs, err := isisManager(t, isisHeader+tc.row+"\n").GetISISAdjacency()
+			if err != nil {
+				t.Fatalf("GetISISAdjacency: %v", err)
+			}
+			if len(adjs) != 1 {
+				t.Fatalf("want 1 adjacency, got %d: %+v", len(adjs), adjs)
+			}
+			a := adjs[0]
+			if a.Malformed {
+				t.Fatalf("a well-formed row was rejected: %+v", a)
+			}
+			if a.SystemID != tc.sysID || a.Interface != tc.iface ||
+				a.Level != tc.level || a.State != tc.state || a.HoldTime != tc.hold {
+				t.Errorf("got %+v, want sysID=%q iface=%q level=%q state=%q hold=%q",
+					a, tc.sysID, tc.iface, tc.level, tc.state, tc.hold)
+			}
+		})
+	}
+}
+
+// TestEscapeBearingHostnameStaysWellFormed keeps #6590 and #6468 orthogonal.
+//
+// A hostname carrying an ESC/CSI sequence but NO space is a well-formed row:
+// the columns are correctly attributed and the escape is the display guard's
+// problem, not the parser's. If this went Malformed, the #6468/#6579 escape
+// regression fixtures would stop exercising the display guard they exist for —
+// they would be testing this parser's rejection instead, and the guard could
+// rot undetected.
+func TestEscapeBearingHostnameStaysWellFormed(t *testing.T) {
+	row := " rtr1\x1b[2Kforged     ge-0-0-1    2  Up           27       2020.2020.2020"
+	adjs, err := isisManager(t, isisHeader+row+"\n").GetISISAdjacency()
+	if err != nil {
+		t.Fatalf("GetISISAdjacency: %v", err)
+	}
+	if len(adjs) != 1 {
+		t.Fatalf("want 1 adjacency, got %d", len(adjs))
+	}
+	a := adjs[0]
+	if a.Malformed {
+		t.Fatal("an escape-bearing (but space-free) hostname must stay a " +
+			"well-formed row — the escape is the display guard's job")
+	}
+	if !strings.Contains(a.SystemID, "\x1b") {
+		t.Errorf("the raw escape must survive into SystemID for the display "+
+			"guard to escape; got %q", a.SystemID)
+	}
+	if a.State != "Up" || a.Level != "2" || a.HoldTime != "27" {
+		t.Errorf("columns misattributed: %+v", a)
+	}
+}
+
+// TestShapeChecksRejectForgedLevelAndHoldTime pins the two FRR-generated
+// columns individually, so neither check can be dropped without a red.
+func TestShapeChecksRejectForgedLevelAndHoldTime(t *testing.T) {
+	for _, tc := range []struct{ name, row string }{
+		// Level slot is not an IS-IS level.
+		{"bad-level", " rtr1 ge-0-0-1 XX Up 27 2020.2020.2020"},
+		// Holdtime slot is not numeric.
+		{"bad-holdtime", " rtr1 ge-0-0-1 2 Up notanumber 2020.2020.2020"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			adjs, err := isisManager(t, isisHeader+tc.row+"\n").GetISISAdjacency()
+			if err != nil {
+				t.Fatalf("GetISISAdjacency: %v", err)
+			}
+			if len(adjs) != 1 || !adjs[0].Malformed {
+				t.Fatalf("want a malformed row, got %+v", adjs)
+			}
+		})
+	}
+}
+
+// TestHeaderAndAreaLinesStillSkipped: the parser's existing skips must survive.
+func TestHeaderAndAreaLinesStillSkipped(t *testing.T) {
+	adjs, err := isisManager(t, isisHeader).GetISISAdjacency()
+	if err != nil {
+		t.Fatalf("GetISISAdjacency: %v", err)
+	}
+	if len(adjs) != 0 {
+		t.Fatalf("header/area lines produced adjacencies: %+v", adjs)
+	}
+}

--- a/pkg/frr/status_parse.go
+++ b/pkg/frr/status_parse.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -78,27 +79,76 @@ func (m *Manager) GetRIPRoutes() ([]RIPRouteEntry, error) {
 // puts peer bytes in each of them. Display sites must sanitize the WHOLE row —
 // see termsafe.SanitizeRowForDisplay.
 //
-// Sanitizing does NOT repair that shift. It keeps the row safe to print; the
-// VALUES remain positionally derived from peer-controlled text, so a shifted
-// row can display a State the peer chose and no display guard can detect it.
-// Fixing that needs this parse to change — FRR's IS-IS JSON output, or
-// right-anchored columns with malformed rows reported rather than rendered.
-// Tracked as #6590. Do not cite the display guard as making this struct
-// trustworthy.
+// #6590: a shifted row is now DETECTED rather than rendered. Sanitizing cannot
+// repair the shift — it keeps the row safe to print, but the VALUES stay
+// positionally derived from peer-controlled text, so a shifted row could
+// display a State the peer chose and no display guard could tell. The parse
+// validates the FRR-GENERATED columns instead (see GetISISAdjacency) and marks
+// an ambiguous row Malformed, leaving every derived field EMPTY.
+//
+// Display sites MUST branch on Malformed. Rendering the empty fields as though
+// they were values would report a neighbour in state "" — quieter than the
+// forgery, but still false. Show the raw row instead, sanitized.
 type ISISAdjacency struct {
 	SystemID  string
 	Interface string
 	Level     string
 	State     string
 	HoldTime  string
+
+	// Malformed is set when the row could not be attributed to columns with
+	// confidence. Every other field is then EMPTY and Raw carries the original
+	// line for display.
+	Malformed bool
+	// Raw is the original row text, populated only when Malformed. It is
+	// peer-tainted like every other field and must be sanitized at the display
+	// site.
+	Raw string
 }
+
+// isisLevelToken matches the `L` column FRR emits for an IS-IS adjacency. FRR
+// generates it, so a row whose level slot does not match has been shifted by a
+// space-bearing token earlier in the line.
+var isisLevelToken = regexp.MustCompile(`^(1|2|1-2|L1|L2|L1L2)$`)
+
+// isisHoldTimeToken matches the Holdtime column, likewise FRR-generated.
+var isisHoldTimeToken = regexp.MustCompile(`^[0-9]+$`)
 
 // GetISISAdjacency queries FRR for IS-IS adjacencies.
 //
 // strings.Fields splits on unicode.IsSpace ONLY, so ESC, DEL, BEL and the C1
 // controls ride inside a token untouched — tokenizing is not sanitizing. The
-// guard belongs at the display sites (see the ISISAdjacency doc); the values
-// here stay raw for machine consumers.
+// display guard belongs at the display sites (see the ISISAdjacency doc); the
+// values here stay raw for machine consumers.
+//
+// #6590: the first column is the hostname the peer advertised in its Dynamic
+// Hostname TLV (RFC 5301), and FRR retains printable ASCII SPACES when decoding
+// that TLV. Assigning tokens to columns purely by POSITION therefore let a
+// space-bearing hostname shift every later column and put peer bytes in each of
+// them — with enough tokens the peer controlled all five displayed cells, and
+// the operator saw a well-formed adjacency table whose values came from the
+// adjacency's own remote end. That is a display INTEGRITY defect, and no
+// display guard can detect it: sanitizing preserves plausible printable text,
+// so a forged `State` survives it intact.
+//
+// The fix validates the columns FRR GENERATES rather than trusting position:
+//
+//   - the row must hold EXACTLY 5 or 6 fields — `System Id, Interface, L,
+//     State, Holdtime` with SNPA optional. Any space in the hostname adds a
+//     token and pushes the count past 6.
+//   - the `L` slot must be an IS-IS level and the `Holdtime` slot must be
+//     numeric. Both are FRR-generated, so a shift that stays within the count
+//     bound still lands peer text in one of them.
+//
+// Together those close the gap: a hostname carrying one space yields 6 fields
+// with `Level` holding an interface name (rejected) or 7 fields (rejected on
+// count), and a hostname crafted to satisfy the shape checks can only ADD
+// tokens, never remove them, so it cannot reach a valid count.
+//
+// An ambiguous row is REPORTED, not rendered and not dropped: Malformed is set,
+// every derived field is left empty, and Raw carries the original line. Dropping
+// it would hide a real adjacency; rendering it would assert values the peer
+// chose.
 func (m *Manager) GetISISAdjacency() ([]ISISAdjacency, error) {
 	output, err := m.executor().Vtysh("show isis neighbor")
 	if err != nil {
@@ -114,22 +164,21 @@ func (m *Manager) GetISISAdjacency() ([]ISISAdjacency, error) {
 		if fields[0] == "System" || strings.HasPrefix(line, "Area") {
 			continue
 		}
-		adj := ISISAdjacency{
-			SystemID: fields[0],
+		// FRR emits `System Id | Interface | L | State | Holdtime [| SNPA]`.
+		// Anything else means a token carried a space.
+		if len(fields) < 5 || len(fields) > 6 ||
+			!isisLevelToken.MatchString(fields[2]) ||
+			!isisHoldTimeToken.MatchString(fields[4]) {
+			adjs = append(adjs, ISISAdjacency{Malformed: true, Raw: strings.TrimSpace(line)})
+			continue
 		}
-		if len(fields) >= 2 {
-			adj.Interface = fields[1]
-		}
-		if len(fields) >= 3 {
-			adj.Level = fields[2]
-		}
-		if len(fields) >= 4 {
-			adj.State = fields[3]
-		}
-		if len(fields) >= 5 {
-			adj.HoldTime = fields[4]
-		}
-		adjs = append(adjs, adj)
+		adjs = append(adjs, ISISAdjacency{
+			SystemID:  fields[0],
+			Interface: fields[1],
+			Level:     fields[2],
+			State:     fields[3],
+			HoldTime:  fields[4],
+		})
 	}
 	return adjs, nil
 }

--- a/pkg/grpcapi/server_routing.go
+++ b/pkg/grpcapi/server_routing.go
@@ -284,6 +284,13 @@ func (s *Server) GetISISStatus(_ context.Context, req *pb.GetISISStatusRequest) 
 			fmt.Fprintf(&b, "  %-20s %-14s %-10s %-10s %s\n",
 				"System ID", "Interface", "Level", "State", "Hold Time")
 			for _, a := range adjs {
+				// #6590: see the CLI sibling — an ambiguous row is reported,
+				// never rendered as columns.
+				if a.Malformed {
+					fmt.Fprintf(&b, "  %s\n", termsafe.SanitizeForDisplay(
+						"(unparseable adjacency row: "+a.Raw+")"))
+					continue
+				}
 				fmt.Fprintf(&b, "  %-20s %-14s %-10s %-10s %s\n",
 					termsafe.SanitizeRowForDisplay(
 						a.SystemID, a.Interface, a.Level, a.State, a.HoldTime)...)


### PR DESCRIPTION
## Problem

`GetISISAdjacency` split each `show isis neighbor` row with `strings.Fields` and assigned tokens to columns **positionally**. The first column is not a numeric system ID — FRR substitutes the hostname the peer advertised in its Dynamic Hostname TLV (RFC 5301, `hostname dynamic`, on by default), and FRR retains printable ASCII **spaces** when decoding that TLV.

```
wire row:  evil peer ge-0-0-1 2 Up 27
parsed as: SystemID=evil Interface=peer Level=ge-0-0-1 State=2 HoldTime=Up
```

With enough space-separated tokens the peer controls **all five displayed cells**, and the operator sees a well-formed adjacency table whose values are supplied by the adjacency's own remote end.

**This is not #6468 and #6579 does not fix it.** Sanitizing preserves plausible printable text, so it cannot distinguish a genuine `State=Up` from a peer-supplied token. The row can be terminal-safe and still materially false — a display *integrity* defect, whose fix belongs in the parser.

## Fix

Validate the columns FRR **generates** rather than trusting position:

- exactly 5 or 6 fields (`System Id, Interface, L, State, Holdtime`, SNPA optional);
- the `L` slot must be an IS-IS level;
- the `Holdtime` slot must be numeric.

A space in the hostname can only **add** tokens, never remove them, so it cannot reach a valid count while also satisfying the shape checks.

**The count bound alone is not sufficient, and the mutation matrix proves it:** a one-space hostname on a row without SNPA yields exactly 6 fields, and only the level-shape check rejects it. That is cell M2 below.

An ambiguous row is **reported, not rendered and not dropped**: `Malformed` is set, every derived field is left empty, and `Raw` carries the original line. Both display sites branch on it. Dropping the row would hide a real adjacency; rendering the empty fields would report a neighbour in state `""` — quieter than the forgery, but still false.

## Keeping #6590 and #6468 orthogonal

An escape-bearing but **space-free** hostname deliberately stays a well-formed row. The escape is the display guard's job — and if such a row went `Malformed`, the #6468/#6579 regression fixtures would stop exercising the guard they exist for: they would be testing this parser's rejection instead, and **the display guard could rot undetected**. A test pins that orthogonality, and the pre-existing escape fixtures still pass unchanged.

## Validation

`go test ./pkg/frr/ ./pkg/cli/ ./pkg/grpcapi/ ./pkg/api/ -count=1` green.

| Cell | Mutation | rc | Reds |
|---|---|---|---|
| M1 | restore the positional assignment verbatim | 1 | all 3 shift cases + both shape cases |
| M2 | drop **only** the shape checks, keep the count bound | 1 | the one-space-without-SNPA case + both shape cases |
| CONTROL | none | 0 | — |

M2 is the interesting cell: it isolates the shape check as load-bearing independently of the count bound, which is the part a reviewer would most plausibly think redundant.

Go control plane only — no `userspace-dp` binary or shim `.o` movement, no cluster/VRRP/session-sync code touched.

Closes #6590