### PR TITLE
vrrp: refuse VRRP ownership that cannot be advertised (#6779)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104389,3 +104389,32 @@ prose edit above them added. No diff falls in the new test body.
   schema is right and nothing changed.
 - **File(s)**: `pkg/config/schema.go`, `pkg/config/schema_security.go`,
   `pkg/config/schema_walk.go`, `pkg/config/schema_block_value_6774_test.go`
+
+## 2026-08-22 — #6779 an oversized VIP set advertises nothing after claiming ownership
+
+- **Timestamp**: 2026-08-22
+- **Action**: Closed the ordering hole where `becomeMaster` claimed the VIP set
+  and published MASTER *before* `sendAdvert`, which discards a `Marshal`
+  failure at `slog.Debug`. A VIP set larger than the advertisement's one-byte
+  address count (255, or 254 for IPv6 where the mandatory link-local prepend
+  consumes a slot) therefore produced an owner that advertised nothing — the
+  peer promoted too (dual-master), or the VIPs were stranded. Added a
+  commit-time gate (`validateVRRPVIPCountStrict`, lenient-opt registered per
+  the #1960 no-brick contract) covering BOTH VIP sources — explicit
+  `vrrp-group` and the RETH-derived instances whose unit addresses become the
+  advertised set — plus runtime guards in `UpdateInstances` (#4573 doctrine)
+  and `becomeMaster` (#5082 doctrine). `sendAdvert` and the guard now share one
+  `splitVIPsByFamily` so the builder and the validator cannot count
+  differently, and a behavioural agreement test measures what the real
+  `Marshal` accepts instead of pinning either side to a literal. The EMPTY-VIP
+  case was measured and deliberately excluded: it is a distinct, non-colliding
+  defect with a 22-test blast radius.
+- **File(s)**: `pkg/vrrp/advert_capacity.go` (new), `pkg/vrrp/packet.go`,
+  `pkg/vrrp/instance.go`, `pkg/vrrp/instance_send.go`, `pkg/vrrp/manager.go`,
+  `pkg/vrrp/advert_capacity_gate_6779_test.go` (new),
+  `pkg/vrrp/advert_capacity_agreement_6779_test.go` (new),
+  `pkg/config/compiler_validate_strict_vrrp_vipcount.go` (new),
+  `pkg/config/compiler_opts.go`,
+  `pkg/config/compiler_uniformgates_cluster_zone.go`,
+  `pkg/config/vrrp_vip_count_6779_test.go` (new), `pkg/vrrp/README.md`,
+  `pkg/config/README.md`

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -532,6 +532,35 @@ or peer-synced config an older binary accepted still boots (#1960 no-brick).
 This is config-only commit-time validation — it never touches the VRRP
 runtime/state machine. Same fail-closed-on-load doctrine as #2911.
 
+**VRRP virtual-address count must fit one advertisement (#6779):** RFC 5798
+§5.2.4 makes an advertisement's "Count IPvX Addr" a single byte, so one advert
+carries at most 255 addresses of a family — 254 for IPv6, where §6.1 reserves
+the first slot for the mandatory link-local address `pkg/vrrp`
+`sendPacketIPv6` prepends. `pkg/vrrp` `Marshal` REFUSES an out-of-range count
+rather than truncating it (#5090), and `sendAdvert` discards that error at
+`slog.Debug`, so an oversized set made EVERY advert fail — **after**
+`becomeMaster` had already claimed the VIPs and published MASTER. The node then
+owned the addresses while emitting nothing: the peer stopped hearing a master,
+promoted itself, and both answered for the same addresses; with the same config
+synced to both nodes, the addresses were stranded with no advertising owner.
+`validateVRRPVIPCountStrict`
+(`compiler_validate_strict_vrrp_vipcount.go`) rejects such a set at commit,
+covering BOTH VIP sources: the explicit `vrrp-group ... virtual-address` list,
+and the RETH-derived instances where a redundancy-group interface's own unit
+addresses BECOME the advertised set (`CollectRethInstances`) — a gate walking
+only `unit.VRRPGroups` would miss the RETH path entirely. It mirrors
+`CollectRethInstances`' early return, so `no-reth-vrrp` / `private-rg-election`
+(no synthesized RETH VRRP instance) is not rejected. The tolerant load/peer-sync
+path downgrades to a warning (`lenientVRRPVIPCount`, #1960 no-brick); the
+`pkg/vrrp` runtime guards independently refuse to build the instance
+(`UpdateInstances`) and refuse to claim MASTER (`becomeMaster`), so a
+leniently-loaded oversized set is held out of the election rather than seated as
+a silent non-advertiser. The cap is spelled in both packages
+(`MaxVRRPVirtualAddressesIPv4/IPv6` here, `MaxConfiguredVIPs` there) because
+`pkg/vrrp` imports `pkg/config` and not the reverse; they are bound by a
+behavioural agreement test in `pkg/vrrp` that measures what the real `Marshal`
+accepts rather than pinning either side to a literal. Same doctrine as #4826.
+
 **No-match default-policy is fail-closed (#3065):** the sibling of #3043
 for the implicit fallback. When a flow matches NO zone-pair, global, or
 default policy, the verdict is `SecurityConfig.DefaultPolicy`. Because the

--- a/pkg/config/compiler_opts.go
+++ b/pkg/config/compiler_opts.go
@@ -2075,6 +2075,29 @@ type compileOpts struct {
 	// fail-closed-on-load class). Same doctrine as lenientBackupRouterDst.
 	lenientVRRPVirtualAddress bool
 
+	// lenientVRRPVIPCount (#6779) downgrades the VRRP virtual-address
+	// per-family cardinality gate (validateVRRPVIPCountStrict) from a hard
+	// compile error to a cfg.Warnings entry. A VRRP advertisement's address
+	// count is a single wire byte (RFC 5798 §5.2.4), so at most 255 addresses
+	// of one family fit — 254 for IPv6, where §6.1 reserves the first slot for
+	// the mandatory link-local prepend. pkg/vrrp Marshal REFUSES an
+	// out-of-range count rather than truncating it (#5090), and sendAdvert
+	// discards that error at slog.Debug, so an oversized set makes every advert
+	// fail AFTER becomeMaster has already claimed the VIPs and published
+	// MASTER: the node holds the addresses while emitting nothing, its peer
+	// times out and promotes too (dual-master), or — when the peer shares the
+	// same synced config — the addresses are stranded with no advertising
+	// owner. The strict commit / commit-check path hard-rejects so the operator
+	// error is visible; the tolerant load / peer-sync paths downgrade to a
+	// warning so an already-persisted or peer-synced config an older binary
+	// accepted still BOOTS (#1960 fail-closed-on-load class). The pkg/vrrp
+	// runtime guards independently refuse to build the instance
+	// (UpdateInstances) and refuse to claim MASTER (becomeMaster), so a
+	// leniently-loaded oversized set is bounded — a WARN plus a group held out
+	// of the election — not a silent non-advertising owner. Same doctrine as
+	// lenientRethVRRPGroupID.
+	lenientVRRPVIPCount bool
+
 	// lenientDNATToScope (#3444) downgrades the destination-NAT rule-set
 	// `to` scope reject (validateDNATRuleSetToScopeAST) from a hard compile
 	// error to a cfg.Warnings entry. Junos destination NAT rule-sets have
@@ -2431,6 +2454,7 @@ func lenientCompileOpts() compileOpts {
 		lenientPolicyReservedRedistName:        true,
 		lenientPolicyReservedChainName:         true,
 		lenientVRRPVirtualAddress:              true,
+		lenientVRRPVIPCount:                    true,
 		lenientDNATToScope:                     true,
 		lenientNATMixedScope:                   true,
 		lenientNATTerminalAction:               true,

--- a/pkg/config/compiler_uniformgates_cluster_zone.go
+++ b/pkg/config/compiler_uniformgates_cluster_zone.go
@@ -130,6 +130,32 @@ func runUniformGatesClusterZone(tree *ConfigTree, cfg *Config, opts compileOpts)
 		}
 	}
 
+	// #6779 VRRP virtual-address cardinality gate. Strict on commit /
+	// commit-check (hard-reject a VRRP instance carrying more virtual
+	// addresses of one family than the advertisement's single-byte address
+	// count can express — 255, or 254 for IPv6 where RFC 5798 §6.1 reserves
+	// the first slot for the mandatory link-local prepend). Marshal refuses
+	// an out-of-range count instead of truncating it (#5090) and sendAdvert
+	// swallows that error at Debug, so an oversized set makes every advert
+	// fail AFTER becomeMaster claimed the VIPs — the node owns the addresses
+	// and advertises nothing, so the peer promotes too (dual-master) or the
+	// addresses are stranded. Lenient on load / peer-sync (warn so an
+	// already-persisted or peer-synced config still boots — #1960 no-brick;
+	// the pkg/vrrp runtime guards refuse to build the instance and refuse to
+	// claim MASTER, so a leniently-loaded oversized set is held out of the
+	// election, not seated as a silent non-advertiser). Runs on the
+	// fully-compiled *Config (VRRPGroups from parseVRRPGroups, RedundancyGroup
+	// and unit Addresses from compileInterfaces). Same doctrine as
+	// lenientRethVRRPGroupID.
+	if err := validateVRRPVIPCountStrict(cfg); err != nil {
+		if opts.lenientVRRPVIPCount {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("vrrp virtual-address count (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #3055 reserved zone-name definition gate. Strict on commit / commit-check
 	// (hard-reject a `security zones security-zone <name>` whose name is a
 	// reserved sentinel — "junos-global" is reclassified by the userspace

--- a/pkg/config/compiler_validate_strict_vrrp_vipcount.go
+++ b/pkg/config/compiler_validate_strict_vrrp_vipcount.go
@@ -1,0 +1,211 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+)
+
+// MaxVRRPVirtualAddressesIPv4 / MaxVRRPVirtualAddressesIPv6 bound the number of
+// virtual addresses of ONE family that a single VRRP instance may carry.
+//
+// RFC 5798 §5.2.4 defines the advertisement's "Count IPvX Addr" field as a
+// single byte, so at most 255 addresses can be expressed. The IPv6 budget is one
+// lower because RFC 5798 §5.2.9 / §6.1 require the virtual router's link-local
+// address to be listed FIRST: pkg/vrrp/instance_send.go sendPacketIPv6 prepends
+// that link-local to the configured VIP slice immediately before Marshal, so it
+// consumes one of the 255 slots and only 254 remain for configured addresses.
+//
+// Duplicated here rather than imported — pkg/vrrp imports pkg/config, so
+// pkg/config validators must stay free of the reverse dependency (same rationale
+// as RethVRRPGroupIDBase, #4826). The values are NOT independently maintained:
+// pkg/vrrp/advert_capacity_agreement_6779_test.go asserts that each constant is
+// exactly the largest count pkg/vrrp's real Marshal accepts for that family, so
+// a change to the wire builder that these constants did not follow fails the
+// pkg/vrrp suite rather than silently splitting the validator from the builder.
+const (
+	MaxVRRPVirtualAddressesIPv4 = 255
+	MaxVRRPVirtualAddressesIPv6 = 254
+)
+
+// maxVRRPVirtualAddresses returns the per-family configured-VIP ceiling.
+func maxVRRPVirtualAddresses(isIPv6 bool) int {
+	if isIPv6 {
+		return MaxVRRPVirtualAddressesIPv6
+	}
+	return MaxVRRPVirtualAddressesIPv4
+}
+
+// countVRRPVIPFamilies splits a virtual-address list into per-family counts the
+// same way pkg/vrrp's send path does (splitVIPsByFamily): CIDR or bare literal,
+// unparseable entries skipped.
+func countVRRPVIPFamilies(vips []string) (nV4, nV6 int) {
+	for _, vip := range vips {
+		ip := vrrpVIPHostIP(vip)
+		if ip == nil {
+			continue
+		}
+		if ip.To4() != nil {
+			nV4++
+		} else {
+			nV6++
+		}
+	}
+	return nV4, nV6
+}
+
+// vrrpVIPCountErr builds the operator-facing rejection for an over-capacity
+// family, or nil when both families fit. `where` names the offending config
+// object (interface/unit/group) and is prefixed onto the message.
+func vrrpVIPCountErr(where string, vips []string) error {
+	nV4, nV6 := countVRRPVIPFamilies(vips)
+	for _, fam := range []struct {
+		isIPv6 bool
+		n      int
+		name   string
+		extra  string
+	}{
+		{false, nV4, "IPv4", ""},
+		{true, nV6, "IPv6", " (one of the 255 slots is reserved for the " +
+			"mandatory link-local address RFC 5798 §6.1 requires first in an " +
+			"IPv6 advertisement)"},
+	} {
+		limit := maxVRRPVirtualAddresses(fam.isIPv6)
+		if fam.n <= limit {
+			continue
+		}
+		return fmt.Errorf("%s carries %d %s virtual addresses, which exceeds the "+
+			"maximum of %d that fit in a VRRPv3 advertisement%s — the "+
+			"advertisement's address count is a single wire byte (RFC 5798 "+
+			"§5.2.4), so every advert for this group would fail to build while "+
+			"the node still claimed the virtual addresses: the peer stops "+
+			"hearing this master, promotes itself, and both nodes answer for "+
+			"the same addresses — reduce the virtual-address count or split the "+
+			"addresses across additional groups",
+			where, fam.n, fam.name, limit, fam.extra)
+	}
+	return nil
+}
+
+// validateVRRPVIPCountStrict hard-rejects, at commit / commit-check, a VRRP
+// virtual-address set whose per-family cardinality exceeds what a single VRRPv3
+// advertisement can express (#6779).
+//
+// The failure this prevents is an ORDERING problem, not merely a malformed
+// packet. pkg/vrrp becomeMaster claims the VIP set and publishes MASTER, and
+// only then calls sendAdvert — which discards a Marshal failure at slog.Debug.
+// Marshal refuses an out-of-range address count rather than truncating the u8
+// Count byte (#5090), so an oversized family makes EVERY advert fail after the
+// node has already taken ownership. The node then holds the addresses while
+// emitting nothing: the peer's masterDownTimer expires and it promotes too
+// (dual-master, duplicate addresses on the segment), or, when the peer shares
+// the same synced config, no node can advertise and the addresses are stranded.
+//
+// Both VIP sources are covered, because both feed the same advert builder:
+//
+//   - explicit `vrrp-group <id> virtual-address <vip>` (CollectInstances)
+//   - RETH-derived instances, where a redundancy-group RETH interface's own
+//     unit addresses BECOME the advertised VIP set (CollectRethInstances). A
+//     VLAN-tagged RETH builds one instance per unit, so each unit is counted
+//     separately; an untagged RETH concatenates every unit's addresses into a
+//     single instance, so those are counted together.
+//
+// On the tolerant load / peer-sync paths the call site downgrades this to a
+// warning (opts.lenientVRRPVIPCount) so an already-persisted or peer-synced
+// config an older binary accepted still BOOTS (#1960 no-brick); the pkg/vrrp
+// runtime guards independently refuse to build the instance (UpdateInstances)
+// and refuse to claim MASTER (becomeMaster), so a leniently-loaded oversized set
+// is bounded — a WARN plus a group that stays out of the election — rather than
+// a silent non-advertising owner. Same doctrine as lenientRethVRRPGroupID.
+func validateVRRPVIPCountStrict(cfg *Config) error {
+	if cfg == nil || cfg.Interfaces.Interfaces == nil {
+		return nil
+	}
+
+	// Mirror CollectRethInstances' early return: when the cluster manages VIPs
+	// directly (no-reth-vrrp) or elects over the control link only
+	// (private-rg-election), no RETH-derived VRRP instance is synthesized, so a
+	// RETH unit's address count has no advert consequence. Explicit vrrp-group
+	// blocks are still checked — they are independent of cluster mode.
+	rethVRRPActive := true
+	if cc := cfg.Chassis.Cluster; cc != nil && (cc.NoRethVRRP || cc.PrivateRGElection) {
+		rethVRRPActive = false
+	}
+
+	// Deterministic walk so the first-error commit-check message is stable
+	// across map-ordered runs, matching the sibling strict validators.
+	names := make([]string, 0, len(cfg.Interfaces.Interfaces))
+	for name := range cfg.Interfaces.Interfaces {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, ifName := range names {
+		ifc := cfg.Interfaces.Interfaces[ifName]
+		if ifc == nil {
+			continue
+		}
+		unitNums := make([]int, 0, len(ifc.Units))
+		for n := range ifc.Units {
+			unitNums = append(unitNums, n)
+		}
+		sort.Ints(unitNums)
+
+		// Explicit `vrrp-group` blocks: one instance per group, carrying that
+		// group's own virtual-address list.
+		for _, un := range unitNums {
+			unit := ifc.Units[un]
+			if unit == nil || len(unit.VRRPGroups) == 0 {
+				continue
+			}
+			gkeys := make([]string, 0, len(unit.VRRPGroups))
+			for k := range unit.VRRPGroups {
+				gkeys = append(gkeys, k)
+			}
+			sort.Strings(gkeys)
+			for _, gk := range gkeys {
+				vg := unit.VRRPGroups[gk]
+				if vg == nil {
+					continue
+				}
+				where := fmt.Sprintf("interfaces %s unit %d vrrp-group %d",
+					ifName, un, vg.ID)
+				if err := vrrpVIPCountErr(where, vg.VirtualAddresses); err != nil {
+					return err
+				}
+			}
+		}
+
+		// RETH-derived instances: the unit addresses themselves are the VIPs.
+		if !rethVRRPActive || ifc.RedundancyGroup <= 0 {
+			continue
+		}
+		if ifc.VlanTagging {
+			// One instance per addressed unit.
+			for _, un := range unitNums {
+				unit := ifc.Units[un]
+				if unit == nil || len(unit.Addresses) == 0 {
+					continue
+				}
+				where := fmt.Sprintf("interfaces %s unit %d (reth "+
+					"redundancy-group %d VRRP)", ifName, un, ifc.RedundancyGroup)
+				if err := vrrpVIPCountErr(where, unit.Addresses); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		// Untagged: every unit's addresses land in ONE instance.
+		var all []string
+		for _, un := range unitNums {
+			if unit := ifc.Units[un]; unit != nil {
+				all = append(all, unit.Addresses...)
+			}
+		}
+		where := fmt.Sprintf("interfaces %s (reth redundancy-group %d VRRP)",
+			ifName, ifc.RedundancyGroup)
+		if err := vrrpVIPCountErr(where, all); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/config/vrrp_vip_count_6779_test.go
+++ b/pkg/config/vrrp_vip_count_6779_test.go
@@ -1,0 +1,259 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+)
+
+// #6779: a VRRP virtual-address set larger than the advertisement's single-byte
+// address count (RFC 5798 §5.2.4) makes EVERY advert fail to build — and
+// pkg/vrrp sendAdvert discards that Marshal error at slog.Debug. The failure is
+// an ORDERING problem: becomeMaster claims the VIPs and publishes MASTER first,
+// so the node owns the addresses while advertising nothing. Its peer stops
+// hearing a master, promotes itself, and both answer for the same addresses.
+//
+// validateVRRPVIPCountStrict rejects such a set at commit / commit-check.
+//
+// FAIL-ON-REVERT: drop the validateVRRPVIPCountStrict dispatch in
+// compiler_uniformgates_cluster_zone.go (or the comparison inside
+// vrrpVIPCountErr) and the over-cap subtests below go green on the BAD config.
+
+// vipCountV4 returns n distinct IPv4 host literals inside 10.9.0.0/16, so every
+// VIP is contained by the unit subnet the #3013 containment gate requires.
+func vipCountV4(n int) []string {
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		// Start at 10.9.0.2 so the unit's own .1 address is not duplicated.
+		out = append(out, fmt.Sprintf("10.9.%d.%d", (i+1)>>8, (i+1)&0xff))
+	}
+	return out
+}
+
+// vipCountV6 returns n distinct IPv6 host literals inside 2001:db8::/64.
+func vipCountV6(n int) []string {
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, fmt.Sprintf("2001:db8::%x", i+2))
+	}
+	return out
+}
+
+// vrrpGroupVIPSetLines builds a unit carrying a vrrp-group with n VIPs of the
+// requested family. A vrrp-group is authored UNDER a specific `family <af>
+// address <prefix>` in Junos, and that prefix is the covering subnet the #3013
+// containment gate requires, so every VIP falls inside it.
+func vrrpGroupVIPSetLines(n int, isIPv6 bool) []string {
+	var base string
+	var vips []string
+	if isIPv6 {
+		base = "set interfaces ge-0/0/0 unit 0 family inet6 address 2001:db8::1/64 "
+		vips = vipCountV6(n)
+	} else {
+		base = "set interfaces ge-0/0/0 unit 0 family inet address 10.9.0.1/16 "
+		vips = vipCountV4(n)
+	}
+	lines := make([]string, 0, n)
+	for _, vip := range vips {
+		lines = append(lines, base+"vrrp-group 1 virtual-address "+vip)
+	}
+	return lines
+}
+
+// compiledGroupVIPCount returns the number of virtual addresses the compiler
+// actually stored for the single vrrp-group in cfg, and whether a group was
+// found at all.
+//
+// Every test below that asserts "this config commits cleanly" calls it. Without
+// that, a fixture whose set-syntax silently produced NO vrrp-group also commits
+// cleanly — the pass would be indistinguishable from a healthy one while
+// exercising nothing. (An earlier revision of these fixtures authored
+// `vrrp-group` directly under `family inet`, which compiles to zero groups.)
+func compiledGroupVIPCount(cfg *Config) (int, bool) {
+	for _, ifc := range cfg.Interfaces.Interfaces {
+		for _, unit := range ifc.Units {
+			for _, vg := range unit.VRRPGroups {
+				if vg != nil {
+					return len(vg.VirtualAddresses), true
+				}
+			}
+		}
+	}
+	return 0, false
+}
+
+// TestVRRPVIPCountOverCapFailsCommit is the fail-on-revert gate. cap+1 is the
+// SMALLEST failing value for each family — the boundary nothing else covers.
+func TestVRRPVIPCountOverCapFailsCommit(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		isIPv6 bool
+		cap    int
+	}{
+		{"inet", false, MaxVRRPVirtualAddressesIPv4},
+		{"inet6", true, MaxVRRPVirtualAddressesIPv6},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			over := tc.cap + 1
+			tree := buildTree(t, vrrpGroupVIPSetLines(over, tc.isIPv6))
+
+			cfg, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("expected commit to reject %d %s virtual addresses "+
+					"(cap %d): every advert would fail to build while the node "+
+					"still owned the VIPs; got nil error (warnings=%v)",
+					over, tc.name, tc.cap, cfg.Warnings)
+			}
+			if !stringContainsAll(err.Error(), "virtual addresses", "exceeds") {
+				t.Fatalf("error %q does not describe the over-capacity VIP set",
+					err.Error())
+			}
+
+			// Tolerant path (load / peer-sync) must NOT brick — #1960 no-brick.
+			// The pkg/vrrp runtime guards hold the group out of the election, so
+			// a leniently-loaded oversized set is bounded, not a silent owner.
+			lcfg, lerr := CompileConfigLenient(tree)
+			if lerr != nil {
+				t.Fatalf("lenient compile must not reject an oversized VRRP VIP "+
+					"set (no-brick), got %v", lerr)
+			}
+			if !warningsContain(lcfg.Warnings, "virtual address") {
+				t.Fatalf("lenient compile should have warned about the VIP count; "+
+					"warnings=%v", lcfg.Warnings)
+			}
+		})
+	}
+}
+
+// TestVRRPVIPCountAtCapCommits is the TIGHTENING control paired with the test
+// above: exactly `cap` addresses is the LARGEST legal set and must commit
+// cleanly with no warning. A guard mutated from `>` to `>=` reds here; a guard
+// deleted entirely reds the over-cap test. Neither mutation can pass both.
+func TestVRRPVIPCountAtCapCommits(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		isIPv6 bool
+		cap    int
+	}{
+		{"inet", false, MaxVRRPVirtualAddressesIPv4},
+		{"inet6", true, MaxVRRPVirtualAddressesIPv6},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildTree(t, vrrpGroupVIPSetLines(tc.cap, tc.isIPv6))
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("%d %s virtual addresses is exactly the cap and must "+
+					"commit, got %v", tc.cap, tc.name, err)
+			}
+			// The clean commit must come from a config that REALLY carries the
+			// cap, not from a fixture that compiled to no group at all.
+			got, found := compiledGroupVIPCount(cfg)
+			if !found {
+				t.Fatalf("fixture produced no vrrp-group: the clean commit "+
+					"proves nothing about a %d-address set", tc.cap)
+			}
+			if got != tc.cap {
+				t.Fatalf("fixture compiled to %d %s virtual addresses, want %d "+
+					"(exactly the cap) — the boundary is not being exercised",
+					got, tc.name, tc.cap)
+			}
+			if warningsContain(cfg.Warnings, "exceeds the maximum") {
+				t.Fatalf("a VIP set at the cap must not warn; warnings=%v",
+					cfg.Warnings)
+			}
+		})
+	}
+}
+
+// rethVIPCountSetLines builds an untagged RETH in a redundancy group carrying n
+// unit addresses. CollectRethInstances turns those unit addresses INTO the
+// advertised VIP set, so the same cap applies even though no `vrrp-group` block
+// is authored. `no-private-rg-election` is required for RETH VRRP instances to
+// be synthesized at all (private RG election is the compiler default).
+func rethVIPCountSetLines(n int) []string {
+	lines := []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster authentication-key test-cluster-psk-6779",
+		"set chassis cluster reth-count 1",
+		"set chassis cluster no-private-rg-election",
+		"set interfaces reth0 redundant-ether-options redundancy-group 1",
+	}
+	for _, vip := range vipCountV4(n) {
+		lines = append(lines, "set interfaces reth0 unit 0 family inet address "+
+			vip+"/16")
+	}
+	return lines
+}
+
+// TestRethDerivedVIPCountOverCapFailsCommit covers the SECOND VIP source. A
+// RETH interface authors no vrrp-group at all — its unit addresses become the
+// advertised set — so a gate that only walked unit.VRRPGroups would miss this
+// entirely while the runtime still built an unadvertisable instance.
+func TestRethDerivedVIPCountOverCapFailsCommit(t *testing.T) {
+	over := MaxVRRPVirtualAddressesIPv4 + 1
+	tree := buildTree(t, rethVIPCountSetLines(over))
+
+	cfg, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("expected commit to reject a RETH carrying %d unit addresses "+
+			"(cap %d) — CollectRethInstances advertises them as the VIP set; "+
+			"got nil error (warnings=%v)", over, MaxVRRPVirtualAddressesIPv4,
+			cfg.Warnings)
+	}
+	if !stringContainsAll(err.Error(), "reth", "exceeds") {
+		t.Fatalf("error %q does not name the reth-derived VRRP VIP set",
+			err.Error())
+	}
+
+	lcfg, lerr := CompileConfigLenient(tree)
+	if lerr != nil {
+		t.Fatalf("lenient compile must not reject the reth-derived oversized "+
+			"set (no-brick), got %v", lerr)
+	}
+	if !warningsContain(lcfg.Warnings, "virtual address") {
+		t.Fatalf("lenient compile should have warned; warnings=%v", lcfg.Warnings)
+	}
+}
+
+// TestRethDerivedVIPCountSkippedWhenRGElectionPrivate pins that the gate mirrors
+// CollectRethInstances' own early return. Under private RG election (the
+// compiler default for any `chassis cluster` stanza) NO reth VRRP instance is
+// synthesized, so an oversized unit address list has no advert consequence and
+// must not be rejected.
+//
+// Without this the gate would reject a working configuration — the guard must
+// be scoped to configs that actually build a RETH VRRP instance.
+func TestRethDerivedVIPCountSkippedWhenRGElectionPrivate(t *testing.T) {
+	lines := rethVIPCountSetLines(MaxVRRPVirtualAddressesIPv4 + 1)
+	// Drop the no-private-rg-election line, restoring the private-election
+	// default under which no RETH VRRP instance exists.
+	kept := lines[:0]
+	for _, l := range lines {
+		if l == "set chassis cluster no-private-rg-election" {
+			continue
+		}
+		kept = append(kept, l)
+	}
+	tree := buildTree(t, kept)
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("private-rg-election synthesizes no RETH VRRP instance, so an "+
+			"oversized unit address list must not be rejected, got %v", err)
+	}
+	// The clean commit must come from a genuinely OVERSIZED reth: if the
+	// fixture lost its addresses, "not rejected" would be true for the wrong
+	// reason and this test would pass with the gate scoping removed.
+	reth := cfg.Interfaces.Interfaces["reth0"]
+	if reth == nil || reth.Units[0] == nil {
+		t.Fatalf("fixture produced no reth0 unit 0")
+	}
+	if n := len(reth.Units[0].Addresses); n <= MaxVRRPVirtualAddressesIPv4 {
+		t.Fatalf("fixture compiled to %d reth unit addresses, want more than the "+
+			"cap %d — the skip-when-private-election path is not being exercised",
+			n, MaxVRRPVirtualAddressesIPv4)
+	}
+	if warningsContain(cfg.Warnings, "exceeds the maximum") {
+		t.Fatalf("no RETH VRRP instance exists — must not warn; warnings=%v",
+			cfg.Warnings)
+	}
+}

--- a/pkg/config/vrrp_vip_count_6779_test.go
+++ b/pkg/config/vrrp_vip_count_6779_test.go
@@ -257,3 +257,36 @@ func TestRethDerivedVIPCountSkippedWhenRGElectionPrivate(t *testing.T) {
 			cfg.Warnings)
 	}
 }
+
+// TestVRRPVIPCountConstantsAreInternallyConsistent is the pkg/config half of
+// the two-test binding on a number that is necessarily spelled twice (#6779).
+//
+// pkg/vrrp imports pkg/config and never the reverse, so the per-family ceiling
+// exists both here and as vrrp.MaxConfiguredVIPs. The BEHAVIOURAL binding —
+// "these constants equal what the real Marshal accepts" — can only live in
+// pkg/vrrp, because only that package can see the wire builder. A developer
+// running just `go test ./pkg/config/` would therefore not observe a broken
+// constant at all; only the repo-wide gate would.
+//
+// This test closes that window from the config side by pinning the RELATIONSHIP
+// rather than either value: an IPv6 advertisement must carry the virtual
+// router's link-local first (RFC 5798 §6.1), and pkg/vrrp sendPacketIPv6
+// prepends it, so exactly ONE slot is unavailable to configured IPv6 VIPs.
+// Editing either constant without the other reds here immediately.
+func TestVRRPVIPCountConstantsAreInternallyConsistent(t *testing.T) {
+	if d := MaxVRRPVirtualAddressesIPv4 - MaxVRRPVirtualAddressesIPv6; d != 1 {
+		t.Fatalf("IPv4 cap %d - IPv6 cap %d = %d, want exactly 1: the IPv6 advert "+
+			"reserves one slot for the mandatory link-local prepend, so the two "+
+			"caps must differ by exactly that slot (see pkg/vrrp "+
+			"MaxConfiguredVIPs, bound behaviourally in "+
+			"advert_capacity_agreement_6779_test.go)",
+			MaxVRRPVirtualAddressesIPv4, MaxVRRPVirtualAddressesIPv6, d)
+	}
+	// Both caps must be expressible in the single wire byte they describe.
+	for _, c := range []int{MaxVRRPVirtualAddressesIPv4, MaxVRRPVirtualAddressesIPv6} {
+		if c < 1 || c > 255 {
+			t.Errorf("cap %d does not fit the one-byte Count IPvX Addr field "+
+				"(RFC 5798 §5.2.4)", c)
+		}
+	}
+}

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -125,6 +125,10 @@ This is the package that drives chassis-cluster failover.
     `removeVIPsLocked`, `nlLinkByName`/`nlAddrAdd`/`nlAddrDel`,
     `removeVIPsIfBackup`, `scheduleVIPRemoveReconcile`, `surfaceStaleVIP`,
     `vipActuationResult`).
+- `advert_capacity.go` — per-family VIP cardinality guard (#6779):
+  `splitVIPsByFamily` (the SSOT for how a configured VIP list is counted
+  by family, shared with `sendAdvert`) and `checkAdvertCapacity` (whether
+  that list can produce a legal advert). See "Advert capacity" below.
 - `packet.go` — VRRPv3 advert parser/builder + IPv4/IPv6 checksums.
 - `track.go` — interface tracking (#1814): the per-instance
   effective-priority primitives (`getPriority`, `setTrackDown`,
@@ -593,13 +597,75 @@ invariants hold by construction:
 - **Count stays consistent.** `Marshal` derives the "Count IPvX Addr" wire byte
   from `len(IPAddresses)` (`packet.go`), so prepending bumps the count in
   lockstep with the payload length; the `MinAdvertAddrCount..MaxAdvertAddrCount`
-  guard still applies (a 255-VIP config would push to 256 and be rejected).
+  guard still applies. The prepend is exactly why the IPv6 CONFIGURED-VIP
+  ceiling is 254 and not 255: a 255-VIP IPv6 config pushes the wire count to
+  256 and `Marshal` rejects it. That rejection is now caught before it can
+  matter — see "Advert capacity" below (#6779).
 - **IPv4 is untouched.** The prepend lives only in the IPv6 send path; the
   IPv4 `sendPacket` builder advertises the configured VIPs verbatim.
 
 Guarded by `TestSendPacketIPv6PrependsVirtualRouterLinkLocal` /
 `TestSendPacketIPv6LinkLocalFirstWithMultipleVIPs`, which re-parse the captured
 advert and assert address[0] is the link-local and the Count field includes it.
+
+### Advert capacity — per-family VIP cardinality (#6779)
+
+RFC 5798 §5.2.4 makes an advertisement's "Count IPvX Addr" a single byte, so
+one advert carries at most **255** addresses of a family. `Marshal` REFUSES an
+out-of-range count rather than truncating it (#5090). Combined with the IPv6
+link-local prepend above, the ceiling on **configured** VIPs is:
+
+| Family | Configured VIP ceiling | Why |
+|---|---|---|
+| IPv4 | 255 (`MaxAdvertAddrCount`) | no prepend — every slot is a configured VIP |
+| IPv6 | 254 (`MaxAdvertAddrCount - 1`) | slot 0 is the mandatory link-local prepend |
+
+`MaxConfiguredVIPs(isIPv6)` (`packet.go`) derives both from
+`MaxAdvertAddrCount`, so the subtraction lives in one place.
+
+**Why an oversized set was more than a malformed packet.** `sendAdvert`
+discards a `Marshal` failure at `slog.Debug`, and `becomeMaster` claimed the
+VIP set and published MASTER **before** calling it. An oversized family
+therefore produced an owner that advertised **nothing**: the peer's
+`masterDownTimer` expired and it promoted too — both nodes answering ARP for
+the same VIPs — or, with the same config synced to both nodes, no node could
+advertise and the VIPs were stranded. Note the failure is *silent* at a default
+log level, so it presented as an unexplained dual-master.
+
+Three layers now close it, and the cap is enforced at each:
+
+1. **Commit** — `validateVRRPVIPCountStrict` (`pkg/config`) hard-rejects an
+   over-capacity set at `commit` / `commit-check`, covering BOTH VIP sources:
+   explicit `vrrp-group ... virtual-address`, and the RETH-derived instances
+   where a redundancy-group interface's own unit addresses become the
+   advertised set (`CollectRethInstances`). Per #1960 no-brick the tolerant
+   load / peer-sync path downgrades it to a warning
+   (`opts.lenientVRRPVIPCount`).
+2. **Instance construction** — `UpdateInstances` refuses to build an
+   instance whose VIP set cannot advertise, same doctrine as the #4573 VRID
+   guard, so a leniently-loaded config leaves the group out of the election
+   rather than seating a silent non-advertiser.
+3. **Ownership** — `becomeMaster` consults `vi.advertCapacityErr` and returns
+   false **before** `setState`/`addVIPs`, so the VIPs are never claimed. This is
+   the #5082 "do not claim what you cannot back" rule applied to the advert
+   instead of to VIP actuation. The predicate is computed once in `newInstance`
+   (the configured VIP list is immutable per instance — a VIP change rebuilds
+   it), so the ~97ms RETH retry path pays a nil check and the operator-facing
+   `Error` is logged once, not per retry.
+
+Because `pkg/vrrp` imports `pkg/config` and never the reverse, the cap is
+necessarily spelled in both packages
+(`config.MaxVRRPVirtualAddressesIPv4/IPv6`). They are NOT independently
+maintained: `advert_capacity_agreement_6779_test.go` measures the largest count
+the REAL `Marshal` accepts per family — driving IPv6 through the same
+link-local prepend — and asserts the config constants equal exactly that, so a
+wire-format change the constants did not follow fails the suite instead of
+silently splitting the validator from the builder.
+
+**Not covered:** an EMPTY (or entirely unparseable) VIP list. Such an instance
+also holds its group without advertising, but it claims no addresses, so there
+is nothing for a second master to collide over. It is a distinct defect tracked
+separately.
 
 ### Receiver goroutine model
 

--- a/pkg/vrrp/advert_capacity.go
+++ b/pkg/vrrp/advert_capacity.go
@@ -1,0 +1,113 @@
+package vrrp
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"strings"
+)
+
+// splitVIPsByFamily parses a configured virtual-address list (CIDR or bare
+// literals) into the per-family net.IP slices a VRRPv3 advertisement carries.
+// Unparseable entries are skipped, exactly as the send path has always done.
+//
+// This is the SINGLE source of the per-family address counts. sendAdvert uses
+// it to build the packets and checkAdvertCapacity uses it to decide whether those
+// packets can legally be built, so the guard and the builder can never disagree
+// about how many addresses a config yields — the counting rule is shared code,
+// not two copies of the same loop (#6779).
+func splitVIPsByFamily(vips []string) (v4Addrs, v6Addrs []net.IP) {
+	for _, vip := range vips {
+		addr := vip
+		if idx := strings.Index(addr, "/"); idx >= 0 {
+			addr = addr[:idx]
+		}
+		ip := net.ParseIP(addr)
+		if ip == nil {
+			continue
+		}
+		if ip.To4() != nil {
+			v4Addrs = append(v4Addrs, ip.To4())
+		} else {
+			v6Addrs = append(v6Addrs, ip.To16())
+		}
+	}
+	return v4Addrs, v6Addrs
+}
+
+// checkAdvertCapacity reports why the given configured virtual-address set cannot
+// produce a legal VRRPv3 advertisement, or nil if it can (#6779).
+//
+// It checks the UPPER bound only: more addresses of one family than the advert
+// can express. Marshal range-checks len(IPAddresses) against
+// MinAdvertAddrCount..MaxAdvertAddrCount and returns an error rather than
+// truncating the u8 Count byte (#5090), so an oversized family makes every
+// Marshal call for that family fail. The per-family ceiling is
+// MaxConfiguredVIPs, which is one lower for IPv6 because sendPacketIPv6
+// prepends the mandatory link-local before Marshal.
+//
+// Deliberately NOT checked here: an EMPTY (or entirely unparseable) VIP list.
+// sendAdvert emits a per-family advert only when that family has at least one
+// address, so a VIP-less instance also holds its group without ever
+// advertising — but it claims no addresses, so there is nothing for a
+// second master to collide over, and it is a distinct defect from the
+// oversized set this guard exists for. Folding it in here would also change
+// the behaviour of every VIP-less instance in one step; that belongs in its
+// own change rather than riding along with this fix.
+//
+// Why this is fatal rather than degraded: sendAdvert discards the Marshal error
+// at slog.Debug, so the failure is silent on a default log level. A node that
+// has claimed ownership and cannot advertise holds the VIPs while emitting
+// nothing — the peer's masterDownTimer expires and it promotes too, so both
+// nodes answer ARP for the same VIP (dual-master), or, if the peer shares the
+// same unsendable config, the VIP is stranded with no advertising owner.
+//
+// The check is per-family and ANY failing configured family fails the whole
+// instance: the families share one VRID and one ownership claim, so a family
+// that cannot advertise is a family whose peer will elect a second master for
+// addresses this node is already answering for. That mirrors the #5082
+// "required VIP set" rule, where a partially-actuated VIP set is also refused
+// rather than partially claimed.
+//
+// The predicate is a pure function of the configured VIP list, which is
+// immutable for the lifetime of an instance (a VIP change rebuilds the
+// instance — see manager.go UpdateInstances), so callers may evaluate it once.
+func checkAdvertCapacity(vips []string) error {
+	v4Addrs, v6Addrs := splitVIPsByFamily(vips)
+
+	if n := len(v4Addrs); n > MaxConfiguredVIPs(false) {
+		return fmt.Errorf("%d IPv4 virtual addresses exceed the %d that fit in a "+
+			"VRRPv3 advertisement (RFC 5798 §5.2.4 Count IPvX Addr is one byte); "+
+			"every IPv4 advert would fail to build", n, MaxConfiguredVIPs(false))
+	}
+	if n := len(v6Addrs); n > MaxConfiguredVIPs(true) {
+		return fmt.Errorf("%d IPv6 virtual addresses exceed the %d that fit in a "+
+			"VRRPv3 advertisement (RFC 5798 §5.2.4 Count IPvX Addr is one byte, and "+
+			"§6.1 reserves the first slot for the mandatory link-local prepend); "+
+			"every IPv6 advert would fail to build", n, MaxConfiguredVIPs(true))
+	}
+	return nil
+}
+
+// instanceAdvertCapacityErr evaluates checkAdvertCapacity for a new instance's
+// configured VIP set and emits the single operator-facing Error for it (#6779).
+//
+// Evaluating ONCE, at construction, is sound because cfg.VirtualAddresses is
+// immutable for an instance's lifetime: manager.go UpdateInstances takes the
+// in-place update arm only when vipsEqual() holds, so any VIP change rebuilds
+// the instance rather than mutating this one. becomeMaster then consults the
+// stored result on every promotion attempt without re-parsing the list — and,
+// more importantly, without re-logging: that path retries every
+// masterDownInterval (~97ms for a RETH instance), so an Error there would put
+// ~10 lines/second into the journal for as long as the bad config is loaded,
+// exactly the flooding CLAUDE.md's logging rules forbid.
+func instanceAdvertCapacityErr(cfg Instance) error {
+	err := checkAdvertCapacity(cfg.VirtualAddresses)
+	if err != nil {
+		slog.Error("vrrp: configured virtual addresses cannot produce a legal "+
+			"advertisement; this instance will never claim MASTER (fail-closed)",
+			"key", StateKey(cfg.Interface, cfg.GroupID, cfg.Family),
+			"vip_count", len(cfg.VirtualAddresses), "err", err)
+	}
+	return err
+}

--- a/pkg/vrrp/advert_capacity_agreement_6779_test.go
+++ b/pkg/vrrp/advert_capacity_agreement_6779_test.go
@@ -1,0 +1,120 @@
+package vrrp
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6779 VALIDATOR<->BUILDER AGREEMENT.
+//
+// The commit-time gate lives in pkg/config (validateVRRPVIPCountStrict) and the
+// wire builder lives here (Marshal). pkg/vrrp imports pkg/config, never the
+// reverse, so the per-family ceiling is necessarily spelled in two places:
+// config.MaxVRRPVirtualAddressesIPv4/IPv6 and vrrp.MaxConfiguredVIPs. Two
+// spellings of one number drift.
+//
+// These tests do NOT pin either side to the literal 255/254 — a literal encodes
+// which side you trust, and if the wire format ever changes the "correct" number
+// changes with it. They instead MEASURE the largest configured-VIP count that
+// pkg/vrrp's real Marshal accepts for each family (driving the IPv6 case through
+// the same link-local prepend sendPacketIPv6 performs) and assert the config
+// constant equals exactly that. A change to Marshal's bound, or to the IPv6
+// prepend, that the config constants did not follow fails here.
+
+// marshalAcceptsConfiguredCount reports whether an advert built from n
+// CONFIGURED virtual addresses of the given family marshals successfully.
+//
+// For IPv6 it reproduces sendPacketIPv6's mandatory link-local prepend, so the
+// count reaching Marshal is n+1 — the exact arithmetic MaxConfiguredVIPs
+// encodes. For IPv4 there is no prepend.
+func marshalAcceptsConfiguredCount(t *testing.T, n int, isIPv6 bool) bool {
+	t.Helper()
+
+	addrs := make([]net.IP, 0, n+1)
+	if isIPv6 {
+		// sendPacketIPv6 prepends the virtual router's link-local first.
+		addrs = append(addrs, net.ParseIP("fe80::1"))
+	}
+	for i := 0; i < n; i++ {
+		if isIPv6 {
+			addrs = append(addrs, net.ParseIP(fmt.Sprintf("2001:db8::%x", i+1)))
+		} else {
+			addrs = append(addrs, net.IPv4(10, 0, byte(i>>8), byte(i)))
+		}
+	}
+
+	pkt := &VRRPPacket{VRID: 7, Priority: 100, MaxAdvertInt: 100, IPAddresses: addrs}
+	var src, dst net.IP
+	if isIPv6 {
+		src, dst = net.ParseIP("fe80::1"), net.ParseIP("ff02::12")
+	} else {
+		src, dst = net.IPv4(10, 0, 0, 2), net.IPv4(224, 0, 0, 18)
+	}
+	_, err := pkt.Marshal(isIPv6, src, dst)
+	return err == nil
+}
+
+// measureMarshalCeiling finds the largest configured-VIP count Marshal accepts
+// for a family by probing the candidate boundary from the config constant: it
+// asserts the constant is accepted and the next value up is refused, which
+// together identify the ceiling uniquely without assuming its value.
+func TestAdvertCapacity_ConfigConstantsMatchMarshalCeiling(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		isIPv6     bool
+		configMax  int
+		runtimeMax int
+	}{
+		{"IPv4", false, config.MaxVRRPVirtualAddressesIPv4, MaxConfiguredVIPs(false)},
+		{"IPv6", true, config.MaxVRRPVirtualAddressesIPv6, MaxConfiguredVIPs(true)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// 1. The two spellings agree with each other.
+			if tc.configMax != tc.runtimeMax {
+				t.Fatalf("config cap (%d) != runtime cap (%d): the commit gate and "+
+					"the advert builder disagree about how many %s virtual "+
+					"addresses fit, so a config the gate accepts can still fail "+
+					"every Marshal", tc.configMax, tc.runtimeMax, tc.name)
+			}
+
+			// 2. Both agree with what Marshal ACTUALLY does. This is the leg a
+			//    literal cannot provide: it exercises the real builder,
+			//    including the IPv6 link-local prepend.
+			if !marshalAcceptsConfiguredCount(t, tc.configMax, tc.isIPv6) {
+				t.Errorf("Marshal REFUSED %d configured %s addresses, but the cap "+
+					"claims that many fit — the gate would accept a config whose "+
+					"every advert fails to build", tc.configMax, tc.name)
+			}
+			if marshalAcceptsConfiguredCount(t, tc.configMax+1, tc.isIPv6) {
+				t.Errorf("Marshal ACCEPTED %d configured %s addresses, one more "+
+					"than the cap claims fits — the gate rejects a config that "+
+					"would have advertised fine", tc.configMax+1, tc.name)
+			}
+		})
+	}
+}
+
+// TestAdvertCapacity_IPv6CapIsOneBelowIPv4 pins the REASON the two families
+// differ rather than the numbers themselves: the IPv6 advert must carry the
+// virtual router's link-local first (RFC 5798 §6.1), and sendPacketIPv6
+// prepends it, so exactly one slot is unavailable to configured VIPs.
+//
+// Mutating MaxConfiguredVIPs to return MaxAdvertAddrCount for IPv6 (dropping
+// the prepend allowance) makes this RED, and so does dropping the prepend in
+// sendPacketIPv6 while leaving the cap alone.
+func TestAdvertCapacity_IPv6ReservesExactlyOneSlotForLinkLocal(t *testing.T) {
+	v4, v6 := MaxConfiguredVIPs(false), MaxConfiguredVIPs(true)
+	if got := v4 - v6; got != 1 {
+		t.Fatalf("IPv4 cap %d - IPv6 cap %d = %d, want exactly 1 slot reserved "+
+			"for the mandatory IPv6 link-local prepend", v4, v6, got)
+	}
+	// The reserved slot is real: an IPv6 advert at the IPv6 cap fills the wire
+	// count to the IPv4 cap once the link-local is prepended.
+	if v6+1 != MaxAdvertAddrCount {
+		t.Fatalf("IPv6 cap %d + link-local = %d, want the wire maximum %d",
+			v6, v6+1, MaxAdvertAddrCount)
+	}
+}

--- a/pkg/vrrp/advert_capacity_gate_6779_test.go
+++ b/pkg/vrrp/advert_capacity_gate_6779_test.go
@@ -1,0 +1,186 @@
+package vrrp
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+// #6779 RUNTIME GATES. becomeMaster used to claim the VIP set and publish
+// MASTER, and only then call sendAdvert — which discards a Marshal failure at
+// slog.Debug. An oversized VIP set therefore produced an owner that advertised
+// NOTHING: the peer's masterDownTimer expires and it promotes too (dual-master),
+// or, with the same config synced to both nodes, the addresses are stranded.
+//
+// Two guards close it, and each is tested against the ORDERING, not just the
+// error value:
+//   - becomeMaster refuses to claim (fail-closed, #5082 doctrine)
+//   - UpdateInstances refuses to build the instance (#4573 doctrine)
+
+// makeVIPs builds n distinct configured virtual addresses (CIDR form, as the
+// compiler emits them) of the requested family.
+func makeVIPs(n int, isIPv6 bool) []string {
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		if isIPv6 {
+			out = append(out, fmt.Sprintf("2001:db8::%x/64", i+1))
+		} else {
+			out = append(out, fmt.Sprintf("10.%d.%d.1/24", i>>8, i&0xff))
+		}
+	}
+	return out
+}
+
+// TestBecomeMaster_RefusesOversizedVIPSet is the fail-on-revert gate for the
+// ORDERING claim. It asserts the three things that together mean "ownership was
+// not claimed": becomeMaster returned false, the state did NOT go MASTER, and
+// no VIP was actuated.
+//
+// Under the pre-fix code becomeMaster returns true and setState(StateMaster)
+// has run, while every advert Marshal fails — the exact silent dual-master
+// condition. Removing the guard makes this RED on the returned value AND on the
+// observed state, so a partial revert cannot hide.
+func TestBecomeMaster_RefusesOversizedVIPSet(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		isIPv6 bool
+	}{
+		{"IPv4", false},
+		{"IPv6", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			over := MaxConfiguredVIPs(tc.isIPv6) + 1
+			vi := newInstance(Instance{
+				Interface:         "reth0.50",
+				GroupID:           42,
+				Priority:          200,
+				AdvertiseInterval: 1000,
+				VirtualAddresses:  makeVIPs(over, tc.isIPv6),
+			}, &net.Interface{Name: "reth0.50", Index: 42}, make(chan VRRPEvent, 16), nil)
+
+			if vi.advertCapacityErr == nil {
+				t.Fatalf("%d %s VIPs (cap %d) must be recorded as unadvertisable",
+					over, tc.name, MaxConfiguredVIPs(tc.isIPv6))
+			}
+			before := vi.getState()
+			if got := vi.becomeMaster(); got {
+				t.Errorf("becomeMaster() = true for an oversized %s VIP set; "+
+					"ownership was claimed for a group that can never advertise",
+					tc.name)
+			}
+			if got := vi.getState(); got == StateMaster {
+				t.Errorf("state = MASTER after a refused promotion (was %v); the "+
+					"node holds the VIPs while every advert fails to build", before)
+			}
+		})
+	}
+}
+
+// TestBecomeMaster_AcceptsVIPSetAtCap is the TIGHTENING control: the guard must
+// not over-reject. A VIP set at exactly the per-family cap advertises fine, so
+// becomeMaster must not be blocked by advertCapacityErr.
+//
+// Boundary pairing matters here — cap is the largest legal value and cap+1 (the
+// test above) the smallest illegal one, so an off-by-one in either direction is
+// caught. A mutation making the guard `>=` instead of `>` reds THIS test.
+func TestBecomeMaster_AcceptsVIPSetAtCap(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		isIPv6 bool
+	}{
+		{"IPv4", false},
+		{"IPv6", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			at := MaxConfiguredVIPs(tc.isIPv6)
+			vi := newInstance(Instance{
+				Interface:         "reth0.50",
+				GroupID:           42,
+				Priority:          200,
+				AdvertiseInterval: 1000,
+				VirtualAddresses:  makeVIPs(at, tc.isIPv6),
+			}, &net.Interface{Name: "reth0.50", Index: 42}, make(chan VRRPEvent, 16), nil)
+
+			if vi.advertCapacityErr != nil {
+				t.Fatalf("%d %s VIPs is exactly the cap and must be advertisable, "+
+					"got: %v", at, tc.name, vi.advertCapacityErr)
+			}
+		})
+	}
+}
+
+// TestUpdateInstances_SkipsUnadvertisableVIPSet pins the construction-side
+// guard: an oversized instance is never seated in the election at all, while a
+// sibling with a legal VIP set still builds.
+//
+// The sibling is what makes this mutation-sensitive in both directions: a guard
+// that rejected everything would fail on the valid instance, and a deleted
+// guard fails on the oversized one.
+func TestUpdateInstances_SkipsUnadvertisableVIPSet(t *testing.T) {
+	m, rec := newTestManagerNoNetwork()
+	defer stopManagerForTest(m)
+
+	over := MaxConfiguredVIPs(false) + 1
+	desired := []*Instance{
+		{Interface: "reth0", GroupID: 100, VirtualAddresses: makeVIPs(over, false)},
+		{Interface: "reth1", GroupID: 101, VirtualAddresses: []string{"10.0.62.1/24"}},
+	}
+	if err := m.UpdateInstances(desired); err != nil {
+		t.Fatalf("UpdateInstances: %v", err)
+	}
+
+	m.mu.RLock()
+	n := len(m.instances)
+	_, haveValid := m.instances[instanceKey{iface: "reth1", groupID: 101}]
+	_, haveOver := m.instances[instanceKey{iface: "reth0", groupID: 100}]
+	m.mu.RUnlock()
+
+	if haveOver {
+		t.Errorf("an instance with %d IPv4 VIPs (cap %d) was built; it would claim "+
+			"the VIPs and never advertise", over, MaxConfiguredVIPs(false))
+	}
+	if !haveValid {
+		t.Error("the legal-VIP-set instance must still be built")
+	}
+	if n != 1 {
+		t.Fatalf("expected exactly 1 instance (only the advertisable one), got %d", n)
+	}
+	if open, _, _ := rec.snapshot(); open != 1 {
+		t.Errorf("openInstanceSocket calls = %d, want 1 (only the advertisable "+
+			"instance should reach socket open)", open)
+	}
+}
+
+// TestSendAdvert_SplitterMatchesGuardCounting binds the guard's counting rule to
+// the builder's. checkAdvertCapacity and sendAdvert must classify the same VIP
+// list into the same per-family counts, or the guard can pass a set the builder
+// then chokes on (or vice-versa).
+//
+// It exercises the shapes that actually differ between naive implementations:
+// CIDR vs bare literal, IPv4-mapped-IPv6 spelling, and an unparseable entry that
+// both sides must SKIP rather than count.
+func TestSendAdvert_SplitterMatchesGuardCounting(t *testing.T) {
+	vips := []string{
+		"10.0.61.1/24",     // v4 CIDR
+		"10.0.61.2",        // v4 bare
+		"2001:db8::1/64",   // v6 CIDR
+		"2001:db8::2",      // v6 bare
+		"not-an-address",   // skipped by both
+		"::ffff:10.0.61.3", // IPv4-mapped: To4() != nil, so it counts as v4
+	}
+	v4, v6 := splitVIPsByFamily(vips)
+	if len(v4) != 3 {
+		t.Errorf("IPv4 count = %d, want 3 (CIDR + bare + IPv4-mapped)", len(v4))
+	}
+	if len(v6) != 2 {
+		t.Errorf("IPv6 count = %d, want 2 (CIDR + bare)", len(v6))
+	}
+	// The unparseable entry must not inflate either family.
+	if len(v4)+len(v6) != len(vips)-1 {
+		t.Errorf("parsed %d of %d entries, want %d (one unparseable entry skipped)",
+			len(v4)+len(v6), len(vips), len(vips)-1)
+	}
+	if err := checkAdvertCapacity(vips); err != nil {
+		t.Errorf("a 5-address mixed-family set must be advertisable: %v", err)
+	}
+}

--- a/pkg/vrrp/advert_capacity_gate_6779_test.go
+++ b/pkg/vrrp/advert_capacity_gate_6779_test.go
@@ -3,7 +3,10 @@ package vrrp
 import (
 	"fmt"
 	"net"
+	"sync"
 	"testing"
+
+	"github.com/vishvananda/netlink"
 )
 
 // #6779 RUNTIME GATES. becomeMaster used to claim the VIP set and publish
@@ -32,14 +35,21 @@ func makeVIPs(n int, isIPv6 bool) []string {
 }
 
 // TestBecomeMaster_RefusesOversizedVIPSet is the fail-on-revert gate for the
-// ORDERING claim. It asserts the three things that together mean "ownership was
-// not claimed": becomeMaster returned false, the state did NOT go MASTER, and
-// no VIP was actuated.
+// ORDERING claim.
 //
-// Under the pre-fix code becomeMaster returns true and setState(StateMaster)
-// has run, while every advert Marshal fails — the exact silent dual-master
-// condition. Removing the guard makes this RED on the returned value AND on the
-// observed state, so a partial revert cannot hide.
+// The VIP netlink seams are wired to SUCCEED (installFakeVIPNetlink). That is
+// essential, not incidental: becomeMaster is ALSO fail-closed on VIP actuation
+// (#5082), so on an unresolvable interface it returns false anyway and an
+// assertion on the return value alone would pass with this guard deleted — the
+// #5082 path would be doing the work. Forcing actuation to succeed leaves the
+// advert-capacity gate as the ONLY thing that can refuse the promotion.
+//
+// The discriminator is addrAdd call count. This guard runs BEFORE
+// setState/addVIPs, so a refused promotion must not have touched netlink at
+// all; the #5082 path, by contrast, refuses only AFTER attempting the adds.
+// Deleting the guard makes every assertion below RED: becomeMaster returns
+// true, the state goes MASTER, a MASTER event is published, and the VIPs are
+// actuated — the exact silent dual-master condition.
 func TestBecomeMaster_RefusesOversizedVIPSet(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
@@ -50,27 +60,60 @@ func TestBecomeMaster_RefusesOversizedVIPSet(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			over := MaxConfiguredVIPs(tc.isIPv6) + 1
+			eventCh := make(chan VRRPEvent, 8)
 			vi := newInstance(Instance{
-				Interface:         "reth0.50",
+				Interface:         "xpf-6779-a0",
 				GroupID:           42,
 				Priority:          200,
 				AdvertiseInterval: 1000,
 				VirtualAddresses:  makeVIPs(over, tc.isIPv6),
-			}, &net.Interface{Name: "reth0.50", Index: 42}, make(chan VRRPEvent, 16), nil)
+			}, &net.Interface{Name: "xpf-6779-a0"}, eventCh, nil)
+			vi.setState(StateBackup) // the state becomeMaster transitions FROM
+			vi.suppressGARP.Store(true)
+
+			// Force VIP actuation to SUCCEED so #5082 cannot mask this guard,
+			// and count the adds so we can prove netlink was never reached.
+			var mu sync.Mutex
+			addrAdds := 0
+			installFakeVIPNetlink(vi)
+			vi.addrAddFn = func(link netlink.Link, addr *netlink.Addr) error {
+				mu.Lock()
+				addrAdds++
+				mu.Unlock()
+				return nil
+			}
 
 			if vi.advertCapacityErr == nil {
 				t.Fatalf("%d %s VIPs (cap %d) must be recorded as unadvertisable",
 					over, tc.name, MaxConfiguredVIPs(tc.isIPv6))
 			}
-			before := vi.getState()
+
 			if got := vi.becomeMaster(); got {
 				t.Errorf("becomeMaster() = true for an oversized %s VIP set; "+
 					"ownership was claimed for a group that can never advertise",
 					tc.name)
 			}
 			if got := vi.getState(); got == StateMaster {
-				t.Errorf("state = MASTER after a refused promotion (was %v); the "+
-					"node holds the VIPs while every advert fails to build", before)
+				t.Errorf("state = MASTER after a refused promotion; the node " +
+					"holds the VIPs while every advert fails to build")
+			}
+			mu.Lock()
+			n := addrAdds
+			mu.Unlock()
+			if n != 0 {
+				t.Errorf("addrAdd called %d times on a refused promotion; the "+
+					"advert-capacity gate must refuse BEFORE any VIP is "+
+					"actuated (a refusal after the adds would be the #5082 "+
+					"path, not this guard)", n)
+			}
+			select {
+			case evt := <-eventCh:
+				if evt.State == StateMaster {
+					t.Errorf("a MASTER event was published for a group that " +
+						"can never advertise; dependent services would trust " +
+						"an ownership this node cannot back")
+				}
+			default:
 			}
 		})
 	}

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -290,24 +290,32 @@ type vrrpInstance struct {
 	// stalling it.
 	resignAckMu sync.Mutex
 	resignAcks  []*ResignBarrier
+
+	// advertCapacityErr is non-nil when this instance's configured VIP set
+	// cannot produce a legal VRRPv3 advertisement, so becomeMaster must not
+	// claim ownership (#6779). Computed once by instanceAdvertCapacityErr
+	// (advert_capacity.go); read-only after construction.
+	advertCapacityErr error
 }
 
 func newInstance(cfg Instance, iface *net.Interface, eventCh chan<- VRRPEvent, onEventDrop func()) *vrrpInstance {
+	capErr := instanceAdvertCapacityErr(cfg) // #6779, advert_capacity.go
 	return &vrrpInstance{
-		cfg:             cfg,
-		desiredPreempt:  cfg.Preempt,
-		state:           StateInitialize,
-		iface:           iface,
-		eventCh:         eventCh,
-		afPacketFD:      -1,
-		ipv6FD:          -1,
-		preemptNowCh:    make(chan struct{}, 1),
-		resignCh:        make(chan struct{}, 1),
-		configUpdatedCh: make(chan struct{}, 1),
-		rxCh:            make(chan *VRRPPacket, 64),
-		stopCh:          make(chan struct{}),
-		stopped:         make(chan struct{}),
-		onEventDrop:     onEventDrop,
+		cfg:               cfg,
+		desiredPreempt:    cfg.Preempt,
+		state:             StateInitialize,
+		iface:             iface,
+		eventCh:           eventCh,
+		afPacketFD:        -1,
+		ipv6FD:            -1,
+		preemptNowCh:      make(chan struct{}, 1),
+		resignCh:          make(chan struct{}, 1),
+		configUpdatedCh:   make(chan struct{}, 1),
+		rxCh:              make(chan *VRRPPacket, 64),
+		stopCh:            make(chan struct{}),
+		stopped:           make(chan struct{}),
+		onEventDrop:       onEventDrop,
+		advertCapacityErr: capErr,
 	}
 }
 
@@ -1370,6 +1378,14 @@ func (vi *vrrpInstance) vipFamilies() (hasIPv4, hasIPv6 bool) {
 // Returns true iff ownership was claimed (VIP set actuated and advert/event
 // published).
 func (vi *vrrpInstance) becomeMaster() bool {
+	// #6779: refuse ownership we cannot advertise — #5082's "do not claim what
+	// you cannot back" applied to the advert. Before setState/addVIPs so there
+	// is nothing to roll back. Rationale + log-rate note: advert_capacity.go.
+	if vi.advertCapacityErr != nil {
+		slog.Debug("vrrp: cannot build a legal advertisement, not claiming ownership (fail-closed)",
+			"key", vi.key(), "err", vi.advertCapacityErr)
+		return false
+	}
 	pri := vi.getPriority()
 	slog.Info("vrrp: transitioning to MASTER",
 		"key", vi.key(), "priority", pri)

--- a/pkg/vrrp/instance_send.go
+++ b/pkg/vrrp/instance_send.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"strings"
 
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
@@ -37,24 +36,10 @@ func (vi *vrrpInstance) emitEvent() {
 
 // sendAdvert sends a VRRPv3 advertisement with the given priority.
 func (vi *vrrpInstance) sendAdvert(priority int) {
-	hasIPv6 := false
-	var v4Addrs, v6Addrs []net.IP
-	for _, vip := range vi.cfg.VirtualAddresses {
-		addr := vip
-		if idx := strings.Index(addr, "/"); idx >= 0 {
-			addr = addr[:idx]
-		}
-		ip := net.ParseIP(addr)
-		if ip == nil {
-			continue
-		}
-		if ip.To4() != nil {
-			v4Addrs = append(v4Addrs, ip.To4())
-		} else {
-			v6Addrs = append(v6Addrs, ip.To16())
-			hasIPv6 = true
-		}
-	}
+	// Shared with checkAdvertCapacity (advert_capacity.go) so the guard that
+	// decides an advert CAN be built counts exactly the addresses this builder
+	// puts in it (#6779).
+	v4Addrs, v6Addrs := splitVIPsByFamily(vi.cfg.VirtualAddresses)
 
 	// Send IPv4 advertisement if we have any IPv4 VIPs.
 	if len(v4Addrs) > 0 {
@@ -72,7 +57,7 @@ func (vi *vrrpInstance) sendAdvert(priority int) {
 	}
 
 	// Send IPv6 advertisement if we have any IPv6 VIPs.
-	if hasIPv6 && len(v6Addrs) > 0 {
+	if len(v6Addrs) > 0 {
 		maxAdvert := uint16(vi.cfg.AdvertiseInterval / 10) // ms → centiseconds
 		pkt := &VRRPPacket{
 			VRID:         uint8(vi.cfg.GroupID),

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -458,6 +458,24 @@ func (m *Manager) UpdateInstances(desired []*Instance) error {
 				"valid_range", fmt.Sprintf("%d..%d", MinVRID, MaxVRID))
 			continue
 		}
+		// #6779 defensive advert-capacity guard, same doctrine as the VRID guard
+		// above. A VIP set carrying more addresses of one family than the u8
+		// "Count IPvX Addr" field can express makes every Marshal for that
+		// family fail — and sendAdvert discards that error at
+		// slog.Debug. Building the instance anyway would put a node in the
+		// election that claims VIPs and never advertises: the peer times out and
+		// promotes too (dual-master), or the VIP is stranded. The config commit
+		// gate (validateVRRPVIPCountStrict, pkg/config) rejects such a set, but
+		// the tolerant load / HA-sync path downgrades it to a warning (#1960
+		// no-brick), so refuse to build the instance rather than seat a silent
+		// non-advertiser.
+		if err := checkAdvertCapacity(inst.VirtualAddresses); err != nil {
+			slog.Warn("vrrp: skipping instance whose virtual addresses cannot "+
+				"produce a legal advertisement",
+				"interface", inst.Interface, "group_id", inst.GroupID,
+				"vip_count", len(inst.VirtualAddresses), "err", err)
+			continue
+		}
 		key := instanceKey{iface: inst.Interface, groupID: inst.GroupID, family: inst.Family}
 		if _, exists := desiredMap[key]; exists {
 			return fmt.Errorf(

--- a/pkg/vrrp/packet.go
+++ b/pkg/vrrp/packet.go
@@ -298,3 +298,27 @@ func vrrpIPv6Checksum(src, dst net.IP, payload []byte) uint16 {
 	}
 	return ^uint16(sum)
 }
+
+// MaxConfiguredVIPs returns the largest number of CONFIGURED virtual addresses
+// of a single family that one VRRP instance can carry in a legal advertisement.
+//
+// It is DERIVED from MaxAdvertAddrCount rather than restated, because the two
+// families do not have the same budget: RFC 5798 §5.2.9 / §6.1 require an IPv6
+// advertisement to list the virtual router's link-local address FIRST, and
+// sendPacketIPv6 (instance_send.go) prepends that link-local to the configured
+// VIP slice immediately before Marshal. That prepended address occupies one of
+// the 255 slots the u8 "Count IPvX Addr" field can express, so the IPv6 budget
+// for CONFIGURED addresses is one less than the wire maximum. IPv4 has no
+// prepend and spends the full budget on configured VIPs.
+//
+// Callers that need the wire-format limit itself (Marshal's own range check)
+// use MaxAdvertAddrCount; callers that need "how many VIPs may an operator
+// configure" use this. Keeping the subtraction in one place is what stops the
+// validator and the builder from disagreeing by exactly the link-local.
+func MaxConfiguredVIPs(isIPv6 bool) int {
+	if isIPv6 {
+		// One slot is reserved for the mandatory link-local prepend.
+		return MaxAdvertAddrCount - 1
+	}
+	return MaxAdvertAddrCount
+}


### PR DESCRIPTION
## Summary

- A VRRP advertisement's `Count IPvX Addr` field is **one byte** (RFC 5798
  §5.2.4), and `Marshal` **refuses** an out-of-range count rather than
  truncating it (#5090). `sendAdvert` discards that error at `slog.Debug`, and
  `becomeMaster` claimed the VIP set and published MASTER **before** calling it.
- The consequence is an **ordering** problem, not a malformed packet: a node
  with an oversized VIP set took ownership, answered ARP for every VIP, and then
  emitted **nothing**. Its peer's `masterDownTimer` expired and it promoted too —
  two nodes answering for the same addresses. With the same config synced to both
  nodes, neither could advertise and the VIPs were stranded. At a default log
  level the entire failure was silent.
- Enforced at three layers: **commit** (`validateVRRPVIPCountStrict`, with a
  registered `lenientVRRPVIPCount` opt per the #1960 no-brick contract),
  **instance construction** (`UpdateInstances`, #4573 doctrine), and
  **ownership** (`becomeMaster`, #5082 doctrine).
- `sendAdvert` and the guard now share one `splitVIPsByFamily`, so the builder
  and the validator cannot count a VIP list differently.

Closes #6779

> **Cites re-derived.** The issue body points at `/tmp/opus-review-001.md`
> section R38, which no longer exists. Everything below was derived from the
> code by symbol name, not from line numbers in the issue.

## What I measured that contradicts / refines the issue

| Issue said | Measured |
|---|---|
| "Enforce per-family cardinality during strict validation" | The **wire-side** guard the issue implies was missing already exists — `Marshal` has range-checked `1..255` since #5090. What was missing is the **ordering**: nothing stopped `becomeMaster` from claiming ownership it could not advertise. That is the real defect and the real fix. |
| "a configured IPv6 maximum of 254 when the link-local address is prepended" | **Confirmed** by reading `sendPacketIPv6`, and now bound by test rather than asserted: the agreement test measures the largest count the real `Marshal` accepts per family, driving IPv6 through the same prepend. |
| "Add transition tests at 255/256 effective addresses" | Those are the IPv4 numbers only. The boundary is **per family**: 255/256 for IPv4, **254/255** for IPv6. A test pinned to 255/256 for both would assert the wrong boundary for IPv6 — so every boundary test derives from `MaxConfiguredVIPs(isIPv6)` rather than a literal. |
| — (not in the issue) | The **RETH-derived** VIP source. A `redundancy-group` RETH authors no `vrrp-group` at all — `CollectRethInstances` turns its own **unit addresses** into the advertised VIP set. A gate walking only `unit.VRRPGroups` would miss it entirely while the runtime still built an unadvertisable instance. Covered, and scoped to mirror `CollectRethInstances`' own `no-reth-vrrp` / `private-rg-election` early return. |
| "Repeat the guard in runtime construction and make advertisement failure gate or roll back MASTER ownership" | Did both, but **gate rather than roll back**, and the check runs *before* `setState`/`addVIPs`. The predicate is a pure function of the configured VIP list, which is immutable per instance, so there is nothing to roll back and no MASTER→BACKUP flap on every `masterDownTimer` retry. |

**Why fail-closed is right here.** An advert-less VRRP group cannot work in
either direction, so the choice is between a nondeterministic dual-master and a
deterministic, loudly-logged refusal. Fail-open leaves two nodes answering for
the same VIPs — ARP flapping, split state, silent at default log level.
Fail-closed leaves the VIP down with an `Error` naming the interface, group, and
count. `becomeMaster` already made exactly this call for VIP actuation in #5082;
this extends the same rule to the advert. `TestBecomeMaster_RefusesOversizedVIPSet`
asserts **the choice** — not just an error value, but that the state did not go
MASTER.

## The cap is not a flat 255

| Family | Configured VIP ceiling | Why |
|---|---|---|
| IPv4 | 255 (`MaxAdvertAddrCount`) | no prepend — every slot is a configured VIP |
| IPv6 | 254 (`MaxAdvertAddrCount - 1`) | slot 0 is the mandatory link-local prepend (RFC 5798 §6.1) |

`MaxConfiguredVIPs(isIPv6)` derives both from `MaxAdvertAddrCount`, so the
subtraction lives in one place.

Because `pkg/vrrp` imports `pkg/config` and never the reverse, the cap is
necessarily spelled in both packages (the same constraint `RethVRRPGroupIDBase`
documents for #4826). Rather than pin either side to a literal — a literal
encodes which side you trust — `advert_capacity_agreement_6779_test.go`
**measures** the largest configured-VIP count the real `Marshal` accepts for each
family and asserts the config constants equal exactly that. A change to the wire
builder, or to the IPv6 prepend, that the constants did not follow fails the
suite.

## Deliberately excluded: the empty-VIP case

An instance with an **empty** (or entirely unparseable) VIP list also holds its
group without advertising. It is excluded, and the exclusion is documented in
`checkAdvertCapacity` and `pkg/vrrp/README.md`:

- It claims **no** addresses, so there is nothing for a second master to collide
  over — a silent no-op group, not a duplicate-address hazard.
- Folding it in changed the behaviour of **22 existing `pkg/vrrp` tests**, which
  use VIP-less instances as a state-machine fixture. That is a behaviour change
  riding along with a bug fix.

Filed as #7577.

## Test plan

- [x] `go build ./... && go vet ./... && go test -count=1 ./...` — green, 67 packages
- [x] `pkg/vrrp`: ownership refusal (both families), at-cap acceptance, construction skip, splitter/guard counting agreement
- [x] `pkg/config`: over-cap rejection (both families + RETH-derived), at-cap clean commit, `private-rg-election` scoping, lenient no-brick path
- [x] Mutation matrix, 14 cells — see below
- [ ] **`make test-failover` on the loss userspace cluster — NOT RUN.** This is
      VRRP/HA code and needs the shared, lock-protected cluster. Flagged for the
      team lead to run; I did not touch any `cluster-*` target.

### Fixture self-verification

`TestVRRPVIPCountAtCapCommits` asserts the compiled config really carries
`cap` virtual addresses before concluding "commits cleanly". An earlier revision
of the fixture authored `vrrp-group` directly under `family inet` — the wrong
Junos hierarchy — which compiles to **zero** groups and also commits cleanly. The
green was indistinguishable from a healthy one while exercising nothing. The
`private-rg-election` test likewise asserts its reth is genuinely oversized, so
"not rejected" cannot be true for the wrong reason.

### Mutation matrix

Each cell: restored from HEAD, anchor verified to match **exactly once**,
mutation verified present, `go build ./...` verified to compile, then the **full
package suite** with `go test -count=1` and **no `-run` filter`**.

| Cell | Mutation | Pkg | Result | Assertion that fired |
|---|---|---|---|---|
| M1 | DELETE `becomeMaster` ownership gate | vrrp | **RED** \* | `becomeMaster() = true for an oversized IPv4 VIP set; ownership was claimed for a group that can never advertise` |
| M2 | DELETE `UpdateInstances` construction guard | vrrp | **RED** | `an instance with 256 IPv4 VIPs (cap 255) was built; it would claim the VIPs and never advertise` |
| M3 | TIGHTEN v4 guard `>` → `>=` | vrrp | **RED** | `255 IPv4 VIPs is exactly the cap and must be advertisable` |
| M4 | TIGHTEN v6 guard `>` → `>=` | vrrp | **RED** | `254 IPv6 VIPs is exactly the cap and must be advertisable` |
| M5 | PERMIT v6 cap 255 (drop link-local prepend allowance) | vrrp | **RED** | `config cap (254) != runtime cap (255): the commit gate and the advert builder disagree` |
| M6 | PERMIT v4 cap 256 (one above the wire byte) | vrrp | **RED** | `config cap (255) != runtime cap (256)` |
| M7 | PERMIT v6 guard to use the v4 cap (ignore prepend) | vrrp | **RED** | `255 IPv6 VIPs (cap 254) must be recorded as unadvertisable` |
| M8 | DELETE commit-gate dispatch | config | **RED** | `expected commit to reject 256 inet virtual addresses (cap 255) ... got nil error` |
| M9 | TIGHTEN commit gate `<=` → `<` | config | **RED** | `255 inet virtual addresses is exactly the cap and must commit` |
| M10 | BREAK v6 constant agreement (254 → 255) | config | **RED** † | `IPv4 cap 255 - IPv6 cap 255 = 0, want exactly 1` |
| M10x | same mutation, observed CROSS-PACKAGE | vrrp | **RED** | `config cap (255) != runtime cap (254)` |
| M11 | DELETE the RETH-derived VIP source from the gate | config | **RED** | `expected commit to reject a RETH carrying 256 unit addresses (cap 255)` |
| M12 | TIGHTEN: gate RETH even under `private-rg-election` | config | **RED** | `private-rg-election synthesizes no RETH VRRP instance, so an oversized unit address list must not be rejected` |
| M13 | BREAK #1960 no-brick (lenient opt unregistered) | config | **RED** | `lenient compile must not reject an oversized VRRP VIP set (no-brick)` |

**Two cells initially SURVIVED, and both were real test weaknesses — fixed, then re-run:**

\* **M1 survived at first.** The test asserted only that `becomeMaster`
returned `false`. But `becomeMaster` is *also* fail-closed on VIP actuation
(#5082), so on the test's unresolvable interface the netlink adds failed and it
returned `false` for that reason — the assertion was binding #5082, not this
guard. Fixed in `40f5709` by forcing the downstream step to succeed
(`installFakeVIPNetlink`) so only the condition under test can reject, and
adding the discriminator between the two refusal paths: **`addrAdd` call
count**. This gate refuses *before* `setState`/`addVIPs` and so must never reach
netlink; #5082 refuses only *after* attempting the adds.

† **M10 survived at first** in `pkg/config`. The behavioural agreement test can
only live in `pkg/vrrp` (only that package can see the wire builder), so
`go test ./pkg/config/` alone did not observe the broken constant — the
repo-wide gate did (M10x). Fixed in `2116af1` by pinning the *relationship*
from the config side (the two caps must differ by exactly the one reserved
link-local slot), so neither test pins a bare literal alone.


## Docs

- `pkg/vrrp/README.md` — new "Advert capacity — per-family VIP cardinality"
  section (the cap table, the three enforcement layers, the agreement-test
  rationale, the empty-VIP exclusion). Also corrects the #5089 prepend note,
  which described the 256-count rejection without its ownership consequence.
- `pkg/config/README.md` — new strict-gate entry alongside #3013/#4826.
- `_Log.md` appended.

## Refs

- #6779 (this), #7577 (empty-VIP follow-up)
- #5090 (Marshal range check), #5089 (IPv6 link-local prepend), #5082
  (fail-closed VIP actuation), #4573 / #4826 (VRID guards — the mirrored
  commit+runtime pattern), #1960 (no-brick tolerant load), #3013 (sibling VRRP
  commit gate)
