### PR TITLE
fabric: bind the live peer-MAC resolver with a fail-on-revert test

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103065,3 +103065,37 @@ prose edit above them added. No diff falls in the new test body.
   userspace-dp/src/afxdp/poll_descriptor/mod.rs,
   userspace-dp/src/afxdp/tests_fragment.rs, docs/multi-wan.md,
   docs/research/7409-learned-route-fib/plan.md (new), _Log.md
+
+## 2026-08-22 — #7443 bind the live fabric peer-MAC resolver
+
+- **Timestamp**: 2026-08-22 (fix/7443-fabric-peer-mac-binding)
+- **Action**: Bind `buildFabricPeerMAC` — the LIVE fabric peer-MAC resolver —
+  with a test that actually executes it. #6598 hardened the selection but its
+  coverage was a table over the extracted helper `selectFabricPeerMAC` plus an
+  AST scan of `pkg/daemon/daemon_ha_fabric.go`; neither ran
+  `buildFabricPeerMAC`, so restoring that function's body to the pre-#6598
+  inline loop (the exact shipped defect: any address-matched entry with a
+  non-nil `HardwareAddr`, no NUD state test, no length test) passed `go vet`
+  and both full suites. `selectFabricPeerMAC` went dead under the revert, but
+  Go does not error on an unused package-level func and this repo runs no
+  `unused`/staticcheck gate, so nothing caught it. Added the
+  `fabricNeighListFn` seam (mirroring `ruleListFn` in routes.go, which is bound
+  by 20+ existing tests, and the `d.linkByNameFn`/`d.neighListFn` seams #6554
+  added for the same purpose) and drove the real resolver against a synthetic
+  neighbour table. Secondary, at the coordinator's direction: cross-reference
+  comments at BOTH NUD masks (`FabricNeighValidStates` and
+  `usableNUD`), each naming the other and the question it answers, so a future
+  single-sourcing pass cannot mistake the divergence for drift. Also corrected
+  `FabricNeighValidStates`'s exclusion list, which named only
+  INCOMPLETE/FAILED/NONE and so read as though NUD_NOARP were accepted.
+  Mutation matrix (4 cells x with/without the new fixture, `go vet` rc=0 in
+  every cell): restoring the pre-#6598 selection reds on
+  `buildFabricPeerMAC = "02:bf:72:cc:00:01", want ""` with the fixture and goes
+  GREEN without it — the escape reproduced, then closed. Bypassing the seam
+  also reds only with the fixture. The length and state halves red in both
+  columns (#6598/#6554 already own those), reported as redundancy rather than
+  claimed as new coverage.
+- **File(s)**: pkg/dataplane/userspace/fabric.go,
+  pkg/dataplane/userspace/fabric_peer_mac_binding_7443_test.go (new),
+  pkg/daemon/daemon_neighbor_listener.go, docs/fabric-cross-chassis-fwd.md,
+  _Log.md

--- a/docs/fabric-cross-chassis-fwd.md
+++ b/docs/fabric-cross-chassis-fwd.md
@@ -370,7 +370,33 @@ Every peer-MAC resolution that reaches the dataplane is keyed on the
   so re-duplicating the mask AND deleting a check outright are both
   caught. Note that `usableNUD` in `daemon_neighbor_listener.go` is a
   DIFFERENT set (it admits `NUD_NOARP` and is a publish-time filter for
-  the neighbour snapshot) and is deliberately not folded in.
+  the neighbour snapshot) and is deliberately not folded in. #7443 wrote
+  that separation into a comment at BOTH masks, each naming the other and
+  the question it answers, so a future single-sourcing pass cannot read
+  the divergence as drift and "fix" it. What is recorded is that keeping
+  them apart is deliberate; what is NOT recorded anywhere is a rationale
+  for excluding `NUD_NOARP` from `FabricNeighValidStates` specifically,
+  and the comment says so rather than inventing one.
+
+  **The live resolver is bound by a test, not just the helper it calls
+  (#7443).** #6598's coverage was a table over `selectFabricPeerMAC` plus
+  the AST scan above. Neither executed `buildFabricPeerMAC`, so restoring
+  that function's body to the pre-#6598 inline loop — the exact shipped
+  defect — passed `go vet` and both full suites; `selectFabricPeerMAC`
+  went dead under the revert, but Go does not error on an unused
+  package-level function and this repo runs no `unused`/staticcheck gate,
+  so nothing complained. The netlink read now goes through the
+  `fabricNeighListFn` seam (same shape as `ruleListFn` in `routes.go`, and
+  as the `d.linkByNameFn`/`d.neighListFn` seams #6554 added for this
+  purpose), and `fabric_peer_mac_binding_7443_test.go` drives the real
+  resolver against a synthetic neighbour table: a `NUD_FAILED` entry
+  holding the peer's old lladdr must not become the redirect MAC, the
+  overlay→parent fallback must survive rejecting the overlay entry, a
+  usable overlay entry must stop the search, and a v6 peer must be looked
+  up on `FAMILY_V6`. Restoring the pre-#6598 body now fails on an
+  assertion — `buildFabricPeerMAC = "02:bf:72:cc:00:01", want ""` — with
+  `go vet` still clean; with the new fixture removed the same revert goes
+  green again, which is what makes it a closure rather than a claim.
 - The Rust redirect's own late resolution
   (`resolve_fabric_links_from_snapshots`) looks the peer up in
   `dynamic_neighbors` keyed on `(ifindex, peer_addr)`.

--- a/pkg/daemon/daemon_neighbor_listener.go
+++ b/pkg/daemon/daemon_neighbor_listener.go
@@ -51,6 +51,15 @@ import (
 // "none" as usable but state-0 entries have no learned MAC info,
 // so we filter them out at publish time
 // (see neighborSnapshotPublishable in pkg/dataplane/userspace).
+//
+// NUD_NOARP is accepted here and is NOT accepted by
+// FabricNeighValidStates (pkg/dataplane/userspace/fabric.go). That is the one
+// axis on which the two masks differ, and it is permissible because they answer
+// different questions: this mask decides which neighbours reach the general
+// snapshot, that one decides which single entry may be adopted as the fabric
+// peer's forwarding identity. Do not unify them -- keeping the two apart is
+// recorded as deliberate in docs/fabric-cross-chassis-fwd.md, and the note at
+// FabricNeighValidStates carries the rest (#7443).
 const usableNUD = netlink.NUD_REACHABLE | netlink.NUD_STALE |
 	netlink.NUD_DELAY | netlink.NUD_PROBE |
 	netlink.NUD_PERMANENT | netlink.NUD_NOARP

--- a/pkg/dataplane/userspace/fabric.go
+++ b/pkg/dataplane/userspace/fabric.go
@@ -280,9 +280,46 @@ func fabricParentUp(linuxName string) bool {
 	}
 }
 
+// fabricNeighListFn is the netlink neighbour enumerator used by the fabric
+// peer-MAC resolver, indirected so a test can drive buildFabricPeerMAC itself
+// against a synthetic neighbour table (#7443).
+//
+// #6598 hardened the selection but bound only the extracted helper
+// (selectFabricPeerMAC) and pkg/daemon's call sites. buildFabricPeerMAC -- the
+// LIVE resolver, whose result becomes FabricSnapshot.PeerMAC and reaches the
+// dataplane as the cross-chassis redirect destination -- called netlink
+// directly, so no test could execute it and reverting its body to the
+// pre-#6598 inline loop left the whole suite green. The seam is what makes the
+// fail-on-revert assertion reach the function the issue names.
+//
+// Same shape as ruleListFn (routes.go) and as the d.linkByNameFn/d.neighListFn
+// seams pkg/daemon added for exactly this purpose in #6554.
+var fabricNeighListFn = netlink.NeighList
+
 // FabricNeighValidStates is the NUD mask of neighbour states whose hardware
 // address is usable for forwarding. INCOMPLETE/FAILED/NONE carry no address, or
-// retain a stale one, and are excluded.
+// retain a stale one, and are excluded. NUD_NOARP is excluded too -- an earlier
+// revision of this comment enumerated only the first three, which read as though
+// NOARP were accepted (#7443).
+//
+// This is deliberately NOT the same mask as usableNUD
+// (pkg/daemon/daemon_neighbor_listener.go), which does accept NUD_NOARP. The
+// two answer different questions and a difference between them is therefore
+// permissible, unlike the pkg/daemon duplication #6598 removed:
+//
+//   - usableNUD governs the GENERAL host-neighbour snapshot and is
+//     contractually pinned to the Rust dataplane's accept rules
+//     (userspace-dp/src/server/handlers.rs, .../afxdp/forwarding/mod.rs).
+//   - this mask governs which single entry may be adopted as the fabric PEER'S
+//     forwarding identity, and answers it more strictly.
+//
+// Do not unify them in a future single-sourcing pass. Widening this one would
+// let a NOARP entry stand in for the peer; narrowing usableNUD would change
+// which neighbours the listener publishes and break its stated mirror of the
+// Rust rules. docs/fabric-cross-chassis-fwd.md records keeping the two apart as
+// deliberate; what it does not record is a rationale for excluding NOARP from
+// THIS mask specifically, so treat that exclusion as the mask's behaviour
+// rather than as a decision this comment can justify for you.
 //
 // It lives here, in the package that owns the LIVE fabric peer-MAC resolver,
 // and pkg/daemon consumes it. Both packages resolve the same thing -- which MAC
@@ -357,7 +394,7 @@ func buildFabricPeerMAC(overlayIfindex, parentIfindex int, peer string) string {
 		if ifindex <= 0 {
 			continue
 		}
-		neighs, err := netlink.NeighList(ifindex, family)
+		neighs, err := fabricNeighListFn(ifindex, family)
 		if err != nil {
 			continue
 		}

--- a/pkg/dataplane/userspace/fabric_peer_mac_binding_7443_test.go
+++ b/pkg/dataplane/userspace/fabric_peer_mac_binding_7443_test.go
@@ -1,0 +1,232 @@
+package userspace
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+// #7443: bind buildFabricPeerMAC ITSELF, not just the helper it calls.
+//
+// #6598 hardened the fabric peer-MAC selection and covered it with a table over
+// selectFabricPeerMAC plus an AST scan of pkg/daemon. Neither executed
+// buildFabricPeerMAC, so reverting that function's body to the pre-#6598 inline
+// loop -- the exact shipped defect -- passed `go vet` and both full suites.
+// selectFabricPeerMAC went dead under the revert, but Go does not error on an
+// unused package-level func and this repo runs no unused/staticcheck gate, so
+// nothing complained.
+//
+// These tests drive the real resolver through the fabricNeighListFn seam. The
+// fail-on-revert case is "a NUD_FAILED entry retaining the peer's old lladdr":
+// with the pre-#6598 body restored, buildFabricPeerMAC returns the stale MAC
+// and staleFabricMAC7443 shows up where "" is required.
+
+const (
+	peerV4_7443        = "10.99.0.2"
+	peerV6_7443        = "fe80::2"
+	staleFabricMAC7443 = "02:bf:72:cc:00:01" // the MAC the peer used to own
+	liveFabricMAC7443  = "02:bf:72:cc:00:02" // the MAC it owns now
+	otherFabricMAC7443 = "02:bf:72:cc:00:03"
+
+	overlayIfindex7443 = 11
+	parentIfindex7443  = 12
+)
+
+func mustMAC7443(t *testing.T, s string) net.HardwareAddr {
+	t.Helper()
+	mac, err := net.ParseMAC(s)
+	if err != nil {
+		t.Fatalf("ParseMAC(%q): %v", s, err)
+	}
+	return mac
+}
+
+// stubFabricNeighList installs a per-ifindex neighbour table and records, in
+// order, which ifindexes the resolver actually asked about.
+func stubFabricNeighList(t *testing.T, byIfindex map[int][]netlink.Neigh, failFor map[int]bool) *[]int {
+	t.Helper()
+	var queried []int
+	orig := fabricNeighListFn
+	t.Cleanup(func() { fabricNeighListFn = orig })
+	fabricNeighListFn = func(ifindex, family int) ([]netlink.Neigh, error) {
+		queried = append(queried, ifindex)
+		if failFor[ifindex] {
+			return nil, errors.New("synthetic netlink failure")
+		}
+		return byIfindex[ifindex], nil
+	}
+	return &queried
+}
+
+func TestBuildFabricPeerMACRejectsStaleNeighbour_7443(t *testing.T) {
+	ip := net.ParseIP(peerV4_7443)
+	stale := mustMAC7443(t, staleFabricMAC7443)
+	live := mustMAC7443(t, liveFabricMAC7443)
+
+	cases := []struct {
+		name    string
+		overlay []netlink.Neigh
+		want    string
+	}{{
+		// THE fail-on-revert case. Restoring the pre-#6598 body makes this
+		// return staleFabricMAC7443.
+		name:    "NUD_FAILED retaining the peer's old lladdr is not the redirect MAC",
+		overlay: []netlink.Neigh{{IP: ip, HardwareAddr: stale, State: netlink.NUD_FAILED}},
+		want:    "",
+	}, {
+		name:    "NUD_INCOMPLETE is not the redirect MAC",
+		overlay: []netlink.Neigh{{IP: ip, HardwareAddr: stale, State: netlink.NUD_INCOMPLETE}},
+		want:    "",
+	}, {
+		name:    "NUD_NONE is not the redirect MAC",
+		overlay: []netlink.Neigh{{IP: ip, HardwareAddr: stale, State: 0}},
+		want:    "",
+	}, {
+		name:    "a non-6-byte lladdr is not the redirect MAC",
+		overlay: []netlink.Neigh{{IP: ip, HardwareAddr: net.HardwareAddr{0x02, 0xbf, 0x72}, State: netlink.NUD_REACHABLE}},
+		want:    "",
+	}, {
+		// Positive control: without this, a resolver that returned "" for
+		// everything would satisfy every case above.
+		name:    "a REACHABLE entry for the peer IS the redirect MAC",
+		overlay: []netlink.Neigh{{IP: ip, HardwareAddr: live, State: netlink.NUD_REACHABLE}},
+		want:    liveFabricMAC7443,
+	}, {
+		name: "a stale entry listed ahead of the live one does not win",
+		overlay: []netlink.Neigh{
+			{IP: ip, HardwareAddr: stale, State: netlink.NUD_FAILED},
+			{IP: ip, HardwareAddr: live, State: netlink.NUD_REACHABLE},
+		},
+		want: liveFabricMAC7443,
+	}, {
+		name:    "an entry for a different address never answers for the peer",
+		overlay: []netlink.Neigh{{IP: net.ParseIP("10.99.0.3"), HardwareAddr: live, State: netlink.NUD_REACHABLE}},
+		want:    "",
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stubFabricNeighList(t, map[int][]netlink.Neigh{
+				overlayIfindex7443: tc.overlay,
+			}, nil)
+			got := buildFabricPeerMAC(overlayIfindex7443, parentIfindex7443, peerV4_7443)
+			if got != tc.want {
+				t.Errorf("buildFabricPeerMAC = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildFabricPeerMACOverlayThenParent_7443 pins the two-ifindex fallback.
+// A usable entry may live on the parent while the overlay holds only an
+// unusable one — that is precisely the RETH-reprogramming window this resolver
+// has to survive — so rejecting the overlay entry must not end the search.
+func TestBuildFabricPeerMACOverlayThenParent_7443(t *testing.T) {
+	ip := net.ParseIP(peerV4_7443)
+	stale := mustMAC7443(t, staleFabricMAC7443)
+	live := mustMAC7443(t, liveFabricMAC7443)
+	other := mustMAC7443(t, otherFabricMAC7443)
+
+	t.Run("unusable on overlay falls through to a usable parent entry", func(t *testing.T) {
+		queried := stubFabricNeighList(t, map[int][]netlink.Neigh{
+			overlayIfindex7443: {{IP: ip, HardwareAddr: stale, State: netlink.NUD_FAILED}},
+			parentIfindex7443:  {{IP: ip, HardwareAddr: live, State: netlink.NUD_STALE}},
+		}, nil)
+		if got := buildFabricPeerMAC(overlayIfindex7443, parentIfindex7443, peerV4_7443); got != liveFabricMAC7443 {
+			t.Errorf("buildFabricPeerMAC = %q, want the parent's %q", got, liveFabricMAC7443)
+		}
+		if len(*queried) != 2 {
+			t.Errorf("queried ifindexes %v, want both overlay and parent consulted", *queried)
+		}
+	})
+
+	t.Run("a usable overlay entry wins and the parent is never consulted", func(t *testing.T) {
+		queried := stubFabricNeighList(t, map[int][]netlink.Neigh{
+			overlayIfindex7443: {{IP: ip, HardwareAddr: live, State: netlink.NUD_REACHABLE}},
+			parentIfindex7443:  {{IP: ip, HardwareAddr: other, State: netlink.NUD_REACHABLE}},
+		}, nil)
+		if got := buildFabricPeerMAC(overlayIfindex7443, parentIfindex7443, peerV4_7443); got != liveFabricMAC7443 {
+			t.Errorf("buildFabricPeerMAC = %q, want the overlay's %q", got, liveFabricMAC7443)
+		}
+		if len(*queried) != 1 || (*queried)[0] != overlayIfindex7443 {
+			t.Errorf("queried ifindexes %v, want only the overlay (%d)", *queried, overlayIfindex7443)
+		}
+	})
+
+	t.Run("a netlink failure on the overlay does not abandon the parent", func(t *testing.T) {
+		stubFabricNeighList(t, map[int][]netlink.Neigh{
+			parentIfindex7443: {{IP: ip, HardwareAddr: live, State: netlink.NUD_REACHABLE}},
+		}, map[int]bool{overlayIfindex7443: true})
+		if got := buildFabricPeerMAC(overlayIfindex7443, parentIfindex7443, peerV4_7443); got != liveFabricMAC7443 {
+			t.Errorf("buildFabricPeerMAC = %q, want the parent's %q", got, liveFabricMAC7443)
+		}
+	})
+
+	t.Run("a stale entry on BOTH ifindexes resolves to nothing", func(t *testing.T) {
+		stubFabricNeighList(t, map[int][]netlink.Neigh{
+			overlayIfindex7443: {{IP: ip, HardwareAddr: stale, State: netlink.NUD_FAILED}},
+			parentIfindex7443:  {{IP: ip, HardwareAddr: stale, State: netlink.NUD_INCOMPLETE}},
+		}, nil)
+		if got := buildFabricPeerMAC(overlayIfindex7443, parentIfindex7443, peerV4_7443); got != "" {
+			t.Errorf("buildFabricPeerMAC = %q, want \"\" — no usable entry exists", got)
+		}
+	})
+
+	t.Run("a non-positive ifindex is skipped, not queried", func(t *testing.T) {
+		queried := stubFabricNeighList(t, map[int][]netlink.Neigh{
+			parentIfindex7443: {{IP: ip, HardwareAddr: live, State: netlink.NUD_REACHABLE}},
+		}, nil)
+		if got := buildFabricPeerMAC(0, parentIfindex7443, peerV4_7443); got != liveFabricMAC7443 {
+			t.Errorf("buildFabricPeerMAC = %q, want the parent's %q", got, liveFabricMAC7443)
+		}
+		if len(*queried) != 1 || (*queried)[0] != parentIfindex7443 {
+			t.Errorf("queried ifindexes %v, want only the parent (%d)", *queried, parentIfindex7443)
+		}
+	})
+}
+
+// TestBuildFabricPeerMACIPv6_7443 covers the v6 fabric peer: the family
+// selection is part of this resolver, and an IPv6 peer address must reach the
+// same NUD/length bar.
+func TestBuildFabricPeerMACIPv6_7443(t *testing.T) {
+	ip := net.ParseIP(peerV6_7443)
+	stale := mustMAC7443(t, staleFabricMAC7443)
+	live := mustMAC7443(t, liveFabricMAC7443)
+
+	t.Run("family is resolved as V6 for a v6 peer", func(t *testing.T) {
+		var families []int
+		orig := fabricNeighListFn
+		t.Cleanup(func() { fabricNeighListFn = orig })
+		fabricNeighListFn = func(ifindex, family int) ([]netlink.Neigh, error) {
+			families = append(families, family)
+			return []netlink.Neigh{{IP: ip, HardwareAddr: live, State: netlink.NUD_REACHABLE}}, nil
+		}
+		if got := buildFabricPeerMAC(overlayIfindex7443, parentIfindex7443, peerV6_7443); got != liveFabricMAC7443 {
+			t.Errorf("buildFabricPeerMAC = %q, want %q", got, liveFabricMAC7443)
+		}
+		if len(families) == 0 || families[0] != netlink.FAMILY_V6 {
+			t.Errorf("queried families %v, want the first to be FAMILY_V6 (%d)", families, netlink.FAMILY_V6)
+		}
+	})
+
+	t.Run("NUD_FAILED on a v6 peer is not the redirect MAC", func(t *testing.T) {
+		stubFabricNeighList(t, map[int][]netlink.Neigh{
+			overlayIfindex7443: {{IP: ip, HardwareAddr: stale, State: netlink.NUD_FAILED}},
+		}, nil)
+		if got := buildFabricPeerMAC(overlayIfindex7443, parentIfindex7443, peerV6_7443); got != "" {
+			t.Errorf("buildFabricPeerMAC = %q, want \"\"", got)
+		}
+	})
+
+	t.Run("an unparseable peer address resolves to nothing without touching netlink", func(t *testing.T) {
+		queried := stubFabricNeighList(t, nil, nil)
+		if got := buildFabricPeerMAC(overlayIfindex7443, parentIfindex7443, "not-an-address"); got != "" {
+			t.Errorf("buildFabricPeerMAC = %q, want \"\"", got)
+		}
+		if len(*queried) != 0 {
+			t.Errorf("queried ifindexes %v, want none — the address never parsed", *queried)
+		}
+	})
+}


### PR DESCRIPTION
Closes #7443

## What was wrong

#6598 hardened `buildFabricPeerMAC` — the **live** fabric peer-MAC resolver,
whose result becomes `FabricSnapshot.PeerMAC` and reaches the dataplane as the
cross-chassis redirect destination — to require a believed NUD state and a
6-byte lladdr. That hardening is correct and stays.

Its coverage was not. The tests bound the extracted helper
`selectFabricPeerMAC` and, via an AST scan, `pkg/daemon`'s call sites. Nothing
executed `buildFabricPeerMAC`. At the merged head, `git grep buildFabricPeerMAC
-- '*_test.go'` returned two hits and both were comments.

So the exact shipped defect could be restored with a fully green suite:
`go vet` rc=0, `pkg/dataplane/userspace` and `pkg/daemon` both `ok`.
`selectFabricPeerMAC` goes dead under the revert, but Go does not error on an
unused package-level function and this repo runs no `unused`/staticcheck gate
(`git grep -n 'staticcheck\|golangci\|unused' -- Makefile .github/workflows/`
is empty), so nothing complained.

#6598's own acceptance criterion — "fail-on-revert test with a stale-lladdr
`NUD_FAILED` entry present" — held for the helper and not for the resolver the
issue names.

## The fix

A `fabricNeighListFn` seam, so a test can drive the real resolver against a
synthetic neighbour table. The shape is not new: `ruleListFn` in `routes.go` is
the same indirection and is bound by 20+ tests **in this package**, and #6554
added `d.linkByNameFn`/`d.neighListFn` to `pkg/daemon` for exactly this purpose.
I verified the local precedent is genuinely test-bound before mirroring it.

The fixture covers the stale `NUD_FAILED` entry the `programRethMAC`
link DOWN → set-MAC → link UP sequence produces, `INCOMPLETE`/`NONE`, a
non-6-byte lladdr, a stale entry listed ahead of a live one, the overlay→parent
fallback (rejecting the overlay entry must not end the search; a usable overlay
entry must stop it; a netlink error on the overlay must not abandon the parent),
and v6 family selection. A `REACHABLE` entry that **must** resolve is included
as a positive control, so a resolver returning nothing for everything fails
rather than passes.

## Mutation matrix

4 cells, each run **with and without** the new fixture. `go vet` rc=0 in every
cell; every mutation is a single hunk; full packages, `-count=1`, no `-run`
filter. Re-confirmed against the final tree after all edits settled.

| # | Mutation (one hunk) | vet | With 7443 fixture | Base (fixture removed) |
|---|---|---|---|---|
| M1 | restore the pre-#6598 selection in `buildFabricPeerMAC` | 0 | **FAIL** — `buildFabricPeerMAC = "02:bf:72:cc:00:01", want ""` | **PASS** |
| M2 | `len(n.HardwareAddr) == 6` → `!= nil` | 0 | FAIL | FAIL |
| M3 | drop `&& n.State&FabricNeighValidStates != 0` | 0 | FAIL | FAIL |
| M4 | bypass the seam (`fabricNeighListFn` → `netlink.NeighList`) | 0 | **FAIL** — `buildFabricPeerMAC = "", want "02:bf:72:cc:00:02"` | **PASS** |

**M1 is the paired cell** — necessary and sufficient. Base green means the
escape is real and reproduced at this head; with-fixture red means it is closed.
M4 shows the seam is load-bearing rather than decorative.

**M2 and M3 red in both columns.** #6598 and #6554 already own the length and
state properties (M3's base red is `TestSelectFabricPeerLinkLocalMAC/unusable_NUD_state_ignored`
at `daemon_ha_fabric_peer_identity_6554_test.go:533`). This fixture adds
redundancy there, not coverage, and I am reporting it that way rather than
banking it.

## Secondary: the two NUD masks

Deliberately in this change rather than deferred, at the coordinator's
direction. The repo holds two NUD masks differing on exactly one axis —
`usableNUD` (`daemon_neighbor_listener.go`) accepts `NUD_NOARP`,
`FabricNeighValidStates` does not. Keeping them apart is already recorded as
deliberate in `docs/fabric-cross-chassis-fwd.md`, but **neither mask said so at
its own definition**, so a future single-sourcing pass reading one in isolation
could take the divergence for drift and unify it — silently changing which
neighbours the listener publishes, or letting a NOARP entry stand in for the
fabric peer. Both now name the other and the question it answers.

`FabricNeighValidStates`' exclusion list is also corrected: it enumerated only
INCOMPLETE/FAILED/NONE, which reads as though NOARP were accepted.

One thing I deliberately did **not** do: claim the NOARP exclusion is
intentional. I drafted that, then checked — the docs record keeping the masks
*apart* as deliberate, which is a different claim from a rationale for this
mask's NOARP exclusion, and no commit or issue carries the latter. The comment
now says exactly that rather than inventing a justification.

## Validation

- Full Go suite green: **66 packages ok**, zero failures, `go vet ./...` clean.
- New tests: 18 `=== RUN` lines actually selected (filter verified, not assumed).
- `gofmt` clean on every file I touched. `daemon_neighbor_listener.go` is listed
  by `gofmt -l`, but that is **pre-existing at master** (numbered-list indentation
  in the package doc comment) and none of my lines appear in its `gofmt -d`
  output — left alone rather than folded in as unrelated churn.

## Owed

`make test-failover` — this is fabric-forwarding code. Not run here; the loss
cluster is shared and smoke is serialized.
