### PR TITLE
daemon: require ingress ownership to sync a fabric-redirect session

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -102995,3 +102995,13 @@ prose edit above them added. No diff falls in the new test body.
     pkg/dataplane/userspace/fabric_peer_mac_6598_test.go,
     pkg/daemon/fabric_neigh_single_source_6598_test.go,
     docs/fabric-cross-chassis-fwd.md
+
+- **Timestamp**: 2026-08-22
+  - **Action**: #6599 — fenced the session-sync delta filter's fabric-redirect
+    carve-out on INGRESS-side RG ownership. It admitted every fabric-redirect
+    delta unconditionally, which is the emission channel the transient-purge
+    re-entry class rides: a node that owns neither side of a flow could push an
+    identity-less Open (plus its forward-wire alias) that overwrote the RG
+    owner's authoritative session family under latest-generation-wins.
+  - **File(s)**: pkg/daemon/daemon_ha_userspace_stream.go,
+    pkg/daemon/userspace_sync_test.go, docs/session-sync-architecture.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -370,9 +370,12 @@ Two invariants hold this together:
   so a divergence between the two filters is always a bug. Single-sourcing the
   walk makes that divergence unrepresentable. This is also why the snapshot is
   framed verbatim: re-applying the coarser `ShouldSyncZone` filter on top of the
-  owner-RG one could drop an entry the incremental path admits (a fabric-redirect
-  wire alias, or a session whose owner RG this node holds but whose ingress zone
-  maps elsewhere), and that entry would then be deleted on the receiver.
+  owner-RG one could drop an entry the incremental path admits (a session whose
+  owner RG this node holds but whose ingress zone maps elsewhere), and that
+  entry would then be deleted on the receiver. Since #6599 a fabric-redirect
+  wire alias is no longer such an entry — that branch now applies
+  `ShouldSyncZone` itself — but the owner-RG example above is untouched, so the
+  verbatim framing is still what keeps the two paths' sets identical.
 - **Fail CLOSED.** If the snapshot source errors, `doBulkSync` returns the error
   and frames **no window at all** rather than falling back to the mirror walk. An
   incomplete authoritative window destroys live sessions; framing none merely
@@ -1662,11 +1665,49 @@ These deltas are **not** blindly mirrored. Filtering in
 `shouldSyncUserspaceDelta()`:
 
 - `local_delivery` disposition is never synced to the peer
-- `FabricRedirect` with `!FabricIngress`: always synced even if the local node
-  is no longer owner, because the peer needs the forward-wire alias to receive
-  redirected traffic. The daemon also synthesizes forward-wire alias session
-  keys via `userspaceForwardWireAliasFromDeltaV4/V6` so the new owner can
-  materialize the translated forward tuple it will receive over the fabric.
+- `missing_neighbor_seed` origin is never synced (a transient ARP-wait seed)
+- `FabricRedirect` with `!FabricIngress`: synced even though the local node is
+  not the owner of the session's `OwnerRGID`, because the peer needs the
+  forward-wire alias to receive redirected traffic. A fabric redirect means the
+  peer owns the flow's EGRESS side by construction, so running these deltas
+  through the owner-RG gate below would refuse every legitimate split-RG
+  handoff. The daemon also synthesizes forward-wire alias session keys via
+  `userspaceForwardWireAliasV4/V6` so the new owner can materialize the
+  translated forward tuple it will receive over the fabric.
+
+  **#6599 — the branch still requires INGRESS ownership.** It used to admit
+  every fabric-redirect delta unconditionally (`return ss != nil`), which made
+  it the emission channel for the transient-purge re-entry class. On a node
+  that is not the RG owner, a spoofed non-closing first packet carrying a
+  peer-owned flow's translated wire tuple drives
+  `should_keep_synced_hit_transient` -> `purge_translated_synced_hit`
+  (`userspace-dp/src/afxdp/session_glue/promote.rs`), which tears down this
+  node's replica of the peer's session family. The following packet
+  clean-misses and installs a fresh `ForwardFlow` whose resolution is a FABRIC
+  REDIRECT — precisely because this node does not own the RG, the same
+  condition that fired the purge. That Open (and the forward-wire alias emitted
+  alongside it) reached `QueueSessionV4` with a fresh #2170 install generation
+  and overwrote the owner's authoritative session family under
+  latest-generation-wins, swapping the victim's mid-flow translation.
+
+  The fence is ownership of the INGRESS side: `ShouldSyncZone(ingressZone)` —
+  the same predicate the non-fabric fallback below already uses. A node may
+  hand a flow off over the fabric only when it is primary for the RG the flow's
+  ingress zone belongs to, i.e. only when it actually owns the traffic it is
+  handing off. The split-RG handoff (ingress RG local, egress RG the peer's)
+  still syncs; a node that owns NEITHER side of a flow can no longer install
+  anything on the peer. Regression coverage:
+  `TestShouldSyncUserspaceDeltaFabricRedirectRequiresIngressOwnership6599` and
+  `TestWalkUserspaceSessionDeltasDropsUnownedFabricRedirect6599` in
+  `pkg/daemon` — the second binds the WALK, so the suppressed delta is proved
+  to contribute zero sessions, forward-wire alias included.
+
+  Residual (unchanged by #6599, tracked with the #6461 Phase-2 identity work):
+  the deltas that survive this gate still carry no per-flow provenance, so an
+  Open cannot prove which incarnation of a tuple it belongs to. A spoofed
+  packet arriving on an ingress zone the node DOES own still fabricates a
+  session on the victim's tuple; the ingress gate removes the unowned-emitter
+  channel, not the identity-carriage gap.
 - if the delta carries `OwnerRGID`, ownership is checked with `IsPrimaryForRGFn`
 - otherwise the fallback is `ShouldSyncZone(ingressZone)`
 

--- a/pkg/daemon/daemon_ha_userspace_stream.go
+++ b/pkg/daemon/daemon_ha_userspace_stream.go
@@ -46,8 +46,40 @@ func (d *Daemon) shouldSyncUserspaceDelta(ss *cluster.SessionSync, delta dpusers
 		slog.Debug("userspace delta: filtered (missing_neighbor_seed)", "src", delta.SrcIP, "dst", delta.DstIP)
 		return false
 	}
+	// A fabric redirect means the PEER owns the flow's egress side, so
+	// delta.OwnerRGID names an RG this node is by construction not primary
+	// for. Judging the delta by the owner-RG gate below would therefore refuse
+	// every legitimate split-RG handoff (a flow that ingresses on an RG this
+	// node owns and leaves via an RG the peer owns), which is why this branch
+	// exists at all.
+	//
+	// #6599: it used to bypass ownership ENTIRELY (`return ss != nil`), which
+	// made it the emission channel for the transient-purge re-entry class. On a
+	// node that is not the RG owner, a spoofed first packet carrying a
+	// peer-owned flow's translated wire tuple drives
+	// should_keep_synced_hit_transient -> purge_translated_synced_hit
+	// (userspace-dp/src/afxdp/session_glue/promote.rs); the following packet
+	// clean-misses and installs a fresh ForwardFlow whose resolution is a
+	// FABRIC REDIRECT — precisely because this node does not own the RG, the
+	// same condition that fired the purge. The Open delta (and the forward-wire
+	// alias the walk emits alongside it) then reached QueueSessionV4 with a
+	// fresh #2170 install generation and overwrote the owner's authoritative
+	// session family under latest-generation-wins.
+	//
+	// The fence is ownership of the INGRESS side: sync the handoff only when
+	// this node is primary for the RG the flow's ingress zone belongs to, i.e.
+	// only when it actually owns the traffic it is handing off. That keeps the
+	// split-RG handoff (ingress RG is local) and drops the fabrication (ingress
+	// RG is the peer's — a node that owns neither side of the flow has no
+	// authority to install anything on the peer). ShouldSyncZone is the same
+	// predicate the non-fabric fallback below already uses, so the two branches
+	// now agree on what "this node owns this flow's ingress" means.
 	if delta.FabricRedirect && !delta.FabricIngress {
-		return ss != nil
+		ok := ss != nil && ss.ShouldSyncZone(ingressZone)
+		if !ok {
+			slog.Debug("userspace delta: filtered (fabric redirect from a zone this node does not own)", "zone", ingressZone, "rg", delta.OwnerRGID, "src", delta.SrcIP, "dst", delta.DstIP)
+		}
+		return ok
 	}
 	if delta.OwnerRGID > 0 && ss != nil && ss.IsPrimaryForRGFn != nil {
 		ok := ss.IsPrimaryForRGFn(delta.OwnerRGID)

--- a/pkg/daemon/userspace_sync_test.go
+++ b/pkg/daemon/userspace_sync_test.go
@@ -769,12 +769,24 @@ func TestShouldSyncUserspaceDeltaSkipsMissingNeighborSeed(t *testing.T) {
 	}
 }
 
+// The property this pins is that the OWNER-RG gate must not block a
+// fabric-redirect handoff: a fabric redirect exists precisely because the peer
+// owns the flow's egress RG, so delta.OwnerRGID always names an RG this node is
+// not primary for.
+//
+// #6599 retargeted the fixture. It used to make the node primary for NOTHING —
+// which also made it not primary for the RG owning the flow's INGRESS zone, so
+// the test asserted that a node owning neither side of the flow may still push
+// an Open to the peer. That is the identity-less-Open emission channel, not the
+// handoff property. The node is now primary for RG 2 and the flow ingresses on
+// a zone that lives on RG 2, so it legitimately owns the traffic it hands off
+// while its owner RG (1) is still the peer's.
 func TestShouldSyncUserspaceDeltaAllowsStaleOwnerFabricRedirect(t *testing.T) {
 	ss := &cluster.SessionSync{
 		IsPrimaryFn:      func() bool { return false },
-		IsPrimaryForRGFn: func(rgID int) bool { return false },
+		IsPrimaryForRGFn: func(rgID int) bool { return rgID == 2 },
 	}
-	ss.SetZoneRGMap(map[uint16]int{1: 1})
+	ss.SetZoneRGMap(map[uint16]int{1: 2})
 	d := &Daemon{sessionSync: ss}
 	delta := dpuserspace.SessionDeltaInfo{
 		OwnerRGID:      1,
@@ -1137,5 +1149,121 @@ func TestBulkSyncFallbackWhenDPIsNil(t *testing.T) {
 	err := d.bulkSyncViaEventStreamOrFallback(nil)
 	if err == nil {
 		t.Fatal("expected error from nil session sync fallback")
+	}
+}
+
+// captureDeltaSink records every session the delta walk admits, so a test can
+// assert on BOTH the canonical open and the forward-wire alias the
+// fabric-redirect branch emits alongside it.
+type captureDeltaSink struct {
+	opensV4   []dataplane.SessionKey
+	opensV6   []dataplane.SessionKeyV6
+	deletesV4 []dataplane.SessionKey
+	deletesV6 []dataplane.SessionKeyV6
+}
+
+func (c *captureDeltaSink) openV4(key dataplane.SessionKey, _ dataplane.SessionValue) {
+	c.opensV4 = append(c.opensV4, key)
+}
+
+func (c *captureDeltaSink) openV6(key dataplane.SessionKeyV6, _ dataplane.SessionValueV6) {
+	c.opensV6 = append(c.opensV6, key)
+}
+
+func (c *captureDeltaSink) deleteV4(key dataplane.SessionKey) {
+	c.deletesV4 = append(c.deletesV4, key)
+}
+
+func (c *captureDeltaSink) deleteV6(key dataplane.SessionKeyV6) {
+	c.deletesV6 = append(c.deletesV6, key)
+}
+
+// #6599: the fabric-redirect carve-out must still require that THIS node owns
+// the RG the flow's INGRESS zone belongs to.
+//
+// A fabric redirect means "the peer owns the EGRESS side", so judging the delta
+// by delta.OwnerRGID would refuse every legitimate split-RG handoff — that is
+// what the carve-out exists for. But bypassing ownership ENTIRELY lets a node
+// that owns neither side emit an Open for a session it fabricated on a
+// peer-owned tuple: the transient-purge re-entry class. The ingress-zone RG is
+// the predicate that keeps the handoff and drops the fabrication.
+func TestShouldSyncUserspaceDeltaFabricRedirectRequiresIngressOwnership6599(t *testing.T) {
+	ss := &cluster.SessionSync{
+		IsPrimaryFn: func() bool { return false },
+		// Split-RG: this node is primary for RG 2 only. RG 1 is the peer's.
+		IsPrimaryForRGFn: func(rgID int) bool { return rgID == 2 },
+	}
+	// Zone 1 lives on RG 1 (peer-owned); zone 5 lives on RG 2 (locally owned).
+	ss.SetZoneRGMap(map[uint16]int{1: 1, 5: 2})
+	d := &Daemon{sessionSync: ss}
+
+	peerIngress := dpuserspace.SessionDeltaInfo{
+		OwnerRGID:      1,
+		FabricRedirect: true,
+		FabricIngress:  false,
+		IngressZone:    "wan",
+		EgressZone:     "lan",
+	}
+	if d.shouldSyncUserspaceDelta(d.sessionSync, peerIngress, 1) {
+		t.Fatal("expected a fabric-redirect delta whose INGRESS RG is peer-owned to be refused (#6599)")
+	}
+
+	// Positive control: the legitimate split-RG handoff. The session's owner RG
+	// is the peer's (that is why it is a fabric redirect at all), but the flow
+	// ingressed on an RG this node owns, so the handoff must still sync.
+	localIngress := peerIngress
+	if !d.shouldSyncUserspaceDelta(d.sessionSync, localIngress, 5) {
+		t.Fatal("expected a fabric-redirect handoff from a locally-owned ingress RG to sync")
+	}
+}
+
+// #6599: the gate is what the WALK consults, and the fabric-redirect branch
+// emits TWO sessions per admitted delta (the canonical key and the forward-wire
+// alias). Bind the walk, not just the predicate: an unowned-ingress delta must
+// contribute ZERO sessions, alias included.
+func TestWalkUserspaceSessionDeltasDropsUnownedFabricRedirect6599(t *testing.T) {
+	zoneIDs := map[string]uint16{"wan": 1, "lan": 5}
+	ss := &cluster.SessionSync{
+		IsPrimaryFn:      func() bool { return false },
+		IsPrimaryForRGFn: func(rgID int) bool { return rgID == 2 },
+	}
+	ss.SetZoneRGMap(map[uint16]int{1: 1, 5: 2})
+	d := &Daemon{sessionSync: ss}
+
+	// The spoofed re-entry: a session the standby fabricated on the peer-owned
+	// flow's translated tuple. It ingressed on the WAN zone, whose RG the peer
+	// owns, and its resolution is a fabric redirect because this node is not
+	// the RG owner — exactly the condition that fired the transient purge.
+	spoofed := dpuserspace.SessionDeltaInfo{
+		Event:          "open",
+		AddrFamily:     dataplane.AFInet,
+		Protocol:       6,
+		SrcIP:          "172.16.80.8",
+		DstIP:          "172.16.80.200",
+		SrcPort:        39906,
+		DstPort:        5201,
+		IngressZone:    "wan",
+		EgressZone:     "lan",
+		OwnerRGID:      1,
+		NATSrcIP:       "172.16.80.9",
+		NATSrcPort:     39906,
+		FabricRedirect: true,
+		FabricIngress:  false,
+	}
+	var sink captureDeltaSink
+	n := d.walkUserspaceSessionDeltas(ss, zoneIDs, []dpuserspace.SessionDeltaInfo{spoofed}, &sink)
+	if n != 0 || len(sink.opensV4) != 0 {
+		t.Fatalf("expected the unowned-ingress fabric-redirect open AND its forward-wire alias to be dropped (#6599); got n=%d opens=%v", n, sink.opensV4)
+	}
+
+	// Positive control: the same delta ingressing on a locally-owned RG still
+	// emits BOTH the canonical session and its forward-wire alias.
+	handoff := spoofed
+	handoff.IngressZone = "lan"
+	handoff.EgressZone = "wan"
+	var okSink captureDeltaSink
+	n = d.walkUserspaceSessionDeltas(ss, zoneIDs, []dpuserspace.SessionDeltaInfo{handoff}, &okSink)
+	if n != 2 || len(okSink.opensV4) != 2 {
+		t.Fatalf("expected the owned-ingress handoff to emit the session and its alias; got n=%d opens=%v", n, okSink.opensV4)
 	}
 }


### PR DESCRIPTION
Closes #6599

## The defect at master

`shouldSyncUserspaceDelta` carved fabric-redirect sessions out of **every**
ownership check:

```go
// pkg/daemon/daemon_ha_userspace_stream.go:49-51 (origin/master)
if delta.FabricRedirect && !delta.FabricIngress {
    return ss != nil
}
```

The carve-out is load-bearing in one direction: a fabric redirect means the
**peer** owns the flow's egress side, so `delta.OwnerRGID` names an RG this node
is by construction not primary for. Running these deltas through the owner-RG
gate below it would refuse every legitimate split-RG handoff.

It is wrong in the other: bypassing ownership *entirely* lets a node that owns
**neither** side of a flow install state on the peer. That is the emission
channel #6599 names.

## The production path

1. Non-owner node, spoofed non-closing first packet carrying a peer-owned flow's
   **translated wire tuple** → `should_keep_synced_hit_transient`
   (`userspace-dp/src/afxdp/session_glue/promote.rs:48`) →
   `purge_translated_synced_hit` (`promote.rs:167`, driven from
   `session_glue/mod.rs:1329-1342`) tears down this node's replica of the peer's
   session family.
2. The next packet clean-misses and installs a fresh `ForwardFlow`. Its
   resolution is a **fabric redirect** — `finalize_new_flow_ha_resolution`
   (`afxdp/forwarding/ha.rs:181`) enforces HA, gets `HAInactive`, and redirects —
   precisely *because* this node does not own the RG, the same condition that
   fired the purge. `SessionTable::install_*` pushes an `Open`
   (`userspace-dp/src/session/install.rs:234`).
3. `session_delta.rs:202` stamps `fabric_redirect=true, fabric_ingress=false`.
4. Go: `walkUserspaceSessionDeltas` → `shouldSyncUserspaceDelta` **admits
   unconditionally** → `QueueSessionV4` for the canonical key *and* for the
   forward-wire alias → fresh #2170 install generation
   (`sync_conn_write.go:56`) → the owner applies latest-generation-wins.

## The fix

Fence the branch on ownership of the **ingress** side — `ShouldSyncZone`, the
same predicate the non-fabric fallback already uses. A node may hand a flow off
over the fabric only when it is primary for the RG the flow's ingress zone
belongs to, i.e. only when it actually owns the traffic it is handing off. The
split-RG handoff (ingress RG local, egress RG the peer's) still syncs; the
fabrication does not.

`TestShouldSyncUserspaceDeltaAllowsStaleOwnerFabricRedirect` is **retargeted,
not deleted**. The property it owns is real, but its fixture made the node
primary for *nothing* — so it also asserted that a node owning neither side may
push an Open to the peer, which is the hole. It now owns RG 2 and ingresses on a
zone that lives on RG 2, while its owner RG (1) stays the peer's.

## Mutation matrix

Every cell run **full-suite** (`go test ./pkg/daemon/ ./pkg/cluster/ -count=1`).

| # | Site | One-line change | Result |
|---|---|---|---|
| control | — | none | `ok pkg/daemon` (39.8s), `ok pkg/cluster` (20.0s) |
| M1 | `daemon_ha_userspace_stream.go:78` | `ok := ss != nil && ss.ShouldSyncZone(ingressZone)` → `ok := ss != nil` (restores what shipped at master) | **RED, assertions**: `...RequiresIngressOwnership6599` ("expected a fabric-redirect delta whose INGRESS RG is peer-owned to be refused"); `...DropsUnownedFabricRedirect6599` ("got n=2 opens=[{172.16.80.8…} {172.16.80.9…}]" — canonical **and** alias). Nothing else in either package reds. |
| M2 | `daemon_ha_userspace_stream.go:77` | `if delta.FabricRedirect && !delta.FabricIngress {` → `if false && …` (neutralize the carve-out) | **RED**: the retargeted `AllowsStaleOwnerFabricRedirect` **plus** both new tests' positive controls — so the carve-out is still necessary and the new predicate is not "reject everything". |

Restored clean after each cell (`git status --porcelain` empty, targeted tests
green).

**Base-fixture column (M1):** all six pre-existing `TestShouldSyncUserspaceDelta*`
fixtures exit **0** under M1 — the retargeted one included. The defect was
genuinely invisible to the existing suite; the new tests are the only owners of
the property. Both new tests were written and run **at origin/master before the
fix** and were red there (the walk emitted `n=2`).

The walk-level test binds the *wiring*, not just the predicate: the
fabric-redirect branch emits **two** sessions per admitted delta, so the
suppressed delta is proved to contribute zero, forward-wire alias included.

## Scope / honesty

This closes the **unowned-emitter** channel: a node that owns neither side of a
flow can no longer install anything on the peer. It does not add per-flow
identity to the deltas — a spoofed packet arriving on an ingress zone the node
*does* own still fabricates a session on the victim's tuple. That residual is
the #6461 Phase-2 identity-carriage work and is written down in
`docs/session-sync-architecture.md` rather than left implicit.

## Validation

- `go build ./...`, `go vet ./pkg/daemon/`, `gofmt` clean on both touched files.
- `go test ./pkg/daemon/ ./pkg/cluster/ -count=1` green.
- No Rust in the diff (`git diff origin/master...HEAD -- userspace-dp/ userspace-xdp/` is empty), so the cargo suite is out of the blast radius.
- **Owes `make test-failover`** on the loss userspace cluster — this touches
  session sync. Not run here (the cluster is shared and smoke is serialized).

## Docs

`docs/session-sync-architecture.md` — the "Delta Drain (Fallback Path)" filter
list now states the ingress-ownership requirement, the attack it closes, the
regression tests, and the residual. The §"One admission filter" note at line 373
claimed a fabric-redirect wire alias is an entry `ShouldSyncZone` could drop;
that half is now false, so it is corrected in the same change (the owner-RG
example it also cites still stands, so the verbatim-framing rule is unchanged).
