### PR TITLE
ha: report a refused synced-session import instead of success

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104430,3 +104430,28 @@ prose edit above them added. No diff falls in the new test body.
   agreement corpus could not cover without turning a wrap into a hung suite.
 - **File(s)**: pkg/dataplane/compiler.go, pkg/dataplane/compiler_test.go,
   pkg/dataplane/userspace/port_expansion_ceiling_6783_test.go, _Log.md
+
+## 2026-08-22 — #6785 HA import capacity refusal reported as success
+
+- **Timestamp**: 2026-08-22
+- **Action**: `upsert_synced_session` returned `()`; its three semantic refusal
+  paths (#2170 stale generation, #5674 import cap, #6600 reserve) each bumped a
+  counter and returned silently, so the control handler answered `ok=true`, Go
+  recorded a success, and Go's BPF mirror row stayed behind for a session the
+  helper never took. Added `SyncedImportOutcome` + `SYNCED_IMPORT_REFUSED_PREFIX`
+  in Rust; the handler now answers `ok=false` with a reason token. Go classifies
+  the token into `dataplane.ErrSyncedImportRefused`, which drives the EXISTING
+  #5305 rollback but deliberately does NOT set the sticky mirror-failure flag
+  (that gates takeover-readiness, #5247, and a refusal comes from a healthy
+  helper). Refusals are counted separately as health debt and rendered in
+  `show chassis cluster information` when non-zero.
+- **File(s)**: userspace-dp/src/afxdp/ha/session_import.rs,
+  userspace-dp/src/afxdp/ha/mod.rs, userspace-dp/src/afxdp/mod.rs,
+  userspace-dp/src/server/handlers/sync_session.rs,
+  userspace-dp/src/afxdp/ha_tests.rs, userspace-dp/src/server/tests.rs,
+  pkg/dataplane/dataplane.go, pkg/dataplane/userspace/process_control.go,
+  pkg/dataplane/userspace/manager.go, pkg/dataplane/userspace/manager_sessions.go,
+  pkg/dataplane/userspace/synced_import_refusal_6785_test.go,
+  pkg/cluster/sync.go, pkg/cluster/sync_conn_gen.go, pkg/cluster/status.go,
+  pkg/cluster/synced_import_refusal_6785_test.go, docs/ha-failover-status.md,
+  _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -104455,3 +104455,13 @@ prose edit above them added. No diff falls in the new test body.
   pkg/cluster/sync.go, pkg/cluster/sync_conn_gen.go, pkg/cluster/status.go,
   pkg/cluster/synced_import_refusal_6785_test.go, docs/ha-failover-status.md,
   _Log.md
+- **Timestamp**: 2026-08-22
+- **Action**: #6785 round 2 — the mutation matrix found a GREEN cell: making a
+  semantic refusal set the sticky mirror-failure flag left the whole suite
+  green, because the only cells that could see it need CAP_BPF and SKIP on an
+  unprivileged runner. Extracted the classification into one shared
+  `noteSyncedMirrorFailureLocked` (the V4/V6 copies were a divergence waiting to
+  happen) and bound it with an unprivileged paired table plus a
+  comment-stripped single-sourcing check.
+- **File(s)**: pkg/dataplane/userspace/manager_sessions.go,
+  pkg/dataplane/userspace/synced_import_refusal_6785_test.go, _Log.md

--- a/docs/ha-failover-status.md
+++ b/docs/ha-failover-status.md
@@ -214,6 +214,47 @@ Standby node:
   → session is forwarding-ready in the helper's session table
 ```
 
+#### Import refusals and the split-truth rollback (#6785)
+
+The standby's install is transactional (#5305): the daemon snapshots the BPF
+session row, writes it, mirrors to the helper, and RESTORES the snapshot if the
+mirror fails — so a failed install never leaves a row for a session the helper
+does not hold.
+
+The helper can refuse an import for three SEMANTIC reasons, none of which are
+faults:
+
+| refusal | reason | issue |
+|---|---|---|
+| `stale-generation` | the stored entry is NEWER than the incoming one | #2170 |
+| `capacity` | the aggregate synced-import entry ceiling is full | #5674 |
+| `reserve` | the translated NAT tuple could not be reserved for this import | #6600 |
+
+Before #6785 all three returned `ok = true`, so the daemon recorded a success
+and left its BPF row behind — the exact split truth the transactional install
+exists to prevent, on the one failure class it could not observe. The helper now
+answers `ok = false` with a `synced-import-refused:<reason>` token, and the
+existing rollback runs.
+
+**A refusal is NOT a mirror failure, and the two must not be conflated.** A
+transport failure means the helper session socket is sick and gates HA
+takeover-readiness (#5247). A refusal comes from a HEALTHY helper answering
+correctly — the peer sent something stale, or this node is at its own ceiling.
+Gating takeover on a refusal would keep a working standby from ever taking over
+once a peer oversubscribed it, which is worse than the divergence being fixed.
+So a refusal:
+
+- rolls back the local BPF row (no split truth),
+- does **not** set the sticky session-mirror-failure flag,
+- does **not** count toward the session-sync `Errors` total,
+- counts into `Imports refused by helper`, rendered by
+  `show chassis cluster information` only when non-zero.
+
+That counter is health **debt**, not an error: the local state is consistent, but
+the PEER believes it synced a session this node does not hold, and only the
+peer's next full sync closes the gap. A persistently non-zero count means the
+peer is oversubscribing this node.
+
 ### Failover Flow (Target)
 
 ```

--- a/pkg/cluster/status.go
+++ b/pkg/cluster/status.go
@@ -469,6 +469,13 @@ func (m *Manager) FormatInformation() string {
 		if syncStats.ConfigsApplyFailed > 0 {
 			fmt.Fprintf(&b, "  Configs apply-failed:  %d\n", syncStats.ConfigsApplyFailed)
 		}
+		// #6785: surface the helper's semantic import refusals. Rendered only
+		// when non-zero, unlike the peer boot incarnation: zero is the ordinary
+		// state and carries no diagnostic value, whereas a non-zero count means
+		// the peer believes it synced sessions this node does not hold.
+		if syncStats.ImportsRefusedByHelper > 0 {
+			fmt.Fprintf(&b, "  Imports refused by helper: %d\n", syncStats.ImportsRefusedByHelper)
+		}
 		// #5084: the peer boot incarnation, rendered ALWAYS rather than only
 		// when non-empty. "none" is the operationally interesting value — it
 		// means the fence is in its fail-open state against this peer — and a

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -234,6 +234,22 @@ type SyncStats struct {
 	// prior config (M-2/#4151). A persistently-nonzero value means a standby is
 	// repeatedly failing to apply the peer's config — investigate divergence.
 	ConfigsApplyFailed atomic.Uint64
+	// ImportsRefusedByHelper counts synced-session installs the LOCAL userspace
+	// helper refused on semantic grounds (#6785) — a stale install generation, the
+	// aggregate synced-import ceiling, or a translated-tuple reservation refusal.
+	// Before #6785 the helper answered ok=true for all three, so these installs
+	// were counted as SessionsInstalled and their BPF mirror rows stayed behind
+	// for sessions the helper never took.
+	//
+	// This is health DEBT, not an error in the sense Errors carries: the helper is
+	// working correctly and the local BPF row has been rolled back, but the PEER
+	// still believes it synced a session this node does not hold, and only the
+	// peer's next full sync closes that gap. It is counted separately from Errors
+	// so a persistently oversubscribed standby is legible as such rather than
+	// looking like a flaky mirror socket, and it deliberately does NOT feed the
+	// takeover-readiness gate — refusing to fail over on a node whose peer is
+	// oversubscribing it would turn a capacity problem into an outage.
+	ImportsRefusedByHelper atomic.Uint64
 	// ConfigApplyNacksReceived counts #7328 config-apply nacks accepted from the
 	// peer — one per generation this node pushed that the peer refused or failed
 	// to apply. A nack for a superseded generation is ignored and not counted.
@@ -337,6 +353,7 @@ type SyncStatsSnapshot struct {
 	// field in the status render already uses.
 	PeerBootIncarnation        string
 	ConfigsApplyFailed         uint64
+	ImportsRefusedByHelper     uint64
 	IPsecSASent                uint64
 	IPsecSAReceived            uint64
 	IPsecSAStaleIgnored        uint64
@@ -1301,7 +1318,7 @@ func (s *SessionSync) Stats() SyncStatsSnapshot {
 		activeFabric = -1
 	}
 	s.mu.Unlock()
-	return SyncStatsSnapshot{SessionsSent: s.stats.SessionsSent.Load(), SessionsReceived: s.stats.SessionsReceived.Load(), SessionsInstalled: s.stats.SessionsInstalled.Load(), DeletesSent: s.stats.DeletesSent.Load(), DeletesReceived: s.stats.DeletesReceived.Load(), BulkSyncs: s.stats.BulkSyncs.Load(), ConfigsSent: s.stats.ConfigsSent.Load(), ConfigsReceived: s.stats.ConfigsReceived.Load(), ConfigsStaleIgnored: s.stats.ConfigsStaleIgnored.Load(), BulkPrimesWithoutIncarnation: s.stats.BulkPrimesWithoutIncarnation.Load(), PeerBootIncarnation: s.PeerBootIncarnation().String(), ConfigsDeadIncarnationDropped: s.stats.ConfigsDeadIncarnationDropped.Load(), ConfigsApplyFailed: s.stats.ConfigsApplyFailed.Load(), IPsecSASent: s.stats.IPsecSASent.Load(), IPsecSAReceived: s.stats.IPsecSAReceived.Load(), IPsecSAStaleIgnored: s.stats.IPsecSAStaleIgnored.Load(), DHCPLeasesSent: s.stats.DHCPLeasesSent.Load(), DHCPLeasesReceived: s.stats.DHCPLeasesReceived.Load(), DHCPLeasesStaleIgnored: s.stats.DHCPLeasesStaleIgnored.Load(), DHCPLeasesSeeded: s.stats.DHCPLeasesSeeded.Load(), FencesSent: s.stats.FencesSent.Load(), FencesReceived: s.stats.FencesReceived.Load(), Errors: s.stats.Errors.Load(), DeletesDropped: s.stats.DeletesDropped.Load(), DeletesStaleIgnored: s.stats.DeletesStaleIgnored.Load(), InstallsStaleIgnored: s.stats.InstallsStaleIgnored.Load(), SessionsStaleConfigIgnored: s.stats.SessionsStaleConfigIgnored.Load(), GenMapOverflow: s.stats.GenMapOverflow.Load(), PreAuthRejected: s.stats.PreAuthRejected.Load(), Connected: s.stats.Connected.Load(), ActiveFabric: activeFabric, BulkSyncStartTime: s.stats.BulkSyncStartTime.Load(), BulkSyncEndTime: s.stats.BulkSyncEndTime.Load(), BulkSyncSessions: s.stats.BulkSyncSessions.Load(), LastConfigSyncTime: s.stats.LastConfigSyncTime.Load(), LastConfigSyncSize: s.stats.LastConfigSyncSize.Load(), LastFenceSeq: s.stats.LastFenceSeq.Load(), LastFenceAckAt: s.stats.LastFenceAckAt.Load()}
+	return SyncStatsSnapshot{SessionsSent: s.stats.SessionsSent.Load(), SessionsReceived: s.stats.SessionsReceived.Load(), SessionsInstalled: s.stats.SessionsInstalled.Load(), DeletesSent: s.stats.DeletesSent.Load(), DeletesReceived: s.stats.DeletesReceived.Load(), BulkSyncs: s.stats.BulkSyncs.Load(), ConfigsSent: s.stats.ConfigsSent.Load(), ConfigsReceived: s.stats.ConfigsReceived.Load(), ConfigsStaleIgnored: s.stats.ConfigsStaleIgnored.Load(), BulkPrimesWithoutIncarnation: s.stats.BulkPrimesWithoutIncarnation.Load(), PeerBootIncarnation: s.PeerBootIncarnation().String(), ConfigsDeadIncarnationDropped: s.stats.ConfigsDeadIncarnationDropped.Load(), ConfigsApplyFailed: s.stats.ConfigsApplyFailed.Load(), ImportsRefusedByHelper: s.stats.ImportsRefusedByHelper.Load(), IPsecSASent: s.stats.IPsecSASent.Load(), IPsecSAReceived: s.stats.IPsecSAReceived.Load(), IPsecSAStaleIgnored: s.stats.IPsecSAStaleIgnored.Load(), DHCPLeasesSent: s.stats.DHCPLeasesSent.Load(), DHCPLeasesReceived: s.stats.DHCPLeasesReceived.Load(), DHCPLeasesStaleIgnored: s.stats.DHCPLeasesStaleIgnored.Load(), DHCPLeasesSeeded: s.stats.DHCPLeasesSeeded.Load(), FencesSent: s.stats.FencesSent.Load(), FencesReceived: s.stats.FencesReceived.Load(), Errors: s.stats.Errors.Load(), DeletesDropped: s.stats.DeletesDropped.Load(), DeletesStaleIgnored: s.stats.DeletesStaleIgnored.Load(), InstallsStaleIgnored: s.stats.InstallsStaleIgnored.Load(), SessionsStaleConfigIgnored: s.stats.SessionsStaleConfigIgnored.Load(), GenMapOverflow: s.stats.GenMapOverflow.Load(), PreAuthRejected: s.stats.PreAuthRejected.Load(), Connected: s.stats.Connected.Load(), ActiveFabric: activeFabric, BulkSyncStartTime: s.stats.BulkSyncStartTime.Load(), BulkSyncEndTime: s.stats.BulkSyncEndTime.Load(), BulkSyncSessions: s.stats.BulkSyncSessions.Load(), LastConfigSyncTime: s.stats.LastConfigSyncTime.Load(), LastConfigSyncSize: s.stats.LastConfigSyncSize.Load(), LastFenceSeq: s.stats.LastFenceSeq.Load(), LastFenceAckAt: s.stats.LastFenceAckAt.Load()}
 }
 
 // IsConnected reports whether a peer sync connection is currently established.

--- a/pkg/cluster/sync_conn_gen.go
+++ b/pkg/cluster/sync_conn_gen.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"errors"
 	"log/slog"
 	"sync/atomic"
 
@@ -553,6 +554,17 @@ func (s *SessionSync) installClusterSyncedV4(key dataplane.SessionKey, val datap
 		if val.IsReverse == 0 && s.OnForwardSessionInstalled != nil {
 			s.OnForwardSessionInstalled()
 		}
+	} else if errors.Is(err, dataplane.ErrSyncedImportRefused) {
+		// #6785: the helper REFUSED this import on semantic grounds and Go has
+		// already rolled its BPF mirror row back, so there is no split truth and
+		// no sick socket — do not bump Errors or fire the mirror-failure warning,
+		// which would make an oversubscribed-but-healthy standby read as a flaky
+		// mirror. Count it as its own debt instead: the peer still believes it
+		// synced a session this node does not hold.
+		s.stats.ImportsRefusedByHelper.Add(1)
+		slog.Debug("cluster sync: helper refused a synced-session import; the "+
+			"local mirror was rolled back and the peer holds a session this node does not",
+			"af", "v4", "err", err)
 	} else {
 		s.noteHelperMirrorResult("v4", &s.sessionMirrorWarnedV4, err)
 	}
@@ -589,6 +601,17 @@ func (s *SessionSync) installClusterSyncedV6(key dataplane.SessionKeyV6, val dat
 		if val.IsReverse == 0 && s.OnForwardSessionInstalled != nil {
 			s.OnForwardSessionInstalled()
 		}
+	} else if errors.Is(err, dataplane.ErrSyncedImportRefused) {
+		// #6785: the helper REFUSED this import on semantic grounds and Go has
+		// already rolled its BPF mirror row back, so there is no split truth and
+		// no sick socket — do not bump Errors or fire the mirror-failure warning,
+		// which would make an oversubscribed-but-healthy standby read as a flaky
+		// mirror. Count it as its own debt instead: the peer still believes it
+		// synced a session this node does not hold.
+		s.stats.ImportsRefusedByHelper.Add(1)
+		slog.Debug("cluster sync: helper refused a synced-session import; the "+
+			"local mirror was rolled back and the peer holds a session this node does not",
+			"af", "v6", "err", err)
 	} else {
 		s.noteHelperMirrorResult("v6", &s.sessionMirrorWarnedV6, err)
 	}

--- a/pkg/cluster/synced_import_refusal_6785_test.go
+++ b/pkg/cluster/synced_import_refusal_6785_test.go
@@ -1,0 +1,123 @@
+package cluster
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// TestHelperRefusalIsCountedAsDebtNotAsAnError6785 is a PAIRED test on the
+// receiver's install accounting: the same call site, two error shapes, opposite
+// classifications.
+//
+// A SEMANTIC refusal from the local userspace helper (#6785) means the helper
+// answered correctly and the Go layer already rolled its BPF mirror row back.
+// There is no split truth left and no sick socket, so it must NOT bump Errors or
+// fire noteHelperMirrorResult's sticky "failed to mirror synced session" warning
+// — that would make a standby whose PEER is oversubscribing it read as a flaky
+// mirror. It must bump ImportsRefusedByHelper instead, because the peer still
+// believes it synced a session this node does not hold and only the peer's next
+// full sync closes that gap.
+//
+// Any OTHER install failure keeps the pre-#6785 behaviour exactly. Without that
+// half, "a refusal does not bump Errors" would be satisfied by an implementation
+// that stopped counting install errors altogether.
+func TestHelperRefusalIsCountedAsDebtNotAsAnError6785(t *testing.T) {
+	forward := dataplane.SessionKey{Protocol: 6, SrcIP: [4]byte{10, 0, 0, 1}, DstIP: [4]byte{10, 0, 0, 2}, SrcPort: 1234, DstPort: 80}
+
+	t.Run("semantic-refusal", func(t *testing.T) {
+		dp := &mockSweepDP{
+			v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{},
+			failSetV4: map[dataplane.SessionKey]error{
+				forward: dataplane.ErrSyncedImportRefused,
+			},
+		}
+		ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
+		ss.installClusterSyncedV4(forward, dataplane.SessionValue{State: dataplane.SessStateEstablished})
+
+		if got := ss.stats.ImportsRefusedByHelper.Load(); got != 1 {
+			t.Fatalf("ImportsRefusedByHelper = %d, want 1 — a helper refusal that "+
+				"is counted nowhere is a silent divergence from the peer (#6785)", got)
+		}
+		if got := ss.stats.Errors.Load(); got != 0 {
+			t.Fatalf("Errors = %d, want 0 — a semantic refusal is the correct "+
+				"answer from a healthy helper, not a mirror error", got)
+		}
+		if got := ss.stats.SessionsInstalled.Load(); got != 0 {
+			t.Fatalf("SessionsInstalled = %d, want 0 — the session was refused", got)
+		}
+	})
+
+	t.Run("other-failure-keeps-the-error-accounting", func(t *testing.T) {
+		dp := &mockSweepDP{
+			v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{},
+			failSetV4: map[dataplane.SessionKey]error{
+				forward: errors.New("session table write failed"),
+			},
+		}
+		ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
+		ss.installClusterSyncedV4(forward, dataplane.SessionValue{State: dataplane.SessStateEstablished})
+
+		if got := ss.stats.Errors.Load(); got != 1 {
+			t.Fatalf("Errors = %d, want 1 — a non-refusal install failure must "+
+				"still be counted as an error", got)
+		}
+		if got := ss.stats.ImportsRefusedByHelper.Load(); got != 0 {
+			t.Fatalf("ImportsRefusedByHelper = %d, want 0 on a non-refusal failure", got)
+		}
+	})
+}
+
+// TestHelperRefusalIsCountedAsDebtNotAsAnErrorV6_6785 is the IPv6 twin. The two
+// install paths carry independently written copies of the classify/count
+// sequence, so a divergence between them is always a bug and binding only V4
+// would leave the V6 receiver reporting refusals as mirror errors.
+func TestHelperRefusalIsCountedAsDebtNotAsAnErrorV6_6785(t *testing.T) {
+	forward := dataplane.SessionKeyV6{Protocol: 6, SrcPort: 1234, DstPort: 80}
+	forward.SrcIP[15] = 1
+	forward.DstIP[15] = 2
+
+	dp := &mockSweepDP{
+		v6sessions: map[dataplane.SessionKeyV6]dataplane.SessionValueV6{},
+		failSetV6: map[dataplane.SessionKeyV6]error{
+			forward: dataplane.ErrSyncedImportRefused,
+		},
+	}
+	ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
+	ss.installClusterSyncedV6(forward, dataplane.SessionValueV6{State: dataplane.SessStateEstablished})
+
+	if got := ss.stats.ImportsRefusedByHelper.Load(); got != 1 {
+		t.Fatalf("v6 ImportsRefusedByHelper = %d, want 1", got)
+	}
+	if got := ss.stats.Errors.Load(); got != 0 {
+		t.Fatalf("v6 Errors = %d, want 0", got)
+	}
+}
+
+// TestRefusalDebtIsRenderedOnlyWhenNonZero6785 pins the operator surface. The
+// counter is health debt, so it has to reach `show chassis cluster information`
+// — a counter nothing renders is a variable, not debt. It is rendered only when
+// non-zero: zero is the ordinary state and a permanently-present "0" line is
+// noise an operator learns to skip past.
+func TestRefusalDebtIsRenderedOnlyWhenNonZero6785(t *testing.T) {
+	const line = "Imports refused by helper:"
+
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200, 1: 100}))
+	cfg.ControlInterface = "em0"
+	m.UpdateConfig(cfg)
+	ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+	m.SetSyncStats(ss)
+
+	if got := m.FormatInformation(); strings.Contains(got, line) {
+		t.Fatalf("the refusal line is rendered at zero:\n%s", got)
+	}
+	ss.stats.ImportsRefusedByHelper.Store(3)
+	out := m.FormatInformation()
+	if !strings.Contains(out, line+" 3") {
+		t.Fatalf("a non-zero refusal count is not rendered anywhere an operator "+
+			"can see it (want %q):\n%s", line+" 3", out)
+	}
+}

--- a/pkg/dataplane/dataplane.go
+++ b/pkg/dataplane/dataplane.go
@@ -23,6 +23,29 @@ import (
 // pkg/dataplane/runtime/import_canary_test.go (forbidden-import
 // canary) after #1528 deleted pkg/dataplane/dpdk and its
 // package-local test.
+// ErrSyncedImportRefused classifies an HA synced-session mirror that REACHED a
+// healthy userspace helper and was refused on SEMANTIC grounds (#6785): a stale
+// install generation (#2170), the aggregate synced-import ceiling (#5674), or a
+// translated-tuple reservation refusal (#6600).
+//
+// It lives here, not in pkg/dataplane/userspace, so the cluster session-sync
+// layer can classify the error it already receives without importing the
+// userspace manager (which would be an import cycle). The wire token that
+// produces it stays with the transport that parses it
+// (syncedImportRefusedPrefix, pkg/dataplane/userspace/process_control.go).
+//
+// The distinction it carries is load-bearing. A transport failure means the
+// helper session socket is sick and must gate HA takeover-readiness (#5247); a
+// refusal is the CORRECT answer from a healthy helper — the peer sent something
+// stale, or this node is at its own import ceiling. Marking the mirror unhealthy
+// for a refusal would latch a working standby "not takeover-ready" the first
+// time a peer oversubscribed it, which is a worse failure than the split truth
+// the refusal reporting exists to fix. What a refusal DOES owe is compensation
+// (the helper did not take the session, so the local BPF row is split truth) and
+// visibility, because the peer believes it synced a session this node does not
+// hold and only its next full sync closes that gap.
+var ErrSyncedImportRefused = errors.New("synced session import refused by helper")
+
 var ErrDPDKBackendRetired = errors.New(
 	"the DPDK dataplane backend has been retired; use " +
 		"'set system dataplane-type userspace' (see #1525)",

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -241,8 +241,23 @@ type Manager struct {
 	appliedSnapshot     appliedSnapshot
 	sessionMirrorFailed bool
 	sessionMirrorErr    string
-	deferWorkers        bool // skip worker spawn until NotifyLinkCycle
-	xskBoundNotified    bool // OnXSKBound fired at most once
+
+	// syncedImportRefusals counts HA synced-session imports the helper REFUSED
+	// on semantic grounds (#6785) — a stale install generation, the aggregate
+	// import ceiling, or a translated-tuple reservation refusal. Each one rolls
+	// back this node's BPF mirror row, so the counter is the health DEBT the
+	// rollback leaves behind: the peer believes it synced a session this node
+	// does not hold, and only the peer's next full sync closes that gap.
+	//
+	// It is deliberately NOT the sticky sessionMirrorFailed flag. That flag
+	// gates HA takeover-readiness (#5247) and means the session socket is sick;
+	// a refusal comes from a HEALTHY helper answering correctly. Counting it
+	// separately keeps the refusal visible without making a standby that a peer
+	// oversubscribed look unfit to take over. Atomic because it is read by the
+	// status path without m.mu.
+	syncedImportRefusals atomic.Uint64
+	deferWorkers         bool // skip worker spawn until NotifyLinkCycle
+	xskBoundNotified     bool // OnXSKBound fired at most once
 	// pendingWorkerArm records "generation debt" from a deferred-MAC
 	// re-apply that failed to publish (#5134). After a live RETH
 	// virtual-MAC change with no link cycle, the first apply publishes a

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/psaab/xpf/pkg/config"
+
+	"github.com/psaab/xpf/pkg/dataplane"
 )
 
 // syncHAWatchdogOnlyLocked syncs HA state to the helper from the periodic
@@ -385,6 +387,38 @@ func (m *Manager) recordSessionMirrorFailureLocked(err error) {
 // self-heals the state without a restart. No-op when the helper is not running:
 // syncSession{V4,V6}Locked returns nil without sending in that case, so there
 // was no real mirror to prove health (and stopLocked already cleared the flag).
+// noteSyncedMirrorFailureLocked accounts a FAILED synced-session mirror for the
+// cluster install paths (#6785). It is shared by SetClusterSyncedSessionV4 and
+// V6 rather than duplicated: the two entry points would otherwise carry two
+// copies of one health decision, and a divergence between them is always a bug
+// — an IPv6-only misclassification would disarm HA takeover on exactly the
+// deployments hardest to notice it on. Callers hold m.mu.
+//
+// The classification is the point. A SEMANTIC refusal (stale generation, import
+// cap, translated-tuple reserve) is the correct answer from a HEALTHY helper:
+// the peer sent something stale, or this node is at its own ceiling. It is
+// counted as debt — the peer believes it synced a session this node does not
+// hold — and the caller still compensates its BPF write, because the helper did
+// not take the session. But it must NOT set the sticky mirror-failure flag,
+// which gates HA takeover-readiness (#5247): latching a working standby "not
+// takeover-ready" the first time a peer oversubscribed it is a worse failure
+// than the split truth being fixed, and a silent one.
+//
+// A refusal does not take the SUCCESS path either. That flag means "a mirror
+// last succeeded", and a refusal is not a mirror; clearing a sticky failure on
+// the strength of a refused write would let a helper that refuses everything
+// read as recovered.
+func (m *Manager) noteSyncedMirrorFailureLocked(err error) {
+	if errors.Is(err, dataplane.ErrSyncedImportRefused) {
+		m.syncedImportRefusals.Add(1)
+		slog.Debug("userspace: helper refused a synced session import; "+
+			"rolling back the BPF mirror", "err", err)
+		return
+	}
+	m.recordSessionMirrorFailureLocked(err)
+	slog.Debug("userspace: session mirror failed", "err", err)
+}
+
 func (m *Manager) recordSessionMirrorSuccessLocked() {
 	if m.proc == nil {
 		return

--- a/pkg/dataplane/userspace/manager_sessions.go
+++ b/pkg/dataplane/userspace/manager_sessions.go
@@ -10,7 +10,6 @@ package userspace
 import (
 	"errors"
 	"fmt"
-	"log/slog"
 
 	"github.com/cilium/ebpf"
 	"github.com/psaab/xpf/pkg/dataplane"
@@ -140,28 +139,7 @@ func (m *Manager) SetClusterSyncedSessionV4(key dataplane.SessionKey, val datapl
 		return err
 	}
 	if err := m.syncSessionV4Locked("upsert", key, &installVal); err != nil {
-		// #6785: a SEMANTIC refusal (stale generation / import cap / translated
-		// tuple) is the correct answer from a HEALTHY helper, not a sick socket.
-		// It still has to compensate — the helper did not take the session, so
-		// the BPF row written above is split truth — but it must NOT set the
-		// sticky mirror-failure flag, which gates HA takeover-readiness (#5247).
-		// Latching a working standby "not takeover-ready" the first time a peer
-		// oversubscribed it would be a worse failure than the one being fixed.
-		//
-		// The success path below is deliberately NOT taken either. The flag
-		// means "a mirror last succeeded", and a refusal is not a mirror; the
-		// round trip proves the socket answered, but clearing a sticky failure
-		// on the strength of a refused write would let a helper that refuses
-		// everything read as recovered.
-		refused := errors.Is(err, dataplane.ErrSyncedImportRefused)
-		if refused {
-			m.syncedImportRefusals.Add(1)
-			slog.Debug("userspace: helper refused a synced session import; "+
-				"rolling back the BPF mirror", "err", err)
-		} else {
-			m.recordSessionMirrorFailureLocked(err)
-			slog.Debug("userspace: session mirror failed", "err", err)
-		}
+		m.noteSyncedMirrorFailureLocked(err)
 		compErr := m.restoreBPFSessionV4Locked(key, prior, hadPrior)
 		return errors.Join(
 			fmt.Errorf("mirror synced v4 session to userspace helper: %w", err),
@@ -298,28 +276,7 @@ func (m *Manager) SetClusterSyncedSessionV6(key dataplane.SessionKeyV6, val data
 		return err
 	}
 	if err := m.syncSessionV6Locked("upsert", key, &installVal); err != nil {
-		// #6785: a SEMANTIC refusal (stale generation / import cap / translated
-		// tuple) is the correct answer from a HEALTHY helper, not a sick socket.
-		// It still has to compensate — the helper did not take the session, so
-		// the BPF row written above is split truth — but it must NOT set the
-		// sticky mirror-failure flag, which gates HA takeover-readiness (#5247).
-		// Latching a working standby "not takeover-ready" the first time a peer
-		// oversubscribed it would be a worse failure than the one being fixed.
-		//
-		// The success path below is deliberately NOT taken either. The flag
-		// means "a mirror last succeeded", and a refusal is not a mirror; the
-		// round trip proves the socket answered, but clearing a sticky failure
-		// on the strength of a refused write would let a helper that refuses
-		// everything read as recovered.
-		refused := errors.Is(err, dataplane.ErrSyncedImportRefused)
-		if refused {
-			m.syncedImportRefusals.Add(1)
-			slog.Debug("userspace: helper refused a synced session import; "+
-				"rolling back the BPF mirror", "err", err)
-		} else {
-			m.recordSessionMirrorFailureLocked(err)
-			slog.Debug("userspace: session mirror failed", "err", err)
-		}
+		m.noteSyncedMirrorFailureLocked(err)
 		compErr := m.restoreBPFSessionV6Locked(key, prior, hadPrior)
 		return errors.Join(
 			fmt.Errorf("mirror synced v6 session to userspace helper: %w", err),

--- a/pkg/dataplane/userspace/manager_sessions.go
+++ b/pkg/dataplane/userspace/manager_sessions.go
@@ -140,8 +140,28 @@ func (m *Manager) SetClusterSyncedSessionV4(key dataplane.SessionKey, val datapl
 		return err
 	}
 	if err := m.syncSessionV4Locked("upsert", key, &installVal); err != nil {
-		m.recordSessionMirrorFailureLocked(err)
-		slog.Debug("userspace: session mirror failed", "err", err)
+		// #6785: a SEMANTIC refusal (stale generation / import cap / translated
+		// tuple) is the correct answer from a HEALTHY helper, not a sick socket.
+		// It still has to compensate — the helper did not take the session, so
+		// the BPF row written above is split truth — but it must NOT set the
+		// sticky mirror-failure flag, which gates HA takeover-readiness (#5247).
+		// Latching a working standby "not takeover-ready" the first time a peer
+		// oversubscribed it would be a worse failure than the one being fixed.
+		//
+		// The success path below is deliberately NOT taken either. The flag
+		// means "a mirror last succeeded", and a refusal is not a mirror; the
+		// round trip proves the socket answered, but clearing a sticky failure
+		// on the strength of a refused write would let a helper that refuses
+		// everything read as recovered.
+		refused := errors.Is(err, dataplane.ErrSyncedImportRefused)
+		if refused {
+			m.syncedImportRefusals.Add(1)
+			slog.Debug("userspace: helper refused a synced session import; "+
+				"rolling back the BPF mirror", "err", err)
+		} else {
+			m.recordSessionMirrorFailureLocked(err)
+			slog.Debug("userspace: session mirror failed", "err", err)
+		}
 		compErr := m.restoreBPFSessionV4Locked(key, prior, hadPrior)
 		return errors.Join(
 			fmt.Errorf("mirror synced v4 session to userspace helper: %w", err),
@@ -278,8 +298,28 @@ func (m *Manager) SetClusterSyncedSessionV6(key dataplane.SessionKeyV6, val data
 		return err
 	}
 	if err := m.syncSessionV6Locked("upsert", key, &installVal); err != nil {
-		m.recordSessionMirrorFailureLocked(err)
-		slog.Debug("userspace: session mirror failed", "err", err)
+		// #6785: a SEMANTIC refusal (stale generation / import cap / translated
+		// tuple) is the correct answer from a HEALTHY helper, not a sick socket.
+		// It still has to compensate — the helper did not take the session, so
+		// the BPF row written above is split truth — but it must NOT set the
+		// sticky mirror-failure flag, which gates HA takeover-readiness (#5247).
+		// Latching a working standby "not takeover-ready" the first time a peer
+		// oversubscribed it would be a worse failure than the one being fixed.
+		//
+		// The success path below is deliberately NOT taken either. The flag
+		// means "a mirror last succeeded", and a refusal is not a mirror; the
+		// round trip proves the socket answered, but clearing a sticky failure
+		// on the strength of a refused write would let a helper that refuses
+		// everything read as recovered.
+		refused := errors.Is(err, dataplane.ErrSyncedImportRefused)
+		if refused {
+			m.syncedImportRefusals.Add(1)
+			slog.Debug("userspace: helper refused a synced session import; "+
+				"rolling back the BPF mirror", "err", err)
+		} else {
+			m.recordSessionMirrorFailureLocked(err)
+			slog.Debug("userspace: session mirror failed", "err", err)
+		}
 		compErr := m.restoreBPFSessionV6Locked(key, prior, hadPrior)
 		return errors.Join(
 			fmt.Errorf("mirror synced v6 session to userspace helper: %w", err),

--- a/pkg/dataplane/userspace/process_control.go
+++ b/pkg/dataplane/userspace/process_control.go
@@ -8,7 +8,10 @@ import (
 	"io"
 	"net"
 	"path/filepath"
+	"strings"
 	"time"
+
+	"github.com/psaab/xpf/pkg/dataplane"
 )
 
 // MaxControlRequestBytes is the maximum serialized size, in bytes, of a
@@ -69,6 +72,15 @@ const (
 // resp.OK=false for this one request) is NOT wrapped with this sentinel, so the
 // batch keeps going: the helper is alive and only this request was refused.
 var errSessionHelperUnreachable = errors.New("session helper unreachable")
+
+// syncedImportRefusedPrefix is the machine-readable token the helper prefixes
+// onto a SEMANTIC synced-import refusal (SYNCED_IMPORT_REFUSED_PREFIX in
+// userspace-dp/src/afxdp/ha/session_import.rs). The two spellings must agree;
+// TestSyncedImportRefusedPrefixMatchesTheHelper asserts the AGREEMENT by
+// reading the Rust constant rather than pinning either side to a literal, so a
+// rename on either side reds instead of silently reclassifying every refusal as
+// a transport failure.
+const syncedImportRefusedPrefix = "synced-import-refused:"
 
 // sessionSyncDialTimeout and sessionSyncRoundtripDeadline bound a single
 // session-socket round-trip so a hung helper fails one mirror request in a few
@@ -256,6 +268,23 @@ func (m *Manager) requestSessionSyncLocked(req ControlRequest) error {
 	if !resp.OK {
 		if resp.Error == "" {
 			resp.Error = "unknown helper error"
+		}
+		// #6785: discriminate a SEMANTIC refusal from a transport failure. Both
+		// arrive as an error, but they mean opposite things about helper health:
+		// a transport failure says the session socket is sick and must gate
+		// takeover-readiness (#5247), while a refusal is the correct answer from
+		// a HEALTHY helper — the peer sent a stale generation, this node is at
+		// its own import ceiling, or the translated tuple could not be reserved.
+		// Treating a refusal as a mirror failure would latch a working standby
+		// "not takeover-ready" the first time a peer oversubscribed it, which is
+		// a worse failure than the split truth this reporting exists to fix.
+		//
+		// Matched on the helper's stable machine-readable prefix, never on the
+		// human-readable remainder, so the sentence can be reworded without
+		// silently reclassifying a refusal as a transport failure.
+		if strings.HasPrefix(resp.Error, syncedImportRefusedPrefix) {
+			return fmt.Errorf("%w: %s", dataplane.ErrSyncedImportRefused,
+				strings.TrimPrefix(resp.Error, syncedImportRefusedPrefix))
 		}
 		return errors.New(resp.Error)
 	}

--- a/pkg/dataplane/userspace/synced_import_refusal_6785_test.go
+++ b/pkg/dataplane/userspace/synced_import_refusal_6785_test.go
@@ -3,6 +3,7 @@ package userspace
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -313,5 +314,110 @@ func TestUnreachableHelperIsNotARefusal6785(t *testing.T) {
 	if !errors.Is(err, errSessionHelperUnreachable) {
 		t.Fatalf("transport failure lost its errSessionHelperUnreachable "+
 			"classification: %v", err)
+	}
+}
+
+// TestSyncedMirrorFailureAccounting6785 binds the health decision itself, with
+// NO BPF maps involved — and it exists because the two rollback cells above
+// SKIP without CAP_BPF.
+//
+// That skip is not cosmetic. A mutation that made a semantic refusal set the
+// sticky mirror-failure flag ran GREEN across the whole suite, because the only
+// cells that could see it were skipped. A guard that skips is indistinguishable
+// from a guard that passes, so the decision is now reachable on its own.
+//
+// It is a PAIRED table: the same function, three error shapes, and the flag must
+// move in opposite directions. The refusal row alone would be satisfied by an
+// implementation that never sets the flag at all — which silently deletes the
+// #5247 takeover gate.
+func TestSyncedMirrorFailureAccounting6785(t *testing.T) {
+	cases := []struct {
+		name            string
+		err             error
+		wantMirrorFail  bool
+		wantRefusalsAdd uint64
+	}{
+		{
+			name:            "semantic-refusal",
+			err:             fmt.Errorf("%w: capacity", dataplane.ErrSyncedImportRefused),
+			wantMirrorFail:  false,
+			wantRefusalsAdd: 1,
+		},
+		{
+			name:            "transport-failure",
+			err:             fmt.Errorf("%w: dial session socket", errSessionHelperUnreachable),
+			wantMirrorFail:  true,
+			wantRefusalsAdd: 0,
+		},
+		{
+			name:            "plain-helper-error",
+			err:             errors.New("session table write failed"),
+			wantMirrorFail:  true,
+			wantRefusalsAdd: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New()
+			m.proc = &exec.Cmd{Process: &os.Process{Pid: 1}}
+
+			m.noteSyncedMirrorFailureLocked(tc.err)
+
+			if m.sessionMirrorFailed != tc.wantMirrorFail {
+				t.Fatalf("sessionMirrorFailed = %v, want %v — this flag gates HA "+
+					"takeover-readiness (#5247): true on a refusal keeps a healthy "+
+					"standby from ever taking over once a peer oversubscribes it, "+
+					"and false on a real failure deletes the gate",
+					m.sessionMirrorFailed, tc.wantMirrorFail)
+			}
+			if got := m.syncedImportRefusals.Load(); got != tc.wantRefusalsAdd {
+				t.Fatalf("syncedImportRefusals = %d, want %d", got, tc.wantRefusalsAdd)
+			}
+		})
+	}
+}
+
+// TestSyncedMirrorFailureAccountingIsSingleSourced6785 pins that both cluster
+// install entry points route their failure accounting through the ONE helper
+// above, rather than carrying their own copy of the classification.
+//
+// This is a source check, and it is deliberate: the behavioural cells for V6
+// need BPF maps and skip here, so "V6 classifies the same way" is currently
+// unprovable behaviourally on an unprivileged runner. A divergence between the
+// two copies is always a bug — an IPv6-only misclassification would disarm HA
+// takeover on exactly the deployments least likely to notice — so the agreement
+// is bound structurally instead of left unbound.
+//
+// Comments are stripped before matching: the doc comment on the helper names
+// both functions, and a gate satisfiable by its own documentation proves
+// nothing.
+func TestSyncedMirrorFailureAccountingIsSingleSourced6785(t *testing.T) {
+	src, err := os.ReadFile("manager_sessions.go")
+	if err != nil {
+		t.Fatalf("read manager_sessions.go: %v", err)
+	}
+	var code strings.Builder
+	for _, line := range strings.Split(string(src), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			code.WriteString("\n")
+			continue
+		}
+		code.WriteString(line)
+		code.WriteString("\n")
+	}
+	body := code.String()
+
+	if n := strings.Count(body, "m.noteSyncedMirrorFailureLocked(err)"); n != 2 {
+		t.Fatalf("noteSyncedMirrorFailureLocked is called %d times, want exactly "+
+			"2 (the v4 and v6 cluster installs) — a path that accounts its own "+
+			"mirror failure has its own copy of the #5247 classification", n)
+	}
+	// The classification must not ALSO appear inline: a call plus a surviving
+	// inline copy is the divergence this guards against.
+	if n := strings.Count(body, "m.recordSessionMirrorFailureLocked("); n != 0 {
+		t.Fatalf("recordSessionMirrorFailureLocked is called %d times directly "+
+			"from manager_sessions.go, want 0 — the cluster install paths must "+
+			"go through noteSyncedMirrorFailureLocked so the refusal "+
+			"classification cannot be bypassed", n)
 	}
 }

--- a/pkg/dataplane/userspace/synced_import_refusal_6785_test.go
+++ b/pkg/dataplane/userspace/synced_import_refusal_6785_test.go
@@ -1,0 +1,317 @@
+package userspace
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// newAnsweringManager6785 builds a Manager whose helper session socket is LIVE
+// and answers every request with the supplied response. That is the shape the
+// #6785 discrimination turns on: the socket round-trips fine, so it is NOT the
+// unreachable-helper case newMirrorFailManager5305 produces — the failure comes
+// back IN the answer.
+func newAnsweringManager6785(t *testing.T, resp ControlResponse) *Manager {
+	t.Helper()
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("RemoveMemlock: %v", err)
+	}
+	dir := t.TempDir()
+	sessionSock := filepath.Join(dir, "userspace-dp-sessions.sock")
+	ln, err := net.Listen("unix", sessionSock)
+	if err != nil {
+		t.Fatalf("listen session socket: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				var req ControlRequest
+				_ = json.NewDecoder(conn).Decode(&req)
+				_ = json.NewEncoder(conn).Encode(resp)
+			}()
+		}
+	}()
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: 1}}
+	m.cfg.ControlSocket = filepath.Join(dir, "control.sock")
+	injectSessionMaps(t, m)
+	return m
+}
+
+// TestSyncedImportRefusalRollsBackWithoutGatingTakeover6785 is the #6785
+// contract on the Go side, and it is a PAIRED test: the same call site, two
+// helper answers, opposite health outcomes.
+//
+// A SEMANTIC refusal (`ok=false` with the helper's refusal token) must:
+//   - roll the BPF mirror row back, because the helper did NOT take the session
+//     and a row left behind is the split truth #5305 exists to prevent;
+//   - NOT set sessionMirrorFailed, because that gates HA takeover-readiness
+//     (#5247) and the helper is healthy — it answered correctly;
+//   - be counted as its own debt.
+//
+// A TRANSPORT-shaped failure (`ok=false` with any other message) must do the
+// opposite on the health flag. Without that half, "does not set the flag on a
+// refusal" would be satisfied by an implementation that never sets the flag at
+// all, which silently removes the #5247 gate.
+func TestSyncedImportRefusalRollsBackWithoutGatingTakeover6785(t *testing.T) {
+	key := rollbackKeyV4()
+	val := dataplane.SessionValue{IsReverse: 0, IngressZone: 1, EgressZone: 2}
+
+	t.Run("semantic-refusal", func(t *testing.T) {
+		m := newAnsweringManager6785(t, ControlResponse{
+			OK:    false,
+			Error: syncedImportRefusedPrefix + "capacity",
+		})
+
+		err := m.SetClusterSyncedSessionV4(key, val)
+		if err == nil {
+			t.Fatal("SetClusterSyncedSessionV4() = nil after the helper REFUSED " +
+				"the import — the caller records a success and keeps a BPF row " +
+				"for a session the helper never took (#6785)")
+		}
+		if !errors.Is(err, dataplane.ErrSyncedImportRefused) {
+			t.Fatalf("error does not classify as a semantic refusal: %v", err)
+		}
+		if _, getErr := m.bpfShim.GetSessionV4(key); !errors.Is(getErr, ebpf.ErrKeyNotExist) {
+			t.Fatalf("BPF row survived a REFUSED import: GetSessionV4 err = %v, "+
+				"want ErrKeyNotExist — this is the split truth", getErr)
+		}
+		if m.sessionMirrorFailed {
+			t.Fatal("sessionMirrorFailed = true after a SEMANTIC refusal: the " +
+				"helper answered correctly, so gating HA takeover-readiness on " +
+				"this would keep a working standby from ever taking over once a " +
+				"peer oversubscribed it (#5247)")
+		}
+		if got := m.syncedImportRefusals.Load(); got != 1 {
+			t.Fatalf("syncedImportRefusals = %d, want 1 — a rolled-back import "+
+				"that is counted nowhere is not health debt, it is a silent drop", got)
+		}
+	})
+
+	t.Run("non-refusal-failure-still-gates", func(t *testing.T) {
+		m := newAnsweringManager6785(t, ControlResponse{
+			OK:    false,
+			Error: "session table write failed",
+		})
+
+		err := m.SetClusterSyncedSessionV4(key, val)
+		if err == nil {
+			t.Fatal("SetClusterSyncedSessionV4() = nil on a helper failure")
+		}
+		if errors.Is(err, dataplane.ErrSyncedImportRefused) {
+			t.Fatalf("an UNPREFIXED helper error was classified as a semantic "+
+				"refusal: %v — the classifier is matching too broadly and every "+
+				"real mirror failure would stop gating takeover", err)
+		}
+		if !m.sessionMirrorFailed {
+			t.Fatal("sessionMirrorFailed = false on a non-refusal helper " +
+				"failure — the #5247 takeover gate is gone")
+		}
+		if got := m.syncedImportRefusals.Load(); got != 0 {
+			t.Fatalf("syncedImportRefusals = %d on a non-refusal failure, want 0", got)
+		}
+	})
+}
+
+// TestSyncedImportRefusalRollsBackWithoutGatingTakeoverV6_6785 is the IPv6 twin.
+// The two entry points carry independently written copies of the classify /
+// compensate / count sequence, so a divergence between them is always a bug and
+// each needs its own cell — binding only V4 would let V6 keep reporting success.
+func TestSyncedImportRefusalRollsBackWithoutGatingTakeoverV6_6785(t *testing.T) {
+	key := rollbackKeyV6()
+	val := dataplane.SessionValueV6{IsReverse: 0, IngressZone: 1, EgressZone: 2}
+
+	m := newAnsweringManager6785(t, ControlResponse{
+		OK:    false,
+		Error: syncedImportRefusedPrefix + "stale-generation",
+	})
+
+	err := m.SetClusterSyncedSessionV6(key, val)
+	if err == nil {
+		t.Fatal("SetClusterSyncedSessionV6() = nil after the helper REFUSED the import (#6785)")
+	}
+	if !errors.Is(err, dataplane.ErrSyncedImportRefused) {
+		t.Fatalf("v6 error does not classify as a semantic refusal: %v", err)
+	}
+	if _, getErr := m.bpfShim.GetSessionV6(key); !errors.Is(getErr, ebpf.ErrKeyNotExist) {
+		t.Fatalf("v6 BPF row survived a REFUSED import: err = %v, want ErrKeyNotExist", getErr)
+	}
+	if m.sessionMirrorFailed {
+		t.Fatal("v6: sessionMirrorFailed = true after a semantic refusal")
+	}
+	if got := m.syncedImportRefusals.Load(); got != 1 {
+		t.Fatalf("v6: syncedImportRefusals = %d, want 1", got)
+	}
+}
+
+// rustRefusalPrefixRe extracts the helper's SYNCED_IMPORT_REFUSED_PREFIX literal.
+var rustRefusalPrefixRe = regexp.MustCompile(
+	`(?m)^pub const SYNCED_IMPORT_REFUSED_PREFIX:\s*&str\s*=\s*"([^"]*)"\s*;`)
+
+// TestSyncedImportRefusedPrefixMatchesTheHelper6785 asserts the AGREEMENT
+// between the Go classifier's token and the Rust constant the helper actually
+// emits, by READING the Rust source rather than pinning either side to a
+// literal.
+//
+// Pinning would encode which side is trusted, and here neither is: if the Rust
+// constant is renamed and Go keeps a hard-coded string, every semantic refusal
+// silently reclassifies as a transport failure — which sets sessionMirrorFailed
+// and permanently disarms HA takeover on a healthy standby. That failure is
+// worse than the bug #6785 fixes, and it is invisible: both sides compile, all
+// unit tests on either side pass, and the only symptom is a standby that never
+// takes over.
+func TestSyncedImportRefusedPrefixMatchesTheHelper6785(t *testing.T) {
+	src, err := os.ReadFile("../../../userspace-dp/src/afxdp/ha/session_import.rs")
+	if err != nil {
+		t.Fatalf("read the helper source that owns the refusal token: %v", err)
+	}
+	// Strip line comments first: the doc comment above the constant quotes the
+	// token, and a gate satisfiable by its own documentation proves nothing.
+	var stripped strings.Builder
+	for _, line := range strings.Split(string(src), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			stripped.WriteString("\n")
+			continue
+		}
+		stripped.WriteString(line)
+		stripped.WriteString("\n")
+	}
+	match := rustRefusalPrefixRe.FindStringSubmatch(stripped.String())
+	if match == nil {
+		t.Fatal("SYNCED_IMPORT_REFUSED_PREFIX not found in the helper source — " +
+			"it was renamed or removed, so Go can no longer tell a semantic " +
+			"refusal from a transport failure and every refusal would disarm " +
+			"HA takeover (#6785)")
+	}
+	if match[1] != syncedImportRefusedPrefix {
+		t.Fatalf("refusal token disagreement: helper emits %q, Go matches %q — "+
+			"every refusal would be misclassified as a transport failure",
+			match[1], syncedImportRefusedPrefix)
+	}
+}
+
+// TestHelperErrorClassification6785 binds the discriminator itself, at the
+// transport, with NO BPF maps involved.
+//
+// This cell exists because the two rollback cells above need real BPF session
+// maps and SKIP without CAP_BPF — a guard that skips is indistinguishable from a
+// guard that passes, and the classification is the decision every other
+// behaviour in #6785 hangs off: get it wrong in the permissive direction and a
+// real mirror failure stops gating HA takeover; get it wrong in the strict
+// direction and every capacity refusal permanently disarms a healthy standby.
+//
+// The table's middle row is the load-bearing one: an `ok=false` answer whose
+// message merely CONTAINS the token, without starting with it, must NOT
+// classify. A `strings.Contains` implementation passes the other two rows.
+func TestHelperErrorClassification6785(t *testing.T) {
+	cases := []struct {
+		name        string
+		helperError string
+		wantRefusal bool
+	}{
+		{"refusal-capacity", syncedImportRefusedPrefix + "capacity", true},
+		{"refusal-stale", syncedImportRefusedPrefix + "stale-generation", true},
+		{"refusal-reserve", syncedImportRefusedPrefix + "reserve", true},
+		{"token-not-at-the-start", "write failed while handling " + syncedImportRefusedPrefix + "capacity", false},
+		{"plain-helper-error", "session table write failed", false},
+		{"unknown-operation", "unknown session sync operation frobnicate", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			sock := filepath.Join(dir, "userspace-dp-sessions.sock")
+			ln, err := net.Listen("unix", sock)
+			if err != nil {
+				t.Fatalf("listen: %v", err)
+			}
+			defer ln.Close()
+			go func() {
+				for {
+					conn, aerr := ln.Accept()
+					if aerr != nil {
+						return
+					}
+					go func() {
+						defer conn.Close()
+						var req ControlRequest
+						_ = json.NewDecoder(conn).Decode(&req)
+						_ = json.NewEncoder(conn).Encode(ControlResponse{
+							OK: false, Error: tc.helperError,
+						})
+					}()
+				}
+			}()
+
+			m := New()
+			m.proc = &exec.Cmd{Process: &os.Process{Pid: 1}}
+			m.cfg.ControlSocket = filepath.Join(dir, "control.sock")
+
+			err = m.requestSessionSync(ControlRequest{
+				Type:           "sync_session",
+				SuppressStatus: true,
+				SessionSync:    &SessionSyncRequest{Operation: "upsert"},
+			})
+			if err == nil {
+				t.Fatal("requestSessionSync() = nil on an ok=false answer")
+			}
+			if got := errors.Is(err, dataplane.ErrSyncedImportRefused); got != tc.wantRefusal {
+				t.Fatalf("classified as a semantic refusal = %v, want %v (err %v)",
+					got, tc.wantRefusal, err)
+			}
+			// A refusal must keep its reason readable; dropping it would leave
+			// an operator unable to tell a capacity problem from a stale peer.
+			if tc.wantRefusal {
+				reason := strings.TrimPrefix(tc.helperError, syncedImportRefusedPrefix)
+				if !strings.Contains(err.Error(), reason) {
+					t.Fatalf("refusal error %q lost the reason %q", err, reason)
+				}
+			}
+		})
+	}
+}
+
+// TestUnreachableHelperIsNotARefusal6785 is the transport half of the same
+// discriminator: with nothing listening, the round trip must classify as
+// errSessionHelperUnreachable and NOT as a semantic refusal. Without this the
+// classifier could return the refusal sentinel for every failure and the two
+// rollback cells above — which skip without CAP_BPF — would be the only thing
+// standing between that and a standby that never gates takeover.
+func TestUnreachableHelperIsNotARefusal6785(t *testing.T) {
+	dir := t.TempDir()
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: 1}}
+	m.cfg.ControlSocket = filepath.Join(dir, "control.sock")
+
+	err := m.requestSessionSync(ControlRequest{
+		Type:           "sync_session",
+		SuppressStatus: true,
+		SessionSync:    &SessionSyncRequest{Operation: "upsert"},
+	})
+	if err == nil {
+		t.Fatal("requestSessionSync() = nil with no helper listening")
+	}
+	if errors.Is(err, dataplane.ErrSyncedImportRefused) {
+		t.Fatalf("an UNREACHABLE helper classified as a semantic refusal: %v — "+
+			"a down helper would stop gating HA takeover-readiness (#5247)", err)
+	}
+	if !errors.Is(err, errSessionHelperUnreachable) {
+		t.Fatalf("transport failure lost its errSessionHelperUnreachable "+
+			"classification: %v", err)
+	}
+}

--- a/userspace-dp/src/afxdp/ha/mod.rs
+++ b/userspace-dp/src/afxdp/ha/mod.rs
@@ -10,6 +10,9 @@ use super::*;
 mod state;
 mod export;
 mod session_import;
+// #6785: the typed synced-import outcome and its refusal-token prefix are read
+// by the control handler, so they must escape this private module.
+pub use session_import::{SyncedImportOutcome, SYNCED_IMPORT_REFUSED_PREFIX};
 mod tunnel_purge;
 
 pub(crate) use self::export::{AllSessionsExport, OwnerRgExportWait};

--- a/userspace-dp/src/afxdp/ha/session_import.rs
+++ b/userspace-dp/src/afxdp/ha/session_import.rs
@@ -1,5 +1,57 @@
 use crate::afxdp::*;
 
+/// The outcome of an HA synced-session import (#6785).
+///
+/// `upsert_synced_session` used to return `()`. It has three SEMANTIC refusal
+/// paths — a stale generation (#2170), the aggregate import cap (#5674), and a
+/// translated-tuple reservation refusal (#6600) — and each one `return`ed
+/// silently after bumping a counter. The control handler therefore answered
+/// `ok = true`, so Go's `SetClusterSyncedSessionV4`/`V6` reported success and
+/// LEFT its BPF mirror row in place for a session the helper had refused. That
+/// is exactly the split truth #5305's transactional install exists to prevent —
+/// its rollback machinery was already built and simply never reached, because
+/// the only failure it could observe was an IPC error.
+///
+/// Reporting the refusal is therefore the whole fix on the helper side: the Go
+/// compensation already exists.
+///
+/// The distinction between `Rejected*` and an IPC/transport failure matters on
+/// the Go side and must not be collapsed. A transport failure means the session
+/// socket is unhealthy and gates takeover-readiness (#5247); a semantic refusal
+/// is an EXPECTED answer from a healthy helper (the peer sent something stale,
+/// or this node is at its own ceiling) and marking the mirror unhealthy for it
+/// would block failover on a node that is working correctly. Go discriminates on
+/// the `SYNCED_IMPORT_REFUSED_PREFIX` token below.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncedImportOutcome {
+    /// The entry was published (new key, or a replace of an existing one).
+    Applied,
+    /// #2170: a strictly-older generation than the stored entry.
+    RejectedStaleGeneration,
+    /// #5674: the aggregate synced-import entry ceiling is full.
+    RejectedCapacity,
+    /// #6600: the translated NAT tuple could not be reserved for this import.
+    RejectedReserve,
+}
+
+/// The machine-readable prefix every semantic refusal carries in the control
+/// response's `error` field. Go matches on THIS, not on the human-readable
+/// remainder, so the sentence can be reworded without silently reclassifying a
+/// refusal as a transport failure.
+pub const SYNCED_IMPORT_REFUSED_PREFIX: &str = "synced-import-refused:";
+
+impl SyncedImportOutcome {
+    /// The stable reason token, or `None` when the import applied.
+    pub fn refusal_reason(self) -> Option<&'static str> {
+        match self {
+            SyncedImportOutcome::Applied => None,
+            SyncedImportOutcome::RejectedStaleGeneration => Some("stale-generation"),
+            SyncedImportOutcome::RejectedCapacity => Some("capacity"),
+            SyncedImportOutcome::RejectedReserve => Some("reserve"),
+        }
+    }
+}
+
 impl crate::afxdp::Coordinator {
     /// #5674: this appliance's aggregate synced-session ENTRY ceiling. The
     /// LOGICAL ceiling is `worker_count * DEFAULT_MAX_SESSIONS` (each worker
@@ -57,6 +109,7 @@ impl crate::afxdp::Coordinator {
     /// per-prefix allocator), so a session can be admissible to one and not the
     /// other. Leaving a half-taken reservation behind would be a leak no worker
     /// ever releases, because no session gets published to reap.
+
     fn reserve_synced_translation(&self, entry: &SyncedSessionEntry) -> bool {
         let now_ns = monotonic_nanos();
         let zones = crate::afxdp::session_glue::synced_source_nat_zone_pair(
@@ -92,7 +145,7 @@ impl crate::afxdp::Coordinator {
         true
     }
 
-    pub fn upsert_synced_session(&self, entry: SyncedSessionEntry) {
+    pub fn upsert_synced_session(&self, entry: SyncedSessionEntry) -> SyncedImportOutcome {
         let now_secs = monotonic_nanos() / 1_000_000_000;
         let ha_state = self.ha.rg_runtime.load();
         // #5154: read the stored entry AND the map length under ONE RECOVERED
@@ -138,7 +191,7 @@ impl crate::afxdp::Coordinator {
             self.sessions
                 .install_stale_ignored
                 .fetch_add(1, Ordering::Relaxed);
-            return;
+            return SyncedImportOutcome::RejectedStaleGeneration;
         }
         // #5674: aggregate synced-import admission bound. Locally-created
         // sessions are capped per worker at `DEFAULT_MAX_SESSIONS`
@@ -199,7 +252,7 @@ impl crate::afxdp::Coordinator {
                 self.sessions
                     .import_cap_drops
                     .fetch_add(1, Ordering::Relaxed);
-                return;
+                return SyncedImportOutcome::RejectedCapacity;
             }
         }
         let reverse_entry = if !entry.metadata.is_reverse {
@@ -252,7 +305,7 @@ impl crate::afxdp::Coordinator {
             self.sessions
                 .import_reserve_refused
                 .fetch_add(1, Ordering::Relaxed);
-            return;
+            return SyncedImportOutcome::RejectedReserve;
         }
         publish_shared_session(
             &self.sessions.synced,
@@ -364,6 +417,7 @@ impl crate::afxdp::Coordinator {
                 pending.push_back(WorkerCommand::UpsertSynced(reverse.clone()));
             }
         }
+        SyncedImportOutcome::Applied
     }
 
     pub fn delete_synced_session(&self, key: SessionKey) {
@@ -515,7 +569,7 @@ impl crate::afxdp::Coordinator {
             policy_counter_idx: 0,
             policy_counter: None,
         };
-        self.upsert_synced_session(SyncedSessionEntry {
+        let _ = self.upsert_synced_session(SyncedSessionEntry {
             key,
             decision: SessionDecision {
                 resolution,

--- a/userspace-dp/src/afxdp/ha_tests.rs
+++ b/userspace-dp/src/afxdp/ha_tests.rs
@@ -2636,3 +2636,107 @@ fn coordinator_pre_publish_reserve_uses_the_workers_zone_pair_6600() {
          fall-through), which no worker will ever release"
     );
 }
+
+// #6785: `upsert_synced_session` used to return `()`. Its three SEMANTIC refusal
+// paths each bumped a counter and returned silently, so the control handler
+// answered `ok = true`, Go recorded a success, and Go's BPF mirror row stayed
+// behind for a session this helper never took — the split truth #5305's
+// transactional install already knows how to compensate but could not, because
+// the only failure it could observe was an IPC error.
+//
+// These cells bind the OUTCOME, not the side effects. The existing tests already
+// assert "the entry was not stored" and "the counter went up"; an implementation
+// that keeps both of those and still returns `Applied` passes every one of them
+// and reproduces the bug exactly. Each cell here therefore pairs a refusal with
+// the SUCCESS case on the same coordinator, so "returns a refusal" cannot be
+// satisfied by returning a refusal unconditionally.
+#[test]
+fn upsert_synced_session_reports_stale_generation_refusal_6785() {
+    let coordinator = Coordinator::new();
+
+    assert_eq!(
+        coordinator.upsert_synced_session(synced_entry_with_generation(2)),
+        SyncedImportOutcome::Applied,
+        "a first install must report Applied"
+    );
+    assert_eq!(
+        coordinator.upsert_synced_session(synced_entry_with_generation(1)),
+        SyncedImportOutcome::RejectedStaleGeneration,
+        "a strictly-older generation is refused (#2170) and the caller must be \
+         told, or Go keeps a BPF row for a session this helper did not take"
+    );
+    // Positive control on the SAME coordinator: the refusal is selective, not a
+    // blanket "reject everything after the first install".
+    assert_eq!(
+        coordinator.upsert_synced_session(synced_entry_with_generation(3)),
+        SyncedImportOutcome::Applied,
+        "a NEWER generation must still report Applied"
+    );
+}
+
+#[test]
+fn upsert_synced_session_reports_capacity_refusal_6785() {
+    let mut coordinator = Coordinator::new();
+    const LOGICAL_CEILING: u16 = 2;
+    coordinator.synced_import_cap_override = LOGICAL_CEILING as usize;
+    let commands = Arc::new(Mutex::new(VecDeque::new()));
+    coordinator.workers.records.insert(
+        0,
+        WorkerRuntimeRecord::for_test(test_worker_handle(commands.clone())),
+    );
+
+    // A full symmetric-peer logical set fits and must all report Applied — the
+    // control that stops this cell from passing on "always RejectedCapacity".
+    for i in 0..LOGICAL_CEILING {
+        assert_eq!(
+            coordinator.upsert_synced_session(synced_entry_port(1000 + i, 0)),
+            SyncedImportOutcome::Applied,
+            "forward session {i} is within the ceiling and must report Applied"
+        );
+    }
+    assert_eq!(
+        coordinator.upsert_synced_session(synced_entry_port(2000, 0)),
+        SyncedImportOutcome::RejectedCapacity,
+        "a NEW forward past the entry ceiling is drop-newest rejected (#5674) \
+         and the caller must be told — otherwise the peer's session count and \
+         this node's diverge with nothing reporting it"
+    );
+    // A REPLACE of an already-admitted key does not grow the map and must still
+    // be accepted at the ceiling, so the refusal is bounded to what it claims.
+    assert_eq!(
+        coordinator.upsert_synced_session(synced_entry_port(1000, 0)),
+        SyncedImportOutcome::Applied,
+        "a REPLACE at the ceiling must still report Applied — refusing it would \
+         stop an in-flight synced session from refreshing"
+    );
+}
+
+// The refusal REASON tokens are part of the control-plane contract: Go strips
+// the prefix and surfaces the remainder to the operator, and it is the only way
+// to tell a capacity problem from a stale peer. Bind that Applied carries no
+// token and that the three refusals carry distinct ones — collapsing them to a
+// single token would compile, pass every behavioural cell above, and leave an
+// operator unable to tell which of three very different conditions they are in.
+#[test]
+fn synced_import_outcome_reason_tokens_are_distinct_6785() {
+    assert_eq!(SyncedImportOutcome::Applied.refusal_reason(), None);
+    let tokens = [
+        SyncedImportOutcome::RejectedStaleGeneration
+            .refusal_reason()
+            .expect("stale generation is a refusal"),
+        SyncedImportOutcome::RejectedCapacity
+            .refusal_reason()
+            .expect("capacity is a refusal"),
+        SyncedImportOutcome::RejectedReserve
+            .refusal_reason()
+            .expect("reserve is a refusal"),
+    ];
+    for (i, a) in tokens.iter().enumerate() {
+        assert!(!a.is_empty(), "token {i} is empty");
+        for (j, b) in tokens.iter().enumerate() {
+            if i != j {
+                assert_ne!(a, b, "refusal tokens {i} and {j} collide: {a}");
+            }
+        }
+    }
+}

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -86,6 +86,9 @@ mod frame;
 #[path = "gre.rs"]
 mod gre;
 mod ha;
+// #6785: the control handler needs the synced-import outcome type and its
+// refusal-token prefix.
+pub use ha::{SyncedImportOutcome, SYNCED_IMPORT_REFUSED_PREFIX};
 #[path = "icmp.rs"]
 mod icmp;
 mod icmp_embed;

--- a/userspace-dp/src/server/handlers/sync_session.rs
+++ b/userspace-dp/src/server/handlers/sync_session.rs
@@ -4,6 +4,7 @@
 
 use super::super::helpers::{build_synced_session_entry, build_synced_session_key};
 use super::super::ServerState;
+use crate::afxdp::SYNCED_IMPORT_REFUSED_PREFIX;
 use crate::{ControlResponse, SessionSyncRequest};
 
 pub(super) fn handle(
@@ -19,7 +20,26 @@ pub(super) fn handle(
     match sync_req.operation.as_str() {
         "upsert" => match build_synced_session_entry(&sync_req, guard.afxdp.zone_name_to_id_ref()) {
             Ok(entry) => {
-                guard.afxdp.upsert_synced_session(entry);
+                // #6785: a SEMANTIC refusal (stale generation / import cap /
+                // translated-tuple reserve) used to return `()` and leave
+                // `response.ok` true, so Go recorded a success and kept the BPF
+                // mirror row for a session this helper never took — the split
+                // truth #5305's transactional install already knows how to
+                // compensate, but could not, because the only failure it could
+                // see was an IPC error. Report the refusal so that rollback runs.
+                //
+                // The reason token is prefixed so Go can tell a refusal from a
+                // transport failure. That distinction is load-bearing, not
+                // cosmetic: a transport failure means the session socket is sick
+                // and gates takeover-readiness (#5247), whereas a refusal is the
+                // correct answer from a HEALTHY helper and must not block
+                // failover on a node that is working.
+                let outcome = guard.afxdp.upsert_synced_session(entry);
+                if let Some(reason) = outcome.refusal_reason() {
+                    response.ok = false;
+                    response.error =
+                        format!("{SYNCED_IMPORT_REFUSED_PREFIX}{reason}");
+                }
             }
             Err(err) => {
                 response.ok = false;

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -3977,3 +3977,81 @@ fn failed_queue_reconcile_restores_every_binding_on_the_queue_6750() {
          whole table",
     );
 }
+
+// #6785: THE WIRING CELL. `upsert_synced_session` now returns a typed outcome,
+// but a typed outcome the handler discards is exactly the bug: the three
+// semantic refusal paths already bumped counters and returned, and the control
+// response still said `ok = true`, so Go recorded a success and kept a BPF
+// mirror row for a session this helper never took.
+//
+// The Coordinator-level cells in ha_tests.rs prove the outcome is COMPUTED. They
+// stay green if this handler drops it on the floor. This drives the real
+// `handle_stream` dispatcher and asserts what actually goes back on the wire.
+//
+// The refusal is provoked through the aggregate import cap because it is the one
+// refusal reachable from a single request pair with no worker fan-out: set the
+// logical ceiling to zero-plus-one entry's worth and push a second NEW forward.
+#[test]
+fn sync_session_upsert_reports_a_semantic_refusal_on_the_wire_6785() {
+    fn upsert_request(src_port: u16) -> ControlRequest {
+        let mut request = req("sync_session");
+        request.session_sync = Some(SessionSyncRequest {
+            operation: "upsert".to_string(),
+            addr_family: 2,
+            protocol: 6,
+            src_ip: "10.0.0.1".to_string(),
+            dst_ip: "10.0.0.2".to_string(),
+            src_port,
+            dst_port: 80,
+            egress_ifindex: 7,
+            neighbor_mac: "02:bf:72:01:02:03".to_string(),
+            src_mac: "02:bf:72:0a:0b:0c".to_string(),
+            ..SessionSyncRequest::default()
+        });
+        request
+    }
+
+    let state = new_state(ProcessStatus::default());
+    // One LOGICAL session fits (2 entries: the forward and its synthesized
+    // reverse companion); the second NEW forward is drop-newest rejected.
+    state
+        .lock()
+        .expect("state")
+        .afxdp
+        .synced_import_cap_override = 1;
+
+    // Control on the SAME state: the first import must still answer ok, so this
+    // cell cannot pass on a handler that reports a refusal unconditionally.
+    let first = run_request(state.clone(), upsert_request(1234));
+    assert!(
+        first.ok,
+        "the first import is within the ceiling and must succeed: {}",
+        first.error
+    );
+
+    let second = run_request(state.clone(), upsert_request(5678));
+    assert!(
+        !second.ok,
+        "a cap-REFUSED import answered ok=true — Go records a success and keeps \
+         a BPF mirror row for a session this helper never took (#6785)"
+    );
+    assert!(
+        second.error.starts_with(crate::afxdp::SYNCED_IMPORT_REFUSED_PREFIX),
+        "a refusal must carry the machine-readable prefix Go classifies on, or \
+         it is indistinguishable from a transport failure and would disarm HA \
+         takeover-readiness on a healthy node; got {:?}",
+        second.error
+    );
+    assert_eq!(
+        second.error,
+        format!(
+            "{}{}",
+            crate::afxdp::SYNCED_IMPORT_REFUSED_PREFIX,
+            crate::afxdp::SyncedImportOutcome::RejectedCapacity
+                .refusal_reason()
+                .expect("capacity is a refusal")
+        ),
+        "the wire error must name WHICH refusal happened — an operator cannot \
+         tell a capacity problem from a stale peer otherwise"
+    );
+}


### PR DESCRIPTION
Closes #6785

## What was wrong

`upsert_synced_session` returned `()`. It has **three** semantic refusal paths —
a stale install generation (#2170), the aggregate synced-import entry ceiling
(#5674), and a translated-tuple reservation refusal (#6600) — and each one
bumped a counter and `return`ed silently. The control handler therefore answered
`ok = true`, so Go's `SetClusterSyncedSessionV4`/`V6` reported success and **left
its BPF mirror row in place** for a session the helper had refused.

That is exactly the split truth #5305's transactional install exists to prevent.
Its snapshot → write → mirror → restore machinery was already built and simply
**never reached**, because the only failure it could observe was an IPC error.
So the helper-side report is the whole fix: say the refusal happened, and the
compensation that already exists runs.

## Cites

The issue body is `(see /tmp/opus-review-001.md section R44)` and nothing else —
that file is gone. Everything here was re-derived from code by symbol name.

## The part that took the most care: refusal ≠ transport failure

Both arrive as an error, and they mean opposite things about helper health.

| | transport failure | semantic refusal |
|---|---|---|
| what it means | the session socket is sick | a **healthy** helper answered correctly |
| roll back the BPF row | yes | **yes** — the helper did not take the session |
| set `sessionMirrorFailed` (gates HA takeover, #5247) | yes | **no** |
| cluster `Errors` | yes | **no** |
| `Imports refused by helper` | no | **yes** |

Gating takeover on a refusal would keep a working standby from **ever** taking
over once a peer oversubscribed it — a worse failure than the divergence being
fixed, and a silent one. A refusal also does not take the *success* path: that
flag means "a mirror last succeeded", and clearing a sticky failure on the
strength of a refused write would let a helper that refuses everything read as
recovered.

The counter is health **debt**, not an error: local state is consistent after the
rollback, but the **peer** still believes it synced a session this node does not
hold, and only the peer's next full sync closes that gap. It deliberately does
not feed the takeover gate — refusing to fail over on a node whose peer is
oversubscribing it would turn a capacity problem into an outage.

`show chassis cluster information` renders `Imports refused by helper` when
non-zero.

## Shape

- **Rust**: `SyncedImportOutcome` (`Applied` / `RejectedStaleGeneration` /
  `RejectedCapacity` / `RejectedReserve`) + `SYNCED_IMPORT_REFUSED_PREFIX`; the
  `sync_session` handler answers `ok=false` with `synced-import-refused:<reason>`.
- **Go**: the sentinel lives in `pkg/dataplane`, **not** in
  `pkg/dataplane/userspace`, so the cluster receive path can classify the error
  it already gets without an import cycle. The transport classifies the token;
  `noteSyncedMirrorFailureLocked` makes the health decision once for both v4 and
  v6; `installClusterSynced*` counts the debt.

## Mutation matrix

Fix committed FIRST. Rust cells run the full `--bins` suite with
`--test-threads=1`; Go cells run the full `pkg/cluster` + `pkg/dataplane/...`
suites with `-count=1` and no `-run` filter. Every mutation verified applied on a
building, vetting tree. **13 cells, all RED.**

| cell | result | assertion |
|---|---|---|
| M1 handler discards the outcome (`ok` stays true) | RED | `sync_session_upsert_reports_a_semantic_refusal_on_the_wire_6785` |
| M2 handler drops the machine-readable prefix | RED | same |
| M3 capacity refusal reported as `Applied` | RED | `..._reports_capacity_refusal_6785` + the wire cell |
| M4 stale-generation refusal reported as `Applied` | RED | `..._reports_stale_generation_refusal_6785` |
| M5 all three reason tokens collapse to one string | RED | `synced_import_outcome_reason_tokens_are_distinct_6785` |
| M6 Go does not classify the refusal token | RED | `TestHelperErrorClassification6785` |
| **M7 TIGHTEN: classify on `Contains`, not `HasPrefix`** | RED | same |
| **M8 TIGHTEN: every helper `ok=false` classifies as a refusal** | RED | same |
| **M9 refusal sets the sticky mirror-failure flag** | RED | `TestSyncedMirrorFailureAccounting6785` |
| **M9b TIGHTEN: a transport failure no longer sets the flag** | RED | same |
| M10 / M10b v4 / v6 refusal counted as a cluster `Error` | RED | `TestHelperRefusalIsCountedAsDebtNotAsAnError{,V6_}6785` |
| **M11 TIGHTEN: cluster counts EVERY install failure as refusal debt** | RED | the **pre-existing** `TestInstallClusterSyncedV4DoesNotCountRolledBackCompanionFailure` + the new cell |
| **M12 TIGHTEN: the debt line is rendered unconditionally** | RED | `TestRefusalDebtIsRenderedOnlyWhenNonZero6785` |

### The green cell, and why it matters more than the reds

Round 1's **M9 came back GREEN**: making a semantic refusal set the sticky
mirror-failure flag left the *entire* suite green.

The two cells that could have caught it need real BPF session maps and **SKIP
without CAP_BPF**, like the #5305 rollback cells they sit beside. A guard that
skips is indistinguishable from a guard that passes — so the decision that gates
HA takeover-readiness was effectively unbound on any unprivileged runner, in a PR
whose entire subject is that decision.

The decision also existed **twice**, once in each of the v4 and v6 installs. Two
copies of one classification is a divergence waiting to happen, and an IPv6-only
misclassification would disarm HA takeover on exactly the deployments least
likely to notice. Both now route through `noteSyncedMirrorFailureLocked`, which
needs no BPF maps, and it is bound by a paired table (a refusal must NOT set the
flag; a transport failure and a plain helper error MUST). The refusal row alone
would be satisfied by an implementation that never sets the flag at all.

A second cell pins that both entry points actually route through the helper and
that `recordSessionMirrorFailureLocked` is not *also* called inline — a call plus
a surviving inline copy is precisely the divergence being guarded. It is a source
check because the v6 behavioural cell skips here; comments are stripped before
matching, since the helper's doc comment names both functions and a gate
satisfiable by its own documentation proves nothing.

### Other test-design notes

- The Rust cells pair each refusal with the **success case on the same
  coordinator**, so "reports a refusal" cannot be satisfied by refusing
  unconditionally. The capacity cell additionally asserts a REPLACE at the
  ceiling still applies, so the refusal is bounded to what it claims.
- One Rust cell drives the real `handle_stream` dispatcher rather than the
  coordinator. Every coordinator-level cell stays green if the handler drops the
  outcome — which *is* the bug — so the wiring needs its own cell.
- `TestHelperErrorClassification6785`'s middle row is the load-bearing one: a
  message merely *containing* the token must not classify. A `strings.Contains`
  implementation passes the other rows (M7).
- The prefix agreement is asserted by **reading the Rust constant** with comments
  stripped, never by pinning either side to a literal. A rename against a
  hard-coded Go string would reclassify every refusal as a transport failure and
  permanently disarm HA takeover, with both sides compiling and every unit test
  on either side passing.

## Gates

- `go build ./... && go vet ./... && go test -count=1 ./...` — all rc=0, 67 packages.
- `cargo test --release --bins --tests -- --test-threads=1` — rc=0.
- rustfmt parity on every touched `.rs` file; no crate-wide `cargo fmt`.
- Head `aebe86d0ecc7e4fe8023ca5b06e90f32526ce3f1`, tree clean.

**This is HA / session-sync code and it moves the `userspace-dp` binary**, so it
owes the cluster smoke on the merge result. Running `make test-failover` under
the cluster lock before merge.
