### PR TITLE
config: do not panic on a malformed address-family node

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103983,3 +103983,13 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: userspace-dp/src/afxdp/gre.rs, userspace-dp/src/afxdp/mod.rs,
   userspace-dp/src/afxdp/tests_gre_outer_bound_6748.rs (new),
   docs/userspace-native-gre-plan.md
+
+## 2026-08-22 — #7522 malformed address-family node no longer panics
+- **Timestamp**: 2026-08-22
+- **Action**: compileInterfaces indexed afNode.Keys[0] with no bounds check; a
+  family child with empty Keys (reachable from a malformed persisted AST, which
+  configstore unmarshals with no Node validator) panicked. Switched to the
+  nil-safe Name(), matching #4827's fix on the sibling firewall walkers. Swept
+  pkg/config for the same shape: no other unguarded site.
+- **File(s)**: pkg/config/compiler_interfaces.go,
+  pkg/config/compiler_interfaces_malformed_af_7522_test.go

--- a/pkg/config/compiler_interfaces.go
+++ b/pkg/config/compiler_interfaces.go
@@ -369,7 +369,27 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig, opts compileOpts, w
 					afNodes = append(afNodes, familyNode.Children...)
 				}
 				for _, afNode := range afNodes {
-					afName := afNode.Keys[0]
+					// #7522: Name() rather than Keys[0]. It returns "" for an
+					// empty Keys slice, where Keys[0] panics with index out of
+					// range. afNodes is either familyNode itself (len(Keys) >= 2
+					// by the branch above, so safe) or familyNode.Children —
+					// and a CHILD's Keys are not structurally guaranteed
+					// non-empty once the tree can come from anywhere but the
+					// parser.
+					//
+					// The live parser and SetPath paths do guarantee
+					// len(Keys) >= 1, so this only bites a malformed persisted
+					// AST — pkg/configstore/db.go's plain json.Unmarshal has no
+					// Node validator — or a handcrafted tree. A bad persisted
+					// state must ERROR on load, never panic (#1960
+					// fail-closed-on-load). Same fix and same reasoning as
+					// #4827 applied to the sibling firewall family walkers.
+					//
+					// An empty afName matches no address family below and the
+					// unit is compiled without one, which is the same outcome as
+					// an unrecognised family name — it does not silently adopt a
+					// neighbour's family.
+					afName := afNode.Name()
 					if len(afNode.Keys) >= 2 {
 						afName = afNode.Keys[1]
 					}

--- a/pkg/config/compiler_interfaces_malformed_af_7522_test.go
+++ b/pkg/config/compiler_interfaces_malformed_af_7522_test.go
@@ -1,0 +1,162 @@
+package config
+
+import "testing"
+
+// #7522: compileInterfaces indexed afNode.Keys[0] with no bounds check, so a
+// family node whose CHILD carries an empty Keys slice panicked with index out
+// of range.
+//
+// afNodes is either the family node itself — guaranteed len(Keys) >= 2 by the
+// branch that selects it — or familyNode.Children, and a child's Keys are only
+// structurally non-empty when the tree came from the parser or SetPath. A
+// malformed persisted AST does not: pkg/configstore/db.go unmarshals the stored
+// JSON with a plain json.Unmarshal and no Node validator, so a corrupted or
+// hand-edited store reaches the compiler directly.
+//
+// A bad persisted state must ERROR on load, never panic (#1960
+// fail-closed-on-load). Same fix and reasoning as #4827 on the sibling firewall
+// family walkers, which is why this uses Name() rather than a length check: the
+// nil-safe accessor already exists and is what those walkers adopted.
+//
+// The tree is hand-built on purpose. Going through ParseSetCommand/SetPath
+// would be a fixture that CANNOT produce the defect — those paths guarantee
+// len(Keys) >= 1, so the test would pass against the unfixed code and prove
+// nothing.
+
+// malformedAFTree7522 builds interfaces { ge-0/0/0 { unit 0 { family { <empty> } } } }
+// where the address-family node has NO keys at all.
+func malformedAFTree7522() *ConfigTree {
+	afNode := &Node{Keys: nil} // the malformed node: no keys
+	familyNode := &Node{Keys: []string{"family"}, Children: []*Node{afNode}}
+	unitNode := &Node{Keys: []string{"unit", "0"}, Children: []*Node{familyNode}}
+	ifNode := &Node{Keys: []string{"ge-0/0/0"}, Children: []*Node{unitNode}}
+	return &ConfigTree{Children: []*Node{
+		{Keys: []string{"interfaces"}, Children: []*Node{ifNode}},
+	}}
+}
+
+// TestMalformedAddressFamilyNodeDoesNotPanic7522 is the defect proper. Before
+// the fix this panics; the assertion is that CompileConfig RETURNS.
+func TestMalformedAddressFamilyNodeDoesNotPanic7522(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("CompileConfig PANICKED on a malformed persisted AST: %v — a corrupted "+
+				"config store must fail the load, never take the daemon down", r)
+		}
+	}()
+
+	cfg, err := CompileConfig(malformedAFTree7522())
+	t.Logf("CompileConfig returned cfg=%v err=%v", cfg != nil, err)
+
+	// The unit must still exist: an unkeyed family child is garbage, and
+	// discarding the whole interface because of it would be a different bug.
+	if err == nil && cfg != nil {
+		ifc := cfg.Interfaces.Interfaces["ge-0/0/0"]
+		if ifc == nil {
+			t.Error("the interface was dropped entirely because one address-family child was " +
+				"malformed; the empty node should be ignored, not poison its parent")
+		}
+	}
+}
+
+// TestWellFormedAddressFamiliesStillCompile7522 is the TIGHTENING control.
+//
+// Name() returns "" for an empty Keys slice, and "" matches no address family —
+// so the malformed node is ignored. A fix that ignored MORE than that (say, an
+// early `continue` on the whole family node, or treating any afName as
+// unrecognised) would satisfy the test above while silently dropping real
+// addresses. This pins that both AST shapes still produce their families.
+func TestWellFormedAddressFamiliesStillCompile7522(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sets []string
+	}{
+		{"flat set shape", []string{
+			"set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24",
+			"set interfaces ge-0/0/0 unit 0 family inet6 address 2001:db8::1/64",
+		}},
+		{"hierarchical shape", []string{
+			"set interfaces ge-0/0/1 unit 0 family inet address 10.0.2.1/24",
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := &ConfigTree{}
+			for _, cmd := range tc.sets {
+				path, err := ParseSetCommand(cmd)
+				if err != nil {
+					t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+				}
+				if err := tree.SetPath(path); err != nil {
+					t.Fatalf("SetPath(%q): %v", cmd, err)
+				}
+			}
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("CompileConfig: %v", err)
+			}
+			var found bool
+			for name, ifc := range cfg.Interfaces.Interfaces {
+				for _, u := range ifc.Units {
+					if u == nil {
+						continue
+					}
+					if len(u.Addresses) > 0 {
+						found = true
+					}
+				}
+				_ = name
+			}
+			if !found {
+				t.Error("no address family compiled an address: the malformed-node guard has " +
+					"widened into dropping well-formed families")
+			}
+		})
+	}
+}
+
+// TestChildShapedFamilyStillCompiles7522 is the TIGHTENING control aimed at the
+// branch this fix actually changed.
+//
+// The test above exercises `family inet` as ONE node with two keys — which is
+// what ParseSetCommand/SetPath produce today (measured: Keys=[family inet]) — so
+// afNodes is the family node itself and the Children branch is never taken. A
+// control built from set commands therefore CANNOT see an over-rejecting change
+// to the Children branch, and passed a mutation that skipped every node with
+// fewer than two keys.
+//
+// This builds the other shape directly: Keys=["family"] with a well-formed
+// child Keys=["inet"]. That is the shape the branch exists for, and the shape a
+// persisted tree from an older writer can still hold. An empty-Keys child must
+// be ignored; a well-formed one must still compile its address.
+func TestChildShapedFamilyStillCompiles7522(t *testing.T) {
+	good := &Node{Keys: []string{"inet"}, Children: []*Node{
+		{Keys: []string{"address", "10.0.9.1/24"}, IsLeaf: true},
+	}}
+	bad := &Node{Keys: nil} // the #7522 malformed sibling, alongside a good one
+	familyNode := &Node{Keys: []string{"family"}, Children: []*Node{bad, good}}
+	unitNode := &Node{Keys: []string{"unit", "0"}, Children: []*Node{familyNode}}
+	ifNode := &Node{Keys: []string{"ge-0/0/9"}, Children: []*Node{unitNode}}
+	tree := &ConfigTree{Children: []*Node{
+		{Keys: []string{"interfaces"}, Children: []*Node{ifNode}},
+	}}
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	ifc := cfg.Interfaces.Interfaces["ge-0/0/9"]
+	if ifc == nil {
+		t.Fatal("interface ge-0/0/9 did not compile at all")
+	}
+	var got []string
+	for _, u := range ifc.Units {
+		if u != nil {
+			got = append(got, u.Addresses...)
+		}
+	}
+	if len(got) != 1 || got[0] != "10.0.9.1/24" {
+		t.Errorf("child-shaped family compiled addresses %v, want [10.0.9.1/24] — the "+
+			"malformed sibling must be ignored WITHOUT dropping the well-formed family "+
+			"next to it", got)
+	}
+}


### PR DESCRIPTION
Closes #7522

`compileInterfaces` indexed `afNode.Keys[0]` with no bounds check. `afNodes` is either the family node itself — guaranteed `len(Keys) >= 2` by the branch that selects it — or `familyNode.Children`, and a child's `Keys` are only structurally non-empty when the tree came from the parser or `SetPath`.

A malformed persisted AST does not qualify: `pkg/configstore/db.go` unmarshals the stored JSON with a plain `json.Unmarshal` and no `Node` validator, so a corrupted or hand-edited store reaches the compiler directly and takes the daemon down with an index-out-of-range panic. A bad persisted state must **error** on load, never panic (#1960 fail-closed-on-load).

Uses `Name()`, the nil-safe accessor, rather than a length check — #4827 adopted exactly that for the sibling firewall family walkers, for exactly this reason. An empty name matches no address family, so the malformed node is ignored and the unit compiles without one: the same outcome as an unrecognised family name, not a silent adoption of a neighbour's family.

## Scope: measured, and the answer was "no siblings"

I expected a class and swept for it — `Keys[0]` indexed on a node reached from a `.Children` range, across `pkg/config`. **31 candidate sites.**

The first pass looked at assignment lines alone and appeared to find eleven unguarded. Reading each site's *preceding* lines showed ten already carry a guard (`len(...) == 0 { continue }`, `len(...) < 2 { continue }`, or an inline `len(...) >= 1 &&`). **This was the only one left** — #4827 had closed the rest of the class.

Reporting the negative because it is the useful part: nobody needs to re-run this sweep, and there is no successor issue to file.

## The tightening control was aimed at the wrong branch, and a mutation caught it

My first control built its fixture from `set` commands. Under a mutation that skipped every family node with fewer than two keys, it **passed** — so I measured the actual AST instead of trusting the shape doc:

```
Keys=[interfaces]
  Keys=[ge-0/0/0]
    Keys=[unit 0]
      Keys=[family inet]          <- ONE node, TWO keys
        Keys=[address 10.0.1.1/24]
```

`ParseSetCommand`/`SetPath` produce `family inet` as one two-key node, so `afNodes` is the family node itself and **the `Children` branch is never taken**. A control built from set commands structurally cannot see an over-rejecting change to the branch this fix modifies.

`TestChildShapedFamilyStillCompiles7522` builds the other shape directly — `Keys=["family"]` with a well-formed child `Keys=["inet"]` carrying an address, and the malformed empty-Keys sibling beside it — and asserts the malformed node is ignored **without dropping the good family next to it**.

## Mutation matrix

Fix committed first. Full `pkg/config` suite per cell, no `-run` filter, rc from a file, control green first.

| # | mutation | rc | fired |
|---|---|---|---|
| V1 | revert to the verbatim `Keys[0]` index | 1 | `TestMalformedAddressFamilyNodeDoesNotPanic7522` — panics |
| V2 | **TIGHTEN**: skip any family node with fewer than 2 keys | 0 → 1 | passed until the control was re-aimed; now `TestChildShapedFamilyStillCompiles7522` |

V2 also reds `TestSchemaSpellingGateCoverageIsGated_7484` — the coverage ratchet landed earlier today. Over-rejecting address families collapses that gate's measured coverage, which is a useful independent signal that the mutation is a real behaviour change and not a no-op.

## Note on the defect fixture

The malformed tree is **hand-built on purpose**. Going through `ParseSetCommand`/`SetPath` would be a fixture that cannot produce the defect — those paths guarantee `len(Keys) >= 1` — so such a test passes against the unfixed code and proves nothing.

## Provenance

Split out of #6744 (`kimi-review-003` cohort triage) and **re-verified at current master** by the lane that filed it. That issue's corrected reachability note is right and worth repeating: the source report's HA-sync path is **false**, because peer sync reparses text. The real reachability is a malformed persisted store or a handcrafted tree.

## Validation

`go build`, `go vet`, `gofmt` clean; `go test -count=1 ./...` green repo-wide. `pkg/config` only — no cluster, no dataplane, no `userspace-dp` binary or shim `.o` moved.
