### PR TITLE
config/routing: install rib inet.0 static routes, and warn on the rest

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103777,3 +103777,25 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: `pkg/cluster/heartbeat_epoch.go`, `pkg/cluster/heartbeat.go`,
   `pkg/cluster/manager.go`,
   `pkg/cluster/heartbeat_epoch_persist_retry_6724_test.go` (new)
+
+## 2026-08-22 — #7512 rib inet.0 static routes silently discarded
+- **Timestamp**: 2026-08-22
+- **Action**: compiler_routing.go matched only `inet6.0`/`*.inet6.0` in the rib
+  loop, with no branch and NO ELSE, so `routing-options rib inet.0 { static {
+  ... } }` compiled to nothing, committed clean and warned nothing — the
+  symmetric v4+v6 pair installed the IPv6 default route and silently blackholed
+  IPv4. Added the `inet.0` / `<vrf>.inet.0` branch AND the missing else: an
+  unimplemented rib is recorded (only when it actually carried routes) and
+  reported by validateUnhandledRibWarnings. WARN not reject — `rib inet.2` is
+  valid Junos a box may already have committed, so rejecting would brick the
+  tolerant load (#1960); a warning reaches both paths so no lenient* opt is
+  needed. Carried UnhandledRibs across the field-by-field VRF copy explicitly.
+- **Golden**: golden_4406.json regenerated after CLASSIFYING the diff — 24 keys
+  added, all `UnhandledRibs`, all null; 0 removed, 0 values changed, so no
+  fixture behaviour moved.
+- **File(s)**: pkg/config/compiler_routing.go, pkg/config/types_routing.go,
+  pkg/config/compiler_validate_warn_routing.go,
+  pkg/config/compiler_validate_warn.go,
+  pkg/config/rib_static_routes_7512_test.go (new),
+  pkg/config/testdata/golden_4406.json, docs/feature-gaps.md
+

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -455,7 +455,29 @@ xpf uses strongSwan for IPsec. Basic certificate-auth IKE generation exists, but
 
 ## 14. Routing Enhancements
 
-xpf has static routes, generate/aggregate routes, ECMP, VRFs, GRE tunnels, rib-groups, next-table route leaking, PBR, qualified-next-hop with interface (link-local IPv6), per-instance `rib <name>.inet6.0` IPv6 static routes, and FRR integration (OSPF, BGP, IS-IS, RIP, LLDP). These are additional routing features.
+**`routing-options rib <name>` scoping (#7512).** Static routes are implemented
+in the IPv4 and IPv6 unicast tables only — bare `inet.0` / `inet6.0` at the top
+level, and `<instance>.inet.0` / `<instance>.inet6.0` inside a routing instance.
+A route scoped to any OTHER table is **not installed**, and the commit now says
+so: `validateUnhandledRibWarnings` emits a WARN naming the rib and how many
+routes were discarded.
+
+Before #7512 the compiler matched only the inet6 tables and every other rib name
+fell through with no branch and no `else`, so `rib inet.0 { static { route
+0.0.0.0/0 { next-hop ...; } } }` — the ordinary Junos way to scope IPv4 statics,
+and the natural thing to write beside a `rib inet6.0` block — compiled to
+NOTHING, committed clean and emitted no warning. An operator authoring the
+symmetric pair got their IPv6 default route and silently lost the IPv4 one, with
+`show configuration` rendering the stanza back verbatim.
+
+The warning is deliberately WARN and not reject: `rib inet.2` is valid Junos that
+xpf does not implement, and a box may already hold a committed config containing
+one, so rejecting at strict commit would fail the tolerant load / peer-sync of a
+config the running node itself accepted (#1960). A warning reaches both paths, so
+no `lenient*` opt is required. Only ribs that actually carried routes are
+reported — an empty `rib foo { }` loses nothing and stays silent.
+
+xpf has static routes, generate/aggregate routes, ECMP, VRFs, GRE tunnels, rib-groups, next-table route leaking, PBR, qualified-next-hop with interface (link-local IPv6), per-instance `rib <name>.inet.0` / `rib <name>.inet6.0` static routes (both families; `inet.0` was silently discarded before #7512 — see below), and FRR integration (OSPF, BGP, IS-IS, RIP, LLDP). These are additional routing features.
 
 **IPIP tunnels are NOT supported (#4785).** This section previously claimed
 "IPIP tunnels (IPv4+IPv6)"; that was never true of the forwarding path. The

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -82,13 +82,48 @@ func compileRoutingOptions(node *Node, ro *RoutingOptionsConfig) error {
 		}
 	}
 
-	// Parse rib inet6.0 { static { route ... } }
-	// In routing-instances, the rib name is "<instance>.inet6.0" (e.g., "ATT.inet6.0").
+	// Parse rib <name> { static { route ... } }.
+	// In routing-instances the rib name is "<instance>.inet6.0" / "<instance>.inet.0"
+	// (e.g. "ATT.inet6.0"); at the top level it is the bare table name.
+	//
+	// #7512: this loop used to match ONLY the inet6 tables, and every other name
+	// fell through with no branch and no else. `rib inet.0 { static { route
+	// 0.0.0.0/0 { next-hop ...; } } }` — the ordinary Junos way to scope IPv4
+	// statics, and the natural thing to write beside a `rib inet6.0` block —
+	// therefore compiled to NOTHING, committed clean, and emitted no warning.
+	// An operator authoring the symmetric pair got their IPv6 default route and
+	// silently lost their IPv4 one, with `show configuration` rendering the
+	// stanza back verbatim so the config looked correct.
+	//
+	// The missing `else` is the real defect and is the durable half of the fix:
+	// adding an `inet.0` branch alone would leave `inet.2`, `inet.3`, a typo'd
+	// `ient.0` and every future table name silently eating routes exactly as
+	// before. An unimplemented rib is now RECORDED so the commit path can say
+	// so — see validateUnhandledRibWarnings.
 	for _, ribNode := range node.FindChildren("rib") {
 		ribName := nodeVal(ribNode)
-		if ribName == "inet6.0" || strings.HasSuffix(ribName, ".inet6.0") {
-			if ribStatic := ribNode.FindChild("static"); ribStatic != nil {
+		ribStatic := ribNode.FindChild("static")
+		switch {
+		case ribName == "inet6.0" || strings.HasSuffix(ribName, ".inet6.0"):
+			if ribStatic != nil {
 				ro.Inet6StaticRoutes = compileStaticRoutes(ribStatic, ro.Inet6StaticRoutes)
+			}
+		case ribName == "inet.0" || strings.HasSuffix(ribName, ".inet.0"):
+			// The IPv4 unicast table is the SAME destination as a bare
+			// `routing-options static` block, so routes reached either way land
+			// in one list and append rather than replace.
+			if ribStatic != nil {
+				ro.StaticRoutes = compileStaticRoutes(ribStatic, ro.StaticRoutes)
+			}
+		default:
+			// Not implemented. Record it ONLY when routes were actually lost —
+			// an empty `rib foo { }` discards nothing, and warning there would
+			// be noise that teaches operators to scroll past the real case.
+			if ribStatic == nil {
+				continue
+			}
+			if n := len(compileStaticRoutes(ribStatic, nil)); n > 0 {
+				ro.UnhandledRibs = append(ro.UnhandledRibs, UnhandledRib{Name: ribName, Routes: n})
 			}
 		}
 	}
@@ -490,6 +525,9 @@ func compileRoutingInstances(node *Node, cfg *Config) error {
 				}
 				ri.StaticRoutes = ro.StaticRoutes
 				ri.Inet6StaticRoutes = ro.Inet6StaticRoutes
+				// #7512: carried explicitly — this copy is field-by-field, so a
+				// VRF's dropped ribs are unreported unless named here.
+				ri.UnhandledRibs = ro.UnhandledRibs
 				// #3870: capture the instance-level autonomous-system so a
 				// per-instance BGP that omits local-as can inherit it (falling
 				// back to the global routing-options AS in resolveBGPAutonomousSystem).

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -1506,6 +1506,10 @@ func ValidateConfig(cfg *Config) []string {
 	// prefix, or a VRF→VRF import target that Phase 1 does not install) so the
 	// operator sees a fail-loud diagnostic rather than a silent no-op.
 	warnings = append(warnings, validateRibGroupLeakWarnings(cfg)...)
+	// #7512: a `routing-options rib <name>` the compiler does not implement
+	// discarded its static routes. Warn rather than reject — see
+	// validateUnhandledRibWarnings for the #1960 reasoning.
+	warnings = append(warnings, validateUnhandledRibWarnings(cfg)...)
 
 	// #1387: DHCP dynamic-DNS live-backend validation. Increment 2 wired the
 	// live RFC 2136 backend, so the increment-1 "no records are published"

--- a/pkg/config/compiler_validate_warn_routing.go
+++ b/pkg/config/compiler_validate_warn_routing.go
@@ -298,3 +298,57 @@ func validateRibGroupLeakWarnings(cfg *Config) []string {
 	}
 	return warnings
 }
+
+// validateUnhandledRibWarnings reports every `routing-options rib <name>` whose
+// static routes the compiler discarded (#7512).
+//
+// Before #7512 the rib loop matched only the inet6 tables and every other name
+// fell through with no branch and no else, so `rib inet.0 { static { route
+// 0.0.0.0/0 { next-hop ...; } } }` compiled to nothing, committed clean and said
+// nothing. `inet.0` is now implemented; this warning covers the REST of the
+// class — `inet.2`, `inet.3`, a typo'd `ient.0`, any future table name — so an
+// unimplemented rib announces itself instead of blackholing.
+//
+// WARN, NOT REJECT, and the choice is the #1960 no-brick split rather than
+// timidity. `rib inet.2 { static { ... } }` is valid Junos that xpf does not
+// implement, and a box may already have committed one: rejecting it at strict
+// commit would fail the tolerant load / peer-sync of a config the running node
+// itself accepted. A warning reaches BOTH paths (ValidateConfig runs for each),
+// so no lenient* opt is required — the same reason the #3226 host-inbound parity
+// advisories are warnings.
+//
+// Only ribs that actually carried routes are recorded, so this cannot fire on an
+// empty `rib foo { }`.
+func validateUnhandledRibWarnings(cfg *Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	var out []string
+	report := func(scope string, ribs []UnhandledRib) {
+		for _, r := range ribs {
+			plural := "routes"
+			if r.Routes == 1 {
+				plural = "route"
+			}
+			out = append(out, fmt.Sprintf(
+				"%srouting-options rib %q: %d static %s DISCARDED — xpf implements static "+
+					"routes only in the inet.0 and inet6.0 tables, so nothing from this rib "+
+					"reaches the forwarding plane. The commit succeeds and `show configuration` "+
+					"renders the stanza back verbatim, so the loss is visible only here: move "+
+					"these routes to `rib inet.0` / `rib inet6.0` (or a bare `static` block) if "+
+					"they are meant to forward traffic.",
+				scope, r.Name, r.Routes, plural))
+		}
+	}
+	report("", cfg.RoutingOptions.UnhandledRibs)
+	// RoutingInstances is an ordered SLICE, so the report order is already
+	// deterministic and must not be re-sorted: the instances render in
+	// configured order everywhere else.
+	for _, ri := range cfg.RoutingInstances {
+		if ri == nil {
+			continue
+		}
+		report(fmt.Sprintf("routing-instance %q ", ri.Name), ri.UnhandledRibs)
+	}
+	return out
+}

--- a/pkg/config/rib_static_routes_7512_test.go
+++ b/pkg/config/rib_static_routes_7512_test.go
@@ -1,0 +1,207 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// #7512 — `routing-options rib inet.0 { static { ... } }` compiled to NOTHING.
+//
+// The rib loop matched only `inet6.0` / `*.inet6.0`, and every other name fell
+// through with no branch and NO ELSE. So the ordinary Junos way to scope IPv4
+// statics discarded every route, `commit` succeeded, and no warning was emitted.
+//
+// The operator-realistic shape is the symmetric pair, which is exactly what
+// someone writes once they have learned that IPv6 statics need `rib inet6.0`:
+//
+//	routing-options {
+//	    rib inet.0  { static { route 0.0.0.0/0 { next-hop 10.0.0.1; } } }
+//	    rib inet6.0 { static { route ::/0      { next-hop 2001:db8::1; } } }
+//	}
+//
+// That committed clean, installed the IPv6 default route, and silently lost the
+// IPv4 one — a total IPv4 blackhole whose only symptom is a routing failure that
+// looks like a network problem, because `show configuration` renders the stanza
+// back verbatim.
+
+func rib7512Compile(t *testing.T, cfgText string) *Config {
+	t.Helper()
+	tree, errs := NewParser(cfgText).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("fixture parse errors: %v\n%s", errs, cfgText)
+	}
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("tolerant compile: %v\n%s", err, cfgText)
+	}
+	return cfg
+}
+
+func rib7512Prefixes(routes []*StaticRoute) []string {
+	out := make([]string, 0, len(routes))
+	for _, r := range routes {
+		if r != nil {
+			out = append(out, r.Destination)
+		}
+	}
+	return out
+}
+
+func rib7512DiscardWarnings(cfg *Config) []string {
+	var out []string
+	for _, w := range ValidateConfig(cfg) {
+		if strings.Contains(w, "DISCARDED") {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+// TestRibInet0AgreesWithBareStatic_7512 is the core property, asserted as an
+// AGREEMENT between the spellings rather than against a hand-written literal.
+// The same route reaches the same table however it is scoped, so pinning one
+// spelling to an expectation would only encode which one I trusted — and in this
+// family the trusted spelling (`rib inet6.0`) was the one that worked while the
+// obvious one silently did not.
+func TestRibInet0AgreesWithBareStatic_7512(t *testing.T) {
+	const prefix = "10.211.0.0/24"
+	spellings := map[string]string{
+		"bare static":  fmt.Sprintf(`routing-options { static { route %s { next-hop 10.0.0.1; } } }`, prefix),
+		"rib inet.0":   fmt.Sprintf(`routing-options { rib inet.0 { static { route %s { next-hop 10.0.0.1; } } } }`, prefix),
+		"vrf V.inet.0": fmt.Sprintf(`routing-instances { V { instance-type vrf; routing-options { rib V.inet.0 { static { route %s { next-hop 10.0.0.1; } } } } } }`, prefix),
+	}
+	var ref []string
+	var refName string
+	for _, name := range []string{"bare static", "rib inet.0", "vrf V.inet.0"} {
+
+		cfg := rib7512Compile(t, spellings[name])
+		routes := cfg.RoutingOptions.StaticRoutes
+		if len(cfg.RoutingInstances) > 0 {
+			routes = cfg.RoutingInstances[0].StaticRoutes
+		}
+		got := rib7512Prefixes(routes)
+		if ref == nil {
+			ref, refName = got, name
+			continue
+		}
+		if strings.Join(got, ",") != strings.Join(ref, ",") {
+			t.Fatalf("%s compiled to %v but %s compiled to %v — one route, two meanings "+
+				"depending on how it was scoped", name, got, refName, ref)
+		}
+	}
+	if len(ref) != 1 || ref[0] != prefix {
+		t.Errorf("every spelling agrees on %v, but the authored route is %s", ref, prefix)
+	}
+}
+
+// TestSymmetricRibPairInstallsBothFamilies_7512 is the regression guard for the
+// reported configuration. It asserts BOTH families, because the defect was
+// precisely that one of them worked: a test that checked only IPv4 would have
+// passed before the fix if it had also been written against `rib inet6.0`, and a
+// test that checked only IPv6 passes both before AND after.
+func TestSymmetricRibPairInstallsBothFamilies_7512(t *testing.T) {
+	cfg := rib7512Compile(t, `routing-options {
+        rib inet.0  { static { route 0.0.0.0/0 { next-hop 10.0.0.1; } } }
+        rib inet6.0 { static { route ::/0      { next-hop 2001:db8::1; } } }
+    }`)
+	v4 := rib7512Prefixes(cfg.RoutingOptions.StaticRoutes)
+	v6 := rib7512Prefixes(cfg.RoutingOptions.Inet6StaticRoutes)
+	if len(v4) != 1 || v4[0] != "0.0.0.0/0" {
+		t.Errorf("IPv4 default route from `rib inet.0` = %v, want [0.0.0.0/0] — this is the "+
+			"blackhole: IPv6 forwards and IPv4 goes nowhere, with a clean commit", v4)
+	}
+	if len(v6) != 1 || v6[0] != "::/0" {
+		t.Errorf("IPv6 default route from `rib inet6.0` = %v, want [::/0] — the pre-existing "+
+			"behaviour must not regress while fixing its sibling", v6)
+	}
+}
+
+// TestVRFRibInet0IsCarried_7512 binds the WIRING, not the callee.
+// compileRoutingInstances copies fields off the per-instance
+// RoutingOptionsConfig ONE BY ONE, so both the v4 routes and the unhandled-rib
+// record are lost for a VRF unless named there. Deleting either copy leaves the
+// global-scope tests entirely green.
+func TestVRFRibInet0IsCarried_7512(t *testing.T) {
+	cfg := rib7512Compile(t, `routing-instances { V { instance-type vrf;
+        routing-options { rib V.inet.0 { static { route 10.211.0.0/24 { next-hop 10.0.0.1; } } } }
+    } }`)
+	if len(cfg.RoutingInstances) != 1 {
+		t.Fatalf("expected one routing instance, got %d", len(cfg.RoutingInstances))
+	}
+	got := rib7512Prefixes(cfg.RoutingInstances[0].StaticRoutes)
+	if len(got) != 1 || got[0] != "10.211.0.0/24" {
+		t.Errorf("VRF `rib V.inet.0` routes = %v, want [10.211.0.0/24]", got)
+	}
+
+	// ...and the unhandled-rib record must cross the same copy.
+	cfg2 := rib7512Compile(t, `routing-instances { V { instance-type vrf;
+        routing-options { rib V.inet.2 { static { route 10.211.0.0/24 { next-hop 10.0.0.1; } } } }
+    } }`)
+	warns := rib7512DiscardWarnings(cfg2)
+	if len(warns) != 1 {
+		t.Fatalf("a VRF rib the compiler does not implement must warn exactly once, got %d: %v",
+			len(warns), warns)
+	}
+	if !strings.Contains(warns[0], `routing-instance "V"`) || !strings.Contains(warns[0], "V.inet.2") {
+		t.Errorf("the warning must name the instance AND the rib, got: %q", warns[0])
+	}
+}
+
+// TestUnimplementedRibWarnsOnBothPaths_7512 is the missing `else` — the durable
+// half. Adding an `inet.0` branch alone would leave `inet.2`, `inet.3`, a typo'd
+// `ient.0` and every future table name silently eating routes exactly as before.
+//
+// WARN, not reject, and both paths are asserted separately: `rib inet.2` is
+// valid Junos that xpf does not implement, so a box may already hold a committed
+// config containing one. Rejecting at strict commit would fail the tolerant load
+// of a config the running node itself accepted — the #1960 no-brick class. A
+// warning reaches both paths, which is why no lenient* opt is needed here.
+func TestUnimplementedRibWarnsOnBothPaths_7512(t *testing.T) {
+	const text = `routing-options { rib inet.2 { static { route 10.211.0.0/24 { next-hop 10.0.0.1; } } } }`
+
+	tolerant := rib7512Compile(t, text)
+	warns := rib7512DiscardWarnings(tolerant)
+	if len(warns) != 1 {
+		t.Fatalf("tolerant load must WARN exactly once about the discarded rib, got %d: %v", len(warns), warns)
+	}
+	for _, want := range []string{`"inet.2"`, "1 static route", "DISCARDED"} {
+		if !strings.Contains(warns[0], want) {
+			t.Errorf("warning must contain %q — it has to name the rib and how much was lost; got: %q", want, warns[0])
+		}
+	}
+
+	tree, errs := NewParser(text).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	strict, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("strict commit must ACCEPT an unimplemented rib (valid Junos; rejecting it "+
+			"would brick the tolerant load of a config a running box already committed): %v", err)
+	}
+	if len(rib7512DiscardWarnings(strict)) != 1 {
+		t.Errorf("strict commit must warn too — a warning that fires only on the tolerant path " +
+			"is invisible at the moment the operator can still act on it")
+	}
+}
+
+// TestImplementedAndEmptyRibsDoNotWarn_7512 is the TIGHTENING control, and it is
+// what a delete-the-branch matrix cannot see. An over-warning implementation —
+// one that reports every rib, or reports a rib that lost nothing — would fire on
+// real configurations and train operators to scroll past the warning that
+// matters, which is the #6617 cost.
+func TestImplementedAndEmptyRibsDoNotWarn_7512(t *testing.T) {
+	for name, text := range map[string]string{
+		"rib inet.0 (implemented)":   `routing-options { rib inet.0 { static { route 10.211.0.0/24 { next-hop 10.0.0.1; } } } }`,
+		"rib inet6.0 (implemented)":  `routing-options { rib inet6.0 { static { route 2001:db8:211::/48 { next-hop 2001:db8::1; } } } }`,
+		"VRF V.inet.0 implemented":   `routing-instances { V { instance-type vrf; routing-options { rib V.inet.0 { static { route 10.211.0.0/24 { next-hop 10.0.0.1; } } } } } }`,
+		"empty rib, nothing lost":    `routing-options { rib inet.2 { } }`,
+		"rib with route-less static": `routing-options { rib inet.2 { static { } } }`,
+		"bare static, no rib":        `routing-options { static { route 10.211.0.0/24 { next-hop 10.0.0.1; } } }`,
+	} {
+		if got := rib7512DiscardWarnings(rib7512Compile(t, text)); len(got) != 0 {
+			t.Errorf("%s must NOT warn — nothing was discarded; got %d: %v", name, len(got), got)
+		}
+	}
+}

--- a/pkg/config/testdata/golden_4406.json
+++ b/pkg/config/testdata/golden_4406.json
@@ -880,6 +880,7 @@
           }
         ],
         "Inet6StaticRoutes": null,
+        "UnhandledRibs": null,
         "GenerateRoutes": null,
         "ForwardingTableExport": "",
         "ForwardingTableExports": null,
@@ -956,6 +957,7 @@
             }
           ],
           "Inet6StaticRoutes": null,
+          "UnhandledRibs": null,
           "OSPF": null,
           "OSPFv3": null,
           "BGP": null,
@@ -2143,6 +2145,7 @@
           }
         ],
         "Inet6StaticRoutes": null,
+        "UnhandledRibs": null,
         "GenerateRoutes": null,
         "ForwardingTableExport": "",
         "ForwardingTableExports": null,
@@ -2219,6 +2222,7 @@
             }
           ],
           "Inet6StaticRoutes": null,
+          "UnhandledRibs": null,
           "OSPF": null,
           "OSPFv3": null,
           "BGP": null,
@@ -3405,6 +3409,7 @@
           }
         ],
         "Inet6StaticRoutes": null,
+        "UnhandledRibs": null,
         "GenerateRoutes": null,
         "ForwardingTableExport": "",
         "ForwardingTableExports": null,
@@ -3481,6 +3486,7 @@
             }
           ],
           "Inet6StaticRoutes": null,
+          "UnhandledRibs": null,
           "OSPF": null,
           "OSPFv3": null,
           "BGP": null,
@@ -4667,6 +4673,7 @@
           }
         ],
         "Inet6StaticRoutes": null,
+        "UnhandledRibs": null,
         "GenerateRoutes": null,
         "ForwardingTableExport": "",
         "ForwardingTableExports": null,
@@ -4743,6 +4750,7 @@
             }
           ],
           "Inet6StaticRoutes": null,
+          "UnhandledRibs": null,
           "OSPF": null,
           "OSPFv3": null,
           "BGP": null,
@@ -5930,6 +5938,7 @@
           }
         ],
         "Inet6StaticRoutes": null,
+        "UnhandledRibs": null,
         "GenerateRoutes": null,
         "ForwardingTableExport": "",
         "ForwardingTableExports": null,
@@ -6006,6 +6015,7 @@
             }
           ],
           "Inet6StaticRoutes": null,
+          "UnhandledRibs": null,
           "OSPF": null,
           "OSPFv3": null,
           "BGP": null,
@@ -7192,6 +7202,7 @@
           }
         ],
         "Inet6StaticRoutes": null,
+        "UnhandledRibs": null,
         "GenerateRoutes": null,
         "ForwardingTableExport": "",
         "ForwardingTableExports": null,
@@ -7268,6 +7279,7 @@
             }
           ],
           "Inet6StaticRoutes": null,
+          "UnhandledRibs": null,
           "OSPF": null,
           "OSPFv3": null,
           "BGP": null,
@@ -8271,6 +8283,7 @@
           }
         ],
         "Inet6StaticRoutes": null,
+        "UnhandledRibs": null,
         "GenerateRoutes": null,
         "ForwardingTableExport": "",
         "ForwardingTableExports": null,
@@ -9245,6 +9258,7 @@
           }
         ],
         "Inet6StaticRoutes": null,
+        "UnhandledRibs": null,
         "GenerateRoutes": null,
         "ForwardingTableExport": "",
         "ForwardingTableExports": null,
@@ -10218,6 +10232,7 @@
           }
         ],
         "Inet6StaticRoutes": null,
+        "UnhandledRibs": null,
         "GenerateRoutes": null,
         "ForwardingTableExport": "",
         "ForwardingTableExports": null,
@@ -11191,6 +11206,7 @@
           }
         ],
         "Inet6StaticRoutes": null,
+        "UnhandledRibs": null,
         "GenerateRoutes": null,
         "ForwardingTableExport": "",
         "ForwardingTableExports": null,
@@ -12165,6 +12181,7 @@
           }
         ],
         "Inet6StaticRoutes": null,
+        "UnhandledRibs": null,
         "GenerateRoutes": null,
         "ForwardingTableExport": "",
         "ForwardingTableExports": null,
@@ -13138,6 +13155,7 @@
           }
         ],
         "Inet6StaticRoutes": null,
+        "UnhandledRibs": null,
         "GenerateRoutes": null,
         "ForwardingTableExport": "",
         "ForwardingTableExports": null,
@@ -13581,6 +13599,7 @@
       "RoutingOptions": {
         "StaticRoutes": null,
         "Inet6StaticRoutes": null,
+        "UnhandledRibs": null,
         "GenerateRoutes": null,
         "ForwardingTableExport": "",
         "ForwardingTableExports": null,
@@ -13859,6 +13878,7 @@
       "RoutingOptions": {
         "StaticRoutes": null,
         "Inet6StaticRoutes": null,
+        "UnhandledRibs": null,
         "GenerateRoutes": null,
         "ForwardingTableExport": "",
         "ForwardingTableExports": null,
@@ -14137,6 +14157,7 @@
       "RoutingOptions": {
         "StaticRoutes": null,
         "Inet6StaticRoutes": null,
+        "UnhandledRibs": null,
         "GenerateRoutes": null,
         "ForwardingTableExport": "",
         "ForwardingTableExports": null,
@@ -14482,6 +14503,7 @@
       "RoutingOptions": {
         "StaticRoutes": null,
         "Inet6StaticRoutes": null,
+        "UnhandledRibs": null,
         "GenerateRoutes": null,
         "ForwardingTableExport": "",
         "ForwardingTableExports": null,
@@ -14816,6 +14838,7 @@
       "RoutingOptions": {
         "StaticRoutes": null,
         "Inet6StaticRoutes": null,
+        "UnhandledRibs": null,
         "GenerateRoutes": null,
         "ForwardingTableExport": "",
         "ForwardingTableExports": null,
@@ -15150,6 +15173,7 @@
       "RoutingOptions": {
         "StaticRoutes": null,
         "Inet6StaticRoutes": null,
+        "UnhandledRibs": null,
         "GenerateRoutes": null,
         "ForwardingTableExport": "",
         "ForwardingTableExports": null,

--- a/pkg/config/types_routing.go
+++ b/pkg/config/types_routing.go
@@ -139,7 +139,14 @@ type RouteFilter struct {
 type RoutingOptionsConfig struct {
 	StaticRoutes      []*StaticRoute
 	Inet6StaticRoutes []*StaticRoute // rib inet6.0 static routes
-	GenerateRoutes    []*GenerateRoute
+	// UnhandledRibs records every `routing-options rib <name>` whose static
+	// routes this compiler does not implement, with how many routes were lost
+	// (#7512). It exists so the drop can be REPORTED: before #7512 the rib loop
+	// matched only the inet6 tables and every other name fell through with no
+	// branch and no else, so `rib inet.0 { static { route ... } }` compiled to
+	// nothing, committed clean, and emitted no warning.
+	UnhandledRibs  []UnhandledRib
+	GenerateRoutes []*GenerateRoute
 	// ForwardingTableExport is the SELECTED `forwarding-table export` policy —
 	// the value nodeVal takes from the first `export` leaf of the first
 	// `forwarding-table` block, re-assigned per top-level `routing-options`
@@ -730,11 +737,16 @@ type RoutingInstanceConfig struct {
 	Interfaces        []string       // interfaces belonging to this instance
 	StaticRoutes      []*StaticRoute // per-instance static routes
 	Inet6StaticRoutes []*StaticRoute // per-instance rib inet6.0 static routes
-	OSPF              *OSPFConfig    // per-instance OSPF (optional)
-	OSPFv3            *OSPFv3Config  // per-instance OSPFv3 (optional)
-	BGP               *BGPConfig     // per-instance BGP (optional)
-	RIP               *RIPConfig     // per-instance RIP (optional)
-	ISIS              *ISISConfig    // per-instance IS-IS (optional)
+	// UnhandledRibs mirrors RoutingOptionsConfig.UnhandledRibs for this
+	// instance (#7512). compileRoutingInstances copies the fields it wants off
+	// the per-instance RoutingOptionsConfig one by one, so this must be carried
+	// across explicitly or a VRF's dropped ribs go unreported.
+	UnhandledRibs []UnhandledRib
+	OSPF          *OSPFConfig   // per-instance OSPF (optional)
+	OSPFv3        *OSPFv3Config // per-instance OSPFv3 (optional)
+	BGP           *BGPConfig    // per-instance BGP (optional)
+	RIP           *RIPConfig    // per-instance RIP (optional)
+	ISIS          *ISISConfig   // per-instance IS-IS (optional)
 	// AutonomousSystem is this instance's `routing-options autonomous-system`
 	// (#3870). When the instance's BGP omits `local-as`, the BGP AS is
 	// resolved from this instance-level AS if set, else the GLOBAL
@@ -743,4 +755,14 @@ type RoutingInstanceConfig struct {
 	TableID                   int    // Linux kernel routing table number (auto-assigned)
 	InterfaceRoutesRibGroup   string // interface-routes { rib-group inet <name>; }
 	InterfaceRoutesRibGroupV6 string // interface-routes { rib-group inet6 <name>; }
+}
+
+// UnhandledRib names a `routing-options rib <name>` whose static routes the
+// compiler does not implement, and how many routes were discarded with it
+// (#7512). Only ribs that actually CARRIED routes are recorded: an empty or
+// route-less `rib` stanza loses nothing, and warning about it would be noise
+// that trains operators to ignore the warning that matters.
+type UnhandledRib struct {
+	Name   string
+	Routes int
 }


### PR DESCRIPTION
Closes #7512

## The defect

`compiler_routing.go` matched only `inet6.0` / `*.inet6.0` in the rib loop, and every other name fell through with **no branch and no `else`**. So `routing-options rib inet.0 { static { route ... } }` — the ordinary Junos way to scope IPv4 statics — compiled to **nothing**, committed clean, and emitted no warning.

The operator-realistic shape is the symmetric pair, which is exactly what someone writes once they've learned that IPv6 statics need `rib inet6.0`:

```
routing-options {
    rib inet.0  { static { route 0.0.0.0/0 { next-hop 10.0.0.1; } } }
    rib inet6.0 { static { route ::/0      { next-hop 2001:db8::1; } } }
}
```

That installed the IPv6 default route and silently lost the IPv4 one — **a total IPv4 blackhole from a clean commit**. It is invisible at every layer an operator would check: no error, no warning, and `show configuration` renders the stanza back verbatim, so it presents as a *network* problem rather than a config one. Same for `<vrf>.inet.0` inside a routing instance.

## The missing `else` is the defect; `inet.0` is one instance of it

Adding only the IPv4 branch would leave `inet.2`, `inet.3`, a typo'd `ient.0` and every future table name eating routes exactly as before. An unimplemented rib is now **recorded** (`RoutingOptionsConfig.UnhandledRibs`) and reported by `validateUnhandledRibWarnings`, naming the rib and how many routes were discarded.

**WARN, not reject — the #1960 split, not timidity.** `rib inet.2 { static { … } }` is valid Junos that xpf does not implement, and a box may already hold a committed config containing one; rejecting at strict commit would fail the tolerant load / peer-sync of a config the running node itself accepted. A warning reaches **both** paths (`ValidateConfig` runs for each), so **no `lenient*` opt is required** — the same reasoning the #3226 host-inbound parity advisories use. Both paths are asserted separately rather than assumed to agree.

Only ribs that actually **carried routes** are recorded: an empty `rib foo { }` loses nothing, and warning there would be noise that trains operators to scroll past the case that matters (#6617).

`UnhandledRibs` is carried across the VRF copy **explicitly** — `compileRoutingInstances` copies fields off the per-instance `RoutingOptionsConfig` one by one, so a routing instance's dropped ribs go unreported unless named there.

## Tests

- the same route via bare `static`, via `rib inet.0`, and via a VRF's `rib V.inet.0` must **agree with each other**, then equal the authored prefix. Agreement first: pinning one spelling to a hand-written expectation encodes which one I trusted — and here the trusted spelling (`rib inet6.0`) was the one that worked while the obvious one silently did not;
- the symmetric pair installs **both** families, asserted on both — the defect was precisely that one of them worked, so a v6-only test passes before *and* after;
- an unimplemented rib warns on the **tolerant** path **and** on **strict**, with the rib name and route count in the message;
- **the tightening control**: `inet.0`, `inet6.0`, `V.inet.0`, an empty rib, a route-less `static`, and a bare `static` must **not** warn.

## Golden

`golden_4406.json` moved and was regenerated **only after classifying the diff**: **24 keys added, all `UnhandledRibs`, all null; 0 removed, 0 values changed.** No fixture behaviour moved — the new field simply serialises. A regen without that check greens the suite either way and would have laundered a behaviour change.

## Mutation matrix

`flock`'d; tree asserted clean before and restored after, mutation asserted APPLIED, `go vet` clean before running (it compiles test files, which `go build` does not), exit code from a file, tests-collected asserted > 0.

| cell | mutation | result |
|---|---|---|
| **Q1** | revert the `inet.0` branch | RED agreement + symmetric + VRF + the no-warn control (`inet.0` falls to the default arm and starts over-warning) |
| **Q2** | delete the unhandled-rib recording (the missing `else`) | RED **only** the two warning tests |
| **Q3** | delete the per-instance `ri.UnhandledRibs` carry (**the wiring**) | RED **only** the VRF test — every global-scope test stays green, which is the point of binding the wiring rather than the callee |
| **Q4** | **TIGHTEN**: let the default arm also catch the implemented `inet.0` | RED the no-warn control (plus the install tests) |
| **Q5** | **TIGHTEN**: record a rib even when it discarded **nothing** | RED **only** the no-warn control |

**Q5 is the cell a delete-only matrix cannot see.** An over-warning implementation fires on correct configurations and is invisible to every "remove the feature" cell — and this warning will be seen by real configs, so over-warning is the failure mode that would get it disabled.

## Scope

`pkg/config` only. **No dataplane, cluster, VRRP, session-sync or failover code touched**, and no `userspace-dp` binary or shim object moved — so no cluster gate.

Validation: `go build ./...` clean; **`go test -count=1 ./...` rc=0, 0 FAIL, 71 packages** (tree-wide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkfVhT4Y3UDa22mU7uoCVt
