### PR TITLE
frr: keep a multi-token BGP neighbor identity out of frr.conf

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104796,3 +104796,23 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/vrrp/reth_rg_parity_6781_test.go` (new),
   `pkg/vrrp/reth_rg_ssot_6781_test.go` (new),
   `pkg/config/reth_rg_gate_6781_test.go` (new), `pkg/vrrp/README.md`
+
+## 2026-08-22 — #6796 BGP neighbor identity could span multiple FRR tokens
+
+- **Timestamp**: 2026-08-22
+- **Action**: `n.Address` was rendered RAW at 24 frr.conf sites while every
+  neighbouring operand was sanitized. FRR's lexer splits on whitespace with no
+  quoted-string token, so an identity carrying a space/newline rendered as
+  MULTIPLE statements — arbitrary FRR config injected through a config value,
+  reaching both the BGP neighbor lines and the BFD peer accumulator. Added
+  `validBGPNeighborAddress` at the shared `validNeighbors` exclusion point
+  (covers all 24 sites and BFD at once) plus a strict commit gate
+  `validateBGPNeighborAddressStrict` with `lenientBGPNeighborAddress` per
+  #1960. First version required a bare IP and was caught OVER-REJECTING by a
+  pre-existing parser test peering with `peer.example.com`; corrected to
+  single-token-ness, which is the actual property.
+- **File(s)**: pkg/frr/render_validate.go, pkg/frr/protocols_render.go,
+  pkg/frr/bgp_neighbor_token_6796_test.go,
+  pkg/config/compiler_validate_strict_routing.go, pkg/config/compiler_opts.go,
+  pkg/config/compiler_uniformgates_log_feed_routing.go,
+  pkg/config/bgp_neighbor_token_6796_test.go, pkg/frr/README.md, _Log.md

--- a/pkg/config/bgp_neighbor_token_6796_test.go
+++ b/pkg/config/bgp_neighbor_token_6796_test.go
@@ -1,0 +1,162 @@
+package config
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func bgpNeighborConfig6796(addr string) *Config {
+	cfg := &Config{}
+	cfg.Protocols.BGP = &BGPConfig{
+		LocalAS:  65001,
+		RouterID: "10.0.0.1",
+		Neighbors: []*BGPNeighbor{
+			{Address: addr, PeerAS: 65000},
+		},
+	}
+	return cfg
+}
+
+// TestMultiTokenNeighborIsRejectedAtCommit6796 is the strict half, PAIRED: the
+// same gate, an injecting identity and a legitimate one, opposite verdicts.
+//
+// The accept leg is not decoration. FRR's grammar is
+// `neighbor <A.B.C.D|X:X::X:X|WORD>`, and this tree already commits configs
+// whose neighbor is a hostname — the first version of this fix required a bare
+// IP and was caught by a PRE-EXISTING parser test peering with
+// `peer.example.com`. Over-rejection in routing config is an outage, so the
+// accepting rows are the ones that keep the gate honest.
+func TestMultiTokenNeighborIsRejectedAtCommit6796(t *testing.T) {
+	rejected := []string{
+		"1.1.1.1 remote-as 65000",
+		"1.1.1.1\n neighbor 2.2.2.2",
+		"1.1.1.1\tremote-as 65000",
+		"",
+	}
+	for _, addr := range rejected {
+		if err := validateBGPNeighborAddressStrict(bgpNeighborConfig6796(addr)); err == nil {
+			t.Errorf("commit ACCEPTED a neighbor identity spanning more than one "+
+				"FRR token (%q) — it renders as multiple frr.conf statements and "+
+				"injects configuration the operator never wrote (#6796)", addr)
+		}
+	}
+
+	accepted := []string{
+		"10.0.0.2",
+		"2001:db8::2",
+		"peer.example.com",
+		"UPSTREAM-GROUP",
+	}
+	for _, addr := range accepted {
+		if err := validateBGPNeighborAddressStrict(bgpNeighborConfig6796(addr)); err != nil {
+			t.Errorf("commit REJECTED the legitimate single-token neighbor %q: %v "+
+				"— dropping a working peering is an outage, and it is the "+
+				"direction a fail-closed gate gets wrong", addr, err)
+		}
+	}
+}
+
+// TestMultiTokenNeighborGateNamesTheNeighbor6796 pins the operator-facing half.
+// A gate that rejects without saying WHICH neighbor leaves an operator grepping
+// a large BGP config; the sibling peer-as gate names it, and so must this one.
+func TestMultiTokenNeighborGateNamesTheNeighbor6796(t *testing.T) {
+	cfg := bgpNeighborConfig6796("1.1.1.1 remote-as 65000")
+	cfg.Protocols.BGP.Neighbors[0].GroupName = "upstream"
+
+	err := validateBGPNeighborAddressStrict(cfg)
+	if err == nil {
+		t.Fatal("expected a rejection")
+	}
+	if !strings.Contains(err.Error(), "upstream") {
+		t.Fatalf("the error does not name the GROUP, so an operator cannot "+
+			"locate the offending stanza: %v", err)
+	}
+	if !strings.Contains(err.Error(), "1.1.1.1") {
+		t.Fatalf("the error does not quote the offending identity: %v", err)
+	}
+}
+
+// TestMultiTokenNeighborGateIsLenientOnTheTolerantPath6796 pins #1960. A
+// strict gate that also fired on the tolerant load / peer-sync path would brick
+// a node whose already-persisted config carries such a neighbor — turning a
+// render-time defect into a boot failure, which is strictly worse.
+//
+// RED-on-revert: unregister lenientBGPNeighborAddress from the tolerant opt set
+// and the lenient compile returns an error instead of a warning.
+func TestMultiTokenNeighborGateIsLenientOnTheTolerantPath6796(t *testing.T) {
+	cfg := bgpNeighborConfig6796("1.1.1.1 remote-as 65000")
+	if err := validateBGPNeighborAddressStrict(cfg); err == nil {
+		t.Fatal("precondition: the fixture must be rejected by the STRICT gate, " +
+			"or the lenient assertion below is vacuous")
+	}
+	if !lenientCompileOpts().lenientBGPNeighborAddress {
+		t.Fatal("lenientBGPNeighborAddress is NOT registered in the tolerant " +
+			"opt set — a leniently-loaded or peer-synced config carrying such a " +
+			"neighbor would fail to compile and the node would not boot, turning " +
+			"a render-time defect into a boot failure (#1960)")
+	}
+}
+
+// rustlessTokenRe extracts the render-side belt's body so the two spellings of
+// "one FRR token" can be compared rather than each pinned to a literal.
+var renderBeltRe = regexp.MustCompile(`(?s)func validBGPNeighborAddress\(s string\) bool \{(.*?)\n\}`)
+var commitGateRe = regexp.MustCompile(`(?s)func isSingleFRRToken\(s string\) bool \{(.*?)\n\}`)
+
+// TestNeighborTokenGateAgreesWithTheRenderBelt6796 asserts the AGREEMENT
+// between the commit gate and the render belt, by reading BOTH bodies rather
+// than pinning either to a literal.
+//
+// The two must accept exactly the same set. If the commit gate were stricter,
+// operators would be told a working config is invalid; if the render belt were
+// stricter, a committed config would silently lose a peering at render time —
+// and neither divergence produces an error anywhere, so nothing else would
+// notice. Pinning one side to a literal would encode which side is trusted, and
+// here neither is: the first version of this fix had BOTH wrong in the same
+// direction (requiring an IP), and only a pre-existing test caught it.
+//
+// Comments are stripped before comparison: both bodies are introduced by doc
+// comments describing the byte set, and a gate satisfiable by its own
+// documentation proves nothing.
+func TestNeighborTokenGateAgreesWithTheRenderBelt6796(t *testing.T) {
+	strip := func(src string) string {
+		var b strings.Builder
+		for _, line := range strings.Split(src, "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "//") {
+				continue
+			}
+			b.WriteString(strings.TrimSpace(line))
+			b.WriteString("\n")
+		}
+		return b.String()
+	}
+
+	beltSrc, err := os.ReadFile("../frr/render_validate.go")
+	if err != nil {
+		t.Fatalf("read the render belt: %v", err)
+	}
+	gateSrc, err := os.ReadFile("compiler_validate_strict_routing.go")
+	if err != nil {
+		t.Fatalf("read the commit gate: %v", err)
+	}
+
+	belt := renderBeltRe.FindStringSubmatch(strip(string(beltSrc)))
+	if belt == nil {
+		t.Fatal("validBGPNeighborAddress not found in pkg/frr — the render belt " +
+			"was renamed or removed, so a committed multi-token neighbor would " +
+			"reach frr.conf (#6796)")
+	}
+	gate := commitGateRe.FindStringSubmatch(strip(string(gateSrc)))
+	if gate == nil {
+		t.Fatal("isSingleFRRToken not found in pkg/config — the commit gate was " +
+			"renamed or removed")
+	}
+	if strings.TrimSpace(belt[1]) != strings.TrimSpace(gate[1]) {
+		t.Fatalf("the commit gate and the render belt disagree about what one "+
+			"FRR token is. A stricter commit gate rejects working configs; a "+
+			"stricter belt silently drops a committed peering. Neither "+
+			"divergence errors anywhere.\n--- render belt ---\n%s\n--- commit "+
+			"gate ---\n%s", belt[1], gate[1])
+	}
+}

--- a/pkg/config/compiler_opts.go
+++ b/pkg/config/compiler_opts.go
@@ -1566,6 +1566,21 @@ type compileOpts struct {
 	// and a leniently-loaded bad neighbor is inert. Same doctrine as
 	// lenientRoutingExportRef.
 	lenientBGPNeighborPeerAS bool
+	// lenientBGPNeighborAddress (#6796) downgrades the BGP neighbor-address
+	// gate (validateBGPNeighborAddressStrict) from a hard compile error to a
+	// cfg.Warnings entry. The address is rendered RAW into frr.conf at 24
+	// sites, and FRR's command lexer splits on whitespace with no
+	// quoted-string token — so an address carrying spaces or newlines renders
+	// as MULTIPLE statements and injects configuration the operator never
+	// wrote. The strict commit / commit-check path hard-rejects so the bad
+	// value is operator-visible, naming the neighbor and its group; the
+	// tolerant load / peer-sync paths warn so an already-persisted or
+	// peer-synced config carrying such a neighbor still BOOTS (#1960
+	// fail-closed-on-load class) — the render path skips a neighbor whose
+	// address is not a bare IP, so it never reaches frr.conf and a leniently
+	// loaded bad address is inert. Same doctrine as lenientBGPNeighborPeerAS,
+	// whose renderer-side exclusion set this shares.
+	lenientBGPNeighborAddress bool
 	// lenientRouterID (#2980) downgrades the OSPF/OSPFv3/BGP router-id gate
 	// (validateRouterIDStrict) from a hard compile error to a cfg.Warnings
 	// entry. router-id is parsed as a raw string with no validation, so a
@@ -2460,6 +2475,7 @@ func lenientCompileOpts() compileOpts {
 		lenientRPMHTTPGetScheme:                true,
 		lenientRPMRoutingInstance:              true,
 		lenientBGPNeighborPeerAS:               true,
+		lenientBGPNeighborAddress:              true,
 		lenientRouterID:                        true,
 		lenientSNMPTrapGroup:                   true,
 		lenientBridgeDomainVlanID:              true,

--- a/pkg/config/compiler_uniformgates_log_feed_routing.go
+++ b/pkg/config/compiler_uniformgates_log_feed_routing.go
@@ -295,6 +295,24 @@ func runUniformGatesLogFeedRouting(tree *ConfigTree, cfg *Config, opts compileOp
 	// already-persisted or peer-synced config still boots — #1960; the render
 	// path now skips an invalid router-id so it never reaches frr.conf). Runs
 	// on the fully-compiled *Config. Mirrors validateBGPNeighborPeerASStrict.
+	// #6796: the BGP neighbor ADDRESS is rendered raw at every frr.conf site,
+	// and FRR's lexer splits on whitespace with no quoted-string token — so an
+	// address carrying spaces or newlines renders as MULTIPLE statements and
+	// injects configuration the operator never wrote. Strict on commit /
+	// commit-check (hard reject naming the neighbor); lenient on load /
+	// peer-sync (warn so an already-persisted config still boots — #1960; the
+	// renderer skips a non-IP neighbor so it never reaches frr.conf). Placed
+	// beside validateBGPNeighborPeerASStrict, whose renderer exclusion set it
+	// shares.
+	if err := validateBGPNeighborAddressStrict(cfg); err != nil {
+		if opts.lenientBGPNeighborAddress {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("bgp neighbor address (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	if err := validateRouterIDStrict(cfg); err != nil {
 		if opts.lenientRouterID {
 			cfg.Warnings = append(cfg.Warnings,

--- a/pkg/config/compiler_validate_strict_routing.go
+++ b/pkg/config/compiler_validate_strict_routing.go
@@ -599,6 +599,99 @@ func validateFRRAuthValuesStrict(cfg *Config) error {
 	return nil
 }
 
+// validateBGPNeighborAddressStrict hard-rejects a BGP neighbor identity that
+// does not occupy exactly ONE FRR token (#6796).
+//
+// The address is rendered RAW into frr.conf at 24 sites — unlike every operand
+// around it (update-source, description, password are all sanitized) — so a
+// value carrying whitespace SPANS MULTIPLE FRR TOKENS. FRR's command lexer has
+// no quoted-string and no rest-of-line token: it splits on whitespace. An
+// address of `1.1.1.1 remote-as 65000\n neighbor 2.2.2.2` therefore renders a
+// valid first statement followed by an attacker-chosen second one — arbitrary
+// FRR configuration injected through a config value, including peerings and
+// route-maps the operator never wrote.
+//
+// Strict on commit / commit-check (hard reject naming the neighbor, and the
+// group when there is one); lenient on load / peer-sync so an already-persisted
+// or peer-synced config still BOOTS (#1960) — the render path skips a neighbor
+// whose address is not a bare IP, so an invalid one never reaches frr.conf and
+// a leniently-loaded bad address is inert. Same doctrine as
+// validateBGPNeighborPeerASStrict, whose exclusion set the renderer shares.
+//
+// The test is token COUNT, deliberately not address form. FRR's grammar is
+// `neighbor <A.B.C.D|X:X::X:X|WORD>` and this tree already commits configs
+// whose neighbor is a hostname, so requiring an IP literal would reject configs
+// that work today — over-rejection in routing config is an outage. Empty is not
+// accepted: an unnamed neighbor cannot be rendered at all, and letting it
+// through would emit `neighbor  remote-as N` with a doubled space.
+
+// isSingleFRRToken reports whether s is one unbroken FRR token: non-empty, and
+// free of every byte FRR's lexer treats as a separator (space, tab, CR, LF,
+// form feed, vertical tab) as well as the remaining control bytes and DEL,
+// which would corrupt the rendered line. It is the commit-side twin of
+// frr.validBGPNeighborAddress; the two must agree, and
+// TestNeighborTokenGateAgreesWithTheRenderBelt6796 asserts that rather than
+// pinning either to a literal.
+func isSingleFRRToken(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] <= 0x20 || s[i] == 0x7f {
+			return false
+		}
+	}
+	return true
+}
+func validateBGPNeighborAddressStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+
+	checkBGP := func(scope string, bgp *BGPConfig) error {
+		if bgp == nil {
+			return nil
+		}
+		neighbors := append([]*BGPNeighbor(nil), bgp.Neighbors...)
+		sort.SliceStable(neighbors, func(i, j int) bool {
+			return neighbors[i].Address < neighbors[j].Address
+		})
+		for _, n := range neighbors {
+			if n == nil {
+				continue
+			}
+			if isSingleFRRToken(n.Address) {
+				continue
+			}
+			detail := fmt.Sprintf("%sprotocols bgp neighbor %q", scope, n.Address)
+			if n.GroupName != "" {
+				detail = fmt.Sprintf("%sprotocols bgp group %s neighbor %q", scope, n.GroupName, n.Address)
+			}
+			return fmt.Errorf("%s: not a single token — FRR's command lexer "+
+				"splits on whitespace and has no quoted-string token, so a "+
+				"neighbor identity carrying spaces or newlines renders as "+
+				"MULTIPLE frr.conf statements and injects configuration the "+
+				"operator did not write; use one unbroken address or peer name",
+				detail)
+		}
+		return nil
+	}
+
+	if err := checkBGP("", cfg.Protocols.BGP); err != nil {
+		return err
+	}
+	for _, ri := range cfg.RoutingInstances {
+		if ri == nil {
+			continue
+		}
+		scope := fmt.Sprintf("routing-instance %s ", ri.Name)
+		if err := checkBGP(scope, ri.BGP); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // validateBGPNeighborPeerASStrict hard-rejects a BGP neighbor whose effective
 // peer-as (remote-as) is missing/0 or out of the valid AS range (#2963).
 //

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -47,6 +47,50 @@ community classification, `renderComposedRouteMap`, and the `-xpf-redist`
 alias guard. The detailed rendering semantics documented in the
 `policy_render.go` row below apply wherever each function now lives:
 
+### BGP neighbor identity is a single FRR token (#6796)
+
+`n.Address` is rendered RAW at 24 sites in `protocols_render.go` — unlike every
+operand around it (`update-source`, `description`, `password` all go through
+`sanitizeFRRValue`). FRR's command lexer has **no quoted-string and no
+rest-of-line token: it splits on whitespace**, so an identity carrying a space
+or a newline SPANS MULTIPLE FRR STATEMENTS. An address of
+`1.1.1.1 remote-as 65000\n neighbor 2.2.2.2` renders a valid first statement
+followed by an attacker-chosen second one — arbitrary FRR configuration,
+including peerings the operator never wrote, injected through a config value.
+
+**`sanitizeFRRValue` is deliberately NOT the tool here.** It maps control bytes
+to a SPACE, and space is exactly the separator FRR tokenizes on: replacing a
+newline with a space still splits the token, and a plain embedded space is not a
+control byte at all, so it passes through untouched. A sanitizer whose
+replacement character is the sink's delimiter cannot make a value safe for that
+sink.
+
+The belt is `validBGPNeighborAddress` (`render_validate.go`), applied at the
+`validNeighbors` construction — the SINGLE exclusion set the declaration loop,
+the address-family activation loop and the BFD accumulator all iterate. That
+placement is deliberate: a per-site guard would have to be repeated 24 times and
+could diverge, and a neighbor declared-but-not-activated (or activated-but-not-
+declared, or carrying a `bfd` peer without a declaration) makes vtysh reject the
+**whole** managed section. It also covers the "reused raw by BGP and BFD" half of
+the issue for free.
+
+**The test is token COUNT, not address form.** FRR's grammar is
+`neighbor <A.B.C.D|X:X::X:X|WORD>`, and this tree already commits configs whose
+neighbor is a hostname — the first version of this fix required a bare IP and was
+caught by a pre-existing parser test peering with `peer.example.com`.
+Over-rejection in routing config is an outage.
+
+Commit / commit-check stay strict (`validateBGPNeighborAddressStrict`,
+`pkg/config`), with `lenientBGPNeighborAddress` registered per #1960 so a
+tolerantly-loaded or peer-synced config still boots. The two predicates must
+accept exactly the same set: a stricter commit gate tells operators a working
+config is invalid, a stricter belt silently drops a committed peering, and
+neither divergence produces an error anywhere.
+`TestNeighborTokenGateAgreesWithTheRenderBelt6796` asserts the agreement by
+reading both function bodies rather than pinning either to a literal — the first
+version had BOTH wrong in the same direction, so trusting either side would have
+encoded the mistake.
+
 | File | Owns |
 |---|---|
 | `manager.go` | `Manager` struct + lifecycle (`New`, `ApplyFull`, `Clear`, `writeManagedSection`, `reload`), top-level types (`InstanceConfig`, `DHCPRoute`, `FullConfig`), package constants, and the zero-value-safe `executor()` accessor. The legacy `Apply`/`ApplyWithInstances` partial constructors were deleted (#1827 AGY F1, PR #1843): they bypassed `assembleFRRConfig` and would have wiped an active failover overlay. |

--- a/pkg/frr/bgp_neighbor_token_6796_test.go
+++ b/pkg/frr/bgp_neighbor_token_6796_test.go
@@ -1,0 +1,129 @@
+package frr
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// injectedNeighbor6796 is the shape the defect permits: a first statement FRR
+// accepts, then a newline, then a second statement the operator never wrote.
+const injectedNeighbor6796 = "1.1.1.1 remote-as 65000\n neighbor 2.2.2.2"
+
+func bgpWithNeighbors6796(addrs ...string) *config.BGPConfig {
+	bgp := &config.BGPConfig{LocalAS: 65001, RouterID: "10.0.0.1"}
+	for _, a := range addrs {
+		bgp.Neighbors = append(bgp.Neighbors, &config.BGPNeighbor{
+			Address:    a,
+			PeerAS:     65000,
+			BFD:        true,
+			FamilyInet: true,
+		})
+	}
+	return bgp
+}
+
+// renderProtocols6796 renders the BGP block the way production does.
+func renderProtocols6796(t *testing.T, bgp *config.BGPConfig) string {
+	t.Helper()
+	m := &Manager{}
+	return m.generateProtocols(nil, nil, bgp, nil, nil, "", 0, nil, nil)
+}
+
+// TestMultiTokenNeighborNeverReachesFRRConf6796 is the render-side belt.
+//
+// n.Address is emitted RAW at 24 sites, and FRR's lexer splits on whitespace
+// with no quoted-string token — so an identity carrying a newline renders a
+// valid first statement plus an attacker-chosen second one. This asserts what
+// the render BECAME, not merely that the raw needle is absent: an absence check
+// alone passes against a renderer that emits nothing at all.
+func TestMultiTokenNeighborNeverReachesFRRConf6796(t *testing.T) {
+	good := "10.0.0.2"
+	out := renderProtocols6796(t, bgpWithNeighbors6796(good, injectedNeighbor6796))
+
+	// The legitimate neighbor must still be fully rendered — otherwise a
+	// renderer that dropped the whole BGP block would pass the absence check
+	// below for the wrong reason.
+	if !strings.Contains(out, "neighbor "+good+" remote-as 65000") {
+		t.Fatalf("the VALID neighbor was not rendered; the belt is dropping "+
+			"more than the bad one:\n%s", out)
+	}
+	if !strings.Contains(out, "neighbor "+good+" bfd") {
+		t.Fatalf("the valid neighbor lost its bfd line:\n%s", out)
+	}
+
+	// The injected second statement must not appear anywhere.
+	if strings.Contains(out, "neighbor 2.2.2.2") {
+		t.Fatalf("a multi-token neighbor identity injected a SECOND frr.conf "+
+			"statement the operator never wrote (#6796):\n%s", out)
+	}
+	// Nor the first half of it, which would still be a peering to a host the
+	// operator did not configure.
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "neighbor 1.1.1.1") {
+			t.Fatalf("the injected identity's first token still rendered as a "+
+				"real peering: %q\n%s", line, out)
+		}
+	}
+}
+
+// TestMultiTokenNeighborIsExcludedFromBFDToo6796 pins the OTHER consumer.
+//
+// The identity is reused by the BFD peer accumulator as well as the neighbor
+// statements, which is the "reused raw by BGP and BFD" half of the issue.
+// Excluding it from validNeighbors covers both — but only because that set is
+// the shared exclusion point; a per-site guard on the neighbor lines alone
+// would leave the BFD peer behind, and a `bfd` peer for a neighbor that was
+// never declared makes vtysh reject the WHOLE managed section.
+func TestMultiTokenNeighborIsExcludedFromBFDToo6796(t *testing.T) {
+	out := renderProtocols6796(t, bgpWithNeighbors6796("10.0.0.2", injectedNeighbor6796))
+
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "peer 1.1.1.1") || strings.HasPrefix(trimmed, "peer 2.2.2.2") {
+			t.Fatalf("a multi-token neighbor still produced a BFD peer: %q\n%s",
+				line, out)
+		}
+	}
+	// Control: the valid neighbor's BFD peer IS present, so the assertion above
+	// is not passing because BFD rendering is off entirely.
+	if !strings.Contains(out, "peer 10.0.0.2") {
+		t.Fatalf("the valid neighbor produced no BFD peer, so the exclusion "+
+			"assertion above proves nothing:\n%s", out)
+	}
+}
+
+// TestNeighborTokenBeltAcceptsAHostname6796 is the OVER-REJECTION control, and
+// it exists because the first version of this fix required a bare IP and was
+// caught by a pre-existing parser test peering with `peer.example.com`.
+//
+// FRR's grammar is `neighbor <A.B.C.D|X:X::X:X|WORD>`, so a hostname or peer
+// name is a legitimate single token. Rejecting it would drop a working peering
+// from frr.conf — in routing config, over-rejection is an outage, and it is the
+// direction a fail-closed belt is most likely to get wrong.
+func TestNeighborTokenBeltAcceptsAHostname6796(t *testing.T) {
+	for _, addr := range []string{
+		"10.0.0.2",
+		"2001:db8::2",
+		"peer.example.com",
+		"UPSTREAM-GROUP",
+	} {
+		if !validBGPNeighborAddress(addr) {
+			t.Errorf("validBGPNeighborAddress(%q) = false — this is a single "+
+				"FRR token and rejecting it drops a working peering", addr)
+		}
+	}
+	for _, addr := range []string{
+		"",
+		"1.1.1.1 remote-as 65000",
+		"1.1.1.1\nneighbor 2.2.2.2",
+		"1.1.1.1\tremote-as 65000",
+		"1.1.1.1\rneighbor 2.2.2.2",
+	} {
+		if validBGPNeighborAddress(addr) {
+			t.Errorf("validBGPNeighborAddress(%q) = true — this spans more than "+
+				"one FRR token and injects a second statement", addr)
+		}
+	}
+}

--- a/pkg/frr/protocols_render.go
+++ b/pkg/frr/protocols_render.go
@@ -241,6 +241,20 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 			if n.PeerAS == 0 {
 				continue
 			}
+			// #6796: the address is rendered RAW at every site below, so a
+			// value carrying whitespace SPANS MULTIPLE FRR TOKENS and injects
+			// attacker-chosen configuration (`1.1.1.1 remote-as 65000\n
+			// neighbor 2.2.2.2` becomes a valid first line plus a second
+			// statement). Excluding it HERE rather than guarding each render
+			// site is deliberate: this set is already the single exclusion
+			// point the declaration loop, the address-family activation loop
+			// and the BFD accumulator all share, so a per-site guard would
+			// have to be repeated 24 times and could diverge — and a neighbor
+			// declared-but-not-activated, or activated-but-not-declared, makes
+			// vtysh reject the WHOLE managed section.
+			if !validBGPNeighborAddress(n.Address) {
+				continue
+			}
 			validNeighbors = append(validNeighbors, n)
 		}
 	}

--- a/pkg/frr/render_validate.go
+++ b/pkg/frr/render_validate.go
@@ -91,6 +91,49 @@ func validClusterID(s string) bool {
 	return err == nil && v >= 1
 }
 
+// validBGPNeighborAddress reports whether a BGP neighbor identity occupies
+// exactly ONE FRR token.
+//
+// Render-side fail-closed belt for #6796. `n.Address` is rendered RAW at 24
+// sites — unlike every other operand around it (update-source, description and
+// password are all sanitized) — so a value carrying whitespace SPANS MULTIPLE
+// FRR TOKENS: an identity of `1.1.1.1 remote-as 65000\n neighbor 2.2.2.2`
+// renders a valid first statement followed by an attacker-chosen second one,
+// which is arbitrary FRR configuration injected through a config value.
+//
+// The test is single-token-ness, deliberately NOT "is an IP". FRR's grammar is
+// `neighbor <A.B.C.D|X:X::X:X|WORD>`, and this tree already commits configs
+// whose neighbor is a hostname (a pre-existing parser test peers with
+// `peer.example.com`). Requiring an IP literal would reject configs that work
+// today — over-rejection in routing config is an outage, and the defect here is
+// about token COUNT, not address form.
+//
+// sanitizeFRRValue is deliberately not the tool, and this is the reason: it
+// maps control bytes to a SPACE, and space is exactly the separator FRR
+// tokenizes on. Replacing a newline with a space still splits the token, and a
+// plain embedded space is not a control byte at all, so it passes through
+// untouched. A sanitizer whose replacement character is the sink's delimiter
+// cannot make a value safe for that sink.
+//
+// Commit / commit-check stay strict (validateBGPNeighborAddressStrict); this is
+// the #1960 belt for the tolerant load / peer-sync / rollback paths, which only
+// warn.
+func validBGPNeighborAddress(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		// Space, tab, CR, LF, form feed, vertical tab — every byte FRR's lexer
+		// treats as a separator — plus the remaining control bytes and DEL,
+		// which have no legitimate place in an identity and would corrupt the
+		// rendered line.
+		if s[i] <= 0x20 || s[i] == 0x7f {
+			return false
+		}
+	}
+	return true
+}
+
 // validBGPOrigin reports whether a route-map `then origin` value is one of the
 // three tokens FRR's `set origin <egp|igp|incomplete>` grammar accepts.
 // Render-side belt for #4919: `then origin` is stored verbatim and was only


### PR DESCRIPTION
Closes #6796

## What was wrong

`n.Address` is rendered **RAW at 24 sites** in `protocols_render.go` — unlike
every operand around it: `update-source`, `description` and `password` all go
through `sanitizeFRRValue`.

FRR's command lexer has **no quoted-string and no rest-of-line token: it splits
on whitespace.** So a neighbor identity carrying a space or a newline spans
MULTIPLE FRR statements. An address of

```
1.1.1.1 remote-as 65000
 neighbor 2.2.2.2
```

renders a valid first statement followed by an attacker-chosen second one —
arbitrary FRR configuration, including peerings and route-maps the operator
never wrote.

The identity is reused by the **BFD peer accumulator** as well as the neighbor
statements, which is the "reused raw by BGP and BFD" half of the title.

## Why `sanitizeFRRValue` is not the tool

It maps control bytes to a **space** — and space is exactly the separator FRR
tokenizes on. Replacing a newline with a space still splits the token, and a
plain embedded space is not a control byte at all, so it passes through
untouched. **A sanitizer whose replacement character is the sink's delimiter
cannot make a value safe for that sink.**

## Where the belt goes, and why there

At the `validNeighbors` construction — already the single exclusion set the
declaration loop, the address-family activation loop and the BFD accumulator all
iterate. That placement covers all 24 sites and the BFD half at once, and it is
the only safe placement: a per-site guard would be repeated 24 times and could
diverge, and a neighbor declared-but-not-activated — or carrying a `bfd` peer
without a declaration — makes vtysh reject the **whole** managed section.

## The correction that came from a pre-existing test

**My first version required a bare IP, and a pre-existing parser test peering
with `peer.example.com` caught it over-rejecting.** FRR's grammar is
`neighbor <A.B.C.D|X:X::X:X|WORD>`, so a hostname or peer-group name is a
legitimate single token. The property is token **count**, not address form.
Over-rejection in routing config is an outage, and it is the direction a
fail-closed belt is most likely to get wrong.

## Commit side

`validateBGPNeighborAddressStrict` hard-rejects on commit / commit-check, naming
the neighbor and its group. `lenientBGPNeighborAddress` is registered per #1960
so a tolerantly-loaded or peer-synced config still boots — the renderer keeps the
bad identity out of `frr.conf`, so a leniently-loaded one is inert. Same doctrine
as `validateBGPNeighborPeerASStrict`, whose renderer exclusion set it shares.

## Mutation matrix

Fix committed FIRST. Every cell runs the full `pkg/config` + `pkg/frr` suites
with `go test -count=1`, no `-run` filter; each mutation verified applied on a
building, vetting tree. **8 cells, all RED.**

| cell | result | assertion |
|---|---|---|
| M1 render belt removed from `validNeighbors` | RED | both render cells |
| M2 belt accepts everything | RED | 4 cells incl. the agreement cell |
| **M3 TIGHTEN: belt requires a bare IP (over-rejects hostnames)** | RED | `...AcceptsAHostname6796`; agreement cell |
| **M4 belt misses the space byte (`< 0x20` instead of `<= 0x20`)** | RED | `...AcceptsAHostname6796` |
| M5 commit gate dispatch removed | RED | the **pre-existing** `TestEveryStrictCommitGateIsWired` |
| M6 commit gate accepts everything | RED | 3 commit cells |
| **M7 TIGHTEN: commit gate requires a bare IP** | RED | 2 new cells + the **pre-existing** `TestBGPGroupFamilyUnparseableAddressInheritsBoth` |
| M8 lenient opt unregistered (#1960) | RED | `...IsLenientOnTheTolerantPath6796` |

M4 is the boundary cell that matters: `0x20` is the space itself, so a `< 0x20`
predicate catches every control byte and misses the one separator an attacker
would actually use. M5 and M7 both red **pre-existing** tests — the third and
fourth time today a `-run <issue>` filter would have under-reported.

## Test design

The render cells assert **what the output became**, not merely that a needle is
absent — an absence check alone passes against a renderer that emits nothing. So
each pairs the injected identity with a legitimate neighbor that must still
render fully, including its `bfd` line and its BFD `peer` entry. A separate cell
pins the BFD accumulator specifically, with a control proving BFD rendering is on
at all.

The commit cells are paired over four rejecting and four accepting identities;
the **accepting** rows are what keep the gate honest.

`TestNeighborTokenGateAgreesWithTheRenderBelt6796` asserts the cross-package
agreement by **reading both function bodies** with comments stripped, rather than
pinning either to a literal. A stricter commit gate tells operators a working
config is invalid; a stricter belt silently drops a committed peering; **neither
divergence produces an error anywhere.** And the first version had both wrong in
the same direction, so trusting either side would have encoded the mistake.

## Gates

`go build ./... && go vet ./... && go test -count=1 ./...` — all rc=0, 67
packages, at head `a01550000` (master merged in, `_Log.md` the only conflict),
tree clean. Go only; nothing moves the `userspace-dp` binary or the shim `.o`, so
no cargo leg. No cluster, VRRP, session-sync or failover code — no smoke owed.
