### PR TITLE
configstore: time-bound the archive reseed directory scan (#6776)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104389,3 +104389,25 @@ prose edit above them added. No diff falls in the new test body.
   schema is right and nothing changed.
 - **File(s)**: `pkg/config/schema.go`, `pkg/config/schema_security.go`,
   `pkg/config/schema_walk.go`, `pkg/config/schema_block_value_6774_test.go`
+
+## 2026-08-22 — #6776 archive reseed scan is time-bounded (fail-open)
+
+- **Timestamp**: 2026-08-22
+- **Action**: Bound the archive-seq reseed directory scan with
+  `archiveScanBudget` (5s) so an unresponsive archive filesystem can no longer
+  hold the global store mutex — or daemon PHASE 4 bring-up — indefinitely. A
+  budget expiry maps onto the existing #6404 UNCONFIRMED semantics (counter not
+  reseeded, `archiveSeedDir` cleared, archiving commit skips its archive), i.e.
+  fail-open: the box comes up and stays configurable, only archival is
+  suspended. The abandoned scan's buffered result is retained and collected by
+  the next call, so a wedged filesystem costs one stall and one goroutine per
+  process, not one per commit.
+- **Measured, contradicting the issue title**: the scanned dir is always the
+  local hardcoded `/var/lib/xpf/archive` (no `archive-dir` config leaf exists);
+  there is no remote `ReadDir` anywhere in the archive path. The mutex claim is
+  correct (`Store.mu`, the global RWMutex, taken for writing). Also corrected a
+  pre-existing FALSE claim in `ArchiveConfig` / README that the seed scan was
+  already "a bounded ReadDir under the lock".
+- **File(s)**: `pkg/configstore/store.go`, `pkg/configstore/store_persist.go`,
+  `pkg/configstore/archive_reseed_scan_timeout_6776_test.go`,
+  `pkg/configstore/README.md`, `_Log.md`

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -1160,9 +1160,10 @@ owned by the `journal/` subpackage.
   the process-global counter cannot be bumped between its seed and its claim in
   the off-lock write window. Only the WRITE itself stays off-lock (a long
   archival I/O must not block reconcile/`QuiesceArchival`, #6185); the seed scan
-  is a bounded `ReadDir` under the lock, exactly what the commit path already
-  does. A genuine seed scan error (mount/permission — the on-disk max unknown)
-  fails the synchronous call rather than write a below-max archive; a
+  is a `ReadDir` under the lock, bounded by `archiveScanBudget` (#6776, below),
+  exactly what the commit path already does. A genuine seed scan error
+  (mount/permission — the on-disk max unknown) fails the synchronous call rather
+  than write a below-max archive, as does a scan that exceeds the budget; a
   nonexistent dir is confirmed-empty, seq 0, and the write path's `MkdirAll`
   creates it.
   These monotonicity / no-overwrite guarantees hold **once the target
@@ -1207,7 +1208,44 @@ owned by the `journal/` subpackage.
   while archival was off (edge 2); likewise a genuine scan FAILURE clears
   `archiveSeedDir`, so navigating away to a dir that fails to scan and back
   (`A`→failed-`B`→`A`) re-scans `A` rather than trusting the stale marker (Codex
-  adjacent). The
+  adjacent).
+  **The reseed scan is time-bounded (#6776).** `ensureArchiveSeededLocked` runs
+  under `s.mu` held for WRITING — the GLOBAL store mutex, the same one that
+  gates `Load`, every commit and every config read — and the scan it performs is
+  `readdir(2)`. A `readdir` on a filesystem that has stopped answering (a
+  network mount under the archive path, a stalled block device) blocks
+  uninterruptibly, and no context or deadline can cancel it: a thread parked in
+  a filesystem wait is not reachable from userspace. That matters most at cold
+  boot, where the boot apply's step 15b `SetArchiveConfig` runs in daemon
+  PHASE 4 — *before* the gRPC/REST/CLI listeners start in PHASE 5 — so an
+  unbounded scan there means the daemon never reaches its control plane at all.
+  The scan therefore runs on a throwaway goroutine and the lock-holder waits at
+  most `archiveScanBudget` (5s) for it (`awaitArchiveScanLocked`). On expiry the
+  goroutine is ABANDONED, not cancelled, and the outcome is **fail-open**: the
+  caller is released, bring-up and config work proceed, and only archival is
+  suspended. Fail-open is the deliberate choice — config archival is a
+  DR/compliance convenience, and refusing to bring a firewall up because a
+  directory did not answer converts a degraded-storage event into a total
+  outage. The suspension reuses the existing #6404 semantics exactly, because a
+  timed-out scan leaves the on-disk max in the same state a read error does —
+  UNKNOWN: the counter is NOT reseeded (never rewound to 0), `archiveSeedDir` is
+  cleared so a later call retries, and an archiving commit SKIPS its archive
+  rather than write a below-max seq rotation would prune. The abandoned scan is
+  not discarded: its buffered result channel is retained (`archiveScanCh`, keyed
+  by `archiveScanDir`), so the next call collects the result with a NON-blocking
+  poll once the filesystem answers, and archival resumes at the correct seq.
+  That retention is also what bounds the cost — a persistently wedged archive
+  filesystem costs exactly ONE budget-length stall and ONE leaked scan goroutine
+  per process, not one per commit. 5s is chosen as ~3 orders of magnitude of
+  headroom over a healthy scan (the dir is retention-capped at `max-archives`,
+  default 10, so a real `readdir` costs microseconds), so the budget cannot fire
+  on a merely loaded disk. NOTE on scope: the scanned directory is always the
+  local `/var/lib/xpf/archive` — the compiler hardcodes it and there is no
+  `archive-dir` configuration leaf — so it becomes remote only if an operator or
+  image makes that path a mount point. The `archive-sites` remote leg is a
+  separate path (scp, already 30s-bounded, off-lock); it never lists a remote
+  directory.
+  The
   rollback/archive writers
   route through package-var seams (`rbWriteFileDurable`,
   `rbWriteFileAtomic`, `rbSyncDir`, `rbRemove`) so tests can pin the

--- a/pkg/configstore/archive_reseed_scan_timeout_6776_test.go
+++ b/pkg/configstore/archive_reseed_scan_timeout_6776_test.go
@@ -296,3 +296,98 @@ func TestReseedScanTimeoutDoesNotHoldStoreMutex6776(t *testing.T) {
 			"the scan is holding the global store mutex unbounded", 20*budget)
 	}
 }
+
+// TestReseedScanTimeoutInvalidatesSeedMarkerOnReturn6776 guards the one part of
+// the timeout path the fail-open test above cannot see: clearing
+// archiveSeedDir. At cold boot the marker is already empty, so clearing it is a
+// no-op there and a fixture built around boot stays GREEN with the clear
+// deleted. The smallest shape where deleting it changes an OUTCOME is a dir
+// SWITCH: A scans cleanly (marker = A), B times out, and the process returns to
+// A. If the timeout did not invalidate the marker, the return to A finds
+// marker == A and SKIPS the rescan — so an on-disk max that advanced in A while
+// this process was pointed at B is never picked up, the counter stays low, and
+// every archive written afterwards is below-max and pruned as stale.
+//
+// This is the #6404-adjacent invariant (A → failed-B → A re-scans A) extended
+// to the #6776 timeout: a scan that did not answer leaves the counter exactly
+// as unconfirmed as a scan that errored, so it must invalidate the marker for
+// the same reason.
+//
+// FAIL-ON-REVERT: deleting `s.archiveSeedDir = ""` from the timeout branch
+// leaves the marker at dirA, the return to dirA short-circuits as
+// already-seeded, the counter stays at 5, and the archive written from it
+// (seq 6, below the advanced max 100..102) is pruned by rotation — reding both
+// the counter signal and the rotation outcome.
+func TestReseedScanTimeoutInvalidatesSeedMarkerOnReturn6776(t *testing.T) {
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	base := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
+
+	// dirA holds seqs 1..5; configuring it seeds the counter to 5 and marks
+	// dirA as the successfully-scanned dir.
+	for seq := 1; seq <= 5; seq++ {
+		ts := base.Add(time.Duration(seq) * time.Second)
+		if err := writeArchive(dirA, 100, fmt.Sprintf("a-%d\n", seq), ts, uint64(seq)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s := &Store{}
+	s.SetArchiveConfig(dirA, 3)
+	if got := s.archiveSeq.Load(); got != 5 || s.archiveSeedDir != dirA {
+		t.Fatalf("after configuring dirA, archiveSeq=%d seedDir=%q, want 5 / %q", got, s.archiveSeedDir, dirA)
+	}
+
+	// Navigate to dirB, whose scan does NOT ANSWER (unresponsive filesystem)
+	// rather than erroring.
+	const budget = 100 * time.Millisecond
+	setArchiveScanBudget(t, budget)
+	realReader := archiveDirReader
+	hangUntil := make(chan struct{})
+	archiveDirReader = func(string) ([]os.DirEntry, error) {
+		select {
+		case <-hangUntil:
+		case <-time.After(5 * time.Second):
+		}
+		return nil, os.ErrPermission
+	}
+	s.SetArchiveConfig(dirB, 3)
+	archiveDirReader = realReader
+	t.Cleanup(func() { close(hangUntil) })
+
+	// While this process was pointed at dirB, an external writer advanced
+	// dirA's on-disk max to 100..102.
+	for seq := 100; seq <= 102; seq++ {
+		ts := base.Add(time.Duration(seq) * time.Second)
+		if err := writeArchive(dirA, 100, fmt.Sprintf("a-%d\n", seq), ts, uint64(seq)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Return to dirA. The timed-out dirB scan must have invalidated
+	// archiveSeedDir, so this re-scans dirA and catches up to 102.
+	s.SetArchiveConfig(dirA, 3)
+	// Supporting signal (non-fatal so the REAL rotation assertion is load-bearing).
+	if got := s.archiveSeq.Load(); got != 102 {
+		t.Errorf("returning to dirA after a TIMED-OUT dirB scan must rescan dirA and catch up to "+
+			"its advanced on-disk max (102); got %d", got)
+	}
+
+	// REAL rotation outcome: an archive written with the re-seeded counter must
+	// survive, and the oldest pre-existing archive (a-100) must be pruned.
+	seq := s.archiveSeq.Add(1) // 103, from the reseeded 102
+	ts := base.Add(time.Duration(seq) * time.Second)
+	if err := writeArchive(dirA, 3, "a-return-6776\n", ts, seq); err != nil {
+		t.Fatal(err)
+	}
+	remain := archiveContents(t, dirA)
+	if !remain["a-return-6776"] {
+		t.Errorf("the archive written after returning to dirA must survive rotation (its "+
+			"re-seeded seq outranks the advanced pre-existing max); remain=%v", remain)
+	}
+	if remain["a-100"] {
+		t.Errorf("the oldest pre-existing archive (a-100) must be pruned; remain=%v", remain)
+	}
+	if len(remain) != 3 {
+		t.Errorf("want 3 archives after rotation (max=3), got %d: %v", len(remain), remain)
+	}
+}

--- a/pkg/configstore/archive_reseed_scan_timeout_6776_test.go
+++ b/pkg/configstore/archive_reseed_scan_timeout_6776_test.go
@@ -1,0 +1,298 @@
+package configstore
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// hangingArchiveReader installs an archiveDirReader that PARKS until release is
+// closed, then performs the real os.ReadDir. It models the only way the reseed
+// scan can actually stall: a readdir(2) that the filesystem does not answer
+// (a wedged network mount under the archive path, a stalled block device). It
+// returns the release func, a launch counter, and restores the seam on cleanup.
+//
+// The parked read has its own 5s safety valve so a REGRESSION (an unbounded
+// scan) fails on the elapsed-time assertion in a few seconds instead of
+// deadlocking the package suite until the go test panic timeout.
+func hangingArchiveReader(t *testing.T, dir string) (release func(), launches *atomic.Int32) {
+	t.Helper()
+	releaseCh := make(chan struct{})
+	launches = &atomic.Int32{}
+	prev := archiveDirReader
+	// The scan goroutine is handed this closure by value at launch
+	// (maxArchiveSeq takes the reader as a parameter, #6776), so restoring the
+	// package var below never races with a scan still parked inside it.
+	archiveDirReader = func(string) ([]os.DirEntry, error) {
+		launches.Add(1)
+		select {
+		case <-releaseCh:
+		case <-time.After(5 * time.Second):
+		}
+		return os.ReadDir(dir)
+	}
+	var once atomic.Bool
+	release = func() {
+		if once.CompareAndSwap(false, true) {
+			close(releaseCh)
+		}
+	}
+	t.Cleanup(func() {
+		release()
+		archiveDirReader = prev
+	})
+	return release, launches
+}
+
+// setArchiveScanBudget shortens the #6776 reseed scan budget for the duration
+// of one test.
+func setArchiveScanBudget(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := archiveScanBudget
+	archiveScanBudget = d
+	t.Cleanup(func() { archiveScanBudget = prev })
+}
+
+// TestReseedScanTimeoutIsFailOpenAndSkipsArchive6776 is the primary #6776
+// guard. It asserts the CHOICE this issue had to make, not merely that a
+// deadline exists: when the archive-directory scan does not answer, the daemon
+// FAILS OPEN — the caller is released, config work proceeds, and only archival
+// is suspended — and the suspension is the #6404 skip (no below-max archive
+// written at an unconfirmed seq), never a silent reseed to 0.
+//
+// The four properties, in the order the daemon meets them at cold boot:
+//
+//  1. BOUNDED. SetArchiveConfig is the boot apply's step 15b; it runs in daemon
+//     PHASE 4, before the gRPC/REST/CLI listeners start in PHASE 5. It must
+//     return while the filesystem is still unresponsive, or bring-up never
+//     reaches the control plane.
+//  2. UNCONFIRMED, not empty. The counter must not be seeded, and
+//     archiveSeedDir must be cleared so a later call retries.
+//  3. FAIL-OPEN. A commit landing during the stall must SUCCEED (this is the
+//     choice: a firewall that will not come up because a directory did not
+//     answer converts degraded storage into a total outage) while SKIPPING its
+//     archive — writing at the low counter would drop a below-max archive that
+//     rotateArchives prunes as stale (#6404).
+//  4. RESUMES. The abandoned scan is not lost: when the filesystem answers, the
+//     next call collects that result and archival resumes at the correct seq.
+//
+// The dir holds 3 pre-existing archives at seq 100..102 with max=4, so a
+// wrongly-written below-max archive SURVIVES rotation and its presence is
+// directly observable on disk — not a private-counter check.
+//
+// FAIL-ON-REVERT: dropping the budget (waiting for the scan) hangs step 15b
+// until the 5s safety valve and reds the elapsed bound; returning true on
+// timeout writes the seq-1 archive and reds the "no below-max archive"
+// assertion; seeding 0 on timeout reds the recovery phase's seq-103 archive.
+func TestReseedScanTimeoutIsFailOpenAndSkipsArchive6776(t *testing.T) {
+	s := newTestStore(t)
+	archiveDir := filepath.Join(t.TempDir(), "archive")
+	base := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
+	for seq := 100; seq <= 102; seq++ {
+		ts := base.Add(time.Duration(seq) * time.Second)
+		if err := writeArchive(archiveDir, 100, fmt.Sprintf("pre-%d\n", seq), ts, uint64(seq)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const budget = 150 * time.Millisecond
+	setArchiveScanBudget(t, budget)
+	release, launches := hangingArchiveReader(t, archiveDir)
+
+	// (1) BOUNDED: the boot apply's SetArchiveConfig must come back while the
+	// scan is still parked.
+	start := time.Now()
+	s.SetArchiveConfig(archiveDir, 4)
+	elapsed := time.Since(start)
+	if elapsed > 20*budget {
+		t.Fatalf("SetArchiveConfig blocked %s on an unresponsive archive dir (budget %s): "+
+			"the reseed scan is not bounded, so the boot apply never reaches the control plane",
+			elapsed, budget)
+	}
+
+	// (2) UNCONFIRMED, not empty.
+	if got := s.archiveSeq.Load(); got != 0 {
+		t.Fatalf("after a timed-out reseed scan archiveSeq = %d, want 0 (never seeded from an unanswered scan)", got)
+	}
+	s.mu.RLock()
+	seededDir := s.archiveSeedDir
+	s.mu.RUnlock()
+	if seededDir != "" {
+		t.Errorf("a timed-out reseed scan must leave archiveSeedDir cleared so a later call retries, got %q", seededDir)
+	}
+
+	// (3) FAIL-OPEN: the commit succeeds; its archive is skipped.
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetFromInput("system host-name stalled-6776"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("a commit during an unresponsive archive scan must still SUCCEED "+
+			"(archival is fail-open; the box must stay configurable): %v", err)
+	}
+	s.archiveWG.Wait()
+	remain := archiveConfigText(t, archiveDir)
+	if hasMarker(remain, "host-name stalled-6776") {
+		t.Errorf("a commit during a timed-out scan must NOT write a below-max archive "+
+			"(the seq is unconfirmed); surviving archives=%v", markerSet(remain))
+	}
+	if len(remain) != 3 {
+		t.Errorf("the 3 pre-existing archives must be untouched by the skipped commit, got %d: %v",
+			len(remain), markerSet(remain))
+	}
+
+	// (4) RESUMES: the filesystem answers, the abandoned scan's result is
+	// collected by the next call, and archival resumes at the confirmed seq.
+	release()
+	deadline := time.Now().Add(3 * time.Second)
+	for s.archiveSeq.Load() != 102 && time.Now().Before(deadline) {
+		s.SetArchiveConfig(archiveDir, 4)
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := s.archiveSeq.Load(); got != 102 {
+		t.Fatalf("after the archive dir answered, the abandoned scan's result must be collected: archiveSeq = %d, want 102", got)
+	}
+	// Still in configure mode from the commit above (Commit does not exit it).
+	if err := s.SetFromInput("system host-name recovered-6776"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("commit after recovery: %v", err)
+	}
+	s.archiveWG.Wait()
+	if got := s.archiveSeq.Load(); got < 103 {
+		t.Errorf("after recovery the commit must archive past the on-disk max (102); archiveSeq = %d, want >= 103", got)
+	}
+	remain = archiveConfigText(t, archiveDir)
+	if !hasMarker(remain, "host-name recovered-6776") {
+		t.Errorf("archival must RESUME once the scan lands; surviving archives=%v", markerSet(remain))
+	}
+	if n := launches.Load(); n < 1 {
+		t.Errorf("expected at least one scan launch, got %d", n)
+	}
+}
+
+// TestReseedScanTimeoutNeverRewindsCounter6776 isolates the one outcome the
+// on-disk assertions above cannot localise: a timeout that is mistaken for a
+// readable-but-empty directory would STORE the scan's zero-value seq over a
+// counter this process has already advanced, rewinding it. Every archive
+// written afterwards would then carry a seq below the on-disk max and be pruned
+// as stale.
+//
+// The fixture deliberately starts the counter at 41 — NOT at 0, which is both
+// the zero value of archiveScanResult.seq and the value the bug falls back to.
+// A fixture starting at 0 cannot tell "left alone" from "reseeded to 0".
+//
+// FAIL-ON-REVERT: applying res.seq on the timeout path (or returning a
+// zero-valued result as if it had succeeded) stores 0 over 41 and reds this.
+func TestReseedScanTimeoutNeverRewindsCounter6776(t *testing.T) {
+	s := newTestStore(t)
+	archiveDir := filepath.Join(t.TempDir(), "archive")
+	if err := os.MkdirAll(archiveDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	s.archiveSeq.Store(41)
+
+	const budget = 100 * time.Millisecond
+	setArchiveScanBudget(t, budget)
+	hangingArchiveReader(t, archiveDir)
+
+	s.SetArchiveConfig(archiveDir, 4)
+
+	if got := s.archiveSeq.Load(); got != 41 {
+		t.Fatalf("a timed-out reseed scan must leave the monotonic counter alone: archiveSeq = %d, want 41 "+
+			"(a rewind to 0 makes every later archive below-max and pruned as stale)", got)
+	}
+}
+
+// TestReseedScanTimeoutStallsOnceNotPerCommit6776 guards the property that
+// makes the fail-open choice affordable: a persistently unresponsive archive
+// directory costs ONE budget-length stall for the whole process, not one per
+// commit, and leaks ONE scan goroutine, not one per commit.
+//
+// Without the pending-scan reuse, each call would launch its own readdir(2) and
+// pay its own budget — turning a wedged mount into a permanent per-commit
+// latency tax on the config plane and an unbounded goroutine leak.
+//
+// FAIL-ON-REVERT: dropping the reuse branch in awaitArchiveScanLocked (always
+// launching a fresh scan) makes the second and third calls each block a full
+// budget and each launch a scan, reding both assertions.
+func TestReseedScanTimeoutStallsOnceNotPerCommit6776(t *testing.T) {
+	s := newTestStore(t)
+	archiveDir := filepath.Join(t.TempDir(), "archive")
+	if err := os.MkdirAll(archiveDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	const budget = 400 * time.Millisecond
+	setArchiveScanBudget(t, budget)
+	_, launches := hangingArchiveReader(t, archiveDir)
+
+	// First call pays the budget once.
+	s.SetArchiveConfig(archiveDir, 4)
+
+	// Subsequent calls must poll the already-outstanding scan without blocking.
+	start := time.Now()
+	for i := 0; i < 3; i++ {
+		s.SetArchiveConfig(archiveDir, 4)
+	}
+	elapsed := time.Since(start)
+	if elapsed >= budget {
+		t.Errorf("3 further calls against an already-known-unresponsive archive dir took %s "+
+			"(>= one budget of %s): each is re-paying the stall instead of polling the outstanding scan", elapsed, budget)
+	}
+	if n := launches.Load(); n != 1 {
+		t.Errorf("a persistently unresponsive archive dir must leak exactly ONE scan goroutine, "+
+			"launched %d (one per call is an unbounded leak)", n)
+	}
+}
+
+// TestReseedScanTimeoutDoesNotHoldStoreMutex6776 pins the half of the issue
+// title that is about the LOCK rather than about boot. s.mu is the global store
+// mutex — it gates Load, every Commit, and every config read — and
+// SetArchiveConfig takes it for WRITING across the reseed scan. An unbounded
+// scan therefore stalls not just its own caller but every concurrent reader of
+// the configuration.
+//
+// FAIL-ON-REVERT: an unbounded scan holds the write lock for the full 5s safety
+// valve, so the concurrent ActiveConfig read blocks far past the budget.
+func TestReseedScanTimeoutDoesNotHoldStoreMutex6776(t *testing.T) {
+	s := newTestStore(t)
+	archiveDir := filepath.Join(t.TempDir(), "archive")
+	if err := os.MkdirAll(archiveDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	const budget = 200 * time.Millisecond
+	setArchiveScanBudget(t, budget)
+	hangingArchiveReader(t, archiveDir)
+
+	readDone := make(chan time.Duration, 1)
+	started := make(chan struct{})
+	go func() {
+		close(started)
+		// Give SetArchiveConfig time to be inside the scan wait holding s.mu.
+		time.Sleep(budget / 4)
+		t0 := time.Now()
+		_ = s.ActiveConfig()
+		readDone <- time.Since(t0)
+	}()
+	<-started
+	s.SetArchiveConfig(archiveDir, 4)
+
+	select {
+	case blocked := <-readDone:
+		if blocked > 20*budget {
+			t.Errorf("a concurrent config read blocked %s behind the reseed scan (budget %s): "+
+				"the scan is holding the global store mutex unbounded", blocked, budget)
+		}
+	case <-time.After(20 * budget):
+		t.Errorf("a concurrent config read is still blocked behind the reseed scan after %s: "+
+			"the scan is holding the global store mutex unbounded", 20*budget)
+	}
+}

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -246,6 +246,25 @@ type Store struct {
 	// not a failure — seq 0 is correct and the write path creates the dir.
 	archiveSeedDir string
 
+	// archiveScanCh / archiveScanDir hold the result channel of a reseed
+	// directory scan that has been LAUNCHED but whose result has not been
+	// consumed yet (#6776). The scan itself is a readdir(2) — an
+	// UNINTERRUPTIBLE syscall that no context or deadline can cancel — so
+	// ensureArchiveSeededLocked runs it on a throwaway goroutine and waits only
+	// archiveScanBudget for it, rather than blocking the global store mutex
+	// (and, at boot, the whole daemon bring-up) for however long the filesystem
+	// takes to answer. When the budget expires the goroutine is ABANDONED, not
+	// cancelled: it keeps its buffered channel, eventually completes, and the
+	// reference kept here lets the NEXT call pick that result up with a
+	// non-blocking poll instead of launching a second scan. That is what bounds
+	// the cost of a wedged archive filesystem to exactly one budget-length stall
+	// per process rather than one per commit, and bounds the leaked goroutine
+	// count to one per distinct dir. The abandoned goroutine never touches Store
+	// state — it only sends on its buffered channel — so it needs no lock and
+	// can race with nothing. Both fields are guarded by s.mu.
+	archiveScanCh  chan archiveScanResult
+	archiveScanDir string
+
 	// archiveSeq is a monotonic counter appended to every archive filename
 	// (#3441 H4, Codex MAJOR). The wall-clock timestamp alone is not a unique
 	// key: two successive (mutex-serialized) commits can format the SAME

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -602,7 +602,27 @@ func (s *Store) ensureArchiveSeededLocked() bool {
 	if dir == "" || s.archiveSeedDir == dir {
 		return true
 	}
-	seed, err := maxArchiveSeq(dir)
+	res, ok := s.awaitArchiveScanLocked(dir)
+	if !ok {
+		// #6776: the scan did not answer within archiveScanBudget. The archive
+		// filesystem is unresponsive, so the on-disk max is UNKNOWN — the SAME
+		// epistemic state a genuine read error leaves, and handled identically:
+		// do NOT reseed to 0, clear archiveSeedDir so a later call retries, and
+		// return false so the commit path SKIPS this commit's archive rather
+		// than writing a below-max seq rotateArchives would prune as stale.
+		//
+		// This is the deliberate FAIL-OPEN choice for the boot path. Config
+		// archival is a DR/compliance convenience; refusing to bring the
+		// firewall up because a directory did not answer would convert a
+		// degraded-storage event into a total outage. So bring-up proceeds and
+		// archival — and only archival — is suspended until a scan lands.
+		slog.Warn("archive seq reseed scan did not complete within budget; "+
+			"counter unconfirmed, archival suspended until the scan lands",
+			"dir", dir, "budget", archiveScanBudget)
+		s.archiveSeedDir = ""
+		return false
+	}
+	seed, err := res.seq, res.err
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			// First use: the archive dir does not exist yet. This is NOT a scan
@@ -671,15 +691,122 @@ func parseArchiveSeq(name string) (uint64, bool) {
 // reliably forced to fail from a unit test, least of all when tests run as root.
 var archiveDirReader = os.ReadDir
 
+// archiveScanBudget bounds how long the archive-seq reseed scan may hold the
+// global store mutex waiting for the archive directory to answer (#6776).
+//
+// WHY A BUDGET AND NOT A CONTEXT. The scan is os.ReadDir — a readdir(2)
+// syscall. A context cannot cancel it: a thread parked in an uninterruptible
+// filesystem wait is not reachable from userspace, so "pass a ctx" would add a
+// parameter that never fires. The only mechanism that actually bounds the wait
+// is to run the syscall on a throwaway goroutine and stop waiting for it. That
+// is what awaitArchiveScanLocked does.
+//
+// WHY 5s. The directory being scanned is the local config archive, which the
+// retention policy caps at max-archives entries (default 10) — a readdir of it
+// costs microseconds on any healthy storage. 5s is more than three orders of
+// magnitude of headroom, so the budget cannot fire on a merely loaded disk; it
+// fires only when the filesystem has genuinely stopped answering. It is also
+// short relative to daemon bring-up: the boot apply runs before the gRPC/REST/
+// CLI listeners start (daemon PHASE 4 precedes PHASE 5), so this is the most
+// bring-up can be delayed by an unresponsive archive filesystem — once, not per
+// commit (see archiveScanCh).
+//
+// Overridable for tests only.
+var archiveScanBudget = 5 * time.Second
+
+// archiveScanResult is one completed archive-directory scan: the highest
+// on-disk sequence number, or the error that made it unknowable.
+type archiveScanResult struct {
+	seq uint64
+	err error
+}
+
+// awaitArchiveScanLocked returns the result of an archive-directory scan of
+// dir, waiting at most archiveScanBudget for it. ok is false when the budget
+// expired with no result — the on-disk max is UNKNOWN, exactly as it is after a
+// genuine read error, and callers must treat it that way.
+//
+// The caller MUST hold s.mu for WRITING: this reads and stores the pending-scan
+// fields. It deliberately keeps the lock across the wait (bounded by the budget)
+// rather than dropping and re-taking it — see #6403, which established that
+// widening this critical section around the archive WRITE is the hazard, while
+// the scan+claim belongs inside it: releasing s.mu here would let a concurrent
+// SetArchiveConfig switch archiveDir out from under a seed the caller is about
+// to store against the old dir.
+//
+// Two paths:
+//
+//   - No scan outstanding for dir: launch one on a throwaway goroutine and wait
+//     up to the budget. The goroutine gets a buffered channel and the
+//     already-sampled directory reader, so it never blocks on the send and never
+//     touches Store state or a package var — it cannot race with anything, and
+//     abandoning it is safe.
+//   - A scan for dir is already outstanding (a previous call abandoned it at the
+//     budget): poll it WITHOUT blocking. A caller must not pay a second full
+//     budget for a filesystem already known to be unresponsive, so this returns
+//     ok=false immediately when the earlier scan still has not landed. When it
+//     HAS landed, its result is consumed here — that is the retry the reseed
+//     contract promises, arriving on the first call after the filesystem
+//     recovers rather than needing a fresh scan.
+//
+// The pending scan is keyed by dir: a call for a DIFFERENT dir drops the
+// reference and launches its own scan (the abandoned goroutine still completes
+// into its buffered channel and exits). A scan is therefore leaked at most once
+// per distinct directory, never once per commit.
+func (s *Store) awaitArchiveScanLocked(dir string) (archiveScanResult, bool) {
+	if s.archiveScanCh != nil && s.archiveScanDir == dir {
+		select {
+		case res := <-s.archiveScanCh:
+			s.archiveScanCh = nil
+			s.archiveScanDir = ""
+			return res, true
+		default:
+			return archiveScanResult{}, false
+		}
+	}
+
+	// Sample the reader seam HERE, on the goroutine that holds the lock, and
+	// hand it to the scan — see maxArchiveSeqWith.
+	read := archiveDirReader
+	ch := make(chan archiveScanResult, 1)
+	s.archiveScanCh = ch
+	s.archiveScanDir = dir
+	go func() {
+		seq, err := maxArchiveSeq(read, dir)
+		ch <- archiveScanResult{seq: seq, err: err}
+	}()
+
+	timer := time.NewTimer(archiveScanBudget)
+	defer timer.Stop()
+	select {
+	case res := <-ch:
+		s.archiveScanCh = nil
+		s.archiveScanDir = ""
+		return res, true
+	case <-timer.C:
+		// Abandon the scan. The goroutine keeps ch (buffered, capacity 1), so it
+		// completes and exits on its own whenever the filesystem answers, and the
+		// reference retained in s.archiveScanCh lets the next call collect it.
+		return archiveScanResult{}, false
+	}
+}
+
 // maxArchiveSeq returns the highest config-<ts>.<seq>.conf sequence number
 // present in dir. It returns a non-nil error when the directory is UNREADABLE,
 // distinct from a readable directory that holds no well-formed archive (which
 // returns 0, nil). The caller MUST NOT treat a scan error as an empty
 // directory: seeding the monotonic counter to 0 on a transient failure would
 // pin it below the on-disk max and prune every fresh archive as stale
-// (#6396 Codex MINOR 4). Used by SetArchiveConfig to seed archiveSeq.
-func maxArchiveSeq(dir string) (uint64, error) {
-	entries, err := archiveDirReader(dir)
+// (#6396 Codex MINOR 4). Reached from SetArchiveConfig / the archiving commit
+// path via awaitArchiveScanLocked, which seeds archiveSeq.
+//
+// #6776: the directory reader is passed in rather than read from the
+// archiveDirReader package var, because this now runs on a throwaway scan
+// goroutine. The seam must be sampled ONCE on the goroutine that holds s.mu and
+// handed in — a test that restores the seam while an abandoned scan is still
+// parked in readdir(2) would otherwise be a data race on the package var.
+func maxArchiveSeq(read func(string) ([]os.DirEntry, error), dir string) (uint64, error) {
+	entries, err := read(dir)
 	if err != nil {
 		return 0, err
 	}
@@ -814,7 +941,18 @@ func (s *Store) ArchiveConfig(archiveDir string, maxArchives int) error {
 		return nil
 	}
 	// #6403: seed the shared counter from THIS dir before claiming the seq.
-	if seed, err := maxArchiveSeq(archiveDir); err != nil {
+	// #6776: bounded by archiveScanBudget — this is the "bounded ReadDir under
+	// the lock" the comment above promises, which before #6776 it was not. A
+	// budget expiry is reported to this SYNCHRONOUS caller as an error, the same
+	// as a genuine read error below: both leave the on-disk max unknown, so the
+	// caller must learn it could not safely archive.
+	scan, ok := s.awaitArchiveScanLocked(archiveDir)
+	if !ok {
+		s.mu.Unlock()
+		return fmt.Errorf("archive seq reseed scan of %s: did not complete within %s",
+			archiveDir, archiveScanBudget)
+	}
+	if seed, err := scan.seq, scan.err; err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			// A genuine scan error (mount/permission) leaves the on-disk max
 			// UNKNOWN, so a claimed seq cannot be guaranteed to outrank the


### PR DESCRIPTION
Closes #6776

All cites below are **re-derived from code at `dd60c48b0`**. The issue body
points at `/tmp/opus-review-001.md` section R34, which no longer exists, and its
line numbers are stale — nothing here is taken from the report.

## What I measured (two of the three title claims do not survive)

**"global store mutex" — TRUE.** The reseed scan runs inside
`Store.ensureArchiveSeededLocked`, which its callers reach holding `Store.mu`
for **writing**. That is the store-wide `sync.RWMutex` (`store.go`), taken at
111 sites across 133 public methods — it gates `Load`, every `Commit`, and every
configuration read.

**"remote `ReadDir`" — FALSE.** The scanned directory is *always* the local
`/var/lib/xpf/archive`. `pkg/config/compiler_system.go` hardcodes
`ArchivalConfig.ArchiveDir`, and there is **no `archive-dir` configuration
leaf** anywhere in the tree (`grep` over `pkg/`, `cmd/`, the schema and the
parser finds only tests and docs). The only production caller of
`SetArchiveConfig` is `daemon_apply_tail.go` step 15b, passing that hardcoded
default; `Store.ArchiveConfig(dir, max)` — the one method that takes a dir —
has **zero production callers**. The remote leg of archival is a different
path entirely: `archiveToSites` → `scpArchiveTransfer`, already bounded at 30s
and run off-lock. Nothing in the archive path ever lists a *remote* directory.
The path becomes remote only if an operator or image makes `/var/lib/xpf/archive`
a mount point — real, but a mount-layer decision, not an xpf configuration one.

**"can wedge cold boot" — TRUE, but not by the mutex.** `SetArchiveConfig` is
step 15b of the boot apply, which runs in daemon **PHASE 4**
(`dataplane-setup` → `setupDataplaneAndInitialConfig` → `applyConfig`), and the
gRPC/HTTP/CLI listeners start in **PHASE 5** (`daemon_run.go`). At boot
`archiveSeedDir == ""`, so the scan runs *unconditionally* on every cold boot,
not just on a dir switch. The blocked thread is the bring-up thread itself, so
the observable is **xpfd never reaches its control plane** — no gRPC, no REST,
no CLI, no health endpoint, no cluster comms — whether or not the lock is held.
The lock is the *runtime* half of the same defect: a scan that stalls also stalls
every concurrent configuration reader.

Net: the report is right that this is an unbounded blocking syscall inside the
global store write lock on the cold-boot critical path. It is wrong about the
trigger. Severity holds; the scope narrows to storage that stops answering
`readdir(2)` under `/var/lib/xpf/archive`.

## The fix, and why it is not "add a context"

`os.ReadDir` is a syscall. A thread parked in an uninterruptible filesystem wait
is not reachable from userspace, so a `ctx` parameter here would be a deadline
that never fires. The only mechanism that actually bounds the wait is to run the
syscall on a throwaway goroutine and stop waiting for it — `awaitArchiveScanLocked`,
budgeted by `archiveScanBudget` (5s).

**The critical section is deliberately NOT shrunk.** Releasing `s.mu` around the
scan would let a concurrent `SetArchiveConfig` switch `archiveDir` out from under
a seed about to be stored against the old dir — exactly the widening #6403
established belongs *inside* the lock. Only the **wait** is bounded.

**Behaviour on expiry is fail-open, and that is the decision this PR exists to
make.** Config archival is a DR/compliance convenience; refusing to bring a
firewall up because a directory did not answer converts a degraded-storage event
into a total outage. So the caller is released, bring-up and config work proceed,
and only archival is suspended. The suspension needs no new state machine: a
timed-out scan leaves the on-disk max in exactly the state a read error does —
UNKNOWN — so it reuses the #6404 UNCONFIRMED path verbatim. The counter is never
reseeded (so it cannot rewind to 0 and make every later archive below-max),
`archiveSeedDir` is cleared so a later call retries, and an archiving commit
SKIPS its archive rather than write a below-max seq rotation would prune.

The abandoned goroutine is **not** leaked per call: it keeps its buffered result
channel, retained on the Store keyed by the dir it was launched for, so the next
call collects the result with a non-blocking poll once the filesystem answers and
archival resumes at the correct seq. A persistently wedged archive filesystem
therefore costs exactly **one** budget-length stall and **one** goroutine per
process, not one per commit.

**Why 5s.** The archive dir is retention-capped at `max-archives` (default 10),
so a healthy `readdir` costs microseconds — 5s is ~3 orders of magnitude of
headroom and cannot fire on a merely loaded disk, while capping the bring-up
delay an unresponsive filesystem can impose. The mutation matrix pins the value
being load-bearing in both directions: cell M1 (unbounded) and cell M6 (zero) are
both red.

`maxArchiveSeq` now takes the directory reader as a parameter so the
`archiveDirReader` test seam is sampled on the lock-holding goroutine and never
read from inside an abandoned scan — cell M9 shows that is load-bearing under
`-race`.

**A false claim corrected.** `Store.ArchiveConfig`'s comment and the matching
`pkg/configstore/README.md` text already asserted the seed scan was "a bounded
`ReadDir` under the lock". Before this change that was false. Its scan is now
bounded by the same helper (reporting an expiry as an error to its synchronous
caller), so the claim is now true.

## Mutation matrix

Every cell: fix committed first, one mutation per line, anchor asserted to match
exactly once, tree re-built, then the **full package suite** with
`go test -count=1 -v ./pkg/configstore/` and **no `-run` filter**. Baseline
(M0, unmutated): **437 tests collected, 0 failed, rc=0** — so every cell below
is a real red, not a run that collected nothing.

| Cell | Mutation (one line) | Result | Which assertion fired |
|---|---|---|---|
| M0 | none (control) | **GREEN** rc=0 | 437 collected / 0 failed |
| M1 | `NewTimer(archiveScanBudget)` → `NewTimer(time.Hour)` (unbounded — the shipped bug) | **RED** 2 | `SetArchiveConfig blocked 5.0009s … the reseed scan is not bounded, so the boot apply never reaches the control plane`; `a concurrent config read blocked 4.952s behind the reseed scan … holding the global store mutex unbounded` |
| M2 | timeout returns `true` (CONFIRMED) instead of `false` | **RED** 1 (4 assertions) | `must leave archiveSeedDir cleared`; `must NOT write a below-max archive … surviving=[pre-100 pre-101 pre-102 system {]`; `3 pre-existing must be untouched, got 4`; `archiveSeq = 1, want 102` |
| M3 | delete `s.archiveSeedDir = ""` from the timeout branch | **RED** 1 | `returning to dirA after a TIMED-OUT dirB scan must rescan dirA … got 5`; `the archive written after returning to dirA must survive rotation; remain=map[a-100 a-101 a-102]` |
| M4 | **tightening** — apply `res.seq` on the timeout path | **RED** 1 | `must leave the monotonic counter alone: archiveSeq = 0, want 41` |
| M5 | drop the pending-scan reuse branch (`if false && …`) | **RED** 1 | `3 further calls … took 1.2019s (>= one budget of 400ms)`; `must leak exactly ONE scan goroutine, launched 4` |
| M6 | **tightening** — `archiveScanBudget = 0` (healthy scans time out) | **RED** **17** | reds the pre-existing #6396/#6403/#6404/#6185 suite: `TestSetArchiveConfigReseedsOnDirSwitch`, `TestArchiveConfigSeedsFromDirBeforeClaimingSeq`, `TestCommitReseedsAfterFailedScan`, … |
| M7 | **tightening** — commit path fails CLOSED on an unconfirmed seq | **RED** **14** | in the new suite: `a commit during an unresponsive archive scan must still SUCCEED (archival is fail-open; the box must stay configurable)` — i.e. the test binds the *choice*, not the existence of a deadline |
| M8 | discard the abandoned scan (`s.archiveScanCh = nil` on timeout) | **RED** 1 | `3 further calls … took 1.2016s`; `launched 4` |
| M9 | read the seam inside the scan goroutine (run under `-race`) | **RED** — 2 `DATA RACE` | `TestReseedScanTimeoutNeverRewindsCounter6776`, `TestReseedScanTimeoutInvalidatesSeedMarkerOnReturn6776` |

**M3 initially SURVIVED**, and that is the matrix earning its keep. Every fixture
reached the timeout from cold boot, where `archiveSeedDir` is already empty — so
clearing it is a no-op there and a boot-shaped fixture stays green with the guard
deleted. Commit 2 adds `TestReseedScanTimeoutInvalidatesSeedMarkerOnReturn6776`,
built on the smallest shape where deleting the guard changes an **outcome**: a
dir switch (A scans cleanly → B times out → return to A), asserting the real
rotation result, not a private counter. M3 is red above with that guard in place.

Fixture note: `TestReseedScanTimeoutNeverRewindsCounter6776` starts the counter
at **41**, never at 0 — 0 is both the zero value of `archiveScanResult.seq` and
the value the bug falls back to, so a 0-based fixture cannot tell "left alone"
from "reseeded to 0".

## Validation

- `go build ./...` — rc=0
- `go vet ./...` — clean
- `go test -count=1 ./...` (repo-wide) — **rc=0**
- `go test -count=1 -race ./pkg/configstore/` — green
- Gated head: **`39121185f4b47be5eac2959028fc652e2a52f0b1`** (includes the merge
  of `origin/master` @ `7a7b6ccc70e71973a9de91122ad60742abc0afe1`; the only
  conflict was an append-vs-append in `_Log.md`, union-resolved with both the
  #6777 and #6776 entries verified intact and zero markers remaining).
  Branched from `dd60c48b06ea00407c6f4ce9442cb2292a2663ca`.
- **The whole matrix was re-run at the merged head** — a fold can invalidate a
  matrix. Baseline there: **438 collected, 0 failed, rc=0**; all 8 cells still
  red, with the same assertions firing (M6 reds 16 rather than 17 pre-existing
  tests, both decisive). `go build`/`go vet`/`go test -count=1 ./...` all re-run
  green at that head.

No Rust touched (`userspace-dp/`, `userspace-xdp/` untouched), so no cargo leg.
**No cluster / VRRP / session-sync / failover code is touched** — the diff is
`pkg/configstore` plus its README and `_Log.md`.

## Docs

`pkg/configstore/README.md` gains a "The reseed scan is time-bounded (#6776)"
paragraph covering the mutex/PHASE-4-vs-PHASE-5 mechanism, why a context is not
the tool, the fail-open decision and its justification, the one-stall/one-goroutine
bound, the choice of 5s, and the scope correction about `archive-dir`. The
pre-existing "bounded `ReadDir` under the lock" sentence is updated so it names
what now makes it true. `_Log.md` appended.
