### PR TITLE
config: expand packed stanza bodies from the schema

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103065,3 +103065,12 @@ prose edit above them added. No diff falls in the new test body.
   userspace-dp/src/afxdp/poll_descriptor/mod.rs,
   userspace-dp/src/afxdp/tests_fragment.rs, docs/multi-wan.md,
   docs/research/7409-learned-route-fib/plan.md (new), _Log.md
+
+- **Timestamp**: 2026-08-22
+  - **Action**: #6684/#6685/#7457 — added a schema-driven expander for packed
+    stanza bodies (compact_tail.go) and wired it into the syslog host, firewall
+    filter term, and filter `from` compile sites. #6683 (screens) is blocked on
+    the screen check leaves being absent from setSchema.
+  - **File(s)**: pkg/config/compact_tail.go, pkg/config/compiler_system.go,
+    pkg/config/compiler_firewall.go,
+    pkg/config/compact_tail_6684_6685_test.go, docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -4,6 +4,71 @@ xpf has **two** command-tree sources of truth. Knowing which one to edit
 is the single most common mistake when adding CLI completion or config
 validation.
 
+
+## Compact (packed) stanza bodies
+
+A stanza body can be written NESTED or PACKED onto one line, and the two are the
+same configuration:
+
+```
+security { screen { ids-option s1 { icmp { ping-death; } } } }   nested
+security { screen { ids-option s1 icmp ping-death; } }           packed
+```
+
+The parser does not normalise them. A packed body arrives as extra tokens on the
+node's OWN `Keys`, with no `Children` at all:
+
+```
+nested   [ids-option s1] -> [icmp] -> [ping-death]
+packed   [ids-option s1 icmp ping-death]
+```
+
+A compiler that descends only `node.Children` therefore sees an EMPTY body. The
+instance NAME survives, which is what makes this class hard to notice: the
+profile/host/term exists, `show configuration` displays what the operator wrote,
+it binds to a zone or an interface normally — and it enforces nothing. Known
+instances all failed in the security-relevant direction: a syslog host with zero
+facilities ships nothing (#6684), a filter term with an empty action does not
+discard (#6685), and a filter term whose `from` was dropped matches EVERYTHING
+(#7457).
+
+**Use `packedBodyChildren` / `packedBody` (`compact_tail.go`) instead of reading
+`node.Children` directly** when compiling a stanza that accepts a packed body.
+
+### Why it is schema-driven
+
+The packed tail does NOT expand uniformly, which is why a split on whitespace is
+wrong and why fixing one site by hand does not generalise:
+
+| packed | expands to | shape |
+|---|---|---|
+| `ids-option s1 icmp ping-death` | `[icmp]` -> `[ping-death]` | a chain |
+| `host 10.0.0.1 any any` | `[any any]` | ONE two-key leaf |
+| `term t1 then discard` | `[then]` -> `[discard]` | a chain |
+
+How many tokens each level swallows is a property of the grammar, and the
+grammar already has a single source of truth: `setSchema`, whose
+`schemaNode.args` is "extra tokens consumed as part of this node's key".
+The expander uses `consumeNodeKeys`, the same primitive `SchemaValidate` uses,
+so expansion cannot drift from validation.
+
+A tail that leaves the modelled grammar is returned UNEXPANDED rather than
+guessed — the helper exists to stop configuration being silently dropped, and
+inventing a shape the schema does not describe is another way of doing that.
+
+**A stanza whose leaves are not modelled in `setSchema` cannot be fixed this
+way.** `security screen ids-option <p> icmp` models only `fragment`, so the
+screen checks are absent from the schema and the packed screen body (#6683)
+cannot be expanded until they are added — which is also why those leaves get no
+`?` completion and no `SchemaValidate` typed-leaf checking.
+
+### Where it is NOT done
+
+Expansion is deliberately not done in the parser. `show configuration` renders
+from the AST, so normalising at parse time would rewrite the operator's packed
+one-liner into nested form on display — a round-trip fidelity change well beyond
+fixing the compile-time drops.
+
 ## Operational tree → `pkg/cmdtree`
 
 `run` / `show` / `clear` / `request` / `monitor` / `ping` / `traceroute`

--- a/pkg/config/compact_tail.go
+++ b/pkg/config/compact_tail.go
@@ -1,0 +1,168 @@
+package config
+
+// Compact ("packed") stanza bodies — #6683 / #6684 / #6685.
+//
+// Junos accepts a stanza body written either NESTED or PACKED onto one line,
+// and the two are the same configuration:
+//
+//	security { screen { ids-option s1 { icmp { ping-death; } } } }   nested
+//	security { screen { ids-option s1 icmp ping-death; } }           packed
+//
+// The parser does not normalise them. A packed body arrives as extra tokens on
+// the node's OWN Keys, with no Children at all:
+//
+//	nested   [ids-option s1] -> [icmp] -> [ping-death]
+//	packed   [ids-option s1 icmp ping-death]
+//
+// A compiler that descends only `node.Children` therefore sees an instance with
+// an EMPTY body. The instance NAME survives, which is what makes this class so
+// hard to notice: the profile/host/term exists, `show configuration` displays
+// what the operator wrote, it binds to a zone or an interface normally — and it
+// enforces nothing.
+//
+// The three known instances all fail in the security-relevant direction: a
+// screen check compiles DISABLED (#6683), a syslog host compiles with ZERO
+// facilities so nothing is shipped (#6684), and a firewall filter term compiles
+// with an EMPTY action so a `discard` does not discard (#6685).
+//
+// # Why this needs the schema rather than a split on whitespace
+//
+// The packed tail does NOT expand uniformly, which is why there was no shared
+// helper before and why fixing one site by hand does not generalise:
+//
+//	ids-option s1 icmp ping-death   ->  [icmp] -> [ping-death]     a CHAIN
+//	host 10.0.0.1 any any           ->  [any any]                  ONE 2-key leaf
+//	term t1 then discard            ->  [then] -> [discard]        a CHAIN
+//
+// How many tokens each level swallows is a property of the GRAMMAR, and the
+// grammar already has a single source of truth: `setSchema`, whose
+// `schemaNode.args` is defined as "extra tokens consumed as part of this node's
+// key". `consumeNodeKeys` is the same primitive `SchemaValidate` uses to answer
+// exactly this question, so expansion here cannot drift from validation there.
+//
+// The expansion is deliberately NOT done in the parser. `show configuration`
+// renders from the AST, so normalising at parse time would rewrite the
+// operator's packed one-liner into nested form on display — a round-trip
+// fidelity change well beyond the scope of these three fail-opens.
+
+// schemaForPath resolves the schema node addressed by an absolute keyword path
+// (e.g. []string{"security", "screen", "ids-option"}), or nil when the path is
+// not modelled. Instance-name slots resolve through the wildcard child, so the
+// path names KEYWORDS only — no instance names.
+func schemaForPath(path ...string) *schemaNode {
+	cur := setSchema
+	for i := 0; i < len(path); i++ {
+		if cur == nil {
+			return nil
+		}
+		cur = resolveSchemaChild(cur, path[i])
+		if cur == nil {
+			return nil
+		}
+		// Compound key (`family inet`): the following token is part of THIS
+		// node's key and selects a sub-child, so the caller spells it as a
+		// path element and it is consumed here rather than resolved as a
+		// child of the compound node — which is where it does not exist.
+		if cur.compoundKey && i+1 < len(path) {
+			if sub, ok := cur.children[path[i+1]]; ok {
+				cur = sub
+				i++
+			}
+		}
+	}
+	return cur
+}
+
+// packedBodyChildren returns the body a compiler should descend for node.
+//
+// When the body was written nested it is `node.Children`, returned unchanged —
+// this is the overwhelmingly common path and costs one length check.
+//
+// When the body was PACKED onto the node's Keys it is a synthesized chain that
+// is shape-identical to what the parser would have produced for the nested
+// spelling, so the caller's existing nested-shape reader handles it with no
+// second code path to keep in step.
+//
+// schema is the node's OWN schema (the one addressing e.g. `ids-option`), used
+// to learn how many leading Keys are the node's identity and how the remaining
+// tokens divide. A nil schema, or a tail that leaves the modelled grammar,
+// returns the children unchanged rather than guessing: this helper exists to
+// stop configuration being silently dropped, and inventing a shape the schema
+// does not describe would be a different way of doing the same thing.
+//
+// Synthesized nodes are FRESH allocations; the input node is never mutated, so
+// a caller that also renders or re-walks the original AST sees exactly what the
+// operator wrote.
+func packedBodyChildren(node *Node, schema *schemaNode) []*Node {
+	if node == nil || schema == nil {
+		return nodeChildren(node)
+	}
+	consumed, cur := consumeNodeKeys(node.Keys, schema)
+	tail := node.Keys[consumed:]
+	if len(tail) == 0 {
+		return node.Children
+	}
+
+	var head, last *Node
+	for len(tail) > 0 {
+		childSchema := resolveSchemaChild(cur, tail[0])
+		if childSchema == nil {
+			// Outside the modelled grammar. Do not guess.
+			return node.Children
+		}
+		n, refined := consumeNodeKeys(tail, childSchema)
+		if n <= 0 {
+			return node.Children
+		}
+		next := &Node{Keys: append([]string(nil), tail[:n]...)}
+		if last == nil {
+			head = next
+		} else {
+			last.Children = []*Node{next}
+		}
+		last = next
+		tail = tail[n:]
+		cur = refined
+	}
+
+	// A packed body and a nested body are alternative spellings, not additive,
+	// so a node carrying both is not something the parser produces. Append
+	// rather than replace anyway: dropping real children would be a silent
+	// loss, which is the very failure this helper exists to end.
+	if len(node.Children) == 0 {
+		return []*Node{head}
+	}
+	return append(append([]*Node(nil), node.Children...), head)
+}
+
+// nodeChildren is node.Children with a nil-node guard.
+func nodeChildren(node *Node) []*Node {
+	if node == nil {
+		return nil
+	}
+	return node.Children
+}
+
+// packedBody returns node with its packed tail expanded into Children, so a
+// caller can keep using the ordinary *Node helpers (FindChild / FindChildren /
+// range over Children) with no second code path for the packed spelling.
+//
+// The returned node is the ORIGINAL when there is nothing to expand — the
+// common case, and the one where identity matters to callers that compare
+// nodes. Otherwise it is a shallow copy carrying the synthesized body; the
+// original is never mutated.
+func packedBody(node *Node, schema *schemaNode) *Node {
+	if node == nil {
+		return nil
+	}
+	children := packedBodyChildren(node, schema)
+	if len(children) == len(node.Children) {
+		// Same backing slice means nothing was synthesized.
+		if len(children) == 0 || &children[0] == &node.Children[0] {
+			return node
+		}
+	}
+	clone := *node
+	clone.Children = children
+	return &clone
+}

--- a/pkg/config/compact_tail_6684_6685_test.go
+++ b/pkg/config/compact_tail_6684_6685_test.go
@@ -1,0 +1,227 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// #6684 / #6685: a stanza body written PACKED onto one line must compile
+// identically to the same body written NESTED.
+//
+// The tests below assert EQUALITY of the two compiled results rather than
+// checking the packed form against a hand-written expectation. That is the
+// property the issues actually ask for ("compiles identically to the nested
+// spelling"), and it cannot drift: if someone changes what the nested form
+// compiles to, the packed form has to move with it or the test reds.
+//
+// Both defects were silent and both failed in the security-relevant direction —
+// a syslog host with ZERO facilities ships nothing, a filter term with an EMPTY
+// action does not discard — while the instance itself survived, so
+// `show configuration` displayed exactly what the operator wrote.
+
+func compileBraced6684(t *testing.T, src string) *Config {
+	t.Helper()
+	tree, perrs := NewParser(src).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse %q: %v", src, perrs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile %q: %v", src, err)
+	}
+	return cfg
+}
+
+func TestPackedSyslogHostBodyMatchesNested_6684(t *testing.T) {
+	cases := []struct{ name, nested, packed string }{
+		{
+			"facility severity pair",
+			`system { syslog { host 10.0.0.1 { any any; } } }`,
+			`system { syslog { host 10.0.0.1 any any; } }`,
+		},
+		{
+			"a specific facility and severity",
+			`system { syslog { host 10.0.0.1 { authorization info; } } }`,
+			`system { syslog { host 10.0.0.1 authorization info; } }`,
+		},
+		{
+			"source-address modifier",
+			`system { syslog { host 10.0.0.1 { source-address 10.9.9.9; } } }`,
+			`system { syslog { host 10.0.0.1 source-address 10.9.9.9; } }`,
+		},
+		{
+			"port modifier",
+			`system { syslog { host 10.0.0.1 { port 5514; } } }`,
+			`system { syslog { host 10.0.0.1 port 5514; } }`,
+		},
+		{
+			"allow-duplicates flag",
+			`system { syslog { host 10.0.0.1 { allow-duplicates; } } }`,
+			`system { syslog { host 10.0.0.1 allow-duplicates; } }`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			nested := compileBraced6684(t, tc.nested).System.Syslog.Hosts
+			packed := compileBraced6684(t, tc.packed).System.Syslog.Hosts
+
+			// Anti-vacuity: if the NESTED spelling compiled nothing, the
+			// equality below would hold for two empty results and prove
+			// nothing at all.
+			if len(nested) != 1 {
+				t.Fatalf("nested spelling compiled %d hosts, want 1 — the fixture is not exercising the stanza", len(nested))
+			}
+			if !reflect.DeepEqual(nested, packed) {
+				t.Errorf("packed body compiled differently from nested (#6684)\n nested = %+v\n packed = %+v",
+					*nested[0], hostsOrNil6684(packed))
+			}
+		})
+	}
+}
+
+func hostsOrNil6684(hosts []*SyslogHostConfig) any {
+	if len(hosts) == 0 {
+		return "<no hosts>"
+	}
+	return *hosts[0]
+}
+
+func TestPackedFilterTermBodyMatchesNested_6685(t *testing.T) {
+	// Every terminal action, plus the argument-bearing `then` modifiers the
+	// issue calls out — an expansion that split the tail on whitespace would
+	// get `forwarding-class be` and `count c1` wrong while still passing for
+	// the bare `discard` the issue happens to name.
+	cases := []struct{ name, body string }{
+		{"discard", `then discard`},
+		{"accept", `then accept`},
+		{"reject", `then reject`},
+		{"count with an argument", `then count c1`},
+		{"forwarding-class with an argument", `then forwarding-class be`},
+		{"dscp with an argument", `then dscp 46`},
+		{"log", `then log`},
+		{"a from condition, not a then action", `from protocol tcp`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			nestedSrc := `firewall { family inet { filter f1 { term t1 { ` + tc.body + `; } } } }`
+			packedSrc := `firewall { family inet { filter f1 { term t1 ` + tc.body + `; } } }`
+
+			nested := compileBraced6684(t, nestedSrc).Firewall.FiltersInet["f1"]
+			packed := compileBraced6684(t, packedSrc).Firewall.FiltersInet["f1"]
+
+			if nested == nil || len(nested.Terms) != 1 {
+				t.Fatalf("nested spelling compiled no term — the fixture is not exercising the stanza")
+			}
+			if packed == nil || len(packed.Terms) != 1 {
+				t.Fatalf("packed spelling compiled no term at all: %+v", packed)
+			}
+			if !reflect.DeepEqual(nested.Terms, packed.Terms) {
+				t.Errorf("packed body compiled differently from nested (#6685)\n nested = %+v\n packed = %+v",
+					*nested.Terms[0], *packed.Terms[0])
+			}
+		})
+	}
+}
+
+// TestPackedBodyLeavesUnmodelledTailAlone_6685 pins the conservative half. The
+// expander is schema-driven; a tail that leaves the modelled grammar must
+// return the node's real children rather than inventing a shape, because
+// guessing would be a new way to compile something the operator did not write.
+func TestPackedBodyLeavesUnmodelledTailAlone_6685(t *testing.T) {
+	node := &Node{Keys: []string{"term", "t1", "not-a-real-keyword", "x"}}
+	got := packedBodyChildren(node, schemaForPath("firewall", "family", "inet", "filter", "term"))
+	if len(got) != 0 {
+		t.Errorf("an unmodelled tail must not be expanded, got %d synthesized children", len(got))
+	}
+
+	// A nil schema must be inert too — never panic, never invent.
+	if got := packedBodyChildren(node, nil); len(got) != 0 {
+		t.Errorf("a nil schema must not expand, got %d children", len(got))
+	}
+}
+
+// TestPackedBodyDoesNotMutateTheAST_6685 matters because `show configuration`
+// renders from the same tree the compiler walks: expanding in place would
+// rewrite the operator's one-liner into nested form on display.
+func TestPackedBodyDoesNotMutateTheAST_6685(t *testing.T) {
+	tree, perrs := NewParser(`firewall { family inet { filter f1 { term t1 then discard; } } }`).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	var term *Node
+	var walk func(n *Node)
+	walk = func(n *Node) {
+		if n.Keys[0] == "term" {
+			term = n
+			return
+		}
+		for _, c := range n.Children {
+			walk(c)
+		}
+	}
+	for _, c := range tree.Children {
+		walk(c)
+	}
+	if term == nil {
+		t.Fatal("did not find the term node")
+	}
+	before := append([]string(nil), term.Keys...)
+	childrenBefore := len(term.Children)
+
+	_ = packedBody(term, schemaForPath("firewall", "family", "inet", "filter", "term"))
+
+	if !reflect.DeepEqual(before, term.Keys) {
+		t.Errorf("expansion mutated the node's Keys: %v -> %v", before, term.Keys)
+	}
+	if len(term.Children) != childrenBefore {
+		t.Errorf("expansion mutated the node's Children: %d -> %d", childrenBefore, len(term.Children))
+	}
+}
+
+// TestPackedFromStatementMatchesNestedFromBlock verifies the defect found while
+// building the table above, on the side the issues all assumed was correct.
+//
+// `term t1 { from protocol tcp; }` writes the condition as a one-line STATEMENT
+// inside the term block, which packs it onto the `from` node's own Keys exactly
+// as the term-level packing does one level up. compileFilterFrom read children,
+// so the condition was silently dropped — and a filter term with NO match
+// conditions matches EVERYTHING. A term meant to discard only TCP discarded
+// everything; a term meant to accept only TCP accepted everything.
+//
+// Confirmed pre-existing on origin/master before the fix:
+//
+//	term t1 { from protocol tcp; }     -> Protocols=[]     WRONG
+//	term t1 { from { protocol tcp; } } -> Protocols=[tcp]  correct
+func TestPackedFromStatementMatchesNestedFromBlock(t *testing.T) {
+	cases := []struct{ name, cond string }{
+		{"protocol", `protocol tcp`},
+		{"source-address", `source-address 10.0.0.0/8`},
+		{"destination-address", `destination-address 192.168.0.0/16`},
+		{"destination-port", `destination-port 443`},
+		{"source-port", `source-port 1024`},
+		{"dscp", `dscp 46`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			block := `firewall { family inet { filter f1 { term t1 { from { ` + tc.cond + `; } then discard; } } } }`
+			stmt := `firewall { family inet { filter f1 { term t1 { from ` + tc.cond + `; then discard; } } } }`
+
+			blockTerms := compileBraced6684(t, block).Firewall.FiltersInet["f1"].Terms
+			stmtTerms := compileBraced6684(t, stmt).Firewall.FiltersInet["f1"].Terms
+
+			if len(blockTerms) != 1 {
+				t.Fatalf("the from-BLOCK spelling compiled no term — fixture is not exercising the stanza")
+			}
+			// Anti-vacuity: the block spelling must actually record a
+			// condition, or "equal" would mean "both empty" — which is the
+			// exact bug, passing as a green.
+			if reflect.DeepEqual(*blockTerms[0], FirewallFilterTerm{Name: "t1", Action: "discard", TerminalActions: []string{"discard"}}) {
+				t.Fatalf("the from-BLOCK spelling recorded no match condition either; the fixture cannot detect the defect")
+			}
+			if !reflect.DeepEqual(blockTerms, stmtTerms) {
+				t.Errorf("a one-line `from %s;` compiled differently from the `from { %s; }` block\n block = %+v\n stmt  = %+v",
+					tc.cond, tc.cond, *blockTerms[0], *stmtTerms[0])
+			}
+		})
+	}
+}

--- a/pkg/config/compiler_firewall.go
+++ b/pkg/config/compiler_firewall.go
@@ -252,8 +252,24 @@ func compileFirewall(node *Node, fw *FirewallConfig) error {
 					// unaffected: SetPath merges duplicate containers into one
 					// node (ast_edit.go), so this only changes the hierarchical
 					// (parser / load merge) shape.
-					for _, fromNode := range termInst.node.FindChildren("from") {
-						compileFilterFrom(fromNode, term, af)
+					// #6685: `term t1 then discard;` packs the term body onto the
+					// term node's Keys, leaving Children empty — the term compiled
+					// with an EMPTY Action, so a discard did not discard while the
+					// term still existed and still matched.
+					termBody := packedBody(termInst.node,
+						schemaForPath("firewall", "family", af, "filter", "term"))
+
+					for _, fromNode := range termBody.FindChildren("from") {
+						// A `from` written as a one-line STATEMENT inside the term
+						// block — `term t1 { from protocol tcp; }` — packs the
+						// condition onto the from node's own Keys, exactly as the
+						// term-level packing does one level up. compileFilterFrom
+						// reads children, so the condition was dropped and the term
+						// matched EVERYTHING. Found by comparing the two spellings
+						// for #6685, where this is the NESTED side.
+						compileFilterFrom(packedBody(fromNode,
+							schemaForPath("firewall", "family", af, "filter", "term", "from")),
+							term, af)
 					}
 
 					// #3850: apply EVERY `then {}` block. compileFilterThen
@@ -261,7 +277,7 @@ func compileFirewall(node *Node, fw *FirewallConfig) error {
 					// terminal action (accept/discard/reject) resolves last-wins
 					// across blocks (Junos merges duplicate stanzas), so the
 					// second block's action is applied, never silently dropped.
-					for _, thenNode := range termInst.node.FindChildren("then") {
+					for _, thenNode := range termBody.FindChildren("then") {
 						compileFilterThen(thenNode, term)
 					}
 

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -304,7 +304,11 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 			sys.Syslog = &SystemSyslogConfig{}
 			for _, slInst := range namedInstances(child.FindChildren("host")) {
 				host := &SyslogHostConfig{Address: slInst.name}
-				for _, prop := range slInst.node.Children {
+				// #6684: `host 10.0.0.1 any any;` packs the whole body onto the
+				// host node's Keys, leaving Children empty — the host compiled
+				// with ZERO facilities and shipped nothing, silently.
+				for _, prop := range packedBodyChildren(slInst.node,
+					schemaForPath("system", "syslog", "host")) {
 					// #4303 S-1: switch on the KNOWN host sub-statements
 					// before the facility/severity fallback. Without this
 					// every non-`allow-duplicates` child (source-address,


### PR DESCRIPTION
Closes #6684
Closes #6685
Closes #7457

Does **not** close #6683 — see "Why #6683 is not fixed here".

## The class

A stanza body written PACKED onto one line arrives as extra tokens on the node's **own `Keys`** with no `Children`, so a compiler that descends only `Children` sees an empty body:

```
nested   [host 10.0.0.1] -> [any any]
packed   [host 10.0.0.1 any any]
```

The instance **name** survives, which is what makes this hard to notice: the host/term exists, `show configuration` displays what the operator wrote, the filter binds normally — and it enforces nothing.

## Same class, but NOT the same fix

The three issues are correctly reported as one class. They do not share a fix, and that is the part worth recording — the packed tail does not expand uniformly:

| packed | expands to | shape |
|---|---|---|
| `ids-option s1 icmp ping-death` | `[icmp]` → `[ping-death]` | a chain |
| `host 10.0.0.1 any any` | `[any any]` | **one 2-key leaf** |
| `term t1 then discard` | `[then]` → `[discard]` | a chain |

How many tokens each level swallows is a property of the **grammar**, so a whitespace split is wrong and a hand fix at one site does not generalise. The grammar already has an SSOT: `setSchema`, whose `schemaNode.args` is *"extra tokens consumed as part of this node's key"*. `packedBodyChildren` walks the tail with `consumeNodeKeys` — the same primitive `SchemaValidate` uses — so expansion cannot drift from validation.

A tail that leaves the modelled grammar is returned **unexpanded rather than guessed**. This helper exists to stop configuration being silently dropped; inventing a shape the schema does not describe is another way of doing that.

Expansion is deliberately **not** in the parser: `show configuration` renders from the AST, so normalising at parse time would rewrite the operator's one-liner into nested form on display. Synthesized nodes are fresh allocations and the input is never mutated — pinned by a test.

## A third defect, found by the test shape

Filed as #7457 and fixed here. Found because the tests assert **equality between the two spellings** rather than checking the packed form against a hand-written expectation:

```
term t1 { from protocol tcp; }      -> Protocols=[]      WRONG
term t1 { from { protocol tcp; } }  -> Protocols=[tcp]   correct
```

The equality failed with the **nested** side empty — the opposite of the direction all three issues assume. A test written as "packed should equal this literal" would have passed and left it in place.

It is the most severe of the three: **a filter term with no match conditions matches everything.** A term meant to discard only TCP discards all traffic; one meant to accept only TCP accepts all traffic and shadows every term after it. Confirmed pre-existing on `origin/master` in a clean worktree before the fix.

## Why #6683 is not fixed here

The screen check leaves are **absent from `setSchema`**. `security screen ids-option <p> icmp` models exactly one child, `fragment`, so `ping-death` and its siblings cannot be resolved and the expander correctly declines.

That is a schema **gap**, not a compiler bug — and it also means those leaves get no `?` completion and no `SchemaValidate` typed-leaf checking. Closing it means modelling the subtree, which changes flat-set token grouping (`ast_edit.go` keys on `args`/`children`/`compoundKey`/`multi`) on a path that **currently works** — the flat-set spelling of the same screen config compiles correctly today. That is a real regression risk and deserves its own change rather than being folded in behind two unrelated fixes.

## Tests

Equality, not literals — the property the issues actually ask for, and it cannot drift: change what the nested form compiles to and the packed form must move with it. Every case carries an anti-vacuity guard that the nested spelling compiled something, so "both empty" — which *is* the bug — cannot pass as green.

Coverage is enumerated per the acceptance criteria rather than probing the one form each issue names: every syslog host modifier (`source-address`, `port`, `allow-duplicates`, facility/severity), every terminal action plus the argument-bearing `then` modifiers (`count`, `forwarding-class`, `dscp`, `log`), and six `from` conditions.

## Mutation matrix

Every cell verified APPLIED first.

| # | mutation | result |
|---|---|---|
| T1 | revert the syslog wiring | **RED** — #6684 cases |
| T2 | revert the filter-term wiring | **RED** — #6685 cases |
| T3 | revert the `from` wiring | **RED** — #7457 cases |
| T4 | make the expander guess on an unmodelled tail | **RED** — the do-not-guess test |

T3 failed to apply on its first attempt — gofmt had reflowed the call across three lines and the anchor no longer matched — and reported `rc=0`. That is a non-result, not a pass, so it was redone against a line-verified anchor.

## Validation

Full `go test -count=1 ./...` green. Docs: `docs/config-schema.md` gains a "Compact (packed) stanza bodies" section covering the shape, why it is schema-driven, and why it is not done in the parser.