### PR TITLE
frr: add the final operand-validity belt to route rendering

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104872,3 +104872,19 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/daemon/daemon_run.go`, `pkg/daemon/daemon_fabric_reassert.go` (new),
   `pkg/daemon/fabric_ipvlan_failclosed_6791_test.go` (new),
   `pkg/daemon/README.md`
+
+## 2026-08-22 — #6795 FRR non-protocol route rendering had no operand belt
+
+- **Timestamp**: 2026-08-22
+- **Action**: `generateStaticRouteInTable` and `renderGenerateRoutes`
+  interpolated raw parser strings (`Destination`, `nh.Address`, `ifName`,
+  `gr.Prefix`) into `ip route` lines with no validity check, unlike the protocol
+  renderers (#2980/#4919). A malformed operand fails the WHOLE frr-reload, so
+  one bad route takes every route on the box; a whitespace-carrying value splits
+  into extra operands or a second statement. Added `validFRRRoutePrefix` /
+  `validFRRNextHopAddress` / `validFRRInterfaceOperand`. A bad destination drops
+  the route, a bad next-hop drops only that next-hop (ECMP must still install
+  the good members). Measured that the DHCP-learned operands are netip-typed and
+  therefore structurally safe — no belt added there, recorded as a test.
+- **File(s)**: pkg/frr/render_validate.go, pkg/frr/config_render.go,
+  pkg/frr/route_operand_belt_6795_test.go, pkg/frr/README.md, _Log.md

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -47,6 +47,58 @@ community classification, `renderComposedRouteMap`, and the `-xpf-redist`
 alias guard. The detailed rendering semantics documented in the
 `policy_render.go` row below apply wherever each function now lives:
 
+### Non-protocol route operands have a final validity belt (#6795)
+
+The `ip route` / `ipv6 route` renderers — static routes
+(`generateStaticRouteInTable`) and generate-routes (`renderGenerateRoutes`) —
+interpolate RAW STRINGS from the parser: `sr.Destination`, `nh.Address`,
+`ifName`, `gr.Prefix`. The protocol renderers already have belts
+(`validRouterID` #2980, `validClusterID` / `validBGPOrigin` #4919); these did
+not.
+
+The blast radius is what makes it matter: a malformed operand fails the **whole**
+frr-reload — one `vtysh -f` add-batch exits non-zero on any
+`CMD_WARNING_CONFIG_FAILED` — so one bad route takes **every other route on the
+box** with it. A value carrying whitespace additionally splits into extra
+operands, or adds a statement outright. Commit validates these, but the tolerant
+load / HA config-sync paths only warn (#1960 no-brick), so the renderer is the
+last place to stop it.
+
+Three predicates in `render_validate.go`:
+
+| operand | predicate | accepts |
+|---|---|---|
+| destination / generate prefix | `validFRRRoutePrefix` | CIDR **or** a bare address |
+| gateway | `validFRRNextHopAddress` | a bare address only |
+| interface | `validFRRInterfaceOperand` | one token |
+
+`validFRRRoutePrefix` accepts a maskless host route deliberately: the
+destination is a raw string and a host route may reach here without a mask, and
+**dropping a route form that renders today is an outage**. The belt exists to
+keep UNRENDERABLE operands out of `frr.conf`, not to re-litigate the accepted
+grammar. `validFRRInterfaceOperand` is a token test rather than a name-charset
+test for the same reason.
+
+**Granularity is deliberate.** A bad DESTINATION drops the route; a bad
+NEXT-HOP drops only that next-hop. A `next-hop [ a b ]` ECMP list with one
+malformed member must still install the good ones — dropping the whole route
+would turn a typo in one gateway into a blackhole for the prefix, and the
+no-next-hop path already renders NOTHING rather than a `Null0` (#3872), so a
+whole-route drop is silently fail-wide.
+
+**The DHCP-learned routes deliberately get no belt.** They look like the
+highest-risk operands — they come from a DHCP server on the wire — but they are
+not raw strings: `lease.Gateway` is a `netip.Addr` and `cr.Destination` a
+`netip.Prefix`, both `String()`-ed, and those types cannot stringify to anything
+containing whitespace. `TestDHCPRouteOperandsAreStructurallySafe6795` records
+that measurement so the question is re-asked if either field is ever widened to
+a string.
+
+Not covered here: the `vrf <name>` clause still goes through `sanitizeFRRValue`
+(#5557). That sanitizer maps control bytes to a space — the sink's own separator
+— so it is the weaker belt described under #6796, but the routing-instance name
+is validated at commit and is out of this issue's scope.
+
 ### BGP neighbor identity is a single FRR token (#6796)
 
 `n.Address` is rendered RAW at 24 sites in `protocols_render.go` — unlike every

--- a/pkg/frr/config_render.go
+++ b/pkg/frr/config_render.go
@@ -124,6 +124,19 @@ func (m *Manager) generateStaticRouteInTable(sr *config.StaticRoute, vrfName str
 	if sr.NextTable != "" {
 		return "" // handled via ip rule in routing package
 	}
+	// #6795: final operand-validity belt. Destination is a RAW STRING from the
+	// parser, and it is interpolated into every `ip route` line this function
+	// emits. A malformed value fails the WHOLE frr-reload — one vtysh
+	// add-batch exits non-zero on any CMD_WARNING_CONFIG_FAILED — so a single
+	// bad route takes every other route on the box with it; a value carrying
+	// whitespace additionally splits into extra operands or an extra statement.
+	// Commit validates it, but the tolerant load / HA config-sync paths only
+	// warn (#1960 no-brick), so the renderer is the last place to stop it.
+	// Skipping THIS route is the fail-closed answer: the alternative is losing
+	// the entire managed section.
+	if !validFRRRoutePrefix(sr.Destination) {
+		return ""
+	}
 	isV6 := strings.Contains(sr.Destination, ":")
 	prefix := "ip"
 	if isV6 {
@@ -207,6 +220,21 @@ func (m *Manager) generateStaticRouteInTable(sr *config.StaticRoute, vrfName str
 			}
 		}
 
+		// #6795: the same belt on the next-hop operands. Address and ifName are
+		// raw strings assembled from config, RETH resolution and a `.vlan`
+		// suffix; either can reach here malformed on the tolerant load /
+		// peer-sync path. An unparseable gateway fails the frr-reload; one
+		// carrying whitespace splits into extra operands or an extra statement.
+		// Dropping the individual NEXT-HOP (not the whole route) is the right
+		// granularity: a `next-hop [ a b ]` ECMP list with one bad member should
+		// still install the good ones, and the no-next-hop case below already
+		// renders nothing rather than a Null0 blackhole (#3872).
+		if nh.Address != "" && !validFRRNextHopAddress(nh.Address) {
+			continue
+		}
+		if ifName != "" && !validFRRInterfaceOperand(ifName) {
+			continue
+		}
 		var nexthop string
 		switch {
 		case nh.Address != "" && ifName != "":
@@ -247,6 +275,13 @@ func renderGenerateRoutes(b *strings.Builder, fc *FullConfig) {
 		return
 	}
 	for _, gr := range fc.GenerateRoutes {
+		// #6795: same belt. A generate-route renders a blackhole, so a
+		// malformed prefix here fails the frr-reload and takes every route with
+		// it — and a blackhole is the one route shape where a mangled operand
+		// could silently widen what is dropped.
+		if !validFRRRoutePrefix(gr.Prefix) {
+			continue
+		}
 		if strings.Contains(gr.Prefix, ":") {
 			fmt.Fprintf(b, "ipv6 route %s blackhole\n", gr.Prefix)
 		} else {

--- a/pkg/frr/render_validate.go
+++ b/pkg/frr/render_validate.go
@@ -16,6 +16,7 @@ package frr
 
 import (
 	"net"
+	"net/netip"
 	"strconv"
 )
 
@@ -89,6 +90,64 @@ func validClusterID(s string) bool {
 	}
 	v, err := strconv.ParseUint(s, 10, 32)
 	return err == nil && v >= 1
+}
+
+// validFRRRoutePrefix reports whether a static / generate-route destination is
+// renderable as a single FRR `ip route <prefix>` operand (#6795).
+//
+// Both a CIDR prefix and a bare address are accepted. FRR's own grammar wants a
+// mask, but this tree stores the destination as a RAW STRING from the parser and
+// a host route may reach here maskless — rejecting a form that commits today
+// would drop a working route, and in routing config a dropped route is an
+// outage. The belt exists to keep UNRENDERABLE operands out of frr.conf, not to
+// re-litigate the accepted grammar.
+//
+// netip parsing is the whole check: it rejects any string containing whitespace
+// or trailing text, so a value that parses is guaranteed to be one token and to
+// be something FRR's parser can consume. A malformed destination that reaches
+// frr.conf fails the WHOLE frr-reload (one vtysh add-batch exits non-zero on any
+// CMD_WARNING_CONFIG_FAILED), taking every other route on the box with it — the
+// same blast radius #2980 documents for a bad router-id.
+func validFRRRoutePrefix(s string) bool {
+	if _, err := netip.ParsePrefix(s); err == nil {
+		return true
+	}
+	_, err := netip.ParseAddr(s)
+	return err == nil
+}
+
+// validFRRNextHopAddress reports whether a next-hop is renderable as a single
+// FRR gateway operand (#6795). Bare address only: FRR's `ip route <p> <gw>`
+// takes an address, and a prefix there is a grammar error that fails the
+// frr-reload.
+func validFRRNextHopAddress(s string) bool {
+	_, err := netip.ParseAddr(s)
+	return err == nil
+}
+
+// validFRRInterfaceOperand reports whether an interface name is renderable as a
+// single FRR token (#6795).
+//
+// Kernel interface names cannot contain whitespace or '/', but the value
+// reaching the renderer is not always a kernel name: it is assembled from
+// config, RETH resolution and a `.vlan` suffix, and on the tolerant load /
+// peer-sync path it is whatever the config carried. A name with an embedded
+// space would split `ip route <p> <gw> <ifname>` into an extra operand and
+// change what FRR installs — or, with a newline, add a statement outright.
+//
+// Deliberately a token test rather than a name-charset test: over-restricting
+// interface names would drop working routes on any naming scheme this tree has
+// not seen, and the defect is about token COUNT.
+func validFRRInterfaceOperand(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] <= 0x20 || s[i] == 0x7f {
+			return false
+		}
+	}
+	return true
 }
 
 // validBGPNeighborAddress reports whether a BGP neighbor identity occupies

--- a/pkg/frr/route_operand_belt_6795_test.go
+++ b/pkg/frr/route_operand_belt_6795_test.go
@@ -1,0 +1,217 @@
+package frr
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// injectedPrefix6795 is the shape the defect permits: a first operand FRR
+// accepts, a newline, then a statement the operator never wrote.
+const injectedPrefix6795 = "10.0.0.0/8\nip route 0.0.0.0/0 Null0"
+
+func staticRoute6795(dest string, nh config.NextHopEntry) *config.StaticRoute {
+	return &config.StaticRoute{Destination: dest, NextHops: []config.NextHopEntry{nh}}
+}
+
+// TestMalformedStaticRouteOperandsNeverReachFRRConf6795 is the render-side belt
+// on the three raw operands of `ip route`: destination, gateway, interface.
+//
+// A malformed value fails the WHOLE frr-reload — one vtysh add-batch exits
+// non-zero on any CMD_WARNING_CONFIG_FAILED — so a single bad route takes every
+// other route on the box with it. A value carrying whitespace additionally
+// splits into extra operands or an extra statement.
+//
+// Each case asserts what the render BECAME, and each is paired with a
+// legitimate route in the same call that must still render — an absence check
+// alone passes against a renderer that emits nothing.
+func TestMalformedStaticRouteOperandsNeverReachFRRConf6795(t *testing.T) {
+	m := &Manager{}
+	good := config.NextHopEntry{Address: "10.0.0.1"}
+
+	cases := []struct {
+		name  string
+		route *config.StaticRoute
+		// absent is a substring that must NOT appear in the render.
+		absent string
+	}{
+		{
+			name:   "destination-with-injected-statement",
+			route:  staticRoute6795(injectedPrefix6795, good),
+			absent: "0.0.0.0/0 Null0",
+		},
+		{
+			name:   "destination-unparseable",
+			route:  staticRoute6795("not-a-prefix", good),
+			absent: "not-a-prefix",
+		},
+		{
+			name: "gateway-with-injected-statement",
+			route: staticRoute6795("10.1.0.0/16", config.NextHopEntry{
+				Address: "10.0.0.1\nip route 0.0.0.0/0 Null0",
+			}),
+			absent: "0.0.0.0/0 Null0",
+		},
+		{
+			name: "gateway-unparseable",
+			route: staticRoute6795("10.1.0.0/16", config.NextHopEntry{
+				Address: "not-an-address",
+			}),
+			absent: "not-an-address",
+		},
+		{
+			name: "interface-with-embedded-space",
+			route: staticRoute6795("10.1.0.0/16", config.NextHopEntry{
+				Interface: "eth0 Null0",
+			}),
+			absent: "eth0 Null0",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := m.generateStaticRouteInTable(tc.route, "", 0, nil, nil)
+			if strings.Contains(out, tc.absent) {
+				t.Fatalf("a malformed route operand reached frr.conf (%q):\n%s",
+					tc.absent, out)
+			}
+
+			// Control on the SAME renderer: a legitimate route must still
+			// render fully, so the assertion above is not passing because the
+			// renderer emits nothing at all.
+			ok := m.generateStaticRouteInTable(
+				staticRoute6795("10.2.0.0/16", good), "", 0, nil, nil)
+			if !strings.Contains(ok, "ip route 10.2.0.0/16 10.0.0.1") {
+				t.Fatalf("the VALID route did not render, so this cell cannot "+
+					"distinguish a working belt from a broken renderer:\n%s", ok)
+			}
+		})
+	}
+}
+
+// TestEcmpDropsOnlyTheBadNextHop6795 pins the GRANULARITY, which is the part a
+// coarser fix gets wrong.
+//
+// A `next-hop [ a b ]` ECMP list with one malformed member must still install
+// the good ones. Dropping the whole route would turn a typo in one gateway into
+// a blackhole for the prefix — and the no-next-hop path already renders NOTHING
+// rather than a Null0 (#3872), so a whole-route drop is silently fail-wide.
+func TestEcmpDropsOnlyTheBadNextHop6795(t *testing.T) {
+	m := &Manager{}
+	route := &config.StaticRoute{
+		Destination: "10.1.0.0/16",
+		NextHops: []config.NextHopEntry{
+			{Address: "10.0.0.1"},
+			{Address: "10.0.0.2\nip route 0.0.0.0/0 Null0"},
+			{Address: "10.0.0.3"},
+		},
+	}
+	out := m.generateStaticRouteInTable(route, "", 0, nil, nil)
+
+	for _, want := range []string{"10.0.0.1", "10.0.0.3"} {
+		if !strings.Contains(out, "ip route 10.1.0.0/16 "+want) {
+			t.Fatalf("a VALID ECMP next-hop (%s) was dropped along with the bad "+
+				"one — one malformed gateway must not blackhole the prefix:\n%s",
+				want, out)
+		}
+	}
+	if strings.Contains(out, "0.0.0.0/0 Null0") {
+		t.Fatalf("the malformed ECMP next-hop injected a statement:\n%s", out)
+	}
+}
+
+// TestGenerateRouteOperandBelt6795 covers the blackhole renderer. A
+// generate-route emits `ip route <p> blackhole`, so a mangled operand is the one
+// shape that could silently WIDEN what is dropped.
+func TestGenerateRouteOperandBelt6795(t *testing.T) {
+	var b strings.Builder
+	renderGenerateRoutes(&b, &FullConfig{
+		GenerateRoutes: []*config.GenerateRoute{
+			{Prefix: "192.168.0.0/16"},
+			{Prefix: injectedPrefix6795},
+			{Prefix: "garbage"},
+		},
+	})
+	out := b.String()
+
+	if !strings.Contains(out, "ip route 192.168.0.0/16 blackhole") {
+		t.Fatalf("the VALID generate-route did not render:\n%s", out)
+	}
+	if strings.Contains(out, "0.0.0.0/0 Null0") {
+		t.Fatalf("a malformed generate-route prefix injected a statement:\n%s", out)
+	}
+	if strings.Contains(out, "garbage") {
+		t.Fatalf("an unparseable generate-route prefix reached frr.conf:\n%s", out)
+	}
+}
+
+// TestRouteOperandBeltAcceptsWhatCommitsToday6795 is the OVER-REJECTION control,
+// and it is the assertion I trust least without it.
+//
+// Dropping a route is an outage, and a belt is most likely to be wrong in the
+// too-strict direction — that is exactly how the first draft of #6796 failed,
+// caught by a pre-existing test. These are the forms this tree renders today.
+func TestRouteOperandBeltAcceptsWhatCommitsToday6795(t *testing.T) {
+	for _, p := range []string{
+		"0.0.0.0/0", "::/0", "10.0.0.0/8", "2001:db8::/32",
+		"10.0.0.1", // a maskless host route
+		"2001:db8::1",
+	} {
+		if !validFRRRoutePrefix(p) {
+			t.Errorf("validFRRRoutePrefix(%q) = false — dropping a route form "+
+				"that renders today is an outage", p)
+		}
+	}
+	for _, g := range []string{"10.0.0.1", "fe80::1", "2001:db8::1"} {
+		if !validFRRNextHopAddress(g) {
+			t.Errorf("validFRRNextHopAddress(%q) = false", g)
+		}
+	}
+	for _, i := range []string{"eth0", "ge-0-0-1", "ge-0-0-1.50", "reth0.80"} {
+		if !validFRRInterfaceOperand(i) {
+			t.Errorf("validFRRInterfaceOperand(%q) = false", i)
+		}
+	}
+
+	// And the negatives, so the accepting rows above are not vacuous.
+	for _, p := range []string{"", "10.0.0.0/8 extra", "not-a-prefix", "10.0.0.0/8\nx"} {
+		if validFRRRoutePrefix(p) {
+			t.Errorf("validFRRRoutePrefix(%q) = true", p)
+		}
+	}
+	for _, g := range []string{"", "10.0.0.0/8", "10.0.0.1 extra", "10.0.0.1\nx"} {
+		if validFRRNextHopAddress(g) {
+			t.Errorf("validFRRNextHopAddress(%q) = true — a prefix or a "+
+				"multi-token value in the gateway slot is a grammar error that "+
+				"fails the frr-reload", g)
+		}
+	}
+	for _, i := range []string{"", "eth0 x", "eth0\nx", "eth0\tx"} {
+		if validFRRInterfaceOperand(i) {
+			t.Errorf("validFRRInterfaceOperand(%q) = true", i)
+		}
+	}
+}
+
+// TestDHCPRouteOperandsAreStructurallySafe6795 records a measurement rather than
+// guarding a fix, and says so.
+//
+// The DHCP-learned routes look like the highest-risk operands — they come from a
+// DHCP server on the wire — but they are NOT raw strings: `lease.Gateway` is a
+// netip.Addr and `cr.Destination` a netip.Prefix, both String()-ed. Those types
+// cannot stringify to anything containing whitespace, so the DHCP path cannot
+// carry the injection this issue is about. No belt was added there.
+//
+// This cell exists so that stays true: if either field is ever widened to a
+// string, the belt question has to be re-asked, and a compile failure here is
+// the cheapest possible reminder.
+func TestDHCPRouteOperandsAreStructurallySafe6795(t *testing.T) {
+	var b strings.Builder
+	renderDHCPDefaults(&b, &FullConfig{
+		DHCPRoutes: []DHCPRoute{{Gateway: "10.0.2.1", Interface: "fxp0"}},
+	})
+	if !strings.Contains(b.String(), "ip route 0.0.0.0/0 10.0.2.1 fxp0 200") {
+		t.Fatalf("the DHCP default route did not render as expected:\n%s", b.String())
+	}
+}


### PR DESCRIPTION
Closes #6795

## What was wrong

The `ip route` / `ipv6 route` renderers interpolate **raw strings from the
parser** — `sr.Destination`, `nh.Address`, `ifName`, `gr.Prefix` — with no
validity check, while the protocol renderers sitting beside them already have
belts (`validRouterID` #2980, `validClusterID` / `validBGPOrigin` #4919).

**The blast radius is what makes this matter, not the likelihood.** A malformed
operand fails the **whole** frr-reload — one `vtysh -f` add-batch exits non-zero
on any `CMD_WARNING_CONFIG_FAILED` — so a single bad route takes **every other
route on the box** with it. A value carrying whitespace additionally splits into
extra operands, or adds a statement outright.

Commit validates these, but the tolerant load / HA config-sync paths only warn
(#1960 no-brick), so the renderer is the last place to stop it.

## Three predicates

| operand | predicate | accepts |
|---|---|---|
| destination / generate prefix | `validFRRRoutePrefix` | CIDR **or** a bare address |
| gateway | `validFRRNextHopAddress` | a bare address only |
| interface | `validFRRInterfaceOperand` | one token |

## Granularity is deliberate — it is what a coarser fix gets wrong

A bad **destination** drops the route. A bad **next-hop** drops only that
next-hop.

A `next-hop [ a b ]` ECMP list with one malformed member must still install the
good ones: dropping the whole route would turn a typo in one gateway into a
blackhole for the prefix — and the no-next-hop path already renders **nothing**
rather than a `Null0` (#3872), so a whole-route drop is silently fail-wide. **M5
is that cell**, and it reds.

## Two accept-side decisions, both in the over-rejection direction

`validFRRRoutePrefix` accepts a **maskless host route**: the destination is a raw
string and a host route can reach here without a mask, and dropping a form that
renders today is an outage. `validFRRInterfaceOperand` is a **token** test rather
than a name-charset test, because over-restricting interface names would drop
working routes on any naming scheme this tree has not seen — and the defect is
about token *count*.

This is the same trap that caught the first draft of #6796 (which required a bare
IP and was caught over-rejecting by a pre-existing test peering with
`peer.example.com`). M6 and M7 are the cells that hold both decisions in place.

## The DHCP-learned routes get no belt, and that is a measurement

They look like the highest-risk operands — they come from a DHCP server on the
wire — but they are **not raw strings**: `lease.Gateway` is a `netip.Addr` and
`cr.Destination` a `netip.Prefix`, both `String()`-ed, and those types cannot
stringify to anything containing whitespace. So the DHCP path structurally cannot
carry this injection.

`TestDHCPRouteOperandsAreStructurallySafe6795` records that, so the question is
re-asked if either field is ever widened to a string.

## Mutation matrix

Fix committed FIRST. Every cell runs the full `pkg/frr` suite with
`go test -count=1`, no `-run` filter; each mutation verified applied on a
building, vetting tree. **8 cells, all RED — half of them tightening.**

| cell | result | assertion |
|---|---|---|
| M1 destination belt removed | RED | `...NeverReachFRRConf6795` |
| M2 next-hop address belt removed | RED | that + `...EcmpDropsOnlyTheBadNextHop6795` |
| M3 interface belt removed | RED | `...NeverReachFRRConf6795` |
| M4 generate-route belt removed | RED | `...GenerateRouteOperandBelt6795` |
| **M5 TIGHTEN: a bad next-hop drops the WHOLE route** | RED | `...EcmpDropsOnlyTheBadNextHop6795` |
| **M6 TIGHTEN: destination belt rejects a maskless host route** | RED | `...AcceptsWhatCommitsToday6795` |
| **M7 TIGHTEN: gateway belt accepts a prefix too** | RED | same |
| **M8 interface belt misses the space byte (`< 0x20`)** | RED | 2 cells |

M8 is the boundary that matters: `0x20` is the space itself, so a `< 0x20`
predicate catches every control byte and misses the one separator that actually
splits an FRR operand.

## Test design

The render cells assert **what the output became** and each pairs the malformed
route with a legitimate one *in the same renderer* — an absence assertion alone
passes against a renderer that emits nothing. The over-rejection control lists
the forms this tree renders today, and is the assertion I trust least without it.

## Not covered here

The `vrf <name>` clause still goes through `sanitizeFRRValue` (#5557). That
sanitizer maps control bytes to a **space** — the sink's own separator — so it is
the weaker belt described under #6796. The routing-instance name is validated at
commit and it is out of this issue's scope; flagged rather than silently left.

## Gates

`go build ./... && go vet ./... && go test -count=1 ./...` — all rc=0, 67
packages, tree clean. **No pre-existing test disturbed**, which for a
fail-closed belt is the result that matters. Go only; nothing moves the
`userspace-dp` binary or the shim `.o`, so no cargo leg. No cluster, VRRP,
session-sync or failover code — no smoke owed.
