### PR TITLE
scripts: never create the day-0 ISO world-readable

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104127,3 +104127,12 @@ prose edit above them added. No diff falls in the new test body.
   forbids. Presence now comes from the option SLOT; option 249's discarded
   parse error is logged.
 - **File(s)**: pkg/dhcp/dhcpv4.go, pkg/dhcp/classless_presence_6756_test.go
+
+## 2026-08-22 — #6764 day-0 ISO is never created world-readable
+- **Timestamp**: 2026-08-22
+- **Action**: Both ISO builders chmod 0600 only AFTER the tool writes the
+  output, so the secret-bearing ISO existed at umask-derived 0644 for the whole
+  build. Added an _owner_only_umask() guard around the tool invocation in
+  make_config_drive.py and xpf-deploy.py; kept the post-chmod as a belt.
+- **File(s)**: scripts/image/make_config_drive.py, scripts/deploy/xpf-deploy.py,
+  scripts/image/test_config_drive_creation_umask_6764.py

--- a/scripts/deploy/xpf-deploy.py
+++ b/scripts/deploy/xpf-deploy.py
@@ -83,6 +83,32 @@ HARDWARE_BACKINGS = {"sriov", "physical", "pci"}
 SYS_NET = "/sys/class/net"
 
 
+
+@contextlib.contextmanager
+def _owner_only_umask():
+    """Force a 0077 umask for the duration of the block (#6764).
+
+    The ISO tools create the output file themselves, so its mode comes from the
+    process umask at creation time — typically 0022, i.e. 0644 world-readable.
+    The chmod that follows the build only narrows it AFTERWARDS, and the file
+    already contains xpf.conf from the moment the tool writes it, so every
+    co-located UID has the whole build's duration to `isoinfo -x /xpf.conf` the
+    day-0 secrets out.
+
+    Setting the umask around the call closes the window at CREATION rather than
+    after it, and it survives the tool unlinking and recreating its output —
+    which a pre-created 0600 file would not. The chmod afterwards is kept as a
+    belt: it also fixes an output file that already existed with a wider mode.
+
+    umask is process-global and not thread-safe; these scripts are
+    single-threaded, and the block is a single subprocess call.
+    """
+    old = os.umask(0o077)
+    try:
+        yield
+    finally:
+        os.umask(old)
+
 def backing_sort_key(backing):
     """Guest enumeration sort key for a backing, mirroring the sk=0
     (virtio) / sk=1 (hardware) tiebreaker in enumeratePCINICs()
@@ -476,7 +502,8 @@ def build_config_drive(ap, runner):
                     "-J", "-r", "-o", iso, stage]
         else:
             argv = [mkiso, "-quiet", "-V", "xpf-config", "-J", "-r", "-o", iso, stage]
-        run_capture(argv)   # die with the mkiso error, not a bare traceback (H-21)
+        with _owner_only_umask():
+            run_capture(argv)   # die with the mkiso error, not a bare traceback (H-21)
         # The ISO embeds xpf.conf — the most secret-bearing day-0 artifact
         # (root-authentication hash, IKE PSK, SNMP community, DDNS tokens).
         # xorriso/genisoimage writes it under the process umask (~0022 ->

--- a/scripts/image/make_config_drive.py
+++ b/scripts/image/make_config_drive.py
@@ -16,12 +16,39 @@ is run through the real commit-check gate and the build FAILS on reject.
 """
 
 import argparse
+import contextlib
 import os
 import shutil
 import subprocess
 import sys
 import tempfile
 
+
+
+@contextlib.contextmanager
+def _owner_only_umask():
+    """Force a 0077 umask for the duration of the block (#6764).
+
+    The ISO tools create the output file themselves, so its mode comes from the
+    process umask at creation time — typically 0022, i.e. 0644 world-readable.
+    The chmod that follows the build only narrows it AFTERWARDS, and the file
+    already contains xpf.conf from the moment the tool writes it, so every
+    co-located UID has the whole build's duration to `isoinfo -x /xpf.conf` the
+    day-0 secrets out.
+
+    Setting the umask around the call closes the window at CREATION rather than
+    after it, and it survives the tool unlinking and recreating its output —
+    which a pre-created 0600 file would not. The chmod afterwards is kept as a
+    belt: it also fixes an output file that already existed with a wider mode.
+
+    umask is process-global and not thread-safe; these scripts are
+    single-threaded, and the block is a single subprocess call.
+    """
+    old = os.umask(0o077)
+    try:
+        yield
+    finally:
+        os.umask(old)
 
 def die(msg):
     sys.exit(f"ERROR: {msg}")
@@ -83,7 +110,8 @@ def build_config_drive(config, out=None, node_id=None, validate=True):
                     "-J", "-r", "-o", out, stage]
         else:
             argv = [tool, "-quiet", "-V", "xpf-config", "-J", "-r", "-o", out, stage]
-        subprocess.run(argv, check=True)
+        with _owner_only_umask():
+            subprocess.run(argv, check=True)
         # The finished ISO embeds xpf.conf — the most secret-bearing day-0
         # artifact. xorriso/genisoimage/mkisofs writes it under the process
         # umask (~0022 -> 0644, world-readable) and it lingers in CWD until an

--- a/scripts/image/test_config_drive_creation_umask_6764.py
+++ b/scripts/image/test_config_drive_creation_umask_6764.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""The day-0 ISO must never EXIST world-readable, not merely end up 0600 (#6764).
+
+The ISO tools create the output file themselves, so its mode comes from the
+process umask at CREATION time — a typical 0022 yields 0644. The chmod that
+follows the build only narrows it afterwards, and the file already contains
+xpf.conf from the moment the tool writes it. On a large image that window is the
+whole build, and every co-located UID can `isoinfo -R -x /xpf.conf` the
+root-authentication hash, the IKE pre-shared key, the SNMP community and the
+DDNS tokens straight out of it.
+
+The pre-existing #4905-C test cannot see this. Its fake explicitly does
+`os.chmod(out, 0o644)` AFTER writing — it simulates the finished artifact and
+asserts the post-build chmod narrows it. That passes whether or not the file was
+ever reachable at 0644 during construction, which is the thing that matters.
+
+This test observes the mode the file has AT THE MOMENT THE TOOL CREATES IT,
+under a deliberately lax 0022 umask, and never chmods it in the fake. With the
+umask guard removed the recorded mode is 0644 and this fails; the post-build
+chmod cannot repair a window that has already closed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_SPEC = importlib.util.spec_from_file_location(
+    "make_config_drive", Path(__file__).with_name("make_config_drive.py"))
+mcd = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(mcd)
+
+
+class ConfigDriveCreationUmaskTests(unittest.TestCase):
+    def _build_recording_creation_mode(self):
+        """Return the ISO's mode as it existed the instant the tool created it."""
+        seen = []
+
+        def fake_run(argv, check=False):
+            out = argv[argv.index("-o") + 1]
+            # Create it the way the real tools do: let the UMASK decide. No
+            # explicit chmod here — that is the whole point of the test.
+            with open(out, "wb") as f:
+                f.write(b"\x00" * 2048)
+            seen.append(os.stat(out).st_mode & 0o777)
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg = os.path.join(td, "xpf.conf")
+            with open(cfg, "w") as f:
+                f.write("system { host-name t; }\n")
+            out = os.path.join(td, "day0.iso")
+
+            old = os.umask(0o022)  # the lax default that produces 0644
+            try:
+                with mock.patch.object(mcd.subprocess, "run", fake_run), \
+                     mock.patch.object(mcd, "_iso_tool", lambda: "xorriso"):
+                    mcd.build_config_drive(cfg, out, node_id=None, validate=False)
+                final = os.stat(out).st_mode & 0o777
+                # Sample the umask HERE, inside the block, before this test's
+                # own finally restores it — otherwise the test repairs the very
+                # leak it is meant to detect and a guard that never restores
+                # passes. (Measured: it did.)
+                umask_after = os.umask(0o022)
+                os.umask(umask_after)
+            finally:
+                os.umask(old)
+
+        self.assertEqual(len(seen), 1, "the ISO tool was not invoked exactly once")
+        return seen[0], final, umask_after
+
+    def test_iso_is_never_created_world_readable(self):
+        creation_mode, final_mode, _ = self._build_recording_creation_mode()
+        self.assertEqual(
+            creation_mode & 0o077, 0,
+            f"the ISO was CREATED mode {creation_mode:04o} under a 0022 umask. It already "
+            "contains xpf.conf at that moment, so every co-located UID can read the day-0 "
+            "secrets for the whole build; chmodding afterwards cannot close a window that "
+            "has already been open")
+        # And the finished artifact is still owner-only — the #4905-C property.
+        self.assertEqual(
+            final_mode & 0o077, 0,
+            f"finished ISO mode {final_mode:04o}, want owner-only")
+
+    def test_umask_is_restored_after_the_build(self):
+        """The guard must not leak a 0077 umask into the rest of the process.
+
+        umask is process-global. A build that left it at 0077 would silently
+        narrow every file the caller creates afterwards — including ones a later
+        step expects to be group-readable."""
+        _, _, umask_after_build = self._build_recording_creation_mode()
+        self.assertEqual(
+            umask_after_build, 0o022,
+            f"the build left the umask at {umask_after_build:04o}, not the caller's 0022. "
+            "umask is process-global, so a leaked 0077 silently narrows every file the "
+            "caller creates afterwards")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #6764

Both config-drive builders chmod the finished ISO `0600` — but the ISO tools **create the output file themselves**, so its mode comes from the process umask at creation time. A typical `0022` yields `0644`, and the chmod only narrows it *afterwards*. The file already contains `xpf.conf` from the moment the tool writes it, so on a large image the world-readable window is the whole build, and any co-located UID can `isoinfo -R -x /xpf.conf` the root-authentication hash, IKE pre-shared key, SNMP community and DDNS tokens straight out of it.

Both scripts already **documented** the umask hazard in a comment next to the chmod. Neither closed it.

```python
# xorriso/genisoimage writes it under the process umask (~0022 ->
# 0644, world-readable) and it lingers in CWD until destroy. ...
os.chmod(iso, 0o600)          # <- only AFTER the tool has finished
```

## The fix

A `_owner_only_umask()` guard around the tool invocation, in **both** `scripts/image/make_config_drive.py` and `scripts/deploy/xpf-deploy.py` — they share the identical window.

Closing it at *creation* rather than after, and via the umask rather than by pre-creating a `0600` file, because the umask **survives the tool unlinking and recreating its output** and a pre-created file's mode would not. The post-build chmod is kept as a belt: it also narrows an output file that already existed with a wider mode.

## Scope: two of the issue's three cites are refuted, and this change does not touch them

The issue body had already been re-derived by symbol (its original cites pointed at a deleted `/tmp` report and a rotted base), and that re-derivation stands:

- **The staging directory is not umask-derived.** Both scripts use `tempfile.mkdtemp()`, which is `0700` by construction and umask-independent.
- **The cited `xpf-deploy.py:224-227` is not ISO code** — it is a path-containment `die()` message with no permission logic.

## The pre-existing test cannot see this defect — measured, not assumed

`test_make_config_drive_mode.py` (#4905-C) already asserts the finished ISO is owner-only. Its fake explicitly does `os.chmod(out, 0o644)` **after** writing, so it simulates the finished artifact and proves the post-build chmod narrows it. That passes whether or not the file was ever reachable at `0644` during construction.

I verified this rather than asserting it: **with the new guard removed, the #4905-C test still passes.**

The new test observes the mode the file has **at the moment the tool creates it**, under a deliberate `0022` umask, and never chmods it in the fake.

## Mutation matrix

| # | mutation | result |
|---|---|---|
| Y1 | remove the umask guard | **RED** — `the ISO was CREATED mode 0644 under a 0022 umask … chmodding afterwards cannot close a window that has already been open` |
| Y2 | guard sets the umask but never restores it | 0 → **RED** — see below |

**Y2 was GREEN first time, and that was a gap in my own test.** My helper restored the umask in its own `finally`, so it repaired the very leak it was meant to detect — a guard that never restores passed. The helper now samples the umask *inside* the block, before its own restore. This matters: `umask` is process-global, and a leaked `0077` would silently narrow every file the caller creates afterwards.

## Validation

`make selftest` — **62 passed, 0 skipped, 0 failed**. I confirmed the new file is actually in that run (the harness globs `scripts/image/test_*.py`) rather than trusting the aggregate.

Scripts only — no Go, no Rust, no cluster surface.
