### PR TITLE
snmp: binary-search the successor instead of scanning the MIB

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -102792,3 +102792,11 @@ prose edit above them added. No diff falls in the new test body.
   the CLEAR half was live.
 - **File(s)**: pkg/dataplane/userspace/legacy_dataplane.go,
   pkg/dataplane/userspace/clear_policy_counters_6566_test.go (new), _Log.md
+
+- **Timestamp**: 2026-08-22
+  - **Action**: #6597 — replaced the linear MIB successor scan with a binary
+    search over a virtual sorted array, and made getIfData's long-documented
+    but never-enforced ifIndex sort real (the binary search depends on it).
+    Full walk at 512 interfaces: 6.32s -> 21.7ms.
+  - **File(s)**: pkg/snmp/agent.go, pkg/snmp/successor_lookup_6597_test.go,
+    pkg/snmp/README.md

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -563,9 +563,45 @@ packet handlers, and MIB view that call into them.
   yields at least two components, so a varbind built from a wire OID re-encodes
   to at least seven bytes and the six-byte `minVarbindEncodedBytes` floor used
   for the structural cap is conservative rather than reachable. A max-size
-  GETNEXT (239 deep ifXTable OIDs) costs ~33 ms and returns all 239 varbinds in
-  a full 4095-byte response; that cost is `findNextOIDSnap` being a linear MIB
-  scan, not unbounded expansion, and is not addressed here.
+  GETNEXT (239 deep ifXTable OIDs) cost ~33 ms and returned all 239 varbinds in
+  a full 4095-byte response; that cost was `findNextOIDSnap` being a linear MIB
+  scan, not unbounded expansion. It was scoped out of #6551 and fixed
+  separately in #6597 (next bullet).
+- **The successor lookup is a binary search over a virtual sorted array
+  (#6597).** `findNextOIDSnap` used to resolve each lexicographic successor by
+  scanning the MIB from the top, so a lookup cost O(static + 20*interfaces) and
+  a full walk was QUADRATIC in the number of served OIDs. Because
+  `buildSNMPIfData` enumerates every kernel link except `lo`, the interface
+  count is driven by configuration — VLAN subinterfaces, GRE tunnels, and one
+  XFRM interface per IPsec tunnel — so it is not small on a real firewall, and
+  the agent runs on a single serial goroutine that every other operation shares.
+  Measured full walk, before -> after: 64 interfaces 145 ms -> 2.3 ms,
+  256 interfaces 1.54 s -> 9.4 ms, 512 interfaces 6.32 s -> 21.7 ms.
+  `nextTableOID` treats each `<prefix>.<col>.<ifIndex>` region as a VIRTUAL
+  sorted array — entry `p` is `cols[p/len(ifaces)]` and
+  `ifaces[p%len(ifaces)].IfIndex`, which enumerates it column-major, exactly
+  lexicographic order — and binary-searches it, building only the O(log n)
+  candidates it probes. It is deliberately not materialised: a one-varbind
+  GETNEXT near the top of the tree costs O(1), and building `20*interfaces`
+  OIDs to answer it would move the cost rather than remove it. The answers are
+  unchanged, pinned by `TestFindNextOIDSnapMatchesLinearScan_6597` and
+  `TestWalkSequenceUnchanged_6597`, which keep the pre-#6597 linear scan
+  verbatim as an equivalence oracle. The regression guard,
+  `TestSuccessorLookupIsNotLinear_6597`, counts allocations rather than elapsed
+  time — every candidate examined is one allocation, so the count IS the number
+  of MIB entries visited (24 versus ~5,632 linear at 512 interfaces), which is
+  deterministic where a timing assertion would be flaky.
+- **`getIfData` sorts by ifIndex, and that is load-bearing (#6597).** It had
+  always DOCUMENTED that it returns sorted data while nothing sorted:
+  `buildSNMPIfData` returns links in raw `netlink.LinkList` (RTM_GETLINK dump)
+  order, which the kernel does not promise is ifIndex-ordered. Ascending
+  ifIndex is what makes the column-major enumeration lexicographic; unsorted,
+  the walk emits varbinds that go backwards and an RFC 3416 manager loops or
+  stops early. The binary search raises the stakes — over an unsorted array it
+  returns an arbitrary entry, not merely a mis-ordered one — so the contract is
+  now enforced instead of assumed. Already-sorted input, the normal case, costs
+  one scan and no allocation; only out-of-order data is cloned, so the
+  callback's slice is never reordered underneath it.
 - **GETBULK varbind order is repetition-major (RFC 3416 §4.2.3, #5065).** For
   `R` repeater columns and `M` repetitions the response interleaves by
   repetition — `rep0-col0, rep0-col1, …, rep1-col0, …` (varbind index

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -10,6 +10,8 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -668,7 +670,44 @@ func (a *Agent) getIfData() []IfData {
 	if a.ifDataFn == nil {
 		return nil
 	}
-	return a.ifDataFn()
+	data := a.ifDataFn()
+	// This function has always DOCUMENTED that it returns sorted interface
+	// data, but nothing ever sorted: buildSNMPIfData hands back links in raw
+	// netlink.LinkList (RTM_GETLINK dump) order, which the kernel does not
+	// promise is ifIndex-ordered. Ascending IfIndex is load-bearing for the
+	// GETNEXT/GETBULK walk -- the successor search enumerates
+	// <prefix>.<col>.<ifIndex> column-major and takes the first entry greater
+	// than the requested OID, which is the lexicographic successor only if
+	// ifIndex ascends. Out of order, the walk emits varbinds that go backwards,
+	// and RFC 3416 managers respond to that by looping or stopping early.
+	//
+	// #6597 makes the contract real rather than assumed, because the successor
+	// search is now a binary search (nextTableOID) and a binary search over an
+	// unsorted array does not merely emit a mis-ordered answer, it emits an
+	// arbitrary one.
+	//
+	// The already-sorted case is the norm and costs one scan and no allocation;
+	// only genuinely out-of-order data is copied, so the callback's slice is
+	// never mutated underneath it.
+	if slices.IsSortedFunc(data, compareIfIndex) {
+		return data
+	}
+	sorted := slices.Clone(data)
+	slices.SortStableFunc(sorted, compareIfIndex)
+	return sorted
+}
+
+// compareIfIndex orders interface rows by ascending IfIndex, the order the
+// ifTable/ifXTable OID space is enumerated in.
+func compareIfIndex(x, y IfData) int {
+	switch {
+	case x.IfIndex < y.IfIndex:
+		return -1
+	case x.IfIndex > y.IfIndex:
+		return 1
+	default:
+		return 0
+	}
 }
 
 // ifSnapshot memoizes a single interface-table read for the lifetime of ONE
@@ -1669,32 +1708,51 @@ func (a *Agent) findNextOIDSnap(oid []int, snap *ifSnapshot) []int {
 		return nil
 	}
 
-	// Build sorted list of all ifTable OIDs.
-	for _, col := range ifTableColumns {
-		for _, iface := range ifaces {
-			candidate := make([]int, len(oidIfTablePrefix)+2)
-			copy(candidate, oidIfTablePrefix)
-			candidate[len(oidIfTablePrefix)] = col
-			candidate[len(oidIfTablePrefix)+1] = iface.IfIndex
-			if oidCompare(candidate, oid) > 0 {
-				return candidate
-			}
-		}
+	// ifTable OIDs: 1.3.6.1.2.1.2.2.1.<col>.<ifIndex>, then ifXTable OIDs:
+	// 1.3.6.1.2.1.31.1.1.1.<col>.<ifIndex>. Every ifTable OID sorts below every
+	// ifXTable OID (2 < 31 at the differing arc), so the first region to yield a
+	// successor holds the answer.
+	if next := nextTableOID(oidIfTablePrefix, ifTableColumns, ifaces, oid); next != nil {
+		return next
 	}
+	return nextTableOID(oidIfXTablePrefix, ifXTableColumns, ifaces, oid)
+}
 
-	// Walk ifXTable OIDs: 1.3.6.1.2.1.31.1.1.1.<col>.<ifIndex>
-	for _, col := range ifXTableColumns {
-		for _, iface := range ifaces {
-			candidate := make([]int, len(oidIfXTablePrefix)+2)
-			copy(candidate, oidIfXTablePrefix)
-			candidate[len(oidIfXTablePrefix)] = col
-			candidate[len(oidIfXTablePrefix)+1] = iface.IfIndex
-			if oidCompare(candidate, oid) > 0 {
-				return candidate
-			}
-		}
+// nextTableOID returns the smallest OID in a <prefix>.<col>.<ifIndex> table
+// region that is strictly greater than oid, or nil if the region holds none.
+//
+// The region is a VIRTUAL sorted array rather than a materialised one: entry p
+// denotes cols[p/len(ifaces)] and ifaces[p%len(ifaces)].IfIndex, which
+// enumerates the region column-major -- exactly the lexicographic order of the
+// OIDs it denotes, given that cols ascends (both column lists are declared
+// sorted) and IfIndex ascends (getIfData now guarantees it).
+//
+// Because that order is ascending, "entry p is greater than oid" is monotone in
+// p: false over a prefix of the region and true over the rest. So the first p
+// satisfying it -- precisely the entry the pre-#6597 linear scan returned -- is
+// a binary search, and only O(log n) candidates are built instead of O(n).
+//
+// The virtual array matters as much as the search. Materialising the region
+// would move the cost rather than remove it: a one-varbind GETNEXT near the top
+// of the tree pays O(1) today, and building 20*len(ifaces) OIDs to answer it
+// would be a regression for the most common poll shape there is.
+func nextTableOID(prefix, cols []int, ifaces []IfData, oid []int) []int {
+	n := len(cols) * len(ifaces)
+	if n == 0 {
+		return nil
 	}
-	return nil
+	at := func(p int) []int {
+		candidate := make([]int, len(prefix)+2)
+		copy(candidate, prefix)
+		candidate[len(prefix)] = cols[p/len(ifaces)]
+		candidate[len(prefix)+1] = ifaces[p%len(ifaces)].IfIndex
+		return candidate
+	}
+	p := sort.Search(n, func(p int) bool { return oidCompare(at(p), oid) > 0 })
+	if p == n {
+		return nil
+	}
+	return at(p)
 }
 
 // varbind holds a single OID-value binding.

--- a/pkg/snmp/successor_lookup_6597_test.go
+++ b/pkg/snmp/successor_lookup_6597_test.go
@@ -1,0 +1,314 @@
+package snmp
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// #6597: findNextOIDSnap resolved each lexicographic successor by scanning the
+// whole MIB, so a walk was quadratic in the number of served OIDs (static +
+// 20*interfaces). It is now a binary search over a virtual sorted array.
+//
+// This is a PERFORMANCE change, so the tests here are in two halves: one half
+// proves the answers did not move, the other proves the cost did.
+
+// ifacesFor6597 returns n interfaces with ascending IfIndex, the shape
+// getIfData guarantees.
+// oidStr6597 renders an OID for comparison and failure messages. nil (no
+// successor) renders distinctly from the empty OID so the two cannot be
+// confused in an equality check.
+func oidStr6597(oid []int) string {
+	if oid == nil {
+		return "<none>"
+	}
+	parts := make([]string, len(oid))
+	for i, v := range oid {
+		parts[i] = strconv.Itoa(v)
+	}
+	return strings.Join(parts, ".")
+}
+
+func ifacesFor6597(n int) []IfData {
+	out := make([]IfData, n)
+	for i := range out {
+		out[i] = IfData{
+			IfIndex: i + 1,
+			IfDescr: fmt.Sprintf("ge-0-0-%d", i),
+			IfName:  fmt.Sprintf("ge-0-0-%d", i),
+			IfType:  6, IfMtu: 1500, IfSpeed: 1_000_000_000,
+			AdminStatus: 1, OperStatus: 1, IfHighSpeed: 1000,
+		}
+	}
+	return out
+}
+
+func agentFor6597(ifaces []IfData) *Agent {
+	a := &Agent{}
+	a.ifDataFn = func() []IfData { return ifaces }
+	return a
+}
+
+// findNextOIDLinear6597 is the pre-#6597 implementation, preserved VERBATIM as
+// the equivalence oracle. If the binary search and this disagree on any OID,
+// the optimisation changed an answer and the change is wrong.
+func findNextOIDLinear6597(oid []int, ifaces []IfData) []int {
+	for _, candidate := range staticOIDs {
+		if oidCompare(candidate, oid) > 0 {
+			return candidate
+		}
+	}
+	if len(ifaces) == 0 {
+		return nil
+	}
+	for _, col := range ifTableColumns {
+		for _, iface := range ifaces {
+			candidate := make([]int, len(oidIfTablePrefix)+2)
+			copy(candidate, oidIfTablePrefix)
+			candidate[len(oidIfTablePrefix)] = col
+			candidate[len(oidIfTablePrefix)+1] = iface.IfIndex
+			if oidCompare(candidate, oid) > 0 {
+				return candidate
+			}
+		}
+	}
+	for _, col := range ifXTableColumns {
+		for _, iface := range ifaces {
+			candidate := make([]int, len(oidIfXTablePrefix)+2)
+			copy(candidate, oidIfXTablePrefix)
+			candidate[len(oidIfXTablePrefix)] = col
+			candidate[len(oidIfXTablePrefix)+1] = iface.IfIndex
+			if oidCompare(candidate, oid) > 0 {
+				return candidate
+			}
+		}
+	}
+	return nil
+}
+
+// probeOIDs6597 returns the OIDs to compare the two implementations over: every
+// OID an actual walk visits, plus off-tree probes a manager can legitimately
+// send -- truncated prefixes, unserved columns, out-of-range ifIndexes, and
+// OIDs longer than any entry (a manager resuming from a leaf it appended to).
+func probeOIDs6597(ifaces []IfData) [][]int {
+	probes := [][]int{
+		{1}, {1, 3}, {1, 3, 6, 1},
+		{1, 3, 6, 1, 2, 1, 1},
+		{1, 3, 6, 1, 2, 1, 2},
+		{1, 3, 6, 1, 2, 1, 2, 2},
+		{1, 3, 6, 1, 2, 1, 2, 2, 1},
+		{1, 3, 6, 1, 2, 1, 31},
+		{1, 3, 6, 1, 2, 1, 31, 1, 1, 1},
+		{1, 3, 6, 1, 2, 1, 99},
+		{1, 3, 6, 1, 4, 1, 1},
+		{2},
+	}
+	// Unserved columns: 6 and 9 are absent from ifTableColumns, 8 and 9 from
+	// ifXTableColumns. A GETNEXT landing on a hole must skip to the next
+	// served column, and the two implementations must agree on where.
+	for _, col := range []int{0, 6, 9, 16, 17, 99} {
+		probes = append(probes,
+			append(append([]int{}, oidIfTablePrefix...), col),
+			append(append([]int{}, oidIfXTablePrefix...), col))
+	}
+	// Every real entry, plus each entry's neighbours in index space.
+	for _, spec := range []struct {
+		prefix []int
+		cols   []int
+	}{{oidIfTablePrefix, ifTableColumns}, {oidIfXTablePrefix, ifXTableColumns}} {
+		for _, col := range spec.cols {
+			for _, idx := range []int{0, 1, len(ifaces), len(ifaces) + 1, 1 << 20} {
+				probes = append(probes,
+					append(append([]int{}, spec.prefix...), col, idx),
+					append(append([]int{}, spec.prefix...), col, idx, 0))
+			}
+			for _, iface := range ifaces {
+				probes = append(probes,
+					append(append([]int{}, spec.prefix...), col, iface.IfIndex))
+			}
+		}
+	}
+	for _, static := range staticOIDs {
+		probes = append(probes, static, append(append([]int{}, static...), 0))
+	}
+	return probes
+}
+
+func TestFindNextOIDSnapMatchesLinearScan_6597(t *testing.T) {
+	for _, n := range []int{0, 1, 2, 3, 8, 17} {
+		t.Run(fmt.Sprintf("ifaces=%d", n), func(t *testing.T) {
+			ifaces := ifacesFor6597(n)
+			a := agentFor6597(ifaces)
+			probes := probeOIDs6597(ifaces)
+			if len(probes) == 0 {
+				t.Fatal("probe set is empty; the comparison would be vacuous")
+			}
+			for _, probe := range probes {
+				got := a.findNextOIDSnap(probe, a.newIfSnapshot())
+				want := findNextOIDLinear6597(probe, ifaces)
+				if oidStr6597(got) != oidStr6597(want) {
+					t.Errorf("findNextOIDSnap(%s): got %s, pre-#6597 linear scan returned %s",
+						oidStr6597(probe), oidStr6597(got), oidStr6597(want))
+				}
+			}
+		})
+	}
+}
+
+// TestWalkSequenceUnchanged_6597 compares the WALK, not just single lookups: a
+// per-probe agreement could still permit a different traversal if the successor
+// relation were subtly non-transitive.
+func TestWalkSequenceUnchanged_6597(t *testing.T) {
+	for _, n := range []int{1, 5, 12} {
+		ifaces := ifacesFor6597(n)
+		a := agentFor6597(ifaces)
+		snap := a.newIfSnapshot()
+
+		var got, want []string
+		for cur := []int{1}; ; {
+			nxt := a.findNextOIDSnap(cur, snap)
+			if nxt == nil {
+				break
+			}
+			got = append(got, oidStr6597(nxt))
+			cur = nxt
+		}
+		for cur := []int{1}; ; {
+			nxt := findNextOIDLinear6597(cur, ifaces)
+			if nxt == nil {
+				break
+			}
+			want = append(want, oidStr6597(nxt))
+			cur = nxt
+		}
+		if wantLen := len(staticOIDs) + n*(len(ifTableColumns)+len(ifXTableColumns)); len(want) != wantLen {
+			t.Fatalf("oracle walk visited %d OIDs, expected %d — the walk is not covering the MIB",
+				len(want), wantLen)
+		}
+		if len(got) != len(want) {
+			t.Fatalf("ifaces=%d: walk length %d, pre-#6597 walk length %d", n, len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("ifaces=%d: walk diverges at %d: got %s, want %s", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestSuccessorLookupIsNotLinear_6597 is the regression guard the issue asks
+// for. It is deliberately NOT a timing assertion: it counts the allocations a
+// worst-case lookup performs, which is deterministic and CI-stable.
+//
+// Every candidate OID the search examines is one allocation, so the count IS
+// the number of MIB entries examined. Linear scans ~11*N candidates to reach
+// the last ifXTable column; a binary search examines ~log2(11*N). At N=512 that
+// is ~5600 versus ~14, so the two regimes are three orders of magnitude apart
+// and no threshold in between is delicate.
+func TestSuccessorLookupIsNotLinear_6597(t *testing.T) {
+	const n = 512
+	ifaces := ifacesFor6597(n)
+	a := agentFor6597(ifaces)
+	snap := a.newIfSnapshot()
+	snap.get() // fault in the interface list so it is not charged to the lookup
+
+	// The last served ifXTable column, last interface: the deepest OID in the
+	// MIB, which a linear scan reaches only by examining every entry before it.
+	deepest := append(append([]int{}, oidIfXTablePrefix...),
+		ifXTableColumns[len(ifXTableColumns)-1], n)
+
+	if got := a.findNextOIDSnap(deepest, snap); got != nil {
+		t.Fatalf("expected the deepest OID to have no successor, got %s — the probe is "+
+			"not landing at the end of the MIB and would not exercise a full linear scan",
+			oidStr6597(got))
+	}
+
+	allocs := testing.AllocsPerRun(50, func() {
+		a.findNextOIDSnap(deepest, snap)
+	})
+
+	linear := float64(len(ifXTableColumns) * n)
+	const budget = 64 // ~14 expected; generous room for search-shape changes
+	if allocs > budget {
+		t.Errorf("worst-case successor lookup examined %.0f candidates over %d interfaces "+
+			"(budget %d, pre-#6597 linear cost ~%.0f): the lookup has regressed toward a "+
+			"linear MIB scan (#6597)", allocs, n, budget, linear)
+	}
+	if allocs >= linear {
+		t.Errorf("lookup cost %.0f is at or above the full linear scan cost %.0f", allocs, linear)
+	}
+	t.Logf("worst-case lookup over %d interfaces: %.0f candidates examined (linear would be ~%.0f)",
+		n, allocs, linear)
+}
+
+// TestGetIfDataSortsCallbackData_6597 binds the precondition the binary search
+// rests on. getIfData's doc has always claimed sorted data while nothing
+// sorted; buildSNMPIfData returns raw netlink.LinkList order. Unsorted, a
+// linear scan emits a mis-ordered walk and a binary search emits an arbitrary
+// one, so this is load-bearing rather than tidiness.
+func TestGetIfDataSortsCallbackData_6597(t *testing.T) {
+	unsorted := []IfData{
+		{IfIndex: 9, IfDescr: "i9", IfName: "i9"},
+		{IfIndex: 2, IfDescr: "i2", IfName: "i2"},
+		{IfIndex: 40, IfDescr: "i40", IfName: "i40"},
+		{IfIndex: 7, IfDescr: "i7", IfName: "i7"},
+	}
+	original := append([]IfData{}, unsorted...)
+	a := agentFor6597(unsorted)
+
+	got := a.getIfData()
+	for i := 1; i < len(got); i++ {
+		if got[i-1].IfIndex >= got[i].IfIndex {
+			t.Fatalf("getIfData returned unsorted data: index %d (%d) not after %d",
+				i, got[i].IfIndex, got[i-1].IfIndex)
+		}
+	}
+
+	// The callback's slice must not be reordered underneath it.
+	for i := range original {
+		if unsorted[i].IfIndex != original[i].IfIndex {
+			t.Errorf("getIfData mutated the callback's slice at %d: %d, was %d",
+				i, unsorted[i].IfIndex, original[i].IfIndex)
+		}
+	}
+
+	// And the resulting walk is strictly ascending, which is what RFC 3416
+	// managers require and what unsorted data breaks.
+	snap := a.newIfSnapshot()
+	prev := []int{1}
+	seen := 0
+	for {
+		nxt := a.findNextOIDSnap(prev, snap)
+		if nxt == nil {
+			break
+		}
+		if oidCompare(nxt, prev) <= 0 {
+			t.Fatalf("walk went backwards: %s after %s", oidStr6597(nxt), oidStr6597(prev))
+		}
+		prev = nxt
+		seen++
+	}
+	if want := len(staticOIDs) + len(unsorted)*(len(ifTableColumns)+len(ifXTableColumns)); seen != want {
+		t.Errorf("walk emitted %d OIDs, expected %d", seen, want)
+	}
+}
+
+// BenchmarkSuccessorLookup6597 pins per-lookup cost against interface count.
+// Run with -benchmem; a linear regression shows as cost growing with N.
+func BenchmarkSuccessorLookup6597(b *testing.B) {
+	for _, n := range []int{8, 64, 512} {
+		b.Run(fmt.Sprintf("ifaces=%d", n), func(b *testing.B) {
+			a := agentFor6597(ifacesFor6597(n))
+			snap := a.newIfSnapshot()
+			snap.get()
+			deepest := append(append([]int{}, oidIfXTablePrefix...),
+				ifXTableColumns[len(ifXTableColumns)-1], n)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				a.findNextOIDSnap(deepest, snap)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #6597

## Measured first

The issue frames this as a per-lookup linear cost. Measuring before designing, as the acceptance criteria ask, shows it is worse: the scan returns at the position of the answer, so a walk pays `1 + 2 + ... + M` and is **quadratic** in the number of served OIDs.

| interfaces | MIB OIDs | full walk before | after |
|---:|---:|---:|---:|
| 8 | 167 | 1.31 ms | 0.19 ms |
| 64 | 1,287 | **145 ms** | 2.27 ms |
| 128 | 2,567 | **662 ms** | 4.81 ms |
| 256 | 5,127 | **1.54 s** | 9.37 ms |
| 512 | 10,247 | **6.32 s** | 21.7 ms |

That distinction is the reason this is worth fixing rather than closing. And the interface count is not bounded by hardware: `buildSNMPIfData` enumerates every kernel link except `lo`, so VLAN subinterfaces, GRE tunnels and **one XFRM interface per IPsec tunnel** all land in the ifTable. A firewall with a hundred site-to-site tunnels is an ordinary box, not a stress case — and the agent runs on a single serial goroutine every other SNMP operation shares.

## The fix

`nextTableOID` treats each `<prefix>.<col>.<ifIndex>` region as a **virtual sorted array**: entry `p` denotes `cols[p/len(ifaces)]` and `ifaces[p%len(ifaces)].IfIndex`, which enumerates it column-major — exactly the lexicographic order of the OIDs it denotes. That order is ascending, so "entry `p` is greater than `oid`" is monotone in `p`, and the first `p` satisfying it — precisely what the linear scan returned — is a binary search.

**Virtual, not materialised, is the load-bearing half.** Building a sorted index per snapshot would move the cost rather than remove it: a one-varbind GETNEXT near the top of the tree costs O(1) today, and building `20*interfaces` OIDs to answer it would be a regression for the most common poll shape there is. Only the O(log n) probed candidates are ever constructed — 24 at 512 interfaces, against ~5,632.

## A precondition that was not true

The search rests on ascending `ifIndex`. `getIfData` has always **documented** that it returns sorted interface data while nothing anywhere sorted — `buildSNMPIfData` hands back raw `netlink.LinkList` (RTM_GETLINK dump) order, which the kernel does not promise is ifIndex-ordered.

The old linear scan already depended on this: unsorted, it emits a walk that goes backwards, and RFC 3416 managers respond by looping or stopping early. So the assumption was load-bearing before this change and merely undetected. A binary search raises the stakes — over an unsorted array it returns an *arbitrary* entry rather than a mis-ordered one. `getIfData` now enforces what it documents; already-sorted input (the norm) costs one scan and no allocation, and only out-of-order data is cloned, so the callback slice is never reordered underneath it.

## Tests: one half proves the answers did not move, the other proves the cost did

Equivalence keeps the **pre-#6597 linear scan verbatim** as an oracle and compares against it over every OID a walk visits plus the off-tree probes a manager can legitimately send — truncated prefixes, unserved columns (6 and 9 are absent from `ifTableColumns`), out-of-range ifIndexes, OIDs longer than any entry. A second test compares the whole **walk** rather than single lookups, since per-probe agreement alone would still permit a different traversal, and asserts the oracle visits `static + 20*interfaces` OIDs so a walk covering nothing cannot pass vacuously.

The regression guard counts **allocations, not elapsed time**. Every candidate examined is one allocation, so the count IS the number of MIB entries visited: ~14 binary vs ~5,632 linear at 512 interfaces. Three orders of magnitude apart, so no threshold in between is delicate — and deterministic where a timing assertion would be flaky in CI. A benchmark pins per-lookup cost against interface count alongside it.

## Mutation matrix

Every cell verified APPLIED first.

| # | mutation | result |
|---|---|---|
| P1 | restore the pre-#6597 linear scan verbatim | **RED** — only the cost guard; equivalence stays green, which is correct, the oracle *is* that scan |
| P2 | drop the `getIfData` sort | **RED** |
| P3 | successor predicate `> 0` → `>= 0` | **RED** |
| P4 | row-major instead of column-major decode | **RED** |
| P5 | `getIfData` sorts in place, mutating the caller's slice | **RED** |

P3 initially **hung** rather than failing: `>= 0` makes an OID its own successor, so the walk never terminates. The matrix now runs under an explicit `-timeout`. Worth recording, because the production v1 walk (`findNextV1OIDSnap`) is the one unbounded loop over this function and terminates only because the successor strictly advances — a property the equivalence oracle now pins. GETNEXT is one lookup per request OID and GETBULK is bounded by `max-repetitions` and the byte budget, so neither can spin.

## Acceptance criteria

- [x] Successor lookup is not linear in the number of MIB entries.
- [x] A benchmark pinning per-lookup cost against interface count, plus a deterministic allocation-count guard so a regression to linear is visible.
- [x] Walk output identical to today's across an exhaustive probe set and full-walk comparison, against the previous implementation kept verbatim.

## Validation

`go test -count=1 ./...` green; `go build ./...` clean; `go vet ./pkg/snmp/` clean. `gofmt` reports `pkg/snmp/v3_auth_test.go`, which is unformatted at `origin/master` already and untouched here.

Docs: `pkg/snmp/README.md` updated — the GETBULK bullet said this cost "is not addressed here", which is no longer true, and both the new search and the sort precondition are now documented.

**No dataplane involvement:** Go control plane only. No shim `.o`, no helper binary, no cluster surface.