### PR TITLE
test: stop asserting scheduler-observable counts in three flaky tests

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104279,3 +104279,18 @@ prose edit above them added. No diff falls in the new test body.
   to `trigger`, `on` and `until`.
 - **File(s)**: pkg/config/compiler_services.go,
   pkg/config/event_trigger_duplicate_6771_test.go
+
+## 2026-08-22 — #7563 load-sensitive test assertions
+
+- **Timestamp**: 2026-08-22
+- **Action**: Removed the scheduler-observing assertions from three tests that
+  failed only under full-tree parallel `go test ./...` and passed on re-run of
+  the same tree. Each was reproduced DETERMINISTICALLY first by injecting the
+  scheduling perturbation a loaded box supplies for free, then fixed, then
+  re-run under the same perturbation. A fourth instance
+  (`TestEventStreamRawDataplaneEventsFeedSyslogFanout`) was found by census and
+  is not in the issue.
+- **File(s)**: `pkg/ddns/fake_dns_portpair_6709_test.go`,
+  `pkg/ddns/README.md`, `pkg/daemon/dhcp_apply_converger_6535_test.go`,
+  `pkg/dataplane/userspace/eventstream_test.go`,
+  `docs/engineering-style.md`

--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -476,6 +476,48 @@ Rules of thumb:
 These are not "style" but are worth keeping next to the rest because
 they repeatedly bite:
 
+- **Never assert an exact count or an in-flight state that the SCHEDULER
+  can move (#7563).** Three tests in three packages failed under a
+  full-tree parallel `go test ./...` and passed on immediate re-run of
+  the SAME tree, on branches that could not reach the code they failed
+  in. They shared one shape: each sampled an asynchronous observable at
+  a fixed point, so the value read was a reading of the machine rather
+  than of the subject.
+  The three mechanisms are worth recognising, because none of them is a
+  data race and `-race` finds none of them:
+  1. a **retry-loop test that let one attempt reach the real resource** —
+     the fixture stubbed the failing attempts and let the winning one
+     bind a live port, so a genuine conflict made the loop resample
+     correctly and the exact-attempt-count assertion fail;
+  2. a **single sample taken right after an async enqueue** — the pass
+     under test hands work to a worker goroutine and returns, so "0
+     applies so far" is the correct answer to the wrong question;
+  3. a **counter read taken from a callback the producer fires BEFORE
+     it accounts the event** — the callback is delivered first by
+     construction, so observing it and then reading the counter races
+     an `Add(1)` that has not happened yet.
+  The fixes, in preference order: make the fixture unable to observe
+  the machine at all (inject the outcome rather than sampling a real
+  resource); otherwise wait on the observable that actually implies the
+  property, and make the wait FAIL LOUDLY, naming what never arrived.
+  Where the producer already publishes a completion watermark, wait on
+  that — it is advanced by the same goroutine after the accounting, so
+  a read taken once it covers the item happens-after the accounting.
+  What NOT to do: add a retry or a sleep to the assertion. That hides
+  the sensitivity instead of removing it, and a test that passes on the
+  second attempt is indistinguishable from one that passes for the
+  wrong reason. Nor is "just re-run it" free: classifying one of these
+  costs a full repo-wide re-run, and — the real damage — it trains
+  reviewers to re-run a red instead of reading it, which is precisely
+  the habit that lets a genuine regression through.
+  **Verify the population empirically rather than by pattern.** Of the
+  15 counter reads in `eventstream_test.go` that matched shape 3 by
+  eye, injecting a delay at the producer's accounting site red-flagged
+  exactly two. Pattern-matching would have rewritten a dozen tests that
+  were already sound. Reproduce a load-sensitive assertion by injecting
+  the scheduling perturbation a loaded box supplies for free, and fix
+  what actually reds.
+
 - **A test that needs a kernel capability must STUB it, not skip on it
   (#6675).** `pkg/dataplane/userspace` builds every snapshot through
   `buildRouteSnapshots`, which dumps the kernel ip-rule table via

--- a/pkg/daemon/dhcp_apply_converger_6535_test.go
+++ b/pkg/daemon/dhcp_apply_converger_6535_test.go
@@ -63,6 +63,34 @@ func (k *keaApplyRecorder) count() int {
 	return k.attempts
 }
 
+// awaitInFlight blocks until want apply attempts have reached the systemctl
+// shell-out.
+//
+// This is a wait on an ASYNC observable, not a retry that papers over a flaky
+// assertion (#7563): ApplyAsync hands the request to a worker goroutine, so
+// "has the apply started" is a question with a real answer that simply is not
+// available yet when reconcileRGState returns. The defect this guards — an
+// edge that enqueues NOTHING — still fails, loudly, at the deadline; it is
+// only the scheduler's head start that is no longer being measured.
+func (k *keaApplyRecorder) awaitInFlight(t *testing.T, want int) {
+	t.Helper()
+	if !waitUntil(t, 10*time.Second, func() bool { return k.count() >= want }) {
+		t.Fatalf("no Kea apply reached systemctl within 10s of the RG transition "+
+			"edge (attempts=%d): the edge enqueued no apply at all, so the node "+
+			"never starts serving DHCP after taking the RG", k.count())
+	}
+	// The over-count half of the original `count() != 1`. It is retained
+	// deliberately but is NOT reachable today: a second apply serialises on
+	// the manager's mutex behind the one blocked in the shell-out, so it
+	// cannot be observed here. No mutation cell reds it, and that is stated
+	// rather than implied — it is defence-in-depth against the manager
+	// losing that serialisation, not a guard with a proof behind it.
+	if n := k.count(); n != want {
+		t.Fatalf("%d Kea applies reached systemctl, want exactly %d: the RG "+
+			"transition edge fired more than once", n, want)
+	}
+}
+
 // quiesce waits until the attempt count stops moving, i.e. the async apply
 // worker has drained its mailbox.
 func (k *keaApplyRecorder) quiesce(t *testing.T) int {
@@ -147,12 +175,22 @@ func TestFailedKeaApplyIsRetriedByReconcileConverger(t *testing.T) {
 	// Pass A: the RG transition edge fires and enqueues the Kea apply, which
 	// is still blocked inside systemctl when the pass returns.
 	d.reconcileRGState()
-	if got := rec.count(); got != 1 {
-		t.Fatalf("fixture: want exactly 1 Kea apply in flight after the edge pass, got %d", got)
-	}
+	// The edge pass ENQUEUES the apply on the manager's async worker and
+	// returns; the systemctl shell-out happens on that worker goroutine.
+	// Sampling the count at the instant the pass returns therefore reads the
+	// SCHEDULER, not the converger — on a loaded box the worker has not been
+	// scheduled yet and 0 is the correct answer to the wrong question
+	// (#7563). Wait for the observable this fixture actually needs: the first
+	// apply reaching the shell-out, where it blocks on rec.release.
+	rec.awaitInFlight(t, 1)
 
 	close(rec.release)
 	settled := rec.quiesce(t)
+	// NOTE: settled is NOT 1. One apply drives several systemctl calls (per
+	// family, stop and restart), so the shell-out total after the pass is a
+	// legitimately variable number and asserting it exactly would trade one
+	// load-sensitive assertion for another. What IS pinned is the relative
+	// movement across passes B and C below.
 	if !d.ApplyFailedForTestingDHCP() {
 		t.Fatalf("fixture: %d apply attempt(s) ran but the manager did not record a failure", settled)
 	}

--- a/pkg/dataplane/userspace/eventstream_test.go
+++ b/pkg/dataplane/userspace/eventstream_test.go
@@ -1240,6 +1240,41 @@ func TestEventStreamDataplaneEventRawCallbackPreferred(t *testing.T) {
 	}
 }
 
+// waitFrameApplied blocks until the dispatcher has FINISHED frame seq.
+//
+// #7563: the dispatcher invokes the raw/decoded callback BEFORE it accounts
+// the frame — both in dispatchOrQueueDataplaneFrame and in the pending-flush
+// path — and advances lastAppliedSeq after both. A test that observes the
+// callback and then reads a counter is therefore racing the accounting: the
+// callback has fired by construction, the Add(1) has not. On an idle box the
+// dispatcher goroutine wins that race every time and the read looks
+// deterministic; under a loaded `go test ./...` it does not. That is exactly
+// why TestEventStreamSessionCloseRTFlowRoutesToRawCallback failed only under
+// full-tree parallel load and passed on re-run of the same tree.
+//
+// lastAppliedSeq is this package's existing completion signal for that
+// question — eventstream_fullresync_prevseq_5362_test.go already waits on it
+// the same way — and it is advanced by the SAME goroutine after the
+// accounting, so a counter read taken once it covers the frame happens-after
+// the Add(1).
+//
+// This is a wait on a real observable, not a retry: a frame that never
+// applies still fails, naming the watermark it never reached.
+func waitFrameApplied(t *testing.T, es *EventStream, seq uint64) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if es.lastAppliedSeq.Load() >= seq {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("frame seq=%d never reached the applied watermark (last_applied=%d): "+
+				"the dispatcher never finished the frame", seq, es.lastAppliedSeq.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
 // TestEventStreamSessionCloseRTFlowRoutesToRawCallback proves the #2460
 // EventFrameTypeSessionClose (type 14) frame is accepted by the event-stream
 // frame dispatcher and routed to the raw dataplane-event callback (the path
@@ -1333,6 +1368,9 @@ func TestEventStreamSessionCloseRTFlowRoutesToRawCallback(t *testing.T) {
 		t.Fatal("session-close RT_FLOW frame did not reach the raw callback")
 	}
 
+	// The raw callback above fires BEFORE the frame is accounted, so read the
+	// counter only once the dispatcher has finished the frame (#7563).
+	waitFrameApplied(t, es, 11)
 	if got := es.SessionCloseEvents.Load(); got != 1 {
 		t.Fatalf("SessionCloseEvents = %d, want 1", got)
 	}
@@ -1561,6 +1599,17 @@ func TestEventStreamRawDataplaneEventsFeedSyslogFanout(t *testing.T) {
 			t.Fatalf("timed out waiting for raw callback %d", i+1)
 		}
 	}
+	// Same #7563 race as the session-close test: draining the raw-callback
+	// channel proves every callback fired, NOT that every frame was accounted.
+	// The last frame's Add(1) trails its callback, so wait for the watermark
+	// to cover the highest seq written above before reading the counters.
+	var maxSeq uint64
+	for _, frame := range frames {
+		if frame.seq > maxSeq {
+			maxSeq = frame.seq
+		}
+	}
+	waitFrameApplied(t, es, maxSeq)
 	if got := es.PolicyDenyEvents.Load(); got != 1 {
 		t.Fatalf("PolicyDenyEvents = %d, want 1", got)
 	}

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -840,6 +840,24 @@ deterministic test (`Test...ResamplesPastAConflictingPort_6709`) instead of by
 occupying a slice of the host's real ephemeral range, which would manufacture
 this very flake for every other test process on the box.
 
+**The seam must be injected for the SUCCEEDING attempt too (#7563).** The
+original loop test stubbed only the failing attempts and let the winning one
+fall through to `realDNSPairAttempt`, so the contention this seam exists to
+describe still reached the test through the back door: under a parallel
+`go test ./...` that fall-through attempt genuinely conflicts, the loop
+genuinely resamples, and `want 2 attempts, got 3` fails — a correct
+implementation failing an assertion about the machine. The loop test now
+returns an inert `stubPacketConn`/`stubListener` pair for the winning attempt
+and additionally asserts the loop hands back THAT pair, so it reads only the
+loop. The same-port property, which genuinely needs a real bind, moved to
+`TestListenDNSPairBindsOneRealPortInBothNamespaces_7563`, which goes through
+the bounded resample loop and so is exactly as reliable as `newFakeDNSServer`
+itself.
+
+The general rule: a test whose subject is a RETRY LOOP must not let any
+attempt reach the resource being retried, or the attempt count becomes a
+reading of the host.
+
 **Process-global warn dedup must be reset by the test that asserts on it.**
 `unsignedUpdateWarned` (`backend_rfc2136.go`) dedups the #4483 unsigned-UPDATE
 warning per update server, keyed by host:port, and it is never reset for the

--- a/pkg/ddns/fake_dns_portpair_6709_test.go
+++ b/pkg/ddns/fake_dns_portpair_6709_test.go
@@ -10,13 +10,26 @@ package ddns
 // listenDNSPair RESAMPLES: each attempt draws a fresh port, so attempts are
 // independent. These tests pin that behaviour deterministically, without
 // occupying real host ports to force a collision.
+//
+// #7563: "deterministically" was only half true. The loop test stubbed the
+// FAILING attempts but let the succeeding one fall through to the real
+// sampler, so the very port contention these tests exist to describe could
+// still reach them through the back door — under a parallel `go test ./...`
+// the fall-through attempt legitimately conflicts, the loop legitimately
+// resamples, and the exact-attempt-count assertion legitimately fails. The
+// resample loop is now driven entirely by injected outcomes and asserts the
+// pair it was handed; the same-port PROPERTY, which genuinely needs the real
+// sampler, is asserted separately through the bounded loop that production
+// uses.
 
 import (
 	"errors"
+	"io"
 	"net"
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 )
 
 // TestListenDNSPairResamplesPastAConflictingPort_6709 is the fail-on-revert
@@ -25,6 +38,15 @@ import (
 // single-attempt implementation returns the first error instead.
 func TestListenDNSPairResamplesPastAConflictingPort_6709(t *testing.T) {
 	for _, conflicts := range []int{1, 3, dnsPairAttempts - 1} {
+		// The winning attempt returns an INERT pair rather than a real one.
+		// A real bind here would consult the host's port space, which is the
+		// one thing this test must not do: another process holding the drawn
+		// port makes the sampler resample, and the resample is correct — so
+		// the attempt count would be a reading of the machine, not of the
+		// loop (#7563).
+		wantPC := stubPacketConn{addr: stubAddr("127.0.0.1:5353")}
+		wantL := stubListener{addr: stubAddr("127.0.0.1:5353")}
+
 		calls := 0
 		prev := dnsPairAttempt
 		dnsPairAttempt = func() (net.PacketConn, net.Listener, error) {
@@ -32,7 +54,7 @@ func TestListenDNSPairResamplesPastAConflictingPort_6709(t *testing.T) {
 			if calls <= conflicts {
 				return nil, nil, &net.OpError{Op: "listen", Net: "tcp", Err: syscall.EADDRINUSE}
 			}
-			return realDNSPairAttempt()
+			return wantPC, wantL, nil
 		}
 		pc, l, err := listenDNSPair()
 		dnsPairAttempt = prev
@@ -43,16 +65,76 @@ func TestListenDNSPairResamplesPastAConflictingPort_6709(t *testing.T) {
 		if calls != conflicts+1 {
 			t.Fatalf("conflicts=%d: want %d attempts, got %d", conflicts, conflicts+1, calls)
 		}
-		// The pair must be on ONE port — that is the whole point of pairing.
-		_, up, _ := net.SplitHostPort(pc.LocalAddr().String())
-		_, tp, _ := net.SplitHostPort(l.Addr().String())
-		if up != tp {
-			t.Fatalf("conflicts=%d: udp port %s != tcp port %s", conflicts, up, tp)
+		// The loop must hand back the SUCCEEDING attempt's pair. A loop that
+		// resampled correctly but returned a stale or zero pair would pass
+		// the attempt-count check and hand the caller an unusable server.
+		if pc != net.PacketConn(wantPC) {
+			t.Fatalf("conflicts=%d: returned udp conn %v, want the succeeding attempt's %v", conflicts, pc, wantPC)
 		}
-		_ = pc.Close()
-		_ = l.Close()
+		if l != net.Listener(wantL) {
+			t.Fatalf("conflicts=%d: returned tcp listener %v, want the succeeding attempt's %v", conflicts, l, wantL)
+		}
 	}
 }
+
+// TestListenDNSPairBindsOneRealPortInBothNamespaces_7563 keeps the same-port
+// property under test after the loop test above stopped touching real ports.
+//
+// This one MUST consult the host, because that pairing is precisely what the
+// host may refuse — but it goes through the bounded resample loop, so it is
+// exactly as reliable as newFakeDNSServer itself: at the measured ~0.2%
+// per-attempt collision rate, 8 independent draws leave a residual around
+// 1e-22. It asserts the INVARIANT (both namespaces, one port number) rather
+// than how many draws it took to get there.
+func TestListenDNSPairBindsOneRealPortInBothNamespaces_7563(t *testing.T) {
+	pc, l, err := listenDNSPair()
+	if err != nil {
+		t.Fatalf("listenDNSPair: %v", err)
+	}
+	defer pc.Close()
+	defer l.Close()
+
+	_, up, err := net.SplitHostPort(pc.LocalAddr().String())
+	if err != nil {
+		t.Fatalf("udp addr %q: %v", pc.LocalAddr(), err)
+	}
+	_, tp, err := net.SplitHostPort(l.Addr().String())
+	if err != nil {
+		t.Fatalf("tcp addr %q: %v", l.Addr(), err)
+	}
+	if up != tp {
+		t.Fatalf("udp port %s != tcp port %s: the pair is not on one port, so a "+
+			"client that retries a truncated reply over TCP reaches nothing", up, tp)
+	}
+	if up == "0" {
+		t.Fatalf("udp port is 0: the pair was never actually bound")
+	}
+}
+
+// stubPacketConn, stubListener and stubAddr are inert stand-ins for a bound
+// pair. They exist so the resample-loop test can express "this attempt
+// succeeded" without asking the kernel for a port — see #7563. Nothing reads
+// or writes them; only identity and LocalAddr/Addr are used.
+type stubAddr string
+
+func (a stubAddr) Network() string { return "stub" }
+func (a stubAddr) String() string  { return string(a) }
+
+type stubPacketConn struct{ addr stubAddr }
+
+func (s stubPacketConn) ReadFrom([]byte) (int, net.Addr, error) { return 0, nil, io.EOF }
+func (s stubPacketConn) WriteTo([]byte, net.Addr) (int, error)  { return 0, io.ErrClosedPipe }
+func (s stubPacketConn) Close() error                           { return nil }
+func (s stubPacketConn) LocalAddr() net.Addr                    { return s.addr }
+func (s stubPacketConn) SetDeadline(time.Time) error            { return nil }
+func (s stubPacketConn) SetReadDeadline(time.Time) error        { return nil }
+func (s stubPacketConn) SetWriteDeadline(time.Time) error       { return nil }
+
+type stubListener struct{ addr stubAddr }
+
+func (s stubListener) Accept() (net.Conn, error) { return nil, io.EOF }
+func (s stubListener) Close() error              { return nil }
+func (s stubListener) Addr() net.Addr            { return s.addr }
 
 // TestListenDNSPairGivesUpLoudly_6709 pins the other half: the loop is BOUNDED
 // and reports the underlying cause. A retry loop that spun forever would turn a


### PR DESCRIPTION
## What

Three tests in three packages failed under a full-tree parallel `go test -count=1 ./...`
and passed on immediate re-run of the **same tree**, on branches that could not reach
the code they failed in. They share one shape: each sampled an **asynchronous
observable at a fixed point**, so the value read was a reading of the machine rather
than of the subject.

No production code changed. The three subjects were already correct; only what the
tests could observe was wrong.

## Each one was reproduced deterministically before being touched

That is what makes this a fix rather than a guess — and the repro named the assertion
in each case, **including one the issue could not**.

| # | test | perturbation injected | reproduced |
|---|---|---|---|
| 1 | `TestListenDNSPairResamplesPastAConflictingPort_6709` (`pkg/ddns`) | make `realDNSPairAttempt` fail its first call | `conflicts=1: want 2 attempts, got 3` — the reported text |
| 2 | `TestFailedKeaApplyIsRetriedByReconcileConverger` (`pkg/daemon`) | sleep 150ms at the top of the async worker loop | `fixture: want exactly 1 Kea apply in flight after the edge pass, got 0` |
| 3 | `TestEventStreamSessionCloseRTFlowRoutesToRawCallback` (`pkg/dataplane/userspace`) | sleep 150ms between the callback and `recordDataplaneEvent` | `SessionCloseEvents = 0, want 1` |

**Two evidence corrections.** #3 is in `pkg/dataplane/userspace`, not `pkg/daemon` as
the issue lists it. And the issue recorded #3 only as "fails under load" — the
assertion is `SessionCloseEvents = 0, want 1`.

## The three mechanisms

**1 — a retry-loop test that let one attempt reach the real resource.** The fixture
stubbed the *failing* attempts and let the winning one fall through to
`realDNSPairAttempt`, which binds a live port. Under a parallel run another process
really does hold the drawn port, the loop resamples — *correctly* — and the
exact-attempt-count assertion fires. The file's own header already claimed these
tests pinned the behaviour "without occupying real host ports"; that was half true,
and the untrue half was the flake.

*Fix:* the winning attempt returns an inert stub pair, so the loop test reads only
the loop. It additionally asserts the loop hands back **that** pair — a loop that
resampled correctly but returned a zero pair passed the old test and handed the
caller an unusable server. The same-port property genuinely needs a real bind, so it
moved to `TestListenDNSPairBindsOneRealPortInBothNamespaces_7563`, which goes through
the bounded resample loop and is therefore exactly as reliable as `newFakeDNSServer`
itself (~1e-22 residual).

**2 — a single sample right after an async enqueue.** `reconcileRGState` hands the
apply to the manager's async worker and returns; the systemctl shell-out happens on
that goroutine. On a loaded box the worker has not run yet, and 0 is the correct
answer to the wrong question.

*Fix:* await the observable the fixture needs (the first apply reaching the
shell-out, where it blocks) using the package's existing `waitUntil` helper.

**3 — a counter read from a callback the producer fires *before* it accounts the
event.** The dispatcher invokes the raw callback before `recordDataplaneEvent` at
both dispatch sites, and advances `lastAppliedSeq` after both. Observing the callback
and then reading the counter races an `Add(1)` that has not happened yet. This is not
a data race and `-race` finds nothing.

*Fix:* wait for `lastAppliedSeq` to cover the frame. That watermark is this package's
existing completion signal for exactly this question — the #5362 test already waits
on it — and is advanced by the **same goroutine after** the accounting, so the read
happens-after the `Add(1)`.

*Verified, not asserted:* running the pre-fix test under the perturbation with
`-race` gives **0** `WARNING: DATA RACE` reports while still failing on
`SessionCloseEvents = 0, want 1`. So `-race` genuinely cannot find this class, which
is why it survived in-tree.

## A fourth instance, found by census rather than by pattern

`TestEventStreamRawDataplaneEventsFeedSyslogFanout` (`FilterLogEvents = 1, want 2`)
is not in the issue.

15 counter reads in `eventstream_test.go` match mechanism 3 *by eye*. Rather than
rewrite them, the delay was injected at the producer's accounting site and the whole
package run: **exactly two red.** `TestEventStreamSessionCloseDropSurfacedInStatus`
looks identical to the eye and is sound. A pattern-driven sweep would have rewritten
a dozen already-correct tests to no benefit.

## No retries or sleeps were added to any assertion

Two fixes are waits on a real observable with a loud, specific failure at the
deadline; the third removes the machine from the fixture entirely, which is strictly
better and is why it was preferred where possible.

## Mutation matrix

flock'd; tree asserted clean before and after; each mutation asserted APPLIED;
`go vet` gated per cell so a non-compiling cell cannot masquerade as a pass; RUN count
asserted non-zero. **Every cell re-applies the perturbation that reproduced the
flake** — a cell that stayed green would mean the guard was not what fixed it.

| Cell | Mutation | Result |
|---|---|---|
| M1 | restore the pre-fix ddns test VERBATIM (`git show BASE:path`) | RED `conflicts=1: want 2 attempts, got 3` |
| M2 | restore the single-sample count check in the Kea fixture | RED `want exactly 1 Kea apply in flight …, got 0` |
| M3 | delete `waitFrameApplied` from the session-close test (**WIRING**) | RED `SessionCloseEvents = 0, want 1` |
| M4 | delete `waitFrameApplied` from the fanout test (**WIRING**) | RED `FilterLogEvents = 1, want 2` |
| M5 | weaken the helper itself: wait for `>= 0` instead of `>= seq` | RED both tests |
| M6 | **TIGHTEN**: make the resample loop return a nil pair on success | RED `returned udp conn <nil>, want the succeeding attempt's …` |
| M7 | **CONTROL**: recorder counts nothing, so no apply is ever observed | RED `no Kea apply reached systemctl within 10s …: the edge enqueued no apply at all` |
| M8 | drop the over-count half of `awaitInFlight` | **PASS — reported, not hidden** (see below) |

**M6 and M7 are the cells that matter.** M6 shows the new identity assertion catches a
defect the old exact-count test could not see. M7 is the necessary-and-sufficient half
for the waits: a wait that merely made the red go away would *also* swallow the real
defect, and M7 proves it does not — the guard still fails, naming the consequence.

**M8 passes, and that is stated in the code rather than implied.** The over-count half
of the original `count() != 1` is unreachable today: a second apply serialises on the
manager's mutex behind the one blocked in the shell-out. It is retained as
defence-in-depth against the manager losing that serialisation, and the comment says
no cell reds it.

## Docs

- `pkg/ddns/README.md` — a test whose subject is a **retry loop** must not let any
  attempt reach the resource being retried, or the attempt count becomes a reading of
  the host.
- `docs/engineering-style.md` — the general entry under project-specific reminders:
  the three mechanisms, the fix preference order, why `-race` finds none of them, the
  empirical-census discipline, and why "just re-run it" is not free — it trains
  reviewers to re-run a red instead of reading it, which is the habit that lets a
  genuine regression through.

## Validation

`go build ./...` clean · `go vet ./...` clean · `go test -count=1 ./...` green.
No cluster targets run. No dataplane binary or shim `.o` moved.

#7482 is the ddns-only precursor that #7563 subsumed as the umbrella. This PR
fixes exactly the test #7482 names — mechanism 1 above — so it reaches terminal
state here rather than being left open behind a superseding issue.

Closes #7563
Closes #7482
