### PR TITLE
snmp: binary-search the successor instead of scanning the MIB (#6597)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -102807,3 +102807,18 @@ prose edit above them added. No diff falls in the new test body.
     store_runtime_view choke point covering all seven, with #6592-style
     previous-view retention for hoist resistance. cfg(test) only.
   - **File(s)**: userspace-dp/src/afxdp/coordinator/{cos_state.rs,mod.rs,tests.rs}
+
+## 2026-08-22 — #6597: SNMP successor lookup is binary search, not a linear scan
+- **Timestamp**: 2026-08-22
+- **Action**: `findNextOIDSnap` linear-scanned the MIB view per varbind on a
+  single serial goroutine. Now builds the ordered view once per PDU
+  (`ifSnapshot.mibOIDs`) and binary-searches it: 677us -> 158ns per lookup at
+  256 interfaces, and flat instead of linear in interface count. Equivalence
+  bound by a differential test against the pre-fix algorithm as a reference
+  oracle (2175 probes + a full-MIB walk, byte-identical). Found a correctness
+  bug while doing it: the linear scan depended on `ifDataFn` returning
+  IfIndex-ascending data, which the production provider does not guarantee —
+  out-of-order input made the walk ascending but INCOMPLETE (40 of 87 rows
+  skipped). `mibOIDs` sorts, so the walk is now correct regardless.
+- **File(s)**: pkg/snmp/agent.go,
+  pkg/snmp/findnext_binary_search_6597_test.go (new), pkg/snmp/README.md, _Log.md

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -401,6 +401,60 @@ swaps both under `Lock`, so a request never observes a half-applied config
 swapped. A `nil` cfg (the whole `snmp` stanza removed) disables the agent's
 authorization surface: every request is dropped because no community matches.
 
+## Successor lookup: binary search over a per-PDU ordered MIB view (#6597)
+
+`findNextOIDSnap` resolves each GETNEXT/GETBULK successor by **binary-searching**
+`ifSnapshot.mibOIDs()` — the whole MIB view for that PDU (staticOIDs, then every
+ifTable cell, then every ifXTable cell) built once on first use.
+
+It used to LINEAR-SCAN that view for every varbind — `O(static + interfaces x
+columns)` per lookup, multiplied by every varbind an operation emits. The agent
+runs on a **single serial goroutine**, so that per-lookup cost is the floor on
+requests/second for every operation at once, and it grows with interface count.
+A max-size plain GETNEXT of 239 deep `ifXTable` OIDs measured **~33 ms** (~30
+req/s for that shape) while fixing #6551.
+
+Measured per-lookup cost, worst-case probe (`-benchtime=2000x`):
+
+| interfaces | linear (before) | binary (after) |
+|---|---|---|
+| 1 | 2,010 ns | 77 ns |
+| 8 | 12,897 ns | 148 ns |
+| 64 | 103,060 ns | 201 ns |
+| 256 | 677,284 ns | 158 ns |
+
+The shape is the point, not the ratio: the old cost grows **linearly** with
+interface count while the new cost stays flat. `BenchmarkFindNextOIDByInterfaceCount`
+pins it so a regression to linear is visible.
+
+**The equivalence obligation is bound by a differential test, not spot checks.**
+`TestFindNextOIDMatchesLinearReference` keeps the pre-fix algorithm as a
+reference oracle and asserts identical successors across an exhaustive probe set
+(every MIB OID, each ±1 in its last sub-identifier, every bare column prefix,
+and the boundaries above/below each table — 2,175 probes across five interface
+counts). `TestFullWalkMatchesLinearReference` additionally walks the entire MIB
+with both and asserts the emitted sequences are byte-identical.
+
+**A correctness bug fell out of this, and it is more serious than the
+performance one.** The linear scan's lexicographic correctness silently depended
+on `ifDataFn` returning IfIndex-ascending data, and nothing enforces that — the
+production provider (`buildSNMPIfData`, `pkg/daemon/daemon_snmp_reconcile.go`)
+appends in netlink `LinkList` order with no sort. Given an out-of-order provider
+the old scan still emitted **ascending** OIDs, because it returned the first
+candidate sorting after the cursor — but it **skipped** every interface whose
+index sorted below one already emitted in that column. Measured on a
+4-interface out-of-order fixture: **40 of 87 MIB rows never appear in the walk**,
+so a manager silently never sees those interfaces.
+
+An ascending-only assertion passes on that broken behaviour; **completeness is
+what discriminates**, which is why `TestUnsortedProviderWalksEveryRowInOrder`
+asserts the full expected row set. `mibOIDs` sorts by IfIndex, so the walk is
+now correct regardless of provider order.
+
+`TestMIBOIDViewIsSorted` pins the precondition the binary search requires —
+`sort.Search` on an unsorted slice returns silently wrong answers, so that guard
+is load-bearing rather than stylistic.
+
 ## Entry points
 
 - `Agent` — `agent.go`.

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -688,6 +689,15 @@ type ifSnapshot struct {
 	a      *Agent
 	loaded bool
 	data   []IfData
+
+	// oids is the full MIB view for this PDU in lexicographic order —
+	// staticOIDs, then every ifTable cell, then every ifXTable cell — built
+	// once on first use and binary-searched by findNextOIDSnap (#6597).
+	// oidsBuilt distinguishes "not yet built" from "built and legitimately
+	// empty" (an agent with no interfaces still has staticOIDs, so empty is in
+	// practice unreachable, but the flag keeps the lazy contract honest).
+	oids      [][]int
+	oidsBuilt bool
 }
 
 // newIfSnapshot returns a fresh per-PDU interface-data snapshot bound to the
@@ -706,6 +716,65 @@ func (s *ifSnapshot) get() []IfData {
 		s.loaded = true
 	}
 	return s.data
+}
+
+// mibOIDs returns this PDU's whole MIB view in lexicographic order, built once
+// per snapshot (#6597).
+//
+// The successor lookup used to LINEAR-SCAN this view for every varbind —
+// O(static + interfaces x columns) per lookup, multiplied by every varbind an
+// operation emits. Because the agent runs on a single serial goroutine, that
+// per-lookup cost is the floor on requests/second for every operation at once,
+// and it grows with interface count: a max-size plain GETNEXT of 239 deep
+// ifXTable OIDs measured ~33 ms, i.e. ~30 req/s for that shape (#6551 fold).
+// Building the ordered view once per PDU and binary-searching it moves the walk
+// from O(varbinds x entries) to O(entries + varbinds x log entries).
+//
+// The interface list is SORTED BY IfIndex here, which the linear scan did not
+// do. Its lexicographic correctness silently depended on `ifDataFn` returning
+// IfIndex-ascending data, and nothing enforces that: the production provider
+// (`buildSNMPIfData`, pkg/daemon) appends in netlink LinkList order with no
+// sort. For the usual ascending case the emitted order is identical to the
+// linear scan's; for a provider that returns them out of order the walk is now
+// correctly lexicographic where it previously could revisit or skip OIDs, which
+// is a fix rather than a behaviour change worth preserving.
+//
+// Column-major with ascending IfIndex IS the lexicographic order of
+// `<prefix>.<col>.<ifIndex>`, so the concatenation below is sorted by
+// construction; `TestMIBOIDViewIsSorted` pins that rather than trusting it.
+func (s *ifSnapshot) mibOIDs() [][]int {
+	if s.oidsBuilt {
+		return s.oids
+	}
+	s.oidsBuilt = true
+
+	ifaces := s.get()
+	sorted := make([]IfData, len(ifaces))
+	copy(sorted, ifaces)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].IfIndex < sorted[j].IfIndex })
+
+	out := make([][]int, 0, len(staticOIDs)+
+		len(sorted)*(len(ifTableColumns)+len(ifXTableColumns)))
+	out = append(out, staticOIDs...)
+	for _, tbl := range []struct {
+		prefix []int
+		cols   []int
+	}{
+		{oidIfTablePrefix, ifTableColumns},
+		{oidIfXTablePrefix, ifXTableColumns},
+	} {
+		for _, col := range tbl.cols {
+			for _, iface := range sorted {
+				candidate := make([]int, len(tbl.prefix)+2)
+				copy(candidate, tbl.prefix)
+				candidate[len(tbl.prefix)] = col
+				candidate[len(tbl.prefix)+1] = iface.IfIndex
+				out = append(out, candidate)
+			}
+		}
+	}
+	s.oids = out
+	return s.oids
 }
 
 // Start binds the UDP/161 listener and then serves requests until the context
@@ -1656,45 +1725,17 @@ func (a *Agent) findNextOID(oid []int) []int {
 // interface snapshot, so a GETNEXT/GETBULK walk reads the interface list once
 // per PDU rather than once per next-OID lookup.
 func (a *Agent) findNextOIDSnap(oid []int, snap *ifSnapshot) []int {
-	// Check static OIDs first.
-	for _, candidate := range staticOIDs {
-		if oidCompare(candidate, oid) > 0 {
-			return candidate
-		}
-	}
-
-	// Walk ifTable OIDs: 1.3.6.1.2.1.2.2.1.<col>.<ifIndex>
-	ifaces := snap.get()
-	if len(ifaces) == 0 {
+	// #6597: binary search the per-PDU ordered MIB view instead of scanning it.
+	// sort.Search returns the first index whose OID sorts strictly after `oid`,
+	// which is exactly the GETNEXT successor.
+	view := snap.mibOIDs()
+	i := sort.Search(len(view), func(i int) bool {
+		return oidCompare(view[i], oid) > 0
+	})
+	if i == len(view) {
 		return nil
 	}
-
-	// Build sorted list of all ifTable OIDs.
-	for _, col := range ifTableColumns {
-		for _, iface := range ifaces {
-			candidate := make([]int, len(oidIfTablePrefix)+2)
-			copy(candidate, oidIfTablePrefix)
-			candidate[len(oidIfTablePrefix)] = col
-			candidate[len(oidIfTablePrefix)+1] = iface.IfIndex
-			if oidCompare(candidate, oid) > 0 {
-				return candidate
-			}
-		}
-	}
-
-	// Walk ifXTable OIDs: 1.3.6.1.2.1.31.1.1.1.<col>.<ifIndex>
-	for _, col := range ifXTableColumns {
-		for _, iface := range ifaces {
-			candidate := make([]int, len(oidIfXTablePrefix)+2)
-			copy(candidate, oidIfXTablePrefix)
-			candidate[len(oidIfXTablePrefix)] = col
-			candidate[len(oidIfXTablePrefix)+1] = iface.IfIndex
-			if oidCompare(candidate, oid) > 0 {
-				return candidate
-			}
-		}
-	}
-	return nil
+	return view[i]
 }
 
 // varbind holds a single OID-value binding.

--- a/pkg/snmp/findnext_binary_search_6597_test.go
+++ b/pkg/snmp/findnext_binary_search_6597_test.go
@@ -1,0 +1,314 @@
+package snmp
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// #6597: the GETNEXT successor lookup must not be linear in the MIB size.
+//
+// `findNextOIDSnap` resolved each lexicographic successor by scanning the whole
+// MIB view — O(static + interfaces x columns) PER VARBIND. Because the agent
+// runs on a single serial goroutine, that per-lookup cost is the floor on
+// requests/second for every operation at once, and it grows with interface
+// count: a max-size plain GETNEXT of 239 deep ifXTable OIDs measured ~33 ms
+// (~30 req/s for that shape) while fixing #6551.
+//
+// This is a PERFORMANCE change, so the binding obligation is that it does not
+// alter results. `TestFindNextOIDMatchesLinearReference` is that binding: it
+// runs the pre-fix algorithm as a reference and asserts byte-identical
+// successors across an exhaustive probe set, rather than spot-checking a few
+// OIDs.
+
+// oidString renders an OID for test messages. Local to this file so the test
+// does not depend on a production formatter that may not exist.
+func oidString(o []int) string {
+	if o == nil {
+		return "<nil>"
+	}
+	parts := make([]string, len(o))
+	for i, v := range o {
+		parts[i] = strconv.Itoa(v)
+	}
+	return strings.Join(parts, ".")
+}
+
+// linearFindNextReference is the PRE-FIX algorithm, verbatim in structure:
+// scan staticOIDs, then ifTable column-major, then ifXTable column-major,
+// returning the first candidate that sorts after oid. It is the oracle the new
+// binary search must agree with.
+func linearFindNextReference(oid []int, ifaces []IfData) []int {
+	for _, candidate := range staticOIDs {
+		if oidCompare(candidate, oid) > 0 {
+			return candidate
+		}
+	}
+	if len(ifaces) == 0 {
+		return nil
+	}
+	for _, col := range ifTableColumns {
+		for _, iface := range ifaces {
+			candidate := make([]int, len(oidIfTablePrefix)+2)
+			copy(candidate, oidIfTablePrefix)
+			candidate[len(oidIfTablePrefix)] = col
+			candidate[len(oidIfTablePrefix)+1] = iface.IfIndex
+			if oidCompare(candidate, oid) > 0 {
+				return candidate
+			}
+		}
+	}
+	for _, col := range ifXTableColumns {
+		for _, iface := range ifaces {
+			candidate := make([]int, len(oidIfXTablePrefix)+2)
+			copy(candidate, oidIfXTablePrefix)
+			candidate[len(oidIfXTablePrefix)] = col
+			candidate[len(oidIfXTablePrefix)+1] = iface.IfIndex
+			if oidCompare(candidate, oid) > 0 {
+				return candidate
+			}
+		}
+	}
+	return nil
+}
+
+func ifDataAscending(n int) []IfData {
+	out := make([]IfData, 0, n)
+	for i := 1; i <= n; i++ {
+		out = append(out, IfData{IfIndex: i, IfDescr: fmt.Sprintf("ge-0-0-%d", i)})
+	}
+	return out
+}
+
+func agentWithIfaces(ifaces []IfData) *Agent {
+	a := &Agent{}
+	a.SetIfDataFn(func() []IfData { return ifaces })
+	return a
+}
+
+// probeOIDs returns an exhaustive probe set for a given MIB view: every OID in
+// the view, each one MINUS the last sub-identifier and PLUS one, plus the
+// boundary probes above and below every table. Walking from each of these
+// exercises every branch the successor lookup can take.
+func probeOIDs(view [][]int) [][]int {
+	var probes [][]int
+	add := func(o []int) { probes = append(probes, append([]int(nil), o...)) }
+	for _, o := range view {
+		add(o)
+		if len(o) > 0 {
+			lower := append([]int(nil), o...)
+			lower[len(lower)-1]--
+			add(lower)
+			higher := append([]int(nil), o...)
+			higher[len(higher)-1]++
+			add(higher)
+			add(o[:len(o)-1]) // the prefix, i.e. a bare column
+		}
+	}
+	add([]int{})
+	add([]int{1})
+	add([]int{1, 3, 6, 1, 2, 1})
+	add([]int{1, 3, 6, 1, 2, 1, 2, 2, 1})
+	add([]int{1, 3, 6, 1, 2, 1, 31, 1, 1, 1})
+	add([]int{1, 3, 6, 1, 2, 1, 99})
+	add([]int{2})
+	return probes
+}
+
+// TestFindNextOIDMatchesLinearReference is the equivalence binding: for every
+// probe, the binary search must return exactly what the linear scan returned.
+func TestFindNextOIDMatchesLinearReference(t *testing.T) {
+	for _, n := range []int{0, 1, 2, 5, 17} {
+		t.Run(fmt.Sprintf("ifaces=%d", n), func(t *testing.T) {
+			ifaces := ifDataAscending(n)
+			a := agentWithIfaces(ifaces)
+			snap := a.newIfSnapshot()
+			view := snap.mibOIDs()
+
+			probes := probeOIDs(view)
+			if len(probes) == 0 {
+				t.Fatal("probe set is empty — the test would pass vacuously")
+			}
+			for _, probe := range probes {
+				got := a.findNextOIDSnap(probe, a.newIfSnapshot())
+				want := linearFindNextReference(probe, ifaces)
+				if oidString(got) != oidString(want) {
+					t.Fatalf("successor of %s: got %s, want %s (linear reference)",
+						oidString(probe), oidString(got), oidString(want))
+				}
+			}
+			t.Logf("%d probes agreed with the linear reference", len(probes))
+		})
+	}
+}
+
+// TestFullWalkMatchesLinearReference walks the ENTIRE MIB from the root with
+// both implementations and asserts the emitted sequences are identical. The
+// probe test above checks each successor in isolation; this checks that
+// chaining them produces the same walk, which is what a manager actually sees.
+func TestFullWalkMatchesLinearReference(t *testing.T) {
+	ifaces := ifDataAscending(7)
+	a := agentWithIfaces(ifaces)
+
+	walk := func(next func([]int) []int) []string {
+		var out []string
+		cur := []int{}
+		for range 10000 {
+			n := next(cur)
+			if n == nil {
+				return out
+			}
+			out = append(out, oidString(n))
+			cur = n
+		}
+		t.Fatal("walk did not terminate")
+		return nil
+	}
+
+	gotWalk := walk(func(o []int) []int { return a.findNextOIDSnap(o, a.newIfSnapshot()) })
+	wantWalk := walk(func(o []int) []int { return linearFindNextReference(o, ifaces) })
+
+	if len(gotWalk) != len(wantWalk) {
+		t.Fatalf("walk length %d != reference %d", len(gotWalk), len(wantWalk))
+	}
+	if len(gotWalk) == 0 {
+		t.Fatal("empty walk — the test would pass vacuously")
+	}
+	for i := range gotWalk {
+		if gotWalk[i] != wantWalk[i] {
+			t.Fatalf("walk diverges at %d: got %s, want %s", i, gotWalk[i], wantWalk[i])
+		}
+	}
+	t.Logf("%d-OID walk is byte-identical to the linear reference", len(gotWalk))
+}
+
+// TestMIBOIDViewIsSorted pins the precondition the binary search REQUIRES.
+// sort.Search on an unsorted slice returns silently wrong answers, so this is
+// not a style assertion: it is the guard that keeps the lookup correct if a
+// column list or table order is ever edited.
+func TestMIBOIDViewIsSorted(t *testing.T) {
+	snap := agentWithIfaces(ifDataAscending(9)).newIfSnapshot()
+	view := snap.mibOIDs()
+	if len(view) == 0 {
+		t.Fatal("empty MIB view")
+	}
+	if !sort.SliceIsSorted(view, func(i, j int) bool { return oidCompare(view[i], view[j]) < 0 }) {
+		for i := 1; i < len(view); i++ {
+			if oidCompare(view[i-1], view[i]) >= 0 {
+				t.Fatalf("MIB view is not sorted at %d: %s then %s — sort.Search "+
+					"gives silently wrong successors on an unsorted slice",
+					i, oidString(view[i-1]), oidString(view[i]))
+			}
+		}
+	}
+}
+
+// TestUnsortedProviderWalksEveryRowInOrder pins the correctness IMPROVEMENT and
+// is the one deterministic RED-on-revert in this file.
+//
+// The linear scan's lexicographic correctness silently depended on `ifDataFn`
+// returning IfIndex-ascending data, and nothing enforces that — the production
+// provider (`buildSNMPIfData`, pkg/daemon) appends in netlink LinkList order
+// with no sort.
+//
+// The interesting part is HOW it failed. Given an out-of-order provider the old
+// scan still emitted ASCENDING OIDs, because it returned the first candidate
+// sorting after the cursor — but it SKIPPED every interface whose index sorted
+// below one already emitted in that column. An ascending-only assertion
+// therefore passes on the broken code; completeness is what discriminates. That
+// is why this asserts the full expected set, not just the ordering.
+//
+// FAIL-ON-REVERT: restore the linear scan and this test reds with missing rows.
+func TestUnsortedProviderWalksEveryRowInOrder(t *testing.T) {
+	unsorted := []IfData{{IfIndex: 7}, {IfIndex: 2}, {IfIndex: 11}, {IfIndex: 1}}
+	a := agentWithIfaces(unsorted)
+
+	var walk [][]int
+	cur := []int{}
+	for range 10000 {
+		n := a.findNextOIDSnap(cur, a.newIfSnapshot())
+		if n == nil {
+			break
+		}
+		walk = append(walk, n)
+		cur = n
+	}
+	if len(walk) == 0 {
+		t.Fatal("empty walk")
+	}
+
+	// Strictly ascending.
+	for i := 1; i < len(walk); i++ {
+		if oidCompare(walk[i-1], walk[i]) >= 0 {
+			t.Fatalf("walk is not strictly ascending at %d: %s then %s — a "+
+				"manager would loop (RFC 3416)",
+				i, oidString(walk[i-1]), oidString(walk[i]))
+		}
+	}
+
+	// ...AND complete. This is the assertion the old scan fails.
+	want := map[string]bool{}
+	for _, o := range staticOIDs {
+		want[oidString(o)] = true
+	}
+	for _, tbl := range []struct {
+		prefix []int
+		cols   []int
+	}{
+		{oidIfTablePrefix, ifTableColumns},
+		{oidIfXTablePrefix, ifXTableColumns},
+	} {
+		for _, col := range tbl.cols {
+			for _, iface := range unsorted {
+				o := append(append([]int(nil), tbl.prefix...), col, iface.IfIndex)
+				want[oidString(o)] = true
+			}
+		}
+	}
+	got := map[string]bool{}
+	for _, o := range walk {
+		got[oidString(o)] = true
+	}
+	var missing []string
+	for k := range want {
+		if !got[k] {
+			missing = append(missing, k)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		shown := missing
+		if len(shown) > 6 {
+			shown = shown[:6]
+		}
+		t.Fatalf("the walk SKIPPED %d of %d MIB rows given an out-of-order "+
+			"provider (e.g. %v) — ascending but incomplete, so a manager "+
+			"silently never sees those interfaces",
+			len(missing), len(want), shown)
+	}
+}
+
+// BenchmarkFindNextOIDByInterfaceCount pins per-lookup cost against interface
+// count. A regression to the linear scan shows up as cost growing with the
+// interface count instead of staying flat-ish (log).
+func BenchmarkFindNextOIDByInterfaceCount(b *testing.B) {
+	for _, n := range []int{1, 8, 64, 256} {
+		b.Run(fmt.Sprintf("ifaces=%d", n), func(b *testing.B) {
+			a := agentWithIfaces(ifDataAscending(n))
+			snap := a.newIfSnapshot()
+			_ = snap.mibOIDs() // build once, as a real PDU does
+			// The worst case for the old scan: an OID near the END of the MIB,
+			// so the linear walk traverses everything before finding it.
+			view := snap.mibOIDs()
+			probe := view[len(view)-2]
+			b.ResetTimer()
+			for range b.N {
+				if got := a.findNextOIDSnap(probe, snap); got == nil {
+					b.Fatal("no successor")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`findNextOIDSnap` resolved each GETNEXT/GETBULK successor by **linear-scanning** the MIB view — `O(static + interfaces × columns)` per lookup, multiplied by every varbind an operation emits. The agent runs on a **single serial goroutine**, so that per-lookup cost is the floor on requests/second for every operation at once, and it grows with interface count. A max-size plain GETNEXT of 239 deep `ifXTable` OIDs measured **~33 ms** while fixing #6551.

## Fix

Build the ordered MIB view once per PDU (`ifSnapshot.mibOIDs`) and binary-search it. Measured per-lookup cost on the worst-case probe (`-benchtime=2000x`):

| interfaces | linear (before) | binary (after) |
|---|---|---|
| 1 | 2,010 ns | 77 ns |
| 8 | 12,897 ns | 148 ns |
| 64 | 103,060 ns | 201 ns |
| 256 | 677,284 ns | 158 ns |

**The shape matters more than the ratio**: the old cost grows linearly with interface count, the new cost stays flat. `BenchmarkFindNextOIDByInterfaceCount` pins it so a regression to linear is visible.

## Equivalence is bound by a differential test, not spot checks

The acceptance criterion is "walk output byte-identical for a representative set of shapes". Rather than pick shapes, the pre-fix algorithm is kept as a **reference oracle**:

- `TestFindNextOIDMatchesLinearReference` — every MIB OID, each ±1 in its last sub-identifier, every bare column prefix, and the boundaries above/below each table. **2,175 probes across five interface counts**, all identical.
- `TestFullWalkMatchesLinearReference` — walks the entire MIB with both implementations; the 147-OID sequences are byte-identical.

## A correctness bug fell out, and it is worse than the performance one

The linear scan's lexicographic correctness **silently depended on `ifDataFn` returning IfIndex-ascending data**, and nothing enforces that — the production provider (`buildSNMPIfData`, `pkg/daemon/daemon_snmp_reconcile.go`) appends in netlink `LinkList` order with **no sort**.

The failure mode is the subtle part. Given an out-of-order provider the old scan still emitted **ascending** OIDs, because it returned the first candidate sorting after the cursor — but it **skipped** every interface whose index sorted below one already emitted in that column. Measured on a 4-interface out-of-order fixture:

```
the walk SKIPPED 40 of 87 MIB rows given an out-of-order provider
(e.g. 1.3.6.1.2.1.2.2.1.1.1, 1.3.6.1.2.1.2.2.1.1.2, ...)
— ascending but incomplete, so a manager silently never sees those interfaces
```

**An ascending-only assertion passes on that broken behaviour** — my first version of the test did exactly that and stayed green under the revert. Completeness is what discriminates, so the test asserts the full expected row set. `mibOIDs` sorts by IfIndex, making the walk correct regardless of provider order.

## On the mutation matrix — stated plainly

**A performance property has no black-box red**, and the differential tests pass under a linear revert *by construction*: under the revert the implementation IS the reference, so they agree trivially. That is not a weakness in them — equivalence is exactly what they exist to bind — but it means they are not the revert guard.

| Evidence | What it covers | Under linear revert |
|---|---|---|
| Benchmark | the performance property | 677 µs vs 158 ns at 256 ifaces |
| `TestUnsortedProviderWalksEveryRowInOrder` | the correctness property | **RED — 40 of 87 rows missing** |
| Differential + full-walk tests | equivalence | pass by construction (oracle == impl) |
| `TestMIBOIDViewIsSorted` | the binary search's precondition | — |

`TestMIBOIDViewIsSorted` is load-bearing rather than stylistic: `sort.Search` on an unsorted slice returns silently wrong answers, so it guards the invariant a future edit to a column list or table order could break.

## Validation

`go test ./pkg/snmp/ ./pkg/daemon/ -count=1` green.

Go control plane only — no `userspace-dp` binary or shim `.o` movement, no cluster/VRRP/session-sync code touched.

Closes #6597