### PR TITLE
test(networkd): vary every axis the activation-tail argv claims to cover (#6914)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-08-22 — #6914: the activation-tail argv fixture varied one axis
+
+- **Timestamp**: 2026-08-22
+- **Action**: The tail's `networkctl reconfigure` argv was asserted in full,
+  but `activationTailIfaces()` had exactly one ELIGIBLE interface, so
+  `[reconfigure trust0]` was also the output of a hardcoded literal, a deleted
+  `Unmanaged` predicate, a deleted `Disable` predicate and a reversed
+  accumulation. Confirmed rather than assumed: all four were run against the
+  BASE fixture and all four exited 0.
+  Extended the fixture to five interfaces covering every arm — two included
+  (`trust0`, `dmz0`) sitting on either side of three excluded (bond member,
+  unmanaged, disabled) — so accumulation and ORDER are both observable, which
+  one eligible interface can never make so.
+  Spelled the expectation out as `wantActivationTailArgv` rather than deriving
+  it by filtering the fixture with the production predicate: deriving it would
+  make the assertion true by construction, since the same predicate would
+  decide both the behaviour and the expectation and deleting an arm would move
+  them together.
+  Left `debtTestIfaces()` untouched — it is deliberately minimal for the
+  reload-debt tests that share it, and the richer fixture is local to the
+  activation-tail file.
+  Mutation matrix M1-M5 all RED at RUN=48 matching the control, vet clean at
+  each; and the same four mutations verified GREEN against the base fixture,
+  which is what shows the fixture change is what closed them.
+- **File(s)**: `pkg/networkd/activation_tail_5718_test.go`,
+  `pkg/networkd/README.md`
+
 ## 2026-08-22 — #6678: device-map OriginalName= no longer falls back to the logical name
 
 - **Timestamp**: 2026-08-22

--- a/pkg/networkd/README.md
+++ b/pkg/networkd/README.md
@@ -58,6 +58,22 @@ Standard library only.
   classifies family by `addressIsIPv6` (colon test on the CIDR string).
 - VRF and tunnel interfaces created elsewhere are excluded from the
   unmanaged-interface scan via the `daemonOwned` map.
+- **The activation tail's `networkctl reconfigure` argv is asserted in
+  full, and the fixture must VARY every axis it claims to cover
+  (#6914).** The tail selects `!Unmanaged && !Disable && BondMaster == ""`
+  and accumulates names in slice order. An argv assertion can only catch a
+  regression along an axis the fixture varies: with a single eligible
+  interface, `[reconfigure trust0]` is also what a hardcoded literal, a
+  deleted `Unmanaged` predicate, a deleted `Disable` predicate and a
+  reversed accumulation all produce — all four were measured green against
+  the one-interface fixture. `activationTailIfaces()` therefore carries two
+  INCLUDED interfaces on either side of the three excluded ones (bond
+  member, unmanaged, disabled), so accumulation and order are both
+  observable. Its expectation (`wantActivationTailArgv`) is spelled out
+  rather than derived by filtering the fixture with the production
+  predicate — deriving it would let the same predicate decide both the
+  behaviour and the expectation, so deleting an arm would change them
+  together and the test could never red.
 - **`Apply` is fail-closed on write errors (#2987).** `writeIfChanged`
   returns `(changed, err)`; `Apply` aggregates per-file write failures
   (still attempting every generated file), reloads whatever did change,

--- a/pkg/networkd/activation_tail_5718_test.go
+++ b/pkg/networkd/activation_tail_5718_test.go
@@ -8,13 +8,33 @@ import (
 	"testing"
 )
 
-// activationTailIfaces extends debtTestIfaces() with a bond MEMBER, which the
-// activation tail must EXCLUDE from `networkctl reconfigure` (reconfiguring a
-// member can eject it from its bond; its Bond= directive is picked up by the
-// reload instead). The shared debtTestIfaces() fixture has only one managed,
-// non-member interface, which cannot distinguish an intact exclusion from a
-// deleted one — both yield the same one-element argv. Kept local to this file
-// so the reload-debt tests that share debtTestIfaces() are unaffected.
+// activationTailIfaces extends debtTestIfaces() so that EVERY dimension of the
+// activation tail's `networkctl reconfigure` argv is observable (#6914).
+//
+// The tail selects interfaces with `!Unmanaged && !Disable && BondMaster == ""`
+// and accumulates their names in slice order. An argv assertion can only catch
+// a regression along an axis the fixture actually VARIES, so a fixture with one
+// eligible interface pins almost nothing: with `[reconfigure trust0]` as the
+// expectation, replacing the accumulated list with the literal "trust0",
+// deleting the Unmanaged predicate, deleting the Disable predicate, or
+// reversing the accumulation all still produce exactly that argv. Each of those
+// was proven to exit 0 against the old fixture.
+//
+// So this carries FIVE interfaces covering all four exclusion/inclusion arms:
+//
+//	trust0  managed, non-member          -> INCLUDED (first)
+//	lag0m   bond MEMBER                  -> excluded (reconfigure can eject it
+//	                                        from its bond; its Bond= directive
+//	                                        is picked up by the reload instead)
+//	ext0    Unmanaged                    -> excluded
+//	off0    Disable                      -> excluded
+//	dmz0    managed, non-member          -> INCLUDED (second)
+//
+// Two included interfaces on either side of the excluded ones make BOTH
+// accumulation and ORDER observable, which one eligible interface never can.
+//
+// Kept local to this file so the reload-debt tests that share debtTestIfaces()
+// are unaffected — that fixture is deliberately minimal for its own purpose.
 func activationTailIfaces() []InterfaceConfig {
 	return append(debtTestIfaces(),
 		InterfaceConfig{
@@ -22,8 +42,31 @@ func activationTailIfaces() []InterfaceConfig {
 			MACAddress: "52:54:00:aa:bb:dd",
 			BondMaster: "ae0",
 		},
+		InterfaceConfig{
+			Name:       "ext0",
+			MACAddress: "52:54:00:aa:bb:ee",
+			Unmanaged:  true,
+		},
+		InterfaceConfig{
+			Name:       "off0",
+			MACAddress: "52:54:00:aa:bb:ef",
+			Disable:    true,
+		},
+		InterfaceConfig{
+			Name:       "dmz0",
+			MACAddress: "52:54:00:aa:bb:f0",
+			Addresses:  []string{"10.0.30.10/24"},
+		},
 	)
 }
+
+// wantActivationTailArgv is the expected `networkctl reconfigure` argv for
+// activationTailIfaces(), SPELLED OUT rather than derived by filtering the
+// fixture with the production predicate. Deriving it would make the assertion
+// true by construction: the same predicate would decide both the expectation
+// and the behaviour, so deleting an arm would change them together and the test
+// could never red.
+var wantActivationTailArgv = []string{"reconfigure", "trust0", "dmz0"}
 
 // rpFilterFixture points procSysNetRoot at a temp tree with the slow-path TUN's
 // rp_filter pre-set to networkd's post-reload default, and returns a reader for
@@ -161,7 +204,7 @@ func TestApplyTailSurvivesExternalDebtDischarge_5718(t *testing.T) {
 	// with the production predicate would be circular. (Hardcoding is not the
 	// only non-circular option; `[]string{"reconfigure", ifaces[0].Name}` would
 	// also work. It is simply the clearest.)
-	wantArgs := []string{"reconfigure", "trust0"}
+	wantArgs := wantActivationTailArgv
 	if len(reconfigureArgs) != 1 || !slices.Equal(reconfigureArgs[0], wantArgs) {
 		t.Fatalf("the activation tail must run %v exactly once; got %v. An address "+
 			"application that names the wrong interfaces leaves the real ones unapplied "+
@@ -221,7 +264,7 @@ func TestApplyTailNotRepeatedOnceComplete_5718(t *testing.T) {
 	// test's subject is repetition, so the call COUNT is load-bearing here —
 	// but a count alone still cannot see a tail that runs the right number of
 	// times against the wrong interfaces.
-	if want := []string{"reconfigure", "trust0"}; !slices.Equal(reconfigureArgs[0], want) {
+	if want := wantActivationTailArgv; !slices.Equal(reconfigureArgs[0], want) {
 		t.Fatalf("first Apply ran %v, want %v", reconfigureArgs[0], want)
 	}
 


### PR DESCRIPTION
The activation tail asserts the **full argv** of its `networkctl reconfigure` call rather than just the call count — the right shape, since reconfiguring the wrong interfaces leaves the real ones' addresses unapplied while still making a call that looks correct, and a count assertion cannot see that at all.

But an argv assertion only catches a regression along an axis the fixture actually **varies**, and `activationTailIfaces()` had exactly **one eligible interface**. With `[reconfigure trust0]` as the expectation, that same argv is also what you get from a hardcoded literal, a deleted `Unmanaged` predicate, a deleted `Disable` predicate, or a reversed accumulation.

## Measured before and after

Not asserted — run. Each mutation was applied against the **base** fixture and against the new one:

| mutation (production code) | base fixture | new fixture |
|---|---|---|
| hardcode the list to `"trust0"` | **exit 0** — unbound | **RED** |
| delete the `Unmanaged` predicate | **exit 0** — unbound | **RED** |
| delete the `Disable` predicate | **exit 0** — unbound | **RED** |
| reverse the accumulation order | **exit 0** — unbound | **RED** |
| delete the bond-member exclusion | RED (already covered) | **RED** |

The base-fixture column is what shows the fixture change is what closed these, rather than something else in the tree.

## The fixture

Five interfaces covering every arm of `!Unmanaged && !Disable && BondMaster == ""`:

```
trust0  managed, non-member   -> INCLUDED (first)
lag0m   bond MEMBER           -> excluded
ext0    Unmanaged             -> excluded
off0    Disable               -> excluded
dmz0    managed, non-member   -> INCLUDED (second)
```

Two included interfaces sitting **on either side** of the three excluded ones makes both accumulation and **order** observable, which one eligible interface never can.

## The expectation is spelled out, not derived

`wantActivationTailArgv` is a literal. Deriving it by filtering the fixture with the production predicate would make the assertion **true by construction**: the same predicate would decide both the behaviour and the expectation, so deleting an arm would move them together and the test could never red. That is the trap this issue exists to close, so the fix must not reintroduce it one level up.

## Scope

`debtTestIfaces()` is left untouched — deliberately minimal for the reload-debt tests that share it, with the richer fixture local to the activation-tail file where it already lived, exactly as #6914 recommends.

**Test-only change; no production behaviour is modified.** Does not reach the Rust helper binary; no hardware or cluster needed.

## Validation

Full `pkg/networkd` suite `-count=1` clean. `go vet` clean at every mutated state, RUN count matching the control (48) at every cell.

Related: #6912 concerns the same activation tail but is a **separate** defect — a production gating bug where an external `networkctl reload` lets the next unchanged `Apply` skip the tail entirely. They share a code region, not a root cause. This PR lands first because its richer fixture is what #6912's fix should be tested against.

Closes #6914