### PR TITLE
policy: deny an unzoned ingress instead of defaulting it

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103065,3 +103065,12 @@ prose edit above them added. No diff falls in the new test body.
   userspace-dp/src/afxdp/poll_descriptor/mod.rs,
   userspace-dp/src/afxdp/tests_fragment.rs, docs/multi-wan.md,
   docs/research/7409-learned-route-fib/plan.md (new), _Log.md
+
+- **Timestamp**: 2026-08-22
+  - **Action**: #6682 — an unzoned INGRESS (zone id 0) no longer falls through to
+    the implicit default policy, where `default-policy permit-all` forwarded it
+    with screens already skipped. Now an explicit deny counted on
+    UNZONED_INGRESS_DENIED. The issue's reported mechanism (a from-any/to-any
+    rule matching zone 0) was already closed by #3110 and was false when filed.
+  - **File(s)**: userspace-dp/src/policy.rs, userspace-dp/src/policy_tests.rs,
+    docs/userspace-dataplane-architecture.md

--- a/_Log.md
+++ b/_Log.md
@@ -103074,3 +103074,14 @@ prose edit above them added. No diff falls in the new test body.
     rule matching zone 0) was already closed by #3110 and was false when filed.
   - **File(s)**: userspace-dp/src/policy.rs, userspace-dp/src/policy_tests.rs,
     docs/userspace-dataplane-architecture.md
+
+- **Timestamp**: 2026-08-22
+  - **Action**: #6682 follow-through — corrected the operator-facing advisory
+    caveat and its four doc/comment copies, which asserted that a wildcard rule
+    matches zone-pair (0,0). That was false when written (#3110) and doubly so
+    after the deny. Conclusion preserved, mechanism corrected.
+  - **File(s)**: pkg/config/compiler_tunnel_plaintext_advisory.go,
+    pkg/config/compiler_wireguard_plaintext_warn.go,
+    pkg/config/compiler_ipsec_plaintext_warn.go,
+    pkg/config/compiler_wireguard_plaintext_warn_5618_test.go,
+    docs/userspace-dataplane-gaps.md

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -1171,7 +1171,10 @@ Scope of the fallback:
   from-any, to-any, both-any or `junos-global` — so a DENY the operator wrote for
   that zone pair is skipped along with everything else and the permissive default
   decides. Refusing to guess a zone is therefore not universally "the safe
-  answer"; it is safe exactly to the extent the default policy is. This is
+  answer"; it is safe exactly to the extent the default policy is. (#6682 closed
+  the INGRESS half of that: `from_id == 0` no longer reaches the default at all,
+  it is an explicit counted deny. A zero EGRESS zone still falls through, so the
+  observation above still holds on that side and this paragraph is still live.) This is
   consistent with the pre-existing #3110 decision to treat zone 0 as
   unmatchable rather than as a wildcard, and it is why #6722 B2 is a blocker
   rather than a cosmetic correctness fix: on a deny-all cluster the ambiguity
@@ -1500,9 +1503,38 @@ snapshot closed via `InterfaceUnknownZone` rather than collapsing to 0.)
 evaluates zone-pair rules AND `junos-global` rules only when
 `from_id != 0 && to_id != 0`. A flow whose ingress OR egress zone is unknown
 does not belong to any *defined* zone pair, so it is ineligible for both
-zone-scoped and global policies and falls straight through to the default
-action (deny, per #3065). This prevents a configured permit-global from leaking
-transit on an unzoned ingress/egress interface. The `junos-global` sentinel
+zone-scoped and global policies.
+
+**Ingress side (#6682): an unzoned INGRESS is now an explicit deny, not a
+fall-through.** Being ineligible for every rule tier is only half of safe. The
+flow still landed on the implicit default policy, and under `default-policy
+permit-all` that default is a PERMIT — so transit on an interface the operator
+never put in a zone was forwarded, with screen/IDS checks already skipped (an
+unresolvable ingress zone returns `ScreenCheckOutcome::Pass`, there being no
+per-zone screen profile to apply). An operator asking for permit-all is saying
+what to do with traffic that matched no policy, not asking to forward traffic
+that had no zone to be adjudicated in; Junos does not pass transit on an unzoned
+interface at all. `from_id == 0` therefore returns `Deny` directly and counts it
+on `UNZONED_INGRESS_DENIED`, kept separate from `default_counter` so the two
+causes stay distinguishable — a rising default-deny means policy is working as
+configured, a rising unzoned count means an interface fell out of its zone.
+
+The two guards are complementary and ORDERED, not redundant: #3110 stops the
+rule tiers from matching (deleting it lets a `from-zone any to-zone any permit`
+match a zone-0 flow before the #6682 deny is ever reached), and #6682 stops the
+fall-through. `both_any_tier_already_refused_zone_zero_before_6682` pins the
+first independently so the newer deny cannot silently take over its job.
+
+Scoped to the ingress side deliberately: a zero EGRESS zone has historically
+meant a bug elsewhere rather than genuine unzoned-ness (#6713 — an xfrmi tunnel
+egress resolved to 0 because `populate_egress` needed a link-layer address a
+MAC-less interface does not have), so denying on `to_id` would risk
+black-holing a correctly configured path. A zero egress zone still falls through
+to the default action.
+
+Together these prevent a configured permit-global from leaking transit on an
+unzoned ingress/egress interface, and prevent a permissive DEFAULT from doing
+the same on an unzoned ingress. The `junos-global` sentinel
 zone-id (`u16::MAX`) is a *defined* global zone, distinct from `0` (unknown),
 and is unaffected by the guard — global policies still apply to every defined
 zone pair. The #3090 wildcard-zone tiers (from-any / to-any / both-any) live

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -544,8 +544,16 @@ chains while force-enabling `ip_forward` — so tunnel-to-LAN transit is
 forwarded unfiltered. `allowed-ips` is not a substitute: it is a cryptographic
 peer/source ownership gate on the inner source address, with no destination, no
 zone-pair, no application and no direction. Leaving the tunnel out of a zone is
-not a mitigation either: an interface in no zone resolves to zone id 0 and a
-`from-zone any to-zone any permit` rule matches zone-pair (0,0) (#6682).
+not a mitigation either: the plaintext never reaches zone policy at all, so
+zoning or not zoning the interface does not change whether it is adjudicated.
+
+(This paragraph used to add that an interface in no zone resolves to zone id 0
+and "a `from-zone any to-zone any permit` rule matches zone-pair (0,0)". That
+was never true: the #3110 guard has fenced every rule tier, wildcard tiers
+included, against zone 0 since before the claim was written, and #6682 went
+further and made an unzoned INGRESS an explicit counted deny. The conclusion
+above is unchanged; only the mechanism was wrong, and the mechanism is what an
+operator would have acted on.)
 
 **Commit-time signal.** Both gaps now emit a commit-time advisory naming the
 affected tunnels and, where one is assigned, the zone that does not govern them:

--- a/pkg/config/compiler_ipsec_plaintext_warn.go
+++ b/pkg/config/compiler_ipsec_plaintext_warn.go
@@ -37,12 +37,17 @@ import (
 // message. The affected tunnels are named inside it.
 //
 // It fires whenever a secure tunnel is configured, NOT only when one carries a
-// zone. Leaving a tunnel out of a zone is not a mitigation: an interface in no
-// zone resolves to zone id 0, and a `from-zone any to-zone any permit` rule
-// matches zone-pair (0,0) with no zone guard (#6682). So an unzoned tunnel's
-// plaintext is not merely unpoliced — it can be affirmatively PERMITTED by a
-// wildcard rule. Gating this advisory on zoning would tell that operator
-// nothing at all.
+// zone. Leaving a tunnel out of a zone is not a mitigation: the plaintext never
+// reaches zone policy at all, so zoning or not zoning the interface does not
+// change whether it is adjudicated. Gating this advisory on zoning would tell
+// that operator nothing at all.
+//
+// #6682: this comment used to say an unzoned interface resolves to zone id 0
+// and could be "affirmatively PERMITTED by a wildcard rule". That was never
+// true — #3110 has fenced every rule tier, wildcard tiers included, against
+// zone 0 since before the claim was written — and #6682 made an unzoned INGRESS
+// an explicit deny on top of that. The advisory still fires for the reason
+// above.
 //
 // The two groups are worded differently on purpose. A ZONED tunnel is the acute
 // case and reads as an escalation, because the operator has been told something

--- a/pkg/config/compiler_tunnel_plaintext_advisory.go
+++ b/pkg/config/compiler_tunnel_plaintext_advisory.go
@@ -97,8 +97,16 @@ const (
 	// plaintextAdvisoryUnzonedCaveat is emitted only when at least one tunnel
 	// is unzoned. Leaving a tunnel out of a zone is NOT a mitigation, and an
 	// operator reading only the zoned paragraph could conclude that it is.
-	plaintextAdvisoryUnzonedCaveat = "An UNZONED tunnel is not safer: an interface in no zone resolves to " +
-		"zone id 0, which a `from-zone any to-zone any permit` rule matches (#6682)."
+	// #6682: this sentence used to say an unzoned interface resolves to zone id
+	// 0 "which a `from-zone any to-zone any permit` rule matches". That was
+	// never true -- the #3110 guard has fenced every rule tier, wildcard tiers
+	// included, against zone 0 since before the claim was written -- and #6682
+	// went further and made an unzoned INGRESS an explicit deny. The conclusion
+	// survives; only the mechanism was wrong, and it is the mechanism an
+	// operator would act on.
+	plaintextAdvisoryUnzonedCaveat = "An UNZONED tunnel is not safer: leaving it out of a zone does " +
+		"not bring its plaintext under policy, it only leaves it unadjudicated by a different route " +
+		"(#6682)."
 )
 
 // renderPlaintextUnadjudicatedAdvisory folds every finding into ONE advisory.

--- a/pkg/config/compiler_wireguard_plaintext_warn.go
+++ b/pkg/config/compiler_wireguard_plaintext_warn.go
@@ -87,12 +87,18 @@ import (
 // renderPlaintextUnadjudicatedAdvisory.
 //
 // It fires whenever a WireGuard tunnel is configured, NOT only when one carries
-// a zone. Leaving the tunnel out of a zone is not a mitigation: an interface in
-// no zone resolves to zone id 0, and a `from-zone any to-zone any permit` rule
-// matches zone-pair (0,0) with no zone guard (#6682). So an unzoned tunnel's
-// plaintext is not merely unpoliced — it can be affirmatively PERMITTED by a
-// wildcard rule. Gating this advisory on zoning would tell that operator
+// a zone. Leaving the tunnel out of a zone is not a mitigation: the decrypted
+// inner packet is written straight to the wgN TUN and routed by the kernel, so
+// it never reaches zone policy at all — zoning or not zoning the interface does
+// not change that. Gating this advisory on zoning would tell that operator
 // nothing at all.
+//
+// #6682: this comment used to add that an unzoned interface resolves to zone id
+// 0 and could be "affirmatively PERMITTED by a wildcard rule". That was never
+// true — #3110 has fenced every rule tier, wildcard tiers included, against
+// zone 0 since before the claim was written — and #6682 made an unzoned INGRESS
+// an explicit deny on top of that. The advisory still fires for the reason
+// above.
 //
 // The two groups are worded differently on purpose. A ZONED tunnel is the acute
 // case and reads as an escalation, because `set security zones security-zone

--- a/pkg/config/compiler_wireguard_plaintext_warn_5618_test.go
+++ b/pkg/config/compiler_wireguard_plaintext_warn_5618_test.go
@@ -98,7 +98,10 @@ func TestWGPlaintextWarningNamesTheContradictedZone(t *testing.T) {
 //
 // Leaving the tunnel out of a zone is not a mitigation — an interface in no
 // zone resolves to zone id 0 and a `from-zone any to-zone any permit` rule
-// matches zone-pair (0,0) with no zone guard (#6682) — so gating on zoning
+// never reaches zone policy at all, whether or not the interface is zoned
+// (#6682: the older "matches zone-pair (0,0) with no zone guard" claim was
+// wrong — #3110 fenced every tier against zone 0, and #6682 made an unzoned
+// ingress an explicit deny) — so gating on zoning
 // would tell exactly this operator nothing.
 func TestWGPlaintextWarningFiresForUnzonedTunnel(t *testing.T) {
 	cfg := compileWarn5618(t, wgTunnel5618("wg0", 0, 51820, wgKeyA, wgKeyB)...)

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -155,6 +155,38 @@ impl Default for PolicyAction {
 /// by a cross-language contract test in pkg/dataplane/userspace).
 pub(crate) const DEFAULT_POLICY_SENTINEL_ID: u32 = u32::MAX;
 
+/// #6682: transit flows refused because their INGRESS interface is in no
+/// security zone.
+///
+/// Zone id 0 is the "unknown / no zone" sentinel — `StableZoneID` folds every
+/// CONFIGURED zone into [1, 65533], so 0 is never a real zone. The #3110 guard
+/// below already refuses to match ANY rule tier for such a flow, including
+/// `from-zone any to-zone any` and `junos-global`. What it did not do was stop
+/// the flow from falling through to the IMPLICIT DEFAULT policy, and with
+/// `set security policies default-policy permit-all` that default is a PERMIT —
+/// so transit on an interface the operator never put in a zone was forwarded,
+/// with screen/IDS checks already skipped (an unresolvable ingress zone returns
+/// `ScreenCheckOutcome::Pass`, there being no per-zone screen profile to apply).
+///
+/// Junos does not forward transit on an unzoned interface at all, so the
+/// disposition is a deny rather than a default.
+///
+/// It is counted HERE rather than on `default_counter` so the two causes stay
+/// distinguishable: a rising default-deny count means policy is working as
+/// configured, whereas a rising count here means an interface fell out of its
+/// zone, which is a configuration fault the operator wants to see.
+///
+/// The RT_FLOW `policy_id` still carries `DEFAULT_POLICY_SENTINEL_ID`, so the
+/// deny LOGS as `default-policy`. That is deliberate scope, not an oversight: a
+/// dedicated sentinel is a wire-visible value mirrored across ~10 Go call sites
+/// (display maps, counter readers, the #4342 invalidation sweep, gRPC/CLI/API)
+/// and interacts with the #4626 policy-id-0 handling, which is far more surface
+/// than this fix needs. `default-policy` is honest — no rule matched — just
+/// less specific than this counter. A distinct log reason is worth doing on its
+/// own, not folded in here.
+pub(crate) static UNZONED_INGRESS_DENIED: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
 /// #3363: stable rule identity under which the IMPLICIT default-policy hit
 /// counter is reported in [`PolicyState::counter_snapshots`] (and persisted in
 /// the [`PolicyCounterStore`] across snapshot rebuilds). The real per-rule
@@ -2891,6 +2923,39 @@ pub(crate) fn evaluate_policy_result_l3_aware(
                 ),
             }
         }
+    }
+    // #6682: an unzoned INGRESS must not reach the implicit default policy.
+    //
+    // The #3110 block above is skipped entirely when either zone id is 0, which
+    // correctly stops every rule tier — zone-pair, from-any, to-any, both-any
+    // and junos-global — from matching. The flow then landed on the implicit
+    // default, and `default-policy permit-all` made that a PERMIT: transit
+    // forwarded on an interface in no zone, with screens already skipped. An
+    // operator asking for permit-all is asking what to do with traffic that
+    // matched no policy, not asking to forward traffic that had no zone to be
+    // adjudicated in.
+    //
+    // Scoped to the INGRESS side deliberately. An unzoned ingress is
+    // unambiguous — Junos does not pass transit on an interface that is in no
+    // zone. A zero EGRESS zone has historically had causes that were bugs
+    // elsewhere rather than genuine unzoned-ness (#6713: an xfrmi tunnel egress
+    // resolved to 0 because `populate_egress` needed a link-layer address a
+    // MAC-less interface does not have), so denying on `to_id` would risk
+    // black-holing a correctly-configured path to fix a case that has not been
+    // shown to occur. It still falls through to the default below.
+    //
+    // Host-inbound is NOT affected: the LocalDelivery arm adjudicates through
+    // `evaluate_junos_host_policy_l3_aware`, which already declines `from_id ==
+    // 0` on its own, and both production callers of this function are transit
+    // (`ForwardCandidate` and the flowless MissingNeighbor arm). Management on
+    // an unzoned fxp0 cannot be locked out by this.
+    if from_id == 0 {
+        UNZONED_INGRESS_DENIED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        return PolicyEvaluationResult {
+            action: PolicyAction::Deny,
+            policy_id: DEFAULT_POLICY_SENTINEL_ID,
+            ..PolicyEvaluationResult::default()
+        };
     }
     // #4569: a flowless fragment that reaches the implicit default policy still
     // fails closed against a port-bearing DENY it skipped. If the default is

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -7519,3 +7519,169 @@ fn omitempty_zero_policy_ids_still_parse() {
         "distinct-rule_id rules never share a counter"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #6682: an unzoned INGRESS must not be forwarded by the implicit default
+// policy.
+//
+// Zone id 0 is the "unknown / no zone" sentinel; StableZoneID folds every
+// CONFIGURED zone into [1, 65533], so 0 is never a real zone. The #3110 guard
+// already stops every rule tier from matching such a flow — including
+// `from-zone any to-zone any`, which is what the issue reported as the bypass
+// and which these tests confirm was ALREADY closed. What was still open is the
+// fall-through: the flow reached the implicit default, and `default-policy
+// permit-all` forwarded it, with screens already skipped.
+// ---------------------------------------------------------------------------
+
+/// A `from-zone any to-zone any permit` rule — the both-any tier.
+fn both_any_permit_snapshot_6682() -> PolicyRuleSnapshot {
+    PolicyRuleSnapshot {
+        rule_id: "both-any-permit".to_string(),
+        name: "baseline-allow".to_string(),
+        from_zone: "any".to_string(),
+        to_zone: "any".to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec!["any".to_string()],
+        action: "permit".to_string(),
+        ..Default::default()
+    }
+}
+
+fn eval_6682(state: &PolicyState, from_id: u16, to_id: u16) -> PolicyEvaluationResult {
+    evaluate_policy_result_l3_aware(
+        state,
+        from_id,
+        to_id,
+        std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 61, 5)),
+        std::net::IpAddr::V4(std::net::Ipv4Addr::new(203, 0, 113, 5)),
+        PROTO_TCP,
+        40000,
+        443,
+        None,
+        64,
+        true,
+    )
+}
+
+fn unzoned_denied_count_6682() -> u64 {
+    crate::policy::UNZONED_INGRESS_DENIED.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+#[test]
+fn unzoned_ingress_is_denied_not_defaulted_6682() {
+    // default-policy permit-all: the operator is saying what to do with traffic
+    // that matched no policy. That is not the same as saying to forward traffic
+    // that had no zone to be adjudicated in.
+    let state = parse_policy_state(
+        "permit",
+        &[both_any_permit_snapshot_6682()],
+        &test_zone_name_to_id(),
+    );
+
+    // Setup guard: the both-any permit really does permit a properly ZONED
+    // flow. Without this the deny below could pass because the rule never
+    // matches anything at all, and the test would prove nothing (the fixture,
+    // not the fix, would be doing the work).
+    assert_eq!(
+        eval_6682(&state, TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID).action,
+        PolicyAction::Permit,
+        "setup: a from-any/to-any permit must admit a zoned flow",
+    );
+
+    // The mechanism, not just the outcome. Several dispositions drop a packet;
+    // an outcome-only assertion cannot say which one fired, and a default-DENY
+    // would satisfy `action == Deny` while the bypass was still wide open.
+    let before = unzoned_denied_count_6682();
+    let result = eval_6682(&state, 0, TEST_WAN_ZONE_ID);
+    let after = unzoned_denied_count_6682();
+
+    assert_eq!(
+        result.action,
+        PolicyAction::Deny,
+        "an unzoned ingress reached the implicit default policy and \
+         default-policy permit-all forwarded it (#6682)",
+    );
+    assert_eq!(
+        after - before,
+        1,
+        "the deny must be attributed to the unzoned-ingress counter, not to \
+         default_counter: a rising default-deny means policy is working, a \
+         rising unzoned count means an interface fell out of its zone",
+    );
+    assert_eq!(
+        result.policy_counter_idx, 0,
+        "an unzoned deny installs no session and must claim no rule's hit \
+         counter (0 is the reserved no-counter handle)",
+    );
+}
+
+#[test]
+fn unzoned_ingress_denied_with_no_rules_at_all_6682() {
+    // The bypass does not need a wildcard rule — the implicit default alone is
+    // enough. This is the case the issue's evidence missed: it attributed the
+    // forward to the both-any tier, which #3110 had already fenced off.
+    let state = parse_policy_state("permit", &[], &test_zone_name_to_id());
+
+    assert_eq!(
+        eval_6682(&state, TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID).action,
+        PolicyAction::Permit,
+        "setup: default-policy permit-all must permit a zoned flow",
+    );
+
+    let before = unzoned_denied_count_6682();
+    assert_eq!(
+        eval_6682(&state, 0, TEST_WAN_ZONE_ID).action,
+        PolicyAction::Deny,
+        "default-policy permit-all must not forward an unzoned ingress (#6682)",
+    );
+    assert_eq!(unzoned_denied_count_6682() - before, 1);
+}
+
+#[test]
+fn both_any_tier_already_refused_zone_zero_before_6682() {
+    // Pins the #3110 guard itself, which is the half of the issue's report that
+    // was NOT true. With a default of DENY, an unzoned flow must be denied
+    // whether or not a both-any permit exists — i.e. the wildcard rule was
+    // never the thing forwarding it.
+    //
+    // This is deliberately a separate test from the two above: they would still
+    // pass if #3110 were deleted and the new deny alone carried the property,
+    // which would silently hand a load-bearing guard's job to a newer one.
+    let with_wildcard = parse_policy_state(
+        "deny",
+        &[both_any_permit_snapshot_6682()],
+        &test_zone_name_to_id(),
+    );
+    assert_eq!(
+        eval_6682(&with_wildcard, 0, TEST_WAN_ZONE_ID).action,
+        PolicyAction::Deny,
+        "a from-any/to-any permit must never match a zone-0 ingress (#3110)",
+    );
+}
+
+#[test]
+fn unzoned_egress_still_falls_through_to_default_6682() {
+    // Documents the deliberate scope of the #6682 deny: INGRESS only.
+    //
+    // A zero EGRESS zone has historically meant a bug elsewhere rather than
+    // genuine unzoned-ness (#6713: an xfrmi tunnel egress resolved to 0 because
+    // populate_egress needed a link-layer address a MAC-less interface has
+    // none of), so denying on it would risk black-holing a correctly configured
+    // path. If that scope is ever widened this test is the one that should be
+    // rewritten rather than deleted — its failure means the behaviour changed,
+    // which is exactly the signal wanted.
+    let state = parse_policy_state("permit", &[], &test_zone_name_to_id());
+    let before = unzoned_denied_count_6682();
+    assert_eq!(
+        eval_6682(&state, TEST_LAN_ZONE_ID, 0).action,
+        PolicyAction::Permit,
+        "the #6682 deny is scoped to the ingress zone; a zero egress zone still \
+         falls through to the default policy",
+    );
+    assert_eq!(
+        unzoned_denied_count_6682() - before,
+        0,
+        "a zero EGRESS zone must not be counted as an unzoned-ingress deny",
+    );
+}


### PR DESCRIPTION
Closes #6682

> **SMOKE OWED** — changes forwarding behaviour in the userspace dataplane and moves the helper binary. Fail-**closed** (traffic that was forwarded is now denied), so the case to exercise is that a normally zoned cluster is unaffected: every smoke interface is zoned, so the new branch should never be taken there.

## The issue's reported mechanism is not the defect — and that correction matters more than the fix

#6682 attributes the forward to a `from-zone any to-zone any permit` matching the `(0,0)` pair in the both-any tier, citing `policy.rs:2764` as having no zone comparison.

The loop body indeed has none — but it sits **inside** the `#3110` guard, `if from_id != 0 && to_id != 0`, which opens ~85 lines above it and closes ~75 below. Brace-matched at the issue's own trace commit `ebe370701`:

```
guard  if from_id != 0 && to_id != 0 {   spans 2679..2863
both-any tier                            at   2787   -> INSIDE
```

So that half was already closed, and was already closed **when the issue was filed**. This is a local read that missed an enclosing scope, not a citation that rotted.

## What is real: the fall-through the guard leaves behind

Being ineligible for every rule tier is only half of safe. The flow still lands on the implicit default, and `default-policy permit-all` makes that a **PERMIT** — with screens already skipped, since an unresolvable ingress zone returns `ScreenCheckOutcome::Pass` (there is no per-zone screen profile to apply).

`docs/userspace-dataplane-architecture.md` already said this in another context — *"under `default-policy permit-all` the same resolution is fail-OPEN … it is safe exactly to the extent the default policy is"* — so the hazard was known and written down, just never connected to unzoned ingress.

So the issue's **conclusion** was right (an unzoned interface forwards transit with IDS bypassed) via a mechanism it did not identify, and its evidence would have been closed by a fix that changed nothing.

## The fix

Zone 0 is never a legitimate zone — `StableZoneID` folds every configured zone into `[1, 65533]`, and the `#2391` over-cap collapse-to-0 path is retired (`#3075`: an interface naming an absent zone now fails the snapshot closed). So denying zone 0 cannot black-hole a real zone.

`from_id == 0` now returns `Deny` directly and counts on `UNZONED_INGRESS_DENIED`, separate from `default_counter` so the causes stay distinguishable: a rising default-deny means policy is working as configured; a rising unzoned count means an interface fell out of its zone. `policy_counter_idx` stays 0 — the deny installs no session and must claim no rule's counter.

**Ingress only, deliberately.** A zero *egress* zone has historically meant a bug elsewhere rather than genuine unzoned-ness (`#6713`: an xfrmi tunnel egress resolved to 0 because `populate_egress` needed a link-layer address a MAC-less interface lacks), so denying on `to_id` would risk black-holing a correctly configured path. A test pins the egress fall-through so widening that scope later is a deliberate edit, not silent drift.

**Management cannot be locked out.** The LocalDelivery arm adjudicates through `evaluate_junos_host_policy_l3_aware`, which already declines `from_id == 0`, and both production callers of this function are transit (the `ForwardCandidate` gate and the flowless `MissingNeighbor` arm). An unzoned `fxp0` is unaffected.

**Log attribution unchanged, deliberately.** `policy_id` still carries `DEFAULT_POLICY_SENTINEL_ID`, so the deny logs as `default-policy`. A dedicated sentinel is wire-visible and mirrored across ~10 Go call sites (display maps, counter readers, the `#4342` invalidation sweep, gRPC/CLI/API) and interacts with `#4626`. `default-policy` is honest — no rule matched — just less specific than the counter. Worth doing on its own.

## Mutation matrix

Every cell verified APPLIED first.

| # | mutation | result |
|---|---|---|
| S1 | delete the #6682 deny block | **RED** — both bypass tests; the #3110 test stays green |
| S2 | deny on `to_id` instead of `from_id` | **RED** — scope test + both bypass tests |
| S3 | deny but do not count | **RED** — mechanism assertions only |
| S4 | delete the #3110 guard | **RED** |

**S4 is the tightening cell.** It reds the dedicated #3110 test *and* one bypass test — because with the guard gone a both-any permit matches the zone-0 flow and returns **before** the new deny is reached. The two guards are complementary and **ordered**, not redundant, and #3110 keeps its own test so the newer deny cannot silently take over its job.

Tests assert the **mechanism**, not the outcome: several dispositions drop a packet, and a default-DENY would satisfy `action == Deny` with the bypass wide open, so the counter delta is asserted alongside. Each bypass test carries a setup guard proving the fixture would otherwise PERMIT.

## Acceptance criteria

- [x] A flow whose ingress ifindex is absent from `ifindex_to_zone_id` does not match a `from-zone any to-zone any permit` — verified already true (#3110), and now pinned by its own test.
- [x] Its disposition is an explicit, counted deny, not a silent fall-through.
- [x] Screen checks: the packet is now **dropped** rather than passed, which is the criterion's stated alternative. The `Pass` return itself is unchanged — with policy denying the flow it is no longer reachable as a bypass.
- [x] Tests assert the specific mechanism (counter delta), not a bare drop.
- [x] Mutation proof: build + vet clean on revert, specific test reds as an assertion.

## Validation

Full cargo suite green with `--test-threads=1`; `cargo check` clean; `go build ./...` clean.