### PR TITLE
config: reject a RETH redundancy-group that is not a usable group

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104505,3 +104505,33 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/config/compiler_uniformgates_cluster_zone.go`,
   `pkg/config/vrrp_vip_count_6779_test.go` (new), `pkg/vrrp/README.md`,
   `pkg/config/README.md`
+
+## 2026-08-22 — #6782 invalid RETH redundancy-group committed as a both-node address
+
+- **Timestamp**: 2026-08-22
+- **Action**: `redundant-ether-options redundancy-group` is an untyped schema
+  leaf and `compileInterfaces` reads it with Atoi-then-discard-the-error, so a
+  non-numeric token collapsed to 0 and a negative one was stored verbatim.
+  Downstream every consumer asks `redundancy-group > 0` (`isReth` /
+  `isVRRPReth` in `pkg/dataplane/compiler_iface.go`), so the interface read as
+  ORDINARY: the `169.254.RG.NODE/32` substitution did not fire and the reth's
+  service address was written to the physical device on BOTH nodes. Measured
+  every value class first — 0, negative, non-numeric, fractional, int64
+  overflow, above-cap and undeclared-but-positive ALL committed clean on both
+  the strict and tolerant paths. Added `validateRethRedundancyGroupTokensAST`,
+  an AST pre-walk gate (strict reject / lenient warn via
+  `lenientRethRedundancyGroup`) accepting 1..255 — floor 1 because RG0 is the
+  control-plane group by `cluster.Manager.DataGroupIDs`' own definition,
+  ceiling 255 because the id is the third octet of the derived link-local. The
+  1..155 VRID bound stays owned by `validateRethVRRPGroupIDStrict`, which
+  correctly returns early under the default `private-rg-election`. The tolerant
+  path additionally SUPPRESSES the reth's addresses (and its members'), because
+  warning and then installing on both nodes anyway would make the lenient path
+  the bug. Deliberately not extended to a missing stanza (measured: in-tree
+  overlay fragments rely on it) or to an undeclared positive id (does not
+  trigger the fail-open).
+- **File(s)**: `pkg/config/compiler_reth_rg_token.go`,
+  `pkg/config/compiler_interfaces.go`, `pkg/config/compiler_opts.go`,
+  `pkg/config/compiler_prewalk.go`,
+  `pkg/config/compiler_reth_rg_token_6782_test.go`,
+  `pkg/daemon/vip_readiness_test.go`, `docs/config-schema.md`

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -236,6 +236,89 @@ The live config-mode completers — `pkg/cli` `completeConfigWithDesc` and
 only supplies the config-mode TOP-LEVEL keywords (`set`/`delete`/`commit`/
 `load`/...) plus the retained `set system dataplane` description overlay.
 
+### RETH `redundancy-group` token fail-open (#6782)
+
+`interfaces <name> redundant-ether-options redundancy-group <id>` is an
+UNTYPED schema leaf (`schema_interfaces.go`: `args: 1`, no `valueType`, no
+`validator`), so `SchemaValidate` never inspects the token. `compileInterfaces`
+then reads it as
+
+```go
+if v, err := strconv.Atoi(nodeVal(rgNode)); err == nil {
+    ifc.RedundancyGroup = v
+}
+```
+
+— the parse error is DISCARDED, so a non-numeric / fractional / int64-overflow
+token leaves the group at its `0` default, and a NEGATIVE token parses
+successfully and is stored verbatim.
+
+The consequence is not cosmetic. Every downstream consumer decides "is this a
+RETH?" with `redundancy-group > 0`: `pkg/dataplane/compiler_iface.go` sets
+`isReth` and `isVRRPReth` that way. With a non-positive group the interface is
+treated as ORDINARY — the `169.254.<group>.<node+1>/32` link-local substitution
+does not fire, and the reth's real service address is written onto the physical
+device with `KeepAddresses:false`. **Both nodes run the same synced
+configuration, so BOTH configure that address** — a duplicate-address /
+split-brain condition on the data path, from a config that commits silently.
+
+`validateRethRedundancyGroupTokensAST` (`compiler_reth_rg_token.go`, an AST
+pre-walk gate in `runPreWalkGates`) closes it: strict-reject at commit /
+commit-check, warn on the tolerant load / peer-sync path
+(`lenientRethRedundancyGroup`). It runs on the raw AST for the same reason
+`validateChassisClusterIdentitiesAST` (#5694) does — once the typed
+`InterfaceConfig` exists, a malformed token has already collapsed to `0` and is
+indistinguishable from a reth with no `redundant-ether-options` stanza at all.
+
+Accepted range is `1..255`:
+
+- The floor is 1 because **group 0 is the chassis-cluster CONTROL-PLANE group**,
+  not a data-plane one — `cluster.Manager.DataGroupIDs` already documents and
+  enforces exactly that ("RG0 is reserved for control-plane ownership and is
+  omitted"). A reth in group 0 is a contradiction by the codebase's own
+  definition.
+- The ceiling is 255 because the group id is the THIRD OCTET of the derived
+  link-local address, and it is also the ceiling
+  `MaxHeartbeatRedundancyGroupID` already places on the group declarations, so
+  no id above it can name a declared group.
+
+This is a DIFFERENT, looser bound than `MaxRethRedundancyGroupID` (155), which
+exists for the RFC 5798 VRID range and is enforced by
+`validateRethVRRPGroupIDStrict` ONLY when a reth-derived VRRP instance is
+actually synthesized — that gate returns early under `no-reth-vrrp` /
+`private-rg-election`, and **private-rg-election is the compiler DEFAULT**
+(`compiler_system.go`), so on a default cluster config it never runs. The
+link-local substitution is not mode-gated, so the octet ceiling has to be
+enforced independently. The two compose: in a VRRP mode the stricter 155
+applies, otherwise this 255 does.
+
+**The tolerant path suppresses, it does not merely warn.** Warning and then
+installing the address anyway would make the lenient path the bug, so
+`suppressInvalidRethAddresses` (`compiler_interfaces.go`) additionally strips
+the affected reth's unit addresses — and those of any interface inheriting from
+it via `RedundantParent`, which would otherwise reintroduce exactly what was
+removed. The node still BOOTS as #1960 requires; it simply offers no service on
+that interface until the group is repaired. The group id is deliberately left
+as written: it is what the operator has to fix, and rewriting it here would
+erase the evidence and let a later strict commit-check pass on a config that is
+still wrong.
+
+**Deliberately out of scope**, each measured rather than assumed:
+
+- A reth with NO `redundant-ether-options` stanza is an ABSENT token, not an
+  invalid one. Several in-tree configs legitimately touch a reth without
+  redeclaring its group as a partial/overlay fragment
+  (`test/incus/sqm-cookbook-config.set` sets an ADDRESS that way), so requiring
+  presence would reject them. Separate policy question.
+- A positive id naming no DECLARED `chassis cluster redundancy-group` does not
+  trigger this fail-open at all — it still reads as RG-scoped and still takes
+  the link-local substitution — so rejecting it would be a new restriction
+  rather than a fix.
+
+Pinned by `compiler_reth_rg_token_6782_test.go`, which tests the range from both
+sides (1 and 255 must commit; 0 and 256 must not) and asserts the tolerant-path
+suppression together with its positive control.
+
 ### firewall-filter term rule-expansion count overflow (#5456)
 
 This is a `uint32`-overflow fix plus an **advisory warning** — NOT a strict

--- a/pkg/config/compiler_interfaces.go
+++ b/pkg/config/compiler_interfaces.go
@@ -23,6 +23,10 @@ var vrrpGroupPropertyKeywords = map[string]bool{
 }
 
 func compileInterfaces(node *Node, ifaces *InterfacesConfig, opts compileOpts, warnings *[]string) error {
+	// #6782: reth interfaces whose redundancy-group token was present but
+	// unusable. Only ever populated on the tolerant path — the strict compile
+	// fails in runPreWalkGates before compileInterfaces runs.
+	var invalidRethRG map[string]bool
 	for _, child := range node.Children {
 		if child.IsLeaf {
 			continue
@@ -138,6 +142,25 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig, opts compileOpts, w
 			if rgNode := reoNode.FindChild("redundancy-group"); rgNode != nil {
 				if v, err := strconv.Atoi(nodeVal(rgNode)); err == nil {
 					ifc.RedundancyGroup = v
+				}
+				// #6782: the Atoi above deliberately keeps its
+				// discard-the-error shape so the compiled value is bit-identical
+				// to what every prior release produced. What changes is that an
+				// unusable token is no longer SILENT. On the strict path
+				// validateRethRedundancyGroupTokensAST has already hard-rejected
+				// this configuration in runPreWalkGates, so reaching here with a
+				// bad token means we are on the tolerant load / peer-sync path.
+				// Record it: the post-pass below strips this reth's addresses so
+				// the lenient boot cannot configure the reth's service address as
+				// an ordinary static address on BOTH nodes, which is precisely the
+				// duplicate-address condition the gate exists to prevent. Warning
+				// on the way in and then doing the damage anyway would make the
+				// tolerant path the bug.
+				if _, bad := rethRGTokenProblem(nodeVal(rgNode)); bad {
+					if invalidRethRG == nil {
+						invalidRethRG = make(map[string]bool)
+					}
+					invalidRethRG[ifName] = true
 				}
 			}
 		}
@@ -581,7 +604,55 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig, opts compileOpts, w
 
 		ifaces.Interfaces[ifName] = ifc
 	}
+	suppressInvalidRethAddresses(ifaces, invalidRethRG)
 	return nil
+}
+
+// suppressInvalidRethAddresses strips every configured address from a reth
+// whose redundancy-group token was present but unusable (#6782), and from any
+// interface that inherits from it as a redundant member.
+//
+// This runs on the tolerant load / peer-sync path only (the strict path
+// hard-rejects in runPreWalkGates). The reth reads as NON-redundant everywhere
+// downstream — pkg/dataplane compiler_iface.go decides both `isReth` and
+// `isVRRPReth` with `redundancy-group > 0` — so leaving the addresses in place
+// would make the lenient boot write the reth's service address onto the
+// physical device as an ordinary static address, with `KeepAddresses:false`,
+// on BOTH nodes of the cluster. Removing the addresses degrades the interface
+// to no-service rather than to duplicate-service: the node still BOOTS as
+// #1960 requires, the operator gets the warning the gate emitted, and no
+// address is contended on the wire until the group is repaired.
+//
+// It clears the addresses rather than the group id because the group id is
+// what the operator has to fix; rewriting it here would erase the evidence and
+// make a later strict commit-check pass on a config that is still wrong.
+func suppressInvalidRethAddresses(ifaces *InterfacesConfig, invalid map[string]bool) {
+	if len(invalid) == 0 || ifaces == nil {
+		return
+	}
+	clear := func(ifc *InterfaceConfig) {
+		if ifc == nil {
+			return
+		}
+		for _, unit := range ifc.Units {
+			if unit == nil {
+				continue
+			}
+			unit.Addresses = nil
+			unit.PrimaryAddress = ""
+			unit.PreferredAddress = ""
+		}
+	}
+	for name := range invalid {
+		clear(ifaces.Interfaces[name])
+	}
+	// A physical member carries the reth's addresses through RedundantParent,
+	// so an untouched member would reintroduce exactly what was just removed.
+	for _, ifc := range ifaces.Interfaces {
+		if ifc != nil && ifc.RedundantParent != "" && invalid[ifc.RedundantParent] {
+			clear(ifc)
+		}
+	}
 }
 
 // parseTunnelWireguard fills the WireGuard fields on tc from a

--- a/pkg/config/compiler_opts.go
+++ b/pkg/config/compiler_opts.go
@@ -353,6 +353,22 @@ type compileOpts struct {
 	// Same doctrine as lenientReservedProposalSetNames.
 	lenientChassisClusterIdentities bool
 
+	// lenientRethRedundancyGroup (#6782) downgrades the RETH redundancy-group
+	// token gate (validateRethRedundancyGroupTokensAST) from a hard compile
+	// error to a cfg.Warnings entry on the tolerant load / peer-sync paths. A
+	// `redundant-ether-options redundancy-group` token that is present but not a
+	// usable data-plane group (0, negative, non-numeric, or above the
+	// link-local octet ceiling) reads as "not RG-scoped" everywhere downstream,
+	// so the reth's service address is configured as an ordinary static address
+	// on BOTH nodes. Commit / commit-check stay strict so a new operator edit is
+	// rejected; an already-persisted or peer-synced config an older binary
+	// accepted must still BOOT (warn) per the #1960 fail-closed-on-load
+	// doctrine. Unlike the sibling lenient gates the warning is NOT the whole
+	// tolerant behaviour: compileInterfaces additionally SUPPRESSES that reth's
+	// unit addresses, because booting into the duplicate-address condition this
+	// gate exists to prevent would make the lenient path the bug.
+	lenientRethRedundancyGroup bool
+
 	// lenientChassisMonitorWeight (#6588) downgrades the redundancy-group
 	// monitor weight gate (validateMonitorWeightTokensAST) from a hard compile
 	// error to a cfg.Warnings entry on the tolerant load / peer-sync paths. A
@@ -2343,6 +2359,7 @@ func lenientCompileOpts() compileOpts {
 		lenientIPsecTrafficSelectors:           true,
 		lenientReservedProposalSetNames:        true,
 		lenientChassisClusterIdentities:        true,
+		lenientRethRedundancyGroup:             true,
 		lenientChassisMonitorWeight:            true,
 		lenientChassisRGStatementArity:         true,
 		lenientLoginPackedStatements:           true,

--- a/pkg/config/compiler_prewalk.go
+++ b/pkg/config/compiler_prewalk.go
@@ -513,6 +513,25 @@ func runPreWalkGates(tree *ConfigTree, opts compileOpts) ([]string, error) {
 		return nil, err
 	}
 
+	// #6782: a RETH `redundant-ether-options redundancy-group` token that is
+	// PRESENT but unusable (0 — the control-plane group, negative, non-numeric,
+	// or above the link-local third-octet ceiling). compileInterfaces reads it
+	// with Atoi-then-default, so a non-numeric token collapses to 0 and a
+	// negative one is stored verbatim; every downstream consumer then decides
+	// "is this a RETH?" with `redundancy-group > 0` and treats the interface as
+	// ORDINARY, writing the reth's service address as a plain static address on
+	// BOTH nodes (a duplicate-address / split-brain condition). Runs on the raw
+	// AST for the same reason the chassis-identity gate does: once the typed
+	// InterfaceConfig exists, a malformed token is indistinguishable from a reth
+	// with no redundant-ether-options stanza at all. Strict at commit /
+	// commit-check; warn on the tolerant load / peer-sync path, where
+	// compileInterfaces also suppresses the affected reth's addresses.
+	rethRGWarnings, err := validateRethRedundancyGroupTokensAST(
+		tree.Children, opts.lenientRethRedundancyGroup)
+	if err != nil {
+		return nil, err
+	}
+
 	// #5695 (codex-182 M16): a redundancy-group gratuitous-arp-count over the
 	// runtime clamp (config.GratuitousARPBurstClamp) is accepted and compiled
 	// verbatim but WARNS — the value is clamped at runtime, never used as
@@ -583,6 +602,7 @@ func runPreWalkGates(tree *ConfigTree, opts compileOpts) ([]string, error) {
 	warnings = append(warnings, dnatToScopeWarnings...)
 	warnings = append(warnings, natMixedScopeWarnings...)
 	warnings = append(warnings, chassisIdentityWarnings...)
+	warnings = append(warnings, rethRGWarnings...)
 	warnings = append(warnings, monitorWeightWarnings...)
 	warnings = append(warnings, rgArityWarnings...)
 	warnings = append(warnings, garpCountWarnings...)

--- a/pkg/config/compiler_reth_rg_token.go
+++ b/pkg/config/compiler_reth_rg_token.go
@@ -1,0 +1,166 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+)
+
+// MinRethRedundancyGroupID is the smallest redundancy-group id a RETH
+// interface may carry. Group 0 is the chassis-cluster CONTROL-PLANE group in
+// Junos (the Routing Engine group); data-plane RETH interfaces are assigned to
+// group 1 and up. A reth carrying group 0 is therefore not "RG 0" — it is a
+// reth with no usable data-plane group, and every downstream consumer reads it
+// as "not RG-scoped" (see validateRethRedundancyGroupTokensAST).
+const MinRethRedundancyGroupID = 1
+
+// MaxRethRedundancyGroupOctet is the largest redundancy-group id that still
+// yields a well-formed RETH link-local base address. pkg/dataplane
+// compiler_iface.go substitutes the VIP addresses of a VRRP-backed RETH with
+// `169.254.<redundancy-group>.<node+1>/32`, so the id occupies the THIRD OCTET
+// of an IPv4 address and cannot exceed 255. It is also the ceiling the chassis
+// redundancy-group id gate already enforces on the group declarations
+// themselves (MaxHeartbeatRedundancyGroupID), so no id above it can ever name
+// a declared group.
+//
+// This is a DIFFERENT and looser bound than MaxRethRedundancyGroupID (155),
+// which exists for the RFC 5798 VRID range and is enforced by
+// validateRethVRRPGroupIDStrict ONLY when a reth-derived VRRP instance is
+// actually synthesized. That gate deliberately returns early under
+// `no-reth-vrrp` / `private-rg-election` (the DEFAULT), where no VRID is
+// derived — but the link-local substitution above is NOT mode-gated, so the
+// octet ceiling has to be enforced independently of the VRRP mode. The two
+// compose: in a VRRP mode the stricter 155 applies, otherwise this 255 does.
+const MaxRethRedundancyGroupOctet = MaxHeartbeatRedundancyGroupID
+
+// validateRethRedundancyGroupTokensAST rejects, at commit / commit-check, an
+// `interfaces <name> redundant-ether-options redundancy-group <id>` whose raw
+// token is PRESENT but does not denote a usable data-plane redundancy group
+// (#6782).
+//
+// The fail-open this closes: compileInterfaces reads the token with
+// `if v, err := strconv.Atoi(...); err == nil { ifc.RedundancyGroup = v }`, so a
+// non-numeric token leaves the field at its 0 default and a NEGATIVE token is
+// stored verbatim. Every downstream consumer decides "is this a RETH?" with
+// `RedundancyGroup > 0` — pkg/dataplane compiler_iface.go sets both `isReth`
+// and `isVRRPReth` that way. With a non-positive group the interface is
+// therefore treated as an ORDINARY interface: the `169.254.RG.NODE/32`
+// link-local substitution does not fire, and the reth's real service address is
+// written onto the physical device with `KeepAddresses:false`. Both nodes run
+// the same synced config, so BOTH nodes configure that address — a
+// duplicate-address / split-brain condition on the data path, from a config
+// that commits without a word of complaint.
+//
+// Why the AST and not the compiled *Config: by the time the typed
+// InterfaceConfig exists, a malformed token has already collapsed to 0 and is
+// indistinguishable from a reth that simply has no redundant-ether-options
+// stanza at all. Only the raw AST can tell "the operator wrote something and we
+// could not use it" from "the operator wrote nothing". This mirrors
+// validateChassisClusterIdentitiesAST (#5694), whose header describes the
+// identical Atoi-then-default mechanism for the sibling chassis-cluster slots.
+//
+// Scope — deliberately NOT extended, each measured rather than assumed:
+//
+//   - A reth with NO redundant-ether-options stanza is not flagged. That is an
+//     ABSENT token, not an invalid one, and several in-tree configs legitimately
+//     touch a reth without redeclaring its group as a partial/overlay fragment
+//     (test/incus/sqm-cookbook-config.set even sets an address that way).
+//     Requiring presence is a separate policy question with a real
+//     over-rejection surface.
+//   - A positive id that names no DECLARED `chassis cluster redundancy-group`
+//     is not flagged. It does not trigger this fail-open at all — it still reads
+//     as RG-scoped and still takes the link-local substitution — so rejecting it
+//     would be a new restriction rather than a fix for the reported failure.
+//   - The 1..155 VRID ceiling stays owned by validateRethVRRPGroupIDStrict,
+//     which is correctly scoped to the modes that actually derive a VRID.
+//
+// Strict (commit / commit-check): the first offending token hard-rejects, naming
+// the interface and the token. Lenient (load / peer-sync): warn, so an
+// already-persisted or peer-synced config an older binary silently accepted
+// still BOOTS (#1960) — compileInterfaces then SUPPRESSES that reth's unit
+// addresses so the tolerant path cannot do the very thing this gate exists to
+// prevent, namely configure the address on both nodes.
+func validateRethRedundancyGroupTokensAST(nodes []*Node, lenient bool) ([]string, error) {
+	var warnings []string
+	// Deterministic order so the first-error commit message is stable across
+	// map-ordered runs, matching the sibling AST gates.
+	type offence struct{ iface, token, why string }
+	var found []offence
+	// The descent mirrors compileInterfaces EXACTLY — the "interfaces" section
+	// node, its interface children, then FindChild + nodeVal for the two levels
+	// below. Binding to the same reads is what keeps the gate and the compiler
+	// from disagreeing about which token is in play across the dual
+	// hierarchical / flat-set AST shapes.
+	err := forEachChild(nodes, "interfaces", func(ifacesNode *Node) error {
+		for _, ifNode := range ifacesNode.Children {
+			name := ifNode.Name()
+			if name == "" {
+				continue
+			}
+			reo := ifNode.FindChild("redundant-ether-options")
+			if reo == nil {
+				continue
+			}
+			rg := reo.FindChild("redundancy-group")
+			if rg == nil {
+				continue
+			}
+			tok := nodeVal(rg)
+			if why, bad := rethRGTokenProblem(tok); bad {
+				found = append(found, offence{iface: name, token: tok, why: why})
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(found, func(i, j int) bool { return found[i].iface < found[j].iface })
+	for _, o := range found {
+		msg := fmt.Sprintf(
+			"interface %s redundant-ether-options redundancy-group %q %s; a "+
+				"redundancy-group that is not a usable data-plane group leaves the "+
+				"interface reading as NON-redundant everywhere downstream "+
+				"(isReth/isVRRPReth are both `redundancy-group > 0`), so its "+
+				"service address is written as an ordinary static address — and "+
+				"because both nodes share the synced configuration, BOTH nodes "+
+				"configure it. Use a group in %d..%d (#6782)",
+			o.iface, o.token, o.why,
+			MinRethRedundancyGroupID, MaxRethRedundancyGroupOctet)
+		if !lenient {
+			return nil, fmt.Errorf("%s", msg)
+		}
+		warnings = append(warnings, msg)
+	}
+	return warnings, nil
+}
+
+// rethRGTokenProblem classifies a raw redundancy-group token, returning a
+// human-readable reason and whether it is unusable. It mirrors
+// compileInterfaces' Atoi-then-default read exactly: whatever Atoi accepts is
+// what the compiler stores, so anything Atoi rejects has silently become 0.
+func rethRGTokenProblem(tok string) (string, bool) {
+	if tok == "" {
+		return "is empty", true
+	}
+	n, err := strconv.Atoi(tok)
+	if err != nil {
+		// Non-numeric, fractional, or out of int range. compileInterfaces
+		// discards this error and leaves the group at its 0 default.
+		return "is not an integer (the compiler discards the parse error and " +
+			"silently leaves the group at 0)", true
+	}
+	if n < MinRethRedundancyGroupID {
+		if n == 0 {
+			return "is 0, which is the chassis-cluster control-plane group, not a " +
+				"data-plane group", true
+		}
+		return "is negative", true
+	}
+	if n > MaxRethRedundancyGroupOctet {
+		return fmt.Sprintf("exceeds %d, so the derived RETH link-local base "+
+			"address 169.254.<group>.<node+1>/32 is not a valid IPv4 address",
+			MaxRethRedundancyGroupOctet), true
+	}
+	return "", false
+}

--- a/pkg/config/compiler_reth_rg_token_6782_test.go
+++ b/pkg/config/compiler_reth_rg_token_6782_test.go
@@ -1,0 +1,342 @@
+package config
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// #6782 — an invalid RETH redundancy-group commits as a non-HA address owned
+// by BOTH nodes.
+//
+// compileInterfaces reads the token with `if v, err := strconv.Atoi(...);
+// err == nil`, so a non-numeric token leaves the group at its 0 default and a
+// negative one is stored verbatim. Every downstream consumer decides "is this a
+// RETH?" with `redundancy-group > 0` (pkg/dataplane compiler_iface.go sets both
+// isReth and isVRRPReth that way), so a non-positive group makes the interface
+// read as ORDINARY: the 169.254.RG.NODE/32 link-local substitution does not
+// fire and the reth's real service address is written onto the physical device.
+// Both nodes share the synced config, so both configure it.
+//
+// These bind the gate AND the tolerant-path behaviour, in both directions.
+
+// rethRGSet builds a minimal committable cluster config carrying one reth whose
+// redundancy-group token is tok.
+//
+// The auth key is present because chassis-cluster commit independently requires
+// one — without it every strict compile fails on THAT gate and a test asserting
+// "strict rejects" would pass for the wrong reason.
+func rethRGSet(tok string, extra ...string) []string {
+	lines := []string{
+		"set chassis cluster cluster-id 1",
+		`set chassis cluster authentication-key "Zm9vYmFyYmF6cXV4MTIzNDU2Nzg5MGFiY2Rl"`,
+		"set chassis cluster node 0",
+		"set chassis cluster redundancy-group 1 node 0 priority 200",
+		"set chassis cluster redundancy-group 1 node 1 priority 100",
+		"set interfaces reth0 unit 0 family inet address 10.0.61.1/24",
+	}
+	lines = append(lines, extra...)
+	if tok != "" {
+		lines = append(lines, "set interfaces reth0 redundant-ether-options redundancy-group "+tok)
+	}
+	return lines
+}
+
+func rethRGTree(t *testing.T, lines []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, l := range lines {
+		p, err := ParseSetCommand(l)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", l, err)
+		}
+		if err := tree.SetPath(p); err != nil {
+			t.Fatalf("SetPath(%q): %v", l, err)
+		}
+	}
+	return tree
+}
+
+// TestRethRedundancyGroupTokenRejectedAtCommit6782 is the primary
+// RED-on-revert: every token class that makes the interface read as
+// NON-redundant must hard-reject on the strict commit path.
+//
+// The classes are enumerated rather than lumped, because they reach the same
+// failure by different routes and a fix that only handles one of them looks
+// identical from the outside: `abc`/`1.5`/an int64 overflow are DISCARDED parse
+// errors that leave the group at 0, while `-1` parses SUCCESSFULLY and is
+// stored verbatim.
+func TestRethRedundancyGroupTokenRejectedAtCommit6782(t *testing.T) {
+	for _, tc := range []struct {
+		name, tok, wantIn string
+	}{
+		{"control-plane-group-zero", "0", "control-plane group"},
+		{"negative", "-1", "is negative"},
+		{"negative-large", "-99999", "is negative"},
+		{"non-numeric", "abc", "is not an integer"},
+		{"fractional", "1.5", "is not an integer"},
+		{"int64-overflow", "99999999999999999999", "is not an integer"},
+		{"above-octet-ceiling", "256", "not a valid IPv4 address"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := rethRGTree(t, rethRGSet(tc.tok))
+			cfg, err := CompileConfig(tree)
+			if err == nil {
+				got := -777
+				if ifc := cfg.Interfaces.Interfaces["reth0"]; ifc != nil {
+					got = ifc.RedundancyGroup
+				}
+				t.Fatalf("redundancy-group %q must be REJECTED at commit — it compiles to "+
+					"RedundancyGroup=%d, which every downstream consumer reads as "+
+					"NOT-a-RETH (isReth/isVRRPReth are `> 0`), so reth0's address is "+
+					"configured as an ordinary static address on BOTH nodes (#6782)",
+					tc.tok, got)
+			}
+			if !strings.Contains(err.Error(), tc.wantIn) {
+				t.Fatalf("the rejection must say WHY this particular token is unusable "+
+					"(the classes have different causes and different operator fixes); "+
+					"want %q in:\n%s", tc.wantIn, err)
+			}
+			if !strings.Contains(err.Error(), "reth0") {
+				t.Fatalf("the rejection must name the offending interface:\n%s", err)
+			}
+		})
+	}
+}
+
+// TestRethRedundancyGroupValidTokensStillCommit6782 is the TIGHTENING control
+// in the other direction: a range gate that over-rejects is its own outage.
+//
+// The boundary is tested from BOTH sides — 1 and 255 must commit, 0 and 256
+// must not (the reject side lives in the test above) — and the fixture never
+// uses the value the bug FALLS BACK TO, so a gate that silently coerced its
+// input to 0 could not pass this.
+func TestRethRedundancyGroupValidTokensStillCommit6782(t *testing.T) {
+	for _, tc := range []struct {
+		name, tok string
+		want      int
+	}{
+		{"lower-boundary-one", "1", 1},
+		{"typical", "2", 2},
+		{"upper-boundary-octet", "255", 255},
+		{"explicit-plus-sign", "+3", 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := rethRGTree(t, rethRGSet(tc.tok))
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("redundancy-group %q is a usable data-plane group and must "+
+					"COMMIT — over-rejecting here takes a working cluster down: %v",
+					tc.tok, err)
+			}
+			ifc := cfg.Interfaces.Interfaces["reth0"]
+			if ifc == nil {
+				t.Fatal("reth0 must compile")
+			}
+			if ifc.RedundancyGroup != tc.want {
+				t.Fatalf("the accepted token must compile to the group the operator "+
+					"WROTE; got %d want %d", ifc.RedundancyGroup, tc.want)
+			}
+			// The whole point of a valid group: the address survives to be
+			// installed (as a VIP), rather than being suppressed.
+			addrs := 0
+			for _, u := range ifc.Units {
+				addrs += len(u.Addresses)
+			}
+			if addrs == 0 {
+				t.Fatal("a VALID redundancy-group must keep the reth's addresses — " +
+					"suppressing them here would break every working cluster")
+			}
+		})
+	}
+}
+
+// TestRethMissingRedundancyGroupStanzaStillCommits6782 pins the scope boundary
+// explicitly, so a later "tighten it up" change has to argue with a test.
+//
+// A reth with NO redundant-ether-options is an ABSENT token, not an invalid
+// one. Several in-tree configs legitimately touch a reth without redeclaring
+// its group as a partial/overlay fragment (test/incus/sqm-cookbook-config.set
+// sets an ADDRESS that way), so requiring presence would reject them. It is a
+// separate policy question from the one #6782 reports.
+func TestRethMissingRedundancyGroupStanzaStillCommits6782(t *testing.T) {
+	tree := rethRGTree(t, rethRGSet(""))
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("a reth with NO redundant-ether-options stanza must still commit — "+
+			"#6782 is about tokens that are PRESENT and unusable, and in-tree overlay "+
+			"fragments rely on this: %v", err)
+	}
+}
+
+// TestRethUndeclaredButPositiveGroupStillCommits6782 is the other half of the
+// scope boundary. A positive group that names no declared `chassis cluster
+// redundancy-group` does NOT trigger this fail-open — it still reads as
+// RG-scoped and still takes the link-local substitution — so rejecting it would
+// be a new restriction rather than a fix, and would break configs that declare
+// interfaces before groups.
+func TestRethUndeclaredButPositiveGroupStillCommits6782(t *testing.T) {
+	tree := rethRGTree(t, rethRGSet("7"))
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("a positive group that is merely undeclared must still commit: %v", err)
+	}
+	if got := cfg.Interfaces.Interfaces["reth0"].RedundancyGroup; got != 7 {
+		t.Fatalf("the undeclared-but-positive group must compile verbatim; got %d", got)
+	}
+}
+
+// TestRethInvalidRedundancyGroupSuppressesAddressesOnLenientLoad6782 is the
+// #1960 half, and the one that decides whether this fix is real.
+//
+// The tolerant load / peer-sync path must not brick on a config an older binary
+// accepted — so it warns instead of failing. But warning and then doing the
+// damage anyway would make the lenient path the bug: the whole defect is that
+// the reth's address gets configured on BOTH nodes. So the lenient path must
+// additionally SUPPRESS the address.
+//
+// FAIL-ON-REVERT: delete the suppressInvalidRethAddresses call and the
+// addresses survive; drop the warning and the diagnostic leg reds.
+func TestRethInvalidRedundancyGroupSuppressesAddressesOnLenientLoad6782(t *testing.T) {
+	for _, tok := range []string{"0", "-1", "abc", "256"} {
+		t.Run(tok, func(t *testing.T) {
+			tree := rethRGTree(t, rethRGSet(tok))
+			cfg, err := CompileConfigLenient(tree)
+			if err != nil {
+				t.Fatalf("the tolerant path must still BOOT an already-persisted config "+
+					"an older binary accepted (#1960); got: %v", err)
+			}
+			ifc := cfg.Interfaces.Interfaces["reth0"]
+			if ifc == nil {
+				t.Fatal("reth0 must still compile on the tolerant path")
+			}
+			addrs := []string{}
+			for _, u := range ifc.Units {
+				addrs = append(addrs, u.Addresses...)
+			}
+			if len(addrs) != 0 {
+				t.Fatalf("the tolerant path must SUPPRESS the address of a reth whose "+
+					"group is unusable — leaving %v installs it as an ordinary static "+
+					"address on BOTH nodes, which is the entire defect #6782 reports",
+					addrs)
+			}
+			found := false
+			for _, w := range cfg.Warnings {
+				if strings.Contains(w, "6782") && strings.Contains(w, "reth0") {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("suppressing the address silently is its own trap — the operator "+
+					"must be told which interface and why; warnings were: %v", cfg.Warnings)
+			}
+		})
+	}
+}
+
+// TestRethValidGroupKeepsAddressesOnLenientLoad6782 is the tightening control
+// for the suppression: it must fire ONLY for the unusable tokens. A suppression
+// that ran unconditionally would strip every cluster's addresses on load — a
+// far worse outage than the bug.
+func TestRethValidGroupKeepsAddressesOnLenientLoad6782(t *testing.T) {
+	tree := rethRGTree(t, rethRGSet("1"))
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile: %v", err)
+	}
+	addrs := 0
+	for _, u := range cfg.Interfaces.Interfaces["reth0"].Units {
+		addrs += len(u.Addresses)
+	}
+	if addrs == 0 {
+		t.Fatal("a VALID group must keep its addresses on the tolerant path — an " +
+			"unconditional suppression would blackhole every healthy cluster on load")
+	}
+}
+
+// TestRethInvalidGroupSuppressesInheritingMemberAddresses6782 covers the second
+// consumer of the same data. A physical member carries the reth's addresses
+// through RedundantParent, so suppressing only the reth would let the member
+// reintroduce exactly what was removed.
+//
+// This is the smallest shape where dropping the member loop changes an outcome:
+// without a member interface in the fixture the loop is dead code and its
+// deletion is invisible.
+func TestRethInvalidGroupSuppressesInheritingMemberAddresses6782(t *testing.T) {
+	lines := rethRGSet("0",
+		"set interfaces ge-0/0/0 gigether-options redundant-parent reth0",
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.61.1/24",
+	)
+	cfg, err := CompileConfigLenient(rethRGTree(t, lines))
+	if err != nil {
+		t.Fatalf("lenient compile: %v", err)
+	}
+	member := cfg.Interfaces.Interfaces["ge-0/0/0"]
+	if member == nil {
+		// Never t.Skip here. A skip on a fixture WE author is indistinguishable
+		// from a pass, so an interface-naming change would silently retire this
+		// guard instead of failing loudly.
+		t.Fatalf("fixture broken: the member interface must compile, got interfaces %v",
+			ifaceNames6782(cfg))
+	}
+	for _, u := range member.Units {
+		if len(u.Addresses) != 0 {
+			t.Fatalf("a member inheriting from a reth with an unusable group must not "+
+				"keep addresses — it would reinstall on both nodes exactly what "+
+				"suppressing the reth removed; got %v", u.Addresses)
+		}
+	}
+
+	// Positive control: the same fixture with a VALID group must KEEP the
+	// member's address. Without this, "zero addresses" above could be true
+	// because the fixture never produced a member address in the first place —
+	// an absence assertion is only as good as the payload's ability to produce
+	// what it asserts absent.
+	okLines := rethRGSet("1",
+		"set interfaces ge-0/0/0 gigether-options redundant-parent reth0",
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.61.1/24",
+	)
+	okCfg, err := CompileConfigLenient(rethRGTree(t, okLines))
+	if err != nil {
+		t.Fatalf("control compile: %v", err)
+	}
+	okMember := okCfg.Interfaces.Interfaces["ge-0/0/0"]
+	if okMember == nil {
+		t.Fatalf("control fixture broken: member must compile, got %v", ifaceNames6782(okCfg))
+	}
+	kept := 0
+	for _, u := range okMember.Units {
+		kept += len(u.Addresses)
+	}
+	if kept == 0 {
+		t.Fatal("control failed: the member carries no address even with a VALID " +
+			"group, so the suppression assertion above proves nothing")
+	}
+}
+
+// ifaceNames6782 lists compiled interface names for fixture-breakage messages.
+func ifaceNames6782(cfg *Config) []string {
+	names := make([]string, 0, len(cfg.Interfaces.Interfaces))
+	for n := range cfg.Interfaces.Interfaces {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TestRethRGTokenProblemClassifier6782 pins the classifier directly, including
+// the two boundaries, so a range edit that shifts a bound by one is caught even
+// if no end-to-end fixture happens to sit on it.
+func TestRethRGTokenProblemClassifier6782(t *testing.T) {
+	bad := []string{"", "0", "-1", "abc", "1.5", "256", "99999"}
+	for _, tok := range bad {
+		if _, isBad := rethRGTokenProblem(tok); !isBad {
+			t.Fatalf("token %q must be classified unusable", tok)
+		}
+	}
+	good := []string{"1", "2", "155", "255"}
+	for _, tok := range good {
+		if why, isBad := rethRGTokenProblem(tok); isBad {
+			t.Fatalf("token %q must be classified usable, got %q", tok, why)
+		}
+	}
+}

--- a/pkg/config/compiler_reth_rg_token_6782_test.go
+++ b/pkg/config/compiler_reth_rg_token_6782_test.go
@@ -340,3 +340,71 @@ func TestRethRGTokenProblemClassifier6782(t *testing.T) {
 		}
 	}
 }
+
+// TestSuppressionIsScopedToTheOffendingReth6782 is the shape the sibling test
+// above CANNOT reach, and the matrix proved it: dropping the
+// `invalid[ifc.RedundantParent]` term from the member loop survived every other
+// cell.
+//
+// The reason is that a fixture containing ONLY a valid reth never enters the
+// member loop at all — suppressInvalidRethAddresses returns early on an empty
+// `invalid` set — so the guard is shadowed by the early return and its deletion
+// is invisible. The discriminating shape needs BOTH a reth whose group is
+// unusable AND a healthy reth, each with its own member: only then does the
+// term decide anything.
+//
+// Over-suppression here is not a cosmetic bug. Clearing a HEALTHY reth's member
+// addresses on a tolerant load would black-hole a working cluster on the very
+// path whose whole purpose (#1960) is to keep a node serving.
+func TestSuppressionIsScopedToTheOffendingReth6782(t *testing.T) {
+	lines := []string{
+		"set chassis cluster cluster-id 1",
+		`set chassis cluster authentication-key "Zm9vYmFyYmF6cXV4MTIzNDU2Nzg5MGFiY2Rl"`,
+		"set chassis cluster node 0",
+		"set chassis cluster redundancy-group 1 node 0 priority 200",
+		"set chassis cluster redundancy-group 2 node 0 priority 200",
+		// The offender.
+		"set interfaces reth0 redundant-ether-options redundancy-group 0",
+		"set interfaces reth0 unit 0 family inet address 10.0.61.1/24",
+		"set interfaces ge-0/0/0 gigether-options redundant-parent reth0",
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.61.1/24",
+		// The healthy neighbour, which must be left completely alone.
+		"set interfaces reth1 redundant-ether-options redundancy-group 2",
+		"set interfaces reth1 unit 0 family inet address 10.0.62.1/24",
+		"set interfaces ge-0/0/1 gigether-options redundant-parent reth1",
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.62.1/24",
+	}
+	cfg, err := CompileConfigLenient(rethRGTree(t, lines))
+	if err != nil {
+		t.Fatalf("lenient compile: %v", err)
+	}
+	countAddrs := func(name string) int {
+		ifc := cfg.Interfaces.Interfaces[name]
+		if ifc == nil {
+			t.Fatalf("fixture broken: %s must compile, got %v", name, ifaceNames6782(cfg))
+		}
+		n := 0
+		for _, u := range ifc.Units {
+			n += len(u.Addresses)
+		}
+		return n
+	}
+	// The offender and its member are stripped.
+	if got := countAddrs("reth0"); got != 0 {
+		t.Fatalf("reth0 has an unusable group; its addresses must be suppressed, got %d", got)
+	}
+	if got := countAddrs("ge-0/0/0"); got != 0 {
+		t.Fatalf("ge-0/0/0 inherits from the offending reth; its addresses must be "+
+			"suppressed, got %d", got)
+	}
+	// The healthy neighbour keeps everything. This is the assertion the
+	// single-reth fixtures could not make.
+	if got := countAddrs("reth1"); got == 0 {
+		t.Fatal("reth1's group is VALID — suppressing its addresses would black-hole a " +
+			"healthy interface on the tolerant load path")
+	}
+	if got := countAddrs("ge-0/0/1"); got == 0 {
+		t.Fatal("ge-0/0/1 inherits from a VALID reth — the member loop must be scoped " +
+			"to members of the OFFENDING reth, not every member on the box")
+	}
+}

--- a/pkg/daemon/vip_readiness_test.go
+++ b/pkg/daemon/vip_readiness_test.go
@@ -10,12 +10,40 @@ import (
 
 	"github.com/psaab/xpf/pkg/cluster"
 	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/vishvananda/netlink"
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/configstore"
 	"github.com/psaab/xpf/pkg/vrrp"
 )
+
+// takeoverReadyDP is a minimal userspace dataplane stand-in that reports
+// takeover-ready.
+//
+// #6782 moved the two TakeoverReadinessForRG fixtures' RETH from
+// redundancy-group 0 to 1, because a reth in RG0 no longer commits (RG0 is the
+// chassis-cluster control-plane group — see cluster.Manager.DataGroupIDs — so a
+// reth assigned to it reads as NON-redundant downstream and its address lands on
+// both nodes). That renumbering matters to the fixture: userspaceRGConfigured
+// exempts `rgID <= 0`, so the old RG0 fixtures never reached the userspace
+// takeover gate at all, while a real DATA redundancy group does. Publishing a
+// ready backend here keeps each test isolating the property it actually names —
+// that takeover readiness does not consult cluster sync readiness — rather than
+// reporting not-ready for an unrelated absent backend.
+type takeoverReadyDP struct{ *dataplane.Manager }
+
+func newTakeoverReadyDP() *takeoverReadyDP {
+	return &takeoverReadyDP{Manager: dataplane.New()}
+}
+
+// Mode reports a forwarding-capable userspace mode so the blackhole-route
+// helpers take their early return and the test never touches netlink.
+func (r *takeoverReadyDP) Mode() dpuserspace.DataplaneMode {
+	return dpuserspace.ModeUserspaceCompat
+}
+
+func (r *takeoverReadyDP) TakeoverReady() (bool, []string) { return true, nil }
 
 // testLink implements netlink.Link for testing.
 type testLink struct {
@@ -356,8 +384,14 @@ func TestTakeoverReadinessForRG_NoRethIgnoresClusterSyncReady(t *testing.T) {
 		"set chassis cluster authentication-key test-cluster-psk-6611",
 		"set chassis cluster node 0",
 		"set chassis cluster no-reth-vrrp",
-		"set chassis cluster redundancy-group 0 node 0 priority 200",
-		"set interfaces reth0 redundant-ether-options redundancy-group 0",
+		"set chassis cluster redundancy-group 1 node 0 priority 200",
+		// #6782: the RETH sits in redundancy-group 1, not 0. RG0 is reserved for
+		// control-plane ownership (see cluster.Manager.DataGroupIDs), so a RETH in
+		// group 0 reads as NON-redundant everywhere downstream and its address is
+		// configured on both nodes — that now hard-rejects at commit. The group
+		// NUMBER is incidental to what this test pins (takeover readiness does not
+		// consult cluster sync readiness); do not renumber it back to 0.
+		"set interfaces reth0 redundant-ether-options redundancy-group 1",
 		"set interfaces reth0 unit 0 family inet address 10.0.1.1/24",
 		"set interfaces ge-0/0/0 gigether-options redundant-parent reth0",
 	})
@@ -379,15 +413,16 @@ func TestTakeoverReadinessForRG_NoRethIgnoresClusterSyncReady(t *testing.T) {
 	if d.cluster.IsSyncReady() {
 		t.Fatal("sync should start not ready for this regression test")
 	}
+	d.setDataplane(newTakeoverReadyDP())
 
 	d.reconcileRGState()
 
-	state := d.cluster.GroupState(0)
+	state := d.cluster.GroupState(1)
 	if state == nil {
-		t.Fatal("expected RG 0 state")
+		t.Fatal("expected RG 1 state")
 	}
 	if !state.Ready {
-		t.Fatalf("expected RG 0 ready, got reasons: %v", state.ReadinessReasons)
+		t.Fatalf("expected RG 1 ready, got reasons: %v", state.ReadinessReasons)
 	}
 	for _, reason := range state.ReadinessReasons {
 		if strings.Contains(reason, "session sync not ready") {
@@ -414,8 +449,14 @@ func TestTakeoverReadinessForRG_PrivateRGElectionIgnoresClusterSyncReady_7102(t 
 		"set chassis cluster authentication-key test-cluster-psk-7102",
 		"set chassis cluster node 0",
 		"set chassis cluster private-rg-election",
-		"set chassis cluster redundancy-group 0 node 0 priority 200",
-		"set interfaces reth0 redundant-ether-options redundancy-group 0",
+		"set chassis cluster redundancy-group 1 node 0 priority 200",
+		// #6782: the RETH sits in redundancy-group 1, not 0. RG0 is reserved for
+		// control-plane ownership (see cluster.Manager.DataGroupIDs), so a RETH in
+		// group 0 reads as NON-redundant everywhere downstream and its address is
+		// configured on both nodes — that now hard-rejects at commit. The group
+		// NUMBER is incidental to what this test pins (takeover readiness does not
+		// consult cluster sync readiness); do not renumber it back to 0.
+		"set interfaces reth0 redundant-ether-options redundancy-group 1",
 		"set interfaces reth0 unit 0 family inet address 10.0.1.1/24",
 		"set interfaces ge-0/0/0 gigether-options redundant-parent reth0",
 	})
@@ -446,15 +487,16 @@ func TestTakeoverReadinessForRG_PrivateRGElectionIgnoresClusterSyncReady_7102(t 
 	if d.cluster.IsSyncReady() {
 		t.Fatal("sync must start NOT ready for this test to mean anything")
 	}
+	d.setDataplane(newTakeoverReadyDP())
 
 	d.reconcileRGState()
 
-	state := d.cluster.GroupState(0)
+	state := d.cluster.GroupState(1)
 	if state == nil {
-		t.Fatal("expected RG 0 state")
+		t.Fatal("expected RG 1 state")
 	}
 	if !state.Ready {
-		t.Fatalf("RG 0 not ready with session sync not ready: %v — promotion in "+
+		t.Fatalf("RG 1 not ready with session sync not ready: %v — promotion in "+
 			"private-rg-election mode is NOT sync-gated at HEAD (the gate was deleted "+
 			"in 0781f7a60). If this now reds because #110 restored the gate, update "+
 			"cluster.SetSyncReady's doc comment, the Manager.syncReady field comment "+


### PR DESCRIPTION
Closes #6782

## Cites re-derived

The issue body had already been re-derived once (at `39f1f8b93`). I re-verified
every link of that chain **by symbol at current master `c54d4b918`** rather than
trusting it — all five steps still hold verbatim. Locations below are from that
re-verification, not from the body.

## Measured before fixing

Every value class, both compile paths, on a real committable cluster config.
The `authentication-key` is in the fixture deliberately: without it every strict
compile fails on *that* gate, and a "strict rejects" reading would be true for
the wrong reason.

| token | class | strict (before) | compiles to | strict (after) |
|---|---|---|---|---|
| `0` | control-plane group | **accepted** | 0 | rejected |
| `-1` | negative | **accepted** | -1 *(verbatim)* | rejected |
| `-99999` | negative | **accepted** | -99999 | rejected |
| `abc` | non-numeric | **accepted** | 0 *(error discarded)* | rejected |
| `1.5` | fractional | **accepted** | 0 | rejected |
| `99999999999999999999` | int64 overflow | **accepted** | 0 | rejected |
| `256` / `99999` | above octet ceiling | **accepted** | verbatim | rejected |
| `156` | above VRID cap | **accepted** | 156 | accepted — see below |
| `7` | undeclared but positive | accepted | 7 | accepted — out of scope |
| `1` / `255` / `+3` | valid | accepted | as written | accepted |

Two findings worth stating:

**The one existing upper-bound gate is inert by default.**
`validateRethVRRPGroupIDStrict` (#4826) caps at 155, but returns early under
`no-reth-vrrp` / `private-rg-election` — and `compiler_system.go` sets
`PrivateRGElection = true` **unconditionally as the default**. Measured
side-by-side: with `no-private-rg-election` it rejects `156`; on a default
cluster config it rejects nothing. That early return is *correct for its own
purpose* (no VRRP instance is synthesized, so no VRID exists), which is why this
needed a separate gate rather than a change to that one.

**Negative values are not a discarded-parse-error case.** `-1` parses
successfully and is stored verbatim. Lumping it with `abc` would have missed
that they reach the same failure by different routes.

## The fix

`validateRethRedundancyGroupTokensAST` — an AST pre-walk gate in
`runPreWalkGates`, strict-reject at commit / warn on tolerant load via
`lenientRethRedundancyGroup`. It runs on the raw AST for the reason
`validateChassisClusterIdentitiesAST` (#5694) does: once the typed
`InterfaceConfig` exists, a malformed token has already collapsed to `0` and is
indistinguishable from a reth with no stanza at all.

Accepted range **1..255**:

- **Floor 1** — group 0 is the chassis-cluster *control-plane* group.
  `cluster.Manager.DataGroupIDs` already documents and enforces exactly this
  ("RG0 is reserved for control-plane ownership and is omitted"), so a reth in
  group 0 is a contradiction by the codebase's own definition. I did not invent
  this boundary; I found it already asserted elsewhere.
- **Ceiling 255** — the id is the **third octet** of the derived link-local
  `169.254.<group>.<node+1>/32`, and is also where `MaxHeartbeatRedundancyGroupID`
  already caps the group declarations, so no id above it can name a declared
  group. Deliberately looser than the 155 VRID bound, which stays owned by the
  correctly mode-scoped gate. The two compose.

**The tolerant path suppresses, it does not merely warn.** Warning and then
installing the address on both nodes anyway would make the lenient path the bug.
`suppressInvalidRethAddresses` strips the offending reth's unit addresses and
those of interfaces inheriting through `RedundantParent`. The node still boots
(#1960); it offers no service on that interface until repaired. The group id is
left as written — it is what the operator must fix, and rewriting it would erase
the evidence and let a later commit-check pass on a config that is still wrong.

## Scope deliberately not extended — each measured

- **A reth with no `redundant-ether-options` stanza.** An *absent* token, not an
  invalid one. Measured: several in-tree configs touch a reth without redeclaring
  its group as overlay fragments, and `test/incus/sqm-cookbook-config.set` sets an
  **address** that way. Requiring presence would reject them. Separate policy
  question, pinned by a test so a later tightening has to argue with it.
- **A positive id naming no declared group.** Does not trigger this fail-open at
  all — it still reads as RG-scoped and still takes the link-local substitution.
  Rejecting it would be a new restriction, not a fix. Also pinned.

## Two pre-existing tests were encoding the bug

`vip_readiness_test.go` authored `redundancy-group 0` and asserted the commit
*succeeded* — the issue cites this as evidence it commits. Their subject is
sync-readiness gating (#7102), not the group number, so they move to group 1.

That renumbering is not cosmetic: `userspaceRGConfigured` exempts `rgID <= 0`, so
the RG0 fixtures **never reached the userspace takeover gate at all**. A ready
backend is now published so each test still isolates the property it names. Cell
M14 confirms the backend is genuinely consulted rather than bypassed.

## Mutation matrix

Fix committed at `897398e9d` **first**. One mutation per line; every cell ran the
**full `pkg/config` + `pkg/daemon` suites** with `-count=1` and **no `-run`
filter**; each verified to match its anchor exactly once and still compile.

| # | Cell | Result | Which assertion fired |
|---|---|---|---|
| M1 | gate not wired into prewalk | KILLED | reject test, all classes |
| M2 | floor → 0 | KILLED | `control-plane-group-zero` + suppression |
| M3 | **tighten:** floor → 2 | KILLED | **pre-existing** `TestShippedClusterConfigsAreKeyed_6611` |
| M4 | **tighten:** ceiling −1 | KILLED | `upper-boundary-octet` + classifier |
| M5 | ceiling removed | KILLED | `above-octet-ceiling` |
| M6 | Atoi error ignored | KILLED | `non-numeric`, `fractional` |
| M7 | empty token allowed | KILLED | classifier |
| M8 | strict downgraded to warn | KILLED | reject test |
| M9 | **tighten:** lenient made strict | KILLED | #1960 no-brick leg |
| M10 | suppression call removed | KILLED | lenient suppression test |
| M11 | early-return removed | **SURVIVED — equivalent** | see below |
| M12 | member loop removed | KILLED | member inheritance test |
| M13 | invalid-marker never set | KILLED | lenient suppression test |
| M14 | daemon backend not ready | KILLED | both takeover-readiness tests |
| M15 | **tighten:** member guard dropped | **SURVIVED → fixed → KILLED** | see below |
| M16 | **tighten:** clears every reth | KILLED | new scope test |

**M11 is an equivalent mutant, not a gap.** Removing `len(invalid) == 0` leaves
behaviour identical — `range` over a nil map yields zero iterations and
`invalid[...]` returns false — so it changes performance, not semantics.
Reporting it as killed would have been false.

**M15 was a real gap and the matrix is why it was found.** Dropping the
`invalid[ifc.RedundantParent]` term — making the loop clear the addresses of
*every* interface with a redundant parent — survived the entire suite. The cause:
that guard is **shadowed by the `len(invalid) == 0` early return**, so a fixture
containing only a valid reth never enters the member loop and the term never
decides anything. Even the positive control I had added was powerless, because it
has exactly that shape. The discriminating fixture needs **both** an unusable
reth and a healthy one, each with a member. Fixed in `deee72848`, after which M15
and M16 both red. The admitted bug was not cosmetic: it would clear a *healthy*
reth's member addresses on a tolerant load, black-holing a working cluster on the
path whose whole purpose is to keep the node serving.

## Docs

`docs/config-schema.md` gains a "RETH `redundancy-group` token fail-open (#6782)"
section under the strict-validators chapter: the mechanism, why it is an AST gate,
both range boundaries with their distinct reasons, how it composes with the #4826
VRID bound, the tolerant-path suppression, and the two out-of-scope decisions.
`_Log.md` appended.

## Validation

- `go build ./... && go vet ./... && go test -count=1 ./...` — **green repo-wide**
  at the merged head `9e261a961`, gated on `go test`'s own exit code (rc=0, 67
  packages ok).
- `origin/master` moved during the work (now carries #6785, which touched the
  `SyncStats` files); merged (not rebased) and re-gated. Per the fold note on my
  last PR I also checked `pkg/cluster/sync.go` has **exactly one**
  `return SyncStatsSnapshot{` — it does.

## Cluster smoke

This changes **commit-time validation and config compilation**, not RETH address
programming at runtime: no file under `pkg/vrrp`, `pkg/networkd`, or the dataplane
address path is touched. The behavioural change reaches a running node only by
rejecting a config that would previously have committed, or by suppressing an
address on a tolerant load that was already producing a duplicate.

I did **not** run any `cluster-*` or `test-failover` target. Given it touches HA
config semantics, a smoke run is a reasonable precaution and is yours to call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc6yPeCaYWQjtLMt3MfqpD
