### PR TITLE
daemon: fail the commit closed on a credential reconcile failure (#6790)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,45 @@
+## 2026-08-26 — #6790: the normal apply joins the five credential-reconcile failures
+
+- **Timestamp**: 2026-08-26
+- **Action**: `applyTailReconciles` ran the five host-credential reconcilers as
+  `_ = d.applySystemLogin/reconcileSudoers/reconcileAbsentLoginUsers/
+  applySSHConfig/applyRootAuth(cfg)`. #5874 had already made all five RETURN
+  their accumulated failures, but only the daemon-stop cancel closeout
+  collected them — the ordinary commit path threw them away, so
+  `delete system login user bob` reported SUCCESS while bob's password and
+  `authorized_keys` were still live, a demoted operator kept a stale NOPASSWD
+  grant, a reverted sshd drop-in kept the pre-commit `PermitRootLogin`, and
+  root's key set never converged. Captured all five and joined them into the
+  tail `errors.Join`, matching the three siblings in the SAME function that
+  already fail closed (`applyLo0Filter` #3392, `applyHostInboundFilter` #3333,
+  `reconcileDNSLocked` #6792).
+  Rejected the standing justification rather than assuming it: "the next boot
+  re-renders login/sudoers/SSH/root-auth so a transient failure converges" is
+  a RENDERING argument applied to a REVOCATION. Nothing retries before the
+  reboot (no dirty-retry owner, no ticker, no metric), the same commit already
+  advanced the durable config, and the green commit was the operator's only
+  signal. Fail-closed, NOT fail-fast: no early return was added, so an sshd
+  failure still cannot skip root-auth — bound by its own cell.
+  Also corrected three now-false doc claims that said the normal apply path
+  ignores these returns (`daemon_system.go` applySystemLogin,
+  `login_password.go` reconcileAbsentLoginUsers + deprovisionLoginUser) and the
+  `applyHostAuthorizationCloseout` comment that implied the cancel path was
+  still the only collector.
+- **File(s)**: `pkg/daemon/daemon_apply_tail.go`, `pkg/daemon/daemon_apply.go`,
+  `pkg/daemon/daemon_system.go`, `pkg/daemon/login_password.go`,
+  `pkg/daemon/apply_credential_failclosed_6790_test.go`,
+  `docs/system-login.md`, `_Log.md`
+- **Validation**: 7 new cells drive the REAL `applyTailReconciles` with exactly
+  ONE owner injected to fail (id/useradd refused; unwritable sudoers dir;
+  unreadable `/etc/passwd` for a marked-but-removed account; `sshd -t`
+  rejecting; an ENOTDIR marker root) plus a healthy PAIRED control and a
+  two-failure cell. Each keys on a substring unique to its owner, so dropping
+  that owner's operand from the join reds that cell alone. Mutation matrix:
+  5/5 per-owner reverts to `_ =` red their named cell, and the control stays
+  green. Repo-wide `go build ./... && go test -count=1 ./...` rc 0. No
+  cluster/VRRP/session-sync/failover code touched, so no `make test-failover`
+  is owed.
+
 ## 2026-08-22 — #6834: typed wildcard identity slots, and the interface-name gate
 
 - **Timestamp**: 2026-08-22

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-08-26 — #6790 r3: the timeout cell was reading the MACHINE, and found #7618
+
+- **Timestamp**: 2026-08-26
+- **Action**: The r2 peer-sync cell drove a REAL command against a short
+  deadline to prove a command timeout is not a context error. It passed
+  unloaded and FAILED under a loaded full-package run —
+  `err="context deadline exceeded"`. The claim was not wrong so much as
+  INCOMPLETE: `exec.CommandContext` has two deadline shapes. Process started
+  then killed -> `*exec.ExitError` ("signal: killed"), safe. Context expired
+  BEFORE fork/exec -> `Start` returns `ctx.Err()` and the caller gets a bare
+  `context.DeadlineExceeded`, which `applyErrSkipsPeerSync` cannot tell from
+  the #2926 daemon-stop abort. Which one you get is decided by machine load,
+  so the cell was sampling the scheduler (the #7563 shape) — corrected my own
+  earlier "measured rather than assumed" claim, which had measured only the
+  unloaded branch.
+  Fixed the cell by CONSTRUCTION rather than by retry: build the ExitError
+  shape by Start-then-cancel, so the deadline race cannot occur. 5 repeat
+  runs green.
+  The misclassification itself is PRE-EXISTING and wider than #6790 —
+  `nftApplyPayload` (5s -> lo0Err/hostInboundErr, #3392/#3333) and the DNS
+  systemctl calls (-> dnsErr, #6792) reach the same classifier the same way.
+  Filed #7618 rather than fixing inline: the fix changes behaviour for five
+  operands that predate this PR. Left
+  `TestACommandDeadlineIsMisclassifiedAsADaemonStopAbort6790` asserting the
+  CURRENT wrong classification so the fix reds a named cell instead of
+  silently passing.
+- **File(s)**: `pkg/daemon/apply_credential_failclosed_6790_test.go`,
+  `docs/system-login.md`, `_Log.md`
+- **Validation**: full `pkg/daemon` green; 5x repeat of the previously flaky
+  cell green; repo-wide gate re-run at the merged head.
+
 ## 2026-08-26 — #6790 follow-up: the #1960 no-brick classification is now pinned
 
 - **Timestamp**: 2026-08-26

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-08-26 — #6790 follow-up: the #1960 no-brick classification is now pinned
+
+- **Timestamp**: 2026-08-26
+- **Action**: Review question on PR #7604: does joining five more operands
+  into `applyTailReconciles`' result make a standby REJECT a peer-synced
+  config? Enumerated all five `applyConfigLocked` call sites. Answer: no.
+  The peer-sync path is `syncAndApply` (`daemon_apply_commit.go:522`), and
+  both it and `applyAndSyncCommitted` route the error through
+  `applyErrSkipsPeerSync`, which names exactly two fatal classes — a
+  required-protocol-gate error (#2138) and a context cancel/deadline
+  (#2926). Everything else keeps the config active + armed and keeps
+  syncing; that is the class #4034 created and it already contains
+  networkdErr / dhcpServerErr / hostInboundErr / lo0Err / dnsErr. A
+  credential failure only leaves the applied-digest unstamped, so the
+  primary re-pushes and the standby RETRIES — a retry, not a brick.
+  Did not assume the one shape that could have broken it: MEASURED that a
+  command killed by `externalCommandTimeout` returns `*exec.ExitError`
+  ("signal: killed") and does NOT satisfy `errors.Is(.., DeadlineExceeded)`
+  even wrapped and joined, so a `useradd` timeout cannot masquerade as the
+  #2926 abort class and suppress a peer sync. Pinned the whole
+  classification with 6 subtests over the REAL reconciler errors plus a
+  paired positive control, so the classifier cannot silently degrade to
+  "nothing is fatal". No `lenient*` compile opt is needed or possible:
+  `compileOpts` downgrades COMPILE-time validators, and these are
+  reconcile-time failures raised after compilation.
+- **File(s)**: `pkg/daemon/apply_credential_failclosed_6790_test.go`,
+  `docs/system-login.md`, `_Log.md`
+- **Validation**: 9 cells green. Repo-wide `go build ./... && go test
+  -count=1 ./...` rc 0. Mutation matrix re-run at the new head.
+
 ## 2026-08-26 — #6790: the normal apply joins the five credential-reconcile failures
 
 - **Timestamp**: 2026-08-26

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -1530,6 +1530,71 @@ the **same UID-file format** as the account registry:
   of `provisionedUsersDir`, so pointing that one package var at a throwaway
   tree relocates all three roots together in tests.
 
+## A failed credential reconcile FAILS THE COMMIT (#6790)
+
+Every reconciler on this page runs from the apply tail
+(`applyTailReconciles`, `pkg/daemon/daemon_apply_tail.go`, steps 11–13):
+
+| step | reconciler | owns |
+|------|------------|------|
+| 11   | `applySystemLogin`         | OS accounts, per-user password, `authorized_keys` |
+| 11b  | `reconcileSudoers`         | `/etc/sudoers.d/xpf-<user>` NOPASSWD grants |
+| 11c  | `reconcileAbsentLoginUsers`| revocation for users removed from config |
+| 12   | `applySSHConfig`           | the sshd drop-in (`PermitRootLogin`, ciphers, …) |
+| 13   | `applyRootAuth`            | root's `/etc/shadow` password + `/root/.ssh/authorized_keys` |
+
+All five were called as `_ = d.<reconciler>(cfg)`. #5874 had already made
+them **return** their accumulated failures, but only the daemon-stop
+cancel closeout (`applyHostAuthorizationCloseout`) collected those
+returns. On the ordinary commit path the returns were **discarded**, so
+a commit reported **success** while:
+
+- the configured operator's account was never created, or their
+  `authorized_keys` was never installed;
+- a super-user's sudo grant was never written — or, on the revoke side,
+  a **demoted** operator's stale NOPASSWD grant was never removed;
+- a **removed** `system login user` kept a live password and
+  `authorized_keys` (the deprovision fails closed and retains its
+  markers to retry, but nothing told the operator the revocation had not
+  happened);
+- the sshd drop-in failed validation and was reverted, so sshd kept the
+  **pre-commit** `PermitRootLogin` posture;
+- root's password or `authorized_keys` did not converge to the committed
+  `system root-authentication`.
+
+Since #6790 the tail **captures** all five returns and joins them into
+the commit result, exactly as its siblings in the same function already
+do — `applyLo0Filter` (#3392), `applyHostInboundFilter` (#3333) and
+`reconcileDNSLocked` (#6792). The prior justification, "the next boot
+re-renders these from the active config so a transient failure
+converges" (the #2926 next-boot contract), does not hold here:
+
+- These are **revocations**, not renderings. The credential stays live
+  until the next reboot — unbounded on an appliance — and there is no
+  dirty-retry owner, ticker, or metric between now and then.
+- The same commit **advances the durable config**, so the next boot
+  renders from a config that already says the user is gone while the box
+  still grants them access.
+- A green commit is the operator's only signal that
+  `delete system login user bob` took effect, and it was unconditional.
+
+Fail-closed, **not** fail-fast: every step still runs, so an sshd reload
+failure never skips root-auth reconciliation. Only the commit *result*
+changes. The config itself is already promoted at this point (as with
+every other tail failure), so the operator sees a failed commit against
+an advanced config and re-commits to retry — the same semantics
+`networkd`/`nft`/DNS failures have had for several releases.
+
+The void-returning steps around them (`applySystemNTP`, `applyHostname`,
+`applySyslogFiles`, …) are deliberately **not** included: those really do
+re-render from the active config on the next apply or boot and carry no
+revocation semantics.
+
+Cells: `pkg/daemon/apply_credential_failclosed_6790_test.go` drives the
+real `applyTailReconciles` with one owner injected to fail per cell, plus
+a healthy control and a both-ends cell proving an early failure does not
+skip a later owner.
+
 ## Idempotency
 
 The password apply reads `/etc/shadow` directly and skips `chpasswd`

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -1642,15 +1642,42 @@ severity of a COMPILE-time validator. These are RECONCILE-time failures
 raised after compilation, inside `applyConfigLocked`; there is no compile
 gate to downgrade, and the tolerant path already does not reject.
 
-One shape was measured rather than assumed: an apply-path command killed
-by `externalCommandTimeout` returns `*exec.ExitError` ("signal: killed"),
-which does **not** satisfy `errors.Is(err, context.DeadlineExceeded)` even
-when wrapped and joined — so a `useradd` that times out cannot masquerade
-as the #2926 abort class and suppress a peer sync.
-`TestCredentialFailuresDoNotSkipThePeerSync6790` pins all five owners plus
-that timeout shape, against the REAL errors the reconcilers produce, and
+`TestCredentialFailuresDoNotSkipThePeerSync6790` pins all five owners
+against the REAL errors the reconcilers produce, and
 `TestApplyErrSkipsPeerSyncStillCatchesTheFatalClasses6790` is its paired
 positive control so the classifier cannot degrade to "nothing is fatal".
+
+#### One pre-existing gap, inherited not introduced (#7618)
+
+`exec.CommandContext` has **two** error shapes at a deadline, and only one
+of them is safe here:
+
+- the process **started** and was killed at the deadline → `*exec.ExitError`
+  ("signal: killed"), which is not a context error → correctly non-fatal;
+- the context expired **before fork/exec completed** → `Start` returns
+  `ctx.Err()`, so the caller gets a **bare `context.DeadlineExceeded`** →
+  `applyErrSkipsPeerSync` cannot tell it from the #2926 daemon-stop abort
+  and classifies it FATAL, suppressing the push (or discarding a
+  peer-promoted config).
+
+Which shape you get depends on whether fork/exec wins the race with the
+deadline — i.e. on machine load. This was observed for real: the cell that
+originally drove a live command against a short deadline passed unloaded
+and failed under a loaded full-package run.
+
+The gap is **not** specific to the credential reconcilers. Every apply-path
+command runner builds its own short context — `nftApplyPayload` (5s,
+feeding `lo0Err`/`hostInboundErr` since #3392/#3333) and `daemon_dns.go`'s
+`systemctl disable/mask` (feeding `dnsErr` since #6792) — so the same
+misclassification already reaches the same classifier through operands that
+predate #6790. #6790 adds members to an already-exposed population rather
+than creating the exposure, and fixing the classifier changes behaviour for
+those older operands, so it is tracked separately as #7618.
+
+Until then it is a tripwire, not folklore:
+`TestACommandDeadlineIsMisclassifiedAsADaemonStopAbort6790` asserts the
+CURRENT (wrong) classification, so the fix reds a named cell and must
+invert it and this section together.
 
 ## Idempotency
 

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -1595,6 +1595,63 @@ real `applyTailReconciles` with one owner injected to fail per cell, plus
 a healthy control and a both-ends cell proving an early failure does not
 skip a later owner.
 
+### What a credential failure does to each apply caller (#1960 no-brick)
+
+`applyTailReconciles`' return reaches `applyConfigLocked`, which has five
+call sites. Two of them CLASSIFY the error rather than just reporting it,
+so the question that matters is whether a credential failure can make a
+node reject a config:
+
+| call site | what a non-nil return does now | config promoted? |
+|---|---|---|
+| `daemon_apply.go:182` `applyActiveConfigResult` | the feed manager (#5646) does not advance its published-hash, so the next identical refetch retries | yes — unchanged |
+| `daemon_apply.go:191` `applyConfigUnderSem` (boot / DHCP callback / feed / config-poll / rollback) | `slog.Warn` + return; `MarkActiveApplied()` is SKIPPED | yes — unchanged |
+| `daemon_apply_commit.go:254` `applyAndSyncCommitted` (operator commit) | the operator's commit reports failure; the peer push still happens; `MarkActiveApplied()` skipped | yes — `Store.Commit` promoted it upstream |
+| `daemon_apply_commit.go:522` `syncAndApply` (**peer-sync recv**) | the error is returned to `handleConfigSync`, which logs it and returns it so the config high-water does NOT advance and the primary re-pushes | yes — `SyncApply` promoted it BEFORE the apply |
+| `daemon_apply_commit.go:766` commit-confirmed auto-rollback | `slog.Error` only (background timer, no return path); the rollback target is applied unconditionally | yes — `PromoteRollback` already ran |
+
+The peer-sync path is `syncAndApply`, and it does **not** reject. Both it
+and `applyAndSyncCommitted` route the error through
+`applyErrSkipsPeerSync`, which names exactly two fatal classes — a
+required-protocol-gate error (dataplane DISARMED, #2138) and a context
+cancel/deadline (the #2926 daemon-stop abort). Everything else is the
+non-fatal best-effort class that **must** keep syncing, because the config
+is already committed + active and the dataplane armed; suppressing the
+sync there is the divergence #4034 fixed. In `syncAndApply` the same
+classifier decides whether to DISCARD the peer-promoted config, and on the
+non-fatal branch it sets `armedActive = true` and returns the error
+alongside the live config.
+
+So a credential reconcile failure on a standby:
+
+- does **not** roll back or reject the peer-synced config — it stays
+  active and armed;
+- does **not** suppress the primary→standby push on the commit side;
+- **does** leave the applied-digest unstamped, so the primary's next
+  re-push re-enters `syncAndApply` and RETRIES instead of taking
+  `handleConfigSync`'s converged shortcut (#4957/#6296).
+
+That is a retry, not a brick, and it is the same behaviour
+`networkdErr`, `dhcpServerErr`, `hostInboundErr`, `lo0Err` and `dnsErr`
+have had in this join since #3333/#3392/#4034/#6792 — the #4034 and #5564
+comments name "host-inbound/lo0 nft, networkd" as precisely this class.
+
+No `lenient*` compile opt is needed or possible: `pkg/config/compiler_opts.go`
+"carries per-call compilation policy", and every flag in it downgrades the
+severity of a COMPILE-time validator. These are RECONCILE-time failures
+raised after compilation, inside `applyConfigLocked`; there is no compile
+gate to downgrade, and the tolerant path already does not reject.
+
+One shape was measured rather than assumed: an apply-path command killed
+by `externalCommandTimeout` returns `*exec.ExitError` ("signal: killed"),
+which does **not** satisfy `errors.Is(err, context.DeadlineExceeded)` even
+when wrapped and joined — so a `useradd` that times out cannot masquerade
+as the #2926 abort class and suppress a peer sync.
+`TestCredentialFailuresDoNotSkipThePeerSync6790` pins all five owners plus
+that timeout shape, against the REAL errors the reconcilers produce, and
+`TestApplyErrSkipsPeerSyncStillCatchesTheFatalClasses6790` is its paired
+positive control so the classifier cannot degrade to "nothing is fatal".
+
 ## Idempotency
 
 The password apply reads `/etc/shadow` directly and skips `chpasswd`

--- a/pkg/daemon/apply_credential_failclosed_6790_test.go
+++ b/pkg/daemon/apply_credential_failclosed_6790_test.go
@@ -1,0 +1,332 @@
+package daemon
+
+// apply_credential_failclosed_6790_test.go — #6790.
+//
+// applyTailReconciles ran the five host-credential reconcilers as
+//
+//	_ = d.applySystemLogin(cfg)
+//	_ = d.reconcileSudoers(cfg)
+//	_ = d.reconcileAbsentLoginUsers(cfg)
+//	_ = d.applySSHConfig(cfg)
+//	_ = d.applyRootAuth(cfg)
+//
+// so EVERY failure they accumulate — an account that could not be created, a
+// sudo grant that could not be revoked, a removed operator whose password and
+// authorized_keys were NOT revoked, an sshd drop-in that failed validation, a
+// root key file that was not written — was discarded and the commit reported
+// SUCCESS. #5874 had already made all five RETURN their failures, but only the
+// daemon-stop cancel closeout collected them; the ordinary commit path an
+// operator actually uses to revoke access kept throwing them away.
+//
+// These cells drive the REAL applyTailReconciles with exactly ONE owner
+// injected to fail and assert the commit result NAMES that owner's failure.
+// Because each cell keys on a substring unique to its owner, dropping that
+// owner's operand from the tail errors.Join (or reverting its capture to
+// `_ =`) reds that cell and only that cell.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/networkd"
+	"github.com/psaab/xpf/pkg/vrrp"
+)
+
+// credentialTailFixture6790 is the shared harness: a Daemon whose tail can run
+// end-to-end with every NON-credential owner (nft lo0 / host-inbound, DNS,
+// VRRP, networkd) stubbed clean, and every credential owner pointed at
+// throwaway trees so it is clean UNLESS the cell injects a failure.
+//
+// The control cell below proves the harness really is clean — without it,
+// "the tail returns an error" would be satisfied by a harness in which
+// something unrelated fails on every run.
+type credentialTailFixture6790 struct {
+	d    *Daemon
+	cfg  *config.Config
+	root string
+}
+
+func newCredentialTailFixture6790(t *testing.T) *credentialTailFixture6790 {
+	t.Helper()
+	installFakeNetworkctl(t)
+
+	origNftApply, origNftDelete := nftApplyPayload, nftDeleteTable
+	nftApplyPayload = func(string) ([]byte, error) { return nil, nil }
+	nftDeleteTable = func(string, string) ([]byte, error) { return nil, nil }
+	t.Cleanup(func() { nftApplyPayload, nftDeleteTable = origNftApply, origNftDelete })
+
+	root := t.TempDir()
+
+	origUsersDir, origSudoersDir := provisionedUsersDir, sudoersDir
+	origSSHDPath, origHomeBase := sshdConfPath, homeBaseDir
+	provisionedUsersDir = filepath.Join(root, "provisioned-users")
+	sudoersDir = filepath.Join(root, "sudoers.d")
+	sshdConfPath = filepath.Join(root, "sshd_config.d", "xpf.conf")
+	homeBaseDir = filepath.Join(root, "home")
+	t.Cleanup(func() {
+		provisionedUsersDir, sudoersDir = origUsersDir, origSudoersDir
+		sshdConfPath, homeBaseDir = origSSHDPath, origHomeBase
+	})
+	if err := os.MkdirAll(sudoersDir, 0o755); err != nil {
+		t.Fatalf("seed sudoers dir: %v", err)
+	}
+	// applySSHConfig's own mkdir targets the hard-coded production
+	// /etc/ssh/sshd_config.d, so the relocated drop-in's parent must exist
+	// here or the WRITE fails and masks whatever the cell injected.
+	if err := os.MkdirAll(filepath.Dir(sshdConfPath), 0o755); err != nil {
+		t.Fatalf("seed sshd drop-in dir: %v", err)
+	}
+
+	// A readable, valid identity pair holding only root, so no login user
+	// resolves and no credential is ever mutated by a cell that did not ask.
+	origPasswd, origShadow := passwdPath, shadowPath
+	passwdPath = filepath.Join(root, "passwd")
+	shadowPath = filepath.Join(root, "shadow")
+	t.Cleanup(func() { passwdPath, shadowPath = origPasswd, origShadow })
+	if err := os.WriteFile(passwdPath, []byte("root:x:0:0::/root:/bin/bash\n"), 0o644); err != nil {
+		t.Fatalf("seed passwd: %v", err)
+	}
+	if err := os.WriteFile(shadowPath, []byte("root:!:19000:0:99999:7:::\n"), 0o644); err != nil {
+		t.Fatalf("seed shadow: %v", err)
+	}
+
+	// No real process ever runs: id/useradd/chown succeed silently unless a
+	// cell replaces this, visudo and the sshd validate/reload are stubbed at
+	// their own seams.
+	origRun := runCommandTimeout
+	runCommandTimeout = func(string, ...string) ([]byte, error) { return nil, nil }
+	t.Cleanup(func() { runCommandTimeout = origRun })
+
+	origValidateSudoers := validateSudoersFile
+	validateSudoersFile = func(string) error { return nil }
+	t.Cleanup(func() { validateSudoersFile = origValidateSudoers })
+
+	origSSHDValidate, origSSHDReload := sshdValidateCmd, sshdReloadCmd
+	sshdValidateCmd = func() ([]byte, error) { return nil, nil }
+	sshdReloadCmd = func() ([]byte, error) { return nil, nil }
+	t.Cleanup(func() { sshdValidateCmd, sshdReloadCmd = origSSHDValidate, origSSHDReload })
+
+	d := &Daemon{
+		networkd: networkd.NewInDir(t.TempDir()),
+		store:    newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		vrrpMgr:  vrrp.NewManager(),
+		opts:     Options{NoDataplane: true},
+	}
+	d.setDataplane(&runtimeOnlyApplyTestDP{})
+	d.reconcileDNSFn = func(*config.Config, bool) error { return nil }
+
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{0: {Number: 0}}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {Name: "trust", Interfaces: []string{"reth0.0"}},
+	}
+	return &credentialTailFixture6790{d: d, cfg: cfg, root: root}
+}
+
+// tail runs the REAL applyTailReconciles with every head-produced deferred
+// error nil, so the only operands that can be non-nil are the ones this
+// function's own steps produce.
+func (f *credentialTailFixture6790) tail() error {
+	return f.d.applyTailReconciles(f.cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+}
+
+// breakMarkerRoots6790 makes all three ownership-marker roots unusable by
+// putting a regular FILE where their parent directory must be: MkdirAll then
+// fails with ENOTDIR, which no amount of privilege can bypass (so the cell
+// behaves identically for a root and a non-root test runner).
+func breakMarkerRoots6790(t *testing.T, root string) {
+	t.Helper()
+	blocked := filepath.Join(root, "blocked")
+	if err := os.WriteFile(blocked, []byte("not a directory\n"), 0o644); err != nil {
+		t.Fatalf("seed the blocking file: %v", err)
+	}
+	provisionedUsersDir = filepath.Join(blocked, "provisioned-users")
+}
+
+// TestApplyTailIsCleanWithHealthyCredentialReconciles6790 is the PAIRED
+// control for every failure cell below. With nothing injected the tail must
+// return nil — otherwise "the tail surfaces a credential failure" would be
+// satisfied by a tail that fails every commit, which is the opposite defect.
+func TestApplyTailIsCleanWithHealthyCredentialReconciles6790(t *testing.T) {
+	f := newCredentialTailFixture6790(t)
+	f.cfg.System.Login = &config.LoginConfig{Users: []*config.LoginUser{
+		{Name: "admin", Class: "super-user"},
+	}}
+	f.cfg.System.Services = &config.SystemServicesConfig{
+		SSH: &config.SSHServiceConfig{RootLogin: "deny"},
+	}
+	if err := f.tail(); err != nil {
+		t.Fatalf("applyTailReconciles returned %v with every credential "+
+			"reconciler healthy — every commit would now fail closed", err)
+	}
+}
+
+// TestApplyTailSurfacesSystemLoginFailure6790: the account could not be
+// created, so the configured operator cannot log in at all, and the commit
+// said success.
+func TestApplyTailSurfacesSystemLoginFailure6790(t *testing.T) {
+	f := newCredentialTailFixture6790(t)
+	f.cfg.System.Login = &config.LoginConfig{Users: []*config.LoginUser{
+		{Name: "admin", Class: "super-user"},
+	}}
+	// `id` reports the account missing and `useradd` then refuses.
+	runCommandTimeout = func(string, ...string) ([]byte, error) {
+		return []byte("simulated: refused"), os.ErrPermission
+	}
+
+	err := f.tail()
+	if err == nil {
+		t.Fatal("applyTailReconciles returned nil while applySystemLogin FAILED " +
+			"to create the configured login account — the commit reports " +
+			"success over an operator who cannot log in (#6790)")
+	}
+	if !strings.Contains(err.Error(), "create user") {
+		t.Fatalf("the commit error does not carry the system-login failure "+
+			"through the tail errors.Join, got %v", err)
+	}
+}
+
+// TestApplyTailSurfacesSudoersFailure6790: the NOPASSWD grant could not be
+// written, so a configured super-user has no sudo — and, on the revoke side,
+// the same accumulator carries a grant that could not be REMOVED, which is a
+// demoted operator keeping passwordless root.
+func TestApplyTailSurfacesSudoersFailure6790(t *testing.T) {
+	f := newCredentialTailFixture6790(t)
+	f.cfg.System.Login = &config.LoginConfig{Users: []*config.LoginUser{
+		{Name: "admin", Class: "super-user"},
+	}}
+	sudoersDir = filepath.Join(f.root, "sudoers-missing") // never created → write fails
+
+	err := f.tail()
+	if err == nil {
+		t.Fatal("applyTailReconciles returned nil while reconcileSudoers FAILED " +
+			"to write a super-user grant — the commit reports success (#6790)")
+	}
+	if !strings.Contains(err.Error(), "write sudoers grant for") {
+		t.Fatalf("the commit error does not carry the sudoers failure through "+
+			"the tail errors.Join, got %v", err)
+	}
+}
+
+// TestApplyTailSurfacesAbsentUserRevocationFailure6790 is the cell the issue is
+// really about: an operator removed from config whose credentials were NOT
+// revoked because the identity database could not be read. The deprovision
+// deliberately fails CLOSED (markers kept, retry next apply) — but the commit
+// that ordered the revocation still reported success, so the operator believes
+// the account is gone while its password and authorized_keys are live.
+func TestApplyTailSurfacesAbsentUserRevocationFailure6790(t *testing.T) {
+	f := newCredentialTailFixture6790(t)
+	// A provisioned account that is no longer in config.
+	if err := os.MkdirAll(provisionedUsersDir, 0o700); err != nil {
+		t.Fatalf("seed the account registry: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(provisionedUsersDir, "ghost"), []byte("4242"), 0o600); err != nil {
+		t.Fatalf("seed the ghost marker: %v", err)
+	}
+	// /etc/passwd unreadable (a directory) → lookupUIDErr returns an error →
+	// deprovisionLoginUser keeps the markers and reports the failure.
+	passwdPath = filepath.Join(f.root, "passwd-as-dir")
+	if err := os.MkdirAll(passwdPath, 0o755); err != nil {
+		t.Fatalf("seed an unreadable passwd: %v", err)
+	}
+
+	err := f.tail()
+	if err == nil {
+		t.Fatal("applyTailReconciles returned nil while a REMOVED login user's " +
+			"credentials could not be revoked — the commit that ordered the " +
+			"deprovision reports success while the password and " +
+			"authorized_keys stay live (#6790)")
+	}
+	if !strings.Contains(err.Error(), "read passwd for removed user") {
+		t.Fatalf("the commit error does not carry the absent-user revocation "+
+			"failure through the tail errors.Join, got %v", err)
+	}
+}
+
+// TestApplyTailSurfacesSSHConfigFailure6790: the sshd drop-in failed
+// validation, so it was reverted and the committed PermitRootLogin posture is
+// NOT what sshd is enforcing.
+func TestApplyTailSurfacesSSHConfigFailure6790(t *testing.T) {
+	f := newCredentialTailFixture6790(t)
+	f.cfg.System.Services = &config.SystemServicesConfig{
+		SSH: &config.SSHServiceConfig{RootLogin: "deny"},
+	}
+	sshdValidateCmd = func() ([]byte, error) {
+		return []byte("simulated: bad configuration option"), os.ErrInvalid
+	}
+
+	err := f.tail()
+	if err == nil {
+		t.Fatal("applyTailReconciles returned nil while the sshd drop-in FAILED " +
+			"validation and was reverted — sshd keeps the pre-commit " +
+			"root-login posture and the commit reports success (#6790)")
+	}
+	if !strings.Contains(err.Error(), "validate sshd config") {
+		t.Fatalf("the commit error does not carry the sshd failure through the "+
+			"tail errors.Join, got %v", err)
+	}
+}
+
+// TestApplyTailSurfacesRootAuthFailure6790: root's authorized_keys were NOT
+// written because the ownership marker could not be recorded, so the committed
+// root key set is not the one root actually accepts.
+func TestApplyTailSurfacesRootAuthFailure6790(t *testing.T) {
+	f := newCredentialTailFixture6790(t)
+	f.cfg.System.RootAuthentication = &config.RootAuthConfig{
+		SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI6790 test@xpf"},
+	}
+	breakMarkerRoots6790(t, f.root)
+
+	err := f.tail()
+	if err == nil {
+		t.Fatal("applyTailReconciles returned nil while applyRootAuth SKIPPED " +
+			"the root authorized_keys write — the committed root key set is " +
+			"not what root accepts and the commit reports success (#6790)")
+	}
+	if !strings.Contains(err.Error(), "mark root key provisioned") {
+		t.Fatalf("the commit error does not carry the root-auth failure through "+
+			"the tail errors.Join, got %v", err)
+	}
+}
+
+// TestApplyTailRunsEveryCredentialOwnerDespiteAnEarlierFailure6790 binds the
+// OTHER half of the contract: fail-closed must not become fail-FAST. A login
+// reconcile that fails must not skip root-auth — skipping it would leave root's
+// credentials at the pre-commit generation, which is the monotonic-revocation
+// violation the fail-closed change exists to prevent.
+//
+// Both failures are injected at once and BOTH must be named in the single
+// joined commit error.
+func TestApplyTailRunsEveryCredentialOwnerDespiteAnEarlierFailure6790(t *testing.T) {
+	f := newCredentialTailFixture6790(t)
+	f.cfg.System.Login = &config.LoginConfig{Users: []*config.LoginUser{
+		{Name: "admin", Class: "super-user"},
+	}}
+	f.cfg.System.RootAuthentication = &config.RootAuthConfig{
+		SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI6790 test@xpf"},
+	}
+	runCommandTimeout = func(string, ...string) ([]byte, error) {
+		return []byte("simulated: refused"), os.ErrPermission
+	}
+	breakMarkerRoots6790(t, f.root)
+
+	err := f.tail()
+	if err == nil {
+		t.Fatal("applyTailReconciles returned nil with TWO credential " +
+			"reconcilers failing (#6790)")
+	}
+	if !strings.Contains(err.Error(), "create user") {
+		t.Fatalf("the earlier (system-login) failure is missing from the joined "+
+			"commit error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "mark root key provisioned") {
+		t.Fatalf("the LATER (root-auth) owner did not run, or its failure was "+
+			"dropped, after an earlier credential reconcile failed — "+
+			"fail-closed must not become fail-fast: %v", err)
+	}
+}

--- a/pkg/daemon/apply_credential_failclosed_6790_test.go
+++ b/pkg/daemon/apply_credential_failclosed_6790_test.go
@@ -25,12 +25,17 @@ package daemon
 // `_ =`) reds that cell and only that cell.
 
 import (
+	"context"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/psaab/xpf/pkg/config"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/networkd"
 	"github.com/psaab/xpf/pkg/vrrp"
 )
@@ -328,5 +333,132 @@ func TestApplyTailRunsEveryCredentialOwnerDespiteAnEarlierFailure6790(t *testing
 		t.Fatalf("the LATER (root-auth) owner did not run, or its failure was "+
 			"dropped, after an earlier credential reconcile failed — "+
 			"fail-closed must not become fail-fast: %v", err)
+	}
+}
+
+// --- #1960 no-brick / peer-sync classification -----------------------------
+//
+// Joining five more operands into applyTailReconciles' result changes what
+// applyConfigLocked RETURNS, and two callers classify that return rather than
+// just reporting it:
+//
+//   - applyAndSyncCommitted (#4034) skips the push to the standby, and
+//   - syncAndApply (#5564) DISCARDS the peer-promoted config,
+//
+// but ONLY for the two error classes applyErrSkipsPeerSync names: a
+// required-protocol-gate error (dataplane disarmed, #2138) or a context
+// cancel/deadline (#2926 daemon-stop abort). Every other error is the
+// non-fatal best-effort class that must keep syncing, because the config is
+// already committed + active and the dataplane armed — skipping the sync there
+// is what #4034 fixed.
+//
+// A credential reconcile failure is a LOCAL, node-specific, transient
+// condition (this node's sshd refused, this node's /etc/passwd was briefly
+// unreadable). It says nothing about whether the CONFIG is good, so it must
+// land in the non-fatal class or a standby would refuse a peer-synced config
+// and the nodes would diverge — the #1960 no-brick contract.
+//
+// These cells pin that classification against the REAL errors the five
+// reconcilers produce, not hand-built ones.
+
+// TestCredentialFailuresDoNotSkipThePeerSync6790 is the #1960 no-brick pin.
+func TestCredentialFailuresDoNotSkipThePeerSync6790(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(t *testing.T, f *credentialTailFixture6790)
+	}{
+		{"system-login", func(t *testing.T, f *credentialTailFixture6790) {
+			f.cfg.System.Login = &config.LoginConfig{Users: []*config.LoginUser{{Name: "admin", Class: "super-user"}}}
+			runCommandTimeout = func(string, ...string) ([]byte, error) {
+				return []byte("simulated: refused"), os.ErrPermission
+			}
+		}},
+		{"sudoers", func(t *testing.T, f *credentialTailFixture6790) {
+			f.cfg.System.Login = &config.LoginConfig{Users: []*config.LoginUser{{Name: "admin", Class: "super-user"}}}
+			sudoersDir = filepath.Join(f.root, "sudoers-missing")
+		}},
+		{"absent-login-users", func(t *testing.T, f *credentialTailFixture6790) {
+			if err := os.MkdirAll(provisionedUsersDir, 0o700); err != nil {
+				t.Fatalf("seed the account registry: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(provisionedUsersDir, "ghost"), []byte("4242"), 0o600); err != nil {
+				t.Fatalf("seed the ghost marker: %v", err)
+			}
+			passwdPath = filepath.Join(f.root, "passwd-as-dir")
+			if err := os.MkdirAll(passwdPath, 0o755); err != nil {
+				t.Fatalf("seed an unreadable passwd: %v", err)
+			}
+		}},
+		{"ssh-config", func(t *testing.T, f *credentialTailFixture6790) {
+			f.cfg.System.Services = &config.SystemServicesConfig{
+				SSH: &config.SSHServiceConfig{RootLogin: "deny"},
+			}
+			sshdValidateCmd = func() ([]byte, error) {
+				return []byte("simulated: bad configuration option"), os.ErrInvalid
+			}
+		}},
+		{"root-auth", func(t *testing.T, f *credentialTailFixture6790) {
+			f.cfg.System.RootAuthentication = &config.RootAuthConfig{
+				SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI6790 test@xpf"},
+			}
+			breakMarkerRoots6790(t, f.root)
+		}},
+		{"external-command-timeout", func(t *testing.T, f *credentialTailFixture6790) {
+			// The one shape that could plausibly carry a context error: an
+			// apply-path command killed by externalCommandTimeout. Produced by
+			// running a REAL command under an expired context rather than by
+			// asserting what Go returns — exec reports `signal: killed` as an
+			// *exec.ExitError, NOT a context error, and if that ever changed
+			// this cell would catch it.
+			f.cfg.System.Login = &config.LoginConfig{Users: []*config.LoginUser{{Name: "admin", Class: "super-user"}}}
+			runCommandTimeout = func(string, ...string) ([]byte, error) {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+				defer cancel()
+				cmd := exec.CommandContext(ctx, "sleep", "5")
+				cmd.WaitDelay = time.Second
+				return cmd.CombinedOutput()
+			}
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newCredentialTailFixture6790(t)
+			tc.setup(t, f)
+
+			err := f.tail()
+			if err == nil {
+				t.Fatalf("precondition: the %s reconcile did not fail, so this cell "+
+					"cannot classify anything", tc.name)
+			}
+			if applyErrSkipsPeerSync(err) {
+				t.Fatalf("a %s credential reconcile failure is classified FATAL by "+
+					"applyErrSkipsPeerSync, so applyAndSyncCommitted would skip the "+
+					"push to the standby and syncAndApply would DISCARD a "+
+					"peer-promoted config. A local, node-specific credential "+
+					"failure must never brick a peer sync (#1960). err=%v", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestApplyErrSkipsPeerSyncStillCatchesTheFatalClasses6790 is the PAIRED
+// positive control for the cells above. Without it, "credential failures are
+// not classified fatal" is satisfied by an applyErrSkipsPeerSync that returns
+// false for everything — which would break the #4034/#2138 fail-closed
+// suppression the classifier exists for.
+func TestApplyErrSkipsPeerSyncStillCatchesTheFatalClasses6790(t *testing.T) {
+	if !applyErrSkipsPeerSync(context.Canceled) {
+		t.Error("context.Canceled is no longer classified fatal — a daemon-stop " +
+			"abort would now push a half-applied config to the standby (#2926)")
+	}
+	if !applyErrSkipsPeerSync(fmt.Errorf("wrapped: %w", context.DeadlineExceeded)) {
+		t.Error("a wrapped context.DeadlineExceeded is no longer classified fatal")
+	}
+	gate := fmt.Errorf("apply: %w", dpuserspace.ErrPolicySchedulerProtocolIncompatible)
+	if !applyErrSkipsPeerSync(gate) {
+		t.Error("a required-protocol-gate error is no longer classified fatal — a " +
+			"config that DISARMS the dataplane would now be pushed to the " +
+			"standby too (#2138/#4034)")
 	}
 }

--- a/pkg/daemon/apply_credential_failclosed_6790_test.go
+++ b/pkg/daemon/apply_credential_failclosed_6790_test.go
@@ -26,6 +26,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -403,20 +404,19 @@ func TestCredentialFailuresDoNotSkipThePeerSync6790(t *testing.T) {
 			}
 			breakMarkerRoots6790(t, f.root)
 		}},
-		{"external-command-timeout", func(t *testing.T, f *credentialTailFixture6790) {
-			// The one shape that could plausibly carry a context error: an
-			// apply-path command killed by externalCommandTimeout. Produced by
-			// running a REAL command under an expired context rather than by
-			// asserting what Go returns — exec reports `signal: killed` as an
-			// *exec.ExitError, NOT a context error, and if that ever changed
-			// this cell would catch it.
+		{"external-command-killed-by-timeout", func(t *testing.T, f *credentialTailFixture6790) {
+			// The shape externalCommandTimeout produces in practice: the process
+			// STARTED and was then killed when the 15s context expired, which
+			// exec reports as *exec.ExitError ("signal: killed") — NOT a context
+			// error. Injected as that exact shape rather than produced by racing
+			// a real `sleep` against a short deadline: which of exec's two error
+			// shapes you get depends on whether fork/exec wins the race with the
+			// deadline, so sampling it is a reading of the MACHINE, not of the
+			// subject (#7563). The pre-expired-start shape is pinned separately
+			// by TestACommandDeadlineIsMisclassified6790.
 			f.cfg.System.Login = &config.LoginConfig{Users: []*config.LoginUser{{Name: "admin", Class: "super-user"}}}
 			runCommandTimeout = func(string, ...string) ([]byte, error) {
-				ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
-				defer cancel()
-				cmd := exec.CommandContext(ctx, "sleep", "5")
-				cmd.WaitDelay = time.Second
-				return cmd.CombinedOutput()
+				return nil, killedByTimeoutErr6790(t)
 			}
 		}},
 	}
@@ -460,5 +460,71 @@ func TestApplyErrSkipsPeerSyncStillCatchesTheFatalClasses6790(t *testing.T) {
 		t.Error("a required-protocol-gate error is no longer classified fatal — a " +
 			"config that DISARMS the dataplane would now be pushed to the " +
 			"standby too (#2138/#4034)")
+	}
+}
+
+// killedByTimeoutErr6790 returns a REAL *exec.ExitError of the shape
+// externalCommandTimeout produces when a started process is killed at the
+// deadline. Built by running a command that is killed deterministically (not by
+// racing a deadline), so the cell using it is a reading of the subject rather
+// than of the scheduler.
+func killedByTimeoutErr6790(t *testing.T) error {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, "sleep", "30")
+	cmd.WaitDelay = time.Second
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start the victim process: %v", err)
+	}
+	cancel() // kill AFTER a successful Start -> ExitError, never ctx.Err()
+	err := cmd.Wait()
+	if err == nil {
+		t.Fatal("the victim process was not killed, so this fixture does not " +
+			"carry the shape it claims")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected an *exec.ExitError from a killed process, got %T: %v", err, err)
+	}
+	return fmt.Errorf("create user admin: %w", err)
+}
+
+// TestACommandDeadlineIsMisclassifiedAsADaemonStopAbort6790 pins a PRE-EXISTING
+// discrimination gap in applyErrSkipsPeerSync that this PR does not fix and
+// does not introduce — see the tracking issue named below.
+//
+// exec.CommandContext has TWO error shapes at a deadline. If the process
+// STARTED, the kill surfaces as *exec.ExitError ("signal: killed") — the cell
+// above. But if the context expires BEFORE fork/exec completes, Start returns
+// ctx.Err() and CombinedOutput hands back a BARE context.DeadlineExceeded.
+//
+// applyErrSkipsPeerSync cannot tell that apart from the #2926 daemon-stop abort
+// it is actually looking for, so it classifies a per-command 15s timeout as
+// FATAL: applyAndSyncCommitted skips the push to the standby and syncAndApply
+// DISCARDS the peer-promoted config. "My useradd took 15s" is not "the daemon
+// is stopping".
+//
+// Tracking issue: #7618.
+//
+// This is NOT new here. Every apply-path command runner builds its own short
+// context — nftApplyPayload (5s, produces lo0Err/hostInboundErr, joined since
+// #3392/#3333) and daemon_dns.go's systemctl disable/mask (produces dnsErr,
+// joined since #6792) — so the same misclassification already reaches the same
+// classifier through operands that predate this change. #6790 adds more members
+// to an already-exposed population; it does not create the exposure. Fixing it
+// means giving the per-command deadline its own sentinel so it is never mistaken
+// for a daemon-stop abort, which changes behaviour for five existing operands
+// and belongs in its own PR.
+//
+// This cell exists so the gap is a tripwire rather than folklore: when that PR
+// lands, THIS test reds and must be inverted in the same change.
+func TestACommandDeadlineIsMisclassifiedAsADaemonStopAbort6790(t *testing.T) {
+	preExpired := fmt.Errorf("create user admin: %w", context.DeadlineExceeded)
+	if !applyErrSkipsPeerSync(preExpired) {
+		t.Fatal("a bare context.DeadlineExceeded from a pre-expired command start " +
+			"is no longer classified as the daemon-stop abort class. If that is " +
+			"because the per-command deadline now carries its own sentinel, this " +
+			"is the FIX landing — invert this cell and update the #1960 section " +
+			"of docs/system-login.md in the same change.")
 	}
 }

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -522,7 +522,10 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 // failure to reconcile a credential to the cancelled/target state was silently
 // DISCARDED and the cancel reported clean. They now return their accumulated
 // failures, this closeout COLLECTS a per-owner outcome and SURFACES every
-// failure, and the "bounded" claim is now an ENFORCED wall-clock budget
+// failure — and since #6790 the ORDINARY (uncancelled) apply joins those same
+// five returns into the commit result too, so the two paths agree that a
+// failed credential reconcile is a failed commit. The "bounded" claim is an
+// ENFORCED wall-clock budget
 // (hostAuthCloseoutBudget) rather than an unbounded best-effort sequence: a
 // wedged reconciler is reported timed-out instead of hanging the daemon-stop
 // path. Still safe to run non-cancellably — no FRR/netlink reload.

--- a/pkg/daemon/daemon_apply_tail.go
+++ b/pkg/daemon/daemon_apply_tail.go
@@ -36,9 +36,11 @@ import (
 // vrrpErr originates in step 8 below when runtime identity validation rejects
 // the desired set (#5083); vrfErr is the #5700 VRF-device-setup (ReconcileVRFs)
 // failure and routingRuleErr/mgmtRouteErr are threaded from the caller;
-// lo0Err/hostInboundErr originate in step 9.5. The returned errors.Join
+// lo0Err/hostInboundErr originate in step 9.5, dnsErr in step 9 (#6792), and
+// the five host-credential errors (loginErr/sudoersErr/absentUsersErr/
+// sshConfigErr/rootAuthErr) in steps 11–13 (#6790). The returned errors.Join
 // preserves the explicit operand order
-// (#1778/#2987/#4433/#5083/#5310/#5679/#5696/#5700).
+// (#1778/#2987/#4433/#5083/#5310/#5679/#5696/#5700/#6790/#6792).
 func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr, mgmtRouteErr, vrfErr error, fabricErr error) error {
 	// 8. Apply VRRP config — merge user VRRP + RETH VRRP instances
 	var vrrpErr error
@@ -106,36 +108,63 @@ func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, 
 	d.applySystemSyslog(cfg)
 
 	// Steps 11–13 are the login/credential reconcilers. They return their
-	// accumulated failures (#5874) so the cancel closeout can surface them,
-	// but on the NORMAL apply path the returns are intentionally DISCARDED:
-	// the tail is best-effort here because the next boot re-renders login /
-	// sudoers / SSH / root-auth from the active config, so a transient failure
-	// converges (the #2926 next-boot contract). Only the daemon-stop cancel
-	// closeout — where next-boot convergence does NOT happen while the daemon
-	// stays intentionally stopped — collects and fails on these.
+	// accumulated failures (#5874) and, since #6790, the NORMAL apply path
+	// CAPTURES those returns and joins them into the commit result — exactly
+	// like their siblings in this same function (applyLo0Filter #3392,
+	// applyHostInboundFilter #3333, reconcileDNSLocked #6792).
+	//
+	// They were previously discarded as `_ =` on the argument that the next
+	// boot re-renders login / sudoers / SSH / root-auth from the active config,
+	// so a transient failure converges (the #2926 next-boot contract). That
+	// argument does not hold for these five owners:
+	//
+	//   - It is a REVOCATION window, not a rendering delay. `delete system
+	//     login user bob` that fails to lock bob's password or remove his
+	//     authorized_keys reported a SUCCESSFUL commit, so the operator
+	//     believes bob is deprovisioned NOW. The credential stays live until
+	//     the next reboot — unbounded on an appliance that is expected to run
+	//     for months — and nothing retries in between: there is no dirty-retry
+	//     owner, no ticker, and no metric for these reconcilers.
+	//   - The same commit is the one that ADVANCES the durable config, so the
+	//     next boot renders from a config that already says bob is gone while
+	//     the box still grants him access. A green commit is the operator's
+	//     only signal, and it was unconditional.
+	//   - The #5874 cancel closeout exists precisely because these five do not
+	//     converge on their own; it made them RETURN their failures but only
+	//     the daemon-stop path collected them. The normal path — the one an
+	//     operator actually uses to revoke access — kept discarding them.
+	//
+	// Fail-closed, same discipline as lo0/host-inbound/DNS: every step below
+	// still RUNS (no early return), so an sshd reload failure never skips
+	// root-auth reconciliation; only the commit RESULT changes.
+	//
+	// Note the asymmetry with the void-returning steps around them
+	// (applySystemNTP, applyHostname, applySyslogFiles, ...): those really do
+	// re-render from the active config on the next apply or boot and hold no
+	// revocation semantics.
 
 	// 11. Apply system login users (create OS accounts, SSH keys)
-	_ = d.applySystemLogin(cfg)
+	loginErr := d.applySystemLogin(cfg)
 
 	// 11b. Reconcile super-user sudo grants against the CURRENT config so a
 	// class downgrade or user removal REVOKES the stale NOPASSWD grant
 	// (#3889). Runs unconditionally — applySystemLogin returns early when
 	// there are no users, which is exactly the "all users removed" case
 	// that must still sweep stale grants.
-	_ = d.reconcileSudoers(cfg)
+	sudoersErr := d.reconcileSudoers(cfg)
 
 	// 11c. Revoke host credentials for any xpf-provisioned login account that
 	// was removed from config (#5128). reconcileSudoers above only revokes the
 	// sudo grant; without this a deprovisioned operator keeps their password
 	// and authorized_keys and can still SSH in. Like reconcileSudoers it MUST
 	// run unconditionally — the "all users removed" case must still revoke.
-	_ = d.reconcileAbsentLoginUsers(cfg)
+	absentUsersErr := d.reconcileAbsentLoginUsers(cfg)
 
 	// 12. Apply SSH service configuration (root-login)
-	_ = d.applySSHConfig(cfg)
+	sshConfigErr := d.applySSHConfig(cfg)
 
 	// 13. Apply root authentication (encrypted-password + SSH keys)
-	_ = d.applyRootAuth(cfg)
+	rootAuthErr := d.applyRootAuth(cfg)
 
 	// 14. Apply syslog file destinations (rsyslog configs)
 	d.applySyslogFiles(cfg)
@@ -360,9 +389,14 @@ func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, 
 	// snapshot republish/FIB-bump failure (#5696 — a stale inter-VRF leak would
 	// otherwise survive on a "successful" commit) through the commit so a step
 	// that left stale or missing kernel/swanctl/dataplane state fails the commit
-	// (fail-closed) instead of reporting success. All are joined so none masks the
-	// other.
-	return errors.Join(networkdErr, applyErr, dhcpServerErr, hostInboundErr, lo0Err, dnsErr, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr, mgmtRouteErr, vrfErr, fabricErr, vrrpErr)
+	// (fail-closed) instead of reporting success. #6790 adds the five
+	// host-credential reconcilers (login / sudoers / absent-user revocation /
+	// sshd / root-auth), whose failures were discarded here — a commit that did
+	// not actually revoke a removed operator's password or authorized_keys is
+	// not a successful commit. All are joined so none masks the other.
+	return errors.Join(networkdErr, applyErr, dhcpServerErr, hostInboundErr, lo0Err, dnsErr,
+		loginErr, sudoersErr, absentUsersErr, sshConfigErr, rootAuthErr,
+		ipsecErr, ifaceErr, routeLeakErr, routingRuleErr, mgmtRouteErr, vrfErr, fabricErr, vrrpErr)
 }
 
 // reconcileDHCPRelay re-applies the DHCP relay config on every commit (#2348).

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -1373,12 +1373,12 @@ func reconcileSyslogDropins(confDir, prefix string, desired map[string]string) b
 // from config. It stays best-effort — a per-user failure is logged and the
 // loop continues to the next user — but it now also ACCUMULATES those
 // failures into the returned error so a caller that needs to know whether the
-// reconcile actually converged (the #5874 cancel closeout) can see them. On
-// the normal apply path the return is intentionally ignored: the next boot
-// re-renders login from the active config, so a transient failure converges
-// (the #2926 next-boot contract). Pure defensive skips (an invalid username
-// refused before any mutation) are NOT accumulated — they are the safe
-// outcome, not an incomplete reconcile.
+// reconcile actually converged (the #5874 cancel closeout) can see them.
+// #6790: the NORMAL apply path now joins this return into the commit result
+// too — a commit that could not create the account or install its
+// authorized_keys must not report success. Pure defensive skips (an invalid
+// username refused before any mutation) are NOT accumulated — they are the
+// safe outcome, not an incomplete reconcile.
 func (d *Daemon) applySystemLogin(cfg *config.Config) (err error) {
 	fail := func(e error) { err = errors.Join(err, e) }
 	if cfg.System.Login == nil || len(cfg.System.Login.Users) == 0 {

--- a/pkg/daemon/login_password.go
+++ b/pkg/daemon/login_password.go
@@ -501,8 +501,10 @@ func managedAuthorizedKeysPath(name string) string {
 // It stays best-effort per account but ACCUMULATES each deprovision failure
 // into the returned error so the #5874 cancel closeout can see that a removed
 // user's credentials were NOT actually revoked (a monotonic-revocation gap).
-// The normal apply path ignores the return — the next boot retries deprovision
-// from the active config.
+// #6790: the NORMAL apply path joins this return into the commit result as
+// well. `delete system login user bob` acknowledged as SUCCESS while bob's
+// password and authorized_keys are still live is the exact failure this
+// reconciler exists to prevent, and nothing retries before the next boot.
 func (d *Daemon) reconcileAbsentLoginUsers(cfg *config.Config) (retErr error) {
 	names := provisionedNames()
 	if len(names) == 0 {
@@ -545,7 +547,8 @@ func (d *Daemon) reconcileAbsentLoginUsers(cfg *config.Config) (retErr error) {
 // It stays best-effort but ACCUMULATES each failure into the returned error so
 // the #5874 cancel closeout can observe that a removed account's credentials
 // were NOT actually revoked; a naked return yields the accumulated retErr, not
-// a block-local err. The normal apply path ignores the return.
+// a block-local err. Since #6790 the normal apply path joins it into the
+// commit result too, so a failed revocation fails the commit.
 func (d *Daemon) deprovisionLoginUser(name string) (retErr error) {
 	fail := func(e error) { retErr = errors.Join(retErr, e) }
 	curUID, found, err := lookupUIDErr(name)


### PR DESCRIPTION
Closes #6790

## Summary

- `applyTailReconciles` ran the five host-credential reconcilers as bare `_ =` discards, so **every** login / sudoers / deprovision / sshd / root-auth failure was thrown away and the commit reported **success**.
- #5874 had already made all five *return* their accumulated failures — but only `applyHostAuthorizationCloseout` (the daemon-stop cancel path) collected them. The ordinary commit path, the one an operator uses to grant and revoke access, kept discarding them.
- Capture all five and join them into the tail `errors.Join`, matching the three siblings in the same function that already fail closed: `applyLo0Filter` (#3392), `applyHostInboundFilter` (#3333), `reconcileDNSLocked` (#6792).
- Fail-closed, **not** fail-fast: no early return is added, so an sshd failure still cannot skip root-auth reconciliation. Only the commit *result* changes.
- Three doc comments asserting "the normal apply path ignores the return" were false the moment this landed and are corrected here; `docs/system-login.md` gains the operator-facing contract.
- The issue's cited evidence file (`/tmp/opus-review-001.md`, root R49) no longer exists in /tmp, `docs/`, or git. The claim was re-derived from the title against `origin/master` and reproduces exactly.

## What was broken

A commit reported success while:

- the configured operator's account was never created, or their `authorized_keys` was never installed;
- a super-user's sudo grant was never written — or, on the revoke side, a **demoted** operator's stale NOPASSWD grant was never removed;
- a **removed** `system login user` kept a live password and `authorized_keys`; the deprovision fails closed and keeps its markers to retry, but nothing told the operator the revocation had not happened;
- the sshd drop-in failed `sshd -t` and was reverted, so sshd kept the **pre-commit** `PermitRootLogin` posture;
- root's `/etc/shadow` password or `/root/.ssh/authorized_keys` did not converge to the committed `system root-authentication`.

The in-code justification was the #2926 next-boot contract — "the next boot re-renders login / sudoers / SSH / root-auth from the active config, so a transient failure converges". That is a **rendering** argument applied to a **revocation**:

- the credential stays live until the next reboot (unbounded on an appliance) and nothing retries in between — no dirty-retry owner, no ticker, no metric;
- the same commit **advances the durable config**, so the next boot renders from a config that already says the user is gone while the box still grants access;
- a green commit is the operator's only signal that `delete system login user bob` took effect, and it was unconditional.

The void-returning steps around them (`applySystemNTP`, `applyHostname`, `applySyslogFiles`) are deliberately left alone — they really do re-render on the next apply and carry no revocation semantics.

## Test plan

- [x] `pkg/daemon/apply_credential_failclosed_6790_test.go` — 7 new cells, each driving the **real** `applyTailReconciles` with exactly ONE owner injected to fail through a real, hermetic failure:

  | cell | injection | asserts |
  |---|---|---|
  | `TestApplyTailSurfacesSystemLoginFailure6790` | `id`/`useradd` refuse | commit error names `create user` |
  | `TestApplyTailSurfacesSudoersFailure6790` | sudoers dir never created | names `write sudoers grant for` |
  | `TestApplyTailSurfacesAbsentUserRevocationFailure6790` | marked-but-removed `ghost`, `/etc/passwd` a directory | names `read passwd for removed user` |
  | `TestApplyTailSurfacesSSHConfigFailure6790` | `sshd -t` rejects | names `validate sshd config` |
  | `TestApplyTailSurfacesRootAuthFailure6790` | marker root's parent is a FILE (ENOTDIR — privilege-independent) | names `mark root key provisioned` |
  | `TestApplyTailIsCleanWithHealthyCredentialReconciles6790` | none — PAIRED control, all seams stubbed to SUCCESS | tail returns **nil** |
  | `TestApplyTailRunsEveryCredentialOwnerDespiteAnEarlierFailure6790` | login **and** root-auth | **both** named — fail-closed is not fail-fast |

- [x] **All-success control confirmed.** The fixture stubs `sshdValidateCmd` / `sshdReloadCmd` / `validateSudoersFile` / `runCommandTimeout` to success and each cell then fails exactly ONE. `TestApplyTailIsCleanWithHealthyCredentialReconciles6790` runs that same fixture with a configured login user and ssh stanza and **nothing** injected, asserting `applyTailReconciles` returns nil (`applyTailReconciles returned %v with every credential reconciler healthy — every commit would now fail closed`). So the failure cells cannot be satisfied by a tail that returns an error unconditionally. It is not a decorative control: it RED'd for real during development (see #7609) and only went green once the fixture was fixed.
- [x] **Mutation matrix** at HEAD `6a8b7d687`, fix committed first, every cell a full-package `go test -count=1 ./pkg/daemon/` with **no** `-run` filter. Each mutation reverts exactly ONE line to the shipped discard (`xErr := error(nil); _ = d.x(cfg)`) so it compiles rather than build-breaking; the harness asserts the mutated text is present before running.

  | mutation | cell that RED | verdict |
  |---|---|---|
  | `loginErr := d.applySystemLogin(cfg)` → discard | `...SystemLoginFailure6790` + `...DespiteAnEarlierFailure6790` | RED |
  | `sudoersErr := d.reconcileSudoers(cfg)` → discard | `...SudoersFailure6790` | RED |
  | `absentUsersErr := d.reconcileAbsentLoginUsers(cfg)` → discard | `...AbsentUserRevocationFailure6790` | RED |
  | `sshConfigErr := d.applySSHConfig(cfg)` → discard | `...SSHConfigFailure6790` | RED |
  | `rootAuthErr := d.applyRootAuth(cfg)` → discard | `...RootAuthFailure6790` + `...DespiteAnEarlierFailure6790` | RED |

  Two more cells pin the #1960 classifier itself, mutating `applyErrSkipsPeerSync` in both directions:

  | mutation | cell that RED | verdict |
  |---|---|---|
  | `applyErrSkipsPeerSync` → `return true` (everything fatal) | `TestCredentialFailuresDoNotSkipThePeerSync6790` (all 6 subtests) | RED |
  | `applyErrSkipsPeerSync` → `return false` (nothing fatal) | `TestApplyErrSkipsPeerSyncStillCatchesTheFatalClasses6790` | RED |

  Both classifier mutations also red PRE-EXISTING cells (`TestCommitAndApplySyncsPeerOnNonFatalApplyError`, `TestCommitAndApplySkipsPeerSyncOnFatalApplyError`, `TestSyncAndApplySkipsInvalidatorsOnFatalApplyError`), which independently corroborates §3 below: the older operands already own this property.

  `buildbreak_lines=0` on every cell (the mutation ran; it did not fail to compile) and `git status` is clean after restore. The control cell is not vacuous — it RED'd for real during development (the relocated sshd drop-in parent did not exist, see #7609) and only went green after the fixture was fixed.

- [x] `go build ./... && go test -count=1 ./...` → **rc 0** at HEAD `6a8b7d68754dd01279288ac83df1201f3a655de6`, 67/67 packages ok, with `origin/master c6b8275a5` merged in (MERGE, never rebase) and `git merge-base --is-ancestor origin/master HEAD` verified. Master moved **5 times** during review and the gate was re-run at every merged head — not ceremony: the #7606 (#6802) merge is what surfaced the scheduler-dependent cell described in §5.
  - `pkg/daemon` ok (42.9s) and `pkg/api` ok (42.9s) — the two packages #6802/#6803 added always-on `Run` goroutines to.
  - Master's own new gates pass on this branch: `TestNoUnresolvedConflictMarkers`, `TestConflictMarkerSweepDetectsAMarker`, `TestLogDuplicateDetectorFindsADuplicate` (#7614/#7616) and `TestStep8ThroughputPortIsUnshaped`, `TestStep8IperfPortGateDetectsAShapedPort` (#7620).
  - `_Log.md` resolution verified structurally, not just by "it merged clean": 0 conflict markers; the `#6799` entry carries master's **repaired** body (`reconcileRGState …`), byte-identical to master's, proving the merge took master's mid-file deletions rather than resurrecting the pre-repair copy; and the file is exactly `theirs + ours_tail` (ends with master's tail verbatim, +6475 B = this branch's three prepended entries).
- [x] **The 5/5 owner matrix was NOT re-measured after the final merges and does not need to be** — the merged commits touch no line it mutates (`daemon_apply_tail.go` is untouched by `origin/master` since the matrix ran). It was, however, re-run at `6a8b7d687` anyway, and all seven cells still RED.
- [x] `make cluster-deploy` → loss userspace cluster, rc 0, pre-flight PASS on both nodes.
- [x] **Real-box credential commit smoke** on `loss:xpf-userspace-fw0` (running as root, real `/etc/passwd`, `/etc/shadow`, `/etc/sudoers.d`). This is the lane the hermetic cells cannot cover: does a *healthy* commit still succeed once five more operands can fail it?
- [x] `./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0` — re-applied (deploy wipes CoS); `atomic commit + verification OK`.
- [x] iperf3 throughput — no forwarding regression.
- [ ] `make test-failover` / `make test-ha-crash` — **not run, and not owed**: the diff touches no cluster, VRRP, session-sync, fabric or failover code.
- [ ] `make test-deploy` (standalone) — **not run**: the standalone `bpfrx-fw` VM is in `ERROR` state in this environment. The cluster lane above covers the same question on a real root box.
- [ ] No `userspace-dp/` or `userspace-xdp/` file is touched, so the cargo leg is not owed.

## #1960 no-brick: what this does to the peer-sync / tolerant load path

Short answer: **nothing rejects.** A credential reconcile failure lands in the non-fatal class that keeps syncing, which is the class `networkdErr` / `dhcpServerErr` / `hostInboundErr` / `lo0Err` / `dnsErr` have been in since #3333 / #3392 / #4034 / #6792.

### 1. All five `applyConfigLocked` call sites

| call site | what a non-nil return does now | config still PROMOTED? |
|---|---|---|
| `daemon_apply.go:182` `applyActiveConfigResult` | the feed manager (#5646) does not advance its per-feed published-hash, so the next identical refetch retries | yes — unchanged |
| `daemon_apply.go:191` `applyConfigUnderSem` (boot / DHCP callback / feed / config-poll / in-process CLI / rollback) | `slog.Warn("apply config failed")` + return; `MarkActiveApplied()` is SKIPPED (`daemon_apply.go:191-203`) | yes — unchanged, nothing rolls back |
| `daemon_apply_commit.go:254` `applyAndSyncCommitted` (operator commit) | the operator's commit reports failure; the peer push **still happens**; `MarkActiveApplied()` skipped | yes — `Store.Commit` promoted it UPSTREAM of the apply |
| `daemon_apply_commit.go:522` `syncAndApply` (**peer-sync recv**) | returned to `handleConfigSync`, which logs it and returns it, so the config high-water does NOT advance and the primary re-pushes | yes — `SyncApply` promoted it BEFORE the apply |
| `daemon_apply_commit.go:766` commit-confirmed auto-rollback | `slog.Error` only — background timer, no return path; the rollback target is applied unconditionally | yes — `PromoteRollback` already ran |

No call site rolls back or un-promotes a config on this error class. The one behavioural delta is the applied-digest stamp.

### 2. The peer-sync path, explicitly

It is `syncAndApply` (`daemon_apply_commit.go:350`, "the cluster-sync-recv analogue of commitAndApply"), reached from `handleConfigSync` (`daemon_ha_sync.go:663`) ← `daemon_ha_comms_wiring.go:186`.

Both it and `applyAndSyncCommitted` route the apply error through **`applyErrSkipsPeerSync`** (`daemon_apply_commit.go:309-340`), which names exactly two fatal classes:

- `compileErrorMustAbortApply(err)` — a required-protocol-gate error; the dataplane is DISARMED (#2138). That delegates to `dpuserspace.IsRequiredProtocolGateError`, a pure `errors.Is` scan over a fixed sentinel list (`manager_compile.go:131`).
- `errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)` — the #2926 daemon-stop abort.

Everything else is non-fatal. In `syncAndApply` the non-fatal branch sets `armedActive = true` and returns the error *alongside* the live config (`daemon_apply_commit.go:519-524`) rather than discarding it; the in-code comment names the class as "host-inbound/lo0 nft, networkd".

So on a standby, a credential failure:

- does **not** roll back or reject the peer-synced config — it stays active and armed;
- does **not** suppress the primary→standby push on the commit side (that suppression is what #4034 removed for this class);
- **does** leave the applied digest unstamped, so the primary's next re-push re-enters `syncAndApply` and **retries** instead of taking `handleConfigSync`'s converged shortcut (#4957 / #6296 — `handleConfigSync`'s doc states the high-water "advances ONLY on a nil return … so a rejection or a compile/promote failure leaves the standby eligible for the primary's re-push instead of being silently stranded").

A retry, not a brick.

### 3. The precedent, verified rather than assumed

`networkdErr`, `applyErr`, `dhcpServerErr`, `hostInboundErr`, `lo0Err` and `dnsErr` are operands of the same `errors.Join` (`daemon_apply_tail.go`, the tail `return`). They reach the identical classifier, and #4034's own comment says so: *"ANY applyConfigLocked error — including the NON-FATAL best-effort tail errors it joins (networkd write / Kea restart / host-inbound + lo0 nft …) — skipped the sync. But those errors leave the config committed + active AND the dataplane armed."* The five credential errors are structurally the same shape, so this change is symmetric with established behaviour.

Corroborated by mutation, not by reading: making `applyErrSkipsPeerSync` return `true` unconditionally reds the pre-existing `TestCommitAndApplySyncsPeerOnNonFatalApplyError` and `TestCommitConfirmedAndApplySyncsPeerOnNonFatalApplyError` alongside the new cells — those guards already own this property for the older operands.

### 4. Do we need a `lenient*` opt? No — and one is not possible here

`pkg/config/compiler_opts.go` `compileOpts` "carries per-call compilation policy … threaded into compileExpanded so the strict commit path and the tolerant load/peer-sync path can share the identical compile + group-expansion pipeline while differing on a single, narrow validator's severity." Every flag in it (`sanitizeFreeTextControlChars`, `lenientVRRPTrackDuplicates`, `lenientVRRPAuthentication`, `lenientDeviceMap`, `lenientTCPMSSRange`, `lenientLogStreamPort`, …) downgrades a **compile-time** validator.

These are **reconcile-time** failures raised after compilation, inside `applyConfigLocked`. There is no compile gate to downgrade — and none is needed, because the tolerant path already does not reject.

### 5. The one shape that could have broken this — and it is a real, pre-existing gap (#7618)

`exec.CommandContext` has **two** error shapes at a deadline:

- the process **started** and was killed → `*exec.ExitError` ("signal: killed"), not a context error → correctly classified non-fatal;
- the context expired **before fork/exec completed** → `Start` returns `ctx.Err()` and the caller gets a **bare `context.DeadlineExceeded`** → `applyErrSkipsPeerSync` cannot tell it from the #2926 daemon-stop abort and classifies it FATAL.

I originally reported this as "measured: a command timeout is not a context error". **That was incomplete and is corrected here.** The first version of the cell drove a live command against a short deadline; it passed unloaded and FAILED under a loaded full-package run with `create user admin: context deadline exceeded`. Which shape you get is decided by whether fork/exec wins the race with the deadline — machine load — so the cell was sampling the scheduler, the shape `engineering-style.md` calls out under #7563. It is now deterministic by construction (Start-then-cancel builds the ExitError shape; the race cannot occur), verified over 5 repeat runs.

**The misclassification is real, and it is pre-existing and wider than this PR.** Every apply-path command runner builds its own short context and feeds the same classifier:

| runner | timeout | operand | joined since |
|---|---|---|---|
| `nftApplyPayload` | 5s | `lo0Err`, `hostInboundErr` | #3392 / #3333 |
| `daemon_dns.go` `systemctl disable/mask` | ctx-scoped | `dnsErr` | #6792 |
| `runCommandTimeout` | 15s | the five credential errors | this PR |

So #6790 adds members to an already-exposed population; it does not create the exposure. Fixing the classifier changes behaviour for operands that predate this PR, so per the narrow-scope rule it is filed as **#7618** rather than ridden along here.

It is left as a tripwire, not folklore: `TestACommandDeadlineIsMisclassifiedAsADaemonStopAbort6790` asserts the CURRENT (wrong) classification, so when #7618 lands that cell reds and must be inverted together with the #1960 section of `docs/system-login.md`.

### Live data — real-box commit smoke

Gated on the CLI's own success markers (`configuration check succeeds`, `commit complete`), not the REPL exit status (#6440), and paired with the OS state so a green commit cannot be green *vacuously*:

| | commit A: `set system login user smoke6790 class super-user` + `encrypted-password` | commit B: `delete system login user smoke6790` |
|---|---|---|
| CLI markers | **PASS** | **PASS** |
| `/etc/passwd` entry | present | present (ordinary removal locks, never `userdel`) |
| `/etc/shadow` field | `$…` (hash set) | `!` — **locked** |
| `/etc/sudoers.d/xpf-smoke6790` | present | **gone** |
| account marker | present | **gone** |
| password marker | present | **gone** |

Both commits reported success and the credential state actually moved in both directions — so the fail-closed change neither breaks a healthy commit nor breaks the revocation path it exists to protect. Config verified byte-identical to the pre-smoke baseline afterwards; the smoke account was `userdel -r`'d.

### Live data — throughput

`iperf3 -P 16 -t 30` from `loss:cluster-userspace-host` → `172.16.80.200`, CoS freshly applied:

| port | class | result |
|---|---|---|
| 5211 | `iperf-uncapped` | **23.2 Gbit/s** sender / 23.1 receiver — meets the ≥ 23 Gbit/s bar |
| 5203 | `iperf-3g` (3.00 Gb/s shaper) | 2.86 Gbit/s — the shaper working correctly |

`docs/engineering-style.md` step 8 names port **5203** with a ≥ 23 Gbit/s criterion, which is the shaped class in the very CoS fixture the same row tells you to apply first. Filed as #7610; the uncapped 5211 number is the one that answers "no regression".

## Deferred

- #7608 — `_Log.md` on `master` carries unresolved conflict markers (arrived with `d6f8f77ab`, PR #7602), and the #6799 entry has #6797's body. Not fixed here: the marker removal is trivial but rewriting another lane's log entry needs that lane's context.
- #7609 — `applySSHConfig` creates a hard-coded `/etc/ssh/sshd_config.d` while `sshdConfPath` is relocatable; the #6790 fixture carries the `MkdirAll` workaround until it lands.
- #7610 — `engineering-style.md` step 8 measures the 3 Gb/s shaped port against a 23 Gbit/s bar.
- #7618 — `applyErrSkipsPeerSync` misclassifies a per-command timeout as the daemon-stop abort, skipping the peer push or discarding a peer-promoted config. Pre-existing (`lo0Err`/`hostInboundErr`/`dnsErr` reach it the same way); found by this PR's own flaky cell. Pinned here by a tripwire test.

## Refs

Closes #6790. Builds directly on #5874 (made the five reconcilers return their failures) and follows #6792 / #3392 / #3333 (the same fail-closed treatment for the other reconcilers in this function). Related: #2926 (the next-boot contract this narrows), #5128 / #5276 / #5841 / #6797 (the credential-ownership lifecycle whose failures now reach the operator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1PvkJxs7KrzEdyC9u1LDu
