### PR TITLE
config: fold duplicate system login user blocks (#6992)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103180,3 +103180,12 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: pkg/config/compiler_chassis_cluster_packed.go (new),
   pkg/config/compiler_system.go, pkg/config/schema_walk.go,
   pkg/config/packed_chassis_cluster_6672_test.go, docs/config-schema.md
+
+## 2026-08-22 — #6992 duplicate system login user blocks
+- **Timestamp**: 2026-08-22
+- **Action**: Fold a duplicated `system login user` name into ONE compiled entry
+  (per-leaf last-authored-wins, matching the flat spelling) so no reader can
+  pick a different block, and register the container in the #5180 duplicate
+  gate so the silent drop is rejected at commit.
+- **File(s)**: pkg/config/compiler_system.go, pkg/config/dup_named_blocks.go,
+  pkg/config/duplicate_login_user_6992_test.go, docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -499,6 +499,60 @@ peer-view wiring (node0 accepts the peer-only overlap). The shipped `test/incus/
 pool drawn by both NAT64 and a source-NAT rule) and were separated into distinct
 pools + proxy-ARP as part of this change.
 
+### Duplicate `system login user` name (#6992)
+
+The same `user` name authored in two `system login` blocks was WORSE than the
+last-writer-wins drop the #5180 gate covers: both blocks survived in
+`Login.Users`, and two readers picked DIFFERENT ones.
+
+| reader | picks |
+|---|---|
+| `configuredClass` (`pkg/cli/identity.go`) | the FIRST block with a non-empty class |
+| `applySystemLogin` (`pkg/daemon/daemon_system.go`) | iterates every block in order, so the account state that lands comes from the LAST |
+
+Measured on a config that committed CLEAN at strict:
+
+```
+user alice { uid 2001; class admins; authentication { ssh-rsa "K1"; } }
+user alice { uid 2002; class ops;    authentication { ssh-rsa "K2"; } }
+```
+
+`applySystemLogin` rewrites `authorized_keys` per entry with
+`WriteFileDurable`, so **K2** — the key the operator wrote under the VIEW-only
+block — is the one on disk, while `configuredClass` answered **admins**. The
+credential that authenticates and the class that authorizes it came from
+different blocks, in the permissive direction. This is the third instance of the
+class in this area: #6861 keyed an advisory on a name the runtime resolved
+differently, #6838 keyed a fold on a class name the runtime picked differently.
+
+**The fix is a fold, not a matched tie-break.** `compileSystemLogin` collapses a
+duplicated name into ONE entry with per-LEAF last-authored-wins — which is what
+the FLAT spelling already produces, because `SetPath` merges `set system login
+user alice …` written twice onto one node and replaces each leaf. That makes the
+two AST shapes agree (the #5180 dual-AST-equivalence property) rather than
+inventing a third answer, and it is stronger than teaching one reader the
+other's tie-break: after the fold there is no tie to break. #6838 records why the
+weaker form is wrong — matching a tie-break is a proxy that rots the day the
+other reader changes.
+
+Per-LEAF, not per-block: a second block authoring only a `class` must leave the
+first block's `uid` in place, because that is what the flat spelling gives.
+Folding to the last BLOCK would silently zero it.
+
+The `authentication` section is the one exception — a later block's section
+replaces the earlier block's key set wholesale rather than merging into it. That
+is chosen so the fold preserves the PROVISIONED state exactly: `authorized_keys`
+is already rewritten per entry, so the last entry's keys are already the ones on
+disk.
+
+`system login user` is also registered in the #5180 duplicate-named-block gate,
+because a fold is still a silent drop of the earlier block's uid / class / keys.
+Strict rejects; the tolerant load / peer-sync path warns and boots (#1960).
+
+Deliberately NOT applied to `system login class`: #6838 already made the class
+cohort reader-independent by folding permissions across the whole same-named
+set, and a merge here would fight that design.
+
 ### Duplicate NAT rule name (#5649, C181-M18)
 
 NAT rule-sets are ordered, first-match tables keyed by rule name, so a rule's

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -147,8 +147,58 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 				lc.MappedPermissions, _ = mapJunosPermissions(lc.Permissions)
 				sys.Login.Classes = append(sys.Login.Classes, lc)
 			}
+			// #6992: a user NAME authored in two blocks folds into ONE entry.
+			//
+			// Without the fold both blocks survive in Login.Users and two
+			// readers pick different ones: pkg/cli configuredClass returns the
+			// FIRST block with a non-empty class, while pkg/daemon
+			// applySystemLogin iterates every block in order, so the account
+			// state that lands (password, authorized_keys) comes from the LAST.
+			// Measured on a config that commits CLEAN at strict: with
+			// `class admins` first and `class ops` second, the SSH key the
+			// operator wrote under the VIEW-only block authenticates and the
+			// CLI then grants super-user. The authorization decision and the
+			// credential that reaches it come from different blocks.
+			//
+			// The fold is per-LEAF last-authored-wins because that is what the
+			// FLAT spelling already produces — SetPath merges `set system login
+			// user alice ...` written twice onto one node, replacing each leaf —
+			// so folding makes the two AST shapes agree rather than inventing a
+			// third answer. This is the #5180 dual-AST-equivalence property, and
+			// the same reasoning as the #6838 cohort fold one stanza over: make
+			// the outcome INDEPENDENT of which reader picks, rather than
+			// teaching one reader the other's tie-break, which is a proxy that
+			// rots the day the other reader changes. Here it is stronger than a
+			// matched tie-break: after the fold there is no tie to break.
+			//
+			// Deliberately NOT applied to `class`: #6838 already made the class
+			// cohort reader-independent by folding permissions across it, and a
+			// merge here would fight that design.
+			userByName := map[string]*LoginUser{}
 			for _, userInst := range namedInstances(child.FindChildren("user")) {
-				user := &LoginUser{Name: userInst.name}
+				user := userByName[userInst.name]
+				if user == nil {
+					user = &LoginUser{Name: userInst.name}
+					userByName[userInst.name] = user
+					sys.Login.Users = append(sys.Login.Users, user)
+				}
+				// A later block's `authentication` section replaces the earlier
+				// block's key set wholesale rather than appending to it. That is
+				// what the runtime already does — applySystemLogin rewrites
+				// authorized_keys per entry with WriteFileDurable, so the last
+				// entry's keys are the ones on disk — so the fold preserves the
+				// provisioned key set exactly and removes only the divergence.
+				authoredAuth := false
+				for _, prop := range userInst.node.Children {
+					if prop.Name() == "authentication" {
+						authoredAuth = true
+						break
+					}
+				}
+				if authoredAuth {
+					user.SSHKeys = nil
+					user.EncryptedPassword = ""
+				}
 				for _, prop := range userInst.node.Children {
 					switch prop.Name() {
 					case "uid":
@@ -172,7 +222,6 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 						}
 					}
 				}
-				sys.Login.Users = append(sys.Login.Users, user)
 			}
 		case "backup-router":
 			if len(child.Keys) >= 2 {

--- a/pkg/config/dup_named_blocks.go
+++ b/pkg/config/dup_named_blocks.go
@@ -40,7 +40,7 @@ type dupBlock struct {
 // candidate authors the SAME named hierarchical block twice inside a container
 // whose compiler does whole-object last-writer-wins replacement — dropping the
 // earlier block's config silently (#5180, consolidating codex-177 A3-b2-F3 +
-// A3-b3-F1). Three containers are affected:
+// A3-b3-F1). Four containers are affected:
 //
 //   - groups { <name> { … } }  — expandGroups keeps only the last definition
 //     (ast_groups.go: groups[name] = g).
@@ -50,6 +50,12 @@ type dupBlock struct {
 //     Screen[profile.Name]; WITHIN one ids-option it also reads each
 //     icmp/ip/tcp/udp/limit-session family with FindChild (first sibling only),
 //     so a repeated family block is dropped too.
+//   - system { login { user <name> { … } } } — compileSystemLogin folds a
+//     duplicated name into ONE entry, per-leaf last-authored-wins (#6992), so
+//     the earlier block's uid / class / keys disappear. Before that fold the
+//     duplicate was WORSE than a drop: both blocks survived and two readers
+//     picked different ones, so an SSH key authored under a VIEW-only block
+//     could authenticate into a super-user CLI.
 //
 // This is a dual-AST-equivalence gate. Under flat `set` these statements MERGE:
 // tree.SetPath collapses `set interfaces ge-0/0/0 …` written twice onto ONE
@@ -194,6 +200,46 @@ func validateDuplicateNamedBlockAST(tree *ConfigTree, lenient bool) ([]string, e
 					} else {
 						famSeen[fn] = true
 					}
+				}
+			}
+		}
+	}
+
+	// 4. system { login { user <name> { … } } } — #6992. compileSystemLogin
+	// now folds a duplicated user name into ONE entry with per-leaf
+	// last-authored-wins (compiler_system.go), matching what the FLAT spelling
+	// already produces, so the container qualifies for this gate on the same
+	// terms as the three above: the earlier block's uid / class / keys
+	// disappear silently.
+	//
+	// Before that fold both blocks survived and two readers picked DIFFERENT
+	// ones — pkg/cli configuredClass takes the first block with a non-empty
+	// class, pkg/daemon applySystemLogin provisions from the last — so an SSH
+	// key authored under a VIEW-only block could authenticate into a
+	// super-user CLI. The fold removes the divergence; this gate is what stops
+	// the operator being silently held to whichever block the merge kept.
+	//
+	// Union across every top-level `system` stanza and every `login` block
+	// therein, matching the screen walk above.
+	seenUser := map[string]bool{}
+	reportedUser := map[string]bool{}
+	for _, child := range tree.Children {
+		if child.Name() != "system" {
+			continue
+		}
+		for _, login := range child.FindChildren("login") {
+			for _, inst := range namedInstances(login.FindChildren("user")) {
+				if inst.name == "" {
+					recordEmpty("login user")
+					continue
+				}
+				if seenUser[inst.name] {
+					if !reportedUser[inst.name] {
+						dups = append(dups, dupBlock{"login user", inst.name})
+						reportedUser[inst.name] = true
+					}
+				} else {
+					seenUser[inst.name] = true
 				}
 			}
 		}

--- a/pkg/config/duplicate_login_user_6992_test.go
+++ b/pkg/config/duplicate_login_user_6992_test.go
@@ -1,0 +1,349 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// #6992 — the same `system login user` name authored in two blocks left TWO
+// entries in Login.Users, and two readers picked DIFFERENT ones.
+//
+//	pkg/cli configuredClass      -> the FIRST block with a non-empty class
+//	pkg/daemon applySystemLogin  -> iterates every block in order, so the
+//	                                account state that lands (password,
+//	                                authorized_keys) comes from the LAST
+//
+// Measured on a config that commits CLEAN at strict, before this fix:
+//
+//	user alice { uid 2001; class admins; authentication { ssh-rsa "K1"; } }
+//	user alice { uid 2002; class ops;    authentication { ssh-rsa "K2"; } }
+//
+// compiled to two entries. applySystemLogin rewrites authorized_keys per entry
+// with WriteFileDurable, so K2 — the key the operator wrote under the VIEW-only
+// block — is the one on disk, while configuredClass answered `admins`. The
+// credential that authenticates and the class that authorizes it came from
+// different blocks, in the permissive direction.
+//
+// THE FIX IS A FOLD, NOT A MATCHED TIE-BREAK. compileSystemLogin now collapses a
+// duplicated name into ONE entry with per-leaf last-authored-wins, which is what
+// the FLAT spelling already produces (SetPath merges `set system login user
+// alice ...` written twice onto one node, replacing each leaf). That is the
+// #5180 dual-AST-equivalence property, and it is stronger than teaching one
+// reader the other's tie-break — the pattern #6838 warns is a proxy that rots
+// the day the other reader changes. After the fold there is no tie to break.
+//
+// The duplicate is ALSO rejected at strict commit, in the #5180 gate, because a
+// fold is still a silent drop of the earlier block's uid/class/keys. Flat merges
+// it in; hierarchical is told to author it once.
+
+const dupUserHier6992 = `
+system {
+    login {
+        class ops { permissions [ view ]; }
+        class admins { permissions [ all ]; }
+        user alice {
+            uid 2001;
+            class admins;
+            authentication { ssh-rsa "ssh-rsa AAAAB3FIRST alice@a"; }
+        }
+        user alice {
+            uid 2002;
+            class ops;
+            authentication { ssh-rsa "ssh-rsa AAAAB3SECOND alice@b"; }
+        }
+    }
+}
+`
+
+// dupUserFlat6992 is the SAME statements in the flat spelling. It is the oracle:
+// SetPath already merges them onto one node, so whatever it compiles to is what
+// the hierarchical shape must compile to.
+var dupUserFlat6992 = []string{
+	"set system login class ops permissions view",
+	"set system login class admins permissions all",
+	"set system login user alice uid 2001",
+	"set system login user alice class admins",
+	`set system login user alice authentication ssh-rsa "ssh-rsa AAAAB3FIRST alice@a"`,
+	"set system login user alice uid 2002",
+	"set system login user alice class ops",
+	`set system login user alice authentication ssh-rsa "ssh-rsa AAAAB3SECOND alice@b"`,
+}
+
+func hierTree6992(t *testing.T, text string) *ConfigTree {
+	t.Helper()
+	tree, errs := NewParser(text).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("fixture parse errors: %v", errs)
+	}
+	return tree
+}
+
+func flatTree6992(t *testing.T, lines []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, quoted, err := ParseSetCommandQuoted(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommandQuoted(%q): %v", line, err)
+		}
+		if err := tree.SetPathQuoted(path, quoted); err != nil {
+			t.Fatalf("SetPathQuoted(%q): %v", line, err)
+		}
+	}
+	return tree
+}
+
+func renderUsers6992(users []*LoginUser) string {
+	parts := make([]string, 0, len(users))
+	for _, u := range users {
+		parts = append(parts, fmt.Sprintf("{name=%s uid=%d class=%s pw=%q keys=%v}",
+			u.Name, u.UID, u.Class, string(u.EncryptedPassword), u.SSHKeys))
+	}
+	return strings.Join(parts, " ")
+}
+
+// TestDuplicateUserFoldsToOneEntry_6992 is the core property: after the fold no
+// two entries share a name, so no reader can pick a different one.
+//
+// It asserts the FIELD VALUES too, not just the count. A fold that produced one
+// entry with the wrong uid or class would satisfy a count-only assertion while
+// still provisioning an account the operator did not describe, and a count-based
+// guard is exactly the kind that goes vacuous.
+func TestDuplicateUserFoldsToOneEntry_6992(t *testing.T) {
+	cfg, err := CompileConfigLenient(hierTree6992(t, dupUserHier6992))
+	if err != nil {
+		t.Fatalf("tolerant compile: %v", err)
+	}
+	users := cfg.System.Login.Users
+	if len(users) != 1 {
+		t.Fatalf("duplicate `user alice` compiled to %d entries; two readers can then "+
+			"pick different ones: %s", len(users), renderUsers6992(users))
+	}
+	u := users[0]
+	if u.Name != "alice" {
+		t.Errorf("folded entry name = %q, want alice", u.Name)
+	}
+	if u.UID != 2002 {
+		t.Errorf("folded uid = %d, want 2002 (the LAST authored value, matching the flat spelling)", u.UID)
+	}
+	if u.Class != "ops" {
+		t.Errorf("folded class = %q, want ops (the LAST authored value)", u.Class)
+	}
+	if len(u.SSHKeys) != 1 || !strings.Contains(u.SSHKeys[0], "SECOND") {
+		t.Errorf("folded SSH keys = %v, want only the LAST block's key — that is the one "+
+			"applySystemLogin already writes to authorized_keys, so the fold must not "+
+			"change which credential is provisioned", u.SSHKeys)
+	}
+}
+
+// TestDuplicateUserFoldMatchesTheFlatSpelling_6992 is the dual-AST-equivalence
+// half, and it is what makes the fold's tie-break a derivation rather than a
+// choice: the flat spelling already merges these statements, so the
+// hierarchical one must land on the same config rather than on a third answer.
+func TestDuplicateUserFoldMatchesTheFlatSpelling_6992(t *testing.T) {
+	hierCfg, err := CompileConfigLenient(hierTree6992(t, dupUserHier6992))
+	if err != nil {
+		t.Fatalf("hierarchical compile: %v", err)
+	}
+	flatCfg, err := CompileConfigLenient(flatTree6992(t, dupUserFlat6992))
+	if err != nil {
+		t.Fatalf("flat compile: %v", err)
+	}
+
+	// Non-vacuity: the oracle must actually carry the values under test. A flat
+	// fixture that compiled to an empty user list would make the comparison
+	// below pass for the wrong reason.
+	if len(flatCfg.System.Login.Users) != 1 || flatCfg.System.Login.Users[0].Class == "" {
+		t.Fatalf("fixture bug: the flat oracle is not a single classed user: %s",
+			renderUsers6992(flatCfg.System.Login.Users))
+	}
+
+	if got, want := renderUsers6992(hierCfg.System.Login.Users), renderUsers6992(flatCfg.System.Login.Users); got != want {
+		t.Errorf("the two spellings of the same statements compile differently\n hier: %s\n flat: %s", got, want)
+	}
+}
+
+// TestClassAndCredentialComeFromTheSameBlock_6992 states the security property
+// directly rather than through the entry count, so it survives a refactor that
+// changes how the fold is implemented.
+//
+// The class a reader resolves for a name and the SSH key the daemon provisions
+// for that name must come from ONE entry. Pre-fix this failed: the first entry
+// carried `admins` and the second carried the key that reaches authorized_keys.
+func TestClassAndCredentialComeFromTheSameBlock_6992(t *testing.T) {
+	cfg, err := CompileConfigLenient(hierTree6992(t, dupUserHier6992))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	// firstClassed mirrors pkg/cli configuredClass: the first entry of this
+	// name with a non-empty class.
+	var firstClassed *LoginUser
+	// lastProvisioned mirrors pkg/daemon applySystemLogin: it iterates every
+	// entry in order and rewrites authorized_keys, so the last one wins.
+	var lastProvisioned *LoginUser
+	for _, u := range cfg.System.Login.Users {
+		if u == nil || u.Name != "alice" {
+			continue
+		}
+		if firstClassed == nil && u.Class != "" {
+			firstClassed = u
+		}
+		if len(u.SSHKeys) > 0 {
+			lastProvisioned = u
+		}
+	}
+	if firstClassed == nil || lastProvisioned == nil {
+		t.Fatalf("fixture bug: no classed entry (%v) or no key-bearing entry (%v)",
+			firstClassed != nil, lastProvisioned != nil)
+	}
+	if firstClassed != lastProvisioned {
+		t.Errorf("the class reader and the credential provisioner resolve DIFFERENT entries: "+
+			"class %q from one block, key %v from another — the key authored under one "+
+			"block authenticates into the other block's class",
+			firstClassed.Class, lastProvisioned.SSHKeys)
+	}
+}
+
+// TestDuplicateUserRejectedAtCommit_6992 pins the gate half. The fold makes the
+// outcome deterministic; it does not make the earlier block's uid/class/keys
+// stop disappearing, and a silent drop is what the #5180 gate exists to refuse.
+//
+// Both severities are asserted: strict rejects, tolerant warns and still boots
+// (#1960 no-brick). A test that only checked the reject would pass on a change
+// that made the tolerant load fail closed and brick an upgrading node.
+func TestDuplicateUserRejectedAtCommit_6992(t *testing.T) {
+	tree := hierTree6992(t, dupUserHier6992)
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("a duplicated `system login user` name committed CLEAN; the earlier " +
+			"block's uid, class and keys are silently dropped")
+	}
+	if !strings.Contains(err.Error(), "login user") || !strings.Contains(err.Error(), "alice") {
+		t.Fatalf("rejected, but NOT by the duplicate-login-user gate: %v", err)
+	}
+
+	cfg, lenientErr := CompileConfigLenient(tree)
+	if lenientErr != nil {
+		t.Fatalf("the tolerant load / peer-sync path must still boot (#1960): %v", lenientErr)
+	}
+	var warned bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "login user") && strings.Contains(w, "alice") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Errorf("the tolerant path dropped a block with NO warning; warnings were:\n%s",
+			strings.Join(cfg.Warnings, "\n"))
+	}
+}
+
+// TestDuplicateUserAcrossTwoLoginBlocks_6992 pins the UNION half of the gate's
+// walk. Both the compiler and the gate treat repeated `system` / `login`
+// stanzas as one stanza, so a name split across two `login` blocks is the same
+// duplicate — and it is the spelling an operator reaches by `load merge`-ing a
+// second file rather than by writing the name twice in one block.
+//
+// Without this fixture the walk could consult only the FIRST `login` block and
+// every other assertion in this file would still pass, because they all author
+// one block.
+func TestDuplicateUserAcrossTwoLoginBlocks_6992(t *testing.T) {
+	tree := hierTree6992(t, `
+system {
+    login {
+        class ops { permissions [ view ]; }
+        user alice { uid 2001; class admins; }
+    }
+    login {
+        user alice { uid 2002; class ops; }
+    }
+}
+`)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Errorf("a name duplicated ACROSS two `login` blocks committed clean")
+	} else if !strings.Contains(err.Error(), "login user") || !strings.Contains(err.Error(), "alice") {
+		t.Errorf("rejected by a different gate: %v", err)
+	}
+
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("tolerant compile: %v", err)
+	}
+	if len(cfg.System.Login.Users) != 1 {
+		t.Errorf("the fold did not span two `login` blocks: %s",
+			renderUsers6992(cfg.System.Login.Users))
+	}
+}
+
+// TestSingleUserBlockUnaffected_6992 is the green control. The fold and the gate
+// must be invisible to every config that authors a name once — which is every
+// real config — so a distinct-name fixture must compile unchanged and commit.
+func TestSingleUserBlockUnaffected_6992(t *testing.T) {
+	cfg, err := CompileConfig(hierTree6992(t, `
+system {
+    login {
+        class ops { permissions [ view ]; }
+        user alice { uid 2001; class ops; }
+        user bob   { uid 2002; class ops; }
+    }
+}
+`))
+	if err != nil {
+		t.Fatalf("distinct user names no longer commit: %v", err)
+	}
+	got := map[string]int{}
+	for _, u := range cfg.System.Login.Users {
+		got[u.Name] = u.UID
+	}
+	want := map[string]int{"alice": 2001, "bob": 2002}
+	if len(got) != len(want) {
+		t.Fatalf("compiled users = %s, want two distinct entries", renderUsers6992(cfg.System.Login.Users))
+	}
+	names := make([]string, 0, len(want))
+	for n := range want {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		if got[n] != want[n] {
+			t.Errorf("user %s uid = %d, want %d", n, got[n], want[n])
+		}
+	}
+}
+
+// TestPartialDuplicateInheritsUnauthoredLeaves_6992 pins the per-LEAF half of
+// the fold, which a "keep only the last block" implementation would get wrong.
+//
+// The second block authors only a class. The uid from the first block must
+// survive, because that is what the flat spelling gives — SetPath replaces the
+// leaves a later statement authors and leaves the others in place. Folding to
+// the last BLOCK instead of the last LEAF would silently zero the uid.
+func TestPartialDuplicateInheritsUnauthoredLeaves_6992(t *testing.T) {
+	cfg, err := CompileConfigLenient(hierTree6992(t, `
+system {
+    login {
+        class ops { permissions [ view ]; }
+        user alice { uid 2001; class admins; }
+        user alice { class ops; }
+    }
+}
+`))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if len(cfg.System.Login.Users) != 1 {
+		t.Fatalf("want one folded entry, got %s", renderUsers6992(cfg.System.Login.Users))
+	}
+	u := cfg.System.Login.Users[0]
+	if u.UID != 2001 {
+		t.Errorf("uid = %d, want 2001 — the second block authored no uid, so the first "+
+			"block's value must survive (per-LEAF last-authored-wins, not last-block-wins)", u.UID)
+	}
+	if u.Class != "ops" {
+		t.Errorf("class = %q, want ops (the second block authored it)", u.Class)
+	}
+}


### PR DESCRIPTION
Closes #6992

## Driven to a runtime conclusion, as the issue asked

The issue says explicitly: *"This was **not** driven to a runtime conclusion — someone taking this should first establish whether the divergence is reachable with a strictly-committable config and what the observable consequence is."*

**It is reachable, it commits CLEAN at strict, and it fails OPEN.**

```
user alice { uid 2001; class admins; authentication { ssh-rsa "K1"; } }
user alice { uid 2002; class ops;    authentication { ssh-rsa "K2"; } }
```

compiles to **two** entries with `err == nil` on the strict commit path. Then:

| reader | picks | result |
|---|---|---|
| `configuredClass` (`pkg/cli/identity.go`) | the FIRST block with a non-empty class | **admins** |
| `applySystemLogin` (`pkg/daemon/daemon_system.go`) | every block in order; `authorized_keys` is rewritten per entry with `WriteFileDurable` | **K2** |

So **K2 — the key the operator wrote under the VIEW-only block — is the one on disk, and it authenticates into `admins`.** The credential that authenticates and the class that authorizes it come from different blocks, in the permissive direction. Reverse the block order and the escalation reverses with it; either way the two are sourced independently.

This is the **third instance of the class in this area**: #6861 keyed an advisory on a name the runtime resolved differently, #6838 keyed a fold on a class name the runtime picked differently.

## The fix is a fold, and the tie-break is derived rather than chosen

Both prior fixes established the pattern the issue restates: make the outcome **independent of which reader picks**, not teach one reader the other's tie-break — *"a proxy that rots the day the other reader changes."*

This applies it in its strongest form. `compileSystemLogin` collapses a duplicated name into **one** entry, so **there is no tie left to break at all**.

And the merge rule is not a judgement call: **the flat spelling already merges these statements.** `SetPath` collapses `set system login user alice …` written twice onto one node and replaces each leaf, so folding makes the two AST shapes agree rather than inventing a third answer. That is the #5180 dual-AST-equivalence property, and it is what `TestDuplicateUserFoldMatchesTheFlatSpelling_6992` asserts against the flat compile as the oracle.

Two details that a coarser implementation gets wrong:

- **Per LEAF, not per block.** A second block authoring only a `class` must leave the first block's `uid` in place — that is what the flat spelling gives. Folding to the last *block* would silently zero it. Pinned by `TestPartialDuplicateInheritsUnauthoredLeaves_6992`.
- **`authentication` is the one wholesale replacement**, chosen so the fold **preserves the provisioned state exactly**: `authorized_keys` is already rewritten per entry, so the last entry's keys are already the ones on disk. The fold therefore changes what the CLI *authorizes*, not what the daemon *installs*.

## The gate is the second half, not an extra

A fold is still a **silent drop** of the earlier block's uid / class / keys, and refusing a silent drop is exactly what the #5180 duplicate-named-block gate exists for — *"the flat shape merges it in, the hierarchical shape is told to author it once."* `system login user` is now its fourth container, which also gets it the pre-expansion walk, the `lenientDuplicateNamedBlock` plumbing, and the post-expansion re-run (`validateDuplicateNamesExpandedAST`, #6455) for free.

Strict rejects; the tolerant load / peer-sync path warns and boots (#1960 no-brick). **Both severities are asserted** — a test that only checked the reject would pass on a change that made the tolerant load fail closed and brick an upgrading node.

## Deliberately NOT applied to `system login class`

#6838 already made the class cohort reader-independent by folding permissions across the whole same-named set. A merge here would fight that design, so `class` is left alone.

## Validation

Full `go test ./... -count=1` green.

The tests pin the folded entry's **field values**, not the entry count — a fold that produced one entry with the wrong uid or class would satisfy a count-only assertion while provisioning an account the operator did not describe, and a count-based guard is exactly the kind that goes vacuous. The security property is also stated **directly**: the entry a class reader resolves and the entry whose SSH key the daemon provisions must be the SAME entry, which survives a refactor of how the fold is implemented.

### Mutation matrix

Each cell is one line, applied by a script that asserts the anchor occurs exactly once, run on a **compiling** tree, restored from git between cells.

| # | mutation | `_6992` | login/5180/6838/6662 |
|---|---|---|---|
| C1 | never reuse an entry (append always — the pre-fix behaviour) | RED | green |
| C2 | fold keeps the FIRST block's class *(tightening)* | RED | green |
| C3 | `authentication` accumulates across blocks instead of replacing | RED | green |
| C4 | the duplicate gate never reports | RED | green |
| C5 | the gate walks only the FIRST `login` block | RED | RED |

**C5 was green on the first run**, and the cause is the now-familiar one: every fixture in the file authored a single `login` block, so "union across every `login` block" was untestable. A name split across two `login` blocks is not a contrived spelling — it is what an operator reaches by `load merge`-ing a second file — and it is now a fixture. Note C5 also reds the neighbouring suite once covered, which is the signal that the union property was load-bearing for the existing gate too.

## Not in scope

No Rust, no compiled artifact, no protocol change — no cluster smoke is owed.

## Docs

`docs/config-schema.md` gains a "Duplicate `system login user` name (#6992)" section beside its #5649 / #5180 siblings, with the measured escalation, the flat-spelling oracle, the per-leaf rule, the `authentication` exception and its reason, and why `class` is excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdWuT1UffSkr1spw8sjNTE
