### PR TITLE
daemon: the policy-rematch half is not deferred; correct the claim (#6723)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103662,3 +103662,20 @@ prose edit above them added. No diff falls in the new test body.
   pkg/cluster/heartbeat_epoch_preserve_6711_test.go (new),
   pkg/cluster/heartbeat_epoch_latch_test.go,
   pkg/cluster/heartbeat_epoch_test.go
+
+## 2026-08-22 — #6723 the policy-rematch half is not deferred; correct the claim
+- **Action**: `deletedPolicyRuntimeIDs`' header — the FIRST comment a reader hits
+  when tracing commit-time session invalidation — called the modified-policy
+  (policy-rematch) half "the deferred #4234 ... half, intentionally out of
+  scope". It is not deferred: `changedPolicyRuntimeIDs` /
+  `clearSessionsForModifiedPolicies` ship in the same file and
+  `clearSessionsForPolicyChanges` runs both on every commit. Following the stale
+  pointer to a now-closed issue leads a reader to conclude a shipped,
+  security-relevant behaviour is missing. Corrected both sites (the second was
+  the same phrasing in `clearSessionsForDeletedPolicies`), keeping the
+  stable-key rationale for why THIS function does not report changed policies.
+  Guarded by a WIRING bind rather than a phrase sweep: a phrase sweep is
+  defeated by paraphrase and would red on the corrections themselves, which
+  quote the old wording so the change is visible.
+- **File(s)**: pkg/daemon/daemon_policy_invalidate.go,
+  pkg/daemon/policy_rematch_shipped_6723_test.go (new)

--- a/pkg/daemon/daemon_policy_invalidate.go
+++ b/pkg/daemon/daemon_policy_invalidate.go
@@ -19,9 +19,20 @@ import (
 //
 // Only DELETED policies are reported. A policy whose match/action CHANGED but
 // whose zones+name are unchanged keeps the same stable key, is present in both
-// maps, and is therefore NOT reported here — that in-progress re-evaluation is
-// the deferred #4234 modified-policy (policy-rematch) half, intentionally out of
-// scope for the Junos-default deletion-clear.
+// maps, and is therefore NOT reported here.
+//
+// That is a division of labour, NOT a gap. The changed-policy case is handled
+// by changedPolicyRuntimeIDs / clearSessionsForModifiedPolicies in this file,
+// gated on `security policies policy-rematch`, and
+// clearSessionsForPolicyChanges runs both on every commit. An earlier revision
+// of this comment called it "the deferred #4234 modified-policy
+// (policy-rematch) half, intentionally out of scope" — which was true when it
+// was written and stopped being true when that half shipped. It matters
+// because this is the first comment a reader hits when tracing commit-time
+// session invalidation: following it to a now-closed issue leads to the
+// conclusion that a shipped, security-relevant behaviour (in-progress sessions
+// re-evaluated against a tightened policy) is missing, and then to
+// re-implementing it or telling an operator xpf does not do it.
 //
 // policy_id 0 is EXCLUDED from the returned set even when the literal first
 // policy (PolicySetID 0, RuleIndex 0 — policyID() == 0) is deleted or renamed.
@@ -97,7 +108,9 @@ func deletedPolicyRuntimeIDs(oldCfg, newCfg *config.Config) map[uint32]struct{} 
 //     session-table scan.
 //   - It clears ONLY sessions whose stored policy_id matches a deleted policy;
 //     a MODIFIED policy (same zones+name) keeps its key and is never touched
-//     (the deferred policy-rematch half).
+//     HERE — clearSessionsForModifiedPolicies covers it under `policy-rematch`.
+//     (This said "the deferred policy-rematch half"; it is not deferred, it
+//     ships in this file.)
 //
 // The clear reuses the same companion-aware delete the GC and cluster-stale
 // reconcile use (SessionStore.DeleteBatchKnownV4/V6 removes the forward entry,

--- a/pkg/daemon/policy_rematch_shipped_6723_test.go
+++ b/pkg/daemon/policy_rematch_shipped_6723_test.go
@@ -1,0 +1,118 @@
+package daemon
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// #6723: `deletedPolicyRuntimeIDs`' header called the modified-policy
+// (policy-rematch) half "the deferred #4234 ... half, intentionally out of
+// scope". It is not deferred — it ships in this same file — and that comment is
+// the FIRST thing a reader hits when tracing commit-time session invalidation.
+// Following it to a now-closed issue leads to concluding that a shipped,
+// security-relevant behaviour (in-progress sessions re-evaluated against a
+// tightened policy) is missing, and then either re-implementing it or telling
+// an operator xpf does not do it.
+//
+// WHY THIS GUARD IS A WIRING BIND AND NOT A PHRASE SWEEP. The obvious guard is
+// "no comment in this file may say 'deferred'". That is defeated by any
+// paraphrase, and worse, it would red on the corrected comments themselves —
+// they QUOTE the old wording so a reader can see what changed. A phrase sweep
+// would therefore push the next author toward deleting the history rather than
+// keeping it.
+//
+// What actually makes the corrected comment true is that the rematch half is
+// WIRED: `clearSessionsForPolicyChanges` calls `clearSessionsForModifiedPolicies`,
+// which consults `changedPolicyRuntimeIDs`. Bind that. If someone removes the
+// rematch half, the old comment becomes accurate again and this test reds with
+// a message saying so — which is the only situation in which reverting the
+// wording would be correct.
+//
+// Parsed with `parser.ParseFile(..., 0)`, so comments are discarded before
+// matching: no prose in this file — including this comment — can satisfy it.
+
+func policyInvalidateCallGraph(t *testing.T) map[string]map[string]bool {
+	t.Helper()
+	_, self, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	path := filepath.Join(filepath.Dir(self), "daemon_policy_invalidate.go")
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	calls := map[string]map[string]bool{}
+	for _, d := range f.Decls {
+		fd, ok := d.(*ast.FuncDecl)
+		if !ok || fd.Body == nil {
+			continue
+		}
+		set := map[string]bool{}
+		ast.Inspect(fd.Body, func(n ast.Node) bool {
+			ce, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			switch fn := ce.Fun.(type) {
+			case *ast.Ident:
+				set[fn.Name] = true
+			case *ast.SelectorExpr:
+				set[fn.Sel.Name] = true
+			}
+			return true
+		})
+		calls[fd.Name.Name] = set
+	}
+	if len(calls) < 5 {
+		t.Fatalf("parsed only %d functions from daemon_policy_invalidate.go; "+
+			"this guard is not reading the file it claims to audit", len(calls))
+	}
+	return calls
+}
+
+// TestPolicyRematchHalfIsWiredNotDeferred6723 asserts the two edges the
+// corrected comments rely on.
+func TestPolicyRematchHalfIsWiredNotDeferred6723(t *testing.T) {
+	calls := policyInvalidateCallGraph(t)
+
+	for _, edge := range []struct {
+		from, to string
+		why      string
+	}{
+		{
+			from: "clearSessionsForPolicyChanges",
+			to:   "clearSessionsForModifiedPolicies",
+			why: "the commit-time invalidation entry point must run the " +
+				"modified-policy half alongside the deletion-clear",
+		},
+		{
+			from: "clearSessionsForModifiedPolicies",
+			to:   "changedPolicyRuntimeIDs",
+			why: "the modified-policy clear must derive its id set from the " +
+				"changed-policy diff, not from the deleted-policy one",
+		},
+	} {
+		from, ok := calls[edge.from]
+		if !ok {
+			t.Fatalf("%s is gone from daemon_policy_invalidate.go; the corrected "+
+				"#6723 comments name it as the thing that makes the modified-policy "+
+				"half non-deferred", edge.from)
+		}
+		if !from[edge.to] {
+			t.Errorf("%s no longer calls %s.\n"+
+				"The policy-rematch half is what makes `deletedPolicyRuntimeIDs`' "+
+				"header true: it says the changed-policy case is handled by "+
+				"clearSessionsForModifiedPolicies rather than deferred. If that half "+
+				"has genuinely been removed, the pre-#6723 wording ('the deferred "+
+				"#4234 modified-policy half') becomes correct again and BOTH comments "+
+				"must be reverted with it — do not silence this test alone. — %s",
+				edge.from, edge.to, edge.why)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`deletedPolicyRuntimeIDs`' header said the modified-policy (policy-rematch) case
was *"the deferred #4234 modified-policy (policy-rematch) half, intentionally out
of scope"*. That was true when it was written and **stopped being true when the
half shipped**: `changedPolicyRuntimeIDs` and `clearSessionsForModifiedPolicies`
live in the same file, gated on `security policies policy-rematch`, and
`clearSessionsForPolicyChanges` runs both on every commit alongside the
deletion-clear.

It matters because this is the **first** comment a reader hits when tracing
commit-time session invalidation, and it points at an issue number now closed as
implemented. Following it leads to concluding that a shipped, security-relevant
behaviour — in-progress sessions re-evaluated against a tightened policy — is
missing, and then either to re-implementing it or to telling an operator xpf does
not do it.

Both sites carrying the phrasing are corrected: the `deletedPolicyRuntimeIDs`
header, and the same claim repeated in `clearSessionsForDeletedPolicies`'
bounded-scope list (the issue asked for the sibling check — this is the sibling).
The stable-key rationale is **kept** in both: it is still the correct explanation
for why *this* function does not report a changed policy. What changes is that
the omission is named as a division of labour rather than a gap.

Both corrections **quote** the old wording rather than silently replacing it, so
a reader arriving from an older branch, a cached view or a stale review can see
what changed and why.

## The guard is a wiring bind, not a phrase sweep

The obvious guard is *"no comment in this file may say 'deferred'"*. It is
defeated by any paraphrase — and worse, it would **red on the corrections
themselves**, pushing the next author to delete the history rather than keep it.

What actually makes the corrected comment true is that the rematch half is
**wired**, so that is what is bound:

```
clearSessionsForPolicyChanges → clearSessionsForModifiedPolicies → changedPolicyRuntimeIDs
```

If someone removes the rematch half, the old wording becomes accurate again and
the test reds with a message saying exactly that — the only situation in which
reverting the comment would be correct. The message says to revert **both**
comments rather than silence the test.

Parsed with `parser.ParseFile(..., 0)`, so comments are discarded before
matching: no prose in the file — **including the test's own** — can satisfy it.
The scan asserts it parsed at least five functions, so a rename or a file move
reds instead of passing over an empty set.

## Mutation matrix

Full-package (`go test -count=1 ./pkg/daemon/`, no `-run` filter except where
noted), each verified applied and restored clean.

| # | Mutation | rc | Which assertion fired |
|---|---|---|---|
| 1 | delete the `clearSessionsForModifiedPolicies` call from the commit-time entry point | 1 | `:108` *"clearSessionsForPolicyChanges no longer calls clearSessionsForModifiedPolicies"* |
| 2 | route the changed-policy diff through a local alias so the direct call disappears | 1 | `:108` *"clearSessionsForModifiedPolicies no longer calls changedPolicyRuntimeIDs"* — the second edge is independently bound |
| 3 | **tightening** — point the scan at a different file in the same package | 1 | `:103` *"clearSessionsForPolicyChanges is gone from daemon_policy_invalidate.go"* — the non-vacuity floor is live, so a rename or move reds rather than passing over an empty set |

A first attempt at cell 2 (swapping in `deletedPolicyRuntimeIDs`, which has a
different signature) broke the build and is reported **VOID** rather than counted
as a red; cell 2 above is the compiling replacement.

## Validation

- `go test ./... -count=1` — **rc=0, 67 packages ok, 0 FAIL**, including
  `pkg/refactoraudit`'s modularity gate.
- **Doc-only: no runtime behaviour changes.** The only non-comment addition is a
  test file. No cluster, VRRP, session-sync, failover, dataplane or shim code.

Closes #6723
