### PR TITLE
_Log.md: remove three duplicated entries, and gate on containment (#7608)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -92977,73 +92977,6 @@ Every RED above is an assertion failure, not a build break.
   pkg/grpcapi/peer_policy_name_6851_test.go, docs/junos-cli-reference.md,
   _Log.md
 
-## 2026-08-05 — #5078 follow-ups: dead sync downgrade guard + a test that could not fail
-
-- **Timestamp**: 2026-08-05
-- **Action**: Two findings from reviewing the #5078 branch, plus the doc
-  half. (1) F-B: `TestSyncAuthHandshakeDowngradeGuardRejects` documented a
-  RED-on-revert that could not fire — flipping its only precondition
-  (`newAuthSync(t, key, true)` -> `false`) left it PASSING, because after
-  #5078 `syncAuthDecision` rejects every unkeyed peer on a keyed node
-  regardless of `peerAuthSeen`. It was a duplicate of
-  `TestSyncAuthHandshakeKeyedNodeRejectsLegacyPeer` wearing a
-  downgrade-guard name; deleted with a comment recording why. (2) F-A: the
-  sync-side downgrade guard it was named for was itself dead —
-  `syncPeerAuthSeen` had ZERO callers and `syncAuthedEver` was write-only
-  in effect (stored in `wrapSyncConn`, read only by the orphan). Go does
-  not flag unused methods, so it compiled green. Deleted, along with
-  `SyncAuthProvider.HeartbeatPeerAuthSeen()` (its only consumer through
-  the interface), the fake's implementation, and the now-meaningless
-  `authSeen` parameter of `newAuthSync`. (3) Docs: the `sync_auth.go`
-  package doc and the `pkg/cluster/README.md` PR-C section still described
-  keyed-node dual-accept, the deleted `pendingFrame` path, the removed
-  sync downgrade guard, and a two-method provider wiring.
-- **Scope verified, not assumed**: `Manager.HeartbeatPeerAuthSeen` is NOT
-  removed — still exported, still consumed by the gRPC fabric listener
-  (`pkg/grpcapi/fabric_auth.go`) and the control-link status string
-  (`status.go`). The #4107 HEARTBEAT downgrade guard is separate state
-  (`heartbeatAuthDecision` over `heartbeatAuthState.peerAuthenticated`),
-  so deleting the sync pair cannot disarm it;
-  `TestHeartbeatAuthDecision/key/legacy-after-peer-authed` and
-  `TestControlLinkAuthStatus` still pass.
-- **Not landed, deliberately**: my own `clusterCommsNeedRestart` guard +
-  `cluster_authkey_no_comms_restart_5078_test.go`. The branch already
-  carries `TestAuthKeyChangeDoesNotRestartClusterComms_5078`, which binds
-  the same property and additionally covers key ROTATION. A second test
-  for one property is noise.
-- **Validation**: `go build ./...` 0; `go vet ./pkg/cluster/ ./pkg/grpcapi/
-  ./pkg/daemon/` 0; `go test -count=1 ./pkg/cluster/ ./pkg/grpcapi/` 0;
-  full `go test ./pkg/... ./cmd/...` exit 0 (59 packages, zero failures).
-- **File(s)**: pkg/cluster/sync_auth.go, pkg/cluster/sync.go,
-  pkg/cluster/sync_auth_test.go, pkg/cluster/sync_admission_test.go,
-  pkg/cluster/sync_accept_test.go, pkg/cluster/README.md, _Log.md
-
-## 2026-08-05 — #6865 gate fold: bind the call site, retarget two RED labels
-
-- **Timestamp**: 2026-08-05
-- **Action**: F1 — added `TestKeyCommitDoesNotRestartCommsAtTheCallSite_5078`.
-  The step-20 decision in `daemon_apply_tail.go` is INLINE, so the existing
-  struct test could not see it: adding `|| keyChanged` there, with
-  `clusterTransportKey`/`clusterTransportFromConfig` byte-identical, produced
-  the permanent deadlock with a green suite. New test observes
-  `clusterCommsGen` across a real `applyTailReconciles`. F2 — retargeted the
-  RED-on-revert on `...KeyedNodeRejectsLegacyPeer`: it claimed "restore the
-  grace in syncAuthDecision", which does NOT fail it (the arm discards the
-  accept bit); it actually binds the arm returning nil. F3 — matrix comment
-  still described the deleted migration window as current and named the
-  removed `peerAuthSeen` param. F4 — de-duplicated a doubled paragraph in
-  `sync_auth.go`. F6 — assert the `reason` substring, since nil key is the
-  failure default of every error path. README — procedure 2 can itself
-  produce the keyed-primary/unkeyed-secondary deadlock if the connection
-  drops mid-rollout.
-- **Validation**: `go test -count=1 ./pkg/cluster/ ./pkg/daemon/` exit 0.
-  M2 (call-site `|| keyChanged`, struct untouched): struct test PASSES, new
-  call-site test FAILS, positive control passes. M4 (legacy arm returns nil):
-  `...KeyedNodeRejectsLegacyPeer` FAILS at the err==nil assertion.
-- **File(s)**: pkg/daemon/cluster_transport_key_5078_test.go,
-  pkg/cluster/sync_auth_test.go, pkg/cluster/sync_auth.go,
-  pkg/cluster/README.md, _Log.md
-
 ## 2026-08-07 — #6706 r11 fold: the `system login` packed gate saw one of three levels
 
 - **Timestamp**: 2026-08-07
@@ -105009,22 +104942,6 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/daemon/login_marker_overclaim_6797_test.go` (new),
   `docs/system-login.md`
 ## 2026-08-23 — #6799 a completing apply must not erase a debt armed mid-flight
-
-- **Timestamp**: 2026-08-23
-- **Action**: #5841 writes the resource ownership markers BEFORE the credential
-  mutation (deliberately, to avoid a mutated-but-unmarked underclaim), but
-  nothing withdrew the marker when the mutation then failed. Because the
-  markers gate a REVOCATION rather than a write, the stale claim makes xpf
-  later delete an operator's pre-existing authorized_keys or lock an account
-  whose password xpf never set. Added `claimOwnership`/`rollback`, which
-  withdraws only a claim the current pass created and preserves one an earlier
-  apply legitimately made, and applied it at all three marker-first sites (user
-  key write, user password chpasswd, root key write). The useradd path is
-  marker-after already and unchanged.
-- **File(s)**: `pkg/daemon/login_password.go`, `pkg/daemon/daemon_system.go`,
-  `pkg/daemon/login_marker_overclaim_6797_test.go` (new),
-  `docs/system-login.md`
-
 - **Timestamp**: 2026-08-23
 - **Action**: `reconcileRGState` captured a transition under `s.mu`, dropped the
   lock, ran `SetRGActive` off-lock, then recorded with an unguarded
@@ -105234,3 +105151,33 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/daemon/host_inbound_conntrack_retry_6802_test.go`,
   `pkg/api/metrics_hostinbound_conntrack_revoke_6802_test.go`,
   `pkg/daemon/README.md`, `docs/host-inbound-service-matrix.md`, `_Log.md`
+
+## 2026-08-26 — `_Log.md`: three duplicated entries from bad union merges, and the gate that sees them
+
+- **Timestamp**: 2026-08-26
+- **Action**: Remove three duplicated entry bodies and add
+  `pkg/refactoraudit/log_duplicate_entry_test.go`.
+- **Why the marker sweep was not enough**: the #7614 sweep catches a conflict
+  that was never RESOLVED. It cannot catch one that was resolved WRONGLY, which
+  leaves no marker behind and is syntactically fine Markdown. Three were live:
+  - **#6797's whole body copied under the #6799 heading**, so the record of
+    #6799 read as a description of a different change while #6799's own body sat
+    below it looking like a continuation. Reported by the #6790 lane; I had
+    resolved the markers around it in #7614 without noticing the body itself was
+    wrong.
+  - a **doubled #5078 follow-ups entry** (byte-identical, twice).
+  - a **truncated copy of a #6865 gate-fold entry** (1533B) beside its full
+    version (21656B).
+- **Two predicates, because one cannot see the other**: exact equality catches a
+  whole entry copied twice; PREFIX CONTAINMENT catches the shape a bad union
+  merge actually produces, where both sides end up concatenated under ONE
+  heading so the survivor's body is the loser's body followed by its own. Those
+  nest rather than match. Equality alone found 1 of the 3; containment found all
+  3.
+- **The control had the assertion the wrong way round**, and fixing it was the
+  point: the "genuinely different" fixture was `body + suffix`, which IS
+  containment by construction — it asserted the gate stays QUIET on exactly the
+  shape it exists to catch. Replaced with a genuinely unrelated body.
+- **Verified paired**: against the pre-fix `_Log.md` the gate reds naming all
+  three; against the fixed one it passes over 1946 entries.
+- **File(s)**: `_Log.md`, `pkg/refactoraudit/log_duplicate_entry_test.go` (new)

--- a/pkg/refactoraudit/log_duplicate_entry_test.go
+++ b/pkg/refactoraudit/log_duplicate_entry_test.go
@@ -1,0 +1,212 @@
+package refactoraudit
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// log_duplicate_entry_test.go — the gate the conflict-marker sweep could not be.
+//
+// The marker sweep (conflict_markers_test.go) catches a conflict that was never
+// resolved. It cannot catch a conflict that was resolved WRONGLY, which is the
+// other half of the same accident and leaves no marker behind.
+//
+// Two of those were live in `_Log.md` when this was written. A bad union merge
+// had copied the #6797 entry's whole body under the #6799 heading — so the
+// record of #6799 read as a description of a different change entirely, while
+// #6799's real body sat below it looking like a continuation — and an older
+// merge had doubled a #5078 entry outright. Nothing could see either: the file
+// is prose, and both are syntactically fine Markdown.
+//
+// The invariant: no two log entries may share a body. `_Log.md` is a
+// chronological record of distinct changes, so two entries with byte-identical
+// prose is a duplication accident every time — there is no legitimate reason to
+// write the same paragraph under two different dates or issue numbers.
+
+var logEntryHeading = regexp.MustCompile(`(?m)^## .*$`)
+
+// TestLogHasNoDuplicatedEntryBodies fails when two `## ` entries in _Log.md have
+// the same body.
+//
+// Bodies are compared with whitespace normalised, so a re-wrap does not hide a
+// duplicate. Only substantial entries are compared: the file contains short
+// stub entries and bare date dividers whose bodies legitimately coincide, and
+// flagging those would make the gate noise rather than signal.
+func TestLogHasNoDuplicatedEntryBodies(t *testing.T) {
+	root := repoRootForMarkerSweep(t)
+	raw, err := os.ReadFile(filepath.Join(root, "_Log.md"))
+	if err != nil {
+		t.Skipf("_Log.md unreadable (%v)", err)
+	}
+
+	entries := splitLogEntries(string(raw))
+	if len(entries) < 500 {
+		// _Log.md carries close to two thousand entries. A run that found almost
+		// none is a pass that proves nothing — the split broke, not the file.
+		t.Fatalf("only %d log entries were parsed; the split is not working", len(entries))
+	}
+
+	const minBody = 200 // bytes, normalised — skips stubs and date dividers
+	var subst []logEntry
+	for _, e := range entries {
+		if len(e.body) >= minBody {
+			subst = append(subst, e)
+		}
+	}
+
+	var findings []string
+
+	// (1) EXACT duplicates — a whole entry copied twice.
+	seen := map[string]string{}
+	for _, e := range subst {
+		if first, ok := seen[e.body]; ok {
+			findings = append(findings, "identical bodies: "+first+"\n         and: "+e.heading)
+			continue
+		}
+		seen[e.body] = e.heading
+	}
+
+	// (2) PREFIX containment — one entry's whole body is the START of another's.
+	//
+	// This is the shape a bad union merge actually produces, and (1) cannot see
+	// it. When a conflict is resolved by concatenating both sides under ONE
+	// heading, the survivor's body is the losing entry's body followed by its
+	// own, so the two are not identical — they nest. That is exactly how the
+	// #6797 entry came to be duplicated under the #6799 heading, and how a
+	// truncated copy of a #6865 entry sat beside its full version. Neither was
+	// visible to an equality check, and neither left a conflict marker behind.
+	//
+	// It cannot fire on honest prose: an entry whose body begins with another
+	// entry's ENTIRE body, verbatim and normalised, is a copy.
+	for i, a := range subst {
+		for j, b := range subst {
+			if i == j || len(b.body) <= len(a.body) || !strings.HasPrefix(b.body, a.body) {
+				continue
+			}
+			findings = append(findings,
+				"body of "+a.heading+"\n      is a PREFIX of: "+b.heading)
+		}
+	}
+
+	if len(findings) > 0 {
+		t.Fatalf("%d duplicated entry body/bodies in _Log.md — a conflict resolved "+
+			"WRONGLY leaves no marker behind, so this is the only thing that sees "+
+			"it:\n  - %s", len(findings), strings.Join(findings, "\n  - "))
+	}
+	t.Logf("%d log entries, %d with a substantial body, no exact duplicates and "+
+		"no prefix containment", len(entries), len(subst))
+}
+
+// TestLogDuplicateDetectorFindsADuplicate is the sensitivity control.
+//
+// Without it, the gate passing means either "the log is clean" or "the splitter
+// returns one entry and the comparison never runs" — the same green. This drives
+// the real splitter and the real comparison over a synthetic log built to
+// contain exactly one duplicated body, and over one that differs only in
+// wrapping (which must still be caught) and one whose entries genuinely differ
+// (which must not be).
+func TestLogDuplicateDetectorFindsADuplicate(t *testing.T) {
+	body := strings.Repeat("some long entry body text that exceeds the floor. ", 6)
+
+	dup := func(entries ...string) int {
+		seen, n := map[string]bool{}, 0
+		for _, e := range splitLogEntries(strings.Join(entries, "")) {
+			if len(e.body) < 200 {
+				continue
+			}
+			if seen[e.body] {
+				n++
+			}
+			seen[e.body] = true
+		}
+		return n
+	}
+
+	a := "## 2026-01-01 — entry A\n\n" + body + "\n"
+	b := "## 2026-01-02 — entry B\n\n" + body + "\n"
+	// Same prose, re-wrapped: normalisation must still see it as a duplicate,
+	// or a reflow would launder one past the gate.
+	bWrapped := "## 2026-01-02 — entry B\n\n" + strings.ReplaceAll(body, ". ", ".\n  ") + "\n"
+	c := "## 2026-01-03 — entry C\n\n" + body + "and this one is different.\n"
+
+	if got := dup(a, b); got != 1 {
+		t.Errorf("identical bodies: detector found %d duplicates, want 1", got)
+	}
+	if got := dup(a, bWrapped); got != 1 {
+		t.Errorf("re-wrapped body: detector found %d duplicates, want 1 — a reflow "+
+			"must not launder a duplicate past the gate", got)
+	}
+	if got := dup(a, c); got != 0 {
+		t.Errorf("genuinely different bodies: detector found %d duplicates, want 0 — "+
+			"the gate would fire on every honest entry", got)
+	}
+	// A short stub body must be ignored, or bare date dividers make the gate noise.
+	stub := "## 2026-01-04 — s\n\ntiny\n"
+	if got := dup(stub, stub); got != 0 {
+		t.Errorf("short stubs: detector found %d duplicates, want 0", got)
+	}
+
+	// The CONTAINMENT half, which the equality check above cannot see. This is
+	// the shape a bad union merge produces and the shape that was actually live
+	// in _Log.md: one entry's whole body concatenated in front of another's.
+	contained := func(entries ...string) int {
+		var subst []logEntry
+		for _, e := range splitLogEntries(strings.Join(entries, "")) {
+			if len(e.body) >= 200 {
+				subst = append(subst, e)
+			}
+		}
+		n := 0
+		for i, a := range subst {
+			for j, b := range subst {
+				if i != j && len(b.body) > len(a.body) && strings.HasPrefix(b.body, a.body) {
+					n++
+				}
+			}
+		}
+		return n
+	}
+	// #6797's body glued in front of #6799's own — nests, is not identical.
+	glued := "## 2026-01-05 — entry D\n\n" + body + " plus this entry's own distinct prose.\n"
+	if got := dup(a, glued); got != 0 {
+		t.Errorf("the equality check reported %d on a GLUED body; it cannot see "+
+			"containment, and claiming otherwise would overstate the gate", got)
+	}
+	if got := contained(a, glued); got != 1 {
+		t.Errorf("containment: detector found %d, want 1 — the bad-union shape "+
+			"would pass the gate", got)
+	}
+	// The negative must be a genuinely UNRELATED body, not an extension.
+	// `c` above is `body` plus a suffix, which IS containment by construction —
+	// using it here would have asserted the gate stays quiet on exactly the shape
+	// it is built to catch, and the assertion would have been the wrong way round.
+	unrelated := "## 2026-01-06 — entry E\n\n" +
+		strings.Repeat("an entirely separate change with its own prose. ", 6) + "\n"
+	if got := contained(a, unrelated); got != 0 {
+		t.Errorf("containment on genuinely unrelated bodies: found %d, want 0 — "+
+			"the gate would fire on every honest entry", got)
+	}
+}
+
+type logEntry struct{ heading, body string }
+
+// splitLogEntries cuts _Log.md at `## ` headings and returns each entry with its
+// body whitespace-normalised, so a re-wrap cannot hide a duplicate.
+func splitLogEntries(s string) []logEntry {
+	locs := logEntryHeading.FindAllStringIndex(s, -1)
+	out := make([]logEntry, 0, len(locs))
+	for i, loc := range locs {
+		end := len(s)
+		if i+1 < len(locs) {
+			end = locs[i+1][0]
+		}
+		out = append(out, logEntry{
+			heading: s[loc[0]:loc[1]],
+			body:    strings.Join(strings.Fields(s[loc[1]:end]), " "),
+		})
+	}
+	return out
+}


### PR DESCRIPTION
Closes #7608.

Follow-up to #7614, which resolved six committed conflict markers in `_Log.md`.
That fixed the markers. It did **not** fix the damage the markers were wrapped
around, and the #6790 lane caught that: **the #6799 entry's body was a verbatim
copy of #6797's**, so the log's record of #6799 read as a description of an
entirely different change, with #6799's own body sitting below it looking like a
continuation.

Auditing for the shape turned up **two more**:

| Defect | Shape |
|---|---|
| #6797's body copied under the **#6799** heading | concatenated — the survivor's body is the loser's body followed by its own |
| **#5078 follow-ups** entry present twice | byte-identical duplication |
| **#6865 gate fold** — a 1533 B truncated copy beside its 21656 B full version | prefix |

## Why the marker sweep could not see any of them

#7614's sweep catches a conflict that was never **resolved**. It cannot catch one
that was resolved **wrongly** — that leaves no marker behind and is syntactically
valid Markdown. This is the other half of the same accident.

## Two predicates, because neither sees the other

- **Exact equality** — a whole entry copied twice.
- **Prefix containment** — the shape a bad union merge actually produces. When
  both sides get concatenated under one heading, the survivor's body is the
  losing entry's body followed by its own, so the two **nest** rather than match.

Measured: equality alone finds **1 of the 3**. Containment finds **all 3**. I only
added containment after checking, rather than assuming one predicate covered the
class — the #6799 case is precisely the one equality misses.

Bodies are compared with whitespace normalised, so a re-wrap cannot launder a
duplicate, and only entries above a 200-byte normalised floor are compared —
the file has short stub entries and bare date dividers whose bodies legitimately
coincide, and flagging those would make the gate noise instead of signal.

## The control had its assertion the wrong way round

Worth reporting, because it is the failure the control existed to prevent. My
"genuinely different bodies must not match" fixture was `body + suffix` — which
**is** containment by construction. It asserted that the gate stays **quiet** on
exactly the shape the gate exists to catch. It went red as soon as containment
was wired in, which is how I found it; replaced with a genuinely unrelated body.

## Deletion safety

Every removal is guarded so it can only ever drop a verbatim copy:

- the #6799 case asserts the block under that heading is a **line-for-line match**
  of #6797's body before cutting, and afterwards asserts what remains is #6799's
  own entry (`- **Timestamp**` first, `reconcileRGState` present in the opening
  lines);
- the #5078 case asserts the two entries are byte-identical before dropping one;
- the #6865 case asserts the shorter is a strict prefix of the longer, and drops
  the shorter — so no unique prose can be lost.

## Validation

- **Paired proof on the real defects**: against the pre-fix `_Log.md` the gate
  **REDs naming all three**; against the fixed file it passes over **1946 entries**.
- `go build ./...` **rc=0**, `go test -count=1 ./...` repo-wide **rc=0** at HEAD
  `31d20d1acda8daf7645c07297c7f62dde356c60e`.
- Rust files touched: **0**. No production code changes at all — `_Log.md` plus
  one new test file. No cluster smoke owed.

Reported independently by four lanes (#6790, #6798, #6800, #6801); #6790 was the
one that spotted the body substitution rather than just the markers.
