### PR TITLE
daemon: background applies re-read the active config under applySem

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103498,3 +103498,16 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/cluster/sync.go`, `pkg/cluster/sync_auth.go`, `pkg/cluster/sync_bulk.go`,
   `pkg/cluster/sync_conn_read.go`, `pkg/cluster/sync_conn_config.go`,
   `pkg/cluster/status.go`, `docs/sync-protocol.md`
+
+## 2026-08-22 — #6716 background applies re-read the active config
+- **Timestamp**: 2026-08-22
+- **Action**: Background apply callbacks (DHCP lease change, dynamic feed,
+  boot-time apply) captured store.ActiveConfig() BEFORE waiting on applySem and
+  then applied that snapshot, silently reverting a commit that landed during the
+  wait. Added applyActiveConfig / applyActiveConfigResult, which re-read under
+  the semaphore; removed the now-dead applyConfigResult so the pre-capturing
+  entry point cannot be reached again.
+- **File(s)**: pkg/daemon/daemon_apply.go, pkg/daemon/daemon_dhcp.go,
+  pkg/daemon/daemon_feeds.go, pkg/daemon/daemon_run_bringup.go,
+  pkg/daemon/apply_active_reread_6716_test.go,
+  pkg/daemon/cluster_transport_race_6290_test.go

--- a/pkg/daemon/apply_active_reread_6716_test.go
+++ b/pkg/daemon/apply_active_reread_6716_test.go
@@ -1,0 +1,198 @@
+package daemon
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// #6716: the background apply callbacks must reconcile against the config that
+// is ACTIVE when they get the apply semaphore, not the one they read before
+// waiting for it.
+//
+// The inversion is a real interleaving, not a simulated one: this test HOLDS an
+// apply inside the applyBodyForTest seam, lands a genuine commit of config B on
+// another goroutine while that apply owns applySem, then releases. A caller that
+// captured A before blocking would apply A after B was committed — silently
+// reverting the operator's commit in every subsystem applyConfigLocked drives,
+// with no error anywhere.
+//
+// The assertion reads the config the apply body actually received, because that
+// is the value the whole pipeline is driven from. Asserting merely that "an
+// apply happened" is what let this hide: both the correct and the inverted path
+// apply exactly once and both return success.
+
+// applyRereadHarness6716 builds a daemon whose store holds config A active, with
+// the apply body replaced by a recorder that can be blocked mid-apply.
+func applyRereadHarness6716(t *testing.T) (*Daemon, *configstore.Store) {
+	t.Helper()
+	s := newConfigStore(t, filepath.Join(t.TempDir(), "config.db"))
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if _, err := s.LoadSet(applyRereadSets6716("A")); err != nil {
+		t.Fatalf("LoadSet(A): %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("Commit(A): %v", err)
+	}
+	return &Daemon{
+		applySem: semaphore.NewWeighted(1),
+		store:    s,
+		opts:     Options{NoDataplane: true},
+	}, s
+}
+
+// applyRereadSets6716 returns a config whose description carries the marker, so
+// the config that reached the apply body is identifiable by value.
+func applyRereadSets6716(marker string) string {
+	return "set interfaces ge-0/0/0 description " + marker + "\n" +
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24\n"
+}
+
+// applyRereadMarker6716 extracts the marker from a compiled config.
+func applyRereadMarker6716(t *testing.T, cfg *config.Config) string {
+	t.Helper()
+	if cfg == nil {
+		return "<nil>"
+	}
+	if iface := cfg.Interfaces.Interfaces["ge-0/0/0"]; iface != nil {
+		return iface.Description
+	}
+	return "<absent>"
+}
+
+// TestBackgroundCallbacksRereadTheActiveConfig6716 is the defect proper, driven
+// through the REAL production callbacks.
+//
+// It deliberately does NOT call applyActiveConfig directly. That would bind the
+// FUNCTION and leave the WIRING free: reverting either call site back to the
+// pre-captured pointer keeps such a test green, which is exactly how the defect
+// survived. Each subtest invokes the callback the daemon actually registers.
+func TestBackgroundCallbacksRereadTheActiveConfig6716(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		fire func(*Daemon)
+	}{
+		{"DHCP lease change", func(d *Daemon) { d.onDHCPAddressChange() }},
+		{"dynamic feed update", func(d *Daemon) { _ = d.onFeedUpdate() }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, s := applyRereadHarness6716(t)
+
+			var applied []string
+			d.applyBodyForTest = func(cfg *config.Config) {
+				applied = append(applied, applyRereadMarker6716(t, cfg))
+			}
+
+			// The seam fires AFTER the callback has read config for its own
+			// decisions and BEFORE it hands off to the apply. Committing B here
+			// reproduces the real interleaving — callback reads A, operator's
+			// commit lands, apply runs — without a sleep or a scheduler race.
+			// Firing the callback after an already-landed commit instead would
+			// let its own read see B and pass either way.
+			var once sync.Once
+			d.preApplyHookForTest = func() {
+				once.Do(func() {
+					if _, err := s.LoadSet(applyRereadSets6716("B")); err != nil {
+						t.Errorf("LoadSet(B): %v", err)
+						return
+					}
+					if _, err := s.Commit(); err != nil {
+						t.Errorf("Commit(B): %v", err)
+					}
+				})
+			}
+
+			tc.fire(d)
+
+			if got := applyRereadMarker6716(t, s.ActiveConfig()); got != "B" {
+				t.Fatalf("test setup: active config after the commit = %q, want B", got)
+			}
+			if len(applied) != 1 {
+				t.Fatalf("expected exactly 1 apply from the callback, got %d: %v", len(applied), applied)
+			}
+			if applied[0] != "B" {
+				t.Errorf("the %s callback applied %q after the operator committed B — a "+
+					"background apply REVERTED a newer commit across every subsystem "+
+					"applyConfigLocked reconciles, with no error reported anywhere. "+
+					"The callback must reconcile against the config active when it gets "+
+					"applySem, not the one it read before waiting for it", tc.name, applied[0])
+			}
+		})
+	}
+}
+
+// TestApplyConfigStillHonoursAnExplicitConfig6716 is the TIGHTENING control.
+//
+// A "fix" that made every apply re-read would satisfy the test above while
+// destroying applyConfig's contract — the commit paths and the lenient
+// boot-apply path depend on applying the EXACT config handed to them, not
+// whatever happens to be active. This pins that side.
+func TestApplyConfigStillHonoursAnExplicitConfig6716(t *testing.T) {
+	d, s := applyRereadHarness6716(t)
+
+	var got []string
+	d.applyBodyForTest = func(cfg *config.Config) {
+		got = append(got, applyRereadMarker6716(t, cfg))
+	}
+
+	// Commit B so the ACTIVE config differs from the one we pass explicitly.
+	if _, err := s.LoadSet(applyRereadSets6716("B")); err != nil {
+		t.Fatalf("LoadSet(B): %v", err)
+	}
+	explicit, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit(B): %v", err)
+	}
+	if _, err := s.LoadSet(applyRereadSets6716("C")); err != nil {
+		t.Fatalf("LoadSet(C): %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("Commit(C): %v", err)
+	}
+
+	d.applyConfig(explicit)
+
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 apply, got %d: %v", len(got), got)
+	}
+	if got[0] != "B" {
+		t.Errorf("applyConfig(cfg) applied %q, want B — an explicit-config caller must apply "+
+			"the config it was handed; re-reading here would break the commit and "+
+			"lenient-boot paths that depend on applying a specific compiled config", got[0])
+	}
+}
+
+// TestApplyActiveConfigNilActiveIsANoOp6716 pins the pre-boot contract the feed
+// path relies on: a nil active config is a vacuous success, not an error and not
+// an apply of nil.
+func TestApplyActiveConfigNilActiveIsANoOp6716(t *testing.T) {
+	s := newConfigStore(t, filepath.Join(t.TempDir(), "config.db"))
+	d := &Daemon{applySem: semaphore.NewWeighted(1), store: s, opts: Options{NoDataplane: true}}
+
+	applies := 0
+	d.applyBodyForTest = func(*config.Config) { applies++ }
+
+	if s.ActiveConfig() != nil {
+		t.Skip("store has an active config; this test needs the pre-boot window")
+	}
+	d.applyActiveConfig()
+	if err := d.applyActiveConfigResult(); err != nil {
+		t.Errorf("applyActiveConfigResult with no active config = %v, want nil — the feed "+
+			"manager records content as published on a nil return, so an error here makes "+
+			"a pre-boot refetch spin forever (#5646)", err)
+	}
+	if applies != 0 {
+		t.Errorf("applied %d times with no active config, want 0", applies)
+	}
+	if !d.applySem.TryAcquire(1) {
+		t.Fatal("applySem not released on the nil-active path")
+	}
+	d.applySem.Release(1)
+}

--- a/pkg/daemon/cluster_transport_race_6290_test.go
+++ b/pkg/daemon/cluster_transport_race_6290_test.go
@@ -18,7 +18,7 @@ import (
 // HTTP servers. The DHCP one is live before the write:
 //
 //	daemon_run_bringup.go  dhcp.New(..., d.onDHCPAddressChange, ...)  callback wired
-//	daemon_run_bringup.go  boot d.applyConfig(cfg)
+//	daemon_run_bringup.go  boot d.applyActiveConfig()
 //	 -> daemon_apply_routing.go  reconcileDHCPClients(cfg)            client goroutines START
 //	daemon_run.go          d.startClusterComms(ctx)                   the WRITE happens here
 //

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -595,6 +595,17 @@ type Daemon struct {
 	// exercise the semaphore contract through the real applyConfig
 	// / commitAndApply paths without standing up the full dataplane.
 	applyBodyForTest func(*config.Config)
+	// preApplyHookForTest fires in a background apply CALLBACK after it has
+	// finished reading config for its own decisions and immediately before it
+	// hands off to applyActiveConfig / applyActiveConfigResult.
+	//
+	// It exists because the #6716 inversion is only observable in that exact
+	// window: a callback must read the active config, THEN a commit must land,
+	// THEN the apply must run. Firing the callback after committing lets the
+	// callback's own read see the new config, so the test passes whether or not
+	// the wiring re-reads under the semaphore — which is how a first version of
+	// the #6716 guard stayed green against a reverted call site.
+	preApplyHookForTest func()
 
 	// bootstrapTeardownForTest, when non-nil, replaces the real per-step
 	// teardown executed inside enterBootstrapMode (#5868). Test-only seam:

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -49,6 +49,83 @@ func setVLANSubAddrGenMode(iface string) {
 func (d *Daemon) applyConfig(cfg *config.Config) {
 	_ = d.applySem.Acquire(context.Background(), 1)
 	defer d.applySem.Release(1)
+	d.applyConfigUnderSem(cfg)
+}
+
+// applyActiveConfig applies whatever config is ACTIVE at the moment the apply
+// semaphore is acquired, rather than one the caller captured before waiting for
+// it (#6716).
+//
+// The background callbacks — a DHCP lease change, a dynamic-feed update, the
+// boot-time apply — all want "reconcile against the current config", not
+// "reconcile against the config that was current when I woke up". They used to
+// read store.ActiveConfig() and only THEN block on applySem, so a commit that
+// landed while they waited was silently reverted by the older snapshot: every
+// subsystem applyConfigLocked reconciles was driven from config A after the
+// operator had committed config B, with no error anywhere.
+//
+// The sharpest instance is a REVOKED api-auth credential being republished by a
+// DHCP callback that happened to be waiting, but the inversion re-applies any
+// A-vs-B difference — bind address, TLS, and everything else the apply pipeline
+// touches. It also made the applied-stamp lie: applyConfig marks the ACTIVE
+// config applied afterwards, so on the inverted path it stamped B applied while
+// A was what ran, and handleConfigSync's #4957 converged shortcut then skipped
+// re-applying B on a peer sync, letting the divergence survive a reconnect.
+//
+// Re-reading under the semaphore closes both halves at once and makes the stamp
+// honest by construction: a commit cannot land between the read and the apply,
+// because a commit needs this same semaphore.
+//
+// A nil active config means there is nothing to reconcile (the pre-boot window)
+// and is a no-op, matching the guard every caller previously wrote inline.
+// applyConfig(cfg) is retained for callers that genuinely mean "apply THIS
+// config" — the commit paths use applyConfigLocked directly, and tests drive a
+// synthetic config through it.
+func (d *Daemon) applyActiveConfig() {
+	_ = d.applySem.Acquire(context.Background(), 1)
+	defer d.applySem.Release(1)
+	if d.store == nil {
+		return
+	}
+	cfg := d.store.ActiveConfig()
+	if cfg == nil {
+		return
+	}
+	d.applyConfigUnderSem(cfg)
+}
+
+// applyActiveConfigResult is applyActiveConfig that RETURNS the apply error
+// instead of only logging it.
+//
+// The feed onUpdate publication path (#5646) uses the returned result to decide
+// whether the feed content was ACCEPTED: the feed manager advances its per-feed
+// published-hash only on a nil return, so a rejected apply leaves publication
+// debt that the next identical refetch retries, rather than committing the
+// content hash and suppressing retry forever. The returned error is still
+// logged — by feeds.installSnapshot's reject branch, not here.
+//
+// A nil active config returns nil: the pre-boot vacuous success the feed
+// manager relies on to record content as published rather than spinning.
+//
+// This replaces applyConfigResult(cfg), which is deliberately gone rather than
+// left unused. It was the natural-looking entry point for exactly the callers
+// that must not pre-capture a config, so keeping a dead copy would invite the
+// #6716 inversion straight back in.
+func (d *Daemon) applyActiveConfigResult() error {
+	_ = d.applySem.Acquire(context.Background(), 1)
+	defer d.applySem.Release(1)
+	if d.store == nil {
+		return nil
+	}
+	cfg := d.store.ActiveConfig()
+	if cfg == nil {
+		return nil
+	}
+	return d.applyConfigLocked(context.Background(), cfg)
+}
+
+// applyConfigUnderSem is applyConfig's body. The caller MUST hold d.applySem.
+func (d *Daemon) applyConfigUnderSem(cfg *config.Config) {
 	// Boot / DHCP-callback / feed / config-poll applies must always run to
 	// completion (they are not request-bound and there is no operator waiting
 	// to cancel them), so the heavy pipeline is driven with a non-cancellable
@@ -69,21 +146,6 @@ func (d *Daemon) applyConfig(cfg *config.Config) {
 	if d.store != nil {
 		d.store.MarkActiveApplied()
 	}
-}
-
-// applyConfigResult applies cfg exactly like applyConfig — under the apply
-// semaphore with a non-cancellable context — but RETURNS the apply error
-// instead of only logging it. The feed onUpdate publication path (#5646) uses
-// the returned result to decide whether the feed content was ACCEPTED: the feed
-// manager advances its per-feed published-hash only on a nil return, so a
-// rejected apply leaves publication debt that the next identical refetch
-// retries (rather than committing the content hash and suppressing retry
-// forever, the pre-#5646 bug). The returned error is still logged — by
-// feeds.installSnapshot's reject branch (feeds side), not by this function.
-func (d *Daemon) applyConfigResult(cfg *config.Config) error {
-	_ = d.applySem.Acquire(context.Background(), 1)
-	defer d.applySem.Release(1)
-	return d.applyConfigLocked(context.Background(), cfg)
 }
 
 // applyCancelCtx returns the context whose cancellation aborts the heavy apply

--- a/pkg/daemon/daemon_dhcp.go
+++ b/pkg/daemon/daemon_dhcp.go
@@ -85,9 +85,20 @@ func (d *Daemon) onDHCPAddressChange() {
 	if activeCfg := d.store.ActiveConfig(); activeCfg != nil {
 		if d.dhcpLeaseChangeRequiresRecompile(activeCfg) {
 			slog.Info("DHCP address changed, recompiling dataplane")
-			// applyConfig runs reconcileDNSLocked, so DNS is
+			// applyActiveConfig runs reconcileDNSLocked, so DNS is
 			// reconciled with the new lease set on this path.
-			d.applyConfig(activeCfg)
+			//
+			// #6716: it re-reads the active config under applySem instead of
+			// applying activeCfg, which was captured BEFORE the semaphore wait.
+			// A commit landing during that wait was otherwise reverted by this
+			// callback. activeCfg above still drives the recompile DECISION —
+			// that only chooses how much work to do, and choosing "full apply"
+			// from a slightly stale read is safe because the apply itself now
+			// reconciles whatever is current.
+			if d.preApplyHookForTest != nil {
+				d.preApplyHookForTest()
+			}
+			d.applyActiveConfig()
 		} else {
 			slog.Info("DHCP address changed on management-only interface, refreshing management routes")
 			// #5867: no commit to fail on this DHCP-callback path (it is a

--- a/pkg/daemon/daemon_feeds.go
+++ b/pkg/daemon/daemon_feeds.go
@@ -23,23 +23,38 @@ func (d *Daemon) ensureFeedManager() {
 	if d.feeds != nil {
 		return
 	}
-	d.feeds = feeds.New(func() error {
-		slog.Info("dynamic-address feed updated, recompiling dataplane")
-		activeCfg := d.store.ActiveConfig()
-		if activeCfg == nil {
-			// No active config to apply the feed content against yet (pre-boot
-			// window). Treat as a vacuous success — there is no policy enforcing
-			// this feed, and the normal commit path re-reads the live feed
-			// snapshot when a config is committed. Returning nil lets the feed
-			// manager record the content as published so it does not spin.
-			return nil
-		}
-		// #5646: return the apply RESULT to the feed manager. A rejected apply
-		// (preflight reject, compile failure, control-socket error) must NOT be
-		// recorded as published, so the next identical feed refetch retries the
-		// apply instead of silently dropping the good content (publication debt).
-		return d.applyConfigResult(activeCfg)
-	})
+	d.feeds = feeds.New(d.onFeedUpdate)
+}
+
+// onFeedUpdate is the dynamic-address feed manager's publication callback.
+//
+// It is a named method rather than an inline closure so a test can drive the
+// REAL callback. The property that matters here is WHICH entry point this site
+// calls: a test that invokes applyActiveConfigResult directly binds the
+// function while leaving the wiring free to regress back to a pre-captured
+// config (#6716).
+func (d *Daemon) onFeedUpdate() error {
+	slog.Info("dynamic-address feed updated, recompiling dataplane")
+	if d.store == nil || d.store.ActiveConfig() == nil {
+		// No active config to apply the feed content against yet (pre-boot
+		// window). Treat as a vacuous success — there is no policy enforcing
+		// this feed, and the normal commit path re-reads the live feed
+		// snapshot when a config is committed. Returning nil lets the feed
+		// manager record the content as published so it does not spin.
+		return nil
+	}
+	// #5646: return the apply RESULT to the feed manager. A rejected apply
+	// (preflight reject, compile failure, control-socket error) must NOT be
+	// recorded as published, so the next identical feed refetch retries the
+	// apply instead of silently dropping the good content (publication debt).
+	//
+	// #6716: applyActiveConfigResult re-reads the active config under applySem.
+	// The nil check above is only the pre-boot guard — a config read out here
+	// and applied would revert a commit that landed during the semaphore wait.
+	if d.preApplyHookForTest != nil {
+		d.preApplyHookForTest()
+	}
+	return d.applyActiveConfigResult()
 }
 
 // feedsConfigHash returns a stable hash over the feed-SERVER configuration that

--- a/pkg/daemon/daemon_run_bringup.go
+++ b/pkg/daemon/daemon_run_bringup.go
@@ -519,7 +519,10 @@ func (d *Daemon) setupDataplaneAndInitialConfig() error {
 			// gate reads the real arm state instead of re-opening forwarding.
 			if cfg := d.store.ActiveConfig(); cfg != nil {
 				slog.Info("applying active configuration")
-				d.applyConfig(cfg)
+				// #6716: re-reads the active config under applySem rather than
+				// applying this pre-semaphore snapshot. The check above stays a
+				// cheap "is there anything to apply yet" guard.
+				d.applyActiveConfig()
 			}
 		}
 	}


### PR DESCRIPTION
Closes #6716

The DHCP lease-change callback, the dynamic-feed `onUpdate` callback and the boot-time apply all read `store.ActiveConfig()` **before** blocking on `applySem`, then applied that captured pointer once they got it. A commit landing in the window between the read and the acquire was silently overwritten: every subsystem `applyConfigLocked` reconciles was driven from config A after the operator had committed config B, and nothing reported an error.

The sharpest instance is a **revoked api-auth credential republished** by a DHCP callback that happened to be waiting, but the inversion re-applies any A-vs-B difference the apply pipeline touches.

It also made the applied-stamp lie: `applyConfig` calls `MarkActiveApplied()` after the apply returns, so on the inverted path it stamped B applied while A was what ran. `handleConfigSync`'s #4957 converged shortcut then skipped re-applying B on a peer sync, letting the divergence survive a reconnect.

## Fix

`applyActiveConfig` / `applyActiveConfigResult` re-read the active config **after** acquiring the semaphore. A commit cannot land between that read and the apply, because a commit needs the same semaphore — so the stamp becomes honest by construction rather than by a second check.

`applyConfig(cfg)` stays for callers that genuinely mean "apply THIS config": the commit paths call `applyConfigLocked` directly, and tests drive a synthetic config through it. **`applyConfigResult` is removed rather than left unused** — it was the natural-looking entry point for exactly the callers that must not pre-capture, so a dead copy would invite the defect straight back.

The DHCP path still reads the config to decide *whether* a recompile is needed. That only chooses how much work to do, and choosing "full apply" from a slightly stale read is safe now that the apply reconciles whatever is current.

The feed callback became a named method (`onFeedUpdate`) instead of an inline closure, so a test can drive the **real** callback.

## The guard went through two wrong versions first — both worth recording

**Version 1 tested `applyActiveConfig` directly.** It passed. Then mutation W1 reverted the DHCP call site to `d.applyConfig(activeCfg)` — the exact pre-fix code — and the suite **stayed green**. The test bound the *function*, not the *wiring*, which is precisely how this defect survived in the first place.

**Version 2 drove the real callbacks but still stayed green under W1**, for a subtler reason: it fired the callback *after* committing B, so the callback's own pre-semaphore read already returned B. The interleaving was never actually reproduced. A test can call the right function, in the right order, and still measure nothing.

**Version 3** adds a `preApplyHookForTest` seam that fires after a callback has read config for its own decisions and immediately before it hands off to the apply. Committing B from that hook reproduces the real sequence — callback reads A, commit lands, apply runs — with no sleep and no scheduler race. Only then did W1 red.

## Mutation matrix

Fix committed first, so `git diff --quiet` means "this cell's mutation is present" and `git checkout --` restores exactly the fix. Full `pkg/daemon` package per cell, no `-run` filter, rc read from a file, control green first.

| # | mutation | rc | fired |
|---|---|---|---|
| W1 | **WIRING**: DHCP site back to the pre-captured pointer | 1 | `…/DHCP_lease_change` — feed subtest stays GREEN |
| W2 | **WIRING**: feed site back to the pre-captured pointer | 1 | `…/dynamic_feed_update` — DHCP subtest stays GREEN |
| W3 | **TIGHTEN**: make `applyConfig(cfg)` re-read too | 1 | `TestApplyConfigStillHonoursAnExplicitConfig6716` |
| W4 | nil-active returns an error instead of vacuous success | 1 | `TestApplyActiveConfigNilActiveIsANoOp6716` |

W1 and W2 are deliberately separate cells: the two sites are symmetric, and a compound revert would have redded on the first half and masked whether the second was bound at all.

W3 is the cell that makes this a fix rather than a blanket change — "re-read everywhere" would satisfy the defect test while breaking the commit and lenient-boot paths that depend on applying a specific compiled config.

## Scope note

The boot-time apply in `daemon_run_bringup.go` also switched to `applyActiveConfig`, but it is **not** covered by a behavioural cell — driving daemon bringup in a unit test would need most of the daemon. Stating it rather than implying the matrix covers all three sites. It calls the same function W1/W2 bind, and the control plane starts after it, so the window there is narrow.

## Validation

`go build`, `go vet`, and `go test -count=1 ./...` clean repo-wide (not just the touched package — that is how `pkg/refactoraudit`'s modularity gate gets seen).

No cluster/VRRP/session-sync/failover code; no `userspace-dp` binary or shim `.o` moved. Go only.
