### PR TITLE
config: redact credentials in URL-shaped fields on marshal

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103676,3 +103676,15 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/daemon/management_start_race_6719_test.go` (new),
   `pkg/daemon/daemon_dp_escape_rest_test.go`,
   `pkg/daemon/hostname_stale_cert_6827_test.go`, `pkg/daemon/README.md`
+
+## 2026-08-22 — #6733 redact credential-bearing URL fields on marshal
+- **Timestamp**: 2026-08-22
+- **Action**: The config redaction pass is name-keyed; several fields are
+  sensitive by CONTENT (URLs/endpoints named for what they are). Added
+  RedactURL coverage to SystemConfig.LicenseAutoUpdate, ArchivalConfig
+  archive-site lists, FeedServer.Hostname, FeedEntry.Path, RPMTest.Target and
+  WgPeerConfig.Endpoint, plus a reflective census gate that fails when a new
+  URL-shaped field renders a planted credential verbatim.
+- **File(s)**: pkg/config/types_system.go, pkg/config/types_security.go,
+  pkg/config/types_routing.go,
+  pkg/config/url_field_redaction_census_6733_test.go

--- a/pkg/config/types_routing.go
+++ b/pkg/config/types_routing.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -589,6 +590,26 @@ type WgPeerConfig struct {
 	Endpoint        string   // optional peer endpoint IP:port (initiator role)
 	KeepaliveSecs   uint16   // optional persistent-keepalive seconds (0 = off)
 	PresharedKeyHex Secret   // optional per-peer PSK (hex, 64 chars); "" = zero PSK (#1434 B2); redacted on marshal
+}
+
+// MarshalJSON redacts a credential embedded in a WireGuard peer ENDPOINT
+// (#6733).
+//
+// A peer endpoint is a host:port, which RedactURL returns unchanged (measured,
+// including bare IPv4/IPv6 literals), so this is defence in depth rather than a
+// live leak: it costs nothing for every real configuration and removes the need
+// to assert, in a census row nobody re-checks, that this field can never hold a
+// credential. The #6733 census fails on any URL-shaped field that renders a
+// planted credential verbatim, and an empty census is a stronger end state than
+// a justified one.
+//
+// The alias type sheds this method to avoid recursion while preserving every
+// field, so a field added to WgPeerConfig later is still marshalled.
+func (w WgPeerConfig) MarshalJSON() ([]byte, error) {
+	type alias WgPeerConfig
+	v := alias(w)
+	v.Endpoint = RedactURL(v.Endpoint)
+	return json.Marshal(v)
 }
 
 // String redacts WgLocalPrivkeyHex AND every per-peer PresharedKeyHex so

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -87,6 +87,33 @@ func (f *FeedServer) MarshalJSON() ([]byte, error) {
 	type alias FeedServer
 	v := alias(*f)
 	v.URL = RedactURL(v.URL)
+	// #6733: Hostname is the other credential-bearing slot on this struct. It
+	// is named for what it IS, not for what it may carry, so the name-keyed
+	// redaction pass never masked it — and an operator who writes
+	// `user:token@feeds.example` here leaks it through the authenticated REST
+	// GET. RedactURL leaves a bare hostname or host:port untouched (measured),
+	// so this narrows nothing for an ordinary config.
+	v.Hostname = RedactURL(v.Hostname)
+	return json.Marshal(v)
+}
+
+// MarshalJSON redacts a credential embedded in a feed entry's PATH (#6733).
+//
+// A feed path is ordinarily a bare path (`/feeds/list.txt`), which RedactURL
+// returns unchanged. It becomes credential-bearing when an operator writes a
+// full URL here — the compiler joins Hostname and Path, so both slots accept
+// one — and a `?token=SECRET` query is the common shape. Redacting the query
+// costs nothing for a plain path and closes that.
+//
+// The alias type sheds this method to avoid recursion while preserving every
+// field, so a field added to FeedEntry later is still marshalled.
+func (e *FeedEntry) MarshalJSON() ([]byte, error) {
+	if e == nil {
+		return []byte("null"), nil
+	}
+	type alias FeedEntry
+	v := alias(*e)
+	v.Path = RedactURL(v.Path)
 	return json.Marshal(v)
 }
 

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -227,6 +227,97 @@ type ArchivalConfig struct {
 	ArchiveSitesWithPassword []string
 }
 
+// MarshalJSON redacts a credential embedded in an RPM test TARGET (#6733).
+//
+// An `http-get` probe's target is a URL, and a monitored endpoint routinely
+// carries an auth token in it. For the icmp-ping / tcp-ping probe types the
+// target is a bare IP or hostname, which RedactURL returns unchanged
+// (measured, including v6 literals), so this is a no-op for them rather than a
+// probe-type conditional that could drift from the type list.
+//
+// The receiver is a VALUE for robustness rather than necessity: RPMProbe holds
+// `Tests map[string]*RPMTest`, so a pointer receiver would be reached today. A
+// value receiver is reached through BOTH a *RPMTest and an RPMTest, so it keeps
+// working if the container is ever changed to hold values — a redaction that
+// silently stops applying when a field's container changes shape is the failure
+// this whole change is about.
+//
+// The alias type sheds this method to avoid recursion while preserving every
+// field, so a field added to RPMTest later is still marshalled.
+func (t RPMTest) MarshalJSON() ([]byte, error) {
+	type alias RPMTest
+	v := alias(t)
+	v.Target = RedactURL(v.Target)
+	return json.Marshal(v)
+}
+
+// MarshalJSON redacts the license auto-update URL (#6733).
+//
+// `system license autoupdate url <url>` is a fetch endpoint, and a licence
+// server URL routinely carries the entitlement token inline or as a query
+// parameter. The field is named for what it is, so the name-keyed redaction
+// pass never reached it and the authenticated REST GET returned it verbatim.
+//
+// The receiver is a VALUE, not a pointer, deliberately: Config holds
+// `System SystemConfig` by value, and encoding/json only promotes to a
+// pointer method when the value is addressable. A pointer receiver here would
+// work when a *Config is marshalled and silently do NOTHING when a Config is
+// marshalled by value — a redaction that depends on the caller's syntax is
+// worse than none, because it tests green on whichever form the test happens
+// to use.
+//
+// The alias type sheds this method to avoid recursion while preserving every
+// field, so a field added to SystemConfig later is still marshalled.
+func (s SystemConfig) MarshalJSON() ([]byte, error) {
+	type alias SystemConfig
+	v := alias(s)
+	v.LicenseAutoUpdate = RedactURL(v.LicenseAutoUpdate)
+	return json.Marshal(v)
+}
+
+// MarshalJSON redacts the credential-bearing URL slots on an ArchivalConfig
+// (#6733).
+//
+// `system archival configuration archive-sites <url>` takes a transfer URL, and
+// the Junos idiom puts the credential inline — `scp://user:pw@host:/dir` or an
+// ftp URL with a password. Both lists hold that URL verbatim:
+// ArchiveSitesWithPassword exists precisely BECAUSE a site carried an inline
+// `password`, so it is the highest-value list on this struct and was returned
+// in full by the authenticated REST GET.
+//
+// The redaction pass is keyed on field NAMES that look secret; these are named
+// for what they are (sites), so no name-keyed rule reaches them. RedactURL
+// leaves a credential-free URL untouched, so an ordinary config renders
+// identically.
+//
+// The alias type sheds this method to avoid recursion while preserving every
+// field, so a field added to ArchivalConfig later is still marshalled.
+func (a *ArchivalConfig) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		return []byte("null"), nil
+	}
+	type alias ArchivalConfig
+	v := alias(*a)
+	v.ArchiveSites = redactURLSlice(v.ArchiveSites)
+	v.ArchiveSitesWithPassword = redactURLSlice(v.ArchiveSitesWithPassword)
+	return json.Marshal(v)
+}
+
+// redactURLSlice returns a redacted COPY of a URL list, leaving the caller's
+// slice untouched. Copying matters: these marshallers run on an alias of a
+// live *Config, and the backing array is shared with it — redacting in place
+// would mutate the running configuration as a side effect of serving a GET.
+func redactURLSlice(in []string) []string {
+	if in == nil {
+		return nil
+	}
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[i] = RedactURL(s)
+	}
+	return out
+}
+
 // InternetOptionsConfig holds internet-options settings.
 type InternetOptionsConfig struct {
 	NoIPv6RejectZeroHopLimit bool

--- a/pkg/config/url_field_redaction_census_6733_test.go
+++ b/pkg/config/url_field_redaction_census_6733_test.go
@@ -1,0 +1,313 @@
+package config
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// #6733: the config redaction pass is keyed on field NAMES that look secret.
+// Several fields are sensitive by CONTENT instead — they are URLs, hostnames
+// and endpoints, named for what they ARE rather than for the credential they
+// may carry — so no amount of adding names to the keyed list generalises. The
+// NEXT URL-shaped field will leak the same way.
+//
+// This is the durable half of that fix. It enumerates every URL-shaped field
+// reachable from a *Config by reflection, plants a credential-bearing URL in
+// each one INDIVIDUALLY, marshals, and asserts the secret does not survive.
+// A new field named like a URL is therefore a failing test rather than a
+// silent leak on the authenticated REST GET.
+//
+// It asserts on BEHAVIOUR (does the secret appear in the JSON), never on the
+// presence of a MarshalJSON method — a method can exist and not cover the
+// field, and a field can be covered by a parent's marshaller.
+
+// urlShapedFieldNames are the field-name patterns that denote a value which is
+// a URL by contract. Matched case-insensitively as substrings.
+//
+// Deliberately a NAME heuristic used to build the POPULATION, not to decide the
+// verdict: the verdict is always "did the planted secret survive marshalling".
+//
+// It is narrow on purpose. A first, broader version also matched "server",
+// "hostname", "target" and "path", and flagged fifteen fields that hold an IP
+// address, an FQDN or a policy NAME — System.HostName, System.NameServers,
+// System.NTPServers, SNMP TrapGroups.Targets, DHCPRelay.Servers,
+// ClassOfService Schedulers.EqualFlowTargetPolicy and the IPsec
+// DynamicHostname among them. None of those can carry a credential, so every
+// one would have been a census row asserting a defect that does not exist, and
+// the gate would have warned on correct configuration. A coverage predicate
+// that counts inputs the subject never depended on is worse than the existence
+// check it replaced.
+var urlShapedFieldNames = []string{
+	"url", "uri", "endpoint", "site", "template",
+}
+
+// urlBearingByContract are fields whose NAME does not say "URL" but whose
+// documented value is one. They are named individually because the whole point
+// of #6733 is that a name-keyed rule cannot find them — so the population has
+// to be told, and each entry is a claim backed by the field's own contract:
+//
+//   - FeedServer.Hostname — the compiler joins it with a feed Path to build the
+//     fetch URL, so it accepts a full URL including userinfo.
+//   - FeedEntry.Path — the other half of that join; accepts a query string.
+//   - RPMTest.Target — a URL for the http-get probe type.
+//
+// Adding a row here is how a reviewer extends the gate to a newly-discovered
+// URL-bearing field that is not named like one.
+var urlBearingByContract = map[string]bool{
+	"Config.Security.DynamicAddress.FeedServers[k].Hostname":            true,
+	"Config.Security.DynamicAddress.FeedServers[k].FeedEntries[0].Path": true,
+	"Config.Services.RPM.Probes[k].Tests[k].Target":                     true,
+	// `system license autoupdate url` — a fetch endpoint whose value routinely
+	// carries the entitlement token. Named "LicenseAutoUpdate", not "…URL".
+	"Config.System.LicenseAutoUpdate": true,
+}
+
+// redactionCensus6733 records URL-shaped fields that are KNOWN to render their
+// value verbatim, each with the reason it is not a leak. An entry is a claim
+// and owes a justification; the test fails if an entry stops being needed, so
+// the census cannot rot into an allowlist that hides a regression.
+var redactionCensus6733 = map[string]string{}
+
+func urlShaped6733(name, path string) bool {
+	if urlBearingByContract[path] {
+		return true
+	}
+	l := strings.ToLower(name)
+	for _, p := range urlShapedFieldNames {
+		if strings.Contains(l, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// walkURLFields6733 finds every settable string / []string field whose name is
+// URL-shaped, reachable from root, and calls fn with its JSON-ish path and a
+// setter. Pointers and maps are materialised as needed so a nil sub-config does
+// not hide its fields from the census.
+func walkURLFields6733(t *testing.T, root reflect.Value, path string, depth int, fn func(string, func(string))) {
+	if depth > 10 {
+		return
+	}
+	switch root.Kind() {
+	case reflect.Ptr:
+		if root.IsNil() {
+			if !root.CanSet() {
+				return
+			}
+			root.Set(reflect.New(root.Type().Elem()))
+		}
+		walkURLFields6733(t, root.Elem(), path, depth+1, fn)
+	case reflect.Struct:
+		rt := root.Type()
+		for i := 0; i < root.NumField(); i++ {
+			f := rt.Field(i)
+			if f.PkgPath != "" { // unexported
+				continue
+			}
+			fv := root.Field(i)
+			sub := path + "." + f.Name
+			switch {
+			case fv.Kind() == reflect.String && urlShaped6733(f.Name, sub):
+				if !fv.CanSet() {
+					continue
+				}
+				fn(sub, func(s string) { fv.SetString(s) })
+			case fv.Kind() == reflect.Slice && fv.Type().Elem().Kind() == reflect.String && urlShaped6733(f.Name, sub+"[]"):
+				if !fv.CanSet() {
+					continue
+				}
+				fn(sub+"[]", func(s string) { fv.Set(reflect.ValueOf([]string{s})) })
+			default:
+				walkURLFields6733(t, fv, sub, depth+1, fn)
+			}
+		}
+	case reflect.Slice:
+		if root.Type().Elem().Kind() == reflect.Struct || root.Type().Elem().Kind() == reflect.Ptr {
+			if root.Len() == 0 && root.CanSet() {
+				root.Set(reflect.MakeSlice(root.Type(), 1, 1))
+			}
+			if root.Len() > 0 {
+				walkURLFields6733(t, root.Index(0), path+"[0]", depth+1, fn)
+			}
+		}
+	case reflect.Map:
+		et := root.Type().Elem()
+		if et.Kind() != reflect.Ptr && et.Kind() != reflect.Struct {
+			return
+		}
+		if root.IsNil() && root.CanSet() {
+			root.Set(reflect.MakeMap(root.Type()))
+		}
+		if !root.CanSet() && root.IsNil() {
+			return
+		}
+		// A map value is not addressable: build one, walk it, store it back.
+		ev := reflect.New(et)
+		if et.Kind() == reflect.Ptr {
+			ev.Elem().Set(reflect.New(et.Elem()))
+		}
+		walkURLFields6733(t, ev.Elem(), path+"[k]", depth+1, fn)
+		key := reflect.ValueOf("k")
+		if root.Type().Key().Kind() == reflect.String {
+			root.SetMapIndex(key, ev.Elem())
+		}
+	}
+}
+
+func TestURLShapedFieldsAreRedactedOnMarshal6733(t *testing.T) {
+	const secret = "CENSUSLEAKTOKEN"
+	planted := "https://user:" + secret + "@example.test/p?token=" + secret
+
+	// Pass 1: enumerate the population against a throwaway config.
+	var fields []string
+	{
+		probe := &Config{}
+		walkURLFields6733(t, reflect.ValueOf(probe).Elem(), "Config", 0, func(p string, _ func(string)) {
+			fields = append(fields, p)
+		})
+	}
+	if len(fields) < 8 {
+		t.Fatalf("census enumerated only %d URL-shaped fields — the walker is broken and a green "+
+			"run would prove nothing (a gate that silently stops sweeping is worse than no gate)", len(fields))
+	}
+	t.Logf("census: %d URL-shaped fields enumerated", len(fields))
+
+	// Pass 2: plant the secret in ONE field at a time so a leak names its own field.
+	var leaked []string
+	for _, want := range fields {
+		cfg := &Config{}
+		walkURLFields6733(t, reflect.ValueOf(cfg).Elem(), "Config", 0, func(p string, set func(string)) {
+			if p == want {
+				set(planted)
+			}
+		})
+		b, err := json.Marshal(cfg)
+		if err != nil {
+			t.Fatalf("%s: marshal: %v", want, err)
+		}
+		if strings.Contains(string(b), secret) {
+			leaked = append(leaked, want)
+		}
+	}
+
+	for _, f := range leaked {
+		if _, known := redactionCensus6733[f]; !known {
+			t.Errorf("URL-shaped field %s renders an embedded credential VERBATIM through "+
+				"json.Marshal, which is what the authenticated REST config GET returns "+
+				"(GET /api/v1/config). Redact it in the owning type's MarshalJSON via "+
+				"RedactURL — which leaves a credential-free URL, bare hostname or path "+
+				"untouched — or add it to redactionCensus6733 with the reason it cannot "+
+				"carry a credential (#6733)", f)
+		}
+	}
+	for f, why := range redactionCensus6733 {
+		found := false
+		for _, l := range leaked {
+			if l == f {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("redactionCensus6733 lists %s (%q) as a known-verbatim field, but it no "+
+				"longer renders the credential — remove the entry. A census that keeps "+
+				"stale rows degrades into an allowlist that hides the next regression", f, why)
+		}
+	}
+}
+
+// TestMarshalDoesNotMutateTheLiveConfig6733 pins the aliasing property the
+// redacting marshallers depend on.
+//
+// These marshallers run on an `alias` COPY of the struct, but a copy is shallow:
+// a []string field's backing array is shared with the live *Config. Redacting
+// the slice in place would therefore rewrite the RUNNING configuration as a side
+// effect of serving a read-only GET — the archive-site list would become
+// "<redacted>@host" and the next archival transfer would use it.
+//
+// Without this test the copy is only asserted in a comment, and a comment cannot
+// fail: swapping redactURLSlice to redact in place leaves every other test in
+// this file green, because they all inspect the JSON rather than the config
+// afterwards.
+func TestMarshalDoesNotMutateTheLiveConfig6733(t *testing.T) {
+	const site = "scp://user:PW@backup.example.test:/var/archive"
+	cfg := &Config{}
+	cfg.System.Archival = &ArchivalConfig{
+		ArchiveSites:             []string{site},
+		ArchiveSitesWithPassword: []string{site},
+	}
+
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "PW@") {
+		t.Fatalf("premise broken: the credential was not redacted in the JSON at all")
+	}
+
+	// Marshalling is a READ. The live config must be byte-identical afterwards.
+	if got := cfg.System.Archival.ArchiveSites[0]; got != site {
+		t.Errorf("marshalling MUTATED the live config: ArchiveSites[0] = %q, want %q — "+
+			"the redaction wrote through the alias into the shared backing array, so a "+
+			"read-only GET has rewritten the archive destination the next transfer will use", got, site)
+	}
+	if got := cfg.System.Archival.ArchiveSitesWithPassword[0]; got != site {
+		t.Errorf("marshalling MUTATED the live config: ArchiveSitesWithPassword[0] = %q, want %q",
+			got, site)
+	}
+
+	// And a second marshal must still redact — an in-place implementation would
+	// "pass" a repeat check by having already destroyed the value.
+	b2, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("second marshal: %v", err)
+	}
+	if string(b) != string(b2) {
+		t.Errorf("marshal is not idempotent: the first call changed what the second sees")
+	}
+}
+
+// TestRedactionSurvivesValueMarshalling6733 pins the receiver shape.
+//
+// Config holds `System SystemConfig` and `Services ServicesConfig` BY VALUE.
+// encoding/json promotes to a pointer-receiver MarshalJSON only when the value
+// is addressable — true for a field reached through a *Config, false when a
+// Config is marshalled by value. So a pointer receiver on SystemConfig redacts
+// when someone writes json.Marshal(cfg) and silently does NOTHING when someone
+// writes json.Marshal(*cfg), on the same data.
+//
+// That is the worst failure shape available here: the redaction would depend on
+// the CALLER'S SYNTAX, and a test written with whichever form the author
+// happened to use would be green either way. Both forms are asserted.
+func TestRedactionSurvivesValueMarshalling6733(t *testing.T) {
+	const secret = "VALUEFORMTOKEN"
+	u := "https://user:" + secret + "@example.test/x?token=" + secret
+
+	cfg := &Config{}
+	cfg.System.LicenseAutoUpdate = u
+	cfg.Services.RPM = &RPMConfig{Probes: map[string]*RPMProbe{
+		"p": {Tests: map[string]*RPMTest{"t": {Name: "t", ProbeType: "http-get", Target: u}}},
+	}}
+
+	for _, tc := range []struct {
+		name string
+		v    any
+	}{
+		{"pointer: json.Marshal(cfg)", cfg},
+		{"VALUE: json.Marshal(*cfg)", *cfg},
+	} {
+		b, err := json.Marshal(tc.v)
+		if err != nil {
+			t.Fatalf("%s: marshal: %v", tc.name, err)
+		}
+		if strings.Contains(string(b), secret) {
+			t.Errorf("%s leaked the credential — the redacting marshaller is not reached in "+
+				"this form. A pointer receiver on a type held BY VALUE in Config is only "+
+				"promoted when the value is addressable, so the redaction silently depends "+
+				"on how the caller spelled the marshal", tc.name)
+		}
+	}
+}


### PR DESCRIPTION
Closes #6733

The config redaction pass is keyed on field **names** that look secret. Several fields are sensitive by **content** instead — URLs and endpoints named for what they *are* rather than for the credential they may carry — so no name-keyed rule reaches them, and the authenticated REST config GET returned them verbatim.

## Measured before changing anything

Planted `https://user:SECRET@host/x?token=SECRET` in each field from the issue's table and marshalled:

| field | before |
|---|---|
| `System.LicenseAutoUpdate` | **LEAKS** |
| `Archival.ArchiveSites[]` | **LEAKS** |
| `Archival.ArchiveSitesWithPassword[]` | **LEAKS** |
| `FeedServer.Hostname` | **LEAKS** |
| `FeedEntry.Path` | **LEAKS** |
| `FeedServer.URL` | already redacted |
| `DDNSProvider.Server` | already redacted |

Two of the issue's rows were already covered, so the fix is the remainder plus the mechanism.

## RedactURL was checked for OVER-redaction first

A gate that mangles ordinary values is worse than the leak. Measured: `example.test`, `feeds.example.test:8443`, `/feeds/list.txt`, `feeds/list.txt`, `192.0.2.10`, `2001:db8::1`, `https://updates.example.test/x` all pass through **unchanged**. Only credential-bearing forms are rewritten. So no real configuration renders differently.

## Two receivers are values on purpose

`Config` holds `System SystemConfig` and `Services ServicesConfig` **by value**. `encoding/json` promotes to a pointer-receiver `MarshalJSON` only when the value is addressable — true through a `*Config`, false for `json.Marshal(*cfg)`. A pointer receiver would therefore redact depending on **how the caller spelled the marshal**, and a test written with either form would be green.

`TestRedactionSurvivesValueMarshalling6733` asserts both forms. Cell R3 (value → pointer receiver) reds it.

## The archive-site helper returns a COPY

These marshallers run on an `alias` copy, but a copy is shallow: a `[]string`'s backing array is shared with the live `*Config`. Redacting in place would rewrite the **running configuration** as a side effect of serving a read-only GET — the archive destination the next transfer uses. `TestMarshalDoesNotMutateTheLiveConfig6733` pins it.

## The durable half: a reflective census

The issue is right that this is structural, not a list of misses. The census enumerates every URL-shaped field reachable from a `*Config`, plants a credential in **one field at a time** so a leak names its own field, and asserts the secret does not survive marshalling. A new URL-shaped field is therefore a failing test rather than a silent leak.

It asserts on **behaviour**, never on the presence of a `MarshalJSON` method — a method can exist and not cover the field, and a field can be covered by its parent's marshaller.

**The name predicate is deliberately narrow, and that was a correction.** A first version also matched `server`, `hostname`, `target`, `path` and flagged fifteen fields that hold an IP, an FQDN or a policy *name* — `System.HostName`, `NameServers`, `NTPServers`, SNMP trap `Targets`, `DHCPRelay.Servers`, `Schedulers.EqualFlowTargetPolicy`, IPsec `DynamicHostname`. None can carry a credential, so each would have been a census row asserting a defect that does not exist, and the gate would have warned on correct configuration. Three fields whose names do not say "URL" but whose contract is one (`FeedServer.Hostname`, `FeedEntry.Path`, `RPMTest.Target`, plus `LicenseAutoUpdate`) are named individually — the only way a name-keyed instrument can find them.

**The census is EMPTY.** `WgPeerConfig.Endpoint` is redacted rather than excused: it costs nothing (a `host:port` is unchanged by `RedactURL`) and avoids a justification nobody re-checks.

## Mutation matrix

Fix committed first, so the applied-check and restore are both well defined. Full `pkg/config` suite per cell, no `-run` filter, rc from a file, control green first.

| # | mutation | rc | fired |
|---|---|---|---|
| R1 | revert the Archival redaction | 1 | census gate |
| R2 | **TIGHTEN**: redact the slice in place instead of copying | 0 → 1 | green until `TestMarshalDoesNotMutateTheLiveConfig6733` existed; then localises to it |
| R3 | value receiver → pointer receiver on `SystemConfig` | 0 → 1 | green until `TestRedactionSurvivesValueMarshalling6733` existed; then localises to it |

**R2 and R3 were both GREEN on the first pass**, and that is the useful part: I had asserted "copying matters" and "the receiver shape matters" in comments, and a comment cannot fail. Each mutation showed the claim was unbound, and each got a test that reds it. Two of the three tests in this PR exist because a mutation cell caught my own prose.

Also worth noting the census caught its own regression: after narrowing the name predicate it enumerated only 4 fields, and the "a gate that silently stops sweeping is worse than no gate" floor failed the test rather than passing with a shrunken population. The cause was a depth limit truncating nested paths.

## Validation

`go build`, `go vet`, `gofmt` clean; `go test -count=1 ./...` green repo-wide. Census enumerates 10 fields, zero allowlist entries.

No cluster/VRRP/session-sync/failover code; no `userspace-dp` binary or shim `.o` moved. Go only.

## Not in scope

The issue's two raw-AST leaks (`system syslog file … archive archive-sites <url>`, and the inline password under `system archival configuration archive-sites … password`) go through `ast_redact.go`, a different pass on the raw tree rather than the typed config. Stating that explicitly rather than implying this closes them — filed as a successor if you want them driven separately.
