### PR TITLE
ha: stop the Kea units before relinquishing ownership

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104505,3 +104505,21 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/config/compiler_uniformgates_cluster_zone.go`,
   `pkg/config/vrrp_vip_count_6779_test.go` (new), `pkg/vrrp/README.md`,
   `pkg/config/README.md`
+
+## 2026-08-22 — #6787 orderly HA shutdown left the Kea units serving
+
+- **Timestamp**: 2026-08-22
+- **Action**: `runShutdownSequence` withdrew RA, removed VIPs, sent VRRP
+  priority-0 and stopped the heartbeat without ever stopping the DHCP server.
+  Kea runs as separate systemd units that outlive xpfd, so the promoted peer
+  and this node both served DHCP on one segment for the whole downtime. Added
+  `dhcpserver.Manager.Shutdown()` — synchronous (an async stop races process
+  exit) and latching (`shuttingDown` coerces every later applier to nil, since
+  a VRRP MASTER transition racing the pre-withdrawal window allocates a NEWER
+  generation the #1835 supersession guard cannot refuse). Called from
+  `runShutdownSequence` BEFORE the withdrawal, gated on cluster mode so a
+  standalone restart does not become a DHCP outage.
+- **File(s)**: pkg/dhcpserver/dhcpserver.go,
+  pkg/dhcpserver/shutdown_latch_6787_test.go,
+  pkg/daemon/daemon_run_shutdown.go,
+  pkg/daemon/shutdown_dhcp_stop_6787_test.go, pkg/dhcpserver/README.md, _Log.md

--- a/pkg/daemon/daemon_run_shutdown.go
+++ b/pkg/daemon/daemon_run_shutdown.go
@@ -179,6 +179,41 @@ func (d *Daemon) runShutdownSequence(wg *sync.WaitGroup, stop func(), runErr err
 		}
 	}
 
+	// #6787: STOP THE KEA UNITS BEFORE RELINQUISHING OWNERSHIP.
+	//
+	// Everything below this point hands the segment to the peer: the RA
+	// goodbye, the VIP removal, VRRP's priority-0 burst, and the heartbeat
+	// stop. None of them touched the DHCP server, and Kea runs as SEPARATE
+	// systemd units that outlive xpfd. So an orderly HA shutdown promoted the
+	// peer — which starts ITS Kea on the same segment — while this node's Kea
+	// kept answering: duplicate OFFERs, and two lease databases handing out
+	// addresses from one pool with neither aware of the other. The units also
+	// survived the whole xpfd downtime, so the condition persisted until the
+	// operator noticed.
+	//
+	// Placed BEFORE the withdrawal, not after, so there is never a moment when
+	// both nodes serve. Synchronous, because ApplyAsync's mailbox is drained by
+	// a worker goroutine and a stop enqueued during shutdown races process exit
+	// — a fix that is present and does nothing looks exactly like a fix that
+	// works. Manager.Shutdown also LATCHES, so a VRRP MASTER transition racing
+	// this window cannot re-arm the units with a newer generation.
+	//
+	// CLUSTER MODE ONLY. In standalone there is no peer to hand the segment to,
+	// and Kea deliberately survives an xpfd restart today; stopping it here
+	// would turn every daemon restart into a DHCP outage. haMode is the
+	// discriminator, not `hitless`: VRRP sends its priority-0 burst even on a
+	// hitless HA restart, so the peer takes over and this node must stop
+	// serving either way.
+	if haMode && d.dhcpServer != nil {
+		if err := d.dhcpServer.Shutdown(); err != nil {
+			slog.Warn("shutdown: failed to stop the DHCP server units — this "+
+				"node may keep answering DHCP while the peer serves the same "+
+				"segment", "err", err)
+		} else {
+			slog.Info("shutdown: DHCP server stopped before relinquishing ownership")
+		}
+	}
+
 	// Withdraw RA senders (sends goodbye RAs with lifetime=0) before VRRP
 	// stop so hosts immediately stop using this node as a default router.
 	if d.ra != nil {

--- a/pkg/daemon/shutdown_dhcp_stop_6787_test.go
+++ b/pkg/daemon/shutdown_dhcp_stop_6787_test.go
@@ -1,0 +1,287 @@
+package daemon
+
+// shutdown_dhcp_stop_6787_test.go — #6787 WIRING + ORDERING regression.
+//
+// The mechanics live in pkg/dhcpserver (Manager.Shutdown + the latch, bound by
+// shutdown_latch_6787_test.go there). Those cells stay GREEN if runShutdownSequence
+// never calls Shutdown at all — which is exactly the bug: an orderly HA shutdown
+// withdrew VRRP ownership, cleared rg_active and stopped the heartbeat while
+// leaving the Kea units running, so the promoted peer and this node both served
+// DHCP on one segment.
+//
+// These cells drive the real teardown path and assert what only the wiring
+// produces.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dhcpserver"
+)
+
+// keaRecorder6787 records systemctl invocations and the resulting unit state.
+type keaRecorder6787 struct {
+	mu     sync.Mutex
+	calls  []string
+	active map[string]bool
+}
+
+func newKeaRecorder6787() *keaRecorder6787 {
+	return &keaRecorder6787{active: map[string]bool{}}
+}
+
+func (r *keaRecorder6787) run(args ...string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, strings.Join(args, " "))
+	if len(args) >= 2 {
+		switch args[0] {
+		case "restart", "start":
+			r.active[args[1]] = true
+		case "stop":
+			r.active[args[1]] = false
+		}
+	}
+	return nil
+}
+
+func (r *keaRecorder6787) isActive(unit string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.active[unit]
+}
+
+func (r *keaRecorder6787) anyActive() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, on := range r.active {
+		if on {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *keaRecorder6787) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+func servingDHCPConfig6787() *config.DHCPServerConfig {
+	return &config.DHCPServerConfig{
+		DHCPLocalServer: &config.DHCPLocalServerConfig{
+			Groups: map[string]*config.DHCPServerGroup{"g4": {
+				Name:       "g4",
+				Interfaces: []string{"reth1.0"},
+				Pools: []*config.DHCPPool{{
+					Name:      "p4",
+					Subnet:    "10.0.61.0/24",
+					RangeLow:  "10.0.61.100",
+					RangeHigh: "10.0.61.200",
+				}},
+			}},
+		},
+	}
+}
+
+// clusterDaemon6787 builds a Daemon whose ACTIVE config is a chassis cluster,
+// with a serving Kea manager wired in, ready to be driven through
+// runShutdownSequence.
+func clusterDaemon6787(t *testing.T, cluster bool) (*Daemon, *keaRecorder6787) {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := configstore.New(filepath.Join(dir, "xpf.conf"))
+	if err != nil {
+		t.Fatalf("configstore.New: %v", err)
+	}
+	if cluster {
+		// A cluster stanza with NO redundancy groups: enough to make haMode
+		// true without entering the rg_active loop, which would need a live HA
+		// controller. hitless-restart is set so the teardown takes the hitless
+		// arm with a nil dataplane — the DHCP stop is gated on haMode, NOT on
+		// hitless, and a fixture that only covered the fail-closed arm would
+		// miss exactly the case this distinction exists for. The
+		// authentication-key is not optional (commit rejects a cluster without
+		// one), so it is fixture scaffolding.
+		if err := store.EnterConfigure(); err != nil {
+			t.Fatalf("EnterConfigure: %v", err)
+		}
+		if err := store.LoadOverride(`
+chassis {
+    cluster {
+        cluster-id 1;
+        node 0;
+        authentication-key "cyaLE6jUXcHqZBB6xSJP7CVc5S9dHRBAtF5vTBqFEss=";
+        hitless-restart;
+    }
+}
+`); err != nil {
+			t.Fatalf("LoadOverride: %v", err)
+		}
+		if _, err := store.Commit(); err != nil {
+			t.Fatalf("Commit: %v", err)
+		}
+		store.ExitConfigure()
+		cfg := store.ActiveConfig()
+		if cfg == nil || cfg.Chassis.Cluster == nil {
+			t.Fatalf("fixture must commit a cluster config; got %+v", cfg)
+		}
+	}
+
+	r := newKeaRecorder6787()
+	mgr := dhcpserver.NewManagerForTesting(
+		filepath.Join(dir, "kea-dhcp4.conf"),
+		filepath.Join(dir, "kea-dhcp6.conf"),
+		r.run,
+		r.isActive,
+	)
+	if err := mgr.Apply(servingDHCPConfig6787()); err != nil {
+		t.Fatalf("precondition Apply: %v", err)
+	}
+	if !r.anyActive() {
+		t.Fatalf("precondition: no Kea unit started, so a later 'nothing "+
+			"active' assertion would prove nothing; calls=%v", r.snapshot())
+	}
+
+	daemonCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	d := &Daemon{
+		store:      store,
+		applySem:   semaphore.NewWeighted(1),
+		daemonCtx:  daemonCtx,
+		dhcpServer: mgr,
+	}
+	return d, r
+}
+
+// runShutdownFor6787 drives the real teardown path and joins it. The empty
+// WaitGroup is deliberate: this harness starts no run goroutines, so the
+// sequence has nothing to wait on and the assertion below observes only what
+// the sequence itself did.
+func runShutdownFor6787(t *testing.T, d *Daemon) {
+	t.Helper()
+	var wg sync.WaitGroup
+	_, stopRun := context.WithCancel(context.Background())
+	sentinel := errors.New("run-error-passthrough")
+	done := make(chan error, 1)
+	go func() { done <- d.runShutdownSequence(&wg, stopRun, sentinel) }()
+	select {
+	case got := <-done:
+		if !errors.Is(got, sentinel) {
+			t.Fatalf("runShutdownSequence returned %v, want the run error passed through", got)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("runShutdownSequence did not return within 30s")
+	}
+}
+
+// TestRunShutdownSequenceStopsKeaInClusterMode6787 is the wiring cell.
+//
+// RED-on-revert: delete the d.dhcpServer.Shutdown() call from
+// runShutdownSequence and the units stay active after the sequence returns,
+// while every pkg/dhcpserver cell stays green.
+func TestRunShutdownSequenceStopsKeaInClusterMode6787(t *testing.T) {
+	d, r := clusterDaemon6787(t, true)
+
+	runShutdownFor6787(t, d)
+
+	if r.anyActive() {
+		t.Fatalf("a Kea unit is still active after an orderly HA shutdown — "+
+			"the peer promotes and starts ITS Kea while this node keeps "+
+			"answering on the same segment (#6787); calls=%v", r.snapshot())
+	}
+}
+
+// TestRunShutdownSequenceLeavesKeaAloneStandalone6787 is the PAIRED half, and
+// it is what keeps the fix from being a regression.
+//
+// In standalone there is no peer to hand the segment to, and the Kea units are
+// separate systemd services that deliberately survive an xpfd restart today.
+// Stopping them here would turn every daemon restart into a DHCP outage. The
+// discriminator is cluster mode, NOT the hitless flag — VRRP sends its
+// priority-0 burst even on a hitless HA restart, so the peer takes over and an
+// HA node must stop serving either way.
+//
+// Without this cell, "cluster mode stops Kea" would be satisfied by an
+// unconditional stop, which is a strictly worse behaviour than the bug.
+func TestRunShutdownSequenceLeavesKeaAloneStandalone6787(t *testing.T) {
+	d, r := clusterDaemon6787(t, false)
+
+	runShutdownFor6787(t, d)
+
+	if !r.anyActive() {
+		t.Fatalf("Kea was stopped on a STANDALONE shutdown — there is no peer "+
+			"to hand the segment to, and the units survive an xpfd restart "+
+			"today, so this makes every daemon restart a DHCP outage; calls=%v",
+			r.snapshot())
+	}
+}
+
+// TestKeaStopPrecedesVRRPWithdrawal6787 pins the ORDERING, which is the whole
+// point of the fix rather than an implementation detail: stopping Kea AFTER the
+// priority-0 burst still leaves a window in which the peer is already serving
+// and this node has not stopped.
+//
+// It is a source check, deliberately. The behavioural observation would need
+// the VRRP manager and the Kea manager instrumented together inside one
+// runShutdownSequence, and pkg/daemon has no seam that orders them — a cell
+// built on a sleep or on goroutine scheduling would be the kind of green that
+// is indistinguishable from healthy.
+//
+// Comments are stripped before matching: the comment introducing the stop names
+// the VRRP stop, and a gate satisfiable by its own documentation proves nothing.
+func TestKeaStopPrecedesVRRPWithdrawal6787(t *testing.T) {
+	src, err := os.ReadFile("daemon_run_shutdown.go")
+	if err != nil {
+		t.Fatalf("read daemon_run_shutdown.go: %v", err)
+	}
+	var code strings.Builder
+	for _, line := range strings.Split(string(src), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			code.WriteString("\n")
+			continue
+		}
+		code.WriteString(line)
+		code.WriteString("\n")
+	}
+	body := code.String()
+
+	const keaStop = "d.dhcpServer.Shutdown()"
+	const vrrpStop = "d.vrrpMgr.Stop()"
+	const clusterStop = "d.cluster.Stop()"
+
+	keaAt := strings.Index(body, keaStop)
+	if keaAt < 0 {
+		t.Fatalf("%s is not called in runShutdownSequence — an orderly HA "+
+			"shutdown relinquishes ownership with the Kea units still serving "+
+			"(#6787)", keaStop)
+	}
+	for _, later := range []struct{ name, needle string }{
+		{"the VRRP priority-0 withdrawal", vrrpStop},
+		{"the cluster heartbeat stop", clusterStop},
+	} {
+		at := strings.Index(body, later.needle)
+		if at < 0 {
+			t.Fatalf("%s not found; this cell can no longer order against %s",
+				later.needle, later.name)
+		}
+		if keaAt > at {
+			t.Fatalf("the Kea stop runs AFTER %s — the peer is already promoted "+
+				"and serving while this node has not stopped, which is the "+
+				"overlap window the fix exists to close (#6787)", later.name)
+		}
+	}
+}

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -32,6 +32,40 @@ parses a torn file, no fsync on the apply path.
   fail-open left stale/removed Kea policy serving). The generated-config
   unlink error on a removed family is surfaced too (a leftover file
   could resurrect a removed subnet on a later manual/boot start).
+- `Shutdown() error` — `dhcpserver.go`. The authoritative DHCP stop
+  for daemon shutdown (#6787), and the only one on that path. Before
+  it, an orderly HA shutdown withdrew VRRP ownership, cleared
+  `rg_active` and stopped the heartbeat while leaving the Kea units
+  RUNNING — they are separate systemd services that outlive xpfd — so
+  the promoted peer started its own Kea and both nodes served DHCP on
+  one segment: duplicate OFFERs, two lease databases issuing addresses
+  from one pool with neither aware of the other, persisting for the
+  whole xpfd downtime.
+
+  It is **synchronous**: `ApplyAsync`'s mailbox is drained by a worker
+  goroutine, so a stop enqueued during shutdown races process exit and
+  is simply lost — a fix that is present and does nothing looks exactly
+  like one that works.
+
+  It also **latches** (`shuttingDown`): once set, EVERY applier —
+  `Apply`, `ApplyClusterCommit` and the async worker — coerces its
+  desired state to `nil`. The latch is not belt-and-braces. `Shutdown`
+  runs BEFORE the priority-0 withdrawal, so this node stops serving
+  before the peer starts, and that ordering leaves a window in which a
+  VRRP MASTER transition can still enqueue an apply. That request
+  allocates a strictly NEWER generation, so the #1835 supersession
+  guard cannot refuse it — without the latch it would re-arm the units
+  after the stop had already reported success. Coercing rather than
+  REFUSING keeps the reconcile idempotent: a late applier still runs,
+  and still lands on "stopped".
+
+  **Cluster mode only** at the call site (`pkg/daemon`,
+  `runShutdownSequence`). Standalone has no peer to hand the segment
+  to and Kea deliberately survives an xpfd restart there; stopping it
+  would turn every daemon restart into a DHCP outage. The
+  discriminator is `haMode`, NOT `hitless` — VRRP sends its priority-0
+  burst even on a hitless HA restart, so the peer takes over and an HA
+  node must stop serving either way.
 - `ApplyAsync(cfg, reason)` — `dhcpserver.go`. Enqueues an `Apply` to
   a single lazily started worker via a 1-slot latest-wins mailbox and
   returns immediately (#1835 F2). Used by the VRRP transition

--- a/pkg/dhcpserver/dhcpserver.go
+++ b/pkg/dhcpserver/dhcpserver.go
@@ -156,6 +156,20 @@ type Manager struct {
 	// errored: the newest state was ATTEMPTED, and replaying an older
 	// state over a failed newer one would regress desired state.
 	lastAppliedGen uint64
+	// shuttingDown latches at daemon shutdown (#6787). Once set, EVERY
+	// applier — sync Apply, ApplyClusterCommit, and the async worker —
+	// coerces its desired state to nil, so no late caller can restart Kea
+	// after the node has begun relinquishing ownership.
+	//
+	// A latch rather than a second stop call, because the hazard is a race,
+	// not a missed step: `Shutdown` runs BEFORE the priority-0 withdrawal so
+	// this node stops serving before the peer starts, which leaves a window in
+	// which a VRRP MASTER transition can still enqueue an ApplyAsync with a
+	// HIGHER generation and re-arm the units. The supersession guard cannot
+	// help there — the racing request is genuinely newer. Coercing rather than
+	// REFUSING keeps the reconcile idempotent and convergent: a late applier
+	// still runs, and still lands on "stopped".
+	shuttingDown atomic.Bool
 	// staleApplySkips counts apply bodies skipped as superseded
 	// (observable by tests; useful telemetry if exported later).
 	staleApplySkips atomic.Uint64
@@ -320,6 +334,16 @@ func (m *Manager) apply(gen uint64, cfg *config.DHCPServerConfig, restartInactiv
 		return nil
 	}
 
+	// #6787: once shutdown has latched, the only legal desired state is
+	// "stopped". A VRRP MASTER transition racing the shutdown allocates a
+	// NEWER generation than Shutdown's own apply, so the supersession guard
+	// above cannot stop it re-arming Kea after this node has begun
+	// relinquishing ownership — which is precisely how both nodes end up
+	// serving DHCP on one segment.
+	if m.shuttingDown.Load() {
+		cfg = nil
+	}
+
 	var errs []error
 
 	want4 := cfg != nil && cfg.DHCPLocalServer != nil && len(cfg.DHCPLocalServer.Groups) > 0
@@ -395,6 +419,34 @@ func (m *Manager) ClaimApplyRetry(now time.Time) bool {
 	}
 	m.lastRetryClaim = now
 	return true
+}
+
+// Shutdown performs the authoritative DHCP-server stop for daemon shutdown
+// (#6787) and is the ONLY stop on that path — before it, an orderly HA
+// shutdown withdrew VRRP ownership, cleared rg_active, and stopped the
+// heartbeat while leaving the Kea units RUNNING. The peer promoted and started
+// its own Kea, so both nodes served DHCP on the same segment: duplicate
+// OFFERs, and two lease databases handing out the same addresses with neither
+// aware of the other.
+//
+// It is SYNCHRONOUS on purpose. ApplyAsync's mailbox is drained by a worker
+// goroutine, so a stop enqueued during shutdown races process exit and is
+// simply lost — the failure mode is "the fix is present and does nothing",
+// which looks identical to working. The commit path already has a synchronous
+// applier for exactly this reason.
+//
+// It also LATCHES (see shuttingDown). Shutdown runs before the priority-0
+// withdrawal so this node stops serving before the peer starts serving, and
+// that ordering leaves a window in which a VRRP MASTER transition can enqueue
+// an apply with a NEWER generation. Stopping without latching would let that
+// window re-arm the units after the stop had "succeeded".
+//
+// The error is returned rather than logged so a caller can report a Kea that
+// refused to stop; the units are separate systemd services, so a failure here
+// means they are still serving and the operator needs to know.
+func (m *Manager) Shutdown() error {
+	m.shuttingDown.Store(true)
+	return m.apply(m.applyGen.Add(1), nil, true)
 }
 
 // ApplyAsync enqueues an authoritative Apply for cfg and returns

--- a/pkg/dhcpserver/shutdown_latch_6787_test.go
+++ b/pkg/dhcpserver/shutdown_latch_6787_test.go
@@ -1,0 +1,244 @@
+package dhcpserver
+
+import (
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// servingConfig6787 is a minimal desired state with BOTH families configured,
+// so a reconcile that honours it starts kea-dhcp4 AND kea-dhcp6.
+func servingConfig6787() *config.DHCPServerConfig {
+	return &config.DHCPServerConfig{
+		DHCPLocalServer: &config.DHCPLocalServerConfig{
+			Groups: map[string]*config.DHCPServerGroup{"g4": {
+				Name:       "g4",
+				Interfaces: []string{"reth1.0"},
+				Pools: []*config.DHCPPool{{
+					Name:      "p4",
+					Subnet:    "10.0.61.0/24",
+					RangeLow:  "10.0.61.100",
+					RangeHigh: "10.0.61.200",
+				}},
+			}},
+		},
+		DHCPv6LocalServer: &config.DHCPLocalServerConfig{
+			Groups: map[string]*config.DHCPServerGroup{"g6": {
+				Name:       "g6",
+				Interfaces: []string{"reth1.0"},
+				Pools: []*config.DHCPPool{{
+					Name:      "p6",
+					Subnet:    "2001:db8:61::/64",
+					RangeLow:  "2001:db8:61::100",
+					RangeHigh: "2001:db8:61::200",
+				}},
+			}},
+		},
+	}
+}
+
+// systemctlRecorder6787 records every systemctl invocation and reports the
+// units it believes are active, so a test can distinguish "asked to stop" from
+// "actually reconciled to stopped".
+type systemctlRecorder6787 struct {
+	mu     sync.Mutex
+	calls  []string
+	active map[string]bool
+}
+
+func newRecorder6787() *systemctlRecorder6787 {
+	return &systemctlRecorder6787{active: map[string]bool{}}
+}
+
+func (r *systemctlRecorder6787) run(args ...string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, strings.Join(args, " "))
+	if len(args) >= 2 {
+		switch args[0] {
+		case "restart", "start":
+			r.active[args[1]] = true
+		case "stop":
+			r.active[args[1]] = false
+		}
+	}
+	return nil
+}
+
+func (r *systemctlRecorder6787) isActive(unit string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.active[unit]
+}
+
+func (r *systemctlRecorder6787) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+func (r *systemctlRecorder6787) anyActive() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, on := range r.active {
+		if on {
+			return true
+		}
+	}
+	return false
+}
+
+func newManager6787(t *testing.T, r *systemctlRecorder6787) *Manager {
+	t.Helper()
+	dir := t.TempDir()
+	return NewManagerForTesting(
+		filepath.Join(dir, "kea-dhcp4.conf"),
+		filepath.Join(dir, "kea-dhcp6.conf"),
+		r.run,
+		r.isActive,
+	)
+}
+
+// TestShutdownStopsRunningKeaUnits6787 is the first half: Shutdown must
+// actually reconcile a SERVING manager to stopped, synchronously.
+//
+// The precondition assert is load-bearing. Without it the test would pass
+// against a manager that never started anything, and "no units active at the
+// end" would be true for the wrong reason — the shape of a green
+// indistinguishable from healthy.
+func TestShutdownStopsRunningKeaUnits6787(t *testing.T) {
+	r := newRecorder6787()
+	m := newManager6787(t, r)
+
+	if err := m.Apply(servingConfig6787()); err != nil {
+		t.Fatalf("precondition Apply: %v", err)
+	}
+	if !r.anyActive() {
+		t.Fatalf("precondition: no Kea unit was started, so a later "+
+			"'nothing active' assertion would prove nothing; calls=%v",
+			r.snapshot())
+	}
+
+	if err := m.Shutdown(); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if r.anyActive() {
+		t.Fatalf("a Kea unit is still active after Shutdown — this node keeps "+
+			"answering DHCP while the peer serves the same segment (#6787); "+
+			"calls=%v", r.snapshot())
+	}
+}
+
+// TestShutdownLatchesAgainstALaterApply6787 is the half that matters, and it is
+// PAIRED: the same Apply call, before and after Shutdown, must have opposite
+// effects.
+//
+// Shutdown deliberately runs BEFORE the priority-0 withdrawal, so this node
+// stops serving before the peer starts. That ordering leaves a window in which
+// a VRRP MASTER transition can still reach the manager — and it allocates a
+// NEWER generation than Shutdown's own apply, so the #1835 supersession guard
+// cannot refuse it. Stopping without latching would let that window re-arm the
+// units after the stop had already reported success.
+//
+// The "before" leg is not decoration: without it, "Apply does not start Kea"
+// would be satisfied by a manager that never starts Kea at all.
+func TestShutdownLatchesAgainstALaterApply6787(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		apply func(m *Manager) error
+	}{
+		{"Apply", func(m *Manager) error { return m.Apply(servingConfig6787()) }},
+		{"ApplyClusterCommit", func(m *Manager) error {
+			return m.ApplyClusterCommit(servingConfig6787())
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newRecorder6787()
+			m := newManager6787(t, r)
+
+			// BEFORE: the same call must genuinely serve. ApplyClusterCommit
+			// only restarts an ALREADY-ACTIVE unit, so start from a serving
+			// state via Apply first; that is its documented semantics, not a
+			// workaround.
+			if err := m.Apply(servingConfig6787()); err != nil {
+				t.Fatalf("precondition Apply: %v", err)
+			}
+			if err := tc.apply(m); err != nil {
+				t.Fatalf("precondition %s: %v", tc.name, err)
+			}
+			if !r.anyActive() {
+				t.Fatalf("precondition: %s did not leave any unit active, so the "+
+					"post-shutdown assertion below would pass vacuously; calls=%v",
+					tc.name, r.snapshot())
+			}
+
+			if err := m.Shutdown(); err != nil {
+				t.Fatalf("Shutdown: %v", err)
+			}
+
+			// AFTER: the identical call, with a strictly newer generation, must
+			// not bring the units back.
+			if err := tc.apply(m); err != nil {
+				t.Fatalf("post-shutdown %s returned an error; it must converge "+
+					"to stopped, not fail: %v", tc.name, err)
+			}
+			if r.anyActive() {
+				t.Fatalf("%s restarted Kea AFTER shutdown had begun — a VRRP "+
+					"MASTER transition racing the shutdown window re-arms the "+
+					"units this node just stopped (#6787); calls=%v",
+					tc.name, r.snapshot())
+			}
+		})
+	}
+}
+
+// TestShutdownLatchAppliesToTheAsyncWorker6787 covers the path the VRRP event
+// loop actually uses. ApplyAsync is the one every ownership transition calls,
+// so a latch that only covered the synchronous appliers would leave the real
+// racing caller untouched.
+//
+// Driven through enqueueAsync with a gen allocated up front, which is the
+// interleaving the mailbox exists to model, and joined by draining the worker
+// synchronously rather than sleeping.
+func TestShutdownLatchAppliesToTheAsyncWorker6787(t *testing.T) {
+	r := newRecorder6787()
+	m := newManager6787(t, r)
+
+	if err := m.Apply(servingConfig6787()); err != nil {
+		t.Fatalf("precondition Apply: %v", err)
+	}
+	if !r.anyActive() {
+		t.Fatal("precondition: nothing was started")
+	}
+	if err := m.Shutdown(); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	m.ApplyAsync(servingConfig6787(), "vrrp MASTER racing shutdown (#6787)")
+	// Join the singleton worker on an OBSERVABLE, not a sleep.
+	//
+	// Deliberately NOT the systemctl call log: a latched apply reconciles to
+	// "stopped", the units are already stopped, so it issues NO systemctl call
+	// at all — waiting for the log to grow times out even though the worker ran
+	// correctly. lastAppliedGen is the right signal because it advances on every
+	// apply body that runs, including a no-op one. A sleep would be worse than
+	// either: a worker that never ran would pass.
+	wantGen := m.applyGen.Load()
+	waitForCondition(t, "the async worker to drain the post-shutdown request",
+		func() bool {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			return m.lastAppliedGen >= wantGen
+		})
+
+	if r.anyActive() {
+		t.Fatalf("the async worker restarted Kea after shutdown — the VRRP "+
+			"event loop's own applier is the one that races this window "+
+			"(#6787); calls=%v", r.snapshot())
+	}
+}


### PR DESCRIPTION
Closes #6787

## What was wrong

`runShutdownSequence` withdrew RA senders, removed VIPs, sent VRRP's priority-0
burst and stopped the cluster heartbeat — and **never touched the DHCP server**.

Kea runs as separate systemd units that outlive xpfd. So an orderly HA shutdown
promoted the peer, the peer started ITS Kea on the same segment, and this node
kept answering: duplicate OFFERs, and two lease databases issuing addresses from
one pool with neither aware of the other. The units also survived the whole xpfd
downtime, so the condition persisted until an operator noticed.

## Cites

The issue body is `(see /tmp/opus-review-001.md section R46)` and nothing else —
that file is gone. Everything here was re-derived from code.

## Three decisions, and why each is the way it is

**Synchronous.** `ApplyAsync`'s mailbox is drained by a worker goroutine, so a
stop enqueued during shutdown races process exit and is simply lost. A fix that
is present and does nothing looks exactly like one that works — worth avoiding
on a path nobody watches. The commit path already keeps a synchronous applier
for the same reason.

**Latching.** `Shutdown` runs BEFORE the withdrawal, deliberately, so this node
stops serving before the peer starts and there is never a moment when both
serve. That ordering leaves a window in which a VRRP MASTER transition can still
reach the manager — and such a request allocates a strictly **newer** generation,
so the #1835 supersession guard cannot refuse it, because it really is newer.
Without the latch that window re-arms the units after the stop reported success.
The latch **coerces** a late applier's desired state to nil rather than refusing
it, so the reconcile stays idempotent and convergent: the applier still runs, and
still lands on stopped.

**Cluster mode only — `haMode`, not `hitless`.** Standalone has no peer to hand
the segment to and Kea deliberately survives an xpfd restart there; an
unconditional stop would turn every daemon restart into a DHCP outage, which is a
worse behaviour than the bug. `hitless` is the wrong discriminator because VRRP
sends its priority-0 burst even on a hitless HA restart, so the peer takes over
and an HA node must stop serving either way.

## Mutation matrix

Fix committed FIRST. Every cell runs the full `pkg/daemon` + `pkg/dhcpserver`
suites with `go test -count=1`, no `-run` filter; each mutation verified applied
on a building, vetting tree. **8 cells, all RED.**

| cell | result | assertion |
|---|---|---|
| M1 wiring removed from `runShutdownSequence` | RED | `...StopsKeaInClusterMode6787`; `...KeaStopPrecedesVRRPWithdrawal6787` |
| **M2 TIGHTEN: stop Kea unconditionally (standalone too)** | RED | `...LeavesKeaAloneStandalone6787` |
| **M3 stop MOVED after the priority-0 burst + heartbeat stop** | RED | `...KeaStopPrecedesVRRPWithdrawal6787` |
| M4 `Shutdown` does not latch (stop only) | RED | `...LatchesAgainstALaterApply6787`; `...LatchAppliesToTheAsyncWorker6787` |
| M5 latch set but never consulted in `apply` | RED | same two |
| **M6 TIGHTEN: latch REFUSES instead of coercing** | RED | 4 cells incl. `...StopsRunningKeaUnits6787` |
| M7 `Shutdown` made asynchronous | RED | `...StopsKeaInClusterMode6787`; `...StopsRunningKeaUnits6787` |

M3 is worth a note: the first attempt inserted a no-op line instead of actually
moving the call, and came back GREEN. That was a bad mutation, not a coverage
gap — re-cut as a real move of the block below `d.cluster.Stop()`, it reds.

## Test design

**Mechanics** (`pkg/dhcpserver`): `Shutdown` reconciles a SERVING manager to
stopped, and a later `Apply` / `ApplyClusterCommit` / `ApplyAsync` with a newer
generation does not bring the units back. Each is paired with the same call
BEFORE shutdown, which must genuinely serve, so "does not start Kea" cannot be
satisfied by a manager that never starts Kea; each also asserts its precondition
actually left a unit active, since otherwise the post-shutdown assertion passes
vacuously.

The async cell joins the worker on `lastAppliedGen`, **not** on the systemctl
call log. A latched apply reconciles to stopped, the units are already stopped,
and it issues no systemctl call at all — the obvious observable times out on
correct behaviour. (It did, on the first draft.)

**Wiring + ordering** (`pkg/daemon`): the mechanics cells stay green if
`runShutdownSequence` never calls `Shutdown`, which is the bug itself. Cluster
mode stops Kea; standalone does not — the paired half that keeps the fix from
being a regression; and the stop precedes both the priority-0 withdrawal and the
heartbeat stop. The ordering cell is a source check with comments stripped:
`pkg/daemon` has no seam that orders the VRRP and Kea managers inside one
sequence, and a cell built on sleeps or goroutine scheduling would be a green
indistinguishable from healthy.

## Gates

`go build ./... && go vet ./... && go test -count=1 ./...` — all rc=0, 67
packages, at head `94e81c05d`, tree clean. Go only; nothing moves the
`userspace-dp` binary or the shim `.o`, so no cargo leg.

**It does change HA shutdown behaviour, so it owes `make test-failover`** — the
smoke reboots fw0, which runs this path. Queued behind #7584's smoke on the
shared cluster; I will post the result here.
