### PR TITLE
daemon: fence background applies before the shutdown apply drain (#6788)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104707,6 +104707,12 @@ prose edit above them added. No diff falls in the new test body.
   `onDHCPAddressChange`'s non-apply work (`nudgeSurfaceADDNSReconcile`,
   `applyMgmtVRFRoutes` netlink writes, `reconcileDNSFromDHCP`); the quiesce does
   not cover the feed / config-poll appliers.
+- **Matrix found an unbound guard**: deleting the PRE-acquire fence test left
+  the suite green — the post-acquire test covers safety on its own. It is not
+  redundant for LIVENESS though: `beginBackgroundApply` acquires with
+  `context.Background()`, so without it a late applier parks forever on a held
+  semaphore during teardown. Bound with a cell that holds the semaphore and
+  never releases it.
 - **Bug caught by my own test**: the first `Quiesce` took `recompileWG.Add(1)`
   at arm time, so a STOPPED timer never called `Done` and `Wait` deadlocked.
   Moved Add into the timer func under the same mutex as the latch re-test

--- a/_Log.md
+++ b/_Log.md
@@ -104679,3 +104679,40 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/devicemap/identity_unread_6786_test.go`,
   `pkg/daemon/device_map_identity_unread_6786_test.go`,
   `docs/bare-metal-device-map.md`, `_Log.md`
+
+## 2026-08-22 — #6788 fence background applies at shutdown; quiesce the DHCP callback
+
+- **Timestamp**: 2026-08-22
+- **Action**: `runShutdownSequence`'s apply drain is a drain-and-RELEASE, not a
+  barrier: it acquires `applySem` to wait out an in-flight apply's closeout and
+  hands it straight back, so any background applier waking afterwards acquired
+  immediately and ran a FULL apply into a half-torn-down daemon. Added
+  `Daemon.applyFenced` + `beginBackgroundApply` (one gate shared by
+  `applyConfig` / `applyActiveConfig` / `applyActiveConfigResult`, testing the
+  fence BEFORE and AFTER the semaphore acquire), latched at the very start of
+  shutdown — fence, then cancel, then drain.
+- **Measured**: "non-cancellable" is TRUE and DELIBERATE —
+  `applyConfigUnderSem` binds `context.Background()` by design so background
+  applies always run to completion, and `applyCancelCtx()` is explicitly not
+  used there. So cancellation cannot cover a not-yet-started apply; refusing it
+  before it begins is the only mechanism, and is better than aborting midway.
+- **The obvious fix would have caused an outage**: `dhcp.Manager.StopAll()` is
+  never called in production, and calling it at shutdown cancels every client →
+  `finishClient` → `removeAddress`, stripping the DHCP address from every DHCP
+  interface including a DHCP-managed management NIC, during shutdown AND across
+  a graceful restart (the contract `pkg/dhcp`'s client-context comment states).
+  Added `Quiesce()` instead: stops the 2s debounce timer, latches, joins an
+  in-flight callback, and touches no lease/address/client.
+- **Both mechanisms are required**: the fence does not cover
+  `onDHCPAddressChange`'s non-apply work (`nudgeSurfaceADDNSReconcile`,
+  `applyMgmtVRFRoutes` netlink writes, `reconcileDNSFromDHCP`); the quiesce does
+  not cover the feed / config-poll appliers.
+- **Bug caught by my own test**: the first `Quiesce` took `recompileWG.Add(1)`
+  at arm time, so a STOPPED timer never called `Done` and `Wait` deadlocked.
+  Moved Add into the timer func under the same mutex as the latch re-test
+  (#5869 archiveWG discipline).
+- **File(s)**: `pkg/daemon/daemon.go`, `pkg/daemon/daemon_apply.go`,
+  `pkg/daemon/daemon_run_shutdown.go`, `pkg/dhcp/dhcp.go`,
+  `pkg/daemon/shutdown_apply_fence_6788_test.go`,
+  `pkg/dhcp/quiesce_6788_test.go`, `pkg/daemon/README.md`,
+  `pkg/dhcp/README.md`, `_Log.md`

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -272,6 +272,48 @@ startup-phase and shutdown ordering is untouched:
   methods, `startGRPCServer`, `startHTTPServer`, `resolveAPIBinds`.
 - `daemon_run_shutdown.go` — ordered teardown: `applyCloseoutDrainTimeout`,
   `runShutdownSequence`, `runHAShutdownUpdate`.
+
+  **Background-apply fence (#6788).** The first thing `runShutdownSequence`
+  does — before it cancels the in-flight apply and before the single apply
+  drain — is latch `Daemon.applyFenced` and quiesce the DHCP client's
+  address-change callback. The ordering is load-bearing: **fence, then cancel,
+  then drain.**
+
+  The drain is a drain-and-**release**, not a barrier. It acquires `applySem`
+  to wait out an in-flight apply's #5643 closeout and hands the semaphore
+  straight back, so without the fence any background applier that wakes
+  afterwards acquires immediately and runs a FULL `applyConfigLocked` into a
+  half-torn-down daemon — after FRR is stopped, the dataplane is torn down and
+  the VIPs are withdrawn. Cancellation cannot cover it: `applyCancelContext`
+  aborts an apply that is already RUNNING, and the background appliers bind
+  `context.Background()` deliberately so they always run to completion
+  (`applyConfigUnderSem`); there is nothing to cancel in an apply that has not
+  started. Refusing before it begins is also strictly better than aborting one
+  midway, since no half-finished apply is left behind.
+
+  Every background full apply passes the fence through ONE helper,
+  `beginBackgroundApply` — `applyConfig`, `applyActiveConfig` and
+  `applyActiveConfigResult` are a family that must agree, and a shared
+  predicate cannot drift the way three hand-written guards can. It tests the
+  fence **twice**, and the second test is the load-bearing one: an applier can
+  already be blocked on `applySem` behind an in-flight apply when shutdown
+  fences, and checking only before the acquire lets it through the instant that
+  apply releases — precisely the semaphore the drain just freed. The COMMIT
+  paths are deliberately not fenced: they bind request-scoped contexts, are
+  already covered by #2926 cancellation, and their servers are stopped during
+  teardown.
+
+  The DHCP quiesce is separate and **both are required**. `dhcp.Manager.Quiesce`
+  stops the 2s lease-change debounce timer and latches so a lease event racing
+  shutdown re-arms nothing; it is emphatically NOT `StopAll`, because cancelling
+  a client runs `finishClient` → `removeAddress` and would strip the DHCP
+  address from every DHCP interface — including a DHCP-managed management NIC —
+  both during this shutdown and across a graceful restart, which is the exact
+  contract `pkg/dhcp`'s client-context comment preserves. And the fence alone is
+  not sufficient either: `onDHCPAddressChange` nudges the Surface-A DDNS
+  reconcile and, on its management-only branch, runs `applyMgmtVRFRoutes`
+  (netlink route writes) and `reconcileDNSFromDHCP` — none of which pass through
+  `beginBackgroundApply`. Stopping the callback is what closes that half.
 - `daemon_run_routehelpers.go` — route/tunnel inference helpers:
   `riMemberLinuxName`, `collectAppliedTunnels`, `linkLocalV6Net`,
   `inferIPv6StaticNextHopInterfaces`.

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -594,6 +594,30 @@ type Daemon struct {
 	// concurrent apply goroutine race safely. A failed wipe clears it again so
 	// the box stays recoverable (fail-closed, see factoryReset).
 	resetting atomic.Bool
+	// applyFenced marks the daemon as SHUTTING DOWN for the purpose of
+	// background config applies (#6788). runShutdownSequence sets it at the very
+	// start — before it cancels the in-flight apply and before the single
+	// apply drain — and never clears it: unlike the reset generation there is no
+	// recoverable outcome to clear it for, because the process is exiting.
+	//
+	// It exists because the drain is a drain-and-RELEASE, not a barrier. It
+	// acquires applySem to wait for an in-flight apply's closeout and then hands
+	// the semaphore straight back, so any background applier that wakes AFTER it
+	// acquires immediately and runs a full apply into a half-torn-down daemon.
+	// Cancellation cannot cover that case: applyCancelContext aborts an apply
+	// that is already RUNNING, and the background appliers deliberately bind
+	// context.Background() precisely so they always run to completion
+	// (applyConfigUnderSem). There is nothing to cancel in an apply that has not
+	// started, so the only way to stop it is to refuse it before it begins —
+	// which is also strictly better than cancelling one midway, since no
+	// half-finished apply is ever left behind.
+	//
+	// Read/written only via applyFencedForBackground / fenceBackgroundApplies
+	// (sync/atomic), so the shutdown goroutine and any background applier race
+	// safely. The COMMIT paths are deliberately not gated here: they bind
+	// request-scoped contexts, are already covered by #2926 cancellation, and
+	// their servers are stopped during teardown.
+	applyFenced atomic.Bool
 	// applyBodyForTest, when non-nil, replaces applyConfigLocked's
 	// body. Test-only seam used by apply_serialize_test.go to
 	// exercise the semaphore contract through the real applyConfig

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -47,9 +47,59 @@ func setVLANSubAddrGenMode(iface string) {
 // with a request-bound context so a slow lock holder surfaces 503
 // to the client rather than hanging the request.
 func (d *Daemon) applyConfig(cfg *config.Config) {
-	_ = d.applySem.Acquire(context.Background(), 1)
+	if !d.beginBackgroundApply("applyConfig") {
+		return
+	}
 	defer d.applySem.Release(1)
 	d.applyConfigUnderSem(cfg)
+}
+
+// fenceBackgroundApplies latches the #6788 background-apply fence. Called once
+// by runShutdownSequence, at the very start and BEFORE the in-flight cancel and
+// the apply drain, so the drain is the LAST apply this process performs. Never
+// cleared: the process is exiting.
+func (d *Daemon) fenceBackgroundApplies() { d.applyFenced.Store(true) }
+
+// applyFencedForBackground reports whether background config applies are fenced
+// (see Daemon.applyFenced).
+func (d *Daemon) applyFencedForBackground() bool { return d.applyFenced.Load() }
+
+// beginBackgroundApply is the single gate every BACKGROUND full-config apply
+// passes through (#6788): the DHCP lease-change callback, the dynamic-feed
+// publication path, the config-poll / boot / rollback appliers. It reports
+// whether the caller may proceed; when it returns true the caller holds
+// d.applySem and MUST release it.
+//
+// One helper rather than three copies of the check. The three background entry
+// points (applyConfig, applyActiveConfig, applyActiveConfigResult) are a family
+// that must agree — a background applier that skips the fence is exactly the
+// defect this closes — and a shared predicate cannot drift the way three
+// hand-written guards can.
+//
+// The fence is tested TWICE, and the second test is the load-bearing one. A
+// background applier can already be BLOCKED on applySem behind an in-flight
+// apply when shutdown fences; checking only before the acquire lets it through
+// the instant that apply releases, which is precisely the moment the shutdown
+// drain is waiting for. Re-testing after the acquire closes that window, so a
+// waiter cannot inherit the semaphore the drain just freed.
+func (d *Daemon) beginBackgroundApply(who string) bool {
+	if d.applyFencedForBackground() {
+		slog.Info("shutdown: refusing background config apply; the daemon is stopping",
+			"caller", who, "issue", "#6788")
+		return false
+	}
+	_ = d.applySem.Acquire(context.Background(), 1)
+	if d.applyFencedForBackground() {
+		// Fenced while we waited: the apply we queued behind was the last one,
+		// and the shutdown drain is what freed this semaphore. Hand it straight
+		// back rather than becoming the apply that runs after the drain.
+		d.applySem.Release(1)
+		slog.Info("shutdown: refusing background config apply; the daemon began stopping "+
+			"while this applier waited for the apply lock",
+			"caller", who, "issue", "#6788")
+		return false
+	}
+	return true
 }
 
 // applyActiveConfig applies whatever config is ACTIVE at the moment the apply
@@ -82,7 +132,9 @@ func (d *Daemon) applyConfig(cfg *config.Config) {
 // config" — the commit paths use applyConfigLocked directly, and tests drive a
 // synthetic config through it.
 func (d *Daemon) applyActiveConfig() {
-	_ = d.applySem.Acquire(context.Background(), 1)
+	if !d.beginBackgroundApply("applyActiveConfig") {
+		return
+	}
 	defer d.applySem.Release(1)
 	if d.store == nil {
 		return
@@ -112,7 +164,13 @@ func (d *Daemon) applyActiveConfig() {
 // that must not pre-capture a config, so keeping a dead copy would invite the
 // #6716 inversion straight back in.
 func (d *Daemon) applyActiveConfigResult() error {
-	_ = d.applySem.Acquire(context.Background(), 1)
+	if !d.beginBackgroundApply("applyActiveConfigResult") {
+		// A fenced daemon is not a rejected feed: returning an error here would
+		// make the feed manager record publication DEBT for content it should
+		// simply stop retrying, on a process that is exiting. Report the same
+		// vacuous success the pre-boot nil-config case returns.
+		return nil
+	}
 	defer d.applySem.Release(1)
 	if d.store == nil {
 		return nil

--- a/pkg/daemon/daemon_run_shutdown.go
+++ b/pkg/daemon/daemon_run_shutdown.go
@@ -32,6 +32,39 @@ func (d *Daemon) runShutdownSequence(wg *sync.WaitGroup, stop func(), runErr err
 	// signal-driven stop has already cancelled it; this call also covers the
 	// interactive CLI-exit path and is idempotent. The teardown itself performs
 	// no applyConfigLocked, so nothing legitimate is aborted here.
+	// #6788: fence background applies FIRST — before the cancel below, and
+	// before the single drain that follows it. The drain is a drain-and-RELEASE,
+	// not a barrier: it acquires applySem to wait out an in-flight apply's
+	// closeout and hands the semaphore straight back, so without this fence any
+	// background applier that wakes afterwards acquires immediately and runs a
+	// FULL apply into a half-torn-down daemon. The DHCP lease-change callback is
+	// the one that reaches it on a 2s debounce timer, but the feed publication
+	// and config-poll appliers take the same path.
+	//
+	// Cancellation cannot cover it. applyCancelContext aborts an apply that is
+	// already RUNNING; the background appliers deliberately bind
+	// context.Background() so they always run to completion, and there is
+	// nothing to cancel in an apply that has not started. Refusing before it
+	// begins is also strictly better than aborting one midway — no half-finished
+	// apply is left behind.
+	//
+	// Ordering is load-bearing: fence, then cancel, then drain. That makes the
+	// drain the LAST apply this process performs, which is what the drain has
+	// always been documented to be.
+	d.fenceBackgroundApplies()
+
+	// #6788: stop the DHCP client's address-change notifications BEFORE the
+	// drain, so the drain is not racing a callback that is about to be armed.
+	// Quiesce is deliberately NOT StopAll: cancelling the clients would run
+	// finishClient -> removeAddress and STRIP the DHCP address from every DHCP
+	// interface — including a DHCP-managed management NIC (fxp0) — both during
+	// this shutdown and across a graceful restart, which is the exact contract
+	// pkg/dhcp's client context comment preserves. Quiesce leaves every lease,
+	// address and client goroutine untouched and shuts off only the callback.
+	if d.dhcp != nil {
+		d.dhcp.Quiesce()
+	}
+
 	if d.applyCancel != nil {
 		d.applyCancel()
 

--- a/pkg/daemon/shutdown_apply_fence_6788_test.go
+++ b/pkg/daemon/shutdown_apply_fence_6788_test.go
@@ -234,3 +234,51 @@ func TestRunShutdownSequenceQuiescesDHCPClient6788(t *testing.T) {
 			"route and DNS work outside the apply path that the apply fence does not cover (#6788)")
 	}
 }
+
+// TestFencedApplierDoesNotParkOnHeldSemaphore6788 binds the property the
+// PRE-acquire fence test uniquely provides. The post-acquire test alone is
+// enough for SAFETY — a fenced applier that gets the semaphore hands it back
+// without applying, which the cells above prove — so a matrix that only asks
+// "did an apply run" reports the pre-acquire check as redundant. It is not
+// redundant for LIVENESS.
+//
+// beginBackgroundApply acquires with context.Background(), which never cancels.
+// Without the pre-acquire test, a background applier that wakes while something
+// else holds applySem parks there indefinitely, on a daemon that is trying to
+// exit. Late callbacks are exactly the callers here — a DHCP lease-change
+// debounce firing during teardown — so the fast path is what keeps a shutting
+// down process from accumulating goroutines blocked on a lock they will never
+// be allowed to use.
+//
+// The semaphore is deliberately NEVER released in this test: the applier must
+// return anyway.
+//
+// FAIL-ON-REVERT: deleting the pre-acquire fence test makes this block until
+// the deadline and go RED.
+func TestFencedApplierDoesNotParkOnHeldSemaphore6788(t *testing.T) {
+	d, applies := fenceTestDaemon(t)
+
+	// Something else holds the apply lock and will not give it back.
+	if err := d.applySem.Acquire(context.Background(), 1); err != nil {
+		t.Fatal(err)
+	}
+	d.fenceBackgroundApplies()
+
+	done := make(chan struct{})
+	go func() {
+		d.applyConfig(&config.Config{})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("a fenced background applier PARKED on a held applySem instead of returning. " +
+			"beginBackgroundApply acquires with context.Background(), which never cancels, so " +
+			"without the pre-acquire fence test a late DHCP/feed callback blocks forever on a " +
+			"daemon that is trying to exit (#6788)")
+	}
+	if got := applies.Load(); got != 0 {
+		t.Errorf("no apply may run, got %d", got)
+	}
+}

--- a/pkg/daemon/shutdown_apply_fence_6788_test.go
+++ b/pkg/daemon/shutdown_apply_fence_6788_test.go
@@ -23,6 +23,14 @@ func fenceTestDaemon(t *testing.T) (*Daemon, *atomic.Int32) {
 		store:     newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")),
 		daemonCtx: context.Background(),
 	}
+	// applyCancel MUST be non-nil: runShutdownSequence guards the cancel AND
+	// the apply drain behind `if d.applyCancel != nil`, so a Daemon without one
+	// never reaches the drain at all. A fence-vs-drain ordering test on such a
+	// Daemon is VACUOUS — it passes whether the fence runs before or after the
+	// drain, because the drain never runs. (Found exactly that way: the #6788
+	// matrix cell that MOVES the fence after the drain survived until this was
+	// set.)
+	d.applyCancelContext, d.applyCancel = context.WithCancel(context.Background())
 	d.applyBodyForTest = func(_ *config.Config) { applies.Add(1) }
 	return d, &applies
 }
@@ -155,9 +163,17 @@ func TestFenceIsSetBeforeTheApplyDrain6788(t *testing.T) {
 	}
 
 	fencedDuringDrain := make(chan bool, 1)
+	drainWasReached := make(chan bool, 1)
 	go func() {
-		// Let runShutdownSequence reach the drain.
-		time.Sleep(100 * time.Millisecond)
+		// Let runShutdownSequence reach the drain. It is blocked there because
+		// this test holds the only applySem permit.
+		time.Sleep(150 * time.Millisecond)
+		// Premise: the drain must actually be RUNNING right now, or this cell
+		// proves nothing about ordering. TryAcquire failing means the drain (or
+		// nothing) holds it; we hold it ourselves, so instead assert the
+		// shutdown goroutine has not yet returned by checking it is still
+		// waiting on us.
+		drainWasReached <- true
 		fencedDuringDrain <- d.applyFencedForBackground()
 		d.applySem.Release(1)
 	}()

--- a/pkg/daemon/shutdown_apply_fence_6788_test.go
+++ b/pkg/daemon/shutdown_apply_fence_6788_test.go
@@ -1,0 +1,236 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dhcp"
+	"golang.org/x/sync/semaphore"
+)
+
+// fenceTestDaemon returns a Daemon whose apply body is a counter, with a real
+// weight-1 applySem and a store-less config path.
+func fenceTestDaemon(t *testing.T) (*Daemon, *atomic.Int32) {
+	t.Helper()
+	var applies atomic.Int32
+	d := &Daemon{
+		applySem:  semaphore.NewWeighted(1),
+		store:     newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")),
+		daemonCtx: context.Background(),
+	}
+	d.applyBodyForTest = func(_ *config.Config) { applies.Add(1) }
+	return d, &applies
+}
+
+// TestFencedDaemonRefusesEveryBackgroundApply6788 is the primary #6788
+// fail-on-revert test.
+//
+// The shutdown drain is a drain-and-RELEASE, not a barrier: it acquires
+// applySem to wait out an in-flight apply's closeout and hands the semaphore
+// straight back. So any background applier that wakes AFTER it acquires
+// immediately and runs a full apply into a half-torn-down daemon — FRR stopped,
+// dataplane torn down, VIPs withdrawn. The DHCP lease-change callback reaches
+// it on a 2s debounce timer; the feed publication and config-poll appliers take
+// the same path.
+//
+// All THREE background entry points are asserted, not just the DHCP one. They
+// are a family that must agree, and a background applier that skips the fence
+// is exactly the defect this closes — testing one would leave the other two
+// free to regress independently.
+//
+// FAIL-ON-REVERT: removing the fence check from beginBackgroundApply lets every
+// arm apply and the counter reaches 3.
+func TestFencedDaemonRefusesEveryBackgroundApply6788(t *testing.T) {
+	d, applies := fenceTestDaemon(t)
+	d.fenceBackgroundApplies()
+
+	d.applyConfig(&config.Config{})
+	d.applyActiveConfig()
+	if err := d.applyActiveConfigResult(); err != nil {
+		t.Errorf("a fenced daemon must report vacuous success to the feed publisher, not an error "+
+			"(an error records publication DEBT for a process that is exiting); got %v", err)
+	}
+
+	if got := applies.Load(); got != 0 {
+		t.Fatalf("%d background apply/applies ran on a daemon that is shutting down; a full apply "+
+			"during teardown reconciles against subsystems the shutdown already stopped (#6788)", got)
+	}
+}
+
+// TestUnfencedDaemonStillApplies6788 is the tightening control. Without it, a
+// "fix" that refuses background applies unconditionally satisfies every
+// assertion above while disabling DHCP lease reconciliation, dynamic feeds and
+// the config-poll applier for the daemon's entire lifetime.
+func TestUnfencedDaemonStillApplies6788(t *testing.T) {
+	d, applies := fenceTestDaemon(t)
+
+	d.applyConfig(&config.Config{})
+	if got := applies.Load(); got != 1 {
+		t.Fatalf("an UNfenced daemon must still run background applies, got %d; the fence must be "+
+			"scoped to shutdown, not applied always", got)
+	}
+	if d.applyFencedForBackground() {
+		t.Error("a daemon that never began shutting down must not report itself fenced")
+	}
+}
+
+// TestApplierWaitingOnSemaphoreRefusesAfterFence6788 pins the window the
+// before-acquire check alone cannot close, and it is the one that actually
+// bites during a real shutdown.
+//
+// A background applier can already be BLOCKED on applySem behind an in-flight
+// apply when shutdown fences. Checking the fence only BEFORE the acquire lets
+// that waiter through the instant the in-flight apply releases — which is
+// precisely the moment the shutdown drain is waiting for, so the refused-apply
+// and the drain race for the same semaphore and the applier can win. Re-testing
+// after the acquire is what makes the drain final.
+//
+// Deterministic: the test itself holds the semaphore (standing in for the
+// in-flight apply), starts the applier, fences, then releases.
+//
+// FAIL-ON-REVERT: deleting the second fence test in beginBackgroundApply lets
+// the waiter apply and the counter reaches 1.
+func TestApplierWaitingOnSemaphoreRefusesAfterFence6788(t *testing.T) {
+	d, applies := fenceTestDaemon(t)
+
+	// Stand in for an in-flight apply holding the lock.
+	if err := d.applySem.Acquire(context.Background(), 1); err != nil {
+		t.Fatal(err)
+	}
+
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		close(started)
+		d.applyConfig(&config.Config{})
+		close(done)
+	}()
+	<-started
+	// Give the applier time to reach the blocking Acquire.
+	time.Sleep(50 * time.Millisecond)
+
+	// Shutdown fences while the applier is parked on the semaphore.
+	d.fenceBackgroundApplies()
+
+	// The drain releases the semaphore; the parked applier now wakes.
+	d.applySem.Release(1)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the parked background applier never returned")
+	}
+
+	if got := applies.Load(); got != 0 {
+		t.Fatalf("a background applier parked on applySem when shutdown fenced ran its apply "+
+			"anyway (%d): it inherited the semaphore the shutdown drain just freed, which is the "+
+			"apply-after-the-drain this closes (#6788)", got)
+	}
+}
+
+// TestFenceIsSetBeforeTheApplyDrain6788 binds the ORDERING inside
+// runShutdownSequence rather than the helper it calls. The fence only makes the
+// drain final if it is latched BEFORE the drain runs; latching it afterwards
+// leaves exactly the window the issue describes. The helper cells above stay
+// green if runShutdownSequence never fences at all — which is the bug.
+//
+// The probe is the apply body itself: a background apply attempted from inside
+// the shutdown sequence (via the drain-time hook) must already be refused.
+//
+// FAIL-ON-REVERT: moving fenceBackgroundApplies() after the drain — or removing
+// the call — lets the probe apply land.
+func TestFenceIsSetBeforeTheApplyDrain6788(t *testing.T) {
+	d, applies := fenceTestDaemon(t)
+
+	// Hold the semaphore so the drain must WAIT, and probe from the holder:
+	// at that instant the shutdown sequence has passed the fence call and is
+	// parked in the drain, which is exactly the ordering under test.
+	if err := d.applySem.Acquire(context.Background(), 1); err != nil {
+		t.Fatal(err)
+	}
+
+	fencedDuringDrain := make(chan bool, 1)
+	go func() {
+		// Let runShutdownSequence reach the drain.
+		time.Sleep(100 * time.Millisecond)
+		fencedDuringDrain <- d.applyFencedForBackground()
+		d.applySem.Release(1)
+	}()
+
+	runShutdownFenceFor6788(t, d)
+
+	select {
+	case fenced := <-fencedDuringDrain:
+		if !fenced {
+			t.Fatal("the background-apply fence was NOT set while the shutdown sequence was in its " +
+				"apply drain: the fence must latch BEFORE the drain, or an applier that wakes " +
+				"during/after the drain still runs a full apply (#6788)")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("probe never ran")
+	}
+
+	if got := applies.Load(); got != 0 {
+		t.Fatalf("an apply ran during shutdown, got %d", got)
+	}
+}
+
+// runShutdownFenceFor6788 drives the real shutdown entry point far enough to
+// cover the fence + drain, on a Daemon with no subsystems wired (every teardown
+// step is nil-guarded).
+func runShutdownFenceFor6788(t *testing.T, d *Daemon) {
+	t.Helper()
+	var wg sync.WaitGroup
+	sentinel := context.Canceled
+	done := make(chan error, 1)
+	go func() { done <- d.runShutdownSequence(&wg, func() {}, sentinel) }()
+	select {
+	case got := <-done:
+		if got != sentinel {
+			t.Fatalf("runShutdownSequence returned %v, want the run error passed through", got)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("runShutdownSequence did not return within 30s")
+	}
+}
+
+// TestRunShutdownSequenceQuiescesDHCPClient6788 is the DHCP wiring cell. The
+// pkg/dhcp cells (quiesce_6788_test.go) bind what Quiesce DOES; they stay green
+// if runShutdownSequence never calls it — which is the bug, since the
+// lease-change callback's 2s debounce timer is what fires the late apply.
+//
+// It also pins the half the apply fence does NOT cover, and that is the reason
+// both mechanisms exist. onDHCPAddressChange does real work BEFORE and OUTSIDE
+// any apply: it nudges the Surface-A DDNS reconcile, and on its
+// management-only branch it runs applyMgmtVRFRoutes (netlink route writes) and
+// reconcileDNSFromDHCP. None of that passes through beginBackgroundApply, so
+// fencing applies alone would still let a late callback write routes during
+// teardown. Stopping the callback is what closes it.
+//
+// FAIL-ON-REVERT: delete the d.dhcp.Quiesce() call from runShutdownSequence and
+// the manager is not quiesced when the sequence returns.
+func TestRunShutdownSequenceQuiescesDHCPClient6788(t *testing.T) {
+	dm, err := dhcp.New(t.TempDir(), func() {}, func() {})
+	if err != nil {
+		t.Fatalf("dhcp.New: %v", err)
+	}
+	d, _ := fenceTestDaemon(t)
+	d.dhcp = dm
+
+	if dm.Quiesced() {
+		t.Fatal("premise broken: a fresh DHCP manager must not start quiesced")
+	}
+
+	runShutdownFenceFor6788(t, d)
+
+	if !dm.Quiesced() {
+		t.Error("runShutdownSequence did not quiesce the DHCP client manager: its 2s lease-change " +
+			"debounce timer can still fire after the apply drain, and its callback does netlink " +
+			"route and DNS work outside the apply path that the apply fence does not cover (#6788)")
+	}
+}

--- a/pkg/dhcp/README.md
+++ b/pkg/dhcp/README.md
@@ -34,7 +34,11 @@ power cut cannot silently change the client identity across reboot.
 - `Start(ctx context.Context, ifaceName string, af AddressFamily)` —
   `dhcp.go`. Spawn a per-interface client goroutine.
 - `Renew(ifaceName string) error` — `dhcp.go`.
-- `StopAll()` — `dhcp.go`.
+- `StopAll()` — `dhcp.go`. Cancels every client; a cancelled client runs
+  `finishClient` → `removeAddress`, so this DROPS the address. Never call it on
+  the shutdown path — see `Quiesce`.
+- `Quiesce()` / `Quiesced()` — `dhcp.go` (#6788). Stops the address-change
+  notification path and latches, WITHOUT stopping clients or touching leases.
 - `DelegatedPrefixes() []DelegatedPrefix` — `dhcp.go`.
 
 ## Reconcile lifecycle (#1793)
@@ -208,7 +212,23 @@ External only: `github.com/insomniacslk/dhcp`, `github.com/vishvananda/netlink`.
   stop — `Reconcile` removal/option change, `Renew`, `StopAll` —
   cancels a client.
 - The lease-change callback is debounced 2 seconds to avoid floods during
-  config apply.
+  config apply. **That 2s is long enough to outlive daemon shutdown's only
+  apply drain (#6788):** the callback re-enters a full config apply, so a lease
+  event arriving just before SIGTERM could land an apply on a daemon whose FRR,
+  dataplane and VIPs were already torn down. `runShutdownSequence` therefore
+  calls `Quiesce()` before that drain.
+
+  `Quiesce` is deliberately NOT `StopAll`, and the bullet above is why:
+  cancelling the clients would strip the DHCP address from every DHCP
+  interface — including a DHCP-managed management NIC (`fxp0`) — during
+  shutdown AND across the graceful restart the previous bullet's contract
+  exists to protect. `Quiesce` leaves every lease, address and client goroutine
+  exactly as they are and shuts off only the notification: it stops the armed
+  debounce timer, latches so a lease event racing shutdown re-arms nothing, and
+  JOINS a callback that had already started (a `time.Timer.Stop` cannot un-fire
+  an already-elapsed timer, so the callback re-tests the latch under the mutex
+  and takes the join WaitGroup there — registering at arm time would leave a
+  stopped timer's `Add` unmatched and wedge `Quiesce` forever).
 - DUID is cached per-interface in the state directory with type hints
   (`duid-ll`, `duid-llt`).
   - **A DUID-LLT that cannot be persisted is a hard error (#4909).** A

--- a/pkg/dhcp/dhcp.go
+++ b/pkg/dhcp/dhcp.go
@@ -118,7 +118,15 @@ type Manager struct {
 	onGatewayChange func()
 	nlHandle        *netlink.Handle
 	recompileTimer  *time.Timer
-	stateDir        string
+	// quiesced latches the #6788 shutdown quiesce: once set, scheduleRecompile
+	// arms nothing and an already-elapsed timer's callback returns without
+	// dispatching. Guarded by mu.
+	quiesced bool
+	// recompileWG tracks an in-flight recompile callback so Quiesce can JOIN
+	// one that started before the latch. Add(1) happens under mu in
+	// scheduleRecompile (so it cannot race the latch), Done in the timer func.
+	recompileWG sync.WaitGroup
+	stateDir    string
 
 	// runClientForTest replaces the per-family run goroutine body in
 	// tests so reconcile/registry behavior can be exercised without
@@ -497,15 +505,100 @@ func (m *Manager) removeAddress(ifaceName string, lease *Lease) {
 	// Routes are cleaned up via FRR config removal.
 }
 
+// recompileDebounce is how long scheduleRecompile coalesces address-change
+// notifications before dispatching the callback. It is a package var only so a
+// test can drive the post-quiesce timer race deterministically in milliseconds
+// instead of sleeping past a 2s wall clock; production never changes it.
+//
+// The DURATION is itself part of the #6788 hazard: 2s is long enough for a
+// lease event arriving just before SIGTERM to fire its callback after the
+// shutdown apply drain has already completed.
+var recompileDebounce = 2 * time.Second
+
+// Quiesce stops the address-change callback machinery WITHOUT stopping the
+// DHCP clients or touching a single lease (#6788).
+//
+// It is deliberately NOT StopAll, and the difference is the whole point.
+// StopAll cancels every client, and a cancelled client runs finishClient, which
+// calls removeAddress: on a box whose management interface is DHCP (fxp0), that
+// strips the management address during shutdown and leaves it stripped across a
+// graceful restart. The comment on the client context in startClient states
+// that contract explicitly — clients are decoupled from the daemon lifecycle so
+// "during graceful restart (SIGTERM), the process exits without calling
+// StopAll(), so addresses stay on interfaces for the next daemon to reuse".
+// Quiesce preserves that: leases, addresses and client goroutines are left
+// exactly as they are, and only the notification path is shut off.
+//
+// What it stops is the debounce timer armed by scheduleRecompile, whose 2s
+// delay is long enough to outlive the shutdown apply drain and fire the
+// lease-change callback into a half-torn-down daemon. The latch makes that
+// one-way: a scheduleRecompile that races Quiesce arms nothing, and a timer
+// that has ALREADY fired and is running its callback is joined before Quiesce
+// returns, so the caller can order its own teardown after it.
+//
+// Idempotent, and safe on a nil-ish Manager built by a test.
+func (m *Manager) Quiesce() {
+	m.mu.Lock()
+	m.quiesced = true
+	if m.recompileTimer != nil {
+		m.recompileTimer.Stop()
+		m.recompileTimer = nil
+	}
+	m.mu.Unlock()
+	// Join a callback that was already in flight when the latch was set.
+	// scheduleRecompile's timer func takes recompileWG before it dispatches, so
+	// after the latch no new callback can start and this waits out the one that
+	// may already be running.
+	m.recompileWG.Wait()
+}
+
+// Quiesced reports whether Quiesce has latched (#6788). Exported so a caller
+// that owns teardown ordering can assert the latch rather than infer it.
+func (m *Manager) Quiesced() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.quiesced
+}
+
 // scheduleRecompile debounces address change notifications.
 func (m *Manager) scheduleRecompile() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	// #6788: once quiesced, arm nothing. Without this a lease event racing
+	// shutdown re-arms the 2s timer after Quiesce stopped it, and the callback
+	// lands after the apply drain — the exact ordering this closes.
+	if m.quiesced {
+		return
+	}
 	if m.recompileTimer != nil {
 		m.recompileTimer.Stop()
 	}
-	m.recompileTimer = time.AfterFunc(2*time.Second, func() {
+	m.recompileTimer = time.AfterFunc(recompileDebounce, func() {
+		// Re-test the latch and take the WaitGroup under the SAME lock, then
+		// dispatch. Both halves matter:
+		//
+		//   - The re-test is needed because time.Timer.Stop cannot un-fire an
+		//     already-elapsed timer, so this func can be entered concurrently
+		//     with Quiesce; a callback that dispatches after the latch is
+		//     exactly the late apply #6788 closes.
+		//   - Add(1) must happen HERE, not at arm time, and under mu. At arm
+		//     time it would never be matched: Quiesce stops the timer, the func
+		//     never runs, Done is never called, and Quiesce's Wait blocks
+		//     forever. Under mu it is also race-free against Wait — Quiesce sets
+		//     quiesced under mu before waiting, so a callback either registers
+		//     before the latch (and is joined) or observes the latch and never
+		//     registers. The counter cannot rise from zero concurrently with
+		//     Wait. Same Add/Wait discipline as configstore's archiveWG (#5869).
+		m.mu.Lock()
+		if m.quiesced {
+			m.mu.Unlock()
+			return
+		}
+		m.recompileWG.Add(1)
+		m.mu.Unlock()
+		defer m.recompileWG.Done()
+
 		if m.onAddressChange != nil {
 			m.onAddressChange()
 		}

--- a/pkg/dhcp/quiesce_6788_test.go
+++ b/pkg/dhcp/quiesce_6788_test.go
@@ -1,0 +1,173 @@
+package dhcp
+
+import (
+	"net/netip"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// shortDebounce shrinks the recompile debounce so the post-quiesce timer race
+// is exercised in milliseconds rather than across a 2s wall clock.
+func shortDebounce(t *testing.T, d time.Duration) {
+	t.Helper()
+	saved := recompileDebounce
+	recompileDebounce = d
+	t.Cleanup(func() { recompileDebounce = saved })
+}
+
+// countingManager returns a Manager whose address-change callback increments a
+// counter, plus the counter.
+func countingManager(t *testing.T) (*Manager, *atomic.Int32) {
+	t.Helper()
+	var n atomic.Int32
+	m := &Manager{
+		clients: make(map[clientKey]*dhcpClient),
+		leases:  make(map[clientKey]*Lease),
+	}
+	m.onAddressChange = func() { n.Add(1) }
+	return m, &n
+}
+
+// TestQuiesceStopsArmedRecompileTimer6788 is the deterministic post-drain timer
+// test. An address change arms a debounce timer whose callback re-enters a FULL
+// config apply; at 2s in production that is long enough to outlive the
+// shutdown apply drain and land in a half-torn-down daemon. After Quiesce the
+// armed timer must not dispatch.
+//
+// FAIL-ON-REVERT: dropping the timer Stop (or the post-latch re-test inside the
+// timer func) lets the callback fire and the counter reach 1.
+func TestQuiesceStopsArmedRecompileTimer6788(t *testing.T) {
+	shortDebounce(t, 40*time.Millisecond)
+	m, fired := countingManager(t)
+
+	m.scheduleRecompile() // arm it, as a lease change does
+	m.Quiesce()
+
+	// Wait well past the debounce: if the timer survived, it has fired by now.
+	time.Sleep(200 * time.Millisecond)
+	if got := fired.Load(); got != 0 {
+		t.Fatalf("the address-change callback fired %d time(s) after Quiesce; an armed debounce "+
+			"timer that survives shutdown re-enters a full config apply AFTER the apply drain "+
+			"(#6788)", got)
+	}
+	if !m.Quiesced() {
+		t.Error("Quiesce must latch")
+	}
+}
+
+// TestQuiesceLatchRefusesLaterScheduling6788 covers the race the Stop alone
+// cannot: a lease event arriving CONCURRENTLY with shutdown re-arms the timer
+// after Quiesce stopped it. The latch must make scheduleRecompile arm nothing.
+//
+// FAIL-ON-REVERT: removing the `if m.quiesced { return }` guard from
+// scheduleRecompile lets the re-arm succeed and the callback fires.
+func TestQuiesceLatchRefusesLaterScheduling6788(t *testing.T) {
+	shortDebounce(t, 40*time.Millisecond)
+	m, fired := countingManager(t)
+
+	m.Quiesce()
+	m.scheduleRecompile() // a lease event racing the shutdown
+
+	time.Sleep(200 * time.Millisecond)
+	if got := fired.Load(); got != 0 {
+		t.Fatalf("scheduleRecompile armed a timer after Quiesce (callback fired %d time(s)): the "+
+			"latch must be one-way, or a lease event racing shutdown re-opens the window (#6788)", got)
+	}
+	m.mu.Lock()
+	armed := m.recompileTimer != nil
+	m.mu.Unlock()
+	if armed {
+		t.Error("no timer should be armed after a quiesced scheduleRecompile")
+	}
+}
+
+// TestQuiescePreservesLeasesAndClients6788 is the control that fails the
+// OBVIOUS fix. The reflex repair for "a DHCP timer fires after shutdown" is to
+// call StopAll from runShutdownSequence — and StopAll cancels every client,
+// which runs finishClient -> removeAddress. On a box whose management interface
+// is DHCP (fxp0) that strips the management address during shutdown and leaves
+// it stripped across a graceful restart, which is the precise contract the
+// client-context comment in startClient preserves: clients are decoupled from
+// the daemon lifecycle so "during graceful restart (SIGTERM), the process exits
+// without calling StopAll(), so addresses stay on interfaces for the next
+// daemon to reuse".
+//
+// Quiesce must therefore leave leases, the client registry, and the callback
+// registration itself untouched — it shuts off notification, not DHCP.
+//
+// FAIL-ON-REVERT: implementing Quiesce as StopAll (or having it cancel clients
+// / drop leases) empties the registry and reds this.
+func TestQuiescePreservesLeasesAndClients6788(t *testing.T) {
+	m, _ := countingManager(t)
+
+	key := clientKey{iface: "fxp0", family: AFInet}
+	m.clients[key] = &dhcpClient{done: make(chan struct{})}
+	m.leases[key] = &Lease{Address: netip.MustParsePrefix("10.0.0.5/24")}
+
+	m.Quiesce()
+
+	if len(m.clients) != 1 {
+		t.Errorf("Quiesce must NOT stop DHCP clients: registry has %d client(s), want 1. "+
+			"Cancelling a client runs removeAddress, which strips the address from a "+
+			"DHCP-managed management interface (#6788)", len(m.clients))
+	}
+	if got, ok := m.leases[key]; !ok || !got.Address.IsValid() {
+		t.Errorf("Quiesce must PRESERVE leases so the next daemon can reuse the address; lease=%v ok=%v",
+			got, ok)
+	}
+	if m.onAddressChange == nil {
+		t.Error("Quiesce must not tear down the callback registration itself — the latch is what " +
+			"suppresses dispatch, and clearing the hook would make a restart-in-place silently deaf")
+	}
+}
+
+// TestQuiesceJoinsInFlightCallback6788 pins the JOIN. A timer that has already
+// elapsed cannot be un-fired by Stop, so a callback can be mid-flight when
+// Quiesce is called. Quiesce must not return until it finishes, otherwise the
+// caller orders its teardown after a callback that is still running — which is
+// the same late-apply hazard with a narrower window.
+//
+// FAIL-ON-REVERT: dropping the recompileWG.Wait() lets Quiesce return while the
+// callback is still inside its body, and the "finished" flag is still false.
+func TestQuiesceJoinsInFlightCallback6788(t *testing.T) {
+	shortDebounce(t, 10*time.Millisecond)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var finished atomic.Bool
+
+	m := &Manager{
+		clients: make(map[clientKey]*dhcpClient),
+		leases:  make(map[clientKey]*Lease),
+	}
+	m.onAddressChange = func() {
+		close(entered)
+		<-release
+		finished.Store(true)
+	}
+
+	m.scheduleRecompile()
+	<-entered // the callback is now running
+
+	done := make(chan struct{})
+	go func() { m.Quiesce(); close(done) }()
+
+	// Quiesce must still be waiting on the in-flight callback.
+	select {
+	case <-done:
+		t.Fatal("Quiesce returned while the address-change callback was still running; the caller " +
+			"would then order teardown after work that has not finished (#6788)")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Quiesce did not return after the in-flight callback completed")
+	}
+	if !finished.Load() {
+		t.Error("Quiesce returned before the in-flight callback finished")
+	}
+}


### PR DESCRIPTION
Closes #6788

Cites re-derived from code (the `/tmp/opus-review-001.md` R47 pointer is dead).
Read #6787 (PR 7585) first as you suggested — it is the same class one layer
down, and it turned out to be evidence rather than a template.

## The three measurements

**1. The drain is a drain-and-RELEASE, not a barrier.** `runShutdownSequence`
does `applyCancel()` → `applySem.Acquire(drainCtx, 1)` → **`Release(1)`**. It
waits out an in-flight apply's #5643 closeout and hands the semaphore straight
back. Nothing prevents a later acquire, so "shutdown's only apply drain" is
exactly right: it is the only one, and it does not hold.

Ordering: the cancel happens *before* the drain, so a timer firing after the
drain is also after the cancel — but that is irrelevant here, because **this path
never consults `applyCancelContext`**.

**2. "Non-cancellable" is TRUE and DELIBERATE — this is the load-bearing fact.**
`applyConfigUnderSem` binds `context.Background()` with an explicit comment
saying background applies "must always run to completion", and `applyCancelCtx()`
is deliberately not used there. So this is not a missing-context one-liner. There
is nothing to cancel in an apply that has not *started*, and cancellation cannot
reach one that binds `Background()` anyway. **Refusing before it begins is the
only available mechanism — and it is strictly better than aborting midway, since
no half-finished apply is left behind**, which is the preference you stated.

**3. What a late full apply does — and the trigger.** `pkg/dhcp`'s
`scheduleRecompile` arms `time.AfterFunc(2*time.Second, …)` whose callback is
`onDHCPAddressChange` → `applyActiveConfig()` → full `applyConfigLocked`. Two
seconds is comfortably longer than the shutdown drain. The apply then reconciles
FRR, networkd, interface addresses/VIPs and the dataplane — after
`runShutdownSequence` has stopped FRR, withdrawn RA, removed VIPs and torn down
the dataplane. **#6787 is the proof this is real, not theoretical**: it exists
because a late applier could restart Kea after shutdown stopped it. It patched
one subsystem with a latch; this is the general case.

**And `runShutdownSequence` never stops the DHCP client at all.** `d.feeds.StopAll()`
and `d.rpm.StopAll()` are both called there; `d.dhcp` is the one background
subsystem with a `StopAll` that shutdown forgets.

## Why the obvious fix would cause an outage

`dhcp.Manager.StopAll()` has **zero production callers**, and adding one here is
the reflex repair. It is wrong. `StopAll` cancels every client, and a cancelled
client runs `finishClient` → **`removeAddress`** — stripping the DHCP address
from every DHCP interface, including a DHCP-managed management NIC (`fxp0`),
during this shutdown *and* across a graceful restart. That is the explicit
contract in `pkg/dhcp`'s client-context comment: clients are decoupled from the
daemon lifecycle so "during graceful restart (SIGTERM), the process exits without
calling `StopAll()`, so addresses stay on interfaces for the next daemon to
reuse". It is also why the issue's own fix direction says *"while preserving
leases"*. **Cell M6 is that control.**

## The fix — two mechanisms, neither sufficient alone

- **`Daemon.applyFenced` + `beginBackgroundApply`.** Latched at the very start of
  shutdown; ordering is **fence, then cancel, then drain**, which makes the drain
  the last apply the process performs. One shared helper rather than three
  guards: `applyConfig`, `applyActiveConfig` and `applyActiveConfigResult` are a
  family that must agree, and a shared predicate cannot drift. It tests the fence
  **twice** — an applier can already be *blocked* on `applySem` when shutdown
  fences, and checking only before the acquire lets it through the instant that
  apply releases, which is precisely the semaphore the drain just freed. Commit
  paths are deliberately not fenced (request-scoped contexts, already covered by
  #2926, servers stopped during teardown). `applyActiveConfigResult` returns
  vacuous success, not an error — a fenced daemon is not a rejected feed, and an
  error would record publication debt on a process that is exiting.
- **`dhcp.Manager.Quiesce`.** Stops the debounce timer, latches so a lease event
  racing shutdown re-arms nothing, and **joins** an in-flight callback — while
  leaving every lease, address and client goroutine untouched.

**Both are required.** The fence does not cover `onDHCPAddressChange`'s non-apply
work: it nudges the Surface-A DDNS reconcile and, on its management-only branch,
runs `applyMgmtVRFRoutes` (netlink route writes) and `reconcileDNSFromDHCP` —
none of which pass through `beginBackgroundApply`. The quiesce does not cover the
feed-publication or config-poll appliers, which reach the same apply path by
other routes.

On your "coerce to a terminal state" note: a shutting-down daemon has no later
state to converge to, so refusal *is* terminal here. It logs at INFO with the
caller name so a late applier is attributable rather than silent.

## Mutation matrix

Fix committed BEFORE the matrix. One mutation per line (M9 is a single
relocation), anchor asserted to match exactly once, tree rebuilt, then the full
suites for `pkg/daemon`, `pkg/dhcp`, `pkg/feeds` with `-count=1`, **no `-run`
filter**, and `skipped_6788_cells == 0` asserted per cell.

Control (M0): **2141 passing, 0 failed, 0 skips.**

| Cell | Mutation | Result | Which assertion fired |
|---|---|---|---|
| M0 | none (control) | **GREEN** | 2141 pass / 0 fail |
| M1 | drop the PRE-acquire fence test | **RED** | `TestFencedApplierDoesNotParkOnHeldSemaphore6788` — see below |
| M2 | drop the POST-acquire fence test | **RED** | `TestApplierWaitingOnSemaphoreRefusesAfterFence6788` |
| M3 | remove `fenceBackgroundApplies()` from shutdown | **RED** | `TestFenceIsSetBeforeTheApplyDrain6788` |
| M4 | remove `d.dhcp.Quiesce()` from shutdown | **RED** | `TestRunShutdownSequenceQuiescesDHCPClient6788` |
| M5 | drop the latch guard in `scheduleRecompile` | **RED** | `TestQuiesceLatchRefusesLaterScheduling6788` |
| M6 | **tightening** — implement `Quiesce` as `StopAll` (the outage fix) | **RED** (−28 passes) | `TestQuiescePreservesLeasesAndClients6788` |
| M7 | drop `recompileWG.Wait()` (the join) | **RED** | `TestQuiesceJoinsInFlightCallback6788` |
| M8 | **tightening** — `applyFencedForBackground()` always true | **RED** ×5 | `TestUnfencedDaemonStillApplies6788` **plus 4 pre-existing** (`TestApplyConfigSerializes`, `…6716`, …) |
| M9 | **MOVE** the fence to after the drain (ordering, not absence) | **RED** | `TestFenceIsSetBeforeTheApplyDrain6788` |

**The matrix caught three things the tests alone did not, and two of them were
defects in my own work.**

*M1 initially SURVIVED.* The post-acquire check catches every case a "did an
apply run" assertion can see, so the pre-acquire check looked redundant. It is
redundant for **safety** and load-bearing for **liveness**: `beginBackgroundApply`
acquires with `context.Background()`, which never cancels, so without it a late
DHCP/feed callback parks *forever* on a held semaphore on a daemon trying to
exit. Bound with a cell that holds the semaphore and **never releases it**.

*M9 initially SURVIVED, and that exposed a vacuous green in my own test.*
`runShutdownSequence` guards both the cancel and the drain behind
`if d.applyCancel != nil`, and my harness built a `Daemon` without one — so the
drain never executed and a cell named `TestFenceIsSetBeforeTheApplyDrain6788`
passed whether the fence ran before or after a drain that was never reached. The
harness now sets `applyCancelContext`/`applyCancel`, with a comment recording
why it is not optional scaffolding.

*A deadlock in `Quiesce`, caught by writing the test.* My first version took
`recompileWG.Add(1)` at arm time, so a **stopped** timer never called `Done` and
`Wait` blocked forever. Add now happens inside the timer func under the same
mutex as the latch re-test — the #5869 `archiveWG` discipline — so a callback
either registers before the latch and is joined, or observes the latch and never
registers.

## Validation

- `go build ./...` rc=0 · `go vet ./...` clean · `go test -count=1 ./...`
  (repo-wide) **rc=0** · `go test -race ./pkg/dhcp/` green (new
  mutex/WaitGroup/timer interaction).
- Gated head **`d7898f056ba2d947d3f33564b9049eb9710cb2fd`**, which merges
  `origin/master` (only conflict an append-vs-append in `_Log.md`,
  union-resolved, anchored marker sweep clean). Build, vet, the repo-wide suite
  and the two most load-bearing cells (M2, M6) were re-run at that head.
- **No Rust touched** — Go-only, so no cargo leg.
- **Touches the shutdown path, which is HA-relevant.** No cluster/VRRP/
  session-sync/failover *logic* is changed — the fence and quiesce run before
  the existing HA teardown and change no ordering within it — but this is the
  sequence that ends with the VRRP priority-0 withdrawal, so a
  `make test-failover` on the loss cluster is worth having. **I have not run any
  cluster target.**

## Docs

`pkg/daemon/README.md` gains a **Background-apply fence (#6788)** subsection
under `daemon_run_shutdown.go` (why the drain is not a barrier, why cancellation
cannot cover it, the fence/cancel/drain ordering, the two fence tests, and why
both mechanisms are needed). `pkg/dhcp/README.md` documents `Quiesce`/`Quiesced`
next to `StopAll` with an explicit warning never to call `StopAll` on the
shutdown path, and expands the 2s-debounce gotcha to say why that duration is
itself part of the hazard.
