### PR TITLE
daemon: refuse the bootstrap lifeline on an incomplete addressing read (#6789)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104702,3 +104702,28 @@ prose edit above them added. No diff falls in the new test body.
   every cell. Added the queue-behind-a-commit interleave, a loop-body cell with
   a shortened interval, and a comment-stripped source check on the start site.
 - **File(s)**: pkg/daemon/ra_dead_sender_retry_6793_test.go, _Log.md
+
+## 2026-08-22 — #6789 bootstrap lifeline refuses on an incomplete addressing snapshot
+
+- **Timestamp**: 2026-08-22
+- **Action**: `interfaceAddrSnapshot` returned empty slices on a `LinkByName`
+  failure and discarded the `AddrList` error; the writer's
+  `isDHCPManaged(x) || (len(v4)==0 && len(v6)==0)` then took the DHCP branch, so
+  a statically-addressed mgmt NIC got a `DHCP=yes` .network and was renamed
+  (link cycle) — a lockout on a box reachable only over that NIC. Replaced both
+  helpers with one typed `snapshotLifelineAddrs` returning an error, added
+  injectable netlink seams, and made `setupBootstrapLifeline` abort BEFORE the
+  .link write, rename and reload.
+- **The two helpers failed in OPPOSITE directions**: `isDHCPManaged` is
+  documented to fail toward static (safe); `interfaceAddrSnapshot` failed toward
+  empty, which defeated it through the OR. They were two netlink walks over one
+  state; now one.
+- **Scoping (caught by a pre-existing test)**: the first version refused
+  unconditionally and reddened `TestSetupBootstrapLifelineAppliance` — the
+  #7114 appliance factory boot has NO default route and no addressing by design,
+  and DHCP is the image's contract. The refusal is now scoped to a lifeline
+  chosen by DEFAULT ROUTE (positive evidence of live addressing); a route-dump
+  failure is fatal only for a family the snapshot has addresses in.
+- **File(s)**: `pkg/daemon/bootstrap.go`,
+  `pkg/daemon/lifeline_snapshot_failclosed_6789_test.go`,
+  `pkg/daemon/README.md`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -104817,6 +104817,18 @@ prose edit above them added. No diff falls in the new test body.
   and DHCP is the image's contract. The refusal is now scoped to a lifeline
   chosen by DEFAULT ROUTE (positive evidence of live addressing); a route-dump
   failure is fatal only for a family the snapshot has addresses in.
+- **Second, more dangerous defect in the same issue (selection half)**:
+  `detectLifelineInterface` discarded the `RouteList` error and returned
+  `("", false)` — indistinguishable from "no default route" — and the caller
+  branches on exactly that: `applianceFactory := routeIface == "" &&
+  d.applianceFactoryBoot()`. On an appliance box a netlink error therefore
+  flipped selection to "claim the FIRST ENUMERATED NIC" and renamed it
+  (`renameInterface` = LinkSetDown/LinkSetName/LinkSetUp, i.e. the NIC cycle).
+  Now returns an error; the caller refuses when the route state is UNKNOWN.
+  Guard keys on the observation FAILING, never on an empty routeIface (keying on
+  empty would strand every factory image console-only). A found+resolved route
+  is positive identification and survives a partial error.
 - **File(s)**: `pkg/daemon/bootstrap.go`,
   `pkg/daemon/lifeline_snapshot_failclosed_6789_test.go`,
+  `pkg/daemon/bootstrap_appliance_factory_7114_test.go`,
   `pkg/daemon/README.md`, `_Log.md`

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -1416,6 +1416,37 @@ never lock an operator out of a remote box it manages.
     (`lifelineLinkByName` / `lifelineAddrList` / `lifelineRouteList`) so each
     observation failure is reachable from a test that asserts zero side
     effects.
+  - **An unreadable route table claims NOTHING (#6789, the selection half).**
+    The same "error reads as a confident answer" shape sits one step earlier, in
+    the SELECTION, and there it is worse. `detectLifelineInterface` dumped
+    routes with the error discarded (`if err != nil { continue }`), and a failed
+    dump returns a nil slice — byte-for-byte what "this box has no default
+    route" looks like. The caller BRANCHES on exactly that distinction:
+    `applianceFactory := routeIface == "" && d.applianceFactoryBoot()`. So on a
+    box carrying the appliance marker that has never committed, a netlink error
+    silently flipped selection from "the NIC holding the default route" to
+    "the FIRST ENUMERATED NIC" — which is then renamed, and `renameInterface`
+    is an explicit `LinkSetDown` → `LinkSetName` → `LinkSetUp`. If the real
+    management NIC is not enumeration index 0, the wrong NIC is claimed and the
+    management NIC is cycled on a box reachable only over it. It is reachable on
+    a real factory box, because the previous boot's lifeline writes an fxp0 DHCP
+    `.network`, so the next boot genuinely HAS a default route while
+    `EverCommitted()` is still false.
+
+    Note the asymmetry: on a NON-appliance box the identical error is harmless —
+    an empty `routeIface` makes `chooseBootstrapLifeline` refuse, which is the
+    console-only contract. The appliance marker is what converts a swallowed
+    netlink error into a claimed and cycled NIC.
+
+    `detectLifelineInterface` now returns an error and the caller refuses when
+    the route state is UNKNOWN (`routeIface == "" && routeErr != nil`). The
+    guard keys on the observation having FAILED, never on `routeIface` being
+    empty: keying on empty would disable the #7114 factory contract entirely and
+    strand every appliance image console-only on first boot. A route that WAS
+    found and resolved is positive identification and is used even if another
+    family's dump errored — the error only matters when it could have hidden the
+    answer. The second swallowed error there (`LinkByIndex` on a found route)
+    is propagated for the same reason.
 - **Protected set** (`resolveProtectedInterfaces` →
   `dataplane.SetProtectedInterfaceResolver`): fxp0 + the lifeline NIC + an
   explicit `system management-interface` leaf are NEVER marked Unmanaged /

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -1335,6 +1335,45 @@ never lock an operator out of a remote box it manages.
     configured (possibly with a device-map that wants no auto-fxp0) is in
     bootstrap because its committed config stopped compiling. Steps 2-4 above
     are unchanged and run identically for either provenance.
+  - **Incomplete addressing observation refuses (#6789).** `setupBootstrapLifeline`
+    is a chain of fail-closed refusals — no default route, NIC enumeration
+    failed, not enumeration index 0 — each of which logs and returns having
+    mutated NOTHING. The addressing snapshot used to be the one observation
+    that GUESSED instead. `interfaceAddrSnapshot` returned empty slices on a
+    `LinkByName` failure and discarded the `AddrList` error, while its sibling
+    `isDHCPManaged` was documented to return false on any uncertainty so the
+    writer would snapshot static addresses — the SAFE direction. The writer
+    asked `isDHCPManaged(x) || (len(v4) == 0 && len(v6) == 0)`, so the very
+    failure that made `isDHCPManaged` fail safe also emptied the address list
+    and drove the OR into the DHCP branch. **Two helpers reading the same
+    netlink state failed in opposite directions, and the unsafe one won.** A
+    statically-addressed management NIC then received a `DHCP=yes` `.network`
+    and was renamed — and the rename cycles the link, so the static address
+    went away on a box reachable only over that NIC, in bootstrap, with no
+    committed config to roll back to.
+
+    Both helpers are now one typed observation, `snapshotLifelineAddrs`, which
+    returns an error instead of an empty result and folds the DHCP-lease
+    heuristic into the SAME netlink walk (they were two walks over one state,
+    which is what allowed them to disagree). An incomplete observation aborts
+    `setupBootstrapLifeline` **before** the `.link` write, the rename and the
+    reload, matching what every other refusal in that function already does and
+    the "selects nothing" console-only posture `chooseBootstrapLifeline`
+    documents.
+
+    The refusal is **scoped to a lifeline chosen by DEFAULT ROUTE**, which is
+    positive evidence the NIC carries live addressing the rename must reproduce
+    under the fxp0 name. The appliance factory lifeline above is chosen
+    precisely when there is no default route, so there is no addressing to
+    reproduce and DHCP is the image's documented contract: a failed observation
+    there cannot change a byte of the output, and refusing would break the
+    factory boot to guard information that was never going to be used. For the
+    same reason a route-dump failure is fatal only for a family the snapshot
+    HAS addresses in — the family whose `Gateway=` line would otherwise be
+    missing. The netlink calls sit behind injectable seams
+    (`lifelineLinkByName` / `lifelineAddrList` / `lifelineRouteList`) so each
+    observation failure is reachable from a test that asserts zero side
+    effects.
 - **Protected set** (`resolveProtectedInterfaces` →
   `dataplane.SetProtectedInterfaceResolver`): fxp0 + the lifeline NIC + an
   explicit `system management-interface` leaf are NEVER marked Unmanaged /

--- a/pkg/daemon/bootstrap.go
+++ b/pkg/daemon/bootstrap.go
@@ -1120,8 +1120,22 @@ func (d *Daemon) setupBootstrapLifeline() {
 	// The lifeline NIC would become fxp0. Snapshot its current addressing
 	// into the bootstrap .network BEFORE the rename, so the link cycle
 	// restores the same reachability under the fxp0 name.
-	if wrote := writeBootstrapLifelineNetwork(lifeline); wrote {
-		// reload picks up the new .network keyed on Name=fxp0.
+	// #6789: an INCOMPLETE addressing observation aborts here, before the .link
+	// write, the rename and the reload — i.e. before anything is mutated. Every
+	// other observation failure in this function already refuses that way (no
+	// default route, NIC enumeration failed, not enumeration index 0); this was
+	// the one that GUESSED instead, substituting `DHCP=yes` and proceeding to
+	// cycle the link. Refusing leaves the NIC under its kernel name with its
+	// live addressing untouched, which is the #1922 console-only posture
+	// chooseBootstrapLifeline documents as "selects nothing".
+	if _, err := writeBootstrapLifelineNetwork(lifeline, source == lifelineSourceDefaultRoute); err != nil {
+		slog.Error("bootstrap lifeline: could not observe the management NIC's addressing, so the "+
+			"bootstrap fxp0 .network cannot be written correctly. Refusing to rename/cycle any "+
+			"interface; staying in bootstrap with NO interface changes so management keeps its "+
+			"current name and addressing. Reach the box via its console and 'commit confirmed' "+
+			"a config.",
+			"interface", lifeline, "err", err)
+		return
 	}
 
 	// Rename just this one NIC to fxp0 (writes the .link + renames).
@@ -1153,15 +1167,39 @@ func (d *Daemon) setupBootstrapLifeline() {
 // reachability. DHCP-managed lifelines get a plain DHCP .network (matching the
 // historical writeBootstrapFxp0Network); a statically-addressed lifeline gets
 // Address=/Gateway= lines. Returns true if the file changed.
-func writeBootstrapLifelineNetwork(lifeline string) bool {
+func writeBootstrapLifelineNetwork(lifeline string, hasRouteEvidence bool) (bool, error) {
 	path := filepath.Join(linkDir, linkPrefix+"fxp0.network")
 
-	// Snapshot the lifeline's addressing ONCE (Copilot: avoid the duplicate
-	// netlink walk). DHCP-managed or address-less lifelines get a plain DHCP
-	// .network; a statically-addressed one gets an Address=/Gateway= snapshot.
-	v4, v6, gw4, gw6 := interfaceAddrSnapshot(lifeline)
+	// Snapshot the lifeline's addressing ONCE. #6789: an observation FAILURE is
+	// returned, never folded into "no addresses" — the address-less case takes
+	// the DHCP branch below, so a failed read that returned empty would write
+	// `DHCP=yes` over a statically-addressed management NIC and then cycle it.
+	//
+	// hasRouteEvidence scopes that refusal to the case where it means anything.
+	// A lifeline chosen because it carries a DEFAULT ROUTE is positive evidence
+	// that the NIC has live addressing which the rename must reproduce under the
+	// fxp0 name, so failing to read it is a real loss of information and the
+	// caller must refuse. The #7114 appliance factory lifeline is chosen
+	// precisely when there is NO default route — the bake purges cloud-init and
+	// netplan, so nothing has brought a NIC up and there is no addressing to
+	// reproduce. DHCP is that image's documented vNIC#1 -> fxp0 contract, and a
+	// failed observation cannot change a single byte of what gets written, so
+	// refusing there would break the factory boot to guard information that was
+	// never going to be used.
+	snap, err := snapshotLifelineAddrs(lifeline)
+	if err != nil {
+		if hasRouteEvidence {
+			return false, err
+		}
+		slog.Warn("bootstrap lifeline: addressing observation failed on an appliance factory "+
+			"boot; writing the image's factory DHCP .network, which is what an empty "+
+			"observation would have produced anyway",
+			"interface", lifeline, "err", err)
+		snap = lifelineAddrSnapshot{}
+	}
+	v4, v6, gw4, gw6 := snap.v4, snap.v6, snap.gw4, snap.gw6
 	var content string
-	if isDHCPManaged(lifeline) || (len(v4) == 0 && len(v6) == 0) {
+	if snap.dhcpManaged || (len(v4) == 0 && len(v6) == 0) {
 		content = "# Managed by xpfd — #1922 bootstrap lifeline (DHCP)\n" +
 			"[Match]\nName=fxp0\n\n[Network]\nDHCP=yes\n\n[DHCPv4]\nUseDNS=yes\nUseRoutes=yes\n"
 	} else {
@@ -1183,19 +1221,19 @@ func writeBootstrapLifelineNetwork(lifeline string) bool {
 		content = b.String()
 	}
 
-	existing, err := os.ReadFile(path)
-	if err == nil && string(existing) == content {
-		return false
+	existing, readErr := os.ReadFile(path)
+	if readErr == nil && string(existing) == content {
+		return false, nil
 	}
 	// AtomicGeneratedConfig: a bootstrap .network snapshot regenerated from
 	// the lifeline state; a torn file is unacceptable but a power-cut loss
 	// is re-derived next boot.
 	if err := fsatomic.WriteFileAtomic(path, []byte(content), 0644); err != nil {
 		slog.Warn("bootstrap lifeline: failed to write fxp0 .network", "path", path, "err", err)
-		return false
+		return false, nil
 	}
 	slog.Info("bootstrap lifeline: wrote fxp0 bootstrap .network", "source_interface", lifeline)
-	return true
+	return true, nil
 }
 
 // resolveProtectedInterfaces is the daemon's #1922 Item 4 protected-set
@@ -1213,29 +1251,95 @@ func (d *Daemon) resolveProtectedInterfaces() map[string]bool {
 	return protectedInterfaces(mgmtLeaf)
 }
 
-// interfaceAddrSnapshot collects the current global addresses + default
-// gateways on name, for the lifeline-aware bootstrap .network writer.
-func interfaceAddrSnapshot(name string) (v4, v6 []string, gw4, gw6 string) {
-	link, err := netlink.LinkByName(name)
+// Injectable netlink seams for the lifeline addressing snapshot (#6789). The
+// snapshot decides whether the bootstrap fxp0 .network is written as DHCP or as
+// a static address snapshot, and getting that wrong cycles the management NIC
+// onto the wrong addressing — so its failure modes must be reachable from a
+// test rather than only from real hardware.
+var (
+	lifelineLinkByName = netlink.LinkByName
+	lifelineAddrList   = netlink.AddrList
+	lifelineRouteList  = netlink.RouteList
+)
+
+// lifelineAddrSnapshot is a COMPLETE observation of a lifeline NIC's
+// addressing. It is only ever constructed by snapshotLifelineAddrs, and only
+// returned alongside a nil error — an incomplete observation has no
+// representation, which is the point (#6789).
+type lifelineAddrSnapshot struct {
+	v4, v6   []string
+	gw4, gw6 string
+	// dhcpManaged reports a global address with a FINITE valid lifetime, the
+	// heuristic for "this address came from DHCP". Folded into the snapshot so
+	// the DHCP-vs-static decision and the address list come from ONE netlink
+	// walk: they used to be two walks over the same state (interfaceAddrSnapshot
+	// and isDHCPManaged) that FAILED IN OPPOSITE DIRECTIONS, which is what made
+	// the defect below possible.
+	dhcpManaged bool
+}
+
+// snapshotLifelineAddrs observes name's global addresses, default gateways and
+// DHCP-lease heuristic. It returns an error when ANY observation failed, and
+// the caller MUST treat that as "unknown", never as "none" (#6789).
+//
+// THE DEFECT THIS CLOSES. The two predecessors read the same netlink state and
+// disagreed on fail direction. isDHCPManaged was documented to return false on
+// any uncertainty so the writer would snapshot static addresses — the SAFE
+// direction, and deliberately so. interfaceAddrSnapshot returned empty slices
+// on a LinkByName failure and discarded the AddrList error entirely. The writer
+// then asked `isDHCPManaged(x) || (len(v4) == 0 && len(v6) == 0)`, so the very
+// failure that made isDHCPManaged fail SAFE also emptied the address list and
+// drove the OR into the DHCP branch. A statically-addressed management NIC
+// whose netlink read failed was written a `DHCP=yes` .network and then renamed
+// — a link cycle that dropped its static address on a box reachable only over
+// that NIC, in bootstrap, with no committed config to roll back to.
+//
+// WHY EVERY ERROR IS PROPAGATED, AND WHY THE ROUTE ONE IS SCOPED. A LinkByName
+// or AddrList failure is always fatal to the snapshot: the DHCP-vs-static
+// decision reads exactly that state, so an error there means the decision
+// cannot be made at all. A RouteList failure is fatal only when the snapshot
+// HAS addresses in that family — i.e. only when a `Gateway=` line for it would
+// have been written, and its absence would leave management reachable on-link
+// only. Failing the snapshot because the v6 route dump errored on a box with no
+// v6 addresses would refuse a lifeline over an observation that could not have
+// changed a single byte of the output.
+func snapshotLifelineAddrs(name string) (lifelineAddrSnapshot, error) {
+	var snap lifelineAddrSnapshot
+	link, err := lifelineLinkByName(name)
 	if err != nil {
-		return nil, nil, "", ""
+		return snap, fmt.Errorf("link %s: %w", name, err)
 	}
-	addrs, _ := netlink.AddrList(link, netlink.FAMILY_ALL)
+	addrs, err := lifelineAddrList(link, netlink.FAMILY_ALL)
+	if err != nil {
+		return snap, fmt.Errorf("address list %s: %w", name, err)
+	}
 	for i := range addrs {
 		ip := addrs[i].IPNet
 		if ip == nil || ip.IP.IsLinkLocalUnicast() || ip.IP.IsLinkLocalMulticast() {
 			continue
 		}
+		// A DHCP lease carries a finite ValidLft; a static address is
+		// typically permanent (ValidLft == 0xffffffff / forever).
+		if addrs[i].ValidLft > 0 && addrs[i].ValidLft != 0xffffffff {
+			snap.dhcpManaged = true
+		}
 		if ip.IP.To4() != nil {
-			v4 = append(v4, ip.String())
+			snap.v4 = append(snap.v4, ip.String())
 		} else {
-			v6 = append(v6, ip.String())
+			snap.v6 = append(snap.v6, ip.String())
 		}
 	}
 	// Default-route gateways for this link.
 	for _, family := range []int{netlink.FAMILY_V4, netlink.FAMILY_V6} {
-		routes, err := netlink.RouteList(link, family)
+		routes, err := lifelineRouteList(link, family)
 		if err != nil {
+			haveAddrs := len(snap.v4) > 0
+			if family == netlink.FAMILY_V6 {
+				haveAddrs = len(snap.v6) > 0
+			}
+			if haveAddrs {
+				return lifelineAddrSnapshot{}, fmt.Errorf("route list %s family %d: %w", name, family, err)
+			}
 			continue
 		}
 		for i := range routes {
@@ -1246,37 +1350,12 @@ func interfaceAddrSnapshot(name string) (v4, v6 []string, gw4, gw6 string) {
 			if r.Gw == nil {
 				continue
 			}
-			if r.Gw.To4() != nil && gw4 == "" {
-				gw4 = r.Gw.String()
-			} else if r.Gw.To4() == nil && gw6 == "" {
-				gw6 = r.Gw.String()
+			if r.Gw.To4() != nil && snap.gw4 == "" {
+				snap.gw4 = r.Gw.String()
+			} else if r.Gw.To4() == nil && snap.gw6 == "" {
+				snap.gw6 = r.Gw.String()
 			}
 		}
 	}
-	return v4, v6, gw4, gw6
-}
-
-// isDHCPManaged reports whether name currently has a DHCP-assigned address
-// (heuristic: a global address with a finite valid lifetime). Used by the
-// lifeline writer to choose DHCP vs static snapshot. Best-effort: on any
-// uncertainty it returns false so the writer snapshots the static addresses
-// (a static snapshot of a DHCP lease still keeps mgmt reachable until the
-// lease would have expired, which is the bootstrap window).
-func isDHCPManaged(name string) bool {
-	link, err := netlink.LinkByName(name)
-	if err != nil {
-		return false
-	}
-	addrs, _ := netlink.AddrList(link, netlink.FAMILY_ALL)
-	for i := range addrs {
-		if addrs[i].IP.IsLinkLocalUnicast() {
-			continue
-		}
-		// A DHCP lease carries a finite ValidLft; a static address is
-		// typically permanent (ValidLft == 0xffffffff / forever).
-		if addrs[i].ValidLft > 0 && addrs[i].ValidLft != 0xffffffff {
-			return true
-		}
-	}
-	return false
+	return snap, nil
 }

--- a/pkg/daemon/bootstrap.go
+++ b/pkg/daemon/bootstrap.go
@@ -893,10 +893,20 @@ func (d *Daemon) applianceFactoryBoot() bool {
 
 // Returns the current kernel name of the lifeline NIC and ok=false when no
 // default route exists.
-func detectLifelineInterface() (name string, ok bool) {
+func detectLifelineInterface() (name string, ok bool, err error) {
+	var (
+		sawDefaultRoute bool
+		firstErr        error
+	)
 	for _, family := range []int{netlink.FAMILY_V4, netlink.FAMILY_V6} {
-		routes, err := netlink.RouteList(nil, family)
-		if err != nil {
+		routes, rerr := lifelineRouteList(nil, family)
+		if rerr != nil {
+			// #6789: RECORDED, not swallowed. A failed dump returns a nil
+			// slice, which is byte-for-byte what "this box has no default
+			// route" looks like — and the caller BRANCHES on that distinction.
+			if firstErr == nil {
+				firstErr = fmt.Errorf("route list family %d: %w", family, rerr)
+			}
 			continue
 		}
 		for i := range routes {
@@ -908,14 +918,28 @@ func detectLifelineInterface() (name string, ok bool) {
 			if r.LinkIndex <= 0 {
 				continue
 			}
-			link, err := netlink.LinkByIndex(r.LinkIndex)
-			if err != nil {
+			sawDefaultRoute = true
+			link, lerr := lifelineLinkByIndex(r.LinkIndex)
+			if lerr != nil {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("link by index %d: %w", r.LinkIndex, lerr)
+				}
 				continue
 			}
-			return link.Attrs().Name, true
+			// A resolved default route is POSITIVE identification. Report it
+			// even if an earlier dump errored: the error only matters when it
+			// could have hidden the answer, and here the answer was found.
+			return link.Attrs().Name, true, nil
 		}
 	}
-	return "", false
+	if firstErr != nil {
+		// Either a dump failed, or every default route we saw had an
+		// unresolvable link. Both leave "is there a default route, and on
+		// which NIC" UNKNOWN — never report that as a confident "none".
+		return "", false, firstErr
+	}
+	_ = sawDefaultRoute
+	return "", false, nil
 }
 
 // pciAddrForInterface resolves the PCI bus address + MAC for a kernel
@@ -1045,11 +1069,38 @@ func protectedInterfacesWith(mgmtLeaf, lifeline string) map[string]bool {
 // enumerated NIC is selected instead of refusing. Steps 2-4 are unchanged and
 // run identically for either provenance.
 func (d *Daemon) setupBootstrapLifeline() {
-	routeIface, _ := detectLifelineInterfaceFn()
+	routeIface, _, routeErr := detectLifelineInterfaceFn()
+	if routeIface == "" && routeErr != nil {
+		// #6789: the route observation FAILED, so "which NIC carries the
+		// default route" is UNKNOWN — not "there is none". The distinction is
+		// load-bearing because the very next line BRANCHES on it: an empty
+		// routeIface is what arms the #7114 appliance fallback, which claims
+		// the first enumerated NIC and RENAMES it (renameInterface does an
+		// explicit LinkSetDown -> LinkSetName -> LinkSetUp, so the rename IS
+		// the NIC cycle). A box whose real management NIC is not enumeration
+		// index 0 would have the wrong NIC claimed and cycled, on the strength
+		// of a netlink error.
+		//
+		// Claim NOTHING instead. That is the same console-only refusal
+		// chooseBootstrapLifeline documents for "cannot identify a management
+		// NIC", and it is what every other observation failure in this
+		// function already does.
+		slog.Warn("bootstrap lifeline: could not enumerate routes, so it is UNKNOWN whether this "+
+			"box has a default route or which NIC carries it. Claiming NOTHING and staying in "+
+			"bootstrap with NO interface changes — an unreadable route table must never be read "+
+			"as 'no default route', because that is what arms the appliance first-NIC fallback. "+
+			"Reach the box via its console and 'commit confirmed' a config.",
+			"err", routeErr)
+		return
+	}
 
 	// #7114: the appliance image's factory boot has no default route to find —
 	// the bake purges cloud-init and netplan, so nothing but xpfd ever brings a
 	// NIC up. Enumerate a fallback there, and ONLY there.
+	//
+	// #6789: reachable only when the route observation SUCCEEDED and genuinely
+	// found nothing (the unknown case returned above), so the factory contract
+	// is unchanged for every box whose route state is actually known.
 	firstNIC := ""
 	applianceFactory := routeIface == "" && d.applianceFactoryBoot()
 	if applianceFactory {
@@ -1257,9 +1308,10 @@ func (d *Daemon) resolveProtectedInterfaces() map[string]bool {
 // onto the wrong addressing — so its failure modes must be reachable from a
 // test rather than only from real hardware.
 var (
-	lifelineLinkByName = netlink.LinkByName
-	lifelineAddrList   = netlink.AddrList
-	lifelineRouteList  = netlink.RouteList
+	lifelineLinkByName  = netlink.LinkByName
+	lifelineLinkByIndex = netlink.LinkByIndex
+	lifelineAddrList    = netlink.AddrList
+	lifelineRouteList   = netlink.RouteList
 )
 
 // lifelineAddrSnapshot is a COMPLETE observation of a lifeline NIC's

--- a/pkg/daemon/bootstrap_appliance_factory_7114_test.go
+++ b/pkg/daemon/bootstrap_appliance_factory_7114_test.go
@@ -211,7 +211,7 @@ func TestSetupBootstrapLifelineAppliance(t *testing.T) {
 			})
 
 			// No default route — the #7114 precondition.
-			detectLifelineInterfaceFn = func() (string, bool) { return "", false }
+			detectLifelineInterfaceFn = func() (string, bool, error) { return "", false, nil }
 			// One NIC, already wearing the target name so the rename is a
 			// no-op and the test needs no netlink.
 			enumeratePCINICsFn = func() ([]pciNIC, error) {

--- a/pkg/daemon/lifeline_snapshot_failclosed_6789_test.go
+++ b/pkg/daemon/lifeline_snapshot_failclosed_6789_test.go
@@ -44,7 +44,7 @@ func staticLifelineSeams(t *testing.T) lifelineSeamState {
 	lifelineRecordFileForTest = filepath.Join(dir, "lifeline.json")
 	// A DEFAULT ROUTE names the management NIC: this is the evidence-bearing
 	// selection path, the one where a failed addressing read is a real loss.
-	detectLifelineInterfaceFn = func() (string, bool) { return defaultMgmtInterface, true }
+	detectLifelineInterfaceFn = func() (string, bool, error) { return defaultMgmtInterface, true, nil }
 	enumeratePCINICsFn = func() ([]pciNIC, error) {
 		return []pciNIC{{sortKey: 0, busAddr: "0000:05:00.0", name: defaultMgmtInterface}}, nil
 	}
@@ -276,7 +276,7 @@ func contains6789(h, n string) bool {
 func TestApplianceFactoryBootIsNotRefusedByASnapshotFailure6789(t *testing.T) {
 	st := staticLifelineSeams(t)
 	// #7114 precondition: NO default route, plus the appliance marker.
-	detectLifelineInterfaceFn = func() (string, bool) { return "", false }
+	detectLifelineInterfaceFn = func() (string, bool, error) { return "", false, nil }
 
 	dir := t.TempDir()
 	oldMarker := applianceMarkerFile
@@ -307,5 +307,240 @@ func TestApplianceFactoryBootIsNotRefusedByASnapshotFailure6789(t *testing.T) {
 	}
 	if !contains6789(string(data), "DHCP=yes") {
 		t.Errorf("the appliance factory .network must be the DHCP form; got:\n%s", data)
+	}
+}
+
+// filesIn lists the files written into the bootstrap link dir, so a test can
+// assert that NOTHING was produced (neither the .network nor the .link).
+func filesIn(t *testing.T, dir string) []string {
+	t.Helper()
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read link dir: %v", err)
+	}
+	var out []string
+	for _, e := range ents {
+		out = append(out, e.Name())
+	}
+	return out
+}
+
+// TestUnreadableRouteTableClaimsNothingOnAppliance6789 is the SECOND defect in
+// this issue, and it is the dangerous one.
+//
+// detectLifelineInterface dumped routes with `routes, err := netlink.RouteList(
+// nil, family); if err != nil { continue }` — the error DISCARDED — and a failed
+// dump returns a nil slice, which is byte-for-byte what "this box has no default
+// route" looks like. The caller then BRANCHES on exactly that distinction:
+//
+//	applianceFactory := routeIface == "" && d.applianceFactoryBoot()
+//
+// So on a box carrying /etc/xpf/appliance that has never committed, a netlink
+// error silently flips the selection from "use the NIC that holds the default
+// route" to "claim the FIRST ENUMERATED NIC" — which is then renamed, and
+// renameInterface is an explicit LinkSetDown -> LinkSetName -> LinkSetUp. If the
+// real management NIC is not enumeration index 0, the wrong NIC is claimed and
+// the management NIC is cycled, on a box reachable only over it.
+//
+// It is reachable on a REAL factory box: the previous boot's bootstrap lifeline
+// writes an fxp0 DHCP .network, so the next boot genuinely has a default route
+// while EverCommitted() is still false.
+//
+// Note the asymmetry this cell exists to pin: on a NON-appliance box the same
+// error is harmless (empty routeIface -> chooseBootstrapLifeline refuses ->
+// console-only). The appliance marker is what turns a swallowed netlink error
+// into a claimed and cycled NIC.
+//
+// FAIL-ON-REVERT: swallowing the RouteList error again (or dropping the
+// routeErr check at the call site) arms the appliance fallback, and the .link /
+// rename / reload assertions all go RED.
+func TestUnreadableRouteTableClaimsNothingOnAppliance6789(t *testing.T) {
+	st := staticLifelineSeams(t)
+
+	dir := t.TempDir()
+	oldMarker := applianceMarkerFile
+	applianceMarkerFile = filepath.Join(dir, "appliance")
+	t.Cleanup(func() { applianceMarkerFile = oldMarker })
+	if err := os.WriteFile(applianceMarkerFile, []byte("appliance\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The route table cannot be read. Drive the REAL detectLifelineInterface
+	// through its netlink seam rather than stubbing the detector, so this cell
+	// binds the actual error-swallowing site.
+	oldDetect := detectLifelineInterfaceFn
+	detectLifelineInterfaceFn = detectLifelineInterface
+	t.Cleanup(func() { detectLifelineInterfaceFn = oldDetect })
+	lifelineRouteList = func(netlink.Link, int) ([]netlink.Route, error) {
+		return nil, errors.New("injected: route dump failed")
+	}
+
+	d := &Daemon{store: newConfigStore(t, filepath.Join(dir, "xpf.conf"))}
+	if d.store.EverCommitted() {
+		t.Fatal("premise: a fresh store must report EverCommitted()==false")
+	}
+	d.setupBootstrapLifeline()
+
+	if got := filesIn(t, st.linkDir); len(got) != 0 {
+		t.Errorf("an UNREADABLE route table must claim NOTHING, but files were written: %v. "+
+			"A failed route dump is indistinguishable from 'no default route', and an empty "+
+			"routeIface is what arms the #7114 appliance first-NIC fallback (#6789)", got)
+	}
+	if *st.renamed {
+		t.Error("the first enumerated NIC was RENAMED because a netlink error was read as " +
+			"'no default route'. renameInterface does LinkSetDown -> LinkSetName -> LinkSetUp, " +
+			"so this cycles a NIC that may not be the management NIC at all (#6789)")
+	}
+	if *st.reloaded {
+		t.Error("networkctl reload ran on a box that must have claimed nothing")
+	}
+}
+
+// TestApplianceFallbackStillFiresWhenRoutesAreReadable6789 is the tightening
+// control for the cell above, and it pins the DISCRIMINATOR.
+//
+// The refusal must key on the route observation having FAILED, not on
+// routeIface being empty — those are the two states the old code conflated, and
+// a fix that refuses whenever routeIface is empty would disable the #7114
+// appliance factory contract entirely, stranding every factory image
+// console-only on first boot.
+//
+// Same fixture as above, one difference: the route dump SUCCEEDS and genuinely
+// returns no default route.
+//
+// FAIL-ON-REVERT: changing the call-site guard from `routeIface == "" &&
+// routeErr != nil` to `routeIface == ""` reds this.
+func TestApplianceFallbackStillFiresWhenRoutesAreReadable6789(t *testing.T) {
+	st := staticLifelineSeams(t)
+
+	dir := t.TempDir()
+	oldMarker := applianceMarkerFile
+	applianceMarkerFile = filepath.Join(dir, "appliance")
+	t.Cleanup(func() { applianceMarkerFile = oldMarker })
+	if err := os.WriteFile(applianceMarkerFile, []byte("appliance\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldDetect := detectLifelineInterfaceFn
+	detectLifelineInterfaceFn = detectLifelineInterface
+	t.Cleanup(func() { detectLifelineInterfaceFn = oldDetect })
+	// Readable, and genuinely empty — the real factory-boot state.
+	lifelineRouteList = func(netlink.Link, int) ([]netlink.Route, error) { return nil, nil }
+	lifelineLinkByName = func(string) (netlink.Link, error) { return okLink(), nil }
+	lifelineAddrList = func(netlink.Link, int) ([]netlink.Addr, error) { return nil, nil }
+
+	d := &Daemon{store: newConfigStore(t, filepath.Join(dir, "xpf.conf"))}
+	d.setupBootstrapLifeline()
+
+	netPath := filepath.Join(st.linkDir, linkPrefix+"fxp0.network")
+	data, err := os.ReadFile(netPath)
+	if err != nil {
+		t.Fatalf("a READABLE route table that genuinely holds no default route must still arm the "+
+			"#7114 appliance factory fallback: the refusal keys on the observation FAILING, not on "+
+			"routeIface being empty. Keying on empty would strand every factory image console-only "+
+			"on first boot. err=%v", err)
+	}
+	if !contains6789(string(data), "DHCP=yes") {
+		t.Errorf("the appliance factory .network must be the DHCP form; got:\n%s", data)
+	}
+}
+
+// TestDetectLifelineInterfaceReportsObservationFailures6789 unit-binds the
+// producer. The cells above drive it through setupBootstrapLifeline, which
+// proves the CONSEQUENCE; this proves the distinction the consequence rests on,
+// and it covers the second swallowed error (LinkByIndex) that no end-to-end
+// cell reaches.
+//
+// The table is a PAIR per row: an observation failure must report an error, and
+// the corresponding success must report none. Without the success rows, a fix
+// that always returns an error would pass — and would strand every box.
+func TestDetectLifelineInterfaceReportsObservationFailures6789(t *testing.T) {
+	injected := errors.New("injected")
+	oldRoute, oldIdx := lifelineRouteList, lifelineLinkByIndex
+	t.Cleanup(func() { lifelineRouteList, lifelineLinkByIndex = oldRoute, oldIdx })
+
+	defaultRoute := []netlink.Route{{LinkIndex: 2}}
+
+	tests := []struct {
+		name    string
+		route   func(netlink.Link, int) ([]netlink.Route, error)
+		byIndex func(int) (netlink.Link, error)
+		wantOK  bool
+		wantErr bool
+	}{
+		{
+			name:    "route-dump-fails-is-UNKNOWN-not-none",
+			route:   func(netlink.Link, int) ([]netlink.Route, error) { return nil, injected },
+			byIndex: func(int) (netlink.Link, error) { return okLink(), nil },
+			wantOK:  false, wantErr: true,
+		},
+		{
+			name:    "readable-and-genuinely-empty-is-none",
+			route:   func(netlink.Link, int) ([]netlink.Route, error) { return nil, nil },
+			byIndex: func(int) (netlink.Link, error) { return okLink(), nil },
+			wantOK:  false, wantErr: false,
+		},
+		{
+			// A default route exists but its link cannot be resolved: still
+			// UNKNOWN, and the old code swallowed this one too.
+			name:    "route-found-but-link-unresolvable-is-UNKNOWN",
+			route:   func(_ netlink.Link, _ int) ([]netlink.Route, error) { return defaultRoute, nil },
+			byIndex: func(int) (netlink.Link, error) { return nil, injected },
+			wantOK:  false, wantErr: true,
+		},
+		{
+			name:    "route-found-and-resolvable-is-positive-identification",
+			route:   func(_ netlink.Link, _ int) ([]netlink.Route, error) { return defaultRoute, nil },
+			byIndex: func(int) (netlink.Link, error) { return okLink(), nil },
+			wantOK:  true, wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lifelineRouteList = tc.route
+			lifelineLinkByIndex = tc.byIndex
+
+			name, ok, err := detectLifelineInterface()
+			if ok != tc.wantOK {
+				t.Errorf("ok = %v (name %q), want %v", ok, name, tc.wantOK)
+			}
+			if (err != nil) != tc.wantErr {
+				t.Errorf("err = %v, want error: %v. A swallowed observation error is reported as "+
+					"a confident 'no default route', which is what arms the appliance first-NIC "+
+					"fallback (#6789)", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestPartialRouteErrorStillUsesAFoundRoute6789 is the anti-over-reach control
+// for the producer: one family's dump fails, the other finds a default route.
+// A FOUND route is positive identification, so the partial error must not
+// discard it — the error only matters when it could have hidden the answer.
+//
+// FAIL-ON-REVERT: returning firstErr unconditionally (before the found-route
+// return) makes this refuse a box whose management NIC was positively
+// identified.
+func TestPartialRouteErrorStillUsesAFoundRoute6789(t *testing.T) {
+	oldRoute, oldIdx := lifelineRouteList, lifelineLinkByIndex
+	t.Cleanup(func() { lifelineRouteList, lifelineLinkByIndex = oldRoute, oldIdx })
+
+	lifelineRouteList = func(_ netlink.Link, family int) ([]netlink.Route, error) {
+		if family == netlink.FAMILY_V4 {
+			return nil, errors.New("injected: v4 dump failed")
+		}
+		return []netlink.Route{{LinkIndex: 2}}, nil
+	}
+	lifelineLinkByIndex = func(int) (netlink.Link, error) { return okLink(), nil }
+
+	name, ok, err := detectLifelineInterface()
+	if !ok || err != nil {
+		t.Fatalf("a default route that WAS found and resolved is positive identification and must "+
+			"be used even though another family's dump errored; got name=%q ok=%v err=%v",
+			name, ok, err)
+	}
+	if name != defaultMgmtInterface {
+		t.Errorf("name = %q, want %q", name, defaultMgmtInterface)
 	}
 }

--- a/pkg/daemon/lifeline_snapshot_failclosed_6789_test.go
+++ b/pkg/daemon/lifeline_snapshot_failclosed_6789_test.go
@@ -1,0 +1,311 @@
+package daemon
+
+import (
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+// lifelineSeamState captures everything setupBootstrapLifeline can MUTATE, so a
+// test can assert zero side effects rather than only a missing file.
+type lifelineSeamState struct {
+	linkDir  string
+	renamed  *bool
+	reloaded *bool
+}
+
+// staticLifelineSeams points the bootstrap lifeline at a NIC that is selected
+// BY DEFAULT ROUTE (the evidence-bearing case) and stubs every mutating seam.
+// The netlink observation seams are left for the caller to set.
+func staticLifelineSeams(t *testing.T) lifelineSeamState {
+	t.Helper()
+	dir := t.TempDir()
+	netDir := filepath.Join(dir, "network")
+	if err := os.MkdirAll(netDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldLinkDir, oldDetect := linkDir, detectLifelineInterfaceFn
+	oldEnum, oldRename, oldReload := enumeratePCINICsFn, renameInterfaceFn, networkctlReloadFn
+	oldRecord := lifelineRecordFileForTest
+	oldLink, oldAddr, oldRoute := lifelineLinkByName, lifelineAddrList, lifelineRouteList
+	t.Cleanup(func() {
+		linkDir, detectLifelineInterfaceFn = oldLinkDir, oldDetect
+		enumeratePCINICsFn, renameInterfaceFn, networkctlReloadFn = oldEnum, oldRename, oldReload
+		lifelineRecordFileForTest = oldRecord
+		lifelineLinkByName, lifelineAddrList, lifelineRouteList = oldLink, oldAddr, oldRoute
+	})
+
+	linkDir = netDir
+	lifelineRecordFileForTest = filepath.Join(dir, "lifeline.json")
+	// A DEFAULT ROUTE names the management NIC: this is the evidence-bearing
+	// selection path, the one where a failed addressing read is a real loss.
+	detectLifelineInterfaceFn = func() (string, bool) { return defaultMgmtInterface, true }
+	enumeratePCINICsFn = func() ([]pciNIC, error) {
+		return []pciNIC{{sortKey: 0, busAddr: "0000:05:00.0", name: defaultMgmtInterface}}, nil
+	}
+	renamed, reloaded := false, false
+	renameInterfaceFn = func(_, _ string) error { renamed = true; return nil }
+	networkctlReloadFn = func() error { reloaded = true; return nil }
+
+	return lifelineSeamState{linkDir: netDir, renamed: &renamed, reloaded: &reloaded}
+}
+
+// okLink is a minimal netlink.Link for the observation seams.
+func okLink() netlink.Link {
+	return &netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: defaultMgmtInterface, Index: 2}}
+}
+
+// staticAddr is a PERMANENT (ValidLft == forever) global address — a static
+// address, the kind whose loss the DHCP branch would cause.
+func staticAddr(cidr string) netlink.Addr {
+	ip, ipnet, _ := net.ParseCIDR(cidr)
+	ipnet.IP = ip
+	return netlink.Addr{IPNet: ipnet, ValidLft: 0xffffffff}
+}
+
+// TestLifelineObservationFailureProducesZeroSideEffects6789 is the #6789
+// fail-on-revert test, and it asserts SIDE EFFECTS rather than a return value.
+//
+// setupBootstrapLifeline is a chain of fail-closed refusals: no default route,
+// NIC enumeration failed, and not-enumeration-index-0 each log and return
+// having touched NOTHING. The addressing snapshot was the one observation that
+// GUESSED instead. interfaceAddrSnapshot returned empty slices on a LinkByName
+// failure and discarded the AddrList error, and the writer asked
+// `isDHCPManaged(x) || (len(v4) == 0 && len(v6) == 0)` — so the very failure
+// that made isDHCPManaged fail SAFE (toward static, as its comment documents)
+// also emptied the address list and drove the OR into the DHCP branch. A
+// statically-addressed management NIC then got a `DHCP=yes` .network and was
+// renamed, and the rename cycles the link: the static address goes away on a
+// box that is reachable only over that NIC, in bootstrap, with no committed
+// config to roll back to.
+//
+// Each arm fails ONE observation. What must be true in every arm is that
+// nothing was mutated: no .network written, no rename, no networkctl reload.
+//
+// FAIL-ON-REVERT: folding any of these errors back into an empty snapshot makes
+// the writer emit a DHCP .network and the rename+reload run, reddening all
+// three assertions in that arm.
+func TestLifelineObservationFailureProducesZeroSideEffects6789(t *testing.T) {
+	injected := errors.New("injected: netlink observation failure")
+
+	tests := []struct {
+		name  string
+		seams func()
+	}{
+		{
+			// The link itself cannot be resolved.
+			name: "link-read-fails",
+			seams: func() {
+				lifelineLinkByName = func(string) (netlink.Link, error) { return nil, injected }
+			},
+		},
+		{
+			// The link resolves but its addresses cannot be listed. This is the
+			// arm the old code could not distinguish from "has no addresses".
+			name: "address-list-fails",
+			seams: func() {
+				lifelineLinkByName = func(string) (netlink.Link, error) { return okLink(), nil }
+				lifelineAddrList = func(netlink.Link, int) ([]netlink.Addr, error) { return nil, injected }
+			},
+		},
+		{
+			// Addresses read fine, but the route dump for a family we HAVE
+			// addresses in failed — so a Gateway= line would have been written
+			// and its absence leaves management reachable on-link only.
+			name: "route-list-fails-for-a-family-with-addresses",
+			seams: func() {
+				lifelineLinkByName = func(string) (netlink.Link, error) { return okLink(), nil }
+				lifelineAddrList = func(netlink.Link, int) ([]netlink.Addr, error) {
+					return []netlink.Addr{staticAddr("192.0.2.10/24")}, nil
+				}
+				lifelineRouteList = func(_ netlink.Link, family int) ([]netlink.Route, error) {
+					if family == netlink.FAMILY_V4 {
+						return nil, injected
+					}
+					return nil, nil
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			st := staticLifelineSeams(t)
+			tc.seams()
+
+			d := &Daemon{store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))}
+			d.setupBootstrapLifeline()
+
+			netPath := filepath.Join(st.linkDir, linkPrefix+"fxp0.network")
+			if data, err := os.ReadFile(netPath); err == nil {
+				t.Errorf("a bootstrap fxp0 .network was written from an INCOMPLETE addressing "+
+					"observation; a failed read must never be treated as 'no addresses', because "+
+					"the address-less case writes DHCP=yes over a statically-addressed management "+
+					"NIC (#6789). content:\n%s", data)
+			}
+			if *st.renamed {
+				t.Error("the management NIC was RENAMED after a failed addressing observation. The " +
+					"rename cycles the link, so on a box reached only over that NIC this is the " +
+					"lockout (#6789)")
+			}
+			if *st.reloaded {
+				t.Error("networkctl reload ran after a failed addressing observation; every other " +
+					"observation failure in setupBootstrapLifeline refuses without touching anything")
+			}
+		})
+	}
+}
+
+// TestCompleteObservationStillWritesAndRenames6789 is the tightening control.
+// Without it, a fix that refuses on EVERY snapshot — or simply never writes —
+// satisfies every assertion above while disabling the bootstrap lifeline
+// entirely, which strands management under its kernel name on every boot.
+//
+// It uses the SAME seams with the only difference being that the observations
+// SUCCEED, and asserts the static snapshot is what gets written (not DHCP), so
+// it also pins that a permanent address is still classified as static.
+func TestCompleteObservationStillWritesAndRenames6789(t *testing.T) {
+	st := staticLifelineSeams(t)
+	lifelineLinkByName = func(string) (netlink.Link, error) { return okLink(), nil }
+	lifelineAddrList = func(netlink.Link, int) ([]netlink.Addr, error) {
+		return []netlink.Addr{staticAddr("192.0.2.10/24")}, nil
+	}
+	lifelineRouteList = func(_ netlink.Link, family int) ([]netlink.Route, error) {
+		if family == netlink.FAMILY_V4 {
+			return []netlink.Route{{Gw: net.ParseIP("192.0.2.1")}}, nil
+		}
+		return nil, nil
+	}
+
+	d := &Daemon{store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))}
+	d.setupBootstrapLifeline()
+
+	netPath := filepath.Join(st.linkDir, linkPrefix+"fxp0.network")
+	data, err := os.ReadFile(netPath)
+	if err != nil {
+		t.Fatalf("a COMPLETE observation must still write the bootstrap fxp0 .network: %v", err)
+	}
+	got := string(data)
+	if !contains6789(got, "Address=192.0.2.10/24") {
+		t.Errorf("the static address must be snapshotted into the .network; got:\n%s", got)
+	}
+	if !contains6789(got, "Gateway=192.0.2.1") {
+		t.Errorf("the default gateway must be snapshotted; got:\n%s", got)
+	}
+	if contains6789(got, "DHCP=yes") {
+		t.Errorf("a PERMANENT (ValidLft==forever) address is STATIC and must not produce a DHCP "+
+			".network — that substitution is the lockout #6789 closes; got:\n%s", got)
+	}
+	if !*st.reloaded {
+		t.Error("a complete observation must still reload networkd")
+	}
+}
+
+// TestRouteFailureForAFamilyWithNoAddressesDoesNotRefuse6789 is the
+// ANTI-OVER-REACH control, and it guards the scoping decision.
+//
+// A route-dump failure only matters when a Gateway= line for that family would
+// have been written. Refusing because the IPv6 route dump errored on a box with
+// no IPv6 addresses would strand the lifeline over an observation that could
+// not have changed a single byte of the output — the kind of over-broad
+// fail-closed that turns a conditional hazard into an unconditional outage.
+//
+// FAIL-ON-REVERT: dropping the `haveAddrs` scope in snapshotLifelineAddrs makes
+// this refuse and reds the write/rename assertions.
+func TestRouteFailureForAFamilyWithNoAddressesDoesNotRefuse6789(t *testing.T) {
+	st := staticLifelineSeams(t)
+	injected := errors.New("injected: v6 route dump failed")
+	lifelineLinkByName = func(string) (netlink.Link, error) { return okLink(), nil }
+	lifelineAddrList = func(netlink.Link, int) ([]netlink.Addr, error) {
+		// v4 only — nothing in the v6 family to write a Gateway= for.
+		return []netlink.Addr{staticAddr("192.0.2.10/24")}, nil
+	}
+	lifelineRouteList = func(_ netlink.Link, family int) ([]netlink.Route, error) {
+		if family == netlink.FAMILY_V6 {
+			return nil, injected
+		}
+		return []netlink.Route{{Gw: net.ParseIP("192.0.2.1")}}, nil
+	}
+
+	d := &Daemon{store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))}
+	d.setupBootstrapLifeline()
+
+	netPath := filepath.Join(st.linkDir, linkPrefix+"fxp0.network")
+	if _, err := os.ReadFile(netPath); err != nil {
+		t.Fatalf("a v6 route-dump failure on a box with NO v6 addresses must NOT refuse the "+
+			"lifeline: nothing it could have observed would appear in the output. err=%v", err)
+	}
+	if !*st.reloaded {
+		t.Error("the lifeline must still complete when the failed observation is irrelevant")
+	}
+}
+
+func contains6789(h, n string) bool {
+	for i := 0; i+len(n) <= len(h); i++ {
+		if h[i:i+len(n)] == n {
+			return true
+		}
+	}
+	return false
+}
+
+// TestApplianceFactoryBootIsNotRefusedByASnapshotFailure6789 binds the OTHER
+// half of the scoping decision, and it is the one that keeps this fix from
+// breaking the factory image.
+//
+// The refusal is conditioned on the lifeline having been chosen BY DEFAULT
+// ROUTE, because that is positive evidence the NIC carries live addressing the
+// rename must reproduce. The #7114 appliance factory lifeline is chosen
+// precisely when there is NO default route — the bake purges cloud-init and
+// netplan, so nothing has brought a NIC up — and DHCP is that image's
+// documented vNIC#1 -> fxp0 contract. A failed observation there cannot change
+// a single byte of what gets written, so refusing would break the factory boot
+// to protect information that was never going to be used.
+//
+// This was not a hypothetical: the first version of the fix refused
+// unconditionally and reddened the pre-existing
+// TestSetupBootstrapLifelineAppliance.
+//
+// FAIL-ON-REVERT: removing the hasRouteEvidence scope makes the appliance boot
+// refuse and reds the "DHCP .network written" assertion.
+func TestApplianceFactoryBootIsNotRefusedByASnapshotFailure6789(t *testing.T) {
+	st := staticLifelineSeams(t)
+	// #7114 precondition: NO default route, plus the appliance marker.
+	detectLifelineInterfaceFn = func() (string, bool) { return "", false }
+
+	dir := t.TempDir()
+	oldMarker := applianceMarkerFile
+	applianceMarkerFile = filepath.Join(dir, "appliance")
+	t.Cleanup(func() { applianceMarkerFile = oldMarker })
+	if err := os.WriteFile(applianceMarkerFile, []byte("appliance\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// And the addressing observation fails, exactly as in the refusing arms.
+	lifelineLinkByName = func(string) (netlink.Link, error) {
+		return nil, errors.New("injected: netlink observation failure")
+	}
+
+	d := &Daemon{store: newConfigStore(t, filepath.Join(dir, "xpf.conf"))}
+	if d.store.EverCommitted() {
+		t.Fatal("premise: a fresh store must report EverCommitted()==false")
+	}
+	d.setupBootstrapLifeline()
+
+	netPath := filepath.Join(st.linkDir, linkPrefix+"fxp0.network")
+	data, err := os.ReadFile(netPath)
+	if err != nil {
+		t.Fatalf("an appliance FACTORY boot must still claim vNIC#1 as fxp0 with the image's DHCP "+
+			".network even when the addressing observation fails: there is no default route and no "+
+			"addressing to reproduce, so nothing observable could have changed the output. "+
+			"Refusing here breaks the factory image (#7114/#6789). err=%v", err)
+	}
+	if !contains6789(string(data), "DHCP=yes") {
+		t.Errorf("the appliance factory .network must be the DHCP form; got:\n%s", data)
+	}
+}


### PR DESCRIPTION
Closes #6789

Cites re-derived from code (the `/tmp/opus-review-001.md` R48 pointer is dead).

## The defect, and the sharpest way to state it

`setupBootstrapLifeline` is a chain of fail-closed refusals. **No default route**,
**NIC enumeration failed**, and **not enumeration index 0** each log and return
having mutated NOTHING — the #1922 console-only posture that
`chooseBootstrapLifeline` documents as *"anything else selects nothing"*. The
surrounding code IS the contract; I did not have to argue it.

The addressing snapshot was the one observation that **guessed** instead:

```go
v4, v6, gw4, gw6 := interfaceAddrSnapshot(lifeline)          // nil,nil,"","" on LinkByName error
if isDHCPManaged(lifeline) || (len(v4) == 0 && len(v6) == 0) { → DHCP=yes }
```

`interfaceAddrSnapshot` returned empty slices on a `LinkByName` failure and
**discarded the `AddrList` error outright** (`addrs, _ := …`). Meanwhile its
sibling `isDHCPManaged` is documented to return false on any uncertainty *"so the
writer snapshots the static addresses"* — explicitly the SAFE direction.

**Two helpers reading the same netlink state failed in OPPOSITE directions, and
the unsafe one won the disjunction.** The very failure that made `isDHCPManaged`
fail safe also emptied the address list and drove the `||` into the DHCP branch.

**The damage is a lockout, not cosmetic.** A statically-addressed management NIC
receives a `DHCP=yes` `.network` and is then renamed to fxp0 — and the rename
cycles the link. The static address is gone, DHCP answers on a segment that
likely has no server, and the box is in *bootstrap* with no committed config to
roll back to, reachable only over the NIC that was just cycled. This is precisely
the "cycling the management NIC on a box you reach only over that NIC" hazard.

## The fix

Both helpers become one typed observation, `snapshotLifelineAddrs`, returning an
error rather than an empty result. Folding the DHCP-lease heuristic into the same
walk is not tidying — they were **two netlink walks over one state**, which is
exactly what let them disagree about what a failure means. (The existing comment
already wanted one walk: *"Snapshot the lifeline's addressing ONCE (Copilot:
avoid the duplicate netlink walk)"* — it just left `isDHCPManaged` as a second.)

An incomplete observation aborts `setupBootstrapLifeline` **before** the `.link`
write, the rename and the reload. Refusing leaves the NIC under its kernel name
with its live addressing untouched — strictly safer than renaming on a guess, and
identical in shape to every other refusal in that function.

## The scope is the load-bearing decision — and a pre-existing test found it

You warned that "fail closed" can itself be the outage. It nearly was: **my first
version refused unconditionally and reddened the pre-existing
`TestSetupBootstrapLifelineAppliance`.**

The refusal applies only to a lifeline chosen **by default route**, because a
default route is positive evidence the NIC carries live addressing the rename
must reproduce under the fxp0 name — so failing to read it is a real loss. The
#7114 appliance factory lifeline is selected *precisely when there is no default
route*: the bake purges cloud-init and netplan, nothing has brought a NIC up,
there is no addressing to reproduce, and DHCP is the image's documented vNIC#1 →
fxp0 contract. A failed observation there cannot change a byte of the output, so
refusing would break the factory boot to guard information that was never going
to be used.

Same reasoning one level down: a **route-dump failure is fatal only for a family
the snapshot HAS addresses in** — the only family whose `Gateway=` line would
otherwise be silently missing, leaving management reachable on-link only.
Refusing because the v6 dump errored on a v4-only box would strand a lifeline
over an observation that could not have mattered.

## The SECOND defect — the selection half, and the dangerous one

Your question 1 pointed at a **different netlink call than the one above**, and
it was right. Fixing only the addressing snapshot would have left the more
dangerous consumer intact, which is exactly the "next consumer inherits the same
wrong conclusion" you warned about.

`detectLifelineInterface` dumped routes with the error discarded:

```go
routes, err := netlink.RouteList(nil, family)
if err != nil { continue }      // ← and then: return "", false
```

A failed dump returns a nil slice — byte-for-byte what *"this box has no default
route"* looks like. And the caller **branches on exactly that distinction**:

```go
applianceFactory := routeIface == "" && d.applianceFactoryBoot()
```

So on a box carrying `/etc/xpf/appliance` that has never committed, a netlink
error silently flips selection from *"use the NIC that holds the default route"*
to *"claim the **first enumerated** NIC"* — which is then renamed. **That is your
question 3: the rename is what cycles the NIC** (`renameInterface` =
`LinkSetDown` → `LinkSetName` → `LinkSetUp`; the `.link` write is durable but
inert until next boot, and the reload only re-applies `.network` files). If the
real management NIC is not enumeration index 0, the wrong NIC is claimed and the
management NIC is cycled — on a box reachable only over it.

**It is reachable on a real factory box**, not just in theory: the previous
boot's bootstrap lifeline writes an fxp0 DHCP `.network`, so the next boot
genuinely HAS a default route while `EverCommitted()` is still false. The gate
stays armed at the moment there is finally a real route for the dump to lose.

**Your question 2 — is the appliance path affected the same way? It is affected
WORSE, and the asymmetry is the point.** On a NON-appliance box the identical
error is harmless: an empty `routeIface` makes `chooseBootstrapLifeline` refuse,
which is the console-only contract working as designed. **The appliance marker is
what converts a swallowed netlink error into a claimed and cycled NIC.**

`detectLifelineInterface` now returns an error and the caller refuses when the
route state is UNKNOWN. Three scoping decisions, so the factory contract is not
collateral damage:

- The guard keys on the observation having **FAILED** (`routeIface == "" &&
  routeErr != nil`), never on `routeIface` being empty. Keying on empty would
  disable the #7114 contract outright and strand every appliance image
  console-only on first boot. **Cell M9 is that control** — and it reds the
  pre-existing `TestSetupBootstrapLifelineAppliance` too.
- A route that **was** found and resolved is positive identification and is used
  even when another family's dump errored: the error only matters when it could
  have hidden the answer. **Cell M11.**
- The second swallowed error on that path — `LinkByIndex` failing for a found
  route — is propagated for the same reason: it also leaves "which NIC" unknown.
  No end-to-end cell reaches it, so the producer table covers it directly.

The existing `detectLifelineInterfaceFn` seams gain a `nil` error, which
preserves each fixture's meaning exactly: they all describe a SUCCESSFUL
observation that found nothing — precisely the state the new guard must still let
through.

One cite correction: `setupBootstrapLifeline` / `chooseBootstrapLifeline` live in
`pkg/daemon/bootstrap.go`, not `linksetup.go` (`renameInterface` is the one in
`linksetup.go`).

## Mutation matrix

Fix committed BEFORE the matrix. One mutation per line, anchor asserted to match
exactly once, tree rebuilt, then the **full `pkg/daemon` suite** with `-count=1`,
**no `-run` filter**, and `skipped_6789_cells == 0` asserted per cell.

Control (M0): **1969 passing, 0 failed, 0 skips** (after the second fix).

| Cell | Mutation | Result | Which assertion fired |
|---|---|---|---|
| M0 | none (control) | **GREEN** | 1938 pass / 0 fail |
| M1 | `LinkByName` error → empty snapshot (**the shipped bug**) | **RED** | `TestLifelineObservationFailureProducesZeroSideEffects6789` |
| M2 | restore `addrs, _ :=` (discard the `AddrList` error) | **RED** | same, `address-list-fails` arm |
| M3 | caller swallows the error and proceeds to rename/reload | **RED** | same — all three side-effect assertions |
| M4 | **tightening** — refuse unconditionally (drop the appliance scope) | **RED** ×2 | `TestApplianceFactoryBootIsNotRefusedByASnapshotFailure6789` **plus the pre-existing `TestSetupBootstrapLifelineAppliance`** |
| M5 | **tightening** — route error always fatal (drop the `haveAddrs` scope) | **RED** | `TestRouteFailureForAFamilyWithNoAddressesDoesNotRefuse6789` |
| M6 | **tightening** — writer always takes the DHCP branch | **RED** | `TestCompleteObservationStillWritesAndRenames6789` |
| M7 | DHCP heuristic drops the `!= 0xffffffff` clause (permanent reads as DHCP) | **RED** | `TestCompleteObservationStillWritesAndRenames6789` — `a PERMANENT address is STATIC and must not produce a DHCP .network` |
| M8 | restore the detector's `RouteList` error swallow (**the second shipped bug**) | **RED** ×2 | `TestUnreadableRouteTableClaimsNothingOnAppliance6789`, `TestDetectLifelineInterfaceReportsObservationFailures6789` |
| M9 | **tightening** — guard on empty `routeIface` instead of the error | **RED** ×3 | both appliance cells **plus the pre-existing `TestSetupBootstrapLifelineAppliance`** |
| M10 | drop the `LinkByIndex` error propagation | **RED** | `…ReportsObservationFailures6789/route-found-but-link-unresolvable` |
| M11 | **tightening** — return `firstErr` before the found-route return | **RED** | `TestPartialRouteErrorStillUsesAFoundRoute6789` |

**M4 is the cell worth reading.** It reds my scoping control *and* a pre-existing
#7114 test — so a `-run 6789` filter would have shown only half the signal, and
the unconditional-refusal version of this fix would have shipped a broken factory
image. That pre-existing test is how the scope was found in the first place.

The failure cells assert **side effects, not return values**: no `.network`
written, no rename, no `networkctl reload`. A returned error is not the property
that matters here — not having moved the management NIC is.

## Validation

- `go build ./...` rc=0 · `go vet ./...` clean · `go test -count=1 ./...`
  (repo-wide) **rc=0** — re-run at the merged head.
- Gated head **`f8b9f43855d501a1c3a8b3964537c71fe80b9cdf`**, which merges
  `origin/master` (10 commits behind by then; only conflict an append-vs-append
  in `_Log.md`, union-resolved, anchored marker sweep clean). M1 and M4 re-run at
  that head, both still red.
- **No Rust touched** — Go-only, no cargo leg.
- **No cluster / VRRP / session-sync / failover code touched.** This is the
  bootstrap path (pre-commit, single node), so no cluster smoke is owed.

## Docs

`pkg/daemon/README.md` §"Bootstrap mode + management lifeline (#1922)" gains an
**Incomplete addressing observation refuses (#6789)** bullet: the opposite-fail-
direction mechanism, the lockout it produced, the single typed observation, where
the abort lands relative to the `.link`/rename/reload, and both halves of the
scope (default-route evidence, and the per-family route rule) plus the injectable
seams.
