### PR TITLE
config: bound the CLI config-file read, not just its length

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103266,3 +103266,17 @@ prose edit above them added. No diff falls in the new test body.
   gate so the silent drop is rejected at commit.
 - **File(s)**: pkg/config/compiler_system.go, pkg/config/dup_named_blocks.go,
   pkg/config/duplicate_login_user_6992_test.go, docs/config-schema.md
+
+- **Timestamp**: 2026-08-22 11:15 UTC
+  - **Action**: #6753 — bound the CLI config-file read instead of checking size
+    after materialising it. Moved the #4909 bounded reader into pkg/configstore
+    (which owns MaxConfigSize) as ReadBounded/ReadBoundedFile/
+    ReadBoundedConfigFile; cmd/xpfd now delegates to it so the logic is
+    single-sourced rather than copied; both CLI load paths call it. Added
+    O_NONBLOCK to the open so a writerless FIFO is classified and refused
+    instead of hanging the process — the "or blocks" half of the issue, which
+    the size cap alone does not address.
+  - **File(s)**: pkg/configstore/bounded_read.go (new),
+    pkg/configstore/bounded_read_6753_test.go (new),
+    pkg/cli/load_bounded_read_6753_test.go (new), pkg/cli/cli_config.go,
+    cmd/cli/main.go, cmd/xpfd/main.go, pkg/configstore/README.md

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -572,7 +572,8 @@ func (c *ctl) handleLoad(args []string) error {
 			return err
 		}
 	} else {
-		data, err := os.ReadFile(source)
+		// #6753: bound the READ, not just the post-read length.
+		data, err := configstore.ReadBoundedConfigFile(source)
 		if err != nil {
 			return fmt.Errorf("load: %v", err)
 		}

--- a/cmd/xpfd/main.go
+++ b/cmd/xpfd/main.go
@@ -137,23 +137,7 @@ func classifyCommand(argv []string) xpfdCommand {
 // and reaching the (max+1)-th byte proves the file is over-cap. A non-regular
 // file (dir/device/FIFO) is refused up front.
 func readBoundedFile(path string, max int64) ([]byte, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-	fi, err := f.Stat()
-	if err != nil {
-		return nil, err
-	}
-	if !fi.Mode().IsRegular() {
-		return nil, fmt.Errorf("%s: not a regular file", path)
-	}
-	data, err := readBounded(f, max)
-	if err != nil {
-		return nil, fmt.Errorf("%s: %w", path, err)
-	}
-	return data, nil
+	return configstore.ReadBoundedFile(path, max)
 }
 
 // readBounded reads at most max+1 bytes from r and rejects a source that
@@ -164,14 +148,7 @@ func readBoundedFile(path string, max int64) ([]byte, error) {
 // balloon memory. io.LimitReader(max+1) caps the read; reaching the (max+1)-th
 // byte proves the source is over-cap.
 func readBounded(r io.Reader, max int64) ([]byte, error) {
-	data, err := io.ReadAll(io.LimitReader(r, max+1))
-	if err != nil {
-		return nil, err
-	}
-	if int64(len(data)) > max {
-		return nil, fmt.Errorf("exceeds %d byte limit", max)
-	}
-	return data, nil
+	return configstore.ReadBounded(r, max)
 }
 
 func main() {

--- a/pkg/cli/cli_config.go
+++ b/pkg/cli/cli_config.go
@@ -166,7 +166,10 @@ func (c *CLI) handleLoad(args []string) error {
 		}
 	} else {
 		// Read from file
-		data, err := os.ReadFile(source)
+		// #6753: bound the READ, not just the post-read length. checkConfigSize
+		// takes an already-materialised string, so it bounds what the store
+		// ACCEPTS, never what this path ALLOCATES.
+		data, err := configstore.ReadBoundedConfigFile(source)
 		if err != nil {
 			return fmt.Errorf("load: %w", err)
 		}

--- a/pkg/cli/load_bounded_read_6753_test.go
+++ b/pkg/cli/load_bounded_read_6753_test.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// TestHandleLoadBoundsTheReadItself_6753 binds the WIRING, not the helper.
+//
+// configstore.ReadBoundedConfigFile has its own tests; they stay green even if
+// this call site is left on os.ReadFile, because they never execute the CLI.
+// The defect #6753 describes is that the LOAD PATH reads unbounded, so the
+// assertion has to run through handleLoad.
+func TestHandleLoadBoundsTheReadItself_6753(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "big.conf")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := f.Truncate(configstore.MaxConfigSize + 1); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	f.Close()
+
+	c := &CLI{}
+	err = c.handleLoad([]string{"override", path})
+	if err == nil {
+		t.Fatal("handleLoad must refuse a file past MaxConfigSize at the READ, not after materialising it (#6753)")
+	}
+	if !strings.Contains(err.Error(), "limit") {
+		t.Fatalf("the refusal must come from the bounded read and name the limit, got %q", err)
+	}
+}
+
+// A normal, small config must still load — the positive control. Without it a
+// load path that refused every file would satisfy the test above.
+func TestHandleLoadStillAcceptsANormalFile_6753(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ok.conf")
+	if err := os.WriteFile(path, []byte("system {\n    host-name xpf;\n}\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// A real store is required: this file gets PAST the read, which is the
+	// point of the control, and the load then reaches the store.
+	st, err := configstore.New(filepath.Join(t.TempDir(), "cfg.db"))
+	if err != nil {
+		t.Fatalf("configstore.New: %v", err)
+	}
+	c := New(st, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	if err := c.handleLoad([]string{"override", path}); err != nil &&
+		strings.Contains(err.Error(), "limit") {
+		t.Fatalf("a normal config must not be refused by the size bound, got %q", err)
+	}
+}
+
+// The "or blocks" half, through the CLI. A writerless FIFO must not hang the
+// load path. A regression HANGS rather than failing, hence the deadline.
+func TestHandleLoadDoesNotBlockOnAFIFO_6753(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fifo.conf")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported here: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		c := &CLI{}
+		done <- c.handleLoad([]string{"override", path})
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("a FIFO must be refused by the load path")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("handleLoad BLOCKED on a writerless FIFO (#6753)")
+	}
+}

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -1285,3 +1285,29 @@ owned by the `journal/` subpackage.
   `applyConfig()` under a single semaphore. Bypassing the daemon (e.g.
   using `Store` directly) loses that serialization, so concurrent CLI +
   HTTP commits can race.
+
+## Bounded config reads (#4909, #6753)
+
+`MaxConfigSize` (16 MiB) is the ceiling on any configuration payload the store
+accepts. Historically it was enforced **only after the payload was resident**:
+`checkConfigSize` takes an already-materialised string, so it bounds what the
+store will *accept*, never what a caller will *allocate*. A caller doing
+`os.ReadFile` then handing the result over read a multi-gigabyte file in full
+and only then had it refused (#6753).
+
+Read configuration files through **`ReadBoundedConfigFile`** (or
+`ReadBoundedFile` / `ReadBounded` for a different ceiling). They bound the read
+itself:
+
+- `io.LimitReader(max+1)` caps the allocation by the *limit*, not by what
+  `Stat` claimed — closing the #4909 TOCTOU where a FUSE-backed or racing file
+  under-reports its size and then streams an unbounded body.
+- The open uses `O_NONBLOCK` and the path is rejected unless it is a **regular
+  file**. Opening a FIFO for reading blocks until a writer appears, so a plain
+  `os.Open` hangs before any size check can run. That is a distinct defect from
+  the size cap and a size-only fix does not address it.
+
+Both CLI surfaces (`pkg/cli` local, `cmd/cli` remote) and `cmd/xpfd` call the
+same implementation. They previously did not, and #4883-D records the cost of
+that shape at a neighbouring site: the local and remote CLI diverged, and the
+divergence itself is what produced the bug.

--- a/pkg/configstore/bounded_read.go
+++ b/pkg/configstore/bounded_read.go
@@ -1,0 +1,81 @@
+package configstore
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+)
+
+// ReadBounded reads at most max+1 bytes from r and rejects a source that
+// exceeds max, allocating no more than max+1 bytes REGARDLESS of how much data
+// r would supply. This is the load-bearing half of the #4909 fix: a plain
+// io.ReadAll materializes the WHOLE source before any cap, so a FUSE/racing
+// file that under-reported its Stat size could still stream an unbounded body
+// and balloon memory. io.LimitReader(max+1) caps the read; reaching the
+// (max+1)-th byte proves the source is over-cap.
+func ReadBounded(r io.Reader, max int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, max+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > max {
+		return nil, fmt.Errorf("exceeds %d byte limit", max)
+	}
+	return data, nil
+}
+
+// ReadBoundedFile reads path, refusing anything larger than max bytes while
+// allocating at most max+1 bytes REGARDLESS of the file's reported size.
+//
+// The pre-#4909 pattern was os.Stat (size gate) then os.ReadFile (whole-file
+// alloc) then a post-read len(data) cap — a TOCTOU: an adversarial or
+// FUSE-backed file can under-report its size to Stat and then stream an
+// unbounded body to ReadFile, ballooning memory before the post-read cap
+// fires. Reading through an io.LimitReader(max+1) on a single opened
+// descriptor closes the window: the allocation is bounded by the limit, not by
+// what Stat claimed, and reaching the (max+1)-th byte proves the file is
+// over-cap. A non-regular file (dir/device/FIFO) is refused up front.
+//
+// #6753: the open uses O_NONBLOCK. Opening a FIFO for reading BLOCKS until a
+// writer appears, so a plain os.Open hangs before Stat can classify the path
+// and reject it — the "or blocks" half of the defect, which a size cap alone
+// does not address. O_NONBLOCK is a no-op for regular files, so the fast path
+// is unchanged; it only ensures a non-regular path can be reached, classified
+// and refused instead of hanging the process.
+func ReadBoundedFile(path string, max int64) ([]byte, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !fi.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s: not a regular file", path)
+	}
+	data, err := ReadBounded(f, max)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	return data, nil
+}
+
+// ReadBoundedConfigFile reads a configuration file under the same MaxConfigSize
+// ceiling the store enforces on any payload it accepts.
+//
+// It exists because that ceiling was previously enforced only AFTER the whole
+// file was resident: checkConfigSize takes an already-materialised string, so
+// it bounds what the store will ACCEPT, never what a caller will ALLOCATE. The
+// CLI load paths read with os.ReadFile and then handed the result over, so a
+// multi-gigabyte file was fully read and only then rejected (#6753).
+//
+// Both CLI surfaces call this rather than each bounding its own read: #4883-D
+// fixed a directly analogous divergence between the local and remote CLI by
+// moving the shared logic to one place, and the comment at that site records
+// that the divergence itself is what produced the bug.
+func ReadBoundedConfigFile(path string) ([]byte, error) {
+	return ReadBoundedFile(path, MaxConfigSize)
+}

--- a/pkg/configstore/bounded_read_6753_test.go
+++ b/pkg/configstore/bounded_read_6753_test.go
@@ -1,0 +1,91 @@
+package configstore
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestReadBoundedConfigFileRejectsOversizeWithoutMaterialising_6753 is the
+// allocation half of #6753. The store's ceiling was previously enforced by
+// checkConfigSize on an ALREADY-MATERIALISED string, so an over-cap file was
+// read in full and only then refused.
+func TestReadBoundedConfigFileRejectsOversizeWithoutMaterialising_6753(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "big.conf")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// One byte past the ceiling is the smallest input that must be refused.
+	if err := f.Truncate(MaxConfigSize + 1); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	f.Close()
+
+	data, err := ReadBoundedConfigFile(path)
+	if err == nil {
+		t.Fatalf("an over-cap file must be refused; got %d bytes and nil error", len(data))
+	}
+	if data != nil {
+		t.Fatalf("a refused read must yield no payload, got %d bytes", len(data))
+	}
+	if !strings.Contains(err.Error(), "limit") {
+		t.Fatalf("error must name the limit, got %q", err)
+	}
+}
+
+// A file exactly AT the ceiling is legal and must still be returned whole —
+// the positive control. Without it a reader that refused everything would
+// satisfy the test above.
+func TestReadBoundedConfigFileAcceptsExactlyAtTheCeiling_6753(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "atmax.conf")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := f.Truncate(MaxConfigSize); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	f.Close()
+
+	data, err := ReadBoundedConfigFile(path)
+	if err != nil {
+		t.Fatalf("a file exactly at the ceiling must be accepted, got %v", err)
+	}
+	if int64(len(data)) != MaxConfigSize {
+		t.Fatalf("want %d bytes, got %d", int64(MaxConfigSize), len(data))
+	}
+}
+
+// TestReadBoundedConfigFileDoesNotBlockOnAFIFO_6753 is the "or blocks" half of
+// #6753, and it is a different defect from the size cap: opening a FIFO for
+// reading BLOCKS until a writer appears, so the process hangs before any size
+// check can run. A size-only fix leaves this untouched. The test asserts the
+// call RETURNS — a regression hangs rather than failing, so it runs on its own
+// goroutine behind a deadline.
+func TestReadBoundedConfigFileDoesNotBlockOnAFIFO_6753(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fifo.conf")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported here: %v", err)
+	}
+	// No writer is ever opened, which is exactly the hanging case.
+	done := make(chan error, 1)
+	go func() {
+		_, err := ReadBoundedConfigFile(path)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("a FIFO is not a regular file and must be refused")
+		}
+		if !strings.Contains(err.Error(), "not a regular file") {
+			t.Fatalf("want a not-a-regular-file refusal, got %q", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ReadBoundedConfigFile BLOCKED on a writerless FIFO — the open must not wait for a writer (#6753)")
+	}
+}


### PR DESCRIPTION
Closes #6753

## The defect

`MaxConfigSize` (16 MiB) bounds what the store will **accept**, never what a
caller will **allocate**: `checkConfigSize` takes an already-materialised
string. Both CLI load paths read with `os.ReadFile` and handed the result over,
so a multi-gigabyte file was read in full and only then refused.

Two distinct failures share that call site, and the issue title names both:

| | failure | a size cap fixes it? |
|---|---|---|
| **allocates** | over-cap file materialised before the ceiling is checked | yes |
| **blocks** | `os.Open` on a FIFO waits for a writer, hanging before any check | **no** |

## The fix reuses what the repo already had

`cmd/xpfd` gained `readBoundedFile` in #4909 with a comment describing this
exact TOCTOU. It could not be reused because it lived in `package main`. It now
lives in `pkg/configstore` — which owns `MaxConfigSize`, so the reader and the
limit are single-sourced — and **`cmd/xpfd` delegates to it** rather than
keeping a second copy. Its #4909 guards still run, unchanged, against the
delegating wrappers.

The open adds `O_NONBLOCK`, so a writerless FIFO is classified and refused
instead of hanging. It is a no-op for regular files, so the normal path is
unchanged.

Both CLI surfaces call the same implementation. #4883-D records the cost of the
other shape at a neighbouring site in this very file: the local and remote CLI
diverged, and *the divergence itself is what produced the bug*.

## Mutation matrix

`go vet` rc 0 in every mutated tree; one line each.

| # | mutation | result |
|---|---|---|
| M1 | CLI call site back to `os.ReadFile` | **RED** — wiring test + FIFO test (10.05s deadline) |
| M1-base | same mutation, new fixtures removed | **rc=0, 0 failures** |
| M3 | drop `O_NONBLOCK` only | **RED** — both FIFO tests hang to their deadlines |

**M1's red is not "an error was returned".** Under the mutation the store still
refuses the file — just after materialising it — so a naive `err != nil`
assertion would have passed. The test discriminates on *which* refusal fired:

```
load_bounded_read_6753_test.go:37: the refusal must come from the bounded read
and name the limit, got "load override: config too large: 16777217 bytes
exceeds maximum 16777216 bytes"
```

That message is the post-materialisation store rejection, i.e. exactly the
behaviour being fixed.

**The M1-base column is what makes the new tests a demonstration**: the
pre-existing suite exits 0 under the mutation, so it could not observe this.

Positive controls: a file **exactly at** the ceiling must load whole, and an
ordinary small config must load — without them a reader that refused everything
would satisfy the negative tests.

The wiring tests run through `handleLoad`, not against the helper. The helper's
own tests stay green even if the call site is left on `os.ReadFile`, so they
cannot bind the defect.

## Validation

`go build ./...`, `go vet ./...`, and `pkg/configstore` + `pkg/cli` + `cmd/cli`
+ `cmd/xpfd` all clean at the merged head. `gofmt` clean on every touched file.

No cluster fence owed or run: this touches config-file reading only — no
forwarding, session-sync, VRRP or fabric path, and no compiled dataplane
artifact.

`pkg/configstore/README.md` gains the bounded-read contract, including why the
FIFO case is a separate defect from the size cap.
