### PR TITLE
daemon: give the VIP warning-suppression set its own mutex

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103878,3 +103878,13 @@ prose edit above them added. No diff falls in the new test body.
   measured staleness header; split the retained root causes into individual
   issues.
 - **File(s)**: `docs/research/6744-kimi-review-003/plan.md`
+
+## 2026-08-22 — #7532 vipWarnedIfaces gets its own mutex
+- **Timestamp**: 2026-08-22
+- **Action**: The field was reset on the apply path (applySem) and lazily
+  created/read/assigned/deleted on the VRRP reconcile path under no shared
+  lock — a reset between the nil-check and the assignment panics, two
+  reconcile writers are a fatal throw. Gave it a dedicated mutex and three
+  accessors; the check-and-record is now one critical section.
+- **File(s)**: pkg/daemon/daemon.go, pkg/daemon/daemon_ha_vip.go,
+  pkg/daemon/daemon_apply.go, pkg/daemon/vip_warn_sync_7532_test.go

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -815,6 +815,20 @@ type Daemon struct {
 	// vipWarnedIfaces tracks interfaces that already emitted a
 	// "directAddVIPs: interface not found" warning to avoid log spam
 	// from the reconcile ticker. Reset on config commit.
+	//
+	// #7532: guarded by its OWN mutex, and reachable only through
+	// resetVIPWarnings / shouldWarnVIPIface / clearVIPWarning. The reset runs
+	// on the apply path under applySem while the lazy-init, read, assign and
+	// delete run on the VRRP reconcile path, which holds no such lock — so the
+	// two used unrelated synchronization. A reset landing between the reconcile
+	// path's nil-check and its assignment is `assignment to entry in nil map`,
+	// and two reconcile writers are a fatal `concurrent map writes` throw.
+	//
+	// A dedicated lock rather than widening applySem: this is warning
+	// suppression, it has no ordering relationship with an apply, and putting
+	// the reconcile ticker behind the apply semaphore would couple a log-spam
+	// guard to the heavy apply pipeline.
+	vipWarnedMu     sync.Mutex
 	vipWarnedIfaces map[string]bool
 
 	// syncPeerAddr is the primary peer address used for gRPC peer dialing

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -201,6 +201,21 @@ func (d *Daemon) applyCancelCtx() context.Context {
 // DHCP / feed and confirmed-rollback callers pass a non-cancellable context so
 // their applies always complete (see applyConfig / executeConfirmedRollback).
 func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) error {
+	// Reset VIP warning suppression so the new config gets fresh warnings.
+	//
+	// #7532: through the accessor. This runs under applySem while the VRRP
+	// reconcile path mutates the same map under no such lock, so the field has
+	// its own mutex and no caller touches it directly.
+	//
+	// Placed BEFORE the applyBodyForTest seam return, for the same reason
+	// enterBootstrapMode places stopAndDiscardNATPoolAlarm there: the lifecycle
+	// is then exercised by the unit tests that stub the apply body, instead of
+	// living on the far side of an early return no test can cross. Moving it
+	// ahead of the pipeline is behaviour-preserving — the warnings it un--
+	// suppresses are emitted by directAddVIPs on the VRRP reconcile path, which
+	// is not driven from inside this function.
+	d.resetVIPWarnings()
+
 	if d.applyBodyForTest != nil {
 		d.applyBodyForTest(cfg)
 		return d.applyErrForTest
@@ -296,9 +311,6 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// the interfaces — to reconcile them to the node's cluster names. One-shot;
 	// a no-op on a standalone config or any later commit.
 	d.maybeReapplyConfigArrivalNaming(cfg)
-
-	// Reset VIP warning suppression so new config gets fresh warnings.
-	d.vipWarnedIfaces = nil
 
 	// Log config validation warnings
 	for _, w := range cfg.Warnings {

--- a/pkg/daemon/daemon_ha_vip.go
+++ b/pkg/daemon/daemon_ha_vip.go
@@ -37,7 +37,6 @@ func (d *Daemon) checkNoRethTakeoverReadiness(rgID int) (bool, []string) {
 	return d.checkVIPReadiness(rgID)
 }
 
-
 // checkVIPReadinessForConfig verifies that RETH interfaces for the given RG
 // exist and have operational carrier. Pure function for testability.
 //
@@ -195,17 +194,13 @@ func (d *Daemon) directAddVIPs(rgID int) int {
 		}
 		link, err := linkByName(ifName)
 		if err != nil {
-			if d.vipWarnedIfaces == nil {
-				d.vipWarnedIfaces = make(map[string]bool)
-			}
-			if !d.vipWarnedIfaces[ifName] {
+			if d.shouldWarnVIPIface(ifName) {
 				slog.Warn("directAddVIPs: interface not found", "iface", ifName, "err", err)
-				d.vipWarnedIfaces[ifName] = true
 			}
 			continue
 		}
 		// Interface exists now — clear any previous warning suppression
-		delete(d.vipWarnedIfaces, ifName)
+		d.clearVIPWarning(ifName)
 		for _, cidr := range addrs {
 			addr, err := netlink.ParseAddr(cidr)
 			if err != nil {
@@ -654,4 +649,40 @@ func (d *Daemon) directSendGARPs(rgID int) {
 			}
 		}
 	}
+}
+
+// resetVIPWarnings drops the VIP warning-suppression set so a new config gets
+// fresh warnings (#7532). Safe to call concurrently with the reconcile path.
+func (d *Daemon) resetVIPWarnings() {
+	d.vipWarnedMu.Lock()
+	defer d.vipWarnedMu.Unlock()
+	d.vipWarnedIfaces = nil
+}
+
+// shouldWarnVIPIface reports whether this interface's "interface not found"
+// warning should be emitted now, and records that it was (#7532).
+//
+// The check and the record are ONE critical section on purpose. Splitting them —
+// as the open-coded version did — lets two reconcile passes both observe "not
+// yet warned" and both log, which is the spam the set exists to prevent, on top
+// of being a racy map write.
+func (d *Daemon) shouldWarnVIPIface(ifName string) bool {
+	d.vipWarnedMu.Lock()
+	defer d.vipWarnedMu.Unlock()
+	if d.vipWarnedIfaces == nil {
+		d.vipWarnedIfaces = make(map[string]bool)
+	}
+	if d.vipWarnedIfaces[ifName] {
+		return false
+	}
+	d.vipWarnedIfaces[ifName] = true
+	return true
+}
+
+// clearVIPWarning forgets this interface's suppression so a later disappearance
+// warns again (#7532). A nil map deletes nothing, which is the intended no-op.
+func (d *Daemon) clearVIPWarning(ifName string) {
+	d.vipWarnedMu.Lock()
+	defer d.vipWarnedMu.Unlock()
+	delete(d.vipWarnedIfaces, ifName)
 }

--- a/pkg/daemon/vip_warn_sync_7532_test.go
+++ b/pkg/daemon/vip_warn_sync_7532_test.go
@@ -1,0 +1,178 @@
+package daemon
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #7532: d.vipWarnedIfaces was reset on the apply path (under applySem) and
+// lazily created / read / assigned / deleted on the VRRP reconcile path, which
+// holds no such lock. The two used unrelated synchronization.
+//
+// A reset landing between the reconcile path's nil-check and its assignment is
+// `assignment to entry in nil map`; two reconcile writers are a fatal
+// `concurrent map writes` throw. The impact is the daemon crashing.
+//
+// These run under `go test -race`. Without -race the pre-fix code still panics
+// often enough for the loop below to catch it, but -race is what makes it
+// deterministic — so the probe reports its own iteration counts rather than
+// asserting a fixed ratio.
+
+// TestVIPWarningSuppressionIsRaceFree7532 is the defect proper.
+//
+// The two goroutines run for a fixed WALL-CLOCK window rather than a fixed
+// iteration count each. Equal counts would be a false green: the reset is a
+// one-line store and the warn path allocates a map, so the cheap side finishes
+// inside the expensive side's first passes and they never interleave where it
+// matters. Both counts are reported and both must be non-trivial.
+func TestVIPWarningSuppressionIsRaceFree7532(t *testing.T) {
+	d := &Daemon{}
+	var resets, warns int64
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() { // the apply path
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			d.resetVIPWarnings()
+			atomic.AddInt64(&resets, 1)
+		}
+	}()
+
+	wg.Add(1)
+	go func() { // the VRRP reconcile path
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if d.shouldWarnVIPIface("reth0") {
+				atomic.AddInt64(&warns, 1)
+			}
+			d.clearVIPWarning("reth1")
+		}
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	r, w := atomic.LoadInt64(&resets), atomic.LoadInt64(&warns)
+	t.Logf("resets=%d warns=%d", r, w)
+	if r < 100 || w < 10 {
+		t.Fatalf("the probe did not exercise the interleaving (resets=%d warns=%d): a green "+
+			"run here would prove nothing", r, w)
+	}
+}
+
+// TestVIPWarningSuppressesRepeats7532 is the TIGHTENING control.
+//
+// A "fix" that made shouldWarnVIPIface always return true would be race-free and
+// would pass the probe above, while destroying the log-spam suppression the set
+// exists for — the reconcile ticker calls this every pass. This pins the other
+// side, and it pins the check-and-record as ONE critical section: the open-coded
+// version tested and set separately, so two passes could both observe "not yet
+// warned" and both log.
+func TestVIPWarningSuppressesRepeats7532(t *testing.T) {
+	d := &Daemon{}
+
+	if !d.shouldWarnVIPIface("reth0") {
+		t.Fatal("the FIRST occurrence must warn")
+	}
+	for i := 0; i < 50; i++ {
+		if d.shouldWarnVIPIface("reth0") {
+			t.Fatalf("occurrence %d warned again: the reconcile ticker would spam this line "+
+				"every pass, which is exactly what the suppression set exists to prevent", i+2)
+		}
+	}
+
+	// A different interface is tracked independently.
+	if !d.shouldWarnVIPIface("reth1") {
+		t.Error("a DIFFERENT interface must warn on its first occurrence — the suppression is " +
+			"per-interface, not global")
+	}
+
+	// Reappearing clears suppression, so a later disappearance warns again.
+	d.clearVIPWarning("reth0")
+	if !d.shouldWarnVIPIface("reth0") {
+		t.Error("after the interface reappeared and its suppression was cleared, a later " +
+			"disappearance must warn again")
+	}
+
+	// A config commit resets everything.
+	d.resetVIPWarnings()
+	if !d.shouldWarnVIPIface("reth1") {
+		t.Error("a config commit must reset suppression so the new config gets fresh warnings")
+	}
+}
+
+// TestVIPWarningAccessorsSurviveANilMap7532 pins the nil-map path directly: the
+// zero-value Daemon has no map, and every accessor must cope. Before #7532 the
+// reset set the field to nil while the reconcile path assumed it could assign
+// after its own nil-check — this asserts each entry point independently rather
+// than relying on the race probe to happen to hit the window.
+func TestVIPWarningAccessorsSurviveANilMap7532(t *testing.T) {
+	t.Run("clear on a nil map", func(t *testing.T) {
+		d := &Daemon{}
+		d.clearVIPWarning("reth0") // must not panic
+	})
+	t.Run("reset on a nil map", func(t *testing.T) {
+		d := &Daemon{}
+		d.resetVIPWarnings()
+		d.resetVIPWarnings()
+	})
+	t.Run("warn after a reset", func(t *testing.T) {
+		d := &Daemon{}
+		if !d.shouldWarnVIPIface("reth0") {
+			t.Fatal("first warn")
+		}
+		d.resetVIPWarnings()
+		if !d.shouldWarnVIPIface("reth0") {
+			t.Error("assignment after a reset must re-create the map, not panic on a nil one")
+		}
+	})
+}
+
+// TestApplyResetsVIPWarnings7532 binds the WIRING, not the accessor.
+//
+// The three tests above drive resetVIPWarnings / shouldWarnVIPIface directly, so
+// they pass whether or not the apply path still calls the reset — deleting the
+// call site leaves every one of them green. This drives the production entry
+// point (applyConfigLocked with the apply body stubbed) and asserts the
+// suppression was actually cleared, which is the property "reset on config
+// commit" names.
+func TestApplyResetsVIPWarnings7532(t *testing.T) {
+	d := &Daemon{}
+	d.applyBodyForTest = func(*config.Config) {}
+
+	if !d.shouldWarnVIPIface("reth0") {
+		t.Fatal("setup: the first occurrence must warn")
+	}
+	if d.shouldWarnVIPIface("reth0") {
+		t.Fatal("setup: the second occurrence must be suppressed — otherwise the assertion " +
+			"below cannot tell a reset from no suppression at all")
+	}
+
+	if err := d.applyConfigLocked(context.Background(), &config.Config{}); err != nil {
+		t.Fatalf("applyConfigLocked: %v", err)
+	}
+
+	if !d.shouldWarnVIPIface("reth0") {
+		t.Error("a config apply did NOT reset the VIP warning suppression: an interface that " +
+			"warned under the previous config stays silent under the new one, so an operator " +
+			"who fixes a config and re-commits never learns the interface is still missing")
+	}
+}


### PR DESCRIPTION
Closes #7532

`d.vipWarnedIfaces` was reset to nil on the apply path under `applySem`, and lazily created, read, assigned and deleted on the VRRP reconcile path, which holds no such lock. The two used **unrelated synchronization**, and the field had no dedicated mutex — its only documented contract was "Reset on config commit".

A reset landing between the reconcile path's nil-check and its assignment is `assignment to entry in nil map`. Two reconcile writers are a fatal `concurrent map writes` throw. Nothing exotic is claimed: **the impact is the daemon crashing.**

The field now has its own mutex and is reachable only through `resetVIPWarnings`, `shouldWarnVIPIface` and `clearVIPWarning`. A dedicated lock rather than widening `applySem`, per the research note carried on the issue: this is warning suppression, it has no ordering relationship with an apply, and putting the reconcile ticker behind the apply semaphore would couple a log-spam guard to the heavy apply pipeline.

`shouldWarnVIPIface` makes the check and the record **one** critical section. Splitting them — as the open-coded version did — lets two reconcile passes both observe "not yet warned" and both log, which is the spam the set exists to prevent, on top of being a racy map write.

## Mutation matrix

Fix committed first. `-race`, full `7532` set per cell, rc from a file, control green first.

| # | mutation | rc | what fired |
|---|---|---|---|
| U1 | restore the pre-fix unsynchronised open-coded version | 1 | **`WARNING: DATA RACE`** — concurrent writes at the same address |
| U2 | **TIGHTEN**: always warn | 1 | `TestVIPWarningSuppressesRepeats7532` |
| U3 | **WIRING**: apply path stops resetting | 0 → 1 | see below |
| U4 | split the check and record into two critical sections | 1 | **`panic: assignment to entry in nil map`** |

**U4 is the cell worth reading.** It is not a contrived mutation — it is the plausible "refactor" of the fix, holding the lock for the read and again for the write. It reproduces the **literal panic from the issue text**, which is the best available evidence that the single-critical-section design is the thing doing the work rather than the mutex alone.

**U3 was GREEN and that was a real gap in my own tests.** The other three drive the accessors directly, so deleting the apply-path call site left all of them passing. Worse, the call site sat **after** `applyConfigLocked`'s `applyBodyForTest` seam, which returns early — so no unit test could reach it at all.

I moved the reset **above** the seam and added `TestApplyResetsVIPWarnings7532`, which drives `applyConfigLocked` and asserts the suppression was actually cleared. U3 then reds.

That move follows this codebase's own documented pattern: `enterBootstrapMode` places `stopAndDiscardNATPoolAlarm` before the seam with a comment saying it is *"so the lifecycle is exercised by the rollback unit tests too"*. It is behaviour-preserving here — the warnings it un-suppresses are emitted by `directAddVIPs` on the VRRP reconcile path, which is not driven from inside `applyConfigLocked`.

## Note on the race probe

The two goroutines run for a fixed **wall-clock window**, not a fixed iteration count each. Equal counts would be a false green: the reset is a one-line store while the warn path allocates a map, so the cheap side finishes inside the expensive side's first passes and they never interleave where it matters. Both counts are reported and both must be non-trivial — measured **72492 resets / 5367 warns**.

## Provenance

Split out of #6744 (`kimi-review-003` cohort triage), and **re-verified at current master** by the lane that filed it rather than inherited from the dead review loop — #6744's research branch went cold on 2026-08-05, is 1738 commits behind master, and the artifacts its later rounds cite no longer exist.

## Validation

`go build`, `go vet`, `gofmt` clean; `go test -count=1 ./...` green repo-wide, and `go test -count=1 -race ./pkg/daemon/` green.

No cluster/VRRP/session-sync/failover *behaviour* changes — this is a synchronization fix on a log-suppression map — and no `userspace-dp` binary or shim `.o` moved. It does touch `pkg/daemon`'s VIP reconcile file, so say if you want a smoke; I will run one if the folding gate prefers it.
