### PR TITLE
test/incus: always emit the failover throughput cell (#6897)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,12 @@ make test-cos-apply-lib # Self-test the #6440 CoS-apply CLI-transcript gate:
 make test-cluster-env-lib # Self-test the cluster-env resolver (#5024): $FW0/
                      #   $FW1/$CLUSTER_LAN_HOST derive from each env's VM0/VM1/
                      #   LAN_HOST and get INCUS_REMOTE-qualified (no cluster)
+make test-iperf-throughput-lib # Self-test the #6897 iperf3 throughput parse +
+                     #   verdict used by test-failover.sh. The defect it guards
+                     #   is a MISSING CELL, not a wrong number: the old parse
+                     #   matched only "Gbits", so a sub-Gbit run matched neither
+                     #   the pass nor the fail branch and the gate emitted
+                     #   NOTHING while still summarising "0 failed". Hermetic.
 make test-newflow-ceiling-lib # Self-test the #4800 connection-rate analysis
                      #   layer (synthetic snapshot pairs -> new-flows/sec +
                      #   which contention site saturated) and the newflow-gen

--- a/Makefile
+++ b/Makefile
@@ -395,7 +395,7 @@ clean:
 # The standalone instance name defaults to xpf-fw; override it for an
 # ad-hoc/renamed VM with `XPF_INSTANCE=<name> make test-deploy` (#2162). The
 # env var flows through to setup.sh (INSTANCE_NAME=${XPF_INSTANCE:-xpf-fw}).
-.PHONY: test-env-init test-vm standalone-test-vm test-ct test-deploy test-deploy-lib test-cluster-lock-lib test-cluster-env-lib test-cos-apply-lib test-ssh test-destroy test-status test-start test-stop test-restart test-logs test-journal
+.PHONY: test-env-init test-vm standalone-test-vm test-ct test-deploy test-deploy-lib test-cluster-lock-lib test-cluster-env-lib test-iperf-throughput-lib test-cos-apply-lib test-ssh test-destroy test-status test-start test-stop test-restart test-logs test-journal
 
 test-env-init:
 	./test/incus/setup.sh init
@@ -444,6 +444,16 @@ test-cos-apply-lib:
 # Run this after touching cluster-env.sh or a cluster *.env file.
 test-cluster-env-lib:
 	bash ./test/incus/cluster-env-selftest.sh
+
+# Self-test the #6897 iperf3 throughput parse + verdict used by
+# test-failover.sh. The defect it guards is a MISSING CELL, not a wrong
+# number: the old inline parse matched only "Gbits", so a sub-Gbit run
+# matched neither the pass nor the fail branch and the gate emitted nothing
+# while still summarising "0 failed". Hermetic — sources the lib and feeds it
+# literal [SUM] lines; no incus, cluster, network or iperf3.
+# Run this after touching test-failover.sh's throughput cell.
+test-iperf-throughput-lib:
+	bash ./test/incus/iperf-throughput-selftest.sh
 
 # Self-test the #4800 new-flow-ceiling analysis layer: the function that
 # turns two helper counter snapshots into "N new flows/sec, and here is

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,44 @@
+## 2026-08-22 — #6897: the failover gate could emit no throughput cell, and had
+
+- **Timestamp**: 2026-08-22
+- **Action**: Answered the "has it already bitten us" question with data
+  instead of leaving it open. Swept every local failover log: 71 runs at
+  `14 passed, 0 failed`, one at `12 passed, 2 failed` (12+2 = 14, all cells
+  emitted), and ONE at `13 passed, 0 failed`. That odd run
+  (`jobs/22249260/tmp/failover.log`) emits 13 cells and `grep -c "iperf3
+  throughput"` returns 0 — the cell is ABSENT, not failed, and
+  `PASS iperf3 completed successfully` fired just before it, so the run looked
+  healthy to the summary. 13 assertions plus one silent absence, reported as a
+  clean green.
+  Root cause: the parse matched only `Gbits`, so a sub-Gbit `[SUM]` line set
+  the throughput to the literal `"0"` and then matched neither the pass branch
+  nor the fail branch — there was no else. Sub-Gbit is exactly what a
+  throughput regression or a CoS-shaped class looks like, so the gate went
+  silent in the case it exists to catch.
+  Fixed by extracting the parse and the verdict into
+  `test/incus/iperf-throughput-lib.sh`: the unit is normalised (K/M/G), and
+  the verdict is TOTAL — absent, unparseable, too-low and healthy each yield
+  exactly one cell. The caller maps the verdict with a catch-all default so an
+  unknown status still emits one. Demonstrated old-vs-new on the exact
+  incident input: OLD emits 0 cells, NEW emits 1 carrying the real 0.0860 Gbps.
+  Extraction was the point, not tidiness: it makes the GATE'S OWN fix testable
+  without a cluster, which is what lets this change be reviewed on its own
+  terms. New hermetic `make test-iperf-throughput-lib` (18 cells).
+  The self-test also binds the WIRING, not just the lib — deleting the call
+  from `test-failover.sh` would otherwise leave it green, which is the shape
+  that has produced repeated false confidence. Mutation M1 is exactly that
+  deletion and it reds.
+  Defect 2 of the issue (the established-session floor) is OBSOLETE: #4052
+  already added the 20 x 0.5s poll the issue asks for, and #7368 already added
+  the fw0/fw1 cross-reference that names an ownership/forwarding divergence
+  instead of blaming establishment — which is precisely the inconsistency the
+  issue observed.
+  Mutation matrix M1-M5 all RED, `bash -n` clean at every mutated state, PASS
+  cell counts compared against the control (18) rather than merely non-zero.
+- **File(s)**: `test/incus/iperf-throughput-lib.sh` (new),
+  `test/incus/iperf-throughput-selftest.sh` (new),
+  `test/incus/test-failover.sh`, `Makefile`, `CLAUDE.md`
+
 ## 2026-08-22 — #6678: device-map OriginalName= no longer falls back to the logical name
 
 - **Timestamp**: 2026-08-22

--- a/test/incus/iperf-throughput-lib.sh
+++ b/test/incus/iperf-throughput-lib.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# #6897 — parsing and verdict for the iperf3 [SUM] sender throughput cell.
+#
+# Extracted from test-failover.sh so the decision is HERMETICALLY TESTABLE.
+# The bug this exists to prevent was not a wrong number, it was NO CELL AT
+# ALL: the old inline block matched only "Gbits", so a sub-Gbit run set the
+# throughput to the literal "0" and then matched neither the pass branch nor
+# the fail branch. There was no else. The run emitted nothing for that gate
+# and still summarised as "0 failed".
+#
+# That is the failure mode the harness exists to catch, wearing the harness's
+# own clothes: iperf3 reports Mbits/sec precisely when throughput has
+# collapsed — a real regression, or a CoS-shaped class. Measured: one local
+# run summarised "13 passed, 0 failed" where every sibling run reported 14
+# cells, with the throughput cell absent rather than failed.
+#
+# Two rules follow, and both are asserted by iperf-throughput-selftest.sh:
+#   1. normalise the UNIT, so a sub-Gbit result is a measurement rather than
+#      a hole;
+#   2. the verdict is TOTAL — every input class yields exactly one cell,
+#      including "no [SUM] line" and "unparseable".
+
+# iperf_sum_rate_gbps <sum_line>
+#   Print the [SUM] sender rate in Gbits/sec, or nothing if the line carries
+#   no recognisable "<number> <K|M|G>bits/sec" pair.
+#
+#   iperf3 chooses the unit by magnitude, so all three must be accepted. The
+#   rate and its unit are ADJACENT fields, which is what makes this parseable
+#   without depending on column positions that differ between iperf3 versions
+#   and between the interval and summary lines.
+iperf_sum_rate_gbps() {
+	local line="$1"
+	[[ -n "$line" ]] || return 0
+	awk '{
+		for (i = 2; i <= NF; i++) {
+			if ($i ~ /^[KMG]bits\/sec$/ && $(i-1) ~ /^[0-9]+(\.[0-9]+)?$/) {
+				unit = substr($i, 1, 1)
+				val = $(i-1) + 0
+				if (unit == "G") { printf "%.4f", val }
+				else if (unit == "M") { printf "%.4f", val / 1000 }
+				else { printf "%.6f", val / 1000000 }
+				exit
+			}
+		}
+	}' <<<"$line"
+}
+
+# iperf_throughput_verdict <min_gbps> <sum_line>
+#   Print exactly one verdict line: "PASS <message>" or "FAIL <message>".
+#
+#   TOTAL BY CONSTRUCTION — every path prints. That totality is the fix; the
+#   normalisation above only decides which branch is taken. A caller must map
+#   the verdict onto its own pass/fail counters with a catch-all default, so a
+#   future unhandled status still emits a cell.
+iperf_throughput_verdict() {
+	local min="$1" line="$2" gbps
+	if [[ -z "$line" ]]; then
+		printf 'FAIL %s\n' "iperf3 throughput: no [SUM] sender line in the iperf3 log — the run produced no measurement at all"
+		return 0
+	fi
+	gbps="$(iperf_sum_rate_gbps "$line")"
+	if [[ -z "$gbps" ]]; then
+		printf 'FAIL %s\n' "iperf3 throughput unparseable — no '<rate> <K|M|G>bits/sec' pair in the [SUM] sender line: ${line}"
+		return 0
+	fi
+	if awk "BEGIN{exit !($gbps >= $min)}"; then
+		printf 'PASS %s\n' "iperf3 throughput: ${gbps} Gbps (>= ${min} Gbps)"
+	else
+		printf 'FAIL %s\n' "iperf3 throughput too low: ${gbps} Gbps (expected >= ${min} Gbps) — [SUM] line: ${line}"
+	fi
+}

--- a/test/incus/iperf-throughput-selftest.sh
+++ b/test/incus/iperf-throughput-selftest.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# #6897 — self-test for test/incus/iperf-throughput-lib.sh.
+#
+# The defect this guards is a MISSING CELL, not a wrong number, so the
+# load-bearing assertion is TOTALITY: every input class must yield exactly
+# one verdict. A test that only checked the arithmetic would have passed
+# against the buggy version, because the buggy version's arithmetic was fine
+# for the one unit it recognised.
+#
+# Hermetic — sources the lib and feeds it literal [SUM] lines. No incus, no
+# cluster, no network, no iperf3.
+#
+# Usage: ./test/incus/iperf-throughput-selftest.sh   (rc 0 = all pass)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="${SCRIPT_DIR}/iperf-throughput-lib.sh"
+[[ -f "$LIB" ]] || { echo "FAIL: lib not found at $LIB" >&2; exit 1; }
+# shellcheck source=/dev/null
+source "$LIB"
+
+PASS=0
+ok()   { PASS=$((PASS + 1)); echo "PASS ($PASS): $*"; }
+bad()  { echo "FAIL: $*" >&2; exit 1; }
+
+# --- unit normalisation -------------------------------------------------
+# Real [SUM] sender lines. The Mbits row is the #6897 case: the old parser
+# matched only "Gbits" and silently produced no cell for it.
+check_rate() { # <desc> <expected> <line>
+	local got; got="$(iperf_sum_rate_gbps "$3")"
+	[[ "$got" == "$2" ]] || bad "$1: want $2 Gbps, got '${got:-<empty>}' from: $3"
+	ok "$1 -> $got Gbps"
+}
+check_rate "Gbits normalises"  "22.9000"  '[SUM]   0.00-120.00  sec   320 GBytes  22.9 Gbits/sec   12  sender'
+check_rate "Mbits normalises"  "0.0860"   '[SUM]   0.00-120.00  sec  1.20 GBytes   86.0 Mbits/sec   0   sender'
+check_rate "Kbits normalises"  "0.000500" '[SUM]   0.00-10.00   sec  0.00 GBytes  500 Kbits/sec    0   sender'
+check_rate "integer rate"      "10.0000"  '[SUM]   0.00-10.00   sec   12 GBytes    10 Gbits/sec    0   sender'
+
+got="$(iperf_sum_rate_gbps '[SUM]   0.00-120.00  sec  no rate here  sender')"
+[[ -z "$got" ]] || bad "a line with no rate/unit pair must yield nothing, got '$got'"
+ok "unrecognised line yields no rate"
+
+got="$(iperf_sum_rate_gbps '')"
+[[ -z "$got" ]] || bad "an empty line must yield nothing, got '$got'"
+ok "empty line yields no rate"
+
+# --- TOTALITY: every input class emits exactly one verdict ---------------
+# This is the #6897 regression guard. Under the pre-fix logic the Mbits row
+# and the unparseable row emitted NOTHING.
+check_verdict() { # <desc> <want-status> <min> <line>
+	local out status n
+	out="$(iperf_throughput_verdict "$3" "$4")"
+	n="$(printf '%s\n' "$out" | grep -c .)"
+	[[ "$n" == "1" ]] || bad "$1: want exactly ONE verdict line, got $n:
+$out"
+	status="${out%% *}"
+	[[ "$status" == "$2" ]] || bad "$1: want $2, got $status ($out)"
+	ok "$1 -> $status"
+}
+check_verdict "healthy Gbits run passes"      PASS 5 '[SUM] 0.00-120.00 sec 320 GBytes 22.9 Gbits/sec 12 sender'
+check_verdict "sub-Gbit run FAILS not silent" FAIL 5 '[SUM] 0.00-120.00 sec 1.20 GBytes 86.0 Mbits/sec 0 sender'
+check_verdict "Gbits below the floor fails"   FAIL 5 '[SUM] 0.00-120.00 sec 40 GBytes 2.5 Gbits/sec 0 sender'
+check_verdict "exactly at the floor passes"   PASS 5 '[SUM] 0.00-120.00 sec 70 GBytes 5.0 Gbits/sec 0 sender'
+check_verdict "unparseable line FAILS"        FAIL 5 '[SUM] 0.00-120.00 sec garbage sender'
+check_verdict "absent [SUM] line FAILS"       FAIL 5 ''
+
+# A sub-Gbit result must be reported with its REAL value, not as "0" and not
+# as an absence — the number is what tells an operator how far it fell.
+out="$(iperf_throughput_verdict 5 '[SUM] 0.00-120.00 sec 1.20 GBytes 86.0 Mbits/sec 0 sender')"
+[[ "$out" == *"0.0860 Gbps"* ]] || bad "a sub-Gbit verdict must carry the normalised value, got: $out"
+ok "sub-Gbit verdict carries its measured value"
+
+# The absent-line and unparseable verdicts must be DISTINGUISHABLE, so a
+# reader can tell "iperf3 produced nothing" from "iperf3 produced something
+# this parser did not understand" — different causes, different next step.
+a="$(iperf_throughput_verdict 5 '')"
+b="$(iperf_throughput_verdict 5 '[SUM] garbage')"
+[[ "$a" != "$b" ]] || bad "absent and unparseable must not render identically"
+[[ "$a" == *"no measurement at all"* ]] || bad "absent verdict must say so, got: $a"
+[[ "$b" == *"unparseable"* ]] || bad "unparseable verdict must say so, got: $b"
+ok "absent and unparseable verdicts are distinguishable"
+
+# --- WIRING: the lib must actually be reached from test-failover.sh --------
+# Binding the lib alone would leave a green if someone deleted the CALL from
+# the production path — the shape that has repeatedly produced false
+# confidence. A behavioural probe of test-failover.sh needs a cluster, so this
+# is a structural guard on the one caller, and it is deliberately narrow:
+# it asserts the wiring exists, not that the surrounding logic is correct.
+FAILOVER="${SCRIPT_DIR}/test-failover.sh"
+[[ -f "$FAILOVER" ]] || bad "test-failover.sh not found at $FAILOVER"
+
+grep -q 'source "${SCRIPT_DIR}/iperf-throughput-lib.sh"' "$FAILOVER" \
+	|| bad "test-failover.sh does not source iperf-throughput-lib.sh"
+ok "test-failover.sh sources the lib"
+
+grep -q 'iperf_throughput_verdict "$MIN_THROUGHPUT" "$sum_line"' "$FAILOVER" \
+	|| bad "test-failover.sh does not call iperf_throughput_verdict — the cell would go silent again"
+ok "test-failover.sh calls iperf_throughput_verdict"
+
+# The catch-all is what makes the caller total. Without it an unknown status
+# falls through the case and emits nothing — reintroducing #6897 one level up.
+awk '/^throughput_verdict=/,/^esac$/' "$FAILOVER" | grep -qE '^\*\)[[:space:]]+fail ' \
+	|| bad "the throughput verdict case has no catch-all '*) fail' — an unhandled status would emit no cell"
+ok "the verdict case has a catch-all that fails loudly"
+
+# The old Gbits-only parse must be gone; if it comes back it silently
+# reintroduces the literal "0" that matched neither branch.
+if grep -q "grep -oP '\[\\d.\]+\\s+Gbits'" "$FAILOVER"; then
+	bad "the Gbits-only inline parse is back in test-failover.sh"
+fi
+ok "the Gbits-only inline parse is gone"
+
+echo
+echo "iperf-throughput-lib self-test: $PASS passed"

--- a/test/incus/test-failover.sh
+++ b/test/incus/test-failover.sh
@@ -37,6 +37,8 @@ source "${SCRIPT_DIR}/cluster-env.sh"
 # `make test-deploy-lib` against a mocked incus.
 # shellcheck source=test/incus/deploy-lib.sh
 source "${SCRIPT_DIR}/deploy-lib.sh"
+# shellcheck source=test/incus/iperf-throughput-lib.sh
+source "${SCRIPT_DIR}/iperf-throughput-lib.sh"
 
 IPERF_TARGET="${IPERF_TARGET:-$IPERF_TARGET4}"
 IPERF_DURATION=120      # seconds — long enough to span retries + reboot + failback
@@ -391,8 +393,16 @@ done
 # streams survived — this produces "control socket has closed unexpectedly"
 # instead of "iperf Done". Accept either outcome as long as the sender
 # [SUM] line shows adequate throughput.
-throughput=$(incus exec "$CLUSTER_LAN_HOST" -- grep '\[SUM\].*sender' /tmp/iperf3-failover.log 2>/dev/null \
-	| grep -oP '[\d.]+\s+Gbits' | grep -oP '[\d.]+' || echo "0")
+# #6897: capture the whole [SUM] sender line and let the lib parse it. The
+# previous inline parse matched only "Gbits", so a sub-Gbit run yielded the
+# literal "0" and then matched NEITHER the pass branch nor the fail branch —
+# there was no else, and the run emitted no throughput cell at all while still
+# summarising as "0 failed". Sub-Gbit is exactly what a throughput regression
+# or a CoS-shaped class looks like, so the gate went silent in the case it
+# exists to catch.
+sum_line=$(incus exec "$CLUSTER_LAN_HOST" -- grep '\[SUM\].*sender' /tmp/iperf3-failover.log 2>/dev/null \
+	| tail -1 || true)
+throughput=$(iperf_sum_rate_gbps "$sum_line")
 
 if incus exec "$CLUSTER_LAN_HOST" -- grep -q "iperf Done" /tmp/iperf3-failover.log 2>/dev/null; then
 	pass "iperf3 completed successfully"
@@ -403,11 +413,16 @@ else
 	fail "iperf3 did not complete: $iperf_log"
 fi
 
-if [[ -n "$throughput" ]] && awk "BEGIN{exit !($throughput >= $MIN_THROUGHPUT)}"; then
-	pass "iperf3 throughput: ${throughput} Gbps (>= ${MIN_THROUGHPUT} Gbps)"
-elif [[ -n "$throughput" ]] && [[ "$throughput" != "0" ]]; then
-	fail "iperf3 throughput too low: ${throughput} Gbps (expected >= ${MIN_THROUGHPUT} Gbps)"
-fi
+# The verdict is total: absent, unparseable, too-low and healthy each yield
+# exactly one cell. The catch-all default keeps that true even if the lib ever
+# grows a status this caller does not know about — a missing cell is the
+# defect, so no path may end without emitting one.
+throughput_verdict=$(iperf_throughput_verdict "$MIN_THROUGHPUT" "$sum_line")
+case "$throughput_verdict" in
+PASS\ *) pass "${throughput_verdict#PASS }" ;;
+FAIL\ *) fail "${throughput_verdict#FAIL }" ;;
+*)       fail "iperf3 throughput: unrecognised verdict from iperf_throughput_verdict: ${throughput_verdict}" ;;
+esac
 
 # ── Results ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
`test-failover.sh` could finish a run without emitting its iperf3 throughput cell at all — not a pass, not a fail, nothing — and still summarise as `0 failed`.

## It has already happened

Swept every local failover log:

```
71 x  Failover test: 14 passed, 0 failed
 1 x  Failover test: 12 passed, 2 failed   <-- 12+2 = 14, every cell emitted
 1 x  Failover test: 13 passed, 0 failed   <-- one cell short, ZERO failures
```

The odd run is `jobs/22249260/tmp/failover.log`. Verified directly rather than inferred from the arithmetic:

- cells emitted: **13** (normal runs emit 14)
- `grep -c "iperf3 throughput"`: **0** — the cell is **absent**, not failed
- `PASS iperf3 completed successfully` fired immediately before it, so the run looked healthy right through to the summary

**13 assertions plus one silent absence, reported as a clean green.** The discriminator for auditing any other run is free: a summary whose passed+failed total is 13 rather than 14 had this cell swallowed.

## Cause

The parse matched only `Gbits`, so a `[SUM] … sender` line reported in `Mbits/sec` set `throughput` to the literal `"0"` — which satisfied neither the pass branch nor the too-low branch. **There was no else.**

iperf3 switches to Mbits precisely when throughput has collapsed — a real regression, or a CoS-shaped class. So the gate fell silent in exactly the case it exists to catch.

## Fix

The parse and verdict move to `test/incus/iperf-throughput-lib.sh`:

- the unit is **normalised** across Kbits/Mbits/Gbits, so a sub-Gbit result is a measurement rather than a hole;
- the verdict is **total** — absent `[SUM]` line, unparseable line, below-floor and healthy each yield exactly one cell;
- absent and unparseable are worded differently, because they have different causes and different next steps;
- the caller maps the verdict through a `case` with a **catch-all default**, so an unrecognised status still emits a cell instead of falling through.

Behaviour on the exact input from the recorded incident:

| | cells emitted |
|---|---|
| old block, `86.0 Mbits/sec` | **0** |
| new block, same line | **1** — `FAIL … 0.0860 Gbps (expected >= 5 Gbps)` |
| new block, healthy `22.9 Gbits/sec` | **1** — `PASS` |

## Why extract rather than patch inline

Because this change modifies **the gate itself**, a green produced by the modified harness is not evidence about the gate. Extracting the decision makes it verifiable **without a cluster**, so the change can be reviewed on its own terms.

`make test-iperf-throughput-lib` is hermetic — no incus, cluster, network or iperf3 — and carries 18 cells. It follows the existing `test-cluster-env-lib` / `test-deploy-lib` convention (a separate make target; `test/incus` self-tests are deliberately not in `run-selftests.sh`).

**The self-test binds the wiring, not only the library.** Binding the library alone would stay green if someone deleted the call from `test-failover.sh` — the shape that keeps producing false confidence. Mutation M1 is that exact deletion and it reds. The wiring guards are structural (a behavioural probe of `test-failover.sh` needs a cluster), and that limit is stated in the file.

## The issue's second defect is obsolete

#6897 also reports the established-session floor failing on master. Both fixes it asks for have since landed:

- *"poll with a timeout rather than sample once"* → **#4052** added the 20 × 0.5s poll that breaks early (`test-failover.sh:198-204`).
- *"print what it actually counted so a failure is diagnosable"* → **#7368** added the fw0/fw1 cross-reference, which reports an **ownership/forwarding divergence** rather than attributing it to establishment — precisely the inconsistency the issue observed between fw0's count and fw1's synced count.

No change made for it.

## Validation

| mutation | `bash -n` | result |
|---|---|---|
| **delete the call from `test-failover.sh`** | 0 | **RED** — `does not call iperf_throughput_verdict` |
| remove the caller's catch-all | 0 | **RED** — `no catch-all '*) fail'` |
| revert the parse to Gbits-only | 0 | **RED** — `Mbits normalises: want 0.0860, got <empty>` |
| drop the unparseable verdict | 0 | **RED** — totality: `want exactly ONE verdict line, got 0` |
| absent and unparseable render identically | 0 | **RED** — `absent verdict must say so` |

PASS cell counts were compared against the control (18) rather than merely checked non-zero. `shellcheck -S warning` clean on both new files; the one warning in `test-failover.sh` is pre-existing at `origin/master` (verified against the base file). `make selftest` unaffected: 61 passed, 0 failed.

**No cluster was touched.** Kept separate from the `pkg/networkd` cohort per instruction.

Closes #6897

## The hit rate is not the risk profile

The sweep found **one occurrence in 73 recorded runs** — the swallowed run is `jobs/22249260/tmp/failover.log`, mtime **2026-07-23 05:25**, in a different session's job directory. An audit of the nine gate logs from the current session found all seven *completed* failover runs at `pass=14` with the cell present (the two zero-pass files were an `FO_RC=2` preflight death that was re-run, and the wg-interop harness, which is a different script). **No recent merge rests on a swallowed cell.**

That ~1.4% background rate makes the defect *more* dangerous rather than less, for two reasons.

**A rare defect that produces a clean green is worse than a frequent one**, because the base rate is low enough that nobody suspects the instrument. There is no accumulating signal to notice.

**And the rate is conditional in the worst possible direction.** The cell is swallowed only when the `[SUM] … sender` line reports sub-Gbit, which is uncommon on this cluster precisely because it normally runs at ~22 Gbps. But sub-Gbit is *what a throughput regression looks like*. So the gate's probability of going silent is lowest when everything is healthy and **approaches certainty exactly when the condition it exists to detect is present**. A 1-in-73 background rate is not the number that matters; the conditional rate is.

That is the difference between "a rare flake" and "an instrument that fails toward reassurance under load" — the same shape as the other fail-to-a-healthy-looking-value defects this campaign has been finding, applied to the gate itself.

## Auditing other runs

The discriminator is free and needs no re-derivation: **a failover summary whose `passed` + `failed` total is 13 rather than 14 had the throughput cell swallowed.** A run that emitted it totals 14 either way — `14 passed, 0 failed` or `12 passed, 2 failed` both sum to 14.
