### PR TITLE
docs: index the standing instruction documents in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,27 @@ project has settled on — hot-path allocation rules, review severity,
 compile-time invariants, PR discipline, and the project-specific
 gotchas that repeatedly bite (deploy wipes CoS, iperf3 target, etc.).
 
+## Required Reading
+
+Read these BEFORE starting work, not after getting stuck. They are the
+contract; a PR that violates one of them gets sent back regardless of
+whether the code is correct.
+
+| File | Read it when | What it governs |
+|------|--------------|-----------------|
+| `docs/engineering-style.md` | before ANY non-trivial code or PR review | hot-path allocation rules, review severity, compile-time invariants, PR discipline, shared-cluster protocol, the project gotchas that repeatedly bite (deploy wipes CoS, iperf3 target, etc.) |
+| `~/.claude/RTK.md` | before running shell commands in bulk | the `rtk` token-optimizing CLI proxy. A hook transparently rewrites most commands (`git status` → `rtk git status`), but the meta commands (`rtk gain`, `rtk discover`, `rtk proxy <cmd>`) must be invoked directly. Use `rtk proxy <cmd>` when you need UNFILTERED output for debugging — filtered output has dropped the line you are looking for more than once. |
+| `AGENTS.md` | before splitting work across agents | orchestrator / architect / implementor role boundaries, worktree assignment, overlap prevention, and the rule that agents keep working until they hit a real stopping point |
+| `COMMITAGENT.md` | before driving a stacked branch series | stack ownership, narrow helper roles, and the commit/stack discipline |
+| `README.md` | when touching a public-facing surface | what the product claims to do; a behaviour change that contradicts it is a docs bug too |
+| `docs/config-schema.md` | before adding a config-mode leaf | `setSchema` typed leaves, multi-value leaves, bracketed-list collapse (#2419 class) |
+| the module's own `README.md` / `docs/*.md` | in the SAME change as the code | updating them is part of the contract, not follow-up work. If none is needed, say why in the review notes. |
+
+Sub-agents inherit this file automatically, but NOT the reasoning behind
+it. When dispatching a lane, name the specific documents its task
+touches — a brief that says "read engineering-style.md" is followed; one
+that assumes the agent already did is not.
+
 ## Logging Rules
 - Maintain a log of all major actions in `_Log.md`.
 - Use YAML or Markdown bullet points for structure:

--- a/_Log.md
+++ b/_Log.md
@@ -105068,3 +105068,23 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: `pkg/daemon/rg_state.go`, `pkg/daemon/daemon_ha.go`,
   `pkg/daemon/rg_apply_invalidate_race_6799_test.go`,
   `pkg/daemon/rg_state_test.go`, `pkg/daemon/README.md`, `_Log.md`
+
+## 2026-08-26 — CLAUDE.md: a Required Reading index
+
+- **Timestamp**: 2026-08-26
+- **Action**: Add a `## Required Reading` section to the project `CLAUDE.md`,
+  between "Working Style" and "Logging Rules".
+- **Why**: `CLAUDE.md` already told a reader to read `docs/engineering-style.md`
+  and to update module docs in the same change, but the other standing
+  documents — `~/.claude/RTK.md`, `AGENTS.md`, `COMMITAGENT.md`,
+  `docs/config-schema.md` — were nowhere named, so an agent had no way to
+  discover them except by tripping over the rule they encode. `RTK.md` is the
+  sharpest omission: a hook silently rewrites most shell commands through the
+  `rtk` token-optimizing proxy, and a reader who does not know that also does
+  not know `rtk proxy <cmd>` exists to get UNFILTERED output back for the cases
+  where the filtered form has dropped the decisive line.
+- **Shape**: a table of file → when to read it → what it governs, so the entry
+  is actionable at dispatch time rather than a bare list of filenames. Closes
+  with the point that sub-agents inherit the file but not the reasoning, so a
+  dispatch brief should name the specific documents its task touches.
+- **File(s)**: `CLAUDE.md`, `_Log.md`


### PR DESCRIPTION
Documentation only.

`CLAUDE.md` already told a reader to read `docs/engineering-style.md` and to
update module docs in the same change as the code. It named none of the other
standing documents this project runs on, so an agent could only discover
`~/.claude/RTK.md`, `AGENTS.md`, `COMMITAGENT.md` and `docs/config-schema.md`
by violating the rule each one encodes and being corrected.

`RTK.md` is the sharpest omission. A hook rewrites most shell commands through
the `rtk` token-optimizing proxy transparently (`git status` → `rtk git
status`), so a reader who does not know `rtk` exists also does not know that
`rtk proxy <cmd>` returns UNFILTERED output. That is exactly what you want any
time you are about to reason about the precise text of a test failure or a
mutation-matrix cell, where the filtered form has dropped the decisive line
before.

## What this adds

A `## Required Reading` section between "Working Style" and "Logging Rules",
shaped as a table of **file → when to read it → what it governs** rather than a
list of filenames, so it is usable at dispatch time.

It closes with the point that motivated it: sub-agents inherit `CLAUDE.md`
automatically but not the reasoning behind it, so a dispatch brief should name
the specific documents its task touches. A brief that says "read
engineering-style.md" gets followed; one that assumes the agent already did
does not.

## Validation

No code, no behaviour change, no test impact — `CLAUDE.md` and `_Log.md` only,
+41/-0. The four lanes running against this checkout were notified of the change
directly so they are not working from the pre-change contract.
