### PR TITLE
ddns: rebuild a bound HTTP client when its resolved device changes

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103871,3 +103871,13 @@ prose edit above them added. No diff falls in the new test body.
   RG + barrier wait, then stopClusterComms) ahead of the teardown.
 - **File(s)**: pkg/daemon/bootstrap.go,
   pkg/daemon/bootstrap_cluster_relinquish_6742_test.go
+
+## 2026-08-22 — #6754 DDNS client cache validates the resolved bind device
+- **Timestamp**: 2026-08-22
+- **Action**: httpClientCache keyed on the raw binding leaves while the bound
+  device is resolved from the whole committed config, so a reth member move
+  left SO_BINDTODEVICE on the old device with the key unchanged. Cache entries
+  now carry the resolved bindConfig and a hit rebuilds when it differs,
+  releasing the superseded transport the #2956 reap could never collect.
+- **File(s)**: pkg/ddns/backend_http.go,
+  pkg/ddns/httpcache_resolved_bind_6754_test.go

--- a/pkg/ddns/backend_http.go
+++ b/pkg/ddns/backend_http.go
@@ -419,7 +419,27 @@ func redirectHost(u *url.URL) string {
 // bounding the map to current config under binding churn.
 type httpClientCache struct {
 	mu      sync.Mutex
-	clients map[string]*http.Client
+	clients map[string]*cachedBoundClient
+}
+
+// cachedBoundClient is a cached client plus the RESOLVED binding it was built
+// with (#6754).
+//
+// The cache key stays the raw config leaves so the #2956 reap stays consistent,
+// but the value a client is actually bound to is resolved — bindDevice comes
+// from config.ResolveKernelIfName, whose output is a function of the WHOLE
+// committed config (reth→physical member, the tunnel name map, the IRB→bridge
+// map, SecureTunnelUnitNetdev, unit-vs-vlan-id). So the resolved device can
+// change while all three key leaves stay byte-identical: move reth0's active
+// member and `destination-interface reth0.50` keeps its key and silently keeps
+// SO_BINDTODEVICE on the OLD physical device.
+//
+// Holding the resolved binding alongside the client lets a hit verify that the
+// resolution still matches before reusing the pool, which is the check the raw
+// key structurally cannot make.
+type cachedBoundClient struct {
+	client *http.Client
+	bind   bindConfig
 }
 
 // closeIdleConns is the seam reap uses to drop a superseded client's keep-alive
@@ -430,7 +450,7 @@ var closeIdleConns = func(cl *http.Client) { cl.CloseIdleConnections() }
 
 // newHTTPClientCache builds an empty per-binding client cache.
 func newHTTPClientCache() *httpClientCache {
-	return &httpClientCache{clients: map[string]*http.Client{}}
+	return &httpClientCache{clients: map[string]*cachedBoundClient{}}
 }
 
 // bindCacheKey is the stable cache key for a provider's source binding. It is
@@ -468,11 +488,20 @@ func (c *httpClientCache) clientFor(p *config.DDNSProvider, resolveIf ...func(st
 	key := bindCacheKey(p)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if cl, ok := c.clients[key]; ok {
-		return cl, nil
+	if ent, ok := c.clients[key]; ok {
+		if ent.bind == b {
+			return ent.client, nil
+		}
+		// #6754: same raw leaves, DIFFERENT resolved binding. The old client's
+		// SO_BINDTODEVICE points at a device this provider no longer egresses
+		// from, so reusing it would keep publishing from the wrong interface
+		// with no error anywhere. Release its idle pool — the reap keys on the
+		// binding leaves, which have NOT changed, so it would never collect
+		// this transport — and rebuild.
+		closeIdleConns(ent.client)
 	}
 	cl := newHTTPClientBound(b)
-	c.clients[key] = cl
+	c.clients[key] = &cachedBoundClient{client: cl, bind: b}
 	return cl, nil
 }
 
@@ -492,11 +521,11 @@ func (c *httpClientCache) reap(live map[string]struct{}) {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	for key, cl := range c.clients {
+	for key, ent := range c.clients {
 		if _, ok := live[key]; ok {
 			continue
 		}
-		closeIdleConns(cl)
+		closeIdleConns(ent.client)
 		delete(c.clients, key)
 	}
 }

--- a/pkg/ddns/httpcache_resolved_bind_6754_test.go
+++ b/pkg/ddns/httpcache_resolved_bind_6754_test.go
@@ -1,0 +1,169 @@
+package ddns
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6754: the HTTP DDNS client cache keys on the RAW binding leaves, but the
+// device a client is actually bound to is RESOLVED — bindDevice comes from
+// config.ResolveKernelIfName, whose output is a function of the whole committed
+// config (reth→physical member, the tunnel name map, the IRB→bridge map,
+// SecureTunnelUnitNetdev, unit-vs-vlan-id).
+//
+// So the resolved device can change while all three key leaves stay
+// byte-identical: move reth0's active member and `destination-interface
+// reth0.50` keeps its key, keeps its cached client, and silently keeps
+// SO_BINDTODEVICE on the OLD physical device. Nothing errors — the publish just
+// egresses from the wrong interface.
+//
+// The cache key is deliberately NOT changed to the resolved value: the #2956
+// reap keys on the binding leaves, and re-keying would decouple the two. The
+// fix validates the resolution on a HIT instead, which is the check the raw key
+// structurally cannot make.
+
+// resolverReturning6754 is a committed-config interface resolver whose answer
+// the test can change between calls, standing in for a commit that moves a
+// reth's active member without touching any DDNS binding leaf.
+func resolverReturning6754(dev *string) func(string) string {
+	return func(string) string { return *dev }
+}
+
+// TestChangedResolutionRebuildsTheBoundClient6754 is the defect proper.
+func TestChangedResolutionRebuildsTheBoundClient6754(t *testing.T) {
+	c := newHTTPClientCache()
+	dev := "eth0"
+	p := &config.DDNSProvider{
+		Name: "p", Backend: "generic", DestinationInterface: "reth0.50",
+	}
+
+	first, err := c.clientFor(p, resolverReturning6754(&dev))
+	if err != nil {
+		t.Fatalf("clientFor (first): %v", err)
+	}
+
+	// Same provider, same leaves, same cache key — but the committed config now
+	// resolves reth0.50 to a different physical member.
+	if got := bindCacheKey(p); got != bindCacheKey(p) {
+		t.Fatal("precondition: the cache key must be stable across the change")
+	}
+	dev = "eth1"
+
+	second, err := c.clientFor(p, resolverReturning6754(&dev))
+	if err != nil {
+		t.Fatalf("clientFor (second): %v", err)
+	}
+
+	if second == first {
+		t.Errorf("the cached client was reused after the RESOLVED bind device changed " +
+			"eth0 -> eth1 with every raw binding leaf unchanged: the provider keeps " +
+			"publishing with SO_BINDTODEVICE on the old device, and nothing reports it")
+	}
+
+	// And the rebuilt client must be the one now cached — a rebuild that does not
+	// replace the entry would rebuild on EVERY call, throwing away the keep-alive
+	// pool #2904 exists to preserve.
+	third, err := c.clientFor(p, resolverReturning6754(&dev))
+	if err != nil {
+		t.Fatalf("clientFor (third): %v", err)
+	}
+	if third != second {
+		t.Errorf("the rebuilt client was not cached: a stable resolution rebuilt again "+
+			"(%p then %p), which discards the connection pool on every publish", second, third)
+	}
+	if c.size() != 1 {
+		t.Errorf("cache size = %d, want 1 — the rebuild must REPLACE the entry under the "+
+			"same key, not accumulate one per resolution", c.size())
+	}
+}
+
+// TestStaleTransportIsReleasedOnRebuild6754 pins the leak half. The #2956 reap
+// keys on the binding leaves, which have NOT changed here, so it would never
+// collect the superseded transport — the rebuild has to release it.
+func TestStaleTransportIsReleasedOnRebuild6754(t *testing.T) {
+	var closed []*http.Client
+	orig := closeIdleConns
+	closeIdleConns = func(cl *http.Client) { closed = append(closed, cl); orig(cl) }
+	defer func() { closeIdleConns = orig }()
+
+	c := newHTTPClientCache()
+	dev := "eth0"
+	p := &config.DDNSProvider{Name: "p", Backend: "generic", DestinationInterface: "reth0.50"}
+
+	first, err := c.clientFor(p, resolverReturning6754(&dev))
+	if err != nil {
+		t.Fatalf("clientFor (first): %v", err)
+	}
+	dev = "eth1"
+	if _, err := c.clientFor(p, resolverReturning6754(&dev)); err != nil {
+		t.Fatalf("clientFor (second): %v", err)
+	}
+
+	found := false
+	for _, cl := range closed {
+		if cl == first {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the superseded client's idle pool was not released on rebuild. Its cache " +
+			"key is unchanged, so the #2956 reap will never collect it — the stale " +
+			"*http.Transport lingers for the daemon lifetime")
+	}
+}
+
+// TestUnchangedResolutionKeepsThePool6754 is the TIGHTENING control.
+//
+// A "fix" that rebuilt on every call would satisfy both tests above while
+// destroying the #2904 keep-alive pool the cache exists for — the Surface A
+// reconcile loop calls clientFor every pass. This pins the other side: a stable
+// resolution must return the SAME client, and must not close anything.
+func TestUnchangedResolutionKeepsThePool6754(t *testing.T) {
+	var closed []*http.Client
+	orig := closeIdleConns
+	closeIdleConns = func(cl *http.Client) { closed = append(closed, cl); orig(cl) }
+	defer func() { closeIdleConns = orig }()
+
+	c := newHTTPClientCache()
+	dev := "eth0"
+	p := &config.DDNSProvider{Name: "p", Backend: "generic", DestinationInterface: "reth0.50"}
+
+	var prev *http.Client
+	for i := 0; i < 5; i++ {
+		cl, err := c.clientFor(p, resolverReturning6754(&dev))
+		if err != nil {
+			t.Fatalf("clientFor (pass %d): %v", i, err)
+		}
+		if prev != nil && cl != prev {
+			t.Fatalf("pass %d rebuilt the client although the resolution never changed: the "+
+				"Surface A reconcile calls this every pass, so this throws away the "+
+				"keep-alive connection pool #2904 exists to preserve", i)
+		}
+		prev = cl
+	}
+	if len(closed) != 0 {
+		t.Errorf("closed %d idle pools with no resolution change, want 0", len(closed))
+	}
+}
+
+// TestUnboundProviderIsUnaffected6754 pins that the no-binding path — the common
+// case, where there is nothing to resolve — still caches on the empty key.
+func TestUnboundProviderIsUnaffected6754(t *testing.T) {
+	c := newHTTPClientCache()
+	p := &config.DDNSProvider{Name: "p", Backend: "generic"}
+
+	a, err := c.clientFor(p)
+	if err != nil {
+		t.Fatalf("clientFor: %v", err)
+	}
+	b, err := c.clientFor(p)
+	if err != nil {
+		t.Fatalf("clientFor (2): %v", err)
+	}
+	if a != b {
+		t.Error("an unbound provider rebuilt its client between calls; there is no resolution " +
+			"to change, so the cache must be a straight hit")
+	}
+}


### PR DESCRIPTION
Closes #6754

`httpClientCache` keys on the **raw** binding leaves — `source-address`, `destination-interface`, `routing-instance` — but the device a client is actually bound to is **resolved** through `config.ResolveKernelIfName`, whose output is a function of the **whole committed config**: reth→physical member, the tunnel name map, the IRB→bridge map, `SecureTunnelUnitNetdev`, unit-vs-vlan-id.

So the resolved device can change while all three key leaves stay byte-identical. Move reth0's active member and a provider bound to `destination-interface reth0.50` keeps its cache key, keeps its cached client, and silently keeps `SO_BINDTODEVICE` on the **old** physical device. The publish still succeeds — it just leaves by the wrong interface, and nothing reports it.

`clientFor` already resolved the binding on every call and then **discarded it on a hit**. Cache entries now carry the resolved `bindConfig` alongside the client, and a hit compares it: equal reuses the pool, different rebuilds.

## The cache key is deliberately unchanged

The obvious fix is to key on the resolved value. That would decouple the cache from the #2956 reap, which keys on the binding leaves — and the existing code says so explicitly: *"The cache KEY stays the raw binding leaves (bindCacheKey) so the #2956 reap stays consistent."* The hazard is a consequence of that choice, not a bug in it, so the fix validates on hit rather than re-keying.

That has a corollary worth stating: because the key has **not** changed, the reap can never collect a transport superseded this way. So the rebuild releases the old client's idle pool itself, and there is a test for it.

## Mutation matrix

Fix committed first, so the applied-check and restore are well defined. Full `pkg/ddns` suite per cell, no `-run` filter, rc from a file, control green first.

| # | mutation | rc | fired |
|---|---|---|---|
| T1 | revert: a hit always reuses | 1 | rebuild guard + leak guard |
| T2 | **TIGHTEN**: always rebuild | 1 | my control **plus 5 pre-existing tests** |
| T3 | rebuild but do not release the superseded transport | 1 | leak guard **only** — localises |

**T2 is the cell that matters.** A fix that simply rebuilt every time would satisfy the defect test while destroying the #2904 keep-alive pool the cache exists for — the Surface A reconcile calls `clientFor` every pass. It reds `TestSurfaceAHTTPClientReusedAcrossPasses`, `...AcrossDifferentProvidersSameBinding`, `...RebuiltWhenBindingChanges`, `TestSurfaceACheckIPClientReused` and `TestHTTPClientCacheReapClosesSupersededTransport` — all of which predate this work. The keep-alive property was already guarded; the tightening control just makes that visible rather than relying on it.

## Validation

`go build`, `go vet`, `gofmt` clean; `go test -count=1 ./...` green repo-wide.

No cluster/VRRP/session-sync/failover code; no `userspace-dp` binary or shim `.o` moved. Go only, `pkg/ddns`.
