### PR TITLE
userspace: fence each protocol gate on its own feature floor

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103096,3 +103096,22 @@ prose edit above them added. No diff falls in the new test body.
     owner's authoritative session family under latest-generation-wins.
   - **File(s)**: pkg/daemon/daemon_ha_userspace_stream.go,
     pkg/daemon/userspace_sync_test.go, docs/session-sync-architecture.md
+
+- **Timestamp**: 2026-08-22
+  - **Action**: #6648 — gave each per-feature required-protocol gate an
+    immutable floor (the version its wire representation landed at) instead of
+    the shared ProtocolVersion, so an unrelated wire bump no longer retroactively
+    re-arms every gate and reports a false reason. #6649 and #6647 were measured
+    already-closed at master (by #6722's unconditional equality gate, and by
+    #5485 + #5488 F7 respectively) and are pinned rather than re-fixed: added the
+    composition cell for #6649, and hardened goFunctionSource to return CODE so
+    the #6647 compensator's source-scanning guard can no longer be satisfied by a
+    comment quoting the call it demands.
+  - **File(s)**: pkg/dataplane/userspace/protocol.go,
+    pkg/dataplane/userspace/manager_compile.go,
+    pkg/dataplane/userspace/protocol_feature_floors_6648_test.go (new),
+    pkg/dataplane/userspace/shim_loader_boundary_test.go,
+    pkg/dataplane/userspace/manager_capabilities_test.go,
+    pkg/dataplane/userspace/set_forwarding_armed_generation_5648_test.go,
+    pkg/dataplane/userspace/sync_desired_forwarding_generation_6165_test.go,
+    docs/userspace-dataplane-architecture.md

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -2174,6 +2174,76 @@ additive *in meaning* (an old reader that ignores it still enforces
 exactly what it enforced before) does not need a bump; a field that
 changes what a rule COVERS does.
 
+#### Per-feature protocol floors (#6648, #6649)
+
+The gates in `manager_compile.go` answer **two different questions**, and
+#6648 was the consequence of one comparison being asked to answer both.
+
+1. **"Can this helper REPRESENT this feature?"** — asked once per gated
+   feature, against an **immutable floor**: the version at which that
+   feature's wire representation landed. The floors live beside
+   `ProtocolVersion` in `pkg/dataplane/userspace/protocol.go`:
+
+   | feature | gate | floor | landed in |
+   |---|---|---|---|
+   | policy scheduler | `ensurePolicySchedulerProtocolLocked` | `MinProtocolPolicyScheduler` = 2 | `f7c4b125c` (#1396) |
+   | persistent source NAT | `ensurePersistentSourceNATProtocolLocked` | `MinProtocolPersistentSourceNAT` = 3 | `c0a047ea2` (#1377) |
+   | scoped-global zone set | `ensureScopedGlobalZoneSetProtocolLocked` | `MinProtocolMultiZoneScopedPolicy` = 4 | `8119bfe27` (#5488/#6644) |
+   | secure-tunnel refusal | `ensureSecureTunnelProtocolLocked` | `MinProtocolSecureTunnelRefusal` = 7 | `be8aec13e` v5, `8d0e09fb8` v6, `8c011681c` v7 (#5619/#6691) |
+
+   A floor is a **historical fact about the wire** and never moves. The
+   secure-tunnel floor is the LAST of the three bumps that built its
+   contract, because a helper below 7 misreads at least one part of it;
+   it moves only if a fourth change to that contract lands, never to
+   track the shared constant.
+
+2. **"Will this helper ACCEPT our snapshot at all?"** — asked ONCE, by
+   `ensureEgressZoneProtocolLocked` (#6722), unconditionally and on
+   **exact equality**, mirroring the helper's own contract
+   (`userspace-dp/src/server/handlers/snapshot.rs` compares `!=` and
+   returns before any mutation).
+
+Before #6648 all four per-feature gates compared against `ProtocolVersion`,
+which conflated the two: every bump for an unrelated feature retroactively
+re-armed all of them, and the operator got a misleading REASON — a helper
+running a scheduled-policy config was told "policy scheduler snapshots"
+required version 8, when scheduler state has been representable since v2.
+
+**What did NOT change is fail-closed coverage.** Since #6722 the
+unconditional equality gate refuses ANY version skew, so a helper between a
+feature's floor and `ProtocolVersion` still disarms and still aborts the
+commit — it now just gets the accurate general reason ("restart the helper
+onto the matching build") instead of a feature-specific one that was not
+true. `TestFeatureFlooredHelperStillFailsClosed6648` pins that composition
+in both directions, including the newer-helper direction.
+
+That newer-helper direction is **#6649**, which the same split resolves.
+The Go gates admitted `>=` while the helper requires `==`, so a helper
+AHEAD of the control plane passed every gate and then refused the snapshot,
+raising no sentinel. #6722's unconditional equality gate closed it; the
+per-feature floors keep it closed by construction, because the acceptance
+rule now has exactly ONE copy in Go rather than one per gate. The rule is
+single-sourced in the direction of the **helper**, which is the authority:
+the helper decides what it accepts, and the Go gate exists to predict that
+decision. `TestSnapshotProtocolVersionLockstepWithRust` parses the Rust
+constant so the two cannot drift.
+
+**#6647** — the ordering of that gate against the apply's irreversible work
+— is closed by two earlier changes rather than by a reorder. #5485 moved the
+interface DETACH (the only pre-gate step that could produce a policy bypass)
+after the acceptance points, and #5488 F7 added
+`disarmSnapshotProtocolFailClosedLocked`, which drives `userspace_ctrl` to
+`Enabled=0` when the disarm IPC itself fails on a path that already mutated
+the classifier maps in place. The surviving pre-gate work — XDP pin deletion
+and the shim ATTACH — is fail-closed in both `ctrl` states, and the bootstrap
+branch programs `Enabled: 0` before the gate runs, so the `mapsMutatedInPlace
+== false` arm needs no compensation. The compensation is pinned by
+`TestSnapshotProtocolDisarmFailureFailsClosed5488` and
+`TestProtocolGateSitesRouteThroughFailClosedHelper5488` — the latter a
+source-scanning guard which, until #6647 hardened `goFunctionSource` to
+return CODE rather than raw file text, could be satisfied by a comment
+quoting the call it demands.
+
 **Why it went to 4.** #4626 gave a scoped global policy a zone-SET scope in
 the plural `match_from_zones`/`match_to_zones` fields, made them
 authoritative, and left the singular `match_from_zone`/`match_to_zone`
@@ -2249,9 +2319,10 @@ may be an older process — which is the whole rolling-upgrade case.
 `ProtocolVersion`.** The question is "can the peer represent THIS shape", and
 that answer stopped changing at v4. Keying on the shared constant would make
 every future unrelated wire bump retroactively refuse multi-zone commits across
-any skew — the defect open **#6648** describes in the local gates. This is the
-first per-feature floor in the tree; #6648 tracks giving the local gates the
-same treatment.
+any skew — the defect **#6648** described in the local gates. This was the first
+per-feature floor in the tree; #6648 has since given the local gates the same
+treatment (see *Per-feature protocol floors* below), and the scoped-global gate
+now shares this very constant.
 
 **Why it is at 6.** #5619/#6691 added
 `InterfaceSnapshot.secure_tunnel`, and made it AUTHORITATIVE over AF_XDP
@@ -2284,7 +2355,8 @@ newly committed deny never installed. So the version bump is paired with
 in the same class as the policy-scheduler and persistent-source-NAT gates
 (#2138): when the committed config carries a policy whose scope holds
 more than one zone on a side and the running helper reports a
-`ConfigSnapshotProtocolVersion` below `ProtocolVersion`, the daemon
+`ConfigSnapshotProtocolVersion` below `MinProtocolMultiZoneScopedPolicy`
+(v4 — it was `ProtocolVersion` before #6648), the daemon
 DISARMS the helper (`set_forwarding_state{armed:false}`) and the commit
 ABORTS with `ErrScopedGlobalZoneSetProtocolIncompatible`, which is
 registered in `requiredProtocolGateSentinels`. The lenient-load doctrine

--- a/pkg/dataplane/userspace/manager_capabilities_test.go
+++ b/pkg/dataplane/userspace/manager_capabilities_test.go
@@ -253,7 +253,17 @@ func TestEnsureRequiredSnapshotProtocolRejectsOldHelperForPersistentSourceNAT(t 
 	}}
 
 	m := New()
-	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion - 1
+	// #6648: BELOW THE FEATURE'S FLOOR, not below ProtocolVersion. This used to
+	// say `ProtocolVersion - 1`, which asserted that a helper one version behind
+	// the shared constant cannot represent persistent source NAT. It can:
+	// persistent SNAT pool leases have been representable since v3
+	// (MinProtocolPersistentSourceNAT), so the sentinel this test names is the
+	// wrong answer for a v7 helper — the right one is the unconditional
+	// egress-zone gate, and pinning the feature sentinel there was pinning the
+	// coupling #6648 removes. Retargeted, not relaxed: the assertion is
+	// unchanged and now runs against a helper that genuinely cannot carry the
+	// feature.
+	m.lastStatus.ConfigSnapshotProtocolVersion = MinProtocolPersistentSourceNAT - 1
 	err := m.ensureRequiredSnapshotProtocolLocked(gateSnapshot(t, cfg))
 	if !errors.Is(err, ErrPersistentSourceNATProtocolIncompatible) {
 		t.Fatalf("error = %v, want ErrPersistentSourceNATProtocolIncompatible", err)

--- a/pkg/dataplane/userspace/manager_compile.go
+++ b/pkg/dataplane/userspace/manager_compile.go
@@ -867,13 +867,13 @@ func (m *Manager) ensureScopedGlobalZoneSetProtocolLocked(cfg *config.Config) er
 	if !configHasMultiZoneScopedPolicy(cfg) {
 		return nil
 	}
-	if m.lastStatus.ConfigSnapshotProtocolVersion >= ProtocolVersion {
+	if m.lastStatus.ConfigSnapshotProtocolVersion >= MinProtocolMultiZoneScopedPolicy {
 		return nil
 	}
 	var status ProcessStatus
 	if err := m.requestLocked(ControlRequest{Type: "status"}, &status); err == nil {
 		m.recordHelperStatusLocked(&status)
-		if status.ConfigSnapshotProtocolVersion >= ProtocolVersion {
+		if status.ConfigSnapshotProtocolVersion >= MinProtocolMultiZoneScopedPolicy {
 			return nil
 		}
 	}
@@ -882,16 +882,27 @@ func (m *Manager) ensureScopedGlobalZoneSetProtocolLocked(cfg *config.Config) er
 			"(an older helper reads only the singular match from-zone/to-zone and would NARROW the scope)",
 		ErrScopedGlobalZoneSetProtocolIncompatible,
 		m.lastStatus.ConfigSnapshotProtocolVersion,
-		ProtocolVersion,
+		MinProtocolMultiZoneScopedPolicy,
 	)
 }
 
 // ensureSecureTunnelProtocolLocked is the fail-closed half of the #5619/#6691
 // protocol bumps — v5 (the SecureTunnel field), v6 (the every-owner refusal
-// rule) and v7 (the fabric parent's verdict), which is why it compares against
-// ProtocolVersion rather than a pinned number: each of the three changes what
-// an older helper does with the same snapshot, and the gate's job is the same
-// for all of them. The bump makes an older helper REFUSE the snapshot outright,
+// rule) and v7 (the fabric parent's verdict). It compares against
+// MinProtocolSecureTunnelRefusal, which is the LAST of those three (7): each of
+// the three changes what an older helper does with the same snapshot, so the
+// first version that reads the WHOLE contract is 7, and a helper below it
+// misreads at least one part.
+//
+// #6648 changed this from `ProtocolVersion` to that pinned floor. The old
+// spelling was not "the same number written differently": it made every future
+// bump for an UNRELATED wire feature retroactively re-arm this gate, and report
+// the secure-tunnel reason for a helper that reads the refusal contract
+// perfectly well. The pin must move only when a FOURTH change to the refusal
+// contract lands — never to track the shared constant. (The 7 -> 8 bump was
+// collision resolution against #6722's parallel v5, not a change to this
+// contract; ProtocolVersion's own comment carries that history.)
+// An older helper REFUSES the snapshot outright,
 // which stops it from planning a binding for the xfrmi — but a refused snapshot
 // leaves that helper ARMED on its previous-good image while the commit reports
 // success. This gate closes that window the way the sibling gates do: the
@@ -935,13 +946,13 @@ func (m *Manager) ensureSecureTunnelProtocolLocked(snap *ConfigSnapshot) error {
 	if !snapshotRequiresRefusalProtocol(snap) {
 		return nil
 	}
-	if m.lastStatus.ConfigSnapshotProtocolVersion >= ProtocolVersion {
+	if m.lastStatus.ConfigSnapshotProtocolVersion >= MinProtocolSecureTunnelRefusal {
 		return nil
 	}
 	var status ProcessStatus
 	if err := m.requestLocked(ControlRequest{Type: "status"}, &status); err == nil {
 		m.recordHelperStatusLocked(&status)
-		if status.ConfigSnapshotProtocolVersion >= ProtocolVersion {
+		if status.ConfigSnapshotProtocolVersion >= MinProtocolSecureTunnelRefusal {
 			return nil
 		}
 	}
@@ -981,7 +992,7 @@ func (m *Manager) ensureSecureTunnelProtocolLocked(snap *ConfigSnapshot) error {
 			"interface to one queue and one worker)",
 		ErrSecureTunnelProtocolIncompatible,
 		m.lastStatus.ConfigSnapshotProtocolVersion,
-		ProtocolVersion,
+		MinProtocolSecureTunnelRefusal,
 	)
 }
 
@@ -989,13 +1000,13 @@ func (m *Manager) ensurePolicySchedulerProtocolLocked(cfg *config.Config) error 
 	if !configHasScheduledPolicy(cfg) {
 		return nil
 	}
-	if m.lastStatus.ConfigSnapshotProtocolVersion >= ProtocolVersion {
+	if m.lastStatus.ConfigSnapshotProtocolVersion >= MinProtocolPolicyScheduler {
 		return nil
 	}
 	var status ProcessStatus
 	if err := m.requestLocked(ControlRequest{Type: "status"}, &status); err == nil {
 		m.recordHelperStatusLocked(&status)
-		if status.ConfigSnapshotProtocolVersion >= ProtocolVersion {
+		if status.ConfigSnapshotProtocolVersion >= MinProtocolPolicyScheduler {
 			return nil
 		}
 	}
@@ -1003,7 +1014,7 @@ func (m *Manager) ensurePolicySchedulerProtocolLocked(cfg *config.Config) error 
 		"%w: helper config snapshot protocol version %d < required %d for policy scheduler snapshots",
 		ErrPolicySchedulerProtocolIncompatible,
 		m.lastStatus.ConfigSnapshotProtocolVersion,
-		ProtocolVersion,
+		MinProtocolPolicyScheduler,
 	)
 }
 
@@ -1011,13 +1022,13 @@ func (m *Manager) ensurePersistentSourceNATProtocolLocked(cfg *config.Config) er
 	if !userspaceConfigUsesPersistentSourceNAT(cfg) {
 		return nil
 	}
-	if m.lastStatus.ConfigSnapshotProtocolVersion >= ProtocolVersion {
+	if m.lastStatus.ConfigSnapshotProtocolVersion >= MinProtocolPersistentSourceNAT {
 		return nil
 	}
 	var status ProcessStatus
 	if err := m.requestLocked(ControlRequest{Type: "status"}, &status); err == nil {
 		m.recordHelperStatusLocked(&status)
-		if status.ConfigSnapshotProtocolVersion >= ProtocolVersion {
+		if status.ConfigSnapshotProtocolVersion >= MinProtocolPersistentSourceNAT {
 			return nil
 		}
 	}
@@ -1025,7 +1036,7 @@ func (m *Manager) ensurePersistentSourceNATProtocolLocked(cfg *config.Config) er
 		"%w: helper config snapshot protocol version %d < required %d for persistent source NAT snapshots",
 		ErrPersistentSourceNATProtocolIncompatible,
 		m.lastStatus.ConfigSnapshotProtocolVersion,
-		ProtocolVersion,
+		MinProtocolPersistentSourceNAT,
 	)
 }
 
@@ -1062,9 +1073,12 @@ func (m *Manager) ensureRequiredSnapshotProtocolLocked(snap *ConfigSnapshot) err
 	if err := m.ensureScopedGlobalZoneSetProtocolLocked(cfg); err != nil {
 		return err
 	}
-	// Secure-tunnel gate FIRST, then egress-zone. Both fence the same
-	// ProtocolVersion, so on a version mismatch both would fire; the order
-	// decides which sentinel the caller sees. The secure-tunnel gate is SCOPED
+	// Secure-tunnel gate FIRST, then egress-zone. Since #6648 they no longer
+	// fence the same number — the secure-tunnel gate asks "can this helper read
+	// the refusal contract?" (floor 7) and the egress-zone gate asks "will this
+	// helper accept our snapshot at all?" (exact equality with ProtocolVersion)
+	// — so both fire only for a helper below BOTH, and the order still decides
+	// which sentinel the caller sees there. The secure-tunnel gate is SCOPED
 	// (snapshotRequiresRefusalProtocol — it returns nil unless the snapshot
 	// actually carries a flagged row) while the egress-zone gate is
 	// UNCONDITIONAL, so asking the specific one first reports the narrower,

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -119,6 +119,46 @@ const (
 	// first per-feature floor in the tree; #6648 tracks giving the local gates
 	// the same treatment. Never renumber it: it names a historical wire fact.
 	MinProtocolMultiZoneScopedPolicy = 4
+
+	// The remaining per-feature floors (#6648). Each names the FIRST snapshot
+	// protocol version whose wire representation carries that feature, and each
+	// is IMMUTABLE: it is a historical fact about the wire, not a tracking
+	// alias for ProtocolVersion. Never renumber one; a new floor is added when
+	// a new feature's representation lands.
+	//
+	// Before #6648 the four gates in manager_compile.go all compared against
+	// ProtocolVersion, so every bump for an unrelated feature retroactively
+	// raised the bar for all of them and reported a misleading reason: a helper
+	// running a scheduled-policy config was told "policy scheduler snapshots"
+	// required version 8, when policy-scheduler snapshots have been
+	// representable since version 2.
+	//
+	// These floors answer ONLY "can this helper represent this feature?". The
+	// separate question "will this helper accept our snapshot at all?" is
+	// answered in exactly ONE place — ensureEgressZoneProtocolLocked's
+	// unconditional equality check — because the helper's own contract is exact
+	// equality (userspace-dp/src/server/handlers/snapshot.rs). Keeping the two
+	// questions apart is what stops the per-feature gates from being a second,
+	// divergent copy of the acceptance rule (#6649).
+
+	// MinProtocolPolicyScheduler: the policy-scheduler inactive-state fields
+	// landed in the v2 bump (f7c4b125c, #1396).
+	MinProtocolPolicyScheduler = 2
+
+	// MinProtocolPersistentSourceNAT: persistent SNAT pool leases landed in the
+	// v3 bump (c0a047ea2, #1377).
+	MinProtocolPersistentSourceNAT = 3
+
+	// MinProtocolSecureTunnelRefusal: the device-level AF_XDP binding refusal
+	// contract spans THREE bumps on the #5619/#6691 branch — v5 added
+	// InterfaceSnapshot.SecureTunnel (be8aec13e), v6 the every-owner refusal
+	// rule (8d0e09fb8), v7 the fabric parent's verdict
+	// (FabricSnapshot.ParentUnbindable, 8c011681c). The floor is the LAST of
+	// them: a helper below 7 misreads at least one part of the contract, so 7
+	// is the first version that reads all of it. (The subsequent 7 -> 8 bump
+	// was collision resolution against #6722's parallel v5, not a fourth change
+	// to this contract — see the ProtocolVersion comment above.)
+	MinProtocolSecureTunnelRefusal   = 7
 	InjectPacketTupleProtocolVersion = 1
 	TypeUserspace                    = "userspace"
 

--- a/pkg/dataplane/userspace/protocol_feature_floors_6648_test.go
+++ b/pkg/dataplane/userspace/protocol_feature_floors_6648_test.go
@@ -1,0 +1,269 @@
+package userspace
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6648: each per-feature required-protocol gate must fence on an IMMUTABLE
+// floor — the version at which that feature's wire representation landed — not
+// on the shared ProtocolVersion constant.
+//
+// Before the fix all four gates compared against ProtocolVersion, so every bump
+// for an unrelated wire feature retroactively re-armed all of them. The
+// operator-visible consequence was a wrong REASON: a helper running a
+// scheduled-policy config was told "policy scheduler snapshots" required
+// version 8, when policy-scheduler state has been representable since v2.
+//
+// The behaviour is NOT "the mismatch stops being caught". Since #6722 the
+// unconditional egress-zone gate refuses ANY version skew, so a helper between
+// a feature's floor and ProtocolVersion still fails closed — it just gets the
+// accurate general reason instead of a misleading feature-specific one. That
+// composition is pinned by TestFeatureFlooredHelperStillFailsClosed6648 below.
+//
+// FAIL-ON-REVERT: point any gate's comparison back at ProtocolVersion and its
+// at-floor cell flips RED (the gate fires for a helper that can represent the
+// feature perfectly well).
+
+func schedulerFloorCfg() *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.GlobalPolicies = []*config.Policy{{Name: "p", SchedulerName: "sched"}}
+	return cfg
+}
+
+func persistentNATFloorCfg() *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.NAT.SourcePools = map[string]*config.NATPool{
+		"pool-a": {
+			Name:          "pool-a",
+			Addresses:     []string{"203.0.113.10"},
+			PersistentNAT: &config.PersistentNATConfig{InactivityTimeout: 300},
+		},
+	}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{{
+		Name: "rs", FromZone: "trust", ToZone: "wan",
+		Rules: []*config.NATRule{{
+			Name: "snat",
+			Then: config.NATThen{Type: config.NATSource, PoolName: "pool-a"},
+		}},
+	}}
+	return cfg
+}
+
+// Reuse the #5488 fixture rather than hand-rolling a second multi-zone shape:
+// policyScopeIsMultiZone reads the scope through config.PolicyMatch, and a
+// locally-invented literal that missed the real field names would leave this
+// cell asserting on a config the gate never considers scoped at all.
+func multiZoneScopeFloorCfg() *config.Config {
+	return multiZoneScopedGlobalDenyConfig()
+}
+
+// Each gate is called DIRECTLY, not through ensureRequiredSnapshotProtocolLocked:
+// at any version below ProtocolVersion the unconditional egress-zone gate at the
+// tail of the chain also fires, so an orchestrator-level assertion could not
+// tell "this gate stayed silent" from "a sibling answered first". That is the
+// distinction the floor changes, so it is the one the cell has to isolate.
+func TestPerFeatureGatesFenceOnTheirOwnFloor6648(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		floor int
+		cfg   *config.Config
+		sent  error
+		call  func(m *Manager, cfg *config.Config) error
+	}{
+		{
+			name: "policy-scheduler", floor: MinProtocolPolicyScheduler,
+			cfg: schedulerFloorCfg(), sent: ErrPolicySchedulerProtocolIncompatible,
+			call: func(m *Manager, cfg *config.Config) error {
+				return m.ensurePolicySchedulerProtocolLocked(cfg)
+			},
+		},
+		{
+			name: "persistent-source-nat", floor: MinProtocolPersistentSourceNAT,
+			cfg: persistentNATFloorCfg(), sent: ErrPersistentSourceNATProtocolIncompatible,
+			call: func(m *Manager, cfg *config.Config) error {
+				return m.ensurePersistentSourceNATProtocolLocked(cfg)
+			},
+		},
+		{
+			name: "scoped-global-zone-set", floor: MinProtocolMultiZoneScopedPolicy,
+			cfg: multiZoneScopeFloorCfg(), sent: ErrScopedGlobalZoneSetProtocolIncompatible,
+			call: func(m *Manager, cfg *config.Config) error {
+				return m.ensureScopedGlobalZoneSetProtocolLocked(cfg)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Premise: the fixture actually trips this gate's feature predicate.
+			// Without this a silent gate would look like a pass for the wrong
+			// reason — the config simply not carrying the feature.
+			m := New()
+			m.lastStatus.ConfigSnapshotProtocolVersion = tc.floor - 1
+			if err := tc.call(m, tc.cfg); !errors.Is(err, tc.sent) {
+				t.Fatalf("helper at floor-1 (%d) got %v, want %v: the fixture must "+
+					"carry the feature and the gate must still fence a helper that "+
+					"genuinely cannot represent it", tc.floor-1, err, tc.sent)
+			}
+
+			// THE CELL THE FLOOR EXISTS FOR. A helper exactly at the feature's
+			// floor can represent it, so this gate must stay silent — even
+			// though the helper is far below ProtocolVersion. Comparing against
+			// ProtocolVersion makes this fire.
+			m = New()
+			m.lastStatus.ConfigSnapshotProtocolVersion = tc.floor
+			if err := tc.call(m, tc.cfg); err != nil {
+				t.Fatalf("helper at the feature floor (%d) was fenced by its own gate: %v. "+
+					"The floor is the version at which the feature became representable, so "+
+					"this gate must have nothing to say about it; firing here is the #6648 "+
+					"coupling to ProtocolVersion (currently %d)", tc.floor, err, ProtocolVersion)
+			}
+
+			// And a helper between the floor and ProtocolVersion is likewise not
+			// this gate's business.
+			if tc.floor < ProtocolVersion {
+				m = New()
+				m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion - 1
+				if err := tc.call(m, tc.cfg); err != nil {
+					t.Fatalf("helper at ProtocolVersion-1 (%d) was fenced by the %s gate: %v",
+						ProtocolVersion-1, tc.name, err)
+				}
+			}
+		})
+	}
+}
+
+// The secure-tunnel gate takes a SNAPSHOT rather than a config (#6691 round 9)
+// and is scoped by snapshotRequiresRefusalProtocol, so it gets its own cell.
+// Its floor is the LAST of the three bumps that built the refusal contract.
+func TestSecureTunnelGateFencesOnItsOwnFloor6648(t *testing.T) {
+	if MinProtocolSecureTunnelRefusal >= ProtocolVersion {
+		t.Skipf("floor %d is not below ProtocolVersion %d, so the coupling this "+
+			"cell isolates is not observable at this version",
+			MinProtocolSecureTunnelRefusal, ProtocolVersion)
+	}
+	// Use the #6691 fixture that actually carries a refusal verdict. An empty
+	// config produces a snapshot with no flagged row, and the gate is then
+	// silent because it is SCOPED OUT — a green indistinguishable from the one
+	// the floor is supposed to produce, i.e. no measurement at all.
+	cfg, _, _ := spellingConfig(t, "st0", "st0", 0)
+	snap := gateSnapshot(t, cfg)
+	if !snapshotRequiresRefusalProtocol(snap) {
+		t.Fatal("premise broken: the snapshot carries no refusal verdict, so a " +
+			"silent gate would say nothing about the floor")
+	}
+
+	// Below the floor the gate must still fire — the floor is not a licence to
+	// stop fencing a helper that cannot read the refusal contract.
+	m := New()
+	m.helperStatusObserved = true
+	m.lastStatus.ConfigSnapshotProtocolVersion = MinProtocolSecureTunnelRefusal - 1
+	if err := m.ensureSecureTunnelProtocolLocked(snap); !errors.Is(err, ErrSecureTunnelProtocolIncompatible) {
+		t.Fatalf("helper at floor-1 (%d) got %v, want ErrSecureTunnelProtocolIncompatible",
+			MinProtocolSecureTunnelRefusal-1, err)
+	}
+
+	m = New()
+	m.helperStatusObserved = true
+	m.lastStatus.ConfigSnapshotProtocolVersion = MinProtocolSecureTunnelRefusal
+	if err := m.ensureSecureTunnelProtocolLocked(snap); err != nil {
+		t.Fatalf("helper at the secure-tunnel floor (%d) was fenced: %v",
+			MinProtocolSecureTunnelRefusal, err)
+	}
+}
+
+// The floors are HISTORICAL FACTS about the wire. Pinning them by literal is
+// the point: a floor written as `ProtocolVersion - N` or re-derived from the
+// shared constant would drift on the next bump and silently restore #6648.
+func TestProtocolFloorsAreImmutableLiterals6648(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"policy scheduler landed in the v2 bump (f7c4b125c)", MinProtocolPolicyScheduler, 2},
+		{"persistent source NAT landed in the v3 bump (c0a047ea2)", MinProtocolPersistentSourceNAT, 3},
+		{"multi-zone scoped policy landed in the v4 bump (8119bfe27)", MinProtocolMultiZoneScopedPolicy, 4},
+		{"the secure-tunnel refusal contract completed at the v7 bump (8c011681c)", MinProtocolSecureTunnelRefusal, 7},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s: floor = %d, want %d. These name when a feature's wire "+
+				"representation appeared; renumbering one rewrites history and "+
+				"re-couples its gate to an unrelated bump", tc.name, tc.got, tc.want)
+		}
+	}
+	if MinProtocolSecureTunnelRefusal > ProtocolVersion {
+		t.Errorf("secure-tunnel floor %d exceeds ProtocolVersion %d: a floor above "+
+			"the shipped version fences every helper unconditionally",
+			MinProtocolSecureTunnelRefusal, ProtocolVersion)
+	}
+}
+
+// #6649 + #6648 COMPOSITION. The per-feature gates admit `>=` their floor,
+// which by design says nothing about a helper NEWER than this control plane.
+// The helper's own contract is EXACT equality (its apply_snapshot and
+// bump_fib_generation handlers compare `!=` and return before any mutation), so
+// a newer helper refuses our snapshot and must still fail the commit closed.
+//
+// #6649 was filed when that was untrue: every gate was `>= ProtocolVersion`, a
+// newer helper passed all of them, and no required-protocol sentinel was
+// raised. #6722 closed it by adding the UNCONDITIONAL equality gate
+// (ensureEgressZoneProtocolLocked) at the tail of the chain — which is also why
+// #6648's per-feature floors are safe: they answer "can this helper represent
+// this feature?", and the acceptance rule lives in exactly ONE place.
+//
+// Nothing pinned that COMPOSITION before this cell. Measured at origin/master
+// (a1a7d9653) with the per-feature gate alone: `<nil>`. Narrow the unconditional
+// gate — or drop it from the chain — and a newer helper silently slips again,
+// with the per-feature gates now floored and even less likely to catch it.
+//
+// FAIL-ON-REVERT: change ensureEgressZoneProtocolLocked's `==` to `>=`, or drop
+// it from ensureRequiredSnapshotProtocolLocked, and this cell reds.
+func TestFeatureFlooredHelperStillFailsClosed6648(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		observed int
+		why      string
+	}{
+		{
+			name:     "newer-helper",
+			observed: ProtocolVersion + 1,
+			why: "the helper's own gate is exact equality, so it refuses our " +
+				"snapshot and stays on its previous-good image (#6649)",
+		},
+		{
+			name:     "between-floor-and-current",
+			observed: ProtocolVersion - 1,
+			why: "it can represent the scheduler feature (floor v2) but cannot " +
+				"accept a snapshot at this version, so the commit must still abort",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := schedulerFloorCfg()
+			m := New()
+			m.lastStatus.ConfigSnapshotProtocolVersion = tc.observed
+
+			// The FEATURE gate is correctly silent: the helper can represent it.
+			if err := m.ensurePolicySchedulerProtocolLocked(cfg); err != nil {
+				t.Fatalf("policy-scheduler gate fired for a helper at %d that can "+
+					"represent the feature (floor %d): %v",
+					tc.observed, MinProtocolPolicyScheduler, err)
+			}
+
+			// The CHAIN must still refuse, and the refusal must be one the
+			// commit-abort policy recognises — that predicate, not a particular
+			// sentinel, is what compileErrorMustAbortApply keys on.
+			err := m.ensureRequiredSnapshotProtocolLocked(gateSnapshot(t, cfg))
+			if err == nil {
+				t.Fatalf("a helper at version %d was ACCEPTED by the whole chain; %s",
+					tc.observed, tc.why)
+			}
+			if !IsRequiredProtocolGateError(err) {
+				t.Fatalf("chain returned %v, which IsRequiredProtocolGateError does "+
+					"not recognise — the commit would not abort and the helper "+
+					"would not be disarmed (#2138)", err)
+			}
+		})
+	}
+}

--- a/pkg/dataplane/userspace/set_forwarding_armed_generation_5648_test.go
+++ b/pkg/dataplane/userspace/set_forwarding_armed_generation_5648_test.go
@@ -62,8 +62,17 @@ func TestSetForwardingArmedRefusesStaleProtocolMismatch(t *testing.T) {
 	// config snapshot protocol version is STALE (below the required version).
 	m.lastStatus.Capabilities.ForwardingSupported = true
 	m.lastStatus.ForwardingArmed = false
-	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion - 1
-	// Last-applied config REQUIRES ProtocolVersion (scheduler-driven policy).
+	// #6648: BELOW THE FEATURE'S FLOOR. This used to say `ProtocolVersion - 1`,
+	// which only produced ErrPolicySchedulerProtocolIncompatible because every
+	// gate compared against the shared constant. Policy-scheduler state has
+	// been representable since v2 (MinProtocolPolicyScheduler), so a helper one
+	// version behind the constant CAN carry this snapshot's scheduler content
+	// and the scheduler gate is the wrong thing to name for it. Retargeted, not
+	// relaxed: the assertion below is unchanged and now runs against a helper
+	// that genuinely cannot represent the feature it names.
+	m.lastStatus.ConfigSnapshotProtocolVersion = MinProtocolPolicyScheduler - 1
+	// Last-applied config carries scheduler-driven policy, so it REQUIRES at
+	// least MinProtocolPolicyScheduler.
 	m.lastSnapshot, _ = buildSnapshot(scheduledPolicyCfg(), config.UserspaceConfig{ControlSocket: sock}, 5, 0)
 
 	_, err := m.SetForwardingArmed(true)

--- a/pkg/dataplane/userspace/shim_loader_boundary_test.go
+++ b/pkg/dataplane/userspace/shim_loader_boundary_test.go
@@ -1,8 +1,10 @@
 package userspace
 
 import (
+	"bytes"
 	"go/ast"
 	"go/parser"
+	"go/printer"
 	"go/token"
 	"os"
 	"path/filepath"
@@ -102,7 +104,84 @@ func goFunctionSource(t *testing.T, path, name string) string {
 	if fn == nil {
 		t.Fatalf("function %s not found in %s", name, path)
 	}
-	start := fset.Position(fn.Pos()).Offset
-	end := fset.Position(fn.End()).Offset
-	return string(data[start:end])
+	// RETURN CODE, NOT TEXT (#6647). This used to slice the raw file bytes
+	// from fn.Pos() to fn.End(), which includes every comment INSIDE the
+	// function body — so a source-scanning guard built on it could be
+	// satisfied by a comment that merely quotes the call it demands.
+	//
+	// MEASURED on this file's own subject before the fix: deleting the real
+	// `m.disarmSnapshotProtocolFailClosedLocked(snap, err, samePlanRefresh)`
+	// from applyCompiledSnapshot, substituting the weaker plain-disarm call,
+	// and leaving the demanded string behind in a `//` comment left
+	// TestProtocolGateSitesRouteThroughFailClosedHelper5488 GREEN — and the
+	// whole pkg/dataplane/userspace suite green with it, at `go vet` rc 0. The
+	// #5488 F7 fail-closed compensation was unpinned in exactly the way the
+	// guard existed to prevent.
+	//
+	// ParseFile ran with mode 0 above, so comments were never attached to the
+	// AST; printing the node back out therefore yields the declaration's CODE
+	// with every interior comment dropped. Formatting is gofmt-normalised,
+	// which is what the tree is already in, so asserted call-expression
+	// substrings are unaffected.
+	//
+	// The direction is right for both assertion shapes every caller uses: a
+	// presence check can no longer be faked by a comment, and a banned-token
+	// check can no longer FALSE-POSITIVE on prose that names the token it
+	// forbids.
+	var buf bytes.Buffer
+	if err := printer.Fprint(&buf, fset, fn); err != nil {
+		t.Fatalf("print %s from %s: %v", name, path, err)
+	}
+	return buf.String()
+}
+
+// #6647: goFunctionSource must return CODE, not raw file text.
+//
+// Every source-scanning guard in this package is built on it, including the one
+// that pins the #5488 F7 fail-closed compensation in applyCompiledSnapshot —
+// the compensator that closes #6647's "abort strands an armed helper behind new
+// classifier state". While the helper sliced raw bytes from fn.Pos() to
+// fn.End(), interior comments came back with the code, so a guard demanding a
+// call could be satisfied by a comment that merely quotes it.
+//
+// MEASURED at origin/master before this fix, on that exact subject: deleting
+// `m.disarmSnapshotProtocolFailClosedLocked(snap, err, samePlanRefresh)` from
+// applyCompiledSnapshot, substituting the weaker plain-disarm call, and leaving
+// the demanded string behind in a `//` comment left
+// TestProtocolGateSitesRouteThroughFailClosedHelper5488 GREEN — and the whole
+// pkg/dataplane/userspace suite green with it, at `go vet` rc 0.
+//
+// This cell is the paired proof: the SAME text is present in a comment and
+// absent from the code, so a helper that leaks comments returns it and a helper
+// that returns code does not. Reverting to the byte-slice form reds it.
+func TestGoFunctionSourceReturnsCodeNotComments6647(t *testing.T) {
+	t.Parallel()
+
+	// A subject whose body carries a comment naming a call it does NOT make.
+	// commentDecoySubject6647 is defined below purely for this cell.
+	src := goFunctionSource(t, "shim_loader_boundary_test.go", "commentDecoySubject6647")
+
+	if strings.Contains(src, "decoyCallThatIsOnlyEverMentionedInAComment") {
+		t.Fatalf("goFunctionSource leaked an interior comment: the returned text "+
+			"contains a call the function never makes, so every presence guard "+
+			"built on this helper can be satisfied by a comment quoting the line "+
+			"it demands (#6647). Got:\n%s", src)
+	}
+	// Positive control: the real call in the body must still be visible, or the
+	// helper would be "safe" by returning nothing useful and every guard above
+	// would pass vacuously.
+	if !strings.Contains(src, "realCallTheSubjectActuallyMakes") {
+		t.Fatalf("goFunctionSource dropped real code; guards built on it would "+
+			"pass vacuously. Got:\n%s", src)
+	}
+}
+
+func realCallTheSubjectActuallyMakes() int { return 0 }
+
+// commentDecoySubject6647 exists only as the subject of
+// TestGoFunctionSourceReturnsCodeNotComments6647.
+func commentDecoySubject6647() int {
+	// decoyCallThatIsOnlyEverMentionedInAComment() is named here and nowhere
+	// else in this function's code. A comment-leaking reader returns it.
+	return realCallTheSubjectActuallyMakes()
 }

--- a/pkg/dataplane/userspace/sync_desired_forwarding_generation_6165_test.go
+++ b/pkg/dataplane/userspace/sync_desired_forwarding_generation_6165_test.go
@@ -48,8 +48,17 @@ func TestSyncDesiredForwardingRefusesStaleProtocolMismatch(t *testing.T) {
 	// STALE — below the required snapshot protocol version.
 	m.lastStatus.Capabilities.ForwardingSupported = true
 	m.lastStatus.ForwardingArmed = false
-	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion - 1
-	// Last-applied config REQUIRES ProtocolVersion (scheduler-driven policy).
+	// #6648: BELOW THE FEATURE'S FLOOR. This used to say `ProtocolVersion - 1`,
+	// which only produced ErrPolicySchedulerProtocolIncompatible because every
+	// gate compared against the shared constant. Policy-scheduler state has
+	// been representable since v2 (MinProtocolPolicyScheduler), so a helper one
+	// version behind the constant CAN carry this snapshot's scheduler content
+	// and the scheduler gate is the wrong thing to name for it. Retargeted, not
+	// relaxed: the assertion below is unchanged and now runs against a helper
+	// that genuinely cannot represent the feature it names.
+	m.lastStatus.ConfigSnapshotProtocolVersion = MinProtocolPolicyScheduler - 1
+	// Last-applied config carries scheduler-driven policy, so it REQUIRES at
+	// least MinProtocolPolicyScheduler.
 	m.lastSnapshot, _ = buildSnapshot(scheduledPolicyCfg(), config.UserspaceConfig{ControlSocket: sock}, 5, 0)
 
 	// Guard the premise: absent the gate the reconcile WOULD arm — it only


### PR DESCRIPTION
Closes #6647
Closes #6648
Closes #6649

Three Codex findings from PR #6644, all in `pkg/dataplane/userspace`. One was
real and is fixed; two were measured **already closed at master** by work that
landed after they were filed, and are pinned rather than re-fixed. All cites are
against `origin/master` today, not the issues' stale `8a69bef9a`.

## The shape: two questions, one comparison

The gates in `manager_compile.go` answer two different questions, and the defect
was one comparison being asked to answer both.

1. **"Can this helper REPRESENT this feature?"** — per gated feature.
2. **"Will this helper ACCEPT our snapshot at all?"** — once, globally.

Question 2 is the helper's own contract: `snapshot.rs` compares
`snapshot.version != CONFIG_SNAPSHOT_PROTOCOL_VERSION` and returns before any
mutation. Question 1 has a different, per-feature answer.

---

## #6648 — REAL, fixed

All four per-feature gates compared against the shared `ProtocolVersion`
(`manager_compile.go:870, :876, :938, :944, :992, :998, :1014, :1020` — the
coordinator's cites, confirmed). Each now fences on an immutable floor:

| feature | floor | landed in |
|---|---|---|
| policy scheduler | `MinProtocolPolicyScheduler` = **2** | `f7c4b125c` (#1396) |
| persistent source NAT | `MinProtocolPersistentSourceNAT` = **3** | `c0a047ea2` (#1377) |
| scoped-global zone set | `MinProtocolMultiZoneScopedPolicy` = **4** (already existed) | `8119bfe27` (#5488/#6644) |
| secure-tunnel refusal | `MinProtocolSecureTunnelRefusal` = **7** | `be8aec13e` v5, `8d0e09fb8` v6, `8c011681c` v7 |

Derived from the constant's full change history, not from the issue — **the
issue's numbers were wrong** (it says scheduler = 3; it is 2). The secure-tunnel
floor is the LAST of its three bumps: a helper below 7 misreads at least one
part of the refusal contract. `MinProtocolMultiZoneScopedPolicy` already existed
for the #6650 peer gate and its comment named this as the follow-up
(`protocol.go:107-121`); the local gates now share it.

**The harm was the REASON, not the coverage — and I am not repeating the issue's
argument for it.** #6648 argues the coupling widens the *disarm blast radius*.
That was true when filed; since #6722 added an unconditional equality gate, ANY
version skew already disarms, so the blast radius is uniform either way. What
actually breaks is truthfulness: a v7 helper was told "policy scheduler
snapshots require version 8" when scheduler state has been representable since
v2. And the four gates were a second, divergent copy of the acceptance rule.

## #6649 — already closed at master, now pinned

Measured, not read. At master, helper at `ProtocolVersion + 1`:

```
per-feature gate alone: <nil>          <- the >= slip #6649 describes is real
orchestrator:           ErrEgressZoneProtocolIncompatible: helper ... 9 != required 8
IsRequiredProtocolGateError = true     <- the sentinel DOES fire
```

`ensureEgressZoneProtocolLocked` (#6722) is unconditional, uses **equality**, is
enumerated in `requiredProtocolGateSentinels`, and is the tail of every gate
chain — so the commit aborts and the helper is disarmed. #6649's stated failure
("the fail-closed sentinel never fires") does not reproduce.

**Single-sourcing direction, as asked:** toward the **helper**. It is the
authority — it decides what it accepts; the Go gate exists only to predict that
decision. So the one Go copy of the rule is exact equality mirroring
`snapshot.rs`, and its constant is bound to the Rust constant by
`TestSnapshotProtocolVersionLockstepWithRust`, which parses `control.rs` rather
than mirroring it. #6648's floors are what *keep* it single-sourced: the
per-feature gates stop re-implementing it.

Nothing pinned that composition, so `TestFeatureFlooredHelperStillFailsClosed6648`
now does, in both directions (helper newer, and helper between floor and current).

## #6647 — already closed at master; its PIN was not

Master has moved under the issue, as the coordinator flagged. I did not reorder
anything.

- The `pendingXSKStartup` branch gates **before** its work (`:370` / `:376`).
- The main path still writes maps (`:419`/`:423`) and calls `ensureProcessLocked`
  (`:427`) before the gate (`:430`) — but the abort routes through
  `disarmSnapshotProtocolFailClosedLocked(snap, err, samePlanRefresh)`, and I
  verified each of its claims:
  - a **successful** disarm sets `binding.armed = false` for every binding and
    reconciles the AF_XDP sockets (`server/helpers/status.rs:456`,
    `handlers/forwarding.rs:53`), so the helper is not forwarding at all;
  - on a **failed** disarm with maps mutated in place it drives `userspace_ctrl`
    to `Enabled=0`, so the shim drops transit;
  - the `mapsMutatedInPlace == false` arm needs no compensation because
    `programBootstrapMapsLocked` already writes `Enabled: 0`
    (`maps_sync.go:177`) — confirmed, not taken on trust.
- The issue's "detached interfaces per the candidate" pre-work is gone: #5485
  moved `syncInterfaceAttachments` after the acceptance points, and the abort
  returns before it.
- All **seven** gate call sites audited; none of the other six mutates state
  before its gate.

**But the guard that pins all of this was defeatable by a comment.** Measured at
master: delete the real
`m.disarmSnapshotProtocolFailClosedLocked(snap, err, samePlanRefresh)` from
`applyCompiledSnapshot`, substitute the weaker plain disarm, leave the demanded
string in a `//` comment —
`TestProtocolGateSitesRouteThroughFailClosedHelper5488` stayed **green**, the
whole package stayed green, `go vet` rc 0. `goFunctionSource` sliced raw file
bytes from `fn.Pos()` to `fn.End()`, so interior comments came back as "source".
It now returns printed CODE. Nine guards across three test files are built on it.

## Mutation matrix

Every cell **full-suite** (`go test ./pkg/dataplane/userspace/ ./pkg/daemon/ -count=1`),
one line, restored clean after each.

| # | Site | Exact one-line change | `go vet` rc | ASSERTION that fired |
|---|---|---|---|---|
| control | — | none | 0 | `ok` both packages (37.0s / 45.8s) |
| M1 | `manager_compile.go:1003` (`ensurePolicySchedulerProtocolLocked`) | `>= MinProtocolPolicyScheduler` → `>= ProtocolVersion` | 0 | `protocol_feature_floors_6648_test.go:117` — *"helper at the feature floor (2) was fenced by its own gate: ... version 2 < required 2"*; and `:249` — *"policy-scheduler gate fired for a helper at 7 that can represent the feature (floor 2)"* |
| M1b | `protocol.go:146` | `MinProtocolPolicyScheduler = 2` → `= ProtocolVersion` | 0 | `:191` — *"policy scheduler landed in the v2 bump: floor = 8, want 2"* |
| M2 | `shim_loader_boundary_test.go:131-135` (`goFunctionSource` body + its two imports — reverting the body reverts them, which is exactly the pre-#6647 shape; leaving them would be a compile break that measures nothing) | printed CODE → raw `data[start:end]` slice | 0 | `:161` — *"goFunctionSource leaked an interior comment: the returned text contains a call the function never makes"* |
| M3 | `manager_compile.go:1113` (`ensureEgressZoneProtocolLocked`) | `observed == ProtocolVersion` → `>=` | 0 | `protocol_feature_floors_6648_test.go:259` — *"a helper at version 9 was ACCEPTED by the whole chain"*; also reds the pre-existing `egress_zone_protocol_6722_test.go:98` |
| M4 | `manager_compile.go:1092` | `return m.ensureEgressZoneProtocolLocked()` → `return nil` | 0 | `:259` at **both** versions 7 and 9; also reds three pre-existing #6722 cells |

M4 is the safety cell for this PR specifically: before the floors, the
per-feature gates would have caught the version-7 case; after them only the
acceptance gate does, and that dependency is now pinned rather than assumed.

**Base-fixture column.** Measured with `origin/master`'s production code AND
`origin/master`'s tests for this package — i.e. the defect present, nothing of
mine in the tree: `go vet` rc 0, `ok github.com/psaab/xpf/pkg/dataplane/userspace`.
The pre-existing suite is **blind** to the #6648 coupling. Likewise for #6647:
under the comment-decoy probe the full package exited 0.

*Honest note on my own test design:* under M1b the parameterized cell in
`TestPerFeatureGatesFenceOnTheirOwnFloor6648` does NOT red, because it derives
its helper version from the same constant being mutated. That is why
`TestProtocolFloorsAreImmutableLiterals6648` pins each floor to a literal — the
parameterized test guards the gate's *comparison*, the literal test guards the
floor's *value*, and neither alone is sufficient.

## Retargeted fixtures (three, none deleted)

Each used `ProtocolVersion - 1` as "a stale helper" and named a feature-specific
sentinel, which only held because of the coupling being removed:

- `TestEnsureRequiredSnapshotProtocolRejectsOldHelperForPersistentSourceNAT` →
  `MinProtocolPersistentSourceNAT - 1`; assertion unchanged.
- `TestSetForwardingArmedRefusesStaleProtocolMismatch` and
  `TestSyncDesiredForwardingRefusesStaleProtocolMismatch` →
  `MinProtocolPolicyScheduler - 1`; assertions unchanged, so their documented
  fail-on-revert (neutralize the guard) still reds. I first tried relaxing these
  to `IsRequiredProtocolGateError` and backed it out — lowering the fixture keeps
  the original specificity and is truthful, whereas the relaxation traded away
  a real assertion.
- `TestSyncDesiredForwardingDisarmNotBlockedByGate` uses the same value at
  `:141` but is the disarm direction, where the gate never fires. Left alone.

## Docs

`docs/userspace-dataplane-architecture.md` — new *Per-feature protocol floors
(#6648, #6649)* section with the floor table and the two-questions split, plus
the #6647 disposition. Two existing claims were made false by this change and
are corrected in the same commit: the #6650 section said "#6648 tracks giving
the local gates the same treatment" (done now), and the #5488 section said the
scoped-global gate fires below `ProtocolVersion` (now below the v4 floor). The
stale in-code claim that the secure-tunnel gate "compares against ProtocolVersion
rather than a pinned number" is corrected at its definition.

## Validation

- `go build ./...` 0, `go vet` 0, `gofmt` clean on every touched file.
- `pkg/dataplane/userspace` + `pkg/daemon` green at `-count=1`, at the **merged**
  head `7609d72fd` (`origin/master` `648a73c71` verified an ancestor).
- No Rust in the diff — the helper side is only read, never changed.
