### PR TITLE
devicemap: refuse a MAC-pinned entry when NIC identity is unreadable (#6786)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104505,3 +104505,31 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/config/compiler_uniformgates_cluster_zone.go`,
   `pkg/config/vrrp_vip_count_6779_test.go` (new), `pkg/vrrp/README.md`,
   `pkg/config/README.md`
+
+## 2026-08-22 — #6786 fail closed when a NIC identity read fails
+
+- **Timestamp**: 2026-08-22
+- **Action**: `EnumeratePresentNICs` read each NIC's identity under
+  `if link, err := netlink.LinkByName(name); err == nil` with the error
+  DISCARDED, so a failed read left `PermMAC == ""` — the same value MAC-less
+  hardware produces. `Resolve`'s card-swap refusal is conditioned on
+  `PermMAC != ""`, so a failed read silently DISABLED it and bound the entry as
+  `BindBoundPCIOnly`. Added `PresentNIC.IdentityUnread`, a new
+  `BindRefusedIdentityUnknown` status (with its own operator remedy), and a
+  narrow refusal that fires only for entries pinning a `mac`.
+- **Scoping (the outage the naive fix would cause)**: the refusal does NOT
+  apply to PCI-only entries — their identity came from sysfs and was read
+  successfully. Widening it would let one transient netlink failure refuse every
+  mapped interface including management. Verified the fail-closed direction is
+  safe here: at commit the operator is still connected and nothing is mutated;
+  at boot the #5490 re-check retains the CURRENT interface naming.
+- **False green caught in my own test**: the first commit-preflight assertion
+  checked for the word "identity" and passed while the generic card-swap message
+  ("at its pinned identity") was returned — the wording it was meant to exclude.
+  Fixed by asserting the correct wording is PRESENT and the card-swap remedy
+  ABSENT, and by giving the new status its own message.
+- **File(s)**: `pkg/devicemap/devicemap.go`, `pkg/daemon/device_map.go`,
+  `pkg/grpcapi/server_show_device_map.go`, `pkg/cli/cli_show_cluster.go`,
+  `pkg/devicemap/identity_unread_6786_test.go`,
+  `pkg/daemon/device_map_identity_unread_6786_test.go`,
+  `docs/bare-metal-device-map.md`, `_Log.md`

--- a/docs/bare-metal-device-map.md
+++ b/docs/bare-metal-device-map.md
@@ -37,6 +37,11 @@ the console is your lifeline.
    0000:05:00.0     a0:36:9f:00:11:22  eno1           up
    0000:09:00.0     a0:36:9f:00:11:30  enp9s0         up
    0000:0a:00.0     a0:36:9f:00:11:31  enp10s0        down
+   0000:0b:00.0     (unknown)          enp11s0        unknown
+
+   `(none)` in the Permanent MAC column means the hardware reported no
+   permanent MAC; `(unknown)` means its identity could not be read, so a `mac`
+   pin for it cannot be verified and would be refused (#6786).
 
    Example:
      set chassis device-map interface ge-0/0/3 pci 0000:05:00.0
@@ -103,7 +108,41 @@ immediately on commit.
   binds via the MAC fallback and flags it in `show` (`bound (via MAC
   fallback — PCI moved, re-pin)`).
 - **No permanent MAC** (common on some VFs/virtio): the entry binds PCI-only
-  and `show` marks it `(PCI-only, unverified)`; `key mac` is rejected.
+  and `show` marks it `(PCI-only, unverified)`; `key mac` is rejected. This is a
+  POSITIVE fact — the read succeeded and the hardware reported no permanent-MAC
+  attribute — and is distinct from the case below.
+- **Unreadable-identity refusal (#6786).** If the NIC at the pinned PCI address
+  is present but its identity could not be READ (the per-NIC netlink query
+  failed), its permanent MAC is **UNKNOWN**, not absent. An entry that pins a
+  `mac` is **REFUSED** — `REFUSED (identity unreadable — cannot verify pinned
+  MAC)` — rather than binding it unverified.
+
+  Before this, the enumerator discarded that read error, leaving an empty
+  permanent MAC: the same value MAC-less hardware produces. The topology-change
+  refusal above is conditioned on the permanent MAC being non-empty, so a failed
+  read did not merely lose information — it silently **disabled the card-swap
+  check** and downgraded the entry to `bound (PCI-only, unverified)`, whose own
+  wording asserts "this hardware has no permanent MAC". A card swapped into the
+  pinned slot could then be renamed into the logical name — and the security
+  zone — the `mac` pin existed to keep it out of.
+
+  The remedy is the OPPOSITE of the topology-change one, so it is reported
+  separately: **retry once the interface is readable**. Nothing is known to be
+  wrong with the card, and re-pinning would have you pin against a MAC you
+  cannot currently read.
+
+  The refusal is deliberately **narrow — it applies only to entries that pin a
+  `mac`.** An entry keyed on PCI alone is unaffected: its identity is the PCI
+  address, which comes from sysfs and was read successfully, so the failed
+  netlink read cost it nothing it asked for. Widening it to every unreadable NIC
+  would let one transient netlink failure refuse every mapped interface on the
+  box, management included.
+
+  `show chassis device-map candidates` distinguishes the two states in the
+  **Permanent MAC** column: `(none)` means the hardware reported none, while
+  `(unknown)` means the read failed. The **Link** column likewise shows
+  `unknown` rather than `down`, so an unreadable NIC does not send you hunting a
+  cabling fault that does not exist.
 - **Non-PCI physical NICs** (USB / platform / SoC ethernet) have no PCI
   address but do carry a factory MAC. They are enumerated (with an empty PCI
   column) so a `key mac` entry binds them; only purely virtual netdevs
@@ -216,12 +255,22 @@ discipline.
 A commit that changes the device-map runs a **node-local pre-flight** against
 the present hardware while you are still connected:
 
-- A `REFUSED` entry is rejected, for EITHER reason — topology-changed, or a
-  logical name claimed by more than one entry (#6546). The two carry different
-  remedies, so the pre-flight reports them separately: "re-pin the entry" for a
-  card swap, "remove the duplicate entry" for a duplicate name. The check tests
-  `BindStatus.Refused()` rather than one sentinel value, so a future refusal
-  reason cannot slip past this hard stop and be treated as a clean result.
+- A `REFUSED` entry is rejected, for ANY reason — topology-changed, a logical
+  name claimed by more than one entry (#6546), or an identity that could not be
+  read (#6786). Each carries a different remedy, so the pre-flight reports them
+  separately: "re-pin the entry" for a card swap, "remove the duplicate entry"
+  for a duplicate name, and "retry once the interface is readable" for an
+  unreadable identity. The check tests `BindStatus.Refused()` rather than one
+  sentinel value, so a future refusal reason cannot slip past this hard stop and
+  be treated as a clean result.
+
+  Commit is the cheapest place for this to fail: you are still connected,
+  nothing on the box has been mutated, and the boot-time re-check (#5490) runs
+  the same detector again before any rename, retaining the current interface
+  naming if it trips. A refusal therefore never renames a NIC and never writes a
+  `.link` file — which matters because a `.link` is durable and udev replays it
+  on every subsequent boot, so a mis-binding written during a transient failure
+  would outlive the failure itself.
 - A map that would move the live management NIC's name onto a different port
   (or steal the management name) is rejected.
 - `commit confirmed` validates BOTH the candidate AND the rollback target

--- a/pkg/cli/cli_show_cluster.go
+++ b/pkg/cli/cli_show_cluster.go
@@ -138,14 +138,12 @@ func (c *CLI) showChassisDeviceMapCandidates() error {
 	fmt.Printf("%-16s %-18s %-14s %s\n", "PCI address", "Permanent MAC", "Current name", "Link")
 	fmt.Printf("%-16s %-18s %-14s %s\n", "-----------", "-------------", "------------", "----")
 	for _, n := range nics {
-		perm := n.PermMAC
-		if perm == "" {
-			perm = "(none)"
-		}
-		link := "down"
-		if n.LinkUp {
-			link = "up"
-		}
+		// #6786: single-sourced so the local CLI and the remote/gRPC
+		// renderer cannot drift, and so an UNREAD identity is not reported
+		// as "(none)"/"down" — which would assert facts the failed read
+		// does not support.
+		perm := n.PermMACDisplay()
+		link := n.LinkDisplay()
 		fmt.Printf("%-16s %-18s %-14s %s\n", n.PCIAddr, perm, n.Name, link)
 	}
 	fmt.Println("\nExample:")

--- a/pkg/daemon/device_map.go
+++ b/pkg/daemon/device_map.go
@@ -254,6 +254,15 @@ func enumerateAndRenameMapped(dm *config.DeviceMapConfig, cfg *config.Config, pr
 				"(topology changed). Refusing to bind to avoid hijacking the wrong NIC; re-pin "+
 				"the device-map.",
 				"logical", b.Entry.LogicalName, "pci", b.Entry.PCIAddr, "mac", b.Entry.MAC)
+		case b.Status == devicemap.BindRefusedIdentityUnknown:
+			// #6786: distinct from the topology-change refusal above — the card
+			// may be entirely correct; its identity just could not be read, so
+			// the pinned MAC could not be verified against it.
+			slog.Error("device-map: entry REFUSED — the NIC at this identity could not be read, so "+
+				"its permanent MAC is UNKNOWN and the pinned MAC cannot be verified. Refusing to "+
+				"bind an unverified NIC into a pinned logical name; retry once the interface is "+
+				"readable.",
+				"logical", b.Entry.LogicalName, "pci", b.Entry.PCIAddr, "mac", b.Entry.MAC)
 		case b.Status == devicemap.BindRefusedDupName:
 			// #6546: more than one entry claims this logical name. Binding
 			// either one would rename a nondeterministically-chosen NIC to it
@@ -489,6 +498,19 @@ func deviceMapStrandsManagement(cfg *config.Config, nics []presentNIC, protected
 			return fmt.Sprintf("device-map entry %q refuses to bind: more than one entry claims "+
 				"this logical name, so binding either would rename an arbitrary NIC to it. "+
 				"Remove the duplicate entry before committing.", b.Entry.LogicalName)
+		}
+		// #6786: an UNREADABLE identity is not a topology change. Nothing is
+		// known to be wrong with the card — the permanent MAC simply could not
+		// be read, so the pinned MAC could not be verified. Telling this
+		// operator to "re-pin the entry" sends them to a fix that changes
+		// nothing (the same wrong-remedy trap #6546 named), and would have them
+		// re-pin against a MAC they cannot currently read.
+		if b.Status == devicemap.BindRefusedIdentityUnknown {
+			return fmt.Sprintf("device-map entry %q refuses to bind: the NIC at its pinned identity "+
+				"could not be read, so its permanent MAC is UNKNOWN and the pinned MAC cannot be "+
+				"verified. Binding it would rename a NIC whose identity was never checked. Retry "+
+				"once the interface is readable; do NOT re-pin against an unreadable MAC.",
+				b.Entry.LogicalName)
 		}
 		if b.Status.Refused() {
 			return fmt.Sprintf("device-map entry %q refuses to bind: a different card is present "+

--- a/pkg/daemon/device_map_identity_unread_6786_test.go
+++ b/pkg/daemon/device_map_identity_unread_6786_test.go
@@ -1,0 +1,262 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/devicemap"
+)
+
+// unreadIdentitySeams stubs the mapped-rename orchestration so the single
+// present NIC at the pinned PCI has an UNREADABLE identity — the per-NIC
+// netlink read failed, so its permanent MAC is unknown. It returns counters
+// for the rename and reload seams and the temp link dir, so a test can assert
+// ZERO side effects rather than merely a returned error.
+func unreadIdentitySeams(t *testing.T) (renameCalls, reloadCalls *int, dir string) {
+	t.Helper()
+	dir = withTempLinkDir(t)
+
+	savedEnum := enumeratePresentNICsFn
+	enumeratePresentNICsFn = func() ([]presentNIC, error) {
+		return []presentNIC{{
+			Name:    "enp9s0",
+			PCIAddr: "0000:09:00.0",
+			// PermMAC deliberately left "" AND IdentityUnread set: this is the
+			// exact state a failed netlink.LinkByName produces, and the state
+			// that used to be indistinguishable from MAC-less hardware.
+			IdentityUnread: true,
+		}}, nil
+	}
+	t.Cleanup(func() { enumeratePresentNICsFn = savedEnum })
+
+	var rc, lc int
+	savedRename := renameInterfaceFn
+	renameInterfaceFn = func(from, to string) error { rc++; return nil }
+	t.Cleanup(func() { renameInterfaceFn = savedRename })
+
+	savedReload := networkctlReloadFn
+	networkctlReloadFn = func() error { lc++; return nil }
+	t.Cleanup(func() { networkctlReloadFn = savedReload })
+
+	lifelineRecordFileForTest = filepath.Join(t.TempDir(), "no-lifeline")
+	t.Cleanup(func() { lifelineRecordFileForTest = "" })
+
+	return &rc, &lc, dir
+}
+
+// macPinnedMapConfig maps ge-0/0/3 to the NIC at 0000:09:00.0 AND pins its
+// permanent MAC — the shape an operator authors precisely so a card swapped
+// into that slot is refused rather than silently adopted.
+func macPinnedMapConfig() (*config.DeviceMapConfig, *config.Config) {
+	dm := &config.DeviceMapConfig{
+		Entries: []config.DeviceMapEntry{{
+			LogicalName: "ge-0/0/3",
+			PCIAddr:     "0000:09:00.0",
+			MAC:         "aa:bb:cc:dd:ee:01",
+		}},
+	}
+	cfg := &config.Config{Chassis: config.ChassisConfig{DeviceMap: dm}}
+	return dm, cfg
+}
+
+// linkFileCount counts .link files written into the device-map link dir.
+func linkFileCount(t *testing.T, dir string) int {
+	t.Helper()
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read link dir: %v", err)
+	}
+	n := 0
+	for _, e := range ents {
+		if filepath.Ext(e.Name()) == ".link" {
+			n++
+		}
+	}
+	return n
+}
+
+// TestUnreadIdentityProducesZeroRenameSideEffects6786 is the injected
+// LinkByName-failure test the issue asked for, and it asserts SIDE EFFECTS
+// rather than a return value.
+//
+// A returned error is not the property that matters here. What matters is that
+// nothing was MOVED: no interface renamed, no `.link` file written (a .link is
+// DURABLE — udev replays it on every subsequent boot, so a wrong one persists
+// the mis-binding long after the transient read failure is gone), and no
+// networkctl reload. A fix that logged the refusal but still renamed would
+// return an error and still have hijacked the NIC.
+//
+// Both arms are exercised because they reach "no side effects" through
+// DIFFERENT code:
+//   - protected non-empty: the #5490 boot re-check runs deviceMapStrandsManagement
+//     first, sees a refused binding, and aborts before phase 1. It must also
+//     return an error so the retry marker is preserved and boot surfaces it.
+//   - protected empty: that pre-check is skipped by contract ("empty protected
+//     == nothing to protect"), so the refusal has to be honoured by the rename
+//     loop itself — the refused entry must never reach desiredByCurrent.
+//
+// FAIL-ON-REVERT: discarding the LinkByName error again (or dropping the
+// IdentityUnread refusal) binds the entry as BindBoundPCIOnly, phase 2 renames
+// enp9s0 to ge-0-0-3 and writes its .link — reddening the rename count and the
+// link-file count in both arms.
+func TestUnreadIdentityProducesZeroRenameSideEffects6786(t *testing.T) {
+	t.Run("protected-set-boot-recheck-aborts", func(t *testing.T) {
+		renames, reloads, dir := unreadIdentitySeams(t)
+		dm, cfg := macPinnedMapConfig()
+
+		err := enumerateAndRenameMapped(dm, cfg, map[string]bool{"fxp0": true})
+		if err == nil {
+			t.Error("a mapped entry whose pinned MAC cannot be verified must FAIL the boot rename " +
+				"so the retry marker is preserved and boot surfaces it loudly; got nil")
+		}
+		if *renames != 0 {
+			t.Errorf("renames = %d, want 0: a NIC whose permanent MAC could not be read must not be "+
+				"renamed into a pinned logical name — that is the silent hijack #1956 forbids", *renames)
+		}
+		if n := linkFileCount(t, dir); n != 0 {
+			t.Errorf(".link files written = %d, want 0: a .link is DURABLE (udev replays it every "+
+				"boot), so writing one on an unverified identity persists the mis-binding long "+
+				"after the transient read failure clears", n)
+		}
+		if *reloads != 0 {
+			t.Errorf("networkctl reloads = %d, want 0", *reloads)
+		}
+	})
+
+	t.Run("no-protected-set-rename-loop-honours-refusal", func(t *testing.T) {
+		renames, reloads, dir := unreadIdentitySeams(t)
+		dm, cfg := macPinnedMapConfig()
+
+		// Empty protected set: the #5490 pre-check is skipped by contract, so
+		// this arm proves the rename loop itself honours the refusal.
+		_ = enumerateAndRenameMapped(dm, cfg, map[string]bool{})
+
+		if *renames != 0 {
+			t.Errorf("renames = %d, want 0: with no protected set the #5490 pre-check is skipped, "+
+				"so the refusal must be honoured by the rename loop itself", *renames)
+		}
+		if n := linkFileCount(t, dir); n != 0 {
+			t.Errorf(".link files written = %d, want 0", n)
+		}
+		if *reloads != 0 {
+			t.Errorf("networkctl reloads = %d, want 0", *reloads)
+		}
+	})
+}
+
+// TestReadableIdentityStillRenames6786 is the tightening control for the test
+// above: it uses the SAME seams with the ONLY difference being that the
+// identity read succeeded and the permanent MAC matches the pin. Without it,
+// a "fix" that refuses every mapped entry unconditionally would satisfy every
+// zero-side-effect assertion above and look correct — while bricking
+// device-map naming entirely.
+func TestReadableIdentityStillRenames6786(t *testing.T) {
+	dir := withTempLinkDir(t)
+
+	savedEnum := enumeratePresentNICsFn
+	enumeratePresentNICsFn = func() ([]presentNIC, error) {
+		return []presentNIC{{
+			Name:    "enp9s0",
+			PCIAddr: "0000:09:00.0",
+			PermMAC: "aa:bb:cc:dd:ee:01", // read OK, matches the pin
+		}}, nil
+	}
+	t.Cleanup(func() { enumeratePresentNICsFn = savedEnum })
+
+	var renames int
+	savedRename := renameInterfaceFn
+	renameInterfaceFn = func(from, to string) error { renames++; return nil }
+	t.Cleanup(func() { renameInterfaceFn = savedRename })
+
+	savedReload := networkctlReloadFn
+	networkctlReloadFn = func() error { return nil }
+	t.Cleanup(func() { networkctlReloadFn = savedReload })
+
+	lifelineRecordFileForTest = filepath.Join(t.TempDir(), "no-lifeline")
+	t.Cleanup(func() { lifelineRecordFileForTest = "" })
+
+	dm, cfg := macPinnedMapConfig()
+	if err := enumerateAndRenameMapped(dm, cfg, map[string]bool{}); err != nil {
+		t.Fatalf("a verified identity must still bind and rename: %v", err)
+	}
+	if renames == 0 {
+		t.Error("renames = 0: a NIC whose permanent MAC was read and MATCHES the pin must still be " +
+			"renamed — the #6786 refusal must be scoped to an UNREADABLE identity, not applied to " +
+			"every mapped entry")
+	}
+	if n := linkFileCount(t, dir); n == 0 {
+		t.Error(".link files written = 0: a verified binding must still persist its .link")
+	}
+}
+
+// TestUnreadIdentityRefusesAtCommitPreflight6786 covers the remaining mutation
+// site named in the issue: commit. #5490 already fails closed when the WHOLE
+// inventory read fails; this is the per-NIC case it does not reach — the
+// enumeration succeeds and returns a NIC whose identity is unknown.
+//
+// Refusing at commit is the cheapest possible place to fail: the operator is
+// still connected, nothing on the box has been mutated, and the remedy (retry,
+// or repair the identity read) is available to them immediately.
+func TestUnreadIdentityRefusesAtCommitPreflight6786(t *testing.T) {
+	_, _, _ = unreadIdentitySeams(t)
+	_, cfg := macPinnedMapConfig()
+
+	d := &Daemon{}
+	if err := d.deviceMapCommitPreflight(cfg, nil); err == nil {
+		t.Fatal("committing a device-map whose pinned MAC cannot be verified against the NIC at " +
+			"its PCI address must be REJECTED while the operator is still connected, rather than " +
+			"accepted and applied unverified at next boot")
+	}
+
+	// The refusal must carry the RIGHT REMEDY. This started as a check for the
+	// word "identity" and passed while the generic card-swap message was being
+	// returned — that message contains "at its pinned identity", so the
+	// assertion was satisfied by exactly the wording it was meant to exclude.
+	// The discriminating pair is: the unreadable-identity wording must be
+	// PRESENT and the card-swap remedy must be ABSENT. Telling an operator
+	// whose NIC is merely unreadable to "re-pin the entry" sends them to a fix
+	// that changes nothing, and asks them to re-pin against a MAC they cannot
+	// currently read (the wrong-remedy trap #6546 named).
+	err := d.deviceMapCommitPreflight(cfg, nil)
+	got := err.Error()
+	if !containsFold(got, "could not be read") || !containsFold(got, "UNKNOWN") {
+		t.Errorf("the rejection must say the identity could not be READ and that the permanent MAC "+
+			"is UNKNOWN; got %q", got)
+	}
+	if containsFold(got, "a different card is present") || containsFold(got, "Re-pin the entry") {
+		t.Errorf("the rejection must NOT use the topology-change remedy: nothing is known to be "+
+			"wrong with the card, and re-pinning against an unreadable MAC fixes nothing; got %q", got)
+	}
+	if devicemap.BindRefusedIdentityUnknown.String() == devicemap.BindRefusedAmbig.String() {
+		t.Error("the unreadable-identity and topology-change statuses must render differently — " +
+			"`show chassis device-map` is where an operator reads which one happened")
+	}
+}
+
+func containsFold(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && indexFold(haystack, needle) >= 0
+}
+
+func indexFold(h, n string) int {
+	lower := func(b byte) byte {
+		if b >= 'A' && b <= 'Z' {
+			return b + 32
+		}
+		return b
+	}
+	for i := 0; i+len(n) <= len(h); i++ {
+		ok := true
+		for j := 0; j < len(n); j++ {
+			if lower(h[i+j]) != lower(n[j]) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/devicemap/devicemap.go
+++ b/pkg/devicemap/devicemap.go
@@ -418,15 +418,26 @@ func classifyNetdev(name, devReal string, devErr error) (pci string, keep bool) 
 // (factory) MAC, running MAC, and link state. Sorted by PCI address, then
 // kernel name, for stable output (non-PCI NICs share an empty PCI address, so
 // the name tiebreak keeps their order deterministic).
+// sysClassNetDir and linkByName are seams so the enumerator's own wiring is
+// testable (#6786). Without them the ONLY way to observe that a failed
+// per-NIC read sets IdentityUnread is on live hardware, so every test would
+// have to construct PresentNIC by hand — which binds Resolve's handling of the
+// flag while leaving the code that SETS it covered by nothing. Production
+// values are the real sysfs path and netlink.
+var (
+	sysClassNetDir = "/sys/class/net"
+	linkByName     = netlink.LinkByName
+)
+
 func EnumeratePresentNICs() ([]PresentNIC, error) {
-	entries, err := os.ReadDir("/sys/class/net")
+	entries, err := os.ReadDir(sysClassNetDir)
 	if err != nil {
 		return nil, err
 	}
 	var nics []PresentNIC
 	for _, e := range entries {
 		name := e.Name()
-		devReal, derr := filepath.EvalSymlinks(filepath.Join("/sys/class/net", name, "device"))
+		devReal, derr := filepath.EvalSymlinks(filepath.Join(sysClassNetDir, name, "device"))
 		pci, keep := classifyNetdev(name, devReal, derr)
 		if !keep {
 			continue
@@ -441,7 +452,7 @@ func EnumeratePresentNICs() ([]PresentNIC, error) {
 		// make a real NIC vanish from `show chassis device-map candidates`); what
 		// changes is that its identity is marked UNKNOWN so a MAC-pinned entry
 		// refuses instead of binding blind.
-		if link, err := netlink.LinkByName(name); err == nil {
+		if link, err := linkByName(name); err == nil {
 			a := link.Attrs()
 			nic.RunningMAC = a.HardwareAddr.String()
 			if len(a.PermHWAddr) != 0 {

--- a/pkg/devicemap/devicemap.go
+++ b/pkg/devicemap/devicemap.go
@@ -8,6 +8,7 @@
 package devicemap
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -22,9 +23,70 @@ import (
 type PresentNIC struct {
 	Name       string // current kernel name (post-udev, pre-xpf-rename)
 	PCIAddr    string // PCI bus address ("" if none)
-	PermMAC    string // permanent/factory MAC ("" if unavailable)
+	PermMAC    string // permanent/factory MAC ("" when IdentityUnread is false: hardware has none)
 	RunningMAC string // current running MAC (diagnostic only)
 	LinkUp     bool   // operational/admin state (diagnostic; for `candidates`)
+
+	// IdentityUnread reports that the per-NIC identity read FAILED, so
+	// PermMAC / RunningMAC / LinkUp are UNKNOWN rather than known-absent
+	// (#6786).
+	//
+	// Before this the two states were the same value. EnumeratePresentNICs
+	// listed the NIC from sysfs and then read its attributes over netlink
+	// under `if link, err := netlink.LinkByName(name); err == nil` — with the
+	// error DISCARDED — so a failed read left PermMAC == "", which is exactly
+	// what hardware with no permanent-MAC attribute produces. Resolve's
+	// topology-change guard is conditioned on `PermMAC != ""`, so a failed
+	// read did not merely lose information: it silently DISABLED the card-swap
+	// refusal and downgraded the entry to BindBoundPCIOnly ("bound, PCI-only,
+	// unverified"), renaming a NIC whose permanent MAC was never checked
+	// against the one the operator pinned. That inverts the #1956 contract
+	// that a PCI hit with a mismatched permanent MAC must REFUSE and never
+	// silently hijack.
+	//
+	// INVARIANT: only EnumeratePresentNICs may set this true. A PresentNIC
+	// built by hand asserts a KNOWN identity, which is why the zero value is
+	// false — a synthesized record describes a NIC the caller already knows,
+	// and the unknown state is only observable by the code that did the read.
+	IdentityUnread bool
+}
+
+// PermMACDisplay renders this NIC's permanent MAC for the operator-facing
+// `show chassis device-map candidates` table (#6786).
+//
+// It distinguishes the two states an empty PermMAC used to collapse: "(none)"
+// asserts the positive fact that the hardware reported no permanent-MAC
+// attribute, while "(unknown)" says the identity read FAILED and nothing is
+// known. Printing "(none)" for a failed read tells an operator authoring a map
+// that this NIC cannot be MAC-pinned, which may be false — and it hides the
+// reason a MAC-pinned entry for it now refuses to bind.
+//
+// Single-sourced deliberately: the local CLI and the gRPC/remote CLI render
+// this same table from two call sites, and a divergence between them is always
+// a bug — they describe one machine's hardware to one operator.
+func (n PresentNIC) PermMACDisplay() string {
+	if n.IdentityUnread {
+		return "(unknown)"
+	}
+	if n.PermMAC == "" {
+		return "(none)"
+	}
+	return n.PermMAC
+}
+
+// LinkDisplay renders this NIC's link state for the candidates table. Like
+// PermMACDisplay it separates a read that succeeded from one that did not:
+// LinkUp is false both for a NIC that is genuinely down and for one whose
+// state was never read, and reporting an unread NIC as "down" invites an
+// operator to go hunting for a cabling fault that does not exist.
+func (n PresentNIC) LinkDisplay() string {
+	if n.IdentityUnread {
+		return "unknown"
+	}
+	if n.LinkUp {
+		return "up"
+	}
+	return "down"
 }
 
 // BindStatus classifies how a device-map entry resolved.
@@ -42,6 +104,14 @@ const (
 	// the hardware and re-pinning an identity fixes nothing — the MAP has two
 	// entries claiming one interface name and one of them must go.
 	BindRefusedDupName
+	// BindRefusedIdentityUnknown: the NIC at this entry's pinned identity
+	// could not be READ, so its permanent MAC is unknown and the entry's
+	// pinned MAC cannot be verified against it (#6786). Distinct from
+	// BindRefusedAmbig because nothing is known to be wrong with the hardware
+	// — the remedy is to retry/repair the identity read, not to re-pin the
+	// entry — and distinct from BindBoundPCIOnly, which asserts the positive
+	// fact that the hardware HAS no permanent MAC to check.
+	BindRefusedIdentityUnknown
 )
 
 func (s BindStatus) String() string {
@@ -58,6 +128,8 @@ func (s BindStatus) String() string {
 		return "REFUSED (topology changed — card swapped at this identity)"
 	case BindRefusedDupName:
 		return "REFUSED (logical name claimed by more than one device-map entry)"
+	case BindRefusedIdentityUnknown:
+		return "REFUSED (identity unreadable — cannot verify pinned MAC)"
 	default:
 		return "unknown"
 	}
@@ -76,7 +148,8 @@ func (s BindStatus) Decisive() bool {
 // single sentinel, so a new refusal reason cannot slip past a `== BindRefusedAmbig`
 // check and be silently treated as a clean result (#6546).
 func (s BindStatus) Refused() bool {
-	return s == BindRefusedAmbig || s == BindRefusedDupName
+	return s == BindRefusedAmbig || s == BindRefusedDupName ||
+		s == BindRefusedIdentityUnknown
 }
 
 // Bound reports whether the status is one of the three bound variants.
@@ -143,6 +216,25 @@ func Resolve(entries []config.DeviceMapEntry, nics []PresentNIC, rethMembers map
 			if e.MAC != "" && !isRETH && len(pm) == 1 &&
 				pm[0].PermMAC != "" && !strings.EqualFold(pm[0].PermMAC, e.MAC) {
 				rb.Status, rb.CurrentNIC, rb.Logical = BindRefusedAmbig, "", ""
+				out = append(out, rb)
+				continue
+			}
+			// (c) #6786: the NIC at the pinned PCI is present but its identity
+			// could not be READ, so its permanent MAC is UNKNOWN and the check
+			// in (b) could not run. The entry pins a MAC precisely to detect a
+			// card swap at this slot; binding anyway would assert "verified by
+			// PCI, hardware has no MAC to check" — a claim the failed read does
+			// not support. Refuse instead, order-independently like (a)/(b).
+			//
+			// This is deliberately NARROW. It fires only when the operator
+			// pinned a MAC for this entry, so an entry keyed on PCI alone is
+			// unaffected: its identity is the PCI address, which came from
+			// sysfs and was read successfully, and the failed netlink read cost
+			// it nothing it asked for. Widening it to every unreadable NIC
+			// would let one transient netlink failure refuse interfaces whose
+			// operator never requested MAC verification.
+			if e.MAC != "" && !isRETH && len(pm) == 1 && pm[0].IdentityUnread {
+				rb.Status, rb.CurrentNIC, rb.Logical = BindRefusedIdentityUnknown, "", ""
 				out = append(out, rb)
 				continue
 			}
@@ -340,6 +432,15 @@ func EnumeratePresentNICs() ([]PresentNIC, error) {
 			continue
 		}
 		nic := PresentNIC{Name: name, PCIAddr: pci}
+		// #6786: the error from this read is RECORDED, not discarded. A failed
+		// read leaves PermMAC == "", which is the same value hardware with no
+		// permanent-MAC attribute produces — and Resolve's card-swap refusal is
+		// conditioned on PermMAC != "", so swallowing the error silently turned
+		// "REFUSE, a different card is at this identity" into "bind, unverified".
+		// The NIC is still listed (it is present in sysfs, and dropping it would
+		// make a real NIC vanish from `show chassis device-map candidates`); what
+		// changes is that its identity is marked UNKNOWN so a MAC-pinned entry
+		// refuses instead of binding blind.
 		if link, err := netlink.LinkByName(name); err == nil {
 			a := link.Attrs()
 			nic.RunningMAC = a.HardwareAddr.String()
@@ -347,6 +448,12 @@ func EnumeratePresentNICs() ([]PresentNIC, error) {
 				nic.PermMAC = a.PermHWAddr.String()
 			}
 			nic.LinkUp = a.OperState == netlink.OperUp || a.Flags&1 != 0 // IFF_UP
+		} else {
+			nic.IdentityUnread = true
+			slog.Warn("device-map: NIC identity read failed; permanent MAC is UNKNOWN. "+
+				"A device-map entry that pins a MAC at this NIC's identity will REFUSE to bind "+
+				"rather than bind it unverified (#6786)",
+				"nic", name, "pci", pci, "err", err)
 		}
 		nics = append(nics, nic)
 	}

--- a/pkg/devicemap/identity_unread_6786_test.go
+++ b/pkg/devicemap/identity_unread_6786_test.go
@@ -1,0 +1,186 @@
+package devicemap
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// pinnedEntry is a device-map entry that pins BOTH a PCI address and a MAC —
+// the shape an operator authors when they want the card-swap check.
+func pinnedEntry(mac string) config.DeviceMapEntry {
+	return config.DeviceMapEntry{LogicalName: "ge-0/0/3", PCIAddr: "0000:09:00.0", MAC: mac}
+}
+
+// TestPinnedMACRefusesWhenIdentityUnread6786 is the #6786 fail-on-revert test.
+//
+// EnumeratePresentNICs used to read each NIC's attributes under
+// `if link, err := netlink.LinkByName(name); err == nil` with the error
+// DISCARDED, so a failed read left PermMAC == "" — the SAME value hardware
+// with no permanent-MAC attribute produces. Resolve's card-swap refusal is
+// conditioned on `PermMAC != ""`, so the failed read did not merely lose
+// information: it silently disabled the refusal and bound the entry as
+// BindBoundPCIOnly, whose own String() asserts "no permanent MAC" — a positive
+// claim the failed read cannot support. A swapped card at the pinned slot was
+// then renamed into the logical name (and hence the security zone) the
+// operator had pinned away from it.
+//
+// The table's THIRD row is the one that makes this test able to fail. Rows that
+// only cover "unread refuses" would stay green under a fix that refuses every
+// NIC lacking a permanent MAC — which would regress #4884 (MAC-less hardware
+// binding by PCI) and turn a benign state into a refusal. The middle row holds
+// that behaviour still.
+func TestPinnedMACRefusesWhenIdentityUnread6786(t *testing.T) {
+	const pinned = "aa:bb:cc:dd:ee:01"
+	tests := []struct {
+		name string
+		nic  PresentNIC
+		want BindStatus
+	}{
+		{
+			// The defect: the read FAILED, so the permanent MAC is UNKNOWN and
+			// the pinned MAC cannot be verified. Must refuse.
+			name: "identity-unread",
+			nic:  PresentNIC{Name: "enp9s0", PCIAddr: "0000:09:00.0", IdentityUnread: true},
+			want: BindRefusedIdentityUnknown,
+		},
+		{
+			// REGRESSION CONTROL (#4884): the read SUCCEEDED and the hardware
+			// genuinely has no permanent-MAC attribute. This is a positive
+			// fact, not an unknown, and it must still bind PCI-only exactly as
+			// before. A fix that refuses on `PermMAC == ""` reds here.
+			name: "no-perm-mac-hardware",
+			nic:  PresentNIC{Name: "enp9s0", PCIAddr: "0000:09:00.0"},
+			want: BindBoundPCIOnly,
+		},
+		{
+			// The read succeeded and the MAC matches the pin.
+			name: "perm-mac-matches",
+			nic:  PresentNIC{Name: "enp9s0", PCIAddr: "0000:09:00.0", PermMAC: pinned},
+			want: BindBound,
+		},
+		{
+			// The read succeeded and a DIFFERENT card is in the slot. This is
+			// the refusal #6786 restores for the unreadable case; it must keep
+			// its own, distinct status so the operator remedies differ.
+			name: "perm-mac-differs",
+			nic:  PresentNIC{Name: "enp9s0", PCIAddr: "0000:09:00.0", PermMAC: "aa:bb:cc:dd:ee:99"},
+			want: BindRefusedAmbig,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Resolve([]config.DeviceMapEntry{pinnedEntry(pinned)}, []PresentNIC{tc.nic}, nil)
+			if len(got) != 1 {
+				t.Fatalf("Resolve returned %d bindings, want 1", len(got))
+			}
+			if got[0].Status != tc.want {
+				t.Errorf("status = %v (%s), want %v (%s)",
+					got[0].Status, got[0].Status.String(), tc.want, tc.want.String())
+			}
+			// A refusal must carry NO binding: an entry that refuses and still
+			// names a NIC would be renamed by the daemon's rename loop, which
+			// keys on CurrentNIC.
+			if tc.want.Refused() && (got[0].CurrentNIC != "" || got[0].Logical != "") {
+				t.Errorf("a refused binding must name no NIC and no logical name, got CurrentNIC=%q Logical=%q",
+					got[0].CurrentNIC, got[0].Logical)
+			}
+		})
+	}
+}
+
+// TestUnreadIdentityDoesNotRefusePCIOnlyEntry6786 is the ANTI-OVER-REACH
+// control, and it guards the decision that keeps this fix from causing an
+// outage of its own.
+//
+// The refusal is scoped to entries that pin a MAC, because those are the only
+// entries whose stated identity the failed read actually damaged. An entry
+// keyed on PCI alone has its identity from sysfs — which succeeded — so
+// nothing it asked for is unknown. Refusing it too would let ONE transient
+// netlink failure refuse every mapped interface on the box, including a
+// management NIC whose operator never requested MAC verification.
+//
+// FAIL-ON-REVERT: widening the guard to `pm[0].IdentityUnread` without the
+// `e.MAC != ""` conjunct reds this.
+func TestUnreadIdentityDoesNotRefusePCIOnlyEntry6786(t *testing.T) {
+	entry := config.DeviceMapEntry{LogicalName: "ge-0/0/3", PCIAddr: "0000:09:00.0"} // no MAC pinned
+	nic := PresentNIC{Name: "enp9s0", PCIAddr: "0000:09:00.0", IdentityUnread: true}
+
+	got := Resolve([]config.DeviceMapEntry{entry}, []PresentNIC{nic}, nil)
+	if len(got) != 1 {
+		t.Fatalf("Resolve returned %d bindings, want 1", len(got))
+	}
+	if got[0].Status.Refused() {
+		t.Fatalf("a PCI-only entry must NOT be refused because some OTHER attribute was unreadable: "+
+			"its identity is the PCI address, which was read successfully. Refusing it lets one "+
+			"transient netlink failure strand every mapped interface, management included. status=%s",
+			got[0].Status.String())
+	}
+	if got[0].CurrentNIC != "enp9s0" {
+		t.Errorf("PCI-only entry must still bind its NIC, got CurrentNIC=%q status=%s",
+			got[0].CurrentNIC, got[0].Status.String())
+	}
+}
+
+// TestRefusedAgreesWithStatusString6786 binds the AGREEMENT between the two
+// spellings of "this status is a refusal" rather than pinning either one.
+//
+// Refused() is an explicit disjunction and every hard-stop in the daemon
+// (deviceMapStrandsManagement, the boot re-check) routes through it — the
+// #6546 comment on it says a new refusal reason must not be able to slip past
+// as a clean result, but the implementation still requires each one to be
+// added by hand. Comparing it against String()'s own "REFUSED" prefix is what
+// makes that promise checkable: adding a refusal status and forgetting
+// Refused() reds here instead of silently becoming a commit-time pass.
+func TestRefusedAgreesWithStatusString6786(t *testing.T) {
+	all := []BindStatus{
+		BindBound, BindBoundPCIOnly, BindBoundViaMAC, BindUnbound,
+		BindRefusedAmbig, BindRefusedDupName, BindRefusedIdentityUnknown,
+	}
+	// Premise: the list covers every declared status, so a new one added
+	// without updating this test cannot hide behind a short list.
+	if got := len(all); BindStatus(got-1) != BindRefusedIdentityUnknown {
+		t.Fatalf("premise broken: %d statuses listed but the last declared one is %d — "+
+			"a status was added without extending this table", got, BindRefusedIdentityUnknown)
+	}
+	for _, s := range all {
+		saysRefused := strings.HasPrefix(s.String(), "REFUSED")
+		if saysRefused != s.Refused() {
+			t.Errorf("status %d disagrees with itself: String()=%q (REFUSED prefix=%v) but Refused()=%v. "+
+				"Every daemon hard-stop routes through Refused(), so a refusal it does not report "+
+				"is silently treated as a clean result", int(s), s.String(), saysRefused, s.Refused())
+		}
+	}
+}
+
+// TestCandidateDisplayDistinguishesUnknownFromNone6786 pins the diagnostics
+// half. "(none)" is a positive claim — the hardware has no permanent-MAC
+// attribute, so this NIC cannot be MAC-pinned. Printing it for a NIC whose
+// read FAILED tells the operator something that may be false, and hides why a
+// MAC-pinned entry for that NIC now refuses to bind. Same for reporting an
+// unread NIC's link as "down", which sends them hunting a cabling fault.
+func TestCandidateDisplayDistinguishesUnknownFromNone6786(t *testing.T) {
+	tests := []struct {
+		name     string
+		nic      PresentNIC
+		wantPerm string
+		wantLink string
+	}{
+		{"unread", PresentNIC{IdentityUnread: true}, "(unknown)", "unknown"},
+		{"unread-down-looking", PresentNIC{IdentityUnread: true, LinkUp: false}, "(unknown)", "unknown"},
+		{"hardware-has-none", PresentNIC{}, "(none)", "down"},
+		{"has-mac-up", PresentNIC{PermMAC: "aa:bb:cc:dd:ee:01", LinkUp: true}, "aa:bb:cc:dd:ee:01", "up"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.nic.PermMACDisplay(); got != tc.wantPerm {
+				t.Errorf("PermMACDisplay() = %q, want %q", got, tc.wantPerm)
+			}
+			if got := tc.nic.LinkDisplay(); got != tc.wantLink {
+				t.Errorf("LinkDisplay() = %q, want %q", got, tc.wantLink)
+			}
+		})
+	}
+}

--- a/pkg/devicemap/identity_unread_6786_test.go
+++ b/pkg/devicemap/identity_unread_6786_test.go
@@ -1,10 +1,15 @@
 package devicemap
 
 import (
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
 )
 
 // pinnedEntry is a device-map entry that pins BOTH a PCI address and a MAC —
@@ -183,4 +188,104 @@ func TestCandidateDisplayDistinguishesUnknownFromNone6786(t *testing.T) {
 			}
 		})
 	}
+}
+
+// fakeSysClassNet builds a hermetic /sys/class/net-shaped tree containing one
+// entry per name, each with a `device` symlink (which is what marks a netdev as
+// backed by real hardware) pointing at a real directory so EvalSymlinks
+// resolves. It points the enumerator's sysfs seam at it.
+func fakeSysClassNet(t *testing.T, names ...string) {
+	t.Helper()
+	root := t.TempDir()
+	hw := filepath.Join(root, "hw")
+	if err := os.MkdirAll(hw, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range names {
+		nd := filepath.Join(root, n)
+		if err := os.MkdirAll(nd, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(hw, filepath.Join(nd, "device")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	saved := sysClassNetDir
+	sysClassNetDir = root
+	t.Cleanup(func() { sysClassNetDir = saved })
+}
+
+// TestEnumeratorRecordsIdentityReadFailure6786 binds the WIRING, which the
+// resolver tests above cannot reach.
+//
+// Every other test in this file constructs PresentNIC by hand, so they pin how
+// Resolve TREATS IdentityUnread while leaving the code that SETS it covered by
+// nothing — and that code is the actual defect: the discarded `err` from the
+// per-NIC read. Deleting the assignment would leave every hand-built fixture
+// green. These two cells run the real EnumeratePresentNICs against a hermetic
+// sysfs tree with the netlink read stubbed, so the flag's producer is bound to
+// the same property its consumers rely on.
+//
+// The PAIR is what proves it: the failing read must set the flag, and the
+// SUCCEEDING read must clear it. A cell that only checked the failure case
+// would stay green under a fix that hard-codes IdentityUnread = true, which
+// would refuse every MAC-pinned entry on every box.
+func TestEnumeratorRecordsIdentityReadFailure6786(t *testing.T) {
+	t.Run("read-fails-marks-unread", func(t *testing.T) {
+		fakeSysClassNet(t, "enp9s0")
+		saved := linkByName
+		linkByName = func(string) (netlink.Link, error) {
+			return nil, errors.New("injected: netlink LinkByName failure")
+		}
+		t.Cleanup(func() { linkByName = saved })
+
+		nics, err := EnumeratePresentNICs()
+		if err != nil {
+			t.Fatalf("EnumeratePresentNICs: %v", err)
+		}
+		if len(nics) != 1 {
+			t.Fatalf("got %d NICs, want 1 (the NIC is present in sysfs and must NOT be dropped — "+
+				"dropping it would make a real NIC vanish from `candidates`)", len(nics))
+		}
+		if !nics[0].IdentityUnread {
+			t.Error("a FAILED per-NIC identity read must set IdentityUnread. Leaving it false makes " +
+				"the failure indistinguishable from hardware that simply has no permanent MAC, " +
+				"which is what silently disabled the card-swap refusal (#6786)")
+		}
+		if nics[0].PermMAC != "" {
+			t.Errorf("a failed read must not invent a permanent MAC, got %q", nics[0].PermMAC)
+		}
+	})
+
+	t.Run("read-succeeds-leaves-known", func(t *testing.T) {
+		fakeSysClassNet(t, "enp9s0")
+		mac, err := net.ParseMAC("aa:bb:cc:dd:ee:01")
+		if err != nil {
+			t.Fatal(err)
+		}
+		saved := linkByName
+		linkByName = func(name string) (netlink.Link, error) {
+			return &netlink.Device{LinkAttrs: netlink.LinkAttrs{
+				Name:         name,
+				PermHWAddr:   mac,
+				HardwareAddr: mac,
+			}}, nil
+		}
+		t.Cleanup(func() { linkByName = saved })
+
+		nics, err := EnumeratePresentNICs()
+		if err != nil {
+			t.Fatalf("EnumeratePresentNICs: %v", err)
+		}
+		if len(nics) != 1 {
+			t.Fatalf("got %d NICs, want 1", len(nics))
+		}
+		if nics[0].IdentityUnread {
+			t.Error("a SUCCESSFUL identity read must leave IdentityUnread false — hard-coding it " +
+				"true would refuse every MAC-pinned device-map entry on every box")
+		}
+		if nics[0].PermMAC != "aa:bb:cc:dd:ee:01" {
+			t.Errorf("PermMAC = %q, want the permanent MAC the read returned", nics[0].PermMAC)
+		}
+	})
 }

--- a/pkg/grpcapi/server_show_device_map.go
+++ b/pkg/grpcapi/server_show_device_map.go
@@ -65,14 +65,12 @@ func (s *Server) showChassisDeviceMapCandidates(buf *strings.Builder) {
 	fmt.Fprintf(buf, "%-16s %-18s %-14s %s\n", "PCI address", "Permanent MAC", "Current name", "Link")
 	fmt.Fprintf(buf, "%-16s %-18s %-14s %s\n", "-----------", "-------------", "------------", "----")
 	for _, n := range nics {
-		perm := n.PermMAC
-		if perm == "" {
-			perm = "(none)"
-		}
-		link := "down"
-		if n.LinkUp {
-			link = "up"
-		}
+		// #6786: single-sourced so the local CLI and the remote/gRPC
+		// renderer cannot drift, and so an UNREAD identity is not reported
+		// as "(none)"/"down" — which would assert facts the failed read
+		// does not support.
+		perm := n.PermMACDisplay()
+		link := n.LinkDisplay()
 		fmt.Fprintf(buf, "%-16s %-18s %-14s %s\n", n.PCIAddr, perm, n.Name, link)
 	}
 	buf.WriteString("\nExample:\n")


### PR DESCRIPTION
Closes #6786

All cites are **re-derived from code** (the issue body's `/tmp/opus-review-001.md`
R45 pointer is dead).

## The defect

`devicemap.EnumeratePresentNICs` listed each NIC from sysfs and then read its
attributes over netlink:

```go
if link, err := netlink.LinkByName(name); err == nil {
    ...
    if len(a.PermHWAddr) != 0 { nic.PermMAC = a.PermHWAddr.String() }
}
```

The error was **discarded**, so a failed read left `PermMAC == ""` — exactly the
value hardware with no permanent-MAC attribute produces. The issue is right that
the two states were one value.

**That is not merely lost information.** `Resolve`'s topology-change refusal is
conditioned on the present NIC's `PermMAC` being non-empty:

```go
if e.MAC != "" && !isRETH && len(pm) == 1 &&
    pm[0].PermMAC != "" && !strings.EqualFold(pm[0].PermMAC, e.MAC) { → BindRefusedAmbig }
```

So a failed read **silently disabled the card-swap check** and fell through to
`BindBoundPCIOnly` — a status whose own `String()` reads *"bound (PCI-only,
unverified — no permanent MAC)"*, asserting a positive fact about the hardware
the failed read cannot support. A card swapped into the pinned slot was then
renamed into the logical name — and hence the security zone — that the
operator's `mac` pin existed to keep it out of. That inverts the #1956 contract
that a PCI hit with a mismatched permanent MAC must REFUSE and never silently
hijack.

## On the direction of "fail closed" — checked, not assumed

You flagged that failing closed on a NIC identity read could mean refusing to
bind a management NIC. I checked before making anything fatal, and the answer is
that this specific fail-closed is safe — for reasons already in the codebase:

- **At commit**, `deviceMapStrandsManagement` already hard-stops on *any*
  `Status.Refused()` — explicitly "refuse while they are still connected".
  Nothing on the box is mutated; the operator retries.
- **At boot**, the #5490 re-check runs that same detector *before any rename*
  and, when it trips, **retains the current interface naming** and returns an
  error. Management stays reachable under the name it already has. A refusal
  therefore never renames and never writes a `.link` — which matters because a
  `.link` is durable and udev replays it every boot, so a mis-binding recorded
  during a transient failure would outlive the failure itself.
- Device-map mode already declares the console the lifeline (§9.6: no auto-fxp0,
  no bootstrap DHCP), so this is the posture that mode is built around.

**But the naive version of this fix WOULD cause an outage, so the refusal is
deliberately narrow: it fires only for entries that pin a `mac`.** An entry keyed
on PCI alone is untouched — its identity is the PCI address, which came from
sysfs and was read successfully, so the failed netlink read cost it nothing it
asked for. Widening the guard to every unreadable NIC would let a single
transient netlink failure refuse every mapped interface on the box, management
included: trading a conditional hijack for an unconditional outage. **Cell M3
below is that control**, and it is the cell I'd most want reviewed.

#5490 already covered a *whole-inventory* enumeration failure; the **per-NIC**
case it does not reach is what this closes.

## The fix

- `PresentNIC.IdentityUnread` — set only by `EnumeratePresentNICs`, so "read
  failed" and "hardware has none" are distinguishable.
- `BindRefusedIdentityUnknown` — its **own** status, not a reuse of
  `BindRefusedAmbig`, because the operator remedy is the opposite: nothing is
  known to be wrong with the card, so "re-pin the entry" would have them re-pin
  against a MAC they cannot currently read. That is the wrong-remedy trap #6546
  named. Both the commit pre-flight and the boot rename log it distinctly.
- Diagnostics: `show chassis device-map candidates` printed `(none)` for an
  unread MAC — telling an operator the NIC cannot be MAC-pinned, which may be
  false — and `down` for its link, sending them after a cabling fault that does
  not exist. Both now render `(unknown)`. The local CLI and the gRPC/remote CLI
  rendered that table from **two copies** of the same formatting; a divergence
  between them is always a bug (one machine, one operator), so the two fields
  whose meaning changed are single-sourced onto `PresentNIC`.

## Mutation matrix

Fix committed BEFORE the matrix. One mutation per line, anchor asserted to match
exactly once, tree rebuilt, then the full suites for all four affected packages
with `-count=1` and **no `-run` filter**. Every cell asserts `skipped_6786 == 0`
so no cell can pass by skipping. **The whole matrix was re-run at the merged
head** after master moved.

Control (M0): **3765 passing, 0 failed, 0 skips.**

| Cell | Mutation (one line) | Result | Which assertion fired |
|---|---|---|---|
| M0 | none (control) | **GREEN** | 3765 pass / 0 fail / 0 skip |
| M1 | `IdentityUnread = true` → `false` (**the shipped bug**) | **RED** | `TestEnumeratorRecordsIdentityReadFailure6786` |
| M2 | disable the new refusal (`if false && …`) | **RED** ×3 | `TestPinnedMACRefusesWhenIdentityUnread6786`, `TestUnreadIdentityProducesZeroRenameSideEffects6786`, `TestUnreadIdentityRefusesAtCommitPreflight6786` |
| M3 | **tightening / over-reach** — drop the `e.MAC != ""` conjunct so every unreadable NIC refuses | **RED** | `TestUnreadIdentityDoesNotRefusePCIOnlyEntry6786` — the outage control |
| M4 | drop the new status from `Refused()` | **RED** | `TestRefusedAgreesWithStatusString6786` |
| M5 | delete the dedicated remedy message (fall through to card-swap wording) | **RED** | `TestUnreadIdentityRefusesAtCommitPreflight6786` |
| M6 | **tightening** — refuse whenever `PermMAC == ""` (treat MAC-less hardware as unknown) | **RED** ×2 | mine, **plus the pre-existing `TestResolvePCIOnlyWhenNoPermMAC`** (#4884 regression) |
| M7 | `PermMACDisplay` stops reporting `(unknown)` | **RED** | `TestCandidateDisplayDistinguishesUnknownFromNone6786` |
| M8 | **tightening** — hard-code `IdentityUnread = true` for every NIC | **RED** | `TestEnumeratorRecordsIdentityReadFailure6786` (the pair's success cell) |

**Two things I want to flag against myself.**

*A false green I caught in my own test.* The commit-preflight assertion first
checked that the rejection mentioned `"identity"` — and it **passed while the
generic card-swap message was being returned**, because that message contains
"at its pinned identity". The assertion was satisfied by exactly the wording it
existed to exclude, and it also hid a real defect: the new refusal was
inheriting the wrong operator remedy. Fixed both — the status got its own
message, and the assertion now requires the correct wording to be PRESENT *and*
the card-swap remedy to be ABSENT. M5 is the cell that now holds it.

*A wiring gap.* Every guard initially constructed `PresentNIC` **by hand**, so
they pinned how `Resolve` *treats* `IdentityUnread` while leaving the code that
*sets* it — the discarded error, i.e. the actual defect — covered by nothing;
deleting the assignment left them all green. The second commit adds seams (sysfs
root + `LinkByName`) so `EnumeratePresentNICs` runs hermetically, and the test is
a **pair**: a failing read must set the flag and a succeeding read must leave it
clear. Without the second half, hard-coding `true` would pass — which is what M8
proves. It also asserts the NIC is still *returned* on a failed read; dropping it
would make a real NIC vanish from `candidates`.

## Validation

- `go build ./...` rc=0 · `go vet ./...` clean · `go test -count=1 ./...`
  (repo-wide) **rc=0** — re-run at the merged head.
- Gated head **`0d2ba9acd0dac14ab8949c38dbf93ea89cc9c8d1`**, which merges
  `origin/master` (master moved twice during this work; each time the only
  conflict was an append-vs-append in `_Log.md`, union-resolved, verified with
  an ANCHORED marker sweep — an unanchored `grep` false-positives on this file's
  own prose about conflict markers — and with both sides' entries confirmed
  present). Build, vet, the repo-wide suite, and the two most load-bearing
  matrix cells (M2, M3) were all re-run at that head: a fold can introduce a
  regression, and a matrix measured at an older tree is not a matrix for the
  head being merged.
- **My branch's own diff is Go-only** (`git diff origin/master...HEAD` touches no
  `.rs`, no `userspace-dp/`, no `userspace-xdp/`, no shim `.o`) — so no cargo leg
  and no cluster smoke is owed. The merge pulled in another lane's Rust changes
  from master; those are master's content, not this PR's.
- **No cluster / VRRP / session-sync / failover code touched.**

## Docs

`docs/bare-metal-device-map.md` gains an **Unreadable-identity refusal (#6786)**
bullet next to the existing topology-change and duplicate-name ones, covering
the mechanism, why the remedy differs, why the refusal is scoped to MAC-pinned
entries, and the `(none)` vs `(unknown)` distinction; the candidates sample table
now shows an `(unknown)` row; and the commit pre-flight section is updated to
list all three refusal reasons with their separate remedies.
