### PR TITLE
config: scope the DHCP host-inbound bypass argument to its plane (#7489)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103777,3 +103777,18 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: `pkg/cluster/heartbeat_epoch.go`, `pkg/cluster/heartbeat.go`,
   `pkg/cluster/manager.go`,
   `pkg/cluster/heartbeat_epoch_persist_retry_6724_test.go` (new)
+
+## 2026-08-22 — #7489 the #6460 bypass argument covered only one plane
+- **Action**: The #6460 DHCP host-inbound advisory told the operator the token
+  gates nothing on v4 because "the AF_PACKET tap is upstream of netfilter" — an
+  argument about ONE of two enforcement planes. The AF_XDP userspace dataplane
+  enforces host-inbound fail-closed on local delivery, and a packet dropped there
+  never reaches the kernel, so AF_PACKET cannot see it (MEASURED on the loss
+  userspace cluster: +22 denies, 0 packets on `tcpdump -ni any`). The advisory's
+  CONCLUSION survives — a DHCPv4 request is a 255.255.255.255 broadcast, which
+  the shim hands to the kernel before userspace — but the reasoning was too
+  broad. Message and header now name the destination and both planes; the doc
+  records the measurement and the interface-mode-SNAT exception.
+- **File(s)**: `pkg/config/compiler_validate_warn_dhcp_hostinbound.go`,
+  `pkg/config/dhcp_hostinbound_plane_scope_7489_test.go` (new),
+  `docs/host-inbound-multicast.md`

--- a/docs/host-inbound-multicast.md
+++ b/docs/host-inbound-multicast.md
@@ -101,14 +101,45 @@ which — an operator told the wrong reason reaches for the wrong remedy:
 
 | Family | Why the zone token does not bound it |
 |---|---|
-| DHCPv4 (`dhcp`) | xpf renders Kea's `Dhcp4` with **no** `dhcp-socket-type` key (`pkg/dhcpserver/dhcpserver.go` emits `interfaces-config` with an `interfaces` list and nothing else), so Kea's default `raw` applies. The server receives on an **AF_PACKET** socket, which is delivered **before** the netfilter input hook — the `xpf_hostinbound` chain never sees the request at all. |
+| DHCPv4 (`dhcp`) | **Two planes, both bypassed (#7489).** (1) A client addresses its DISCOVER/REQUEST to the **255.255.255.255 broadcast**, and `should_fallback_early` (`userspace-xdp/src/lib.rs`) hands `dst_v4 == 0xffff_ffff` straight to the kernel — the request never enters the AF_XDP userspace dataplane or its host-inbound gate. (2) xpf renders Kea's `Dhcp4` with **no** `dhcp-socket-type` key (`pkg/dhcpserver/dhcpserver.go` emits `interfaces-config` with an `interfaces` list and nothing else), so Kea's default `raw` applies and the server receives on an **AF_PACKET** socket, delivered **before** the netfilter input hook. |
 | DHCPv6 (`dhcpv6`) | Kea's `Dhcp6` has no raw mode, but a client addresses the server at the **ff02::1:2** multicast group. Every per-zone host-inbound rule — the accepts AND the #3361 catch-all deny — is scoped `<fam> daddr <zone unicast addrs>` (`pkg/nftables/netlink_hostinbound.go`, `emitHostInboundZoneNetlink`), so a multicast destination matches neither and falls through the base chain's `policy accept` (`pkg/nftables/netlink_installer.go`). This is the same fall-through the routing-multicast gap above rides. |
 
 The remedy in the message deliberately leads with **removing the interface from
 the group**, not with adding the token: adding the token cannot enforce anything
-on the v4 path (the AF_PACKET tap is upstream of netfilter), so presenting it as
-*the fix* would restate the same false signal in a new place. The token is
+on the DHCP server's request path (both planes above are bypassed), so presenting
+it as *the fix* would restate the same false signal in a new place. The token is
 offered only as a way to record that the segment is meant to be served.
+
+### Scope of the bypass argument — do not generalise it (#7489)
+
+"The AF_PACKET tap is upstream of netfilter" is an argument about **one** plane,
+and it does **not** establish that a host-inbound token is inert for v4 traffic
+at large. The AF_XDP userspace dataplane enforces host-inbound itself,
+**fail-closed**, on the local-delivery path (`host_inbound_gated_lo0_action`,
+`userspace-dp/src/afxdp/poll_descriptor/filter.rs`), and a packet dropped there
+never reaches the kernel on any device — so an AF_PACKET tap cannot see it.
+
+**Measured** on the loss userspace cluster: 20 unicast datagrams to an
+interface-mode-SNAT address, on a port the arrival zone did not admit, produced
+**+22 host-inbound denies and ZERO packets on `tcpdump -ni any`**, with a
+same-host ping (which the zone *does* admit) answering normally.
+
+What decides which plane applies is the **destination**, not the port. On a
+session miss the shim steers on address alone — `should_fallback_early`, then
+`is_local_destination`, which deliberately returns false for an address in
+`USERSPACE_INTERFACE_NAT_V4` ("the common WAN case"). So:
+
+| v4 destination | plane | host-inbound token |
+|---|---|---|
+| `255.255.255.255` (DHCP DISCOVER) | kernel, via the shim's early fallback | inert — this advisory's subject |
+| ordinary local unicast | kernel, via `is_local_destination` | inert on the userspace plane |
+| unicast to an **interface-mode-SNAT** address | **redirected to the AF_XDP dataplane** | **load-bearing, fail-closed** |
+
+The third row is not this advisory's subject, but the sentence above was being
+read as covering it. A DHCP **client** on such an interface receives its
+RENEWING-state ACK as a unicast to that address; whether that specific frame
+loses its lease when the token is absent was **not** measured and is not claimed
+here.
 
 Zone attribution and effective-admission resolution reuse the same two SSOTs
 Component B uses (`zoneIfaceLogicalKeys`, `ZoneConfig.InterfaceHostInboundEffective`),

--- a/pkg/config/compiler_validate_warn_dhcp_hostinbound.go
+++ b/pkg/config/compiler_validate_warn_dhcp_hostinbound.go
@@ -23,15 +23,27 @@ import (
 // reasons, and the message says which, because an operator who is told the wrong
 // reason will reach for the wrong remedy.
 //
-//   - DHCPv4 (`system services dhcp-local-server`) — xpf renders Kea's Dhcp4
-//     with no `dhcp-socket-type` key (pkg/dhcpserver/dhcpserver.go builds
-//     `interfaces-config` with an `interfaces` list and nothing else), so Kea's
-//     default `raw` applies and the server receives on an AF_PACKET socket.
-//     AF_PACKET delivery happens BEFORE the netfilter input hook, so the
-//     `xpf_hostinbound` chain cannot gate it AT ALL. This is not a
-//     matched-the-wrong-rule case: the packet never reaches the chain. Adding
-//     the token does not change that; it only makes the config stop claiming
-//     otherwise.
+//   - DHCPv4 (`system services dhcp-local-server`) — TWO planes have to be
+//     accounted for, and #7489 corrected this entry because it originally named
+//     only one.
+//
+//     Plane 1, the XDP shim: a client's DISCOVER/REQUEST is addressed to the
+//     255.255.255.255 BROADCAST, and `should_fallback_early`
+//     (userspace-xdp/src/lib.rs) hands `dst_v4 == 0xffff_ffff` straight to the
+//     kernel. So the request never enters the AF_XDP userspace dataplane and
+//     never reaches its host-inbound gate.
+//
+//     Plane 2, netfilter: xpf renders Kea's Dhcp4 with no `dhcp-socket-type`
+//     key (pkg/dhcpserver/dhcpserver.go builds `interfaces-config` with an
+//     `interfaces` list and nothing else), so Kea's default `raw` applies and
+//     the server receives on an AF_PACKET socket. AF_PACKET delivery happens
+//     BEFORE the netfilter input hook, so the `xpf_hostinbound` chain cannot
+//     gate it either.
+//
+//     Both planes are bypassed, so the token really does gate nothing for THIS
+//     traffic — but the reason is the broadcast destination as much as the
+//     socket type, and the two are not interchangeable. See the scope note
+//     below before reusing this argument.
 //
 //   - DHCPv6 (`system services dhcpv6-local-server`) — Kea's Dhcp6 has no raw
 //     mode; it receives on UDP. But a client's Solicit/Request is addressed to
@@ -64,11 +76,30 @@ import (
 // token serves addresses, gateway and DNS to anything on that segment.
 //
 // THE REMEDY IS DELIBERATELY NOT "ADD THE TOKEN". Adding the token silences
-// nothing real on v4 — it cannot, the AF_PACKET tap is upstream of netfilter —
-// so telling the operator to add it as a FIX would be the same false signal in a
-// new place. The message names both moves and labels them: remove the interface
-// from the group (the move that actually stops serving that segment), or add the
-// token to record the intent that the segment IS served.
+// nothing real FOR THE DHCP SERVER'S REQUEST PATH — both planes above are
+// bypassed — so telling the operator to add it as a FIX would be the same false
+// signal in a new place. The message names both moves and labels them: remove
+// the interface from the group (the move that actually stops serving that
+// segment), or add the token to record the intent that the segment IS served.
+//
+// SCOPE, and do not generalise past it (#7489). "The AF_PACKET tap is upstream
+// of netfilter" is an argument about ONE plane and does NOT establish that a
+// host-inbound token is inert for v4 traffic at large. The AF_XDP userspace
+// dataplane enforces host-inbound itself, fail-closed, on the local-delivery
+// path (`host_inbound_gated_lo0_action`, userspace-dp poll_descriptor/filter.rs),
+// and a packet dropped there never reaches the kernel on any device — so
+// AF_PACKET cannot rescue it. MEASURED on the loss userspace cluster: 20
+// unicast datagrams to an interface-mode-SNAT address on a port the arrival
+// zone did not admit produced +22 host-inbound denies and ZERO packets on
+// `tcpdump -ni any`, with a same-host ping (admitted) answering normally.
+//
+// What decides which plane applies is the DESTINATION, not the port: on a
+// session miss the shim steers on address alone (`should_fallback_early`, then
+// `is_local_destination`, which deliberately returns false for an address in
+// `USERSPACE_INTERFACE_NAT_V4` — "the common WAN case"). A broadcast DISCOVER
+// goes to the kernel; a unicast to an interface-mode-SNAT address is redirected
+// into userspace and IS gated. That second case is not this advisory's subject,
+// but the sentence above was being read as covering it.
 //
 // SCOPE. Interfaces only; a group with no interfaces binds nothing. An interface
 // in no zone has no host-inbound dimension and is not reported (the zone lookup
@@ -101,9 +132,11 @@ func validateDHCPServerHostInboundBypassWarnings(cfg *Config) []string {
 			srv:    cfg.System.DHCPServer.DHCPLocalServer,
 			stanza: "dhcp-local-server",
 			token:  "dhcp",
-			whyOpen: "the DHCPv4 server (Kea) receives on an AF_PACKET raw socket, which is " +
-				"delivered BEFORE the netfilter input hook, so the host-inbound chain never " +
-				"sees the request",
+			whyOpen: "a DHCPv4 client addresses the server at the 255.255.255.255 broadcast, " +
+				"which the XDP shim hands to the kernel without entering the userspace " +
+				"dataplane, and Kea then receives it on an AF_PACKET raw socket delivered " +
+				"BEFORE the netfilter input hook — so neither host-inbound plane sees the " +
+				"request",
 		},
 		{
 			srv:    cfg.System.DHCPServer.DHCPv6LocalServer,

--- a/pkg/config/dhcp_hostinbound_plane_scope_7489_test.go
+++ b/pkg/config/dhcp_hostinbound_plane_scope_7489_test.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #7489 — the #6460 advisory's bypass argument covered only ONE of the two
+// host-inbound enforcement planes.
+//
+// Its message told the operator the DHCP server answers "REGARDLESS of the
+// zone's host-inbound set, because the DHCPv4 server (Kea) receives on an
+// AF_PACKET raw socket ... delivered BEFORE the netfilter input hook". That is
+// an argument about netfilter. xpf also enforces host-inbound in the AF_XDP
+// userspace dataplane, fail-closed, on the local-delivery path — and a packet
+// dropped THERE never reaches the kernel on any device, so AF_PACKET cannot
+// rescue it (measured: 20 unicast datagrams to an interface-mode-SNAT address
+// on an unadmitted port produced +22 host-inbound denies and zero packets on
+// `tcpdump -ni any`).
+//
+// The conclusion for THIS advisory survives, because a DHCPv4 request is
+// addressed to the 255.255.255.255 broadcast and `should_fallback_early` hands
+// that to the kernel before userspace. The reasoning did not: the operator was
+// given a general-sounding rule that is false off the broadcast path.
+//
+// This is a wording/scope defect in operator guidance, so the guard is on the
+// wording. It asserts the message names the DESTINATION — the thing that
+// actually decides which plane applies — rather than resting on the socket type
+// alone.
+
+func dhcpBypassWarning7489(t *testing.T) string {
+	t.Helper()
+	tree := buildTree(t, []string{
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.9.1/24",
+		"set security zones security-zone lan interfaces ge-0/0/1.0",
+		"set security zones security-zone lan host-inbound-traffic system-services ping",
+		"set system services dhcp-local-server group g interface ge-0/0/1.0",
+		"set system services dhcp-local-server group g pool p subnet 10.0.9.0/24",
+		"set system services dhcp-local-server group g pool p address-range low 10.0.9.10 high 10.0.9.99",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	var got string
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#6460") {
+			got = w
+			break
+		}
+	}
+	if got == "" {
+		t.Fatalf("precondition: the #6460 advisory must fire on a dhcp-local-server group whose "+
+			"zone omits `dhcp`; without it this test asserts nothing. warnings=%v", cfg.Warnings)
+	}
+	return got
+}
+
+// TestDHCPBypassMessageNamesTheDestinationNotOnlyTheSocket7489 is the guard.
+//
+// FAIL-ON-REVERT: restore the pre-#7489 v4 sentence ("the DHCPv4 server (Kea)
+// receives on an AF_PACKET raw socket, which is delivered BEFORE the netfilter
+// input hook, so the host-inbound chain never sees the request") and this reds:
+// it names one plane and no destination.
+func TestDHCPBypassMessageNamesTheDestinationNotOnlyTheSocket7489(t *testing.T) {
+	msg := dhcpBypassWarning7489(t)
+
+	if !strings.Contains(msg, "255.255.255.255") {
+		t.Fatalf("the v4 bypass sentence must name the BROADCAST destination. That is what "+
+			"decides which enforcement plane applies: on a session miss the XDP shim steers "+
+			"on destination address alone, so a broadcast DISCOVER goes to the kernel while "+
+			"a unicast to an interface-mode-SNAT address is redirected into the userspace "+
+			"dataplane and IS gated fail-closed. Resting the claim on the socket type alone "+
+			"gives the operator a rule that is false off the broadcast path (#7489).\ngot: %s", msg)
+	}
+	if !strings.Contains(msg, "userspace") {
+		t.Fatalf("the v4 bypass sentence must account for the userspace dataplane plane, not "+
+			"only netfilter (#7489).\ngot: %s", msg)
+	}
+	// The netfilter half is still true and must not be dropped in the process —
+	// Kea really does read from AF_PACKET, upstream of the input hook.
+	if !strings.Contains(msg, "AF_PACKET") || !strings.Contains(msg, "netfilter") {
+		t.Fatalf("the netfilter half of the argument is still correct and must survive the "+
+			"rewording; dropping it would trade one incomplete explanation for another.\ngot: %s", msg)
+	}
+}
+
+// TestDHCPBypassMessageMakesNoUnscopedV4Claim7489 is the over-correction guard.
+// The fix must not turn into "the token DOES gate the server", which would be
+// wrong in the other direction and would tell the operator to add a token that
+// still changes nothing for this traffic.
+func TestDHCPBypassMessageMakesNoUnscopedV4Claim7489(t *testing.T) {
+	msg := dhcpBypassWarning7489(t)
+	if !strings.Contains(msg, "REGARDLESS") {
+		t.Fatalf("the advisory's conclusion is unchanged and must stay: for the DHCP server's "+
+			"broadcast request path the zone stanza genuinely does not bound it. Only the "+
+			"REASONING was too broad (#7489).\ngot: %s", msg)
+	}
+	if strings.Contains(msg, "add `host-inbound-traffic system-services dhcp` to fix") {
+		t.Fatalf("the remedy must not become \"add the token\": it silences nothing for this "+
+			"traffic, which is the false signal #6460 exists to avoid.\ngot: %s", msg)
+	}
+}


### PR DESCRIPTION
Closes #7489

## The defect: a two-plane system explained with a one-plane argument

The #6460 advisory told the operator a zone's host-inbound token gates nothing
for a DHCPv4 server because

> "the DHCPv4 server (Kea) receives on an AF_PACKET raw socket, which is
> delivered BEFORE the netfilter input hook"

and its header generalised that to *"Adding the token silences nothing real on
v4 — it cannot, the AF_PACKET tap is upstream of netfilter."*

That is an argument about **one** enforcement plane. xpf has two. The AF_XDP
userspace dataplane enforces host-inbound itself, **fail-closed**, on the
local-delivery path (`host_inbound_gated_lo0_action`,
`userspace-dp/src/afxdp/poll_descriptor/filter.rs`), and a packet dropped there
never reaches the kernel on any device — so an AF_PACKET tap cannot rescue it.
CLAUDE.md is explicit that AF_XDP is the only runtime forwarding path, which
makes that the primary plane rather than a corner case.

## Measured, not argued

On the loss userspace cluster: 20 unicast datagrams to an **interface-mode-SNAT**
address, on a port the arrival zone did not admit —

```
Host-inbound denies:  121  ->  143      (+22; background is ~1/interval)
tcpdump -ni any -c 40 udp port 9999:  0 captured
positive control ping (admitted):     5/5, 0% loss
```

**A userspace host-inbound denial is invisible to AF_PACKET.**

## This is a scope fix, NOT a reversal

The advisory's **conclusion survives intact**. A DHCPv4 client addresses its
DISCOVER/REQUEST to the 255.255.255.255 broadcast, and `should_fallback_early`
(`userspace-xdp/src/lib.rs`) hands `dst_v4 == 0xffff_ffff` straight to the kernel
— so the request never enters the userspace dataplane. **Both** planes really are
bypassed for this traffic, and "don't add the token expecting it to gate your
DHCP server" remains correct.

What was wrong is the **reason**, and the reason is load-bearing: an operator who
takes "the tap is upstream of netfilter" as a general v4 rule, and removes a
zone-level token from an interface whose address is under interface-mode SNAT,
loses traffic the userspace gate then drops.

## The destination decides the plane — not the port, not the socket type

On a session miss the shim steers on address alone: `should_fallback_early`, then
`is_local_destination`, which deliberately returns false for an address in
`USERSPACE_INTERFACE_NAT_V4` — described in that code as *"the common WAN case"*.

| v4 destination | plane | token |
|---|---|---|
| `255.255.255.255` (DHCP DISCOVER) | kernel, via the shim's early fallback | inert — this advisory's subject |
| ordinary local unicast | kernel, via `is_local_destination` | inert on the userspace plane |
| unicast to an **interface-mode-SNAT** address | **redirected to the AF_XDP dataplane** | **load-bearing, fail-closed** |

## Deliberately NOT claimed

That a real DHCP client on a SNAT WAN loses its lease when the token is absent.
That its RENEWING-state ACK arrives as a unicast session-miss to that address
follows from `nclient4`'s AF_PACKET request path, but **no run exercised it**. The
docs say so explicitly rather than letting a reader infer it.

A follow-up experiment was **declined** rather than run: closing that gap needs
either a WAN-segment host or an edit to the shared cluster's `lan` zone — whose
own comment says it must admit `dhcp` for the local server — and the discriminator
is already readable in the source. The measured run used udp/9999 rather than
udp/68, which covers the DHCP unicast case **by construction**: on a session miss,
with WireGuard off, the destination port is not consulted anywhere in the shim's
steering decision.

## Guards

The defect is in operator guidance, so the guards are on the wording:

- one asserts the message names the **destination** and both planes — resting the
  claim on the socket type alone is what made it over-broad;
- one asserts the fix did **not** over-correct into "add the token", which would
  be wrong in the opposite direction and would restate the false signal #6460
  exists to avoid.

Restoring the **verbatim** pre-fix sentence reds the first on its own assertion.

## Validation

- `go build ./...`, `gofmt`, `go vet` clean.
- **`go test -count=1 ./...` green repo-wide, rc=0, 71 packages, zero failures.**

One process note worth recording: an earlier revision of this commit contained
the tests and docs but **not the production fix** — `git checkout --` after the
mutation cell reverted the then-unstaged edit. The repo-wide gate caught it
(`pkg/config` red on my own new test); a touched-file-only check would not have.
Re-applied and amended.

## Cluster surface

None in this diff — `pkg/config` compile-time advisory text plus its doc. **Does
not owe `make test-failover`.** (The measurement behind it was run on the cluster
by the cluster-owning lane, not from here.)

Refs #6460, #6519, #3485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VM24XVAYBhzAUSAAhnR8Xp
