### PR TITLE
nat: stop reading "no pool to reserve from" as a collision

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104505,3 +104505,18 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/config/compiler_uniformgates_cluster_zone.go`,
   `pkg/config/vrrp_vip_count_6779_test.go` (new), `pkg/vrrp/README.md`,
   `pkg/config/README.md`
+
+## 2026-08-22 — #7581 synced reserve read "no pool" as a collision
+
+- **Timestamp**: 2026-08-22
+- **Action**: `reserve_synced_on_first_pool_owner` returned a bare bool, so "no
+  candidate rule's pool owns the translated address" was indistinguishable from
+  "a pool-owning candidate refused". Interface-mode SNAT is permanently the
+  former, so since #6600 every peer-synced import under interface-mode SNAT was
+  refused BEFORE publish — the standby's helper never received the session,
+  while Go's BPF mirror (what `show security flow session` reads) kept the row.
+  Found by deploying #6785's refusal reporting to the loss cluster: 17
+  `reserve` refusals on fw1 in one iperf3 run, cap drops 0. Made the
+  reservation tri-state; only a pool-owning decline blocks the publish.
+- **File(s)**: userspace-dp/src/nat/source.rs,
+  userspace-dp/src/nat/tests_pool.rs, docs/session-sync-architecture.md, _Log.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -91,6 +91,31 @@ installed into both places:
 install, they clear the cached FIB result so the receiving node recomputes
 node-local forwarding.
 
+**#7581 — a synced import with no pool to reserve from is not a collision.**
+Before publishing a peer-synced session the helper reserves its translated NAT
+tuple (#6600), so the standby cannot advertise a translation a local flow
+already owns. That reservation walks the source-NAT rules for one whose POOL
+contains the translated address. It used to return a bare `bool`, which
+collapsed two opposite outcomes into one `false`: a pool-owning candidate that
+DECLINED (a genuine collision), and NO candidate owning the address at all.
+
+**Interface-mode source NAT is permanently the second case** — the translated
+address is the egress interface's own address, no rule is `pool_mode`, and no
+allocator has anything to hand out. So every peer-synced import under
+interface-mode SNAT read as a collision, and `upsert_synced_session` refused it
+BEFORE `publish_shared_session`: since #6600 those sessions reached neither the
+standby's shared `synced` map nor its worker tables, and a promoted node had no
+state for the flow. It was invisible because the Go side still wrote and kept
+its BPF mirror row — which is what `show security flow session` reads — so an
+operator saw synced sessions the forwarding path did not have. Measured on the
+loss userspace cluster: 17 refusals on the standby during one iperf3 run, all
+`reserve`, with `xpf_userspace_synced_import_cap_drops_total` at 0.
+
+The reservation is now tri-state (`SyncedReserveOutcome`): `Reserved`,
+`Refused`, and `NothingToReserve`. Only `Refused` blocks the publish;
+`NothingToReserve` is answered exactly like the long-standing
+`rewrite_src == None` early return one line above it.
+
 **#5305 — the forward install is transactional.** A forward cluster-synced
 install writes the pinned BPF session mirror FIRST, then mirrors the entry to
 the Rust helper. If the helper mirror fails (connect/write/decode), the install

--- a/userspace-dp/src/nat/source.rs
+++ b/userspace-dp/src/nat/source.rs
@@ -1867,7 +1867,7 @@ fn reserve_synced_source_nat_allocation_with_holder(
             nat.rewrite_src_port,
             now_ns,
             holder,
-        )
+        ) == SyncedReserveOutcome::Reserved
     {
         return true;
     }
@@ -1883,6 +1883,10 @@ fn reserve_synced_source_nat_allocation_with_holder(
     // exactly what shipped before this fix, so no configuration can come out
     // of #6211 with FEWER reservations than it had. Pass 1 can only move a
     // reservation to a better-justified allocator, never remove one.
+    // #7581: PASS 2's answer decides. `NothingToReserve` — no rule's pool owns
+    // the translated address, the shape interface-mode source NAT always
+    // produces — is NOT a refusal, and is answered exactly like the
+    // `rewrite_src == None` early return above.
     reserve_synced_on_first_pool_owner(
         rules.iter(),
         flow,
@@ -1891,6 +1895,7 @@ fn reserve_synced_source_nat_allocation_with_holder(
         now_ns,
         holder,
     )
+    .may_publish()
 }
 
 /// #6211: reserve the synced translation on the first rule in `rules` whose
@@ -1899,6 +1904,46 @@ fn reserve_synced_source_nat_allocation_with_holder(
 /// differ ONLY in which rules they are offered — the reservation semantics
 /// (pool-mode gate, address-index math, address-only vs port-bearing arm,
 /// per-rule fall-through) cannot drift between them.
+/// The outcome of a synced-translation reservation attempt (#7581).
+///
+/// `reserve_synced_on_first_pool_owner` used to return a bare `bool`, which
+/// collapsed two opposite situations into one `false`:
+///
+///   * a candidate rule's pool OWNS the translated address and its allocator
+///     DECLINED — a genuine collision, and the case #6600 exists to refuse; and
+///   * NO candidate owns the translated address at all, so there is nothing to
+///     reserve.
+///
+/// The second is not a refusal. It is the same situation as a decision with no
+/// `rewrite_src`, which the caller has always answered `true` to. Interface-mode
+/// source NAT is exactly this case — the translated address is the egress
+/// interface's own address, no rule is `pool_mode`, and no allocator has
+/// anything to hand out — so every peer-synced import under interface-mode SNAT
+/// read as a collision. `upsert_synced_session` refuses before
+/// `publish_shared_session`, so since #6600 those sessions reached neither the
+/// standby's shared `synced` map nor its worker tables, and the promoted node
+/// had no state for them after a failover. It was invisible because the Go side
+/// kept its BPF mirror row, which is what `show security flow session` reads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SyncedReserveOutcome {
+    /// A pool-owning candidate accepted the reservation.
+    Reserved,
+    /// A pool-owning candidate DECLINED — a different live allocation owns the
+    /// translated identity (#6600). The import must be refused.
+    Refused,
+    /// No candidate rule's pool owns the translated address, so no allocator
+    /// has anything to reserve. Not a refusal.
+    NothingToReserve,
+}
+
+impl SyncedReserveOutcome {
+    /// Whether the caller may publish the synced session. Only `Refused`
+    /// blocks it.
+    pub(crate) fn may_publish(self) -> bool {
+        !matches!(self, SyncedReserveOutcome::Refused)
+    }
+}
+
 fn reserve_synced_on_first_pool_owner<'a>(
     rules: impl Iterator<Item = &'a SourceNatRule>,
     flow: SourceNatFlowKey,
@@ -1909,7 +1954,11 @@ fn reserve_synced_on_first_pool_owner<'a>(
     // #6211 F2: the worker taking this reservation, so a fan-out to N workers
     // records N holders on ONE allocator record.
     holder: NatHolder,
-) -> bool {
+) -> SyncedReserveOutcome {
+    // #7581: `saw_candidate` records whether ANY rule's pool actually owned the
+    // translated address. Without it, "no owner" and "every owner declined"
+    // both fell out of the loop as the same value.
+    let mut saw_candidate = false;
     for rule in rules {
         if !rule.pool_mode {
             continue;
@@ -1930,12 +1979,13 @@ fn reserve_synced_on_first_pool_owner<'a>(
             if !in_pool {
                 continue;
             }
+            saw_candidate = true;
             if rule
                 .pool_allocator
                 .reserve_address_only(flow, rewrite_src, holder)
                 .is_ok()
             {
-                return true;
+                return SyncedReserveOutcome::Reserved;
             }
             continue;
         };
@@ -1954,6 +2004,7 @@ fn reserve_synced_on_first_pool_owner<'a>(
         let Some(addr_index) = addr_index else {
             continue;
         };
+        saw_candidate = true;
         // #5178: tag the reservation deterministic iff this rule runs a
         // deterministic CGNAT (mode 1) pool, so its release uses
         // `free_no_recycle` and the standby's recycle queue does not grow under
@@ -1970,10 +2021,14 @@ fn reserve_synced_on_first_pool_owner<'a>(
             now_ns,
             holder,
         ) {
-            return true;
+            return SyncedReserveOutcome::Reserved;
         }
     }
-    false
+    if saw_candidate {
+        SyncedReserveOutcome::Refused
+    } else {
+        SyncedReserveOutcome::NothingToReserve
+    }
 }
 
 /// #4381: allocate a UNIQUE translated `(pool v4 address, L4 port/identifier)`

--- a/userspace-dp/src/nat/tests_pool.rs
+++ b/userspace-dp/src/nat/tests_pool.rs
@@ -7605,3 +7605,121 @@ fn retained_index_map_remaps_positions_not_replays_them_6765() {
     // Fully disjoint: nothing to carry.
     assert!(crate::nat::retained_pool_index_map_v4(&[a, b], &[c]).is_empty());
 }
+
+// #7581 — the synced reservation must not read "nothing to reserve" as a
+// refusal.
+//
+// `reserve_synced_on_first_pool_owner` returned a bare `bool`, so two opposite
+// situations produced the same `false`: a pool-owning candidate that DECLINED
+// (a real collision, what #6600 exists to refuse) and NO candidate owning the
+// translated address at all. Interface-mode source NAT is permanently the
+// second case — the translated address is the egress interface's own address,
+// no rule is `pool_mode`, and no allocator has anything to hand out — so every
+// peer-synced import under interface-mode SNAT read as a collision and
+// `upsert_synced_session` refused it BEFORE `publish_shared_session`. Since
+// #6600 those sessions reached neither the standby's shared `synced` map nor
+// its worker tables.
+//
+// This is a PAIRED cell on purpose. A lone "no pool returns true" assertion is
+// satisfied by deleting the refusal path outright, which reopens #6600 — so the
+// same call site is driven with a genuine collision and must still refuse.
+#[test]
+fn synced_reserve_distinguishes_no_pool_from_a_refusal_7581() {
+    // (a) INTERFACE MODE: no pool anywhere, translated address is the egress
+    // interface's own address. Nothing owns it, so nothing can reserve it —
+    // and that must not block the import.
+    let iface_rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "snat-iface".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        interface_mode: true,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    // Guard the fixture's own premise: if the parse ever produced a pool-mode
+    // rule here, this cell would be exercising the wrong arm and would pass for
+    // the wrong reason.
+    assert!(
+        iface_rules.iter().all(|r| !r.pool_mode),
+        "fixture must be interface-mode (no pool_mode rule), got {:?}",
+        iface_rules.iter().map(|r| r.pool_mode).collect::<Vec<_>>()
+    );
+
+    let key = session_key_from_src("10.0.61.50", 40000, "8.8.8.8", 443);
+    let iface_nat = NatDecision {
+        // The egress interface address — deliberately NOT a pool member.
+        rewrite_src: Some("172.16.80.8".parse().unwrap()),
+        rewrite_src_port: Some(42650),
+        ..NatDecision::default()
+    };
+    assert!(
+        reserve_synced_source_nat_allocation_untracked(
+            &iface_rules,
+            &key,
+            iface_nat,
+            false,
+            Some(("lan", "wan")),
+            0,
+        ),
+        "an interface-mode synced import has NOTHING to reserve — no rule's \
+         pool owns the egress address — and must not be read as a collision. \
+         Refusing it stops the standby publishing the session at all, so a \
+         promoted node has no state for the flow (#7581)"
+    );
+
+    // (b) POOL MODE, GENUINE COLLISION: the same call site must still refuse
+    // when a pool-owning candidate declines. Without this leg, (a) is satisfied
+    // by removing the refusal entirely and #6600 silently reopens.
+    let pool_rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "snat-pool".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "pool-lan".to_string(),
+        pool_addresses: vec!["203.0.113.10/32".to_string()],
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    let pool_nat = NatDecision {
+        rewrite_src: Some("203.0.113.10".parse().unwrap()),
+        rewrite_src_port: Some(20000),
+        ..NatDecision::default()
+    };
+
+    // A DIFFERENT live local flow already owns the translated identity.
+    let squatter = SourceNatFlowKey {
+        protocol: PROTO_TCP,
+        src_ip: "10.0.61.99".parse().unwrap(),
+        dst_ip: "8.8.8.8".parse().unwrap(),
+        src_port: 40099,
+        dst_port: 443,
+    };
+    assert!(
+        pool_rules[0].pool_allocator.reserve_flow(
+            squatter,
+            TranslatedTuple {
+                ip: "203.0.113.10".parse().unwrap(),
+                port: 20000,
+            },
+            0,
+            false,
+            0,
+            NatHolder::Untracked,
+        ),
+        "fixture: the squatting local flow must take the identity first, or the \
+         refusal leg below cannot happen"
+    );
+
+    assert!(
+        !reserve_synced_source_nat_allocation_untracked(
+            &pool_rules,
+            &key,
+            pool_nat,
+            false,
+            Some(("lan", "wan")),
+            0,
+        ),
+        "a pool-owning candidate that DECLINES is a genuine collision and must \
+         still refuse the import — the standby would otherwise advertise a \
+         translation it does not own (#6600)"
+    );
+}


### PR DESCRIPTION
Closes #7581

## The bug, found by deploying #6785 rather than by reading

Before publishing a peer-synced session the helper reserves its translated NAT
tuple (#6600), so the standby cannot advertise a translation a local flow
already owns. `reserve_synced_on_first_pool_owner` returned a bare `bool`, and
that collapsed **two opposite outcomes** into one `false`:

- a candidate rule whose pool **owns** the translated address and whose
  allocator **declined** — a genuine collision, the case #6600 exists to refuse;
- **no candidate owning the address at all**, so the loop falls out having never
  consulted an allocator.

**Interface-mode source NAT is permanently the second case.** The translated
address is the egress interface's own address, no rule is `pool_mode`, and no
allocator has anything to hand out. So every peer-synced import under
interface-mode SNAT read as a collision, and `upsert_synced_session` refuses
*before* `publish_shared_session` — meaning **since #6600 those sessions reached
neither the standby's shared `synced` map nor its worker tables, and a promoted
node had no state for the flow.**

It stayed invisible because the failure had no reporting path in either
direction: `upsert_synced_session` returned `()`, so Go recorded a success and
kept its BPF mirror row — and that row is what `show security flow session`
reads. An operator saw synced sessions the forwarding path did not have.

One line above the defect, the same function already has the correct shape:
`let Some(rewrite_src) = nat.rewrite_src else { return true; }`. "Nothing to
reserve" has always been treated as success there. The no-pool case is the same
situation and got the opposite answer.

## Measured, not reasoned

Deployed #6785's refusal reporting to the loss userspace cluster and drove
iperf3 across it:

```
fw1 (standby): 17 x  "...refused a synced session import ... err=...: reserve"
fw0 (active):  0
xpf_userspace_synced_import_cap_drops_total  0      (not the #5674 cap)
```

That cluster's WAN SNAT is interface-mode — a session renders as
`In: 172.16.80.8/42650 --> 172.16.80.200/5201`, and `172.16.80.8` is reth0.80's
**own** address, not a pool member.

Sequence that produced it: PR 7580 (#6785) failed the failover smoke on two
session-count cells, twice, reproducibly. Plain `origin/master` passed the same
smoke **14/14**, which isolated the change; a diagnostic deploy that logged the
refusal reason named `reserve`; and the code read then explained why `reserve`
fires on every import on this cluster.

## Fix

The reservation is tri-state (`SyncedReserveOutcome`): `Reserved`, `Refused`,
`NothingToReserve`. Only `Refused` blocks the publish. `saw_candidate` records
whether any rule's pool actually owned the address — the distinction the bool
could not carry.

## Test: a paired cell, and the second leg is the load-bearing one

`synced_reserve_distinguishes_no_pool_from_a_refusal_7581` drives the **same
call site** with both shapes:

1. an **interface-mode** fixture — asserted to contain no `pool_mode` rule, so
   it cannot pass by exercising the wrong arm — must **not** be refused;
2. a **pool-mode** rule whose translated identity a different live local flow
   already holds must **still** be refused.

Leg 2 is not decoration: a lone "no pool returns true" assertion is satisfied by
deleting the refusal path outright, which silently reopens #6600.

## Gates

- `cargo test --release --bins --tests -- --test-threads=1` — rc=0, 4586 tests.
- `go build ./... && go vet ./... && go test -count=1 ./...` — rc=0, 67 packages.
- rustfmt diff-line count against `origin/master` **unchanged per touched file**
  (source.rs 80→80, tests_pool.rs 747→747); no crate-wide `cargo fmt`.
- Head `98ad458c9`, tree clean.
- **Cluster smoke running** — this changes what the standby publishes, so it
  owes `make test-failover` and I am running it before merge.

## Relationship to the other issues

- **#6785 cannot land until this does.** Its refusal reporting is correct, but
  reporting a refusal that fires on every import empties the standby's session
  table. PR 7580 stays open until this merges.
- **#6751** (interface-mode SNAT admits indistinguishable no-PAT return tuples)
  is the same blind spot — interface mode has no allocator involvement at all —
  with a different consequence.
