### PR TITLE
dataplane: count registry lookups serving an obsolete generation (#6741 Increment 1)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104050,3 +104050,32 @@ prose edit above them added. No diff falls in the new test body.
   userspace-dp/src/server/handlers/binding.rs,
   userspace-dp/src/server/handlers/queue.rs,
   userspace-dp/src/server/tests.rs
+
+## 2026-08-22 — #6741 Increment 1: count obsolete registry generations
+- **Timestamp**: 2026-08-22
+- **Action**: Split #6741 and shipped the observability half only. Added
+  registryGeneration (bumped inside publishShimRegistryLocked's existing m.mu
+  hold), registryObsoleteFrom (recorded by Teardown, NOT Close — Close keeps its
+  pinned handles live for hitless restart), and a counter incremented at the two
+  lookup choke points when a lookup SERVES a handle from a superseded
+  generation, with a once-per-epoch warn naming the map. No behaviour change at
+  any of the 135 call sites.
+- **Deliberately NOT closed**: the escape window. lookupMapLocked returns the
+  handle by reference then releases m.mu, so a republish after the lookup is
+  invisible; a zero counter means "no lookup observed a superseded generation",
+  not "no obsolete mutation occurred". Said so in the source, the README and on
+  the issue — a metric implying a guard it lacks is worse than no metric.
+- **Design tension recorded on #6741**: #6740 forbids a BPF syscall under m.mu;
+  a mutation-time generation check requires exactly that (or a token threaded
+  through 135 sites). The two fixes pull in opposite directions and someone must
+  decide deliberately.
+- **Not wired to Prometheus**: the collector reaches the dataplane through the
+  narrow apiRuntimeDataPlane interface (47 references + test fakes); widening it
+  is a separable change. Counter is readable via ObsoleteRegistryAccesses().
+- **Also filed**: #7547 (AttachXDP/DetachXDP read-modify-write sequences have no
+  concurrent coverage; their atomicity rests on an untested applySem claim) —
+  kept OUT of #6741 so a concrete gap does not get buried in a design item.
+- **File(s)**: pkg/dataplane/armed_gate.go, pkg/dataplane/loader.go,
+  pkg/dataplane/registry_generation_6741_test.go (new),
+  pkg/dataplane/armed_gate_matrix_test.go, pkg/dataplane/README.md
+

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -690,6 +690,55 @@ arrival from the `muAcquireProbeHook` pre-lock seam (a signal before
 the contended call can pass the silence window without the goroutine
 ever reaching the mutex).
 
+## Obsolete registry generations are COUNTED, not prevented (#6741 Increment 1)
+
+`Teardown` runs `Cleanup`, which destroys the pinned kernel objects — but it
+deliberately does **not** clear `m.maps` / `m.programs`, and the A3 rule above
+deliberately lets a retained-state method **proceed**. So between a
+Teardown-retain and the next publish, a registry lookup hands back a handle to an
+obsolete forwarding generation and the caller mutates it: a mutation that
+succeeds and reaches nothing. Both recurrence paths do this —
+`bootstrap.go`'s `enterBootstrapMode`, and the standalone first-commit timeout in
+`daemon_apply_commit.go`.
+
+`registryGeneration` is bumped inside `publishShimRegistryLocked`'s existing
+`m.mu` hold, so it and the registry contents can never be read out of step.
+`Teardown` records the superseded boundary in `registryObsoleteFrom`. The two
+lookup helpers — the uniform funnel every registry access already goes through —
+count a lookup that SERVES a handle while the registry is superseded, and log
+once per obsolete epoch naming the map. `ObsoleteRegistryAccesses()` reads the
+total.
+
+**Read the counter correctly.** A zero means *"no lookup OBSERVED a superseded
+generation"*, never *"no obsolete mutation occurred"*:
+
+- it is a **lookup-time** observation. `lookupMapLocked` returns the `*ebpf.Map`
+  by reference and then **releases `m.mu`**, so a republish landing after the
+  lookup returns is invisible to it. A caller holding an escaped handle across a
+  republish is counted **zero** times.
+- it changes **no behaviour**. Every caller proceeds exactly as before. Making
+  retained mutations fail is a behaviour change at 135 call sites and is the
+  deferred half of #6741.
+
+**Why the stronger guarantee is not just a tighter lock.** Checking the
+generation at *mutation* time means threading a token through those 135 sites, or
+converting them to `withMap(name, func(*ebpf.Map) error)` callbacks — and the
+callback form puts a BPF syscall inside `m.mu`, which #6740 established must not
+happen (the 1 Hz status path needs that lock). #6740 and #6741's first acceptance
+criterion therefore pull in opposite directions, and closing the escape window
+needs a mechanism that is neither: a generation-tagged handle wrapper, a per-map
+lock separate from `m.mu`, or an accepted narrowing of the guarantee. That is
+recorded on #6741 rather than decided here.
+
+What this increment buys the redesign is the thing it lacked: **evidence about
+frequency**. A counter that never moves on the two recurrence paths changes what
+the redesign should be; one that moves often gives it a reproducible trigger.
+
+The counter is currently readable through `ObsoleteRegistryAccesses()` and the
+per-epoch log. It is **not** wired to Prometheus: the API collector reaches the
+dataplane through the narrow `apiRuntimeDataPlane` interface (47 references plus
+several test fakes), and widening that is a separable change with its own review.
+
 ## Live-indirection primitives (#2114 / #6743 r6)
 
 `live.go` carries the three things the daemon's `liveDataPlane` adapter

--- a/pkg/dataplane/armed_gate.go
+++ b/pkg/dataplane/armed_gate.go
@@ -2,6 +2,7 @@ package dataplane
 
 import (
 	"errors"
+	"log/slog"
 	"sync/atomic"
 
 	"github.com/cilium/ebpf"
@@ -114,7 +115,67 @@ func (m *Manager) lookupMapLocked(name string) (h *ebpf.Map, present bool, st re
 		registryLookupHook()
 	}
 	h, present = m.maps[name]
+	if present {
+		m.obsoleteRegistryLocked("map", name)
+	}
 	return h, present, classifyRegistry(&m.loaded, len(m.maps))
+}
+
+// obsoleteRegistryLocked records that a lookup just served a handle from a
+// SUPERSEDED registry generation (#6741). The caller must hold m.mu.
+//
+// WHAT THIS IS. Teardown's Cleanup destroys the pinned kernel objects but does
+// not clear m.maps / m.programs, and the #2114 A3 rule deliberately lets a
+// retained-state method PROCEED. So between a Teardown-retain and the next
+// publish, a lookup hands back a handle to an obsolete forwarding generation and
+// the caller mutates it: a mutation that succeeds and reaches nothing. Nothing
+// measured that before this counter, on either recurrence path
+// (bootstrap.go's enterBootstrapMode, and the standalone first-commit timeout in
+// daemon_apply_commit.go).
+//
+// WHAT THIS IS NOT — and the distinction is the whole reason it is a counter and
+// not a guard. It does NOT close the hazard, and it must not be read as
+// evidence that the hazard cannot happen:
+//
+//   - it is a LOOKUP-TIME observation. lookupMapLocked returns the *ebpf.Map by
+//     reference and then RELEASES m.mu, so a republish that lands after the
+//     lookup returns is invisible here. A caller holding an escaped handle
+//     across a republish is counted zero times.
+//   - it changes no behaviour. Every caller proceeds exactly as before,
+//     deliberately: making retained mutations fail is a behaviour change at 135
+//     call sites and is the deferred half of #6741.
+//
+// A zero counter therefore means "no lookup OBSERVED a superseded generation",
+// never "no obsolete mutation occurred". The design tension that makes the
+// stronger guarantee expensive — #6740 forbids holding m.mu across a BPF
+// syscall, which is what a mutation-time check would require — is recorded on
+// #6741.
+func (m *Manager) obsoleteRegistryLocked(kind, name string) {
+	if m.registryObsoleteFrom == 0 || m.registryGeneration > m.registryObsoleteFrom {
+		return
+	}
+	m.obsoleteRegistryAccesses++
+	if m.obsoleteEpochLogged {
+		return
+	}
+	// Once per obsolete epoch, not once per access: these helpers are on every
+	// registry access, and a per-access log here would flood exactly when the
+	// daemon is already in a degraded lifecycle state.
+	m.obsoleteEpochLogged = true
+	slog.Warn("dataplane: registry lookup served a handle from a superseded generation",
+		"kind", kind, "name", name,
+		"generation", m.registryGeneration, "obsolete_from", m.registryObsoleteFrom,
+		"detail", "Teardown retained the registry and no publish has followed; "+
+			"mutations through this handle reach an obsolete forwarding generation (#6741)")
+}
+
+// ObsoleteRegistryAccesses reports how many registry lookups have served a
+// handle from a superseded generation (#6741). See obsoleteRegistryLocked for
+// what a zero does and does not prove.
+func (m *Manager) ObsoleteRegistryAccesses() uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.obsoleteRegistryAccesses
 }
 
 // lookupProgramLocked is lookupMapLocked for the m.programs registry
@@ -129,6 +190,9 @@ func (m *Manager) lookupProgramLocked(name string) (p *ebpf.Program, present boo
 		registryLookupHook()
 	}
 	p, present = m.programs[name]
+	if present {
+		m.obsoleteRegistryLocked("program", name)
+	}
 	return p, present, classifyRegistry(&m.loaded, len(m.maps))
 }
 
@@ -159,6 +223,11 @@ func (m *Manager) publishShimRegistryLocked(prog *ebpf.Program, collMaps, shared
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	// #6741: a new registry generation. Bumped inside the SAME m.mu hold that
+	// installs the handles, so the counter and the map contents can never be
+	// read out of step. Publishing above registryObsoleteFrom is what ends an
+	// obsolete epoch.
+	m.registryGeneration++
 	m.programs[userspaceShimEntryProg] = prog
 	for name, umap := range collMaps {
 		m.maps[name] = umap

--- a/pkg/dataplane/armed_gate_matrix_test.go
+++ b/pkg/dataplane/armed_gate_matrix_test.go
@@ -187,7 +187,11 @@ var managerMethodClasses = map[string]string{
 	"XDPEntryPrograms":   "catG",
 	"IsVLANSubInterface": "catG",
 	"SetLinkForTest":     "catG",
-	"DetachTC":           "catG", // reads only the construction link map
+	// #6741: a pure read of the observability counter under m.mu. It changes no
+	// behaviour and needs no armed state, so it classifies with the other
+	// registry-state reads.
+	"ObsoleteRegistryAccesses": "catG",
+	"DetachTC":                 "catG", // reads only the construction link map
 	// DetachXDP's single label is category G (its direct access is the
 	// construction link map) with the class-3-LIKE delegation target
 	// setXDPAttachedFlag: scoped lookups, cleanup always runs, NO gate.
@@ -243,8 +247,8 @@ func TestManager_PreArmMethodMatrix(t *testing.T) {
 		}
 	}
 
-	if len(inventory) != 163 {
-		t.Fatalf("exported *Manager method inventory = %d, want 163 (the plan census 157 + the two #6743 r4 additions + ReplaceFloodCounterOffsets (#3651) + the three #6740 additions: XDPEntryPrograms, IsVLANSubInterface, SetLinkForTest); reconcile the count or the plan", len(inventory))
+	if len(inventory) != 164 {
+		t.Fatalf("exported *Manager method inventory = %d, want 164 (the plan census 157 + the two #6743 r4 additions + ReplaceFloodCounterOffsets (#3651) + the three #6740 additions: XDPEntryPrograms, IsVLANSubInterface, SetLinkForTest) + the #6741 observability accessor ObsoleteRegistryAccesses); reconcile the count or the plan", len(inventory))
 	}
 	for name := range inventory {
 		if _, ok := managerMethodClasses[name]; !ok {

--- a/pkg/dataplane/loader.go
+++ b/pkg/dataplane/loader.go
@@ -51,18 +51,34 @@ type Manager struct {
 	// SNAPSHOT rather than the live map: handing out the map by reference put
 	// the range loop outside any lock the accessor could take, which is how the
 	// race survived the #2114 A3 registry rule.
-	xdpLinks                map[int]link.Link
-	tcLinks                 map[int]link.Link
-	lastCompile             *CompileResult
-	applyMu                 sync.Mutex
-	applyGeneration         uint64
-	lastApply               *ApplyResult
-	PersistentNAT           *PersistentNATTable
-	EnableCPUMap            bool // Enable cpumap multi-CPU distribution (adds startup overhead)
-	xdpEntryProg            string
-	vlanSubInterfaces       map[int]bool      // VLAN sub-interface ifindexes (skip XDP swap for these); guarded by m.mu (#6740)
-	mu                      sync.Mutex        // protects userspaceCounterOffsets + natRuleCounterOffsets + zone/flood offsets; #2114 A3: also the uniform m.maps/m.programs registry rule (every access goes through the lookupMapLocked/lookupProgramLocked scoped helpers, classification + handle selection atomic inside) and the xdpEntryProg field
-	userspaceCounterOffsets map[uint32]uint64 // userspace counter deltas merged in ReadGlobalCounter
+	xdpLinks        map[int]link.Link
+	tcLinks         map[int]link.Link
+	lastCompile     *CompileResult
+	applyMu         sync.Mutex
+	applyGeneration uint64
+	// registryGeneration counts REGISTRY publications (#6741). It is bumped
+	// inside publishShimRegistryLocked's m.mu hold, so it and the m.maps /
+	// m.programs contents always move together.
+	//
+	// registryObsoleteFrom records the generation that Teardown superseded.
+	// Teardown's Cleanup destroys the pinned kernel objects, so every handle
+	// still sitting in the registry at that moment refers to an obsolete
+	// forwarding generation — Close does NOT set this, because Close
+	// deliberately keeps its pinned handles live for hitless-restart reuse.
+	//
+	// obsoleteRegistryAccesses counts lookups that SERVED such a handle. It is
+	// an observability counter, not a guard: see obsoleteRegistryLocked.
+	registryGeneration       uint64
+	registryObsoleteFrom     uint64
+	obsoleteRegistryAccesses uint64
+	obsoleteEpochLogged      bool
+	lastApply                *ApplyResult
+	PersistentNAT            *PersistentNATTable
+	EnableCPUMap             bool // Enable cpumap multi-CPU distribution (adds startup overhead)
+	xdpEntryProg             string
+	vlanSubInterfaces        map[int]bool      // VLAN sub-interface ifindexes (skip XDP swap for these); guarded by m.mu (#6740)
+	mu                       sync.Mutex        // protects userspaceCounterOffsets + natRuleCounterOffsets + zone/flood offsets; #2114 A3: also the uniform m.maps/m.programs registry rule (every access goes through the lookupMapLocked/lookupProgramLocked scoped helpers, classification + handle selection atomic inside) and the xdpEntryProg field
+	userspaceCounterOffsets  map[uint32]uint64 // userspace counter deltas merged in ReadGlobalCounter
 	// natRuleCounterOffsets holds per-rule NAT translation hit totals reported
 	// by the Rust userspace dataplane (keyed by compiler-assigned counter ID),
 	// merged into ReadNATRuleCounter. The Rust forwarder never writes the
@@ -1381,6 +1397,16 @@ func (m *Manager) Close() error {
 func (m *Manager) Teardown() error {
 	m.Close()
 	err := teardownCleanupFn()
+	// #6741: Cleanup has just destroyed the pinned kernel objects, so every
+	// handle still in m.maps / m.programs now refers to an obsolete forwarding
+	// generation. Record the boundary so a lookup that serves one can be
+	// counted. The registry itself is deliberately NOT cleared — the retained
+	// state is what the #2114 A3 proceed-on-retained rule acts on, and changing
+	// that is the deferred half of #6741.
+	m.mu.Lock()
+	m.registryObsoleteFrom = m.registryGeneration
+	m.obsoleteEpochLogged = false
+	m.mu.Unlock()
 	// #6740: scoped section around the clears. teardownCleanupFn's unpin/remove
 	// sweep runs BEFORE it, never under the lock.
 	m.mu.Lock()

--- a/pkg/dataplane/registry_generation_6741_test.go
+++ b/pkg/dataplane/registry_generation_6741_test.go
@@ -1,0 +1,174 @@
+package dataplane
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+// #6741 Increment 1 — make an obsolete-generation registry access OBSERVABLE.
+//
+// Teardown's Cleanup destroys the pinned kernel objects but deliberately does
+// NOT clear m.maps / m.programs, and the #2114 A3 rule deliberately lets a
+// retained-state method PROCEED. So between a Teardown-retain and the next
+// publish, a lookup hands back a handle to an obsolete forwarding generation
+// and the caller mutates it — a mutation that succeeds and reaches nothing.
+//
+// These tests pin the counter's SEMANTICS, including what it deliberately does
+// not do. The "does not" cases matter more than the "does": a counter that
+// silently over-reports would make the deferred redesign chase noise, and one
+// that implies a guard it lacks is worse than no counter at all.
+
+func regTestManager6741() *Manager {
+	return &Manager{
+		maps:     make(map[string]*ebpf.Map),
+		programs: make(map[string]*ebpf.Program),
+	}
+}
+
+// TestObsoleteRegistryAccessCounted_6741 is the core case: a Teardown-retained
+// registry, then a lookup that serves a handle from it.
+func TestObsoleteRegistryAccessCounted_6741(t *testing.T) {
+	m := regTestManager6741()
+
+	// A published generation, then a lookup: nothing obsolete yet.
+	m.mu.Lock()
+	m.registryGeneration = 1
+	m.maps["sessions"] = &ebpf.Map{}
+	m.mu.Unlock()
+
+	if _, present, _ := m.lookupMapLocked("sessions"); !present {
+		t.Fatalf("premise broken: the seeded handle must be present")
+	}
+	if got := m.ObsoleteRegistryAccesses(); got != 0 {
+		t.Fatalf("a lookup against the CURRENT generation must not count as obsolete, got %d", got)
+	}
+
+	// Teardown supersedes generation 1 without clearing the registry.
+	m.mu.Lock()
+	m.registryObsoleteFrom = m.registryGeneration
+	m.mu.Unlock()
+
+	if _, present, _ := m.lookupMapLocked("sessions"); !present {
+		t.Fatalf("the retained registry must still SERVE the handle — proceed-on-retained is " +
+			"the deliberate #2114 A3 behaviour and this change must not alter it")
+	}
+	if got := m.ObsoleteRegistryAccesses(); got != 1 {
+		t.Errorf("obsolete access count = %d, want 1 — a lookup served a handle whose kernel "+
+			"object Cleanup destroyed, and nothing measured that before #6741", got)
+	}
+}
+
+// TestRepublishEndsTheObsoleteEpoch_6741 pins the other half: a new publish
+// makes the registry current again, so the counter must STOP moving. Without
+// this the counter would latch on forever after the first Teardown and every
+// later reading would be noise.
+func TestRepublishEndsTheObsoleteEpoch_6741(t *testing.T) {
+	m := regTestManager6741()
+	m.mu.Lock()
+	m.registryGeneration = 1
+	m.registryObsoleteFrom = 1
+	m.maps["sessions"] = &ebpf.Map{}
+	m.mu.Unlock()
+
+	m.lookupMapLocked("sessions")
+	before := m.ObsoleteRegistryAccesses()
+	if before != 1 {
+		t.Fatalf("premise broken: expected the obsolete epoch to count 1, got %d", before)
+	}
+
+	// A re-Start publishes a fresh generation above the obsolete boundary.
+	m.mu.Lock()
+	m.registryGeneration++
+	m.mu.Unlock()
+
+	m.lookupMapLocked("sessions")
+	m.lookupMapLocked("sessions")
+	if got := m.ObsoleteRegistryAccesses(); got != before {
+		t.Errorf("count moved from %d to %d after a republish — the epoch ended, so these "+
+			"lookups serve the CURRENT generation and must not be counted", before, got)
+	}
+}
+
+// TestCloseDoesNotStartAnObsoleteEpoch_6741 is the precision case, and it is the
+// one most likely to regress. Close() keeps its pinned handles LIVE on purpose
+// for hitless restart, so a Close-retained registry is not obsolete — only
+// Teardown, whose Cleanup destroys the pinned objects, supersedes a generation.
+//
+// A counter that fired on Close would report on every ordinary daemon restart
+// and be dismissed as noise within a day.
+func TestCloseDoesNotStartAnObsoleteEpoch_6741(t *testing.T) {
+	m := regTestManager6741()
+	m.mu.Lock()
+	m.registryGeneration = 3
+	m.maps["sessions"] = &ebpf.Map{}
+	m.mu.Unlock()
+	m.loaded.Store(true)
+
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	m.lookupMapLocked("sessions")
+	if got := m.ObsoleteRegistryAccesses(); got != 0 {
+		t.Errorf("Close started an obsolete epoch (count=%d). Close deliberately keeps its "+
+			"pinned handles live for hitless-restart reuse; only Teardown's Cleanup "+
+			"destroys them", got)
+	}
+}
+
+// TestAbsentLookupIsNotCounted_6741 keeps the counter honest about what it
+// measures. A miss serves no handle, so there is nothing obsolete to mutate; a
+// counter that included misses would inflate exactly during the fresh/retained
+// windows where lookups miss most often.
+func TestAbsentLookupIsNotCounted_6741(t *testing.T) {
+	m := regTestManager6741()
+	m.mu.Lock()
+	m.registryGeneration = 1
+	m.registryObsoleteFrom = 1
+	m.mu.Unlock()
+
+	m.lookupMapLocked("no_such_map")
+	m.lookupProgramLocked("no_such_program")
+	if got := m.ObsoleteRegistryAccesses(); got != 0 {
+		t.Errorf("a lookup that found NOTHING was counted as an obsolete access (%d) — it "+
+			"served no handle, so no obsolete mutation is possible through it", got)
+	}
+}
+
+// TestProgramLookupCountedToo_6741 covers the second choke point. The two
+// helpers are separate functions with the same rule, which is exactly the shape
+// where one gets updated and the other does not.
+func TestProgramLookupCountedToo_6741(t *testing.T) {
+	m := regTestManager6741()
+	m.mu.Lock()
+	m.registryGeneration = 1
+	m.registryObsoleteFrom = 1
+	m.programs["xdp_entry"] = &ebpf.Program{}
+	m.mu.Unlock()
+
+	m.lookupProgramLocked("xdp_entry")
+	if got := m.ObsoleteRegistryAccesses(); got != 1 {
+		t.Errorf("program-registry lookup was not counted (%d) — lookupProgramLocked is the "+
+			"sibling choke point and carries the identical rule", got)
+	}
+}
+
+// TestPublishBumpsTheGeneration_6741 binds the producer side. Without the bump
+// the obsolete epoch could never end, so every test above would still pass while
+// the counter latched permanently after the first Teardown.
+func TestPublishBumpsTheGeneration_6741(t *testing.T) {
+	m := regTestManager6741()
+	m.mu.Lock()
+	before := m.registryGeneration
+	m.mu.Unlock()
+
+	m.publishShimRegistryLocked(&ebpf.Program{}, map[string]*ebpf.Map{"sessions": {}}, nil)
+
+	m.mu.Lock()
+	after := m.registryGeneration
+	m.mu.Unlock()
+	if after != before+1 {
+		t.Errorf("registryGeneration %d -> %d, want +1: the publisher is what ends an "+
+			"obsolete epoch, so a missing bump latches the counter on forever", before, after)
+	}
+}


### PR DESCRIPTION
Refs #6741 — ships **Increment 1** (observability). Increment 2 (enforcement + drain) stays open, with the design tension recorded on the issue. Related: #7547.

## The hazard

`Teardown` runs `Cleanup`, which destroys the pinned kernel objects — but it does **not** clear `m.maps` / `m.programs`, and the #2114 A3 rule deliberately lets a retained-state method **proceed**. So between a Teardown-retain and the next publish, a registry lookup hands back a handle to an obsolete forwarding generation and the caller mutates it: **a mutation that succeeds and reaches nothing.** Both recurrence paths do it — `bootstrap.go`'s `enterBootstrapMode` and the standalone first-commit timeout in `daemon_apply_commit.go`. Nothing measured it.

## Two functions, not 135 call sites

`registryGeneration` is bumped inside `publishShimRegistryLocked`'s **existing** `m.mu` hold, so it and the registry contents can never be read out of step. `Teardown` records the superseded boundary. The two lookup helpers — the uniform funnel every registry access already goes through, already under `m.mu`, already carrying test hooks — count a lookup that **serves** a handle while the registry is superseded, and log once per obsolete epoch naming the map.

**`Close` does NOT start an obsolete epoch**, and that precision is the point: Close deliberately keeps its pinned handles live for hitless-restart reuse. A counter firing on every ordinary restart would be dismissed as noise within a day.

**No behaviour change** at any of the 135 call sites. Proceed-on-retained is the deliberate A3 rule; reversing it is the deferred half.

## What this deliberately does NOT do

It does **not close the escape window.** `lookupMapLocked` returns the `*ebpf.Map` **by reference and then releases `m.mu`**, so a republish landing after the lookup returns is invisible to it — a caller holding an escaped handle across a republish is counted **zero** times.

**A zero counter means "no lookup OBSERVED a superseded generation", never "no obsolete mutation occurred".** That is stated in the source, in `pkg/dataplane/README.md`, and on the issue. A metric that implies a guard it does not provide is worse than no metric.

### The design tension, recorded on #6741

Checking the generation at **mutation** time means threading a token through 135 sites, or converting them to `withMap(name, func(*ebpf.Map) error)` callbacks — and the callback form puts a BPF syscall inside `m.mu`, which **#6740 established must not happen** (the 1 Hz status path needs that lock). #6740 and #6741's first acceptance criterion pull in opposite directions; closing the window needs a mechanism that is neither.

## Why this ordering

Nothing currently measures whether the hazard fires at all. A counter that never moves on the two recurrence paths is **itself a finding** and changes what the redesign should be; one that moves often gives the redesign a reproducible trigger it does not have today. The acceptance criterion explicitly permits *"a verified no-op with a metric"*.

## Not wired to Prometheus — a scope decision, not an oversight

The collector reaches the dataplane through the narrow `apiRuntimeDataPlane` interface (**47 references** plus several test fakes); widening it is a separable change with its own review. The counter is readable via `ObsoleteRegistryAccesses()` and the per-epoch log. Happy to do the wiring as a follow-up if the counter proves to move.

## Mutation matrix

`flock`'d; tree asserted clean before and restored after, mutation asserted APPLIED, `go vet` clean before running, tests-collected asserted > 0.

| cell | mutation | result |
|---|---|---|
| **S1** | remove the counter call from the **map** lookup | RED the core case + the epoch-ends case |
| **S2** | remove it from the **program** lookup only | RED **only** the program test — two separate functions carrying one rule is exactly the shape where one gets updated and the other doesn't |
| **S3** | remove the generation bump from the publisher | RED the producer test. Without it the epoch could never end and the counter would latch on forever after the first Teardown, while every other test still passed |
| **S4** | **TIGHTEN**: drop the `present` guard so **misses** are counted | RED **only** the absent-lookup control |
| **S5** | **TIGHTEN**: let `Close()` start an obsolete epoch | RED **only** the Close-precision control |

**S4 and S5 are the cells a delete-only matrix cannot see.** An over-counting implementation is the realistic failure here — it would make the deferred redesign chase noise — and it is invisible to every "remove the feature" cell.

Census reconciled 163 → 164 for `ObsoleteRegistryAccesses`, classified with the other registry-state reads.

## Filed separately rather than folded in

**#7547** — `AttachXDP`/`DetachXDP`'s read-modify-write sequences have no concurrent coverage, and their atomicity rests on an untested `applySem` claim (`loader.go:1379`). Concrete and testable today, unlike #6741's hazard 2. Burying a concrete gap inside a design item is how it stops being actionable, and accumulating them there is how the design stops being decidable. Cross-referenced both ways.

## Scope

`pkg/dataplane` Go control plane. **No `userspace-dp` binary or shim object moved, no Rust, no forwarding behaviour, no control-socket traffic** — so no smoke owed.

Validation: `go build ./...` clean; **`go test -count=1 ./...` rc=0, 0 FAIL, 71 packages**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkfVhT4Y3UDa22mU7uoCVt
