### PR TITLE
daemon: assert the #6799 retry debt PERSISTS, not merely that it existed

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -105011,6 +105011,11 @@ prose edit above them added. No diff falls in the new test body.
 - **The reader**: `!s.NeedsApply()` gates `setLocalFailoverCommitReady`, which
   feeds `waitLocalFailoverCommitReady` → `cluster.requestPeerFailover`. The
   activation arm now raises it only inside the accepted branch.
+- **Persistence, not the instant**: the debt cell now drives further reconcile
+  passes and asserts the debt is STILL owed — checking `NeedsApply()` immediately
+  after the race proves only the transient, and the defect is that the debt never
+  comes BACK. Paired with an assertion that a genuine accepted apply DOES clear
+  it, so "never clears" cannot pass either.
 - **Matrix found an unbound branch**: reverting the DEACTIVATION arm to a raw
   `MarkApplied` left the whole suite green — the activation cell cannot see it,
   since each arm records its own result. Added a deactivation fixture (an RG the

--- a/pkg/daemon/rg_apply_invalidate_race_6799_test.go
+++ b/pkg/daemon/rg_apply_invalidate_race_6799_test.go
@@ -68,6 +68,35 @@ func TestFenceDebtSurvivesAnInFlightApply6799(t *testing.T) {
 			"nothing re-arms it — the RG never re-drives and forwarding stays wherever the fence " +
 			"left it, which is exactly the failure #6530 was written to prevent (#6799)")
 	}
+
+	// PERSISTENCE, not just the instant. Checking NeedsApply() immediately after
+	// the race proves only that the debt existed at that moment; the defect is
+	// that it never comes BACK. Drive further reconcile passes — the 2s loop's
+	// steady state, same desired value, nothing applied — and the debt must
+	// still be owed, because nothing has successfully converged. A fix that let
+	// the debt lapse on a later tick, or one that only deferred the erasure by a
+	// pass, would satisfy a snapshot assertion and fail here.
+	for i := 0; i < 3; i++ {
+		s.Reconcile(true, nil)
+		if !s.NeedsApply() {
+			t.Fatalf("the retry debt lapsed after %d further reconcile pass(es) with nothing "+
+				"applied. It must persist until an apply is actually ACCEPTED — otherwise the RG "+
+				"stops re-driving while still un-converged (#6799)", i+1)
+		}
+	}
+
+	// And it must not persist FOREVER: a genuine, uncontested apply clears it.
+	// Without this the cell would be satisfied by a fix that simply never
+	// clears applyPending, which would re-drive SetRGActive on every 2s tick
+	// and hold the failover-readiness gate low permanently.
+	fresh := s.Reconcile(true, nil)
+	if !s.RecordApplied(fresh, fresh.Active) {
+		t.Fatal("an uncontested apply on a current transition must be recorded")
+	}
+	if s.NeedsApply() {
+		t.Error("a recorded, uncontested apply must clear the retry debt; a debt that never " +
+			"clears re-drives every tick forever and holds failover readiness low")
+	}
 }
 
 // TestEpochAloneCannotDetectTheFenceRace6799 pins WHY the fix is keyed on the


### PR DESCRIPTION
Follow-up to #6799 (PR #7601, merged). Test-only.

You asked for two bindings on #6799. The reader binding
(`setLocalFailoverCommitReady`) was already in #7601 — cells
`TestRefusedRecordDoesNotRaiseFailoverReadiness6799` /
`TestAcceptedRecordDoesRaiseFailoverReadiness6799`, and matrix cell M3 (the
wiring revert) reds the refusal one. **The persistence binding was not**, and
#7601 merged before I could add it, so it lands here.

## What was missing

The debt cell checked `NeedsApply()` **immediately** after the race. That proves
the debt existed at that instant — the transient. The defect is that it never
comes **back**: `reconcileLocked` sets `applyPending` only when
`applied != active`, so once a stale record clears it with the two in agreement,
nothing re-arms it and the RG stops re-driving while still un-converged.

A snapshot assertion cannot distinguish that from a fix that merely deferred the
erasure by one tick — exactly the wrong-property risk you named.

## What this adds

- **Persistence.** Drive further reconcile passes — the 2s loop's steady state,
  same desired value, nothing applied — and require the debt to still be owed
  after each.
- **The paired opposite**, because persistence must not become permanence: a
  genuine uncontested apply on a current transition must still clear the debt.
  Without it the cell would be satisfied by a fix that never clears
  `applyPending` at all, which would re-drive `SetRGActive` on every 2s tick
  forever and hold the failover-readiness gate low permanently.

## Verification that the new assertion is sensitive

Two mutations, and the first one is worth reporting because it did **not**
discriminate:

| Mutation | Result | Why |
|---|---|---|
| `if s.active != s.applied { s.applyPending = true }` → `s.applyPending = s.active != s.applied` | **GREEN — not a discriminator** | After the race `applied` is still `!active` (InvalidateApplied set it), so the condition is true either way and the debt stays armed. Reported rather than counted as a red. |
| `if s.active != s.applied { s.applyPending = true }` → `… = false` | **RED** | `the retry debt lapsed after 1 further reconcile pass(es) with nothing applied` |

## Validation

- `go test -count=1 ./...` (repo-wide) **rc=0** at head
  `4f07d106ed271cd12e3edaa0c8e72d1e1fbd7be5`, which merges current
  `origin/master` (only conflict an append-vs-append in `_Log.md`,
  union-resolved, anchored marker sweep clean).
- Tree diff vs master is **2 files, +35/-1** — `_Log.md` and the one test file.
  No production code changes.
- **No Rust touched**, no cargo leg owed.

## Smoke

**No new smoke owed by this PR** — it is test-only and adds no production
behaviour. The cluster smoke owed by #7601 itself (`make test-failover`, for the
`reconcileRGStateLoop` / fence / failover-commit-gate changes) is unchanged and
still yours to run; I have run no cluster target.
