### PR TITLE
dataplane/userspace: adopt pinned ingress classifier rows on a fresh manager (#6784)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104505,3 +104505,32 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/config/compiler_uniformgates_cluster_zone.go`,
   `pkg/config/vrrp_vip_count_6779_test.go` (new), `pkg/vrrp/README.md`,
   `pkg/config/README.md`
+
+## 2026-08-22 — #6784 adopt the pinned ingress-classifier rows on a fresh manager
+
+- **Timestamp**: 2026-08-22
+- **Action**: `syncIngressIfaceMapLocked` reaped stale `userspace_ingress_ifaces`
+  rows by scanning `m.lastIngressIfaces`, an in-process inventory that is nil on
+  a freshly constructed Manager. The map is `PinByName`-pinned, so its rows
+  outlive xpfd and the first sync after a daemon restart deleted nothing. Added
+  `adoptIngressInventoryLocked`: enumerate the pinned map ONCE per Manager,
+  union into the inventory (never dropping a #6537 retry debt), record only on a
+  successful enumeration, and treat an enumeration failure as fatal so the
+  caller drives `userspace_ctrl` to `Enabled=0`. Adoption takes only rows the
+  shim ACTS on (value != 0): a 0-valued row reads exactly like an absent one to
+  the shim, and keying on that keeps adoption correct on a dense map instead of
+  assuming a HashMap — the #6537 delete-failure fixture deliberately uses an
+  Array, and an unfiltered enumeration adopted all 16 dense slots and broke it.
+- **Measured, refining the issue**: only ONE of the classifier syncs had this
+  hole. `syncLocalAddressMapsLocked` and `syncInterfaceNATAddressMapsLocked`
+  already prune by iterating the MAP, and `userspace_heartbeat` already sweeps
+  its Array's own capacity (#6702) — so no sweep-and-recreate was needed and no
+  empty-classifier window was opened. `userspace_bindings` shares the nil-
+  inventory shape (`clearAllBindingRowsLocked` at bootstrap) but its stale rows
+  are unreachable once the ingress gate is repaired, and its Array is 1,048,576
+  rows so a blanket sweep is not viable; corrected the `heartbeatZeroSlotBound`
+  comment that leaned on the bindings clear being effective on a fresh manager.
+- **File(s)**: `pkg/dataplane/userspace/manager.go`,
+  `pkg/dataplane/userspace/maps_sync.go`,
+  `pkg/dataplane/userspace/maps_sync_ingress_adopt_6784_test.go`,
+  `docs/afxdp-packet-processing.md`, `_Log.md`

--- a/docs/afxdp-packet-processing.md
+++ b/docs/afxdp-packet-processing.md
@@ -24,18 +24,50 @@ The shim checks several conditions before redirecting a packet to userspace:
 
    **Delete inventory (#6537).** `syncIngressIfaceMapLocked`
    (`pkg/dataplane/userspace/maps_sync.go`) keeps `m.lastIngressIfaces`, the
-   only record of which rows exist in this map; its reap loop rescans nothing
-   else. The inventory is therefore written on EVERY exit from the sync, not
-   only the all-succeeded one. On an early return — a failed `Update` (map
-   full / ENOMEM / EPERM) or a failed stale-row `Delete` — it becomes
-   `prior ∪ installed-this-pass`, so a row the aborted pass created is still
-   reachable later; on a clean pass it is exactly the new ingress set, because
-   every prior row outside that set was successfully deleted. Recording it only
-   on the all-succeeded path wrote the debt down exactly when there was none:
-   a row installed on a pass that failed partway became permanently
-   unreachable, and the shim kept treating a de-configured interface as ingress
-   until the daemon restarted. Same shape as the #5697 retry inventory
+   record of which rows THIS PROCESS installed in this map; its reap loop
+   rescans nothing else. The inventory is therefore written on EVERY exit from
+   the sync, not only the all-succeeded one. On an early return — a failed
+   `Update` (map full / ENOMEM / EPERM) or a failed stale-row `Delete` — it
+   becomes `prior ∪ installed-this-pass`, so a row the aborted pass created is
+   still reachable later; on a clean pass it is exactly the new ingress set,
+   because every prior row outside that set was successfully deleted. Recording
+   it only on the all-succeeded path wrote the debt down exactly when there was
+   none: a row installed on a pass that failed partway became permanently
+   unreachable, and the shim kept treating a de-configured interface as
+   ingress. Same shape as the #5697 retry inventory
    `clearStaleBindingRowsLocked` keeps for stale `userspace_bindings` rows.
+
+   **Restart adoption (#6784).** A daemon restart did NOT clear such a row —
+   this section previously said it did, and that was the defect. Every shim map
+   here is `PinByName`-pinned under `/sys/fs/bpf/xpf`, so `userspace_ingress_ifaces`
+   rows outlive xpfd, while `m.lastIngressIfaces` is an ordinary Manager field
+   that starts nil. The first sync after a restart therefore reaped nothing:
+   any ifindex that dropped out of the config while xpfd was down — or whose
+   interface was deleted and its ifindex later reused by a new tunnel/VLAN —
+   stayed in the map, and since this map is the gate every later stage sits
+   behind, the shim kept diverting that interface's traffic away from
+   `cpumap_or_pass` into the AF_XDP path. Retention is deliberate for the
+   SESSION maps (that is how HA continuity survives a restart) but it is merely
+   incidental for the classifier maps, and nothing rebuilt an inventory for
+   them. `adoptIngressInventoryLocked` now enumerates the pinned map ONCE per
+   Manager, before the inventory is read, so the reap starts from a truthful
+   set. It is a union with any inventory already held (so a #6537 retry debt is
+   never dropped) and it is recorded only after a successful enumeration (so a
+   transient scan failure retries rather than latching a partial view); an
+   enumeration failure is fatal to the classifier sync, which drives
+   `userspace_ctrl` to `Enabled=0`. It adopts only rows the shim ACTS on —
+   value != 0 — because the shim reads a 0-valued row exactly as it reads an
+   absent one (`map_or(true, |v| *v == 0)`), so such a row diverts no traffic;
+   that also keeps adoption correct independent of the map's density rather
+   than by assuming a HashMap. The sibling classifier maps
+   (`userspace_local_v4`/`_v6`, `userspace_interface_nat_v4`/`_v6`) never had
+   this hole — they prune by iterating the MAP — so this makes ingress
+   consistent with them rather than adding a new mechanism.
+
+   Adoption runs ONCE per Manager, not per pass: within a live process the
+   Manager is the sole writer of this map (the Rust helper never touches it,
+   the shim only reads it) and `m.lastIngressIfaces` is the #6537 record of
+   what this process installed.
 3. A binding must exist in `userspace_bindings` for (ifindex, queue_id) and be
    marked `USERSPACE_BINDING_READY`. `queue_id` is the packet's OWN RX queue,
    read once from the XDP context and never transformed on the way to the

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -194,11 +194,22 @@ type Manager struct {
 	// buildFabricSnapshots when unset (so bare &Manager{} literals still work).
 	fabricSnapshotBuilder func(*config.Config) []FabricSnapshot
 	lastIngressIfaces     []uint32
-	lastRSTv4             []netip.Addr
-	lastRSTv6             []netip.Addr
-	lastRSTAttempt        time.Time
-	lastRSTInstallOK      bool
-	lastSnapshotHash      [32]byte // content hash of last published snapshot (excludes volatile fields)
+	// ingressInventoryAdopted records whether this Manager has reconciled
+	// lastIngressIfaces against the rows actually present in the PINNED
+	// userspace_ingress_ifaces map (#6784). It is false on a freshly
+	// constructed Manager, which is exactly the daemon-restart case: the map
+	// is PinByName-pinned at /sys/fs/bpf/xpf and its rows outlive the process,
+	// but lastIngressIfaces does not — so without one adoption pass the reap
+	// loop in syncIngressIfaceMapLocked scans an EMPTY inventory and deletes
+	// nothing, leaving rows this process never wrote and cannot name. Set once
+	// per Manager, after a successful enumeration; within a process the
+	// inventory is then maintained exactly as #6537 established.
+	ingressInventoryAdopted bool
+	lastRSTv4               []netip.Addr
+	lastRSTv6               []netip.Addr
+	lastRSTAttempt          time.Time
+	lastRSTInstallOK        bool
+	lastSnapshotHash        [32]byte // content hash of last published snapshot (excludes volatile fields)
 	// #1866 D3: canonical summary of the WG endpoint set in the last
 	// successfully published snapshot, for publish-boundary transition
 	// logging (logWgEndpointSetTransitionLocked).

--- a/pkg/dataplane/userspace/maps_sync.go
+++ b/pkg/dataplane/userspace/maps_sync.go
@@ -646,13 +646,30 @@ func (m *Manager) entryProgramsLocked() map[int]string {
 // inventory the reap loop below rescans.
 //
 // #6537: the inventory is recorded on EVERY exit, not only the all-succeeded
-// one. It is the sole record of which rows exist in the BPF map, and the reap
-// loop only ever revisits ifindexes named in it, so a row that is installed but
-// never recorded is permanently unreachable: when its interface later drops out
-// of the config nothing deletes it, and the XDP shim keeps redirecting that
-// interface's traffic to userspace. Recording it only when no retry is needed
-// wrote the debt down exactly when there was none — the same shape #5697 fixed
-// for the stale userspace_bindings clears (clearStaleBindingRowsLocked).
+// one. Within a process it is the record of which rows exist in the BPF map,
+// and the reap loop only ever revisits ifindexes named in it, so a row that is
+// installed but never recorded is permanently unreachable: when its interface
+// later drops out of the config nothing deletes it, and the XDP shim keeps
+// redirecting that interface's traffic to userspace. Recording it only when no
+// retry is needed wrote the debt down exactly when there was none — the same
+// shape #5697 fixed for the stale userspace_bindings clears
+// (clearStaleBindingRowsLocked).
+//
+// #6784: "within a process" is the load-bearing qualifier, and before #6784 it
+// was missing — the comment claimed the inventory was the SOLE record of the
+// map's rows. It is not: userspace_ingress_ifaces is PinByName-pinned at
+// /sys/fs/bpf/xpf, so its rows outlive xpfd while the inventory is an ordinary
+// Manager field that starts nil. A daemon restart therefore reaped nothing on
+// its first pass — the loop below scanned an empty `prior` — and any ifindex
+// that dropped out of the config while xpfd was down (or whose interface was
+// deleted and its ifindex reused) stayed in the map with the shim still
+// treating it as an ingress interface. adoptIngressInventoryLocked closes that
+// by enumerating the pinned map ONCE per Manager before the inventory is read,
+// so the reap has a truthful starting set. The sibling classifier maps already
+// worked this way — syncLocalAddressMapsLocked and
+// syncInterfaceNATAddressMapsLocked prune by iterating the MAP rather than an
+// in-process list — so this makes ingress consistent with them rather than
+// inventing a mechanism.
 //
 // On an early return the inventory becomes prior ∪ installed: the prior entries
 // are kept because a failed (or not-yet-attempted) delete still has to be
@@ -664,6 +681,14 @@ func (m *Manager) syncIngressIfaceMapLocked(snapshot *ConfigSnapshot) error {
 	ifaceMap := m.bpfShim.Map(mapNameUserspaceIngressIfaces)
 	if ifaceMap == nil {
 		return errors.New("userspace_ingress_ifaces map not loaded")
+	}
+
+	// #6784: make the delete inventory truthful about the PINNED map before
+	// anything reads it. On a fresh Manager (daemon restart) this is what turns
+	// the reap below from a no-op into a real reconcile; on every later pass it
+	// is a single already-adopted bool test.
+	if err := m.adoptIngressInventoryLocked(ifaceMap); err != nil {
+		return fmt.Errorf("adopt userspace_ingress_ifaces inventory: %w", err)
 	}
 
 	newIngress := buildUserspaceIngressIfindexes(snapshot)
@@ -699,6 +724,81 @@ func (m *Manager) syncIngressIfaceMapLocked(snapshot *ConfigSnapshot) error {
 		}
 	}
 	m.lastIngressIfaces = newIngress
+	return nil
+}
+
+// adoptIngressInventoryLocked folds the rows actually present in the pinned
+// userspace_ingress_ifaces map into m.lastIngressIfaces, ONCE per Manager
+// (#6784).
+//
+// WHY THIS IS NEEDED AT ALL. Session state is retained across a helper/daemon
+// restart deliberately — that is how HA continuity survives one. The classifier
+// maps are retained by the same PinByName mechanism, but NOT for the same
+// reason: nothing about a classifier row is worth preserving across a config
+// reload, and unlike sessions there is no code that rebuilds an inventory for
+// them. So a fresh Manager inherits rows it never wrote and cannot name, and
+// the reap loop — which only ever revisits ifindexes the inventory names —
+// silently reaps nothing on its first pass.
+//
+// That matters because the row is not inert. The XDP shim reads this map on
+// EVERY packet (userspace-xdp/src/lib.rs: `USERSPACE_INGRESS_IFACES.get(
+// &ingress_ifindex)`) and a present non-zero row is what diverts the packet
+// away from `cpumap_or_pass` into the AF_XDP redirect path. A stale row for an
+// interface that dropped out of the config therefore does not merely leak — it
+// keeps steering that interface's traffic, and this map is the gate every
+// later binding/XSK stage sits behind.
+//
+// UNION, not replace. The adopted set is merged with whatever the inventory
+// already holds rather than overwriting it, so adoption can never DROP a #6537
+// retry debt recorded before the first sync completed. Adoption is recorded
+// only after a successful enumeration, so a failed scan retries on the next
+// pass instead of latching a partial view.
+//
+// Only rows the SHIM ACTS ON are adopted — those with a non-zero value. The
+// shim's test is `USERSPACE_INGRESS_IFACES.get(&ifindex).map_or(true, |v| *v
+// == 0)`, so a 0-valued row means "not ingress" and takes the same
+// cpumap_or_pass path as an absent one. A 0-valued row therefore diverts no
+// traffic and is not a stale classifier row in the sense this repairs; the Go
+// sync is the map's sole producer (the Rust helper never touches it, the shim
+// only reads it) and only ever writes 1, so in production the filter excludes
+// nothing that exists.
+//
+// The filter also makes adoption correct independent of the map's DENSITY
+// rather than by assuming a HashMap. Enumerating a dense map — an Array, where
+// every index is present — would otherwise adopt every slot as a live row and
+// send the reap loop into Delete calls that an Array rejects with EINVAL.
+// Keying on the value the shim reads is the property that actually matters, and
+// it holds for either shape.
+//
+// An enumeration failure is returned to the caller and is FATAL, matching the
+// established treatment of a classifier-map iteration failure in
+// syncLocalAddressMapsLocked / syncInterfaceNATAddressMapsLocked: if the map's
+// contents cannot be established, the reap cannot be trusted, and the caller
+// (syncUserspaceClassifierMapsFailClosedLocked) drives ctrl to Enabled=0 so the
+// shim stops redirecting transit rather than running against a classifier no
+// one can account for.
+func (m *Manager) adoptIngressInventoryLocked(ifaceMap *ebpf.Map) error {
+	if m.ingressInventoryAdopted {
+		return nil
+	}
+	var (
+		key uint32
+		val uint8
+	)
+	present := make([]uint32, 0, len(m.lastIngressIfaces))
+	iter := ifaceMap.Iterate()
+	for iter.Next(&key, &val) {
+		if val == 0 {
+			// Inert: the shim reads this exactly as it reads an absent row.
+			continue
+		}
+		present = append(present, key)
+	}
+	if err := iter.Err(); err != nil {
+		return fmt.Errorf("iterate userspace_ingress_ifaces: %w", err)
+	}
+	m.lastIngressIfaces = mergeIngressInventory(m.lastIngressIfaces, present)
+	m.ingressInventoryAdopted = true
 	return nil
 }
 
@@ -1639,6 +1739,29 @@ const heartbeatSlotsPerWorker = 2 * 16
 // function; this widens no window that call does not already open. (The binding
 // half of that hazard is separately acknowledged and repaired by
 // verifyBindingsMapLocked.)
+//
+// #6784 CORRECTION to the paragraph above: "zeroing every binding row the
+// manager wrote" is true only of rows THIS Manager wrote.
+// clearAllBindingRowsLocked iterates m.lastBindingIndices, which is nil on a
+// freshly constructed Manager, so on the first apply after a daemon restart it
+// zeroes NOTHING while userspace_bindings — PinByName-pinned like every other
+// shim map — still holds the previous process's rows. The conclusion survives,
+// but not for the stated reason: zeroing a heartbeat slot can only move a
+// packet ONTO the stale-heartbeat branch, which is fail-closed
+// (drop_degraded_transit for transit, pass_local_control for local), so the
+// widening is in the safe direction regardless of what the binding rows hold.
+//
+// The stale binding rows themselves are left alone deliberately, and the reason
+// is the gate order in the shim: userspace_ingress_ifaces is consulted BEFORE
+// the binding array, so a binding row is only ever reached for an ifindex the
+// ingress map still admits. Repairing the ingress map (adoptIngressInventoryLocked)
+// therefore makes a stale binding row for a de-configured interface
+// unreachable, and for an interface still in the config
+// applyHelperStatusLocked rewrites its rows from live helper status every poll.
+// A blanket zero of this Array is NOT the answer here the way it was for the
+// heartbeat: BindingArrayMaxEntries is MaxInterfaces*BindingQueuesPerIface =
+// 1,048,576 rows (versus the heartbeat Array's 4096), so sweeping it would put
+// a million map syscalls on every non-same-plan apply.
 //
 // Taking the Array's own capacity also closes #4572 and #5718-A6-b01-C1 BY
 // CONSTRUCTION rather than by a clamp — the bound no longer reads `workers` at

--- a/pkg/dataplane/userspace/maps_sync_ingress_adopt_6784_test.go
+++ b/pkg/dataplane/userspace/maps_sync_ingress_adopt_6784_test.go
@@ -1,0 +1,219 @@
+package userspace
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+// prepopulateIngressRows writes ifindex rows straight into the injected
+// userspace_ingress_ifaces map, WITHOUT going through the Manager. That is the
+// point: it models rows left in the PINNED map by a previous xpfd process, which
+// the current Manager never wrote and has no inventory for.
+func prepopulateIngressRows(t *testing.T, ifaceMap *ebpf.Map, ifindexes ...uint32) {
+	t.Helper()
+	for _, idx := range ifindexes {
+		if err := ifaceMap.Update(idx, uint8(1), ebpf.UpdateAny); err != nil {
+			t.Fatalf("prepopulate userspace_ingress_ifaces %d: %v", idx, err)
+		}
+	}
+}
+
+// ingressRowsPresent returns the ifindex keys currently in the map, sorted.
+func ingressRowsPresent(t *testing.T, ifaceMap *ebpf.Map) []uint32 {
+	t.Helper()
+	var (
+		key uint32
+		val uint8
+	)
+	var out []uint32
+	iter := ifaceMap.Iterate()
+	for iter.Next(&key, &val) {
+		out = append(out, key)
+	}
+	if err := iter.Err(); err != nil {
+		t.Fatalf("iterate userspace_ingress_ifaces: %v", err)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// TestFreshManagerReapsPrepopulatedIngressRows6784 is the #6784 fail-on-revert
+// test, and it is the test the issue's own fix direction asked for: "test a new
+// manager against stale prepopulated pins".
+//
+// userspace_ingress_ifaces is PinByName-pinned at /sys/fs/bpf/xpf, so its rows
+// outlive xpfd. m.lastIngressIfaces does not — it is an ordinary Manager field
+// that starts nil. Before #6784 the reap loop in syncIngressIfaceMapLocked
+// scanned that empty inventory, so the FIRST sync after a daemon restart
+// deleted nothing and every row the previous process left behind survived. The
+// row is not inert: the XDP shim reads this map on every packet and a present
+// non-zero row is what diverts traffic away from cpumap_or_pass into the AF_XDP
+// redirect path, so a stale row keeps steering a de-configured interface.
+//
+// Both cases below start from a FRESH Manager (New(), inventory nil) against a
+// map that already holds rows, exactly as a restart finds it.
+//
+//   - overlap: some prepopulated rows are still in the config and some are not.
+//     This is the case that needs the reap to be SELECTIVE — it fails a fix that
+//     adopts and then deletes everything, as well as one that reaps nothing.
+//   - no-overlap: nothing prepopulated is still configured. This is the
+//     interface-deleted-while-xpfd-was-down / ifindex-reused shape.
+//
+// FAIL-ON-REVERT: dropping the adoptIngressInventoryLocked call (or making it a
+// no-op) leaves `prior` empty on the first pass, so the stale rows survive and
+// the "must be gone" assertion goes RED with the stale ifindex named.
+//
+// PRIVILEGE NOTE: like the #6537 tests it extends, this needs real BPF maps and
+// SKIPs unprivileged. The #6784 mutation matrix was run under sudo so these
+// cells actually executed; a SKIP here is not a pass.
+func TestFreshManagerReapsPrepopulatedIngressRows6784(t *testing.T) {
+	tests := []struct {
+		name string
+		// prepopulated models the rows the pinned map carried across the restart.
+		prepopulated []uint32
+		// configured is the ingress set the new snapshot adjudicates.
+		configured []int
+		// want is the exact row set the map must hold after the sync.
+		want []uint32
+		// gone names the stale rows whose survival is the defect.
+		gone []uint32
+	}{
+		{
+			name:         "overlap",
+			prepopulated: []uint32{10, 11, 99},
+			configured:   []int{10, 11},
+			want:         []uint32{10, 11},
+			gone:         []uint32{99},
+		},
+		{
+			name:         "no-overlap",
+			prepopulated: []uint32{7, 8},
+			configured:   []int{21},
+			want:         []uint32{21},
+			gone:         []uint32{7, 8},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, ifaceMap := newIngressManager(t, ebpf.Hash, 16)
+
+			// Premise: the Manager is FRESH — it has no inventory naming any of
+			// these rows, which is the whole reason the pre-#6784 reap was a
+			// no-op. Assert it rather than assuming it.
+			if len(m.lastIngressIfaces) != 0 {
+				t.Fatalf("premise broken: a fresh Manager must have an empty ingress inventory, got %v",
+					m.lastIngressIfaces)
+			}
+			if m.ingressInventoryAdopted {
+				t.Fatal("premise broken: a fresh Manager must not be marked as having adopted the pinned map")
+			}
+
+			prepopulateIngressRows(t, ifaceMap, tc.prepopulated...)
+
+			if err := m.syncIngressIfaceMapLocked(ingressSnapshot(tc.configured...)); err != nil {
+				t.Fatalf("syncIngressIfaceMapLocked: %v", err)
+			}
+
+			got := ingressRowsPresent(t, ifaceMap)
+			for _, stale := range tc.gone {
+				if slices.Contains(got, stale) {
+					t.Errorf("ifindex %d was left in the PINNED userspace_ingress_ifaces map by a "+
+						"previous process and is NOT in the new config, but the first sync of a fresh "+
+						"Manager did not reap it: rows=%v. The XDP shim reads this map per packet, so "+
+						"the shim keeps steering that interface's traffic into the AF_XDP path (#6784)",
+						stale, got)
+				}
+			}
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("userspace_ingress_ifaces = %v, want exactly %v "+
+					"(the reap must be SELECTIVE — configured rows must survive it)", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIngressAdoptionFailureIsFatal6784 binds the fail-direction choice. If the
+// pinned map cannot be enumerated, the rows it holds are UNKNOWN, so the reap
+// below cannot be trusted and the sync must NOT report success — the caller
+// (syncUserspaceClassifierMapsFailClosedLocked) drives ctrl to Enabled=0 so the
+// shim stops redirecting transit rather than running against a classifier no
+// one can account for. This matches how syncLocalAddressMapsLocked and
+// syncInterfaceNATAddressMapsLocked already treat an iteration failure.
+//
+// The failure is injected by CLOSING the map, which makes every subsequent map
+// operation fail — so the assertion checks the error names the ADOPTION step,
+// not merely that some error occurred.
+//
+// FAIL-ON-REVERT: swallowing the adoption error (logging and continuing) makes
+// the sync return nil, and the "must fail" assertion goes RED.
+func TestIngressAdoptionFailureIsFatal6784(t *testing.T) {
+	m, ifaceMap := newIngressManager(t, ebpf.Hash, 16)
+	prepopulateIngressRows(t, ifaceMap, 42)
+
+	if err := ifaceMap.Close(); err != nil {
+		t.Fatalf("close userspace_ingress_ifaces: %v", err)
+	}
+
+	err := m.syncIngressIfaceMapLocked(ingressSnapshot(10))
+	if err == nil {
+		t.Fatal("an unreadable userspace_ingress_ifaces map must FAIL the classifier sync " +
+			"(the caller then drives ctrl to Enabled=0); got nil, so the reap silently ran " +
+			"against an unknown map (#6784)")
+	}
+	if !strings.Contains(err.Error(), "adopt userspace_ingress_ifaces inventory") {
+		t.Errorf("the error must name the adoption step so the fail-closed cause is attributable; got %q", err)
+	}
+	if m.ingressInventoryAdopted {
+		t.Error("a FAILED enumeration must not mark the inventory adopted — the next pass has to retry, " +
+			"otherwise a single transient scan failure permanently disables the restart reap (#6784)")
+	}
+}
+
+// TestIngressAdoptionRunsOncePerManager6784 is the tightening control: adoption
+// is a RESTART-RECOVERY step, not a standing authority grab over the map.
+//
+// Within a live process the Manager is the sole writer of
+// userspace_ingress_ifaces (the Rust helper never touches it; the shim only
+// reads it), and #6537 established m.lastIngressIfaces as the record of what
+// this process installed. Re-enumerating on every pass would quietly widen the
+// reap to rows the Manager never installed and never recorded, which is a
+// different contract from the one #6537 tests pin.
+//
+// The discriminator: a row injected BETWEEN two syncs is not in the config and
+// not in the inventory. A once-per-Manager adoption leaves it alone; a
+// per-pass adoption reaps it.
+//
+// FAIL-ON-REVERT: removing the `if m.ingressInventoryAdopted { return nil }`
+// early return makes the second sync re-enumerate and delete ifindex 77, and
+// the "must survive" assertion goes RED.
+func TestIngressAdoptionRunsOncePerManager6784(t *testing.T) {
+	m, ifaceMap := newIngressManager(t, ebpf.Hash, 16)
+
+	if err := m.syncIngressIfaceMapLocked(ingressSnapshot(10)); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	if !m.ingressInventoryAdopted {
+		t.Fatal("premise broken: the first sync must have adopted the pinned map")
+	}
+
+	// A row appears that this Manager did not install and did not record.
+	prepopulateIngressRows(t, ifaceMap, 77)
+
+	if err := m.syncIngressIfaceMapLocked(ingressSnapshot(10)); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	got := ingressRowsPresent(t, ifaceMap)
+	if !slices.Contains(got, uint32(77)) {
+		t.Errorf("adoption must run ONCE per Manager (restart recovery), not on every pass: "+
+			"ifindex 77 was injected after the first sync, so it is neither configured nor in the "+
+			"#6537 inventory, and a per-pass re-enumeration reaped it. rows=%v (#6784)", got)
+	}
+	if !slices.Contains(got, uint32(10)) {
+		t.Errorf("the configured ifindex 10 must still be present; rows=%v", got)
+	}
+}


### PR DESCRIPTION
Closes #6784

All cites are **re-derived from code at `c54d4b918`**. The issue body points at
`/tmp/opus-review-001.md` section R43, which no longer exists.

## The three questions, measured separately

The issue's fix direction contains the sharp observation — *"separate classifier
pin lifecycle from intentionally retained session maps"* — so I tested each half
of it rather than accepting it.

**1. Does the pin survive?** YES. `userspace_ingress_ifaces` is in
`userspacePinnedShimMaps()` and loaded via `loadOrCreatePinnedShimMapWith`, which
sets `spec.Pinning = ebpf.PinByName` against `/sys/fs/bpf/xpf`. Nothing on the
normal startup path unlinks it (`os.RemoveAll(bpfPinPath)` exists only on the
legacy loader's Unload path). An ABI-incompatible pin is *refused*, not reset.

**2. Does a fresh manager fail to enumerate it?** YES. `syncIngressIfaceMapLocked`
reaps by iterating `m.lastIngressIfaces`, an ordinary `Manager` field that starts
nil. On the first pass after a restart `prior` is empty, so the reap loop deletes
nothing. `flushStaleBPFStateOnCtrlEnableLocked` — the one thing that *does* run a
cross-restart cleanup — touches only the SESSION maps, which is exactly the
deliberate HA retention the issue contrasts against.

**3. Does a stale row still MATCH traffic?** YES, and this is the answer that set
the severity. `userspace-xdp/src/lib.rs`:
`if USERSPACE_INGRESS_IFACES.get(&ingress_ifindex).map_or(true, |v| *v == 0) {
return Ok(cpumap_or_pass(ctrl)); }` — read on **every packet**. A present
non-zero row is precisely what diverts a packet away from the kernel path into
the AF_XDP redirect pipeline. So this is not a leak of an unread row; it is the
gate every later stage sits behind.

Trigger in the field: a config change while xpfd is down, or an interface deleted
and its ifindex later reused (this map is explicitly keyed on kernel ifindex,
"which can exceed MAX_INTERFACES on long-lived VMs — ifindex grows
monotonically").

## What contradicts / refines the issue

**The issue says "classifier rows"; only ONE of the three classifier syncs had
the hole.** I checked each:

| sync | reap bound by | fresh-manager safe? |
|---|---|---|
| `syncIngressIfaceMapLocked` | in-process `m.lastIngressIfaces` | **NO — this PR** |
| `syncLocalAddressMapsLocked` | `localV4Map.Iterate()` — the MAP | yes, already |
| `syncInterfaceNATAddressMapsLocked` | `natV4Map.Iterate()` — the MAP | yes, already |
| `userspace_heartbeat` zero-init | the Array's OWN capacity (#6702) | yes, already |
| `userspace_ctrl` | single key, fully rewritten | yes |

So **reconstructing inventory from the pinned map was not merely the preferable
option — it was already the established pattern in this same file**, with three
precedents. No sweep-and-recreate, and therefore no window where the classifier
is empty at bring-up.

**`userspace_bindings` shares the shape but is deliberately NOT fixed here.**
`programBootstrapMapsLocked` calls `clearAllBindingRowsLocked`, which also
iterates an in-process list (`m.lastBindingIndices`) and so zeroes nothing on a
fresh Manager. Two reasons to leave it:
- **Unreachable once the gate is repaired.** The shim consults
  `userspace_ingress_ifaces` BEFORE the binding array, so a stale binding for a
  de-configured interface is never reached; for an interface still in the config,
  `applyHelperStatusLocked` rewrites its rows from live helper status every poll.
- **A blanket sweep is not viable at that size.** `BindingArrayMaxEntries` is
  `MaxInterfaces * BindingQueuesPerIface` = **1,048,576** rows (the heartbeat
  Array is 4096), so sweeping it would put a million map syscalls on every
  non-same-plan apply.

`verifyBindingsMapLocked` does **not** cover it either — it is a repair-only
watchdog in the opposite direction (it repopulates rows that are wrongly zero).

## The fix

`adoptIngressInventoryLocked` enumerates the pinned map ONCE per Manager, before
the inventory is read. Four deliberate properties:

- **Union, not replace** — cannot drop a #6537 retry debt.
- **Recorded only on success** — a transient scan failure retries rather than
  latching a partial view.
- **Enumeration failure is FATAL** — matching how the two sibling classifier
  syncs already treat an iteration failure; the caller
  (`syncUserspaceClassifierMapsFailClosedLocked`) then drives `userspace_ctrl` to
  `Enabled=0`, so the shim stops redirecting transit rather than running against
  a classifier no one can account for.
- **Only rows the shim ACTS on (value != 0)** — a 0-valued row takes the same
  `cpumap_or_pass` path as an absent one, so it diverts nothing. This filter also
  keeps adoption correct independent of the map's DENSITY instead of assuming a
  HashMap, and that is not hypothetical: see M4 below.

Adoption runs once per Manager, not per pass — within a live process the Manager
is the map's sole writer (the Rust helper never touches it; the shim only reads
it) and `m.lastIngressIfaces` is the #6537 record of what this process installed.

## Mutation matrix

Fix committed BEFORE the matrix. One mutation per line, anchor asserted to match
exactly once, tree rebuilt, then the **full package suite** with `-count=1` and
**no `-run` filter**.

**Privilege handling matters here and is the reason this matrix is trustworthy.**
These tests need real BPF maps and SKIP unprivileged — as `uid 1000` the entire
#6537/#6784 group silently skips and *every cell would be a false green*. So every
cell was run **under `sudo`, from the package directory** (a compiled binary run
from `/tmp` breaks the source-scanning tests' relative paths — that alone
produced 27 phantom failures before I corrected it), and each cell asserts
`skipped_6784_cells == 0`. Cells are diffed against a **root baseline captured at
unmodified master** in a separate detached worktree, with durations stripped from
the comparison (they are part of the `--- FAIL` line and caused one phantom).

Control (M0): **1837 passing, 0 skipped 6784 cells, 0 new failures vs base.**
Base has 7 pre-existing root-only failures, plus two XDP tests that fail
identically at base and at HEAD when run in isolation (verified over 2 runs each)
and are excluded as environmental.

| Cell | Mutation (one line) | Result | Which assertion fired |
|---|---|---|---|
| M0 | none (control) | **GREEN** | 1837 pass / 0 new failures / 0 skips in the 6784 cells |
| M1 | adoption becomes a no-op (**the shipped bug**) | **RED** ×3 | `ifindex 99 was left in the PINNED map … the first sync of a fresh Manager did not reap it: rows=[10 11 99]`; `= [10 11 99], want exactly [10 11]` |
| M2 | **tightening** — drop the once-per-Manager gate (adopt every pass) | **RED** | `adoption must run ONCE per Manager (restart recovery), not on every pass: ifindex 77 … a per-pass re-enumeration reaped it. rows=[10]` |
| M3 | union → overwrite (`= present`) | **SURVIVED** | see below |
| M4 | drop the `val == 0` filter | **RED** | **`TestSyncIngressIfaceMapRetainsInventoryOnDeleteFailure`** (pre-existing #6537 test): `premise broken: seeding sync failed: delete userspace_ingress_ifaces 0: delete: invalid argument` |
| M5 | **tightening** — invert the filter (`val != 0` → skip) | **RED** ×2 | `rows=[10 11 99], want exactly [10 11]`, plus the same #6537 test |
| M6 | mark adopted BEFORE the error return | **RED** | `a FAILED enumeration must not mark the inventory adopted — the next pass has to retry` |
| M7 | swallow the adoption error (`_ = err`) | **RED** | `an unreadable map must FAIL the classifier sync … got nil, so the reap silently ran against an unknown map` |

**M4 is the cell worth reading.** It is caught by a **pre-existing** test, not one
of mine — a `-run 6784` filter would have reported the value filter as unguarded.
It is also how the filter got written: my first implementation adopted every row
regardless of value, which on the #6537 fixture's deliberately-`ebpf.Array` map
(its own comment notes "the production map is a HashMap"; it uses an Array purely
to force a `Delete` failure) enumerated all 16 dense slots and made the seeding
pass fail with `EINVAL`. I caught it by diffing against the root baseline rather
than assuming a root-only failure was environmental, and fixed it on the merits —
keying on the value the shim actually reads — which restores that fixture
**unchanged**, i.e. without decommissioning the guard it encodes.

**M3 SURVIVED, and I am reporting it rather than papering over it.** The union
only differs from an overwrite when `m.lastIngressIfaces` is non-empty while
`ingressInventoryAdopted` is false. `m.lastIngressIfaces` is written at exactly
two sites, both inside `syncIngressIfaceMapLocked` and both AFTER adoption, so
that state is **unreachable by construction** — the discriminator does not vary,
and a test for it would certify a path production never takes. The union is kept
because it costs nothing and reuses the existing `mergeIngressInventory` helper,
but it is defensive code with no reachable discriminator and should be read that
way.

## Validation

- `go build ./...` rc=0 · `go vet ./...` clean · `go test -count=1 ./...`
  (repo-wide, unprivileged) **rc=0**
- Gated head **`446d71e31e162a429afded46687c9785418d6ff7`**, branched from
  `c54d4b9186ce01229edbf12904f7e64c782aede3` and still up to date with
  `origin/master` (verified by `merge-base --is-ancestor`).
- **No Rust touched** (`userspace-xdp/`, `userspace-dp/` unchanged, no shim `.o`),
  so no cargo leg and no cluster smoke is owed. The change is Go-side map
  bookkeeping only.
- **No cluster / VRRP / session-sync / failover code touched.**

## Docs

`docs/afxdp-packet-processing.md` §"Packet steering decision" gains a **Restart
adoption (#6784)** subsection. It also corrects two false statements the old text
made: that `m.lastIngressIfaces` is "the only record of which rows exist in this
map" (it is the record of what *this process* installed), and that a stale row
persisted only "until the daemon restarted" — the restart is exactly what did
*not* clear it. In-code, the `heartbeatZeroSlotBound` comment justified zeroing
the whole heartbeat Array by asserting `clearAllBindingRowsLocked` had "zeroed
every binding row" 25 lines earlier; that is untrue on a fresh Manager, and the
comment now says so (the conclusion survives, because zeroing a heartbeat slot
can only move a packet onto the fail-closed stale-heartbeat branch).
