### PR TITLE
test/userspace: stub the ip-rule dump instead of depending on it

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103065,3 +103065,11 @@ prose edit above them added. No diff falls in the new test body.
   userspace-dp/src/afxdp/poll_descriptor/mod.rs,
   userspace-dp/src/afxdp/tests_fragment.rs, docs/multi-wan.md,
   docs/research/7409-learned-route-fib/plan.md (new), _Log.md
+
+- **Timestamp**: 2026-08-22
+  - **Action**: #6675 — made pkg/dataplane/userspace hermetic w.r.t. the kernel
+    ip-rule table via TestMain, so an EPERM dump can no longer nil-deref a
+    snapshot and SIGSEGV the whole test binary. Chose stubbing over skipping so
+    the package keeps coverage in reduced-capability sandboxes.
+  - **File(s)**: pkg/dataplane/userspace/hermetic_iprules_6675_test.go,
+    docs/engineering-style.md

--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -476,6 +476,27 @@ Rules of thumb:
 These are not "style" but are worth keeping next to the rest because
 they repeatedly bite:
 
+- **A test that needs a kernel capability must STUB it, not skip on it
+  (#6675).** `pkg/dataplane/userspace` builds every snapshot through
+  `buildRouteSnapshots`, which dumps the kernel ip-rule table via
+  `ruleListFn` and — correctly, per #3772 M9 — refuses to swallow a dump
+  failure. In a sandbox without `CAP_NET_ADMIN` that returns EPERM,
+  `buildSnapshot` returns a nil `*ConfigSnapshot`, and the ~45 test call
+  sites that discard the error dereference it. A nil dereference is a
+  SIGSEGV that aborts the whole test BINARY, so the first one takes every
+  remaining test in the package with it: the review run shows a crash with
+  no diagnostic, and reviewers chase a phantom regression in whatever PR
+  happened to be under test.
+  The fix is a `TestMain` that replaces the enumerator package-wide, NOT a
+  `t.Skipf` on EPERM. Skipping trades a crash for silence and leaves the
+  package with zero coverage in exactly the reduced-capability
+  environments where reviews run; stubbing lets those tests actually run
+  there. Guard the wiring with a code-pointer comparison against the real
+  function (`TestPackageIsHermeticWrtKernelIPRules_6675`) — a behavioural
+  check passes on any machine that HAS the capability, which is every
+  laptop and most CI runners, so it would never notice the stub being
+  deleted.
+
 - **Smoke tests run ONLY on the loss userspace cluster.** The smoke
   target is `loss:xpf-userspace-fw0` / `loss:xpf-userspace-fw1`,
   driven by `INCUS_REMOTE=loss` + `test/incus/loss-userspace-cluster.env`.

--- a/pkg/dataplane/userspace/hermetic_iprules_6675_test.go
+++ b/pkg/dataplane/userspace/hermetic_iprules_6675_test.go
@@ -1,0 +1,86 @@
+package userspace
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// #6675: this package's tests must not depend on being allowed to dump the
+// kernel ip-rule table.
+//
+// buildRouteSnapshots enumerates ip-rules through ruleListFn and, since #3772
+// (M9), deliberately does NOT swallow a dump failure — a snapshot missing a
+// family's route-leak routes would blackhole or policy-bypass inter-VRF
+// traffic. That is correct for production and it is what makes the test
+// surface fragile: in a sandbox without CAP_NET_ADMIN the dump returns EPERM,
+// buildRouteSnapshots returns (nil, err), buildSnapshot propagates it, and the
+// ~45 test call sites that discard the error dereference a nil
+// *ConfigSnapshot.
+//
+// The cost is not one failed test. A nil dereference is a SIGSEGV that aborts
+// the whole test BINARY, so the first one takes every remaining test in the
+// package down with it and the run reports a crash with no diagnostic rather
+// than a skip. That is what made an unrelated PR's review look like a
+// regression (a Codex hostile review of #6670, whose sandbox could not
+// enumerate route rules).
+//
+// The fix is hermeticity rather than detection. Skipping on EPERM — the
+// obvious reading — would trade a crash for silence and leave the package with
+// NO coverage in exactly the reduced-capability environments where reviews run.
+// Stubbing the enumerator instead lets every one of those tests actually RUN
+// there. No test in this package wants real kernel rules: the three that care
+// about rule CONTENT (routes_6467*, manager_fabric_writeback_5306,
+// manager_overlay_scheduler_5328) already install their own stub, and they
+// still work — they capture the current ruleListFn and restore it on cleanup,
+// which now restores to this stub rather than to netlink.RuleList.
+func TestMain(m *testing.M) {
+	ruleListFn = func(int) ([]netlink.Rule, error) { return nil, nil }
+	os.Exit(m.Run())
+}
+
+// TestPackageIsHermeticWrtKernelIPRules_6675 binds the WIRING above, not the
+// behaviour of the stub. Deleting the assignment in TestMain is the exact
+// regression this guards, and without a check on the live value that deletion
+// is invisible on any machine that happens to have CAP_NET_ADMIN — which is
+// every developer laptop and most CI runners, i.e. everywhere except the
+// sandbox this was filed for.
+//
+// Comparing code pointers is what makes it detectable: it asks "is the
+// enumerator still the real netlink one?" rather than "does calling it
+// happen to work here?", so the guard fails on a capable machine too.
+func TestPackageIsHermeticWrtKernelIPRules_6675(t *testing.T) {
+	live := reflect.ValueOf(ruleListFn).Pointer()
+	real := reflect.ValueOf(netlink.RuleList).Pointer()
+
+	// Vacuity: if these two ever compared equal for a reason other than the
+	// one under test, the assertion below would be meaningless. A nil
+	// ruleListFn would panic in reflect, so pin that it is set at all.
+	if ruleListFn == nil {
+		t.Fatal("ruleListFn is nil; the package cannot build a route snapshot at all")
+	}
+
+	if live == real {
+		t.Fatal("ruleListFn is still netlink.RuleList: this package's tests will " +
+			"dump the kernel ip-rule table, and in a sandbox without CAP_NET_ADMIN " +
+			"that EPERM becomes a nil *ConfigSnapshot dereference that SIGSEGVs the " +
+			"whole test binary. Restore the stub in TestMain (#6675).")
+	}
+}
+
+// TestSnapshotBuildsWithoutKernelIPRules_6675 is the end-to-end half: it proves
+// the property the stub exists to provide, so the guard above cannot be
+// satisfied by a stub that is installed but does not actually make snapshot
+// building work.
+func TestSnapshotBuildsWithoutKernelIPRules_6675(t *testing.T) {
+	snap, err := buildSnapshot(&config.Config{}, config.UserspaceConfig{}, 1, 0)
+	if err != nil {
+		t.Fatalf("buildSnapshot failed with the hermetic ip-rule enumerator: %v", err)
+	}
+	if snap == nil {
+		t.Fatal("buildSnapshot returned a nil snapshot with a nil error")
+	}
+}


### PR DESCRIPTION
Closes #6675

## What the cost actually is

In a sandbox without `CAP_NET_ADMIN` the kernel ip-rule dump returns EPERM. `buildRouteSnapshots` surfaces it rather than swallowing it — correct, and deliberate since #3772 (M9), because a snapshot missing a family's route-leak routes would blackhole or policy-bypass inter-VRF traffic. `buildSnapshot` propagates it and returns a nil `*ConfigSnapshot`. **~45 test call sites** in `pkg/dataplane/userspace` discard that error and dereference the result.

The cost is not one failed test — which is what I assumed before measuring. A nil dereference is a **SIGSEGV that aborts the whole test binary**, so the first one takes every remaining test in the package with it.

Reproduced by making the enumerator return EPERM:

| | before | after |
|---|---|---|
| result | **SIGSEGV**, binary aborted | `ok` |
| panics | 1 (then the run dies) | 0 |
| reported failures | 1 — a vast undercount | 0 |

That is why it reads as a regression in whatever PR is under review, with no diagnostic pointing anywhere near route rules. It is exactly how this surfaced: a Codex hostile review of #6670, which had nothing to do with routing.

## Implemented differently from the prescription, deliberately

The issue prescribes `t.Skipf` on a permission error and `t.Fatalf` otherwise.

Skipping treats "cannot enumerate route rules" as a reason to stop — but these tests don't want kernel rules, they want a snapshot. It trades a crash for silence and leaves the package with **zero coverage in exactly the reduced-capability environments where reviews run**, which the issue itself names as the second half of the problem. A `TestMain` that replaces `ruleListFn` package-wide lets all of them actually **run** there.

Verified against the reported condition rather than argued: with the default enumerator returning EPERM the full package is now green.

It is also one line rather than ~45 edits, and it covers tests not yet written — the next test to call `buildSnapshot` inherits hermeticity instead of re-introducing the trap.

**Nothing in the package wants real kernel rules.** The three tests that care about rule *content* (`routes_6467*`, `manager_fabric_writeback_5306`, `manager_overlay_scheduler_5328`) already install their own stub, and they keep working: each captures the current `ruleListFn` and restores it on cleanup, which now restores to this stub rather than to `netlink.RuleList`.

## Why the guard compares code pointers

It asks *"is the enumerator still the real netlink one?"*, not *"does calling it happen to work here?"*. A behavioural check passes on any machine that **has** the capability — every developer laptop and most CI runners — so it would never notice the stub being deleted, and the regression would resurface only in the sandbox this was filed for.

A second test proves the end-to-end property, so an installed-but-broken stub cannot satisfy the wiring guard alone.

## Mutation matrix

Every cell verified APPLIED first.

| # | mutation | result |
|---|---|---|
| R1 | delete the assignment from `TestMain` | **RED** — wiring guard |
| R2 | stub installed but returns an error | **RED** — end-to-end test |
| R3 | assign `netlink.RuleList` explicitly | **RED** — wiring guard |

R1/R3 red the wiring guard; R2 reds only the end-to-end test. The split is intentional — neither test alone covers both failures.

## Not fixed here

The ~45 sites that discard the `buildSnapshot` error remain. With the package hermetic they can no longer fail for an *environmental* reason, so what is left is ordinary test-authoring breakage that shows up immediately and locally rather than as a phantom regression in someone else's review. Filing separately rather than folding a 45-file mechanical change into this one.

## Validation

`go test -count=1 ./...` green; `go build ./...` clean.

**Test-only change plus a docs note** (`docs/engineering-style.md`, project-specific reminders). No production code, no shim `.o`, no helper binary, no cluster surface.