### PR TITLE
config: duplicate event trigger siblings take the last value

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104217,3 +104217,12 @@ prose edit above them added. No diff falls in the new test body.
   materialising it.
 - **File(s)**: pkg/config/ast_groups.go,
   pkg/config/group_expand_budget_6767_test.go
+
+## 2026-08-22 — #6771 duplicate event trigger siblings take the last value
+- **Timestamp**: 2026-08-22
+- **Action**: `within … trigger` read siblings with FindChild (first-wins), so a
+  later `trigger on N` was silently dropped where Junos replaces. Applied
+  #6714's FindChildren rule — the same fix two cases below in the same switch —
+  to `trigger`, `on` and `until`.
+- **File(s)**: pkg/config/compiler_services.go,
+  pkg/config/event_trigger_duplicate_6771_test.go

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -2110,7 +2110,24 @@ func compileEventOptions(node *Node, policies *[]*EventPolicy) error {
 						w.Seconds = n
 					}
 				}
-				if trigNode := child.FindChild("trigger"); trigNode != nil {
+				// #6771: FindChildrEN on BOTH levels, and LAST wins — the same
+				// rule #6714 applied to `then change-configuration commands`
+				// two cases below, for the same reason. The hierarchical parser
+				// keeps repeated same-keyed statements as SIBLINGS
+				// (parseStatements), and SetPath does the same for a repeated
+				// flat `set`: `trigger on 3` followed by `trigger on 9` yields
+				// TWO leaf children under one `trigger` node (measured).
+				//
+				// FindChild returned the FIRST, so the later value was silently
+				// dropped and the operator got 3 where Junos — which REPLACES a
+				// single-valued leaf on a later set — gives 9. It committed
+				// clean with zero warnings.
+				//
+				// No warning is emitted for the duplicate: re-setting a leaf is
+				// ordinary operator behaviour and every override would trip it.
+				// Taking the last value IS the Junos semantic, so honouring it
+				// is the whole fix.
+				for _, trigNode := range child.FindChildren("trigger") {
 					// trigger on N or trigger until N
 					for i := 1; i < len(trigNode.Keys)-1; i++ {
 						switch trigNode.Keys[i] {
@@ -2124,15 +2141,17 @@ func compileEventOptions(node *Node, policies *[]*EventPolicy) error {
 							}
 						}
 					}
-					// Also check children
-					if onNode := trigNode.FindChild("on"); onNode != nil {
+					// Also check children. Every sibling is read and the LAST
+					// assignment stands, so a re-set overrides rather than
+					// being discarded (#6771).
+					for _, onNode := range trigNode.FindChildren("on") {
 						if v := nodeVal(onNode); v != "" {
 							if n, err := strconv.Atoi(v); err == nil {
 								w.TriggerOn = n
 							}
 						}
 					}
-					if untilNode := trigNode.FindChild("until"); untilNode != nil {
+					for _, untilNode := range trigNode.FindChildren("until") {
 						if v := nodeVal(untilNode); v != "" {
 							if n, err := strconv.Atoi(v); err == nil {
 								w.TriggerUntil = n

--- a/pkg/config/event_trigger_duplicate_6771_test.go
+++ b/pkg/config/event_trigger_duplicate_6771_test.go
@@ -1,0 +1,175 @@
+package config
+
+import "testing"
+
+// #6771: the `within … trigger` compile read used FindChild — the FIRST
+// same-keyed sibling — on both levels.
+//
+// The hierarchical parser keeps repeated same-keyed statements as SIBLINGS
+// (parseStatements), and SetPath does the same for a repeated flat `set`.
+// Measured: `trigger on 3` followed by `trigger on 9` yields TWO leaf children
+// under one `trigger` node:
+//
+//	Keys=[within 60]
+//	  Keys=[trigger]
+//	    Keys=[on 3]  leaf
+//	    Keys=[on 9]  leaf
+//
+// So the later value was silently dropped and the operator got 3 where Junos —
+// which REPLACES a single-valued leaf on a later set — gives 9. It committed
+// clean with zero warnings.
+//
+// This is the same defect #6714 fixed two cases below in the same switch, for
+// `then change-configuration commands`, with the same reasoning. `trigger` is
+// the sibling input that rule never reached.
+//
+// No warning is asserted for the duplicate on purpose: re-setting a leaf is
+// ordinary operator behaviour and every override would trip it. Taking the LAST
+// value IS the Junos semantic.
+
+func eventTree6771(t *testing.T, sets ...string) *Config {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, c := range sets {
+		p, err := ParseSetCommand(c)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", c, err)
+		}
+		if err := tree.SetPath(p); err != nil {
+			t.Fatalf("SetPath(%q): %v", c, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	return cfg
+}
+
+func within6771(t *testing.T, cfg *Config) *EventWithin {
+	t.Helper()
+	for _, p := range cfg.EventOptions {
+		if p.Name != "P" {
+			continue
+		}
+		if len(p.WithinClauses) != 1 {
+			t.Fatalf("expected exactly one within clause, got %d", len(p.WithinClauses))
+		}
+		return p.WithinClauses[0]
+	}
+	t.Fatal("policy P did not compile")
+	return nil
+}
+
+// TestDuplicateTriggerOnTakesTheLastValue6771 is the defect proper.
+func TestDuplicateTriggerOnTakesTheLastValue6771(t *testing.T) {
+	cfg := eventTree6771(t,
+		"set event-options policy P events ev1",
+		"set event-options policy P within 60 trigger on 3",
+		"set event-options policy P within 60 trigger on 9",
+	)
+	w := within6771(t, cfg)
+	if w.TriggerOn != 9 {
+		t.Errorf("TriggerOn = %d, want 9 — a later `set` of a single-valued leaf REPLACES in "+
+			"Junos, but the first-only sibling read kept the earlier value and dropped the "+
+			"operator's override silently, with a clean commit and no warning", w.TriggerOn)
+	}
+}
+
+// TestDuplicateTriggerUntilTakesTheLastValue6771 pins the sibling keyword —
+// `until` had the identical first-only read, and a fix applied to `on` alone
+// would leave it open while this file still looked covered.
+func TestDuplicateTriggerUntilTakesTheLastValue6771(t *testing.T) {
+	cfg := eventTree6771(t,
+		"set event-options policy P events ev1",
+		"set event-options policy P within 60 trigger until 4",
+		"set event-options policy P within 60 trigger until 11",
+	)
+	w := within6771(t, cfg)
+	if w.TriggerUntil != 11 {
+		t.Errorf("TriggerUntil = %d, want 11 — the later value must replace the earlier one",
+			w.TriggerUntil)
+	}
+	// TriggerOn must stay ZERO. Asserting only TriggerUntil above cannot see a
+	// read that takes every CHILD of the trigger node regardless of keyword —
+	// such a read sets TriggerOn from the `until` value too, and a config with
+	// only `until` would then look like the contradictory on+until form.
+	// (Measured: a mutation doing exactly that passed until this assertion
+	// existed.)
+	if w.TriggerOn != 0 {
+		t.Errorf("TriggerOn = %d for a trigger specifying ONLY `until`, want 0 — the "+
+			"keyword must select which field is written, not merely the position of the "+
+			"child", w.TriggerOn)
+	}
+}
+
+// TestSingleTriggerIsUnchanged6771 is the TIGHTENING control.
+//
+// Reading every sibling and letting the last win must not disturb the ordinary
+// single-trigger case. A fix that, say, took the last CHILD regardless of
+// keyword, or reset the field before scanning, would satisfy both tests above
+// while corrupting the common config.
+func TestSingleTriggerIsUnchanged6771(t *testing.T) {
+	cfg := eventTree6771(t,
+		"set event-options policy P events ev1",
+		"set event-options policy P within 60 trigger on 3",
+	)
+	w := within6771(t, cfg)
+	if w.Seconds != 60 || w.TriggerOn != 3 || w.TriggerUntil != 0 {
+		t.Errorf("single trigger compiled as seconds=%d on=%d until=%d, want 60/3/0",
+			w.Seconds, w.TriggerOn, w.TriggerUntil)
+	}
+}
+
+// TestContradictoryTriggerStillRejected6771 pins that reading MORE siblings did
+// not weaken the existing contradiction gate: `on` and `until` together is
+// rejected at commit, and must stay rejected now that both are read from
+// every sibling rather than the first.
+func TestContradictoryTriggerStillRejected6771(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, c := range []string{
+		"set event-options policy P events ev1",
+		"set event-options policy P within 60 trigger on 3",
+		"set event-options policy P within 60 trigger until 5",
+	} {
+		p, err := ParseSetCommand(c)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", c, err)
+		}
+		if err := tree.SetPath(p); err != nil {
+			t.Fatalf("SetPath(%q): %v", c, err)
+		}
+	}
+	if _, err := CompileConfig(tree); err == nil {
+		t.Error("a trigger specifying BOTH on and until compiled cleanly; the contradiction " +
+			"gate must survive the widened sibling read")
+	}
+}
+
+// TestMultipleWithinClausesUnaffected6771 pins that distinct `within` values
+// still produce distinct clauses — measured as already correct, and worth
+// holding so the trigger fix cannot collapse them.
+func TestMultipleWithinClausesUnaffected6771(t *testing.T) {
+	cfg := eventTree6771(t,
+		"set event-options policy P events ev1",
+		"set event-options policy P within 60 trigger on 3",
+		"set event-options policy P within 120 trigger on 7",
+	)
+	for _, p := range cfg.EventOptions {
+		if p.Name != "P" {
+			continue
+		}
+		if len(p.WithinClauses) != 2 {
+			t.Fatalf("expected 2 within clauses, got %d", len(p.WithinClauses))
+		}
+		got := map[int]int{}
+		for _, w := range p.WithinClauses {
+			got[w.Seconds] = w.TriggerOn
+		}
+		if got[60] != 3 || got[120] != 7 {
+			t.Errorf("within clauses compiled as %v, want {60:3, 120:7}", got)
+		}
+		return
+	}
+	t.Fatal("policy P did not compile")
+}


### PR DESCRIPTION
Closes #6771

## Derived from code — the issue carries no evidence at all

This one's Evidence and Fix-direction sections are *entirely* pointers to `/tmp/opus-review-001.md`, which no longer exists. Nothing was inherited; the mechanism, the AST shape and the clean-commit behaviour below were all measured at current master before anything changed.

## The defect

`within … trigger` read siblings with `FindChild` — the **first** same-keyed node — on both levels. The hierarchical parser keeps repeated same-keyed statements as siblings (`parseStatements`), and `SetPath` does the same for a repeated flat `set`. Measured:

```
set event-options policy P within 60 trigger on 3
set event-options policy P within 60 trigger on 9

Keys=[within 60]
  Keys=[trigger]
    Keys=[on 3]  leaf
    Keys=[on 9]  leaf
```

Both leaves exist; the first-only read kept **3**. Junos replaces a single-valued leaf on a later `set`, so the answer is **9**. It committed clean with **zero warnings** — the operator's override simply vanished.

## This rule already exists two cases below

`then change-configuration commands` got exactly this fix in **#6714**, whose comment states the reasoning verbatim: *"the hierarchical parser keeps repeated same-keyed statements as SIBLINGS … the first-only read compiled command 'a' and silently discarded every later one."*

`trigger`, `on` and `until` are the sibling inputs that rule never reached. Applying an established rule to a sibling input is a much better argument than re-deriving one.

**No warning is emitted for a duplicate.** Re-setting a leaf is ordinary operator behaviour and every override would trip it. Taking the last value *is* the Junos semantic, so honouring it is the whole fix.

## What was already correct, and stays that way

Measured before changing anything, so the fix could be aimed narrowly:

- `trigger on` **and** `until` together is already **rejected** at commit with a clear message — not a silent drop.
- Two `within` clauses with different seconds already produce two clauses.

Both have tests here so the widened read cannot regress them.

## Mutation matrix

Fix committed first. Full `pkg/config` suite per cell, no `-run` filter, rc from a file, control green first.

| # | mutation | rc | fired |
|---|---|---|---|
| A1 | revert `on` to first-wins | 1 | the `on` test — localises |
| A2 | revert `until` to first-wins | 1 | the `until` test — localises |
| A3 | **TIGHTEN**: take every child regardless of keyword | 0 → 1 | see below |

A1 and A2 are deliberately separate: a fix applied to `on` alone would leave `until` open while this file still looked covered.

**A3 was GREEN first time and the control was the problem.** My `until` test asserted only `TriggerUntil`, so a read that took every *child* — setting `TriggerOn` from the `until` value too — passed. That is not cosmetic: a config specifying only `until` would then look like the contradictory `on`+`until` form and be **rejected at commit**. The test now also asserts `TriggerOn == 0`, pinning that the keyword selects which field is written rather than the child's position, and A3 reds.

## Validation

`go build`, `go vet`, `gofmt` clean; `go test -count=1 ./...` green repo-wide. `pkg/config` only — no cluster, no dataplane, no `userspace-dp` binary or shim `.o` moved.
