### PR TITLE
config: register six more duplicate containers in the #5180 gate

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104279,3 +104279,14 @@ prose edit above them added. No diff falls in the new test body.
   to `trigger`, `on` and `until`.
 - **File(s)**: pkg/config/compiler_services.go,
   pkg/config/event_trigger_duplicate_6771_test.go
+
+- **Timestamp**: 2026-08-22
+  **Action**: #6768 — turn the #5180 duplicate-named-block gate into a registry
+  and add six containers derived from the predicate "a container authorable
+  twice hierarchically whose compile silently loses config the flat spelling
+  merges": security log stream/profile (last-writer-wins), protocols bgp group
+  (split instances), services flow-monitoring/rpm/ip-monitoring (FindChild
+  first-wins). Per-container effect messages replace the single sentence that
+  said "earlier block dropped" for every mode — backwards for a first-wins read.
+  **File(s)**: pkg/config/dup_named_blocks.go,
+  pkg/config/duplicate_container_6768_test.go, docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -692,6 +692,62 @@ Deliberately NOT applied to `system login class`: #6838 already made the class
 cohort reader-independent by folding permissions across the whole same-named
 set, and a merge here would fight that design.
 
+### Duplicate containers beyond the original four (#6768)
+
+The #5180 gate started as four hand-written copies of one walk. #6768 turned
+the walk into a registry — `namedDupRules` / `singletonDupRules` in
+`pkg/config/dup_named_blocks.go` — so adding a container is one row and the
+strict gate, the lenient warning, and the #6455 group-expanded re-run all pick
+it up without any of the three being edited. `groups` and `interfaces` keep
+bespoke walks: their name extraction (a merged two-key head) and skip rules
+(the non-interface keyword allowlist) genuinely differ, and folding them into
+the table would mean inventing hooks for two callers.
+
+The rows added were derived from a PREDICATE, not from the effects the issue
+named: *a container that can be authored more than once as a hierarchical
+sibling, and whose compile silently loses configuration the FLAT `set` spelling
+would have merged.* `tree.SetPath` collapses a repeated flat statement onto one
+node, so a duplicate CONTAINER sibling is reachable only from the hierarchical
+shape — which is exactly the dual-AST-equivalence invariant #5180 exists to
+enforce. Six sites matched, in three distinct loss modes:
+
+| container | loss mode | measured effect |
+|---|---|---|
+| `security log stream <n>` | last-writer-wins (`Streams[name] = stream`) | a stream authored `transport { protocol tls; }` in the first block and `severity info` in the second compiles with severity=info and NO transport — a TLS syslog stream silently reverts to plain syslog |
+| `security log profile <n>` | last-writer-wins (`Profiles[name] = p`) | `stream-name` and `default-profile` from the first block both vanish; the profile is left bound to nothing |
+| `protocols bgp group <n>` | split instances (per-instance locals) | `group g { peer-as 65001; export P; }` + `group g { neighbor N; }` compiles N with `peerAS=0` and `export=[]`; only the peer-as half warns |
+| `services flow-monitoring` | first-wins (`FindChild`) | the whole second block is ignored — a `version-ipfix` half authored after a `version9` half never exists |
+| `services rpm` | first-wins (`FindChild`) | every probe in the second block disappears |
+| `services ip-monitoring` | first-wins (`FindChild`) | every policy in the second block disappears, with zero warnings |
+
+Three of the six are the effects the issue named; the other three came from the
+predicate. `services application-identification` is deliberately excluded — it
+is a presence flag, so a repeat loses nothing, and a gate that rejected every
+repeated sibling would break configurations that are fine.
+
+Two side notes worth keeping:
+
+- The message is now per-container. The original single sentence said the
+  EARLIER block is dropped, which is true for a last-writer-wins map store and
+  exactly backwards for a `FindChild` first-sibling-only read; it would have
+  sent an operator to delete the surviving block. `dupEffectStrict` /
+  `dupEffectLenient` render the truth for each mode. The pre-existing
+  ids-option FAMILY check was mislabelled the same way and is corrected to
+  first-wins, which is what `compileScreen` actually does.
+- A duplicate can BLIND another gate. With the BGP blocks duplicated the export
+  policy never reaches the neighbour, so the existing undefined-`policy-statement`
+  cross-reference gate has nothing to check and stays silent; the same config
+  authored once is correctly rejected when the policy is undefined.
+
+**Gate only, no fold.** #6992 folded `system login user` because two READERS
+picked different blocks — a credential authored under a VIEW-only block could
+authenticate into a super-user CLI — and a fold was the only way to remove that
+divergence. There is no divergent reader here; the loss is a plain silent drop,
+the shape `groups` / `interfaces` / `screen ids-option` are already handled
+with, so the gate alone is the matching remedy. Strict rejects on commit /
+commit-check; the tolerant load / peer-sync path warns and boots (#1960), where
+the historical result is preserved unchanged.
+
 ### Duplicate NAT rule name (#5649, C181-M18)
 
 NAT rule-sets are ordered, first-match tables keyed by rule name, so a rule's

--- a/pkg/config/dup_named_blocks.go
+++ b/pkg/config/dup_named_blocks.go
@@ -32,8 +32,9 @@ var screenIDSFamily = map[string]bool{
 
 // dupBlock is one detected duplicate authored hierarchical named block.
 type dupBlock struct {
-	kind string // human category, e.g. "interface" / "screen ids-option"
-	name string // the duplicated name
+	kind   string // human category, e.g. "interface" / "screen ids-option"
+	name   string // the duplicated name
+	effect dupContainerEffect
 }
 
 // validateDuplicateNamedBlockAST rejects (strict) or warns (lenient) when the
@@ -114,7 +115,7 @@ func validateDuplicateNamedBlockAST(tree *ConfigTree, lenient bool) ([]string, e
 			}
 			if seenGroup[name] {
 				if !reportedGroup[name] {
-					dups = append(dups, dupBlock{"group", name})
+					dups = append(dups, dupBlock{"group", name, dupEffectLastWins})
 					reportedGroup[name] = true
 				}
 			} else {
@@ -149,7 +150,7 @@ func validateDuplicateNamedBlockAST(tree *ConfigTree, lenient bool) ([]string, e
 			}
 			if seenIf[name] {
 				if !reportedIf[name] {
-					dups = append(dups, dupBlock{"interface", name})
+					dups = append(dups, dupBlock{"interface", name, dupEffectLastWins})
 					reportedIf[name] = true
 				}
 			} else {
@@ -158,11 +159,47 @@ func validateDuplicateNamedBlockAST(tree *ConfigTree, lenient bool) ([]string, e
 		}
 	}
 
-	// 3. security { screen { ids-option <name> { … } } } — duplicate profile
-	// names AND duplicate same-family blocks within one profile. Union across
-	// every top-level `security` stanza and every `screen` block therein.
-	seenProfile := map[string]bool{}
-	reportedProfile := map[string]bool{}
+	// 3. Table-driven named containers (namedDupRules). This replaces two
+	// hand-written copies of the same walk (screen ids-option, login user) and
+	// carries the six #6768 rows on the same code path, so a container added to
+	// the registry is covered by the strict gate, the lenient warning, and the
+	// #6455 group-expanded re-run without any of the three being edited.
+	// Union across every top-level stanza and every intermediate container
+	// therein, matching what the hand-written walks did.
+	for _, rule := range namedDupRules {
+		seen := map[string]bool{}
+		reported := map[string]bool{}
+		for _, child := range tree.Children {
+			if child.Name() != rule.stanza {
+				continue
+			}
+			holders := []*Node{child}
+			if rule.inner != "" {
+				holders = child.FindChildren(rule.inner)
+			}
+			for _, holder := range holders {
+				for _, inst := range namedInstances(holder.FindChildren(rule.keyword)) {
+					if inst.name == "" {
+						recordEmpty(rule.kind)
+						continue
+					}
+					if seen[inst.name] {
+						if !reported[inst.name] {
+							dups = append(dups, dupBlock{rule.kind, inst.name, rule.effect})
+							reported[inst.name] = true
+						}
+						continue
+					}
+					seen[inst.name] = true
+				}
+			}
+		}
+	}
+
+	// 3b. Duplicate ids-option FAMILY block within ONE profile. This is not a
+	// named container — the duplicate is the family keyword itself — so it
+	// keeps its own walk. compileScreen reads each family with FindChild, so a
+	// repeat is first-sibling-only, not last-writer-wins.
 	for _, child := range tree.Children {
 		if child.Name() != "security" {
 			continue
@@ -170,18 +207,8 @@ func validateDuplicateNamedBlockAST(tree *ConfigTree, lenient bool) ([]string, e
 		for _, screen := range child.FindChildren("screen") {
 			for _, inst := range namedInstances(screen.FindChildren("ids-option")) {
 				if inst.name == "" {
-					recordEmpty("screen ids-option")
-					continue
+					continue // already recorded by the table walk above
 				}
-				if seenProfile[inst.name] {
-					if !reportedProfile[inst.name] {
-						dups = append(dups, dupBlock{"screen ids-option", inst.name})
-						reportedProfile[inst.name] = true
-					}
-				} else {
-					seenProfile[inst.name] = true
-				}
-				// Duplicate family block WITHIN this ids-option instance.
 				famSeen := map[string]bool{}
 				famReported := map[string]bool{}
 				for _, fam := range inst.node.Children {
@@ -192,54 +219,52 @@ func validateDuplicateNamedBlockAST(tree *ConfigTree, lenient bool) ([]string, e
 					if famSeen[fn] {
 						if !famReported[fn] {
 							dups = append(dups, dupBlock{
-								kind: fmt.Sprintf("screen ids-option %q family", inst.name),
-								name: fn,
+								kind:   fmt.Sprintf("screen ids-option %q family", inst.name),
+								name:   fn,
+								effect: dupEffectFirstWins,
 							})
 							famReported[fn] = true
 						}
-					} else {
-						famSeen[fn] = true
+						continue
 					}
+					famSeen[fn] = true
 				}
 			}
 		}
 	}
 
-	// 4. system { login { user <name> { … } } } — #6992. compileSystemLogin
-	// now folds a duplicated user name into ONE entry with per-leaf
-	// last-authored-wins (compiler_system.go), matching what the FLAT spelling
-	// already produces, so the container qualifies for this gate on the same
-	// terms as the three above: the earlier block's uid / class / keys
-	// disappear silently.
-	//
-	// Before that fold both blocks survived and two readers picked DIFFERENT
-	// ones — pkg/cli configuredClass takes the first block with a non-empty
-	// class, pkg/daemon applySystemLogin provisions from the last — so an SSH
-	// key authored under a VIEW-only block could authenticate into a
-	// super-user CLI. The fold removes the divergence; this gate is what stops
-	// the operator being silently held to whichever block the merge kept.
-	//
-	// Union across every top-level `system` stanza and every `login` block
-	// therein, matching the screen walk above.
-	seenUser := map[string]bool{}
-	reportedUser := map[string]bool{}
-	for _, child := range tree.Children {
-		if child.Name() != "system" {
-			continue
+	// 4. Singleton containers (singletonDupRules) — #6768. These carry no name,
+	// so the duplicate IS the keyword. compileServices reads each with
+	// FindChild, so every block after the first is silently ignored in full.
+	for _, rule := range singletonDupRules {
+		want := make(map[string]bool, len(rule.keywords))
+		for _, k := range rule.keywords {
+			want[k] = true
 		}
-		for _, login := range child.FindChildren("login") {
-			for _, inst := range namedInstances(login.FindChildren("user")) {
-				if inst.name == "" {
-					recordEmpty("login user")
-					continue
-				}
-				if seenUser[inst.name] {
-					if !reportedUser[inst.name] {
-						dups = append(dups, dupBlock{"login user", inst.name})
-						reportedUser[inst.name] = true
+		seen := map[string]bool{}
+		reported := map[string]bool{}
+		for _, child := range tree.Children {
+			if child.Name() != rule.stanza {
+				continue
+			}
+			holders := []*Node{child}
+			if rule.inner != "" {
+				holders = child.FindChildren(rule.inner)
+			}
+			for _, holder := range holders {
+				for _, c := range holder.Children {
+					name := c.Name()
+					if !want[name] || c.IsLeaf {
+						continue
 					}
-				} else {
-					seenUser[inst.name] = true
+					if seen[name] {
+						if !reported[name] {
+							dups = append(dups, dupBlock{rule.kind, name, dupEffectFirstWins})
+							reported[name] = true
+						}
+						continue
+					}
+					seen[name] = true
 				}
 			}
 		}
@@ -262,19 +287,18 @@ func validateDuplicateNamedBlockAST(tree *ConfigTree, lenient bool) ([]string, e
 		// unchanged when no empty name is present.
 		if len(dups) > 0 {
 			d := dups[0]
-			return nil, fmt.Errorf("duplicate %s %q: a repeated hierarchical block is "+
-				"silently reduced to last-writer-wins, dropping the earlier block's "+
-				"configuration — author it once (flat `set` merges repeated "+
-				"statements automatically) (#5180)", d.kind, d.name)
+			return nil, fmt.Errorf("duplicate %s %q: %s — author it once (flat `set` "+
+				"merges repeated statements automatically) (#5180)",
+				d.kind, d.name, dupEffectStrict(d.effect))
 		}
 		return nil, emptyNameError(emptyKinds[0])
 	}
 
 	warnings := make([]string, 0, len(dups)+len(emptyKinds))
 	for _, d := range dups {
-		warnings = append(warnings, fmt.Sprintf("duplicate %s %q: only the LAST "+
-			"hierarchical block is kept (earlier block dropped) — author it once "+
-			"to avoid silently losing config (#5180)", d.kind, d.name))
+		warnings = append(warnings, fmt.Sprintf("duplicate %s %q: %s — author it "+
+			"once to avoid silently losing config (#5180)",
+			d.kind, d.name, dupEffectLenient(d.effect)))
 	}
 	for _, k := range emptyKinds {
 		warnings = append(warnings, emptyNameWarning(k))
@@ -293,4 +317,126 @@ func groupDefinitionName(g *Node) string {
 		return g.Keys[1]
 	}
 	return g.Keys[0]
+}
+
+// dupContainerEffect names WHAT a duplicate costs for one container, so the
+// operator message states the truth for that container instead of a single
+// blanket sentence. The three shapes differ, and saying "the earlier block is
+// dropped" about a first-sibling-only read would be exactly backwards.
+type dupContainerEffect int
+
+const (
+	// dupEffectLastWins: the compiler stores by name into a map, so the LAST
+	// authored block replaces the earlier one wholesale.
+	dupEffectLastWins dupContainerEffect = iota
+	// dupEffectFirstWins: the compiler reads the container with FindChild —
+	// the FIRST sibling only — so every LATER block is silently ignored.
+	dupEffectFirstWins
+	// dupEffectSplitInstances: the compiler loops over every instance with
+	// per-instance local state, so neither block is dropped but neither sees
+	// the other's settings; children authored under one block do not inherit
+	// what was authored under the other.
+	dupEffectSplitInstances
+)
+
+// namedDupRule describes one NAMED container to check for duplicate
+// hierarchical siblings: `<stanza> { [<inner> {] <keyword> <name> { … } [}] }`.
+//
+// The four original #5180 checks were four hand-written copies of this walk.
+// Two of them (screen ids-option, login user) are exactly this shape and are
+// now table rows; `groups` and `interfaces` keep bespoke walks because their
+// name extraction and skip rules genuinely differ (a merged two-key head, and
+// the non-interface keyword allowlist). A divergence between copies of one walk
+// is always a bug, so the copies that CAN be single-sourced are.
+type namedDupRule struct {
+	stanza  string // top-level stanza, e.g. "security"
+	inner   string // optional intermediate container, "" if none
+	keyword string // the named container keyword, e.g. "stream"
+	kind    string // human category used in the message and the empty-name report
+	effect  dupContainerEffect
+}
+
+// singletonDupRule describes an UNNAMED container that may legitimately be
+// authored only once: `<stanza> { [<inner> {] <keyword> { … } [}] }`. The
+// compiler reads it with FindChild, so a repeat is not last-writer-wins — every
+// later block is silently ignored.
+type singletonDupRule struct {
+	stanza   string
+	inner    string
+	keywords []string
+	kind     string
+}
+
+// namedDupRules and singletonDupRules are the registry this gate walks. Adding
+// a container is one row; the walk itself exists once.
+//
+// #6768 added the six rows below the original two. They were derived from the
+// stated predicate — a container that can be authored twice as a hierarchical
+// sibling and whose compile silently loses configuration the FLAT spelling
+// would have merged — not from the three effects the issue happened to name.
+// Each was measured at master before it was added; see
+// duplicate_container_6768_test.go, which reproduces the loss for every row.
+var namedDupRules = []namedDupRule{
+	{stanza: "security", inner: "screen", keyword: "ids-option", kind: "screen ids-option", effect: dupEffectLastWins},
+	{stanza: "system", inner: "login", keyword: "user", kind: "login user", effect: dupEffectLastWins},
+
+	// #6768. `security log stream <n>` and `profile <n>` are stored as
+	// Streams[name] / Profiles[name] (compiler_security_log.go), so a second
+	// block replaces the first — measured: a stream authored with
+	// `transport { protocol tls; }` in the first block and `severity info` in
+	// the second compiles to severity=info and NO transport at all, which is
+	// the TLS syslog transport silently reverting to plain UDP.
+	{stanza: "security", inner: "log", keyword: "stream", kind: "security log stream", effect: dupEffectLastWins},
+	{stanza: "security", inner: "log", keyword: "profile", kind: "security log profile", effect: dupEffectLastWins},
+
+	// #6768. `protocols bgp group <n>` is compiled by a loop with per-instance
+	// local state (compiler_protocols.go: groupExport, peerAS, … are declared
+	// inside the namedInstances range), so two blocks do not merge — measured:
+	// `group g { peer-as 65001; export P; }` plus `group g { neighbor N; }`
+	// compiles N with peerAS=0 and export=[]. The export policy the operator
+	// authored never reaches the neighbour, and only the peer-as half warns.
+	{stanza: "protocols", inner: "bgp", keyword: "group", kind: "bgp group", effect: dupEffectSplitInstances},
+}
+
+var singletonDupRules = []singletonDupRule{
+	// #6768. compileServices reads each of these with FindChild — the FIRST
+	// sibling only — so a second block is silently ignored in full. Measured:
+	// `services { flow-monitoring { version9 … } flow-monitoring { version-ipfix
+	// … } }` compiles the v9 half and drops the IPFIX half entirely, with zero
+	// warnings. `application-identification` is excluded deliberately: it is a
+	// presence flag, so a repeat loses nothing.
+	{stanza: "services", keywords: []string{"flow-monitoring", "rpm", "ip-monitoring"}, kind: "services container"},
+}
+
+// dupEffectStrict / dupEffectLenient render what a duplicate actually costs for
+// one container. The original single sentence said the EARLIER block is
+// dropped, which is true for a last-writer-wins map store and exactly backwards
+// for a FindChild first-sibling-only read — a wrong message here is a wrong
+// diagnosis, not a wording nit, because it sends the operator to delete the
+// wrong block.
+func dupEffectStrict(e dupContainerEffect) string {
+	switch e {
+	case dupEffectFirstWins:
+		return "the compiler reads only the FIRST block, so every later block is " +
+			"silently ignored in full"
+	case dupEffectSplitInstances:
+		return "each block is compiled independently with its own state, so " +
+			"settings authored in one block do not reach children authored in the " +
+			"other — the config is silently split, not merged"
+	default:
+		return "a repeated hierarchical block is silently reduced to " +
+			"last-writer-wins, dropping the earlier block's configuration"
+	}
+}
+
+func dupEffectLenient(e dupContainerEffect) string {
+	switch e {
+	case dupEffectFirstWins:
+		return "only the FIRST hierarchical block is read (every later block ignored)"
+	case dupEffectSplitInstances:
+		return "each hierarchical block compiles independently, so neither sees the " +
+			"other's settings"
+	default:
+		return "only the LAST hierarchical block is kept (earlier block dropped)"
+	}
 }

--- a/pkg/config/duplicate_container_6768_test.go
+++ b/pkg/config/duplicate_container_6768_test.go
@@ -242,6 +242,22 @@ func TestUnregisteredContainerRepeatStillAccepted_6768(t *testing.T) {
 	if _, err := CompileConfig(tree); err != nil {
 		t.Fatalf("CompileConfig rejected a repeated presence flag, which loses nothing: %v", err)
 	}
+
+	// And a REGISTERED container repeated as an empty leaf. The singleton walk
+	// skips `c.IsLeaf` deliberately: two empty `flow-monitoring;` statements
+	// carry no configuration, so neither can lose any, and rejecting them would
+	// be a false positive on a config that is merely redundant. Without this
+	// cell the guard is unbound — the mutation matrix removed it and every
+	// other cell stayed green, because the presence-flag fixture above uses a
+	// keyword that is not in the registry at all and so never reaches it.
+	leafTree := parseHier5180(t, `services {
+    flow-monitoring;
+    flow-monitoring;
+}`)
+	if _, err := CompileConfig(leafTree); err != nil {
+		t.Fatalf("CompileConfig rejected two EMPTY flow-monitoring statements, which "+
+			"cannot lose configuration: %v", err)
+	}
 }
 
 // TestEveryDuplicateContainerRuleHasAFixture_6768 binds the REGISTRY to the

--- a/pkg/config/duplicate_container_6768_test.go
+++ b/pkg/config/duplicate_container_6768_test.go
@@ -1,0 +1,390 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6768 — unnormalized duplicate containers silently lose configuration.
+//
+// The issue names three effects: BGP export policy, TLS syslog transport, and
+// monitoring state. Its evidence and fix-direction sections are pointers to a
+// review file that no longer exists, so every claim below was re-derived by
+// SYMBOL at current master and measured before anything was changed.
+//
+// PREDICATE used to derive the population — not the three effects the issue
+// happened to name: a container that can be authored more than once as a
+// hierarchical sibling, and whose compile silently loses configuration the FLAT
+// `set` spelling would have merged. `tree.SetPath` collapses a repeated flat
+// statement onto one node, so a duplicate CONTAINER sibling is reachable only
+// from the hierarchical shape — which is exactly the dual-AST-equivalence
+// invariant the #5180 gate already exists to enforce.
+//
+// Population measured at master: SIX sites, in three distinct loss modes.
+//
+//	security log stream <n>      last-writer-wins  Streams[name] = stream
+//	security log profile <n>     last-writer-wins  Profiles[name] = p
+//	protocols bgp group <n>      split instances   per-instance local state
+//	services flow-monitoring     first-wins        FindChild
+//	services rpm                 first-wins        FindChild
+//	services ip-monitoring       first-wins        FindChild
+//
+// Three of the six are the effects the issue names; the other three came from
+// the predicate. A count that rises when the population is derived properly is
+// the derivation working, not scope creep.
+//
+// The fix registers all six in the #5180 duplicate-named-block gate: strict
+// reject on commit / commit-check, warn on the tolerant load / peer-sync path
+// (#1960 no-brick). It deliberately does NOT fold the blocks together. #6992
+// folded `system login user` because two READERS picked different blocks — a
+// credential authored under a VIEW-only block could authenticate into a
+// super-user CLI — and a fold was the only way to remove the divergence. There
+// is no divergent reader here: the loss is a plain silent drop, which is the
+// shape `groups` / `interfaces` / `screen ids-option` are handled with, so the
+// gate alone is the matching remedy.
+
+// dup6768Case is one registry row plus the fixture that reproduces its loss.
+type dup6768Case struct {
+	name     string // subtest name
+	kind     string // the `kind` the gate reports
+	instance string // the duplicated name the gate reports
+	dupSrc   string // hierarchical config authoring the container TWICE
+	oneSrc   string // the same content authored ONCE — must compile clean
+	effect   string // a distinctive fragment of the effect sentence
+}
+
+func dup6768Cases() []dup6768Case {
+	return []dup6768Case{
+		{
+			name:     "security_log_stream",
+			kind:     "security log stream",
+			instance: "s",
+			effect:   "last-writer-wins",
+			dupSrc: `security {
+    log {
+        stream s { host 10.0.0.9; transport { protocol tls; } }
+        stream s { host 10.0.0.9; severity info; }
+    }
+}`,
+			oneSrc: `security {
+    log {
+        stream s { host 10.0.0.9; transport { protocol tls; } severity info; }
+    }
+}`,
+		},
+		{
+			name:     "security_log_profile",
+			kind:     "security log profile",
+			instance: "pf",
+			effect:   "last-writer-wins",
+			dupSrc: `security {
+    log {
+        stream s { host 10.0.0.9; }
+        profile pf { stream-name s; default-profile; }
+        profile pf { category all; }
+    }
+}`,
+			oneSrc: `security {
+    log {
+        stream s { host 10.0.0.9; }
+        profile pf { stream-name s; default-profile; category all; }
+    }
+}`,
+		},
+		{
+			name:     "protocols_bgp_group",
+			kind:     "bgp group",
+			instance: "g",
+			effect:   "compiled independently",
+			dupSrc: `policy-options { policy-statement EXPORT-POLICY { then accept; } }
+protocols {
+    bgp {
+        group g { type external; peer-as 65001; export EXPORT-POLICY; }
+        group g { neighbor 10.0.0.1; }
+    }
+}`,
+			oneSrc: `policy-options { policy-statement EXPORT-POLICY { then accept; } }
+protocols {
+    bgp {
+        group g { type external; peer-as 65001; export EXPORT-POLICY; neighbor 10.0.0.1; }
+    }
+}`,
+		},
+		{
+			name:     "services_flow_monitoring",
+			kind:     "services container",
+			instance: "flow-monitoring",
+			effect:   "FIRST block",
+			dupSrc: `services {
+    flow-monitoring { version9 { template t { flow-active-timeout 30; } } }
+    flow-monitoring { version-ipfix { template u { flow-active-timeout 40; } } }
+}`,
+			oneSrc: `services {
+    flow-monitoring {
+        version9 { template t { flow-active-timeout 30; } }
+        version-ipfix { template u { flow-active-timeout 40; } }
+    }
+}`,
+		},
+		{
+			name:     "services_rpm",
+			kind:     "services container",
+			instance: "rpm",
+			effect:   "FIRST block",
+			dupSrc: `services {
+    rpm { probe p1 { test t1 { target address 10.0.0.1; } } }
+    rpm { probe p2 { test t2 { target address 10.0.0.2; } } }
+}`,
+			oneSrc: `services {
+    rpm {
+        probe p1 { test t1 { target address 10.0.0.1; } }
+        probe p2 { test t2 { target address 10.0.0.2; } }
+    }
+}`,
+		},
+		{
+			name:     "services_ip_monitoring",
+			kind:     "services container",
+			instance: "ip-monitoring",
+			effect:   "FIRST block",
+			dupSrc: `services {
+    rpm { probe pr { test tt { target address 10.0.0.1; } } }
+    ip-monitoring {
+        policy a { match { rpm-probe pr; } then { preferred-route { route 0.0.0.0/0 { next-hop 10.0.0.254; } } } }
+    }
+    ip-monitoring {
+        policy b { match { rpm-probe pr; } then { preferred-route { route 1.0.0.0/8 { next-hop 10.0.0.253; } } } }
+    }
+}`,
+			oneSrc: `services {
+    rpm { probe pr { test tt { target address 10.0.0.1; } } }
+    ip-monitoring {
+        policy a { match { rpm-probe pr; } then { preferred-route { route 0.0.0.0/0 { next-hop 10.0.0.254; } } } }
+        policy b { match { rpm-probe pr; } then { preferred-route { route 1.0.0.0/8 { next-hop 10.0.0.253; } } } }
+    }
+}`,
+		},
+	}
+}
+
+// TestDuplicateContainerRejectedAtCommit_6768 is the strict-path proof for
+// every row. Removing a row from the registry reds only its own subtest, so a
+// partial revert cannot hide behind the others.
+func TestDuplicateContainerRejectedAtCommit_6768(t *testing.T) {
+	for _, tc := range dup6768Cases() {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := parseHier5180(t, tc.dupSrc)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig accepted a duplicate %s %q; the duplicate silently "+
+					"loses configuration the flat spelling would have merged", tc.kind, tc.instance)
+			}
+			for _, want := range []string{"duplicate", tc.kind, tc.instance, tc.effect, "#5180"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q missing %q", err.Error(), want)
+				}
+			}
+		})
+	}
+}
+
+// TestDuplicateContainerLenientWarns_6768: the tolerant load / peer-sync path
+// must NOT hard-reject — an already-persisted or peer-synced config authored by
+// a pre-gate version still has to boot (#1960) — but it must say so.
+func TestDuplicateContainerLenientWarns_6768(t *testing.T) {
+	for _, tc := range dup6768Cases() {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := parseHier5180(t, tc.dupSrc)
+			cfg, err := CompileConfigLenient(tree)
+			if err != nil {
+				t.Fatalf("CompileConfigLenient hard-rejected a duplicate %s: %v", tc.kind, err)
+			}
+			found := false
+			for _, w := range cfg.Warnings {
+				if strings.Contains(w, "duplicate "+tc.kind) && strings.Contains(w, tc.instance) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("no downgraded warning naming %s %q; warnings=%v", tc.kind, tc.instance, cfg.Warnings)
+			}
+		})
+	}
+}
+
+// TestSingleContainerStillCompiles_6768 is the negative control, and it is the
+// cell that stops the gate from being satisfied by "reject everything": the
+// SAME content authored once must compile clean at strict. Each fixture is the
+// merged form of its duplicate twin, so this also pins that the gate rejects
+// the SHAPE and not the content.
+func TestSingleContainerStillCompiles_6768(t *testing.T) {
+	for _, tc := range dup6768Cases() {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := parseHier5180(t, tc.oneSrc)
+			if _, err := CompileConfig(tree); err != nil {
+				t.Fatalf("CompileConfig rejected the singly-authored form: %v", err)
+			}
+		})
+	}
+}
+
+// TestUnregisteredContainerRepeatStillAccepted_6768 is the tightening control.
+// `services application-identification` is deliberately NOT in the registry: it
+// is a presence flag, so authoring it twice loses nothing. A gate that rejected
+// every repeated sibling would satisfy every cell above while breaking configs
+// that are fine, so this cell must stay green.
+func TestUnregisteredContainerRepeatStillAccepted_6768(t *testing.T) {
+	tree := parseHier5180(t, `services {
+    application-identification;
+    application-identification;
+}`)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a repeated presence flag, which loses nothing: %v", err)
+	}
+}
+
+// TestEveryDuplicateContainerRuleHasAFixture_6768 binds the REGISTRY to the
+// tests. A registry row is a claim that a duplicate of that container loses
+// config; adding one without a fixture would leave the claim untested while the
+// file still looked covered. The subtests above are per-row, so this cell is
+// what makes their coverage total rather than incidental.
+func TestEveryDuplicateContainerRuleHasAFixture_6768(t *testing.T) {
+	covered := map[string]bool{}
+	for _, tc := range dup6768Cases() {
+		covered[tc.kind+"/"+tc.instance] = true
+	}
+	// The two pre-#6768 rows are covered by dup_named_blocks_5180_test.go and
+	// are exempt here; every row this issue added owes a fixture.
+	preexisting := map[string]bool{"screen ids-option": true, "login user": true}
+	for _, r := range namedDupRules {
+		if preexisting[r.kind] {
+			continue
+		}
+		if !anyCoveredKind(covered, r.kind) {
+			t.Errorf("namedDupRules row %q has no fixture in dup6768Cases()", r.kind)
+		}
+	}
+	for _, r := range singletonDupRules {
+		for _, kw := range r.keywords {
+			if !covered[r.kind+"/"+kw] {
+				t.Errorf("singletonDupRules row %s %q has no fixture in dup6768Cases()", r.kind, kw)
+			}
+		}
+	}
+}
+
+func anyCoveredKind(covered map[string]bool, kind string) bool {
+	for k := range covered {
+		if strings.HasPrefix(k, kind+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDuplicateContainerInGroupBodyCaught_6768: the #5180 walk runs
+// PRE-expansion, so a duplicate authored entirely inside an applied group body
+// is invisible to it — #6455 re-runs the same function on a group-expanded
+// clone to close that. Existence-closure through a shared call site is
+// transitive; GUARDEDNESS-closure is not, so this cell proves the new rows are
+// actually reached on the expanded path rather than assuming it.
+func TestDuplicateContainerInGroupBodyCaught_6768(t *testing.T) {
+	tree := parseHier5180(t, `groups {
+    g1 {
+        services {
+            flow-monitoring { version9 { template t { flow-active-timeout 30; } } }
+            flow-monitoring { version-ipfix { template u { flow-active-timeout 40; } } }
+        }
+    }
+}
+apply-groups g1;`)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a duplicate container authored inside an applied group body")
+	}
+	if !strings.Contains(err.Error(), "flow-monitoring") {
+		t.Errorf("error %q does not name the duplicated container", err.Error())
+	}
+}
+
+// TestDuplicateContainerHarmIsMeasured_6768 records WHAT the three effects the
+// issue names actually cost, on the tolerant path where the historical result
+// is deliberately preserved (#1960 no-brick). These are not aspirational
+// assertions — they pin the contract that is in force. If the compiler is ever
+// changed to FOLD duplicate blocks the way #6992 folded `system login user`,
+// these cells must be updated to assert the merged result; that is the point of
+// writing them down rather than leaving the loss implicit in a commit message.
+func TestDuplicateContainerHarmIsMeasured_6768(t *testing.T) {
+	t.Run("bgp_export_policy_erased", func(t *testing.T) {
+		cfg := lenientHier6768(t, `policy-options { policy-statement EXPORT-POLICY { then accept; } }
+protocols {
+    bgp {
+        group g { type external; peer-as 65001; export EXPORT-POLICY; }
+        group g { neighbor 10.0.0.1; }
+    }
+}`)
+		if cfg.Protocols.BGP == nil || len(cfg.Protocols.BGP.Neighbors) != 1 {
+			t.Fatalf("expected exactly one compiled neighbour, got %+v", cfg.Protocols.BGP)
+		}
+		n := cfg.Protocols.BGP.Neighbors[0]
+		if len(n.Export) != 0 {
+			t.Fatalf("export = %v; the measured pre-gate behaviour is that the second "+
+				"group block compiles with its own empty state — update this cell if a "+
+				"fold was added", n.Export)
+		}
+		if n.PeerAS != 0 {
+			t.Errorf("peer-as = %d, want 0 (same erasure, and the only half that warns)", n.PeerAS)
+		}
+	})
+
+	t.Run("tls_syslog_transport_erased", func(t *testing.T) {
+		cfg := lenientHier6768(t, `security {
+    log {
+        stream s { host 10.0.0.9; transport { protocol tls; } }
+        stream s { host 10.0.0.9; severity info; }
+    }
+}`)
+		s := cfg.Security.Log.Streams["s"]
+		if s == nil {
+			t.Fatal("stream s missing")
+		}
+		if s.Transport.Protocol != "" {
+			t.Fatalf("transport protocol = %q; the measured pre-gate behaviour is that the "+
+				"second block replaces the first wholesale, leaving the TLS transport "+
+				"unset — a stream the operator configured for TLS reverts to plain "+
+				"syslog", s.Transport.Protocol)
+		}
+		if s.Severity != "info" {
+			t.Errorf("severity = %q, want info (the surviving block's value)", s.Severity)
+		}
+	})
+
+	t.Run("monitoring_state_erased", func(t *testing.T) {
+		cfg := lenientHier6768(t, `services {
+    flow-monitoring { version9 { template t { flow-active-timeout 30; } } }
+    flow-monitoring { version-ipfix { template u { flow-active-timeout 40; } } }
+}`)
+		fm := cfg.Services.FlowMonitoring
+		if fm == nil {
+			t.Fatal("flow-monitoring missing entirely")
+		}
+		if fm.Version9 == nil {
+			t.Error("version9 (the FIRST block) should survive")
+		}
+		if fm.VersionIPFIX != nil {
+			t.Fatal("version-ipfix survived; the measured pre-gate behaviour is that " +
+				"compileServices reads flow-monitoring with FindChild, so the whole " +
+				"second block is ignored")
+		}
+	})
+}
+
+func lenientHier6768(t *testing.T, src string) *Config {
+	t.Helper()
+	cfg, err := CompileConfigLenient(parseHier5180(t, src))
+	if err != nil {
+		t.Fatalf("CompileConfigLenient: %v", err)
+	}
+	return cfg
+}


### PR DESCRIPTION
Closes #6768

## What was wrong

A duplicate hierarchical container silently loses configuration that the flat
`set` spelling would have merged. `tree.SetPath` collapses a repeated flat
statement onto one node, so a duplicate **container** sibling is reachable only
from the hierarchical shape — which is exactly the dual-AST-equivalence
invariant the #5180 gate exists to enforce. It covered four containers. Six more
matched the same predicate and were not registered.

## Cites re-derived, population derived from a predicate

The issue names three effects and carries no evidence — its Evidence and Fix
direction sections are pointers to a review file that no longer exists. **Every
claim was located by SYMBOL and re-derived at current master**, and each row was
measured before it was added.

The population came from the predicate, not from the three effects the issue
happened to name:

> *a container that can be authored more than once as a hierarchical sibling,
> and whose compile silently loses configuration the FLAT `set` spelling would
> have merged.*

**Six sites matched, in three distinct loss modes.** Three of the six are the
effects the issue names; the other three came from the predicate.

| container | loss mode | measured effect |
|---|---|---|
| `security log stream <n>` | last-writer-wins (`Streams[name] = stream`) | a stream authored `transport { protocol tls; }` in the first block and `severity info` in the second compiles with severity=info and **no transport** — a TLS syslog stream silently reverts to plain syslog |
| `security log profile <n>` | last-writer-wins (`Profiles[name] = p`) | `stream-name` and `default-profile` both vanish; the profile is left bound to nothing |
| `protocols bgp group <n>` | split instances (per-instance locals) | `group g { peer-as 65001; export P; }` + `group g { neighbor N; }` compiles N with `peerAS=0` and `export=[]`; only the peer-as half warns |
| `services flow-monitoring` | first-wins (`FindChild`) | the whole second block is ignored — a `version-ipfix` half authored after a `version9` half never exists |
| `services rpm` | first-wins (`FindChild`) | every probe in the second block disappears |
| `services ip-monitoring` | first-wins (`FindChild`) | every policy in the second block disappears, with zero warnings |

`services application-identification` is deliberately excluded: it is a presence
flag, so a repeat loses nothing.

## Registry, not a fifth copy

The gate was four hand-written copies of one walk; adding six more copies was the
wrong shape. Two of the four (screen ids-option, login user) are exactly the same
walk and became rows in `namedDupRules`. `groups` and `interfaces` keep bespoke
walks — their name extraction (a merged two-key head) and skip rules (the
non-interface keyword allowlist) genuinely differ. `singletonDupRules` carries
the unnamed containers, where the duplicate *is* the keyword. A row now reaches
the strict gate, the lenient warning, **and** the #6455 group-expanded re-run
without any of the three being edited.

## The message was backwards for one mode

The original single sentence said the **earlier** block is dropped. True for a
last-writer-wins map store; exactly backwards for a `FindChild`
first-sibling-only read, where it would send an operator to delete the block that
survived. `dupEffectStrict` / `dupEffectLenient` render the truth per mode. The
pre-existing ids-option **family** check was mislabelled the same way and is
corrected.

## Gate only, no fold

#6992 folded `system login user` because two **readers** picked different blocks
— a credential authored under a VIEW-only block could authenticate into a
super-user CLI — and a fold was the only way to remove that divergence. There is
no divergent reader here: the loss is a plain silent drop, the shape `groups` /
`interfaces` / `screen ids-option` are already handled with, so the gate alone is
the matching remedy. Strict rejects on commit / commit-check; the tolerant load /
peer-sync path warns and boots (#1960), preserving the historical result.

## One finding worth recording

**A duplicate can blind another gate.** With the BGP blocks duplicated the export
policy never reaches the neighbour, so the existing
undefined-`policy-statement` cross-reference gate has nothing to check and stays
silent. The same config authored once is correctly rejected when the policy is
undefined.

## Mutation matrix

Every cell verified applied (`git diff --stat` non-empty) and run against the
full `pkg/config` suite, not a `-run` filter.

| cell | mutation | result | assertion that fired |
|---|---|---|---|
| drop_bgp | remove the `protocols bgp group` row | **RED** | `…RejectedAtCommit_6768/protocols_bgp_group` + the lenient twin |
| drop_stream | remove the `security log stream` row | **RED** | `CompileConfig accepted a duplicate security log stream "s"` |
| drop_singleton | shrink the services keyword list to `flow-monitoring` | **RED** | the `rpm` and `ip_monitoring` subtests only — localised exactly |
| wrong_effect | restore the blanket "earlier block dropped" sentence for first-wins | **RED** | all three services subtests, `missing "FIRST block"` |
| no_inner | make the table walk ignore the intermediate container | **RED** | the **pre-existing** `TestDuplicateNamedBlockRejected/hierarchical_duplicate_ids-option_rejected` and `TestDup6455QuotedEmptyNameRejected/screen_ids-option`, plus three new subtests — the refactor is bound by the old tests too |
| leaf_guard | remove the `c.IsLeaf` skip from the singleton walk | **GREEN → fixed** | see below |

`leaf_guard` stayed green. The tightening control meant to cover it uses
`services application-identification`, a keyword that is not in the registry at
all, so it never reaches the guard — the fixture varied the right axis and
sampled the one point where the guard is not consulted. The third commit extends
it with a registered container repeated as an **empty leaf**; re-running the
mutation now reds it.

## Docs

`docs/config-schema.md` gains a #6768 section with the predicate, the six-row
table, the two side notes, and the gate-not-fold rationale.

## Notes for the fold gate

Go-only change (`pkg/config`, docs). Does not touch cluster / VRRP /
session-sync / failover code, and does not move the `userspace-dp` binary or the
shim `.o`.

`go test -count=1 ./...` green at `4a20c67c9`.