### PR TITLE
cluster: fence config-apply on the peer boot incarnation (#5084)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103336,7 +103336,10 @@ prose edit above them added. No diff falls in the new test body.
   #6900 post-mortem: a ranking cannot express "same peer boot?"). Fails OPEN on
   an absent incarnation, counts both halves, renders the incarnation + counters
   in cluster status, and raises NO health/alarm state. The ~20s half-open-socket
-  residual is shipped bounded and documented, not closed.
+  residual is shipped bounded and documented, not closed. Two drop sites, neither
+  redundant: at RECEIVE (before recordRecvConfigGen, so a dead boot's high
+  generation cannot inflate the #5563 readiness mark and wedge the standby
+  config-stale) and at APPLY (the already-queued payload, the reported defect).
 - **File(s)**: `pkg/cluster/sync_boot_incarnation.go` (new),
   `pkg/cluster/sync_boot_incarnation_5084_test.go` (new),
   `pkg/cluster/sync.go`, `pkg/cluster/sync_auth.go`, `pkg/cluster/sync_bulk.go`,

--- a/_Log.md
+++ b/_Log.md
@@ -103324,3 +103324,21 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/frr/policy_render.go`,
   `pkg/config/compiler_as_path_multitoken_6686_test.go` (new),
   `pkg/frr/policy_aspath_regex_6686_test.go` (new), `docs/config-schema.md`
+
+## 2026-08-22 — #5084 peer boot incarnation on the config-sync wire
+- **Action**: Stamped every queued `configApplyItem` with the peer BOOT
+  INCARNATION (`/proc/sys/kernel/random/boot_id`) carried as a length-gated
+  8→24 byte extension of the `syncMsgBulkStart` payload, and dropped a queued
+  payload whose incarnation a re-prime has replaced. Fixes a queued prior-boot
+  config applying after `resetRecvGen`, recording a dead incarnation's
+  generation as the high-water, and then refusing the rebooted peer's
+  lower-generation current config permanently. Compared for EQUALITY only (the
+  #6900 post-mortem: a ranking cannot express "same peer boot?"). Fails OPEN on
+  an absent incarnation, counts both halves, renders the incarnation + counters
+  in cluster status, and raises NO health/alarm state. The ~20s half-open-socket
+  residual is shipped bounded and documented, not closed.
+- **File(s)**: `pkg/cluster/sync_boot_incarnation.go` (new),
+  `pkg/cluster/sync_boot_incarnation_5084_test.go` (new),
+  `pkg/cluster/sync.go`, `pkg/cluster/sync_auth.go`, `pkg/cluster/sync_bulk.go`,
+  `pkg/cluster/sync_conn_read.go`, `pkg/cluster/sync_conn_config.go`,
+  `pkg/cluster/status.go`, `docs/sync-protocol.md`

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -531,6 +531,18 @@ receiver resets `lastAppliedConfigGen` to 0 (`resetRecvGen`), so bulk re-sync
 after a peer reboot is never falsely rejected (the reset makes the compare
 baseline 0 until the peer re-pushes its current config).
 
+**The reset does not drain the config-apply QUEUE (#5084).** A config payload
+already sitting in `configApplyCh` when a rebooted peer re-primes belongs to the
+peer's PREVIOUS boot, and its generation — drawn from the pre-reboot monotonic
+seed — is far higher than anything the new boot can produce. Applying it after
+the reset records that generation as the high-water and refuses the rebooted
+peer's current config from then on. Every queued item is therefore stamped with
+the peer's BOOT INCARNATION (`/proc/sys/kernel/random/boot_id`, carried as a
+length-gated 8 → 24 byte extension of the `BulkStart` payload), and a payload
+whose incarnation a re-prime has replaced is dropped — compared for EQUALITY
+only, never ordered. Full design, fail-open rule, observability contract and the
+bounded ~20s residual: `docs/sync-protocol.md`, "Peer boot incarnation".
+
 **Enforcement is authoritative in the Go cluster layer, not the userspace
 helper.** The #3931 config-sync-generation namespace lives entirely in
 `SessionSync`; the helper's own `config_generation` is a *local* commit counter

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -828,12 +828,30 @@ HELLO-carried incarnation would be silently absent on unkeyed clusters.
 - A `BulkStart` carrying the **same** incarnation is a mid-connection re-prime
   (the #5450 forced resync) and invalidates nothing — same boot, comparable
   generations.
-- A queued config payload whose incarnation differs from the current one is
-  dropped **permanently** and is never re-admitted. Because membership is an
+- A config payload whose incarnation differs from the current one is dropped
+  **permanently** and is never re-admitted. Because membership is an
   equivalence, the dropped payload's generation carries no information the
   current high-water needs, so the drop cannot strand the mark the way #6900's
   fence could.
 - A payload with **no** incarnation is never dropped on incarnation grounds.
+
+There are **two** drop sites and neither subsumes the other:
+
+- **At receive** (`handleConfigPayload`), before `recordRecvConfigGen`. The
+  received-config high-water is a monotone max that gates manual-failover
+  readiness (#5563 refuses promotion while `PeerConfigGen > AppliedConfigGen`),
+  and a dead incarnation's generation comes from the peer's PRE-reboot counter,
+  so it is higher than anything the live incarnation can produce. Letting it
+  raise the received mark would strand the standby reading config-stale with
+  nothing able to close the gap short of another re-prime.
+- **At apply** (`configApplyLoop`), before the generation gate. This is the one
+  that catches a payload already sitting in `configApplyCh` when the re-prime
+  landed — the reported defect, since `resetRecvGen` does not drain the queue.
+
+In the `BulkStart` handler the incarnation is recorded **before**
+`resetRecvGen`. Reversing them opens a window where the high-waters are already
+zeroed while the current incarnation is still the dead one, so a prior-boot
+payload dequeued in that window passes the fence and records its generation.
 
 ### Fail-open across the mixed-version window
 

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -38,7 +38,7 @@ All multi-byte integers in the wire format are **little-endian**, matching the n
 | 2    | SessionV6        | Primary→Secondary | length-gated        | Create/update IPv6 session |
 | 3    | DeleteV4         | Primary→Secondary | 16 or 24 bytes      | Delete IPv4 session |
 | 4    | DeleteV6         | Primary→Secondary | 40 or 48 bytes      | Delete IPv6 session |
-| 5    | BulkStart        | Primary→Secondary | 0                   | Marks start of bulk transfer |
+| 5    | BulkStart        | Primary→Secondary | 8 or 24 bytes       | Marks start of bulk transfer: 8B epoch, plus the sender's 16B boot incarnation (#5084) when it has one |
 | 6    | BulkEnd          | Primary→Secondary | 0                   | Marks end of bulk transfer |
 | 7    | Heartbeat        | Bidirectional     | 0                   | Keepalive (sent on 30s idle) |
 | 8    | Config           | Primary→Secondary | Variable (UTF-8) + 16B gen framing | Full config text + monotonic config generation (#3931) |
@@ -781,6 +781,137 @@ apply and the invalidators, completing the reconcile/finalization the tail error
 left unfinished — rather than the pre-#4957 behavior where the fast path returned
 nil and advanced the mark over a config the dataplane never finished applying.
 
+## Peer boot incarnation (#5084)
+
+Config generations are comparable **only within one sender boot**.
+`initGenState` seeds `configGenCounter` from `CLOCK_MONOTONIC` nanos, so a
+daemon restart within a boot produces a strictly HIGHER seed (still comparable)
+while an OS reboot restarts the clock and produces a LOWER one (not comparable).
+
+Before #5084 the ordered apply queue (`configApplyCh`, cap 64) held only
+`{gen, text}`. When the peer rebooted and re-primed, `resetRecvGen` zeroed the
+generation high-waters but did **not** drain items already queued from the prior
+boot. A queued prior-boot payload could then apply after the reset, record its
+(large, pre-reboot) generation as the high-water, and the rebooted peer's
+lower-generation CURRENT config was refused as stale from then on — persistent
+HA policy/routing divergence.
+
+**The guard is an EQUIVALENCE, never a ranking.** PR #6900 tried a floor over
+the per-connection `syncConnID` counter and failed across seven review rounds: a
+total order over connections cannot express "were these two payloads produced by
+the same peer boot?". A floor that never descends locks out a live
+same-incarnation sibling that merely connected earlier; a floor that descends
+re-admits departed older-incarnation connections. The full post-mortem is on
+#5084 and in `docs/peer-boot-incarnation-plan.md`.
+
+### The field
+
+`/proc/sys/kernel/random/boot_id` — a 128-bit UUID the kernel regenerates at
+each OS boot, stable for that boot, unchanged by a daemon restart. That is
+exactly the granularity at which `CLOCK_MONOTONIC` restarts, so it is forced by
+the generation seed, not chosen. It is **compared for equality only**; ordering
+two boot ids is the mistake #6900 made.
+
+It rides in the `syncMsgBulkStart` payload as a length-gated trailing extension
+(8 → 24 bytes), the same #2170 discipline the delete frames use. `BulkStart` is
+the carrier because the prime IS the claim event: the incarnation arrives in the
+frame that declares it current, so no connection is ever installed with an
+unknown incarnation. The auth `HELLO` was rejected as a carrier —
+`performSyncHandshake` returns immediately when the cluster is unkeyed, so a
+HELLO-carried incarnation would be silently absent on unkeyed clusters.
+
+### Receiver rules
+
+- A `BulkStart` whose incarnation **differs** from the current one switches the
+  namespace: the generation high-waters clear (`resetRecvGen`, which already
+  fired here) and the new incarnation is recorded.
+- A `BulkStart` carrying the **same** incarnation is a mid-connection re-prime
+  (the #5450 forced resync) and invalidates nothing — same boot, comparable
+  generations.
+- A queued config payload whose incarnation differs from the current one is
+  dropped **permanently** and is never re-admitted. Because membership is an
+  equivalence, the dropped payload's generation carries no information the
+  current high-water needs, so the drop cannot strand the mark the way #6900's
+  fence could.
+- A payload with **no** incarnation is never dropped on incarnation grounds.
+
+### Fail-open across the mixed-version window
+
+`len(payload) < 24` ⇒ no incarnation ⇒ exactly today's generation-only
+ordering. This is the same legacy-sentinel convention the package already uses
+(`gen == 0`, `epoch == 0`, `incarnation == 0 || seq == 0`), and the fallback is
+`origin/master`'s behaviour rather than a weakened version of it. Failing
+**closed** would refuse ALL config from a not-yet-upgraded peer for the whole
+rolling-upgrade window, stranding the standby on stale config — strictly worse
+than the bug being fixed. It is not a security decision: the incarnation is not
+an authorisation token and grants nothing; the authentication boundary is the
+PSK handshake and the frame HMAC, both untouched.
+
+No capability negotiation exists, and that is the point — presence is decided
+per-frame by payload length, so there is no handshake round to get wrong.
+Upgrade order does not matter:
+
+| receiver | sender | outcome |
+|---|---|---|
+| old | old | today's behaviour |
+| old | new | 24-byte `BulkStart`; old receiver reads `payload[:8]`, ignores the tail |
+| new | old | 8-byte `BulkStart`; no incarnation; today's behaviour |
+| new | new | full #5084 guard |
+
+A node whose own `boot_id` is unreadable appends **nothing** rather than 16 zero
+bytes, so it presents as an un-incarnated (old-build) sender rather than as a
+distinct boot that changes on every read.
+
+**Contingency, recorded deliberately:** if a future requirement demands that an
+un-incarnated peer be REFUSED, that forces either a flag day or making the keyed
+handshake mandatory — an upgraded receiver cannot distinguish "old peer that
+cannot send the field" from "peer suppressing the field" without a negotiated
+capability, and a negotiated capability has nowhere to live on the unkeyed path.
+Both are decisions well outside #5084.
+
+### Observability — a status field and counters, NOT a health state
+
+A silent fail-open is how a half-upgraded cluster hides, so both halves are
+counted and rendered by `show chassis cluster information`:
+
+- `Peer boot incarnation: <hex>|none` — rendered **always**, including `none`,
+  because `none` is the operationally interesting value and a line that
+  disappears in exactly that case would hide it.
+- `Primes without incarnation: N` — the fail-open fallback is active.
+- `Configs dead-incarnation-dropped: N` — the fence did its job.
+
+Plus one `slog.Warn` per CONNECTION (not per frame) when a peer primes without
+an incarnation.
+
+This deliberately does **not** raise a cluster health annotation or alarm state.
+An un-incarnated peer is the expected steady state of a rolling upgrade, not a
+fault; raising health for it would make every upgrade look degraded, and a
+stale-incarnation discard is an expected event during a peer reboot. #6387 set
+the precedent in the other direction by making a config-sync APPLY FAILURE
+diagnostic-only so it never gates failover — a less severe condition must not be
+louder.
+
+### Known residual — shipped BOUNDED, not closed
+
+A pre-reboot socket that is half-open and has not yet errored can still hold a
+buffered `BulkStart` from the DEAD incarnation. If it lands after the new
+incarnation primed, the namespace switches BACK, and config from the live
+incarnation is dropped until the next prime re-switches it.
+
+The window is bounded by the receive loop rather than by luck: `receiveLoop`
+arms a 10s read deadline and gives up at `missedHeartbeats >= 2`, so such a
+socket self-evicts within **~20s** of silence — and an OS reboot, the only thing
+that changes an incarnation, outlasts that window, which makes the frame hard to
+produce at all. It is self-healing: the peer re-pushes its current config on the
+reconnect that follows, and every drop is counted in
+`ConfigsDeadIncarnationDropped` and rendered in status.
+
+Closing it rather than bounding it means a receiver-local strictly-increasing
+"namespace claim ordinal" bumped on each switch, with a switch refused from a
+connection whose slot is no longer installed. That is deliberately out of scope:
+it is the same add-an-ordering instinct that produced #6900, and it should be
+added against a demonstrated failure, not pre-emptively.
+
 ## Full-set state-sync ordering (#5706)
 
 IPsec SA sync (type 9) and DHCP-server lease sync (types 25/26) are **full-set
@@ -1154,6 +1285,8 @@ All counters are `atomic.Uint64` / `atomic.Bool`, lock-free:
 | ConfigsSent/Received | Config sync messages |
 | ConfigsStaleIgnored | Config messages dropped by the #3931 ordering guard (incoming generation not strictly newer than last-applied) |
 | ConfigsApplyFailed | Config messages admitted by the ordering guard but whose apply did NOT take effect (compile/promote failure or a transient RG0-primary rejection). The high-water is left unadvanced so the peer's re-push re-converges the standby (M-2/#4151) |
+| BulkPrimesWithoutIncarnation | `BulkStart` frames received carrying no boot incarnation (#5084) — a peer on a pre-#5084 build, or a peer whose own `boot_id` was unreadable. The incarnation fence is in its fail-open state against that peer; expected during a rolling upgrade, and NOT a health/alarm state |
+| ConfigsDeadIncarnationDropped | Config payloads dropped because the boot incarnation they arrived under has been replaced by a re-prime (#5084) — a queued prior-boot config that would otherwise apply across the reset and strand the generation high-water. Expected once per peer reboot that races a queued config; a persistently rising counter means the peer is flapping |
 | IPsecSASent/Received | IPsec SA list messages |
 | IPsecSAStaleIgnored | IPsec SA full-sets dropped by the #5706 ordering guard (incoming `(incarnation, seq)` not strictly newer — a reorder across the redundant fabric streams) |
 | DHCPLeasesSent/Received | DHCP-server full-set lease push messages (per family) |

--- a/pkg/cluster/status.go
+++ b/pkg/cluster/status.go
@@ -469,6 +469,24 @@ func (m *Manager) FormatInformation() string {
 		if syncStats.ConfigsApplyFailed > 0 {
 			fmt.Fprintf(&b, "  Configs apply-failed:  %d\n", syncStats.ConfigsApplyFailed)
 		}
+		// #5084: the peer boot incarnation, rendered ALWAYS rather than only
+		// when non-empty. "none" is the operationally interesting value — it
+		// means the fence is in its fail-open state against this peer — and a
+		// line that disappears in exactly that case would hide it.
+		//
+		// A status line plus counters, deliberately NOT a health annotation: an
+		// un-incarnated peer is the expected steady state of a rolling upgrade,
+		// not a fault, and raising cluster health for it would make every
+		// upgrade look degraded. #6387 set the precedent in the other direction
+		// by making a config-sync APPLY FAILURE diagnostic-only so it never
+		// gates failover; a less severe condition must not be louder.
+		fmt.Fprintf(&b, "  Peer boot incarnation: %s\n", syncStats.PeerBootIncarnation)
+		if syncStats.BulkPrimesWithoutIncarnation > 0 {
+			fmt.Fprintf(&b, "  Primes without incarnation: %d\n", syncStats.BulkPrimesWithoutIncarnation)
+		}
+		if syncStats.ConfigsDeadIncarnationDropped > 0 {
+			fmt.Fprintf(&b, "  Configs dead-incarnation-dropped: %d\n", syncStats.ConfigsDeadIncarnationDropped)
+		}
 	} else {
 		fmt.Fprintln(&b, "  Not configured")
 	}

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -215,6 +215,15 @@ type SyncStats struct {
 	// guard prevented a rapid-commit reorder (C1 applied after C2) from
 	// leaving the standby on the older config.
 	ConfigsStaleIgnored atomic.Uint64
+	// BulkPrimesWithoutIncarnation counts bulk primes received from a peer
+	// that sent no boot incarnation (#5084) — the legacy 8-byte BulkStart.
+	// A silent fail-open is how a half-upgraded cluster hides, so the fallback
+	// is counted rather than merely permitted.
+	BulkPrimesWithoutIncarnation atomic.Uint64
+	// ConfigsDeadIncarnationDropped counts config payloads dropped because
+	// they belonged to a peer boot incarnation that a re-prime has replaced
+	// (#5084 rule 3) — the defect this fence exists to close, made countable.
+	ConfigsDeadIncarnationDropped atomic.Uint64
 	// ConfigsApplyFailed counts config-sync messages that were admitted by the
 	// #3931 ordering guard but whose apply did NOT take effect on this node —
 	// a compile/promote failure (a mixed-build ISSU syntax error, a store
@@ -306,15 +315,27 @@ type SyncStats struct {
 // SyncStatsSnapshot is a point-in-time copy of SyncStats with plain
 // non-atomic fields, safe to copy by value and pass across API boundaries.
 type SyncStatsSnapshot struct {
-	SessionsSent               uint64
-	SessionsReceived           uint64
-	SessionsInstalled          uint64
-	DeletesSent                uint64
-	DeletesReceived            uint64
-	BulkSyncs                  uint64
-	ConfigsSent                uint64
-	ConfigsReceived            uint64
-	ConfigsStaleIgnored        uint64
+	SessionsSent        uint64
+	SessionsReceived    uint64
+	SessionsInstalled   uint64
+	DeletesSent         uint64
+	DeletesReceived     uint64
+	BulkSyncs           uint64
+	ConfigsSent         uint64
+	ConfigsReceived     uint64
+	ConfigsStaleIgnored uint64
+	// #5084 observability. A fail-open fence is silent by construction, so
+	// both halves are counted: primes that arrived without an incarnation
+	// (the peer is old, or half-upgraded and hiding), and payloads dropped
+	// because their incarnation was replaced (the fence doing its job).
+	BulkPrimesWithoutIncarnation  uint64
+	ConfigsDeadIncarnationDropped uint64
+	// PeerBootIncarnation renders the boot id of the peer incarnation that
+	// most recently primed, or "none". It travels in the snapshot rather than
+	// through a new Manager accessor because the Manager holds only the
+	// SyncStatsProvider interface, and this is the same transport every other
+	// field in the status render already uses.
+	PeerBootIncarnation        string
 	ConfigsApplyFailed         uint64
 	IPsecSASent                uint64
 	IPsecSAReceived            uint64
@@ -424,6 +445,15 @@ type SessionSync struct {
 	// which is what makes a reconnect derive a different key.
 	configCrypto0 *configCryptoState
 	configCrypto1 *configCryptoState
+	// peerBootIncarnation is the boot id of the peer incarnation that most
+	// recently primed (#5084). Zero means no incarnated prime has been seen —
+	// an old peer, or none yet — and puts the fence in its fail-open state.
+	// Guarded by mu, beside the connections whose primes set it.
+	//
+	// Compared for EQUALITY only. It is an equivalence class ("same peer
+	// boot?"), never a ranking; ordering two of these is the mistake #6900
+	// made and cannot express the predicate.
+	peerBootIncarnation bootIncarnation
 	// peerIncarnation identifies which run of the peer process the currently
 	// installed connections belong to, and conn0Gen/conn1Gen record the
 	// incarnation each slot's connection was installed under. All three are
@@ -995,6 +1025,15 @@ type SessionSync struct {
 type configApplyItem struct {
 	gen  uint64
 	text string
+	// incarnation is the peer boot the payload arrived under (#5084), taken
+	// from the connection that carried it. Zero = un-incarnated: the payload
+	// is never dropped on incarnation grounds (plan §6 rule 4).
+	//
+	// This field is the whole fix. Without it a payload queued from a peer's
+	// PRIOR boot can apply after resetRecvGen has zeroed the high-water, record
+	// a high mark, and then refuse the rebooted peer's lower-generation current
+	// config permanently.
+	incarnation bootIncarnation
 }
 type failoverAck struct {
 	status uint8
@@ -1262,7 +1301,7 @@ func (s *SessionSync) Stats() SyncStatsSnapshot {
 		activeFabric = -1
 	}
 	s.mu.Unlock()
-	return SyncStatsSnapshot{SessionsSent: s.stats.SessionsSent.Load(), SessionsReceived: s.stats.SessionsReceived.Load(), SessionsInstalled: s.stats.SessionsInstalled.Load(), DeletesSent: s.stats.DeletesSent.Load(), DeletesReceived: s.stats.DeletesReceived.Load(), BulkSyncs: s.stats.BulkSyncs.Load(), ConfigsSent: s.stats.ConfigsSent.Load(), ConfigsReceived: s.stats.ConfigsReceived.Load(), ConfigsStaleIgnored: s.stats.ConfigsStaleIgnored.Load(), ConfigsApplyFailed: s.stats.ConfigsApplyFailed.Load(), IPsecSASent: s.stats.IPsecSASent.Load(), IPsecSAReceived: s.stats.IPsecSAReceived.Load(), IPsecSAStaleIgnored: s.stats.IPsecSAStaleIgnored.Load(), DHCPLeasesSent: s.stats.DHCPLeasesSent.Load(), DHCPLeasesReceived: s.stats.DHCPLeasesReceived.Load(), DHCPLeasesStaleIgnored: s.stats.DHCPLeasesStaleIgnored.Load(), DHCPLeasesSeeded: s.stats.DHCPLeasesSeeded.Load(), FencesSent: s.stats.FencesSent.Load(), FencesReceived: s.stats.FencesReceived.Load(), Errors: s.stats.Errors.Load(), DeletesDropped: s.stats.DeletesDropped.Load(), DeletesStaleIgnored: s.stats.DeletesStaleIgnored.Load(), InstallsStaleIgnored: s.stats.InstallsStaleIgnored.Load(), SessionsStaleConfigIgnored: s.stats.SessionsStaleConfigIgnored.Load(), GenMapOverflow: s.stats.GenMapOverflow.Load(), PreAuthRejected: s.stats.PreAuthRejected.Load(), Connected: s.stats.Connected.Load(), ActiveFabric: activeFabric, BulkSyncStartTime: s.stats.BulkSyncStartTime.Load(), BulkSyncEndTime: s.stats.BulkSyncEndTime.Load(), BulkSyncSessions: s.stats.BulkSyncSessions.Load(), LastConfigSyncTime: s.stats.LastConfigSyncTime.Load(), LastConfigSyncSize: s.stats.LastConfigSyncSize.Load(), LastFenceSeq: s.stats.LastFenceSeq.Load(), LastFenceAckAt: s.stats.LastFenceAckAt.Load()}
+	return SyncStatsSnapshot{SessionsSent: s.stats.SessionsSent.Load(), SessionsReceived: s.stats.SessionsReceived.Load(), SessionsInstalled: s.stats.SessionsInstalled.Load(), DeletesSent: s.stats.DeletesSent.Load(), DeletesReceived: s.stats.DeletesReceived.Load(), BulkSyncs: s.stats.BulkSyncs.Load(), ConfigsSent: s.stats.ConfigsSent.Load(), ConfigsReceived: s.stats.ConfigsReceived.Load(), ConfigsStaleIgnored: s.stats.ConfigsStaleIgnored.Load(), BulkPrimesWithoutIncarnation: s.stats.BulkPrimesWithoutIncarnation.Load(), PeerBootIncarnation: s.PeerBootIncarnation().String(), ConfigsDeadIncarnationDropped: s.stats.ConfigsDeadIncarnationDropped.Load(), ConfigsApplyFailed: s.stats.ConfigsApplyFailed.Load(), IPsecSASent: s.stats.IPsecSASent.Load(), IPsecSAReceived: s.stats.IPsecSAReceived.Load(), IPsecSAStaleIgnored: s.stats.IPsecSAStaleIgnored.Load(), DHCPLeasesSent: s.stats.DHCPLeasesSent.Load(), DHCPLeasesReceived: s.stats.DHCPLeasesReceived.Load(), DHCPLeasesStaleIgnored: s.stats.DHCPLeasesStaleIgnored.Load(), DHCPLeasesSeeded: s.stats.DHCPLeasesSeeded.Load(), FencesSent: s.stats.FencesSent.Load(), FencesReceived: s.stats.FencesReceived.Load(), Errors: s.stats.Errors.Load(), DeletesDropped: s.stats.DeletesDropped.Load(), DeletesStaleIgnored: s.stats.DeletesStaleIgnored.Load(), InstallsStaleIgnored: s.stats.InstallsStaleIgnored.Load(), SessionsStaleConfigIgnored: s.stats.SessionsStaleConfigIgnored.Load(), GenMapOverflow: s.stats.GenMapOverflow.Load(), PreAuthRejected: s.stats.PreAuthRejected.Load(), Connected: s.stats.Connected.Load(), ActiveFabric: activeFabric, BulkSyncStartTime: s.stats.BulkSyncStartTime.Load(), BulkSyncEndTime: s.stats.BulkSyncEndTime.Load(), BulkSyncSessions: s.stats.BulkSyncSessions.Load(), LastConfigSyncTime: s.stats.LastConfigSyncTime.Load(), LastConfigSyncSize: s.stats.LastConfigSyncSize.Load(), LastFenceSeq: s.stats.LastFenceSeq.Load(), LastFenceAckAt: s.stats.LastFenceAckAt.Load()}
 }
 
 // IsConnected reports whether a peer sync connection is currently established.

--- a/pkg/cluster/sync_auth.go
+++ b/pkg/cluster/sync_auth.go
@@ -197,6 +197,18 @@ type authConn struct {
 	readKey  []byte
 	writeKey []byte
 
+	// bootIncarnation is the peer boot id the BulkStart on THIS connection
+	// primed under (#5084). Zero until an incarnated prime arrives, and zero
+	// forever against a peer that predates the field. Per connection rather
+	// than per slot because a config payload must be stamped with the
+	// incarnation of the stream that carried it, not with whatever the other
+	// fabric last saw.
+	//
+	// unincarnatedWarned makes the fail-open notice ONE line per connection
+	// instead of one per prime.
+	bootIncarnation    bootIncarnation
+	unincarnatedWarned bool
+
 	// authPSK is the control-link PSK this connection's authentication was
 	// established under — the staleness test the #6628 reconciler uses. Nil on
 	// an unauthenticated connection. It is what lets ReconcileConnectionAuth

--- a/pkg/cluster/sync_boot_incarnation.go
+++ b/pkg/cluster/sync_boot_incarnation.go
@@ -1,0 +1,312 @@
+package cluster
+
+// Peer boot incarnation on the config-sync wire (#5084, plan #5480).
+//
+// THE DEFECT. `configApplyItem` carried only {gen, text}. When a peer reboots
+// and re-primes, `resetRecvGen` zeroes the last-applied high-water but does not
+// drain items already queued from the PRIOR boot. An old-boot item can apply
+// after the reset and record a high high-water, after which the rebooted peer's
+// lower-generation CURRENT config is refused as stale — persistent HA
+// policy/routing divergence, healed only by another commit or reconnect.
+//
+// WHY THE OBVIOUS FIX IS WRONG, AND WAS TRIED. PR #6900 fenced on
+// `configNamespaceConnID`, a floor over the per-connection `syncConnID`
+// counter, and failed across seven review rounds. The post-mortem in one line:
+//
+//	`syncConnID` is a total ORDER over connections. The predicate the guard
+//	needs is an EQUIVALENCE — were these two payloads produced by the same peer
+//	boot? — because config generations are comparable only within one sender
+//	incarnation. A ranking cannot express an equivalence, and the floor has no
+//	correct setting: never descending locks out a live same-incarnation sibling
+//	that merely connected earlier, while descending re-admits departed
+//	older-incarnation connections and makes the floor a mutable target an
+//	in-flight resetRecvGen can reclaim.
+//
+// Do not re-derive that. The converged design is
+// `docs/peer-boot-incarnation-plan.md`.
+//
+// THE GRANULARITY IS FORCED, NOT CHOSEN. `initGenState` seeds
+// `configGenCounter` from `MonotonicNanos()` so generations survive a daemon
+// restart WITHIN a boot; they become incomparable exactly when CLOCK_MONOTONIC
+// restarts, i.e. on OS boot. So the incarnation must change exactly on OS boot —
+// not per process, not per connection. `/proc/sys/kernel/random/boot_id` is a
+// 128-bit UUID the kernel regenerates per boot, stable for that boot, readable
+// unprivileged, unchanged by a daemon restart. It matches exactly.
+//
+// COMPARE FOR EQUALITY ONLY. The value is opaque. Never order two boot ids —
+// ordering is precisely the property established as unable to carry this
+// meaning. "Which incarnation is current" is answered by WHICH ONE PRIMED.
+//
+// WHERE IT GOES. The `syncMsgBulkStart` payload grows 8 -> 24 bytes: the
+// existing little-endian epoch, then 16 raw boot-id bytes. BulkStart is where
+// the value is CONSUMED — the prime is the claim event — so there is no window
+// in which a connection is installed but its incarnation is unknown. The auth
+// HELLO was rejected as a carrier: `performSyncHandshake` returns immediately
+// when `len(key) == 0`, so on an UNKEYED cluster a HELLO-carried incarnation
+// would not exist at all and the guard would be silently absent — a
+// configuration-dependent security property.
+//
+// FAIL OPEN on an absent incarnation, and that is a decision, not a default.
+// A payload with no incarnation gets exactly today's generation-only ordering.
+// The fallback is `origin/master`'s behaviour, not a weakened version of it; it
+// is the convention every legacy sentinel in this package already uses
+// (`gen == 0`, `epoch == 0`, `incarnation == 0 || seq == 0`); and failing closed
+// would refuse ALL config from a not-yet-upgraded peer for the whole
+// rolling-upgrade window, stranding the standby — strictly worse than the bug.
+//
+// It is also NOT a security decision. The incarnation is not an authorisation
+// token and grants nothing; a peer that omits it gets what an old build gets.
+// The authentication boundary is the PSK handshake and the frame HMAC, both
+// untouched.
+//
+// THE KNOWN RESIDUAL, SHIPPED BOUNDED RATHER THAN CLOSED (plan §7). A
+// pre-reboot socket that is half-open and has not yet errored can still hold a
+// buffered BulkStart from the DEAD incarnation. If that frame lands after the
+// new incarnation has primed, rule 1 switches the namespace BACK, and config
+// from the live incarnation is then dropped until the next prime re-switches
+// it. The window is bounded by the receive loop, not by chance: `receiveLoop`
+// arms a 10s read deadline and gives up at `missedHeartbeats >= 2`, so such a
+// socket self-evicts within ~20s of silence — and an OS reboot, which is the
+// only thing that changes an incarnation, outlasts that window, so the frame is
+// hard to produce at all. It is also SELF-HEALING: the peer re-pushes its
+// current config on the reconnect that follows, and the drop is counted in
+// ConfigsDeadIncarnationDropped and rendered in cluster status.
+//
+// Closing it rather than bounding it means a receiver-local strictly-increasing
+// "namespace claim ordinal" bumped on each switch, with a switch refused from a
+// connection whose slot is no longer installed. That is deliberately NOT done
+// here: it is the same add-an-ordering instinct that produced #6900, and it
+// should be added against a demonstrated failure, not pre-emptively. Operator
+// documentation: docs/sync-protocol.md, "Peer boot incarnation".
+//
+// THE CONTINGENCY, recorded per the plan so a later reviewer knows what they
+// would be signing up for: if a future requirement demands that an
+// un-incarnated peer be REFUSED, that forces either a flag day or making the
+// keyed handshake mandatory, because an upgraded receiver cannot distinguish
+// "old peer that cannot send the field" from "peer suppressing the field"
+// without a negotiated capability — and a negotiated capability has nowhere to
+// live on the unkeyed path. Both are decisions well outside #5084.
+
+import (
+	"bytes"
+	"encoding/hex"
+	"log/slog"
+	"net"
+	"os"
+	"strings"
+	"sync"
+)
+
+// bootIncarnationLen is the raw byte length of a boot id (a 128-bit UUID).
+const bootIncarnationLen = 16
+
+// bootIncarnation is a peer boot identity. The zero value means
+// "un-incarnated" — either a peer that predates this, or a local read failure.
+type bootIncarnation [bootIncarnationLen]byte
+
+// known reports whether this is a real incarnation rather than the
+// un-incarnated sentinel.
+func (b bootIncarnation) known() bool { return b != bootIncarnation{} }
+
+// String renders the incarnation for operator output. Opaque and safe to log:
+// a boot id is not a secret, and it is the only handle an operator has for
+// "which peer boot is this".
+func (b bootIncarnation) String() string {
+	if !b.known() {
+		return "none"
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// bootIDPath is the kernel's per-boot UUID. A var so a test can point it
+// elsewhere; production never reassigns it.
+var bootIDPath = "/proc/sys/kernel/random/boot_id"
+
+var (
+	localBootOnce sync.Once
+	localBootID   bootIncarnation
+)
+
+// localBootIncarnation returns this node's boot id, read once and cached.
+//
+// A read or parse failure yields the ZERO value, which puts this node in the
+// un-incarnated class — the same fail-open posture as an old peer, and the only
+// safe answer: a synthesised or random substitute would be a value that changes
+// when it must not, making every reconnect look like a reboot and clearing the
+// peer's high-water on a node that never rebooted.
+func localBootIncarnation() bootIncarnation {
+	localBootOnce.Do(func() { localBootID = readBootIncarnation(bootIDPath) })
+	return localBootID
+}
+
+// readBootIncarnation parses a boot_id file. Returns the zero value on any
+// failure.
+func readBootIncarnation(path string) bootIncarnation {
+	var out bootIncarnation
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return out
+	}
+	// The kernel renders it as a dashed UUID with a trailing newline.
+	text := strings.TrimSpace(string(raw))
+	text = strings.ReplaceAll(text, "-", "")
+	if len(text) != bootIncarnationLen*2 {
+		return out
+	}
+	decoded, err := hex.DecodeString(text)
+	if err != nil {
+		return out
+	}
+	copy(out[:], decoded)
+	return out
+}
+
+// appendBootIncarnation extends a BulkStart payload with this node's
+// incarnation, per the #2170 trailing-field discipline every prior extension in
+// this protocol used (`syncMsgBulkStart` gates on `len >= 8`, the delete frames
+// on `>= 24` / `>= 48`). An old receiver reads payload[:8] and ignores the tail;
+// the HMAC trailer covers the whole payload, so the authenticated path needs no
+// change.
+//
+// A node whose own boot id could not be read appends NOTHING rather than 16
+// zero bytes: an explicit zero would be indistinguishable on the wire from a
+// real incarnation the receiver must compare against, and the absent-field path
+// is the one already specified to fail open.
+//
+// `local` is a parameter rather than an internal `localBootIncarnation()` call
+// so the unreadable-boot-id arm is reachable from a test without mutating the
+// process-wide cache; the single production call site passes
+// `localBootIncarnation()`.
+func appendBootIncarnation(payload []byte, local bootIncarnation) []byte {
+	if !local.known() {
+		return payload
+	}
+	return append(payload, local[:]...)
+}
+
+// parseBootIncarnation extracts the incarnation from a BulkStart payload, or
+// the zero value when the peer sent the legacy 8-byte form.
+func parseBootIncarnation(payload []byte) bootIncarnation {
+	var out bootIncarnation
+	if len(payload) < 8+bootIncarnationLen {
+		return out
+	}
+	copy(out[:], payload[8:8+bootIncarnationLen])
+	return out
+}
+
+// notePeerBootIncarnation applies rules 1 and 2 of the plan's §6 to a BulkStart
+// that has just arrived, and reports whether the namespace SWITCHED.
+//
+//	rule 1  an incarnation DIFFERENT from the current one switches the
+//	        namespace: the caller clears the generation high-waters (which
+//	        resetRecvGen already does) and this records the new incarnation.
+//	rule 2  the SAME incarnation is a mid-connection re-prime (the #5450 forced
+//	        resync) and must NOT invalidate queued payloads — same incarnation,
+//	        comparable generations. This is the case #6900's equal-id exemption
+//	        was approximating.
+//
+// An un-incarnated prime records nothing and switches nothing: it leaves any
+// incarnation already learned in place, so a peer that primes once with an
+// incarnation and once without does not lose the fence. That asymmetry is
+// deliberate — the absent field means "no information", not "a different boot".
+func (s *SessionSync) notePeerBootIncarnation(inc bootIncarnation) (switched bool) {
+	if !inc.known() {
+		s.stats.BulkPrimesWithoutIncarnation.Add(1)
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.peerBootIncarnation == inc {
+		return false
+	}
+	s.peerBootIncarnation = inc
+	return true
+}
+
+// PeerBootIncarnation returns the incarnation of the peer boot that most
+// recently primed, or the zero value when none has. Safe to render.
+func (s *SessionSync) PeerBootIncarnation() bootIncarnation {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.peerBootIncarnation
+}
+
+// configItemIncarnationStale applies rule 3: a queued payload whose incarnation
+// differs from the current one is dead PERMANENTLY and is never re-admitted.
+//
+// Rule 4 is the `!known()` arm: an un-incarnated payload is never dropped on
+// incarnation grounds.
+//
+// Rule 3 is also what removes the hazard that killed #6900 — there, skipping a
+// payload also skipped the generation gate, so a dropped payload could strand
+// the high-water. Here a dropped payload comes from a DEAD incarnation whose
+// generations are incomparable with the current one, so its generation carries
+// no information the current high-water needs. That is true only because
+// membership is an equivalence rather than a ranking.
+func (s *SessionSync) configItemIncarnationStale(item configApplyItem) bool {
+	if !item.incarnation.known() {
+		return false
+	}
+	current := s.PeerBootIncarnation()
+	if !current.known() {
+		// Nothing has primed with an incarnation yet; there is no namespace to
+		// be outside of.
+		return false
+	}
+	return !bytes.Equal(item.incarnation[:], current[:])
+}
+
+// noteConnBootIncarnation records the incarnation a BulkStart on this
+// connection primed under. An un-incarnated prime records nothing, leaving any
+// incarnation the connection already learned in place: the absent field means
+// "no information", not "a different boot".
+//
+// Guarded by s.mu, like every other per-connection field.
+func (s *SessionSync) noteConnBootIncarnation(conn net.Conn, inc bootIncarnation) {
+	ac, ok := conn.(*authConn)
+	if !ok || !inc.known() {
+		return
+	}
+	s.mu.Lock()
+	ac.bootIncarnation = inc
+	s.mu.Unlock()
+}
+
+// connBootIncarnation returns the incarnation this connection primed under, or
+// the zero value for a connection that never received an incarnated prime —
+// including the second fabric, which may carry config without having primed.
+// Zero puts the payload in the never-dropped class (plan §6 rule 4), which is
+// the correct fail-open answer: no prime means no evidence of which boot the
+// payload belongs to.
+func (s *SessionSync) connBootIncarnation(conn net.Conn) bootIncarnation {
+	ac, ok := conn.(*authConn)
+	if !ok {
+		return bootIncarnation{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return ac.bootIncarnation
+}
+
+// warnUnincarnatedPrimeOnce emits the fail-open notice a single time per
+// connection. Per the plan, observability here is mandatory rather than
+// optional: the fallback is silent by construction, and a half-upgraded cluster
+// that hides is the failure mode.
+func (s *SessionSync) warnUnincarnatedPrimeOnce(conn net.Conn) {
+	ac, ok := conn.(*authConn)
+	if !ok {
+		return
+	}
+	s.mu.Lock()
+	already := ac.unincarnatedWarned
+	ac.unincarnatedWarned = true
+	s.mu.Unlock()
+	if already {
+		return
+	}
+	slog.Warn("cluster sync: peer primed without a boot incarnation — config ordering on this "+
+		"connection falls back to generation-only, exactly as before #5084. Expected while the "+
+		"peer is on an older build; if both nodes are upgraded, investigate.",
+		"remote", connRemoteAddrString(conn))
+}

--- a/pkg/cluster/sync_boot_incarnation.go
+++ b/pkg/cluster/sync_boot_incarnation.go
@@ -250,8 +250,18 @@ func (s *SessionSync) configItemIncarnationStale(item configApplyItem) bool {
 	}
 	current := s.PeerBootIncarnation()
 	if !current.known() {
-		// Nothing has primed with an incarnation yet; there is no namespace to
-		// be outside of.
+		// Nothing has primed with an incarnation yet, so there is no namespace
+		// to be outside of.
+		//
+		// UNREACHABLE while the two records are made together: the only writer
+		// of a connection's stamp is noteConnBootIncarnation, called from the
+		// same BulkStart arm that calls notePeerBootIncarnation, so an item
+		// cannot carry an incarnation the receiver has never seen. A mutation
+		// flipping this arm to `true` therefore changes nothing observable —
+		// it is kept as an explicit FAIL-OPEN so that if a future change ever
+		// splits the two records, the outcome is today's generation-only
+		// ordering rather than every payload being dropped against a namespace
+		// that does not exist.
 		return false
 	}
 	return !bytes.Equal(item.incarnation[:], current[:])

--- a/pkg/cluster/sync_boot_incarnation_5084_test.go
+++ b/pkg/cluster/sync_boot_incarnation_5084_test.go
@@ -637,3 +637,123 @@ func assertNoHealthEscalation5084(t *testing.T, m *Manager, when string) {
 			"must never raise a monitor failure:\n%s", when, n, m.FormatStatus())
 	}
 }
+
+// TestUnkeyedConnectionStampsTheIncarnation5084 binds the INSTALL wiring on the
+// posture the plan singles out: an UNKEYED cluster.
+//
+// `performSyncHandshake` returns immediately with syncAuthUnauthenticated when
+// `len(key) == 0`, which is exactly why the auth HELLO was rejected as the
+// carrier — a HELLO-borne incarnation would be silently absent there, making
+// the whole guard configuration-dependent. Carrying it on BulkStart is only
+// correct if the connection-install path still produces a per-connection
+// carrier on that path, and it does: handleNewConnection wraps EVERY connection
+// in an *authConn regardless of mode, and connBootIncarnation keys off that
+// wrapper.
+//
+// This drives the real thing: an unkeyed install, a BulkStart written onto the
+// wire, and the receiveLoop's own decode. Every other cell in this file injects
+// through handleMessage directly, so all of them stay green if the wrap is
+// dropped from handleNewConnection — and then connBootIncarnation returns the
+// zero value forever, every payload lands in the never-dropped class, and the
+// fence is silently inert on exactly the clusters that cannot authenticate.
+func TestUnkeyedConnectionStampsTheIncarnation5084(t *testing.T) {
+	s := NewSessionSync(":0", "10.0.0.2:4785", &mockSweepDP{})
+	cli, srv := net.Pipe()
+	defer cli.Close()
+	defer srv.Close()
+
+	if !s.beginSetup(srv, true) {
+		t.Fatal("setup: beginSetup should admit the first inbound connection")
+	}
+	// The install path emits advisory frames (clock sync, capabilities, key
+	// exchange). net.Pipe is unbuffered, so drain them or the install blocks.
+	drain := make(chan syncFrame, 32)
+	readFramesInto(cli, drain)
+	go s.handleNewConnection(context.Background(), 0, srv)
+
+	if err := writeMsg(cli, syncMsgBulkStart, bulkStartPayload(7, &incA)); err != nil {
+		t.Fatalf("write BulkStart: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if s.PeerBootIncarnation() == incA {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if got := s.PeerBootIncarnation(); got != incA {
+		t.Fatalf("an UNKEYED connection must still learn the peer boot incarnation; got %s. "+
+			"That posture performs no auth handshake at all, which is precisely why the "+
+			"incarnation rides on BulkStart rather than the HELLO", got)
+	}
+	s.mu.Lock()
+	installed := s.conn0
+	s.mu.Unlock()
+	if installed == nil {
+		t.Fatal("setup: the connection was never installed in fabric slot 0")
+	}
+	if got := s.connBootIncarnation(installed); got != incA {
+		t.Fatalf("the INSTALLED connection must carry the stamp (%s), so every config payload "+
+			"it delivers is enqueued with it; got %s. A connection the install path did not "+
+			"wrap yields the zero value and lands every payload in the never-dropped class",
+			incA, got)
+	}
+}
+
+// TestDeadIncarnationConfigNeverRaisesTheReceivedHighWater5084 covers the OTHER
+// drop site, and the fail state that made it necessary.
+//
+// `recordRecvConfigGen` runs at RECEIVE time and is a monotone max. #5563 gates
+// manual-failover readiness on it: `ReadyForManualFailover` refuses promotion
+// while `PeerConfigGen > AppliedConfigGen`. A dead incarnation's generation is
+// drawn from the peer's PRE-reboot counter, so it is far higher than anything
+// the live incarnation can produce. Dropping such a payload only at APPLY time
+// would leave the received mark inflated with nothing able to close the gap
+// short of another re-prime: the standby reads config-stale and refuses
+// promotion indefinitely — the #5084 divergence traded for a different silent
+// wedge, which is precisely the failure mode that killed #6900.
+//
+// The shape is the surviving-fabric one: fabric 0 primed under the dead boot,
+// the peer rebooted and re-primed over fabric 1, and a buffered payload from
+// the dead boot then arrives on fabric 0.
+//
+// FAIL-ON-REVERT: delete the receive-time check in handleConfigPayload and the
+// high-water assertion below reds while every apply-time cell stays green.
+func TestDeadIncarnationConfigNeverRaisesTheReceivedHighWater5084(t *testing.T) {
+	e := newIncEnv(t, 2)
+	e.prime(0, 1, &incA) // fabric 0 primed under boot A
+	e.prime(1, 2, &incB) // the peer rebooted; its re-prime arrives over fabric 1
+
+	e.pushConfig(0, "buffered-from-the-dead-boot", 9_000_001)
+	if got := e.waitApplied(1500 * time.Millisecond); got != "" {
+		t.Fatalf("a payload arriving under a replaced incarnation must not apply; got %q", got)
+	}
+	if n := e.s.stats.ConfigsDeadIncarnationDropped.Load(); n != 1 {
+		t.Fatalf("the receive-time drop must be counted exactly once; got %d", n)
+	}
+	if got := e.s.lastRecvConfigGen.Load(); got != 0 {
+		t.Fatalf("the received-config high-water rose to %d for a payload from a DEAD peer "+
+			"boot. #5563 refuses manual failover while PeerConfigGen > AppliedConfigGen, and "+
+			"no generation the live incarnation can produce will ever exceed a pre-reboot "+
+			"one — the standby would read config-stale and refuse promotion until the next "+
+			"re-prime", got)
+	}
+
+	// The live incarnation's own lower-generation config still applies, and
+	// leaves readiness clean (received == applied).
+	e.pushConfig(1, "current-on-the-live-fabric", 42)
+	if got := e.waitApplied(3 * time.Second); got != "current-on-the-live-fabric" {
+		t.Fatalf("the live incarnation's config must apply; got %q", got)
+	}
+	// recordAppliedConfigGen runs AFTER OnConfigReceived returns, so poll
+	// rather than read the mark the instant the text lands.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && e.s.lastAppliedConfigGen.Load() != 42 {
+		time.Sleep(time.Millisecond)
+	}
+	if r, a := e.s.lastRecvConfigGen.Load(), e.s.lastAppliedConfigGen.Load(); r != 42 || a != 42 {
+		t.Fatalf("received/applied marks = %d/%d, want 42/42 — a standby whose received mark "+
+			"exceeds its applied mark refuses manual failover (#5563)", r, a)
+	}
+}

--- a/pkg/cluster/sync_boot_incarnation_5084_test.go
+++ b/pkg/cluster/sync_boot_incarnation_5084_test.go
@@ -1,0 +1,639 @@
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+var (
+	incA = bootIncarnation{0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf}
+	incB = bootIncarnation{0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf}
+)
+
+// bulkStartPayload builds a BulkStart body: the 8-byte epoch, plus the 16-byte
+// incarnation when one is given. The no-incarnation form is byte-identical to
+// what a pre-#5084 sender emits.
+func bulkStartPayload(epoch uint64, inc *bootIncarnation) []byte {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, epoch)
+	if inc != nil {
+		buf = append(buf, inc[:]...)
+	}
+	return buf
+}
+
+// incEnv drives the real receive and apply paths over installed connections.
+//
+// The apply handler can be made to BLOCK for exactly one payload (holdNext), so
+// a test can leave a second payload sitting in configApplyCh across a re-prime.
+// That is the shape #5084 is about — "resetRecvGen does not drain items already
+// queued from the prior boot" — and it is reproduced here without reaching into
+// any connection's incarnation stamp by hand: every payload is stamped by the
+// production enqueue from the connection that carried it.
+type incEnv struct {
+	s       *SessionSync
+	conns   []*authConn
+	applied chan string
+	entered chan string
+
+	mu   sync.Mutex
+	hold chan struct{}
+}
+
+func newIncEnv(t *testing.T, fabrics int) *incEnv {
+	t.Helper()
+	s := NewSessionSync(":0", "10.0.0.2:4785", &mockSweepDP{})
+	e := &incEnv{s: s, applied: make(chan string, 16), entered: make(chan string, 16)}
+	s.OnConfigReceived = func(text string) error {
+		e.mu.Lock()
+		h := e.hold
+		e.hold = nil
+		e.mu.Unlock()
+		if h != nil {
+			// Announce that this payload cleared EVERY gate and is now inside
+			// the apply. Without this the test could push the next payload
+			// while the loop had merely dequeued this one and not yet run the
+			// incarnation check — a fixture race, not a production one.
+			e.entered <- text
+			<-h
+		}
+		e.applied <- text
+		return nil
+	}
+	for i := 0; i < fabrics; i++ {
+		local, remote := net.Pipe()
+		t.Cleanup(func() { local.Close(); remote.Close() })
+		ac := &authConn{Conn: local}
+		s.mu.Lock()
+		if i == 0 {
+			s.conn0 = ac
+		} else {
+			s.conn1 = ac
+		}
+		s.mu.Unlock()
+		e.conns = append(e.conns, ac)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go s.configApplyLoop(ctx)
+	return e
+}
+
+// holdNext makes the NEXT apply block until the returned channel is closed.
+func (e *incEnv) holdNext() chan struct{} {
+	h := make(chan struct{})
+	e.mu.Lock()
+	e.hold = h
+	e.mu.Unlock()
+	return h
+}
+
+// waitEntered blocks until the held payload is INSIDE OnConfigReceived, so the
+// apply loop is provably occupied and anything pushed next stays queued.
+func (e *incEnv) waitEntered(t *testing.T, want string) {
+	t.Helper()
+	select {
+	case got := <-e.entered:
+		if got != want {
+			t.Fatalf("setup: apply loop entered with %q, want %q", got, want)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("setup: the apply loop never entered the handler for %q", want)
+	}
+}
+
+func (e *incEnv) prime(idx int, epoch uint64, inc *bootIncarnation) {
+	e.s.handleMessage(e.conns[idx], syncMsgBulkStart, bulkStartPayload(epoch, inc))
+}
+
+func (e *incEnv) pushConfig(idx int, text string, gen uint64) {
+	e.s.handleMessage(e.conns[idx], syncMsgConfig, encodeConfigPayload(text, gen))
+}
+
+// waitApplied returns the next applied config text, or "" if none arrives.
+func (e *incEnv) waitApplied(d time.Duration) string {
+	select {
+	case text := <-e.applied:
+		return text
+	case <-time.After(d):
+		return ""
+	}
+}
+
+// waitQueued asserts that n payloads are sitting in configApplyCh. It is only
+// meaningful once waitEntered has proved the apply loop is blocked inside the
+// handler, which is what makes the count stable.
+func (e *incEnv) waitQueued(t *testing.T, n int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(e.s.configApplyCh) == n {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("setup: %d payload(s) never reached the apply queue (len=%d)", n, len(e.s.configApplyCh))
+}
+
+// TestQueuedPriorIncarnationConfigNeverApplies5084 is the binder the plan's §8
+// names first: it must RED as an ASSERTION when the incarnation comparison is
+// removed, showing a prior-incarnation config applying.
+//
+// It is the reported defect end to end, driven entirely through production
+// paths:
+//
+//  1. Boot A primes and a config applies (gen 5). The apply is HELD inside
+//     OnConfigReceived, so the apply loop is busy.
+//  2. Boot A pushes a second config at a LARGE generation — its
+//     monotonic-seeded counter has been climbing all boot. It sits in
+//     configApplyCh, stamped by the production enqueue with boot A.
+//  3. The peer REBOOTS and re-primes as boot B. resetRecvGen zeroes the
+//     generation high-waters — and does NOT drain the queue. That undrained
+//     item is the whole issue.
+//  4. The held apply is released. The queued boot-A payload reaches the front.
+//
+// Before the fence it applied and recorded its large generation as the
+// high-water, after which boot B's LOWER-generation current config was refused
+// as stale — permanently, because the mark is monotone-max. Both halves are
+// asserted: the stale payload must not apply, AND boot B's current config must.
+func TestQueuedPriorIncarnationConfigNeverApplies5084(t *testing.T) {
+	e := newIncEnv(t, 1)
+
+	// (1) Boot A primes and applies a config; the apply blocks in the handler.
+	e.prime(0, 1, &incA)
+	hold := e.holdNext()
+	e.pushConfig(0, "config-from-boot-A", 5)
+	e.waitEntered(t, "config-from-boot-A")
+
+	// (2) A second boot-A config queues behind it at a large generation.
+	e.pushConfig(0, "stale-from-boot-A", 9_000_001)
+	e.waitQueued(t, 1)
+
+	// (3) The peer reboots and re-primes. The queue is NOT drained.
+	e.prime(0, 2, &incB)
+
+	// (4) Release.
+	close(hold)
+	if got := e.waitApplied(3 * time.Second); got != "config-from-boot-A" {
+		t.Fatalf("setup: boot A's first config must apply normally; got %q", got)
+	}
+	if got := e.waitApplied(1500 * time.Millisecond); got != "" {
+		t.Fatalf("a config QUEUED from a REPLACED peer boot incarnation must never apply; it "+
+			"applied as %q. Applying it records a high-water drawn from a dead incarnation, "+
+			"after which the rebooted peer's lower-generation CURRENT config is refused as "+
+			"stale permanently — the #5084 divergence", got)
+	}
+	if n := e.s.stats.ConfigsDeadIncarnationDropped.Load(); n != 1 {
+		t.Fatalf("the drop must be counted (a fail-open fence is silent by construction); got %d", n)
+	}
+
+	// And the point of the whole fix: boot B's own config, at a generation far
+	// LOWER than boot A ever reached, still applies.
+	e.pushConfig(0, "current-from-boot-B", 42)
+	if got := e.waitApplied(3 * time.Second); got != "current-from-boot-B" {
+		t.Fatalf("the rebooted peer's current config must apply even though its generation is "+
+			"far LOWER than the dead incarnation's; got %q. If the queued boot-A payload "+
+			"applied above, its generation is now the high-water and every generation boot B "+
+			"can produce is refused", got)
+	}
+}
+
+// TestIncarnationIsComparedByEqualityNotOrder5084 binds the central finding of
+// the #6900 post-mortem: the predicate is an EQUIVALENCE, never a ranking.
+//
+// Same sequence as the binder above with the two boot ids REVERSED, so the dead
+// incarnation sorts ABOVE the live one. Any implementation that reaches for a
+// comparison — `<`, `>`, a floor, a high-water over incarnations — passes when
+// the ids happen to ascend and fails here, silently admitting a dead boot's
+// config. The sibling binder alone cannot see it, because there `incA < incB`
+// and an ordering test gives the right answer for the wrong reason.
+func TestIncarnationIsComparedByEqualityNotOrder5084(t *testing.T) {
+	e := newIncEnv(t, 1)
+
+	// The peer's FIRST boot sorts HIGHER than the boot that replaces it.
+	e.prime(0, 1, &incB)
+	hold := e.holdNext()
+	e.pushConfig(0, "config-from-the-higher-sorting-boot", 5)
+	e.waitEntered(t, "config-from-the-higher-sorting-boot")
+	e.pushConfig(0, "stale-from-the-higher-sorting-boot", 9_000_001)
+	e.waitQueued(t, 1)
+
+	// Reboot into an incarnation that sorts LOWER.
+	e.prime(0, 2, &incA)
+	close(hold)
+
+	if got := e.waitApplied(3 * time.Second); got != "config-from-the-higher-sorting-boot" {
+		t.Fatalf("setup: the first boot's config must apply normally; got %q", got)
+	}
+	if got := e.waitApplied(1500 * time.Millisecond); got != "" {
+		t.Fatalf("a config from a replaced boot must be dropped whatever the two ids sort "+
+			"like; it applied as %q. A ranking cannot express \"same peer boot?\" — that is "+
+			"the finding seven review rounds of #6900 converged on, and this is the case "+
+			"that catches an implementation which reached for a comparison anyway", got)
+	}
+}
+
+// TestSameIncarnationRePrimeKeepsQueuedConfig5084 is the plan's over-reach
+// guard, and it must stay GREEN under the revert above. A mid-connection
+// re-prime (the #5450 forced resync) carries the SAME incarnation, so
+// generations remain comparable and nothing queued may be discarded.
+//
+// The payload is genuinely queued ACROSS the re-prime, matching the binder's
+// shape exactly, so the two differ only in whether the boot id changed. A guard
+// that over-rejects — dropping on any re-prime, or on a connection-establishment
+// ranking — reds here while the binder stays green.
+func TestSameIncarnationRePrimeKeepsQueuedConfig5084(t *testing.T) {
+	e := newIncEnv(t, 1)
+	e.prime(0, 1, &incA)
+	hold := e.holdNext()
+	e.pushConfig(0, "first-config", 5)
+	e.waitEntered(t, "first-config")
+	e.pushConfig(0, "config-across-a-re-prime", 7)
+	e.waitQueued(t, 1)
+
+	e.prime(0, 2, &incA) // forced resync, SAME boot
+	close(hold)
+
+	if got := e.waitApplied(3 * time.Second); got != "first-config" {
+		t.Fatalf("setup: the first config must apply; got %q", got)
+	}
+	if got := e.waitApplied(3 * time.Second); got != "config-across-a-re-prime" {
+		t.Fatalf("a SAME-incarnation re-prime must not invalidate a queued payload — the "+
+			"generations are comparable and the peer did not reboot; got %q", got)
+	}
+	if n := e.s.stats.ConfigsDeadIncarnationDropped.Load(); n != 0 {
+		t.Fatalf("a same-incarnation re-prime must drop nothing; dropped %d", n)
+	}
+}
+
+// TestSurvivingFabricSameIncarnationIsNeverFenced5084 is the two-fabric case
+// that defeated #6900, and the plan requires it to be green BY CONSTRUCTION
+// rather than by a floor that descends.
+//
+// Fabric 0 primes first (it would hold the LOWER syncConnID under the old
+// ranking design). Fabric 1 then primes with the SAME incarnation — the same
+// peer boot, reached over the redundant link. A config arriving on fabric 0
+// must still apply: under a floor over connection ids, fabric 0 sits below the
+// floor fabric 1 raised and is fenced out, which is the live-sibling lockout
+// that killed the previous attempt.
+func TestSurvivingFabricSameIncarnationIsNeverFenced5084(t *testing.T) {
+	e := newIncEnv(t, 2)
+	e.prime(0, 1, &incA) // earlier connection, same boot
+	e.prime(1, 2, &incA) // later connection, SAME boot
+
+	e.pushConfig(0, "config-on-the-earlier-fabric", 11)
+	if got := e.waitApplied(3 * time.Second); got != "config-on-the-earlier-fabric" {
+		t.Fatalf("a config on the EARLIER fabric of the SAME peer boot must never be fenced "+
+			"out; got %q. This is the exact live-sibling lockout that defeated #6900: a "+
+			"ranking over connections cannot express \"same boot?\"", got)
+	}
+	if n := e.s.stats.ConfigsDeadIncarnationDropped.Load(); n != 0 {
+		t.Fatalf("no drop is legitimate here; dropped %d", n)
+	}
+}
+
+// TestUnincarnatedPeerBehavesExactlyAsBefore5084 is the mixed-version cell, and
+// the one that binds the FAIL-OPEN decision rather than merely documenting it:
+// an 8-byte BulkStart from an old peer must produce today's generation-only
+// ordering, with nothing dropped on incarnation grounds (plan §6 rule 4).
+//
+// A guard TIGHTENED to refuse an absent incarnation — the plausible "be safe,
+// reject what you cannot verify" edit — reds here and only here. Failing closed
+// would refuse ALL config from a not-yet-upgraded peer for the whole
+// rolling-upgrade window, stranding the standby: strictly worse than the bug
+// being fixed.
+//
+// The queued-across-a-re-prime shape is used deliberately, so this exercises
+// the same code path the binder does and differs only in the absent field.
+func TestUnincarnatedPeerBehavesExactlyAsBefore5084(t *testing.T) {
+	e := newIncEnv(t, 1)
+	e.prime(0, 1, nil) // legacy 8-byte BulkStart
+
+	if n := e.s.stats.BulkPrimesWithoutIncarnation.Load(); n != 1 {
+		t.Fatalf("an un-incarnated prime must be COUNTED — a silent fallback is how a "+
+			"half-upgraded cluster hides; got %d", n)
+	}
+	hold := e.holdNext()
+	e.pushConfig(0, "config-from-an-old-peer", 5)
+	e.waitEntered(t, "config-from-an-old-peer")
+	e.pushConfig(0, "queued-config-from-an-old-peer", 6)
+	e.waitQueued(t, 1)
+
+	// A second prime from the same old peer must not look like a reboot, and
+	// must not invalidate the payload queued behind it.
+	e.prime(0, 2, nil)
+	close(hold)
+
+	if got := e.waitApplied(3 * time.Second); got != "config-from-an-old-peer" {
+		t.Fatalf("an un-incarnated payload must never be dropped on incarnation grounds; got %q", got)
+	}
+	if got := e.waitApplied(3 * time.Second); got != "queued-config-from-an-old-peer" {
+		t.Fatalf("a second un-incarnated prime is not a namespace switch, and must not "+
+			"invalidate a queued payload; got %q. Failing CLOSED here refuses every config "+
+			"a not-yet-upgraded peer sends for the whole rolling-upgrade window", got)
+	}
+	if n := e.s.stats.ConfigsDeadIncarnationDropped.Load(); n != 0 {
+		t.Fatalf("nothing may be dropped against an un-incarnated peer; dropped %d", n)
+	}
+	if n := e.s.stats.BulkPrimesWithoutIncarnation.Load(); n != 2 {
+		t.Fatalf("both un-incarnated primes must be counted; got %d", n)
+	}
+}
+
+// TestIncarnatedPeerThenUnincarnatedPrimeKeepsTheFence5084 pins the asymmetry
+// in the absent-field rule: "no incarnation" means NO INFORMATION, not "a
+// different boot". A prime that carries nothing must leave an incarnation
+// already learned in place, so a peer that primes once with one and once
+// without does not silently lose the fence.
+func TestIncarnatedPeerThenUnincarnatedPrimeKeepsTheFence5084(t *testing.T) {
+	e := newIncEnv(t, 1)
+	e.prime(0, 1, &incA)
+	e.prime(0, 2, nil)
+	if got := e.s.PeerBootIncarnation(); got != incA {
+		t.Fatalf("an un-incarnated prime must not CLEAR a learned incarnation; got %s", got)
+	}
+}
+
+// TestBulkStartCarriesTheLocalBootIncarnationOnTheWire5084 binds the SENDER
+// wiring, not the helper it calls. Deleting `appendBootIncarnation` from
+// bulkSyncWindow leaves every receiver-side test above green — they inject
+// their own payloads — and ships a build that never emits the field at all.
+//
+// The frame is read off a real connection through the production write path.
+func TestBulkStartCarriesTheLocalBootIncarnationOnTheWire5084(t *testing.T) {
+	local, peer := net.Pipe()
+	defer local.Close()
+	defer peer.Close()
+
+	s := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", &mockSweepDP{})
+	s.mu.Lock()
+	s.conn0 = local
+	s.mu.Unlock()
+	s.stats.Connected.Store(true)
+
+	frames := make(chan syncFrame, 8)
+	readFramesInto(peer, frames)
+	go func() { _ = s.BulkSyncSnapshot(BulkSnapshot{}) }()
+
+	var start syncFrame
+	select {
+	case start = <-frames:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no BulkStart frame was written")
+	}
+	if start.typ != syncMsgBulkStart {
+		t.Fatalf("first frame type = %d, want BulkStart %d", start.typ, syncMsgBulkStart)
+	}
+
+	want := localBootIncarnation()
+	if !want.known() {
+		t.Fatalf("this node's %s could not be read, so the sender has nothing to advertise "+
+			"and the #5084 fence is inert on it. On Linux this file always exists; a build "+
+			"or sandbox that hides it silently disables the guard", bootIDPath)
+	}
+	if len(start.payload) != 8+bootIncarnationLen {
+		t.Fatalf("BulkStart payload = %d bytes, want %d (8B epoch + 16B boot incarnation). "+
+			"An 8-byte payload means the sender never appends the field, so an upgraded "+
+			"receiver sees an un-incarnated peer forever and the fence never engages",
+			len(start.payload), 8+bootIncarnationLen)
+	}
+	if !bytes.Equal(start.payload[8:], want[:]) {
+		t.Fatalf("BulkStart tail = %x, want this node's boot incarnation %s",
+			start.payload[8:], want)
+	}
+	// The receiver's parse of the frame this sender actually produced must
+	// agree with the sender's own value — the two spellings are asserted
+	// against each other rather than either being pinned to a literal.
+	if got := parseBootIncarnation(start.payload); got != want {
+		t.Fatalf("the receiver parses %s out of the frame the sender wrote for %s — the two "+
+			"halves of the wire contract disagree", got, want)
+	}
+}
+
+// TestUnreadableLocalBootIdEmitsTheLegacyPayload5084 pins the sender's own
+// fail-open. A node that cannot read its boot id appends NOTHING rather than 16
+// zero bytes: an explicit zero would be indistinguishable on the wire from a
+// real incarnation the receiver must compare against, and would fence every
+// payload against a namespace that does not exist.
+func TestUnreadableLocalBootIdEmitsTheLegacyPayload5084(t *testing.T) {
+	epoch := make([]byte, 8)
+	binary.LittleEndian.PutUint64(epoch, 0x1122334455667788)
+
+	legacy := appendBootIncarnation(append([]byte(nil), epoch...), bootIncarnation{})
+	if len(legacy) != 8 || !bytes.Equal(legacy, epoch) {
+		t.Fatalf("an unreadable boot id must emit the legacy 8-byte payload unchanged; got %x", legacy)
+	}
+	if parseBootIncarnation(legacy).known() {
+		t.Fatal("the legacy payload must read back as un-incarnated")
+	}
+
+	extended := appendBootIncarnation(append([]byte(nil), epoch...), incA)
+	if len(extended) != 8+bootIncarnationLen {
+		t.Fatalf("a known boot id must extend the payload to %d bytes; got %d", 8+bootIncarnationLen, len(extended))
+	}
+	if !bytes.Equal(extended[:8], epoch) {
+		t.Fatalf("the extension must not disturb the leading epoch; got %x", extended[:8])
+	}
+	if got := parseBootIncarnation(extended); got != incA {
+		t.Fatalf("round-trip: parsed %s, want %s", got, incA)
+	}
+}
+
+// TestExtendedBulkStartDecodesTheEpochUnchanged5084 is the wire-compatibility
+// cell the plan says must NOT be established by inspection.
+//
+// The claim under test is the one the whole design rests on: extending the
+// BulkStart payload from 8 to 24 bytes leaves the existing 8-byte field
+// readable exactly as before. It is asserted against the ACTUAL decode path —
+// the real `syncMsgBulkStart` arm, observed through the state it writes —
+// rather than by re-reading the bytes in the test, because a wire-compat claim
+// verified by reading is the shape that has failed repeatedly.
+func TestExtendedBulkStartDecodesTheEpochUnchanged5084(t *testing.T) {
+	const epoch = uint64(0x0102_0304_0506_0708)
+
+	legacy := newIncEnv(t, 1)
+	legacy.prime(0, epoch, nil)
+	legacy.s.bulkMu.Lock()
+	legacyEpoch := legacy.s.bulkRecvEpoch
+	legacy.s.bulkMu.Unlock()
+
+	extended := newIncEnv(t, 1)
+	extended.prime(0, epoch, &incA)
+	extended.s.bulkMu.Lock()
+	extendedEpoch := extended.s.bulkRecvEpoch
+	extended.s.bulkMu.Unlock()
+
+	if legacyEpoch != epoch {
+		t.Fatalf("precondition: the 8-byte form must decode the epoch (got %#x); without this "+
+			"the comparison below is between two wrong answers", legacyEpoch)
+	}
+	if extendedEpoch != legacyEpoch {
+		t.Fatalf("the 24-byte payload must decode the SAME epoch as the 8-byte one through the "+
+			"real receive arm: got %#x, want %#x. If the tail disturbs the leading field, "+
+			"every old receiver misreads a new sender's bulk epoch and bulk-ack matching "+
+			"breaks across the whole rolling upgrade", extendedEpoch, legacyEpoch)
+	}
+	if got := extended.s.PeerBootIncarnation(); got != incA {
+		t.Fatalf("the extended form must also yield the incarnation; got %s", got)
+	}
+	if got := legacy.s.PeerBootIncarnation(); got.known() {
+		t.Fatalf("the legacy form must yield NO incarnation; got %s", got)
+	}
+}
+
+// TestBootIncarnationParsingIsTotal5084 pins the parse boundaries. A short or
+// absent tail is "no information" and must never be mistaken for a real
+// incarnation, because a zero incarnation compared as a value would fence every
+// payload against a namespace that does not exist.
+func TestBootIncarnationParsingIsTotal5084(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   []byte
+		want bool
+	}{
+		{"empty", nil, false},
+		{"epoch only", make([]byte, 8), false},
+		{"one byte short", make([]byte, 8+bootIncarnationLen-1), false},
+		{"exact", append(make([]byte, 8), incA[:]...), true},
+	} {
+		got := parseBootIncarnation(tc.in)
+		if got.known() != tc.want {
+			t.Fatalf("%s: known()=%v want %v", tc.name, got.known(), tc.want)
+		}
+	}
+	// An all-zero tail is indistinguishable from absence, and must be treated
+	// as absence: the sender never emits one (appendBootIncarnation appends
+	// nothing when the local read failed) precisely so this case cannot arise
+	// as a real value.
+	zeroTail := make([]byte, 8+bootIncarnationLen)
+	if parseBootIncarnation(zeroTail).known() {
+		t.Fatal("an all-zero incarnation must read as absent, not as a distinct boot")
+	}
+}
+
+// TestLocalBootIncarnationParsesTheKernelFormat5084 drives the real reader
+// against the kernel's actual rendering — a dashed UUID with a trailing
+// newline — rather than a hand-rolled hex string.
+func TestLocalBootIncarnationParsesTheKernelFormat5084(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/boot_id"
+	if err := os.WriteFile(path, []byte("550e8400-e29b-41d4-a716-446655440000\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := readBootIncarnation(path)
+	want := bootIncarnation{0x55, 0x0e, 0x84, 0x00, 0xe2, 0x9b, 0x41, 0xd4, 0xa7, 0x16, 0x44, 0x66, 0x55, 0x44, 0x00, 0x00}
+	if got != want {
+		t.Fatalf("kernel boot_id parse: got %s want %s", got, want)
+	}
+	// Every failure mode yields the un-incarnated sentinel, never a partial or
+	// synthesised value: a substitute that changes when it must not would make
+	// every reconnect look like a reboot and clear the peer's high-water on a
+	// node that never rebooted.
+	if readBootIncarnation(dir + "/missing").known() {
+		t.Fatal("a missing boot_id must read as un-incarnated")
+	}
+	if err := os.WriteFile(path, []byte("not-a-uuid\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if readBootIncarnation(path).known() {
+		t.Fatal("an unparseable boot_id must read as un-incarnated")
+	}
+	// The real kernel file must parse too — the fixture above proves the
+	// FORMAT, this proves the deployed node actually yields an incarnation.
+	if !readBootIncarnation("/proc/sys/kernel/random/boot_id").known() {
+		t.Fatalf("%s did not yield an incarnation on this host; the sender would silently "+
+			"advertise nothing and the #5084 fence would be inert", bootIDPath)
+	}
+}
+
+// TestIncarnationSurfacesAsStatusNotHealth5084 binds the third design decision:
+// a stale-incarnation discard and an un-incarnated peer are EXPECTED events —
+// a peer reboot and a rolling upgrade — so they are surfaced as a status field
+// plus counters and must NOT raise a cluster health / alarm state.
+//
+// #6387 set the precedent in the other direction by making a config-sync APPLY
+// FAILURE diagnostic-only so it never gates failover; a strictly less severe
+// condition must not be louder. Raising health on an un-incarnated peer would
+// make every rolling upgrade render as degraded.
+func TestIncarnationSurfacesAsStatusNotHealth5084(t *testing.T) {
+	e := newIncEnv(t, 1)
+	m := NewManager(0, 22)
+	m.UpdateConfig(makeConfig(makeRG(0, false, map[int]int{0: 200, 1: 100})))
+	m.SetSyncStats(e.s)
+
+	// (1) Nothing has primed. The line must render ANYWAY, carrying "none" —
+	// the operationally interesting value is exactly the one a
+	// render-only-when-set line would hide.
+	info := m.FormatInformation()
+	if !strings.Contains(info, "Peer boot incarnation: none") {
+		t.Fatalf("status must always render the peer boot incarnation, including \"none\":\n%s", info)
+	}
+	assertNoHealthEscalation5084(t, m, "before any prime")
+
+	// (2) An un-incarnated (old-build) peer primes: counted and rendered, and
+	// still not a fault.
+	e.prime(0, 1, nil)
+	info = m.FormatInformation()
+	if !strings.Contains(info, "Primes without incarnation: 1") {
+		t.Fatalf("an un-incarnated prime must be rendered:\n%s", info)
+	}
+	if !strings.Contains(info, "Peer boot incarnation: none") {
+		t.Fatalf("an un-incarnated peer must still render \"none\":\n%s", info)
+	}
+	assertNoHealthEscalation5084(t, m, "against an un-incarnated peer")
+
+	// (3) A real incarnation primes, a payload queued from it survives a reboot
+	// into another incarnation, and the fence drops it.
+	e.prime(0, 2, &incA)
+	hold := e.holdNext()
+	e.pushConfig(0, "first", 5)
+	e.waitEntered(t, "first")
+	e.pushConfig(0, "queued-from-the-dead-boot", 9_000_001)
+	e.waitQueued(t, 1)
+	e.prime(0, 3, &incB)
+	close(hold)
+	if got := e.waitApplied(3 * time.Second); got != "first" {
+		t.Fatalf("setup: the first config must apply; got %q", got)
+	}
+	if got := e.waitApplied(1500 * time.Millisecond); got != "" {
+		t.Fatalf("setup: the dead-boot payload must be dropped; it applied as %q", got)
+	}
+
+	info = m.FormatInformation()
+	if !strings.Contains(info, "Peer boot incarnation: "+incB.String()) {
+		t.Fatalf("status must render the CURRENT incarnation (%s):\n%s", incB, info)
+	}
+	if !strings.Contains(info, "Configs dead-incarnation-dropped: 1") {
+		t.Fatalf("the fence's drop must be rendered as a counter:\n%s", info)
+	}
+	assertNoHealthEscalation5084(t, m, "after a dead-incarnation drop")
+}
+
+// assertNoHealthEscalation5084 checks the two node-health surfaces #6387 uses.
+// "Local node: degraded" is the FormatInformation health line, and a second
+// "CF" occurrence in FormatStatus means a redundancy-group row picked up a
+// config-sync monitor failure (the legend line always contributes one).
+func assertNoHealthEscalation5084(t *testing.T, m *Manager, when string) {
+	t.Helper()
+	info := m.FormatInformation()
+	if strings.Contains(info, "Local node: degraded") {
+		t.Fatalf("%s: the incarnation fence must not degrade node health — an un-incarnated "+
+			"peer is a rolling upgrade and a stale-incarnation discard is a peer reboot, "+
+			"neither is a fault:\n%s", when, info)
+	}
+	if strings.Contains(info, "Config sync: failing") {
+		t.Fatalf("%s: the incarnation fence must not raise the #6387 config-sync health "+
+			"signal:\n%s", when, info)
+	}
+	if n := strings.Count(m.FormatStatus(), "CF"); n != 1 {
+		t.Fatalf("%s: FormatStatus must carry only the legend's CF (count=%d) — the fence "+
+			"must never raise a monitor failure:\n%s", when, n, m.FormatStatus())
+	}
+}

--- a/pkg/cluster/sync_bulk.go
+++ b/pkg/cluster/sync_bulk.go
@@ -193,9 +193,16 @@ func (s *SessionSync) bulkSyncWindow(walk *bulkWalk) error {
 		"queue_len", len(s.sendCh),
 		"queue_cap", cap(s.sendCh))
 
-	// Send bulk start marker with epoch.
+	// Send bulk start marker with epoch, plus this node's boot incarnation
+	// (#5084). The payload grows 8 -> 24 bytes as a length-gated trailing
+	// extension: an old receiver reads payload[:8] and ignores the tail, which
+	// is the same #2170 discipline the delete frames use. BulkStart is the
+	// carrier because the prime IS the claim event — the incarnation arrives in
+	// the frame that declares it current, so no connection is ever installed
+	// with an unknown incarnation.
+	startPayload := appendBootIncarnation(epochBuf[:], localBootIncarnation())
 	s.writeMu.Lock()
-	err := writeMsg(conn, syncMsgBulkStart, epochBuf[:])
+	err := writeMsg(conn, syncMsgBulkStart, startPayload)
 	s.writeMu.Unlock()
 	if err != nil {
 		s.pendingBulkAckEpoch.Store(0)

--- a/pkg/cluster/sync_conn_config.go
+++ b/pkg/cluster/sync_conn_config.go
@@ -461,6 +461,31 @@ func (s *SessionSync) configApplyLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case item := <-s.configApplyCh:
+			// #5084 rule 3, and it must run BEFORE the generation gate. The
+			// payload's generation is drawn from a DEAD peer incarnation, so it
+			// is incomparable with the current one — feeding it to a
+			// monotone-max high-water is precisely the defect: an old-boot item
+			// applying after resetRecvGen records a high mark, and the rebooted
+			// peer's lower-generation current config is then refused as stale,
+			// permanently.
+			//
+			// Dropping here strands nothing, and that is true only because
+			// membership is an EQUIVALENCE. #6900 failed partly because
+			// skipping a payload also skipped the generation gate and could
+			// leave the high-water holding information from a connection it had
+			// just fenced out; here the dropped payload's generation carries no
+			// information the current namespace needs, because it was never
+			// comparable to begin with.
+			if s.configItemIncarnationStale(item) {
+				s.stats.ConfigsDeadIncarnationDropped.Add(1)
+				slog.Warn("cluster sync: dropping config from a replaced peer boot incarnation — "+
+					"the peer rebooted and re-primed, so this payload's generation is incomparable "+
+					"with the current one (#5084)",
+					"item_incarnation", item.incarnation.String(),
+					"current_incarnation", s.PeerBootIncarnation().String(),
+					"gen", item.gen, "size", len(item.text))
+				continue
+			}
 			if !s.shouldApplyConfigGen(item.gen) {
 				s.stats.ConfigsStaleIgnored.Add(1)
 				slog.Warn("cluster sync: dropping out-of-order config sync (stale generation) — standby retains newer config",

--- a/pkg/cluster/sync_conn_read.go
+++ b/pkg/cluster/sync_conn_read.go
@@ -189,6 +189,12 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 		// CONNECTION so every config payload arriving on it is stamped with the
 		// incarnation that primed it, and compared against the receiver-wide
 		// current incarnation to decide a namespace switch.
+		//
+		// ORDER MATTERS: both records land BEFORE resetRecvGen below. Reversing
+		// them opens a window in which the high-waters are already zeroed while
+		// the current incarnation is still the DEAD one, so a prior-boot payload
+		// dequeued in that window passes the fence and records its (large)
+		// generation — the exact defect this exists to close.
 		inc := parseBootIncarnation(payload)
 		s.noteConnBootIncarnation(conn, inc)
 		switched := s.notePeerBootIncarnation(inc)
@@ -624,6 +630,33 @@ func (s *SessionSync) handleConfigPayload(conn net.Conn, payload []byte) {
 	// needs no CAS") holds per connection but there are TWO receive loops,
 	// so a raise driven by one fabric raced resetRecvGen's clear driven by
 	// the other and could re-raise the mark that clear had just zeroed.
+	// #5084: a payload arriving under a peer boot incarnation that a re-prime
+	// has ALREADY replaced is dead, and has to be refused here as well as at
+	// apply. recordRecvConfigGen below is a monotone max that gates
+	// manual-failover readiness (#5563 refuses promotion while PeerConfigGen >
+	// AppliedConfigGen), and a dead incarnation's generation is drawn from the
+	// peer's PRE-reboot counter, so it is far higher than anything the live
+	// incarnation can produce. Raising the received mark for a payload the
+	// apply loop is then going to drop would strand the standby reading
+	// config-stale, with nothing able to close the gap short of another
+	// re-prime — trading the #5084 divergence for a different silent wedge.
+	//
+	// The apply-time check is NOT made redundant by this one. This site sees
+	// only payloads that ARRIVE after the switch; the apply-time site catches a
+	// payload that was already QUEUED when the re-prime landed, which is the
+	// reported defect ("resetRecvGen does not drain items already queued from
+	// the prior boot"). Neither site subsumes the other.
+	item := configApplyItem{gen: gen, text: configText, incarnation: s.connBootIncarnation(conn)}
+	if s.configItemIncarnationStale(item) {
+		s.stats.ConfigsDeadIncarnationDropped.Add(1)
+		slog.Warn("cluster sync: dropping config received under a replaced peer boot "+
+			"incarnation — the peer rebooted and re-primed, so this payload's generation "+
+			"is incomparable with the current one (#5084)",
+			"item_incarnation", item.incarnation.String(),
+			"current_incarnation", s.PeerBootIncarnation().String(),
+			"gen", gen, "size", len(configText), "remote", connRemoteAddrString(conn))
+		return
+	}
 	s.recordRecvConfigGen(gen)
 	// #3931: enqueue onto the single-consumer ordered apply queue instead
 	// of spawning a racing `go OnConfigReceived`. The receiveLoop is
@@ -633,11 +666,7 @@ func (s *SessionSync) handleConfigPayload(conn net.Conn, payload []byte) {
 	// heartbeats on this connection.
 	if s.configApplyCh != nil {
 		select {
-		case s.configApplyCh <- configApplyItem{
-			gen:         gen,
-			text:        configText,
-			incarnation: s.connBootIncarnation(conn),
-		}:
+		case s.configApplyCh <- item:
 		default:
 			// Ordered apply queue full — practically impossible (commits
 			// are seconds apart, apply is sub-second). Drop with an alarm;

--- a/pkg/cluster/sync_conn_read.go
+++ b/pkg/cluster/sync_conn_read.go
@@ -193,8 +193,15 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 		// ORDER MATTERS: both records land BEFORE resetRecvGen below. Reversing
 		// them opens a window in which the high-waters are already zeroed while
 		// the current incarnation is still the DEAD one, so a prior-boot payload
-		// dequeued in that window passes the fence and records its (large)
-		// generation — the exact defect this exists to close.
+		// dequeued by configApplyLoop in that window passes the fence and
+		// records its (large) generation — the exact defect this exists to
+		// close. In this order there is no such window.
+		//
+		// Not covered by a test, and deliberately called out rather than left
+		// implied: binding it would mean interleaving the apply-loop goroutine
+		// between two adjacent statements here, which no deterministic fixture
+		// in this package can do. A mutation moving both records after the
+		// reset leaves the whole suite green.
 		inc := parseBootIncarnation(payload)
 		s.noteConnBootIncarnation(conn, inc)
 		switched := s.notePeerBootIncarnation(inc)

--- a/pkg/cluster/sync_conn_read.go
+++ b/pkg/cluster/sync_conn_read.go
@@ -185,6 +185,13 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 		if len(payload) >= 8 {
 			epoch = binary.LittleEndian.Uint64(payload[:8])
 		}
+		// #5084: the peer's boot incarnation, when it sent one. Recorded on the
+		// CONNECTION so every config payload arriving on it is stamped with the
+		// incarnation that primed it, and compared against the receiver-wide
+		// current incarnation to decide a namespace switch.
+		inc := parseBootIncarnation(payload)
+		s.noteConnBootIncarnation(conn, inc)
+		switched := s.notePeerBootIncarnation(inc)
 		s.stats.BulkSyncStartTime.Store(time.Now().UnixNano())
 		s.stats.BulkSyncEndTime.Store(0)
 		s.stats.BulkSyncSessions.Store(0)
@@ -201,7 +208,16 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 		s.bulkRecvV6 = make(map[dataplane.SessionKeyV6]struct{})
 		s.bulkZoneSnapshot = zoneSnap
 		s.bulkMu.Unlock()
-		slog.Info("cluster sync: bulk transfer starting", "epoch", epoch, "local", connLocalAddrString(conn), "remote", connRemoteAddrString(conn))
+		slog.Info("cluster sync: bulk transfer starting", "epoch", epoch,
+			"peer_boot_incarnation", inc.String(), "incarnation_switched", switched,
+			"local", connLocalAddrString(conn), "remote", connRemoteAddrString(conn))
+		// #5084: a peer that primes without an incarnation gets today's
+		// generation-only ordering (fail open). Warn ONCE per connection, not
+		// per frame — a silent fallback is how a half-upgraded cluster hides,
+		// and the CLAUDE.md logging rule forbids the per-frame version.
+		if !inc.known() {
+			s.warnUnincarnatedPrimeOnce(conn)
+		}
 	case syncMsgBulkEnd:
 		var epoch uint64
 		if len(payload) >= 8 {
@@ -323,7 +339,7 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 		// speak for the current one. See noteHeartbeatAck (sync_conn.go).
 		s.noteHeartbeatAck(conn)
 	case syncMsgConfig:
-		s.handleConfigPayload(payload)
+		s.handleConfigPayload(conn, payload)
 	case syncMsgConfigEncrypted:
 		// #6629: same payload, sealed under this connection's ephemeral key.
 		// Decrypt, then hand the plaintext to the SAME handler — the two arms
@@ -360,7 +376,7 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 				"err", err, "remote", connRemoteAddrString(conn))
 			return
 		}
-		s.handleConfigPayload(plaintext)
+		s.handleConfigPayload(conn, plaintext)
 	case syncMsgConfigKeyExchange:
 		s.handleConfigKeyExchange(conn, payload)
 	case syncMsgAuthUpgradeHello:
@@ -586,7 +602,11 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 // generation high-water accounting and the apply-queue admission must be
 // identical for the two — a divergence between them is always a bug, so the
 // behaviour is single-sourced rather than duplicated and kept in agreement.
-func (s *SessionSync) handleConfigPayload(payload []byte) {
+// The conn parameter is #5084: the payload is stamped with the boot incarnation
+// the CONNECTION primed under, so a payload queued from a peer's prior boot can
+// be dropped at apply time rather than applying across a reset and stranding
+// the high-water.
+func (s *SessionSync) handleConfigPayload(conn net.Conn, payload []byte) {
 	s.stats.ConfigsReceived.Add(1)
 	s.stats.LastConfigSyncTime.Store(time.Now().UnixNano())
 	configText, gen := decodeConfigPayload(payload)
@@ -613,7 +633,11 @@ func (s *SessionSync) handleConfigPayload(payload []byte) {
 	// heartbeats on this connection.
 	if s.configApplyCh != nil {
 		select {
-		case s.configApplyCh <- configApplyItem{gen: gen, text: configText}:
+		case s.configApplyCh <- configApplyItem{
+			gen:         gen,
+			text:        configText,
+			incarnation: s.connBootIncarnation(conn),
+		}:
 		default:
 			// Ordered apply queue full — practically impossible (commits
 			// are seconds apart, apply is sub-second). Drop with an alarm;


### PR DESCRIPTION
Closes #5084

## The defect

`configApplyItem` carried only `{gen, text}`. When the peer rebooted and
re-primed, `resetRecvGen` zeroed the generation high-waters but did **not**
drain items already queued from the prior boot. Such an item could apply after
the reset and record its (large, pre-reboot) generation as the high-water, after
which the rebooted peer's lower-generation **current** config was refused as
stale — permanently, because the mark is monotone-max. Persistent HA
policy/routing divergence, healed only by another commit or reconnect.

Verified live on `origin/master` before this branch: `pkg/cluster/sync.go`
`configApplyItem{gen uint64; text string}`, and the sole production enqueue in
`sync_conn_read.go` tagging nothing.

## Why the obvious fix is wrong, and was tried

PR #6900 fenced on `configNamespaceConnID`, a floor over the per-connection
`syncConnID` counter, and failed across seven review rounds. The one-line
post-mortem:

> `syncConnID` is a total **ORDER** over connections. The predicate the guard
> needs is an **EQUIVALENCE** — *were these two payloads produced by the same
> peer boot?* A ranking cannot express an equivalence, and the floor has no
> correct setting: never descending locks out a live same-incarnation sibling
> that merely connected earlier, while descending re-admits departed
> older-incarnation connections.

This implements the converged design merged as
`docs/peer-boot-incarnation-plan.md` (#6919). It is **not** a retry of #6900.

## What ships

- **The discriminator is `/proc/sys/kernel/random/boot_id`** — a 128-bit UUID
  the kernel regenerates per OS boot, stable for that boot, unchanged by a
  daemon restart. The granularity is *forced*: `initGenState` seeds
  `configGenCounter` from `CLOCK_MONOTONIC`, which restarts exactly on OS boot.
- **Compared for EQUALITY only.** Ordering two boot ids is the mistake #6900
  made and cannot carry the meaning.
- **It rides on `syncMsgBulkStart`, 8 → 24 bytes**, a length-gated trailing
  extension (the same discipline the delete frames use). `BulkStart` is the
  carrier because the prime IS the claim event, and because
  `performSyncHandshake` returns immediately on an **unkeyed** cluster — a
  HELLO-carried field would be silently absent exactly there.
- **Two drop sites, neither redundant.** At receive (before
  `recordRecvConfigGen`) and at apply (before the generation gate). See
  "Second commit" below.

## The three sign-off decisions

**1. Fail open in the mixed-version window — accepted.** `len(payload) < 24` ⇒
no incarnation ⇒ exactly today's generation-only ordering. This is the
convention every legacy sentinel in the package already uses (`gen == 0`,
`epoch == 0`, `incarnation == 0 || seq == 0`), and the fallback is master's
behaviour rather than a weakened version of it. Failing closed would refuse ALL
config from a not-yet-upgraded peer for the whole rolling-upgrade window. It is
not a security decision: the incarnation is not an authorisation token; the
authentication boundary is the PSK handshake and frame HMAC, both untouched. A
node whose own `boot_id` is unreadable appends **nothing** rather than 16 zero
bytes, so it presents as an old-build sender rather than a distinct boot.

The contingency is recorded at the code site and in the doc: a future
requirement to *refuse* an un-incarnated peer forces either a flag day or a
mandatory keyed handshake, because presence cannot be distinguished from
suppression without a negotiated capability, and that has nowhere to live on the
unkeyed path.

**2. The ~20s residual is accepted, bounded, and documented — not closed and not
expanded.** A half-open pre-reboot socket can hold a buffered `BulkStart` from
the dead incarnation; if it lands after the new incarnation primed, the
namespace switches back. `receiveLoop` arms a 10s read deadline and gives up at
`missedHeartbeats >= 2`, so such a socket self-evicts within ~20s of silence,
and an OS reboot outlasts that window. It is self-healing (the peer re-pushes on
the following reconnect) and every drop is counted. Closing it means a
receiver-local claim ordinal — the same add-an-ordering instinct that produced
#6900 — and is deliberately left to a demonstrated failure. Documented in
`sync_boot_incarnation.go` and in `docs/sync-protocol.md`, "Known residual".

**3. A status field plus counters, never a health/alarm state.**
`show chassis cluster information` renders `Peer boot incarnation: <hex>|none`
**always** — `none` is the operationally interesting value and a
render-only-when-set line would hide exactly it — plus
`Primes without incarnation: N` and `Configs dead-incarnation-dropped: N`, and
one `slog.Warn` per **connection** (not per frame). No cluster health
annotation: an un-incarnated peer is the steady state of a rolling upgrade and a
stale-incarnation discard is an expected peer reboot. #6387 set the precedent by
making a config-sync APPLY FAILURE diagnostic-only so it never gates failover; a
less severe condition must not be louder. A test asserts the absence
(`Local node: degraded`, `Config sync: failing`, and the `CF` monitor column).

## Second commit — the receive-time site

The apply-time check alone traded the #5084 divergence for a different silent
wedge, and it was caught during self-review rather than by the tests.
`handleConfigPayload` raises `lastRecvConfigGen` at receive, and #5563 refuses
manual failover while `PeerConfigGen > AppliedConfigGen`. A dead incarnation's
generation comes from the peer's pre-reboot counter, so it is higher than
anything the live incarnation can produce: dropping only at apply left the
received mark inflated with nothing able to close the gap short of another
re-prime — the standby reads config-stale and refuses promotion indefinitely.
That is the same one-permanent-fail-state-for-one-self-correcting-one shape that
ended #6900, so it is closed rather than documented.

Neither site subsumes the other: the receive-time site sees only payloads that
*arrive* after the switch; the apply-time site catches a payload already sitting
in `configApplyCh` when the re-prime landed, which is the reported defect.

## Wire compatibility

No `SessionSyncWireVersion` bump — the extension is additive and self-detecting
by payload length, and bumping the version would break session sync for the
whole mixed-base window (the #2239 lesson).

| receiver | sender | outcome |
|---|---|---|
| old | old | today's behaviour |
| old | new | 24-byte `BulkStart`; old receiver reads `payload[:8]`, ignores the tail |
| new | old | 8-byte `BulkStart`; no incarnation; today's behaviour |
| new | new | full #5084 guard |

Both mixed states are stable indefinitely; upgrade order does not matter.

## Validation

- `go build ./...` clean; `go vet ./pkg/cluster/` clean; `gofmt` clean.
- `go test ./pkg/cluster/ -count=1` green; `-race` green across the whole
  package. The `-race` run caught a real fixture defect (a mark polled too
  early) that the plain run passed by luck.
- **Mutation matrix, full-suite per cell** (no `-run` filter), each mutation
  verified applied via `git diff --stat` and restored verbatim from the base
  commit — table below.

**Not run here: `make test-failover`.** This is cluster config-sync code and
owes the HA smoke on the shared, lock-protected loss userspace cluster; it is
run centrally rather than by this lane.

Third commit is comment-only: it records the two GREEN matrix cells (M3, M14)
in the code rather than leaving a reader to assume a test stands behind either.

## Mutation matrix

Every cell: `go build ./pkg/cluster/` **rc=0** (no red on a non-compiling tree),
mutation verified applied via a non-empty `git diff --stat`, restored verbatim
with `git checkout e580b4103 -- …`, and the **full** `pkg/cluster` suite run
with no `-run` filter (`-count=1 -timeout 150s -v`). Tests collected = 908 in
every cell except M2, where the cell's own hang truncated the run at 679 — still
> 0, so it RAN.

| # | Mutation | Site | Verdict — which assertion fired |
|---|---|---|---|
| **M1** | apply-time fence disabled (`if false && …`) | `sync_conn_config.go` | **RED ×3** — `QueuedPriorIncarnationConfigNeverApplies` ("a config QUEUED from a REPLACED peer boot incarnation must never apply"), `IncarnationIsComparedByEqualityNotOrder`, `IncarnationSurfacesAsStatusNotHealth`. The four over-reach guards stayed **GREEN**: `SameIncarnationRePrimeKeepsQueuedConfig`, `SurvivingFabricSameIncarnationIsNeverFenced`, `UnincarnatedPeerBehavesExactlyAsBefore`, `BulkStartCarriesTheLocalBootIncarnation` |
| **M2** | **TIGHTEN** — an item with **no** incarnation is stale | `sync_boot_incarnation.go` | **RED** — `UnincarnatedPeerBehavesExactlyAsBefore` ("an un-incarnated payload must never be dropped on incarnation grounds"), plus two pre-existing owners (`ConfigApplyLoopSendsNackOnFailure7328`, `ConfigSyncPayloadDoesNotCarryThePSKInCleartext6629`) and a hang in `ConfigApplyFenceRefusesStaleInstallDuringSweep6284`. **This is the cell that proves fail-open is BOUND, not merely written** |
| **M3** | **TIGHTEN** — stale when the receiver has no current incarnation | `sync_boot_incarnation.go` | **GREEN — equivalent mutation.** The arm is unreachable: the only writer of a connection's stamp is the same `BulkStart` that sets the receiver-wide incarnation, so an item cannot carry one the receiver has never seen. Re-aimed rather than forced; the branch is kept as an explicit fail-open and the code comment now says it is unreachable (commit 3) |
| **M4** | equality → ordering (`bytes.Compare(…) < 0`) | `sync_boot_incarnation.go` | **RED ×1, exclusively** — `IncarnationIsComparedByEqualityNotOrder`. The binder stays green because its ids ascend, which is exactly the wrong-reason pass that cell exists to catch |
| **M5** | drop the enqueue stamp (`incarnation:` omitted) — **wiring** | `sync_conn_read.go` | **RED ×4** incl. both drop-site cells |
| **M6** | delete the `noteConnBootIncarnation` call — **wiring** | `sync_conn_read.go` | **RED ×5** incl. `UnkeyedConnectionStampsTheIncarnation` |
| **M7** | neutralise `notePeerBootIncarnation` — **wiring** | `sync_conn_read.go` | **RED ×8** |
| **M8** | sender stops appending (`startPayload := epochBuf[:]`) — **wiring** | `sync_bulk.go` | **RED ×1, exclusively** — `BulkStartCarriesTheLocalBootIncarnationOnTheWire` ("An 8-byte payload means the sender never appends the field"). Every receiver-side cell stays green, which is the point |
| **M9** | sender appends 16 **zero** bytes when the local boot id is unreadable | `sync_boot_incarnation.go` | **RED ×1** — `UnreadableLocalBootIdEmitsTheLegacyPayload` |
| **M10** | **TIGHTEN** — an un-incarnated prime CLEARS the learned incarnation | `sync_boot_incarnation.go` | **RED ×1** — `IncarnatedPeerThenUnincarnatedPrimeKeepsTheFence` ("absent means NO INFORMATION, not a different boot") |
| **M11** | status line rendered only when `!= "none"` | `status.go` | **RED ×1** — `IncarnationSurfacesAsStatusNotHealth` ("status must always render the peer boot incarnation, including \"none\"") |
| **M12** | `PeerBootIncarnation` dropped from the stats snapshot — **wiring** | `sync.go` | **RED ×1** — same cell |
| **M13** | receive-time fence disabled (`if false && …`) | `sync_conn_read.go` | **RED ×1, exclusively** — `DeadIncarnationConfigNeverRaisesTheReceivedHighWater`. Paired with M1 this is the evidence that **neither drop site subsumes the other**: each has a red no other cell produces |
| **M14** | both records moved **after** `resetRecvGen` (deferred) | `sync_conn_read.go` | **GREEN — reported, not claimed.** The ordering is real and load-bearing (a prior-boot payload dequeued between a reset and a later record passes the fence and records its generation), but binding it means interleaving the apply-loop goroutine between two adjacent statements, which no deterministic fixture here can do. The code comment now states the property is uncovered rather than letting a reader assume a test stands behind it |
| **M15** | drop the `conn = wrapSyncConn(…)` assignment — **wiring** | `sync_conn.go` | **RED ×1, exclusively** — `UnkeyedConnectionStampsTheIncarnation`. Without it `connBootIncarnation` returns the zero value forever and the fence is silently inert on unkeyed clusters |


## Notes for review

- The binder does **not** stamp a connection by hand. It holds an apply inside
  `OnConfigReceived` so the next payload is genuinely **queued** across the
  re-prime, then releases — the reported defect driven entirely through
  production paths.
- `TestIncarnationIsComparedByEqualityNotOrder5084` runs the same sequence with
  the two boot ids **reversed**, so the dead incarnation sorts *above* the live
  one. An implementation that reached for a comparison passes the binder (where
  the ids happen to ascend) and fails only there.
- `TestUnkeyedConnectionStampsTheIncarnation5084` drives an unkeyed
  `handleNewConnection` end-to-end. Every other cell injects through
  `handleMessage`, so all of them stay green if the connection wrap is dropped —
  and then the fence is silently inert on exactly the clusters that cannot
  authenticate.

Refs #5480, #6900, #6919, #6963.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VM24XVAYBhzAUSAAhnR8Xp
