### PR TITLE
docs(config): scope the closed-world open-world branch claim (#6725)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103662,3 +103662,10 @@ prose edit above them added. No diff falls in the new test body.
   pkg/cluster/heartbeat_epoch_preserve_6711_test.go (new),
   pkg/cluster/heartbeat_epoch_latch_test.go,
   pkg/cluster/heartbeat_epoch_test.go
+
+## 2026-08-22 — #6725 closed-world doc claim
+- **Action**: Corrected the one residual false claim in the open-world branch
+  ("the default for every production subtree"; unscoped "byte-identical").
+  Two of the issue's three claims were already fixed by f37fdf19b (2026-08-05),
+  four days after the issue was filed.
+- **File(s)**: `pkg/config/schema_walk.go`

--- a/pkg/config/schema_walk.go
+++ b/pkg/config/schema_walk.go
@@ -353,9 +353,26 @@ func walkSchemaNode(node *Node, parent *schemaNode, path []string, vc *walkConte
 		if closed {
 			return typedLeafErrorf(path, "unknown configuration keyword %q under closed-world subtree", keyword)
 		}
-		// Open-world (the default for every production subtree): unknown
-		// keywords are not our concern — the gate is opt-in; leave reporting
-		// to the compiler. Behaviour here is byte-identical to pre-#4313.
+		// Open-world — the default for a subtree that has NOT opted in, which
+		// is most of them and emphatically not all. Unknown keywords are not
+		// our concern here; the gate is opt-in, so leave reporting to the
+		// compiler.
+		//
+		// "BYTE-IDENTICAL TO PRE-#4313" IS TRUE OF THIS BRANCH AND OF NOTHING
+		// WIDER, and saying which is the whole correction. The FUNCTION's
+		// behaviour did change: a typo'd leaf under an armed subtree is
+		// rejected at commit where it used to commit clean and be silently
+		// dropped. The unscoped form of this sentence was read as a claim
+		// about the MECHANISM — #6725 quoted it to conclude the gate was inert
+		// — which is the same misreading the keyword-resolution gate above was
+		// corrected for, surviving here because that correction did not reach
+		// this branch. A scope-free "behaviour is unchanged" sitting next to
+		// an opt-in gate always reads as the wider claim.
+		//
+		// Bound, not merely asserted: each schema_closedworld_*_4313_test.go
+		// commits a typo under one armed subtree and requires a REJECT, so if
+		// open-world ever did become universal they would red rather than this
+		// prose quietly becoming true again.
 		return nil
 	}
 


### PR DESCRIPTION
Closes #6725

Doc-only. No runtime behaviour changes; `go test ./... -count=1` clean.

## Measured at current master before rewriting — and the issue is mostly stale

#6725 quotes three false claims in `schema_walk.go`. **Two of them were already corrected by `f37fdf19b` ("config: close snmp community, and stop the mechanism lying about itself", 2026-08-05)** — four days *after* the issue was filed on 2026-08-01, and without referencing it. At current master:

| #6725 quotes | at `2b51eac30` |
|---|---|
| "false (open-world) **everywhere in production today**" | "false (open-world) **for any subtree that has not opted in**" ✅ |
| "**no production subtree does so today**" | "Only a subtree that opted in … reaches this branch", plus a paragraph on why no count may be stated ✅ |
| "Behaviour here is **byte-identical to pre-#4313**" | **still present**, in the open-world branch ❌ |

So this PR is much smaller than the issue asks for. The enumeration in the issue is otherwise accurate — ten production subtrees opt in (9 in `schema_security.go`, 1 in `schema_system.go`) — and there are now **six** `schema_closedworld_*_4313_test.go` files, not the four it lists.

## What was actually left

The `f37fdf19b` correction reached the doc block and the keyword-resolution gate, but not the open-world branch a few lines below, which still said:

> Open-world (**the default for every production subtree**): … Behaviour here is byte-identical to pre-#4313.

Two problems, one obvious and one subtle:

1. **"the default for every production subtree" is false** — ten opt in. Same error as the two sentences already fixed.
2. **"byte-identical to pre-#4313" is TRUE of that branch and false of the function**, and the unscoped form is what #6725 read to conclude the gate was inert. A typo'd leaf under an armed subtree *is* now rejected at commit where it used to commit clean and be silently dropped. A scope-free "behaviour is unchanged" sitting next to an opt-in gate always reads as the wider claim, so the sentence now names its scope and says why the distinction matters.

## The prose is bound, not merely asserted

Each `schema_closedworld_*_4313_test.go` commits a typo under one armed subtree and requires a REJECT (and a valid config to still commit clean). So if open-world ever did become universal again, those tests red — the prose cannot quietly become true. That is cited in the comment rather than left for a reader to rediscover.

No new test is added, deliberately: the property the corrected sentence states is already covered by six behavioural tests, and a seventh asserting the same thing would be coverage theatre.

## A corroboration worth recording

The gate's existing comment warns that spelling the flag's field-and-value as a contiguous literal made the comment a false positive in the very grep it tells you to run, "inflating the count by one". Verifying the issue's enumeration reproduced exactly that: `grep -rn 'closedWorld: *true' --include=*.go pkg/config/ | grep -v _test` returns **11**, of which one is a `git grep` command inside a comment in `schema.go`. Reading the matched lines rather than the count gives the real **10**.
