### PR TITLE
config: bound the DDNS TTL and the heartbeat timeout product

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104279,3 +104279,14 @@ prose edit above them added. No diff falls in the new test body.
   to `trigger`, `on` and `until`.
 - **File(s)**: pkg/config/compiler_services.go,
   pkg/config/event_trigger_duplicate_6771_test.go
+
+## 2026-08-22 — #6772/#6773 bound two typed leaves at their runtime domains
+- **Timestamp**: 2026-08-22
+- **Action**: #6773 DDNS ttl was min-only while reaching a uint32 DNS RR header
+  (2^32 wraps to 0, "do not cache"); bounded at MaxDNSTTLSeconds. #6772
+  heartbeat-threshold is MULTIPLIED by heartbeat-interval into a time.Duration
+  and neither field alone can be capped usefully, so the PRODUCT (doubled, as
+  failover.go computes it) is validated at strict commit.
+- **File(s)**: pkg/config/schema_validators.go, pkg/config/schema_system.go,
+  pkg/config/compiler_validate_strict_chassis.go,
+  pkg/config/numeric_bounds_6772_6773_test.go

--- a/pkg/cluster/heartbeat_default_agreement_6772_test.go
+++ b/pkg/cluster/heartbeat_default_agreement_6772_test.go
@@ -1,0 +1,30 @@
+package cluster
+
+import (
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6772: pkg/config's heartbeat overflow validator must substitute the SAME
+// defaults the runtime does for an unset field, or it validates a config the
+// runtime will not run.
+//
+// The constants are duplicated because pkg/cluster imports pkg/config, so the
+// dependency cannot run the other way. A divergence between the two copies is
+// always a bug, so this asserts the AGREEMENT rather than pinning either side
+// to a literal — pinning one would encode which copy is trusted, and the stale
+// comments this change corrected (`0=default(1000)` / `0=default(3)`, against a
+// runtime of 100ms/5) are what that looks like when it goes wrong.
+func TestHeartbeatDefaultsAgreeAcrossPackages6772(t *testing.T) {
+	if got := time.Duration(config.DefaultHeartbeatIntervalMillis) * time.Millisecond; got != DefaultHeartbeatInterval {
+		t.Errorf("config.DefaultHeartbeatIntervalMillis = %v, runtime DefaultHeartbeatInterval = %v — "+
+			"the overflow validator would model an interval the runtime never uses",
+			got, DefaultHeartbeatInterval)
+	}
+	if int(config.DefaultHeartbeatThreshold) != DefaultHeartbeatThreshold {
+		t.Errorf("config.DefaultHeartbeatThreshold = %d, runtime DefaultHeartbeatThreshold = %d",
+			config.DefaultHeartbeatThreshold, DefaultHeartbeatThreshold)
+	}
+}

--- a/pkg/config/compiler_validate_strict_chassis.go
+++ b/pkg/config/compiler_validate_strict_chassis.go
@@ -131,6 +131,26 @@ func validateChassisClusterStrict(cfg *Config) error {
 	if cfg == nil || cfg.Chassis.Cluster == nil {
 		return nil
 	}
+	// #6772: the dead-peer timeout is `time.Duration(threshold) * interval`
+	// (pkg/cluster/heartbeat.go), and failover.go doubles it for the transfer
+	// grace. Each field is individually bounded — interval by MaxDurationMillis,
+	// threshold at >= 1 — but nothing bounded their PRODUCT, and time.Duration
+	// is int64 nanoseconds.
+	//
+	// An overflowed product does not merely become large: it wraps NEGATIVE,
+	// and a negative timeout reads as already-expired. The peer is declared
+	// lost on the first check, on both nodes, which is the exact inversion of
+	// the liveness guard the threshold exists to provide — the same failure
+	// MaxDurationSeconds' comment describes for ip-monitoring hold-down.
+	//
+	// Checked as a PRODUCT rather than by capping threshold alone: a cap safe
+	// at a 1 ms interval overflows at a large one, so any single-field bound
+	// would be either useless or arbitrary. This rejects exactly the
+	// combinations that cannot be represented.
+	if err := validateHeartbeatTimeoutProduct(cfg.Chassis.Cluster); err != nil {
+		return err
+	}
+
 	rgs := cfg.Chassis.Cluster.RedundancyGroups
 
 	if len(rgs) > MaxHeartbeatRedundancyGroups {
@@ -283,6 +303,62 @@ func validateChassisClusterStrict(cfg *Config) error {
 				}
 			}
 		}
+	}
+	return nil
+}
+
+// validateHeartbeatTimeoutProduct rejects a heartbeat interval/threshold pair
+// whose dead-peer timeout cannot be represented as a time.Duration (#6772).
+//
+// The runtime computes `time.Duration(threshold) * interval` and, for the
+// transfer grace, `2 * time.Duration(threshold) * interval + slack`. The
+// doubled form is checked because it overflows FIRST, so a pair that passes the
+// plain timeout can still invert the grace.
+//
+// Zero means "use the default" for both fields at runtime, so a zero is left
+// alone here rather than substituted — the defaults are small and cannot
+// overflow, and substituting them would make this validator disagree with the
+// runtime about what the config says.
+// DefaultHeartbeatIntervalMillis and DefaultHeartbeatThreshold mirror the
+// runtime's substitutions for an unset heartbeat field
+// (cluster.DefaultHeartbeatInterval / cluster.DefaultHeartbeatThreshold).
+//
+// They are duplicated rather than imported because pkg/cluster imports
+// pkg/config, so the dependency cannot run the other way. The duplication is
+// bound by an agreement test in pkg/cluster, which CAN see both — a divergence
+// here is always a bug, so it is asserted rather than trusted.
+const (
+	DefaultHeartbeatIntervalMillis = int64(100)
+	DefaultHeartbeatThreshold      = int64(5)
+)
+
+func validateHeartbeatTimeoutProduct(cc *ClusterConfig) error {
+	if cc == nil {
+		return nil
+	}
+	interval, threshold := int64(cc.HeartbeatInterval), int64(cc.HeartbeatThreshold)
+	// An unset field is not "no value" — the runtime substitutes its own
+	// default (group_state.go only assigns when > 0), so an unset interval
+	// paired with a huge threshold still overflows at run time. Model what the
+	// runtime does rather than skipping: skipping accepted exactly that pair.
+	if interval <= 0 {
+		interval = DefaultHeartbeatIntervalMillis
+	}
+	if threshold <= 0 {
+		threshold = DefaultHeartbeatThreshold
+	}
+	// Work in milliseconds and compare against the ms-denominated ceiling, so
+	// the check itself cannot overflow while testing for overflow.
+	if threshold > MaxDurationMillis/(2*interval) {
+		return fmt.Errorf("chassis cluster: heartbeat-threshold %d with "+
+			"heartbeat-interval %dms yields a dead-peer timeout that overflows "+
+			"time.Duration (int64 nanoseconds) and wraps NEGATIVE — a negative "+
+			"timeout reads as already-expired, so both nodes declare the peer "+
+			"lost on the first check, inverting the liveness guard the threshold "+
+			"exists to provide. Reduce heartbeat-threshold or heartbeat-interval "+
+			"(the product, doubled for the failover transfer grace, must stay "+
+			"under %dms)",
+			threshold, interval, MaxDurationMillis)
 	}
 	return nil
 }

--- a/pkg/config/numeric_bounds_6772_6773_test.go
+++ b/pkg/config/numeric_bounds_6772_6773_test.go
@@ -1,0 +1,224 @@
+package config
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// #6772 / #6773: two typed leaves were min-only, and each fed a downstream
+// domain that WRAPS rather than failing.
+//
+// They are the same class — "the schema admits a value the runtime's arithmetic
+// cannot represent" — but they need different fixes, which is why both are here
+// with their own cases:
+//
+//   - #6773 `system services dhcp-local-server … ttl` reaches a 32-bit unsigned
+//     DNS RR header field. A single max bound at the wire domain fixes it.
+//   - #6772 `chassis cluster heartbeat-threshold` is MULTIPLIED by
+//     heartbeat-interval into a time.Duration. Neither field alone can be
+//     capped usefully — a threshold safe at a 1 ms interval overflows at a large
+//     one — so the PRODUCT is what must be validated.
+
+// schemaCheck6773 drives SchemaValidate, which is where a typed-leaf validator
+// runs. CompileConfig does NOT invoke it, so a test that only compiled would
+// report the TTL bound as absent even when it is present — measured.
+func schemaCheck6773(t *testing.T, sets ...string) error {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, c := range sets {
+		p, err := ParseSetCommand(c)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", c, err)
+		}
+		if err := tree.SetPath(p); err != nil {
+			t.Fatalf("SetPath(%q): %v", c, err)
+		}
+	}
+	return SchemaValidate(tree, nil)
+}
+
+func compile6772(t *testing.T, sets ...string) error {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, c := range sets {
+		p, err := ParseSetCommand(c)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", c, err)
+		}
+		if err := tree.SetPath(p); err != nil {
+			t.Fatalf("SetPath(%q): %v", c, err)
+		}
+	}
+	_, err := CompileConfig(tree)
+	return err
+}
+
+func clusterSets6772(interval, threshold string) []string {
+	return []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster node 0",
+		// #6611 precondition: an unkeyed cluster is rejected on its own, which
+		// would make every case below pass for the wrong reason.
+		"set chassis cluster authentication-key test-cluster-psk-6772",
+		"set chassis cluster heartbeat-interval " + interval,
+		"set chassis cluster heartbeat-threshold " + threshold,
+	}
+}
+
+// TestHeartbeatTimeoutProductMustBeRepresentable6772 is #6772's defect.
+func TestHeartbeatTimeoutProductMustBeRepresentable6772(t *testing.T) {
+	// interval 1000 ms with a threshold near MaxInt64: the product
+	// time.Duration(threshold)*interval wraps negative, and a negative timeout
+	// reads as already-expired.
+	err := compile6772(t, clusterSets6772("1000", "9223372036854775807")...)
+	if err == nil {
+		t.Fatal("a heartbeat-threshold whose product with the interval overflows " +
+			"time.Duration compiled CLEANLY. The dead-peer timeout wraps NEGATIVE, so both " +
+			"nodes declare the peer lost on the first check — the liveness guard the " +
+			"threshold exists to provide is inverted by the value that configures it")
+	}
+	if !strings.Contains(err.Error(), "heartbeat-threshold") {
+		t.Errorf("rejected for the wrong reason: %v", err)
+	}
+}
+
+// TestHeartbeatGraceDoublingIsAccountedFor6772 pins the factor of two.
+//
+// failover.go computes `2*time.Duration(threshold)*interval + slack`, so the
+// DOUBLED form overflows first. A check written against the plain timeout would
+// pass a pair that still inverts the transfer grace — and every test above
+// would still be green.
+func TestHeartbeatGraceDoublingIsAccountedFor6772(t *testing.T) {
+	// Chosen to fit the PLAIN product and overflow the doubled one.
+	const interval = int64(1000)
+	justOverDoubled := MaxDurationMillis/(2*interval) + 1
+	if justOverDoubled > MaxDurationMillis/interval {
+		t.Fatalf("fixture broken: %d must fit the plain product", justOverDoubled)
+	}
+
+	err := compile6772(t, clusterSets6772("1000", itoa6772(justOverDoubled))...)
+	if err == nil {
+		t.Errorf("threshold %d with a 1000ms interval fits the plain timeout but overflows "+
+			"the DOUBLED failover transfer grace, and compiled cleanly — the check is "+
+			"written against the wrong expression", justOverDoubled)
+	}
+}
+
+// TestOrdinaryHeartbeatSettingsStillCompile6772 is the TIGHTENING control.
+//
+// The shipped defaults and the Junos-documented range must keep compiling. A
+// product check written with the comparison inverted, or with a stray factor,
+// would satisfy both tests above while rejecting every real cluster config —
+// and this validator runs on the commit path.
+func TestOrdinaryHeartbeatSettingsStillCompile6772(t *testing.T) {
+	for _, tc := range []struct{ interval, threshold string }{
+		{"1000", "3"},   // Junos minimum threshold
+		{"1000", "5"},   // xpf default
+		{"1000", "8"},   // Junos maximum threshold
+		{"30", "5"},     // the shipped 30ms RETH advertisement cadence
+		{"200", "5"},    // the interval named throughout pkg/cluster
+		{"60000", "10"}, // a deliberately slow cluster
+	} {
+		if err := compile6772(t, clusterSets6772(tc.interval, tc.threshold)...); err != nil {
+			t.Errorf("interval=%s threshold=%s was REJECTED: %v — this is an ordinary "+
+				"cluster configuration and the validator runs at commit",
+				tc.interval, tc.threshold, err)
+		}
+	}
+}
+
+// TestUnsetIntervalStillBoundsTheThreshold6772 pins the zero contract, and it
+// exists because a mutation found the gap.
+//
+// An earlier version SKIPPED validation when either field was unset, reasoning
+// that zero means "use the default". But the runtime substitutes that default
+// (group_state.go assigns only when > 0), so an unset interval paired with a
+// huge threshold still overflows at run time — and skipping accepted exactly
+// that pair. The validator now models the substitution instead.
+func TestUnsetIntervalStillBoundsTheThreshold6772(t *testing.T) {
+	err := compile6772(t,
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster node 0",
+		"set chassis cluster authentication-key test-cluster-psk-6772",
+		"set chassis cluster heartbeat-threshold 9223372036854775807",
+	)
+	if err == nil {
+		t.Error("a huge heartbeat-threshold with an UNSET interval compiled cleanly. The " +
+			"runtime substitutes its default interval, so the product still overflows and " +
+			"the dead-peer timeout still wraps negative — an unset field is not 'no value'")
+	}
+}
+
+// TestUnsetHeartbeatFieldsAreLeftAlone6772 pins the other side: a cluster with
+// NEITHER field set must still compile, since the substituted defaults are
+// small and cannot overflow.
+func TestUnsetHeartbeatFieldsAreLeftAlone6772(t *testing.T) {
+	if err := compile6772(t,
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster node 0",
+		"set chassis cluster authentication-key test-cluster-psk-6772",
+	); err != nil {
+		t.Errorf("a cluster with neither heartbeat field set was rejected: %v", err)
+	}
+}
+
+// TestDDNSTTLIsBoundedAtTheWireDomain6773 is #6773's defect.
+func TestDDNSTTLIsBoundedAtTheWireDomain6773(t *testing.T) {
+	base := []string{
+		"set system services dhcp-local-server group g interface ge-0/0/0.0",
+		"set system services dhcp-local-server dynamic-dns domain example.net",
+	}
+	// 2^32 is the first value that wraps to 0 in the RR header's uint32 TTL.
+	// A zero TTL tells every resolver not to cache the record at all.
+	err := schemaCheck6773(t, append(append([]string{}, base...),
+		"set system services dhcp-local-server dynamic-dns ttl 4294967296")...)
+	if err == nil {
+		t.Error("a DDNS ttl of 2^32 compiled cleanly. The DNS RR header TTL is a 32-bit " +
+			"unsigned wire field, so it WRAPS to 0 — telling every resolver not to cache " +
+			"the record, which is a materially different answer from the one configured")
+	}
+
+	// And the largest representable TTL must still be accepted, or the bound is
+	// off by one in the direction that rejects a legal value.
+	if err := schemaCheck6773(t, append(append([]string{}, base...),
+		"set system services dhcp-local-server dynamic-dns ttl 4294967295")...); err != nil {
+		t.Errorf("the maximum representable TTL (2^32-1) was rejected: %v", err)
+	}
+}
+
+// TestOrdinaryDDNSTTLStillCompiles6773 is the tightening control for the TTL
+// bound — a max written too low would reject ordinary values.
+func TestOrdinaryDDNSTTLStillCompiles6773(t *testing.T) {
+	for _, ttl := range []string{"1", "300", "3600", "86400"} {
+		err := schemaCheck6773(t,
+			"set system services dhcp-local-server group g interface ge-0/0/0.0",
+			"set system services dhcp-local-server dynamic-dns domain example.net",
+			"set system services dhcp-local-server dynamic-dns ttl "+ttl)
+		if err != nil {
+			t.Errorf("ordinary DDNS ttl %s was rejected: %v", ttl, err)
+		}
+	}
+}
+
+// TestMaxDNSTTLMatchesTheWireField6773 pins the constant to the wire domain it
+// claims, rather than to a hand-copied literal that can drift from its meaning.
+func TestMaxDNSTTLMatchesTheWireField6773(t *testing.T) {
+	if MaxDNSTTLSeconds != int64(math.MaxUint32) {
+		t.Errorf("MaxDNSTTLSeconds = %d, want math.MaxUint32 (%d) — the bound must BE the "+
+			"wire field's domain, not a literal that resembles it",
+			MaxDNSTTLSeconds, int64(math.MaxUint32))
+	}
+}
+
+func itoa6772(v int64) string {
+	if v == 0 {
+		return "0"
+	}
+	var b []byte
+	for v > 0 {
+		b = append([]byte{byte('0' + v%10)}, b...)
+		v /= 10
+	}
+	return string(b)
+}

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -781,10 +781,14 @@ func dhcpDynamicDNSSchema() *schemaNode {
 			desc:          "TTL (seconds) for published A/AAAA/PTR records (default 300)",
 			args:          1,
 			valueType:     ValueInteger,
-			valueDesc:     "Record TTL in seconds (>= 1; default 300 when unset)",
+			valueDesc:     "Record TTL in seconds (1..4294967295; default 300 when unset)",
 			valueExamples: []string{"300", "3600"},
-			validator:     ValidateIntegerMin(1),
-			children:      nil,
+			// #6773: bounded at the DNS wire domain. The RR header TTL is a
+			// 32-bit unsigned field, so a larger value WRAPS rather than
+			// failing — 2^32 lands as 0, telling every resolver not to cache
+			// the record. Min-only admitted exactly that.
+			validator: ValidateInteger(1, MaxDNSTTLSeconds),
+			children:  nil,
 		},
 		"hostname-source": {
 			desc:          "How the published label is derived from the lease",

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -257,6 +257,19 @@ func ValidatePercent(min, max float64) LeafValidator {
 // review on PR #1845: no schema-only caps).
 const MaxDurationMillis = int64(math.MaxInt64) / int64(time.Millisecond)
 
+// MaxDNSTTLSeconds is the largest TTL a DNS record can carry: the RR header's
+// TTL is a 32-bit unsigned wire field (RFC 1035 §3.2.1), so a larger value does
+// not fail — it WRAPS. 2^32 becomes 0, and a zero TTL tells every resolver not
+// to cache the record at all, which is a materially different answer from the
+// one the operator configured.
+//
+// #6773: the DDNS ttl leaf was min-only, and pkg/ddns's rfc2136 backend carried
+// `uint32(rec.TTL) //nolint:gosec // TTL is a small positive config value` — a
+// comment asserting a property nothing enforced, suppressing exactly the
+// warning that would have caught it. Same shape as MaxDurationSeconds below:
+// bound the typed leaf at the domain its runtime actually has.
+const MaxDNSTTLSeconds = int64(math.MaxUint32)
+
 // MaxDurationSeconds is the seconds analogue of MaxDurationMillis: the
 // largest second count that survives `time.Duration(n) * time.Second`
 // without int64 overflow (math.MaxInt64 / 1e9 = 9223372036). Used for

--- a/pkg/config/types_chassis.go
+++ b/pkg/config/types_chassis.go
@@ -100,10 +100,13 @@ type ClusterConfig struct {
 	// cluster stanza but no explicit `node` leaf must NOT be treated as
 	// "node 0" when reconciling against the /etc/xpf/node-id file, or an
 	// absent leaf on a node-1 box would false-reject as a mismatch.
-	NodeIDSet           bool
-	RethCount           int
-	HeartbeatInterval   int    // milliseconds, 0=default(1000)
-	HeartbeatThreshold  int    // missed heartbeats before lost, 0=default(3)
+	NodeIDSet bool
+	RethCount int
+	// #6772: both defaults corrected. The runtime substitutes
+	// cluster.DefaultHeartbeatInterval (100ms) and
+	// cluster.DefaultHeartbeatThreshold (5); these comments said 1000 and 3.
+	HeartbeatInterval   int    // milliseconds, 0 = runtime default (100)
+	HeartbeatThreshold  int    // missed heartbeats before lost, 0 = runtime default (5)
 	ControlInterface    string // interface for heartbeat traffic (e.g. "hb0")
 	PeerAddress         string // peer node's control link IP (e.g. "10.99.0.2")
 	FabricInterface     string // interface for session/config sync (e.g. "fab0")


### PR DESCRIPTION
Closes #6772
Closes #6773

Two typed leaves were min-only while feeding a downstream domain that **wraps** rather than failing. Same class — but they need different fixes, and the reason each shape was chosen is the substance here.

**Both derived from code.** Neither issue carries any evidence: their Evidence *and* Fix-direction sections are pointers to `/tmp/opus-review-001.md`, which no longer exists.

## #6773 — a single bound at the wire domain

`dhcp-local-server dynamic-dns ttl` reaches the DNS RR header TTL, a 32-bit unsigned wire field (RFC 1035 §3.2.1). `2^32` lands as **0**, and a zero TTL tells every resolver not to cache the record — a materially different answer from the one configured.

The giveaway was in `pkg/ddns`:

```go
Ttl: uint32(rec.TTL), //nolint:gosec // TTL is a small positive config value
```

A comment asserting a property nothing enforced, suppressing exactly the warning that would have caught it. Bounded at `MaxDNSTTLSeconds`, defined next to the existing `MaxDurationMillis`/`MaxDurationSeconds` whose comments describe the identical hazard.

## #6772 — a PRODUCT, because no single field can be capped usefully

`heartbeat-threshold` is multiplied by `heartbeat-interval` into `time.Duration(threshold) * interval`, and `failover.go` doubles it for the transfer grace. Each field is individually bounded; **nothing bounded their product**, and `time.Duration` is int64 nanoseconds.

An overflowed product does not merely become large — it wraps **negative**, and a negative timeout reads as already-expired. Both nodes declare the peer lost on the first check: the exact inversion of the liveness guard the threshold configures. That is the same failure `MaxDurationSeconds`' own comment describes for ip-monitoring hold-down.

Validated as a product rather than by capping threshold, because a cap safe at a 1 ms interval overflows at a large one — any single-field bound would be either useless or arbitrary. The check uses the **doubled** form because that overflows first; a check written against the plain timeout passes pairs that still invert the grace, and has its own cell.

## Two things the tests found in my own work

**An unset field is not "no value".** My first version *skipped* validation when either field was zero, reasoning that zero means "use the default". The runtime substitutes that default (`group_state.go` assigns only when > 0), so an **unset interval with a huge threshold still overflows at run time** — and skipping accepted exactly that pair. Cell B4 caught it; the validator now models the substitution.

**The documented defaults were wrong.** `types_chassis.go` said `0=default(1000)` and `0=default(3)`; the runtime uses `DefaultHeartbeatInterval = 100ms` and `DefaultHeartbeatThreshold = 5`. Corrected — and since `pkg/cluster` imports `pkg/config`, the constants must be duplicated rather than imported, so an **agreement test in `pkg/cluster`** (which can see both) binds them. That asserts the agreement rather than pinning either side to a literal; pinning one encodes which copy you trust, and the stale comments are what that looks like when it goes wrong.

## Mutation matrix

Fix committed first. Full `pkg/config` + `pkg/cluster` per cell, no `-run` filter, rc from a file, control green first.

| # | mutation | rc | fired |
|---|---|---|---|
| B1 | revert the TTL bound to min-only | 1 | TTL wire-domain test |
| B2 | remove the product check | 1 | both product tests |
| B3 | check the plain product, dropping the ×2 | 1 | **doubling test only** — localises |
| B4 | skip validation when a field is unset | 1 | unset-interval test *(green until that test existed)* |
| B5 | drift the duplicated default 100 → 1000 | 1 | cross-package agreement test |

## Fixture defects the tests found first

Two, both of which would have made every case pass for the wrong reason:

- the cluster fixtures were being rejected by the unrelated **#6611 auth-key gate**, so nothing was reaching the check under test;
- the TTL cases ran `CompileConfig`, which does **not** invoke `SchemaValidate` — so the bound read as absent when it was present.

## Validation

`go build`, `go vet`, `gofmt` clean; `go test -count=1 ./...` green repo-wide. Tightening controls pin the shipped defaults, the Junos 3..8 threshold range, the 30 ms RETH cadence and ordinary TTLs — both validators run at commit, so an inverted comparison would reject every real config.

`pkg/config` + one `pkg/cluster` test — no dataplane, no `userspace-dp` binary or shim `.o` moved.
