### PR TITLE
_Log.md: resolve six committed conflict markers, and gate against more

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -104994,8 +104994,6 @@ prose edit above them added. No diff falls in the new test body.
   pkg/api/metrics_userspace.go, pkg/api/metrics_test.go,
   docs/userspace-dataplane-architecture.md, _Log.md
 ## 2026-08-23 — #6797 withdraw a credential ownership claim when the mutation fails
-<<<<<<< HEAD
-
 - **Timestamp**: 2026-08-23
 - **Action**: #5841 writes the resource ownership markers BEFORE the credential
   mutation (deliberately, to avoid a mutated-but-unmarked underclaim), but
@@ -105010,8 +105008,6 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: `pkg/daemon/login_password.go`, `pkg/daemon/daemon_system.go`,
   `pkg/daemon/login_marker_overclaim_6797_test.go` (new),
   `docs/system-login.md`
-=======
->>>>>>> origin/master
 ## 2026-08-23 — #6799 a completing apply must not erase a debt armed mid-flight
 
 - **Timestamp**: 2026-08-23
@@ -105069,7 +105065,6 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/daemon/rg_apply_invalidate_race_6799_test.go`,
   `pkg/daemon/rg_state_test.go`, `pkg/daemon/README.md`, `_Log.md`
 
-<<<<<<< HEAD
 ## 2026-08-26 — #6803: a management listener that dies is now rebound at the same endpoint
 
 - **Timestamp**: 2026-08-26
@@ -105119,7 +105114,7 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/daemon/mgmt_listener_reassert_6803_test.go`,
   `pkg/api/reconcile_http_dead_leg_6803_test.go`, `pkg/daemon/README.md`,
   `pkg/api/README.md`, `_Log.md`
-=======
+
 ## 2026-08-26 — CLAUDE.md: a Required Reading index
 
 - **Timestamp**: 2026-08-26
@@ -105139,7 +105134,6 @@ prose edit above them added. No diff falls in the new test body.
   with the point that sub-agents inherit the file but not the reasoning, so a
   dispatch brief should name the specific documents its task touches.
 - **File(s)**: `CLAUDE.md`, `_Log.md`
->>>>>>> origin/master
 
 ## 2026-08-26 — #6803 follow-up: dampen the re-assert owner's per-tick logging
 
@@ -105159,3 +105153,36 @@ prose edit above them added. No diff falls in the new test body.
   that actually brought the listener back, not on one that merely returned nil.
 - **File(s)**: `pkg/daemon/mgmt_listener_reassert.go`, `pkg/daemon/daemon.go`,
   `pkg/daemon/mgmt_listener_reassert_6803_test.go`, `_Log.md`
+
+## 2026-08-26 — `_Log.md` carried six committed conflict markers; add a repo-wide sweep
+
+- **Timestamp**: 2026-08-26
+- **Action**: Union-resolve two merge-conflict blocks that were COMMITTED into
+  `_Log.md` on master, and add `pkg/refactoraudit/conflict_markers_test.go` so a
+  marker can never sit in a tracked file again.
+- **Why**: master carried six marker lines across two blocks. Both arrived the
+  same way — a `git merge` conflicted, the conflict was not checked, and a
+  `git add -A` staged the marker-laden file. One of the two had an EMPTY
+  "theirs" side, so an entire #6797 log entry sat inside a conflict block. I
+  authored the second block myself, in the #6803 dampening commit, by doing
+  exactly that.
+- **Why nothing caught it**: `_Log.md` is prose. No compiler, linter or test
+  reads it, so a marker is invisible to `go test ./...`. A marker in a SOURCE
+  file breaks the build loudly — the real exposure is docs, prose, configs,
+  fixtures and goldens, which is where one can sit indefinitely.
+- **The sweep**: over `git ls-files`, not a filesystem walk — this repo keeps
+  ~140 git worktrees under `.claude/wt-*` and a walk would descend into every
+  one, scanning other branches' trees. Anchored at line start, because an
+  unanchored search false-positives on prose ABOUT markers, which `_Log.md` is
+  full of. `=======` counts only when the line is EXACTLY seven equals, since
+  Markdown uses it as a setext underline and an ASCII rule.
+- **The needles are assembled at runtime**, not written as literals: a gate that
+  greps for a string must not contain that string, or it is the permanent first
+  hit of its own sweep and the only way to stay green is an exemption that also
+  hides real markers.
+- **Two anti-vacuity floors** (`len(files) >= 100`, `scanned >= 100`) plus a
+  sensitivity control that drives the same predicate over a synthetic conflicted
+  document and over the prose forms that must stay quiet. Verified paired: run
+  against the PRE-FIX `_Log.md` the gate REDs; against the fixed one it passes,
+  sweeping 7007 tracked text files.
+- **File(s)**: `_Log.md`, `pkg/refactoraudit/conflict_markers_test.go` (new)

--- a/pkg/refactoraudit/conflict_markers_test.go
+++ b/pkg/refactoraudit/conflict_markers_test.go
@@ -1,0 +1,201 @@
+package refactoraudit
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// conflict_markers_test.go — a repo-wide sweep for unresolved merge-conflict
+// markers in tracked files.
+//
+// This exists because master carried SIX of them in `_Log.md`, across two
+// blocks, for days. Both arrived the same way: a `git merge` conflicted,
+// the conflict was not checked, and a `git add -A` staged the marker-laden
+// file. Nothing caught it — `_Log.md` is prose, so no compiler, linter or
+// test ever reads it, and the damage is invisible in `go test ./...` output.
+// The second block swallowed an entire log entry into the "ours" side of a
+// block whose "theirs" side was empty.
+//
+// A conflict marker in a SOURCE file breaks the build loudly, so the real
+// exposure is everything else: docs, prose, configs, fixtures, JSON goldens.
+// Those are exactly the files a marker can sit in indefinitely.
+//
+// The sweep is over `git ls-files`, not a filesystem walk, on purpose: this
+// repo keeps many git worktrees under `.claude/wt-*`, and a walk would descend
+// into every one of them — scanning other branches' trees, reporting findings
+// that are not in THIS tree, and taking a long time to do it.
+
+// markerPrefixes are the three conflict-marker line prefixes, ASSEMBLED AT
+// RUNTIME rather than written as literals.
+//
+// That is not stylistic. A gate that greps for a string must not contain that
+// string, or it reports itself: written literally, this file would be the
+// permanent first hit of its own sweep, and the only way to keep the suite
+// green would be to exempt the file — which then also exempts any real marker
+// that ever lands in it. Assembling the needles means no line of this source
+// begins with one.
+func markerPrefixes() []string {
+	return []string{
+		strings.Repeat("<", 7) + " ",
+		strings.Repeat("=", 7),
+		strings.Repeat(">", 7) + " ",
+	}
+}
+
+// TestNoUnresolvedConflictMarkers fails if any tracked file contains a line
+// that BEGINS with a conflict marker.
+//
+// Anchored at line start, deliberately. An unanchored search false-positives on
+// prose ABOUT conflict markers — including this file's own doc comments, and
+// the `_Log.md` entries that describe resolving a conflict. The anchor is what
+// makes the gate usable in a repo whose log discusses its own merges.
+func TestNoUnresolvedConflictMarkers(t *testing.T) {
+	root := repoRootForMarkerSweep(t)
+
+	out, err := exec.Command("git", "-C", root, "ls-files", "-z").Output()
+	if err != nil {
+		t.Skipf("git ls-files unavailable (%v); the sweep needs a git checkout", err)
+	}
+	files := strings.Split(strings.TrimRight(string(out), "\x00"), "\x00")
+	if len(files) < 100 {
+		// A sweep that enumerated almost nothing is a PASS that proves nothing —
+		// the failure mode where the gate goes green because it looked at an
+		// empty set. This repo has thousands of tracked files.
+		t.Fatalf("git ls-files returned only %d paths; the sweep did not run over "+
+			"the repository", len(files))
+	}
+
+	prefixes := markerPrefixes()
+	var findings []string
+	scanned := 0
+	for _, rel := range files {
+		if rel == "" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			// A tracked path that cannot be read here is a submodule, a symlink
+			// to nowhere, or a file removed in the working tree. Not this gate's
+			// business.
+			continue
+		}
+		if bytes.IndexByte(data, 0) >= 0 {
+			continue // binary
+		}
+		scanned++
+		for i, line := range strings.Split(string(data), "\n") {
+			for _, p := range prefixes {
+				if !strings.HasPrefix(line, p) {
+					continue
+				}
+				// `=======` is also a legitimate Markdown setext heading underline
+				// and a common ASCII rule, so it only counts as a marker when the
+				// line is EXACTLY the seven characters. The other two carry a
+				// trailing space and a branch name, which prose does not.
+				if p == strings.Repeat("=", 7) && strings.TrimRight(line, "\r") != p {
+					continue
+				}
+				findings = append(findings,
+					filepath.Join(rel)+":"+itoa(i+1)+": "+truncate(line, 60))
+			}
+		}
+	}
+	if scanned < 100 {
+		t.Fatalf("only %d text files were scanned; the sweep is not covering the "+
+			"repository", scanned)
+	}
+	if len(findings) > 0 {
+		t.Fatalf("unresolved merge-conflict markers in %d tracked line(s) — a "+
+			"conflicted file was staged with `git add -A` without checking "+
+			"`git diff --diff-filter=U` first:\n  %s",
+			len(findings), strings.Join(findings, "\n  "))
+	}
+	t.Logf("swept %d tracked text files, no conflict markers", scanned)
+}
+
+// TestConflictMarkerSweepDetectsAMarker is the sensitivity control.
+//
+// Without it, `TestNoUnresolvedConflictMarkers` passing means either "the repo
+// is clean" or "the matcher matches nothing" — and those are the same green.
+// This drives the same predicate over a synthetic conflicted document and
+// requires all three marker lines to be found, plus requires the prose forms
+// that must NOT match to stay unmatched.
+func TestConflictMarkerSweepDetectsAMarker(t *testing.T) {
+	prefixes := markerPrefixes()
+	lt, eq, gt := prefixes[0], prefixes[1], prefixes[2]
+
+	match := func(line string) bool {
+		for _, p := range prefixes {
+			if strings.HasPrefix(line, p) {
+				if p == eq && strings.TrimRight(line, "\r") != p {
+					continue
+				}
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, want := range []string{lt + "HEAD", eq, gt + "origin/master"} {
+		if !match(want) {
+			t.Errorf("the sweep does not match %q; it would pass over a genuinely "+
+				"conflicted file", want)
+		}
+	}
+	// Directions that must stay quiet, or the gate is unusable in this repo:
+	// `_Log.md` and the docs discuss conflict resolution in prose, and Markdown
+	// uses `=====` rules and setext underlines.
+	for _, quiet := range []string{
+		"  " + lt + "HEAD",                    // indented, i.e. quoted in prose
+		"a " + lt + "HEAD marker was staged",  // mid-line mention
+		eq + "==",                             // a longer ASCII rule
+		eq + " (a markdown setext underline)", // seven equals plus text
+		"# " + gt + "origin/master",           // quoted inside a heading
+	} {
+		if match(quiet) {
+			t.Errorf("the sweep matches %q; prose about conflict markers and "+
+				"markdown rules would make the gate unusable", quiet)
+		}
+	}
+}
+
+func repoRootForMarkerSweep(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find the repository root (no go.mod above the test)")
+		}
+		dir = parent
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}


### PR DESCRIPTION
`origin/master` was carrying **six unresolved merge-conflict marker lines** in
`_Log.md`, across two blocks. One of them had an **empty "theirs" side**, so an
entire #6797 log entry was sitting inside a conflict block.

Both arrived the same way: a `git merge` conflicted, the conflict was not
checked, and a `git add -A` staged the marker-laden file. **I authored the second
block myself**, in the #6803 dampening commit (`e9ad236b`) — I chained the merge
into other work with `&&`, piped its output through `tail -2`, never looked at
`git diff --diff-filter=U`, and committed.

## Why nothing caught it

`_Log.md` is prose. No compiler, no linter and no test reads it, so `go test
./...` was green the entire time. A conflict marker in a *source* file breaks the
build loudly — which is exactly why this feels safe and is not. The real exposure
is everything else: docs, prose, configs, fixtures, JSON goldens. Those are the
files a marker can sit in indefinitely.

## The resolution

Union — every entry on both sides of both blocks is a real log entry and belongs
in the file. Only the six marker lines are dropped. The diff is **+1/-7 in one
file**, and it is all marker removal; `gh pr diff` shows no prose changed.

Resolved **structurally from the merge stages** (`git show :1:` / `:2:` / `:3:`,
assert both sides are appends onto the base, then `base + ours_tail +
theirs_tail`), not with a regex over the marker text. My first attempt *was* a
regex and it mis-paired markers across blocks and produced a scrambled file; the
stage-based union was correct on the first try. Verified afterwards that no
**non-marker** line was lost — that check is what separates a union from a
truncation.

One thing worth recording, because it bit the verification: heading *uniqueness*
is the wrong invariant for this file. `_Log.md` already contains repeated
headings (a bare `## 2026-07-03` appears four times). The right invariant is that
the union introduces no duplicate the base did not already have.

## The gate

`pkg/refactoraudit/conflict_markers_test.go` — a repo-wide sweep, in the package
whose stated purpose is "to give `go test ./...` a home for the gate".

- **Over `git ls-files`, not a filesystem walk.** This repo keeps ~140 git
  worktrees under `.claude/wt-*`; a walk descends into every one, scans other
  branches' trees, and reports findings that are not in this tree.
- **Anchored at line start.** An unanchored search false-positives on prose
  *about* conflict markers, which `_Log.md` is full of. `=======` counts only
  when the line is **exactly** seven equals, since Markdown uses it as a setext
  heading underline and an ASCII rule.
- **The needles are assembled at runtime**, not written as literals. A gate that
  greps for a string must not *contain* that string, or it becomes the permanent
  first hit of its own sweep and the only way to keep the suite green is an
  exemption that also hides every real marker landing in that file.
- **Two anti-vacuity floors** — the file list and the scanned count must each
  exceed 100 — because a sweep that enumerated nothing is a pass that proves
  nothing.
- **A sensitivity control**, `TestConflictMarkerSweepDetectsAMarker`, drives the
  same predicate over a synthetic conflicted document (all three marker lines
  must match) *and* over the forms that must stay quiet: an indented marker, a
  mid-line mention, a longer ASCII rule, seven equals followed by text, and a
  marker quoted inside a heading.

## Validation

- **Paired proof of sensitivity, on the real defect**: with `_Log.md` restored to
  the pre-fix `origin/master` content the gate **REDs**; with the fix in place it
  passes, sweeping **7007** tracked text files.
- `go build ./...` **rc=0**; `go test -count=1 ./...` repo-wide **rc=0** at HEAD
  `1a1788ddba10db978414ee5a304b7ba644317adf`.
- Rust files touched: **0**. No cluster smoke owed — no production code changes
  at all; the only Go added is a test.
