### PR TITLE
config: give the spelling gate typed path identifiers

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103662,3 +103662,26 @@ prose edit above them added. No diff falls in the new test body.
   pkg/cluster/heartbeat_epoch_preserve_6711_test.go (new),
   pkg/cluster/heartbeat_epoch_latch_test.go,
   pkg/cluster/heartbeat_epoch_test.go
+
+## 2026-08-22 — #7492 typed path identifiers recover 72 more leaves
+- **Timestamp**: 2026-08-22
+- **Action**: Found the dominant cause of the `unreachable` bucket: the harness
+  names every `args` path slot with a synthetic WORD, but `interfaces <if> unit
+  <n>` needs a NUMBER, so the whole unit subtree was discarded. gateEffectivePath
+  now falls back to a numeric-arg path when (and only when) the word path leaves
+  the leaf inert. Coverage 629 -> 687; unreachable 215 -> 143 (72 moved: 58
+  compared, 14 revealed as flags, so the flag ceiling rises 161 -> 175 again).
+  Substitution is compile-time only, so siteKey/parentKey normalisation and every
+  allowlist/prereq row are untouched.
+- **Refuted first, both measured**: (a) the #6696 "schema advertises knobs nothing
+  implements" hypothesis — only 22 leaves have a name absent from compiler
+  source, and 21 are self-documented as deliberately unimplemented; (b) the
+  dangling-reference hypothesis — scheduler-map/classifier values land whether or
+  not the referent exists. Over-application was measured too: numeric-by-default
+  scores 635 (worse than 687) AND manufactures false findings at loss-priority.
+- **One real finding surfaced**: `security log profile <*> category session
+  field-extra-name` commits clean and never reaches the compiled config, with no
+  "not implemented" note in its description. Filed separately.
+- **File(s)**: pkg/config/schema_spelling_differential_gate_test.go,
+  pkg/config/schema_spelling_gate_coverage_7484_test.go, docs/config-schema.md
+

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -4049,6 +4049,58 @@ could finally see them. The `flag` ceiling therefore goes UP (158 → 161) in th
 same change that improves coverage. The population changed; a pre-fix number
 carried forward as a target would have read that as a regression.
 
+### Typed path identifiers, and the real cause of the `unreachable` bucket (#7492)
+
+The harness names every `args` slot in a synthetic parent path with a
+synthetic WORD (`xa20`). Many slots are not word-typed. `interfaces <if> unit
+<n>` needs a NUMBER, and `unit xa20` does not parse as a unit — so the compiler
+discards the whole unit subtree and every leaf beneath it looks `inert`.
+
+That single cause accounted for **72 of the 215** remaining `unreachable`
+leaves, all under `interfaces <*>` — the largest parent prefix, and one general
+mechanism rather than the 46 per-parent recipes the issue predicted.
+
+`gateEffectivePath` therefore compiles a leaf with the **word path first** and
+falls back to a numeric-arg path only when the word path leaves the first value
+inert AND the numeric path does not. The substitution happens at COMPILE time
+only: `gateLeaf.path` keeps its word tokens, so `siteKey()` / `parentKey()`
+normalisation, allowlist rows and prerequisite rows are all unaffected by which
+form a leaf ends up using.
+
+**Fallback, never default — and that is not caution, it is measured.** Making
+the numeric form the default instead scores **worse in both directions**:
+coverage falls to 635 (below the 687 the fallback reaches, because ~52 slots
+genuinely need a word), *and* it manufactures FALSE #2419 findings at
+`class-of-service classifiers dscp <*> forwarding-class <*> loss-priority <*>
+code-points` with `A=inert B=inert C=inert D=keep E=keep F=inert` — `7` is not a
+valid loss-priority, so the brace forms go inert while the set forms still read
+the leaf. An always-numeric harness would have looked like a simplification and
+been strictly worse.
+
+**What the `unreachable` bucket is NOT.** Two hypotheses were measured and
+refuted before this one:
+
+- *"setSchema advertises knobs nothing implements"* (the #6696 class). Of the
+  215, only 14 distinct leaf names never appear as a quoted literal anywhere in
+  non-test, non-schema compiler source — 22 leaves — and **21 of those 22 are
+  explicitly self-documented in their own schema description**: `rx-mode` says
+  "retired, ignored", `security ipsec vpn <*> manual` says "NOT supported —
+  rejected at commit", and every `dhcp-local-server … interface <*>` modifier
+  says "(parsed, not implemented)". Deliberate, declared, and correctly inert.
+  Exactly one leaf lacks such a note — see below.
+- *"the value is a dangling reference the harness never defines"*. Refuted
+  directly: `scheduler-map SM1` and `classifiers dscp CL1` both land in the
+  compiled config whether or not the referent exists.
+
+Widening the instrument does not rescue the first hypothesis either: only 31 of
+the 215 carry a not-implemented marker in their description at all.
+
+**The one genuine finding it did surface.** `security log profile <*> category
+session field-extra-name` commits CLEAN on the strict path, its container
+materialises, and the value never reaches the compiled config — while its
+description ("Extra field to include in session records") reads like a working
+feature, unlike its 21 neighbours. Tracked separately rather than folded here.
+
 **The durable half is the gate.** `TestSchemaSpellingDifferentialGate` gains a
 SEVENTH spelling, `F-hier-mixed` (`leaf <v1> { <v2>; }`) — the only spelling that
 puts values in both AST slots of one node, which is exactly what an either/or

--- a/pkg/config/schema_spelling_differential_gate_test.go
+++ b/pkg/config/schema_spelling_differential_gate_test.go
@@ -354,6 +354,9 @@ type gateLeaf struct {
 	path  []string
 	leaf  string
 	multi bool
+	// desc is the schema's operator-facing description, read by #7492 to tell a
+	// leaf the project has DECLARED unimplemented from one that is silently so.
+	desc string
 	// args is the schema's declared value arity. #7484 reads it to prove that
 	// `args == 0` does NOT imply value-less, so nobody "optimises" the coverage
 	// classifier into excluding those leaves.
@@ -435,7 +438,7 @@ func enumerateGateLeaves() []gateLeaf {
 				if ch.midKeyword != "" || ch.args > 1 {
 					continue
 				}
-				g := gateLeaf{path: append([]string{}, path...), leaf: key, multi: ch.multi, args: ch.args}
+				g := gateLeaf{path: append([]string{}, path...), leaf: key, multi: ch.multi, args: ch.args, desc: ch.desc}
 				if _, skip := notAValueList[g.siteKey()]; skip {
 					continue
 				}
@@ -567,6 +570,92 @@ var gateSpellingsScalar = []string{"A-hier-bracket", "B-hier-block", "D-set-brac
 //	"err"      a spelling failed to parse or compile
 //
 // ---------------------------------------------------------------------------
+// TYPED PATH IDENTIFIERS (#7492).
+//
+// The harness names every `args` slot in a parent path with a synthetic WORD
+// (`xa20`). Many slots are not word-typed: `interfaces <if> unit <n>` needs a
+// NUMBER, and `unit xa20` does not parse as a unit, so the compiler discards the
+// whole unit subtree and every leaf beneath it looks inert. Measured: retrying
+// the unreachable leaves with a numeric arg token recovers 72 of 215, all under
+// `interfaces <*>` — one general cause, not 46 per-parent ones.
+//
+// The numeric form is a FALLBACK, never the default. A leaf is compiled with the
+// word path first; the numeric path is used only when the word path leaves the
+// FIRST value inert and the numeric path does not. So this can only ever turn
+// an uncomparable leaf into a comparable one — it cannot change an existing
+// verdict, and a slot that genuinely needs a word is unaffected.
+//
+// The substitution happens at COMPILE time only. gateLeaf.path keeps its word
+// tokens, so siteKey()/parentKey() normalisation, the allowlist rows and the
+// prerequisite rows are all untouched by which form a leaf ends up using.
+// ---------------------------------------------------------------------------
+
+// gateNumericArgs returns a copy of path with every synthetic ARG token replaced
+// by a number. Wildcard tokens are left alone: they name a container instance,
+// not a typed value, and a numeric name is no more valid there than a word.
+func gateNumericArgs(path []string) []string {
+	out := make([]string, len(path))
+	for i, tok := range path {
+		if strings.HasPrefix(tok, gateArgPrefix) {
+			out[i] = "7"
+			continue
+		}
+		out[i] = tok
+	}
+	return out
+}
+
+var gateEffectivePathCache = map[string][]string{}
+
+// gateEffectivePath picks the path this leaf is compiled with: the authored word
+// form, or the numeric-arg form when the word form makes the leaf unreadable.
+func gateEffectivePath(g gateLeaf) []string {
+	key := g.siteKey()
+	if p, ok := gateEffectivePathCache[key]; ok {
+		return p
+	}
+	chosen := g.path
+	numeric := gateNumericArgs(g.path)
+	if !equalPaths(numeric, g.path) {
+		if wordInert(g, g.path) && !wordInert(g, numeric) {
+			chosen = numeric
+		}
+	}
+	gateEffectivePathCache[key] = chosen
+	return chosen
+}
+
+func equalPaths(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// wordInert reports whether the leaf's FIRST value fails to move the compiled
+// output under this path — the same "inert" condition the differential uses,
+// tried across every value pair so a type mismatch on one pair is not mistaken
+// for the leaf being unreadable.
+func wordInert(g gateLeaf, path []string) bool {
+	base, err := gateCompileBrace(gateBraceConfig(path, ""))
+	if err != nil {
+		return true
+	}
+	for _, vp := range gateValuePairs {
+		one, err := gateCompileBrace(gateBraceConfig(path, g.leaf+" "+vp.v1+";"))
+		if err == nil && one != base {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
 // PARENT PREREQUISITES (#7492).
 //
 // The harness authors a leaf ALONE inside its synthetic parent path. Some
@@ -624,13 +713,14 @@ func gateLeafPrereq(g gateLeaf) (string, []string) {
 			// experiment from the one the row was verified for.
 			return "", nil
 		}
-		sets = append(sets, "set "+strings.Join(g.path, " ")+" "+stmt)
+		sets = append(sets, "set "+strings.Join(gateEffectivePath(g), " ")+" "+stmt)
 	}
 	return body, sets
 }
 
 func spellingVerdicts(g gateLeaf, v1, v2 string) map[string]string {
-	flat := "set " + strings.Join(append(append([]string{}, g.path...), g.leaf), " ")
+	epath := gateEffectivePath(g)
+	flat := "set " + strings.Join(append(append([]string{}, epath...), g.leaf), " ")
 	// #7492: prepend the parent prerequisite, identically in every form, so it
 	// cancels out of the comparison and only decides whether a comparison exists.
 	preBody, preSets := gateLeafPrereq(g)
@@ -638,7 +728,7 @@ func spellingVerdicts(g gateLeaf, v1, v2 string) map[string]string {
 		if preBody != "" {
 			stmt = preBody + " " + stmt
 		}
-		return gateCompileBrace(gateBraceConfig(g.path, stmt))
+		return gateCompileBrace(gateBraceConfig(epath, stmt))
 	}
 	sets := func(cmds ...string) (string, error) {
 		return gateCompileSet(append(append([]string{}, preSets...), cmds...))

--- a/pkg/config/schema_spelling_gate_coverage_7484_test.go
+++ b/pkg/config/schema_spelling_gate_coverage_7484_test.go
@@ -107,11 +107,12 @@ func classifyGateBlindLeaf(g gateLeaf) gateBlindClass {
 	// classifier reasons about a different config than the gate it explains —
 	// a leaf the prerequisite rescued would still be reported as unreachable.
 	pre, _ := gateLeafPrereq(g)
+	epath := gateEffectivePath(g)
 	withPre := func(stmt string) (string, error) {
 		if pre != "" {
 			stmt = pre + " " + stmt
 		}
-		return gateCompileBrace(gateBraceConfig(g.path, stmt))
+		return gateCompileBrace(gateBraceConfig(epath, stmt))
 	}
 	noLeaf, errNo := withPre("")
 	bare, errBare := withPre(g.leaf + ";")
@@ -148,16 +149,18 @@ func classifyGateBlindLeaf(g gateLeaf) gateBlindClass {
 // Measured at 6b47801de. Raising a ceiling is a real decision: it says a leaf
 // the #2419 class can hide in was added on purpose.
 // ---------------------------------------------------------------------------
-const gateCoverageFloor = 629
+const gateCoverageFloor = 687
 
 var gateBlindCeiling = map[gateBlindClass]int{
-	// #7492 moved 13 leaves out of `unreachable`: 10 became COMPARED and 3 were
-	// revealed to be flags once the parent prerequisite let their container
-	// materialise. That is why the flag ceiling RISES here — the population
+	// #7492 moved leaves out of `unreachable` in two rounds. The parent
+	// prerequisite moved 13 (10 compared, 3 revealed as flags); the typed
+	// path-identifier fallback then moved 72 more (58 compared, 14 revealed as
+	// flags) by giving `interfaces <if> unit <n>` a NUMERIC unit instead of a
+	// synthetic word. That is why the flag ceiling RISES here — the population
 	// changed, and a blind-spot count going up after a fix is the fix working,
 	// not a regression. Never carry a pre-fix number forward as a target.
-	gateBlindUnreachable: 215,
-	gateBlindFlag:        161,
+	gateBlindUnreachable: 143,
+	gateBlindFlag:        175,
 	gateBlindErr:         43,
 	gateBlindValueMoves:  1,
 }


### PR DESCRIPTION
Refs #7492 — recovers 72 more leaves and identifies the bucket's dominant cause. Surfaced finding: #7502.

## The cause

The harness names every `args` slot in a synthetic parent path with a synthetic **word** (`xa20`). Many slots are not word-typed: `interfaces <if> unit <n>` needs a **number**, and `unit xa20` does not parse as a unit — so the compiler discards the whole unit subtree and every leaf beneath it looks `inert`.

That one cause accounted for **72 of the 215** remaining `unreachable` leaves, all under `interfaces <*>`, the largest parent prefix. A single general mechanism, not the 46 per-parent recipes #7492 predicted.

**Coverage 629 → 687. `unreachable` 215 → 143.**

As before, the leaves that left the bucket did not all become comparable: **58 became compared, 14 were revealed to be flags** once their subtree survived compilation. The `flag` ceiling rises 161 → 175 in the same change that improves coverage.

## Fallback, never default — measured, not cautious

`gateEffectivePath` compiles a leaf with the **word path first** and uses the numeric-arg path only when the word path leaves the first value inert *and* the numeric path does not. It can only ever turn an uncomparable leaf into a comparable one.

Making numeric the **default** instead is worse in *both* directions:

- coverage falls to **635**, below the 687 the fallback reaches, because ~52 slots genuinely need a word;
- it **manufactures false #2419 findings** at `class-of-service classifiers dscp <*> forwarding-class <*> loss-priority <*> code-points` — `A=inert B=inert C=inert D=keep E=keep F=inert`, because `7` is not a valid loss-priority, so brace forms go inert while set forms still read the leaf.

An always-numeric harness would have looked like a simplification and been strictly worse. Substitution is **compile-time only**: `gateLeaf.path` keeps its word tokens, so `siteKey()`/`parentKey()` normalisation and every allowlist and prerequisite row are unaffected.

## Two hypotheses measured and refuted first

- **"`setSchema` advertises knobs nothing implements"** (the #6696 class). Of the 215, only 14 distinct leaf names never appear as a quoted literal in non-test, non-schema compiler source — 22 leaves — and **21 of those 22 are explicitly self-documented**: `rx-mode` says "retired, ignored", `security ipsec vpn <*> manual` says "NOT supported — rejected at commit", every `dhcp-local-server … interface <*>` modifier says "(parsed, not implemented)". Widening the instrument does not rescue it either: only 31 of the 215 carry a not-implemented marker at all.
- **"the value is a dangling reference the harness never defines"**. Refuted directly: `scheduler-map SM1` and `classifiers dscp CL1` both land whether or not the referent exists.

**Instrument limits, stated rather than glossed:** a grep HIT does not prove a leaf is read at that path (`port` hits everywhere), and a MISS does not prove it is unread (a compiler can read children without naming them). Only absence-of-any-occurrence was treated as a signal, and **every candidate was then read by hand** — which is exactly what showed 21 of 22 to be deliberate. An earlier pass reported 23 because `grep -Ff` matches substrings and `encryption` pulled in `encryption-algorithm` (which is implemented); the count is 22 with exact matching.

## The one genuine finding — filed, not folded

`security log profile <*> category session field-extra-name` commits **clean** on the strict path, its container materialises, and the value never reaches the compiled config — while its description reads like a working feature, unlike its 21 neighbours which say otherwise. **#7502.**

## Mutation matrix

`flock`'d; tree asserted clean before and restored after, mutation asserted APPLIED, `go vet` clean before running, exit code from a file, tests-collected asserted > 0.

| cell | mutation | result |
|---|---|---|
| **P1** | delete the numeric fallback (always word path) | **RED**, exactly reversed: `COVERAGE REGRESSED 629 vs floor 687` + `unreachable 215 vs ceiling 143 (+72)` |
| **P2** | make numeric the **default** rather than a fallback | **RED on both counts**: coverage 635 (below floor) **and** `TestSchemaSpellingDifferentialGate` fails with the false loss-priority findings above |

P2 is the cell that matters: it shows the fallback **shape** is load-bearing, not merely its presence. A delete-only matrix would have proven the feature does something; only the over-application cell shows that the obvious simplification is wrong.

## Scope

`pkg/config` test-harness only, plus docs. No production code.

Validation: `go build ./...` clean; **`go test -count=1 ./...` rc=0, 0 FAIL, 71 packages** at the merged head (tree-wide, not package-scoped — the disk incident that would have limited it is resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkfVhT4Y3UDa22mU7uoCVt
