### PR TITLE
configstore: identify the bounded-read refusal structurally

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104279,3 +104279,16 @@ prose edit above them added. No diff falls in the new test body.
   to `trigger`, `on` and `until`.
 - **File(s)**: pkg/config/compiler_services.go,
   pkg/config/event_trigger_duplicate_6771_test.go
+
+- **Timestamp**: 2026-08-23 00:45 UTC
+  - **Action**: #7469 — replace the #6753 bounded-read string discriminator with
+    an exported ErrExceedsLimit sentinel wrapped via %w, so the refusal is
+    identified structurally. Fixed cmd/cli's `%v` wrap, which flattened the
+    chain and would have made errors.Is succeed on the local CLI and silently
+    fail on the remote one. Added the cmd/cli wiring tests that #6753 omitted.
+    Documented that the IsRegular check must precede the read, because
+    O_NONBLOCK turns a pipe read into a 0-byte read with err == nil.
+  - **File(s)**: pkg/configstore/bounded_read.go,
+    pkg/configstore/bounded_read_6753_test.go,
+    pkg/cli/load_bounded_read_6753_test.go, cmd/cli/main.go,
+    cmd/cli/load_bounded_read_7469_test.go (new), pkg/configstore/README.md

--- a/cmd/cli/load_bounded_read_7469_test.go
+++ b/cmd/cli/load_bounded_read_7469_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// The remote CLI surface had no wiring test when #6753 landed — only the local
+// one in pkg/cli did. #7469: that asymmetry is exactly the shape #4883-D
+// records, where the local and remote CLI diverged and the divergence itself
+// produced the bug. The shared reader was unified; the error handling around it
+// was not, and `cmd/cli` flattened the chain with %v so an errors.Is assertion
+// would have succeeded locally and silently failed here.
+//
+// `package main` tests are established practice in this repo — cmd/xpfd's own
+// check_config_bounded_4909_test.go, which this path delegates through, is one.
+func TestCtlHandleLoadBoundsTheReadItself_7469(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "big.conf")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := f.Truncate(configstore.MaxConfigSize + 1); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	f.Close()
+
+	c := &ctl{}
+	err = c.handleLoad([]string{"override", path})
+	if err == nil {
+		t.Fatal("the remote CLI must refuse a file past MaxConfigSize at the READ (#6753)")
+	}
+	// Structural, not substring — and this is the assertion that fails if the
+	// %v regresses, because %v flattens the chain errors.Is walks.
+	if !errors.Is(err, configstore.ErrExceedsLimit) {
+		t.Fatalf("the refusal must be identifiable via errors.Is(ErrExceedsLimit); "+
+			"a %%v wrap here flattens the chain and breaks it. got %q", err)
+	}
+}
+
+// The remote surface must not hang on a writerless FIFO either. A regression
+// HANGS rather than failing, hence the deadline.
+func TestCtlHandleLoadDoesNotBlockOnAFIFO_7469(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fifo.conf")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported here: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		c := &ctl{}
+		done <- c.handleLoad([]string{"override", path})
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("a FIFO must be refused by the remote load path")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("the remote handleLoad BLOCKED on a writerless FIFO (#6753/#7469)")
+	}
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -575,7 +575,11 @@ func (c *ctl) handleLoad(args []string) error {
 		// #6753: bound the READ, not just the post-read length.
 		data, err := configstore.ReadBoundedConfigFile(source)
 		if err != nil {
-			return fmt.Errorf("load: %v", err)
+			// #7469: %w, not %v — %v flattens the chain, so errors.Is
+			// against configstore.ErrExceedsLimit fails on this surface while
+			// succeeding on the local CLI. The shared helper was unified; the
+			// error handling around it was not.
+			return fmt.Errorf("load: %w", err)
 		}
 		content = string(data)
 	}

--- a/pkg/cli/load_bounded_read_6753_test.go
+++ b/pkg/cli/load_bounded_read_6753_test.go
@@ -1,9 +1,9 @@
 package cli
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -33,8 +33,13 @@ func TestHandleLoadBoundsTheReadItself_6753(t *testing.T) {
 	if err == nil {
 		t.Fatal("handleLoad must refuse a file past MaxConfigSize at the READ, not after materialising it (#6753)")
 	}
-	if !strings.Contains(err.Error(), "limit") {
-		t.Fatalf("the refusal must come from the bounded read and name the limit, got %q", err)
+	// #7469: identify the refusal STRUCTURALLY. Substring-matching "limit"
+	// separated this from the store's post-materialisation "config too large"
+	// rejection only by accident of wording: rewording the STORE's message to
+	// contain "limit" would have made this assertion pass against the very
+	// code #6753 fixed, without touching any #6753 file.
+	if !errors.Is(err, configstore.ErrExceedsLimit) {
+		t.Fatalf("the refusal must come from the bounded read (errors.Is ErrExceedsLimit), got %q", err)
 	}
 }
 
@@ -52,8 +57,7 @@ func TestHandleLoadStillAcceptsANormalFile_6753(t *testing.T) {
 		t.Fatalf("configstore.New: %v", err)
 	}
 	c := New(st, nil, nil, nil, nil, nil, nil, nil, nil, nil)
-	if err := c.handleLoad([]string{"override", path}); err != nil &&
-		strings.Contains(err.Error(), "limit") {
+	if err := c.handleLoad([]string{"override", path}); errors.Is(err, configstore.ErrExceedsLimit) {
 		t.Fatalf("a normal config must not be refused by the size bound, got %q", err)
 	}
 }

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -1307,6 +1307,14 @@ itself:
   `os.Open` hangs before any size check can run. That is a distinct defect from
   the size cap and a size-only fix does not address it.
 
+Identify the over-cap refusal with `errors.Is(err, ErrExceedsLimit)`, never by
+matching the message. The store's own post-materialisation rejection is a
+*different* refusal produced by independently-maintained wording, so a
+substring test silently changes verdict when either message is reworded — and
+rewording the store's to contain the matched word makes such a test pass
+against unfixed code (#7469). Callers must wrap with `%w`, not `%v`: `%v`
+flattens the chain and breaks `errors.Is` at that surface only.
+
 Both CLI surfaces (`pkg/cli` local, `cmd/cli` remote) and `cmd/xpfd` call the
 same implementation. They previously did not, and #4883-D records the cost of
 that shape at a neighbouring site: the local and remote CLI diverged, and the

--- a/pkg/configstore/bounded_read.go
+++ b/pkg/configstore/bounded_read.go
@@ -1,11 +1,24 @@
 package configstore
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"syscall"
 )
+
+// ErrExceedsLimit is returned (wrapped) when a bounded read refuses a source
+// for being over its ceiling. It exists so callers can identify THIS refusal
+// structurally with errors.Is rather than by matching an error string.
+//
+// #7469: the #6753 tests originally distinguished the bounded read's refusal
+// from the store's post-materialisation "config too large" rejection by
+// checking for the substring "limit". Both messages are maintained
+// independently, so rewording either one silently changed the verdict — and
+// rewording the STORE's to contain "limit" would have made the test pass
+// against the very code #6753 fixed, with no change to any #6753 file.
+var ErrExceedsLimit = errors.New("exceeds size limit")
 
 // ReadBounded reads at most max+1 bytes from r and rejects a source that
 // exceeds max, allocating no more than max+1 bytes REGARDLESS of how much data
@@ -20,7 +33,7 @@ func ReadBounded(r io.Reader, max int64) ([]byte, error) {
 		return nil, err
 	}
 	if int64(len(data)) > max {
-		return nil, fmt.Errorf("exceeds %d byte limit", max)
+		return nil, fmt.Errorf("%w: %d byte ceiling", ErrExceedsLimit, max)
 	}
 	return data, nil
 }
@@ -36,6 +49,15 @@ func ReadBounded(r io.Reader, max int64) ([]byte, error) {
 // descriptor closes the window: the allocation is bounded by the limit, not by
 // what Stat claimed, and reaching the (max+1)-th byte proves the file is
 // over-cap. A non-regular file (dir/device/FIFO) is refused up front.
+//
+// The IsRegular check MUST precede the read, and the ordering is load-bearing
+// rather than stylistic (#7469). On a pipe, O_NONBLOCK silently turns a
+// would-be 24-byte read into a 0-byte read with err == nil — a truncation that
+// reports success. Refusing every non-regular path before any read is the only
+// thing that keeps this function from returning a silently short payload, and
+// it is exported, so a caller reordering these two steps would reintroduce
+// that. O_NONBLOCK being a no-op for regular files is the half that is NOT the
+// risk.
 //
 // #6753: the open uses O_NONBLOCK. Opening a FIFO for reading BLOCKS until a
 // writer appears, so a plain os.Open hangs before Stat can classify the path

--- a/pkg/configstore/bounded_read_6753_test.go
+++ b/pkg/configstore/bounded_read_6753_test.go
@@ -1,6 +1,7 @@
 package configstore
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,8 +33,10 @@ func TestReadBoundedConfigFileRejectsOversizeWithoutMaterialising_6753(t *testin
 	if data != nil {
 		t.Fatalf("a refused read must yield no payload, got %d bytes", len(data))
 	}
-	if !strings.Contains(err.Error(), "limit") {
-		t.Fatalf("error must name the limit, got %q", err)
+	// #7469: structural, not substring. This assertion previously matched the
+	// word "limit", which couples the verdict to wording maintained elsewhere.
+	if !errors.Is(err, ErrExceedsLimit) {
+		t.Fatalf("an over-cap refusal must wrap ErrExceedsLimit, got %q", err)
 	}
 }
 


### PR DESCRIPTION
Closes #7469

Follow-up to #6753, acting on a hostile review of my own PR #7466. Every finding
below came from that review, not from me.

## The defect: a verdict coupled to wording in another package

#6753's tests separated the bounded read's refusal from the store's
post-materialisation rejection by checking the error text for `limit`. Two
messages, two independently maintained packages, one substring joining them.

Both failure directions are real, and the second needs **no change to any #6753
file**:

| reword | effect on the old test |
|---|---|
| `ReadBounded`'s `"exceeds %d byte limit"` | false RED |
| the **store**'s `"...exceeds maximum %d bytes"` → `"...exceeds the %d byte limit"` | **goes VACUOUS and certifies unfixed code** |

`ErrExceedsLimit` is now exported and wrapped with `%w`; every assertion uses
`errors.Is`.

## `cmd/cli` flattened the chain with `%v`

```go
pkg/cli/cli_config.go:  fmt.Errorf("load: %w", err)   // chain preserved
cmd/cli/main.go:        fmt.Errorf("load: %v", err)   // chain FLATTENED
```

So the sentinel would have worked on the local CLI and silently not worked on
the remote one — and #6753 wrote a wiring test only for the surface where it
works. That is the divergence #4883-D records between these two CLIs,
reappearing in the error handling *after* the reader itself had been unified.

My stated reason for omitting the remote test ("`cmd/cli` is `package main` and
awkward to test") does not hold: `cmd/xpfd/check_config_bounded_4909_test.go` —
the file this path delegates through — is itself `package main`.

## Mutation matrix

`go vet` rc 0 in every cell.

| # | mutation | required | result |
|---|---|---|---|
| M-A | revert the #6753 call site **and** reword the store's message to contain `limit` | RED | **RED** |
| M-B | restore `%v` in `cmd/cli` | RED | **RED** |
| M-C | reword the reader's own message | **unchanged** | pass (after a fix, below) |

**M-A is the one that matters.** It reds reporting
`"config too large: 16777217 bytes exceeds the 16777216 byte limit"` — a message
containing `limit`, so the old substring assertion would have gone **green
against the unfixed code**.

**M-B shows the inverse.** Its error text still contains `limit`
(`exceeds size limit`) while `errors.Is` correctly fails — a broken chain that a
substring check cannot see.

**M-C failed on first run and that was the point.** It exposed a substring
assertion still live in `pkg/configstore`'s own #6753 test, which I had missed
while converting the CLI ones. Now structural; M-C re-run is clean across all
three packages.

## Deliberately not changed

`bounded_read_6753_test.go` still matches `"not a regular file"` as a string.
That refusal has **no competing producer** — nothing else in the path emits a
similar message — so a reword there causes a false red, which is noisy but
safe, never a vacuous green. Different risk class from the `limit` coupling,
so I left it rather than widening scope.

## Doc

`ReadBoundedFile`'s comment now records that the `IsRegular` check **must**
precede the read: on a pipe, `O_NONBLOCK` silently turns a would-be 24-byte
read into a **0-byte read with `err == nil`**. Refusing non-regular paths first
is the only thing keeping this exported function from returning a silently
truncated payload — measured by the reviewer, and previously undocumented
because the doc explained only the half that is not the risk.

`pkg/configstore/README.md` gains the `errors.Is` / `%w` contract.

## Validation

`go build ./...`, `go vet ./...`, and `pkg/configstore` + `pkg/cli` + `cmd/cli`
+ `cmd/xpfd` clean at the merged head. No cluster fence owed or run: config-file
reading only, no forwarding, session-sync, VRRP or fabric path, no dataplane
artifact, no Rust.
