### PR TITLE
daemon: hand released NICs back their RSS and coalescence (#6801)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -105106,9 +105106,9 @@ prose edit above them added. No diff falls in the new test body.
   coalescence, host-scope knobs and neigh retrans). Separate lifecycle question
   — a second bounded ethtool round-trip per owned NIC on a path already capped
   by `TimeoutStopSec=20`, plus a changed restart profile.
-- **Mutation matrix**: 7 production lines reverted one at a time, each with a
-  full-package `go test -count=1 ./pkg/daemon/` and no `-run` filter; every cell
-  named a RED. Fixtures run two reconciles and move an interface out of the
+- **Mutation matrix**: 10 cells, each reverting ONE production line/guard, each
+  with a full-package `go test -count=1 ./pkg/daemon/` and no `-run` filter;
+  every cell named a RED, none escaped, none build-broke. Fixtures run two reconciles and move an interface out of the
   binding set between them — a fixture whose allowlist never shrinks cannot see
   the teardown at all. The pre-xpfd probe uses rx-usecs 42 / tx-usecs 43, values
   xpf never writes, so a restore assertion cannot be satisfied by an apply.

--- a/_Log.md
+++ b/_Log.md
@@ -105045,3 +105045,51 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: `pkg/daemon/rg_state.go`, `pkg/daemon/daemon_ha.go`,
   `pkg/daemon/rg_apply_invalidate_race_6799_test.go`,
   `pkg/daemon/rg_state_test.go`, `pkg/daemon/README.md`, `_Log.md`
+
+## 2026-08-26 — #6801 released-NIC RSS/coalescence teardown
+
+- **Timestamp**: 2026-08-26
+- **Action**: Hand a NIC's RSS indirection table and interrupt coalescence back
+  when it LEAVES the userspace-dp interface allowlist, instead of leaving xpf's
+  tuning live on a released NIC until daemon shutdown.
+- **Root cause**: both reconcilers derive their target set from one allowlist,
+  `dpuserspace.UserspaceBoundLinuxInterfaces(cfg)`, recomputed from the NEW
+  compiled config on every reconcile — so both are blind to a SHRINKING
+  allowlist. `{ge-0-0-1, ge-0-0-2}` → `{ge-0-0-1}` walks only the new set;
+  nothing ever visits the released name. The coalescence capture was reverted
+  only at daemon stop; the RSS table was never reverted at all.
+- **Fix**: `released_nic_tunables.go` adds a level-triggered `owned - current`
+  teardown wired into `applyStep0TunablesWith` (boot + every commit), ahead of
+  the claim and the re-apply, mirroring the managed→unmapped teardown
+  `device_map.go` runs before `networkd.Apply`. Ownership is the union of the
+  new `priorHostTunables.rssOwned` set and the existing `mlx5Adaptive` capture
+  map; it is dropped only after the restore write SUCCEEDS (#5114 retry-debt
+  shape), so a failed `ethtool` is retried on the next reconcile.
+- **The middle row**: an EMPTY allowlist is not, by itself, a withdrawal.
+  `UserspaceBoundLinuxInterfaces` degrades to nil when its snapshot build fails
+  (#2514) and `applyTailReconciles` still runs the tunable step on a commit
+  whose dataplane apply FAILED — so "no names" as "release everything" would rip
+  the tuning off NICs the dataplane is still forwarding on, and
+  `ethtool -X ... default` mid-traffic re-steers in-flight flows onto different
+  RX queues. The withdrawal trigger is the config signal (`userspaceDP ==
+  false`), never an empty list. Without that guard the fix is a regression, and
+  a fixture that only ever shrinks a non-empty list cannot see it.
+- **Interface disappearance**: a released name that is no longer an mlx5 netdev
+  drops ownership WITHOUT an ethtool call — honors the #797 H1 "never ethtool a
+  non-mlx5 netdev" guard and stops retry debt growing without bound on a NIC
+  that can never accept the restore.
+- **Out of scope, reported as a follow-up**: `restoreStep0TunablesOnShutdown`
+  still does not restore the default RSS table on daemon stop (it does revert
+  coalescence, host-scope knobs and neigh retrans). Separate lifecycle question
+  — a second bounded ethtool round-trip per owned NIC on a path already capped
+  by `TimeoutStopSec=20`, plus a changed restart profile.
+- **Mutation matrix**: 7 production lines reverted one at a time, each with a
+  full-package `go test -count=1 ./pkg/daemon/` and no `-run` filter; every cell
+  named a RED. Fixtures run two reconciles and move an interface out of the
+  binding set between them — a fixture whose allowlist never shrinks cannot see
+  the teardown at all. The pre-xpfd probe uses rx-usecs 42 / tx-usecs 43, values
+  xpf never writes, so a restore assertion cannot be satisfied by an apply.
+- **File(s)**: `pkg/daemon/released_nic_tunables.go` (new),
+  `pkg/daemon/released_nic_tunables_6801_test.go` (new),
+  `pkg/daemon/host_tunables.go`, `pkg/daemon/host_tunables_daemon.go`,
+  `pkg/daemon/rss_indirection.go`, `pkg/daemon/README.md`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -105112,7 +105112,18 @@ prose edit above them added. No diff falls in the new test body.
   binding set between them — a fixture whose allowlist never shrinks cannot see
   the teardown at all. The pre-xpfd probe uses rx-usecs 42 / tx-usecs 43, values
   xpf never writes, so a restore assertion cannot be satisfied by an apply.
+- **Docs**: `pkg/daemon/README.md` gains "NIC tuning ownership +
+  released-interface teardown (#6801)" (the module doc — all the code is in
+  `pkg/daemon`). `docs/userspace-dataplane-architecture.md` gains the
+  allowlist-EXIT contract next to the existing D3/RSS allowlist block, since
+  that doc is where the allowlist's meaning is defined and "what happens when a
+  netdev leaves it" was the gap. NOT touched, with reasons:
+  `pkg/dataplane/README.md` (carries no RSS/D3/coalescence surface at all —
+  `grep -n 'rss\|coalesc\|D3'` is empty), root `README.md` (same), and
+  `docs/config-schema.md` (no config-mode leaf added or changed — the teardown
+  is keyed on the EXISTING `system dataplane` knobs).
 - **File(s)**: `pkg/daemon/released_nic_tunables.go` (new),
   `pkg/daemon/released_nic_tunables_6801_test.go` (new),
   `pkg/daemon/host_tunables.go`, `pkg/daemon/host_tunables_daemon.go`,
-  `pkg/daemon/rss_indirection.go`, `pkg/daemon/README.md`, `_Log.md`
+  `pkg/daemon/rss_indirection.go`, `pkg/daemon/README.md`,
+  `docs/userspace-dataplane-architecture.md`, `_Log.md`

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -577,6 +577,27 @@ Cross-plane parity is guarded by `replan_queues_binds_vlan_unit_on_parent_netdev
 `snapshot_allowlist_test.go`). Changing one plane's rule without the other
 turns these RED.
 
+**Leaving the allowlist is a contract, not just an absence (#6801).** The
+allowlist is not only a permission to bind — it is also what authorises xpf to
+reshape the NIC: the D3 RSS indirection table (`pkg/daemon/rss_indirection.go`)
+and interrupt coalescence (`pkg/daemon/coalescence.go`) are applied to its mlx5
+members. Both reconcilers walk only the CURRENT allowlist, so until #6801 a
+netdev DROPPED from it kept xpf's concentrated RSS table and its adaptive-off /
+pinned-usecs coalescence — the coalescence capture was reverted only at daemon
+shutdown, and the RSS table was never reverted at all. A NIC handed back to the
+host stack or to another dataplane stayed limited to the old AF_XDP queue
+subset.
+
+The operator-visible contract is now symmetric: **a netdev that leaves the
+userspace-dp allowlist gets its default RSS indirection table and its pre-xpf
+coalescence back on the same commit.** Withdrawal is keyed on the CONFIG signal
+(the userspace dataplane being disabled), never on an empty derived list —
+`UserspaceBoundLinuxInterfaces` degrades to nil on a snapshot-build error
+(#2514), and treating "no names" as "release everything" would rip the tuning
+off NICs the dataplane is still forwarding on. Mechanism, ownership records and
+retry-debt semantics: `pkg/daemon/README.md`, "NIC tuning ownership +
+released-interface teardown (#6801)".
+
 #### Session Table (`session.rs`)
 
 Per-worker hash table using a SEEDED `FxHasher` (`FxSeededState`, fast

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -1255,6 +1255,82 @@ Any interface not declared in the active config is brought down and given
 `ActivationPolicy=always-down` in networkd — EXCEPT the #1922 protected set
 (see below).
 
+### NIC tuning ownership + released-interface teardown (#6801)
+
+Two per-interface knobs are written to the mlx5 NICs the userspace
+dataplane binds AF_XDP on:
+
+- the **RSS indirection table** (`rss_indirection.go`, D3 / #785) — hash
+  outputs are concentrated onto queues `0..workers-1`;
+- **interrupt coalescence** (`coalescence.go`, #801 Step-0) — adaptive
+  off, `rx-usecs`/`tx-usecs` pinned.
+
+Both take their target set from ONE allowlist,
+`dpuserspace.UserspaceBoundLinuxInterfaces(cfg)`, recomputed from the
+**new** compiled config on every reconcile — so both were blind to an
+allowlist that SHRANK. Binding `{ge-0-0-1, ge-0-0-2}` and then committing
+a config that binds only `ge-0-0-1` left `ge-0-0-2` with xpf's
+concentrated RSS table and adaptive-off/pinned-usecs coalescence: every
+loop walked the new set, so nothing ever visited the released name. The
+coalescence capture was reverted only at daemon shutdown; the RSS table
+was never reverted at all. A NIC handed back to the host stack or to
+another dataplane stayed limited to the old AF_XDP queue subset.
+
+`released_nic_tunables.go` closes that with a level-triggered
+`owned - current` teardown, run from `applyStep0TunablesWith` (which
+executes at boot AND on every commit):
+
+| Step | Function | What it does |
+|------|----------|--------------|
+| release | `releaseUnboundNICTunables` | For each owned interface absent from the current allowlist: `ethtool -X <if> default` + restore the captured pre-xpfd coalescence, then drop ownership |
+| claim | `claimNICTunableOwnership` | Union the current allowlist's mlx5 members into the owned set |
+
+Ownership is two records, unioned, because the knobs diverge on error
+paths: `priorHostTunables.rssOwned` (a set — the restore is the
+idempotent `ethtool -X default`, so no prior table has to be captured)
+and `priorHostTunables.mlx5Adaptive` (the coalescence capture, which
+exists only when the `ethtool -c` probe parsed).
+
+Invariants worth keeping:
+
+- **Ownership is released only after the restore write SUCCEEDS.** A
+  failed `ethtool` keeps the interface owned, so the next reconcile
+  recomputes the same released set and retries. No timer is needed —
+  a released name stays outside the allowlist until it is re-bound.
+  Same shape as the #5114 host-scope retry debt.
+- **An empty allowlist is NOT, by itself, a withdrawal.**
+  `UserspaceBoundLinuxInterfaces` degrades to nil when its snapshot build
+  fails (#2514), and `applyTailReconciles` still runs the tunable step on
+  a commit whose dataplane apply failed. Treating "no names" as "release
+  everything" would let a transient derivation error rip the tuning off
+  NICs the dataplane is still forwarding on, and `ethtool -X ... default`
+  mid-traffic re-steers in-flight flows onto different RX queues. The
+  withdrawal trigger is therefore the CONFIG signal — `userspaceDP ==
+  false`, a pure config read with no error path — never an empty list.
+  With userspace-dp still enabled and an empty list, ownership is
+  retained untouched, mirroring the refusal `applyRSSIndirection` and
+  `applyCoalescence` already make.
+- **A released name that is no longer an mlx5 netdev drops ownership
+  without an ethtool call.** Unplugged, renamed by a `.link` change, or
+  rebound to another driver — the ring/coalescence configuration went
+  with it. This honors the "never invoke ethtool on a non-mlx5 netdev"
+  guard (#797 H1) and stops retry debt growing without bound on a NIC
+  that can never accept the restore.
+- **The claim is config-derived, deliberately a superset** of "actually
+  reprogrammed this reconcile". Over-claiming costs at most one extra
+  idempotent `ethtool -X <if> default` on release — the same call the
+  rss-indirection kill switch already issues on exactly this set.
+  Under-claiming is the defect: a NIC xpf tunes but never records can
+  never be handed back.
+
+Not covered: restoring the default RSS table on **daemon stop**.
+`restoreStep0TunablesOnShutdown` reverts coalescence, host-scope knobs
+and neigh `retrans_time_ms`, but not `rssOwned` — that is a separate
+lifecycle question (a second bounded `ethtool` round-trip per owned NIC
+on a shutdown path already capped by `TimeoutStopSec=20`, plus a changed
+restart profile). #6801 scopes itself to interfaces that leave xpf's
+ownership while the daemon keeps running.
+
 ## Bootstrap mode + management lifeline (#1922)
 
 `bootstrap.go` implements the SAFE-BOOTSTRAP daemon state so the daemon can

--- a/pkg/daemon/host_tunables.go
+++ b/pkg/daemon/host_tunables.go
@@ -575,6 +575,17 @@ type priorHostTunables struct {
 	// that path; restore does nothing on it. Stored as a string so the
 	// exact byte form the kernel served is round-tripped on restore.
 	neighRetrans map[string]string
+	// rssOwned is the set of mlx5 interfaces whose RSS indirection
+	// table xpfd may have moved away from the kernel default (#6801).
+	// Unlike the maps above this holds no captured VALUE: the restore
+	// action is `ethtool -X <iface> default`, the same idempotent call
+	// the rss-indirection kill switch issues, so the pre-xpfd table
+	// never has to be reconstructed. Membership is the ownership claim
+	// — see claimNICTunableOwnership for why it is deliberately a
+	// superset of "reprogrammed on this reconcile", and
+	// releaseUnboundNICTunables for the `owned - current` teardown that
+	// consumes it.
+	rssOwned map[string]struct{}
 }
 
 // mlx5CoalesceState captures the four fields xpfd writes via ethtool -C.
@@ -595,6 +606,7 @@ func newPriorHostTunables() *priorHostTunables {
 		governors:    map[string]string{},
 		mlx5Adaptive: map[string]mlx5CoalesceState{},
 		neighRetrans: map[string]string{},
+		rssOwned:     map[string]struct{}{},
 	}
 }
 
@@ -651,6 +663,20 @@ func (p *priorHostTunables) captureMlx5Coalesce(iface string, s mlx5CoalesceStat
 		return
 	}
 	p.mlx5Adaptive[iface] = s
+}
+
+// claimRSSOwnership records that xpfd holds the RSS indirection table of
+// iface (#6801). Idempotent. Lazily allocates the set so a capture
+// struct built by an older newPriorHostTunables caller (tests predating
+// the field) does not panic.
+func (p *priorHostTunables) claimRSSOwnership(iface string) {
+	if p == nil || iface == "" {
+		return
+	}
+	if p.rssOwned == nil {
+		p.rssOwned = map[string]struct{}{}
+	}
+	p.rssOwned[iface] = struct{}{}
 }
 
 // restoreHostTunables writes every captured tunable back to the kernel.
@@ -804,8 +830,11 @@ func restoreNeighRetransTime(p *priorHostTunables, fs hostTunableFS) map[string]
 
 // restoreMlx5Coalesce emits one `ethtool -C <iface> adaptive-rx ...
 // adaptive-tx ... rx-usecs ... tx-usecs ...` matching the pre-xpfd
-// capture. Errors logged, never returned.
-func restoreMlx5Coalesce(iface string, s mlx5CoalesceState, execer rssExecutor) {
+// capture. Errors are logged here and ALSO returned (#6801): the
+// released-interface teardown releases ownership of a capture only after
+// its restore write succeeds, so it needs the outcome, while the
+// shutdown and full-restore callers keep ignoring it (best-effort).
+func restoreMlx5Coalesce(iface string, s mlx5CoalesceState, execer rssExecutor) error {
 	adaptRX := "off"
 	if s.adaptiveRX {
 		adaptRX = "on"
@@ -825,15 +854,16 @@ func restoreMlx5Coalesce(iface string, s mlx5CoalesceState, execer rssExecutor) 
 		if isExecNotFound(err) {
 			slog.Warn("linksetup: host tunable restore — ethtool missing for mlx5 coalesce restore",
 				"iface", iface)
-			return
+			return err
 		}
 		slog.Warn("linksetup: host tunable restore — ethtool -C failed",
 			"iface", iface, "err", err,
 			"output", strings.TrimSpace(string(out)))
-		return
+		return err
 	}
 	slog.Info("linksetup: coalescence restored to pre-xpfd value",
 		"iface", iface, "adaptive_rx", s.adaptiveRX,
 		"adaptive_tx", s.adaptiveTX,
 		"rx_usecs", s.rxUsecs, "tx_usecs", s.txUsecs)
+	return nil
 }

--- a/pkg/daemon/host_tunables_daemon.go
+++ b/pkg/daemon/host_tunables_daemon.go
@@ -114,11 +114,34 @@ func (d *Daemon) applyStep0TunablesWith(userspaceDP, claimHostTunables bool,
 		prior = newPriorHostTunables()
 	}
 
+	// #6801: hand back every NIC that LEFT the userspace-dp allowlist
+	// before re-applying anything to the set xpfd retains. Both
+	// reconcilers below (and reapplyRSSIndirection on the commit path)
+	// iterate only the CURRENT allowlist, so without this pass a NIC
+	// dropped from the binding set — or the whole set, when userspace-dp
+	// is disabled at runtime and rssAllowed goes empty — kept xpfd's
+	// concentrated RSS table and adaptive-off/pinned-usecs coalescence
+	// until the daemon exited.
+	//
+	// Ordering: released and retained are disjoint by construction
+	// (released = owned - current), so placing this before the claim and
+	// the re-apply is the device_map managed->unmapped precedent — hand
+	// the NIC back first — not a correctness dependency.
+	//
+	// An empty allowlist is NOT a withdrawal while userspace-dp is still
+	// enabled; only the config signal is. See releaseUnboundNICTunables.
+	releaseUnboundNICTunables(prior, rssAllowed, userspaceDP, execer)
+
 	// Coalescence always runs for userspace-dp deploys. Empty
 	// allowlist = no-op inside applyCoalescence. The allowlist is
 	// D3-scoped (UserspaceBoundLinuxInterfaces) so we never touch an
 	// mlx5 interface outside xpfd's zone model.
 	if userspaceDP {
+		// #6801: claim the current allowlist's mlx5 members before the
+		// writes below. Ownership is what the released-NIC teardown
+		// consumes on a later reconcile; a NIC xpfd tunes but never
+		// records is a NIC it can never hand back.
+		claimNICTunableOwnership(prior, rssAllowed, execer)
 		applyCoalescence(coalesceEnable, coalesceRX, coalesceTX, rssAllowed, execer, prior)
 		// #1636 option B: lower the kernel neighbor retrans_time_ms so a
 		// dropped ARP/NDP solicit is re-driven ~4× sooner. NOT gated on
@@ -218,6 +241,15 @@ func (d *Daemon) applyStep0TunablesWith(userspaceDP, claimHostTunables bool,
 //   - Per-interface coalescence (mlx5Adaptive map): captured any time
 //     coalescence ran, which is any userspace-dp start regardless of
 //     the opt-in gate (Codex round-2 fix).
+//
+// NOT covered: the #6801 rssOwned claim. Restoring the default RSS
+// indirection table on daemon stop is a separate lifecycle question from
+// the allowlist-shrink teardown this file implements — it would add a
+// second bounded `ethtool` round-trip per owned NIC to a shutdown path
+// already capped by the unit's TimeoutStopSec=20, and it changes the
+// restart profile (default table on stop, re-concentrated on the next
+// boot). #6801 deliberately scopes itself to interfaces that leave xpf's
+// ownership while the daemon keeps running.
 //
 // Best-effort: never returns an error. Safe to call when no tunable
 // was ever captured (no-op).

--- a/pkg/daemon/released_nic_tunables.go
+++ b/pkg/daemon/released_nic_tunables.go
@@ -1,0 +1,223 @@
+// Released-NIC tuning teardown (#6801).
+//
+// # The ownership hole this closes
+//
+// Two per-interface tuning knobs are applied to the mlx5 NICs that the
+// userspace dataplane binds AF_XDP on — the D3 RSS indirection table
+// (rss_indirection.go) and interrupt coalescence (coalescence.go). Both
+// derive their target set from ONE allowlist,
+// dpuserspace.UserspaceBoundLinuxInterfaces(cfg), recomputed from the
+// *new* compiled config on every reconcile.
+//
+// That made both reconcilers blind to a SHRINKING allowlist. With config
+// A binding {ge-0-0-1, ge-0-0-2} and config B binding only {ge-0-0-1},
+// every loop walks the new set — so ge-0-0-2 kept xpf's concentrated RSS
+// table and its adaptive-off / pinned-usecs coalescence even though xpf
+// no longer owned it. The coalescence capture was restored only at daemon
+// shutdown; the RSS table was never restored at all. A NIC handed back to
+// the host stack (or to another dataplane) stayed limited to the old
+// AF_XDP queue subset with latency-oriented coalescence until xpfd
+// stopped or an operator ran ethtool by hand.
+//
+// # The invariant
+//
+// Every host/NIC mutation must be reverted when the interface leaves xpf
+// ownership — not only when the process exits. This file implements that
+// as a level-triggered `owned - current` teardown:
+//
+//	release: for each iface in owned but NOT in the current allowlist,
+//	         restore the default RSS indirection table and the captured
+//	         pre-xpfd coalescence, then drop ownership.
+//	claim:   union the current allowlist's mlx5 members into the owned
+//	         set (claim-before-touch; see claimNICTunableOwnership).
+//
+// The released and retained sets are disjoint by construction, so the
+// release is order-independent with respect to both the claim and the
+// re-apply. It is placed first anyway, mirroring the managed->unmapped
+// teardown that pkg/daemon/device_map.go runs before networkd.Apply: a
+// NIC leaving xpf's ownership is handed back before xpf spends
+// bounded-but-real ethtool round-trips on the set it keeps.
+//
+// # Why an EMPTY allowlist is not, by itself, a withdrawal
+//
+// UserspaceBoundLinuxInterfaces degrades to nil when its snapshot build
+// fails (see its #2514 comment), and applyTailReconciles still runs the
+// tunable step on a commit whose dataplane apply failed. Treating "no
+// names" as "release everything" would therefore let a transient
+// derivation error rip xpf's tuning off NICs the dataplane is still
+// forwarding on — and `ethtool -X ... default` mid-traffic re-steers
+// in-flight flows onto different RX queues. So the withdrawal trigger is
+// the CONFIG signal (`userspaceDP == false`, a pure config read with no
+// error path), never an empty list. With userspace-dp still enabled and
+// an empty list, ownership is retained untouched — the same refusal to
+// act on an empty allowlist that applyRSSIndirection and applyCoalescence
+// already make.
+//
+// # Retry debt (#5114 shape)
+//
+// Ownership is dropped only after the restore write SUCCEEDS. A failed
+// `ethtool -X`/`-C` keeps the interface in the owned/capture map, so the
+// next reconcile recomputes the same released set and retries. No timer
+// is needed: the release is driven purely by `owned - current`, and a
+// released name stays outside the allowlist until it is re-bound.
+//
+// # Interface disappearance
+//
+// If a released name is no longer an mlx5 netdev — unplugged, renamed by
+// a .link change, or rebound to another driver — the tuning went with it
+// (a driver rebind resets ring and coalescence configuration). Ownership
+// is dropped WITHOUT an ethtool call: that both honors the Codex H1
+// invariant (never invoke ethtool on a non-mlx5 netdev) and stops the
+// retry debt from growing without bound on a NIC that can never accept
+// the restore.
+package daemon
+
+import (
+	"log/slog"
+	"sort"
+)
+
+// releasedNICTunableOwners returns, in deterministic (sorted) order, the
+// interfaces xpf still holds tuning ownership of that are ABSENT from
+// the current userspace-dp allowlist.
+//
+// Ownership is the union of two independent records, because the two
+// knobs can diverge on error paths: prior.rssOwned (the RSS indirection
+// claim) and prior.mlx5Adaptive (the coalescence capture, which only
+// exists when the `ethtool -c` probe parsed). An interface in either is
+// an interface xpf must hand back.
+//
+// A nil prior yields nil. An empty `current` yields every owned name —
+// that is the userspace-dataplane-disabled case, a withdrawal of the
+// full prior set, and it is deliberately not special-cased.
+func releasedNICTunableOwners(prior *priorHostTunables, current []string) []string {
+	if prior == nil {
+		return nil
+	}
+	if len(prior.rssOwned) == 0 && len(prior.mlx5Adaptive) == 0 {
+		return nil
+	}
+	keep := make(map[string]struct{}, len(current))
+	for _, iface := range current {
+		keep[iface] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(prior.rssOwned)+len(prior.mlx5Adaptive))
+	out := make([]string, 0, len(prior.rssOwned)+len(prior.mlx5Adaptive))
+	collect := func(iface string) {
+		if _, held := keep[iface]; held {
+			return
+		}
+		if _, dup := seen[iface]; dup {
+			return
+		}
+		seen[iface] = struct{}{}
+		out = append(out, iface)
+	}
+	for iface := range prior.rssOwned {
+		collect(iface)
+	}
+	for iface := range prior.mlx5Adaptive {
+		collect(iface)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// releaseUnboundNICTunables reverts xpf's RSS and coalescence changes on
+// every interface that has left the userspace-dp allowlist, then drops
+// ownership of the ones that restored successfully.
+//
+// Best-effort by contract, like every other tunable path: it never
+// returns an error and a failure never blocks a commit. A failure is
+// instead RETAINED as ownership so the next reconcile retries it.
+//
+// `userspaceDP` is the config signal, not a derived one: it is the only
+// thing that authorises a FULL withdrawal. When it is true but `current`
+// is empty the allowlist derivation may simply have failed, so this is a
+// no-op and ownership is retained — see the file header.
+//
+// Mutates prior's maps in place; the caller is responsible for holding
+// whatever lock guards the snapshot (applyStep0TunablesWith runs under
+// d.applySem, matching the existing capture/restore discipline).
+func releaseUnboundNICTunables(prior *priorHostTunables, current []string, userspaceDP bool, execer rssExecutor) {
+	if userspaceDP && len(current) == 0 {
+		slog.Debug("linksetup: released-NIC teardown skipped (userspace-dp enabled with an empty allowlist)")
+		return
+	}
+	released := releasedNICTunableOwners(prior, current)
+	if len(released) == 0 {
+		return
+	}
+	for _, iface := range released {
+		_, rssHeld := prior.rssOwned[iface]
+		coalesce, coalesceHeld := prior.mlx5Adaptive[iface]
+
+		// The netdev must still be the mlx5 NIC we tuned. If it is gone
+		// or rebound, its ring/coalescence configuration went with it —
+		// drop ownership rather than accruing debt we can never settle.
+		if drv := execer.readDriver(iface); drv != mlx5Driver {
+			delete(prior.rssOwned, iface)
+			delete(prior.mlx5Adaptive, iface)
+			slog.Info("linksetup: released interface is no longer an mlx5 netdev, dropping tuning ownership",
+				"iface", iface, "driver", drv)
+			continue
+		}
+
+		if rssHeld {
+			if err := restoreDefaultRSSIndirectionOne(iface, execer); err != nil {
+				slog.Warn("linksetup: released interface rss restore failed, retaining ownership for retry",
+					"iface", iface, "err", err)
+			} else {
+				delete(prior.rssOwned, iface)
+				slog.Info("linksetup: released interface restored to default rss indirection",
+					"iface", iface)
+			}
+		}
+		if coalesceHeld {
+			if err := restoreMlx5Coalesce(iface, coalesce, execer); err != nil {
+				slog.Warn("linksetup: released interface coalescence restore failed, retaining capture for retry",
+					"iface", iface, "err", err)
+			} else {
+				delete(prior.mlx5Adaptive, iface)
+			}
+		}
+	}
+}
+
+// claimNICTunableOwnership records every mlx5 member of the current
+// userspace-dp allowlist as an interface whose RSS indirection table xpf
+// may have moved away from the kernel default.
+//
+// The claim is CONFIG-derived, not touch-derived, and is deliberately a
+// superset of "reprogrammed this reconcile":
+//
+//   - It is claim-before-touch. An apply that dies partway through still
+//     leaves the NIC owned, so the next reconcile can hand it back.
+//   - Over-claiming costs at most one extra `ethtool -X <iface> default`
+//     on release. That call is idempotent and is exactly what the
+//     rss-indirection kill switch already issues on exactly this set, so
+//     it can never leave the NIC in a worse state.
+//   - Under-claiming is the actual defect (#6801): a NIC whose table xpf
+//     concentrated but did not record is never handed back.
+//
+// It is a UNION, not a replacement: releaseUnboundNICTunables has already
+// removed the names it restored and kept the names whose restore failed,
+// and that retry debt must survive the claim.
+//
+// Scope is unchanged from the reconcilers this mirrors: `lo` is skipped
+// and every name passes the same mlx5 driver guard, so no netdev outside
+// the userspace-dp binding allowlist is ever recorded.
+func claimNICTunableOwnership(prior *priorHostTunables, current []string, execer rssExecutor) {
+	if prior == nil || len(current) == 0 {
+		return
+	}
+	for _, iface := range current {
+		if iface == "lo" {
+			continue
+		}
+		if execer.readDriver(iface) != mlx5Driver {
+			continue
+		}
+		prior.claimRSSOwnership(iface)
+	}
+}

--- a/pkg/daemon/released_nic_tunables_6801_test.go
+++ b/pkg/daemon/released_nic_tunables_6801_test.go
@@ -1,0 +1,434 @@
+// Released-NIC tuning teardown tests (#6801).
+//
+// The defect these pin is invisible to any fixture whose allowlist never
+// SHRINKS: every reconciler walks the current allowlist, so with a fixed
+// set the teardown has nothing to do and deleting it changes nothing.
+// Every case here therefore runs at least two reconciles and moves an
+// interface OUT of the userspace-dp binding set between them.
+//
+// The pre-xpfd fixture deliberately uses rx-usecs 42 / tx-usecs 43 —
+// values xpf never writes (it writes the operator's 8/8) — so a restore
+// assertion cannot be satisfied by an apply that happened to run.
+package daemon
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// mlx5CoalesceProbePreXpfd is an `ethtool -c` dump whose adaptive state
+// and usecs are all distinct from anything xpf writes, so "restored to
+// the capture" and "applied xpf's config" are never confusable.
+const mlx5CoalesceProbePreXpfd = `Coalesce parameters for ge-0-0-1:
+Adaptive RX: on  TX: on
+stats-block-usecs: 0
+sample-interval: 0
+pkt-rate-low: 0
+pkt-rate-high: 0
+
+rx-usecs: 42
+rx-frames: 128
+rx-usecs-irq: 0
+rx-frames-irq: 0
+
+tx-usecs: 43
+tx-frames: 128
+tx-usecs-irq: 0
+tx-frames-irq: 0
+`
+
+// errEthtoolDenied is a transient ethtool failure injected through
+// fakeRSSExecutor.argvErr to exercise the retain-on-failure path.
+var errEthtoolDenied = errors.New("transient ethtool failure (test)")
+
+// twoNICExecer returns a fake whose ifaceA/ifaceB are both mlx5 NICs
+// reporting the pre-xpfd coalescence dump above.
+func twoNICExecer() *fakeRSSExecutor {
+	return &fakeRSSExecutor{
+		drivers: map[string]string{"ge-0-0-1": mlx5Driver, "ge-0-0-2": mlx5Driver},
+		ethtoolC: map[string][]byte{
+			"ge-0-0-1": []byte(mlx5CoalesceProbePreXpfd),
+			"ge-0-0-2": []byte(mlx5CoalesceProbePreXpfd),
+		},
+	}
+}
+
+// callIndex returns the index of the first recorded ethtool argv whose
+// verb is `verb` and whose target interface is `iface`, or -1.
+func callIndex(calls [][]string, verb, iface string) int {
+	for i, c := range calls {
+		if len(c) >= 2 && c[0] == verb && c[1] == iface {
+			return i
+		}
+	}
+	return -1
+}
+
+// coalesceArgs flattens the key/value tail of an `ethtool -C` argv.
+func coalesceArgs(c []string) map[string]string {
+	kv := map[string]string{}
+	for i := 2; i+1 < len(c); i += 2 {
+		kv[c[i]] = c[i+1]
+	}
+	return kv
+}
+
+// findCoalesceRestore reports whether an `ethtool -C <iface>` call
+// restoring the pre-xpfd capture (adaptive back on, rx 42 / tx 43) was
+// issued. An apply writes adaptive off + 8/8, so this can only match a
+// restore.
+func findCoalesceRestore(calls [][]string, iface string) bool {
+	for _, c := range calls {
+		if len(c) < 2 || c[0] != "-C" || c[1] != iface {
+			continue
+		}
+		kv := coalesceArgs(c)
+		if kv["adaptive-rx"] == "on" && kv["adaptive-tx"] == "on" &&
+			kv["rx-usecs"] == "42" && kv["tx-usecs"] == "43" {
+			return true
+		}
+	}
+	return false
+}
+
+// seedTwoBoundNICs runs the first reconcile with both NICs bound and
+// asserts the ownership records that the teardown later consumes.
+func seedTwoBoundNICs(t *testing.T) (*Daemon, *fakeHostFS, *fakeRSSExecutor) {
+	t.Helper()
+	d := &Daemon{}
+	fs := newFakeHostFS()
+	execer := twoNICExecer()
+
+	d.applyStep0TunablesWith(
+		true,  // userspaceDP
+		false, // claimHostTunables — irrelevant, coalescence is not gated on it
+		"", 0,
+		false, false, 8, 8,
+		[]string{"ge-0-0-1", "ge-0-0-2"},
+		fs, execer,
+	)
+
+	if d.priorTunables == nil {
+		t.Fatal("setup: priorTunables must exist after a userspace-dp apply")
+	}
+	for _, iface := range []string{"ge-0-0-1", "ge-0-0-2"} {
+		if _, ok := d.priorTunables.rssOwned[iface]; !ok {
+			t.Fatalf("setup: %s must be claimed as RSS-owned, got %v", iface, d.priorTunables.rssOwned)
+		}
+		st, ok := d.priorTunables.mlx5Adaptive[iface]
+		if !ok {
+			t.Fatalf("setup: %s must have a coalescence capture, got %v", iface, d.priorTunables.mlx5Adaptive)
+		}
+		if !st.adaptiveRX || st.rxUsecs != 42 || st.txUsecs != 43 {
+			t.Fatalf("setup: %s captured the wrong pre-xpfd state: %+v", iface, st)
+		}
+	}
+	execer.calls = nil
+	return d, fs, execer
+}
+
+// TestAllowlistShrink_ReleasesRSSAndCoalescence_6801 is the core case:
+// {ge-0-0-1, ge-0-0-2} -> {ge-0-0-1}. The released NIC must get its
+// default RSS table and its pre-xpfd coalescence back; the retained NIC
+// must not be touched by the teardown; and ownership must move.
+func TestAllowlistShrink_ReleasesRSSAndCoalescence_6801(t *testing.T) {
+	d, fs, execer := seedTwoBoundNICs(t)
+
+	// Second reconcile: ge-0-0-2 has left the userspace-dp binding set.
+	d.applyStep0TunablesWith(
+		true, false,
+		"", 0,
+		false, false, 8, 8,
+		[]string{"ge-0-0-1"},
+		fs, execer,
+	)
+
+	if callIndex(execer.calls, "-X", "ge-0-0-2") < 0 {
+		t.Errorf("#6801: released ge-0-0-2 must get `ethtool -X ge-0-0-2 default`, calls=%v", execer.calls)
+	}
+	if !findCoalesceRestore(execer.calls, "ge-0-0-2") {
+		t.Errorf("#6801: released ge-0-0-2 must be restored to its pre-xpfd coalescence "+
+			"(adaptive on, rx 42 / tx 43), calls=%v", execer.calls)
+	}
+
+	// The RETAINED interface must not be released. `-X ge-0-0-1 default`
+	// would hand back a NIC the dataplane is still bound to.
+	if i := callIndex(execer.calls, "-X", "ge-0-0-1"); i >= 0 {
+		t.Errorf("#6801: retained ge-0-0-1 must NOT be released, saw %v", execer.calls[i])
+	}
+	if findCoalesceRestore(execer.calls, "ge-0-0-1") {
+		t.Errorf("#6801: retained ge-0-0-1 must NOT have its coalescence restored, calls=%v", execer.calls)
+	}
+
+	// Ownership moved: the released NIC is gone from both records, the
+	// retained one is still held.
+	if _, ok := d.priorTunables.rssOwned["ge-0-0-2"]; ok {
+		t.Errorf("#6801: RSS ownership of the released NIC must be dropped, got %v", d.priorTunables.rssOwned)
+	}
+	if _, ok := d.priorTunables.mlx5Adaptive["ge-0-0-2"]; ok {
+		t.Errorf("#6801: coalescence capture of the released NIC must be dropped, got %v",
+			d.priorTunables.mlx5Adaptive)
+	}
+	if _, ok := d.priorTunables.rssOwned["ge-0-0-1"]; !ok {
+		t.Errorf("#6801: retained NIC must stay RSS-owned, got %v", d.priorTunables.rssOwned)
+	}
+	if _, ok := d.priorTunables.mlx5Adaptive["ge-0-0-1"]; !ok {
+		t.Errorf("#6801: retained NIC must keep its coalescence capture, got %v",
+			d.priorTunables.mlx5Adaptive)
+	}
+}
+
+// TestAllowlistShrink_TeardownRunsBeforeReapply_6801 pins the WIRING
+// ORDER documented in applyStep0TunablesWith: the released NIC is handed
+// back before xpfd re-applies tuning to the set it retains. The two sets
+// are disjoint, so this is the documented device_map-style
+// teardown-before-apply ordering rather than a correctness dependency —
+// moving the release call below applyCoalescence reds this cell.
+func TestAllowlistShrink_TeardownRunsBeforeReapply_6801(t *testing.T) {
+	d, fs, execer := seedTwoBoundNICs(t)
+
+	d.applyStep0TunablesWith(
+		true, false,
+		"", 0,
+		false, false, 8, 8,
+		[]string{"ge-0-0-1"},
+		fs, execer,
+	)
+
+	release := callIndex(execer.calls, "-X", "ge-0-0-2")
+	// The retained NIC's re-apply opens with its `ethtool -c` probe.
+	reapply := callIndex(execer.calls, "-c", "ge-0-0-1")
+	if release < 0 {
+		t.Fatalf("#6801: no release call for ge-0-0-2, calls=%v", execer.calls)
+	}
+	if reapply < 0 {
+		t.Fatalf("#6801: no re-apply probe for ge-0-0-1, calls=%v", execer.calls)
+	}
+	if release > reapply {
+		t.Errorf("#6801: released-NIC teardown (index %d) must run BEFORE the retained-set "+
+			"re-apply (index %d), calls=%v", release, reapply, execer.calls)
+	}
+}
+
+// TestUserspaceDataplaneDisabled_WithdrawsFullPriorSet_6801: turning the
+// userspace dataplane off at runtime is a withdrawal of the ENTIRE prior
+// set, not a shrink. Both NICs must be handed back and both ownership
+// records emptied.
+func TestUserspaceDataplaneDisabled_WithdrawsFullPriorSet_6801(t *testing.T) {
+	d, fs, execer := seedTwoBoundNICs(t)
+
+	// userspaceDP=false is the config signal; the allowlist goes empty
+	// with it, exactly as daemon_apply_tail.go derives it.
+	d.applyStep0TunablesWith(
+		false, false,
+		"", 0,
+		false, false, 8, 8,
+		nil,
+		fs, execer,
+	)
+
+	for _, iface := range []string{"ge-0-0-1", "ge-0-0-2"} {
+		if callIndex(execer.calls, "-X", iface) < 0 {
+			t.Errorf("#6801: %s must get its default RSS table back on userspace-dp disable, calls=%v",
+				iface, execer.calls)
+		}
+		if !findCoalesceRestore(execer.calls, iface) {
+			t.Errorf("#6801: %s must get its pre-xpfd coalescence back on userspace-dp disable, calls=%v",
+				iface, execer.calls)
+		}
+	}
+	if len(d.priorTunables.rssOwned) != 0 {
+		t.Errorf("#6801: RSS ownership must be fully released, got %v", d.priorTunables.rssOwned)
+	}
+	if len(d.priorTunables.mlx5Adaptive) != 0 {
+		t.Errorf("#6801: coalescence captures must be fully released, got %v", d.priorTunables.mlx5Adaptive)
+	}
+}
+
+// TestEmptyAllowlistWhileUserspaceEnabled_RetainsOwnership_6801 is the
+// middle row that separates a real withdrawal from a derivation
+// failure. UserspaceBoundLinuxInterfaces degrades to nil when its
+// snapshot build fails, and the tunable step still runs on a commit
+// whose dataplane apply failed — so "no names" must NOT mean "release
+// everything". Ripping the tuning off a NIC the dataplane is still
+// forwarding on costs a mid-traffic RX re-steer.
+//
+// Deleting the empty-allowlist guard reds this cell while every other
+// cell in this file stays green.
+func TestEmptyAllowlistWhileUserspaceEnabled_RetainsOwnership_6801(t *testing.T) {
+	d, fs, execer := seedTwoBoundNICs(t)
+
+	// userspace-dp is STILL enabled; only the derived list is empty.
+	d.applyStep0TunablesWith(
+		true, false,
+		"", 0,
+		false, false, 8, 8,
+		nil,
+		fs, execer,
+	)
+
+	for _, c := range execer.calls {
+		if len(c) >= 1 && (c[0] == "-X" || c[0] == "-C") {
+			t.Errorf("#6801: an empty allowlist under an ENABLED userspace-dp must not "+
+				"release anything, saw %v", c)
+		}
+	}
+	if len(d.priorTunables.rssOwned) != 2 {
+		t.Errorf("#6801: RSS ownership must be retained, got %v", d.priorTunables.rssOwned)
+	}
+	if len(d.priorTunables.mlx5Adaptive) != 2 {
+		t.Errorf("#6801: coalescence captures must be retained, got %v", d.priorTunables.mlx5Adaptive)
+	}
+}
+
+// TestReleaseFailure_RetainsOwnershipAndRetries_6801 pins the #5114
+// retry-debt shape on the new path: a failed restore write keeps the
+// interface owned so the next reconcile — which recomputes the same
+// `owned - current` set — retries it, and only a SUCCESSFUL restore
+// releases ownership.
+func TestReleaseFailure_RetainsOwnershipAndRetries_6801(t *testing.T) {
+	d, fs, execer := seedTwoBoundNICs(t)
+
+	// Both restores fail on the released NIC.
+	execer.argvErr = map[string]argvErrSpec{
+		"-X ge-0-0-2": {err: errEthtoolDenied},
+		"-C ge-0-0-2": {err: errEthtoolDenied},
+	}
+
+	d.applyStep0TunablesWith(
+		true, false, "", 0,
+		false, false, 8, 8,
+		[]string{"ge-0-0-1"},
+		fs, execer,
+	)
+
+	if _, ok := d.priorTunables.rssOwned["ge-0-0-2"]; !ok {
+		t.Errorf("#6801: a FAILED RSS restore must retain ownership as retry debt, got %v",
+			d.priorTunables.rssOwned)
+	}
+	if _, ok := d.priorTunables.mlx5Adaptive["ge-0-0-2"]; !ok {
+		t.Errorf("#6801: a FAILED coalescence restore must retain the capture as retry debt, got %v",
+			d.priorTunables.mlx5Adaptive)
+	}
+
+	// Next reconcile with the same (still shrunk) allowlist: the debt is
+	// retried and, on success, released.
+	execer.argvErr = nil
+	execer.calls = nil
+	d.applyStep0TunablesWith(
+		true, false, "", 0,
+		false, false, 8, 8,
+		[]string{"ge-0-0-1"},
+		fs, execer,
+	)
+
+	if callIndex(execer.calls, "-X", "ge-0-0-2") < 0 {
+		t.Errorf("#6801: retry must re-issue the RSS restore, calls=%v", execer.calls)
+	}
+	if !findCoalesceRestore(execer.calls, "ge-0-0-2") {
+		t.Errorf("#6801: retry must re-issue the coalescence restore, calls=%v", execer.calls)
+	}
+	if _, ok := d.priorTunables.rssOwned["ge-0-0-2"]; ok {
+		t.Errorf("#6801: a successful retry must release RSS ownership, got %v", d.priorTunables.rssOwned)
+	}
+	if _, ok := d.priorTunables.mlx5Adaptive["ge-0-0-2"]; ok {
+		t.Errorf("#6801: a successful retry must release the coalescence capture, got %v",
+			d.priorTunables.mlx5Adaptive)
+	}
+}
+
+// TestReleasedNICGone_DropsOwnershipWithoutEthtool_6801: a released name
+// that is no longer an mlx5 netdev (unplugged, renamed, or rebound) took
+// its ring/coalescence configuration with it. Ownership must be dropped
+// WITHOUT an ethtool call — both to honor the "never ethtool a non-mlx5
+// netdev" invariant and to stop the retry debt growing without bound on
+// a NIC that can never accept the restore.
+func TestReleasedNICGone_DropsOwnershipWithoutEthtool_6801(t *testing.T) {
+	d, fs, execer := seedTwoBoundNICs(t)
+
+	// The NIC vanished from sysfs between reconciles.
+	delete(execer.drivers, "ge-0-0-2")
+
+	d.applyStep0TunablesWith(
+		true, false, "", 0,
+		false, false, 8, 8,
+		[]string{"ge-0-0-1"},
+		fs, execer,
+	)
+
+	for _, c := range execer.calls {
+		if strings.Contains(strings.Join(c, " "), "ge-0-0-2") {
+			t.Errorf("#6801: no ethtool call may target a released non-mlx5 netdev, saw %v", c)
+		}
+	}
+	if _, ok := d.priorTunables.rssOwned["ge-0-0-2"]; ok {
+		t.Errorf("#6801: a vanished NIC must not accrue unbounded RSS retry debt, got %v",
+			d.priorTunables.rssOwned)
+	}
+	if _, ok := d.priorTunables.mlx5Adaptive["ge-0-0-2"]; ok {
+		t.Errorf("#6801: a vanished NIC must not accrue unbounded coalescence retry debt, got %v",
+			d.priorTunables.mlx5Adaptive)
+	}
+}
+
+// TestClaimNICTunableOwnership_SkipsNonMlx5_6801 pins the claim scope:
+// the userspace-dp allowlist legitimately carries virtio / i40e / iavf
+// names, and recording one as RSS-owned would make a later teardown
+// invoke ethtool on a netdev the RSS reconciler never touches.
+func TestClaimNICTunableOwnership_SkipsNonMlx5_6801(t *testing.T) {
+	d := &Daemon{}
+	fs := newFakeHostFS()
+	execer := &fakeRSSExecutor{
+		drivers: map[string]string{
+			"ge-0-0-1": mlx5Driver,
+			"ge-0-0-3": "virtio_net",
+		},
+		ethtoolC: map[string][]byte{"ge-0-0-1": []byte(mlx5CoalesceProbePreXpfd)},
+	}
+
+	d.applyStep0TunablesWith(
+		true, false, "", 0,
+		false, false, 8, 8,
+		[]string{"ge-0-0-1", "ge-0-0-3", "lo"},
+		fs, execer,
+	)
+
+	if _, ok := d.priorTunables.rssOwned["ge-0-0-1"]; !ok {
+		t.Errorf("#6801: the mlx5 member must be claimed, got %v", d.priorTunables.rssOwned)
+	}
+	if _, ok := d.priorTunables.rssOwned["ge-0-0-3"]; ok {
+		t.Errorf("#6801: a non-mlx5 allowlist member must NOT be claimed, got %v", d.priorTunables.rssOwned)
+	}
+	if _, ok := d.priorTunables.rssOwned["lo"]; ok {
+		t.Errorf("#6801: lo must never be claimed, got %v", d.priorTunables.rssOwned)
+	}
+}
+
+// TestReleasedNICTunableOwners_UnionsBothRecords_6801 pins the set
+// algebra directly, including the case the two records disagree on: an
+// `ethtool -c` probe that fails leaves an RSS claim with no coalescence
+// capture, and that interface must still be released.
+func TestReleasedNICTunableOwners_UnionsBothRecords_6801(t *testing.T) {
+	prior := newPriorHostTunables()
+	prior.claimRSSOwnership("rss-only")
+	prior.claimRSSOwnership("both")
+	prior.claimRSSOwnership("kept")
+	prior.captureMlx5Coalesce("both", mlx5CoalesceState{rxUsecs: 42})
+	prior.captureMlx5Coalesce("coalesce-only", mlx5CoalesceState{rxUsecs: 42})
+	prior.captureMlx5Coalesce("kept", mlx5CoalesceState{rxUsecs: 42})
+
+	got := releasedNICTunableOwners(prior, []string{"kept"})
+	want := []string{"both", "coalesce-only", "rss-only"}
+	if len(got) != len(want) {
+		t.Fatalf("released set: want %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("released set must be deduplicated and sorted: want %v, got %v", want, got)
+		}
+	}
+	if len(releasedNICTunableOwners(nil, nil)) != 0 {
+		t.Error("a nil capture struct must yield no released interfaces")
+	}
+}

--- a/pkg/daemon/rss_indirection.go
+++ b/pkg/daemon/rss_indirection.go
@@ -227,20 +227,42 @@ func restoreDefaultRSSIndirection(allowed []string, execer rssExecutor) {
 		if execer.readDriver(iface) != mlx5Driver {
 			continue
 		}
-		out, err := execer.runEthtool("-X", iface, "default")
-		if err != nil {
-			if isExecNotFound(err) {
-				slog.Warn("linksetup: ethtool binary not found, cannot restore default rss indirection",
-					"iface", iface)
-				return
-			}
-			slog.Warn("linksetup: ethtool -X default failed",
-				"iface", iface, "err", err,
-				"output", strings.TrimSpace(string(out)))
-			continue
+		err := restoreDefaultRSSIndirectionOne(iface, execer)
+		if err != nil && isExecNotFound(err) {
+			// ethtool is missing for the whole process, not just this
+			// NIC — abandon the sweep instead of logging once per
+			// interface (unchanged from the pre-#6801 inline loop).
+			return
 		}
-		slog.Info("linksetup: restored default rss indirection", "iface", iface)
 	}
+}
+
+// restoreDefaultRSSIndirectionOne runs `ethtool -X <iface> default` on a
+// single interface and REPORTS the outcome (#6801).
+//
+// Split out of restoreDefaultRSSIndirection's loop so the
+// released-interface teardown can release ownership only on success and
+// retain a failure as retry debt. The caller is responsible for the
+// mlx5 driver guard, exactly as it was when this body was inline.
+//
+// Idempotent: restoring an already-default table is a no-op ethtool
+// call, which is why this is a safe restore action for an interface
+// whose pre-xpfd table was never captured.
+func restoreDefaultRSSIndirectionOne(iface string, execer rssExecutor) error {
+	out, err := execer.runEthtool("-X", iface, "default")
+	if err != nil {
+		if isExecNotFound(err) {
+			slog.Warn("linksetup: ethtool binary not found, cannot restore default rss indirection",
+				"iface", iface)
+			return err
+		}
+		slog.Warn("linksetup: ethtool -X default failed",
+			"iface", iface, "err", err,
+			"output", strings.TrimSpace(string(out)))
+		return err
+	}
+	slog.Info("linksetup: restored default rss indirection", "iface", iface)
+	return nil
 }
 
 // applyRSSIndirectionOne applies the weight-vector to a single mlx5 iface.


### PR DESCRIPTION
Closes #6801

## Summary

- **The allowlist was one-directional.** Both per-interface tuning knobs — the D3 RSS indirection table (`pkg/daemon/rss_indirection.go`, #785) and interrupt coalescence (`pkg/daemon/coalescence.go`, #801 Step-0) — derive their target set from `dpuserspace.UserspaceBoundLinuxInterfaces(cfg)`, recomputed from the **new** compiled config on every reconcile. Every loop walks the new set, so a netdev DROPPED from it is never visited.
- **Result:** bind `{ge-0-0-1, ge-0-0-2}`, then commit a config binding only `ge-0-0-1`, and `ge-0-0-2` keeps xpf's concentrated RSS table and its adaptive-off / pinned-usecs coalescence. The coalescence capture was reverted only at daemon shutdown; the RSS table was **never** reverted at all. A NIC handed back to the host stack or another dataplane stayed limited to the old AF_XDP queue subset — throughput loss and interrupt amplification outside xpf's current ownership.
- **Fix:** new `pkg/daemon/released_nic_tunables.go` adds a level-triggered `owned - current` teardown, wired into `applyStep0TunablesWith` (which runs at boot AND on every commit) ahead of the ownership claim and the re-apply — mirroring the managed→unmapped teardown `pkg/daemon/device_map.go` runs before `networkd.Apply`.
- **Ownership** is the union of two records, because the two knobs diverge on error paths: the new `priorHostTunables.rssOwned` **set** (no captured value needed — the restore is the idempotent `ethtool -X <if> default` the kill switch already issues) and the existing `mlx5Adaptive` capture map. Ownership is dropped only after the restore write SUCCEEDS, so a failed `ethtool` is retained and retried on the next reconcile (#5114 retry-debt shape). No timer: a released name stays outside the allowlist until it is re-bound, so the same released set is recomputed every reconcile.
- **An empty allowlist is NOT, by itself, a withdrawal** — this guard is what keeps the fix from being a regression. `UserspaceBoundLinuxInterfaces` degrades to nil when its snapshot build fails (#2514), and `applyTailReconciles` still runs the tunable step on a commit whose *dataplane apply failed*. Treating "no names" as "release everything" would let a transient derivation error rip the tuning off NICs the dataplane is still forwarding on, and `ethtool -X … default` mid-traffic re-steers in-flight flows onto different RX queues (the cost #3954 documents). Withdrawal is keyed on the CONFIG signal (`userspaceDP == false`, a pure config read with no error path), never on an empty list.
- **A released name that is no longer an mlx5 netdev** — unplugged, renamed by a `.link` change, rebound to another driver — drops ownership WITHOUT an ethtool call. Its ring/coalescence configuration went with the rebind, so this honors the #797 H1 "never invoke ethtool on a non-mlx5 netdev" guard and stops retry debt growing without bound on a NIC that can never accept the restore.

Re-derived against `origin/master` before fixing: still present at `f2ac81e8f` at `rss_indirection.go:151-209` (apply walks only `allowed`), `:219-244` (kill-switch restore walks only `allowed`), `host_tunables_daemon.go:117-122` (coalescence walks only `rssAllowed`) and `:272-278` (captures restored only on shutdown).

## Hot-path shape

None. Every line added runs on the config-apply path under `d.applySem`, never per-packet. Cost per reconcile is O(released NICs) — one `readlink` per allowlist member for the mlx5 guard (the same guard `applyCoalescence` already makes), and for a released NIC at most one `ethtool -X` plus one `ethtool -C`, both `runCommandTimeout`-bounded. With a stable allowlist the released set is empty and the added cost is one map length check.

## Mechanism

| Step | Function | What it does |
|------|----------|--------------|
| release | `releaseUnboundNICTunables` | For each owned interface absent from the current allowlist: `ethtool -X <if> default` + restore the captured pre-xpf coalescence, then drop ownership |
| claim | `claimNICTunableOwnership` | Union the current allowlist's mlx5 members into the owned set |

The release is placed ahead of both the claim and the re-apply. The released and retained sets are **disjoint by construction**, so that ordering is the documented `device_map` precedent rather than a correctness dependency — the code comment says exactly that rather than over-claiming it.

`restoreDefaultRSSIndirection`'s loop body is split out as `restoreDefaultRSSIndirectionOne` so the teardown can see the per-interface outcome; `restoreMlx5Coalesce` now returns its error for the same reason. Both keep their existing best-effort behavior at the old call sites, including the abandon-the-sweep-on-`ErrNotFound` behavior.

## Test plan

- [x] 8 new tests in `pkg/daemon/released_nic_tunables_6801_test.go`. Every case runs **two reconciles** and moves an interface out of the binding set between them — a fixture whose allowlist never shrinks cannot see the teardown at all and would stay green with the whole feature deleted.
- [x] The pre-xpf coalescence probe uses `rx-usecs 42 / tx-usecs 43`, values xpf never writes (it writes the operator's 8/8), so a restore assertion cannot be satisfied by an apply that happened to run.
- [x] Wiring, not just the helper: M1/M2/M9 below drive `applyStep0TunablesWith` — the same entry point the boot naming path and `applyTailReconciles` step 21 use — not the teardown function directly.
- [x] **Mutation matrix, 10 cells, ALL RED.** Each reverts ONE production line or guard on top of the committed fix; each runs full-package `go test -count=1 ./pkg/daemon/` with **no `-run` filter**, with an applied-check (working tree must differ from HEAD) and a restore-check after.
- [x] `go build ./...` rc 0 · `go vet ./pkg/daemon/` rc 0 · **`go test -count=1 ./...` rc 0**, 67 packages ok — re-run in full at the current merged head `ecdbf466c`, not carried over from any earlier gate.
- [ ] `make test-deploy` / `make cluster-deploy` + iperf3 — **NOT RUN**, see "Validation not executed" below.

| # | Reverted line | Verdict | Named RED |
|---|---------------|---------|-----------|
| M1 | delete the `releaseUnboundNICTunables(...)` call in `applyStep0TunablesWith` | RED | `TestAllowlistShrink_ReleasesRSSAndCoalescence_6801` +4 |
| M2 | delete the `claimNICTunableOwnership(...)` call | RED | `TestClaimNICTunableOwnership_SkipsNonMlx5_6801` +6 |
| M3 | delete the empty-allowlist withdrawal guard | RED | `TestEmptyAllowlistWhileUserspaceEnabled_RetainsOwnership_6801` (only) |
| M4 | RSS restore `err != nil` → `err == nil` (drop ownership on failure) | RED | `TestReleaseFailure_RetainsOwnershipAndRetries_6801` +2 |
| M5 | coalescence restore `err != nil` → `err == nil` | RED | `TestReleaseFailure_RetainsOwnershipAndRetries_6801` +2 |
| M6 | release-path mlx5 driver guard `!=` → `==` | RED | `TestReleasedNICGone_DropsOwnershipWithoutEthtool_6801` +4 |
| M7 | `restoreMlx5Coalesce` `return err` → `return nil` (pre-fix swallow) | RED | `TestReleaseFailure_RetainsOwnershipAndRetries_6801` (only) |
| M8 | claim-path mlx5 driver guard `!=` → `==` | RED | `TestClaimNICTunableOwnership_SkipsNonMlx5_6801` +6 |
| M9 | MOVE the release call to after `applyCoalescence` | RED | `TestAllowlistShrink_TeardownRunsBeforeReapply_6801` (only) |
| M10 | drop `mlx5Adaptive` from the ownership union | RED | `TestReleasedNICTunableOwners_UnionsBothRecords_6801` (only) |

No cell escaped green; no cell build-broke. M3, M7, M9 and M10 each red exactly **one** named cell, so each guard has a test that owns it rather than riding on a neighbour.

Gated HEAD: **`ecdbf466c88997b161385cf37b996f5fb5843cba`**. `git merge-base --is-ancestor origin/master HEAD` passes.

Master has moved three times under this branch (`f2ac81e8f` → `d6f8f77ab` → `23102bc88` → `6f9494cdc`); every time it was **merged, not rebased**, and the full repo-wide `go build ./... && go test -count=1 ./...` was re-run at the merged head rather than the previous result being re-asserted. That matters here: #6802/#6803 each added an always-on reassert goroutine to `Run` in `pkg/daemon` and each touches `pkg/api`, and #6790 rewrote steps 11–13 of `applyTailReconciles` to capture and join the five host-credential errors that were previously discarded. A textually clean merge is not evidence the suite still passes.

`_Log.md` conflicted on that merge and was resolved with **theirs-as-authoritative** (`theirs + ours_tail`), not the usual `base + ours_tail + theirs_tail` union. Master's side is no longer a pure append: #7614 and #7616 DELETED lines mid-file (six committed conflict markers, three duplicated entry bodies), so a base-prefix union would have reintroduced every one of them. Verified after resolution: 0 conflict markers, this PR's entry present exactly once, all 1947 of master's `##` headings survive, and no line lost from master's side. `pkg/refactoraudit`'s `TestNoUnresolvedConflictMarkers` / `TestLogHasNoDuplicatedEntryBodies` (plus their two self-detectors) pass — 4 tests collected, confirmed with `-v`.

**The mutation matrix was NOT re-measured at this head, and this PR does not claim it was.** It was measured at `e47308c46`, and it reverts lines in `released_nic_tunables.go`, `host_tunables_daemon.go`, `host_tunables.go` and `rss_indirection.go`. Disjointness was re-verified over the CURRENT range, not carried over from the previous one — a range check is only as good as the range it was run over: `git diff --name-only d6f8f77ab..6f9494cdc` intersects those four files in **0** places.

File-level disjointness is not sufficient on its own here, because #6790 DOES touch `daemon_apply_tail.go`, which is this PR's call site: step 21 calls `applyStep0Tunables`, and the teardown lives inside `applyStep0TunablesWith`. Re-verified semantically in the merged tree — step 21 is intact with `reapplyRSSIndirection` (line 378) still preceding `d.applyStep0Tunables` (line 380); `releaseUnboundNICTunables` and `claimNICTunableOwnership` are still wired inside `applyStep0TunablesWith`; and #6790 introduced **no early return** between step 11 and step 21, so its fail-closed credential errors change the commit RESULT without skipping this step.

No files under `userspace-dp/` or `userspace-xdp/` are touched (`git diff --name-only origin/master..HEAD | grep -c '^userspace-'` = 0), so no cargo leg is owed.

## Validation not executed

`docs/engineering-style.md` step 8 nominally asks every change for `make test-deploy` (ping between zones) and `make cluster-deploy` + iperf3. **Neither was run**, and this PR does not claim they were. Reasons:

- The loss userspace cluster is shared and lock-protected (#1875/#4020); this lane was explicitly instructed not to take the lock. Dispatch belongs to the orchestrator.
- The change moves no Rust binary and touches nothing on the forwarding, session-sync, VRRP or fabric path — the rows that make a cluster smoke load-bearing.
- On a cluster whose allowlist is stable across commits (which the loss userspace cluster is — `docs/ha-cluster-userspace.conf` binds a fixed `reth0`/`reth1` set), `released` is always empty, so the runtime behavior is bit-identical to master. The only new runtime action is `ethtool` on a NIC that has already LEFT the binding set.

If the orchestrator wants coverage anyway, the meaningful smoke is not iperf3 — it is a commit that REMOVES an mlx5 interface from the zone/binding set on a deployed node, then `ethtool -x <if>` / `ethtool -c <if>` on the released NIC to confirm the default table and the pre-xpf coalescence came back.

## Deferred

- **#7619 — the RSS indirection table is never restored on daemon STOP** (#6801's sibling trigger). `restoreStep0TunablesOnShutdown` reverts coalescence, host-scope knobs and neigh `retrans_time_ms`, but not `rssOwned`. Same ownership hole, different trigger. Deliberately out of scope here: it adds a second bounded `ethtool` round-trip per owned NIC to a shutdown path already capped by the unit's `TimeoutStopSec=20`; it changes the restart profile (default table on stop, re-concentrated on the next boot); and a failed restore-on-stop has no later tick to retry on, so the retry-debt model this PR uses does not carry over. Called out in `host_tunables_daemon.go`, `pkg/daemon/README.md` and `_Log.md`, and tracked in #7619.

## Docs

- `pkg/daemon/README.md` — new "NIC tuning ownership + released-interface teardown (#6801)" subsection under Interface management. This is the module doc: all the code is in `pkg/daemon`.
- `docs/userspace-dataplane-architecture.md` — the allowlist-EXIT contract, stated next to the existing block that defines allowlist membership. That doc said what the allowlist contains; it did not say what membership means on the way out.
- **Deliberately not touched, with reasons:** `pkg/dataplane/README.md` and the root `README.md` carry no RSS / D3 / coalescence surface at all (`grep -niE 'rss|coalesc|ethtool'` is empty in both); `docs/config-schema.md` is untouched because no config-mode leaf was added or changed — the teardown keys off the EXISTING `system dataplane` knobs.

## Reviews still owed

Per `docs/engineering-style.md` steps 3/7/9, this branch has not yet had the hostile Codex plan review or the hostile Codex code review. It is opened for review, not for merge.

Copilot did not run: `--add-reviewer copilot-pull-request-reviewer` left `requested_reviewers` empty and `pulls/7607/reviews` returns 0 after repeated polling. This is repo-wide, not specific to this PR — #7600/#7601/#7602/#7604 all show 0 Copilot reviews as well. Flagged rather than claimed as a pass, since losing one of the two review surfaces halves the coverage.

## Refs

- Closes #6801 (opus-review-001 root R62). Deferred sibling tracked in #7619. The issue cites `/tmp/opus-review-001.md`, which no longer exists; R62 was read in full from `/home/ps/git/opus-review-001.md`, so the claim was re-derived from the original evidence rather than from the title.
- Ownership/retry-debt shape mirrors #5114. Restore action mirrors the #785 kill switch. Driver guard is #797 H1. Teardown ordering mirrors #1956 (`device_map.go`). Mid-traffic re-steer cost is #3954. Allowlist nil-degradation is #2514. Related but distinct: #5328 (subset-of-active-queues on a *currently managed* NIC), #5124/#805 (worker-count transitions on interfaces still in the supplied list).
