### PR TITLE
config: bound flow-export template seconds at MaxDurationSeconds

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104246,3 +104246,19 @@ prose edit above them added. No diff falls in the new test body.
   scripts/deploy/test_xpf_deploy_recreate_keepalive_6762.py (new),
   docs/in-place-upgrade.md
 
+
+- **Timestamp**: 2026-08-22
+  **Action**: #6769 — bound the `services flow-monitoring` template `seconds`
+  knobs at `MaxDurationSeconds`. `template-refresh-rate seconds` was the one
+  untyped member of the trio, so a value large enough to overflow
+  `time.Duration(n) * time.Second` reached pkg/flowexport, wrapped, and became a
+  512 ns template ticker (gcd(1e9, 2^64) = 512). Three layers, one constant:
+  typed setSchema leaf, compiler-side `validateFlowExportSecondsStrict`
+  (strict-reject / lenient-warn, #1960), and `flowexport.secondsToDuration`
+  falling back at the consumer.
+  **File(s)**: pkg/config/schema_system.go,
+  pkg/config/compiler_validate_strict_observability.go,
+  pkg/config/compiler_uniformgates_sampling_appset.go,
+  pkg/config/compiler_opts.go, pkg/flowexport/manager.go,
+  pkg/config/flow_export_seconds_overflow_6769_test.go,
+  pkg/flowexport/template_seconds_overflow_6769_test.go, docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -10032,6 +10032,25 @@ the value sits in a single typed slot:
     ActiveTimeout/InactiveTimeout). The parallel `version-ipfix` pair is typed
     identically for UX parity even though it does NOT reach the wire
     (`buildFlowExportSnapshot` reads `fm.Version9` only).
+  - `services flow-monitoring version9 template <t> template-refresh-rate
+    seconds` (and the `version-ipfix` twin) — `ValidateInteger(0,
+    MaxDurationSeconds)` (**#6769**). This leaf was the one UNTYPED member of
+    the trio: its two siblings above already carried a validator, so a refresh
+    rate large enough to overflow `time.Duration(n) * time.Second` reached
+    `pkg/flowexport`, wrapped, and became a sub-second template ticker. Because
+    `gcd(1e9, 2^64) = 512` the wrapped residues are multiples of 512 ns and the
+    smallest positive one is exactly 512 ns — `seconds 20211507185753197`
+    produced a 512 ns ticker, re-exporting templates thousands of times a second
+    at every collector, and the consumer's only guard (`templateRefreshInterval`
+    rejecting `<= 0`) does not see a positive wrap. The ceiling is the
+    runtime-derived overflow point already used elsewhere in this file, NOT a
+    new policy cap ("no schema-only caps"). Two companion layers share the same
+    constant: `validateFlowExportSecondsStrict` (`pkg/config`,
+    compiler-side defense-in-depth for the tolerant load / peer-sync path and
+    direct `CompileConfig` callers, strict-reject / lenient-warn per #1960,
+    mirroring #5244) and `flowexport.secondsToDuration`, which falls back to the
+    default for an out-of-range value so a running exporter is safe even on a
+    config admitted leniently.
   - `security flow tcp-session` expanded to a container: `established-timeout`
     (Rust u64 TCPSessionTimeout), `initial-timeout`, `closing-timeout`,
     `time-wait-timeout` (config-only, not wire-reaching — see **#6539** below)

--- a/pkg/config/compiler_opts.go
+++ b/pkg/config/compiler_opts.go
@@ -1002,6 +1002,20 @@ type compileOpts struct {
 	// loaded negative rate runs safely as sample-all. Same doctrine as
 	// lenientSamplingInstanceConflicts.
 	lenientSamplingInputRate bool
+	// lenientFlowExportSeconds (#6769) downgrades the flow-export template
+	// `seconds` range gate (validateFlowExportSecondsStrict) from a hard compile
+	// error to a cfg.Warnings entry. The strict commit / commit-check path
+	// rejects a `template-refresh-rate` / `flow-active-timeout` /
+	// `flow-inactive-timeout` above MaxFlowExportSeconds, because the consumer
+	// converts with `time.Duration(n) * time.Second` and a large enough value
+	// overflows int64 and can WRAP to a sub-second interval — 20211507185753197
+	// yields a 512ns template ticker, flooding every collector. The tolerant
+	// load / peer-sync paths downgrade to a warning so an already-persisted or
+	// peer-synced config still BOOTS (#1960 no-brick); behaviour there is safe
+	// regardless, because `flowexport.secondsToDuration` falls back to the
+	// default for an out-of-range value. Same doctrine as
+	// lenientSamplingInputRate.
+	lenientFlowExportSeconds bool
 	// lenientApplicationSetMembers (#2217 Finding B) downgrades the
 	// application-set member cross-reference gate
 	// (validateApplicationSetMembersStrict) from a hard compile error to a
@@ -2350,6 +2364,7 @@ func lenientCompileOpts() compileOpts {
 		lenientFlowServerTemplateRef:           true,
 		lenientSamplingInstanceConflicts:       true,
 		lenientSamplingInputRate:               true,
+		lenientFlowExportSeconds:               true,
 		lenientApplicationSetMembers:           true,
 		lenientPolicyMatchApplications:         true,
 		lenientNATMatchApplications:            true,

--- a/pkg/config/compiler_uniformgates_sampling_appset.go
+++ b/pkg/config/compiler_uniformgates_sampling_appset.go
@@ -70,6 +70,24 @@ func runUniformGatesSamplingAppSet(tree *ConfigTree, cfg *Config, opts compileOp
 	// snapshot builder clamps rate <= 0 -> 1, so the running dataplane is
 	// safe). `0` stays valid (sample every packet). Mirrors
 	// validateSamplingInstanceConflictsStrict.
+	// #6769: flow-export template `seconds` knobs are stored by the compiler
+	// with a bare strconv.Atoi and no range check, and the consumer converts
+	// with `time.Duration(n) * time.Second`, which OVERFLOWS int64 for a large
+	// enough value and can wrap to a sub-second interval — a template-export
+	// flood at every collector. Strict on commit / commit-check; lenient on
+	// load / peer-sync (warn — #1960; `flowexport.secondsToDuration` falls back
+	// to the default independently, so the running exporter is safe either way
+	// and this gate is about the operator being TOLD rather than silently
+	// getting the default).
+	if err := validateFlowExportSecondsStrict(cfg); err != nil {
+		if opts.lenientFlowExportSeconds {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("flow-export template seconds (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	if err := validateSamplingInputRateStrict(cfg); err != nil {
 		if opts.lenientSamplingInputRate {
 			cfg.Warnings = append(cfg.Warnings,

--- a/pkg/config/compiler_validate_strict_observability.go
+++ b/pkg/config/compiler_validate_strict_observability.go
@@ -759,6 +759,107 @@ func validateSamplingInstanceConflictsStrict(cfg *Config) error {
 // config authored by a pre-guard version still BOOTS — #1960; the snapshot
 // clamp keeps the running dataplane safe). Mirrors
 // validateSamplingInstanceConflictsStrict.
+// validateFlowExportSecondsStrict hard-rejects a `services flow-monitoring`
+// template `seconds` knob whose value cannot be converted to a duration
+// (#6769).
+//
+// The compiler stores `template-refresh-rate`, `flow-active-timeout` and
+// `flow-inactive-timeout` with a bare `strconv.Atoi` and NO range check, and
+// the consumer computes `time.Duration(n) * time.Second`. For a large enough
+// n that multiply overflows int64 and WRAPS. The wrapped value can be small and
+// POSITIVE, which is the dangerous half: `templateRefreshInterval` only rejects
+// `<= 0`, so it is accepted and `time.NewTicker` fires on it.
+//
+// Because gcd(1e9, 2^64) = 512, the wrapped residues are multiples of 512 ns and
+// the smallest positive one is exactly 512 ns —
+// `template-refresh-rate seconds 20211507185753197` produces a 512 ns template
+// ticker, and 18446744074 produces 290 ms. The exporter then re-emits its
+// templates thousands of times a second at every collector.
+//
+// The ceiling is the existing MaxDurationSeconds (math.MaxInt64 / 1e9 =
+// 9223372036) — the honest runtime-derived bound this codebase already uses for
+// second-denominated leaves, NOT a new policy cap ("no schema-only caps", Codex
+// review on PR #1845).
+//
+// Three layers, one constant. `setSchema` types the leaves (#1979 Layer B), so
+// strict operator commit rejects before the compiler runs; this gate is the
+// compiler-side defense-in-depth for the paths SchemaValidate does not cover
+// (tolerant load / peer-sync / direct CompileConfig callers), exactly mirroring
+// validateSamplingInputRateStrict (#5244); and `secondsToDuration`
+// (pkg/flowexport) falls back at the consumer, so a running exporter is safe
+// regardless. This gate exists so an operator finds out at COMMIT rather than
+// discovering the knob was silently defaulted.
+//
+// Not an ambiguity — unlike the #6735 packed-tail shape, a seconds value has
+// exactly one reading and it is simply out of range, so rejecting names the
+// fault precisely rather than guessing between two intents.
+func validateFlowExportSecondsStrict(cfg *Config) error {
+	fm := cfg.Services.FlowMonitoring
+	if fm == nil {
+		return nil
+	}
+	type namedSeconds struct {
+		template string
+		leaf     string
+		value    int
+	}
+	var found []namedSeconds
+	collect := func(version string, name string, refresh, active, inactive int) {
+		for _, item := range []struct {
+			leaf  string
+			value int
+		}{
+			{"template-refresh-rate", refresh},
+			{"flow-active-timeout", active},
+			{"flow-inactive-timeout", inactive},
+		} {
+			if int64(item.value) > MaxDurationSeconds || item.value < 0 {
+				found = append(found, namedSeconds{
+					template: version + " template " + name,
+					leaf:     item.leaf,
+					value:    item.value,
+				})
+			}
+		}
+	}
+	if v9 := fm.Version9; v9 != nil {
+		names := make([]string, 0, len(v9.Templates))
+		for name := range v9.Templates {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			if t := v9.Templates[name]; t != nil {
+				collect("version9", name, t.TemplateRefreshRate, t.FlowActiveTimeout, t.FlowInactiveTimeout)
+			}
+		}
+	}
+	if ipfix := fm.VersionIPFIX; ipfix != nil {
+		names := make([]string, 0, len(ipfix.Templates))
+		for name := range ipfix.Templates {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			if t := ipfix.Templates[name]; t != nil {
+				collect("version-ipfix", name, t.TemplateRefreshRate, t.FlowActiveTimeout, t.FlowInactiveTimeout)
+			}
+		}
+	}
+	if len(found) == 0 {
+		return nil
+	}
+	f := found[0]
+	return fmt.Errorf("services flow-monitoring %s: %s is %d seconds, outside the "+
+		"accepted range 0-%d (0 = use the default). Past that ceiling `time.Duration(n) "+
+		"* time.Second` overflows int64 and WRAPS, and the wrapped value can be small "+
+		"and positive — 20211507185753197 yields a 512ns template ticker, which floods "+
+		"every collector with template re-exports. The exporter falls back to the "+
+		"default for such a value, so the number you configured would be silently "+
+		"ignored either way",
+		f.template, f.leaf, f.value, MaxDurationSeconds)
+}
+
 func validateSamplingInputRateStrict(cfg *Config) error {
 	if cfg == nil || cfg.ForwardingOptions.Sampling == nil {
 		return nil

--- a/pkg/config/flow_export_seconds_overflow_6769_test.go
+++ b/pkg/config/flow_export_seconds_overflow_6769_test.go
@@ -1,0 +1,178 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6769 — `services flow-monitoring` template `seconds` knobs were unbounded.
+//
+// The compiler stores `template-refresh-rate seconds`, `flow-active-timeout`
+// and `flow-inactive-timeout` with a bare `strconv.Atoi` and no range check.
+// pkg/flowexport then computed `time.Duration(n) * time.Second`, which
+// overflows int64 past MaxDurationSeconds (math.MaxInt64/1e9 = 9223372036) and
+// WRAPS. The wrapped product can be small and positive — the dangerous half,
+// because the consumer's only guard was `<= 0`. gcd(1e9, 2^64) = 512, so the
+// smallest positive residue is exactly 512ns: the fixture below produces a
+// 512ns template ticker, re-exporting templates thousands of times a second at
+// every collector.
+//
+// Three layers, one constant (MaxDurationSeconds):
+//   - setSchema types the leaves (#1979 Layer B) -> strict operator commit
+//     rejects before the compiler runs. Guarded by the SchemaValidate cells.
+//   - validateFlowExportSecondsStrict is the compiler-side defense-in-depth for
+//     the paths SchemaValidate does not cover (tolerant load / peer-sync,
+//     direct CompileConfig callers), mirroring #5244. Guarded by the
+//     CompileConfig / CompileConfigLenient cells, which do NOT run
+//     SchemaValidate and so isolate the gate.
+//   - flowexport.secondsToDuration falls back at the consumer (guarded in
+//     pkg/flowexport/template_seconds_overflow_6769_test.go).
+const overflowRefreshSeconds = "20211507185753197"
+
+func v9RefreshCmds(seconds string) []string {
+	return []string{
+		"set services flow-monitoring version9 template t template-refresh-rate seconds " + seconds,
+		"set forwarding-options sampling instance s input rate 1000",
+		"set forwarding-options sampling instance s family inet output flow-server 10.0.0.1 port 2055 version9 template t",
+	}
+}
+
+func ipfixRefreshCmds(seconds string) []string {
+	return []string{
+		"set services flow-monitoring version-ipfix template t template-refresh-rate seconds " + seconds,
+		"set forwarding-options sampling instance s input rate 1000",
+		"set forwarding-options sampling instance s family inet output flow-server 10.0.0.1 port 2055 version-ipfix template t",
+	}
+}
+
+// TestFlowExportRefreshOverflowRejectedAtCommit_6769: the compiler-side gate
+// hard-rejects an out-of-range v9 refresh rate. Reverting
+// validateFlowExportSecondsStrict (or unregistering it) makes this accept.
+func TestFlowExportRefreshOverflowRejectedAtCommit_6769(t *testing.T) {
+	tree := buildTreeFromSet(t, v9RefreshCmds(overflowRefreshSeconds))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted an overflowing template-refresh-rate; expected rejection")
+	}
+	for _, want := range []string{"flow-monitoring", "version9", "t", "template-refresh-rate", overflowRefreshSeconds} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+// TestFlowExportIPFIXRefreshOverflowRejectedAtCommit_6769 is the IPFIX arm.
+// The compiler parses the two template families in separate code paths, so a
+// gate that walked only Version9 would pass the v9 cell and leave this open.
+func TestFlowExportIPFIXRefreshOverflowRejectedAtCommit_6769(t *testing.T) {
+	tree := buildTreeFromSet(t, ipfixRefreshCmds(overflowRefreshSeconds))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted an overflowing IPFIX template-refresh-rate; expected rejection")
+	}
+	if !strings.Contains(err.Error(), "version-ipfix") {
+		t.Errorf("error %q does not name the version-ipfix family", err.Error())
+	}
+}
+
+// TestFlowExportTimeoutOverflowRejectedAtCommit_6769: the two timeout leaves go
+// through the same gate. They are typed in setSchema at maxWireU32 (#1979),
+// which is BELOW MaxDurationSeconds and therefore already blocks the overflow
+// at strict operator commit — but SchemaValidate does not run on the tolerant
+// load / peer-sync path or for direct CompileConfig callers, which is what this
+// cell covers.
+func TestFlowExportTimeoutOverflowRejectedAtCommit_6769(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set services flow-monitoring version9 template t flow-active-timeout " + overflowRefreshSeconds,
+		"set forwarding-options sampling instance s input rate 1000",
+		"set forwarding-options sampling instance s family inet output flow-server 10.0.0.1 port 2055 version9 template t",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted an overflowing flow-active-timeout; expected rejection")
+	}
+	if !strings.Contains(err.Error(), "flow-active-timeout") {
+		t.Errorf("error %q does not name the offending leaf", err.Error())
+	}
+}
+
+// TestFlowExportRefreshOverflowLenientWarns_6769: on the tolerant load /
+// peer-sync path the same value is downgraded to a warning so an
+// already-persisted or peer-synced config authored by a pre-guard version still
+// BOOTS (#1960). The running exporter is safe regardless because
+// flowexport.secondsToDuration falls back independently.
+func TestFlowExportRefreshOverflowLenientWarns_6769(t *testing.T) {
+	tree := buildTreeFromSet(t, v9RefreshCmds(overflowRefreshSeconds))
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must NOT hard-reject an overflowing refresh rate: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "flow-export template seconds") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("lenient compile must emit a downgraded warning; warnings=%v", cfg.Warnings)
+	}
+}
+
+// TestFlowExportSaneSecondsAccepted_6769 is the negative control. An ordinary
+// configuration must compile cleanly AND store the values unchanged — a gate
+// that rejected too much, or a "fix" that clamped every value, fails here. The
+// ceiling itself is in range (it is the last value that does not overflow).
+func TestFlowExportSaneSecondsAccepted_6769(t *testing.T) {
+	for _, seconds := range []string{"0", "60", "300", "9223372036"} {
+		tree := buildTreeFromSet(t, v9RefreshCmds(seconds))
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("CompileConfig rejected an in-range template-refresh-rate %s: %v", seconds, err)
+		}
+		fm := cfg.Services.FlowMonitoring
+		if fm == nil || fm.Version9 == nil || fm.Version9.Templates["t"] == nil {
+			t.Fatalf("template t missing after compiling refresh rate %s", seconds)
+		}
+		got := fm.Version9.Templates["t"].TemplateRefreshRate
+		if want := atoiOrFatal(t, seconds); got != want {
+			t.Errorf("TemplateRefreshRate = %d, want %d (an in-range value must be stored unchanged)", got, want)
+		}
+	}
+}
+
+// TestFlowExportRefreshSecondsIsTypedInSchema_6769 binds the SCHEMA layer.
+// `template-refresh-rate seconds` was the one untyped member of the trio (its
+// two siblings already carried ValidateInteger), so SchemaValidate — the gate
+// that runs at strict operator commit BEFORE the compiler — passed it through.
+// Dropping the validator from setSchema reds here while every CompileConfig
+// cell above still passes, which is why this cell exists separately.
+func TestFlowExportRefreshSecondsIsTypedInSchema_6769(t *testing.T) {
+	for _, family := range []string{"version9", "version-ipfix"} {
+		bad := buildTreeFromSet(t, []string{
+			"set services flow-monitoring " + family + " template t template-refresh-rate seconds " + overflowRefreshSeconds,
+		})
+		if err := SchemaValidate(bad, nil); err == nil {
+			t.Errorf("%s: SchemaValidate accepted an overflowing template-refresh-rate seconds; "+
+				"the leaf must be typed so strict operator commit rejects before the compiler runs", family)
+		}
+		good := buildTreeFromSet(t, []string{
+			"set services flow-monitoring " + family + " template t template-refresh-rate seconds 60",
+		})
+		if err := SchemaValidate(good, nil); err != nil {
+			t.Errorf("%s: SchemaValidate rejected an ordinary 60s refresh rate: %v", family, err)
+		}
+	}
+}
+
+func atoiOrFatal(t *testing.T, s string) int {
+	t.Helper()
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			t.Fatalf("non-numeric fixture %q", s)
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}

--- a/pkg/config/flow_export_seconds_overflow_6769_test.go
+++ b/pkg/config/flow_export_seconds_overflow_6769_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -138,6 +139,36 @@ func TestFlowExportSaneSecondsAccepted_6769(t *testing.T) {
 		if want := atoiOrFatal(t, seconds); got != want {
 			t.Errorf("TemplateRefreshRate = %d, want %d (an in-range value must be stored unchanged)", got, want)
 		}
+	}
+}
+
+// TestFlowExportCeilingBoundaryIsExact_6769 pins the bound itself, in BOTH
+// directions. The mutation matrix for this change loosened the comparison to
+// `> MaxDurationSeconds+1` and every other cell stayed green: the ceiling was
+// accepted and a huge value rejected, but the first value PAST the ceiling was
+// exercised by nothing, so the bound could drift upward undetected. It is not a
+// cosmetic drift — MaxDurationSeconds+1 is precisely the smallest value whose
+// `time.Duration(n) * time.Second` overflows int64.
+func TestFlowExportCeilingBoundaryIsExact_6769(t *testing.T) {
+	const ceiling = MaxDurationSeconds // 9223372036
+	accept := strconv.FormatInt(ceiling, 10)
+	reject := strconv.FormatInt(ceiling+1, 10)
+
+	if _, err := CompileConfig(buildTreeFromSet(t, v9RefreshCmds(accept))); err != nil {
+		t.Errorf("CompileConfig rejected the ceiling %s, which does NOT overflow: %v", accept, err)
+	}
+	_, err := CompileConfig(buildTreeFromSet(t, v9RefreshCmds(reject)))
+	if err == nil {
+		t.Fatalf("CompileConfig accepted %s — one past the ceiling, and the smallest value "+
+			"whose nanosecond conversion overflows int64", reject)
+	}
+	if !strings.Contains(err.Error(), reject) {
+		t.Errorf("error %q does not name the offending value", err.Error())
+	}
+	if err := SchemaValidate(buildTreeFromSet(t, []string{
+		"set services flow-monitoring version9 template t template-refresh-rate seconds " + reject,
+	}), nil); err == nil {
+		t.Errorf("SchemaValidate accepted %s — the typed leaf's ceiling must be exact too", reject)
 	}
 }
 

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -724,8 +724,18 @@ var schemaServices = &schemaNode{desc: "Services configuration", children: map[s
 				"flow-inactive-timeout": {desc: "Inactive flow export timeout in seconds (default 15)", args: 1, placeholder: "<seconds>",
 					valueType: ValueInteger, valueDesc: "Inactive flow export timeout in seconds (0..4294967295)",
 					valueExamples: []string{"15"}, validator: ValidateInteger(0, maxWireU32), children: nil},
+				// #6769: typed at MaxDurationSeconds. This leaf was the one
+				// untyped member of the trio — its two siblings above already
+				// carry ValidateInteger — so a `seconds` value large enough to
+				// overflow `time.Duration(n) * time.Second` reached
+				// pkg/flowexport, wrapped, and became a SUB-SECOND template
+				// ticker (20211507185753197 -> 512ns) that re-exports templates
+				// thousands of times a second at every collector. The ceiling is
+				// the runtime-derived overflow point, not a policy cap.
 				"template-refresh-rate": {desc: "Interval between template re-exports", children: map[string]*schemaNode{
-					"seconds": {desc: "Template refresh interval in seconds (default 60)", args: 1, placeholder: "<seconds>", children: nil},
+					"seconds": {desc: "Template refresh interval in seconds (default 60)", args: 1, placeholder: "<seconds>",
+						valueType: ValueInteger, valueDesc: "Template refresh interval in seconds (0..9223372036; 0 = default 60)",
+						valueExamples: []string{"60"}, validator: ValidateInteger(0, MaxDurationSeconds), children: nil},
 				}},
 			}},
 		}},
@@ -743,8 +753,18 @@ var schemaServices = &schemaNode{desc: "Services configuration", children: map[s
 				"flow-inactive-timeout": {desc: "Inactive flow export timeout in seconds (default 15)", args: 1, placeholder: "<seconds>",
 					valueType: ValueInteger, valueDesc: "Inactive flow export timeout in seconds (0..4294967295)",
 					valueExamples: []string{"15"}, validator: ValidateInteger(0, maxWireU32), children: nil},
+				// #6769: typed at MaxDurationSeconds. This leaf was the one
+				// untyped member of the trio — its two siblings above already
+				// carry ValidateInteger — so a `seconds` value large enough to
+				// overflow `time.Duration(n) * time.Second` reached
+				// pkg/flowexport, wrapped, and became a SUB-SECOND template
+				// ticker (20211507185753197 -> 512ns) that re-exports templates
+				// thousands of times a second at every collector. The ceiling is
+				// the runtime-derived overflow point, not a policy cap.
 				"template-refresh-rate": {desc: "Interval between template re-exports", children: map[string]*schemaNode{
-					"seconds": {desc: "Template refresh interval in seconds (default 60)", args: 1, placeholder: "<seconds>", children: nil},
+					"seconds": {desc: "Template refresh interval in seconds (default 60)", args: 1, placeholder: "<seconds>",
+						valueType: ValueInteger, valueDesc: "Template refresh interval in seconds (0..9223372036; 0 = default 60)",
+						valueExamples: []string{"60"}, validator: ValidateInteger(0, MaxDurationSeconds), children: nil},
 				}},
 				"ipv4-template": {desc: "IPv4 flow record template options", children: map[string]*schemaNode{
 					"export-extension": {desc: "Export extension (accepted; not applied to IPFIX records)", args: 1, placeholder: "<extension>", children: nil},

--- a/pkg/flowexport/manager.go
+++ b/pkg/flowexport/manager.go
@@ -274,6 +274,42 @@ type templateContext struct {
 // defaultTemplateContext is the timeout/refresh fallback used for a
 // collector that referenced no template and when a referenced template
 // name has no matching definition that overrides a field.
+// #6769: the accepted range for the flow-export `seconds` knobs is
+// config.MaxDurationSeconds — the same constant the schema typed leaves and the
+// commit-time gate (validateFlowExportSecondsStrict) use, so no two layers can
+// disagree about where the ceiling is.
+//
+// The defect the bound exists for: the compiler stores these as a plain `int`
+// from `strconv.Atoi` with NO range check, and this file computed
+// `time.Duration(n) * time.Second`. For a large enough n that multiply overflows
+// int64 and WRAPS, and the wrapped value can be small and POSITIVE — which is
+// the dangerous half, because `templateRefreshInterval` only rejects `<= 0`.
+//
+// gcd(1e9, 2^64) = 512, so the wrapped residues are multiples of 512 ns and the
+// smallest positive one is exactly 512 ns: `template-refresh-rate seconds
+// 20211507185753197` yields a 512 ns ticker, and 18446744074 yields 290 ms. The
+// exporter then re-emits its templates thousands of times a second at every
+// collector — a self-inflicted flood, and the reason this is a security issue
+// rather than a cosmetic one.
+
+// secondsToDuration converts a config `seconds` value, falling back for
+// anything outside the accepted range.
+//
+// It replaces `if n > 0 { d = time.Duration(n) * time.Second }` at all three
+// sites. Behaviour for a sane value is identical; what changes is that an
+// out-of-range value now yields the DEFAULT instead of an overflowed one.
+//
+// Falling back rather than clamping to the maximum is deliberate: a value this
+// far out of range is not an operator asking for 24h, it is a typo or a hostile
+// config, and silently honouring it as "the largest thing we allow" would be
+// inventing an intent. The default is what an absent knob already means.
+func secondsToDuration(seconds int, fallback time.Duration) time.Duration {
+	if seconds <= 0 || int64(seconds) > config.MaxDurationSeconds {
+		return fallback
+	}
+	return time.Duration(seconds) * time.Second
+}
+
 func defaultTemplateContext() templateContext {
 	return templateContext{
 		activeTimeout:   60 * time.Second,
@@ -289,15 +325,11 @@ func v9TemplateContext(tmpl *config.NetFlowV9Template) templateContext {
 	if tmpl == nil {
 		return tc
 	}
-	if tmpl.FlowActiveTimeout > 0 {
-		tc.activeTimeout = time.Duration(tmpl.FlowActiveTimeout) * time.Second
-	}
-	if tmpl.FlowInactiveTimeout > 0 {
-		tc.inactiveTimeout = time.Duration(tmpl.FlowInactiveTimeout) * time.Second
-	}
-	if tmpl.TemplateRefreshRate > 0 {
-		tc.refreshRate = time.Duration(tmpl.TemplateRefreshRate) * time.Second
-	}
+	// #6769: range-checked. An untyped seconds value large enough to overflow
+	// `time.Duration(n) * time.Second` used to wrap into a sub-second ticker.
+	tc.activeTimeout = secondsToDuration(tmpl.FlowActiveTimeout, tc.activeTimeout)
+	tc.inactiveTimeout = secondsToDuration(tmpl.FlowInactiveTimeout, tc.inactiveTimeout)
+	tc.refreshRate = secondsToDuration(tmpl.TemplateRefreshRate, tc.refreshRate)
 	for _, ext := range tmpl.ExportExtensions {
 		if ext == "flow-dir" {
 			// #3270: flow-dir is applied again, derived in Go from the per-zone
@@ -318,15 +350,11 @@ func ipfixTemplateContext(tmpl *config.NetFlowIPFIXTemplate) templateContext {
 	if tmpl == nil {
 		return tc
 	}
-	if tmpl.FlowActiveTimeout > 0 {
-		tc.activeTimeout = time.Duration(tmpl.FlowActiveTimeout) * time.Second
-	}
-	if tmpl.FlowInactiveTimeout > 0 {
-		tc.inactiveTimeout = time.Duration(tmpl.FlowInactiveTimeout) * time.Second
-	}
-	if tmpl.TemplateRefreshRate > 0 {
-		tc.refreshRate = time.Duration(tmpl.TemplateRefreshRate) * time.Second
-	}
+	// #6769: range-checked. An untyped seconds value large enough to overflow
+	// `time.Duration(n) * time.Second` used to wrap into a sub-second ticker.
+	tc.activeTimeout = secondsToDuration(tmpl.FlowActiveTimeout, tc.activeTimeout)
+	tc.inactiveTimeout = secondsToDuration(tmpl.FlowInactiveTimeout, tc.inactiveTimeout)
+	tc.refreshRate = secondsToDuration(tmpl.TemplateRefreshRate, tc.refreshRate)
 	for _, ext := range tmpl.ExportExtensions {
 		if ext == "flow-dir" {
 			tc.includeFlowDir = true

--- a/pkg/flowexport/template_seconds_overflow_6769_test.go
+++ b/pkg/flowexport/template_seconds_overflow_6769_test.go
@@ -1,0 +1,177 @@
+package flowexport
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6769 — a flow-export template `seconds` knob large enough to overflow
+// `time.Duration(n) * time.Second` used to WRAP into a sub-second interval.
+//
+// The three knobs (`template-refresh-rate seconds`, `flow-active-timeout`,
+// `flow-inactive-timeout`) are stored by the compiler as a plain int from
+// `strconv.Atoi`. This package then computed `time.Duration(n) * time.Second`.
+// int64 nanoseconds overflow past math.MaxInt64/1e9 = 9223372036 seconds, and
+// the wrapped product can be small and POSITIVE — the dangerous half, because
+// `templateRefreshInterval` only rejects `<= 0`, so `time.NewTicker` happily
+// fires on it and the exporter re-emits its templates thousands of times a
+// second at every collector.
+//
+// gcd(1e9, 2^64) = 512, so wrapped residues are multiples of 512ns and the
+// smallest positive one is exactly 512ns. overflowSeconds below is the value
+// that produces it.
+const overflowSeconds = 20211507185753197
+
+// TestOverflowFixtureActuallyWraps_6769 is the non-vacuity guard for every
+// other cell in this file: it proves the fixture value is a REAL overflow that
+// lands positive and sub-second, not merely a large number. If someone edits
+// overflowSeconds to something that no longer wraps, the range-check cells
+// below would still pass while testing nothing — this cell fails instead.
+func TestOverflowFixtureActuallyWraps_6769(t *testing.T) {
+	if overflowSeconds <= config.MaxDurationSeconds {
+		t.Fatalf("fixture %d is within MaxDurationSeconds (%d); it cannot overflow and the "+
+			"other cells in this file would be vacuous", overflowSeconds, config.MaxDurationSeconds)
+	}
+	// Via a variable, not a constant expression: Go rejects the constant form at
+	// compile time. That is itself part of the story — the value only reaches
+	// this multiply at RUNTIME, as an int the compiler read with strconv.Atoi,
+	// which is precisely why nothing caught it.
+	n := overflowSeconds
+	wrapped := time.Duration(n) * time.Second
+	if wrapped <= 0 {
+		t.Fatalf("fixture wraps to %v; the cells here guard the POSITIVE wrap (the one "+
+			"templateRefreshInterval's `<= 0` check does not catch)", wrapped)
+	}
+	if wrapped >= time.Second {
+		t.Fatalf("fixture wraps to %v, not a sub-second interval; pick a value whose residue "+
+			"is small or the flood scenario is not reproduced", wrapped)
+	}
+	if wrapped != 512*time.Nanosecond {
+		t.Errorf("fixture wraps to %v, want 512ns (gcd(1e9, 2^64) = 512)", wrapped)
+	}
+	if config.MaxDurationSeconds != int64(math.MaxInt64)/int64(time.Second) {
+		t.Errorf("MaxDurationSeconds = %d, want math.MaxInt64/1e9 — the ceiling must stay the "+
+			"runtime-derived overflow point, not a policy cap", config.MaxDurationSeconds)
+	}
+}
+
+// TestV9TemplateContextRejectsOverflowSeconds_6769: all three v9 knobs fall
+// back to their defaults for an out-of-range value. Reverting secondsToDuration
+// to `if n > 0 { d = time.Duration(n) * time.Second }` makes each of these 512ns.
+func TestV9TemplateContextRejectsOverflowSeconds_6769(t *testing.T) {
+	tc := v9TemplateContext(&config.NetFlowV9Template{
+		TemplateRefreshRate: overflowSeconds,
+		FlowActiveTimeout:   overflowSeconds,
+		FlowInactiveTimeout: overflowSeconds,
+	})
+	if tc.refreshRate != 60*time.Second {
+		t.Errorf("refreshRate = %v, want 60s (out-of-range value must fall back to the default)", tc.refreshRate)
+	}
+	if tc.activeTimeout != 60*time.Second {
+		t.Errorf("activeTimeout = %v, want 60s", tc.activeTimeout)
+	}
+	if tc.inactiveTimeout != 15*time.Second {
+		t.Errorf("inactiveTimeout = %v, want 15s", tc.inactiveTimeout)
+	}
+}
+
+// TestIPFIXTemplateContextRejectsOverflowSeconds_6769 is the IPFIX arm. Both
+// template families carry an independent copy of the conversion, so a fix
+// applied to only one of them leaves the other wrapping.
+func TestIPFIXTemplateContextRejectsOverflowSeconds_6769(t *testing.T) {
+	tc := ipfixTemplateContext(&config.NetFlowIPFIXTemplate{
+		TemplateRefreshRate: overflowSeconds,
+		FlowActiveTimeout:   overflowSeconds,
+		FlowInactiveTimeout: overflowSeconds,
+	})
+	if tc.refreshRate != 60*time.Second {
+		t.Errorf("refreshRate = %v, want 60s", tc.refreshRate)
+	}
+	if tc.activeTimeout != 60*time.Second {
+		t.Errorf("activeTimeout = %v, want 60s", tc.activeTimeout)
+	}
+	if tc.inactiveTimeout != 15*time.Second {
+		t.Errorf("inactiveTimeout = %v, want 15s", tc.inactiveTimeout)
+	}
+}
+
+// TestSaneTemplateSecondsUnchanged_6769 is the negative control: an ordinary
+// configuration must be converted exactly as before. A "fix" that clamped
+// everything, or that fell back on any non-default value, fails here.
+func TestSaneTemplateSecondsUnchanged_6769(t *testing.T) {
+	tc := v9TemplateContext(&config.NetFlowV9Template{
+		TemplateRefreshRate: 300,
+		FlowActiveTimeout:   120,
+		FlowInactiveTimeout: 30,
+	})
+	if tc.refreshRate != 300*time.Second {
+		t.Errorf("refreshRate = %v, want 300s (a valid value must pass through unchanged)", tc.refreshRate)
+	}
+	if tc.activeTimeout != 120*time.Second {
+		t.Errorf("activeTimeout = %v, want 120s", tc.activeTimeout)
+	}
+	if tc.inactiveTimeout != 30*time.Second {
+		t.Errorf("inactiveTimeout = %v, want 30s", tc.inactiveTimeout)
+	}
+	// The boundary itself is in range and must NOT be rejected.
+	tcMax := v9TemplateContext(&config.NetFlowV9Template{TemplateRefreshRate: int(config.MaxDurationSeconds)})
+	if tcMax.refreshRate != time.Duration(config.MaxDurationSeconds)*time.Second {
+		t.Errorf("refreshRate at the ceiling = %v, want the converted ceiling; the bound is "+
+			"inclusive because that value does not overflow", tcMax.refreshRate)
+	}
+}
+
+// TestResolveV9TemplateGroupsDoesNotShipAWrappedRefresh_6769 binds the WIRING:
+// it drives the production resolver a manager uses to build ExportConfigs, so
+// deleting the secondsToDuration call from v9TemplateContext (rather than
+// breaking secondsToDuration itself) reds here.
+//
+// The tolerant load / peer-sync path is exactly how such a value reaches this
+// code in practice: strict commit now rejects it, but an already-persisted or
+// peer-synced config authored by a pre-guard version is admitted with a warning
+// (#1960), and the running exporter must still be safe.
+func TestResolveV9TemplateGroupsDoesNotShipAWrappedRefresh_6769(t *testing.T) {
+	svc := &config.ServicesConfig{
+		FlowMonitoring: &config.FlowMonitoringConfig{
+			Version9: &config.NetFlowV9Config{
+				Templates: map[string]*config.NetFlowV9Template{
+					"poisoned": {Name: "poisoned", TemplateRefreshRate: overflowSeconds},
+				},
+			},
+		},
+	}
+	fo := &config.ForwardingOptionsConfig{
+		Sampling: &config.SamplingConfig{
+			Instances: map[string]*config.SamplingInstance{
+				"alpha": {
+					Name:      "alpha",
+					InputRate: 1,
+					FamilyInet: &config.SamplingFamily{
+						FlowServers: []*config.FlowServer{{
+							Address:          "10.0.0.1",
+							Port:             2055,
+							Version:          config.FlowServerVersion9,
+							Version9Template: "poisoned",
+						}},
+					},
+				},
+			},
+		},
+	}
+	groups := ResolveV9TemplateGroups(svc, fo)
+	if len(groups) != 1 {
+		t.Fatalf("got %d export groups, want 1", len(groups))
+	}
+	got := groups[0].TemplateRefreshRate
+	if got != 60*time.Second {
+		t.Fatalf("shipped TemplateRefreshRate = %v, want 60s; a sub-second refresh floods the "+
+			"collector with template re-exports", got)
+	}
+	// And the value the exporter's ticker would actually use.
+	if eff := templateRefreshInterval(got); eff < time.Second {
+		t.Errorf("effective ticker interval = %v (sub-second)", eff)
+	}
+}

--- a/pkg/flowexport/template_seconds_overflow_6769_test.go
+++ b/pkg/flowexport/template_seconds_overflow_6769_test.go
@@ -124,6 +124,21 @@ func TestSaneTemplateSecondsUnchanged_6769(t *testing.T) {
 	}
 }
 
+// TestConsumerCeilingBoundaryIsExact_6769 is the consumer-side twin of
+// TestFlowExportCeilingBoundaryIsExact_6769: the ceiling converts, the first
+// value past it falls back. Without this cell the comparison could be loosened
+// by one and nothing would notice.
+func TestConsumerCeilingBoundaryIsExact_6769(t *testing.T) {
+	ceiling := int(config.MaxDurationSeconds)
+	if got := secondsToDuration(ceiling, 60*time.Second); got != time.Duration(ceiling)*time.Second {
+		t.Errorf("secondsToDuration(ceiling) = %v, want the converted ceiling — it does not overflow", got)
+	}
+	if got := secondsToDuration(ceiling+1, 60*time.Second); got != 60*time.Second {
+		t.Errorf("secondsToDuration(ceiling+1) = %v, want the 60s fallback; ceiling+1 is the "+
+			"smallest value whose nanosecond conversion overflows int64", got)
+	}
+}
+
 // TestResolveV9TemplateGroupsDoesNotShipAWrappedRefresh_6769 binds the WIRING:
 // it drives the production resolver a manager uses to build ExportConfigs, so
 // deleting the secondsToDuration call from v9TemplateContext (rather than


### PR DESCRIPTION
Closes #6769

## What was wrong

`services flow-monitoring … template-refresh-rate seconds` was the one untyped
member of a trio of second-denominated leaves. Its siblings `flow-active-timeout`
and `flow-inactive-timeout` already carried `ValidateInteger(0, maxWireU32)` from
#1979; the refresh rate had no `valueType` and no validator at all. The compiler
stored it with a bare `strconv.Atoi` and `pkg/flowexport` converted it with
`time.Duration(n) * time.Second`.

That multiply is int64 nanoseconds, so it overflows past `math.MaxInt64 / 1e9 =
9223372036` seconds and **wraps**. The wrapped product can be small and
**positive**, which is the dangerous half: the consumer's only guard,
`templateRefreshInterval`, rejects `<= 0` and nothing else, so `time.NewTicker`
fires on it. Because `gcd(1e9, 2^64) = 512` the wrapped residues are multiples of
512 ns and the smallest positive one is exactly 512 ns — `seconds
20211507185753197` produced a **512 ns template ticker**, re-exporting the
template thousands of times a second at every configured collector.

Reproduced end to end before writing the fix: an exporter built from that config
reported `refreshRate=512ns effective_ticker=512ns`.

## Cites re-derived

The issue body carries no evidence — its Evidence and Fix direction sections are
pointers to `/tmp/opus-review-001.md`, which no longer exists. **Every claim here
was located by SYMBOL and re-derived at current master**, not from the cited
ranges.

## The fix — three layers, one constant

The ceiling is the existing `MaxDurationSeconds`, documented in
`schema_validators.go` as "the largest second count that survives
`time.Duration(n) * time.Second` without int64 overflow" and already used for
`hold-down` and the tcp-session timeouts. Deliberately **not** a new policy cap
such as 24h — this codebase settled on runtime-derived bounds ("no schema-only
caps", Codex review on PR #1845), and a policy cap would reject configurations
that work today.

| layer | file | behaviour |
|---|---|---|
| typed leaf | `pkg/config/schema_system.go` | strict operator commit rejects before the compiler runs (both `version9` and `version-ipfix`) |
| compiler gate | `validateFlowExportSecondsStrict` | covers what `SchemaValidate` does not — tolerant load, peer-sync, direct `CompileConfig` callers. Strict reject / lenient warn per #1960, mirroring `validateSamplingInputRateStrict` (#5244) |
| consumer | `flowexport.secondsToDuration` | falls back to the default at all six conversion sites (three knobs × two template families), so a running exporter is safe even on a leniently-admitted config |

Falling back rather than clamping to the ceiling is deliberate: a value this far
out of range is a typo or a hostile config, not an operator asking for 292 years,
and honouring it as "the largest thing we allow" would be inventing an intent.

## Mutation matrix

Cells restore verbatim pre-fix bytes; each was verified applied (`git diff
--stat` non-empty) and each ran the full `pkg/config` + `pkg/flowexport` suites,
not a `-run` filter.

| cell | mutation | result | assertion that fired |
|---|---|---|---|
| schema | drop the validator from both `template-refresh-rate seconds` leaves | **RED** | `TestFlowExportRefreshSecondsIsTypedInSchema_6769` |
| gate | unregister `validateFlowExportSecondsStrict` from the uniform gates | **RED** | all four compiler cells + the repo's own `TestEveryStrictCommitGateIsWired` |
| consumer | revert `secondsToDuration` to `if n > 0` | **RED** | v9 / IPFIX context cells (`activeTimeout = 512ns`) + the resolver cell |
| v9only | make the gate walk `Version9` only | **RED** | `TestFlowExportIPFIXRefreshOverflowRejectedAtCommit_6769` |
| wiring_v9 | delete the `secondsToDuration` calls from `v9TemplateContext`, leaving the function intact | **RED** | `TestResolveV9TemplateGroupsDoesNotShipAWrappedRefresh_6769` — `shipped TemplateRefreshRate = 512ns` |
| tighten | loosen the bound to `> MaxDurationSeconds+1` | **GREEN → fixed** | see below |

The `tighten` cell stayed green: the ceiling was covered and a wildly
out-of-range value was covered, but the first value *past* the ceiling was
exercised by nothing, so the bound could drift upward undetected. `MaxDurationSeconds+1`
is exactly the smallest value whose conversion overflows, so that is the boundary
the change exists to draw. The second commit adds a boundary cell per layer,
asserting both directions; re-running the loosening mutation now reds both
(`CompileConfig accepted 9223372037`, `secondsToDuration(ceiling+1) =
-2562047h47m16.709551616s`).

## Docs

`docs/config-schema.md` #1979 Layer B section documents the new typed leaf, the
overflow arithmetic, and the two companion layers.

## Notes for the fold gate

Go-only change (`pkg/config`, `pkg/flowexport`, docs). Does not touch
cluster / VRRP / session-sync / failover code, and does not move the
`userspace-dp` binary or the shim `.o`.

`go test -count=1 ./...` green at `6b6e34b4e`.