### PR TITLE
daemon: reconcile management on paths that promote without applying (#6718, #6720)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103676,3 +103676,14 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/daemon/management_start_race_6719_test.go` (new),
   `pkg/daemon/daemon_dp_escape_rest_test.go`,
   `pkg/daemon/hostname_stale_cert_6827_test.go`, `pkg/daemon/README.md`
+
+## 2026-08-22 — #6718 + #6720: the management reconcile follows the promotion
+- **Action**: Added `reconcileManagementAfterPromotion` and called it from the
+  three paths that promote a config to active and then return BEFORE
+  `applyConfigLocked` (its only caller): the first-commit-confirmed rollback's
+  `prevCfg == nil` branch (#6718), and `syncAndApply`'s topology and identity
+  backstops (#6720). Each left a superseded api-auth credential authenticating
+  against the live listener. Enforcement of the backstops is unchanged.
+- **File(s)**: `pkg/daemon/management.go`, `pkg/daemon/daemon_apply_commit.go`,
+  `pkg/daemon/promote_reconcile_6718_6720_test.go` (new),
+  `pkg/daemon/README.md`

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -399,6 +399,36 @@ mirrors `reconcileSNMP`: `reconcileWebManagement` runs EARLY in
 credential revocation is enforced even on an apply that returns early
 (`store.Commit` has already promoted the config). Reconcile discipline:
 
+**The reconcile follows the PROMOTION, not the apply (#6718, #6720).**
+`reconcileWebManagement` runs early in `applyConfigLocked` so a committed auth
+revocation survives an apply that *aborts partway*. That contract had an
+unstated precondition: `applyConfigLocked` is its only caller, so a path that
+returns **before entering the apply** never reaches it. Two do, and both leave a
+superseded credential authenticating against the live listener:
+
+- `executeConfirmedRollback`'s `prevCfg == nil` branch — a first
+  `commit confirmed` on a fresh store times out, the store reverts to the empty
+  tree, `enterBootstrapMode` runs and the function returns. The abandoned
+  commit's off-box bind and api-auth credential stayed live.
+- `syncAndApply`'s topology (#5840) and identity (#6192) backstops — `SyncApply`
+  has already promoted the peer config, then the backstop returns. The listener
+  kept honouring a credential the now-active config revoked.
+
+Both now call `reconcileManagementAfterPromotion`. The reconcile is the GENERIC
+one in every case, including the bootstrap one: with the empty tree active there
+is no web-management stanza, so the desired state IS the `--api-addr` flag
+default with no credential — which is exactly "revert to the flag-default
+endpoint and drop the abandoned credential". Keeping the management LIFELINE,
+which is why that branch skips the apply, is not the same as keeping the
+abandoned commit's off-box bind and secret.
+
+The backstops keep returning their error and keep refusing to arm the dataplane.
+Their constraint is the boot-only HA runtime; the authorization reconcile has no
+such constraint. Hoisting those checks ABOVE the `SyncApply` promotion would also
+close the divergence, but it changes the tolerant path from "converge with the
+peer, refuse to arm" to "refuse the config" — a deliberate #1960 behaviour choice
+that does not belong in a bug fix.
+
 **Startup ordering and publication (#6719).** `d.mgmt` is an
 `atomic.Pointer[managementReconciler]`, not a plain field, and the type is doing
 real work rather than being defensive. `startClusterComms` runs at

--- a/pkg/daemon/daemon_apply_commit.go
+++ b/pkg/daemon/daemon_apply_commit.go
@@ -401,6 +401,13 @@ func (d *Daemon) syncAndApply(ctx context.Context, configText string, chassisPre
 		slog.Error("cluster: refusing to apply a peer-synced standalone<->cluster "+
 			"topology transition live; a restart is required to (de)construct the "+
 			"HA runtime", "err", terr)
+		// #6720: SyncApply has already promoted this config, so the AUTHORIZATION
+		// it carries is live policy even though the dataplane must not be armed
+		// under it. The backstop's constraint is boot-only HA runtime
+		// construction; reconcileWebManagement has no such constraint, and
+		// skipping it leaves the listener honouring a credential the now-active
+		// config revoked.
+		d.reconcileManagementAfterPromotion(compiled, "peer-synced topology transition refused")
 		return nil, terr
 	}
 
@@ -418,6 +425,10 @@ func (d *Daemon) syncAndApply(ctx context.Context, configText string, chassisPre
 		slog.Error("cluster: refusing to apply a peer-synced node-id/cluster-id "+
 			"identity change live; a restart is required to re-key the HA manager",
 			"err", ierr)
+		// #6720: same reasoning as the topology backstop above — the promoted
+		// config's authorization is live policy regardless of the HA re-key
+		// constraint that stops the apply.
+		d.reconcileManagementAfterPromotion(compiled, "peer-synced identity change refused")
 		return nil, ierr
 	}
 
@@ -721,6 +732,16 @@ func (d *Daemon) executeConfirmedRollback(gen uint64) {
 				"teardown did not fully converge (see the teardown step errors above); "+
 				"config-driven takeover state may remain partially live", "err", err)
 		}
+		// #6718: the store has promoted the empty tree to active, but this
+		// branch returns without ever entering applyConfigLocked — the only
+		// caller of reconcileWebManagement. Without this the listener stays
+		// bound where the ABANDONED commit put it and its api-auth credential
+		// keeps authenticating, authorised by a config the box has formally
+		// abandoned. The empty active resolves to the --api-addr flag default
+		// (loopback, no credential), which is exactly the endpoint the reverted
+		// config implies.
+		d.reconcileManagementAfterPromotion(d.store.ActiveConfig(),
+			"first commit-confirmed timeout reverted to bootstrap")
 		// #3868: no peer re-sync here. This branch reverts a FIRST commit on a
 		// fresh store to the empty tree + bootstrap mode; the reverted active
 		// carries no chassis-cluster/config-sync stanza, so syncConfigToPeer ->

--- a/pkg/daemon/management.go
+++ b/pkg/daemon/management.go
@@ -831,6 +831,46 @@ func (m *managementReconciler) wait() {
 	}
 }
 
+// reconcileManagementAfterPromotion runs the management reconcile for a config
+// the store has ALREADY promoted to active, on a path that deliberately does NOT
+// reach applyConfigLocked (#6718, #6720).
+//
+// reconcileWebManagement's own contract (below) is written for an apply that
+// ABORTS PARTWAY: "so a committed authentication tightening/revocation or bind
+// change is live even on an apply that returns early". That contract had an
+// unstated precondition — applyConfigLocked is its ONLY caller, so a path that
+// returns BEFORE entering the apply never reaches it at all, and two do:
+//
+//   - executeConfirmedRollback's prevCfg == nil branch (#6718): a first
+//     `commit confirmed` on a fresh store times out, PromoteRollback reverts to
+//     the empty tree, and enterBootstrapMode returns. The abandoned commit's
+//     off-box bind and its api-auth credential stayed live — authorised by a
+//     config the box has formally abandoned.
+//   - syncAndApply's topology / identity backstops (#6720): SyncApply has
+//     already promoted the peer config, then the backstop returns. The listener
+//     kept honouring a credential the now-active config revoked.
+//
+// The reconcile is deliberately the GENERIC one in both cases, including the
+// bootstrap case where #6718 wondered whether a special bootstrap-management
+// reconcile was needed. It is not: with the empty tree active, committedDesired
+// resolves to no web-management stanza, so desired() leaves Addr at the
+// --api-addr flag default (loopback) and Auth nil — which IS "revert to the
+// flag-default endpoint and drop the abandoned credential". Keeping the
+// management LIFELINE, which is why that branch skipped the reconcile, is not
+// the same thing as keeping the abandoned commit's off-box bind and secret.
+//
+// Failure is logged, never propagated: both callers are already returning (an
+// error, or from a fire-and-forget timer), and a bind failure here must not
+// change what they return. This mirrors reconcileWebManagement's own
+// warn-and-retry posture.
+func (d *Daemon) reconcileManagementAfterPromotion(cfg *config.Config, why string) {
+	if err := d.reconcileWebManagement(cfg); err != nil {
+		slog.Error("management reconcile after a promotion that skipped the apply did not "+
+			"converge; the listener may still honour a superseded endpoint or credential",
+			"reason", why, "err", err)
+	}
+}
+
 // reconcileWebManagement is the applyConfigLocked entry point (#5866). It
 // mirrors reconcileSNMP: it runs EARLY in the apply — before the dataplane apply
 // that can abort on a protocol-gate error — so a committed authentication

--- a/pkg/daemon/promote_reconcile_6718_6720_test.go
+++ b/pkg/daemon/promote_reconcile_6718_6720_test.go
@@ -1,0 +1,298 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/psaab/xpf/pkg/api"
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// #6718 / #6720 — a path that PROMOTES a config to active must reach the
+// management reconcile even when it deliberately never enters applyConfigLocked.
+//
+// reconcileWebManagement's contract is already written in the tree: it runs
+// early in the apply "so a committed authentication tightening/revocation or
+// bind change is live even on an apply that returns early". That is stated for
+// an apply that ABORTS PARTWAY, and it had an unstated precondition —
+// applyConfigLocked is its only caller. Two paths return BEFORE entering it,
+// and each leaves a superseded credential authenticating against the live
+// listener.
+//
+// The two guards below must fail INDEPENDENTLY. They share an invariant, a fix
+// shape and a helper, which is exactly the setup in which one guard ends up
+// wearing two names: each drives its OWN trigger path (a first-commit rollback
+// timeout vs a peer push carrying a topology transition), so removing one call
+// site reds one test and leaves the other green.
+
+// promoteReconcileEnv wires a daemon whose management listener is LIVE and
+// currently honouring `secret` on an off-box bind — the precondition both
+// defects need, because a listener that never started makes reconcileTo a no-op
+// on `m.srv == nil` and every assertion below would pass vacuously.
+type promoteReconcileEnv struct {
+	d     *Daemon
+	store *configstore.Store
+	m     *managementReconciler
+}
+
+func newPromoteReconcileEnv(t *testing.T) *promoteReconcileEnv {
+	t.Helper()
+	mgmtAuthIfaceAddrs(t)
+	s, err := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err != nil {
+		t.Fatalf("configstore.New: %v", err)
+	}
+	d := &Daemon{applySem: semaphore.NewWeighted(1), store: s}
+	reg := newFakeReg()
+	m := newManagementReconciler(d, api.Config{ListenFunc: reg.listen})
+	d.mgmt.Store(m)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	if err := m.start(ctx); err != nil {
+		t.Fatalf("mgmt start: %v", err)
+	}
+	return &promoteReconcileEnv{d: d, store: s, m: m}
+}
+
+// liveSecret returns the api-auth password the LIVE listener currently accepts
+// for `webadmin`, or "" when it accepts none.
+func (e *promoteReconcileEnv) liveSecret(t *testing.T) string {
+	t.Helper()
+	e.m.mu.Lock()
+	srv := e.m.srv
+	e.m.mu.Unlock()
+	if srv == nil {
+		t.Fatal("setup: the management server must be live, or every assertion here is vacuous")
+	}
+	auth := srv.LiveAuth()
+	if auth == nil {
+		return ""
+	}
+	return auth.Users["webadmin"]
+}
+
+// TestFirstCommitRollbackDropsTheAbandonedCredential6718 is the #6718 guard.
+//
+// A first `commit confirmed` on a fresh store enables a credentialed off-box
+// bind; the operator never confirms; the timer fires. PromoteRollback returns
+// prevCfg == nil, the store is back to the empty tree and marked
+// never-committed — and before #6718 the listener stayed bound where the
+// abandoned commit put it, with its credential still authenticating, authorised
+// by a config the box has formally abandoned.
+//
+// The reverted endpoint is the generic one and that is the point: with the empty
+// tree active there is no web-management stanza, so the desired state IS the
+// --api-addr flag default with no credential. Keeping the management LIFELINE —
+// the reason this branch skips the apply — is not the same as keeping the
+// abandoned commit's off-box bind and secret.
+//
+// FAIL-ON-REVERT: delete the reconcileManagementAfterPromotion call from the
+// prevCfg == nil branch of executeConfirmedRollback. This test reds; the #6720
+// test below stays GREEN.
+func TestFirstCommitRollbackDropsTheAbandonedCredential6718(t *testing.T) {
+	const abandoned = "ABANDONED-first-commit-secret"
+	e := newPromoteReconcileEnv(t)
+
+	// A fresh store starts with no credential at all.
+	if got := e.liveSecret(t); got != "" {
+		t.Fatalf("setup: a fresh store must authorise no credential, got %q", got)
+	}
+
+	// The FIRST commit, unconfirmed, enables the credentialed off-box bind.
+	if err := e.store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if _, err := e.store.LoadSet(mgmtAuthConfigFor("ge-0/0/0", abandoned)); err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	if _, err := e.store.CommitConfirmed(1); err != nil {
+		t.Fatalf("CommitConfirmed: %v", err)
+	}
+	e.store.ExitConfigure()
+
+	// Stand in for the apply that the real commit path runs: the listener is now
+	// where the abandoned commit put it. This is the state #6718 describes, so
+	// establishing it is setup, not the property under test.
+	if err := e.d.reconcileWebManagement(e.store.ActiveConfig()); err != nil {
+		t.Fatalf("setup reconcile: %v", err)
+	}
+	if got := e.liveSecret(t); got != abandoned {
+		t.Fatalf("setup: the abandoned commit's credential must be live before the timeout, got %q", got)
+	}
+
+	// The operator never confirms. Fire the timer through the production
+	// executor, not by calling the branch directly.
+	e.d.applyBodyForTest = func(_ *config.Config) {}
+	e.store.SetRollbackExecutor(e.d.executeConfirmedRollback)
+	e.store.InvokeRollbackTimerForTesting(e.store.ConfirmGenForTesting())
+
+	if !e.d.inBootstrap() {
+		t.Fatal("setup: the first-commit timeout must take the prevCfg == nil branch " +
+			"(bootstrap mode); if it did not, this test is not exercising #6718 at all")
+	}
+	if e.store.EverCommitted() {
+		t.Fatal("setup: the store must read never-committed after a first-commit rollback")
+	}
+
+	if got := e.liveSecret(t); got == abandoned {
+		t.Fatalf("the listener still authenticates the ABANDONED commit's credential after "+
+			"the first-commit-confirmed timeout. The store has reverted to the empty tree "+
+			"and marked itself never-committed, so that credential is authorised by a "+
+			"config the box has formally abandoned — and under #5561 it still yields a "+
+			"full-power principal (#6718). live=%q", got)
+	}
+	if got := e.liveSecret(t); got != "" {
+		t.Fatalf("the reverted endpoint must carry NO credential — the empty active config "+
+			"names no api-auth — got %q", got)
+	}
+}
+
+// TestPeerSyncBackstopStillReconcilesManagement6720 is the #6720 guard.
+//
+// SyncApply promotes the peer config FIRST; the topology backstop then refuses
+// the live apply and returns before applyConfigLocked. The backstop is right to
+// refuse to arm the dataplane — the HA runtime is boot-only — but that
+// constraint does not apply to the AUTHORIZATION reconcile, and skipping it left
+// the listener honouring a credential the now-active config had revoked.
+//
+// FAIL-ON-REVERT: delete the reconcileManagementAfterPromotion call from the
+// topology backstop in syncAndApply. This test reds; the #6718 test above stays
+// GREEN.
+func TestPeerSyncBackstopStillReconcilesManagement6720(t *testing.T) {
+	const oldSecret, newSecret = "OLD-peer-secret", "NEW-peer-secret"
+	e := newPromoteReconcileEnv(t)
+	d := e.d
+
+	// Active config carries the OLD credential, reconciled live.
+	mgmtAuthCommit(t, e.store, mgmtAuthConfigFor("ge-0/0/0", oldSecret))
+	if err := e.d.reconcileWebManagement(e.store.ActiveConfig()); err != nil {
+		t.Fatalf("setup reconcile: %v", err)
+	}
+	if got := e.liveSecret(t); got != oldSecret {
+		t.Fatalf("setup: the old credential must be live before the sync, got %q", got)
+	}
+
+	// The peer pushes a config that BOTH revokes the old credential and carries
+	// a topology transition. This daemon HAS an HA runtime and the pushed config
+	// is standalone, so clusterTopologyCommitPreflight rejects the live apply —
+	// the "removing `chassis cluster` cannot tear down the HA runtime" direction.
+	//
+	// That direction is used deliberately: it needs no chassis stanza to survive
+	// the peer-text round trip, so the fixture cannot pass for the wrong reason
+	// if the cluster block fails to compile. The backstop's code path — promote,
+	// then return before applyConfigLocked — is identical in both directions.
+	d.cluster = cluster.NewManager(0, 1)
+
+	// Build the peer text the way a PEER actually produces it: commit the new
+	// config in its own store and render it with ShowActive(), which is exactly
+	// what pushConfigToPeer sends (daemon_ha_sync.go). Deriving it from the local
+	// candidate instead does not work — the candidate render did not carry the
+	// changed secret, so SyncApply promoted a config identical to the active one
+	// and the test passed its setup while proving nothing.
+	peerStore, err := configstore.New(filepath.Join(t.TempDir(), "peer.conf"))
+	if err != nil {
+		t.Fatalf("configstore.New (peer): %v", err)
+	}
+	mgmtAuthCommit(t, peerStore, mgmtAuthConfigFor("ge-0/0/0", newSecret))
+	peerText := peerStore.ShowActive()
+
+	_, err = e.d.syncAndApply(context.Background(), peerText, nil)
+	if err == nil {
+		t.Fatal("setup: the topology backstop must reject a peer-synced topology transition " +
+			"on a daemon whose HA runtime cannot be torn down live; without that rejection " +
+			"this test exercises the ordinary apply path and proves nothing about #6720")
+	}
+	if !strings.Contains(err.Error(), "restart") {
+		t.Fatalf("setup: expected the topology backstop's restart-required error, got %v", err)
+	}
+
+	// The promotion happened regardless — that is the backstop's deliberate
+	// design (the store converges with the peer). So the credential it revoked
+	// must be gone from the live listener.
+	if got := e.liveSecret(t); got == oldSecret {
+		t.Fatalf("the listener still authenticates %q, a credential the now-ACTIVE peer "+
+			"config revoked. SyncApply promoted that config before the backstop returned, "+
+			"so the revocation is live policy; the backstop's constraint is the boot-only "+
+			"HA runtime, which has nothing to do with the authorization reconcile (#6720)", oldSecret)
+	}
+	if got := e.liveSecret(t); got != newSecret {
+		t.Fatalf("the listener must honour the promoted config's credential; got %q", got)
+	}
+}
+
+// TestPeerSyncIdentityBackstopStillReconcilesManagement6720 covers the SECOND
+// #6720 call site. The identity backstop is a separate `return nil, err` before
+// applyConfigLocked, so it is a separate claim and owes its own guard — a fix
+// applied to the topology branch alone would leave this one silently open, and
+// the topology test above cannot see it.
+//
+// Here both sides are clustered (so the topology backstop passes) and the peer's
+// cluster-id differs from the running manager's, which is what
+// clusterIdentityCommitPreflight refuses: the boot-constructed HA manager cannot
+// be re-keyed live.
+//
+// FAIL-ON-REVERT: delete the reconcileManagementAfterPromotion call from the
+// identity backstop. This test reds; the other two stay GREEN.
+func TestPeerSyncIdentityBackstopStillReconcilesManagement6720(t *testing.T) {
+	const oldSecret, newSecret = "OLD-identity-secret", "NEW-identity-secret"
+	e := newPromoteReconcileEnv(t)
+
+	clusterLines := func(clusterID int) string {
+		return "set chassis cluster cluster-id " + strconv.Itoa(clusterID) + "\n" +
+			"set chassis cluster node 0\n" +
+			"set chassis cluster authentication-key identity-6720-psk\n" +
+			"set chassis cluster redundancy-group 1 node 0 priority 200\n"
+	}
+
+	// Local active: clustered, cluster-id 1, OLD credential.
+	mgmtAuthCommit(t, e.store, mgmtAuthConfigFor("ge-0/0/0", oldSecret)+clusterLines(1))
+	// A hard precondition, NOT a t.Skip. A skip here would silently disable the
+	// only guard on the identity call site the moment the chassis stanza stopped
+	// compiling from this fixture — a green indistinguishable from a healthy one.
+	if act := e.store.ActiveConfig(); act == nil || act.Chassis.Cluster == nil {
+		t.Fatal("setup: the local active config must compile a chassis-cluster stanza, or " +
+			"the identity backstop is unreachable and this guard proves nothing")
+	}
+	if err := e.d.reconcileWebManagement(e.store.ActiveConfig()); err != nil {
+		t.Fatalf("setup reconcile: %v", err)
+	}
+	if got := e.liveSecret(t); got != oldSecret {
+		t.Fatalf("setup: the old credential must be live before the sync, got %q", got)
+	}
+
+	// Running HA manager is keyed to cluster-id 1; the peer pushes cluster-id 2.
+	e.d.cluster = cluster.NewManager(0, 1)
+
+	peerStore, err := configstore.New(filepath.Join(t.TempDir(), "peer-identity.conf"))
+	if err != nil {
+		t.Fatalf("configstore.New (peer): %v", err)
+	}
+	mgmtAuthCommit(t, peerStore, mgmtAuthConfigFor("ge-0/0/0", newSecret)+clusterLines(2))
+	peerText := peerStore.ShowActive()
+
+	_, err = e.d.syncAndApply(context.Background(), peerText, nil)
+	if err == nil {
+		t.Fatal("setup: the identity backstop must reject a peer-synced cluster-id change; " +
+			"without that rejection this test exercises the ordinary apply path")
+	}
+	if !strings.Contains(err.Error(), "restart") {
+		t.Fatalf("setup: expected the identity backstop's restart-required error, got %v", err)
+	}
+
+	if got := e.liveSecret(t); got == oldSecret {
+		t.Fatalf("the listener still authenticates %q after the IDENTITY backstop refused the "+
+			"apply. SyncApply promoted the peer config first, so its revocation is live "+
+			"policy; the backstop's constraint is re-keying the boot-constructed HA manager, "+
+			"which has nothing to do with the authorization reconcile (#6720)", oldSecret)
+	}
+	if got := e.liveSecret(t); got != newSecret {
+		t.Fatalf("the listener must honour the promoted config's credential; got %q", got)
+	}
+}


### PR DESCRIPTION
Closes #6718
Closes #6720

## The invariant was already written in the tree

`reconcileWebManagement`'s own doc says it runs early in `applyConfigLocked`

> "so a committed authentication tightening/revocation or bind change is live
> even on an apply that **returns early**"

That contract was never wrong — it had an **unstated precondition**.
`applyConfigLocked` is its only caller, so the contract holds for an apply that
aborts *partway* and says nothing about a path that returns **before entering
the apply at all**. Two do, and each leaves a superseded credential
authenticating against the live listener. This PR extends an existing rule to
the paths that bypass its only caller rather than inventing a new one.

## #6718 — the abandoned first commit

`executeConfirmedRollback`'s `prevCfg == nil` branch: a first `commit confirmed`
on a fresh store times out, `PromoteRollback` reverts to the empty tree and marks
the store never-committed, `enterBootstrapMode` unwinds the takeover, and the
function returns. The abandoned commit's off-box bind and its `api-auth`
credential stayed live — authorised by a config the box has **formally
abandoned**, and under #5561 still yielding a full-power principal.

The issue flagged a tension to resolve rather than a missing call: "keep the
management lifeline" is why that branch skips the reconcile. Measured against the
code, it resolves in favour of the **generic** reconcile, and no bootstrap-special
path is needed: with the empty tree active there is no web-management stanza, so
`committedDesired` → `desired()` leaves `Addr` at the `--api-addr` flag default
and `Auth` nil. That *is* "revert to the flag-default endpoint and drop the
abandoned credential". Keeping the management **lifeline** is not the same thing
as keeping the abandoned commit's off-box bind and secret.

## #6720 — the peer-sync backstops

`syncAndApply`'s topology (#5840) and identity (#6192) backstops: `SyncApply` has
already promoted the peer config, then the backstop returns before
`applyConfigLocked`. The listener kept honouring a credential the now-active
config revoked.

Both backstops still return their error and still refuse to arm the dataplane —
their constraint is the boot-only HA runtime, which has nothing to do with the
authorization reconcile.

**On the larger alternative the issue suggested:** hoisting the checks *above*
the `SyncApply` promotion would also remove the divergence, but it changes the
tolerant path from "converge with the peer, refuse to arm" — a documented,
deliberate choice at that call site — to "refuse the config". That is a #1960
behaviour decision, not a bug fix, and the two do not ride in the same PR. Not
taken, and said so rather than silently picking the bigger change.

## Three guards that fail independently

The three call sites share an invariant, a fix shape and now a helper — the exact
setup in which one guard ends up wearing two names. Each drives its **own trigger
path** (a first-commit rollback timeout, a peer push carrying a topology
transition, a peer push carrying a cluster-id change), not the helper.

The identity backstop gets its own guard rather than riding on the topology one:
it is a separate `return nil, err`, so it is a separate claim and owes a test — a
fix applied to the topology branch alone would have left it silently open.

## Two fixture defects found while writing them

Both of the pass-for-the-wrong-reason kind, and both would have shipped a green
board:

1. **`SyncApply` parses hierarchical Junos text, not `set` lines.** A set-line
   peer payload compiled to an effectively empty tree — no web-management, no
   chassis — so the backstop never fired and the test fell through to the
   ordinary apply path.
2. **The peer text has to come from a peer store's `ShowActive()`** — what
   `pushConfigToPeer` actually sends. A candidate render did not carry the changed
   secret, so `SyncApply` promoted a config identical to the active one; the test
   passed its setup while proving nothing.

The identity guard also asserts its chassis-cluster precondition with a `Fatal`
rather than a `t.Skip`: a skip there would silently disable the only cover on that
call site the moment the fixture stopped compiling a cluster stanza — a green
indistinguishable from a healthy one.

## Validation

- `go build ./...`, `gofmt`, `go vet ./pkg/daemon/` clean.
- **`go test -count=1 ./...` green repo-wide** (0 failures), not just the touched
  package.

### Independence matrix — full `pkg/daemon` suite per cell, 1903 tests collected each, no build breaks

| # | Mutation | Verdict |
|---|---|---|
| **Q1** | delete the **#6718** call site | **RED — `TestFirstCommitRollbackDropsTheAbandonedCredential6718` ONLY**; both #6720 guards green |
| **Q2** | delete the **topology** call site | **RED — `TestPeerSyncBackstopStillReconcilesManagement6720` ONLY**; the other two green |
| **Q3** | delete the **identity** call site | **RED — `TestPeerSyncIdentityBackstopStillReconcilesManagement6720` ONLY**; the other two green |

Each cell reds exactly one guard, which is the property that says these are three
distinct reproductions rather than one guard under three names.

## Cluster surface

Touches the **peer-sync apply path** (`syncAndApply`). **It owes
`make test-failover`, which runs centrally**; no cluster targets were run from
this lane.

Refs #5561, #5840, #6192, #6719, #1960.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VM24XVAYBhzAUSAAhnR8Xp
