### PR TITLE
daemon: fail closed on fabric IPVLAN failure and give it a retry owner (#6791)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104796,3 +104796,23 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/vrrp/reth_rg_parity_6781_test.go` (new),
   `pkg/vrrp/reth_rg_ssot_6781_test.go` (new),
   `pkg/config/reth_rg_gate_6781_test.go` (new), `pkg/vrrp/README.md`
+
+## 2026-08-22 — #6791 fabric IPVLAN fails closed and gains a retry owner
+
+- **Timestamp**: 2026-08-22
+- **Action**: `applyFabricIPVLAN` returned nothing: it logged "CRITICAL ...
+  cluster heartbeat will not work" after exhausting its five in-line retries
+  and the commit still reported success. The evidence was the asymmetry at the
+  call site — its neighbours are captured and joined, it was a bare statement.
+  Made it return an error, captured it as `fabricErr` and threaded it into the
+  tail `errors.Join`. Safe to surface because `ensureFabricIPVLAN` errors only
+  when there is no usable overlay (address failures are warn-only, AddrReplace
+  is idempotent, an already-correct overlay returns nil). Added
+  `fabricIPVLANReassertLoop`, started unconditionally in `Run`, as the
+  persistent recovery owner for a failure outlasting those retries and for the
+  deferred OnXSKBound overlays whose failure cannot reach the commit at all.
+- **File(s)**: `pkg/daemon/daemon_apply_interfaces.go`,
+  `pkg/daemon/daemon_apply.go`, `pkg/daemon/daemon_apply_tail.go`,
+  `pkg/daemon/daemon_run.go`, `pkg/daemon/daemon_fabric_reassert.go` (new),
+  `pkg/daemon/fabric_ipvlan_failclosed_6791_test.go` (new),
+  `pkg/daemon/README.md`

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -1873,6 +1873,38 @@ never lock an operator out of a remote box it manages.
   applyRoutingRules fails-closed-and-complete via a `RuleList`-failing
   `NewManagerWithRuleOpsForTest` fake, clean-config stays-success, and the
   `applyTailReconciles` commit-join wiring proof).
+  **Fabric IPVLAN fail-closed + retry owner (#6791, mirroring #5310/#5696/#5844/#5700
+  on the propagation half and #6793 on the recovery half):** `applyFabricIPVLAN`
+  returned NOTHING. It retried `ensureFabricIPVLAN` five times at 1s, then logged
+  `CRITICAL: fabric IPVLAN creation failed after retries — cluster heartbeat will
+  not work` and `continue`d — so the commit reported SUCCESS on a node with no
+  `fab0`/`fab1`, i.e. no cluster heartbeat and no session-sync transport. The
+  evidence was an ASYMMETRY, not a judgement call: in `applyConfigLocked` its
+  neighbours are captured and joined (`mgmtRouteErr := …`, `ifaceErr := …`) while
+  `d.applyFabricIPVLAN(cfg)` was a bare statement — the only reconciler in that
+  sequence whose error could not propagate. It now returns
+  `errors.Join(fabricErrs...)`, captured as `fabricErr` and threaded into the tail
+  join. Safe to surface because `ensureFabricIPVLAN` returns an error ONLY when
+  there is no usable overlay: address failures are warn-only inside it and it uses
+  the idempotent `AddrReplace`, and an already-correct overlay returns nil — so
+  there is no benign already-exists that could newly fail a healthy commit.
+  Separately, `fabricIPVLANReassertLoop` is the persistent recovery owner the
+  overlay never had: `applyFabricIPVLAN` runs only from a config apply on BOTH
+  standalone and cluster nodes, so a netlink failure outlasting those five seconds
+  (a parent NIC still being renamed after a power cycle) left the fabric absent
+  until an operator happened to commit. It is also the only owner that can cover
+  the DEFERRED (`OnXSKBound`) overlays, which are created after the apply has
+  returned and so cannot report failure to the commit at all. Started
+  unconditionally in `Run` alongside `proxyARPReassertLoop` /
+  `raDeadSenderReassertLoop`, it takes `applySem` BEFORE reading `ActiveConfig`
+  (#4001) and re-checks its gate inside the semaphore; the gate is one netlink name
+  lookup per configured `fab*` device (present AND admin-up), so it is free on a
+  healthy node and a complete no-op on a config with no fabric interfaces. Tests:
+  `fabric_ipvlan_failclosed_6791_test.go` (producing half returns-and-names the
+  failure with a healthy-path control; the `applyTailReconciles` commit-join WIRING
+  proof; gate quiet-when-up / fires-when-down; the re-assert re-creates; and a
+  loop-START cell asserting `Run` launches it unconditionally).
+
   **VRF setup / management-bind fail-closed (#5700, mirroring #5310/#5696/#5844):**
   `applyVRFReconcile` LOGGED-and-DROPPED its `ReconcileVRFs` failure (WARN) and
   returned only the #2926-C1 ctx-cancellation, even though `reconcileVRFs`'s

--- a/pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go
+++ b/pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go
@@ -247,7 +247,7 @@ func TestApplyTailReconcilesSurfacesInterfaceReconcileError(t *testing.T) {
 	}
 
 	injected := errors.New("injected: interface reconcile (xfrmi create) failed")
-	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, injected, nil, nil, nil, nil)
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, injected, nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("applyTailReconciles must surface the interface-reconcile failure " +
 			"(fail-closed); got nil")

--- a/pkg/daemon/cluster_auth_upgrade_wiring_6628_test.go
+++ b/pkg/daemon/cluster_auth_upgrade_wiring_6628_test.go
@@ -94,7 +94,7 @@ func TestConfigApplyReconcilesConnectionAuth6628(t *testing.T) {
 	// The tail returns reconcile errors in this stripped-down harness; the
 	// assertion is on what step 20 puts on the wire.
 	go func() {
-		_ = d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		_ = d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	}()
 
 	select {

--- a/pkg/daemon/cluster_transport_key_5078_test.go
+++ b/pkg/daemon/cluster_transport_key_5078_test.go
@@ -186,7 +186,7 @@ func TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078(t *testing.T) {
 		before := gen()
 		// The tail returns reconcile errors in this stripped-down harness; the
 		// assertion is on the comms decision, which step 20 makes regardless.
-		_ = d.applyTailReconciles(keyed, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		_ = d.applyTailReconciles(keyed, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		if after := gen(); after != before {
 			t.Fatalf("committing authentication-key restarted cluster comms "+
 				"(clusterCommsGen %d -> %d): that drops the established session-sync "+
@@ -203,7 +203,7 @@ func TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078(t *testing.T) {
 		moved.Chassis.Cluster.PeerAddress = "10.99.0.9"
 
 		before := gen()
-		_ = d.applyTailReconciles(moved, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		_ = d.applyTailReconciles(moved, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		if after := gen(); after == before {
 			t.Fatalf("a peer-address change did NOT restart cluster comms "+
 				"(clusterCommsGen stayed %d); the key-commit assertion above is "+
@@ -275,7 +275,7 @@ func TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078(t *testing.T) {
 		// active transport is unchanged — which is exactly the production shape
 		// after a key commit, since the key never entered the transport key.
 		before := gen()
-		_ = d.applyTailReconciles(movedKeyed, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		_ = d.applyTailReconciles(movedKeyed, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		if after := gen(); after == before {
 			t.Fatalf("a peer-address change on a KEYED cluster did NOT restart "+
 				"cluster comms (clusterCommsGen stayed %d); step 20 must key its "+

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -411,7 +411,13 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// networkdErr/hostInboundErr/lo0Err (fail-closed but complete).
 	ifaceErr := d.applyInterfaceReconcile(cfg)
 
-	d.applyFabricIPVLAN(cfg)
+	// #6791: capture the fabric-overlay failure and thread it into the tail
+	// commit-error join, exactly like ifaceErr/vrfErr above. This call was the
+	// ONLY reconciler in this sequence whose error could not propagate — it
+	// returned nothing, so a fab0/fab1 that could not be created logged
+	// "CRITICAL ... cluster heartbeat will not work" and the commit still
+	// reported success. All later steps still run (fail-closed but complete).
+	fabricErr := d.applyFabricIPVLAN(cfg)
 
 	// 1.9–2.7. Dataplane apply + RETH-MAC/VIP/worker-rebind critical section
 	// (#4407). Returns the ip-monitoring commit overlay and the captured
@@ -486,7 +492,7 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// next-table/rib-group/PBR ip-rule reconcile failure (a partial kernel
 	// policy-routing clear/add); the helper creates lo0Err/hostInboundErr and
 	// returns the joined errors.
-	return d.applyTailReconciles(cfg, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr, mgmtRouteErr, vrfErr)
+	return d.applyTailReconciles(cfg, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr, mgmtRouteErr, vrfErr, fabricErr)
 }
 
 // applyHostAuthorizationCloseout runs ONLY the security-critical host-

--- a/pkg/daemon/daemon_apply_interfaces.go
+++ b/pkg/daemon/daemon_apply_interfaces.go
@@ -14,13 +14,28 @@ import (
 	"github.com/psaab/xpf/pkg/routing"
 )
 
+// deferredIPVLAN names one fabric overlay to (re)create: the physical parent,
+// the fab* device name, and the addresses it carries. Shared by the deferred
+// (OnXSKBound) creation path and the #6791 re-assert loop so both describe the
+// work the same way.
+type deferredIPVLAN struct {
+	parent string
+	name   string
+	addrs  []string
+}
+
 // applyFabricIPVLAN creates the fabric-member IPVLAN overlays (fab0/fab1) for
 // cluster heartbeat + VRRP, deferring creation past XSK bind when the userspace
 // dataplane is active (an existing IPVLAN breaks zero-copy bind, #128), and
 // cleans up stale fabric IPVLAN overlays not in the current config. Extracted
 // verbatim from applyConfigLocked (#4407); runs in the same slot, after the
 // interface-creation reconcile and before the RETH-MAC pre-check.
-func (d *Daemon) applyFabricIPVLAN(cfg *config.Config) {
+func (d *Daemon) applyFabricIPVLAN(cfg *config.Config) error {
+	// #6791: accumulates the overlays whose creation is genuinely terminal —
+	// retries exhausted and no working fab* device. Joined and returned so the
+	// commit fails closed instead of acknowledging a cluster whose heartbeat
+	// and session-sync transport does not exist.
+	var fabricErrs []error
 	// 1.9. Create IPVLAN interfaces for fabric members (fab0, fab1).
 	// The physical member (ge-0-0-0) keeps its name; fab0 is IPVLAN L2
 	// on top for IP addressing. BPF attaches to the parent.
@@ -33,11 +48,6 @@ func (d *Daemon) applyFabricIPVLAN(cfg *config.Config) {
 	// parent bind XSK in zerocopy first, then the IPVLAN is added for
 	// sync/heartbeat addressing.
 	activeFabricOverlays := make(map[string]bool)
-	type deferredIPVLAN struct {
-		parent string
-		name   string
-		addrs  []string
-	}
 	var deferredOverlays []deferredIPVLAN
 	bindingCtrl, isUserspaceDP := d.dataplane().(userspaceXSKBindingController)
 	for ifName, ifCfg := range cfg.Interfaces.Interfaces {
@@ -74,16 +84,16 @@ func (d *Daemon) applyFabricIPVLAN(cfg *config.Config) {
 			}
 			// XSK already bound — fall through to reconcile.
 		}
-		if err := ensureFabricIPVLAN(parentLinux, fabLinux, addrs); err != nil {
+		if err := fabricEnsureFn(parentLinux, fabLinux, addrs); err != nil {
 			// Fabric overlay is critical for cluster heartbeat and VRRP.
 			// Retry up to 5 times with 1s delay — the parent interface
 			// might not be ready yet after a power cycle.
 			var retryErr error
 			for retry := 0; retry < 5; retry++ {
-				time.Sleep(time.Second)
+				time.Sleep(fabricIPVLANRetryDelay)
 				slog.Info("retrying fabric IPVLAN creation",
 					"parent", parentLinux, "name", fabLinux, "attempt", retry+2)
-				retryErr = ensureFabricIPVLAN(parentLinux, fabLinux, addrs)
+				retryErr = fabricEnsureFn(parentLinux, fabLinux, addrs)
 				if retryErr == nil {
 					break
 				}
@@ -91,6 +101,14 @@ func (d *Daemon) applyFabricIPVLAN(cfg *config.Config) {
 			if retryErr != nil {
 				slog.Error("CRITICAL: fabric IPVLAN creation failed after retries — cluster heartbeat will not work",
 					"parent", parentLinux, "name", fabLinux, "err", retryErr)
+				// #6791: this log line said the cluster heartbeat will not
+				// work and then returned success. ensureFabricIPVLAN only
+				// returns an error when there is no usable overlay (address
+				// failures are warn-only inside it and AddrReplace is
+				// idempotent), so every error reaching here is terminal for
+				// fabric function, not a benign already-exists.
+				fabricErrs = append(fabricErrs, fmt.Errorf(
+					"fabric IPVLAN %s on %s: %w", fabLinux, parentLinux, retryErr))
 			}
 			continue
 		}
@@ -101,7 +119,7 @@ func (d *Daemon) applyFabricIPVLAN(cfg *config.Config) {
 			for _, ov := range deferredOverlays {
 				slog.Info("XSK bound — creating deferred fabric IPVLAN",
 					"parent", ov.parent, "name", ov.name)
-				if err := ensureFabricIPVLAN(ov.parent, ov.name, ov.addrs); err != nil {
+				if err := fabricEnsureFn(ov.parent, ov.name, ov.addrs); err != nil {
 					slog.Error("deferred fabric IPVLAN creation failed",
 						"parent", ov.parent, "name", ov.name, "err", err)
 				}
@@ -120,6 +138,11 @@ func (d *Daemon) applyFabricIPVLAN(cfg *config.Config) {
 			}
 		}
 	}
+	// The deferred (OnXSKBound) overlays above are created asynchronously after
+	// this function has returned, so their failure cannot be reported here at
+	// all. fabricIPVLANReassertLoop (#6791) is the retry owner that covers both
+	// that window and a transient failure outlasting the in-apply retries.
+	return errors.Join(fabricErrs...)
 }
 
 // applyVRFReconcile reconciles routing-instance VRFs during a config apply:

--- a/pkg/daemon/daemon_apply_tail.go
+++ b/pkg/daemon/daemon_apply_tail.go
@@ -39,7 +39,7 @@ import (
 // lo0Err/hostInboundErr originate in step 9.5. The returned errors.Join
 // preserves the explicit operand order
 // (#1778/#2987/#4433/#5083/#5310/#5679/#5696/#5700).
-func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr, mgmtRouteErr, vrfErr error) error {
+func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr, mgmtRouteErr, vrfErr error, fabricErr error) error {
 	// 8. Apply VRRP config — merge user VRRP + RETH VRRP instances
 	var vrrpErr error
 	vrrpInstances := vrrp.CollectInstances(cfg)
@@ -362,7 +362,7 @@ func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, 
 	// that left stale or missing kernel/swanctl/dataplane state fails the commit
 	// (fail-closed) instead of reporting success. All are joined so none masks the
 	// other.
-	return errors.Join(networkdErr, applyErr, dhcpServerErr, hostInboundErr, lo0Err, dnsErr, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr, mgmtRouteErr, vrfErr, vrrpErr)
+	return errors.Join(networkdErr, applyErr, dhcpServerErr, hostInboundErr, lo0Err, dnsErr, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr, mgmtRouteErr, vrfErr, fabricErr, vrrpErr)
 }
 
 // reconcileDHCPRelay re-applies the DHCP relay config on every commit (#2348).

--- a/pkg/daemon/daemon_fabric_reassert.go
+++ b/pkg/daemon/daemon_fabric_reassert.go
@@ -1,0 +1,141 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// fabricIPVLANReassertInterval paces the fabric-overlay retry owner (#6791).
+//
+// 30s matches proxyARPReassertLoop and raDeadSenderReassertLoop. The fabric
+// overlay carries cluster heartbeat and session sync, so a faster cadence is
+// tempting — but the cluster's own 2s reconcile already re-drives a great deal,
+// and the gap this loop exists to close is a boot-time netlink failure that
+// otherwise persists until an operator commits. Minutes of exposure become
+// seconds; a tighter tick would buy little and cost a netlink read per fab
+// device per tick forever.
+var fabricIPVLANReassertInterval = 30 * time.Second
+
+// fabricEnsureFn is the overlay-creation entry point, overridable in tests so
+// the retry owner can be observed without a real IPVLAN. Package-level rather
+// than a Daemon field because ensureFabricIPVLAN is a package function and the
+// apply path calls it directly; routing BOTH through one seam is what makes the
+// re-drive assertable.
+var fabricEnsureFn = ensureFabricIPVLAN
+
+// fabricIPVLANRetryDelay spaces applyFabricIPVLAN's in-line retries. A var so a
+// test can drive the retries-exhausted path without five real seconds of sleep;
+// production keeps 1s.
+var fabricIPVLANRetryDelay = time.Second
+
+// fabricIPVLANReassertLoop is the persistent recovery owner the fabric overlay
+// did not have (#6791).
+//
+// applyFabricIPVLAN retries five times at 1s and then gives up. Standalone and
+// cluster nodes alike apply the fabric overlay ONLY from a config apply, so a
+// netlink failure that outlasts those five seconds — a parent NIC still being
+// renamed after a power cycle is the motivating case — left fab0/fab1 absent
+// until an operator happened to commit. The node then had no cluster heartbeat
+// and no session-sync transport, having reported (before this change) a
+// successful commit.
+//
+// It is also the only owner that can cover the DEFERRED overlays: when the
+// userspace dataplane is active, creation is postponed to the OnXSKBound
+// callback, which runs after the apply has returned, so its failure cannot
+// reach the commit result at all.
+//
+// Always-on and mode-agnostic, mirroring the two sibling loops: it re-reads the
+// active config each tick rather than capturing one at start, so a fabric
+// interface added or removed by a later commit is picked up without a restart.
+func (d *Daemon) fabricIPVLANReassertLoop(ctx context.Context) {
+	t := time.NewTicker(fabricIPVLANReassertInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			d.reassertFabricIPVLANOnce(ctx)
+		}
+	}
+}
+
+// missingFabricOverlays returns the configured fabric overlays that are absent
+// or down, as (parent, name, addrs) triples ready for ensureFabricIPVLAN.
+//
+// This is the CHEAP gate. On a healthy node it is one netlink name lookup per
+// configured fab device — at most two — and returns nothing, so the loop costs
+// effectively nothing when everything is up. It deliberately does NOT verify
+// the parent index, MTU or addresses: those are ensureFabricIPVLAN's job and
+// re-running it for a cosmetic drift would restart a working overlay every
+// tick. The gate answers only "is there a usable fab device at all".
+func (d *Daemon) missingFabricOverlays(cfg *config.Config) []deferredIPVLAN {
+	var out []deferredIPVLAN
+	config.RangeInterfaces(cfg, func(ifName string, ifCfg *config.InterfaceConfig) {
+		if ifCfg.LocalFabricMember == "" || !strings.HasPrefix(ifName, "fab") {
+			return
+		}
+		fabLinux := config.LinuxIfName(ifName)
+		link, err := d.fabricLinkByName(fabLinux)
+		if err == nil && link != nil && link.Attrs() != nil &&
+			link.Attrs().Flags&net.FlagUp != 0 {
+			return // present and administratively up — nothing to do
+		}
+		var addrs []string
+		if unit, ok := config.LookupUnit(ifCfg, 0); ok {
+			addrs = unit.Addresses
+		}
+		out = append(out, deferredIPVLAN{
+			parent: config.LinuxIfName(ifCfg.LocalFabricMember),
+			name:   fabLinux,
+			addrs:  addrs,
+		})
+	})
+	return out
+}
+
+// reassertFabricIPVLANOnce re-creates one round of missing fabric overlays.
+//
+// It takes applySem BEFORE reading ActiveConfig, for the reason #4001 gave the
+// proxy-ARP loop: reading the config outside the semaphore lets a tick capture a
+// PRE-commit snapshot and re-assert state a concurrent commit has just removed —
+// here, re-creating a fab device for a fabric interface the operator had just
+// deleted, which the commit's own stale-overlay sweep had torn down moments
+// before.
+//
+// The gate is re-run INSIDE the semaphore. The pre-check outside it is only an
+// optimisation to avoid queueing behind a commit for nothing; a commit that
+// lands in between may already have created the overlay, and re-running
+// ensureFabricIPVLAN then would be a gratuitous rebuild of a working device.
+func (d *Daemon) reassertFabricIPVLANOnce(ctx context.Context) {
+	if d.store == nil {
+		return
+	}
+	if cfg := d.store.ActiveConfig(); cfg == nil || len(d.missingFabricOverlays(cfg)) == 0 {
+		return // cheap path: nothing configured, or everything already up
+	}
+	if err := d.applySem.Acquire(ctx, 1); err != nil {
+		return // ctx cancelled (daemon shutdown) — do not reconcile.
+	}
+	defer d.applySem.Release(1)
+
+	cfg := d.store.ActiveConfig()
+	if cfg == nil {
+		return
+	}
+	for _, ov := range d.missingFabricOverlays(cfg) {
+		slog.Warn("fabric IPVLAN missing — re-asserting",
+			"parent", ov.parent, "name", ov.name)
+		if err := fabricEnsureFn(ov.parent, ov.name, ov.addrs); err != nil {
+			slog.Error("fabric IPVLAN re-assert failed; will retry",
+				"parent", ov.parent, "name", ov.name, "err", err)
+			continue
+		}
+		slog.Info("fabric IPVLAN re-asserted", "parent", ov.parent, "name", ov.name)
+	}
+}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -567,6 +567,24 @@ func (d *Daemon) Run(ctx context.Context) error {
 		d.raDeadSenderReassertLoop(ctx)
 	}()
 
+	// #6791: the always-on retry owner for a fabric IPVLAN overlay whose
+	// creation failed. Started unconditionally, alongside the proxy-ARP and RA
+	// re-asserts and for the same reason: BOTH standalone and cluster nodes
+	// create fab0/fab1 only from a config apply, whose in-line retry gives up
+	// after five seconds, so a boot-time netlink failure (a parent NIC still
+	// being renamed after a power cycle) otherwise left the node with no
+	// cluster heartbeat and no session-sync transport until an operator
+	// happened to commit. It also covers the deferred (OnXSKBound) overlays,
+	// which are created after the apply has returned and so cannot report
+	// failure to the commit at all. The gate is one netlink name lookup per
+	// configured fab device, so it costs nothing on a healthy node and nothing
+	// at all on a config with no fabric interfaces.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		d.fabricIPVLANReassertLoop(ctx)
+	}()
+
 	// #1387 inc-2: start the always-on DHCP dynamic-DNS reconcile loop. It
 	// is constructed UNCONDITIONALLY (idle when disabled) so an
 	// enabled→disabled commit can still withdraw published records; the loop

--- a/pkg/daemon/device_map_teardown_failclosed_5309_test.go
+++ b/pkg/daemon/device_map_teardown_failclosed_5309_test.go
@@ -262,7 +262,7 @@ func TestApplyTailReconcilesSurfacesDeviceMapTeardownError_5309(t *testing.T) {
 
 	teardownErr := fmt.Errorf("device-map teardown: %w",
 		errors.New("rename-back ge-0-0-9 -> enp99s0: EBUSY"))
-	err := d.applyTailReconciles(cfg, teardownErr, nil, nil, nil, nil, nil, nil, nil, nil)
+	err := d.applyTailReconciles(cfg, teardownErr, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("applyTailReconciles must surface a device-map teardown failure carried " +
 			"in networkdErr (fail-closed); got nil")

--- a/pkg/daemon/dns_ownership_failclosed_6792_test.go
+++ b/pkg/daemon/dns_ownership_failclosed_6792_test.go
@@ -240,7 +240,7 @@ func TestApplyTailReconcilesSurfacesTheDNSError6792(t *testing.T) {
 		return injected
 	}
 
-	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if called == 0 {
 		t.Fatal("applyTailReconciles never ran the DNS reconcile, so this cell " +
 			"cannot distinguish a joined error from a dropped one")
@@ -285,7 +285,7 @@ func TestApplyTailReconcilesIsCleanWhenDNSSucceeds6792(t *testing.T) {
 	}
 	d.reconcileDNSFn = func(*config.Config, bool) error { return nil }
 
-	if err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil); err != nil {
+	if err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil); err != nil {
 		t.Fatalf("applyTailReconciles returned %v with a SUCCEEDING DNS "+
 			"reconcile — every commit would now fail closed on DNS", err)
 	}

--- a/pkg/daemon/fabric_ipvlan_failclosed_6791_test.go
+++ b/pkg/daemon/fabric_ipvlan_failclosed_6791_test.go
@@ -1,0 +1,338 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sync/semaphore"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/networkd"
+	"github.com/psaab/xpf/pkg/vrrp"
+)
+
+// #6791: applyFabricIPVLAN converted a terminal netlink failure into commit
+// SUCCESS, and nothing ever retried it.
+//
+// The evidence was an asymmetry, not a judgement call: in applyConfigLocked the
+// neighbouring reconcilers are captured and threaded into the tail error join
+// (`mgmtRouteErr := …`, `ifaceErr := …`), while `d.applyFabricIPVLAN(cfg)` was a
+// bare statement returning nothing. It logged "CRITICAL: fabric IPVLAN creation
+// failed after retries — cluster heartbeat will not work" and the commit
+// reported success — a node with no heartbeat and no session-sync transport.
+//
+// Both halves of the title are covered here, and separately:
+//   1. the failure PROPAGATES, and reaches the caller that acts on it
+//   2. a persistent recovery owner exists, is started by Run, and re-drives
+
+// fakeFabricLink is a minimal netlink.Link whose admin flags are controllable.
+type fakeFabricLink struct{ attrs netlink.LinkAttrs }
+
+func (f *fakeFabricLink) Attrs() *netlink.LinkAttrs { return &f.attrs }
+func (f *fakeFabricLink) Type() string              { return "ipvlan" }
+
+// fabricCfg6791 builds a config with one fabric interface fab0 over ge-0/0/0.
+func fabricCfg6791() *config.Config {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"fab0": {
+			Name:              "fab0",
+			LocalFabricMember: "ge-0/0/0",
+			Units: map[int]*config.InterfaceUnit{
+				0: {Number: 0, Addresses: []string{"10.99.0.1/24"}},
+			},
+		},
+	}
+	return cfg
+}
+
+// withFabricEnsure swaps the overlay-creation seam for the duration of a test.
+func withFabricEnsure(t *testing.T, fn func(parent, name string, addrs []string) error) {
+	t.Helper()
+	prev := fabricEnsureFn
+	fabricEnsureFn = fn
+	t.Cleanup(func() { fabricEnsureFn = prev })
+}
+
+// --- 1. PROPAGATION -------------------------------------------------------
+
+// TestApplyTailReconcilesJoinsFabricErr is the WIRING cell. Making
+// applyFabricIPVLAN return an error is worthless if that error is dropped at
+// the call site or left out of the join, and a test that only exercised
+// applyFabricIPVLAN's own return value would stay green through exactly that
+// regression.
+//
+// FAIL-ON-REVERT: drop `fabricErr` from the errors.Join in applyTailReconciles
+// (or stop threading it from applyConfigLocked) and this goes RED.
+func TestApplyTailReconcilesJoinsFabricErr_6791(t *testing.T) {
+	// Same construction as the #6792 route-leak/DNS wiring cells: the tail
+	// dispatches to real subsystems, so they are stubbed to SUCCEED and the
+	// injected fabric error is the only operand that can surface.
+	installFakeNetworkctl(t)
+	origApply, origDelete := nftApplyPayload, nftDeleteTable
+	nftApplyPayload = func(string) ([]byte, error) { return nil, nil }
+	nftDeleteTable = func(string, string) ([]byte, error) { return nil, nil }
+	t.Cleanup(func() { nftApplyPayload, nftDeleteTable = origApply, origDelete })
+
+	d := &Daemon{
+		networkd: networkd.NewInDir(t.TempDir()),
+		store:    newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		vrrpMgr:  vrrp.NewManager(),
+		opts:     Options{NoDataplane: true},
+	}
+	d.setDataplane(&runtimeOnlyApplyTestDP{})
+
+	cfg := &config.Config{}
+	injected := errors.New("fabric-ipvlan-injected-6791")
+
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil, injected)
+	if err == nil {
+		t.Fatalf("applyTailReconciles returned nil; a terminal fabric IPVLAN " +
+			"failure must fail the commit closed, not be acknowledged as success")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("joined error %v does not wrap the injected fabric error; the "+
+			"commit result must carry it so the operator sees the cluster has "+
+			"no heartbeat transport", err)
+	}
+}
+
+// TestApplyFabricIPVLANReturnsTerminalFailure covers the PRODUCING half: the
+// retries-exhausted path must yield an error naming the overlay, instead of the
+// bare `continue` that discarded it.
+//
+// FAIL-ON-REVERT: restore that `continue` (drop the fabricErrs append) and this
+// reds on the nil return — while the log line still says the cluster heartbeat
+// will not work.
+func TestApplyFabricIPVLANReturnsTerminalFailure_6791(t *testing.T) {
+	prev := fabricIPVLANRetryDelay
+	fabricIPVLANRetryDelay = time.Millisecond
+	t.Cleanup(func() { fabricIPVLANRetryDelay = prev })
+
+	boom := errors.New("no such device")
+	var mu sync.Mutex
+	var calls int
+	withFabricEnsure(t, func(parent, name string, addrs []string) error {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		return boom
+	})
+
+	d := &Daemon{}
+	err := d.applyFabricIPVLAN(fabricCfg6791())
+
+	mu.Lock()
+	got := calls
+	mu.Unlock()
+	if got == 0 {
+		t.Fatal("applyFabricIPVLAN never attempted the overlay, so this cell " +
+			"cannot distinguish a returned error from a dropped one")
+	}
+	if err == nil {
+		t.Fatalf("applyFabricIPVLAN returned nil after %d failed attempts; a "+
+			"terminal netlink failure must not be converted into commit "+
+			"success — the node has no cluster heartbeat transport", got)
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("returned error %v does not wrap the netlink failure", err)
+	}
+	if !strings.Contains(err.Error(), "fab0") {
+		t.Errorf("returned error %v does not name the overlay that failed", err)
+	}
+}
+
+// TestApplyFabricIPVLANSucceedsWhenOverlayCreates is the TIGHTENING control for
+// the propagation change: applyFabricIPVLAN must return nil on the healthy
+// path. A version that returned an error unconditionally would fail every
+// commit on every node, so this is the cell that makes "fail closed" mean
+// "fail closed on FAILURE" rather than "fail always".
+func TestApplyFabricIPVLANSucceedsWhenOverlayCreates_6791(t *testing.T) {
+	withFabricEnsure(t, func(parent, name string, addrs []string) error { return nil })
+
+	d := &Daemon{}
+	if err := d.applyFabricIPVLAN(fabricCfg6791()); err != nil {
+		t.Fatalf("applyFabricIPVLAN returned %v on a healthy overlay creation; "+
+			"the commit must not fail when the fabric came up", err)
+	}
+}
+
+// --- 2. RECOVERY OWNER ----------------------------------------------------
+
+// TestFabricReassertGateIsQuietWhenOverlayIsUp is the TIGHTENING control: the
+// retry owner must do NOTHING when the overlay is present and up, or it would
+// rebuild a working fabric device every 30s forever.
+//
+// FAIL-ON-REVERT: make the gate unconditional (always report the overlay
+// missing) and this reds.
+func TestFabricReassertGateIsQuietWhenOverlayIsUp_6791(t *testing.T) {
+	d := &Daemon{linkByNameFn: func(name string) (netlink.Link, error) {
+		return &fakeFabricLink{attrs: netlink.LinkAttrs{
+			Name:  name,
+			Flags: net.FlagUp,
+		}}, nil
+	}}
+	if got := d.missingFabricOverlays(fabricCfg6791()); len(got) != 0 {
+		t.Errorf("gate reported %v as needing re-assert while fab0 is present "+
+			"and UP; the loop must be free on a healthy node", got)
+	}
+}
+
+// TestFabricReassertGateFiresWhenOverlayIsDown pins the other side of the gate:
+// a link that exists but is DOWN still needs re-asserting. A gate that only
+// checked existence would leave a down fab0 carrying no traffic forever.
+func TestFabricReassertGateFiresWhenOverlayIsDown_6791(t *testing.T) {
+	d := &Daemon{linkByNameFn: func(name string) (netlink.Link, error) {
+		return &fakeFabricLink{attrs: netlink.LinkAttrs{Name: name}}, nil // no FlagUp
+	}}
+	if got := d.missingFabricOverlays(fabricCfg6791()); len(got) != 1 {
+		t.Errorf("gate did not fire for a fab0 that exists but is DOWN; got %v", got)
+	}
+}
+
+// TestReassertFabricIPVLANOnceRedrives proves the owner actually re-creates the
+// overlay — the behaviour the whole loop exists for.
+func TestReassertFabricIPVLANOnceRedrives_6791(t *testing.T) {
+	var mu sync.Mutex
+	var seen []string
+	withFabricEnsure(t, func(parent, name string, addrs []string) error {
+		mu.Lock()
+		seen = append(seen, parent+"->"+name)
+		mu.Unlock()
+		return nil
+	})
+
+	d := newFabricReassertDaemon(t, fabricCfg6791())
+	d.reassertFabricIPVLANOnce(context.Background())
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seen) != 1 || seen[0] != "ge-0-0-0->fab0" {
+		t.Fatalf("re-assert did not re-create the missing overlay; ensure calls = %v", seen)
+	}
+}
+
+// TestRunStartsFabricReassertLoop is the LOOP-START cell. Every test above
+// drives the re-assert function directly, so a Run that never launched the
+// owner would pass all of them — and "no persistent recovery owner" is half the
+// issue. This asserts the loop is actually started, and started
+// UNCONDITIONALLY (no cluster/standalone gate), by driving the same goroutine
+// Run launches and observing a tick.
+//
+// FAIL-ON-REVERT: delete the `go d.fabricIPVLANReassertLoop(ctx)` block from Run
+// (or wrap it in a mode condition) and this reds on the timeout.
+func TestRunStartsFabricReassertLoop_6791(t *testing.T) {
+	// Prove Run launches it, by source: the loop is a goroutine in Run's
+	// startup fan-out, and a behavioural probe of Run() would need a fully
+	// constructed daemon (netlink, dataplane, sockets) that this package's
+	// unit tests cannot stand up.
+	src := readDaemonSource(t, "daemon_run.go")
+	if !strings.Contains(src, "d.fabricIPVLANReassertLoop(ctx)") {
+		t.Fatalf("Run does not start fabricIPVLANReassertLoop; the fabric " +
+			"overlay has no persistent recovery owner (#6791) and a boot-time " +
+			"netlink failure persists until an operator commits")
+	}
+	// …and that it is not gated behind a mode check, the way the proxy-ARP loop
+	// is. Locate the launch and require the enclosing statement to be the
+	// unconditional wg.Add/go pair.
+	idx := strings.Index(src, "d.fabricIPVLANReassertLoop(ctx)")
+	window := src[clampZero6791(idx-400):idx]
+	if strings.Contains(window, "if d.cluster != nil") ||
+		strings.Contains(window, "if d.isCluster") {
+		t.Errorf("fabricIPVLANReassertLoop is started behind a cluster-mode " +
+			"gate; standalone nodes create fab* from a config apply too and " +
+			"need the same retry owner")
+	}
+
+	// Behavioural half: the loop body itself must tick and call the re-assert.
+	prev := fabricIPVLANReassertInterval
+	fabricIPVLANReassertInterval = 5 * time.Millisecond
+	t.Cleanup(func() { fabricIPVLANReassertInterval = prev })
+
+	fired := make(chan struct{}, 1)
+	withFabricEnsure(t, func(parent, name string, addrs []string) error {
+		select {
+		case fired <- struct{}{}:
+		default:
+		}
+		return nil
+	})
+
+	d := newFabricReassertDaemon(t, fabricCfg6791())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go d.fabricIPVLANReassertLoop(ctx)
+
+	select {
+	case <-fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fabricIPVLANReassertLoop never re-asserted the missing overlay")
+	}
+}
+
+func clampZero6791(i int) int {
+	if i < 0 {
+		return 0
+	}
+	return i
+}
+
+// newFabricReassertDaemon builds a Daemon whose active config is cfg and whose
+// fab* devices are ABSENT, so the re-assert gate fires. applySem is real: the
+// #4001 lock discipline (acquire before reading ActiveConfig) is part of what
+// is under test, and a nil semaphore would panic rather than exercise it.
+func newFabricReassertDaemon(t *testing.T, cfg *config.Config) *Daemon {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := configstore.New(filepath.Join(dir, "xpf.conf"))
+	if err != nil {
+		t.Fatalf("configstore.New: %v", err)
+	}
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	// LocalFabricMember is resolved only under a chassis-cluster stanza
+	// (compiler_derivations.go), and only for a member whose FPC slot maps to
+	// this node — ge-0/0/0 is slot 0, i.e. node 0.
+	if _, err := s.LoadSet(
+		"set chassis cluster cluster-id 1\n" +
+			"set chassis cluster authentication-key test-cluster-psk-6791\n" +
+			"set interfaces ge-0/0/0 unit 0 family inet address 10.99.0.254/24\n" +
+			"set interfaces fab0 fabric-options member-interfaces ge-0/0/0\n" +
+			"set interfaces fab0 unit 0 family inet address 10.99.0.1/24\n",
+	); err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	return &Daemon{
+		store:    s,
+		applySem: semaphore.NewWeighted(1),
+		// Every fab* lookup fails => the gate reports it missing.
+		linkByNameFn: func(name string) (netlink.Link, error) {
+			return nil, errors.New("no such device")
+		},
+	}
+}
+
+// readDaemonSource reads a production source file from this package so a test
+// can assert a WIRING fact (that Run starts a goroutine) that no unit-level
+// behavioural probe can reach without standing up a full daemon.
+func readDaemonSource(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}

--- a/pkg/daemon/fabric_ipvlan_failclosed_6791_test.go
+++ b/pkg/daemon/fabric_ipvlan_failclosed_6791_test.go
@@ -336,3 +336,114 @@ func readDaemonSource(t *testing.T, name string) string {
 	}
 	return string(b)
 }
+
+// TestApplyConfigLockedCapturesAndPassesFabricErr is the CALL-SITE half of the
+// wiring binding, and it exists because the join cell above could not see it.
+//
+// TestApplyTailReconcilesJoinsFabricErr passes the error to applyTailReconciles
+// DIRECTLY, so it stays green if applyConfigLocked stops capturing the return
+// value or stops threading it — which would be the entire fix undone. Measured:
+// replacing the call site with `_ = d.applyFabricIPVLAN(cfg)` left the whole
+// package suite green.
+//
+// applyConfigLocked cannot be driven from a unit test (it needs netlink, a
+// dataplane, sockets), so this asserts the wiring at the source, the same way
+// the loop-START cell does for Run.
+func TestApplyConfigLockedCapturesAndPassesFabricErr_6791(t *testing.T) {
+	src := stripLineComments6791(readDaemonSource(t, "daemon_apply.go"))
+
+	if !strings.Contains(src, "fabricErr := d.applyFabricIPVLAN(cfg)") {
+		t.Errorf("applyConfigLocked does not CAPTURE applyFabricIPVLAN's error; " +
+			"a discarded return value means a terminal fabric failure is still " +
+			"reported as commit success (#6791)")
+	}
+	call := "d.applyTailReconciles("
+	i := strings.Index(src, call)
+	if i < 0 {
+		t.Fatal("could not find the applyTailReconciles call in daemon_apply.go")
+	}
+	end := strings.Index(src[i:], ")")
+	if end < 0 {
+		t.Fatal("malformed applyTailReconciles call")
+	}
+	if !strings.Contains(src[i:i+end], "fabricErr") {
+		t.Errorf("applyConfigLocked does not PASS fabricErr to "+
+			"applyTailReconciles; captured-but-unthreaded is the same false "+
+			"success. Call: %s", src[i:i+end+1])
+	}
+}
+
+// TestReassertTakesApplySemBeforeReadingConfig binds the #4001 lock discipline
+// this loop's doc comment claims.
+//
+// Reading ActiveConfig outside applySem lets a tick capture a PRE-commit
+// snapshot and re-create a fab device the commit's own stale-overlay sweep has
+// just torn down. The ordering is not observable from a unit test without a
+// real concurrent commit, so it is asserted structurally: the semaphore must be
+// acquired before the config read that drives the re-creation loop.
+//
+// FAIL-ON-REVERT: delete the applySem.Acquire and this reds — measured; the
+// behavioural cells all stayed green without it.
+func TestReassertTakesApplySemBeforeReadingConfig_6791(t *testing.T) {
+	src := stripLineComments6791(readDaemonSource(t, "daemon_fabric_reassert.go"))
+	body, ok := fabricFuncBody6791(src, "reassertFabricIPVLANOnce")
+	if !ok {
+		t.Fatal("could not locate reassertFabricIPVLANOnce")
+	}
+	acq := strings.Index(body, "d.applySem.Acquire(")
+	if acq < 0 {
+		t.Fatalf("reassertFabricIPVLANOnce does not acquire applySem; a tick can " +
+			"then re-create an overlay a concurrent commit just removed (#4001)")
+	}
+	if !strings.Contains(body, "defer d.applySem.Release(1)") {
+		t.Errorf("reassertFabricIPVLANOnce acquires applySem without releasing it")
+	}
+	// The config read that drives the re-creation loop must come AFTER the
+	// acquire. The cheap pre-check read before it is fine (it reconciles
+	// nothing), so anchor on the loop itself.
+	loop := strings.Index(body, "for _, ov := range d.missingFabricOverlays(")
+	if loop < 0 {
+		t.Fatal("could not find the re-creation loop")
+	}
+	if loop < acq {
+		t.Errorf("reassertFabricIPVLANOnce re-creates overlays BEFORE acquiring " +
+			"applySem; the config it acts on can be a pre-commit snapshot (#4001)")
+	}
+}
+
+func stripLineComments6791(s string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(s, "\n") {
+		if i := strings.Index(line, "//"); i >= 0 {
+			line = line[:i]
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func fabricFuncBody6791(src, name string) (string, bool) {
+	i := strings.Index(src, ") "+name+"(")
+	if i < 0 {
+		return "", false
+	}
+	open := strings.Index(src[i:], "{")
+	if open < 0 {
+		return "", false
+	}
+	open += i
+	depth := 0
+	for j := open; j < len(src); j++ {
+		switch src[j] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[open : j+1], true
+			}
+		}
+	}
+	return "", false
+}

--- a/pkg/daemon/route_leak_snapshot_failclosed_5696_test.go
+++ b/pkg/daemon/route_leak_snapshot_failclosed_5696_test.go
@@ -149,7 +149,7 @@ func TestApplyTailReconcilesSurfacesRouteLeakError(t *testing.T) {
 	}
 
 	injected := errors.New("injected: route-leak snapshot republish failed")
-	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, injected, nil, nil, nil)
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, injected, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("applyTailReconciles must surface the route-leak reconcile failure " +
 			"(fail-closed); got nil")

--- a/pkg/daemon/routing_rule_reconcile_failclosed_5844_test.go
+++ b/pkg/daemon/routing_rule_reconcile_failclosed_5844_test.go
@@ -130,7 +130,7 @@ func TestApplyTailReconcilesSurfacesRoutingRuleError_5844(t *testing.T) {
 	injected := errors.New("injected: next-table ip-rule reconcile failed")
 	// routingRuleErr is the final applyTailReconciles operand; every other
 	// deferred error is nil so it is the only thing that can surface.
-	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, injected, nil, nil)
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, injected, nil, nil, nil)
 	if err == nil {
 		t.Fatal("applyTailReconciles must surface the routing-rule reconcile failure " +
 			"(fail-closed); got nil")
@@ -184,7 +184,7 @@ func TestApplyTailReconcilesSurfacesMgmtRouteError_5867(t *testing.T) {
 	injected := errors.New("injected: mgmt-VRF RouteReplace rejected")
 	// mgmtRouteErr is the FINAL applyTailReconciles operand; every other deferred
 	// error is nil so it is the only thing that can surface.
-	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, injected, nil)
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, injected, nil, nil)
 	if err == nil {
 		t.Fatal("applyTailReconciles must surface the mgmt-VRF route reconcile failure " +
 			"(fail-closed); got nil")

--- a/pkg/daemon/vrf_setup_bind_commit_truth_5700_test.go
+++ b/pkg/daemon/vrf_setup_bind_commit_truth_5700_test.go
@@ -198,7 +198,7 @@ func TestApplyTailReconcilesSurfacesVRFError_5700(t *testing.T) {
 
 	injected := errors.New("injected: VRF reconcile (vrf-mgmt create) failed")
 	// vrfErr is the LAST operand of applyTailReconciles.
-	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, nil, injected)
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, nil, injected, nil)
 	if err == nil {
 		t.Fatal("applyTailReconciles must surface the VRF reconcile failure " +
 			"(fail-closed); got nil")

--- a/pkg/daemon/vrrp_identity_failclosed_5083_test.go
+++ b/pkg/daemon/vrrp_identity_failclosed_5083_test.go
@@ -48,7 +48,7 @@ func TestApplyTailReconcilesSurfacesVRRPIdentityCollision(t *testing.T) {
 		},
 	}
 
-	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("VRRP identity collision must fail the commit, got nil")
 	}


### PR DESCRIPTION
## Summary

`applyFabricIPVLAN` returned **nothing**. After exhausting five 1s retries it
logged

> `CRITICAL: fabric IPVLAN creation failed after retries — cluster heartbeat will not work`

…and `continue`d, so the commit reported **success** on a node with no
`fab0`/`fab1` — no cluster heartbeat and no session-sync transport. Nothing ever
retried it afterwards.

Closes #6791

> **Cites re-derived.** The issue body points at `/tmp/opus-review-001.md`
> section R50, which no longer exists. Derived from code by symbol.

## The evidence is an asymmetry, not a judgement call

In `applyConfigLocked` the neighbouring reconcilers are captured and threaded
into the tail error join. This one was a bare statement:

```go
mgmtRouteErr := d.applyMgmtVRFRoutes()
ifaceErr     := d.applyInterfaceReconcile(cfg)
d.applyFabricIPVLAN(cfg)          // ← returns nothing
```

It was the **only** reconciler in that sequence whose failure could not
propagate — the same shape as #6792's DNS reconcile sitting between two captured
siblings.

## 1. Propagation

`applyFabricIPVLAN` now returns `errors.Join(fabricErrs...)`, captured as
`fabricErr` and joined in `applyTailReconciles` alongside `ifaceErr`/`vrfErr`.

**Which failures are terminal vs benign-idempotent** — the question that decides
whether this bricks healthy commits. `ensureFabricIPVLAN` already had a sound
taxonomy, so nothing needed reclassifying: it returns an error **only** when
there is no usable overlay (parent lookup, `LinkAdd`, post-create lookup, or
`LinkSetUp` failing). An **already-correct overlay returns nil** after
reconciling; address failures are **warn-only** inside it; and it uses the
idempotent `AddrReplace`. So there is no benign already-exists to misread as
terminal.

At boot it is not fatal either: `applyConfigUnderSem` logs the error and
returns — and correctly skips `MarkActiveApplied`, so a config that never
converged is never stamped applied.

## 2. Persistent recovery owner

Unlike #6793 there was **no existing recovery path to wire up** — I checked
first; nothing retried at all. `applyFabricIPVLAN` runs only from a config
apply, on **both** standalone and cluster nodes, so a netlink failure outlasting
those five seconds (a parent NIC still being renamed after a power cycle is the
motivating case) left the fabric absent until an operator happened to commit.

`fabricIPVLANReassertLoop` is that owner, modelled on `proxyARPReassertLoop` /
`raDeadSenderReassertLoop`: started **unconditionally** in `Run`, re-reading the
active config each tick, taking `applySem` **before** reading `ActiveConfig`
(#4001) and re-checking its gate inside the semaphore so a tick cannot re-create
an overlay a concurrent commit just removed.

It is also the **only** owner that can cover the deferred (`OnXSKBound`)
overlays, which are created after the apply has returned and so cannot report
failure to the commit at all.

**The gate is cheap and deliberately shallow**: one netlink name lookup per
configured `fab*` device, checking presence and admin-up only. It does *not*
verify parent index, MTU or addresses — those are `ensureFabricIPVLAN`'s job, and
re-running it for cosmetic drift would rebuild a working fabric device every 30s.
So the loop costs nothing on a healthy node and nothing at all on a config with
no fabric interfaces.

## Test plan

- [x] `go build ./... && go vet ./... && go test -count=1 ./...` — green, 67 packages
- [x] Mutation matrix, 10 cells, all RED — see below
- [ ] **`make test-failover` — NOT RUN.** Fabric IPVLAN carries cluster heartbeat
      and session sync, so this needs the shared cluster. Flagged for the team
      lead; I ran no `cluster-*` target.

### Mutation matrix

Each cell: restored from HEAD, anchor verified to match exactly once, mutation
verified present, `go build ./...` verified, then the **full package suite**,
`-count=1`, **no `-run` filter**.

| Cell | Mutation | Result | Assertion that fired |
|---|---|---|---|
| F1 | DROP the error (restore the bare `continue`) | **RED** | `applyFabricIPVLAN returned nil after 6 failed attempts` |
| F2 | WIRING: drop `fabricErr` from the tail `errors.Join` | **RED** | `applyTailReconciles returned nil` |
| F3 | WIRING: discard the error at the **call site** | **RED** \* | `applyConfigLocked does not CAPTURE applyFabricIPVLAN's error` |
| F4 | TIGHTEN: return an error **unconditionally** | **RED** | `applyConfigLocked(...) = always, want nil` |
| F5 | LOOP START: `Run` never launches the owner | **RED** | `Run does not start fabricIPVLANReassertLoop` |
| F6 | LOOP BODY: tick never calls the re-assert | **RED** | `never re-asserted the missing overlay` |
| F7 | RE-DRIVE: never call `ensureFabricIPVLAN` | **RED** | `re-assert did not re-create the missing overlay` |
| F8 | GATE: ignore admin-up (a DOWN fab0 looks healthy) | **RED** | `gate did not fire for a fab0 that exists but is DOWN` |
| F9 | GATE: always report missing | **RED** | `gate reported [...] while fab0 is present and UP` |
| F10 | LOCK: drop the #4001 `applySem` acquire | **RED** \* | `does not acquire applySem` |

**F4 is the tightening control** for the fail-closed change — "returns an error
unconditionally" must red, or "fail closed" would mean "fail always" and every
commit on every node would fail.

\* **F3 and F10 initially SURVIVED**, and both are the lessons you named:

- **F3 — bind the WIRING, not just the function.** The join cell passes the
  error to `applyTailReconciles` *directly*, so replacing
  `fabricErr := d.applyFabricIPVLAN(cfg)` with `_ = d.applyFabricIPVLAN(cfg)`
  left the whole package suite green — the entire fix undone, invisibly.
  Exactly #6792's shape. `applyConfigLocked` can't be driven from a unit test,
  so the capture *and* the threading are now asserted at the source, the way the
  loop-START cell asserts `Run`.
- **F10 — the #4001 lock ordering my own comment claimed.** Every behavioural
  cell drives the re-assert single-threaded, where the semaphore is invisible.
  Now asserted structurally: acquired, released, and ordered before the
  re-creation loop's config read.

Both were claims the comments already made; now they are proven.

## Deliberately not changed

The in-apply retry still sleeps up to 5×1s per overlay, holding the apply
semaphore. With a recovery owner it is arguably redundant, but shortening it is
a behaviour change riding on a bug fix, and the retry genuinely helps the common
boot case where the parent appears within a second or two.

## Refs

- #6791 (this), #6792 / #6793 (same family, the asymmetry and
  undriven-recovery-owner patterns), #5310 / #5696 / #5844 / #5700 (the
  fail-closed-and-complete deferred-error precedent this joins), #4001
  (applySem before ActiveConfig), #2865 / #128 / #127 (fabric overlay history)
