### PR TITLE
deploy: close two holes in the golden-immutability guard (#6760 + #6761)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104091,3 +104091,25 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: pkg/ddns/state.go, pkg/ddns/surface_a.go, pkg/ddns/manager.go,
   pkg/ddns/cross_surface_authority_6755_test.go,
   pkg/ddns/cross_surface_clobber_5748_test.go
+
+## 2026-08-22 — #6760 + #6761 golden-image guard: two holes, one path
+- **Timestamp**: 2026-08-22
+- **Action**: Merged two A10-b4 issues into one PR after verifying a shared
+  mechanism: #6761's cited line ranges are a strict SUBSET of #6760's, and both
+  are defects in the same four functions (_qcow2_backing_file,
+  _dependent_overlays, _install_libvirt_golden, libvirt_disk).
+  #6760: the probe collapsed four outcomes into "no backing file", so an
+  unprobeable overlay was classified as not-dependent and the golden was
+  overwritten under it. Probe now raises _ProbeIndeterminate; classifier returns
+  (deps, unknown); install refuses on either, with distinct operator messages.
+  Preserved the one legitimate case (qemu-img absent entirely = determinate
+  none, the documented #5043 reasoning).
+  #6761: replacement was an unlocked check-then-in-place-copy — TOCTOU against
+  overlay creation AND a truncated golden on interruption. Now temp+os.replace
+  under an flock that libvirt_disk takes too.
+- **Also found**: /tmp/opus-review-001.md, the "fix direction" reference for all
+  six A10-b4 issues (#6758-#6763), no longer exists — the stated direction is
+  unreachable and had to be derived from the code.
+- **File(s)**: scripts/deploy/xpf-deploy.py,
+  scripts/deploy/test_xpf_deploy_disk.py, docs/distribution.md
+

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -237,7 +237,38 @@ shares one golden, a single re-fetch would poison *both* nodes' disks. So
 `fetch --install-libvirt` refuses to overwrite a golden that still has
 dependent overlays (it scans `/var/lib/libvirt/images/*.qcow2` and checks each
 one's `qemu-img info` backing file). First install (no golden yet) and a
-re-fetch after the dependents are gone both proceed normally. To roll a new
+re-fetch after the dependents are gone both proceed normally.
+
+**Two holes in that guard, closed together (#6760 + #6761).** They are one code
+path — the probe, the classifier, the replacement and the overlay creator — and
+fixing either alone leaves it unsafe.
+
+*An unprobeable sibling is not evidence of safety (#6760).* The backing probe
+returned "no backing file" for four different outcomes: `qemu-img` absent,
+`qemu-img` exited non-zero, unparseable JSON, and a genuine absence. The
+classifier read that as *not a dependent overlay*, so a file the tool could not
+read was assumed safe and the golden was overwritten under it. A running
+domain's overlay is the realistic instance — `qemu-img` can fail on an image a
+live VM holds open. The probe now distinguishes **indeterminate** from
+**no-backing**, and an indeterminate sibling BLOCKS the install with its own
+message (investigate the file) separate from a known dependant (destroy the VM).
+
+The one case that legitimately means "no backing" is preserved: `qemu-img`
+missing *entirely* still classifies as determinate-none, because `qemu-img` is a
+hard dependency of the overlay-create path, so its absence means this tool never
+created an overlay on that host. That reasoning covers a missing binary only; it
+never covered a probe that ran and failed, which was the hole.
+
+*The replacement is atomic and locked (#6761).* It was an unlocked
+check-then-in-place-copy, which fails two ways. An overlay created between the
+check and the copy backs onto bytes that are about to be swapped and nothing
+looks again (TOCTOU); and an **interrupted** in-place copy leaves a truncated
+golden, corrupting every existing overlay with no concurrency involved at all.
+The new image is now written to a sibling temp file and moved into place with an
+atomic rename, so the golden is either wholly the old image or wholly the new
+one — under an exclusive `flock` on `<images-dir>/.xpf-golden.lock` that
+`libvirt_disk` takes as well. Both sides must hold the same lock: locking only
+the replacement would close nothing. To roll a new
 image onto hosts with live VMs, EITHER:
 
 - destroy the dependent VM(s) first so no overlay references the old golden —

--- a/scripts/deploy/test_xpf_deploy_disk.py
+++ b/scripts/deploy/test_xpf_deploy_disk.py
@@ -26,6 +26,8 @@ path and it IS the golden.
 
 from __future__ import annotations
 
+import contextlib
+import fcntl
 import importlib.util
 import os
 import shutil
@@ -39,6 +41,10 @@ _SPEC = importlib.util.spec_from_file_location(
 xpf_deploy = importlib.util.module_from_spec(_SPEC)
 assert _SPEC.loader is not None
 _SPEC.loader.exec_module(xpf_deploy)
+
+
+# Sentinel for "the probe ran and could not determine the answer" (#6760).
+_INDETERMINATE = object()
 
 
 class RecordingRunner:
@@ -193,8 +199,15 @@ class LibvirtGoldenOverwriteGuardTests(unittest.TestCase):
         # required): a {realpath: backing-or-None} map drives the classifier.
         self._backing = {}
 
+        # #6760: the map value may be the sentinel _INDETERMINATE, so a test can
+        # express "the probe RAN and failed" — distinct from "no backing file".
+        # Before #6760 the production probe collapsed both to None and the guard
+        # read that as "not a dependent overlay".
         def fake_backing(path):
-            return self._backing.get(os.path.realpath(path))
+            v = self._backing.get(os.path.realpath(path))
+            if v is _INDETERMINATE:
+                raise xpf_deploy._ProbeIndeterminate(f"fake probe failed for {path}")
+            return v
 
         xpf_deploy._qcow2_backing_file = fake_backing
 
@@ -259,17 +272,253 @@ class LibvirtGoldenOverwriteGuardTests(unittest.TestCase):
         self._backing[os.path.realpath(dep1)] = os.path.realpath(golden)
         # Backs onto a DIFFERENT golden -> not a dependent of this one.
         self._backing[os.path.realpath(indep)] = "/var/lib/libvirt/images/other.qcow2"
-        deps = {os.path.realpath(d)
-                for d in xpf_deploy._dependent_overlays(golden)}
+        found, unknown = xpf_deploy._dependent_overlays(golden)
+        deps = {os.path.realpath(d) for d in found}
         self.assertEqual(deps,
                          {os.path.realpath(dep0), os.path.realpath(dep1)})
+        self.assertEqual(unknown, [], "every fixture probes cleanly here, so "
+                                      "nothing may land in the unknown bucket")
 
     def test_golden_is_not_its_own_overlay(self):
         # A golden whose own backing (spuriously) resolves to itself must never
         # be reported as a dependent overlay of itself.
         golden = self._write(self._golden_path(), b"G")
         self._backing[os.path.realpath(golden)] = os.path.realpath(golden)
-        self.assertEqual(xpf_deploy._dependent_overlays(golden), [])
+        self.assertEqual(xpf_deploy._dependent_overlays(golden), ([], []))
+
+
+class GoldenProbeIndeterminateTests(unittest.TestCase):
+    """#6760: an overlay whose backing could not be PROBED must not be
+    classified as "does not back onto the golden".
+
+    The old probe returned None for four different outcomes — qemu-img absent,
+    qemu-img failed, unparseable JSON, and genuinely no backing file — and the
+    guard read None as "not a dependent overlay". So an unprobeable overlay was
+    assumed safe and the golden was overwritten under exactly the file the tool
+    had failed to read. A running domain's overlay is the realistic instance:
+    qemu-img can fail on an image a live VM holds open.
+    """
+
+    def setUp(self):
+        self._imgdir = tempfile.mkdtemp(prefix="xpf-golden-images-")
+        self._srcdir = tempfile.mkdtemp(prefix="xpf-golden-src-")
+        self._orig_images = xpf_deploy.LIBVIRT_IMAGES
+        self._orig_backing = xpf_deploy._qcow2_backing_file
+        xpf_deploy.LIBVIRT_IMAGES = self._imgdir
+        self._backing = {}
+
+        def fake_backing(path):
+            v = self._backing.get(os.path.realpath(path))
+            if v is _INDETERMINATE:
+                raise xpf_deploy._ProbeIndeterminate(f"fake probe failed for {path}")
+            return v
+
+        xpf_deploy._qcow2_backing_file = fake_backing
+
+    def tearDown(self):
+        xpf_deploy.LIBVIRT_IMAGES = self._orig_images
+        xpf_deploy._qcow2_backing_file = self._orig_backing
+        shutil.rmtree(self._imgdir, ignore_errors=True)
+        shutil.rmtree(self._srcdir, ignore_errors=True)
+
+    def _write(self, path, content=b"x"):
+        with open(path, "wb") as f:
+            f.write(content)
+        return path
+
+    def _golden(self):
+        return self._write(os.path.join(self._imgdir, "appliance.qcow2"), b"GOLDEN")
+
+    def _src(self):
+        return self._write(os.path.join(self._srcdir, "verified.qcow2"), b"NEW")
+
+    def test_unprobeable_sibling_is_reported_unknown_not_independent(self):
+        golden = self._golden()
+        opaque = self._write(os.path.join(self._imgdir, "running-vm.qcow2"))
+        self._backing[os.path.realpath(opaque)] = _INDETERMINATE
+
+        deps, unknown = xpf_deploy._dependent_overlays(golden)
+        self.assertEqual(deps, [], "an unprobeable file is not PROVABLY a dependant")
+        self.assertEqual([p for p, _ in unknown], [os.path.abspath(opaque)],
+                         "...but it must be reported as unknown, not dropped: "
+                         "before #6760 it vanished and the golden was overwritten "
+                         "under it")
+
+    def test_overwrite_refused_when_a_sibling_is_unprobeable(self):
+        golden = self._golden()
+        before = open(golden, "rb").read()
+        opaque = self._write(os.path.join(self._imgdir, "running-vm.qcow2"))
+        self._backing[os.path.realpath(opaque)] = _INDETERMINATE
+
+        with self.assertRaises(SystemExit):
+            xpf_deploy._install_libvirt_golden(self._src(), "appliance")
+        self.assertEqual(open(golden, "rb").read(), before,
+                         "the golden was overwritten despite an unprobeable sibling "
+                         "— this is the #6760 corruption path")
+
+    def test_qemu_img_absent_still_means_no_backing(self):
+        # The ONE case the original reasoning covered and which must NOT start
+        # blocking: qemu-img missing entirely means this tool never created an
+        # overlay here (#5043). Restoring the real probe with no qemu-img on
+        # PATH must yield a determinate None, not an indeterminate.
+        xpf_deploy._qcow2_backing_file = self._orig_backing
+        orig_run = xpf_deploy.subprocess.run
+
+        def no_qemu_img(argv, *a, **kw):
+            if argv and argv[0] == "qemu-img":
+                raise FileNotFoundError("qemu-img")
+            return orig_run(argv, *a, **kw)
+
+        xpf_deploy.subprocess.run = no_qemu_img
+        try:
+            self.assertIsNone(xpf_deploy._qcow2_backing_file("/nonexistent.qcow2"),
+                              "a missing qemu-img must stay DETERMINATE-none; "
+                              "making it indeterminate would block every install "
+                              "on a host without qemu-img, which the #5043 "
+                              "reasoning explicitly covers")
+        finally:
+            xpf_deploy.subprocess.run = orig_run
+
+    def test_clean_probe_still_permits_install(self):
+        # The over-blocking control: with every sibling probing cleanly and none
+        # backing onto the golden, the install must still proceed. An
+        # implementation that treated any probe as suspicious would pass every
+        # test above and break ordinary re-fetches.
+        golden = self._golden()
+        indep = self._write(os.path.join(self._imgdir, "other-vm.qcow2"))
+        self._backing[os.path.realpath(indep)] = "/var/lib/libvirt/images/other.qcow2"
+        self._backing[os.path.realpath(golden)] = None
+
+        out = xpf_deploy._install_libvirt_golden(self._src(), "appliance")
+        self.assertEqual(open(out, "rb").read(), b"NEW",
+                         "a clean re-fetch with no dependants must still install")
+
+
+class GoldenAtomicReplaceTests(unittest.TestCase):
+    """#6761: golden replacement was an unlocked check-then-in-place-copy.
+
+    Two distinct failures, and the second needs no concurrency at all: an
+    INTERRUPTED `shutil.copyfile` onto the live golden leaves it TRUNCATED, and
+    a truncated golden shifts the backing bytes under every existing overlay —
+    the exact corruption the dependency guard exists to prevent.
+    """
+
+    def setUp(self):
+        self._imgdir = tempfile.mkdtemp(prefix="xpf-golden-images-")
+        self._srcdir = tempfile.mkdtemp(prefix="xpf-golden-src-")
+        self._orig_images = xpf_deploy.LIBVIRT_IMAGES
+        xpf_deploy.LIBVIRT_IMAGES = self._imgdir
+
+    def tearDown(self):
+        xpf_deploy.LIBVIRT_IMAGES = self._orig_images
+        shutil.rmtree(self._imgdir, ignore_errors=True)
+        shutil.rmtree(self._srcdir, ignore_errors=True)
+
+    def _paths(self):
+        golden = os.path.join(self._imgdir, "appliance.qcow2")
+        with open(golden, "wb") as f:
+            f.write(b"OLD-GOLDEN-CONTENT")
+        src = os.path.join(self._srcdir, "verified.qcow2")
+        with open(src, "wb") as f:
+            f.write(b"NEW")
+        return src, golden
+
+    def test_interrupted_replace_leaves_the_old_golden_intact(self):
+        src, golden = self._paths()
+        before = open(golden, "rb").read()
+
+        real_copy = xpf_deploy.shutil.copyfile
+
+        def boom(a, b, *args, **kw):
+            real_copy(a, b, *args, **kw)   # write the temp fully...
+            raise KeyboardInterrupt("interrupted after the temp write")
+
+        xpf_deploy.shutil.copyfile = boom
+        try:
+            with self.assertRaises(KeyboardInterrupt):
+                xpf_deploy._atomic_install_golden(src, golden)
+        finally:
+            xpf_deploy.shutil.copyfile = real_copy
+
+        self.assertEqual(open(golden, "rb").read(), before,
+                         "an interruption before the rename must leave the golden "
+                         "WHOLLY the old image — an in-place copy would have left "
+                         "it truncated and corrupted every overlay backing onto it")
+
+    def test_successful_replace_is_whole(self):
+        src, golden = self._paths()
+        xpf_deploy._atomic_install_golden(src, golden)
+        self.assertEqual(open(golden, "rb").read(), b"NEW")
+
+    def test_no_temp_file_is_left_behind(self):
+        # A stray sibling temp would itself be scanned by the dependency guard
+        # on the next run, so cleanup is part of the contract rather than tidiness.
+        src, golden = self._paths()
+        xpf_deploy._atomic_install_golden(src, golden)
+        strays = [n for n in os.listdir(self._imgdir) if "xpf-tmp" in n]
+        self.assertEqual(strays, [], f"temp file(s) left behind: {strays}")
+
+    def test_overlay_create_actually_takes_the_lock(self):
+        # BIND THE WIRING, not the callee. The exclusivity test below proves the
+        # lock works when held; it does NOT prove libvirt_disk takes it, and a
+        # mutation that removed the lock from the overlay-create side passed
+        # every other test in this file. Without both sides on the same lock the
+        # TOCTOU is only half-closed, which is indistinguishable from closed.
+        _, golden = self._paths()
+        overlay_dir = tempfile.mkdtemp(prefix="xpf-overlay-")
+        self.addCleanup(shutil.rmtree, overlay_dir, ignore_errors=True)
+
+        taken = []
+        real_lock = xpf_deploy._golden_lock
+
+        @contextlib.contextmanager
+        def recording_lock(path):
+            taken.append(path)
+            with real_lock(path) as held:
+                yield held
+
+        class LiveRunner:
+            dry = False
+
+            def __init__(self):
+                self.calls = []
+
+            def run(self, argv):
+                self.calls.append(list(argv))
+                return ""
+
+        orig_overlay = xpf_deploy.libvirt_overlay_path
+        xpf_deploy._golden_lock = recording_lock
+        xpf_deploy.libvirt_overlay_path = lambda name: os.path.join(overlay_dir, f"{name}.qcow2")
+        try:
+            runner = LiveRunner()
+            xpf_deploy.libvirt_disk({"name": "vm0", "image": "appliance"}, runner)
+        finally:
+            xpf_deploy._golden_lock = real_lock
+            xpf_deploy.libvirt_overlay_path = orig_overlay
+
+        self.assertEqual(len(taken), 1,
+                         "libvirt_disk did not take the golden lock; the overlay "
+                         "create races golden replacement (#6761)")
+        self.assertEqual(os.path.realpath(taken[0]), os.path.realpath(golden),
+                         "the overlay create must lock on the SAME golden the "
+                         "replacement locks on, or the two never contend")
+
+    def test_lock_is_exclusive_between_replace_and_overlay_create(self):
+        # #6761 TOCTOU: the replacement and the overlay create must contend on
+        # the SAME lock. Holding it in this process must block a second
+        # acquisition, which is what serializes the two paths.
+        _, golden = self._paths()
+        with xpf_deploy._golden_lock(golden) as held:
+            self.assertTrue(held, "the temp images dir is writable, so the lock "
+                                  "must actually be taken here")
+            lockpath = os.path.join(self._imgdir, ".xpf-golden.lock")
+            fd = os.open(lockpath, os.O_CREAT | os.O_RDWR, 0o644)
+            try:
+                with self.assertRaises(BlockingIOError):
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            finally:
+                os.close(fd)
 
 
 if __name__ == "__main__":

--- a/scripts/deploy/xpf-deploy.py
+++ b/scripts/deploy/xpf-deploy.py
@@ -53,6 +53,7 @@ Examples:
 
 import argparse
 import contextlib
+import fcntl
 import json
 import os
 import re
@@ -721,48 +722,81 @@ def libvirt_overlay_path(name):
     return contained_join(LIBVIRT_IMAGES, f"{name}.qcow2", "per-VM overlay")
 
 
-def _qcow2_backing_file(path):
-    """Absolute (realpath) backing-file of a qcow2 image, or None.
+class _ProbeIndeterminate(Exception):
+    """A qcow2 backing-file probe could not determine the answer (#6760).
 
-    Parses `qemu-img info --output=json` and returns the resolved
-    `full-backing-filename` (falling back to `backing-filename`), or None when
-    the image has no backing file, is unreadable, or qemu-img is absent.
-    qemu-img is a hard dependency of the libvirt overlay-create path
-    (`libvirt_disk` -> `qemu-img create`), so its absence means this tool
-    never created an overlay here — treating "unknown" as "no backing" is
-    therefore safe for the overwrite guard below (#5043)."""
+    Distinct from "this image has no backing file". The overwrite guard below
+    treats the two OPPOSITELY: no-backing means the file is not a dependent
+    overlay, while indeterminate means it MIGHT be and must not be assumed
+    away."""
+
+
+def _qcow2_backing_file(path):
+    """Absolute (realpath) backing-file of a qcow2 image, or None when the
+    image demonstrably has no backing file.
+
+    Raises _ProbeIndeterminate when the answer could not be determined —
+    qemu-img exited non-zero (unreadable, locked by a running domain,
+    permission denied, corrupt header) or its JSON did not parse.
+
+    #6760: this used to return None for FOUR different outcomes — qemu-img
+    absent, qemu-img failed, unparseable JSON, and genuinely no backing file —
+    and `_dependent_overlays` read None as "does not back onto the golden". So
+    an overlay this tool could not probe was silently classified as NOT
+    dependent, and `_install_libvirt_golden` then overwrote the golden and
+    corrupted exactly the overlay it had failed to read. A running VM's overlay
+    is a realistic instance: qemu-img can fail on an image held by a live
+    domain.
+
+    The ONE case that legitimately means "no backing" is qemu-img being absent
+    ENTIRELY, and the original reasoning for it still holds and is preserved
+    below: qemu-img is a hard dependency of the overlay-CREATE path
+    (`libvirt_disk` -> `qemu-img create`), so if it is missing from this host
+    then this tool never created an overlay here (#5043). That argument covers
+    a missing binary only; it never covered a probe that ran and failed, which
+    is the hole."""
     try:
         r = subprocess.run(["qemu-img", "info", "--output=json", path],
                            capture_output=True, text=True)
     except FileNotFoundError:
+        # qemu-img absent: no overlay can have been created here. Determinate.
         return None
     if r.returncode != 0:
-        return None
+        raise _ProbeIndeterminate(
+            f"qemu-img info failed for {path}: rc={r.returncode} "
+            f"{(r.stderr or '').strip()}")
     try:
         info = json.loads(r.stdout)
-    except (ValueError, TypeError):
-        return None
+    except (ValueError, TypeError) as exc:
+        raise _ProbeIndeterminate(f"qemu-img info for {path} did not parse: {exc}")
     bf = info.get("full-backing-filename") or info.get("backing-filename")
     return os.path.realpath(bf) if bf else None
 
 
 def _dependent_overlays(golden):
-    """Per-VM overlay qcow2 files in the golden's directory that back onto it.
+    """Classify sibling `*.qcow2` files by whether they back onto `golden`.
+
+    Returns `(deps, unknown)` — sorted absolute paths that PROVABLY back onto
+    the golden, and those whose backing could not be determined (#6760).
 
     `libvirt_disk` creates each VM's overlay as `qemu-img create -b <golden>`,
     so the overlay depends on the golden's bytes being IMMUTABLE. Overwriting
     the golden in place shifts the backing bytes under every one of these
     overlays and corrupts them (#5043) — commonly BOTH HA nodes at once, since
-    a cluster pair shares one golden. Scans sibling `*.qcow2` files and returns
-    the sorted absolute paths whose backing file resolves to `golden` (empty
-    when none, or when the images dir is missing/unreadable)."""
+    a cluster pair shares one golden.
+
+    `unknown` exists because an unprobeable file is not evidence of safety. It
+    is returned separately rather than folded into `deps` so the caller can say
+    something true and actionable about each: a known dependant names the VM to
+    destroy, an unknown one names a file to investigate."""
     golden_real = os.path.realpath(golden)
     imgdir = os.path.dirname(golden_real)
     deps = []
+    unknown = []
     try:
         entries = sorted(os.listdir(imgdir))
     except OSError:
-        return deps
+        return deps, unknown
     for entry in entries:
         if not entry.endswith(".qcow2"):
             continue
@@ -771,49 +805,144 @@ def _dependent_overlays(golden):
             continue  # the golden is not its own overlay
         if not os.path.isfile(cand):
             continue
-        if _qcow2_backing_file(cand) == golden_real:
+        try:
+            backing = _qcow2_backing_file(cand)
+        except _ProbeIndeterminate as exc:
+            unknown.append((os.path.abspath(cand), str(exc)))
+            continue
+        if backing == golden_real:
             deps.append(os.path.abspath(cand))
-    return deps
+    return deps, unknown
+
+
+@contextlib.contextmanager
+def _golden_lock(golden):
+    """Serialize golden replacement against overlay creation (#6761).
+
+    An exclusive flock on `<images-dir>/.xpf-golden.lock`, held across the
+    whole check-then-replace in `_install_libvirt_golden` and across the
+    `qemu-img create -b <golden>` in `libvirt_disk`. Without it the dependency
+    check and the copy are a plain TOCTOU: an overlay created between them
+    backs onto a golden that is about to be replaced, and nothing ever looks
+    again.
+
+    The lock file lives beside the golden so both operations on the same host
+    agree on it. If the directory is not writable by this user the lock cannot
+    be taken; that is not a reason to proceed unserialized, but it is also not
+    a reason to fail a first install on a root-owned images dir, so the lock is
+    best-effort and its absence is reported rather than silently ignored."""
+    lockpath = os.path.join(os.path.dirname(os.path.realpath(golden)),
+                            ".xpf-golden.lock")
+    fd = None
+    try:
+        try:
+            os.makedirs(os.path.dirname(lockpath), exist_ok=True)
+            fd = os.open(lockpath, os.O_CREAT | os.O_RDWR, 0o644)
+        except OSError as exc:
+            print(f"==> note: golden lock {lockpath} unavailable ({exc}); "
+                  f"proceeding WITHOUT serialization against overlay creation "
+                  f"(#6761)")
+            yield False
+            return
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield True
+    finally:
+        if fd is not None:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
 
 
 def _install_libvirt_golden(srcq, image):
     """Install a verified qcow2 to the libvirt golden path deploy reads
-    (fable-165 H-30). Falls back to `sudo install` when the images dir is
-    root-owned (the common case). Returns the destination path.
+    (fable-165 H-30). Returns the destination path.
 
     Golden-immutability contract (#5043): the golden is a SHARED read-only
     backing store — every per-VM overlay is `qemu-img create -b <golden>` and
     depends on its bytes NEVER changing. Overwriting it in place while overlays
     back onto it shifts the backing bytes under live/created overlays and
     corrupts EVERY one (both HA nodes commonly share one golden — a single
-    re-fetch would poison both disks). First install (no golden yet) and a
-    legitimate re-fetch with no dependent overlays are safe; the dangerous
-    in-place overwrite of an in-use golden fails closed with a clear operator
-    message."""
+    re-fetch would poison both disks).
+
+    Two holes in that guard are closed here, and they are one path:
+
+    #6760 — an overlay whose backing could not be PROBED was classified as not
+    dependent, so the guard passed and the golden was overwritten under exactly
+    the file the tool had failed to read. Indeterminate now blocks, separately
+    worded from a known dependant.
+
+    #6761 — the check and the copy were an unlocked check-then-act on a live
+    file. Two failures, not one: an overlay created between the check and the
+    copy is corrupted (TOCTOU), and an INTERRUPTED in-place `copyfile` leaves a
+    truncated golden that corrupts every existing overlay even when the check
+    was correct. The replacement is now written to a temp file in the same
+    directory and moved into place with an atomic rename, under the same lock
+    `libvirt_disk` takes to create an overlay."""
     golden = libvirt_golden_path(image)
-    if os.path.isfile(golden):
-        deps = _dependent_overlays(golden)
-        if deps:
-            listing = "\n    - ".join(deps)
-            die(f"refusing to overwrite golden {golden} in place: "
-                f"{len(deps)} per-VM overlay(s) back onto it and would be "
-                f"corrupted (the qcow2 backing bytes would shift under a live "
-                f"disk — HA-pair disk corruption, #5043):\n    - {listing}\n"
-                f"  Fix by EITHER destroying the dependent VM(s) first "
-                f"(xpf-deploy.py --hypervisor libvirt destroy <appliance.yaml> "
-                f"for each), OR installing the new image under a fresh tag so "
-                f"existing overlays keep their immutable backing "
-                f"(fetch --install-libvirt --alias <new-name>, then reference "
-                f"image: <new-name> in the deploy YAML).")
-    print(f"==> installing verified qcow2 -> {golden} (libvirt golden)")
+    with _golden_lock(golden):
+        if os.path.isfile(golden):
+            deps, unknown = _dependent_overlays(golden)
+            if deps:
+                listing = "\n    - ".join(deps)
+                die(f"refusing to overwrite golden {golden} in place: "
+                    f"{len(deps)} per-VM overlay(s) back onto it and would be "
+                    f"corrupted (the qcow2 backing bytes would shift under a live "
+                    f"disk — HA-pair disk corruption, #5043):\n    - {listing}\n"
+                    f"  Fix by EITHER destroying the dependent VM(s) first "
+                    f"(xpf-deploy.py --hypervisor libvirt destroy <appliance.yaml> "
+                    f"for each), OR installing the new image under a fresh tag so "
+                    f"existing overlays keep their immutable backing "
+                    f"(fetch --install-libvirt --alias <new-name>, then reference "
+                    f"image: <new-name> in the deploy YAML).")
+            if unknown:
+                listing = "\n    - ".join(f"{p}: {why}" for p, why in unknown)
+                die(f"refusing to overwrite golden {golden} in place: "
+                    f"{len(unknown)} sibling qcow2 file(s) could not be probed, so "
+                    f"whether they back onto this golden is UNKNOWN — and an "
+                    f"unprobeable overlay is not evidence of safety (#6760). A "
+                    f"running domain's overlay is a common cause: qemu-img can "
+                    f"fail on an image a live VM holds open.\n    - {listing}\n"
+                    f"  Fix by EITHER making each file probeable (stop the domain "
+                    f"holding it, or correct its permissions) and re-running, OR "
+                    f"installing under a fresh tag so existing overlays keep their "
+                    f"immutable backing (fetch --install-libvirt --alias <new-name>).")
+        print(f"==> installing verified qcow2 -> {golden} (libvirt golden)")
+        _atomic_install_golden(srcq, golden)
+    return golden
+
+
+def _atomic_install_golden(srcq, golden):
+    """Place `srcq` at `golden` by an ATOMIC RENAME, never an in-place copy
+    (#6761).
+
+    An interrupted `shutil.copyfile` onto the live golden leaves it TRUNCATED,
+    which shifts the backing bytes under every existing overlay — the same
+    corruption the dependency guard exists to prevent, reached without any
+    concurrency at all. Writing a sibling temp file and renaming means the
+    golden is either wholly the old image or wholly the new one.
+
+    The temp file is created in the golden's own directory so the rename is
+    within one filesystem (os.replace across filesystems is not atomic and
+    raises). The sudo fallback mirrors the same shape for the root-owned
+    /var/lib/libvirt/images case."""
+    tmp = f"{golden}.xpf-tmp.{os.getpid()}"
     try:
         os.makedirs(os.path.dirname(golden), exist_ok=True)
-        shutil.copyfile(srcq, golden)
+        shutil.copyfile(srcq, tmp)
+        os.replace(tmp, golden)
+        return
     except OSError:
-        # /var/lib/libvirt/images is normally root-owned; -D creates the dir.
-        # run_capture so a failing install reports its stderr, not a traceback.
-        run_capture(["sudo", "install", "-m", "0644", "-D", srcq, golden])
-    return golden
+        # Clean up our partial temp before falling back, so a failed attempt
+        # never leaves a stray sibling *.qcow2-adjacent file behind.
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+    # /var/lib/libvirt/images is normally root-owned; -D creates the dir.
+    # install writes the temp, mv -f renames it into place atomically.
+    run_capture(["sudo", "install", "-m", "0644", "-D", srcq, tmp])
+    run_capture(["sudo", "mv", "-f", tmp, golden])
 
 
 def libvirt_disk(ap, runner):
@@ -846,8 +975,22 @@ def libvirt_disk(ap, runner):
             f"(see `xpf-deploy.py fetch`) or set image: in the YAML.")
     # Fresh overlay per deploy so the VM boots clean from golden; the
     # golden is the read-only -b backing store and is never written.
-    runner.run(["qemu-img", "create", "-f", "qcow2",
-                "-b", golden, "-F", "qcow2", overlay])
+    #
+    # #6761: taken under the SAME lock `_install_libvirt_golden` holds across
+    # its check-then-replace. Without it the two race: a golden replacement
+    # can check for dependent overlays, find none, and then be overtaken by
+    # this create — leaving a brand-new overlay backing onto bytes that are
+    # about to be swapped, which nothing looks at again. Locking only the
+    # replacement side would close nothing; both sides must agree on the lock.
+    #
+    # A dry run performs no filesystem work, so it takes no lock.
+    if runner.dry:
+        runner.run(["qemu-img", "create", "-f", "qcow2",
+                    "-b", golden, "-F", "qcow2", overlay])
+        return overlay
+    with _golden_lock(golden):
+        runner.run(["qemu-img", "create", "-f", "qcow2",
+                    "-b", golden, "-F", "qcow2", overlay])
     return overlay
 
 


### PR DESCRIPTION
Closes #6760
Closes #6761

Two A10-b4 issues in **one PR**, because they are one code path and fixing either alone leaves it unsafe. #6761's cited line ranges are a strict **subset** of #6760's: both are defects in `_qcow2_backing_file`, `_dependent_overlays`, `_install_libvirt_golden` and `libvirt_disk`.

## The contract they protect

The golden is a **shared read-only backing store** — every per-VM overlay is `qemu-img create -b <golden>` and depends on the golden's bytes never changing. Overwriting it in place shifts the backing bytes under every overlay and corrupts them, and an HA pair usually shares one golden, so a single re-fetch poisons **both** nodes' disks (#5043).

## #6760 — an unprobeable sibling is not evidence of safety

`_qcow2_backing_file` returned `None` for **four** different outcomes: `qemu-img` absent, `qemu-img` exited non-zero, unparseable JSON, and a genuine absence. `_dependent_overlays` read `None` as *"does not back onto the golden"*, so a file the tool **could not read** was classified as safe and the golden was overwritten under exactly the overlay it had failed to probe. A running domain's overlay is the realistic instance — `qemu-img` can fail on an image a live VM holds open.

**The docstring is the evidence this was a hole rather than a choice.** Its justification — *"qemu-img is a hard dependency of the overlay-create path, so its absence means this tool never created an overlay here"* — reasons about **one** cause (a missing binary) and the code applied that conclusion to all four. That case is preserved exactly: a missing `qemu-img` still classifies as determinate-none. A probe that **ran and failed** never fell under the argument.

The probe now raises `_ProbeIndeterminate`, the classifier returns `(deps, unknown)`, and the install refuses on either — with **distinct messages**, because a known dependant names a VM to destroy while an unknown names a file to investigate. Keeping them separate rather than folding unknown into deps is what lets each message be true.

## #6761 — the replacement was an unlocked check-then-in-place-copy

Two failures, and only one needs concurrency:

- an overlay created between the check and the copy backs onto bytes about to be swapped, and nothing looks again (**TOCTOU**);
- an **interrupted** `shutil.copyfile` onto the live golden leaves it **truncated**, which shifts the backing bytes under every existing overlay — the same corruption the guard exists to prevent, reached with no concurrency at all.

The new image is now written to a sibling temp file and moved into place with an **atomic rename**, so the golden is either wholly the old image or wholly the new one. The whole check-then-replace runs under an exclusive `flock` on `<images-dir>/.xpf-golden.lock`, which **`libvirt_disk` takes as well** — both sides must hold the same lock, because locking only the replacement closes nothing. The temp lives in the golden's own directory so the rename stays within one filesystem, and is cleaned up on the fallback path so a failed attempt never leaves a stray sibling the dependency scan would later see.

## Mutation matrix

`flock`'d; tree asserted clean before and restored after, mutation asserted APPLIED, syntax checked before running, tests-collected asserted.

| cell | mutation | result |
|---|---|---|
| **T1** | collapse indeterminate back into "no backing" | RED both #6760 tests |
| **T2** | keep the classification but drop the unknown-bucket **refusal** | RED only the refusal test — classifying correctly and then not acting on it is a distinct failure and gets its own cell |
| **T3** | revert to an in-place copy | RED the interrupted-replace test |
| **T4** | remove the lock from the **overlay-create** side only | RED the wiring test — see below |
| **T5** | **TIGHTEN**: make a *missing* `qemu-img` indeterminate too | RED the determinate-none control |

**T4 passed on its first run, and that is the most useful thing in this matrix.** My exclusivity test proved the lock *works when held* but not that `libvirt_disk` **takes** it — so half-closing the TOCTOU was invisible. A lock-correctness test is not a lock-usage test. The added test binds the wiring: assert the call happens, and on the **same** golden.

**T5 is the over-blocking control.** Making a missing `qemu-img` indeterminate would block every install on a host without it — precisely the case the #5043 reasoning covers. T2 and T5 are the cells a delete-only matrix cannot see.

## Worth flagging for the rest of the A10-b4 batch

**`/tmp/opus-review-001.md` no longer exists.** All six issues (#6758–#6763) say *"Fix direction: (per the root section — see link)"* and reference that file, so the stated fix direction is **unreachable** for the whole batch. I derived this one from the code; whoever takes #6758/#6759/#6762/#6763 will have to do the same, or recover the review.

## Validation

`make selftest` — **OK, all self-tests passed or SKIP-gated**. Every `scripts/deploy/test_*.py` suite green (183 tests across 13 files, 18 in the touched file). `go build ./...` clean and `go test -count=1 ./...` **rc=0, 0 FAIL, 71 packages** (no Go code touched; run to confirm nothing regressed).

Deploy tooling only — no dataplane, no cluster runtime, no `userspace-dp` binary or shim moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkfVhT4Y3UDa22mU7uoCVt
