### PR TITLE
config: read every dhcp-local-server group list element

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103313,3 +103313,12 @@ prose edit above them added. No diff falls in the new test body.
     pkg/daemon/rollback_target_appliable_6707_test.go (new),
     pkg/daemon/daemon_apply_commit.go, pkg/daemon/README.md,
     docs/bare-metal-device-map.md
+
+## 2026-08-22 — #6696 dhcp-local-server group interface / pool dns-server
+- **Action**: Both arms now read every element of a bracketed list; modelled
+  the two leaves (and both families' shared `group` subtree) in `setSchema`
+  with per-element validators; `interface` keeps its per-interface modifiers
+  out of the value list via `valueList` + modelled modifier children.
+- **File(s)**: `pkg/config/schema_system.go`, `pkg/config/compiler_services.go`,
+  `pkg/config/compiler_dhcp_group_multivalue_6696_test.go` (new),
+  `docs/config-schema.md`

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1777,6 +1777,83 @@ single-site mutations were run, each localising to its own assertion with
 leading-dash gate (leaving the read widened) and one that swaps `api-key` to the
 empty-skipping reader.
 
+### #6696: the two dhcp-local-server list leaves, and why they take DIFFERENT readers
+
+`system services dhcp-local-server group <g> interface` and `... group <g> pool
+<p> dns-server` were read with `nodeVal`, so a bracketed list — which the lexer
+collapses onto ONE node's `Keys` — compiled its first member and dropped the
+rest. The group served only its first interface (the second segment got **no
+leases at all**, a failure that looks like a network problem rather than a config
+one) and a pool offered one resolver where two were configured, so the operator's
+redundancy was simply absent.
+
+**The failing axis is BRACKETED-vs-repeated-leaf, not strict-vs-tolerant.**
+Measured at `origin/master` before the fix:
+
+| spelling | strict | tolerant |
+|---|---|---|
+| `interface [ ge-0/0/0.0 ge-0/0/1.0 ]` | `["ge-0/0/0.0"]` | `["ge-0/0/0.0"]` |
+| two `set … interface <v>` lines | both | both |
+
+The issue that reported this named the tolerant path as the one that mattered. A
+reader who tested only that path would have found the drop there, concluded the
+strict commit path was safe, and been wrong. The strict-path result makes the HA
+argument STRONGER, not weaker: a bracket-authored group is narrowed at the
+ORIGINAL commit, so both cluster nodes agree — on the wrong value — and there is
+no divergence to notice. The tests therefore compile every case on BOTH paths and
+assert the two AGREE.
+
+**Both leaves are now modelled, and modelling is what made the fix decidable.**
+Neither leaf existed in `setSchema` at all, so the grammar said nothing about how
+many tokens they take. Both families' `group` subtrees are now ONE function,
+`dhcpLocalServerGroupSchema` — a divergence between v4 and v6 is always a bug
+(the compiler is one function with an `isV6` flag), so it is made
+unrepresentable rather than merely tested against.
+
+**They take different readers, and that is the point:**
+
+- `pool dns-server` is a plain value list (`multi: true`, `children: nil`,
+  `ValidateIPAddress`), read with `firewallMatchValues` — both sides, every key
+  of every child. Modelling it also brought it under the spelling-differential
+  gate, which immediately caught a `Keys`-only first attempt as class-C INERT in
+  spelling B (`dns-server { v1; v2; }`), a shape the old `nodeVal` fallback did
+  handle.
+- `group interface` is NOT a plain value list. It is the one leaf here carrying
+  per-interface Junos MODIFIERS (`interface ge-0/0/0.0 exclude`, `…
+  upgrade-server <addr>`), so it is `multi: true, valueList: true` with those
+  modifier keywords modelled as CHILDREN — the #3872 static-route `next-hop`
+  precedent, whose doc comment uses this exact `interface` modifier as its
+  example. `valueList` absorbs a trailing token that is neither a sibling nor a
+  known child (the bracket list) while still DESCENDING when the next token names
+  a known child (the modifier). xpf parses and ignores every one of those
+  modifiers — as it did before, where the single-value read dropped them — and
+  they are modelled so the grammar has somewhere to park them other than the
+  value list.
+
+  `dhcpGroupInterfaceValues` then reads `Keys[1:]` when the statement names an
+  interface on its own line (any child is then a modifier BODY), and every key of
+  every child only for a bare `interface { … }` value block, whose values have
+  nowhere else to live. Using `firewallMatchValues` here would PROMOTE `exclude`
+  into the interface list — the #6673 promotion class, but with an unusually
+  sharp consequence: `group.Interfaces` is handed to Kea verbatim as
+  `interfaces-config.interfaces`, and one name no device answers to takes the
+  WHOLE DHCP server down, not just that group. **The spelling-differential gate
+  cannot see this direction** — it detects a DROPPED value, never a PROMOTED
+  modifier — so it is asserted directly by
+  `TestDHCPGroup6696PerInterfaceModifierIsNotAnInterface`.
+
+**A widened read needs a widened validator.** Before the fix only slot 0 could
+reach a consumer, so a malformed element past it was inert; now every element is
+installed. `dns-server` carries `ValidateIPAddress`; `interface` carries
+`keyValidator: ValidateInterfaceName` — keyValidator rather than validator
+because the node declares children, so its values ride the identity KEY slot and
+it is the #5726 `valueList`+`keyValidator` arm of the schema walk that checks
+EVERY packed value instead of only the first. Both run on the strict commit /
+commit-check path only (`schemaValidateExpandedTreeForNode`, `pkg/configstore`),
+so an already-persisted config still boots (#1960).
+
+Fail-on-revert covered by `pkg/config/compiler_dhcp_group_multivalue_6696_test.go`.
+
 ### A widened read must not PROMOTE a token the old reader discarded (#6673)
 
 Widening a one-sided reader has a failure mode symmetric to the one it fixes.

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1837,10 +1837,14 @@ unrepresentable rather than merely tested against.
   into the interface list — the #6673 promotion class, but with an unusually
   sharp consequence: `group.Interfaces` is handed to Kea verbatim as
   `interfaces-config.interfaces`, and one name no device answers to takes the
-  WHOLE DHCP server down, not just that group. **The spelling-differential gate
-  cannot see this direction** — it detects a DROPPED value, never a PROMOTED
-  modifier — so it is asserted directly by
-  `TestDHCPGroup6696PerInterfaceModifierIsNotAnInterface`.
+  WHOLE DHCP server down, not just that group. **The differential gate does not
+  state that direction** — it detects a DROPPED value, not a PROMOTED modifier.
+  Measured rather than assumed: swapping in `firewallMatchValues` DOES red the
+  gate, but only INDIRECTLY, at the modelled `interface <if> <modifier>` sub-leaf
+  sites — which exist only because the modifiers are modelled. Delete those
+  children and the gate goes green with the promotion still present, and only
+  `TestDHCPGroup6696PerInterfaceModifierIsNotAnInterface` reds. The property is
+  owned by that test, not by the gate.
 
 **A widened read needs a widened validator.** Before the fix only slot 0 could
 reach a consumer, so a malformed element past it was inert; now every element is

--- a/pkg/config/compiler_dhcp_group_multivalue_6696_test.go
+++ b/pkg/config/compiler_dhcp_group_multivalue_6696_test.go
@@ -231,8 +231,12 @@ func TestDHCPv6Group6696SpellingsAgree(t *testing.T) {
 // is handed to Kea as interfaces-config.interfaces and a name no device
 // answers to takes the WHOLE DHCP server down, not just that group.
 //
-// The spelling-differential gate cannot see this direction (it detects a
-// dropped value, never a promoted modifier), so it is asserted here.
+// The spelling-differential gate does not state this direction: it detects
+// a dropped value, not a promoted modifier. Measured — swapping in
+// firewallMatchValues does red that gate, but only indirectly, at the
+// modelled `interface <if> <modifier>` sub-leaf sites, which exist only
+// because the modifiers are modelled; removing those children leaves the
+// gate green with the promotion still present, and only this test red.
 //
 // FAIL-ON-REVERT: replacing dhcpGroupInterfaceValues with
 // firewallMatchValues — the union reader used for every other multi-value

--- a/pkg/config/compiler_dhcp_group_multivalue_6696_test.go
+++ b/pkg/config/compiler_dhcp_group_multivalue_6696_test.go
@@ -1,0 +1,371 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6696: `system services dhcp-local-server group <g> interface` and
+// `... group <g> pool <p> dns-server` kept only the FIRST element of a
+// bracketed list.
+//
+// The failing axis is BRACKETED-vs-repeated-leaf, NOT strict-vs-tolerant —
+// measured, and the issue's original framing said otherwise. Every case
+// below is therefore run on BOTH compile paths and asserts the same
+// result, so a fix that repaired only one path cannot pass.
+//
+//   - `group interface` — the DHCP server served only the first interface
+//     in the group; the second segment got no leases at all, and the
+//     failure looks like a network problem rather than a config one.
+//   - `pool dns-server` — clients received one resolver where two were
+//     configured, so the redundancy was simply absent.
+//
+// Because the bracketed spelling fails at the ORIGINAL commit, both
+// cluster nodes agree — on the narrowed value — and there is no divergence
+// to notice.
+
+// dhcpGroups compiles a config on BOTH the strict and the tolerant path,
+// asserts they agree, and returns the v4 groups.
+func dhcpGroups6696(t *testing.T, build func() *ConfigTree) map[string]*DHCPServerGroup {
+	t.Helper()
+
+	strictCfg, sErr := CompileConfig(build())
+	if sErr != nil {
+		t.Fatalf("strict compile: %v", sErr)
+	}
+	lenientCfg, lErr := CompileConfigLenient(build())
+	if lErr != nil {
+		t.Fatalf("tolerant compile: %v", lErr)
+	}
+
+	sGroups := dhcpV4Groups6696(strictCfg)
+	lGroups := dhcpV4Groups6696(lenientCfg)
+
+	// The two paths must agree. Asserting the AGREEMENT rather than pinning
+	// each path to a literal is deliberate: the issue's original diagnosis
+	// named the tolerant path as the failing one, and a test that pinned
+	// only that path would have certified the strict path it never looked at.
+	for name, sg := range sGroups {
+		lg := lGroups[name]
+		if lg == nil {
+			t.Fatalf("group %q present on the strict path, absent on the tolerant path", name)
+		}
+		if strings.Join(sg.Interfaces, ",") != strings.Join(lg.Interfaces, ",") {
+			t.Errorf("group %q: strict Interfaces=%q but tolerant Interfaces=%q — the two "+
+				"compile paths disagree, so a node that loaded a persisted config would "+
+				"serve a different set than the node that committed it",
+				name, sg.Interfaces, lg.Interfaces)
+		}
+		for i, sp := range sg.Pools {
+			if i >= len(lg.Pools) {
+				t.Fatalf("group %q: strict has %d pools, tolerant has %d", name, len(sg.Pools), len(lg.Pools))
+			}
+			if strings.Join(sp.DNSServers, ",") != strings.Join(lg.Pools[i].DNSServers, ",") {
+				t.Errorf("group %q pool %q: strict DNSServers=%q but tolerant DNSServers=%q",
+					name, sp.Name, sp.DNSServers, lg.Pools[i].DNSServers)
+			}
+		}
+	}
+	return sGroups
+}
+
+func dhcpV4Groups6696(cfg *Config) map[string]*DHCPServerGroup {
+	if cfg == nil || cfg.System.DHCPServer.DHCPLocalServer == nil {
+		return nil
+	}
+	return cfg.System.DHCPServer.DHCPLocalServer.Groups
+}
+
+func setTree6696(t *testing.T, lines ...string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, l := range lines {
+		path, err := ParseSetCommand(l)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", l, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", l, err)
+		}
+	}
+	return tree
+}
+
+func braceTree6696(t *testing.T, src string) *ConfigTree {
+	t.Helper()
+	tree, errs := NewParser(src).Parse()
+	if errs != nil {
+		t.Fatalf("parse: %v", errs)
+	}
+	return tree
+}
+
+// TestDHCPGroup6696InterfaceSpellingsAgree asserts that every spelling of a
+// two-interface group compiles to BOTH interfaces, and that the spellings
+// agree with each other.
+//
+// FAIL-ON-REVERT: restoring `if v := nodeVal(prop); v != ""` drops
+// everything past slot 0 in the two bracketed spellings, which reds both
+// the agreement check and the element check.
+func TestDHCPGroup6696InterfaceSpellingsAgree(t *testing.T) {
+	want := []string{"ge-0/0/0.0", "ge-0/0/1.0"}
+
+	cases := []struct {
+		name  string
+		build func() *ConfigTree
+	}{
+		{"set bracketed", func() *ConfigTree {
+			return setTree6696(t, `set system services dhcp-local-server group g1 interface [ ge-0/0/0.0 ge-0/0/1.0 ]`)
+		}},
+		{"set repeated", func() *ConfigTree {
+			return setTree6696(t,
+				`set system services dhcp-local-server group g1 interface ge-0/0/0.0`,
+				`set system services dhcp-local-server group g1 interface ge-0/0/1.0`)
+		}},
+		{"brace bracketed", func() *ConfigTree {
+			return braceTree6696(t, "system {\n services {\n  dhcp-local-server {\n   group g1 {\n"+
+				"    interface [ ge-0/0/0.0 ge-0/0/1.0 ];\n   }\n  }\n }\n}\n")
+		}},
+		{"brace repeated", func() *ConfigTree {
+			return braceTree6696(t, "system {\n services {\n  dhcp-local-server {\n   group g1 {\n"+
+				"    interface ge-0/0/0.0;\n    interface ge-0/0/1.0;\n   }\n  }\n }\n}\n")
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			groups := dhcpGroups6696(t, tc.build)
+			g := groups["g1"]
+			if g == nil {
+				t.Fatal("group g1 missing")
+			}
+			if strings.Join(g.Interfaces, ",") != strings.Join(want, ",") {
+				t.Fatalf("Interfaces=%q, want %q — the group serves only part of what was "+
+					"authored, so the missing segment gets NO leases (#6696)", g.Interfaces, want)
+			}
+		})
+	}
+}
+
+// TestDHCPPool6696DNSServerSpellingsAgree is the same guard for the pool's
+// resolver list — where the drop silently removes the operator's
+// redundancy.
+func TestDHCPPool6696DNSServerSpellingsAgree(t *testing.T) {
+	want := []string{"192.0.2.53", "198.51.100.53"}
+
+	cases := []struct {
+		name  string
+		build func() *ConfigTree
+	}{
+		{"set bracketed", func() *ConfigTree {
+			return setTree6696(t, `set system services dhcp-local-server group g1 pool p1 dns-server [ 192.0.2.53 198.51.100.53 ]`)
+		}},
+		{"set repeated", func() *ConfigTree {
+			return setTree6696(t,
+				`set system services dhcp-local-server group g1 pool p1 dns-server 192.0.2.53`,
+				`set system services dhcp-local-server group g1 pool p1 dns-server 198.51.100.53`)
+		}},
+		{"brace bracketed", func() *ConfigTree {
+			return braceTree6696(t, "system {\n services {\n  dhcp-local-server {\n   group g1 {\n    pool p1 {\n"+
+				"     dns-server [ 192.0.2.53 198.51.100.53 ];\n    }\n   }\n  }\n }\n}\n")
+		}},
+		{"brace repeated", func() *ConfigTree {
+			return braceTree6696(t, "system {\n services {\n  dhcp-local-server {\n   group g1 {\n    pool p1 {\n"+
+				"     dns-server 192.0.2.53;\n     dns-server 198.51.100.53;\n    }\n   }\n  }\n }\n}\n")
+		}},
+		{"brace value block", func() *ConfigTree {
+			return braceTree6696(t, "system {\n services {\n  dhcp-local-server {\n   group g1 {\n    pool p1 {\n"+
+				"     dns-server {\n      192.0.2.53;\n      198.51.100.53;\n     }\n    }\n   }\n  }\n }\n}\n")
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			groups := dhcpGroups6696(t, tc.build)
+			g := groups["g1"]
+			if g == nil || len(g.Pools) != 1 {
+				t.Fatalf("group g1 / pool p1 missing: %#v", g)
+			}
+			if strings.Join(g.Pools[0].DNSServers, ",") != strings.Join(want, ",") {
+				t.Fatalf("DNSServers=%q, want %q — clients receive one resolver where two "+
+					"were configured, so the redundancy is absent (#6696)",
+					g.Pools[0].DNSServers, want)
+			}
+		})
+	}
+}
+
+// TestDHCPv6Group6696SpellingsAgree proves the v6 family carries the same
+// fix. The two families' group subtrees are ONE schema function and ONE
+// compiler function, so this is the guard that the single-sourcing is real
+// rather than asserted.
+func TestDHCPv6Group6696SpellingsAgree(t *testing.T) {
+	tree := setTree6696(t,
+		`set system services dhcpv6-local-server group g6 interface [ ge-0/0/0.0 ge-0/0/1.0 ]`,
+		`set system services dhcpv6-local-server group g6 pool p6 dns-server [ 2001:db8::53 2001:db8::54 ]`)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("strict compile: %v", err)
+	}
+	srv := cfg.System.DHCPServer.DHCPv6LocalServer
+	if srv == nil || srv.Groups["g6"] == nil {
+		t.Fatal("dhcpv6-local-server group g6 missing")
+	}
+	g := srv.Groups["g6"]
+	if strings.Join(g.Interfaces, ",") != "ge-0/0/0.0,ge-0/0/1.0" {
+		t.Errorf("v6 Interfaces=%q, want both (#6696)", g.Interfaces)
+	}
+	if len(g.Pools) != 1 || strings.Join(g.Pools[0].DNSServers, ",") != "2001:db8::53,2001:db8::54" {
+		t.Errorf("v6 DNSServers=%#v, want both (#6696)", g.Pools)
+	}
+}
+
+// TestDHCPGroup6696PerInterfaceModifierIsNotAnInterface is the
+// counter-direction, and it is the reason `interface` is read from Keys
+// alone rather than through firewallMatchValues.
+//
+// A per-interface Junos modifier (`interface ge-0/0/0.0 exclude`, `...
+// upgrade-server <addr>`) is not an interface NAME. xpf parses and ignores
+// these — as it did before #6696, where the single-value read dropped them
+// — and they must not be promoted into the list, because group.Interfaces
+// is handed to Kea as interfaces-config.interfaces and a name no device
+// answers to takes the WHOLE DHCP server down, not just that group.
+//
+// The spelling-differential gate cannot see this direction (it detects a
+// dropped value, never a promoted modifier), so it is asserted here.
+//
+// FAIL-ON-REVERT: replacing dhcpGroupInterfaceValues with
+// firewallMatchValues — the union reader used for every other multi-value
+// leaf — makes `exclude` an interface and reds this test.
+func TestDHCPGroup6696PerInterfaceModifierIsNotAnInterface(t *testing.T) {
+	cases := []struct {
+		name  string
+		build func() *ConfigTree
+	}{
+		{"flat set exclude", func() *ConfigTree {
+			return setTree6696(t, `set system services dhcp-local-server group g1 interface ge-0/0/0.0 exclude`)
+		}},
+		{"flat set upgrade-server", func() *ConfigTree {
+			return setTree6696(t, `set system services dhcp-local-server group g1 interface ge-0/0/0.0 upgrade-server 192.0.2.9`)
+		}},
+		{"brace modifier body", func() *ConfigTree {
+			return braceTree6696(t, "system {\n services {\n  dhcp-local-server {\n   group g1 {\n"+
+				"    interface ge-0/0/0.0 {\n     exclude;\n    }\n   }\n  }\n }\n}\n")
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			groups := dhcpGroups6696(t, tc.build)
+			g := groups["g1"]
+			if g == nil {
+				t.Fatal("group g1 missing")
+			}
+			if strings.Join(g.Interfaces, ",") != "ge-0/0/0.0" {
+				t.Fatalf("Interfaces=%q, want exactly [ge-0/0/0.0] — a per-interface modifier "+
+					"keyword was promoted into the interface list; Kea cannot bind it and the "+
+					"whole DHCP server fails to start (#6696)", g.Interfaces)
+			}
+		})
+	}
+}
+
+// TestDHCPGroup6696BareValueBlockStillReadsEveryValue pins the one shape
+// whose values legitimately live in Children: a bare `interface { ... }`
+// block with no name on the statement line. The pre-#6696 reader handled
+// it (returning the FIRST child only), so a Keys-only read would have
+// regressed the group to serving NOTHING.
+func TestDHCPGroup6696BareValueBlockStillReadsEveryValue(t *testing.T) {
+	groups := dhcpGroups6696(t, func() *ConfigTree {
+		return braceTree6696(t, "system {\n services {\n  dhcp-local-server {\n   group g1 {\n"+
+			"    interface {\n     ge-0/0/0.0;\n     ge-0/0/1.0;\n    }\n   }\n  }\n }\n}\n")
+	})
+	g := groups["g1"]
+	if g == nil {
+		t.Fatal("group g1 missing")
+	}
+	if strings.Join(g.Interfaces, ",") != "ge-0/0/0.0,ge-0/0/1.0" {
+		t.Fatalf("Interfaces=%q, want both — a bare value block carries its values as "+
+			"children and must not compile to an EMPTY group (#6696)", g.Interfaces)
+	}
+}
+
+// TestDHCPGroup6696EveryElementIsValidated is the "a widened read needs a
+// widened validator" half. Before #6696 only slot 0 could ever reach a
+// consumer, so a malformed element past it was inert; now every element is
+// installed, and every element is therefore checked at commit.
+//
+// The check runs through the schema (schemaValidateExpandedTreeForNode,
+// pkg/configstore), which is the STRICT commit / commit-check path only —
+// the tolerant load / peer-sync path does not run it, so an
+// already-persisted config still boots (#1960).
+func TestDHCPGroup6696EveryElementIsValidated(t *testing.T) {
+	bad := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			"second dns-server is not an IP",
+			`set system services dhcp-local-server group g1 pool p1 dns-server [ 192.0.2.53 not-an-ip ]`,
+			"not-an-ip",
+		},
+		{
+			"second interface has a glob metacharacter",
+			`set system services dhcp-local-server group g1 interface [ ge-0/0/0.0 ge-* ]`,
+			"ge-*",
+		},
+		{
+			"v6 second dns-server is not an IP",
+			`set system services dhcpv6-local-server group g6 pool p6 dns-server [ 2001:db8::53 nope ]`,
+			"nope",
+		},
+	}
+	for _, tc := range bad {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := setTree6696(t, tc.line)
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			verr := SchemaValidate(tree, cfg)
+			if verr == nil {
+				t.Fatalf("commit ACCEPTED a malformed element %q — a widened read needs a "+
+					"widened validator (#6696)", tc.want)
+			}
+			if !strings.Contains(verr.Error(), tc.want) {
+				t.Errorf("rejection does not name the offending element %q: %v", tc.want, verr)
+			}
+		})
+	}
+}
+
+// TestDHCPGroup6696RealValuesStillCommitClean is the TIGHTENING control for
+// the validators added above. The interface leaf accepts the Junos slash
+// spelling, the xpf dash spelling, a bare name and a unit-qualified name;
+// the dns-server leaf accepts v4 and v6. A validator tightened to, say,
+// require a unit suffix or reject '/' reds here while every
+// delete-the-fix cell stays green.
+func TestDHCPGroup6696RealValuesStillCommitClean(t *testing.T) {
+	tree := setTree6696(t,
+		`set system services dhcp-local-server group g1 interface [ ge-0/0/1.0 ge-0-0-2 reth0.80 fxp0 ge-0/0/3 ]`,
+		`set system services dhcp-local-server group g1 pool p1 dns-server [ 192.0.2.53 2001:db8::53 ]`,
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("strict compile REJECTED a legitimate group: %v", err)
+	}
+	if verr := SchemaValidate(tree, cfg); verr != nil {
+		t.Fatalf("commit-check REJECTED legitimate interface / resolver values: %v", verr)
+	}
+	g := dhcpV4Groups6696(cfg)["g1"]
+	if g == nil {
+		t.Fatal("group g1 missing")
+	}
+	if got, want := strings.Join(g.Interfaces, ","), "ge-0/0/1.0,ge-0-0-2,reth0.80,fxp0,ge-0/0/3"; got != want {
+		t.Errorf("Interfaces=%q, want %q", got, want)
+	}
+	if got, want := strings.Join(g.Pools[0].DNSServers, ","), "192.0.2.53,2001:db8::53"; got != want {
+		t.Errorf("DNSServers=%q, want %q", got, want)
+	}
+}

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -2267,9 +2267,14 @@ func compileBridgeDomains(node *Node, bds *[]*BridgeDomainConfig, lenient bool, 
 // undo exactly that: it would promote `exclude` into the interface list,
 // and these names go straight into Kea's interfaces-config.interfaces,
 // where one Kea cannot bind takes the whole DHCP server down. The
-// spelling-differential gate cannot catch that direction — it detects a
-// DROPPED value, never a PROMOTED modifier — so the discrimination has to
-// be right here by construction.
+// spelling-differential gate does not state that direction — it detects a
+// DROPPED value, not a PROMOTED modifier. Measured, not assumed: swapping
+// in firewallMatchValues here DOES red that gate, but only INDIRECTLY, at
+// the modelled `interface <if> <modifier>` sub-leaf sites, which exist
+// only because the modifiers are modelled; delete those children and the
+// gate goes silent while the promotion is still there. So the
+// discrimination has to be right here by construction, and the property is
+// stated by a dedicated test.
 //
 // The two shapes are told apart by whether the statement names an
 // interface on its own line:

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -410,9 +410,30 @@ func compileDHCPLocalServer(node *Node, dhcp *DHCPServerConfig, isV6 bool) error
 		for _, prop := range groupInst.node.Children {
 			switch prop.Name() {
 			case "interface":
-				if v := nodeVal(prop); v != "" {
-					group.Interfaces = append(group.Interfaces, v)
-				}
+				// #6696: read EVERY interface, not slot 0. `interface`
+				// is an `args: 1, multi: true, valueList: true` leaf, so
+				// the bracketed spelling — `interface [ ge-0/0/0.0
+				// ge-0/0/1.0 ]`, the ordinary way to write a
+				// multi-segment group — collapses the whole list onto
+				// this ONE node's Keys (the #2419 contract) instead of
+				// producing one sibling node per interface. The prior
+				// nodeVal read kept Keys[1] alone, so the group served
+				// only its FIRST interface and every later segment got
+				// no leases at all — a failure that looks like a network
+				// problem rather than a config one. Identical on the
+				// strict commit path and the tolerant load path: the
+				// failing axis is bracketed-vs-repeated-leaf, so a
+				// bracket-authored group is narrowed at the ORIGINAL
+				// commit and both cluster nodes agree on the wrong value.
+				//
+				// The tail is read from Keys ONLY. A per-interface Junos
+				// MODIFIER (`interface ge-0/0/0.0 exclude`) is a modelled
+				// CHILD of this leaf, so it parks in Children and cannot
+				// be mistaken for an interface name here — which matters,
+				// because these names go straight into Kea's
+				// interfaces-config.interfaces and one Kea cannot bind
+				// takes the whole DHCP server down.
+				group.Interfaces = append(group.Interfaces, dhcpGroupInterfaceValues(prop)...)
 			case "pool":
 				poolName := nodeVal(prop)
 				if poolName != "" {
@@ -433,9 +454,19 @@ func compileDHCPLocalServer(node *Node, dhcp *DHCPServerConfig, isV6 bool) error
 						case "router":
 							pool.Router = nodeVal(pp)
 						case "dns-server":
-							if v := nodeVal(pp); v != "" {
-								pool.DNSServers = append(pool.DNSServers, v)
-							}
+							// #6696: read EVERY resolver, not slot 0.
+							// Same class as `group interface` above —
+							// `dns-server [ 192.0.2.53 198.51.100.53 ]`
+							// collapses onto this one node's Keys, and
+							// the prior nodeVal read handed clients ONE
+							// resolver where two were configured, so the
+							// redundancy the operator wrote was simply
+							// absent (the RA RDNSS shape). The leaf is
+							// modelled `multi: true` with
+							// ValidateIPAddress, so every element of the
+							// widened list is checked at commit rather
+							// than only the first.
+							pool.DNSServers = append(pool.DNSServers, firewallMatchValues(pp)...)
 						case "lease-time":
 							if v := nodeVal(pp); v != "" {
 								if n, err := strconv.Atoi(v); err == nil {
@@ -2222,4 +2253,56 @@ func compileBridgeDomains(node *Node, bds *[]*BridgeDomainConfig, lenient bool, 
 		*bds = append(*bds, bd)
 	}
 	return nil
+}
+
+// dhcpGroupInterfaceValues extracts every interface a `system services
+// dhcp-local-server group <g> interface ...` statement names (#6696).
+//
+// It is NOT firewallMatchValues, and the difference is the whole point.
+// `interface` is the one leaf in this subtree that carries per-interface
+// Junos MODIFIERS — `interface ge-0/0/0.0 exclude`, `... upgrade-server
+// <addr>` — which the schema models as CHILDREN of the leaf so the
+// valueList absorber parks them there instead of swallowing the keyword as
+// an interface name. A reader that unions Keys[1:] with the children would
+// undo exactly that: it would promote `exclude` into the interface list,
+// and these names go straight into Kea's interfaces-config.interfaces,
+// where one Kea cannot bind takes the whole DHCP server down. The
+// spelling-differential gate cannot catch that direction — it detects a
+// DROPPED value, never a PROMOTED modifier — so the discrimination has to
+// be right here by construction.
+//
+// The two shapes are told apart by whether the statement names an
+// interface on its own line:
+//
+//	interface ge-0/0/0.0                     Keys=[interface ge-0/0/0.0]
+//	interface [ ge-0/0/0.0 ge-0/0/1.0 ]      Keys=[interface ge-0/0/0.0 ge-0/0/1.0]
+//	interface ge-0/0/0.0 { exclude; }        Keys=[interface ge-0/0/0.0]  Children=[exclude]
+//	interface { ge-0/0/0.0; ge-0/0/1.0; }    Keys=[interface]             Children=[ge-0/0/0.0, ge-0/0/1.0]
+//
+// With a name on the Keys tail, the tail IS the value list and any child is
+// a modifier body — read Keys[1:] and ignore the children, which is what
+// the pre-#6696 single-value read did for the modifier case too (it read
+// Keys[1] and dropped the rest of the tail; the modifier was never a
+// value). With NO name on the tail, the statement opened a bare value
+// block, so the children are values: read every KEY of every child, not
+// just each child's name — reading "the children" is not the same as
+// reading every key of each child (the #7126 lesson).
+func dhcpGroupInterfaceValues(prop *Node) []string {
+	var vals []string
+	if len(prop.Keys) >= 2 {
+		for _, v := range prop.Keys[1:] {
+			if v != "" {
+				vals = append(vals, v)
+			}
+		}
+		return vals
+	}
+	for _, child := range prop.Children {
+		for _, k := range child.Keys {
+			if k != "" {
+				vals = append(vals, k)
+			}
+		}
+	}
+	return vals
 }

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -533,20 +533,12 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 		}},
 		"dns": {desc: "DNS service", children: nil},
 		"dhcp-local-server": {desc: "DHCP local server", children: map[string]*schemaNode{
-			"group": {desc: "DHCP group", args: 1, placeholder: "<group-name>", children: map[string]*schemaNode{
-				"pool": {desc: "Address pool", args: 1, placeholder: "<pool-name>", children: map[string]*schemaNode{
-					"static-binding": dhcpStaticBindingSchema(),
-				}},
-			}},
+			"group":                     dhcpLocalServerGroupSchema("DHCP"),
 			"dynamic-dns":               dhcpDynamicDNSSchema(),
 			"expired-leases-processing": dhcpExpiredLeasesSchema(),
 		}},
 		"dhcpv6-local-server": {desc: "DHCPv6 local server", children: map[string]*schemaNode{
-			"group": {desc: "DHCPv6 group", args: 1, placeholder: "<group-name>", children: map[string]*schemaNode{
-				"pool": {desc: "Address pool", args: 1, placeholder: "<pool-name>", children: map[string]*schemaNode{
-					"static-binding": dhcpStaticBindingSchema(),
-				}},
-			}},
+			"group":                     dhcpLocalServerGroupSchema("DHCPv6"),
 			"dynamic-dns":               dhcpDynamicDNSSchema(),
 			"expired-leases-processing": dhcpExpiredLeasesSchema(),
 		}},
@@ -995,6 +987,111 @@ func dhcpExpiredLeasesSchema() *schemaNode {
 			children:      nil,
 		},
 	}}
+}
+
+// dhcpLocalServerGroupSchema returns the `group <name>` subtree shared by
+// `system services dhcp-local-server` and `system services
+// dhcpv6-local-server`, fresh per call so the two families do not alias a
+// mutable map (same pattern as dhcpDynamicDNSSchema /
+// dhcpStaticBindingSchema). fam is "DHCP" / "DHCPv6", used only in the
+// completion descriptions.
+//
+// SINGLE-SOURCED ON PURPOSE (#6696). The two families previously carried
+// two independent literal copies of this subtree, and a divergence between
+// them is always a bug: `interface` and `pool dns-server` mean the same
+// thing in both, and the compiler (compileDHCPLocalServer) is ONE function
+// that runs for both with an isV6 flag. One definition makes drift
+// unrepresentable rather than merely tested-against.
+//
+// #6696 — WHY `interface` AND `dns-server` ARE MODELLED AT ALL. Both were
+// unmodelled, so the grammar said nothing about how many tokens they take
+// and the compiler read one value with nodeVal. A bracketed list —
+// `interface [ ge-0/0/0.0 ge-0/0/1.0 ]`, the ordinary way to write a
+// multi-segment group — collapses onto ONE leaf's Keys (the #2419
+// contract), so everything past slot 0 was silently DROPPED: the group
+// served only its first interface and the second segment got no leases at
+// all, and a pool offered one resolver where two were configured. It
+// reproduces identically on the strict commit path and the tolerant load
+// path — the failing axis is BRACKETED-vs-repeated-leaf, not
+// strict-vs-tolerant.
+//
+//   - `multi: true` states that the trailing tokens are VALUES, which is
+//     what lets the compiler read the whole tail instead of guessing.
+//   - `valueList: true` on `interface` is the #3872 static-route `next-hop`
+//     precedent, and it is load-bearing: it absorbs a trailing token that is
+//     neither a sibling NOR a known child (the bracket list) while STILL
+//     descending into the container when the next token names a known child
+//     (a per-interface MODIFIER). Without it the modifier keyword would be
+//     absorbed as an interface NAME and shipped to Kea's
+//     interfaces-config.interfaces, where a name no device answers to takes
+//     the whole DHCP server down.
+//   - the per-interface modifier keywords are therefore modelled — not
+//     because xpf implements them (it does not, and did not before this
+//     change either: the token was silently dropped by the single-value
+//     read) but because the grammar has to be able to PARK them somewhere
+//     other than the value list. They are parsed and ignored, exactly as
+//     before.
+//   - the typed validators (ValidateInterfaceName / ValidateIPAddress) are
+//     the "widened read needs a widened validator" half: every element of a
+//     widened list is now checked, not just slot 0. They run on the strict
+//     commit / commit-check path only (schemaValidateExpandedTreeForNode,
+//     pkg/configstore), so an already-persisted config still boots (#1960).
+func dhcpLocalServerGroupSchema(fam string) *schemaNode {
+	return &schemaNode{
+		desc:        fam + " group",
+		args:        1,
+		placeholder: "<group-name>",
+		children: map[string]*schemaNode{
+			"interface": {
+				desc:             "Interface this group serves (repeatable; accepts a bracketed list)",
+				args:             1,
+				multi:            true,
+				valueList:        true,
+				placeholder:      "<interface>",
+				keyValueDesc:     "Interface name, optionally unit-qualified",
+				keyValueExamples: []string{"ge-0/0/1.0", "reth0.80"},
+				// keyValidator, NOT validator: this node declares CHILDREN
+				// (the per-interface modifiers), so its values ride on the
+				// identity KEY slot, and the #5726 valueList+keyValidator arm
+				// of the schema walk is what validates EVERY packed value
+				// rather than only the first — the same arm the static-route
+				// `next-hop [ gw1 gw2 ]` list relies on. A plain `validator`
+				// is only consulted for a childless leaf and would have left
+				// every element of a widened list unchecked.
+				keyValidator: ValidateInterfaceName,
+				// Junos per-interface options. xpf parses and IGNORES every
+				// one of them; they are modelled so valueList can descend
+				// into them instead of absorbing the keyword as an interface
+				// name. See the function comment.
+				children: map[string]*schemaNode{
+					"access-profile":        {desc: "Per-interface access profile (parsed, not implemented)", args: 1, placeholder: "<profile>", children: nil},
+					"client-discover-match": {desc: "Client discover match option (parsed, not implemented)", args: 1, placeholder: "<match>", children: nil},
+					"dynamic-profile":       {desc: "Per-interface dynamic profile (parsed, not implemented)", args: 1, placeholder: "<profile>", children: nil},
+					"exclude":               {desc: "Exclude this interface from the group (parsed, not implemented)", children: nil},
+					"overrides":             {desc: "Per-interface overrides (parsed, not implemented)", children: nil},
+					"service-profile":       {desc: "Per-interface service profile (parsed, not implemented)", args: 1, placeholder: "<profile>", children: nil},
+					"short-cycle-protection-lockout-max-time": {desc: "Short-cycle lockout max time (parsed, not implemented)", args: 1, placeholder: "<seconds>", children: nil},
+					"short-cycle-protection-lockout-min-time": {desc: "Short-cycle lockout min time (parsed, not implemented)", args: 1, placeholder: "<seconds>", children: nil},
+					"trace":          {desc: "Per-interface tracing (parsed, not implemented)", children: nil},
+					"upgrade-server": {desc: "Per-interface upgrade server (parsed, not implemented)", args: 1, placeholder: "<address>", children: nil},
+				},
+			},
+			"pool": {desc: "Address pool", args: 1, placeholder: "<pool-name>", children: map[string]*schemaNode{
+				"dns-server": {
+					desc:          "DNS resolver offered to clients of this pool (repeatable; accepts a bracketed list)",
+					args:          1,
+					multi:         true,
+					placeholder:   "<address>",
+					valueType:     ValueIPAddress,
+					valueDesc:     "Resolver IP address",
+					valueExamples: []string{"192.0.2.53", "2001:db8::53"},
+					validator:     ValidateIPAddress,
+					children:      nil,
+				},
+				"static-binding": dhcpStaticBindingSchema(),
+			}},
+		},
+	}
 }
 
 // dhcpStaticBindingSchema returns the typed-leaf schema for a #2243


### PR DESCRIPTION
Closes #6696

## The defect

`system services dhcp-local-server group <g> interface` and `... group <g> pool <p> dns-server` were read with `nodeVal`, so a bracketed list — which the lexer collapses onto ONE node's `Keys` (#2419) — compiled its first member and dropped the rest.

- **`group interface`** — the group served only its first interface. The second segment got **no leases at all**, and the failure looks like a network problem rather than a config one.
- **`pool dns-server`** — clients received one resolver where two were configured, so the redundancy the operator wrote was simply absent.

## The failing axis is BRACKETED-vs-repeated-leaf, not strict-vs-tolerant

The issue says the drop was *"observed on the TOLERANT load path"* and that this *"matters specifically"*. Re-measured at `origin/master` before touching anything:

| spelling | strict | tolerant |
|---|---|---|
| `interface [ ge-0/0/0.0 ge-0/0/1.0 ]` | `["ge-0/0/0.0"]` — dropped | `["ge-0/0/0.0"]` — dropped |
| two `set … interface <v>` lines | both | both |

A reader who tested only the tolerant path, as the issue directs, would have found the drop there, concluded the strict path was safe, and been wrong. The strict-path result makes the HA argument **stronger**: a bracket-authored group is narrowed at the ORIGINAL commit, so both cluster nodes agree — on the wrong value — and there is no divergence to notice. Every test case here compiles on BOTH paths and asserts they agree, so a fix that repaired one path cannot pass.

(The issue carries a comment recording this correction. No PR, branch, or worktree existed for it — all five claim legs were clear before and immediately before `checkout -b`.)

## Modelling is what made the fix decidable

Neither leaf existed in `setSchema`, so the grammar said nothing about how many tokens they take. Both are modelled now, and both families' `group` subtree became ONE function, `dhcpLocalServerGroupSchema` — a v4/v6 divergence is always a bug (the compiler is one function with an `isV6` flag), so it is made unrepresentable rather than merely tested against.

**The two leaves take different readers, and that is the point:**

- **`pool dns-server`** is a plain value list (`multi: true`, `children: nil`, `ValidateIPAddress`) → `firewallMatchValues`, both sides, every key of every child. Modelling it brought it under the #2419 **spelling-differential gate**, which immediately caught a `Keys`-only first attempt as class-C **inert** in spelling B (`dns-server { v1; v2; }`) — a shape the old `nodeVal` fallback did handle. That is the "operand on the opposite side" trap, caught by an existing gate before it shipped.
- **`group interface`** is **not** a plain value list. It is the one leaf here carrying per-interface Junos MODIFIERS (`interface ge-0/0/0.0 exclude`, `… upgrade-server <addr>`, which commit clean today and are silently ignored), so it is `multi: true, valueList: true` with those modifier keywords modelled as CHILDREN — the #3872 static-route `next-hop` precedent, whose own doc comment uses this exact `interface` modifier as its example. `dhcpGroupInterfaceValues` reads `Keys[1:]` when the statement names an interface (any child is then a modifier BODY), and every key of every child only for a bare `interface { … }` value block, whose values have nowhere else to live.

  Using `firewallMatchValues` there would **PROMOTE** `exclude` into the interface list — the #6673 promotion class, with an unusually sharp consequence: `group.Interfaces` is handed to Kea verbatim as `interfaces-config.interfaces`, and one name no device answers to takes the **whole DHCP server** down, not just that group.

## A widened read needs a widened validator

Before the fix only slot 0 could reach a consumer, so a malformed element past it was inert; now every element is installed and every element is checked. `dns-server` carries `ValidateIPAddress`; `interface` carries **`keyValidator`** (not `validator`) `ValidateInterfaceName` — because the node declares children, its values ride the identity KEY slot, and it is the #5726 `valueList`+`keyValidator` arm of the schema walk that validates EVERY packed value rather than only the first. Both run on the strict commit / commit-check path only (`schemaValidateExpandedTreeForNode`, `pkg/configstore`), so an already-persisted config still boots (#1960).

## A claim in the first draft was wrong, and the matrix caught it

The first version of the comments and docs said the differential gate **cannot** see the promotion direction. Cell **V4** measured otherwise: it *does* red the gate — indirectly, at the modelled `interface <if> <modifier>` sub-leaf sites, which exist only because the modifiers are modelled. Cell **V5** (delete those children) leaves the gate **green** with the promotion still present and only the dedicated test red. The wording now says what was measured, and the operative point survives: the property is owned by the test, not the gate.

## Mutation matrix

Every cell verified APPLIED first (`git diff --stat` asserted non-empty), `go build ./...` clean before running, exit codes read from files, full `pkg/config` suite at `-count=1` per cell — no `-run` filter. Control green at HEAD first; tree verified clean after every restore.

| cell | mutation | result |
|---|---|---|
| **V1** | restore the **verbatim** pre-fix `nodeVal` bytes of BOTH arms (`git show <base>:`) | RED 5 tests **+ the pre-existing spelling-differential gate** |
| **V2** | interface arm only → pre-fix single-value read | RED 4 tests |
| **V3** | dns-server arm only → pre-fix single-value read | RED 3 tests + the differential gate |
| **V4** | **PROMOTION** — swap `dhcpGroupInterfaceValues` for `firewallMatchValues` (the wrong generalisation) | RED `…PerInterfaceModifierIsNotAnInterface` (+ the gate, indirectly — see above) |
| **V5** | delete the modelled per-interface modifier children (the `valueList` parking spot) | RED `…PerInterfaceModifierIsNotAnInterface` **only** — the gate stays green, which is the measurement behind the corrected claim |
| **V6** | **TIGHTEN** the interface key validator (`ValidateLogicalUnit`, which rejects real interface names) | RED `…RealValuesStillCommitClean` — the over-rejection control |
| **V7** | drop the `dns-server` element validator | RED `…EveryElementIsValidated` |

V6's first form failed to COMPILE and was re-aimed rather than reported: a red on a non-building tree is a non-result.

## Tests

`pkg/config/compiler_dhcp_group_multivalue_6696_test.go` — four interface spellings and five dns-server spellings (including the brace value block) compile to the FULL list and agree across strict and tolerant; the v6 family carries the same fix; three modifier spellings do not leak a keyword into the interface list; the bare value block is not regressed to empty; malformed elements are rejected at commit; nine legitimate interface / resolver values (Junos slash, xpf dash, bare, unit-qualified, v4 and v6) still commit clean.

`go build`, `go vet`, and the **full repo-wide `go test ./... -count=1`** are clean.

## Docs

`docs/config-schema.md` gains "#6696: the two dhcp-local-server list leaves, and why they take DIFFERENT readers", next to the #6692 multi-value section and the #6673 promotion section it extends.
