### PR TITLE
config: single-source the management-interface class (#7515)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103871,3 +103871,20 @@ prose edit above them added. No diff falls in the new test body.
   RG + barrier wait, then stopClusterComms) ahead of the teardown.
 - **File(s)**: pkg/daemon/bootstrap.go,
   pkg/daemon/bootstrap_cluster_relinquish_6742_test.go
+
+## 2026-08-22 — #7515 single-source the management-interface class
+- **Action**: `config.IsManagementIfName` is now the SSOT for the fxp/fab/em
+  class, previously restated VERBATIM at three sites: the daemon's management-VRF
+  set (`managementVRFIfaceSet`, extracted for testability), the networkd `VRF=`
+  emitter, and the ip-monitoring next-hop validator. Semantics preserved exactly
+  — no behaviour change. `isCanonicalFabricName` now calls the shared
+  `ifNameNumericSuffix` instead of carrying a second copy of the same formula.
+  Corrected the issue's premise: `emu0` IS management today (the daemon binds it
+  to vrf-mgmt via the same prefix), so the ip-monitoring refusal was truthful;
+  narrowing the class is a behaviour decision, filed separately.
+- **File(s)**: `pkg/config/ifname_class_6731.go`, `pkg/config/lifeline.go`,
+  `pkg/config/compiler_services.go`, `pkg/daemon/daemon_apply_interfaces.go`,
+  `pkg/dataplane/compiler_iface.go`,
+  `pkg/config/mgmt_ifname_ssot_7515_test.go` (new),
+  `pkg/daemon/mgmt_vrf_ifaceset_ssot_7515_test.go` (new),
+  `pkg/dataplane/mgmt_vrf_networkd_ssot_7515_test.go` (new), `docs/multi-wan.md`

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -648,7 +648,17 @@ routing, and only on double fault).
 
   The named unit must be configured with `family inet dhcp` (Junos
   configured name, `<ifd>.<unit>`; v4 destinations only; management
-  interfaces rejected). Tunnel and loopback interfaces are rejected too
+  interfaces rejected). "Management interface" is
+  `config.IsManagementIfName` (#7515) — the SAME predicate the daemon uses
+  to build the `vrf-mgmt` interface set and the networkd `VRF=` emitter
+  uses to write the stanza. That agreement is the whole basis of the
+  refusal: the lease is excluded from FRR by `collectDHCPRoutes` precisely
+  BECAUSE the interface is in that set, so a next-hop through it could
+  never resolve. The rule was previously restated verbatim at all three
+  sites; it is a bare `fxp`/`fab`/`em` prefix today, so `fabric0` and
+  `emu0` ARE management interfaces and are refused truthfully. Narrowing
+  the class would change which DHCP routes FRR owns and is a deliberate
+  behaviour decision, now a single edit in one place. Tunnel and loopback interfaces are rejected too
   — a DHCP client can never acquire a lease on one, so accepting it
   would only manufacture a permanently-unresolvable route. That test is
   a NAME CLASS, `IsTunnelOrLoopbackIfName`, not a raw prefix match

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -1071,8 +1071,11 @@ func resolveIPMonitoringInterfaceNextHop(cfg *Config, polName string, pr *Prefer
 		return "", fmt.Errorf("services ip-monitoring policy %q route %s: next-hop %q is not a valid IP address or DHCP interface unit (interface units use the configured Junos name, e.g. ge-0/0/3.0)",
 			polName, pr.Destination, val)
 	}
-	if strings.HasPrefix(ifdName, "fxp") || strings.HasPrefix(ifdName, "em") ||
-		strings.HasPrefix(ifdName, "fab") {
+	// #7515: IsManagementIfName is the SSOT this must agree with. This refusal is
+	// only truthful while it matches the class the daemon actually binds to
+	// vrf-mgmt — that binding is WHY the lease is excluded from FRR, which is
+	// what makes it unusable as a preferred-route next-hop.
+	if IsManagementIfName(ifdName) {
 		return "", fmt.Errorf("services ip-monitoring policy %q route %s: next-hop %q names a management interface; management leases cannot back an ip-monitoring preferred route",
 			polName, pr.Destination, val)
 	}

--- a/pkg/config/ifname_class_6731.go
+++ b/pkg/config/ifname_class_6731.go
@@ -95,3 +95,37 @@ func IsTunnelOrLoopbackIfName(base string) bool {
 	}
 	return false
 }
+
+// IsManagementIfName reports whether name is in the MANAGEMENT interface class —
+// the names the daemon binds to `vrf-mgmt`.
+//
+// It is the SSOT for a rule that was previously restated verbatim at three
+// sites, where a divergence is always a bug rather than a legitimate difference:
+//
+//   - `pkg/daemon/daemon_apply_interfaces.go` builds the management-VRF
+//     interface set, which decides which leases `collectDHCPRoutes` EXCLUDES
+//     from FRR (their routes go into table 999 by netlink instead);
+//   - `pkg/dataplane/compiler_iface.go` emits `VRF=vrf-mgmt` into the
+//     interface's `.network` file so `networkctl reconfigure` preserves that
+//     binding;
+//   - `pkg/config/compiler_services.go` refuses such an interface as an
+//     ip-monitoring preferred-route next-hop, precisely BECAUSE its lease is
+//     excluded from FRR.
+//
+// The third only tells the truth while it agrees with the first two. Three
+// copies of a prefix list cannot be kept in agreement by convention.
+//
+// DELIBERATELY LOOSER THAN isCanonicalFabricName (lifeline.go), and the two must
+// not be merged. That predicate answers "is this one of the daemon-CREATED
+// fabric devices" for host-inbound lifeline exemption, and it excludes
+// `fabric0`. This one answers "does the daemon bind this to vrf-mgmt", and today
+// it DOES bind `fabric0` — so an ip-monitoring next-hop on `fabric0` is refused
+// truthfully, not spuriously. Narrowing this class to match would change which
+// interfaces land in the management VRF and therefore which DHCP routes FRR
+// owns: a behaviour decision, tracked separately, and one this SSOT reduces to a
+// single edit.
+func IsManagementIfName(name string) bool {
+	return strings.HasPrefix(name, "fxp") ||
+		strings.HasPrefix(name, "fab") ||
+		strings.HasPrefix(name, "em")
+}

--- a/pkg/config/lifeline.go
+++ b/pkg/config/lifeline.go
@@ -92,14 +92,8 @@ func HostInboundLifelineInterface(name string, lifelines map[string]bool) bool {
 // "fabric0" are NOT canonical: a configured fabric interface with such a name
 // reaches the lifeline set through HostInboundLifelineSet instead.
 func isCanonicalFabricName(base string) bool {
-	rest, ok := strings.CutPrefix(base, "fab")
-	if !ok || rest == "" {
-		return false
-	}
-	for i := 0; i < len(rest); i++ {
-		if rest[i] < '0' || rest[i] > '9' {
-			return false
-		}
-	}
-	return true
+	// #7515: one formula, not two. ifNameNumericSuffix (ifname_class_6731.go) is
+	// the same "prefix followed by digits and nothing else" rule this needed, and
+	// the two drifting apart would be a bug in either direction.
+	return ifNameNumericSuffix(base, "fab")
 }

--- a/pkg/config/mgmt_ifname_ssot_7515_test.go
+++ b/pkg/config/mgmt_ifname_ssot_7515_test.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #7515 — the "is this a management interface" rule was restated VERBATIM at
+// three sites: the daemon's management-VRF set, the networkd `VRF=` emitter, and
+// the ip-monitoring next-hop validator. Three copies of a prefix list cannot be
+// kept in agreement by convention, and a divergence between them is always a bug
+// rather than a legitimate difference — so it is single-sourced on
+// IsManagementIfName rather than pinned three times.
+//
+// NOTE ON THE ORIGINAL FILING, which was WRONG. #7515 claimed `emu0` was
+// "not a management interface — the daemon binds no mgmt VRF for it". It does:
+// the daemon's set used the same `HasPrefix(name, "em")` rule, so `emu0` really
+// is bound to vrf-mgmt and its DHCP lease really is excluded from FRR by
+// collectDHCPRoutes. The ip-monitoring refusal was therefore TRUTHFUL, not
+// spurious. The defect is the triplication and the class's looseness, and
+// narrowing the class is a behaviour change to which interfaces land in the
+// management VRF — tracked separately, not made here.
+
+// mgmtIfNameCases7515 is the probe POPULATION. The sibling tests in pkg/daemon
+// and pkg/dataplane keep their own copy: every assertion compares that site's
+// answer against IsManagementIfName, so a drifted list only weakens coverage
+// there — it can never invert a result the way a duplicated EXPECTATION would.
+var mgmtIfNameCases7515 = []string{
+	// Management class today.
+	"fxp0", "fxp1", "em0", "em1", "fab0", "fab1",
+	// Look-alikes that are ALSO in the class today, because the rule is a bare
+	// prefix. Listed explicitly so narrowing the class is a visible, deliberate
+	// edit to this table rather than a silent behaviour change.
+	"emu0", "embed0", "fabric0", "fxpanel0",
+	// Not management.
+	"ge-0/0/0", "reth0", "lo0", "st0", "start0", "e0", "f0", "",
+}
+
+// TestManagementIfNameSemantics7515 pins what the class means TODAY.
+func TestManagementIfNameSemantics7515(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want bool
+	}{
+		{"fxp0", true}, {"em0", true}, {"fab0", true}, {"fab1", true},
+		// Currently in the class — see the file header. If a later change
+		// narrows the class these flip, and that edit should be deliberate.
+		{"emu0", true}, {"embed0", true}, {"fabric0", true}, {"fxpanel0", true},
+		{"ge-0/0/0", false}, {"reth0", false}, {"lo0", false}, {"", false},
+		{"e0", false}, {"f0", false},
+	} {
+		if got := IsManagementIfName(tc.name); got != tc.want {
+			t.Errorf("IsManagementIfName(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestIPMonNextHopAgreesWithManagementSSOT7515 binds the AGREEMENT, not a
+// literal: for every name in the shared table, the ip-monitoring validator
+// refuses the next-hop as a management interface exactly when
+// IsManagementIfName says it is one.
+//
+// That refusal is only truthful while it matches the class the daemon actually
+// binds to vrf-mgmt — the binding is WHY the lease is excluded from FRR, which
+// is the whole reason such an interface cannot back a preferred route.
+//
+// FAIL-ON-REVERT: restore the raw prefix list at the validator and this stays
+// green only while the two happen to coincide; narrow either side alone and it
+// reds. That is the point — it fails on DIVERGENCE, in either direction.
+func TestIPMonNextHopAgreesWithManagementSSOT7515(t *testing.T) {
+	for _, name := range mgmtIfNameCases7515 {
+		if name == "" || strings.ContainsAny(name, "/") {
+			continue // an ifd with a port path needs a different fixture shape
+		}
+		lines := []string{
+			"set services rpm probe WAN test wan-a probe-type icmp-ping",
+			"set services rpm probe WAN test wan-a target address 1.1.1.1",
+			"set services rpm probe WAN test wan-a destination-interface " + name + ".0",
+			"set services rpm probe WAN test wan-a next-hop 172.16.50.1",
+			"set interfaces " + name + " unit 0 family inet dhcp",
+			"set services ip-monitoring policy p match rpm-probe WAN",
+			"set services ip-monitoring policy p then preferred-route route 0.0.0.0/0 next-hop " + name + ".0",
+		}
+		tree := buildTree(t, lines)
+		_, err := CompileConfig(tree)
+		refusedAsMgmt := err != nil && strings.Contains(err.Error(), "names a management interface")
+		if want := IsManagementIfName(name); refusedAsMgmt != want {
+			t.Errorf("%s: ip-monitoring refuses-as-management = %v, but IsManagementIfName = %v. "+
+				"The validator's message claims the lease is excluded from FRR; that is only "+
+				"true while it agrees with the class the daemon binds to vrf-mgmt (#7515). err=%v",
+				name, refusedAsMgmt, want, err)
+		}
+	}
+}

--- a/pkg/daemon/daemon_apply_interfaces.go
+++ b/pkg/daemon/daemon_apply_interfaces.go
@@ -167,12 +167,7 @@ func (d *Daemon) applyVRFReconcile(ctx context.Context, cfg *config.Config) (ctx
 	// the godoc on routing.ReconcileVRFs for the current contract.)
 	const mgmtVRFName = "mgmt"
 	const mgmtTableID = 999
-	mgmtIfaces := make(map[string]bool)
-	for name := range cfg.Interfaces.Interfaces {
-		if strings.HasPrefix(name, "fxp") || strings.HasPrefix(name, "fab") || strings.HasPrefix(name, "em") {
-			mgmtIfaces[config.LinuxIfName(name)] = true
-		}
-	}
+	mgmtIfaces := managementVRFIfaceSet(cfg)
 
 	if d.routing != nil {
 		var desired []routing.VRFSpec
@@ -376,4 +371,27 @@ func (d *Daemon) applyInterfaceReconcile(cfg *config.Config) error {
 	}
 
 	return errors.Join(errs...)
+}
+
+// managementVRFIfaceSet is the set of Linux interface names the daemon binds to
+// vrf-mgmt, keyed the way the DHCP-callback readers look them up
+// (config.LinuxIfName). Extracted from the apply path so the class rule has a
+// callable, testable entry point rather than living inline in a long reconcile.
+//
+// #7515: the class comes from config.IsManagementIfName, the SSOT shared with
+// the networkd `VRF=` emitter and the ip-monitoring next-hop validator. Those
+// three answer the same question, and a divergence between them is always a bug:
+// the daemon would bind a VRF networkd strips, or the validator would refuse a
+// next-hop whose lease FRR actually owns.
+func managementVRFIfaceSet(cfg *config.Config) map[string]bool {
+	out := make(map[string]bool)
+	if cfg == nil {
+		return out
+	}
+	for name := range cfg.Interfaces.Interfaces {
+		if config.IsManagementIfName(name) {
+			out[config.LinuxIfName(name)] = true
+		}
+	}
+	return out
 }

--- a/pkg/daemon/mgmt_vrf_ifaceset_ssot_7515_test.go
+++ b/pkg/daemon/mgmt_vrf_ifaceset_ssot_7515_test.go
@@ -1,0 +1,68 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #7515 — the daemon's management-VRF interface set is the ENFORCEMENT site of
+// the management-interface class: what lands in it is what collectDHCPRoutes
+// excludes from FRR, and therefore what the ip-monitoring next-hop validator is
+// telling the truth about when it refuses one.
+//
+// This binds the AGREEMENT with config.IsManagementIfName rather than pinning
+// its own prefix literal. A literal here would encode which site is trusted, and
+// the whole defect was that three sites each carried their own.
+//
+// FAIL-ON-REVERT: put `strings.HasPrefix(name, "fxp") || ...` back into
+// managementVRFIfaceSet and this stays green only while the two coincide —
+// narrow or widen either side alone and it reds, in either direction.
+// mgmtIfNameCases7515 is the probe POPULATION, mirrored from the sibling test in
+// pkg/config. It is duplicated rather than exported from production code, and
+// that is safe in a way a duplicated EXPECTATION would not be: every assertion
+// below compares this site's answer against config.IsManagementIfName, so if the
+// lists drift the only effect is that a name stops being probed here — coverage
+// weakens, a result never inverts. A pinned expected-answer literal would
+// silently encode which site is trusted, which is the defect being fixed.
+var mgmtIfNameCases7515 = []string{
+	"fxp0", "fxp1", "em0", "em1", "fab0", "fab1",
+	"emu0", "embed0", "fabric0", "fxpanel0",
+	"ge-0/0/0", "reth0", "lo0", "st0", "start0", "e0", "f0",
+}
+
+func TestManagementVRFIfaceSetAgreesWithSSOT7515(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{}
+	for _, name := range mgmtIfNameCases7515 {
+		if name == "" {
+			continue
+		}
+		cfg.Interfaces.Interfaces[name] = &config.InterfaceConfig{Name: name}
+	}
+
+	got := managementVRFIfaceSet(cfg)
+
+	for _, name := range mgmtIfNameCases7515 {
+		if name == "" {
+			continue
+		}
+		// The set is keyed by the LINUX name, the way the lock-free
+		// DHCP-callback readers look it up.
+		inSet := got[config.LinuxIfName(name)]
+		if want := config.IsManagementIfName(name); inSet != want {
+			t.Errorf("%s: in management-VRF set = %v, but config.IsManagementIfName = %v. "+
+				"A divergence here is always a bug: this set decides which DHCP leases "+
+				"collectDHCPRoutes excludes from FRR, and the ip-monitoring validator's "+
+				"refusal message asserts exactly that exclusion (#7515)", name, inSet, want)
+		}
+	}
+}
+
+// TestManagementVRFIfaceSetIsNilSafe7515 — the apply path can reach this with a
+// nil config on early-boot paths; it must return an empty set, not panic.
+func TestManagementVRFIfaceSetIsNilSafe7515(t *testing.T) {
+	if got := managementVRFIfaceSet(nil); len(got) != 0 {
+		t.Fatalf("a nil config must yield an empty management set, got %v", got)
+	}
+}

--- a/pkg/dataplane/compiler_iface.go
+++ b/pkg/dataplane/compiler_iface.go
@@ -1211,7 +1211,11 @@ func buildInterfaceNetworkdModels(cfg *config.Config, result *CompileResult, see
 				// Management interfaces (fxp*, fab*) are bound to vrf-mgmt.
 				// Include VRF= in .network so networkctl reconfigure preserves binding.
 				vrfName := ""
-				if strings.HasPrefix(ifName, "fxp") || strings.HasPrefix(ifName, "fab") || strings.HasPrefix(ifName, "em") {
+				// #7515: config.IsManagementIfName is the SSOT. If this drifts
+				// from the daemon's management-VRF set, networkctl reconfigure
+				// strips a binding the daemon just made (or preserves one it
+				// never made).
+				if config.IsManagementIfName(ifName) {
 					vrfName = "vrf-mgmt"
 				}
 				result.ManagedInterfaces = append(result.ManagedInterfaces, networkd.InterfaceConfig{

--- a/pkg/dataplane/mgmt_vrf_networkd_ssot_7515_test.go
+++ b/pkg/dataplane/mgmt_vrf_networkd_ssot_7515_test.go
@@ -1,0 +1,81 @@
+package dataplane
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #7515 — the networkd `VRF=vrf-mgmt` stanza is the third site of the
+// management-interface class. It must agree with the daemon's management-VRF
+// set: if it drifts, `networkctl reconfigure` strips a binding the daemon just
+// made, or preserves one the daemon never made.
+//
+// The assertion is against config.IsManagementIfName, not a prefix literal. The
+// name list below is a probe POPULATION mirrored from the sibling tests — a
+// drifted list only weakens coverage here, while a duplicated EXPECTATION would
+// silently encode which of the three sites is trusted.
+var mgmtIfNameCases7515 = []string{
+	"fxp0", "em0", "fab0", "fab1",
+	"emu0", "embed0", "fabric0", "fxpanel0",
+	"ge-0/0/0", "reth0", "lo0", "start0", "e0", "f0",
+}
+
+// TestNetworkdVRFStanzaAgreesWithManagementSSOT7515 drives the real networkd
+// model builder and reads VRF= off the emitted models.
+//
+// FAIL-ON-REVERT: put the raw prefix list back at the emitter and this stays
+// green only while the two coincide — narrow or widen either side alone and it
+// reds, in either direction.
+func TestNetworkdVRFStanzaAgreesWithManagementSSOT7515(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{}
+	ifCache := map[string]*net.Interface{}
+	for i, name := range mgmtIfNameCases7515 {
+		cfg.Interfaces.Interfaces[name] = &config.InterfaceConfig{
+			Name:  name,
+			Units: map[int]*config.InterfaceUnit{0: {Number: 0, Addresses: []string{"10.0.0.1/24"}}},
+		}
+		ln := config.LinuxIfName(name)
+		// A HardwareAddr is REQUIRED: the builder skips any interface whose MAC
+		// is empty (`if mac == "" { continue }`), so a fixture without one emits
+		// no models at all and every assertion below would be vacuous. The
+		// precondition at the end of this test is what caught that.
+		ifCache[ln] = &net.Interface{
+			Index:        i + 1,
+			Name:         ln,
+			HardwareAddr: net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, byte(i + 1)},
+		}
+	}
+
+	result := &CompileResult{ifCache: ifCache}
+	buildInterfaceNetworkdModels(cfg, result, map[string]bool{})
+
+	seen := map[string]bool{}
+	for _, mi := range result.ManagedInterfaces {
+		seen[mi.Name] = true
+		// Recover the CONFIG name this model came from, so the SSOT is asked
+		// the same question the emitter was.
+		var cfgName string
+		for name := range cfg.Interfaces.Interfaces {
+			if config.LinuxIfName(name) == mi.Name {
+				cfgName = name
+				break
+			}
+		}
+		if cfgName == "" {
+			continue
+		}
+		gotMgmt := mi.VRFName == "vrf-mgmt"
+		if want := config.IsManagementIfName(cfgName); gotMgmt != want {
+			t.Errorf("%s: networkd VRFName=%q (management=%v), but config.IsManagementIfName = %v. "+
+				"A divergence here means networkctl reconfigure strips a binding the daemon "+
+				"made, or preserves one it never made (#7515)", cfgName, mi.VRFName, gotMgmt, want)
+		}
+	}
+	if len(seen) == 0 {
+		t.Fatal("precondition: the networkd builder emitted no managed interfaces at all, so " +
+			"every assertion above was vacuous")
+	}
+}


### PR DESCRIPTION
Closes #7515

## The issue's premise was wrong, and I filed it — the real defect is bigger

#7515 (mine) claimed the ip-monitoring next-hop validator spuriously rejects
`emu0` because *"the daemon binds no mgmt VRF for it"*. **It does.** The daemon's
management-VRF set used the same `strings.HasPrefix(name, "em")` rule, so `emu0`
really is bound to `vrf-mgmt` and its DHCP lease really is excluded from FRR by
`collectDHCPRoutes`. **The refusal was truthful.** I filed that from reading the
validator alone without tracing the enforcement site.

Tracing it found something worth more. `collectDHCPRoutes` doesn't test a name at
all — it excludes on a *computed* management-VRF set — and that set, the networkd
`VRF=` emitter, and the validator each carried their **own verbatim copy** of the
prefix rule.

## Three copies of a rule where divergence is always a bug

| site | what it decides |
|---|---|
| `pkg/daemon/daemon_apply_interfaces.go` | which interfaces are bound to `vrf-mgmt` — and therefore which leases `collectDHCPRoutes` **excludes from FRR** |
| `pkg/dataplane/compiler_iface.go` | whether `VRF=vrf-mgmt` is written into the `.network` file, so `networkctl reconfigure` preserves that binding |
| `pkg/config/compiler_services.go` | whether an ip-monitoring preferred-route next-hop is refused, **because** the lease is excluded from FRR |

The third only tells the truth while it agrees with the first two. If the daemon
and the emitter drift, `networkctl reconfigure` strips a binding the daemon just
made — or preserves one it never made. Three copies of a prefix list cannot be
kept in agreement by convention, so this **single-sources** rather than binding
copies.

## Semantics preserved exactly — no behaviour change

All three now call `config.IsManagementIfName`, which is the current prefix rule
verbatim. `fabric0` and `emu0` remain management interfaces.

**Narrowing the class is deliberately NOT done here.** It would change which
interfaces land in the management VRF and therefore which DHCP routes FRR owns —
a behaviour decision, not a bug fix. The SSOT reduces that future change to a
single edit, and `TestManagementIfNameSemantics7515` makes it visible when
someone makes it.

`isCanonicalFabricName` (`lifeline.go`) now calls the shared
`ifNameNumericSuffix` instead of carrying a second copy of the same
"prefix + digits" formula — the duplication #6731 left in place on purpose,
which is now correct to collapse because the callers change together. It stays a
**different, stricter** predicate answering a different question (which
daemon-created fabric devices are host-inbound lifeline-exempt — which excludes
`fabric0`). That difference is now documented as deliberate rather than looking
accidental.

## The tests bind the AGREEMENT, never a literal

Each site asserts **its own observable answer == `config.IsManagementIfName`** for
a probe population. A pinned expected-answer would encode which of the three
sites is trusted, and the defect was that each carried its own.

The population list is duplicated per package, and that is safe in a way an
expectation would not be: if the lists drift, a name stops being probed there —
coverage weakens, a result never inverts.

## Validation

- `go build ./...`, `gofmt`, `go vet` clean on every file touched (the `gofmt`
  noise in these packages is pre-existing at `origin/master`; verified).
- **`go test -count=1 ./...` rc=0, 71 packages, zero failures.**

### Divergence matrix — three packages per cell, 8954 tests collected each, no build breaks

| # | Mutation | Verdict |
|---|---|---|
| **S1** | narrow the **daemon** site alone | **RED — the daemon agreement ONLY** |
| **S2** | narrow the **validator** alone | **RED — the config agreement ONLY** |
| **S3** | narrow the **networkd emitter** alone | **RED — the dataplane agreement ONLY** |
| **S4** | narrow the **SSOT itself** | **RED — the semantics test ONLY; all three agreement tests stay GREEN**, because all three sites follow |

**S4 is the design property stated as a test**: a deliberate class change is one
visible edit, while an accidental divergence is caught at whichever site drifted.

### A fixture note

The networkd test first emitted **zero** models, because the builder skips any
interface with an empty MAC (`if mac == "" { continue }`) — so every assertion was
vacuous and passing. The precondition guard at the end of that test caught it, not
the assertions.

## Cluster surface

No cluster/session-sync/config-sync code. It does touch `pkg/daemon`'s interface
apply path and the networkd emitter, both semantics-preserving. **Does not owe
`make test-failover`** on my read — flag it if you'd rather run it anyway, since
the management-VRF bind sits near HA interface handling.

Refs #6731, #1844, #3682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VM24XVAYBhzAUSAAhnR8Xp
