### PR TITLE
vrrp/config: one predicate for RETH redundancy-group ownership (#6781)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104716,7 +104716,11 @@ prose edit above them added. No diff falls in the new test body.
   interface's address on both nodes with nobody installing it back. Added
   `Config.RethRGOwners` as the shared structural-or-nominal predicate, routed
   both collectors through it, stopped networkd treating a non-reth as a VRRP
-  reth member, and added a commit gate with a lenient opt.
+  reth member, and added a commit gate with a lenient opt. Then folded in the
+  five pkg/daemon RG-membership readers (stable link-local add/remove, direct
+  GARP burst, DHCP RG-scoping, BACKUP blackhole routes), which each carried
+  their own name test — without them a structurally valid pair got VIPs from
+  both modes and then no GARP, link-local or blackhole routes.
 - **File(s)**: `pkg/config/reth_rg_owner.go` (new),
   `pkg/config/compiler_validate_strict_reth_rg.go` (new),
   `pkg/config/compiler_opts.go`,

--- a/_Log.md
+++ b/_Log.md
@@ -104622,3 +104622,26 @@ prose edit above them added. No diff falls in the new test body.
   pkg/dhcpserver/shutdown_latch_6787_test.go,
   pkg/daemon/daemon_run_shutdown.go,
   pkg/daemon/shutdown_dhcp_stop_6787_test.go, pkg/dhcpserver/README.md, _Log.md
+
+## 2026-08-22 — #6781 one predicate for RETH redundancy-group ownership
+
+- **Timestamp**: 2026-08-22
+- **Action**: Reproduced both ownership readings from real compiled configs
+  before choosing a survivor, and found BOTH wrong in opposite directions: the
+  VRRP-backed collector's bare `RedundancyGroup > 0` claimed a non-reth
+  interface (turning its own address into a MASTER-only VIP), while the direct
+  collector's `reth`-name filter dropped a structurally valid pair not spelled
+  `reth*` (leaving that group with no VIPs). Under `no-reth-vrrp` the two
+  combined with networkd's link-local substitution to strip a non-reth
+  interface's address on both nodes with nobody installing it back. Added
+  `Config.RethRGOwners` as the shared structural-or-nominal predicate, routed
+  both collectors through it, stopped networkd treating a non-reth as a VRRP
+  reth member, and added a commit gate with a lenient opt.
+- **File(s)**: `pkg/config/reth_rg_owner.go` (new),
+  `pkg/config/compiler_validate_strict_reth_rg.go` (new),
+  `pkg/config/compiler_opts.go`,
+  `pkg/config/compiler_uniformgates_routing_rib_rpm.go`,
+  `pkg/vrrp/vrrp.go`, `pkg/dataplane/compiler_iface.go`,
+  `pkg/vrrp/reth_rg_parity_6781_test.go` (new),
+  `pkg/vrrp/reth_rg_ssot_6781_test.go` (new),
+  `pkg/config/reth_rg_gate_6781_test.go` (new), `pkg/vrrp/README.md`

--- a/pkg/config/compiler_opts.go
+++ b/pkg/config/compiler_opts.go
@@ -1825,7 +1825,7 @@ type compileOpts struct {
 	// Same doctrine as lenientIfNameCollision.
 	lenientRethMember bool
 
-	// lenientRethRedundancyGroup (#6781) downgrades the RETH
+	// lenientRethRGOwnership (#6781) downgrades the RETH
 	// redundancy-group ownership gate (validateRethRedundancyGroupStrict)
 	// from a hard compile error to a cfg.Warnings entry. An interface
 	// carrying `redundant-ether-options redundancy-group <N>` that no port
@@ -1844,7 +1844,7 @@ type compileOpts struct {
 	// (Config.RethRGOwners), so a leniently-loaded config keeps the
 	// interface as a plain L3 interface with its address rather than
 	// half-applying a redundancy group. Same doctrine as lenientRethMember.
-	lenientRethRedundancyGroup bool
+	lenientRethRGOwnership bool
 	// lenientReservedZoneNames (#3055) downgrades the reserved zone-name
 	// definition gate (validateReservedZoneNamesStrict) from a hard compile
 	// error to a cfg.Warnings entry. The strict commit / commit-check path
@@ -2478,7 +2478,7 @@ func lenientCompileOpts() compileOpts {
 		lenientRethVRRPGroupID:                 true,
 		lenientIfNameCollision:                 true,
 		lenientRethMember:                      true,
-		lenientRethRedundancyGroup:             true,
+		lenientRethRGOwnership:                 true,
 		lenientReservedZoneNames:               true,
 		lenientBackupRouterDst:                 true,
 		lenientSecureTunnelBindIface:           true,

--- a/pkg/config/compiler_opts.go
+++ b/pkg/config/compiler_opts.go
@@ -1808,6 +1808,27 @@ type compileOpts struct {
 	// and its ifindex identifies no zone (fail-closed).
 	// Same doctrine as lenientIfNameCollision.
 	lenientRethMember bool
+
+	// lenientRethRedundancyGroup (#6781) downgrades the RETH
+	// redundancy-group ownership gate (validateRethRedundancyGroupStrict)
+	// from a hard compile error to a cfg.Warnings entry. An interface
+	// carrying `redundant-ether-options redundancy-group <N>` that no port
+	// names as its `gigether-options redundant-parent` is not a
+	// redundant-ethernet interface, and the three consumers of that stanza
+	// disagreed about it: networkd generation replaced the operator's
+	// address with a link-local /32, the VRRP-backed owner claimed the real
+	// address as a VIP that exists only while MASTER, and the direct owner
+	// (no-reth-vrrp / private-rg-election) skipped it — so in direct mode the
+	// address was stripped and installed by nobody, on both nodes. The strict
+	// commit / commit-check path hard-rejects so the operator error is
+	// visible; the tolerant load / peer-sync paths downgrade to a warning so
+	// an already-persisted or peer-synced config an older binary accepted
+	// still BOOTS (#1960 fail-closed-on-load class). The runtime resolves
+	// ownership through the shared structural predicate
+	// (Config.RethRGOwners), so a leniently-loaded config keeps the
+	// interface as a plain L3 interface with its address rather than
+	// half-applying a redundancy group. Same doctrine as lenientRethMember.
+	lenientRethRedundancyGroup bool
 	// lenientReservedZoneNames (#3055) downgrades the reserved zone-name
 	// definition gate (validateReservedZoneNamesStrict) from a hard compile
 	// error to a cfg.Warnings entry. The strict commit / commit-check path
@@ -2440,6 +2461,7 @@ func lenientCompileOpts() compileOpts {
 		lenientRethVRRPGroupID:                 true,
 		lenientIfNameCollision:                 true,
 		lenientRethMember:                      true,
+		lenientRethRedundancyGroup:             true,
 		lenientReservedZoneNames:               true,
 		lenientBackupRouterDst:                 true,
 		lenientSecureTunnelBindIface:           true,

--- a/pkg/config/compiler_uniformgates_routing_rib_rpm.go
+++ b/pkg/config/compiler_uniformgates_routing_rib_rpm.go
@@ -265,5 +265,28 @@ func runUniformGatesRoutingRibRPM(tree *ConfigTree, cfg *Config, opts compileOpt
 		}
 	}
 
+	// #6781 RETH redundancy-group ownership gate. Strict on commit /
+	// commit-check: `redundant-ether-options redundancy-group <N>` on an
+	// interface no port names as its redundant-parent is not a
+	// redundant-ethernet interface, and the three consumers of that stanza
+	// disagreed about it — networkd replaced the operator's address with a
+	// link-local /32, the VRRP-backed owner claimed the real address as a VIP,
+	// and the direct owner skipped it, so under no-reth-vrrp the address was
+	// stripped and installed by nobody on both nodes. Lenient on load /
+	// peer-sync (warn so an already-persisted or peer-synced config still
+	// boots — #1960 no-brick; the runtime resolves ownership through the shared
+	// structural predicate, so the interface stays a plain L3 interface).
+	// Runs after validateRethMemberStrict, which has already established that
+	// the redundant-parent declarations themselves are coherent. Same doctrine
+	// as lenientRethMember.
+	if err := validateRethRedundancyGroupStrict(cfg); err != nil {
+		if opts.lenientRethRedundancyGroup {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("reth redundancy-group (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/pkg/config/compiler_uniformgates_routing_rib_rpm.go
+++ b/pkg/config/compiler_uniformgates_routing_rib_rpm.go
@@ -280,7 +280,7 @@ func runUniformGatesRoutingRibRPM(tree *ConfigTree, cfg *Config, opts compileOpt
 	// the redundant-parent declarations themselves are coherent. Same doctrine
 	// as lenientRethMember.
 	if err := validateRethRedundancyGroupStrict(cfg); err != nil {
-		if opts.lenientRethRedundancyGroup {
+		if opts.lenientRethRGOwnership {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("reth redundancy-group (downgraded to warning on tolerant path): %v", err))
 		} else {

--- a/pkg/config/compiler_validate_strict_reth_rg.go
+++ b/pkg/config/compiler_validate_strict_reth_rg.go
@@ -1,0 +1,107 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// validateRethRedundancyGroupStrict rejects, at commit / commit-check, a
+// `redundant-ether-options redundancy-group <N>` authored on an interface that
+// is neither structurally nor nominally a redundant-ethernet interface:
+// nothing names it as their `gigether-options redundant-parent`, AND it is not
+// spelled `reth*` (#6781).
+//
+// Junos scopes `redundant-ether-options` to a reth; xpf's schema attaches it to
+// any interface node (schema_interfaces.go), so `ge-0/0/5
+// redundant-ether-options redundancy-group 1` committed cleanly and then meant
+// three different things to three different consumers:
+//
+//   - networkd generation (pkg/dataplane compiler_iface.go) treated the
+//     interface as a VRRP-backed reth member and REPLACED the operator's
+//     configured address with a 169.254.<rg>.<node>/32 link-local.
+//   - The VRRP-backed owner (CollectRethInstances) synthesized a VRRP instance
+//     on it whose "VIPs" were that same configured address — so it existed only
+//     while the node was MASTER, and was deleted on BACKUP.
+//   - The direct owner (RethVIPsForRG, used under `no-reth-vrrp` /
+//     `private-rg-election`) skipped it entirely.
+//
+// The two ownership modes therefore disagreed, and the disagreement was not
+// symmetric: under `no-reth-vrrp` the address was stripped by networkd and
+// installed by NOBODY, on both nodes, so a plain L3 interface silently lost its
+// address by being given a redundancy group.
+//
+// Requiring member ports is the honest reading of what the operator asked for.
+// A redundancy group is a failover relationship between two physical ports on
+// two chassis; an interface with no members has nothing to fail over between
+// and no netdev for VRRP to bind (RETH is bondless here — the reth name is not
+// a kernel device). This gate does NOT require the interface to be NAMED
+// `reth*`: interface names are validated by character class only
+// (validate_interface_name.go), so the spelling is a convention, and rejecting
+// a structurally valid pair for its name would turn a working config into a
+// failed commit with no operator workaround.
+//
+// On the tolerant load / peer-sync paths the call site downgrades this to a
+// warning (opts.lenientRethRedundancyGroup) so an already-persisted or
+// peer-synced config an older binary accepted still BOOTS (#1960 no-brick); the
+// runtime consumers independently resolve ownership through the shared
+// structural predicate (Config.RethRGOwners), so a leniently-loaded config
+// keeps the interface as a plain L3 interface with its configured address
+// rather than half-applying a redundancy group to it. Same doctrine as
+// lenientRethMember (#6722).
+func validateRethRedundancyGroupStrict(cfg *Config) error {
+	if cfg == nil || cfg.Interfaces.Interfaces == nil {
+		return nil
+	}
+	rethToPhys := cfg.RethToPhysical()
+
+	names := make([]string, 0, len(cfg.Interfaces.Interfaces))
+	for name := range cfg.Interfaces.Interfaces {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		ifc, ok := LookupInterface(cfg, name)
+		if !ok || ifc.RedundancyGroup <= 0 {
+			continue
+		}
+		if _, hasMembers := rethToPhys[name]; hasMembers {
+			continue
+		}
+		// A `reth*`-named interface with no members yet is DELIBERATELY not
+		// rejected here. It is a declaration of intent to be a
+		// redundant-ethernet interface — an incompletely-wired one — and
+		// rejecting it would newly refuse a shape the repo's own fixtures and
+		// an operator building a config incrementally both use. It is also not
+		// what #6781 is about: the disagreement this gate closes is over
+		// interfaces that are neither structurally NOR nominally a reth.
+		//
+		// It is safe to leave: the shared structural predicate
+		// (Config.RethRGOwners) excludes it at runtime, so neither ownership
+		// mode claims it and no address is taken from it. Before #6781 both
+		// modes DID claim it and then failed in netlink against a `reth0`
+		// netdev that does not exist (RETH is bondless), so this is strictly
+		// quieter than what it replaces.
+		if strings.HasPrefix(name, "reth") {
+			continue
+		}
+		return fmt.Errorf(
+			"interface %q sets `redundant-ether-options redundancy-group %d`, "+
+				"but no interface names %q as its `gigether-options "+
+				"redundant-parent`, so it is not a redundant-ethernet interface. "+
+				"A redundancy group is a failover relationship between member "+
+				"ports on the two chassis; with no members there is nothing to "+
+				"fail over between and no kernel device to bind (a reth name is "+
+				"not itself a netdev). The configured address on %q would be "+
+				"replaced with a 169.254.%d.<node>/32 link-local in the generated "+
+				"networkd config and handed to VRRP as a virtual address — and "+
+				"under `no-reth-vrrp` nothing would install it back, so %q would "+
+				"silently lose its address on both nodes. Add "+
+				"`gigether-options redundant-parent %s` to the member ports, or "+
+				"remove the redundancy-group from %q",
+			name, ifc.RedundancyGroup, name, name, ifc.RedundancyGroup, name,
+			name, name)
+	}
+	return nil
+}

--- a/pkg/config/compiler_validate_strict_reth_rg.go
+++ b/pkg/config/compiler_validate_strict_reth_rg.go
@@ -42,7 +42,7 @@ import (
 // failed commit with no operator workaround.
 //
 // On the tolerant load / peer-sync paths the call site downgrades this to a
-// warning (opts.lenientRethRedundancyGroup) so an already-persisted or
+// warning (opts.lenientRethRGOwnership) so an already-persisted or
 // peer-synced config an older binary accepted still BOOTS (#1960 no-brick); the
 // runtime consumers independently resolve ownership through the shared
 // structural predicate (Config.RethRGOwners), so a leniently-loaded config

--- a/pkg/config/reth_rg_gate_6781_test.go
+++ b/pkg/config/reth_rg_gate_6781_test.go
@@ -1,0 +1,136 @@
+package config
+
+import "testing"
+
+// #6781: `redundant-ether-options redundancy-group <N>` on an interface that is
+// neither structurally nor nominally a redundant-ethernet interface committed
+// cleanly and then meant three different things — networkd replaced the
+// operator's address with a link-local /32, the VRRP-backed owner claimed the
+// real address as a MASTER-only VIP, and the direct owner skipped it, so under
+// `no-reth-vrrp` the address was stripped and installed by nobody on BOTH nodes.
+//
+// FAIL-ON-REVERT: drop the validateRethRedundancyGroupStrict dispatch in
+// compiler_uniformgates_routing_rib_rpm.go (or the comparison inside the
+// validator) and the reject subtests go green on the BAD config.
+
+func rethRGGateLines(extra ...string) []string {
+	return append([]string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster authentication-key test-cluster-psk-6781",
+		"set chassis cluster reth-count 2",
+	}, extra...)
+}
+
+func TestRedundancyGroupOnNonRethFailsCommit(t *testing.T) {
+	tree := buildTree(t, rethRGGateLines(
+		"set interfaces ge-0/0/5 redundant-ether-options redundancy-group 1",
+		"set interfaces ge-0/0/5 unit 0 family inet address 10.0.99.1/24",
+	))
+
+	cfg, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("expected commit to reject redundancy-group on ge-0/0/5 (no "+
+			"port names it as a redundant-parent, and it is not named reth*); "+
+			"got nil error (warnings=%v)", cfg.Warnings)
+	}
+	if !stringContainsAll(err.Error(), "ge-0/0/5", "redundant-parent") {
+		t.Fatalf("error %q does not name the interface and what it is missing",
+			err.Error())
+	}
+
+	// Tolerant path must NOT brick (#1960) — and must warn.
+	lcfg, lerr := CompileConfigLenient(tree)
+	if lerr != nil {
+		t.Fatalf("lenient compile must not reject (no-brick), got %v", lerr)
+	}
+	if !warningsContain(lcfg.Warnings, "redundancy-group") {
+		t.Fatalf("lenient compile should warn; warnings=%v", lcfg.Warnings)
+	}
+	// And the leniently-loaded config must leave the interface a PLAIN L3
+	// interface — not a half-applied RG owner. This is the property that keeps
+	// its address from being replaced by a link-local /32 downstream.
+	if _, owns := lcfg.RethRGOwner("ge-0/0/5"); owns {
+		t.Errorf("a leniently-loaded ge-0/0/5 must not own a redundancy group; "+
+			"owners=%v", lcfg.RethRGOwners())
+	}
+}
+
+// TestRedundancyGroupOnRealRethCommits is the TIGHTENING control: the gate must
+// not over-reject. Both legitimate shapes commit cleanly and own their group.
+func TestRedundancyGroupOnRealRethCommits(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		owner string
+		lines []string
+	}{
+		{
+			name:  "conventional-reth-with-members",
+			owner: "reth0",
+			lines: []string{
+				"set interfaces ge-0/0/1 gigether-options redundant-parent reth0",
+				"set interfaces reth0 redundant-ether-options redundancy-group 1",
+				"set interfaces reth0 unit 0 family inet address 10.0.61.1/24",
+			},
+		},
+		{
+			// Structurally a reth, not spelled reth*. Rejecting this for its
+			// NAME would turn a working config into a failed commit.
+			name:  "structural-pair-not-named-reth",
+			owner: "bond0",
+			lines: []string{
+				"set interfaces ge-0/0/1 gigether-options redundant-parent bond0",
+				"set interfaces bond0 redundant-ether-options redundancy-group 1",
+				"set interfaces bond0 unit 0 family inet address 10.0.61.1/24",
+			},
+		},
+		{
+			// Declared but not yet wired. Deliberately NOT rejected: both
+			// ownership modes accepted it before #6781, and narrowing that is
+			// out of scope.
+			name:  "reth-named-without-members",
+			owner: "reth0",
+			lines: []string{
+				"set interfaces reth0 redundant-ether-options redundancy-group 1",
+				"set interfaces reth0 unit 0 family inet address 10.0.61.1/24",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := CompileConfig(buildTree(t, rethRGGateLines(tc.lines...)))
+			if err != nil {
+				t.Fatalf("%s must commit cleanly, got %v", tc.name, err)
+			}
+			if warningsContain(cfg.Warnings, "redundant-parent") {
+				t.Errorf("%s must not warn; warnings=%v", tc.name, cfg.Warnings)
+			}
+			if _, owns := cfg.RethRGOwner(tc.owner); !owns {
+				t.Errorf("%s must own its redundancy group; owners=%v",
+					tc.owner, cfg.RethRGOwners())
+			}
+		})
+	}
+}
+
+// TestRethRGOwnersExcludesDefaultZeroInterfaces pins the guard the replaced
+// name filter was really providing: an RG-0 query must not sweep in every
+// interface whose redundancy-group is merely UNSET (fabric, control, mgmt all
+// default to 0). The structural/nominal test subsumes it.
+func TestRethRGOwnersExcludesDefaultZeroInterfaces(t *testing.T) {
+	cfg, err := CompileConfig(buildTree(t, rethRGGateLines(
+		"set interfaces ge-0/0/1 gigether-options redundant-parent reth0",
+		"set interfaces reth0 redundant-ether-options redundancy-group 1",
+		"set interfaces reth0 unit 0 family inet address 10.0.61.1/24",
+		"set interfaces ge-0/0/9 unit 0 family inet address 10.0.77.1/24",
+	)))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	owners := cfg.RethRGOwners()
+	if _, ok := owners["ge-0/0/9"]; ok {
+		t.Errorf("an interface with an UNSET redundancy-group must not own "+
+			"group 0; owners=%v", owners)
+	}
+	if _, ok := owners["reth0"]; !ok {
+		t.Errorf("reth0 must still own its group; owners=%v", owners)
+	}
+}

--- a/pkg/config/reth_rg_owner.go
+++ b/pkg/config/reth_rg_owner.go
@@ -1,0 +1,109 @@
+package config
+
+import "strings"
+
+// RETH redundancy-group ownership — the single source of truth for "does this
+// interface own a chassis-cluster redundancy group?" (#6781).
+//
+// The question has one right answer and, before this file, had two wrong ones.
+// Consumers split into two camps, and BOTH were measurably wrong, in OPPOSITE
+// directions:
+//
+//	RedundancyGroup > 0 alone            (pkg/vrrp CollectRethInstances)
+//	RedundancyGroup > 0 && name "reth*"  (everyone else)
+//
+// Measured on configs that COMMIT CLEANLY today:
+//
+//	`ge-0/0/5 redundant-ether-options redundancy-group 1`, nothing naming it as
+//	a redundant-parent. The RG-only reading synthesizes a VRRP instance on it
+//	whose "VIPs" are that interface's OWN unit addresses — so the node ADDS
+//	them on MASTER and DELETES them on BACKUP, stripping a plain interface's
+//	configured address. The name reading excludes it. Over-inclusion, harmful.
+//
+//	`bond0 redundant-ether-options redundancy-group 1` with
+//	`ge-0/0/1 gigether-options redundant-parent bond0` — a STRUCTURALLY valid
+//	redundant pair whose owner is not named "reth*". The RG-only reading
+//	resolves it correctly to the physical member; the name reading returns
+//	NOTHING, so the direct ownership mode installs no VIPs at all and the group
+//	is dark. Under-inclusion, an outage.
+//
+// So the fix is not to make one camp match the other — that would ship one of
+// the two defects everywhere. The discriminator both readings miss is
+// STRUCTURAL: a redundant-ethernet interface is the L3 owner of a pair of
+// member PORTS, and what makes it one is that ports name it
+// (`gigether-options redundant-parent <name>`), not how it is spelled.
+// RethToPhysical already keys on exactly that relation, and the whole runtime
+// resolves a RETH to its local member through it — an interface absent from
+// that map has no netdev for VRRP to bind, no member to fail over between, and
+// nothing for a VIP to move onto.
+//
+// Naming is NOT used as the test, deliberately. Interface names are validated
+// by character class only (validate_interface_name.go), so "reth" is a
+// convention rather than a closed namespace, and rejecting an odd-named but
+// structurally valid pair would turn a working config into a failed commit with
+// no operator workaround — the #6564 lesson that file already records.
+//
+// validateRethRedundancyGroupStrict rejects the over-inclusion shape at commit;
+// this predicate makes every runtime consumer agree on the answer.
+
+// RethRGOwners returns interface name -> redundancy-group id for every
+// interface that is a REDUNDANT-ETHERNET INTERFACE — either STRUCTURALLY (some
+// port names it as its `gigether-options redundant-parent`) or NOMINALLY (it is
+// spelled `reth*`) — mapped to the redundancy group it carries.
+//
+// It deliberately does NOT filter on `RedundancyGroup > 0`. That term belongs
+// to the CALLER, because the two ownership modes need different things from it:
+// the VRRP-backed collector synthesizes instances only for groups above 0,
+// while the direct collector is legitimately queried FOR group 0 and must
+// answer for a reth carrying it. Folding `> 0` in here silently broke the
+// second. What the RG-0 query actually needs protecting from is every
+// unconfigured interface DEFAULTING to 0 — and the structural/nominal test
+// above already excludes those, since a fabric, control, or management
+// interface is neither a reth by name nor by membership. That is the guard the
+// replaced `strings.HasPrefix(name, "reth")` filter was really providing.
+//
+// The predicate is deliberately the UNION of the two readings it replaces,
+// minus their shared blind spot. That direction matters: it EXCLUDES only the
+// shape that was actively wrong (a redundancy group on an interface that is
+// neither, which one mode half-applied and the other ignored) and INCLUDES the
+// shape one mode was wrongly dropping (a structurally valid pair not spelled
+// `reth*`, which the direct mode left with no VIPs at all). No configuration
+// that either mode previously owned stops being owned — in HA ownership code a
+// newly-excluded interface is an outage, so the nominal term is kept even
+// though a `reth*` with no members yet is an incomplete config: both modes
+// accepted it before, and narrowing that is not what #6781 is about.
+//
+// Build it ONCE per walk and look names up in it; it is O(interfaces) and
+// recomputes RethToPhysical on each call. Present-but-nil interface slots are
+// skipped (#6780).
+func (c *Config) RethRGOwners() map[string]int {
+	if c == nil {
+		return nil
+	}
+	rethToPhys := c.RethToPhysical()
+	owners := make(map[string]int, len(rethToPhys))
+	for name, ifc := range c.Interfaces.Interfaces {
+		if ifc == nil {
+			continue
+		}
+		_, hasMembers := rethToPhys[name]
+		if !hasMembers && !strings.HasPrefix(name, "reth") {
+			// Neither structurally nor nominally a redundant-ethernet
+			// interface: no port names it as their redundant-parent AND it is
+			// not spelled `reth*`. It owns no group. Commit rejects this shape
+			// (validateRethRedundancyGroupStrict); a tolerantly-loaded config
+			// that still carries it is excluded here rather than half-applied.
+			continue
+		}
+		owners[name] = ifc.RedundancyGroup
+	}
+	return owners
+}
+
+// RethRGOwner reports which redundancy group `name` owns, and whether it owns
+// one at all. Convenience for a caller inspecting a single interface; a caller
+// walking every interface should build RethRGOwners once instead.
+func (c *Config) RethRGOwner(name string) (int, bool) {
+	rg, ok := c.RethRGOwners()[name]
+	return rg, ok
+}

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -1356,11 +1356,16 @@ func rethInterfacesForRG(cfg *config.Config, rgID int) []string {
 // RG member as node-local (both nodes serve DHCP on one redundant segment).
 func rethInterfacesMatchingRG(cfg *config.Config, want func(rgID int) bool) []string {
 	var names []string
+	rgOwners := cfg.RethRGOwners() // #6781
 	for name, ifc := range cfg.Interfaces.Interfaces {
 		if ifc == nil {
 			continue
 		}
-		if want(ifc.RedundancyGroup) && strings.HasPrefix(name, "reth") {
+		// #6781: RG ownership from the shared predicate, not a name test. The
+		// #6520 rationale in this function's doc comment — "a divergence
+		// between them is ALWAYS a bug" — is exactly why it must not carry a
+		// private reading of its own.
+		if owns, ok := rgOwners[name]; ok && want(owns) {
 			// Resolve RETH to physical member for Linux-level operations.
 			resolved := config.LinuxIfName(cfg.ResolveReth(name))
 			for _, unit := range ifc.Units {
@@ -1404,11 +1409,12 @@ func (d *Daemon) injectBlackholeRoutesFor(userspaceActive bool, rgID int) {
 	}
 
 	var routes []netlink.Route
+	rgOwners := cfg.RethRGOwners() // #6781
 	for name, ifc := range cfg.Interfaces.Interfaces {
 		if ifc == nil {
 			continue
 		}
-		if ifc.RedundancyGroup != rgID || !strings.HasPrefix(name, "reth") {
+		if owns, ok := rgOwners[name]; !ok || owns != rgID { // #6781
 			continue
 		}
 		for _, unit := range ifc.Units {

--- a/pkg/daemon/daemon_ha_vip.go
+++ b/pkg/daemon/daemon_ha_vip.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"strings"
 	"syscall"
 	"time"
 
@@ -277,11 +276,16 @@ func (d *Daemon) addStableRethLinkLocal(rgID int) {
 	stableLL := cluster.StableRethLinkLocal(clusterID, rgID)
 	rethToPhys := cfg.RethToPhysical()
 
+	rgOwners := cfg.RethRGOwners() // #6781
 	for ifName, ifc := range cfg.Interfaces.Interfaces {
-		if ifc == nil || ifc.RedundancyGroup != rgID {
+		if ifc == nil {
 			continue
 		}
-		if !strings.HasPrefix(ifName, "reth") {
+		// #6781: RG ownership from the shared predicate. The name test this
+		// replaces excluded a structurally valid redundant pair not spelled
+		// reth*, so its group got VIPs from both ownership modes but no stable
+		// link-local — VRRP mastering an interface nothing else manages.
+		if owns, ok := rgOwners[ifName]; !ok || owns != rgID {
 			continue
 		}
 		// Skip interfaces with an explicitly configured link-local address —
@@ -344,11 +348,16 @@ func (d *Daemon) removeStableRethLinkLocal(rgID int) {
 	stableLL := cluster.StableRethLinkLocal(clusterID, rgID)
 	rethToPhys := cfg.RethToPhysical()
 
+	rgOwners := cfg.RethRGOwners() // #6781
 	for ifName, ifc := range cfg.Interfaces.Interfaces {
-		if ifc == nil || ifc.RedundancyGroup != rgID {
+		if ifc == nil {
 			continue
 		}
-		if !strings.HasPrefix(ifName, "reth") {
+		// #6781: RG ownership from the shared predicate. The name test this
+		// replaces excluded a structurally valid redundant pair not spelled
+		// reth*, so its group got VIPs from both ownership modes but no stable
+		// link-local — VRRP mastering an interface nothing else manages.
+		if owns, ok := rgOwners[ifName]; !ok || owns != rgID {
 			continue
 		}
 		physName := ifc.Name
@@ -612,8 +621,12 @@ func (d *Daemon) directSendGARPs(rgID int) {
 		stableLL := cluster.StableRethLinkLocal(cfg.Chassis.Cluster.ClusterID, rgID)
 		rethToPhys := cfg.RethToPhysical()
 		seen := make(map[string]bool)
+		rgOwners := cfg.RethRGOwners() // #6781
 		for ifName, ifc := range cfg.Interfaces.Interfaces {
-			if ifc == nil || ifc.RedundancyGroup != rgID || !strings.HasPrefix(ifName, "reth") {
+			if ifc == nil {
+				continue
+			}
+			if owns, ok := rgOwners[ifName]; !ok || owns != rgID { // #6781
 				continue
 			}
 			// Use configured link-local if present, otherwise stable LL.

--- a/pkg/daemon/reth_rg_ssot_6781_test.go
+++ b/pkg/daemon/reth_rg_ssot_6781_test.go
@@ -1,0 +1,175 @@
+package daemon
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6781 STRUCTURAL binding for the pkg/daemon RG-ownership readers.
+//
+// These five decide "which interfaces belong to redundancy group N" for stable
+// RETH link-local add/remove, the direct-mode GARP / router-LL burst, DHCP
+// RG-scoping, and BACKUP blackhole routes. Each carried its own
+// `strings.HasPrefix(name, "reth")` reading, so a structurally valid redundant
+// pair not spelled `reth*` got VIPs from both ownership modes and then no GARP,
+// no stable link-local and no blackhole routes — VRRP mastering an interface
+// nothing else manages.
+//
+// rethInterfacesMatchingRG's own doc comment (#6520) already states the rule
+// this enforces: "Deriving the two from one walker is not a style preference: a
+// divergence between them is ALWAYS a bug."
+//
+// A behavioural test alone is probe-bounded — it covers the shapes someone
+// thought to write down. This asserts the MECHANISM: none of these functions
+// may re-derive RG membership from a name test or a raw RedundancyGroup
+// comparison; all must read config.Config.RethRGOwners.
+func TestDaemonRGReadersUseTheSharedPredicate(t *testing.T) {
+	for _, tc := range []struct{ file, fn string }{
+		{"daemon_ha_vip.go", "addStableRethLinkLocal"},
+		{"daemon_ha_vip.go", "removeStableRethLinkLocal"},
+		{"daemon_ha_vip.go", "directSendGARPs"},
+		{"daemon_ha.go", "rethInterfacesMatchingRG"},
+		{"daemon_ha.go", "injectBlackholeRoutesFor"},
+	} {
+		t.Run(tc.fn, func(t *testing.T) {
+			raw, err := os.ReadFile(tc.file)
+			if err != nil {
+				t.Fatalf("read %s: %v", tc.file, err)
+			}
+			body, ok := rgFuncBody(stripGoLineComments(string(raw)), tc.fn)
+			if !ok {
+				t.Fatalf("could not locate %s in %s — this guard is anchored on "+
+					"the function name; rename it here too", tc.fn, tc.file)
+			}
+			if !strings.Contains(body, "RethRGOwners()") {
+				t.Errorf("%s does not call cfg.RethRGOwners(); RETH "+
+					"redundancy-group membership must come from the one shared "+
+					"predicate (#6781/#6520)", tc.fn)
+			}
+			if strings.Contains(body, `HasPrefix(name, "reth")`) ||
+				strings.Contains(body, `HasPrefix(ifName, "reth")`) {
+				t.Errorf("%s name-tests for \"reth\". That reading excluded a "+
+					"structurally valid pair not spelled reth*, leaving its "+
+					"group with VIPs but no GARP, link-local or blackhole "+
+					"routes (#6781)", tc.fn)
+			}
+			if m := regexp.MustCompile(`\.RedundancyGroup\s*(<=|>=|==|!=|>|<)`).FindString(body); m != "" {
+				t.Errorf("%s compares .RedundancyGroup directly (%q); membership "+
+					"is decided by config.RethRGOwners", tc.fn, m)
+			}
+		})
+	}
+}
+
+// stripGoLineComments removes //-comments so the scan cannot be satisfied — or
+// tripped — by prose quoting the very pattern it looks for.
+func stripGoLineComments(s string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(s, "\n") {
+		if i := strings.Index(line, "//"); i >= 0 {
+			line = line[:i]
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// rgFuncBody returns the brace-matched body of the named func (method or not).
+func rgFuncBody(src, name string) (string, bool) {
+	idx := strings.Index(src, ") "+name+"(")
+	if idx < 0 {
+		idx = strings.Index(src, "func "+name+"(")
+		if idx < 0 {
+			return "", false
+		}
+	}
+	open := strings.Index(src[idx:], "{")
+	if open < 0 {
+		return "", false
+	}
+	open += idx
+	depth := 0
+	for i := open; i < len(src); i++ {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[open : i+1], true
+			}
+		}
+	}
+	return "", false
+}
+
+// TestAllRGReadersAgreeOnStructuralPair is the BEHAVIOURAL half for the daemon
+// readers: on a structurally valid redundant pair NOT spelled `reth*`, the
+// membership walk must resolve it, exactly as the two ownership modes now do.
+//
+// This is the shape the name tests dropped. Before #6781 the group got VIPs
+// installed by the ownership modes and then nothing else: no GARP, no stable
+// link-local, no blackhole routes on BACKUP — so return traffic escaped via the
+// default route while VRRP mastered an interface nothing else managed.
+//
+// FAIL-ON-REVERT: restore `strings.HasPrefix(name, "reth")` in
+// rethInterfacesMatchingRG and this reds, naming what it resolved instead.
+func TestAllRGReadersAgreeOnStructuralPair(t *testing.T) {
+	cfg := rgOwnerTestConfig(t)
+
+	// Precondition: the shared predicate owns bond0 at group 1, so a failure
+	// below is about this reader and not about the fixture.
+	if rg, ok := cfg.RethRGOwners()["bond0"]; !ok || rg != 1 {
+		t.Fatalf("fixture: bond0 must own group 1, got rg=%d ok=%v (owners=%v)",
+			rg, ok, cfg.RethRGOwners())
+	}
+
+	names := rethInterfacesMatchingRG(cfg, func(rgID int) bool { return rgID == 1 })
+	found := false
+	for _, n := range names {
+		if n == "ge-0-0-1" { // bond0 resolves to its local member port
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("RG membership did not resolve the structurally valid pair "+
+			"bond0 to its member ge-0-0-1; got %v. Its group would get VIPs "+
+			"from both ownership modes and then no GARP, no stable link-local "+
+			"and no blackhole routes", names)
+	}
+}
+
+// rgOwnerTestConfig builds a cluster config whose redundant pair is owned by
+// `bond0` — structurally a reth (ports name it as their redundant-parent) but
+// not spelled `reth*`.
+func rgOwnerTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	tree := &config.ConfigTree{}
+	for _, l := range []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster authentication-key test-cluster-psk-6781",
+		"set chassis cluster reth-count 2",
+		"set chassis cluster no-private-rg-election",
+		"set interfaces ge-0/0/1 gigether-options redundant-parent bond0",
+		"set interfaces bond0 redundant-ether-options redundancy-group 1",
+		"set interfaces bond0 unit 0 family inet address 10.0.61.1/24",
+	} {
+		path, err := config.ParseSetCommand(l)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", l, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", l, err)
+		}
+	}
+	cfg, err := config.CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("a structurally valid pair must commit: %v", err)
+	}
+	return cfg
+}

--- a/pkg/dataplane/compiler_iface.go
+++ b/pkg/dataplane/compiler_iface.go
@@ -1011,7 +1011,27 @@ func buildInterfaceNetworkdModels(cfg *config.Config, result *CompileResult, see
 				isVRRPReth = rethCfg.RedundancyGroup > 0 && clusterNodeID >= 0
 			}
 		} else {
-			isVRRPReth = ifCfg.RedundancyGroup > 0 && clusterNodeID >= 0
+			// #6781: an interface with no `redundant-parent` is a member of no
+			// redundant pair, and an interface that OWNS one was already skipped
+			// above (the skip keys on RethToPhysical, i.e. on some port naming
+			// it as their redundant-parent). So reaching here with
+			// RedundancyGroup > 0 is exactly the shape #6781 is about:
+			// `redundant-ether-options redundancy-group` on an interface that is
+			// neither a member nor an owner.
+			//
+			// Treating it as a VRRP-backed reth REPLACED the operator's
+			// configured address with a 169.254.<rg>.<node>/32 link-local below
+			// and handed the real address to VRRP as a VIP. In VRRP mode that
+			// demoted a plain L3 interface's address to one that exists only
+			// while MASTER; under `no-reth-vrrp` the direct collector skipped
+			// the interface too, so the address was stripped here and installed
+			// by NOBODY, on both nodes. It also armed the RETH virtual-MAC
+			// recovery search below for a MAC this interface can never carry.
+			//
+			// Commit now rejects the shape (validateRethRedundancyGroupStrict);
+			// this keeps a tolerantly-loaded config that still carries it from
+			// losing the address.
+			isVRRPReth = false
 		}
 
 		linuxName := config.LinuxIfName(ifName)

--- a/pkg/dataplane/reth_rg_networkd_6781_test.go
+++ b/pkg/dataplane/reth_rg_networkd_6781_test.go
@@ -1,0 +1,106 @@
+package dataplane
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6781: buildInterfaceNetworkdModels decided "is this a VRRP-backed reth
+// member?" and, for an interface with NO `redundant-parent`, answered from a
+// bare `RedundancyGroup > 0`. A genuine RG owner never reaches that arm — the
+// skip above it keys on RethToPhysical — so the arm only ever fired on the
+// broken shape: `redundant-ether-options redundancy-group` on an interface that
+// is neither a reth member nor a reth owner.
+//
+// When it fired it REPLACED the operator's configured address with a
+// 169.254.<rg>.<node>/32 link-local and set KeepConfiguration=static, handing
+// the real address to VRRP as a virtual address. Under `no-reth-vrrp` the
+// direct owner skipped the interface too, so the address was stripped here and
+// installed by NOBODY, on both nodes.
+//
+// FAIL-ON-REVERT: restore `isVRRPReth = ifCfg.RedundancyGroup > 0 &&
+// clusterNodeID >= 0` in that else arm and this goes RED — the configured
+// address disappears from the model and a 169.254.x/32 takes its place.
+
+func rethRGNetworkdCfg(t *testing.T) *config.Config {
+	t.Helper()
+	tree := &config.ConfigTree{}
+	for _, l := range []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster authentication-key test-cluster-psk-6781",
+		"set chassis cluster node 0",
+		"set chassis cluster reth-count 2",
+		// Neither a reth member nor a reth owner, but carries a group.
+		"set interfaces ge-0/0/5 redundant-ether-options redundancy-group 1",
+		"set interfaces ge-0/0/5 unit 0 family inet address 10.0.99.1/24",
+	} {
+		path, err := config.ParseSetCommand(l)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", l, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", l, err)
+		}
+	}
+	// Tolerant path: strict commit now rejects this shape, and the point here
+	// is what the generator does with a config that reached it anyway.
+	cfg, err := config.CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile must not brick (#1960): %v", err)
+	}
+	return cfg
+}
+
+func TestNetworkdKeepsAddressOfNonRethCarryingRedundancyGroup(t *testing.T) {
+	cfg := rethRGNetworkdCfg(t)
+	// Seed the netdev so the interface reaches the physical-interface path;
+	// without it the model may be skipped for an unrelated reason and the test
+	// would pass vacuously.
+	result := &CompileResult{ifCache: map[string]*net.Interface{
+		"ge-0-0-5": {
+			Index:        77,
+			Name:         "ge-0-0-5",
+			HardwareAddr: net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x05},
+		},
+	}}
+	buildInterfaceNetworkdModels(cfg, result, map[string]bool{})
+
+	var found bool
+	for _, m := range result.ManagedInterfaces {
+		if m.Name != "ge-0-0-5" {
+			continue
+		}
+		found = true
+		var hasReal, hasLinkLocal bool
+		for _, a := range m.Addresses {
+			if a == "10.0.99.1/24" {
+				hasReal = true
+			}
+			if strings.HasPrefix(a, "169.254.") {
+				hasLinkLocal = true
+			}
+		}
+		if !hasReal {
+			t.Errorf("ge-0-0-5 lost its configured address 10.0.99.1/24 from the "+
+				"networkd model (addresses=%v). It is neither a reth member nor "+
+				"a reth owner, so nothing may substitute a VRRP link-local for "+
+				"its address — under no-reth-vrrp nobody installs the real one "+
+				"back, on either node", m.Addresses)
+		}
+		if hasLinkLocal {
+			t.Errorf("ge-0-0-5 was given a VRRP reth link-local (addresses=%v); "+
+				"it is not a VRRP-backed reth member", m.Addresses)
+		}
+		if m.KeepAddresses {
+			t.Errorf("ge-0-0-5 was marked KeepAddresses (KeepConfiguration=" +
+				"static), which is the VRRP-VIP preservation flag; it owns no VIPs")
+		}
+	}
+	if !found {
+		t.Fatalf("ge-0-0-5 produced no networkd model at all, so this test "+
+			"asserted nothing; models=%d", len(result.ManagedInterfaces))
+	}
+}

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -650,7 +650,7 @@ structural/nominal test already excludes those, which is what the old name
 filter was really providing.
 
 `validateRethRedundancyGroupStrict` (`pkg/config`) rejects the offending shape
-at commit, with `lenientRethRedundancyGroup` for the tolerant load / peer-sync
+at commit, with `lenientRethRGOwnership` for the tolerant load / peer-sync
 path (#1960). A `reth*` with no members yet is deliberately NOT rejected — it is
 an incompletely-wired declaration that both modes accepted before, and
 narrowing it is not what #6781 is about.

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -608,6 +608,59 @@ Guarded by `TestSendPacketIPv6PrependsVirtualRouterLinkLocal` /
 `TestSendPacketIPv6LinkLocalFirstWithMultipleVIPs`, which re-parse the captured
 advert and assert address[0] is the link-local and the Count field includes it.
 
+### Which interfaces own a redundancy group (#6781)
+
+Both ownership modes ask the same question — "does this interface own RG N?" —
+and before #6781 they answered it differently, each with its own reading:
+
+| Reading | Used by | Blind spot |
+|---|---|---|
+| `RedundancyGroup > 0` alone | `CollectRethInstances` (VRRP-backed) | claims an interface that is not a reth at all |
+| + `strings.HasPrefix(name, "reth")` | `RethVIPsForRG` (direct) | drops a structurally valid pair not spelled `reth*` |
+
+**Both were wrong, in opposite directions**, and both shapes committed cleanly:
+
+- `ge-0/0/5 redundant-ether-options redundancy-group 1`, nothing naming it as a
+  `redundant-parent`. VRRP-backed synthesized an instance on it whose "VIPs"
+  were the interface's OWN configured addresses — so they existed only while
+  MASTER and were deleted on BACKUP. networkd generation
+  (`pkg/dataplane/compiler_iface.go`) independently replaced that address with a
+  `169.254.<rg>.<node>/32` link-local. Under `no-reth-vrrp` the direct collector
+  skipped the interface, so the address was stripped and installed by **nobody,
+  on both nodes**.
+- `bond0` with `ge-0/0/1 gigether-options redundant-parent bond0` — a
+  structurally valid redundant pair not spelled `reth*`. VRRP-backed resolved it
+  correctly; the direct collector returned nothing, leaving that group with no
+  VIPs at all.
+
+`Config.RethRGOwners` (`pkg/config/reth_rg_owner.go`) is now the single source
+of truth. An interface owns the group it carries when it is a
+redundant-ethernet interface **structurally** (some port names it as their
+`redundant-parent`) **or nominally** (spelled `reth*`). That is deliberately the
+UNION of the two old readings minus their shared blind spot: it excludes only
+the shape that was actively wrong and includes the shape one mode was dropping,
+so nothing either mode previously owned stops being owned — in HA ownership code
+a newly-excluded interface is an outage.
+
+The `> 0` test lives at the CALLER, not in the predicate: the VRRP-backed
+collector synthesizes instances only for groups above 0, while the direct
+collector is legitimately queried FOR group 0. What an RG-0 query needs
+protecting from is every unconfigured interface defaulting to 0 — and the
+structural/nominal test already excludes those, which is what the old name
+filter was really providing.
+
+`validateRethRedundancyGroupStrict` (`pkg/config`) rejects the offending shape
+at commit, with `lenientRethRedundancyGroup` for the tolerant load / peer-sync
+path (#1960). A `reth*` with no members yet is deliberately NOT rejected — it is
+an incompletely-wired declaration that both modes accepted before, and
+narrowing it is not what #6781 is about.
+
+Bound by two tests, because a behavioural one alone is probe-bounded:
+`reth_rg_parity_6781_test.go` asserts the two modes reach the same conclusion on
+both shapes plus a control, and `reth_rg_ssot_6781_test.go` asserts they still
+read it from one place (neither collector may compare `.RedundancyGroup` or
+name-test for `"reth"` itself).
+
 ### Advert capacity — per-family VIP cardinality (#6779)
 
 RFC 5798 §5.2.4 makes an advertisement's "Count IPvX Addr" a single byte, so

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -655,6 +655,16 @@ path (#1960). A `reth*` with no members yet is deliberately NOT rejected — it 
 an incompletely-wired declaration that both modes accepted before, and
 narrowing it is not what #6781 is about.
 
+**All eight readers now share it.** Besides the two ownership collectors and
+networkd generation, the five `pkg/daemon` readers that decide RG membership for
+stable RETH link-local add/remove, the direct-mode GARP / router-LL burst, DHCP
+RG-scoping and BACKUP blackhole routes each carried their own name test. Left
+alone they would have given a structurally valid pair VIPs from both ownership
+modes and then no GARP, no stable link-local and no blackhole routes — VRRP
+mastering an interface nothing else manages. `rethInterfacesMatchingRG`'s own
+doc comment (#6520) already states the rule: *"Deriving the two from one walker
+is not a style preference: a divergence between them is ALWAYS a bug."*
+
 Bound by two tests, because a behavioural one alone is probe-bounded:
 `reth_rg_parity_6781_test.go` asserts the two modes reach the same conclusion on
 both shapes plus a control, and `reth_rg_ssot_6781_test.go` asserts they still

--- a/pkg/vrrp/reth_rg_parity_6781_test.go
+++ b/pkg/vrrp/reth_rg_parity_6781_test.go
@@ -158,3 +158,49 @@ func TestRethRGOwnersIsTheDiscriminator(t *testing.T) {
 			"NOT own a group; owners=%v", owners)
 	}
 }
+
+// TestCollectRethInstancesSkipsGroupZero pins the `> 0` guard that lives at the
+// CALLER rather than in the shared predicate (see Config.RethRGOwners).
+//
+// RG 0 is the control-plane group and an UNSET redundancy-group also reads as
+// 0, so a reth carrying neither must get no VRRP instance. Without the guard
+// every reth with an unset group would be handed VRID 100 (RethVRRPGroupIDBase
+// + 0) and start advertising — while the direct collector, which is
+// legitimately queried FOR group 0, must still answer for that same reth. The
+// two needs differ, which is exactly why the term is not in the predicate.
+//
+// FAIL-ON-REVERT: drop `|| rgID <= 0` from CollectRethInstances and this reds.
+func TestCollectRethInstancesSkipsGroupZero(t *testing.T) {
+	cfg := compileRethCfg(t, append(rethParityBase(),
+		// A structurally real reth with NO redundancy-group line: rgID 0.
+		"set interfaces ge-0/0/1 gigether-options redundant-parent reth0",
+		"set interfaces reth0 unit 0 family inet address 10.0.61.1/24",
+	))
+
+	// Precondition: the shared predicate DOES own it (at group 0), so the
+	// assertion below is about the caller's guard and not about the predicate
+	// having quietly dropped the interface.
+	owners := cfg.RethRGOwners()
+	if rg, ok := owners["reth0"]; !ok || rg != 0 {
+		t.Fatalf("fixture: reth0 should be owned at group 0, got rg=%d ok=%v "+
+			"(owners=%v)", rg, ok, owners)
+	}
+
+	if insts := CollectRethInstances(cfg, map[int]int{0: 200}); len(insts) != 0 {
+		var got []string
+		for _, i := range insts {
+			got = append(got, i.Interface)
+		}
+		t.Errorf("CollectRethInstances synthesized %d instance(s) %v for "+
+			"redundancy-group 0; RG 0 is the control-plane group and an unset "+
+			"group reads as 0, so no RETH VRRP instance may be created for it",
+			len(insts), got)
+	}
+
+	// The direct collector, by contrast, must still answer for group 0 — the
+	// asymmetry the caller-side guard exists to preserve.
+	if vips := RethVIPsForRG(cfg, 0); len(vips) == 0 {
+		t.Errorf("RethVIPsForRG(0) returned nothing; the direct mode is " +
+			"legitimately queried for group 0 and must still resolve the reth")
+	}
+}

--- a/pkg/vrrp/reth_rg_parity_6781_test.go
+++ b/pkg/vrrp/reth_rg_parity_6781_test.go
@@ -1,0 +1,160 @@
+package vrrp
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6781: the VRRP-backed and direct RETH ownership modes disagreed about which
+// interfaces own a redundancy group, and BOTH readings were wrong — in opposite
+// directions. Measured on configs that committed cleanly:
+//
+//	shape A  `ge-0/0/5 redundant-ether-options redundancy-group 1`, nothing
+//	         naming it as a redundant-parent.
+//	         VRRP-backed INCLUDED it (RedundancyGroup > 0 alone) and made the
+//	         interface's OWN address a VIP — present only while MASTER.
+//	         direct EXCLUDED it (strings.HasPrefix name, "reth")).
+//	         networkd meanwhile replaced that address with a link-local /32, so
+//	         under `no-reth-vrrp` NOBODY installed it, on either node.
+//
+//	shape B  `bond0 redundant-ether-options redundancy-group 1` with
+//	         `ge-0/0/1 gigether-options redundant-parent bond0` — a
+//	         structurally valid redundant pair not spelled "reth*".
+//	         VRRP-backed resolved it correctly; direct returned NOTHING, so the
+//	         group had no VIPs at all.
+//
+// Both modes now resolve ownership through the one shared predicate
+// (config.Config.RethRGOwners), so they agree by construction. These are the
+// BEHAVIOURAL half of the binding; the structural half (that they still read
+// from one place) is reth_rg_ssot_6781_test.go.
+//
+// FAIL-ON-REVERT: restore either reading — the bare `RedundancyGroup > 0` in
+// CollectRethInstances, or the `HasPrefix(name,"reth")` filter in
+// RethVIPsForRG — and the corresponding shape's subtest reports the two modes
+// disagreeing, naming which included and which excluded.
+
+func compileRethCfg(t *testing.T, lines []string) *config.Config {
+	t.Helper()
+	tree := &config.ConfigTree{}
+	for _, l := range lines {
+		path, err := config.ParseSetCommand(l)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", l, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", l, err)
+		}
+	}
+	// The tolerant path: shape A is rejected at strict commit
+	// (validateRethRedundancyGroupStrict), and the point of this test is that
+	// the two RUNTIME modes agree on a config that reached them anyway.
+	cfg, err := config.CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile must not brick (#1960): %v", err)
+	}
+	return cfg
+}
+
+func rethParityBase() []string {
+	return []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster authentication-key test-cluster-psk-6781",
+		"set chassis cluster reth-count 2",
+		"set chassis cluster no-private-rg-election",
+		"set chassis cluster redundancy-group 1 node 0 priority 200",
+	}
+}
+
+// modeVerdicts returns whether each ownership mode considers ANY interface to
+// own RG 1, plus what each resolved to, for reporting.
+func modeVerdicts(cfg *config.Config) (vrrpOwns, directOwns bool, vrrpNames []string, directMap map[string][]string) {
+	for _, inst := range CollectRethInstances(cfg, map[int]int{1: 200}) {
+		vrrpNames = append(vrrpNames, inst.Interface)
+	}
+	directMap = RethVIPsForRG(cfg, 1)
+	return len(vrrpNames) > 0, len(directMap) > 0, vrrpNames, directMap
+}
+
+func TestRethOwnershipModesAgree(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		lines     []string
+		wantOwned bool
+		why       string
+	}{
+		{
+			name: "shape-A/redundancy-group-on-a-non-reth",
+			lines: append(rethParityBase(),
+				"set interfaces ge-0/0/5 redundant-ether-options redundancy-group 1",
+				"set interfaces ge-0/0/5 unit 0 family inet address 10.0.99.1/24",
+			),
+			wantOwned: false,
+			why: "ge-0/0/5 is neither structurally nor nominally a reth, so " +
+				"neither mode may claim it — claiming it turns the interface's " +
+				"own address into a MASTER-only VIP",
+		},
+		{
+			name: "shape-B/structurally-valid-pair-not-named-reth",
+			lines: append(rethParityBase(),
+				"set interfaces ge-0/0/1 gigether-options redundant-parent bond0",
+				"set interfaces bond0 redundant-ether-options redundancy-group 1",
+				"set interfaces bond0 unit 0 family inet address 10.0.61.1/24",
+			),
+			wantOwned: true,
+			why: "ports name bond0 as their redundant-parent, so it IS a " +
+				"redundant-ethernet interface and both modes must own it — " +
+				"excluding it leaves the group with no VIPs at all",
+		},
+		{
+			name: "control/conventional-reth",
+			lines: append(rethParityBase(),
+				"set interfaces ge-0/0/1 gigether-options redundant-parent reth0",
+				"set interfaces reth0 redundant-ether-options redundancy-group 1",
+				"set interfaces reth0 unit 0 family inet address 10.0.61.1/24",
+			),
+			wantOwned: true,
+			why:       "the ordinary shape must keep working unchanged",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := compileRethCfg(t, tc.lines)
+			vrrpOwns, directOwns, vrrpNames, directMap := modeVerdicts(cfg)
+
+			// THE agreement assertion: the two modes reach the same conclusion.
+			if vrrpOwns != directOwns {
+				t.Fatalf("the two RETH ownership modes DISAGREE: "+
+					"VRRP-backed owns=%v (%v), direct owns=%v (%v).\n%s",
+					vrrpOwns, vrrpNames, directOwns, directMap, tc.why)
+			}
+			// …and that the conclusion they agree on is the right one. Without
+			// this, both modes returning nothing would pass the check above.
+			if vrrpOwns != tc.wantOwned {
+				t.Errorf("both modes agree owned=%v, want %v.\n%s",
+					vrrpOwns, tc.wantOwned, tc.why)
+			}
+		})
+	}
+}
+
+// TestRethRGOwnersIsTheDiscriminator pins the PROPERTY the agreement rests on,
+// so the two modes cannot be made to agree on a WRONG answer: ownership is
+// decided by being a redundant-ethernet interface structurally or nominally,
+// never by the redundancy-group value alone.
+func TestRethRGOwnersIsTheDiscriminator(t *testing.T) {
+	cfg := compileRethCfg(t, append(rethParityBase(),
+		"set interfaces ge-0/0/1 gigether-options redundant-parent bond0",
+		"set interfaces bond0 redundant-ether-options redundancy-group 1",
+		"set interfaces bond0 unit 0 family inet address 10.0.61.1/24",
+		"set interfaces ge-0/0/5 redundant-ether-options redundancy-group 1",
+		"set interfaces ge-0/0/5 unit 0 family inet address 10.0.99.1/24",
+	))
+	owners := cfg.RethRGOwners()
+	if _, ok := owners["bond0"]; !ok {
+		t.Errorf("bond0 has member ports and must own its group; owners=%v", owners)
+	}
+	if _, ok := owners["ge-0/0/5"]; ok {
+		t.Errorf("ge-0/0/5 has no member ports and is not named reth*; it must "+
+			"NOT own a group; owners=%v", owners)
+	}
+}

--- a/pkg/vrrp/reth_rg_ssot_6781_test.go
+++ b/pkg/vrrp/reth_rg_ssot_6781_test.go
@@ -1,0 +1,96 @@
+package vrrp
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// #6781 STRUCTURAL half of the binding. TestRethOwnershipModesAgree is
+// behavioural and therefore probe-bounded: it proves the two ownership modes
+// agree on the shapes I thought to write down. It cannot prove they still read
+// the decision from ONE place — a future edit could reintroduce a private
+// reading that happens to agree on those three fixtures and diverge on a fourth.
+//
+// This test asserts the mechanism instead: neither RETH ownership collector may
+// decide ownership from a `RedundancyGroup` comparison or a `"reth"` name test
+// of its own. Both must route through config.RethRGOwners.
+//
+// The two tests fail in different ways on purpose. Deleting the shared
+// predicate and hand-rolling an equivalent reading in both collectors keeps the
+// behavioural test GREEN and reds this one.
+func TestRethOwnershipCollectorsUseTheSharedPredicate(t *testing.T) {
+	src, err := os.ReadFile("vrrp.go")
+	if err != nil {
+		t.Fatalf("read vrrp.go: %v", err)
+	}
+	body := stripLineComments(string(src))
+
+	for _, fn := range []string{"CollectRethInstances", "RethVIPsForRG"} {
+		t.Run(fn, func(t *testing.T) {
+			b, ok := funcBody(body, fn)
+			if !ok {
+				t.Fatalf("could not locate func %s in vrrp.go — this guard is "+
+					"anchored on the function name; rename it here too", fn)
+			}
+			if !strings.Contains(b, "RethRGOwners()") {
+				t.Errorf("%s does not call cfg.RethRGOwners(); RETH redundancy-"+
+					"group ownership must come from the one shared predicate "+
+					"(#6781), or the two ownership modes drift apart again", fn)
+			}
+			// A private re-reading of the same decision.
+			if m := regexp.MustCompile(`\.RedundancyGroup\s*(<=|>=|==|!=|>|<)`).FindString(b); m != "" {
+				t.Errorf("%s compares .RedundancyGroup directly (%q). Ownership "+
+					"is decided by config.RethRGOwners; a local comparison is "+
+					"the divergence #6781 fixed", fn, m)
+			}
+			if strings.Contains(b, `HasPrefix(name, "reth")`) ||
+				strings.Contains(b, `HasPrefix(ifName, "reth")`) {
+				t.Errorf("%s name-tests for \"reth\". That reading excluded a "+
+					"structurally valid pair not spelled reth* and left its "+
+					"group with no VIPs (#6781); use config.RethRGOwners", fn)
+			}
+		})
+	}
+}
+
+// stripLineComments removes //-comments so the scan cannot be satisfied — or
+// tripped — by prose that merely quotes the pattern it looks for.
+func stripLineComments(s string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(s, "\n") {
+		if i := strings.Index(line, "//"); i >= 0 {
+			line = line[:i]
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// funcBody returns the body of the named top-level func by brace matching.
+func funcBody(src, name string) (string, bool) {
+	idx := strings.Index(src, "func "+name+"(")
+	if idx < 0 {
+		return "", false
+	}
+	open := strings.Index(src[idx:], "{")
+	if open < 0 {
+		return "", false
+	}
+	open += idx
+	depth := 0
+	for i := open; i < len(src); i++ {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[open : i+1], true
+			}
+		}
+	}
+	return "", false
+}

--- a/pkg/vrrp/vrrp.go
+++ b/pkg/vrrp/vrrp.go
@@ -173,15 +173,27 @@ func CollectRethInstances(cfg *config.Config, localPriority map[int]int) []*Inst
 	}
 	sort.Strings(names)
 
+	// #6781: RG ownership comes from the shared structural predicate, not from
+	// a bare RedundancyGroup > 0. Built once for the whole walk.
+	rgOwners := cfg.RethRGOwners()
+
 	var instances []*Instance
 	for _, name := range names {
 		ifc := cfg.Interfaces.Interfaces[name]
 		// #6780: skip a present-but-nil interface, matching CollectInstances
 		// above and every RETH-ownership walk in pkg/daemon.
-		if ifc == nil || ifc.RedundancyGroup <= 0 {
+		if ifc == nil {
 			continue
 		}
-		rgID := ifc.RedundancyGroup
+		rgID, owns := rgOwners[name]
+		// RG 0 is the control-plane group; no RETH VRRP instance is
+		// synthesized for it, and an unset redundancy-group also reads as 0.
+		// The `> 0` term lives here rather than in the shared predicate
+		// because the direct collector below is legitimately queried for
+		// group 0 (see Config.RethRGOwners).
+		if !owns || rgID <= 0 {
+			continue
+		}
 
 		pri := localPriority[rgID]
 		if pri == 0 {
@@ -267,17 +279,24 @@ func RethVIPsForRG(cfg *config.Config, rgID int) map[string][]string {
 	rethToPhys := cfg.RethToPhysical()
 
 	result := make(map[string][]string)
+	// #6781: the same structural ownership predicate the VRRP-backed collector
+	// uses. This replaces a `strings.HasPrefix(name, "reth")` filter whose
+	// stated purpose — "skip fabric, control, and management interfaces that
+	// default to RedundancyGroup 0" — is already served by the predicate (those
+	// interfaces own no group), but which ALSO excluded a structurally valid
+	// redundant pair whose owner is not spelled "reth*", leaving that group
+	// with no VIPs installed at all.
+	rgOwners := cfg.RethRGOwners()
+
 	for _, name := range sortedIfNames(cfg) {
 		ifc := cfg.Interfaces.Interfaces[name]
 		// #6780: skip a present-but-nil interface — this is the direct
 		// (no-reth-vrrp / private-rg-election) ownership mode's collector, and
 		// it carried the same raw deref as the VRRP-mode one above.
-		if ifc == nil || ifc.RedundancyGroup != rgID {
+		if ifc == nil {
 			continue
 		}
-		// Only include actual RETH interfaces — skip fabric, control,
-		// and management interfaces that default to RedundancyGroup 0.
-		if !strings.HasPrefix(name, "reth") {
+		if owns, ok := rgOwners[name]; !ok || owns != rgID {
 			continue
 		}
 


### PR DESCRIPTION
## Summary

The VRRP-backed and direct RETH ownership modes each had their own reading of
"does this interface own redundancy group N". Measuring both against real
compiled configs showed **both were wrong, in opposite directions** — so neither
could be adopted as the survivor, and merging one into the other would have
shipped one of the two defects everywhere.

| Reading | Used by | Blind spot |
|---|---|---|
| `RedundancyGroup > 0` alone | `CollectRethInstances` (VRRP-backed) | claims an interface that is not a reth at all |
| + `HasPrefix(name, "reth")` | `RethVIPsForRG` (direct) | drops a structurally valid pair not spelled `reth*` |

Closes #6781

> **Cites re-derived.** The issue body points at `/tmp/opus-review-001.md`
> section R40, which no longer exists. Derived from code by symbol.

## Measured before writing anything

Both shapes below **commit cleanly today**, and both readings were reproduced
from one compiled config rather than from hand-built structs:

**Shape A — `ge-0/0/5` carries `redundancy-group 1`, nothing names it as a
`redundant-parent`.** VRRP-backed *included* it and synthesized an instance
whose "VIPs" were the interface's **own** configured addresses — so they existed
only while MASTER and were deleted on BACKUP. Direct *excluded* it. Meanwhile
networkd generation independently **replaced that address with a
`169.254.<rg>.<node>/32` link-local**. So under `no-reth-vrrp` the address was
stripped by networkd and installed by **nobody, on both nodes** — a plain L3
interface silently loses its address by being given a redundancy group.

**Shape B — `bond0` with `ge-0/0/1 gigether-options redundant-parent bond0`**, a
structurally valid redundant pair not spelled `reth*`. VRRP-backed resolved it
correctly to `ge-0-0-1`; direct returned an **empty map**, leaving that group
with no VIPs at all.

So this is the "both are wrong → third answer + commit gate" case, not a merge
of two readings.

## The predicate

`Config.RethRGOwners` is the single source of truth: an interface owns the group
it carries when it is a redundant-ethernet interface **structurally** (a port
names it as their `redundant-parent`) **or nominally** (spelled `reth*`).

That is deliberately the **union** of the two old readings minus their shared
blind spot — it excludes only the shape that was actively wrong and includes the
shape one mode was dropping, so **nothing either mode previously owned stops
being owned**. In HA ownership code a newly-excluded interface is an outage, so
the direction matters more than the elegance: I did *not* adopt the pure
structural predicate, because it would newly exclude a declared-but-unwired
`reth*` that both modes accept today.

Naming is not used as the *test* of correctness, only as a declaration of
intent: interface names are validated by character class only
(`validate_interface_name.go`), so `reth` is a convention, not a closed
namespace — and rejecting a structurally valid pair for its spelling is the
#6564 "wrong in the rejecting direction" trap that file already records.

**The `> 0` test lives at the caller, not in the predicate.** The VRRP-backed
collector synthesizes instances only for groups above 0; the direct collector is
legitimately queried **for group 0**. Folding `> 0` into the predicate silently
broke the second — caught by `TestCheckVIPReadiness_*`, not by anything I wrote.
What an RG-0 query actually needs protecting from is every unconfigured
interface *defaulting* to 0, and the structural/nominal test already excludes
those. That is what the old name filter was really providing.

## Also fixed: the networkd `else` arm

`buildInterfaceNetworkdModels` treated any `RedundancyGroup > 0` interface with
no `redundant-parent` as a VRRP-backed reth member. A genuine owner never
reaches that arm — the skip above it already keys on `RethToPhysical` — so the
arm only ever fired on the broken shape. It now resolves false, which also
disarms a RETH virtual-MAC recovery search for a MAC such an interface can never
carry.

## Commit gate

`validateRethRedundancyGroupStrict` rejects `redundancy-group` on an interface
that is neither structurally nor nominally a reth, with `lenientRethRGOwnership`
registered for the tolerant load / peer-sync path (#1960 no-brick).

A `reth*` with **no members yet** is deliberately **not** rejected — a
declared-but-unwired interface that the repo's own fixtures and an operator
building a config incrementally both use. Verified against every shipped cluster
config (`docs/ha-cluster*.conf`, `test/incus/xpf-cluster-fw{0,1}.conf`): all ten
RG-carrying interfaces have member ports, so none is newly rejected.

## Test plan

- [x] `go build ./... && go vet ./... && go test -count=1 ./...` — green, 67 packages
- [x] Mutation matrix, 11 cells, all RED — see below
- [ ] **`make test-failover` — NOT RUN.** RETH/VRRP ownership code on the
      shared, lock-protected cluster. Flagged for the team lead; I ran no
      `cluster-*` target.

**Two tests, not one**, because a behavioural test alone is probe-bounded — it
only covers the shapes I thought of:

- `reth_rg_parity_6781_test.go` — the two modes reach the **same** conclusion on
  both shapes plus a control, *and* that the shared conclusion is the right one
  (without the second assertion, both modes returning nothing would pass).
- `reth_rg_ssot_6781_test.go` — **structural**: neither collector may compare
  `.RedundancyGroup` or name-test for `"reth"` itself. Hand-rolling an
  equivalent private reading in both collectors keeps the behavioural test green
  and reds this one. Comments are stripped before scanning so the guard cannot
  be satisfied by prose quoting the pattern it looks for.

### Mutation matrix

Each cell: restored from HEAD, anchor verified to match exactly once, mutation
verified present, `go build ./...` verified, then the **full package suite**,
`-count=1`, **no `-run` filter**.

| Cell | Mutation | Pkg | Result | Assertion that fired |
|---|---|---|---|---|
| P1 | REVERT VRRP mode to bare `RedundancyGroup > 0` | vrrp | **RED** | `the two RETH ownership modes DISAGREE: VRRP-backed owns=true ([ge-0-0-5]), direct owns=false` |
| P2 | REVERT direct mode to the `reth` name filter | vrrp | **RED** | `…DISAGREE: VRRP-backed owns=true ([ge-0-0-1]), direct owns=false` |
| P3 | PREDICATE: structural term only | vrrp | **RED** | `expected the live reth0 instance to still be collected` |
| P4 | PREDICATE: nominal term only | vrrp | **RED** | `both modes agree owned=false, want true` |
| P5 | PREDICATE: own everything | vrrp | **RED** | `both modes agree owned=true, want false` |
| P6 | PREDICATE: re-add `> 0` (breaks the RG-0 query) | daemon | **RED** | `should NOT be ready with interface down` |
| P7 | CALLER: drop the `> 0` guard | vrrp | **RED** \* | `synthesized 1 instance(s) [ge-0-0-1] for redundancy-group 0` |
| P8 | REVERT the networkd `else` arm | dataplane | **RED** \* | `ge-0-0-5 lost its configured address 10.0.99.1/24 (addresses=[169.254.1.1/32])` |
| P9 | DELETE the commit-gate dispatch | config | **RED** | `expected commit to reject redundancy-group on ge-0/0/5` |
| P10 | TIGHTEN gate: also reject a memberless `reth*` | config | **RED** | `in-range reth redundancy-group 1 must commit cleanly` |
| P11 | BREAK #1960 (lenient opt unregistered) | config | **RED** | `lenient compile must not reject (no-brick)` |

\* **P7 and P8 initially SURVIVED** — two mechanisms with no test behind them.
P7: every parity fixture used group 1, so nothing exercised group 0. P8:
`pkg/dataplane` had no test for the shape at all. Both are now covered
(`aa6e8be`) and re-run red. The new RG-0 test asserts the predicate *does* own
the reth at group 0 first, so the assertion is about the caller's guard rather
than the interface having quietly disappeared; the networkd test seeds the
netdev in `ifCache` so the interface really reaches the physical-interface path,
and fails loudly if no model is produced at all.

P10 is the over-rejection control and P6 the tightening control for the
predicate — the gate must not reject what already works.

## All eight readers, not three

The issue's own fix direction names "networkd generation and both owner
implementations" — three sites. That left the agreement **half-bound**: five
`pkg/daemon` readers still decided RG membership with their own name test
(stable RETH link-local add/remove, the direct-mode GARP / router-LL burst,
DHCP RG-scoping, BACKUP blackhole routes).

Left alone, a structurally valid pair would get VIPs from **both** ownership
modes — which this PR had just fixed — and then nothing else: **no GARP, no
stable link-local, and no blackhole routes on BACKUP**, so return traffic
escapes via the default route. That is VRRP mastering an interface nothing else
manages, and fixing only the collectors would have made it *more* reachable,
not less. All eight now read `Config.RethRGOwners`.

`rethInterfacesMatchingRG`'s own doc comment (#6520) already states the rule:
*"Deriving the two from one walker is not a style preference: a divergence
between them is ALWAYS a bug."*

Behaviour is identical on every shipped cluster config — a reth with member
ports satisfies the old name test and the new predicate alike — so the only
shape whose handling changes is the one the name test was dropping. The daemon
readers are bound by their own pair of tests (`pkg/daemon/reth_rg_ssot_6781_test.go`):
structural, that none re-derives membership privately, and behavioural, that the
membership walk resolves the structural pair to its member port.

## Merge note

`origin/master` moved 15 commits during this work; merged (not rebased) and
re-gated at the pushed head. The merge was textually clean but declared one
symbol twice: #6782 landed its own `lenientRethRedundancyGroup` for the same
stanza (a *token* validator, where this is an *ownership* gate). Renamed this
one to `lenientRethRGOwnership`; the two gates are independent and coexist —
verified by a full green suite on the merged tree.

## Refs

- #6781 (this), #6782 (same stanza, token validity — landed during this work)
- #6780 / #6779 (prior work on these collectors), #6722 (`validateRethMemberStrict`,
  the sibling gate this mirrors), #6520 ("a divergence between two readings is
  ALWAYS a bug"), #1960 (no-brick tolerant load), #6564 (wrong-in-the-rejecting-
  direction)
