### PR TITLE
upgrade: refuse staged-gen GC when current-gen cannot be resolved

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104157,3 +104157,22 @@ prose edit above them added. No diff falls in the new test body.
   make_config_drive.py and xpf-deploy.py; kept the post-chmod as a belt.
 - **File(s)**: scripts/image/make_config_drive.py, scripts/deploy/xpf-deploy.py,
   scripts/image/test_config_drive_creation_umask_6764.py
+
+## 2026-08-22 — #6763 staged-gen GC fails closed on an unresolvable current-gen
+- **Timestamp**: 2026-08-22
+- **Action**: GC read `if cur, rerr := c.ResolveCurrent(); rerr == nil && cur !=
+  ""` — the error was DISCARDED, so when current-gen could not be resolved the
+  live generation was never added to the protection set and the destructive loop
+  deleted it once outside the retention window. Every ResolveCurrent error path
+  means "cannot establish which generation is live", including a DANGLING
+  current-gen (corrupt layout — exactly when protection matters most). GC now
+  returns an error and deletes nothing. Absence stays benign: ResolveCurrent
+  returns ("", nil) with no link, so a never-published root still GCs.
+- **Not a new policy**: publish_generation.go already applies this rule to the
+  JOURNAL half of the protection set (#4876 — unknown protection set means skip
+  GC, "skipping is safe"). current-gen was the half that never got it. All three
+  callers treat a GC error as a warning, so the refusal cannot block a publish,
+  seed or cut.
+- **File(s)**: pkg/upgrade/stagedgen/stagedgen.go,
+  pkg/upgrade/stagedgen/stagedgen_test.go, docs/in-place-upgrade.md
+

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -808,7 +808,22 @@ window for ALL FOUR managed binaries:
   the pinned generation is UNKNOWN, so publish-generation SKIPS the GC
   rather than run it with an empty protection set and reap the crashed
   cut's source (which would leave the resume unrecoverable). An absent
-  journal means no crashed cut, so GC proceeds normally.
+  journal means no crashed cut, so GC proceeds normally. **The SAME rule now covers
+  the other half of the protection set (#6763):** `current-gen` is
+  resolved explicitly, and that resolution can FAIL — a readlink error, a
+  hand-edited symlink carrying path components that would escape the
+  staged-gen root, a target that is not a valid `genid`, or a DANGLING
+  `current-gen` whose directory is missing. The error used to be
+  DISCARDED, so the live generation simply went unprotected and GC reaped
+  it as soon as it fell outside the retention window — with the dangling
+  case being the sharpest, since a corrupt layout is exactly when the live
+  generation most needs protecting. GC now REFUSES and deletes nothing
+  when `current-gen` cannot be resolved. The benign case stays benign:
+  `ResolveCurrent` returns `("", nil)` when there is no `current-gen` link
+  at all, so a never-published root still GCs normally — absence is
+  determinate, failure is not. All three GC callers already treat a GC
+  error as a warning, never fatal, so the refusal degrades to "GC
+  skipped" and cannot block a publish, a seed or a cut.
 - **Same-version replacement (B-P3b OPT1).** `versions/<ver>` carries a
   `.srcgen` stamp; the copy-skip is generation-aware. A same-version
   re-stage with NEW bytes (a new generation) RE-COPIES a stale, non-live

--- a/pkg/upgrade/stagedgen/stagedgen.go
+++ b/pkg/upgrade/stagedgen/stagedgen.go
@@ -321,7 +321,47 @@ func (c Config) GC(protected map[string]bool) error {
 	for g := range protected {
 		extraProtected[g] = true
 	}
-	if cur, rerr := c.ResolveCurrent(); rerr == nil && cur != "" {
+	// #6763: an UNRESOLVABLE current generation aborts the GC. This used to
+	// read `if cur, rerr := c.ResolveCurrent(); rerr == nil && cur != ""`,
+	// which DISCARDED rerr — so when current-gen could not be resolved the
+	// live generation simply was not added to the protection set, and the
+	// destructive loop below then deleted it as soon as it fell outside the
+	// retention window.
+	//
+	// Every one of ResolveCurrent's error paths means "I cannot establish
+	// which generation is live", and each is reachable: a readlink failure
+	// (I/O, permissions), a hand-edited symlink with path components that
+	// would escape the staged-gen root, a target that is not a valid genid,
+	// and a DANGLING current-gen whose directory is missing. The last is the
+	// sharpest — a corrupt layout is exactly when the live generation most
+	// needs protecting, and it was exactly when protection silently vanished.
+	//
+	// ResolveCurrent already distinguishes the one benign case: NO current-gen
+	// link at all returns ("", nil), not an error, so a fresh root that has
+	// never published still GCs normally. Absence is determinate; failure is
+	// not.
+	//
+	// Aborting is the established response, not a new policy: publish-
+	// generation applies the same rule to the OTHER half of the protection set
+	// (#4876) — "if the journal is present but unreadable or malformed, we
+	// cannot see which generation a crashed cut pins, so GC is SKIPPED rather
+	// than run with an empty protection set", and "skipping is safe — the
+	// extra staged generations are harmless and the next publish reclaims
+	// them". current-gen was the half that never got the rule. All three
+	// callers already treat a GC error as a warning, never fatal, so this
+	// degrades to "GC skipped" and cannot block a publish, a seed or a cut.
+	//
+	// sweepPartials above stays: a `.partial` directory is never a generation
+	// (ValidGenID cannot match a name carrying partialSuffix, so current-gen
+	// can never resolve to one), so removing them cannot destroy the live
+	// generation and is not gated on identifying it.
+	cur, rerr := c.ResolveCurrent()
+	if rerr != nil {
+		return fmt.Errorf("stagedgen: gc REFUSED, no generation deleted: the current "+
+			"generation could not be resolved, so it cannot be protected from "+
+			"deletion: %w", rerr)
+	}
+	if cur != "" {
 		extraProtected[cur] = true
 	}
 

--- a/pkg/upgrade/stagedgen/stagedgen_test.go
+++ b/pkg/upgrade/stagedgen/stagedgen_test.go
@@ -3,6 +3,7 @@ package stagedgen
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -471,5 +472,130 @@ func bumpMtime(t *testing.T, path string, secs int64) {
 	mt := time.Unix(base+secs, 0)
 	if err := os.Chtimes(path, mt, mt); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// #6763 — GC discarded ResolveCurrent's error and proceeded to destructive
+// deletion with the live generation unprotected.
+//
+// The old line was `if cur, rerr := c.ResolveCurrent(); rerr == nil && cur !=
+// ""` — rerr was tested only for nil-ness and then dropped. Every one of
+// ResolveCurrent's error paths means "I cannot establish which generation is
+// live": a readlink failure, a symlink with path components that would escape
+// the staged-gen root, a target that is not a valid genid, and a DANGLING
+// current-gen whose directory is missing. In each, GC then reaped whatever fell
+// outside the retention window — including the live generation.
+//
+// The rule applied here is not new. publish-generation already refuses to run
+// GC when the OTHER half of the protection set is unknown (#4876: an unreadable
+// or malformed journal means "GC is SKIPPED rather than run with an empty
+// protection set"). current-gen was the half that never got it.
+
+// gcFixtureBeyondWindow publishes RetainGenerations+1 generations and returns
+// them oldest-first. The oldest is outside the retention window, so it is what
+// an unprotected GC deletes — which makes it the observable for these tests.
+func gcFixtureBeyondWindow(t *testing.T) (Config, []string) {
+	t.Helper()
+	root := t.TempDir()
+	staged := filepath.Join(root, "staged")
+	writeStaged(t, staged, "v1")
+	c := newConfig(t, staged)
+	var gens []string
+	for i := 0; i < RetainGenerations+1; i++ {
+		g, err := c.Publish()
+		if err != nil {
+			t.Fatal(err)
+		}
+		gens = append(gens, g)
+	}
+	return c, gens
+}
+
+func TestGCRefusesWhenCurrentGenIsDangling_6763(t *testing.T) {
+	c, gens := gcFixtureBeyondWindow(t)
+	oldest := gens[0]
+
+	// A DANGLING current-gen: the link names a generation whose directory is
+	// gone. ResolveCurrent calls this a corrupt layout and errors — and a
+	// corrupt layout is exactly when the live generation most needs protecting.
+	missing := "00000000000000000001-000000000000dead"
+	if err := atomicRelSymlink(filepath.Join(c.Dir, CurrentGenLink), missing); err != nil {
+		t.Fatal(err)
+	}
+
+	err := c.GC(nil)
+	if err == nil {
+		t.Fatalf("GC returned nil with an unresolvable current-gen — it proceeded to " +
+			"destructive deletion without knowing which generation is live (#6763)")
+	}
+	if !strings.Contains(err.Error(), "current") {
+		t.Errorf("the error must name the cause so an operator can act on it, got: %v", err)
+	}
+	// Nothing may have been deleted: the refusal is the whole point.
+	for _, g := range gens {
+		if _, serr := os.Stat(c.GenDir(g)); serr != nil {
+			t.Errorf("GC deleted generation %s despite refusing: %v", g, serr)
+		}
+	}
+	_ = oldest
+}
+
+func TestGCRefusesWhenCurrentGenEscapesTheRoot_6763(t *testing.T) {
+	c, gens := gcFixtureBeyondWindow(t)
+	// A hand-edited symlink with a path component. ResolveCurrent rejects it
+	// BEFORE deriving a genid precisely so it cannot escape the root; GC must
+	// treat that rejection as "unknown", not "no current generation".
+	if err := atomicRelSymlink(filepath.Join(c.Dir, CurrentGenLink), "../"+gens[len(gens)-1]); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.GC(nil); err == nil {
+		t.Fatalf("GC proceeded with a current-gen symlink that escapes the staged-gen root")
+	}
+	for _, g := range gens {
+		if _, serr := os.Stat(c.GenDir(g)); serr != nil {
+			t.Errorf("GC deleted generation %s despite an unresolvable current-gen: %v", g, serr)
+		}
+	}
+}
+
+// TestGCStillRunsWhenThereIsNoCurrentGen_6763 is the OVER-BLOCKING control, and
+// it is the cell that separates this fix from "abort whenever ResolveCurrent
+// returns anything unusual".
+//
+// ResolveCurrent distinguishes the benign case deliberately: NO current-gen link
+// returns ("", nil), not an error. Absence is determinate — there is nothing to
+// protect — so GC must still reap. An implementation that aborted here would
+// leave a never-published root accumulating generations forever while passing
+// both refusal tests above.
+func TestGCStillRunsWhenThereIsNoCurrentGen_6763(t *testing.T) {
+	c, gens := gcFixtureBeyondWindow(t)
+	if err := os.Remove(filepath.Join(c.Dir, CurrentGenLink)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.GC(nil); err != nil {
+		t.Fatalf("GC refused with NO current-gen link: absence is determinate and must "+
+			"not block reclamation: %v", err)
+	}
+	if _, serr := os.Stat(c.GenDir(gens[0])); !os.IsNotExist(serr) {
+		t.Errorf("the oldest generation survived a GC that should have reaped it "+
+			"(err=%v) — the retention window was not applied", serr)
+	}
+}
+
+// TestGCProtectsResolvableCurrentGen_6763 is the green control: when current-gen
+// resolves, the pre-existing protection must still hold. Without it, "refuse on
+// error" could be satisfied by an implementation that also stopped protecting
+// on success.
+func TestGCProtectsResolvableCurrentGen_6763(t *testing.T) {
+	c, gens := gcFixtureBeyondWindow(t)
+	oldest := gens[0]
+	if err := atomicRelSymlink(filepath.Join(c.Dir, CurrentGenLink), oldest); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.GC(nil); err != nil {
+		t.Fatalf("GC failed with a perfectly resolvable current-gen: %v", err)
+	}
+	if _, serr := os.Stat(c.GenDir(oldest)); serr != nil {
+		t.Errorf("GC deleted the resolvable current-gen %s: %v", oldest, serr)
 	}
 }


### PR DESCRIPTION
Closes #6763

## The defect

`GC` read:

```go
if cur, rerr := c.ResolveCurrent(); rerr == nil && cur != "" {
    extraProtected[cur] = true
}
```

`rerr` was tested only for nil-ness and then **discarded**. When current-gen could not be resolved, the live generation was simply never added to the protection set — and the destructive loop below deleted it as soon as it fell outside the retention window.

**Every** `ResolveCurrent` error path means *"I cannot establish which generation is live"*, and each is reachable:

- a readlink failure (I/O, permissions);
- a hand-edited symlink carrying path components — which `ResolveCurrent` rejects *precisely* so it cannot escape the staged-gen root;
- a target that is not a valid `genid`;
- a **dangling** current-gen whose directory is missing.

The last is the sharpest: **a corrupt layout is exactly when the live generation most needs protecting**, and it was exactly when the protection silently vanished. The comment directly above the discarded error even states the property being lost — *"current-gen is resolved EXPLICITLY rather than relying on it being the newest by mtime"* — while the explicit resolution's failure was swallowed.

GC now returns an error and deletes **nothing** when current-gen cannot be resolved.

## This is not a new policy

`publish-generation` already applies exactly this rule to the **other half** of the protection set (#4876):

> "if the journal is present but unreadable (I/O error) or malformed, we cannot see which generation a crashed cut pins, so GC is SKIPPED rather than run with an empty protection set" … "Skipping is safe — the extra staged generations are harmless and the next publish with a readable journal reclaims them."

current-gen was the half that never got the rule. This applies it to the sibling input.

## The benign case stays benign

`ResolveCurrent` already drew the distinction: **no current-gen link at all returns `("", nil)`, not an error.** A never-published root still GCs normally. Absence is determinate; failure is not — the same distinction #6760 drew between "no backing file" and "could not probe".

**Not a brick risk.** All three GC callers — `publish_generation.go`, `seed.go`, `flip.go` — already treat a GC error as a **warning, never fatal**, so the refusal degrades to "GC skipped" and cannot block a publish, a seed or a cut. `sweepPartials` still runs: a `.partial` directory is never a generation (`ValidGenID` cannot match a name carrying `partialSuffix`, so current-gen can never resolve to one), so removing them cannot destroy the live generation and is not gated on identifying it.

## Mutation matrix

`flock`'d; tree asserted clean before and restored after, mutation asserted APPLIED, `go vet` clean before running, tests-collected asserted.

| cell | mutation | result |
|---|---|---|
| **U1** | restore the **verbatim** pre-fix line (discard the resolve error) | RED both refusal tests |
| **U2** | **TIGHTEN**: abort when there is **no** current-gen either — treat determinate absence as unknown | RED the no-current-gen control |
| **U3** | refuse on error but stop protecting on **success** | RED the resolvable control **and the pre-existing `TestGCProtectsCurrentGenEvenIfNotNewest`** |

**U2 is the over-blocking cell.** Aborting on absence would leave a never-published root accumulating generations forever while passing both refusal tests — invisible to any delete-the-feature cell.

**U3 redding a pre-existing test alongside the new one is the useful part:** the protection property was already owned by the suite, so this change neither decommissioned it nor duplicated it.

## Validation

`go build ./...` clean; **`go test -count=1 ./...` rc=0, 0 FAIL, 71 packages**.

`pkg/upgrade` only — no dataplane, no cluster runtime, no `userspace-dp` binary or shim moved.

## Note for the rest of the A10-b4 batch

`/tmp/opus-review-001.md` — the "fix direction" reference for all six issues (#6758–#6763) — **no longer exists**, so that direction is unreachable batch-wide. This fix was derived from the code, and the #4876 precedent in `publish_generation.go` is what settled the policy question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkfVhT4Y3UDa22mU7uoCVt
