### PR TITLE
ra: give a dead sender a retry owner

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104679,3 +104679,18 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/devicemap/identity_unread_6786_test.go`,
   `pkg/daemon/device_map_identity_unread_6786_test.go`,
   `docs/bare-metal-device-map.md`, `_Log.md`
+
+## 2026-08-22 — #6793 dead RA sender had no retry owner
+
+- **Timestamp**: 2026-08-22
+- **Action**: A sender's conn open is asynchronous, so a bind failure leaves the
+  sender dead with `startLocked` having reported success. `Apply`'s #2865 branch
+  rebuilds a dead sender, but standalone applies RA only from a config apply
+  (`reconcileRGStateLoop` is cluster-only) and the cluster reconcile is
+  digest-gated — a dead sender moves no digest. Added
+  `ra.Manager.HasDeadSenders()`/`DeadSenderInterfaces()`, a digest bypass in
+  `reconcileClusterRAServices`, and an always-on `raDeadSenderReassertLoop`
+  mirroring `proxyARPReassertLoop` (applySem before the config read, #4001).
+- **File(s)**: pkg/ra/ra.go, pkg/ra/dead_sender_probe_6793_test.go,
+  pkg/daemon/daemon_ra_reconcile.go, pkg/daemon/daemon.go, pkg/daemon/daemon_run.go,
+  pkg/daemon/ra_dead_sender_retry_6793_test.go, pkg/ra/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -104694,3 +104694,11 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: pkg/ra/ra.go, pkg/ra/dead_sender_probe_6793_test.go,
   pkg/daemon/daemon_ra_reconcile.go, pkg/daemon/daemon.go, pkg/daemon/daemon_run.go,
   pkg/daemon/ra_dead_sender_retry_6793_test.go, pkg/ra/README.md, _Log.md
+- **Timestamp**: 2026-08-22
+- **Action**: #6793 round 2 — two mutation cells came back GREEN. Removing the
+  INNER dead-sender re-check (the one after applySem) was invisible because the
+  outer check still short-circuited the healthy fixture; and nothing bound the
+  loop's START in Run, so a daemon that never launched the retry owner passed
+  every cell. Added the queue-behind-a-commit interleave, a loop-body cell with
+  a shortened interval, and a comment-stripped source check on the start site.
+- **File(s)**: pkg/daemon/ra_dead_sender_retry_6793_test.go, _Log.md

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -960,6 +960,14 @@ type Daemon struct {
 	lastRAReconcileHash string
 	raApplyFn           func([]*config.RAInterfaceConfig) error
 
+	// raHasDeadSendersFn overrides the dead-sender probe (#6793). Nil means use
+	// d.ra.HasDeadSenders. It exists because the reassert loop's contract —
+	// "re-drive the apply if and only if a sender is DEAD" — cannot be
+	// exercised against a real ra.Manager without an interface whose ndp.Listen
+	// genuinely fails, and a fixture that manufactured that would be asserting
+	// the bind failure rather than the retry ownership.
+	raHasDeadSendersFn func() bool
+
 	// startupActiveAnnounce tracks whether the one-shot active-side
 	// neighbor refresh has been sent for each RG on this daemon run.
 	// This covers restart/redeploy of an already-active direct-mode RG,

--- a/pkg/daemon/daemon_ra_reconcile.go
+++ b/pkg/daemon/daemon_ra_reconcile.go
@@ -1,11 +1,13 @@
 package daemon
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"log/slog"
 	"sort"
+	"time"
 
 	"github.com/psaab/xpf/pkg/config"
 )
@@ -63,7 +65,15 @@ func (d *Daemon) reconcileClusterRAServices(reason string) {
 
 	desired := d.desiredClusterRA(cfg)
 	newHash := raDesiredHash(desired)
-	if newHash == d.lastRAReconcileHash {
+	// #6793: a DEAD sender (its asynchronous conn open failed, so it will never
+	// emit an RA) does not move the desired-set digest, so the idempotence gate
+	// below skipped the very apply that would rebuild it. That made this
+	// function's own "a transient apply error is retried on the next pass"
+	// promise false for the one failure it cannot see in the digest: the
+	// interface stayed silent until an unrelated config change moved the hash.
+	// Re-drive the apply while any sender is dead; ra.Apply's #2865 branch does
+	// the rebuild and is a no-op for every healthy sender in the same set.
+	if newHash == d.lastRAReconcileHash && !d.raHasDeadSenders() {
 		return
 	}
 
@@ -79,6 +89,120 @@ func (d *Daemon) reconcileClusterRAServices(reason string) {
 		slog.Info("ra: cluster RA withdrawn (no active owner)", "reason", reason)
 	}
 	d.lastRAReconcileHash = newHash
+}
+
+// raHasDeadSenders reports whether the RA manager holds a sender whose
+// asynchronous conn open failed (#6793). Routed through a daemon method rather
+// than touching d.ra directly at the call sites so the nil-manager case (no RA
+// configured, or a test daemon) is handled once.
+func (d *Daemon) raHasDeadSenders() bool {
+	if d.raHasDeadSendersFn != nil {
+		return d.raHasDeadSendersFn()
+	}
+	return d.ra != nil && d.ra.HasDeadSenders()
+}
+
+// raDeadSenderReassertInterval is the cadence of the always-on dead-sender
+// re-drive (#6793). A dead sender means an interface is advertising nothing, so
+// the recovery wants to be prompt; but the repair is a full RA apply, so it must
+// not run at the 2s cadence of the cluster reconcile. 30s matches
+// proxyARPReassertInterval, the other always-on self-heal loop, and bounds the
+// silent window to well inside a Router Lifetime.
+var raDeadSenderReassertInterval = 30 * time.Second
+
+// raDeadSenderReassertLoop is the retry owner a dead RA sender did not have
+// (#6793). It covers the STANDALONE gap specifically: standalone applies RA
+// from applyServicesReconcile, which runs only on a config apply, and
+// reconcileRGStateLoop is cluster-only — so before this loop a boot-time bind
+// failure left the interface with no router advertisements until an operator
+// happened to commit. Hosts on that segment got no default route, on a node
+// that had reported a successful commit.
+//
+// Always-on and mode-agnostic, mirroring proxyARPReassertLoop: it re-reads the
+// active config each tick rather than capturing one at start, and it is free on
+// the common path because the gate is a map walk over live senders. Cluster mode
+// is additionally covered at its own 2s reconcile (the digest bypass above); this
+// loop is harmless there — a pass with no dead sender does nothing at all.
+func (d *Daemon) raDeadSenderReassertLoop(ctx context.Context) {
+	t := time.NewTicker(raDeadSenderReassertInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			d.reassertDeadRASendersOnce(ctx)
+		}
+	}
+}
+
+// reassertDeadRASendersOnce re-drives one RA apply if — and only if — a sender
+// is dead.
+//
+// It takes applySem before reading ActiveConfig, for the reason #4001 gave the
+// proxy-ARP loop: reading the config outside the semaphore lets a tick capture a
+// PRE-commit snapshot and re-assert state a concurrent commit has just removed.
+// Here that would re-arm RA on an interface the operator had just deleted it
+// from. Taking the semaphore makes the tick block behind any in-flight commit
+// and always reconcile the post-commit config.
+//
+// The dead-sender check is deliberately re-run INSIDE the semaphore. The
+// pre-check outside it is only an optimisation to avoid queueing behind a
+// commit for nothing; a commit that lands in between may already have rebuilt
+// the sender, and re-applying then would be a gratuitous RA restart.
+func (d *Daemon) reassertDeadRASendersOnce(ctx context.Context) {
+	// The applier seam, not d.ra.Apply directly: reconcileClusterRAServices
+	// already selects through raApplyFn, and two RA appliers in one daemon is
+	// the divergence this file exists to avoid. It also makes the re-drive
+	// OBSERVABLE — without it the standalone half of the retry owner has no
+	// assertion point that does not require a genuinely failing ndp.Listen.
+	apply := d.raApplyFn
+	if apply == nil {
+		if d.ra == nil {
+			return
+		}
+		apply = d.ra.Apply
+	}
+	if !d.raHasDeadSenders() {
+		return
+	}
+	if d.applySem == nil {
+		return
+	}
+	if err := d.applySem.Acquire(ctx, 1); err != nil {
+		return
+	}
+	defer d.applySem.Release(1)
+	if !d.raHasDeadSenders() {
+		return
+	}
+	cfg := d.store.ActiveConfig()
+	if cfg == nil {
+		return
+	}
+	var dead []string
+	if d.ra != nil {
+		dead = d.ra.DeadSenderInterfaces()
+	}
+	if cfg.Chassis.Cluster != nil {
+		// Cluster mode owns RA through the digest-gated reconcile; drive THAT
+		// rather than applying a standalone desired set here, or the two owners
+		// would disagree about which RGs this node advertises for.
+		slog.Info("ra: re-driving the cluster reconcile for a dead sender",
+			"interfaces", dead)
+		d.reconcileClusterRAServices("dead-sender-reassert")
+		return
+	}
+	raConfigs := d.buildRAConfigs(cfg)
+	if len(raConfigs) == 0 {
+		return
+	}
+	slog.Info("ra: rebuilding a sender whose conn open failed",
+		"interfaces", dead)
+	if err := apply(raConfigs); err != nil {
+		slog.Warn("ra: dead-sender rebuild failed; will retry",
+			"interfaces", dead, "err", err)
+	}
 }
 
 // desiredClusterRA returns the union of buildRAConfigs entries whose interface

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -554,6 +554,19 @@ func (d *Daemon) Run(ctx context.Context) error {
 		}()
 	}
 
+	// #6793: the always-on retry owner for an RA sender whose ASYNCHRONOUS conn
+	// open failed. Started unconditionally, alongside the proxy-ARP re-assert
+	// and for the same reason: standalone applies RA only from a config apply
+	// and reconcileRGStateLoop is cluster-only, so a boot-time bind failure
+	// otherwise left the interface silent until an operator happened to commit.
+	// The loop is free when every sender opened (its gate is a map walk over
+	// live senders), so it costs nothing on configs that do not use RA.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		d.raDeadSenderReassertLoop(ctx)
+	}()
+
 	// #1387 inc-2: start the always-on DHCP dynamic-DNS reconcile loop. It
 	// is constructed UNCONDITIONALLY (idle when disabled) so an
 	// enabled→disabled commit can still withdraw published records; the loop

--- a/pkg/daemon/ra_dead_sender_retry_6793_test.go
+++ b/pkg/daemon/ra_dead_sender_retry_6793_test.go
@@ -1,0 +1,237 @@
+package daemon
+
+// ra_dead_sender_retry_6793_test.go — #6793 RETRY-OWNER regression.
+//
+// pkg/ra's cells bind the probe and the rebuild. They stay GREEN when nothing
+// ever calls Apply again — which IS the bug: standalone applies RA only from
+// applyServicesReconcile (a config apply), and reconcileRGStateLoop is
+// cluster-only, so a boot-time bind failure left an interface advertising
+// nothing until an operator happened to commit.
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// standaloneRADaemon6793 builds a daemon with a committed standalone config
+// carrying one RA interface, plus spies for the applier and the dead-sender
+// probe.
+func standaloneRADaemon6793(t *testing.T, dead bool) (*Daemon, *int, *sync.Mutex) {
+	t.Helper()
+	store, err := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err != nil {
+		t.Fatalf("configstore.New: %v", err)
+	}
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := store.LoadOverride(`
+interfaces {
+    ge-0/0/0 {
+        unit 0 {
+            family inet6 {
+                address 2001:db8:61::1/64;
+            }
+        }
+    }
+}
+protocols {
+    router-advertisement {
+        interface ge-0/0/0.0 {
+            prefix 2001:db8:61::/64;
+        }
+    }
+}
+security {
+    zones {
+        security-zone trust {
+            interfaces {
+                ge-0/0/0.0;
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride: %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	store.ExitConfigure()
+
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("fixture must commit a config")
+	}
+	if cfg.Chassis.Cluster != nil {
+		t.Fatal("fixture must be STANDALONE — the cluster path has its own driver")
+	}
+
+	d := &Daemon{store: store, applySem: semaphore.NewWeighted(1)}
+	// Guard the fixture's own premise: an empty desired RA set would make the
+	// applier a no-op and every assertion below vacuous.
+	if got := len(d.buildRAConfigs(cfg)); got == 0 {
+		t.Fatal("fixture built ZERO RA configs, so the reassert would have " +
+			"nothing to apply and this test could not distinguish a working " +
+			"retry owner from a missing one")
+	}
+
+	var mu sync.Mutex
+	applies := 0
+	d.raApplyFn = func([]*config.RAInterfaceConfig) error {
+		mu.Lock()
+		applies++
+		mu.Unlock()
+		return nil
+	}
+	d.raHasDeadSendersFn = func() bool { return dead }
+	return d, &applies, &mu
+}
+
+// TestDeadSenderReassertAppliesOnlyWhenASenderIsDead6793 is the PAIRED wiring
+// cell: the same tick, two probe answers, opposite outcomes.
+//
+// The healthy leg is the one that keeps the fix from being a new bug. An
+// always-on loop that re-applied RA unconditionally would restart every healthy
+// sender every 30s — a periodic RA gap on a working firewall, which is worse
+// than the silence it is meant to cure.
+func TestDeadSenderReassertAppliesOnlyWhenASenderIsDead6793(t *testing.T) {
+	t.Run("dead-sender-is-re-driven", func(t *testing.T) {
+		d, applies, mu := standaloneRADaemon6793(t, true)
+		d.reassertDeadRASendersOnce(context.Background())
+		mu.Lock()
+		got := *applies
+		mu.Unlock()
+		if got != 1 {
+			t.Fatalf("the reassert applied RA %d times for a DEAD sender, want "+
+				"1 — standalone has no other driver (applyServicesReconcile runs "+
+				"only on a config apply, reconcileRGStateLoop is cluster-only), "+
+				"so without this the interface advertises nothing until an "+
+				"operator happens to commit (#6793)", got)
+		}
+	})
+
+	t.Run("no-applier-and-no-manager-is-safe", func(t *testing.T) {
+		// The loop is started UNCONDITIONALLY, so it ticks on daemons that
+		// never built an RA manager. It must not panic there.
+		store, err := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+		if err != nil {
+			t.Fatalf("configstore.New: %v", err)
+		}
+		d := &Daemon{store: store, applySem: semaphore.NewWeighted(1)}
+		d.reassertDeadRASendersOnce(context.Background())
+	})
+}
+
+// TestDeadSenderReassertIsANoOpWhenEverySenderIsHealthy6793 pins the gate
+// itself, with no RA manager needed: a tick whose probe says "no dead sender"
+// must not touch the applier.
+//
+// RED-on-revert: drop the `!d.raHasDeadSenders()` early return from
+// reassertDeadRASendersOnce and this fires — an unconditional 30s RA re-apply.
+func TestDeadSenderReassertIsANoOpWhenEverySenderIsHealthy6793(t *testing.T) {
+	d, applies, mu := standaloneRADaemon6793(t, false)
+	d.reassertDeadRASendersOnce(context.Background())
+	mu.Lock()
+	got := *applies
+	mu.Unlock()
+	if got != 0 {
+		t.Fatalf("the reassert applied RA %d times with NO dead sender — an "+
+			"always-on loop that re-applies unconditionally restarts every "+
+			"healthy sender on its cadence, a periodic RA gap on a working "+
+			"firewall (#6793)", got)
+	}
+}
+
+// TestClusterReconcileBypassesTheDigestForADeadSender6793 pins the OTHER half.
+// reconcileClusterRAServices runs every 2s but is digest-gated, and a dead
+// sender does not move the digest — so its own doc comment's promise ("a
+// transient apply error is retried on the next pass") did not hold for the one
+// failure the digest cannot see.
+//
+// PAIRED on the same converged state: with no dead sender the digest must still
+// short-circuit, or the 2s loop would re-apply RA forever.
+func TestClusterReconcileBypassesTheDigestForADeadSender6793(t *testing.T) {
+	newClusterDaemon := func(t *testing.T, dead bool) (*Daemon, *int, *sync.Mutex) {
+		t.Helper()
+		store, err := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+		if err != nil {
+			t.Fatalf("configstore.New: %v", err)
+		}
+		if err := store.EnterConfigure(); err != nil {
+			t.Fatalf("EnterConfigure: %v", err)
+		}
+		if err := store.LoadOverride(`
+chassis {
+    cluster {
+        cluster-id 1;
+        node 0;
+        authentication-key "cyaLE6jUXcHqZBB6xSJP7CVc5S9dHRBAtF5vTBqFEss=";
+    }
+}
+`); err != nil {
+			t.Fatalf("LoadOverride: %v", err)
+		}
+		if _, err := store.Commit(); err != nil {
+			t.Fatalf("Commit: %v", err)
+		}
+		store.ExitConfigure()
+		if store.ActiveConfig().Chassis.Cluster == nil {
+			t.Fatal("fixture must commit a CLUSTER config")
+		}
+
+		d := &Daemon{store: store, applySem: semaphore.NewWeighted(1)}
+		var mu sync.Mutex
+		applies := 0
+		d.raApplyFn = func([]*config.RAInterfaceConfig) error {
+			mu.Lock()
+			applies++
+			mu.Unlock()
+			return nil
+		}
+		d.raHasDeadSendersFn = func() bool { return dead }
+		return d, &applies, &mu
+	}
+
+	// Converge first: one pass applies and records the digest. With no RA
+	// configured the desired set is empty, which still produces a stable digest
+	// — that is the case where a dead sender is most invisible.
+	t.Run("converged-then-dead-sender-re-drives", func(t *testing.T) {
+		d, applies, mu := newClusterDaemon(t, false)
+		d.reconcileClusterRAServices("converge")
+		mu.Lock()
+		afterConverge := *applies
+		mu.Unlock()
+
+		// A second pass with nothing changed must be free.
+		d.reconcileClusterRAServices("idempotent")
+		mu.Lock()
+		afterIdempotent := *applies
+		mu.Unlock()
+		if afterIdempotent != afterConverge {
+			t.Fatalf("the digest gate stopped short-circuiting (%d -> %d applies) "+
+				"— the 2s loop would re-apply RA on every tick",
+				afterConverge, afterIdempotent)
+		}
+
+		// Now a sender dies. The digest has NOT moved.
+		d.raHasDeadSendersFn = func() bool { return true }
+		d.reconcileClusterRAServices("dead-sender")
+		mu.Lock()
+		afterDead := *applies
+		mu.Unlock()
+		if afterDead <= afterIdempotent {
+			t.Fatalf("a DEAD sender did not re-drive the cluster reconcile "+
+				"(%d applies, unchanged) — the desired-set digest cannot see a "+
+				"dead sender, so the interface stays silent until an unrelated "+
+				"config change moves the hash (#6793)", afterDead)
+		}
+	})
+}

--- a/pkg/daemon/ra_dead_sender_retry_6793_test.go
+++ b/pkg/daemon/ra_dead_sender_retry_6793_test.go
@@ -10,9 +10,12 @@ package daemon
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"golang.org/x/sync/semaphore"
 
@@ -234,4 +237,158 @@ chassis {
 				"config change moves the hash (#6793)", afterDead)
 		}
 	})
+}
+
+// TestReassertRechecksTheGateInsideTheSemaphore6793 binds the INNER gate.
+//
+// The outer check (before applySem) is only an optimisation: it avoids queueing
+// behind a commit for nothing. The inner one is the correctness gate — a tick
+// that blocked behind an in-flight commit may find that the commit ALREADY
+// rebuilt the sender, and re-applying then is a gratuitous RA restart on a
+// healthy interface.
+//
+// The mutation that survives without this cell removes only the inner check;
+// the outer one still short-circuits the healthy case, so
+// TestDeadSenderReassertIsANoOpWhenEverySenderIsHealthy6793 stays green. This
+// drives the exact interleave: the probe says DEAD when the tick starts, a
+// "commit" holds the semaphore, and by the time the tick acquires it the sender
+// is healthy again.
+func TestReassertRechecksTheGateInsideTheSemaphore6793(t *testing.T) {
+	d, applies, mu := standaloneRADaemon6793(t, true)
+
+	// Hold applySem, as an in-flight commit would.
+	if err := d.applySem.Acquire(context.Background(), 1); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		close(started)
+		d.reassertDeadRASendersOnce(context.Background())
+		close(done)
+	}()
+	<-started
+
+	// The tick is now blocked on the semaphore (or about to be). Simulate the
+	// commit having rebuilt the sender, then let the tick through.
+	var probeMu sync.Mutex
+	healthy := false
+	d.raHasDeadSendersFn = func() bool {
+		probeMu.Lock()
+		defer probeMu.Unlock()
+		return !healthy
+	}
+	probeMu.Lock()
+	healthy = true
+	probeMu.Unlock()
+	d.applySem.Release(1)
+	<-done
+
+	mu.Lock()
+	got := *applies
+	mu.Unlock()
+	if got != 0 {
+		t.Fatalf("the reassert applied RA %d times after the commit it queued "+
+			"behind had already rebuilt the sender, want 0 — re-checking the "+
+			"gate INSIDE the semaphore is what stops a gratuitous RA restart "+
+			"on a healthy interface (#6793)", got)
+	}
+}
+
+// TestDeadSenderReassertLoopTicks6793 binds the loop BODY: the ticker actually
+// drives the reassert, and stops on context cancellation.
+//
+// Separate from the source check below because they fail for different reasons:
+// this reds if the loop is wired to the wrong function or never ticks; the
+// source check reds if Run never starts it.
+func TestDeadSenderReassertLoopTicks6793(t *testing.T) {
+	d, applies, mu := standaloneRADaemon6793(t, true)
+
+	orig := raDeadSenderReassertInterval
+	raDeadSenderReassertInterval = 5 * time.Millisecond
+	t.Cleanup(func() { raDeadSenderReassertInterval = orig })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	loopDone := make(chan struct{})
+	go func() { d.raDeadSenderReassertLoop(ctx); close(loopDone) }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		mu.Lock()
+		got := *applies
+		mu.Unlock()
+		if got > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			<-loopDone
+			t.Fatal("the reassert loop never applied RA for a dead sender — " +
+				"standalone has no other retry owner (#6793)")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	cancel()
+	select {
+	case <-loopDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("raDeadSenderReassertLoop did not return on context cancellation")
+	}
+}
+
+// TestRunStartsTheDeadSenderReassertLoop6793 binds the WIRING.
+//
+// Every cell above stays green if Run never starts the loop — which IS the bug
+// in standalone, where nothing else re-drives Apply. It is a source check
+// because pkg/daemon has no seam that observes Run's goroutine set, and a cell
+// that started Run for real would need the whole daemon bring-up.
+//
+// The start must also be UNCONDITIONAL: the loop is cheap when no sender is
+// dead, and gating it on a config predicate read at start would miss the case
+// where RA is added by a later commit. So this asserts the call is not nested
+// inside the proxy-ARP block's conditional.
+//
+// Comments are stripped before matching: the comment introducing the start
+// names the function, and a gate satisfiable by its own documentation proves
+// nothing.
+func TestRunStartsTheDeadSenderReassertLoop6793(t *testing.T) {
+	src, err := os.ReadFile("daemon_run.go")
+	if err != nil {
+		t.Fatalf("read daemon_run.go: %v", err)
+	}
+	var code strings.Builder
+	for _, line := range strings.Split(string(src), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			code.WriteString("\n")
+			continue
+		}
+		code.WriteString(line)
+		code.WriteString("\n")
+	}
+	body := code.String()
+
+	const start = "d.raDeadSenderReassertLoop(ctx)"
+	at := strings.Index(body, start)
+	if at < 0 {
+		t.Fatal("Run never starts raDeadSenderReassertLoop — in standalone " +
+			"nothing else re-drives ra.Apply, so a sender whose conn open " +
+			"failed stays dead until an operator commits (#6793)")
+	}
+	// One tab of indentation = function body scope, not nested in a conditional
+	// block. Two or more means it was folded into another block's guard.
+	lineStart := strings.LastIndex(body[:at], "\n") + 1
+	indent := 0
+	for _, r := range body[lineStart:at] {
+		if r == '\t' {
+			indent++
+		}
+	}
+	if indent != 2 {
+		t.Fatalf("raDeadSenderReassertLoop is started at indent %d, want 2 (the "+
+			"goroutine body inside an unconditional wg.Add block) — a start "+
+			"nested under another feature's conditional would skip the retry "+
+			"owner on configs that do not use that feature", indent)
+	}
 }

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -119,6 +119,32 @@ after HA failover. To make that **structural**, not flag-defended:
   goroutine's `openConn()` BEFORE its main loop, NOT under `m.mu` (see "Bind
   retry runs unlocked" below). The tombstone (held) still provides mutual
   exclusion for the start.
+- **A dead sender has a retry owner (#6793).** `openConn` runs in the owner
+  goroutine — the bind retry must not hold `m.mu` — so `startLocked` returns
+  SUCCESS and a failed open surfaces only as `sender.dead()` afterwards. `Apply`
+  has known how to rebuild that sender since #2865 (the "rebuilding dead sender
+  (initial conn open failed)" branch), but only when something calls `Apply`
+  again, and until #6793 nothing did:
+  - **standalone** applies RA from `applyServicesReconcile`, which runs only on
+    a config apply, and `reconcileRGStateLoop` is cluster-only — so a boot-time
+    bind failure left the interface advertising nothing until an operator
+    happened to commit, on a node that reported a successful commit;
+  - **cluster** runs `reconcileClusterRAServices` every 2s but DIGEST-GATES it,
+    and a dead sender does not move the desired-set digest — so its own "a
+    transient boot-time bind failure recovers on the next reconcile with NO
+    config change" promise did not hold either.
+
+  `Manager.HasDeadSenders()` is the probe both owners gate on (a map walk over
+  live senders; `dead()` is a non-blocking channel probe, so it is free on the
+  common path). The cluster reconcile bypasses its digest while it is true; the
+  daemon additionally runs an always-on `raDeadSenderReassertLoop`, mirroring
+  `proxyARPReassertLoop` — unconditional, re-reading the active config each tick,
+  and taking `applySem` BEFORE that read for the #4001 reason (a tick that read
+  the config outside the semaphore could re-assert RA on an interface a
+  concurrent commit had just removed it from). The gate is checked again INSIDE
+  the semaphore: a commit that landed while the tick queued may already have
+  rebuilt the sender, and re-applying then would be a gratuitous RA restart.
+
 - **A failed FINAL goodbye is returned AND retained (#6777).** The graceful
   withdrawal path gets exactly two chances to put a lifetime-0 RA on the wire:
   the owner's own emit in `finishShutdown`, and — if that failed, leaving

--- a/pkg/ra/dead_sender_probe_6793_test.go
+++ b/pkg/ra/dead_sender_probe_6793_test.go
@@ -1,0 +1,141 @@
+package ra
+
+import (
+	"errors"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/mdlayher/ndp"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestHasDeadSendersSeesAFailedAsyncOpen6793 is the probe the #6793 retry owner
+// gates on, and it is PAIRED: the same manager, two listen outcomes, opposite
+// answers.
+//
+// A sender's conn open runs ASYNCHRONOUSLY in the owner goroutine (the bind
+// retry must not run under m.mu), so `startLocked` returns success and the
+// failure surfaces only as `dead()` later. That is why nothing noticed: Apply
+// reported success, the interface advertised nothing, and the only state
+// recording it was a per-sender flag no caller read.
+//
+// The success leg is load-bearing. Without it, "HasDeadSenders is true after a
+// failed open" is satisfied by an implementation that returns true always,
+// which would make the always-on reassert loop re-apply RA every 30s forever.
+func TestHasDeadSendersSeesAFailedAsyncOpen6793(t *testing.T) {
+	requireLo(t)
+
+	t.Run("open-fails", func(t *testing.T) {
+		origListen, origEnsure := listenFn, ensureLinkLocalFn
+		t.Cleanup(func() { listenFn, ensureLinkLocalFn = origListen, origEnsure })
+		ensureLinkLocalFn = func(*net.Interface) error { return nil }
+		listenFn = func(*net.Interface, ndp.Addr) (ndpConn, netip.Addr, error) {
+			return nil, netip.Addr{}, errors.New("simulated: no usable link-local yet")
+		}
+
+		m := New()
+		if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+		// The open is async; wait for the sender to settle either way rather
+		// than sleeping a fixed interval.
+		waitFor(t, "the sender to finish its conn open attempt", func() bool {
+			return m.HasDeadSenders()
+		})
+		if got := m.DeadSenderInterfaces(); len(got) != 1 || got[0] != "lo" {
+			t.Fatalf("DeadSenderInterfaces() = %v, want [lo]", got)
+		}
+	})
+
+	t.Run("open-succeeds", func(t *testing.T) {
+		installFakeListen(t)
+
+		m := New()
+		if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+		waitFor(t, "the sender's conn to come up", func() bool {
+			m.mu.Lock()
+			s := m.senders["lo"]
+			m.mu.Unlock()
+			return s != nil && s.waitConnReady(claimWaitTimeout)
+		})
+		if m.HasDeadSenders() {
+			t.Fatal("HasDeadSenders() = true for a sender whose conn opened — " +
+				"the always-on #6793 loop would re-apply RA every tick forever, " +
+				"restarting healthy senders")
+		}
+		if got := m.DeadSenderInterfaces(); len(got) != 0 {
+			t.Fatalf("DeadSenderInterfaces() = %v, want empty", got)
+		}
+	})
+}
+
+// TestApplyRebuildsADeadSenderOnceItCanOpen6793 is the property the retry owner
+// exists to deliver: re-driving Apply with the UNCHANGED desired set must
+// rebuild a dead sender. It is the #2865 branch, asserted end to end — that
+// branch existed before #6793, but nothing in standalone ever called Apply
+// again, so it was unreachable.
+//
+// The mid-test flip from failing to succeeding listen is the point: a rebuild
+// that only worked when the config changed would pass a fixture that changed
+// the config, and that is exactly the bug.
+func TestApplyRebuildsADeadSenderOnceItCanOpen6793(t *testing.T) {
+	requireLo(t)
+
+	origListen, origEnsure := listenFn, ensureLinkLocalFn
+	t.Cleanup(func() { listenFn, ensureLinkLocalFn = origListen, origEnsure })
+	ensureLinkLocalFn = func(*net.Interface) error { return nil }
+
+	fail := true
+	listenFn = func(iface *net.Interface, _ ndp.Addr) (ndpConn, netip.Addr, error) {
+		if fail {
+			return nil, netip.Addr{}, errors.New("simulated: link-local not settled")
+		}
+		return newFakeConn(), netip.MustParseAddr("fe80::1"), nil
+	}
+
+	m := New()
+	cfgs := []*config.RAInterfaceConfig{testCfg("lo")}
+	if err := m.Apply(cfgs); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	waitFor(t, "the first open to fail", func() bool { return m.HasDeadSenders() })
+
+	// The link-local settles. The desired set is BYTE-IDENTICAL — no config
+	// change — which is the whole point.
+	fail = false
+	if err := m.Apply(cfgs); err != nil {
+		t.Fatalf("rebuild Apply: %v", err)
+	}
+	waitFor(t, "the dead sender to be rebuilt", func() bool { return !m.HasDeadSenders() })
+
+	m.mu.Lock()
+	s := m.senders["lo"]
+	m.mu.Unlock()
+	if s == nil {
+		t.Fatal("no sender for lo after the rebuild")
+	}
+	if s.dead() {
+		t.Fatal("the sender is still dead after a re-drive with the same config " +
+			"— the #2865 rebuild did not run, so the retry owner has nothing to " +
+			"drive (#6793)")
+	}
+}
+
+// waitFor polls cond until true or fails. Polling an OBSERVABLE rather than
+// sleeping: the conn open is asynchronous, so a fixed sleep either flakes on a
+// loaded machine or hides a rebuild that never happened.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	for i := 0; i < 500; i++ {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}

--- a/pkg/ra/ra.go
+++ b/pkg/ra/ra.go
@@ -18,6 +18,7 @@ import (
 	"log/slog"
 	"net"
 	"net/netip"
+	"sort"
 	"sync"
 	"time"
 
@@ -156,6 +157,57 @@ type goodbyeDebt struct {
 // log every 2s forever. After this many further attempts the debt is dropped
 // with a single Warn — we tried, we said so, we stop.
 const maxGoodbyeRetries = 3
+
+// HasDeadSenders reports whether any live sender's ASYNCHRONOUS conn open
+// failed, so it will never emit an RA (#2865's dead-sender state, #6793).
+//
+// It exists because a dead sender has no retry owner of its own. `openConn`
+// runs in the owner goroutine with a bounded bind retry (~2s, for a link-local
+// that has not settled yet); when that retry is exhausted the owner exits and
+// the sender stays in `m.senders` marked dead. `Apply`'s changed-config branch
+// knows how to rebuild it — the #2865 "rebuilding dead sender (initial conn
+// open failed)" path — but only when something calls `Apply` again, and nothing
+// does:
+//
+//   - STANDALONE: RA is applied from `applyServicesReconcile`, which runs only
+//     on a config apply. `reconcileRGStateLoop` is cluster-only. So a boot-time
+//     bind failure leaves the interface with NO router advertisements until an
+//     operator happens to commit — hosts on that segment get no default route,
+//     silently, on a node that reports a successful commit.
+//   - CLUSTER: `reconcileClusterRAServices` runs every 2s but is DIGEST-GATED,
+//     and a dead sender does not move the desired-set digest. So its "a
+//     transient boot-time bind failure recovers on the next reconcile with NO
+//     config change" promise did not hold either.
+//
+// Cheap by construction: it is a map walk over live senders and `dead()` is a
+// non-blocking channel probe, so the always-on caller costs nothing on the
+// common path where every sender opened.
+func (m *Manager) HasDeadSenders() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, s := range m.senders {
+		if s.dead() {
+			return true
+		}
+	}
+	return false
+}
+
+// DeadSenderInterfaces returns the interfaces whose sender is dead, sorted, for
+// logging. Separate from HasDeadSenders so the hot always-on probe allocates
+// nothing.
+func (m *Manager) DeadSenderInterfaces() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var names []string
+	for name, s := range m.senders {
+		if s.dead() {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
 
 // New creates a new RA manager.
 func New() *Manager {


### PR DESCRIPTION
Closes #6793

## What was wrong

A sender's conn open runs **asynchronously** in the owner goroutine — the bind
retry sleeps up to ~2s waiting for a link-local to settle and must not hold
`m.mu` — so `startLocked` returns SUCCESS and a failed open surfaces only as
`sender.dead()` afterwards.

`Apply` has known how to rebuild that sender since #2865. But only when
something calls `Apply` again, and **nothing did**:

| mode | driver | why it never fired |
|---|---|---|
| standalone | `applyServicesReconcile` | runs only on a config apply; `reconcileRGStateLoop` is cluster-only |
| cluster | `reconcileClusterRAServices` (2s) | **digest-gated** — a dead sender does not move the desired-set digest |

So a boot-time bind failure left the interface advertising nothing until an
operator happened to commit. Hosts on that segment got no default route,
silently, on a node that had reported a successful commit.

The cluster half is worth calling out separately: `reconcileClusterRAServices`'
own comment promises "a transient boot-time bind failure recovers on the next
reconcile with NO config change". That was false for exactly the failure the
digest cannot see.

## Cites

The issue body is `(see /tmp/opus-review-001.md section R52)` and the fix
direction is `(per the root section — see link)`. That file is gone; everything
here was re-derived from code.

## Shape

- `ra.Manager.HasDeadSenders()` — the probe both owners gate on. A map walk over
  live senders; `dead()` is a non-blocking channel probe, so it is free on the
  common path.
- **cluster**: the digest gate yields while a sender is dead. The rebuild is
  `Apply`'s existing #2865 branch and is a no-op for every healthy sender in the
  same set.
- **standalone**: an always-on `raDeadSenderReassertLoop`, started
  unconditionally alongside `proxyARPReassertLoop` and modelled on it — re-reads
  the active config each tick, and takes `applySem` **before** that read for the
  #4001 reason (a tick reading the config outside the semaphore could capture a
  pre-commit snapshot and re-assert RA on an interface a concurrent commit had
  just removed it from).
- Both owners route through the `raApplyFn` seam rather than calling
  `d.ra.Apply` directly. Two RA appliers in one daemon is the divergence
  `daemon_ra_reconcile.go` exists to prevent — and it is also what makes the
  standalone half observable, since that path otherwise has no assertion point
  short of an interface whose `ndp.Listen` genuinely fails.

## Mutation matrix

Fix committed FIRST. Every cell runs the full `pkg/daemon` + `pkg/ra` suites
with `go test -count=1`, no `-run` filter; each mutation verified applied on a
building, vetting tree. **9 cells, all RED.**

| cell | result | assertion |
|---|---|---|
| M1 cluster digest gate no longer yields to a dead sender | RED | `...BypassesTheDigestForADeadSender6793` |
| **M2 TIGHTEN: cluster digest gate removed entirely** | RED | that cell + the **pre-existing** `TestClusterRAMultiPDPrefixOrderStableNoFlap` |
| **M3 reassert drops its INNER dead-sender re-check** | GREEN → fixed → RED | `...RechecksTheGateInsideTheSemaphore6793` |
| M4 standalone reassert never applies | RED | `...AppliesOnlyWhenASenderIsDead6793` |
| M5 `HasDeadSenders` always false | RED | both `pkg/ra` cells |
| **M6 TIGHTEN: `HasDeadSenders` always true** | RED | both `pkg/ra` cells |
| **M7 reassert loop never started by `Run`** | GREEN → fixed → RED | `...RunStartsTheDeadSenderReassertLoop6793` |

### The two green cells

**M3.** Removing the inner re-check was invisible because the OUTER check still
short-circuited the healthy fixture. The inner one is the correctness gate: a
tick that blocked behind an in-flight commit may find the commit already rebuilt
the sender, and re-applying then is a gratuitous RA restart on a healthy
interface. Now driven by the exact interleave — probe says dead when the tick
starts, a "commit" holds the semaphore, sender is healthy by the time the tick
acquires it.

**M7 is the more important one.** Every cell drove `reassertDeadRASendersOnce`
or the loop body directly, so a `Run` that never launched the retry owner passed
all of them — and that is the entire bug in standalone. Two cells now cover it
and they fail for different reasons: a loop-body cell with a shortened interval
reds if the ticker is wired to the wrong function or never fires, and a source
check reds if `Run` never starts it. The source check also asserts the start is
**unconditional**, by indentation: the loop is cheap when no sender is dead, and
folding it into the neighbouring feature's conditional block would skip the retry
owner on configs that do not use that feature. Comments are stripped before
matching.

**M2 is worth reading too** — removing the digest gate outright reds a
*pre-existing* test (`TestClusterRAMultiPDPrefixOrderStableNoFlap`), which is
the guard that stops this fix from turning the 2s reconcile into a 2s RA
restart loop.

## Test design

`pkg/ra` cells are paired: a failing listen must report dead, a succeeding one
must not — the success leg matters because an "always true" probe would make the
always-on loop restart every healthy sender every 30s, a periodic RA gap on a
working firewall. The rebuild cell re-applies a **byte-identical** desired set,
because a rebuild that only worked when the config changed would pass a fixture
that changed the config, and that is precisely the bug.

Fixtures assert their own premises — a zero-length desired RA set would make
every assertion vacuous, so the harness fails loudly on one. Waits poll an
observable rather than sleeping, since the conn open is asynchronous.

## Gates

`go build ./... && go vet ./... && go test -count=1 ./...` — all rc=0, 67
packages, at head `31771bb6b`, tree clean. Go only; nothing moves the
`userspace-dp` binary or the shim `.o`, so no cargo leg.

It changes RA behaviour on the cluster reconcile path, so it owes
`make test-failover`; queued on the shared cluster and I will post the result.
