### PR TITLE
userspace-dp: keep a half-open TCP flow on the opening window (#6752)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104026,3 +104026,30 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: userspace-dp/src/server/helpers/planning.rs,
   userspace-dp/src/server/handlers/snapshot.rs,
   userspace-dp/src/main_tests.rs
+
+## 2026-08-22 — #6752 half-open flow no longer holds the established window
+- **Action**: Promotion is on the reverse SYN-ACK, not the final ACK, so the
+  reverse half jumped to the 300s class immediately; #4109 deliberately did not
+  extend the forward half and said so, and #4380's handshake-agnostic companion
+  probe (three days later) falsified that by re-stamping the forward half off
+  the reverse half's fresh 300s window. Both halves of a never-completed
+  handshake persisted ~300s. Added node-local `SessionEntry.handshake_pending`
+  (set on both halves by the SYN-ACK, cleared by the handshake-completing
+  forward segment); the idle-window selection now uses
+  `established && !handshake_pending`, and `companion_keeps_alive` refuses to
+  extend a half whose companion is still pending. The two close
+  DIFFERENT-SIZED leaks and an early draft overstated this: a mutation showed
+  the class change alone already reaps both halves at ~20s, so the probe refusal
+  closes the smaller retransmission-driven leak (a server retransmitting its
+  SYN-ACK slides the reverse half's window forward and the handshake-agnostic
+  probe re-stamps the forward half off it). A third test cell was added to
+  exercise it, since the first two could not. Verified the completing segment is
+  guaranteed to reach the slow path: `packet_eligible`/`should_cache` admit TCP
+  to the flow cache only when `is_ack_only`, so neither the SYN nor the SYN-ACK
+  seeds an entry and the final ACK is a cache miss. Rewrote #4109's now-false
+  comment and the README claim rather than leaving them asserting a guarantee
+  the code did not provide.
+- **File(s)**: userspace-dp/src/session/mod.rs,
+  userspace-dp/src/session/lookup.rs, userspace-dp/src/session/install.rs,
+  userspace-dp/src/session/expire.rs, userspace-dp/src/session/tests.rs,
+  userspace-dp/src/session/README.md

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -117,8 +117,7 @@ bare SYN (SYN set, ACK clear) starts in the OPENING (half-open) state
 (`SessionEntry.established == false`) and is reaped on the short
 `SessionTimeouts.tcp_opening_ns` window (20 s, the Junos
 `tcp-initial-timeout` default) instead of the full 300 s established
-timeout. It is promoted to ESTABLISHED — and the established / per-app
-idle window then applies — only on a genuine reverse SYN-ACK
+timeout. It is promoted to ESTABLISHED only on a genuine reverse SYN-ACK
 (**#4109**, tightened from "any ACK-bearing segment"): the server's
 handshake response is a SYN-ACK on the REVERSE half of the flow, so ONLY a
 SYN-ACK (`is_syn_ack`, not merely `has_ack`) on the reverse companion
@@ -129,6 +128,30 @@ any ACK did, so a bare SYN followed by a bare ACK pinned a 300 s
 established entry with no peer ever replying, a 2-packet bypass of the
 #3152 half-open reap (a real vSRX with the syn-check default does not mark
 a session ESTABLISHED on a client ACK that precedes the server's SYN-ACK).
+
+**The established idle window applies only once the handshake COMPLETES
+(#6752),** which is a strictly later moment than the promotion above.
+Promotion is on the SYN-ACK, so a SYN-ACK the client never ACKs used to put
+BOTH halves on the 300 s window: the reverse half was re-stamped to 300 s
+immediately, and the #4380 companion probe — protocol- and
+handshake-agnostic — then re-stamped the forward half off it at the forward
+half's 20 s deadline. #4109 had explicitly declined to extend the forward
+half's expiry "so a handshake the client never completes still reaps on the
+short opening window"; #4380 landed three days later and falsified that
+without either change being wrong on its own. `SessionEntry.handshake_pending`
+closes the gap: it is set on both halves by the SYN-ACK and cleared by the
+handshake-completing forward segment. The idle-window selection then treats
+`established && !handshake_pending` as the established class, which is what
+closes the ~300 s hold — with it, both halves reap at ~20 s on their own.
+`companion_keeps_alive` additionally refuses to extend a half whose companion
+is still pending; that closes a smaller, separate leak, where a server
+retransmitting its SYN-ACK slides the reverse half's window forward and the
+handshake-agnostic probe re-stamps the forward half off it for as long as the
+retransmissions continue. A completed handshake is unaffected — the forward segment that
+completes it is guaranteed to reach the slow path, because `packet_eligible`
+admits a TCP packet to the flow cache only when `is_ack_only` and
+`should_cache` uses the same predicate, so neither the SYN nor the SYN-ACK
+ever seeds an entry and the final ACK is a cache miss.
 Requiring the SYN bit (not just `has_ack` on the reverse tuple) also closes
 the residual where a server-spoofed bare reverse ACK could promote — in a
 legitimate 3-way handshake (and simultaneous open) the server's only

--- a/userspace-dp/src/session/expire.rs
+++ b/userspace-dp/src/session/expire.rs
@@ -496,6 +496,23 @@ impl SessionTable {
         let companion_key = reverse_session_key(key, entry_nat);
         let companion_last_seen = match self.entry_by_key(&companion_key) {
             Some(companion) => {
+                // #6752: never extend a half whose companion is still waiting on
+                // the handshake-completing segment. The probe is otherwise
+                // handshake-agnostic, and that is precisely how a SYN-ACK the
+                // client never ACKed held BOTH halves for ~300s: the reverse
+                // half was on its fresh established window, so this probe kept
+                // re-stamping the forward half off it. Refusing here is the
+                // second half of the fix — the effective-class change in
+                // `lookup` keeps the reverse half short, and this keeps the
+                // probe from undoing it.
+                //
+                // Checking the COMPANION alone is sufficient because the bit is
+                // set and cleared on both halves together
+                // (`promote_from_reverse` plus
+                // `propagate_tcp_state_to_companion`).
+                if companion.handshake_pending {
+                    return false;
+                }
                 // Companion still within ITS idle window (complement of the
                 // Case-3 `> expires_after` expiry test) → the whole flow is
                 // active; keep this half. Otherwise fall through: both halves

--- a/userspace-dp/src/session/install.rs
+++ b/userspace-dp/src/session/install.rs
@@ -161,6 +161,8 @@ impl SessionTable {
                 // pre-#3152 full-established-timeout behaviour. Computed once
                 // here and reused for the initial timeout selection.
                 established: !(matches!(protocol, PROTO_TCP) && is_initial_syn(tcp_flags)),
+                // #6752: a fresh install has seen no SYN-ACK, so nothing is pending.
+                handshake_pending: false,
                 expires_after_ns: session_timeout_ns(
                     protocol,
                     tcp_flags,
@@ -389,6 +391,10 @@ impl SessionTable {
                 // `established` field is node-local and never crosses the HA
                 // wire, so this is a pure import-side decision (no wire change).
                 established: true,
+                // #6752: a mid-stream pickup is seeded ESTABLISHED with no handshake
+                // to wait for — pending must stay false or it would be held on the
+                // opening window forever.
+                handshake_pending: false,
                 expires_after_ns: session_timeout_ns(
                     protocol,
                     tcp_flags,

--- a/userspace-dp/src/session/lookup.rs
+++ b/userspace-dp/src/session/lookup.rs
@@ -32,6 +32,9 @@ struct TcpStatePropagation {
     /// A reverse SYN-ACK promoted the matched (reverse) entry (F16): promote the
     /// forward companion too, so ESTABLISHED requires real handshake evidence.
     established: bool,
+    /// #6752: the companion's `handshake_pending` must clear with this half's,
+    /// or the companion probe keeps refusing to extend a flow that IS complete.
+    handshake_completed: bool,
 }
 
 impl SessionTable {
@@ -146,6 +149,25 @@ impl SessionTable {
             let promote_from_reverse = is_tcp && is_syn_ack(tcp_flags) && entry.metadata.is_reverse;
             if promote_from_reverse {
                 entry.established = true;
+                // #6752: promotion is on the SYN-ACK, which is NOT handshake
+                // completion. Mark the gap so the idle window below stays on the
+                // OPENING class until the completing forward segment arrives.
+                entry.handshake_pending = true;
+            }
+            // #6752: the handshake-completing forward segment. Any FORWARD-
+            // direction TCP segment ends the gap — the final ACK normally, and a
+            // data segment implies it too.
+            //
+            // This is reachable, which the fix depends on: `packet_eligible`
+            // (afxdp/flow_cache.rs) admits a TCP packet to the flow cache only
+            // when `is_ack_only`, and `should_cache` uses the same predicate, so
+            // neither the SYN nor the SYN-ACK ever seeds an entry. The final ACK
+            // is therefore a cache MISS and falls through to this slow path,
+            // where it both completes the handshake and seeds the cache for the
+            // data that follows.
+            let handshake_completed = is_tcp && entry.handshake_pending && !entry.metadata.is_reverse;
+            if handshake_completed {
+                entry.handshake_pending = false;
             }
             entry.last_seen_ns = now_ns;
             entry.expires_after_ns = if is_tcp && entry.closing {
@@ -163,7 +185,11 @@ impl SessionTable {
                 session_timeout_ns(
                     key.protocol,
                     tcp_flags,
-                    entry.established,
+                    // #6752: the EFFECTIVE established class. A flow promoted by
+                    // the SYN-ACK but not yet completed stays on the opening
+                    // window, so a handshake the client never finishes reaps at
+                    // ~20s instead of holding 300s.
+                    entry.established && !entry.handshake_pending,
                     &timeouts,
                     entry.metadata.inactivity_timeout_ns,
                     // #3527: per-zone half-open override resolved above.
@@ -175,6 +201,7 @@ impl SessionTable {
                 close: do_close,
                 reset: is_tcp && has_rst(tcp_flags),
                 established: promote_from_reverse,
+                handshake_completed,
             };
             (
                 (
@@ -201,7 +228,7 @@ impl SessionTable {
         // from the matched CANONICAL key (`actual_key`, not the alias lookup
         // `key`) + its own nat, exactly as `account_packet` hops reverse→forward.
         // Skipped entirely when there is nothing to propagate.
-        if propagate.close || propagate.established {
+        if propagate.close || propagate.established || propagate.handshake_completed {
             self.propagate_tcp_state_to_companion(
                 &actual_key,
                 propagate.nat,
@@ -209,6 +236,7 @@ impl SessionTable {
                 propagate.close,
                 propagate.reset,
                 propagate.established,
+                propagate.handshake_completed,
             );
         }
         // Push the canonical key (NOT the alias lookup `key`) into

--- a/userspace-dp/src/session/mod.rs
+++ b/userspace-dp/src/session/mod.rs
@@ -385,6 +385,41 @@ struct SessionEntry {
     /// Close-delta propagation, not its own OPENING window. No wire-format
     /// change.
     established: bool,
+    /// #6752: `established` was set by the reverse SYN-ACK, so it does NOT mean
+    /// the three-way handshake COMPLETED. This bit is the gap: true from the
+    /// moment the SYN-ACK promotes the flow until the handshake-completing
+    /// forward segment arrives.
+    ///
+    /// It exists because two correct changes combined into an incorrect
+    /// outcome. #4109 (2026-07-04) promoted on the SYN-ACK and deliberately did
+    /// NOT extend the forward half's expiry, "so a handshake the client never
+    /// completes still reaps on the short opening window". #4380 (2026-07-07)
+    /// then added the companion probe, which is protocol- and
+    /// handshake-agnostic: at the forward half's 20s deadline it saw the
+    /// reverse half alive on its brand-new 300s window, kept the forward half
+    /// and re-stamped it. Neither change was wrong; together they held BOTH
+    /// halves of a never-completed handshake for ~300s, and #4109's comment
+    /// went on asserting the conservative behaviour, which is why nobody
+    /// re-checked it.
+    ///
+    /// Two things consult it, and they close DIFFERENT-SIZED leaks — stated
+    /// separately because an earlier revision of this comment claimed both were
+    /// needed for the 300s case, and a mutation showed that was false:
+    ///   * the idle-window selection treats `established && !handshake_pending`
+    ///     as the established class, so the SYN-ACK stamps the OPENING window
+    ///     rather than 300s. THIS is what closes the ~300s hold; with it in
+    ///     place and no further traffic, both halves reap at ~20s on their own.
+    ///   * `companion_keeps_alive` refuses to extend a half whose companion is
+    ///     still pending. This closes a SMALLER, retransmission-driven leak: a
+    ///     server retransmitting its SYN-ACK slides the reverse half's window
+    ///     forward, and a handshake-agnostic probe would re-stamp the forward
+    ///     half off it for as long as the retransmissions continue
+    ///     (`retransmitted_synack_does_not_resurrect_the_forward_half_6752`).
+    ///
+    /// Node-local derived state, like `established`: `SessionEntry` is not
+    /// serialized, so this is not on any wire and an HA peer re-derives it from
+    /// the segments it sees.
+    handshake_pending: bool,
     /// #965: absolute wheel tick at which this session is scheduled to
     /// be checked for expiration. Updated on every push to the wheel.
     /// A WheelEntry whose `scheduled_tick != entry.wheel_tick` is a
@@ -1318,6 +1353,7 @@ impl SessionTable {
         close: bool,
         reset: bool,
         established: bool,
+        handshake_completed: bool,
     ) {
         let companion_key = reverse_session_key(matched_key, matched_nat);
         let mut shortened = false;
@@ -1327,10 +1363,28 @@ impl SessionTable {
                 // half — promote the forward companion too. Sticky and flag-only:
                 // the companion's own next segment (the handshake-completing
                 // forward ACK) re-stamps the established idle window via
-                // `session_timeout_ns(established=true)`. We deliberately do NOT
-                // extend its expiry here so a handshake the client never
-                // completes still reaps on the short opening window.
+                // `session_timeout_ns(established=true)`.
+                //
+                // #6752: the expiry is still not extended here, and #4109's
+                // comment used to justify that with "so a handshake the client
+                // never completes still reaps on the short opening window".
+                // THAT STOPPED BEING TRUE three days after it was written.
+                // #4380's companion probe is handshake-agnostic: it saw the
+                // reverse half alive on the 300s window the SYN-ACK had just
+                // stamped, kept this half, and re-stamped it — so both halves
+                // held for ~300s. Not extending here was never sufficient on its
+                // own; `handshake_pending` is what makes the claim true again,
+                // by keeping BOTH halves in the opening class and by stopping
+                // the probe from extending either.
                 entry.established = true;
+                entry.handshake_pending = true;
+            }
+            if handshake_completed {
+                // #6752: the matched (forward) half saw the completing segment;
+                // clear the companion's gap too, so the probe may extend this
+                // flow again and the reverse half's next segment stamps the
+                // established window.
+                entry.handshake_pending = false;
             }
             if close {
                 // F17: a FIN/RST on one half kills the whole flow. Stamp the

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -7641,3 +7641,197 @@ fn close_delta_carries_observed_tos_and_tcp_flags() {
         "OR of all TCP flags seen in both directions, not 0"
     );
 }
+
+/// #6752: SYN → SYN-ACK → **no final ACK** must reap on the OPENING window,
+/// not hold both halves for the full established timeout.
+///
+/// The gap the issue names: promotion happens on the SYN-ACK, not on the final
+/// ACK, so the reverse half jumped straight to the 300s class. #4109
+/// deliberately did NOT extend the forward half's expiry, and said so — "a
+/// handshake the client never completes still reaps on the short opening
+/// window". Three days later #4380's companion probe, which is protocol- and
+/// handshake-agnostic, made that false: at the forward half's 20s deadline it
+/// saw the reverse half alive on its brand-new 300s window and re-stamped the
+/// forward half off it. Both halves then persisted ~300s from the SYN-ACK.
+///
+/// WHY THE EXISTING COVERAGE DID NOT CATCH IT.
+/// `tcp_handshake_promotes_opening_to_established` asserts the `established`
+/// FLAG after the SYN-ACK, then sends the final ACK and only afterwards asserts
+/// `expires_after_ns`. It never asserts the reverse entry's window after the
+/// SYN-ACK, and it never runs the no-final-ACK case at all.
+/// `forward_ack_without_reverse_synack_stays_opening` covers the opposite shape
+/// (no SYN-ACK). Neither can see this.
+#[test]
+fn synack_without_final_ack_stays_on_the_opening_window_6752() {
+    let mut table = SessionTable::new();
+    let forward = key_v4();
+    let now = 1_000_000_000u64;
+    let reverse = install_forward_reverse_pair(&mut table, &forward, now, TCP_SYN);
+
+    // The server answers; the client never completes.
+    assert!(
+        table
+            .lookup(&reverse, now + 1_000_000, TCP_SYN | TCP_ACK)
+            .is_some()
+    );
+
+    let rev = table.entry_by_key(&reverse).expect("rev after synack");
+    assert!(
+        rev.established,
+        "premise: the SYN-ACK still promotes the flag — this fix does not change \
+         WHEN a flow counts as established, only which idle window it ages on",
+    );
+    assert_eq!(
+        rev.expires_after_ns,
+        table.timeouts.tcp_opening_ns,
+        "the reverse half jumped to the ESTABLISHED idle window on the SYN-ACK, \
+         so a handshake the client never completes is held for the full \
+         established timeout instead of reaping at the opening window (#6752)",
+    );
+    let fwd = table.entry_by_key(&forward).expect("fwd after synack");
+    assert_eq!(
+        fwd.expires_after_ns,
+        table.timeouts.tcp_opening_ns,
+        "the forward half must also still be on the opening window",
+    );
+
+    // The companion probe must not resurrect either half. Step past the opening
+    // window and expire: with the flow still half-open, BOTH halves must go.
+    // A few seconds past the opening window — comfortably beyond it, and still
+    // two orders of magnitude short of the 300s established window, so a reap
+    // here can only mean the opening class was applied. The margin also clears
+    // the wheel's `cursor_tick < now_tick` sweep boundary and the GC interval
+    // gate, which is test plumbing rather than part of the property.
+    let past = now + table.timeouts.tcp_opening_ns + 5_000_000_000;
+    // Drive the wheel forward the way the other expiry tests do: the sweep only
+    // examines ticks between `last_gc_ns` and `now_ns`.
+    table.last_gc_ns = past - 2_000_000_000;
+    table.expire_stale_entries(past);
+    assert!(
+        table.entry_by_key(&forward).is_none(),
+        "the forward half survived past the opening window — the #4380 companion \
+         probe extended it off the reverse half, which is exactly the resurrection \
+         #6752 is about",
+    );
+    assert!(
+        table.entry_by_key(&reverse).is_none(),
+        "the reverse half survived past the opening window",
+    );
+}
+
+/// #6752 NEGATIVE CONTROL — the completed handshake must still get its full
+/// established window, in BOTH directions.
+///
+/// Without this the fix is indistinguishable from "never promote the idle
+/// window at all", which would reap every legitimate idle TCP session at 20s.
+/// The forward half's window is asserted directly; the reverse half's is
+/// asserted through the companion probe, because a completed flow's reverse
+/// half keeps whatever window its last segment stamped and relies on #4380 to
+/// age with its sibling — so the probe must start extending again the moment
+/// the handshake completes.
+#[test]
+fn completed_handshake_still_gets_the_established_window_6752() {
+    let mut table = SessionTable::new();
+    let forward = key_v4();
+    let now = 1_000_000_000u64;
+    let reverse = install_forward_reverse_pair(&mut table, &forward, now, TCP_SYN);
+
+    assert!(
+        table
+            .lookup(&reverse, now + 1_000_000, TCP_SYN | TCP_ACK)
+            .is_some()
+    );
+    // The client completes. This segment reaches the slow path by construction:
+    // `packet_eligible` admits a TCP packet to the flow cache only when
+    // `is_ack_only`, and `should_cache` uses the same predicate, so neither the
+    // SYN nor the SYN-ACK ever seeded an entry — the final ACK is a cache MISS.
+    assert!(table.lookup(&forward, now + 2_000_000, TCP_ACK).is_some());
+
+    let fwd = table.entry_by_key(&forward).expect("fwd after final ack");
+    assert!(fwd.established);
+    assert_eq!(
+        fwd.expires_after_ns,
+        table.timeouts.tcp_established_ns,
+        "a COMPLETED handshake must get the established idle window — without \
+         this the #6752 fix would reap every legitimate idle TCP session at the \
+         20s opening window",
+    );
+
+    // Past the opening window but well inside the established one: the flow —
+    // both halves — must still be there. The reverse half survives via the
+    // companion probe, which the fix must have re-enabled on completion.
+    let past_opening = now + table.timeouts.tcp_opening_ns + 5_000_000_000;
+    table.last_gc_ns = past_opening - 2_000_000_000;
+    table.expire_stale_entries(past_opening);
+    assert!(
+        table.entry_by_key(&forward).is_some(),
+        "the completed flow's forward half was reaped at the opening window",
+    );
+    assert!(
+        table.entry_by_key(&reverse).is_some(),
+        "the completed flow's reverse half was reaped at the opening window — the \
+         companion probe must extend again once the handshake completes, or the \
+         fix trades a half-open leak for a reaped live session",
+    );
+}
+
+/// #6752, the second half of the fix: the companion probe must not resurrect a
+/// half-open flow that the SERVER keeps refreshing.
+///
+/// The effective-class change alone is not sufficient here, and the two cells
+/// above cannot show it — with both halves on the opening window and no further
+/// traffic, the probe's own idle test already fails, so it never gets the chance
+/// to extend. The gap opens when the reverse half keeps receiving packets: a
+/// server retransmitting its SYN-ACK (normally ~5 times over ~30 s) slides the
+/// reverse half's window forward, and a handshake-agnostic probe then re-stamps
+/// the forward half off it for as long as the retransmissions continue.
+///
+/// That is a smaller leak than the ~300 s the class change closes, and it is
+/// stated that way rather than as "both halves for 300 s" — but it is the reason
+/// `companion_keeps_alive` consults `handshake_pending` rather than relying on
+/// the class change to make the probe harmless.
+#[test]
+fn retransmitted_synack_does_not_resurrect_the_forward_half_6752() {
+    let mut table = SessionTable::new();
+    let forward = key_v4();
+    let now = 1_000_000_000u64;
+    let reverse = install_forward_reverse_pair(&mut table, &forward, now, TCP_SYN);
+
+    // Server answers, then retransmits 15 s later. The client never completes.
+    assert!(
+        table
+            .lookup(&reverse, now + 1_000_000, TCP_SYN | TCP_ACK)
+            .is_some()
+    );
+    let retransmit = now + 15_000_000_000;
+    assert!(
+        table
+            .lookup(&reverse, retransmit, TCP_SYN | TCP_ACK)
+            .is_some()
+    );
+
+    // Past the FORWARD half's opening window, while the reverse half is fresh
+    // (10 s idle, inside its own 20 s window) — precisely the state in which the
+    // probe would extend.
+    let past_forward = retransmit + 10_000_000_000;
+    assert!(
+        past_forward.saturating_sub(now) > table.timeouts.tcp_opening_ns,
+        "fixture: the forward half must have crossed its window",
+    );
+    assert!(
+        past_forward.saturating_sub(retransmit) < table.timeouts.tcp_opening_ns,
+        "fixture: the reverse half must still be INSIDE its window, or the probe \
+         would decline for the ordinary idle reason and this cell would prove \
+         nothing",
+    );
+    table.last_gc_ns = past_forward - 2_000_000_000;
+    table.expire_stale_entries(past_forward);
+
+    assert!(
+        table.entry_by_key(&forward).is_none(),
+        "the forward half was kept alive off a retransmitted SYN-ACK. The #4380 \
+         companion probe is handshake-agnostic, so without the handshake_pending \
+         refusal a server that keeps retransmitting holds the client-side half of \
+         a handshake that never completed (#6752)",
+    );
+}


### PR DESCRIPTION
## Summary

A SYN-ACK the client never ACKs held **both** halves of the flow for the full
300 s established timeout instead of reaping at the 20 s opening window.

Two correct changes combined into an incorrect outcome, which is why it survived
review of each:

- **#4109** (2026-07-04) promoted on the reverse SYN-ACK — correct, and tighter
  than the "any ACK" it replaced — and deliberately did **not** extend the
  forward half's expiry, saying so: *"a handshake the client never completes
  still reaps on the short opening window"*.
- **#4380** (2026-07-07) added the companion probe, which is protocol- and
  handshake-agnostic. At the forward half's 20 s deadline it saw the reverse half
  alive on the 300 s window the SYN-ACK had just stamped, kept the forward half
  and re-stamped it off the reverse.

Neither is wrong on its own. Together they hold both halves ~300 s from the
SYN-ACK — and #4109's comment went on asserting the conservative behaviour, which
is exactly why nobody re-checked it. **A comment that overstates safety is one
readers stop reading.**

## Promotion is not completion

`established` is set by the SYN-ACK, so it does not mean the handshake finished.
The new node-local `SessionEntry.handshake_pending` is that gap: set on both
halves when the SYN-ACK promotes, cleared by the handshake-completing forward
segment.

**Two consumers, closing different-sized leaks — and an earlier draft of this PR
got that wrong.** It claimed *"both are required — fixing either alone leaves the
other half on 300 s"*. **Mutation cell 2 falsified it** (see below), so:

- the idle-window selection uses `established && !handshake_pending`, so the
  SYN-ACK stamps the **opening** window rather than 300 s. **This is what closes
  the ~300 s hold**; with it alone and no further traffic, both halves reap at
  ~20 s.
- `companion_keeps_alive` refuses to extend a half whose companion is still
  pending. This closes a **smaller, separate** leak: a server retransmitting its
  SYN-ACK (~5 times over ~30 s) slides the reverse half's window forward, and the
  handshake-agnostic probe would re-stamp the forward half off it for as long as
  the retransmissions continue. It needed **its own test cell**, because the two
  obvious cells cannot reach it — with both halves quiet on the opening window
  the probe's own idle test already declines.

`SessionEntry` is not serialized, so this is node-local like `established`: no
wire change, and an HA peer re-derives it from the segments it sees.

## Why the completing segment is guaranteed to be seen

The fix depends on observing the final ACK, so that was **verified rather than
assumed** — it is the premise that decides whether this reaps legitimate flows.

`FlowCacheEntry::packet_eligible` admits a TCP packet to the flow cache only when
`is_ack_only`, and `should_cache` uses the **identical** predicate — so neither
the SYN nor the SYN-ACK ever seeds an entry. The final ACK is therefore a cache
**miss**, falls through to the slow path where it completes the handshake, and
only then seeds the cache for the data that follows. Had a control segment been
cacheable, this design would have reaped legitimate established flows at 20 s.

## The comment is part of the fix

The issue is explicit that the false comment is the thing that hid the defect.
#4109's rationale in `propagate_tcp_state_to_companion` and the matching claim in
`session/README.md` both stated a guarantee the code stopped providing; both are
rewritten to say what the system now does, and why the earlier statement was true
when written.

## Why the existing coverage could not see it

`tcp_handshake_promotes_opening_to_established` asserts the `established` **flag**
after the SYN-ACK, then sends the final ACK and only afterwards asserts
`expires_after_ns` — it never asserts the reverse entry's window after the
SYN-ACK, and never runs the no-final-ACK case at all.
`forward_ack_without_reverse_synack_stays_opening` covers the opposite shape (no
SYN-ACK).

## Mutation matrix

Full-binary per cell (`cargo test --bin xpf-userspace-dp -- --test-threads=1`, no
name filter), rc + tests-collected from a file. Base `0af1849d6…`, head
`9f61f5ade…`.

| # | Mutation | rc | collected | Which assertion fired |
|---|---|---|---|---|
| 1 | revert the effective-class change — the SYN-ACK stamps 300 s again | 101 | 4573 | *"the reverse half jumped to the ESTABLISHED idle window on the SYN-ACK … held for the full established timeout"*, `left: 300000000000` |
| 2 | revert the companion-probe refusal only | 101 | 4574 | the retransmitted-SYN-ACK cell |
| 3 | the completing forward segment never clears pending | 101 | 4572 | the completed-handshake cell **and two pre-existing tests** — `tcp_handshake_promotes_opening_to_established` and `opening_session_ignores_app_override_until_established` |
| 4 | the SYN-ACK never **sets** pending (mechanism inert) | 101 | 4573 | both half-open cells |

**Cell 2 is the one worth reading, because it did not red the first time.** With
only the two obvious cells present it passed cleanly — which showed my
"both are required" claim was false and that the probe refusal was untested. The
response was to write the cell that actually exercises it (the retransmitted
SYN-ACK) and to correct the claim in the commit message, the field doc and the
README, rather than to keep an unproven guard behind a confident sentence.

Cell 3 is the reassuring one: the completion clear is load-bearing for the
**pre-existing** contract, not only for my new cells.

## Validation

- `cargo test -- --test-threads=1` — **rc=0, 4704 tests ok, 0 failed**.
- `go test ./... -count=1` — **rc=0, 67 packages ok, 0 FAIL**.

## ⚠️ Cluster gate owed

**This moves the `userspace-dp` binary**, and it changes TCP session lifetime on
the forwarding path — the class of change most worth smoking. No XDP shim change
(so #7494's verifier-headroom constraint does not apply), no wire-format change,
no cluster/VRRP/session-sync/failover code. The **cargo leg on the merge result**
is worth running alongside. I ran no cluster target.

Closes #6752
