### PR TITLE
test/userspace: make the checked snapshot build the short form

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103277,3 +103277,11 @@ prose edit above them added. No diff falls in the new test body.
     pkg/config/compiler_security_screen.go,
     pkg/config/screen_packed_body_6683_test.go,
     pkg/config/schema_spelling_differential_gate_test.go, docs/config-schema.md
+
+- **Timestamp**: 2026-08-22
+  - **Action**: #7446 — converted the 44 pointer-returning buildSnapshot discard
+    sites (16 files) to must-helpers, added an AST guard against
+    re-introduction, and folded in the contributed #3772 propagation-link test.
+  - **File(s)**: pkg/dataplane/userspace/buildsnapshot_must_7446_test.go,
+    pkg/dataplane/userspace/buildsnapshot_discard_guard_7446_test.go,
+    16 converted *_test.go files, docs/engineering-style.md

--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -496,6 +496,21 @@ they repeatedly bite:
   check passes on any machine that HAS the capability, which is every
   laptop and most CI runners, so it would never notice the stub being
   deleted.
+  **Follow-through (#7446):** hermeticity stops the ENVIRONMENT causing
+  that crash; it does not stop a bad fixture causing it. The 44 call sites
+  that discarded the error now go through `mustBuildSnapshot` /
+  `mustBuildSnapshotWithSchedulerState`, which make the safe form the SHORT
+  form — a call site gets shorter by adopting them, which is what keeps the
+  population from growing back. An AST guard
+  (`TestNoDiscardedSnapshotBuildErrors_7446`) fails if the discarding shape
+  returns. Scope such a guard to the builders that return a POINTER: a nil
+  slice or map reads back safely, so sweeping those in would flag call sites
+  that cannot exhibit the defect — the guard carries a negative-control cell
+  proving it does not.
+  And when a package-wide default is introduced, compare the PASS SET before
+  and after, not just "still green": still-green and unchanged are different
+  claims, and only the second rules out a test that was passing because the
+  real dependency happened to return real data.
 
 - **Smoke tests run ONLY on the loss userspace cluster.** The smoke
   target is `loss:xpf-userspace-fw0` / `loss:xpf-userspace-fw1`,

--- a/pkg/dataplane/userspace/app_catalog_test.go
+++ b/pkg/dataplane/userspace/app_catalog_test.go
@@ -23,7 +23,7 @@ func appCatalogTestConfig() *config.Config {
 
 func TestBuildSnapshotShipsAppCatalog_M5(t *testing.T) {
 	cfg := appCatalogTestConfig()
-	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 1, 0)
 	if len(snap.AppCatalog) == 0 {
 		t.Fatal("snapshot AppCatalog is empty; catalog never ships to Rust (#2008 M5)")
 	}
@@ -44,7 +44,7 @@ func TestBuildSnapshotShipsAppCatalog_M5(t *testing.T) {
 
 func TestAppCatalogSnapshotJSONRoundTrip_M5(t *testing.T) {
 	cfg := appCatalogTestConfig()
-	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 1, 0)
 
 	data, err := json.Marshal(snap)
 	if err != nil {
@@ -80,7 +80,7 @@ func TestAppCatalogSnapshotJSONRoundTrip_M5(t *testing.T) {
 // and a new Rust helper sees an empty catalog (every session keeps app_id 0).
 func TestAppCatalogOmittedWhenEmpty_M5(t *testing.T) {
 	cfg := &config.Config{} // no applications referenced, AppID off
-	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 1, 0)
 	if len(snap.AppCatalog) != 0 {
 		t.Fatalf("expected empty AppCatalog for bare config, got %+v", snap.AppCatalog)
 	}

--- a/pkg/dataplane/userspace/buildsnapshot_discard_guard_7446_test.go
+++ b/pkg/dataplane/userspace/buildsnapshot_discard_guard_7446_test.go
@@ -1,0 +1,101 @@
+package userspace
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #7446: the discarding form must not come back.
+//
+// The population was 44 call sites across 16 files, all of the shape
+// `snap, _ := buildSnapshot(...)` followed by a dereference. Re-introducing one
+// is a two-character edit, and nothing about the result looks wrong until a
+// build failure turns it into a SIGSEGV that aborts the whole test binary. A
+// population that large is not policed by review attention.
+//
+// The scan is over the AST rather than the text, so a comment showing the bad
+// form — including the ones in this file and in the helper file — can neither
+// satisfy nor trip it.
+//
+// Scoped to the three POINTER-returning builders. The sibling builders return
+// slices and maps, where a nil result reads back safely, so a discarded error
+// there is a vacuity smell and not this crash; sweeping them here would flag
+// call sites that cannot exhibit the defect.
+var pointerSnapshotBuilders7446 = map[string]struct{}{
+	"buildSnapshot":                                 {},
+	"buildSnapshotWithSchedulerState":               {},
+	"buildSnapshotWithSchedulerStateAndNATCounters": {},
+}
+
+func TestNoDiscardedSnapshotBuildErrors_7446(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading package dir: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	var offenders []string
+	filesScanned, callsSeen := 0, 0
+
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", name, err)
+		}
+		filesScanned++
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			assign, ok := n.(*ast.AssignStmt)
+			if !ok || len(assign.Rhs) != 1 {
+				return true
+			}
+			call, ok := assign.Rhs[0].(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			fn, ok := call.Fun.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if _, tracked := pointerSnapshotBuilders7446[fn.Name]; !tracked {
+				return true
+			}
+			callsSeen++
+			// The error is the LAST result. Discarding it means the final
+			// left-hand side is the blank identifier.
+			last, ok := assign.Lhs[len(assign.Lhs)-1].(*ast.Ident)
+			if ok && last.Name == "_" {
+				offenders = append(offenders,
+					filepath.Base(fset.Position(assign.Pos()).String())+": "+fn.Name)
+			}
+			return true
+		})
+	}
+
+	// Vacuity, both halves. A scan that read no files, or that read them and
+	// recognised no builder call, would report "no offenders" for the wrong
+	// reason — and this guard's whole value is the absence it asserts.
+	if filesScanned < 50 {
+		t.Fatalf("scanned only %d test files; the guard is not reading the package", filesScanned)
+	}
+	if callsSeen == 0 {
+		t.Fatal("scanned the package and recognised no pointer-returning snapshot " +
+			"builder call at all — the guard would report clean no matter what")
+	}
+
+	if len(offenders) > 0 {
+		t.Errorf("%d call site(s) discard the error from a pointer-returning snapshot "+
+			"builder and can dereference nil, which SIGSEGVs the whole test binary "+
+			"(#7446). Use mustBuildSnapshot / mustBuildSnapshotWithSchedulerState:\n\t%s",
+			len(offenders), strings.Join(offenders, "\n\t"))
+	}
+}

--- a/pkg/dataplane/userspace/buildsnapshot_must_7446_test.go
+++ b/pkg/dataplane/userspace/buildsnapshot_must_7446_test.go
@@ -1,0 +1,101 @@
+package userspace
+
+import (
+	"os"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// #7446: buildSnapshot returns (*ConfigSnapshot, error) and, on ANY failure,
+// returns a NIL pointer. Test call sites that discarded the error dereferenced
+// it, and a nil dereference is a SIGSEGV that aborts the whole test binary —
+// so one bad fixture took every remaining test in the package down with it and
+// reported a crash with no diagnostic instead of naming the failing build step.
+//
+// These helpers make the safe form the SHORT form. A call site gets shorter by
+// adopting them, which is what keeps the population from growing back: the
+// discarding spelling is now strictly more typing than the checked one.
+//
+// Scope, stated because the site count depends entirely on how you count it
+// (#7446 says ~45; a narrower regex counts 36; both are right about different
+// populations): these cover the THREE builders that return a POINTER and can
+// therefore nil-dereference — buildSnapshot, buildSnapshotWithSchedulerState
+// and buildSnapshotWithSchedulerStateAndNATCounters. The sibling builders
+// (buildPolicySnapshots, buildAddressBookTable*, ...) return slices and maps,
+// where a nil result reads back safely; discarding their error is a vacuity
+// smell rather than this crash, and is deliberately NOT swept in here.
+
+func mustBuildSnapshot(t *testing.T, cfg *config.Config, ucfg config.UserspaceConfig,
+	generation uint64, fibGeneration uint32) *ConfigSnapshot {
+	t.Helper()
+	snap, err := buildSnapshot(cfg, ucfg, generation, fibGeneration)
+	return checkedSnapshot7446(t, "buildSnapshot", snap, err)
+}
+
+func mustBuildSnapshotWithSchedulerState(t *testing.T, cfg *config.Config, ucfg config.UserspaceConfig,
+	generation uint64, fibGeneration uint32, activeState map[string]bool,
+	routeOverlay []config.RouteOverlayEntry, feedOverlay map[string][]string) *ConfigSnapshot {
+	t.Helper()
+	snap, err := buildSnapshotWithSchedulerState(cfg, ucfg, generation, fibGeneration,
+		activeState, routeOverlay, feedOverlay)
+	return checkedSnapshot7446(t, "buildSnapshotWithSchedulerState", snap, err)
+}
+
+// checkedSnapshot7446 fails the test rather than returning something a caller
+// can dereference. The nil-with-nil-error arm is not redundant defensiveness:
+// it is the ONLY thing standing between a future builder that forgets to set
+// its error and the exact SIGSEGV this issue exists to remove.
+func checkedSnapshot7446(t *testing.T, who string, snap *ConfigSnapshot, err error) *ConfigSnapshot {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s: %v", who, err)
+	}
+	if snap == nil {
+		t.Fatalf("%s returned a nil snapshot with a nil error", who)
+	}
+	return snap
+}
+
+// TestPermissionDeniedRuleListStillFailsClosed_6675 is the propagation link
+// #6675 left unpinned, contributed on the #7446 issue thread by the lane that
+// independently fixed the same defect (PR #7453, closed as a duplicate of the
+// merged #7445). It belongs with this work rather than as its own PR.
+//
+// routes_rulelist_3772_test.go pins that buildRouteSnapshots SURFACES a
+// RuleList failure. What was not pinned is that buildSnapshot PROPAGATES it and
+// returns nothing shippable — and that link matters precisely BECAUSE the
+// package now installs a stub that can never fail. A future change making
+// buildSnapshot tolerant of a route-snapshot error, or returning a partial
+// snapshot alongside one, would go unnoticed: every call site converted above
+// would then hand the apply path a snapshot #3772 M9 says must not ship.
+//
+// A hermetic default that made a test pass under a real EPERM would be worse
+// than the panic it replaced — it would report coverage for a path never taken.
+//
+// The override restores to the hermetic TestMain stub rather than to
+// netlink.RuleList, so it composes with it.
+func TestPermissionDeniedRuleListStillFailsClosed_6675(t *testing.T) {
+	orig := ruleListFn
+	t.Cleanup(func() { ruleListFn = orig })
+	ruleListFn = func(int) ([]netlink.Rule, error) { return nil, os.ErrPermission }
+
+	cfg := &config.Config{
+		RoutingOptions: config.RoutingOptionsConfig{
+			StaticRoutes: []*config.StaticRoute{{
+				Destination: "10.9.0.0/24",
+				NextHops:    []config.NextHopEntry{{Address: "10.0.1.254"}},
+			}},
+		},
+	}
+	snap, err := buildSnapshot(cfg, config.UserspaceConfig{Workers: 1}, 1, 0)
+	if err == nil {
+		t.Fatalf("a permission-denied ip-rule enumeration was swallowed; #3772 M9 " +
+			"requires the snapshot build to fail closed")
+	}
+	if snap != nil {
+		t.Errorf("buildSnapshot returned a snapshot alongside an error; the apply " +
+			"path must have nothing to ship")
+	}
+}

--- a/pkg/dataplane/userspace/feed_enforcement_test.go
+++ b/pkg/dataplane/userspace/feed_enforcement_test.go
@@ -226,8 +226,8 @@ func TestFeedContentChangeReshapesPublishedSnapshot(t *testing.T) {
 	overlayP1 := map[string][]string{"bad-actors": {"198.51.100.0/24"}}
 	overlayP2 := map[string][]string{"bad-actors": {"203.0.113.0/24"}}
 
-	s1, _ := buildSnapshotWithSchedulerState(cfg, ucfg, 1, 0, nil, nil, overlayP1)
-	s2, _ := buildSnapshotWithSchedulerState(cfg, ucfg, 1, 0, nil, nil, overlayP2)
+	s1 := mustBuildSnapshotWithSchedulerState(t, cfg, ucfg, 1, 0, nil, nil, overlayP1)
+	s2 := mustBuildSnapshotWithSchedulerState(t, cfg, ucfg, 1, 0, nil, nil, overlayP2)
 
 	// The published address-book row follows the new content.
 	row1 := findBookByName(s1.AddressBooks, "bad-actors")
@@ -254,7 +254,7 @@ func TestFeedContentChangeReshapesPublishedSnapshot(t *testing.T) {
 
 	// Conversely: identical overlay content yields an identical hash (the skip
 	// is correct — no wasted round-trip).
-	s1b, _ := buildSnapshotWithSchedulerState(cfg, ucfg, 9, 7, nil, nil, overlayP1)
+	s1b := mustBuildSnapshotWithSchedulerState(t, cfg, ucfg, 9, 7, nil, nil, overlayP1)
 	h1b, _ := snapshotContentHash(s1b)
 	if h1 != h1b {
 		t.Fatalf("identical feed content must yield identical content hash; %x != %x", h1, h1b)

--- a/pkg/dataplane/userspace/flow_wire_coerce_test.go
+++ b/pkg/dataplane/userspace/flow_wire_coerce_test.go
@@ -151,7 +151,7 @@ func TestFullSnapshotMarshalsInRange_1977(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Security.Flow.TCPMSSGreIn = 70000
 	cfg.Security.Flow.TCPSession = &config.TCPSessionConfig{EstablishedTimeout: math.MaxInt64}
-	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 1, 0)
 	if _, err := json.Marshal(&ControlRequest{Type: "apply_snapshot", Snapshot: snap}); err != nil {
 		t.Fatalf("marshal: %v", err)
 	}

--- a/pkg/dataplane/userspace/manager_cos_test.go
+++ b/pkg/dataplane/userspace/manager_cos_test.go
@@ -32,7 +32,7 @@ func TestBuildSnapshotIncludesThreeColorPolicerSchema(t *testing.T) {
 		},
 	}
 
-	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 1, 0)
 	if !snap.Capabilities.ForwardingSupported {
 		t.Fatalf("ForwardingSupported = false, want three-color policers admitted. Reasons: %+v", snap.Capabilities.UnsupportedReasons)
 	}

--- a/pkg/dataplane/userspace/manager_interfaces_test.go
+++ b/pkg/dataplane/userspace/manager_interfaces_test.go
@@ -194,7 +194,7 @@ func TestBuildSnapshotIncludesUnitInterfaces(t *testing.T) {
 		"wan": {Name: "wan", Interfaces: []string{"reth0.50"}},
 	}
 
-	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{Workers: 2, RingEntries: 2048}, 1, 0)
+	snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{Workers: 2, RingEntries: 2048}, 1, 0)
 	got := map[string]InterfaceSnapshot{}
 	for _, iface := range snap.Interfaces {
 		got[iface.Name] = iface

--- a/pkg/dataplane/userspace/manager_mirrors_test.go
+++ b/pkg/dataplane/userspace/manager_mirrors_test.go
@@ -47,7 +47,7 @@ func TestBuildSnapshotIncludesMirrorConfigsFromRealInterfaceSnapshot(t *testing.
 		},
 	}
 
-	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 1, 0)
 	var loIfindex int
 	for _, iface := range snap.Interfaces {
 		if iface.Name == "lo" {

--- a/pkg/dataplane/userspace/manager_policy_test.go
+++ b/pkg/dataplane/userspace/manager_policy_test.go
@@ -33,7 +33,7 @@ func TestUserspaceSupportsSimpleZonePolicies(t *testing.T) {
 			Action: config.PolicyPermit,
 		}},
 	}}
-	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 1, 0)
 	if snap.DefaultPolicy != "deny" || len(snap.Policies) != 1 || snap.Policies[0].Action != "permit" {
 		t.Fatalf("unexpected policy snapshot: %+v", snap.Policies)
 	}
@@ -71,7 +71,7 @@ func TestUserspaceSupportsAddressBookPolicyMatches(t *testing.T) {
 			Action: config.PolicyPermit,
 		}},
 	}}
-	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 1, 0)
 	if len(snap.Policies) != 1 {
 		t.Fatalf("len(Policies) = %d, want 1", len(snap.Policies))
 	}
@@ -109,7 +109,7 @@ func TestUserspaceSupportsNamedApplicationPolicyMatches(t *testing.T) {
 			Action: config.PolicyPermit,
 		}},
 	}}
-	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 1, 0)
 	if len(snap.Policies) != 1 {
 		t.Fatalf("len(Policies) = %d, want 1", len(snap.Policies))
 	}
@@ -138,7 +138,7 @@ func TestUserspaceSupportsGlobalPolicies(t *testing.T) {
 		},
 		Action: config.PolicyPermit,
 	}}
-	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 1, 0)
 	if len(snap.Policies) != 1 || snap.Policies[0].Action != "permit" {
 		t.Fatalf("unexpected global-policy snapshot: %+v", snap.Policies)
 	}
@@ -324,7 +324,7 @@ func TestUpdatePolicyScheduleStatePublishesUserspaceSnapshot(t *testing.T) {
 	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
 	m.cfg.ControlSocket = controlSock
 	m.generation = 7
-	m.lastSnapshot, _ = buildSnapshot(cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
+	m.lastSnapshot = mustBuildSnapshot(t, cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
 	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
 
 	m.UpdatePolicyScheduleState(cfg, map[string]bool{"workhours": false})
@@ -422,7 +422,7 @@ func TestUpdatePolicyScheduleStateRefusesOldHelperForScheduledPolicies(t *testin
 	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
 	m.cfg.ControlSocket = controlSock
 	m.generation = 7
-	m.lastSnapshot, _ = buildSnapshot(cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
+	m.lastSnapshot = mustBuildSnapshot(t, cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
 	m.lastSnapshot.Policies[0].Inactive = false
 
 	m.UpdatePolicyScheduleState(cfg, map[string]bool{"workhours": false})
@@ -475,7 +475,7 @@ func TestUpdatePolicyScheduleStateWithoutHelperDoesNotMutateSnapshot(t *testing.
 
 	m := New()
 	m.generation = 7
-	m.lastSnapshot, _ = buildSnapshot(cfg, config.UserspaceConfig{}, 7, 0)
+	m.lastSnapshot = mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 7, 0)
 	m.lastSnapshot.Policies[0].Inactive = false
 
 	m.UpdatePolicyScheduleState(cfg, map[string]bool{"workhours": false})

--- a/pkg/dataplane/userspace/manager_republish_3780_test.go
+++ b/pkg/dataplane/userspace/manager_republish_3780_test.go
@@ -46,7 +46,7 @@ func TestUpdatePolicyScheduleStateReturnsErrorOnPublishFailure(t *testing.T) {
 	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
 	m.cfg.ControlSocket = controlSock
 	m.generation = 7
-	m.lastSnapshot, _ = buildSnapshot(cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
+	m.lastSnapshot = mustBuildSnapshot(t, cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
 	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
 
 	err := m.UpdatePolicyScheduleState(cfg, map[string]bool{"workhours": false})
@@ -77,7 +77,7 @@ func TestUpdatePolicyScheduleStateNoHelperReportsConverged(t *testing.T) {
 	}
 
 	// Snapshot present but helper not running: still a no-op success.
-	m.lastSnapshot, _ = buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	m.lastSnapshot = mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 1, 0)
 	if err := m.UpdatePolicyScheduleState(cfg, map[string]bool{"workhours": false}); err != nil {
 		t.Fatalf("helperless republish must report converged (nil), got %v", err)
 	}

--- a/pkg/dataplane/userspace/manager_screens_test.go
+++ b/pkg/dataplane/userspace/manager_screens_test.go
@@ -334,13 +334,13 @@ func TestBuildScreenSnapshotsMarksSynCookieMode(t *testing.T) {
 	if !snaps[0].SYNCookie {
 		t.Fatalf("SYNCookie = false, want true: %+v", snaps[0])
 	}
-	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 1, 0)
 	if len(snap.SYNCookieMasterKey) != 32 {
 		t.Fatalf("SYNCookieMasterKey len = %d, want 32", len(snap.SYNCookieMasterKey))
 	}
 	cfg.System.RootAuthentication = nil
 	cfg.System.MasterPassword = "juniper-prf1"
-	snap, _ = buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap = mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 1, 0)
 	if snap.SYNCookieMasterKey != "" {
 		t.Fatalf("SYNCookieMasterKey without root secret = %q, want empty", snap.SYNCookieMasterKey)
 	}

--- a/pkg/dataplane/userspace/manager_snapshot_test.go
+++ b/pkg/dataplane/userspace/manager_snapshot_test.go
@@ -86,7 +86,7 @@ func TestBuildSnapshotSummary(t *testing.T) {
 		},
 	}
 
-	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{Workers: 2, RingEntries: 2048}, 11, 5)
+	snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{Workers: 2, RingEntries: 2048}, 11, 5)
 	if snap.Generation != 11 {
 		t.Fatalf("Generation = %d, want 11", snap.Generation)
 	}
@@ -255,8 +255,8 @@ func TestSnapshotContentHashIgnoresVolatileFields(t *testing.T) {
 	cfg.Security.Zones = map[string]*config.ZoneConfig{
 		"trust": {Name: "trust"},
 	}
-	snap1, _ := buildSnapshot(cfg, config.UserspaceConfig{Workers: 1}, 1, 10)
-	snap2, _ := buildSnapshot(cfg, config.UserspaceConfig{Workers: 1}, 99, 50)
+	snap1 := mustBuildSnapshot(t, cfg, config.UserspaceConfig{Workers: 1}, 1, 10)
+	snap2 := mustBuildSnapshot(t, cfg, config.UserspaceConfig{Workers: 1}, 99, 50)
 
 	h1, ok1 := snapshotContentHash(snap1)
 	h2, ok2 := snapshotContentHash(snap2)
@@ -279,8 +279,8 @@ func TestSnapshotContentHashDiffersOnForwardingChange(t *testing.T) {
 		"untrust": {Name: "untrust"},
 	}
 
-	snap1, _ := buildSnapshot(cfg1, config.UserspaceConfig{Workers: 1}, 1, 1)
-	snap2, _ := buildSnapshot(cfg2, config.UserspaceConfig{Workers: 1}, 1, 1)
+	snap1 := mustBuildSnapshot(t, cfg1, config.UserspaceConfig{Workers: 1}, 1, 1)
+	snap2 := mustBuildSnapshot(t, cfg2, config.UserspaceConfig{Workers: 1}, 1, 1)
 
 	h1, ok1 := snapshotContentHash(snap1)
 	h2, ok2 := snapshotContentHash(snap2)

--- a/pkg/dataplane/userspace/protocol_failopen_2124_test.go
+++ b/pkg/dataplane/userspace/protocol_failopen_2124_test.go
@@ -119,7 +119,7 @@ func TestBuildOneRuleSnapshotEmitsUnsupportedSentinel(t *testing.T) {
 	// sentinel term (so Rust fails the whole snapshot closed), NEVER nil (which
 	// Rust would read as genuine match-any — the publish-window fail-open).
 	cfg := twoZonePolicyCfg(&config.Application{Name: "weird", Protocol: "definitely-not-a-proto"}, "weird")
-	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 1, 0)
 	if len(snap.Policies) != 1 {
 		t.Fatalf("len(Policies) = %d, want 1", len(snap.Policies))
 	}
@@ -136,7 +136,7 @@ func TestBuildOneRuleSnapshotNoSentinelForSupportedApp(t *testing.T) {
 	// A supported named protocol must NOT trigger the sentinel; the rule carries
 	// a normal canonicalized term.
 	cfg := twoZonePolicyCfg(&config.Application{Name: "esp-only", Protocol: "esp"}, "esp-only")
-	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 1, 0)
 	terms := snap.Policies[0].ApplicationTerms
 	if len(terms) != 1 || terms[0].Protocol != "50" {
 		t.Fatalf("ApplicationTerms = %+v, want one esp term canonicalized to \"50\"", terms)

--- a/pkg/dataplane/userspace/protocol_null_collections_2214_test.go
+++ b/pkg/dataplane/userspace/protocol_null_collections_2214_test.go
@@ -133,7 +133,7 @@ func TestSnapshotWireNoNullCollections2214(t *testing.T) {
 	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
 		"EMPTY": {Name: "EMPTY"},
 	}
-	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 1, 0)
 
 	if len(snap.NAT64) != 1 {
 		t.Fatalf("snap.NAT64 = %d, want 1", len(snap.NAT64))

--- a/pkg/dataplane/userspace/route_overlay_test.go
+++ b/pkg/dataplane/userspace/route_overlay_test.go
@@ -108,8 +108,8 @@ func TestRouteOverlayWholeEntryReplacement(t *testing.T) {
 // would be a failover-doesn't-happen bug).
 func TestRouteOverlayContentHashDelta(t *testing.T) {
 	cfg := overlayTestConfig()
-	base, _ := buildSnapshotWithSchedulerState(cfg, config.UserspaceConfig{}, 1, 0, nil, nil, nil)
-	withOverlay, _ := buildSnapshotWithSchedulerState(cfg, config.UserspaceConfig{}, 1, 0, nil,
+	base := mustBuildSnapshotWithSchedulerState(t, cfg, config.UserspaceConfig{}, 1, 0, nil, nil, nil)
+	withOverlay := mustBuildSnapshotWithSchedulerState(t, cfg, config.UserspaceConfig{}, 1, 0, nil,
 		[]config.RouteOverlayEntry{{Destination: "0.0.0.0/0", NextHop: "172.16.80.1", Policy: "p"}}, nil)
 
 	h1, ok1 := snapshotContentHash(base)
@@ -122,7 +122,7 @@ func TestRouteOverlayContentHashDelta(t *testing.T) {
 	}
 
 	// Same overlay again ⇒ identical hash (duplicate-publish basis).
-	again, _ := buildSnapshotWithSchedulerState(cfg, config.UserspaceConfig{}, 2, 7, nil,
+	again := mustBuildSnapshotWithSchedulerState(t, cfg, config.UserspaceConfig{}, 2, 7, nil,
 		[]config.RouteOverlayEntry{{Destination: "0.0.0.0/0", NextHop: "172.16.80.1", Policy: "p"}}, nil)
 	h3, _ := snapshotContentHash(again)
 	if h2 != h3 {
@@ -183,7 +183,7 @@ func TestPublishRouteOverlaySnapshot(t *testing.T) {
 	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
 	m.cfg.ControlSocket = controlSock
 	m.generation = 7
-	m.lastSnapshot, _ = buildSnapshot(cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
+	m.lastSnapshot = mustBuildSnapshot(t, cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
 	if h, ok := snapshotContentHash(m.lastSnapshot); ok {
 		m.lastSnapshotHash = h
 	}
@@ -262,7 +262,7 @@ func TestPublishRouteOverlaySnapshot(t *testing.T) {
 	// Full-apply preservation (AGY r2-2): the cached overlay feeds the
 	// full snapshot build, so an operator commit while a policy is
 	// FAILED keeps the injected route.
-	snap, _ := buildSnapshotWithSchedulerState(cfg, config.UserspaceConfig{}, 9, 0, nil, m.routeOverlaySnapshot(), m.feedSnapshotOverlay())
+	snap := mustBuildSnapshotWithSchedulerState(t, cfg, config.UserspaceConfig{}, 9, 0, nil, m.routeOverlaySnapshot(), m.feedSnapshotOverlay())
 	kept := false
 	for _, r := range snap.Routes {
 		if r.Table == "inet.0" && r.Destination == "0.0.0.0/0" &&
@@ -326,7 +326,7 @@ func TestPublishRouteOverlaySnapshotRefusesPolicyHybrid(t *testing.T) {
 	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
 	m.cfg.ControlSocket = controlSock
 	m.generation = 7
-	m.lastSnapshot, _ = buildSnapshot(cfgA, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
+	m.lastSnapshot = mustBuildSnapshot(t, cfgA, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
 	if h, ok := snapshotContentHash(m.lastSnapshot); ok {
 		m.lastSnapshotHash = h
 	}
@@ -396,7 +396,7 @@ func TestPublishRouteOverlaySnapshotAcceptsEqualConfigDistinctPointer(t *testing
 	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
 	m.cfg.ControlSocket = controlSock
 	m.generation = 7
-	m.lastSnapshot, _ = buildSnapshot(applied, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
+	m.lastSnapshot = mustBuildSnapshot(t, applied, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
 	if h, ok := snapshotContentHash(m.lastSnapshot); ok {
 		m.lastSnapshotHash = h
 	}
@@ -562,7 +562,7 @@ func TestPublishRouteOverlaySnapshotFailureKeepsBaseline(t *testing.T) {
 	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
 	m.cfg.ControlSocket = controlSock
 	m.generation = 7
-	m.lastSnapshot, _ = buildSnapshot(cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
+	m.lastSnapshot = mustBuildSnapshot(t, cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
 	if h, ok := snapshotContentHash(m.lastSnapshot); ok {
 		m.lastSnapshotHash = h
 	}
@@ -607,7 +607,7 @@ func TestPublishRouteOverlaySnapshotFailureKeepsBaseline(t *testing.T) {
 
 	// (b) A full apply reads the cached overlay; it must rebuild A's route,
 	//     matching what the dataplane actually has — NOT the failed B.
-	snap, _ := buildSnapshotWithSchedulerState(cfg, config.UserspaceConfig{}, 9, 0, nil, m.routeOverlaySnapshot(), m.feedSnapshotOverlay())
+	snap := mustBuildSnapshotWithSchedulerState(t, cfg, config.UserspaceConfig{}, 9, 0, nil, m.routeOverlaySnapshot(), m.feedSnapshotOverlay())
 	for _, r := range snap.Routes {
 		if r.Table == "inet.0" && r.Destination == "0.0.0.0/0" {
 			if len(r.NextHops) != 1 || r.NextHops[0] != "172.16.80.1" {

--- a/pkg/dataplane/userspace/set_forwarding_armed_generation_5648_test.go
+++ b/pkg/dataplane/userspace/set_forwarding_armed_generation_5648_test.go
@@ -73,7 +73,7 @@ func TestSetForwardingArmedRefusesStaleProtocolMismatch(t *testing.T) {
 	m.lastStatus.ConfigSnapshotProtocolVersion = MinProtocolPolicyScheduler - 1
 	// Last-applied config carries scheduler-driven policy, so it REQUIRES at
 	// least MinProtocolPolicyScheduler.
-	m.lastSnapshot, _ = buildSnapshot(scheduledPolicyCfg(), config.UserspaceConfig{ControlSocket: sock}, 5, 0)
+	m.lastSnapshot = mustBuildSnapshot(t, scheduledPolicyCfg(), config.UserspaceConfig{ControlSocket: sock}, 5, 0)
 
 	_, err := m.SetForwardingArmed(true)
 	if !errors.Is(err, ErrPolicySchedulerProtocolIncompatible) {
@@ -111,7 +111,7 @@ func TestSetForwardingArmedArmsWhenProtocolMatches(t *testing.T) {
 	// Helper's accepted image is CURRENT — satisfies the required protocol.
 	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
 	// Same protocol-requiring config as the mismatch test.
-	m.lastSnapshot, _ = buildSnapshot(scheduledPolicyCfg(), config.UserspaceConfig{ControlSocket: sock}, 5, 0)
+	m.lastSnapshot = mustBuildSnapshot(t, scheduledPolicyCfg(), config.UserspaceConfig{ControlSocket: sock}, 5, 0)
 
 	// applyHelperStatusLocked touches a BPF map absent in a unit test, so the
 	// call may return that local-bookkeeping error AFTER the wire arm request

--- a/pkg/dataplane/userspace/sync_desired_forwarding_generation_6165_test.go
+++ b/pkg/dataplane/userspace/sync_desired_forwarding_generation_6165_test.go
@@ -59,7 +59,7 @@ func TestSyncDesiredForwardingRefusesStaleProtocolMismatch(t *testing.T) {
 	m.lastStatus.ConfigSnapshotProtocolVersion = MinProtocolPolicyScheduler - 1
 	// Last-applied config carries scheduler-driven policy, so it REQUIRES at
 	// least MinProtocolPolicyScheduler.
-	m.lastSnapshot, _ = buildSnapshot(scheduledPolicyCfg(), config.UserspaceConfig{ControlSocket: sock}, 5, 0)
+	m.lastSnapshot = mustBuildSnapshot(t, scheduledPolicyCfg(), config.UserspaceConfig{ControlSocket: sock}, 5, 0)
 
 	// Guard the premise: absent the gate the reconcile WOULD arm — it only
 	// sends when desired != current and desired is true.
@@ -106,7 +106,7 @@ func TestSyncDesiredForwardingArmsWhenProtocolMatches(t *testing.T) {
 	// Helper's accepted image is CURRENT — satisfies the required protocol.
 	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
 	// Same protocol-requiring config as the mismatch test.
-	m.lastSnapshot, _ = buildSnapshot(scheduledPolicyCfg(), config.UserspaceConfig{ControlSocket: sock}, 5, 0)
+	m.lastSnapshot = mustBuildSnapshot(t, scheduledPolicyCfg(), config.UserspaceConfig{ControlSocket: sock}, 5, 0)
 
 	// applyHelperStatusLocked touches a BPF map absent in a unit test, so the
 	// call may return that local-bookkeeping error AFTER the wire arm request
@@ -148,7 +148,7 @@ func TestSyncDesiredForwardingDisarmNotBlockedByGate(t *testing.T) {
 	m.lastStatus.Capabilities.ForwardingSupported = true
 	m.lastStatus.ForwardingArmed = true
 	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion - 1
-	m.lastSnapshot, _ = buildSnapshot(scheduledPolicyCfg(), config.UserspaceConfig{ControlSocket: sock}, 5, 0)
+	m.lastSnapshot = mustBuildSnapshot(t, scheduledPolicyCfg(), config.UserspaceConfig{ControlSocket: sock}, 5, 0)
 
 	if m.desiredForwardingArmedLocked() {
 		t.Fatal("test setup: desiredForwardingArmedLocked() must be false so the reconcile disarms")

--- a/pkg/dataplane/userspace/wire_uint8list_test.go
+++ b/pkg/dataplane/userspace/wire_uint8list_test.go
@@ -169,7 +169,7 @@ func TestBuildSnapshotFromFullConfigDecodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{Workers: 4, RingEntries: 1024}, 3, 3)
+	snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{Workers: 4, RingEntries: 1024}, 3, 3)
 	buf, err := json.Marshal(&ControlRequest{Type: "apply_snapshot", Snapshot: snap})
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)


### PR DESCRIPTION
Closes #7446

`buildSnapshot` returns `(*ConfigSnapshot, error)` and on **any** failure returns a nil pointer. 44 test call sites across 16 files discarded the error and dereferenced it — and a nil dereference is a **SIGSEGV that aborts the whole test binary**, so one bad fixture takes every remaining test in the package with it and reports a crash with no diagnostic.

#6675 made the package hermetic, which stopped the *environment* causing that. It did not stop a bad fixture causing it, and it left a population too large for review attention to police.

## Which population — because the count depends on how you measure it

| measurement | count |
|---|---|
| the issue | ~45 |
| the independent lane's narrower regex | 36 |
| any discarded error from any `build*` helper here | 78 |
| **fixed here: the three POINTER-returning builders** | **44 across 16 files** |

The other 34 are deliberately **not** swept in. `buildPolicySnapshots`, `buildAddressBookTable*` and siblings return slices and maps, where a nil result reads back safely — ranging a nil slice and indexing a nil map both work. Discarding their error is a vacuity smell, a different and weaker defect, and folding it in would flag call sites that **cannot exhibit this crash**. The guard carries a negative-control cell that fails if it ever starts flagging them.

## The mechanism is that the safe form is now the *short* form

`mustBuildSnapshot` / `mustBuildSnapshotWithSchedulerState` make a call site **shorter** by adopting them, so the discarding spelling is strictly more typing than the checked one and the population does not grow back by inertia. They also fail on a nil snapshot with a nil error — not redundant defensiveness, but the only thing between a future builder that forgets to set its error and the exact SIGSEGV this removes.

`TestNoDiscardedSnapshotBuildErrors_7446` fails if the discarding shape returns. It scans the **AST**, so a comment showing the bad form — including the ones in these two files — can neither satisfy nor trip it. Both vacuity halves are asserted: a scan that read no files, or read them and recognised no builder call, would report "no offenders" for the wrong reason, and the whole value of this guard is the absence it asserts.

## Contributed test, folded in

`TestPermissionDeniedRuleListStillFailsClosed_6675` comes from the #7446 thread, from the lane that independently fixed the same defect (PR #7453, closed as a duplicate of the merged #7445).

It pins the link #6675 left open: `routes_rulelist_3772_test.go` pins that `buildRouteSnapshots` **surfaces** a `RuleList` failure, but nothing pinned that `buildSnapshot` **propagates** it and returns nothing shippable. That matters *because* the package now installs a stub that can never fail — a hermetic default that made a test pass under a real EPERM would be worse than the panic it replaced, since it would report coverage for a path never taken.

## Pass-set comparison, not just a green run

Using the technique offered on the same thread — still-green and unchanged are different claims, and only the second rules out a test that was passing for a different reason.

`-count=1 -v` at `origin/master` vs this branch:

```
before 1800 results
after  1802 results
removed/changed  0
added            exactly the 2 tests below
```

**The first attempt at that comparison was void**, and it is worth recording: the "after" leg ran in the main checkout rather than this worktree because the subshell never changed directory. It reported 156 results removed and a failure that does not exist here. A measurement's tree is part of the measurement.

## Mutation matrix

Every cell verified APPLIED first.

| # | mutation | result |
|---|---|---|
| V1 | re-introduce one discard site | **RED** — the AST guard |
| V2 | `buildSnapshot` swallows the route error | **RED** — propagation test, `err` arm |
| V3 | return a partial snapshot **with** the error | **RED** — propagation test, `snap` arm |
| V4 | make the guard scan an empty directory | **RED** — its own vacuity assert |
| V5 | discard on a **slice**-returning builder | **GREEN, by design** |

V5 is a negative control rather than a gap: it proves the guard's scope is deliberate and not "flag every discarded error".

## Validation

Full `go test -count=1 ./...` green; `go build ./...` clean.

**Test-only change plus a docs note** (`docs/engineering-style.md`). No production code, no dataplane, no cluster surface.