### PR TITLE
lldp: recover a dark interface on an unchanged config (#6794)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104796,3 +104796,28 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/vrrp/reth_rg_parity_6781_test.go` (new),
   `pkg/vrrp/reth_rg_ssot_6781_test.go` (new),
   `pkg/config/reth_rg_gate_6781_test.go` (new), `pkg/vrrp/README.md`
+
+## 2026-08-22 — #6794 LLDP recovers a dark interface on unchanged config
+
+- **Timestamp**: 2026-08-22
+- **Action**: `reconcileLLDP` recorded `d.lldpApplied = want` BEFORE calling
+  `d.lldpMgr.Apply`, and `Apply` was void while bringing each interface up
+  INDEPENDENTLY (a lookup failure logs + `continue`s). So a partial generation
+  was indistinguishable from a converged one, and every later reconcile with the
+  same config took the early return — recovery needed a `protocols lldp` edit or
+  a daemon restart. `Apply` now returns the interfaces that failed NAME
+  resolution; the caller records it AFTER the apply and `lldpRecoveryDue`
+  re-tests exactly those names.
+- **Why not "retry whenever incomplete"**: `Apply` `Stop()`s the whole
+  generation first (closes every socket, wipes the neighbor table), so a
+  permanently-absent interface (a config typo) would rebuild LLDP on every
+  unrelated commit — the #2372 finding-6 churn the guard exists to prevent. The
+  retry gates on the WORLD changing (a previously-unresolved name now resolves),
+  not on time or a counter.
+- **Socket-failure residual, stated deliberately**: a `newIfSession` failure
+  (CAP_NET_RAW/bind) is logged and skipped but NOT reported as retry debt — it
+  does not self-heal within a process, so retrying it would churn.
+- **File(s)**: `pkg/lldp/lldp.go`, `pkg/lldp/test_seams.go`,
+  `pkg/lldp/apply_partial_6794_test.go`, `pkg/daemon/daemon.go`,
+  `pkg/daemon/daemon_apply_tail.go`,
+  `pkg/daemon/lldp_recovery_6794_test.go`, `pkg/lldp/README.md`, `_Log.md`

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -416,6 +416,15 @@ type Daemon struct {
 	lldpMgr          *lldp.Manager
 	lldpApplied      *lldp.LLDPConfig // last effective LLDP config Apply()'d (#2372 diff-guard); nil = stopped
 	lldpApplyInit    bool             // true once reconcileLLDP has run at least once
+	// lldpUnresolved is the set of configured LLDP interfaces the LAST
+	// Manager.Apply could not resolve to a kernel interface (#6794). Apply is
+	// partial — it brings each interface up independently and skips the ones it
+	// cannot find — so this is what makes an INCOMPLETE generation
+	// distinguishable from a converged one. Written AFTER the apply, from the
+	// apply's own return, and read by lldpRecoveryDue to decide whether an
+	// unchanged-config reconcile should nevertheless re-apply. Mutated under
+	// applySem like the two fields above.
+	lldpUnresolved []string
 	// scheduler is the live policy-window scheduler. It is an atomic.Pointer so
 	// the metrics collector can read it lock-free for the
 	// xpf_scheduler_republish_fail_closed SSOT gauge

--- a/pkg/daemon/daemon_apply_tail.go
+++ b/pkg/daemon/daemon_apply_tail.go
@@ -448,16 +448,35 @@ func (d *Daemon) reconcileLLDP(cfg *config.Config) {
 	// Skip when the effective config is unchanged since the last reconcile, so
 	// an unrelated commit never bounces a healthy LLDP generation (sockets +
 	// neighbor table). The first reconcile (boot) always runs.
-	if d.lldpApplyInit && lldpConfigEqual(d.lldpApplied, want) {
+	//
+	// #6794: "unchanged config" is not sufficient on its own. Manager.Apply is
+	// PARTIAL — it brings each interface up independently and skips the ones it
+	// cannot resolve — so a generation can be live for some interfaces and dark
+	// for others while the config is entirely unchanged. The desired config used
+	// to be recorded as applied BEFORE Apply ran, so an incomplete generation
+	// was indistinguishable from a healthy one and every later reconcile took
+	// this early return. Recovery then required a change to `protocols lldp` or
+	// a daemon restart — on a box where the only thing wrong was that a NIC
+	// showed up a moment after boot.
+	//
+	// lldpRecoveryDue re-tests exactly the interfaces the last Apply could not
+	// resolve. It gates on the WORLD having changed in a way that could fix
+	// them, not on time or on a retry counter, so a permanently-absent
+	// interface (a typo in the config) never resolves, never triggers a retry,
+	// and cannot churn the generation on every commit — which is the #2372
+	// finding-6 regression this guard exists to prevent.
+	if d.lldpApplyInit && lldpConfigEqual(d.lldpApplied, want) && !d.lldpRecoveryDue() {
 		return
 	}
-	d.lldpApplyInit = true
-	d.lldpApplied = want
 
 	if want == nil {
 		// Disabled / empty: stop the running service (idempotent if already
-		// stopped).
+		// stopped). Stop cannot partially fail, so there is no unresolved set
+		// to carry: record convergence directly.
 		d.lldpMgr.Stop()
+		d.lldpApplyInit = true
+		d.lldpApplied = want
+		d.lldpUnresolved = nil
 		return
 	}
 
@@ -465,7 +484,48 @@ func (d *Daemon) reconcileLLDP(cfg *config.Config) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	d.lldpMgr.Apply(ctx, want)
+	// Record what the apply ACHIEVED, and record it AFTER the apply. The
+	// unresolved set is the ground truth that makes an incomplete generation
+	// distinguishable from a converged one.
+	unresolved := d.lldpMgr.Apply(ctx, want)
+	d.lldpApplyInit = true
+	d.lldpApplied = want
+	d.lldpUnresolved = unresolved
+	if len(unresolved) > 0 {
+		slog.Warn("LLDP: generation is INCOMPLETE — these configured interfaces could not be "+
+			"resolved and are dark; they will be retried automatically as soon as they appear, "+
+			"without needing a config change",
+			"interfaces", unresolved)
+	}
+}
+
+// lldpRecoveryDue reports whether any interface the last Apply could not
+// RESOLVE now resolves, i.e. whether re-applying could bring a dark interface
+// up (#6794).
+//
+// This is the whole reason the unchanged-config guard is safe to keep. It gates
+// the retry on an observable change in the world rather than on time or a
+// counter, so:
+//
+//   - a NIC that showed up after boot (renamed by a .link file, created as a
+//     VLAN/tunnel, brought up late) resolves on the next reconcile and the
+//     generation is rebuilt — recovery on an UNCHANGED config, which is what
+//     #6794 is about; and
+//   - an interface that is permanently absent (a typo, a NIC that was removed)
+//     never resolves, so this never fires and an unrelated commit never bounces
+//     a generation that is as complete as it can be.
+//
+// It deliberately re-tests only the previously-UNRESOLVED names. Testing the
+// whole desired set would fire on nothing, and testing the interfaces that
+// failed at the SOCKET layer would retry a condition that does not self-heal
+// (see Manager.Apply).
+func (d *Daemon) lldpRecoveryDue() bool {
+	for _, name := range d.lldpUnresolved {
+		if lldp.InterfaceResolvable(name) {
+			return true
+		}
+	}
+	return false
 }
 
 // initEventEngine constructs the event-options engine and registers the RPM

--- a/pkg/daemon/lldp_recovery_6794_test.go
+++ b/pkg/daemon/lldp_recovery_6794_test.go
@@ -1,0 +1,194 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/lldp"
+)
+
+// lldpDaemon returns a Daemon with a real lldp.Manager, plus a mutable set of
+// "present" kernel interface names the lookup seam resolves. Socket setup
+// always fails so no real socket is opened — name RESOLUTION is the axis #6794
+// turns on, and that still runs.
+func lldpDaemon(t *testing.T) (*Daemon, map[string]bool) {
+	t.Helper()
+	present := map[string]bool{}
+	lldp.SetInterfaceByNameForTesting(func(name string) (*net.Interface, error) {
+		if present[name] {
+			return &net.Interface{Index: 1, Name: name}, nil
+		}
+		return nil, errors.New("no such interface: " + name)
+	})
+	lldp.FailIfSessionForTesting(errors.New("injected: no CAP_NET_RAW in test"))
+	mgr := lldp.New()
+	t.Cleanup(func() {
+		mgr.Stop()
+		lldp.SetInterfaceByNameForTesting(nil)
+		lldp.FailIfSessionForTesting(nil)
+	})
+	return &Daemon{lldpMgr: mgr, daemonCtx: context.Background()}, present
+}
+
+// TestUnchangedConfigRecoversADarkInterface6794 is the #6794 fail-on-revert
+// test, and it is a WIRING cell by construction: everything it asserts is about
+// what reconcileLLDP DOES with Apply's return value. The pkg/lldp cells prove
+// Apply reports the unresolved set correctly, and they stay green if the caller
+// throws that value away — which is exactly what the caller used to do, because
+// it recorded the desired config as applied BEFORE calling Apply at all.
+//
+// Scenario, which is an ordinary boot race rather than an exotic one: LLDP is
+// configured on two interfaces and one of them does not exist yet (renamed a
+// moment later by a .link file, or created later as a VLAN/tunnel). The first
+// reconcile brings up one and leaves the other dark. The interface then appears.
+// A LATER reconcile with an entirely UNCHANGED config must rebuild the
+// generation — otherwise recovery needs a `protocols lldp` edit or a daemon
+// restart.
+//
+// FAIL-ON-REVERT: moving the cache back above the Apply call (or dropping the
+// lldpRecoveryDue term from the guard) makes the second reconcile take the
+// early return, ApplyCount stays 1, and this reds.
+func TestUnchangedConfigRecoversADarkInterface6794(t *testing.T) {
+	d, present := lldpDaemon(t)
+	present["ge-0-0-0"] = true // ge-0/0/1 is not there yet
+
+	cfg := lldpCfg(false, "ge-0/0/0", "ge-0/0/1")
+
+	d.reconcileLLDP(cfg)
+	if got := d.lldpMgr.ApplyCount(); got != 1 {
+		t.Fatalf("premise: first reconcile must apply, ApplyCount = %d", got)
+	}
+	if len(d.lldpUnresolved) != 1 || d.lldpUnresolved[0] != "ge-0/0/1" {
+		t.Fatalf("the incomplete generation must be RECORDED from Apply's return; unresolved = %v. "+
+			"If the caller discards it, an incomplete generation is indistinguishable from a "+
+			"converged one (#6794)", d.lldpUnresolved)
+	}
+
+	// The missing NIC appears. Config is byte-identical.
+	present["ge-0-0-1"] = true
+
+	d.reconcileLLDP(cfg)
+	if got := d.lldpMgr.ApplyCount(); got != 2 {
+		t.Fatalf("a reconcile on UNCHANGED config must re-apply once a previously-dark interface "+
+			"appears; ApplyCount = %d, want 2. Without it LLDP stays dark on that interface until "+
+			"someone edits `protocols lldp` or restarts the daemon (#6794)", got)
+	}
+	if len(d.lldpUnresolved) != 0 {
+		t.Errorf("after the recovering apply nothing should remain unresolved, got %v", d.lldpUnresolved)
+	}
+
+	// And once converged, the guard must go quiet again.
+	d.reconcileLLDP(cfg)
+	if got := d.lldpMgr.ApplyCount(); got != 2 {
+		t.Errorf("a converged generation must not re-apply on an unchanged config; ApplyCount = %d, "+
+			"want 2", got)
+	}
+}
+
+// TestPermanentlyAbsentInterfaceDoesNotChurn6794 is the tightening control, and
+// it guards the regression a naive fix causes.
+//
+// Manager.Apply Stop()s the whole generation before rebuilding — closing every
+// socket AND wiping the neighbor table — so re-applying on every commit is the
+// exact churn the #2372 finding-6 guard exists to prevent. A fix that simply
+// retries whenever the last apply was incomplete would do that forever on a box
+// with one typo'd interface name, blanking `show lldp neighbors` on every
+// unrelated firewall-policy commit.
+//
+// The retry must gate on the WORLD having changed in a way that could fix it.
+// Here it never does.
+//
+// FAIL-ON-REVERT: making lldpRecoveryDue return true whenever lldpUnresolved is
+// non-empty reds this on the second reconcile.
+func TestPermanentlyAbsentInterfaceDoesNotChurn6794(t *testing.T) {
+	d, present := lldpDaemon(t)
+	present["ge-0-0-0"] = true // "ge-0/0/9" is a typo and will never appear
+
+	cfg := lldpCfg(false, "ge-0/0/0", "ge-0/0/9")
+
+	d.reconcileLLDP(cfg)
+	if got := d.lldpMgr.ApplyCount(); got != 1 {
+		t.Fatalf("premise: first reconcile must apply, ApplyCount = %d", got)
+	}
+
+	for i := 0; i < 3; i++ {
+		d.reconcileLLDP(cfg)
+	}
+	if got := d.lldpMgr.ApplyCount(); got != 1 {
+		t.Errorf("an interface that is permanently absent must NOT make every later commit rebuild "+
+			"the LLDP generation; ApplyCount = %d, want 1. Apply Stop()s first, so each rebuild "+
+			"closes every socket and wipes the neighbor table — the #2372 churn this guard "+
+			"exists to prevent (#6794)", got)
+	}
+}
+
+// TestHealthyGenerationStillSkipsOnUnchangedConfig6794 is the second tightening
+// control: the ORIGINAL #2372 guard must survive. Without this cell, a "fix"
+// that simply deleted the unchanged-config short-circuit would satisfy the
+// recovery test above while bouncing LLDP on every commit.
+func TestHealthyGenerationStillSkipsOnUnchangedConfig6794(t *testing.T) {
+	d, present := lldpDaemon(t)
+	present["ge-0-0-0"] = true
+
+	cfg := lldpCfg(false, "ge-0/0/0")
+	d.reconcileLLDP(cfg)
+	if got := d.lldpMgr.ApplyCount(); got != 1 {
+		t.Fatalf("premise: ApplyCount = %d, want 1", got)
+	}
+	if len(d.lldpUnresolved) != 0 {
+		t.Fatalf("premise: a fully-resolvable config must leave nothing unresolved, got %v",
+			d.lldpUnresolved)
+	}
+
+	for i := 0; i < 3; i++ {
+		d.reconcileLLDP(cfg)
+	}
+	if got := d.lldpMgr.ApplyCount(); got != 1 {
+		t.Errorf("an unrelated commit must not bounce a HEALTHY LLDP generation (sockets + "+
+			"neighbor table); ApplyCount = %d, want 1 (#2372)", got)
+	}
+}
+
+// TestDisabledBranchRecordsConvergence6794 covers the OTHER branch of
+// reconcileLLDP. The function forks on `want == nil` — Stop() — and a fixture
+// that only ever exercises the Apply branch leaves the nil branch's bookkeeping
+// mutation-invisible: it could record nothing, or carry stale retry debt
+// forward, and every Apply-branch cell would stay green.
+//
+// Stop cannot partially fail, so the nil branch must record convergence
+// outright: unchanged-nil must then skip, and the stale unresolved set from a
+// previous generation must be CLEARED — otherwise lldpRecoveryDue would keep
+// firing against interfaces that LLDP is no longer even configured on.
+func TestDisabledBranchRecordsConvergence6794(t *testing.T) {
+	d, present := lldpDaemon(t)
+	present["ge-0-0-0"] = true
+
+	// A generation with retry debt (ge-0/0/1 is dark).
+	d.reconcileLLDP(lldpCfg(false, "ge-0/0/0", "ge-0/0/1"))
+	if len(d.lldpUnresolved) == 0 {
+		t.Fatalf("premise: expected retry debt after a partial apply")
+	}
+	afterFirst := d.lldpMgr.ApplyCount()
+
+	// LLDP is disabled: the nil branch.
+	d.reconcileLLDP(&config.Config{})
+	if len(d.lldpUnresolved) != 0 {
+		t.Errorf("disabling LLDP must CLEAR the unresolved set, got %v. Carrying it forward makes "+
+			"the recovery guard fire against interfaces LLDP is no longer configured on (#6794)",
+			d.lldpUnresolved)
+	}
+	if d.lldpApplied != nil {
+		t.Errorf("the disabled branch must record the nil config as applied, got %v", d.lldpApplied)
+	}
+
+	// The missing interface appears; LLDP is still disabled. Nothing must move.
+	present["ge-0-0-1"] = true
+	d.reconcileLLDP(&config.Config{})
+	if got := d.lldpMgr.ApplyCount(); got != afterFirst {
+		t.Errorf("an unchanged DISABLED config must not apply; ApplyCount = %d, want %d",
+			got, afterFirst)
+	}
+}

--- a/pkg/lldp/README.md
+++ b/pkg/lldp/README.md
@@ -11,11 +11,32 @@ frame flood cannot exhaust memory (#4044).
 - `Neighbor` — `lldp.go`. Chassis ID, port ID, TTL, system name and
   description.
 - `New()` — `lldp.go`.
-- `Apply(ctx context.Context, cfg *LLDPConfig)` — `lldp.go`. Reconcile-shaped:
-  `Stop()`s the current generation before starting the new one, so calling it
-  repeatedly is idempotent. A nil/disabled/empty config stops the service.
-  Holds `lifecycleMu` across the whole transition so a concurrent `Stop()`
-  cannot interleave (see **Apply/Stop concurrency** below).
+- `Apply(ctx context.Context, cfg *LLDPConfig) (unresolved []string)` —
+  `lldp.go`. Reconcile-shaped: `Stop()`s the current generation before starting
+  the new one, so calling it repeatedly is idempotent. A nil/disabled/empty
+  config stops the service. Holds `lifecycleMu` across the whole transition so a
+  concurrent `Stop()` cannot interleave (see **Apply/Stop concurrency** below).
+
+  **Apply is PARTIAL, and says so (#6794).** Each configured interface is
+  brought up independently and a failure skips just that one, so a call that
+  "succeeded" can leave part of the generation dark. It returns the interfaces
+  that failed NAME RESOLUTION — the recoverable half, where the NIC simply is
+  not there yet (renamed a moment later by a `.link` file, created later as a
+  VLAN/tunnel, or not yet up). It used to return nothing at all, which is what
+  let the daemon's unchanged-config guard record an incomplete generation as
+  converged and skip every reconcile that would have fixed it; recovery then
+  needed a `protocols lldp` edit or a daemon restart. A SOCKET-setup failure
+  (CAP_NET_RAW, bind) is deliberately NOT reported: it is logged and the
+  interface skipped, but it does not self-heal within a process the way an
+  absent NIC does, so surfacing it as retry debt would rebuild the whole
+  generation on every later commit — wiping the neighbor table over a condition
+  that will not change.
+- `InterfaceResolvable(name string) bool` — `lldp.go` (#6794). Whether a
+  configured interface name resolves to a kernel interface right now. Uses the
+  SAME name conversion and the SAME lookup seam as `Apply`, deliberately: the
+  daemon's recovery guard reads this to decide whether a previously-unresolved
+  interface has appeared, and the apply acts on it, so a divergence between the
+  two would mean either no recovery or endless re-`Apply`.
 - `Stop()` — `lldp.go`. Holds `lifecycleMu`, then tears the generation down via
   the internal `stopLocked`.
 - `Running()` — `lldp.go`. Reports whether a live generation has at least one

--- a/pkg/lldp/apply_partial_6794_test.go
+++ b/pkg/lldp/apply_partial_6794_test.go
@@ -1,0 +1,138 @@
+package lldp
+
+import (
+	"context"
+	"errors"
+	"net"
+	"slices"
+	"testing"
+)
+
+// resolveOnly installs an interface lookup that resolves exactly the given
+// KERNEL names and fails everything else, and makes socket setup fail so no
+// real socket is opened. It restores both seams on cleanup.
+func resolveOnly(t *testing.T, kernelNames ...string) {
+	t.Helper()
+	ok := make(map[string]bool, len(kernelNames))
+	for _, n := range kernelNames {
+		ok[n] = true
+	}
+	SetInterfaceByNameForTesting(func(name string) (*net.Interface, error) {
+		if ok[name] {
+			return &net.Interface{Index: 1, Name: name}, nil
+		}
+		return nil, errors.New("no such interface: " + name)
+	})
+	FailIfSessionForTesting(errors.New("injected: no CAP_NET_RAW in test"))
+	t.Cleanup(func() {
+		SetInterfaceByNameForTesting(nil)
+		FailIfSessionForTesting(nil)
+	})
+}
+
+func cfgFor(names ...string) *LLDPConfig {
+	c := &LLDPConfig{}
+	for _, n := range names {
+		c.Interfaces = append(c.Interfaces, LLDPInterface{Name: n})
+	}
+	return c
+}
+
+// TestApplyReportsUnresolvedInterfaces6794 pins the producer half of #6794.
+//
+// Manager.Apply brings each configured interface up INDEPENDENTLY and a lookup
+// failure skips just that one, so a call that "succeeded" can leave part of the
+// generation dark. It used to return nothing at all, which is what let the
+// caller's unchanged-config guard treat an incomplete generation as converged.
+//
+// The table has one row per branch, because a fixture that never enters a
+// branch cannot see that branch's guard: all-resolvable, none-resolvable, and
+// the MIXED row — the mixed row is the one that fails a "fix" that reports
+// all-or-nothing instead of naming the actual failures.
+func TestApplyReportsUnresolvedInterfaces6794(t *testing.T) {
+	tests := []struct {
+		name    string
+		present []string
+		cfg     []string
+		want    []string
+	}{
+		{"all-resolvable", []string{"ge-0-0-0", "ge-0-0-1"}, []string{"ge-0/0/0", "ge-0/0/1"}, nil},
+		{"none-resolvable", nil, []string{"ge-0/0/0", "ge-0/0/1"}, []string{"ge-0/0/0", "ge-0/0/1"}},
+		{"mixed-partial", []string{"ge-0-0-0"}, []string{"ge-0/0/0", "ge-0/0/1"}, []string{"ge-0/0/1"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resolveOnly(t, tc.present...)
+			m := New()
+			t.Cleanup(m.Stop)
+
+			got := m.Apply(context.Background(), cfgFor(tc.cfg...))
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("Apply unresolved = %v, want %v. A partial apply that reports nothing is "+
+					"indistinguishable from a converged one, so the caller's unchanged-config "+
+					"guard skips the reconcile that would have recovered it (#6794)", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestApplyReturnsNothingForADisabledConfig6794 covers the early-return branch:
+// a nil/disabled/empty config stops the service and has no interfaces to fail,
+// so there is no retry debt to report. Without this row the nil branch's return
+// is unbound.
+func TestApplyReturnsNothingForADisabledConfig6794(t *testing.T) {
+	resolveOnly(t)
+	m := New()
+	t.Cleanup(m.Stop)
+
+	for _, cfg := range []*LLDPConfig{nil, {Disable: true}, {}} {
+		if got := m.Apply(context.Background(), cfg); got != nil {
+			t.Errorf("Apply(%v) unresolved = %v, want nil: a disabled config has no interfaces to "+
+				"fail and must not manufacture retry debt", cfg, got)
+		}
+	}
+}
+
+// TestInterfaceResolvableAgreesWithApply6794 binds the AGREEMENT between the
+// two places that decide whether a configured interface exists, rather than
+// pinning either one.
+//
+// Apply resolves `config.LinuxIfName(name)`; InterfaceResolvable is what the
+// daemon's recovery guard consults to decide whether a previously-unresolved
+// interface has appeared. If those two ever disagreed — a different name form,
+// a different seam — the guard would either never fire (no recovery, the
+// original bug) or fire forever (churn). The Junos slash form is the case that
+// would expose a divergence, since a slash never appears in a kernel ifname.
+func TestInterfaceResolvableAgreesWithApply6794(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		present []string
+		iface   string
+		want    bool
+	}{
+		{"slash-form-resolves-via-kernel-dash-name", []string{"ge-0-0-0"}, "ge-0/0/0", true},
+		{"slash-form-absent", nil, "ge-0/0/0", false},
+		{"already-kernel-form", []string{"em0"}, "em0", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resolveOnly(t, tc.present...)
+
+			if got := InterfaceResolvable(tc.iface); got != tc.want {
+				t.Errorf("InterfaceResolvable(%q) = %v, want %v", tc.iface, got, tc.want)
+			}
+
+			// The agreement: Apply must report it unresolved exactly when
+			// InterfaceResolvable says it is not resolvable.
+			m := New()
+			t.Cleanup(m.Stop)
+			unresolved := m.Apply(context.Background(), cfgFor(tc.iface))
+			applySaysResolvable := !slices.Contains(unresolved, tc.iface)
+			if applySaysResolvable != tc.want {
+				t.Errorf("Apply and InterfaceResolvable disagree for %q: Apply resolvable=%v, "+
+					"InterfaceResolvable=%v. The daemon's recovery guard reads one and the apply "+
+					"acts on the other, so a divergence means either no recovery or endless "+
+					"re-apply (#6794)", tc.iface, applySaysResolvable, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/lldp/lldp.go
+++ b/pkg/lldp/lldp.go
@@ -260,7 +260,20 @@ func New() *Manager {
 // the new one, and every wg.Add(1) all happen atomically with respect to a
 // racing Stop (#5121). The internal teardown uses stopLocked() (not Stop) to
 // avoid re-acquiring the non-reentrant lifecycleMu.
-func (m *Manager) Apply(ctx context.Context, cfg *LLDPConfig) {
+// #6794: Apply is PARTIAL and reports it. Each configured interface is brought
+// up independently and a failure skips just that one — so a "successful" call
+// can leave part of the generation dark. It returns the interfaces that failed
+// NAME RESOLUTION, which is the recoverable half: the NIC is simply not there
+// yet (renamed later by a .link file, created later as a VLAN/tunnel, or not
+// yet up). A caller that guards on unchanged config MUST consult this, or the
+// reconcile that would have recovered those interfaces is skipped forever.
+//
+// A socket-setup failure (CAP_NET_RAW, bind) is deliberately NOT reported here:
+// it is logged and the interface is skipped, but it does not self-heal within a
+// process the way an absent NIC does, so surfacing it as retry debt would make
+// every later commit rebuild the whole generation — wiping the neighbor table
+// on a condition that will not change.
+func (m *Manager) Apply(ctx context.Context, cfg *LLDPConfig) (unresolved []string) {
 	m.lifecycleMu.Lock()
 	defer m.lifecycleMu.Unlock()
 
@@ -268,7 +281,7 @@ func (m *Manager) Apply(ctx context.Context, cfg *LLDPConfig) {
 	m.stopLocked()
 
 	if cfg == nil || cfg.Disable || len(cfg.Interfaces) == 0 {
-		return
+		return nil
 	}
 
 	lldpCtx, cancel := context.WithCancel(ctx)
@@ -303,6 +316,12 @@ func (m *Manager) Apply(ctx context.Context, cfg *LLDPConfig) {
 		if err != nil {
 			slog.Warn("LLDP: interface not found", "interface", lldpIf.Name,
 				"kernel", kernelName, "err", err)
+			// #6794: REPORTED, not just logged. This is the recoverable
+			// failure — the interface simply is not there yet (renamed later,
+			// created later, brought up later) — so the caller needs to know
+			// this generation is incomplete, or its unchanged-config guard
+			// will skip the reconcile that would have fixed it.
+			unresolved = append(unresolved, lldpIf.Name)
 			continue
 		}
 
@@ -336,12 +355,25 @@ func (m *Manager) Apply(ctx context.Context, cfg *LLDPConfig) {
 		slog.Info("LLDP started", "interface", lldpIf.Name, "interval", interval)
 	}
 
+	sort.Strings(unresolved)
+
 	// Start neighbor expiry goroutine.
 	m.wg.Add(1)
 	go func() {
 		defer m.wg.Done()
 		m.expiryLoop(lldpCtx)
 	}()
+	return unresolved
+}
+
+// InterfaceResolvable reports whether a configured LLDP interface name resolves
+// to a kernel interface right now (#6794). It is the same lookup Apply performs
+// — the SAME name conversion and the SAME seam — so a caller deciding whether a
+// previously-unresolved interface has appeared cannot disagree with the code
+// that will act on that decision.
+func InterfaceResolvable(name string) bool {
+	_, err := interfaceByNameFn(config.LinuxIfName(name))
+	return err == nil
 }
 
 // Stop halts all LLDP goroutines and clears the neighbor table. It holds

--- a/pkg/lldp/test_seams.go
+++ b/pkg/lldp/test_seams.go
@@ -1,0 +1,35 @@
+package lldp
+
+import "net"
+
+// Test-only helpers for pkg/lldp. They live in the production package so tests
+// in DEPENDENT packages (pkg/daemon) can drive Apply's failure modes without
+// real NICs or CAP_NET_RAW. That matters for #6794 specifically: the recovery
+// guard spans both packages, and a test that could only reach these seams from
+// inside pkg/lldp would bind Apply's RETURN VALUE while leaving the caller free
+// to ignore it — which was the whole defect. Not for production callers.
+// Mirrors the pkg/configstore/test_seams.go convention.
+
+// SetInterfaceByNameForTesting overrides the kernel interface lookup used by
+// Manager.Apply AND by InterfaceResolvable — deliberately the same seam, so a
+// test cannot make those two disagree in a way production never could. Pass nil
+// to restore net.InterfaceByName.
+func SetInterfaceByNameForTesting(fn func(string) (*net.Interface, error)) {
+	if fn == nil {
+		interfaceByNameFn = net.InterfaceByName
+		return
+	}
+	interfaceByNameFn = fn
+}
+
+// FailIfSessionForTesting makes every per-interface socket setup fail with err,
+// so Apply can be exercised without CAP_NET_RAW: name resolution still runs
+// (which is what #6794's unresolved set reports), and no real socket is opened
+// or goroutine started. Pass nil to restore the real newIfSession.
+func FailIfSessionForTesting(err error) {
+	if err == nil {
+		newIfSessionFn = newIfSession
+		return
+	}
+	newIfSessionFn = func(*net.Interface) (*ifSession, error) { return nil, err }
+}


### PR DESCRIPTION
Closes #6794

Cites re-derived from code (the `/tmp/opus-review-001.md` R53 pointer is dead).

## The defect

`reconcileLLDP` recorded the desired config as applied **before** calling
`Apply`:

```go
d.lldpApplyInit = true
d.lldpApplied = want      // ← cached here
...
d.lldpMgr.Apply(ctx, want) // ← applied here, and void
```

And `Apply` brings each configured interface up **independently** — a name
lookup failure logs a warning and `continue`s, skipping just that one:

```go
iface, err := interfaceByNameFn(kernelName)
if err != nil { slog.Warn("LLDP: interface not found", …); continue }
```

So a generation can be live for some interfaces and dark for others while the
cache claims the whole config is applied. Every later reconcile then hits
`lldpConfigEqual(d.lldpApplied, want)` and takes the early return, so **a dark
interface stays dark until someone edits `protocols lldp` or restarts the
daemon**.

The triggering scenario is an ordinary boot race, not an exotic one: the NIC is
renamed a moment later by a `.link` file, created later as a VLAN/tunnel, or
simply not up yet. LLDP comes up on whatever happened to exist and never
revisits the rest.

## The fix, and the trap it avoids

`Apply` now returns the interfaces that failed **name resolution**; the caller
records that **after** the apply; and `lldpRecoveryDue` re-tests exactly those
names on the next reconcile. An unchanged config re-applies precisely when one of
them has appeared.

**Why not simply "retry whenever the last apply was incomplete"** — this is the
trap, and it is why the fix needed a gate rather than a flag. `Apply` `Stop()`s
the entire generation before rebuilding, closing every socket **and wiping the
neighbor table**. A permanently-absent interface (which is what a typo in the
config produces) would then rebuild LLDP on every unrelated commit and blank
`show lldp neighbors` each time — exactly the churn the #2372 finding-6 guard
exists to prevent. So the retry gates on the **world** having changed in a way
that could fix it, not on time or a retry counter. A name that never resolves
never fires it. **Cell M3 is that control**, and it reds the pre-existing
`TestReconcileLLDPSkipsUnchangedCommit` too.

**A residual I am stating rather than hiding:** a *socket*-setup failure
(CAP_NET_RAW, bind) is logged and skipped but deliberately **not** reported as
retry debt. Unlike an absent NIC it does not self-heal within a process, so
treating it as recoverable reintroduces the churn above for a condition that will
not change. It is documented in the code and the README.

`InterfaceResolvable` is exported from `pkg/lldp` and uses the **same** name
conversion and the **same** lookup seam as `Apply`. The daemon's guard reads it
and the apply acts on it, so a divergence would mean either no recovery or
endless re-`Apply`; a test binds the two against each other on the Junos slash
form, the shape that would expose one.

## Tests — split to bind the WIRING

Taking your #6792 lesson directly: the `pkg/lldp` cells prove `Apply` reports the
unresolved set, **and they stay green if the caller discards it** — which is
precisely what the caller did. So the load-bearing cells live in `pkg/daemon` and
assert what `reconcileLLDP` *does* with that return value.

`pkg/lldp` gains a `test_seams.go` so a dependent package can drive interface
resolution and socket failure without real NICs or `CAP_NET_RAW` — the recovery
guard spans two packages and could not otherwise be bound from the side that
matters.

Taking your second lesson too: `reconcileLLDP` **branches** on `want == nil`, and
that branch's bookkeeping (record convergence, and **clear** stale retry debt) is
mutation-invisible to any Apply-branch fixture — so it gets its own cell.
`TestApplyReportsUnresolvedInterfaces6794` likewise has one row per branch, and
the **mixed** row is the one that fails a fix reporting all-or-nothing instead of
naming the actual failures.

## Mutation matrix

Fix committed BEFORE the matrix. One mutation per line, anchor asserted to match
exactly once, tree rebuilt, then the full `pkg/lldp` + `pkg/daemon` suites with
`-count=1`, **no `-run` filter**, `skipped_6794_cells == 0` per cell.

Control (M0): **2028 passing, 0 failed, 0 skips.**

| Cell | Mutation | Result | Which assertion fired |
|---|---|---|---|
| M0 | none (control) | **GREEN** | 2028 pass / 0 fail |
| M1 | cache moved back **above** `Apply` (**the shipped bug**) | **RED** ×2 | `TestUnchangedConfigRecoversADarkInterface6794`, `TestDisabledBranchRecordsConvergence6794` |
| M2 | drop `!d.lldpRecoveryDue()` from the guard | **RED** | `TestUnchangedConfigRecoversADarkInterface6794` |
| M3 | **tightening** — retry whenever incomplete (the churn regression) | **RED** ×2 | `TestPermanentlyAbsentInterfaceDoesNotChurn6794` **plus the pre-existing `TestReconcileLLDPSkipsUnchangedCommit`** |
| M4 | `Apply` stops reporting unresolved interfaces | **RED** ×4 | producer + agreement + both daemon wiring cells |
| M5 | **tightening** — delete the unchanged-config short-circuit entirely | **RED** ×4 | `TestHealthyGenerationStillSkipsOnUnchangedConfig6794` **plus the pre-existing #2372 cell** |
| M6 | nil branch stops clearing `lldpUnresolved` | **RED** | `TestDisabledBranchRecordsConvergence6794` — stale debt fires against interfaces LLDP is no longer configured on |
| M7 | `InterfaceResolvable` drops the kernel-name conversion | **RED** ×2 | `TestInterfaceResolvableAgreesWithApply6794` + the recovery cell |

M3 and M5 both red **pre-existing** tests, so a `-run 6794` filter would have
under-reported twice.

## Validation

- `go build ./...` rc=0 · `go vet ./...` clean · `go test -count=1 ./...`
  (repo-wide) **rc=0** — re-run at the merged head.
- Gated head **`fb1a51b909ef521e6bd7431fe34015d92aed2c8c`**, which merges
  `origin/master` (8 behind by then; only conflict an append-vs-append in
  `_Log.md`, union-resolved, anchored marker sweep clean). Master moved twice
  during this work and the second fold **auto-merged `daemon_apply_tail.go`**
  — my own file — so the change was re-verified intact and M1/M3 were re-run at
  that head, both still red. A fold that touches the file under change is
  exactly where a matrix measured at an older tree stops being a matrix for the
  head being merged.
- **No Rust touched** — Go-only, no cargo leg.
- **No cluster / VRRP / session-sync / failover code touched.** LLDP is a
  per-node protocol service; no cluster smoke owed.

## Docs

`pkg/lldp/README.md` updates the `Apply` entry for its new signature and adds an
**Apply is PARTIAL, and says so (#6794)** paragraph plus an `InterfaceResolvable`
entry, including why a socket failure is deliberately not retry debt. The daemon
side is documented in the `reconcileLLDP` doc comment (that function is not
covered by `pkg/daemon/README.md`).
