### PR TITLE
userspace-dp: bound GRE decap by the outer IP datagram (#6748)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103871,3 +103871,25 @@ prose edit above them added. No diff falls in the new test body.
   RG + barrier wait, then stopClusterComms) ahead of the teardown.
 - **File(s)**: pkg/daemon/bootstrap.go,
   pkg/daemon/bootstrap_cluster_relinquish_6742_test.go
+
+## 2026-08-22 — #6748 GRE decap bounded by the outer IP datagram
+- **Action**: Native GRE decap capped the inner extent at `frame.len() -
+  inner_offset` with no cross-check against the outer IPv4 Total Length / IPv6
+  Payload Length, so a peer that appended a trailer past the outer datagram AND
+  inflated the inner IP Total Length to cover it had those out-of-datagram bytes
+  promoted into the decapsulated packet. NOT the mechanism the title implies —
+  `packet_trimmed_len` already kept the inner inside the frame and already
+  trimmed Ethernet padding, so bounding by the frame length would have fixed
+  nothing. Extracted `outer_datagram_end` from `gre_checksum_region` (which
+  already applied exactly this bound, to the checksum only — the asymmetry that
+  made this an oversight) and ran the GRE option-field skips and the inner
+  extraction on `frame[..outer_end]`. An over-declaring outer header is refused
+  rather than clamped. Negative control asserts an HONEST inner under ordinary
+  trailing padding still decaps byte-identically, so the fix is not a blanket
+  rejection of trailers. Checked the issue's "the same pattern is used by the
+  WireGuard decap path": the only other `packet_trimmed_len` callers are ENCAP
+  paths (gre.rs's outer builder and frame/wg.rs's), where no outer datagram
+  exists yet, so nothing to bound there.
+- **File(s)**: userspace-dp/src/afxdp/gre.rs, userspace-dp/src/afxdp/mod.rs,
+  userspace-dp/src/afxdp/tests_gre_outer_bound_6748.rs (new),
+  docs/userspace-native-gre-plan.md

--- a/docs/userspace-native-gre-plan.md
+++ b/docs/userspace-native-gre-plan.md
@@ -321,6 +321,31 @@ decapsulated inner. The inner is first trimmed to its IP-declared total
 length (`packet_trimmed_len`), so an inner whose declared length ends
 before its L4 header survives to the parse.
 
+**That trim is bounded by the OUTER datagram, not by the frame (#6748).**
+`packet_trimmed_len` keeps the inner extent inside the slice it is given,
+and until #6748 that slice ran to the end of the FRAME — so a peer that
+appended a trailer past the outer IP datagram AND inflated the inner IP
+Total Length to cover it had those out-of-datagram bytes promoted into
+the decapsulated packet. The frame length is not a bound worth having
+here: `raw_frame` is the AF_XDP descriptor length, `classify_metadata`
+performs no length validation at all, and the XDP shim declares
+`tot_len`/`payload_len` in its header structs but never reads either.
+`outer_datagram_end` now computes the authoritative end once — IPv4 Total
+Length, or 40 + IPv6 Payload Length, refused rather than clamped when it
+exceeds the capture — and the GRE option-field skips and the inner
+extraction both run on `frame[..outer_end]`. An inner header that reaches
+past it is refused, not trimmed: it is lying about the datagram it
+arrived in. An HONEST inner under ordinary trailing padding still decaps
+byte-identically, which is the negative control that separates this from
+rejecting padded frames outright.
+
+The bound was not new — `gre_checksum_region` already applied it, and
+said why (item 2 of the flag-handling list below). It was applied to the
+checksum only, so checksummed GRE got an incidental outer-length sanity
+check that non-checksummed GRE did not; that asymmetry is what made #6748
+an oversight rather than a design choice. Both now share one computation
+rather than two possibly-divergent notions of "outer end".
+
 Inner TCP was always length-validated (the IHL + 20-byte TCP-header
 check). UDP, ICMP, and ICMPv6, however, advanced the payload offset by 8
 unconditionally — with NO check that the inner actually contained the

--- a/userspace-dp/src/afxdp/gre.rs
+++ b/userspace-dp/src/afxdp/gre.rs
@@ -64,13 +64,27 @@ fn parse_outer_addresses(frame: &[u8], meta: UserspaceDpMeta) -> Option<(IpAddr,
 /// the outer header is truncated or its declared length lies outside the
 /// captured frame (fail-closed — a truncated/lying header must not
 /// over-read or pass an unvalidated frame).
-fn gre_checksum_region<'a>(
-    frame: &'a [u8],
-    meta: UserspaceDpMeta,
-    gre_offset: usize,
-) -> Option<&'a [u8]> {
+/// #6748: the authoritative end of the OUTER IP datagram, in frame offsets.
+///
+/// IPv4 Total Length, or 40 + IPv6 Payload Length, both relative to
+/// `meta.l3_offset`, and refused when the declaration runs past what was
+/// actually captured. Nothing earlier in the path establishes this: `raw_frame`
+/// is the AF_XDP descriptor length, `classify_metadata` validates
+/// snapshot/config-gen/fib-gen/addr-family and performs no length validation at
+/// all, and the XDP shim declares `tot_len`/`payload_len` in its header structs
+/// but never reads either.
+///
+/// This computation used to live inside `gre_checksum_region` and be applied to
+/// the CHECKSUM only. Its docstring said why — "so trailing Ethernet min-frame
+/// padding is excluded" — while payload promotion was bounded by
+/// `frame.len() - inner_offset` instead. The asymmetry is what made #6748 an
+/// oversight rather than a design choice: checksummed GRE got an incidental
+/// outer-length sanity check that non-checksummed GRE did not. Extracted here so
+/// there is ONE notion of "outer end" for the checksum, the option-field skips
+/// and the inner extraction, rather than a second, possibly divergent one.
+pub(in crate::afxdp) fn outer_datagram_end(frame: &[u8], meta: UserspaceDpMeta) -> Option<usize> {
     let l3 = meta.l3_offset as usize;
-    let gre_region_end = match meta.addr_family as i32 {
+    let end = match meta.addr_family as i32 {
         libc::AF_INET => {
             let total = u16::from_be_bytes([*frame.get(l3 + 2)?, *frame.get(l3 + 3)?]) as usize;
             l3.checked_add(total)?
@@ -82,9 +96,23 @@ fn gre_checksum_region<'a>(
         }
         _ => return None,
     };
-    // The declared region must start at/after the GRE header and fit
-    // within what we actually captured.
-    if gre_region_end < gre_offset || gre_region_end > frame.len() {
+    // A declaration longer than what we captured is refused rather than
+    // clamped: clamping would silently accept a header that lies about its own
+    // datagram, which is the same class of trust this function exists to remove.
+    if end > frame.len() {
+        return None;
+    }
+    Some(end)
+}
+
+fn gre_checksum_region<'a>(
+    frame: &'a [u8],
+    meta: UserspaceDpMeta,
+    gre_offset: usize,
+) -> Option<&'a [u8]> {
+    let gre_region_end = outer_datagram_end(frame, meta)?;
+    // The declared region must start at/after the GRE header.
+    if gre_region_end < gre_offset {
         return None;
     }
     frame.get(gre_offset..gre_region_end)
@@ -627,7 +655,24 @@ pub(super) fn try_native_gre_decap_from_frame(
         return None;
     }
     let gre_offset = meta.l4_offset as usize;
-    let base = frame.get(gre_offset..gre_offset + 4)?;
+    // #6748: everything below reads through `outer`, never `frame`. The outer
+    // IP header's own declared length is the authoritative end of this
+    // datagram; bytes after it are a trailer the sender appended, not part of
+    // the packet the tunnel carries.
+    //
+    // Bounding by the FRAME length — which is what implementing this from its
+    // title alone would produce — fixes nothing: `packet_trimmed_len` below
+    // already keeps the inner extent inside the frame, and Ethernet min-frame
+    // padding is already trimmed. The missing bound was against the outer
+    // DATAGRAM. A peer that appends a trailer past it AND inflates the inner IP
+    // Total Length to cover it had those out-of-datagram bytes promoted into
+    // the decapsulated packet.
+    let outer_end = outer_datagram_end(frame, meta)?;
+    if outer_end < gre_offset {
+        return None;
+    }
+    let outer = frame.get(..outer_end)?;
+    let base = outer.get(gre_offset..gre_offset + 4)?;
     let flags_version = u16::from_be_bytes([base[0], base[1]]);
     if (flags_version & GRE_VERSION_MASK) != 0 {
         return None;
@@ -663,21 +708,23 @@ pub(super) fn try_native_gre_decap_from_frame(
             return None;
         }
         // Past the checksum/reserved field; bounds-check before advance.
-        frame.get(inner_offset..inner_offset + 4)?;
+        // #6748: bounded by the outer datagram, so an option field that would
+        // only fit in a trailer is refused rather than parsed.
+        outer.get(inner_offset..inner_offset + 4)?;
         inner_offset += 4;
     }
     let mut key = 0u32;
     if key_present {
         key = u32::from_be_bytes(
-            <[u8; 4]>::try_from(frame.get(inner_offset..inner_offset + 4)?).ok()?,
+            <[u8; 4]>::try_from(outer.get(inner_offset..inner_offset + 4)?).ok()?,
         );
         inner_offset += 4;
     }
     if sequence_present {
-        frame.get(inner_offset..inner_offset + 4)?;
+        outer.get(inner_offset..inner_offset + 4)?;
         inner_offset += 4;
     }
-    let inner_packet = frame.get(inner_offset..)?;
+    let inner_packet = outer.get(inner_offset..)?;
     let inner_len = packet_trimmed_len(inner_packet, inner_family)?;
     let inner_packet = &inner_packet[..inner_len];
 

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -538,6 +538,8 @@ mod tests_nat64_tunnel;
 #[path = "tests_gre_local_delivery.rs"]
 mod tests_gre_local_delivery;
 #[cfg(test)]
+mod tests_gre_outer_bound_6748;
+#[cfg(test)]
 #[path = "tests_decap_dnat_table.rs"]
 mod tests_decap_dnat_table;
 #[cfg(test)]

--- a/userspace-dp/src/afxdp/tests_gre_outer_bound_6748.rs
+++ b/userspace-dp/src/afxdp/tests_gre_outer_bound_6748.rs
@@ -1,0 +1,216 @@
+//! #6748: native GRE decap must not promote bytes outside the OUTER IP
+//! datagram.
+//!
+//! THE TITLE MISDESCRIBES THE MECHANISM, and implementing from it would fix
+//! nothing. Decap does not use the frame length as the inner end:
+//! `packet_trimmed_len` reads the INNER header's own declared length and fails
+//! closed when it exceeds the slice, so Ethernet min-frame padding was already
+//! trimmed and was never promoted. What was missing is a bound against the
+//! OUTER datagram: the inner extent was capped at `frame.len() - inner_offset`,
+//! and nothing cross-checked it against the outer IPv4 Total Length / IPv6
+//! Payload Length.
+//!
+//! So the attack needs BOTH halves: a trailer appended past the outer datagram
+//! AND an inner header inflated to cover it. Either alone is already refused.
+//!
+//! The asymmetry is what makes this an oversight rather than a design choice:
+//! `gre_checksum_region` in the same file DID bound by the outer length, and
+//! said so in its docstring — "so trailing Ethernet min-frame padding is
+//! excluded" — while payload promotion did not. Checksummed GRE got an
+//! incidental sanity check that non-checksummed GRE did not.
+
+use super::tests_support::*;
+use super::*;
+use crate::afxdp::forwarding_build::build_forwarding_state;
+use crate::afxdp::gre::try_native_gre_decap_from_frame;
+
+/// Marker byte for the out-of-datagram trailer. Distinctive so a promotion
+/// shows up as this byte appearing in a decapped payload, rather than as a
+/// length mismatch that could have several causes.
+const TRAILER_BYTE: u8 = 0xAA;
+const TRAILER_LEN: usize = 16;
+
+/// Rewrite an IPv4 packet's Total Length and fix its header checksum.
+fn set_inner_total_len(packet: &mut [u8], total: u16) {
+    packet[2..4].copy_from_slice(&total.to_be_bytes());
+    packet[10] = 0;
+    packet[11] = 0;
+    let sum = checksum16(&packet[0..20]);
+    packet[10] = (sum >> 8) as u8;
+    packet[11] = sum as u8;
+}
+
+/// #6748 PRIMARY. A peer appends a trailer past the outer datagram and inflates
+/// the inner Total Length to cover it. Those bytes must never reach the
+/// decapped packet.
+#[test]
+fn gre_decap_refuses_an_inner_that_reaches_past_the_outer_datagram_6748() {
+    let forwarding = build_forwarding_state(&gre_to_self_snapshot());
+
+    let honest = build_gre_inner_icmp_packet_v4();
+    let mut lying = honest.clone();
+    set_inner_total_len(&mut lying, (honest.len() + TRAILER_LEN) as u16);
+
+    // The outer Total Length written here covers 20 + 4 + lying.len() — i.e.
+    // the REAL inner extent. The trailer is appended AFTER that, so it is
+    // outside the outer datagram by construction.
+    let mut frame = build_gre_to_self_outer_frame_v4(0, &lying);
+    let outer_end = frame.len();
+    frame.extend(std::iter::repeat_n(TRAILER_BYTE, TRAILER_LEN));
+
+    // Premise checks: without these, a decap refused for some unrelated reason
+    // would read as the fix working.
+    assert_eq!(
+        u16::from_be_bytes([frame[14 + 2], frame[14 + 3]]) as usize,
+        outer_end - 14,
+        "fixture: the outer Total Length must describe the datagram WITHOUT the trailer",
+    );
+    assert!(
+        frame.len() > outer_end,
+        "fixture: the trailer must actually sit past the outer datagram",
+    );
+
+    let meta = gre_to_self_outer_meta(0, frame.len());
+    let decapped = try_native_gre_decap_from_frame(&frame, meta, &forwarding);
+
+    if let Some(d) = decapped {
+        assert!(
+            !d.frame.contains(&TRAILER_BYTE),
+            "decap PROMOTED bytes from outside the outer IP datagram. A peer that \
+             appends a trailer and inflates the inner Total Length to cover it gets \
+             attacker-chosen bytes into the packet the firewall then adjudicates and \
+             forwards (#6748).",
+        );
+        panic!(
+            "decap accepted a frame whose inner header declares {} bytes while the outer \
+             datagram carries only {}. The inner extent must be bounded by the OUTER \
+             datagram, and an inner header that lies about it is refused, not clamped.",
+            honest.len() + TRAILER_LEN,
+            honest.len(),
+        );
+    }
+}
+
+/// #6748 NEGATIVE CONTROL, and the cell that stops the fix from being a
+/// blanket rejection of trailers.
+///
+/// An HONEST inner with the same trailer must still decap, byte-identically.
+/// Trailers are ordinary: Ethernet min-frame padding puts one on every small
+/// frame, and refusing them would blackhole legitimate GRE. Without this cell,
+/// "bound the inner by the outer datagram" and "reject anything with bytes
+/// after the outer datagram" are indistinguishable, and the second is an
+/// outage.
+#[test]
+fn gre_decap_still_accepts_an_honest_inner_under_a_trailer_6748() {
+    let forwarding = build_forwarding_state(&gre_to_self_snapshot());
+    let honest = build_gre_inner_icmp_packet_v4();
+
+    let mut frame = build_gre_to_self_outer_frame_v4(0, &honest);
+    frame.extend(std::iter::repeat_n(TRAILER_BYTE, TRAILER_LEN));
+
+    let meta = gre_to_self_outer_meta(0, frame.len());
+    let decap = try_native_gre_decap_from_frame(&frame, meta, &forwarding)
+        .expect("an honest inner under trailing padding must still decap — padding is ordinary");
+    assert_eq!(
+        &decap.frame[decap.meta.l3_offset as usize..],
+        &honest[..],
+        "the decapped inner must be byte-identical to the authored one",
+    );
+    assert!(
+        !decap.frame.contains(&TRAILER_BYTE),
+        "the trailer must be trimmed, not carried",
+    );
+}
+
+/// #6748 on the CHECKSUM-PRESENT path. The option-field skips move inside the
+/// outer bound too, so a checksummed frame is subject to the same rule — and
+/// must still accept an honest one, since `gre_checksum_region` already
+/// excluded the trailer from the sum.
+#[test]
+fn gre_decap_checksum_present_honours_the_outer_bound_6748() {
+    let forwarding = build_forwarding_state(&gre_to_self_snapshot());
+    let honest = build_gre_inner_icmp_packet_v4();
+    let mut lying = honest.clone();
+    set_inner_total_len(&mut lying, (honest.len() + TRAILER_LEN) as u16);
+
+    // Honest: still decaps.
+    let mut ok_frame = build_gre_checksum_present_outer_frame_v4(
+        0,
+        crate::afxdp::gre::GRE_FLAG_CHECKSUM,
+        0,
+        0,
+        &honest,
+        false,
+    );
+    ok_frame.extend(std::iter::repeat_n(TRAILER_BYTE, TRAILER_LEN));
+    let ok_meta = gre_to_self_outer_meta(0, ok_frame.len());
+    let decap = try_native_gre_decap_from_frame(&ok_frame, ok_meta, &forwarding)
+        .expect("a checksummed frame with padding must still decap");
+    assert_eq!(&decap.frame[decap.meta.l3_offset as usize..], &honest[..]);
+
+    // Lying: refused, and in particular the trailer is never promoted.
+    let mut bad_frame = build_gre_checksum_present_outer_frame_v4(
+        0,
+        crate::afxdp::gre::GRE_FLAG_CHECKSUM,
+        0,
+        0,
+        &lying,
+        false,
+    );
+    bad_frame.extend(std::iter::repeat_n(TRAILER_BYTE, TRAILER_LEN));
+    let bad_meta = gre_to_self_outer_meta(0, bad_frame.len());
+    if let Some(d) = try_native_gre_decap_from_frame(&bad_frame, bad_meta, &forwarding) {
+        assert!(
+            !d.frame.contains(&TRAILER_BYTE),
+            "checksum-present decap promoted out-of-datagram bytes (#6748)",
+        );
+        panic!("checksum-present decap accepted an inner that reaches past the outer datagram");
+    }
+}
+
+/// #6748: the outer-end computation itself, for BOTH families.
+///
+/// The decap cells above are IPv4-only because the frame builders are; this
+/// covers the v6 arm directly rather than leaving it unasserted. It also pins
+/// the refuse-don't-clamp choice: a declaration longer than the capture is
+/// `None`, because clamping would silently accept a header lying about its own
+/// datagram — the same trust this function exists to remove.
+#[test]
+fn outer_datagram_end_reads_both_families_and_refuses_overdeclaration_6748() {
+    // IPv4: l3 at 14, Total Length 60 -> end 74.
+    let mut v4 = vec![0u8; 14];
+    v4.extend_from_slice(&[0x45, 0x00]);
+    v4.extend_from_slice(&60u16.to_be_bytes());
+    v4.extend(std::iter::repeat_n(0u8, 60 - 4));
+    v4.extend(std::iter::repeat_n(TRAILER_BYTE, 8));
+    let v4_meta = gre_to_self_outer_meta(0, v4.len());
+    assert_eq!(
+        crate::afxdp::gre::outer_datagram_end(&v4, v4_meta),
+        Some(74),
+        "IPv4 outer end is l3 + Total Length, excluding the trailer",
+    );
+
+    // IPv6: l3 at 14, Payload Length 20 -> end 14 + 40 + 20 = 74.
+    let mut v6 = vec![0u8; 14];
+    v6.extend_from_slice(&[0x60, 0x00, 0x00, 0x00]);
+    v6.extend_from_slice(&20u16.to_be_bytes());
+    v6.extend(std::iter::repeat_n(0u8, 40 - 6 + 20));
+    v6.extend(std::iter::repeat_n(TRAILER_BYTE, 8));
+    let mut v6_meta = gre_to_self_outer_meta(0, v6.len());
+    v6_meta.addr_family = libc::AF_INET6 as u8;
+    assert_eq!(
+        crate::afxdp::gre::outer_datagram_end(&v6, v6_meta),
+        Some(74),
+        "IPv6 outer end is l3 + 40 + Payload Length, excluding the trailer",
+    );
+
+    // Over-declaration is refused, not clamped, in both families.
+    let mut short_v4 = v4[..40].to_vec();
+    short_v4[14 + 2..14 + 4].copy_from_slice(&600u16.to_be_bytes());
+    let short_meta = gre_to_self_outer_meta(0, short_v4.len());
+    assert_eq!(
+        crate::afxdp::gre::outer_datagram_end(&short_v4, short_meta),
+        None,
+        "an outer header declaring more than was captured must be refused",
+    );
+}


### PR DESCRIPTION
## Summary

Native GRE decap capped the inner extent at `frame.len() - inner_offset` with
**no cross-check against the outer IPv4 Total Length / IPv6 Payload Length**. A
peer that appends a trailer past the outer datagram **and** inflates the inner IP
Total Length to cover it therefore had those out-of-datagram bytes promoted into
the decapsulated packet — the packet the firewall then adjudicates and forwards.

The attack needs both halves; either alone is already refused.

## Not the mechanism the title implies

Decap does **not** use the frame length as the inner end. `packet_trimmed_len`
reads the *inner* header's own declared length and fails closed when it exceeds
the slice, so Ethernet min-frame padding was already trimmed and was never
promoted. **Bounding by the frame length — which is what implementing this from
its title alone would produce — would look correct and fix nothing.** The missing
bound is against the outer *datagram*.

Nothing earlier establishes it either: `raw_frame` is the AF_XDP descriptor
length, `classify_metadata` validates snapshot/config-gen/fib-gen/addr-family and
performs **no length validation at all**, and the XDP shim declares
`tot_len`/`payload_len` in its header structs but never reads either.

## The bound already existed — in one place

`gre_checksum_region`, in the same file, *did* compute the outer end, and its
docstring said why: *"bounded by the OUTER IP length … so trailing Ethernet
min-frame padding is excluded"*. It was applied to the **checksum only**, so
checksummed GRE got an incidental outer-length sanity check that non-checksummed
GRE did not. That asymmetry is the strongest evidence this was an oversight
rather than a design choice, and it is why the fix **extracts** that computation
(`outer_datagram_end`) instead of writing a second, possibly divergent, notion of
"outer end". The GRE option-field skips and the inner extraction now both run on
`frame[..outer_end]`.

An outer header declaring more than was captured is **refused, not clamped**:
clamping would silently accept a header lying about its own datagram, which is
the same trust this bound exists to remove. An inner header reaching past the
outer end is likewise refused rather than trimmed.

## The negative control is load-bearing

Trailers are ordinary — Ethernet min-frame padding puts one on every small frame.
Without a cell asserting that an **honest** inner under the same trailer still
decaps byte-identically, *"bound the inner by the outer datagram"* and *"reject
anything with bytes after the outer datagram"* are indistinguishable, and the
second is a blackhole for legitimate GRE. Both the flagless and the
checksum-present paths carry that control, and **mutation cell 3 is that mistake
applied.**

The v6 arm is covered directly on `outer_datagram_end` rather than left
unasserted: the frame builders in this crate are IPv4-only, and a cell quietly
testing one family while claiming both would be worse than naming the gap.

## The issue's WireGuard question, answered

It asks whether the identical `packet_trimmed_len` pattern in the WireGuard decap
path needs the same treatment. **Checked: no.** The only other callers are
*encap* paths — this file's outer builder and `frame/wg.rs`'s — where no outer
datagram exists yet, so there is nothing to bound. Recorded so the question is
not re-opened.

## Mutation matrix

Full-binary per cell (`cargo test --bin xpf-userspace-dp -- --test-threads=1`, no
name filter), rc + tests-collected from a file so a build break cannot
masquerade as a clean red. Base `cadb5e90c…`, head `ac6fe21ef…`.

| # | Mutation | rc | collected | Which assertion fired |
|---|---|---|---|---|
| 1 | revert the inner extraction to the **frame** bound (verbatim pre-fix) | 101 | 4558 | `:77` *"decap PROMOTED bytes from outside the outer IP datagram. A peer that appends a trailer and inflates the inner Total Length to cover it gets attacker-chosen bytes into the packet the firewall then adjudicates and forwards"* — plus the checksum-present cell at `:163` |
| 2 | **clamp** an over-declaring outer header instead of refusing it | 101 | 4559 | `:211` *"an outer header declaring more than was captured must be refused"* |
| 3 | **over-reject** — refuse any frame with bytes after the outer datagram | 101 | 4558 | `:113` *"an honest inner under trailing padding must still decap — padding is ordinary"* and `:148` for the checksummed path |

**Cell 1 is the measurement**: it reproduces the defect by name, so the fix is
demonstrated against the behaviour rather than argued from the diff. **Cell 3 is
the one that keeps the fix honest** — it is the plausible over-correction, and it
reds only the negative controls.

## Validation

- `cargo test -- --test-threads=1` — **rc=0, 4689 tests ok, 0 failed**.
- `go test ./... -count=1` — **rc=0, 67 packages ok, 0 FAIL**.

## ⚠️ Cluster gate owed

**This moves the `userspace-dp` binary.** It does not touch the XDP shim, so
#7494's verifier-headroom constraint does not apply, and there is no cluster,
VRRP, session-sync or failover code and no wire-format change. But the deployed
dataplane binary changes and this is the GRE forwarding path, so it wants the
centrally-run smoke — and per your note the Go-only fold gate cannot see a Rust
regression, so the **cargo leg on the merge result** is worth running too. I ran
no cluster target.

Closes #6748
