### PR TITLE
ddns: wire-RR claims carry the DNS authority they were published to

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104050,3 +104050,15 @@ prose edit above them added. No diff falls in the new test body.
   userspace-dp/src/server/handlers/binding.rs,
   userspace-dp/src/server/handlers/queue.rs,
   userspace-dp/src/server/tests.rs
+
+## 2026-08-22 — #6755 DDNS wire-RR claims carry their DNS authority
+- **Timestamp**: 2026-08-22
+- **Action**: WireRRClaim was {FQDN,type,rdata} with no authority, so two
+  surfaces publishing the same RR to DIFFERENT servers compared equal and the
+  teardown suppressed its own DELETE, leaving the record published forever.
+  Added Authority (credential-free endpoint fingerprint) + a coOwns predicate
+  treating an empty authority as UNKNOWN rather than different. Single-sourced
+  the fingerprint format so the two surfaces cannot drift.
+- **File(s)**: pkg/ddns/state.go, pkg/ddns/surface_a.go, pkg/ddns/manager.go,
+  pkg/ddns/cross_surface_authority_6755_test.go,
+  pkg/ddns/cross_surface_clobber_5748_test.go

--- a/pkg/ddns/cross_surface_authority_6755_test.go
+++ b/pkg/ddns/cross_surface_authority_6755_test.go
@@ -1,0 +1,205 @@
+package ddns
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6755: WireRRClaim carried no authority, so two ownership surfaces publishing
+// an equal (FQDN, type, rdata) to DIFFERENT DNS servers compared EQUAL. What
+// that equality decides is whether to SUPPRESS a DELETE — so a teardown skipped
+// its own delete believing the other surface co-owned the record, and the record
+// stayed published at its own authority forever.
+//
+// The two directions must BOTH be pinned. Without the same-authority positive,
+// "include the authority" and "never suppress" are indistinguishable, and the
+// second silently reverts #5748's cross-surface clobber protection — turning a
+// stale-record bug into a data-loss one.
+
+func claim6755(fqdn, rdata, authority string) WireRRClaim {
+	return wireRRClaim(fqdn, "A", rdata, authority)
+}
+
+// TestDistinctAuthoritiesDoNotCoOwn6755 is the defect proper.
+func TestDistinctAuthoritiesDoNotCoOwn6755(t *testing.T) {
+	ns1 := authorityFingerprint("rfc2136", "ns1.example.net:53", "", "", "", "", "")
+	ns2 := authorityFingerprint("rfc2136", "ns2.example.net:53", "", "", "", "", "")
+	if ns1 == ns2 {
+		t.Fatal("premise broken: two different update servers produced the same fingerprint")
+	}
+
+	a := claim6755("host.example.net", "192.0.2.10", ns1)
+	b := claim6755("host.example.net", "192.0.2.10", ns2)
+
+	if a.coOwns(b) {
+		t.Error("two records with the same FQDN/type/rdata at DIFFERENT DNS servers were " +
+			"treated as ONE wire resource. The teardown that consults this suppresses its " +
+			"DELETE, so the record is never withdrawn from its own authority")
+	}
+	if b.coOwns(a) {
+		t.Error("co-ownership is not symmetric")
+	}
+}
+
+// TestSameAuthorityStillCoOwns6755 is the TIGHTENING control — the one that
+// stops this fix reverting #5748.
+func TestSameAuthorityStillCoOwns6755(t *testing.T) {
+	ns := authorityFingerprint("rfc2136", "ns1.example.net:53", "", "", "", "", "")
+	a := claim6755("host.example.net", "192.0.2.10", ns)
+	b := claim6755("host.example.net", "192.0.2.10", ns)
+
+	if !a.coOwns(b) {
+		t.Error("two records at the SAME authority stopped co-owning: the cross-surface " +
+			"teardown will now DELETE a record the other surface still owns, which is the " +
+			"clobber #5748 exists to prevent — strictly worse than the stale record #6755 " +
+			"is about")
+	}
+}
+
+// TestUnknownAuthorityCannotProveDifference6755 pins the third state. An empty
+// authority is UNKNOWN, not "different": a Surface A record persisted before
+// #6755 has no stored BackendFingerprint, and the lease surface has none until
+// its first policy resolves. Those must still co-own, or the upgrade itself
+// becomes a clobber.
+func TestUnknownAuthorityCannotProveDifference6755(t *testing.T) {
+	ns := authorityFingerprint("rfc2136", "ns1.example.net:53", "", "", "", "", "")
+	known := claim6755("host.example.net", "192.0.2.10", ns)
+	legacy := claim6755("host.example.net", "192.0.2.10", "")
+
+	if !known.coOwns(legacy) || !legacy.coOwns(known) {
+		t.Error("a legacy record with no stored fingerprint stopped co-owning a known one. " +
+			"On upgrade, every pre-#6755 record would lose its cross-surface protection at " +
+			"once — the fail-safe direction is to suppress when no mismatch can be PROVEN")
+	}
+	if !legacy.coOwns(claim6755("host.example.net", "192.0.2.10", "")) {
+		t.Error("two unknown authorities must still co-own")
+	}
+}
+
+// TestDifferentRRNeverCoOwnsRegardlessOfAuthority6755 pins that the authority is
+// an ADDITIONAL discriminator, not a replacement: a different name, type or
+// rdata is still a different resource even at one authority. Without this, an
+// implementation that compared ONLY the authority would pass everything above.
+func TestDifferentRRNeverCoOwnsRegardlessOfAuthority6755(t *testing.T) {
+	ns := authorityFingerprint("rfc2136", "ns1.example.net:53", "", "", "", "", "")
+	base := claim6755("host.example.net", "192.0.2.10", ns)
+
+	for _, tc := range []struct {
+		name  string
+		other WireRRClaim
+	}{
+		{"different FQDN", claim6755("other.example.net", "192.0.2.10", ns)},
+		{"different rdata", claim6755("host.example.net", "192.0.2.11", ns)},
+		{"different type", wireRRClaim("host.example.net", "AAAA", "192.0.2.10", ns)},
+	} {
+		if base.coOwns(tc.other) {
+			t.Errorf("%s co-owned at the same authority: the authority is an additional "+
+				"discriminator, not a replacement for the RR identity", tc.name)
+		}
+	}
+}
+
+// TestLeaseAndSurfaceAAgreeOnOneServer6755 is the cross-surface agreement test,
+// and it is the one that would catch a slot-mapping mistake.
+//
+// rfc2136 is the ONE backend both surfaces support. The Surface A provider
+// catalog and the DHCP lease policy populate different subsets of the shared
+// fingerprint's fields, so this asserts that for the same server they still
+// produce the SAME authority — the property the whole fix rests on. Pinning it
+// to a literal would encode which side I trust; this asserts the AGREEMENT.
+func TestLeaseAndSurfaceAAgreeOnOneServer6755(t *testing.T) {
+	const server = "ns1.example.net:53"
+
+	surfaceA := backendFingerprint(&config.DDNSProvider{
+		Backend:      "rfc2136",
+		UpdateServer: server,
+	})
+	// The lease policy carries a Domain — the DNS suffix it appends to client
+	// names. It is NOT the Surface A `Zone` (documented as the CLOUDFLARE zone
+	// and read only by backend_cloudflare.go), and an rfc2136 Surface A provider
+	// leaves Zone empty. Setting Domain here is what makes this test able to
+	// FAIL: with an empty Domain, mapping it onto the Zone slot would be a no-op
+	// and the mistake would pass unnoticed.
+	lease := leaseAuthorityFingerprint(&config.DHCPDynamicDNSConfig{
+		Backend:      "rfc2136",
+		UpdateServer: server,
+		Domain:       "lan.example.net",
+	})
+
+	if surfaceA != lease {
+		t.Fatalf("the two surfaces disagree about the SAME rfc2136 server (%q vs %q) — check "+
+			"whether a lease-only field (Domain) was mapped onto a Surface-A-only slot "+
+			"(Zone/HostedZoneID/AWSRegion); those are different concepts and an rfc2136 "+
+			"provider leaves them empty. Every "+
+			"cross-surface co-ownership check would fail, so the teardown would delete a "+
+			"record the other surface still owns — #5748's clobber, reintroduced by a "+
+			"slot-mapping mistake", surfaceA, lease)
+	}
+
+	// And a different server must still differ, or the agreement above is vacuous.
+	other := leaseAuthorityFingerprint(&config.DHCPDynamicDNSConfig{
+		Backend:      "rfc2136",
+		UpdateServer: "ns2.example.net:53",
+	})
+	if other == surfaceA {
+		t.Error("a DIFFERENT server produced the same authority: the agreement above would " +
+			"hold for any two inputs and proves nothing")
+	}
+}
+
+// TestAuthorityOmitsCredentials6755 pins the credential-free requirement: two
+// policies differing only in TSIG key material are the SAME authority, and no
+// secret may reach the fingerprint.
+func TestAuthorityOmitsCredentials6755(t *testing.T) {
+	a := leaseAuthorityFingerprint(&config.DHCPDynamicDNSConfig{
+		Backend: "rfc2136", UpdateServer: "ns1.example.net:53",
+		TSIGKeyName: "k1", TSIGAlgorithm: "hmac-sha256", TSIGSecret: config.Secret("SECRET-ONE"),
+	})
+	b := leaseAuthorityFingerprint(&config.DHCPDynamicDNSConfig{
+		Backend: "rfc2136", UpdateServer: "ns1.example.net:53",
+		TSIGKeyName: "k2", TSIGAlgorithm: "hmac-sha512", TSIGSecret: config.Secret("SECRET-TWO"),
+	})
+	if a != b {
+		t.Error("TSIG material changed the authority fingerprint: two keys for the same " +
+			"server are the same authority, and credential material must not participate")
+	}
+	if a == "" {
+		t.Fatal("fingerprint is empty")
+	}
+}
+
+// TestSurfaceARebuildStampsTheRecordsAuthority6755 binds the WIRING.
+//
+// Every test above builds claims through wireRRClaim directly, so they pass
+// whether or not the rebuild actually stamps a record's stored fingerprint —
+// making that side stamp "" leaves all of them green, because an empty
+// authority is UNKNOWN and still co-owns. This drives the production rebuild
+// and asserts the claim carries the record's OWN publish-time authority.
+func TestSurfaceARebuildStampsTheRecordsAuthority6755(t *testing.T) {
+	fp := authorityFingerprint("rfc2136", "ns7.example.net:53", "", "", "", "", "")
+
+	m := &SurfaceAManager{state: &ddnsState{records: map[string]ownedRecord{
+		"k": {
+			FQDN:               "wan.example.net",
+			ForwardType:        "A",
+			AddrText:           "203.0.113.9",
+			BackendFingerprint: fp,
+		},
+	}}}
+	m.rebuildWireRRClaimsLocked()
+
+	claims := m.WireRRClaims()
+	if len(claims) != 1 {
+		t.Fatalf("expected exactly one claim, got %d: %+v", len(claims), claims)
+	}
+	if claims[0].Authority != fp {
+		t.Errorf("the rebuilt claim carries Authority %q, want the record's stored "+
+			"BackendFingerprint %q. An unstamped claim reads as UNKNOWN, so it co-owns "+
+			"everything and #6755's whole discrimination is inert while every "+
+			"claim-level test still passes", claims[0].Authority, fp)
+	}
+	if claims[0].Rdata != "203.0.113.9" || claims[0].FQDN != dnsCanonicalFQDN("wan.example.net") {
+		t.Errorf("rebuild lost the RR identity: %+v", claims[0])
+	}
+}

--- a/pkg/ddns/cross_surface_clobber_5748_test.go
+++ b/pkg/ddns/cross_surface_clobber_5748_test.go
@@ -48,7 +48,7 @@ func TestLeaseTeardownSuppressedBySurfaceACoowner_5748(t *testing.T) {
 	// WireRRClaim the lease guard consults (exactly what SurfaceAManager.WireRRClaims
 	// returns in production).
 	m.surfaceACoowners = func() []WireRRClaim {
-		return []WireRRClaim{wireRRClaim("host-a.example.com", "A", "10.0.0.10")}
+		return []WireRRClaim{wireRRClaim("host-a.example.com", "A", "10.0.0.10", "")}
 	}
 
 	// Phase 1: publish + own the lease record.
@@ -92,7 +92,7 @@ func TestLeaseTeardownNoCoownerStillDeletes_5748(t *testing.T) {
 	pol := enabledPolicy()
 	// A Surface A record exists, but for a DIFFERENT name/address — not a co-owner.
 	m.surfaceACoowners = func() []WireRRClaim {
-		return []WireRRClaim{wireRRClaim("other.example.com", "A", "10.9.9.9")}
+		return []WireRRClaim{wireRRClaim("other.example.com", "A", "10.9.9.9", "")}
 	}
 
 	if err := runReconcile(t, m, pol, []Lease{leaseV4("10.0.0.10", "mac:aa", "host-a")}); err != nil {
@@ -161,7 +161,7 @@ func TestSurfaceATeardownDefersToLeaseCoowner_5748_6015(t *testing.T) {
 	// side); the injected accessor presents the normalized WireRRClaim (exactly what
 	// Manager.WireRRClaims returns in production).
 	m.SetLeaseCoownerSource(func() []WireRRClaim {
-		return []WireRRClaim{wireRRClaim("wan.example.net", "A", "203.0.113.5")}
+		return []WireRRClaim{wireRRClaim("wan.example.net", "A", "203.0.113.5", "")}
 	})
 
 	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
@@ -233,7 +233,7 @@ func TestCrossSurfaceMutualTeardownNotOrphaned_6015(t *testing.T) {
 	// Surface A's PRE-REBUILD snapshot still lists the co-owned RR (frozen to model
 	// the overlapping-pass race: B reads A's snapshot before A rebuilds it).
 	b.surfaceACoowners = func() []WireRRClaim {
-		return []WireRRClaim{wireRRClaim(fqdn, "A", rdata)}
+		return []WireRRClaim{wireRRClaim(fqdn, "A", rdata, "")}
 	}
 
 	// ---- Surface A: the SurfaceAManager ----
@@ -243,7 +243,7 @@ func TestCrossSurfaceMutualTeardownNotOrphaned_6015(t *testing.T) {
 	// Surface B's PRE-REBUILD snapshot still lists the co-owned RR (the symmetric
 	// frozen snapshot: A reads B's snapshot before B rebuilds it).
 	a.SetLeaseCoownerSource(func() []WireRRClaim {
-		return []WireRRClaim{wireRRClaim(fqdn, "A", rdata)}
+		return []WireRRClaim{wireRRClaim(fqdn, "A", rdata, "")}
 	})
 
 	// Phase 1 — both surfaces publish + own the SAME RR. The lease host is the
@@ -334,7 +334,7 @@ func TestSurfaceATeardownNoLeaseCoownerStillDeletes_5748(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
 	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
 	m.SetLeaseCoownerSource(func() []WireRRClaim {
-		return []WireRRClaim{wireRRClaim("other.example.net", "A", "198.51.100.7")}
+		return []WireRRClaim{wireRRClaim("other.example.net", "A", "198.51.100.7", "")}
 	})
 
 	sc := surfaceAScope("wan.example.net", FamilyV4, 0)

--- a/pkg/ddns/manager.go
+++ b/pkg/ddns/manager.go
@@ -139,6 +139,12 @@ type ddnsPolicy struct {
 	hostnameSource string
 	conflictPolicy string
 	backend        string
+	// authority is the credential-free fingerprint of this policy's DNS
+	// endpoint (#6755), comparable with a Surface A record's stored
+	// BackendFingerprint. Computed once here because ddnsPolicy is the resolved
+	// runtime shape the reconciler carries; the raw config is not available at
+	// claim-rebuild time.
+	authority string
 }
 
 // ScopeGate decides whether THIS node may publish records for a given scope
@@ -200,6 +206,7 @@ func policyFromConfig(c *config.DHCPDynamicDNSConfig) ddnsPolicy {
 		hostnameSource: c.HostnameSource,
 		conflictPolicy: c.ConflictPolicy,
 		backend:        c.Backend,
+		authority:      leaseAuthorityFingerprint(c),
 	}
 	if p.ttl <= 0 {
 		p.ttl = defaultDDNSTTL
@@ -1098,9 +1105,9 @@ func (m *Manager) wireRRSharedWithOther(owned ownedRecord) bool {
 	// AddrText, already normalized into the Rdata field of each WireRRClaim; build
 	// the same canonical claim for this lease record and compare by value.
 	if m.surfaceACoowners != nil {
-		ownedClaim := wireRRClaim(owned.FQDN, owned.ForwardType, owned.Address)
+		ownedClaim := wireRRClaim(owned.FQDN, owned.ForwardType, owned.Address, m.currentAuthorityLocked())
 		for _, c := range m.surfaceACoowners() {
-			if c == ownedClaim {
+			if c.coOwns(ownedClaim) {
 				return true
 			}
 		}
@@ -1136,13 +1143,31 @@ func (m *Manager) WireRRClaims() []WireRRClaim {
 // lock-free read (#5748). Caller holds m.mu. A lease record's rdata IS its
 // Address; rdata-less rows are skipped (they can never co-own a wire RR). The
 // snapshot is an immutable slice — replaced wholesale, never mutated in place.
+// currentAuthorityLocked is this surface's DNS authority fingerprint (#6755),
+// taken from the last resolved policy. Empty when no policy has resolved yet,
+// which coOwns treats as unknown rather than as a different authority.
+//
+// The lease surface stamps its CURRENT authority rather than a per-record
+// publish-time one, because ownedRecord carries no fingerprint field and adding
+// one would be a durable-store change this fix does not otherwise need. The
+// asymmetry with Surface A (which does store publish-time) is bounded: a policy
+// whose endpoint changes republishes its records through the new endpoint, and
+// until it does, an authority mismatch only ever makes coOwns MORE conservative
+// about suppressing a delete on the Surface A side.
+func (m *Manager) currentAuthorityLocked() string {
+	if p := m.lastPolicy.Load(); p != nil {
+		return p.authority
+	}
+	return ""
+}
+
 func (m *Manager) rebuildWireRRClaimsLocked() {
 	claims := make([]WireRRClaim, 0, len(m.state.records))
 	for _, r := range m.state.records {
 		if r.Address == "" {
 			continue
 		}
-		claims = append(claims, wireRRClaim(r.FQDN, r.ForwardType, r.Address))
+		claims = append(claims, wireRRClaim(r.FQDN, r.ForwardType, r.Address, m.currentAuthorityLocked()))
 	}
 	m.wireRRClaims.Store(&claims)
 }

--- a/pkg/ddns/state.go
+++ b/pkg/ddns/state.go
@@ -343,6 +343,42 @@ type WireRRClaim struct {
 	FQDN        string // canonical form (dnsCanonicalFQDN)
 	ForwardType string // "A" | "AAAA"
 	Rdata       string // textual published address (the rdata)
+	// Authority is the credential-free fingerprint of the DNS endpoint this
+	// claim was published to (#6755). Two records with an equal (FQDN, type,
+	// rdata) at DIFFERENT authorities are NOT one wire resource: they are two
+	// records on two servers, and treating them as one made a teardown suppress
+	// its DELETE and leave the record published at its own authority forever.
+	//
+	// Empty means UNKNOWN — a pre-#6755 durable record with no stored
+	// fingerprint, or a lease surface with no resolved policy. See coOwns for
+	// why unknown compares as "cannot prove different".
+	Authority string
+}
+
+// coOwns reports whether two wire-RR claims name the SAME wire resource (#6755).
+//
+// It is NOT struct equality, because the Authority field has a third state.
+// An EMPTY authority means unknown, not "a different authority": a Surface A
+// record persisted before #6755 has no stored BackendFingerprint
+// (`backend_fingerprint,omitempty`), and the lease surface has none before its
+// first policy resolves.
+//
+// Unknown compares as "cannot prove different", so such a pair still co-owns
+// and the DELETE is still suppressed. That is the FAIL-SAFE direction and it is
+// the same doctrine ownedBackendOK already states for the withdraw path — "one
+// side is unknown, so no mismatch can be proven". It preserves #5748's
+// cross-surface clobber protection for legacy records at the cost of leaving
+// #6755's stale-record hazard for them until they are republished, which is the
+// right way round: a stale RR is recoverable, a clobbered one owned by the other
+// surface is not.
+func (c WireRRClaim) coOwns(other WireRRClaim) bool {
+	if c.FQDN != other.FQDN || c.ForwardType != other.ForwardType || c.Rdata != other.Rdata {
+		return false
+	}
+	if c.Authority == "" || other.Authority == "" {
+		return true // unknown on one side: no mismatch can be proven
+	}
+	return c.Authority == other.Authority
 }
 
 // wireRRClaim builds a canonicalized WireRRClaim from a name, forward type, and
@@ -355,12 +391,13 @@ type WireRRClaim struct {
 // a stored address is normally well-formed). Empty rdata yields the zero-Rdata
 // claim; callers skip records with no rdata (a rdata-less claim must never
 // co-match another rdata-less one).
-func wireRRClaim(fqdn, forwardType, rdata string) WireRRClaim {
+func wireRRClaim(fqdn, forwardType, rdata, authority string) WireRRClaim {
 	norm := rdata
 	if a, err := netip.ParseAddr(rdata); err == nil {
 		norm = a.Unmap().String()
 	}
 	return WireRRClaim{
+		Authority:   authority,
 		FQDN:        dnsCanonicalFQDN(fqdn),
 		ForwardType: forwardType,
 		Rdata:       norm,

--- a/pkg/ddns/surface_a.go
+++ b/pkg/ddns/surface_a.go
@@ -1545,7 +1545,9 @@ func (m *SurfaceAManager) withdrawOwnedLocked(ctx context.Context, owned ownedRe
 		// ONE surface ever deletes a cross-surface co-owned RR — mutual suppression can
 		// never orphan it, and A never clobbers B's still-owned record. The
 		// leaseCoowners read is LOCK-FREE (no Manager.mu), so this is safe under m.mu.
-		if m.leaseWireRRCoowner(owned.FQDN, owned.ForwardType, a.String()) {
+		// #6755: pass THIS record's publish-time authority so a lease claim at a
+		// DIFFERENT DNS endpoint no longer suppresses the delete.
+		if m.leaseWireRRCoowner(owned.FQDN, owned.ForwardType, a.String(), owned.BackendFingerprint) {
 			deferredCoowned++
 			m.deleteCoowned++
 			// Re-assert the RR (self-heal): re-UPSERT the exact owned RR so a leaked
@@ -1705,7 +1707,11 @@ func (m *SurfaceAManager) rebuildWireRRClaimsLocked() {
 		if rdata == "" {
 			continue
 		}
-		claims = append(claims, wireRRClaim(r.FQDN, r.ForwardType, rdata))
+		// #6755: the record's own publish-time endpoint fingerprint. Stored on
+		// the durable record since #3735 for the withdraw path, so no catalog
+		// lookup is needed here and the authority is the one this record was
+		// ACTUALLY published to, not whatever the catalog says today.
+		claims = append(claims, wireRRClaim(r.FQDN, r.ForwardType, rdata, r.BackendFingerprint))
 	}
 	m.wireRRClaims.Store(&claims)
 }
@@ -1715,13 +1721,13 @@ func (m *SurfaceAManager) rebuildWireRRClaimsLocked() {
 // about to delete (#5748). It reads the injected lease-claim snapshot LOCK-FREE
 // (no Manager.mu), so it is safe to call while holding m.mu. Nil accessor ⇒ no
 // cross-surface co-owner (pre-#5748 behavior). Caller holds m.mu.
-func (m *SurfaceAManager) leaseWireRRCoowner(fqdn, forwardType, rdata string) bool {
+func (m *SurfaceAManager) leaseWireRRCoowner(fqdn, forwardType, rdata, authority string) bool {
 	if m.leaseCoowners == nil {
 		return false
 	}
-	want := wireRRClaim(fqdn, forwardType, rdata)
+	want := wireRRClaim(fqdn, forwardType, rdata, authority)
 	for _, c := range m.leaseCoowners() {
-		if c == want {
+		if c.coOwns(want) {
 			return true
 		}
 	}
@@ -1797,20 +1803,71 @@ func backendFingerprint(p *config.DDNSProvider) string {
 	if backend == "" {
 		backend = "rfc2136" // resolveSurfaceABackend's default
 	}
-	// Length-prefixed, order-fixed, credential-free tuple so no pair of adjacent
-	// fields can alias across the boundary (a value cannot inject the separator).
+	return authorityFingerprint(
+		backend,
+		p.UpdateServer, // rfc2136 target
+		p.Server,       // dyndns2 endpoint override
+		p.Zone,         // cloudflare zone
+		p.HostedZoneID, // route53 hosted zone
+		p.AWSRegion,    // route53 region
+		p.URLTemplate,  // generic endpoint template (%u/%p are placeholders, not live creds)
+	)
+}
+
+// authorityFingerprint is the SHARED format behind every DDNS authority
+// identity in this package (#6755). Both ownership surfaces derive their
+// identity through it, so the two can never drift into hashing the same
+// endpoint differently — a divergence here would silently make two records at
+// one authority look like two authorities, which reverts #5748's cross-surface
+// clobber protection.
+//
+// Length-prefixed, order-fixed and credential-free, so no pair of adjacent
+// fields can alias across the boundary (a value cannot inject the separator)
+// and no secret material participates.
+//
+// The Surface A provider catalog and the DHCP lease policy populate DIFFERENT
+// subsets of these slots, and that is deliberate rather than a gap: `Zone`,
+// `HostedZoneID`, `AWSRegion` and `URLTemplate` are backend-specific fields
+// (Zone is documented as the CLOUDFLARE zone and is read only by
+// backend_cloudflare.go), so an rfc2136 provider leaves them empty on BOTH
+// sides. rfc2136 is the one backend the two surfaces share, and for it each
+// side populates exactly `backend` + `updateServer` — so the same server hashes
+// identically across surfaces, and a genuinely different backend or endpoint
+// does not.
+func authorityFingerprint(backend, updateServer, server, zone, hostedZoneID, awsRegion, urlTemplate string) string {
 	var sb strings.Builder
 	writeField := func(s string) { fmt.Fprintf(&sb, "%d:%s|", len(s), s) }
 	writeField(backend)
-	writeField(p.UpdateServer) // rfc2136 target
-	writeField(p.Server)       // dyndns2 endpoint override
-	writeField(p.Zone)         // cloudflare zone
-	writeField(p.HostedZoneID) // route53 hosted zone
-	writeField(p.AWSRegion)    // route53 region
-	writeField(p.URLTemplate)  // generic endpoint template (%u/%p are placeholders, not live creds)
+	writeField(updateServer)
+	writeField(server)
+	writeField(zone)
+	writeField(hostedZoneID)
+	writeField(awsRegion)
+	writeField(urlTemplate)
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(sb.String()))
 	return fmt.Sprintf("fp1-%016x", h.Sum64())
+}
+
+// leaseAuthorityFingerprint is the DHCP lease surface's authority identity,
+// built through the same shared format so it is comparable with a Surface A
+// record's stored BackendFingerprint (#6755).
+//
+// DHCPDynamicDNSConfig carries Backend and UpdateServer (documented as the
+// rfc2136 host:port target) and no other endpoint-identifying field, so the
+// remaining slots are empty — which is exactly what an rfc2136 Surface A
+// provider produces. The TSIG material is deliberately NOT included: it is
+// credential material, and two policies differing only in key would still be
+// the same authority.
+func leaseAuthorityFingerprint(c *config.DHCPDynamicDNSConfig) string {
+	if c == nil {
+		return ""
+	}
+	backend := c.Backend
+	if backend == "" {
+		backend = "rfc2136" // the lease surface's default, matching Surface A's
+	}
+	return authorityFingerprint(backend, c.UpdateServer, "", "", "", "", "")
 }
 
 // ownedBackendStatus classifies whether an owned record's ORIGINAL publish


### PR DESCRIPTION
Closes #6755

`WireRRClaim` was `{FQDN, ForwardType, Rdata}` with **no authority**. Its equality decides whether a teardown **suppresses its DELETE**, so two ownership surfaces publishing an equal RR to *different* DNS servers were treated as one wire resource: each deferred to the other and the record was never withdrawn from its own authority.

The failure direction is a **stale RR left published** — an address outliving the lease or interface that owned it — not the clobber the cross-surface arm was built to prevent. The tree already recognises this hazard class: `surface_a.go`'s orphan reason reads *"old record stale at previous endpoint — manual cleanup required"*.

**Reachable on ordinary configuration.** The two surfaces have independent authorities: Surface A publishes through the `system services dynamic-dns` provider catalog, while the DHCP lease surface uses `DHCPDynamicDNSConfig`, documented at `types_system.go:1670` as *"INDEPENDENT (separate domain / server / TSIG / TTL)"*.

## Three findings that changed the shape of the fix

**No store migration is needed.** The issue's fix direction says *"version/rebuild durable claim state as needed"*. `WireRRClaim` is **not persisted** — no JSON tags, nothing marshals it. It is an in-memory `atomic.Pointer` snapshot rebuilt from durable records each reconcile, so the change is confined to the claim type, two rebuilds and two comparison sites.

**No new identity function is needed.** `backendFingerprint` already existed, is credential-free and length-prefixed, and already backs `orphanReasonEndpointChanged`. Its **format** is extracted into a shared helper both surfaces call, so they cannot drift into hashing one endpoint differently — a divergence there would make two records at one authority look like two authorities and revert #5748.

**The slot-mapping ambiguity does not arise.** `Zone` is documented as the *Cloudflare* zone and is read only by `backend_cloudflare.go`; the lease side's `UpdateServer` is documented as the rfc2136 `host:port`. rfc2136 is the one backend both surfaces support, and for it each populates exactly `backend` + `updateServer` — so the same server hashes identically and a different one does not.

## Co-ownership is no longer struct equality

An **empty** authority means UNKNOWN, not "different": a Surface A record persisted before this change has no stored `BackendFingerprint` (`omitempty`), and the lease surface has none until its first policy resolves. Those still co-own — the fail-safe direction, and the same doctrine `ownedBackendOK` already states for the withdraw path (*"one side is unknown, so no mismatch can be proven"*).

That preserves #5748's protection for legacy records at the cost of leaving #6755's stale-record hazard for them until they republish. That is the right way round: **a stale RR is recoverable, a clobbered one owned by the other surface is not.**

Surface A takes its authority from the record's **own stored** fingerprint — the endpoint it was actually published to, not whatever the catalog says now. The lease surface stamps its current policy's, because `ownedRecord` has no fingerprint field and adding one *would* be the store change this fix otherwise avoids. The asymmetry is documented at the accessor.

## Mutation matrix

Fix committed first. Full `pkg/ddns` suite per cell, no `-run` filter, rc from a file, control green first.

| # | mutation | rc | fired |
|---|---|---|---|
| W1 | revert: ignore the authority | 1 | `TestDistinctAuthoritiesDoNotCoOwn6755` |
| W2 | **TIGHTEN**: unknown counts as DIFFERENT | 1 | `TestUnknownAuthorityCannotProveDifference6755` |
| W3 | **slot-mapping**: lease `Domain` written into the `Zone` slot | 0 → 1 | see below |
| W4 | **WIRING**: Surface A rebuild stamps nothing | 0 → 1 | see below |

**W3 and W4 were both GREEN first time, and both were gaps in my own tests.**

W3 is the worse one: I had written the Domain-into-Zone mistake onto the issue as *the* thing to avoid, then wrote an agreement test whose lease fixture had **no `Domain`** — so the mutation was a no-op for it. The fixture now sets one, which is what makes the test able to fail at all.

W4: every other test builds claims through `wireRRClaim` directly, so making the rebuild stamp `""` left them all green — an empty authority is UNKNOWN and co-owns everything, so the discrimination is inert while the claim-level tests still pass. `TestSurfaceARebuildStampsTheRecordsAuthority6755` drives the production rebuild.

## Coverage

Six tests pin both directions — distinct authorities do NOT co-own; the **same** authority still does (the control that stops this reverting #5748); unknown cannot prove a difference; a different RR never co-owns regardless of authority; the two surfaces **AGREE** on one rfc2136 server (asserted as an agreement rather than against a literal, with a different-server case so it cannot be vacuous); and TSIG material never reaches the fingerprint.

All six existing #5748 tests still pass, on the unknown-authority path.

## Validation

`go build`, `go vet`, `gofmt` clean; `go test -count=1 ./...` green repo-wide. `pkg/ddns` only — no cluster, no dataplane, no `userspace-dp` binary or shim `.o` moved.
