### PR TITLE
config: accept the Junos hierarchical default-policy block spelling

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104305,3 +104305,15 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: pkg/config/schema_validators.go, pkg/config/schema_system.go,
   pkg/config/compiler_validate_strict_chassis.go,
   pkg/config/numeric_bounds_6772_6773_test.go
+
+## 2026-08-22 — #6774 strict schema rejects the Junos hierarchical default-policy
+
+- **Timestamp**: 2026-08-22
+- **Action**: Taught SchemaValidate the hierarchical block spelling
+  `default-policy { deny-all; }` — the form Junos itself displays, which the
+  compiler already honours deliberately — via a per-leaf `blockValue` opt-in
+  rather than a blanket relaxation. A census found 42 distinct typed leaves
+  where the compiler tolerates a block form the schema rejects; for those the
+  schema is right and nothing changed.
+- **File(s)**: `pkg/config/schema.go`, `pkg/config/schema_security.go`,
+  `pkg/config/schema_walk.go`, `pkg/config/schema_block_value_6774_test.go`

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -47,6 +47,29 @@ type schemaNode struct {
 	// sets it; every other multi+children node is unchanged.
 	valueList bool
 
+	// blockValue opts a single-value typed leaf into the HIERARCHICAL BLOCK
+	// spelling `keyword { value; }`, in addition to the ordinary
+	// `keyword value` (#6774).
+	//
+	// This is an OPT-IN, not a general relaxation, because the two spellings
+	// are not interchangeable in Junos. `default-policy` is a CHOICE
+	// CONTAINER in the Junos schema — `permit-all` / `deny-all` /
+	// `reject-all` are alternative sub-statements, which is why Junos itself
+	// DISPLAYS it as `default-policy { deny-all; }` — while this schema
+	// models it as a valued leaf so the flat-set spelling works. The compiler
+	// accommodates both deliberately (compiler_security_policy.go). Without
+	// the opt-in the strict commit path rejects a configuration that is
+	// canonical Junos, that the compiler compiles correctly, and that the
+	// tolerated Load/SyncApply path already applies.
+	//
+	// Most typed leaves must NOT set this. `mtu { 1500; }` is not Junos, and
+	// the rejection there is correct; the compiler tolerates it only
+	// incidentally, through the generic nodeVal helper. A census of setSchema
+	// found 42 distinct leaves where the compiler accepts a block form the
+	// schema rejects, and `default-policy` is the only one where the block
+	// form is the shape Junos actually emits.
+	blockValue bool
+
 	// groupReplace opts a multi leaf OUT of apply-groups leaf-list UNION
 	// (#4070). By default a `multi:true && children==nil && args<=1` leaf is a
 	// pure single-token value-list whose group + inline members UNION under

--- a/pkg/config/schema_block_value_6774_test.go
+++ b/pkg/config/schema_block_value_6774_test.go
@@ -1,0 +1,230 @@
+package config
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// #6774: `security policies default-policy` is a CHOICE CONTAINER in Junos —
+// `permit-all` / `deny-all` / `reject-all` are alternative sub-statements, and
+// Junos itself DISPLAYS the stanza as `default-policy { deny-all; }`. This
+// schema models it as a valued leaf so the flat-set spelling works, and the
+// compiler accommodates BOTH shapes deliberately
+// (compiler_security_policy.go). Strict SchemaValidate read the value only
+// from Keys[1:], so it rejected the block spelling with "missing value" — an
+// operator pasting canonical Junos could not commit a configuration that the
+// compiler compiles correctly and that the TOLERATED Load/SyncApply path
+// (which downgrades the gate to a warning, #1960) already applies.
+//
+// #7568 is tested alongside it because the two defects are the same question
+// asked of different code: what does `keyword { value; }` mean to the walker,
+// and to the compiler.
+
+func mustParseTree6774(t *testing.T, cfg string) *ConfigTree {
+	t.Helper()
+	tree, perrs := NewParser(cfg).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v\n--- config ---\n%s", perrs, cfg)
+	}
+	return tree
+}
+
+func defaultPolicyBlock(action string) string {
+	return "security {\n    policies {\n        default-policy {\n            " + action + ";\n        }\n    }\n}"
+}
+
+func defaultPolicyFlat(action string) string {
+	return "security {\n    policies {\n        default-policy " + action + ";\n    }\n}"
+}
+
+// TestDefaultPolicyBlockFormCommits is the fail-on-revert proof: the
+// hierarchical block spelling must pass strict validation AND compile to the
+// same action as the flat spelling.
+func TestDefaultPolicyBlockFormCommits_6774(t *testing.T) {
+	for _, action := range []string{"permit-all", "deny-all", "reject-all"} {
+		blkTree := mustParseTree6774(t, defaultPolicyBlock(action))
+		blkCfg, err := CompileConfig(blkTree)
+		if err != nil {
+			t.Fatalf("%s: block form failed to compile: %v", action, err)
+		}
+		if verr := SchemaValidate(blkTree, blkCfg); verr != nil {
+			t.Fatalf("%s: strict validation REJECTED the canonical Junos block "+
+				"spelling `default-policy { %s; }`: %v", action, action, verr)
+		}
+	}
+}
+
+// TestDefaultPolicyBlockAndFlatFormsAgree binds the two spellings to EACH
+// OTHER rather than pinning either to a literal action constant. If a future
+// change made one spelling mean something different, pinning the block form to
+// a constant would only catch it on the side the test happened to encode.
+func TestDefaultPolicyBlockAndFlatFormsAgree_6774(t *testing.T) {
+	for _, action := range []string{"permit-all", "deny-all", "reject-all"} {
+		flatTree := mustParseTree6774(t, defaultPolicyFlat(action))
+		blkTree := mustParseTree6774(t, defaultPolicyBlock(action))
+
+		flatCfg, ferr := CompileConfig(flatTree)
+		blkCfg, berr := CompileConfig(blkTree)
+		if ferr != nil || berr != nil {
+			t.Fatalf("%s: compile flat=%v block=%v", action, ferr, berr)
+		}
+		if flatCfg.Security.DefaultPolicy != blkCfg.Security.DefaultPolicy {
+			t.Fatalf("%s: the two Junos spellings disagree: flat=%v block=%v",
+				action, flatCfg.Security.DefaultPolicy, blkCfg.Security.DefaultPolicy)
+		}
+		// And the whole compiled config must match, so the block form cannot
+		// be quietly setting something extra.
+		if !reflect.DeepEqual(flatCfg.Security, blkCfg.Security) {
+			t.Fatalf("%s: block and flat spellings produced different SecurityConfig", action)
+		}
+	}
+}
+
+// TestDefaultPolicyBlockRejectsAmbiguousAndInvalid is the TIGHTEN half. The
+// opt-in must not become "accept whatever is in the block".
+func TestDefaultPolicyBlockRejectsAmbiguousAndInvalid_6774(t *testing.T) {
+	cases := []struct{ name, cfg, wantSubstr string }{
+		{
+			// The compiler reads Children[0] and silently DISCARDS the rest, so
+			// this does not do what it reads as and must not commit.
+			name: "two-actions",
+			cfg: "security {\n    policies {\n        default-policy {\n" +
+				"            deny-all;\n            permit-all;\n        }\n    }\n}",
+			wantSubstr: "missing value",
+		},
+		{
+			// The block value must be VALIDATED, not merely accepted.
+			name:       "invalid-action",
+			cfg:        defaultPolicyBlock("bogus-all"),
+			wantSubstr: "bogus-all",
+		},
+		{
+			name:       "empty-block",
+			cfg:        "security {\n    policies {\n        default-policy {\n        }\n    }\n}",
+			wantSubstr: "missing value",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := mustParseTree6774(t, tc.cfg)
+			cfg, _ := CompileConfig(tree)
+			err := SchemaValidate(tree, cfg)
+			if err == nil {
+				t.Fatalf("strict validation ACCEPTED %s; the compiler discards all "+
+					"but the first token, so this config does not do what it reads as", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Fatalf("error %q does not mention %q", err, tc.wantSubstr)
+			}
+		})
+	}
+}
+
+// TestBlockValueIsOptInNotBlanketRelaxation is the over-application control,
+// and the most important cell here. A census of setSchema found 42 distinct
+// typed leaves where the COMPILER tolerates a block form (incidentally, via
+// the generic nodeVal helper) that the schema rejects. For those the schema is
+// RIGHT — `mtu { 1500; }` is not Junos — so the #6774 fix must stay opt-in.
+// Without this test, replacing the blockValue check with an unconditional
+// fallback would pass every other test in this file.
+func TestBlockValueIsOptInNotBlanketRelaxation_6774(t *testing.T) {
+	cfg := "interfaces {\n    ge-0/0/0 {\n        mtu {\n            1500;\n        }\n    }\n}"
+	tree := mustParseTree6774(t, cfg)
+	compiled, _ := CompileConfig(tree)
+	if err := SchemaValidate(tree, compiled); err == nil {
+		t.Fatal("strict validation accepted `mtu { 1500; }`: the block-form " +
+			"allowance leaked from the opted-in leaf to every typed leaf, which " +
+			"relaxes the gate on ~42 leaves where the block spelling is not Junos")
+	}
+	// Control: the same leaf in its real spelling must still commit, so the
+	// test above cannot pass merely because everything about mtu is broken.
+	okTree := mustParseTree6774(t, "interfaces {\n    ge-0/0/0 {\n        mtu 1500;\n    }\n}")
+	okCfg, err := CompileConfig(okTree)
+	if err != nil {
+		t.Fatalf("control: `mtu 1500` failed to compile: %v", err)
+	}
+	if verr := SchemaValidate(okTree, okCfg); verr != nil {
+		t.Fatalf("control: `mtu 1500` was rejected: %v", verr)
+	}
+}
+
+// TestSingleBlockValueShape pins the helper's strictness directly.
+func TestSingleBlockValueShape_6774(t *testing.T) {
+	cases := []struct {
+		name string
+		node *Node
+		want string
+		ok   bool
+	}{
+		{"one-child-one-token", &Node{Keys: []string{"default-policy"}, Children: []*Node{{Keys: []string{"deny-all"}}}}, "deny-all", true},
+		{"no-children", &Node{Keys: []string{"default-policy"}}, "", false},
+		{"two-children", &Node{Keys: []string{"default-policy"}, Children: []*Node{{Keys: []string{"deny-all"}}, {Keys: []string{"permit-all"}}}}, "", false},
+		{"child-with-two-tokens", &Node{Keys: []string{"default-policy"}, Children: []*Node{{Keys: []string{"deny-all", "extra"}}}}, "", false},
+		{"child-with-own-block", &Node{Keys: []string{"default-policy"}, Children: []*Node{{Keys: []string{"deny-all"}, Children: []*Node{{Keys: []string{"x"}}}}}}, "", false},
+	}
+	for _, tc := range cases {
+		got, ok := singleBlockValue(tc.node)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("%s: singleBlockValue = (%q,%v), want (%q,%v)", tc.name, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// TestDefaultPolicySchemaAcceptanceMatchesCompilerSupport_6774 binds the two
+// sides to EACH OTHER rather than pinning "the block form is accepted" to a
+// literal.
+//
+// The property is an agreement: the strict schema must accept exactly the
+// spellings that compiler_security_policy.go deliberately HONOURS. Pinning
+// the schema side alone would keep passing if someone later narrowed the
+// compiler's `default-policy { deny-all; }` branch — the schema would then be
+// accepting a spelling that silently does nothing, which is a worse failure
+// than the rejection this issue fixed.
+//
+// "Honoured" is measured against a baseline config with no default-policy
+// stanza at all. Note that deny-all cannot discriminate — it is also the
+// unset default (fail-closed, #3065) — so the honoured direction is asserted
+// with permit-all and reject-all, which both differ from the baseline. That
+// is stated rather than papered over: a table row that cannot fail is not
+// evidence, and including deny-all silently would make this look like three
+// discriminating cases when it is two.
+func TestDefaultPolicySchemaAcceptanceMatchesCompilerSupport_6774(t *testing.T) {
+	baseTree := mustParseTree6774(t, "security {\n    policies {\n    }\n}")
+	baseCfg, err := CompileConfig(baseTree)
+	if err != nil {
+		t.Fatalf("baseline compile: %v", err)
+	}
+	baseline := baseCfg.Security.DefaultPolicy
+
+	spellings := map[string]func(string) string{
+		"flat":  defaultPolicyFlat,
+		"block": defaultPolicyBlock,
+	}
+	// Only actions that DIFFER from the unset default can prove the compiler
+	// honoured the stanza.
+	for _, action := range []string{"permit-all", "reject-all"} {
+		for name, render := range spellings {
+			tree := mustParseTree6774(t, render(action))
+			cfg, cerr := CompileConfig(tree)
+			if cerr != nil {
+				t.Fatalf("%s/%s: compile: %v", name, action, cerr)
+			}
+			compilerHonours := cfg.Security.DefaultPolicy != baseline
+			schemaAccepts := SchemaValidate(tree, cfg) == nil
+
+			if compilerHonours != schemaAccepts {
+				t.Fatalf("%s spelling of %q: compiler honours it = %v, but strict "+
+					"schema accepts it = %v. These must agree: a spelling the "+
+					"compiler applies and the schema rejects cannot be committed "+
+					"(the #6774 defect), and a spelling the schema accepts but the "+
+					"compiler ignores commits clean and does nothing.",
+					name, action, compilerHonours, schemaAccepts)
+			}
+			if !compilerHonours {
+				t.Fatalf("%s spelling of %q was not honoured by the compiler at all; "+
+					"the fixture no longer discriminates", name, action)
+			}
+		}
+	}
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -220,6 +220,11 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 			valueExamples: []string{"deny-all", "permit-all", "reject-all"},
 			validator:     ValidateEnum([]string{"permit-all", "deny-all", "reject-all"}),
 			children:      nil,
+			// #6774: Junos displays this as `default-policy { deny-all; }` —
+			// it is a CHOICE CONTAINER there, modelled here as a valued leaf
+			// so the flat-set spelling works. Accept both; the compiler
+			// already does.
+			blockValue: true,
 		},
 		// #3534 (split from #3363 Part 2): RT_FLOW session logging for the
 		// IMPLICIT default-policy verdict. The `default-policy` leaf above is a

--- a/pkg/config/schema_walk.go
+++ b/pkg/config/schema_walk.go
@@ -402,6 +402,19 @@ func walkSchemaNode(node *Node, parent *schemaNode, path []string, vc *walkConte
 		if err := validateTypedLeaf(node, childSchema, path, siblings, vc); err != nil {
 			return err
 		}
+		// #6774: for a blockValue leaf written in the BLOCK spelling
+		// (`default-policy { deny-all; }`) the single child is the VALUE —
+		// already validated by validateTypedLeaf just above — not a modifier.
+		// Without this the modifier loop below rejects it as
+		// `unknown modifier "deny-all"`, because the leaf declares no
+		// children. This mirrors the multi-leaf branch earlier in this
+		// function, where block children are likewise values and that path
+		// therefore replaces the modifier loop too.
+		if childSchema.blockValue && len(node.Keys) == 1 {
+			if _, ok := singleBlockValue(node); ok {
+				return nil
+			}
+		}
 		// Validate modifier CHILDREN. The flat-set grouping and hierarchical
 		// blocks both nest trailing modifier tokens as children
 		// (`transmit-rate 1g { exact; }` → child Keys=["exact"];
@@ -735,6 +748,26 @@ func consumeNodeKeys(keys []string, childSchema *schemaNode) (int, *schemaNode) 
 	return consumed, childSchema
 }
 
+// singleBlockValue returns the lone value token of a hierarchical block-form
+// leaf — `keyword { value; }` parses to a node with no trailing keys and one
+// childless child whose sole key is the value (#6774).
+//
+// It is deliberately strict. More than one child, a child carrying more than
+// one token, or a child carrying its own block all return false, so the leaf
+// falls through to the ordinary "missing value" rejection rather than silently
+// binding the first token of an ambiguous block — which is exactly what the
+// compiler would then discard.
+func singleBlockValue(node *Node) (string, bool) {
+	if len(node.Children) != 1 {
+		return "", false
+	}
+	c := node.Children[0]
+	if c == nil || len(c.Keys) != 1 || len(c.Children) != 0 || c.Keys[0] == "" {
+		return "", false
+	}
+	return c.Keys[0], true
+}
+
 // validateTypedLeaf validates the value token(s) of a typed leaf.
 //
 // Value/modifier tokens come from node.Keys[1:] (flat-set + hierarchical
@@ -759,6 +792,22 @@ func validateTypedLeaf(node *Node, leafSchema *schemaNode, parentPath []string, 
 	path := append(append([]string(nil), parentPath...), leafName)
 	values := node.Keys[1:]
 	check := leafSchema.checkValue(vc)
+
+	// #6774: the hierarchical BLOCK spelling `keyword { value; }`, for the
+	// leaves that opt in via blockValue. Junos displays a choice container
+	// (`default-policy`) that way, and the compiler reads it deliberately, so
+	// without this the strict commit path rejects canonical Junos that the
+	// compiler compiles correctly and the tolerated load path applies.
+	//
+	// EXACTLY ONE child carrying EXACTLY ONE token is accepted. Two children
+	// is NOT "the first one wins": the compiler reads Children[0] and
+	// silently discards the rest, so `default-policy { deny-all; permit-all; }`
+	// does not do what it reads as and must still be rejected.
+	if len(values) == 0 && leafSchema.blockValue {
+		if v, ok := singleBlockValue(node); ok {
+			values = []string{v}
+		}
+	}
 
 	if len(values) == 0 {
 		return typedLeafErrorf(path, "missing value")


### PR DESCRIPTION
## What

`security policies default-policy` is a **choice container** in Junos —
`permit-all` / `deny-all` / `reject-all` are alternative sub-statements — which is why
Junos itself *displays* the stanza as:

```
security {
    policies {
        default-policy {
            deny-all;
        }
    }
}
```

This schema models it as a valued leaf so the flat-set spelling works, and the compiler
accommodates **both** shapes deliberately, in a dedicated branch reading
`child.Children[0].Name()` with a comment naming the form
(`compiler_security_policy.go`). Strict `SchemaValidate` did not — it took the value
only from `Keys[1:]` — so an operator pasting canonical Junos could not commit a
configuration the compiler compiles correctly.

Measured before anything was touched:

| form | compiles to | `SchemaValidate` |
|---|---|---|
| `default-policy { deny-all; }` | `PolicyDeny` | ❌ `missing value` |
| `default-policy deny-all;` | `PolicyDeny` | ✅ |
| `default-policy { permit-all; }` | `PolicyPermit` | ❌ `missing value` |

## Severity is narrower than it sounds — checked, not assumed

`Store.compileTreeLenient` downgrades a `SchemaValidate` failure to a **warning** on the
tolerated `Load`/`SyncApply` ingress (#1960), so a persisted or peer-synced config in
this spelling still compiles to the correct action. The break is confined to the
operator's strict commit path. **There is no fail-open.**

## Why an opt-in and not a general relaxation

I censused every typed single-value leaf in `setSchema`. **131 leaves** (42 distinct —
the rest are the `groups` mirror) accept a block form in the compiler that the schema
rejects.

That looks like 131 bugs until you ask *which side is wrong*. For `mtu { 1500; }` or
`tunnel source { 10.0.2.10; }` the block form is **not** Junos and the schema is **right**
to reject it; the compiler tolerates it only incidentally, through the generic `nodeVal`
helper (`Keys[1]` else `Children[0].Name()`, **449 call sites**). They are not 131
defects — they are one generic leniency, and relaxing the schema to match would widen the
gate on 41 leaves in order to fix one.

`default-policy` is different because the compiler accommodates it **deliberately**, for a
shape Junos actually emits. That is the discriminator, and it is why `blockValue` is set
per leaf, each opt-in owing a test.

*Recording the number here so the next person to run that census finds the answer rather
than repeating it. No separate issue — this is not a defect.*

## Two exemption sites, worth knowing for the next opt-in

The walker needed the block value exempted in **two** places: `validateTypedLeaf` reads
the value, and the modifier-child loop in `walkSchemaNode` would otherwise reject the same
child as `unknown modifier "deny-all"` because the leaf declares no children. The
multi-value leaf branch a few lines above already sets that precedent — there too the
block children are *values*, not modifiers, and that path likewise replaces the modifier
loop.

## Acceptance is deliberately strict

`singleBlockValue` requires **exactly one** child carrying **exactly one** token. So
`default-policy { deny-all; permit-all; }` is still rejected: the compiler reads
`Children[0]` and silently discards the rest, so that config does not do what it reads as.

## Tests bind the agreement, not a literal

`TestDefaultPolicySchemaAcceptanceMatchesCompilerSupport_6774` asserts the schema accepts
exactly the spellings the compiler **honours**. Pinning "block form accepted" to a literal
would keep passing if someone later narrowed the compiler branch — the schema would then
be accepting a spelling that silently does nothing, which is a worse failure than the
rejection fixed here.

The honoured direction uses `permit-all` and `reject-all` only: `deny-all` is also the
unset default (#3065) and therefore **cannot discriminate**. That is stated in the test
rather than padded out to three rows that would look like evidence.

## Mutation matrix

flock'd; fix committed before mutating; each mutation asserted APPLIED; `go vet` gated per
cell; RUN count asserted non-zero.

| Cell | Mutation | Result |
|---|---|---|
| M1 | remove the `blockValue: true` opt-in | RED — block spelling rejected again |
| M2 | disable the value substitution in `validateTypedLeaf` | RED — same |
| M3 | disable the modifier-child exemption | RED — incl. the agreement test |
| M4 | **TIGHTEN**: make the block form unconditional (drop the opt-in check) | RED — `mtu { 1500; }` accepted |
| M5 | **TIGHTEN**: allow more than one child | RED — `deny-all; permit-all;` accepted |
| M6 | **TIGHTEN**: drop the child-shape checks | RED — child-with-two-tokens / child-with-own-block |

**M4 is the cell that matters.** It is the shorter, simpler implementation — and it
relaxes the gate on ~41 leaves where the block spelling is not Junos. Every other test in
the file passes under it.

## Validation

`go build ./...` clean · `go vet ./...` clean · `go test -count=1 ./...` green.
No cluster targets run. No dataplane binary or shim `.o` moved.

The compiler **panic** found while investigating this issue ships separately as #7568 —
it is an #1960 no-brick violation on the tolerated load path and should not queue behind
a schema-acceptance discussion.

Closes #6774
