### PR TITLE
config: classify ip-monitoring next-hop interfaces by name class (#6731)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103777,3 +103777,14 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: `pkg/cluster/heartbeat_epoch.go`, `pkg/cluster/heartbeat.go`,
   `pkg/cluster/manager.go`,
   `pkg/cluster/heartbeat_epoch_persist_retry_6724_test.go` (new)
+
+## 2026-08-22 — #6731 ip-monitoring next-hop interface-class test
+- **Action**: Replaced the raw prefix tests in
+  `resolveIPMonitoringInterfaceNextHop` with `IsTunnelOrLoopbackIfName`, a
+  canonical name-class predicate. `HasPrefix(name,"lo")` also matched `login0`,
+  `"st"` matched `start0`, `"fti"` matched `ftime0` and `"gr-"` matched
+  `gr-eenwich` — ordinary data interfaces refused as tunnels. Each namespace now
+  uses the rule the tree already uses to resolve a device in it.
+- **File(s)**: `pkg/config/ifname_class_6731.go` (new),
+  `pkg/config/compiler_services.go`,
+  `pkg/config/ipmon_nexthop_ifclass_6731_test.go` (new), `docs/multi-wan.md`

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -648,7 +648,19 @@ routing, and only on double fault).
 
   The named unit must be configured with `family inet dhcp` (Junos
   configured name, `<ifd>.<unit>`; v4 destinations only; management
-  interfaces rejected). The injected route then tracks the unit's
+  interfaces rejected). Tunnel and loopback interfaces are rejected too
+  — a DHCP client can never acquire a lease on one, so accepting it
+  would only manufacture a permanently-unresolvable route. That test is
+  a NAME CLASS, `IsTunnelOrLoopbackIfName`, not a raw prefix match
+  (#6731): interface names are wildcard-authorable with no reservation
+  on these prefixes, so `lo`/`st`/`fti`/`gr-`/`ip-` as bare prefixes
+  also matched `login0`, `start0`, `ftime0` and `gr-eenwich` — ordinary
+  data interfaces an operator may legitimately name and run a DHCP
+  client on. Each namespace now uses the same rule the tree uses to
+  RESOLVE a device in it: `st<N>` defers to `IsSecureTunnelIfName`
+  (sharing its if_id range with `XFRMIfNameAndID`, so `st65536` — which
+  yields no xfrmi — is a data interface); `lo<N>`/`fti<N>` require
+  digits; `gr-`/`ip-` require a Junos port path. The injected route then tracks the unit's
   DHCP-learned gateway: the ipmon engine resolves it at every overlay
   computation, and lease events (first lease, gateway change on
   renewal, lease-record removal) re-actuate through the routes-only

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -1085,10 +1085,12 @@ func resolveIPMonitoringInterfaceNextHop(cfg *Config, polName string, pr *Prefer
 		return "", fmt.Errorf("services ip-monitoring policy %q route %s: next-hop %q: interface %s has no unit %d",
 			polName, pr.Destination, val, ifdName, unitNum)
 	}
-	if ifc.Tunnel != nil || unit.Tunnel != nil ||
-		strings.HasPrefix(ifdName, "lo") || strings.HasPrefix(ifdName, "st") ||
-		strings.HasPrefix(ifdName, "gr-") || strings.HasPrefix(ifdName, "ip-") ||
-		strings.HasPrefix(ifdName, "fti") {
+	// #6731: the name test is IsTunnelOrLoopbackIfName, not raw prefixes.
+	// `strings.HasPrefix(ifdName, "lo")` also matched `login0`, `"st"` matched
+	// `start0`, `"fti"` matched `ftime0` and `"gr-"` matched `gr-eenwich` — all
+	// ordinary data interfaces an operator may name and run a DHCP client on,
+	// refused here with a message telling them they had named a tunnel.
+	if ifc.Tunnel != nil || unit.Tunnel != nil || IsTunnelOrLoopbackIfName(ifdName) {
 		return "", fmt.Errorf("services ip-monitoring policy %q route %s: next-hop %q names a tunnel or loopback interface; a DHCP-tracked next-hop requires a broadcast interface unit",
 			polName, pr.Destination, val)
 	}

--- a/pkg/config/ifname_class_6731.go
+++ b/pkg/config/ifname_class_6731.go
@@ -1,0 +1,97 @@
+package config
+
+import "strings"
+
+// ifname_class_6731.go carries the canonical name-class predicates for the
+// interface namespaces that a DHCP client can never live on: loopback, GRE,
+// IP-IP, flexible-tunnel and secure-tunnel.
+//
+// They exist because raw prefix tests are WRONG here, not merely loose.
+// Interface names are wildcard-authorable with no reservation on these prefixes
+// (`schema_interfaces.go`), so `strings.HasPrefix(name, "lo")` also matches
+// `login0`, `"st"` matches `start0`, `"fti"` matches `ftime0`, and `"gr-"`
+// matches `gr-eenwich`. Each of those is an ordinary data interface that an
+// operator may legitimately name and run a DHCP client on, and the prefix test
+// refused it (#6731).
+//
+// The rule per namespace is the one the rest of the tree already uses to
+// RESOLVE a device in that namespace, so a name that no resolver would ever
+// turn into a tunnel is not classified as one:
+//
+//   - `st<N>`  — IsSecureTunnelIfName, which shares its range rule with
+//     XFRMIfNameAndID (`xfrmi.go`). A name outside the if_id range yields no
+//     xfrmi, so it is not a secure tunnel — `st65536` is a data interface.
+//   - `lo<N>` / `fti<N>` — the prefix followed by digits and nothing else.
+//   - `gr-<port>` / `ip-<port>` — the prefix followed by a Junos port path,
+//     which is how the interface compiler recognises them when it defaults a
+//     tunnel's mode (`compiler_interfaces.go`: "ip-X/X/X → ipip, gr-X/X/X →
+//     gre") and what LinuxIfName rewrites into a kernel name.
+
+// ifNameNumericSuffix reports whether name is exactly prefix followed by one or
+// more decimal digits — the `lo0` / `fti3` shape. The digits are not parsed into
+// a value: no caller needs the index, and refusing a huge one would invent a
+// range rule this namespace does not have (contrast IsSecureTunnelIfName, whose
+// range comes from the XFRM if_id it must produce).
+//
+// NOTE: `isCanonicalFabricName` (lifeline.go) is the same rule for the `fab`
+// namespace, and its doc makes the same point ("`fabric0` are NOT canonical").
+// The two are not merged here because the management-interface arm of this same
+// validator still uses raw prefixes and has the identical defect; single-sourcing
+// this formula belongs with that fix, where both callers change together, rather
+// than half-done now. Filed separately as #7515.
+func ifNameNumericSuffix(name, prefix string) bool {
+	rest, ok := strings.CutPrefix(name, prefix)
+	if !ok || rest == "" {
+		return false
+	}
+	for _, r := range rest {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// ifNameJunosPortPath reports whether name is prefix followed by a Junos port
+// path — `gr-0/0/0`, and the `gr-0-0-0` spelling LinuxIfName produces. The
+// component COUNT is deliberately not checked: this repo accepts both
+// separators and the compiler's own tunnel-mode default keys on the prefix
+// alone, so requiring exactly fpc/pic/port here would reject a form the rest of
+// the tree admits. What it does reject is the reported defect — a name whose
+// first character after the prefix is not a digit (`gr-eenwich`, `ip-sec0`).
+func ifNameJunosPortPath(name, prefix string) bool {
+	rest, ok := strings.CutPrefix(name, prefix)
+	if !ok || rest == "" {
+		return false
+	}
+	if rest[0] < '0' || rest[0] > '9' {
+		return false
+	}
+	for _, r := range rest {
+		if (r < '0' || r > '9') && r != '/' && r != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+// IsTunnelOrLoopbackIfName reports whether base names an interface in a class
+// that cannot carry a DHCP client: loopback, GRE, IP-IP, flexible-tunnel or
+// secure-tunnel.
+//
+// It answers a LEXICAL question only. A caller that also has the compiled
+// interface should test `ifc.Tunnel != nil` / `unit.Tunnel != nil` first — that
+// is authoritative where it applies, and this predicate covers the case those
+// miss: a tunnel-class NAME with no `tunnel` stanza, on which the interface
+// compiler still accepts `family inet dhcp`.
+func IsTunnelOrLoopbackIfName(base string) bool {
+	switch {
+	case IsSecureTunnelIfName(base):
+		return true
+	case ifNameNumericSuffix(base, "lo"), ifNameNumericSuffix(base, "fti"):
+		return true
+	case ifNameJunosPortPath(base, "gr-"), ifNameJunosPortPath(base, "ip-"):
+		return true
+	}
+	return false
+}

--- a/pkg/config/ipmon_nexthop_ifclass_6731_test.go
+++ b/pkg/config/ipmon_nexthop_ifclass_6731_test.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6731 — the ip-monitoring interface next-hop validator rejected any interface
+// whose NAME merely began with a tunnel/loopback prefix.
+//
+// Interface names are wildcard-authorable with no reservation on those prefixes,
+// so `strings.HasPrefix(name, "lo")` also matched `login0`, `"st"` matched
+// `start0`, `"fti"` matched `ftime0` and `"gr-"` matched `gr-eenwich`. Each is
+// an ordinary data interface an operator may legitimately name and run a DHCP
+// client on, and the commit was refused with a message telling them they had
+// named a tunnel.
+//
+// The fix LOOSENS a validator, so the dangerous direction is over-loosening.
+// Every cell below therefore comes in a pair: the look-alike must compile AND
+// the genuine tunnel/loopback name in the same namespace must still be refused.
+// A test that only asserted the look-alikes would pass just as well against
+// `return false`.
+
+// ipmonNextHopLines builds a config whose ip-monitoring preferred route names
+// <ifd>.0 as its interface-typed next-hop, with a DHCP client on that unit.
+func ipmonNextHopLines(ifd string) []string {
+	return []string{
+		"set services rpm probe WAN test wan-a probe-type icmp-ping",
+		"set services rpm probe WAN test wan-a target address 1.1.1.1",
+		"set services rpm probe WAN test wan-a destination-interface " + ifd + ".0",
+		"set services rpm probe WAN test wan-a next-hop 172.16.50.1",
+		"set interfaces " + ifd + " unit 0 family inet dhcp",
+		"set services ip-monitoring policy p match rpm-probe WAN",
+		"set services ip-monitoring policy p then preferred-route route 0.0.0.0/0 next-hop " + ifd + ".0",
+	}
+}
+
+// compileIPMonNextHop6731 compiles a config naming ifd as the next-hop and
+// returns the tunnel/loopback rejection message, or "" when it compiled.
+func compileIPMonNextHop6731(t *testing.T, ifd string) string {
+	t.Helper()
+	tree := buildTree(t, ipmonNextHopLines(ifd))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		return ""
+	}
+	if !strings.Contains(err.Error(), "names a tunnel or loopback interface") {
+		t.Fatalf("%s: compile failed for an unrelated reason, so this cell is not testing the "+
+			"interface-class validator: %v", ifd, err)
+	}
+	return err.Error()
+}
+
+// TestIPMonNextHopAcceptsTunnelLookalikeNames6731 is the reported defect.
+func TestIPMonNextHopAcceptsTunnelLookalikeNames6731(t *testing.T) {
+	for _, tc := range []struct{ ifd, why string }{
+		{"start0", "begins with `st` but is not a secure tunnel — XFRMIfNameAndID builds no xfrmi for it"},
+		{"login0", "begins with `lo` but is not a loopback"},
+		{"ftime0", "begins with `fti` but is not a flexible-tunnel interface"},
+		{"st65536", "an `st` name OUTSIDE the if_id range, so it can never be an xfrmi"},
+		{"gr-eenwich", "begins with `gr-` but is not a Junos GRE port path"},
+		{"ip-sec0", "begins with `ip-` but is not a Junos IP-IP port path"},
+	} {
+		if msg := compileIPMonNextHop6731(t, tc.ifd); msg != "" {
+			t.Errorf("%s must be usable as a DHCP-tracked next-hop — it %s. Got: %s",
+				tc.ifd, tc.why, msg)
+		}
+	}
+}
+
+// TestIPMonNextHopStillRejectsRealTunnels6731 is the over-loosening guard, and
+// it is the half that makes the test above mean anything. Neutralising
+// IsTunnelOrLoopbackIfName (or reverting it to `return false`) reds here while
+// every look-alike cell above stays green.
+func TestIPMonNextHopStillRejectsRealTunnels6731(t *testing.T) {
+	for _, tc := range []struct{ ifd, why string }{
+		{"lo0", "loopback"},
+		{"st0", "secure tunnel (in the if_id range)"},
+		{"fti0", "flexible tunnel interface"},
+		{"gr-0/0/0", "GRE, a Junos port path"},
+		{"ip-0/0/0", "IP-IP, a Junos port path"},
+	} {
+		if msg := compileIPMonNextHop6731(t, tc.ifd); msg == "" {
+			t.Errorf("%s is a %s and can never acquire a DHCP lease, so it must still be "+
+				"refused as an ip-monitoring next-hop — accepting it manufactures a "+
+				"permanently-unresolvable route", tc.ifd, tc.why)
+		}
+	}
+}
+
+// TestTunnelOrLoopbackIfNameBoundaries6731 pins the predicate directly, at the
+// boundaries the compile-level cells cannot reach cheaply.
+func TestTunnelOrLoopbackIfNameBoundaries6731(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want bool
+	}{
+		// Genuine members of each namespace.
+		{"lo0", true}, {"lo1", true}, {"fti0", true}, {"fti12", true},
+		{"st0", true}, {"st1", true}, {"st65535", true},
+		{"gr-0/0/0", true}, {"ip-0/0/0", true},
+		// The kernel spelling LinuxIfName produces.
+		{"gr-0-0-0", true}, {"ip-0-0-0", true},
+		// Look-alikes: the reported defect.
+		{"login0", false}, {"lo", false}, {"loop", false},
+		{"start0", false}, {"st", false}, {"stuff", false},
+		{"ftime0", false}, {"fti", false},
+		{"gr-eenwich", false}, {"ip-sec0", false}, {"gr-", false}, {"ip-", false},
+		// st65536 is outside the XFRM if_id range, so no xfrmi is ever built
+		// for it — the range rule is shared with XFRMIfNameAndID rather than
+		// restated here.
+		{"st65536", false},
+		// Ordinary data interfaces.
+		{"ge-0/0/0", false}, {"reth0", false}, {"", false},
+	} {
+		if got := IsTunnelOrLoopbackIfName(tc.name); got != tc.want {
+			t.Errorf("IsTunnelOrLoopbackIfName(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #6731

## The defect

`resolveIPMonitoringInterfaceNextHop` rejected any interface whose **name** merely
began with a tunnel or loopback prefix:

```go
strings.HasPrefix(ifdName, "lo") || strings.HasPrefix(ifdName, "st") ||
strings.HasPrefix(ifdName, "gr-") || strings.HasPrefix(ifdName, "ip-") ||
strings.HasPrefix(ifdName, "fti")
```

Interface names are wildcard-authorable with no reservation on those prefixes
(`schema_interfaces.go`), so this also matched `login0`, `start0`, `ftime0`,
`gr-eenwich` and `ip-sec0` — ordinary data interfaces an operator may
legitimately name and run a DHCP client on. The commit was refused with a
message telling them they had named a tunnel.

## The fix

`IsTunnelOrLoopbackIfName` replaces the prefix tests. Per namespace it uses **the
rule the tree already uses to RESOLVE a device in that namespace**, so a name no
resolver would ever turn into a tunnel is not classified as one:

| namespace | rule | consequence |
|---|---|---|
| `st<N>` | defers to `IsSecureTunnelIfName` | shares the if_id range with `XFRMIfNameAndID`, so **`st65536` yields no xfrmi and is a data interface**. The range is deferred to, not restated. |
| `lo<N>`, `fti<N>` | prefix + digits only | `login0`, `ftime0` are data interfaces |
| `gr-`, `ip-` | prefix + a Junos port path | how the interface compiler itself recognises them when defaulting a tunnel's mode (*"ip-X/X/X → ipip, gr-X/X/X → gre"*) and what `LinuxIfName` rewrites |

Both the `0/0/0` and `0-0-0` spellings are accepted. The component **count** is
deliberately not checked — requiring exactly fpc/pic/port would reject a form the
rest of the tree admits.

The authoritative `ifc.Tunnel != nil || unit.Tunnel != nil` test is unchanged and
still runs first. The name class covers only what that misses: a tunnel-class
**name** with no `tunnel` stanza, on which the interface compiler still accepts
`family inet dhcp`.

## This LOOSENS a validator, so every test is a pair

The dangerous direction here is over-loosening, not under-loosening. So each
namespace is asserted twice — the look-alike must **compile**, and the genuine
name in the same namespace must still be **refused**. A suite that only asserted
the look-alikes would pass just as well against `return false`.

## Deliberately not folded in — filed as #7515

The **management-interface** arm three lines above has the identical defect
shape: `HasPrefix(name, "em")` matches `emu0`, `"fab"` matches `fabric0`, `"fxp"`
matches `fxpanel0`.

It is worth reading #7515 for one detail: `isCanonicalFabricName` in
`lifeline.go` already implements exactly the right rule for `fab`, and its doc
says outright that **`fabric0` is NOT canonical** — so the tree currently
disagrees with itself about that name, on two different paths. That is a live
inconsistency, not a hypothetical.

Not fixed here because it is a distinct namespace whose canonical predicate for
`em`/`fxp` is not obvious (`HostInboundLifelineInterface` treats **`em0`
specifically**, not `em*`). Same reasoning that split #6731 itself out of #6691:
keep the claim no broader than the sweep.

`ifNameNumericSuffix` is therefore left **duplicated** with `isCanonicalFabricName`
**on purpose, with a comment naming #7515**, because single-sourcing that formula
belongs where both callers change together rather than half-done in a PR that
does not touch the management arm.

## Validation

- `go build ./...`, `gofmt`, `go vet ./pkg/config/` clean.
- **`go test -count=1 ./...`** — 73 packages, **one** failing package:
  `pkg/ddns` `TestListenDNSPairResamplesPastAConflictingPort_6709`, the known
  #7482 ephemeral-port-contention flake. Confirmed green on re-run rather than
  assumed: the full package re-ran `ok`, and the specific test re-ran `ok` three
  more times. No other package failed.

### Mutation — full `pkg/config` suite per cell, no `-run` filter, 6461 tests collected each, no build breaks

| # | Mutation | Verdict |
|---|---|---|
| **R1** | `IsTunnelOrLoopbackIfName` → `return false` (**over-loosen**) | **RED** — the still-rejects pair, the predicate boundaries, **and the pre-existing `TestIPMonitoringInterfaceNextHopValidation` gre/st0/loopback subtests**. Running cells full-suite rather than under `-run` is what surfaced that older owner. Look-alike cells stay green, correctly. |
| **R2** | restore the **verbatim** pre-fix prefix tests | **RED — the look-alike cell ONLY**; the still-rejects half stays green. That pairing is the point. |
| **R3** | drop the digit check from `ifNameNumericSuffix` | **RED** — look-alikes + predicate boundaries |

## Cluster surface

None. `pkg/config` compile-time validation plus its doc. **Does not owe
`make test-failover`.**

Refs #1844, #6691, #7515.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VM24XVAYBhzAUSAAhnR8Xp
