### PR TITLE
cluster: recover a config dropped by a full apply queue

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104389,3 +104389,28 @@ prose edit above them added. No diff falls in the new test body.
   schema is right and nothing changed.
 - **File(s)**: `pkg/config/schema.go`, `pkg/config/schema_security.go`,
   `pkg/config/schema_walk.go`, `pkg/config/schema_block_value_6774_test.go`
+
+## 2026-08-22 — #6778 a full config-apply queue stranded the newest generation
+
+- **Timestamp**: 2026-08-22
+- **Action**: The `default:` arm of the non-blocking enqueue in
+  `handleConfigPayload` discards the INCOMING payload, which is the NEWEST
+  generation the peer has sent, while the queue retains older ones — so the
+  standby drains onto a superseded config. `recordRecvConfigGen` had already
+  raised the received high-water for it, so the node read config-stale and
+  #5563 refused manual-failover promotion, with nothing driving the missing
+  generation back: the sender's #5863 (epoch x generation) marker is claimed
+  BEFORE the push and only a nack clears it. The drop now takes the three
+  actions an apply failure already took — its own `ConfigsQueueFullDropped`
+  counter rendered in cluster status, the #6387 grace timer via
+  `noteConfigApplyFailure(errConfigApplyQueueFull)`, and `sendConfigApplyNack`
+  so the sender's existing 30s reconcile re-pushes. No new retry queue.
+  `noteConfigApplySuccess` was narrowed to take the applied generation and
+  no-op while it is still below `lastRecvConfigGen`, because a queue only
+  fills when the consumer is behind and the backlog's successful applies were
+  cancelling the drop's debt milliseconds after it armed.
+- **File(s)**: `pkg/cluster/sync.go`, `pkg/cluster/status.go`,
+  `pkg/cluster/sync_conn_read.go`, `pkg/cluster/sync_conn_config.go`,
+  `pkg/cluster/sync_config_queue_full_6778_test.go`,
+  `pkg/cluster/sync_config_health_6387_test.go`, `docs/sync-protocol.md`,
+  `docs/session-sync-architecture.md`

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -622,11 +622,24 @@ the sender accepts it only when it names `lastSentConfigGen` — the generation 
 most recently put on the wire — and invalidates the push marker, so the next
 ordinary reconcile tick re-sends.
 
+#6778 added a SECOND sender of that frame: `handleConfigPayload`'s queue-full
+drop. When `configApplyCh` is full the non-blocking enqueue discards the
+INCOMING payload — the newest generation — and no apply ever runs, so
+`configApplyLoop` never reaches the failure branch and nothing re-armed the
+sender's marker. The receive-edge drop is the same condition ("this node did not
+apply the generation you pushed") reached one step earlier, so it takes the same
+three actions: its own counter (`ConfigsQueueFullDropped`), the #6387 grace
+timer, and this nack. Writing it from the receive loop matches the heartbeat-ack
+and `sendBulkAck` shape already in that switch. The drop is documented in full
+under **Queue-full drop (#6778)** in `docs/sync-protocol.md`.
+
 Properties worth stating, because the asymmetry is the whole design:
 
 - **It fires only on failure.** A successful apply sends no nack, nothing
   re-arms, and a healthy connection still pushes a generation exactly once. The
-  #5863 no-storm property is preserved unchanged.
+  #5863 no-storm property is preserved unchanged. #6778's queue-full sender is
+  inside the `default:` arm for the same reason: an enqueue that SUCCEEDS must
+  stay silent, or every push would re-arm the sender's marker.
 - **The retry is bounded to the reconciler's cadence.** The nack handler clears
   the marker and returns; it deliberately does not push inline, so a failure
   that recurs instantly cannot become a push/fail/nack tight loop on the shared

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -560,7 +560,10 @@ older C1 with no alarm. The receiver now:
 2. Enqueues `{gen, configText}` onto a bounded, single-consumer ordered apply
    queue (`configApplyLoop`) — the `receiveLoop` is single-threaded per
    connection, so this preserves receive order. The non-blocking enqueue never
-   stalls session sync / heartbeats behind a slow config apply.
+   stalls session sync / heartbeats behind a slow config apply. If the queue is
+   full the enqueue drops — see **Queue-full drop (#6778)** below, because the
+   `default:` arm discards the payload it is *holding*, which is the NEWEST
+   generation, not the oldest queued one.
 3. Applies a config only when `shouldApplyConfigGen` accepts its generation
    (strictly newer than the last-applied high-water mark, or `gen=0`). An
    out-of-order older config is **dropped with an alarm** and counted in
@@ -584,6 +587,58 @@ reintroduced on the *receiver* by the #3931 ordering guard). This preserves the
 #1960 lenient-load posture: whatever `syncAndApply` reports as its outcome
 (nil = store promoted + applied; error = not applied) is exactly what gates the
 mark, so the high-water always reflects the config actually in effect.
+
+**Queue-full drop (#6778).** The non-blocking enqueue in step 2 takes its
+`default:` arm when `configApplyCh` (cap 64) is full. The item it discards is
+the INCOMING one — the newest generation the peer has sent — while the queue
+retains the older ones, so the node finishes draining on a *superseded* config.
+`recordRecvConfigGen` has already run for that payload (deliberately: see the
+#5563 gate below), so the node correctly reads config-stale and manual-failover
+promotion is refused. Before #6778 nothing closed that gap: the sender's #5863
+`(epoch × generation)` marker was claimed BEFORE the push and only a nack clears
+it, so on a stable connection the standby stayed behind the primary until the
+next commit or reconnect — a wedge, not a blip.
+
+The drop is now treated as the same class of event as an apply failure, because
+the operator consequence is identical and the repairs already existed:
+
+- **Counted** on its own `ConfigsQueueFullDropped` counter, rendered in
+  `show chassis cluster information` as `Configs queue-full-dropped:`. It is
+  deliberately NOT folded into `ConfigsApplyFailed` — the apply never ran, so
+  sending an operator to look for a compile error would be wrong — nor left on
+  the generic `Errors` counter, where "the standby is behind the primary's
+  committed config" is indistinguishable from a send failure.
+- **Debt.** `noteConfigApplyFailure(errConfigApplyQueueFull)` arms the #6387
+  grace-expiry timer, so a drop that does not re-converge inside the grace
+  raises `CF` on its own with no further delivery required.
+- **Retry.** `sendConfigApplyNack(gen)` re-arms the sender's #5863 push marker
+  through `OnPeerConfigApplyFailed`, and the sender's existing 30s
+  `configSyncReconcileLoop` re-pushes. There is **no new retry queue**: buffering
+  the dropped payload on the receiver is exactly the unbounded growth the
+  non-blocking send exists to avoid, and the payload is the peer's ACTIVE config,
+  so re-asking for it is strictly better than holding a copy that may already be
+  superseded. Writing the nack from the receive loop is the established shape in
+  that switch (the heartbeat ack and `sendBulkAck` do the same under `writeMu`),
+  and it is rate-bounded by the peer's push rate.
+
+The queue itself was left lossy rather than converted to an evict-oldest
+"latest-generation slot". Evicting the oldest would require the receive loop to
+become a second consumer of `configApplyCh`, and under a cross-fabric reorder
+(the active connection flipping between `conn0`/`conn1`) it could evict a NEWER
+queued item to make room for an OLDER arrival — losing a generation that, having
+enqueued successfully, would take no nack and no debt. That trades a visible,
+recovered loss for a silent one.
+
+**Debt is not cancelled by a stale backlog apply (#6778).** A queue only fills
+because the consumer is behind, so a drop is always followed within milliseconds
+by successful applies of the backlog. `noteConfigApplySuccess` therefore takes
+the generation whose apply just succeeded and no-ops while it is still below
+`lastRecvConfigGen` — the same predicate `TransferReadinessSnapshot.ConfigStale`
+uses. Under the pre-#6778 unconditional clear those backlog successes disarmed
+the grace timer and the drop's debt evaporated long before `CF` could raise. The
+gate cannot pin `CF` raised: a payload refused before `recordRecvConfigGen` never
+raises the received mark, `resetRecvGen` clears BOTH marks to 0 on reconnect, and
+a legacy peer leaves both at 0.
 
 **Config-sync apply-failure health surfacing (`CF`, #6387).** Leaving the
 high-water pinned on a persistent apply failure is correct for convergence but
@@ -706,7 +761,8 @@ which is true per connection but there are two of them.
 **Manual-failover config-staleness gate (#5563).** A second high-water mark,
 `lastRecvConfigGen`, records the highest generation this node has *received*
 from the peer (advanced in the `syncMsgConfig` handler at enqueue, BEFORE
-apply, even if the ordered apply queue is full and the payload is dropped). It
+apply, even if the ordered apply queue is full and the payload is dropped —
+#6778 keeps that raise and adds the nack that closes the resulting gap). It
 is the receiver's local view of the config *sender's* current committed
 generation. `TransferReadiness` carries both marks (`PeerConfigGen =
 lastRecvConfigGen`, `AppliedConfigGen = lastAppliedConfigGen`), and
@@ -1303,6 +1359,8 @@ All counters are `atomic.Uint64` / `atomic.Bool`, lock-free:
 | ConfigsSent/Received | Config sync messages |
 | ConfigsStaleIgnored | Config messages dropped by the #3931 ordering guard (incoming generation not strictly newer than last-applied) |
 | ConfigsApplyFailed | Config messages admitted by the ordering guard but whose apply did NOT take effect (compile/promote failure or a transient RG0-primary rejection). The high-water is left unadvanced so the peer's re-push re-converges the standby (M-2/#4151) |
+| ConfigsQueueFullDropped | Config payloads that never reached the ordered apply queue because it was full at enqueue (#6778). The non-blocking send discards the INCOMING payload — the NEWEST generation — so the node is left on a superseded config. The received high-water is still raised (the node reads config-stale), a config-apply nack re-arms the sender's #5863 marker, and the #6387 grace timer arms. A nonzero value climbing while `ConfigApplyNacksReceived` on the PEER stays at zero means the recovery path itself is broken |
+| ConfigApplyNacksReceived | #7328 config-apply nacks accepted from the peer — one per generation this node pushed that the peer refused, failed to apply, or dropped at its receive edge (#6778). A nack naming a superseded generation is ignored and not counted |
 | BulkPrimesWithoutIncarnation | `BulkStart` frames received carrying no boot incarnation (#5084) — a peer on a pre-#5084 build, or a peer whose own `boot_id` was unreadable. The incarnation fence is in its fail-open state against that peer; expected during a rolling upgrade, and NOT a health/alarm state |
 | ConfigsDeadIncarnationDropped | Config payloads dropped because the boot incarnation they arrived under has been replaced by a re-prime (#5084) — a queued prior-boot config that would otherwise apply across the reset and strand the generation high-water. Expected once per peer reboot that races a queued config; a persistently rising counter means the peer is flapping |
 | IPsecSASent/Received | IPsec SA list messages |

--- a/pkg/cluster/status.go
+++ b/pkg/cluster/status.go
@@ -469,6 +469,23 @@ func (m *Manager) FormatInformation() string {
 		if syncStats.ConfigsApplyFailed > 0 {
 			fmt.Fprintf(&b, "  Configs apply-failed:  %d\n", syncStats.ConfigsApplyFailed)
 		}
+		// #6778: a config that never reached the ordered apply queue. Rendered
+		// beside apply-failed because the operator consequence is identical —
+		// this node is running a config older than the primary's committed one
+		// — but the cause is different (receive-edge saturation, not a compile
+		// or promote failure), so it gets its own line rather than being folded
+		// into apply-failed.
+		if syncStats.ConfigsQueueFullDropped > 0 {
+			fmt.Fprintf(&b, "  Configs queue-full-dropped: %d\n", syncStats.ConfigsQueueFullDropped)
+		}
+		// #7328/#6778: nacks this node ACCEPTED from the peer, i.e. generations
+		// we pushed that the peer did not apply. Surfaced because it is the
+		// sender-side half of the queue-full / apply-failure recovery loop: a
+		// peer whose queue-full drops climb while this counter stays at zero has
+		// no working re-push driver.
+		if syncStats.ConfigApplyNacksReceived > 0 {
+			fmt.Fprintf(&b, "  Config apply-nacks received: %d\n", syncStats.ConfigApplyNacksReceived)
+		}
 		// #5084: the peer boot incarnation, rendered ALWAYS rather than only
 		// when non-empty. "none" is the operationally interesting value — it
 		// means the fence is in its fail-open state against this peer — and a

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -234,6 +234,19 @@ type SyncStats struct {
 	// prior config (M-2/#4151). A persistently-nonzero value means a standby is
 	// repeatedly failing to apply the peer's config — investigate divergence.
 	ConfigsApplyFailed atomic.Uint64
+	// ConfigsQueueFullDropped counts config payloads that never reached the
+	// #3931 ordered apply queue because it was full at enqueue (#6778). The
+	// non-blocking enqueue discards the INCOMING payload, which is the NEWEST
+	// generation the peer has sent, while the queue retains older ones — so the
+	// drop leaves this node applying a superseded config. Counted separately
+	// from ConfigsApplyFailed because the failure is on the RECEIVE edge (the
+	// apply never ran) and from the generic Errors counter because "the standby
+	// is behind the primary's committed config" is a distinct operator action.
+	// The recovery is the same one an apply failure uses: the received
+	// high-water is still raised (so the node reads config-stale and #5563
+	// refuses manual-failover promotion), a config-apply nack re-arms the
+	// sender's #5863 push marker, and the sender's periodic reconcile re-pushes.
+	ConfigsQueueFullDropped atomic.Uint64
 	// ConfigApplyNacksReceived counts #7328 config-apply nacks accepted from the
 	// peer — one per generation this node pushed that the peer refused or failed
 	// to apply. A nack for a superseded generation is ignored and not counted.
@@ -335,8 +348,15 @@ type SyncStatsSnapshot struct {
 	// through a new Manager accessor because the Manager holds only the
 	// SyncStatsProvider interface, and this is the same transport every other
 	// field in the status render already uses.
-	PeerBootIncarnation        string
-	ConfigsApplyFailed         uint64
+	PeerBootIncarnation string
+	ConfigsApplyFailed  uint64
+	// #6778 receive-edge loss, and #7328's nack counter alongside it: the
+	// queue-full drop is recovered BY a nack, so a drop that is climbing while
+	// nacks are not tells the operator the recovery path itself is broken (a
+	// pre-#7328 peer, or a nack that never matched lastSentConfigGen). Both are
+	// rendered only when nonzero.
+	ConfigsQueueFullDropped    uint64
+	ConfigApplyNacksReceived   uint64
 	IPsecSASent                uint64
 	IPsecSAReceived            uint64
 	IPsecSAStaleIgnored        uint64
@@ -1301,7 +1321,7 @@ func (s *SessionSync) Stats() SyncStatsSnapshot {
 		activeFabric = -1
 	}
 	s.mu.Unlock()
-	return SyncStatsSnapshot{SessionsSent: s.stats.SessionsSent.Load(), SessionsReceived: s.stats.SessionsReceived.Load(), SessionsInstalled: s.stats.SessionsInstalled.Load(), DeletesSent: s.stats.DeletesSent.Load(), DeletesReceived: s.stats.DeletesReceived.Load(), BulkSyncs: s.stats.BulkSyncs.Load(), ConfigsSent: s.stats.ConfigsSent.Load(), ConfigsReceived: s.stats.ConfigsReceived.Load(), ConfigsStaleIgnored: s.stats.ConfigsStaleIgnored.Load(), BulkPrimesWithoutIncarnation: s.stats.BulkPrimesWithoutIncarnation.Load(), PeerBootIncarnation: s.PeerBootIncarnation().String(), ConfigsDeadIncarnationDropped: s.stats.ConfigsDeadIncarnationDropped.Load(), ConfigsApplyFailed: s.stats.ConfigsApplyFailed.Load(), IPsecSASent: s.stats.IPsecSASent.Load(), IPsecSAReceived: s.stats.IPsecSAReceived.Load(), IPsecSAStaleIgnored: s.stats.IPsecSAStaleIgnored.Load(), DHCPLeasesSent: s.stats.DHCPLeasesSent.Load(), DHCPLeasesReceived: s.stats.DHCPLeasesReceived.Load(), DHCPLeasesStaleIgnored: s.stats.DHCPLeasesStaleIgnored.Load(), DHCPLeasesSeeded: s.stats.DHCPLeasesSeeded.Load(), FencesSent: s.stats.FencesSent.Load(), FencesReceived: s.stats.FencesReceived.Load(), Errors: s.stats.Errors.Load(), DeletesDropped: s.stats.DeletesDropped.Load(), DeletesStaleIgnored: s.stats.DeletesStaleIgnored.Load(), InstallsStaleIgnored: s.stats.InstallsStaleIgnored.Load(), SessionsStaleConfigIgnored: s.stats.SessionsStaleConfigIgnored.Load(), GenMapOverflow: s.stats.GenMapOverflow.Load(), PreAuthRejected: s.stats.PreAuthRejected.Load(), Connected: s.stats.Connected.Load(), ActiveFabric: activeFabric, BulkSyncStartTime: s.stats.BulkSyncStartTime.Load(), BulkSyncEndTime: s.stats.BulkSyncEndTime.Load(), BulkSyncSessions: s.stats.BulkSyncSessions.Load(), LastConfigSyncTime: s.stats.LastConfigSyncTime.Load(), LastConfigSyncSize: s.stats.LastConfigSyncSize.Load(), LastFenceSeq: s.stats.LastFenceSeq.Load(), LastFenceAckAt: s.stats.LastFenceAckAt.Load()}
+	return SyncStatsSnapshot{SessionsSent: s.stats.SessionsSent.Load(), SessionsReceived: s.stats.SessionsReceived.Load(), SessionsInstalled: s.stats.SessionsInstalled.Load(), DeletesSent: s.stats.DeletesSent.Load(), DeletesReceived: s.stats.DeletesReceived.Load(), BulkSyncs: s.stats.BulkSyncs.Load(), ConfigsSent: s.stats.ConfigsSent.Load(), ConfigsReceived: s.stats.ConfigsReceived.Load(), ConfigsStaleIgnored: s.stats.ConfigsStaleIgnored.Load(), BulkPrimesWithoutIncarnation: s.stats.BulkPrimesWithoutIncarnation.Load(), PeerBootIncarnation: s.PeerBootIncarnation().String(), ConfigsDeadIncarnationDropped: s.stats.ConfigsDeadIncarnationDropped.Load(), ConfigsApplyFailed: s.stats.ConfigsApplyFailed.Load(), ConfigsQueueFullDropped: s.stats.ConfigsQueueFullDropped.Load(), ConfigApplyNacksReceived: s.stats.ConfigApplyNacksReceived.Load(), IPsecSASent: s.stats.IPsecSASent.Load(), IPsecSAReceived: s.stats.IPsecSAReceived.Load(), IPsecSAStaleIgnored: s.stats.IPsecSAStaleIgnored.Load(), DHCPLeasesSent: s.stats.DHCPLeasesSent.Load(), DHCPLeasesReceived: s.stats.DHCPLeasesReceived.Load(), DHCPLeasesStaleIgnored: s.stats.DHCPLeasesStaleIgnored.Load(), DHCPLeasesSeeded: s.stats.DHCPLeasesSeeded.Load(), FencesSent: s.stats.FencesSent.Load(), FencesReceived: s.stats.FencesReceived.Load(), Errors: s.stats.Errors.Load(), DeletesDropped: s.stats.DeletesDropped.Load(), DeletesStaleIgnored: s.stats.DeletesStaleIgnored.Load(), InstallsStaleIgnored: s.stats.InstallsStaleIgnored.Load(), SessionsStaleConfigIgnored: s.stats.SessionsStaleConfigIgnored.Load(), GenMapOverflow: s.stats.GenMapOverflow.Load(), PreAuthRejected: s.stats.PreAuthRejected.Load(), Connected: s.stats.Connected.Load(), ActiveFabric: activeFabric, BulkSyncStartTime: s.stats.BulkSyncStartTime.Load(), BulkSyncEndTime: s.stats.BulkSyncEndTime.Load(), BulkSyncSessions: s.stats.BulkSyncSessions.Load(), LastConfigSyncTime: s.stats.LastConfigSyncTime.Load(), LastConfigSyncSize: s.stats.LastConfigSyncSize.Load(), LastFenceSeq: s.stats.LastFenceSeq.Load(), LastFenceAckAt: s.stats.LastFenceAckAt.Load()}
 }
 
 // IsConnected reports whether a peer sync connection is currently established.

--- a/pkg/cluster/sync_config_health_6387_test.go
+++ b/pkg/cluster/sync_config_health_6387_test.go
@@ -456,7 +456,7 @@ func TestConfigSyncHealthRaiseClearReorderSerialized(t *testing.T) {
 	// (3) A successful apply runs concurrently while the raise is mid-delivery.
 	successDone := make(chan struct{})
 	go func() {
-		s.noteConfigApplySuccess()
+		s.noteConfigApplySuccess(0)
 		close(successDone)
 	}()
 

--- a/pkg/cluster/sync_config_queue_full_6778_test.go
+++ b/pkg/cluster/sync_config_queue_full_6778_test.go
@@ -1,0 +1,417 @@
+package cluster
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #6778 — a full config-apply queue strands the NEWEST generation.
+//
+// The non-blocking enqueue in handleConfigPayload discards the INCOMING
+// payload, which is the newest generation the peer has sent, while the queue
+// retains older ones. recordRecvConfigGen has already raised the received
+// high-water for it, so the node reads config-stale (and #5563 refuses
+// manual-failover promotion) with nothing driving the missing generation back:
+// the sender's #5863 (epoch x generation) marker was claimed before the push
+// and only a nack clears it. That is a wedge, not a blip.
+//
+// These tests pin the three halves of the repair on the DROP path:
+//   - the drop is COUNTED on its own counter and rendered in cluster status,
+//   - it accrues HEALTH DEBT (the #6387 grace timer), and that debt is not
+//     cancelled by the apply of an older generation still in the queue, and
+//   - it NACKS, re-arming the sender's push marker so the existing periodic
+//     reconcile re-pushes.
+
+// fillConfigApplyQueue6778 saturates the ordered apply queue with placeholder
+// items so the next enqueue must take the non-blocking send's default arm. No
+// consumer is running, so the queue stays full for the duration of the test.
+func fillConfigApplyQueue6778(t *testing.T, s *SessionSync) {
+	t.Helper()
+	for i := 0; i < cap(s.configApplyCh); i++ {
+		select {
+		case s.configApplyCh <- configApplyItem{gen: uint64(i + 1), text: "backlog"}:
+		default:
+			t.Fatalf("setup: could not fill the apply queue, stalled at %d of %d", i, cap(s.configApplyCh))
+		}
+	}
+	if len(s.configApplyCh) != cap(s.configApplyCh) {
+		t.Fatalf("setup: queue must be full, got len=%d cap=%d", len(s.configApplyCh), cap(s.configApplyCh))
+	}
+}
+
+// readOneFrame6778 reads a single length-prefixed sync frame off peer, or
+// reports ok=false if none arrives before the deadline.
+func readOneFrame6778(peer net.Conn, timeout time.Duration) (typ uint8, gen uint64, ok bool) {
+	type frame struct {
+		typ uint8
+		gen uint64
+		ok  bool
+	}
+	got := make(chan frame, 1)
+	go func() {
+		hdr := make([]byte, 12)
+		if _, err := io.ReadFull(peer, hdr); err != nil {
+			got <- frame{}
+			return
+		}
+		length := binary.LittleEndian.Uint32(hdr[8:12])
+		body := make([]byte, length)
+		if length > 0 {
+			if _, err := io.ReadFull(peer, body); err != nil {
+				got <- frame{}
+				return
+			}
+		}
+		f := frame{typ: hdr[4], ok: true}
+		if len(body) >= 8 {
+			f.gen = binary.LittleEndian.Uint64(body[:8])
+		}
+		got <- f
+	}()
+	select {
+	case f := <-got:
+		return f.typ, f.gen, f.ok
+	case <-time.After(timeout):
+		return 0, 0, false
+	}
+}
+
+// TestConfigQueueFullDropCountsNacksAndArmsDebt6778 binds the production
+// WIRING at the drop site, not the functions it calls.
+//
+// It drives a real config payload through handleMessage into a SATURATED
+// queue over a real connection and asserts all three repairs at once, plus the
+// pre-existing property the repair must not disturb (the received high-water is
+// still raised, so the node honestly reads config-stale).
+//
+// The fixture is the smallest shape where removing any one of the three lines
+// changes an OUTCOME: the queue must be full (otherwise the enqueue succeeds
+// and the default arm is never entered), and a connection must be installed
+// (otherwise sendConfigApplyNack returns before writing and the nack assertion
+// could not distinguish "not called" from "no peer").
+//
+// FAIL-ON-REVERT, one line each:
+//   - delete s.stats.ConfigsQueueFullDropped.Add(1)   -> the counter leg reds
+//   - delete s.noteConfigApplyFailure(...)            -> the armed-timer leg reds
+//   - delete s.sendConfigApplyNack(gen)               -> the nack leg reds on the deadline
+//   - delete s.recordRecvConfigGen(gen) above the enqueue -> the config-stale leg reds
+func TestConfigQueueFullDropCountsNacksAndArmsDebt6778(t *testing.T) {
+	const droppedGen = 9_001
+
+	s := NewSessionSync(":0", "10.0.0.2:4785", &mockSweepDP{})
+	af := &fakeAfterFunc{}
+	s.afterFuncFn = af.schedule
+
+	local, peer := net.Pipe()
+	defer local.Close()
+	defer peer.Close()
+	s.mu.Lock()
+	s.conn0 = local
+	s.stats.Connected.Store(true)
+	s.mu.Unlock()
+
+	fillConfigApplyQueue6778(t, s)
+
+	// Deliver the newest generation through the REAL receive-side entry point.
+	// The read must be concurrent with the delivery: net.Pipe is unbuffered, so
+	// the nack write inside handleMessage blocks until the peer reads it.
+	frames := make(chan [3]uint64, 1)
+	go func() {
+		typ, gen, ok := readOneFrame6778(peer, 2*time.Second)
+		okv := uint64(0)
+		if ok {
+			okv = 1
+		}
+		frames <- [3]uint64{uint64(typ), gen, okv}
+	}()
+	s.handleMessage(local, syncMsgConfig, encodeConfigPayload("newest-config", droppedGen))
+
+	// (1) Counted on its OWN counter. ConfigsApplyFailed must stay at zero —
+	// the apply never ran, and folding the two together would tell an operator
+	// to go read a compile error that does not exist.
+	if got := s.stats.ConfigsQueueFullDropped.Load(); got != 1 {
+		t.Fatalf("a queue-full drop must be counted on ConfigsQueueFullDropped; got %d", got)
+	}
+	if got := s.stats.ConfigsApplyFailed.Load(); got != 0 {
+		t.Fatalf("a queue-full drop is not an apply failure — the apply never ran; "+
+			"ConfigsApplyFailed=%d", got)
+	}
+
+	// (2) The received high-water is still raised, so the node reads
+	// config-stale rather than silently healthy on a superseded config.
+	if got := s.lastRecvConfigGen.Load(); got != droppedGen {
+		t.Fatalf("the received high-water must be raised for a dropped generation so the node "+
+			"reads config-stale (#5563); got %d want %d", got, droppedGen)
+	}
+	snap := TransferReadinessSnapshot{
+		PeerConfigGen:    s.lastRecvConfigGen.Load(),
+		AppliedConfigGen: s.lastAppliedConfigGen.Load(),
+	}
+	if !snap.ConfigStale() {
+		t.Fatal("a node that dropped the newest generation must report config-stale")
+	}
+
+	// (3) Health debt armed: the #6387 grace timer starts on this edge, so a
+	// drop that never re-converges raises CF with no further delivery.
+	if calls, d := af.armed(); calls != 1 || d != DefaultConfigApplyFailGrace {
+		t.Fatalf("a queue-full drop must arm the config-apply grace timer exactly once with the "+
+			"grace; got calls=%d d=%s", calls, d)
+	}
+
+	// (4) The sender is told, which is the ONLY thing that re-arms its #5863
+	// push marker on a live connection.
+	select {
+	case f := <-frames:
+		if f[2] != 1 {
+			t.Fatal("a queue-full drop must send a config-apply nack — without it the sender's " +
+				"#5863 marker suppresses every re-push of the dropped generation and the " +
+				"standby stays behind the primary indefinitely (#6778)")
+		}
+		if uint8(f[0]) != syncMsgConfigApplyNack {
+			t.Fatalf("expected a config-apply nack frame, got message type %d", f[0])
+		}
+		if f[1] != droppedGen {
+			t.Fatalf("the nack must name the DROPPED generation so the sender's scope guard "+
+				"matches it against lastSentConfigGen; got %d want %d", f[1], droppedGen)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("no frame observed after a queue-full drop")
+	}
+}
+
+// TestConfigEnqueueSuccessIsSilent6778 is the TIGHTENING control for the test
+// above: it makes the code MORE aggressive than shipped rather than deleting a
+// line.
+//
+// Hoisting any of the three drop-path calls out of the `default:` arm so it
+// fires on every received config would count a drop that did not happen, arm
+// health debt on a healthy node, and — worst — nack every successful push,
+// re-arming the sender's marker on each one and reintroducing exactly the push
+// storm #5863 exists to prevent. With room in the queue, none of the three may
+// fire.
+func TestConfigEnqueueSuccessIsSilent6778(t *testing.T) {
+	s := NewSessionSync(":0", "10.0.0.2:4785", &mockSweepDP{})
+	af := &fakeAfterFunc{}
+	s.afterFuncFn = af.schedule
+
+	local, peer := net.Pipe()
+	defer local.Close()
+	defer peer.Close()
+	s.mu.Lock()
+	s.conn0 = local
+	s.stats.Connected.Store(true)
+	s.mu.Unlock()
+
+	frames := make(chan bool, 1)
+	go func() {
+		_, _, ok := readOneFrame6778(peer, 750*time.Millisecond)
+		frames <- ok
+	}()
+
+	// Queue deliberately NOT filled: the enqueue succeeds.
+	s.handleMessage(local, syncMsgConfig, encodeConfigPayload("accepted-config", 4_242))
+
+	if len(s.configApplyCh) != 1 {
+		t.Fatalf("setup: the payload must have been enqueued; queue len=%d", len(s.configApplyCh))
+	}
+	if got := s.stats.ConfigsQueueFullDropped.Load(); got != 0 {
+		t.Fatalf("an ACCEPTED config must not count a queue-full drop; got %d", got)
+	}
+	if calls, _ := af.armed(); calls != 0 {
+		t.Fatalf("an ACCEPTED config must not arm config-apply health debt; armed %d times", calls)
+	}
+	if <-frames {
+		t.Fatal("an ACCEPTED config must send NO nack — a nack on the success path re-arms the " +
+			"sender's #5863 marker on every push and reintroduces the push storm")
+	}
+}
+
+// TestQueueFullDebtSurvivesStaleBacklogApply6778 pins the #6778 narrowing of
+// noteConfigApplySuccess: the health debt raised by a dropped generation must
+// not be cancelled by the apply of an OLDER generation that was already sitting
+// in the queue when the drop happened.
+//
+// This is the interaction the lone-drop fixture cannot see. A queue only fills
+// because the consumer is behind, so the drop is ALWAYS followed within
+// milliseconds by successful applies of the backlog. Under the pre-#6778
+// unconditional clear those successes disarmed the grace timer, and the drop's
+// debt evaporated long before the grace could raise CF — leaving a standby
+// behind the primary with the health signal silent.
+//
+// It drives the REAL configApplyLoop, so it binds the `noteConfigApplySuccess(item.gen)`
+// wiring and not just the function.
+//
+// FAIL-ON-REVERT:
+//   - drop the `appliedGen < s.lastRecvConfigGen.Load()` gate (restore the
+//     unconditional clear) -> the stale-backlog leg reds.
+//   - pass a constant (e.g. 0) instead of item.gen at the call site -> the
+//     caught-up leg reds, because the debt would never clear again.
+func TestQueueFullDebtSurvivesStaleBacklogApply6778(t *testing.T) {
+	s := NewSessionSync(":0", "10.0.0.2:4785", &mockSweepDP{})
+	af := &fakeAfterFunc{}
+	s.afterFuncFn = af.schedule
+	s.OnConfigReceived = func(string) error { return nil }
+
+	// The peer's newest generation is 20; it was dropped at the receive edge,
+	// so the received high-water sits at 20 and the debt is armed.
+	s.recordRecvConfigGen(20)
+	s.noteConfigApplyFailure(errConfigApplyQueueFull)
+	if calls, _ := af.armed(); calls != 1 {
+		t.Fatalf("setup: the drop must arm the grace timer once; armed %d times", calls)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.configApplyLoop(ctx)
+
+	// Gen 19 was already queued when 20 was dropped. It applies cleanly — and
+	// must NOT clear the debt, because the node is still behind gen 20.
+	s.configApplyCh <- configApplyItem{gen: 19, text: "backlog-19"}
+	drainConfigApply(t, s)
+	if got := s.lastAppliedConfigGen.Load(); got != 19 {
+		t.Fatalf("setup: gen 19 must apply; high-water=%d", got)
+	}
+	s.configApplyMu.Lock()
+	stillArmed := s.firstUnappliedFailNano != 0
+	reason := s.configApplyFailReason
+	s.configApplyMu.Unlock()
+	if !stillArmed {
+		t.Fatal("applying an OLDER queued generation must NOT clear the debt for the NEWER " +
+			"generation the queue-full drop lost — the node is still behind the primary, and " +
+			"disarming here is what let a stranded standby look healthy (#6778)")
+	}
+	if !strings.Contains(reason, "queue full") {
+		t.Fatalf("the debt must retain the queue-full reason; got %q", reason)
+	}
+
+	// The re-push lands as a newer generation and the node catches up: NOW the
+	// debt clears.
+	s.configApplyCh <- configApplyItem{gen: 21, text: "re-pushed"}
+	drainConfigApply(t, s)
+	if got := s.lastAppliedConfigGen.Load(); got != 21 {
+		t.Fatalf("gen 21 must apply; high-water=%d", got)
+	}
+	s.configApplyMu.Lock()
+	cleared := s.firstUnappliedFailNano == 0
+	s.configApplyMu.Unlock()
+	if !cleared {
+		t.Fatal("once the applied generation catches up with the received high-water the debt " +
+			"must clear — a gate that never releases would pin CF raised forever")
+	}
+}
+
+// TestQueueFullDebtRaisesHealthWithoutRedelivery6778 completes the debt half:
+// a drop that never re-converges must raise the CF config-sync health
+// annotation on the grace timer alone, with no second delivery. The sender
+// pushes a generation at most once per connection/generation, so a drop on a
+// STABLE connection whose nack was not actionable (a pre-#7328 peer, or a nack
+// superseded by a newer push) gets no re-delivery edge at all.
+func TestQueueFullDebtRaisesHealthWithoutRedelivery6778(t *testing.T) {
+	const grace = 5 * time.Second
+	clk := &healthClk{}
+	clk.set(1_000_000_000)
+	af := &fakeAfterFunc{}
+
+	m := NewManager(0, 22)
+	m.UpdateConfig(makeConfig(makeRG(0, false, map[int]int{0: 200, 1: 100})))
+	flushClusterEvents(m)
+
+	s := NewSessionSync(":0", "10.0.0.2:4785", &mockSweepDP{})
+	s.nowMonoFn = clk.now
+	s.configApplyFailGrace = grace
+	s.afterFuncFn = af.schedule
+	s.OnConfigApplyHealth = func(failing bool, reason string) { m.SetConfigSyncHealth(failing, reason) }
+
+	local, peer := net.Pipe()
+	defer local.Close()
+	defer peer.Close()
+	s.mu.Lock()
+	s.conn0 = local
+	s.stats.Connected.Store(true)
+	s.mu.Unlock()
+	go func() {
+		// Drain whatever the drop path writes so the unbuffered pipe never
+		// blocks the delivery under test.
+		buf := make([]byte, 256)
+		for {
+			if _, err := peer.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	fillConfigApplyQueue6778(t, s)
+	s.handleMessage(local, syncMsgConfig, encodeConfigPayload("newest-config", 9_100))
+
+	if mgrConfigSyncFailing(m) {
+		t.Fatal("CF must not raise before the grace elapses — a transient saturation that " +
+			"re-converges must never flap the flag")
+	}
+	clk.advance(grace + time.Second)
+	af.fire()
+	if !mgrConfigSyncFailing(m) {
+		t.Fatal("a queue-full drop that never re-converges must raise the config-sync health " +
+			"annotation once the grace elapses, with no second delivery (#6778)")
+	}
+	info := m.FormatInformation()
+	if !strings.Contains(info, "Config sync: failing") {
+		t.Fatalf("the raised health must render for the operator:\n%s", info)
+	}
+}
+
+// TestQueueFullDropRendersInStatus6778 binds the operator-visible half in both
+// directions. A counter that is only ever asserted nonzero cannot tell a
+// missing render from a working one, so the zero case is asserted too: the line
+// must be ABSENT on a healthy node and PRESENT once a drop has happened.
+func TestQueueFullDropRendersInStatus6778(t *testing.T) {
+	s := NewSessionSync(":0", "10.0.0.2:4785", &mockSweepDP{})
+	m := NewManager(0, 22)
+	m.UpdateConfig(makeConfig(makeRG(0, false, map[int]int{0: 200, 1: 100})))
+	m.SetSyncStats(s)
+
+	const dropLine = "Configs queue-full-dropped:"
+	const nackLine = "Config apply-nacks received:"
+
+	if info := m.FormatInformation(); strings.Contains(info, dropLine) {
+		t.Fatalf("a node that has dropped nothing must not render %q:\n%s", dropLine, info)
+	}
+	if info := m.FormatInformation(); strings.Contains(info, nackLine) {
+		t.Fatalf("a node that has received no nacks must not render %q:\n%s", nackLine, info)
+	}
+
+	s.stats.ConfigsQueueFullDropped.Add(3)
+	s.stats.ConfigApplyNacksReceived.Add(2)
+	info := m.FormatInformation()
+	if !strings.Contains(info, dropLine+" 3") {
+		t.Fatalf("a queue-full drop must be operator-visible in cluster status:\n%s", info)
+	}
+	if !strings.Contains(info, nackLine+" 2") {
+		t.Fatalf("the sender-side half of the recovery loop must be operator-visible — a peer "+
+			"whose drops climb while nacks stay at zero has no working re-push driver:\n%s", info)
+	}
+}
+
+// TestQueueFullDropReasonIsDistinctFromApplyFailure6778 pins that the health
+// debt carries a reason an operator can act on. An apply failure points at the
+// config or the store; a queue-full drop points at a saturated receive path.
+// Both raise the same annotation, so the reason string is the only thing that
+// separates them.
+func TestQueueFullDropReasonIsDistinctFromApplyFailure6778(t *testing.T) {
+	if errConfigApplyQueueFull == nil {
+		t.Fatal("the queue-full health-debt reason must exist")
+	}
+	got := errConfigApplyQueueFull.Error()
+	if !strings.Contains(got, "queue full") {
+		t.Fatalf("the queue-full reason must name the saturated queue; got %q", got)
+	}
+	other := errors.New("host-inbound apply failed: dependency missing")
+	if got == other.Error() {
+		t.Fatal("the queue-full reason must be distinguishable from an apply-failure reason")
+	}
+}

--- a/pkg/cluster/sync_conn_config.go
+++ b/pkg/cluster/sync_conn_config.go
@@ -194,13 +194,13 @@ func (s *SessionSync) fireConfigApplyGraceExpiry(epoch uint64) {
 // noteConfigApplySuccess clears the config-sync health streak on a successful
 // apply (#6387). It cancels the grace-expiry timer, resets the streak, and
 // bumps the epoch so an in-flight timer callback becomes a no-op. It then
-// clears the node-global CF annotation UNCONDITIONALLY — NOT gated on this
-// instance's configApplyHealthRaised. A comms transport change tears down this
+// clears the node-global CF annotation without consulting THIS instance's
+// configApplyHealthRaised flag. A comms transport change tears down this
 // SessionSync but KEEPS the cluster Manager (daemon stopClusterComms), so a CF
 // raised by a PRIOR SessionSync instance would otherwise stay stuck forever:
 // the replacement instance records the applied generation but, gated on its own
 // never-set flag, would never clear the manager. An idempotent clear is cheap,
-// so the first successful apply on ANY instance re-converges the annotation.
+// so a caught-up successful apply on ANY instance re-converges the annotation.
 // Called from the single-consumer configApplyLoop; guarded by configApplyMu.
 //
 // #6778: the clear is gated on the applied generation having CAUGHT UP with the

--- a/pkg/cluster/sync_conn_config.go
+++ b/pkg/cluster/sync_conn_config.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"log/slog"
 	"time"
 )
@@ -76,9 +77,12 @@ func (s *SessionSync) afterFunc(d time.Duration, f func()) *time.Timer {
 // raiseConfigApplyHealthLocked, which is idempotent and epoch-guarded, so CF
 // raises at most once per streak. A transient failure that clears within the
 // grace never raises (noteConfigApplySuccess cancels the timer and resets the
-// streak) — no flap. Called from the single-consumer configApplyLoop; the
-// shared state is guarded by configApplyMu because the timer callback runs on
-// its own goroutine.
+// streak) — no flap. Called from the single-consumer configApplyLoop and, since
+// #6778, from handleConfigPayload's queue-full drop on the receive loop: a
+// generation received and never applied is the condition this timer exists to
+// surface, whether the apply failed or never ran. The shared state is guarded
+// by configApplyMu, which is what makes the second (concurrent) caller safe —
+// the timer callback already runs on its own goroutine.
 func (s *SessionSync) noteConfigApplyFailure(applyErr error) {
 	now := s.nowMono()
 	reason := ""
@@ -198,7 +202,31 @@ func (s *SessionSync) fireConfigApplyGraceExpiry(epoch uint64) {
 // never-set flag, would never clear the manager. An idempotent clear is cheap,
 // so the first successful apply on ANY instance re-converges the annotation.
 // Called from the single-consumer configApplyLoop; guarded by configApplyMu.
-func (s *SessionSync) noteConfigApplySuccess() {
+//
+// #6778: the clear is gated on the applied generation having CAUGHT UP with the
+// received high-water — the same predicate TransferReadinessSnapshot.ConfigStale
+// uses. Before this gate any successful apply cleared the streak, so a config
+// dropped at the receive edge (queue full) armed the debt and then had it
+// cancelled milliseconds later by the apply of an OLDER generation still sitting
+// in the queue — the standby stayed behind the primary with the health signal
+// disarmed. appliedGen is the generation whose apply just succeeded; the caller
+// has not yet advanced lastAppliedConfigGen when it calls this (the advance must
+// follow, for the #6284 fence-release ordering), so the comparison is made
+// against the incoming generation rather than the mark.
+//
+// The gate cannot strand CF raised: a generation the receiver refuses before
+// recordRecvConfigGen never raises the received mark, resetRecvGen clears BOTH
+// marks to 0 on reconnect, and a legacy peer leaves both at 0 — so appliedGen >=
+// lastRecvConfigGen holds in every case where the node is genuinely caught up,
+// including the cross-instance clear the paragraph above describes.
+func (s *SessionSync) noteConfigApplySuccess(appliedGen uint64) {
+	if appliedGen < s.lastRecvConfigGen.Load() {
+		// Still behind the newest generation the peer has sent — an older
+		// queued config applied while a newer one was lost or is still in
+		// flight. Leave the streak and its grace timer armed so a drop that
+		// never re-converges still raises CF.
+		return
+	}
 	s.configApplyMu.Lock()
 	defer s.configApplyMu.Unlock()
 	s.firstUnappliedFailNano = 0
@@ -297,10 +325,19 @@ func (s *SessionSync) QueueConfig(configText string) {
 		"encrypted", encrypted)
 }
 
+// errConfigApplyQueueFull is the health-debt reason recorded when a config
+// payload is dropped at the receive edge because the #3931 ordered apply queue
+// was full (#6778). It is not returned by an apply — no apply ran — but it
+// feeds the same #6387 grace timer, because "received a generation, never
+// applied it" is the condition that timer exists to surface, and the operator
+// needs the DISTINCT reason: an apply failure points at the config or the
+// store, a queue-full drop points at a saturated receive path.
+var errConfigApplyQueueFull = errors.New("config apply queue full: the newest config generation was dropped before apply")
+
 // sendConfigApplyNack tells the SENDER that this node did not apply the config
-// generation it pushed (#7328). Called from configApplyLoop's failure branch,
-// which is the single ordered consumer, so nacks are naturally rate-bounded by
-// how often the peer pushes.
+// generation it pushed (#7328). Called from configApplyLoop's failure branch —
+// the single ordered consumer — and from handleConfigPayload's queue-full drop
+// (#6778), so nacks are rate-bounded by how often the peer pushes.
 //
 // Best-effort by construction: with no active connection there is nothing to
 // tell, and a write error disconnects, which bumps the peer's connection epoch
@@ -550,10 +587,14 @@ func (s *SessionSync) configApplyLoop(ctx context.Context) {
 				continue
 			}
 			// #6387: a confirmed apply clears any raised CF health signal (the
-			// standby has re-converged). Fired on every success — including a
-			// gen==0 legacy apply that does not advance the high-water — since
-			// the host-inbound sub-step applied cleanly.
-			s.noteConfigApplySuccess()
+			// standby has re-converged). #6778 narrows "re-converged" to mean
+			// CAUGHT UP: the clear now takes the applied generation and no-ops
+			// while it is still behind the received high-water, so an older
+			// queued config applying after a newer one was dropped at the
+			// receive edge cannot cancel the debt for the generation that was
+			// lost. A gen==0 legacy apply still clears (a legacy peer never
+			// raises the received mark, so both sides read 0).
+			s.noteConfigApplySuccess(item.gen)
 			// Apply confirmed — advance the high-water so a duplicate re-push of
 			// the same generation is correctly skipped as stale, THEN drop the
 			// fence. Advancing first keeps the effective refusal threshold

--- a/pkg/cluster/sync_conn_read.go
+++ b/pkg/cluster/sync_conn_read.go
@@ -675,12 +675,53 @@ func (s *SessionSync) handleConfigPayload(conn net.Conn, payload []byte) {
 		select {
 		case s.configApplyCh <- item:
 		default:
-			// Ordered apply queue full — practically impossible (commits
-			// are seconds apart, apply is sub-second). Drop with an alarm;
-			// the next commit / reconnect re-push (fresh higher gen)
-			// re-converges the standby.
+			// #6778: the ordered apply queue is full. The non-blocking send
+			// discards the INCOMING payload — which is the NEWEST generation
+			// the peer has sent — while the queue retains the older ones, so
+			// this node ends the drain applying a SUPERSEDED config. That
+			// inversion is what makes the drop a wedge rather than a blip: the
+			// received high-water was already raised above (deliberately, so
+			// the node reads config-stale and #5563 refuses manual-failover
+			// promotion), and before this fix nothing on either node was
+			// driving the missing generation back.
+			//
+			// The queue-full drop is treated as the same class of event as an
+			// apply failure, because the operator consequence is identical (the
+			// standby is behind the primary's committed config) and the repair
+			// is the one this repo already built:
+			//
+			//   counter  ConfigsQueueFullDropped, rendered in cluster status —
+			//            distinct from ConfigsApplyFailed because the apply
+			//            never ran, and from the generic Errors counter because
+			//            a stale standby is its own operator action.
+			//   debt     noteConfigApplyFailure arms the #6387 grace timer, so a
+			//            drop that does NOT re-converge inside the grace raises
+			//            the CF config-sync health annotation on its own — no
+			//            further delivery required. A drop that re-converges
+			//            cancels the timer on the successful apply, so a
+			//            transient saturation never flaps the flag.
+			//   retry    sendConfigApplyNack re-arms the SENDER's #5863
+			//            (epoch x generation) push marker via
+			//            OnPeerConfigApplyFailed, and the sender's existing
+			//            30s configSyncReconcileLoop re-pushes. No new retry
+			//            queue: buffering the dropped payload here is exactly
+			//            the unbounded growth the non-blocking send exists to
+			//            avoid, and the payload is the peer's ACTIVE config, so
+			//            re-asking for it is strictly better than holding a
+			//            copy that may already be superseded.
+			//
+			// Writing the nack from the receive loop is the established shape
+			// in this switch (the heartbeat ack and sendBulkAck do the same
+			// under writeMu). It is rate-bounded by the peer's push rate, which
+			// is itself bounded by the queue depth that produced the drop.
+			s.stats.ConfigsQueueFullDropped.Add(1)
 			s.stats.Errors.Add(1)
-			slog.Error("cluster sync: config apply queue full, dropping config (will re-converge on next push)", "gen", gen, "size", len(configText))
+			slog.Error("cluster sync: config apply queue full, dropping the NEWEST config generation — "+
+				"this node stays on a superseded config until the peer re-pushes (#6778)",
+				"gen", gen, "size", len(configText),
+				"queue_len", len(s.configApplyCh), "queue_cap", cap(s.configApplyCh))
+			s.noteConfigApplyFailure(errConfigApplyQueueFull)
+			s.sendConfigApplyNack(gen)
 		}
 	}
 }


### PR DESCRIPTION
Closes #6778

## Provenance of the cites

The issue body is a dead pointer — `/tmp/opus-review-001.md` section R37 is
gone. Everything below is **re-derived from code by symbol**, never by the
issue's line numbers. The only surviving trace of the original finding is in
`docs/reviews/archive/ps-review-038-A5_go_ha_vrrp_ra_conntrack-b1.md`, which
lists "`configApplyCh` non-blocking drop (LOW)" among the reviewed sites — the
tracker filed it as Medium. Having read the code I agree with the tracker, for
the reason in "What I measured" below.

## What I measured (before fixing)

**1. The dropped item really is the newest — confirmed.** `handleConfigPayload`
(`pkg/cluster/sync_conn_read.go`) ends in a `select { case s.configApplyCh <-
item: default: }`. Go's `default:` arm discards the item the *sender* is
holding, so the payload lost is the INCOMING one — the newest generation the
peer has put on the wire — while the queue keeps the 64 older ones. The apply
loop then drains that backlog and the node finishes on a *superseded* config.
Generations are genuinely monotone here: `QueueConfig` stamps
`s.nextConfigGen()`, an atomic counter, not the daemon's `configGenerationHash`
(that hash is only the sender's local `(epoch × generation)` push marker and
never reaches the wire), so "newest" is well-defined.

**2. It is a wedge, not a blip — confirmed, and it changes the severity.**
`recordRecvConfigGen(gen)` runs **before** the enqueue, deliberately (#5563).
So the received high-water is raised for a config that is then thrown away:
`TransferReadinessSnapshot.ConfigStale()` returns true and #5563 refuses manual
failover, indefinitely. That raise is *correct* — the node genuinely is behind,
and suppressing it would trade a visible wedge for a silent one — but nothing
was closing the gap. The sender's #5863 `(epoch × generation)` marker is claimed
**before** the push and only a nack clears it, so on a stable connection no
trigger would ever re-push that generation. The standby stayed behind the
primary until an unrelated commit or a reconnect.

**3. "Without retry or health debt" is two claims, and both held.** The only
observables were `stats.Errors.Add(1)` (shared with send failures and bad magic)
and one log line. No dedicated counter, no `noteConfigApplyFailure`, no nack.

**4. An existing retry driver was already in the tree.** #7328 built exactly the
shape the brief describes: `configApplyLoop`'s *apply-failure* branch calls
`sendConfigApplyNack`, the sender matches it against `lastSentConfigGen`,
`OnPeerConfigApplyFailed` → `invalidateConfigSyncPushed()` re-arms the marker,
and the existing 30s `configSyncReconcileLoop` re-pushes. The queue-full drop is
the *same condition reached one step earlier* — "this node did not apply the
generation you pushed" — so it now takes the same three actions instead of
getting a new mechanism.

## The fix

In the `default:` arm of the enqueue:

| | |
|---|---|
| **counter** | `ConfigsQueueFullDropped`, rendered as `Configs queue-full-dropped:` in `show chassis cluster information`. Kept out of `ConfigsApplyFailed` — the apply never ran, so sending an operator to hunt a compile error would be wrong — and off the generic `Errors` counter, where a stale standby is indistinguishable from a send failure. |
| **debt** | `noteConfigApplyFailure(errConfigApplyQueueFull)` arms the #6387 grace timer, so a drop that does not re-converge inside the grace raises `CF` on its own with no second delivery required. |
| **retry** | `sendConfigApplyNack(gen)` re-arms the sender's #5863 marker; its existing 30s reconcile re-pushes. |

Plus one correctness follow-on the drop path forced:
`noteConfigApplySuccess` now takes the generation whose apply just succeeded and
no-ops while it is still below `lastRecvConfigGen` — the same predicate
`ConfigStale()` uses. **A queue only fills because the consumer is behind**, so a
drop is *always* followed within milliseconds by successful applies of the
backlog; under the prior unconditional clear those cancelled the drop's debt long
before the grace could raise CF, which would have made the "health debt" half of
this fix cosmetic. The gate cannot pin CF raised: a payload refused before
`recordRecvConfigGen` never raises the received mark, `resetRecvGen` clears both
marks on reconnect, and a legacy peer leaves both at 0.

`ConfigApplyNacksReceived` (#7328) was counted but never reached the stats
snapshot or the status render — it is added here because it is the *sender-side
half* of this recovery loop: drops climbing on one node while nacks stay at zero
on the other means the recovery path itself is broken.

## What I rejected, and why

**An unbounded (or any) retry queue on the receiver.** Buffering the dropped
payload is precisely the unbounded growth the non-blocking send exists to
prevent, and the payload is the peer's *active* config — re-asking for it beats
holding a copy that may already be superseded.

**Converting the queue to an evict-oldest "latest-generation slot"** (the issue's
own suggested direction). It fixes the headline inversion in four lines, but it
requires the receive loop to become a second consumer of `configApplyCh`, and
under a cross-fabric reorder — the active connection flipping between
`conn0`/`conn1` — it could evict a **newer** queued item to make room for an
**older** arrival. That item, having enqueued successfully, would take no nack
and no debt: a silent loss traded for a visible, recovered one. Not worth it.

**Refusing to raise the received mark for a dropped payload.** That was the other
option in the brief. It would clear `ConfigStale()` and let #5563 promote a node
running an older security policy. The honest signal is to stay flagged and fix
the *recovery*, which is what this does.

## Mutation matrix

Fix committed at `c06a5692e` **first**; every cell mutated on top of that
commit. One mutation per line. Every cell ran the **full `pkg/cluster` suite**
with `go test -count=1` and **no `-run` filter**; each was verified to match its
anchor exactly once and still compile before running, and the tree was verified
clean after restore.

| # | Cell | Result | Which assertion fired |
|---|---|---|---|
| M1 | delete `ConfigsQueueFullDropped.Add(1)` | **KILLED** | `must be counted on ConfigsQueueFullDropped; got 0` |
| M2 | delete `noteConfigApplyFailure(...)` | **KILLED** | `must arm the config-apply grace timer ... got calls=0` + `TestQueueFullDebtRaisesHealthWithoutRedelivery6778` |
| M3 | delete `sendConfigApplyNack(gen)` | **KILLED** | `must send a config-apply nack` (read deadline) |
| M4 | delete `recordRecvConfigGen(gen)` | **KILLED** | mine + two **pre-existing**: `TestDeadIncarnationConfigNeverRaisesTheReceivedHighWater5084`, `TestTransferReadinessCarriesConfigGenerations` |
| M5 | **tighten:** hoist the nack out of `default:` (nack on every config) | **KILLED** | `an ACCEPTED config must send NO nack` |
| M6 | **tighten:** hoist the debt out of `default:` | **KILLED** | `an ACCEPTED config must not arm config-apply health debt; armed 1 times` |
| M7 | delete the `appliedGen < lastRecvConfigGen` gate | **KILLED** | `applying an OLDER queued generation must NOT clear the debt` |
| M8 | pass constant `0` instead of `item.gen` | **KILLED** | `once the applied generation catches up ... the debt must clear` |
| M9 | delete the queue-full status line | **KILLED** | `must be operator-visible in cluster status` |
| M10 | delete the nack status line | **KILLED** | `the sender-side half of the recovery loop must be operator-visible` |
| M11 | **tighten:** render the drop line unconditionally | **KILLED** | `a node that has dropped nothing must not render ...` |
| M12 | **tighten:** widen the gate to `appliedGen <= lastRecvConfigGen` | **KILLED** | **pre-existing** `TestConfigSyncHealthRaiseClearReorderSerialized`: `CF stuck raised after a successful apply` |
| M13 | drop the field from the `Stats()` snapshot | **KILLED** | `must be operator-visible in cluster status` |

13/13 killed. M12 is the one worth calling out: it was killed **only** by a
pre-existing #6398 test, not by anything in this PR — which is exactly why the
matrix runs full-suite with no `-run` filter.

## Tests added

`pkg/cluster/sync_config_queue_full_6778_test.go` — six tests, all binding the
production **wiring** over a real `net.Pipe` connection and the real
`configApplyLoop`, not the helpers they call:

- `TestConfigQueueFullDropCountsNacksAndArmsDebt6778` — drives a real payload
  through `handleMessage` into a saturated queue; asserts the counter, the
  retained received high-water (`ConfigStale()` true), the armed grace timer, and
  reads the nack frame off the wire and checks it names the dropped generation.
- `TestConfigEnqueueSuccessIsSilent6778` — the tightening control: with room in
  the queue, none of the three may fire.
- `TestQueueFullDebtSurvivesStaleBacklogApply6778` — the interaction a lone-drop
  fixture cannot see: an older queued generation applying after the drop must not
  disarm the debt, and a caught-up generation must.
- `TestQueueFullDebtRaisesHealthWithoutRedelivery6778` — CF raises on the timer
  alone, and renders.
- `TestQueueFullDropRendersInStatus6778` — asserts both directions: the lines are
  **absent** at zero and present with the right values when nonzero.
- `TestQueueFullDropReasonIsDistinctFromApplyFailure6778` — the debt's reason
  string separates a saturated receive path from a compile/promote failure.

## Docs

`docs/sync-protocol.md` gains a **Queue-full drop (#6778)** subsection (the
inversion, the three repairs, the rejected alternatives) plus a **debt is not
cancelled by a stale backlog apply** subsection, two counter-table rows, and a
correction to the #5563 paragraph. `docs/session-sync-architecture.md` records
the second sender of `syncMsgConfigApplyNack`. `_Log.md` appended.

One follow-up commit corrects a claim this change made false:
`noteConfigApplySuccess`'s doc said it clears CF "UNCONDITIONALLY", which is no
longer true read on its own — narrowed to the property that survives (it does not
consult *this instance's* raised flag).

## Validation

- `go build ./... && go vet ./... && go test -count=1 ./...` — **green repo-wide**
  at the merged head, gated on `go test`'s own exit code (`rc=0`, 67 packages ok),
  not a pipeline's.
- `origin/master` moved during the work; merged (not rebased) and re-gated at
  `ea63db4f4`.

## ⚠️ Smoke required — NOT run by me

This is cluster / session-sync code. It needs `make test-failover` on the shared
`loss:` userspace cluster. I did **not** run any `cluster-*` or `test-failover`
target — the cluster is shared and lock-protected. Please run the smoke before
merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc6yPeCaYWQjtLMt3MfqpD
