### PR TITLE
tests: serialise the two process-global observables that break parallel runs (#7413)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103096,3 +103096,22 @@ prose edit above them added. No diff falls in the new test body.
     owner's authoritative session family under latest-generation-wins.
   - **File(s)**: pkg/daemon/daemon_ha_userspace_stream.go,
     pkg/daemon/userspace_sync_test.go, docs/session-sync-architecture.md
+
+- **Timestamp**: 2026-08-22
+  - **Action**: #7413 — three tests read process-global state and failed under a
+    parallel `cargo test`. Two independent resources, each with a single
+    mechanism, measured rather than inferred: `DETERMINISTIC_V6_DOWNGRADE_COUNT`
+    (2 asserters, 6/6 fail at --test-threads=2, `left: 2 right: 1`) and the
+    process-wide `neigh-monitor` thread count (10 spawners across 2 modules,
+    4/8 fail running ONLY the two asserters, `before=0 during=2`). Both take a
+    poison-tolerant serial guard. Corrected my own issue text: the nat64
+    counter is PRODUCTION state, so the `thread_local!` pattern does not apply
+    — it would break the product. Population enumerated by running all 4549
+    tests alone and watching each observable's own log line, which also proved
+    no spawner leaks. Guard on the two asserters is BOUND (5/8 red); the guard
+    on the other eight is precautionary and reported as such — it does not red
+    even paired one-to-one, and the `before == 0` precondition is the anti-rot
+    diagnostic that makes a future collision name the missing lock.
+  - **File(s)**: userspace-dp/src/afxdp/coordinator/{neighbor_manager.rs,mod.rs,
+    tests.rs}, userspace-dp/src/afxdp/mod.rs, userspace-dp/src/main_tests.rs,
+    userspace-dp/src/nat64_tests.rs, docs/engineering-style.md

--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -560,6 +560,35 @@ they repeatedly bite:
     `stop` ALREADY set is an exact fail-on-revert
     (`reconcile_churn_completes_a_cycle_even_when_already_stopped_6633`),
     which the scheduling assertion it replaces could never be.
+  - **`thread_local!` is only for a TEST-ONLY global. A PRODUCTION global
+    takes the guard, whatever its shape.** `DETERMINISTIC_V6_DOWNGRADE_COUNT`
+    (`nat64.rs`) is an `AtomicU64` two tests assert deltas on, which looks like
+    the counter case above — but it is bumped on the real downgrade path and
+    read by the operator warning, so making it thread-local would break the
+    product: the increment happens on whichever thread compiles the snapshot
+    and a reader on another thread would see zero. Check where the global is
+    WRITTEN before choosing the pattern (#7413).
+  - **Enumerate the affected population by RUNNING every test alone, not by
+    reading call sites.** For #7413 the two shared observables were a
+    production counter and the process-wide count of threads named
+    `neigh-monitor`. Reading call sites suggested ~28 candidate coordinator
+    tests; running all 4549 tests individually and watching for each
+    observable's own log line found **exactly 2** counter bumpers and
+    **exactly 10** monitor spawners — and showed that every one of the ten
+    STOPS its monitor, which ruled out a leak and left concurrent overlap as
+    the only mechanism. It also found the one spawner in a different module,
+    which is what forced the guard to be `pub(crate)` rather than
+    module-scoped. A guard over the population you guessed is a guard over
+    part of it.
+  - **Be explicit about which guards are BOUND and which are precautionary.**
+    In #7413 the guard on the two asserting gates reds 5/8 when removed; the
+    guard on the other eight spawners does NOT red even when paired one-to-one
+    with an asserter at `--test-threads=2`, because their monitor windows are
+    too short to overlap the assertion window today. They are kept as defence
+    in depth over an enumerated population — not claimed as tested — and the
+    two gates carry a `before == 0` precondition so a future spawner that does
+    collide fails by NAMING the missing lock instead of as an off-by-one delta
+    that reads like a real leak.
   - Prove the ISOLATION variant with a **deterministic fail-on-revert**
     (two barrier-synced threads whose per-thread counter assertion is
     mathematically impossible under a shared global). The mutex GUARD

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -46,6 +46,13 @@ pub(crate) use cos_state::SharedCoSState;
 pub(crate) use cos_state::PrePublishSiblings;
 pub(in crate::afxdp) use ha_state::HaState;
 pub(crate) use neighbor_manager::NeighborManager;
+/// #7413: re-exported so `main_tests.rs` — the one `neigh-monitor` spawner
+/// outside `coordinator/tests.rs` — can take the same guard. `mod
+/// neighbor_manager` is private, and `mod coordinator` is private in
+/// `afxdp/mod.rs`, so the guard needs a re-export at each level to be reachable
+/// crate-wide; see `afxdp/mod.rs` for the second one.
+#[cfg(test)]
+pub(crate) use neighbor_manager::neigh_monitor_test_serial;
 pub(crate) use neighbor_manager::WarmItem;
 pub(in crate::afxdp) use neighbor_manager::{
     WARM_GC_INTERVAL_NS, WARM_GC_MAX_AGE_NS, WARM_PER_KEY_RATE_LIMIT_NS, WARM_QUEUE_DEPTH,

--- a/userspace-dp/src/afxdp/coordinator/neighbor_manager.rs
+++ b/userspace-dp/src/afxdp/coordinator/neighbor_manager.rs
@@ -204,6 +204,41 @@ impl NeighborManager {
     }
 }
 
+/// #7413: serialises every test that spawns a `neigh-monitor` thread.
+///
+/// The observable the #6637 leak gates read is the PROCESS-WIDE count of
+/// threads named `neigh-monitor` (`/proc/self/task`), so it is shared by every
+/// test that brings a coordinator up — not only the two that assert on it.
+/// Under the parallel `cargo test` runner two spawners overlap and each sees
+/// the other's monitor: measured `before=0 during=2` against an expected
+/// `before+1`, with BOTH gates failing together in 4 of 8 runs of just those
+/// two tests at `--test-threads=2`.
+///
+/// TEN tests across TWO modules spawn one. That population was enumerated by
+/// running every test in the binary alone and watching for the monitor's own
+/// `listening` line, not by reading call sites — which is also how it was
+/// established that none of them LEAKS one (every spawner stops it), so the
+/// contamination is concurrent overlap and nothing else.
+///
+/// It lives in the production module beside the thing it guards, mirroring
+/// `icmp_ratelimit::global_bucket_test_lock`, and is `pub(crate)` rather than
+/// module-scoped because one of the ten spawners is in `main_tests.rs`.
+///
+/// Poison-tolerant (`into_inner`) so a panicking guarded test cannot deadlock
+/// the rest of the suite. Hold it for the WHOLE test body: the window that must
+/// be exclusive is spawn → assert → teardown, not the assert alone.
+///
+/// The two asserting gates ALSO check `before == 0` as a precondition, and that
+/// is the anti-rot half of this fix. An eleventh spawner added without the
+/// guard makes them fail loudly, naming the missing lock, instead of failing as
+/// an off-by-one delta that reads like a real leak.
+#[cfg(test)]
+pub(crate) fn neigh_monitor_test_serial() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::Mutex;
+    static LOCK: Mutex<()> = Mutex::new(());
+    LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 #[cfg(test)]
 mod monitor_join_tests_5165 {
     use super::*;

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -2340,6 +2340,10 @@ fn teardown_quiesce_skipped_on_no_snapshot_even_with_live_workers() {
 /// and this assertion fails.
 #[test]
 fn teardown_quiesce_fires_when_live_workers_and_snapshot_rebinds() {
+    // #7413: this test spawns a `neigh-monitor` thread, and the #6637 leak
+    // gates read the PROCESS-WIDE count of those. Held for the whole body so a
+    // parallel sibling cannot move that count inside their window.
+    let _neigh_serial = crate::afxdp::neigh_monitor_test_serial();
     let mut coordinator = StoppedCoordinator::wrap(gre1881_coordinator_with_worker()); // #6637
     assert!(
         !coordinator.workers.records.is_empty(),
@@ -4067,6 +4071,10 @@ fn reconcile_missing_session_pin_keeps_prior_generation_published() {
 /// fixtures; here we only assert the publish happened.
 #[test]
 fn reconcile_all_mandatory_maps_open_advances_published_generation() {
+    // #7413: this test spawns a `neigh-monitor` thread, and the #6637 leak
+    // gates read the PROCESS-WIDE count of those. Held for the whole body so a
+    // parallel sibling cannot move that count inside their window.
+    let _neigh_serial = crate::afxdp::neigh_monitor_test_serial();
     let mut coordinator = StoppedCoordinator::new(); // #6637
     let prior = ValidationState {
         snapshot_installed: true,
@@ -5026,6 +5034,10 @@ fn rejected_apply_does_not_prune_live_zone_counters_6832() {
 
 #[test]
 fn committed_reconcile_prunes_zone_counters_for_removed_zones_6832() {
+    // #7413: this test spawns a `neigh-monitor` thread, and the #6637 leak
+    // gates read the PROCESS-WIDE count of those. Held for the whole body so a
+    // parallel sibling cannot move that count inside their window.
+    let _neigh_serial = crate::afxdp::neigh_monitor_test_serial();
     // POSITIVE direction, reconcile call site. Anti-over-fix: deferring the
     // prune must not DELETE it. Same zone move, but the workers come up, so the
     // apply commits and zone 200 is dropped.
@@ -5328,6 +5340,10 @@ fn zone_flood_counters_drops_a_zone_that_lost_its_slot_3651() {
 /// preflight-zone-source fix prevents.
 #[test]
 fn reconcile_fresh_boot_concrete_zone_policy_passes_preflight_3402() {
+    // #7413: this test spawns a `neigh-monitor` thread, and the #6637 leak
+    // gates read the PROCESS-WIDE count of those. Held for the whole body so a
+    // parallel sibling cannot move that count inside their window.
+    let _neigh_serial = crate::afxdp::neigh_monitor_test_serial();
     let mut coordinator = StoppedCoordinator::new(); // #6637
     // Fresh coordinator: the live forwarding zone table is EMPTY (the bug
     // condition — the snapshot carries the zones, the live table does not yet).
@@ -5741,6 +5757,10 @@ fn reconcile_present_dnat_pin_open_failure_keeps_prior_generation() {
 /// failure).
 #[test]
 fn reconcile_empty_optional_pins_advance_published_generation() {
+    // #7413: this test spawns a `neigh-monitor` thread, and the #6637 leak
+    // gates read the PROCESS-WIDE count of those. Held for the whole body so a
+    // parallel sibling cannot move that count inside their window.
+    let _neigh_serial = crate::afxdp::neigh_monitor_test_serial();
     let mut coordinator = StoppedCoordinator::new(); // #6637
     let prior = ValidationState {
         snapshot_installed: true,
@@ -5776,6 +5796,10 @@ fn reconcile_empty_optional_pins_advance_published_generation() {
 /// healthy configured map).
 #[test]
 fn reconcile_present_optional_pins_open_ok_advance_generation() {
+    // #7413: this test spawns a `neigh-monitor` thread, and the #6637 leak
+    // gates read the PROCESS-WIDE count of those. Held for the whole body so a
+    // parallel sibling cannot move that count inside their window.
+    let _neigh_serial = crate::afxdp::neigh_monitor_test_serial();
     let mut coordinator = StoppedCoordinator::new(); // #6637
     let prior = ValidationState {
         snapshot_installed: true,
@@ -6163,6 +6187,10 @@ fn multi_fault_map_pins_use_two_pass_precedence_from_both_paths_6243() {
 /// — proving each walks and opens the FULL bundle before returning Ok.
 #[test]
 fn both_paths_open_full_seven_pin_bundle_before_ok_6243() {
+    // #7413: this test spawns a `neigh-monitor` thread, and the #6637 leak
+    // gates read the PROCESS-WIDE count of those. Held for the whole body so a
+    // parallel sibling cannot move that count inside their window.
+    let _neigh_serial = crate::afxdp::neigh_monitor_test_serial();
     let mut pins = all_map_pins_ok_6243();
     pins.conntrack_v4 = format!("{TEST_MAP_PIN_OK}conntrack_v4");
     pins.conntrack_v6 = format!("{TEST_MAP_PIN_OK}conntrack_v6");
@@ -6630,7 +6658,22 @@ fn await_neigh_monitor_count(want: usize) -> usize {
 /// Preventing the spawn reds the first.
 #[test]
 fn coordinator_bringup_does_not_leak_a_neigh_monitor_thread_6637() {
+    // #7413: this test spawns a `neigh-monitor` thread, and the #6637 leak
+    // gates read the PROCESS-WIDE count of those. Held for the whole body so a
+    // parallel sibling cannot move that count inside their window.
+    let _neigh_serial = crate::afxdp::neigh_monitor_test_serial();
     let before = neigh_monitor_thread_count();
+    // #7413 anti-rot precondition. The guard above makes this hold; an
+    // ELEVENTH spawner added without taking it breaks it, and this fails
+    // naming the missing lock instead of failing later as an off-by-one delta
+    // that reads like a real monitor leak.
+    assert_eq!(
+        before, 0,
+        "a neigh-monitor thread is already running when this gate started \
+         (before={before}). Either a sibling test spawned one without taking \
+         neigh_monitor_test_serial(), or a previous test leaked one; both make \
+         the deltas below measure the wrong thing (#7413)"
+    );
 
     let mut coordinator = Coordinator::new();
     zone_counter_live_coordinator(&mut coordinator);
@@ -6671,7 +6714,22 @@ fn coordinator_bringup_does_not_leak_a_neigh_monitor_thread_6637() {
 /// Deleting the `Drop` impl reds this.
 #[test]
 fn stopped_coordinator_guard_joins_the_neigh_monitor_on_drop_6637() {
+    // #7413: this test spawns a `neigh-monitor` thread, and the #6637 leak
+    // gates read the PROCESS-WIDE count of those. Held for the whole body so a
+    // parallel sibling cannot move that count inside their window.
+    let _neigh_serial = crate::afxdp::neigh_monitor_test_serial();
     let before = neigh_monitor_thread_count();
+    // #7413 anti-rot precondition. The guard above makes this hold; an
+    // ELEVENTH spawner added without taking it breaks it, and this fails
+    // naming the missing lock instead of failing later as an off-by-one delta
+    // that reads like a real monitor leak.
+    assert_eq!(
+        before, 0,
+        "a neigh-monitor thread is already running when this gate started \
+         (before={before}). Either a sibling test spawned one without taking \
+         neigh_monitor_test_serial(), or a previous test leaked one; both make \
+         the deltas below measure the wrong thing (#7413)"
+    );
     {
         let mut coordinator = StoppedCoordinator::new();
         zone_counter_live_coordinator(&mut coordinator);

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -496,6 +496,10 @@ const fn tx_frame_capacity() -> usize {
 
 #[path = "coordinator/mod.rs"]
 mod coordinator;
+/// #7413: see `coordinator/mod.rs` — the `neigh-monitor` test serial guard,
+/// re-exported so every spawner across both test modules takes the SAME lock.
+#[cfg(test)]
+pub(crate) use coordinator::neigh_monitor_test_serial;
 // afxdp/tests.rs (14k-LOC catch-all) was split into cohesive per-subsystem
 // sibling test modules plus a shared support module in #4840. Pure test
 // code-motion; each file carries the union use-block and reaches production

--- a/userspace-dp/src/main_tests.rs
+++ b/userspace-dp/src/main_tests.rs
@@ -2057,6 +2057,11 @@ fn apply_path_persistent_snat_key(
 
 #[test]
 fn apply_snapshot_same_plan_preserves_persistent_snat_lease_state() {
+    // #7413: this test brings a coordinator up and therefore spawns a
+    // `neigh-monitor` thread, which the #6637 leak gates count PROCESS-WIDE.
+    // It is the one spawner outside `coordinator/tests.rs`, which is why the
+    // guard is `pub(crate)` rather than module-scoped.
+    let _neigh_serial = crate::afxdp::neigh_monitor_test_serial();
     let state = Arc::new(Mutex::new(ServerState {
         status: ProcessStatus {
             forwarding_armed: true,

--- a/userspace-dp/src/nat64_tests.rs
+++ b/userspace-dp/src/nat64_tests.rs
@@ -178,11 +178,37 @@ fn napt64_without_deterministic_stays_round_robin() {
     assert_eq!(port, 1024, "round-robin allocates from the cursor start (port_low)");
 }
 
+/// #7413: serialises the two tests that assert on `DETERMINISTIC_V6_DOWNGRADE_COUNT`.
+///
+/// That counter is PRODUCTION state (`nat64.rs`, bumped on the real
+/// downgrade path), not test-only, so the `thread_local!` pattern
+/// `docs/engineering-style.md` gives for test-only globals does NOT apply here
+/// — making it thread-local would break the product, because the increment
+/// happens on whichever thread compiles the snapshot and a status reader on
+/// another thread would see zero. The settled pattern for a genuinely shared
+/// global is this: a poison-tolerant serial guard held for the whole body by
+/// every test that touches it.
+///
+/// Both tests already read a RELATIVE delta (`before + 1`), which is correct in
+/// isolation and still wrong concurrently: each sees the other's increment and
+/// asserts `left: 2, right: 1`. Reproduced 6 of 6 runs at `--test-threads=2`.
+///
+/// EXACTLY TWO tests bump the counter, established by running all 4549 tests in
+/// the binary alone and watching for the paired operator warning rather than by
+/// reading call sites — so this guard covers the whole population, not the part
+/// that was easy to find.
+fn deterministic_v6_downgrade_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::Mutex;
+    static LOCK: Mutex<()> = Mutex::new(());
+    LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 // #4559: an IPv6-host deterministic NAT64 snapshot with an UNSUPPORTED prefix
 // length (only /32 and /64 map to a 32-bit subscriber word) does NOT build a
 // deterministic prefix — it round-robins (the commit-time advisory covers it).
 #[test]
 fn napt64_deterministic_v6_unsupported_prefix_len_falls_back() {
+    let _downgrade_serial = deterministic_v6_downgrade_test_lock();
     let before = DETERMINISTIC_V6_DOWNGRADE_COUNT.load(Ordering::Relaxed);
     let state = Nat64State::from_snapshots(&[NAT64RuleSnapshot {
         name: "napt64-bad-prefix".to_string(),
@@ -219,6 +245,7 @@ fn napt64_deterministic_v6_unsupported_prefix_len_falls_back() {
 // (silently), but the counter no longer moves.
 #[test]
 fn napt64_deterministic_v6_host_count_overflow_warns_operator() {
+    let _downgrade_serial = deterministic_v6_downgrade_test_lock();
     let before = DETERMINISTIC_V6_DOWNGRADE_COUNT.load(Ordering::Relaxed);
     // blocks_per_ip at its u16 max; a 70_000-entry pool makes
     // `num_pool_ips * blocks_per_ip` (70_000 * 65_535 ≈ 4.59e9) exceed


### PR DESCRIPTION
Closes #7413.

## Two resources, one mechanism each — measured, not inferred

The question the issue had to answer first was whether this is one mechanism or
several, because the `pkg/ddns` pair earlier tonight turned out to be **two flakes
sharing one root resource**, and folding them would have closed one while making the
other look fixed. Here it is the other shape: **two independent resources, each with a
single mechanism.**

| Resource | Population | Reproduction |
|---|---|---|
| `DETERMINISTIC_V6_DOWNGRADE_COUNT` (production `AtomicU64`) | 2 asserters | **6/6** fail at `--test-threads=2`, `left: 2, right: 1` |
| process-wide `neigh-monitor` thread count (`/proc/self/task`) | 10 spawners, 2 of them assert | **4/8** fail running *only the two asserters* at `--test-threads=2`, `before=0 during=2` |

Both take a poison-tolerant serial guard held for the whole body — the settled pattern
for a genuinely shared global.

A timing mechanism was considered and ruled out: the coordinator failures sit at the
full 5s poll deadline because the count never reaches the expected value, not because
a spawn was slow.

## Correcting my own issue text

**#7413 prescribed `thread_local!` for the nat64 counter. That was wrong and would
have broken the product.** `DETERMINISTIC_V6_DOWNGRADE_COUNT` is *production* state —
declared at `nat64.rs:932`, incremented at `:1153` on the real downgrade path, paired
with the operator warning. Thread-locality would put the increment on whichever thread
compiled the snapshot while a status reader on another saw zero.

`thread_local!` is for **test-only** globals. A production global takes the guard
whatever its shape. Corrected on the issue as well as here, because I filed it.

## Population enumerated by running, not by reading

Every one of the **4549** tests in the binary was run alone while watching for each
observable's own log line:

- **2** tests bump the counter → the nat64 guard is complete.
- **10** tests spawn a monitor — nine in `coordinator/tests.rs` plus
  `tests::apply_snapshot_same_plan_preserves_persistent_snat_lease_state` in
  `main_tests.rs`. That cross-module one is why the guard is `pub(crate)` and
  re-exported through two private modules rather than being module-scoped.
- **Every spawner stops its monitor**, which ruled out a leaked-thread mechanism and
  left concurrent overlap as the only one.

Reading call sites had suggested ~28 candidate coordinator tests. A guard over the
population you guessed is a guard over part of it.

## What is bound, and what is not — reported rather than implied

| Cell | Verdict |
|---|---|
| nat64 guard removed from both asserters | **RED 6/6** |
| monitor guard removed from the two ASSERTERS | **RED 5/8** |
| monitor guard removed from one non-asserting spawner (paired 1:1 with an asserter) | **GREEN 0/8** |
| monitor guard removed from the `main_tests.rs` spawner (paired 1:1) | **GREEN 0/8** |
| `before == 0` precondition removed | **GREEN 0/8** |

The two green spawner cells are not a reason to drop those guards, and not a claim
that they are tested. Their monitor windows are too short to overlap an assertion
window *today*; the hazard is real in principle, the population is enumerated so the
rule "every spawner takes the lock" is checkable, and the cost is one line each. They
are **precautionary, and labelled as such in the code and the docs** rather than
counted as coverage.

The `before == 0` precondition is the same kind of thing: instrumentation for a future
failure. An eleventh spawner added without the guard makes the two gates fail **naming
the missing lock**, instead of failing as an off-by-one delta that reads like a real
monitor leak.

## Docs

`docs/engineering-style.md`, in the "Rust tests must be parallel-safe" section, gains
three points this cost real time to learn:

1. `thread_local!` is only for a **test-only** global; check where the global is
   *written* before choosing the pattern.
2. Enumerate the affected population by **running** every test alone, not by reading
   call sites — that is also what proved there was no leak and found the cross-module
   spawner.
3. Be explicit about which guards are bound and which are precautionary.

## Validation

- **5 ×** full parallel `cargo test --release --bins` — 4547 passed, 0 failed. It
  failed 3/3 before.
- Serial `--test-threads=1` — green.
- Targeted reproductions: **8/8** and **6/6** clean, where they were 4/8 and 6/6
  failing.

Test-only change plus a doc. No production code, no `.o` movement, no protocol change,
so no cluster smoke is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAsT5gCGP7k2vhdZ1sDuRi
