### PR TITLE
daemon: publish the management reconciler atomically and start it under its lock (#6719)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103606,3 +103606,17 @@ prose edit above them added. No diff falls in the new test body.
   `userspace-dp/src/afxdp/frame/tests_shim_ext_parity.rs`,
   `pkg/dataplane/userspace_xdp_bpfel.o`, `pkg/dataplane/userspace_xdp_manifest.json`,
   `pkg/dataplane/README.md`
+
+## 2026-08-22 — #6719 management reconciler startup race + unguarded publish
+- **Action**: `d.mgmt` became an `atomic.Pointer[managementReconciler]` (was a
+  plain field written in startHTTPServer and read unguarded by
+  reconcileWebManagement, with cluster comms — and therefore peer sync — live
+  ~190 lines earlier in Run). `managementReconciler.start` now derives its
+  desired state from `store.ActiveConfig()` UNDER `m.mu` via a new `startLocked`
+  shared body, so a promotion racing startup is no longer dropped by a reconcile
+  that no-ops on `m.srv == nil` and then overwritten by the stale snapshot.
+- **File(s)**: `pkg/daemon/daemon.go`, `pkg/daemon/daemon_run_servers.go`,
+  `pkg/daemon/management.go`,
+  `pkg/daemon/management_start_race_6719_test.go` (new),
+  `pkg/daemon/daemon_dp_escape_rest_test.go`,
+  `pkg/daemon/hostname_stale_cert_6827_test.go`, `pkg/daemon/README.md`

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -399,6 +399,33 @@ mirrors `reconcileSNMP`: `reconcileWebManagement` runs EARLY in
 credential revocation is enforced even on an apply that returns early
 (`store.Commit` has already promoted the config). Reconcile discipline:
 
+**Startup ordering and publication (#6719).** `d.mgmt` is an
+`atomic.Pointer[managementReconciler]`, not a plain field, and the type is doing
+real work rather than being defensive. `startClusterComms` runs at
+`daemon_run.go` ~:405 and `startHTTPServer` at ~:596, so for roughly 190 lines of
+`Run` the peer-sync apply path is live while the reconciler does not exist yet —
+`reconcileWebManagement` reads the pointer on exactly that path. A plain field
+write racing those reads is a data race on the pointer that gates the management
+auth reconcile; the atomic gives the happens-before edge and makes the plain read
+impossible to reintroduce. (#6827 round 5 had narrowed this to the stale-cert
+path under `staleCertMu` and said so explicitly — "Do not read this as `mgmt is
+guarded`; it is not". It is now.)
+
+`start` also derives its snapshot from `store.ActiveConfig()` **under `m.mu`**,
+not before taking it. The pre-#6719 shape read the active config first and only
+then contended for the lock, which lost a promotion outright: startup read config
+A, a peer sync promoted B (revoking A's credential) and called `reconcile`, that
+reconcile won the lock, found `m.srv == nil` and no-opped, and `start` then
+installed the server built from the stale A. The credential stayed accepted until
+some later reconcile or a restart, and the same window applied to the bind
+address and TLS. Reading under the lock makes both interleavings correct rather
+than one lossy: a promotion that lands before the read is simply seen, and one
+that lands while the lock is held blocks and then converges against a server that
+now exists. `committedDesired` (the reconcile path) reads the same
+`store.ActiveConfig()`, so the two derivations agree on their authority by
+construction. `startLocked` is the shared body; `startTo` remains the
+explicit-config test seam.
+
 - **Auth change on an unchanged endpoint** → live `api.Server.ReplaceAuth`
   (atomic snapshot swap, effective next request, no rebind, no window).
 - **Endpoint change** → reconcile ONLY the listener leg that changed, PER LEG:

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -328,16 +328,20 @@ type Daemon struct {
 	// listener + authentication snapshot against the committed web-management
 	// config (make-before-break rebind on an endpoint change; live auth swap on
 	// an unchanged bind). nil when the API is not enabled (--api-addr empty).
-	mgmt *managementReconciler
-	// staleCertMu guards staleCertPending and staleCertGen, and publishes the
-	// mgmt pointer the stale-cert delivery path reads (#6827 round 5) — so that
-	// read is memory-model safe rather than a benign-looking data race.
-	//
-	// ONLY that read. `mgmt` is still read unguarded elsewhere (daemon_run_servers.go
-	// and reconcileWebManagement), exactly as it was before #6827 — the publish
-	// was unsynchronised on every path then, and this PR narrowed the problem to
-	// the path it touched rather than solving it. Do not read this as "mgmt is
-	// guarded"; it is not, and the remaining readers are tracked separately.
+	// #6719: an atomic pointer, not a plain field. It is written once in
+	// startHTTPServer and read from goroutines that are already running by then
+	// — startClusterComms is ~190 lines EARLIER in Run, so the peer-sync apply
+	// path reaches reconcileWebManagement while this is still nil. A plain field
+	// write racing those reads is a data race on the pointer that gates the
+	// management auth reconcile, which is what #6827 round 5 narrowed to the
+	// stale-cert path and explicitly left open elsewhere ("Do not read this as
+	// 'mgmt is guarded'; it is not"). The type now enforces it: every access is
+	// a Load or a Store, so a future edit cannot reintroduce the plain read.
+	mgmt atomic.Pointer[managementReconciler]
+	// staleCertMu guards staleCertPending and staleCertGen. It no longer
+	// publishes the mgmt pointer — mgmt is atomic (above), so the stale-cert
+	// delivery path loads it like every other reader and does not need this
+	// mutex to make that read safe.
 	staleCertMu sync.Mutex
 	// staleCertPending records that a `set system host-name` moved the kernel
 	// name and the management-TLS staleness diagnostic has NOT yet been

--- a/pkg/daemon/daemon_dp_escape_rest_test.go
+++ b/pkg/daemon/daemon_dp_escape_rest_test.go
@@ -78,10 +78,11 @@ func startEscapeTestREST(t *testing.T, d *Daemon) string {
 		cancel()
 		wg.Wait()
 	})
-	if d.mgmt == nil || d.mgmt.srv == nil {
+	mgmt := d.mgmt.Load()
+	if mgmt == nil || mgmt.srv == nil {
 		t.Fatal("startHTTPServer did not converge a management listener")
 	}
-	addr := d.mgmt.srv.EffectiveHTTPAddr()
+	addr := mgmt.srv.EffectiveHTTPAddr()
 	if addr == "" {
 		t.Fatal("management listener reported no effective HTTP address")
 	}

--- a/pkg/daemon/daemon_run_servers.go
+++ b/pkg/daemon/daemon_run_servers.go
@@ -43,7 +43,7 @@ func (d *Daemon) effectiveListeners() sysservices.Listeners {
 		// binds on loopback, so report the requested address as Listening.
 		ls.GRPC = sysservices.Listener{Addr: d.opts.GRPCAddr, State: sysservices.StateListening}
 	}
-	ls.HTTP = d.mgmt.effectiveHTTPListener()
+	ls.HTTP = d.mgmt.Load().effectiveHTTPListener()
 	return ls
 }
 
@@ -491,13 +491,18 @@ func (d *Daemon) startHTTPServer(ctx context.Context, wg *sync.WaitGroup, eventB
 	// swap on an unchanged bind. Before #5866 the server was constructed once
 	// here and never reconciled, so a committed bind/TLS/port/auth change (e.g.
 	// a revoked credential) sat inert until a daemon restart.
-	// #6827 round 5: publish d.mgmt under staleCertMu, the same mutex the
-	// stale-cert delivery path reads it through, so that read is memory-model
-	// safe rather than a benign-looking data race.
+	// #6719: publish the reconciler ATOMICALLY, and BEFORE start() runs. The
+	// readers are already live — startClusterComms is ~190 lines earlier in Run,
+	// so a peer sync can reach reconcileWebManagement before this line. The
+	// atomic makes that read safe; publishing before start() also means such a
+	// reconcile finds a non-nil reconciler and is merely no-opped by the
+	// `m.srv == nil` gate rather than dropped at the daemon level — and start()
+	// then derives its snapshot from the store UNDER m.mu, so the promotion that
+	// reconcile carried is picked up rather than lost. (#6827 round 5 published
+	// this under staleCertMu; the atomic supersedes that and covers every
+	// reader, not just the stale-cert path.)
 	mgmt := newManagementReconciler(d, apiCfg)
-	d.staleCertMu.Lock()
-	d.mgmt = mgmt
-	d.staleCertMu.Unlock()
+	d.mgmt.Store(mgmt)
 	if err := mgmt.start(ctx); err != nil {
 		// A boot bind failure is non-fatal (matches the pre-#5866 async
 		// srv.Run error log): the daemon keeps running and the next commit's
@@ -518,7 +523,7 @@ func (d *Daemon) startHTTPServer(ctx context.Context, wg *sync.WaitGroup, eventB
 	go func() {
 		defer wg.Done()
 		<-ctx.Done()
-		d.mgmt.wait()
+		d.mgmt.Load().wait()
 	}()
 	slog.Info("HTTP API server started", "addr", d.opts.APIAddr)
 }

--- a/pkg/daemon/hostname_stale_cert_6827_test.go
+++ b/pkg/daemon/hostname_stale_cert_6827_test.go
@@ -86,7 +86,7 @@ func TestWarnStaleMgmtCertForHostNameWithoutServer_6827(t *testing.T) {
 
 	reg := newFakeReg()
 	d := &Daemon{}
-	d.mgmt = newManagementReconciler(d, api.Config{ListenFunc: reg.listen})
+	d.mgmt.Store(newManagementReconciler(d, api.Config{ListenFunc: reg.listen}))
 	noteRename(t, d, "new-fw-6827")
 	d.deliverStaleMgmtCertDiagnosis()
 }
@@ -262,7 +262,7 @@ func TestBootHostNameReachesTheDiagnostic_6827(t *testing.T) {
 		reg := newFakeReg()
 		d := &Daemon{}
 		m := newManagementReconciler(d, api.Config{ListenFunc: reg.listen})
-		d.mgmt = m
+		d.mgmt.Store(m)
 		stubHostname(t, "new-fw-6827")
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
@@ -371,7 +371,7 @@ func serveStaleCert(t *testing.T, d *Daemon, certName string) *managementReconci
 	t.Helper()
 	reg := newFakeReg()
 	m := newManagementReconciler(d, api.Config{ListenFunc: reg.listen})
-	d.mgmt = m
+	d.mgmt.Store(m)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	if err := m.startTo(ctx, cfgFor(reg, "10.0.0.1:8080", false, "", nil)); err != nil {
@@ -650,10 +650,10 @@ func TestDeferredDeliveryIsWiredAtItsRetryPoints_6827(t *testing.T) {
 			// hoisted above mgmt.start would still read the name (d.mgmt is
 			// published first) but could never reach a certificate, because no
 			// server exists yet.
-			if d.mgmt != nil {
-				d.mgmt.mu.Lock()
-				srvUpAtRead = d.mgmt.srv != nil
-				d.mgmt.mu.Unlock()
+			if m := d.mgmt.Load(); m != nil {
+				m.mu.Lock()
+				srvUpAtRead = m.srv != nil
+				m.mu.Unlock()
 			}
 			return "new-fw-6827", nil
 		}
@@ -700,7 +700,7 @@ func TestDeferredDeliveryIsWiredAtItsRetryPoints_6827(t *testing.T) {
 		)
 		reg := newFakeReg()
 		m := newManagementReconciler(d, api.Config{ListenFunc: reg.listen})
-		d.mgmt = m
+		d.mgmt.Store(m)
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
 
@@ -795,7 +795,7 @@ func TestADeadHTTPSLegIsRebuiltByTheNextReconcile_6827(t *testing.T) {
 	)
 	reg := newFakeReg()
 	m := newManagementReconciler(d, api.Config{ListenFunc: reg.listen})
-	d.mgmt = m
+	d.mgmt.Store(m)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -979,7 +979,7 @@ func TestDebtClearIsGenerationSafe_6827(t *testing.T) {
 		)
 		reg := newFakeReg()
 		m := newManagementReconciler(d, api.Config{ListenFunc: reg.listen})
-		d.mgmt = m
+		d.mgmt.Store(m)
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
 

--- a/pkg/daemon/management.go
+++ b/pkg/daemon/management.go
@@ -200,7 +200,31 @@ func (m *managementReconciler) desired(cfg *config.Config) api.Config {
 // start builds and starts the initial listener from the active config. A bind
 // failure is returned (the caller logs it non-fatally); the next commit retries.
 func (m *managementReconciler) start(ctx context.Context) error {
-	return m.startTo(ctx, m.desired(m.d.store.ActiveConfig()))
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// #6719: derive the desired state from the store UNDER m.mu, not before
+	// taking it. The pre-#6719 shape read ActiveConfig() first and only then
+	// contended for the lock, which lost a promotion outright:
+	//
+	//  1. start reads active config A (credential A);
+	//  2. a peer sync promotes B, revoking A, and calls reconcile;
+	//  3. that reconcile wins the lock, finds m.srv == nil, and no-ops;
+	//  4. start finally takes the lock and installs the server built from A.
+	//
+	// Credential A then stayed accepted until some later reconcile or a restart
+	// — and the same window applied to the bind address and TLS.
+	//
+	// Reading under the lock removes the case entirely, because the two orders
+	// are now both correct rather than one being lossy. If the promotion landed
+	// BEFORE this line, ActiveConfig() returns B and we install B. If it lands
+	// while we hold the lock, its reconcile blocks here and runs afterwards
+	// against a server that now exists, so it converges to B itself. There is no
+	// interleaving left in which the newer snapshot is dropped.
+	//
+	// committedDesired (the reconcile path) reads the same store.ActiveConfig(),
+	// so the two derivations agree on their authority by construction rather
+	// than by convention.
+	return m.startLocked(ctx, m.desired(m.d.store.ActiveConfig()))
 }
 
 // startTo starts the initial listener for an explicit desired config. Split from
@@ -210,6 +234,14 @@ func (m *managementReconciler) start(ctx context.Context) error {
 func (m *managementReconciler) startTo(ctx context.Context, next api.Config) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	return m.startLocked(ctx, next)
+}
+
+// startLocked is the body of start/startTo. The caller MUST hold m.mu — that is
+// the whole point of the split (#6719): start derives its snapshot from the
+// store under the same lock the reconcile path contends for, so a promotion
+// racing startup is never dropped.
+func (m *managementReconciler) startLocked(ctx context.Context, next api.Config) error {
 	// Record the attempted HTTP bind BEFORE Start so a bind failure (curSet stays
 	// false) can report it as `(bind failed)` in `show system services` (#6401).
 	m.lastHTTPAttempt = next.Addr
@@ -669,8 +701,9 @@ func (d *Daemon) deliverStaleMgmtCertDiagnosis() {
 		return
 	}
 	d.staleCertMu.Lock()
-	pending, gen, mgmt := d.staleCertPending, d.staleCertGen, d.mgmt
+	pending, gen := d.staleCertPending, d.staleCertGen
 	d.staleCertMu.Unlock()
+	mgmt := d.mgmt.Load()
 	if !pending || mgmt == nil {
 		return
 	}
@@ -810,10 +843,11 @@ func (m *managementReconciler) wait() {
 // logged (retry debt), mirroring reconcileSNMP's warn-and-retry posture rather
 // than bricking an otherwise-successful commit.
 func (d *Daemon) reconcileWebManagement(cfg *config.Config) error {
-	if d.mgmt == nil {
+	mgmt := d.mgmt.Load()
+	if mgmt == nil {
 		return nil
 	}
-	err := d.mgmt.reconcile(cfg)
+	err := mgmt.reconcile(cfg)
 	// #6827: a reconcile may have just brought HTTPS up (enable, or a retried
 	// bind). If a host-name staleness diagnosis is still owed from a window
 	// when nothing was serving, settle it now rather than losing it.

--- a/pkg/daemon/management_start_race_6719_test.go
+++ b/pkg/daemon/management_start_race_6719_test.go
@@ -1,0 +1,198 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/api"
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// #6719 — the management reconciler must not install a STALE auth snapshot when
+// a config promotion races daemon startup, and `d.mgmt` must not be a plain
+// field write racing its readers.
+//
+// The two halves are one issue because they are one window. Cluster comms start
+// at `daemon_run.go` ~:405 and the HTTP server at ~:596, so for ~190 lines of
+// Run the peer-sync apply path is live while `d.mgmt` does not exist yet. In
+// that window the pre-fix code could BOTH race the pointer AND drop the
+// promotion the peer just made.
+
+// This file deliberately reuses the #5561 management-auth fixtures
+// (mgmtAuthIfaceAddrs / mgmtAuthConfigFor / mgmtAuthCommit) rather than growing
+// a second way to commit a web-management config. They already bind an
+// OFF-LOOPBACK listener, which matters here: the #4047/#5127 runtime clamp pulls
+// a credentialed non-loopback bind back to loopback only when there is no
+// credential, so a loopback-only fixture resolves Auth to nil and the
+// stale-vs-fresh question this test asks cannot even be posed.
+
+// TestStartInstallsTheNewestSnapshotAcrossAPromotion6719 is the binder.
+//
+// It drives the PRODUCTION entry point `managementReconciler.start` — not
+// `startLocked` and not `startTo` — because the defect is in where `start`
+// reads the store relative to taking `m.mu`. A guard that called the locked
+// helper directly would pin the helper and stay green when the caller
+// regressed, which is exactly the shape that must not be shipped here.
+//
+// Sequence, deterministic by construction rather than by timing:
+//
+//  1. the store's active config carries api-key AAAA;
+//  2. the test takes m.mu, standing in for a reconcile that won the lock;
+//  3. start() is launched — post-fix it BLOCKS on the lock before reading the
+//     store; pre-fix it had already read AAAA;
+//  4. the peer promotion lands: BBBB replaces AAAA in the store;
+//  5. the lock is released and start() proceeds.
+//
+// FAIL-ON-REVERT: move the derive back outside the lock —
+// `return m.startTo(ctx, m.desired(m.d.store.ActiveConfig()))` — and start
+// installs AAAA, a credential the active config has revoked.
+func TestStartInstallsTheNewestSnapshotAcrossAPromotion6719(t *testing.T) {
+	const oldSecret, newSecret = "AAAA-old-credential", "BBBB-new-credential"
+	mgmtAuthIfaceAddrs(t)
+
+	store, err := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err != nil {
+		t.Fatalf("configstore.New: %v", err)
+	}
+	// (1) active config carries the OLD credential.
+	mgmtAuthCommit(t, store, mgmtAuthConfigFor("ge-0/0/0", oldSecret))
+
+	d := &Daemon{store: store}
+	reg := newFakeReg()
+	m := newManagementReconciler(d, api.Config{ListenFunc: reg.listen})
+	d.mgmt.Store(m)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// (2) hold the lock the way a racing reconcile would.
+	m.mu.Lock()
+
+	started := make(chan error, 1)
+	go func() { started <- m.start(ctx) }()
+
+	// The goroutine must be blocked on the lock, not past it. There is no
+	// happens-before edge to wait on, so give it a real window; if the derive is
+	// outside the lock (the pre-fix shape) it has certainly run by now, which is
+	// what makes the assertion below discriminating rather than lucky.
+	time.Sleep(150 * time.Millisecond)
+
+	// (4) the promotion the peer sync makes: same interface, NEW credential, so
+	// the endpoint is unchanged and only the credential distinguishes the two
+	// snapshots. Pinning the bind removes "it rebound" as an alternative
+	// explanation for the assertion below.
+	mgmtAuthCommit(t, store, mgmtAuthConfigFor("ge-0/0/0", newSecret))
+
+	// (5) release and let start finish.
+	m.mu.Unlock()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("start: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("start never returned after the lock was released")
+	}
+
+	m.mu.Lock()
+	srv := m.srv
+	m.mu.Unlock()
+	if srv == nil {
+		t.Fatal("setup: start must adopt a server")
+	}
+	live := srv.LiveAuth()
+	if live == nil {
+		t.Fatal("the started server carries no auth snapshot at all; the promoted config " +
+			"configures an api-auth user on an off-loopback bind, so this is not the " +
+			"stale-vs-fresh question — the fixture is not reaching resolveAPIBinds")
+	}
+	if live.Users["webadmin"] == oldSecret {
+		t.Fatalf("the started listener honours the REVOKED credential. start() derived its " +
+			"snapshot before taking m.mu, so a promotion that landed while it contended for " +
+			"the lock was dropped: the reconcile that carried it found m.srv == nil and " +
+			"no-opped, and start then installed the stale snapshot over it. The credential " +
+			"stays accepted until some later reconcile or a restart (#6719)")
+	}
+	if live.Users["webadmin"] != newSecret {
+		t.Fatalf("the started listener does not honour the newly promoted credential "+
+			"(users=%d); the newest snapshot must win", len(live.Users))
+	}
+}
+
+// TestMgmtPointerIsSafeAgainstConcurrentPublish6719 is the -race half.
+//
+// `d.mgmt` was a plain field write in startHTTPServer read unguarded by
+// reconcileWebManagement, with no happens-before edge between them — and
+// `daemon.go` said so outright: "Do not read this as `mgmt is guarded`; it is
+// not, and the remaining readers are tracked separately." This is that reader.
+//
+// The two sides deliberately do NOT run equal iteration counts. The reader
+// loops until the writer signals it is done, so the cheap side cannot finish
+// inside the expensive side's first pass and report a false green; the observed
+// read count is asserted to be non-trivial so a no-op probe is visible as one.
+//
+// FAIL-ON-REVERT: make `mgmt` a plain `*managementReconciler` field again and
+// `go test -race` reports a data race between this reader and the publish.
+func TestMgmtPointerIsSafeAgainstConcurrentPublish6719(t *testing.T) {
+	mgmtAuthIfaceAddrs(t)
+	store, err := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err != nil {
+		t.Fatalf("configstore.New: %v", err)
+	}
+	cfg := mgmtAuthCommit(t, store, mgmtAuthConfigFor("ge-0/0/0", "RACE-secret"))
+	d := &Daemon{store: store}
+
+	// BOTH sides run for the same WALL CLOCK window rather than the same
+	// iteration count. Matching the counts is the false-green shape: whichever
+	// side is cheaper finishes inside the other's first pass, and the probe
+	// reports success having never overlapped. Which side is cheaper here is not
+	// even stable — reconcileWebManagement is a fast nil-check while the pointer
+	// is unset and real work once it is set — so a duration is the only bound
+	// that guarantees contention in both regimes.
+	var reads, writes atomic.Int64
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	reg := newFakeReg()
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			d.mgmt.Store(newManagementReconciler(d, api.Config{ListenFunc: reg.listen}))
+			writes.Add(1)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			_ = d.reconcileWebManagement(cfg)
+			reads.Add(1)
+		}
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+	close(done)
+	wg.Wait()
+
+	r, w := reads.Load(), writes.Load()
+	if r < 50 || w < 50 {
+		t.Fatalf("the two sides did not actually contend (%d reads, %d publishes in 300ms), "+
+			"so this probe would report a green under -race whatever the publish did", r, w)
+	}
+	t.Logf("#6719 race probe: %d reconcileWebManagement reads vs %d publishes in 300ms "+
+		"(%.2f reads per publish)", r, w, float64(r)/float64(w))
+}


### PR DESCRIPTION
Closes #6719

Two defects, one startup window, and they are the same window rather than two
adjacent bugs. `startClusterComms` runs at `daemon_run.go` ~:405 and
`startHTTPServer` at ~:596, so for roughly **190 lines of `Run`** the peer-sync
apply path is live while the management reconciler does not exist yet.

## 1 — the publish was a data race

`d.mgmt` was a plain field written in `startHTTPServer` and read unguarded by
`reconcileWebManagement`, with no happens-before edge — on the pointer that
gates the management **auth** reconcile.

This is not a newly-suspected race. #6827 round 5 narrowed it to the stale-cert
path under `staleCertMu` and said outright that it had not solved it:

> "ONLY that read. `mgmt` is still read unguarded elsewhere … Do not read this
> as `mgmt is guarded`; it is not, and the remaining readers are tracked
> separately."

This PR is those readers. The field is now an `atomic.Pointer`, so the **type**
enforces it and a later edit cannot reintroduce the plain read. `staleCertMu`
goes back to guarding only `staleCertPending`/`staleCertGen`, and its comment no
longer claims a publication role it no longer has.

## 2 — a stale snapshot could win the startup race

`start` derived `m.desired(m.d.store.ActiveConfig())` **before** contending for
`m.mu`:

1. startup reads config A (credential A);
2. a peer sync promotes B, revoking A, and calls `reconcile`;
3. that reconcile wins the lock, finds `m.srv == nil`, and **no-ops**;
4. `start` then takes the lock and installs the server built from the stale **A**.

Credential A stayed accepted until some later reconcile or a restart. The same
window applied to the bind address and TLS.

The derive now happens **under the lock**. That does not pick a winner — it
removes the lossy interleaving. A promotion landing before the read is seen by
`ActiveConfig()`; one landing while the lock is held blocks and then converges
against a server that now exists. `committedDesired` (the reconcile path) reads
the same `store.ActiveConfig()`, so the two derivations agree on their authority
**by construction** rather than by convention. `startLocked` is the shared body;
`startTo` stays the explicit-config test seam.

Publishing before `start()` now matters too: a reconcile arriving in the window
finds a non-nil reconciler and is merely no-opped by the `m.srv == nil` gate
rather than dropped at the daemon level — and `start` then reads the store, so
the promotion that reconcile carried is picked up rather than lost.

## Why this lands before #6718 / #6720

Those two share a different mechanism (a path that promotes a config and returns
before `applyConfigLocked`, the sole caller of `reconcileWebManagement`) and are
coming next in one PR. **#6720's fix depends on this one.** A
`reconcileWebManagement` call added to the peer-sync path would land inside the
window above and be swallowed **twice** — `reconcileWebManagement` returns nil on
`d.mgmt == nil`, and `reconcileTo` no-ops on `m.srv == nil`. A fix that no-ops on
the exact path it was written for, with every test green, is the worst available
outcome, so the ordering dependency is paid first.

#6718 is *not* coupled: `commit confirmed` requires an operator commit, which
requires the management surface to already be up.

## Guards

Both drive **production entry points**, not the locked helpers — the binder calls
`m.start`, the probe calls `d.reconcileWebManagement`. A guard on `startLocked`
would pin the helper and stay green when the caller regressed, which is precisely
the defect being fixed.

The race probe runs both sides for a fixed **wall-clock window** rather than
equal iteration counts, and asserts both counts are non-trivial. Equal counts
would be a false green here in a way that is not even stable in one direction:
`reconcileWebManagement` is a fast nil-check while the pointer is unset and real
work once it is set, so whichever side is "cheap" depends on scheduling. Observed:
~26k reads against ~600k publishes in 300ms.

The fixtures are the existing #5561 ones (`mgmtAuthIfaceAddrs` /
`mgmtAuthConfigFor` / `mgmtAuthCommit`) rather than a second way to commit a
web-management config. That is load-bearing, not tidiness: they bind an
**off-loopback** listener, and the #4047/#5127 runtime clamp resolves `Auth` to
nil on a loopback-only fixture — the stale-vs-fresh question could not even be
posed. The binder pins the bind address across the promotion and changes only the
credential, so "it rebound" is not an alternative explanation for the result.

## Validation

- `go build ./...`, `gofmt`, `go vet ./pkg/daemon/` clean.
- **`go test -count=1 ./...` green repo-wide**, not just the touched package.
- `go test ./pkg/daemon/ -race` green.

### Mutation

| # | Mutation | Verdict |
|---|---|---|
| **P1b** | restore the **verbatim** pre-#6719 `start` body from `origin/master` | **RED** — the binder fires its own assertion: "the started listener honours the REVOKED credential" |
| **P2** | revert the atomic to an unsynchronised pointer wearing the same `Load`/`Store` shape | **RED** — `WARNING: DATA RACE` under `-race` |

An earlier attempt (P1) that unlocked and re-locked *inside* `start` came back
**green and was discarded as unfaithful, not recorded as a result**: it re-read
the store after the test had already released the lock, so it never reproduced
the pre-fix ordering. That is why the recorded cell restores the verbatim
pre-fix bytes rather than a paraphrase.

## Cluster surface

This touches `Run` phase ordering with cluster comms live and the peer-sync
apply path's reconciler. **It owes `make test-failover`, which runs centrally**;
no cluster targets were run from this lane.

Refs #6718, #6720, #6827, #7486.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VM24XVAYBhzAUSAAhnR8Xp
