### PR TITLE
dhcp: RFC 3442 presence is the option slot, not parse success

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104091,3 +104091,12 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: pkg/ddns/state.go, pkg/ddns/surface_a.go, pkg/ddns/manager.go,
   pkg/ddns/cross_surface_authority_6755_test.go,
   pkg/ddns/cross_surface_clobber_5748_test.go
+
+## 2026-08-22 — #6756 RFC 3442 option presence vs parse success
+- **Timestamp**: 2026-08-22
+- **Action**: classlessStaticRoutes derived `present` from len(parsedRoutes)!=0,
+  collapsing absent / present-but-zero-length / present-but-malformed into one
+  false, so a broken option 121/249 fell through to the option-3 Router the RFC
+  forbids. Presence now comes from the option SLOT; option 249's discarded
+  parse error is logged.
+- **File(s)**: pkg/dhcp/dhcpv4.go, pkg/dhcp/classless_presence_6756_test.go

--- a/pkg/dhcp/classless_presence_6756_test.go
+++ b/pkg/dhcp/classless_presence_6756_test.go
@@ -1,0 +1,116 @@
+package dhcp
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/insomniacslk/dhcp/dhcpv4"
+)
+
+// #6756: RFC 3442 conditions its rule on the option being RETURNED — "If the
+// DHCP server returns both a Classless Static Routes option and a Router
+// option, the DHCP client MUST ignore the Router option."
+//
+// classlessStaticRoutes derived `present` from len(parsedRoutes) != 0, which
+// collapsed THREE distinct cases into one false:
+//
+//	absent                  -> option 3 honoured   (correct)
+//	present but zero-length -> option 3 honoured   (RFC says ignore it)
+//	present but malformed   -> option 3 honoured   (RFC says ignore it)
+//
+// So a server that emits a broken option 121/249 alongside a Router option got
+// the router installed anyway — the exact fall-through the RFC forbids. Option
+// 249's parse error was additionally discarded in silence.
+//
+// The four cases below are the ones the old code could not tell apart. The
+// ABSENT case is the control: without it, "presence is the option slot" and
+// "never honour option 3" are indistinguishable, and the second silently breaks
+// every ordinary lease that relies on the Router option.
+
+const presence6756Router = "198.51.100.99"
+
+func presenceACK6756(t *testing.T, opts ...dhcpv4.Option) *dhcpv4.DHCPv4 {
+	t.Helper()
+	all := append([]dhcpv4.Option{dhcpv4.OptRouter(net.ParseIP(presence6756Router))}, opts...)
+	return classlessACK(t, all...)
+}
+
+func TestClasslessOptionPresenceSuppressesRouter6756(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		opts    []dhcpv4.Option
+		wantGW  string // "" means no gateway at all
+		wantWhy string
+	}{
+		{
+			name:    "ABSENT: option 3 is honoured (the control)",
+			opts:    nil,
+			wantGW:  presence6756Router,
+			wantWhy: "with no classless option the Router option is the ONLY source of a default route; suppressing it here would break every ordinary lease",
+		},
+		{
+			name:    "option 121 present but ZERO-LENGTH",
+			opts:    []dhcpv4.Option{{Code: dhcpv4.OptionClasslessStaticRoute, Value: dhcpv4.OptionGeneric{Data: []byte{}}}},
+			wantGW:  "",
+			wantWhy: "the option was RETURNED, so RFC 3442 requires the Router option to be ignored even though the option yielded nothing",
+		},
+		{
+			name:    "option 121 present but MALFORMED",
+			opts:    []dhcpv4.Option{{Code: dhcpv4.OptionClasslessStaticRoute, Value: dhcpv4.OptionGeneric{Data: []byte{0xff, 0x01}}}},
+			wantGW:  "",
+			wantWhy: "a prefix length of 255 cannot be parsed; the option is still RETURNED",
+		},
+		{
+			name:    "option 249 present but MALFORMED",
+			opts:    []dhcpv4.Option{{Code: dhcpv4.GenericOptionCode(249), Value: dhcpv4.OptionGeneric{Data: []byte{0xff, 0x01}}}},
+			wantGW:  "",
+			wantWhy: "the legacy Microsoft option is the same encoding and the same rule; its parse error used to be discarded in silence",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lease, err := leaseFromACKv4("wan0", presenceACK6756(t, tc.opts...))
+			if err != nil {
+				t.Fatalf("leaseFromACKv4: %v", err)
+			}
+			if tc.wantGW == "" {
+				if lease.Gateway.IsValid() {
+					t.Errorf("lease.Gateway = %v, want NO gateway — %s. Installing the "+
+						"option-3 router here routes traffic via a gateway the server's "+
+						"classless option was meant to override",
+						lease.Gateway, tc.wantWhy)
+				}
+				return
+			}
+			want := netip.MustParseAddr(tc.wantGW)
+			if lease.Gateway != want {
+				t.Errorf("lease.Gateway = %v, want %v — %s", lease.Gateway, want, tc.wantWhy)
+			}
+		})
+	}
+}
+
+// TestWellFormedClasslessStillSupersedes6756 pins that the presence change did
+// not disturb the working path: a VALID option 121 must still supply the
+// gateway and the more-specific routes, and still suppress option 3.
+//
+// Without this, a "fix" that made presence always true would pass every case
+// above while breaking the feature #4118 added.
+func TestWellFormedClasslessStillSupersedes6756(t *testing.T) {
+	classless := dhcpv4.OptClasslessStaticRoute(
+		&dhcpv4.Route{Dest: mustCIDR(t, "0.0.0.0/0"), Router: net.ParseIP("192.0.2.1")},
+		&dhcpv4.Route{Dest: mustCIDR(t, "10.20.0.0/16"), Router: net.ParseIP("192.0.2.9")},
+	)
+	lease, err := leaseFromACKv4("wan0", presenceACK6756(t, classless))
+	if err != nil {
+		t.Fatalf("leaseFromACKv4: %v", err)
+	}
+	if want := netip.MustParseAddr("192.0.2.1"); lease.Gateway != want {
+		t.Errorf("lease.Gateway = %v, want %v (the option-121 default, not the option-3 router)",
+			lease.Gateway, want)
+	}
+	if len(lease.ClasslessRoutes) != 1 {
+		t.Fatalf("lease.ClasslessRoutes = %+v, want exactly the one more-specific route",
+			lease.ClasslessRoutes)
+	}
+}

--- a/pkg/dhcp/dhcpv4.go
+++ b/pkg/dhcp/dhcpv4.go
@@ -407,20 +407,52 @@ func leaseFromACKv4(ifaceName string, ack *dhcpv4.DHCPv4) (*Lease, error) {
 // route is installed — the server's explicit choice). A malformed entry
 // (bad mask, short buffer) is skipped rather than failing the whole lease.
 func classlessStaticRoutes(ack *dhcpv4.DHCPv4) (routes []LeaseRoute, defaultGW netip.Addr, present bool) {
+	// #6756: PRESENCE is whether the server RETURNED the option, not whether it
+	// parsed. RFC 3442 is explicit — "If the DHCP server returns both a Classless
+	// Static Routes option and a Router option, the DHCP client MUST ignore the
+	// Router option" — and it conditions that on the option being RETURNED. A
+	// zero-length or malformed option 121/249 is still returned.
+	//
+	// Deriving presence from len(parsedRoutes) != 0 collapsed three distinct
+	// cases — absent, present-but-empty, present-but-unparseable — into one
+	// false, so the caller fell through to option 3 in exactly the situations
+	// the RFC forbids it. A server that means "no default route via option 3"
+	// and emits a malformed 121 got the router honoured anyway.
+	//
+	// Read the raw option slots directly. gopacket-style accessors cannot
+	// express "present but unusable": ClasslessStaticRoute() maps any per-entry
+	// error to nil, and the option-249 branch below discards its parse error.
+	_, has121 := ack.Options[uint8(dhcpv4.OptionClasslessStaticRoute)]
+	_, has249 := ack.Options[249]
+	present = has121 || has249
+
 	libRoutes := ack.ClasslessStaticRoute() // option 121
 	if len(libRoutes) == 0 {
 		// Legacy option 249 (Microsoft), identical RFC 3442 encoding.
 		if raw := ack.Options.Get(dhcpv4.GenericOptionCode(249)); len(raw) > 0 {
 			var r dhcpv4.Routes
-			if err := r.FromBytes(raw); err == nil {
+			if err := r.FromBytes(raw); err != nil {
+				// #6756: previously discarded silently. The option is still
+				// PRESENT, so option 3 stays suppressed either way — but an
+				// operator whose default route vanished deserves to know the
+				// server sent something unparseable rather than nothing.
+				slog.Warn("dhcp: classless-static-route option 249 is malformed; ignoring its contents (option 3 stays suppressed per RFC 3442)",
+					"err", err, "len", len(raw))
+			} else {
 				libRoutes = r
 			}
 		}
 	}
-	if len(libRoutes) == 0 {
+	if !present {
 		return nil, netip.Addr{}, false
 	}
-	present = true
+	if len(libRoutes) == 0 {
+		// Present but yielding nothing usable. Return present=true so the caller
+		// does NOT fall back to option 3.
+		slog.Warn("dhcp: classless-static-route option present but yielded no usable routes; option 3 (router) is suppressed per RFC 3442",
+			"option_121", has121, "option_249", has249)
+		return nil, netip.Addr{}, true
+	}
 	for _, lr := range libRoutes {
 		if lr == nil || lr.Dest == nil {
 			continue


### PR DESCRIPTION
Closes #6756

`classlessStaticRoutes` derived its `present` return from `len(parsedRoutes) != 0`, which collapsed **three distinct cases into one `false`**:

| case | old behaviour | RFC 3442 |
|---|---|---|
| option 121/249 **absent** | option 3 honoured | correct |
| option 121 present but **zero-length** | option 3 honoured | **must be ignored** |
| option 121/249 present but **malformed** | option 3 honoured | **must be ignored** |

The caller uses that flag to decide whether to honour option 3, so a server emitting a broken classless-static-route option alongside a Router option got the router installed anyway.

RFC 3442 conditions its rule on the option being **returned** — *"If the DHCP server returns both a Classless Static Routes option and a Router option, the DHCP client MUST ignore the Router option"* — and a zero-length or malformed option is still returned. So the fall-through happened in exactly the situations the RFC forbids it, routing traffic via a gateway the server's classless option was meant to override.

## The fix

Presence now reads the raw option slots. The accessors structurally cannot express "present but unusable": `ClasslessStaticRoute()` maps any per-entry error to `nil`, and the option-249 branch discarded its parse error outright.

That discarded error is now **logged**. The option stays present either way, so option 3 stays suppressed — but an operator whose default route vanished deserves to know the server sent something unparseable rather than nothing.

## The behaviour change, stated plainly

A malformed option 121/249 now yields **no default gateway** where it previously yielded the option-3 router. That is what the RFC requires and it is the fail-closed direction — no gateway is recoverable and visible; a *wrong* gateway silently routes traffic past a policy the server was expressing. Both new suppression paths log at WARN so it is diagnosable rather than mysterious.

## Mutation matrix

Fix committed first. Full `pkg/dhcp` suite per cell, no `-run` filter, rc from a file, control green first.

| # | mutation | rc | fired |
|---|---|---|---|
| X1 | revert: presence from parse success | 1 | the three present-but-broken cases — **not** the ABSENT control, so it localises |
| X2 | **TIGHTEN**: presence always true | 1 | the ABSENT control **+ pre-existing `TestLeaseFromACKv4Option3OnlyUnchanged`** |
| X3 | drop the option-249 slot from the presence test | 1 | the 249 case **+ pre-existing `TestLeaseFromACKv4LegacyOption249`** |

**X2 is the cell that matters.** A fix that simply made `present` always true would satisfy every broken-option case above while **suppressing option 3 on every ordinary lease** — and it reds a test that predates this work. The ABSENT case exists precisely so "presence is the option slot" and "never honour option 3" are distinguishable; without it the two are the same test.

X3 reds pre-existing coverage too, so the legacy Microsoft option's handling is bound by more than my own tests.

## Validation

`go build`, `go vet`, `gofmt` clean; `go test -count=1 ./...` green repo-wide. `pkg/dhcp` only — no cluster, no dataplane, no `userspace-dp` binary or shim `.o` moved.

## Provenance

Split from the opus-review-001 cohort. Its cites had rotted (`/tmp/opus-review-001.md` gone, base `ad9591177481`); the issue body had already been re-derived by symbol, and I re-verified the mechanism at current master before changing anything.
