### PR TITLE
nft: mirror flexible-match-range in the kernel lo0 filter

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104912,3 +104912,21 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/lldp/apply_partial_6794_test.go`, `pkg/daemon/daemon.go`,
   `pkg/daemon/daemon_apply_tail.go`,
   `pkg/daemon/lldp_recovery_6794_test.go`, `pkg/lldp/README.md`, `_Log.md`
+
+## 2026-08-23 — #6804 lo0 mirror dropped flexible-match-range
+
+- **Timestamp**: 2026-08-23
+- **Action**: The lo0 kernel nft mirror had NO handling for
+  `from flexible-match-range` — `Lo0FilterTerm` had no field for it, so the
+  predicate was dropped at the spec boundary and the term rendered without its
+  narrowing (an accept-term admitted everything it scoped) on the chain that is
+  the PRIMARY host-traffic enforcement. Added the predicate to both renderers
+  (text oracle `@nh,off,len & mask == value`; netlink payload+bitwise+cmp), with
+  an unrepresentable predicate making the term match NOTHING to mirror
+  userspace's `FlexMatchStart::Unsupported` — deliberately not the #5512
+  tcp-flags drop, which has a `meta l4proto 6` narrowing a flex-match lacks.
+  Bound by real-`nft` parity cases across three widths.
+- **File(s)**: pkg/nftables/netlink_spec.go, pkg/nftables/netlink_build.go,
+  pkg/nftables/netlink_lo0.go, pkg/daemon/daemon_nft.go,
+  pkg/daemon/daemon_nft_netlink.go,
+  pkg/daemon/daemon_nft_netlink_parity_test.go, pkg/daemon/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -104930,3 +104930,11 @@ prose edit above them added. No diff falls in the new test body.
   pkg/nftables/netlink_lo0.go, pkg/daemon/daemon_nft.go,
   pkg/daemon/daemon_nft_netlink.go,
   pkg/daemon/daemon_nft_netlink_parity_test.go, pkg/daemon/README.md, _Log.md
+- **Timestamp**: 2026-08-23
+- **Action**: #6804 round 2 — three mutation cells came back GREEN, all fixture
+  gaps: no zero-bit-length case (so treating 0 as "no constraint" was
+  invisible), no oversized-width case (so capping to 4 — the #3406 fail-open —
+  was invisible), and every value already inside its mask, so pre-masking was a
+  no-op on both sides and skipping it still agreed. Added all three shapes plus
+  an assertion that a following deny term survives an unrepresentable one.
+- **File(s)**: pkg/daemon/daemon_nft_netlink_parity_test.go, _Log.md

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -2238,6 +2238,48 @@ never lock an operator out of a remote box it manages.
   reverted arm emits `meta l4proto 6 accept`, the widen) and
   `TestLo0FilterPayloadUnrepresentableTCPFlagsParses` (the emission parses under
   `nft -c -f -`, proving it never fails the whole ruleset).
+
+  **flexible-match-range is MIRRORED, and an unrepresentable one matches
+  NOTHING (#6804):** before this the lo0 mirror had no handling for
+  `from flexible-match-range` at ALL — the netlink spec (`Lo0FilterTerm`) had no
+  field for it, so the predicate was dropped at that boundary and the term
+  rendered WITHOUT its narrowing. An `accept` term meant to admit only packets
+  whose header bytes match a pattern admitted every packet it scoped: the same
+  control-plane fail-OPEN #5512 fixed for tcp-flags, on the chain that is the
+  PRIMARY enforcement for host traffic.
+
+  A representable predicate now renders as nft's raw payload match,
+  `@nh,<byteOffset*8>,<byteLen*8> & <mask> == <value>` — `layer-3` match-start
+  (the only start point the compiler emits) is the network-header base. The load
+  is whole BYTES because nft loads byte-aligned; a sub-byte bit length is carried
+  by the MASK, exactly as the userspace matcher does it, and the expected value
+  is pre-masked on both sides (nft compares the masked load, so a value with bits
+  outside the mask would never match — a silent never-match is a different fail
+  direction but just as quiet).
+
+  An UNREPRESENTABLE predicate — more than one named range (#5823), an
+  unparseable numeric token (`UnknownFlexMatch`), or a load width outside 1..4
+  bytes — makes the term match NOTHING (no rule emitted), so later terms still
+  run. That mirrors userspace, which poisons the term to
+  `FlexMatchStart::Unsupported` so `flex_matches()` returns false. It is
+  deliberately NOT the #5512 tcp-flags drop: a tcp-flags constraint only ever
+  matches TCP so that drop can be scoped with `meta l4proto 6`, whereas a
+  flexible-match-range has no natural narrowing — a term whose ONLY predicate was
+  the flex-match would render a bare `drop` and deny ALL host-inbound traffic,
+  turning a fail-open into a lockout.
+
+  The width rules mirror the userspace snapshot builder exactly: a zero
+  bit-length defaults to 4 (32-bit), and an oversized width is NOT capped to 4 —
+  capping would compare only the truncated window and BROADEN the match (the
+  #3406 fail-open), so it is reported unrepresentable instead.
+
+  Pinned by `TestNftNetlinkParity/lo0_flexible_match_range` (three widths,
+  including a sub-byte 12-bit case, diffed between the nft-parsed oracle and the
+  real netlink install) and
+  `TestNftNetlinkParity/lo0_unrepresentable_flex_match_matches_nothing`. The
+  parity case is what makes the two renderers' agreement real rather than
+  asserted — both go through the actual `nft` parser and the actual netlink
+  install.
 - host-inbound-traffic (`security zones <z> host-inbound-traffic`) is the
   PRIMARY kernel enforcement for host-bound traffic to a firewall interface IP
   / VRRP VIP (SSH, ping, OSPF/BGP to the box — #3070). Such traffic is shunted

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -2196,6 +2196,24 @@ func nftRulesFromTerm(term *config.FirewallFilterTerm, family string, prefixList
 	// this file was hardened). Record the unrepresentable expression and fail
 	// THIS term closed below (drop its scoped traffic) instead of appending a
 	// flag predicate.
+	// #6804: an unrepresentable flexible-match-range makes the term match
+	// NOTHING, mirroring userspace (which poisons it to
+	// FlexMatchStart::Unsupported so flex_matches() returns false and later
+	// terms still run). Returning "" makes buildLo0FilterPayload skip the rule,
+	// which is the kernel equivalent.
+	//
+	// Deliberately NOT the #5512 tcp-flags drop: a tcp-flags constraint only
+	// ever matches TCP, so that drop can be scoped with `meta l4proto 6`. A
+	// flexible-match-range has no such natural narrowing, so a term whose ONLY
+	// predicate was the flex-match would render a bare `drop` and deny ALL
+	// host-inbound traffic — turning a fail-open into a lockout.
+	if lo0FlexMatchUnrepresentable(term) {
+		slog.Warn("lo0 kernel nftables mirror: unrepresentable flexible-match-range; "+
+			"the term matches NOTHING (mirroring the userspace fail-closed) so its "+
+			"narrowing is never silently dropped", "term", term.Name)
+		return nil
+	}
+
 	tcpFlagsFailClosed := false
 	if len(term.TCPFlags) > 0 {
 		if required, forbidden, ok, err := config.ParseTCPFlagsExpression(term.TCPFlags); err != nil {
@@ -2218,6 +2236,20 @@ func nftRulesFromTerm(term *config.FirewallFilterTerm, family string, prefixList
 		} else {
 			parts = append(parts, "ip frag-off & 0x1fff != 0")
 		}
+	}
+
+	// #6804: flexible-match-range. Before this the oracle had no case for it at
+	// all, so the predicate was silently DROPPED and the term rendered WIDER
+	// than configured — an accept-term admitted every packet it scoped instead
+	// of only those whose header bytes matched. This chain is the PRIMARY
+	// enforcement for host traffic (the XDP shim shunts host-bound packets to
+	// the kernel before userspace-dp), so that is a control-plane fail-OPEN.
+	//
+	// nft's raw payload syntax takes BIT offset and BIT length from the base:
+	// `@nh,<off>,<len>`. match-start layer-3 — the only start point the compiler
+	// emits — is the network header base.
+	if fm := term.FlexMatch; fm != nil && !lo0FlexMatchUnrepresentable(term) {
+		parts = append(parts, nftFlexMatchExpr(*fm))
 	}
 
 	// Disposition. Mirror the userspace lo0 evaluator
@@ -2496,4 +2528,53 @@ func nftDSCPValue(name string) string {
 		return strconv.Itoa(v)
 	}
 	return strings.ToLower(strings.TrimSpace(name))
+}
+
+// lo0FlexMatchUnrepresentable reports whether a term's flexible-match-range
+// cannot be rendered faithfully (#6804): more than one named range (#5823), an
+// unparseable numeric token (UnknownFlexMatch), or a load width outside 1..4
+// bytes.
+//
+// The width rule mirrors the userspace snapshot builder exactly: a zero
+// bit-length defaults to 4 (32-bit) and an oversized width is NOT capped —
+// capping would compare only the truncated window and BROADEN the match, which
+// is the #3406 fail-open.
+func lo0FlexMatchUnrepresentable(term *config.FirewallFilterTerm) bool {
+	if len(term.FlexMatchRangeNames) > 1 || len(term.UnknownFlexMatch) > 0 {
+		return true
+	}
+	if term.FlexMatch == nil {
+		return false
+	}
+	n := nftFlexMatchByteLen(term.FlexMatch.BitLength)
+	return n < 1 || n > 4
+}
+
+// nftFlexMatchByteLen is the payload load width in bytes for a bit length,
+// matching the userspace snapshot builder (0 -> 4, else ceil(bits/8)).
+func nftFlexMatchByteLen(bits uint8) int {
+	if bits == 0 {
+		return 4
+	}
+	return (int(bits) + 7) / 8
+}
+
+// nftFlexMatchExpr renders `@nh,<bitoff>,<bitlen> & <mask> == <value>`.
+//
+// The load width is whole BYTES (nft loads byte-aligned), so the bit length in
+// the expression is the byte width times 8 — the sub-byte narrowing is carried
+// by the mask, exactly as the userspace matcher does it. The expected value is
+// pre-masked for the same reason the netlink builder pre-masks it: nft compares
+// the MASKED load, so a value carrying bits outside the mask would never match,
+// and a silent never-match is a different fail direction but just as quiet.
+func nftFlexMatchExpr(fm config.FlexMatchConfig) string {
+	n := nftFlexMatchByteLen(fm.BitLength)
+	mask := fm.Mask
+	value := fm.Value & mask
+	if n < 4 {
+		trunc := uint32(1)<<(uint(n)*8) - 1
+		mask &= trunc
+		value &= trunc
+	}
+	return fmt.Sprintf("@nh,%d,%d & 0x%x == 0x%x", int(fm.ByteOffset)*8, n*8, mask, value)
 }

--- a/pkg/daemon/daemon_nft_netlink.go
+++ b/pkg/daemon/daemon_nft_netlink.go
@@ -213,11 +213,38 @@ func toNftLo0Term(term *config.FirewallFilterTerm, pl map[string]*config.PrefixL
 		ICMPTypes:         term.ICMPTypes,
 		ICMPCodes:         term.ICMPCodes,
 		TCPFlags:          term.TCPFlags,
-		IsFragment:        term.IsFragment,
-		Log:               term.Log,
-		Count:             term.Count,
-		Action:            term.Action,
-		NextTerm:          term.NextTerm,
-		RoutingInstance:   term.RoutingInstance,
+		// #6804: carry the flexible-match-range so the kernel mirror renders the
+		// term's narrowing. Before this the spec had no field for it, so the
+		// predicate was dropped at this boundary and the term rendered WIDER
+		// than configured — a control-plane fail-open on the chain that is the
+		// PRIMARY enforcement for host traffic.
+		FlexMatch:                lo0FlexMatch(term.FlexMatch),
+		FlexMatchUnrepresentable: len(term.FlexMatchRangeNames) > 1 || len(term.UnknownFlexMatch) > 0,
+		IsFragment:               term.IsFragment,
+		Log:                      term.Log,
+		Count:                    term.Count,
+		Action:                   term.Action,
+		NextTerm:                 term.NextTerm,
+		RoutingInstance:          term.RoutingInstance,
+	}
+}
+
+// lo0FlexMatch converts a compiled flexible-match-range into the mirror's
+// transport type (#6804). nil in, nil out: a term with no flex-match carries no
+// predicate and must render exactly as before.
+//
+// The conversion is deliberately field-for-field with no interpretation — the
+// byte width, the mask application and the endianness all live in the netlink
+// builder, so the two renderers cannot disagree about what the same config
+// means.
+func lo0FlexMatch(fm *config.FlexMatchConfig) *xnft.Lo0FlexMatch {
+	if fm == nil {
+		return nil
+	}
+	return &xnft.Lo0FlexMatch{
+		ByteOffset: fm.ByteOffset,
+		BitLength:  fm.BitLength,
+		Value:      fm.Value,
+		Mask:       fm.Mask,
 	}
 }

--- a/pkg/daemon/daemon_nft_netlink_parity_test.go
+++ b/pkg/daemon/daemon_nft_netlink_parity_test.go
@@ -121,6 +121,79 @@ func runNftNetlinkParityInner(t *testing.T) {
 		parityCheck(t, xnft.Lo0TableName, oracle, func() error { _, err := inst.InstallLo0(spec); return err })
 	})
 
+	// #6804: the flexible-match-range predicate. Before the fix NEITHER renderer
+	// carried it — the lo0 netlink spec had no field for it at all — so the term
+	// rendered WITHOUT its narrowing on the chain that is the PRIMARY
+	// enforcement for host traffic. This case is what makes the two renderers'
+	// agreement real rather than asserted: both go through the actual `nft`
+	// parser and the actual netlink install, and the installed rulesets are
+	// diffed.
+	//
+	// The widths are chosen to exercise the parts most likely to diverge: a
+	// sub-byte bit length (12 -> a 2-byte load narrowed by the mask), a
+	// byte-aligned one, and a full 32-bit one.
+	t.Run("lo0_flexible_match_range", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			fm   config.FlexMatchConfig
+		}{
+			{"sub-byte-12-bits", config.FlexMatchConfig{MatchStart: "layer-3", ByteOffset: 6, BitLength: 12, Value: 0x0abc, Mask: 0x0fff}},
+			{"byte-aligned-8-bits", config.FlexMatchConfig{MatchStart: "layer-3", ByteOffset: 9, BitLength: 8, Value: 0x11, Mask: 0xff}},
+			{"full-32-bits", config.FlexMatchConfig{MatchStart: "layer-3", ByteOffset: 12, BitLength: 32, Value: 0x0a000001, Mask: 0xffffffff}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				fm := tc.fm
+				cfg := &config.Config{}
+				cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+					"flexf": {Terms: []*config.FirewallFilterTerm{
+						{Name: "flex", Protocols: []string{"tcp"}, FlexMatch: &fm, Action: "accept"},
+						{Name: "deny-rest", Action: "discard"},
+					}},
+				}
+				nftDeleteTableBestEffort(xnft.Lo0TableName)
+				oracle := buildLo0FilterPayload(cfg, "flexf", "")
+				// Guard the fixture's own premise: an oracle that omitted the
+				// predicate would make the diff below pass for the wrong reason.
+				if !strings.Contains(oracle, "@nh,") {
+					t.Fatalf("the oracle emitted no raw-payload match, so this "+
+						"cell cannot detect a dropped predicate:\n%s", oracle)
+				}
+				spec := toNftLo0Spec(cfg, "flexf", "")
+				parityCheck(t, xnft.Lo0TableName, oracle, func() error { _, err := inst.InstallLo0(spec); return err })
+			})
+		}
+	})
+
+	// #6804: an unrepresentable flexible-match-range must make the term match
+	// NOTHING on BOTH sides — mirroring the userspace fail-closed, where the
+	// term is poisoned to FlexMatchStart::Unsupported and later terms still run.
+	// A drop would be wrong: a flex-match has no natural narrowing like
+	// tcp-flags' `meta l4proto 6`, so a term whose only predicate was the
+	// flex-match would deny ALL host-inbound traffic.
+	t.Run("lo0_unrepresentable_flex_match_matches_nothing", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+			"flexbad": {Terms: []*config.FirewallFilterTerm{
+				{
+					Name:                "multi-range",
+					Protocols:           []string{"tcp"},
+					FlexMatchRangeNames: []string{"r1", "r2"},
+					FlexMatch:           &config.FlexMatchConfig{MatchStart: "layer-3", ByteOffset: 6, BitLength: 8, Value: 1, Mask: 0xff},
+					Action:              "accept",
+				},
+				{Name: "deny-rest", Action: "discard"},
+			}},
+		}
+		nftDeleteTableBestEffort(xnft.Lo0TableName)
+		oracle := buildLo0FilterPayload(cfg, "flexbad", "")
+		if strings.Contains(oracle, "@nh,") {
+			t.Fatalf("an UNREPRESENTABLE flex-match still rendered a payload "+
+				"match:\n%s", oracle)
+		}
+		spec := toNftLo0Spec(cfg, "flexbad", "")
+		parityCheck(t, xnft.Lo0TableName, oracle, func() error { _, err := inst.InstallLo0(spec); return err })
+	})
+
 	t.Run("lo0_unrepresentable_port_fails_closed", func(t *testing.T) {
 		// #6405 FIX-1: a port token nft cannot resolve (not numeric, not a service
 		// name). BOTH sides must FAIL CLOSED: the oracle emits the raw token and

--- a/pkg/daemon/daemon_nft_netlink_parity_test.go
+++ b/pkg/daemon/daemon_nft_netlink_parity_test.go
@@ -140,6 +140,20 @@ func runNftNetlinkParityInner(t *testing.T) {
 			{"sub-byte-12-bits", config.FlexMatchConfig{MatchStart: "layer-3", ByteOffset: 6, BitLength: 12, Value: 0x0abc, Mask: 0x0fff}},
 			{"byte-aligned-8-bits", config.FlexMatchConfig{MatchStart: "layer-3", ByteOffset: 9, BitLength: 8, Value: 0x11, Mask: 0xff}},
 			{"full-32-bits", config.FlexMatchConfig{MatchStart: "layer-3", ByteOffset: 12, BitLength: 32, Value: 0x0a000001, Mask: 0xffffffff}},
+			// Zero bit-length: the userspace snapshot builder DEFAULTS it to 4
+			// (32-bit). Without this row, an implementation that treated 0 as
+			// "no constraint" would render the term with no narrowing at all —
+			// the exact widening this issue is about — and every other row would
+			// still pass.
+			{"zero-bit-length-defaults-to-32", config.FlexMatchConfig{MatchStart: "layer-3", ByteOffset: 12, BitLength: 0, Value: 0x0a000001, Mask: 0xffffffff}},
+			// Value carrying bits OUTSIDE the mask. Every row above has the
+			// value already inside its mask, so pre-masking is a NO-OP on both
+			// sides and a renderer that skipped it would still agree — the
+			// fixture varies the right axis but samples only the point where it
+			// cannot fail. nft compares the MASKED load, so an unmasked expected
+			// value never matches: a silent never-match, which is a different
+			// fail direction from the widening but just as quiet.
+			{"value-outside-mask-is-pre-masked", config.FlexMatchConfig{MatchStart: "layer-3", ByteOffset: 9, BitLength: 8, Value: 0xff11, Mask: 0x0f}},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				fm := tc.fm
@@ -171,27 +185,73 @@ func runNftNetlinkParityInner(t *testing.T) {
 	// tcp-flags' `meta l4proto 6`, so a term whose only predicate was the
 	// flex-match would deny ALL host-inbound traffic.
 	t.Run("lo0_unrepresentable_flex_match_matches_nothing", func(t *testing.T) {
-		cfg := &config.Config{}
-		cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
-			"flexbad": {Terms: []*config.FirewallFilterTerm{
-				{
+		for _, tc := range []struct {
+			name string
+			term *config.FirewallFilterTerm
+		}{
+			{
+				// #5823: more than one named range.
+				name: "multi-range",
+				term: &config.FirewallFilterTerm{
 					Name:                "multi-range",
 					Protocols:           []string{"tcp"},
 					FlexMatchRangeNames: []string{"r1", "r2"},
 					FlexMatch:           &config.FlexMatchConfig{MatchStart: "layer-3", ByteOffset: 6, BitLength: 8, Value: 1, Mask: 0xff},
 					Action:              "accept",
 				},
-				{Name: "deny-rest", Action: "discard"},
-			}},
+			},
+			{
+				// An unparseable numeric token: strict commit rejects it, the
+				// tolerant load only warns (#1960), so it reaches the mirror.
+				name: "unknown-token",
+				term: &config.FirewallFilterTerm{
+					Name:             "unknown-token",
+					Protocols:        []string{"tcp"},
+					UnknownFlexMatch: []string{"byte-offset=not-a-number"},
+					FlexMatch:        &config.FlexMatchConfig{MatchStart: "layer-3", ByteOffset: 6, BitLength: 8, Value: 1, Mask: 0xff},
+					Action:           "accept",
+				},
+			},
+			{
+				// Width OUTSIDE 1..4 bytes. The commit gate bounds bit-length to
+				// 1..32, so 40 bits arrives only on a corrupt / version-drifted
+				// tolerant-load snapshot — and CAPPING it to 4 would compare only
+				// the truncated window and BROADEN the match (the #3406
+				// fail-open), so it must be unrepresentable, not clamped.
+				name: "oversized-width",
+				term: &config.FirewallFilterTerm{
+					Name:      "oversized-width",
+					Protocols: []string{"tcp"},
+					FlexMatch: &config.FlexMatchConfig{MatchStart: "layer-3", ByteOffset: 6, BitLength: 40, Value: 1, Mask: 0xff},
+					Action:    "accept",
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				cfg := &config.Config{}
+				cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+					"flexbad": {Terms: []*config.FirewallFilterTerm{
+						tc.term,
+						{Name: "deny-rest", Action: "discard"},
+					}},
+				}
+				nftDeleteTableBestEffort(xnft.Lo0TableName)
+				oracle := buildLo0FilterPayload(cfg, "flexbad", "")
+				if strings.Contains(oracle, "@nh,") {
+					t.Fatalf("an UNREPRESENTABLE flex-match still rendered a "+
+						"payload match:\n%s", oracle)
+				}
+				// The later term must survive: "matches nothing" means the term
+				// contributes no enforcement, NOT that the filter is emptied.
+				if !strings.Contains(oracle, "drop") {
+					t.Fatalf("the following deny term did not render, so the "+
+						"unrepresentable term swallowed the rest of the "+
+						"filter:\n%s", oracle)
+				}
+				spec := toNftLo0Spec(cfg, "flexbad", "")
+				parityCheck(t, xnft.Lo0TableName, oracle, func() error { _, err := inst.InstallLo0(spec); return err })
+			})
 		}
-		nftDeleteTableBestEffort(xnft.Lo0TableName)
-		oracle := buildLo0FilterPayload(cfg, "flexbad", "")
-		if strings.Contains(oracle, "@nh,") {
-			t.Fatalf("an UNREPRESENTABLE flex-match still rendered a payload "+
-				"match:\n%s", oracle)
-		}
-		spec := toNftLo0Spec(cfg, "flexbad", "")
-		parityCheck(t, xnft.Lo0TableName, oracle, func() error { _, err := inst.InstallLo0(spec); return err })
 	})
 
 	t.Run("lo0_unrepresentable_port_fails_closed", func(t *testing.T) {

--- a/pkg/nftables/netlink_build.go
+++ b/pkg/nftables/netlink_build.go
@@ -20,6 +20,7 @@ package nftables
 // (`ip daddr X icmp type Y`) bit-equivalent to the oracle text.
 
 import (
+	"encoding/binary"
 	"fmt"
 	"net/netip"
 
@@ -258,6 +259,18 @@ func (a *ruleAsm) tcpFlags(required, forbidden uint8) *ruleAsm {
 func (a *ruleAsm) fragV4() *ruleAsm {
 	a.needNfproto(famV4)
 	return a.add(fragV4Match()...)
+}
+
+// flexMatch appends a `flexible-match-range` predicate (#6804): load BitLength
+// bits at ByteOffset from the LAYER-3 header, mask, and compare.
+//
+// No nfproto/l4proto dep is added, deliberately. `layer-3` means "from the start
+// of the network header", which is well-defined in both families, and adding an
+// nfproto dep would narrow the term to one family — silently dropping the
+// predicate's effect in the other pass, which is the widening this exists to
+// prevent.
+func (a *ruleAsm) flexMatch(fm Lo0FlexMatch) *ruleAsm {
+	return a.add(flexMatchExprs(fm)...)
 }
 
 // exthdrFragV6 appends `exthdr frag exists` with its nfproto(ipv6) dep.
@@ -549,6 +562,64 @@ func fragV4Match() []expr.Any {
 		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseNetworkHeader, Offset: 6, Len: 2},
 		&expr.Bitwise{SourceRegister: 1, DestRegister: 1, Len: 2, Mask: []byte{0x1f, 0xff}, Xor: []byte{0x00, 0x00}},
 		&expr.Cmp{Op: expr.CmpOpNeq, Register: 1, Data: []byte{0x00, 0x00}},
+	}
+}
+
+// flexMatchByteLen is the payload load width for a bit length: ceil(bits/8),
+// matching the userspace snapshot builder (pkg/dataplane/userspace/filters.go),
+// which derives its own load width the same way. The compiler constrains
+// BitLength to 1..32, so the result is 1..4.
+// It mirrors the userspace snapshot builder EXACTLY, including its two edge
+// rules (pkg/dataplane/userspace/filters.go): a zero bit-length defaults to 4
+// (32-bit), and an oversized width is NOT capped to 4 — capping would compare
+// only the truncated window and BROADEN the match, the #3406 fail-open. An
+// oversized width is reported here as unrepresentable instead, which is the same
+// direction userspace takes (it rejects the snapshot outright).
+func flexMatchByteLen(bits uint8) uint32 {
+	if bits == 0 {
+		return 4
+	}
+	return uint32((uint16(bits) + 7) / 8)
+}
+
+// flexMatchRepresentable reports whether a resolved predicate can be rendered
+// as an nft payload load. Only the width can fail: the commit gate bounds
+// bit-length to 1..32, so a width outside 1..4 arrives only on a corrupt /
+// version-drifted tolerant-load snapshot.
+func flexMatchRepresentable(fm Lo0FlexMatch) bool {
+	n := flexMatchByteLen(fm.BitLength)
+	return n >= 1 && n <= 4
+}
+
+// flexMatchExprs renders `@nh,<off*8>,<bits> & mask == value` as
+// payload + bitwise + cmp, the same three-expression shape fragV4Match uses.
+//
+// Value and Mask are emitted BIG-ENDIAN over the load width, because a payload
+// load returns network-order bytes and the compiler stores both as host-order
+// integers over that same width (config.FlexMatchConfig). Truncating from the
+// low end of a big-endian encoding is what keeps a 1-byte match comparing the
+// byte the operator wrote rather than the top byte of a 32-bit word.
+func flexMatchExprs(fm Lo0FlexMatch) []expr.Any {
+	n := flexMatchByteLen(fm.BitLength)
+	if !flexMatchRepresentable(fm) {
+		return nil
+	}
+	var val, mask [4]byte
+	binary.BigEndian.PutUint32(val[:], fm.Value)
+	binary.BigEndian.PutUint32(mask[:], fm.Mask)
+	v := append([]byte(nil), val[4-n:]...)
+	m := append([]byte(nil), mask[4-n:]...)
+	// Apply the mask to the expected value too. nft's own `& mask == value`
+	// lowering compares the MASKED load, so an operator value carrying bits
+	// outside the mask would otherwise never match — a silent never-match is a
+	// different fail direction from the widening this fixes, and just as quiet.
+	for i := range v {
+		v[i] &= m[i]
+	}
+	return []expr.Any{
+		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseNetworkHeader, Offset: uint32(fm.ByteOffset), Len: n},
+		&expr.Bitwise{SourceRegister: 1, DestRegister: 1, Len: n, Mask: m, Xor: make([]byte, n)},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: v},
 	}
 }
 

--- a/pkg/nftables/netlink_lo0.go
+++ b/pkg/nftables/netlink_lo0.go
@@ -85,6 +85,25 @@ func buildLo0TermNetlink(p *nlPlan, t Lo0FilterTerm, f nlFamily) {
 			tcpFailClosed = true
 		}
 	}
+	// #6804: fail-closed for an unrepresentable flexible-match-range.
+	//
+	// The direction is NOT the tcp-flags drop, and mirroring userspace is what
+	// decides that. Userspace poisons such a term to FlexMatchStart::Unsupported
+	// so flex_matches() returns false and the term matches NOTHING — later terms
+	// still run (pkg/dataplane/userspace/filters.go). The kernel equivalent of
+	// "matches nothing" is to emit NO RULE for the term.
+	//
+	// A drop would be wrong here in a way it is not for tcp-flags: a tcp-flags
+	// constraint only ever matches TCP, so #5512 can scope its drop with
+	// `meta l4proto 6`. A flexible-match-range has no such natural narrowing, so
+	// a term whose ONLY predicate was the flex-match would render a bare `drop`
+	// and deny ALL host-inbound traffic — turning a fail-open into a lockout.
+	if t.FlexMatchUnrepresentable || (t.FlexMatch != nil && !flexMatchRepresentable(*t.FlexMatch)) {
+		slog.Warn("lo0 netlink mirror: unrepresentable flexible-match-range; the "+
+			"term matches NOTHING (mirroring the userspace fail-closed) so its "+
+			"narrowing is never silently dropped", "term", t.Name)
+		return
+	}
 	// addPorts resolves one port-token list and appends its transport-port match.
 	// An unrepresentable token FAILS the plan CLOSED (a.p.fail), exactly as the
 	// nft oracle does: the oracle emits the raw token and `nft -f -` REJECTS it,
@@ -143,6 +162,11 @@ func buildLo0TermNetlink(p *nlPlan, t Lo0FilterTerm, f nlFamily) {
 			} else {
 				a.fragV4()
 			}
+		}
+		// #6804: emit the flexible-match-range narrowing. Skipped when failing
+		// closed, exactly like tcp-flags — the drop below covers the term.
+		if !tcpFailClosed && t.FlexMatch != nil {
+			a.flexMatch(*t.FlexMatch)
 		}
 	}
 	applyMods := func(a *ruleAsm) {

--- a/pkg/nftables/netlink_spec.go
+++ b/pkg/nftables/netlink_spec.go
@@ -97,12 +97,47 @@ type Lo0FilterTerm struct {
 	TCPFlags          []string
 	IsFragment        bool
 
+	// FlexMatch carries a `from flexible-match-range` predicate (#6804). Before
+	// it existed the lo0 mirror had NO field for it at all, so the predicate was
+	// dropped at this boundary and the term rendered WITHOUT its narrowing — an
+	// `accept` term meant to admit only packets whose header bytes match a
+	// pattern admitted everything else in its scope. The XDP shim shunts
+	// host-bound traffic to the kernel before userspace-dp, so this chain is the
+	// PRIMARY enforcement for host traffic: that is a control-plane fail-OPEN,
+	// the same class #5512 fixed for tcp-flags.
+	//
+	// Only `layer-3` match-start is representable, which is exactly what the
+	// compiler accepts (FlexMatchConfig.MatchStart), and it maps to nft's
+	// network-header payload base.
+	FlexMatch *Lo0FlexMatch
+	// FlexMatchUnrepresentable marks a term whose flexible-match-range could NOT
+	// be resolved — an unknown range name, or a numeric token the compiler could
+	// not parse (config.FilterTerm.UnknownFlexMatch). Strict commit rejects
+	// those, but the tolerant load / peer-sync paths only warn (#1960), so the
+	// mirror must still decide. It fails the TERM closed, mirroring the #5512
+	// tcp-flags direction: rendering the term without its narrowing is the
+	// fail-open this issue is about.
+	FlexMatchUnrepresentable bool
+
 	Log   bool
 	Count string
 
 	Action          string
 	NextTerm        bool
 	RoutingInstance string
+}
+
+// Lo0FlexMatch is a resolved `flexible-match-range` predicate: compare
+// BitLength bits at ByteOffset from the layer-3 header against Value, after
+// masking with Mask. It is a verbatim copy of config.FlexMatchConfig's
+// representable fields — the netlink builder re-derives the payload/bitwise/cmp
+// expressions, so the two renderers share this input rather than each
+// interpreting the config type.
+type Lo0FlexMatch struct {
+	ByteOffset uint8
+	BitLength  uint8
+	Value      uint32
+	Mask       uint32
 }
 
 // Lo0FilterSpec is the full lo0 input-filter render request: the ordered v4 then


### PR DESCRIPTION
Closes #6804

## What was wrong

The lo0 kernel nftables mirror had **no handling for `from flexible-match-range`
at all** — the netlink spec type `Lo0FilterTerm` had no field for it, so the
predicate was dropped at that boundary and the term rendered **without its
narrowing**. An `accept` term meant to admit only packets whose header bytes
match a pattern admitted **every packet it scoped**.

That is a control-plane fail-OPEN, not a cosmetic shadow: the XDP shim shunts
host-bound traffic to the kernel before userspace-dp, so this chain is the
**primary** enforcement for host traffic. It is the same reasoning #5512 gives
for the tcp-flags case it fixed **in the same function** — the predicate next to
this one already had the treatment.

## The fix

A representable predicate renders as nft's raw payload match on both sides:
`@nh,<byteOffset*8>,<byteLen*8> & <mask> == <value>` in the text oracle, and
payload+bitwise+cmp in the netlink builder. `layer-3` match-start — the only
start point the compiler emits — is the network-header base.

The load is whole **bytes** because nft loads byte-aligned, so a sub-byte bit
length is carried by the **mask**, exactly as the userspace matcher does it. The
expected value is **pre-masked on both sides**: nft compares the masked load, so
a value carrying bits outside the mask would never match — a silent never-match
is a different fail direction from the widening, but just as quiet.

## Why "matches nothing" and not a drop

An unrepresentable predicate makes the term match **nothing** (no rule emitted),
so later terms still run. That direction is decided by **mirroring userspace**,
which poisons such a term to `FlexMatchStart::Unsupported` so `flex_matches()`
returns false.

It is deliberately **not** the #5512 tcp-flags drop. A tcp-flags constraint only
ever matches TCP, so that drop can be scoped with `meta l4proto 6`. A
flexible-match-range has no natural narrowing — **a term whose only predicate was
the flex-match would render a bare `drop` and deny ALL host-inbound traffic**,
turning a fail-open into a lockout.

The width rules mirror the userspace snapshot builder exactly, including both
edge cases: a zero bit-length defaults to 4 (32-bit), and an oversized width is
**not** capped to 4 — capping compares only the truncated window and broadens the
match (the #3406 fail-open), so it is reported unrepresentable instead.

## The binding is real-`nft` parity, not an assertion

`TestNftNetlinkParity/lo0_flexible_match_range` runs each case through the
**actual `nft` parser** and the **actual netlink install** in a private netns and
diffs the installed rulesets, so the two renderers cannot disagree about what one
config means. Each case first asserts the oracle emitted a raw-payload match at
all — an oracle that omitted the predicate would make the diff pass for the wrong
reason.

Fifteen parity subtests pass, including three widths, a zero bit-length, a
value-outside-mask, and three unrepresentable shapes.

## Mutation matrix

Fix committed FIRST. Every cell runs the full `pkg/daemon` + `pkg/nftables`
suites with `go test -count=1`, no `-run` filter. **9 cells, all RED.**

| cell | result | assertion |
|---|---|---|
| M1 netlink renderer drops the predicate | RED | all 3 width parity cases |
| M2 oracle drops the predicate | RED | same |
| M3 spec never populated from the term | RED | same |
| M4 netlink: unrepresentable renders anyway | RED | `...matches_nothing` |
| M5 oracle: unrepresentable renders anyway | RED | same |
| **M6 TIGHTEN: oversized width CAPPED to 4 (the #3406 fail-open)** | GREEN → fixed → RED | `...matches_nothing/oversized-width` |
| **M7 TIGHTEN: zero bit-length yields no constraint** | GREEN → fixed → RED | `.../zero-bit-length-defaults-to-32` |
| **M8 netlink value not pre-masked** | GREEN → fixed → RED | `.../value-outside-mask-is-pre-masked` |
| M9 netlink offset in BITS instead of bytes | RED | all 3 width parity cases |

### The three green cells were all fixture gaps

**M6** — no fixture used a width outside 1..4 bytes, so capping was invisible.
**M7** — no fixture used a zero bit-length, so treating 0 as "no constraint"
rendered the term with no narrowing at all while every other case passed.

**M8 is the one worth naming.** Every value in the corpus was already inside its
mask, so pre-masking was a **no-op on both sides** — a renderer that skipped it
still agreed, and parity passed. The fixture varied the right axis and sampled
only the point where it could not fail.

The unrepresentable case also gained the two shapes it was missing (an
unparseable numeric token, the oversized width) and an assertion that the
**following deny term still renders** — "matches nothing" must mean the term
contributes no enforcement, not that it swallows the rest of the filter.

## Gates

`go build ./... && go vet ./... && go test -count=1 ./...` — all rc=0, 67
packages, tree clean. Go only; nothing moves the `userspace-dp` binary or the
shim `.o`, so no cargo leg. No cluster, VRRP, session-sync or failover code — no
smoke owed.
