### PR TITLE
config: charge the apply-groups budget for the merge fan-out

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104157,3 +104157,13 @@ prose edit above them added. No diff falls in the new test body.
   make_config_drive.py and xpf-deploy.py; kept the post-chmod as a belt.
 - **File(s)**: scripts/image/make_config_drive.py, scripts/deploy/xpf-deploy.py,
   scripts/image/test_config_drive_creation_umask_6764.py
+
+## 2026-08-22 — #6767 apply-groups work budget covers the merge fan-out
+- **Timestamp**: 2026-08-22
+- **Action**: Work was charged once per `apply-groups <name>` reference, while
+  mergeNodes — which clones and merges — took no budget. A wildcard container
+  merges into EVERY matching destination, so the cost is the product. Threaded
+  the budget through mergeNodes, charging per merged node and per clone before
+  materialising it.
+- **File(s)**: pkg/config/ast_groups.go,
+  pkg/config/group_expand_budget_6767_test.go

--- a/pkg/config/ast_groups.go
+++ b/pkg/config/ast_groups.go
@@ -30,6 +30,37 @@ type groupExpandBudget struct {
 	work int // group expansions performed so far
 }
 
+// charge accounts n units of expansion work and reports when the budget is
+// exhausted (#6767).
+//
+// Before this, work was charged ONCE per `apply-groups <name>` reference
+// resolved, and mergeNodes — which does the actual cloning and merging — took
+// no budget at all. A wildcard group container is merged into EVERY matching
+// destination container, so the real cost is the (wildcard node x matching
+// container) product, and a config with a handful of apply-groups references
+// could build a quadratic AST while charging a handful of units.
+func (b *groupExpandBudget) charge(n int) error {
+	b.work += n
+	if b.work > maxGroupExpandWork {
+		return fmt.Errorf("apply-groups expansion exceeds maximum work budget of %d (possible generated or pathological config)", maxGroupExpandWork)
+	}
+	return nil
+}
+
+// countNodes is the size of a subtree forest, used to charge the budget for a
+// clone BEFORE performing it — so a pathological fan-out is refused rather than
+// materialised and then noticed.
+func countNodes(nodes []*Node) int {
+	n := 0
+	for _, x := range nodes {
+		if x == nil {
+			continue
+		}
+		n += 1 + countNodes(x.Children)
+	}
+	return n
+}
+
 // ExpandGroups resolves all "apply-groups" references in the tree.
 // It collects group definitions from the "groups" stanza, then for each
 // "apply-groups <name>" node, clones the referenced group's children and
@@ -246,7 +277,14 @@ func expandGroupsRecursive(nodes *[]*Node, groups map[string]*Node, ancestorPath
 		memoKey := name + "\x00" + ancestorPathKey(ancestorPath)
 		if cached, hit := memo[memoKey]; hit {
 			if cached != nil {
-				mergeNodes(nodes, cloneNodes(cached), ancestorPath)
+				// #6767: a memo HIT still clones and merges the whole cached
+				// subtree, so it costs the same as a miss and must be charged.
+				if err := budget.charge(countNodes(cached)); err != nil {
+					return err
+				}
+				if err := mergeNodes(nodes, cloneNodes(cached), ancestorPath, budget); err != nil {
+					return err
+				}
 			}
 			continue
 		}
@@ -296,7 +334,9 @@ func expandGroupsRecursive(nodes *[]*Node, groups map[string]*Node, ancestorPath
 		// merge a SEPARATE clone into the parent so the cache is never mutated.
 		memo[memoKey] = cloneNodes(expanded)
 		if expanded != nil {
-			mergeNodes(nodes, expanded, ancestorPath)
+			if err := mergeNodes(nodes, expanded, ancestorPath, budget); err != nil {
+				return err
+			}
 		}
 
 		delete(seen, name)
@@ -351,8 +391,14 @@ func expandGroupsRecursive(nodes *[]*Node, groups map[string]*Node, ancestorPath
 // block+block UNIONED — so an inline `match application junos-http` that
 // inherited a group's `match application junos-https` silently DROPPED
 // junos-https (fable-164 L-8), narrowing a `then deny` to junos-http only.
-func mergeNodes(dst *[]*Node, src []*Node, ancestorPath [][]string) {
+func mergeNodes(dst *[]*Node, src []*Node, ancestorPath [][]string, budget *groupExpandBudget) error {
 	for _, s := range src {
+		// #6767: one unit per source node MERGED, so a deep group subtree is
+		// bounded by its own size rather than by the single reference that
+		// pulled it in.
+		if err := budget.charge(1); err != nil {
+			return err
+		}
 		if s.IsLeaf {
 			key := ""
 			if len(s.Keys) > 0 {
@@ -379,8 +425,17 @@ func mergeNodes(dst *[]*Node, src []*Node, ancestorPath [][]string) {
 			// Wildcard merge: apply to all matching containers in dst.
 			for _, d := range *dst {
 				if !d.IsLeaf && keysMatchWildcard(d.Keys, s.Keys) {
+					// #6767: THIS is the fan-out. One wildcard source is cloned
+					// into every matching destination container, so the cost is
+					// the product, not the reference count. Charge the clone's
+					// size BEFORE materialising it.
+					if err := budget.charge(countNodes(s.Children)); err != nil {
+						return err
+					}
 					cloned := cloneNodes(s.Children)
-					mergeNodes(&d.Children, cloned, appendPath(ancestorPath, d.Keys))
+					if err := mergeNodes(&d.Children, cloned, appendPath(ancestorPath, d.Keys), budget); err != nil {
+						return err
+					}
 				}
 			}
 			continue
@@ -410,7 +465,9 @@ func mergeNodes(dst *[]*Node, src []*Node, ancestorPath [][]string) {
 		for _, d := range *dst {
 			if !d.IsLeaf && keysEqual(d.Keys, s.Keys) {
 				// Merge children recursively.
-				mergeNodes(&d.Children, s.Children, appendPath(ancestorPath, d.Keys))
+				if err := mergeNodes(&d.Children, s.Children, appendPath(ancestorPath, d.Keys), budget); err != nil {
+					return err
+				}
 				found = true
 				break
 			}
@@ -425,9 +482,19 @@ func mergeNodes(dst *[]*Node, src []*Node, ancestorPath [][]string) {
 			if len(s.Keys) == 1 && hasMatchingLeaf(*dst, s.Keys) {
 				continue
 			}
+			// #6767: adopting a container WHOLESALE adds its entire subtree to
+			// the AST without recursing into it, so the per-node charge above
+			// never sees those nodes — a group carrying a million-node subtree
+			// merged into a non-matching parent cost ONE unit. Charge the
+			// subtree it actually adds. (The node itself was charged on entry,
+			// hence -1.)
+			if err := budget.charge(countNodes([]*Node{s}) - 1); err != nil {
+				return err
+			}
 			*dst = append(*dst, s)
 		}
 	}
+	return nil
 }
 
 // appendPath returns a fresh copy of base with keys appended, so recursive

--- a/pkg/config/group_expand_budget_6767_test.go
+++ b/pkg/config/group_expand_budget_6767_test.go
@@ -1,0 +1,227 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// #6767: the apply-groups work budget charged ONE unit per `apply-groups <name>`
+// reference resolved, and mergeNodes — which does the actual cloning and merging
+// — took no budget at all.
+//
+// A wildcard group container is merged into EVERY matching destination
+// container, so the real cost is the (wildcard node x matching container)
+// product. A config with a handful of references could therefore build a
+// quadratic AST while charging a handful of units, and the budget that exists
+// to stop exactly that never fired.
+//
+// The fixtures below are built from `set` commands through ParseSetCommand +
+// SetPath, never NewParser, because the parser treats newlines as whitespace and
+// merges every line into one node.
+
+func buildTree6767(t *testing.T, lines []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range lines {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// wildcardFanout6767 builds a config with ONE wildcard group applied once, whose
+// expansion touches `containers` destination containers each receiving `depth`
+// nodes. Pre-#6767 this charges 1 unit no matter how large it is.
+func wildcardFanout6767(containers, leaves int) []string {
+	var out []string
+	// A group whose interface container is a wildcard: it merges into EVERY
+	// interface below.
+	for i := 0; i < leaves; i++ {
+		out = append(out, fmt.Sprintf(
+			"set groups WIDE interfaces <*> unit 0 family inet address 10.%d.%d.1/24", i/250, i%250))
+	}
+	for c := 0; c < containers; c++ {
+		out = append(out, fmt.Sprintf("set interfaces ge-0/0/%d unit 0 family inet mtu 1500", c))
+	}
+	out = append(out, "set apply-groups WIDE")
+	return out
+}
+
+// TestPathologicalWildcardFanoutIsRefused6767 is the defect proper.
+//
+// It drives the PUBLIC ExpandGroups so it depends on the behaviour, not on the
+// internal budget plumbing. Pre-#6767 this expands happily: the single
+// `apply-groups WIDE` reference charges ONE unit, mergeNodes charges nothing,
+// and the quadratic AST is built unchecked.
+func TestPathologicalWildcardFanoutIsRefused6767(t *testing.T) {
+	// 400 x 400 = 160k merge units, comfortably past maxGroupExpandWork=100000,
+	// while each individual list stays small enough to build quickly.
+	tree := buildTree6767(t, wildcardFanout6767(400, 400))
+
+	err := tree.ExpandGroups()
+	if err == nil {
+		t.Fatalf("a 400x400 wildcard fan-out expanded WITHOUT error. maxGroupExpandWork is "+
+			"%d and the budget exists to refuse exactly this — but work was charged per "+
+			"apply-groups REFERENCE (one, here) rather than per node merged, so a "+
+			"generated or pathological config builds a quadratic AST unchecked",
+			maxGroupExpandWork)
+	}
+	if !strings.Contains(err.Error(), "work budget") {
+		t.Errorf("expansion failed for the wrong reason: %v", err)
+	}
+}
+
+// TestOrdinaryConfigStillExpands6767 is the TIGHTENING control.
+//
+// Charging per merged node makes the budget bite sooner. A fix that charged too
+// aggressively — or lowered the ceiling — would satisfy both tests above while
+// refusing ordinary configs, which is a commit-blocking regression far worse
+// than the quadratic AST. This pins that a realistic apply-groups config still
+// expands, and that its expansion is CORRECT rather than merely error-free.
+func TestOrdinaryConfigStillExpands6767(t *testing.T) {
+	tree := buildTree6767(t, []string{
+		"set groups COMMON interfaces <*> unit 0 family inet mtu 9000",
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.1/24",
+		"set apply-groups COMMON",
+	})
+	if err := tree.ExpandGroups(); err != nil {
+		t.Fatalf("an ordinary two-interface apply-groups config was REFUSED: %v — the "+
+			"budget now bites on configs it must not", err)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig after expansion: %v", err)
+	}
+	for _, name := range []string{"ge-0/0/0", "ge-0/0/1"} {
+		ifc := cfg.Interfaces.Interfaces[name]
+		if ifc == nil {
+			t.Fatalf("%s did not compile", name)
+		}
+		var mtu int
+		for _, u := range ifc.Units {
+			if u != nil && u.MTU != 0 {
+				mtu = u.MTU
+			}
+		}
+		if mtu != 9000 {
+			t.Errorf("%s unit MTU = %d, want 9000 from the wildcard group — the group "+
+				"expanded without error but did not actually apply", name, mtu)
+		}
+	}
+}
+
+// deepGroupTree6767 builds a NON-wildcard group with `units` unit containers
+// under one interface, applied into one matching container.
+//
+// Built directly rather than through ParseSetCommand: at the size needed to
+// cross maxGroupExpandWork the set-command path spends minutes in SetPath, and
+// the parser is not what is under test here.
+func deepGroupTree6767(units int) *ConfigTree {
+	// Shaped WIDE-ish but shallow-fanned on purpose: each unit carries many
+	// leaves rather than there being many units. mergeNodes scans the whole
+	// destination sibling list for each source container, so a fixture with
+	// 100k SIBLINGS spends minutes in that O(n^2) scan before the budget trips
+	// (measured: 185 s). Same node count, ~1/100th the siblings, same property
+	// under test.
+	const leavesPerUnit = 100
+	unitCount := units/leavesPerUnit + 1
+	groupUnits := make([]*Node, 0, unitCount)
+	for i := 0; i < unitCount; i++ {
+		leaves := make([]*Node, 0, leavesPerUnit)
+		for j := 0; j < leavesPerUnit; j++ {
+			leaves = append(leaves, &Node{
+				Keys:   []string{fmt.Sprintf("address 10.%d.%d.1/24", j/250, j%250)},
+				IsLeaf: true,
+			})
+		}
+		groupUnits = append(groupUnits, &Node{
+			Keys: []string{"unit", fmt.Sprint(i)},
+			Children: []*Node{{
+				Keys:     []string{"family", "inet"},
+				Children: leaves,
+			}},
+		})
+	}
+	return &ConfigTree{Children: []*Node{
+		{Keys: []string{"groups"}, Children: []*Node{
+			{Keys: []string{"DEEP"}, Children: []*Node{
+				{Keys: []string{"interfaces"}, Children: []*Node{
+					{Keys: []string{"ge-0/0/0"}, Children: groupUnits},
+				}},
+			}},
+		}},
+		{Keys: []string{"interfaces"}, Children: []*Node{
+			{Keys: []string{"ge-0/0/0"}, Children: []*Node{
+				{Keys: []string{"unit", "0"}, Children: []*Node{
+					{Keys: []string{"family", "inet"}, Children: []*Node{
+						{Keys: []string{"mtu", "1500"}, IsLeaf: true},
+					}},
+				}},
+			}},
+		}},
+		{Keys: []string{"apply-groups", "DEEP"}, IsLeaf: true},
+	}}
+}
+
+// TestDeepNonWildcardGroupIsCharged6767 binds the per-merged-node charge.
+//
+// The wildcard fan-out test above passes with ONLY the clone charged, so
+// removing the per-node charge is invisible to it. This shape has no wildcard
+// and no fan-out — its whole cost is the size of the group subtree being merged
+// — so it is refused only if each merged node is charged.
+func TestDeepNonWildcardGroupIsCharged6767(t *testing.T) {
+	tree := deepGroupTree6767(maxGroupExpandWork + 5000)
+
+	err := tree.ExpandGroups()
+	if err == nil {
+		t.Fatalf("a group subtree with more than maxGroupExpandWork (%d) nodes merged "+
+			"WITHOUT error. With no wildcard there is no fan-out to charge, so only the "+
+			"per-merged-node charge can bound it — one unit per apply-groups reference "+
+			"cannot", maxGroupExpandWork)
+	}
+	if !strings.Contains(err.Error(), "work budget") {
+		t.Errorf("expansion failed for the wrong reason: %v", err)
+	}
+}
+
+// TestRealisticConfigStillExpands6767 is the second TIGHTENING control, and it
+// is sized to bite.
+//
+// The two-interface control below is far too small to notice an over-aggressive
+// charge — charging 100x per node still fits inside maxGroupExpandWork there,
+// so it passed a mutation that multiplied every charge by 100. A realistic
+// chassis (48 ports, a group applying a handful of settings to each) is the
+// smallest shape where over-charging actually refuses a config an operator
+// would really write.
+func TestRealisticConfigStillExpands6767(t *testing.T) {
+	// Sized to BITE. A three-setting group over 48 ports costs a few hundred
+	// units, so a mutation multiplying every charge by 100 still fits inside
+	// maxGroupExpandWork and the control passes — measured. A realistic
+	// standardised-port group carries far more than three settings; at ~30 the
+	// 1x cost is ~1500 units, which a 100x over-charge pushes past the ceiling.
+	var lines []string
+	for i := 0; i < 30; i++ {
+		lines = append(lines, fmt.Sprintf(
+			"set groups CHASSIS interfaces <*> unit 0 family inet address 10.%d.%d.1/24",
+			i/250, i%250))
+	}
+	for i := 0; i < 48; i++ {
+		lines = append(lines, fmt.Sprintf(
+			"set interfaces ge-0/0/%d unit 0 family inet address 10.0.%d.1/24", i, i))
+	}
+	lines = append(lines, "set apply-groups CHASSIS")
+
+	tree := buildTree6767(t, lines)
+	if err := tree.ExpandGroups(); err != nil {
+		t.Fatalf("a realistic 48-port apply-groups config was REFUSED: %v — the budget now "+
+			"bites on configs an operator would really write, which is a commit-blocking "+
+			"regression worse than the quadratic AST it was meant to prevent", err)
+	}
+}


### PR DESCRIPTION
Closes #6767

The apply-groups work budget charged **one unit per `apply-groups <name>` reference resolved**, inside `expandGroupsRecursive`. `mergeNodes` — which does the actual cloning and merging — took no budget parameter and had no counter of any kind.

A wildcard group container is merged into **every** matching destination container, so the real cost is the (wildcard node × matching container) product. A config with a handful of references could therefore build a quadratic AST while charging a handful of units, and `maxGroupExpandWork` — which exists to refuse exactly that — never fired.

## Three charge sites, and the second two came from tests failing

`mergeNodes` now takes the budget and returns an error:

1. **One unit per source node merged**, so a deep group subtree is bounded by its own size rather than by the single reference that pulled it in.
2. **The clone's node count, charged BEFORE materialising it** in the wildcard branch — a pathological fan-out is refused rather than built and then noticed.
3. **The subtree's node count when a container is adopted WHOLESALE.**

Site 3 exists because my own test found the gap. Appending a container that has no match in the destination adds its **entire subtree** to the AST without recursing into it, so the per-node charge never sees those nodes — a group carrying a million-node subtree merged into a non-matching parent cost **one unit**. The deep non-wildcard test failed until this was added.

A memo **hit** is charged too: it still clones and merges the whole cached subtree, so it costs the same as a miss.

`cloneNodes` is deliberately left alone — it has callers outside group expansion (`ast_edit.go`, `ast.go`) that have no budget and must not acquire one.

## Mutation matrix

Fix committed first. Full `pkg/config` suite per cell, no `-run` filter, rc from a file, control green first.

| # | mutation | rc | fired |
|---|---|---|---|
| Z1 | revert: `mergeNodes` charges nothing | 1 | wildcard fan-out test |
| Z4 | drop the wholesale-adopt charge | 1 | deep non-wildcard test — localises |
| Z3 | **TIGHTEN**: charge 100× per node | 0 → 1 | realistic-config control, after resizing |
| Z2 | drop the per-node merge charge | **0** | **unbound — see below** |

**Z3 was green first time and the control was the problem, not the fix.** A three-setting group over 48 ports costs a few hundred units, so a 100× over-charge still fits inside `maxGroupExpandWork` and the control passed. A realistic standardised-port group carries far more than three settings; at ~30 the 1× cost is ~1500 units, which 100× pushes past the ceiling. Over-charging is the realistic failure mode here — it would refuse configs an operator really writes, which is a commit-blocking regression worse than the quadratic AST — so that control had to be sized to bite.

**Z2 is reported as UNBOUND rather than claimed.** Removing the per-node charge leaves the suite green, because every node in the shapes under test is either recursed into (and charged by its own adopt/clone) or adopted wholesale (charged by site 3). The path it uniquely bounds is a **leaf-list union** — `mergeLeafListInto` adds values without adopting or cloning a container — and I have not written a fixture for that shape. The charge is kept because that path is real and the charge is one increment; but no cell distinguishes it, and saying so is better than implying coverage this PR does not have.

## A residual worth knowing about

The budget bounds the **number of charges**, not the work per charge. `mergeNodes` scans the whole destination sibling list for each source container, so a fixture with 100k siblings spends minutes in that O(n²) scan before the budget trips — measured at **185 s** on my first deep fixture. Reshaping it to the same node count with ~1/100th the siblings brought the same assertion to **0.13 s**.

That scan cost is a separate concern from the AST size this issue is about, and this PR does not address it. Flagging it rather than leaving it to be rediscovered.

## Validation

`go build`, `go vet`, `gofmt` clean; `go test -count=1 ./...` green repo-wide. All four new tests run in ~0.15 s combined. `pkg/config` only — no cluster, no dataplane, no `userspace-dp` binary or shim `.o` moved.
