### PR TITLE
ra: surface and retain a failed final graceful goodbye

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104336,3 +104336,10 @@ prose edit above them added. No diff falls in the new test body.
   (`Manager.goodbyeOwed`) that `Apply` re-drives via `WithdrawOnce`.
 - **File(s)**: pkg/ra/ra.go, pkg/ra/sender.go,
   pkg/ra/goodbye_retry_debt_6777_test.go, pkg/ra/README.md, _Log.md
+- **Timestamp**: 2026-08-22
+- **Action**: #6777 round 2 — bound the two mutation cells that came back GREEN.
+  `recordedEpoch` (a debt recorded by the current Apply is held over, not
+  retried on the same pass) and the busy-skip attempt refund were both
+  documented claims with no assertion behind them; a mutation neutralising
+  either left the suite green.
+- **File(s)**: pkg/ra/goodbye_retry_debt_6777_test.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -104318,3 +104318,21 @@ prose edit above them added. No diff falls in the new test body.
     pkg/configstore/bounded_read_6753_test.go,
     pkg/cli/load_bounded_read_6753_test.go, cmd/cli/main.go,
     cmd/cli/load_bounded_read_7469_test.go (new), pkg/configstore/README.md
+
+## 2026-08-22 — #6777 graceful RA withdrawal: final goodbye failure surfaced + retry debt
+
+- **Timestamp**: 2026-08-22
+- **Action**: Graceful RA withdrawal discarded the final lifetime-0 goodbye
+  failure and erased the state a retry needed. `finishDrainDecision` logged the
+  standalone-backstop failure, set `goodbyeClaimed`, deleted the tombstone and
+  returned only the replacement-start error; `Manager.Withdraw` returned a
+  hard-coded `nil`, making the `if err := d.ra.Withdraw(); err != nil` branch at
+  all three production call sites unreachable. Because
+  `reconcileClusterRAServices` advances `lastRAReconcileHash` only on a
+  successful apply, the swallowed failure was latched as converged and the 2s
+  pass never retried — the stale IPv6 default-router identity survived on hosts
+  until Router Lifetime expiry. Fix propagates the goodbye error out through
+  `releaseDrain` to `Withdraw`/`Apply`, and retains bounded retry debt
+  (`Manager.goodbyeOwed`) that `Apply` re-drives via `WithdrawOnce`.
+- **File(s)**: pkg/ra/ra.go, pkg/ra/sender.go,
+  pkg/ra/goodbye_retry_debt_6777_test.go, pkg/ra/README.md, _Log.md

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -119,6 +119,55 @@ after HA failover. To make that **structural**, not flag-defended:
   goroutine's `openConn()` BEFORE its main loop, NOT under `m.mu` (see "Bind
   retry runs unlocked" below). The tombstone (held) still provides mutual
   exclusion for the start.
+- **A failed FINAL goodbye is returned AND retained (#6777).** The graceful
+  withdrawal path gets exactly two chances to put a lifetime-0 RA on the wire:
+  the owner's own emit in `finishShutdown`, and — if that failed, leaving
+  `goodbyeEmitted` false — `finishDrainDecision`'s standalone backstop on a
+  fresh conn. Before #6777 a failure of that LAST chance was logged and then
+  erased: the same pass set `goodbyeClaimed`, deleted the tombstone and dropped
+  the sender, and `finishDrainDecision` returned only the replacement-start
+  error. `Withdraw()` returned a hard-coded `nil`, so all three production call
+  sites (`applyServicesReconcile`'s RA-removal branch, daemon shutdown, and the
+  VRRP BACKUP transition) carried an `if err := d.ra.Withdraw(); err != nil`
+  branch that was unreachable. Worse, the daemon's own retry driver
+  (`reconcileClusterRAServices`) advances `lastRAReconcileHash` **only on a
+  successful apply** — so a swallowed failure was latched as converged and the
+  every-2s pass never retried. Operators saw a clean withdrawal while the stale
+  IPv6 default-router identity lived on hosts for up to Router Lifetime (default
+  1800s).
+
+  Both halves are now fixed. `finishDrainDecision` returns the goodbye error
+  separately from the start error; `releaseDrain` joins them; `Withdraw()` and
+  `Apply`'s empty-config branch aggregate across interfaces. And the failure
+  leaves **retry debt** in `Manager.goodbyeOwed`, because surfacing alone is not
+  enough — once the tombstone and sender are gone a later pass has nothing left
+  to act on. `Apply` re-attempts every owed goodbye whose interface is not in the
+  desired set (through `WithdrawOnce`, so a retry takes the same claim-and-hold
+  tombstone and can never open a second conn), and returns non-nil while any debt
+  survives — which is what keeps the reconcile digest un-advanced so the periodic
+  pass re-drives it. The debt is the graceful-path twin of the one-shot
+  `WithdrawOnce` debt #5093 introduced.
+
+  Three rules keep the debt from becoming a liability of its own:
+  - **A vanished netdev records nothing.** `sendOneGoodbye` wraps a missing
+    interface as `errGoodbyeIfaceMissing`; there is no link to emit on and no
+    host behind it left to hear a goodbye, so retaining it would make a
+    legitimately removed interface a permanent `Apply` error and suppress the
+    node's whole RA reconcile digest. Only a bind failure or `errGoodbyeWrite`
+    is retained — the transient shapes the debt exists for.
+  - **It is bounded** (`maxGoodbyeRetries`). An interface that can never accept
+    the goodbye is given up on with a single Warn rather than re-applying and
+    logging every 2s forever.
+  - **It is dropped when the router comes back.** A debt whose interface
+    reappears in the desired set is dropped rather than retried — emitting it
+    would withdraw the router the new sender is advertising. That drop lives in
+    exactly ONE place (`retryOwedGoodbyes`), not also in `startLocked`: every
+    path that starts a sender does so from an interface that is in `desired`, so
+    a second clear there would be a redundant copy of one invariant, and a
+    divergence between two copies of "a sender implies no debt" is always a bug.
+    A debt recorded by the CURRENT `Apply` is held over to the next pass
+    (`recordedEpoch`) instead of being retried microseconds after the backstop
+    already failed on a fresh conn.
 - **Draining tombstone — one live conn per interface, including replaces.**
   Every transition that removes OR replaces a sender installs a
   per-interface DRAINING tombstone under the manager mutex BEFORE releasing

--- a/pkg/ra/goodbye_retry_debt_6777_test.go
+++ b/pkg/ra/goodbye_retry_debt_6777_test.go
@@ -1,0 +1,358 @@
+package ra
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mdlayher/ndp"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// errSimGoodbyeWrite is the injected write failure. It is NOT errGoodbyeWrite
+// itself: the production code wraps this into errGoodbyeWrite at the
+// sendGoodbyeStandalone boundary, and asserting on the wrapper is what proves
+// the classification survives the whole path rather than being re-derived from
+// a value the test planted.
+var errSimGoodbyeWrite = errors.New("simulated lifetime-0 write failure")
+
+// goodbyeProbe is the #6777 seam. Every conn BINDS successfully; a write of a
+// lifetime-0 (goodbye) RA is counted and — while failing is set — rejected.
+// Normal RAs are left alone, so a sender started through this probe behaves
+// normally right up to its final goodbye. Counting ATTEMPTS (not conns) is the
+// point: the property under test is "was another lifetime-0 emit tried at all",
+// which is exactly what the pre-#6777 code could not do once it had erased the
+// tombstone and dropped the sender.
+type goodbyeProbe struct {
+	mu       sync.Mutex
+	failing  bool
+	attempts map[string]int
+}
+
+func (g *goodbyeProbe) setFailing(v bool) {
+	g.mu.Lock()
+	g.failing = v
+	g.mu.Unlock()
+}
+
+func (g *goodbyeProbe) attemptsFor(name string) int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.attempts[name]
+}
+
+func installGoodbyeProbe(t *testing.T, failing bool) *goodbyeProbe {
+	t.Helper()
+	g := &goodbyeProbe{failing: failing, attempts: map[string]int{}}
+	origListen := listenFn
+	origEnsure := ensureLinkLocalFn
+	t.Cleanup(func() { listenFn = origListen; ensureLinkLocalFn = origEnsure })
+	ensureLinkLocalFn = func(*net.Interface) error { return nil }
+	listenFn = func(iface *net.Interface, _ ndp.Addr) (ndpConn, netip.Addr, error) {
+		name := iface.Name
+		fc := newFakeConn()
+		// The hook runs BEFORE WriteTo consults writeErr, so arming it here
+		// takes effect on this very write.
+		fc.setBeforeWrite(func(lifetime time.Duration) {
+			if lifetime != 0 {
+				return
+			}
+			g.mu.Lock()
+			g.attempts[name]++
+			fail := g.failing
+			g.mu.Unlock()
+			if fail {
+				fc.setWriteErr(errSimGoodbyeWrite)
+			} else {
+				fc.setWriteErr(nil)
+			}
+		})
+		return fc, netip.MustParseAddr("fe80::1"), nil
+	}
+	return g
+}
+
+func requireLo(t *testing.T) {
+	t.Helper()
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+}
+
+func (m *Manager) owedCountForTest() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.goodbyeOwed)
+}
+
+// TestGracefulWithdrawSurfacesFinalGoodbyeFailure6777 is the SURFACE half of
+// #6777. Manager.Withdraw returned a hard-coded nil: releaseDrain's goodbye
+// outcome was logged inside finishDrainDecision and then thrown away, so all
+// three production call sites — the config-removal apply, daemon shutdown, and
+// the VRRP BACKUP transition — carried an `if err := d.ra.Withdraw(); err !=
+// nil` branch that could never be reached. A router whose final lifetime-0 RA
+// never went out was reported to operators as a clean withdrawal.
+//
+// NON-TAUTOLOGY: revert Withdraw to `return nil` and this fails RED.
+func TestGracefulWithdrawSurfacesFinalGoodbyeFailure6777(t *testing.T) {
+	requireLo(t)
+	g := installGoodbyeProbe(t, false)
+
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	g.setFailing(true)
+	err := m.Withdraw()
+	if err == nil {
+		t.Fatal("Withdraw() returned nil after EVERY lifetime-0 write failed — " +
+			"the final goodbye was discarded and reported as success (#6777)")
+	}
+	if g.attemptsFor("lo") == 0 {
+		t.Fatal("no lifetime-0 write was even attempted; the probe did not " +
+			"exercise the goodbye path, so the assertion above proves nothing")
+	}
+}
+
+// TestApplyRemovalSurfacesFinalGoodbyeFailure6777 is the same surface property
+// on the OTHER graceful-withdrawal entry point: Apply with an empty desired set,
+// which is the cluster "this node owns no RG any more" withdrawal driven by
+// reconcileClusterRAServices. That caller latches convergence on a nil return,
+// so a swallowed failure there is what erases the retry.
+//
+// NON-TAUTOLOGY: restore the empty-config branch's `return nil` → RED.
+func TestApplyRemovalSurfacesFinalGoodbyeFailure6777(t *testing.T) {
+	requireLo(t)
+	g := installGoodbyeProbe(t, false)
+
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	g.setFailing(true)
+	if err := m.Apply(nil); err == nil {
+		t.Fatal("Apply(nil) returned nil after every lifetime-0 write failed — " +
+			"reconcileClusterRAServices would latch this as converged (#6777)")
+	}
+	if g.attemptsFor("lo") == 0 {
+		t.Fatal("no lifetime-0 write attempted; probe did not reach the goodbye")
+	}
+}
+
+// TestFailedFinalGoodbyeIsRetriedByALaterApply6777 is the RETRY-DEBT half, and
+// the load-bearing cell of the pair. Surfacing the error alone is not the fix:
+// pre-#6777 finishDrainDecision also set goodbyeClaimed, deleted the tombstone
+// and dropped the sender, so even a caller that DID see a failure had nothing
+// left to retry — a later Apply found no sender and no tombstone for the
+// interface and emitted nothing. The debt is what makes the daemon's existing
+// every-2s driver able to act.
+//
+// NON-TAUTOLOGY: delete the recordGoodbyeDebtLocked call (keeping the error
+// return) and the second Apply attempts NO further lifetime-0 write → RED.
+func TestFailedFinalGoodbyeIsRetriedByALaterApply6777(t *testing.T) {
+	requireLo(t)
+	g := installGoodbyeProbe(t, false)
+
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	g.setFailing(true)
+	if err := m.Apply(nil); err == nil {
+		t.Fatal("withdrawal with a failing goodbye reported success (#6777)")
+	}
+	afterWithdraw := g.attemptsFor("lo")
+	if afterWithdraw == 0 {
+		t.Fatal("no lifetime-0 write attempted during the withdrawal")
+	}
+	if m.owedCountForTest() != 1 {
+		t.Fatalf("retry debt not retained after a failed final goodbye: owed=%d",
+			m.owedCountForTest())
+	}
+
+	// A LATER pass with the interface still un-desired must try again. This is
+	// the pass reconcileClusterRAServices makes only because the previous Apply
+	// returned non-nil and left the convergence digest un-advanced.
+	if err := m.Apply(nil); err == nil {
+		t.Fatal("the second pass reported success while the goodbye was still owed")
+	}
+	afterRetry := g.attemptsFor("lo")
+	if afterRetry <= afterWithdraw {
+		t.Fatalf("no goodbye was re-attempted on the next pass "+
+			"(attempts %d -> %d): the retry debt was cleared along with the "+
+			"tombstone, so the withdrawal can never complete (#6777)",
+			afterWithdraw, afterRetry)
+	}
+}
+
+// TestFinalGoodbyeRetrySucceedsAndClearsDebt6777 closes the loop: once the
+// interface accepts the write, the retry SENDS, the debt is dropped, and no
+// further pass emits a stray lifetime-0 RA. The trailing no-op assertion is the
+// tightening control — a debt that is reported cleared but keeps re-emitting
+// would advertise a withdrawal for an interface nobody is withdrawing.
+func TestFinalGoodbyeRetrySucceedsAndClearsDebt6777(t *testing.T) {
+	requireLo(t)
+	g := installGoodbyeProbe(t, false)
+
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	g.setFailing(true)
+	if err := m.Apply(nil); err == nil {
+		t.Fatal("withdrawal with a failing goodbye reported success")
+	}
+
+	// The link recovers. The next pass must retry and succeed.
+	g.setFailing(false)
+	beforeRetry := g.attemptsFor("lo")
+	if err := m.Apply(nil); err != nil {
+		t.Fatalf("the retry pass should have SENT the goodbye and returned nil, got %v", err)
+	}
+	if g.attemptsFor("lo") <= beforeRetry {
+		t.Fatal("the successful pass emitted no lifetime-0 RA at all — it " +
+			"returned nil without doing the work")
+	}
+	if m.owedCountForTest() != 0 {
+		t.Fatalf("debt survived a SUCCESSFUL retry: owed=%d", m.owedCountForTest())
+	}
+
+	settled := g.attemptsFor("lo")
+	if err := m.Apply(nil); err != nil {
+		t.Fatalf("a pass with no debt outstanding must return nil, got %v", err)
+	}
+	if g.attemptsFor("lo") != settled {
+		t.Fatalf("a cleared debt still emitted a goodbye (attempts %d -> %d)",
+			settled, g.attemptsFor("lo"))
+	}
+}
+
+// TestFinalGoodbyeRetryDebtIsBounded6777 guards the other direction. Apply
+// returns non-nil while debt is outstanding, and that non-nil is precisely what
+// stops reconcileClusterRAServices advancing its digest — so an interface that
+// can NEVER accept the goodbye would otherwise re-apply and log every 2s
+// forever. After maxGoodbyeRetries the debt is dropped, Apply goes quiet, and no
+// further emit is attempted.
+func TestFinalGoodbyeRetryDebtIsBounded6777(t *testing.T) {
+	requireLo(t)
+	g := installGoodbyeProbe(t, false)
+
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	g.setFailing(true)
+	if err := m.Apply(nil); err == nil {
+		t.Fatal("withdrawal with a failing goodbye reported success")
+	}
+
+	// Drive passes until Apply goes quiet. The bound must be reached in a small,
+	// fixed number of passes; the loop cap is deliberately far above
+	// maxGoodbyeRetries so an unbounded implementation fails on the cap rather
+	// than hanging.
+	quietAt := -1
+	for i := 0; i < maxGoodbyeRetries+5; i++ {
+		if err := m.Apply(nil); err == nil {
+			quietAt = i
+			break
+		}
+	}
+	if quietAt < 0 {
+		t.Fatalf("Apply(nil) still reported an outstanding goodbye after %d "+
+			"passes — the retry debt is unbounded and would suppress the RA "+
+			"reconcile digest forever", maxGoodbyeRetries+5)
+	}
+	if m.owedCountForTest() != 0 {
+		t.Fatalf("debt survived the bound: owed=%d", m.owedCountForTest())
+	}
+	settled := g.attemptsFor("lo")
+	if err := m.Apply(nil); err != nil {
+		t.Fatalf("a pass after the bound must return nil, got %v", err)
+	}
+	if g.attemptsFor("lo") != settled {
+		t.Fatalf("a dropped debt still emitted a goodbye (attempts %d -> %d)",
+			settled, g.attemptsFor("lo"))
+	}
+}
+
+// TestGoodbyeDebtDroppedWhenInterfaceIsAdvertisedAgain6777 asserts the debt is
+// not a zombie. If the operator (or a VRRP re-promotion) brings RA back on the
+// interface, the owed lifetime-0 RA must NOT be emitted — it would withdraw the
+// router the sender we just started is advertising.
+func TestGoodbyeDebtDroppedWhenInterfaceIsAdvertisedAgain6777(t *testing.T) {
+	requireLo(t)
+	g := installGoodbyeProbe(t, false)
+
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	g.setFailing(true)
+	if err := m.Apply(nil); err == nil {
+		t.Fatal("withdrawal with a failing goodbye reported success")
+	}
+	if m.owedCountForTest() != 1 {
+		t.Fatalf("precondition: expected 1 owed goodbye, got %d", m.owedCountForTest())
+	}
+
+	g.setFailing(false)
+	beforeReadvertise := g.attemptsFor("lo")
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("re-advertising Apply: %v", err)
+	}
+	if m.owedCountForTest() != 0 {
+		t.Fatalf("debt survived the interface being advertised again: owed=%d",
+			m.owedCountForTest())
+	}
+	if g.attemptsFor("lo") != beforeReadvertise {
+		t.Fatalf("a lifetime-0 goodbye was emitted on an interface that is "+
+			"advertising again (attempts %d -> %d) — that withdraws the router "+
+			"the new sender just announced", beforeReadvertise, g.attemptsFor("lo"))
+	}
+}
+
+// TestVanishedInterfaceLeavesNoGoodbyeRetryDebt6777 is the PAIRED cell for the
+// debt-classification rule: the same call site, two error shapes, opposite
+// outcomes. A netdev that no longer exists can never accept a goodbye and has
+// no hosts behind it left to hear one, so retaining debt for it would make a
+// legitimately removed interface a permanent Apply error and suppress the RA
+// reconcile digest for the whole node. A write failure IS retained.
+//
+// Without the negative half, "records debt on failure" would be satisfied by an
+// implementation that records debt for EVERY failure — the shape that bricks
+// the reconcile.
+func TestVanishedInterfaceLeavesNoGoodbyeRetryDebt6777(t *testing.T) {
+	m := New()
+	cfg := testCfg("ge-0-0-vanished")
+
+	// Negative: the exact wrapping sendOneGoodbye produces for a missing netdev.
+	missing := fmt.Errorf("%w %s: %w", errGoodbyeIfaceMissing, cfg.Interface, os.ErrNotExist)
+	m.mu.Lock()
+	m.recordGoodbyeDebtLocked(cfg.Interface, cfg, missing)
+	m.mu.Unlock()
+	if got := m.owedCountForTest(); got != 0 {
+		t.Fatalf("a vanished interface recorded retry debt (owed=%d) — every "+
+			"later Apply would return non-nil forever and the node's RA "+
+			"reconcile digest would never advance", got)
+	}
+
+	// Positive control: a write failure on the same call site MUST be retained,
+	// so the negative above is a classification and not a dead code path.
+	writeFail := fmt.Errorf("%w on %s", errGoodbyeWrite, cfg.Interface)
+	m.mu.Lock()
+	m.recordGoodbyeDebtLocked(cfg.Interface, cfg, writeFail)
+	m.mu.Unlock()
+	if got := m.owedCountForTest(); got != 1 {
+		t.Fatalf("a lifetime-0 WRITE failure recorded no retry debt (owed=%d) — "+
+			"recordGoodbyeDebtLocked is rejecting everything", got)
+	}
+}

--- a/pkg/ra/goodbye_retry_debt_6777_test.go
+++ b/pkg/ra/goodbye_retry_debt_6777_test.go
@@ -356,3 +356,124 @@ func TestVanishedInterfaceLeavesNoGoodbyeRetryDebt6777(t *testing.T) {
 			"recordGoodbyeDebtLocked is rejecting everything", got)
 	}
 }
+
+func (m *Manager) debtAttemptsForTest(name string) (int, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	d := m.goodbyeOwed[name]
+	if d == nil {
+		return 0, false
+	}
+	return d.attempts, true
+}
+
+// TestFreshGoodbyeDebtIsNotRetriedInTheSamePass6777 binds the recordedEpoch
+// hold-over. retryOwedGoodbyes runs at the END of Apply, and Apply bumps the
+// epoch at its start, so a debt recorded by THIS Apply's own withdrawal would
+// otherwise be retried microseconds after the standalone backstop already
+// failed on a fresh conn — burning one of the bounded attempts on the same tick.
+// The budget exists to span the daemon's 2s reconcile passes; spending it three
+// times on one pass shortens the window in which a transient failure can
+// recover to almost nothing.
+//
+// The assertion is on the ATTEMPT COUNTER rather than on an emit count because
+// the counter is what the bound consumes; an emit count would also move for
+// reasons (owner emit vs backstop emit) that are not the property under test.
+//
+// NON-TAUTOLOGY: neutralise the `d.recordedEpoch == m.epoch` hold-over and the
+// withdrawing Apply leaves attempts at 1 → RED.
+func TestFreshGoodbyeDebtIsNotRetriedInTheSamePass6777(t *testing.T) {
+	requireLo(t)
+	g := installGoodbyeProbe(t, false)
+
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	g.setFailing(true)
+	if err := m.Apply(nil); err == nil {
+		t.Fatal("withdrawal with a failing goodbye reported success")
+	}
+
+	attempts, owed := m.debtAttemptsForTest("lo")
+	if !owed {
+		t.Fatal("precondition: no debt was retained by the failing withdrawal")
+	}
+	if attempts != 0 {
+		t.Fatalf("the withdrawing Apply spent %d retry attempt(s) on its own "+
+			"fresh debt; the bounded budget is meant to span reconcile passes, "+
+			"not be consumed on the pass that created the debt", attempts)
+	}
+
+	// The NEXT pass is the one that may spend an attempt. Asserting this is what
+	// makes the check above a hold-over rather than a never-retry.
+	if err := m.Apply(nil); err == nil {
+		t.Fatal("the next pass reported success while the goodbye was still owed")
+	}
+	if attempts, _ := m.debtAttemptsForTest("lo"); attempts != 1 {
+		t.Fatalf("the next pass spent %d attempts, want exactly 1 — the "+
+			"hold-over must defer the retry, not cancel it", attempts)
+	}
+}
+
+// TestBusySkipDoesNotSpendARetryAttempt6777 binds the refund. A retry that finds
+// the interface BUSY (another owner holds a claim tombstone, so WithdrawOnce
+// self-skips) emitted nothing — charging it against the bounded budget would let
+// a few unlucky passes exhaust the retries without a single lifetime-0 write
+// ever having been attempted, and the debt would then be dropped as "gave up"
+// on an interface we never actually tried.
+//
+// The tombstone is installed directly because that is the state a concurrent
+// Apply/Withdraw/WithdrawOnce leaves; driving a real concurrent owner would make
+// the fixture timing-dependent for no additional coverage.
+//
+// NON-TAUTOLOGY: remove the refund and the busy pass leaves attempts at 1 → RED.
+func TestBusySkipDoesNotSpendARetryAttempt6777(t *testing.T) {
+	requireLo(t)
+	g := installGoodbyeProbe(t, false)
+
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	g.setFailing(true)
+	if err := m.Apply(nil); err == nil {
+		t.Fatal("withdrawal with a failing goodbye reported success")
+	}
+	if attempts, owed := m.debtAttemptsForTest("lo"); !owed || attempts != 0 {
+		t.Fatalf("precondition: want owed debt with 0 attempts, got attempts=%d owed=%v",
+			attempts, owed)
+	}
+
+	// Another owner claims the interface. A retry must self-skip on this.
+	m.mu.Lock()
+	m.draining["lo"] = &drainEntry{cfg: testCfg("lo"), goodbyeClaimed: true}
+	m.mu.Unlock()
+
+	beforeBusy := g.attemptsFor("lo")
+	if err := m.Apply(nil); err == nil {
+		t.Fatal("a pass that could not emit reported success")
+	}
+	if got := g.attemptsFor("lo"); got != beforeBusy {
+		t.Fatalf("a lifetime-0 RA was emitted on an interface another owner "+
+			"holds (attempts %d -> %d) — that is the second-conn shape "+
+			"WithdrawOnce's claim exists to prevent", beforeBusy, got)
+	}
+	if attempts, owed := m.debtAttemptsForTest("lo"); !owed || attempts != 0 {
+		t.Fatalf("a busy skip spent a retry attempt (attempts=%d owed=%v): "+
+			"nothing was emitted, so nothing should be charged against the "+
+			"bounded budget", attempts, owed)
+	}
+
+	// Release the claim: the following pass must actually try.
+	m.mu.Lock()
+	delete(m.draining, "lo")
+	m.mu.Unlock()
+	if err := m.Apply(nil); err == nil {
+		t.Fatal("the pass after the claim cleared reported success")
+	}
+	if attempts, _ := m.debtAttemptsForTest("lo"); attempts != 1 {
+		t.Fatalf("after the claim cleared the retry spent %d attempts, want 1 — "+
+			"the refund must not make the debt un-spendable", attempts)
+	}
+}

--- a/pkg/ra/ra.go
+++ b/pkg/ra/ra.go
@@ -13,6 +13,7 @@
 package ra
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -105,14 +106,64 @@ type Manager struct {
 	// (re)placement only if THIS interface's epoch is still unchanged. A withdraw
 	// of interface B thus cannot cancel interface A's restart.
 	ifaceEpoch map[string]uint64
+
+	// goodbyeOwed is the graceful-withdrawal RETRY DEBT (#6777). A graceful
+	// withdrawal's FINAL lifetime-0 goodbye is the last chance hosts get to drop
+	// this router before Router Lifetime (default 1800s) expiry; before #6777 a
+	// failure of that final emit was logged and then ERASED — finishDrainDecision
+	// set goodbyeClaimed, deleted the tombstone, dropped the sender, and returned
+	// only the replacement-start error, so Withdraw()/Apply() reported success.
+	// The daemon's own retry driver (reconcileClusterRAServices) advances
+	// lastRAReconcileHash ONLY on a successful apply, so a swallowed failure was
+	// latched as converged and the every-2s pass never retried it: the stale IPv6
+	// default-router identity lived on hosts for up to 30 minutes while operators
+	// saw a clean withdrawal. This is the graceful-path twin of the one-shot
+	// WithdrawOnce debt #5093 fixed.
+	//
+	// An entry here means "a lifetime-0 RA is still OWED on this interface and no
+	// sender/tombstone remains to carry it". Apply re-attempts every owed goodbye
+	// whose interface is not in the desired set and returns a non-nil error while
+	// any debt survives, which keeps the reconcile digest un-advanced so the
+	// periodic pass re-drives it. Debt is bounded (maxGoodbyeRetries) so a
+	// permanently unsendable interface cannot spin the 2s reconcile forever, and
+	// is dropped outright when a sender is (re)started on the interface — the
+	// router is BACK, so there is nothing left to withdraw.
+	goodbyeOwed map[string]*goodbyeDebt
 }
+
+// goodbyeDebt is one interface's outstanding final-goodbye retry debt (#6777).
+type goodbyeDebt struct {
+	cfg      *config.RAInterfaceConfig
+	attempts int
+	// recordedEpoch is the whole-manager epoch this debt was (re-)recorded at.
+	// retryOwedGoodbyes runs at the END of Apply, and Apply bumps the epoch at
+	// its start, so a debt recorded by THIS Apply's own withdrawal carries the
+	// current epoch. Retrying it in the same pass would burn one of the bounded
+	// attempts microseconds after the standalone backstop already failed on a
+	// fresh conn — the budget exists to span the daemon's 2s reconcile passes,
+	// not to be spent three times on one tick. Same-epoch debts are therefore
+	// held over (and still reported outstanding, which is what keeps the
+	// reconcile digest un-advanced so a next pass happens at all).
+	recordedEpoch uint64
+}
+
+// maxGoodbyeRetries bounds the #6777 retry debt. The debt exists to survive a
+// TRANSIENT emit failure (a link-local that has not come back yet, a momentary
+// write error) across the daemon's 2s reconcile pass. It must NOT become an
+// unbounded error source: Apply returns non-nil while any debt is outstanding,
+// which suppresses the reconcile digest, so an interface that can never accept
+// the goodbye (its link-local is permanently gone) would otherwise re-apply and
+// log every 2s forever. After this many further attempts the debt is dropped
+// with a single Warn — we tried, we said so, we stop.
+const maxGoodbyeRetries = 3
 
 // New creates a new RA manager.
 func New() *Manager {
 	return &Manager{
-		senders:    make(map[string]*sender),
-		draining:   make(map[string]*drainEntry),
-		ifaceEpoch: make(map[string]uint64),
+		senders:     make(map[string]*sender),
+		draining:    make(map[string]*drainEntry),
+		ifaceEpoch:  make(map[string]uint64),
+		goodbyeOwed: make(map[string]*goodbyeDebt),
 	}
 }
 
@@ -122,6 +173,132 @@ func (m *Manager) bumpEpoch() { m.epoch++ }
 // bumpIfaceEpoch increments the per-interface supersession revision for name
 // (#4961). Callers must hold m.mu.
 func (m *Manager) bumpIfaceEpoch(name string) { m.ifaceEpoch[name]++ }
+
+// recordGoodbyeDebtLocked retains the #6777 retry debt for a FAILED final
+// lifetime-0 goodbye on name, so a later Apply can re-attempt it. Callers hold
+// m.mu.
+//
+// A "interface not found" failure records NOTHING: the netdev is gone, so there
+// is no link to emit on and no host behind it left to hear a goodbye. Retrying
+// that would be a permanent error source for a legitimately-removed interface.
+// A bind or write failure IS retained — those are the transient shapes the debt
+// exists for (a link-local that has not come back yet on a demoting RETH member
+// mid-MAC-cycle, a momentary write error).
+//
+// The attempt counter is preserved across re-records so a repeatedly failing
+// interface converges on maxGoodbyeRetries rather than restarting its budget
+// every pass.
+func (m *Manager) recordGoodbyeDebtLocked(name string, cfg *config.RAInterfaceConfig, err error) {
+	if cfg == nil {
+		return
+	}
+	if !errors.Is(err, errGoodbyeWrite) && !isGoodbyeBindFailure(err) {
+		slog.Debug("ra: final goodbye failed on a vanished interface; no retry debt",
+			"interface", name, "err", err)
+		return
+	}
+	d := m.goodbyeOwed[name]
+	if d == nil {
+		d = &goodbyeDebt{}
+		m.goodbyeOwed[name] = d
+	}
+	d.cfg = cfg
+	d.recordedEpoch = m.epoch
+	slog.Info("ra: retaining final-goodbye retry debt", "interface", name,
+		"attempts", d.attempts)
+}
+
+// isGoodbyeBindFailure reports whether err is a goodbye failure that happened
+// BEFORE the lifetime-0 write — i.e. sendOneGoodbye's ndp.Listen leg failed.
+// sendOneGoodbye wraps the two pre-write failures distinctly: a missing netdev
+// is wrapped with the "goodbye interface" prefix (permanent — no debt), while a
+// bind failure propagates ndp.Listen's error unwrapped. Anything that is
+// neither a write failure nor a missing netdev is therefore a bind failure.
+func isGoodbyeBindFailure(err error) bool {
+	return err != nil && !errors.Is(err, errGoodbyeIfaceMissing)
+}
+
+// retryOwedGoodbyes re-attempts every #6777 retry debt whose interface is NOT
+// in desired, and reports whether any debt is still outstanding afterwards.
+//
+// It runs on the Apply path deliberately: Apply is what the daemon's periodic
+// reconcile drives, and reconcileClusterRAServices advances its convergence
+// digest only when Apply returns nil. Returning a non-nil error while debt
+// survives is therefore the whole retry mechanism — it keeps the digest
+// un-advanced so the every-2s pass calls Apply again instead of latching the
+// failed withdrawal as converged.
+//
+// An interface that reappeared in desired has its debt DROPPED, not retried:
+// the router is coming back on that link, so withdrawing it would be wrong.
+// The emit goes through WithdrawOnce, which takes the same claim-and-hold
+// tombstone every other goodbye path takes, so a retry can never open a second
+// conn on an interface that already has a live sender (#2033 MAJOR 1). A
+// Skipped result (the interface was busy) leaves the debt in place WITHOUT
+// spending an attempt — nothing was tried.
+func (m *Manager) retryOwedGoodbyes(desired map[string]*config.RAInterfaceConfig) error {
+	m.mu.Lock()
+	var todo []*config.RAInterfaceConfig
+	var held []string
+	for name, d := range m.goodbyeOwed {
+		if _, back := desired[name]; back {
+			slog.Info("ra: dropping final-goodbye retry debt; interface is advertised again",
+				"interface", name)
+			delete(m.goodbyeOwed, name)
+			continue
+		}
+		if d == nil || d.cfg == nil {
+			delete(m.goodbyeOwed, name)
+			continue
+		}
+		if d.recordedEpoch == m.epoch {
+			// Recorded by THIS Apply's own withdrawal — hold it over to the next
+			// pass, but still report it outstanding.
+			held = append(held, name)
+			continue
+		}
+		if d.attempts >= maxGoodbyeRetries {
+			slog.Warn("ra: giving up on the final lifetime-0 goodbye; hosts may "+
+				"hold this router until Router Lifetime expiry",
+				"interface", name, "attempts", d.attempts)
+			delete(m.goodbyeOwed, name)
+			continue
+		}
+		d.attempts++
+		todo = append(todo, d.cfg)
+	}
+	m.mu.Unlock()
+
+	var errs []error
+	for _, name := range held {
+		errs = append(errs, fmt.Errorf("ra: final goodbye owed on %s (retry deferred to the next pass)", name))
+	}
+	if len(todo) == 0 {
+		return errors.Join(errs...)
+	}
+
+	for _, r := range m.WithdrawOnce(todo) {
+		switch {
+		case r.Sent:
+			m.mu.Lock()
+			delete(m.goodbyeOwed, r.Interface)
+			m.mu.Unlock()
+			slog.Info("ra: retried final goodbye succeeded; debt cleared",
+				"interface", r.Interface)
+		case r.Skipped:
+			// Busy: another owner holds the interface and will emit. Refund the
+			// attempt — a skip is not a try.
+			m.mu.Lock()
+			if d := m.goodbyeOwed[r.Interface]; d != nil && d.attempts > 0 {
+				d.attempts--
+			}
+			m.mu.Unlock()
+			errs = append(errs, fmt.Errorf("ra: final goodbye still owed on %s (interface busy)", r.Interface))
+		default:
+			errs = append(errs, r.Err)
+		}
+	}
+	return errors.Join(errs...)
+}
 
 // interfaceBusy reports whether the named interface currently has an active
 // sender or a draining tombstone. Callers must hold m.mu.
@@ -207,12 +384,16 @@ func (m *Manager) releaseDrain(name string, s *sender, startEpoch uint64, onProv
 	// no observable 0-live-conn window across a config replace (#2834). The old
 	// conn was PROVEN closed before the replacement started (≤1 live conn), and
 	// waitConnReady returns promptly if the open gives up or is pre-empted.
-	repl, err := m.finishDrainDecision(name, s, startEpoch, onProvenClose)
+	repl, goodbyeErr, startErr := m.finishDrainDecision(name, s, startEpoch, onProvenClose)
 	if repl != nil && !repl.waitConnReady(claimWaitTimeout) {
 		slog.Warn("ra: replacement sender conn did not come up after a "+
 			"config replace", "interface", name)
 	}
-	return err
+	// #6777: a failed FINAL goodbye is a caller-visible failure, not a log line.
+	// Joining it with the start error is what makes Apply's firstErr and
+	// Withdraw's aggregate non-nil, which in turn keeps the daemon's reconcile
+	// digest un-advanced so the owed goodbye is actually retried.
+	return errors.Join(goodbyeErr, startErr)
 }
 
 // finishDrainDecision runs the ordered post-close decision for a draining
@@ -245,7 +426,13 @@ func (m *Manager) releaseDrain(name string, s *sender, startEpoch uint64, onProv
 // installs the entry immediately before this runs, and a racing Withdraw only
 // flips fields on that SAME entry (never replaces it), so the guard always
 // holds there — the behavior is unchanged.
-func (m *Manager) finishDrainDecision(name string, s *sender, startEpoch uint64, onProvenClose func() error) (*sender, error) {
+func (m *Manager) finishDrainDecision(name string, s *sender, startEpoch uint64, onProvenClose func() error) (*sender, error, error) {
+	// goodbyeErr survives the re-loop: the emit runs with m.mu dropped and the
+	// loop re-acquires to decide the replacement, so a failure recorded on the
+	// emit pass must still be returned after the (goodbye-free) second pass
+	// falls through to the tombstone delete. Returning it is only half of
+	// #6777 — recordGoodbyeDebtLocked below retains the state a retry needs.
+	var goodbyeErr error
 	for {
 		m.mu.Lock()
 		e := m.draining[name]
@@ -253,7 +440,7 @@ func (m *Manager) finishDrainDecision(name string, s *sender, startEpoch uint64,
 			// Gone, or a newer call re-claimed the interface with its own entry;
 			// that newer owner manages its own goodbye/replacement/release.
 			m.mu.Unlock()
-			return nil, nil
+			return nil, goodbyeErr, nil
 		}
 
 		// Decide goodbye claim-once with FRESH goodbyeWanted/goodbyeClaimed.
@@ -267,9 +454,22 @@ func (m *Manager) finishDrainDecision(name string, s *sender, startEpoch uint64,
 				// Surface a failed backstop goodbye (#5093): this is the last
 				// retry the graceful-withdraw path has, so a swallowed write
 				// error here would silently leave the stale router live on hosts.
+				// #6777: "surface" means RETURN it and RETAIN the debt — the
+				// pre-#6777 code logged it here and then fell through to the
+				// tombstone delete with goodbyeClaimed set, erasing every trace
+				// a retry could act on while reporting success to the caller.
 				if err := m.sendOneGoodbye(cfg); err != nil {
 					slog.Warn("ra: standalone goodbye failed",
 						"interface", name, "err", err)
+					goodbyeErr = err
+					m.mu.Lock()
+					m.recordGoodbyeDebtLocked(name, cfg, err)
+					m.mu.Unlock()
+				} else {
+					// A late success clears any debt an earlier attempt left.
+					m.mu.Lock()
+					delete(m.goodbyeOwed, name)
+					m.mu.Unlock()
 				}
 			}
 			// Re-loop: re-acquire the lock and re-evaluate against fresh state
@@ -297,7 +497,7 @@ func (m *Manager) finishDrainDecision(name string, s *sender, startEpoch uint64,
 		}
 		delete(m.draining, name)
 		m.mu.Unlock()
-		return repl, startErr
+		return repl, goodbyeErr, startErr
 	}
 }
 
@@ -328,10 +528,18 @@ func (m *Manager) reclaimTombstoneWhenStopped(name string, s *sender, startEpoch
 	go func() {
 		<-s.stopped
 		// The wedged owner has finally exited; its conn is now PROVEN closed.
-		repl, err := m.finishDrainDecision(name, s, startEpoch, onProvenClose)
-		if err != nil {
+		repl, goodbyeErr, startErr := m.finishDrainDecision(name, s, startEpoch, onProvenClose)
+		// #6777: the reclaimer has no caller to return to, so the retry debt
+		// recordGoodbyeDebtLocked left behind IS the surface here — the next
+		// Apply picks it up. Log the two failures distinctly; conflating them
+		// under the replacement-start message hid which one actually happened.
+		if goodbyeErr != nil {
+			slog.Warn("ra: reclaimer final goodbye failed after wedged owner "+
+				"exited; retry debt retained", "interface", name, "err", goodbyeErr)
+		}
+		if startErr != nil {
 			slog.Warn("ra: reclaimer replacement start failed after wedged owner "+
-				"exited", "interface", name, "err", err)
+				"exited", "interface", name, "err", startErr)
 			return
 		}
 		// Best-effort make-before-break for the healed replacement (bounded).
@@ -382,11 +590,22 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 		// no-goodbye primitive for a forced/unsafe stop.
 		owned, epoch := m.collectGracefulWithdrawLocked()
 		m.mu.Unlock()
+		var errs []error
 		for _, o := range owned {
 			// nil onProvenClose: a removal never starts a replacement.
-			m.releaseDrain(o.name, o.s, epoch, nil)
+			// #6777: a failed final goodbye here is returned, not dropped —
+			// this branch IS the cluster "no active owner" withdrawal, and its
+			// caller (reconcileClusterRAServices) latches convergence on a nil
+			// return.
+			if err := m.releaseDrain(o.name, o.s, epoch, nil); err != nil {
+				errs = append(errs, err)
+			}
 		}
-		return nil
+		// Nothing is desired, so every outstanding debt is still owed.
+		if err := m.retryOwedGoodbyes(nil); err != nil {
+			errs = append(errs, err)
+		}
+		return errors.Join(errs...)
 	}
 
 	// Build desired map.
@@ -535,6 +754,16 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 		}
 	}
 
+	// #6777: re-attempt any final goodbye a PREVIOUS graceful withdrawal failed
+	// to emit. This runs LAST so the removals above have already released their
+	// tombstones — a retry claims the interface through WithdrawOnce and would
+	// otherwise self-skip on a tombstone this very Apply still holds. While any
+	// debt survives this returns non-nil, which keeps the daemon's RA reconcile
+	// digest un-advanced so the periodic pass re-drives Apply.
+	if err := m.retryOwedGoodbyes(desired); err != nil && firstErr == nil {
+		firstErr = err
+	}
+
 	return firstErr
 }
 
@@ -636,11 +865,18 @@ func (m *Manager) Withdraw() error {
 	m.bumpEpoch()
 	owned, epoch := m.collectGracefulWithdrawLocked()
 	m.mu.Unlock()
+	// #6777: aggregate the per-interface outcomes instead of returning a
+	// hard-coded nil. Every caller already had an `if err := d.ra.Withdraw();
+	// err != nil` branch — those branches were unreachable, so a final goodbye
+	// that never went out was reported to operators as a clean withdrawal.
+	var errs []error
 	for _, o := range owned {
 		// nil onProvenClose: a withdraw never starts a replacement.
-		m.releaseDrain(o.name, o.s, epoch, nil)
+		if err := m.releaseDrain(o.name, o.s, epoch, nil); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // collectGracefulWithdrawLocked flips graceful-withdrawal intent on every active
@@ -683,7 +919,13 @@ func (m *Manager) WithdrawInterfaces(names []string) {
 	epoch := m.epoch
 	m.mu.Unlock()
 	for _, o := range owned {
-		m.releaseDrain(o.name, o.s, epoch, nil)
+		// #6777: no error return to thread this through (this entry point has
+		// no production caller today), but a failed final goodbye still leaves
+		// retry debt that the next Apply picks up. Log which interface it was.
+		if err := m.releaseDrain(o.name, o.s, epoch, nil); err != nil {
+			slog.Warn("ra: interface-scoped withdraw failed",
+				"interface", o.name, "err", err)
+		}
 	}
 }
 
@@ -884,7 +1126,7 @@ func (m *Manager) sendOneGoodbye(cfg *config.RAInterfaceConfig) error {
 	if err != nil {
 		slog.Debug("ra: WithdrawOnce: interface not found",
 			"interface", cfg.Interface, "err", err)
-		return fmt.Errorf("ra: goodbye interface %s: %w", cfg.Interface, err)
+		return fmt.Errorf("%w %s: %w", errGoodbyeIfaceMissing, cfg.Interface, err)
 	}
 	s := newSender(cfg, iface)
 	if err := s.sendGoodbyeStandalone(); err != nil {
@@ -936,7 +1178,15 @@ func (m *Manager) clearLocked() error {
 	// starts a replacement.
 	m.mu.Unlock()
 	for _, p := range ps {
-		m.releaseDrain(p.name, p.s, epoch, nil)
+		// Clear is the explicit NO-goodbye primitive, so a goodbye is owed here
+		// only when a racing graceful Withdraw flipped goodbyeWanted on one of
+		// these entries. That Withdraw does not own the release and cannot
+		// observe the outcome, so this log (plus the #6777 retry debt) is the
+		// only surface for it.
+		if err := m.releaseDrain(p.name, p.s, epoch, nil); err != nil {
+			slog.Warn("ra: clear: a goodbye claimed by a racing withdraw failed",
+				"interface", p.name, "err", err)
+		}
 	}
 	m.mu.Lock()
 	return nil

--- a/pkg/ra/sender.go
+++ b/pkg/ra/sender.go
@@ -313,6 +313,15 @@ func (s *sender) openConn() bool {
 // Lifetime expiry while operators see success (#5093).
 var errGoodbyeWrite = errors.New("ra: goodbye RA write failed")
 
+// errGoodbyeIfaceMissing marks a goodbye that could not even be attempted
+// because the netdev no longer exists. It is PERMANENT, unlike errGoodbyeWrite
+// and a bind failure: there is no link to emit on and no host behind it left to
+// hear a lifetime-0 RA, so the #6777 retry debt deliberately does NOT retain it
+// (see recordGoodbyeDebtLocked). Retaining it would make a legitimately removed
+// interface a permanent Apply error, suppressing the daemon's RA reconcile
+// digest forever.
+var errGoodbyeIfaceMissing = errors.New("ra: goodbye interface missing")
+
 // sendGoodbyeStandalone is the WithdrawOnce goodbye-only entry point. It opens
 // a connection, emits the lifetime-0 goodbye, and closes — WITHOUT launching
 // run() and WITHOUT the startup burst (so it never re-advertises the router it


### PR DESCRIPTION
Closes #6777

## What was wrong

The graceful RA withdrawal path gets exactly two chances to put a lifetime-0 RA
on the wire: the owner's own emit in `finishShutdown`, and — when that failed,
leaving `goodbyeEmitted` false — `finishDrainDecision`'s standalone backstop on
a fresh conn. **A failure of that last chance was logged and then erased.** The
same pass set `goodbyeClaimed`, deleted the tombstone, dropped the sender, and
returned only the replacement-start error. `Manager.Withdraw` returned a
hard-coded `nil`.

Two consequences, and the second is the one that makes it more than a logging
bug:

1. All three production call sites carried an `if err := d.ra.Withdraw(); err
   != nil` branch that **could never be reached** — the RA-removal branch of
   `applyServicesReconcile`, daemon shutdown, and the VRRP BACKUP transition.
2. It defeated the daemon's own retry driver. `reconcileClusterRAServices`
   advances `lastRAReconcileHash` **only on a successful apply**, and its
   comment says why: "so a transient apply error is retried on the next pass
   rather than being latched as converged". A `nil` return latched it. The
   every-2s pass never retried, and the stale IPv6 default-router identity lived
   on hosts until Router Lifetime expiry (default 1800s) while operators saw a
   clean withdrawal.

This is the graceful-path twin of the one-shot `WithdrawOnce` defect #5093
fixed.

## Why surfacing the error is only half a fix

Once the tombstone is deleted and the sender dropped, a later `Apply` finds
nothing for the interface and emits nothing. A caller that *did* see the failure
would have had nothing to act on. So the failure now also leaves **retry debt**.

`finishDrainDecision` returns the goodbye error separately from the start error
(the reclaimer logs the two distinctly instead of conflating them under the
replacement-start message); `releaseDrain` joins them; `Withdraw` and `Apply`'s
empty-config branch aggregate across interfaces. On failure the interface is
retained in `Manager.goodbyeOwed`, and `Apply` re-attempts every owed goodbye
whose interface is not in the desired set — through `WithdrawOnce`, so a retry
takes the same claim-and-hold tombstone every other goodbye path takes and can
never open a second conn on a live interface (#2033 MAJOR 1). **`Apply` returns
non-nil while any debt survives, and that is the whole mechanism**: it keeps the
reconcile digest un-advanced so the periodic pass re-drives `Apply`.

Three rules keep the debt from becoming a liability of its own:

- **A vanished netdev records nothing.** `sendOneGoodbye` now wraps that case as
  `errGoodbyeIfaceMissing`. There is no link to emit on and no host behind it
  left to hear a goodbye, and retaining it would make a legitimately removed
  interface a permanent `Apply` error that suppresses the node's whole RA
  reconcile digest.
- **It is bounded** (`maxGoodbyeRetries`). An interface that can never accept a
  goodbye is given up on with one Warn rather than re-applying and logging every
  2s forever.
- **It is dropped when the router comes back.** A debt whose interface reappears
  in the desired set is dropped rather than emitted — emitting it would withdraw
  the router the new sender just announced. That drop lives in exactly ONE place
  (`retryOwedGoodbyes`), deliberately not also in `startLocked`: every path that
  starts a sender does so for an interface that is in `desired`, so a second
  clear would be a redundant copy of one invariant.

## Cites

The issue body is `(see /tmp/opus-review-001.md section R36)` and nothing else —
that file is gone. Every cite here was re-derived from code by symbol name.

## Mutation matrix

Fix committed FIRST. Every cell full `pkg/ra` suite, `go test -count=1`, no
`-run` filter, each mutation verified applied on a compiling tree.

| cell | result | assertion that fired |
|---|---|---|
| M1 `Withdraw` returns hard-coded nil | RED | `...GracefulWithdrawSurfacesFinalGoodbyeFailure6777` |
| M2 `Apply` empty-config branch returns nil | RED | 5 subtests incl. `...ApplyRemovalSurfacesFinalGoodbyeFailure6777` |
| M3 no retry debt recorded | RED | `...FailedFinalGoodbyeIsRetriedByALaterApply6777` + 2 |
| M4 goodbye error dropped in `finishDrainDecision` | RED | `...GracefulWithdrawSurfacesFinalGoodbyeFailure6777` |
| M5 `Apply` never retries owed goodbyes | RED | `...GoodbyeDebtDroppedWhenInterfaceIsAdvertisedAgain6777` |
| M6 debt records EVERY failure (no vanished-iface discrimination) | RED | `...VanishedInterfaceLeavesNoGoodbyeRetryDebt6777` |
| M7 debt unbounded | RED | `...FinalGoodbyeRetryDebtIsBounded6777` |
| M8 debt not dropped when interface is desired again | RED | `...GoodbyeDebtDroppedWhenInterfaceIsAdvertisedAgain6777` |
| M9 `releaseDrain` returns start error only | RED | `...GracefulWithdrawSurfacesFinalGoodbyeFailure6777` |
| **T1 TIGHTEN: same-epoch hold-over removed** | **GREEN -> fixed** | now reds `...FreshGoodbyeDebtIsNotRetriedInTheSamePass6777` |
| **T2 TIGHTEN: busy-skip no longer refunds the attempt** | **GREEN -> fixed** | now reds `...BusySkipDoesNotSpendARetryAttempt6777` |

**Both tightening cells came back green on round 1**, which is the finding worth
recording. Neither is a crash — they are quiet reductions in the recovery window:

- Without the `recordedEpoch` hold-over, the withdrawing `Apply` spends one of
  its three bounded attempts microseconds after the backstop already failed on a
  fresh conn, shortening the window in which a transient failure can recover.
- Without the busy-skip refund, a few unlucky passes exhaust the retries and the
  debt is then dropped as "gave up" on an interface where **no lifetime-0 write
  was ever attempted**.

A delete-the-guard matrix cannot see either. Round 2 binds both on the attempt
COUNTER rather than an emit count — the counter is what the bound consumes,
whereas an emit count also moves for reasons that are not the property under
test. Each also asserts the opposite direction (the next pass DOES spend an
attempt; the pass after the claim clears DOES try), so neither is satisfiable by
an implementation that simply never retries.

## Test design

The probe binds successfully and fails **only lifetime-0 writes**, counting emit
ATTEMPTS rather than conns — the property is whether another emit was tried at
all, which is exactly what the pre-fix code could not do once it had erased the
tombstone and dropped the sender. Nine guards:

- both surfaces (`Withdraw` and `Apply(nil)` return non-nil) each with a control
  asserting the probe actually reached the goodbye path, so the assertion is not
  vacuous;
- the retry (a later `Apply` re-attempts), which is the load-bearing cell —
  surfacing alone would pass M1/M2/M4/M9 and still leave the withdrawal
  impossible to complete;
- the success path clearing the debt, with a no-further-emit control;
- the bound, with a loop cap far above `maxGoodbyeRetries` so an unbounded
  implementation fails on the cap rather than hanging;
- drop-on-re-advertise;
- a **paired cell** for the classification rule — a vanished interface records
  no debt while a write failure on the same call site does. Without the negative
  half, "records debt on failure" would be satisfied by an implementation that
  records debt for every failure, which is the shape that bricks the reconcile.

## Scope

`pkg/ra` only, plus `pkg/ra/README.md` and `_Log.md`. **No cluster, VRRP,
session-sync or failover code is touched, and nothing moves the `userspace-dp`
binary or the shim `.o`** — no cargo leg and no cluster smoke needed.

`go build ./... && go vet ./... && go test -count=1 ./...` all rc=0, 67 packages,
at head `e494544b7e3fc94da7cd7175777fb92cffb67aa3`, tree clean.
