### PR TITLE
userspace-dp: drop NextTableUnsupported instead of reinjecting it, and route both refusal points through one admit (#6664)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103158,3 +103158,41 @@ prose edit above them added. No diff falls in the new test body.
     pkg/config/compiler_ipsec_plaintext_warn.go,
     pkg/config/compiler_wireguard_plaintext_warn_5618_test.go,
     docs/userspace-dataplane-gaps.md
+
+## 2026-08-22 — #6664 NextTableUnsupported fails closed + single-door admit
+- **Action**: Removed `NextTableUnsupported` from `is_slow_path_eligible`, so an
+  inter-VRF next-table chain the helper cannot resolve (over-deep or cyclic) is
+  DROPPED instead of reinjected to the kernel FIB, which forwarded it with no
+  zone policy, session, NAT or screen. Collapsed the two refusal points (the
+  filtered `maybe_reinject_slow_path` wrapper and the `poll_descriptor`
+  chokepoint) into one `slow_path_admit` function so the predicate and the
+  fail-closed accounting cannot disagree, and added
+  `next_table_unsupported_drops` — exported as
+  `xpf_userspace_binding_next_table_unsupported_drops_total` — because the deny
+  freezes the accept-path counter the signal used to live on. Corrected two
+  stale enumerations of the unfiltered-reinject caller set (the code said ONE,
+  the architecture doc said TWO and named the wrong pair) and added a source
+  guard that reds if a second production caller of the predicate appears — the
+  `poll_descriptor` chokepoint is not reachable by any behavioural test in the
+  crate, which is how the pre-#6664 duplicated accounting survived a mutation.
+  NoRoute and LocalDelivery — the attacker-steerable legs — are filed as #7480.
+- **File(s)**: userspace-dp/src/afxdp/types/forwarding.rs,
+  userspace-dp/src/afxdp/tx/dispatch/slow_path.rs,
+  userspace-dp/src/afxdp/tx/dispatch/mod.rs,
+  userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/afxdp/binding_state/mod.rs,
+  userspace-dp/src/afxdp/binding_state/snapshot.rs,
+  userspace-dp/src/afxdp/binding_state/tests/tx_inbox.rs,
+  userspace-dp/src/afxdp/coordinator/reconcile/reset.rs,
+  userspace-dp/src/afxdp/coordinator/refresh_bindings.rs,
+  userspace-dp/src/afxdp/worker/mod.rs,
+  userspace-dp/src/afxdp/forwarding_build/tests.rs,
+  userspace-dp/src/afxdp/tests_slow_path_disposition.rs,
+  userspace-dp/src/protocol/binding.rs,
+  userspace-dp/tests/fixtures/protocol_wire_v1.json,
+  userspace-dp/tests/slow_path_admit_single_site_6664.rs (new),
+  pkg/api/metrics.go, pkg/api/metrics_descriptors_binding.go,
+  pkg/api/metrics_userspace_slowpath.go,
+  pkg/api/metrics_slowpath_reinject_7409_test.go,
+  pkg/dataplane/userspace/protocol_binding.go,
+  docs/userspace-dataplane-architecture.md

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -2614,18 +2614,40 @@ is [`userspace-dataplane-gaps.md`](userspace-dataplane-gaps.md).
   `docs/research/3616-ipsec-host-inbound/plan.md`.
 - Packets failing forwarding resolution can enter the bounded slow path,
   but ONLY for the slow-path-eligible dispositions: `LocalDelivery`,
-  `NoRoute`, `MissingNeighbor`, and `NextTableUnsupported`
+  `NoRoute`, and `MissingNeighbor`
   (`ForwardingDisposition::is_slow_path_eligible`, the single source of
-  truth shared by the filtered `maybe_reinject_slow_path` wrapper and the
-  trailing chokepoint in `poll_binding_process_descriptor`). `PolicyDenied`,
-  `HAInactive`, and `DiscardRoute` are NOT eligible — reinjecting them
-  would hand the packet to the kernel FIB and silently bypass a zone-policy
-  DENY / HA gate / discard route (#1913). They are dropped (counted by
-  `record_forwarding_disposition`, recycled) instead. The raw
-  `maybe_reinject_slow_path_from_frame` primitive does NOT apply the
-  filter; its two intentional unfiltered callers (the FabricRedirect-Owned
-  fallback in `tx/dispatch/mod.rs` and the ForwardCandidate build-failure
-  fallback in `tx/dispatch/slow_path.rs`) own the eligibility decision.
+  truth). `PolicyDenied`, `HAInactive`, `DiscardRoute` and — since #6664 —
+  `NextTableUnsupported` are NOT eligible: reinjecting them would hand the
+  packet to the kernel FIB and silently bypass a zone-policy DENY / HA gate
+  / discard route (#1913), or forward an unresolvable inter-VRF next-table
+  chain with no zone policy, session, NAT or screen (#6664). They are
+  dropped (counted by `record_forwarding_disposition`, recycled) instead.
+  `NextTableUnsupported` additionally carries its own fail-closed drop
+  counter, `next_table_unsupported_drops` — exported as
+  `xpf_userspace_binding_next_table_unsupported_drops_total` — because the
+  deny silences the accept-path counter it used to bump
+  (`slow_path_next_table_packets`), which is still exported for existing
+  dashboards but no longer advances.
+- Both refusal points — the filtered `maybe_reinject_slow_path` wrapper and
+  the trailing chokepoint in `poll_binding_process_descriptor` — route
+  through ONE function, `slow_path_admit` (#6664), so the predicate and the
+  accounting cannot disagree about a frame. Before that the accounting was
+  duplicated per caller, and a mutation deleting the `poll_descriptor` copy
+  passed the whole suite because no test drives that function.
+- The raw `maybe_reinject_slow_path_from_frame` primitive does NOT apply the
+  filter. It has exactly TWO intentional unfiltered non-test callers, and
+  neither can carry a disposition the predicate would refuse:
+  the ForwardCandidate build-failure fallback in `tx/dispatch/slow_path.rs`
+  (reached only from the forward-frame TX dispatch, so the disposition is
+  structurally `ForwardCandidate` or `FabricRedirect`, and #1946 drops the
+  latter fail-closed before this point); and the host-terminated IPsec
+  passthrough in `poll_stages.rs`, which passes a SYNTHETIC decision whose
+  disposition is the literal `LocalDelivery`. This paragraph previously
+  named the pair as the `tx/dispatch/mod.rs` fabric fallback plus the
+  build-failure fallback — the first had already become a fail-closed drop
+  in #1946 and the IPsec passthrough was never listed. The enumeration
+  matters: it is the whole argument for why removing a disposition from
+  `is_slow_path_eligible` is enforcement rather than decoration.
   Note that `MissingNeighbor` IS slow-path-eligible, so a denied flow
   must be converted to `PolicyDenied` BEFORE it reaches the gate: the
   MissingNeighbor arm has its own policy evaluation (the main

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -535,6 +535,7 @@ type xpfCollector struct {
 	// forwarded by the kernel with no zone policy, session, NAT or screen.
 	bindingSlowPathNoRoutePackets         *prometheus.Desc
 	bindingSlowPathNextTablePackets       *prometheus.Desc
+	bindingNextTableUnsupportedDrops      *prometheus.Desc
 	bindingSlowPathLocalDeliveryPackets   *prometheus.Desc
 	bindingSlowPathMissingNeighborPackets *prometheus.Desc
 	// #1248: class-specific active flow distribution by egress CoS
@@ -908,6 +909,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.bindingVMinThrottleHardCapOverrides
 	ch <- c.bindingSlowPathNoRoutePackets
 	ch <- c.bindingSlowPathNextTablePackets
+	ch <- c.bindingNextTableUnsupportedDrops
 	ch <- c.bindingSlowPathLocalDeliveryPackets
 	ch <- c.bindingSlowPathMissingNeighborPackets
 	ch <- c.cosActiveFlowCount

--- a/pkg/api/metrics_descriptors_binding.go
+++ b/pkg/api/metrics_descriptors_binding.go
@@ -75,12 +75,25 @@ func (c *xpfCollector) initBindingDescriptors() {
 	)
 	c.bindingSlowPathNextTablePackets = prometheus.NewDesc(
 		"xpf_userspace_binding_slow_path_next_table_packets_total",
-		"Transit frames reinjected to the kernel because they hit an "+
-			"inter-VRF next-table chain the helper does not implement — "+
-			"including an acyclic chain deeper than the eight-table limit "+
-			"(#7409/#6664). Kernel-routable, policy-unevaluated. Unlike "+
-			"no_route an attacker cannot create this condition; it needs an "+
-			"operator config defect.",
+		"RETIRED by #6664 and frozen at its last value: NextTableUnsupported "+
+			"is no longer reinjected to the kernel, so this counter no longer "+
+			"advances. It is still exported so an existing dashboard or alert "+
+			"does not break on a missing series. Use "+
+			"xpf_userspace_binding_next_table_unsupported_drops_total instead — "+
+			"the same packets, now counted where they are dropped.",
+		[]string{"binding_slot", "queue_id", "worker_id", "iface"}, nil,
+	)
+	c.bindingNextTableUnsupportedDrops = prometheus.NewDesc(
+		"xpf_userspace_binding_next_table_unsupported_drops_total",
+		"Transit frames DROPPED fail-closed because they hit an inter-VRF "+
+			"next-table chain the helper cannot resolve — deeper than the "+
+			"eight-table limit, or a cycle (#6664). Before #6664 these were "+
+			"reinjected to the kernel, which forwarded them with no zone "+
+			"policy, session, NAT or screen. Unlike no_route the condition is "+
+			"not transient — no FIB refresh resolves it — so delegating was a "+
+			"standing policy bypass rather than a window. A non-zero value "+
+			"means an operator config defect: an over-deep or cyclic "+
+			"next-table chain. An attacker cannot create this condition.",
 		[]string{"binding_slot", "queue_id", "worker_id", "iface"}, nil,
 	)
 	c.bindingSlowPathLocalDeliveryPackets = prometheus.NewDesc(

--- a/pkg/api/metrics_slowpath_reinject_7409_test.go
+++ b/pkg/api/metrics_slowpath_reinject_7409_test.go
@@ -43,6 +43,14 @@ func collectSlowPathSeries(t *testing.T, c *xpfCollector, status dpuserspace.Pro
 			"slow_path_next_table_packets_total",
 			"slow_path_local_delivery_packets_total",
 			"slow_path_missing_neighbor_packets_total",
+			// #6664. Note this one makes the quoted-fqName anchoring below
+			// load-bearing rather than merely careful: the RETIRED
+			// slow_path_next_table_packets HELP now names
+			// xpf_userspace_binding_next_table_unsupported_drops_total in
+			// prose, to point operators at its replacement. A bare
+			// strings.Contains on the metric name would match that HELP and
+			// attribute the retired series' value to this one.
+			"next_table_unsupported_drops_total",
 		} {
 			// Desc.String() embeds the HELP text as well as the fqName, and
 			// several of these help strings cross-reference the other
@@ -72,8 +80,13 @@ func TestSlowPathReinjectCountersAreEmittedEvenWhenZero(t *testing.T) {
 	}
 
 	got := collectSlowPathSeries(t, c, status)
-	if len(got) != 4 {
-		t.Fatalf("want all 4 reinject series present at zero, got %d: %v", len(got), got)
+	// #6664: five now — the four #7409 reinject series plus the next_table
+	// fail-closed drop. The zero-datapoint property matters MORE for the drop
+	// than for the reinjects: a next_table drop is an operator config defect,
+	// so its steady state is legitimately 0 and the series would otherwise
+	// never appear until the defect already existed.
+	if len(got) != 5 {
+		t.Fatalf("want all 5 slow-path allow-list series present at zero, got %d: %v", len(got), got)
 	}
 	for name, v := range got {
 		if v != 0 {
@@ -95,6 +108,7 @@ func TestSlowPathReinjectCountersMapToTheCorrectSeries(t *testing.T) {
 			SlowPathNextTablePackets:       22,
 			SlowPathLocalDeliveryPackets:   33,
 			SlowPathMissingNeighborPackets: 44,
+			NextTableUnsupportedDrops:      55,
 		}},
 	}
 
@@ -104,6 +118,10 @@ func TestSlowPathReinjectCountersMapToTheCorrectSeries(t *testing.T) {
 		"slow_path_next_table_packets_total":       22,
 		"slow_path_local_delivery_packets_total":   33,
 		"slow_path_missing_neighbor_packets_total": 44,
+		// #6664: the fail-closed drop that replaced the next_table reinject.
+		// Asserted by VALUE, not just present in the series count below, so a
+		// wiring that emitted the wrong field cannot pass.
+		"next_table_unsupported_drops_total": 55,
 	} {
 		if got[name] != want {
 			t.Errorf("%s = %v, want %v", name, got[name], want)
@@ -131,7 +149,9 @@ func TestSlowPathReinjectCountersAreEmittedPerBinding(t *testing.T) {
 	for range ch {
 		n++
 	}
-	if n != 8 {
-		t.Fatalf("want 4 series x 2 bindings = 8 metrics, got %d", n)
+	// #6664 made this five: the four #7409 reinject counters plus the
+	// next_table fail-closed drop that replaced one of them.
+	if n != 10 {
+		t.Fatalf("want 5 series x 2 bindings = 10 metrics, got %d", n)
 	}
 }

--- a/pkg/api/metrics_userspace_slowpath.go
+++ b/pkg/api/metrics_userspace_slowpath.go
@@ -18,7 +18,19 @@ import (
 // reinject counters, split by the disposition that sent the frame to the
 // kernel (#7409).
 //
-// All four have been on the BindingStatus wire since the helper gained them
+// #6664 added a FIFTH series that is not a reinject: NextTableUnsupported left
+// the slow-path allow-list, so it is now dropped fail-closed and counted as
+// `next_table_unsupported_drops`. It is emitted here, beside the four, because
+// it is the same question — what did the slow-path allow-list do with this
+// frame — on the same label set, and because it is the REPLACEMENT signal for
+// `slow_path_next_table_packets`, which is frozen from #6664 onward. Splitting
+// it into its own emitter would put the before and after of one migration in
+// two places. The function keeps its historical `Reinject` name; that name is
+// now a slight over-narrowing rather than a description, and is left alone only
+// because renaming it ripples into a #7409-named test file for no behavioural
+// gain. Naming it here so the drift is recorded rather than silent.
+//
+// The four reinject counters have been on the BindingStatus wire since the helper gained them
 // and are already aggregated with deltas in pkg/monitoriface, but nothing
 // exported them to Prometheus — so a rising reinject rate was visible only in
 // `show`-style status output and reached no alerting. That is what made the
@@ -42,6 +54,7 @@ func (c *xpfCollector) emitBindingSlowPathReinjectCounters(ch chan<- prometheus.
 		}{
 			{c.bindingSlowPathNoRoutePackets, b.SlowPathNoRoutePackets},
 			{c.bindingSlowPathNextTablePackets, b.SlowPathNextTablePackets},
+			{c.bindingNextTableUnsupportedDrops, b.NextTableUnsupportedDrops},
 			{c.bindingSlowPathLocalDeliveryPackets, b.SlowPathLocalDeliveryPackets},
 			{c.bindingSlowPathMissingNeighborPackets, b.SlowPathMissingNeighborPackets},
 		} {

--- a/pkg/dataplane/userspace/protocol_binding.go
+++ b/pkg/dataplane/userspace/protocol_binding.go
@@ -270,9 +270,14 @@ type BindingStatus struct {
 	SlowPathMissingNeighborPackets uint64 `json:"slow_path_missing_neighbor_packets,omitempty"`
 	SlowPathNoRoutePackets         uint64 `json:"slow_path_no_route_packets,omitempty"`
 	SlowPathNextTablePackets       uint64 `json:"slow_path_next_table_packets,omitempty"`
-	SlowPathForwardBuildPackets    uint64 `json:"slow_path_forward_build_packets,omitempty"`
-	SlowPathDrops                  uint64 `json:"slow_path_drops,omitempty"`
-	SlowPathRateLimited            uint64 `json:"slow_path_rate_limited,omitempty"`
+	// NextTableUnsupportedDrops counts NextTableUnsupported frames dropped
+	// fail-closed by the slow-path allow-list (#6664). Since #6664 this is
+	// where the signal lives; SlowPathNextTablePackets above stays on the wire
+	// for older readers but no longer advances.
+	NextTableUnsupportedDrops   uint64 `json:"next_table_unsupported_drops,omitempty"`
+	SlowPathForwardBuildPackets uint64 `json:"slow_path_forward_build_packets,omitempty"`
+	SlowPathDrops               uint64 `json:"slow_path_drops,omitempty"`
+	SlowPathRateLimited         uint64 `json:"slow_path_rate_limited,omitempty"`
 	// TunnelEncapUnresolvedDrops counts tunnel-marked inner packets
 	// dropped at the slow-path chokepoint / pending-neigh exclusion
 	// instead of plaintext kernel reinjection (#1873 R-C/R-E).

--- a/userspace-dp/src/afxdp/binding_state/mod.rs
+++ b/userspace-dp/src/afxdp/binding_state/mod.rs
@@ -370,6 +370,19 @@ pub(in crate::afxdp) struct BindingLiveState {
     /// to the local kernel slow path (a wrong-path / conntrack-poison
     /// hazard; cf. the #1873 R-C `tunnel_encap_unresolved_drops` gate).
     pub(in crate::afxdp) fabric_redirect_unsendable_drops: AtomicU64,
+    /// #6664: `NextTableUnsupported` frames refused by the slow-path
+    /// allow-list and dropped fail-closed.
+    ///
+    /// This counter EXISTS BECAUSE the deny silences another one. Before
+    /// #6664 the disposition was slow-path eligible, so every such packet
+    /// bumped `slow_path_next_table_packets` on the accept path
+    /// (`record_slow_path_accept`) and that counter is exported all the way
+    /// to `xpf_userspace_binding_slow_path_next_table_packets_total`.
+    /// Refusing the reinject without adding this would have driven that
+    /// metric to a permanent zero -- indistinguishable, to an operator,
+    /// from "no such packets ever arrived". The drop is counted here
+    /// instead, so the signal moves rather than disappears.
+    pub(in crate::afxdp) next_table_unsupported_drops: AtomicU64,
     pub(super) kernel_rx_dropped: AtomicU64,
     pub(super) kernel_rx_invalid_descs: AtomicU64,
     pub(super) tx_packets: AtomicU64,
@@ -790,10 +803,21 @@ pub(in crate::afxdp) struct BindingLiveState {
 // difference between them and the runtime cell: the runtime cell can be
 // re-measured green, and these cannot. Removing them is therefore a reviewable
 // act, not cleanup.
+//
+// #6664 re-measured the two offset literals (2152 -> 2160, 2280 -> 2288) when
+// `next_table_unsupported_drops` was added to the cold-counter run above. That
+// is the legitimate case for this guard, and it is worth naming why: the hazard
+// documented above is a `#[cfg(test)]` field, for which production and test
+// builds DISAGREE and so at most one of them can be green at any one pair of
+// literals. This field is unconditional, so both configurations shift by the
+// same 8 bytes and re-measuring makes both green together -- which is the
+// guard reporting a real layout change and being answered, not defeated.
+// `size_of` is unchanged at 2304: the 8 bytes came out of existing tail
+// padding, so the next field added here will move it and should expect to.
 const _: [(); 2304] = [(); std::mem::size_of::<BindingLiveState>()];
 const _: [(); 64] = [(); std::mem::align_of::<BindingLiveState>()];
-const _: [(); 2152] = [(); std::mem::offset_of!(BindingLiveState, pending_tx_admitted)];
-const _: [(); 2280] = [(); std::mem::offset_of!(BindingLiveState, delta_loss_pending)];
+const _: [(); 2160] = [(); std::mem::offset_of!(BindingLiveState, pending_tx_admitted)];
+const _: [(); 2288] = [(); std::mem::offset_of!(BindingLiveState, delta_loss_pending)];
 
 impl BindingLiveState {
     pub(super) fn new() -> Self {
@@ -891,6 +915,7 @@ impl BindingLiveState {
             slow_path_rate_limited: AtomicU64::new(0),
             tunnel_encap_unresolved_drops: AtomicU64::new(0),
             fabric_redirect_unsendable_drops: AtomicU64::new(0),
+            next_table_unsupported_drops: AtomicU64::new(0),
             kernel_rx_dropped: AtomicU64::new(0),
             kernel_rx_invalid_descs: AtomicU64::new(0),
             tx_packets: AtomicU64::new(0),
@@ -1136,6 +1161,20 @@ impl BindingLiveState {
             }
             _ => {}
         }
+    }
+
+    /// #6664: record a `NextTableUnsupported` frame refused by the slow-path
+    /// allow-list and dropped fail-closed.
+    ///
+    /// Called from BOTH refusal sites -- the filtered wrapper
+    /// `maybe_reinject_slow_path` and the trailing chokepoint in
+    /// `poll_descriptor` -- because the two must never disagree about whether
+    /// a refusal was counted. A divergence there is always a bug, never a
+    /// policy difference, so it is one function rather than two agreeing
+    /// increments.
+    pub(in crate::afxdp) fn record_next_table_unsupported_drop(&self) {
+        self.next_table_unsupported_drops
+            .fetch_add(1, Ordering::Relaxed);
     }
 }
 

--- a/userspace-dp/src/afxdp/binding_state/snapshot.rs
+++ b/userspace-dp/src/afxdp/binding_state/snapshot.rs
@@ -155,6 +155,7 @@ impl BindingLiveState {
                 .load(Ordering::Relaxed),
             slow_path_no_route_packets: self.slow_path_no_route_packets.load(Ordering::Relaxed),
             slow_path_next_table_packets: self.slow_path_next_table_packets.load(Ordering::Relaxed),
+            next_table_unsupported_drops: self.next_table_unsupported_drops.load(Ordering::Relaxed),
             slow_path_forward_build_packets: self
                 .slow_path_forward_build_packets
                 .load(Ordering::Relaxed),

--- a/userspace-dp/src/afxdp/binding_state/tests/tx_inbox.rs
+++ b/userspace-dp/src/afxdp/binding_state/tests/tx_inbox.rs
@@ -117,6 +117,13 @@ fn enqueue_tx_owned_below_cap_does_not_touch_overflow_counter() {
 /// `#[cfg(test)]` `AtomicU64` field declared ahead of `pending_tx_admitted`
 /// leaves size and align UNCHANGED (it fits in existing tail slack) and moves
 /// `pending_tx_admitted` 2152 -> 2160; declared last, after
+/// #6664 moved the two OFFSET literals here (2152 -> 2160, 2280 -> 2288) in
+/// lockstep with the `const _` asserts beside the struct, when the production
+/// field `next_table_unsupported_drops` was added to the cold-counter run.
+/// Size and align are unchanged — the 8 bytes came out of tail padding. This
+/// cell is the readable mirror, so it moves WITH those asserts or it is not a
+/// mirror; it is not independent evidence and must never be re-measured alone.
+///
 /// `delta_loss_pending`, it leaves size, align and `pending_tx_admitted`
 /// unchanged and moves `delta_loss_pending` 2280 -> 2288. A size-only guard
 /// calls both of those layout-neutral, and both would be exactly the
@@ -148,14 +155,14 @@ fn admission_attempt_instrument_leaves_four_pinned_layout_values_unchanged_6304(
     );
     assert_eq!(
         std::mem::offset_of!(BindingLiveState, pending_tx_admitted),
-        2152,
+        2160,
         "#6304/#6114: ...nor the OFFSET of the admission counter whose \
          cacheline this is all about. A `cfg(test)` field ahead of it moves \
          this to 2160 while leaving the size assert above satisfied"
     );
     assert_eq!(
         std::mem::offset_of!(BindingLiveState, delta_loss_pending),
-        2280,
+        2288,
         "#6304: ...nor the offset of the last-declared field, which is the \
          sentinel for a `cfg(test)` member appended at the END of the struct — \
          that shape moves this to 2288 and trips nothing else"

--- a/userspace-dp/src/afxdp/coordinator/reconcile/reset.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/reset.rs
@@ -64,6 +64,7 @@ pub(super) fn reset_binding_counters(bindings: &mut [BindingStatus]) {
         binding.slow_path_missing_neighbor_packets = 0;
         binding.slow_path_no_route_packets = 0;
         binding.slow_path_next_table_packets = 0;
+        binding.next_table_unsupported_drops = 0;
         binding.slow_path_forward_build_packets = 0;
         binding.slow_path_drops = 0;
         binding.slow_path_rate_limited = 0;

--- a/userspace-dp/src/afxdp/coordinator/refresh_bindings.rs
+++ b/userspace-dp/src/afxdp/coordinator/refresh_bindings.rs
@@ -148,6 +148,7 @@ fn copy_live_snapshot(binding: &mut BindingStatus, snap: BindingLiveSnapshot) {
     binding.slow_path_missing_neighbor_packets = snap.slow_path_missing_neighbor_packets;
     binding.slow_path_no_route_packets = snap.slow_path_no_route_packets;
     binding.slow_path_next_table_packets = snap.slow_path_next_table_packets;
+    binding.next_table_unsupported_drops = snap.next_table_unsupported_drops;
     binding.slow_path_forward_build_packets = snap.slow_path_forward_build_packets;
     binding.slow_path_drops = snap.slow_path_drops;
     binding.slow_path_rate_limited = snap.slow_path_rate_limited;
@@ -370,6 +371,7 @@ fn zero_unbound_slot(binding: &mut BindingStatus) {
     binding.slow_path_missing_neighbor_packets = 0;
     binding.slow_path_no_route_packets = 0;
     binding.slow_path_next_table_packets = 0;
+    binding.next_table_unsupported_drops = 0;
     binding.slow_path_forward_build_packets = 0;
     binding.slow_path_drops = 0;
     binding.slow_path_rate_limited = 0;

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -6963,3 +6963,110 @@ fn secure_tunnel_unit_ifindex_decides_route_disposition() {
     assert!(r0.disposition.is_slow_path_eligible());
     assert!(r42.disposition.is_slow_path_eligible());
 }
+
+/// #6664: a genuine inter-VRF next-table CYCLE resolves to
+/// `NextTableUnsupported` through the real recursion, and that disposition is
+/// not slow-path eligible.
+///
+/// The chain is built rather than simulated: `inet.0` leaks 172.16/12 into
+/// `blue.inet.0`, which leaks the same prefix back. The walk pushes "inet.0"
+/// onto the visited set, recurses, and the second hop trips
+/// `visited.contains(next_table_name)` — the production cycle check in
+/// `fib.rs`, reached the way a packet reaches it. Passing `depth =
+/// MAX_NEXT_TABLE_DEPTH` directly would land on the same disposition by a
+/// different door and would keep passing if the cycle check were deleted.
+///
+/// Honest scope note. No config can currently put this state into the FIB:
+/// every `next_table`-bearing route the snapshot publishes lives in the GLOBAL
+/// table (`pkg/dataplane/userspace/routes.go` — the global static pass and the
+/// synthetic ip-rule leak pass are the only two producers), and a next-table
+/// authored UNDER a routing-instance is hard-rejected at commit (#5830) and
+/// dropped from the snapshot even on the tolerant load / peer-sync path. So the
+/// recursion is at most one hop, global -> instance, and terminates there. This
+/// test therefore pins DEFENSE-IN-DEPTH, not a live exposure: the safety above
+/// is an emergent property of two guards in another language and package, and
+/// a third producer or one relaxed guard would reopen the bypass silently.
+#[test]
+fn next_table_cycle_resolves_unsupported_and_is_not_slow_path_eligible_6664() {
+    let snapshot = ConfigSnapshot {
+        routes: vec![
+            crate::RouteSnapshot {
+                table: "inet.0".into(),
+                family: "inet".into(),
+                destination: "172.16.0.0/12".into(),
+                next_table: "blue.inet.0".into(),
+                ..Default::default()
+            },
+            crate::RouteSnapshot {
+                table: "blue.inet.0".into(),
+                family: "inet".into(),
+                destination: "172.16.0.0/12".into(),
+                next_table: "inet.0".into(),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+
+    // Premise: both legs of the cycle are actually present. Without this a
+    // snapshot that silently dropped one leg would still reach
+    // NextTableUnsupported — via NoRoute-shaped termination — and the test
+    // would pass for the wrong reason.
+    assert!(
+        state
+            .routes_v4
+            .get("inet.0")
+            .is_some_and(|t| t.iter().any(|r| r.next_table == "blue.inet.0")),
+        "premise broken: the global leg of the cycle is missing"
+    );
+    assert!(
+        state
+            .routes_v4
+            .get("blue.inet.0")
+            .is_some_and(|t| t.iter().any(|r| r.next_table == "inet.0")),
+        "premise broken: the return leg of the cycle is missing"
+    );
+
+    let dst = Ipv4Addr::new(172, 16, 5, 5);
+    let cycled = lookup_forwarding_resolution_v4(&state, None, dst, "inet.0", 0, true, None);
+    assert_eq!(
+        cycled.disposition,
+        ForwardingDisposition::NextTableUnsupported,
+        "an A->B->A next-table cycle must resolve NextTableUnsupported"
+    );
+    assert_eq!(
+        cycled.egress_ifindex, 0,
+        "NextTableUnsupported carries no egress interface — which is why a \
+         zone-PAIR adjudication cannot be computed for it and #6664 fails it \
+         closed instead"
+    );
+    assert!(
+        !cycled.disposition.is_slow_path_eligible(),
+        "a cyclic next-table chain must NOT be handed to the kernel FIB, which \
+         would forward it with no zone policy, session, NAT or screen (#6664)"
+    );
+
+    // Positive control: a destination with no route at all still resolves
+    // NoRoute and REMAINS delegable. Without this, deleting the whole
+    // next-table arm would satisfy the assertions above.
+    let unrouted = lookup_forwarding_resolution_v4(
+        &state,
+        None,
+        Ipv4Addr::new(203, 0, 113, 7),
+        "inet.0",
+        0,
+        true,
+        None,
+    );
+    assert_eq!(
+        unrouted.disposition,
+        ForwardingDisposition::NoRoute,
+        "premise broken: an unrouted destination must resolve NoRoute"
+    );
+    assert!(
+        unrouted.disposition.is_slow_path_eligible(),
+        "NoRoute must STILL delegate to the kernel — it is transient and #7409 \
+         forbids black-holing a destination the kernel can still reach"
+    );
+}

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -5455,7 +5455,7 @@ pub(super) fn poll_binding_process_descriptor(
                     // already counted by record_forwarding_disposition
                     // above and recycled by the recycle_now epilogue
                     // below — no leak, no double-count.
-                    if decision.resolution.disposition.is_slow_path_eligible() {
+                    if slow_path_admit(&binding.live, decision.resolution.disposition) {
                         maybe_reinject_slow_path_from_frame(
                             &worker_ctx.ident,
                             &binding.live,

--- a/userspace-dp/src/afxdp/tests_slow_path_disposition.rs
+++ b/userspace-dp/src/afxdp/tests_slow_path_disposition.rs
@@ -99,11 +99,16 @@ fn slow_path_eligibility_predicate_allow_list() {
     assert!(LocalDelivery.is_slow_path_eligible());
     assert!(NoRoute.is_slow_path_eligible());
     assert!(MissingNeighbor.is_slow_path_eligible());
-    assert!(NextTableUnsupported.is_slow_path_eligible());
     // NOT eligible: must drop, never reinject.
     assert!(!PolicyDenied.is_slow_path_eligible());
     assert!(!HAInactive.is_slow_path_eligible());
     assert!(!DiscardRoute.is_slow_path_eligible());
+    // #6664: NextTableUnsupported left the allow-list. Unlike NoRoute it is
+    // NOT transient -- no FIB refresh resolves an over-deep or cyclic
+    // next-table chain -- so reinjecting it was a STANDING zone-policy bypass
+    // for that config rather than a window, and the #7409 "do not black-hole a
+    // destination the kernel can still reach" argument does not reach it.
+    assert!(!NextTableUnsupported.is_slow_path_eligible());
     // Forward/fabric dispositions never reach the generic slow path.
     assert!(!ForwardCandidate.is_slow_path_eligible());
     assert!(!FabricRedirect.is_slow_path_eligible());
@@ -1064,3 +1069,141 @@ fn syn_cookie_counters_hot_path_accumulate_in_batch() {
 // still forwards, is NOT flow-cached, and self-heals below cap), I6
 // (refused seed is recycled, not buffered), I14 (NAT64 refusal drops).
 
+
+
+// #6664: NextTableUnsupported is DROPPED by the filtered wrapper and counted,
+// and NoRoute still DELEGATES. Both halves are asserted in one test against
+// the same harness because the failure this guards against is not "the deny
+// does not work" -- it is "the deny was applied to the wrong disposition", and
+// only the pair can see that. A change that denied both would satisfy a
+// deny-only test.
+//
+// The two dispositions produce OPPOSITE counter signatures, which is what
+// makes the assertions mutation-sensitive:
+//   - filtered at the top   -> slow_path_drops == 0, no exception,
+//                              next_table_unsupported_drops == 1
+//   - proceeds past the top -> slow_path_drops == 1, an exception recorded
+//                              (there is no reinjector in this harness),
+//                              next_table_unsupported_drops == 0
+// Restoring NextTableUnsupported to the allow-list flips it onto the second
+// signature and reds on an assertion rather than on a build error.
+#[test]
+fn next_table_unsupported_is_dropped_and_counted_no_route_still_delegates_6664() {
+    struct Case {
+        disposition: ForwardingDisposition,
+        filtered: bool,
+    }
+    for case in [
+        Case {
+            disposition: ForwardingDisposition::NextTableUnsupported,
+            filtered: true,
+        },
+        Case {
+            disposition: ForwardingDisposition::NoRoute,
+            filtered: false,
+        },
+    ] {
+        let disposition = case.disposition;
+        let frame =
+            build_icmp_echo_frame_v4(Ipv4Addr::new(10, 0, 61, 102), Ipv4Addr::new(1, 1, 1, 1), 64);
+        let mut area = MmapArea::new(4096).expect("mmap");
+        area.slice_mut(0, frame.len())
+            .expect("slice")
+            .copy_from_slice(&frame);
+        let local_tunnel_reinjectors = Arc::new(ArcSwap::from_pointee(BTreeMap::new()));
+
+        let binding = BindingIdentity {
+            slot: 3,
+            queue_id: 2,
+            worker_id: 1,
+            interface: Arc::<str>::from("ge-0-0-1"),
+            ifindex: 5,
+        };
+        let live = BindingLiveState::new();
+        let recent_exceptions = Arc::new(Mutex::new(ExceptionEventRing::new()));
+        let meta = UserspaceDpMeta {
+            magic: USERSPACE_META_MAGIC,
+            version: USERSPACE_META_VERSION,
+            length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+            l3_offset: 14,
+            l4_offset: 34,
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_ICMP,
+            ..UserspaceDpMeta::default()
+        };
+        // egress_ifindex 0 mirrors what the FIB actually builds for both of
+        // these dispositions (there is no egress interface), so the harness
+        // is not quietly kinder to them than production is.
+        let decision = SessionDecision {
+            resolution: ForwardingResolution {
+                disposition,
+                local_ifindex: 0,
+                egress_ifindex: 0,
+                tx_ifindex: 0,
+                tunnel_endpoint_id: 0,
+                next_hop: Some(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))),
+                neighbor_mac: None,
+                src_mac: None,
+                tx_vlan_id: 0,
+            },
+            nat: NatDecision::default(),
+        };
+
+        maybe_reinject_slow_path(
+            &binding,
+            &live,
+            None,
+            &local_tunnel_reinjectors,
+            &area,
+            XdpDesc {
+                addr: 0,
+                len: frame.len() as u32,
+                options: 0,
+            },
+            meta,
+            decision,
+            &recent_exceptions,
+            &ForwardingState::default(),
+        );
+
+        let drops = live.next_table_unsupported_drops.load(Ordering::Relaxed);
+        let slow_path_drops = live.slow_path_drops.load(Ordering::Relaxed);
+        let exception_seen = !recent_exceptions.lock().expect("exceptions").is_empty();
+
+        if case.filtered {
+            assert_eq!(
+                drops, 1,
+                "{disposition:?} must be counted as a fail-closed drop so the signal \
+                 moves to next_table_unsupported_drops instead of vanishing with the \
+                 accept-path counter it used to bump",
+            );
+            assert_eq!(
+                slow_path_drops, 0,
+                "{disposition:?} is filtered by the allow-list before any slow-path \
+                 drop accounting",
+            );
+            assert!(
+                !exception_seen,
+                "{disposition:?} is filtered cleanly, with no slow-path exception",
+            );
+        } else {
+            assert_eq!(
+                drops, 0,
+                "{disposition:?} must NOT be counted as a next-table drop -- the #6664 \
+                 deny is scoped to one disposition, not to the slow path generally",
+            );
+            assert_eq!(
+                slow_path_drops, 1,
+                "{disposition:?} must still DELEGATE: it proceeds past the allow-list \
+                 and is only dropped here because this harness has no reinjector. If \
+                 this is 0 the packet was filtered out, i.e. NoRoute stopped being \
+                 slow-path eligible -- the #7409 black-hole regression.",
+            );
+            assert!(
+                exception_seen,
+                "{disposition:?} proceeded into the slow-path body, which records an \
+                 exception when no reinjector is configured",
+            );
+        }
+    }
+}

--- a/userspace-dp/src/afxdp/tx/dispatch/mod.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/mod.rs
@@ -12,7 +12,8 @@
 //                        resolve_tx_binding_ifindex,
 //                        and the slot-resolution helpers).
 // - `slow_path`       — handle_forward_build_failure,
-//                       maybe_reinject_slow_path*,
+//                       maybe_reinject_slow_path*, slow_path_admit
+//                       (the single admit/refuse decision, #6664),
 //                       extract_l3_packet* family. All marked
 //                       #[cold] #[inline(never)] per AGY round-2
 //                       finding D.
@@ -53,7 +54,7 @@ use shared_recycle::{
 };
 pub(in crate::afxdp) use slow_path::{
     extract_l3_packet_with_nat, handle_forward_build_failure, maybe_reinject_slow_path,
-    maybe_reinject_slow_path_from_frame,
+    maybe_reinject_slow_path_from_frame, slow_path_admit,
 };
 // pub(in crate::afxdp::tx) was previously pub(super) on the
 // extract_l3_packet[_from_frame] family; the re-export keeps the

--- a/userspace-dp/src/afxdp/tx/dispatch/slow_path.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/slow_path.rs
@@ -67,9 +67,13 @@ pub(in crate::afxdp) fn handle_forward_build_failure(
     // SHARED `fabric_redirect_unsendable_drops` counter (distinct
     // exception reason for path observability). This also keeps the
     // documented invariant true: after #1946 the only intentional
-    // unfiltered caller of the raw primitive is the ForwardCandidate
-    // build-failure reinject below (ForwardCandidate IS a route the
-    // kernel may legitimately serve).
+    // unfiltered caller of the raw primitive ON A RESOLVED DISPOSITION is
+    // the ForwardCandidate build-failure reinject below (ForwardCandidate
+    // IS a route the kernel may legitimately serve). #6664 corrects the
+    // scope of that sentence: `poll_stages.rs` also calls the raw
+    // primitive unfiltered, but with a SYNTHETIC `LocalDelivery` decision
+    // for host-terminated IPsec passthrough, so it never carries a
+    // resolved disposition past the predicate.
     if decision.resolution.disposition == ForwardingDisposition::FabricRedirect {
         live.fabric_redirect_unsendable_drops
             .fetch_add(1, Ordering::Relaxed);
@@ -100,6 +104,39 @@ pub(in crate::afxdp) fn handle_forward_build_failure(
     }
 }
 
+/// #1913/#6664: the ONE place that asks whether a disposition may be handed to
+/// the kernel slow path, and the one place a refusal is accounted.
+///
+/// Returns true to admit. On a refusal it records the per-disposition
+/// fail-closed drop, which is why this is a function rather than two calls to
+/// `is_slow_path_eligible`: the predicate and the accounting must never
+/// disagree about a frame. Both refusal points -- this module's filtered
+/// wrapper and the trailing chokepoint in `poll_descriptor` -- route through
+/// here, so there is a single site to bind and a single site to get wrong.
+///
+/// Before #6664 the accounting lived at each caller. That is a divergence that
+/// could only ever be a bug, never a policy difference, and it showed up as one
+/// immediately: a mutation deleting the `poll_descriptor` copy passed the whole
+/// suite, because no test drives that function. Collapsing the two sites into
+/// one is what makes the behaviour testable at all.
+pub(in crate::afxdp) fn slow_path_admit(
+    live: &BindingLiveState,
+    disposition: ForwardingDisposition,
+) -> bool {
+    if disposition.is_slow_path_eligible() {
+        return true;
+    }
+    // #6664: NextTableUnsupported left the allow-list, so its refusal is
+    // counted here. Without this the signal would vanish with the accept-path
+    // counter it used to bump (`slow_path_next_table_packets`), which is
+    // exported to Prometheus and would have frozen at zero -- to an operator,
+    // indistinguishable from "no such packets ever arrived".
+    if disposition == ForwardingDisposition::NextTableUnsupported {
+        live.record_next_table_unsupported_drop();
+    }
+    false
+}
+
 #[cold]
 #[inline(never)]
 pub(in crate::afxdp) fn maybe_reinject_slow_path(
@@ -119,7 +156,7 @@ pub(in crate::afxdp) fn maybe_reinject_slow_path(
     // disposition the predicate rejects (PolicyDenied / HAInactive /
     // DiscardRoute / ForwardCandidate / FabricRedirect) must be dropped,
     // never reinjected to the kernel FIB.
-    if !decision.resolution.disposition.is_slow_path_eligible() {
+    if !slow_path_admit(live, decision.resolution.disposition) {
         return;
     }
     let Some(frame) = area.slice(desc.addr as usize, desc.len as usize) else {

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -1186,9 +1186,8 @@ impl ForwardingDisposition {
     ///     try, rate-limited.
     ///   - `MissingNeighbor`: route exists, ARP/NDP unresolved; the kernel
     ///     can resolve and forward (the userspace prober runs in parallel).
-    ///   - `NextTableUnsupported`: inter-VRF next-table the helper does not
-    ///     implement; defer to the kernel FIB.
     ///
+
     /// NOT eligible (drop — do NOT reinject):
     ///   - `PolicyDenied`: a zone-policy DENY. Reinjecting would silently
     ///     bypass the firewall by forwarding the packet via the kernel FIB
@@ -1198,6 +1197,33 @@ impl ForwardingDisposition {
     ///     (duplicate/asymmetric forwarding, wrong-node plaintext send).
     ///   - `DiscardRoute`: matched a discard/reject route whose entire
     ///     purpose is to drop the traffic.
+    ///   - `NextTableUnsupported`: an inter-VRF next-table chain the helper
+    ///     cannot resolve — deeper than `MAX_NEXT_TABLE_DEPTH`, or a cycle
+    ///     (`fib.rs`). Reinjecting handed it to the kernel FIB, which forwards
+    ///     with no zone policy, session, NAT or screen (#6664).
+    ///
+    ///     Unlike `NoRoute` this is NOT transient, so the #7409 "do not
+    ///     black-hole a destination the kernel can still reach" argument does
+    ///     not apply: no FIB refresh resolves an over-deep or cyclic chain, so
+    ///     delegating it was a STANDING policy bypass for that config rather
+    ///     than a window. Failing closed matches the posture this codebase
+    ///     already takes when the dataplane cannot represent a config.
+    ///
+    ///     This is defense-in-depth, not a live exposure fix, and the
+    ///     distinction is worth stating honestly: no config that reaches the
+    ///     dataplane can currently produce this disposition. Every
+    ///     `next_table`-bearing route in the FIB lives in the GLOBAL table --
+    ///     the only two producers are the global static-route pass and the
+    ///     synthetic ip-rule leak pass, and a next-table authored UNDER a
+    ///     routing-instance is hard-rejected at commit (#5830) and dropped
+    ///     from the snapshot even on the tolerant load / peer-sync path
+    ///     (`pkg/dataplane/userspace/routes.go`). So the recursion is at most
+    ///     one hop, global -> instance, and it terminates there: neither the
+    ///     depth cap nor a cycle is reachable. That safety is an EMERGENT
+    ///     property of two guards in a different language and package, not an
+    ///     invariant this predicate enforces -- a third `next_table` producer,
+    ///     or one relaxed guard, would silently reopen the bypass. Fail closed
+    ///     here so the dataplane's own posture is correct on its own terms.
     ///   - `ForwardCandidate` / `FabricRedirect`: handled by the forward /
     ///     fabric path, never the generic slow path. The ONE intentional
     ///     unfiltered `_from_frame` caller — the ForwardCandidate
@@ -1213,7 +1239,6 @@ impl ForwardingDisposition {
             ForwardingDisposition::LocalDelivery
                 | ForwardingDisposition::NoRoute
                 | ForwardingDisposition::MissingNeighbor
-                | ForwardingDisposition::NextTableUnsupported
         )
     }
 }

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -1555,6 +1555,8 @@ pub(crate) struct BindingLiveSnapshot {
     /// #1946 FabricRedirect-unsendable fail-closed drop counter (see
     /// umem/mod.rs).
     pub(crate) fabric_redirect_unsendable_drops: u64,
+    /// #6664 NextTableUnsupported fail-closed drop counter.
+    pub(crate) next_table_unsupported_drops: u64,
     pub(crate) kernel_rx_dropped: u64,
     pub(crate) kernel_rx_invalid_descs: u64,
     pub(crate) tx_packets: u64,

--- a/userspace-dp/src/protocol/binding.rs
+++ b/userspace-dp/src/protocol/binding.rs
@@ -617,6 +617,12 @@ pub(crate) struct BindingStatus {
     pub slow_path_no_route_packets: u64,
     #[serde(rename = "slow_path_next_table_packets", default)]
     pub slow_path_next_table_packets: u64,
+    /// #6664: NextTableUnsupported frames dropped fail-closed by the
+    /// slow-path allow-list. Since #6664 this is where the signal lives;
+    /// `slow_path_next_table_packets` above stays on the wire for older
+    /// readers but no longer advances.
+    #[serde(rename = "next_table_unsupported_drops", default)]
+    pub next_table_unsupported_drops: u64,
     #[serde(rename = "slow_path_forward_build_packets", default)]
     pub slow_path_forward_build_packets: u64,
     #[serde(rename = "slow_path_drops", default)]

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -126,6 +126,7 @@
     "nat_frag_untranslated_dropped": 0,
     "neighbor_miss_packets": 0,
     "next_table_packets": 0,
+    "next_table_unsupported_drops": 0,
     "outstanding_tx": 0,
     "pending_tx_local_overflow_drops": 0,
     "policy_denied_packets": 0,

--- a/userspace-dp/tests/slow_path_admit_single_site_6664.rs
+++ b/userspace-dp/tests/slow_path_admit_single_site_6664.rs
@@ -1,0 +1,183 @@
+//! #6664: `is_slow_path_eligible` must be reachable from production code
+//! through exactly ONE door — `slow_path_admit` — and both kernel-reinject
+//! refusal points must walk through it.
+//!
+//! WHY A SOURCE GUARD RATHER THAN A BEHAVIOURAL TEST. The second refusal point
+//! is the trailing chokepoint in `poll_binding_process_descriptor`, and no test
+//! in this crate drives that function. That is not an oversight this issue
+//! could fix: it takes a live binding, a UMEM, a descriptor ring and a worker
+//! context. So the accounting there is unobservable to the suite, and before
+//! #6664 that was demonstrated rather than assumed — a mutation deleting the
+//! `poll_descriptor` copy of the fail-closed accounting passed the entire
+//! cargo suite.
+//!
+//! #6664's answer was to collapse the predicate and the accounting into one
+//! function so there is a single site to get wrong. This test is what makes
+//! that answer load-bearing instead of a convention: reverting either refusal
+//! point to a bare `is_slow_path_eligible()` call reds here, at the wiring,
+//! which is the property a behavioural test cannot reach.
+//!
+//! FAIL-ON-REVERT, in both directions:
+//!   * a second production call to `is_slow_path_eligible` (e.g. restoring the
+//!     `poll_descriptor` chokepoint to call the predicate directly, which
+//!     would refuse the frame but never count the drop) -> RED;
+//!   * a refusal point that stops calling `slow_path_admit` -> RED;
+//!   * the one permitted call moving out of `slow_path_admit`'s body -> RED.
+//!
+//! SCOPE, stated so a reader does not over-read it. Comment lines are stripped
+//! before matching, so no prose here or anywhere else can satisfy this test.
+//! Whole files whose NAME contains "test" are excluded; a `#[cfg(test)]` module
+//! inlined into a production-named file is NOT excluded and would trip the
+//! guard. That is over-strict in the safe direction — it can only deny a new
+//! call site, never admit one — and no such module exists today.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn repo_src() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()));
+    for entry in entries {
+        let path = entry.expect("dir entry").path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// True for a file that holds tests rather than production code.
+fn is_test_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.contains("test"))
+}
+
+/// The file's lines with comment-only lines blanked, so a match can never come
+/// from prose. Trailing `// ...` on a code line is left alone: a call written
+/// there is still a call.
+fn code_lines(path: &Path) -> Vec<String> {
+    fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+        .lines()
+        .map(|l| {
+            let t = l.trim_start();
+            if t.starts_with("//") { String::new() } else { l.to_string() }
+        })
+        .collect()
+}
+
+struct Site {
+    file: PathBuf,
+    line: usize,
+}
+
+fn production_call_sites(needle: &str) -> Vec<Site> {
+    let mut files = Vec::new();
+    rust_sources(&repo_src(), &mut files);
+    files.sort();
+    assert!(
+        files.len() > 100,
+        "scanned only {} Rust sources under {}; this guard is not reading the \
+         crate it claims to audit",
+        files.len(),
+        repo_src().display()
+    );
+    let mut sites = Vec::new();
+    for path in files {
+        if is_test_file(&path) {
+            continue;
+        }
+        for (i, line) in code_lines(&path).iter().enumerate() {
+            // `fn <needle>(` is the definition, not a call.
+            if line.contains(needle) && !line.contains(&format!("fn {}", needle.trim_end_matches('('))) {
+                sites.push(Site { file: path.clone(), line: i + 1 });
+            }
+        }
+    }
+    sites
+}
+
+fn rel(p: &Path) -> String {
+    p.strip_prefix(repo_src())
+        .unwrap_or(p)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+#[test]
+fn is_slow_path_eligible_has_exactly_one_production_caller_6664() {
+    let sites = production_call_sites("is_slow_path_eligible(");
+    let listed: Vec<String> = sites.iter().map(|s| format!("{}:{}", rel(&s.file), s.line)).collect();
+
+    assert_eq!(
+        sites.len(),
+        1,
+        "`is_slow_path_eligible` must be consulted from exactly ONE production \
+         site — inside `slow_path_admit`, which also records the fail-closed \
+         drop. Found {}: {:?}.\n\
+         A second caller is how the predicate and the accounting come apart: \
+         the frame is still refused, so no forwarding test changes, but the \
+         refusal is never counted and the operator sees a metric frozen at zero \
+         — indistinguishable from \"no such packets ever arrived\".",
+        sites.len(),
+        listed
+    );
+
+    let site = &sites[0];
+    assert_eq!(
+        rel(&site.file),
+        "afxdp/tx/dispatch/slow_path.rs",
+        "the single caller moved to {}; #6664's invariant is that it lives in \
+         `slow_path_admit`",
+        rel(&site.file)
+    );
+
+    // ...and inside slow_path_admit's body, not merely in the same file.
+    let lines = code_lines(&site.file);
+    let start = lines
+        .iter()
+        .position(|l| l.contains("fn slow_path_admit("))
+        .expect("slow_path_admit is gone from slow_path.rs");
+    let end = lines[start..]
+        .iter()
+        .position(|l| l == "}")
+        .map(|off| start + off)
+        .expect("slow_path_admit has no closing brace at column 0");
+    assert!(
+        site.line > start && site.line <= end + 1,
+        "the only `is_slow_path_eligible` call is at line {} but \
+         `slow_path_admit`'s body spans {}..={}; the predicate is being \
+         consulted outside the one function that also accounts for a refusal",
+        site.line,
+        start + 1,
+        end + 1
+    );
+}
+
+#[test]
+fn both_reinject_refusal_points_call_slow_path_admit_6664() {
+    let sites = production_call_sites("slow_path_admit(");
+    let mut files: Vec<String> = sites.iter().map(|s| rel(&s.file)).collect();
+    files.sort();
+    files.dedup();
+
+    assert_eq!(
+        files,
+        vec![
+            "afxdp/poll_descriptor/mod.rs".to_string(),
+            "afxdp/tx/dispatch/slow_path.rs".to_string(),
+        ],
+        "both kernel-reinject refusal points must route through \
+         `slow_path_admit`: the filtered `maybe_reinject_slow_path` wrapper in \
+         tx/dispatch/slow_path.rs and the trailing chokepoint in \
+         poll_binding_process_descriptor. Found {files:?}.\n\
+         The chokepoint is not covered by any behavioural test in this crate \
+         (it needs a live binding, UMEM and descriptor ring), so this is the \
+         only place a regression there is visible."
+    );
+}


### PR DESCRIPTION
## Summary

`NextTableUnsupported` — an inter-VRF next-table chain the helper cannot
resolve (deeper than `MAX_NEXT_TABLE_DEPTH`, or cyclic) — was slow-path
eligible, so the frame went to the kernel FIB, which forwarded it with **no zone
policy, no session, no NAT and no screen**. This is the #1913 class: a
disposition the dataplane cannot represent, delegated to a forwarder that
enforces none of the firewall's decisions.

Unlike `NoRoute` the condition is **not transient**, so #7409's "do not
black-hole a destination the kernel can still reach" argument does not apply —
no FIB refresh resolves an over-deep or cyclic chain. Delegating it was a
*standing* policy bypass for that configuration, not a window.

## ⚠️ What this does NOT close, stated up front

**This is the defense-in-depth leg, not the live-exposure one.** No config that
reaches the dataplane can currently produce this disposition: every
`next_table`-bearing FIB route lives in the global table (the global static pass
and the synthetic ip-rule leak pass are the only two producers), and a
`next_table` authored under a routing-instance is hard-rejected at commit by
`validateNextTableTargetReferencesStrict` (#5830) *and* dropped from the
snapshot on the tolerant load / peer-sync path
(`pkg/dataplane/userspace/routes.go:139`). So the recursion is at most one hop
and terminates.

That safety is an **emergent property of two guards in another language and
another package**, not an invariant the dataplane enforces. A third `next_table`
producer, or one relaxed guard, reopens the bypass silently. The dataplane's
posture should be correct on its own terms — that is the whole argument for this
change, and it is written into the predicate's doc rather than left in a commit
message.

**The two attacker-steerable legs of #6664 — `NoRoute` and `LocalDelivery` — are
NOT fixed here.** They are filed as **#7480** (`security`, `dataplane`) with the
analysis, including that #7438's kernel-route import changes the `NoRoute`
calculus and that adjudicating `NoRoute` is a forwarding-behaviour change owing
the HA cluster smoke gate. #6664 is closed as a split; **reopen it instead if
you would rather the parent track the residual.**

## One door, not two

Both kernel-reinject refusal points now route through a single
`slow_path_admit`: the filtered `maybe_reinject_slow_path` wrapper and the
trailing chokepoint in `poll_binding_process_descriptor`. The predicate and the
fail-closed accounting must never disagree about a frame, and a duplicated
increment per caller is a divergence that could only ever be a bug.

It had already behaved like one: **a mutation deleting the `poll_descriptor`
copy of the accounting passed the entire cargo suite**, because no test in the
crate drives that function — it needs a live binding, a UMEM, a descriptor ring
and a worker context.

Since no behavioural test can reach that site,
`userspace-dp/tests/slow_path_admit_single_site_6664.rs` binds it **at the
wiring**: `is_slow_path_eligible` must have exactly ONE production caller and it
must sit inside `slow_path_admit`'s body, and both refusal points must call
`slow_path_admit`. Comment lines are stripped before matching, so no prose —
including that file's own — can satisfy it.

## The signal moves rather than disappears

Refusing the reinject stops `slow_path_next_table_packets` advancing: that
counter is bumped on the **accept** path and is exported as
`xpf_userspace_binding_slow_path_next_table_packets_total`. Left alone it would
sit at a permanent zero, which to an operator is indistinguishable from *"no
such packets ever arrived"*. The drop is counted instead on
`next_table_unsupported_drops` →
`xpf_userspace_binding_next_table_unsupported_drops_total`; the retired series
stays on the wire so existing dashboards do not break, with its HELP text saying
so and naming the replacement.

**Wire compatibility**: additive, `#[serde(default)]` on the Rust side and
`json:",omitempty"` on the Go side, and neither decoder sets
`DisallowUnknownFields`. A new helper against an old control plane and an old
helper against a new one both degrade to zero rather than failing to parse. The
`protocol_wire_v1` golden gains **exactly one key at value 0** — none removed,
no existing value changed — so the regeneration is additive rather than a
laundered behaviour change.

## Two stale enumerations corrected

Removing a disposition from `is_slow_path_eligible` is worth exactly as much as
the set of paths that consult it, so the unfiltered callers of the raw
`maybe_reinject_slow_path_from_frame` primitive **are** the argument. Both
existing statements of that set were wrong:

- `slow_path.rs` called the ForwardCandidate build-failure reinject *"the only
  intentional unfiltered caller"*.
- `docs/userspace-dataplane-architecture.md` said there were two and named the
  FabricRedirect fallback in `tx/dispatch/mod.rs` — which #1946 had already
  turned into a fail-closed drop — while never listing the IPsec passthrough in
  `poll_stages.rs`.

The true set is two, and **neither can carry `NextTableUnsupported`**: the
build-failure fallback is reached only from forward-frame TX dispatch, so the
disposition is structurally `ForwardCandidate` or `FabricRedirect` (the latter
returns early on its own counter); the IPsec passthrough passes a *synthetic*
decision whose disposition is the literal `LocalDelivery`. That is what makes
this removal enforcement rather than decoration.

No defensive branch was added at those two sites. The condition never varies
there, so a guard would be a branch on a constant and a test for it would
exercise a site production never reaches.

`BindingLiveState`'s layout literals were re-measured (2152 → 2160, 2280 →
2288). `size_of` is unchanged at 2304 — the 8 bytes came out of existing tail
padding, and the next field added there will move it.

## Mutation matrix

Every cell verified applied (`git diff --stat` non-empty), built clean, run
**full-suite** (no `-run` / `--test` filter), rc read from a file.
`--test-threads=1` throughout; `CARGO_TARGET_DIR` outside the worktree.

| # | Mutation | rc | tests collected | Which assertion fired |
|---|---|---|---|---|
| A | restore `NextTableUnsupported` to the eligible set (verbatim pre-fix line) | 101 | 4611 | **3 red.** `tests_slow_path_disposition.rs:1174` *"must be counted as a fail-closed drop so the signal moves … instead of vanishing with the accept-path counter"* (`left: 0, right: 1`); `forwarding_build/tests.rs:7044`; and the pre-existing `slow_path_eligibility_predicate_allow_list` at `:111` — the older guard is load-bearing |
| B | revert the `poll_descriptor` chokepoint to a bare `is_slow_path_eligible()` (**wiring bind**) | 101 | 4678 | **only the source guard red**, which is the point: `:169` *"both kernel-reinject refusal points must route through slow_path_admit"* (`Found ["afxdp/tx/dispatch/slow_path.rs"]`) and `:117` *"must be consulted from exactly ONE production site … Found 2"*. **No behavioural test moved** — this is the site the suite cannot reach |
| C | refuse the frame but delete the fail-closed accounting | 101 | 4613 | `tests_slow_path_disposition.rs:1174`, `left: 0, right: 1` — localised to one test |
| D | wire the new Prometheus series to the WRONG status field | 1 | — | `metrics_slowpath_reinject_7409_test.go:127` *"next_table_unsupported_drops_total = 11, want 55"* — bound by VALUE, not by presence |
| E | revert one `BindingLiveState` offset literal (**tightening**) | build fail | — | `error[E0308] … expected an array with a size of 2152, found one with a size of 2160` — the layout guard is live, not decorative |

Cell B is the one worth reading twice: it is the only cell where the behavioural
suite is silent, and it is exactly the regression that escaped before #6664.

## Validation

- `cargo test -- --test-threads=1` — **rc=0, 4683 tests ok, 0 failed**, at
  `a26bdeb341b4943beaa803b94680698edc8cd1e5`.
- `go test ./... -count=1` — **rc=0, 66 packages ok, 0 FAIL**.
- One earlier full Rust run red on
  `afxdp::wg::tests::framed_handshake::concurrent_consume_response_and_reinitiation_is_sound`
  with *"no handshake completed — the race path was not exercised"*. That is a
  **setup guard in a load-sensitive concurrency probe**, not an assertion about
  behaviour: this branch touches 0 lines in `wg/tests.rs` (last changed on an
  unrelated WG lock-poison branch), and the test passes 3/3 standalone and in the
  clean full run above. Reported rather than hidden.
- **Not deployed.** The disposition is unreachable from any committable
  configuration, so no cluster smoke run can exercise it — a deploy would prove
  nothing about the changed path. Stated as a limitation, not claimed as a pass.
  No cluster / VRRP / session-sync / failover code touched and the shim `.o` is
  unmoved; the wire change is additive and default-tolerant in both directions.

Closes #6664
