### PR TITLE
daemon: bootstrap rollback relinquishes cluster mastership

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103777,3 +103777,13 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: `pkg/cluster/heartbeat_epoch.go`, `pkg/cluster/heartbeat.go`,
   `pkg/cluster/manager.go`,
   `pkg/cluster/heartbeat_epoch_persist_retry_6724_test.go` (new)
+
+## 2026-08-22 — #6742 bootstrap rollback relinquishes cluster mastership
+- **Timestamp**: 2026-08-22
+- **Action**: enterBootstrapMode tore down networkd/FRR/dataplane but never
+  stopped cluster comms, so a node rolled back into bootstrap kept advertising
+  VRRP, could hold RG mastership, and answered for the RETH VIPs with a
+  detached dataplane. Added relinquishClusterForBootstrap (ResignRG per live
+  RG + barrier wait, then stopClusterComms) ahead of the teardown.
+- **File(s)**: pkg/daemon/bootstrap.go,
+  pkg/daemon/bootstrap_cluster_relinquish_6742_test.go

--- a/pkg/daemon/bootstrap.go
+++ b/pkg/daemon/bootstrap.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -402,6 +403,26 @@ func (d *Daemon) enterBootstrapMode() error {
 	// no-op when no monitor is running). Runs under the caller's d.applySem.
 	d.stopAndDiscardNATPoolAlarm()
 
+	// #6742: relinquish cluster mastership and stop cluster comms BEFORE the
+	// teardown below detaches the dataplane, and the order is the whole point.
+	//
+	// A node that rolls back into bootstrap is logically unconfigured — but
+	// nothing here stopped VRRP, the heartbeat or session sync, so it kept
+	// advertising, could hold or win RG mastership, and answered for the RETH
+	// VIPs with a dataplane the teardown then detached. The peer saw a healthy
+	// node throughout. That is the bootstrap-with-live-cluster hybrid.
+	//
+	// Resigning while this node can STILL forward makes the handover a planned
+	// failover (priority-0 burst, peer takes over in ~1ms) instead of a
+	// blackhole the peer discovers a heartbeat interval later. Doing it after
+	// the dataplane detach would invert that.
+	//
+	// Placed BEFORE the seam branch below for the same reason
+	// stopAndDiscardNATPoolAlarm is: the lifecycle then runs on every path,
+	// including the rollback unit tests that stub the apply body. It is a no-op
+	// on a standalone node.
+	clusterSteps := d.relinquishClusterForBootstrap()
+
 	var steps []bootstrapTeardownStep
 	switch {
 	case d.bootstrapTeardownForTest != nil:
@@ -419,6 +440,11 @@ func (d *Daemon) enterBootstrapMode() error {
 	default:
 		steps = d.runBootstrapTeardownSteps()
 	}
+
+	// The cluster relinquish ran before the seam, so its outcomes are folded in
+	// FIRST — a failed resign is part of the same honest report, not a separate
+	// channel that a stubbed teardown could hide.
+	steps = append(clusterSteps, steps...)
 
 	// #5868: aggregate the per-step outcomes and report HONESTLY. A partial
 	// teardown must never be logged/returned as a clean rollback.
@@ -479,6 +505,84 @@ func summarizeBootstrapTeardown(steps []bootstrapTeardownStep) (err error, degra
 // earlier failures — a bootstrap rollback tears down as much as it can — but
 // failures are captured (not discarded) so the caller can report DEGRADED.
 // Runs under the caller's d.applySem.
+// relinquishClusterForBootstrap resigns every redundancy group this node holds
+// and stops cluster comms, so a node that has rolled back into bootstrap mode
+// cannot keep acting clustered while logically unconfigured (#6742).
+//
+// It is a no-op on a standalone node (no cluster manager, or no VRRP manager).
+//
+// It deliberately does NOT call vrrp.Manager.Stop(). That method is
+// single-shot: its own contract says the daemon does "Start-once at init and
+// Stop-once at shutdown, never concurrently" (#2625), and it closes the event
+// channel and cancels the manager context. Bootstrap rollback is RECOVERABLE —
+// the next compilable `commit confirmed` (or a cluster SyncApply) re-arms the
+// node — so tearing the manager down permanently would trade a hybrid state for
+// a node that can never run VRRP again until xpfd restarts. ResignRG is the
+// restartable path, the same one manual failover and a weight drop use.
+//
+// Each resign is awaited on its barrier so the virtual addresses are physically
+// off the interface before the caller detaches the dataplane; a barrier that
+// does not complete is reported as a failed step rather than waited on forever,
+// because a wedged VRRP instance must not block the rollback that is trying to
+// make this node safe.
+//
+// Runs under the caller's d.applySem. stopClusterComms takes clusterCommsMu,
+// which is the same order the apply tail already uses when a transport change
+// restarts comms (daemon_apply_tail.go), so there is no new lock edge.
+func (d *Daemon) relinquishClusterForBootstrap() []bootstrapTeardownStep {
+	if d.cluster == nil {
+		return nil
+	}
+	var steps []bootstrapTeardownStep
+
+	// Enumerate the RGs from the LIVE state machines, not from the config: the
+	// config that defined them is exactly what this rollback is discarding.
+	d.rgStatesMu.RLock()
+	rgIDs := make([]int, 0, len(d.rgStates))
+	for id := range d.rgStates {
+		rgIDs = append(rgIDs, id)
+	}
+	d.rgStatesMu.RUnlock()
+	sort.Ints(rgIDs)
+
+	for _, rgID := range rgIDs {
+		barrier := d.resignRethRG(rgID)
+		if barrier == nil {
+			// Nothing to release for this RG — no RETH tenure to hand over.
+			continue
+		}
+		timeout := d.rethVIPReleaseTimeout
+		if timeout <= 0 {
+			timeout = rethVIPReleaseTimeout
+		}
+		timer := time.NewTimer(timeout)
+		select {
+		case <-barrier.Done():
+			if err := barrier.Err(); err != nil {
+				steps = append(steps, bootstrapTeardownStep{
+					name: fmt.Sprintf("resign redundancy group %d", rgID),
+					err:  err,
+				})
+			}
+		case <-timer.C:
+			steps = append(steps, bootstrapTeardownStep{
+				name: fmt.Sprintf("resign redundancy group %d", rgID),
+				err: fmt.Errorf("timed out after %s waiting for virtual addresses to be released",
+					timeout),
+			})
+		}
+		timer.Stop()
+	}
+
+	// Stop heartbeats, session sync and the fabric refresh loops. Until this
+	// runs the peer keeps seeing a healthy node and keeps syncing sessions to
+	// one whose dataplane is about to be detached.
+	d.stopClusterComms()
+	slog.Info("bootstrap rollback: cluster comms stopped and redundancy groups resigned",
+		"redundancy_groups", len(rgIDs))
+	return steps
+}
+
 func (d *Daemon) runBootstrapTeardownSteps() []bootstrapTeardownStep {
 	steps := make([]bootstrapTeardownStep, 0, 3)
 

--- a/pkg/daemon/bootstrap_cluster_relinquish_6742_test.go
+++ b/pkg/daemon/bootstrap_cluster_relinquish_6742_test.go
@@ -1,0 +1,206 @@
+package daemon
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/vrrp"
+)
+
+// #6742: a node that rolls back into bootstrap mode must not keep acting
+// clustered while it is logically unconfigured.
+//
+// Before this, enterBootstrapMode tore down networkd files, FRR and the
+// dataplane but never touched cluster comms — so VRRP kept advertising, the
+// node could hold or win RG mastership, and it answered for the RETH VIPs with
+// a dataplane the same function had just detached. The peer saw a healthy node
+// throughout.
+//
+// The ORDER is the load-bearing property and is what these tests assert:
+// resigning while this node can still forward makes the handover a planned
+// failover (priority-0 burst, ~1 ms takeover); resigning after the detach would
+// blackhole until the peer noticed a missing heartbeat.
+
+// relinquish6742Daemon builds a clustered daemon whose resignation seam records
+// the order of events against the dataplane teardown.
+func relinquish6742Daemon(t *testing.T, rgIDs []int, barrier vipReleaseBarrier) (*Daemon, *[]string, *sync.Mutex) {
+	t.Helper()
+	cm := cluster.NewManager(0, 1)
+	var rgs []*config.RedundancyGroup
+	for _, id := range rgIDs {
+		rgs = append(rgs, &config.RedundancyGroup{ID: id, NodePriorities: map[int]int{0: 200}})
+	}
+	cm.UpdateConfig(&config.ClusterConfig{RedundancyGroups: rgs})
+
+	d := &Daemon{
+		applySem:              semaphore.NewWeighted(1),
+		cluster:               cm,
+		vrrpMgr:               vrrp.NewManager(),
+		rgStates:              make(map[int]*rgStateMachine),
+		rethVIPReleaseTimeout: 2 * time.Second,
+		opts:                  Options{NoDataplane: true},
+	}
+	// Materialise the live RG state machines — the production enumeration reads
+	// these, NOT the config, because the config is what the rollback discards.
+	for _, id := range rgIDs {
+		d.getOrCreateRGState(id)
+	}
+
+	var mu sync.Mutex
+	var order []string
+	d.resignRethRGFn = func(rgID int) vipReleaseBarrier {
+		mu.Lock()
+		order = append(order, "resign")
+		mu.Unlock()
+		return barrier
+	}
+	// The apply-body seam makes enterBootstrapMode skip the real fs / FRR /
+	// dataplane teardown. Record that it was reached so the ORDER assertion has
+	// a second event to order against.
+	d.applyBodyForTest = func(*config.Config) {}
+	d.bootstrapTeardownForTest = func() []bootstrapTeardownStep {
+		mu.Lock()
+		order = append(order, "teardown")
+		mu.Unlock()
+		return nil
+	}
+	return d, &order, &mu
+}
+
+// TestBootstrapRollbackResignsBeforeTeardown6742 is the defect proper.
+func TestBootstrapRollbackResignsBeforeTeardown6742(t *testing.T) {
+	barrier := newFakeVIPRelease()
+	barrier.release(nil) // VIPs already off; the wait resolves immediately.
+	d, order, mu := relinquish6742Daemon(t, []int{0, 1}, barrier)
+
+	if err := d.enterBootstrapMode(); err != nil {
+		t.Fatalf("enterBootstrapMode: %v", err)
+	}
+
+	mu.Lock()
+	got := append([]string(nil), *order...)
+	mu.Unlock()
+
+	if len(got) != 3 {
+		t.Fatalf("expected one resign per redundancy group plus the teardown, got %v", got)
+	}
+	if got[0] != "resign" || got[1] != "resign" {
+		t.Errorf("cluster mastership was not relinquished for every redundancy group before the "+
+			"teardown: %v — a node rolling back into bootstrap kept advertising VRRP and could "+
+			"hold or win RG mastership while logically unconfigured", got)
+	}
+	if got[2] != "teardown" {
+		t.Errorf("the dataplane teardown ran BEFORE the resign (%v). Resigning after the detach "+
+			"blackholes traffic for the RETH VIPs until the peer notices a missing heartbeat, "+
+			"instead of handing over in ~1ms via the priority-0 burst", got)
+	}
+	if !d.bootstrapMode.Load() {
+		t.Error("bootstrapMode not set")
+	}
+}
+
+// TestBootstrapRollbackReportsAFailedResign6742 pins the honest-reporting half:
+// a resign that does not complete must make the rollback DEGRADED, not clean.
+// #5868 requires a partial teardown never be reported as a clean rollback, and
+// a silently-swallowed resign failure is exactly that — the operator would be
+// told the node is safely unconfigured while it still holds the VIPs.
+func TestBootstrapRollbackReportsAFailedResign6742(t *testing.T) {
+	barrier := newFakeVIPRelease()
+	barrier.release(errors.New("vip release refused"))
+	d, _, _ := relinquish6742Daemon(t, []int{0}, barrier)
+
+	err := d.enterBootstrapMode()
+	if err == nil {
+		t.Fatal("a failed VIP release was reported as a CLEAN rollback — the operator is told the " +
+			"node is safely unconfigured while it may still answer for the RETH virtual addresses")
+	}
+	if !errorMentions6742(err, "resign redundancy group 0") {
+		t.Errorf("the rollback error does not name the failed step: %v", err)
+	}
+}
+
+// TestBootstrapRollbackStandaloneIsANoOp6742 is the TIGHTENING control. A fix
+// that unconditionally resigned or stopped comms would satisfy the tests above
+// while breaking every standalone node's rollback. A daemon with no cluster
+// manager must reach the teardown with no resign at all.
+func TestBootstrapRollbackStandaloneIsANoOp6742(t *testing.T) {
+	d := &Daemon{
+		applySem: semaphore.NewWeighted(1),
+		rgStates: make(map[int]*rgStateMachine),
+		opts:     Options{NoDataplane: true},
+	}
+	var mu sync.Mutex
+	var order []string
+	d.resignRethRGFn = func(int) vipReleaseBarrier {
+		mu.Lock()
+		order = append(order, "resign")
+		mu.Unlock()
+		return nil
+	}
+	d.applyBodyForTest = func(*config.Config) {}
+	d.bootstrapTeardownForTest = func() []bootstrapTeardownStep {
+		mu.Lock()
+		order = append(order, "teardown")
+		mu.Unlock()
+		return nil
+	}
+
+	// clusterCommsGen is the observable that discriminates the standalone
+	// guard. Every ACTION the guard skips is independently a no-op without a
+	// cluster — the RG loop finds an empty map, and stopClusterComms checks
+	// d.cluster itself — so a test that only watched for a resign would pass
+	// with the guard deleted. What is NOT a no-op is stopClusterComms bumping
+	// the comms generation and the function logging that redundancy groups were
+	// resigned, on a node that has none. Pinning the generation makes the guard
+	// load-bearing against something real rather than defensive-by-assertion.
+	d.clusterCommsMu.Lock()
+	genBefore := d.clusterCommsGen
+	d.clusterCommsMu.Unlock()
+
+	if err := d.enterBootstrapMode(); err != nil {
+		t.Fatalf("standalone rollback returned an error: %v", err)
+	}
+
+	d.clusterCommsMu.Lock()
+	genAfter := d.clusterCommsGen
+	d.clusterCommsMu.Unlock()
+	if genAfter != genBefore {
+		t.Errorf("a standalone node ran the cluster-comms teardown during bootstrap rollback "+
+			"(clusterCommsGen %d -> %d): it has no comms to stop, and the relinquish then "+
+			"reports redundancy groups resigned on a node that has none", genBefore, genAfter)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, ev := range order {
+		if ev == "resign" {
+			t.Errorf("a standalone node (no cluster manager) attempted a VRRP resignation during "+
+				"bootstrap rollback: %v", order)
+		}
+	}
+	if len(order) != 1 || order[0] != "teardown" {
+		t.Errorf("standalone rollback did not reach the teardown: %v", order)
+	}
+}
+
+func errorMentions6742(err error, want string) bool {
+	if err == nil {
+		return false
+	}
+	return len(want) > 0 && contains6742(err.Error(), want)
+}
+
+func contains6742(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #6742

## The answer to the question

**Yes — entering bootstrap mode with a live cluster runtime should tear down cluster comms.** The issue asked it as a policy question; here is the reasoning that decides it.

`enterBootstrapMode` removed the takeover networkd files, cleared the FRR managed section and **detached the dataplane** — but nothing stopped VRRP, the heartbeat or session sync. So a node that rolled back into bootstrap kept advertising, could hold or win RG mastership, and answered for the RETH virtual addresses with a dataplane the same function had just torn down. The peer saw a healthy node throughout.

That is not a hybrid that merely looks wrong: the node is a **blackhole that still claims the VIPs**, and the peer has no signal to take over.

## The ORDER is the fix, not the teardown

Resigning happens **before** the dataplane detach. That makes the handover a planned failover — the priority-0 burst the peer takes over on in ~1 ms — instead of a blackhole the peer discovers a heartbeat interval later. Doing it after the detach inverts exactly the property that makes this safe, which is why cell **S2** exists and reds.

## What it deliberately does NOT do

It does **not** call `vrrp.Manager.Stop()`. That method is single-shot by its own contract — the daemon does "Start-once at init and Stop-once at shutdown, never concurrently" (#2625) — and it closes the event channel and cancels the manager context. Bootstrap rollback is **recoverable**: the next compilable `commit confirmed`, or a cluster `SyncApply`, re-arms the node. Stopping the manager would trade a hybrid state for a node that can never run VRRP again until xpfd restarts. `ResignRG` is the restartable path, the same one manual failover and a weight drop use.

I went looking for `Manager.Stop()` first because it is the obvious primitive; its own doc comment is what ruled it out.

## Details that matter

- **RGs are enumerated from the live `rgStates`, not the config** — the config that defined them is exactly what this rollback discards.
- **Each resign is awaited on its `ResignBarrier`** so the VIPs are physically off before the dataplane goes, with a bounded timeout: a wedged VRRP instance must not block the rollback that is trying to make the node safe.
- **Failures join the #5868 aggregate.** A swallowed resign failure would tell the operator the node is safely unconfigured while it still answers for the VIPs — the same dishonesty #5868 closed for the other steps.
- **Placed before the apply-body seam**, for the reason `stopAndDiscardNATPoolAlarm` already is: the lifecycle then runs on every path, including the rollback unit tests that stub the teardown.
- **Lock order unchanged.** `enterBootstrapMode` runs under `applySem`; `stopClusterComms` takes `clusterCommsMu` — the same order `daemon_apply_tail.go` already uses when a transport change restarts comms.

## Mutation matrix

Fix committed first, so the applied-check and restore are well defined. Full `pkg/daemon` suite per cell, no `-run` filter, rc from a file, control green first.

| # | mutation | rc | fired |
|---|---|---|---|
| S1 | revert: no relinquish at all | 1 | ordering guard + degraded guard |
| S2 | **ORDER**: relinquish AFTER the teardown | 1 | ordering guard **only** — localises |
| S3 | **TIGHTEN**: drop the standalone guard | 0 → 1 | see below |
| S4 | swallow a failed resign | 1 | degraded guard |

**S3 was GREEN first time and that was a real gap in my own test.** The standalone fixture had an empty `rgStates`, so the RG loop no-opped whether or not the guard was there, and `stopClusterComms` checks `d.cluster` itself — every *action* the guard skips is independently a no-op. A test watching only for a resign would pass with the guard deleted.

What is **not** a no-op is `stopClusterComms` bumping the comms generation, and the function then logging that redundancy groups were resigned on a node that has none. The standalone test now pins `clusterCommsGen`, and S3 reds.

## Validation

`go build`, `go vet`, `gofmt` clean; `go test -count=1 ./...` green repo-wide.

**This is cluster code and owes `make test-failover`** — I run it centrally on the folded merge result before merging, and will post the raw output here.
