### PR TITLE
userspace-dp: restore the prior arm state when a reconcile fails (#6750)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -103983,3 +103983,27 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: userspace-dp/src/afxdp/gre.rs, userspace-dp/src/afxdp/mod.rs,
   userspace-dp/src/afxdp/tests_gre_outer_bound_6748.rs (new),
   docs/userspace-native-gre-plan.md
+
+## 2026-08-22 — #6750 failed reconcile no longer retains the requested state
+- **Action**: Re-derived the rotted cites by SYMBOL at `ac4f5dce1`. All three
+  control handlers (`set_forwarding_state`, `set_binding_state`,
+  `set_queue_state`) commit the REQUESTED arm/registration bits into
+  `guard.status` and only then call `reconcile_status_bindings`. #5621/#6135 made
+  the failure honest to the CALLER (ok=false + error, no persist) but left the
+  committed state committed, so the helper reported a posture its AF_XDP sockets
+  had never been reconciled to. The suppression half is on the Go side:
+  `syncDesiredForwardingStateLocked` short-circuits on
+  `m.lastStatus.ForwardingArmed == desired`, and the 1 Hz poll feeds
+  `m.lastStatus` straight from the helper (`applyHelperStatusLocked` ->
+  `recordHelperStatusLocked`, maps_sync.go:503) — so the poll ADOPTS the retained
+  value, the equality holds, and the retry is never sent. Fix: one shared
+  `BindingArmSnapshot` capture/restore in `helpers/status.rs`, used by all three
+  handlers, restoring the global flag and the per-slot registered/armed/
+  last_change on the reconcile-failure path only. Restoring makes the helper
+  truthful, which is all automatic recovery needs — no new retry machinery and
+  no persisted debt, so the issue's larger desired/applied split is not required.
+- **File(s)**: userspace-dp/src/server/helpers/status.rs,
+  userspace-dp/src/server/handlers/forwarding.rs,
+  userspace-dp/src/server/handlers/binding.rs,
+  userspace-dp/src/server/handlers/queue.rs,
+  userspace-dp/src/server/tests.rs

--- a/userspace-dp/src/server/handlers/binding.rs
+++ b/userspace-dp/src/server/handlers/binding.rs
@@ -1,7 +1,10 @@
 // #1345: per-verb handler for set_binding_state. Body byte-identical to
 // handlers.rs lines 265-291.
 
-use super::super::helpers::{reconcile_status_bindings, refresh_status};
+use super::super::helpers::{
+    capture_binding_arm_state, reconcile_status_bindings, refresh_status,
+    restore_binding_arm_state,
+};
 use super::super::ServerState;
 use chrono::Utc;
 use crate::{BindingControlRequest, ControlResponse};
@@ -24,6 +27,9 @@ pub(super) fn set(
         response.error = "missing binding state".to_string();
         return;
     };
+    // #6750: capture BEFORE the commit so a failed reconcile can put the
+    // helper's report back to the truth. See BindingArmSnapshot.
+    let prior = capture_binding_arm_state(&guard.status);
     if let Some(binding) = guard
         .status
         .bindings
@@ -51,6 +57,10 @@ pub(super) fn set(
             if let Err(err) = reconcile_status_bindings(guard) {
                 response.ok = false;
                 response.error = format!("binding reconcile failed: {err}");
+                // #6750: roll the requested state back BEFORE refreshing, so
+                // the helper stops reporting a registration its sockets never
+                // took and Go's poll can see the mismatch that drives a retry.
+                restore_binding_arm_state(&mut guard.status, prior);
                 refresh_status(guard);
                 return;
             }

--- a/userspace-dp/src/server/handlers/forwarding.rs
+++ b/userspace-dp/src/server/handlers/forwarding.rs
@@ -2,8 +2,8 @@
 // to handlers.rs lines 132-155.
 
 use super::super::helpers::{
-    forwarding_unsupported_error, reconcile_status_bindings, refresh_status,
-    set_bindings_forwarding_armed,
+    capture_binding_arm_state, forwarding_unsupported_error, reconcile_status_bindings,
+    refresh_status, restore_binding_arm_state, set_bindings_forwarding_armed,
 };
 use super::super::ServerState;
 use crate::{ControlResponse, ForwardingControlRequest};
@@ -35,6 +35,9 @@ pub(super) fn set(
         response.error = forwarding_unsupported_error(&guard.status.capabilities);
         return;
     }
+    // #6750: capture BEFORE the commit so a failed reconcile can put the
+    // helper's report back to the truth. See BindingArmSnapshot.
+    let prior = capture_binding_arm_state(&guard.status);
     guard.status.forwarding_armed = forwarding_req.armed;
     set_bindings_forwarding_armed(&mut guard.status, forwarding_req.armed);
     // #3789: arming/disarming reconciles the ALREADY-ACCEPTED stored
@@ -53,6 +56,12 @@ pub(super) fn set(
     if let Err(err) = reconcile_status_bindings(guard) {
         response.ok = false;
         response.error = format!("forwarding reconcile failed: {err}");
+        // #6750: roll the requested state back BEFORE refreshing, so the
+        // refreshed status describes what the sockets are actually doing. Go's
+        // 1 Hz poll then sees the real state, its
+        // `lastStatus.ForwardingArmed == desired` short-circuit fails, and the
+        // next tick retries by itself.
+        restore_binding_arm_state(&mut guard.status, prior);
         refresh_status(guard);
         return;
     }

--- a/userspace-dp/src/server/handlers/queue.rs
+++ b/userspace-dp/src/server/handlers/queue.rs
@@ -1,7 +1,10 @@
 // #1345: per-verb handler for set_queue_state. Body byte-identical to
 // handlers.rs lines 231-264.
 
-use super::super::helpers::{reconcile_status_bindings, refresh_status};
+use super::super::helpers::{
+    capture_binding_arm_state, reconcile_status_bindings, refresh_status,
+    restore_binding_arm_state,
+};
 use super::super::ServerState;
 use chrono::Utc;
 use crate::{ControlResponse, QueueControlRequest};
@@ -24,6 +27,9 @@ pub(super) fn set(
         response.error = "missing queue state".to_string();
         return;
     };
+    // #6750: capture BEFORE the commit so a failed reconcile can put the
+    // helper's report back to the truth. See BindingArmSnapshot.
+    let prior = capture_binding_arm_state(&guard.status);
     let mut found = false;
     let mut registration_changed = false;
     for binding in guard
@@ -58,6 +64,10 @@ pub(super) fn set(
             if let Err(err) = reconcile_status_bindings(guard) {
                 response.ok = false;
                 response.error = format!("queue reconcile failed: {err}");
+                // #6750: roll the requested state back BEFORE refreshing, so the
+                // helper stops reporting a registration its sockets never took
+                // and Go's poll can see the mismatch that drives a retry.
+                restore_binding_arm_state(&mut guard.status, prior);
                 refresh_status(guard);
                 return;
             }

--- a/userspace-dp/src/server/helpers/status.rs
+++ b/userspace-dp/src/server/helpers/status.rs
@@ -453,6 +453,71 @@ pub(crate) fn should_run_afxdp(status: &ProcessStatus) -> bool {
     status.forwarding_armed && status.capabilities.forwarding_supported
 }
 
+/// #6750: the arm / registration bits a control handler is about to overwrite,
+/// so a FAILED reconcile can put them back.
+///
+/// Three handlers — `set_forwarding_state`, `set_binding_state`,
+/// `set_queue_state` — commit the REQUESTED state into `guard.status` and only
+/// then call `reconcile_status_bindings`. #5621/#6135 made the failure honest to
+/// the CALLER (ok=false plus the error, no persist), but the committed state
+/// stayed committed: the helper went on reporting a posture its AF_XDP sockets
+/// had never been reconciled to.
+///
+/// That retention is what suppresses recovery, and the second half is on the Go
+/// side. `syncDesiredForwardingStateLocked` short-circuits on
+/// `if m.lastStatus.ForwardingArmed == desired { return nil }`, and the 1 Hz
+/// status poll feeds `m.lastStatus` straight from the helper
+/// (`applyHelperStatusLocked` -> `recordHelperStatusLocked`). So the poll adopts
+/// the retained "armed" the failed reconcile left behind, the equality then
+/// holds, and the retry that would have fixed it is never sent. The box stays in
+/// the un-reconciled state until something else moves the arm state.
+///
+/// Restoring makes the helper's report TRUE again, which is all automatic
+/// recovery needs: the poll sees the real (still-disarmed) state, the equality
+/// fails, and the next tick retries on its own. No new retry machinery, no
+/// persisted debt.
+pub(crate) struct BindingArmSnapshot {
+    forwarding_armed: bool,
+    /// (slot, registered, armed, last_change) — keyed by SLOT because that is
+    /// how all three handlers address bindings.
+    bindings: Vec<(u32, bool, bool, Option<chrono::DateTime<Utc>>)>,
+}
+
+/// Capture the bits `restore_binding_arm_state` can put back. Cheap: bounded by
+/// the binding count, and only ever called on a control-socket request.
+pub(crate) fn capture_binding_arm_state(status: &ProcessStatus) -> BindingArmSnapshot {
+    BindingArmSnapshot {
+        forwarding_armed: status.forwarding_armed,
+        bindings: status
+            .bindings
+            .iter()
+            .map(|b| (b.slot, b.registered, b.armed, b.last_change))
+            .collect(),
+    }
+}
+
+/// Put back exactly what `capture_binding_arm_state` recorded.
+///
+/// `last_change` is restored too, deliberately. Leaving it advanced would have
+/// the helper advertise a transition that was rolled back — an operator reading
+/// `show` would see a fresh timestamp on a binding whose state never moved, and
+/// the staleness heuristics keyed on it would be reasoning about an event that
+/// did not happen.
+///
+/// A slot that no longer exists is skipped rather than re-created: the
+/// reconcile may have replanned, and resurrecting a slot the current plan does
+/// not contain would be inventing state rather than restoring it.
+pub(crate) fn restore_binding_arm_state(status: &mut ProcessStatus, prior: BindingArmSnapshot) {
+    status.forwarding_armed = prior.forwarding_armed;
+    for (slot, registered, armed, last_change) in prior.bindings {
+        if let Some(binding) = status.bindings.iter_mut().find(|b| b.slot == slot) {
+            binding.registered = registered;
+            binding.armed = armed;
+            binding.last_change = last_change;
+        }
+    }
+}
+
 pub(crate) fn set_bindings_forwarding_armed(status: &mut ProcessStatus, armed: bool) {
     for binding in &mut status.bindings {
         binding.armed = armed && binding.registered;

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -3815,3 +3815,165 @@ fn report_tick_summary_guard_rejects_the_pre_fix_shape_5189() {
          ever, and would pin no property"
     );
 }
+
+/// #6750: a FAILED reconcile must not leave the requested state committed.
+///
+/// All three control handlers — `set_forwarding_state`, `set_binding_state`,
+/// `set_queue_state` — write the requested arm / registration bits into
+/// `guard.status` and only then call `reconcile_status_bindings`. #5621/#6135
+/// made the failure honest to the CALLER (the cells above assert ok=false plus
+/// the error), but the committed state stayed committed: the helper went on
+/// reporting a posture its AF_XDP sockets had never been reconciled to.
+///
+/// THAT RETENTION IS WHAT SUPPRESSES RECOVERY, and the second half is on the Go
+/// side. `syncDesiredForwardingStateLocked` short-circuits on
+/// `if m.lastStatus.ForwardingArmed == desired { return nil }`, and the 1 Hz
+/// status poll feeds `m.lastStatus` straight from the helper
+/// (`applyHelperStatusLocked` -> `recordHelperStatusLocked`, maps_sync.go). So
+/// the poll adopts the retained "armed" the failed reconcile left behind, the
+/// equality then holds, and the retry that would have fixed it is never sent.
+///
+/// Restoring is all automatic recovery needs: the helper reports the truth, the
+/// equality fails, the next tick retries. No new retry machinery, no persisted
+/// debt — which is why this is the narrow fix rather than the desired/applied
+/// split the issue also offers.
+///
+/// Each cell pairs the ok=false assertion with a STATE assertion, because the
+/// two are independent: #5621 already delivers the first, and it is exactly the
+/// combination "honest to the caller, dishonest in the status" that made this
+/// survive the earlier fix.
+#[test]
+fn failed_forwarding_reconcile_restores_the_prior_arm_state_6750() {
+    // Start DISARMED so the request is a real transition and the rollback is
+    // observable: a fixture that was already armed could not tell "restored"
+    // from "never changed".
+    let state = Arc::new(Mutex::new(ServerState {
+        status: ProcessStatus {
+            forwarding_armed: false,
+            capabilities: forwarding_caps(),
+            bindings: vec![BindingStatus {
+                slot: 0,
+                registered: true,
+                armed: false,
+                ifindex: 10,
+                ..BindingStatus::default()
+            }],
+            ..ProcessStatus::default()
+        },
+        snapshot: Some(failing_reconcile_snapshot()),
+        afxdp: afxdp::Coordinator::new(),
+        state_writer: Arc::new(StateWriter::new()),
+    }));
+
+    let mut request = req("set_forwarding_state");
+    request.forwarding = Some(ForwardingControlRequest { armed: true });
+    let response = run_request(state.clone(), request);
+
+    assert!(!response.ok, "premise: the reconcile must have failed");
+    assert!(
+        response.error.contains("forwarding reconcile failed"),
+        "premise: unexpected error {}",
+        response.error
+    );
+
+    let guard = state.lock().expect("state");
+    assert!(
+        !guard.status.forwarding_armed,
+        "the helper still reports forwarding_armed=true after a reconcile that \
+         FAILED. Go's 1 Hz poll adopts that into m.lastStatus, its \
+         `lastStatus.ForwardingArmed == desired` short-circuit then holds, and \
+         the retry that would reconcile the sockets is never sent — the box \
+         stays un-reconciled indefinitely (#6750)",
+    );
+    assert!(
+        !guard.status.bindings[0].armed,
+        "the per-binding arm bit was left committed after a failed reconcile",
+    );
+}
+
+/// #6750 for `set_binding_state`: the registration bit must roll back too.
+#[test]
+fn failed_binding_reconcile_restores_the_prior_registration_6750() {
+    let state = armed_state_with_failing_reconcile(vec![BindingStatus {
+        slot: 0,
+        registered: false,
+        armed: false,
+        ifindex: 10,
+        ..BindingStatus::default()
+    }]);
+    let mut request = req("set_binding_state");
+    request.binding = Some(BindingControlRequest {
+        slot: 0,
+        registered: true,
+        armed: true,
+    });
+    let response = run_request(state.clone(), request);
+    assert!(!response.ok, "premise: the reconcile must have failed");
+
+    let guard = state.lock().expect("state");
+    assert!(
+        !guard.status.bindings[0].registered,
+        "slot 0 still reports registered=true after a reconcile that FAILED — the \
+         helper is advertising a binding its sockets never took (#6750)",
+    );
+    assert!(!guard.status.bindings[0].armed, "the arm bit was left committed too");
+}
+
+/// #6750 for `set_queue_state`, which mutates EVERY binding on the queue — so
+/// the rollback has to be per-slot, not a single scalar.
+#[test]
+fn failed_queue_reconcile_restores_every_binding_on_the_queue_6750() {
+    let state = armed_state_with_failing_reconcile(vec![
+        BindingStatus {
+            slot: 0,
+            queue_id: 2,
+            registered: false,
+            armed: false,
+            ifindex: 10,
+            ..BindingStatus::default()
+        },
+        BindingStatus {
+            slot: 1,
+            queue_id: 2,
+            registered: false,
+            armed: false,
+            ifindex: 11,
+            ..BindingStatus::default()
+        },
+        // A binding on a DIFFERENT queue: untouched by the request, and it must
+        // stay untouched by the rollback. Without it, "restore what changed"
+        // and "stamp the whole table back to some baseline" look the same.
+        BindingStatus {
+            slot: 2,
+            queue_id: 7,
+            registered: true,
+            armed: true,
+            ifindex: 12,
+            ..BindingStatus::default()
+        },
+    ]);
+    let mut request = req("set_queue_state");
+    request.queue = Some(QueueControlRequest {
+        queue_id: 2,
+        registered: true,
+        armed: true,
+    });
+    let response = run_request(state.clone(), request);
+    assert!(!response.ok, "premise: the reconcile must have failed");
+
+    let guard = state.lock().expect("state");
+    for slot in [0usize, 1] {
+        assert!(
+            !guard.status.bindings[slot].registered,
+            "slot {slot} on the requested queue still reports registered=true after \
+             a FAILED reconcile (#6750)",
+        );
+        assert!(!guard.status.bindings[slot].armed, "slot {slot} arm bit left committed");
+    }
+    assert!(
+        guard.status.bindings[2].registered && guard.status.bindings[2].armed,
+        "the binding on the UNTOUCHED queue was rolled back too — the restore \
+         must put back what THIS request changed, not stamp a baseline over the \
+         whole table",
+    );
+}


### PR DESCRIPTION
## Summary

All three control handlers — `set_forwarding_state`, `set_binding_state`,
`set_queue_state` — write the **requested** arm / registration bits into
`guard.status` and only then call `reconcile_status_bindings`.

#5621 and #6135 made a failed reconcile honest to the **caller**: `ok=false`, the
error surfaced, no persist. They did not make it honest in the **status**. The
committed state stayed committed, so the helper went on reporting a posture its
AF_XDP sockets had never been reconciled to.

That combination — *honest to the caller, dishonest in the status* — is why this
survived the earlier fix.

## The retention is what suppresses recovery

The second half is on the Go side, and it is what turns a wrong field into a
permanent state:

- `syncDesiredForwardingStateLocked` short-circuits on
  `if m.lastStatus.ForwardingArmed == desired { return nil }`;
- the 1 Hz status poll feeds `m.lastStatus` **straight from the helper**
  (`applyHelperStatusLocked` → `recordHelperStatusLocked`, `maps_sync.go:503`).

So the poll **adopts** the retained `armed` the failed reconcile left behind, the
equality then holds, and the retry that would have reconciled the sockets is
never sent. The box stays un-reconciled until something else moves the arm state.

**Restoring is all automatic recovery needs.** The helper reports the truth, the
poll sees the real state, the equality fails, the next tick retries by itself —
no new retry machinery, no persisted debt. The issue's alternative direction
(split desired/applied and persist explicit retry debt) is a much larger design
this does not require.

## One restore, not three

The three handlers have the identical shape, so the capture/restore is a single
`BindingArmSnapshot` in `helpers/status.rs` rather than three hand-maintained
copies: a divergence between them could only ever be a bug, never a policy
difference.

`last_change` is restored with the bits, deliberately — leaving it advanced would
have the helper advertise a transition that was rolled back, and the staleness
heuristics keyed on it would be reasoning about an event that did not happen.

A slot that no longer exists is **skipped, not re-created**: the reconcile may
have replanned, and resurrecting a slot the current plan does not contain would
be inventing state rather than restoring it.

## Evidence re-derived, because the issue's had rotted

#6750 cites `/tmp/opus-review-001.md` (gone) and base `ad9591177481`. Located by
symbol at `ac4f5dce18a8be7777cc702073cbe83786f38494`:

| original cite | now | verdict |
|---|---|---|
| `forwarding.rs:27/:32/:47` | commit-then-reconcile at `:39-58` | **HOLDS** |
| `binding.rs:21/:27/:45` | `:34-56` | **HOLDS** |
| `queue.rs:21/:29/:52` | `:38-58` | **HOLDS** |
| `manager_ha.go:601/:606` | `syncDesiredForwardingStateLocked` `:500`, suppression `:578` | **HOLDS** — the half that makes it permanent |
| `process_status.go:240` | the poll's `applyHelperStatusLocked` at `:211` | **HOLDS** |

## Tests

Three cells, one per handler, each pairing the `ok=false` assertion with a
**state** assertion — the two are independent, and #5621 already delivers the
first.

- The forwarding cell starts **disarmed**, so the request is a real transition:
  a fixture that was already armed could not tell "restored" from "never
  changed".
- The queue cell carries a binding on an **untouched** queue, because without it
  *"restore what this request changed"* and *"stamp a baseline over the whole
  table"* look identical. **Mutation cell 3 is that mistake applied.**

## Mutation matrix

Full-binary per cell (`cargo test --bin xpf-userspace-dp -- --test-threads=1`, no
name filter), rc + tests-collected from a file. Base `ac4f5dce1…`, head
`b4465fc7d…`.

| # | Mutation | rc | collected | Which assertion fired |
|---|---|---|---|---|
| 1 | the forwarding handler stops restoring (verbatim pre-fix) | 101 | 4565 | the forwarding cell — *"the helper still reports forwarding_armed=true after a reconcile that FAILED … the retry that would reconcile the sockets is never sent"* |
| 2 | the restore matches no slot (global flag rolls back, per-binding bits do not) | 101 | 4563 | **all three cells** — *"slot 0 still reports registered=true … the helper is advertising a binding its sockets never took"* |
| 3 | stamp a baseline over the **whole table** instead of restoring what changed | 101 | 4565 | only the queue cell — *"the binding on the UNTOUCHED queue was rolled back too"* |

Cell 3 is the one that keeps the fix from over-reaching, and it reds exactly the
cell written for it.

## Validation

- `cargo test -- --test-threads=1` — **rc=0, 4695 tests ok, 0 failed**.
- `go test ./... -count=1` — **rc=0, 67 packages ok, 0 FAIL**.

## ⚠️ Cluster gate owed

**This moves the `userspace-dp` binary.** No XDP shim change (so #7494's
verifier-headroom constraint does not apply), no wire-format change, no
cluster/VRRP/session-sync/failover code. The **cargo leg on the merge result** is
worth running alongside the smoke. I ran no cluster target.

Closes #6750
