### PR TITLE
dns: fail the commit closed on a DNS ownership failure

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104695,3 +104695,12 @@ prose edit above them added. No diff falls in the new test body.
   accumulated error.
 - **File(s)**: pkg/daemon/daemon_dns.go, pkg/daemon/daemon_apply_tail.go,
   pkg/daemon/dns_ownership_failclosed_6792_test.go, docs/dns-ownership.md, _Log.md
+- **Timestamp**: 2026-08-22
+- **Action**: #6792 round 2 — the mutation matrix found a GREEN cell: removing
+  `dnsErr` from `applyTailReconciles`' tail `errors.Join` left the whole suite
+  green. The reconcile can return errors all day and the commit still succeeds
+  if nothing joins them, and that join IS the fix. Added a `reconcileDNSFn`
+  seam and two cells driving the REAL `applyTailReconciles` (#5696 precedent),
+  paired so "always returns an error" also fails.
+- **File(s)**: pkg/daemon/daemon.go, pkg/daemon/daemon_dns.go,
+  pkg/daemon/dns_ownership_failclosed_6792_test.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -104679,3 +104679,19 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/devicemap/identity_unread_6786_test.go`,
   `pkg/daemon/device_map_identity_unread_6786_test.go`,
   `docs/bare-metal-device-map.md`, `_Log.md`
+
+## 2026-08-22 — #6792 DNS ownership failures were warning-only
+
+- **Timestamp**: 2026-08-22
+- **Action**: `dnsReconciler.reconcile` logged all three failure points (mask,
+  stale drop-in removal, managed-file write) at WARN and returned nothing;
+  `reconcileDNSLocked` returned nothing, so a commit could report success while
+  leaving a dual resolver or a stale `/etc/resolv.conf`. Its two siblings in
+  `applyTailReconciles` (`applyLo0Filter`, `applyHostInboundFilter`) already
+  fail the commit closed — DNS was the only reconciler there whose error could
+  not propagate. Now accumulates and returns; joined into the commit result.
+  Accumulate-not-return-early preserves the deliberate "still own resolv.conf
+  after a mask failure" behaviour, and both SUCCESS early returns carry the
+  accumulated error.
+- **File(s)**: pkg/daemon/daemon_dns.go, pkg/daemon/daemon_apply_tail.go,
+  pkg/daemon/dns_ownership_failclosed_6792_test.go, docs/dns-ownership.md, _Log.md

--- a/docs/dns-ownership.md
+++ b/docs/dns-ownership.md
@@ -96,6 +96,52 @@ branch. The stanza is accepted but emits a commit-check warning; the
 runtime still owns `/etc/resolv.conf` directly with resolved
 disabled+masked. There is exactly one DNS owner.
 
+## Failure handling (#6792)
+
+Every step of the reconcile — disable+mask `systemd-resolved`, remove stale
+resolved drop-ins, write the managed `/etc/resolv.conf` — used to log at WARN
+and continue, and neither `reconcile` nor `reconcileDNSLocked` returned
+anything, so nothing could propagate. **A commit reported success while leaving
+one of two states the operator did not ask for:**
+
+- **dual resolver** — the disable+mask failed, `systemd-resolved` keeps running,
+  and xpf still writes `/etc/resolv.conf`. xpf's own networkd `.network` files
+  carry `UseDNS=yes`, so a surviving resolved is independently fed DHCP
+  nameservers;
+- **stale `/etc/resolv.conf`** — the write failed *after* the mask and drop-in
+  removal had already run, so resolved is gone and the file is not current.
+
+There is no retry, no ticker and no metric behind either, so an unreported
+failure persisted until the next commit happened to succeed.
+
+The reconcile now ACCUMULATES its failures and returns them.
+`applyTailReconciles` joins the result into the commit error alongside
+`lo0Err` / `hostInboundErr` — its two siblings in that same function, which
+already fail the commit closed (#3392, #3333). `reconcileDNS` sat between them
+as a bare statement and was the only reconciler there whose error could not
+propagate.
+
+Two properties are deliberately preserved:
+
+- **Accumulate, do not return early.** The pre-#6792 control flow is correct: a
+  mask failure still writes `/etc/resolv.conf`, because a static file wins over
+  an inactive stub. Returning at the first failure would make a systemd hiccup
+  *also* cost the resolver file. Only the reporting changed.
+- **The two SUCCESS early returns still carry accumulated errors.** The boot
+  empty-merge policy and the idempotence skip both run *after* the mask and
+  drop-in steps. Returning a bare `nil` there would report success for exactly
+  the steady-state pass where nothing else changed and a mask failure was the
+  only news — i.e. every pass on a converged system.
+
+`disableMaskResolved` was already idempotent and quiet — it returns success on a
+systemd-less host, when the unit is already `masked`, and when it is
+`not-found` — so a non-nil error genuinely means the desired end state was not
+reached. Failing the commit on it does not affect hosts without resolved.
+
+The DHCP-lease callback (`reconcileDNSFromDHCP`) logs instead of returning:
+there is no commit to fail, the end state is the same, and the next commit or
+lease change re-drives the idempotent reconcile.
+
 ## Operator notes
 
 - To inspect: `cat /etc/resolv.conf` (a real file beginning with

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -130,7 +130,14 @@ type Daemon struct {
 	// once after the boot apply and read only under applySem in
 	// reconcileDNSLocked.
 	dnsBootDone bool
-	dhcpServer  *dhcpserver.Manager
+
+	// reconcileDNSFn overrides the DNS reconcile (#6792). Nil means the real
+	// one. It exists so a test can drive the REAL applyTailReconciles and prove
+	// a DNS failure reaches the commit result — before #6792 that error could
+	// not propagate at all, and the per-function cells stay green if the join
+	// is removed again.
+	reconcileDNSFn func(*config.Config, bool) error
+	dhcpServer     *dhcpserver.Manager
 	// ddns is the always-on DHCP dynamic-DNS manager (#1387 inc-2). It is
 	// constructed UNCONDITIONALLY at daemon start (plan §4.2) — even when
 	// DDNS is disabled — so an enabled→disabled commit always has a running

--- a/pkg/daemon/daemon_apply_tail.go
+++ b/pkg/daemon/daemon_apply_tail.go
@@ -66,7 +66,18 @@ func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, 
 	// /etc/resolv.conf a dangling symlink. bootEmptyRepairOnly is set
 	// before DHCP clients start so the first apply does not blank a good
 	// resolv.conf when no static name-server is configured yet.
-	d.reconcileDNSLocked(cfg, !d.dnsBootDone)
+	// #6792: joined into the commit result, not swallowed at WARN. Its two
+	// siblings in this same function — applyLo0Filter and
+	// applyHostInboundFilter — are both captured and joined; reconcileDNS sat
+	// between them as a bare statement and was the ONLY reconciler here whose
+	// error could not propagate. A failed disable+mask leaves systemd-resolved
+	// as a second resolver owner (and xpf's own networkd .network files carry
+	// UseDNS=yes, so a surviving resolved is independently fed DHCP
+	// nameservers); a failed write leaves /etc/resolv.conf stale AFTER the mask
+	// and drop-in removal have already run. Both reported a successful commit.
+	// The remaining apply steps still run, matching the lo0/host-inbound
+	// pattern: management/SSH reconcile is never skipped by a DNS failure.
+	dnsErr := d.reconcileDNSLocked(cfg, !d.dnsBootDone)
 	d.applySystemNTP(cfg)
 
 	// 9.5. Apply system hostname, timezone, and kernel tuning
@@ -351,7 +362,7 @@ func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, 
 	// that left stale or missing kernel/swanctl/dataplane state fails the commit
 	// (fail-closed) instead of reporting success. All are joined so none masks the
 	// other.
-	return errors.Join(networkdErr, applyErr, dhcpServerErr, hostInboundErr, lo0Err, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr, mgmtRouteErr, vrfErr, vrrpErr)
+	return errors.Join(networkdErr, applyErr, dhcpServerErr, hostInboundErr, lo0Err, dnsErr, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr, mgmtRouteErr, vrfErr, vrrpErr)
 }
 
 // reconcileDHCPRelay re-applies the DHCP relay config on every commit (#2348).

--- a/pkg/daemon/daemon_dns.go
+++ b/pkg/daemon/daemon_dns.go
@@ -369,6 +369,13 @@ func disableMaskResolved() error {
 // later commit / DHCP change passes false so clearing DNS truly clears
 // the file.
 func (d *Daemon) reconcileDNSLocked(cfg *config.Config, bootEmptyRepairOnly bool) error {
+	// #6792: test seam. The reconcile's own failures are covered directly
+	// against a dnsReconciler; this exists so a test can drive the REAL
+	// applyTailReconciles and prove the error actually reaches the commit
+	// result — the wiring the per-function cells cannot see.
+	if d.reconcileDNSFn != nil {
+		return d.reconcileDNSFn(cfg, bootEmptyRepairOnly)
+	}
 	var leases []*dhcp.Lease
 	if d.dhcp != nil {
 		leases = d.dhcp.Leases()

--- a/pkg/daemon/daemon_dns.go
+++ b/pkg/daemon/daemon_dns.go
@@ -194,7 +194,23 @@ func mergeDNSInput(cfg *config.Config, leases []*dhcp.Lease) system.ResolvedDrop
 // declarative "clear DNS" and the managed file is written so removing
 // all name-servers / expiring the last lease actually clears the
 // resolver instead of leaking stale servers.
-func (r *dnsReconciler) reconcile(in system.ResolvedDropinInput, bootEmptyRepairOnly bool) {
+func (r *dnsReconciler) reconcile(in system.ResolvedDropinInput, bootEmptyRepairOnly bool) error {
+	// #6792: every failure below is ACCUMULATED and returned rather than left
+	// at WARN. Each one leaves the host in a resolver state the operator did
+	// not ask for — a live systemd-resolved alongside xpf's managed file (and
+	// xpf's own networkd .network files carry UseDNS=yes, so a surviving
+	// resolved is independently fed DHCP nameservers), or a stale
+	// /etc/resolv.conf whose write failed AFTER the mask and drop-in removal
+	// already ran. A commit reported success either way, and there is no
+	// retry, no ticker and no metric behind it.
+	//
+	// Accumulate rather than return early: the pre-#6792 control flow is
+	// deliberate — a mask failure still writes resolv.conf, because a static
+	// file wins over an inactive stub — and returning at the first failure
+	// would make a systemd hiccup ALSO skip the resolver write. So the
+	// sequence is unchanged; only its reporting is.
+	var errs []error
+
 	// Always converge resolved off + remove stale drop-ins, regardless of
 	// whether resolv.conf needs rewriting, so a previously-installed
 	// drop-in / running resolved is cleaned up even on an idempotent pass.
@@ -203,10 +219,12 @@ func (r *dnsReconciler) reconcile(in system.ResolvedDropinInput, bootEmptyRepair
 		// owner. Still own resolv.conf (a static file wins over an
 		// inactive stub), but surface the failure loudly.
 		slog.Warn("DNS: failed to disable+mask systemd-resolved; it may remain a second resolver owner", "err", err)
+		errs = append(errs, fmt.Errorf("disable+mask systemd-resolved: %w", err))
 	}
 	for _, p := range []string{r.legacyResolvedDropin, r.xpfResolvedDropin} {
 		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
 			slog.Warn("DNS: failed to remove stale resolved drop-in", "path", p, "err", err)
+			errs = append(errs, fmt.Errorf("remove stale resolved drop-in %s: %w", p, err))
 		}
 	}
 
@@ -224,24 +242,26 @@ func (r *dnsReconciler) reconcile(in system.ResolvedDropinInput, bootEmptyRepair
 	// file. Keyed on the nameserver set, not in.Empty(), so a
 	// domain-name/domain-search-only config does not blank a good file.
 	if len(in.NameServers) == 0 && bootEmptyRepairOnly && !isSymlink && !missing && lerr == nil {
-		return
+		return errors.Join(errs...)
 	}
 
 	// Idempotence: if the target is already a regular file with identical
 	// content, skip the rewrite (and the restart churn it would imply).
 	if !isSymlink && lerr == nil {
 		if cur, err := os.ReadFile(r.resolvConfPath); err == nil && string(cur) == content {
-			return
+			return errors.Join(errs...)
 		}
 	}
 
 	if err := r.atomicWrite(content); err != nil {
 		slog.Warn("DNS: failed to write managed /etc/resolv.conf", "path", r.resolvConfPath, "err", err)
-		return
+		errs = append(errs, fmt.Errorf("write managed %s: %w", r.resolvConfPath, err))
+		return errors.Join(errs...)
 	}
 	slog.Info("DNS: reconciled managed /etc/resolv.conf",
 		"servers", in.NameServers, "domain", in.DomainName, "search", in.DomainSearch,
 		"replaced_symlink", isSymlink)
+	return errors.Join(errs...)
 }
 
 // atomicWrite replaces resolvConfPath with content via
@@ -348,13 +368,13 @@ func disableMaskResolved() error {
 // start) so an empty merge does not blank a pre-existing good file; a
 // later commit / DHCP change passes false so clearing DNS truly clears
 // the file.
-func (d *Daemon) reconcileDNSLocked(cfg *config.Config, bootEmptyRepairOnly bool) {
+func (d *Daemon) reconcileDNSLocked(cfg *config.Config, bootEmptyRepairOnly bool) error {
 	var leases []*dhcp.Lease
 	if d.dhcp != nil {
 		leases = d.dhcp.Leases()
 	}
 	in := mergeDNSInput(cfg, leases)
-	newDNSReconciler().reconcile(in, bootEmptyRepairOnly)
+	return newDNSReconciler().reconcile(in, bootEmptyRepairOnly)
 }
 
 // reconcileDNSFromDHCP is the DHCP-callback entry point. It acquires
@@ -373,5 +393,15 @@ func (d *Daemon) reconcileDNSFromDHCP() {
 	}
 	defer d.applySem.Release(1)
 	cfg := d.store.ActiveConfig()
-	d.reconcileDNSLocked(cfg, false)
+	// #6792: no commit to fail here — this is a lease-change callback, not an
+	// operator action — so the failure is logged rather than returned. It is
+	// logged at WARN with the same wording the commit path surfaces, because
+	// the end state is identical (a second resolver owner, or a stale
+	// resolv.conf) and an operator reading the log after a DHCP change needs
+	// the same signal a commit would have given them. The next commit or lease
+	// change re-drives the reconcile, which is idempotent.
+	if err := d.reconcileDNSLocked(cfg, false); err != nil {
+		slog.Warn("DNS: reconcile after a DHCP change did not reach the "+
+			"declared resolver state", "err", err)
+	}
 }

--- a/pkg/daemon/dns_ownership_failclosed_6792_test.go
+++ b/pkg/daemon/dns_ownership_failclosed_6792_test.go
@@ -25,7 +25,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/daemon/system"
+	"github.com/psaab/xpf/pkg/networkd"
+	"github.com/psaab/xpf/pkg/vrrp"
 )
 
 func dnsInput6792() system.ResolvedDropinInput {
@@ -193,4 +196,97 @@ func TestReconcileEarlyReturnsStillCarryTheirErrors6792(t *testing.T) {
 			t.Fatalf("the boot policy clobbered a good resolv.conf:\n%s", got)
 		}
 	})
+}
+
+// TestApplyTailReconcilesSurfacesTheDNSError6792 binds the WIRING, which every
+// cell above is blind to.
+//
+// The reconcile can return errors all day and the commit still succeeds if
+// applyTailReconciles does not join them — and that join is the entire fix.
+// Removing `dnsErr` from the tail errors.Join left the whole suite green until
+// this cell existed.
+//
+// It drives the REAL applyTailReconciles, following the #5696 precedent for the
+// route-leak slot: the nft seams are stubbed to succeed so the injected DNS
+// error is the only operand that can surface.
+func TestApplyTailReconcilesSurfacesTheDNSError6792(t *testing.T) {
+	installFakeNetworkctl(t)
+
+	origApply, origDelete := nftApplyPayload, nftDeleteTable
+	nftApplyPayload = func(string) ([]byte, error) { return nil, nil }
+	nftDeleteTable = func(string, string) ([]byte, error) { return nil, nil }
+	t.Cleanup(func() { nftApplyPayload, nftDeleteTable = origApply, origDelete })
+
+	d := &Daemon{
+		networkd: networkd.NewInDir(t.TempDir()),
+		store:    newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		vrrpMgr:  vrrp.NewManager(),
+		opts:     Options{NoDataplane: true},
+	}
+	d.setDataplane(&runtimeOnlyApplyTestDP{})
+
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{0: {Number: 0}}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {Name: "trust", Interfaces: []string{"reth0.0"}},
+	}
+
+	injected := errors.New("injected: systemd-resolved may remain a second owner")
+	called := 0
+	d.reconcileDNSFn = func(*config.Config, bool) error {
+		called++
+		return injected
+	}
+
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	if called == 0 {
+		t.Fatal("applyTailReconciles never ran the DNS reconcile, so this cell " +
+			"cannot distinguish a joined error from a dropped one")
+	}
+	if err == nil {
+		t.Fatal("applyTailReconciles returned nil while the DNS reconcile FAILED " +
+			"— the commit reports success with a possible dual resolver or a " +
+			"stale /etc/resolv.conf, which is the whole of #6792")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("the commit error does not include the DNS failure via the tail "+
+			"errors.Join wiring, got %v", err)
+	}
+}
+
+// TestApplyTailReconcilesIsCleanWhenDNSSucceeds6792 is the paired control: with
+// the same harness and a SUCCEEDING DNS reconcile the tail must return nil.
+// Without it, the cell above is satisfied by an applyTailReconciles that always
+// returns an error — which would fail every commit.
+func TestApplyTailReconcilesIsCleanWhenDNSSucceeds6792(t *testing.T) {
+	installFakeNetworkctl(t)
+
+	origApply, origDelete := nftApplyPayload, nftDeleteTable
+	nftApplyPayload = func(string) ([]byte, error) { return nil, nil }
+	nftDeleteTable = func(string, string) ([]byte, error) { return nil, nil }
+	t.Cleanup(func() { nftApplyPayload, nftDeleteTable = origApply, origDelete })
+
+	d := &Daemon{
+		networkd: networkd.NewInDir(t.TempDir()),
+		store:    newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		vrrpMgr:  vrrp.NewManager(),
+		opts:     Options{NoDataplane: true},
+	}
+	d.setDataplane(&runtimeOnlyApplyTestDP{})
+
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{0: {Number: 0}}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {Name: "trust", Interfaces: []string{"reth0.0"}},
+	}
+	d.reconcileDNSFn = func(*config.Config, bool) error { return nil }
+
+	if err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil); err != nil {
+		t.Fatalf("applyTailReconciles returned %v with a SUCCEEDING DNS "+
+			"reconcile — every commit would now fail closed on DNS", err)
+	}
 }

--- a/pkg/daemon/dns_ownership_failclosed_6792_test.go
+++ b/pkg/daemon/dns_ownership_failclosed_6792_test.go
@@ -1,0 +1,196 @@
+package daemon
+
+// dns_ownership_failclosed_6792_test.go — #6792.
+//
+// Every failure in the DNS reconcile was WARN-only and `reconcile` /
+// `reconcileDNSLocked` both returned nothing, so nothing could propagate. A
+// commit reported success while leaving one of two states the operator did not
+// ask for:
+//
+//   - DUAL RESOLVER: the disable+mask failed, systemd-resolved keeps running,
+//     and xpf still writes /etc/resolv.conf. xpf's own networkd .network files
+//     carry UseDNS=yes, so the surviving resolved is independently fed DHCP
+//     nameservers.
+//   - STALE resolv.conf: the write failed AFTER the mask and drop-in removal
+//     had already run.
+//
+// No retry, no ticker, no metric — and the pre-existing tests stubbed
+// disableMaskResolved to always return nil, so no failure path was covered at
+// all.
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/daemon/system"
+)
+
+func dnsInput6792() system.ResolvedDropinInput {
+	return system.ResolvedDropinInput{NameServers: []string{"1.1.1.1"}}
+}
+
+// TestReconcileReturnsAMaskFailure6792 is PAIRED: the same reconcile, two
+// disable+mask outcomes, opposite returns.
+//
+// The success leg is load-bearing. Without it, "returns an error when the mask
+// fails" is satisfied by a reconcile that returns an error unconditionally,
+// which would fail every commit on every system.
+func TestReconcileReturnsAMaskFailure6792(t *testing.T) {
+	maskErr := errors.New("simulated: systemctl mask refused")
+
+	t.Run("mask-fails", func(t *testing.T) {
+		dir := t.TempDir()
+		r, _ := newTestReconciler(t, dir)
+		r.disableMaskResolved = func() error { return maskErr }
+
+		err := r.reconcile(dnsInput6792(), false)
+		if err == nil {
+			t.Fatal("reconcile returned nil after the disable+mask FAILED — " +
+				"systemd-resolved may still be running as a second resolver " +
+				"owner and the commit reports success (#6792)")
+		}
+		if !errors.Is(err, maskErr) {
+			t.Fatalf("returned error does not wrap the mask failure: %v", err)
+		}
+
+		// Behaviour preserved: a mask failure must NOT skip the resolv.conf
+		// write. A static file wins over an inactive stub, and returning early
+		// would make a systemd hiccup also cost the resolver file.
+		got := readFile(t, filepath.Join(dir, "resolv.conf"))
+		if !strings.Contains(got, "1.1.1.1") {
+			t.Fatalf("resolv.conf was not written after a mask failure:\n%s", got)
+		}
+	})
+
+	t.Run("mask-succeeds", func(t *testing.T) {
+		dir := t.TempDir()
+		r, calls := newTestReconciler(t, dir)
+
+		if err := r.reconcile(dnsInput6792(), false); err != nil {
+			t.Fatalf("reconcile returned %v on the healthy path — every commit "+
+				"would now fail closed on DNS", err)
+		}
+		if *calls == 0 {
+			t.Fatal("the fixture never called disable+mask, so the failing leg " +
+				"above is not exercising the path this test claims")
+		}
+	})
+}
+
+// TestReconcileReturnsAWriteFailure6792 covers the other reachable end state:
+// the mask and drop-in removal have already run, and the write fails, so
+// /etc/resolv.conf is stale while resolved is gone — the host has no working
+// resolver and the commit said success.
+//
+// The failure is induced by making the target path a DIRECTORY, so both the
+// atomic rename and its bind-mount in-place fallback fail. That is a real
+// filesystem refusal rather than a stubbed error, so it also exercises
+// atomicWrite's fallback chain.
+func TestReconcileReturnsAWriteFailure6792(t *testing.T) {
+	dir := t.TempDir()
+	r, _ := newTestReconciler(t, dir)
+	if err := os.MkdirAll(r.resolvConfPath, 0o755); err != nil {
+		t.Fatalf("seed a directory at the resolv.conf path: %v", err)
+	}
+
+	err := r.reconcile(dnsInput6792(), false)
+	if err == nil {
+		t.Fatal("reconcile returned nil after the managed resolv.conf write " +
+			"FAILED — the mask and drop-in removal already ran, so the host is " +
+			"left with a stale (here: unwritable) resolver file and the commit " +
+			"reports success (#6792)")
+	}
+	if !strings.Contains(err.Error(), "write managed") {
+		t.Fatalf("returned error does not name the write failure: %v", err)
+	}
+}
+
+// TestReconcileReturnsADropinRemovalFailure6792 covers the third warn-only
+// point. A surviving drop-in re-arms resolved's view of the nameservers if it
+// is ever unmasked, so failing to remove it is a failure to reach the declared
+// end state — not a cosmetic one.
+//
+// Induced by making the drop-in a NON-EMPTY DIRECTORY, which os.Remove refuses
+// with something other than IsNotExist.
+func TestReconcileReturnsADropinRemovalFailure6792(t *testing.T) {
+	dir := t.TempDir()
+	r, _ := newTestReconciler(t, dir)
+	if err := os.MkdirAll(filepath.Join(r.xpfResolvedDropin, "child"), 0o755); err != nil {
+		t.Fatalf("seed an unremovable drop-in: %v", err)
+	}
+
+	err := r.reconcile(dnsInput6792(), false)
+	if err == nil {
+		t.Fatal("reconcile returned nil after a stale resolved drop-in could " +
+			"not be removed (#6792)")
+	}
+	if !strings.Contains(err.Error(), "remove stale resolved drop-in") {
+		t.Fatalf("returned error does not name the drop-in removal: %v", err)
+	}
+
+	// The write still happened: a drop-in that will not go away must not cost
+	// the resolver file too.
+	got := readFile(t, filepath.Join(dir, "resolv.conf"))
+	if !strings.Contains(got, "1.1.1.1") {
+		t.Fatalf("resolv.conf was not written after a drop-in removal failure:\n%s", got)
+	}
+}
+
+// TestReconcileEarlyReturnsStillCarryTheirErrors6792 is the cell a naive
+// accumulator fails.
+//
+// `reconcile` has two SUCCESS early-returns — the boot empty-merge policy and
+// the idempotence skip — that run AFTER the mask and drop-in steps. An
+// implementation that accumulated errors but returned a bare `nil` at those
+// two points would report success for exactly the pass where nothing else
+// changed and the mask failure was the only news.
+func TestReconcileEarlyReturnsStillCarryTheirErrors6792(t *testing.T) {
+	maskErr := errors.New("simulated: systemctl mask refused")
+
+	t.Run("idempotence-skip", func(t *testing.T) {
+		dir := t.TempDir()
+		r, _ := newTestReconciler(t, dir)
+		// Converge first so the content matches and the next pass skips.
+		if err := r.reconcile(dnsInput6792(), false); err != nil {
+			t.Fatalf("precondition reconcile: %v", err)
+		}
+		r.disableMaskResolved = func() error { return maskErr }
+
+		err := r.reconcile(dnsInput6792(), false)
+		if err == nil {
+			t.Fatal("the idempotence skip swallowed a mask failure — on a " +
+				"steady-state config that is EVERY pass, so a resolved that " +
+				"came back would never be reported (#6792)")
+		}
+		if !errors.Is(err, maskErr) {
+			t.Fatalf("idempotent pass lost the mask failure: %v", err)
+		}
+	})
+
+	t.Run("boot-empty-repair-only", func(t *testing.T) {
+		dir := t.TempDir()
+		r, _ := newTestReconciler(t, dir)
+		// A good regular file already present + no nameservers + boot policy
+		// = the leave-it-alone early return.
+		if err := os.WriteFile(r.resolvConfPath, []byte("nameserver 9.9.9.9\n"), 0o644); err != nil {
+			t.Fatalf("seed a good resolv.conf: %v", err)
+		}
+		r.disableMaskResolved = func() error { return maskErr }
+
+		err := r.reconcile(system.ResolvedDropinInput{}, true)
+		if err == nil {
+			t.Fatal("the boot empty-merge early return swallowed a mask " +
+				"failure (#6792)")
+		}
+		if !errors.Is(err, maskErr) {
+			t.Fatalf("boot early return lost the mask failure: %v", err)
+		}
+		// The policy itself is unchanged: the good file is left alone.
+		if got := readFile(t, r.resolvConfPath); !strings.Contains(got, "9.9.9.9") {
+			t.Fatalf("the boot policy clobbered a good resolv.conf:\n%s", got)
+		}
+	})
+}


### PR DESCRIPTION
Closes #6792

## What was wrong

All three failure points in the DNS reconcile logged at WARN and continued, and
neither `reconcile` nor `reconcileDNSLocked` returned anything — so nothing
could propagate. A commit reported **success** while leaving one of two states
the operator did not ask for:

- **dual resolver** — the disable+mask failed, `systemd-resolved` keeps running,
  and xpf still writes `/etc/resolv.conf`. xpf's own networkd `.network` files
  carry `UseDNS=yes`, so the surviving resolved is independently fed DHCP
  nameservers.
- **stale `/etc/resolv.conf`** — the write failed *after* the mask and drop-in
  removal had already run, so resolved is gone and the file is not current.

Neither has a retry, a ticker, or a metric behind it, so an unreported failure
persisted until some later commit happened to succeed.

**The asymmetry is the evidence.** In `applyTailReconciles`, `applyLo0Filter`
and `applyHostInboundFilter` are both captured and joined into the commit result
(#3392, #3333 — for exactly this fail-open reason). `reconcileDNSLocked` sat
between them as a bare statement and was the **only** reconciler in that function
whose error could not propagate.

The issue's evidence was already re-derived at `39f1f8b93` by whoever filed it;
I verified each cite against current master rather than trusting it.

## Two properties deliberately preserved

**Accumulate, do not return early.** The pre-#6792 control flow is correct — a
mask failure still writes `resolv.conf`, because a static file wins over an
inactive stub. Returning at the first failure would make a systemd hiccup *also*
cost the resolver file. Only the reporting changed.

**Both SUCCESS early returns carry the accumulated error.** The boot empty-merge
policy and the idempotence skip run *after* the mask and drop-in steps. A bare
`nil` there would report success for exactly the steady-state pass where nothing
else changed and a mask failure was the only news — on a converged system, that
is every pass.

Failing the commit on `disableMaskResolved` is safe because it was already
idempotent and quiet: success on a systemd-less host, on an already-`masked`
unit, and on `not-found`. A non-nil error genuinely means the end state was not
reached.

The DHCP-lease callback logs instead of returning — there is no commit to fail,
the end state is identical, and the next commit or lease change re-drives the
idempotent reconcile.

## Mutation matrix

Fix committed FIRST. Every cell runs the full `pkg/daemon` suite with
`go test -count=1`, no `-run` filter; each mutation verified applied on a
building, vetting tree. **9 cells, all RED.**

| cell | result | assertion |
|---|---|---|
| M1 mask failure not accumulated | RED | `...ReturnsAMaskFailure6792`; `...EarlyReturnsStillCarry...` |
| M2 write failure not accumulated | RED | `...ReturnsAWriteFailure6792` |
| M3 drop-in removal failure not accumulated | RED | `...ReturnsADropinRemovalFailure6792` |
| M4 idempotence early return drops accumulated errors | RED | `...EarlyReturnsStillCarryTheirErrors6792` |
| M5 boot early return drops accumulated errors | RED | same |
| **M6 commit result no longer joins the DNS error** | GREEN → fixed → RED | `...ApplyTailReconcilesSurfacesTheDNSError6792` |
| **M7 TIGHTEN: mask failure returns EARLY (skips the resolv.conf write)** | RED | `...ReturnsAMaskFailure6792` |
| **M8 TIGHTEN: reconcile always returns an error** | RED | 2 cells |

### The green cell is the one that matters

**M6.** Every round-1 cell covered the reconcile's own return value — and the
reconcile can return errors all day while the commit still succeeds if nothing
joins them. **That join is the entire fix**, and removing it left the whole suite
green.

Binding it needs a seam, because the real failures are filesystem and systemd
conditions a tail-level test cannot induce without also breaking the twelve other
reconcilers in that function. So `reconcileDNSLocked` consults `reconcileDNSFn`,
and two cells drive the **real** `applyTailReconciles` with the nft seams stubbed
to succeed — the #5696 precedent for the route-leak slot — so the injected DNS
error is the only operand that can surface. Paired with a succeeding-DNS control,
because "surfaces the DNS error" is otherwise satisfied by a tail that always
returns one, which would fail every commit. The failing cell also asserts the
reconcile was actually called, so it cannot pass by never reaching DNS.

M7 and M8 are the tightening pair around the accumulate decision: returning
early on a mask failure (skipping the resolv.conf write) reds, and returning an
error unconditionally reds.

## Test design

The pre-existing `daemon_dns_test.go` stubs `disableMaskResolved` to always
return `nil`, so **no failure path had any coverage at all**. The new cells
induce real filesystem refusals rather than stubbed errors where possible: a
directory at the `resolv.conf` path defeats both the atomic rename *and* its
bind-mount in-place fallback, and a non-empty directory at the drop-in path
defeats `os.Remove` with something other than `IsNotExist`. The mask cell also
asserts `resolv.conf` was still written, pinning the preserved behaviour.

## Gates

`go build ./... && go vet ./... && go test -count=1 ./...` — all rc=0, 67
packages, at head `6f09464ea`, tree clean. Go only; nothing moves the
`userspace-dp` binary or the shim `.o`, so no cargo leg. No cluster, VRRP,
session-sync or failover code touched — no smoke owed.
