### PR TITLE
config: ratify the two one-value multi leaves (#6674)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103096,3 +103096,17 @@ prose edit above them added. No diff falls in the new test body.
     owner's authoritative session family under latest-generation-wins.
   - **File(s)**: pkg/daemon/daemon_ha_userspace_stream.go,
     pkg/daemon/userspace_sync_test.go, docs/session-sync-architecture.md
+
+## 2026-08-22 — #6674 ratify both multi-value arms
+- **Timestamp**: 2026-08-22
+- **Action**: Ratify `forwarding-table export` and static-NAT
+  `match destination-address` as one-value leaves; measure and record that a
+  policy chain is NOT equivalent to its first member; clear six source sites
+  that promised a follow-up.
+- **File(s)**: pkg/config/types_routing.go, pkg/config/types_security.go,
+  pkg/config/compiler_validate_strict_routing.go,
+  pkg/config/compiler_validate_strict_nat.go,
+  pkg/config/compiler_uniformgates_log_feed_routing.go,
+  pkg/config/compiler_uniformgates_firewall_nat2.go,
+  pkg/config/multivalue_ratified_contract_6674_test.go,
+  pkg/frr/forwarding_export_chain_6674_test.go, docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1278,6 +1278,45 @@ empty command, so an empty entry never reaches a checker and the remediation
 batch is unaffected by it. Its entry is kept because the compiled list is
 observable in its own right (below), not because anything gates on it.
 
+**Two of those leaves accept ONE value permanently, and #6674 ratified that
+rather than implementing the list.** #6673 fixed the READ half for both — every
+authored value now reaches validation and a multi-valued list is hard-REJECTED
+at commit, warned on the tolerant path — but the scalar the runtime installs is
+still a single value at three successive layers. Six source sites told the
+reader a follow-up was coming; none is. The two arms ratify for DIFFERENT
+reasons, and conflating them is how the wrong decision gets made for the pair:
+
+- `security nat static … rule … match destination-address`: **Junos takes one
+  prefix here**, so the schema's `multi: true` is an xpf over-advertisement of
+  the grammar, not a promise. A static-NAT rule is a 1:1 mapping — one `match
+  destination-address` against one `then static-nat prefix` — so N external
+  prefixes against one internal prefix names no target, and fanning the rule
+  into N rows would have to invent a pairing Junos does not define. `rule R1` /
+  `rule R2` already expresses the intent.
+- `routing-options forwarding-table export`: **Junos genuinely takes a policy
+  CHAIN**, so "the schema over-advertises" is not available here — and neither
+  is the tempting shortcut "a chain is equivalent to its first policy", which
+  was MEASURED FALSE (`pkg/frr/forwarding_export_chain_6674_test.go`: for a
+  plain first policy and a load-balancing second, the first-policy reading gives
+  `maximum-paths` 0 and the OR-composed chain gives 64). It ratifies for a
+  structural reason instead: `resolveECMP` derives exactly two booleans from the
+  ONE named policy — any term with a load-balance action sets `ecmpMaxPaths` to
+  64, any `consistent-hash` term sets `ConsistentHash` — and evaluates no `from`
+  match, term order, or terminating action. Junos evaluates an export chain PER
+  ROUTE and stops at the first terminating action, so the cheap composition
+  (OR across the chain) is not Junos, and the faithful one is not expressible at
+  all because the value being derived is FRR's GLOBAL `maximum-paths`. A chain
+  needs a per-route forwarding-policy model xpf does not have — a feature,
+  tracked as its own issue, not a defect in the multi-value read.
+
+The operator-facing half is pinned behaviourally rather than by comment:
+`TestRatifiedGatesDoNotPromiseAFollowUp_6674` compiles each config on the
+tolerant path and asserts the warning the operator READS neither promises a
+follow-up nor drops the reason, with the still-rejects/still-commits pair as its
+green control. A comment that rots is bad; a warning that promises a feature
+which is never coming is worse, because the operator acts on it — they leave the
+list in place and wait.
+
 **SIX leaf families, SEVEN read sites AT #6673 — the category table above has
 FOUR rows and is not the inventory.** (The table is appended to as later fixes
 land; row 8 is #6687's, and the counts in this sentence describe #6673 only.) The four rows classify EMPTY-VALUE semantics, and

--- a/pkg/config/compiler_uniformgates_firewall_nat2.go
+++ b/pkg/config/compiler_uniformgates_firewall_nat2.go
@@ -168,9 +168,12 @@ func runUniformGatesFirewallNAT2(tree *ConfigTree, cfg *Config, opts compileOpts
 					"(the LAST authored `match destination-address` statement, or within "+
 					"a bracketed list that statement's first value; none at all when that "+
 					"value is empty) — and the rest carry no translation; "+
-					"author one rule per external prefix (support for the list form is tracked "+
-					"in #6674). Downgraded to a warning on the tolerant load / peer-sync path "+
-					"so an already-persisted config still boots: %v", err))
+					"author one rule per external prefix. A static-NAT rule is a 1:1 "+
+					"mapping — one `match destination-address` against one `then static-nat "+
+					"prefix` — so N external prefixes against one internal prefix has no "+
+					"defined target, which is why this is the permanent contract and not a "+
+					"pending feature (#6674). Downgraded to a warning on the tolerant load / "+
+					"peer-sync path so an already-persisted config still boots: %v", err))
 		} else {
 			return err
 		}

--- a/pkg/config/compiler_uniformgates_log_feed_routing.go
+++ b/pkg/config/compiler_uniformgates_log_feed_routing.go
@@ -161,8 +161,10 @@ func runUniformGatesLogFeedRouting(tree *ConfigTree, cfg *Config, opts compileOp
 					"the ECMP render honours AT MOST ONE policy (the one the wrapped "+
 					"error names — none at all when the selected value is empty) and "+
 					"the rest have no "+
-					"effect on load-balancing; configure one export policy (support for the Junos "+
-					"export policy CHAIN is tracked in #6674). Downgraded to a warning on the "+
+					"effect on load-balancing; configure one export policy. xpf models "+
+					"forwarding-table export as a GLOBAL ECMP toggle derived from one "+
+					"policy, not as a per-route Junos policy chain, so a chain has no "+
+					"representable meaning here (#6674). Downgraded to a warning on the "+
 					"tolerant load / peer-sync path so an already-persisted config still boots: %v", err))
 		} else {
 			return err

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -2567,8 +2567,13 @@ func validateStaticNATInetTargetStrict(cfg *Config) error {
 // inventing rule-fanout semantics (which external prefix pairs with the single
 // `then static-nat prefix`?). Junos likewise takes one prefix here. Rejecting
 // makes the previously-silent collapse loud and fails CLOSED; the operator
-// writes one rule per external prefix. Widening static NAT to fan a rule across
-// several external prefixes is a separate semantic change, tracked as #6674.
+// writes one rule per external prefix.
+//
+// #6674 RATIFIED that as the permanent contract. The pairing question above has
+// no answer to find: a static-NAT rule is a 1:1 mapping, and `rule R1` /
+// `rule R2` already expresses N external prefixes exactly. The `multi: true` on
+// the schema leaf (schema_security.go) is an xpf over-advertisement of the
+// grammar, not a promise — see docs/config-schema.md.
 //
 // Strict on commit / commit-check (hard reject); the call site downgrades to a
 // warning on the tolerant load / peer-sync path (#1960 no-brick), where Match

--- a/pkg/config/compiler_validate_strict_routing.go
+++ b/pkg/config/compiler_validate_strict_routing.go
@@ -286,10 +286,25 @@ func validateRoutingExportReferencesStrict(cfg *Config) error {
 // multi-policy chain silently collapsed to the first — the operator's remaining
 // policies had no effect on load-balancing and nothing said so.
 //
-// Rejecting makes that collapse loud and fails CLOSED. It is deliberately NOT a
-// renderer change: implementing a real policy chain means deciding how several
-// policies compose into one ecmpMaxPaths, which is a routing-semantics design
-// question rather than a multi-value-read fix. Tracked as #6674.
+// Rejecting makes that collapse loud and fails CLOSED, and #6674 RATIFIED it as
+// the permanent contract rather than a pending renderer change.
+//
+// The reason, stated because "Junos takes a chain here" is true and still does
+// not make a chain implementable: resolveECMP (pkg/frr/config_render.go) derives
+// exactly TWO booleans from the ONE named policy — any term with a load-balance
+// action sets ecmpMaxPaths to 64, any term with `consistent-hash` sets
+// fc.ConsistentHash — and evaluates no `from` match, no term order, and no
+// terminating action. Junos evaluates an export chain PER ROUTE and stops at the
+// first terminating action, so the only cheap composition (OR the flags across
+// the chain) is NOT Junos: a route accepted by the first policy never reaches
+// the second, yet the OR would apply the second's load-balance to it. Measured,
+// not assumed — the two readings differ whenever the first policy carries no
+// load-balance term and a later one does, which is pinned by
+// TestForwardingTableExportIsAGlobalToggleNotAChain_6674. The faithful reading
+// cannot be expressed at all: the value being derived is FRR's GLOBAL
+// `maximum-paths`, which has no per-route form. A chain therefore needs a
+// per-route forwarding-policy model xpf does not have — a feature, tracked
+// separately, not a defect in this gate.
 //
 // Strict on commit / commit-check (hard reject); the call site downgrades to a
 // warning on the tolerant load / peer-sync path (#1960 no-brick), where

--- a/pkg/config/multivalue_ratified_contract_6674_test.go
+++ b/pkg/config/multivalue_ratified_contract_6674_test.go
@@ -1,0 +1,318 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// #6674 — the two `multi: true` leaves whose extra values are not representable
+// are RATIFIED as accepting one value, not implemented as lists.
+//
+// WHAT #6673 ALREADY DID, so this is not re-litigated: both leaves now
+// accumulate every authored value into a plural field, so nothing escapes
+// validation, and a multi-valued list is hard-REJECTED at commit / commit-check
+// and warned on the tolerant load / peer-sync path. The fail-open half is gone.
+// What remained was a TYPE-SHAPE limit and six source sites telling the reader a
+// follow-up was coming.
+//
+// THE TWO ARMS RATIFY FOR DIFFERENT REASONS, and conflating them is how a wrong
+// decision gets made for the pair:
+//
+//   - `security nat static rule-set <rs> rule <r> match destination-address`:
+//     Junos takes ONE prefix here. A static-NAT rule is a 1:1 mapping — one
+//     `match destination-address` against one `then static-nat prefix` — so N
+//     external prefixes against one internal prefix names no target. `rule R1` /
+//     `rule R2` already expresses the intent. The schema's `multi: true` is an
+//     xpf OVER-ADVERTISEMENT of the grammar, not a promise.
+//   - `routing-options forwarding-table export`: Junos genuinely takes a policy
+//     CHAIN, so "the schema over-advertises" is NOT available as an argument
+//     here, and neither is "a chain is equivalent to its first policy" — that
+//     equivalence is measured FALSE in
+//     pkg/frr/forwarding_export_chain_6674_test.go. It ratifies because
+//     resolveECMP derives FRR's GLOBAL `maximum-paths`, which has no per-route
+//     form, while Junos evaluates the chain per route and stops at the first
+//     terminating action. The cheap composition is not Junos and the faithful
+//     one is not expressible.
+//
+// This file pins the OPERATOR-FACING half of that decision. A source comment
+// that rots is bad; a warning message that promises a feature which is never
+// coming is worse, because the operator acts on it — they leave the list in
+// place and wait.
+
+// warningsFor6674 compiles a config on the TOLERANT path (load / peer-sync) and
+// returns the warnings, which is where the operator-facing text for these two
+// gates lives. The strict path returns the same text as an error.
+func warningsFor6674(t *testing.T, cmds ...string) []string {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("tolerant compile failed: %v", err)
+	}
+	return cfg.Warnings
+}
+
+func warningMatching6674(t *testing.T, warnings []string, needle string) string {
+	t.Helper()
+	for _, w := range warnings {
+		if strings.Contains(w, needle) {
+			return w
+		}
+	}
+	t.Fatalf("no warning containing %q; got %d warnings:\n%s",
+		needle, len(warnings), strings.Join(warnings, "\n"))
+	return ""
+}
+
+// TestRatifiedGatesDoNotPromiseAFollowUp_6674 is the behavioural guard, and it
+// asserts on the text the OPERATOR reads rather than on the source.
+//
+// Both halves are required. The negative half alone would pass on a gate that
+// stopped warning entirely; the positive half alone would pass on a gate that
+// says both "this is permanent" and "support is tracked in #6674".
+func TestRatifiedGatesDoNotPromiseAFollowUp_6674(t *testing.T) {
+	cases := []struct {
+		name string
+		cmds []string
+		// needle identifies the gate's own warning among the others, so the
+		// assertion cannot be satisfied by an unrelated warning.
+		needle string
+		// wantReason is a phrase that states WHY the limit is permanent. Keyed
+		// to the reason, not to a fix: a rewording that keeps the reason keeps
+		// this green, and a rewording that drops it does not.
+		wantReason string
+	}{
+		{
+			name: "forwarding-table-export",
+			cmds: []string{
+				"set policy-options policy-statement p1 then accept",
+				"set policy-options policy-statement p2 then accept",
+				"set routing-options forwarding-table export [ p1 p2 ]",
+			},
+			needle:     "forwarding-table export LIST FORM IS NOT SUPPORTED",
+			wantReason: "GLOBAL ECMP toggle",
+		},
+		{
+			name: "static-nat-match-destination-address",
+			cmds: []string{
+				"set security nat static rule-set rs from zone untrust",
+				"set security nat static rule-set rs rule r1 match destination-address [ 10.6.0.1/32 10.6.0.2/32 ]",
+				"set security nat static rule-set rs rule r1 then static-nat prefix 10.0.1.1/32",
+			},
+			needle:     "static NAT `match destination-address` LIST FORM IS NOT SUPPORTED",
+			wantReason: "1:1 mapping",
+		},
+	}
+
+	// Wording that tells the operator a follow-up is coming. Normalized for
+	// line wrapping first — these strings are built from concatenated source
+	// literals, and a claim that breaks across two of them is invisible to a
+	// literal search.
+	promises := []string{
+		"tracked in #6674",
+		"tracked as #6674",
+		"support for the list form is tracked",
+		"support for the junos export policy chain is tracked",
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			w := warningMatching6674(t, warningsFor6674(t, tc.cmds...), tc.needle)
+			flat := strings.ToLower(strings.Join(strings.Fields(w), " "))
+			for _, p := range promises {
+				if strings.Contains(flat, strings.ToLower(p)) {
+					t.Errorf("the warning still promises a follow-up (%q), which #6674 "+
+						"decided is not coming — the operator leaves the list in place "+
+						"and waits:\n%s", p, w)
+				}
+			}
+			if !strings.Contains(w, tc.wantReason) {
+				t.Errorf("the warning does not say WHY the limit is permanent "+
+					"(want a mention of %q):\n%s", tc.wantReason, w)
+			}
+		})
+	}
+}
+
+// ratifiedFollowUpClaim matches source text that presents #6674 as a pending
+// follow-up. It is applied to WHITESPACE-NORMALIZED file text so a claim broken
+// across two comment lines is still caught — the failure mode a literal grep
+// has on exactly this kind of wrapped prose.
+var ratifiedFollowUpClaim = regexp.MustCompile(
+	`(?i)(tracked (as|in) #6674|separate (semantic change|renderer change)[^.]{0,40}#6674|#6674[^.]{0,40}(is a separate|not this fix))`)
+
+// flattenSourceFor6674 normalizes source text so a claim WRAPPED across comment
+// lines is visible to the regex.
+//
+// Collapsing whitespace alone is not enough, and that is the trap: a claim that
+// breaks mid-phrase leaves the `//` marker of the next line embedded in the
+// flattened text ("tracked as // #6674"), which no adjacency regex matches. The
+// comment markers have to go too. TestSweepNormalizationSeesAWrappedClaim_6674
+// is the positive control for exactly this — without it the normalization is an
+// untested claim, and a sweep that cannot see a wrapped promise reports a clean
+// tree it never actually searched.
+func flattenSourceFor6674(text string) string {
+	r := strings.NewReplacer("//", " ", "/*", " ", "*/", " ")
+	return strings.Join(strings.Fields(r.Replace(text)), " ")
+}
+
+// TestSweepNormalizationSeesAWrappedClaim_6674 is the positive control for the
+// sweep below. It asserts BOTH directions on one synthetic sample: the raw text
+// must NOT match (or the control proves nothing about normalization) and the
+// normalized text MUST match.
+func TestSweepNormalizationSeesAWrappedClaim_6674(t *testing.T) {
+	// The claim breaks between "tracked as" and "#6674", which is the shape a
+	// literal grep and a whitespace-only normalization both miss: the `//` of
+	// the continuation line lands between the two halves.
+	const wrapped = "\t// Widening static NAT to fan a rule across several\n" +
+		"\t// external prefixes is a change tracked as\n" +
+		"\t// #6674 and is out of scope here.\n"
+
+	if m := ratifiedFollowUpClaim.FindString(wrapped); m != "" {
+		t.Fatalf("the RAW sample already matches (%q), so this control cannot show "+
+			"that normalization is doing anything", m)
+	}
+	if m := ratifiedFollowUpClaim.FindString(flattenSourceFor6674(wrapped)); m == "" {
+		t.Fatalf("a claim wrapped across comment lines is INVISIBLE to the sweep; "+
+			"normalized text was %q", flattenSourceFor6674(wrapped))
+	}
+}
+
+// TestNoSourceStillCallsThisAPendingFollowUp_6674 sweeps the tree for the six
+// breadcrumbs, so a future edit cannot reinstate the promise in a comment while
+// the warning text stays correct.
+//
+// It is a source sweep because that IS the artifact — the claim lives only in
+// comments, and there is no runtime observation of a comment.
+func TestNoSourceStillCallsThisAPendingFollowUp_6674(t *testing.T) {
+	root := ".."
+	var offenders []string
+	checked := 0
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		text := string(b)
+		if !strings.Contains(text, "6674") {
+			return nil
+		}
+		checked++
+		flat := flattenSourceFor6674(text)
+		if m := ratifiedFollowUpClaim.FindString(flat); m != "" {
+			offenders = append(offenders, path+": "+m)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if checked == 0 {
+		t.Fatalf("no non-test source file mentions 6674 at all — the sweep found " +
+			"nothing to search, so a green here says nothing about the claim")
+	}
+	if len(offenders) > 0 {
+		t.Errorf("source still presents #6674 as a pending follow-up; it was RATIFIED "+
+			"(neither arm is being implemented):\n  %s", strings.Join(offenders, "\n  "))
+	}
+	t.Logf("swept %d non-test source files mentioning 6674", checked)
+}
+
+// TestRatifiedGatesStillRejectOnCommit_6674 is the green control for the pair.
+// A ratification must not weaken the gate: the list is still a hard REJECT on
+// the strict commit path, and a single value still commits. Without both halves
+// the tests above would pass on a change that simply stopped gating.
+func TestRatifiedGatesStillRejectOnCommit_6674(t *testing.T) {
+	build := func(cmds ...string) *ConfigTree {
+		tree := &ConfigTree{}
+		for _, cmd := range cmds {
+			path, err := ParseSetCommand(cmd)
+			if err != nil {
+				t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+			}
+			if err := tree.SetPath(path); err != nil {
+				t.Fatalf("SetPath(%q): %v", cmd, err)
+			}
+		}
+		return tree
+	}
+
+	t.Run("forwarding-table export list rejected", func(t *testing.T) {
+		_, err := CompileConfig(build(
+			"set policy-options policy-statement p1 then accept",
+			"set policy-options policy-statement p2 then accept",
+			"set routing-options forwarding-table export [ p1 p2 ]",
+		))
+		if err == nil {
+			t.Fatal("a two-policy export list committed clean")
+		}
+		if !strings.Contains(err.Error(), "forwarding-table export declares 2 policies") {
+			t.Fatalf("rejected by a different gate: %v", err)
+		}
+	})
+
+	t.Run("forwarding-table export single still commits", func(t *testing.T) {
+		cfg, err := CompileConfig(build(
+			"set policy-options policy-statement p1 then accept",
+			"set routing-options forwarding-table export p1",
+		))
+		if err != nil {
+			t.Fatalf("a single export policy no longer commits: %v", err)
+		}
+		if cfg.RoutingOptions.ForwardingTableExport != "p1" {
+			t.Errorf("selected export policy = %q, want p1", cfg.RoutingOptions.ForwardingTableExport)
+		}
+	})
+
+	t.Run("static NAT match list rejected", func(t *testing.T) {
+		_, err := CompileConfig(build(
+			"set security nat static rule-set rs from zone untrust",
+			"set security nat static rule-set rs rule r1 match destination-address [ 10.6.0.1/32 10.6.0.2/32 ]",
+			"set security nat static rule-set rs rule r1 then static-nat prefix 10.0.1.1/32",
+		))
+		if err == nil {
+			t.Fatal("a two-prefix static NAT match committed clean")
+		}
+	})
+
+	t.Run("static NAT single prefix still commits", func(t *testing.T) {
+		cfg, err := CompileConfig(build(
+			"set security nat static rule-set rs from zone untrust",
+			"set security nat static rule-set rs rule r1 match destination-address 10.6.0.1/32",
+			"set security nat static rule-set rs rule r1 then static-nat prefix 10.0.1.1/32",
+		))
+		if err != nil {
+			t.Fatalf("a single static NAT prefix no longer commits: %v", err)
+		}
+		var found bool
+		for _, rs := range cfg.Security.NAT.Static {
+			for _, r := range rs.Rules {
+				if r.Match == "10.6.0.1/32" {
+					found = true
+				}
+			}
+		}
+		if !found {
+			t.Errorf("the single external prefix did not reach the compiled rule")
+		}
+	})
+}

--- a/pkg/config/types_routing.go
+++ b/pkg/config/types_routing.go
@@ -157,8 +157,23 @@ type RoutingOptionsConfig struct {
 	// ForwardingTableExport remains what the FRR renderer consumes (resolveECMP
 	// derives ecmpMaxPaths from exactly one policy-statement).
 	// validateForwardingTableExportSingleStrict rejects a multi-valued list
-	// rather than letting it silently collapse. Honouring a full Junos export
-	// policy CHAIN is a separate renderer change, not this fix (#6674).
+	// rather than letting it silently collapse.
+	//
+	// #6674 RATIFIED that rejection as the permanent contract rather than a
+	// pending feature, and the reason is worth stating because "Junos takes a
+	// chain here" is true and still does not make a chain implementable.
+	// resolveECMP derives exactly TWO booleans from the ONE named policy: any
+	// term with a load-balance action sets ecmpMaxPaths to 64, and any term
+	// with `consistent-hash` sets fc.ConsistentHash. It evaluates no `from`
+	// match, no term order, and no terminating action. Junos evaluates an
+	// export chain PER ROUTE and stops at the first terminating action, so the
+	// only cheap composition — OR the flags across the chain — is NOT Junos: a
+	// route accepted by the first policy never reaches the second, yet the OR
+	// would apply the second's load-balance to it. And the faithful reading
+	// cannot be expressed at all, because the value being derived is FRR's
+	// global `maximum-paths`, which has no per-route form. Supporting a chain
+	// therefore needs a per-route forwarding-policy model xpf does not have —
+	// a feature, tracked separately, not a bug in this read.
 	//
 	// #6673: the scalar is NOT element [0] of this list, and the list is read
 	// with multiLeafAuthoredValues so empty values are KEPT. Two shapes make

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -1007,8 +1007,14 @@ type StaticNATRule struct {
 	// so a rule with more than one prefix has no representable meaning today.
 	// validateStaticNATMatchAddressesStrict therefore REJECTS a multi-valued
 	// list at commit rather than letting it silently collapse to the first.
-	// Widening static NAT to fan one rule into N external prefixes is a
-	// separate semantic change (see #6674), not this fix.
+	//
+	// #6674 RATIFIED that rejection as the permanent contract. A static-NAT
+	// rule is a 1:1 mapping: ONE `match destination-address` against ONE
+	// `then static-nat prefix` (Then, below). N external prefixes against one
+	// internal prefix names no target, so fanning the rule into N rows would
+	// have to invent a pairing rule Junos does not define — and `rule R1` /
+	// `rule R2` already expresses the intent exactly. The `multi: true` on the
+	// schema leaf is an xpf over-advertisement of the grammar, not a promise.
 	//
 	// #6673: read with multiLeafAuthoredValues, which KEEPS empty values, so this
 	// list always contains what Match selected; an empty entry is a selection, not

--- a/pkg/frr/forwarding_export_chain_6674_test.go
+++ b/pkg/frr/forwarding_export_chain_6674_test.go
@@ -1,0 +1,113 @@
+package frr
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6674 arm B — `routing-options forwarding-table export` is RATIFIED as
+// accepting one policy, not a Junos policy chain, and this file records the
+// measurement that decides it rather than the claim.
+//
+// The tempting argument for ratification was that a chain would be
+// OBSERVATIONALLY IDENTICAL to taking the first policy, because resolveECMP
+// only ever answers "is load-balancing on". That argument is FALSE, and this
+// file exists partly to say so: composing a chain by OR-ing the flags gives a
+// DIFFERENT answer than taking the first policy whenever the first carries no
+// load-balance term and a later one does.
+//
+// The ratification therefore rests on a different and stronger reason. Junos
+// evaluates an export chain PER ROUTE, stopping at the first terminating
+// action, so:
+//
+//   - the cheap composition (OR across the chain) is not Junos — a route
+//     accepted by the first policy never reaches the second, yet the OR would
+//     apply the second's load-balance to it; and
+//   - the faithful composition cannot be expressed, because the value being
+//     derived is FRR's GLOBAL `maximum-paths`, which has no per-route form.
+//
+// A chain needs a per-route forwarding-policy model xpf does not have. That is
+// a feature, not a defect in the multi-value read, which is why #6674 closes
+// with the reject intact and the "follow-up coming" text removed from six
+// source sites.
+
+func policyWithLoadBalance6674(name, lb string) *config.PolicyStatement {
+	return &config.PolicyStatement{
+		Name:  name,
+		Terms: []*config.PolicyTerm{{Name: "t1", LoadBalance: lb}},
+	}
+}
+
+func resolveECMPFor6674(t *testing.T, selected string, policies ...*config.PolicyStatement) (int, bool) {
+	t.Helper()
+	byName := make(map[string]*config.PolicyStatement, len(policies))
+	for _, p := range policies {
+		byName[p.Name] = p
+	}
+	fc := &FullConfig{
+		ForwardingTableExport: selected,
+		PolicyOptions:         &config.PolicyOptionsConfig{PolicyStatements: byName},
+	}
+	return resolveECMP(fc), fc.ConsistentHash
+}
+
+// TestForwardingTableExportIsAGlobalToggleNotAChain_6674 measures what
+// resolveECMP actually derives, and falsifies the equivalence that would have
+// made ratification easy.
+//
+// Read the two halves together: the first pins that resolveECMP is a function
+// of ONE named policy and nothing else, and the second pins that the OR
+// composition and the first-policy reading DISAGREE — so "a chain is
+// equivalent to its first member" is not available as an argument.
+func TestForwardingTableExportIsAGlobalToggleNotAChain_6674(t *testing.T) {
+	plain := policyWithLoadBalance6674("plain", "")
+	perPacket := policyWithLoadBalance6674("lb", "per-packet")
+	consistent := policyWithLoadBalance6674("ch", "consistent-hash")
+
+	t.Run("derives two booleans from one named policy", func(t *testing.T) {
+		if paths, ch := resolveECMPFor6674(t, "plain", plain, perPacket, consistent); paths != 0 || ch {
+			t.Errorf("selecting a policy with no load-balance term: got maxPaths=%d consistentHash=%v, want 0/false "+
+				"(the OTHER policies in the map must not contribute)", paths, ch)
+		}
+		if paths, ch := resolveECMPFor6674(t, "lb", plain, perPacket, consistent); paths != 64 || ch {
+			t.Errorf("per-packet: got maxPaths=%d consistentHash=%v, want 64/false", paths, ch)
+		}
+		if paths, ch := resolveECMPFor6674(t, "ch", plain, perPacket, consistent); paths != 64 || !ch {
+			t.Errorf("consistent-hash: got maxPaths=%d consistentHash=%v, want 64/true", paths, ch)
+		}
+	})
+
+	t.Run("a chain is not equivalent to its first member", func(t *testing.T) {
+		// The discriminating shape: first policy plain, second load-balancing.
+		firstOnly, _ := resolveECMPFor6674(t, "plain", plain, perPacket)
+
+		// The OR composition a naive chain implementation would produce.
+		orComposed := 0
+		for _, name := range []string{"plain", "lb"} {
+			if paths, _ := resolveECMPFor6674(t, name, plain, perPacket); paths > orComposed {
+				orComposed = paths
+			}
+		}
+
+		if firstOnly == orComposed {
+			t.Fatalf("the two readings AGREE on the discriminating input (%d) — "+
+				"then the equivalence argument WOULD hold and this ratification "+
+				"needs re-deciding, not this test relaxing", firstOnly)
+		}
+		t.Logf("measured: first-policy reading = %d, OR-composed chain = %d — "+
+			"a chain is a semantic choice, not a no-op", firstOnly, orComposed)
+	})
+
+	t.Run("an unresolvable selection contributes nothing", func(t *testing.T) {
+		// The reject gate lets an empty SELECTION through (`export [ "" p1 ]`),
+		// and the renderer must then look nothing up rather than falling back to
+		// some other policy in the map.
+		if paths, ch := resolveECMPFor6674(t, "", plain, perPacket, consistent); paths != 0 || ch {
+			t.Errorf("empty selection: got maxPaths=%d consistentHash=%v, want 0/false", paths, ch)
+		}
+		if paths, ch := resolveECMPFor6674(t, "not-defined", perPacket); paths != 0 || ch {
+			t.Errorf("dangling selection: got maxPaths=%d consistentHash=%v, want 0/false", paths, ch)
+		}
+	})
+}


### PR DESCRIPTION
Closes #6674

## The decision

Both arms **ratify**. Neither list form is being implemented, and six source sites that told the reader a follow-up was coming are corrected.

#6673 already fixed the **read** half of both leaves: every authored value reaches validation, a multi-valued list is hard-**rejected** at commit and warned on the tolerant load / peer-sync path, and nothing escapes a gate. The fail-open severity is gone. What remained was a **type-shape** limit plus a promise that should not be kept.

## The two arms ratify for DIFFERENT reasons

Conflating them is how the wrong decision gets made for the pair.

### `security nat static … rule … match destination-address` — the schema over-advertises

**Junos takes one prefix here.** A static-NAT rule is a 1:1 mapping — one `match destination-address` against one `then static-nat prefix` — so N external prefixes against one internal prefix names **no target**, and fanning the rule into N rows would have to invent a pairing Junos does not define. `rule R1` / `rule R2` already expresses the intent exactly. The `multi: true` on the schema leaf is an xpf over-advertisement of the grammar, not a promise.

### `routing-options forwarding-table export` — the schema is right, and it still ratifies

Junos genuinely takes a policy **chain**, so "the schema over-advertises" is not available here.

Neither is the tempting shortcut that a chain would be *observationally identical* to taking the first policy — since `resolveECMP` only ever answers "is load-balancing on". **I measured that and it is FALSE**, and I am reporting it rather than the convenient answer, because it removes the easy argument and forces the real one:

```
measured: first-policy reading = 0, OR-composed chain = 64
```

(plain first policy, load-balancing second — `pkg/frr/forwarding_export_chain_6674_test.go`, which `t.Fatalf`s if the two ever agree on that input, so a future change that *does* make them equivalent re-opens the decision instead of relaxing the test.)

The real reason is structural. `resolveECMP` derives exactly two booleans from the one named policy and evaluates no `from` match, no term order, and no terminating action. Junos evaluates an export chain **per route** and stops at the first terminating action. So:

- the cheap composition (OR the flags across the chain) is **not Junos** — a route accepted by the first policy never reaches the second, yet the OR would apply the second's load-balance to it; and
- the faithful composition is **not expressible at all**, because the value being derived is FRR's **global** `maximum-paths`, which has no per-route form.

A chain needs a per-route forwarding-policy model xpf does not have. That is a feature, filed as **#7455**, not a defect in the multi-value read. #7455 explicitly says not to land the OR shortcut: accepting the Junos spelling while computing a different answer than Junos is worse than the current rejection, because it is silent.

## Why the operator-facing half is pinned behaviourally

A source comment that rots is bad. **A warning message that promises a feature which is never coming is worse, because the operator acts on it** — they leave the list in place and wait.

So both tolerant-path warnings are compiled and inspected: they must not carry a follow-up promise **and** must still state *why* the limit is permanent. Each half alone is defeatable — the negative by a gate that stops warning entirely, the positive by one that says both — so both are asserted, with a still-rejects / still-commits control so a ratification cannot quietly weaken the gate it ratifies.

The `wantReason` assertions are keyed to the **reason** (`GLOBAL ECMP toggle`, `1:1 mapping`), not to the fix: a rewording that keeps the reason stays green, and one that drops it does not.

## The source sweep, and the trap in it

Six comment breadcrumbs are cleared and a sweep keeps them clear. It runs on **normalized** text, because a claim wrapped across two comment lines is invisible to a literal search.

**Whitespace collapsing alone is not enough**, and I only found that because a mutation cell went green: a claim that breaks mid-phrase leaves the `//` marker of the continuation line *between the two halves* (`tracked as // #6674`), which no adjacency regex matches. The normalizer strips comment markers too, and `TestSweepNormalizationSeesAWrappedClaim_6674` is the positive control for exactly that — it asserts the raw sample does **not** match (or the control proves nothing) and the normalized one **does**. The sweep also fails loudly if it finds no file mentioning the issue at all: a sweep that searched nothing reports a clean tree it never looked at.

## Validation

Full `go test ./... -count=1` green.

### Mutation matrix

Each cell is one line, applied by a script that asserts the anchor occurs exactly once, run on a **compiling** tree, restored from git between cells.

| # | mutation | `_6674` (config) | `_6674` (frr) | 6659/6673/7216 |
|---|---|---|---|---|
| C1 | reinstate the promise in the export warning | RED | green | green |
| C2 | reinstate the promise in the NAT warning | RED | green | green |
| C3 | drop the REASON from the export warning *(tightening)* | RED | green | green |
| C4 | reinstate the comment breadcrumb | RED | green | green |
| C5 | sweep keeps comment markers (wrap-blind) | RED | green | green |
| C5b | sweep does no normalization at all | RED | green | green |
| C6 | `resolveECMP` ORs the whole policy map | green | RED | green |
| C7 | the static-NAT gate stops rejecting | RED | green | RED |

**C5 was green on the first run** and that is the finding worth carrying: the wrap-insensitivity claim in the comment was not true of the implementation, and no fixture in the tree had a wrapped claim to expose it. The fix is the comment-marker strip **plus** the positive control — a normalization with no control is an untested claim, and this one was wrong.

C6 is what makes the arm-B argument checkable rather than rhetorical: it binds "resolveECMP is a function of ONE named policy" so a future OR-composition cannot land without going red here first.

## Not in scope

No Rust, no compiled artifact, no protocol change — no cluster smoke is owed. The gates themselves are unchanged in behaviour; this PR changes what they *say* and adds what pins it.

## Docs

`docs/config-schema.md` gains the ratification beside the #6673 multi-value inventory, including the falsified-equivalence measurement, so the next reader who has the same idea finds the number rather than re-deriving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdWuT1UffSkr1spw8sjNTE
