### PR TITLE
vrrp/daemon: skip nil config slots on the RETH ownership path (#6780)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104505,3 +104505,23 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/config/compiler_uniformgates_cluster_zone.go`,
   `pkg/config/vrrp_vip_count_6779_test.go` (new), `pkg/vrrp/README.md`,
   `pkg/config/README.md`
+
+## 2026-08-22 — #6780 nil config slots on the RETH ownership path
+
+- **Timestamp**: 2026-08-22
+- **Action**: Measured the issue's claim before fixing. All three slot types do
+  panic the collectors (nil-RG affects the VRRP mode only, since the direct mode
+  never reads `RedundancyGroups` — 5 of 6 cells, not 6), but the panic is NOT
+  reachable: each container has exactly one compiler write site and each stores
+  a freshly-allocated pointer, persistence decodes the AST and recompiles, HA
+  config-sync ships TEXT, and nothing deserializes a `*config.Config`. The
+  "#3494/#5068 tolerant path admits nils" premise cited at ~12 sites is
+  circular. Enforced the invariant at the source with a new compiler canary,
+  guarded the two RETH ownership-mode collectors plus the RG-membership walks
+  they share the path with, and corrected the reachability claim in the docs
+  instead of repeating it.
+- **File(s)**: `pkg/vrrp/vrrp.go`, `pkg/daemon/daemon_ha.go`,
+  `pkg/daemon/daemon_ha_vip.go`, `pkg/config/interfaces_iter.go`,
+  `pkg/config/nil_slot_invariant_6780_test.go` (new),
+  `pkg/vrrp/reth_nil_slot_6780_test.go` (new),
+  `pkg/daemon/reth_rg_nil_slot_6780_test.go` (new), `pkg/vrrp/README.md`

--- a/pkg/config/interfaces_iter.go
+++ b/pkg/config/interfaces_iter.go
@@ -2,10 +2,26 @@ package config
 
 // Nil-safe interface/unit iterators for read-only presenters (#5813).
 //
-// The lenient load / HA config-sync path admits PRESENT-BUT-NIL InterfaceConfig
-// and InterfaceUnit map values (a key with a nil pointer value — #3494/#5068):
-// a peer-synced or tolerantly-loaded config can carry a `cfg.Interfaces.
-// Interfaces["ge-0/0/0"] = nil` slot, or an `ifc.Units[7] = nil` slot. Every
+// REACHABILITY, corrected in #6780. The comments here and at ~12 call sites
+// state that the lenient load / HA config-sync path ADMITS present-but-nil
+// InterfaceConfig / InterfaceUnit map values (#3494/#5068). That premise was
+// never demonstrated and is, as of #6780, believed to be FALSE: each container
+// has exactly one compiler write site and each stores a freshly-allocated
+// pointer, persistence decodes the AST (*ConfigTree) and recompiles, HA
+// config-sync ships config TEXT, and nothing deserializes a *Config. The
+// invariant is now enforced by TestCompilerNeverEmitsNilConfigSlots
+// (nil_slot_invariant_6780_test.go) rather than assumed in either direction.
+//
+// These helpers are retained: they are correct, free, and make a consumer
+// degrade rather than panic if a future config ingress ever breaks that
+// invariant. What changed is the JUSTIFICATION — they are defence in depth
+// behind an enforced invariant, not a fix for a reachable panic. Do not cite
+// them as evidence that nil slots occur; that circularity (#5068 citing the
+// #3494 test, whose own header says "The strict compiler never emits these
+// nils") is what #6780 unwound.
+//
+// A peer-synced or tolerantly-loaded config would carry such a slot as a
+// `cfg.Interfaces.Interfaces["ge-0/0/0"] = nil`, or an `ifc.Units[7] = nil`. Every
 // read-only presenter that walks the interface tree — the CLI/gRPC/REST session
 // egress-interface map builders, interface displays, completers — must SKIP
 // those nil slots, not dereference them: a raw `for _, ifc := range … { for _,

--- a/pkg/config/nil_slot_invariant_6780_test.go
+++ b/pkg/config/nil_slot_invariant_6780_test.go
@@ -1,0 +1,181 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+)
+
+// #6780: the compiler NEVER emits a present-but-nil interface, unit, or
+// redundancy-group slot — on the strict path OR the tolerant one.
+//
+// Why this test exists. Roughly a dozen sites across the tree carry a comment
+// of the form "the tolerant / HA-sync path may carry a nil entry
+// (#3494/#5068)" and guard against it. That premise was never demonstrated;
+// tracing it back, the chain is circular:
+//
+//	#5068 justifies itself by citing compiler_validate_warn_nil_3494_test.go
+//	  ↓  …whose own header states "The strict compiler never emits these nils."
+//	#3494 justifies itself by citing the #3474/#3476 "reachability premise"
+//	  ↓  …whose write-up (docs/feature-gaps.md) says the class is
+//	     "DEFENSIVE hardening, NOT a reachable-bug fix".
+//
+// No link in that chain demonstrates a mechanism, and every nil slot in the
+// repository is injected synthetically by a test. The structural reason is
+// that each container has exactly ONE write site, and each stores a
+// freshly-allocated pointer:
+//
+//	Interfaces.Interfaces[name]  compiler_interfaces.go  (ifc  := &InterfaceConfig{…})
+//	ifc.Units[n]                 compiler_interfaces.go  (unit := &InterfaceUnit{…})
+//	Cluster.RedundancyGroups     compiler_system.go      (rg   := &RedundancyGroup{…})
+//
+// …and no path deserializes a *Config: persistence decodes the AST
+// (*ConfigTree) and recompiles, HA config-sync ships config TEXT, and the one
+// JSON-tagged *Config (the userspace dataplane Snapshot) is marshal-only.
+//
+// This test makes that invariant ENFORCED rather than believed. If a future
+// change introduces a nil-emitting path — a new config ingress, a map copy, an
+// early-insert-then-fill — this goes RED at the source, which is where the
+// class can actually be fixed. It is deliberately NOT a guard at a consumer:
+// distributing the belief is what produced the doubled dead guards in
+// pkg/cli/cli_show_interfaces_terse.go (the same nil check twice, once tagged
+// #5886 and once #5068).
+//
+// FAIL-ON-REVERT: make either compiler write site store a nil (e.g. drop the
+// allocation and store a nil *InterfaceUnit for a quarantined unit) and the
+// matching subtest goes RED naming the slot.
+
+// countNilSlots returns the number of present-but-nil interface, unit, and
+// redundancy-group slots in a compiled config.
+func countNilSlots(cfg *Config) (nilIfc, nilUnit, nilRG int, detail []string) {
+	if cfg == nil {
+		return 0, 0, 0, nil
+	}
+	for name, ifc := range cfg.Interfaces.Interfaces {
+		if ifc == nil {
+			nilIfc++
+			detail = append(detail, fmt.Sprintf("interface %q is a nil slot", name))
+			continue
+		}
+		for n, unit := range ifc.Units {
+			if unit == nil {
+				nilUnit++
+				detail = append(detail, fmt.Sprintf("interface %q unit %d is a nil slot", name, n))
+			}
+		}
+	}
+	if cc := cfg.Chassis.Cluster; cc != nil {
+		for i, rg := range cc.RedundancyGroups {
+			if rg == nil {
+				nilRG++
+				detail = append(detail, fmt.Sprintf("redundancy-group index %d is a nil slot", i))
+			}
+		}
+	}
+	return nilIfc, nilUnit, nilRG, detail
+}
+
+// nilSlotCorpus is deliberately weighted toward inputs that STRESS the
+// quarantine / fold / last-writer-wins branches, because those are the only
+// places a partially-built entry could plausibly be left behind. A corpus of
+// only well-formed configs would pass vacuously.
+func nilSlotCorpus() map[string][]string {
+	return map[string][]string{
+		// The realistic HA shape both RETH ownership modes actually consume.
+		"reth-cluster": {
+			"set chassis cluster cluster-id 1",
+			"set chassis cluster authentication-key test-cluster-psk-6780",
+			"set chassis cluster reth-count 2",
+			"set chassis cluster no-private-rg-election",
+			"set chassis cluster redundancy-group 1 node 0 priority 200",
+			"set chassis cluster redundancy-group 1 node 1 priority 100",
+			"set interfaces reth0 redundant-ether-options redundancy-group 1",
+			"set interfaces reth0 vlan-tagging",
+			"set interfaces reth0 unit 50 vlan-id 50 family inet address 172.16.50.8/24",
+			"set interfaces reth0 unit 80 vlan-id 80 family inet address 172.16.80.8/24",
+			"set interfaces reth1 redundant-ether-options redundancy-group 1",
+			"set interfaces reth1 unit 0 family inet address 10.0.61.1/24",
+		},
+		// Malformed unit id: the lenient path QUARANTINES it. The question this
+		// case answers is whether the quarantine drops the unit or leaves a
+		// present-but-nil slot behind.
+		"quarantined-unit-id": {
+			"set interfaces reth0 redundant-ether-options redundancy-group 1",
+			"set interfaces reth0 unit abc family inet address 10.0.61.1/24",
+			"set interfaces reth0 unit 0 family inet address 10.0.62.1/24",
+		},
+		"negative-unit-id": {
+			"set interfaces reth0 unit -1 family inet address 10.0.61.1/24",
+		},
+		"overflow-unit-id": {
+			"set interfaces reth0 unit 99999999999999999999 family inet address 10.0.61.1/24",
+		},
+		// Repeated spellings exercise the last-writer-wins unit merge.
+		"duplicate-unit": {
+			"set interfaces reth0 redundant-ether-options redundancy-group 1",
+			"set interfaces reth0 unit 0 family inet address 10.0.61.1/24",
+			"set interfaces reth0 unit 0 family inet address 10.0.61.2/24",
+		},
+		// An interface with no units, and a unit with no family — the shapes
+		// most likely to leave a half-built entry.
+		"interface-without-units": {
+			"set interfaces reth0 redundant-ether-options redundancy-group 1",
+		},
+		"unit-without-family": {
+			"set interfaces reth0 redundant-ether-options redundancy-group 1",
+			"set interfaces reth0 unit 0",
+		},
+		// Non-numeric and canonically-duplicate RG ids exercise the #6543
+		// fold-by-canonical-id path, the only place RedundancyGroups grows.
+		"redundancy-group-non-numeric": {
+			"set chassis cluster cluster-id 1",
+			"set chassis cluster redundancy-group xyz node 0 priority 200",
+			"set interfaces reth0 redundant-ether-options redundancy-group 1",
+		},
+		"redundancy-group-duplicate-canonical-ids": {
+			"set chassis cluster cluster-id 1",
+			"set chassis cluster redundancy-group 1 node 0 priority 200",
+			"set chassis cluster redundancy-group 01 node 1 priority 100",
+			"set chassis cluster redundancy-group 001 node 0 priority 150",
+		},
+	}
+}
+
+func TestCompilerNeverEmitsNilConfigSlots(t *testing.T) {
+	for name, lines := range nilSlotCorpus() {
+		t.Run(name, func(t *testing.T) {
+			tree := buildTree(t, lines)
+			compiled := 0
+			for _, mode := range []struct {
+				name string
+				fn   func(*ConfigTree) (*Config, error)
+			}{
+				{"strict", CompileConfig},
+				{"lenient", CompileConfigLenient},
+			} {
+				cfg, err := mode.fn(tree)
+				if err != nil || cfg == nil {
+					// A rejected config emits nothing, so it cannot carry a nil
+					// slot. The tolerant path must still compile (#1960
+					// no-brick), which the count below asserts.
+					continue
+				}
+				compiled++
+				nilIfc, nilUnit, nilRG, detail := countNilSlots(cfg)
+				if nilIfc+nilUnit+nilRG > 0 {
+					t.Errorf("%s compile emitted present-but-nil slots "+
+						"(interfaces=%d units=%d redundancy-groups=%d): %v\n"+
+						"A consumer walking this config would nil-deref. Fix the "+
+						"compiler write site, not the consumer.",
+						mode.name, nilIfc, nilUnit, nilRG, detail)
+				}
+			}
+			// Guard against a vacuous pass: if NEITHER path produced a config,
+			// the corpus entry asserted nothing at all.
+			if compiled == 0 {
+				t.Fatalf("neither the strict nor the tolerant path compiled this "+
+					"corpus entry, so the nil-slot assertion was vacuous "+
+					"(lines=%v)", lines)
+			}
+		})
+	}
+}

--- a/pkg/config/nil_slot_invariant_6780_test.go
+++ b/pkg/config/nil_slot_invariant_6780_test.go
@@ -140,6 +140,36 @@ func nilSlotCorpus() map[string][]string {
 	}
 }
 
+// compileForNilSlotScan runs one compile and converts a PANIC into a named test
+// failure instead of taking the test binary down with a SIGSEGV stack.
+//
+// This is not cosmetic. When the invariant is broken, the compiler frequently
+// cannot even finish compiling its own output: pkg/config's tail gates walk the
+// interface tree they just built (runTailGates -> vrrpTrackConfigWarnings,
+// compiler_interfaces.go) and dereference it raw. Measured by mutation:
+// injecting a nil interface slot at the compiler write site panics INSIDE
+// CompileConfigLenient, before any consumer ever sees the config.
+//
+// That closes the reachability question from the other end. A "tolerantly
+// loaded config carrying a nil slot" could not survive the very compile that
+// would have produced it — so the premise that such a config reaches a consumer
+// is not merely undemonstrated, it is self-defeating. Recovering here keeps the
+// failure attributable to THIS test and names the mode and corpus entry.
+func compileForNilSlotScan(t *testing.T, mode string, fn func(*ConfigTree) (*Config, error), tree *ConfigTree) (cfg *Config, err error) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("%s compile PANICKED: %v\n"+
+				"The compiler emitted a config it cannot itself walk — pkg/config's "+
+				"own tail gates dereference the interface tree raw. Fix the "+
+				"compiler write site: a nil slot must never be stored.", mode, r)
+			cfg, err = nil, nil
+		}
+	}()
+	cfg, err = fn(tree)
+	return cfg, err
+}
+
 func TestCompilerNeverEmitsNilConfigSlots(t *testing.T) {
 	for name, lines := range nilSlotCorpus() {
 		t.Run(name, func(t *testing.T) {
@@ -152,7 +182,7 @@ func TestCompilerNeverEmitsNilConfigSlots(t *testing.T) {
 				{"strict", CompileConfig},
 				{"lenient", CompileConfigLenient},
 			} {
-				cfg, err := mode.fn(tree)
+				cfg, err := compileForNilSlotScan(t, mode.name, mode.fn, tree)
 				if err != nil || cfg == nil {
 					// A rejected config emits nothing, so it cannot carry a nil
 					// slot. The tolerant path must still compile (#1960

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -1364,6 +1364,9 @@ func rethInterfacesMatchingRG(cfg *config.Config, want func(rgID int) bool) []st
 			// Resolve RETH to physical member for Linux-level operations.
 			resolved := config.LinuxIfName(cfg.ResolveReth(name))
 			for _, unit := range ifc.Units {
+				if unit == nil { // #6780
+					continue
+				}
 				if unit.VlanID > 0 {
 					names = append(names, resolved+"."+fmt.Sprintf("%d", unit.VlanID))
 				} else {
@@ -1409,6 +1412,9 @@ func (d *Daemon) injectBlackholeRoutesFor(userspaceActive bool, rgID int) {
 			continue
 		}
 		for _, unit := range ifc.Units {
+			if unit == nil { // #6780
+				continue
+			}
 			for _, addr := range unit.Addresses {
 				_, ipNet, err := net.ParseCIDR(addr)
 				if err != nil {

--- a/pkg/daemon/daemon_ha_vip.go
+++ b/pkg/daemon/daemon_ha_vip.go
@@ -299,6 +299,9 @@ func (d *Daemon) addStableRethLinkLocal(rgID int) {
 		for unitNum := range ifc.Units {
 			if unitNum > 0 && rethUnitHasIPv6(ifc, unitNum) {
 				unit := ifc.Units[unitNum]
+				if unit == nil { // #6780
+					continue
+				}
 				subIface := linuxName
 				if unit.VlanID > 0 {
 					subIface = fmt.Sprintf("%s.%d", linuxName, unit.VlanID)
@@ -357,6 +360,9 @@ func (d *Daemon) removeStableRethLinkLocal(rgID int) {
 		for unitNum := range ifc.Units {
 			if unitNum > 0 {
 				unit := ifc.Units[unitNum]
+				if unit == nil { // #6780
+					continue
+				}
 				subIface := linuxName
 				if unit.VlanID > 0 {
 					subIface = fmt.Sprintf("%s.%d", linuxName, unit.VlanID)
@@ -636,6 +642,9 @@ func (d *Daemon) directSendGARPs(rgID int) {
 			}
 			// Send on each VLAN sub-interface.
 			for _, unit := range ifc.Units {
+				if unit == nil { // #6780
+					continue
+				}
 				if unit.VlanID > 0 {
 					subIface := fmt.Sprintf("%s.%d", linuxName, unit.VlanID)
 					if !seen[subIface] {

--- a/pkg/daemon/reth_rg_nil_slot_6780_test.go
+++ b/pkg/daemon/reth_rg_nil_slot_6780_test.go
@@ -1,0 +1,63 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6780: rethInterfacesMatchingRG is the third reading of "which interfaces
+// belong to this redundancy group" on the RETH ownership path (alongside
+// pkg/vrrp CollectRethInstances and RethVIPsForRG). It already skipped a nil
+// INTERFACE but dereferenced unit values raw (`unit.VlanID`), so a
+// present-but-nil unit nil-derefed the daemon while resolving RG membership —
+// the same shape as the two collectors.
+//
+// Reachability is stated honestly in the pkg/vrrp companion test and enforced
+// at the source by TestCompilerNeverEmitsNilConfigSlots (pkg/config): the
+// compiler cannot currently emit such a slot. This guard makes the walk degrade
+// rather than panic if that invariant is ever broken; the nil below is injected
+// deliberately and does not reproduce a live panic.
+//
+// FAIL-ON-REVERT: drop the `if unit == nil { continue }` in
+// rethInterfacesMatchingRG and this panics.
+func TestRethInterfacesMatchingRGSkipsNilUnit(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {
+			Name:            "reth0",
+			RedundancyGroup: 1,
+			Units: map[int]*config.InterfaceUnit{
+				// A live VLAN unit the walk MUST still return, so a guard that
+				// skipped everything cannot pass this test.
+				50: {Number: 50, VlanID: 50},
+				7:  nil, // the injected nil slot
+			},
+		},
+		// A nil interface alongside it: already guarded, pinned here so the
+		// existing guard cannot regress unnoticed either.
+		"reth9-nil": nil,
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("rethInterfacesMatchingRG panicked on a nil unit slot: %v\n"+
+				"RG membership resolution must skip the slot, not nil-deref on "+
+				"the HA ownership path", r)
+		}
+	}()
+
+	names := rethInterfacesMatchingRG(cfg, func(rgID int) bool { return rgID == 1 })
+
+	// The live VLAN sub-interface must still resolve.
+	found := false
+	for _, n := range names {
+		if n == "reth0.50" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("live VLAN unit missing from RG membership: got %v, want it to "+
+			"contain reth0.50", names)
+	}
+}

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -667,6 +667,41 @@ also holds its group without advertising, but it claims no addresses, so there
 is nothing for a second master to collide over. It is a distinct defect tracked
 separately.
 
+### RETH ownership modes and nil config slots (#6780)
+
+A RETH redundancy group's ownership is resolved by one of TWO collectors,
+depending on cluster mode — both in `vrrp.go`, both walking the same interface
+tree:
+
+| Mode | Collector | Selected when |
+|---|---|---|
+| VRRP-backed | `CollectRethInstances` | default (RETH VRRP instances synthesized) |
+| Direct | `RethVIPsForRG` | `no-reth-vrrp` or `private-rg-election` |
+
+Both dereferenced interface, unit, and (VRRP mode) redundancy-group map values
+raw, so a present-but-nil slot would nil-deref on the HA ownership path. Their
+in-file sibling `CollectInstances` already skipped nil interfaces and units, and
+6 of the 8 RETH-ownership walks in `pkg/daemon` already skipped nil interfaces —
+these two collectors were the outliers. They now skip nil slots too, as does
+`rethInterfacesMatchingRG` (`pkg/daemon`), the third reading of RG membership.
+
+**Reachability — stated honestly.** This is NOT a fix for a reachable panic. The
+compiler cannot currently emit such a slot: each container has exactly one write
+site and each stores a freshly-allocated pointer, persistence decodes the AST
+(`*ConfigTree`) and recompiles, HA config-sync ships config TEXT, and nothing
+deserializes a `*config.Config`. The widely-cited claim that "the tolerant /
+HA-sync path may carry a nil entry (#3494/#5068)" traces to a circular chain —
+#5068 cites the #3494 test, whose own header says "The strict compiler never
+emits these nils" — and every nil slot in the repository is injected
+synthetically by a test.
+
+That invariant is now ENFORCED at the source by
+`TestCompilerNeverEmitsNilConfigSlots` (`pkg/config`), which is where the class
+can actually be prevented. The consumer-side guards are defence in depth behind
+it: they cost nothing, are provably inert on every reachable config (the branch
+is never taken), and make the highest-consequence path degrade rather than
+panic if a future config ingress breaks the invariant.
+
 ### Receiver goroutine model
 
 When AF_PACKET opens (`afPacketFD >= 0`), a single `receiverAfPacket()`

--- a/pkg/vrrp/reth_nil_slot_6780_test.go
+++ b/pkg/vrrp/reth_nil_slot_6780_test.go
@@ -1,0 +1,134 @@
+package vrrp
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6780: both RETH ownership modes walk the interface tree to decide what this
+// node owns, and both dereferenced map values raw.
+//
+//	VRRP-backed mode   → CollectRethInstances (synthesizes VRRP instances)
+//	direct mode        → RethVIPsForRG        (no-reth-vrrp / private-rg-election)
+//
+// A present-but-nil interface / unit / redundancy-group slot nil-derefs and
+// takes down the daemon on the HA ownership path. Their in-file sibling
+// CollectInstances already skipped nil interfaces and units, and 6 of the 8
+// RETH-ownership walks in pkg/daemon already skipped nil interfaces — these two
+// collectors were the outliers.
+//
+// REACHABILITY, stated honestly: the compiler cannot currently emit such a slot
+// (every container has one write site and each stores a freshly-allocated
+// pointer; nothing deserializes a *config.Config). That invariant is now
+// ENFORCED by TestCompilerNeverEmitsNilConfigSlots in pkg/config, which is
+// where the class can actually be prevented. These guards make the
+// highest-consequence consumer degrade (skip the slot) instead of panicking the
+// daemon if that invariant is ever broken by a future ingress. They are not a
+// fix for a live panic, and this test does not claim to reproduce one — the
+// nil slots below are injected deliberately.
+//
+// FAIL-ON-REVERT: remove any one guard and the matching subtest panics, which
+// the harness reports as a failure naming the mode and the slot type.
+
+// rethCfgWithNilSlot builds the smallest config where the collectors must
+// produce a REAL result alongside the nil slot. A fixture carrying ONLY a nil
+// slot would still pass with the guard deleted for the wrong reason (nothing
+// to collect), so each case pairs the nil with a live reth0 the collectors are
+// required to return.
+func rethCfgWithNilSlot(t *testing.T, nilIfc, nilUnit, nilRG bool) *config.Config {
+	t.Helper()
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{}
+
+	live := &config.InterfaceConfig{
+		Name:            "reth0",
+		RedundancyGroup: 1,
+		Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.61.1/24"}},
+		},
+	}
+	cfg.Interfaces.Interfaces["reth0"] = live
+
+	if nilIfc {
+		// Sorts AFTER reth0, so the live interface is collected first and the
+		// walk must survive reaching the nil one.
+		cfg.Interfaces.Interfaces["reth9-nil"] = nil
+	}
+	if nilUnit {
+		live.Units[7] = nil // alongside the real unit 0
+	}
+	cfg.Chassis.Cluster = &config.ClusterConfig{ClusterID: 1}
+	if nilRG {
+		cfg.Chassis.Cluster.RedundancyGroups = []*config.RedundancyGroup{
+			nil,
+			{ID: 1, GratuitousARPCount: 4},
+		}
+	}
+	return cfg
+}
+
+func TestRethOwnershipModesSkipNilSlots(t *testing.T) {
+	for _, tc := range []struct {
+		name                   string
+		nilIfc, nilUnit, nilRG bool
+	}{
+		{"nil-interface", true, false, false},
+		{"nil-unit", false, true, false},
+		{"nil-redundancy-group", false, false, true},
+		{"all-three", true, true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// VRRP-backed ownership mode.
+			t.Run("vrrp-mode", func(t *testing.T) {
+				cfg := rethCfgWithNilSlot(t, tc.nilIfc, tc.nilUnit, tc.nilRG)
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("CollectRethInstances panicked on a %s slot: %v\n"+
+							"the VRRP-backed RETH ownership mode must skip the slot, "+
+							"not nil-deref on the HA ownership path", tc.name, r)
+					}
+				}()
+				insts := CollectRethInstances(cfg, map[int]int{1: 200})
+				// The live reth0 must still be collected — a guard that skipped
+				// everything would otherwise pass this test.
+				if len(insts) != 1 {
+					t.Fatalf("expected the live reth0 instance to still be "+
+						"collected alongside the nil slot, got %d instances", len(insts))
+				}
+				if got := insts[0].Interface; got == "" {
+					t.Errorf("collected instance has no interface name")
+				}
+			})
+
+			// Direct (no-reth-vrrp / private-rg-election) ownership mode.
+			t.Run("direct-mode", func(t *testing.T) {
+				cfg := rethCfgWithNilSlot(t, tc.nilIfc, tc.nilUnit, tc.nilRG)
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("RethVIPsForRG panicked on a %s slot: %v\n"+
+							"the direct RETH ownership mode must skip the slot, "+
+							"not nil-deref on the HA ownership path", tc.name, r)
+					}
+				}()
+				vips := RethVIPsForRG(cfg, 1)
+				// The live reth0's VIP must still be returned.
+				if len(vips) == 0 {
+					t.Fatalf("expected the live reth0 VIP to still be returned " +
+						"alongside the nil slot, got an empty map")
+				}
+				found := false
+				for _, addrs := range vips {
+					for _, a := range addrs {
+						if a == "10.0.61.1/24" {
+							found = true
+						}
+					}
+				}
+				if !found {
+					t.Errorf("live reth0 VIP 10.0.61.1/24 missing from %v", vips)
+				}
+			})
+		})
+	}
+}

--- a/pkg/vrrp/reth_nil_slot_6780_test.go
+++ b/pkg/vrrp/reth_nil_slot_6780_test.go
@@ -36,17 +36,28 @@ import (
 // slot would still pass with the guard deleted for the wrong reason (nothing
 // to collect), so each case pairs the nil with a live reth0 the collectors are
 // required to return.
-func rethCfgWithNilSlot(t *testing.T, nilIfc, nilUnit, nilRG bool) *config.Config {
+func rethCfgWithNilSlot(t *testing.T, nilIfc, nilUnit, nilRG, vlanTagged bool) *config.Config {
 	t.Helper()
 	cfg := &config.Config{}
 	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{}
 
+	// Both collectors branch on VlanTagging into SEPARATE unit loops, each with
+	// its own nil-unit guard, so the fixture must cover both. An untagged-only
+	// fixture leaves the tagged branch's guard mutation-INVISIBLE (measured: it
+	// survived deletion until this parameter was added).
 	live := &config.InterfaceConfig{
 		Name:            "reth0",
 		RedundancyGroup: 1,
-		Units: map[int]*config.InterfaceUnit{
+		VlanTagging:     vlanTagged,
+	}
+	if vlanTagged {
+		live.Units = map[int]*config.InterfaceUnit{
+			50: {Number: 50, VlanID: 50, Addresses: []string{"10.0.61.1/24"}},
+		}
+	} else {
+		live.Units = map[int]*config.InterfaceUnit{
 			0: {Number: 0, Addresses: []string{"10.0.61.1/24"}},
-		},
+		}
 	}
 	cfg.Interfaces.Interfaces["reth0"] = live
 
@@ -78,57 +89,63 @@ func TestRethOwnershipModesSkipNilSlots(t *testing.T) {
 		{"nil-redundancy-group", false, false, true},
 		{"all-three", true, true, true},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
-			// VRRP-backed ownership mode.
-			t.Run("vrrp-mode", func(t *testing.T) {
-				cfg := rethCfgWithNilSlot(t, tc.nilIfc, tc.nilUnit, tc.nilRG)
-				defer func() {
-					if r := recover(); r != nil {
-						t.Fatalf("CollectRethInstances panicked on a %s slot: %v\n"+
-							"the VRRP-backed RETH ownership mode must skip the slot, "+
-							"not nil-deref on the HA ownership path", tc.name, r)
+		for _, tag := range []struct {
+			name   string
+			tagged bool
+		}{{"untagged", false}, {"vlan-tagged", true}} {
+			tc, tag := tc, tag
+			t.Run(tc.name+"/"+tag.name, func(t *testing.T) {
+				// VRRP-backed ownership mode.
+				t.Run("vrrp-mode", func(t *testing.T) {
+					cfg := rethCfgWithNilSlot(t, tc.nilIfc, tc.nilUnit, tc.nilRG, tag.tagged)
+					defer func() {
+						if r := recover(); r != nil {
+							t.Fatalf("CollectRethInstances panicked on a %s slot: %v\n"+
+								"the VRRP-backed RETH ownership mode must skip the slot, "+
+								"not nil-deref on the HA ownership path", tc.name, r)
+						}
+					}()
+					insts := CollectRethInstances(cfg, map[int]int{1: 200})
+					// The live reth0 must still be collected — a guard that skipped
+					// everything would otherwise pass this test.
+					if len(insts) != 1 {
+						t.Fatalf("expected the live reth0 instance to still be "+
+							"collected alongside the nil slot, got %d instances", len(insts))
 					}
-				}()
-				insts := CollectRethInstances(cfg, map[int]int{1: 200})
-				// The live reth0 must still be collected — a guard that skipped
-				// everything would otherwise pass this test.
-				if len(insts) != 1 {
-					t.Fatalf("expected the live reth0 instance to still be "+
-						"collected alongside the nil slot, got %d instances", len(insts))
-				}
-				if got := insts[0].Interface; got == "" {
-					t.Errorf("collected instance has no interface name")
-				}
-			})
+					if got := insts[0].Interface; got == "" {
+						t.Errorf("collected instance has no interface name")
+					}
+				})
 
-			// Direct (no-reth-vrrp / private-rg-election) ownership mode.
-			t.Run("direct-mode", func(t *testing.T) {
-				cfg := rethCfgWithNilSlot(t, tc.nilIfc, tc.nilUnit, tc.nilRG)
-				defer func() {
-					if r := recover(); r != nil {
-						t.Fatalf("RethVIPsForRG panicked on a %s slot: %v\n"+
-							"the direct RETH ownership mode must skip the slot, "+
-							"not nil-deref on the HA ownership path", tc.name, r)
+				// Direct (no-reth-vrrp / private-rg-election) ownership mode.
+				t.Run("direct-mode", func(t *testing.T) {
+					cfg := rethCfgWithNilSlot(t, tc.nilIfc, tc.nilUnit, tc.nilRG, tag.tagged)
+					defer func() {
+						if r := recover(); r != nil {
+							t.Fatalf("RethVIPsForRG panicked on a %s slot: %v\n"+
+								"the direct RETH ownership mode must skip the slot, "+
+								"not nil-deref on the HA ownership path", tc.name, r)
+						}
+					}()
+					vips := RethVIPsForRG(cfg, 1)
+					// The live reth0's VIP must still be returned.
+					if len(vips) == 0 {
+						t.Fatalf("expected the live reth0 VIP to still be returned " +
+							"alongside the nil slot, got an empty map")
 					}
-				}()
-				vips := RethVIPsForRG(cfg, 1)
-				// The live reth0's VIP must still be returned.
-				if len(vips) == 0 {
-					t.Fatalf("expected the live reth0 VIP to still be returned " +
-						"alongside the nil slot, got an empty map")
-				}
-				found := false
-				for _, addrs := range vips {
-					for _, a := range addrs {
-						if a == "10.0.61.1/24" {
-							found = true
+					found := false
+					for _, addrs := range vips {
+						for _, a := range addrs {
+							if a == "10.0.61.1/24" {
+								found = true
+							}
 						}
 					}
-				}
-				if !found {
-					t.Errorf("live reth0 VIP 10.0.61.1/24 missing from %v", vips)
-				}
+					if !found {
+						t.Errorf("live reth0 VIP 10.0.61.1/24 missing from %v", vips)
+					}
+				})
 			})
-		})
+		}
 	}
 }

--- a/pkg/vrrp/vrrp.go
+++ b/pkg/vrrp/vrrp.go
@@ -152,6 +152,13 @@ func CollectRethInstances(cfg *config.Config, localPriority map[int]int) []*Inst
 			advertInterval = cc.RethAdvertiseInterval
 		}
 		for _, rg := range cc.RedundancyGroups {
+			// #6780: skip a present-but-nil redundancy-group. Every sibling
+			// walk of this slice already guards it (compiler_validate_warn.go,
+			// compiler_validate_strict_chassis.go); this collector was the
+			// outlier.
+			if rg == nil {
+				continue
+			}
 			if rg.GratuitousARPCount > 0 {
 				garpCounts[rg.ID] = rg.GratuitousARPCount
 			}
@@ -169,7 +176,9 @@ func CollectRethInstances(cfg *config.Config, localPriority map[int]int) []*Inst
 	var instances []*Instance
 	for _, name := range names {
 		ifc := cfg.Interfaces.Interfaces[name]
-		if ifc.RedundancyGroup <= 0 {
+		// #6780: skip a present-but-nil interface, matching CollectInstances
+		// above and every RETH-ownership walk in pkg/daemon.
+		if ifc == nil || ifc.RedundancyGroup <= 0 {
 			continue
 		}
 		rgID := ifc.RedundancyGroup
@@ -201,7 +210,9 @@ func CollectRethInstances(cfg *config.Config, localPriority map[int]int) []*Inst
 		if ifc.VlanTagging {
 			for _, n := range unitNums {
 				unit := ifc.Units[n]
-				if len(unit.Addresses) == 0 {
+				// #6780: a present-but-nil unit reaches len(unit.Addresses) as
+				// a nil deref, not as a zero length.
+				if unit == nil || len(unit.Addresses) == 0 {
 					continue
 				}
 				subIface := linuxName
@@ -222,7 +233,11 @@ func CollectRethInstances(cfg *config.Config, localPriority map[int]int) []*Inst
 		} else {
 			var vips []string
 			for _, n := range unitNums {
-				vips = append(vips, ifc.Units[n].Addresses...)
+				unit := ifc.Units[n]
+				if unit == nil { // #6780
+					continue
+				}
+				vips = append(vips, unit.Addresses...)
 			}
 			if len(vips) == 0 {
 				continue
@@ -254,7 +269,10 @@ func RethVIPsForRG(cfg *config.Config, rgID int) map[string][]string {
 	result := make(map[string][]string)
 	for _, name := range sortedIfNames(cfg) {
 		ifc := cfg.Interfaces.Interfaces[name]
-		if ifc.RedundancyGroup != rgID {
+		// #6780: skip a present-but-nil interface — this is the direct
+		// (no-reth-vrrp / private-rg-election) ownership mode's collector, and
+		// it carried the same raw deref as the VRRP-mode one above.
+		if ifc == nil || ifc.RedundancyGroup != rgID {
 			continue
 		}
 		// Only include actual RETH interfaces — skip fabric, control,
@@ -278,7 +296,8 @@ func RethVIPsForRG(cfg *config.Config, rgID int) map[string][]string {
 		if ifc.VlanTagging {
 			for _, n := range unitNums {
 				unit := ifc.Units[n]
-				if len(unit.Addresses) == 0 {
+				// #6780: nil unit derefs at len(unit.Addresses).
+				if unit == nil || len(unit.Addresses) == 0 {
 					continue
 				}
 				subIface := linuxName
@@ -290,7 +309,11 @@ func RethVIPsForRG(cfg *config.Config, rgID int) map[string][]string {
 		} else {
 			var vips []string
 			for _, n := range unitNums {
-				vips = append(vips, ifc.Units[n].Addresses...)
+				unit := ifc.Units[n]
+				if unit == nil { // #6780
+					continue
+				}
+				vips = append(vips, unit.Addresses...)
 			}
 			if len(vips) > 0 {
 				result[linuxName] = append(result[linuxName], vips...)


### PR DESCRIPTION
## Summary

Both RETH ownership-mode collectors walked the interface tree with raw map-value
derefs, so a present-but-nil interface, unit, or (VRRP mode) redundancy-group
slot would nil-deref while resolving who owns a redundancy group:

| Mode | Collector | Selected when |
|---|---|---|
| VRRP-backed | `CollectRethInstances` | default |
| Direct | `RethVIPsForRG` | `no-reth-vrrp` / `private-rg-election` |

Closes #6780

> **Cites re-derived.** The issue body points at `/tmp/opus-review-001.md`
> section R39, which no longer exists. Everything below was derived from the
> code by symbol name.

## What I measured, and how it changes the issue

**1. "BOTH ownership modes" — confirmed, with a correction.** All three slot
types panic, but the nil-redundancy-group case reaches only the VRRP mode: the
direct collector never reads `RedundancyGroups`. It is **5 of 6 cells, not 6**.

**2. The panic is NOT reachable from any production config path.** This is the
finding that changes the issue's severity, and I did not take it from a
synthetic fixture — a synthetic nil proves *which deref* is unsafe, never
*whether a config can carry one*.

- Each container has exactly **one** compiler write site, and each stores a
  freshly-allocated pointer (`compiler_interfaces.go` for interfaces and units,
  `compiler_system.go` for redundancy groups). The lenient path's
  malformed-unit *quarantine* `continue`s **before** the allocation, so it drops
  the unit rather than leaving a nil slot behind.
- **Nothing deserializes a `*config.Config`.** Persistence decodes the AST
  (`*ConfigTree`) and recompiles; HA config-sync ships config **TEXT**
  (`SyncApply(content string)`, `QueueConfig(configText string)`); the one
  JSON-tagged `*Config` (the userspace dataplane `Snapshot`) is marshal-only and
  is consumed by Rust. No gob/msgpack/cbor anywhere.
- Empirically: eight pathological configs (malformed / negative / overflow unit
  ids, duplicate interfaces, unit-without-family, interface-without-units,
  non-numeric RG id, duplicate canonical RG ids) through **both** the strict and
  tolerant paths produce **zero** nil slots.

**3. The premise the issue rests on is circular.** ~12 sites assert "the
tolerant / HA-sync path may carry a nil entry (#3494/#5068)". Tracing it:

```
#5068  justifies itself by citing compiler_validate_warn_nil_3494_test.go
   ↓   …whose own header says "The strict compiler never emits these nils."
#3494  justifies itself by citing the #3474/#3476 "reachability premise"
   ↓   …whose write-up (docs/feature-gaps.md) says the class is
       "DEFENSIVE hardening, NOT a reachable-bug fix".
```

No link in that chain demonstrates a mechanism, and **every** nil slot in the
repository is injected synthetically by a test.

**4. A nil slot cannot survive its own compile.** Found by mutation, not by
reading: injecting a nil at the compiler write site panics *inside*
`CompileConfigLenient` — `runTailGates` → `vrrpTrackConfigWarnings` walks the
interface tree it just built and derefs it raw. So "a tolerantly-loaded config
carrying a nil slot reaches a consumer" is not merely undemonstrated, it is
self-defeating.

**5. "before fail-closed reconciliation" has no actionable content.** I looked
for the reconcile the title implies runs too late (`reconcileDirectVIPOwnership`,
`reconcileVRRPInstances`, `reconcileRGStatePass`). There is no ordering defect
to bind: the collectors are not racing a reconcile that would have handled the
nil — there is no nil. Reporting this explicitly because it was the half of the
title most likely to hide a real bug.

## What this PR actually does

The durable fix is **at the source**, not at the consumer.
`TestCompilerNeverEmitsNilConfigSlots` compiles a corpus weighted toward the
quarantine / fold / last-writer-wins branches — the only places a half-built
entry could plausibly survive — through **both** compile paths and asserts zero
nil slots, with a vacuous-pass guard for a corpus entry neither path compiles.
A future ingress that breaks the invariant now goes RED where the class can
actually be prevented, instead of as a panic in whichever consumer happens to
walk it first.

The consumer guards are kept as defence in depth **behind** that invariant, and
framed honestly in the docs rather than repeating the folklore. They are
provably inert on every reachable config (the branch is never taken) and close a
real intra-file asymmetry: `CollectInstances`, in the same file, already skipped
nil interfaces and units, and 6 of the 8 RETH-ownership walks in `pkg/daemon`
already skipped nil interfaces — these collectors were the outliers.
`rethInterfacesMatchingRG`, the third reading of RG membership, gets the
nil-unit skip it was missing.

`pkg/config/interfaces_iter.go` claimed a reachability it could not support; it
now records what was measured and tells future readers not to cite the helpers
as evidence that nil slots occur.

**Deliberately NOT done:** I did not blanket-guard every raw walk in
`pkg/daemon`. Guarding a proven-impossible condition everywhere is what produced
the doubled dead guards in `pkg/cli/cli_show_interfaces_terse.go` (the same nil
check twice, once tagged #5886 and once #5068). Scope is the RETH ownership
path the issue names.

## Test plan

- [x] `go build ./... && go vet ./... && go test -count=1 ./...` — green, 67 packages
- [x] Both ownership modes × all three slot types × untagged **and** VLAN-tagged
- [x] Mutation matrix, 12 cells — see below
- [ ] **`make test-failover` — NOT RUN.** This is RETH/HA code and needs the
      shared, lock-protected cluster. Flagged for the team lead; I ran no
      `cluster-*` target.

### Mutation matrix

Each cell: restored from HEAD, anchor verified to match **exactly once**,
mutation verified present, `go build ./...` verified, then the **full package
suite** with `-count=1` and **no `-run` filter**.

| Cell | Mutation | Pkg | Result | Assertion that fired |
|---|---|---|---|---|
| N1 | DELETE nil-interface guard, VRRP mode | vrrp | **RED** | `CollectRethInstances panicked on a nil-interface slot` |
| N2 | DELETE nil-unit guard, VRRP mode **tagged** branch | vrrp | **RED** \* | `CollectRethInstances panicked on a nil-unit slot` |
| N3 | DELETE nil-redundancy-group guard, VRRP mode | vrrp | **RED** | `CollectRethInstances panicked on a nil-redundancy-group slot` |
| N4 | DELETE nil-interface guard, direct mode | vrrp | **RED** | `RethVIPsForRG panicked on a nil-interface slot` |
| N5 | DELETE nil-unit guard, direct mode **tagged** branch | vrrp | **RED** \* | `RethVIPsForRG panicked on a nil-unit slot` |
| N6 | DELETE nil-unit guard, `rethInterfacesMatchingRG` | daemon | **RED** | `rethInterfacesMatchingRG panicked on a nil unit slot` |
| N7 | TIGHTEN VRRP mode: skip EVERY interface | vrrp | **RED** | `expected the live reth0 instance to still be collected … got 0` |
| N8 | TIGHTEN direct mode: skip EVERY interface | vrrp | **RED** | `expected the live reth0 VIP to still be returned … got an empty map` |
| N9 | TIGHTEN `rethInterfacesMatchingRG`: skip EVERY unit | daemon | **RED** | `reth1.0 group on a BACKUP RG must be filtered to nil` |
| N10 | COMPILER emits a nil **unit** slot | config | **RED** † | `strict compile PANICKED` (canary) |
| N11 | COMPILER emits a nil **interface** slot | config | **RED** † | `lenient compile PANICKED` (canary) |
| N12 | DELETE the canary's vacuous-pass guard | config | SURVIVED ‡ | — |

\* **N2 and N5 initially SURVIVED.** Both collectors branch on `VlanTagging`
into two separate unit loops, each with its own guard, and my fixture built an
**untagged** reth0 — so the tagged branch was never entered and its guard was
mutation-invisible. The fixture is now parameterized on tagging (8 → 16
subtests); both cells red. This is the same class of hole as a fixture that
varies an axis but only samples the passing point.

† **N10/N11 initially red via a raw SIGSEGV**, not through the canary's own
assertion, so "which assertion fired" was unanswerable. The panic turned out to
be finding #4 above. The canary now recovers per-compile and reports it as its
own named failure. (Caught a harness bug too: the first re-run reverted the
uncommitted improvement via `git checkout -- .` — the fix has to be committed
*before* the matrix runs.)

‡ **N12 SURVIVED by design.** The vacuous-pass guard is a tripwire for a corpus
entry that neither compile path accepts; every current entry compiles on at
least one path, so it correctly does not fire. Listed rather than hidden.

## Follow-ups

None filed for the nil class itself — it is now enforced at the source. Two
observations recorded here rather than acted on, both out of scope:
`pkg/cli/cli_show_interfaces_terse.go` carries the same nil check twice
back-to-back in three places, and `pkg/appid/catalog.go` repeats the same
"JSON null decoding to a nil pointer" claim for `cfg.Applications`, which has no
JSON decode either.

## Refs

- #6780 (this), #6779 (prior RETH/VRRP work on the same collectors)
- #3494 / #5068 / #5813 / #5886 (the nil-slot helper + canary lineage), #3474
  (the one entry that measured it), #1960 (no-brick tolerant load), #6520
  (the "a divergence between two readings is ALWAYS a bug" precedent)
