### PR TITLE
upgrade: clear BootNext when the two-phase arm fails after setting it

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104157,3 +104157,25 @@ prose edit above them added. No diff falls in the new test body.
   make_config_drive.py and xpf-deploy.py; kept the post-chmod as a belt.
 - **File(s)**: scripts/image/make_config_drive.py, scripts/deploy/xpf-deploy.py,
   scripts/image/test_config_drive_creation_umask_6764.py
+
+## 2026-08-22 — #6758 clear BootNext when the two-phase arm fails after SetBootNext
+- **Timestamp**: 2026-08-22
+- **Action**: The arm records ARMING, sets BootNext, reads it back, then advances
+  to ARMED. Every failure after SetBootNext SUCCEEDED returned an error and left
+  the journal at ARMING — while the firmware would still one-shot the candidate.
+  ARMING documents the opposite ("the firmware still boots the known-good
+  default"), which is what lets Arm re-arm and what stops self-recovery
+  suppressing failback, so a drained node could rejoin with an untested kernel
+  queued. Added KernelSystem.ClearBootNext (efibootmgr --delete-bootnext) and a
+  single-sourced disarmAfterArmFailure on all four post-SetBootNext failure
+  paths. A failed clear is reported loudly with the operator command rather than
+  escalated to a journal state (ARMED would assert a recorded promote binary
+  that may be exactly what is missing).
+- **Sharpest path**: recordPromoteBinary failing AFTER a confirmed readback left
+  a genuinely queued candidate with no xpfd designated to verify it — the thing
+  #6601 added that record to prevent.
+- **File(s)**: pkg/upgrade/kernel.go, pkg/upgrade/kernel_linux.go,
+  pkg/upgrade/kernel_run.go, pkg/upgrade/kernel_test.go,
+  pkg/upgrade/kernel_bootnext_disarm_6758_test.go (new),
+  docs/in-place-upgrade.md
+

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -1527,6 +1527,26 @@ treats an unreadable observation as a definite safe state:
      the variable must NOT yield a verified-ARMED journal;
   4. only THEN durably transition `ARMING -> ARMED`, recording the
      confirmed `BootID` for boot-provenance.
+  5. **and on ANY failure after step 2, clear the one-shot (#6758).**
+     `SetBootNext` has already succeeded by then, so returning an error and
+     leaving the journal at `ARMING` used to leave the FIRMWARE armed while
+     every durable software gate said unarmed — the exact inverse of what
+     `ARMING` asserts below. Steps 3 and 4 both fail this way, as does the
+     `recordPromoteBinary` write between them, and that last one is the
+     sharpest: the readback had already CONFIRMED the one-shot, so the
+     candidate was genuinely queued while no xpfd was designated to verify
+     it — an armed candidate with nothing to run the promotion gate, which
+     #6601 added that record specifically to prevent. The undo is
+     single-sourced (`disarmAfterArmFailure`) because four failure paths
+     needing the identical cleanup is how one gets missed, and clearing an
+     absent BootNext is not an error so it is safe even where the firmware
+     dropped the variable itself. If the clear ITSELF fails the divergence
+     is real and cannot be undone in-process, so the error says so and names
+     `efibootmgr --delete-bootnext`; it is deliberately NOT escalated to a
+     journal state, because `ARMED` asserts a verified one-shot WITH a
+     recorded promote binary — precisely what may be missing on the
+     `recordPromoteBinary` path — so claiming it would substitute a
+     different false record for this one.
 
   `ARMING` sits BELOW `ARMED` in the journal order, so a journal stuck
   there (readback failed / never ran) lets `Arm` RE-ARM (the `>= ARMED`

--- a/pkg/daemon/kernel_upgrade_status_6495_test.go
+++ b/pkg/daemon/kernel_upgrade_status_6495_test.go
@@ -205,6 +205,7 @@ func (f kernelStatusFakeSys) WriteSlotSelector(string, string) error        { re
 func (f kernelStatusFakeSys) ReadSlotSelector(string) (string, error)       { return "", nil }
 func (f kernelStatusFakeSys) SetBootNext(string) error                      { return nil }
 func (f kernelStatusFakeSys) GetBootNext() (string, error)                  { return "", nil }
+func (f kernelStatusFakeSys) ClearBootNext() error                          { return nil }
 func (f kernelStatusFakeSys) ArmWatchdog() error                            { return nil }
 func (f kernelStatusFakeSys) Reboot() error                                 { return nil }
 func (f kernelStatusFakeSys) WritePromotionMarker(string) error             { return nil }

--- a/pkg/upgrade/kernel.go
+++ b/pkg/upgrade/kernel.go
@@ -272,6 +272,13 @@ type KernelSystem interface {
 	// before recording the verified ARMED journal — a firmware that silently
 	// dropped or partial-wrote the variable must not yield a false-ARMED journal.
 	GetBootNext() (string, error)
+	// ClearBootNext removes the one-shot BootNext variable (#6758). The
+	// two-phase arm calls it on EVERY failure that happens after SetBootNext
+	// has already succeeded, so NVRAM never stays armed while the durable
+	// journal records ARMING — a state the journal explicitly defines as "the
+	// firmware still boots the known-good default (no confirmed one-shot)".
+	// Clearing an already-absent BootNext is not an error.
+	ClearBootNext() error
 	// ArmWatchdog arms the persistent watchdog before the reboot (best
 	// effort; the firmware BootNext clear is the loop-safety, the watchdog
 	// only converts a hang into the reset that triggers the fallback).

--- a/pkg/upgrade/kernel_bootnext_disarm_6758_test.go
+++ b/pkg/upgrade/kernel_bootnext_disarm_6758_test.go
@@ -1,0 +1,126 @@
+package upgrade
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// #6758 — BootNext could remain armed in NVRAM while every durable software
+// gate classified the node as unarmed.
+//
+// The two-phase arm records ARMING before touching NVRAM and advances to ARMED
+// only after a positive BootNext readback. Every failure between those points
+// returned an error and left the journal at ARMING — but `SetBootNext` had
+// ALREADY SUCCEEDED, so the firmware would still one-shot the candidate on the
+// next reboot.
+//
+// ARMING is documented as exactly the opposite: "the firmware still boots the
+// known-good default (no confirmed one-shot)". That claim is what lets `Arm`
+// re-arm from ARMING and what stops self-recovery suppressing expired-lease
+// failback — so a drained node could rejoin with an untested candidate kernel
+// queued for its next boot, while `IsArmed()` reported false.
+//
+// The observable in these tests is the FIRMWARE state (the fake's bootNext),
+// not the journal: the journal was always right about what it had confirmed;
+// NVRAM was the half that disagreed with it.
+
+func TestArmClearsBootNextWhenReadbackFails_6758(t *testing.T) {
+	f := newFakeKernelSystem()
+	f.getBootNextErr = errors.New("efivarfs readback raced / unavailable")
+	r := newKernelRunner(t, f)
+
+	if err := r.Arm("6.18.5-12-generic"); err == nil {
+		t.Fatal("premise broken: the arm must fail when the readback cannot confirm")
+	}
+	if f.bootNext != "" {
+		t.Errorf("BootNext is still %q after a failed arm — the firmware will one-shot the "+
+			"candidate while the journal records ARMING (no trial) and IsArmed() reports "+
+			"false (#6758)", f.bootNext)
+	}
+	j, err := r.loadKernelJournal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j.State != KernelStateArming {
+		t.Errorf("journal state = %s, want ARMING — the disarm must not change the "+
+			"journal's meaning, only make NVRAM agree with it", j.State)
+	}
+}
+
+func TestArmClearsBootNextWhenReadbackDisagrees_6758(t *testing.T) {
+	f := newFakeKernelSystem()
+	// The firmware silently accepted something else — a partial write or a
+	// dropped variable. Whatever is in NVRAM, it must not survive a failed arm.
+	f.getBootNextRet = "Boot9999"
+	r := newKernelRunner(t, f)
+
+	if err := r.Arm("6.18.5-12-generic"); err == nil {
+		t.Fatal("premise broken: a readback mismatch must fail the arm")
+	}
+	if f.bootNext != "" {
+		t.Errorf("BootNext left as %q after a readback mismatch — a one-shot the arm "+
+			"refused to record must not survive it (#6758)", f.bootNext)
+	}
+}
+
+// TestArmReportsAnUnclearableBootNext_6758 covers the case the disarm cannot
+// fix. If the clear itself fails the divergence is real, so the error must say
+// so and name the operator command — a failed arm that quietly leaves the
+// firmware armed is the original defect wearing a different error message.
+func TestArmReportsAnUnclearableBootNext_6758(t *testing.T) {
+	f := newFakeKernelSystem()
+	f.getBootNextErr = errors.New("efivarfs readback raced / unavailable")
+	f.clearBootNextErr = errors.New("efibootmgr: cannot write efivarfs")
+	r := newKernelRunner(t, f)
+
+	err := r.Arm("6.18.5-12-generic")
+	if err == nil {
+		t.Fatal("premise broken: the arm must fail")
+	}
+	msg := err.Error()
+	for _, want := range []string{"could not be cleared", "efibootmgr --delete-bootnext"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("the error must name the un-undoable divergence and the remedy; "+
+				"missing %q in: %v", want, err)
+		}
+	}
+	if !strings.Contains(msg, "readback") {
+		t.Errorf("the ORIGINAL cause must survive the wrapping — an operator needs to know "+
+			"why the arm failed, not only that a cleanup failed: %v", err)
+	}
+}
+
+// TestSuccessfulArmKeepsBootNext_6758 is the OVER-CLEARING control, and it is
+// the one that matters most: an implementation that cleared BootNext
+// unconditionally would pass every test above and DISARM EVERY SUCCESSFUL ARM —
+// turning a kernel upgrade into a silent no-op that boots the old kernel and
+// reports success.
+func TestSuccessfulArmKeepsBootNext_6758(t *testing.T) {
+	f := newFakeKernelSystem()
+	r := newKernelRunner(t, f)
+
+	if err := r.Arm("6.18.5-12-generic"); err != nil {
+		t.Fatalf("premise broken: this arm must succeed: %v", err)
+	}
+	if f.bootNext == "" {
+		t.Fatal("a SUCCESSFUL arm left BootNext cleared — the candidate would never be " +
+			"trialled and the next boot would silently use the old kernel while the " +
+			"journal records ARMED")
+	}
+	j, err := r.loadKernelJournal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j.State != KernelStateArmed {
+		t.Fatalf("journal state = %s, want ARMED", j.State)
+	}
+	if f.bootNext != j.BootID {
+		t.Errorf("BootNext = %q but the journal records BootID %q — NVRAM and the journal "+
+			"must name the SAME one-shot, which is the agreement #6758 is about",
+			f.bootNext, j.BootID)
+	}
+	if armed, _, _ := r.IsArmed(); !armed {
+		t.Error("IsArmed() must be true after a verified arm")
+	}
+}

--- a/pkg/upgrade/kernel_linux.go
+++ b/pkg/upgrade/kernel_linux.go
@@ -415,6 +415,16 @@ func (s *realKernelSystem) SetBootNext(bootID string) error {
 	return runCmd("efibootmgr", "--bootnext", bootID)
 }
 
+// ClearBootNext deletes the one-shot BootNext variable (#6758).
+//
+// efibootmgr treats deleting an absent BootNext as success, which is what the
+// arm's failure path needs: it clears unconditionally rather than reading first,
+// so there is no read-then-delete window and no special case for "the firmware
+// silently dropped it already".
+func (s *realKernelSystem) ClearBootNext() error {
+	return runCmd("efibootmgr", "--delete-bootnext")
+}
+
 // GetBootNext parses the one-shot BootNext id out of efibootmgr's output (the
 // "BootNext: XXXX" line), or returns "" if no one-shot is armed (#5847). The
 // two-phase arm reads this back to POSITIVELY CONFIRM the firmware accepted the

--- a/pkg/upgrade/kernel_run.go
+++ b/pkg/upgrade/kernel_run.go
@@ -391,12 +391,14 @@ func (r *KernelRunner) armCandidate(j *KernelJournal) error {
 	// ARMING and surface the error so no false-ARMED journal is persisted.
 	got, err = sys.GetBootNext()
 	if err != nil {
-		return fmt.Errorf("kernel-upgrade arm: read back BootNext (staying ARMING): %w", err)
+		return disarmAfterArmFailure(sys, fmt.Errorf(
+			"kernel-upgrade arm: read back BootNext (staying ARMING): %w", err))
 	}
 	if got != inactiveID {
-		return fmt.Errorf("kernel-upgrade arm: BootNext readback = %q, expected inactive slot %s "+
-			"(%s); firmware did not accept the one-shot — refusing to record ARMED (staying ARMING)",
-			got, j.InactiveSlot, inactiveID)
+		return disarmAfterArmFailure(sys, fmt.Errorf(
+			"kernel-upgrade arm: BootNext readback = %q, expected inactive slot %s "+
+				"(%s); firmware did not accept the one-shot — refusing to record ARMED (staying ARMING)",
+			got, j.InactiveSlot, inactiveID))
 	}
 
 	// Verified: the firmware WILL boot the candidate next. Record the confirmed
@@ -407,13 +409,56 @@ func (r *KernelRunner) armCandidate(j *KernelJournal) error {
 	// state; failing here refuses the arm rather than producing an armed
 	// candidate nothing is designated to verify (#6601 r6).
 	if err := r.recordPromoteBinary(j); err != nil {
-		return fmt.Errorf("kernel-upgrade arm: %w", err)
+		return disarmAfterArmFailure(sys, fmt.Errorf("kernel-upgrade arm: %w", err))
 	}
 	if err := r.ktransition(j, KernelStateArmed); err != nil {
-		return err
+		return disarmAfterArmFailure(sys, err)
 	}
 
 	return nil
+}
+
+// disarmAfterArmFailure clears the one-shot BootNext for a failure that happens
+// AFTER SetBootNext has already succeeded, and returns the original cause
+// (#6758).
+//
+// THE DIVERGENCE IT CLOSES. The two-phase arm records ARMING before touching
+// NVRAM and only advances to ARMED after a positive BootNext readback. Every
+// failure between those two points returned an error and left the journal at
+// ARMING — but SetBootNext had ALREADY SUCCEEDED, so the firmware would still
+// one-shot the candidate on the next reboot. ARMING is documented as exactly
+// the opposite: "the firmware still boots the known-good default (no confirmed
+// one-shot)", which is what lets `Arm` re-arm from ARMING and what stops
+// self-recovery suppressing expired-lease failback. So BootNext stayed armed
+// while every durable software gate classified the node as unarmed, and a
+// drained node could rejoin with an untested candidate kernel queued for its
+// next boot.
+//
+// The `recordPromoteBinary` path is the sharpest: the readback had already
+// CONFIRMED the one-shot, so the candidate was genuinely queued while no xpfd
+// was designated to verify it — an armed candidate with nothing to run the
+// promotion gate, which #6601 added that record specifically to prevent.
+//
+// SINGLE-SOURCED on purpose: four failure paths need the identical undo, and
+// four copies of it is how one gets missed. Clearing an absent BootNext is not
+// an error, so this is safe on the readback-mismatch path where the firmware
+// may have dropped the variable already.
+//
+// If the clear itself FAILS the divergence is real and cannot be undone here,
+// so the error says so explicitly and names the operator command. It is
+// deliberately not escalated to a journal state: ARMED asserts a verified
+// one-shot WITH a recorded promote binary, which is precisely what may be
+// missing on the recordPromoteBinary path, so claiming it would substitute a
+// different false record for this one.
+func disarmAfterArmFailure(sys KernelSystem, cause error) error {
+	if cerr := sys.ClearBootNext(); cerr != nil {
+		return fmt.Errorf("%w; AND the one-shot BootNext could not be cleared (%v) — "+
+			"the firmware may still boot the candidate on the next reboot while the "+
+			"journal records ARMING (no trial), so self-recovery will not treat this "+
+			"node as being in a trial. Clear it manually before rebooting: "+
+			"efibootmgr --delete-bootnext", cause, cerr)
+	}
+	return cause
 }
 
 // newArmNonce builds a per-attempt arm token (#5847). It combines the system

--- a/pkg/upgrade/kernel_test.go
+++ b/pkg/upgrade/kernel_test.go
@@ -34,6 +34,7 @@ type fakeKernelSystem struct {
 	bootCurrent       string
 	bootCurrentErr    error
 	getBootNextErr    error  // #5847: force a readback error (stay ARMING)
+	clearBootNextErr  error  // #6758: force the un-undoable case (NVRAM stays armed)
 	getBootNextRet    string // #5847: override readback (firmware "lied"); "" => mirror bootNext
 	runningErr        error
 	armWatchdogErr    error
@@ -126,6 +127,19 @@ func (f *fakeKernelSystem) ReadSlotSelector(slot string) (string, error) {
 func (f *fakeKernelSystem) SetBootNext(id string) error {
 	f.log("bootnext:" + id)
 	f.bootNext = id
+	return nil
+}
+
+// ClearBootNext mirrors efibootmgr --delete-bootnext (#6758): it drops the
+// one-shot unconditionally, so clearing an already-absent BootNext succeeds.
+// clearBootNextErr injects the un-undoable case — NVRAM stays armed while the
+// journal records ARMING, which is the divergence the arm must report loudly.
+func (f *fakeKernelSystem) ClearBootNext() error {
+	f.log("bootnext-clear")
+	if f.clearBootNextErr != nil {
+		return f.clearBootNextErr
+	}
+	f.bootNext = ""
 	return nil
 }
 


### PR DESCRIPTION
Closes #6758

## The defect

The two-phase arm records `ARMING` before touching NVRAM and advances to `ARMED` only after a positive BootNext readback. Every failure between those points returned an error and left the journal at `ARMING` — but **`SetBootNext` had already succeeded**, so the firmware would still one-shot the candidate on the next reboot.

`ARMING` documents exactly the opposite: *"the firmware still boots the known-good default (no confirmed one-shot)"*. That claim is load-bearing in two places — it is why `Arm` may **re-arm** from `ARMING`, and why self-recovery must **not** suppress expired-lease failback there. So BootNext stayed armed while every durable software gate classified the node as unarmed, `IsArmed()` reported false, and **a drained node could rejoin with an untested candidate kernel queued for its next boot**.

**Four paths, all after `SetBootNext` succeeded:** the readback errors; the readback disagrees; `recordPromoteBinary` fails; the `ARMING -> ARMED` transition fails.

**The third is the sharpest.** The readback had already *confirmed* the one-shot, so the candidate was genuinely queued while no xpfd was designated to verify it — an armed candidate with nothing to run the promotion gate, which is precisely what #6601 added that record to prevent.

## The fix

`KernelSystem` gains `ClearBootNext` (`efibootmgr --delete-bootnext`), and every post-`SetBootNext` failure routes through one `disarmAfterArmFailure` helper that clears the one-shot and returns the original cause.

**Single-sourced** because four paths needing the identical undo is how one gets missed — the same reasoning that made #6740's VLAN writer one function. Clearing an absent BootNext is not an error, so it is safe on the readback-mismatch path where the firmware may have dropped the variable itself.

**When the clear itself fails**, the divergence is real and cannot be undone in-process, so the error says so and names `efibootmgr --delete-bootnext`, with the **original cause preserved** (an operator needs to know why the arm failed, not only that a cleanup failed). It is deliberately **not** escalated to a journal state: `ARMED` asserts a verified one-shot *with a recorded promote binary*, which is exactly what may be missing on the `recordPromoteBinary` path, so claiming it would substitute a different false record for this one.

## Mutation matrix

`flock`'d; tree asserted clean before and restored after, mutation asserted APPLIED, `go vet` clean before running, tests-collected asserted.

| cell | mutation | result |
|---|---|---|
| **V1** | revert the readback-**error** path | RED that path's test + the unclearable-BootNext test |
| **V2** | revert the readback-**mismatch** path only | RED **only** the mismatch test — the paths are separately bound, so fixing three of four cannot pass |
| **V3** | swallow a failed clear (report the cause alone) | RED the unclearable test — an arm that quietly leaves the firmware armed is the original defect wearing a new message |
| **V4** | **TIGHTEN**: clear BootNext on the **success** path too | RED the successful-arm control, and only that |

**V4 is the cell that matters.** Clearing unconditionally passes every other test here while **disarming every successful arm** — a kernel upgrade that silently boots the old kernel and reports success. It is invisible to every "remove the fix" cell, and what catches it is the firmware state agreeing with the journal's recorded `BootID`, not the journal alone.

The tests assert the **firmware** state (the fake's `bootNext`) rather than the journal throughout: the journal was always right about what it had confirmed; NVRAM was the half that disagreed with it.

## One thing the tree-wide gate caught that nothing else did

A **second** fake implements `upgrade.KernelSystem` — `kernelStatusFakeSys` in `pkg/daemon` — and adding an interface method broke it. `go build ./...` passed (it does not compile test files) and `go test ./pkg/upgrade/...` passed (different package); only `go test -count=1 ./...` failed. My initial implementer count was wrong because I grepped for `func (.*) SetBootNext(` in `pkg/` and the daemon fake's one-line receiver form did not match how I read the result. The implementers are now enumerated by the interface's own method signature: `pkg/upgrade/kernel.go`, `kernel_linux.go`, `kernel_test.go`, `pkg/daemon/kernel_upgrade_status_6495_test.go`.

## Validation

`go build ./...` clean; **`go test -count=1 ./...` rc=0, 0 FAIL, 71 packages**.

`pkg/upgrade` + one `pkg/daemon` test fake. No dataplane, no cluster runtime, no `userspace-dp` binary or shim moved.

## Note for the rest of the A10-b4 batch

`/tmp/opus-review-001.md` — the "fix direction" reference for all six issues (#6758–#6763) — **no longer exists**, so that direction is unreachable batch-wide. This fix was derived from the code; the `ARMING` state's own doc comment is what established what the divergence violated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkfVhT4Y3UDa22mU7uoCVt
