### PR TITLE
userspace-dp: never arm the dead-host cache on an lladdr-less egress (#6710)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103662,3 +103662,26 @@ prose edit above them added. No diff falls in the new test body.
   pkg/cluster/heartbeat_epoch_preserve_6711_test.go (new),
   pkg/cluster/heartbeat_epoch_latch_test.go,
   pkg/cluster/heartbeat_epoch_test.go
+
+## 2026-08-22 — #6710 measured: the dead-host cache drops permitted LAN->tunnel traffic
+- **Action**: #6710 was filed as an OPEN QUESTION, read from source with the
+  worker loop never executed. MEASURED it: a LAN->xfrmi egress resolves
+  `MissingNeighbor` with a `next_hop` and `tunnel_endpoint_id == 0` — the last
+  is the discriminator against #1912, which excludes tunnel-MARKED decisions
+  from `pending_neigh` and therefore from the cache; an xfrmi is a connected
+  route to an ordinary ifindex, so it takes the buffered path and the cache CAN
+  arm. Once armed the fast-fail recycles the frame before the fall-through to
+  the slow-path reinject, and that reinject is the only way LAN->tunnel traffic
+  reaches the kernel XFRM stack (an xfrmi gets no AF_XDP binding). Because an
+  xfrmi has no lladdr, resolved-neighbor-wins can never evict, so it is a
+  permanent drop cycle rather than the 3s the issue estimated. Fix:
+  `ForwardingState.lladdrless_egress`, built from the ALREADY-SHIPPED
+  `InterfaceSnapshot.secure_tunnel` flag (no wire change, no Go change),
+  suppresses the ARMING for those ifindexes only; the negative control asserts
+  an ordinary egress still arms, so #1651's storm defense is intact.
+- **File(s)**: userspace-dp/src/afxdp/types/forwarding.rs,
+  userspace-dp/src/afxdp/forwarding_build/interfaces.rs,
+  userspace-dp/src/afxdp/neighbor_dispatch.rs,
+  userspace-dp/src/afxdp/forwarding_build/tests.rs,
+  docs/userspace-dataplane-architecture.md,
+  docs/userspace-cold-start-resolution.md

--- a/docs/userspace-cold-start-resolution.md
+++ b/docs/userspace-cold-start-resolution.md
@@ -336,7 +336,11 @@ The #1651 dead-host negative cache (`afxdp/neg_neigh.rs`) fast-fails a
 SYN to a negatively-cached `(egress_ifindex, next_hop)` **before** the
 ARP probe and the `pending_neigh` buffer
 (`poll_descriptor/mod.rs` MissingNeighbor arm). That is correct for a
-genuinely dead host, but it produced a stuck state for a
+genuinely dead host — and #6710 is the case where the dst is not a host at
+all: an IPsec `xfrmi` egress has no link-layer address, so the
+resolved-neighbor-wins escape can never fire and the cache is never allowed
+to arm for it (`ForwardingState.lladdrless_egress`). It also produced a
+stuck state for a
 directly-connected, **outbound-only** target (e.g. the smoke iperf3 dst
 `172.16.80.200` on `ge-0-0-2.80`):
 

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -426,6 +426,23 @@ in `neighbor_dispatch.rs`). A hop that never resolves within the pending
 timeout is negatively cached for 3 s (`neg_neigh.rs`), and subsequent
 cold packets to it fast-fail at the buffer site.
 
+**Except for an egress that can never have a neighbor (#6710).** An IPsec
+`xfrmi` has no link-layer address, so `lookup_neighbor_entry` can never hit
+and a LAN→tunnel packet resolves `MissingNeighbor` forever. The cache's
+escape hatch is resolved-neighbor-wins — the entry is evicted the moment the
+host answers — and an xfrmi has nothing to answer with, so the arm/expire
+cycle would repeat for as long as the tunnel carried traffic. That is not a
+3 s penalty but a permanent one: the fast-fail recycles the frame at the top
+of the MissingNeighbor arm (`break 'missing_neighbor RecycleAndContinue`),
+which skips the fall-through to the slow-path reinject — and that reinject is
+the only way a LAN→tunnel packet reaches the kernel XFRM stack at all, since
+an xfrmi gets no AF_XDP binding. `ForwardingState.lladdrless_egress`, built
+from the already-shipped `InterfaceSnapshot.secure_tunnel` flag, suppresses
+the ARMING for those ifindexes only. Nothing else changes: the timeout still
+drops the representative packet, and the #1651 protection is untouched
+everywhere else (a hop pins ≤1 `pending_neigh` entry post-#1771 §2.2, so the
+cache was buying nothing here).
+
 `pending_neigh_admission` returns one of three outcomes, each counted
 separately so an operator can tell normal cold-start coalescing from an
 exhaustion/attack mode (`record_pending_neigh_admission_drop`,

--- a/userspace-dp/src/afxdp/forwarding_build/interfaces.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/interfaces.rs
@@ -125,6 +125,15 @@ pub(super) fn populate_interfaces(
         if !iface.linux_name.is_empty() {
             linux_to_ifindex.insert(iface.linux_name.clone(), iface.ifindex);
         }
+        // #6710: an xfrmi has no link-layer address, so an egress to it can
+        // never resolve a neighbor. Record the ifindex so the dead-host
+        // negative cache is not armed against a device that has nothing to
+        // answer with — see ForwardingState::lladdrless_egress. The flag is
+        // read, never re-derived: `secure_tunnel` is the same authoritative
+        // bit `userspace_unbindable_netdev` uses for binding planning.
+        if iface.secure_tunnel {
+            state.lladdrless_egress.insert(iface.ifindex);
+        }
         // #921: resolve zone NAME → u16 once at config build, so every read on
         // the hot path is one HashMap lookup (ifindex → u16). An unzoned row
         // resolves to 0, the "no zone" sentinel.

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -7070,3 +7070,142 @@ fn next_table_cycle_resolves_unsupported_and_is_not_slow_path_eligible_6664() {
          forbids black-holing a destination the kernel can still reach"
     );
 }
+
+/// #6710 — THE MEASUREMENT. The issue was filed as an OPEN QUESTION, read from
+/// source with the worker loop never executed, and asks first whether the
+/// interaction occurs at all. It does, and this is the half of the chain that
+/// can be executed here: what a LAN→xfrmi egress actually RESOLVES to, and
+/// which properties of that resolution decide whether the dead-host negative
+/// cache can be armed against it.
+///
+/// `secure_tunnel_unit_ifindex_decides_route_disposition` above already
+/// establishes `MissingNeighbor`; what #6710 turns on are two further facts it
+/// does not assert, and each is load-bearing in a different direction:
+///
+///   * `next_hop` is `Some(..)` — the negative cache is keyed
+///     `(egress_ifindex, next_hop)`, and the arming site in
+///     `neighbor_dispatch.rs` is inside `if let Some(next_hop)`. No next hop,
+///     no key, no interaction.
+///   * `tunnel_endpoint_id == 0` — this is the discriminator against #1912,
+///     which states that "tunnel-marked decisions are NEVER buffered in
+///     pending_neigh ... so for an unresolved OUTER hop the top-of-arm neg
+///     fast-fail can never arm". That exclusion is real, and it is exactly why
+///     a GRE outer hop is safe and an xfrmi is not: an xfrmi egress is a
+///     CONNECTED route to an ordinary ifindex, not a tunnel endpoint, so it
+///     takes the buffered path and the cache CAN arm.
+///
+/// The third fact — that an armed entry then recycles the frame before the
+/// slow-path reinject — is control flow inside
+/// `poll_binding_process_descriptor`, which no test in this crate can drive
+/// (it needs a live binding, UMEM and descriptor ring). It is stated in the
+/// PR body with its line references rather than asserted here, and the
+/// behavioural guard for the fix lives at the arming site instead, where it
+/// IS executable: `lan_to_xfrmi_timeout_does_not_arm_the_dead_host_cache_6710`
+/// in neighbor_dispatch.rs.
+#[test]
+fn xfrmi_egress_resolves_a_negative_cache_key_6710() {
+    fn snapshot(secure_tunnel: bool) -> ConfigSnapshot {
+        let addr = |a: &str| crate::InterfaceAddressSnapshot {
+            family: "inet".into(),
+            address: a.into(),
+            scope: 0,
+        };
+        ConfigSnapshot {
+            zones: vec![
+                ZoneSnapshot {
+                    name: "trust".into(),
+                    id: 1,
+                    ..Default::default()
+                },
+                ZoneSnapshot {
+                    name: "vpn".into(),
+                    id: 2,
+                    ..Default::default()
+                },
+            ],
+            interfaces: vec![
+                crate::InterfaceSnapshot {
+                    name: "ge-0/0/1.0".into(),
+                    zone: "trust".into(),
+                    linux_name: "ge-0-0-1.0".into(),
+                    ifindex: 11,
+                    mtu: 1500,
+                    addresses: vec![addr("10.0.1.1/24")],
+                    ..Default::default()
+                },
+                crate::InterfaceSnapshot {
+                    name: "st0.0".into(),
+                    zone: "vpn".into(),
+                    linux_name: "st0.0".into(),
+                    ifindex: 42,
+                    mtu: 1400,
+                    addresses: vec![addr("10.5.5.1/30")],
+                    secure_tunnel,
+                    ..Default::default()
+                },
+            ],
+            routes: vec![crate::RouteSnapshot {
+                table: "inet.0".into(),
+                family: "inet".into(),
+                destination: "192.168.99.0/24".into(),
+                next_hops: vec!["10.5.5.2".into()],
+                preference: 5,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    let state = build_forwarding_state(&snapshot(true));
+    let dst = Ipv4Addr::new(192, 168, 99, 5);
+    let r = lookup_forwarding_resolution_v4(&state, None, dst, "inet.0", 0, true, None);
+
+    assert_eq!(
+        r.disposition,
+        ForwardingDisposition::MissingNeighbor,
+        "premise: a LAN→xfrmi packet must take the cold MissingNeighbor arm — \
+         an xfrmi has no lladdr, so lookup_neighbor_entry can never hit"
+    );
+    assert_eq!(r.egress_ifindex, 42);
+    assert!(
+        r.next_hop.is_some(),
+        "the negative cache is keyed (egress_ifindex, next_hop) and the arming \
+         site is inside `if let Some(next_hop)`; with no next hop there is no \
+         key and #6710's interaction cannot occur at all"
+    );
+    assert_eq!(
+        r.tunnel_endpoint_id, 0,
+        "THE #1912 DISCRIMINATOR. A tunnel-marked decision is never buffered in \
+         pending_neigh, so its hop can never arm the cache — that is why a GRE \
+         outer hop is safe. An xfrmi egress is a CONNECTED route to an ordinary \
+         ifindex, carries no endpoint id, takes the buffered path, and therefore \
+         CAN arm it. If this ever becomes non-zero, #6710 stops applying and \
+         this test should say so rather than being deleted"
+    );
+    assert!(
+        r.disposition.is_slow_path_eligible(),
+        "the intended fate of this packet is the slow-path reinject — an xfrmi \
+         gets no AF_XDP binding, so the kernel XFRM stack is the ONLY way it is \
+         ever encrypted. A negative-cache fast-fail recycles it before that."
+    );
+
+    // The fix is keyed on the shipped `secure_tunnel` flag, not on a name
+    // grammar. Assert both directions so the set cannot silently become
+    // "everything" or "nothing".
+    assert!(
+        state.lladdrless_egress.contains(&42),
+        "the xfrmi ifindex must be recorded as lladdr-less so the dead-host \
+         cache is not armed against a device that has nothing to answer with"
+    );
+    assert!(
+        !state.lladdrless_egress.contains(&11),
+        "an ordinary LAN interface must NOT be recorded lladdr-less; the #1651 \
+         dead-host protection has to keep working everywhere else"
+    );
+    let plain = build_forwarding_state(&snapshot(false));
+    assert!(
+        plain.lladdrless_egress.is_empty(),
+        "with secure_tunnel unset the set must be empty — the flag is the only \
+         input, so an older control plane that omits it changes nothing"
+    );
+}

--- a/userspace-dp/src/afxdp/neighbor_dispatch.rs
+++ b/userspace-dp/src/afxdp/neighbor_dispatch.rs
@@ -223,7 +223,33 @@ pub(super) fn retry_pending_neigh(
                 .pending_neigh
                 .remove(&key)
                 .expect("key from this map");
-            neg_neigh_record(&mut binding.neg_neigh_cache, key, now_ns);
+            // #6710: do NOT arm the dead-host cache against an egress that has
+            // no link-layer address by construction (an IPsec xfrmi).
+            //
+            // The cache exists to stop packets to a host that is NOT ANSWERING
+            // from re-buffering every window, and its escape hatch is
+            // resolved-neighbor-wins: the entry is evicted the moment the host
+            // answers. An xfrmi has nothing to answer with, so that escape can
+            // never fire and the arm/expire cycle repeats for as long as the
+            // tunnel carries traffic.
+            //
+            // That is not a 3 s penalty, it is a permanent one, because the
+            // fast-fail recycles the frame at the top of the MissingNeighbor
+            // arm and so skips the fall-through to the slow-path reinject —
+            // and the reinject is the ONLY way a LAN→tunnel packet reaches the
+            // kernel XFRM stack, since an xfrmi gets no AF_XDP binding
+            // (`userspace_unbindable_netdev`). Every armed window drops
+            // permitted, policy-evaluated traffic on a healthy tunnel.
+            //
+            // Skipping the arming costs nothing the cache was buying. Its
+            // stated purpose is protecting the BOUNDED pending_neigh map from
+            // a multi-hop scan, and post-#1771 §2.2 that map holds ONE
+            // representative packet per (egress_ifindex, next_hop) — so an
+            // xfrmi hop pins exactly one entry whether or not it is cached.
+            // The probe and resolver enqueue are separately rate-limited.
+            if !forwarding.lladdrless_egress.contains(&key.0) {
+                neg_neigh_record(&mut binding.neg_neigh_cache, key, now_ns);
+            }
             // #1772: count the never-resolved timeout drop.
             if let Some(resolver) = neighbor_resolver {
                 resolver.record_pending_timeout_drop();
@@ -911,6 +937,13 @@ mod mirror_tests {
             "timed-out dst must be negatively cached",
         );
     }
+
+    // #6710 lives in its own file (neighbor_dispatch/mirror_tests/) so
+    // appending it does not push this one past the 1500 LOC [WATCH] modularity
+    // floor (pkg/refactoraudit). A child module can see this module's private
+    // helpers, so `push_pending`, `resolved_neighbor_decision` and friends are
+    // reachable unchanged via `use super::*`.
+    mod xfrmi_6710_tests;
 
     /// #1772: build a worker-facing `NeighborResolver` handle wired to a
     /// fresh latency-telemetry set, so a test can pass it into

--- a/userspace-dp/src/afxdp/neighbor_dispatch/mirror_tests/xfrmi_6710_tests.rs
+++ b/userspace-dp/src/afxdp/neighbor_dispatch/mirror_tests/xfrmi_6710_tests.rs
@@ -1,0 +1,138 @@
+//! #6710 negative-cache / lladdr-less-egress cell, split out of
+//! `neighbor_dispatch.rs`'s `mirror_tests` so that file stays under the
+//! 1500 LOC [WATCH] modularity floor. It is a CHILD of `mirror_tests`, so the
+//! private fixtures there (`push_pending`, `resolved_neighbor_decision`,
+//! `pending_neighbor_meta`, `build_ipv4_test_packet`, ...) are in scope via
+//! `use super::*` with no visibility changes.
+
+use super::*;
+/// #6710 — THE FIX, at the only site in this chain a test can execute.
+///
+/// The dead-host negative cache (#1651 B3) is armed by a pending_neigh
+/// TIMEOUT, and its escape hatch is resolved-neighbor-wins: the entry is
+/// evicted the moment the host answers. An IPsec xfrmi has no link-layer
+/// address, so it has nothing to answer with — the escape can never fire
+/// and the arm/expire cycle repeats for as long as the tunnel carries
+/// traffic. Every armed window recycles the frame at the top of the
+/// MissingNeighbor arm (`break 'missing_neighbor RecycleAndContinue`),
+/// which skips the fall-through to the slow-path reinject, and that
+/// reinject is the ONLY way a LAN→tunnel packet reaches the kernel XFRM
+/// stack at all, since an xfrmi gets no AF_XDP binding.
+///
+/// So the cache is not paying for a dead host here; it is dropping
+/// permitted, policy-evaluated traffic on a healthy tunnel. This asserts
+/// the timeout no longer arms it for such an egress.
+///
+/// The NEGATIVE CONTROL is the load-bearing half. Without it this cell
+/// would pass equally well against a change that disabled #1651 outright,
+/// which would reopen the multi-hop-scan exhaustion the cache exists for.
+#[test]
+fn lan_to_xfrmi_timeout_does_not_arm_the_dead_host_cache_6710() {
+    // egress_ifindex 80 is what resolved_neighbor_decision resolves to.
+    const XFRMI_EGRESS: i32 = 80;
+
+    fn timed_out_arms_cache(lladdrless: bool) -> bool {
+        let mut bindings = vec![
+            BindingWorker::new_for_mirror_test(0, 0, 11, 0),
+            BindingWorker::new_for_mirror_test(1, 0, 22, 0),
+        ];
+        let original_frame = build_ipv4_test_packet(0);
+        // SAFETY: single-threaded test over a UMEM created just above; no
+        // other borrow into [0, len) exists and the mutable slice is
+        // consumed by the immediate copy_from_slice.
+        unsafe {
+            bindings[0]
+                .umem
+                .area()
+                .slice_mut_unchecked(0, original_frame.len())
+        }
+        .expect("ingress frame")
+        .copy_from_slice(&original_frame);
+
+        let next_hop = IpAddr::V4(Ipv4Addr::new(10, 5, 5, 2));
+        let meta = pending_neighbor_meta(original_frame.len());
+        push_pending(
+            &mut bindings[0],
+            PendingNeighPacket {
+                addr: 0,
+                desc: XdpDesc {
+                    addr: 0,
+                    len: original_frame.len() as u32,
+                    options: 0,
+                },
+                meta,
+                decision: resolved_neighbor_decision(next_hop),
+                flow_key: Some(test_session_key(12345, 443)),
+                queued_ns: 0,
+                // Every probe already fired; an xfrmi never resolves.
+                probe_attempts: PROBE_SCHEDULE_NS.len() as u8,
+            },
+        );
+
+        let mut forwarding = ForwardingState::default();
+        if lladdrless {
+            forwarding.lladdrless_egress.insert(XFRMI_EGRESS);
+        }
+        let lookup = WorkerBindingLookup::from_bindings(&bindings);
+        let mirror_targets = MirrorTargetMap::default();
+        let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+        let mut shared_recycles = Vec::new();
+        let area = bindings[0].umem.area() as *const MmapArea;
+        let (left, rest) = bindings.split_at_mut(0);
+        let (binding, right) = rest.split_first_mut().expect("ingress binding");
+
+        let now_ns = PENDING_NEIGH_TIMEOUT_NS + 1;
+        retry_pending_neigh(
+            binding,
+            left,
+            0,
+            right,
+            &lookup,
+            &mirror_targets,
+            &forwarding,
+            &dynamic_neighbors,
+            None,
+            now_ns,
+            // SAFETY: as in the sibling timeout test — `area` was cast
+            // from a `&MmapArea` borrowed out of bindings[0].umem above,
+            // the Rc-backed allocation outlives this call, the split
+            // borrows cover disjoint binding state, and the test is
+            // single-threaded.
+            unsafe { &*area },
+            &mut shared_recycles,
+        );
+
+        assert!(
+            bindings[0].pending_neigh.is_empty(),
+            "premise: the timeout must still DROP the packet and drain the \
+             queue in both configurations — this change is about the cache, \
+             not about holding the frame longer",
+        );
+        let key = (XFRMI_EGRESS, next_hop);
+        crate::afxdp::neg_neigh::neg_neigh_active(
+            &mut bindings[0].neg_neigh_cache,
+            &key,
+            now_ns,
+        )
+    }
+
+    assert!(
+        !timed_out_arms_cache(true),
+        "a timeout on an lladdr-less egress ARMED the dead-host cache. The \
+         next 3s of permitted LAN→tunnel packets then fast-fail and are \
+         recycled BEFORE the slow-path reinject, which is the only path to \
+         the kernel XFRM stack — and because an xfrmi can never resolve a \
+         neighbor, resolved-neighbor-wins never evicts it, so the cycle \
+         repeats indefinitely on a healthy tunnel (#6710)",
+    );
+    assert!(
+        timed_out_arms_cache(false),
+        "a timeout on an ORDINARY egress no longer arms the dead-host cache. \
+         The #1651 B3 protection must keep working everywhere else — without \
+         it a multi-hop scan re-buffers every window and exhausts the \
+         distinct-hop cap. The fix must be keyed on the egress, not a \
+         blanket disable",
+    );
+}
+
+

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -367,6 +367,28 @@ pub(in crate::afxdp) struct ForwardingState {
     /// Default) means "unset" — callers fall back to
     /// `PENDING_NEIGH_TIMEOUT_NS`.
     pub(in crate::afxdp) pending_neigh_timeout_ns: u64,
+    /// #6710: egress ifindexes that can NEVER resolve a link-layer neighbor,
+    /// because the netdev has no link-layer address by construction.
+    ///
+    /// Today this is exactly the IPsec `xfrmi` set, carried by the existing
+    /// authoritative `InterfaceSnapshot.secure_tunnel` flag — no wire change:
+    /// the Go control plane already computes it (`snapshotSecureTunnel`, the
+    /// union of "some `security ipsec vpn <n> bind-interface` names this
+    /// device" and "the netdev's kernel link kind is `xfrm`") and this plane
+    /// reads the one flag rather than re-deriving a name grammar, exactly as
+    /// `userspace_unbindable_netdev` already does for binding planning.
+    ///
+    /// WHY THE FORWARDING PLANE NEEDS IT. A connected route to such an ifindex
+    /// resolves `MissingNeighbor` forever: `lookup_neighbor_entry` can never
+    /// hit, so the packet takes the cold arm, is buffered in `pending_neigh`,
+    /// probes, times out — and the timeout is what ARMS the dead-host negative
+    /// cache. For a real dead host that cache is a 3 s penalty that ends when
+    /// the host answers; here the "host" is a device that has nothing to answer
+    /// with, so `neg_neigh_gate`'s resolved-neighbor-wins escape can never
+    /// fire and the arm/expire cycle repeats indefinitely. Every armed window
+    /// recycles the frame BEFORE the slow-path reinject that is the only way
+    /// LAN→tunnel traffic reaches the kernel XFRM stack at all.
+    pub(in crate::afxdp) lladdrless_egress: FastSet<i32>,
     /// #1635: direct `(from_zone_id, to_zone_id) → slot` map for the
     /// cold-path histogram, built at config apply from the configured
     /// policy zone-pairs. Replaces the splitmix64 16-slot hash. Shared


### PR DESCRIPTION
## The measurement first — #6710 was an open question, and it reproduces

The issue was filed as *"does the cache fast-fail a permitted flow instead of
falling through to the reinject gate?"*, read from source with the worker loop
never executed, and explicitly says **"the first task here is to settle it by
execution"**. Settled: **the interaction occurs.**

Two links are executed:

| Link | Executed by |
|---|---|
| a LAN→xfrmi egress resolves `MissingNeighbor` with `next_hop = Some(..)` and `tunnel_endpoint_id == 0` | **new** `xfrmi_egress_resolves_a_negative_cache_key_6710`, driven through the real `build_forwarding_state` + `lookup_forwarding_resolution_v4` |
| a `pending_neigh` timeout on that key arms the dead-host negative cache | **pre-existing** `timed_out_pending_neighbor_records_negative_cache` |

**`tunnel_endpoint_id == 0` is the load-bearing fact**, and the reason this is
not already covered. #1912 states that tunnel-MARKED decisions are never
buffered in `pending_neigh`, *"so for an unresolved OUTER hop the top-of-arm neg
fast-fail can never arm"* — which is exactly why a GRE outer hop is safe. An
xfrmi egress is a **connected route to an ordinary ifindex** and carries no
endpoint id, so it takes the buffered path and the cache **can** arm.

### It is worse than the issue estimated

#6710 says *"dropped for up to 3 s at a time"*. The cache's escape hatch is
`neg_neigh_gate`'s resolved-neighbor-wins eviction, which bounds the penalty for
a real dead host to however long it stays silent. **An xfrmi has no link-layer
address, so it has nothing to answer with** — the escape can never fire, and the
arm/expire cycle repeats for as long as the tunnel carries traffic.

And an armed window does not merely delay the packet. The fast-fail recycles the
frame at the top of the MissingNeighbor arm (`break 'missing_neighbor
StageOutcome::RecycleAndContinue`, `poll_descriptor/mod.rs:4805`), skipping the
fall-through to `StageOutcome::Continue` and therefore the trailing slow-path
reinject. That reinject is the **only** way a LAN→tunnel packet reaches the
kernel XFRM stack, because an xfrmi gets no AF_XDP binding
(`userspace_unbindable_netdev`). A permitted, policy-evaluated flow on a healthy
tunnel is dropped.

### What is NOT executed, stated plainly

That last link is control flow inside `poll_binding_process_descriptor`, which
**no test in this crate can drive** — it needs a live binding, UMEM and
descriptor ring (the same limitation #6664 documented and worked around with a
source guard). It is traced by line reference above rather than asserted, and
the behavioural guard for the fix sits at the **arming site** instead, where it
is executable.

## The fix

`ForwardingState` gains `lladdrless_egress`; the timeout site does not arm the
cache for those ifindexes. Nothing else changes — the timeout still drops the
representative packet, and the probe and resolver enqueue keep their own rate
limits.

**No wire change, no protocol bump, no Go change.** The set is built from
`InterfaceSnapshot.secure_tunnel`, which the control plane already ships and
which is already authoritative for binding planning. This plane reads the one
flag rather than re-deriving a name grammar — the same reason #6691 round 5
*deleted* the local `is_secure_tunnel_ifname` copy: a second hand-maintained
spelling of the rule can only drift.

**Skipping the arming costs nothing the cache was buying here.** Its stated
purpose is protecting the *bounded* `pending_neigh` map from a multi-hop scan,
and post-#1771 §2.2 that map holds ONE representative packet per
`(egress_ifindex, next_hop)` — so an xfrmi hop pins exactly one entry whether or
not it is cached.

### Scope checks against the adjacent work

- **#7167** is the bounded logical-tunnel-**ingress** umbrella (decapped
  plaintext arriving). This is the **egress** direction, so it is adjacent, not
  subsumed.
- **#7494** constrains anything needing new per-packet state in the XDP shim
  (~78% of the verifier instruction cap). **Nothing is added to the shim** — the
  whole change is userspace Rust plus two doc sites.

## Mutation matrix

Every cell verified applied, run **full-binary** (`cargo test --bin
xpf-userspace-dp -- --test-threads=1`, no name filter), rc + tests-collected read
from a file so a build break cannot masquerade as a clean red. Base
`2b51eac30…`, head `0adc8ab25…`.

| # | Mutation | rc | collected | Which assertion fired |
|---|---|---|---|---|
| 1 | revert the skip (verbatim pre-fix: always arm) | 101 | 4555 | `xfrmi_6710_tests.rs:119` — *"a timeout on an lladdr-less egress ARMED the dead-host cache … recycled BEFORE the slow-path reinject … the cycle repeats indefinitely on a healthy tunnel"* |
| 2 | **never** arm (blanket disable of #1651) — the negative control | 101 | 4554 | **two** red: the new negative control **and** the pre-existing `timed_out_pending_neighbor_records_negative_cache` at `neighbor_dispatch.rs:931`. The dead-host storm defense is still guarded everywhere else |
| 3 | **wiring** — stop populating the set from the shipped `secure_tunnel` flag | 101 | 4555 | `forwarding_build/tests.rs:7195` — the FIB-side measurement reds |

Cell 2 is the one that matters most: without a negative control this change
would pass equally well as a blanket disable, which would reopen the multi-hop
scan exhaustion the cache exists for.

## Validation

- `cargo test -- --test-threads=1` — **rc=0, 4685 tests ok, 0 failed**.
- `go test ./... -count=1` — **rc=0, 67 packages, 0 FAIL**, including
  `pkg/refactoraudit`.
- No cluster, VRRP, session-sync, failover or shim code touched. **No cluster
  gate owed**; I ran no cluster target.

### One structural note

The new test lives in `neighbor_dispatch/mirror_tests/xfrmi_6710_tests.rs`
rather than appended to `neighbor_dispatch.rs`: appending pushed that file from
1460 → 1615 LOC and redded `pkg/refactoraudit`'s touched-file modularity gate.
A child module sees the parent's private fixtures, so no visibility changed.

## Docs

`docs/userspace-dataplane-architecture.md` (the N1 negative-cache section) and
`docs/userspace-cold-start-resolution.md` (the #1769 stuck-state section) both
now carry the lladdr-less exception and why it is not merely a 3 s penalty.

Closes #6710
