### PR TITLE
config: split a packed chassis cluster body (#6672)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -102938,3 +102938,12 @@ prose edit above them added. No diff falls in the new test body.
   pkg/dataplane/compiler.go, pkg/dataplane/compiler_iface.go,
   pkg/dataplane/original_kernel_name_callsite_7426_test.go (new),
   pkg/daemon/daemon_reth.go, pkg/daemon/daemon_reth_pciaddr_6199_test.go, _Log.md
+
+## 2026-08-22 — #6672 packed chassis cluster body
+- **Timestamp**: 2026-08-22
+- **Action**: Split a packed `chassis cluster` body into statements before BOTH
+  the compiler and the schema walker, so all five spellings compile identically
+  and the packed spelling cannot escape the typed-leaf range gates.
+- **File(s)**: pkg/config/compiler_chassis_cluster_packed.go (new),
+  pkg/config/compiler_system.go, pkg/config/schema_walk.go,
+  pkg/config/packed_chassis_cluster_6672_test.go, docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2570,12 +2570,26 @@ is what Junos renders (one statement per line).
 
 Consequences worth knowing when adding a reader:
 
-- **The schema walker does not see this shape at all.** `SchemaValidate` walks
-  the AST from `setSchema`, and a packed tail sits below the depth it reaches,
-  so a typed leaf's `validator` never fires on it. A range/arity gate that must
-  cover the packed spelling has to run on the COMPILED struct
-  (`validateChassisClusterStrict`), not on the schema — which is only true once
-  the packed shape actually compiles.
+- **The schema walker does not see this shape** — unless the subtree is
+  NORMALIZED before the walk. `SchemaValidate` walks the AST from `setSchema`,
+  and a packed tail sits below the depth it reaches, so a typed leaf's
+  `validator` never fires on it. Two answers exist, and which one is available
+  depends on whether the packed body can be split back into statements:
+  - Where it can, split it **before both consumers**. `chassis cluster`
+    (#6672, below) expands its packed body into children at the top of
+    `SchemaValidateWithDefinitions` and inside `compileChassis`, so the
+    EXISTING typed-leaf validators fire on the packed spelling unchanged. That
+    is strictly better than a parallel gate: there is one bounds table, and it
+    is the one the container spelling already uses.
+  - Where it cannot, the gate has to run on the COMPILED struct
+    (`validateChassisClusterStrict`), not on the schema — which is only true
+    once the packed shape actually compiles.
+
+  Either way, **making a packed spelling compile without also making it
+  validate opens a range-gate escape that did not exist before**: while the
+  packed form compiled to nothing, the missing walker coverage was inert. This
+  is not hypothetical — `cluster-id` is one byte of the RETH virtual MAC and
+  `reth-advertise-interval` is a 12-bit VRRP wire field.
 - **Silently compiling to nothing is the worst of the three options.** A
   statement whose packed spelling is genuinely unsupported must be REJECTED at
   commit with an actionable error. `services ip-monitoring` (a different
@@ -2584,6 +2598,55 @@ Consequences worth knowing when adding a reader:
   compiled routes is a hard commit error ("at least one then preferred-route
   route is required"), so the operator is told rather than left with a silent
   no-op.
+- **`chassis cluster` is the whole-stanza case (#6672).** The same shape one
+  level ABOVE the redundancy group dropped the ENTIRE cluster configuration.
+  Four spellings exist and three were silently empty:
+
+  ```
+  chassis { cluster { cluster-id 1; node 0; } }   # container  -> compiles
+  chassis { cluster cluster-id 1 node 0; }        # packed body -> ClusterConfig, every field zero
+  chassis cluster { cluster-id 1; node 0; }       # keyword packed onto the chassis line -> Cluster == nil
+  chassis cluster cluster-id 1 node 0;            # fully packed -> Cluster == nil
+  ```
+
+  A fifth arrives from the child side — `cluster { node 1 reth-count 2; }`, one
+  child carrying two statements — and is split the same way. `compileChassis`
+  reads the body with `FindChild`, i.e. off `.Children`, so a packed body was an
+  empty stanza: no cluster-id, no node identity, no control PSK, no fabric
+  addresses, no redundancy groups, and a clean `commit` with
+  `show configuration` echoing what the operator wrote.
+
+  `clusterStatements` (`compiler_chassis_cluster_packed.go`) is the SSOT for the
+  statement set and each statement's value arity, and `clusterBodyStatements` is
+  the splitter. Two properties are specific to this level and worth carrying:
+
+  - **It nests, so `packedStatementPropsArity` (#6665) is not enough.** That
+    helper is flat: any registered keyword re-arms it. The cluster and
+    redundancy-group tables OVERLAP on exactly one token, `node` — the cluster's
+    own identity and a group's per-node priority — so under the flat rule
+    `redundancy-group 1 node 0 priority 200` re-arms at `node`, setting the
+    CLUSTER's node identity and dropping the group's election priority. That is
+    the #6588 failure reintroduced one level up. The rule is: once
+    `redundancy-group` opens, a token re-arms only if it is `redundancy-group`
+    itself or a cluster statement that is NOT also a redundancy-group statement.
+    Overlap resolves to the INNER scope; cluster-only statements written after a
+    packed group (`... redundancy-group 1 preempt reth-count 2`) still compile.
+  - **The #6665 value-slot reservation crosses the boundary.** While a
+    redundancy-group tail is open the splitter honours
+    `redundancyGroupStatementArity`, so `interface-monitor reth-count weight 255`
+    keeps a monitored interface literally named after a CLUSTER keyword instead
+    of re-arming the outer splitter. `ValidateDeviceMapLogicalName` admits
+    keyword-shaped names, so that is a name an operator can configure.
+
+  Two divergences the work surfaced, both tracked separately rather than folded
+  in: `fabric1-interface` and `fabric1-peer-address` are compiled by
+  `compileChassis` but absent from `schemaChassis` (no completion, no
+  validator), and `additional-authentication-key` / `control-ports` /
+  `private-rg-election` sit on the other side of that line for stated reasons.
+  `TestClusterSplitterAndSchemaAgree_6672` binds the set in both directions with
+  the exception list as an EQUALITY, so the exception cannot outlive the
+  divergence it documents.
+
 - **`system login` is the fail-closed example with a dedicated gate (#6662).**
   Where `ip-monitoring` gets its rejection for free (an empty policy is
   independently invalid), an empty login class is *structurally* fine, so the

--- a/pkg/config/compiler_chassis_cluster_packed.go
+++ b/pkg/config/compiler_chassis_cluster_packed.go
@@ -1,0 +1,345 @@
+package config
+
+// compiler_chassis_cluster_packed.go undoes a PACKED `chassis cluster` body
+// (#6672) — the one-level-up twin of the redundancy-group packing
+// compiler_system.go already undoes (#6588/#6665).
+//
+// THE DEFECT. A packed statement puts all its tokens on ONE node's Keys with no
+// Children. compileChassis reads the cluster body with FindChild, i.e. off
+// `.Children`, so all four spellings below had to be handled and only the first
+// two were:
+//
+//	chassis { cluster { cluster-id 1; node 0; } }   -> compiles (container)
+//	chassis { cluster cluster-id 1 node 0; }        -> ClusterConfig, EMPTY
+//	chassis cluster { cluster-id 1; node 0; }       -> Cluster == nil
+//	chassis cluster cluster-id 1 node 0;            -> Cluster == nil
+//
+// The blast radius is the whole stanza: cluster-id, node identity, the control
+// PSK, the fabric addresses, every redundancy group. The commit SUCCEEDS and
+// `show configuration` echoes what the operator wrote, so nothing indicates the
+// firewall is running with no cluster configuration at all. At the
+// redundancy-group level the same shape lost one group's election priority
+// (#6588); here it loses the cluster.
+//
+// TWO CONSUMERS, ONE SPLITTER. The body is normalized BEFORE both the compiler
+// and the schema walker, not inside each. That matters for more than tidiness:
+// making the packed spelling COMPILE without also making it VALIDATE would open
+// a range-gate escape that does not exist today. Every cluster value is gated by
+// its typed schema leaf (`cluster-id` 0..255 — one byte of the RETH virtual MAC;
+// `reth-advertise-interval` 10..40959 — the encodable range of a 12-bit VRRP
+// wire field), and the schema WALKER only reaches a statement that sits at its
+// modeled depth. A packed statement sits below it, so no validator fires. While
+// the packed form compiled to nothing that was harmless; the moment it compiles,
+// an ungated MAC byte and an ungated VRRP interval reach the runtime by writing
+// the config on one line. Normalizing first means the EXISTING validators fire
+// on the packed body unchanged — one source of bounds, no parallel table to
+// drift.
+
+// clusterStatements is the SINGLE SOURCE OF TRUTH for what a `chassis cluster`
+// body may contain, and for how many tokens each statement consumes as its
+// VALUE before the splitter may open another statement.
+//
+// Two consumers read it: the packed-line splitter below, and the tests that
+// pin packed-vs-container agreement per statement. It is deliberately a
+// keyword->arity map rather than a keyword->compiler-func dispatch table (the
+// shape redundancyGroupStatements uses): compileChassis reads the cluster body
+// as a flat if-chain of heterogeneous types (int, string, bool, Secret), and
+// rewriting 150 lines of it into closures to derive the token set would be a
+// much larger and riskier change than the defect warrants. The binding is
+// instead BEHAVIOURAL — see TestEveryCompiledClusterStatementIsSplit_6672,
+// which compiles each candidate keyword in container form and requires anything
+// the compiler actually honours to appear here. That test is the reason this
+// table cannot silently fall behind the compiler, and it does not model the
+// compiler's SOURCE TEXT, which is the tool #6588 rejected.
+//
+// THE ARITY IS WHAT STOPS A VALUE TOKEN FROM RE-ARMING THE SPLITTER (#6665). A
+// splitter with no positional state opens a new statement wherever a registered
+// keyword appears, INCLUDING where a value is expected: `control-interface node`
+// would otherwise compile to no control interface plus a fabricated `node`
+// statement, silently changing which node this box believes it is. Every
+// statement with a value slot reserves exactly one token.
+var clusterStatements = map[string]int{
+	// Value-carrying statements: exactly one token each.
+	"cluster-id":                    1,
+	"node":                          1,
+	"reth-count":                    1,
+	"heartbeat-interval":            1,
+	"heartbeat-threshold":           1,
+	"authentication-key":            1,
+	"additional-authentication-key": 1,
+	"control-interface":             1,
+	"peer-address":                  1,
+	"fabric-interface":              1,
+	"fabric-peer-address":           1,
+	"fabric1-interface":             1,
+	"fabric1-peer-address":          1,
+	"reth-advertise-interval":       1,
+	"peer-fencing":                  1,
+	"takeover-hold-time":            1,
+	// `redundancy-group <id>` — the id is its value slot; everything after it
+	// belongs to the group's own body until a cluster-only keyword or the next
+	// `redundancy-group`. See clusterBodyStatements.
+	"redundancy-group": 1,
+
+	// Valueless flags: the token after them genuinely opens a statement.
+	"control-link-recovery":         0,
+	"configuration-synchronize":     0,
+	"nat-state-synchronization":     0,
+	"ipsec-session-synchronization": 0,
+	"dhcp-lease-synchronization":    0,
+	"hitless-restart":               0,
+	"no-reth-vrrp":                  0,
+	"private-rg-election":           0,
+	"no-private-rg-election":        0,
+	// Accepted for Junos compatibility and never compiled (schema_chassis.go
+	// documents it as ignored). Registered anyway: an unregistered keyword is
+	// not inert, it FOLDS onto whatever statement precedes it on a packed
+	// line, so leaving a known-ignored statement out would corrupt its
+	// NEIGHBOUR rather than itself.
+	"control-ports": 0,
+}
+
+const clusterKeyword = "cluster"
+const redundancyGroupKeyword = "redundancy-group"
+
+// isClusterStatement reports whether tok opens a `chassis cluster` body
+// statement.
+func isClusterStatement(tok string) bool {
+	_, ok := clusterStatements[tok]
+	return ok
+}
+
+// clusterStatementArity is how many tokens tok consumes as its VALUE before the
+// splitter may open another statement.
+func clusterStatementArity(tok string) int { return clusterStatements[tok] }
+
+// clusterBodyStatements splits a packed `chassis cluster` body into one node per
+// statement, then appends any real children (a config may carry both).
+//
+// skip is how many leading identity Keys to drop: 1 for a `cluster` node
+// (`cluster <body>`), 2 for a chassis node carrying the whole thing
+// (`chassis cluster <body>`).
+//
+// WHY THIS IS NOT packedStatementPropsArity. That helper (#6665) is flat: one
+// open statement, an arity countdown, and any registered keyword re-arms it.
+// A cluster body nests — `redundancy-group <id>` is followed by the GROUP's
+// statements, which redundancyGroupBody re-splits with its own table — and the
+// two tables OVERLAP on exactly one token, `node`. Under the flat rule
+// `redundancy-group 1 node 0 priority 200` re-arms at `node`, which sets the
+// CLUSTER's node identity to 0 and drops the group's election priority: the
+// precise failure #6588 exists to prevent, reintroduced one level up.
+//
+// The nesting rule is therefore: once `redundancy-group` opens, a token
+// re-arms the splitter only if it is `redundancy-group` itself or a cluster
+// statement that is NOT also a redundancy-group statement. Overlap tokens
+// resolve to the INNER scope, which is the only reading that preserves the
+// group's own `node <id> priority <p>`. `reth-count` and friends are
+// cluster-only, so a cluster statement written after a packed group is still
+// compiled rather than swallowed.
+//
+// The RG tail additionally honours redundancyGroupStatementArity while it is
+// open, so an interface named after a cluster-only keyword
+// (`interface-monitor reth-count weight 255`) stays in the monitor's value slot
+// instead of being stolen — the #6665 reservation, applied across the nesting
+// boundary.
+func clusterBodyStatements(cfgNode *Node, skip int) []*Node {
+	stmts := splitClusterKeys(cfgNode.Keys, skip, cfgNode.Line, cfgNode.Column)
+	// A CHILD can be packed too: `cluster { node 1 reth-count 2; }` is one child
+	// carrying two statements, the shape #6588 undoes at the redundancy-group
+	// level. Split each child's KEYS with the same table, and hand the child's
+	// own Children to the LAST statement they belong to — a `redundancy-group`
+	// body stays with the redundancy-group, where redundancyGroupBody re-splits
+	// it with the RG table rather than this one.
+	for _, c := range cfgNode.Children {
+		if c == nil {
+			continue
+		}
+		stmts = append(stmts, splitPackedClusterChild(c)...)
+	}
+	return stmts
+}
+
+// splitPackedClusterChild returns c unchanged — the SAME pointer, so Inactive,
+// Annotation and key provenance are preserved — when its keys are already one
+// statement, and otherwise the statements packed onto them.
+func splitPackedClusterChild(c *Node) []*Node {
+	parts := splitClusterKeys(c.Keys, 0, c.Line, c.Column)
+	if len(parts) <= 1 {
+		return []*Node{c}
+	}
+	parts[len(parts)-1].Children = c.Children
+	parts[len(parts)-1].IsLeaf = c.IsLeaf && len(c.Children) == 0
+	return parts
+}
+
+func splitClusterKeys(keys []string, skip, line, column int) []*Node {
+	var stmts []*Node
+	if len(keys) > skip {
+		var cur *Node
+		pending := 0   // value tokens the open CLUSTER statement must absorb
+		inRG := false  // the open statement is a redundancy-group tail
+		rgPending := 0 // value tokens the open RG statement must absorb
+		for _, tok := range keys[skip:] {
+			if pending > 0 {
+				pending--
+				cur.Keys = append(cur.Keys, tok)
+				continue
+			}
+			if inRG && tok != redundancyGroupKeyword {
+				if rgPending > 0 {
+					rgPending--
+					cur.Keys = append(cur.Keys, tok)
+					continue
+				}
+				if isRedundancyGroupStatement(tok) {
+					rgPending = redundancyGroupStatementArity(tok)
+					cur.Keys = append(cur.Keys, tok)
+					continue
+				}
+			}
+			if cur == nil || isClusterStatement(tok) {
+				cur = &Node{Keys: []string{tok}, Line: line, Column: column}
+				stmts = append(stmts, cur)
+				pending = clusterStatementArity(tok)
+				inRG = tok == redundancyGroupKeyword
+				rgPending = 0
+				continue
+			}
+			cur.Keys = append(cur.Keys, tok)
+		}
+	}
+	return stmts
+}
+
+// normalizedClusterNode returns the `chassis cluster` node with its body in
+// Children, across all four spellings, or nil when the chassis stanza carries
+// no cluster at all.
+//
+// The container spelling is returned UNTOUCHED — same pointer, no clone — so
+// the overwhelmingly common path allocates nothing and cannot be perturbed by
+// this code at all.
+func normalizedClusterNode(chassisNode *Node) *Node {
+	if chassisNode == nil {
+		return nil
+	}
+	if cn := chassisNode.FindChild(clusterKeyword); cn != nil {
+		if !clusterBodyNeedsSplit(cn, 1) {
+			return cn // `cluster { ... }` — already one node per statement.
+		}
+		return synthesizedClusterNode(cn, 1)
+	}
+	// `chassis cluster ...` — the keyword is packed onto the chassis node's own
+	// Keys, so FindChild sees nothing and the pre-#6672 compiler returned early
+	// with Cluster == nil. This covers both the fully packed body and
+	// `chassis cluster { ... }`, where the braces put the body in Children but
+	// the `cluster` keyword is still on the chassis line.
+	if len(chassisNode.Keys) > 1 && chassisNode.Keys[1] == clusterKeyword {
+		return synthesizedClusterNode(chassisNode, 2)
+	}
+	return nil
+}
+
+func synthesizedClusterNode(n *Node, skip int) *Node {
+	return &Node{
+		Keys:     []string{clusterKeyword},
+		Children: clusterBodyStatements(n, skip),
+		Line:     n.Line,
+		Column:   n.Column,
+	}
+}
+
+// chassisClusterIsPacked reports whether a chassis node carries a cluster body
+// in a spelling the container-shaped readers cannot see.
+func chassisClusterIsPacked(chassisNode *Node) bool {
+	if chassisNode == nil {
+		return false
+	}
+	if cn := chassisNode.FindChild(clusterKeyword); cn != nil {
+		return clusterBodyNeedsSplit(cn, 1)
+	}
+	return len(chassisNode.Keys) > 1 && chassisNode.Keys[1] == clusterKeyword
+}
+
+// clusterBodyNeedsSplit reports whether any statement of this cluster body is
+// packed — on the cluster line itself (`cluster <body>`) or onto one of its
+// children (`cluster { node 1 reth-count 2; }`, the #6588 shape at cluster
+// level). False means every statement is already its own node and the caller
+// must return the body untouched, which is the overwhelmingly common path.
+func clusterBodyNeedsSplit(cn *Node, skip int) bool {
+	if cn == nil {
+		return false
+	}
+	if len(cn.Keys) > skip {
+		return true
+	}
+	for _, c := range cn.Children {
+		if c == nil {
+			continue
+		}
+		if len(splitClusterKeys(c.Keys, 0, c.Line, c.Column)) > 1 {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizePackedChassisCluster returns a tree whose packed `chassis cluster`
+// bodies are expanded into children, so a reader that walks `.Children` — the
+// schema walker, and compileChassis via normalizedClusterNode — sees the same
+// statements for every spelling.
+//
+// It returns the ORIGINAL tree, uncloned, when nothing is packed. That is the
+// common path and it must stay free; it also means a caller cannot tell the
+// two apart by identity alone, which is why the test for this asserts on a
+// tree that IS packed and fails loudly if the transform declined to run.
+func normalizePackedChassisCluster(t *ConfigTree) *ConfigTree {
+	if t == nil {
+		return nil
+	}
+	var out []*Node
+	for i, n := range t.Children {
+		if n == nil || n.Name() != "chassis" || !chassisClusterIsPacked(n) {
+			continue
+		}
+		if out == nil {
+			out = make([]*Node, len(t.Children))
+			copy(out, t.Children)
+		}
+		out[i] = normalizedChassisNode(n)
+	}
+	if out == nil {
+		return t
+	}
+	return &ConfigTree{Children: out}
+}
+
+// normalizedChassisNode rebuilds one `chassis` node with its cluster body
+// expanded, preserving every sibling statement (a `device-map` under a
+// standalone box's chassis stanza must survive — #1956 R-7).
+func normalizedChassisNode(chassisNode *Node) *Node {
+	cluster := normalizedClusterNode(chassisNode)
+	out := &Node{
+		Keys:       []string{"chassis"},
+		IsLeaf:     false,
+		Annotation: chassisNode.Annotation,
+		Inactive:   chassisNode.Inactive,
+		Line:       chassisNode.Line,
+		Column:     chassisNode.Column,
+	}
+	for _, c := range chassisNode.Children {
+		if c != nil && c.Name() == clusterKeyword {
+			continue // replaced by the normalized node below
+		}
+		// A `chassis cluster <body>` node's children ARE the cluster body and
+		// were already folded in by clusterBodyStatements; keep siblings only
+		// for the `chassis { ... }` shape.
+		if len(chassisNode.Keys) > 1 && chassisNode.Keys[1] == clusterKeyword {
+			continue
+		}
+		out.Children = append(out.Children, c)
+	}
+	if cluster != nil {
+		out.Children = append(out.Children, cluster)
+	}
+	return out
+}

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -1932,7 +1932,12 @@ func compileChassis(node *Node, ch *ChassisConfig) error {
 		}
 	}
 
-	clusterNode := node.FindChild("cluster")
+	// #6672: resolve the cluster body across all four spellings. A body packed
+	// onto the `cluster` line — or onto the `chassis` line above it — carries
+	// its statements on Keys with NO children, so the FindChild reads below saw
+	// an empty stanza and compiled nothing while the commit succeeded. The
+	// container spelling returns the same node, untouched.
+	clusterNode := normalizedClusterNode(node)
 	if clusterNode == nil {
 		return nil
 	}
@@ -2383,7 +2388,13 @@ func redundancyGroupStatementArity(tok string) int {
 
 // redundancyGroupBody returns the body statements of one `redundancy-group`
 // instance across both spellings (#6588). It is the ONE-LEVEL-UP twin of the
-// packing this file already undoes inside the body:
+// packing this file already undoes inside the body — and is itself one level
+// BELOW the `chassis cluster` body, where the same shape dropped the entire
+// cluster stanza (#6672, compiler_chassis_cluster_packed.go). The two splitters
+// interact on exactly one token: `node` is both a cluster statement and a
+// redundancy-group statement, so the cluster splitter must NOT re-arm on it
+// inside a group's tail or this function never sees the priority it exists to
+// preserve:
 //
 //	redundancy-group 1 { interface-monitor ge-0/0/0 weight 255; }
 //	  -> Keys=["redundancy-group","1"], one child per statement

--- a/pkg/config/packed_chassis_cluster_6672_test.go
+++ b/pkg/config/packed_chassis_cluster_6672_test.go
@@ -1,0 +1,678 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// #6672 — a packed `chassis cluster` body dropped the ENTIRE cluster stanza.
+//
+// A packed statement puts all its tokens on ONE node's Keys with no Children,
+// and compileChassis read the body with FindChild, i.e. off `.Children`. Three
+// of the four spellings therefore compiled nothing while the commit SUCCEEDED
+// and `show configuration` echoed what the operator wrote:
+//
+//	chassis { cluster { ... } }        -> compiles
+//	chassis { cluster <body>; }        -> a ClusterConfig with every field zero
+//	chassis cluster { ... }            -> Cluster == nil
+//	chassis cluster <body>;            -> Cluster == nil
+//
+// The issue named two of those three. The `chassis cluster { ... }` shape — the
+// brace at the top level, so the body IS in Children but the `cluster` keyword
+// is packed onto the chassis line — drops just as silently and is covered here.
+//
+// The blast radius is the whole stanza: cluster-id, node identity, the control
+// PSK, the fabric addresses, and every redundancy group under it. At the
+// redundancy-group level (#6588) the same shape lost one group's election
+// priority; here it loses the cluster.
+
+// clusterOracleValues supplies one VALID value per statement so a fixture can
+// be generated for every entry in clusterStatements rather than for a
+// hand-picked sample. An entry missing here fails
+// TestEveryClusterStatementHasAnOracleValue_6672, so adding a statement to the
+// table without adding a fixture for it is a build failure, not a silent
+// coverage hole.
+var clusterOracleValues = map[string]string{
+	"cluster-id":                    "22",
+	"node":                          "1",
+	"reth-count":                    "2",
+	"heartbeat-interval":            "200",
+	"heartbeat-threshold":           "5",
+	"authentication-key":            "primary-psk",
+	"additional-authentication-key": "rollover-psk",
+	"control-interface":             "em0",
+	"peer-address":                  "10.99.0.2",
+	"fabric-interface":              "fab0",
+	"fabric-peer-address":           "10.98.0.2",
+	"fabric1-interface":             "fab1",
+	"fabric1-peer-address":          "10.97.0.2",
+	"reth-advertise-interval":       "30",
+	"peer-fencing":                  "disable-rg",
+	"takeover-hold-time":            "5000",
+	"redundancy-group":              "1 node 0 priority 200",
+
+	"control-link-recovery":         "",
+	"configuration-synchronize":     "",
+	"nat-state-synchronization":     "",
+	"ipsec-session-synchronization": "",
+	"dhcp-lease-synchronization":    "",
+	"hitless-restart":               "",
+	"no-reth-vrrp":                  "",
+	"private-rg-election":           "",
+	"no-private-rg-election":        "",
+	"control-ports":                 "",
+}
+
+// clusterCompilerOnlyStatements are compiled by compileChassis but NOT declared
+// in schemaChassis, so they have no tab completion and no typed-leaf validator.
+// That is a live #6663-class divergence, tracked separately rather than folded
+// into this fix. This set exists so the agreement test below can be an EQUALITY
+// rather than a one-sided containment: when the schema gains these leaves, the
+// test fails and the entry must be deleted here in the same change.
+var clusterCompilerOnlyStatements = map[string]bool{
+	"fabric1-interface":    true,
+	"fabric1-peer-address": true,
+}
+
+func clusterSchemaChildren(t *testing.T) map[string]*schemaNode {
+	t.Helper()
+	cl := schemaChassis.children["cluster"]
+	if cl == nil || len(cl.children) == 0 {
+		t.Fatalf("schemaChassis has no cluster children — this test asserts nothing")
+	}
+	return cl.children
+}
+
+func compileClusterJSON6672(t *testing.T, src string) string {
+	t.Helper()
+	tree, errs := NewParser(src).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("fixture parse errors: %v\n%s", errs, src)
+	}
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("compile: %v\n%s", err, src)
+	}
+	b, err := json.Marshal(cfg.Chassis.Cluster)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+// clusterSpellings renders one cluster body in the four spellings. body is the
+// statement text WITHOUT a trailing `;` and using packed (one-line) form; the
+// container spelling wraps it in braces on its own line, which for a
+// single-statement body is the same tokens with different structure.
+func clusterSpellings(body string) map[string]string {
+	return map[string]string{
+		"container":         "chassis {\n    cluster {\n        " + body + ";\n    }\n}\n",
+		"packed-in-chassis": "chassis {\n    cluster " + body + ";\n}\n",
+		"packed-top-level":  "chassis cluster " + body + ";\n",
+		"brace-top-level":   "chassis cluster {\n    " + body + ";\n}\n",
+	}
+}
+
+// TestEveryClusterStatementCompilesTheSameInEverySpelling_6672 is the issue's
+// acceptance: "pinned for every statement the cluster body admits, with a
+// fail-on-revert test per statement rather than one aggregate assertion".
+//
+// One subtest per statement per spelling, so a revert names WHICH statement and
+// WHICH spelling broke instead of failing one lump assertion. The oracle is the
+// container spelling — the one that always worked — so the test cannot be
+// satisfied by all four agreeing on nothing.
+func TestEveryClusterStatementCompilesTheSameInEverySpelling_6672(t *testing.T) {
+	keywords := make([]string, 0, len(clusterStatements))
+	for kw := range clusterStatements {
+		keywords = append(keywords, kw)
+	}
+	sort.Strings(keywords)
+
+	for _, kw := range keywords {
+		kw := kw
+		t.Run(kw, func(t *testing.T) {
+			val, ok := clusterOracleValues[kw]
+			if !ok {
+				t.Fatalf("no oracle value for %q", kw)
+			}
+			body := kw
+			if val != "" {
+				body += " " + val
+			}
+			spellings := clusterSpellings(body)
+			want := compileClusterJSON6672(t, spellings["container"])
+
+			// The oracle must be non-vacuous for every statement that has a
+			// compiled effect: if the container form compiles to the same thing
+			// as an EMPTY cluster body, the agreement below is satisfied by all
+			// four spellings doing nothing.
+			empty := compileClusterJSON6672(t, "chassis {\n    cluster {\n    }\n}\n")
+			compiled := want != empty
+			if !compiled && !clusterStatementIsKnownInert(kw) {
+				t.Fatalf("container spelling of %q compiles to an empty cluster — "+
+					"either the statement is not compiled (register it in "+
+					"clusterStatementIsKnownInert with a reason) or the oracle "+
+					"value %q is wrong", kw, val)
+			}
+
+			for _, spelling := range []string{"packed-in-chassis", "packed-top-level", "brace-top-level"} {
+				got := compileClusterJSON6672(t, spellings[spelling])
+				if got != want {
+					t.Errorf("%s spelling of %q does not match the container spelling\n want %s\n  got %s",
+						spelling, kw, want, got)
+				}
+			}
+		})
+	}
+}
+
+// clusterStatementIsKnownInert names the statements with NO compiled effect, so
+// the non-vacuity guard above can tell "correctly compiles nothing" from
+// "silently dropped". Each needs a reason, because the default answer is that a
+// statement the operator can write should do something.
+func clusterStatementIsKnownInert(kw string) bool {
+	switch kw {
+	case "control-ports":
+		// Accepted for Junos compatibility, never read by compileChassis
+		// (schema_chassis.go documents the compiled-leaf-only invariant).
+		return true
+	case "node":
+		// The oracle sets node 1, and NodeID/NodeIDSet do land — but on a
+		// standalone parse the compiled node identity is later overridden by
+		// the node-id file, so treat a no-delta result as acceptable rather
+		// than asserting on it here.
+		return false
+	case "private-rg-election":
+		// The DEFAULT is already true, so setting it explicitly is a no-op on
+		// the compiled struct. Its negation (no-private-rg-election) is the one
+		// with an effect, and that is covered by its own subtest.
+		return true
+	}
+	return false
+}
+
+// TestEveryClusterStatementHasAnOracleValue_6672 keeps the generated fixture
+// set complete: adding a statement to clusterStatements without a value here
+// would silently skip it in the per-statement test above.
+func TestEveryClusterStatementHasAnOracleValue_6672(t *testing.T) {
+	for kw := range clusterStatements {
+		if _, ok := clusterOracleValues[kw]; !ok {
+			t.Errorf("clusterStatements has %q with no clusterOracleValues entry — "+
+				"the per-statement agreement test would skip it", kw)
+		}
+	}
+	for kw := range clusterOracleValues {
+		if !isClusterStatement(kw) {
+			t.Errorf("clusterOracleValues has %q, which is not a cluster statement", kw)
+		}
+	}
+}
+
+// TestClusterSplitterAndSchemaAgree_6672 binds the splitter table to the schema
+// in BOTH directions, with the one known divergence named rather than tolerated.
+//
+// Direction 1 (schema => splitter) is the one that corrupts: a statement the
+// operator can write and the schema completes, but the splitter does not know,
+// FOLDS onto whichever statement precedes it on a packed line — so it silently
+// does nothing AND corrupts its neighbour, while the same statement alone on a
+// line still works. A developer therefore sees it work.
+//
+// Direction 2 (splitter => schema) catches the reverse: a statement registered
+// here that the grammar does not admit would reserve value slots for tokens
+// that can never appear.
+//
+// The ARITY must agree too. A splitter that reserves the wrong number of value
+// tokens is worse than one that reserves none: it swallows the following
+// statement.
+func TestClusterSplitterAndSchemaAgree_6672(t *testing.T) {
+	schemaChildren := clusterSchemaChildren(t)
+
+	for kw, sn := range schemaChildren {
+		arity, ok := clusterStatements[kw]
+		if !ok {
+			t.Errorf("schema declares `chassis cluster %s` but the packed-line splitter "+
+				"does not know it — on a packed line its tokens FOLD onto the preceding "+
+				"statement, so it silently does nothing and corrupts its neighbour", kw)
+			continue
+		}
+		if arity != sn.args {
+			t.Errorf("`chassis cluster %s`: splitter reserves %d value token(s), schema "+
+				"declares args=%d — a wrong reservation swallows the NEXT statement",
+				kw, arity, sn.args)
+		}
+	}
+
+	for kw := range clusterStatements {
+		if _, ok := schemaChildren[kw]; ok {
+			continue
+		}
+		if clusterCompilerOnlyStatements[kw] {
+			continue
+		}
+		t.Errorf("the splitter registers `chassis cluster %s`, which the schema does not "+
+			"declare and which is not in the documented compiler-only set", kw)
+	}
+
+	// EQUALITY, not containment: when the schema gains a compiler-only leaf,
+	// the exception must be deleted in the same change or this fires. Without
+	// this half the exception set would silently outlive the divergence it
+	// documents.
+	for kw := range clusterCompilerOnlyStatements {
+		if _, ok := schemaChildren[kw]; ok {
+			t.Errorf("`chassis cluster %s` is now declared in the schema — delete it from "+
+				"clusterCompilerOnlyStatements", kw)
+		}
+		if !isClusterStatement(kw) {
+			t.Errorf("clusterCompilerOnlyStatements names %q, which the splitter does not register", kw)
+		}
+	}
+}
+
+var clusterFindChildRe = regexp.MustCompile(`clusterNode\.FindChild(?:ren)?\("([a-z0-9-]+)"\)`)
+
+// TestEveryCompiledClusterStatementIsSplit_6672 is the BEHAVIOURAL binding
+// between the compiler and the splitter table, and it is what stops the table
+// falling behind compileChassis.
+//
+// The assertion is behavioural on purpose: for each candidate keyword the
+// splitter does NOT register, the container spelling must compile to an EMPTY
+// cluster. If it compiles to something, the compiler honours a statement the
+// splitter will fold on a packed line.
+//
+// The candidate POPULATION is a floor, and saying so matters. It is the union
+// of the schema's cluster children, the splitter table, and a source scan of
+// compileChassis for `clusterNode.FindChild("...")` literals. The source scan
+// is used only to WIDEN the population, never as the assertion — modelling one
+// program's source text as an oracle is the tool #6588 removed, because it
+// misses a case on a named CONSTANT, a statement handled by a helper outside
+// the block, and dispatch nested inside another arm. A keyword missed by all
+// three sources degrades to "not covered", which is where it already was.
+func TestEveryCompiledClusterStatementIsSplit_6672(t *testing.T) {
+	candidates := map[string]bool{}
+	for kw := range clusterSchemaChildren(t) {
+		candidates[kw] = true
+	}
+	for kw := range clusterStatements {
+		candidates[kw] = true
+	}
+
+	src, err := os.ReadFile("compiler_system.go")
+	if err != nil {
+		t.Fatalf("read compiler_system.go: %v", err)
+	}
+	scanned := clusterFindChildRe.FindAllStringSubmatch(string(src), -1)
+	if len(scanned) == 0 {
+		t.Fatalf("the source scan found no clusterNode.FindChild literals — the " +
+			"candidate population lost one of its three sources, so this test is " +
+			"weaker than it reads")
+	}
+	for _, m := range scanned {
+		candidates[m[1]] = true
+	}
+
+	empty := compileClusterJSON6672(t, "chassis {\n    cluster {\n    }\n}\n")
+	names := make([]string, 0, len(candidates))
+	for kw := range candidates {
+		names = append(names, kw)
+	}
+	sort.Strings(names)
+
+	for _, kw := range names {
+		if isClusterStatement(kw) {
+			continue
+		}
+		for _, val := range []string{"", "x", "1"} {
+			body := kw
+			if val != "" {
+				body += " " + val
+			}
+			got := compileClusterJSON6672(t, "chassis {\n    cluster {\n        "+body+";\n    }\n}\n")
+			if got != empty {
+				t.Errorf("compileChassis honours `chassis cluster %s` but the splitter does "+
+					"not register it — on a packed line its tokens fold onto the preceding "+
+					"statement\n compiled: %s", body, got)
+				break
+			}
+		}
+	}
+}
+
+// TestPackedClusterDoesNotEscapeTheRangeGates_6672 is the reason this fix is
+// not just the compiler change.
+//
+// Every typed cluster leaf is bounded by its schema validator, and the schema
+// WALKER only reaches a statement at its modeled depth. A packed statement sits
+// below that depth, so no validator fires on it. While the packed spelling
+// compiled to nothing that was inert; the moment it compiles, writing the
+// config on ONE LINE would have been a way to install an out-of-range value
+// that the container spelling refuses — an ungated `cluster-id` is one byte of
+// the RETH virtual MAC (256 aliases another cluster's MAC) and an ungated
+// `reth-advertise-interval` is a 12-bit VRRP wire field (40960 encodes as 0).
+//
+// Every typed leaf is exercised, and the REJECTION MESSAGE must match the
+// container spelling's — same validator, not a second bounds table that agrees
+// today and drifts tomorrow.
+func TestPackedClusterDoesNotEscapeTheRangeGates_6672(t *testing.T) {
+	outOfRange := map[string]string{
+		"cluster-id":              "999",
+		"node":                    "7",
+		"reth-count":              "0",
+		"heartbeat-interval":      "0",
+		"heartbeat-threshold":     "0",
+		"reth-advertise-interval": "40960",
+		"takeover-hold-time":      "-1",
+		"peer-fencing":            "shoot-the-other-node",
+	}
+
+	// Guard the population: every typed (validator-bearing) leaf must have a
+	// bad value here, or a leaf could gain a gate and quietly go uncovered.
+	for kw, sn := range clusterSchemaChildren(t) {
+		if sn.validator == nil {
+			continue
+		}
+		if _, ok := outOfRange[kw]; !ok {
+			t.Errorf("`chassis cluster %s` has a schema validator but no out-of-range "+
+				"fixture — the packed spelling could escape it uncovered", kw)
+		}
+	}
+
+	names := make([]string, 0, len(outOfRange))
+	for kw := range outOfRange {
+		names = append(names, kw)
+	}
+	sort.Strings(names)
+
+	for _, kw := range names {
+		kw := kw
+		t.Run(kw, func(t *testing.T) {
+			body := kw + " " + outOfRange[kw]
+			spellings := clusterSpellings(body)
+
+			containerErr := schemaValidateSrc6672(t, spellings["container"])
+			if containerErr == nil {
+				t.Fatalf("fixture bug: the CONTAINER spelling of %q accepts %q, so this "+
+					"test cannot show the packed spelling escaping anything",
+					kw, outOfRange[kw])
+			}
+			for _, spelling := range []string{"packed-in-chassis", "packed-top-level", "brace-top-level"} {
+				err := schemaValidateSrc6672(t, spellings[spelling])
+				if err == nil {
+					t.Errorf("%s spelling of `%s` was ACCEPTED while the container spelling "+
+						"was rejected with: %v", spelling, body, containerErr)
+					continue
+				}
+				if err.Error() != containerErr.Error() {
+					t.Errorf("%s spelling of `%s` was rejected by a DIFFERENT gate\n"+
+						" container: %v\n %s: %v", spelling, body, containerErr, spelling, err)
+				}
+			}
+		})
+	}
+}
+
+func schemaValidateSrc6672(t *testing.T, src string) error {
+	t.Helper()
+	tree, errs := NewParser(src).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("fixture parse errors: %v\n%s", errs, src)
+	}
+	return SchemaValidate(tree, nil)
+}
+
+// TestPackedRedundancyGroupKeepsItsOwnNode_6672 is the nesting rule, and the
+// single token where the two tables overlap decides it.
+//
+// `node` is BOTH a cluster statement (this box's identity) and a
+// redundancy-group statement (that group's per-node priority). Under a flat
+// splitter `redundancy-group 1 node 0 priority 200` re-arms at `node`, which
+// sets the CLUSTER's node identity and drops the group's election priority —
+// exactly the failure #6588 exists to prevent, reintroduced one level up. The
+// overlap must resolve to the INNER scope.
+func TestPackedRedundancyGroupKeepsItsOwnNode_6672(t *testing.T) {
+	// The cluster's own node identity is 1; the group's per-node priority is
+	// for node 0. If the splitter re-arms at the group's `node`, the cluster
+	// identity flips to 0 and the priority vanishes — both observable.
+	body := "node 1 redundancy-group 1 node 0 priority 200 reth-count 2"
+	want := compileClusterJSON6672(t, `
+chassis {
+    cluster {
+        node 1;
+        redundancy-group 1 {
+            node 0 priority 200;
+        }
+        reth-count 2;
+    }
+}
+`)
+	for spelling, src := range clusterSpellings(body) {
+		if spelling == "container" {
+			continue
+		}
+		if got := compileClusterJSON6672(t, src); got != want {
+			t.Errorf("%s: the redundancy-group's `node` was stolen by the cluster splitter\n want %s\n  got %s",
+				spelling, want, got)
+		}
+	}
+
+	// And the oracle itself must be non-trivial: assert the values it is
+	// supposed to carry actually appear, so a fixture that compiled to an empty
+	// cluster could not satisfy the comparison above.
+	for _, want := range []string{`"NodeID":1`, `"RethCount":2`, `"0":200`} {
+		if !strings.Contains(compileClusterJSON6672(t, clusterSpellings(body)["container"]), want) {
+			t.Fatalf("fixture bug: the container oracle does not contain %s", want)
+		}
+	}
+}
+
+// TestPackedClusterStatementReservesItsValueSlot_6672 is the cluster-level
+// #6665 property, and it needs a value that SPELLS A KEYWORD to be observable
+// at all — every ordinary fixture value (`22`, `em0`, `10.99.0.2`) can never
+// re-arm the splitter, so a fixture built from those varies the right axis and
+// samples only the passing point.
+//
+// `control-interface node` is the shape: a control link named after the cluster
+// statement that sets this box's NODE IDENTITY. Without the reservation the
+// splitter opens a `node` statement in the value slot, so the control interface
+// compiles empty AND the following `reth-count` token is consumed as the node
+// id — a firewall that believes it is a different node and has no control link.
+func TestPackedClusterStatementReservesItsValueSlot_6672(t *testing.T) {
+	body := "control-interface node reth-count 2"
+	want := compileClusterJSON6672(t, `
+chassis {
+    cluster {
+        control-interface node;
+        reth-count 2;
+    }
+}
+`)
+	for _, need := range []string{`"ControlInterface":"node"`, `"RethCount":2`, `"NodeIDSet":false`} {
+		if !strings.Contains(want, need) {
+			t.Fatalf("fixture bug: the container oracle does not contain %s: %s", need, want)
+		}
+	}
+	for spelling, src := range clusterSpellings(body) {
+		if spelling == "container" {
+			continue
+		}
+		if got := compileClusterJSON6672(t, src); got != want {
+			t.Errorf("%s: a keyword-shaped value token re-armed the cluster splitter\n want %s\n  got %s",
+				spelling, want, got)
+		}
+	}
+}
+
+// TestPackedMonitorKeepsAKeywordShapedInterfaceName_6672 carries the #6665
+// value-slot reservation across the nesting boundary.
+//
+// The redundancy-group splitter reserves `interface-monitor`'s one free-form
+// identifier slot so a monitored interface whose NAME spells a statement
+// keyword is not consumed as that statement. At the cluster level the same
+// theft is available with a CLUSTER keyword: an interface literally named
+// `reth-count` would re-arm the outer splitter. ValidateDeviceMapLogicalName
+// admits keyword-shaped names, so this is a name an operator can configure.
+func TestPackedMonitorKeepsAKeywordShapedInterfaceName_6672(t *testing.T) {
+	body := "redundancy-group 1 interface-monitor reth-count weight 255"
+	want := compileClusterJSON6672(t, `
+chassis {
+    cluster {
+        redundancy-group 1 {
+            interface-monitor reth-count weight 255;
+        }
+    }
+}
+`)
+	if !strings.Contains(want, `"Interface":"reth-count"`) {
+		t.Fatalf("fixture bug: the container oracle did not keep the keyword-shaped name: %s", want)
+	}
+	for spelling, src := range clusterSpellings(body) {
+		if spelling == "container" {
+			continue
+		}
+		if got := compileClusterJSON6672(t, src); got != want {
+			t.Errorf("%s: a monitored interface named after a cluster keyword was stolen\n want %s\n  got %s",
+				spelling, want, got)
+		}
+	}
+}
+
+// TestPackedClusterKeepsASiblingDeviceMap_6672 pins the #1956 R-7 invariant
+// through the normalization: a `device-map` beside a packed cluster must not be
+// dropped when the chassis node is rebuilt.
+func TestPackedClusterKeepsASiblingDeviceMap_6672(t *testing.T) {
+	tree, errs := NewParser(`
+chassis {
+    cluster cluster-id 22 node 1;
+    device-map {
+        interface fxp0 { pci 0000:05:00.0; }
+    }
+}
+`).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if cfg.Chassis.Cluster == nil || cfg.Chassis.Cluster.ClusterID != 22 {
+		t.Errorf("packed cluster body did not compile: %+v", cfg.Chassis.Cluster)
+	}
+	if cfg.Chassis.DeviceMap == nil || len(cfg.Chassis.DeviceMap.Entries) == 0 {
+		t.Errorf("the sibling device-map was dropped by the cluster normalization")
+	}
+}
+
+// TestSchemaWalkStillSeesSiblingsOfAPackedCluster_6672 guards the normalization
+// REBUILD. The tree normalizer replaces the whole `chassis` node, so a sibling
+// statement dropped there would vanish from the schema walk — and vanishing
+// from a validator is invisible: the config gets MORE permissive, not less, so
+// nothing fails and no test that only checks the cluster would notice.
+//
+// The probe is a device-map with an invalid PCI address beside a packed
+// cluster. It must still be rejected. A control with the same device-map beside
+// a CONTAINER cluster proves the rejection is the device-map's, not an artifact
+// of the packed spelling.
+func TestSchemaWalkStillSeesSiblingsOfAPackedCluster_6672(t *testing.T) {
+	const badDeviceMap = `
+    device-map {
+        interface fxp0 { pci not-a-pci-address; }
+    }
+`
+	control := schemaValidateSrc6672(t, "chassis {\n    cluster {\n        cluster-id 22;\n    }\n"+badDeviceMap+"}\n")
+	if control == nil {
+		t.Fatalf("fixture bug: the invalid device-map is accepted even beside a CONTAINER " +
+			"cluster, so this test cannot show the packed path dropping it")
+	}
+	packed := schemaValidateSrc6672(t, "chassis {\n    cluster cluster-id 22;\n"+badDeviceMap+"}\n")
+	if packed == nil {
+		t.Fatalf("the sibling device-map vanished from the schema walk when the cluster "+
+			"body was packed — it was rejected beside a container cluster with: %v", control)
+	}
+	if packed.Error() != control.Error() {
+		t.Errorf("the sibling device-map was rejected by a DIFFERENT gate on the packed path\n container: %v\n packed:    %v",
+			control, packed)
+	}
+}
+
+// TestNormalizeIsANoOpForTheContainerSpelling_6672 pins the zero-churn half:
+// the spelling that always worked is returned as the SAME pointer, so this code
+// cannot perturb it at all.
+//
+// The second half is the one that matters more. normalizePackedChassisCluster
+// returns its input unchanged when there is nothing to do, so a test that only
+// checked "the container tree is unchanged" would also pass with the transform
+// deleted outright. Assert that a PACKED tree comes back changed.
+func TestNormalizeIsANoOpForTheContainerSpelling_6672(t *testing.T) {
+	container, errs := NewParser("chassis {\n    cluster {\n        cluster-id 22;\n    }\n}\n").Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	if got := normalizePackedChassisCluster(container); got != container {
+		t.Errorf("the container spelling was rewritten; it must be returned untouched")
+	}
+
+	packed, errs := NewParser("chassis {\n    cluster cluster-id 22;\n}\n").Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	got := normalizePackedChassisCluster(packed)
+	if got == packed {
+		t.Fatalf("the packed spelling was NOT rewritten — the transform declined to run, " +
+			"so every other assertion in this file about it would be vacuous")
+	}
+	chassis := got.FindChild("chassis")
+	if chassis == nil {
+		t.Fatalf("normalized tree lost the chassis node")
+	}
+	cluster := chassis.FindChild("cluster")
+	if cluster == nil {
+		t.Fatalf("normalized tree has no cluster child: %v", chassis.Keys)
+	}
+	if len(cluster.Keys) != 1 {
+		t.Errorf("normalized cluster node still carries a packed tail: %v", cluster.Keys)
+	}
+	if cluster.FindChild("cluster-id") == nil {
+		t.Errorf("normalized cluster body has no cluster-id child: %v", cluster.Children)
+	}
+}
+
+// TestPackedClusterSplitterIsNotFlat_6672 documents, by measurement, why this
+// splitter is not packedStatementPropsArity (#6665). Under the flat rule the
+// redundancy-group's `node` re-arms the outer splitter; under the nested rule
+// it does not. Both readings are produced here so the difference is a fact in
+// the tree rather than a claim in a comment.
+func TestPackedClusterSplitterIsNotFlat_6672(t *testing.T) {
+	packed := &Node{Keys: strings.Fields("cluster redundancy-group 1 node 0 priority 200")}
+
+	nested := clusterBodyStatements(packed, 1)
+	flat := packedStatementPropsArity(packed, 1, isClusterStatement, clusterStatementArity)
+
+	describe := func(nodes []*Node) string {
+		parts := make([]string, 0, len(nodes))
+		for _, n := range nodes {
+			parts = append(parts, fmt.Sprintf("%v", n.Keys))
+		}
+		return strings.Join(parts, " | ")
+	}
+
+	if len(nested) != 1 {
+		t.Errorf("nested splitter produced %d statements, want 1 (the whole group): %s",
+			len(nested), describe(nested))
+	}
+	if len(flat) == len(nested) {
+		t.Fatalf("the flat splitter agrees with the nested one on this input, so it "+
+			"cannot show why the nested rule is needed: %s", describe(flat))
+	}
+	for _, n := range flat {
+		if n.Name() == "node" {
+			return // the flat rule does steal it, as documented
+		}
+	}
+	t.Errorf("expected the flat splitter to open a CLUSTER-level `node` statement "+
+		"from the group's own node; it produced: %s", describe(flat))
+}

--- a/pkg/config/schema_walk.go
+++ b/pkg/config/schema_walk.go
@@ -81,6 +81,19 @@ func SchemaValidateWithDefinitions(tree, defsSource *ConfigTree, cfg *Config) er
 	// no-op (no clone) when nothing is deactivated.
 	tree = tree.WithoutInactive()
 	defsSource = defsSource.WithoutInactive()
+	// #6672: expand a PACKED `chassis cluster` body into children before the
+	// walk. The walker descends `.Children`, so a statement packed onto the
+	// cluster (or chassis) line sits below every modeled depth and no typed-leaf
+	// validator fires on it. That was harmless while the packed spelling also
+	// compiled to nothing; now that it compiles, the same normalization must
+	// happen HERE or the packed spelling would reach the runtime with an ungated
+	// `cluster-id` (one byte of the RETH virtual MAC) and an ungated
+	// `reth-advertise-interval` (a 12-bit VRRP wire field) while the container
+	// spelling stays gated. One splitter, both consumers — the alternative is a
+	// second hand-written bounds table that drifts from the schema.
+	//
+	// No-op (no clone) when nothing is packed, like WithoutInactive above.
+	tree = normalizePackedChassisCluster(tree)
 	// #4060: reject the raw-AST redaction placeholder ("##SECRET-DATA##") on
 	// commit-ingest. This is the symmetric guard for the #4051 display
 	// redaction — re-applying a secret-redacted REST export must not silently


### PR DESCRIPTION
Closes #6672

## What was broken

A packed statement puts all its tokens on ONE node's `Keys` with no `Children`, and `compileChassis` read the cluster body with `FindChild`, i.e. off `.Children`. Three of the four spellings compiled nothing:

```
chassis { cluster { cluster-id 1; node 0; } }   # container   -> compiles
chassis { cluster cluster-id 1 node 0; }        # packed body -> ClusterConfig, every field zero
chassis cluster { cluster-id 1; node 0; }       # keyword packed onto the chassis line -> Cluster == nil
chassis cluster cluster-id 1 node 0;            # fully packed -> Cluster == nil
```

**The issue named two of those three.** `chassis cluster { ... }` — the brace at the top level, so the body *is* in `Children` but the `cluster` keyword is packed onto the chassis line — drops just as silently. A **fifth** shape arrives from the child side (`cluster { node 1 reth-count 2; }`, one child carrying two statements). All five are covered.

The blast radius is the whole stanza: cluster-id, node identity, the control PSK, the fabric addresses, and every redundancy group under it. `commit` succeeds and `show configuration` echoes what the operator wrote, so nothing indicates the firewall is running with no cluster configuration at all. At the redundancy-group level the same shape lost one group's election priority (#6588); here it loses the cluster.

## The escape this fix had to close, not just the drop

Making the packed spelling **compile** without also making it **validate** opens a range-gate escape that does not exist today.

Every cluster value is bounded by its typed schema leaf, and the schema *walker* only reaches a statement at its modeled depth — a packed statement sits below it, so no validator fires. While the packed form compiled to nothing that was inert. The moment it compiles, writing the config **on one line** becomes a way to install a `cluster-id` above 255 (one byte of the RETH virtual MAC, so it aliases another cluster's MAC) or a `reth-advertise-interval` of 40960 (encodes as 0 in a 12-bit VRRP wire field) that the container spelling refuses.

So the body is normalized **before both consumers** rather than inside each: `normalizePackedChassisCluster` at the top of `SchemaValidateWithDefinitions`, `normalizedClusterNode` inside `compileChassis`. The **existing** validators then fire on the packed spelling unchanged — one bounds table, not a parallel one that agrees today and drifts tomorrow. The test asserts not merely that the packed spelling is rejected but that it is rejected with the **same message**, which is what makes "same validator" checkable.

## Why the splitter is not `packedStatementPropsArity` (#6665)

A cluster body **nests**, and the two statement tables overlap on exactly one token: **`node`** — the cluster's own identity, and a group's per-node priority.

Under the flat rule, `redundancy-group 1 node 0 priority 200` re-arms at `node`, which sets the **cluster's** node identity and drops the group's election priority: the #6588 failure reintroduced one level up. `TestPackedClusterSplitterIsNotFlat_6672` produces both readings so that is a fact in the tree rather than a claim in a comment.

The rule: **once `redundancy-group` opens, a token re-arms only if it is `redundancy-group` itself or a cluster statement that is NOT also a redundancy-group statement.** Overlap resolves to the inner scope, and `... redundancy-group 1 preempt reth-count 2` still compiles the `reth-count`.

The #6665 value-slot reservation is honoured **across** that boundary, so `interface-monitor reth-count weight 255` keeps a monitored interface named after a *cluster* keyword instead of re-arming the outer splitter. `ValidateDeviceMapLogicalName` admits keyword-shaped names, so that is a name an operator can configure.

## Why `clusterStatements` is a keyword→arity map, not a dispatch table

`redundancyGroupStatements` is keyword→compiler-func, which makes the compiler and the splitter one table by construction. `compileChassis` reads the cluster body as a flat if-chain over heterogeneous types (int, string, bool, `Secret`), and rewriting 150 lines of it into closures purely to derive the token set would be a larger and riskier change than the defect warrants.

The binding is instead **behavioural**: `TestEveryCompiledClusterStatementIsSplit_6672` compiles each candidate keyword in container form and requires anything the compiler actually honours to be registered. That does **not** model the compiler's source text, which is the tool #6588 removed. The candidate *population* is stated as a **floor** — schema children ∪ table ∪ a source scan for `clusterNode.FindChild("...")` — with the source scan used only to widen it, never as the oracle, and its three known blind spots named (a named constant, a helper outside the block, dispatch nested in another arm).

## Two divergences surfaced, tracked separately

`fabric1-interface` and `fabric1-peer-address` are compiled by `compileChassis` but **absent from `schemaChassis`** — no tab completion, no validator. A live #6663-class instance, filed rather than folded in.

`TestClusterSplitterAndSchemaAgree_6672` records them as an **equality-checked** exception list: when the schema gains those leaves the test fails and the entry must be deleted in the same change. Without that half the exception would outlive the divergence it documents.

## Validation

Full `go test ./... -count=1` green. (One unrelated `pkg/ddns` ephemeral-port flake, `TestListenDNSPairResamplesPastAConflictingPort_6709`, which passes on re-run and which #7403 was already chasing.)

`packed_chassis_cluster_6672_test.go` **generates** a fixture for every entry in `clusterStatements` — one subtest per statement per spelling, so a revert names which statement and which spelling broke rather than failing one lump assertion, which is the issue's stated acceptance. A **non-vacuity guard** fails any statement whose container spelling compiles to an empty cluster unless it is registered as knowingly inert *with a reason*, so the four spellings cannot satisfy the comparison by all agreeing on nothing. `TestEveryClusterStatementHasAnOracleValue_6672` keeps the generated set complete in both directions.

### Mutation matrix

Each cell is one line, applied by a script that asserts the anchor occurs exactly once and that the edit landed, run on a **compiling** tree, restored from git between cells.

| # | mutation | `_6672` | cluster/6588 suite |
|---|---|---|---|
| C1 | compiler skips the normalization | RED | RED |
| C2 | schema walker skips the normalization | RED | RED |
| C3 | `chassis cluster ...` top-line shape unhandled | RED | RED |
| C4 | packed CHILD not split | RED | RED |
| C5 | splitter is flat (no RG nesting) | RED | RED |
| C6 | RG tail swallows cluster statements too *(tightening)* | RED | green |
| C7 | no cluster value-slot reservation | RED | RED |
| C8 | RG arity not honoured across the boundary | RED | green |
| C9 | `fabric1-interface` unregistered | RED | RED |
| C10 | tree normalizer always rewrites *(tightening)* | RED | green |
| C11 | sibling statements dropped on rebuild | RED | RED |
| C12 | `clusterBodyNeedsSplit` ignores children | RED | green |

Three cells were **vacuous on the first run and were fixed, not accepted**:

- **C7** passed because every fixture value was `22`, `em0`, `10.99.0.2` — values that *cannot* re-arm the splitter, so the fixture varied the right axis and sampled only the passing point. The property needs a value that **spells a keyword**: `control-interface node reth-count 2`. Without the reservation the control link compiles empty *and* `reth-count` is consumed as the node id — a firewall that believes it is a different node and has no control link.
- **C11** passed because the sibling test used the **compile** path, which reads `device-map` off the original chassis node, while the mutation is in the **tree** rebuild that only the schema walker sees. Dropping a sibling from a validator is invisible by construction — the config gets *more* permissive, so nothing fails. The new test probes with an invalid PCI address that must still be rejected, with the container spelling as the control.
- **C10** as originally written mutated `normalizedClusterNode`'s "return the container untouched" fast path, which is **behaviour-preserving** — a synthesized node with the same children compiles identically. That is an identity/allocation property with no behavioural red, so the cell was re-aimed at `chassisClusterIsPacked`, where the tree-level no-op *is* observable.

## Not in scope

No Rust, no compiled artifact, no protocol change — no cluster smoke is owed.

## Docs

`docs/config-schema.md`'s packed-statement section gains the `chassis cluster` case and — more importantly — **corrects a claim that this PR makes false**: it stated flatly that a gate covering a packed spelling "has to run on the COMPILED struct, not on the schema". That is now one of two answers, and the better one is available wherever the packed body can be split back into statements. The `redundancyGroupBody` doc comment gains the cross-reference to the level above it and to the single token where the two splitters interact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdWuT1UffSkr1spw8sjNTE
