### PR TITLE
pkg/daemon: fail closed when an ownership inventory cannot be read (#6798)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -105413,3 +105413,153 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/dataplane/userspace/helper_status_apply.go`,
   `pkg/dataplane/session_value_offsets_6816_test.go` (new),
   `pkg/dataplane/README.md`, `_Log.md`
+
+## 2026-08-26 — #6798 credential revocation fail-closed on unreadable ownership inventories
+
+- **Timestamp**: 2026-08-26
+- **Action**: Make every ownership-inventory read distinguish ABSENT from
+  UNREADABLE, so credential revocation stops reporting convergence over an
+  inventory it could not read (opus-review-001 root R58, High).
+- **The collapse**: three reads answered "did xpf provision this?" with a value
+  that could not tell "no" from "could not tell". `os.ReadFile(<marker>)` returned
+  a bare `false` on EACCES/EIO/EISDIR exactly as it did on ENOENT;
+  `provisionedNames` did `continue` on any `ReadDir` error; `reconcileSudoers`
+  discarded its error outright with `entries, _ :=`. Every revocation gate read
+  that value as "not ours, skip" and returned nil — SUCCESS — while a removed
+  admin's password, `authorized_keys`, and passwordless sudo grant stayed live.
+  The #5874 closeout, which exists to observe exactly this monotonic-revocation
+  gap, saw nothing to report.
+- **Worst shape**: `reconcileAbsentLoginUsers` read `names := provisionedNames();
+  if len(names) == 0 { return nil }`. A wholly unreadable inventory yields NO
+  names, which that early return treated as "nothing was ever provisioned" —
+  bit-identical to a fresh install.
+- **Both directions matter**: the fix reports WITHOUT revoking. Revoking on an
+  unproven marker is #6797's overclaim from the other side, and for root's
+  `authorized_keys` it is a total lockout. So each gate leaves the credential
+  untouched AND declines to converge. Markers are retained: dropping one on an
+  unreadable read is PERMANENT abandonment, since the account is no longer
+  enumerated once the root reads again (#5493's discipline at a new site).
+- **`hasProvenanceMarker` deleted, not wrapped**: leaving a bool-only twin beside
+  the fixed reader is how this class regresses. Its four test call sites moved to
+  `readProvenanceMarker` via `ownedMarker`/`ownedAccount`/`ownedPassword`/
+  `ownedKey`, which `t.Fatal` on a read error rather than returning false — a
+  helper that repeated the collapse would let a fixture whose root became
+  unreadable pass while proving nothing.
+- **`claimOwnership` fail-closed**: an unreadable marker now counts as
+  PRE-EXISTING. `preExisting` gates only `rollback()`, which REMOVES the marker,
+  i.e. releases ownership; withdrawing a claim that may be genuine orphans a live
+  credential xpf can never revoke (#5841 underclaim).
+- **Shadowing hazard caught in review**: `reconcileSudoers` has a NAMED return
+  `err`, so a function-scope `entries, err := os.ReadDir(...)` ASSIGNS to it
+  rather than shadowing — an absent `/etc/sudoers.d` would have returned a bogus
+  ENOENT failure on every apply forever. Uses `readErr`.
+- **Fixtures are uid-independent**: unreadability is staged as EISDIR (marker
+  path is a directory) and ENOTDIR (root path is a file), never `chmod 000` —
+  the suite may run as root, where permission bits are bypassed and the fixture
+  would silently become readable, i.e. a false green. Both helpers assert the
+  fixture actually errors and is not an ENOENT, so no assertion built on them is
+  vacuous.
+- **Paired controls**: each ReadDir cell has an ABSENT twin pinning `nil`, so the
+  degenerate "always error" mutation also REDS — without it, a reconciler that
+  failed on every fresh install would satisfy the guard.
+- **#1960**: runtime reconcile only, no commit-time gate added, so no matching
+  `lenient*` opt is owed.
+- **File(s)**: `pkg/daemon/login_password.go`, `pkg/daemon/daemon_system.go`,
+  `pkg/daemon/login_inventory_read_failclosed_6798_test.go`,
+  `pkg/daemon/login_password_test.go`,
+  `pkg/daemon/login_marker_overclaim_6797_test.go`,
+  `pkg/daemon/login_resource_ownership_5841_test.go`,
+  `docs/system-login.md`, `_Log.md`
+
+## 2026-08-26 — #6798 follow-up: bind the closeout consequence + module docs
+
+- **Timestamp**: 2026-08-26
+- **Action**: Re-read the new CLAUDE.md "Required Reading" contract
+  (`docs/engineering-style.md`, `AGENTS.md`, module READMEs) and closed the gaps
+  it exposed in the #6798 change.
+- **The gap that mattered**: the nine cells proved each reconciler RETURNS an
+  error, which is only half of R58's invariant ("retain debt and PREVENT A
+  SUCCESSFUL CLOSEOUT"). Traced the callers: `applyTailReconciles` DISCARDS all
+  four returns (`_ = d.reconcileSudoers(cfg)`), so on the normal apply path the
+  fix is log-only by design (#2926 next-boot convergence). The single consumer
+  is the #5874/M35 daemon-stop cancel closeout via `hostAuthCloseoutOwners` —
+  exactly the case where next-boot convergence does NOT happen. Nothing bound
+  that end to end, so the fix could have reported into a void at the one site
+  R58 names.
+- **Added `TestHostAuthCloseoutSurfacesUnreadableInventory_6798`**: drives the
+  REAL `reconcileAbsentLoginUsers` through `runHostAuthCloseoutOwners` +
+  `summarizeHostAuthCloseout` with the other six owners stubbed to no-ops, so a
+  green cannot come from an unrelated owner failing. Asserts the closeout error
+  names BOTH the owner (`absent-login-users`) and the reason
+  (`read ownership inventory`). Verified RED on reverting either M3 or M4
+  (2005 tests collected per cell).
+- **The control caught a real fixture bug of mine**: the three marker roots are
+  SIBLINGS derived from `filepath.Dir(provisionedUsersDir)`, so the control's
+  first form still resolved `provisionedKeysDir()` to the same unreadable file
+  and redded for the fixture's reason. The control needs a fresh PARENT, not a
+  fresh leaf — without that control the cell would have passed while proving
+  nothing about a clean inventory.
+- **#1960 re-verified by tracing, not asserting**: all four returns are `_ =`
+  discarded on the apply tail, so no commit can be rejected by this change and
+  no `lenient*` opt is owed. Previously claimed; now proven from the call sites.
+- **#6534 checked and does NOT apply**: that rule governs a snapshot builder
+  DROPPING a config object while `show` still renders it as enforced. No `show`
+  surface renders credential-ownership state, and this change makes a silent
+  failure VISIBLE rather than dropping a rendered object. Recorded in the doc.
+- **Docs**: `pkg/daemon/README.md` — the #5874 closeout bullet enumerates which
+  failures it collects, and this adds a class, so it gains the #6798 paragraph.
+  `docs/system-login.md` — new "Where the operator sees it" subsection drawing
+  the apply-tail (discarded, log-only) vs cancel-closeout (collected, fails the
+  cancel) distinction, plus the #6534 non-applicability note.
+- **File(s)**: `pkg/daemon/login_inventory_read_failclosed_6798_test.go`,
+  `pkg/daemon/README.md`, `docs/system-login.md`, `_Log.md`
+
+## 2026-08-26 — #6798 x #6790 composition: restate the no-brick premise, bind it
+
+- **Timestamp**: 2026-08-26
+- **Action**: #6790 merged (PR #7604) and `applyTailReconciles` now CAPTURES the
+  five host-credential returns into the commit result instead of discarding
+  them. #6798's errors therefore became commit-failing. Restated the #1960
+  argument on a premise that survives that, and bound it with a test.
+- **The dead premise**: the PR, the commit message, AND `docs/system-login.md`
+  all said "the apply tail discards these returns, so no commit can be
+  rejected". True when measured, FALSE the moment #7604 landed. A premise about
+  to stop being true is worse than none — a reader checks it, finds it false,
+  and distrusts the conclusion it supported.
+- **The durable premise**: the no-brick guarantee rests on the SHAPE OF THE
+  REJECTION SET, not on any caller discarding a return. `applyErrSkipsPeerSync`
+  (`daemon_apply_commit.go`) closes it over exactly two fatal classes — a
+  required-protocol-gate error (dataplane DISARMED) and a context
+  cancel/deadline from a daemon-stop abort — and its own comment states every
+  other error still syncs "because the config is committed + active and the
+  dataplane armed". An inventory-read failure is neither class. Verified at
+  source, not taken from the review.
+- **Bound it**: `TestUnreadableInventoryErrorDoesNotSkipPeerSync_6798` feeds the
+  REAL error from `reconcileAbsentLoginUsers` (not a synthetic `errors.New`,
+  which would prove only that the classifier rejects strings) and asserts it
+  does NOT skip peer sync. Two positive controls assert `context.Canceled` and
+  `context.DeadlineExceeded` still DO — without them the main assertion is
+  satisfied by a classifier returning false for everything, which is exactly
+  the mutation that WOULD brick, by pushing a dataplane-disarming config to the
+  standby.
+- **#7618 caveat, scoped deliberately**: #6790's section records that a COMMAND
+  deadline (short per-command context, e.g. `chpasswd`) is currently
+  misclassified as a daemon-stop abort, pinned by
+  `TestACommandDeadlineIsMisclassifiedAsADaemonStopAbort6790`. That does NOT
+  extend to what #6798 adds: these errors come from `os.ReadFile`/`os.ReadDir`
+  and carry EACCES/EIO/EISDIR/ENOTDIR, never a `context.DeadlineExceeded`, so
+  they cannot reach the misclassified branch. The reconcilers' COMMAND failures
+  were already in that population before #6798.
+- **Doc conflict resolved by rewriting, not by picking a side**: `#6790` and
+  `#6798` both added a section at the same anchor. Kept both, ordered #6790
+  first (it establishes that these errors fail the commit) then #6798 (what
+  counts as a failure), and REWROTE the two #6798 paragraphs #6790 falsified —
+  "Where the operator sees it" now says the tail CAPTURES, and the #1960
+  paragraph became "Why this does not brick a tolerant load or peer sync".
+- **`_Log.md` union, new form**: `theirs + ours_tail` guarded by
+  `assert ours.startswith(base)` (True). `theirs.startswith(base)` is False —
+  master deleted 87 lines mid-file across three regions (#7614/#7616), so the
+  old `base + ours_tail + theirs_tail` would have reintroduced every one.
+  Verified after writing that `theirs` is a prefix of the result.
+- **File(s)**: `pkg/daemon/login_inventory_read_failclosed_6798_test.go`,
+  `docs/system-login.md`, `_Log.md`

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -1339,6 +1339,13 @@ The path is scoped and fail-closed:
   `authorized_keys` removal failure, the marker is **retained** so the
   next apply retries — a credential is never forgotten while it may still
   be live.
+- On an **ownership marker** read error (or an unreadable marker **root**
+  during enumeration) the deprovision is **skipped**, the markers are
+  **retained**, and the failure is **returned** (#6798). An unreadable
+  marker is not proof the credential is not ours: acting on it would revoke
+  an operator's credential, while silently skipping it reported convergence
+  for a removal that never happened. See "Unreadable ownership inventories
+  are not empty ones (#6798)" below.
 - `root` is never deprovisioned **by this login-user path** — it is
   reconciled separately by `applyRootAuth` (see "Root credentials are
   revoked on removal (#5276)" below).
@@ -1678,6 +1685,122 @@ Until then it is a tripwire, not folklore:
 `TestACommandDeadlineIsMisclassifiedAsADaemonStopAbort6790` asserts the
 CURRENT (wrong) classification, so the fix reds a named cell and must
 invert it and this section together.
+
+## Unreadable ownership inventories are not empty ones (#6798)
+
+Every ownership read above answers one question — *did xpf provision this?* —
+and until #6798 it answered with a value that could not distinguish **"no"**
+from **"could not tell"**:
+
+| Read | Absent (a determination) | Unreadable (proves nothing) | Collapsed to |
+|---|---|---|---|
+| `os.ReadFile(<marker>)` | `ENOENT` — not ours | `EACCES` / `EIO` / `EISDIR` | `false` |
+| `os.ReadDir(<marker root>)` | `ENOENT` — nothing provisioned | `EACCES` / `ENOTDIR` | no names |
+| `os.ReadDir(/etc/sudoers.d)` | `ENOENT` — no grants exist | `EACCES` / `ENOTDIR` | `entries, _ :=` |
+
+Because both spellings arrived as the same value, every revocation gate read
+"could not tell" as **"not ours, skip"** and then returned `nil` — reporting
+**convergence**. A removed administrator kept their password, `authorized_keys`,
+and passwordless sudo grant while the apply reported success, and the #5874
+cancellation closeout (which exists to observe exactly this
+monotonic-revocation gap) saw nothing to report. `reconcileAbsentLoginUsers`
+made it worst: an entirely unreadable inventory yields **no names**, which its
+`len(names) == 0` early return treated as *"nothing was ever provisioned"* —
+indistinguishable from a fresh install.
+
+The governing invariant is now: **only proven absence may release ownership
+work.** Unknown ownership retains the debt and never converges.
+
+- **`readProvenanceMarker` returns `(bool, error)`.** Only `ENOENT` is absence
+  (`false, nil`); every other read error is returned. A UID mismatch or a
+  corrupt marker stays a *determination* (`false, nil`) — the bytes were read,
+  they simply are not this account's — and is still cleaned inline. There is
+  deliberately **no** bool-only wrapper: one would reintroduce the collapse.
+- **Report, but never revoke.** On an unreadable marker each gate keeps
+  ownership `false` and **skips the revocation**, then returns the error.
+  Revoking on an unproven claim is #6797's overclaim from the other side, and
+  for `root`'s `authorized_keys` it is a total lockout. So the gates are
+  fail-closed in **both** directions: the credential is untouched *and* the
+  apply does not converge. Applied at `applySystemLogin`'s emptied-key branch,
+  `reconcileUserPassword`'s `pwLock` branch, `applyRootAuth`'s revoke arm, and
+  `deprovisionLoginUser`.
+- **`provisionedNames` returns `(names, error)` and keeps sweeping.** An
+  unreadable root is reported, but the roots that *did* read still contribute
+  their names — revoking what we can see is strictly better than revoking
+  nothing, and the returned error carries the debt.
+  `reconcileAbsentLoginUsers` joins it into its accumulated error instead of
+  returning `nil` on the empty set.
+- **`reconcileSudoers` reports its `ReadDir` failure.** An absent
+  `/etc/sudoers.d` stays a clean `nil` (no drop-in can exist in a directory
+  that does not), but an unreadable one is accumulated — otherwise the
+  revocation sweep iterates nothing and a demoted admin keeps passwordless
+  root.
+- **`claimOwnership` treats an unreadable marker as PRE-EXISTING.** `preExisting`
+  gates only `rollback()`, which *removes* the marker — i.e. it releases
+  ownership. Unable to prove xpf did not already own the credential, it must not
+  withdraw: dropping a genuine claim orphans a live credential xpf can then
+  never lock or revoke (the #5841 underclaim). The cost of erring this way is
+  at most a stale marker, which the next apply reconciles.
+- **Retry debt is retained.** Markers are never dropped on an unreadable read.
+  Dropping one would be permanent abandonment: once the root is readable again
+  the account is no longer enumerated, so its credentials stay live forever.
+  This is the same three-state discipline #5493 applied to an unreadable
+  `/etc/passwd` — *unknown → retry*, never *absent → abandon*.
+
+### Where the operator sees it
+
+The four reconcilers that report an unreadable inventory (`applySystemLogin`,
+`reconcileSudoers`, `reconcileAbsentLoginUsers`, `applyRootAuth`) are reached
+from **two** callers, and since #6790 *both* of them surface the failure:
+
+- **The normal apply tail** (`applyTailReconciles`, steps 11–13) **captures**
+  these returns and joins them into the commit result — see "A failed
+  credential reconcile FAILS THE COMMIT (#6790)" above. Before #6790 they were
+  discarded (`_ = d.reconcileSudoers(cfg)`) on the #2926 next-boot-convergence
+  argument, so a commit over an unreadable inventory reported success. It now
+  fails, naming the account and the unreadable path.
+- **The #5874/M35 daemon-stop cancel closeout** (`hostAuthCloseoutOwners`)
+  collects them too, and that is the case where next-boot convergence does
+  *not* happen — the daemon is stopping and staying stopped.
+  `summarizeHostAuthCloseout` names the owning reconciler, so a cancel that
+  previously reported **clean** over an unreadable inventory now fails visibly
+  with e.g. `host-auth closeout owner "absent-login-users": read ownership
+  inventory /var/lib/xpf/provisioned-keys: ... not a directory`.
+
+That second path is the invariant R58 names — *unknown ownership inventory
+state must retain debt and prevent a successful closeout* — and it is bound by
+`TestHostAuthCloseoutSurfacesUnreadableInventory_6798`.
+
+### Why this does not brick a tolerant load or peer sync (#1960)
+
+#6798 adds no commit-time gate of its own; what makes its errors commit-failing
+is #6790's capture above. The no-brick guarantee therefore rests on the **shape
+of the rejection set**, not on any caller discarding a return:
+`applyErrSkipsPeerSync` (`pkg/daemon/daemon_apply_commit.go`) closes that set
+over exactly two fatal classes — a required-protocol-gate error
+(`compileErrorMustAbortApply`, which leaves the dataplane **disarmed**) and a
+context cancellation/deadline from a daemon-stop abort. Every *other* error
+still syncs, "because the config is committed + active and the dataplane
+armed". An inventory-read failure is neither class, so on the peer-sync receive
+path (`syncAndApply`) the config stays **active and armed** and the failure is
+surfaced rather than swallowed. No `lenient*` option in
+`pkg/config/compiler_opts.go` is owed.
+
+One caveat, deliberately scoped: #7618 records that a **command** deadline (a
+short per-command context, e.g. `chpasswd` via `runCommandStdinTimeout`) is
+currently misclassified by that same classifier as a daemon-stop abort, and
+`TestACommandDeadlineIsMisclassifiedAsADaemonStopAbort6790` pins the current
+wrong behaviour. That does **not** extend to what #6798 adds: these errors
+originate in `os.ReadFile` / `os.ReadDir` and carry `EACCES`/`EIO`/`EISDIR`/
+`ENOTDIR`, never a `context.DeadlineExceeded`, so they cannot reach the
+misclassified branch. The credential reconcilers' *command* failures were
+already in that population before #6798.
+
+There is **no `show` surface** that renders credential-ownership state, so the
+#6534 "a fail-closed exclusion owes a show-surface annotation" rule does not
+apply here: nothing in `show` claims these credentials are revoked, and this
+change makes a previously *silent* failure *visible* rather than dropping an
+object the operator can still see rendered as enforced.
 
 ## Idempotency
 

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -1798,6 +1798,26 @@ never lock an operator out of a remote box it manages.
       intentionally discarded (`_ =`) — next-boot convergence still covers a
       transient failure there; only the daemon-stop cancel, where next-boot
       convergence does not happen, collects and fails on them.
+    - **Unreadable ownership inventories now reach this closeout (#6798).**
+      The reconcilers above could only report failures they could SEE, and an
+      ownership read that failed was invisible to them: `hasProvenanceMarker`
+      collapsed every `os.ReadFile` error to the same `false` a genuine `ENOENT`
+      produces, `provisionedNames` skipped an unreadable root with a bare
+      `continue`, and `reconcileSudoers` discarded its `ReadDir` error outright
+      (`entries, _ :=`). Each gate then read "could not tell" as "not ours,
+      skip" and returned **nil**, so the closeout — whose entire job is to catch
+      an unconverged host-auth state — was handed a clean result over a removed
+      administrator's still-live password, `authorized_keys`, and passwordless
+      sudo grant. The reads now distinguish **absent** (a determination) from
+      **unreadable** (proves nothing) and return the latter, so
+      `summarizeHostAuthCloseout` attributes it to the owning reconciler
+      (`system-login`, `sudoers`, `absent-login-users`, `root-auth`) and the
+      cancel fails visibly. The gates report **without revoking** — acting on a
+      marker xpf cannot read is #6797's overclaim from the other side, and for
+      root's `authorized_keys` a total lockout — and markers are **retained**, so
+      the debt survives for the next apply instead of being abandoned. See
+      `docs/system-login.md` §"Unreadable ownership inventories are not empty
+      ones (#6798)".
   - **Early signal capture — startup is abortable (#5807).** The shutdown
     signal context is captured at the **TOP of `Run`** (`startupSignalContext`),
     BEFORE the mutating startup phases (config load + bootstrap → interface

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -1561,7 +1561,21 @@ func (d *Daemon) applySystemLogin(cfg *config.Config) (err error) {
 			// (#5841): a user whose PASSWORD xpf set but whose keys it never
 			// wrote has no key marker, so an operator-installed authorized_keys
 			// is left untouched (the overclaim this closes).
-			if uid, ok := lookupUID(user.Name); ok && keyProvisioned(user.Name, uid) {
+			uid, uidOK := lookupUID(user.Name)
+			ownsKeys, ownErr := false, error(nil)
+			if uidOK {
+				ownsKeys, ownErr = keyProvisioned(user.Name, uid)
+			}
+			if ownErr != nil {
+				// #6798: an unreadable key marker proves nothing. Do NOT remove
+				// the file (that would revoke on unproven ownership), but do not
+				// report convergence either — the emptied key list has NOT been
+				// honoured, and the next apply retries.
+				slog.Error("cannot determine SSH-key ownership; NOT revoking keys "+
+					"and NOT reporting convergence", "user", user.Name, "err", ownErr)
+				fail(fmt.Errorf("determine key ownership for %s: %w", user.Name, ownErr))
+			}
+			if uidOK && ownsKeys {
 				keysFile := managedAuthorizedKeysPath(user.Name)
 				switch err := os.Remove(keysFile); {
 				case err == nil:
@@ -1665,7 +1679,26 @@ func (d *Daemon) reconcileSudoers(cfg *config.Config) (err error) {
 	}
 
 	// Revoke: remove any xpf-managed drop-in that is no longer desired.
-	entries, _ := os.ReadDir(sudoersDir)
+	//
+	// #6798: the ReadDir error used to be discarded. An ABSENT sudoers.d is a
+	// determination — no drop-in can exist in a directory that does not, so
+	// there is nothing to revoke and nil is correct. An UNREADABLE one
+	// (EACCES/EIO/ENOTDIR) is NOT: it yields the same empty slice, the sweep
+	// below iterates nothing, and reconcileSudoers returns nil — SUCCESS —
+	// while a demoted or deleted admin's xpf-<user> NOPASSWD grant is still
+	// live on disk. Report it so the #5874 closeout sees the revocation debt.
+	//
+	// NOTE: readErr, not err — `err` is this function's NAMED RETURN, and a
+	// function-scope `entries, err :=` would ASSIGN ENOENT to it (no shadowing
+	// at this block level), making a host with no /etc/sudoers.d report a
+	// bogus reconcile failure forever.
+	entries, readErr := os.ReadDir(sudoersDir)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		slog.Error("cannot read sudoers directory; a demoted or removed "+
+			"super-user's passwordless sudo grant may NOT have been revoked",
+			"dir", sudoersDir, "err", readErr)
+		fail(fmt.Errorf("read sudoers inventory %s: %w", sudoersDir, readErr))
+	}
 	for _, e := range entries {
 		name := e.Name()
 		if e.IsDir() || !strings.HasPrefix(name, sudoersPrefix) {
@@ -1817,7 +1850,20 @@ func (d *Daemon) reconcileUserPassword(user *config.LoginUser) (err error) {
 	case pwLock:
 		// Only lock the exact account whose PASSWORD xpf provisioned (password
 		// marker) — never an account xpf touched solely for its SSH key (#5841).
-		if !uidOK || !passwordProvisioned(user.Name, curUID) {
+		ownsPassword, ownErr := false, error(nil)
+		if uidOK {
+			ownsPassword, ownErr = passwordProvisioned(user.Name, curUID)
+		}
+		if ownErr != nil {
+			// #6798: never LOCK on unproven ownership (that is the #6797
+			// overclaim), but never report the declarative lock converged
+			// either.
+			slog.Error("cannot determine password ownership; NOT locking and "+
+				"NOT reporting convergence", "user", user.Name, "err", ownErr)
+			fail(fmt.Errorf("determine password ownership for %s: %w", user.Name, ownErr))
+			break
+		}
+		if !uidOK || !ownsPassword {
 			break
 		}
 		stdin := strings.NewReader(user.Name + ":!\n")
@@ -2198,7 +2244,15 @@ func (d *Daemon) applyRootAuth(cfg *config.Config) (retErr error) {
 			}
 			slog.Info("root SSH keys applied", "keys", len(keys))
 		}
-	} else if keyProvisioned("root", 0) {
+	} else if rootOwnsKeys, rootOwnErr := keyProvisioned("root", 0); rootOwnErr != nil {
+		// #6798: an unreadable root key marker proves nothing. Do NOT remove
+		// root's authorized_keys on unproven ownership — if it is the
+		// operator's own out-of-band key that is a total lockout — but do not
+		// report the emptied key list as converged either.
+		slog.Error("cannot determine root SSH-key ownership; NOT revoking root "+
+			"keys and NOT reporting convergence", "err", rootOwnErr)
+		fail(fmt.Errorf("determine root key ownership: %w", rootOwnErr))
+	} else if rootOwnsKeys {
 		// Empty/absent key list AND xpf wrote root's keys: revoke the xpf-managed
 		// root authorized_keys so removing the keys from config actually disables
 		// key-based root login. The KEY marker gate leaves an operator-installed

--- a/pkg/daemon/login_inventory_read_failclosed_6798_test.go
+++ b/pkg/daemon/login_inventory_read_failclosed_6798_test.go
@@ -1,0 +1,683 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6798: credential revocation treated an UNREADABLE ownership inventory as an
+// EMPTY or UNOWNED one.
+//
+// Every marker read (os.ReadFile) and every inventory enumeration (os.ReadDir)
+// collapsed its error into the same value a genuine ABSENCE produces — `false`
+// for a marker, an empty slice for a root, a discarded error for sudoers.d.
+// Absence is a determination ("this credential is not xpf's, skip it");
+// unreadability proves nothing. Because both spellings arrived as the same
+// value, every revocation gate read "could not tell" as "not ours" and
+// SKIPPED, then returned nil — reporting convergence — while a removed or
+// demoted administrator's password, authorized_keys, or passwordless sudo
+// grant stayed live on disk. The #5874 cancellation closeout, which exists to
+// observe exactly this monotonic-revocation gap, saw nothing to report.
+//
+// The invariant these guards pin: only PROVEN ABSENCE may release ownership
+// work. Unknown ownership retains the debt (markers stay, an error is
+// returned) and never converges. It equally must not REVOKE on unproven
+// ownership — acting on a marker xpf cannot read is #6797's overclaim from the
+// other side, and for root's authorized_keys it is a total lockout. So each
+// gate below asserts BOTH halves: the credential is untouched AND the error is
+// reported.
+//
+// Each test is named for the one production line it pins; reverting that line
+// alone must turn the named cell RED.
+
+// unreadableMarkerPath makes one marker path UNREADABLE without depending on
+// file permissions: it replaces the marker with a DIRECTORY, so os.ReadFile
+// opens it and then fails the read with EISDIR.
+//
+// Permission bits are the obvious lever and the wrong one — the suite may run
+// as root, where chmod 000 is bypassed and the fixture would silently become a
+// readable marker, i.e. a false green. EISDIR is uid-independent.
+func unreadableMarkerPath(t *testing.T, dir, name string) string {
+	t.Helper()
+	path := markerPathIn(dir, name)
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Prove the fixture actually produces a read ERROR and not an absence,
+	// otherwise every assertion built on it is vacuous.
+	if _, err := os.ReadFile(path); err == nil {
+		t.Fatalf("fixture is inert: %s reads cleanly, so no gate under test "+
+			"can enter its unreadable branch", path)
+	} else if os.IsNotExist(err) {
+		t.Fatalf("fixture produced ABSENCE, not unreadability, at %s: %v", path, err)
+	}
+	return path
+}
+
+// unreadableRootDir makes one inventory ROOT unreadable by replacing the
+// directory with a regular FILE, so os.ReadDir fails with ENOTDIR. Like
+// unreadableMarkerPath this is uid-independent — root can read a 000 dir.
+func unreadableRootDir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dir, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.ReadDir(dir); err == nil {
+		t.Fatalf("fixture is inert: ReadDir(%s) succeeded", dir)
+	} else if os.IsNotExist(err) {
+		t.Fatalf("fixture produced ABSENCE, not unreadability, at %s: %v", dir, err)
+	}
+}
+
+// TestReadProvenanceMarkerSeparatesAbsentFromUnreadable_6798 pins the
+// ENOENT-vs-other split in readProvenanceMarker.
+//
+// This is the root of the defect: the reader returned a bare bool, so ENOENT
+// (a determination) and EISDIR/EACCES/EIO (not a determination) were the same
+// `false`.
+//
+// FAIL-ON-REVERT: restore `if err != nil { return false }` in
+// readProvenanceMarker (dropping the os.IsNotExist split) and the UNREADABLE
+// row goes RED — err becomes nil, so "could not tell" reads as "proven not
+// ours" again. The ABSENT row is the paired control: it pins err == nil, so
+// the opposite mutation (returning an error unconditionally) also REDS. A
+// guard with only the unreadable row would be satisfied by a reader that
+// errored on everything, which would brick every fresh install.
+func TestReadProvenanceMarkerSeparatesAbsentFromUnreadable_6798(t *testing.T) {
+	dir := t.TempDir()
+
+	// ABSENT: a determination. Not ours, no error.
+	owned, err := readProvenanceMarker(dir, "absent", 1001)
+	if owned || err != nil {
+		t.Errorf("absent marker = (%v, %v), want (false, nil): a marker that is "+
+			"genuinely missing PROVES the credential is not xpf's, and must not "+
+			"be reported as a read failure — every fresh install has no markers",
+			owned, err)
+	}
+
+	// PRESENT and matching: a determination. Ours, no error.
+	if err := writeProvenanceMarker(dir, "mine", 1002); err != nil {
+		t.Fatal(err)
+	}
+	owned, err = readProvenanceMarker(dir, "mine", 1002)
+	if !owned || err != nil {
+		t.Errorf("matching marker = (%v, %v), want (true, nil)", owned, err)
+	}
+
+	// UNREADABLE: NOT a determination. Ownership stays false (never revoke on
+	// an unproven claim) but the error must surface.
+	unreadableMarkerPath(t, dir, "opaque")
+	owned, err = readProvenanceMarker(dir, "opaque", 1003)
+	if err == nil {
+		t.Error("an UNREADABLE marker reported no error, so it is indistinguishable " +
+			"from a genuinely absent one. Every revocation gate reads that as " +
+			"\"not ours, skip\" and then reports convergence, leaving the " +
+			"credential live (#6798)")
+	}
+	if owned {
+		t.Error("an UNREADABLE marker reported OWNERSHIP; xpf would revoke a " +
+			"credential it cannot prove it owns (#6797 overclaim)")
+	}
+}
+
+// TestClaimOwnershipTreatsUnreadableMarkerAsPreExisting_6798 pins the
+// claimOwnership fail-closed default.
+//
+// preExisting gates exactly one thing: rollback(), which REMOVES the marker.
+// Removing a marker RELEASES ownership, and only proven absence may do that.
+// If the marker cannot be read, xpf cannot prove it did not already own the
+// credential, and withdrawing a real marker orphans a live credential xpf can
+// then never lock or revoke — the #5841 underclaim.
+//
+// FAIL-ON-REVERT: drop the `owned = true` assignment in claimOwnership's
+// readErr branch and this REDS — preExisting becomes false and rollback()
+// would withdraw a claim that may be genuine.
+func TestClaimOwnershipTreatsUnreadableMarkerAsPreExisting_6798(t *testing.T) {
+	dir := t.TempDir()
+	path := unreadableMarkerPath(t, dir, "opaque")
+
+	// The marker write also fails here (rename over a directory); that is
+	// incidental. What is under test is the ownership READ that precedes it.
+	c, _ := claimOwnership(dir, "opaque", 1004)
+	if !c.preExisting {
+		t.Fatal("claimOwnership over an UNREADABLE marker reported preExisting=false, " +
+			"which makes rollback() WITHDRAW the marker. xpf cannot prove it did " +
+			"not already own this credential, and withdrawing a genuine claim " +
+			"orphans a live credential it can never revoke (#5841 underclaim, #6798)")
+	}
+
+	// The consequence: rollback must be inert in this state.
+	c.rollback()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("rollback removed a marker whose ownership could not be read: %v", err)
+	}
+}
+
+// TestProvisionedNamesReportsUnreadableRoot_6798 pins the ReadDir error split
+// in provisionedNames.
+//
+// FAIL-ON-REVERT: restore the bare `continue` (dropping the
+// `if !os.IsNotExist(err)` accumulation) and the UNREADABLE subtest REDS.
+// The ABSENT subtest is the paired control that keeps the fix from degenerating
+// into "always error": all three roots missing is a fresh install and MUST stay
+// a clean nil.
+func TestProvisionedNamesReportsUnreadableRoot_6798(t *testing.T) {
+	t.Run("all roots absent is a clean determination", func(t *testing.T) {
+		dir := t.TempDir()
+		orig := provisionedUsersDir
+		provisionedUsersDir = filepath.Join(dir, "provisioned-users")
+		t.Cleanup(func() { provisionedUsersDir = orig })
+
+		names, err := provisionedNames()
+		if err != nil {
+			t.Errorf("provisionedNames with no roots at all = %v, want nil: a "+
+				"fresh install has provisioned nothing, which is a "+
+				"determination, not a read failure", err)
+		}
+		if len(names) != 0 {
+			t.Errorf("provisionedNames = %v, want empty", names)
+		}
+	})
+
+	t.Run("unreadable root is reported and does not truncate the sweep", func(t *testing.T) {
+		dir := t.TempDir()
+		orig := provisionedUsersDir
+		provisionedUsersDir = filepath.Join(dir, "provisioned-users")
+		t.Cleanup(func() { provisionedUsersDir = orig })
+
+		// A readable root that DOES name an account...
+		if err := markPasswordProvisioned("readable", 1005); err != nil {
+			t.Fatal(err)
+		}
+		// ...and an unreadable one beside it.
+		unreadableRootDir(t, provisionedKeysDir())
+
+		names, err := provisionedNames()
+		if err == nil {
+			t.Error("an UNREADABLE ownership root contributed no names AND no error, " +
+				"so the inventory looks complete when it is truncated. Accounts " +
+				"whose only marker lived there are silently never revoked (#6798)")
+		}
+		// Revoking what we CAN see is strictly better than revoking nothing:
+		// the error carries the debt, it must not discard the readable half.
+		if _, ok := names["readable"]; !ok {
+			t.Errorf("names = %v, want it to still contain \"readable\": an "+
+				"unreadable root must not suppress the roots that DID read", names)
+		}
+	})
+}
+
+// stageRemovedUserEnv stages a removed login user who still has a live
+// password and a live authorized_keys on disk, with all three ownership marker
+// roots relocated under a temp dir. It returns the user's managed
+// authorized_keys path.
+func stageRemovedUserEnv(t *testing.T, name string, uid int) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	shadow := filepath.Join(dir, "shadow")
+	// A USABLE hash, deliberately: the removed user's password is live, which
+	// is the credential the deprovision is supposed to lock.
+	shadowContent := fmt.Sprintf(
+		"root:*:19000:0:99999:7:::\n%s:$6$salt$livehash:19000:0:99999:7:::\n", name)
+	if err := os.WriteFile(shadow, []byte(shadowContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	passwd := filepath.Join(dir, "passwd")
+	passwdContent := fmt.Sprintf(
+		"root:x:0:0:root:/root:/bin/bash\n%s:x:%d:%d:,,,:/home/%s:/bin/bash\n",
+		name, uid, uid, name)
+	if err := os.WriteFile(passwd, []byte(passwdContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	origShadow, origPasswd, origDir, origHome := shadowPath, passwdPath, provisionedUsersDir, homeBaseDir
+	shadowPath, passwdPath = shadow, passwd
+	provisionedUsersDir = filepath.Join(dir, "provisioned-users")
+	homeBaseDir = filepath.Join(dir, "home")
+	t.Cleanup(func() {
+		shadowPath, passwdPath, provisionedUsersDir, homeBaseDir = origShadow, origPasswd, origDir, origHome
+	})
+
+	keysFile := managedAuthorizedKeysPath(name)
+	if err := os.MkdirAll(filepath.Dir(keysFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keysFile, []byte("ssh-ed25519 AAAA "+name+"-live\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return keysFile
+}
+
+// TestDeprovisionUnreadableOwnershipDoesNotConverge_6798 pins the ownErr gate
+// in deprovisionLoginUser — the highest-consequence site.
+//
+// Before the fix, all three marker reads failing produced three falses, which
+// matched the "nothing xpf-owned, never touch an out-of-band account" branch
+// and returned nil. That nil is the whole defect: a removed administrator kept
+// their password and SSH keys while the reconcile reported success.
+//
+// FAIL-ON-REVERT: drop the `if ownErr != nil { ... return retErr }` block and
+// this REDS on the error assertion — the function returns nil for a removed
+// user whose credentials are demonstrably still live.
+func TestDeprovisionUnreadableOwnershipDoesNotConverge_6798(t *testing.T) {
+	keysFile := stageRemovedUserEnv(t, "mallory", 1006)
+
+	// All three ownership markers are unreadable: xpf cannot tell whether it
+	// provisioned mallory's credentials.
+	unreadableMarkerPath(t, provisionedUsersDir, "mallory")
+	unreadableMarkerPath(t, provisionedPasswordsDir(), "mallory")
+	unreadableMarkerPath(t, provisionedKeysDir(), "mallory")
+
+	d := &Daemon{}
+	err := d.deprovisionLoginUser("mallory")
+
+	if err == nil {
+		t.Fatal("deprovisionLoginUser reported SUCCESS for a removed user whose " +
+			"ownership markers could not be read. Its password and authorized_keys " +
+			"are still live, but the #5874 closeout sees convergence and lets " +
+			"shutdown/HA promotion proceed — the removed admin keeps host access (#6798)")
+	}
+	if !strings.Contains(err.Error(), "determine ownership for removed user mallory") {
+		t.Errorf("error = %v, want it to name the ownership-determination failure "+
+			"for mallory; a different error would mean this cell is green for the "+
+			"wrong reason", err)
+	}
+
+	// Never revoke on unproven ownership: the key file may be the operator's own.
+	if _, statErr := os.Stat(keysFile); statErr != nil {
+		t.Errorf("authorized_keys was REMOVED on unreadable ownership (%v); xpf "+
+			"revoked a credential it cannot prove it owns (#6797 overclaim)", statErr)
+	}
+	// Retry debt is retained: the markers must survive so the next apply retries.
+	for _, dir := range []string{provisionedUsersDir, provisionedPasswordsDir(), provisionedKeysDir()} {
+		if _, statErr := os.Stat(markerPathIn(dir, "mallory")); statErr != nil {
+			t.Errorf("ownership marker under %s was dropped on an unreadable read "+
+				"(%v); once the root is readable again mallory is no longer "+
+				"enumerated, so revocation is abandoned PERMANENTLY", dir, statErr)
+		}
+	}
+}
+
+// TestReconcileAbsentLoginUsersReportsUnreadableInventory_6798 pins the invErr
+// propagation in reconcileAbsentLoginUsers.
+//
+// The reverted form read `names := provisionedNames(); if len(names) == 0 {
+// return nil }`, so an inventory that was entirely unreadable produced an empty
+// set and an immediate SUCCESS. The fixture therefore keeps the readable roots
+// ABSENT so the name set really is empty — that is the exact shape the old
+// early return converged on. A fixture with any readable name would not enter
+// it and would be a false green.
+//
+// FAIL-ON-REVERT: drop the `if invErr != nil { retErr = errors.Join(...) }`
+// block and this REDS.
+func TestReconcileAbsentLoginUsersReportsUnreadableInventory_6798(t *testing.T) {
+	dir := t.TempDir()
+	orig := provisionedUsersDir
+	provisionedUsersDir = filepath.Join(dir, "provisioned-users")
+	t.Cleanup(func() { provisionedUsersDir = orig })
+
+	// The keys root is unreadable; the other two are genuinely absent, so the
+	// readable half of the inventory names NOTHING.
+	unreadableRootDir(t, provisionedKeysDir())
+
+	d := &Daemon{}
+	err := d.reconcileAbsentLoginUsers(loginCfg())
+
+	if err == nil {
+		t.Fatal("reconcileAbsentLoginUsers reported SUCCESS over an inventory it " +
+			"could not read. An unreadable root yields no names, which the old " +
+			"len(names)==0 early return treated as \"nothing was ever " +
+			"provisioned, nothing to revoke\" — indistinguishable from a fresh " +
+			"install, and the removed users it should have swept keep their " +
+			"credentials (#6798)")
+	}
+	if !strings.Contains(err.Error(), "read ownership inventory") {
+		t.Errorf("error = %v, want it to name the unreadable inventory root", err)
+	}
+}
+
+// TestEmptiedKeyListUnreadableMarkerDoesNotConverge_6798 pins the ownErr gate
+// in applySystemLogin's emptied-key-list branch.
+//
+// FAIL-ON-REVERT: drop the `if ownErr != nil { fail(...) }` block in
+// applySystemLogin and this REDS — ownsKeys stays false, the revoke branch is
+// skipped, and the apply reports convergence for a key list that was never
+// honoured.
+func TestEmptiedKeyListUnreadableMarkerDoesNotConverge_6798(t *testing.T) {
+	keysFile := stageEmptiedKeysEnv(t, "nora", 1007)
+
+	// The key file is live on disk but xpf cannot read its ownership marker.
+	if err := os.MkdirAll(filepath.Dir(keysFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keysFile, []byte("ssh-ed25519 AAAA nora-live\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	unreadableMarkerPath(t, provisionedKeysDir(), "nora")
+
+	// nora is RETAINED in config but her key list is now empty.
+	d := &Daemon{}
+	err := d.applySystemLogin(loginCfg(&config.LoginUser{Name: "nora", Class: "operator"}))
+
+	if err == nil {
+		t.Fatal("applySystemLogin reported SUCCESS after emptying a key list whose " +
+			"ownership marker could not be read. The key file is still on disk, so " +
+			"key-based login is NOT revoked, yet the apply converged (#6798)")
+	}
+	if !strings.Contains(err.Error(), "determine key ownership for nora") {
+		t.Errorf("error = %v, want it to name the key-ownership determination "+
+			"failure for nora; any other error means this cell is green for the "+
+			"wrong reason", err)
+	}
+	// And it must NOT have revoked on the unproven claim.
+	if _, statErr := os.Stat(keysFile); statErr != nil {
+		t.Errorf("authorized_keys removed on unreadable ownership (%v) — that is "+
+			"the #6797 overclaim: the file may be the operator's own", statErr)
+	}
+}
+
+// TestPasswordLockUnreadableMarkerDoesNotConverge_6798 pins the ownErr gate in
+// reconcileUserPassword's pwLock branch.
+//
+// FAIL-ON-REVERT: drop the `if ownErr != nil { fail(...); break }` block and
+// this REDS — the `!uidOK || !ownsPassword` test below it swallows the
+// unreadable marker as "not ours" and breaks silently, reporting convergence
+// for a declarative lock that never happened.
+func TestPasswordLockUnreadableMarkerDoesNotConverge_6798(t *testing.T) {
+	dir := t.TempDir()
+
+	// A USABLE hash with NO encrypted-password in config → passwordAction
+	// returns pwLock, which is the branch under test. A locked hash would
+	// return pwNoop and never reach the gate — an inert fixture.
+	shadow := filepath.Join(dir, "shadow")
+	if err := os.WriteFile(shadow,
+		[]byte("root:*:19000:0:99999:7:::\nolga:$6$salt$livehash:19000:0:99999:7:::\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	passwd := filepath.Join(dir, "passwd")
+	if err := os.WriteFile(passwd,
+		[]byte("root:x:0:0:root:/root:/bin/bash\nolga:x:1008:1008:,,,:/home/olga:/bin/bash\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	origShadow, origPasswd, origDir := shadowPath, passwdPath, provisionedUsersDir
+	shadowPath, passwdPath = shadow, passwd
+	provisionedUsersDir = filepath.Join(dir, "provisioned-users")
+	t.Cleanup(func() {
+		shadowPath, passwdPath, provisionedUsersDir = origShadow, origPasswd, origDir
+	})
+
+	// chpasswd must never run on an unproven claim; record it if it does.
+	sentinel := filepath.Join(dir, "chpasswd-ran")
+	fakeBin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fakeBin, "chpasswd"),
+		[]byte("#!/bin/sh\ncat > "+sentinel+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", fakeBin+":"+os.Getenv("PATH"))
+
+	unreadableMarkerPath(t, provisionedPasswordsDir(), "olga")
+
+	d := &Daemon{}
+	err := d.reconcileUserPassword(&config.LoginUser{Name: "olga", Class: "operator"})
+
+	if err == nil {
+		t.Fatal("reconcileUserPassword reported SUCCESS for a declarative password " +
+			"LOCK whose ownership marker could not be read. olga's password is " +
+			"still usable, but the apply converged (#6798)")
+	}
+	if !strings.Contains(err.Error(), "determine password ownership for olga") {
+		t.Errorf("error = %v, want it to name the password-ownership determination "+
+			"failure for olga", err)
+	}
+	if _, statErr := os.Stat(sentinel); statErr == nil {
+		t.Error("chpasswd RAN on an unreadable ownership marker — xpf locked an " +
+			"account whose password it cannot prove it set (#6797 overclaim)")
+	}
+}
+
+// TestRootKeyRevokeUnreadableMarkerDoesNotConverge_6798 pins the rootOwnErr
+// gate in applyRootAuth.
+//
+// Root is the highest-consequence case in both directions: skipping silently
+// leaves root key login live after the operator removed the keys from config,
+// while revoking on an unproven claim can delete the operator's own
+// out-of-band root key and lock them out of the box entirely. The gate must
+// therefore report WITHOUT revoking.
+//
+// FAIL-ON-REVERT: drop the `else if rootOwnErr != nil { fail(...) }` arm and
+// this REDS — the chain falls through to `else if rootOwnsKeys` with a false
+// and applyRootAuth returns nil.
+func TestRootKeyRevokeUnreadableMarkerDoesNotConverge_6798(t *testing.T) {
+	_, rootKeys := stageRootAuthEnv(t, "*")
+	writeRootKeys(t, rootKeys, rootKeyContent)
+
+	unreadableMarkerPath(t, provisionedKeysDir(), "root")
+
+	// root-authentication present but the key list is EMPTY → the revoke arm.
+	d := &Daemon{}
+	err := d.applyRootAuth(rootAuthCfg(""))
+
+	if err == nil {
+		t.Fatal("applyRootAuth reported SUCCESS after the root key list was emptied " +
+			"but root's key-ownership marker could not be read. " +
+			"/root/.ssh/authorized_keys is still on disk, so key-based root login " +
+			"is NOT revoked, yet the apply converged (#6798)")
+	}
+	if !strings.Contains(err.Error(), "determine root key ownership") {
+		t.Errorf("error = %v, want it to name the root key-ownership determination "+
+			"failure", err)
+	}
+	if _, statErr := os.Stat(rootKeys); statErr != nil {
+		t.Errorf("root authorized_keys was REMOVED on unreadable ownership (%v). "+
+			"If that file is the operator's own out-of-band root key this is a "+
+			"total lockout (#6797 overclaim)", statErr)
+	}
+}
+
+// TestReconcileSudoersReportsUnreadableDir_6798 pins the ReadDir error split in
+// reconcileSudoers — the third inventory R58 names, and the one whose error was
+// discarded outright with `entries, _ :=`.
+//
+// FAIL-ON-REVERT: restore `entries, _ := os.ReadDir(sudoersDir)` and the
+// UNREADABLE subtest REDS. The ABSENT subtest is the paired control: a host
+// with no /etc/sudoers.d has no grants to revoke, so it MUST stay nil — a
+// reconciler that errored on both would report a permanent bogus failure on
+// every apply.
+func TestReconcileSudoersReportsUnreadableDir_6798(t *testing.T) {
+	t.Run("absent sudoers dir is a clean determination", func(t *testing.T) {
+		dir := t.TempDir()
+		origDir, origValidate := sudoersDir, validateSudoersFile
+		sudoersDir = filepath.Join(dir, "does-not-exist")
+		validateSudoersFile = func(string) error { return nil }
+		t.Cleanup(func() { sudoersDir, validateSudoersFile = origDir, origValidate })
+
+		d := &Daemon{}
+		if err := d.reconcileSudoers(loginCfg()); err != nil {
+			t.Errorf("reconcileSudoers with an ABSENT sudoers.d = %v, want nil: no "+
+				"drop-in can exist in a directory that does not, so there is "+
+				"nothing to revoke", err)
+		}
+	})
+
+	t.Run("unreadable sudoers dir is reported", func(t *testing.T) {
+		dir := t.TempDir()
+		origDir, origValidate := sudoersDir, validateSudoersFile
+		sudoersDir = filepath.Join(dir, "sudoers.d")
+		validateSudoersFile = func(string) error { return nil }
+		t.Cleanup(func() { sudoersDir, validateSudoersFile = origDir, origValidate })
+
+		unreadableRootDir(t, sudoersDir)
+
+		// No super-users in config: every xpf-<user> grant on disk is stale and
+		// the sweep is supposed to revoke it.
+		d := &Daemon{}
+		err := d.reconcileSudoers(loginCfg())
+
+		if err == nil {
+			t.Fatal("reconcileSudoers reported SUCCESS over a sudoers.d it could not " +
+				"read. The revocation sweep iterated an empty slice, so a demoted " +
+				"or removed admin's xpf-<user> NOPASSWD grant is still live, and " +
+				"the closeout sees convergence (#6798)")
+		}
+		if !strings.Contains(err.Error(), "read sudoers inventory") {
+			t.Errorf("error = %v, want it to name the unreadable sudoers inventory", err)
+		}
+	})
+}
+
+// TestHostAuthCloseoutSurfacesUnreadableInventory_6798 is the END-TO-END cell:
+// it binds the consequence R58 actually names — "unknown ownership inventory
+// state must retain debt and PREVENT A SUCCESSFUL CLOSEOUT".
+//
+// The nine cells above prove each reconciler RETURNS an error. That is only
+// half the property, because on the normal apply path every one of those
+// returns is deliberately discarded (`_ = d.reconcileAbsentLoginUsers(cfg)` in
+// applyTailReconciles — the #2926 next-boot convergence contract). The single
+// caller that CONSUMES them is the #5874/M35 daemon-stop cancel closeout, which
+// is precisely the moment next-boot convergence does NOT happen. If the error
+// did not reach it, the fix would report into a void at the one site that
+// matters.
+//
+// Only "absent-login-users" is a real reconciler here; the other six owners are
+// clean no-ops, so a green cannot come from some unrelated owner failing — the
+// closeout error must be attributable to THIS condition. The control run
+// (readable inventory, same owners) pins nil, so an owner that failed for an
+// environmental reason would break the control instead of silently passing the
+// assertion.
+//
+// FAIL-ON-REVERT: revert any of M3 (provisionedNames error accumulation) or M4
+// (reconcileAbsentLoginUsers invErr join) and this REDS — the owner returns nil
+// and the cancel reports CLEAN over an inventory it could not read.
+func TestHostAuthCloseoutSurfacesUnreadableInventory_6798(t *testing.T) {
+	dir := t.TempDir()
+	orig := provisionedUsersDir
+	provisionedUsersDir = filepath.Join(dir, "provisioned-users")
+	t.Cleanup(func() { provisionedUsersDir = orig })
+
+	// The keys root is unreadable; the other two are genuinely absent.
+	unreadableRootDir(t, provisionedKeysDir())
+
+	d := &Daemon{}
+	cfg := loginCfg()
+	owners := []hostAuthOwner{
+		{"lo0-filter", noopCloseoutOwner},
+		{"host-inbound-filter", noopCloseoutOwner},
+		{"system-login", noopCloseoutOwner},
+		{"sudoers", noopCloseoutOwner},
+		{"absent-login-users", d.reconcileAbsentLoginUsers}, // REAL reconciler
+		{"ssh-config", noopCloseoutOwner},
+		{"root-auth", noopCloseoutOwner},
+	}
+
+	err := summarizeHostAuthCloseout(
+		runHostAuthCloseoutOwners(cfg, hostAuthCloseoutBudget, owners), hostAuthCloseoutBudget)
+	if err == nil {
+		t.Fatal("the host-auth cancel closeout returned CLEAN over an ownership " +
+			"inventory it could not read. The daemon is stopping, so next-boot " +
+			"convergence will NOT happen, and a removed operator's credentials " +
+			"stay live behind a cancel that reported success (#6798)")
+	}
+	if !strings.Contains(err.Error(), "absent-login-users") {
+		t.Errorf("closeout error %q does not attribute the failure to the "+
+			"absent-login-users owner", err)
+	}
+	if !strings.Contains(err.Error(), "read ownership inventory") {
+		t.Errorf("closeout error %q does not carry the unreadable-inventory "+
+			"reason; the operator is left to guess which of the owner's failure "+
+			"modes fired", err)
+	}
+
+	// Control: a fully READABLE (absent) inventory over the SAME owner set must
+	// be clean. Without this, an owner failing for an environmental reason would
+	// satisfy the assertion above and the cell would pass proving nothing.
+	//
+	// The control needs a fresh PARENT, not just a fresh leaf: the three roots
+	// are siblings computed from filepath.Dir(provisionedUsersDir), so pointing
+	// provisionedUsersDir at a sibling of the broken tree would still resolve
+	// provisionedKeysDir() to the same unreadable file and the control would
+	// red for the fixture's reason rather than the code's.
+	provisionedUsersDir = filepath.Join(dir, "fresh", "provisioned-users")
+	if err := summarizeHostAuthCloseout(
+		runHostAuthCloseoutOwners(cfg, hostAuthCloseoutBudget, owners), hostAuthCloseoutBudget); err != nil {
+		t.Fatalf("closeout returned %v over a readable (fresh-install) inventory, "+
+			"want nil — a fresh install must not fail the cancel", err)
+	}
+}
+
+// TestUnreadableInventoryErrorDoesNotSkipPeerSync_6798 binds the COMPOSITION
+// with #6790, which neither lane could see from its own diff.
+//
+// #6798 adds no commit-time gate of its own. What makes these errors
+// commit-failing is #6790: applyTailReconciles now CAPTURES the five
+// host-credential returns instead of discarding them (`_ = d.reconcileSudoers`).
+// So the #1960 no-brick argument cannot rest on "the caller discards the
+// return" — that premise died the moment #6790 merged. It rests instead on the
+// SHAPE OF THE REJECTION SET: applyErrSkipsPeerSync closes it over exactly two
+// fatal classes, a required-protocol-gate error (dataplane disarmed) and a
+// context cancel/deadline from a daemon-stop abort. Every other error still
+// syncs with the config committed, active, and the dataplane armed.
+//
+// The error here is the REAL one the production path produces, not a synthetic
+// stand-in: a synthetic errors.New would prove only that applyErrSkipsPeerSync
+// rejects strings, while the actual question is what os.ReadDir's ENOTDIR
+// becomes after provisionedNames wraps it and reconcileAbsentLoginUsers joins
+// it.
+//
+// The two positive controls are load-bearing. Without them a mutation making
+// applyErrSkipsPeerSync `return false` unconditionally would satisfy the main
+// assertion vacuously — and that mutation is precisely the one that WOULD
+// brick, by pushing a dataplane-disarming config to the standby.
+//
+// FAIL-ON-REVERT: this cell reds if applyErrSkipsPeerSync is ever widened to
+// swallow a generic subsystem error (main assertion) or narrowed so a real
+// fatal class stops skipping (controls).
+func TestUnreadableInventoryErrorDoesNotSkipPeerSync_6798(t *testing.T) {
+	dir := t.TempDir()
+	orig := provisionedUsersDir
+	provisionedUsersDir = filepath.Join(dir, "provisioned-users")
+	t.Cleanup(func() { provisionedUsersDir = orig })
+	unreadableRootDir(t, provisionedKeysDir())
+
+	d := &Daemon{}
+	err := d.reconcileAbsentLoginUsers(loginCfg())
+	if err == nil {
+		t.Fatal("fixture is inert: the unreadable inventory produced no error, so " +
+			"this cell would assert nothing about the real error class")
+	}
+
+	if applyErrSkipsPeerSync(err) {
+		t.Fatalf("an unreadable-inventory failure (%v) is classified as a "+
+			"peer-sync-skipping FATAL error. It is neither a required-protocol-gate "+
+			"error nor a daemon-stop abort, so the config is committed, active and "+
+			"the dataplane armed — refusing to sync it would strand the peer on a "+
+			"stale config over a filesystem read hiccup (#1960 no-brick, #6798 x #6790)", err)
+	}
+
+	// Controls: the two classes that MUST still skip. Without these the
+	// assertion above is satisfied by an applyErrSkipsPeerSync that returns
+	// false for everything — the mutation that would actually brick.
+	if !applyErrSkipsPeerSync(context.Canceled) {
+		t.Error("context.Canceled no longer skips peer sync; a daemon-stop abort " +
+			"would push a half-applied config at the peer")
+	}
+	if !applyErrSkipsPeerSync(context.DeadlineExceeded) {
+		t.Error("context.DeadlineExceeded no longer skips peer sync")
+	}
+}

--- a/pkg/daemon/login_marker_overclaim_6797_test.go
+++ b/pkg/daemon/login_marker_overclaim_6797_test.go
@@ -65,7 +65,7 @@ func TestFailedKeyWriteDoesNotClaimOperatorKeys_6797(t *testing.T) {
 		SSHKeys: []string{"ssh-ed25519 AAAA carol-from-config"},
 	}))
 
-	if keyProvisioned("carol", 1003) {
+	if ownedKey(t, "carol", 1003) {
 		t.Fatalf("a FAILED authorized_keys write left a key-ownership marker "+
 			"(%s). xpf now claims a key file it never wrote, and the emptied-key "+
 			"reconcile will delete the operator's own (#6797)",
@@ -122,7 +122,7 @@ func TestPreExistingKeyClaimSurvivesAFailedRewrite_6797(t *testing.T) {
 	if err := os.WriteFile(keysFile, []byte("ssh-ed25519 AAAA dave-from-xpf\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if !keyProvisioned("dave", 1004) {
+	if !ownedKey(t, "dave", 1004) {
 		t.Fatal("test setup: dave should start with a genuine key claim")
 	}
 
@@ -136,7 +136,7 @@ func TestPreExistingKeyClaimSurvivesAFailedRewrite_6797(t *testing.T) {
 		SSHKeys: []string{"ssh-ed25519 AAAA dave-rotated"},
 	}))
 
-	if !keyProvisioned("dave", 1004) {
+	if !ownedKey(t, "dave", 1004) {
 		t.Fatal("a failed REWRITE withdrew a key claim an earlier apply " +
 			"legitimately made; xpf can no longer revoke a key file it owns — " +
 			"the #5841 underclaim, reintroduced (#6797)")
@@ -154,14 +154,14 @@ func TestOwnershipClaimRollbackSemantics_6797(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !hasProvenanceMarker(dir, "erin", 1005) {
+	if !ownedMarker(t, dir, "erin", 1005) {
 		t.Fatal("claimOwnership did not write the marker")
 	}
 	if fresh.preExisting {
 		t.Error("a first-time claim must not report preExisting")
 	}
 	fresh.rollback()
-	if hasProvenanceMarker(dir, "erin", 1005) {
+	if ownedMarker(t, dir, "erin", 1005) {
 		t.Error("rollback did not withdraw a claim created by this pass")
 	}
 
@@ -177,7 +177,7 @@ func TestOwnershipClaimRollbackSemantics_6797(t *testing.T) {
 		t.Error("a re-claim of an already-owned credential must report preExisting")
 	}
 	again.rollback()
-	if !hasProvenanceMarker(dir, "frank", 1006) {
+	if !ownedMarker(t, dir, "frank", 1006) {
 		t.Error("rollback withdrew a pre-existing claim; that orphans a " +
 			"credential xpf really owns (#5841 underclaim)")
 	}
@@ -195,7 +195,7 @@ func TestOwnershipClaimRollbackSemantics_6797(t *testing.T) {
 		t.Error("a marker for a different UID must not count as prior ownership")
 	}
 	stale.rollback()
-	if hasProvenanceMarker(dir, "gina", 1007) {
+	if ownedMarker(t, dir, "gina", 1007) {
 		t.Error("rollback did not withdraw a claim over a UID-mismatched marker")
 	}
 }
@@ -231,7 +231,7 @@ func TestFailedKeyFileWriteDoesNotClaim_6797(t *testing.T) {
 		SSHKeys: []string{"ssh-ed25519 AAAA helen-from-config"},
 	}))
 
-	if keyProvisioned("helen", 1008) {
+	if ownedKey(t, "helen", 1008) {
 		t.Fatalf("a FAILED authorized_keys WRITE left a key-ownership marker; " +
 			"the mkdir-failure rollback is not enough on its own (#6797)")
 	}
@@ -258,7 +258,7 @@ func TestFailedRootKeyWriteDoesNotClaim_6797(t *testing.T) {
 	d := &Daemon{}
 	_ = d.applyRootAuth(rootAuthCfg("", "ssh-ed25519 AAAAROOT root@host"))
 
-	if keyProvisioned("root", 0) {
+	if ownedKey(t, "root", 0) {
 		t.Fatalf("a FAILED root authorized_keys write left a key-ownership " +
 			"marker; a later empty key list would then remove root's key file " +
 			"— including an operator-installed one (#6797)")
@@ -301,12 +301,12 @@ func TestFailedChpasswdDoesNotClaimPassword_6797(t *testing.T) {
 		EncryptedPassword: config.Secret("$6$salt$xpfhash"),
 	}))
 
-	if passwordProvisioned("ivan", 1009) {
+	if ownedPassword(t, "ivan", 1009) {
 		t.Errorf("a FAILED chpasswd left a password-ownership marker; removing " +
 			"the directive later would LOCK an account whose password xpf " +
 			"never set (#6797)")
 	}
-	if xpfProvisioned("ivan", 1009) {
+	if ownedAccount(t, "ivan", 1009) {
 		t.Errorf("a FAILED chpasswd left an account-registry marker; xpf claims " +
 			"to manage an account it never provisioned (#6797)")
 	}
@@ -335,7 +335,7 @@ func TestPreExistingPasswordClaimSurvivesAFailedChpasswd_6797(t *testing.T) {
 		EncryptedPassword: config.Secret("$6$salt$rotated"),
 	}))
 
-	if !passwordProvisioned("judy", 1010) {
+	if !ownedPassword(t, "judy", 1010) {
 		t.Error("a failed password ROTATION withdrew a claim an earlier apply " +
 			"legitimately made; xpf can no longer lock a password it set — the " +
 			"#5841 underclaim, reintroduced (#6797)")
@@ -358,11 +358,11 @@ func TestFailedRootSSHDirDoesNotClaim_6797(t *testing.T) {
 	d := &Daemon{}
 	_ = d.applyRootAuth(rootAuthCfg("", "ssh-ed25519 AAAAROOT root@host"))
 
-	if keyProvisioned("root", 0) {
+	if ownedKey(t, "root", 0) {
 		t.Errorf("a FAILED /root/.ssh creation left a root key-ownership " +
 			"marker (#6797)")
 	}
-	if xpfProvisioned("root", 0) {
+	if ownedAccount(t, "root", 0) {
 		t.Errorf("a FAILED /root/.ssh creation left a root account-registry " +
 			"marker (#6797)")
 	}
@@ -393,7 +393,7 @@ func TestAccountMarkerFailureWithdrawsThePasswordClaim_6797(t *testing.T) {
 		EncryptedPassword: config.Secret("$6$salt$xpfhash"),
 	}))
 
-	if passwordProvisioned("karl", 1011) {
+	if ownedPassword(t, "karl", 1011) {
 		t.Errorf("the password claim survived an aborted apply: the account " +
 			"marker could not be written, so chpasswd never ran, yet xpf still " +
 			"claims to own this password (#6797)")

--- a/pkg/daemon/login_password.go
+++ b/pkg/daemon/login_password.go
@@ -264,30 +264,50 @@ func writeProvenanceMarker(dir, name string, uid int) error {
 	return fsatomic.WriteFileDurable(markerPathIn(dir, name), []byte(strconv.Itoa(uid)), 0o600)
 }
 
-// hasProvenanceMarker reports whether dir records name as xpf-owned for the
-// account that currently has UID curUID. It returns true ONLY if the marker
+// readProvenanceMarker reports whether dir records name as xpf-owned for the
+// account that currently has UID curUID. It reports true ONLY if the marker
 // exists AND its recorded UID equals curUID. A marker whose UID no longer
 // matches (account deleted/recreated out of band with a different UID) or is
 // corrupt is opportunistically removed — no separate GC pass — and reports
 // false, so a revoke decision never touches an out-of-band account. #1944 §5.4.
-func hasProvenanceMarker(dir, name string, curUID int) bool {
+//
+// #6798: it carries the ABSENT/UNREADABLE distinction a bare bool cannot. It
+// replaced a bool-only hasProvenanceMarker that collapsed EVERY os.ReadFile
+// error — ENOENT, EACCES, EIO, ENOTDIR — into the same `false`. A genuinely
+// ABSENT marker proves the resource is not xpf's (owned false, err nil); an
+// UNREADABLE one proves NOTHING, yet produced the identical `false`, and every
+// revocation gate read that false as "not ours, skip". The credential then
+// survived a deprovision that reported success.
+//
+// The returned ownership stays FALSE on a read error, deliberately: the caller
+// must not revoke a credential it cannot prove it owns — that is #6797's
+// overclaim from the other direction. What changes is that the caller can now
+// tell "proven not ours" from "could not tell" and report the latter instead of
+// converging on it. There is deliberately NO bool-only wrapper: one would
+// reintroduce the exact collapse this closes.
+func readProvenanceMarker(dir, name string, curUID int) (bool, error) {
 	path := markerPathIn(dir, name)
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return false
+		if os.IsNotExist(err) {
+			return false, nil // genuinely not ours
+		}
+		return false, fmt.Errorf("read ownership marker %s: %w", path, err)
 	}
 	recorded, err := strconv.Atoi(strings.TrimSpace(string(data)))
 	if err != nil {
-		// Corrupt marker — treat as not-ours and clean it up.
+		// Corrupt marker — treat as not-ours and clean it up. This IS a
+		// determination (the bytes were read; they are not a UID), so it is not
+		// an unreadable-inventory error.
 		_ = os.Remove(path)
-		return false
+		return false, nil
 	}
 	if recorded != curUID {
 		// Stale marker for a different (recreated) account: clean inline.
 		_ = os.Remove(path)
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }
 
 // ownershipClaim records a marker-first ownership claim so a FAILED credential
@@ -323,10 +343,26 @@ type ownershipClaim struct {
 // rolled back. The write error is returned unchanged so every existing
 // fail-visible caller keeps its behaviour.
 func claimOwnership(dir, name string, uid int) (ownershipClaim, error) {
-	// hasProvenanceMarker's inline cleanup of a mismatched/corrupt marker is
+	// readProvenanceMarker's inline cleanup of a mismatched/corrupt marker is
 	// harmless here: such a marker is not this account's prior ownership, so
 	// preExisting=false is the correct reading and the write below replaces it.
-	c := ownershipClaim{dir: dir, name: name, preExisting: hasProvenanceMarker(dir, name, uid)}
+	//
+	// #6798: an UNREADABLE marker is treated as PRE-EXISTING, not absent. The
+	// only thing preExisting gates is rollback(), which REMOVES the marker —
+	// i.e. it releases ownership. "Only proven absence may release ownership
+	// work": if we cannot read the marker we cannot prove xpf did not already
+	// own this credential, and withdrawing a real marker orphans a live
+	// credential xpf can then never lock or revoke (the #5841 underclaim).
+	// Erring toward preExisting=true costs at most a stale marker, which the
+	// next apply re-reads and reconciles.
+	owned, readErr := readProvenanceMarker(dir, name, uid)
+	if readErr != nil {
+		slog.Warn("cannot read ownership marker before claiming it; treating "+
+			"as pre-existing so a failed mutation does not withdraw a claim "+
+			"xpf may already hold", "dir", dir, "name", name, "err", readErr)
+		owned = true
+	}
+	c := ownershipClaim{dir: dir, name: name, preExisting: owned}
 	return c, writeProvenanceMarker(dir, name, uid)
 }
 
@@ -383,8 +419,8 @@ func markProvisioned(name string, uid int) error {
 // xpfProvisioned reports whether the account registry records name for UID
 // curUID (marker present AND UID matches; a mismatch/corrupt marker is cleaned
 // inline). #1944 §5.4.
-func xpfProvisioned(name string, curUID int) bool {
-	return hasProvenanceMarker(provisionedUsersDir, name, curUID)
+func xpfProvisioned(name string, curUID int) (bool, error) {
+	return readProvenanceMarker(provisionedUsersDir, name, curUID)
 }
 
 // --- password-ownership marker (xpf set the /etc/shadow password) ----------
@@ -402,8 +438,8 @@ func markPasswordProvisioned(name string, uid int) error {
 
 // passwordProvisioned reports whether xpf set name's password for UID curUID.
 // #5841.
-func passwordProvisioned(name string, curUID int) bool {
-	return hasProvenanceMarker(provisionedPasswordsDir(), name, curUID)
+func passwordProvisioned(name string, curUID int) (bool, error) {
+	return readProvenanceMarker(provisionedPasswordsDir(), name, curUID)
 }
 
 // --- SSH-key-ownership marker (xpf wrote authorized_keys) ------------------
@@ -422,8 +458,8 @@ func markKeyProvisioned(name string, uid int) error {
 
 // keyProvisioned reports whether xpf wrote name's authorized_keys for UID
 // curUID. #5841.
-func keyProvisioned(name string, curUID int) bool {
-	return hasProvenanceMarker(provisionedKeysDir(), name, curUID)
+func keyProvisioned(name string, curUID int) (bool, error) {
+	return readProvenanceMarker(provisionedKeysDir(), name, curUID)
 }
 
 // provisionedNames returns the UNION of account names that appear in any of the
@@ -431,12 +467,25 @@ func keyProvisioned(name string, curUID int) bool {
 // for. reconcileAbsentLoginUsers deprovisions each name in this set that is no
 // longer in config, so a pre-existing account xpf only added an SSH key to
 // (key marker, no account registry entry) is still revoked when removed. #5841.
-func provisionedNames() map[string]struct{} {
+func provisionedNames() (map[string]struct{}, error) {
+	var readErr error
 	out := make(map[string]struct{})
 	for _, dir := range []string{provisionedUsersDir, provisionedPasswordsDir(), provisionedKeysDir()} {
 		entries, err := os.ReadDir(dir)
 		if err != nil {
-			continue // absent/unreadable root contributes no names
+			// #6798: an ABSENT root is legitimately empty — a fresh install has
+			// provisioned nothing, so it contributes no names and that is a
+			// determination. An UNREADABLE root contributes no names either,
+			// but that is not the same fact: the inventory is INCOMPLETE, and
+			// silently truncating it makes the revocation sweep skip accounts
+			// whose only marker lived there. Report it; keep sweeping the roots
+			// that DO read, because revoking what we can see is strictly better
+			// than revoking nothing.
+			if !os.IsNotExist(err) {
+				readErr = errors.Join(readErr, fmt.Errorf(
+					"read ownership inventory %s: %w", dir, err))
+			}
+			continue
 		}
 		for _, e := range entries {
 			if e.IsDir() {
@@ -445,7 +494,7 @@ func provisionedNames() map[string]struct{} {
 			out[e.Name()] = struct{}{}
 		}
 	}
-	return out
+	return out, readErr
 }
 
 // homeBaseDir is the parent directory of per-user home directories. It is a
@@ -506,11 +555,18 @@ func managedAuthorizedKeysPath(name string) string {
 // password and authorized_keys are still live is the exact failure this
 // reconciler exists to prevent, and nothing retries before the next boot.
 func (d *Daemon) reconcileAbsentLoginUsers(cfg *config.Config) (retErr error) {
-	names := provisionedNames()
-	if len(names) == 0 {
-		// No markers yet (fresh install) or unreadable — nothing xpf
-		// provisioned, so nothing to revoke.
-		return nil
+	// #6798: an unreadable inventory root is NOT "nothing provisioned". The
+	// previous form collapsed both into len(names)==0 and returned nil —
+	// SUCCESS — so a removed operator kept their password and authorized_keys
+	// while the reconcile reported convergence, and the #5874 closeout (which
+	// exists to catch exactly this class) saw nothing to report. Surface the
+	// read failure and still revoke every account the readable roots DID name.
+	names, invErr := provisionedNames()
+	if invErr != nil {
+		slog.Error("ownership inventory could not be fully read; a removed "+
+			"account's credentials may NOT have been revoked",
+			"err", invErr)
+		retErr = errors.Join(retErr, invErr)
 	}
 
 	// The set of usernames still declared in config; these are kept.
@@ -583,9 +639,23 @@ func (d *Daemon) deprovisionLoginUser(name string) (retErr error) {
 	// Resolve per-resource ownership for the account CURRENTLY at curUID. Each
 	// check cleans a UID-mismatched/corrupt marker inline (out-of-band
 	// recreate), so a false here also means "not ours".
-	ownsPassword := passwordProvisioned(name, curUID)
-	ownsKey := keyProvisioned(name, curUID)
-	ownsAccount := xpfProvisioned(name, curUID)
+	ownsPassword, pwErr := passwordProvisioned(name, curUID)
+	ownsKey, keyErr := keyProvisioned(name, curUID)
+	ownsAccount, acctErr := xpfProvisioned(name, curUID)
+	if ownErr := errors.Join(pwErr, keyErr, acctErr); ownErr != nil {
+		// #6798: a marker that could not be READ proves nothing. Before this,
+		// all three reads failing produced three falses, matched the
+		// "nothing owned" branch below, and returned nil — SUCCESS — leaving
+		// the removed account's password and authorized_keys live. Keep the
+		// markers (so the next apply retries) and report, WITHOUT revoking:
+		// acting on unproven ownership is #6797's overclaim from the other
+		// side.
+		slog.Error("cannot determine credential ownership for a removed login "+
+			"user; NOT revoking, and NOT reporting convergence",
+			"user", name, "err", ownErr)
+		fail(fmt.Errorf("determine ownership for removed user %s: %w", name, ownErr))
+		return retErr
+	}
 	if !ownsPassword && !ownsKey && !ownsAccount {
 		// Nothing xpf-owned for the current account (markers absent, or a UID
 		// mismatch already cleaned inline). NEVER touch a non-xpf / out-of-band

--- a/pkg/daemon/login_password_test.go
+++ b/pkg/daemon/login_password_test.go
@@ -8,6 +8,40 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 )
 
+// ownedMarker/ownedAccount/ownedPassword/ownedKey adapt the #6798 (bool, error)
+// marker readers for tests that assert ownership in a boolean context.
+//
+// They deliberately FAIL the test on a read error instead of returning false.
+// Every one of these call sites is asserting a DETERMINATION — "the marker is
+// genuinely absent" or "the marker is genuinely ours" — and a reader that
+// silently reported an unreadable marker as `false` is precisely the collapse
+// #6798 closes. A test helper that repeated it would let a fixture whose marker
+// root became unreadable pass while proving nothing.
+func ownedMarker(t *testing.T, dir, name string, curUID int) bool {
+	t.Helper()
+	owned, err := readProvenanceMarker(dir, name, curUID)
+	if err != nil {
+		t.Fatalf("readProvenanceMarker(%s, %s, %d): unexpected read error, so "+
+			"this assertion proves nothing: %v", dir, name, curUID, err)
+	}
+	return owned
+}
+
+func ownedAccount(t *testing.T, name string, curUID int) bool {
+	t.Helper()
+	return ownedMarker(t, provisionedUsersDir, name, curUID)
+}
+
+func ownedPassword(t *testing.T, name string, curUID int) bool {
+	t.Helper()
+	return ownedMarker(t, provisionedPasswordsDir(), name, curUID)
+}
+
+func ownedKey(t *testing.T, name string, curUID int) bool {
+	t.Helper()
+	return ownedMarker(t, provisionedKeysDir(), name, curUID)
+}
+
 // TestPasswordAction is the central #1944 safety-invariant table test
 // (§7.6): fail-OPEN toward applying a real password, fail-CLOSED (noop) on
 // a read error in the lock branch so a transient /etc/shadow read failure
@@ -71,16 +105,16 @@ func TestProvenanceMarkerUIDKeyed(t *testing.T) {
 	t.Cleanup(func() { provisionedUsersDir = old })
 
 	// No marker → not provisioned.
-	if xpfProvisioned("op", 1001) {
-		t.Error("xpfProvisioned with no marker = true, want false")
+	if ownedAccount(t, "op", 1001) {
+		t.Error("account marker with no marker = true, want false")
 	}
 
 	// markProvisioned then matching UID → provisioned.
 	if err := markProvisioned("op", 1001); err != nil {
 		t.Fatalf("markProvisioned: %v", err)
 	}
-	if !xpfProvisioned("op", 1001) {
-		t.Error("xpfProvisioned(op,1001) = false after mark, want true")
+	if !ownedAccount(t, "op", 1001) {
+		t.Error("account marker for (op,1001) = false after mark, want true")
 	}
 
 	// Re-mark with same UID then UID mismatch (out-of-band recreate with a
@@ -88,8 +122,8 @@ func TestProvenanceMarkerUIDKeyed(t *testing.T) {
 	if err := markProvisioned("op", 1001); err != nil {
 		t.Fatalf("markProvisioned: %v", err)
 	}
-	if xpfProvisioned("op", 2002) {
-		t.Error("xpfProvisioned(op,2002) on UID mismatch = true, want false")
+	if ownedAccount(t, "op", 2002) {
+		t.Error("account marker for (op,2002) on UID mismatch = true, want false")
 	}
 	if _, err := os.Stat(markerPath("op")); !os.IsNotExist(err) {
 		t.Error("stale marker not removed on UID mismatch")
@@ -99,16 +133,16 @@ func TestProvenanceMarkerUIDKeyed(t *testing.T) {
 	if err := markProvisioned("op", 1001); err != nil {
 		t.Fatalf("markProvisioned: %v", err)
 	}
-	if !xpfProvisioned("op", 1001) {
-		t.Error("xpfProvisioned(op,1001) on rejoin = false, want true")
+	if !ownedAccount(t, "op", 1001) {
+		t.Error("account marker for (op,1001) on rejoin = false, want true")
 	}
 
 	// Corrupt marker → not provisioned, cleaned.
 	if err := os.WriteFile(markerPath("op"), []byte("not-a-number"), 0o600); err != nil {
 		t.Fatalf("write corrupt marker: %v", err)
 	}
-	if xpfProvisioned("op", 1001) {
-		t.Error("xpfProvisioned with corrupt marker = true, want false")
+	if ownedAccount(t, "op", 1001) {
+		t.Error("account marker with corrupt marker = true, want false")
 	}
 	if _, err := os.Stat(markerPath("op")); !os.IsNotExist(err) {
 		t.Error("corrupt marker not removed")

--- a/pkg/daemon/login_resource_ownership_5841_test.go
+++ b/pkg/daemon/login_resource_ownership_5841_test.go
@@ -39,7 +39,7 @@ func TestApplySystemLoginPasswordOnlyDoesNotClaimSSHKey(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Prove the key marker is genuinely absent for the setup.
-	if keyProvisioned("bob", 1002) {
+	if ownedKey(t, "bob", 1002) {
 		t.Fatal("test setup wrote a key marker for bob; the overclaim guard needs it absent")
 	}
 


### PR DESCRIPTION
## Problem

Credential revocation answered *"did xpf provision this?"* with a value that
could not distinguish **"no"** from **"could not tell"**, and every revocation
gate read the ambiguous value as *"not ours, skip"*.

Three reads collapsed the two cases (all four sites named in R58):

| Site | Absent (a determination) | Unreadable (proves nothing) | Collapsed to |
|---|---|---|---|
| `hasProvenanceMarker` (`login_password.go`) | `ENOENT` — not ours | `EACCES`/`EIO`/`EISDIR` | `false` |
| `provisionedNames` (`login_password.go`) | `ENOENT` — nothing provisioned | `EACCES`/`ENOTDIR` | no names |
| `reconcileSudoers` (`daemon_system.go`) | `ENOENT` — no grants exist | `EACCES`/`ENOTDIR` | `entries, _ :=` |

Downstream, each gate skipped its revocation and the reconcile returned `nil` —
**SUCCESS** — while a removed administrator's password, `authorized_keys`, and
passwordless sudo grant were still live on disk. The #5874 cancellation
closeout, which exists to observe exactly this monotonic-revocation gap, saw
nothing to report.

`reconcileAbsentLoginUsers` had the worst shape:

```go
names := provisionedNames()
if len(names) == 0 {
    return nil   // "nothing was ever provisioned, nothing to revoke"
}
```

An inventory that was *entirely unreadable* yields no names — bit-identical to a
fresh install.

Re-derived against `origin/master` before fixing: all four sites still present.

## Fix

The governing invariant is now **only proven absence may release ownership work.**

- `readProvenanceMarker` returns `(bool, error)`; only `ENOENT` is absence. A UID
  mismatch or corrupt marker stays a *determination* (the bytes were read, they
  simply are not this account's) and is still cleaned inline.
- `provisionedNames` returns its read errors **while still contributing the roots
  that did read** — revoking what we can see beats revoking nothing, and the
  error carries the debt.
- `reconcileSudoers` accumulates a non-`ENOENT` `ReadDir` failure.
- **Report without revoking.** Acting on a marker xpf cannot read is #6797's
  overclaim from the other side, and for root's `authorized_keys` it is a total
  lockout. Each gate leaves the credential untouched *and* declines to converge.
- **Markers are retained.** Dropping one on an unreadable read is *permanent*
  abandonment — the account stops being enumerated once the root reads again.
  Same three-state discipline #5493 applied to an unreadable `/etc/passwd`.
- `claimOwnership` treats an unreadable marker as **pre-existing**. `preExisting`
  gates only `rollback()`, which *removes* the marker and so releases ownership;
  withdrawing a claim that may be genuine orphans a live credential xpf can never
  revoke (the #5841 underclaim).
- `hasProvenanceMarker` is **deleted, not wrapped** — leaving an error-discarding
  twin beside the fixed reader is how this class regresses. Test call sites moved
  to helpers that `t.Fatal` on a read error rather than returning `false`.

### Caught in review

`reconcileSudoers` has a **named return** `err`, so a function-scope
`entries, err := os.ReadDir(...)` would *assign* to it rather than shadow it — a
host with no `/etc/sudoers.d` would then report a bogus `ENOENT` failure on every
apply, forever. Uses `readErr`.

## Test plan

- [x] `go build ./...` — rc=0
- [x] `go test -count=1 ./...` repo-wide — **rc=0**, 67 packages ok, 0 FAIL, at
      `5705bdb99130e6e977499f1f99b4102fc7fc1b09` (parent `origin/master`
      `ba8ba3329`, post-#6790/#6801/#6816; `merge-base --is-ancestor` rc=0).
      Includes the new `pkg/refactoraudit` `_Log.md` gates — 4 collected, pass.
- [x] **Full 14-cell mutation matrix re-run at the composed (post-#6790) head** —
      14/14 RED, 2046 tests collected per cell
- [x] 9 forward mutation cells, one per production line changed — 9/9 RED
- [x] 3 paired controls (degenerate "always error") — 3/3 RED
- [x] End-to-end closeout cell — RED on reverting either M3 or M4
- [x] `gofmt -l` clean on every touched file
- [ ] `make test-deploy` (standalone) + ping between zones — **NOT RUN**, see below
- [ ] `make cluster-deploy` + iperf3 — **NOT RUN**, see below
- [ ] Codex hostile code review (`MERGE YES`) — **not run**; parent owns the review round
- [ ] Copilot inline review — none posted as of this push

No Rust touched (`userspace-dp/`, `userspace-xdp/` untouched), so no cargo leg
is owed.

### Deploy validation not run — explicit disposition

`docs/engineering-style.md` step 8 nominally asks for a standalone deploy + a
cluster deploy on **any** change. Neither was run here, and per that section's
own rule I am stating it rather than claiming a check that was not executed.

Reason the risk is low, and what would actually exercise it:

- The diff touches no forwarding, dataplane, cluster, VRRP, session-sync, or
  fabric code — it is confined to the host-credential reconcile path in
  `pkg/daemon`. Zone-to-zone ping and iperf3 throughput cannot observe it.
- The behaviour change is reachable only when an ownership marker or inventory
  root is genuinely **unreadable** (EACCES/EIO/EISDIR/ENOTDIR). A healthy test
  VM has readable marker roots, so a deploy would exercise only the unchanged
  ENOENT/present paths — which the paired controls already pin.
- The one lane that *would* be meaningful is a fault-injected deploy: chmod the
  marker roots unreadable on a live box, remove a configured login user, commit,
  then trigger a daemon-stop cancel and confirm the cancel fails visibly naming
  `absent-login-users`. That needs a VM and root; happy to run it if wanted.

### Mutation matrix — 9 cells, one per production line changed

Every cell: revert exactly that one line, full-package `go test -count=1` with
**no `-run` filter**. All 2004 tests collected in each cell (so each RED is a
genuine assertion failure, not a build break).

| Cell | Expected RED | Verdict |
|---|---|---|
| M1 `readProvenanceMarker` ENOENT split | `TestReadProvenanceMarkerSeparatesAbsentFromUnreadable_6798` | **RED** |
| M2 `claimOwnership` unreadable⇒preExisting | `TestClaimOwnershipTreatsUnreadableMarkerAsPreExisting_6798` | **RED** |
| M3 `provisionedNames` ReadDir error | `TestProvisionedNamesReportsUnreadableRoot_6798` | **RED** |
| M4 `reconcileAbsentLoginUsers` invErr | `TestReconcileAbsentLoginUsersReportsUnreadableInventory_6798` | **RED** |
| M5 `deprovisionLoginUser` ownErr gate | `TestDeprovisionUnreadableOwnershipDoesNotConverge_6798` | **RED** |
| M6 `applySystemLogin` emptied-key ownErr | `TestEmptiedKeyListUnreadableMarkerDoesNotConverge_6798` | **RED** |
| M7 `reconcileUserPassword` pwLock ownErr | `TestPasswordLockUnreadableMarkerDoesNotConverge_6798` | **RED** |
| M8 `applyRootAuth` rootOwnErr arm | `TestRootKeyRevokeUnreadableMarkerDoesNotConverge_6798` | **RED** |
| M9 `reconcileSudoers` ReadDir error | `TestReconcileSudoersReportsUnreadableDir_6798` | **RED** |

**9/9 RED** (re-run at the composed head: 2046 tests collected per cell).

### End-to-end: the error must reach the closeout

The nine cells prove each reconciler *returns* an error — only half of R58's
invariant, which is *"retain debt and **prevent a successful closeout**"*. On
the normal apply path all four returns are deliberately discarded
(`_ = d.reconcileSudoers(cfg)` in `applyTailReconciles`, the #2926 next-boot
convergence contract). The single consumer is the **#5874/M35 daemon-stop
cancel closeout** — exactly the case where next-boot convergence does *not*
happen. Nothing bound that end to end, so the fix could have reported into a
void at the one site R58 names.

`TestHostAuthCloseoutSurfacesUnreadableInventory_6798` drives the **real**
`reconcileAbsentLoginUsers` through `runHostAuthCloseoutOwners` +
`summarizeHostAuthCloseout` with the other six owners stubbed to no-ops, so a
green cannot come from an unrelated owner failing, and asserts the cancel error
names **both** the owner (`absent-login-users`) and the reason
(`read ownership inventory`).

| Cell | Expected RED | Verdict |
|---|---|---|
| M3 reverted | `TestHostAuthCloseoutSurfacesUnreadableInventory_6798` | **RED** (2005 ran) |
| M4 reverted | `TestHostAuthCloseoutSurfacesUnreadableInventory_6798` | **RED** (2005 ran) |

Its control caught a real fixture bug: the three marker roots are **siblings**
derived from `filepath.Dir(provisionedUsersDir)`, so the control's first form
still resolved `provisionedKeysDir()` to the same unreadable file and redded for
the fixture's reason. It needs a fresh *parent*, not a fresh leaf.

### Paired controls — the fix is necessary AND sufficient

The forward matrix alone is satisfied by a degenerate fix that errors on *every*
read, which would make a fresh install fail its reconcile forever. These cells
delete the `os.IsNotExist` half so `ENOENT` is reported too; the **absent**
controls must red:

| Control | Expected RED | Verdict |
|---|---|---|
| C1 `readProvenanceMarker` errors on ENOENT too | `...SeparatesAbsentFromUnreadable_6798` (absent row) | **RED** |
| C2 `provisionedNames` accumulates ENOENT too | `.../all_roots_absent_is_a_clean_determination` | **RED** |
| C3 `reconcileSudoers` reports ENOENT too | `.../absent_sudoers_dir_is_a_clean_determination` | **RED** |

**3/3 RED.**

### Fixture soundness

Unreadability is staged as **EISDIR** (marker path is a directory) and **ENOTDIR**
(root path is a file), never `chmod 000` — the suite may run as root, where
permission bits are bypassed and the fixture would silently become readable, i.e.
a false green. Both helpers assert the fixture genuinely errors *and* is not an
`ENOENT`, so no assertion built on them is vacuous. The
`reconcileAbsentLoginUsers` fixture deliberately keeps the readable roots absent
so the name set really is empty — the exact shape the old early return converged
on; a fixture with any readable name would not enter it.

## Scope / contracts

- Diff is scoped to the revocation + inventory-read path. It touches
  `daemon_system.go`, which overlaps #6790's lane, but only in
  `applySystemLogin`'s emptied-key branch, `reconcileUserPassword`'s `pwLock`
  branch, `applyRootAuth`'s revoke arm, and `reconcileSudoers`' revoke sweep.
- **#1960 no-brick — rests on the rejection set, not on the caller.** #6798 adds
  no commit-time gate of its own; what makes these errors commit-failing is
  **#6790 (now merged)**, which captures the five host-credential returns into
  `applyTailReconciles`' `errors.Join`. The guarantee therefore rests on the
  **shape of the rejection set**: `applyErrSkipsPeerSync`
  (`pkg/daemon/daemon_apply_commit.go`) closes it over exactly two fatal classes
  — a required-protocol-gate error (`compileErrorMustAbortApply`, dataplane
  **disarmed**) and a context cancel/deadline from a daemon-stop abort. Its own
  comment: every *other* error still syncs "because the config is committed +
  active and the dataplane armed". An inventory-read failure is neither class,
  so on `syncAndApply` the config stays **active and armed**. No brick, no
  `lenient*` option owed. Verified at source, not assumed.

  Bound by `TestUnreadableInventoryErrorDoesNotSkipPeerSync_6798`, which feeds
  the **real** `reconcileAbsentLoginUsers` error (a synthetic `errors.New` would
  prove only that the classifier rejects strings) and carries two positive
  controls on `context.Canceled`/`DeadlineExceeded` — without them the assertion
  is satisfied by a classifier returning false for everything, which is exactly
  the mutation that *would* brick.

  **#7618 scoped:** that issue records a COMMAND deadline being misclassified as
  a daemon-stop abort. It does not reach what #6798 adds — these errors come
  from `os.ReadFile`/`os.ReadDir` and carry `EACCES`/`EIO`/`EISDIR`/`ENOTDIR`,
  never a `context.DeadlineExceeded`. The reconcilers' *command* failures were
  already in that population before #6798.
- **#6534 checked, does not apply:** that rule governs a snapshot builder
  DROPPING or DISARMING a config object while `show` still renders it as
  enforced. No `show` surface renders credential-ownership state, and this change
  makes a previously *silent* failure *visible* rather than dropping a rendered
  object. Recorded in `docs/system-login.md`.
- Docs updated in the same change (per the CLAUDE.md Required Reading contract):
  `docs/system-login.md` gains "Unreadable ownership inventories are not empty
  ones (#6798)", a "Where the operator sees it" subsection drawing the
  apply-tail (discarded, log-only) vs cancel-closeout (collected, fails the
  cancel) distinction, and a bullet in the deprovision fail-closed list.
  `pkg/daemon/README.md`'s #5874 closeout bullet enumerates which failures the
  closeout collects, and this adds a class, so it gains the #6798 paragraph.
  `_Log.md` appended.

## Note for a separate issue

`_Log.md` on `origin/master` currently contains **unresolved conflict markers**
at lines ~104997–105014 (`<<<<<<< HEAD` / `=======` / `>>>>>>> origin/master`
around the #6797 entry). They are pre-existing and inherited by this branch's
merge; `git diff origin/master...HEAD -- _Log.md` adds **zero** markers. Worth
its own issue rather than an unrelated fix inside a security PR.

Closes #6798
