### PR TITLE
dataplane: remove the u16-wrapping port expansion helper

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104414,3 +104414,19 @@ prose edit above them added. No diff falls in the new test body.
   documented claims with no assertion behind them; a mutation neutralising
   either left the suite green.
 - **File(s)**: pkg/ra/goodbye_retry_debt_6777_test.go, _Log.md
+
+## 2026-08-22 — #6783 appPortsFromSpec u16 wrap: dead helper removed, ceiling guarded
+
+- **Timestamp**: 2026-08-22
+- **Action**: `pkg/dataplane.appPortsFromSpec` expanded a port range using the
+  parse's uint16 bounds as the loop counter, so any spec ending at 65535 with a
+  width > 1 never terminated. Reproduced (`65534-65535` hangs). Its last
+  production caller was removed by `ad31711e3`, so the defect is no longer
+  reachable — the helper was dead code carrying an infinite loop, and is
+  deleted with its test rather than repaired. Swept the repo for the same
+  pattern: five ascending expansion loops, four already total (int/uint64
+  counters or an explicit ceiling break). Added a watchdogged ceiling guard on
+  the surviving live helpers in pkg/dataplane/userspace, which the existing
+  agreement corpus could not cover without turning a wrap into a hung suite.
+- **File(s)**: pkg/dataplane/compiler.go, pkg/dataplane/compiler_test.go,
+  pkg/dataplane/userspace/port_expansion_ceiling_6783_test.go, _Log.md

--- a/pkg/dataplane/compiler.go
+++ b/pkg/dataplane/compiler.go
@@ -1440,28 +1440,19 @@ func parsePorts(spec string) ([]uint16, error) {
 	return []uint16{uint16(port)}, nil
 }
 
-// appPortsFromSpec parses an application's DestinationPort spec (e.g. "80", "8080-8090")
-// into a slice of individual port ints. Returns nil for empty spec.
-func appPortsFromSpec(spec string) []int {
-	if spec == "" {
-		return nil
-	}
-	lo, hi, err := parsePortRange(spec)
-	if err != nil {
-		return nil
-	}
-	if hi > lo {
-		var ports []int
-		for p := lo; p <= hi; p++ {
-			ports = append(ports, int(p))
-		}
-		return ports
-	}
-	return []int{int(lo)}
-}
-
 // parsePortRange parses a port spec like "80", "1024-65535", or "" into (low, high).
 // Unlike parsePorts, it does NOT expand ranges — returns the range boundaries.
+//
+// The bounds are uint16, so they MUST NOT be used directly as an ascending loop
+// counter to expand the range: at high == 65535 the counter wraps to 0 after the
+// final iteration, `p <= high` is true again, and the loop never terminates
+// (#6783). Callers that expand must widen to int/uint64 first, or carry an
+// explicit ceiling break the way the per-port application writer above does
+// ("prevent uint16 overflow"). Every current caller keeps the bounds AS bounds;
+// the one expander that did not was `appPortsFromSpec`, removed in #6783 after
+// ad31711e3 dropped its last production caller. pkg/dataplane/userspace owns the
+// surviving port-expansion helpers and parses into uint64 for exactly this
+// reason.
 func parsePortRange(spec string) (uint16, uint16, error) {
 	if spec == "" {
 		return 0, 0, nil

--- a/pkg/dataplane/compiler_test.go
+++ b/pkg/dataplane/compiler_test.go
@@ -591,30 +591,6 @@ func TestHostInboundAllowlistLogic(t *testing.T) {
 	}
 }
 
-func TestAppPortsFromSpec(t *testing.T) {
-	tests := []struct {
-		spec string
-		want []int
-	}{
-		{"", nil},
-		{"80", []int{80}},
-		{"8080-8083", []int{8080, 8081, 8082, 8083}},
-		{"443-443", []int{443}},
-	}
-	for _, tt := range tests {
-		got := appPortsFromSpec(tt.spec)
-		if len(got) != len(tt.want) {
-			t.Errorf("appPortsFromSpec(%q) len = %d, want %d", tt.spec, len(got), len(tt.want))
-			continue
-		}
-		for i := range got {
-			if got[i] != tt.want[i] {
-				t.Errorf("appPortsFromSpec(%q)[%d] = %d, want %d", tt.spec, i, got[i], tt.want[i])
-			}
-		}
-	}
-}
-
 func TestResolvePortName(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/dataplane/userspace/port_expansion_ceiling_6783_test.go
+++ b/pkg/dataplane/userspace/port_expansion_ceiling_6783_test.go
@@ -1,0 +1,97 @@
+package userspace
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+// appPortSpecCeilingCorpus is the set of specs whose HIGH bound is the u16
+// ceiling AND whose width is greater than 1, so each one enters the range
+// EXPANSION arm rather than the exact-port arm.
+//
+// These deliberately do NOT live in appPortSpecCorpus, even though the agreement
+// they are checked for below is the same one that corpus drives. A wrap is
+// non-termination, not a wrong answer: an implementation that counts in uint16
+// would make the shared corpus test HANG the whole package until the go test
+// timeout, surfacing as a timeout panic in whichever test happened to be running
+// rather than as a named failure. Keeping the ceiling specs behind the watchdog
+// below buys the same coverage without putting that hazard into a test that has
+// no deadline of its own.
+var appPortSpecCeilingCorpus = []string{
+	"65534-65535", "65530-65535",
+}
+
+// #6783. A port-expansion helper that uses the parse's uint16 bounds directly as
+// its ascending loop counter cannot terminate when the high bound is 65535:
+// after the final iteration the counter wraps to 0, `p <= hi` is true again, and
+// the loop appends forever until the process is OOM-killed. `pkg/dataplane`
+// carried exactly that helper; #6783 removed it, its last production caller
+// having gone away in ad31711e3. The helpers in THIS package parse into uint64
+// and are total — a property nothing asserted, because the existing corpus holds
+// "65535" (exact port: never enters the expansion arm) and "1-65535" (enters it,
+// but a wrap there reads as a hung suite).
+//
+// The goroutine cannot be reaped on the failure path: a wrapped loop is not
+// interruptible, and a context it does not check would not stop it. It therefore
+// leaks — appending into an ever-growing slice — until the process exits. That
+// hazard is NOT introduced here: appPortSpecCorpus already contains "1-65535"
+// and "0-65535", so a wrapped implementation already runs a leaking expansion for
+// the whole go test timeout. The short window below strictly SHORTENS it, and is
+// several orders of magnitude above the microseconds a correct expansion needs,
+// so it cannot flake on a loaded machine. Two cells rather than five for the same
+// reason: each additional ceiling spec is another leaked goroutine, and they
+// prove the same thing.
+const watchdogWindow = 3 * time.Second
+
+func TestPortExpansionTerminatesAtTheU16Ceiling6783(t *testing.T) {
+	for _, spec := range appPortSpecCeilingCorpus {
+		t.Run(spec, func(t *testing.T) {
+			lo, hi, ok := appPortSpecBounds(spec)
+			if !ok {
+				t.Fatalf("appPortSpecBounds(%q) reported no bounds; the fixture "+
+					"never reaches the expansion arm it exists to exercise", spec)
+			}
+			if hi != 65535 || hi <= lo {
+				t.Fatalf("fixture %q has bounds [%d,%d]; a ceiling cell must have "+
+					"high == 65535 AND width > 1 or it cannot detect a wrap",
+					spec, lo, hi)
+			}
+
+			type result struct {
+				ports  []int
+				ranges []NatPortRangeWire
+			}
+			done := make(chan result, 1)
+			go func() {
+				ports := appPortsFromSpec(spec)
+				done <- result{ports: ports, ranges: coalescePortRanges(ports)}
+			}()
+
+			var got result
+			select {
+			case got = <-done:
+			case <-time.After(watchdogWindow):
+				t.Fatalf("appPortsFromSpec(%q) did not terminate: the expansion "+
+					"loop is counting in uint16 and wrapped past the 65535 "+
+					"ceiling (#6783)", spec)
+			}
+
+			if want := int(hi-lo) + 1; len(got.ports) != want {
+				t.Fatalf("appPortsFromSpec(%q) produced %d ports, want %d",
+					spec, len(got.ports), want)
+			}
+			if last := got.ports[len(got.ports)-1]; last != 65535 {
+				t.Fatalf("appPortsFromSpec(%q) ended at port %d, want 65535 — the "+
+					"expansion stopped short of the ceiling", spec, last)
+			}
+
+			// The same agreement appPortSpecCorpus drives, run at the ceiling:
+			// the live no-materialize path must equal the coalesced expansion.
+			if ranges := appPortRangesFromSpec(spec); !reflect.DeepEqual(ranges, got.ranges) {
+				t.Fatalf("appPortRangesFromSpec(%q) = %v, coalescePortRanges("+
+					"appPortsFromSpec(%q)) = %v", spec, ranges, spec, got.ranges)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #6783

## The defect is real, and I reproduced it before touching anything

`pkg/dataplane.appPortsFromSpec` expanded a port range using the parse's
**uint16** bounds as the loop counter:

```go
lo, hi, err := parsePortRange(spec)   // both uint16
for p := lo; p <= hi; p++ { ports = append(ports, int(p)) }
```

At `hi == 65535` the counter wraps to 0 after the final iteration, `p <= hi` is
true again, and the loop appends until the process is OOM-killed.
`"65534-65535"` is the smallest such spec. Under a 2s deadline it does not
return.

## The severity in the issue no longer holds, and saying so is part of the fix

The issue is graded High on "makes a valid DNAT application apply
non-terminating". That was true at the review's base. It is not true at master:
**`ad31711e3` ("dataplane: drop dead eBPF NAT record construction") removed
`compileNAT`'s `dnatAppTerm` construction, which was this helper's last
production caller.** At `7a7b6ccc7` nothing outside its own test calls it, so no
DNAT application can reach the loop.

What was left is dead code carrying an infinite loop — a trap for whoever adds
the next caller. That is why it is **deleted rather than repaired**.
`pkg/dataplane/userspace` owns the surviving port helpers, parses into `uint64`,
and its live builder path (`appPortRangesFromSpec`, #5250) does not expand at
all.

## Swept the class, did not assume one site was the story

Five ascending expansion loops exist in the tree. Four are already total:

| site | counter | why it is safe |
|---|---|---|
| `pkg/config/compiler_nat_destination.go` `appendDNATPortRange` | `int` | refuses out-of-range endpoints (#3449) |
| `pkg/dataplane/compiler.go` `parsePorts` | `uint64` (ParseUint) | cannot wrap |
| `pkg/dataplane/userspace/nat.go` `appPortsFromSpec` | `uint64` | cannot wrap |
| `pkg/dataplane/compiler.go` per-port application writer | `uint16` | explicit `if port == 65535 { break // prevent uint16 overflow }` |
| **`pkg/dataplane/compiler.go` `appPortsFromSpec`** | **`uint16`** | **nothing — this is #6783** |

That last guarded site is **674 lines above the deleted helper, in the same
file**. The hazard was known and guarded at one site and missed at the other,
which is worth recording where the next expander will be written —
`parsePortRange`'s doc comment now carries the warning, since it is the function
handing out the uint16 bounds.

## The guard goes on the live helpers, not the deleted one

The #5250 agreement corpus already holds `"65535"` and `"1-65535"`, but neither
covers this: an exact port never enters the expansion arm, and a wrap on a
corpus entry hangs the whole package until the `go test` timeout and surfaces as
a timeout panic in whichever test happened to be running — not as a named
failure. I confirmed that empirically (see M1 below).

So the ceiling specs live behind a watchdog in their own test, which runs **the
same agreement predicate the corpus drives** —
`appPortRangesFromSpec == coalescePortRanges(appPortsFromSpec)` — plus a count
and a last-element check, on two specs whose high bound is 65535 and whose width
is greater than one. It also asserts its own fixtures actually reach the
expansion arm, so a future parse change cannot make the cells vacuous.

**On the leak, stated rather than hidden:** a wrapped loop is not interruptible,
so the watchdog's goroutine leaks until the process exits. That hazard is not
introduced here — `appPortSpecCorpus` already contains `"1-65535"`, so a wrapped
implementation already runs a leaking expansion for the whole test timeout. The
3s window strictly *shortens* it, and two cells are used rather than five because
each extra ceiling spec is another leaked goroutine proving the same thing.

## Mutation matrix

Fix committed FIRST. Cells run the full `pkg/dataplane/userspace` suite with
`go test -count=1`, no `-run` filter; each mutation verified applied on a
compiling, vetting tree.

| cell | result | assertion that fired |
|---|---|---|
| M1 live `appPortsFromSpec` counts in uint16 (the #6783 defect itself) | RED | package **timeout, no named failure** — see below |
| M2 expansion stops one short of the ceiling | RED | `...MatchesCoalescedSlice`; `...RejectsReversedRange`; `...TerminatesAtTheU16Ceiling6783` |
| **M3 TIGHTEN: `appPortRangesFromSpec` clamps high to 65534** | RED | `...MatchesCoalescedSlice`; `...DoesNotMaterializeTheRange`; `...TerminatesAtTheU16Ceiling6783` |
| **T1 TIGHTEN: add a ceiling cell that never enters the expansion arm (`"65535"`)** | RED | `...TerminatesAtTheU16Ceiling6783` — the fixture self-check |

**M1 is the cell worth reading.** It reports RED with *no named failing test*,
because the pre-existing corpus test hangs and the package dies at the timeout.
Run with the new test selected alone, the watchdog names it at 3s per cell:

```
port_expansion_ceiling_6783_test.go:74: appPortsFromSpec("65534-65535") did not
terminate: the expansion loop is counting in uint16 and wrapped past the 65535
ceiling (#6783)
```

That difference — a package timeout versus a named assertion — is the entire
argument for the watchdog, and M1 is what demonstrates it rather than asserting
it in a comment.

T1 is the anti-vacuity control: `"65535"` is a ceiling spec that parses to
`[65535,65535]` and never enters the expansion arm, so a cell built from it
could never detect a wrap. The test refuses it.

## Scope

`pkg/dataplane` and `pkg/dataplane/userspace` (Go only). **No cluster, VRRP,
session-sync or failover code; nothing moves the `userspace-dp` binary or the
shim `.o`** — no cargo leg, no cluster smoke.

No documentation change: `appPortsFromSpec` was package-private with no
production caller, and no operator-visible behaviour changes.

`go build ./... && go vet ./... && go test -count=1 ./...` all rc=0, 67 packages,
at head `a5df5688d68eec1e3115f2f200d966a8bfb8ea1f`, tree clean.
