### PR TITLE
show: annotate the third port-mirroring renderer and gate the fail-closed exclusion class (#6534)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103324,3 +103324,27 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/frr/policy_render.go`,
   `pkg/config/compiler_as_path_multitoken_6686_test.go` (new),
   `pkg/frr/policy_aspath_regex_6686_test.go` (new), `docs/config-schema.md`
+
+## 2026-08-22 — #6534 closure: third port-mirroring renderer + cross-surface gate
+- **Action**: Closed #6534 by fixing the one live instance the three landed
+  family PRs missed and adding the mechanism that makes the class mechanically
+  enumerable. `cli.showForwardingOptions` is a THIRD port-mirroring renderer —
+  the only one printing full per-instance detail under `show
+  forwarding-options`, since the gRPC twin emits only a pointer line — and it
+  rendered an instance the snapshot builder DROPS as armed. New `pkg/showaudit`
+  registers the six builder-side `pkg/config` drop predicates across five
+  families and asserts (a) exact equality between the predicates the builder
+  calls and the registry, so a NEW fail-closed exclusion cannot land without
+  declaring its surfaces; (b) existence closure — some surface consults each
+  verdict; (c) guardedness closure — the census of render functions that do NOT
+  consult it, asserted EXACTLY in both directions so a deferral cannot decay
+  into an allowlist. Measured population: 6 predicates, 32 render functions
+  across 5 surface packages, 20 still unannotated (filed as #7473). Corrected
+  two stale enumeration claims that said "BOTH" of two port-mirroring surfaces.
+- **File(s)**: pkg/showaudit/doc.go (new),
+  pkg/showaudit/surface_gate_6534_test.go (new),
+  pkg/cli/cli_show_routing.go,
+  pkg/cli/mirror_exclusion_surfaces_6534_test.go (new),
+  pkg/config/mirror_exclusion_reason.go,
+  pkg/grpcapi/mirror_exclusion_surfaces_6534_test.go,
+  docs/junos-cli-reference.md

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -1416,9 +1416,10 @@ Two deliberate non-annotations:
 
 ## Port-mirroring instances the dataplane does not install (#6534)
 
-`show forwarding-options` (gRPC) and the CLI `show forwarding-options
-port-mirroring` render instances from configuration. An instance the
-snapshot builder DROPS carries a `NOT INSTALLED` line naming why:
+Three commands render a port-mirroring instance from configuration —
+the CLI `show forwarding-options port-mirroring`, its gRPC twin, and the
+CLI `show forwarding-options`. All three annotate an instance the
+snapshot builder DROPS with a `NOT INSTALLED` line naming why:
 
 ```
 Instance: span1
@@ -1428,10 +1429,23 @@ Instance: span1
   NOT INSTALLED: negative input rate
 ```
 
-The negative-rate case is the one to know about. Both renderers print
-`Input rate: all packets` whenever the rate is not greater than zero, so
-before this annotation a dropped instance advertised the most permissive
-mirror possible while mirroring nothing at all.
+The negative-rate case is the one to know about. Every renderer prints
+`Input rate: all packets` (or `Sampling rate:` omitted, in the `show
+forwarding-options` layout) whenever the rate is not greater than zero,
+so before this annotation a dropped instance advertised the most
+permissive mirror possible while mirroring nothing at all.
+
+`no output interface configured` is reachable through an ordinary
+`commit`, not only through the lenient load path: `compilePortMirroring`
+rejects a negative or non-integer rate, but nothing rejects an instance
+with no `output interface`.
+
+The gRPC `show forwarding-options` does not repeat the per-instance
+detail — it emits a pointer to `show forwarding-options port-mirroring`
+— so only the local CLI renders the full instance under that command.
+That asymmetry is why the local copy was the last one still rendering a
+dropped instance as armed; `pkg/showaudit` now enumerates every renderer
+of the collection so a fourth copy cannot be added unannotated.
 
 Coverage is deliberately partial. The annotation covers the drops
 decidable from configuration — no output interface, and a negative input
@@ -1465,6 +1479,20 @@ The annotation appears on `show security nat source rule detail`,
 `destination rule detail`, `static [rule [detail]]`, and `nptv6`. It is
 emitted ONLY for a rule the dataplane is not enforcing, so output for a
 healthy configuration is unchanged.
+
+**It does NOT yet appear on the source/destination SUMMARY topics.**
+`show security nat source`, `... source summary`, `... source pool`,
+`... source rule-set`, `... source rule` (without `detail`) and their
+destination equivalents — plus the REST `/nat/*` views and the gRPC
+`GetNATSource` / `GetNATDestination` / `GetNATPoolStats` /
+`GetNATRuleStats` responses — still render a disarmed rule as though it
+were enforced, several of them alongside a translation-hit counter. The
+static-NAT and NPTv6 topics are complete because every surface delegates
+to `pkg/natshow`; the source and destination summaries have their own
+formatters, which is how they diverged from their own `detail` views.
+20 render functions are affected; they are enumerated exactly in
+`pkg/showaudit` and tracked in #7473. Until that closes, read `rule
+detail` before believing a summary.
 
 Reachability: the strict commit gates reject these configurations, so a
 rule cannot reach this state through `commit`. It reaches it through the

--- a/pkg/cli/cli_show_routing.go
+++ b/pkg/cli/cli_show_routing.go
@@ -1151,6 +1151,18 @@ func (c *CLI) showForwardingOptions() error {
 			if inst.Output != "" {
 				fmt.Printf("    Output interface:  %s\n", inst.Output)
 			}
+			// #6534: this is the THIRD renderer of a port-mirroring instance
+			// and the only one that was still printing a dropped instance as
+			// if it were armed. `show forwarding-options port-mirroring`
+			// (showPortMirroring) and the gRPC ShowText twin both annotate;
+			// this one prints strictly MORE per-instance detail than the gRPC
+			// `show forwarding-options`, which only emits a pointer line, so
+			// it was the surface most likely to be believed. Same verdict
+			// function as the snapshot builder, so the three copies cannot
+			// disagree about which instances the dataplane installs.
+			if reason := config.PortMirroringInstanceExcludedReason(inst); reason != "" {
+				fmt.Printf("    NOT INSTALLED: %s\n", reason)
+			}
 		}
 		hasContent = true
 	}

--- a/pkg/cli/mirror_exclusion_surfaces_6534_test.go
+++ b/pkg/cli/mirror_exclusion_surfaces_6534_test.go
@@ -1,0 +1,186 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// #6534, port-mirroring — the LOCAL CLI half, both of its render paths.
+//
+// pkg/grpcapi/mirror_exclusion_surfaces_6534_test.go binds the gRPC copy and
+// states that the CLI copy is bound "by asserting the TEXT both are required to
+// produce". That is a claim about a surface the test cannot reach, and it was
+// wrong in a way the claim could not expose: there are THREE renderers of a
+// port-mirroring instance, not two, and the third — `show forwarding-options`
+// in cli_show_routing.go — printed the full per-instance detail with no
+// annotation at all.
+//
+// It is also the copy most likely to be believed. The gRPC `show
+// forwarding-options` emits only a pointer line ("see 'show forwarding-options
+// port-mirroring' for details"), so the remote CLI cannot show a dropped
+// instance's rate and interfaces; the local CLI's version of the same command
+// shows all of them.
+//
+// Reachability is worse than the lenient-load backstop the NAT family needs.
+// Nothing in the strict commit gates rejects an instance with no `output
+// interface` — compilePortMirroring rejects only a negative or non-integer
+// rate, and there is no strict validator for a missing output — so
+// `no output interface configured` is reachable through an ORDINARY commit,
+// which is what the fixture below performs.
+
+// mirrorSurfaceCLIStore commits one healthy and one dropped instance through
+// the ordinary commit path.
+//
+// Two instances, not one, on purpose: with a single dropped instance a
+// renderer that unconditionally printed the annotation would pass every cell.
+// The healthy instance is the negative control that makes "annotates" mean
+// "annotates the right one".
+func mirrorSurfaceCLIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+forwarding-options {
+    port-mirroring {
+        instance armed {
+            input {
+                rate 100;
+                ingress {
+                    interface ge-0/0/1.0;
+                }
+            }
+            output {
+                interface ge-0/0/9.0;
+            }
+        }
+        instance dropped {
+            input {
+                rate 100;
+                ingress {
+                    interface ge-0/0/2.0;
+                }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v — the fixture's premise is that a "+
+			"port-mirroring instance with no output interface commits cleanly; "+
+			"if a strict gate now rejects it, this test is exercising a state "+
+			"the operator can no longer reach and must be rewritten against the "+
+			"lenient Load/SyncApply path instead", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	pm := cfg.ForwardingOptions.PortMirroring
+	if pm == nil || len(pm.Instances) != 2 {
+		t.Fatalf("compiled port-mirroring instances = %v, want exactly 2", pm)
+	}
+	// Ground truth. Without this pin a predicate that stopped recognising the
+	// shape would make every assertion below agree on "installed" and the
+	// whole file would pass over an empty set.
+	if got := config.PortMirroringInstanceExcludedReason(pm.Instances["dropped"]); got != "no output interface configured" {
+		t.Fatalf("fixture no longer constructs a dropped instance: reason = %q", got)
+	}
+	if got := config.PortMirroringInstanceExcludedReason(pm.Instances["armed"]); got != "" {
+		t.Fatalf("fixture's healthy instance is not healthy: reason = %q", got)
+	}
+	return store
+}
+
+// instanceBlock returns the render lines belonging to one instance, so an
+// assertion cannot be satisfied by an annotation printed against the OTHER
+// instance. Matching "NOT INSTALLED" anywhere in the whole output would pass
+// for a renderer that annotated the healthy instance and not the dropped one.
+func instanceBlock(t *testing.T, out, name string) string {
+	t.Helper()
+	lines := strings.Split(out, "\n")
+	start := -1
+	for i, l := range lines {
+		if strings.Contains(l, "Instance: "+name) {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatalf("instance %q absent from render:\n--- output ---\n%s", name, out)
+	}
+	end := len(lines)
+	for i := start + 1; i < len(lines); i++ {
+		if strings.Contains(lines[i], "Instance: ") {
+			end = i
+			break
+		}
+	}
+	return strings.Join(lines[start:end], "\n")
+}
+
+// TestCLIPortMirroringSurfacesAnnotateTheDroppedInstance6534 drives BOTH local
+// CLI render paths over one config and requires the same verdict from each.
+//
+// `show forwarding-options` is the path this test was written for. Deleting the
+// annotation from either renderer reds exactly one subtest, so a failure names
+// the surface that resumed lying rather than "port-mirroring broke".
+func TestCLIPortMirroringSurfacesAnnotateTheDroppedInstance6534(t *testing.T) {
+	store := mirrorSurfaceCLIStore(t)
+	c := &CLI{store: store}
+
+	surfaces := []struct {
+		name   string
+		render func() error
+	}{
+		{"show_forwarding-options_port-mirroring", c.showPortMirroring},
+		{"show_forwarding-options", c.showForwardingOptions},
+	}
+
+	for _, s := range surfaces {
+		t.Run(s.name, func(t *testing.T) {
+			out := captureStdout(t, func() {
+				if err := s.render(); err != nil {
+					t.Fatalf("%s: %v", s.name, err)
+				}
+			})
+
+			dropped := instanceBlock(t, out, "dropped")
+			if !strings.Contains(dropped, "NOT INSTALLED") {
+				t.Fatalf("%s renders an instance the snapshot builder DROPS as if "+
+					"it were armed — the operator sees a mirror that captures "+
+					"nothing.\n--- dropped instance block ---\n%s", s.name, dropped)
+			}
+			if !strings.Contains(dropped, "no output interface configured") {
+				t.Fatalf("%s annotated the dropped instance without naming the "+
+					"reason, so the operator cannot tell WHICH condition "+
+					"disarmed it.\n--- dropped instance block ---\n%s", s.name, dropped)
+			}
+
+			armed := instanceBlock(t, out, "armed")
+			if strings.Contains(armed, "NOT INSTALLED") {
+				t.Fatalf("%s annotated a healthy instance — crying wolf on a "+
+					"mirror that works.\n--- armed instance block ---\n%s", s.name, armed)
+			}
+
+			// The premise of the whole class: these renderers print the
+			// instance's operational detail. If a future change reduced this
+			// surface to a pointer line (as the gRPC `show forwarding-options`
+			// already is), it could no longer lie and this cell would be
+			// asserting an annotation on output nobody reads for enforcement.
+			if !strings.Contains(dropped, "ge-0/0/2.0") {
+				t.Fatalf("%s no longer renders the dropped instance's ingress "+
+					"interface, so this cell no longer exercises the #6534 shape "+
+					"it was written for.\n--- dropped instance block ---\n%s",
+					s.name, dropped)
+			}
+		})
+	}
+}

--- a/pkg/config/mirror_exclusion_reason.go
+++ b/pkg/config/mirror_exclusion_reason.go
@@ -20,13 +20,23 @@ package config
 // surface — the one place in this audit where the "give the renderer applied
 // state" instinct has real force, rather than the predicate being enough.
 //
-// Callers: buildMirrorSnapshots (pkg/dataplane/userspace/mirrors.go), and BOTH
-// duplicated show surfaces — cli.showPortMirroring and
-// Server.showForwardingOptionsPortMirroring. Those two are byte-identical
-// copies with no shared formatter; until they are single-sourced the way
-// pkg/natshow and pkg/dataplane/userspace/format already are, the agreement
-// test must assert BOTH of them, because fixing one copy leaves the other
-// lying.
+// Callers: buildMirrorSnapshots (pkg/dataplane/userspace/mirrors.go), and all
+// THREE show surfaces — cli.showPortMirroring,
+// Server.showForwardingOptionsPortMirroring, and cli.showForwardingOptions.
+//
+// This comment said TWO until #6534's closure, and the miscount was the bug:
+// the first two are byte-identical copies of each other and were annotated
+// together, while `show forwarding-options` in cli_show_routing.go — a third
+// copy with its own layout, printing MORE per-instance detail than the gRPC
+// command of the same name — was not, and kept rendering a dropped instance as
+// armed with the suite green. An enumeration in a comment is a claim about a
+// population nobody measured; pkg/showaudit measures it now
+// (TestSurfaceAnnotationCensusIsExact6534), so a fourth renderer cannot appear
+// unannotated and cannot make this sentence wrong again without a red test.
+//
+// Until these copies are single-sourced the way pkg/natshow and
+// pkg/dataplane/userspace/format already are, every one of them must consult
+// this predicate: annotating some leaves the rest lying.
 func PortMirroringInstanceExcludedReason(inst *PortMirrorInstance) string {
 	if inst == nil {
 		return ""

--- a/pkg/grpcapi/mirror_exclusion_surfaces_6534_test.go
+++ b/pkg/grpcapi/mirror_exclusion_surfaces_6534_test.go
@@ -17,10 +17,17 @@ import (
 // rendering a dropped mirror as armed.
 //
 // This file can only reach the gRPC copy (importing pkg/cli from here is not
-// how the tree is layered), so the CLI copy is bound by asserting the TEXT both
-// are required to produce, and the builder half lives in
-// pkg/dataplane/userspace/mirror_exclusion_6534_test.go. The three together are
-// what make the property hold; any one alone does not.
+// how the tree is layered), and the builder half lives in
+// pkg/dataplane/userspace/mirror_exclusion_6534_test.go.
+//
+// An earlier revision of this comment said the CLI copy was "bound by asserting
+// the TEXT both are required to produce". That was not a bind — this file never
+// executes a CLI renderer — and it was also counting wrong: there are THREE
+// port-mirroring renderers, and the third (cli.showForwardingOptions) was
+// unannotated at the time the sentence was written. The CLI surfaces are now
+// driven directly in pkg/cli/mirror_exclusion_surfaces_6534_test.go, and the
+// population itself is measured rather than asserted in prose, by
+// pkg/showaudit.
 
 func mirrorSurfaceConfig(output string, rate int) *config.Config {
 	cfg := &config.Config{}

--- a/pkg/showaudit/doc.go
+++ b/pkg/showaudit/doc.go
@@ -1,0 +1,69 @@
+// Package showaudit hosts the cross-cutting gate for #6534: a config
+// object the userspace snapshot builder REFUSES to install must not be
+// rendered by an operator surface as though it were enforced.
+//
+// It contains no runtime code. Like pkg/refactoraudit it exists only to
+// give `go test ./...` a home for a source-level property that no single
+// package can assert, because the two halves of this property live in
+// different packages by construction: the builder decides, and five
+// unrelated surfaces render.
+//
+// # Why a gate rather than more per-site fixes
+//
+// #6534's own history is the argument. Each fail-closed hardening fix
+// added a builder exclusion and, reviewed on its own, looked complete;
+// the surface that rendered the same object from configuration was in
+// another package and nobody looked. #7330 (NAT), #7348 (CoS) and #7354
+// (port-mirroring) closed three families of this by hand. Each landed
+// with an agreement test for its own family, and each of those tests is
+// blind to the next family — so the next fail-closed fix would have
+// minted instance number four with the suite green.
+//
+// The gate is the part that generalises. It does not know what a NAT
+// rule is. It knows two things:
+//
+//   - which pkg/config drop predicates the snapshot builder consults,
+//     and refuses to let a NEW one appear without a registry row
+//     (TestEveryBuilderDropPredicateIsRegistered6534); and
+//   - for each registered family, which functions in the surface
+//     packages iterate that family's config collection and emit output,
+//     and whether each of them reaches the family's drop predicate
+//     (TestSurfaceAnnotationCensusIsExact6534).
+//
+// # What is proved, and what is not
+//
+// Two different closure properties are at work here and they do not
+// compose the same way, so the registry states which one each family
+// gets:
+//
+//   - EXISTENCE closure — "some surface consults the predicate". Cheap,
+//     transitive, and nearly worthless on its own: it is exactly the
+//     property that held while cli.showForwardingOptions was lying,
+//     because two OTHER port-mirroring renderers annotated correctly.
+//   - GUARDEDNESS closure — "EVERY surface that renders this object
+//     consults the predicate". Not transitive, has to be re-established
+//     whenever a renderer is added, and is the property the operator
+//     actually depends on.
+//
+// TestSurfaceAnnotationCensusIsExact6534 asserts guardedness for every
+// family, and expresses the families that are not yet closed as an
+// explicit census of the render functions that still do not annotate.
+// That census is asserted EXACTLY, in both directions: a new unannotated
+// renderer reds, and so does an entry that has since been fixed. The
+// list can therefore never decay into a permanent allowlist — the only
+// way to keep the suite green is to keep it true.
+//
+// # Scope, stated honestly
+//
+// The gate covers exclusions the builder decides by calling a shared
+// pkg/config predicate. It does NOT see a fail-closed drop written
+// inline in the builder with no predicate at all; such a drop has no
+// symbol for the scan to key on and no verdict a renderer could consult
+// even if it wanted to. Routing every builder exclusion through a shared
+// predicate is what makes it visible here, and that convention is what
+// this package enforces rather than assumes.
+//
+// See surface_gate_6534_test.go, pkg/config/mirror_exclusion_reason.go,
+// pkg/config/nat_exclusion_reason.go, pkg/config/cos_exclusion_reason.go
+// and pkg/config/nptv6_scope.go.
+package showaudit

--- a/pkg/showaudit/surface_gate_6534_test.go
+++ b/pkg/showaudit/surface_gate_6534_test.go
@@ -1,0 +1,650 @@
+package showaudit
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+// family is one class of fail-closed snapshot exclusion: a config object the
+// builder may refuse to install, the pkg/config predicates that carry that
+// verdict, and the census of surfaces that render the object.
+type family struct {
+	// Name is the failure message's subject.
+	Name string
+
+	// Collections are substrings of a `for ... range <expr>` expression that
+	// identify iteration over this family's config collection, matched after
+	// one round of local alias expansion (so `pm := cfg.ForwardingOptions.
+	// PortMirroring; for ... range pm.Instances` matches
+	// "PortMirroring.Instances").
+	Collections []string
+
+	// BuilderPredicates are the pkg/config drop predicates the SNAPSHOT
+	// BUILDER consults. TestEveryBuilderDropPredicateIsRegistered6534 asserts
+	// the union of these is exactly what pkg/dataplane/userspace calls.
+	BuilderPredicates []string
+
+	// SurfacePredicates are the predicates a RENDERER may consult to learn the
+	// same verdict. It is a superset of BuilderPredicates wherever the two
+	// halves reach the verdict through differently-shaped helpers: source NAT
+	// publishes the rule carrying a PoolUnusable marker rather than dropping
+	// it, so the builder asks SourceNATPoolUnusableReason while the renderer
+	// asks SourceNATPoolDisarmedReason / SourceNATDisarmReasonText.
+	SurfacePredicates []string
+
+	// Unannotated is the EXACT census of render functions that iterate this
+	// family's collection, emit output, and do NOT reach a surface predicate.
+	// Empty means the family is closed. Asserted exactly in both directions:
+	// a new lying renderer reds, and so does a repaired one still listed.
+	Unannotated []string
+
+	// Successor names the issue tracking a non-empty Unannotated census.
+	Successor string
+}
+
+// surfacePkgs are the operator-facing render packages: the local CLI, the gRPC
+// ShowText server, the REST API, and the two shared formatter packages the
+// first three delegate to.
+var surfacePkgs = []string{
+	"pkg/cli",
+	"pkg/grpcapi",
+	"pkg/api",
+	"pkg/natshow",
+	"pkg/dataplane/userspace/format",
+}
+
+// builderPkg is the snapshot builder whose exclusions this gate is about.
+const builderPkg = "pkg/dataplane/userspace"
+
+// exemptRenderers are functions the collection scan reaches that do not render
+// an object's enforcement state to an operator, keyed "<pkg>/<file>:<func>".
+//
+// Both entries are tab-completion value providers: they iterate the NAT
+// rule-sets to offer rule NAMES for the next token. A completion list is not a
+// claim that a rule is armed, and annotating one would put "NOT INSTALLED" in
+// the middle of a completion menu.
+var exemptRenderers = map[string]string{
+	"pkg/cli/completion.go:valueProvider":         "tab-completion name list, not an enforcement render",
+	"pkg/grpcapi/server_cluster.go:valueProvider": "tab-completion name list, not an enforcement render",
+}
+
+var families = []family{
+	{
+		Name:              "port-mirroring instance",
+		Collections:       []string{"PortMirroring.Instances"},
+		BuilderPredicates: []string{"PortMirroringInstanceExcludedReason"},
+		SurfacePredicates: []string{"PortMirroringInstanceExcludedReason"},
+		Unannotated:       nil, // closed by this change
+	},
+	{
+		Name: "class-of-service classifier / rewrite-rule entry",
+		Collections: []string{
+			"ClassOfService.DSCPClassifiers",
+			"ClassOfService.IEEE8021Classifiers",
+			"ClassOfService.INetPrecedenceClassifierDefs",
+			"ClassOfService.DSCPRewriteRules",
+			"ClassOfService.IEEE8021RewriteRules",
+		},
+		BuilderPredicates: []string{"CoSForwardingClassUndefined"},
+		SurfacePredicates: []string{"CoSForwardingClassUndefined"},
+		Unannotated:       nil, // closed by #7348
+	},
+	{
+		Name:              "static NAT / NPTv6 rule",
+		Collections:       []string{"NAT.Static"},
+		BuilderPredicates: []string{"StaticNATRuleExcludedReason", "NPTv6ScopeUnsupported"},
+		SurfacePredicates: []string{"StaticNATRuleExcludedReason", "NPTv6ScopeUnsupported"},
+		Unannotated:       nil, // closed by #7330 — every surface delegates to pkg/natshow
+	},
+	{
+		Name:              "source NAT rule",
+		Collections:       []string{"NAT.Source"},
+		BuilderPredicates: []string{"SourceNATPoolUnusableReason"},
+		SurfacePredicates: []string{"SourceNATPoolUnusableReason", "SourceNATPoolDisarmedReason", "SourceNATDisarmReasonText"},
+		Unannotated: []string{
+			"pkg/api/metrics_nat.go:collectNATPoolMetrics",
+			"pkg/api/nat.go:natPoolStatsHandler",
+			"pkg/api/nat.go:natRuleStatsHandler",
+			"pkg/api/nat.go:natSourceHandler",
+			"pkg/cli/cli_show_nat.go:showNATSource",
+			"pkg/cli/cli_show_nat.go:showNATSourcePool",
+			"pkg/cli/cli_show_nat.go:showNATSourceRuleAll",
+			"pkg/cli/cli_show_nat.go:showNATSourceRuleSet",
+			"pkg/cli/cli_show_nat.go:showNATSourceSummary",
+			"pkg/grpcapi/server_nat.go:GetNATPoolStats",
+			"pkg/grpcapi/server_nat.go:GetNATRuleStats",
+			"pkg/grpcapi/server_nat.go:GetNATSource",
+		},
+		Successor: "#7473",
+	},
+	{
+		Name:              "destination NAT rule",
+		Collections:       []string{"NAT.Destination"},
+		BuilderPredicates: []string{"DestinationNATRuleExcludedReason"},
+		SurfacePredicates: []string{"DestinationNATRuleExcludedReason"},
+		Unannotated: []string{
+			"pkg/api/nat.go:natDestHandler",
+			"pkg/cli/cli_show_nat.go:showNATDestination",
+			"pkg/cli/cli_show_nat.go:showNATDestinationPool",
+			"pkg/cli/cli_show_nat.go:showNATDestinationRuleAll",
+			"pkg/cli/cli_show_nat.go:showNATDestinationRuleSet",
+			"pkg/cli/cli_show_nat.go:showNATDestinationSummary",
+			"pkg/grpcapi/server_nat.go:GetNATDestination",
+			"pkg/grpcapi/server_nat.go:GetNATRuleStats",
+		},
+		Successor: "#7473",
+	},
+}
+
+// dropPredicateName matches the naming family the repo uses for a shared
+// fail-closed verdict. The convention is what makes the population
+// enumerable, so the gate enforces it rather than trusting it: a builder
+// exclusion spelled outside this family has no row and no test.
+var dropPredicateName = regexp.MustCompile(`(?:Excluded|Unusable|Disarmed)Reason$|Unsupported$|Undefined$`)
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestEveryBuilderDropPredicateIsRegistered6534 is the anti-recurrence gate.
+//
+// It asserts EXACT equality between the drop predicates pkg/dataplane/userspace
+// actually calls and the union of the registry's BuilderPredicates. A new
+// fail-closed exclusion wired into the builder therefore cannot land without a
+// registry row, and the row forces its author to declare which surfaces render
+// the object — which is the step every previous instance of this bug skipped.
+//
+// Equality, not containment, on purpose: containment would let a row rot in
+// place after its predicate was deleted, and a registry describing a predicate
+// that no longer exists is worse than no registry, because the family it claims
+// to cover would read as covered.
+func TestEveryBuilderDropPredicateIsRegistered6534(t *testing.T) {
+	pkgs := parsePackage(t, builderPkg)
+	called := map[string]bool{}
+	for _, fn := range pkgs.order {
+		for _, sym := range configCallsIn(pkgs.fset, pkgs.funcs[fn].fd) {
+			if dropPredicateName.MatchString(sym) {
+				called[sym] = true
+			}
+		}
+	}
+	// Non-vacuity. A scan that parsed nothing, or a regexp that stopped
+	// matching, would otherwise report an empty set that trivially equals an
+	// empty registry and read as "no drift".
+	if len(pkgs.order) < 100 {
+		t.Fatalf("scan of %s found only %d functions; the gate is not reading the "+
+			"builder it claims to audit", builderPkg, len(pkgs.order))
+	}
+	if len(called) == 0 {
+		t.Fatalf("scan of %s found ZERO drop predicates. Either every fail-closed "+
+			"exclusion stopped using a shared pkg/config verdict, or "+
+			"dropPredicateName no longer matches the naming convention. Both are "+
+			"a broken gate, not a clean tree.", builderPkg)
+	}
+
+	registered := map[string]bool{}
+	for _, f := range families {
+		for _, p := range f.BuilderPredicates {
+			registered[p] = true
+		}
+	}
+
+	for _, sym := range sortedKeys(called) {
+		if !registered[sym] {
+			t.Errorf("pkg/dataplane/userspace calls config.%s to decide a "+
+				"fail-closed exclusion, but no #6534 registry row covers it.\n"+
+				"Add a family to `families` naming the config collection it "+
+				"drops and the surfaces that render it — otherwise the object "+
+				"keeps rendering from config as though the dataplane installed "+
+				"it, which is the entire defect #6534 exists for.", sym)
+		}
+	}
+	for _, sym := range sortedKeys(registered) {
+		if !called[sym] {
+			t.Errorf("#6534 registry declares config.%s as a builder drop "+
+				"predicate, but no non-test file in %s calls it. Either the "+
+				"builder stopped consulting the shared verdict (the two halves "+
+				"can now disagree) or the row is stale and must be removed.",
+				sym, builderPkg)
+		}
+	}
+}
+
+// TestEveryFamilyHasABuilderAndASurfaceCaller6534 is EXISTENCE closure: the
+// weak half, asserted because its absence is unambiguous. A family whose
+// predicate no surface consults at all is a builder that knows the object is
+// disarmed and an operator who is never told.
+//
+// This is deliberately NOT the property the class needs — see
+// TestSurfaceAnnotationCensusIsExact6534 for guardedness — and it is stated
+// separately so a reader cannot mistake one for the other.
+func TestEveryFamilyHasABuilderAndASurfaceCaller6534(t *testing.T) {
+	builder := parsePackage(t, builderPkg)
+	for _, f := range families {
+		for _, p := range f.BuilderPredicates {
+			if !packageCallsPredicate(builder, p) {
+				t.Errorf("%s: no non-test file in %s calls config.%s",
+					f.Name, builderPkg, p)
+			}
+		}
+		found := ""
+		for _, dir := range surfacePkgs {
+			pkg := parsePackage(t, dir)
+			for _, p := range f.SurfacePredicates {
+				if packageCallsPredicate(pkg, p) {
+					found = dir + " -> config." + p
+				}
+			}
+		}
+		if found == "" {
+			t.Errorf("%s: the builder consults a drop verdict for this object "+
+				"and NO surface package does. Every render of a dropped %s is a "+
+				"lie the operator has no way to detect.", f.Name, f.Name)
+		} else {
+			t.Logf("%s: surface caller %s", f.Name, found)
+		}
+	}
+}
+
+// TestSurfaceAnnotationCensusIsExact6534 is GUARDEDNESS closure, and it is the
+// test that would have caught cli.showForwardingOptions.
+//
+// For every family it enumerates the render functions across all surface
+// packages — a function that iterates the family's config collection AND emits
+// output — and partitions them by whether they reach one of the family's
+// surface predicates, directly or through a same-package helper. The
+// unannotated partition must equal the registry's declared census EXACTLY.
+//
+// Both directions matter and they fail for opposite reasons:
+//
+//   - an unlisted unannotated renderer is a NEW instance of #6534;
+//   - a listed renderer that now annotates means the census is describing a
+//     defect that no longer exists, which is how a deferral list quietly
+//     becomes a permanent allowlist.
+func TestSurfaceAnnotationCensusIsExact6534(t *testing.T) {
+	for _, f := range families {
+		t.Run(strings.ReplaceAll(f.Name, " ", "_"), func(t *testing.T) {
+			var population, unannotated []string
+			for _, dir := range surfacePkgs {
+				pkg := parsePackage(t, dir)
+				for _, key := range pkg.order {
+					rec := pkg.funcs[key]
+					// Population = every non-test function in a surface package
+					// that ITERATES this family's config collection. There is
+					// deliberately no "and prints text" filter: the REST and
+					// gRPC handlers serve the same objects as JSON and protobuf,
+					// and a rule serialised without a not-installed field is the
+					// same lie as one printed without an annotation. Anything
+					// that touches the collection for a non-enforcement reason
+					// belongs in exemptRenderers, with the reason written down.
+					if !rangesOverAny(pkg.fset, rec.fd, f.Collections) {
+						continue
+					}
+					id := dir + "/" + filepath.Base(rec.file) + ":" + rec.fd.Name.Name
+					if _, ok := exemptRenderers[id]; ok {
+						continue
+					}
+					population = append(population, id)
+					if !reachesPredicate(pkg, key, f.SurfacePredicates, 3, map[string]bool{}) {
+						unannotated = append(unannotated, id)
+					}
+				}
+			}
+			sort.Strings(population)
+			sort.Strings(unannotated)
+
+			// Non-vacuity, two ways. An empty population means the collection
+			// selectors stopped matching and every assertion below is over
+			// nothing; a population with no ANNOTATED member means the
+			// reachesPredicate detector could be broken-shut and the test could
+			// not tell.
+			if len(population) < 2 {
+				t.Fatalf("found %d render functions for %s (%v). The collection "+
+					"selectors %v no longer match this family's renderers, so "+
+					"this cell asserts nothing.", len(population), f.Name, population, f.Collections)
+			}
+			if len(unannotated) == len(population) {
+				t.Fatalf("every one of the %d render functions for %s reads as "+
+					"unannotated. Either the whole family regressed at once, or "+
+					"reachesPredicate is broken and would report a lie as clean.\n"+
+					"population: %v", len(population), f.Name, population)
+			}
+
+			want := append([]string(nil), f.Unannotated...)
+			sort.Strings(want)
+			for _, got := range unannotated {
+				if !contains(want, got) {
+					t.Errorf("%s: %s renders an object the snapshot builder can "+
+						"REFUSE TO INSTALL and never consults %v, so a dropped "+
+						"object prints as enforced.\nEither annotate it (the "+
+						"predicate is already exported and shared with the "+
+						"builder) or, if this is genuinely not an enforcement "+
+						"surface, add it to exemptRenderers with a reason.",
+						f.Name, got, f.SurfacePredicates)
+				}
+			}
+			for _, w := range want {
+				if !contains(unannotated, w) {
+					if !contains(population, w) {
+						t.Errorf("%s: census names %s but no such render function "+
+							"was found. It was renamed, moved or deleted; update "+
+							"the census so it keeps describing the tree.", f.Name, w)
+						continue
+					}
+					t.Errorf("%s: census names %s as unannotated, but it now "+
+						"consults the drop verdict. Remove it from the census — "+
+						"a list of known-lying surfaces that outlives the lie is "+
+						"an allowlist, and the next unannotated renderer would "+
+						"hide inside it.", f.Name, w)
+				}
+			}
+			if len(unannotated) > 0 && f.Successor == "" {
+				t.Errorf("%s: %d render functions still do not annotate and the "+
+					"registry names no successor issue tracking them: %v",
+					f.Name, len(unannotated), unannotated)
+			}
+			t.Logf("%s: %d render functions, %d annotated, %d not (%s)",
+				f.Name, len(population), len(population)-len(unannotated),
+				len(unannotated), f.Successor)
+		})
+	}
+}
+
+// TestExemptionsNameRealRenderers6534 keeps the exemption table from outliving
+// what it exempts. An exemption for a function that no longer exists is dead
+// text that reads, to the next author, as coverage.
+func TestExemptionsNameRealRenderers6534(t *testing.T) {
+	seen := map[string]bool{}
+	for _, dir := range surfacePkgs {
+		pkg := parsePackage(t, dir)
+		for _, key := range pkg.order {
+			rec := pkg.funcs[key]
+			seen[dir+"/"+filepath.Base(rec.file)+":"+rec.fd.Name.Name] = true
+		}
+	}
+	if len(seen) < 200 {
+		t.Fatalf("surface scan found only %d functions across %v; the gate is "+
+			"not reading the packages it claims to audit", len(seen), surfacePkgs)
+	}
+	for _, id := range sortedKeys(exemptRenderers) {
+		if !seen[id] {
+			t.Errorf("exemptRenderers names %s (%q) but no such function exists",
+				id, exemptRenderers[id])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Source scanning
+//
+// Every parse discards comments (parser.ParseFile with mode 0), so no
+// assertion in this file can be satisfied by prose — including the prose in
+// this file. The gate keys on call expressions and range expressions only.
+// ---------------------------------------------------------------------------
+
+type fnRec struct {
+	fd   *ast.FuncDecl
+	file string
+}
+
+type parsedPkg struct {
+	fset  *token.FileSet
+	funcs map[string]*fnRec
+	order []string
+}
+
+var pkgCache = map[string]*parsedPkg{}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, self, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed; cannot locate the repository root")
+	}
+	return filepath.Dir(filepath.Dir(filepath.Dir(self)))
+}
+
+func parsePackage(t *testing.T, dir string) *parsedPkg {
+	t.Helper()
+	if p, ok := pkgCache[dir]; ok {
+		return p
+	}
+	files, err := filepath.Glob(filepath.Join(repoRoot(t), dir, "*.go"))
+	if err != nil {
+		t.Fatalf("glob %s: %v", dir, err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no Go files under %s — the gate's package list is stale", dir)
+	}
+	sort.Strings(files)
+	p := &parsedPkg{fset: token.NewFileSet(), funcs: map[string]*fnRec{}}
+	for _, path := range files {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(p.fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		for _, d := range f.Decls {
+			fd, ok := d.(*ast.FuncDecl)
+			if !ok || fd.Body == nil {
+				continue
+			}
+			key := fd.Name.Name
+			if _, dup := p.funcs[key]; dup {
+				key = fmt.Sprintf("%s#%d", fd.Name.Name, len(p.order))
+			}
+			p.funcs[key] = &fnRec{fd: fd, file: path}
+			p.order = append(p.order, key)
+		}
+	}
+	pkgCache[dir] = p
+	return p
+}
+
+// configCallsIn returns the `config.X` selector names called in fd.
+func configCallsIn(fset *token.FileSet, fd *ast.FuncDecl) []string {
+	var out []string
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		ce, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		se, ok := ce.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if id, ok := se.X.(*ast.Ident); ok && id.Name == "config" {
+			out = append(out, se.Sel.Name)
+		}
+		return true
+	})
+	return out
+}
+
+func packageCallsPredicate(p *parsedPkg, pred string) bool {
+	for _, key := range p.order {
+		for _, sym := range configCallsIn(p.fset, p.funcs[key].fd) {
+			if sym == pred {
+				return true
+			}
+		}
+		// A package may declare the predicate itself (pkg/config) or call it
+		// unqualified from within that package.
+		if callsUnqualified(p.funcs[key].fd, pred) {
+			return true
+		}
+	}
+	return false
+}
+
+func callsUnqualified(fd *ast.FuncDecl, name string) bool {
+	found := false
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		ce, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if id, ok := ce.Fun.(*ast.Ident); ok && id.Name == name {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// reachesPredicate reports whether fn, or a same-package function it calls
+// within `depth` hops, consults one of preds. The hop budget exists because
+// both shared formatters delegate the verdict to a private helper
+// (natshow.staticRuleNotInstalledReason, format.noteUninstalledCoSEntries); a
+// direct-call-only check would report those correct renderers as lying.
+func reachesPredicate(p *parsedPkg, key string, preds []string, depth int, seen map[string]bool) bool {
+	if depth < 0 || seen[key] {
+		return false
+	}
+	seen[key] = true
+	rec := p.funcs[key]
+	if rec == nil {
+		return false
+	}
+	for _, sym := range configCallsIn(p.fset, rec.fd) {
+		for _, pred := range preds {
+			if sym == pred {
+				return true
+			}
+		}
+	}
+	for _, pred := range preds {
+		if callsUnqualified(rec.fd, pred) {
+			return true
+		}
+	}
+	for _, callee := range calleeNames(rec.fd) {
+		if reachesPredicate(p, callee, preds, depth-1, seen) {
+			return true
+		}
+	}
+	return false
+}
+
+func calleeNames(fd *ast.FuncDecl) []string {
+	var out []string
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		ce, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch f := ce.Fun.(type) {
+		case *ast.Ident:
+			out = append(out, f.Name)
+		case *ast.SelectorExpr:
+			out = append(out, f.Sel.Name)
+		}
+		return true
+	})
+	return out
+}
+
+// rangesOverAny reports whether fd iterates a collection named by any of subs,
+// after expanding local aliases: `pm := cfg.ForwardingOptions.PortMirroring`
+// followed by `for ... range pm.Instances` must match "PortMirroring.Instances".
+func rangesOverAny(fset *token.FileSet, fd *ast.FuncDecl, subs []string) bool {
+	alias := map[string]string{}
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		as, ok := n.(*ast.AssignStmt)
+		if !ok || len(as.Lhs) != 1 || len(as.Rhs) != 1 {
+			return true
+		}
+		id, ok := as.Lhs[0].(*ast.Ident)
+		if !ok || id.Name == "_" {
+			return true
+		}
+		if _, dup := alias[id.Name]; dup {
+			return true // first binding wins; a rebound name is ambiguous
+		}
+		rhs := exprString(fset, as.Rhs[0])
+		// A self-referential binding (x := f(x), x = append(x, ...)) would
+		// make the substitution loop grow the string without converging.
+		if regexp.MustCompile(`\b` + regexp.QuoteMeta(id.Name) + `\b`).MatchString(rhs) {
+			return true
+		}
+		alias[id.Name] = rhs
+		return true
+	})
+	// Substitution is global, not prefix-only: the shared CoS formatter ranges
+	// over `sortedMapKeys(cos.DSCPClassifiers)`, so the alias sits INSIDE a
+	// call expression and a prefix-anchored expansion would miss it — and miss
+	// it silently, reporting the family as having no renderers at all.
+	expand := func(s string) string {
+		for i := 0; i < 4; i++ {
+			changed := false
+			for _, v := range sortedKeys(alias) {
+				re := regexp.MustCompile(`\b` + regexp.QuoteMeta(v) + `\.`)
+				if next := re.ReplaceAllString(s, alias[v]+"."); next != s {
+					s = next
+					changed = true
+				}
+			}
+			if !changed {
+				break
+			}
+		}
+		return strings.ReplaceAll(strings.ReplaceAll(s, "&", ""), "*", "")
+	}
+	found := false
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		rs, ok := n.(*ast.RangeStmt)
+		if !ok {
+			return true
+		}
+		s := expand(exprString(fset, rs.X))
+		for _, sub := range subs {
+			if strings.Contains(s, sub) {
+				found = true
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func exprString(fset *token.FileSet, e ast.Expr) string {
+	var b bytes.Buffer
+	if err := printer.Fprint(&b, fset, e); err != nil {
+		return ""
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Closes the last live instance of #6534's port-mirroring family and adds the
mechanism that makes the class mechanically enumerable, so #6534 can close
rather than being reopened by the next fail-closed fix.

`cli.showForwardingOptions` is a **third** renderer of a port-mirroring
instance, and it was still printing an instance the snapshot builder DROPS as
though the dataplane had installed it — sampling rate, ingress interfaces,
output interface, no annotation. It is also the copy most likely to be
believed: the gRPC `show forwarding-options` emits only a pointer line, so the
remote CLI never shows a dropped instance's operational detail under that
command; the local CLI shows all of it.

#7354 annotated the two renderers that *are* byte-identical copies of each
other, and left a comment recording that there were two.

## Reachability

Worse than the NAT family, which needs the lenient boot / peer-sync path.
Nothing in the strict commit gates rejects an instance with no `output
interface` — `compilePortMirroring` rejects only a negative or non-integer rate
— so `no output interface configured` is reachable through an **ordinary
commit**. The test fixture commits it.

## The mechanism — `pkg/showaudit`

#6534's history is a sequence of fail-closed hardenings that each minted a new
lying surface, because the builder and the renderer are in different packages
and each fix was reviewed alone. #7330, #7348 and #7354 closed three families by
hand and each landed an agreement test blind to the next family. A fourth would
have landed the same way.

`pkg/showaudit` is a test-only package (like `pkg/refactoraudit`) holding the
property no single package can assert:

| Test | Property | Fails when |
|---|---|---|
| `TestEveryBuilderDropPredicateIsRegistered6534` | EXACT equality between the drop predicates `pkg/dataplane/userspace` calls and the registry | a NEW fail-closed exclusion lands without declaring its surfaces; or a row outlives its predicate |
| `TestEveryFamilyHasABuilderAndASurfaceCaller6534` | **existence** closure — some surface consults each verdict | a family's verdict reaches no surface at all |
| `TestSurfaceAnnotationCensusIsExact6534` | **guardedness** closure — the unannotated partition equals the declared census EXACTLY | a new lying renderer appears, **or** a listed one is fixed and left listed |
| `TestExemptionsNameRealRenderers6534` | the exemption table names live functions | an exemption outlives what it exempted |

The two closure properties are named separately on purpose. Existence closure
is what held while `showForwardingOptions` was lying — two *other* renderers
were correct. Guardedness is the property the operator depends on, and it is
not transitive.

Every parse discards comments (`parser.ParseFile(..., 0)`), so no assertion can
be satisfied by prose — including the prose in the gate's own file. It keys on
call and range expressions only.

The census being asserted **in both directions** is what stops it decaying into
a permanent allowlist: fixing a listed renderer without removing its entry reds
the suite (mutation cell 3).

## Population — measured, not inherited

The issue says "20 sites". That was a floor, and it was also the wrong
population — it counted builder exclusions, and what matters is *renderers*.
Measured here by a stated predicate:

> A **render function** is a non-test function in an operator-surface package
> (`pkg/cli`, `pkg/grpcapi`, `pkg/api`, `pkg/natshow`,
> `pkg/dataplane/userspace/format`) that iterates a family's config collection.
> It is **annotated** if it reaches that family's `pkg/config` drop predicate
> directly or through a same-package helper.

| Family | render fns | annotated | not |
|---|---|---|---|
| port-mirroring instance | 3 | **3** | 0 |
| CoS classifier / rewrite-rule entry | 2 | 2 | 0 |
| static NAT / NPTv6 rule | 3 | 3 | 0 |
| source NAT rule | 13 | 1 | **12** |
| destination NAT rule | 9 | 1 | **8** |

**6 builder-side drop predicates over 5 families; 32 render functions (2 exempt
tab-completion providers excluded); 10 annotated; 20 not.** Port-mirroring goes
2 → 3 in this PR.

The 20 are the NAT source/destination **summary** renderers — the `rule detail`
views delegate to `pkg/natshow` and are correct; the summaries have their own
formatters, which is how they diverged from their own detail views. Several
attach a translation-hit counter to a rule the dataplane never installed.
Enumerated exactly in the registry and tracked in **#7473**.

### What this does NOT prove

The gate sees an exclusion only if the builder routes it through a shared
`pkg/config` predicate. A fail-closed drop written inline with no predicate has
no symbol to key on — and no verdict a renderer could consult even if it wanted
to. Enforcing that convention is the point; the gate does not assume it.

Also out of scope and tracked separately: the runtime-state exclusions (the two
ifindex-dependent port-mirroring drops and the DNAT address-resolution drop)
need applied state threaded to the surface — **#7357**.

## Stale claims corrected

Two enumerations were wrong in a way no test could see, so both were fixed with
the code:

- `PortMirroringInstanceExcludedReason`'s "Callers: ... **BOTH** duplicated show
  surfaces" — there are three.
- the gRPC agreement test's claim that the CLI copy was "bound by asserting the
  TEXT both are required to produce". That file never executes a CLI renderer,
  so nothing was bound. The CLI surfaces are now driven directly in
  `pkg/cli/mirror_exclusion_surfaces_6534_test.go`.

## Mutation matrix

Base `da4583384b00b5851c2e5d5a79c7230b3d41ee08`. Every cell verified applied
(`git diff --stat` non-empty), built clean, and run FULL-package (no `-run`
filter). Cell 1 restores verbatim pre-fix bytes via `git show <base>:<path>`.

| # | Mutation | rc | Which assertion fired |
|---|---|---|---|
| 1 | revert the fix (verbatim pre-fix `cli_show_routing.go`) | 1 | `mirror_exclusion_surfaces_6534_test.go:157` *"show_forwarding-options renders an instance the snapshot builder DROPS as if it were armed"* **and** `surface_gate_6534_test.go:331` naming `cli_show_routing.go:showForwardingOptions`. Localised: the `port-mirroring` subtest stayed GREEN |
| 2 | delete the annotation from the OTHER CLI renderer (`showPortMirroring`) | 1 | same two assertions, mirror-image: subtest `show_forwarding-options_port-mirroring` RED, `show_forwarding-options` GREEN; gate names `show_services_mirror.go:showPortMirroring` |
| 3 | **FIX** a deferred renderer without updating the census | 1 | `:348` *"census names …:showNATSourceRuleAll as unannotated, but it now consults the drop verdict. Remove it from the census"* — the anti-allowlist direction |
| 4 | builder gains an UNREGISTERED drop predicate | 1 | `:208` *"pkg/dataplane/userspace calls config.SourceNATPoolDisarmedReason … but no #6534 registry row covers it"* — the anti-recurrence gate |
| 5 | builder STOPS consulting a registered predicate (**tightening**) | 1 | `:218` *"registry declares … but no non-test file … calls it"*, `:240`, **and** the pre-existing `mirror_exclusion_6534_test.go:77` — the older guard is load-bearing |
| 6 | `reachesPredicate` broken SHUT | 1 | `:321` *"every one of the 3 render functions … reads as unannotated … or reachesPredicate is broken and would report a lie as clean"* (all 5 families) |
| 7 | `rangesOverAny` broken SHUT | 1 | `:316` *"found 0 render functions … the collection selectors no longer match"* (all 5 families) |

Cells 6 and 7 are the harness-soundness pair: both broken-shut failure modes of
the scanner produce a hard failure, not a clean pass, so the gate cannot report
a lie as green.

## Validation

- `go test ./... -count=1` — **67 packages ok, 0 FAIL** (rc read from a file, not
  a pipe).
- `go vet ./pkg/showaudit/ ./pkg/cli/` clean.
- No Rust, no shim `.o`, no wire format, no cluster/VRRP/session-sync/failover
  code touched, so the cargo leg and the HA smoke gate are unaffected. **Not
  deployed**: the change is one show surface plus a test-only package, with no
  dataplane reach — there is nothing a `make test-deploy` run would exercise
  that the CLI test does not.

## Docs

`docs/junos-cli-reference.md`: the port-mirroring section now names three
renderers and the ordinary-commit reachability; the NAT section now states
plainly that the **summary** topics still lie and points at #7473, instead of
opening with "Every `show security nat …` topic".

Closes #6534
