### PR TITLE
config: model the screen subtree and expand its packed spellings

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103221,3 +103221,14 @@ prose edit above them added. No diff falls in the new test body.
   - **File(s)**: pkg/config/compact_tail.go, pkg/config/compiler_system.go,
     pkg/config/compiler_firewall.go,
     pkg/config/compact_tail_6684_6685_test.go, docs/config-schema.md
+
+- **Timestamp**: 2026-08-22
+  - **Action**: #6683/#7460 — modelled the whole screen subtree in setSchema and
+    routed the screen compiler through the packed-body expander at both the
+    ids-option and family-option levels. Single-sourced the four sub-knob
+    readers onto the child shape (flood was the odd one out) and armed
+    recordChildExtras on every modelled leaf.
+  - **File(s)**: pkg/config/schema_security.go,
+    pkg/config/compiler_security_screen.go,
+    pkg/config/screen_packed_body_6683_test.go,
+    pkg/config/schema_spelling_differential_gate_test.go, docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -56,11 +56,34 @@ A tail that leaves the modelled grammar is returned UNEXPANDED rather than
 guessed — the helper exists to stop configuration being silently dropped, and
 inventing a shape the schema does not describe is another way of doing that.
 
-**A stanza whose leaves are not modelled in `setSchema` cannot be fixed this
-way.** `security screen ids-option <p> icmp` models only `fragment`, so the
-screen checks are absent from the schema and the packed screen body (#6683)
-cannot be expanded until they are added — which is also why those leaves get no
-`?` completion and no `SchemaValidate` typed-leaf checking.
+**A stanza whose leaves are not modelled in `setSchema` cannot be expanded**,
+because an unmodelled keyword cannot be resolved and the expander declines
+rather than guessing. That was the blocker on #6683: `security screen ids-option
+<p> icmp` modelled only `fragment`. The screen subtree is now modelled in full
+(#6683/#7460) — every check flag plus every sub-knob — which also gives those
+leaves `?` completion and `SchemaValidate` reach that they never had.
+
+Modelling a subtree is not free, and the screen case is the worked example of
+what else has to move with it:
+
+- **Sub-knob children are load-bearing, not decoration.** `flood` modelled as a
+  bare flag makes the expander stop at `[flood]` and silently DROP a trailing
+  `threshold 500` — the same silent weakening the issues are about. Model the
+  value, or do not model the parent.
+- **Modelling changes flat-set token grouping.** `ast_edit.go` keys on
+  `args`/`children`/`compoundKey`/`multi`, so a value that used to collapse onto
+  `Keys` now parks as a CHILD. Any compiler reading a fixed `Keys` index for
+  that value breaks on a path that worked. `flood` read `Keys[2]` while its
+  siblings read `Children`; single-sourcing all four onto the child shape is
+  what made the change safe (#7460).
+- **It moves trailing-garbage detection from `Keys` to `Children`.** A modelled
+  childless leaf parks flat-set trailing tokens as children, so a compiler
+  calling only `recordKeyExtras` stops seeing them and the #3332/#3318 gate goes
+  quiet. Arm `recordChildExtras` on every leaf you model.
+- **It can add entries to the #2419 spelling-differential gate.** Ten bare flags
+  legitimately name a different garbage token per spelling. Allowlisting that is
+  a CLAIM, so it is paired with a test asserting the commit decision is REJECT
+  in BOTH spellings — otherwise the allowlist would hide a fail-open.
 
 ### Where it is NOT done
 

--- a/pkg/config/compiler_security_screen.go
+++ b/pkg/config/compiler_security_screen.go
@@ -244,10 +244,37 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 			}
 		}
 
+		// #6683: `ids-option s1 icmp ping-death;` packs the WHOLE body onto
+		// the ids-option node's Keys, leaving Children empty — every check in
+		// the profile compiled DISABLED while the profile itself survived and
+		// bound to a zone normally, so the operator got no protection from a
+		// check they configured and nothing said so.
+		idsSchema := schemaForPath("security", "screen", "ids-option")
+		body := packedBody(inst.node, idsSchema)
+
+		// screenOpt normalises ONE family-option node so a sub-knob written
+		// packed (`flood threshold 500;`) is read from the same CHILD shape as
+		// the block spelling (`flood { threshold 500; }`). #7460: the two
+		// spellings were read by two different readers — ip-sweep/port-scan/
+		// syn-flood iterated Children and never saw the packed form, so the
+		// configured threshold was silently replaced by the default.
+		screenOpt := func(famSchema *schemaNode, n *Node) *Node {
+			if famSchema == nil || n == nil || len(n.Keys) == 0 {
+				return n
+			}
+			return packedBody(n, resolveSchemaChild(famSchema, n.Keys[0]))
+		}
+		famSchema := func(fam string) *schemaNode {
+			if idsSchema == nil {
+				return nil
+			}
+			return resolveSchemaChild(idsSchema, fam)
+		}
+
 		// #3318: the screen schema subtrees are open. Record any unknown/
 		// unsupported top-level screen family so validateScreenUnknownStrict can
 		// reject the commit fail-closed instead of silently dropping it.
-		for _, fam := range inst.node.Children {
+		for _, fam := range body.Children {
 			switch fam.Name() {
 			case "icmp", "ip", "tcp", "udp", "limit-session":
 				// handled below
@@ -270,19 +297,45 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 			}
 		}
 
-		icmpNode := inst.node.FindChild("icmp")
+		icmpNode := body.FindChild("icmp")
 		if icmpNode != nil {
-			for _, opt := range icmpNode.Children {
+			icmpSchema := famSchema("icmp")
+			for _, rawOpt := range icmpNode.Children {
+				opt := screenOpt(icmpSchema, rawOpt)
 				switch opt.Name() {
 				case "ping-death":
 					profile.ICMP.PingDeath = true
 					recordKeyExtras("icmp ping-death", opt, 1)
+					recordChildExtras("icmp ping-death", opt)
 				case "fragment":
 					profile.ICMP.Fragment = true
 					recordKeyExtras("icmp fragment", opt, 1)
+					recordChildExtras("icmp fragment", opt)
 				case "flood":
 					recordKeyExtras("icmp flood", opt, 3)
-					if n, ok := parseThresh("icmp flood", numVal(opt, 2)); ok {
+					// #7460: read the threshold from the CHILD shape too, which
+					// is what the expander normalises the packed spelling into
+					// and what ip-sweep / port-scan / syn-flood already read.
+					// Before this, `flood` was the ONLY sub-knob reading Keys,
+					// so it accepted the spelling its siblings rejected and
+					// rejected the one they accepted.
+					floodVal := ""
+					if len(opt.Keys) > 2 {
+						floodVal = opt.Keys[2]
+					}
+					for _, fOpt := range opt.Children {
+						if fOpt.Name() != "threshold" {
+							profile.UnknownLeaves = append(profile.UnknownLeaves, "icmp flood "+fOpt.Name())
+							continue
+						}
+						recordKeyExtras("icmp flood threshold", fOpt, 2)
+						// Prefix is the FLOOD path, not the threshold path: a
+						// trailing token after the value is garbage on `icmp flood`,
+						// and that is the leaf name the #3332 gate reports.
+						recordChildExtras("icmp flood", fOpt)
+						floodVal = numVal(fOpt, 1)
+					}
+					if n, ok := parseThresh("icmp flood", floodVal); ok {
 						profile.ICMP.FloodThreshold = n
 					}
 					// icmp flood enabled without an explicit threshold: arm at
@@ -297,21 +350,26 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 			}
 		}
 
-		ipNode := inst.node.FindChild("ip")
+		ipNode := body.FindChild("ip")
 		if ipNode != nil {
-			for _, opt := range ipNode.Children {
+			ipSchema := famSchema("ip")
+			for _, rawOpt := range ipNode.Children {
+				opt := screenOpt(ipSchema, rawOpt)
 				switch opt.Name() {
 				case "source-route-option":
 					profile.IP.SourceRouteOption = true
 					recordKeyExtras("ip source-route-option", opt, 1)
+					recordChildExtras("ip source-route-option", opt)
 				case "tear-drop":
 					profile.IP.TearDrop = true
 					recordKeyExtras("ip tear-drop", opt, 1)
+					recordChildExtras("ip tear-drop", opt)
 				case "ip-sweep":
 					for _, swOpt := range opt.Children {
 						switch swOpt.Name() {
 						case "threshold":
 							recordKeyExtras("ip ip-sweep threshold", swOpt, 2)
+							recordChildExtras("ip ip-sweep threshold", swOpt)
 							if n, ok := parseThresh("ip ip-sweep threshold", numVal(swOpt, 1)); ok {
 								profile.IP.IPSweepThreshold = n
 							}
@@ -332,28 +390,36 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 			}
 		}
 
-		tcpNode := inst.node.FindChild("tcp")
+		tcpNode := body.FindChild("tcp")
 		if tcpNode != nil {
-			for _, opt := range tcpNode.Children {
+			tcpSchema := famSchema("tcp")
+			for _, rawOpt := range tcpNode.Children {
+				opt := screenOpt(tcpSchema, rawOpt)
 				switch opt.Name() {
 				case "land":
 					profile.TCP.Land = true
 					recordKeyExtras("tcp land", opt, 1)
+					recordChildExtras("tcp land", opt)
 				case "winnuke":
 					profile.TCP.WinNuke = true
 					recordKeyExtras("tcp winnuke", opt, 1)
+					recordChildExtras("tcp winnuke", opt)
 				case "syn-frag":
 					profile.TCP.SynFrag = true
 					recordKeyExtras("tcp syn-frag", opt, 1)
+					recordChildExtras("tcp syn-frag", opt)
 				case "syn-fin":
 					profile.TCP.SynFin = true
 					recordKeyExtras("tcp syn-fin", opt, 1)
+					recordChildExtras("tcp syn-fin", opt)
 				case "no-flag":
 					profile.TCP.NoFlag = true
 					recordKeyExtras("tcp no-flag", opt, 1)
+					recordChildExtras("tcp no-flag", opt)
 				case "fin-no-ack":
 					profile.TCP.FinNoAck = true
 					recordKeyExtras("tcp fin-no-ack", opt, 1)
+					recordChildExtras("tcp fin-no-ack", opt)
 				case "syn-flood":
 					sf := &SynFloodConfig{}
 					for _, sfOpt := range opt.Children {
@@ -361,26 +427,31 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 						switch sfOpt.Name() {
 						case "alarm-threshold":
 							recordKeyExtras("tcp syn-flood alarm-threshold", sfOpt, 2)
+							recordChildExtras("tcp syn-flood alarm-threshold", sfOpt)
 							if n, ok := parseThresh("tcp syn-flood alarm-threshold", val); ok {
 								sf.AlarmThreshold = n
 							}
 						case "attack-threshold":
 							recordKeyExtras("tcp syn-flood attack-threshold", sfOpt, 2)
+							recordChildExtras("tcp syn-flood attack-threshold", sfOpt)
 							if n, ok := parseThresh("tcp syn-flood attack-threshold", val); ok {
 								sf.AttackThreshold = n
 							}
 						case "source-threshold":
 							recordKeyExtras("tcp syn-flood source-threshold", sfOpt, 2)
+							recordChildExtras("tcp syn-flood source-threshold", sfOpt)
 							if n, ok := parseThresh("tcp syn-flood source-threshold", val); ok {
 								sf.SourceThreshold = n
 							}
 						case "destination-threshold":
 							recordKeyExtras("tcp syn-flood destination-threshold", sfOpt, 2)
+							recordChildExtras("tcp syn-flood destination-threshold", sfOpt)
 							if n, ok := parseThresh("tcp syn-flood destination-threshold", val); ok {
 								sf.DestinationThreshold = n
 							}
 						case "timeout":
 							recordKeyExtras("tcp syn-flood timeout", sfOpt, 2)
+							recordChildExtras("tcp syn-flood timeout", sfOpt)
 							if n, ok := parseThresh("tcp syn-flood timeout", val); ok {
 								sf.Timeout = n
 							}
@@ -404,6 +475,7 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 						switch psOpt.Name() {
 						case "threshold":
 							recordKeyExtras("tcp port-scan threshold", psOpt, 2)
+							recordChildExtras("tcp port-scan threshold", psOpt)
 							if n, ok := parseThresh("tcp port-scan threshold", numVal(psOpt, 1)); ok {
 								profile.TCP.PortScanThreshold = n
 							}
@@ -424,13 +496,37 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 			}
 		}
 
-		udpNode := inst.node.FindChild("udp")
+		udpNode := body.FindChild("udp")
 		if udpNode != nil {
-			for _, opt := range udpNode.Children {
+			udpSchema := famSchema("udp")
+			for _, rawOpt := range udpNode.Children {
+				opt := screenOpt(udpSchema, rawOpt)
 				switch opt.Name() {
 				case "flood":
 					recordKeyExtras("udp flood", opt, 3)
-					if n, ok := parseThresh("udp flood", numVal(opt, 2)); ok {
+					// #7460: read the threshold from the CHILD shape too, which
+					// is what the expander normalises the packed spelling into
+					// and what ip-sweep / port-scan / syn-flood already read.
+					// Before this, `flood` was the ONLY sub-knob reading Keys,
+					// so it accepted the spelling its siblings rejected and
+					// rejected the one they accepted.
+					floodVal := ""
+					if len(opt.Keys) > 2 {
+						floodVal = opt.Keys[2]
+					}
+					for _, fOpt := range opt.Children {
+						if fOpt.Name() != "threshold" {
+							profile.UnknownLeaves = append(profile.UnknownLeaves, "udp flood "+fOpt.Name())
+							continue
+						}
+						recordKeyExtras("udp flood threshold", fOpt, 2)
+						// Prefix is the FLOOD path, not the threshold path: a
+						// trailing token after the value is garbage on `udp flood`,
+						// and that is the leaf name the #3332 gate reports.
+						recordChildExtras("udp flood", fOpt)
+						floodVal = numVal(fOpt, 1)
+					}
+					if n, ok := parseThresh("udp flood", floodVal); ok {
 						profile.UDP.FloodThreshold = n
 					}
 					// udp flood enabled without an explicit threshold: arm at
@@ -445,19 +541,23 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 			}
 		}
 
-		limitNode := inst.node.FindChild("limit-session")
+		limitNode := body.FindChild("limit-session")
 		if limitNode != nil {
-			for _, opt := range limitNode.Children {
+			limitsessionSchema := famSchema("limit-session")
+			for _, rawOpt := range limitNode.Children {
+				opt := screenOpt(limitsessionSchema, rawOpt)
 				val := numVal(opt, 1)
 				switch opt.Name() {
 				case "source-ip-based":
 					recordKeyExtras("limit-session source-ip-based", opt, 2)
+					recordChildExtras("limit-session source-ip-based", opt)
 					recordChildExtras("limit-session source-ip-based", opt)
 					if n, ok := parseThresh("limit-session source-ip-based", val); ok {
 						profile.LimitSession.SourceIPBased = n
 					}
 				case "destination-ip-based":
 					recordKeyExtras("limit-session destination-ip-based", opt, 2)
+					recordChildExtras("limit-session destination-ip-based", opt)
 					recordChildExtras("limit-session destination-ip-based", opt)
 					if n, ok := parseThresh("limit-session destination-ip-based", val); ok {
 						profile.LimitSession.DestinationIPBased = n

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -318,18 +318,52 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 				// opt-in; schema_walk.go), so `icmp framgent` is not caught
 				// here. Unknown-screen-leaf rejection is the separate #3318.
 				"fragment": {desc: "Drop fragmented ICMP/ICMPv6 packets", children: nil},
-				// ping-death, flood -> leaf
+				// #6683/#7460: every check and every sub-knob is modelled so
+				// the schema-driven expander (compact_tail.go) can normalise
+				// the PACKED spellings into the nested shape. An unmodelled
+				// keyword cannot be resolved, and the body was silently
+				// dropped -- the check compiled DISABLED (#6683) or armed at a
+				// default instead of the configured threshold (#7460).
+				//
+				// The sub-knob children are load-bearing, not decoration: as a
+				// bare flag the expander would stop at `[flood]` and DROP a
+				// trailing `threshold 500`, which is the same silent weakening
+				// these issues are about.
+				"ping-death": {desc: "Drop oversized ICMP (ping of death)", children: nil},
+				"flood": {desc: "ICMP flood protection", children: map[string]*schemaNode{
+					"threshold": {desc: "Detection threshold", args: 1, placeholder: "<number>", children: nil},
+				}},
 			}},
 			"tcp": {desc: "TCP screening", children: map[string]*schemaNode{
-				"syn-flood": {desc: "SYN flood protection", children: nil},
-				"port-scan": {desc: "Port scan protection", children: nil},
-				// land, winnuke, syn-frag -> leaf
+				"syn-flood": {desc: "SYN flood protection", children: map[string]*schemaNode{
+					"alarm-threshold":       {desc: "Detection threshold", args: 1, placeholder: "<number>", children: nil},
+					"attack-threshold":      {desc: "Detection threshold", args: 1, placeholder: "<number>", children: nil},
+					"source-threshold":      {desc: "Detection threshold", args: 1, placeholder: "<number>", children: nil},
+					"destination-threshold": {desc: "Detection threshold", args: 1, placeholder: "<number>", children: nil},
+					"timeout":               {desc: "Detection threshold", args: 1, placeholder: "<number>", children: nil},
+				}},
+				"port-scan": {desc: "Port scan protection", children: map[string]*schemaNode{
+					"threshold": {desc: "Detection threshold", args: 1, placeholder: "<number>", children: nil},
+				}},
+				"land":       {desc: "Drop LAND attack (src == dst)", children: nil},
+				"winnuke":    {desc: "Drop WinNuke (OOB to NetBIOS)", children: nil},
+				"syn-frag":   {desc: "Drop fragmented SYN", children: nil},
+				"syn-fin":    {desc: "Drop SYN+FIN", children: nil},
+				"no-flag":    {desc: "Drop TCP with no flags set", children: nil},
+				"fin-no-ack": {desc: "Drop FIN without ACK", children: nil},
 			}},
 			"ip": {desc: "IP screening", children: map[string]*schemaNode{
-				"ip-sweep": {desc: "IP sweep protection", children: nil},
-				// source-route-option, tear-drop -> leaf
+				"ip-sweep": {desc: "IP sweep protection", children: map[string]*schemaNode{
+					"threshold": {desc: "Detection threshold", args: 1, placeholder: "<number>", children: nil},
+				}},
+				"source-route-option": {desc: "Drop IP source-route option", children: nil},
+				"tear-drop":           {desc: "Drop teardrop (overlapping fragments)", children: nil},
 			}},
-			"udp": {desc: "UDP screening", children: nil},
+			"udp": {desc: "UDP screening", children: map[string]*schemaNode{
+				"flood": {desc: "UDP flood protection", children: map[string]*schemaNode{
+					"threshold": {desc: "Detection threshold", args: 1, placeholder: "<number>", children: nil},
+				}},
+			}},
 			"limit-session": {desc: "Session limits", children: map[string]*schemaNode{
 				"source-ip-based":      {desc: "Source IP based limit", args: 1, placeholder: "<number>", children: nil},
 				"destination-ip-based": {desc: "Destination IP based limit", args: 1, placeholder: "<number>", children: nil},

--- a/pkg/config/schema_spelling_differential_gate_test.go
+++ b/pkg/config/schema_spelling_differential_gate_test.go
@@ -233,10 +233,34 @@ var notAValueList = map[string]string{
 	"firewall family inet6 filter <*> term <*> then reject": "action plus ONE optional reason token; extras land in UnknownActions",
 
 	"security screen ids-option <*> alarm-without-drop": "bare flag; trailing tokens land in UnknownLeaves",
-	"security screen ids-option <*> ip ip-sweep":        "container with sub-knobs (`ip-sweep { threshold N; }`)",
-	"security screen ids-option <*> tcp port-scan":      "container with sub-knobs",
-	"security screen ids-option <*> tcp syn-flood":      "container with sub-knobs",
-	"security screen ids-option <*> udp":                "container with sub-knobs",
+
+	// #6683: the screen check flags are modelled in setSchema so the packed
+	// stanza body can be expanded (compact_tail.go). They are BARE FLAGS, so a
+	// "two-element value list" is not a shape they have; what diverges is only
+	// WHICH garbage token gets named. In flat-set a trailing token parks as a
+	// CHILD and recordChildExtras names Keys[0] of each child; hierarchically it
+	// stays on Keys and recordKeyExtras names every one.
+	//
+	// That difference does NOT reach the commit decision, which is what this
+	// gate is protecting. Verified rather than assumed:
+	// TestScreenBareFlagTrailingTokenRejectsInBothSpellings compiles trailing
+	// garbage on every one of these ten in BOTH spellings and asserts both are
+	// REJECTED. If that ever stops holding, these entries are hiding a
+	// fail-open and that test reds rather than this allowlist growing quietly.
+	"security screen ids-option <*> icmp fragment":          "bare flag; trailing tokens land in UnknownLeaves (#6683)",
+	"security screen ids-option <*> icmp ping-death":        "bare flag; trailing tokens land in UnknownLeaves (#6683)",
+	"security screen ids-option <*> ip source-route-option": "bare flag; trailing tokens land in UnknownLeaves (#6683)",
+	"security screen ids-option <*> ip tear-drop":           "bare flag; trailing tokens land in UnknownLeaves (#6683)",
+	"security screen ids-option <*> tcp fin-no-ack":         "bare flag; trailing tokens land in UnknownLeaves (#6683)",
+	"security screen ids-option <*> tcp land":               "bare flag; trailing tokens land in UnknownLeaves (#6683)",
+	"security screen ids-option <*> tcp no-flag":            "bare flag; trailing tokens land in UnknownLeaves (#6683)",
+	"security screen ids-option <*> tcp syn-fin":            "bare flag; trailing tokens land in UnknownLeaves (#6683)",
+	"security screen ids-option <*> tcp syn-frag":           "bare flag; trailing tokens land in UnknownLeaves (#6683)",
+	"security screen ids-option <*> tcp winnuke":            "bare flag; trailing tokens land in UnknownLeaves (#6683)",
+	"security screen ids-option <*> ip ip-sweep":            "container with sub-knobs (`ip-sweep { threshold N; }`)",
+	"security screen ids-option <*> tcp port-scan":          "container with sub-knobs",
+	"security screen ids-option <*> tcp syn-flood":          "container with sub-knobs",
+	"security screen ids-option <*> udp":                    "container with sub-knobs",
 
 	// #6688 fixed the value drop here and its own reader states the
 	// classification in as many words: "`port range` is not a value list — it

--- a/pkg/config/screen_packed_body_6683_test.go
+++ b/pkg/config/screen_packed_body_6683_test.go
@@ -1,0 +1,181 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// #6683 / #7460: a screen stanza written PACKED must compile identically to the
+// same stanza written NESTED.
+//
+// Both defects were silent and both left the profile LOOKING configured:
+// #6683 packed the whole body onto the ids-option node's Keys so every check
+// compiled DISABLED, and #7460 packed a sub-knob onto its check's Keys so the
+// check armed at the DEFAULT threshold instead of the configured one. In both
+// cases `show configuration` displays what the operator wrote and the profile
+// binds to a zone normally.
+
+func screenProfile6683(t *testing.T, src string) (*ScreenProfile, error) {
+	t.Helper()
+	tree, perrs := NewParser(src).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse %q: %v", src, perrs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		return nil, err
+	}
+	for _, s := range cfg.Security.Screen {
+		return s, nil
+	}
+	return nil, nil
+}
+
+// screenBoolFlags6683 is every boolean check the screen compiler recognises,
+// enumerated rather than sampled: #6683 explicitly warns that a fix closing
+// only the `ping-death` it names leaves the same fail-open on the siblings.
+var screenBoolFlags6683 = []struct{ fam, leaf string }{
+	{"icmp", "ping-death"}, {"icmp", "fragment"},
+	{"ip", "source-route-option"}, {"ip", "tear-drop"},
+	{"tcp", "land"}, {"tcp", "winnuke"}, {"tcp", "syn-frag"},
+	{"tcp", "syn-fin"}, {"tcp", "no-flag"}, {"tcp", "fin-no-ack"},
+}
+
+func TestScreenPackedBodyMatchesNested_6683(t *testing.T) {
+	for _, f := range screenBoolFlags6683 {
+		t.Run(f.fam+"-"+f.leaf, func(t *testing.T) {
+			nested, err := screenProfile6683(t,
+				`security { screen { ids-option s1 { `+f.fam+` { `+f.leaf+`; } } } }`)
+			if err != nil {
+				t.Fatalf("nested spelling failed to compile: %v", err)
+			}
+			packed, err := screenProfile6683(t,
+				`security { screen { ids-option s1 `+f.fam+` `+f.leaf+`; } }`)
+			if err != nil {
+				t.Fatalf("packed spelling failed to compile: %v", err)
+			}
+
+			// Anti-vacuity: the nested spelling must actually enable
+			// something. Two all-false profiles compare equal, and that is
+			// exactly the bug passing as a green.
+			if reflect.DeepEqual(*nested, ScreenProfile{Name: nested.Name}) {
+				t.Fatalf("the nested spelling enabled nothing — the fixture cannot detect the defect")
+			}
+			if !reflect.DeepEqual(nested, packed) {
+				t.Errorf("packed body compiled differently from nested (#6683)\n nested = %+v\n packed = %+v",
+					*nested, *packed)
+			}
+		})
+	}
+}
+
+// TestScreenSubKnobSpellingsAgree_7460 covers the THRESHOLD axis.
+//
+// Every value here is deliberately distinct from the check's default. An
+// earlier probe using `threshold 5000` reported a false green because 5000 IS
+// the ip-sweep/port-scan default: the bug substitutes the default, so a fixture
+// that happens to configure the default cannot see it.
+func TestScreenSubKnobSpellingsAgree_7460(t *testing.T) {
+	cases := []struct {
+		name, fam, knob string
+		get             func(*ScreenProfile) int
+		def             int
+	}{
+		{"ip-sweep threshold", "ip", "ip-sweep threshold 7777",
+			func(s *ScreenProfile) int { return s.IP.IPSweepThreshold }, defaultIPSweepThreshold},
+		{"port-scan threshold", "tcp", "port-scan threshold 4444",
+			func(s *ScreenProfile) int { return s.TCP.PortScanThreshold }, defaultPortScanThreshold},
+		{"icmp flood threshold", "icmp", "flood threshold 3333",
+			func(s *ScreenProfile) int { return s.ICMP.FloodThreshold }, defaultICMPFloodThreshold},
+		{"udp flood threshold", "udp", "flood threshold 2222",
+			func(s *ScreenProfile) int { return s.UDP.FloodThreshold }, defaultUDPFloodThreshold},
+		{"syn-flood attack-threshold", "tcp", "syn-flood attack-threshold 999",
+			func(s *ScreenProfile) int { return synFloodAttack7460(s) }, defaultSynFloodAttackThreshold},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			knob, rest := splitFirst7460(tc.knob)
+			want := lastToken7460(rest)
+
+			leafSrc := `security { screen { ids-option s1 { ` + tc.fam + ` { ` + tc.knob + `; } } } }`
+			blockSrc := `security { screen { ids-option s1 { ` + tc.fam + ` { ` + knob + ` { ` + rest + `; } } } } }`
+			packedSrc := `security { screen { ids-option s1 ` + tc.fam + ` ` + tc.knob + `; } }`
+
+			for _, s := range []struct{ label, src string }{
+				{"leaf", leafSrc}, {"block", blockSrc}, {"packed", packedSrc},
+			} {
+				prof, err := screenProfile6683(t, s.src)
+				if err != nil {
+					t.Fatalf("%s spelling failed to compile: %v", s.label, err)
+				}
+				got := tc.get(prof)
+				if got == tc.def && want != tc.def {
+					t.Errorf("%s spelling armed the check at the DEFAULT %d instead of the configured %d — "+
+						"the configured threshold was silently discarded (#7460)", s.label, tc.def, want)
+					continue
+				}
+				if got != want {
+					t.Errorf("%s spelling compiled %d, want %d", s.label, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestScreenBareFlagTrailingTokenRejectsInBothSpellings is what makes the ten
+// new entries in the #2419 spelling-differential allowlist honest.
+//
+// Those entries record that the two spellings name a DIFFERENT garbage token
+// when a bare flag carries trailing junk — flat-set parks it as a child and
+// recordChildExtras names Keys[0] of each child, hierarchically it stays on
+// Keys and recordKeyExtras names every one. An allowlist entry asserting that
+// difference is harmless is a CLAIM, and this is its proof: the commit decision
+// must be REJECT in both spellings. If that ever stops holding, the allowlist
+// is hiding a fail-open and this reds instead of the gate going quiet.
+func TestScreenBareFlagTrailingTokenRejectsInBothSpellings(t *testing.T) {
+	for _, f := range screenBoolFlags6683 {
+		t.Run(f.fam+"-"+f.leaf, func(t *testing.T) {
+			if _, err := compileSet(t, []string{
+				"set security screen ids-option bad " + f.fam + " " + f.leaf + " bogus",
+			}); err == nil {
+				t.Errorf("flat-set spelling ACCEPTED trailing garbage on the bare flag %s %s", f.fam, f.leaf)
+			}
+			tree, perrs := NewParser(
+				`security { screen { ids-option bad { ` + f.fam + ` { ` + f.leaf + ` bogus; } } } }`).Parse()
+			if len(perrs) > 0 {
+				t.Fatalf("parse: %v", perrs)
+			}
+			if _, err := CompileConfig(tree); err == nil {
+				t.Errorf("hierarchical spelling ACCEPTED trailing garbage on the bare flag %s %s", f.fam, f.leaf)
+			}
+		})
+	}
+}
+
+func synFloodAttack7460(s *ScreenProfile) int {
+	if s.TCP.SynFlood == nil {
+		return -1
+	}
+	return s.TCP.SynFlood.AttackThreshold
+}
+
+func splitFirst7460(s string) (string, string) {
+	for i := 0; i < len(s); i++ {
+		if s[i] == ' ' {
+			return s[:i], s[i+1:]
+		}
+	}
+	return s, ""
+}
+
+func lastToken7460(s string) int {
+	n := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] >= '0' && s[i] <= '9' {
+			n = n*10 + int(s[i]-'0')
+		} else {
+			n = 0
+		}
+	}
+	return n
+}


### PR DESCRIPTION
Closes #6683
Closes #7460

Two silent screen defects, both leaving the profile **looking** configured.

## #6683 — the packed body disables every check

`ids-option s1 icmp ping-death;` packs the whole body onto the ids-option node's `Keys`, so `Children` is empty and every check compiles **disabled**. The profile survives, binds to a zone normally, and `show configuration` displays what the operator wrote. There is no downstream symptom — traffic flows, which is what a working screen profile looks like until an attack arrives.

## #7460 — found while scoping the first, and arguably worse

The same packing one level down silently replaces a configured **threshold** with the default:

| sub-knob | leaf spelling | block spelling |
|---|---|---|
| `ip ip-sweep threshold 7777` | **5000** (default) | 7777 |
| `tcp port-scan threshold 4444` | **5000** (default) | 4444 |
| `tcp syn-flood attack-threshold 999` | **200** (default) | 999 |
| `icmp flood threshold 3333` | 3333 | **commit error** |

An earlier probe of the same thing using `threshold 5000` reported a **false green** — 5000 *is* the ip-sweep/port-scan default. The bug substitutes the default, so a fixture that happens to configure the default cannot see it.

**Cause:** two sub-knob readers with opposite shape assumptions. `ip-sweep`/`port-scan`/`syn-flood` iterate `Children` and never see the packed form; `flood` reads `Keys[2]` and never sees the block form. `flood` — the odd one out — accepted the spelling its siblings rejected and rejected the one they accepted.

## The fix

The #6684/#6685 schema-driven expander applied at **both** levels, which requires modelling the screen subtree in `setSchema` (an unmodelled keyword cannot be resolved, and the expander declines rather than guessing). Every check flag and every sub-knob is now modelled — which also gives those leaves `?` completion and `SchemaValidate` reach they never had.

Sub-knob children are **load-bearing, not decoration**: modelled as a bare flag, `flood` makes the expander stop at `[flood]` and silently drop a trailing `threshold 500` — the same silent weakening this exists to end. **U3** is that exact mutation.

## What else had to move

This was attempted once and backed out precisely here, so the list is **measured, not anticipated**:

- **Modelling changes flat-set token grouping** (`ast_edit.go` keys on `args`/`children`/`compoundKey`/`multi`), so a value that collapsed onto `Keys` now parks as a **child**. `flood` read `Keys[2]` and broke on a path that *worked* — a commit error on config that commits clean today. Single-sourcing all four readers onto the child shape is what makes the grouping change safe rather than a regression.
- **Trailing-garbage detection moves from `Keys` to `Children`.** A modelled childless leaf parks flat-set trailing tokens as children, so a compiler calling only `recordKeyExtras` stops seeing them and the #3332/#3318 gate goes quiet. `recordChildExtras` is now armed on every modelled leaf.
- **Ten entries added to the #2419 spelling-differential allowlist.** The bare flags legitimately *name* a different garbage token per spelling. That difference does not reach the commit **decision** — but an allowlist entry saying so is a **claim**, so it is paired with `TestScreenBareFlagTrailingTokenRejectsInBothSpellings`, which compiles trailing garbage on all ten in both spellings and asserts both are REJECTED. **U5** removes `recordChildExtras` and that test reds — the proof the allowlist is not hiding a fail-open.

## Tests

Enumerated, not sampled. #6683 explicitly warns that a fix closing only the `ping-death` it names leaves the same fail-open on fifteen siblings, so all ten boolean checks are covered — and each case asserts the nested spelling enabled *something* first, because two all-false profiles compare equal, which is the bug passing as a green.

## Mutation matrix

Every cell verified APPLIED first.

| # | mutation | result |
|---|---|---|
| U1 | revert the ids-option body expansion | **RED** — #6683 cases |
| U2 | revert the per-option expansion | **RED** — #7460 cases |
| U3 | model `flood` as a bare flag | **RED** — #7460 + the #3332 gate |
| U4 | revert the flood child reader | **RED** — #7460 flood cases |
| U5 | drop `recordChildExtras` from the flags | **RED** — both-spellings-reject test |

The five tests named in the earlier scoping as the gates that would say this landed — `TestScreenCompilation`, `TestScreenFloodScanExplicitThresholdsPreserved`, `TestScreenNumericValidCommit`, `TestDualASTDifferential/security-screen`, `TestScreenTrailingTokenFailsCommit` — all pass.

## Validation

Full `go test -count=1 ./...` green; `go build ./...` clean.

One unrelated test (`pkg/ra TestRestartTimeoutNoGoodbyeNoReplacement`) failed once under full-`./...` parallel load and passed 3/3 in isolation, 2/2 as a full package, and on a second full-suite run. It is a restart-timeout test and nothing here touches RA.

**Go control plane only** — no dataplane, no shim `.o`, no helper binary, no cluster surface.