### PR TITLE
config: type the interfaces wildcard identity, and make that possible (#6834)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-08-22 — #6834: typed wildcard identity slots, and the interface-name gate
+
+- **Timestamp**: 2026-08-22
+- **Action**: Wrote the validator and wired `keyValidator` onto the interfaces
+  wildcard — and the WIRING TEST FAILED, which is why it existed. `keyValidator`
+  never reached a wildcard identity slot at all: `walkSchemaNode` validates
+  `Keys[1:1+args]`, and a wildcard's identity is `Keys[0]` with args 0, so the
+  span was empty. No wildcard in the schema carried a keyValidator, so the gap
+  had no instance. Corrected my own earlier triage claim that "the mechanism
+  already exists" — true for `<keyword> <arg>` slots, false for wildcards.
+  Hoisted the exactness predicate that was open-coded for the scalar-value-leaf
+  rule into one `exactMatch` local read by both sites, rather than adding a
+  second copy that could drift.
+  Verified the pointer-equality precondition instead of assuming it: 0 schema
+  nodes register a child that IS their wildcard, across 1464 nodes. Kept as a
+  permanent tripwire — and then gave the tripwire a POSITIVE CONTROL after a
+  mutation showed it could not red (there is nothing to detect today, so
+  breaking its comparison changed nothing). The detector is now bound by a
+  planted alias.
+  Two harness lessons paid for in this issue. A mutation that reddened via
+  `declared and not used` with vet rc 1 was DISCARDED and re-run with the
+  variable kept live. And an uncommitted edit was EATEN by the harness's
+  `git checkout -- pkg/` restore; re-applied and committed before mutating,
+  which is the rule I already knew and did not follow.
+  Character class only, no length bound — the repo carries a 17-char fixture
+  and IFNAMSIZ applies to the DERIVED name.
+  M1-M5 + M7 RED with vet 0 at every mutated state; M1 deletes the CALL from
+  the production path and M5 is the reject-everything control.
+- **File(s)**: `pkg/config/schema_walk.go`, `pkg/config/schema_interfaces.go`,
+  `pkg/config/validate_interface_name.go` (new),
+  `pkg/config/validate_interface_name_6834_test.go` (new),
+  `docs/config-schema.md`
+
 ## 2026-08-22 — #6914: the activation-tail argv fixture varied one axis
 
 - **Timestamp**: 2026-08-22

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -47,6 +47,57 @@ Because completion (3) and validation (4) read the SAME node, they cannot
 drift — typing a leaf fixes both `set ... ?` help and `commit check`
 rejection together.
 
+## Typed WILDCARD identity slots (`keyValidator` on a wildcard, #6834)
+
+A `keyValidator` on a **named-keyword** node validates the arg token(s) that
+follow the keyword — `unit <n>`, `address <cidr>`. The walker implements that as
+`node.Keys[1:1+args]`.
+
+A **wildcard** node is different: its identity IS the keyword, at `Keys[0]`, and
+it declares no args. So the arg span is `Keys[1:1]` — empty — and before #6834 a
+`keyValidator` on a wildcard validated **nothing at all** and returned nil. Every
+one of the schema's existing `keyValidator`s sat on a `<keyword> <arg>` slot, so
+the gap had no instance and no symptom until an interface name needed gating.
+
+`walkSchemaNode` now validates a wildcard's own keyword as identity slot 0.
+Which of the two cases applies is decided by a single hoisted `exactMatch`
+local, read by both the scalar-value-leaf rule and this one — two copies of
+"was this an exact match?" could only ever disagree by mistake.
+
+**Precondition, verified rather than assumed.** `exactMatch` is
+`parent.children[keyword] == childSchema`, a POINTER comparison. If any parent
+registered the same `*schemaNode` as both a named child and as its wildcard, the
+predicate would report EXACT for a wildcard match and this gate would silently
+stop running — no failure, just unvalidated config again.
+`TestNoSchemaNodeIsBothChildAndWildcard_6834` walks the whole schema (1464 nodes,
+0 aliases at the time of writing) to keep that true, and
+`TestAliasDetectorFindsARealAlias_6834` plants an alias so the detector itself
+cannot rot into a tripwire that never fires.
+
+### `interfaces <name>` is the first typed wildcard identity
+
+The interface name is interpolated into four sites in the generated systemd
+units, and one of them — `[Match] Name=` in the `.network` file — systemd reads
+as a **whitespace-separated list of shell-style globs, matching the device name
+or its alternative names**. An unvalidated name does not corrupt the unit file;
+it makes one `.network` claim SEVERAL interfaces.
+
+`ValidateInterfaceName` is an **allowlist**: letters, digits, `-`, `.`, `_`, `/`.
+The slash is included because the Junos spelling `ge-0/0/0` is the documented
+form and is canonicalised to `ge-0-0-0` downstream.
+
+**Do not "simplify" it into a call to `sanitizeUnitValue`.** That helper maps
+control bytes to a SPACE, which for a whitespace-separated list is the
+SEPARATOR — it would turn one pattern into two, each claiming devices. Applying
+the safe-looking neighbouring helper to this sink is strictly worse than
+rendering the field raw.
+
+**No length bound**, deliberately: `IFNAMSIZ` applies to the DERIVED kernel name
+(slashes folded, `.<unit>` appended), so a bound here would have to model that
+derivation, and a validator wrong in the *rejecting* direction turns a working
+config into a failed commit with no operator workaround (the #6564
+`ValidateOSPFArea` lesson, where a `>= 1` floor would have refused OSPF area 0).
+
 ## Strict commit-time validators → `pkg/config/compiler_validate_strict_*.go`
 
 The typed per-leaf `SchemaValidate` walk (4) cannot express cross-field or

--- a/pkg/config/schema_interfaces.go
+++ b/pkg/config/schema_interfaces.go
@@ -33,7 +33,17 @@ package config
 // dhcp/dhcpv6 client knobs and tunnel keepalives (deferred:
 // low-risk pass-through integers), `speed`/`duplex`/`encapsulation`
 // (free-form pass-through strings).
-var schemaInterfaces = &schemaNode{desc: "Interface configuration", wildcard: &schemaNode{desc: "Interface name", valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: map[string]*schemaNode{
+// The interfaces wildcard identity token is TYPED (keyValidator
+// ValidateInterfaceName, #6834). The name is interpolated into four sites in
+// the generated systemd units, one of which — `[Match] Name=` in the .network
+// file — systemd reads as a WHITESPACE-SEPARATED LIST OF SHELL-STYLE GLOBS. An
+// unvalidated name containing a space or a glob metacharacter therefore does
+// not corrupt the file; it makes one .network claim SEVERAL interfaces. Gating
+// the identity here closes all four render sites at once and reports the
+// problem at commit rather than as a rename that silently fails at next boot.
+// See validate_interface_name.go for why escaping at the render site would be
+// worse than doing nothing.
+var schemaInterfaces = &schemaNode{desc: "Interface configuration", wildcard: &schemaNode{desc: "Interface name", valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", keyValidator: ValidateInterfaceName, children: map[string]*schemaNode{
 	"description": {desc: "Text description of interface", args: 1, scalar: true, children: nil},
 	// Compiled verbatim (compiler_interfaces.go:44, Atoi with the
 	// error swallowed → garbage silently means "MTU not set", the

--- a/pkg/config/schema_walk.go
+++ b/pkg/config/schema_walk.go
@@ -395,7 +395,21 @@ func walkSchemaNode(node *Node, parent *schemaNode, path []string, vc *walkConte
 	// Keys=["bogus"]), which the compiler never reads and silently drops.
 	// Only applies on an EXACT keyword match: a wildcard match means keyword
 	// is a dynamic instance NAME, not this leaf's value slot.
-	if childSchema.isScalarValueLeaf() && parent.children != nil && parent.children[keyword] == childSchema {
+	//
+	// exactMatch is computed ONCE and read by both rules that need it (#6834).
+	// It used to be open-coded here and nowhere else; the wildcard-identity
+	// gate below needs the same distinction, and two copies of "was this an
+	// exact match?" can only ever disagree by mistake — if they drifted, one
+	// rule would treat a match as a dynamic instance name and the other as a
+	// value slot.
+	//
+	// PRECONDITION, verified rather than assumed: no schema parent registers
+	// the same *schemaNode as both a named child AND its wildcard. Pointer
+	// equality would report "exact" for a wildcard match if one did, silently
+	// disabling the identity gate. TestNoSchemaNodeIsBothChildAndWildcard_6834
+	// walks the whole schema and keeps that true.
+	exactMatch := parent.children != nil && parent.children[keyword] == childSchema
+	if childSchema.isScalarValueLeaf() && exactMatch {
 		return validateScalarValueLeaf(node, childSchema, path)
 	}
 
@@ -430,6 +444,22 @@ func walkSchemaNode(node *Node, parent *schemaNode, path []string, vc *walkConte
 	// distinct grammar per position (prefix slot vs match-type slot).
 	if childSchema.keyValidatorPos != nil || childSchema.keyValidator != nil {
 		keyPath := append(append([]string(nil), path...), keyword)
+		// #6834: a WILDCARD's identity IS the keyword — Keys[0] — not an arg
+		// token. The declared-arg span below is Keys[1:1+args], and a wildcard
+		// declares no args, so that span is EMPTY and a wildcard's identity was
+		// never validated at all. Every keyValidator in the schema was on a
+		// `<keyword> <arg>` slot, so the gap had no instance until an interface
+		// name needed gating (the name is interpolated into the generated
+		// .network file's [Match] Name=, which systemd reads as a
+		// whitespace-separated glob list, so an unvalidated name can claim
+		// several devices).
+		//
+		// Validated as identity slot 0, which is what it is positionally.
+		if !exactMatch {
+			if err := validateKeySlot(childSchema, 0, keyword, vc); err != nil {
+				return typedLeafInvalidErrorf(path, keyword, err)
+			}
+		}
 		if childSchema.valueList && childSchema.keyValidator != nil {
 			// #5726: a VALUE-LIST container leaf (only the static-route
 			// `next-hop`: multi + valueList + keyValidator + an `interface`

--- a/pkg/config/validate_interface_name.go
+++ b/pkg/config/validate_interface_name.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// validate_interface_name.go — the commit-time gate on the `interfaces`
+// wildcard identity token (#6834).
+//
+// WHY AT COMMIT RATHER THAN AT RENDER. The interface name is interpolated into
+// the generated systemd units at four sites in pkg/networkd — `[NetDev] Name=`
+// (x2), `[Link] Name=` and, the one that matters, `[Match] Name=` in the
+// .network file. Validating the identity once here closes all four at the
+// source, and gives the operator a diagnosable commit error instead of a
+// rename that silently fails at the next boot.
+//
+// WHY ESCAPING AT RENDER WOULD BE WORSE THAN DOING NOTHING. The obvious
+// treatment is to reuse the neighbouring sanitizeUnitValue, which is applied to
+// `Description=` on adjacent lines. Do not. It maps every control byte to a
+// SPACE, and systemd documents `[Match] Name=` (and `[Match] OriginalName=`) as
+// "a whitespace-separated list of shell-style globs matching the device name,
+// or device's alternative names". A sanitizer whose replacement character is
+// the sink's SEPARATOR does not neutralise the value — it MANUFACTURES a second
+// pattern out of one, and each pattern claims devices. Applying that helper to
+// these fields is strictly worse than rendering them raw. This comment exists
+// so a later simplification into a call to it is recognisably wrong.
+//
+// WHAT IS AND IS NOT REACHABLE. Measured on the real config path:
+//
+//	"ge 0"           ACCEPTED before this gate -> Name="ge 0"
+//	"ge-0-0-0 eth0"  ACCEPTED before this gate -> a TWO-pattern payload
+//	"ge*"            ACCEPTED before this gate -> a glob
+//	"ge\t0"          already REJECTED at compile ("contains control characters")
+//
+// So the newline/directive-injection vector is ALREADY closed by the existing
+// control-character guard and needs nothing here; and `OriginalName=` is not
+// operator-reachable at all (it is daemon-derived from the kernel). The live
+// vector is whitespace and glob metacharacters in the operator-authored name.
+//
+// NO LENGTH BOUND, DELIBERATELY. The kernel's IFNAMSIZ limit applies to the
+// FINAL kernel name, which is derived from this token (`/` becomes `-`) and,
+// for a unit, extended with `.<unit>`. Deriving a correct bound here would mean
+// modelling that derivation, and a bound that is wrong in the REJECTING
+// direction turns a working config into a failed commit with no operator
+// workaround — the #6564 ValidateOSPFArea lesson, where a `>= 1` floor copied
+// from a sibling would have refused OSPF area 0, the backbone. The repo already
+// carries a 17-character fixture (`ge-0/0/1234567890`), so the population here
+// is not obviously bounded either. Character class only.
+
+// interfaceNameAllowed reports whether c may appear in an interface name.
+//
+// The set is the intersection of what the kernel accepts and what renders
+// unambiguously into a systemd match list: alphanumerics plus '-', '.', '_'
+// and '/'. The slash is included because the Junos spelling `ge-0/0/0` is the
+// normal way to write these and is canonicalised to `ge-0-0-0` downstream
+// (types.go); rejecting it here would refuse the documented syntax.
+func interfaceNameAllowed(c byte) bool {
+	switch {
+	case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		return true
+	case c == '-', c == '.', c == '_', c == '/':
+		return true
+	}
+	return false
+}
+
+// ValidateInterfaceName gates the `interfaces <name>` identity token.
+//
+// It is an ALLOWLIST rather than a denylist of the two known-dangerous classes.
+// A denylist would have to enumerate every character that is a separator or a
+// metacharacter to some consumer of the name, and the consumers are not all in
+// this repo; the legal shape of an interface name is narrow and known, so
+// stating it positively is both shorter and closed against a consumer nobody
+// has thought of yet.
+func ValidateInterfaceName(raw string, _ *Config) error {
+	if raw == "" {
+		return fmt.Errorf("interface name must not be empty")
+	}
+	for i := 0; i < len(raw); i++ {
+		c := raw[i]
+		if interfaceNameAllowed(c) {
+			continue
+		}
+		// The two classes that are not merely invalid but ACTIVELY dangerous
+		// get their own message, because "invalid character" would not tell an
+		// operator that the name they wrote would have claimed other devices.
+		switch {
+		case c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\v' || c == '\f':
+			return fmt.Errorf(
+				"interface name %q contains whitespace at byte %d; the name is rendered into "+
+					"the generated .network file's [Match] Name=, which systemd reads as a "+
+					"WHITESPACE-SEPARATED list of globs — a name with a space matches, and "+
+					"claims, more than one interface", raw, i)
+		case c == '*' || c == '?' || c == '[' || c == ']':
+			return fmt.Errorf(
+				"interface name %q contains the glob metacharacter %q at byte %d; the name is "+
+					"rendered into the generated .network file's [Match] Name=, which systemd "+
+					"reads as a list of SHELL-STYLE GLOBS — the name would match, and claim, "+
+					"every interface it globs (including by alternative name)", raw, string(c), i)
+		}
+		return fmt.Errorf(
+			"interface name %q contains %q at byte %d; allowed characters are letters, digits, "+
+				"'-', '.', '_' and '/'", raw, string(c), i)
+	}
+	return nil
+}
+
+// interfaceNameRendersAsOnePattern reports whether name occupies exactly one
+// slot of a systemd whitespace-separated match list. It exists so the property
+// the validator protects can be asserted directly against systemd's documented
+// grammar, rather than only through the validator's own allowlist — a test that
+// checked the allowlist against itself would be true by construction.
+func interfaceNameRendersAsOnePattern(name string) bool {
+	return len(strings.Fields(name)) == 1 && strings.Fields(name)[0] == name
+}

--- a/pkg/config/validate_interface_name_6834_test.go
+++ b/pkg/config/validate_interface_name_6834_test.go
@@ -1,0 +1,251 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6834. The interface name reaches four render sites in the generated systemd
+// units, and one of them — `[Match] Name=` in the .network file — is a
+// WHITESPACE-SEPARATED LIST OF SHELL-STYLE GLOBS. An unvalidated name does not
+// corrupt the unit file; it makes one .network claim several interfaces.
+//
+// Before this gate, measured on the real config path: "ge 0", "ge-0-0-0 eth0"
+// and "ge*" all committed and reached ifc.Name verbatim.
+
+// TestValidateInterfaceNameAcceptsRealNames_6834 is the OVER-REJECTION half,
+// and it is the half that matters most for a narrowing change: a validator
+// wrong in the rejecting direction turns a working config into a failed commit
+// with no operator workaround. Every form here is one the repo or the docs
+// actually use.
+func TestValidateInterfaceNameAcceptsRealNames_6834(t *testing.T) {
+	for _, name := range []string{
+		"ge-0/0/0",     // the documented Junos spelling — slashes REQUIRED
+		"ge-0-0-0",     // its canonical kernel form
+		"ge-0/0/1.100", // VLAN unit
+		"xe-7/0/2",     // node-1 FPC
+		"reth0",        // redundant ethernet
+		"reth0.50",     // RETH with a VLAN unit
+		"fxp0", "em0", "fab0", "ae0", "irb", "lo0",
+		"enp5s0", "eno5np0", "enp183s0f0v0", // predictable kernel names
+		"st0.1", "gr-0/0/0", "ip-0/0/0.0", // tunnels
+		"vlan-100", "wg0", "vrf-mgmt",
+		"interface-range",           // a schema keyword at this position
+		"ge-0/0/1234567890",         // an existing 17-char fixture: NO length bound
+		"a", "A", "0", "x_y", "x.y", // boundary shapes of the allowed class
+	} {
+		if err := ValidateInterfaceName(name, nil); err != nil {
+			t.Errorf("ValidateInterfaceName(%q) must ACCEPT a real interface name, got %v", name, err)
+		}
+	}
+}
+
+// TestValidateInterfaceNameRejectsMultiPattern_6834 is the #6834 vector: a name
+// that occupies more than one slot of a whitespace-separated match list.
+func TestValidateInterfaceNameRejectsMultiPattern_6834(t *testing.T) {
+	for _, tc := range []struct{ name, wantIn string }{
+		{"ge 0", "whitespace"},
+		{"ge-0-0-0 eth0", "whitespace"}, // the two-pattern payload
+		{"ge\t0", "whitespace"},
+		{"ge\n0", "whitespace"},
+		{" ge0", "whitespace"},
+		{"ge0 ", "whitespace"},
+	} {
+		err := ValidateInterfaceName(tc.name, nil)
+		if err == nil {
+			t.Errorf("ValidateInterfaceName(%q) must REJECT — it would claim more than one interface", tc.name)
+			continue
+		}
+		// Assert the error EXPLAINS the consequence, not merely that it errored.
+		// "invalid character" would not tell an operator their name claims other
+		// devices, which is the whole point of rejecting it.
+		if !strings.Contains(err.Error(), tc.wantIn) {
+			t.Errorf("ValidateInterfaceName(%q) error must mention %q, got %v", tc.name, tc.wantIn, err)
+		}
+		if !strings.Contains(err.Error(), "[Match] Name=") {
+			t.Errorf("ValidateInterfaceName(%q) error must name the sink, got %v", tc.name, err)
+		}
+	}
+}
+
+// TestValidateInterfaceNameRejectsGlobs_6834 covers the other live class. A
+// glob is a legal KERNEL name, so nothing downstream would reject it — it just
+// silently matches every interface it globs.
+func TestValidateInterfaceNameRejectsGlobs_6834(t *testing.T) {
+	for _, name := range []string{"ge*", "ge?", "ge[0-9]", "*", "en[p]5s0"} {
+		err := ValidateInterfaceName(name, nil)
+		if err == nil {
+			t.Errorf("ValidateInterfaceName(%q) must REJECT a glob metacharacter", name)
+			continue
+		}
+		if !strings.Contains(err.Error(), "glob") {
+			t.Errorf("ValidateInterfaceName(%q) error must say it is a glob, got %v", name, err)
+		}
+	}
+}
+
+// TestValidateInterfaceNameRejectsOtherInvalid_6834 pins the allowlist's tail:
+// characters that are neither whitespace nor globs but still have no business
+// in an interface name. ':' matters because the kernel itself rejects it.
+func TestValidateInterfaceNameRejectsOtherInvalid_6834(t *testing.T) {
+	for _, name := range []string{"ge:0", "ge;0", "ge$0", "ge`0", "ge\"0", "ge'0", "gé0", ""} {
+		if err := ValidateInterfaceName(name, nil); err == nil {
+			t.Errorf("ValidateInterfaceName(%q) must REJECT", name)
+		}
+	}
+}
+
+// TestAcceptedNamesRenderAsExactlyOnePattern_6834 checks the validator against
+// systemd's grammar rather than against its own allowlist.
+//
+// Asserting "the allowlist rejects what the allowlist rejects" would be true by
+// construction. The property that actually matters is that anything ACCEPTED
+// occupies exactly ONE slot of a whitespace-separated match list — so this
+// derives the check from the sink's documented parsing, independently of how
+// the validator decides.
+func TestAcceptedNamesRenderAsExactlyOnePattern_6834(t *testing.T) {
+	for _, name := range []string{
+		"ge-0/0/0", "ge-0-0-0", "reth0.50", "enp183s0f0v0", "ge-0/0/1234567890",
+	} {
+		if err := ValidateInterfaceName(name, nil); err != nil {
+			t.Fatalf("fixture %q must be accepted: %v", name, err)
+		}
+		if !interfaceNameRendersAsOnePattern(name) {
+			t.Errorf("accepted name %q does not occupy exactly one match-list slot", name)
+		}
+	}
+	// And the converse, so the helper is not vacuously true for everything.
+	for _, name := range []string{"ge 0", "ge-0-0-0 eth0", " ge0"} {
+		if interfaceNameRendersAsOnePattern(name) {
+			t.Errorf("%q occupies more than one slot; the helper must say so", name)
+		}
+	}
+}
+
+// TestInterfaceNameGateIsWiredIntoTheSchema_6834 binds the WIRING. The
+// validator existing proves nothing if the schema does not call it — the shape
+// that has repeatedly produced tests which pass while production bypasses the
+// code they cover. This drives the real commit path.
+func TestInterfaceNameGateIsWiredIntoTheSchema_6834(t *testing.T) {
+	commit := func(name string) error {
+		tree := &ConfigTree{}
+		path, err := ParseSetCommand(`set interfaces "` + name + `" unit 0 family inet address 10.0.0.1/24`)
+		if err != nil {
+			return err
+		}
+		if err := tree.SetPath(path); err != nil {
+			return err
+		}
+		return SchemaValidate(tree, nil)
+	}
+
+	if err := commit("ge-0/0/0"); err != nil {
+		t.Fatalf("a normal interface name must still commit: %v", err)
+	}
+	err := commit("ge-0-0-0 eth0")
+	if err == nil {
+		t.Fatal("a multi-pattern interface name must be REFUSED at commit — " +
+			"the schema does not reach ValidateInterfaceName")
+	}
+	if !strings.Contains(err.Error(), "whitespace") {
+		t.Errorf("the commit refusal must carry the validator's reason, got %v", err)
+	}
+	if err := commit("ge*"); err == nil {
+		t.Fatal("a glob interface name must be REFUSED at commit")
+	}
+}
+
+// findChildWildcardAliases returns "<path> <key>" for every schema parent that
+// registers the same *schemaNode as both a named child AND its wildcard.
+//
+// Extracted so the DETECTOR itself can be tested against a schema that really
+// contains one. Walking the real schema and finding nothing proves the schema
+// is clean; it does not prove the walk would notice if it were not — and a
+// tripwire that cannot fire is indistinguishable from one that works.
+func findChildWildcardAliases(root *schemaNode) []string {
+	var out []string
+	seen := map[*schemaNode]bool{}
+	var walk func(n *schemaNode, path string)
+	walk = func(n *schemaNode, path string) {
+		if n == nil || seen[n] {
+			return
+		}
+		seen[n] = true
+		if n.wildcard != nil {
+			for k, c := range n.children {
+				if c == n.wildcard {
+					out = append(out, path+" "+k)
+				}
+			}
+		}
+		for k, c := range n.children {
+			walk(c, path+" "+k)
+		}
+		walk(n.wildcard, path+" <*>")
+	}
+	walk(root, "")
+	return out
+}
+
+// TestAliasDetectorFindsARealAlias_6834 is the positive control for the
+// tripwire below. Without it the tripwire passes on a clean schema whether or
+// not its comparison works at all — the same vacuity it exists to guard
+// against, one level up.
+func TestAliasDetectorFindsARealAlias_6834(t *testing.T) {
+	shared := &schemaNode{desc: "shared"}
+	aliased := &schemaNode{
+		desc:     "parent",
+		wildcard: shared,
+		children: map[string]*schemaNode{"dup": shared},
+	}
+	if got := findChildWildcardAliases(aliased); len(got) != 1 {
+		t.Fatalf("the detector must find a planted alias, got %v", got)
+	}
+	// And it must not cry alias when the wildcard is a DISTINCT node.
+	clean := &schemaNode{
+		desc:     "parent",
+		wildcard: &schemaNode{desc: "w"},
+		children: map[string]*schemaNode{"a": {desc: "a"}},
+	}
+	if got := findChildWildcardAliases(clean); len(got) != 0 {
+		t.Fatalf("a distinct wildcard is not an alias, got %v", got)
+	}
+}
+
+// TestNoSchemaNodeIsBothChildAndWildcard_6834 keeps the precondition that makes
+// the exactness predicate in walkSchemaNode sound.
+//
+// That predicate is `parent.children[keyword] == childSchema` — POINTER
+// equality. If any parent ever registered the same *schemaNode as both a named
+// child and as its wildcard, the predicate would report "exact" for a wildcard
+// match and the wildcard-identity gate would silently stop running. Nothing
+// would fail: the config would simply commit unvalidated again, which is the
+// original defect returning with no signal.
+//
+// Measured at the time of writing: 0 aliases across 1464 schema nodes. This is
+// a TRIPWIRE for a future schema edit, so it cannot red today; the detector it
+// relies on is bound separately by TestAliasDetectorFindsARealAlias_6834.
+func TestNoSchemaNodeIsBothChildAndWildcard_6834(t *testing.T) {
+	if got := findChildWildcardAliases(setSchema); len(got) != 0 {
+		t.Errorf("schema nodes register a child that IS their wildcard: %v; "+
+			"the exactness predicate in walkSchemaNode is pointer-based and would report "+
+			"EXACT for a wildcard match there, silently disabling wildcard-identity validation", got)
+	}
+	seen := map[*schemaNode]bool{}
+	var count func(n *schemaNode)
+	count = func(n *schemaNode) {
+		if n == nil || seen[n] {
+			return
+		}
+		seen[n] = true
+		for _, c := range n.children {
+			count(c)
+		}
+		count(n.wildcard)
+	}
+	count(setSchema)
+	if len(seen) < 100 {
+		t.Fatalf("the walk visited only %d nodes; it is not reaching the schema and proves nothing", len(seen))
+	}
+	t.Logf("walked %d schema nodes, no child/wildcard aliasing", len(seen))
+}


### PR DESCRIPTION
An interface name reaches **four** sites in the generated systemd units, and one of them — `[Match] Name=` in the `.network` file — systemd reads as *"a whitespace-separated list of shell-style globs matching the device name, **or device's alternative names**"*. An unvalidated name does not corrupt the unit file; it makes one `.network` **claim several interfaces**.

Measured on the real config path before fixing:

```
"ge 0"           ACCEPTED -> Name="ge 0"
"ge-0-0-0 eth0"  ACCEPTED -> a TWO-pattern payload
"ge*"            ACCEPTED -> a glob
"ge\t0"          already REJECTED ("contains control characters")
```

## The issue's three severity rankings are each wrong, in different directions

- The **newline/directive-injection** vector it leads with is **already closed** by the existing compile-time control-character guard. Nothing is added for it.
- **`OriginalName=`**, which it calls *"the one that matters"*, is **not operator-reachable** — daemon-derived from the kernel.
- The vector it **dismissed** as "single-valued, lower severity" is the live one. It read `[Link] Name=` (the rename *target*, `networkd.go:791`) rather than `[Match] Name=` (the *match list*, `:811`). **Two fields with the same name — one benign, one device-claiming.**

## Wiring the validator was not enough, and the wiring test is what said so

`keyValidator` **never reached a wildcard identity slot**. `walkSchemaNode` validates `node.Keys[1:1+args]`; a wildcard's identity **is** the keyword at `Keys[0]` and it declares no args, so the span was `Keys[1:1]` — empty — and the validator returned nil having inspected nothing.

Every existing `keyValidator` in the schema sits on a `<keyword> <arg>` slot, so the gap had **no instance and no symptom** until an interface name needed gating. (This corrects my own earlier claim that "the mechanism already exists" — true for arg slots, false for wildcards.)

`walkSchemaNode` now validates a wildcard's own keyword as identity slot 0.

**The exactness test is hoisted, not duplicated.** It was already open-coded for the scalar-value-leaf rule at `:398`; rather than add a second copy, both sites now read one `exactMatch` local — two copies of "was this an exact match?" can only ever disagree by mistake, and drift would mean one rule treats a match as a dynamic instance name while the other treats it as a value slot.

**Its precondition is verified, not assumed.** `exactMatch` is a **pointer** comparison, so if any parent registered the same `*schemaNode` as both a named child and as its wildcard, it would report EXACT for a wildcard match and this gate would **silently stop running** — no failure, just unvalidated config again. Measured: **0 aliases across 1464 schema nodes**, kept as a permanent tripwire.

**And the tripwire failed its own mutation.** With nothing to detect, breaking its comparison changed nothing observable — a check that cannot fire is indistinguishable from one that works. It now has a **positive control** that plants a real alias, so the detector itself is bound.

## The validator

Allowlist: letters, digits, `-`, `.`, `_`, `/`. The slash is included because `ge-0/0/0` is the documented Junos spelling, canonicalised to `ge-0-0-0` downstream (`types.go:13`) — a naive `dev_valid_name` port would have rejected the ordinary syntax.

**No length bound, deliberately.** `IFNAMSIZ` applies to the **derived** kernel name (slashes folded, `.<unit>` appended), so a bound here would have to model that derivation, and the repo already carries a 17-character fixture (`ge-0/0/1234567890`). A validator wrong in the *rejecting* direction turns a working config into a failed commit with no operator workaround — the #6564 `ValidateOSPFArea` lesson, where a `>= 1` floor copied from a sibling would have refused **OSPF area 0, the backbone**.

**Do not simplify this into a call to `sanitizeUnitValue`.** That helper maps control bytes to a **space**, and for a whitespace-separated list a space is the **separator** — it would turn one pattern into two, each claiming devices. Applying the safe-looking neighbouring helper to this sink is **worse than rendering the field raw**. Recorded in the validator's doc comment so a later "simplification" is recognisably wrong.

## What would newly fail

Any committed interface name containing whitespace or a glob metacharacter. Both are already broken in practice — a space produces a multi-match, and a glob cannot be renamed to — so I expect zero legitimate configs affected.

Evidence rather than expectation: **full `pkg/config` clean, plus `pkg/configstore`, `pkg/cli`, `pkg/api` and `pkg/daemon` clean.** The entire existing config corpus still commits.

## Mutation matrix

`go vet` rc 0 at every mutated state; RUN count matched the control at every cell.

| mutation | vet | result |
|---|---|---|
| **delete the new call from the production path** | 0 | **RED** — `a multi-pattern interface name must be REFUSED at commit` |
| invert the exactness guard (validate EXACT, never wildcard) | 0 | **RED** — `a normal interface name must still commit` |
| unwire the `keyValidator` from the wildcard | 0 | **RED** — same refusal assertion |
| validator accepts whitespace | 0 | **RED** — `ValidateInterfaceName("ge 0") must REJECT` |
| **validator rejects everything** (positive control) | 0 | **RED** — `ValidateInterfaceName("ge-0/0/0") must ACCEPT` |
| break the alias detector | 0 | **RED** — `the detector must find a planted alias, got []` |

The first deletes the **call from the production path**, not the callee. The fifth is the control that a reject-everything validator also passes a test which only checks rejection.

Two cells were discarded and redone rather than counted: one reddened via `declared and not used` with `go vet` rc **1**, and one was invalidated when the harness's `git checkout -- pkg/` **ate an uncommitted edit** — re-applied and committed before re-running.

No hardware or cluster needed; does not reach the Rust helper binary.

Closes #6834
