### PR TITLE
daemon: rebind a management listener that died at the same endpoint

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -105068,3 +105068,53 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: `pkg/daemon/rg_state.go`, `pkg/daemon/daemon_ha.go`,
   `pkg/daemon/rg_apply_invalidate_race_6799_test.go`,
   `pkg/daemon/rg_state_test.go`, `pkg/daemon/README.md`, `_Log.md`
+
+## 2026-08-26 — #6803: a management listener that dies is now rebound at the same endpoint
+
+- **Timestamp**: 2026-08-26
+- **Action**: Give the HTTP management leg the liveness question #6827 round 6
+  gave HTTPS, in both places round 6 fixed it for HTTPS, and add the always-on
+  owner that makes either fix reachable without an operator commit.
+- **Why**: an unexpected management-listener serve exit was OBSERVABLE and never
+  RECONCILED. Observable: the leg is marked dead, `EffectiveHTTPAddr` stops
+  reporting it, `show system services` renders the HTTP listener Failed. Never
+  reconciled, for three independent reasons, each of which alone keeps the
+  endpoint down:
+  1. `api.Server.ReconcileHTTP` short-circuited a same-address call on a
+     non-nil pointer rather than on `serving()`. A dead leg stays INSTALLED (it
+     cannot be unlinked without `lifeMu`, which deadlocks a shutdown racing the
+     exit), so the compare matched a corpse and the rebind returned nil having
+     done nothing. `ReconcileHTTPS` has asked `serving()` since #6827 round 6.
+  2. `reconcileTo`'s HTTP arm gated on the converged FINGERPRINT alone. The
+     fingerprint records what the last SUCCESSFUL reconcile bound; it is not
+     evidence the socket is up. The HTTPS arm carries `|| (next.TLS &&
+     !m.srv.HTTPSServing())`; the HTTP arm carried nothing.
+  3. The only caller of `reconcileWebManagement` is `applyConfigLocked`, so even
+     with both gates fixed the endpoint came back only when an operator
+     committed — from a box whose management API had just died.
+- **Shape**: (1) `api.Server.HTTPServing()`, the exact counterpart of
+  `HTTPSServing()`; `ReconcileHTTP`'s no-op now asks it. (2) the HTTP arm fires
+  on `next.Addr != m.cur.addr || (next.Addr != "" && !m.srv.HTTPServing())` —
+  the non-empty guard keeps the change strictly ADDITIVE, because
+  `ReconcileHTTP` refuses an empty bind and the existing #6827 over-reach guard
+  `a_failed_boot_then_an_empty_bind_binds_nothing` pins that direction.
+  (3) `mgmtListenerReassertLoop` in a new `mgmt_listener_reassert.go`, mirroring
+  #6791/#6793/#6802: unconditional in `Run`, 30s, `applySem` before acting
+  (#4001), gate re-checked inside the semaphore.
+- **Gate identity**: the owner's gate is
+  `effectiveHTTPListener().State == StateFailed` — the SAME question `show
+  system services` answers, on purpose. A second private predicate could
+  disagree with the operator view, and then the box either reports a dead
+  listener nothing retries or retries one it reports healthy.
+- **Every cell is PAIRED**, because all three fixes WIDEN a trigger and the
+  over-reach failure is real: a rebind that fires on a healthy leg bounces the
+  management socket on every commit and every 30s tick.
+- **Found while re-deriving, filed separately**: the PRIMARY (loopback) gRPC
+  listener has the same hole — `Run` logs a serve error and the goroutine exits
+  with nothing re-binding — while the FABRIC gRPC listener beside it has had a
+  bounded-backoff supervisor since #5047.
+- **File(s)**: `pkg/api/listener.go`, `pkg/daemon/management.go`,
+  `pkg/daemon/mgmt_listener_reassert.go`, `pkg/daemon/daemon_run.go`,
+  `pkg/daemon/mgmt_listener_reassert_6803_test.go`,
+  `pkg/api/reconcile_http_dead_leg_6803_test.go`, `pkg/daemon/README.md`,
+  `pkg/api/README.md`, `_Log.md`

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -1871,6 +1871,19 @@ the drop fails loudly instead of going quietly vacuous.
     uniform unavailable/error contract (#3464, below) so a degraded
     interface-counter bridge is no longer handled divergently across surfaces.
 
+    **`ReconcileHTTP` asks `serving()`, not just the address** (#6803).
+    `ReconcileHTTPS`'s same-address arm has tested `httpsLeg.serving()` since
+    #6827 round 6; `ReconcileHTTP`'s tested a non-nil pointer. An unexpected
+    serve exit marks a leg dead and leaves it INSTALLED, so the address compare
+    matched a corpse and a rebind to the same endpoint returned `nil` having done
+    nothing — the HTTP management API was unrecoverable on an unchanged
+    configuration for the life of the process. `HTTPServing()` is the new exact
+    counterpart of `HTTPSServing()`, and it is what both this no-op and the
+    daemon-side `reconcileTo` gate now ask. Pinned by
+    `reconcile_http_dead_leg_6803_test.go`, paired against the over-reach
+    direction: a HEALTHY same-address leg must still be a no-op, or the
+    management socket is rebuilt on every commit and every 30s re-assert tick.
+
   Pinned by `stats_counter_error_test.go` +
   `zones_policies_counter_error_test.go` (REST + Prometheus),
   `pkg/grpcapi/global_stats_counter_error_test.go` (incl. the late-read

--- a/pkg/api/listener.go
+++ b/pkg/api/listener.go
@@ -490,6 +490,20 @@ func (s *Server) HTTPSServing() bool {
 	return s.httpsLeg.serving()
 }
 
+// HTTPServing reports whether the HTTP leg is bound and still serving. It is the
+// exact counterpart of HTTPSServing and exists for the same reason (#6803): the
+// reconciler's converged-fingerprint records what the last SUCCESSFUL reconcile
+// bound, which is not evidence that the socket is still up. An unexpected serve
+// exit marks the leg dead and leaves it INSTALLED (listenerLeg.dead — it cannot
+// be removed under lifeMu without deadlocking a shutdown that races the exit),
+// so a fingerprint-only gate matches on every later commit and never rebinds.
+// #6827 round 6 gave HTTPS this question; the HTTP leg never got it.
+func (s *Server) HTTPServing() bool {
+	s.lifeMu.Lock()
+	defer s.lifeMu.Unlock()
+	return s.httpLeg.serving()
+}
+
 // ReconcileHTTP make-before-break rebinds ONLY the HTTP listener to addr (#5866),
 // leaving the HTTPS leg untouched. A same-addr call is a no-op. The new listener
 // is bound and serving BEFORE the old is retired (no unreachable HTTP window). A
@@ -501,7 +515,12 @@ func (s *Server) ReconcileHTTP(addr string) error {
 	if addr == "" {
 		return fmt.Errorf("api: refusing to reconcile the HTTP listener to an empty bind address")
 	}
-	if s.httpLeg != nil && s.httpLeg.srv.Addr == addr {
+	// The same-address short circuit requires the leg to still be SERVING, the
+	// way ReconcileHTTPS's does (#6803). Without the serving() half, a leg whose
+	// serve loop exited unexpectedly — dead, but still installed — satisfied the
+	// address compare, so a rebind to the same endpoint returned nil having done
+	// nothing and the management API stayed down until a daemon restart.
+	if s.httpLeg.serving() && s.httpLeg.srv.Addr == addr {
 		return nil
 	}
 	plan := s.planHTTPLeg(addr)

--- a/pkg/api/reconcile_http_dead_leg_6803_test.go
+++ b/pkg/api/reconcile_http_dead_leg_6803_test.go
@@ -1,0 +1,149 @@
+package api
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// reconcile_http_dead_leg_6803_test.go — #6803.
+//
+// ReconcileHTTPS short-circuits a same-address call only when the leg is still
+// SERVING:
+//
+//	case s.httpsLeg.serving() && s.httpsLeg.srv.Addr == addr: return nil
+//
+// ReconcileHTTP short-circuited on the address alone. An unexpected serve exit
+// marks the leg dead and leaves it INSTALLED (it cannot be removed under lifeMu
+// without deadlocking a shutdown that races the exit), so the address compare
+// matched a corpse and the rebind returned nil having done nothing. The
+// management API then stayed down until a daemon restart, whatever the caller
+// did.
+//
+// The cells are PAIRED because this widens a trigger: over-widening it to fire
+// on a healthy leg would tear the management socket down and rebuild it on every
+// commit — an availability defect traded for an availability defect.
+
+// killHTTPLeg6803 produces an UNEXPECTED serve exit the way production does:
+// the listening socket goes away underneath a live Serve loop, which returns a
+// non-ErrServerClosed error. It does not poke listenerLeg.dead directly, so the
+// cell exercises the path the defect actually arrives on.
+func killHTTPLeg6803(t *testing.T, s *Server, ln net.Listener) {
+	t.Helper()
+	_ = ln.Close()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if !s.HTTPServing() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("the HTTP leg was still reported serving after its socket died")
+}
+
+// bootHTTPLeg6803 binds an HTTP leg at a real ephemeral loopback port and
+// returns the server, the leg's listener, and its concrete address.
+func bootHTTPLeg6803(t *testing.T) (*Server, net.Listener, string) {
+	t.Helper()
+	// retireTestServer's injected listen always binds 127.0.0.1:0, so the
+	// address STRING carried on the leg (srv.Addr, which is what the short
+	// circuit compares) is decoupled from the concrete port. That is what lets
+	// this cell hold the address constant while the socket underneath changes —
+	// the exact shape the defect needs.
+	s := retireTestServer(t, nil)
+
+	s.lifeMu.Lock()
+	s.httpSlot = s.newAuthSlot()
+	ln, err := s.listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		s.lifeMu.Unlock()
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	s.httpServer = s.buildHTTPServer(addr, s.httpSlot)
+	s.httpLeg = s.serveLegLocked(s.httpLegPlan(), ln, false)
+	s.lifeMu.Unlock()
+
+	if !s.HTTPServing() {
+		t.Fatal("the boot bind did not leave the HTTP leg serving; the case starts wrong")
+	}
+	return s, ln, addr
+}
+
+// TestReconcileHTTPRebindsADeadSameAddressLeg6803 is the cell the fix turns on.
+//
+// The SAME address is the whole point: it is the only shape where the address
+// compare and the liveness question disagree. A fixture that changed the address
+// could not see the defect, because the short circuit would not have fired
+// either way.
+//
+// FAIL-ON-REVERT: restore the short circuit to
+// `if s.httpLeg != nil && s.httpLeg.srv.Addr == addr { return nil }` and the
+// dead leg is never replaced.
+func TestReconcileHTTPRebindsADeadSameAddressLeg6803(t *testing.T) {
+	s, ln, addr := bootHTTPLeg6803(t)
+	dead := s.httpLeg
+	killHTTPLeg6803(t, s, ln)
+
+	if err := s.ReconcileHTTP(addr); err != nil {
+		t.Fatalf("ReconcileHTTP to the same address: %v", err)
+	}
+	if s.httpLeg == dead {
+		t.Fatal("ReconcileHTTP short-circuited on a DEAD same-address leg, so the " +
+			"management API stays down until a daemon restart — ReconcileHTTPS asks " +
+			"serving() for exactly this reason (#6803)")
+	}
+	if !s.HTTPServing() {
+		t.Fatal("ReconcileHTTP replaced the dead leg but the replacement is not serving")
+	}
+	if got := s.EffectiveHTTPAddr(); got == "" {
+		t.Error("EffectiveHTTPAddr is still empty after a successful rebind, so " +
+			"`show system services` keeps reporting the listener Failed")
+	}
+}
+
+// TestReconcileHTTPLeavesALiveSameAddressLegAlone6803 is the over-reach half.
+//
+// Without it the fix is satisfied by dropping the short circuit entirely, which
+// rebuilds the management socket on every reconcile — and reconcile runs on
+// every commit and, since this issue, every 30s.
+func TestReconcileHTTPLeavesALiveSameAddressLegAlone6803(t *testing.T) {
+	s, _, addr := bootHTTPLeg6803(t)
+	live := s.httpLeg
+
+	if err := s.ReconcileHTTP(addr); err != nil {
+		t.Fatalf("ReconcileHTTP to the same address: %v", err)
+	}
+	if s.httpLeg != live {
+		t.Fatal("ReconcileHTTP REBOUND a healthy same-address leg; the liveness " +
+			"question must widen the trigger for a dead leg only")
+	}
+	if !s.HTTPServing() {
+		t.Fatal("the healthy leg stopped serving after a no-op reconcile")
+	}
+}
+
+// TestHTTPServingMirrorsHTTPSServing6803 pins the accessor the two gates share.
+//
+// It is not a tautology: HTTPServing is what both api.ReconcileHTTP and the
+// daemon's reconcileTo/re-assert gate ask, so an implementation that reported a
+// dead leg as serving would re-open the whole issue at three call sites at once,
+// with every behavioural cell above still green (they would simply never enter
+// the rebind branch, and their "did it rebind" assertions would fail — but a
+// version that reported a LIVE leg as dead passes those and bounces the socket
+// forever, which is what this direction catches).
+func TestHTTPServingMirrorsHTTPSServing6803(t *testing.T) {
+	s, ln, _ := bootHTTPLeg6803(t)
+	if !s.HTTPServing() {
+		t.Fatal("HTTPServing reported a live leg as dead")
+	}
+	killHTTPLeg6803(t, s, ln)
+	if s.HTTPServing() {
+		t.Fatal("HTTPServing reported a dead leg as serving")
+	}
+	// A server with no HTTP leg at all reads not-serving, matching
+	// HTTPSServing's nil-leg behaviour — serving() is defined on the nil leg.
+	if (&Server{}).HTTPServing() {
+		t.Error("a server with no HTTP leg reported one as serving")
+	}
+}

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -680,6 +680,44 @@ explicit-config test seam.
     `TestADeadHTTPSLegIsRebuiltByTheNextReconcile_6827` (daemon, end to end from
     `reconcileWebManagement`) and `TestReconcileHTTPSReplacesADeadLeg_6827`
     (`pkg/api`).
+  - **The HTTP leg never got that fix** (#6803). Round 6 repaired the HTTPS arm
+    and stopped. The HTTP arm still gated on the converged fingerprint alone
+    (`next.Addr != m.cur.addr`), and `api.Server.ReconcileHTTP`'s same-address
+    short circuit still tested a non-nil pointer rather than `serving()` — the
+    two defects round 6 named, on the other leg. So an HTTP serve loop that
+    terminated unexpectedly left the REST/management API down for the life of
+    the process on an UNCHANGED configuration, exactly as HTTPS did before round
+    6. The HTTP arm now also fires when `next.Addr != "" && !m.srv.HTTPServing()`
+    — gated on a non-empty desired address so it stays strictly additive, since
+    `ReconcileHTTP` refuses an empty bind and the #6827 over-reach guard
+    `a_failed_boot_then_an_empty_bind_binds_nothing` pins that direction — and
+    `ReconcileHTTP`'s no-op now asks `s.httpLeg.serving()`, mirroring
+    `ReconcileHTTPS`. New accessor `api.Server.HTTPServing()` is the exact
+    counterpart of `HTTPSServing()`.
+  - **…and nothing CALLED the reconcile** (#6803). Both gate fixes are only
+    reachable from `applyConfigLocked`, the sole caller of
+    `reconcileWebManagement`, so recovery still waited on an operator committing
+    — from a box whose management API had just died, which is the box they can no
+    longer reach to commit from. `mgmtListenerReassertLoop`
+    (`mgmt_listener_reassert.go`) is the owner: started unconditionally in `Run`
+    beside `proxyARPReassertLoop` / `raDeadSenderReassertLoop` (#6793) /
+    `fabricIPVLANReassertLoop` (#6791) / `hostInboundConntrackReassertLoop`
+    (#6802), 30s, taking `applySem` before acting (#4001) and re-checking the
+    gate INSIDE the semaphore because the commit it queued behind may already
+    have rebound the listener. Its gate is
+    `effectiveHTTPListener().State == StateFailed` — deliberately the SAME
+    question `show system services` answers, so the box can never report a dead
+    listener nothing is retrying, or retry one it reports healthy. Pinned by
+    `mgmt_listener_reassert_6803_test.go` (dead-leg rebind on an UNCHANGED
+    config, paired against a healthy leg that must NOT be bounced; the gate
+    tracks the operator view; the owner re-binds with no commit; the
+    inside-the-semaphore re-check; the loop ticks; and a loop-START cell) and
+    `pkg/api/reconcile_http_dead_leg_6803_test.go`.
+
+    Not covered by #6803: the PRIMARY (loopback) gRPC listener has the same hole
+    — `Run` logs a serve error and the goroutine exits with nothing re-binding —
+    while the FABRIC gRPC listener beside it has had a backoff supervisor since
+    #5047. Filed separately.
 
   Pinned by `TestMgmtReconcileRevokeHonoredDespiteHTTPSBindFailure_5866`
   (revocation honored across a failing HTTPS rebind),

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -567,6 +567,21 @@ func (d *Daemon) Run(ctx context.Context) error {
 		d.raDeadSenderReassertLoop(ctx)
 	}()
 
+	// #6803: the always-on retry owner for a management listener whose serve
+	// loop exited unexpectedly. Started unconditionally, alongside the proxy-ARP
+	// and RA re-assert loops and for the same reason: the ONLY caller of
+	// reconcileWebManagement is applyConfigLocked, so before this the endpoint
+	// came back only when an operator happened to commit — on a box whose
+	// management API had just died, which is the box they can no longer reach to
+	// commit from. The gate is a state read on the reconciler, so the loop is
+	// free on a node whose listeners are healthy and a no-op with no reconciler
+	// at all.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		d.mgmtListenerReassertLoop(ctx)
+	}()
+
 	// #6791: the always-on retry owner for a fabric IPVLAN overlay whose
 	// creation failed. Started unconditionally, alongside the proxy-ARP and RA
 	// re-asserts and for the same reason: BOTH standalone and cluster nodes

--- a/pkg/daemon/management.go
+++ b/pkg/daemon/management.go
@@ -466,7 +466,23 @@ func (m *managementReconciler) reconcileTo(next api.Config) error {
 
 	// HTTP leg: make-before-break rebind ONLY if the HTTP bind changed. Advance
 	// the converged fingerprint only on success (retry debt on failure).
-	if next.Addr != m.cur.addr {
+	//
+	// The `!HTTPServing()` disjunct is the HTTP counterpart of the HTTPS
+	// liveness check below, and it was missing (#6803). The fingerprint records
+	// what the last SUCCESSFUL reconcile bound; it is not evidence the socket is
+	// still up. An unexpected serve exit marks the leg dead and leaves it
+	// installed, so `next.Addr != m.cur.addr` was FALSE on every later commit,
+	// ReconcileHTTP was never called, and the REST/management API stayed down
+	// until a daemon restart even though the operator's configuration never
+	// changed — the identical defect #6827 round 6 fixed for HTTPS, on the leg
+	// that fix did not touch.
+	//
+	// The liveness disjunct is gated on a NON-EMPTY desired address so this stays
+	// strictly ADDITIVE: the original `next.Addr != m.cur.addr` arm is untouched
+	// (an empty desired address still reaches ReconcileHTTP and still surfaces its
+	// refusal), and the new arm only fires where something was actually asked to
+	// serve. Not-serving is a defect only when a bind was requested.
+	if next.Addr != m.cur.addr || (next.Addr != "" && !m.srv.HTTPServing()) {
 		// Record the attempted bind so `show system services` reports the address
 		// a boot-failed listener is retrying, not the one it failed at boot (#6401).
 		m.lastHTTPAttempt = next.Addr

--- a/pkg/daemon/mgmt_listener_reassert.go
+++ b/pkg/daemon/mgmt_listener_reassert.go
@@ -1,0 +1,120 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/sysservices"
+)
+
+// mgmt_listener_reassert.go — #6803.
+//
+// An unexpected management-listener serve exit was OBSERVABLE and never
+// RECONCILED. Observable: the leg is marked dead, EffectiveHTTPAddr stops
+// reporting it, and `show system services` renders the HTTP listener Failed.
+// Never reconciled: the only caller of reconcileWebManagement is
+// applyConfigLocked (daemon_apply.go), so the endpoint came back only when an
+// operator happened to commit — on a box whose management API had just died,
+// which is the box they can no longer reach to commit from.
+//
+// Two separate gaps had to close for a re-bind to be possible at all, both of
+// them asymmetries with the HTTPS leg that #6827 round 6 had already fixed:
+//
+//   - api.Server.ReconcileHTTP short-circuited on a same-address leg WITHOUT
+//     asking whether it was still serving, so even a forced re-drive returned
+//     nil having done nothing. ReconcileHTTPS asks.
+//   - managementReconciler.reconcileTo gated the HTTP rebind on the converged
+//     FINGERPRINT alone. The fingerprint records what the last successful
+//     reconcile bound; it is not evidence the socket is up.
+//
+// This file adds the third piece: an owner that notices. It mirrors
+// proxyARPReassertLoop / raDeadSenderReassertLoop (#6793) /
+// fabricIPVLANReassertLoop (#6791) / hostInboundConntrackReassertLoop (#6802) —
+// started unconditionally in Run, cheap gate, applySem before acting.
+
+// mgmtListenerReassertInterval is the cadence of the #6803 owner. A dead
+// management listener is how an operator gets back IN, so recovery wants to be
+// prompt; but the re-drive is a full management reconcile (a bind, and possibly
+// a TLS load), so it must not run at the 2s cadence of the cluster reconcile.
+// 30s matches the other always-on self-heal loops.
+var mgmtListenerReassertInterval = 30 * time.Second
+
+// mgmtListenerReassertLoop re-drives the management reconcile while a listener
+// the configuration asked for is not serving.
+//
+// Always-on and mode-agnostic. The gate is a state read on the reconciler, so it
+// is free on a node whose listeners are healthy, and a complete no-op on a node
+// with no management reconciler at all (--api-addr empty).
+func (d *Daemon) mgmtListenerReassertLoop(ctx context.Context) {
+	t := time.NewTicker(mgmtListenerReassertInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			d.reassertMgmtListenersOnce(ctx)
+		}
+	}
+}
+
+// mgmtListenerDown reports whether a management listener the configuration asked
+// for is not currently serving.
+//
+// It asks the SAME question `show system services` answers, deliberately: the
+// operator-visible Failed state and the retry trigger must not be able to
+// disagree, or the box reports a dead listener that nothing is retrying (or
+// retries one it reports healthy). StateFailed covers both a boot bind that
+// never converged and a converged leg whose serve loop exited.
+func (d *Daemon) mgmtListenerDown() bool {
+	mgmt := d.mgmt.Load()
+	if mgmt == nil {
+		return false
+	}
+	return mgmt.effectiveHTTPListener().State == sysservices.StateFailed
+}
+
+// reassertMgmtListenersOnce re-drives one management reconcile if a listener is
+// down.
+//
+// It takes applySem before acting, for the #4001 reason the sibling loops give:
+// an apply may be mid-flight, and reconciling the management listener against a
+// half-applied configuration could bind an endpoint the in-flight apply is about
+// to move. The gate is re-checked INSIDE the semaphore because the commit this
+// tick queued behind may have rebound the listener already — re-driving then is
+// a redundant bind on a healthy socket.
+//
+// The reconcile is driven from the ACTIVE config, not a snapshot taken before
+// the wait, so a tick that blocked behind a commit converges on what that commit
+// committed rather than on what was live when the tick started. reconcileTo's
+// own committedDesired fence (#5561 round 14) makes that the same answer, and
+// passing the active config keeps the two agreeing rather than relying on it.
+func (d *Daemon) reassertMgmtListenersOnce(ctx context.Context) {
+	if !d.mgmtListenerDown() {
+		return
+	}
+	if d.applySem == nil {
+		return
+	}
+	if err := d.applySem.Acquire(ctx, 1); err != nil {
+		return
+	}
+	defer d.applySem.Release(1)
+	if !d.mgmtListenerDown() {
+		return
+	}
+	var cfg *config.Config
+	if d.store != nil {
+		cfg = d.store.ActiveConfig()
+	}
+	slog.Warn("management listener is not serving; re-driving the management " +
+		"reconcile (#6803) — an unexpected serve exit used to stay down until " +
+		"an operator committed, on a box whose management API had just died")
+	if err := d.reconcileWebManagement(cfg); err != nil {
+		// Retained-listener fail-safe: a failed rebind keeps whatever is still
+		// live. Log and let the next tick retry — that IS the retry owner.
+		slog.Error("management listener re-assert failed; will retry", "err", err)
+	}
+}

--- a/pkg/daemon/mgmt_listener_reassert.go
+++ b/pkg/daemon/mgmt_listener_reassert.go
@@ -41,6 +41,21 @@ import (
 // 30s matches the other always-on self-heal loops.
 var mgmtListenerReassertInterval = 30 * time.Second
 
+// mgmtReassertApply is the reconcile seam for the #6803 owner, in the same
+// spirit as conntrackDeleteFilters and nftApplyPayload: a package var so a test
+// can observe WHETHER the owner re-drove a reconcile, not merely what the
+// listener ended up as. Production code must never mutate it.
+//
+// It exists because the re-drive is IDEMPOTENT. Asking "was the listener rebound"
+// cannot distinguish an owner that correctly skipped a redundant reconcile from
+// one that ran a full reconcile for nothing — a reconcile against an
+// already-healthy leg changes no listener, so the #4001 inside-the-semaphore
+// re-check was invisible to an outcome-shaped assertion and survived its
+// mutation cell. The call itself is the observable.
+var mgmtReassertApply = func(d *Daemon, cfg *config.Config) error {
+	return d.reconcileWebManagement(cfg)
+}
+
 // mgmtListenerReassertLoop re-drives the management reconcile while a listener
 // the configuration asked for is not serving.
 //
@@ -112,7 +127,7 @@ func (d *Daemon) reassertMgmtListenersOnce(ctx context.Context) {
 	slog.Warn("management listener is not serving; re-driving the management " +
 		"reconcile (#6803) — an unexpected serve exit used to stay down until " +
 		"an operator committed, on a box whose management API had just died")
-	if err := d.reconcileWebManagement(cfg); err != nil {
+	if err := mgmtReassertApply(d, cfg); err != nil {
 		// Retained-listener fail-safe: a failed rebind keeps whatever is still
 		// live. Log and let the next tick retry — that IS the retry owner.
 		slog.Error("management listener re-assert failed; will retry", "err", err)

--- a/pkg/daemon/mgmt_listener_reassert_6803_test.go
+++ b/pkg/daemon/mgmt_listener_reassert_6803_test.go
@@ -1,0 +1,359 @@
+// mgmt_listener_reassert_6803_test.go — #6803.
+//
+// An unexpected management-listener serve exit was OBSERVABLE and never
+// RECONCILED at the same endpoint. Three things had to be true for that, and
+// each needs its own cell, because fixing any one alone leaves the endpoint down:
+//
+//  1. api.Server.ReconcileHTTP short-circuited on a same-address leg WITHOUT
+//     asking whether it was still serving, so even a forced re-drive returned nil
+//     having done nothing. ReconcileHTTPS asks. (pkg/api cell.)
+//  2. reconcileTo gated the HTTP rebind on the converged FINGERPRINT alone, which
+//     records what the last SUCCESSFUL reconcile bound and is not evidence the
+//     socket is up. #6827 round 6 gave the HTTPS arm this liveness question; the
+//     HTTP arm never got it.
+//  3. Nothing CALLED reconcile except applyConfigLocked, so recovery waited on an
+//     operator committing — from a box whose management API had just died.
+//
+// Every cell here is PAIRED against the healthy case, because each fix is a
+// widened trigger and the failure mode of over-widening is real: a rebind that
+// fires on a healthy leg bounces the management socket on every commit / every
+// 30s tick. The existing #6827 over-reach guards
+// (management_recovery_6827_test.go) already pin the empty-bind direction.
+package daemon
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/psaab/xpf/pkg/api"
+	"github.com/psaab/xpf/pkg/sysservices"
+)
+
+// killLeg6803 simulates an UNEXPECTED serve exit the way production produces
+// one: the listening socket goes away underneath a live Serve loop, which
+// returns a non-ErrServerClosed error and marks the leg dead. It does NOT reach
+// into api's unexported state, so the cell exercises the same path the defect
+// arrives on.
+func killLeg6803(t *testing.T, m *managementReconciler, reg *fakeReg, addr string) {
+	t.Helper()
+	reg.mu.Lock()
+	ln := reg.byAddr[addr]
+	reg.mu.Unlock()
+	if ln == nil {
+		t.Fatalf("no listener was ever created at %s; the case starts wrong", addr)
+	}
+	ln.Close()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if !m.srv.HTTPServing() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("the HTTP leg at %s was still reported serving after its socket died", addr)
+}
+
+// bootMgmt6803 boots a management reconciler on a live (fake) listener and
+// returns it with the Daemon that OWNS it.
+//
+// The daemon's opts.APIAddr is the address, and d.mgmt holds the reconciler, so
+// reconcileWebManagement's own derivation (desired -> resolveAPIBinds) lands on
+// the same endpoint the boot bound. That matters: the owner cells must exercise
+// the REAL production entry point, not reconcileTo with a hand-built config —
+// a helper that fed the address in directly would keep passing if the owner
+// derived a different (or empty) desired endpoint, which is exactly how the
+// first cut of this fixture went green on a no-op.
+//
+// addr is loopback because resolveAPIBinds' #4047/#5127 clamp pulls an off-box
+// bind back to loopback when no api-auth is configured; using an off-box address
+// here would silently reconcile toward a DIFFERENT endpoint than the one booted.
+func bootMgmt6803(t *testing.T, reg *fakeReg, addr string) (*Daemon, *managementReconciler) {
+	t.Helper()
+	d := &Daemon{applySem: semaphore.NewWeighted(1)}
+	d.opts.APIAddr = addr
+	m := newManagementReconciler(d, api.Config{ListenFunc: reg.listen})
+	d.mgmt.Store(m)
+
+	if got := m.desired(nil).Addr; got != addr {
+		t.Fatalf("the reconciler's own derivation wants %q but the fixture booted "+
+			"%q; the owner cells would reconcile toward a different endpoint and "+
+			"pass vacuously", got, addr)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	if err := m.startTo(ctx, cfgFor(reg, addr, false, "", nil)); err != nil {
+		t.Fatalf("startTo: %v", err)
+	}
+	if !m.srv.HTTPServing() {
+		t.Fatal("the boot bind did not leave the HTTP leg serving; the case starts wrong")
+	}
+	return d, m
+}
+
+func listenerCount6803(reg *fakeReg, addr string) int {
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	if _, ok := reg.byAddr[addr]; ok {
+		return 1
+	}
+	return 0
+}
+
+// TestReconcileRebindsADeadLegAtTheSameAddress6803 is the cell the whole issue
+// turns on, and it is PAIRED.
+//
+// The dead leg drives the SAME desired config that is already recorded as
+// converged — the smallest shape where the fingerprint gate and the liveness
+// gate disagree. A fixture that also changed the address could not see the
+// defect at all: `next.Addr != m.cur.addr` would be true and the rebind would
+// happen either way.
+//
+// FAIL-ON-REVERT: restore reconcileTo's arm to a bare `next.Addr != m.cur.addr`,
+// or restore ReconcileHTTP's short circuit to a bare address compare, and the
+// dead leg is never rebound.
+func TestReconcileRebindsADeadLegAtTheSameAddress6803(t *testing.T) {
+	const addr = "127.0.0.1:8080"
+
+	t.Run("dead-leg-is-rebound", func(t *testing.T) {
+		reg := newFakeReg()
+		_, m := bootMgmt6803(t, reg, addr)
+		killLeg6803(t, m, reg, addr)
+
+		// Same config the reconciler already recorded as converged.
+		if err := m.reconcileTo(cfgFor(reg, addr, false, "", nil)); err != nil {
+			t.Fatalf("reconcileTo: %v", err)
+		}
+		if !m.srv.HTTPServing() {
+			t.Fatal("an UNCHANGED reconcile did not rebind the dead HTTP leg — the " +
+				"management API stays down until a daemon restart even though the " +
+				"operator's configuration never changed (#6803)")
+		}
+		if got := m.effectiveHTTPListener(); got.State != sysservices.StateListening {
+			t.Errorf("`show system services` still reports the HTTP listener as %v "+
+				"after a successful re-bind", got.State)
+		}
+	})
+
+	t.Run("live-leg-is-not-bounced", func(t *testing.T) {
+		// The over-reach direction. Widening the trigger to fire on a HEALTHY leg
+		// would tear the management socket down and rebuild it on every commit and
+		// on every 30s re-assert tick — an availability defect traded for an
+		// availability defect.
+		reg := newFakeReg()
+		_, m := bootMgmt6803(t, reg, addr)
+		reg.mu.Lock()
+		before := reg.byAddr[addr]
+		reg.mu.Unlock()
+
+		if err := m.reconcileTo(cfgFor(reg, addr, false, "", nil)); err != nil {
+			t.Fatalf("reconcileTo: %v", err)
+		}
+		reg.mu.Lock()
+		after := reg.byAddr[addr]
+		reg.mu.Unlock()
+		if after != before {
+			t.Fatal("an unchanged reconcile REBOUND a healthy HTTP leg; the liveness " +
+				"trigger must fire on a dead leg only")
+		}
+		if !before.isOpen() {
+			t.Fatal("the healthy listener was closed by an unchanged reconcile")
+		}
+	})
+}
+
+// TestMgmtListenerDownTracksTheOperatorView6803 pins the retry gate to the SAME
+// question `show system services` answers.
+//
+// If they can disagree, the box either reports a dead listener nothing retries,
+// or retries one it reports healthy. Binding the gate to StateFailed rather than
+// to a second private predicate is what makes that impossible.
+func TestMgmtListenerDownTracksTheOperatorView6803(t *testing.T) {
+	const addr = "127.0.0.1:8080"
+	reg := newFakeReg()
+	d, m := bootMgmt6803(t, reg, addr)
+
+	if d.mgmtListenerDown() {
+		t.Fatal("a healthy serving listener reported DOWN; the re-assert owner " +
+			"would rebind a working socket every 30s")
+	}
+	killLeg6803(t, m, reg, addr)
+	if !d.mgmtListenerDown() {
+		t.Fatal("a listener whose serve loop exited reported UP; nothing would " +
+			"ever re-drive it (#6803)")
+	}
+	if got := m.effectiveHTTPListener().State; got != sysservices.StateFailed {
+		t.Errorf("the operator view says %v while the gate says down — the two "+
+			"must be the same question", got)
+	}
+
+	// No reconciler at all (--api-addr empty) must read UP, not down: an absent
+	// management plane is not a failed one, and reporting it down would make the
+	// owner re-drive a reconcile forever on a node that never wanted one.
+	if (&Daemon{}).mgmtListenerDown() {
+		t.Error("a daemon with no management reconciler reported a DOWN listener")
+	}
+}
+
+// TestReassertRebindsWithoutACommit6803 is the OWNER cell: the piece that makes
+// the two gate fixes reachable without an operator commit.
+//
+// PAIRED, because "re-drives the reconcile" is satisfied by an owner that
+// re-drives unconditionally — which is the healthy-leg bounce again, now on a
+// 30s timer.
+func TestReassertRebindsWithoutACommit6803(t *testing.T) {
+	const addr = "127.0.0.1:8080"
+
+	t.Run("down-leg-is-re-driven", func(t *testing.T) {
+		reg := newFakeReg()
+		d, m := bootMgmt6803(t, reg, addr)
+		killLeg6803(t, m, reg, addr)
+
+		d.reassertMgmtListenersOnce(context.Background())
+
+		if !m.srv.HTTPServing() {
+			t.Fatal("the re-assert owner did not bring the management listener back; " +
+				"the ONLY caller of reconcileWebManagement is applyConfigLocked, so " +
+				"without this the endpoint returns only when an operator commits — " +
+				"from a box whose management API has just died (#6803)")
+		}
+	})
+
+	t.Run("healthy-leg-is-left-alone", func(t *testing.T) {
+		reg := newFakeReg()
+		d, m := bootMgmt6803(t, reg, addr)
+		if !m.srv.HTTPServing() {
+			t.Fatal("the healthy-case fixture is not serving; the case starts wrong")
+		}
+		reg.mu.Lock()
+		before := reg.byAddr[addr]
+		reg.mu.Unlock()
+
+		d.reassertMgmtListenersOnce(context.Background())
+
+		reg.mu.Lock()
+		after := reg.byAddr[addr]
+		reg.mu.Unlock()
+		if after != before || !before.isOpen() {
+			t.Fatal("the re-assert owner rebound a HEALTHY management listener; on a " +
+				"30s ticker that is a management socket bounce every 30s forever")
+		}
+	})
+}
+
+// TestReassertRechecksTheGateInsideTheSemaphore6803 pins the #4001 ordering.
+//
+// The outer check is an optimisation; the inner one is the correctness gate. A
+// tick that blocked behind an in-flight commit may find that the commit's own
+// reconcile already rebound the listener — re-driving then is a redundant bind
+// on a healthy socket, which is precisely what the paired cells above forbid.
+//
+// Every other cell drives the re-assert single-threaded, where the semaphore is
+// invisible by construction, so this is the only cell that can see it.
+func TestReassertRechecksTheGateInsideTheSemaphore6803(t *testing.T) {
+	const addr = "127.0.0.1:8080"
+	reg := newFakeReg()
+	d, m := bootMgmt6803(t, reg, addr)
+	killLeg6803(t, m, reg, addr)
+
+	if err := d.applySem.Acquire(context.Background(), 1); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		close(started)
+		d.reassertMgmtListenersOnce(context.Background())
+		close(done)
+	}()
+	<-started
+
+	// Simulate the commit this tick queued behind having rebound the listener.
+	if err := m.reconcileTo(cfgFor(reg, addr, false, "", nil)); err != nil {
+		t.Fatalf("simulated commit reconcile: %v", err)
+	}
+	reg.mu.Lock()
+	afterCommit := reg.byAddr[addr]
+	reg.mu.Unlock()
+
+	d.applySem.Release(1)
+	<-done
+
+	reg.mu.Lock()
+	afterReassert := reg.byAddr[addr]
+	reg.mu.Unlock()
+	if afterReassert != afterCommit {
+		t.Fatal("the re-assert rebound the listener again after the commit it queued " +
+			"behind had already brought it back — re-checking INSIDE the semaphore " +
+			"is what prevents that (#6803/#4001)")
+	}
+	if !afterCommit.isOpen() {
+		t.Fatal("the listener the commit rebound was closed by the re-assert")
+	}
+}
+
+// TestRunStartsMgmtListenerReassertLoop6803 is the LOOP-START cell.
+//
+// Every cell above drives reassertMgmtListenersOnce directly, so a Run that
+// never launched the owner would pass all of them — and "no owner" is gap 3 of
+// three. #6793 shipped with exactly this hole.
+//
+// Run() cannot be driven from a unit test (netlink, a dataplane, sockets), so
+// the start is asserted at the source with comments stripped: a source-scanning
+// gate that greps for a line its own doc comment quotes is satisfied by the
+// comment.
+func TestRunStartsMgmtListenerReassertLoop6803(t *testing.T) {
+	src := stripLineComments6791(readDaemonSource(t, "daemon_run.go"))
+
+	const call = "d.mgmtListenerReassertLoop(ctx)"
+	if !strings.Contains(src, call) {
+		t.Fatalf("Run does not start mgmtListenerReassertLoop; a management " +
+			"listener whose serve loop exited has no owner, so it comes back only " +
+			"when an operator commits — from a box whose management API just died " +
+			"(#6803)")
+	}
+	idx := strings.Index(src, call)
+	window := src[clampZero6791(idx-400):idx]
+	for _, gate := range []string{
+		"if d.cluster != nil",
+		"if d.isCluster",
+		"if d.opts.ClusterEnabled",
+	} {
+		if strings.Contains(window, gate) {
+			t.Errorf("mgmtListenerReassertLoop is started behind %q; a standalone "+
+				"node's management listener dies the same way", gate)
+		}
+	}
+}
+
+// TestReassertLoopTicks6803 binds the loop BODY. It and the START cell fail for
+// different reasons: this reds if the ticker is wired to the wrong function,
+// that one reds if Run never launches it.
+func TestReassertLoopTicks6803(t *testing.T) {
+	const addr = "127.0.0.1:8080"
+	prev := mgmtListenerReassertInterval
+	mgmtListenerReassertInterval = 5 * time.Millisecond
+	t.Cleanup(func() { mgmtListenerReassertInterval = prev })
+
+	reg := newFakeReg()
+	d, m := bootMgmt6803(t, reg, addr)
+	killLeg6803(t, m, reg, addr)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go d.mgmtListenerReassertLoop(ctx)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if m.srv.HTTPServing() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("mgmtListenerReassertLoop never re-drove the dead management listener")
+}

--- a/pkg/daemon/mgmt_listener_reassert_6803_test.go
+++ b/pkg/daemon/mgmt_listener_reassert_6803_test.go
@@ -24,12 +24,14 @@ package daemon
 import (
 	"context"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"golang.org/x/sync/semaphore"
 
 	"github.com/psaab/xpf/pkg/api"
+	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/sysservices"
 )
 
@@ -264,6 +266,19 @@ func TestReassertRechecksTheGateInsideTheSemaphore6803(t *testing.T) {
 		t.Fatalf("Acquire: %v", err)
 	}
 
+	// Count RECONCILE CALLS, not listener outcomes. The re-drive is idempotent —
+	// a reconcile against an already-healthy leg rebinds nothing — so an
+	// outcome-shaped assertion cannot tell a correctly-skipped reconcile from a
+	// full one run for nothing, and deleting the inner re-check left exactly that
+	// assertion GREEN. The call is the observable.
+	var reconciles atomic.Int64
+	prev := mgmtReassertApply
+	mgmtReassertApply = func(dd *Daemon, cfg *config.Config) error {
+		reconciles.Add(1)
+		return prev(dd, cfg)
+	}
+	t.Cleanup(func() { mgmtReassertApply = prev })
+
 	started := make(chan struct{})
 	done := make(chan struct{})
 	go func() {
@@ -284,16 +299,27 @@ func TestReassertRechecksTheGateInsideTheSemaphore6803(t *testing.T) {
 	d.applySem.Release(1)
 	<-done
 
+	if n := reconciles.Load(); n != 0 {
+		t.Fatalf("the re-assert ran %d management reconcile(s) after the commit it "+
+			"queued behind had already brought the listener back — re-checking the "+
+			"gate INSIDE the semaphore is what prevents that (#6803/#4001)", n)
+	}
 	reg.mu.Lock()
 	afterReassert := reg.byAddr[addr]
 	reg.mu.Unlock()
-	if afterReassert != afterCommit {
-		t.Fatal("the re-assert rebound the listener again after the commit it queued " +
-			"behind had already brought it back — re-checking INSIDE the semaphore " +
-			"is what prevents that (#6803/#4001)")
+	if afterReassert != afterCommit || !afterCommit.isOpen() {
+		t.Fatal("the listener the commit rebound was disturbed by the re-assert")
 	}
-	if !afterCommit.isOpen() {
-		t.Fatal("the listener the commit rebound was closed by the re-assert")
+
+	// POSITIVE CONTROL. Without it "ran 0 reconciles" is satisfied by an owner
+	// that never reconciles at all, and the whole cell would be vacuous — the
+	// gate under test is a SKIP, so it has to be shown skipping something that
+	// otherwise happens.
+	killLeg6803(t, m, reg, addr)
+	d.reassertMgmtListenersOnce(context.Background())
+	if n := reconciles.Load(); n != 1 {
+		t.Fatalf("with the listener genuinely down the owner ran %d reconcile(s), "+
+			"want 1 — the skip above proves nothing if the owner never reconciles", n)
 	}
 }
 


### PR DESCRIPTION
Closes #6803.

Note: this issue's cited evidence file (`/tmp/opus-review-001.md`) no longer
exists — not in `/tmp`, not in `docs/reviews/`, never committed. Everything below
is re-derived from source at current `origin/master`. I annotated all 15 issues
sharing that dead reference.

## What the defect is

An unexpected management-listener serve exit is **observable** and was **never
reconciled**. Observable: the leg is marked dead, `EffectiveHTTPAddr` stops
reporting it, and `show system services` renders the HTTP listener `Failed`. Not
reconciled — for **three independent reasons, any one of which alone keeps the
endpoint down**.

The first two are the exact defects **#6827 round 6 fixed for the HTTPS leg and
did not apply to the HTTP one**:

1. `api.Server.ReconcileHTTP` short-circuited a same-address call on a non-nil
   leg **pointer**:
   ```go
   if s.httpLeg != nil && s.httpLeg.srv.Addr == addr { return nil }
   ```
   A dead leg stays **installed** — it cannot be unlinked there without taking
   `lifeMu`, which deadlocks a shutdown racing the exit — so the compare matched
   a corpse and the rebind returned `nil` having done nothing.
   `ReconcileHTTPS` asks `s.httpsLeg.serving()`.
2. `reconcileTo`'s HTTP arm gated on the converged **fingerprint** alone
   (`next.Addr != m.cur.addr`). The fingerprint records what the last
   *successful* reconcile bound; it is not evidence the socket is up. The HTTPS
   arm beside it carries `|| (next.TLS && !m.srv.HTTPSServing())`.
3. **Nothing called the reconcile.** `applyConfigLocked` is the only caller of
   `reconcileWebManagement`, so even with both gates fixed the endpoint came back
   only when an operator committed — from a box whose management API had just
   died, which is the box they can no longer reach to commit from.

## The fix

- **`api.Server.HTTPServing()`** — the exact counterpart of `HTTPSServing()`.
  `ReconcileHTTP`'s no-op now asks it.
- **The HTTP arm** fires on
  `next.Addr != m.cur.addr || (next.Addr != "" && !m.srv.HTTPServing())`. The
  non-empty guard keeps the change **strictly additive**: the original arm is
  untouched, so an empty desired address still reaches `ReconcileHTTP` and still
  surfaces its refusal. That direction is not hypothetical — the existing #6827
  over-reach guard `a_failed_boot_then_an_empty_bind_binds_nothing` pins it, and
  M5 below confirms it still does.
- **`mgmtListenerReassertLoop`** (`pkg/daemon/mgmt_listener_reassert.go`) —
  unconditional in `Run` beside `proxyARPReassertLoop`,
  `raDeadSenderReassertLoop` (#6793), `fabricIPVLANReassertLoop` (#6791) and
  `hostInboundConntrackReassertLoop` (#6802). 30s; takes `applySem` before acting
  (#4001) and re-checks its gate **inside** the semaphore.

The owner's gate is `effectiveHTTPListener().State == StateFailed` —
deliberately the **same question `show system services` answers**. A second
private predicate could disagree with the operator view, and then the box either
reports a dead listener nothing is retrying, or retries one it reports healthy.

## Mutation matrix

Fix committed first. Every cell is a full-package `go test -count=1`, **no `-run`
filter**. Controls: unmutated `pkg/api` and `pkg/daemon` both GREEN.

| # | Mutation | Result | Cell that red |
|---|---|---|---|
| M1 | `ReconcileHTTP` short circuit back to pointer+address | **RED** | `TestReconcileHTTPRebindsADeadSameAddressLeg6803` |
| M2 | `HTTPServing` hardwired **true** (a corpse reads healthy) | **RED** | `TestHTTPServingMirrorsHTTPSServing6803` |
| M3 | `HTTPServing` hardwired **false** (a live leg reads dead) | **RED** | `TestReconcileHTTPLeavesALiveSameAddressLegAlone6803` |
| M4 | HTTP arm back to the fingerprint alone | **RED** | `TestReconcileRebindsADeadLegAtTheSameAddress6803` |
| M5 | HTTP arm made **unconditional** (over-reach) | **RED** | `TestMgmtBootRetryDoesNotOverReach_6827` — the pre-existing guard |
| M6 | owner gate hardwired **down** | **RED** | `TestReassertRebindsWithoutACommit6803/healthy-leg-is-left-alone` |
| M7 | owner gate hardwired **up** | **RED** | `TestReassertRebindsWithoutACommit6803/down-leg-is-re-driven` |
| M8b | drop the inside-the-semaphore re-check (#4001) | **RED** | `TestReassertRechecksTheGateInsideTheSemaphore6803` |
| M9 | `Run` no longer starts the loop | **RED** | `TestRunStartsMgmtListenerReassertLoop6803` |
| M10 | the loop body calls nothing | **RED** | `TestReassertLoopTicks6803` |
| M11 | the owner never calls the reconcile (positive control) | **RED** | three cells |

**M8 survived on the first pass, and that is worth reporting.** The re-drive is
**idempotent** — a reconcile against an already-healthy leg rebinds nothing — so
my cell's outcome-shaped assertion ("was the listener disturbed?") could not tell
a correctly-skipped reconcile from a full one run for nothing. Deleting the inner
gate left it green. Fixed by routing the owner's reconcile through a package-var
seam (the shape `conntrackDeleteFilters` and `nftApplyPayload` already use) and
counting **calls**, plus a **positive control**: with the listener genuinely down
the owner must run exactly one reconcile, or "ran 0" is satisfied by an owner
that never reconciles at all. M8b then reds.

Every cell is **paired** against the healthy case, because all three fixes widen
a trigger and the over-reach failure is real: a rebind that fires on a healthy leg
tears the management socket down and rebuilds it on every commit *and* every 30s
tick. M3, M5 and M6 are those directions.

## Found while re-deriving, filed separately

**#7611** — the **primary (loopback) gRPC listener** has the identical hole: `Run`
logs a serve error and the goroutine exits with nothing re-binding, and a bind
failure at start is equally terminal. Meanwhile the **fabric** gRPC listener in
the same file has had a bounded-backoff supervisor since #5047, whose own comment
describes this exact failure. Kept out of this PR: different package, different
mechanism, and #5047 is the template.

## Validation

- `go build ./...`, `go vet ./...`, `go test -count=1 ./...` repo-wide — rc and
  HEAD reported in the gate comment below.
- Rust files touched: **0** — no cargo leg owed.
- Docs updated in the same change: `pkg/daemon/README.md` (two new bullets in the
  #6827 management-listener section, plus the #7611 pointer) and
  `pkg/api/README.md`.

## Smoke

**No cluster smoke owed by the change class** — nothing here touches cluster,
VRRP, session sync or failover code. The behavioural risk is the over-reach
direction (bouncing a healthy management socket), which is bound by M3/M5/M6
rather than by a smoke run: a smoke would exercise a healthy listener and see
nothing either way.
