### PR TITLE
docs: step 8 measured the shaped iperf port against the line-rate bar (#7610)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -105181,3 +105181,37 @@ prose edit above them added. No diff falls in the new test body.
 - **Verified paired**: against the pre-fix `_Log.md` the gate reds naming all
   three; against the fixed one it passes over 1946 entries.
 - **File(s)**: `_Log.md`, `pkg/refactoraudit/log_duplicate_entry_test.go` (new)
+
+## 2026-08-26 — #7610: step 8 measured the 3 Gb/s shaped port against a 23 Gbit/s bar
+
+- **Timestamp**: 2026-08-26
+- **Action**: Point `docs/engineering-style.md` step 8's throughput row at port
+  5211, explain why the ports are not interchangeable, and add
+  `pkg/refactoraudit/step8_iperf_port_test.go` to bind the doc and the CoS
+  fixture to each other.
+- **Why**: the row instructed every lane to apply
+  `test/incus/cos-iperf-config.set` and then measure `iperf3 … -p 5203` against
+  `≥ 23 Gbit/s`. In that fixture THE PORT IS THE CLASS: `bandwidth-output`
+  term 3 maps 5203 → `iperf-3g` → `scheduler-3g`, `transmit-rate 3.0g exact`.
+  So the row said "shape this to 3 Gb/s, then fail the change if it does not
+  reach 23". A lane following it literally reads a correctly working shaper as
+  an 8x regression — measured on a healthy fw0: 5203 → 2.86 Gbit/s, 5211 → 23.1
+  Gbit/s.
+- **The "no regression vs previous run" clause made it worse, not better**:
+  every previous run of the same wrong port also reported ~3 Gbit/s, so the
+  false reading looked corroborated by history.
+- **The gate binds the AGREEMENT, not a literal.** Pinning the doc to "5211"
+  would encode which side I trust; a fixture renumber would then leave the test
+  green and the doc wrong again. The invariant is "the port step 8 names must
+  resolve, IN THE FIXTURE, to a class with no explicit transmit-rate", which
+  survives a renumber. The row is located by CONTENT (an iperf3 check against
+  the documented target) and the gate refuses to guess if there is not exactly
+  one.
+- **Verified paired**: against the pre-fix doc the gate REDs naming
+  `iperf-3g`/`scheduler-3g`/`3.0g`; against the fixed doc it resolves 5211 to
+  `iperf-uncapped` with no rate and passes. A sensitivity control drives the
+  real parsers over a synthetic fixture in both directions.
+- **Found by**: the #6790 lane, which measured both ports back-to-back on a
+  real box rather than trusting the doc.
+- **File(s)**: `docs/engineering-style.md`,
+  `pkg/refactoraudit/step8_iperf_port_test.go` (new), `_Log.md`

--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -96,9 +96,26 @@ the mechanics, so this section is sequencing only.
    | What changed | Deploy | Validation | Pass criteria |
    |---|---|---|---|
    | Any change | `make test-deploy` (standalone) | ping between zones | 0% loss |
-   | Any change | `make cluster-deploy` (loss userspace cluster) + re-apply CoS (`./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0` — deploy wipes CoS) | `iperf3 -P 16 -t 30 -p 5203` → 172.16.80.200 | ≥ 23 Gbit/s, no regression vs previous run |
+   | Any change | `make cluster-deploy` (loss userspace cluster) + re-apply CoS (`./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0` — deploy wipes CoS) | `iperf3 -P 16 -t 30 -p 5211` → 172.16.80.200 | ≥ 23 Gbit/s, no regression vs previous run |
    | Admission / DSCP / scheduler / queueing | above + re-apply CoS (`./test/incus/apply-cos-config.sh <target>`) | `show class-of-service interface` | targeted counter (`flow_share`, `buffer`, `ecn_marked`) moves in the predicted direction — see [`cos-validation-notes.md`](cos-validation-notes.md) |
    | NAT / screens / filter / VLAN / IPsec | above | exercise that feature end-to-end from a test host | session / hit counters advance; negative case drops |
+
+   **Use 5211, not 5203, for the throughput row — and the two are not
+   interchangeable (#7610).** The same row tells you to apply
+   `test/incus/cos-iperf-config.set` first, and in that fixture the port IS the
+   class: `bandwidth-output` term 3 maps **5203 → `iperf-3g` → `scheduler-3g`,
+   `transmit-rate 3.0g exact`**, while term 11 maps **5211 → `iperf-uncapped`**.
+   Measured back-to-back on a healthy fw0: **5203 → 2.86 Gbit/s, 5211 → 23.1
+   Gbit/s**. This row asked for 5203 against a ≥ 23 Gbit/s bar until #7610, so a
+   lane following it literally read a *correctly working shaper* as an 8x
+   throughput regression — and the criterion "no regression vs previous run" made
+   that reading look confirmed, because every previous run of the same wrong port
+   reported the same ~3 Gbit/s. Ports 5200-5211 each select a different
+   forwarding class; check `cos-iperf-config.set` before substituting one.
+
+   5203 is the right port when you are validating the **shaper** rather than the
+   dataplane: there the pass criterion is ≈ 3 Gbit/s, and a result near 23 means
+   the shaper is NOT engaging.
    | HA / VRRP / session sync / fabric | `make cluster-deploy` | `make test-failover` + `make test-ha-crash` | 0 / very low packet loss across failover/failback, both nodes converge |
 
    When a validation lane can't be run in the test env, say so

--- a/pkg/refactoraudit/step8_iperf_port_test.go
+++ b/pkg/refactoraudit/step8_iperf_port_test.go
@@ -1,0 +1,183 @@
+package refactoraudit
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// step8_iperf_port_test.go — #7610.
+//
+// `docs/engineering-style.md` step 8 tells every lane to apply
+// `test/incus/cos-iperf-config.set` and then measure throughput on a specific
+// port against a ≥ 23 Gbit/s bar. In that fixture THE PORT IS THE CLASS: the
+// `bandwidth-output` filter maps each of 5200-5211 to a different
+// forwarding-class, and several of those classes are shaped.
+//
+// The doc named 5203, which maps to `iperf-3g` → `scheduler-3g`,
+// `transmit-rate 3.0g exact`. So the instruction was "shape this traffic to
+// 3 Gb/s, then fail the change if it does not reach 23" — a lane following it
+// literally reads a correctly working shaper as an 8x regression. The
+// "no regression vs previous run" clause made it worse, not better: every
+// previous run of the same wrong port also reported ~3 Gbit/s, so the reading
+// looked corroborated.
+//
+// This gate binds the AGREEMENT between the two files rather than pinning
+// either to a literal. Pinning the doc to "5211" would encode which side I
+// trust; if someone renumbers the fixture, a literal-pinned test keeps passing
+// while the doc goes wrong again. The invariant is "the port step 8 names must
+// resolve, IN THE FIXTURE, to an unshaped class" — which stays true under a
+// renumber.
+
+var (
+	step8PortRe = regexp.MustCompile(`iperf3 [^|]*-p (\d{4})`)
+	// `... term N from destination-port PPPP`
+	cosTermPortRe = regexp.MustCompile(`(?m)^set firewall family inet filter bandwidth-output term (\d+) from destination-port (\d{4})\s*$`)
+	// `... term N then forwarding-class CLASS`
+	cosTermClassRe = regexp.MustCompile(`(?m)^set firewall family inet filter bandwidth-output term (\d+) then forwarding-class (\S+)\s*$`)
+	// `set class-of-service schedulers SCHED transmit-rate RATE`
+	schedRateRe = regexp.MustCompile(`(?m)^set class-of-service schedulers (\S+) transmit-rate (\S+)\s*$`)
+	// `set class-of-service scheduler-maps MAP forwarding-class FC scheduler SCHED`
+	schedMapRe = regexp.MustCompile(`(?m)^set class-of-service scheduler-maps \S+ forwarding-class (\S+) scheduler (\S+)\s*$`)
+)
+
+// TestStep8ThroughputPortIsUnshaped asserts that the port
+// docs/engineering-style.md's step-8 throughput row names resolves, in
+// test/incus/cos-iperf-config.set, to a forwarding class with no explicit
+// transmit-rate cap.
+func TestStep8ThroughputPortIsUnshaped(t *testing.T) {
+	root := repoRootForMarkerSweep(t)
+	doc := readRepoFile(t, root, "docs/engineering-style.md")
+	cos := readRepoFile(t, root, "test/incus/cos-iperf-config.set")
+
+	row := step8ThroughputRow(t, doc)
+	m := step8PortRe.FindStringSubmatch(row)
+	if m == nil {
+		t.Fatalf("could not find an `iperf3 … -p <port>` in step 8's throughput "+
+			"row; the gate cannot check what it cannot parse:\n  %s", row)
+	}
+	port := m[1]
+
+	class, sched, rate := cosClassForPort(t, cos, port)
+	t.Logf("step 8 measures port %s → forwarding-class %q (scheduler %q, transmit-rate %q)",
+		port, class, sched, rate)
+
+	if rate != "" {
+		t.Fatalf("step 8's throughput row measures port %s, which the CoS fixture "+
+			"maps to forwarding-class %q → scheduler %q with `transmit-rate %s` — "+
+			"a SHAPED class. The row's pass criterion is an unshaped-line-rate "+
+			"number, so a healthy box reads as a large regression and the shaper "+
+			"working correctly is what fails the gate (#7610). Point the row at an "+
+			"unshaped class, or change its criterion to the shaped rate.",
+			port, class, sched, rate)
+	}
+}
+
+// TestStep8IperfPortGateDetectsAShapedPort is the sensitivity control.
+//
+// Without it, the gate passing means either "the doc names an unshaped port" or
+// "the parse returned nothing and the comparison never ran" — the same green.
+// It drives the real parsers over a synthetic doc row naming a port the
+// synthetic fixture shapes, and requires the shaped rate to come back.
+func TestStep8IperfPortGateDetectsAShapedPort(t *testing.T) {
+	cos := strings.Join([]string{
+		"set class-of-service schedulers sched-slow transmit-rate 3.0g",
+		"set class-of-service schedulers sched-slow transmit-rate exact",
+		"set class-of-service scheduler-maps m forwarding-class fc-slow scheduler sched-slow",
+		"set class-of-service scheduler-maps m forwarding-class fc-open scheduler sched-open",
+		"set firewall family inet filter bandwidth-output term 3 from destination-port 5203",
+		"set firewall family inet filter bandwidth-output term 3 then forwarding-class fc-slow",
+		"set firewall family inet filter bandwidth-output term 11 from destination-port 5211",
+		"set firewall family inet filter bandwidth-output term 11 then forwarding-class fc-open",
+	}, "\n") + "\n"
+
+	if _, _, rate := cosClassForPort(t, cos, "5203"); rate != "3.0g" {
+		t.Errorf("a SHAPED port resolved to transmit-rate %q, want \"3.0g\" — the "+
+			"gate would pass over the exact defect it exists to catch", rate)
+	}
+	if _, _, rate := cosClassForPort(t, cos, "5211"); rate != "" {
+		t.Errorf("an UNSHAPED port resolved to transmit-rate %q, want empty — the "+
+			"gate would fire on a correct doc", rate)
+	}
+
+	// And the row extractor must pick the throughput row's port, not some other
+	// `-p` elsewhere in a long document.
+	doc := "| x | y | `iperf3 -P 16 -t 30 -p 5211` → 172.16.80.200 | ≥ 23 Gbit/s |\n"
+	if m := step8PortRe.FindStringSubmatch(doc); m == nil || m[1] != "5211" {
+		t.Errorf("port extractor returned %v, want 5211", m)
+	}
+}
+
+// step8ThroughputRow returns the step-8 table row that carries the iperf3
+// throughput check. It is located by CONTENT (an iperf3 invocation against the
+// documented target) rather than by line number, so an edit above it does not
+// silently make the gate inspect the wrong row.
+func step8ThroughputRow(t *testing.T, doc string) string {
+	t.Helper()
+	var hits []string
+	for _, line := range strings.Split(doc, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "|") &&
+			strings.Contains(line, "iperf3") && strings.Contains(line, "172.16.80.200") {
+			hits = append(hits, line)
+		}
+	}
+	if len(hits) != 1 {
+		t.Fatalf("expected exactly ONE step-8 table row with an iperf3 check against "+
+			"172.16.80.200, found %d; the gate must not guess which one it means",
+			len(hits))
+	}
+	return hits[0]
+}
+
+// cosClassForPort resolves a destination port through the CoS fixture to its
+// forwarding class, that class's scheduler, and that scheduler's explicit
+// transmit-rate ("" when the class is unshaped).
+func cosClassForPort(t *testing.T, cos, port string) (class, sched, rate string) {
+	t.Helper()
+	term := ""
+	for _, m := range cosTermPortRe.FindAllStringSubmatch(cos, -1) {
+		if m[2] == port {
+			term = m[1]
+			break
+		}
+	}
+	if term == "" {
+		t.Fatalf("port %s is not mapped by any bandwidth-output term in the CoS "+
+			"fixture; the doc names a port the fixture does not classify", port)
+	}
+	for _, m := range cosTermClassRe.FindAllStringSubmatch(cos, -1) {
+		if m[1] == term {
+			class = m[2]
+			break
+		}
+	}
+	if class == "" {
+		t.Fatalf("bandwidth-output term %s matches port %s but assigns no "+
+			"forwarding-class", term, port)
+	}
+	for _, m := range schedMapRe.FindAllStringSubmatch(cos, -1) {
+		if m[1] == class {
+			sched = m[2]
+			break
+		}
+	}
+	for _, m := range schedRateRe.FindAllStringSubmatch(cos, -1) {
+		// `transmit-rate exact` is a modifier on the rate above it, not a rate.
+		if m[1] == sched && m[2] != "exact" {
+			rate = m[2]
+			break
+		}
+	}
+	return class, sched, rate
+}
+
+func readRepoFile(t *testing.T, root, rel string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(root, rel))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
Closes #7610.

`docs/engineering-style.md` step 8 told **every lane** to apply
`test/incus/cos-iperf-config.set` and then measure:

> `iperf3 -P 16 -t 30 -p 5203` → 172.16.80.200 | **≥ 23 Gbit/s**, no regression vs previous run

In that fixture **the port IS the class**. `bandwidth-output` term 3 maps
**5203 → `iperf-3g` → `scheduler-3g`, `transmit-rate 3.0g exact`**; term 11 maps
**5211 → `iperf-uncapped`**.

So the row said: *shape this traffic to 3 Gb/s, then fail the change if it does
not reach 23.* A lane following it literally reads a **correctly working shaper**
as an 8x throughput regression. Measured back-to-back on a healthy fw0:

| port | class | scheduler | measured |
|---|---|---|---|
| 5203 | `iperf-3g` | `scheduler-3g` (`transmit-rate 3.0g exact`) | **2.86 Gbit/s** |
| 5211 | `iperf-uncapped` | `scheduler-uncapped` | **23.1 Gbit/s** |

**The "no regression vs previous run" clause made this worse, not better.** Every
previous run of the same wrong port also reported ~3 Gbit/s, so the false reading
looked *corroborated by history*. That is the shape of the defect worth naming:
the criterion designed to catch drift was instead confirming a fixed error.

The row was also self-contradicting: it instructs you to apply the CoS fixture in
the same cell where it then measures against an un-shaped bar.

## The fix

Point the row at **5211**, and add a note that the ports are not interchangeable,
that 5200-5211 each select a different forwarding class, and that **5203 is the
right port when validating the shaper itself** — where a result near 23 means the
shaper is *not* engaging.

## The gate binds the AGREEMENT, not a literal

`pkg/refactoraudit/step8_iperf_port_test.go` resolves the port step 8 names
*through the fixture* and fails if it lands on a class with an explicit
`transmit-rate`.

Pinning the doc to `"5211"` would have encoded **which side I trust**. If someone
renumbers `cos-iperf-config.set`, a literal-pinned test stays green while the doc
goes wrong again — the same defect, re-armed. The invariant asserted instead is
*"the port step 8 names must resolve, in the fixture, to an unshaped class"*,
which survives a renumber.

Two things it refuses to guess at:

- The row is located **by content** (a table row with an iperf3 check against the
  documented target), not by line number, so an edit above it cannot silently
  make the gate inspect a different row — and it `Fatal`s if there is not
  **exactly one**.
- `transmit-rate exact` is a modifier on the rate above it, not a rate, so it is
  excluded rather than being read as a shaping value.

## Validation

- **Paired proof on the real defect**: against the pre-fix doc the gate **REDs**,
  naming `iperf-3g` / `scheduler-3g` / `3.0g`; against the fixed doc it resolves
  5211 → `iperf-uncapped` with no rate and passes.
- A sensitivity control drives the **real parsers** over a synthetic fixture in
  both directions — a shaped port must come back with its rate, an unshaped one
  must come back empty — so a green cannot mean "the parse returned nothing".
- `go build ./...` **rc=0**, `go test -count=1 ./...` repo-wide **rc=0** at HEAD
  `9f436eb814ff7a3e082ef57de6a0a586b3245868`.
- Rust touched: **0**. Doc + one new test; no production code, no smoke owed.

Found by the lane driving #6790, which measured both ports on a real box rather
than trusting the doc.
