### PR TITLE
dataplane: stop deciding secure-tunnel-ness by a two-letter prefix (#6729, #6730)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103777,3 +103777,12 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: `pkg/cluster/heartbeat_epoch.go`, `pkg/cluster/heartbeat.go`,
   `pkg/cluster/manager.go`,
   `pkg/cluster/heartbeat_epoch_persist_retry_6724_test.go` (new)
+
+## 2026-08-22 — #6729 + #6730 st-prefix predicate
+- **Action**: Replaced two raw `strings.HasPrefix(name, "st")` tests in
+  `compiler_iface.go` with the bounded predicate / shared resolver:
+  `resolveInterfaceRef` now reads the authored bind-interface via
+  `Config.SecureTunnelUnitNetdev`, and `buildInterfaceNetworkdModels` gates on
+  `config.IsSecureTunnelIfName`.
+- **File(s)**: `pkg/dataplane/compiler_iface.go`,
+  `pkg/dataplane/compiler_iface_st_prefix_6729_6730_test.go` (new)

--- a/pkg/dataplane/compiler_iface.go
+++ b/pkg/dataplane/compiler_iface.go
@@ -70,10 +70,47 @@ func resolveInterfaceRef(ref string, cfg *config.Config) (physName string, confi
 		physBase = phys
 	}
 
-	if strings.HasPrefix(configName, "st") && len(parts) == 2 {
-		physName = config.LinuxIfName(ref)
-		unitNum, _ = strconv.Atoi(parts[1])
-		return
+	// Secure-tunnel units resolve through the SHARED rule, not a third
+	// hand-copied instance of it (#6729).
+	//
+	// TWO DEFECTS LIVED IN THE `strings.HasPrefix(configName, "st")` TEST THIS
+	// REPLACES, and they are independent:
+	//
+	//  1. It RECONSTRUCTED the device name from the unit REF. The reconciler
+	//     creates the xfrmi under the AUTHORED bind-interface string verbatim
+	//     (pkg/routing/xfrm.go), and a bare `bind-interface st0` and an
+	//     explicit `bind-interface st0.0` derive the same if_id under
+	//     DIFFERENT device names — while the unit ref is `st0.0` in both
+	//     cases. So the device name is not a function of the ref and has to be
+	//     read back from the config. Under the bare spelling this returned
+	//     `st0.0`, `cachedInterfaceByName` failed, and mapZoneInterface logged
+	//     "interface not found, skipping": the tunnel was dropped from the
+	//     zone programming and from the SNAT egress-address walk.
+	//  2. `HasPrefix("st")` is not the secure-tunnel predicate. It also
+	//     matched an ordinary NIC whose name merely starts with those two
+	//     letters — `start0.0` resolved to `start0.0` instead of the base
+	//     netdev — which is the same raw-prefix mistake #6730 fixes in
+	//     buildInterfaceNetworkdModels below.
+	//
+	// Config.SecureTunnelUnitNetdev is the single resolver behind the rule
+	// (#6691, xfrmi.go); it declines for a name the xfrmi constructor would
+	// reject, so an ordinary interface falls through to the resolution below.
+	// The IsSecureTunnelIfName arm mirrors ResolveKernelIfName's own fallback:
+	// an in-range st<N> unit that no VPN binds keeps the verbatim ref, which
+	// is what this returned before. (An in-range st<N> PHYSICAL interface is a
+	// separate, deliberate question — #6737 — and is deliberately unchanged
+	// here.)
+	if len(parts) == 2 {
+		if dev, ok := cfg.SecureTunnelUnitNetdev(ref); ok {
+			physName = config.LinuxIfName(dev)
+			unitNum, _ = strconv.Atoi(parts[1])
+			return
+		}
+		if config.IsSecureTunnelIfName(configName) {
+			physName = config.LinuxIfName(ref)
+			unitNum, _ = strconv.Atoi(parts[1])
+			return
+		}
 	}
 
 	// Resolve fabric interface to local physical member for BPF attachment.
@@ -908,7 +945,20 @@ func buildInterfaceNetworkdModels(cfg *config.Config, result *CompileResult, see
 		if ifCfg == nil {
 			continue
 		}
-		if strings.HasPrefix(ifName, "st") {
+		// #6730: the SECURE-TUNNEL predicate, not a raw two-letter prefix.
+		// This branch ends in an unconditional `continue`, so every name it
+		// claims is skipped by the physical-interface handling below — and
+		// `HasPrefix(ifName, "st")` claimed `start0`, `stx` and `st65536` too.
+		// For those, XFRMIfNameAndID returns ("", 0) for every unit, so each
+		// unit `continue`s and the trailing `continue` then drops the whole
+		// interface: no addresses, no MTU, no DHCP, no networkd model at all.
+		// Nothing downstream re-adds it — stripUnmanagedInterfaces runs
+		// against this same `seen` set, so the NIC is brought DOWN.
+		//
+		// IsSecureTunnelIfName is the bounded predicate the xfrmi constructor
+		// itself uses, so exactly the names that can become an xfrmi take this
+		// branch and everything else reaches the ordinary handling.
+		if config.IsSecureTunnelIfName(ifName) {
 			mtu := ifCfg.MTU
 			for unitNum, unit := range ifCfg.Units {
 				unitName, _ := config.XFRMIfNameAndID(fmt.Sprintf("%s.%d", ifName, unitNum))

--- a/pkg/dataplane/compiler_iface_st_prefix_6729_6730_test.go
+++ b/pkg/dataplane/compiler_iface_st_prefix_6729_6730_test.go
@@ -1,0 +1,207 @@
+package dataplane
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6729 / #6730: `pkg/dataplane/compiler_iface.go` carried TWO raw
+// `strings.HasPrefix(name, "st")` tests and treated both as "this is a secure
+// tunnel". They are one family and they are fixed together, but the defects
+// they caused are different:
+//
+//   - resolveInterfaceRef ALSO reconstructed the xfrmi device name from the
+//     unit REF. The reconciler creates the device under the AUTHORED
+//     bind-interface string verbatim (pkg/routing/xfrm.go), so a bare
+//     `bind-interface st0` yields a netdev named `st0` while the unit ref is
+//     `st0.0` — and the resolver answered `st0.0`, a device that does not
+//     exist. mapZoneInterface then logs "interface not found, skipping": the
+//     tunnel is dropped from zone programming and from the SNAT
+//     egress-address walk.
+//   - buildInterfaceNetworkdModels ends its `st` branch in an unconditional
+//     `continue`, so a NIC merely named `start0` got no networkd model at all
+//     — no addresses, no MTU, no DHCP — and stripUnmanagedInterfaces then
+//     brings it DOWN.
+//
+// Both now use the bounded predicate the xfrmi constructor itself uses.
+
+// stCfg6729 builds a config with one interface and, optionally, one IPsec VPN
+// binding the given string. Only the fields the two resolvers read are set.
+func stCfg6729(ifName string, units []int, bindInterface string) *config.Config {
+	unitMap := map[int]*config.InterfaceUnit{}
+	for _, u := range units {
+		unitMap[u] = &config.InterfaceUnit{Addresses: []string{"10.5.5.1/30"}}
+	}
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				ifName: {Name: ifName, Units: unitMap},
+			},
+		},
+	}
+	if bindInterface != "" {
+		cfg.Security.IPsec.VPNs = map[string]*config.IPsecVPN{
+			"v": {Name: "v", BindInterface: bindInterface},
+		}
+	}
+	return cfg
+}
+
+// TestResolveInterfaceRefReadsTheAuthoredBindInterface_6729 is the #6729
+// fail-on-revert: under the BARE spelling the resolver must answer the device
+// the reconciler actually created.
+//
+// The two spellings are the whole point, and they are asserted TOGETHER: `st0`
+// and `st0.0` derive the same if_id but create DIFFERENT device names, while
+// the unit ref is `st0.0` either way. A test that only checked the explicit
+// spelling would pass against the reconstruct-from-ref bug, because for that
+// spelling the reconstruction happens to be right.
+func TestResolveInterfaceRefReadsTheAuthoredBindInterface_6729(t *testing.T) {
+	cases := []struct {
+		name          string
+		bindInterface string
+		wantPhys      string
+	}{
+		{
+			// The reported shape. The netdev is `st0`; reconstructing from
+			// the ref gives `st0.0`, which does not exist.
+			name: "bare bind-interface", bindInterface: "st0", wantPhys: "st0",
+		},
+		{
+			// The spelling the old code got right by coincidence — kept so
+			// the fix is shown not to have simply inverted the answer.
+			name: "explicit unit bind-interface", bindInterface: "st0.0", wantPhys: "st0.0",
+		},
+		{
+			// No VPN binds it: there is no xfrmi, and the verbatim ref is
+			// what this returned before #6729. Unchanged on purpose.
+			name: "no VPN binds the ref", bindInterface: "", wantPhys: "st0.0",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := stCfg6729("st0", []int{0}, tc.bindInterface)
+			phys, cfgName, unitNum, _ := resolveInterfaceRef("st0.0", cfg)
+			if phys != tc.wantPhys {
+				t.Fatalf("physName = %q, want %q — the reconciler creates the xfrmi under the "+
+					"AUTHORED bind-interface string, so a name reconstructed from the ref "+
+					"resolves a device that does not exist and the tunnel is dropped from "+
+					"zone programming (#6729)", phys, tc.wantPhys)
+			}
+			if cfgName != "st0" || unitNum != 0 {
+				t.Fatalf("cfgName/unitNum = %q/%d, want st0/0", cfgName, unitNum)
+			}
+			// Corroboration: the config-reading resolver that already had this
+			// right is the one this now agrees with. Asserting the AGREEMENT
+			// rather than only the literal is what keeps the two from drifting
+			// apart again — they answered differently for exactly one spelling.
+			if got := cfg.ResolveKernelIfName("st0.0"); got != phys {
+				t.Fatalf("resolveInterfaceRef = %q but Config.ResolveKernelIfName = %q: the "+
+					"dataplane resolver and the config resolver disagree about the same ref",
+					phys, got)
+			}
+		})
+	}
+}
+
+// TestResolveInterfaceRefDoesNotClaimAnStPrefixedNIC_6729 is the second defect
+// at the same site: `HasPrefix("st")` is not the secure-tunnel predicate.
+//
+// `start0` is a legal interface name — names are wildcard-authorable and there
+// is no reserved `st` namespace — and its unit must resolve to the ordinary
+// base netdev, not to the verbatim ref.
+func TestResolveInterfaceRefDoesNotClaimAnStPrefixedNIC_6729(t *testing.T) {
+	for _, ifName := range []string{"start0", "stx", "st65536"} {
+		t.Run(ifName, func(t *testing.T) {
+			cfg := stCfg6729(ifName, []int{0}, "")
+			phys, _, _, _ := resolveInterfaceRef(ifName+".0", cfg)
+			if phys != ifName {
+				t.Fatalf("physName = %q for %q.0, want the base netdev %q — a raw two-letter "+
+					"prefix claimed an ordinary NIC as a secure tunnel (#6729/#6730)",
+					phys, ifName, ifName)
+			}
+		})
+	}
+}
+
+// TestNetworkdModelsCoverAnStPrefixedNIC_6730 is the #6730 fail-on-revert.
+//
+// The `st` branch in buildInterfaceNetworkdModels ends in an unconditional
+// `continue`, so any name it claims never reaches the physical-interface
+// handling. For `start0` every unit also failed XFRMIfNameAndID, so the
+// interface produced NO model at all and stripUnmanagedInterfaces — running
+// against this same `seen` set — brings it down.
+//
+// FAIL-ON-REVERT: restore `strings.HasPrefix(ifName, "st")` and `start0`
+// vanishes from ManagedInterfaces entirely.
+func TestNetworkdModelsCoverAnStPrefixedNIC_6730(t *testing.T) {
+	for _, ifName := range []string{"start0", "stx", "st65536"} {
+		t.Run(ifName, func(t *testing.T) {
+			cfg := stCfg6729(ifName, []int{0}, "")
+			// Seed the interface cache: the physical path skips a name with
+			// no netdev (`if physIface == nil { continue }`), so without this
+			// the test would observe THIS HOST rather than the fix, and would
+			// red identically before and after it.
+			result := &CompileResult{ifCache: map[string]*net.Interface{
+				config.LinuxIfName(ifName): {
+					Index: 99,
+					Name:  config.LinuxIfName(ifName),
+					// A MAC is required, not decoration: the physical path
+					// does `if mac == "" { continue }`, so a MAC-less stub
+					// would skip the append for a reason that has nothing to
+					// do with this fix.
+					HardwareAddr: net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x01},
+				},
+			}}
+			buildInterfaceNetworkdModels(cfg, result, map[string]bool{})
+
+			found := false
+			for _, m := range result.ManagedInterfaces {
+				if m.Name == ifName || m.Name == config.LinuxIfName(ifName) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				names := make([]string, 0, len(result.ManagedInterfaces))
+				for _, m := range result.ManagedInterfaces {
+					names = append(names, m.Name)
+				}
+				t.Fatalf("%q produced no networkd model (models: %v) — it is silently "+
+					"unconfigured (no addresses, no MTU, no DHCP) and "+
+					"stripUnmanagedInterfaces then brings it DOWN (#6730)", ifName, names)
+			}
+		})
+	}
+}
+
+// TestNetworkdModelsStillSkipARealSecureTunnel_6730 is the TIGHTENING control.
+//
+// The fix narrows which names take the tunnel branch, so it owes a proof that
+// it did not narrow it to nothing: a genuine in-range `st<N>` must still take
+// that branch and must NOT be emitted as an ordinary physical interface — the
+// xfrmi is created by pkg/routing, not by networkd.
+func TestNetworkdModelsStillSkipARealSecureTunnel_6730(t *testing.T) {
+	cfg := stCfg6729("st0", []int{0}, "st0")
+	// Seeded for the same reason, and here it is what gives the control its
+	// teeth: with the netdev present, a predicate that wrongly let `st0` reach
+	// the physical path WOULD emit a model, so this can actually fail.
+	result := &CompileResult{ifCache: map[string]*net.Interface{
+		"st0": {
+			Index:        98,
+			Name:         "st0",
+			HardwareAddr: net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x02},
+		},
+	}}
+	buildInterfaceNetworkdModels(cfg, result, map[string]bool{})
+
+	for _, m := range result.ManagedInterfaces {
+		if m.Name == "st0" {
+			t.Fatalf("a real secure tunnel reached the physical-interface handling and was "+
+				"emitted as a networkd model (%q) — the xfrmi is created by pkg/routing, "+
+				"and the narrowed predicate must not widen this branch's escape hatch", m.Name)
+		}
+	}
+}


### PR DESCRIPTION
Closes #6729
Closes #6730

**One fix, two issues** — that is the finding, not a convenience. Both are the same mistake at two sites in one file, and the shared-mechanism question was checked before treating them as two jobs.

Does not touch cluster/session-sync/failover code and moves no binary or shim object.

## The shared mechanism

`pkg/dataplane/compiler_iface.go` used a raw `strings.HasPrefix(name, "st")` as the secure-tunnel predicate, twice. The project already has the bounded predicate the xfrmi constructor itself uses (`config.IsSecureTunnelIfName`) and a single resolver for the name rule (`Config.SecureTunnelUnitNetdev`, #6691) — which is the same shape #7505 (#6710) just used when it read the shipped `secure_tunnel` flag instead of re-deriving a name grammar, citing #6691 r5 for deleting a local copy. These are two more hand-copied instances that #6691 did not reach.

`resolveInterfaceRef` additionally carried a **second, independent** defect at the same site, which is why #6729 is the larger of the two.

## #6729 — the device name is not a function of the ref

The reconciler creates the xfrmi under the **authored** `bind-interface` string verbatim (`pkg/routing/xfrm.go`). A bare `bind-interface st0` and an explicit `bind-interface st0.0` derive the same if_id under **different device names**, while the unit ref is `st0.0` in both cases — so the name has to be read back from the config.

Under the bare spelling the resolver answered `st0.0`, `cachedInterfaceByName` failed, and `mapZoneInterface` logged *"interface not found, skipping"*: the tunnel was dropped from zone programming **and** from the SNAT egress-address walk.

| ref `st0.0`, `bind-interface st0` | before | after |
|---|---|---|
| `resolveInterfaceRef` | `st0.0` (no such device) | `st0` |
| `Config.ResolveKernelIfName` | `st0` | `st0` |

The fix routes through `Config.SecureTunnelUnitNetdev` — the single resolver behind the rule — with the same `IsSecureTunnelIfName` fallback `ResolveKernelIfName` uses for an in-range ref no VPN binds.

## #6730 — a branch that ends in `continue` claiming names it should not

`buildInterfaceNetworkdModels`'s `st` branch ends in an unconditional `continue`, so **every name it claims is skipped by the physical-interface handling below**. `HasPrefix` claimed `start0`, `stx` and `st65536`; for those `XFRMIfNameAndID` returns `("", 0)` for every unit, so each unit `continue`d and the trailing `continue` dropped the whole interface — no addresses, no MTU, no DHCP, no model at all. `stripUnmanagedInterfaces` runs against the same `seen` set, so the NIC is then brought **DOWN**.

## Why the same substitution closes both halves of #6729

Once the arm uses the bounded predicate, an ordinary NIC named `start0` no longer takes it at all, so `start0.0` resolves to its base netdev rather than to the verbatim ref — the #6730 defect, at the #6729 site. That is the whole argument for one PR.

## Explicitly NOT changed: #6737

An **in-range** `st<N>` physical interface still classifies as a secure tunnel here, exactly as before. That is a separate and deliberately documented question (`userspace-dp/src/server/README.md` states the exclusion keys on the name and that an `st`-named interface without a route-based VPN is not a supported topology), and #6737 is about making that boundary *loud* rather than changing where it sits. This PR preserves today's answer for it precisely.

## Mutation matrix

Every cell applied-verified, `go build ./...` clean first, full `pkg/dataplane` suite per cell, tree restored and re-verified after each.

| cell | mutation | result |
|---|---|---|
| **Y1** | restore the verbatim pre-fix resolver arm | RED both `resolveInterfaceRef` tests |
| **Y2** | restore the verbatim pre-fix networkd predicate | RED the networkd coverage test |
| **Y3** | **HALF fix** — keep the shared resolver, drop the unbound-ref fallback | RED the bind-interface table **and the pre-existing `TestResolveInterfaceRefXFRMUnit`** |
| **Y4** | **OVER-WIDEN** — let the tunnel branch claim every interface | RED the coverage test **and the pre-existing `TestOriginalKernelNameIsCalledFromNetworkdGeneration`** |

Y3 and Y4 are the tighten/widen pair, and both also red a pre-existing test — the change is bounded on both sides by coverage that was already there.

## Tests

`compiler_iface_st_prefix_6729_6730_test.go`: three `bind-interface` spellings asserted **together** (bare, explicit, unbound) — a table checking only the explicit spelling would have passed against the reconstruct-from-ref bug, because for that spelling the reconstruction is right by coincidence — plus agreement with `Config.ResolveKernelIfName`, which already had this right and disagreed with this resolver on exactly one spelling. Then three `st`-prefixed NIC names resolving to their base netdev and producing networkd models, and a tightening control that a real secure tunnel still does **not** reach the physical-interface handling.

The networkd fixtures seed the interface cache **with a MAC**, and that is load-bearing: the physical path skips a name with no netdev (`if physIface == nil`) and again with no MAC (`if mac == ""`). A stub missing either would have failed for a reason that has nothing to do with this fix — the test would have been observing this host. Both were hit while writing it.

`go build`, `go vet`, and the full repo-wide `go test ./... -count=1` are clean.
