### PR TITLE
config: read the whole as-path regex token tail, and validate it

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103313,3 +103313,14 @@ prose edit above them added. No diff falls in the new test body.
     pkg/daemon/rollback_target_appliable_6707_test.go (new),
     pkg/daemon/daemon_apply_commit.go, pkg/daemon/README.md,
     docs/bare-metal-device-map.md
+
+## 2026-08-22 — #6686 as-path multi-token regex
+- **Action**: Fixed `policy-options as-path` reading only the first tail token
+  (unquoted `.* 65000 .*` compiled to `.*`), added the shared
+  `ValidASPathRegex` predicate + strict commit gate + FRR render belt.
+- **File(s)**: `pkg/config/aspath_regex.go` (new),
+  `pkg/config/compiler_routing.go`, `pkg/config/compiler_validate_strict_routing.go`,
+  `pkg/config/compiler_opts.go`, `pkg/config/compiler_uniformgates_log_feed_routing.go`,
+  `pkg/frr/policy_render.go`,
+  `pkg/config/compiler_as_path_multitoken_6686_test.go` (new),
+  `pkg/frr/policy_aspath_regex_6686_test.go` (new), `docs/config-schema.md`

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -5110,6 +5110,57 @@ is exactly the repetition). The ordered list lands in `PolicyTerm.ASPathPrepend
 `TestGeneratePolicyOptions_ASPathPrepend` in
 `pkg/frr/policy_as_path_prepend_2892_test.go` (render).
 
+### The as-path REGEX is the whole token tail, and it is validated (#6686)
+
+`policy-options as-path <name> <regex>` is a `args: 2, multi: true` schema node
+(`schema_routing.go`), so the definition's regular expression is the node's
+whole trailing token run — not one key. The two spellings of one value land
+differently:
+
+| authored | Keys |
+|---|---|
+| `as-path AP1 ".* 65000 .*"` | `["as-path" "AP1" ".* 65000 .*"]` (one lexer string token) |
+| `as-path AP1 .* 65000 .*` | `["as-path" "AP1" ".*" "65000" ".*"]` |
+
+Reading `Keys[2]` alone kept the FIRST token of the unquoted spelling, compiling
+`.* 65000 .*` down to `.*` — the whole-path wildcard. A `from as-path AP1; then
+accept` term built on that definition accepts **every** BGP path instead of only
+those transiting AS 65000: a route-leak / hijack-acceptance exposure that
+committed clean with zero warnings, in BOTH the flat-`set` and hierarchical
+spellings, while `show configuration` displayed the authored regex back
+verbatim. The same widening applied one level down, to a hierarchical brace body
+(`as-path AP1 { .* 65000 .*; }`), whose regex tokens land on a CHILD leaf's
+`Keys` and were read as `entry.Keys[0]`.
+
+`ASPathRegexFromTokens` (`aspath_regex.go`) rejoins the tail with single spaces
+at both sites. That is reconstruction, not a guess: every regex metacharacter
+that is also lexer syntax (`^`, `{`, `}`, `|`, `[`, `]`, `;`, `"`) either fails
+to lex unquoted or is stripped, so an unquoted regex reaching the compiler is a
+whitespace-separated run of identifier tokens. FRR's `bgp as-path access-list`
+DEFUN ends in a variadic `LINE...` that `argv_concat` rejoins with single
+spaces, which is what makes a multi-AS pattern expressible at all — so the join
+matches what FRR itself does with the rendered line.
+
+**The regex is validated, at three layers with one predicate.** `ValidASPathRegex`
+(`aspath_regex.go`) rejects an EMPTY regex — reachable with no diagnostic at all
+via `set policy-options as-path AP1` with no value — and one that is not a valid
+POSIX ERE. Either renders a line frr-reload rejects (an incomplete command, or a
+regcomp failure), and a single `CMD_WARNING_CONFIG_FAILED` exits the whole vtysh
+add-batch non-zero, failing the ENTIRE reload and leaving every dynamic routing
+change stale. `validatePolicyASPathRegexStrict` hard-rejects on commit /
+commit-check; the tolerant load / peer-sync paths downgrade to a warning
+(`lenientPolicyASPathRegex`, the #1960 no-brick class); and `generatePolicyOptions`
+(`pkg/frr/policy_render.go`) OMITS an unrenderable definition so the leniently
+loaded config cannot poison the reload — FRR resolves a `match as-path <name>`
+with no such list to NO MATCH, confining the damage to the referencing terms.
+The three layers share `ValidASPathRegex` so they cannot drift.
+
+Fail-on-revert covered by `pkg/config/compiler_as_path_multitoken_6686_test.go`
+(five spellings asserted to AGREE and to equal the authored regex, the empty and
+malformed strict/lenient legs, and a tightening control that commits nine real
+AS-path regexes clean) and `pkg/frr/policy_aspath_regex_6686_test.go` (the
+multi-token regex renders whole; the unrenderable ones are omitted).
+
 ### Repeated policy-statement blocks MERGE, not last-win (#5824)
 
 A single `policy-options policy-statement <name>` may be authored across MULTIPLE

--- a/pkg/config/aspath_regex.go
+++ b/pkg/config/aspath_regex.go
@@ -1,0 +1,102 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// aspath_regex.go owns the two shared primitives for a `policy-options
+// as-path <name> <regex>` definition: reconstructing the regex from the
+// token tail the grammar packs onto ONE node, and deciding whether the
+// resulting string can be rendered into frr.conf at all (#6686).
+//
+// Both are shared on purpose. The compiler (compiler_routing.go), the
+// strict commit gate (compiler_validate_strict_routing.go) and the FRR
+// renderer (pkg/frr/policy_render.go) must agree on what a valid as-path
+// regex is: a divergence there is always a bug — either the commit gate
+// rejects something the renderer would have emitted happily, or the
+// renderer emits a line the gate believed it had already excluded.
+
+// ASPathRegexFromTokens joins the token TAIL of an as-path definition back
+// into one regular expression.
+//
+// The `policy-options as-path` grammar is `args: 2, multi: true`
+// (schema_routing.go): the node's own Keys carry `["as-path", <name>,
+// <regex>...]`, and `multi` absorbs every trailing token onto that same
+// key list. A QUOTED regex — `as-path AP1 ".* 65000 .*"` — is one lexer
+// string token and lands whole in Keys[2]. The UNQUOTED spelling of the
+// same value — `as-path AP1 .* 65000 .*` — lexes as three identifier
+// tokens and lands as Keys[2:] = [".*", "65000", ".*"].
+//
+// Reading Keys[2] alone therefore kept only the FIRST token of the
+// unquoted spelling, silently compiling `.* 65000 .*` down to `.*` — the
+// whole-path wildcard. A `from as-path AP1; then accept` term built on
+// that definition accepts EVERY BGP path instead of only those transiting
+// AS 65000: a route-leak / hijack-acceptance exposure that commits clean
+// with zero warnings and displays the authored regex back verbatim in
+// `show configuration` (#6686).
+//
+// Joining with a single space is faithful rather than a guess. The lexer
+// only ever hands back identifier tokens here — every regex metacharacter
+// that is also lexer syntax (`^`, `{`, `}`, `|`, `[`, `]`, `;`, `"`)
+// either fails to lex unquoted or is stripped, so an unquoted regex that
+// reaches this function is a whitespace-separated run of identifier
+// tokens and re-joining them reconstructs the authored text (runs of
+// whitespace collapse to one space, which an AS-path regex — matched
+// against a single-space-separated AS_PATH string — treats identically).
+// FRR takes the as-path regex as a REST-OF-LINE token (see the
+// `bgp as-path access-list` render in pkg/frr/policy_render.go), so an
+// embedded space survives the render intact.
+//
+// Empty tokens are skipped so a stray separator cannot introduce a double
+// space. A tail of only empty tokens returns "" — the caller decides what
+// an absent regex means.
+func ASPathRegexFromTokens(tokens []string) string {
+	parts := make([]string, 0, len(tokens))
+	for _, tok := range tokens {
+		if tok != "" {
+			parts = append(parts, tok)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// ValidASPathRegex reports why an as-path regex cannot be rendered into
+// frr.conf, or nil when it can.
+//
+// xpf renders one `bgp as-path access-list <name> permit <regex>` line per
+// definition. Two values break that line rather than narrowing it:
+//
+//   - an EMPTY regex renders `bgp as-path access-list AP1 permit` with no
+//     argument, which FRR rejects as an incomplete command;
+//   - a regex that is not a valid POSIX extended regular expression fails
+//     FRR's regcomp at config load.
+//
+// Either one is a CMD_WARNING_CONFIG_FAILED, and a single such failure
+// exits the whole vtysh add-batch non-zero — so it does not merely lose
+// this one as-path list, it fails the ENTIRE frr-reload and leaves every
+// dynamic routing change stale. That is why this is a validation gate and
+// not a render-time shrug.
+//
+// The check is `regexp.CompilePOSIX`, Go's egrep-syntax (POSIX ERE) mode,
+// which is the same dialect FRR compiles with REG_EXTENDED. Where the two
+// engines differ they differ in the SAFE direction: Go is the stricter of
+// the pair, so a pattern rejected here is at worst one glibc would have
+// accepted with undefined semantics (a leading bare `*`, a Perl class
+// escape POSIX reads as a literal) — an operator-visible commit error on
+// a pattern that was not going to mean what it looked like, rather than a
+// poisoned reload.
+//
+// Control characters are NOT re-checked here: the strict #1798 commit
+// control-char gate already rejects them, and pkg/frr's sanitizeFRRValue
+// is the render-side belt for the leniently-loaded case.
+func ValidASPathRegex(regex string) error {
+	if strings.TrimSpace(regex) == "" {
+		return fmt.Errorf("empty regular expression")
+	}
+	if _, err := regexp.CompilePOSIX(regex); err != nil {
+		return fmt.Errorf("not a valid POSIX extended regular expression: %w", err)
+	}
+	return nil
+}

--- a/pkg/config/compiler_as_path_multitoken_6686_test.go
+++ b/pkg/config/compiler_as_path_multitoken_6686_test.go
@@ -1,0 +1,259 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6686: a `policy-options as-path <name> <regex>` written in its
+// MULTI-TOKEN (unquoted) spelling compiled to the FIRST token only, so
+// `.* 65000 .*` became `.*` — the whole-path wildcard. A
+// `from as-path AP1; then accept` term built on that definition accepts
+// EVERY BGP path instead of only those transiting AS 65000: a route-leak /
+// hijack-acceptance exposure that committed clean with zero warnings while
+// `show configuration` displayed the authored regex back verbatim.
+
+// aspathCompile builds a tree from flat `set` lines and returns the
+// compiled as-path regex for name, plus the compile error.
+func aspathCompileSet(t *testing.T, lines ...string) (string, error) {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, l := range lines {
+		path, err := ParseSetCommand(l)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", l, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", l, err)
+		}
+	}
+	cfg, cerr := CompileConfig(tree)
+	if cfg == nil {
+		return "", cerr
+	}
+	ap := cfg.PolicyOptions.ASPaths["AP1"]
+	if ap == nil {
+		return "", cerr
+	}
+	return ap.Regex, cerr
+}
+
+// aspathCompileSrc is aspathCompileSet for the hierarchical brace spelling.
+func aspathCompileSrc(t *testing.T, src string) (string, error) {
+	t.Helper()
+	tree, perr := NewParser(src).Parse()
+	if perr != nil {
+		t.Fatalf("parse %q: %v", src, perr)
+	}
+	cfg, cerr := CompileConfig(tree)
+	if cfg == nil {
+		return "", cerr
+	}
+	ap := cfg.PolicyOptions.ASPaths["AP1"]
+	if ap == nil {
+		return "", cerr
+	}
+	return ap.Regex, cerr
+}
+
+// TestASPath6686SpellingsAgreeOnTheAuthoredRegex is the core guard. Five
+// spellings of ONE as-path definition must compile to ONE regex.
+//
+// The assertion is written as an AGREEMENT between the spellings first and
+// a literal second, deliberately: pinning only the packed spelling to a
+// hand-written expectation encodes which side is trusted, and in the
+// sibling packed-body work (#7457) the defect turned out to be on the side
+// every issue had assumed was correct. Agreement fails whichever side
+// breaks.
+//
+// FAIL-ON-REVERT: restoring `Regex: child.Keys[2]` (and the child loop's
+// `ap.Regex = entry.Keys[0]`) in compilePolicyOptions makes the three
+// unquoted spellings compile to `.*` while the quoted ones keep the full
+// pattern, so both the agreement check and the wildcard check red.
+func TestASPath6686SpellingsAgreeOnTheAuthoredRegex(t *testing.T) {
+	const authored = `.* 65000 .*`
+
+	type spelling struct {
+		name  string
+		regex string
+	}
+	var got []spelling
+
+	// 1. flat set, QUOTED — the spelling that always worked.
+	r, err := aspathCompileSet(t, `set policy-options as-path AP1 ".* 65000 .*"`)
+	if err != nil {
+		t.Fatalf("quoted flat set: compile: %v", err)
+	}
+	got = append(got, spelling{"flat-set quoted", r})
+
+	// 2. flat set, UNQUOTED — the #6686 defect. `multi: true` packs the
+	//    tail onto the node's own Keys: [".*" "65000" ".*"].
+	r, err = aspathCompileSet(t, `set policy-options as-path AP1 .* 65000 .*`)
+	if err != nil {
+		t.Fatalf("unquoted flat set: compile: %v", err)
+	}
+	got = append(got, spelling{"flat-set unquoted", r})
+
+	// 3. hierarchical leaf, QUOTED.
+	r, err = aspathCompileSrc(t, "policy-options {\n    as-path AP1 \".* 65000 .*\";\n}\n")
+	if err != nil {
+		t.Fatalf("quoted hierarchical: compile: %v", err)
+	}
+	got = append(got, spelling{"hierarchical quoted", r})
+
+	// 4. hierarchical leaf, UNQUOTED — the issue reports the defect in
+	//    BOTH spellings, so both are covered.
+	r, err = aspathCompileSrc(t, "policy-options {\n    as-path AP1 .* 65000 .*;\n}\n")
+	if err != nil {
+		t.Fatalf("unquoted hierarchical: compile: %v", err)
+	}
+	got = append(got, spelling{"hierarchical unquoted", r})
+
+	// 5. hierarchical BRACE BODY, unquoted — the same widening one level
+	//    down, where the regex tokens land on a CHILD leaf's Keys.
+	r, err = aspathCompileSrc(t, "policy-options {\n    as-path AP1 {\n        .* 65000 .*;\n    }\n}\n")
+	if err != nil {
+		t.Fatalf("unquoted hierarchical body: compile: %v", err)
+	}
+	got = append(got, spelling{"hierarchical body unquoted", r})
+
+	for _, s := range got {
+		if s.regex != got[0].regex {
+			t.Errorf("spelling %q compiled Regex=%q, but %q compiled Regex=%q — "+
+				"the two spellings of one as-path definition disagree",
+				s.name, s.regex, got[0].name, got[0].regex)
+		}
+		// The security property, stated directly: the authored pattern is
+		// a TRANSIT match; `.*` matches every AS path there is.
+		if s.regex == ".*" {
+			t.Errorf("spelling %q compiled Regex=%q — the whole-path wildcard. "+
+				"A `from as-path AP1; then accept` term now accepts EVERY BGP "+
+				"path instead of only those transiting AS 65000 (#6686)", s.name, s.regex)
+		}
+		if s.regex != authored {
+			t.Errorf("spelling %q compiled Regex=%q, want the authored %q",
+				s.name, s.regex, authored)
+		}
+	}
+}
+
+// TestASPath6686EmptyRegexRejectedStrictWarnedLenient covers the value that
+// reached the FRR render with no diagnostic at all: `set policy-options
+// as-path AP1` with no regex compiled to Regex "" and committed clean. xpf
+// then renders `bgp as-path access-list AP1 permit` with no argument — an
+// incomplete FRR command, and a single CMD_WARNING_CONFIG_FAILED exits the
+// whole vtysh add-batch non-zero, failing the ENTIRE frr-reload.
+//
+// Strict (commit / commit-check) must REJECT; the tolerant load / peer-sync
+// path must WARN and still boot (#1960 no-brick).
+//
+// FAIL-ON-REVERT: deleting the validatePolicyASPathRegexStrict call from
+// the gate chain makes the strict leg return nil and reds.
+func TestASPath6686EmptyRegexRejectedStrictWarnedLenient(t *testing.T) {
+	build := func() *ConfigTree {
+		tree := &ConfigTree{}
+		path, err := ParseSetCommand(`set policy-options as-path AP1`)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("setpath: %v", err)
+		}
+		return tree
+	}
+
+	if _, err := CompileConfig(build()); err == nil {
+		t.Fatal("strict commit ACCEPTED `as-path AP1` with no regex — xpf would " +
+			"render `bgp as-path access-list AP1 permit` with no argument and " +
+			"fail the entire frr-reload (#6686)")
+	} else if !strings.Contains(err.Error(), "as-path AP1") {
+		t.Errorf("strict rejection does not name the as-path: %v", err)
+	}
+
+	cfg, err := CompileConfigLenient(build())
+	if err != nil {
+		t.Fatalf("tolerant load REJECTED an already-persisted config (#1960 brick): %v", err)
+	}
+	if !warnMentions(cfg.Warnings, "as-path AP1") {
+		t.Errorf("tolerant load produced no as-path warning; warnings=%v", cfg.Warnings)
+	}
+}
+
+// TestASPath6686MalformedRegexRejectedStrictWarnedLenient is the same gate
+// for a regex FRR's regcomp cannot compile.
+func TestASPath6686MalformedRegexRejectedStrictWarnedLenient(t *testing.T) {
+	build := func() *ConfigTree {
+		tree := &ConfigTree{}
+		path, err := ParseSetCommand(`set policy-options as-path AP1 "((("`)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("setpath: %v", err)
+		}
+		return tree
+	}
+
+	if _, err := CompileConfig(build()); err == nil {
+		t.Fatal("strict commit ACCEPTED an as-path regex `(((` — frr-reload " +
+			"rejects the rendered line and fails the entire FRR config load (#6686)")
+	}
+	cfg, err := CompileConfigLenient(build())
+	if err != nil {
+		t.Fatalf("tolerant load REJECTED an already-persisted config (#1960 brick): %v", err)
+	}
+	if !warnMentions(cfg.Warnings, "as-path AP1") {
+		t.Errorf("tolerant load produced no as-path warning; warnings=%v", cfg.Warnings)
+	}
+}
+
+// TestASPath6686RealRegexesStillCommitClean is the TIGHTENING control. The
+// gate above is a new commit-path rejection, so it owes a proof that it
+// does not over-reject the AS-path regular expressions operators actually
+// write — including the multi-token pattern the fix now reconstructs
+// (which a whitespace-hostile validator would reject) and `^$`, the
+// locally-originated match, which an "empty means absent" validator that
+// stripped metacharacters would reject.
+//
+// A validator tightened to reject spaces, or to reject any pattern that is
+// not a bare ASN, reds here while every delete-the-guard cell stays green.
+func TestASPath6686RealRegexesStillCommitClean(t *testing.T) {
+	for _, re := range []string{
+		`.* 65000 .*`,      // transit through AS 65000 — the #6686 pattern
+		`^65000$`,          // exactly one AS
+		`^65000 65001$`,    // an exact two-AS path (multi-token by nature)
+		`(65000|65001)`,    // alternation
+		`65000{1,3}`,       // POSIX ERE bound
+		`^65000 [0-9]+$`,   // character class
+		`.*`,               // an INTENTIONAL match-everything
+		`^$`,               // locally originated (empty AS path)
+		`^65000 .* 65010$`, // origin + transit
+	} {
+		tree := &ConfigTree{}
+		line := `set policy-options as-path AP1 "` + re + `"`
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+		cfg, cerr := CompileConfig(tree)
+		if cerr != nil {
+			t.Errorf("strict commit REJECTED a legitimate as-path regex %q: %v", re, cerr)
+			continue
+		}
+		if ap := cfg.PolicyOptions.ASPaths["AP1"]; ap == nil || ap.Regex != re {
+			t.Errorf("as-path regex %q compiled to %#v, want it preserved verbatim", re, ap)
+		}
+	}
+}
+
+func warnMentions(warnings []string, want string) bool {
+	for _, w := range warnings {
+		if strings.Contains(w, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/config/compiler_opts.go
+++ b/pkg/config/compiler_opts.go
@@ -1996,6 +1996,23 @@ type compileOpts struct {
 	// community VALUE (e.g. 65000:100), not a list reference, and is not
 	// checked. Same doctrine as lenientRoutingExportRef.
 	lenientPolicyCommunityRef bool
+	// lenientPolicyASPathRegex (#6686) downgrades the as-path regex gate
+	// (validatePolicyASPathRegexStrict) from a hard compile error to a
+	// cfg.Warnings entry. xpf renders one `bgp as-path access-list <name>
+	// permit <regex>` line per `policy-options as-path` definition; an EMPTY
+	// regex is an incomplete FRR command and a malformed one fails FRR's
+	// regcomp, and either is a CMD_WARNING_CONFIG_FAILED that exits the whole
+	// vtysh add-batch non-zero — failing the ENTIRE frr-reload, not just this
+	// list, and leaving every dynamic routing change stale. The strict commit
+	// / commit-check path hard-rejects so the operator sees it (naming the
+	// as-path and the line that would be rendered); the tolerant load /
+	// peer-sync paths downgrade to a warning so an already-persisted or
+	// peer-synced config still BOOTS (#1960 fail-closed-on-load class), with
+	// pkg/frr's ValidASPathRegex belt keeping the unrenderable definition out
+	// of frr.conf on that path so the reload survives. Runs on the
+	// fully-compiled *Config so the as-path map is populated regardless of
+	// authoring order. Same doctrine as lenientPolicyCommunityRef.
+	lenientPolicyASPathRegex bool
 	// lenientPolicyReservedRedistName (#5116) downgrades the reserved
 	// route-map-suffix gate (validatePolicyReservedRedistNameStrict) from a
 	// hard compile error to a cfg.Warnings entry. An operator policy-statement
@@ -2395,6 +2412,7 @@ func lenientCompileOpts() compileOpts {
 		lenientPolicyMissingMatch:              true,
 		lenientPolicyValuelessMatch:            true,
 		lenientPolicyCommunityRef:              true,
+		lenientPolicyASPathRegex:               true,
 		lenientPolicyReservedRedistName:        true,
 		lenientPolicyReservedChainName:         true,
 		lenientVRRPVirtualAddress:              true,

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -682,24 +682,40 @@ func compilePolicyOptions(node *Node, po *PolicyOptionsConfig) error {
 		po.ASPaths = make(map[string]*ASPathDef)
 	}
 	for _, child := range node.FindChildren("as-path") {
-		if len(child.Keys) >= 3 {
-			// Hierarchical: Keys=["as-path", "NAME", "REGEX"]
-			po.ASPaths[child.Keys[1]] = &ASPathDef{
-				Name:  child.Keys[1],
-				Regex: child.Keys[2],
-			}
-		} else if len(child.Keys) >= 2 {
-			// Flat set syntax may produce: Keys=["as-path","NAME"] with children
-			name := child.Keys[1]
-			ap := &ASPathDef{Name: name}
-			// Look for path child (regex value)
+		if len(child.Keys) < 2 {
+			continue
+		}
+		// Keys=["as-path", NAME, REGEX-TOKEN...]. The `policy-options
+		// as-path` schema node is `args: 2, multi: true`, so the regex is
+		// the whole trailing token run, not one key: a QUOTED regex
+		// (`as-path AP1 ".* 65000 .*"`) is one lexer string token and
+		// arrives whole in Keys[2], while the UNQUOTED spelling of the
+		// same value arrives as Keys[2:] = [".*" "65000" ".*"]. The prior
+		// `Regex: child.Keys[2]` read kept only the FIRST token, so the
+		// unquoted spelling compiled `.* 65000 .*` to `.*` — the
+		// whole-path wildcard — and a `from as-path AP1; then accept`
+		// term built on it accepted EVERY BGP path (#6686). Reproduced in
+		// BOTH spellings (flat `set` and a hierarchical brace block),
+		// both of which committed clean with zero warnings while
+		// `show configuration` displayed the authored regex back verbatim.
+		name := child.Keys[1]
+		regex := ASPathRegexFromTokens(child.Keys[2:])
+		if regex == "" {
+			// No tail on the instance node: the regex sits on a CHILD
+			// leaf instead, which is what a hierarchical brace body
+			// (`as-path AP1 { ".* 65000 .*"; }`) produces. Join that
+			// leaf's keys for the same reason — an unquoted body lands as
+			// Keys=[".*" "65000" ".*"] one level down and the previous
+			// `entry.Keys[0]` read widened it identically. Last child
+			// wins, preserving the pre-#6686 behaviour for a body that
+			// somehow carries several leaves.
 			for _, entry := range child.Children {
-				if len(entry.Keys) > 0 {
-					ap.Regex = entry.Keys[0]
+				if v := ASPathRegexFromTokens(entry.Keys); v != "" {
+					regex = v
 				}
 			}
-			po.ASPaths[name] = ap
 		}
+		po.ASPaths[name] = &ASPathDef{Name: name, Regex: regex}
 	}
 
 	// Parse policy-statements. A named policy-statement may be defined across

--- a/pkg/config/compiler_uniformgates_log_feed_routing.go
+++ b/pkg/config/compiler_uniformgates_log_feed_routing.go
@@ -194,6 +194,29 @@ func runUniformGatesLogFeedRouting(tree *ConfigTree, cfg *Config, opts compileOp
 		}
 	}
 
+	// #6686: as-path regex gate. `policy-options as-path <name> <regex>`
+	// renders one `bgp as-path access-list <name> permit <regex>` line. An
+	// EMPTY regex (reachable with no diagnostic: `set policy-options as-path
+	// AP1` alone) is an incomplete FRR command, and a malformed one fails
+	// FRR's regcomp — either is a CMD_WARNING_CONFIG_FAILED, and a single
+	// vtysh -f add-batch exits non-zero on any of those, failing the WHOLE
+	// reload and leaving dynamic routing stale. Strict on commit /
+	// commit-check (hard reject naming the as-path and the line that would be
+	// rendered); lenient on load / peer-sync (warn so an already-persisted or
+	// peer-synced config still boots — #1960; the render path carries the
+	// ValidASPathRegex belt that keeps the unrenderable definition out of
+	// frr.conf on that path). Runs on the fully-compiled *Config so the
+	// as-path map is populated regardless of authoring order. Mirrors
+	// validatePolicyCommunityReferencesStrict.
+	if err := validatePolicyASPathRegexStrict(cfg); err != nil {
+		if opts.lenientPolicyASPathRegex {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("policy as-path regex (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #5116: reserved route-map-suffix gate. The FRR renderer derives a
 	// per-use-site fail-closed redistribute alias `name + "-xpf-redist"`
 	// (redistFailClosedRouteMap) into FRR's GLOBAL name-keyed route-map

--- a/pkg/config/compiler_validate_strict_routing.go
+++ b/pkg/config/compiler_validate_strict_routing.go
@@ -1324,3 +1324,60 @@ func validatePolicyReservedChainNameStrict(cfg *Config) error {
 	}
 	return nil
 }
+
+// validatePolicyASPathRegexStrict hard-rejects a `policy-options as-path
+// <name>` whose regular expression cannot be rendered into frr.conf at
+// all — an EMPTY regex, or one that is not a valid POSIX extended regular
+// expression (#6686).
+//
+// xpf renders one `bgp as-path access-list <name> permit <regex>` line per
+// definition (pkg/frr/policy_render.go). FRR's DEFUN for that command ends
+// in a variadic `LINE...` parameter which argv_concat joins back with
+// single spaces, which is what makes a multi-AS regex like `.* 65000 .*`
+// expressible at all — but it also means an ABSENT regex is an incomplete
+// command, and a malformed one fails FRR's regcomp. Either is a
+// CMD_WARNING_CONFIG_FAILED, and a single such failure exits the whole
+// vtysh add-batch non-zero: it does not merely drop this one access-list,
+// it fails the ENTIRE frr-reload and leaves every dynamic routing change
+// stale.
+//
+// An empty regex was reachable with no diagnostic at all: `set
+// policy-options as-path AP1` with no value compiled to an ASPathDef with
+// Regex "" and committed clean.
+//
+// On the tolerant load / peer-sync paths the call site downgrades this to
+// a warning (opts.lenientPolicyASPathRegex) so an already-persisted or
+// peer-synced config still boots (#1960 fail-closed-on-load class);
+// pkg/frr's ValidASPathRegex belt then keeps the unrenderable definition
+// out of frr.conf on that path, so the reload survives. Commit /
+// commit-check stay strict. Runs on the fully-compiled *Config so the
+// as-path map is populated regardless of authoring order. Mirrors
+// validatePolicyCommunityReferencesStrict.
+func validatePolicyASPathRegexStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	// Sort for a deterministic first-error message (the typed-config map
+	// iteration order is otherwise random).
+	names := make([]string, 0, len(cfg.PolicyOptions.ASPaths))
+	for name := range cfg.PolicyOptions.ASPaths {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		ap := cfg.PolicyOptions.ASPaths[name]
+		if ap == nil {
+			continue
+		}
+		if err := ValidASPathRegex(ap.Regex); err != nil {
+			return fmt.Errorf("policy-options as-path %s: %v — xpf renders "+
+				"`bgp as-path access-list %s permit %s`, which frr-reload "+
+				"rejects (failing the entire FRR config load); write the "+
+				"regular expression as a QUOTED value, e.g. "+
+				"`set policy-options as-path %s \".* 65000 .*\"`",
+				name, err, name, ap.Regex, name)
+		}
+	}
+	return nil
+}

--- a/pkg/frr/policy_aspath_regex_6686_test.go
+++ b/pkg/frr/policy_aspath_regex_6686_test.go
@@ -1,0 +1,63 @@
+package frr
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6686 render-side belt. The strict commit gate hard-rejects an as-path
+// whose regex is empty or malformed, but the tolerant load / peer-sync
+// paths downgrade that to a warning (#1960 no-brick), so such a definition
+// CAN reach the renderer on an already-persisted config. It must not be
+// emitted: `bgp as-path access-list AP1 permit` with no argument is an
+// incomplete FRR command and `(((` fails regcomp, and a single
+// CMD_WARNING_CONFIG_FAILED exits the whole vtysh add-batch non-zero —
+// failing the ENTIRE frr-reload, not just this list.
+
+func aspathPO(t *testing.T, name, regex string) *config.PolicyOptionsConfig {
+	t.Helper()
+	return &config.PolicyOptionsConfig{
+		ASPaths: map[string]*config.ASPathDef{
+			name: {Name: name, Regex: regex},
+		},
+	}
+}
+
+// TestASPathRender6686EmitsAMultiTokenRegex is the positive control: a
+// legitimate transit regex with spaces MUST still render, whole. FRR's
+// `bgp as-path access-list` DEFUN ends in a variadic `LINE...` that
+// argv_concat rejoins with single spaces, which is what makes a multi-AS
+// pattern expressible at all — so the belt must not treat a space as
+// unrenderable.
+func TestASPathRender6686EmitsAMultiTokenRegex(t *testing.T) {
+	got := New().generatePolicyOptions(aspathPO(t, "AP1", `.* 65000 .*`))
+	if !strings.Contains(got, "bgp as-path access-list AP1 permit .* 65000 .*\n") {
+		t.Fatalf("multi-token as-path regex not rendered whole:\n%s", got)
+	}
+}
+
+// TestASPathRender6686OmitsUnrenderableRegexes is the belt itself.
+//
+// FAIL-ON-REVERT: deleting the ValidASPathRegex `continue` from
+// generatePolicyOptions emits `bgp as-path access-list AP1 permit` (and
+// `... permit (((`), which reds here.
+func TestASPathRender6686OmitsUnrenderableRegexes(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		regex string
+	}{
+		{"empty", ""},
+		{"whitespace only", "   "},
+		{"malformed", "((("},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := New().generatePolicyOptions(aspathPO(t, "AP1", tc.regex))
+			if strings.Contains(got, "bgp as-path access-list AP1") {
+				t.Fatalf("unrenderable as-path (%s) reached frr.conf — the line "+
+					"fails frr-reload and takes the WHOLE reload down:\n%s", tc.name, got)
+			}
+		})
+	}
+}

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -249,6 +249,26 @@ func (m *Manager) generatePolicyOptions(po *config.PolicyOptionsConfig, bgpAccep
 		sort.Strings(aspNames)
 		for _, name := range aspNames {
 			ap := po.ASPaths[name]
+			// #6686 render-side belt: an as-path whose regex is EMPTY or
+			// not a valid POSIX ERE renders a line FRR rejects — an
+			// incomplete command or a regcomp failure — and a single
+			// CMD_WARNING_CONFIG_FAILED exits the whole vtysh add-batch
+			// non-zero, failing the ENTIRE frr-reload and leaving every
+			// dynamic routing change stale. The strict commit gate
+			// (validatePolicyASPathRegexStrict, pkg/config) hard-rejects
+			// it, but the tolerant load / peer-sync paths only warn (#1960
+			// no-brick), so the renderer must keep a leniently-loaded
+			// definition out of frr.conf entirely. Omitting the list is
+			// strictly better than poisoning the reload: FRR resolves a
+			// `match as-path <name>` with no such list to NO MATCH, which
+			// confines the damage to the terms that reference it. Same
+			// predicate as the commit gate — ValidASPathRegex is shared so
+			// the two cannot drift. Mirrors validRouterID (render_validate.go).
+			if err := config.ValidASPathRegex(ap.Regex); err != nil {
+				slog.Warn("frr: omitting unrenderable as-path access-list",
+					"as_path", name, "reason", err)
+				continue
+			}
 			// #4097: sanitize the regex so an embedded newline cannot
 			// inject an extra frr.conf line — parity with the auth /
 			// description fields. FRR takes the regex as a rest-of-line


### PR DESCRIPTION
Closes #6686

## The defect

`policy-options as-path <name> <regex>` is an `args: 2, multi: true` schema node, so the regex is the node's **whole trailing token run** — not one key. The compiler read `Keys[2]` alone, which is the complete value only when the operator QUOTED it (one lexer string token):

| authored | `Keys` | compiled `Regex` (before) |
|---|---|---|
| `as-path AP1 ".* 65000 .*"` | `["as-path" "AP1" ".* 65000 .*"]` | `.* 65000 .*` ✅ |
| `as-path AP1 .* 65000 .*` | `["as-path" "AP1" ".*" "65000" ".*"]` | **`.*`** ❌ |

`.*` is the whole-path wildcard, so a `from as-path AP1; then accept` term accepts **every** BGP path rather than only those transiting AS 65000 — a route-leak / hijack-acceptance exposure. It commits clean with zero warnings in **both** spellings (flat `set` and hierarchical), and `show configuration` displays the authored regex back verbatim, so nothing on the box reveals it.

The same widening applied **one level down**: a hierarchical brace body (`as-path AP1 { .* 65000 .*; }`) parks the regex tokens on a CHILD leaf's `Keys`, which was read as `entry.Keys[0]`. Both sites are fixed.

## Why JOIN and not REJECT

The issue accepts either. JOIN, because:

- **The grammar says so.** `args: 2, multi: true` — `multi` is documented in `schema.go` as absorbing the trailing tokens onto this node's key, and as-path is named there as one of the leaves that is "multi-token by nature".
- **Rejecting would brick the upgrade.** The persisted/rendered form of an already-committed broken config *is* the unquoted spelling (`FormatSet` renders `set policy-options as-path AP1 .* 65000 .*`), so a hard reject would fail the tolerant load on a config the running box committed — the #1960 no-brick class. Joining instead makes that same config compile to the operator's authored intent on the next load.
- **The join is reconstruction, not a guess.** Every regex metacharacter that is also lexer syntax (`^`, `{`, `}`, `|`, `[`, `]`, `;`, `"`) either fails to lex unquoted or is stripped, so an unquoted regex that reaches the compiler is a whitespace-separated run of identifier tokens. FRR's `bgp as-path access-list` DEFUN ends in a variadic `LINE...` that `argv_concat` rejoins with single spaces — the join matches what FRR itself does with the line xpf renders.

## The validator the issue asks for

Nothing downstream caught the widened pattern, and two values are worse than widened — they are **unrenderable**:

- an **EMPTY** regex, reachable with no diagnostic at all via a bare `set policy-options as-path AP1`, renders `bgp as-path access-list AP1 permit` with no argument — an incomplete FRR command;
- a **malformed** regex fails FRR's regcomp.

Either is a `CMD_WARNING_CONFIG_FAILED`, and a single one exits the whole vtysh add-batch non-zero: it does not lose one access-list, it fails the **entire** frr-reload and leaves every dynamic routing change stale.

`ValidASPathRegex` is one predicate applied at three layers so they cannot drift:

1. `validatePolicyASPathRegexStrict` — hard reject on commit / commit-check, naming the as-path and the line that would be rendered;
2. `lenientPolicyASPathRegex` — downgraded to a warning on the tolerant load / peer-sync paths (#1960);
3. `generatePolicyOptions` — **omits** the unrenderable definition from frr.conf, so the leniently loaded config cannot poison the reload. Omitting is strictly better than emitting: FRR resolves `match as-path <name>` with no such list to NO MATCH, confining the damage to the referencing terms instead of taking the whole reload down.

`regexp.CompilePOSIX` is Go's egrep-syntax mode — the same dialect FRR compiles with `REG_EXTENDED`. Where the two differ, Go is the stricter, so a pattern rejected here is at worst one glibc would have accepted with undefined semantics.

## Tests

`pkg/config/compiler_as_path_multitoken_6686_test.go`:

- **five spellings** — flat-set quoted/unquoted, hierarchical quoted/unquoted, hierarchical brace body — asserted to **AGREE** with each other, then to equal the authored literal, plus an explicit `!= ".*"` check naming the security consequence. Agreement first is deliberate: pinning only the packed spelling to a hand-written expectation encodes which side is trusted, and in the sibling packed-body work (#7457) the defect turned out to be on the side every issue assumed was correct.
- empty and malformed: **rejected** strict, **warned** lenient (both legs, separately).
- **the tightening control** — nine real AS-path regexes (`.* 65000 .*`, `^65000 65001$`, `(65000|65001)`, `65000{1,3}`, `^65000 [0-9]+$`, `^$` …) must still commit clean, and compile verbatim.

`pkg/frr/policy_aspath_regex_6686_test.go`: the multi-token regex renders whole (positive control — a space must NOT be treated as unrenderable); empty / whitespace-only / malformed are omitted.

## Mutation matrix

Every cell verified APPLIED first (`git diff --stat` non-empty, asserted), `go build ./...` clean before running, exit codes read from files, full `pkg/config` + `pkg/frr` suites at `-count=1` per cell — no `-run` filter, so a pre-existing test that owns a property cannot hide.

| cell | mutation | result |
|---|---|---|
| **U1** | restore the **verbatim** pre-fix `Regex: child.Keys[2]` / `entry.Keys[0]` bytes (`git show <base>:`) | RED `TestASPath6686SpellingsAgreeOnTheAuthoredRegex` |
| **U2** | delete the `validatePolicyASPathRegexStrict` **call** from the gate chain (the wiring, not the callee) | RED both strict/lenient tests + the pre-existing `TestEveryStrictCommitGateIsWired` |
| **U3** | delete the `ValidASPathRegex` `continue` from the FRR renderer | RED `TestASPathRender6686OmitsUnrenderableRegexes` |
| **U4** | **TIGHTEN** — make `ValidASPathRegex` reject any regex containing a space | RED `TestASPath6686RealRegexesStillCommitClean` + the render positive control + two pre-existing #4097 tests (which corroborate that a space-bearing as-path regex is an established supported value) |
| **U5** | remove `lenientPolicyASPathRegex: true` from the tolerant defaults | RED the two lenient legs (the #1960 no-brick property is bound, not assumed) |
| **U6** | **TIGHTEN** — join the tail with `""` instead of `" "` | RED `TestASPath6686SpellingsAgreeOnTheAuthoredRegex` (the separator itself is bound, so a paraphrase of the fix does not certify) |

Control: full `pkg/config` + `pkg/frr` suites green at HEAD before the matrix, and the tree verified clean after every restore.

## Docs

`docs/config-schema.md` gains "The as-path REGEX is the whole token tail, and it is validated (#6686)" next to the sibling as-path-prepend contract: the two spellings' `Keys` shapes, why the join is reconstruction, and the three-layer validation with its fail-on-revert cites.

## Not in scope

The issue also observes there is **no reference gate on `from as-path`** — a term naming an UNDEFINED as-path commits clean and FRR resolves it to NO MATCH (fail-open on a `then reject` term). That is a distinct defect from the widening this closes (the name here *is* defined), it needs its own gate and lenient flag mirroring `validatePolicyCommunityReferencesStrict`, and it is filed separately as #7471.
