### PR TITLE
daemon: refuse commit confirmed against an unappliable rollback target

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103238,3 +103238,19 @@ prose edit above them added. No diff falls in the new test body.
   - **File(s)**: pkg/config/compact_tail.go, pkg/config/compiler_system.go,
     pkg/config/compiler_firewall.go,
     pkg/config/compact_tail_6684_6685_test.go, docs/config-schema.md
+
+- **Timestamp**: 2026-08-22
+  - **Action**: #6707 — added a `commit confirmed` rollback-target APPLIABILITY
+    pre-flight so the confirmed-commit safety net cannot arm against a target
+    the dataplane is guaranteed to refuse (#5575 lenient-content poison). The
+    timeout path applies its target unconditionally by design, so the decision
+    has to be made at arm time. Measured the issue's other two consequences at
+    master: the peer-sync divergence is CLOSED by #7328's config-apply NACK, and
+    the ctrl-disable outage is real but its stated fix direction is unsafe —
+    both reported rather than changed.
+  - **File(s)**: pkg/config/compiler_security_policy.go,
+    pkg/config/lenient_dropped_locator_6707_test.go (new),
+    pkg/daemon/rollback_target_appliable_6707.go (new),
+    pkg/daemon/rollback_target_appliable_6707_test.go (new),
+    pkg/daemon/daemon_apply_commit.go, pkg/daemon/README.md,
+    docs/bare-metal-device-map.md

--- a/docs/bare-metal-device-map.md
+++ b/docs/bare-metal-device-map.md
@@ -227,6 +227,11 @@ the present hardware while you are still connected:
 - `commit confirmed` validates BOTH the candidate AND the rollback target
   (the config restored on timeout), so a confirmed-commit timeout reverts to
   a known-safe config and applies it unconditionally (no split-brain).
+  "Known-safe" is device-map safety here; since #6707 the same pre-flight also
+  requires the rollback target to be APPLIABLE (its policy snapshot must not
+  carry the #5575 lenient-content poison, which the dataplane refuses whole).
+  Both are arm-time decisions for the same reason: the timeout path cannot
+  abort without diverging the already-promoted store from the dataplane.
 - **The pre-flight fails CLOSED on an unreadable NIC inventory (#5490).** If
   the present-NIC scan (a cold-path sysfs/netlink read) fails, the commit is
   **rejected** — the strand-management safety check cannot run, so the commit

--- a/pkg/config/compiler_security_policy.go
+++ b/pkg/config/compiler_security_policy.go
@@ -1,5 +1,7 @@
 package config
 
+import "fmt"
+
 func compilePolicies(node *Node, sec *SecurityConfig) error {
 	for _, child := range node.Children {
 		if child.Name() == "default-policy" {
@@ -490,4 +492,46 @@ func applyCollapsedDenyModifiers(pol *Policy, denyNode *Node) {
 	for _, c := range denyNode.Children {
 		walk(c)
 	}
+}
+
+// LenientDroppedPolicyLocator names the first policy in cfg whose compile
+// SILENTLY DROPPED a match / then-permit constraint on the tolerant path
+// (#5575 LenientContentDropped), or "" when none did.
+//
+// The flag is the compiler's fail-closed poison: policies_lower.go stamps such
+// a rule with the __unsupported__ application sentinel so the Rust integrity
+// preflight REJECTS THE WHOLE SNAPSHOT rather than arming a permit broader than
+// the operator configured. So a config carrying this flag is one the dataplane
+// is GUARANTEED to refuse — which makes it a usable local predicate for "this
+// config cannot become the running snapshot" without a round trip to the
+// helper.
+//
+// It walks BOTH policy shapes. A zone-pair rule and a global rule reach the
+// poison through the same compilePolicy path, so a walker that checked only
+// `Security.Policies` would report a clean config for a poisoned global policy
+// — the exact miss that would let an unappliable rollback target through the
+// #6707 gate. Returning the locator rather than a bare bool lets the caller
+// name the offending rule to the operator; a rule with no zone context is a
+// global policy and is labelled as such.
+func LenientDroppedPolicyLocator(cfg *Config) string {
+	if cfg == nil {
+		return ""
+	}
+	for _, zpp := range cfg.Security.Policies {
+		if zpp == nil {
+			continue
+		}
+		for _, pol := range zpp.Policies {
+			if pol != nil && pol.LenientContentDropped {
+				return fmt.Sprintf("from-zone %s to-zone %s policy %q",
+					zpp.FromZone, zpp.ToZone, pol.Name)
+			}
+		}
+	}
+	for _, pol := range cfg.Security.GlobalPolicies {
+		if pol != nil && pol.LenientContentDropped {
+			return fmt.Sprintf("global policy %q", pol.Name)
+		}
+	}
+	return ""
 }

--- a/pkg/config/lenient_dropped_locator_6707_test.go
+++ b/pkg/config/lenient_dropped_locator_6707_test.go
@@ -1,0 +1,121 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6707: LenientDroppedPolicyLocator is the local proof that a config cannot
+// become the running dataplane snapshot. Its consumers gate operator actions on
+// it, so a shape it fails to walk is a shape that slips the gate.
+//
+// The fixtures are compiled by the REAL tolerant compiler rather than hand-set
+// struct literals. LenientContentDropped is set by compilePolicy from three
+// AST predicates; a literal `&Policy{LenientContentDropped: true}` would prove
+// only that the field can be read, not that the production path that sets it is
+// the one this locator sees.
+//
+// FAIL-ON-REVERT: delete the GlobalPolicies loop and the global cell reds;
+// delete the zone-pair loop and the zone-pair cell reds.
+
+func lenientCfg6707(t *testing.T, text string) *Config {
+	t.Helper()
+	tree, perrs := NewParser(text).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile: %v", err)
+	}
+	return cfg
+}
+
+const zonePairPoisoned6707 = `security {
+  policies {
+    from-zone trust to-zone untrust {
+      policy zp-bad {
+        then { permit; }
+      }
+    }
+  }
+}`
+
+const globalPoisoned6707 = `security {
+  policies {
+    global {
+      policy g-bad {
+        then { permit; }
+      }
+    }
+  }
+}`
+
+const zonePairClean6707 = `security {
+  policies {
+    from-zone trust to-zone untrust {
+      policy zp-ok {
+        match { source-address any; destination-address any; application any; }
+        then { permit; }
+      }
+    }
+  }
+}`
+
+func TestLenientDroppedPolicyLocatorWalksBothPolicyShapes6707(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		text     string
+		wantHit  bool
+		wantName string
+	}{
+		{"zone-pair-poisoned", zonePairPoisoned6707, true, "zp-bad"},
+		{"global-poisoned", globalPoisoned6707, true, "g-bad"},
+		{"zone-pair-clean", zonePairClean6707, false, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := lenientCfg6707(t, tc.text)
+
+			// Premise: the REAL compiler set (or did not set) the poison. Without
+			// this a locator that always returns "" would pass the clean cell and
+			// the poisoned cells would be failing for the wrong reason.
+			poisoned := false
+			for _, zpp := range cfg.Security.Policies {
+				for _, p := range zpp.Policies {
+					poisoned = poisoned || p.LenientContentDropped
+				}
+			}
+			for _, p := range cfg.Security.GlobalPolicies {
+				poisoned = poisoned || p.LenientContentDropped
+			}
+			if poisoned != tc.wantHit {
+				t.Fatalf("premise broken: compiled LenientContentDropped = %v, want %v — "+
+					"the fixture does not exercise what this cell claims to measure",
+					poisoned, tc.wantHit)
+			}
+
+			got := LenientDroppedPolicyLocator(cfg)
+			if !tc.wantHit {
+				if got != "" {
+					t.Fatalf("locator = %q for a clean config, want \"\" — a false positive "+
+						"here refuses a `commit confirmed` the operator is entitled to", got)
+				}
+				return
+			}
+			if got == "" {
+				t.Fatalf("locator = \"\" for a poisoned %s config; the gate built on it "+
+					"would arm a rollback timer whose target the dataplane refuses", tc.name)
+			}
+			if !strings.Contains(got, tc.wantName) {
+				t.Errorf("locator = %q, want it to name policy %q so the operator can find "+
+					"the offending rule", got, tc.wantName)
+			}
+		})
+	}
+}
+
+func TestLenientDroppedPolicyLocatorNilConfig6707(t *testing.T) {
+	if got := LenientDroppedPolicyLocator(nil); got != "" {
+		t.Fatalf("locator(nil) = %q, want \"\"", got)
+	}
+}

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -167,6 +167,55 @@ the primary compile/apply gate.
 - `CompileHealth` — `daemon.go`. Snapshot of the most recent compile
   outcome; `pkg/api` consumes it for the `/health` endpoint.
 
+### `commit confirmed` rollback-target pre-flight (#6707)
+
+`commit confirmed` arms a timer that, on expiry, reverts the store to the
+previously-active config and re-applies it. That re-apply is **unconditional
+by design** (#1956 OQ-15.2, `daemon_apply_commit.go`): `PromoteRollback` has
+already reverted the STORE, so aborting the dataplane apply at that point
+would leave store and dataplane disagreeing — a split-brain strictly worse
+than applying the target. The consequence is that every property the rollback
+depends on has to be decided at ARM time, which is what the pre-flight closure
+in `commitConfirmedAndApply` is for. It already validated the rollback target
+for device-map safety (#1956 R-8/V-3), cluster topology (#5840) and cluster
+identity (#6192).
+
+`rollbackTargetAppliablePreflight` (`rollback_target_appliable_6707.go`) adds
+the missing property: the target must be **appliable at all**. A config whose
+policy compile silently dropped a match / `then permit` constraint on the
+tolerant path carries `config.Policy.LenientContentDropped` (#5575); the
+snapshot lowering stamps such a rule with the `__unsupported__` application
+sentinel and the Rust integrity pre-flight then rejects the WHOLE snapshot. So
+the flag is a local, allocation-free proof that the helper will refuse this
+config — no round trip, and no dependence on helper liveness at arm time.
+`config.LenientDroppedPolicyLocator` is the predicate; it walks BOTH the
+zone-pair and the global policy shapes, because both reach the poison through
+the same `compilePolicy` path.
+
+Without the gate the #6707 sequence is: boot from a persisted config A whose
+policy hits the poison (a lenient boot load, or a peer-sync `SyncApply` — a
+strict commit rejects it outright, so the target can only be poisoned by a
+route that does not strict-compile), correct it in candidate B, `commit
+confirmed` B, then lose contact. At timeout the store reverts to A, the
+dataplane refuses A's snapshot — **logged only** — and forwarding stays on the
+UNCONFIRMED B while the store and the tail subsystems say A, with the rollback
+announced as successful. The recovery mechanism has failed to recover, which is
+the #1960 no-brick concern in its concrete form.
+
+The refusal is deliberately narrow, and only the CONFIRMED variant is gated. A
+plain `commit` of B is untouched and remains the way forward — it makes B
+permanent, which is what an operator correcting a broken active config wants.
+Gating the plain path would remove the only route OFF a poisoned active config.
+A nil rollback target (the first commit on a fresh store) is also unaffected:
+that timeout path reverts to bootstrap mode (#1922 Item 1b) rather than to a
+compiled config, so there is nothing to validate.
+
+Regression coverage: `rollback_target_appliable_6707_test.go` (gate behaviour
+plus an AST wiring guard that the call is reached from `commitConfirmedAndApply`
+and absent from the plain-commit entry points) and
+`pkg/config/lenient_dropped_locator_6707_test.go` (both policy shapes, compiled
+by the real tolerant compiler rather than asserted into a struct literal).
+
 ### Config-apply file layout (#5661)
 
 The config-apply path was carved out of the former ~3095-line

--- a/pkg/daemon/daemon_apply_commit.go
+++ b/pkg/daemon/daemon_apply_commit.go
@@ -587,6 +587,17 @@ func (d *Daemon) commitConfirmedAndApply(ctx context.Context, minutes int, syncP
 			if ierr := clusterIdentityCommitPreflight(d.cluster, cand); ierr != nil {
 				return ierr
 			}
+			// #6707: the rollback target must be APPLIABLE, not merely
+			// device-map safe. The timeout path applies it unconditionally
+			// (OQ-15.2, see the rollback callback), so a target the dataplane
+			// is guaranteed to refuse turns the safety net into a store-only
+			// revert: the store says the target, forwarding stays on the
+			// unconfirmed candidate, and the rollback is ANNOUNCED as done.
+			// Decide it here, while the operator is still connected and
+			// nothing has been promoted.
+			if rerr := rollbackTargetAppliablePreflight(d.store.ActiveConfig()); rerr != nil {
+				return rerr
+			}
 			return d.deviceMapCommitPreflight(cand, d.store.ActiveConfig())
 		},
 		func(gen uint64) (*config.Config, error) { return d.store.CommitConfirmedGen(minutes, gen) },

--- a/pkg/daemon/rollback_target_appliable_6707.go
+++ b/pkg/daemon/rollback_target_appliable_6707.go
@@ -1,0 +1,70 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// errRollbackTargetUnappliable is the #6707 sentinel: `commit confirmed` was
+// asked to arm a rollback timer whose TARGET the dataplane is guaranteed to
+// refuse.
+var errRollbackTargetUnappliable = errors.New("commit confirmed rollback target cannot be applied")
+
+// rollbackTargetAppliablePreflight refuses to ARM a `commit confirmed` whose
+// rollback target — the currently-active config, restored when the confirm
+// timer expires — carries the #5575 lenient-content poison and therefore cannot
+// become the running dataplane snapshot.
+//
+// WHY THIS IS A PRE-FLIGHT AND NOT A ROLLBACK-TIME ABORT. The rollback path
+// applies its target UNCONDITIONALLY and deliberately: by then
+// PromoteRollback has already reverted the STORE, so aborting the dataplane
+// apply would leave the store and the dataplane disagreeing — a split-brain
+// strictly worse than applying the target (#1956 OQ-15.2,
+// daemon_apply_commit.go). That reasoning holds, which is exactly why the
+// decision has to be made BEFORE the store is committed to. The existing
+// device-map, cluster-topology and cluster-identity gates already validate the
+// rollback target for the same reason; this extends "KNOWN-safe" from
+// "will not strand management on next boot" to "can actually be applied".
+//
+// WHAT MAKES THE PREDICTION SOUND. LenientContentDropped is not a heuristic. A
+// policy carrying it is stamped with the __unsupported__ application sentinel
+// when the snapshot is lowered (pkg/dataplane/userspace/policies_lower.go), and
+// the Rust integrity preflight rejects the WHOLE snapshot on that sentinel. So
+// the flag is a local, allocation-free proof that the helper will refuse this
+// config — no round trip, and no dependence on helper liveness at arm time.
+//
+// It fires ONLY on the tolerant path's poison, which a strict commit already
+// rejects outright. So the target can only be poisoned if it arrived by a route
+// that does not strict-compile: a lenient boot load of a persisted config, or a
+// peer-sync SyncApply. That is precisely the #6707 sequence — boot from a
+// poisoned persisted config A, correct it in candidate B, and `commit confirmed`
+// B — where the safety net silently could not fire.
+//
+// The refusal is deliberately narrow. A plain `commit` of B is unaffected and
+// remains the way forward: it makes B permanent, which is what an operator
+// correcting a broken active config wants. Only the CONFIRMED variant is
+// refused, and only because its promise — "this reverts cleanly if I lose
+// contact" — would be false.
+func rollbackTargetAppliablePreflight(rollbackTarget *config.Config) error {
+	// A nil target is the first-commit case: there is nothing to roll back to,
+	// which the timeout path already handles by reverting to bootstrap mode
+	// (daemon_apply_commit.go's nil-prevCfg branch). Not this gate's business.
+	if rollbackTarget == nil {
+		return nil
+	}
+	locator := config.LenientDroppedPolicyLocator(rollbackTarget)
+	if locator == "" {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: the active configuration (which `commit confirmed` would restore when the "+
+			"timer expires) contains security policy %s whose match/then content was "+
+			"DROPPED when it was loaded — the dataplane refuses that whole policy snapshot "+
+			"(#5575 fail-closed), so the rollback would revert the configuration store "+
+			"without reverting forwarding, leaving the store and the dataplane "+
+			"disagreeing. Use a plain `commit` to make this change permanent, or repair "+
+			"the active configuration first (a strict `commit` reports the exact leaf)",
+		errRollbackTargetUnappliable, locator)
+}

--- a/pkg/daemon/rollback_target_appliable_6707_test.go
+++ b/pkg/daemon/rollback_target_appliable_6707_test.go
@@ -1,0 +1,174 @@
+package daemon
+
+import (
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6707: `commit confirmed` must refuse to ARM when its rollback target cannot
+// become the running snapshot.
+//
+// The rollback timer applies its target UNCONDITIONALLY and deliberately — by
+// then PromoteRollback has already reverted the STORE, so aborting there would
+// leave store and dataplane disagreeing (#1956 OQ-15.2). That is precisely why
+// the decision belongs at arm time. Without this gate the sequence is: boot from
+// a persisted config A whose policy hits the #5575 poison, correct it in B,
+// `commit confirmed` B, lose contact — and at timeout the store reverts to A,
+// the dataplane refuses A's snapshot (logged only,
+// daemon_apply_commit.go's `slog.Error("commit confirmed auto-rollback
+// dataplane apply failed")`), forwarding stays on the UNCONFIRMED B, and the
+// rollback is announced as done.
+//
+// FAIL-ON-REVERT: make rollbackTargetAppliablePreflight return nil
+// unconditionally and the poisoned cell reds; drop the call from
+// CommitConfirmed's preflight closure and the wiring test reds.
+
+func poisonedTarget6707(t *testing.T) *config.Config {
+	t.Helper()
+	// Compiled by the REAL tolerant compiler, so the poison is set by the
+	// production path rather than asserted into a struct literal.
+	tree, perrs := config.NewParser(`security {
+  policies {
+    from-zone trust to-zone untrust {
+      policy rollback-bad {
+        then { permit; }
+      }
+    }
+  }
+}`).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	cfg, err := config.CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile: %v", err)
+	}
+	if config.LenientDroppedPolicyLocator(cfg) == "" {
+		t.Fatal("premise broken: the fixture config is not poisoned, so this test " +
+			"cannot measure the gate")
+	}
+	return cfg
+}
+
+func cleanTarget6707(t *testing.T) *config.Config {
+	t.Helper()
+	tree, perrs := config.NewParser(`security {
+  policies {
+    from-zone trust to-zone untrust {
+      policy rollback-ok {
+        match { source-address any; destination-address any; application any; }
+        then { permit; }
+      }
+    }
+  }
+}`).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	cfg, err := config.CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile: %v", err)
+	}
+	if got := config.LenientDroppedPolicyLocator(cfg); got != "" {
+		t.Fatalf("premise broken: the clean fixture is poisoned (%q), so the "+
+			"over-gating cell below would pass for the wrong reason", got)
+	}
+	return cfg
+}
+
+func TestRollbackTargetAppliablePreflight6707(t *testing.T) {
+	t.Run("poisoned target is refused", func(t *testing.T) {
+		err := rollbackTargetAppliablePreflight(poisonedTarget6707(t))
+		if err == nil {
+			t.Fatal("a rollback target the dataplane is guaranteed to refuse was ACCEPTED; " +
+				"`commit confirmed` would arm a safety net that reverts the store without " +
+				"reverting forwarding")
+		}
+		if !errors.Is(err, errRollbackTargetUnappliable) {
+			t.Errorf("error %v does not wrap errRollbackTargetUnappliable", err)
+		}
+		// The operator has to be able to act on it: name the offending rule and
+		// the way forward.
+		for _, want := range []string{"rollback-bad", "commit"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("gate error does not mention %q; a refusal the operator cannot "+
+					"act on is a support ticket, not a fence. Got: %v", want, err)
+			}
+		}
+	})
+
+	t.Run("clean target is accepted", func(t *testing.T) {
+		if err := rollbackTargetAppliablePreflight(cleanTarget6707(t)); err != nil {
+			t.Fatalf("a clean rollback target was refused: %v — over-gating denies an "+
+				"operator the confirmed-commit safety net they are entitled to", err)
+		}
+	})
+
+	t.Run("nil target (first commit) is accepted", func(t *testing.T) {
+		// The timeout path handles a nil rollback target by reverting to
+		// bootstrap mode (#1922 Item 1b); refusing here would block the FIRST
+		// commit-confirmed on a fresh store — a brick, not a fence.
+		if err := rollbackTargetAppliablePreflight(nil); err != nil {
+			t.Fatalf("nil rollback target refused: %v", err)
+		}
+	})
+}
+
+// The gate must be REACHED, and reached from the CONFIRMED commit only. A gate
+// that exists but is never called is the same as no gate; a gate wired into the
+// plain commit path would refuse an operator's only route OFF a poisoned active
+// config.
+func TestRollbackTargetGateIsWiredIntoCommitConfirmedOnly6707(t *testing.T) {
+	t.Parallel()
+
+	const file = "daemon_apply_commit.go"
+	fset := token.NewFileSet()
+	// Mode 0: comments are not attached, so a comment naming the call cannot
+	// satisfy this guard (#6647).
+	f, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+
+	callers := map[string]bool{}
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		ast.Inspect(fn, func(n ast.Node) bool {
+			ce, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			id, ok := ce.Fun.(*ast.Ident)
+			if !ok || id.Name != "rollbackTargetAppliablePreflight" {
+				return true
+			}
+			callers[fn.Name.Name] = true
+			return true
+		})
+	}
+
+	// commitConfirmedAndApply is the single confirmed-commit implementation;
+	// commitConfirmedAndApplyOperator is a thin peer-policy wrapper over it.
+	if !callers["commitConfirmedAndApply"] {
+		t.Fatalf("commitConfirmedAndApply does not call rollbackTargetAppliablePreflight. "+
+			"The #6707 gate exists but nothing invokes it, so a confirmed commit still "+
+			"arms a rollback timer whose target the dataplane refuses. Callers found: %v",
+			callers)
+	}
+	for _, forbidden := range []string{"commitAndApply", "commitAndApplyOperator"} {
+		if callers[forbidden] {
+			t.Errorf("%s calls rollbackTargetAppliablePreflight. A PLAIN commit has no "+
+				"rollback target to protect, and gating it would refuse the operator's only "+
+				"way to replace a poisoned active config", forbidden)
+		}
+	}
+}


### PR DESCRIPTION
Refs #6707 — **partial by design; see "What this leaves open" before gating.**

I did not inherit the issue's framing. Each of its three consequences was
measured at current master: **one is closed by unrelated work, one is real and
fixed here, one is real but its stated fix direction is unsafe.**

## Premise: is the poison still reachable?

Yes. Measured on `origin/master` with the real compiler — the issue's
discriminator table reproduces exactly:

| `match` form | strict compile | lenient `LenientContentDropped` |
|---|---|---|
| `source-address 10.0.0.0/8;` | rejected only for an unrelated undefined-zone reason | `false` |
| `source-address;` (valueless) | REJECTED (#6526) | **`true`** |
| omitted entirely | REJECTED (#3044) | **`true`** |

Both poisoned forms are strict-rejected, so a poisoned config can only arrive by
a route that does not strict-compile: a lenient boot load of a persisted config,
or a peer-sync `SyncApply`. That is the population every claim below applies to.

---

## Consequence 2 — **ALREADY CLOSED at master by #7328.** Not fixed here.

The issue's mechanism was right and its conclusion is now stale. It says
recovery "requires a reconnect or another commit" because the sender marks the
generation pushed and pushes at most once per (connection-epoch, generation) —
`pkg/daemon/daemon_ha_sync.go:565`. That marker is real and still there. What
changed:

- The receiver keeps its high-water pinned and `ActiveApplied()` false on a
  failed apply, so it stays eligible for a re-push (M-2/#4151, #4957 —
  `daemon_ha_sync.go:641-654`).
- The receiver now sends a **config-apply NACK** on *any* apply error —
  `pkg/cluster/sync_conn_config.go:513` `s.sendConfigApplyNack(item.gen)`, in the
  unconditional `err != nil` branch.
- The sender clears its push marker on that NACK —
  `daemon_ha_comms_wiring.go:205` → `invalidateConfigSyncPushed()`
  (`daemon_ha_sync.go:494`), whose doc comment names this exact failure mode:
  *"a generation the peer refused or failed to apply is otherwise never sent
  again on the live connection — convergence would wait for a new commit or a
  reconnect."*

So the pair converges on the reconciler's cadence with no operator action.
Acceptance criterion 3's convergence half is satisfied. Its "does not promote it
into the active store" half is still literally true (`SyncApply` promotes before
`applyConfigLocked` and does not roll back — the deliberate #1799
degrade-not-fail doctrine), but the divergence that made it matter is now
self-correcting.

## Consequence 3 — **REAL. This is what the PR fixes.**

`pkg/daemon/daemon_apply_commit.go:734`:

```go
if err := d.applyConfigLocked(context.Background(), prevCfg); err != nil {
    slog.Error("commit confirmed auto-rollback dataplane apply failed", "err", err)
}
```

Logged only. Execution continues: session invalidation runs, the rolled-back
config is re-synced to the peer, and `"commit confirmed timed out, configuration
rolled back"` is announced — while forwarding is still on the **unconfirmed**
candidate.

And the pre-flight validates the rollback target for device-map safety, cluster
topology and cluster identity, but not for **appliability**. The comment at
`:722-728` is explicit that the timeout applies its target unconditionally
*because* it was validated at arm time.

**The fix keeps that design and completes it.** Aborting at rollback time would
be wrong — `PromoteRollback` has already reverted the store, so an abort is a
split-brain. So the decision belongs at arm time, in the pre-flight closure that
already validates this exact target for three other properties.

`rollbackTargetAppliablePreflight` refuses to arm when the rollback target
carries `LenientContentDropped`. That flag is not a heuristic: the lowering
stamps such a rule with the `__unsupported__` application sentinel
(`policies_lower.go:194`) and the Rust integrity pre-flight rejects the whole
snapshot on it — a local, allocation-free proof the helper will refuse the
config, with no round trip and no dependence on helper liveness at arm time.

`config.LenientDroppedPolicyLocator` walks **both** policy shapes. A walker that
checked only `Security.Policies` would report a clean config for a poisoned
*global* policy and let it straight through — cells M3/M4 below are the paired
proof for each half.

The refusal is narrow: only the confirmed variant, and a nil target (first
commit on a fresh store) is exempt because that timeout path reverts to
bootstrap mode, not to a compiled config. A plain `commit` is untouched — it is
the operator's only route *off* a poisoned active config, and gating it would be
the real brick.

## Consequence 1 — **REAL, not fixed here, and the issue's fix direction is UNSAFE.**

Fix direction 1 says *"Do not disable `userspace_ctrl.Enabled` when the helper
has retained a usable previous snapshot."* Following that as written would
reintroduce the #4959 fail-open. On the `samePlanRefresh` path the classifier
maps were **already rewritten to the new plan** before the publish
(`manager_compile.go:419`), so the helper's retained old snapshot and the maps
disagree; the ctrl-disable is compensating for that, not gratuitous.

Deriving the severity rather than inheriting it — it splits in two:

- **Same-plan policy-only update: a bounded ≈1s outage that self-heals.** The
  1 Hz status tick re-syncs the classifier maps from `m.lastSnapshot`
  (`maps_sync.go:469-477`, and the rejection never advanced `m.lastSnapshot`)
  and re-enables ctrl (`:483-489`). Not permanent.
- **Fresh start: permanent, and the manager is left inert.**
  `ensureStatusLoopLocked()` is at `manager_compile.go:521`, *after* the publish
  at `:453` — so a first-apply rejection returns with no reconcile worker ever
  started. Transit stays dropped (fail-closed, and management still reaches the
  kernel) until the operator commits a fix.

A correct fix exists — roll the classifier maps **back** to `m.lastSnapshot` on
rejection instead of disabling ctrl, falling back to the ctrl-disable if the
rollback fails — but it is a genuine dataplane-state change, and the obvious
companion ("just start the status loop") risks enabling ctrl with
`m.lastSnapshot == nil`, which I could not rule out as a fail-open without more
work. It needs its own issue and its own gate, not a rushed rider on this PR.

## What this leaves open

`#6707` should stay OPEN. This PR satisfies **acceptance criterion 4** and
retires criterion 3 with evidence. Criteria 1 and 2 (consequence 1) are
untouched. I have filed the follow-up separately rather than resolving the tracker
against partial work — see the linked issue.

I also do not accept the issue's "fix them together or the next subsystem is out
of step" premise: consequence 2 was closed on its own by #7328 with no
collateral, and consequence 3's fix is confined to the arm-time pre-flight. The
three share a *cause* but not an implementation.

## Mutation matrix

Every cell full-suite (`go test ./pkg/daemon/ ./pkg/config/ -count=1`), one
line, restored clean after each.

| # | Site | Exact one-line change | `go vet` rc | ASSERTION that fired |
|---|---|---|---|---|
| control | — | none | 0 | `ok` both packages (38.3s / 44.5s) |
| M1 | `rollback_target_appliable_6707.go:58` | `if locator == ""` → `if locator != "" \|\| true` (gate always accepts) | 0 | `:89` — *"a rollback target the dataplane is guaranteed to refuse was ACCEPTED; `commit confirmed` would arm a safety net that reverts the store without reverting forwarding"* |
| M2 | `daemon_apply_commit.go:598` | delete the 3-line call from the pre-flight closure | 0 | `:162` — *"commitConfirmedAndApply does not call rollbackTargetAppliablePreflight … Callers found: map[]"* |
| M3 | `compiler_security_policy.go:531` | delete the `GlobalPolicies` loop | 0 | `:106` — *"locator = \"\" for a poisoned global-poisoned config"*. Localises: the `global-poisoned` subtest reds, `zone-pair-poisoned` and `zone-pair-clean` stay green |
| M4 | `compiler_security_policy.go:520` | delete the zone-pair loop | 0 | the `zone-pair-poisoned` subtest reds **and** `TestRollbackTargetAppliablePreflight6707/poisoned_target_is_refused` reds — the daemon gate is downstream of the locator |

M3 and M4 are run as separate cells on purpose: deleting both loops at once
would red the cell while masking which half was load-bearing. Each half is
independently necessary.

**Base-fixture column:** none of these sites existed before this PR — the gate,
the predicate and their tests are all new — so there is no pre-existing fixture
for the mutation to exit 0 against. The nearest pre-existing guard,
`TestDeviceMapCommitPreflight_*_5490`, covers the same pre-flight closure for a
different property and stays green under all four cells, which is the honest
statement of what the existing suite could see: nothing.

The wiring guard earned its keep on first run — it reded naming
`CommitConfirmed`, and the actual entry point is `commitConfirmedAndApply`. It
parses with `parser.ParseFile(..., 0)` so a comment naming the call cannot
satisfy it (#6647).

## Fixtures

Both poisoned and clean fixtures are produced by the **real** tolerant compiler
(`config.CompileConfigLenient`), not by a `&Policy{LenientContentDropped: true}`
literal — a literal would prove only that the field can be read, not that the
production path that sets it is the one the locator sees. Each cell asserts its
premise (that the compiler did or did not set the flag) before asserting the
behaviour.

## Cluster fence

**No `make test-failover` owed.** The change is confined to the arm-time commit
pre-flight: a new pure predicate in `pkg/config` and a new refusal in
`pkg/daemon` reached only from `commitConfirmedAndApply`. No session-sync, HA
state, VRRP, fabric or forwarding path is touched, no dataplane artifact
changes, and there is no Rust in the diff. The only runtime effect is that one
CLI operation can now return an error it previously did not.

## Docs

`pkg/daemon/README.md` — new *`commit confirmed` rollback-target pre-flight
(#6707)* section: why the decision must be arm-time, what makes the prediction
sound, and why the refusal is narrow. `docs/bare-metal-device-map.md` — its
"validates BOTH the candidate AND the rollback target … known-safe" bullet was
made imprecise by this change (it meant device-map safety); it now says which
property is which.

## Validation

- `go build ./...` 0, `go vet` 0, `gofmt` clean on all five touched files.
- `pkg/daemon` + `pkg/config` green at `-count=1`, at merged head `f7964ae4d`
  (`origin/master` `1b3d5ffae` verified an ancestor).

