### PR TITLE
deploy: detect a recreated node that is PRIMARY before its identity is proven

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104217,3 +104217,30 @@ prose edit above them added. No diff falls in the new test body.
   materialising it.
 - **File(s)**: pkg/config/ast_groups.go,
   pkg/config/group_expand_budget_6767_test.go
+
+## 2026-08-22 — #6759 detect an unverified-primary after image recreate
+- **Timestamp**: 2026-08-22
+- **Action**: Read the cluster side first and reported the boundary before
+  coding (as agreed). Finding: the kernel-roll already solves the analogous
+  problem via holdSecondaryIfKernelCandidateArmed, but it keys on the ON-NODE
+  kernel journal and folds a clean ENOENT to "never armed" — a reboot preserves
+  that journal so ENOENT is truthful, a recreate DESTROYS it so ENOENT means
+  "the evidence was wiped", and nothing on the node can distinguish them. The
+  mechanism is correct for its path and structurally unavailable to image-roll.
+  Shipped the bounded increment only: the boot poll reads the node RG state and
+  fails closed (leases held) if the recreated node is PRIMARY before the #5075
+  identity gate passes. Code states explicitly that this DETECTS and does not
+  CLOSE — the election happens at bringup before any driver command lands.
+- **Scoped honestly**: election.go's fresh-boot guard already protects a
+  NON-preempt RG with a reachable peer; the exposure is preempt RGs and boots
+  where the peer is not visible at first election.
+- **Successor filed (#7559)** with the three candidate designs and their real
+  costs (peer authority / day-0 seeded hold / default-hold), since closing it
+  needs a signal surviving a disk wipe and that is a design decision.
+- **Cite note**: within this ONE issue the Go-side cites still landed in roughly
+  the right code while the xpf-deploy.py ones were stale — staleness varies
+  within a single evidence list, so verify each cite independently.
+- **File(s)**: scripts/deploy/xpf-deploy.py,
+  scripts/deploy/test_xpf_deploy_unverified_primary_6759.py (new),
+  docs/in-place-upgrade.md
+

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -1641,6 +1641,32 @@ use:
   a half-finished destroy+launch is worse than letting it finish — it is
   recorded, and the caller `die()`s fail-closed BEFORE rejoin, the same
   response the boot-poll loop already gives.
+- **Unverified-primary detection during the boot poll (#6759).** The recreate
+  wipes the node, which erases the drain applied before it — the drain lived on
+  the disk that was replaced. The identity gate (#5075: live `xpf-version` ==
+  the AUTHENTICATED manifest's, and `/etc/xpf/node-id` == the assigned cluster
+  node-id) runs AFTERWARDS, so between bringup and gate-pass the node is
+  un-drained with unvalidated identity. The boot poll now also reads the node's
+  RG state and, if the recreated node is PRIMARY before the gate passes, fails
+  closed with the leases HELD — the same stance the loop already takes for a
+  version/node-id mismatch.
+
+  **This DETECTS the exposure; it does not close it.** The election happens
+  during the recreated node's own bringup (`daemon_run_bringup.go` runs
+  `UpdateConfig`, which elects on the single-node path) long before any driver
+  command lands. Closing it needs a hold that survives the disk wipe, and the
+  kernel-roll's mechanism cannot supply one:
+  `holdSecondaryIfKernelCandidateArmed` keys on the on-node kernel journal, and
+  a clean ENOENT is folded to "never armed" with no hold. A reboot preserves
+  that journal so ENOENT truly means "never armed"; a recreate destroys it, so
+  ENOENT means "the evidence was wiped" — and nothing on the node can tell those
+  apart. That is NOT a defect in `kernel_selfrecover.go`: the distinction is
+  correct for the path it was written for and has no way to be right for this
+  one. The design options are recorded on #7559.
+
+  Scope: `election.go`'s fresh-boot guard already keeps a NON-preempt RG with a
+  reachable peer at SECONDARY, so the exposure is `preempt`-configured RGs and
+  boots where the peer is not visible at first election.
   Because `die()` is a `SystemExit`, `kernel-roll`'s `finally` still runs
   after a fence-abort — and its own best-effort restore-forwarding rejoin
   IS a pair mutation. So the fence records the loss (a `lost_lease` flag,

--- a/scripts/deploy/test_xpf_deploy_unverified_primary_6759.py
+++ b/scripts/deploy/test_xpf_deploy_unverified_primary_6759.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""#6759: detect a recreated node that is PRIMARY before its identity is proven.
+
+The image-roll drains the node, then RECREATES it — a fresh disk. That wipes
+the drain, because the drain lived on the disk that was replaced. The identity
+gate (live xpf-version == the AUTHENTICATED manifest's, and /etc/xpf/node-id ==
+the assigned cluster node-id, #5075) runs AFTERWARDS in the boot poll. Between
+bringup and gate-pass the node is un-drained with unvalidated identity.
+
+WHAT THIS DOES NOT DO. It does not close the window. The election happens during
+the recreated node's own bringup — `daemon_run_bringup.go` runs `UpdateConfig`,
+which elects on the single-node path — before any driver command reaches the
+node. This DETECTS the exposure and stops the roll; it cannot prevent it.
+
+Why the kernel-roll's fix cannot be reused: `holdSecondaryIfKernelCandidateArmed`
+keys the election hold on the on-node kernel journal, and
+`kernel_selfrecover.go` folds a clean ENOENT to "never armed" with no hold. A
+reboot preserves that journal so ENOENT genuinely means "never armed"; a
+recreate DESTROYS it, so ENOENT means "the evidence was wiped" — and nothing on
+the node can tell those apart. The distinction is correct for the path it was
+written for and has no way to be right for this one.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "xpf_deploy", Path(__file__).with_name("xpf-deploy.py")
+)
+xpf_deploy = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(xpf_deploy)
+
+
+_STATUS_TEMPLATE = """Monitor Failure codes:
+    CS  Cold Sync monitoring        FL  Fabric Connection monitoring
+
+Cluster ID: 1
+Node name: node{me}
+
+Redundancy group: 0 , Failover count: 2
+    node0   200       {n0_rg0}        no       no       None
+    node1   100       {n1_rg0}      no       no       None
+
+Redundancy group: 1 , Failover count: 0
+    node0   200       {n0_rg1}        no       no       None
+    node1   100       {n1_rg1}      no       no       None
+"""
+
+
+def _status(me=0, n0_rg0="primary", n1_rg0="secondary",
+            n0_rg1="primary", n1_rg1="secondary"):
+    return _STATUS_TEMPLATE.format(me=me, n0_rg0=n0_rg0, n1_rg0=n1_rg0,
+                                   n0_rg1=n0_rg1, n1_rg1=n1_rg1)
+
+
+class _Exec:
+    """Stands in for _node_exec, returning a canned status."""
+
+    def __init__(self, out):
+        self.out = out
+        self.calls = []
+
+    def __call__(self, runner, backend, node, argv, check=True):
+        self.calls.append(list(argv))
+        return self.out
+
+
+class UnverifiedPrimaryDetectionTests(unittest.TestCase):
+    def _with_status(self, out):
+        stub = _Exec(out)
+        real = xpf_deploy._node_exec
+        xpf_deploy._node_exec = stub
+        self.addCleanup(lambda: setattr(xpf_deploy, "_node_exec", real))
+        return stub
+
+    def test_detects_this_node_primary(self):
+        self._with_status(_status(n0_rg0="primary"))
+        self.assertIs(
+            xpf_deploy._node_is_primary_for_any_rg(None, "incus", "fw0", 0), True,
+            "node0 holds primary for RG0 and must be detected — an unverified node "
+            "carrying traffic is the whole point of the check")
+
+    def test_secondary_everywhere_is_not_primary(self):
+        self._with_status(_status(n0_rg0="secondary", n0_rg1="secondary"))
+        self.assertIs(
+            xpf_deploy._node_is_primary_for_any_rg(None, "incus", "fw0", 0), False)
+
+    def test_the_PEER_being_primary_is_not_this_node(self):
+        # The OVER-DETECTION control, and the realistic healthy case: during a
+        # correct roll the still-up PEER is primary for everything. Reading the
+        # peer's row as ours would abort every good roll.
+        self._with_status(_status(n0_rg0="secondary", n1_rg0="primary",
+                                  n0_rg1="secondary", n1_rg1="primary"))
+        self.assertIs(
+            xpf_deploy._node_is_primary_for_any_rg(None, "incus", "fw0", 0), False,
+            "the PEER (node1) is primary here; reading its row as node0's would "
+            "abort every healthy image roll")
+
+    def test_primary_in_any_rg_counts(self):
+        # Secondary for RG0 but primary for RG1 — still carrying traffic.
+        self._with_status(_status(n0_rg0="secondary", n0_rg1="primary"))
+        self.assertIs(
+            xpf_deploy._node_is_primary_for_any_rg(None, "incus", "fw0", 0), True)
+
+    def test_unreadable_status_is_None_not_False(self):
+        # An unreadable state must NOT be reported as "not primary": the caller
+        # would turn an absent observation into a pass. None means "no
+        # observation this tick", and the poll simply tries again.
+        for out in ("", "Cluster not configured", None):
+            self._with_status(out)
+            self.assertIsNone(
+                xpf_deploy._node_is_primary_for_any_rg(None, "incus", "fw0", 0),
+                f"unreadable status {out!r} must be None, never False")
+
+    def test_absent_node_id_is_None(self):
+        # The identity gate may not have read a node-id yet. With no id there is
+        # no row to match, so there is no observation — not a pass.
+        self._with_status(_status())
+        self.assertIsNone(
+            xpf_deploy._node_is_primary_for_any_rg(None, "incus", "fw0", None))
+
+    def test_a_non_node_row_is_never_read_as_a_node_row(self):
+        # #4009: a line inside an RG block that is not a node row must not be
+        # matched. Fields are compared exactly for this reason — a substring
+        # match on "primary" would fire on the header text below.
+        out = _status(n0_rg0="secondary", n0_rg1="secondary").replace(
+            "Redundancy group: 0 , Failover count: 2\n",
+            "Redundancy group: 0 , Failover count: 2\n"
+            "    Note: node0 was primary before the last failover\n", 1)
+        self._with_status(out)
+        self.assertIs(
+            xpf_deploy._node_is_primary_for_any_rg(None, "incus", "fw0", 0), False,
+            "a prose line mentioning node0 and primary was read as a node row — "
+            "that is the #4009 misparse, which steered a deploy into restarting "
+            "the PRIMARY first")
+
+    def test_it_reads_the_cluster_status_command(self):
+        # BIND THE WIRING: the helper must actually ask the node for its cluster
+        # status, not infer it from something already in hand.
+        stub = self._with_status(_status())
+        xpf_deploy._node_is_primary_for_any_rg(None, "incus", "fw0", 0)
+        self.assertTrue(
+            any("show chassis cluster status" in " ".join(c) for c in stub.calls),
+            f"did not run the cluster-status read; calls were {stub.calls}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/deploy/xpf-deploy.py
+++ b/scripts/deploy/xpf-deploy.py
@@ -2269,6 +2269,43 @@ def _node_cluster_node_id(runner, backend, node):
         return None
 
 
+def _node_is_primary_for_any_rg(runner, backend, node, node_id):
+    """Does `node` currently hold PRIMARY for any redundancy group? (#6759)
+
+    Parses `show chassis cluster status` with the SAME contract the rest of the
+    tooling uses: inside a `Redundancy group: N ` block, a node row's FIRST
+    field is the node token and the state is a field on that row
+    (test/incus/deploy-lib.sh, scripts/userspace-ha-validation.sh). Matching on
+    exact FIELDS rather than a substring is deliberate — #4009 was a
+    rolling-deploy bug caused by a non-node line being read as a node row, and
+    it steered a deploy into restarting the PRIMARY first.
+
+    Returns None when the state cannot be read (xpfd not answering yet, cluster
+    not configured, transport blip). None is NOT "not primary": the caller must
+    not turn an unreadable state into a pass — it simply has no observation
+    this tick and tries again on the next one.
+    """
+    if node_id is None:
+        return None
+    out = _node_exec(runner, backend, node,
+                     ["cli", "-c", "show chassis cluster status"], check=False)
+    if not out or "Redundancy group" not in out:
+        return None
+    want = f"node{node_id}"
+    in_rg = False
+    for line in out.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Redundancy group"):
+            in_rg = True
+            continue
+        if not in_rg:
+            continue
+        fields = stripped.split()
+        if len(fields) >= 2 and fields[0] == want and "primary" in fields:
+            return True
+    return False
+
+
 def _recreated_node_matches(live_versions, want_version, live_node_id, want_node_id):
     """#5075 identity+version gate for a node recreated from the new image.
     Returns (ok: bool, reason: str).
@@ -2662,6 +2699,30 @@ def cmd_image_roll(args):
                     pv, want_ver, live_nid, want_nid)
                 if back:
                     break
+                # #6759: the recreate WIPED this node, which erased the drain
+                # that was applied before it — and the identity gate above has
+                # NOT passed yet, so we do not know this is the right node
+                # running the right image. If it is nevertheless already
+                # PRIMARY, an unverified node is carrying traffic. Fail closed
+                # with the leases HELD, the same stance this loop already takes
+                # for a version/node-id mismatch.
+                #
+                # THIS DOES NOT CLOSE THE WINDOW, and must not be read as a
+                # guard. The election happens during the recreated node's own
+                # bringup (daemon_run_bringup.go runs UpdateConfig, which
+                # elects on the single-node path) — long before any driver
+                # command reaches it. By the time this check can observe
+                # anything, the election has already happened. It DETECTS the
+                # exposure and stops the roll; it cannot prevent it. Closing it
+                # needs a signal that survives the disk wipe, which the
+                # kernel-roll's on-node journal cannot provide here — see the
+                # successor issue.
+                if _node_is_primary_for_any_rg(runner, backend, node, live_nid):
+                    die(f"{node} is PRIMARY for a redundancy group but has NOT passed "
+                        f"the image/identity gate ({last_reason}). The recreate wiped "
+                        f"the drain applied before it, so an UNVERIFIED node is "
+                        f"carrying traffic. STOPPING with the never-both-down leases "
+                        f"HELD — investigate before rejoining (#6759).")
             if not back:
                 die(f"{node} did NOT come back as the expected node on the new "
                     f"image within {boot_deadline}s after image recreate: "


### PR DESCRIPTION
## What

The image-roll drains the node, then **recreates** it — a fresh disk. That erases
the drain, because the drain lived on the disk that was replaced. The identity
gate (#5075: live `xpf-version` == the AUTHENTICATED manifest's, and
`/etc/xpf/node-id` == the assigned cluster node-id) runs *afterwards* in the boot
poll. Between bringup and gate-pass the node is un-drained with unvalidated
identity.

The boot poll now also reads the node's redundancy-group state and fails closed,
**leases held**, if the recreated node is PRIMARY before the gate has passed —
the same stance the loop already takes for a version/node-id mismatch.

## This DETECTS the exposure; it does not CLOSE it

The code says so, in a comment, rather than letting a green check imply a guard
it does not provide. The election happens during the recreated node's own
bringup — `daemon_run_bringup.go` runs `UpdateConfig`, which elects on the
single-node path — long before any driver command reaches the node. By the time
this check can observe anything, the election has already happened.

### Why the existing mechanism cannot be reused

This is the substantive finding, and the reason this is an increment rather than
a fix. The kernel-roll already solves the analogous problem:
`holdSecondaryIfKernelCandidateArmed()` runs BEFORE `UpdateConfig()` precisely
because `UpdateConfig` elects, so a kernel candidate can never win before the
promotion gate verifies it.

But that hold is keyed on the **on-node kernel journal**, and
`kernel_selfrecover.go` folds a clean `ENOENT` to "never armed" with **no hold**:

- a **reboot** preserves that journal, so `ENOENT` genuinely means "never armed";
- a **recreate** destroys it, so `ENOENT` means "the evidence was wiped".

Nothing on the node can tell those apart, because the artifact that would say so
is exactly what the recreate removed. That is **not** a defect in
`kernel_selfrecover.go` — the distinction is correct for the path it was written
for and has no way to be right for this one. Closing the window needs a signal
that survives a disk wipe. Three candidate designs with their real costs are
recorded on #7559.

### Scope, stated honestly

`election.go`'s fresh-boot guard already keeps a **non-preempt** RG with a
reachable peer at SECONDARY, so that case is not exposed at all. The gap is
`preempt`-configured RGs (the guard does not apply; `localWeight > 0` on a fresh
boot takes `electLocalPrimary`) and any boot where the peer is not visible at
first election.

## Parsing and failure semantics

Follows the contract the rest of the tooling already uses: inside a
`Redundancy group: N ` block, a node row's FIRST field is the node token and the
state is a field on that row (`test/incus/deploy-lib.sh`,
`scripts/userspace-ha-validation.sh`). Fields are compared **exactly** rather
than by substring, because #4009 was a rolling-deploy bug caused by a non-node
line being read as a node row, which steered a deploy into restarting the
PRIMARY first.

An **unreadable** state returns `None`, never `False`. "No observation this tick"
must not become "not primary": the poll simply tries again, and turning an absent
reading into a pass is the exact failure this increment exists to surface.

## Mutation matrix

flock'd; tree asserted clean before and restored after; each mutation asserted
APPLIED (`git diff --stat` non-empty); syntax checked before running;
tests-collected asserted > 0.

| Cell | Mutation | Result |
|---|---|---|
| X1 | substring match instead of exact fields (the #4009 misparse) | RED — `..._non_node_row_is_never_read_as_a_node_row` |
| X2 | report an unreadable status as "not primary" instead of `None` | RED — `..._unreadable_status_is_none_not_false` |
| X3 | **TIGHTEN**: ignore the node token, count any primary row | RED — the PEER-primary control **and** the non-node-row test |
| X4 | stop reading the cluster status at all (**WIRING**) | RED — 6 of 8, incl. `..._reads_the_cluster_status_command` |
| X5 | **TIGHTEN**: treat a missing node-id as primary | RED — `..._absent_node_id_is_none` |

**X3 is the cell that matters.** During a *correct* roll the still-up peer is
primary for everything, so an implementation that ignored the node token would
abort every healthy image roll — and that defect is invisible to every
"remove the check" cell.

## Cite note for the rest of the opus-review-001 cohort

Within this **one** issue's evidence list the Go-side cites still landed in
roughly the right code, while the `xpf-deploy.py` ones were stale (review base
`ad9591177481`) — the same split as #6762. Staleness varies *within* a single
evidence list, so verify each cite independently rather than reaching a blanket
verdict either way. `/tmp/opus-review-001.md`, the stated fix-direction reference
for all six A10-b4 issues, no longer exists; locate by NAME, not by line range.

## Validation

- 8 new tests in `scripts/deploy/test_xpf_deploy_unverified_primary_6759.py`
- every `scripts/deploy/test_*.py` suite green — 192 tests across 15 files
- `make selftest` — OK

## Docs

`docs/in-place-upgrade.md` gains the detection semantics, the "does not close the
window" statement, the journal-ENOENT reasoning, and the scope caveat.

No cluster targets were run. No dataplane binary or shim `.o` moved.

Closes #6759
