### PR TITLE
config: read both AST slots at five NAT match-address arms

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103324,3 +103324,24 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/frr/policy_render.go`,
   `pkg/config/compiler_as_path_multitoken_6686_test.go` (new),
   `pkg/frr/policy_aspath_regex_6686_test.go` (new), `docs/config-schema.md`
+## 2026-08-22 — #6693 NAT match arms read both AST slots
+- **Timestamp**: 2026-08-22
+- **Action**: Replace the either/or reader at five NAT match-address arms with
+  an accumulate-both reader that preserves authored empties and synthesizes
+  nothing; add the mixed spelling to the schema spelling differential gate.
+- **File(s)**: pkg/config/compiler_nat_match_values.go (new),
+  pkg/config/compiler_nat_source.go, pkg/config/compiler_nat_destination.go,
+  pkg/config/compiler_nat_static.go,
+  pkg/config/nat_match_mixed_shape_6693_test.go,
+  pkg/config/schema_spelling_differential_gate_test.go, docs/config-schema.md
+- **Timestamp**: 2026-08-22
+  - **Action**: #6693 follow-up on the rescued commit — widened the coverage to
+    all five arms on BOTH compile paths (strict + tolerant, asserted to agree),
+    per-arm malformed-tail gate reachability with a tolerant-accept no-brick leg,
+    the spelling-equivalence test extended from one arm to five, and a new
+    persistence round-trip test (Format / FormatSet re-readings must agree with
+    the authored tree). Completed the static-NAT fixture with a valid `match
+    destination-address` so the #7216 gate cannot fire first and mask the gate
+    under test.
+  - **File(s)**: pkg/config/nat_match_mixed_shape_6693_test.go,
+    docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3793,6 +3793,91 @@ both AST shapes):
   isolation break. Coverage: `compiler_routing_instance_interface_3904_test.go`
   (both AST shapes + single-value back-compat).
 
+**NAT match address arms read both slots (#6693) — the #4121 defect at five
+sites that were not swept.** Source-NAT `match source-address` /
+`match destination-address`, destination-NAT `match destination-address` /
+`match source-address`, and static-NAT `match source-address` all carried the
+same per-arm either/or (`if len(m.Keys) >= 2 { Keys[1:] } else { Children }`),
+while the four SIBLING arms in the same switch — `source-address-name`,
+`destination-address-name`, `protocol`, `application` — already read both slots.
+
+The reachable input is `match { source-address 10.0.0.0/8 { 192.0.2.0/24; } }`:
+`parseStatement`'s `case TokenLBrace` keeps every key token AND the block, so
+`Keys=["source-address","10.0.0.0/8"]` with `Children=[["192.0.2.0/24"]]`, the
+first branch fires, and the `else if` is structurally unreachable. It commits
+CLEAN — these leaves are untyped (`args: 1, multi: true, children: nil`, no
+validator) in an open-world subtree — and the second prefix never reaches the
+dataplane. Two consequences, and they are independent: the rule silently matches
+LESS traffic than authored (for source NAT that means untranslated egress, i.e.
+an internal source address on the wire), and the dropped value ESCAPES
+`validateNATMatchAddressLiteralsStrict` (#7145), which reasons from the compiled
+list — so a malformed prefix in the child slot committed clean.
+
+It is NOT reachable from flat-set: for a `multi` leaf with no children `SetPath`
+always emits a leaf at the same level and never descends, so a flat replay
+produces packed Keys or sibling leaves and never both slots. That is worth
+recording, because a prior investigation enumerated the flat and one-slot
+hierarchical spellings, found perfect agreement, and concluded the shape was
+unreachable and a fix would be unfalsifiable. The enumeration was sound; it was
+not exhaustive.
+
+The five arms now use `natMatchAddressValues`
+(`compiler_nat_match_values.go`), which accumulates both slots. It is
+deliberately NEITHER of the two existing readers, and both alternatives were
+measured rather than reasoned about:
+
+- **not `firewallMatchValues`** (what the siblings use): it DROPS empty tokens,
+  and here an authored empty is not absence. Switching these arms to it turned
+  five #7216 subtests from reject to commit-clean, because `match
+  source-address ""` no longer reached the compiled list that
+  `validateStaticNATSelectedMatchAddressStrict` reasons from. Fixing a
+  fail-closed drop by opening a fail-open hole is worse than the drop.
+- **not `multiLeafAuthoredValues`** (#6673, which does keep empties): it
+  synthesizes ONE empty value for a node with no value slot at all, to keep
+  `values[0] == nodeVal(n)` total for a SELECTION leaf. These arms have no such
+  scalar invariant, and a bare `source-address;` compiling to `[""]` would make
+  the Rust `source_constrained` flag true over a prefix that parses as nothing —
+  the rule then matches NOTHING instead of leaving the criterion absent.
+
+So: accumulate both slots, keep empties, synthesize nothing. It reads every KEY
+of each child rather than `child.Name()`, per #6714.
+
+**The durable half is the gate.** `TestSchemaSpellingDifferentialGate` gains a
+SEVENTH spelling, `F-hier-mixed` (`leaf <v1> { <v2>; }`) — the only spelling that
+puts values in both AST slots of one node, which is exactly what an either/or
+reader cannot see. Across the whole schema it moved ONE site beyond the five it
+was added for, and that site is not a defect: `system archival configuration
+archive-sites` puts a per-site MODIFIER block under an authored value
+(`archive-sites a { password S; }`), so its child is not a member and dropping it
+is correct. That is recorded in a third category,
+`mixedChildIsAModifierBlock` — separate from `notAValueList` (the leaf is not a
+list in ANY spelling) and from `knownSpellingInconsistencies` (a tracked
+DEFECT), because neither of those is true here and using either would state
+something false.
+
+**The sharpest statement of the defect is a PERSISTENCE divergence.** The mixed
+shape round-trips two different ways and they used to disagree with each other.
+`ConfigTree.Format()` re-renders it verbatim (value in the identifier slot, tail
+in the block), while `FormatSet()` — the spelling the configstore persists and
+the CLI replays — renders it PACKED (`set … match source-address 10.0.0.0/8
+192.0.2.0/24`). Both re-parse to a ONE-SLOT shape the either/or reader handled
+correctly, so one config text had two meanings: as authored it matched only the
+first prefix, and after any save/load cycle through the set spelling it matched
+both. A rule silently WIDENS on the next reboot while `show | compare` reports no
+change. `TestMixedShapeAgreesWithItsOwnPersistedRendering_6693` asserts the three
+readings AGREE rather than pinning any one of them to a hand-written expectation.
+
+Coverage is per-arm on both compile paths. The five arms are each asserted under
+STRICT `CompileConfig` and tolerant `CompileConfigLenient`, agreeing with each
+other before either is compared to the authored pair, and each is separately
+shown to carry a malformed tail INTO its strict gate (three different gates cover
+the five arms) while the tolerant path still ACCEPTS it — the #1960 no-brick
+half, since a box can already hold a config whose tail never reached a gate. The
+static-NAT fixture carries a valid `match destination-address` sibling for the
+same reason the issue names: without it the #7216 "selected external prefix is
+MISSING" gate fires first and its rejection is indistinguishable from the gate
+under test firing on the tail.
+
 **Policy match source-/destination-address/application share the reader
 (#4121, divergence-elimination, NOT a fail-open).** `compilePolicy`
 (`compiler_security.go`) previously read the three `multi: true` policy-match

--- a/pkg/config/compiler_nat_destination.go
+++ b/pkg/config/compiler_nat_destination.go
@@ -114,13 +114,16 @@ func compileNATDestination(node *Node, sec *SecurityConfig) error {
 					switch m.Name() {
 					case "destination-address":
 						// Support bracket lists: destination-address [ addr1 addr2 ... ]
-						if len(m.Keys) >= 2 {
-							rule.Match.DestinationAddresses = append(rule.Match.DestinationAddresses, m.Keys[1:]...)
-						} else if len(m.Children) > 0 {
-							for _, child := range m.Children {
-								rule.Match.DestinationAddresses = append(rule.Match.DestinationAddresses, child.Name())
-							}
-						}
+						// #6693: read BOTH slots through the natMatchAddressValues
+						// SSOT. The either/or form below read Keys[1:] OR the
+						// children, never both, so the MIXED shape
+						// `destination-address <v1> { <v2>; }` — a value in the
+						// identifier slot beside a block — silently dropped the
+						// child tail. It is the #4121 defect (fixed for
+						// `security policies ... match`) at five NAT sites; the
+						// four sibling arms in this same switch already use this
+						// reader.
+						rule.Match.DestinationAddresses = append(rule.Match.DestinationAddresses, natMatchAddressValues(m)...)
 						if len(rule.Match.DestinationAddresses) > 0 {
 							rule.Match.DestinationAddress = rule.Match.DestinationAddresses[0]
 						} else {
@@ -144,13 +147,16 @@ func compileNATDestination(node *Node, sec *SecurityConfig) error {
 						}
 					case "source-address":
 						// Support bracket lists: source-address [ addr1 addr2 ... ]
-						if len(m.Keys) >= 2 {
-							rule.Match.SourceAddresses = append(rule.Match.SourceAddresses, m.Keys[1:]...)
-						} else if len(m.Children) > 0 {
-							for _, child := range m.Children {
-								rule.Match.SourceAddresses = append(rule.Match.SourceAddresses, child.Name())
-							}
-						}
+						// #6693: read BOTH slots through the natMatchAddressValues
+						// SSOT. The either/or form below read Keys[1:] OR the
+						// children, never both, so the MIXED shape
+						// `source-address <v1> { <v2>; }` — a value in the
+						// identifier slot beside a block — silently dropped the
+						// child tail. It is the #4121 defect (fixed for
+						// `security policies ... match`) at five NAT sites; the
+						// four sibling arms in this same switch already use this
+						// reader.
+						rule.Match.SourceAddresses = append(rule.Match.SourceAddresses, natMatchAddressValues(m)...)
 						if len(rule.Match.SourceAddresses) > 0 {
 							rule.Match.SourceAddress = rule.Match.SourceAddresses[0]
 						}

--- a/pkg/config/compiler_nat_match_values.go
+++ b/pkg/config/compiler_nat_match_values.go
@@ -1,0 +1,70 @@
+package config
+
+// natMatchAddressValues returns EVERY prefix a NAT `match source-address` /
+// `match destination-address` leaf carries, across BOTH AST slots (#6693).
+//
+// THE DEFECT IT REPLACES. Five arms — source-NAT source/destination, dest-NAT
+// destination/source, static-NAT source — read the node with an either/or:
+//
+//	if len(m.Keys) >= 2 {
+//	    vals = append(vals, m.Keys[1:]...)
+//	} else if len(m.Children) > 0 {
+//	    for _, child := range m.Children { vals = append(vals, child.Name()) }
+//	}
+//
+// which is correct for every spelling that puts the whole list in ONE slot —
+// a bracket list, a compact tail, a block, or repeated sibling statements — and
+// wrong for the one spelling that uses both. A value in the identifier slot
+// BESIDE a block:
+//
+//	match { source-address 10.0.0.0/8 { 192.0.2.0/24; } }
+//	  -> Keys=["source-address","10.0.0.0/8"], Children=[["192.0.2.0/24"]]
+//
+// takes the first branch, so the `else if` is structurally unreachable and
+// every prefix past the first is dropped. It commits CLEAN: these leaves are
+// untyped (`args: 1, multi: true, children: nil`, no validator) and sit in an
+// open-world subtree, so the schema walker has nothing to reject.
+//
+// This is the #4121 defect — fixed there for `security policies … match` — at
+// five NAT sites that were not swept at the time. The four SIBLING arms in the
+// same switch (`source-address-name`, `destination-address-name`, `protocol`,
+// `application`) already read both slots.
+//
+// WHY NOT firewallMatchValues, which is what the siblings use. It DROPS empty
+// tokens, and here an authored empty is not absence: `match source-address ""`
+// must reach the compiled list so validateStaticNATSelectedMatchAddressStrict
+// (#7216) can reject a rule that would lower an empty prefix and be dropped
+// wholesale by the Rust `parse_nat_prefix`. Measured: switching these five arms
+// to firewallMatchValues turned five #7216 subtests from reject to
+// commit-clean — a fail-open introduced by the fix for a fail-closed drop.
+//
+// WHY NOT multiLeafAuthoredValues, the #6673 reader that does keep empties. It
+// synthesizes ONE empty value for a node with no value slot at all, to keep
+// `multiLeafAuthoredValues(n)[0] == nodeVal(n)` total for a SELECTION leaf.
+// These arms have no such scalar invariant, and a bare `source-address;` would
+// then compile to [""] — which makes the Rust `source_constrained` flag true
+// over a prefix that parses as nothing, so the rule matches NOTHING instead of
+// leaving the criterion absent.
+//
+// So: accumulate both slots, keep empties, synthesize nothing.
+//
+// It reads every KEY of each child rather than child.Name(), so
+// `source-address { 10.0.0.0/8 192.0.2.0/24; }` — two tokens on one statement
+// inside a block — yields both. That is the #6714 rule: the same token sequence
+// must not read differently depending on which side of the AST it landed on.
+func natMatchAddressValues(child *Node) []string {
+	if child == nil {
+		return nil
+	}
+	var vals []string
+	if len(child.Keys) > 1 {
+		vals = append(vals, child.Keys[1:]...)
+	}
+	for _, vn := range child.Children {
+		if vn == nil {
+			continue
+		}
+		vals = append(vals, vn.Keys...)
+	}
+	return vals
+}

--- a/pkg/config/compiler_nat_source.go
+++ b/pkg/config/compiler_nat_source.go
@@ -891,13 +891,16 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 					switch m.Name() {
 					case "source-address":
 						// Support bracket lists: source-address [ addr1 addr2 ... ]
-						if len(m.Keys) >= 2 {
-							rule.Match.SourceAddresses = append(rule.Match.SourceAddresses, m.Keys[1:]...)
-						} else if len(m.Children) > 0 {
-							for _, child := range m.Children {
-								rule.Match.SourceAddresses = append(rule.Match.SourceAddresses, child.Name())
-							}
-						}
+						// #6693: read BOTH slots through the natMatchAddressValues
+						// SSOT. The either/or form below read Keys[1:] OR the
+						// children, never both, so the MIXED shape
+						// `source-address <v1> { <v2>; }` — a value in the
+						// identifier slot beside a block — silently dropped the
+						// child tail. It is the #4121 defect (fixed for
+						// `security policies ... match`) at five NAT sites; the
+						// four sibling arms in this same switch already use this
+						// reader.
+						rule.Match.SourceAddresses = append(rule.Match.SourceAddresses, natMatchAddressValues(m)...)
 						if len(rule.Match.SourceAddresses) > 0 {
 							rule.Match.SourceAddress = rule.Match.SourceAddresses[0]
 						}
@@ -914,13 +917,16 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 						}
 					case "destination-address":
 						// Support bracket lists: destination-address [ addr1 addr2 ... ]
-						if len(m.Keys) >= 2 {
-							rule.Match.DestinationAddresses = append(rule.Match.DestinationAddresses, m.Keys[1:]...)
-						} else if len(m.Children) > 0 {
-							for _, child := range m.Children {
-								rule.Match.DestinationAddresses = append(rule.Match.DestinationAddresses, child.Name())
-							}
-						}
+						// #6693: read BOTH slots through the natMatchAddressValues
+						// SSOT. The either/or form below read Keys[1:] OR the
+						// children, never both, so the MIXED shape
+						// `destination-address <v1> { <v2>; }` — a value in the
+						// identifier slot beside a block — silently dropped the
+						// child tail. It is the #4121 defect (fixed for
+						// `security policies ... match`) at five NAT sites; the
+						// four sibling arms in this same switch already use this
+						// reader.
+						rule.Match.DestinationAddresses = append(rule.Match.DestinationAddresses, natMatchAddressValues(m)...)
 						if len(rule.Match.DestinationAddresses) > 0 {
 							rule.Match.DestinationAddress = rule.Match.DestinationAddresses[0]
 						} else {

--- a/pkg/config/compiler_nat_static.go
+++ b/pkg/config/compiler_nat_static.go
@@ -892,13 +892,16 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 						// m.Keys[1:] (flat-set) or m.Children (hierarchical).
 						// Reading only nodeVal dropped every prefix after the
 						// first. Mirror the source/destination-NAT loops above.
-						if len(m.Keys) >= 2 {
-							rule.SourceAddresses = append(rule.SourceAddresses, m.Keys[1:]...)
-						} else if len(m.Children) > 0 {
-							for _, child := range m.Children {
-								rule.SourceAddresses = append(rule.SourceAddresses, child.Name())
-							}
-						}
+						// #6693: read BOTH slots through the natMatchAddressValues
+						// SSOT. The either/or form below read Keys[1:] OR the
+						// children, never both, so the MIXED shape
+						// `source-address <v1> { <v2>; }` — a value in the
+						// identifier slot beside a block — silently dropped the
+						// child tail. It is the #4121 defect (fixed for
+						// `security policies ... match`) at five NAT sites; the
+						// four sibling arms in this same switch already use this
+						// reader.
+						rule.SourceAddresses = append(rule.SourceAddresses, natMatchAddressValues(m)...)
 						if len(rule.SourceAddresses) > 0 {
 							// Back-compat: first element stays in the singular
 							// field (NAT64 "::/0" tests, peer-sync).

--- a/pkg/config/nat_match_mixed_shape_6693_test.go
+++ b/pkg/config/nat_match_mixed_shape_6693_test.go
@@ -1,0 +1,488 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// #6693 — five NAT `match` address arms dropped every prefix past the first in
+// the MIXED AST shape.
+//
+// THE SHAPE, and why it went unfound. The arms read the node with an either/or:
+// `Keys[1:]` OR the children, never both. That is correct for every spelling
+// that puts the whole list in ONE slot — bracket, compact tail, block, repeated
+// siblings — which is exactly the set a previous investigation enumerated
+// before recording a NEGATIVE RESULT ("the shape is not reachable from any
+// config spelling I can author", and "a fix would be unfalsifiable").
+//
+// The unenumerated spelling is a value in the identifier slot BESIDE a block:
+//
+//	match { source-address 10.0.0.0/8 { 192.0.2.0/24; } }
+//	  -> Keys=["source-address","10.0.0.0/8"], Children=[["192.0.2.0/24"]]
+//
+// parseStatement's `case TokenLBrace` keeps every key token AND the block, so
+// `len(m.Keys) >= 2` is true and the `else if` is structurally unreachable.
+// It commits CLEAN — these leaves are untyped (`args: 1, multi: true,
+// children: nil`, no validator) in an open-world subtree, so the schema walker
+// has nothing to reject — and `192.0.2.0/24` never reaches the dataplane.
+//
+// It is NOT reachable from flat-set, which is why the earlier enumeration was
+// consistent with itself: for a `multi` leaf with no children SetPath always
+// emits a LEAF at the same level and never descends, so the flat replay can
+// only ever produce packed Keys or sibling leaves. Hierarchical text — a config
+// file, `load merge`, `load override`, a peer-synced tree — reaches it trivially.
+//
+// This is the #4121 defect, fixed there for `security policies … match`, at five
+// NAT sites that were not swept at the time. The four SIBLING arms in the same
+// switch already read both slots.
+
+// natMixed6693 renders one NAT rule whose named match leaf carries v1 in the
+// identifier slot and v2 in a block.
+func natMixed6693(natType, leaf, v1, v2 string) string {
+	return natRuleBody6693(natType, leaf, fmt.Sprintf("%s %s { %s; }", leaf, v1, v2))
+}
+
+// natRuleBody6693 renders one NAT rule of the given kind whose `match` body is
+// exactly matchBody. leaf names the arm under test, which is only used to decide
+// whether the completing sibling below would collide with it.
+func natRuleBody6693(natType, leaf, matchBody string) string {
+	var from string
+	switch natType {
+	case "source":
+		from = "from zone trust;\n                to zone untrust;"
+	case "destination":
+		from = "from zone untrust;"
+	default:
+		from = "from zone untrust;"
+	}
+	then := "then { source-nat interface; }"
+	switch natType {
+	case "destination":
+		then = "then { destination-nat pool p1; }"
+	case "static":
+		then = "then { static-nat prefix 10.0.1.1/32; }"
+	}
+	extra := ""
+	if natType == "destination" {
+		extra = `
+    nat { destination { pool p1 { address 10.0.1.1/32; } } }`
+	}
+	// A static-NAT rule with no `match destination-address` is rejected at strict
+	// commit by #7216 ("the selected external prefix is MISSING"), regardless of
+	// anything this fixture is testing. Left off, the strict leg of every static
+	// subtest would fail for a reason that has nothing to do with the mixed
+	// shape — and, worse, in the MALFORMED-tail subtest it would produce a
+	// rejection that looks like the gate firing on the tail. That is exactly the
+	// "a strict gate firing first can mask an unvalidated tail" hazard, so the
+	// rule is completed with a valid, unrelated external prefix.
+	sibling := ""
+	if natType == "static" && leaf != "destination-address" {
+		sibling = " destination-address 198.51.100.1/32;"
+	}
+	return fmt.Sprintf(`
+security {%s
+    nat {
+        %s {
+            rule-set rs1 {
+                %s
+                rule r1 {
+                    match { %s%s }
+                    %s
+                }
+            }
+        }
+    }
+}
+`, extra, natType, from, matchBody, sibling, then)
+}
+
+func compileNAT6693(t *testing.T, text string) *Config {
+	t.Helper()
+	tree, errs := NewParser(text).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("fixture parse errors: %v\n%s", errs, text)
+	}
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("compile: %v\n%s", err, text)
+	}
+	return cfg
+}
+
+// natArm6693 names one of the five arms, the compiled list it feeds, and the
+// singular back-compat field it also sets. It is a package-level table so every
+// test below iterates the SAME five arms — a sixth arm added to one test and not
+// the others would be a coverage claim that is only true of one property.
+type natArm6693 struct {
+	name    string
+	natType string
+	leaf    string
+	// list returns the compiled slice this arm accumulates into.
+	list func(*Config) []string
+}
+
+func natArms6693() []natArm6693 {
+	return []natArm6693{
+		{
+			name: "source-nat/source-address", natType: "source", leaf: "source-address",
+			list: func(c *Config) []string { return c.Security.NAT.Source[0].Rules[0].Match.SourceAddresses },
+		},
+		{
+			name: "source-nat/destination-address", natType: "source", leaf: "destination-address",
+			list: func(c *Config) []string { return c.Security.NAT.Source[0].Rules[0].Match.DestinationAddresses },
+		},
+		{
+			name: "destination-nat/destination-address", natType: "destination", leaf: "destination-address",
+			list: func(c *Config) []string {
+				return c.Security.NAT.Destination.RuleSets[0].Rules[0].Match.DestinationAddresses
+			},
+		},
+		{
+			name: "destination-nat/source-address", natType: "destination", leaf: "source-address",
+			list: func(c *Config) []string { return c.Security.NAT.Destination.RuleSets[0].Rules[0].Match.SourceAddresses },
+		},
+		{
+			name: "static-nat/source-address", natType: "static", leaf: "source-address",
+			list: func(c *Config) []string { return c.Security.NAT.Static[0].Rules[0].SourceAddresses },
+		},
+	}
+}
+
+// TestEveryNATMatchArmReadsBothSlots_6693 covers all five arms, one subtest
+// each, so a partial revert names WHICH arm regressed rather than failing one
+// lump assertion.
+//
+// BOTH compile paths, per arm, because the issue asks for the tolerant path to
+// be checked SEPARATELY: a strict gate firing first would mask an unvalidated
+// tail, and conversely a fix proven only on the lenient path says nothing about
+// what an operator's `commit` produces. Here the mixed shape is VALID config, so
+// both paths must accept it AND both must see both prefixes — asserting the two
+// AGREE first, then that they equal the authored pair.
+func TestEveryNATMatchArmReadsBothSlots_6693(t *testing.T) {
+	const v1, v2 = "10.0.0.0/8", "192.0.2.0/24"
+
+	for _, tc := range natArms6693() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			text := natMixed6693(tc.natType, tc.leaf, v1, v2)
+
+			strictTree, errs := NewParser(text).Parse()
+			if len(errs) > 0 {
+				t.Fatalf("fixture parse errors: %v\n%s", errs, text)
+			}
+			strictCfg, err := CompileConfig(strictTree)
+			if err != nil {
+				t.Fatalf("STRICT commit rejected a valid mixed-shape rule: %v\n%s", err, text)
+			}
+			strictGot := tc.list(strictCfg)
+			lenientGot := tc.list(compileNAT6693(t, text))
+
+			if len(strictGot) != len(lenientGot) {
+				t.Fatalf("strict and lenient disagree on the mixed shape: strict=%v lenient=%v",
+					strictGot, lenientGot)
+			}
+			for i := range strictGot {
+				if strictGot[i] != lenientGot[i] {
+					t.Fatalf("strict and lenient disagree at index %d: strict=%v lenient=%v",
+						i, strictGot, lenientGot)
+				}
+			}
+			if len(strictGot) != 2 || strictGot[0] != v1 || strictGot[1] != v2 {
+				t.Errorf("mixed shape compiled to %v, want [%s %s] — the child tail was dropped, "+
+					"so the rule silently matches less traffic than authored", strictGot, v1, v2)
+			}
+		})
+	}
+}
+
+// TestMixedShapeAgreesWithTheOneSlotSpellings_6693 is the equivalence half. The
+// same two prefixes must compile identically however they are spelled — that is
+// the property, and it is what makes the fix a correction rather than a new
+// reading of its own.
+//
+// The one-slot spellings are the GREEN CONTROL as well: they were correct
+// before this change and must stay correct, so a fix that broke them to make
+// the mixed shape work cannot pass.
+//
+// Run for ALL FIVE arms, not just one: the issue asks for the pure-bracketed,
+// pure-nested and mixed shapes to be covered per arm, and five readers were
+// edited. A one-arm equivalence proof would leave four of them asserted only by
+// the mixed-shape test, which cannot see a reader that started dropping the
+// BRACKET tail instead.
+//
+// Agreement is asserted between the spellings FIRST and against the authored
+// literal second. Pinning one spelling to a hand-written expectation would
+// encode which side is trusted, and in this family the trusted side has been the
+// broken one before (#7457).
+func TestMixedShapeAgreesWithTheOneSlotSpellings_6693(t *testing.T) {
+	const v1, v2 = "10.0.0.0/8", "192.0.2.0/24"
+
+	// Deterministic order so a failure names the same spelling every run.
+	order := []string{"mixed", "bracket", "compact", "block", "repeat"}
+
+	for _, tc := range natArms6693() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			spelling := map[string]string{
+				"mixed":   fmt.Sprintf("%s %s { %s; }", tc.leaf, v1, v2),
+				"bracket": fmt.Sprintf("%s [ %s %s ];", tc.leaf, v1, v2),
+				"compact": fmt.Sprintf("%s %s %s;", tc.leaf, v1, v2),
+				"block":   fmt.Sprintf("%s { %s; %s; }", tc.leaf, v1, v2),
+				"repeat":  fmt.Sprintf("%s %s; %s %s;", tc.leaf, v1, tc.leaf, v2),
+			}
+
+			var ref []string
+			var refName string
+			for _, name := range order {
+				got := tc.list(compileNAT6693(t, natRuleBody6693(tc.natType, tc.leaf, spelling[name])))
+				if ref == nil {
+					ref, refName = got, name
+					continue
+				}
+				if len(got) != len(ref) {
+					t.Fatalf("%s spelling compiled to %v but %s spelling compiled to %v — "+
+						"one config text, two match sets", name, got, refName, ref)
+				}
+				for i := range got {
+					if got[i] != ref[i] {
+						t.Fatalf("%s spelling compiled to %v but %s spelling compiled to %v "+
+							"(differ at index %d)", name, got, refName, ref, i)
+					}
+				}
+			}
+			if len(ref) != 2 || ref[0] != v1 || ref[1] != v2 {
+				t.Errorf("every spelling agrees on %v, but the authored pair is [%s %s]", ref, v1, v2)
+			}
+		})
+	}
+}
+
+// TestMixedShapeKeepsTheScalarBackCompat_6693 pins the singular field the
+// arms also set. It is what the NAT64 fixtures and the peer-sync path read, and
+// a reader change that accumulated correctly while dropping the scalar would
+// pass every assertion above.
+func TestMixedShapeKeepsTheScalarBackCompat_6693(t *testing.T) {
+	cfg := compileNAT6693(t, natMixed6693("source", "source-address", "10.0.0.0/8", "192.0.2.0/24"))
+	if got := cfg.Security.NAT.Source[0].Rules[0].Match.SourceAddress; got != "10.0.0.0/8" {
+		t.Errorf("scalar SourceAddress = %q, want the FIRST value 10.0.0.0/8", got)
+	}
+}
+
+// TestNATMatchReaderKeepsAnAuthoredEmpty_6693 is the guard for the reader
+// CHOICE, and it exists because the obvious choice is wrong.
+//
+// `firewallMatchValues` is what the four sibling arms in the same switch use,
+// and switching these five to it turned five #7216 subtests from reject to
+// commit-clean: it DROPS empty tokens, so an authored `match source-address ""`
+// never reached the compiled list and the gate that rejects an empty selected
+// prefix had nothing to see. Fixing a fail-closed drop by opening a fail-open
+// hole is worse than the drop.
+//
+// So the property is: an authored empty must survive into the list, in BOTH
+// slots. Asserted here directly rather than only through the #7216 gate, so a
+// future change to that gate cannot silently retire this constraint.
+func TestNATMatchReaderKeepsAnAuthoredEmpty_6693(t *testing.T) {
+	cases := map[string]*Node{
+		"empty in the identifier slot": {Keys: []string{"source-address", ""}},
+		"empty in the child slot": {
+			Keys:     []string{"source-address"},
+			Children: []*Node{{Keys: []string{""}}},
+		},
+		"empty beside a real value": {
+			Keys:     []string{"source-address", ""},
+			Children: []*Node{{Keys: []string{"10.0.0.0/8"}}},
+		},
+	}
+	for name, n := range cases {
+		got := natMatchAddressValues(n)
+		found := false
+		for _, v := range got {
+			if v == "" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s: reader returned %v with no empty entry — the #7216 gate "+
+				"reasons from this list, so dropping the empty makes an inert rule "+
+				"commit clean", name, got)
+		}
+	}
+}
+
+// TestNATMatchReaderSynthesizesNothing_6693 is the other half of the reader
+// choice, and it rules out the OTHER in-tree candidate.
+//
+// `multiLeafAuthoredValues` (#6673) keeps empties — which is what the test above
+// wants — but it synthesizes ONE empty value for a node with no value slot at
+// all, to keep `values[0] == nodeVal(n)` total for a SELECTION leaf. These arms
+// have no such scalar invariant, and a bare `source-address;` compiling to [""]
+// would make the Rust `source_constrained` flag true over a prefix that parses
+// as nothing — so the rule matches NOTHING instead of leaving the criterion
+// absent. A fail-closed outage in place of an absent match.
+func TestNATMatchReaderSynthesizesNothing_6693(t *testing.T) {
+	if got := natMatchAddressValues(&Node{Keys: []string{"source-address"}}); len(got) != 0 {
+		t.Errorf("a value-less leaf yielded %v; it must yield nothing, not a synthesized "+
+			"empty — an empty entry here constrains the rule to match nothing", got)
+	}
+	if got := natMatchAddressValues(nil); got != nil {
+		t.Errorf("nil node yielded %v, want nil", got)
+	}
+}
+
+// TestNATMatchReaderTakesEveryChildKey_6693 pins the #6714 property: the same
+// token sequence must not read differently depending on which side of the AST
+// it landed on. `source-address { a b; }` puts two tokens on ONE child node;
+// reading only child.Name() would take `a` and drop `b`, while the identical
+// tokens in the identifier slot yield both.
+func TestNATMatchReaderTakesEveryChildKey_6693(t *testing.T) {
+	n := &Node{
+		Keys:     []string{"source-address"},
+		Children: []*Node{{Keys: []string{"10.0.0.0/8", "192.0.2.0/24"}}},
+	}
+	got := natMatchAddressValues(n)
+	if len(got) != 2 || got[0] != "10.0.0.0/8" || got[1] != "192.0.2.0/24" {
+		t.Errorf("multi-token child read as %v, want both tokens", got)
+	}
+}
+
+// TestMixedShapeValuesReachTheCommitGates_6693 is the fail-open half that the
+// drop also caused, and it is a distinct property from the narrowing.
+//
+// The strict literal gates (validateNATMatchAddressLiteralsStrict #7145,
+// validateDestinationNATAddressesStrict #3228, and the static-NAT gate) all walk
+// the COMPILED list, so a dropped child tail escaped every one of them: a
+// malformed prefix in the second slot committed clean. Asserted per arm, because
+// each arm is reached by a different gate and a fix that widened four readers
+// would still leave one arm's tail unvalidated.
+//
+// The LENIENT leg is the #1960 no-brick half and it is not decoration. A box can
+// already hold a committed config with a malformed tail — before this change the
+// tail never reached a gate — and `FormatSet` renders that config back in the
+// packed spelling, so the tolerant load / peer-sync path must keep ACCEPTING it
+// (with the value carried through for the runtime to drop) rather than refusing
+// to load. Strict MAY reject; tolerant MUST NOT brick.
+func TestMixedShapeValuesReachTheCommitGates_6693(t *testing.T) {
+	const good, bad = "10.0.0.0/8", "999.1.1.1/24"
+
+	for _, tc := range natArms6693() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			text := natMixed6693(tc.natType, tc.leaf, good, bad)
+
+			tree, errs := NewParser(text).Parse()
+			if len(errs) > 0 {
+				t.Fatalf("fixture parse errors: %v", errs)
+			}
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("a malformed prefix in the CHILD slot committed clean; the literal gate " +
+					"reasons from the compiled list, so a dropped tail escapes it")
+			}
+			if !strings.Contains(err.Error(), bad) {
+				t.Errorf("rejected, but the message does not name the offending tail value: %v", err)
+			}
+
+			lenientTree, errs := NewParser(text).Parse()
+			if len(errs) > 0 {
+				t.Fatalf("fixture parse errors: %v", errs)
+			}
+			cfg, lerr := CompileConfigLenient(lenientTree)
+			if lerr != nil {
+				t.Fatalf("the TOLERANT path refused a config a box can already hold: %v — "+
+					"a peer-sync / startup load that rejects here bricks the node (#1960)", lerr)
+			}
+			got := tc.list(cfg)
+			if len(got) != 2 || got[0] != good || got[1] != bad {
+				t.Errorf("tolerant load compiled to %v, want [%s %s] — the tolerant path must "+
+					"carry the authored values through, not silently narrow the rule", got, good, bad)
+			}
+		})
+	}
+}
+
+// TestMixedShapeAgreesWithItsOwnPersistedRendering_6693 is the sharpest statement
+// of the defect, and it is a property no single-tree assertion can express: the
+// mixed shape must mean the SAME THING before and after a save/load cycle.
+//
+// `ConfigTree.Format()` renders the mixed shape back verbatim (the value stays in
+// the identifier slot, the tail stays in the block), while `FormatSet()` — the
+// spelling the configstore persists and the CLI replays — renders it PACKED:
+//
+//	set … match source-address 10.0.0.0/8 192.0.2.0/24
+//
+// Both re-parse to a one-slot shape the either/or reader handled correctly. So
+// before this change, one config had TWO meanings: as authored it matched only
+// 10.0.0.0/8, and after any round-trip through the persisted set spelling it
+// matched both. A rule silently WIDENS on the next reboot, or an operator's
+// `show | compare` shows no change while the compiled match set moved.
+//
+// Asserting the three readings AGREE — rather than pinning any one of them to a
+// hand-written expectation — is deliberate: pinning encodes which spelling is
+// trusted, and the whole family of these defects has been cases where the
+// trusted side was the broken one.
+func TestMixedShapeAgreesWithItsOwnPersistedRendering_6693(t *testing.T) {
+	const v1, v2 = "10.0.0.0/8", "192.0.2.0/24"
+
+	for _, tc := range natArms6693() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			text := natMixed6693(tc.natType, tc.leaf, v1, v2)
+			tree, errs := NewParser(text).Parse()
+			if len(errs) > 0 {
+				t.Fatalf("fixture parse errors: %v", errs)
+			}
+			authored := tc.list(compileNAT6693(t, text))
+
+			viaBrace := tc.list(compileNAT6693(t, tree.Format()))
+			viaSet := natCompileSetLines6693(t, tree.FormatSet())
+
+			same := func(label string, got []string) {
+				t.Helper()
+				if len(got) != len(authored) {
+					t.Fatalf("%s reading disagrees with the authored tree: %v vs %v — one config, "+
+						"two meanings across a save/load cycle", label, got, authored)
+				}
+				for i := range got {
+					if got[i] != authored[i] {
+						t.Fatalf("%s reading disagrees with the authored tree at %d: %v vs %v",
+							label, i, got, authored)
+					}
+				}
+			}
+			same("Format() brace", viaBrace)
+			same("FormatSet() packed", tc.list(viaSet))
+
+			if len(authored) != 2 || authored[0] != v1 || authored[1] != v2 {
+				t.Errorf("all three readings agree on %v, but the authored pair is [%s %s]",
+					authored, v1, v2)
+			}
+		})
+	}
+}
+
+// natCompileSetLines6693 replays a `set`-spelling config through ParseSetCommand
+// + SetPath, which is how the CLI and `load set` build a tree — NOT NewParser,
+// which treats newlines as whitespace and would merge every line into one node.
+func natCompileSetLines6693(t *testing.T, setText string) *Config {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, line := range strings.Split(setText, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("compile replayed set config: %v", err)
+	}
+	return cfg
+}

--- a/pkg/config/schema_spelling_differential_gate_test.go
+++ b/pkg/config/schema_spelling_differential_gate_test.go
@@ -174,6 +174,24 @@ package config
 // assert a defect at 30 sites no operator can author — the same mistake
 // notAValueList exists to avoid.
 //
+// A SEVENTH spelling WAS added, by #6693: `leaf <v1> { <v2>; }` — a value in
+// the identifier slot BESIDE a block (F-hier-mixed). It is the only spelling
+// that puts values in BOTH AST slots of one node, Keys[1:] AND Children, and
+// every other spelling puts them in exactly one. An either/or reader
+// (`Keys` OR children, never both) therefore agrees with itself across A-E and
+// drops the tail only here.
+//
+// That gap is why #6693's five NAT arms survived this gate. A previous
+// investigation enumerated A-E, found perfect agreement, and recorded that the
+// mixed shape "is not reachable from any config spelling I can author" — a
+// conclusion consistent with its own enumeration and wrong about the grammar.
+// It is not reachable from FLAT-SET (SetPath emits a leaf at the same level for
+// a `multi` leaf and never descends), which is what that enumeration mostly
+// covered; hierarchical text reaches it directly.
+//
+// Adding it moved exactly ONE site beyond the five it was added for, and that
+// site is not a defect: see mixedChildIsAModifierBlock.
+//
 // This gate also sees ONE DIRECTION. It detects a compiler DROPPING a value. It
 // cannot detect the opposite defect — a reader PROMOTING a per-value modifier
 // keyword into the value list, the hazard #6690 had to avoid — and no detector
@@ -209,6 +227,34 @@ var knownSpellingInconsistencies = map[string]string{
 	// its defect: #6687, #6688, #6692, #6695, #6697, #7126. Adding a row is the
 	// THIRD response to a gate failure and the rarest — see the header: fix the
 	// read, or classify the leaf as not-a-value-list with a verified reason.
+}
+
+// ---------------------------------------------------------------------------
+// Sites where the MIXED spelling's child slot is a MODIFIER position, not a
+// second value (#6693).
+//
+// The F-hier-mixed spelling authors `<leaf> <v1> { <v2>; }`. For most value
+// leaves that is two members of one list, which is exactly what makes it able
+// to catch an either/or reader. For a leaf whose grammar puts a MODIFIER BLOCK
+// under an authored value, the child is not a member at all and dropping it is
+// correct — so the F verdict carries no information and is excluded from the
+// comparison for that site.
+//
+// This is a THIRD category, deliberately separate from both neighbours below
+// and above: notAValueList says the leaf is not a list in ANY spelling, and
+// knownSpellingInconsistencies asserts a tracked DEFECT. Neither is true here,
+// and using either would state something false.
+//
+// Every entry is verified by reading where the child tokens land, not assumed
+// from the name.
+// ---------------------------------------------------------------------------
+var mixedChildIsAModifierBlock = map[string]string{
+	// archiveSiteEntries (compiler_system.go): "Any CHILD here is a modifier
+	// block for the last authored site (`archive-sites a { password S; }`),
+	// never an additional site." An unrecognized modifier is ignored, which is
+	// what the F verdict sees as a drop. Verified against that function, whose
+	// value-on-Keys branch returns before the children are read at all.
+	"system archival configuration archive-sites": "child is a per-site modifier block (`{ password S; }`), not a second site",
 }
 
 // ---------------------------------------------------------------------------
@@ -485,7 +531,7 @@ func gateCompileSet(cmds []string) (string, error) {
 	return gateMarshal(cfg)
 }
 
-var gateSpellingsMulti = []string{"A-hier-bracket", "B-hier-block", "C-hier-repeat", "D-set-bracket", "E-set-repeat"}
+var gateSpellingsMulti = []string{"A-hier-bracket", "B-hier-block", "C-hier-repeat", "D-set-bracket", "E-set-repeat", "F-hier-mixed"}
 
 // gateSpellingsScalar omits the REPEATED spellings. For a leaf the schema marks
 // multi: false, a repeated statement legitimately REPLACES (last write wins), so
@@ -543,6 +589,32 @@ func spellingVerdicts(g gateLeaf, v1, v2 string) map[string]string {
 			func() (string, error) { return gateCompileSet([]string{flat + " " + v1}) },
 			func() (string, error) { return gateCompileSet([]string{flat + " " + v1, flat + " " + v2}) },
 		},
+		// #6693: a value in the IDENTIFIER slot beside a block. It is the only
+		// spelling that puts values in BOTH AST slots of one node — Keys[1:]
+		// AND Children — and every spelling above puts them in exactly one, so
+		// an either/or reader (`Keys` OR children, never both) agrees with
+		// itself across A-E and drops the tail here.
+		//
+		// That gap is why #6693 survived this gate. A previous investigation
+		// enumerated A-E, found perfect agreement, and recorded that the mixed
+		// shape "is not reachable from any config spelling I can author" — a
+		// conclusion consistent with its own enumeration and wrong about the
+		// grammar. Adding the spelling is the durable half of that fix: the
+		// class is otherwise invisible to the one gate designed to find it.
+		//
+		// The zero-value form has no mixed spelling (there is nothing to put in
+		// the identifier slot), so it reuses the block form's empty body. That
+		// only feeds the inert-leaf check, which asks whether the FIRST value
+		// changed anything.
+		"F-hier-mixed": {
+			func() (string, error) { return gateCompileBrace(gateBraceConfig(g.path, g.leaf+" { }")) },
+			func() (string, error) {
+				return gateCompileBrace(gateBraceConfig(g.path, fmt.Sprintf("%s %s;", g.leaf, v1)))
+			},
+			func() (string, error) {
+				return gateCompileBrace(gateBraceConfig(g.path, fmt.Sprintf("%s %s { %s; }", g.leaf, v1, v2)))
+			},
+		},
 	}
 	state := map[string]string{}
 	for _, name := range gateSpellingsMulti {
@@ -595,6 +667,19 @@ func TestSchemaSpellingDifferentialGate(t *testing.T) {
 			cmpSet := gateSpellingsScalar
 			if g.multi {
 				cmpSet = gateSpellingsMulti
+			}
+			// #6693: a leaf whose CHILD slot is a modifier position rather than
+			// another value has no meaningful mixed-spelling verdict — see
+			// mixedChildIsAModifierBlock. Drop F rather than allowlisting the
+			// site, because an allowlist row asserts a DEFECT and there is none.
+			if _, modifier := mixedChildIsAModifierBlock[g.siteKey()]; modifier {
+				var without []string
+				for _, n := range cmpSet {
+					if n != "F-hier-mixed" {
+						without = append(without, n)
+					}
+				}
+				cmpSet = without
 			}
 			var flags []bool
 			inert := 0


### PR DESCRIPTION
Closes #6693

## The defect

Five NAT `match` address arms read the node with an **either/or** — `Keys[1:]` **OR** the children, never both — while the four SIBLING arms in the same switch already read both. It is the #4121 defect, fixed there for `security policies … match`, at five NAT sites that were not swept at the time.

The reachable input is a value in the **identifier slot beside a block**:

```
match { source-address 10.0.0.0/8 { 192.0.2.0/24; } }
  -> Keys=["source-address","10.0.0.0/8"]  Children=[["192.0.2.0/24"]]
```

`parseStatement`'s `case TokenLBrace` keeps every key token AND the block, so `len(m.Keys) >= 2` is true and the `else if` is **structurally unreachable**. It commits CLEAN: `setSchema` types these leaves `args: 1, multi: true, children: nil` with no validator, in an open-world subtree, so the schema walker has nothing to reject.

The issue's own prior investigation enumerated the bracket, compact, block, flat-set-bracket and flat-set-repeat spellings, found perfect agreement, and recorded that the shape "is not reachable from any config spelling I can author" and that a fix "would be unfalsifiable". The enumeration was sound and **not exhaustive** — it never tried a value in the identifier slot beside a block. That spelling is genuinely unreachable from flat-set (for a `multi` leaf with no children `SetPath` emits a leaf at the same level and never descends), which is why the conclusion was self-consistent. Hierarchical text — a config file, `load merge`, `load override`, a peer-synced tree — reaches it directly.

## Three independent consequences

1. **The rule matches LESS traffic than authored.** For source NAT the dropped sources egress untranslated (an internal address on the wire); for destination NAT the dropped prefixes miss the translation.
2. **The dropped value ESCAPES the strict literal gates** — three of them cover the five arms (`validateNATMatchAddressLiteralsStrict` #7145, `validateDestinationNATAddressesStrict` #3228, and the static-NAT gate) — because every one reasons from the COMPILED list. A malformed prefix in the child slot committed clean.
3. **One config text had TWO MEANINGS across a save/load cycle.** `Format()` re-renders the mixed shape verbatim; `FormatSet()` — the spelling the configstore persists and the CLI replays — renders it PACKED (`set … match source-address 10.0.0.0/8 192.0.2.0/24`). Both re-parse to a one-slot shape the either/or reader read correctly, so the rule silently **widened on the next reboot** while `show | compare` reported no change.

## The reader

`natMatchAddressValues` accumulates both slots and reads every **KEY** of each child rather than `child.Name()` (#6714 / #7126). It is deliberately NEITHER existing reader, and both alternatives were **measured**:

- **not `firewallMatchValues`** (what the siblings use): it DROPS empty tokens. Switching these arms to it turned **five #7216 subtests from reject to commit-clean**, because `match source-address ""` no longer reached the compiled list the static-NAT gate reasons from — a fail-open introduced by the fix for a fail-closed drop.
- **not `multiLeafAuthoredValues`** (#6673): it synthesizes ONE empty for a value-less node to keep `values[0] == nodeVal(n)` total for a SELECTION leaf. These arms have no such invariant, and a bare `source-address;` compiling to `[""]` would make the Rust `source_constrained` flag true over a prefix that parses as nothing — the rule then matches NOTHING.

**No new gate, deliberately.** The three strict gates already reject a malformed tail once it reaches the compiled list, and their tolerant counterparts already accept it, so widening the reader widens all five validators at once and the #1960 no-brick split is preserved without a new `lenient*` opt. A box can already hold a committed config whose tail never reached a gate, and `FormatSet` renders it back in the packed spelling, so the tolerant load MUST keep accepting it. Both legs asserted per arm.

## The durable half is the gate

`TestSchemaSpellingDifferentialGate` gains a **seventh spelling**, `F-hier-mixed` (`leaf <v1> { <v2>; }`) — the only spelling that puts values in BOTH AST slots of one node, which is exactly what an either/or reader cannot see, and the gap that let these five arms survive the one gate designed to find them.

Across the whole schema it moved **ONE** site beyond the five it was added for, and that site is not a defect: `system archival configuration archive-sites` puts a per-site MODIFIER block under an authored value (`archive-sites a { password S; }`), so its child is not a member and dropping it is correct. Recorded in a third category, `mixedChildIsAModifierBlock` — separate from `notAValueList` (not a list in ANY spelling) and `knownSpellingInconsistencies` (a tracked DEFECT), because neither is true here and using either would state something false.

## Tests

`pkg/config/nat_match_mixed_shape_6693_test.go`, **all five arms**:

- the mixed shape under STRICT and TOLERANT compile, asserted to **agree with each other first** and to equal the authored pair second;
- **five spellings** (mixed, bracket, compact, block, repeat) asserted to agree with **each other**, then with the authored pair — pinning one spelling to a hand-written expectation would encode which side is trusted, and in this family the trusted side has been the broken one (#7457);
- the **persistence round-trip**: the authored tree, its `Format()` re-reading and its `FormatSet()` re-reading must all agree;
- a malformed tail **rejected strict** with the offending value named, and **accepted tolerant** with both values carried through;
- the scalar back-compat field still takes the FIRST value;
- reader-level guards for the two rejected alternatives (an authored empty survives in both slots; a value-less leaf synthesizes nothing).

The static-NAT fixture carries a valid `match destination-address` sibling: without it the #7216 "selected external prefix is MISSING" gate fires first and its rejection is **indistinguishable from the gate under test firing on the tail** — the exact masking hazard the issue names.

## Mutation matrix

Single-instance (`flock`) harness. Every cell: worktree asserted CLEAN before mutation, mutation asserted APPLIED (`git diff --stat` non-empty), `go build ./...` clean before running, exit code read from a FILE, **full `pkg/config` suite at `-count=1` with no `-run` filter** (6406 `=== RUN` lines collected per cell, so a build-break cannot masquerade as a pass), worktree asserted restored after.

U1–U5 restore the **verbatim pre-fix bytes** one arm at a time (`git apply -R` of that arm's own hunk from `git diff <base> HEAD`) — never a compound revert, so each cell LOCALISES instead of masking a sibling.

| cell | mutation | result — which assertion fired |
|---|---|---|
| **U1** | verbatim pre-fix either/or at source-NAT `source-address` | RED — all four tests at subtest `source-nat/source-address`, **plus `TestSchemaSpellingDifferentialGate`** |
| **U2** | same, source-NAT `destination-address` | RED — all four at `source-nat/destination-address`, plus the differential gate |
| **U3** | same, dest-NAT `destination-address` | RED — all four at `destination-nat/destination-address`, plus the differential gate |
| **U4** | same, dest-NAT `source-address` | RED — all four at `destination-nat/source-address`, plus the differential gate |
| **U5** | same, static-NAT `source-address` | RED — all four at `static-nat/source-address`, plus the differential gate |

The differential gate redding in U1–U5 is the proof that the durable half works: it catches the class **independently of the dedicated tests**.

| cell | mutation | result — which assertion fired |
|---|---|---|
| **U6** | **TIGHTEN** — reader DROPS empty tokens (behave like `firewallMatchValues`) | RED `TestNATMatchReaderKeepsAnAuthoredEmpty_6693` (all three slots) **+ 5 subtests of the pre-existing `TestStaticNATBlankExternalPrefix7216RejectsEverySlot`** — the exact fail-open the commit message says was measured |
| **U7** | **TIGHTEN** — read `vn.Name()` instead of every child key | RED `TestNATMatchReaderTakesEveryChildKey_6693` (the #6714/#7126 property) |
| **U8** | **allowlist necessity** — delete the `mixedChildIsAModifierBlock` exclusion | RED `TestSchemaSpellingDifferentialGate`, naming `system archival configuration archive-sites` with `spellings: A=keep B=keep C=keep D=keep E=keep F=drop` — the entry is load-bearing and scoped to exactly that one site |
| **U9** | **WIDEN** — synthesize an empty for a value-less leaf (behave like `multiLeafAuthoredValues`) | RED `TestNATMatchReaderSynthesizesNothing_6693` |

U6/U7 narrow the reader and U9 widens it, so the matrix constrains it from **both** directions rather than only proving "something was deleted". U8 is the paired necessary/sufficient cell for the allowlist row: with the exclusion the gate is green (baseline), without it the gate reds and names exactly the one site the row claims.

Coverage context from the same runs: `TestSchemaSpellingCoverage` reports **1019 value-bearing leaves** in `setSchema`, 24 non-value-list exclusions, **0** allowlisted known-inconsistent sites — the seventh spelling was added across all of them and produced exactly one new classification.

Worktree asserted clean and the full `pkg/config` suite re-run GREEN at `01edf3f56` after the matrix, so no cell leaked.

## Scope

`pkg/config` only. No cluster / VRRP / session-sync / failover code touched; no `userspace-dp` binary or shim `.o` moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkfVhT4Y3UDa22mU7uoCVt
