### PR TITLE
cluster: retry a boot-epoch persist that could not land (#6724 trigger half)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103662,3 +103662,12 @@ prose edit above them added. No diff falls in the new test body.
   pkg/cluster/heartbeat_epoch_preserve_6711_test.go (new),
   pkg/cluster/heartbeat_epoch_latch_test.go,
   pkg/cluster/heartbeat_epoch_test.go
+
+## 2026-08-22 — #6724 boot-epoch persist-retry trigger
+- **Action**: `refineBootEpochReporting` now reports whether a persist is OWED
+  (fault, not a deliberate decline); `Manager.retryOwedBootEpochPersist` re-runs
+  refinement from the heartbeat sender loop while one is. The mis-ordering half
+  is split to #7501.
+- **File(s)**: `pkg/cluster/heartbeat_epoch.go`, `pkg/cluster/heartbeat.go`,
+  `pkg/cluster/manager.go`,
+  `pkg/cluster/heartbeat_epoch_persist_retry_6724_test.go` (new)

--- a/pkg/cluster/heartbeat.go
+++ b/pkg/cluster/heartbeat.go
@@ -1266,12 +1266,27 @@ func (s *heartbeatSender) run() {
 	ticker := time.NewTicker(s.interval)
 	defer ticker.Stop()
 
+	// #6724: the boot-epoch persist-retry trigger rides this loop rather than
+	// owning a goroutine. This package's start/stop discipline is where its
+	// hazards live (superseded starts, leaked loops whose stopCh is never
+	// closed), so a retry that needs no new lifecycle is the cheaper thing to
+	// get right. The per-tick cost when nothing is owed is one atomic load —
+	// and it is only paid once every retryEvery ticks, so the 200ms send path
+	// is untouched in the ordinary case.
+	retryEvery := bootEpochPersistRetryTicks(s.interval)
+	ticks := 0
+
 	for {
 		select {
 		case <-s.stopCh:
 			return
 		case <-ticker.C:
 			s.send()
+			ticks++
+			if ticks >= retryEvery {
+				ticks = 0
+				s.mgr.retryOwedBootEpochPersist()
+			}
 		}
 	}
 }

--- a/pkg/cluster/heartbeat_epoch.go
+++ b/pkg/cluster/heartbeat_epoch.go
@@ -197,20 +197,6 @@ const (
 	// rather than preserved forever.
 	bootEpochPreserveMaxSkew uint64 = 30 * 24 * 60 * 60 * 1_000_000_000
 
-	// bootEpochPersistRetryInterval is how often the #6724 trigger re-attempts
-	// a persist that a previous refine pass could not complete.
-	//
-	// 30s is chosen against what the retry is racing, not against the fault:
-	// a peer that latched a raise this node emitted but could not persist
-	// refuses a concurrent incarnation until the value reaches the file. The
-	// pre-#6724 bound on that was "until the next heartbeat (re)start", which
-	// is event-driven and unbounded — a daemon can run for days without one.
-	// Anything in the tens of seconds converts an unbounded wait into a bounded
-	// one; shorter buys nothing, because the faults that make a persist fail
-	// (a full or read-only filesystem, a wedged store) do not clear in
-	// milliseconds, and each attempt takes the epoch file lock.
-	bootEpochPersistRetryInterval = 30 * time.Second
-
 	// epochClockSaneFloor is 2020-01-01T00:00:00Z in nanoseconds: the point
 	// below which the LOCAL clock is obviously unset rather than merely wrong.
 	//
@@ -242,6 +228,26 @@ var bootEpochPath = "/var/lib/xpf/ha-boot-epoch"
 // Stop runs immediately after VRRP priority-0 and before the session-sync stop
 // (its own 5s), inside the unit's TimeoutStopSec=20.
 const bootEpochStopJoinBudget = 2 * time.Second
+
+// bootEpochPersistRetryInterval is how often the #6724 trigger re-attempts a
+// persist that a previous refine pass could not complete.
+//
+// 30s is chosen against what the retry is racing, not against the fault: a peer
+// that latched a raise this node emitted but could not persist refuses a
+// concurrent incarnation until the value reaches the file. The pre-#6724 bound
+// on that was "until the next heartbeat (re)start", which is event-driven and
+// unbounded — a daemon can run for days without one. Anything in the tens of
+// seconds converts an unbounded wait into a bounded one; shorter buys nothing,
+// because the faults that make a persist fail (a full or read-only filesystem,
+// a wedged store) do not clear in milliseconds, and each attempt takes the
+// epoch file lock.
+//
+// A var, not a const, for the same reason bootEpochPath and epochFlock are:
+// the WIRING test drives a real heartbeatSender loop, and at the production
+// interval the retry cadence is 150 ticks — thirty seconds of wall clock the
+// test would have to spend to observe one retry. Never reassigned in
+// production.
+var bootEpochPersistRetryInterval = 30 * time.Second
 
 // epochFlock is the lock withEpochFileLock takes. A var for the same reason
 // epochNowNanos is one: the SECOND of its two failure branches is otherwise

--- a/pkg/cluster/heartbeat_epoch.go
+++ b/pkg/cluster/heartbeat_epoch.go
@@ -197,6 +197,20 @@ const (
 	// rather than preserved forever.
 	bootEpochPreserveMaxSkew uint64 = 30 * 24 * 60 * 60 * 1_000_000_000
 
+	// bootEpochPersistRetryInterval is how often the #6724 trigger re-attempts
+	// a persist that a previous refine pass could not complete.
+	//
+	// 30s is chosen against what the retry is racing, not against the fault:
+	// a peer that latched a raise this node emitted but could not persist
+	// refuses a concurrent incarnation until the value reaches the file. The
+	// pre-#6724 bound on that was "until the next heartbeat (re)start", which
+	// is event-driven and unbounded — a daemon can run for days without one.
+	// Anything in the tens of seconds converts an unbounded wait into a bounded
+	// one; shorter buys nothing, because the faults that make a persist fail
+	// (a full or read-only filesystem, a wedged store) do not clear in
+	// milliseconds, and each attempt takes the epoch file lock.
+	bootEpochPersistRetryInterval = 30 * time.Second
+
 	// epochClockSaneFloor is 2020-01-01T00:00:00Z in nanoseconds: the point
 	// below which the LOCAL clock is obviously unset rather than merely wrong.
 	//
@@ -504,8 +518,11 @@ func epochWithinForwardBound(epoch uint64, nowNanos int64) bool {
 // (Manager.refreshBootEpoch), so the stranded incarnation raises itself above
 // the file again at its next heartbeat (re)start instead of being pinned below
 // the floor for the life of the process by a one-shot sync.Once. Between the
-// mis-ordering and that next start this node IS refused, and there is no
-// periodic re-check — tracked as #6724. See
+// mis-ordering and that next start this node IS refused. #6724 closed the
+// half of that gap which was a MISSING TRIGGER rather than missing state —
+// Manager.retryOwedBootEpochPersist re-runs refinement from the sender loop
+// when, and only when, a pass could not persist — and the mis-ordering itself
+// is tracked as #7501. See
 // TestConcurrentIncarnationsAreOrderedByLockAcquisition_6669.
 //
 // THAT RECOVERY CARRIES TWO CONDITIONS, and stating it flat overstates it. The
@@ -535,13 +552,18 @@ func epochWithinForwardBound(epoch uint64, nowNanos int64) bool {
 // "a predecessor wrote it after a backward clock step" needs a writer identity
 // or a lifetime-held liveness lock, which is where the leapfrog lives.
 //
-// CONDITION 1 needs neither. It needs A to RETRY ITS FAILED PERSIST, and the
-// code already does the right thing on a retry: A's published value is already
-// b+1, so `next := prev+1` is not > epoch, nothing ratchets, and the
-// WriteFileDurable is simply re-attempted. Once b+1 reaches the file, B's next
-// refreshBootEpoch reads it, raises to b+2 and is admitted. What is missing is
-// only a TRIGGER for that retry — the "no periodic re-check" half of #6724 —
-// which is a materially smaller change than a writer identity.
+// CONDITION 1 needs neither, and is CLOSED (#6724). It needed A to RETRY ITS
+// FAILED PERSIST, and the code already did the right thing on a retry: A's
+// published value is already b+1, so `next := prev+1` is not > epoch, nothing
+// ratchets, and the WriteFileDurable is simply re-attempted. Once b+1 reaches
+// the file, B's next refreshBootEpoch reads it, raises to b+2 and is admitted.
+// What was missing was only a TRIGGER for that retry, which is a materially
+// smaller change than a writer identity: refineBootEpochReporting now reports
+// whether a persist is OWED, and Manager.retryOwedBootEpochPersist re-runs
+// refinement from the heartbeat sender loop while one is. The gate is
+// load-bearing in the other direction too — an UNCONDITIONAL periodic refine
+// would make the leapfrog below continuous, so both nodes would be refused for
+// part of every period instead of one being refused until its next restart.
 //
 // Fails CLOSED: if the lock cannot be taken, the read-modify-write is SKIPPED
 // rather than run unlocked. A lock whose failure path executes the critical
@@ -1108,7 +1130,12 @@ func (m *Manager) startBootEpochRefine(ready chan struct{}) {
 			}
 		}()
 		for {
-			m.bootEpochWrote.Store(refineBootEpoch(path, &m.bootEpoch, m.bootEpochWrote.Load()))
+			gotWrote, owed := refineBootEpochReporting(path, &m.bootEpoch, m.bootEpochWrote.Load())
+			m.bootEpochWrote.Store(gotWrote)
+			// #6724: record the retry trigger AFTER the watermark, so an
+			// observer that sees the flag also sees the watermark the pass
+			// produced.
+			m.bootEpochPersistOwed.Store(owed)
 			if ready != nil && !signalled {
 				signalled = true
 				close(ready)
@@ -1119,6 +1146,54 @@ func (m *Manager) startBootEpochRefine(ready chan struct{}) {
 			}
 		}
 	}()
+}
+
+// bootEpochPersistRetryTicks is how many heartbeat sender ticks pass between
+// two #6724 persist retries, derived from the send interval so the RATE is
+// what is configured, not the tick count.
+//
+// A TICK COUNT, not a deadline. Every clock this package could compare against
+// is the wall clock, and a backward step in it is the exact fault the boot
+// epoch exists to survive — a deadline would suspend retries for the duration
+// of the very step that makes them matter. Ticks are monotonic by
+// construction. The counter lives on the sender, so it resets on a heartbeat
+// restart, which is harmless: a restart already runs a full refine.
+func bootEpochPersistRetryTicks(interval time.Duration) int {
+	if interval <= 0 {
+		return 1
+	}
+	if n := int(bootEpochPersistRetryInterval / interval); n > 1 {
+		return n
+	}
+	return 1
+}
+
+// retryOwedBootEpochPersist re-runs refinement when, and ONLY when, a previous
+// pass left a persist owed (#6724).
+//
+// THE GATE IS THE WHOLE DESIGN, and an unconditional periodic refine — the
+// obvious simpler thing — is worse rather than merely more expensive. While two
+// incarnations overlap, each refine pass raises above the other and rewrites
+// the file, so they leapfrog; running that on a timer would make the leapfrog
+// CONTINUOUS, and each node would be refused by the peer for part of every
+// period instead of one node being refused until its next heartbeat restart.
+// Alternating refusal is worse for HA than a stable one: it is what makes a
+// peer fail over repeatedly. Gating on an owed persist makes this a no-op in
+// exactly that case — two healthy incarnations both persist successfully, so
+// neither ever owes anything — while still closing the case the trigger exists
+// for, where a pass could not write at all.
+//
+// It cannot fix the mis-ordering itself. Separating "a concurrent newer
+// incarnation wrote it" from "a predecessor wrote it after a backward clock
+// step" needs a writer identity or a lifetime-held liveness lock, which is
+// larger than the epoch — see withEpochFileLock and #7501.
+func (m *Manager) retryOwedBootEpochPersist() {
+	if !m.bootEpochPersistOwed.Load() {
+		return
+	}
+	// refreshBootEpoch coalesces onto a running worker and never blocks, so
+	// this cannot stall the send loop it is called from.
+	m.refreshBootEpoch()
 }
 
 // refineBootEpoch is the off-path half of heartbeatBootEpoch: consult the
@@ -1144,14 +1219,46 @@ func (m *Manager) startBootEpochRefine(ready chan struct{}) {
 // post-rename directory-fsync failure as a typed *PostRenameSyncError, and at
 // that point the new content is already VISIBLE (#5185); only its durability is
 // unknown. That pass DID move the file, so it returns the value it wrote.
+// refineBootEpoch is the value-only form, kept because it is what the epoch
+// tests drive. Production uses refineBootEpochReporting, which additionally
+// reports whether a persist is still OWED — see that function.
 func refineBootEpoch(path string, published *atomic.Uint64, lastWrote uint64) (wrote uint64) {
+	wrote, _ = refineBootEpochReporting(path, published, lastWrote)
+	return wrote
+}
+
+// refineBootEpochReporting is refineBootEpoch plus the #6724 retry signal.
+//
+// persistOwed is true when this pass ended with the published epoch NOT known
+// to be on disk because something FAILED or was SKIPPED — the directory create,
+// the lock, the read, or the write. It is deliberately false for every pass
+// that DECLINED to write on purpose (the #6711 preserve branch, the heal
+// branch, and the `prev == lastWrote` no-op), because those are decisions, not
+// faults, and retrying them forever would be a busy loop over a file this node
+// has already decided not to touch.
+//
+// WHY THE SIGNAL CANNOT BE DERIVED FROM published != wrote AT THE CALL SITE,
+// which is the obvious cheaper thing: the #6711 preserve branch also ends with
+// published (this incarnation's wall-clock seed) != wrote (0, nothing written),
+// and it ends that way FOREVER by design. A caller comparing those two would
+// retry a preserved file on every period for the life of the process, which is
+// exactly the state #7499 created on purpose. Only this function knows which
+// branch it took.
+func refineBootEpochReporting(path string, published *atomic.Uint64, lastWrote uint64) (wrote uint64, persistOwed bool) {
 	wrote = lastWrote
 	if err := fsatomic.MkdirAllDurable(filepath.Dir(path), 0o755); err != nil {
 		slog.Warn("cluster: HA boot-epoch state dir create failed; this incarnation's epoch is NOT durable "+
 			"(a backward clock step across the next restart could regress it)", "path", path, "err", err)
-		return wrote
+		return wrote, true
 	}
+	// `ran` distinguishes "the lock could not be taken, so the critical section
+	// never executed" from "it ran and decided not to write" (#6724).
+	// withEpochFileLock reports nothing itself, and giving it a return value
+	// would churn every one of its callers for a fact the caller can observe
+	// here for free.
+	ran := false
 	withEpochFileLock(path, func() {
+		ran = true
 		var prev uint64
 		if data, err := os.ReadFile(path); err == nil {
 			// ONE clock sample, taken AFTER the read RETURNS and shared by the
@@ -1292,6 +1399,8 @@ func refineBootEpoch(path string, published *atomic.Uint64, lastWrote uint64) (w
 			// overwriting unknown state is not a safe way to fail.
 			slog.Warn("cluster: HA boot-epoch state read error; keeping the wall-clock epoch "+
 				"and NOT overwriting the persisted value", "path", path, "err", err)
+			// #6724: unknown state, not a decision — worth re-reading later.
+			persistOwed = true
 			return
 		}
 
@@ -1333,9 +1442,18 @@ func refineBootEpoch(path string, published *atomic.Uint64, lastWrote uint64) (w
 			}
 			slog.Warn("cluster: HA boot-epoch state persist failed; this incarnation's epoch is NOT durable "+
 				"(a backward clock step across the next restart could regress it)", "path", path, "err", err)
+			// #6724: the raise this pass published (if any) is on the wire but
+			// not on disk. Until it lands, a peer that latched it can refuse a
+			// concurrent incarnation that has no other way to learn of it.
+			persistOwed = true
 			return
 		}
 		wrote = epoch
 	})
-	return wrote
+	if !ran {
+		// The lock was unavailable, so the read-modify-write was skipped
+		// entirely (withEpochFileLock fails CLOSED). Nothing was decided.
+		persistOwed = true
+	}
+	return wrote, persistOwed
 }

--- a/pkg/cluster/heartbeat_epoch_persist_retry_6724_test.go
+++ b/pkg/cluster/heartbeat_epoch_persist_retry_6724_test.go
@@ -1,0 +1,296 @@
+package cluster
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// #6724: a refine pass that could not PERSIST used to have no retry at all.
+// The only re-run was at the next heartbeat (re)start, which is event-driven
+// and unbounded — a daemon can run for days without one. Meanwhile a peer that
+// latched a raise this node emitted but could not write refuses a concurrent
+// incarnation, which has no other channel to learn of it.
+//
+// These pin the trigger and, just as importantly, WHEN IT MUST NOT FIRE.
+
+// TestPersistOwedIsSetOnlyByFAULTS_6724 is the discriminator the whole trigger
+// rests on: a pass that DECLINED to write on purpose must not be retried.
+//
+// The #6711 preserve branch is the case that makes a cheaper design wrong. It
+// ends with the published epoch (this incarnation's wall-clock seed) different
+// from what this incarnation has written (nothing), and it ends that way
+// FOREVER, deliberately — so a trigger keyed on `published != wrote` would spin
+// on a preserved file for the life of the process, re-reading state #7499 went
+// out of its way to leave alone.
+//
+// FAIL-ON-REVERT: making refineBootEpochReporting return `persistOwed = true`
+// from the preserve or heal branch reds the "declined" rows; dropping it from
+// the write-failure branch reds the "faulted" rows.
+func TestPersistOwedIsSetOnlyByFAULTS_6724(t *testing.T) {
+	now := uint64(time.Now().UnixNano())
+
+	cases := []struct {
+		name string
+		// prep returns the state-file path to refine against.
+		prep     func(t *testing.T) string
+		wantOwed bool
+		why      string
+	}{
+		{
+			name: "clean first write",
+			prep: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "ha-boot-epoch")
+			},
+			wantOwed: false,
+			why:      "the write succeeded; there is nothing to retry",
+		},
+		{
+			name: "preserve branch (#6711)",
+			prep: func(t *testing.T) string {
+				// A value far enough ahead that this node declines to chain,
+				// but inside the preserve band, so #7499 leaves it alone.
+				ahead := now + bootEpochPreserveMaxSkew/2
+				return writeEpochFile6724(t, ahead)
+			},
+			wantOwed: false,
+			why: "the pass DECIDED not to write — retrying would spin on a file " +
+				"#7499 preserves on purpose",
+		},
+		{
+			name: "heal branch (value beyond the preserve band)",
+			prep: func(t *testing.T) string {
+				// Beyond the preserve band: garbage, healed by the ordinary
+				// write below it.
+				return writeEpochFile6724(t, now+bootEpochPreserveMaxSkew*4)
+			},
+			wantOwed: false,
+			why:      "the heal path WRITES, so the persist is not owed",
+		},
+		{
+			name: "unparseable file",
+			prep: func(t *testing.T) string {
+				p := filepath.Join(t.TempDir(), "ha-boot-epoch")
+				if err := os.WriteFile(p, []byte("not-a-number\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return p
+			},
+			wantOwed: false,
+			why:      "a parse failure falls through to the write, which succeeds",
+		},
+		{
+			name: "write fails (read-only directory)",
+			prep: func(t *testing.T) string {
+				dir := t.TempDir()
+				sub := filepath.Join(dir, "state")
+				if err := os.Mkdir(sub, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				// Seed a value so the pass gets past the read and reaches the
+				// write, then make the directory unwritable so the atomic
+				// rename cannot land.
+				p := filepath.Join(sub, "ha-boot-epoch")
+				if err := os.WriteFile(p, []byte(strconv.FormatUint(now-1000, 10)+"\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chmod(sub, 0o555); err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { _ = os.Chmod(sub, 0o755) })
+				return p
+			},
+			wantOwed: true,
+			why:      "the epoch is on the wire but not on disk — the case the trigger exists for",
+		},
+		{
+			name: "lock unavailable",
+			prep: func(t *testing.T) string {
+				p := filepath.Join(t.TempDir(), "ha-boot-epoch")
+				orig := epochFlock
+				epochFlock = func(int, int) error { return unix.EWOULDBLOCK }
+				t.Cleanup(func() { epochFlock = orig })
+				return p
+			},
+			wantOwed: true,
+			why:      "the read-modify-write was SKIPPED entirely; nothing was decided",
+		},
+	}
+
+	sawOwed, sawNotOwed := false, false
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := tc.prep(t)
+			var published atomic.Uint64
+			published.Store(now)
+
+			_, owed := refineBootEpochReporting(path, &published, 0)
+			if owed != tc.wantOwed {
+				t.Fatalf("persistOwed = %v, want %v — %s", owed, tc.wantOwed, tc.why)
+			}
+			if owed {
+				sawOwed = true
+			} else {
+				sawNotOwed = true
+			}
+		})
+	}
+	// Both kinds must be present, or the table cannot tell a signal from a
+	// constant.
+	if !sawOwed || !sawNotOwed {
+		t.Fatalf("the table produced owed=%v and not-owed=%v: it must contain BOTH to "+
+			"show persistOwed is a discriminator and not a constant", sawOwed, sawNotOwed)
+	}
+}
+
+// TestRetryIsANoOpWhenNothingIsOwed_6724 binds the GATE, which is the part that
+// keeps this trigger from making the two-incarnation case worse.
+//
+// An unconditional periodic refine would make the leapfrog described in
+// withEpochFileLock continuous: while two incarnations overlap, each pass
+// raises above the other and rewrites the file, so both nodes would be refused
+// by the peer for part of every period instead of one being refused until its
+// next heartbeat restart. Alternating refusal is worse for HA than a stable
+// one. The gate makes the trigger a no-op for two healthy incarnations, because
+// neither ever owes a persist.
+//
+// FAIL-ON-REVERT: delete the `if !m.bootEpochPersistOwed.Load() { return }`
+// guard and the file moves under a manager that owes nothing.
+func TestRetryIsANoOpWhenNothingIsOwed_6724(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ha-boot-epoch")
+	m := keyedEpochManager(t, path)
+
+	m.initHeartbeatEpochState()
+	awaitFirstRefine(t, m, "first refine")
+	waitBootEpochIdle(t, m)
+
+	settled := readPersistedEpoch(t, path)
+	if settled == 0 {
+		t.Fatal("nothing persisted after the first refine")
+	}
+	if m.bootEpochPersistOwed.Load() {
+		t.Fatal("a clean first refine reported an owed persist")
+	}
+
+	// Every retry the sender loop would make in a minute of ticks.
+	for i := 0; i < 8; i++ {
+		m.retryOwedBootEpochPersist()
+	}
+	waitBootEpochIdle(t, m)
+
+	if got := readPersistedEpoch(t, path); got != settled {
+		t.Fatalf("the epoch file moved from %d to %d while nothing was owed — the "+
+			"retry gate is not holding, so two overlapping incarnations would "+
+			"leapfrog on every period (#6724)", settled, got)
+	}
+	if got := m.bootEpoch.Load(); got != settled {
+		t.Fatalf("the published epoch moved from %d to %d while nothing was owed", settled, got)
+	}
+}
+
+// TestRetryPersistsWhatTheFailedPassCouldNot_6724 is the trigger doing its job:
+// a pass that could not write is retried, and once the write lands the value is
+// the one that was already on the wire — not a ratchet.
+//
+// The "not a ratchet" half matters as much as the persist. The peer latched
+// what this node EMITTED; a retry that wrote something higher would leave the
+// file describing an epoch no peer ever saw.
+func TestRetryPersistsWhatTheFailedPassCouldNot_6724(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "state")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sub, "ha-boot-epoch")
+	m := keyedEpochManager(t, path)
+
+	// Fail the write: an unwritable directory cannot take the atomic rename.
+	if err := os.Chmod(sub, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	m.initHeartbeatEpochState()
+	awaitFirstRefine(t, m, "the failing refine")
+	waitBootEpochIdle(t, m)
+
+	published := m.bootEpoch.Load()
+	if published == 0 {
+		t.Fatal("no epoch published")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("the epoch file exists after a write that could not land: %v", err)
+	}
+	if !m.bootEpochPersistOwed.Load() {
+		t.Fatal("a failed persist did not set the retry trigger — nothing would ever " +
+			"re-attempt it, which is the #6724 gap")
+	}
+
+	// The fault clears (the operator frees the filesystem, remounts rw, ...).
+	if err := os.Chmod(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m.retryOwedBootEpochPersist()
+	waitBootEpochIdle(t, m)
+
+	got := readPersistedEpoch(t, path)
+	if got == 0 {
+		t.Fatal("the retry did not persist anything")
+	}
+	if got != published {
+		t.Fatalf("the retry persisted %d but this node had already emitted %d — a retry "+
+			"must land the value the peer may have latched, not a new one", got, published)
+	}
+	if m.bootEpochPersistOwed.Load() {
+		t.Fatal("the trigger is still armed after a successful retry; it would re-run forever")
+	}
+}
+
+// TestPersistRetryTicksTracksTheInterval_6724 pins the tick derivation.
+//
+// It is a TICK count rather than a deadline on purpose: every clock available
+// here is the wall clock, and a backward step in it is precisely the fault the
+// boot epoch exists to survive — a deadline would suspend retries for the
+// duration of the step that makes them matter.
+func TestPersistRetryTicksTracksTheInterval_6724(t *testing.T) {
+	cases := []struct {
+		interval time.Duration
+		want     int
+	}{
+		{200 * time.Millisecond, 150}, // the RETH default
+		{30 * time.Second, 1},
+		{time.Minute, 1}, // longer than the retry interval: every tick
+		{0, 1},           // degenerate
+		{-1 * time.Second, 1},
+	}
+	for _, tc := range cases {
+		if got := bootEpochPersistRetryTicks(tc.interval); got != tc.want {
+			t.Errorf("bootEpochPersistRetryTicks(%v) = %d, want %d", tc.interval, got, tc.want)
+		}
+		// The property behind the table: whatever the interval, the retry
+		// cadence must never be zero (a zero would mean "never retry", which is
+		// the pre-#6724 behaviour) and never exceed the configured interval.
+		got := bootEpochPersistRetryTicks(tc.interval)
+		if got < 1 {
+			t.Errorf("bootEpochPersistRetryTicks(%v) = %d: a cadence below one tick "+
+				"never fires", tc.interval, got)
+		}
+		if tc.interval > 0 && time.Duration(got)*tc.interval > bootEpochPersistRetryInterval+tc.interval {
+			t.Errorf("bootEpochPersistRetryTicks(%v) = %d ticks = %v, which overshoots the "+
+				"configured %v retry interval", tc.interval, got,
+				time.Duration(got)*tc.interval, bootEpochPersistRetryInterval)
+		}
+	}
+}
+
+func writeEpochFile6724(t *testing.T, epoch uint64) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "ha-boot-epoch")
+	if err := os.WriteFile(p, []byte(strconv.FormatUint(epoch, 10)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}

--- a/pkg/cluster/heartbeat_epoch_persist_retry_6724_test.go
+++ b/pkg/cluster/heartbeat_epoch_persist_retry_6724_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -148,19 +149,24 @@ func TestPersistOwedIsSetOnlyByFAULTS_6724(t *testing.T) {
 	}
 }
 
-// TestRetryIsANoOpWhenNothingIsOwed_6724 binds the GATE, which is the part that
-// keeps this trigger from making the two-incarnation case worse.
+// TestRetryIsANoOpWhenNothingIsOwed_6724 binds the GATE, which is the part
+// that keeps this trigger from making the two-incarnation case worse.
 //
-// An unconditional periodic refine would make the leapfrog described in
-// withEpochFileLock continuous: while two incarnations overlap, each pass
-// raises above the other and rewrites the file, so both nodes would be refused
-// by the peer for part of every period instead of one being refused until its
-// next heartbeat restart. Alternating refusal is worse for HA than a stable
-// one. The gate makes the trigger a no-op for two healthy incarnations, because
-// neither ever owes a persist.
+// THE FIXTURE NEEDS A SECOND WRITER, and an earlier revision of this test did
+// not have one. With a lone manager, refinement is IDEMPOTENT — the
+// `prev == lastWrote` shortcut returns without writing — so deleting the gate
+// changed nothing observable and the test passed against the mutation it was
+// written for. Measured: mutation cell X1 (drop the
+// `if !m.bootEpochPersistOwed.Load() { return }` guard) was GREEN.
 //
-// FAIL-ON-REVERT: delete the `if !m.bootEpochPersistOwed.Load() { return }`
-// guard and the file moves under a manager that owes nothing.
+// The gate only earns its keep when the file has MOVED under us, which is what
+// a concurrent incarnation does. That is the smallest shape in which removing
+// the guard changes an outcome: an ungated retry reads the higher value, raises
+// ITSELF above it and rewrites the file — the leapfrog withEpochFileLock
+// describes, which on a timer would run every period and leave both nodes
+// refused by the peer for part of each one.
+//
+// FAIL-ON-REVERT: delete the guard and both assertions below move.
 func TestRetryIsANoOpWhenNothingIsOwed_6724(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "ha-boot-epoch")
 	m := keyedEpochManager(t, path)
@@ -169,27 +175,111 @@ func TestRetryIsANoOpWhenNothingIsOwed_6724(t *testing.T) {
 	awaitFirstRefine(t, m, "first refine")
 	waitBootEpochIdle(t, m)
 
-	settled := readPersistedEpoch(t, path)
+	settled := m.bootEpoch.Load()
 	if settled == 0 {
-		t.Fatal("nothing persisted after the first refine")
+		t.Fatal("nothing published after the first refine")
 	}
 	if m.bootEpochPersistOwed.Load() {
 		t.Fatal("a clean first refine reported an owed persist")
 	}
 
-	// Every retry the sender loop would make in a minute of ticks.
+	// A CONCURRENT INCARNATION raises the file above us — the exact input the
+	// gate exists to make us ignore. Kept inside bootEpochMaxSkew so the value
+	// is chainable: if it were out of range the refine would decline for a
+	// different reason and the mutation would be invisible again.
+	sibling := settled + 1000
+	if err := os.WriteFile(path, []byte(strconv.FormatUint(sibling, 10)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Every retry the sender loop would make over many periods.
 	for i := 0; i < 8; i++ {
 		m.retryOwedBootEpochPersist()
 	}
 	waitBootEpochIdle(t, m)
 
-	if got := readPersistedEpoch(t, path); got != settled {
-		t.Fatalf("the epoch file moved from %d to %d while nothing was owed — the "+
-			"retry gate is not holding, so two overlapping incarnations would "+
-			"leapfrog on every period (#6724)", settled, got)
+	if got := readPersistedEpoch(t, path); got != sibling {
+		t.Fatalf("the epoch file moved from %d to %d while nothing was owed — an ungated "+
+			"retry chased a concurrent incarnation's value, which is the leapfrog "+
+			"the gate exists to prevent (#6724)", sibling, got)
 	}
 	if got := m.bootEpoch.Load(); got != settled {
-		t.Fatalf("the published epoch moved from %d to %d while nothing was owed", settled, got)
+		t.Fatalf("the published epoch rose from %d to %d while nothing was owed — this "+
+			"node raised itself above a live sibling on a timer", settled, got)
+	}
+}
+
+// TestSenderLoopDrivesTheRetry_6724 binds the WIRING: the trigger is only
+// reached because heartbeatSender.run calls it.
+//
+// An earlier revision of this file tested retryOwedBootEpochPersist directly
+// and nothing else, so deleting the call from the send loop left every test
+// green — measured as mutation cell X2. A retry nothing invokes is not a retry.
+// This drives the REAL loop (`sender.start()` spawns the production `run()`)
+// against a real socket, with the retry interval shortened so one tick is one
+// retry.
+//
+// FAIL-ON-REVERT: remove `s.mgr.retryOwedBootEpochPersist()` from
+// heartbeatSender.run and the persist never lands.
+func TestSenderLoopDrivesTheRetry_6724(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "state")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sub, "ha-boot-epoch")
+	m := keyedEpochManager(t, path)
+
+	// One tick, one retry — otherwise the production cadence is 150 ticks and
+	// this test would have to spend 30s of wall clock to see one.
+	origInterval := bootEpochPersistRetryInterval
+	bootEpochPersistRetryInterval = time.Nanosecond
+	t.Cleanup(func() { bootEpochPersistRetryInterval = origInterval })
+
+	// Fail the first persist.
+	if err := os.Chmod(sub, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	m.initHeartbeatEpochState()
+	awaitFirstRefine(t, m, "the failing refine")
+	waitBootEpochIdle(t, m)
+	if !m.bootEpochPersistOwed.Load() {
+		t.Fatal("the failing persist did not arm the trigger; this test would pass vacuously")
+	}
+	published := m.bootEpoch.Load()
+
+	// The fault clears, and from here ONLY the send loop can drive the retry.
+	if err := os.Chmod(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("sender socket: %v", err)
+	}
+	defer conn.Close()
+	peer := conn.LocalAddr().(*net.UDPAddr)
+
+	sender := newHeartbeatSender(m, conn, peer, time.Millisecond)
+	sender.start()
+	t.Cleanup(sender.stop)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if !m.bootEpochPersistOwed.Load() {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	waitBootEpochIdle(t, m)
+
+	if m.bootEpochPersistOwed.Load() {
+		t.Fatal("the send loop never drove a retry: the trigger is still armed after 5s of " +
+			"ticks, so nothing in production reaches retryOwedBootEpochPersist (#6724)")
+	}
+	got := readPersistedEpoch(t, path)
+	if got != published {
+		t.Fatalf("the send-loop retry persisted %d, want the already-emitted %d", got, published)
 	}
 }
 

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -342,14 +342,20 @@ type Manager struct {
 	// what keeps Stop's refuse-then-join ordering airtight; bootEpochStopped,
 	// under that mutex, refuses a spawn once Stop has begun.
 	// See Manager.joinBootEpochRefine.
-	bootEpochOnce     sync.Once
-	bootEpoch         atomic.Uint64
-	bootEpochReady    chan struct{}
-	bootEpochWrote    atomic.Uint64
-	bootEpochRefine   atomic.Uint32
-	bootEpochRefineMu sync.Mutex
-	bootEpochStopped  bool
-	bootEpochWorker   atomic.Pointer[bootEpochRefineWorker]
+	bootEpochOnce  sync.Once
+	bootEpoch      atomic.Uint64
+	bootEpochReady chan struct{}
+	bootEpochWrote atomic.Uint64
+	// bootEpochPersistOwed is set when a refine pass ended with the published
+	// epoch not known to be on disk because something FAILED or was SKIPPED
+	// (the dir create, the lock, the read, or the write) — never because a
+	// pass decided not to write. It is the #6724 retry trigger's only input;
+	// see Manager.retryOwedBootEpochPersist and refineBootEpochReporting.
+	bootEpochPersistOwed atomic.Bool
+	bootEpochRefine      atomic.Uint32
+	bootEpochRefineMu    sync.Mutex
+	bootEpochStopped     bool
+	bootEpochWorker      atomic.Pointer[bootEpochRefineWorker]
 
 	// lastEpochDowngradeWarn rate-limits the epoch-downgrade rejection warning.
 	// The rejection is operator-actionable — a peer rolled back to a pre-#6169


### PR DESCRIPTION
Ships the half of #6724 that was a missing **trigger**, and splits the mis-ordering itself — which needs state the design does not keep — to **#7501**. **#6724 is closed as split**, not by this PR's keyword.

## ⚠️ Cluster gates owed

This touches boot-epoch **persistence** and adds a call to the heartbeat **sender loop**, so it wants `make test-failover` AND `make test-ha-crash` — the latter because boot-epoch state only moves across a restart. I did not run any cluster target.

## Measured at current master first

#7499 (#6711) landed in this same file shortly before this work. It does **not** change #6724's schedule: the mis-ordering has A read a value from a concurrent incarnation whose seed is only slightly ahead, so it is *inside* the forward bound and chains normally. #7499's preserve band only engages for values that are **not** chainable. The two are independent, and the preserve branch is what makes the cheaper design of this fix wrong (below).

## What was missing, in the issue's own decomposition

`withEpochFileLock`'s comment already separates the remaining gap into two conditions, and says they do **not** need the same missing state:

- **Condition 2** (the leapfrog: both incarnations live) needs a writer identity or a lifetime-held liveness lock — larger than the epoch itself. → **#7501**.
- **Condition 1** needs only that A **retry its failed persist**: *"the code already does the right thing on a retry… What is missing is only a TRIGGER for that retry."*

This is that trigger. `refineBootEpochReporting` reports whether a persist is **owed**, and `Manager.retryOwedBootEpochPersist` re-runs refinement while one is. Before this, the only re-run was at the next heartbeat (re)start — event-driven and unbounded; a daemon can run for days without one — while the value sits on the wire but not on disk and a peer that latched it refuses a concurrent incarnation.

Not academic: the fault that arms this is a persist failure, i.e. ENOSPC or a read-only filesystem. **The box this was developed on hit 100% disk mid-session.**

## The gate is the design, not an optimisation

An unconditional periodic refine — the obvious simpler thing — is **worse**, not merely more expensive. While two incarnations overlap, each pass raises above the other and rewrites the file, so a timer makes that leapfrog **continuous**: both nodes are then refused by the peer for part of every period, instead of one being refused until its next heartbeat restart. **Alternating refusal is what makes a peer fail over repeatedly.** Gating on an owed persist makes the trigger a no-op for two healthy incarnations, which never owe anything.

**Owed means a FAULT, never a decision.** The dir create, the lock, the read and the write each set it; the #6711 preserve branch, the heal branch and the `prev == lastWrote` no-op do not.

Deriving the signal at the call site from `published != wrote` is the cheaper thing and it is **wrong**, for a reason #7499 created three weeks of file-history ago: the preserve branch also ends with published (this incarnation's seed) ≠ wrote (nothing), and it ends that way **forever, by design**. Such a trigger would spin on a preserved file for the life of the process, re-reading state #7499 went out of its way to leave alone. Only `refineBootEpoch` knows which branch it took, so it reports it — behind a value-only wrapper, so all 25 existing call sites are untouched.

**Cadence is a TICK COUNT, not a deadline.** Every clock available here is the wall clock, and a backward step in it is the exact fault the boot epoch exists to survive; a deadline would suspend retries for the duration of the step that makes them matter.

**No new goroutine.** This package's hazards live in its start/stop discipline (superseded starts, loops whose `stopCh` is never closed), so the retry rides the sender's existing ticker. Cost when nothing is owed: one atomic load, once every 150 ticks at the RETH default.

## The mutation matrix found two of my own tests, not the fix

First run: **X1 and X2 were GREEN**. Both were the tests' fault, and both are the classic shapes.

- **X1** (delete the `persistOwed` gate) passed because the fixture was a **lone manager**, and refinement is idempotent for one — the `prev == lastWrote` shortcut returns without writing, so an ungated retry changed nothing observable. A guard test whose fixture omits the interaction cannot see the guard. The fixture now has a **second writer** raise the file, which is the smallest shape where removing the guard changes an outcome.
- **X2** (delete the call from `heartbeatSender.run`) passed because every test called `retryOwedBootEpochPersist` **directly** and nothing drove the loop. A retry nothing invokes is not a retry. `TestSenderLoopDrivesTheRetry_6724` now starts the **real** sender loop against a real socket with no other caller in play.

Both rewritten in a separate commit so the before/after is legible. Final matrix, every cell applied-verified, `go build ./...` clean first, full `pkg/cluster` suite per cell, tree restored and re-verified after each:

| cell | mutation | result |
|---|---|---|
| **X1** | delete the `persistOwed` gate (retry unconditionally) | RED `TestRetryIsANoOpWhenNothingIsOwed_6724` |
| **X2** | **the WIRING** — `heartbeatSender.run` stops calling the trigger | RED `TestSenderLoopDrivesTheRetry_6724` (at its 5s deadline) |
| **X3** | never report an owed persist (pre-#6724 behaviour) | RED 2 |
| **X4** | **OVER-report** — mark the #6711 preserve decline as owed (the `published != wrote` design) | RED the discriminator table |
| **X5** | **TIGHTEN** the cadence so it can round to zero ticks | RED the tick test |

X4 is the one that pins the direction the cheaper design gets wrong, and X5 the one that pins a cadence of "never".

## Tests

`heartbeat_epoch_persist_retry_6724_test.go`: a six-row table proving `persistOwed` is a **discriminator and not a constant** (both kinds present, asserted); the gate held across repeated retries with a sibling's value in the file; a failed persist retried after the fault clears, landing **the value already emitted** rather than a ratchet — because the peer latched what this node *emitted*, and a retry that wrote something higher would leave the file describing an epoch no peer ever saw; the real send loop driving it; and the tick derivation.

## Comments moved with the code

Two sites said there is **no periodic re-check — tracked as #6724**, which this makes false. Both now say what closed and what did not, and point the mis-ordering at #7501.

`go build`, `go vet`, and the full repo-wide `go test ./... -count=1` are clean.
