### PR TITLE
config: fix compiler panic on the hierarchical prefix-list block form

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104305,3 +104305,18 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: pkg/config/schema_validators.go, pkg/config/schema_system.go,
   pkg/config/compiler_validate_strict_chassis.go,
   pkg/config/numeric_bounds_6772_6773_test.go
+
+## 2026-08-22 — #7568 compiler panic on the hierarchical prefix-list block form
+
+- **Timestamp**: 2026-08-22
+- **Action**: Fixed a `CompileConfig` panic (`slice bounds out of range [2:1]`)
+  on `policy-options { prefix-list { name; } }`. `namedInstances` returns two
+  node shapes and the #6564 compact-leaf read assumed one. Reachable on the
+  TOLERATED Store.Load / SyncApply ingress, so it crashed the daemon on load
+  rather than rejecting the config (#1960). The tail is now taken relative to
+  the instance NAME, not a fixed index, because a bare bounds check silently
+  drops the block form's compact value. Bound the one-site claim with a census
+  test over all 1129 schema paths.
+- **File(s)**: `pkg/config/compiler_routing.go`,
+  `pkg/config/compiler_prefix_list_block_7568_test.go`,
+  `pkg/config/compiler_block_form_panic_census_7568_test.go`

--- a/pkg/config/compiler_block_form_panic_census_7568_test.go
+++ b/pkg/config/compiler_block_form_panic_census_7568_test.go
@@ -1,0 +1,98 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestNoSchemaPathPanicsOnTheBlockForm_7568 is the census that justifies
+// #7568 being a ONE-SITE fix rather than an audit.
+//
+// The panic came from `namedInstances` returning two node shapes while one
+// caller read a fixed key index. That is a shape a reviewer cannot spot by
+// eye — every `.node.Keys[...]` access looks equally plausible — so the claim
+// "exactly one site is affected" has to be MEASURED, and re-measured whenever
+// a caller is added.
+//
+// The walk emits the hierarchical block spelling `<path> { probeval; }` for
+// EVERY path in setSchema, built from real parsed text, and compiles it under
+// recover. A compiler that REJECTS the config is fine; one that PANICS is not,
+// because the panic is reachable on the tolerated Store.Load / Store.SyncApply
+// ingress where the schema gate is downgraded to a warning (#1960) — it
+// crashes the daemon on load rather than refusing the config.
+//
+// This test is deliberately assumption-free about which nodes are "named
+// instances". An earlier version of this probe keyed on `sn.wildcard != nil`,
+// reached 12 containers, and reported ZERO panics over a defect that had
+// already been reproduced by hand — `policy-options prefix-list` is declared
+// `args:1, children:nil`, not a wildcard. A predicate that never reaches the
+// subject produces a clean green, which is worse than no test at all. Walk
+// everything.
+func TestNoSchemaPathPanicsOnTheBlockForm_7568(t *testing.T) {
+	var paths []string
+	var walk func(nodes map[string]*schemaNode, path []string, depth int)
+	walk = func(nodes map[string]*schemaNode, path []string, depth int) {
+		if depth > 4 {
+			return
+		}
+		keys := make([]string, 0, len(nodes))
+		for k := range nodes {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			sn := nodes[k]
+			// `groups` re-hosts the whole schema under an instance name; its
+			// contents are reached on their own below, and walking it again
+			// only doubles the runtime.
+			if k == "groups" || k == "apply-groups" {
+				continue
+			}
+			p := append(append([]string(nil), path...), k)
+			paths = append(paths, strings.Join(p, " "))
+			if sn.children != nil {
+				walk(sn.children, p, depth+1)
+			}
+			if sn.wildcard != nil && sn.wildcard.children != nil {
+				walk(sn.wildcard.children, append(append([]string(nil), p...), "xa1"), depth+1)
+			}
+		}
+	}
+	walk(setSchema.children, nil, 0)
+
+	if len(paths) < 500 {
+		t.Fatalf("the walk reached only %d schema paths; it is no longer covering "+
+			"the schema and a clean result would mean nothing", len(paths))
+	}
+
+	var panicked []string
+	for _, p := range paths {
+		toks := strings.Fields(p)
+		cfg := "probeval;"
+		for i := len(toks) - 1; i >= 0; i-- {
+			cfg = fmt.Sprintf("%s {\n%s\n}", toks[i], cfg)
+		}
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					panicked = append(panicked, fmt.Sprintf("%s -> %v", p, r))
+				}
+			}()
+			tree, perrs := NewParser(cfg).Parse()
+			if len(perrs) > 0 {
+				return
+			}
+			_, _ = CompileConfig(tree)
+		}()
+	}
+
+	if len(panicked) > 0 {
+		t.Fatalf("the compiler PANICS on the hierarchical block spelling at %d of %d "+
+			"schema paths. A panic here crashes the daemon on the tolerated load path "+
+			"(#1960), it does not reject the config:\n  %s",
+			len(panicked), len(paths), strings.Join(panicked, "\n  "))
+	}
+	t.Logf("block-form probe: %d schema paths, 0 compiler panics", len(paths))
+}

--- a/pkg/config/compiler_prefix_list_block_7568_test.go
+++ b/pkg/config/compiler_prefix_list_block_7568_test.go
@@ -1,0 +1,164 @@
+package config
+
+import "testing"
+
+// #7568: `policy-options { prefix-list { <name>; } }` parses cleanly and used
+// to PANIC the compiler with "slice bounds out of range [2:1]".
+//
+// namedInstances returns TWO shapes. When the node carries its own name
+// (Keys=["prefix-list", NAME, ...]) it returns that node, so Keys[2:] is the
+// #6564 compact-leaf prefix tail. In the hierarchical block spelling it
+// instead returns the SUB-node as the instance, whose Keys is just ["NAME"] —
+// length 1 — and the unguarded Keys[2:] panicked.
+//
+// This mattered beyond "reject a bad config": the panic is reachable on the
+// TOLERATED ingress. Store.compileTreeLenient (Store.Load / Store.SyncApply)
+// deliberately downgrades a SchemaValidate failure to a warning so a config
+// the operator did not just author cannot blackout-boot the node or alarm-loop
+// HA config sync (#1960) — and then compiles it anyway, reaching the panic.
+// A hand-edited persisted config, or one from a peer, crashed the daemon on
+// load.
+//
+// Every test here builds the tree from PARSED TEXT. A hand-assembled Node
+// could exhibit the shape without proving the parser ever produces it, which
+// would make the whole regression vacuous.
+
+// TestPrefixListBlockFormDoesNotPanic_7568 is the fail-on-revert proof.
+func TestPrefixListBlockFormDoesNotPanic_7568(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  string
+	}{
+		{"bare-name", "policy-options {\n    prefix-list {\n        foo;\n    }\n}"},
+		{"cidr-as-name", "policy-options {\n    prefix-list {\n        10.0.0.0/8;\n    }\n}"},
+		{"named-with-prefixes", "policy-options {\n    prefix-list {\n        PL {\n            10.0.0.0/8;\n            192.168.0.0/16;\n        }\n    }\n}"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree, perrs := NewParser(tc.cfg).Parse()
+			if len(perrs) > 0 {
+				t.Fatalf("parse: %v", perrs)
+			}
+			// A panic here fails the test by crashing the binary, which is the
+			// point: this is the shape that used to do exactly that.
+			if _, err := CompileConfig(tree); err != nil {
+				t.Fatalf("compile returned an error (a REJECTION is acceptable, "+
+					"a panic is not — but this one should compile): %v", err)
+			}
+		})
+	}
+}
+
+// TestPrefixListBlockFormCollectsPrefixes_7568 pins that the guard SKIPS the
+// compact tail rather than skipping the whole instance: the block spelling's
+// prefixes live in the node's children and must still be collected.
+func TestPrefixListBlockFormCollectsPrefixes_7568(t *testing.T) {
+	cfg := "policy-options {\n    prefix-list {\n        PL {\n            10.0.0.0/8;\n            192.168.0.0/16;\n        }\n    }\n}"
+	tree, perrs := NewParser(cfg).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	compiled, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	pl := compiled.PolicyOptions.PrefixLists["PL"]
+	if pl == nil {
+		t.Fatalf("prefix-list PL was not compiled at all; lists=%v", compiled.PolicyOptions.PrefixLists)
+	}
+	want := map[string]bool{"10.0.0.0/8": true, "192.168.0.0/16": true}
+	if len(pl.Prefixes) != len(want) {
+		t.Fatalf("PL prefixes = %v, want the two authored entries", pl.Prefixes)
+	}
+	for _, p := range pl.Prefixes {
+		if !want[p] {
+			t.Fatalf("PL carries unexpected prefix %q (all: %v)", p, pl.Prefixes)
+		}
+	}
+}
+
+// TestPrefixListCompactLeafStillReadsTail_7568 is the necessary control. The
+// fix adds `len(Keys) > 2` around the #6564 compact-leaf read, so it must be
+// proven that the guard did not disable the very feature #6564 added — a
+// guard that made the panic go away by skipping the tail on EVERY shape would
+// pass every other test in this file.
+func TestPrefixListCompactLeafStillReadsTail_7568(t *testing.T) {
+	cfg := "policy-options {\n    prefix-list PL 10.0.0.0/8;\n}"
+	tree, perrs := NewParser(cfg).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	compiled, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	pl := compiled.PolicyOptions.PrefixLists["PL"]
+	if pl == nil {
+		t.Fatal("compact-leaf prefix-list PL was not compiled")
+	}
+	if len(pl.Prefixes) != 1 || pl.Prefixes[0] != "10.0.0.0/8" {
+		t.Fatalf("compact-leaf spelling lost its prefix tail: %v — the #6774/#7568 "+
+			"length guard must skip the tail only for the 1-key block shape, "+
+			"not for the compact leaf #6564 added", pl.Prefixes)
+	}
+}
+
+// TestPrefixListBlockFormWithCompactLeafKeepsPrefix_7568 is the cell that
+// rejects the OBVIOUS fix. A bare `len(inst.node.Keys) > 2` bounds check at
+// the panic site stops the crash and passes every other test in this file —
+// but this shape carries Keys=["PL","10.0.0.0/8"], length 2, so the bounds
+// check SKIPS it and the list compiles NAMED BUT EMPTY. That is the #6564
+// defect (a filter term scoped by a silently-empty prefix-list stops
+// matching, on a config that committed clean) reintroduced in the other
+// shape. The tail must be taken relative to the NAME, not to a fixed index.
+func TestPrefixListBlockFormWithCompactLeafKeepsPrefix_7568(t *testing.T) {
+	cfg := "policy-options {\n    prefix-list {\n        PL 10.0.0.0/8;\n    }\n}"
+	tree, perrs := NewParser(cfg).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	compiled, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	pl := compiled.PolicyOptions.PrefixLists["PL"]
+	if pl == nil {
+		t.Fatal("prefix-list PL was not compiled")
+	}
+	if len(pl.Prefixes) != 1 || pl.Prefixes[0] != "10.0.0.0/8" {
+		t.Fatalf("PL prefixes = %v, want [10.0.0.0/8]: the block spelling's "+
+			"compact value was dropped, so the list is NAMED BUT EMPTY and any "+
+			"filter term scoped by it silently stops matching (#6564)", pl.Prefixes)
+	}
+}
+
+// TestInstanceValueTailHandlesBothNamedInstanceShapes_7568 pins the helper
+// directly, including the shapes that must yield nothing.
+func TestInstanceValueTailHandlesBothNamedInstanceShapes_7568(t *testing.T) {
+	cases := []struct {
+		name string
+		node *Node
+		inst string
+		want []string
+	}{
+		{"self-named-with-tail", &Node{Keys: []string{"prefix-list", "PL", "10.0.0.0/8"}}, "PL", []string{"10.0.0.0/8"}},
+		{"self-named-no-tail", &Node{Keys: []string{"prefix-list", "PL"}}, "PL", nil},
+		{"block-sub-with-tail", &Node{Keys: []string{"PL", "10.0.0.0/8"}}, "PL", []string{"10.0.0.0/8"}},
+		{"block-sub-no-tail", &Node{Keys: []string{"PL"}}, "PL", nil},
+		{"name-nowhere", &Node{Keys: []string{"prefix-list", "OTHER", "10.0.0.0/8"}}, "PL", nil},
+		{"nil-node", nil, "PL", nil},
+	}
+	for _, tc := range cases {
+		got := instanceValueTail(tc.node, tc.inst)
+		if len(got) != len(tc.want) {
+			t.Errorf("%s: tail = %v, want %v", tc.name, got, tc.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("%s: tail = %v, want %v", tc.name, got, tc.want)
+				break
+			}
+		}
+	}
+}

--- a/pkg/config/compiler_protocols.go
+++ b/pkg/config/compiler_protocols.go
@@ -1023,6 +1023,30 @@ func namedInstances(nodes []*Node) []struct {
 	return result
 }
 
+// instanceValueTail returns an instance node's trailing VALUE tokens — the
+// keys that follow its NAME — for both node shapes namedInstances can hand
+// back (#7568).
+//
+// namedInstances resolves an instance either from a node that carries its own
+// name (Keys=["<keyword>", NAME, ...]) or, for the hierarchical block
+// spelling, from a SUB-node whose keys begin with the name (Keys=[NAME, ...]).
+// Anchoring on the name rather than on a fixed index is what makes a caller
+// correct against both: a fixed Keys[2:] panics on the short shape, and a bare
+// length guard silently drops a compact value that the block shape
+// legitimately carries.
+func instanceValueTail(node *Node, name string) []string {
+	if node == nil {
+		return nil
+	}
+	if len(node.Keys) >= 2 && node.Keys[1] == name {
+		return node.Keys[2:]
+	}
+	if len(node.Keys) >= 1 && node.Keys[0] == name {
+		return node.Keys[1:]
+	}
+	return nil
+}
+
 // parseASNumber parses a BGP AS-number string, returning the value and true
 // ONLY when it is a valid 4-byte AS in [1, 4294967295]. A negative, oversized,
 // non-numeric, or zero value returns ok=false so the caller leaves the field

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -678,7 +678,14 @@ func compilePolicyOptions(node *Node, po *PolicyOptionsConfig) error {
 		// compiled NAMED but EMPTY. A filter term scoped by it then silently
 		// stopped matching, on a config that committed clean. Read the
 		// instance node's own trailing keys as well as its children.
-		for _, p := range inst.node.Keys[2:] {
+		// #7568: take the tail relative to the instance NAME, not a fixed
+		// index. namedInstances returns two node shapes and the tail starts
+		// at a different offset in each (see instanceValueTail). Reading
+		// Keys[2:] unconditionally PANICKED on the block spelling
+		// `prefix-list { NAME; }`, and a bare length guard silently drops the
+		// prefix in `prefix-list { NAME 10.0.0.0/8; }` — compiling the list
+		// NAMED BUT EMPTY, which is the #6564 defect in the other shape.
+		for _, p := range instanceValueTail(inst.node, inst.name) {
 			if p != "" {
 				pl.Prefixes = append(pl.Prefixes, p)
 			}


### PR DESCRIPTION
## What

`CompileConfig` **panicked** on a configuration that parses cleanly:

```
policy-options {
    prefix-list {
        foo;
    }
}
```
```
panic: runtime error: slice bounds out of range [2:1]
  pkg/config/compiler_routing.go:681  compilePolicyOptions
```

## Why this is a crash and not a rejection

The panic is reachable on the **tolerated** ingress, not just on operator commit.
`Store.compileTreeLenient` (`pkg/configstore/store.go:582`) deliberately downgrades a
`SchemaValidate` failure to a **warning** on `Store.Load` / `Store.SyncApply`, so a
config the operator did not just author cannot blackout-boot the node or alarm-loop HA
config sync (#1960) — and then it compiles the tree anyway, reaching the panic inside
`CompileConfig`, after the gate that would have objected has already been downgraded.

So a hand-edited persisted config, or one arriving from a peer, **crashed the daemon on
load**. That is precisely the no-brick property #1960 exists to protect.

## Root cause

`namedInstances` resolves an instance from one of **two** node shapes:

| spelling | instance node | name at | value tail at |
|---|---|---|---|
| `prefix-list PL 10.0.0.0/8;` | the leaf itself, `Keys=["prefix-list","PL","10.0.0.0/8"]` | `Keys[1]` | `Keys[2:]` |
| `prefix-list { PL … }` | the **sub-node**, `Keys=["PL", …]` | `Keys[0]` | `Keys[1:]` |

The #6564 compact-leaf read took the tail at a fixed index — `inst.node.Keys[2:]` —
which is correct for the first shape and out of range for the second.

The asymmetry that produced this is worth naming: the sibling read a few lines down
(the routing-instance `members` leaf) guards its length before indexing; this one did
not. Two adjacent reads of the same two-shape value, one guarded and one not, is how
the next one gets written unguarded too.

## The obvious fix is wrong

A bare `if len(inst.node.Keys) > 2` stops the crash and passes every block-form test.
But the block spelling can legitimately carry a compact value:

```
policy-options { prefix-list { PL 10.0.0.0/8; } }
```

parses to `Keys=["PL","10.0.0.0/8"]` — **length 2**. The bounds check skips it, the
prefix is dropped, and the list compiles **named but empty**. That is the #6564 defect
itself — a filter term scoped by a silently-empty prefix-list stops matching, on a
config that committed clean — reintroduced in the other shape.

So the tail is taken relative to the **name**, not to a fixed index, via
`instanceValueTail`, which is correct for both shapes.

## Scope is measured, and the measurement is now a test

`compiler_block_form_panic_census_7568_test.go` emits the block spelling
`<path> { probeval; }` for **every** path in `setSchema`, built from real parsed text,
and compiles each under `recover`:

> **1129 schema paths, 0 compiler panics**

A rejection is fine; a panic is not. Committing the probe rather than quoting its
result is what will catch the second site when a caller is added — otherwise "exactly
one site" is a fact about today.

**The census is deliberately assumption-free about which nodes are "named instances."**
An earlier version keyed on `sn.wildcard != nil`, reached **12** containers and reported
**zero** panics — over a defect that had already been reproduced by hand — because
`policy-options prefix-list` is declared `args:1, children:nil`, not a wildcard. A
predicate that never reaches the subject yields a clean green, which is worse than no
test at all.

Every regression test builds its tree from **parsed text**. A hand-assembled `Node`
could exhibit the panicking shape without proving the parser ever produces it, which
would make the whole thing vacuous.

## Mutation matrix

flock'd; fix **committed before mutating** (a first attempt used `git checkout --` to
restore an *uncommitted* fix, wiping it and voiding its own cells); each mutation
asserted APPLIED; `go vet` gated per cell so a build break cannot be miscounted as a
red; RUN count asserted non-zero.

| Cell | Mutation | Result |
|---|---|---|
| P1 | restore the original unguarded `Keys[2:]` | RED — census: *"PANICS … at 1 of 1129 schema paths"* |
| P2 | **the obvious fix**: bare `len(Keys) > 2` bounds check | RED — `PL prefixes = []`, *"NAMED BUT EMPTY"* |
| P3 | make `instanceValueTail` miss the self-named shape | RED — *"compact-leaf spelling lost its prefix tail"* |
| P4 | make `instanceValueTail` miss the block shape | RED — *"NAMED BUT EMPTY"* |

**P2 is the cell that matters.** It is the fix most reviewers would accept, it removes
the crash, and it silently reintroduces a data-loss bug that only the compact-value cell
can see.

## Placement

`instanceValueTail` lives beside `namedInstances` in `compiler_protocols.go` rather than
at its call site. That is where the two-shape contract is *created*, and the bug existed
precisely because the contract lived in one file while its consumer read a fixed index in
another. It also keeps `compiler_routing.go` under the 1500 LOC `[WATCH]` floor
(1474 → 1481), which the modularity gate flagged on the first attempt — the placement is
defensible on merit, and an `accepted.txt` entry asserting that a 1500-line file mixing
routing-options, policy-options and protocols "stays whole" would not have been.

## Validation

`go build ./...` clean · `go vet ./...` clean · `go test -count=1 ./...` green.
No cluster targets run. No dataplane binary or shim `.o` moved.

Found while investigating #6774; the two are independent and ship separately.

Closes #7568
