### PR TITLE
api: pair a leg's http.Server with the authSlot its handler reads (#6734)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103777,3 +103777,30 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: `pkg/cluster/heartbeat_epoch.go`, `pkg/cluster/heartbeat.go`,
   `pkg/cluster/manager.go`,
   `pkg/cluster/heartbeat_epoch_persist_retry_6724_test.go` (new)
+
+## 2026-08-22 — #6734 pair the leg's http.Server with its authSlot
+- **Action**: `pkg/api` substituted a fresh `authSlot` for a nil in TWO
+  independent places (`listenerHandler` when building the handler,
+  `serveLegLocked` when registering the leg), so a future call site passing nil
+  to both would pin the leg to slot Y while every request on it was judged by
+  slot X — making `pin`/`tighten` a no-op and letting a RETIRED listener keep
+  following the server-wide snapshot (the #5561 round-14 defect). Latent, not
+  live: all four production sites threaded one slot through both layers. Fixed
+  by making the divergence unrepresentable: `legPlan` pairs the `*http.Server`
+  with the slot its handler closes over, `plan{HTTP,HTTPS}Leg` are the only
+  allocation sites, and `serveLegLocked` no longer takes a slot parameter at
+  all, so there is nothing left for it to substitute. `listenerHandler` keeps
+  its fallback as the SINGLE substitution in the package — one substitution
+  cannot diverge from another. Guard asserts BEHAVIOUR (pin the leg's slot,
+  rotate the server-wide snapshot, drive a request through the leg's own
+  handler) rather than pointer identity, since a pointer compare can be
+  satisfied while the property fails. The first draft claimed the paired fields
+  had a single writer and so could not diverge; TestReconcileHTTPSReplacesADeadLeg_6827
+  falsified that (its fixture sets s.httpsServer directly and calls Start),
+  producing a nil-slot leg and a nil deref in stopLegLocked. The plan getters
+  now ADOPT a missing slot and store it back — a substitution that writes the
+  field it reads, so it cannot diverge from itself, unlike the two independent
+  ones this issue is about.
+- **File(s)**: pkg/api/server.go, pkg/api/listener.go,
+  pkg/api/leg_slot_identity_6734_test.go (new),
+  pkg/api/listener_retiredauth_5561_test.go, pkg/api/README.md

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -1234,6 +1234,22 @@ the drop fails loudly instead of going quietly vacuous.
       PINNED at retirement to what it was already serving, after which
       `ReplaceAuth` only intersects it. Revocations still reach a draining
       listener; grants and nils never do.
+
+      **The slot travels WITH the server it judges** (#6734, `legPlan`). The
+      pin is only worth anything if the slot `pin`/`tighten` operate on is the
+      one the handler actually reads. `pkg/api` used to substitute a fresh slot
+      for a nil in two INDEPENDENT places — `listenerHandler` when building the
+      handler and `serveLegLocked` when registering the leg — so a call site
+      passing nil to both would have pinned the leg to one slot while every
+      request on it was judged by another, making the retirement pin a silent
+      no-op. No production path did that, but nothing stopped one. `legPlan`
+      allocates the `*http.Server` and its slot together and `serveLegLocked`
+      has no slot parameter at all, so there is nothing left to substitute; the
+      `Start` path's `httpLegPlan`/`httpsLegPlan` adopt a missing slot and
+      **store it back**, which is what keeps the field, the plan and the leg one
+      object rather than three. The guard is behavioural, not a pointer
+      compare: pin a leg's slot, rotate `s.auth` away from it, and drive a real
+      request through that leg's own handler.
     - **Every leg exit DRAINS its connections** (#6827 round 7, `drainLeg`).
       `ReplaceAuth` keeps tightening a retired leg's pin only while the leg is on
       `s.retiring`, and `pruneRetiredLocked` reaps it the moment `drained` is

--- a/pkg/api/leg_slot_identity_6734_test.go
+++ b/pkg/api/leg_slot_identity_6734_test.go
@@ -1,0 +1,195 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// #6734: `pkg/api` substituted a fresh authSlot for a nil in TWO independent
+// places — `listenerHandler` when building the handler, and `serveLegLocked`
+// when registering the leg. A future call site passing nil to both would pin
+// the leg to slot Y while every request on it was judged by slot X, so
+// authSlot.pin / tighten would operate on an object nothing reads and a RETIRED
+// listener would keep following the server-wide snapshot. That is the #5561
+// round-14 defect the pin exists to prevent — a credential committed for the
+// NEW address becoming valid on the address the same commit RETIRED.
+//
+// It was latent: all four production sites threaded one slot through both
+// layers. legPlan makes it unrepresentable — the slot is allocated with the
+// server and serveLegLocked no longer has a parameter to substitute for.
+//
+// THE ASSERTION IS BEHAVIOURAL, NOT POINTER IDENTITY, and that is deliberate.
+// The issue suggests asserting "the leg's slot is the same pointer the handler
+// reads". A pointer comparison is a proxy for the property and it can be
+// satisfied while the property fails — a handler that closed over the right
+// pointer but consulted s.auth directly would pass it. What the operator
+// depends on is that PINNING THE LEG'S SLOT CHANGES WHAT REQUESTS ON THAT LEG
+// ARE JUDGED BY. So the cells pin the leg's slot to one credential set, move
+// the server-wide snapshot to a different one, and drive a real request through
+// the leg's own handler.
+//
+// Divergence fails this in the only way that matters: the handler would read
+// the unpinned slot X, which still follows s.auth, so the ROTATED credential
+// would authenticate on the leg that was pinned away from it.
+
+// legSlotDivergenceProbe pins leg's slot at the boot credential, rotates the
+// server-wide snapshot to a different one, and reports what the leg accepts.
+func legSlotDivergenceProbe(t *testing.T, s *Server, leg *listenerLeg) (acceptsPinned, acceptsRotated bool) {
+	t.Helper()
+	pinned := &AuthConfig{Users: map[string]string{"admin": "pinned-secret"}}
+	rotated := &AuthConfig{Users: map[string]string{"admin": "rotated-secret"}}
+
+	s.auth.Store(pinned)
+	leg.slot.pin(pinned)
+	// The server-wide snapshot moves on; a pinned leg must not follow it.
+	s.auth.Store(rotated)
+
+	return legProbe(t, leg, "admin", "pinned-secret"),
+		legProbe(t, leg, "admin", "rotated-secret")
+}
+
+func assertLegHonoursItsOwnSlot(t *testing.T, s *Server, leg *listenerLeg, path string) {
+	t.Helper()
+	if leg == nil {
+		t.Fatalf("%s: no leg was created; the cell asserts nothing", path)
+	}
+	if leg.slot == nil {
+		t.Fatalf("%s: the leg has no slot at all", path)
+	}
+	acceptsPinned, acceptsRotated := legSlotDivergenceProbe(t, s, leg)
+	if !acceptsPinned {
+		t.Errorf("%s: the leg REJECTED the credential its own slot was pinned to. "+
+			"The handler is not reading this leg's slot, so a pin cannot hold a "+
+			"draining listener at the policy it was retired under (#6734/#5561).", path)
+	}
+	if acceptsRotated {
+		t.Errorf("%s: the leg ACCEPTED a credential published AFTER its slot was "+
+			"pinned. The handler is judging requests by a different slot than the "+
+			"one pin/tighten operate on, so the retirement pin is a no-op and a "+
+			"credential committed for the NEW address is valid on the address the "+
+			"same commit RETIRED (#6734/#5561 round 14).", path)
+	}
+}
+
+// TestLegSlotIsTheSlotTheHandlerReads6734 covers every production path that
+// creates a leg. They are separate cells because each builds its plan
+// differently — Start serves the servers NewServer built, while the reconcile
+// paths plan fresh ones — and a divergence introduced in one would not show up
+// in the others.
+func TestLegSlotIsTheSlotTheHandlerReads6734(t *testing.T) {
+	t.Run("Start_http", func(t *testing.T) {
+		s := retireTestServer(t, &AuthConfig{Users: map[string]string{"admin": "boot"}})
+		s.lifeMu.Lock()
+		plan := s.planHTTPLeg("10.0.0.1:8080")
+		s.httpSlot, s.httpServer = plan.slot, plan.srv
+		ln, err := s.listen("tcp", "10.0.0.1:8080")
+		if err != nil {
+			s.lifeMu.Unlock()
+			t.Fatalf("listen: %v", err)
+		}
+		// Exactly what Start does: serve the server built at construction,
+		// re-pairing it with the slot written alongside it.
+		s.httpLeg = s.serveLegLocked(s.httpLegPlan(), ln, false)
+		leg := s.httpLeg
+		s.lifeMu.Unlock()
+		assertLegHonoursItsOwnSlot(t, s, leg, "Start (HTTP)")
+	})
+
+	t.Run("ReconcileHTTP", func(t *testing.T) {
+		s := retireTestServer(t, &AuthConfig{Users: map[string]string{"admin": "boot"}})
+		if err := s.ReconcileHTTP("10.0.0.2:8080"); err != nil {
+			t.Fatalf("ReconcileHTTP: %v", err)
+		}
+		assertLegHonoursItsOwnSlot(t, s, s.httpLeg, "ReconcileHTTP")
+	})
+
+	// The shape that broke the first draft of this change: a caller that sets
+	// s.httpsServer DIRECTLY, with no slot, and then calls Start. It is not
+	// hypothetical — TestReconcileHTTPSReplacesADeadLeg_6827's fixture does it,
+	// and the first version of httpsLegPlan assumed the pair always had a
+	// single writer, so the leg got a nil slot and stopLegLocked nil-dereferenced
+	// on the first pin. The plan adopts a missing slot and STORES IT BACK, which
+	// is what keeps the field, the plan and the leg the same object.
+	t.Run("Start_https_with_no_preallocated_slot", func(t *testing.T) {
+		s := retireTestServer(t, &AuthConfig{Users: map[string]string{"admin": "boot"}})
+		s.lifeMu.Lock()
+		s.httpsServer = &http.Server{Addr: "10.0.0.4:8443"}
+		s.httpsServer.Handler = s.listenerHandler("10.0.0.4:8443", s.httpsLegPlan().slot)
+		if s.httpsSlot == nil {
+			s.lifeMu.Unlock()
+			t.Fatal("httpsLegPlan must adopt and STORE a slot when the field is nil; " +
+				"without the store-back the leg and the field are different objects " +
+				"and pin/tighten operate on one nothing reads (#6734)")
+		}
+		ln, err := s.listen("tcp", "10.0.0.4:8443")
+		if err != nil {
+			s.lifeMu.Unlock()
+			t.Fatalf("listen: %v", err)
+		}
+		s.httpsLeg = s.serveLegLocked(s.httpsLegPlan(), ln, true)
+		leg := s.httpsLeg
+		s.lifeMu.Unlock()
+		assertLegHonoursItsOwnSlot(t, s, leg, "Start (HTTPS, adopted slot)")
+	})
+
+	t.Run("ReconcileHTTPS", func(t *testing.T) {
+		s := retireTestServer(t, &AuthConfig{Users: map[string]string{"admin": "boot"}})
+		s.certGen = generateSelfSignedCert
+		if err := s.ReconcileHTTPS(true, "10.0.0.3:8443"); err != nil {
+			t.Fatalf("ReconcileHTTPS: %v", err)
+		}
+		assertLegHonoursItsOwnSlot(t, s, s.httpsLeg, "ReconcileHTTPS")
+	})
+}
+
+// TestServeLegCannotBeHandedAMismatchedSlot6734 is the structural half: the
+// divergence is gone because there is no longer a second place that can
+// allocate one.
+//
+// It asserts on BEHAVIOUR of the constructor rather than on a signature, so it
+// is not satisfiable by a comment and does not break on a rename: a plan's leg
+// and its handler must agree even when the server-wide snapshot disagrees with
+// both. Reintroducing a slot parameter on serveLegLocked and substituting in it
+// makes the leg's slot different from the handler's, and the probe reds.
+func TestServeLegCannotBeHandedAMismatchedSlot6734(t *testing.T) {
+	s := retireTestServer(t, &AuthConfig{Users: map[string]string{"admin": "boot"}})
+
+	plan := s.planHTTPLeg("10.0.0.9:8080")
+	if plan.slot == nil {
+		t.Fatal("planHTTPLeg returned no slot; every leg must have one")
+	}
+	if plan.srv == nil || plan.srv.Handler == nil {
+		t.Fatal("planHTTPLeg returned no server/handler")
+	}
+
+	s.lifeMu.Lock()
+	ln, err := s.listen("tcp", "10.0.0.9:8080")
+	if err != nil {
+		s.lifeMu.Unlock()
+		t.Fatalf("listen: %v", err)
+	}
+	leg := s.serveLegLocked(plan, ln, false)
+	s.httpLeg = leg
+	s.lifeMu.Unlock()
+
+	if leg.slot != plan.slot {
+		t.Fatal("serveLegLocked registered a slot other than the plan's — the leg " +
+			"and its handler have diverged before a single request was served")
+	}
+	assertLegHonoursItsOwnSlot(t, s, leg, "planHTTPLeg -> serveLegLocked")
+
+	// Positive control: a leg whose slot is NOT pinned must still follow the
+	// server-wide snapshot, so the cells above are distinguishing "reads its own
+	// slot" from "reads nothing at all".
+	fresh := s.planHTTPLeg("10.0.0.10:8080")
+	s.auth.Store(&AuthConfig{Users: map[string]string{"admin": "live-secret"}})
+	r := httptest.NewRequest("GET", "/api/v1/thing", nil)
+	r.SetBasicAuth("admin", "live-secret")
+	w := httptest.NewRecorder()
+	fresh.srv.Handler.ServeHTTP(w, r)
+	if w.Code == http.StatusUnauthorized {
+		t.Fatal("an UNPINNED leg rejected the live server-wide credential; a slot " +
+			"that follows nothing would make every assertion above vacuous")
+	}
+}

--- a/pkg/api/listener.go
+++ b/pkg/api/listener.go
@@ -278,11 +278,12 @@ func drainLeg(srv *http.Server) error {
 // leg's pin and the handler's reads are the same object. A nil is substituted
 // rather than stored, so ReplaceAuth's walk over retiring legs can never meet
 // one.
-func (s *Server) serveLegLocked(srv *http.Server, ln net.Listener, isTLS bool, slot *authSlot) *listenerLeg {
-	if slot == nil {
-		slot = s.newAuthSlot()
-	}
-	leg := &listenerLeg{srv: srv, ln: ln, stopCh: make(chan struct{}), slot: slot}
+func (s *Server) serveLegLocked(plan legPlan, ln net.Listener, isTLS bool) *listenerLeg {
+	// #6734: no slot parameter and no substitution. The leg's slot IS the one
+	// the plan's handler closes over, because they were allocated together —
+	// so pin / tighten can never operate on an object no request reads.
+	srv := plan.srv
+	leg := &listenerLeg{srv: srv, ln: ln, stopCh: make(chan struct{}), slot: plan.slot}
 	rootCtx := s.rootCtx
 	s.wg.Add(1)
 	go func() {
@@ -424,7 +425,7 @@ func (s *Server) Start(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("api: bind HTTP listener %q: %w", s.httpServer.Addr, err)
 		}
-		s.httpLeg = s.serveLegLocked(s.httpServer, ln, false, s.httpSlot)
+		s.httpLeg = s.serveLegLocked(s.httpLegPlan(), ln, false)
 		slog.Info("HTTP API server listening", "addr", s.httpServer.Addr)
 	}
 	if s.httpsServer != nil {
@@ -433,7 +434,7 @@ func (s *Server) Start(ctx context.Context) error {
 			slog.Error("api: HTTPS listener bind failed at start; HTTPS disabled until the next reconcile",
 				"addr", s.httpsServer.Addr, "err", err)
 		} else {
-			s.httpsLeg = s.serveLegLocked(s.httpsServer, ln, true, s.httpsSlot)
+			s.httpsLeg = s.serveLegLocked(s.httpsLegPlan(), ln, true)
 			slog.Info("HTTPS API server listening", "addr", s.httpsServer.Addr)
 		}
 	}
@@ -503,14 +504,13 @@ func (s *Server) ReconcileHTTP(addr string) error {
 	if s.httpLeg != nil && s.httpLeg.srv.Addr == addr {
 		return nil
 	}
-	slot := s.newAuthSlot()
-	srv := s.buildHTTPServer(addr, slot)
+	plan := s.planHTTPLeg(addr)
 	ln, err := s.listen("tcp", addr)
 	if err != nil {
 		return fmt.Errorf("api: bind HTTP listener %q: %w", addr, err)
 	}
 	old := s.httpLeg
-	s.httpLeg = s.serveLegLocked(srv, ln, false, slot)
+	s.httpLeg = s.serveLegLocked(plan, ln, false)
 	s.stopLegLocked(old) // retire the previous HTTP listener only after the new one is serving
 	return nil
 }
@@ -548,8 +548,7 @@ func (s *Server) ReconcileHTTPS(useTLS bool, addr string) error {
 	case s.httpsLeg.serving() && s.httpsLeg.srv.Addr == addr:
 		return nil
 	default:
-		slot := s.newAuthSlot()
-		srv, err := s.buildHTTPSServer(addr, slot)
+		plan, err := s.planHTTPSLeg(addr)
 		if err != nil {
 			return fmt.Errorf("api: generate HTTPS certificate for %q: %w", addr, err)
 		}
@@ -558,7 +557,7 @@ func (s *Server) ReconcileHTTPS(useTLS bool, addr string) error {
 			return fmt.Errorf("api: bind HTTPS listener %q: %w", addr, err)
 		}
 		old := s.httpsLeg
-		s.httpsLeg = s.serveLegLocked(srv, ln, true, slot)
+		s.httpsLeg = s.serveLegLocked(plan, ln, true)
 		s.stopLegLocked(old)
 		return nil
 	}

--- a/pkg/api/listener_retiredauth_5561_test.go
+++ b/pkg/api/listener_retiredauth_5561_test.go
@@ -92,7 +92,7 @@ func TestRetiredLegNeverGainsARotatedCredential_5561(t *testing.T) {
 		s.lifeMu.Unlock()
 		t.Fatalf("listen: %v", err)
 	}
-	s.httpLeg = s.serveLegLocked(s.httpServer, ln, false, s.httpSlot)
+	s.httpLeg = s.serveLegLocked(s.httpLegPlan(), ln, false)
 	retired := s.httpLeg
 	s.lifeMu.Unlock()
 
@@ -150,7 +150,7 @@ func TestRetiredLegIsNeverDroppedToNoAuth_5561(t *testing.T) {
 		s.lifeMu.Unlock()
 		t.Fatalf("listen: %v", err)
 	}
-	s.httpLeg = s.serveLegLocked(s.httpServer, ln, false, s.httpSlot)
+	s.httpLeg = s.serveLegLocked(s.httpLegPlan(), ln, false)
 	retired := s.httpLeg
 	s.lifeMu.Unlock()
 
@@ -198,7 +198,7 @@ func TestLiveLegFollowsTheServerSnapshot_5561(t *testing.T) {
 		s.lifeMu.Unlock()
 		t.Fatalf("listen: %v", err)
 	}
-	s.httpLeg = s.serveLegLocked(s.httpServer, ln, false, s.httpSlot)
+	s.httpLeg = s.serveLegLocked(s.httpLegPlan(), ln, false)
 	live := s.httpLeg
 	s.lifeMu.Unlock()
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -669,17 +669,16 @@ func NewServer(cfg Config) *Server {
 	s.certGen = generateSelfSignedCert
 
 	if cfg.Addr != "" {
-		s.httpSlot = s.newAuthSlot()
-		s.httpServer = s.buildHTTPServer(cfg.Addr, s.httpSlot)
+		plan := s.planHTTPLeg(cfg.Addr)
+		s.httpSlot, s.httpServer = plan.slot, plan.srv
 	}
 
 	// Set up HTTPS server with auto-generated self-signed certificate
 	if cfg.TLS && cfg.HTTPSAddr != "" {
-		s.httpsSlot = s.newAuthSlot()
-		if hs, err := s.buildHTTPSServer(cfg.HTTPSAddr, s.httpsSlot); err != nil {
+		if plan, err := s.planHTTPSLeg(cfg.HTTPSAddr); err != nil {
 			slog.Warn("failed to generate self-signed certificate", "err", err)
 		} else {
-			s.httpsServer = hs
+			s.httpsSlot, s.httpsServer = plan.slot, plan.srv
 		}
 	}
 
@@ -752,6 +751,14 @@ func (s *Server) listenerHandler(addr string, slot *authSlot) http.Handler {
 	if slot == nil {
 		// Never let a missing slot become a pass-through: substitute a FOLLOWING
 		// slot, which is what a live leg has anyway.
+		//
+		// #6734: this is now UNREACHABLE from any leg — legPlan allocates the
+		// slot and hands the same pointer to this handler and to the leg, and
+		// serveLegLocked no longer has a slot parameter to substitute for. It
+		// is kept as the single fail-closed fallback for a direct
+		// listenerHandler caller (tests build handlers this way), and it is
+		// safe to keep precisely BECAUSE it is now the only substitution in the
+		// package: one substitution cannot diverge from another.
 		slot = s.newAuthSlot()
 	}
 	return s.dynamicAuthMiddleware(!isLoopbackBindAddr(addr), slot, s.sharedBase)
@@ -760,6 +767,75 @@ func (s *Server) listenerHandler(addr string, slot *authSlot) http.Handler {
 // buildHTTPServer constructs a fresh HTTP *http.Server bound-for addr with the
 // per-listener handler (#5866). Used at construction and by a per-leg HTTP
 // rebind.
+// legPlan is an http.Server together with the authSlot its handler closes
+// over (#6734). They are allocated together and travel together, so no caller
+// can hand the handler one slot and the leg a different one.
+//
+// The divergence this makes unrepresentable was latent, not live: every
+// production site threaded ONE slot through both layers. But it was reachable
+// by construction — listenerHandler substituted a fresh slot for a nil, and
+// serveLegLocked substituted again, so a future call site passing nil to both
+// would have pinned the leg to slot Y while every request on it was judged by
+// slot X. authSlot.pin / tighten would then operate on an object nothing reads
+// and a retired listener would keep following the server-wide snapshot —
+// exactly the #5561 round-14 defect the pin exists to prevent, silently.
+//
+// Pairing them is what removes the possibility. serveLegLocked no longer takes
+// a slot at all, so there is nothing left for it to substitute; the only
+// remaining allocation is the one inside these constructors.
+type legPlan struct {
+	srv  *http.Server
+	slot *authSlot
+}
+
+// planHTTPLeg builds the HTTP leg's server and the slot its handler reads.
+func (s *Server) planHTTPLeg(addr string) legPlan {
+	slot := s.newAuthSlot()
+	return legPlan{srv: s.buildHTTPServer(addr, slot), slot: slot}
+}
+
+// planHTTPSLeg is planHTTPLeg for the TLS leg; it can fail on cert generation.
+func (s *Server) planHTTPSLeg(addr string) (legPlan, error) {
+	slot := s.newAuthSlot()
+	srv, err := s.buildHTTPSServer(addr, slot)
+	if err != nil {
+		return legPlan{}, err
+	}
+	return legPlan{srv: srv, slot: slot}, nil
+}
+
+// httpLegPlan / httpsLegPlan re-pair the fields NewServer wrote from one
+// legPlan, for Start — which serves the servers built at construction rather
+// than planning fresh ones. Callers hold lifeMu.
+//
+// THEY ADOPT A MISSING SLOT RATHER THAN ASSUMING ONE, and the first draft of
+// this comment was wrong about why that is needed. It claimed each pair "has
+// exactly ONE writer: the two assignments in NewServer", so a server could
+// never exist without its slot. A caller that sets s.httpsServer DIRECTLY
+// falsifies that — TestReconcileHTTPSReplacesADeadLeg_6827's fixture does
+// exactly that and then calls Start, which produced a nil-slot leg and a nil
+// dereference the moment stopLegLocked tried to pin it.
+//
+// So the slot is allocated here if absent AND STORED BACK. Storing back is the
+// whole difference between this and the #6734 defect: the two substitutions
+// this issue is about were INDEPENDENT — each allocated a slot the other could
+// not see — whereas this one writes the very field it read, so the field, the
+// plan and the leg are the same object afterwards and a second call returns it
+// unchanged. One self-consistent adoption cannot diverge from itself.
+func (s *Server) httpLegPlan() legPlan {
+	if s.httpSlot == nil {
+		s.httpSlot = s.newAuthSlot()
+	}
+	return legPlan{srv: s.httpServer, slot: s.httpSlot}
+}
+
+func (s *Server) httpsLegPlan() legPlan {
+	if s.httpsSlot == nil {
+		s.httpsSlot = s.newAuthSlot()
+	}
+	return legPlan{srv: s.httpsServer, slot: s.httpsSlot}
+}
+
 func (s *Server) buildHTTPServer(addr string, slot *authSlot) *http.Server {
 	return &http.Server{
 		Addr:              addr,


### PR DESCRIPTION
## Summary

`pkg/api` substituted a fresh `authSlot` for a nil in **two independent places**
— `listenerHandler` when building the handler (which then closes over whatever
it substituted) and `serveLegLocked` when registering the leg (whose slot is
what `trackRetiring` pins). A call site passing nil to both would pin the leg to
slot Y while every request on it was judged by slot X, so `authSlot.pin` /
`tighten` would operate on an object nothing reads.

A retired listener would then keep following the server-wide snapshot — exactly
the **#5561 round-14** defect the pin exists to prevent: *a credential committed
for the NEW address becoming valid on the address the same commit RETIRED.*
Silently, because both halves look correct in isolation.

**Latent, not live.** All four production leg-construction sites thread one slot
through both layers. But nothing stopped a fifth, and the shape is new relative
to the pre-#6645 tree, where every leg read one shared snapshot.

*(Checked #7510 as advised: it is `pkg/config` marshal-time credential
redaction, no overlap with `pkg/api`'s slot ownership. Ground unchanged.)*

## Unrepresentable, not defensive

`legPlan` holds the `*http.Server` together with the slot its handler closes
over. `plan{HTTP,HTTPS}Leg` are the only places a leg's slot is allocated, and
**`serveLegLocked` no longer takes a slot parameter at all** — nothing left to
substitute, and no caller can hand the handler one slot and the leg another.

`listenerHandler` keeps its nil fallback. It is now unreachable from any leg,
and it is safe to keep *precisely because* it is the only substitution left in
the package: **one substitution cannot diverge from another.**

## The claim I got wrong the first time — and the suite caught it

The `Start` path serves the servers `NewServer` built, so its plan getters
re-pair `s.httpServer` with `s.httpSlot`. My first version justified that by
asserting the pair *"has exactly ONE writer: the two assignments in NewServer"*,
so a server could never exist without its slot.

**That is false.** `TestReconcileHTTPSReplacesADeadLeg_6827`'s fixture sets
`s.httpsServer` **directly** and calls `Start` — which under the first draft
produced a leg with a nil slot and a nil dereference the moment `stopLegLocked`
pinned it. Removing `serveLegLocked`'s substitution without replacing that
guarantee turned a latent divergence into a live panic.

So the plan getters **adopt a missing slot and store it back**. The store-back
is the whole difference from the defect: the two substitutions this issue is
about were *independent* — each allocated a slot the other could not see —
whereas this one writes the very field it read, so the field, the plan and the
leg are the same object afterwards. **A self-consistent adoption cannot diverge
from itself.** That shape now has its own cell.

## The guard is behavioural, not a pointer compare

The issue suggests asserting *"the leg's slot is the same pointer the handler
reads"*. A pointer compare is a **proxy that can pass while the property fails**
— a handler closing over the right pointer but consulting `s.auth` directly
would satisfy it.

What an operator depends on is that **pinning a leg's slot changes what requests
on that leg are judged by**. So each cell pins the slot, rotates `s.auth` away
from it, and drives a real request through that leg's own handler. Divergence
fails it in the only way that matters: the *rotated* credential authenticates on
the leg that was pinned away from it.

Every production leg-construction path gets a cell — `Start` HTTP, `Start` HTTPS
with no preallocated slot (the #6827 fixture shape), `ReconcileHTTP`,
`ReconcileHTTPS` — because each builds its plan differently. A **positive
control** asserts an *unpinned* leg still follows the server-wide snapshot, so
the cells distinguish "reads its own slot" from "reads nothing at all".

## Mutation matrix

Full-package (`go test -count=1 ./pkg/api/`, no `-run` filter), each verified
applied and `go vet`-clean before running, restored clean after. Base
`dfa1aaf20…`, head `8274b4026…`.

| # | Mutation | rc | Which assertion fired |
|---|---|---|---|
| 1 | reintroduce an **independent** slot allocation in `serveLegLocked` — the exact #6734 divergence | 1 | all 5 new cells, **plus the pre-existing `TestRetiredLegNeverGainsARotatedCredential_5561` and `TestRetiredLegIsNeverDroppedToNoAuth_5561`** — once actually constructed, the divergence is a security regression the older guards also see |
| 2 | adopt a missing slot **without storing it back** | 1 | `:121` *"httpsLegPlan must adopt and STORE a slot … without the store-back the leg and the field are different objects and pin/tighten operate on one nothing reads"* — localises to the `Start_https_with_no_preallocated_slot` cell alone |
| 3 | divergence at the **other end** — the plan hands the handler a different slot than the leg | 1 | `:96` / `:104` *"the leg ACCEPTED a credential published AFTER its slot was pinned … the retirement pin is a no-op"* |
| 4 | **harness soundness** — never pin, so the probe asserts over an unpinned slot | 1 | same assertions across all cells: the probe is measuring the pin, not passing by accident |

Cell 1 is the one worth reading: the mutation is the issue's own hypothetical,
and it reds **two pre-existing #5561 tests** as well as the new ones.

## Validation

- `go test ./... -count=1` — **rc=0, 67 packages ok, 0 FAIL**, including
  `pkg/refactoraudit`'s modularity gate.
- No cluster, VRRP, session-sync, failover, dataplane or shim code; no Rust.
  **No cluster gate owed**; I ran no cluster target.
- `pkg/api/README.md` carries the invariant and why the guard is behavioural.

Closes #6734
