### PR TITLE
daemon: give a failed host-inbound conntrack revocation a retry owner

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -105068,3 +105068,51 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: `pkg/daemon/rg_state.go`, `pkg/daemon/daemon_ha.go`,
   `pkg/daemon/rg_apply_invalidate_race_6799_test.go`,
   `pkg/daemon/rg_state_test.go`, `pkg/daemon/README.md`, `_Log.md`
+
+## 2026-08-26 — #6802: a retry owner for a failed host-inbound conntrack revocation
+
+- **Timestamp**: 2026-08-26
+- **Action**: Give the #5566 host-inbound kernel-conntrack reconcile a return
+  value, retry debt, a persistent retry owner, and two Prometheus series.
+- **Why**: the flush deletes established kernel conntrack entries for host
+  services the operator has just REMOVED, because those entries would otherwise
+  ride the host-inbound chain's leading `ct state established,related accept`. So
+  a delete failure fails **OPEN** — the now-denied service keeps being served on
+  every existing connection. The in-code rationale for not failing the commit is
+  sound and is retained (the nft table is applied, so new connections are
+  enforced, and rolling the commit back over a transient conntrack error would
+  discard correct enforcement). The defect was that it was not anything ELSE
+  either: no return value, no dirty flag, no counter, no metric, and no ticker
+  re-ran it. Every ticker under `pkg/daemon` was enumerated — DDNS, RPM, HA
+  fabric, HA, IPsec rebind, DHCP lease sync, neighbor, proxy-ARP, archive,
+  kernel self-recover — and none re-drives `applyConfig`,
+  `applyHostInboundFilter` or the flush, so the only re-attempt was the next
+  externally-triggered apply, itself gated on `InstallHostInbound` succeeding.
+- **Shape**: mirrors #6793 / #6791. `flushDeniedHostInboundConntrack` returns a
+  bool; `noteHostInboundConntrackFlush` retains the EXACT failed request as debt
+  (not a set re-derived at retry time — that would attempt a different revocation
+  than the one that failed, and the two diverge precisely when a commit landed in
+  between) and bumps a counter; `hostInboundConntrackReassertLoop` is started
+  unconditionally in `Run` at 30s, takes `applySem` before acting (#4001), and
+  re-reads the debt INSIDE the semaphore because the commit it queued behind may
+  already have flushed successfully. A one-family failure still sweeps the other
+  family; the failure is carried out in the return value rather than swallowed.
+- **Wired, not merely exported**: `HostInboundConntrackRevocationOwed` /
+  `HostInboundConntrackFlushFailures` reach `daemon_run_servers.go` as
+  `xpf_host_inbound_conntrack_revocation_pending` and `…_failures_total`,
+  mirroring the `IPsecRebindPendingFn` (#4899) precedent. An accessor with no
+  production caller is the #6852 shape and would have left the operator exactly
+  as blind as before. Both series are OMITTED rather than published as `0` when
+  unwired (the #6828 absent-vs-zero distinction).
+- **Test gaps this closed**: the pre-existing #5566 stub always returned
+  `(0, nil)`, so no test exercised the delete-ERROR path at all. Added a loop-START
+  cell after #6793 shipped without one — every other cell drives the retry
+  function directly, so a `Run` that never launched the owner passes all of them.
+- **File(s)**: `pkg/daemon/host_inbound_conntrack_flush.go`,
+  `pkg/daemon/daemon.go`, `pkg/daemon/daemon_nft.go`,
+  `pkg/daemon/daemon_run.go`, `pkg/daemon/daemon_run_servers.go`,
+  `pkg/api/metrics.go`, `pkg/api/metrics_descriptors_controlplane.go`,
+  `pkg/api/server.go`,
+  `pkg/daemon/host_inbound_conntrack_retry_6802_test.go`,
+  `pkg/api/metrics_hostinbound_conntrack_revoke_6802_test.go`,
+  `pkg/daemon/README.md`, `docs/host-inbound-service-matrix.md`, `_Log.md`

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -577,16 +577,69 @@ catch-all instead of short-circuiting on the established-accept. Properties:
 - **Global exemptions preserved.** ESP/AH (proto 50/51), ICMP ND/PMTUD/error, and
   the configured WireGuard listen port (#5582) are never flushed, mirroring the
   chain's global accepts. ICMP echo conntrack is short-lived and left to age out.
-- **Best effort.** The nft table is already applied, so enforcement for NEW
-  connections holds regardless; a conntrack-subsystem flush failure is logged, not
-  surfaced as a commit failure (failing the commit would roll back correct
-  enforcement over a transient error). It only leaves PRE-EXISTING flows on their
-  old authorization — the pre-fix behavior.
+- **Not a commit failure — but it IS retried and IS visible (#6802).** The nft
+  table is already applied, so enforcement for NEW connections holds regardless,
+  and failing the commit would roll back correct enforcement over a transient
+  conntrack-subsystem error. That rationale is unchanged. What #6802 corrected is
+  the rest of it: before #6802 the flush returned nothing, set no dirty flag,
+  bumped no counter, published no metric, and no ticker re-ran it — every ticker
+  under `pkg/daemon` was enumerated and none re-drives `applyConfig`,
+  `applyHostInboundFilter` or the flush, so the only re-attempt was the next
+  externally-triggered apply. See "Revocation failure is retried" below.
 
 Kernel netfilter conntrack on this appliance tracks only host-terminated /
 kernel-forwarded flows (transit forwarding runs through userspace-dp's own session
 table), so the swept table is small. Fail-on-revert proofs:
 `pkg/daemon/host_inbound_conntrack_flush_5566_test.go`.
+
+### Revocation failure is retried, counted, and published (#6802)
+
+The failure direction is what made "best effort" a defect rather than a
+tradeoff. A stale entry rides the chain's **leading**
+`ct state established,related accept`, so a failed revocation fails **OPEN**: a
+host service the operator has just REMOVED keeps being served on every
+already-established direct-kernel connection. Before #6802 that persisted until
+the flow closed or timed out, with nothing to notice it and nothing to re-drive
+it.
+
+`flushDeniedHostInboundConntrack` now returns whether every family's delete
+succeeded, and the call site records the outcome as **retry debt**:
+
+- **The debt retains the exact request** — the `views` / `unzonedV4` /
+  `unzonedV6` / `wgListenPorts` the failed flush was called with — not a set
+  re-derived at retry time. A retry that re-derived from the current config would
+  attempt a *different* revocation than the one that failed, and the two diverge
+  exactly when a commit landed in between.
+- **A failure of one family does not abandon the other.** The loop `continue`s so
+  the second family is still swept; the failure is carried out in the return
+  value rather than swallowed.
+- **`hostInboundConntrackReassertLoop` is the retry owner**, started
+  unconditionally in `Run` alongside `proxyARPReassertLoop`,
+  `raDeadSenderReassertLoop` (#6793) and `fabricIPVLANReassertLoop` (#6791), at
+  the same 30s cadence. The gate is a single atomic pointer load, so it is free
+  on a node whose revocations have all succeeded. Like its siblings it takes
+  `applySem` **before** acting (#4001) — an in-flight apply must not race a
+  revocation against a half-applied host-inbound set — and re-reads the debt
+  **inside** the semaphore, because the commit it queued behind may already have
+  flushed successfully.
+- **A later successful flush clears the debt.** The filter is built from the
+  desired set, so a current successful revocation subsumes an older failed one;
+  retaining stale debt would make the owner re-drive a revocation whose target no
+  longer exists.
+
+Operator-visible surface — both emitted even when the dataplane is not loaded,
+because the daemon rebuilds the kernel table in config-only mode too:
+
+| Series | Meaning |
+|---|---|
+| `xpf_host_inbound_conntrack_revocation_pending` | `1` while a revocation has failed and not yet been re-driven. While set, a now-denied host service may still be reachable on an established kernel connection. |
+| `xpf_host_inbound_conntrack_revocation_failures_total` | Every failed attempt, retries included. Climbing while the gauge stays `1` means the retry owner is running but not converging. |
+
+Both are omitted entirely — not published as `0` — on a server that has not wired
+the accessors, so an unwired node cannot be mistaken for a converged one (the
+#6828 absent-vs-zero distinction). Fail-on-revert proofs:
+`pkg/daemon/host_inbound_conntrack_retry_6802_test.go` and
+`pkg/api/metrics_hostinbound_conntrack_revoke_6802_test.go`.
 
 ## Fail-closed invariant for a nil / configured=false known zone (#3705)
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -208,6 +208,15 @@ type xpfCollector struct {
 	// address (the retry loop has not yet reconverged).
 	ipsecRebindPending *prometheus.Desc
 
+	// #6802: 0/1 gauge — 1 while a host-inbound kernel-conntrack revocation
+	// has FAILED and not yet been re-driven. While set, direct-kernel
+	// connections to a service the operator has REMOVED may still be riding
+	// the host-inbound chain's leading `ct state established,related accept`,
+	// i.e. the failure is fail-OPEN. hostInboundConntrackRevocationFailures is
+	// the monotonic count of those failures.
+	hostInboundConntrackRevocationPending  *prometheus.Desc
+	hostInboundConntrackRevocationFailures *prometheus.Desc
+
 	// #3780: 0/1 gauge — 1 while the most recent scheduler-driven policy
 	// republish failed and has not yet converged (stale enforcement past
 	// a schedule window: a permit still forwarding, or a scheduled block
@@ -762,6 +771,8 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.schedulerRepublishFailed
 	ch <- c.schedulerRepublishStale
 	ch <- c.schedulerRepublishFailClosed
+	ch <- c.hostInboundConntrackRevocationPending
+	ch <- c.hostInboundConntrackRevocationFailures
 	ch <- c.configPersistDegraded
 	ch <- c.rollbackHistoryDegraded
 	ch <- c.userspacePolicyContentRejected
@@ -1078,6 +1089,25 @@ func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 		ch <- prometheus.MustNewConstMetric(c.ipsecRebindPending,
 			prometheus.GaugeValue, v)
+	}
+
+	// #6802: host-inbound conntrack revocation is a control-plane signal (the
+	// daemon rebuilds the kernel host-inbound table and reconciles conntrack
+	// even in config-only mode) — emit it BEFORE the dataplane gate so a
+	// now-denied host service that is still reachable over an established
+	// kernel connection stays visible even when the dataplane is not loaded.
+	if c.srv.hostInboundConntrackRevocationOwedFn != nil {
+		v := 0.0
+		if c.srv.hostInboundConntrackRevocationOwedFn() {
+			v = 1
+		}
+		ch <- prometheus.MustNewConstMetric(c.hostInboundConntrackRevocationPending,
+			prometheus.GaugeValue, v)
+	}
+	if c.srv.hostInboundConntrackFlushFailuresFn != nil {
+		ch <- prometheus.MustNewConstMetric(c.hostInboundConntrackRevocationFailures,
+			prometheus.CounterValue,
+			float64(c.srv.hostInboundConntrackFlushFailuresFn()))
 	}
 
 	// #3780: scheduler republish-failure is a control-plane signal (the

--- a/pkg/api/metrics_descriptors_controlplane.go
+++ b/pkg/api/metrics_descriptors_controlplane.go
@@ -31,6 +31,31 @@ func (c *xpfCollector) initControlPlaneDescriptors() {
 			"local_addrs reconverge on the current lease.",
 		nil, nil,
 	)
+	// #6802: a failed host-inbound conntrack revocation is deliberately NOT a
+	// commit failure — the nft table is already applied, so enforcement for NEW
+	// connections holds, and rolling the commit back over a transient conntrack
+	// error would discard correct enforcement. But before #6802 it was not
+	// anything ELSE either: no return value, no dirty flag, no counter, no
+	// metric and no retry owner. These two series are that missing signal.
+	c.hostInboundConntrackRevocationPending = prometheus.NewDesc(
+		"xpf_host_inbound_conntrack_revocation_pending",
+		"1 while a host-inbound kernel-conntrack revocation has failed and "+
+			"has not yet been re-driven (#6802). The failure is fail-OPEN: an "+
+			"established direct-kernel connection to a service the operator "+
+			"has REMOVED keeps riding the host-inbound chain's leading "+
+			"`ct state established,related accept`, so a now-denied host "+
+			"service stays reachable on that connection. The daemon re-drives "+
+			"the owed revocation autonomously every 30s; 0 once it succeeds.",
+		nil, nil,
+	)
+	c.hostInboundConntrackRevocationFailures = prometheus.NewDesc(
+		"xpf_host_inbound_conntrack_revocation_failures_total",
+		"Total host-inbound kernel-conntrack revocation failures (#6802). "+
+			"Counts every failed attempt including retries, so a value that "+
+			"climbs while xpf_host_inbound_conntrack_revocation_pending stays "+
+			"1 means the retry owner is running but not converging.",
+		nil, nil,
+	)
 	c.schedulerRepublishFailed = prometheus.NewDesc(
 		"xpf_scheduler_republish_failed",
 		"1 while the most recent scheduler-driven policy republish "+

--- a/pkg/api/metrics_hostinbound_conntrack_revoke_6802_test.go
+++ b/pkg/api/metrics_hostinbound_conntrack_revoke_6802_test.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// metrics_hostinbound_conntrack_revoke_6802_test.go — #6802.
+//
+// A failed host-inbound kernel-conntrack revocation had no return value, no
+// dirty flag, no counter, NO METRIC and no retry owner. The daemon side of the
+// fix adds the debt and the retry loop; this file binds the operator-visible
+// half, which is the part that stays silently missing if the accessor is
+// exported but never reaches a Desc.
+//
+// Both series must emit with the dataplane NOT loaded (`dp` nil): the daemon
+// rebuilds the kernel host-inbound table and reconciles conntrack in
+// config-only mode too, so a now-denied host service that is still reachable
+// over an established kernel connection has to stay visible exactly when the
+// dataplane is absent.
+//
+// A pedantic registry is the instrument on purpose: it is the only registry
+// that enforces Describe() ⊇ Collect(), so deleting either `ch <-` line from
+// Describe reds these instead of silently degrading a production scrape.
+
+// TestHostInboundConntrackRevocationPendingGauge6802 is PAIRED. The owed leg
+// alone is satisfied by a gauge hardwired to 1, which would page an operator on
+// every healthy node forever; the healthy leg alone is satisfied by one
+// hardwired to 0, which is the pre-#6802 blindness with extra steps.
+func TestHostInboundConntrackRevocationPendingGauge6802(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		owed bool
+		want float64
+	}{
+		{"revocation-owed", true, 1},
+		{"converged", false, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{ // dp intentionally nil — gauge must still emit
+				hostInboundConntrackRevocationOwedFn: func() bool { return tc.owed },
+			}
+			got, ok := gatherSingleSample6802(t, s,
+				"xpf_host_inbound_conntrack_revocation_pending")
+			if !ok {
+				t.Fatalf("xpf_host_inbound_conntrack_revocation_pending was not " +
+					"emitted; a failed host-inbound conntrack revocation is " +
+					"invisible to an operator, which is half of #6802")
+			}
+			if got != tc.want {
+				t.Errorf("gauge = %v, want %v — the gauge does not track the wired "+
+					"fn, so it reports the same value whether or not a now-denied "+
+					"host service is still authorized", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHostInboundConntrackRevocationFailuresCounter6802 pins the counter to the
+// wired fn's VALUE, not merely to its existence. A counter stuck at 0 is
+// indistinguishable from a healthy node; the distinguishing case is a node that
+// has failed repeatedly, so the non-zero leg carries the weight and the zero leg
+// exists to reject a counter hardwired to the non-zero constant.
+func TestHostInboundConntrackRevocationFailuresCounter6802(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		failures uint64
+		want     float64
+	}{
+		{"none", 0, 0},
+		{"repeated", 7, 7},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{ // dp intentionally nil
+				hostInboundConntrackFlushFailuresFn: func() uint64 { return tc.failures },
+			}
+			got, ok := gatherSingleSample6802(t, s,
+				"xpf_host_inbound_conntrack_revocation_failures_total")
+			if !ok {
+				t.Fatalf("xpf_host_inbound_conntrack_revocation_failures_total was " +
+					"not emitted; an operator cannot tell a retry owner that is " +
+					"running-but-not-converging from one that never ran (#6802)")
+			}
+			if got != tc.want {
+				t.Errorf("counter = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHostInboundConntrackSeriesAreOptional6802 pins the nil-fn contract the
+// sibling control-plane signals all carry: a Server with the fns unset must not
+// emit the series at all, rather than publishing an authoritative 0. That is the
+// #6828 absent-vs-zero distinction — a hardcoded 0 from a node that never wired
+// the accessor reads exactly like a converged node.
+func TestHostInboundConntrackSeriesAreOptional6802(t *testing.T) {
+	s := &Server{} // both fns nil
+	for _, name := range []string{
+		"xpf_host_inbound_conntrack_revocation_pending",
+		"xpf_host_inbound_conntrack_revocation_failures_total",
+	} {
+		if _, ok := gatherSingleSample6802(t, s, name); ok {
+			t.Errorf("%s was emitted with no fn wired; an unwired node publishes "+
+				"an authoritative value indistinguishable from a converged one", name)
+		}
+	}
+}
+
+// gatherSingleSample6802 scrapes s through a PEDANTIC registry and returns the
+// single sample of the named family. The pedantic registry is what makes a
+// missing Describe() entry a hard error rather than a silent production
+// degradation.
+func gatherSingleSample6802(t *testing.T, s *Server, name string) (float64, bool) {
+	t.Helper()
+	reg := prometheus.NewPedanticRegistry()
+	reg.MustRegister(newCollector(s))
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		ms := mf.GetMetric()
+		if len(ms) != 1 {
+			t.Fatalf("%s: metric count = %d, want 1", name, len(ms))
+		}
+		if g := ms[0].GetGauge(); g != nil {
+			return g.GetValue(), true
+		}
+		if c := ms[0].GetCounter(); c != nil {
+			return c.GetValue(), true
+		}
+		t.Fatalf("%s: sample is neither a gauge nor a counter", name)
+	}
+	return 0, false
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -234,6 +234,19 @@ type Config struct {
 	// Backs the xpf_ipsec_rebind_pending gauge (0/1, no labels). Optional;
 	// if nil, the gauge is not emitted.
 	IPsecRebindPendingFn func() bool
+	// HostInboundConntrackRevocationOwedFn reports whether a host-inbound
+	// kernel-conntrack revocation failed and has not yet been re-driven
+	// (#6802). While true, an established direct-kernel connection to a
+	// now-REMOVED host service may still be authorized by the host-inbound
+	// chain's leading established/related accept. Backs the
+	// xpf_host_inbound_conntrack_revocation_pending gauge (0/1, no labels).
+	// Optional; if nil, the gauge is not emitted.
+	HostInboundConntrackRevocationOwedFn func() bool
+	// HostInboundConntrackFlushFailuresFn reports the monotonic count of
+	// host-inbound conntrack revocation failures (#6802), retries included.
+	// Backs the xpf_host_inbound_conntrack_revocation_failures_total counter.
+	// Optional; if nil, the counter is not emitted.
+	HostInboundConntrackFlushFailuresFn func() uint64
 	// SchedulerRepublishFailedFn reports whether the most recent
 	// scheduler-driven policy republish failed and has not yet converged
 	// (#3780). A scheduler window transition republishes enforcement; a
@@ -384,43 +397,45 @@ type Server struct {
 	peerLookupFn func(client, server net.Addr) authz.PeerIdentity
 	// peerLocalityFn is Config.PeerLocalityFn; nil means
 	// authz.PeerCouldBeLocalNow (#5561).
-	peerLocalityFn                   func(client, server net.Addr) bool
-	store                            *configstore.Store
-	dp                               apiRuntimeDataPlane
-	eventBuf                         *logging.EventBuffer
-	gc                               *conntrack.GC
-	routing                          *routing.Manager
-	frr                              *frr.Manager
-	ipsec                            *ipsec.Manager
-	dhcp                             *dhcp.Manager
-	vrrpMgr                          *vrrp.Manager
-	commitFn                         func(ctx context.Context, comment string) (*config.Config, error)
-	commitConfirmedFn                func(ctx context.Context, minutes int) (*config.Config, error)
-	compileHealthFn                  func() CompileHealthSnapshot
-	bootstrapImportFn                func() BootstrapImportSnapshot
-	configPersistDegradedFn          func() bool
-	rollbackHistoryDegradedFn        func() bool
-	neighborPhaseAgeFn               func() map[string]float64
-	frrReloadDegradedFn              func() bool
-	ipsecRebindPendingFn             func() bool
-	schedulerRepublishFailedFn       func() bool
-	schedulerRepublishStaleSecondsFn func() float64
-	schedulerRepublishFailClosedFn   func() bool
-	ipmonStatusFn                    func() []ipmon.PolicyStatus
-	ipmonActuationFailuresFn         func() uint64
-	eventActionStatsFn               func() eventengine.Stats
-	rpmPinFailedFn                   func() float64
-	feedsFn                          func() map[string]feeds.FeedInfo
-	ddnsStatsFn                      func() *dhcpserver.DDNSStats
-	surfaceAStatsFn                  func() *ddns.SurfaceAStats
-	flowCollectorHealthFn            func() []flowexport.ExporterCollectorHealth
-	flowExportBatchStatsFn           func() []flowexport.ExporterBatchStats
-	feedOverlayFn                    func() map[string][]string
-	policySchedActiveFn              func() (map[string]bool, bool)
-	haActiveFn                       func() bool
-	nodeIDFn                         func() int
-	clusterSessionFn                 func() ClusterSessionService
-	startTime                        time.Time
+	peerLocalityFn                       func(client, server net.Addr) bool
+	store                                *configstore.Store
+	dp                                   apiRuntimeDataPlane
+	eventBuf                             *logging.EventBuffer
+	gc                                   *conntrack.GC
+	routing                              *routing.Manager
+	frr                                  *frr.Manager
+	ipsec                                *ipsec.Manager
+	dhcp                                 *dhcp.Manager
+	vrrpMgr                              *vrrp.Manager
+	commitFn                             func(ctx context.Context, comment string) (*config.Config, error)
+	commitConfirmedFn                    func(ctx context.Context, minutes int) (*config.Config, error)
+	compileHealthFn                      func() CompileHealthSnapshot
+	bootstrapImportFn                    func() BootstrapImportSnapshot
+	configPersistDegradedFn              func() bool
+	rollbackHistoryDegradedFn            func() bool
+	neighborPhaseAgeFn                   func() map[string]float64
+	frrReloadDegradedFn                  func() bool
+	ipsecRebindPendingFn                 func() bool
+	hostInboundConntrackRevocationOwedFn func() bool
+	hostInboundConntrackFlushFailuresFn  func() uint64
+	schedulerRepublishFailedFn           func() bool
+	schedulerRepublishStaleSecondsFn     func() float64
+	schedulerRepublishFailClosedFn       func() bool
+	ipmonStatusFn                        func() []ipmon.PolicyStatus
+	ipmonActuationFailuresFn             func() uint64
+	eventActionStatsFn                   func() eventengine.Stats
+	rpmPinFailedFn                       func() float64
+	feedsFn                              func() map[string]feeds.FeedInfo
+	ddnsStatsFn                          func() *dhcpserver.DDNSStats
+	surfaceAStatsFn                      func() *ddns.SurfaceAStats
+	flowCollectorHealthFn                func() []flowexport.ExporterCollectorHealth
+	flowExportBatchStatsFn               func() []flowexport.ExporterBatchStats
+	feedOverlayFn                        func() map[string][]string
+	policySchedActiveFn                  func() (map[string]bool, bool)
+	haActiveFn                           func() bool
+	nodeIDFn                             func() int
+	clusterSessionFn                     func() ClusterSessionService
+	startTime                            time.Time
 }
 
 // Management HTTP/HTTPS server timeouts (M-6). Both http.Server literals used
@@ -471,42 +486,44 @@ const (
 // NewServer creates a new API server.
 func NewServer(cfg Config) *Server {
 	s := &Server{
-		store:                            cfg.Store,
-		dp:                               cfg.DP,
-		eventBuf:                         cfg.EventBuf,
-		gc:                               cfg.GC,
-		routing:                          cfg.Routing,
-		frr:                              cfg.FRR,
-		ipsec:                            cfg.IPsec,
-		dhcp:                             cfg.DHCP,
-		vrrpMgr:                          cfg.VRRPMgr,
-		commitFn:                         cfg.CommitFn,
-		commitConfirmedFn:                cfg.CommitConfirmedFn,
-		compileHealthFn:                  cfg.CompileHealthFn,
-		bootstrapImportFn:                cfg.BootstrapImportFn,
-		configPersistDegradedFn:          cfg.ConfigPersistDegradedFn,
-		rollbackHistoryDegradedFn:        cfg.RollbackHistoryDegradedFn,
-		neighborPhaseAgeFn:               cfg.NeighborPhaseAgeFn,
-		frrReloadDegradedFn:              cfg.FRRReloadDegradedFn,
-		ipsecRebindPendingFn:             cfg.IPsecRebindPendingFn,
-		schedulerRepublishFailedFn:       cfg.SchedulerRepublishFailedFn,
-		schedulerRepublishStaleSecondsFn: cfg.SchedulerRepublishStaleSecondsFn,
-		schedulerRepublishFailClosedFn:   cfg.SchedulerRepublishFailClosedFn,
-		ipmonStatusFn:                    cfg.IPMonStatusFn,
-		ipmonActuationFailuresFn:         cfg.IPMonActuationFailuresFn,
-		eventActionStatsFn:               cfg.EventActionStatsFn,
-		rpmPinFailedFn:                   cfg.RPMPinFailedFn,
-		feedsFn:                          cfg.FeedsFn,
-		ddnsStatsFn:                      cfg.DDNSStatsFn,
-		surfaceAStatsFn:                  cfg.SurfaceAStatsFn,
-		flowCollectorHealthFn:            cfg.FlowCollectorHealthFn,
-		flowExportBatchStatsFn:           cfg.FlowExportBatchStatsFn,
-		feedOverlayFn:                    cfg.FeedOverlayFn,
-		policySchedActiveFn:              cfg.PolicySchedulerActiveStateFn,
-		haActiveFn:                       cfg.HAActiveFn,
-		nodeIDFn:                         cfg.NodeIDFn,
-		clusterSessionFn:                 cfg.ClusterSessionFn,
-		startTime:                        time.Now(),
+		store:                                cfg.Store,
+		dp:                                   cfg.DP,
+		eventBuf:                             cfg.EventBuf,
+		gc:                                   cfg.GC,
+		routing:                              cfg.Routing,
+		frr:                                  cfg.FRR,
+		ipsec:                                cfg.IPsec,
+		dhcp:                                 cfg.DHCP,
+		vrrpMgr:                              cfg.VRRPMgr,
+		commitFn:                             cfg.CommitFn,
+		commitConfirmedFn:                    cfg.CommitConfirmedFn,
+		compileHealthFn:                      cfg.CompileHealthFn,
+		bootstrapImportFn:                    cfg.BootstrapImportFn,
+		configPersistDegradedFn:              cfg.ConfigPersistDegradedFn,
+		rollbackHistoryDegradedFn:            cfg.RollbackHistoryDegradedFn,
+		neighborPhaseAgeFn:                   cfg.NeighborPhaseAgeFn,
+		frrReloadDegradedFn:                  cfg.FRRReloadDegradedFn,
+		ipsecRebindPendingFn:                 cfg.IPsecRebindPendingFn,
+		hostInboundConntrackRevocationOwedFn: cfg.HostInboundConntrackRevocationOwedFn,
+		hostInboundConntrackFlushFailuresFn:  cfg.HostInboundConntrackFlushFailuresFn,
+		schedulerRepublishFailedFn:           cfg.SchedulerRepublishFailedFn,
+		schedulerRepublishStaleSecondsFn:     cfg.SchedulerRepublishStaleSecondsFn,
+		schedulerRepublishFailClosedFn:       cfg.SchedulerRepublishFailClosedFn,
+		ipmonStatusFn:                        cfg.IPMonStatusFn,
+		ipmonActuationFailuresFn:             cfg.IPMonActuationFailuresFn,
+		eventActionStatsFn:                   cfg.EventActionStatsFn,
+		rpmPinFailedFn:                       cfg.RPMPinFailedFn,
+		feedsFn:                              cfg.FeedsFn,
+		ddnsStatsFn:                          cfg.DDNSStatsFn,
+		surfaceAStatsFn:                      cfg.SurfaceAStatsFn,
+		flowCollectorHealthFn:                cfg.FlowCollectorHealthFn,
+		flowExportBatchStatsFn:               cfg.FlowExportBatchStatsFn,
+		feedOverlayFn:                        cfg.FeedOverlayFn,
+		policySchedActiveFn:                  cfg.PolicySchedulerActiveStateFn,
+		haActiveFn:                           cfg.HAActiveFn,
+		nodeIDFn:                             cfg.NodeIDFn,
+		clusterSessionFn:                     cfg.ClusterSessionFn,
+		startTime:                            time.Now(),
 	}
 	// #5866: seed the live auth snapshot; the middleware reads it atomically per
 	// request so ReplaceAuth can swap credentials without rebinding the listener.

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -2024,6 +2024,39 @@ never lock an operator out of a remote box it manages.
   proof; gate quiet-when-up / fires-when-down; the re-assert re-creates; and a
   loop-START cell asserting `Run` launches it unconditionally).
 
+  **Host-inbound conntrack revocation retry (#6802, the same recovery shape):**
+  `flushDeniedHostInboundConntrack` (the #5566 reconcile) deletes established
+  kernel conntrack entries for host services the operator has just removed,
+  because those entries would otherwise ride the host-inbound chain's leading
+  `ct state established,related accept`. A delete failure therefore fails **OPEN**
+  — the now-denied service keeps being served on its existing connections. It is
+  deliberately still NOT a commit failure (the nft table is applied, so new
+  connections are enforced, and rolling back over a transient conntrack error
+  would discard correct enforcement); what #6802 added is everything else, since
+  before it the flush returned nothing, set no flag, bumped no counter, published
+  no metric, and no ticker re-ran it. The flush now returns a bool, and
+  `noteHostInboundConntrackFlush` retains the **exact** failed request as debt —
+  not a set re-derived at retry time, which would attempt a different revocation
+  than the one that failed, and the two diverge precisely when a commit landed in
+  between. `hostInboundConntrackReassertLoop` is the owner, started
+  unconditionally in `Run` beside the three loops above, 30s, gated on a single
+  atomic pointer load; it takes `applySem` before acting (#4001) and re-reads the
+  debt INSIDE the semaphore, because the commit it queued behind may already have
+  flushed successfully. A success clears the debt: the filter is built from the
+  desired set, so a current revocation subsumes an older one.
+  `HostInboundConntrackRevocationOwed` / `HostInboundConntrackFlushFailures` are
+  wired into the REST/metrics server (`daemon_run_servers.go`) as
+  `xpf_host_inbound_conntrack_revocation_pending` and
+  `…_failures_total`; an accessor with no production caller would leave the
+  operator exactly as blind as before (the #6852 shape). Tests:
+  `host_inbound_conntrack_retry_6802_test.go` (paired outcome cell on the delete
+  seam, which had no failing fixture at all before; debt retain/clear; the retry
+  re-drives the OWED request; the inside-the-semaphore re-check; the loop ticks; a
+  loop-START cell; and a WIRING cell for the two metric assignments) plus
+  `pkg/api/metrics_hostinbound_conntrack_revoke_6802_test.go` (both series track
+  their fn, and are OMITTED rather than published as `0` when unwired — the #6828
+  absent-vs-zero distinction).
+
   **VRF setup / management-bind fail-closed (#5700, mirroring #5310/#5696/#5844):**
   `applyVRFReconcile` LOGGED-and-DROPPED its `ReconcileVRFs` failure (WARN) and
   returned only the #2926-C1 ctx-cancellation, even though `reconcileVRFs`'s

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -709,6 +709,28 @@ type Daemon struct {
 	// ordered operations in separate state domains, not one atomic publication.
 	hostInboundEnforced atomic.Bool
 
+	// hostInboundConntrackDebt is the #6802 retry debt: a conntrack revocation
+	// that FAILED, so stale kernel entries for now-denied host services may
+	// still be riding the chain's leading `ct state established,related accept`.
+	//
+	// Deliberately not a commit failure. The nft table is already applied so
+	// enforcement for NEW connections holds, and failing the commit would roll
+	// back correct enforcement over a transient conntrack-subsystem error — that
+	// rationale predates #6802 and is unchanged. What #6802 adds is everything
+	// else: before it there was no return value, no dirty flag, no counter, no
+	// metric and no periodic reconcile, so the failure left no trace and the only
+	// re-attempt was the next externally-triggered apply.
+	//
+	// It stores the exact arguments the failed flush was called with, because a
+	// retry must re-drive the SAME desired set: re-deriving it from the current
+	// config would silently retry a different revocation than the one that
+	// failed, and the two differ precisely when a commit landed in between.
+	hostInboundConntrackDebt atomic.Pointer[hostInboundConntrackFlushRequest]
+	// hostInboundConntrackFlushFailures counts revocation failures (#6802). It is
+	// the operator-visible signal the pre-#6802 code had none of; a rising value
+	// means now-denied host-inbound flows may still be authorized.
+	hostInboundConntrackFlushFailures atomic.Uint64
+
 	// hostInboundCoveredAddrs is the set of firewall-local DESTINATION addresses
 	// (keyed "<fam>|<addr>", fam '4'/'6') that the currently-RETAINED host-inbound
 	// enforcement (the last successfully-loaded real table OR address-scoped

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -662,7 +662,19 @@ func (d *Daemon) applyHostInboundFilter(cfg *config.Config) error {
 	// local-delivery per-hit re-eval/teardown. Best effort (see the function doc):
 	// enforcement for NEW connections is already in place, so a flush failure never
 	// fails the commit.
-	d.flushDeniedHostInboundConntrack(views, unzonedV4, unzonedV6, wgListenPorts)
+	// #6802: record the outcome as retry DEBT. Still not a commit failure — the
+	// rationale above holds — but before #6802 a failure left no return value, no
+	// dirty flag, no counter and no retry owner, so a now-denied host-inbound
+	// flow kept its old authorization until it closed or timed out, with nothing
+	// to notice or re-drive it.
+	ctReq := hostInboundConntrackFlushRequest{
+		views:         views,
+		unzonedV4:     unzonedV4,
+		unzonedV6:     unzonedV6,
+		wgListenPorts: wgListenPorts,
+	}
+	d.noteHostInboundConntrackFlush(ctReq,
+		d.flushDeniedHostInboundConntrack(views, unzonedV4, unzonedV6, wgListenPorts))
 	slog.Info("host-inbound filter applied", "zones", len(views),
 		"unzoned_deny_v4", len(unzonedV4), "unzoned_deny_v6", len(unzonedV6),
 		"junos_host_deny_programs", len(programs))

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -567,6 +567,19 @@ func (d *Daemon) Run(ctx context.Context) error {
 		d.raDeadSenderReassertLoop(ctx)
 	}()
 
+	// #6802: the always-on retry owner for a FAILED host-inbound conntrack
+	// revocation. Started unconditionally, alongside the proxy-ARP and RA
+	// re-assert loops and for the same reason: no ticker under pkg/daemon
+	// re-runs applyConfig / applyHostInboundFilter / the flush, so before this
+	// the only re-attempt was the next externally-triggered apply. The gate is a
+	// single atomic pointer load, so the loop is free on a node whose
+	// revocations have all succeeded.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		d.hostInboundConntrackReassertLoop(ctx)
+	}()
+
 	// #6791: the always-on retry owner for a fabric IPVLAN overlay whose
 	// creation failed. Started unconditionally, alongside the proxy-ARP and RA
 	// re-asserts and for the same reason: BOTH standalone and cluster nodes

--- a/pkg/daemon/daemon_run_servers.go
+++ b/pkg/daemon/daemon_run_servers.go
@@ -335,6 +335,13 @@ func (d *Daemon) startHTTPServer(ctx context.Context, wg *sync.WaitGroup, eventB
 		// operator sees a tunnel that cannot re-establish instead of a
 		// silently-dropped reload error.
 		IPsecRebindPendingFn: d.IPsecRebindPending,
+		// #6802: surface a FAILED host-inbound conntrack revocation. The
+		// failure is fail-open — a now-denied host service stays reachable
+		// over its established kernel connection — and before #6802 it left
+		// no trace at all, so an operator had no way to see that a service
+		// they had just removed was still being served.
+		HostInboundConntrackRevocationOwedFn: d.HostInboundConntrackRevocationOwed,
+		HostInboundConntrackFlushFailuresFn:  d.HostInboundConntrackFlushFailures,
 		// #3780: surface scheduler republish-failure so
 		// xpf_scheduler_republish_failed reads 1 (and
 		// xpf_scheduler_republish_stale_seconds climbs) while a

--- a/pkg/daemon/host_inbound_conntrack_flush.go
+++ b/pkg/daemon/host_inbound_conntrack_flush.go
@@ -1,8 +1,10 @@
 package daemon
 
 import (
+	"context"
 	"log/slog"
 	"net/netip"
+	"time"
 
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -284,17 +286,39 @@ func buildHostInboundConntrackFlushFilter(views []dpuserspace.ZoneHostInboundVie
 // PRE-EXISTING flows on their old authorization (the pre-fix behavior), so it is
 // logged rather than surfaced as a commit failure — failing the commit would roll
 // back correct enforcement over a transient conntrack-subsystem error.
-func (d *Daemon) flushDeniedHostInboundConntrack(views []dpuserspace.ZoneHostInboundView, unzonedV4, unzonedV6 []string, wgListenPorts []uint16) {
+// #6802: it returns whether every family's delete SUCCEEDED. A failure is still
+// not a commit failure — the rationale above is sound and unchanged — but before
+// #6802 it was not anything else either: no return value, no dirty flag, no
+// counter, no metric, and no periodic reconcile re-ran it. Every ticker under
+// pkg/daemon was enumerated and none re-drives applyConfig,
+// applyHostInboundFilter or this flush, so the only re-attempt was the next
+// externally-triggered apply — itself gated on InstallHostInbound succeeding.
+//
+// The failure direction is what makes that a defect rather than a tradeoff: the
+// stale entry rides the chain's leading `ct state established,related accept`,
+// so a now-DENIED host-inbound flow keeps working. It fails OPEN, and it stayed
+// open until the flow closed or timed out.
+//
+// The caller records the outcome as retry DEBT and an always-on owner re-drives
+// it (hostInboundConntrackReassertLoop), which is the same shape #6793 used for
+// a dead RA sender: surface the failure, keep the state a retry needs, and let a
+// cheap always-on gate re-drive it.
+func (d *Daemon) flushDeniedHostInboundConntrack(views []dpuserspace.ZoneHostInboundView, unzonedV4, unzonedV6 []string, wgListenPorts []uint16) bool {
 	filter := buildHostInboundConntrackFlushFilter(views, unzonedV4, unzonedV6, wgListenPorts)
 	if filter == nil {
-		return
+		return true
 	}
 	var flushed uint
+	ok := true
 	for _, family := range []netlink.InetFamily{unix.AF_INET, unix.AF_INET6} {
 		n, err := conntrackDeleteFilters(family, filter)
 		if err != nil {
 			slog.Warn("host-inbound conntrack reconcile failed: existing direct-kernel connections to a now-denied host service may retain OLD authorization until they close or time out",
 				"family", family, "err", err)
+			// Keep going: the OTHER family's stale entries are independent and
+			// still worth flushing. `continue` here is deliberate, not a
+			// swallow — the failure is carried out in the return value.
+			ok = false
 			continue
 		}
 		flushed += n
@@ -303,4 +327,113 @@ func (d *Daemon) flushDeniedHostInboundConntrack(views []dpuserspace.ZoneHostInb
 		slog.Info("host-inbound conntrack reconcile: flushed now-denied kernel conntrack entries so stale direct-kernel host connections are re-evaluated against the current host-inbound set",
 			"flushed", flushed)
 	}
+	return ok
+}
+
+// hostInboundConntrackFlushRequest is the exact desired set a flush was called
+// with (#6802). The retry owner re-drives THIS, not a freshly-derived set: a
+// retry that re-derived the set from the current config would silently attempt a
+// different revocation than the one that failed, and the two differ exactly when
+// a commit landed in between — which is when getting it wrong matters most.
+type hostInboundConntrackFlushRequest struct {
+	views         []dpuserspace.ZoneHostInboundView
+	unzonedV4     []string
+	unzonedV6     []string
+	wgListenPorts []uint16
+}
+
+// noteHostInboundConntrackFlush records the outcome of a revocation attempt
+// (#6802): on failure it retains the request as retry debt and counts it; on
+// success it clears any debt, because a later successful flush over the CURRENT
+// desired set has already revoked everything an older failed one would have.
+//
+// Clearing on success is safe for that reason and not merely convenient: the
+// filter is built from the desired set, and a superset revocation subsumes an
+// earlier one. Retaining stale debt after a good flush would make the owner
+// re-drive a revocation whose target no longer exists.
+func (d *Daemon) noteHostInboundConntrackFlush(req hostInboundConntrackFlushRequest, ok bool) {
+	if ok {
+		d.hostInboundConntrackDebt.Store(nil)
+		return
+	}
+	d.hostInboundConntrackFlushFailures.Add(1)
+	r := req
+	d.hostInboundConntrackDebt.Store(&r)
+	slog.Warn("host-inbound conntrack revocation failed; retaining retry debt " +
+		"so an always-on owner re-drives it — until it succeeds, a now-denied " +
+		"host-inbound flow may still be authorized by the chain's leading " +
+		"established/related accept (#6802)")
+}
+
+// hostInboundConntrackReassertInterval is the cadence of the #6802 retry owner.
+// A stale entry means a denied service is still reachable, so recovery wants to
+// be prompt; but the retry is a conntrack dump+delete, so it must not run at the
+// 2s cadence of the cluster reconcile. 30s matches proxyARPReassertInterval and
+// raDeadSenderReassertInterval, the other always-on self-heal loops.
+var hostInboundConntrackReassertInterval = 30 * time.Second
+
+// hostInboundConntrackReassertLoop is the retry owner a failed revocation did
+// not have (#6802).
+//
+// Every ticker under pkg/daemon was enumerated when this issue was measured —
+// DDNS, RPM, HA fabric, HA, IPsec rebind, DHCP lease sync, neighbor, proxy-ARP,
+// archive, kernel self-recover — and NONE re-runs applyConfig,
+// applyHostInboundFilter or the flush. So the only re-attempt was the next
+// externally-triggered apply, itself gated on InstallHostInbound succeeding.
+//
+// Always-on and mode-agnostic, mirroring proxyARPReassertLoop: free on the
+// common path because the gate is a single atomic pointer load, so it costs
+// nothing on a node whose revocations have all succeeded.
+func (d *Daemon) hostInboundConntrackReassertLoop(ctx context.Context) {
+	t := time.NewTicker(hostInboundConntrackReassertInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			d.retryHostInboundConntrackFlushOnce(ctx)
+		}
+	}
+}
+
+// retryHostInboundConntrackFlushOnce re-drives one owed revocation.
+//
+// It takes applySem before acting, for the #4001 reason the proxy-ARP loop
+// gives: an apply may be mid-flight, and re-driving a revocation against a
+// half-applied host-inbound set could revoke flows the in-flight apply is about
+// to re-admit. The debt is re-read INSIDE the semaphore because the commit this
+// tick queued behind may already have flushed successfully and cleared it —
+// re-driving then would be a conntrack dump for nothing.
+func (d *Daemon) retryHostInboundConntrackFlushOnce(ctx context.Context) {
+	if d.hostInboundConntrackDebt.Load() == nil {
+		return
+	}
+	if d.applySem == nil {
+		return
+	}
+	if err := d.applySem.Acquire(ctx, 1); err != nil {
+		return
+	}
+	defer d.applySem.Release(1)
+	req := d.hostInboundConntrackDebt.Load()
+	if req == nil {
+		return
+	}
+	slog.Info("host-inbound conntrack revocation: re-driving a failed flush (#6802)")
+	ok := d.flushDeniedHostInboundConntrack(req.views, req.unzonedV4, req.unzonedV6, req.wgListenPorts)
+	d.noteHostInboundConntrackFlush(*req, ok)
+}
+
+// HostInboundConntrackFlushFailures reports the #6802 revocation failure count
+// for the metrics collector.
+func (d *Daemon) HostInboundConntrackFlushFailures() uint64 {
+	return d.hostInboundConntrackFlushFailures.Load()
+}
+
+// HostInboundConntrackRevocationOwed reports whether a revocation is still owed
+// (#6802) — the operator-facing form of "a now-denied host-inbound flow may
+// still be authorized".
+func (d *Daemon) HostInboundConntrackRevocationOwed() bool {
+	return d.hostInboundConntrackDebt.Load() != nil
 }

--- a/pkg/daemon/host_inbound_conntrack_retry_6802_test.go
+++ b/pkg/daemon/host_inbound_conntrack_retry_6802_test.go
@@ -226,8 +226,8 @@ func TestRetryRechecksTheDebtInsideTheSemaphore6802(t *testing.T) {
 	}
 }
 
-// TestRetryLoopTicks6802 binds the loop BODY, and TestRunStartsTheConntrackRetryLoop6802
-// (below) binds its START. They fail for different reasons: this reds if the
+// TestRetryLoopTicks6802 binds the loop BODY, and
+// TestRunStartsHostInboundConntrackReassertLoop6802 (below) binds its START. They fail for different reasons: this reds if the
 // ticker is wired to the wrong function, that one reds if Run never launches it.
 func TestRetryLoopTicks6802(t *testing.T) {
 	calls := installConntrackDeleteStub(t, errors.New("still failing"))
@@ -331,5 +331,48 @@ func TestDaemonWiresHostInboundConntrackMetrics6802(t *testing.T) {
 				"conntrack revocation is still invisible to an operator (#6802, "+
 				"and the #6852 no-production-caller shape)", want)
 		}
+	}
+}
+
+// TestApplyHostInboundFilterRecordsTheFlushOutcome6802 is the CALL-SITE half of
+// the wiring binding, and it exists because nothing else in this file can see it.
+//
+// Every behavioural cell above calls noteHostInboundConntrackFlush directly, so
+// they all stay green if applyHostInboundFilter goes back to calling
+// flushDeniedHostInboundConntrack and DISCARDING its return — which is the whole
+// fix undone, with the debt never armed on the one path that arms it in
+// production. That is the repeated "bind the wiring, not the function it calls"
+// failure; the #6791 fabric fix hit the identical shape.
+//
+// applyHostInboundFilter cannot be driven from a unit test (it needs a real nft
+// install path), so the wiring is asserted at the source with comments stripped.
+//
+// FAIL-ON-REVERT: change the call site back to a bare
+// `d.flushDeniedHostInboundConntrack(views, unzonedV4, unzonedV6, wgListenPorts)`
+// and this reds while every other cell in the file stays green.
+func TestApplyHostInboundFilterRecordsTheFlushOutcome6802(t *testing.T) {
+	src := stripLineComments6791(readDaemonSource(t, "daemon_nft.go"))
+
+	const note = "d.noteHostInboundConntrackFlush("
+	i := strings.Index(src, note)
+	if i < 0 {
+		t.Fatalf("applyHostInboundFilter does not record the flush outcome; a " +
+			"failed host-inbound conntrack revocation arms no debt on the one " +
+			"path that arms it in production, so the retry owner never runs " +
+			"(#6802)")
+	}
+	// The recorded outcome must be the flush's OWN return value. A call that
+	// passed a constant, or recorded an outcome derived from something else,
+	// would arm or clear the debt without reference to whether the revocation
+	// actually happened.
+	end := strings.Index(src[i:], "\n\tslog.")
+	if end < 0 {
+		end = len(src) - i
+	}
+	if !strings.Contains(src[i:i+end], "d.flushDeniedHostInboundConntrack(") {
+		t.Errorf("the outcome recorded by applyHostInboundFilter does not come " +
+			"from flushDeniedHostInboundConntrack's return value; the debt would " +
+			"be armed or cleared independently of whether the revocation " +
+			"succeeded (#6802)")
 	}
 }

--- a/pkg/daemon/host_inbound_conntrack_retry_6802_test.go
+++ b/pkg/daemon/host_inbound_conntrack_retry_6802_test.go
@@ -1,0 +1,335 @@
+package daemon
+
+// host_inbound_conntrack_retry_6802_test.go — #6802.
+//
+// A failed host-inbound conntrack revocation had NO return value, no dirty flag,
+// no counter, no metric, and no periodic reconcile that re-ran it. Every ticker
+// under pkg/daemon was enumerated when the issue was measured and none re-runs
+// applyConfig / applyHostInboundFilter / the flush, so the only re-attempt was
+// the next externally-triggered apply — itself gated on InstallHostInbound
+// succeeding.
+//
+// The failure direction is what makes that a defect rather than a tradeoff: the
+// stale entry rides the chain's leading `ct state established,related accept`,
+// so a now-DENIED host-inbound flow keeps working. It fails OPEN, and stayed
+// open until the flow closed or timed out.
+//
+// The pre-existing #5566 test's conntrackDeleteFilters stub always returns
+// (0, nil), so before these cells NO test exercised the delete-error path at all.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/psaab/xpf/pkg/config"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	"golang.org/x/sync/semaphore"
+)
+
+// installConntrackDeleteStub replaces the delete seam and records every call.
+func installConntrackDeleteStub(t *testing.T, err error) *int {
+	t.Helper()
+	orig := conntrackDeleteFilters
+	calls := 0
+	var mu sync.Mutex
+	conntrackDeleteFilters = func(netlink.InetFamily, ...netlink.CustomConntrackFilter) (uint, error) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		return 0, err
+	}
+	t.Cleanup(func() { conntrackDeleteFilters = orig })
+	return &calls
+}
+
+func flushReq6802() hostInboundConntrackFlushRequest {
+	cfg := hostInboundFlushTestConfig()
+	views := dpuserspace.BuildZoneHostInboundViews(cfg)
+	unzonedV4, unzonedV6 := unzonedHostAddrsForTest6802(cfg)
+	return hostInboundConntrackFlushRequest{
+		views:     views,
+		unzonedV4: unzonedV4,
+		unzonedV6: unzonedV6,
+	}
+}
+
+// unzonedHostAddrsForTest6802 mirrors the #5566 test's own derivation. The
+// values only need to make buildHostInboundConntrackFlushFilter return non-nil —
+// a nil filter short-circuits the flush and every assertion here would pass
+// vacuously, which the cells guard against by asserting the delete seam was
+// actually reached.
+func unzonedHostAddrsForTest6802(cfg *config.Config) ([]string, []string) {
+	return []string{"10.0.61.1"}, nil
+}
+
+// TestFlushReportsItsOutcome6802 is PAIRED on the seam that had no failing
+// fixture at all: the same flush, a failing delete and a succeeding one,
+// opposite returns.
+//
+// The success leg matters because "returns false on failure" is satisfied by a
+// flush that returns false always — which would arm the retry owner on every
+// apply on every healthy node, a conntrack dump every 30s forever.
+func TestFlushReportsItsOutcome6802(t *testing.T) {
+	req := flushReq6802()
+
+	t.Run("delete-fails", func(t *testing.T) {
+		calls := installConntrackDeleteStub(t, errors.New("simulated: conntrack subsystem unavailable"))
+		d := &Daemon{}
+		if d.flushDeniedHostInboundConntrack(req.views, req.unzonedV4, req.unzonedV6, nil) {
+			t.Fatal("flushDeniedHostInboundConntrack reported SUCCESS while every " +
+				"conntrack delete failed — a now-denied host-inbound flow keeps " +
+				"its old authorization and nothing records it (#6802)")
+		}
+		// Both families must still be attempted: their stale entries are
+		// independent, and abandoning v6 because v4 failed would leave half the
+		// revocation undone for a reason unrelated to v6.
+		if *calls != 2 {
+			t.Fatalf("conntrack delete attempted %d times, want 2 (one per "+
+				"address family) — a failure in one family must not abandon the "+
+				"other", *calls)
+		}
+	})
+
+	t.Run("delete-succeeds", func(t *testing.T) {
+		installConntrackDeleteStub(t, nil)
+		d := &Daemon{}
+		if !d.flushDeniedHostInboundConntrack(req.views, req.unzonedV4, req.unzonedV6, nil) {
+			t.Fatal("flushDeniedHostInboundConntrack reported FAILURE on a clean " +
+				"delete — the retry owner would re-drive a conntrack dump every " +
+				"30s on a healthy node")
+		}
+	})
+}
+
+// TestFailedFlushRetainsDebtAndSuccessClearsIt6802 pins the state a retry needs.
+// Reporting the failure is only half: before #6802 nothing kept the desired set,
+// so even a caller that SAW the failure had nothing to re-drive.
+func TestFailedFlushRetainsDebtAndSuccessClearsIt6802(t *testing.T) {
+	d := &Daemon{}
+	req := flushReq6802()
+
+	d.noteHostInboundConntrackFlush(req, false)
+	if !d.HostInboundConntrackRevocationOwed() {
+		t.Fatal("a FAILED revocation left no retry debt, so nothing can re-drive " +
+			"it and the now-denied flow stays authorized (#6802)")
+	}
+	if got := d.HostInboundConntrackFlushFailures(); got != 1 {
+		t.Fatalf("flush failures = %d, want 1 — a failure counted nowhere is "+
+			"invisible to an operator", got)
+	}
+
+	d.noteHostInboundConntrackFlush(req, true)
+	if d.HostInboundConntrackRevocationOwed() {
+		t.Fatal("debt survived a SUCCESSFUL revocation — the owner would re-drive " +
+			"a revocation whose target no longer exists")
+	}
+	if got := d.HostInboundConntrackFlushFailures(); got != 1 {
+		t.Fatalf("a SUCCESS bumped the failure counter to %d", got)
+	}
+}
+
+// TestRetryReDrivesTheOwedRequest6802 is the retry-owner cell, and it is PAIRED:
+// with debt the owner acts, without it the owner must not touch conntrack.
+//
+// The no-debt leg is what keeps the always-on loop free — an owner that dumped
+// conntrack every tick regardless would be a permanent cost on every healthy
+// node.
+func TestRetryReDrivesTheOwedRequest6802(t *testing.T) {
+	t.Run("with-debt", func(t *testing.T) {
+		calls := installConntrackDeleteStub(t, errors.New("still failing"))
+		d := &Daemon{applySem: semaphore.NewWeighted(1)}
+		d.noteHostInboundConntrackFlush(flushReq6802(), false)
+		before := *calls
+
+		d.retryHostInboundConntrackFlushOnce(context.Background())
+
+		if *calls <= before {
+			t.Fatal("the retry owner did not re-drive the owed revocation — " +
+				"no ticker under pkg/daemon re-runs the flush, so without this " +
+				"the only re-attempt is the next externally-triggered apply (#6802)")
+		}
+		if !d.HostInboundConntrackRevocationOwed() {
+			t.Fatal("a retry that FAILED AGAIN cleared the debt, so it would " +
+				"never be retried a third time")
+		}
+	})
+
+	t.Run("no-debt", func(t *testing.T) {
+		calls := installConntrackDeleteStub(t, nil)
+		d := &Daemon{applySem: semaphore.NewWeighted(1)}
+
+		d.retryHostInboundConntrackFlushOnce(context.Background())
+
+		if *calls != 0 {
+			t.Fatalf("the retry owner dumped conntrack %d times with NO debt "+
+				"owed — the always-on loop must be free on a healthy node", *calls)
+		}
+	})
+
+	t.Run("retry-that-succeeds-clears-the-debt", func(t *testing.T) {
+		installConntrackDeleteStub(t, nil)
+		d := &Daemon{applySem: semaphore.NewWeighted(1)}
+		d.noteHostInboundConntrackFlush(flushReq6802(), false)
+
+		d.retryHostInboundConntrackFlushOnce(context.Background())
+
+		if d.HostInboundConntrackRevocationOwed() {
+			t.Fatal("a SUCCESSFUL retry did not clear the debt — the owner would " +
+				"re-drive it forever")
+		}
+	})
+}
+
+// TestRetryRechecksTheDebtInsideTheSemaphore6802 pins the #4001 ordering.
+//
+// The outer check is an optimisation; the inner one is the correctness gate. A
+// tick that blocked behind an in-flight commit may find that the commit's own
+// flush already succeeded and cleared the debt — re-driving then is a conntrack
+// dump for nothing, against a desired set that is no longer current.
+//
+// Every other cell drives the retry single-threaded, where the semaphore is
+// invisible by construction, so this is the only cell that can see it.
+func TestRetryRechecksTheDebtInsideTheSemaphore6802(t *testing.T) {
+	calls := installConntrackDeleteStub(t, nil)
+	d := &Daemon{applySem: semaphore.NewWeighted(1)}
+	d.noteHostInboundConntrackFlush(flushReq6802(), false)
+
+	if err := d.applySem.Acquire(context.Background(), 1); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	before := *calls
+
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		close(started)
+		d.retryHostInboundConntrackFlushOnce(context.Background())
+		close(done)
+	}()
+	<-started
+
+	// Simulate the commit this tick queued behind having flushed successfully.
+	d.noteHostInboundConntrackFlush(flushReq6802(), true)
+	d.applySem.Release(1)
+	<-done
+
+	if *calls != before {
+		t.Fatalf("the retry dumped conntrack %d extra times after the commit it "+
+			"queued behind had already cleared the debt — re-checking INSIDE the "+
+			"semaphore is what prevents that (#6802)", *calls-before)
+	}
+}
+
+// TestRetryLoopTicks6802 binds the loop BODY, and TestRunStartsTheConntrackRetryLoop6802
+// (below) binds its START. They fail for different reasons: this reds if the
+// ticker is wired to the wrong function, that one reds if Run never launches it.
+func TestRetryLoopTicks6802(t *testing.T) {
+	calls := installConntrackDeleteStub(t, errors.New("still failing"))
+	d := &Daemon{applySem: semaphore.NewWeighted(1)}
+	d.noteHostInboundConntrackFlush(flushReq6802(), false)
+
+	orig := hostInboundConntrackReassertInterval
+	hostInboundConntrackReassertInterval = 5 * time.Millisecond
+	t.Cleanup(func() { hostInboundConntrackReassertInterval = orig })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	loopDone := make(chan struct{})
+	go func() { d.hostInboundConntrackReassertLoop(ctx); close(loopDone) }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for *calls == 0 {
+		if time.Now().After(deadline) {
+			cancel()
+			<-loopDone
+			t.Fatal("the retry loop never re-drove the owed revocation (#6802)")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	cancel()
+	select {
+	case <-loopDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("hostInboundConntrackReassertLoop did not return on cancellation")
+	}
+}
+
+// TestRunStartsHostInboundConntrackReassertLoop6802 is the LOOP-START cell.
+//
+// It exists because every cell above drives retryHostInboundConntrackFlushOnce
+// or the loop function DIRECTLY, so a Run that never launched the owner would
+// pass all of them — and "no retry owner" is the entire issue. #6793 shipped
+// this exact gap: its matrix came back green on the loop-start question because
+// nothing bound it.
+//
+// Run() itself cannot be driven from a unit test (netlink, a dataplane, sockets,
+// listeners), so the start is asserted at the source, the way #6791 does for
+// fabricIPVLANReassertLoop. Comments are stripped first: a source-scanning gate
+// that greps for a line its own doc comment quotes is satisfied by the comment.
+//
+// FAIL-ON-REVERT: delete the `d.hostInboundConntrackReassertLoop(ctx)` goroutine
+// from Run, or gate it behind a mode check, and this reds.
+func TestRunStartsHostInboundConntrackReassertLoop6802(t *testing.T) {
+	src := stripLineComments6791(readDaemonSource(t, "daemon_run.go"))
+
+	const call = "d.hostInboundConntrackReassertLoop(ctx)"
+	if !strings.Contains(src, call) {
+		t.Fatalf("Run does not start hostInboundConntrackReassertLoop; a failed " +
+			"host-inbound conntrack revocation has no retry owner (#6802) and a " +
+			"now-denied host service stays reachable on its established kernel " +
+			"connection until it closes or an operator commits again")
+	}
+	// …and it must be UNCONDITIONAL. The revocation is driven from every real
+	// apply on standalone AND cluster nodes, so a mode gate would leave one of
+	// them with no owner — the same defect, narrowed.
+	idx := strings.Index(src, call)
+	window := src[clampZero6791(idx-400):idx]
+	for _, gate := range []string{
+		"if d.cluster != nil",
+		"if d.isCluster",
+		"if d.opts.ClusterEnabled",
+	} {
+		if strings.Contains(window, gate) {
+			t.Errorf("hostInboundConntrackReassertLoop is started behind %q; the "+
+				"host-inbound conntrack revocation runs on standalone nodes too "+
+				"and needs the same retry owner", gate)
+		}
+	}
+}
+
+// TestDaemonWiresHostInboundConntrackMetrics6802 binds the OBSERVABILITY half of
+// the fix to a production caller.
+//
+// The issue's finding was not only "no retry owner" — it was that the failure
+// left no return value, no dirty flag, no counter, NO METRIC and no retry. An
+// exported HostInboundConntrackRevocationOwed / HostInboundConntrackFlushFailures
+// that nothing calls satisfies none of that: it is the #6852 shape (an exported
+// method with no production caller), and the accessor tests would stay green
+// with the operator still blind.
+//
+// startHTTPServer builds the api.Config inline and launches a goroutine, so it
+// cannot be driven from a unit test; the assignment is asserted at the source
+// with comments stripped, the same instrument the loop-start cell uses.
+//
+// FAIL-ON-REVERT: drop either assignment from daemon_run_servers.go and this
+// reds, while every behavioural cell in this file stays green.
+func TestDaemonWiresHostInboundConntrackMetrics6802(t *testing.T) {
+	src := stripLineComments6791(readDaemonSource(t, "daemon_run_servers.go"))
+
+	for _, want := range []string{
+		"HostInboundConntrackRevocationOwedFn: d.HostInboundConntrackRevocationOwed",
+		"HostInboundConntrackFlushFailuresFn:  d.HostInboundConntrackFlushFailures",
+	} {
+		if !strings.Contains(src, want) {
+			t.Errorf("daemon does not wire %q into the REST/metrics server; the "+
+				"accessor has no production caller, so a failed host-inbound "+
+				"conntrack revocation is still invisible to an operator (#6802, "+
+				"and the #6852 no-production-caller shape)", want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #6802.

## What the issue is, re-derived at head

The #5566 reconcile deletes established **kernel** conntrack entries for host
services the operator has just removed, because those entries would otherwise
ride the host-inbound chain's leading `ct state established,related accept`. So a
delete failure fails **OPEN**: the now-denied service keeps being served on every
connection that already existed.

**Failing the commit is deliberately not the fix, and I did not make it one.**
The in-code rationale is sound — the nft table is already applied, so enforcement
for NEW connections holds, and rolling the commit back over a transient
conntrack-subsystem error would discard correct enforcement. What was missing was
everything *else*. The flush returned no value, set no dirty flag, bumped no
counter, published no metric, and nothing re-ran it: I enumerated every ticker
under `pkg/daemon` — DDNS, RPM, HA fabric, HA, IPsec rebind, DHCP lease sync,
neighbor, proxy-ARP, archive, kernel self-recover — and **none** re-drives
`applyConfig`, `applyHostInboundFilter` or the flush. The only re-attempt was the
next externally-triggered apply, itself gated on `InstallHostInbound` succeeding.
The stale authorization persisted until the flow closed or timed out.

Note that this issue's cited evidence file (`/tmp/opus-review-001.md`) no longer
exists and is not in git or `docs/reviews/`; the above is re-derived from source
at current `origin/master`. I annotated all 15 issues sharing that dead
reference.

## The fix

Mirrors the recovery shape #6793 (dead RA senders) and #6791 (fabric IPVLAN)
already use.

- `flushDeniedHostInboundConntrack` returns whether every family's delete
  succeeded. A one-family failure still sweeps the other family — the `continue`
  is deliberate and the failure is carried out in the return value, not swallowed.
- `noteHostInboundConntrackFlush` retains the **exact** request the failed flush
  was called with. Not a set re-derived at retry time: a re-derived set would
  attempt a *different* revocation than the one that failed, and the two diverge
  precisely when a commit landed in between.
- `hostInboundConntrackReassertLoop` is the retry owner, started
  **unconditionally** in `Run` beside the proxy-ARP / RA / fabric loops at the
  same 30s cadence. The gate is a single atomic pointer load, so it is free on a
  node whose revocations have all succeeded. Like its siblings it takes `applySem`
  **before** acting (#4001) and re-reads the debt **inside** the semaphore,
  because the commit it queued behind may already have flushed successfully.
- A success clears the debt — the filter is built from the desired set, so a
  current revocation subsumes an older one.

## Wired, not merely exported

`HostInboundConntrackRevocationOwed` / `HostInboundConntrackFlushFailures` reach
the REST/metrics server via `daemon_run_servers.go`, mirroring the
`IPsecRebindPendingFn` (#4899) precedent:

| Series | Meaning |
|---|---|
| `xpf_host_inbound_conntrack_revocation_pending` | `1` while a revocation has failed and not been re-driven |
| `xpf_host_inbound_conntrack_revocation_failures_total` | every failed attempt, retries included — climbing while the gauge stays `1` means the owner runs but does not converge |

An exported accessor with no production caller is the #6852 shape and would have
left an operator exactly as blind as before. Both series are **omitted**, not
published as `0`, when unwired — the #6828 absent-vs-zero distinction.

## Mutation matrix

Fix committed first. Every cell is a full-package `go test -count=1` with **no
`-run` filter**. Controls: unmutated `pkg/daemon` and `pkg/api` both GREEN.

| # | Mutation | Result | Cell that red |
|---|---|---|---|
| M1 | flush drops `ok = false` on a delete error | **RED** | `TestFlushReportsItsOutcome6802` |
| M2 | failed flush no longer stores debt | **RED** | `TestFailedFlushRetainsDebtAndSuccessClearsIt6802` |
| M3 | successful flush no longer clears debt | **RED** | `TestFailedFlushRetainsDebtAndSuccessClearsIt6802` |
| M4 | call site discards the flush outcome (**the wiring revert**) | **RED** | `TestApplyHostInboundFilterRecordsTheFlushOutcome6802` |
| M5b | debt read **once, before** the semaphore (the #4001 revert) | **RED** | `TestRetryRechecksTheDebtInsideTheSemaphore6802` |
| M6 | retry no longer records its own outcome | **RED** | `TestRetryReDrivesTheOwedRequest6802` |
| M7 | `Run` no longer starts the loop | **RED** | `TestRunStartsHostInboundConntrackReassertLoop6802` |
| M8 | daemon stops wiring the pending-gauge fn | **RED** | `TestDaemonWiresHostInboundConntrackMetrics6802` |
| M9 | collector stops emitting the pending gauge | **RED** | `TestHostInboundConntrackRevocationPendingGauge6802` |
| M10 | `Describe` drops the pending-gauge desc | **RED** | `TestHostInboundConntrackRevocationPendingGauge6802` |
| M11 | counter emits a constant `0` instead of the fn's value | **RED** | `TestHostInboundConntrackRevocationFailuresCounter6802` |
| M12 | collector stops emitting the counter (tightening control) | **RED** | `TestHostInboundConntrackRevocationFailuresCounter6802` |

**One mutation is worth reporting because it did NOT discriminate.** My first cut
of M5 replaced the inner re-read with a helper returning an empty request on nil.
That came back **GREEN** — and correctly so: an empty request builds a **nil**
filter, so the delete seam is never reached either way, exactly as if the function
had returned early. The mutation was extensionally equivalent to the fix at the
observed seam, not a test gap. Re-cut as the real revert (hoist the load above
`Acquire` and use that stale pointer), it reds. Reporting it rather than counting
it.

Two gaps this closed, both of the kind that stay invisible:

- the pre-existing #5566 stub always returned `(0, nil)`, so **no test exercised
  the delete-error path at all**;
- #6793 shipped without a loop-START cell — every other cell drives the retry
  function directly, so a `Run` that never launched the owner passes all of them.
  M7 confirms this one is now bound.

## Validation

- `go build ./...` **rc=0**, `go vet ./...` **rc=0**, `go test -count=1 ./...`
  repo-wide **rc=0**, at HEAD `d1a77ad17ada0726f4d204804873ed6731694e65` (merges
  current `origin/master`).
- Rust files touched: **0** — no cargo leg owed.
- Docs updated in the same change: `docs/host-inbound-service-matrix.md` (the
  "Best effort" bullet was stating the pre-fix contract; replaced, plus a new
  "Revocation failure is retried, counted, and published" section) and
  `pkg/daemon/README.md` (beside the #6791/#6793 reassert-loop entries).

## Smoke

**No cluster smoke owed by the change class** — nothing here touches cluster,
VRRP, session sync or failover code, and it does not change *which* conntrack
entries are flushed, only that a failed flush is retried with the same desired
set. The one staleness question I checked explicitly: debt armed at T0 with set
S0 is superseded at the next apply (success clears it, failure overwrites it with
the new set), so the retry can never re-drive a revocation the operator has
already replaced. Happy to run `make cluster-deploy && make test-failover` if you
want it anyway — master measured 14/14 earlier today, so a failure would be
cleanly attributable.
