### PR TITLE
dataplane: read Created at the offset the ABI actually puts it at (#6816)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -105318,3 +105318,39 @@ prose edit above them added. No diff falls in the new test body.
   real box rather than trusting the doc.
 - **File(s)**: `docs/engineering-style.md`,
   `pkg/refactoraudit/step8_iperf_port_test.go` (new), `_Log.md`
+
+## 2026-08-26 — #6816: the ctrl-enable cleanup read a session ID as a timestamp
+
+- **Timestamp**: 2026-08-26
+- **Action**: Derive the session-value `Created` offset from the ABI struct and
+  fix the initial-control cleanup that had it wrong.
+- **Why**: `pkg/dataplane/userspace/helper_status_apply.go` decoded `Created`
+  from bytes `[16:24]` of the raw BPF map value, justified by an in-comment sum
+  `State(1)+Flags(1)+TCPState(1)+IsReverse(1)+AppTimeout(4)+SessionID(8)=16`.
+  That sum is wrong twice over: `Flags` has been a `uint16` since #5460, and the
+  struct carries three explicit padding gaps (#6082) it omits entirely.
+  `SessionID` is at 16; `Created` is at 24. So on every ctrl enable the
+  keep-or-delete decision for synced sessions compared a SESSION ID against a
+  seconds-since-boot cutoff — a decision made on a number that is not a
+  timestamp, with no error and no log to show for it.
+- **The issue's cite had rotted**: it named `maps_sync.go:609`, which is now an
+  unrelated per-CPU stats loop. The code moved to `helper_status_apply.go` in
+  the #6429 split. Re-derived by searching for the decode itself rather than
+  trusting the line number.
+- **Fix shape — derive, do not re-type**: `SessionValueCreatedOffset` /
+  `SessionValueSessionIDOffset` are exported from `bpf_session_value.go` via
+  `unsafe.Offsetof`. The offset and the layout MUST agree, and a derived value
+  cannot disagree; a literal can, and this one did for as long as it took two ABI
+  changes to move the field out from under it.
+- **Test shape**: asserting `SessionValueCreatedOffset == 24` would be a
+  tautology against `unsafe.Offsetof` — it can only fail if the compiler is
+  wrong. The cells assert the DISCRIMINATOR instead: that Created and SessionID
+  are different offsets, that decoding at the exported offset returns the value
+  the struct stored (paired both ways, so two offsets both pointing at Created
+  cannot satisfy it), and that bytes `[16:24]` decode to the SESSION ID — which
+  records the defect's mechanism as an executable fact, and reds if a future
+  layout change makes the old narrative stale.
+- **File(s)**: `pkg/dataplane/bpf_session_value.go`,
+  `pkg/dataplane/userspace/helper_status_apply.go`,
+  `pkg/dataplane/session_value_offsets_6816_test.go` (new),
+  `pkg/dataplane/README.md`, `_Log.md`

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -331,6 +331,27 @@ Guard layers (`build-userspace-xdp.sh`):
    pin is still present, because the new map can only be pinned after the
    stale one is released.
 
+   **Never hand-compute a session-value byte offset (#6816).** The shared
+   conntrack value's Go mirror (`bpfSessionValue`, `bpf_session_value.go`)
+   carries THREE explicit padding gaps (#6082) and a `Flags` field that has
+   been a `uint16` since #5460. A consumer that decodes a field out of a raw
+   `[]byte` map read by adding up the field widths gets a number that is
+   wrong by however much padding it skipped — and it stays wrong silently,
+   because the read succeeds and returns a plausible integer.
+   `pkg/dataplane/userspace`'s initial-control cleanup did exactly that: it
+   read bytes `[16:24]` as `Created`, justified by an in-comment sum
+   `State(1)+Flags(1)+TCPState(1)+IsReverse(1)+AppTimeout(4)+SessionID(8)=16`.
+   `SessionID` is at 16 and `Created` at 24, so on every ctrl enable the
+   keep-or-delete decision for synced sessions was made by comparing a
+   SESSION ID against a seconds-since-boot cutoff.
+   `SessionValueCreatedOffset` / `SessionValueSessionIDOffset` are exported
+   from `bpf_session_value.go`, derived with `unsafe.Offsetof`, and are the
+   only supported way to reach those fields from a raw value. A derived
+   offset cannot disagree with the layout; a literal can, and this one did
+   for as long as it took two ABI changes to move the field out from under
+   it. Guarded by `session_value_offsets_6816_test.go`, which pins the
+   defect's mechanism as well as the fix.
+
    **Whether a restart releases the pin is MODE-DEPENDENT**, and this text
    has been wrong in both directions (#6928). It first said "a reload"
    releases it — nothing does. It then said restarting NEVER releases it and

--- a/pkg/dataplane/bpf_session_value.go
+++ b/pkg/dataplane/bpf_session_value.go
@@ -357,3 +357,28 @@ func (v bpfSessionValueV6) sessionValue() SessionValueV6 {
 		IngressVlanID:  v.IngressVlanID,
 	}
 }
+
+// SessionValueCreatedOffset / SessionValueSessionIDOffset are the on-map byte
+// offsets of `Created` and `SessionID` in the shared conntrack session value,
+// DERIVED from the struct rather than written down (#6816).
+//
+// They are exported because a consumer outside this package
+// (pkg/dataplane/userspace's initial-control cleanup) decodes those two fields
+// out of a raw []byte read straight from the BPF map, and it had the offset
+// WRONG: it read bytes [16:24] as `Created` on the strength of an in-comment sum
+//
+//	State(1) + Flags(1) + TCPState(1) + IsReverse(1) + AppTimeout(4) + SessionID(8) = 16
+//
+// which is wrong twice over. `Flags` is a uint16 since #5460, and the struct
+// carries three explicit padding gaps (#6082) that the sum omits entirely.
+// SessionID sits at 16 and Created at 24, so the cleanup was reading a session
+// ID and comparing it against a seconds-since-boot cutoff.
+//
+// Deriving them with unsafe.Offsetof is the point: the offset and the layout
+// MUST agree, and a derived value cannot disagree. A literal can — and did, for
+// as long as it took two ABI changes to move the field out from under it. Any
+// future field insertion, padding change or type widen moves these with it.
+var (
+	SessionValueCreatedOffset   = int(unsafe.Offsetof(bpfSessionValue{}.Created))
+	SessionValueSessionIDOffset = int(unsafe.Offsetof(bpfSessionValue{}.SessionID))
+)

--- a/pkg/dataplane/session_value_offsets_6816_test.go
+++ b/pkg/dataplane/session_value_offsets_6816_test.go
@@ -1,0 +1,132 @@
+package dataplane
+
+import (
+	"encoding/binary"
+	"testing"
+	"unsafe"
+)
+
+// session_value_offsets_6816_test.go — #6816.
+//
+// pkg/dataplane/userspace's initial-control cleanup decodes `Created` out of a
+// raw []byte read straight from the BPF map. It used the literal offset 16, on
+// the strength of an in-comment sum:
+//
+//	State(1) + Flags(1) + TCPState(1) + IsReverse(1) + AppTimeout(4) + SessionID(8) = 16
+//
+// wrong twice over. `Flags` has been a uint16 since #5460, and the struct
+// carries three explicit padding gaps (#6082) the sum omits entirely. SessionID
+// is at 16; Created is at 24. So the cleanup read a SESSION ID and compared it
+// against a seconds-since-boot cutoff — the keep-or-delete decision for synced
+// sessions on ctrl enable was made on a number that is not a timestamp.
+//
+// The fix derives the offsets with unsafe.Offsetof, so a literal cannot drift
+// from the layout again. These cells guard the two things that derivation does
+// NOT make automatic.
+
+// TestCreatedIsNotWhereTheOldLiteralSaid_6816 is the cell that reds on the
+// defect, and it is deliberately phrased as the DISCRIMINATOR rather than as a
+// restatement of the fix.
+//
+// Asserting `SessionValueCreatedOffset == 24` would be a tautology against
+// unsafe.Offsetof — it can only fail if the compiler is wrong. What actually
+// matters is that Created and SessionID are DIFFERENT fields at DIFFERENT
+// offsets and that the old literal named the wrong one. That claim is false the
+// moment someone reintroduces a hand-written 16, and it stays meaningful under
+// any future layout change.
+func TestCreatedIsNotWhereTheOldLiteralSaid_6816(t *testing.T) {
+	if SessionValueCreatedOffset == SessionValueSessionIDOffset {
+		t.Fatal("Created and SessionID resolve to the SAME offset; the whole " +
+			"premise of #6816 (that the cleanup read one as the other) cannot be " +
+			"tested and something is badly wrong with the struct")
+	}
+	if SessionValueSessionIDOffset != 16 {
+		t.Errorf("SessionID is at %d, not 16 — the ABI moved. That is allowed, but "+
+			"the #6816 narrative (the old literal 16 pointed at SessionID) is now "+
+			"stale and the docs referencing it need updating",
+			SessionValueSessionIDOffset)
+	}
+	if SessionValueCreatedOffset == 16 {
+		t.Fatal("Created is at 16, which is where the pre-#6816 literal read it " +
+			"from — either the padding was removed or someone widened a field back; " +
+			"re-check pkg/dataplane/userspace/helper_status_apply.go")
+	}
+}
+
+// TestCreatedOffsetDecodesARealCreatedValue_6816 is the BEHAVIOURAL cell: it
+// builds a session value the way the kernel lays one out, decodes it the way the
+// cleanup does, and requires the timestamp back.
+//
+// This is what an offset assertion alone cannot give. The cleanup reads through
+// encoding/binary on a []byte, not through the struct, so the property that
+// matters is "decoding at the exported offset yields the value the struct
+// stored there" — which is exactly the step that was broken.
+//
+// FAIL-ON-REVERT: change the decode offset back to 16 (or to
+// SessionValueSessionIDOffset) and this reds with the session ID in the message.
+func TestCreatedOffsetDecodesARealCreatedValue_6816(t *testing.T) {
+	const (
+		wantCreated   uint64 = 1_700_000_042 // seconds since boot — a plausible timestamp
+		wantSessionID uint64 = 0xDEADBEEFCAFE
+	)
+	v := bpfSessionValue{Created: wantCreated, SessionID: wantSessionID}
+
+	// Serialise exactly as the kernel map value is laid out.
+	raw := unsafe.Slice((*byte)(unsafe.Pointer(&v)), unsafe.Sizeof(v))
+	buf := append([]byte(nil), raw...)
+
+	got := binary.NativeEndian.Uint64(
+		buf[SessionValueCreatedOffset : SessionValueCreatedOffset+8])
+	if got != wantCreated {
+		if got == wantSessionID {
+			t.Fatalf("decoding at SessionValueCreatedOffset (%d) returned the "+
+				"SESSION ID (%#x), not Created — this is #6816 exactly: the "+
+				"keep-or-delete decision for synced sessions is made on a number "+
+				"that is not a timestamp", SessionValueCreatedOffset, got)
+		}
+		t.Fatalf("decoding at SessionValueCreatedOffset (%d) returned %d, want %d",
+			SessionValueCreatedOffset, got, wantCreated)
+	}
+
+	// The paired half: the SessionID offset must decode the session ID. Without
+	// it, both exported offsets pointing at Created would satisfy the assertion
+	// above, and the "read one as the other" defect could reappear with the roles
+	// swapped.
+	gotID := binary.NativeEndian.Uint64(
+		buf[SessionValueSessionIDOffset : SessionValueSessionIDOffset+8])
+	if gotID != wantSessionID {
+		t.Fatalf("decoding at SessionValueSessionIDOffset (%d) returned %#x, want %#x",
+			SessionValueSessionIDOffset, gotID, wantSessionID)
+	}
+}
+
+// TestTheOldLiteralWouldHaveReadTheSessionID_6816 pins the defect itself, so the
+// bug's mechanism is recorded as an executable fact rather than as prose in a
+// commit message.
+//
+// It is not redundant with the cells above: they assert the fix is right, this
+// asserts the OLD code was wrong and names what it read instead. If a future
+// layout change ever made 16 the correct offset for Created, this cell reds and
+// forces the docs and the #6816 narrative to be revisited together, rather than
+// leaving a comment on master describing a defect that no longer exists.
+func TestTheOldLiteralWouldHaveReadTheSessionID_6816(t *testing.T) {
+	const (
+		created   uint64 = 1_700_000_042
+		sessionID uint64 = 0xDEADBEEFCAFE
+	)
+	v := bpfSessionValue{Created: created, SessionID: sessionID}
+	raw := unsafe.Slice((*byte)(unsafe.Pointer(&v)), unsafe.Sizeof(v))
+	buf := append([]byte(nil), raw...)
+
+	atOldLiteral := binary.NativeEndian.Uint64(buf[16:24])
+	if atOldLiteral != sessionID {
+		t.Fatalf("bytes [16:24] decode to %#x, want the session ID %#x — the "+
+			"#6816 defect narrative (and the comments citing it) assume the old "+
+			"literal 16 pointed at SessionID; if that is no longer true, update "+
+			"them together", atOldLiteral, sessionID)
+	}
+	if atOldLiteral == created {
+		t.Fatal("bytes [16:24] decode to Created, so the pre-#6816 code was " +
+			"correct and this fix has no subject")
+	}
+}

--- a/pkg/dataplane/userspace/helper_status_apply.go
+++ b/pkg/dataplane/userspace/helper_status_apply.go
@@ -354,11 +354,19 @@ func (m *Manager) flushStaleBPFStateOnCtrlEnableLocked() {
 	// the userspace helper's own session table (Rust SessionTable +
 	// shared_sessions) is authoritative.
 	//
-	// session_value layout: State[1]+Flags[1]+TCPState[1]+
-	// IsReverse[1]+AppTimeout[4]+SessionID[8]+Created[8].
-	// Created is at byte offset 16. The value is seconds since
-	// boot (bpf_ktime_get_coarse_ns / 1e9). ctrlDisabledAt is
-	// nanoseconds, so convert to seconds for comparison.
+	// #6816: the `Created` offset is DERIVED from the Go struct that mirrors the
+	// C ABI (dataplane.SessionValueCreatedOffset), not written down here.
+	//
+	// It used to be the literal 16, justified by an in-comment sum
+	// "State(1)+Flags(1)+TCPState(1)+IsReverse(1)+AppTimeout(4)+SessionID(8)=16"
+	// that was wrong twice over: `Flags` has been a uint16 since #5460, and the
+	// struct carries three explicit padding gaps (#6082) the sum omits. SessionID
+	// is at 16 and Created at 24 — so this read a SESSION ID and compared it
+	// against a seconds-since-boot cutoff, and the "keep synced sessions" branch
+	// decided on a number that is not a timestamp.
+	//
+	// The value is seconds since boot (bpf_ktime_get_coarse_ns / 1e9);
+	// ctrlDisabledAt is nanoseconds, so convert to seconds for comparison.
 	cutoffSec := m.ctrlDisabledAt / 1_000_000_000
 	for _, mapName := range []string{"sessions", "sessions_v6"} {
 		if ctMap := m.bpfShim.Map(mapName); ctMap != nil {
@@ -374,13 +382,13 @@ func (m *Manager) flushStaleBPFStateOnCtrlEnableLocked() {
 					break
 				}
 				copy(key, nextKey)
-				// Read session value to check Created timestamp.
-				// Created is at byte offset 16:
-				//   State(1) + Flags(1) + TCPState(1) + IsReverse(1)
-				//   + AppTimeout(4) + SessionID(8) = 16
+				// Read session value to check the Created timestamp, at the
+				// offset the ABI struct actually puts it at (#6816).
 				if cutoffSec > 0 {
-					if err := ctMap.Lookup(key, val); err == nil && len(val) >= 24 {
-						created := binary.NativeEndian.Uint64(val[16:24])
+					end := dataplane.SessionValueCreatedOffset + 8
+					if err := ctMap.Lookup(key, val); err == nil && len(val) >= end {
+						created := binary.NativeEndian.Uint64(
+							val[dataplane.SessionValueCreatedOffset:end])
 						if created > 0 && created <= cutoffSec {
 							kept++
 							continue // synced session — keep it

--- a/pkg/dataplane/userspace/session_offset_wiring_6816_test.go
+++ b/pkg/dataplane/userspace/session_offset_wiring_6816_test.go
@@ -1,0 +1,134 @@
+package userspace
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// session_offset_wiring_6816_test.go — #6816, the WIRING half.
+//
+// The offset cells live in pkg/dataplane and assert that
+// SessionValueCreatedOffset resolves to the right field. None of them can see
+// whether THIS package actually uses it — and that gap is not hypothetical: the
+// mutation matrix reverted this file's decode to the hand-written literal 16 and
+// the whole suite stayed GREEN. That revert is the entire defect restored.
+//
+// The property is textual by nature ("do not hand-write an ABI offset here"), so
+// it is asserted textually, on comment-stripped source. A source-scanning gate
+// that greps for a string its own doc comment contains is satisfied by the
+// comment, so the needles are assembled at runtime and comments are stripped.
+
+var lineComment6816 = regexp.MustCompile(`(?m)//.*$`)
+
+// rawSessionDecode6816 matches a 64-bit ABI field READ at a HAND-WRITTEN
+// numeric offset — `binary.…Uint64(val[16:24])` and friends. A read through the
+// exported constant does not match, because its index is an identifier rather
+// than a digit.
+//
+// It is deliberately narrower than "any slice at a numeric offset", which was
+// the first cut and which fired on `maps_sync.go`'s cpumap writes:
+//
+//	val := make([]byte, 8)
+//	binary.NativeEndian.PutUint32(val[0:4], 2048) // qsize
+//	binary.NativeEndian.PutUint32(val[4:8], 0)    // no attached program
+//
+// That is a LOCALLY-DEFINED two-field 8-byte struct with no padding, written on
+// the spot — the offsets cannot drift from a layout the same function declares
+// three lines up, and there is no exported constant to use instead. Flagging it
+// would have been a gate firing on correct code, which gets a gate suppressed
+// rather than obeyed. Exempting the FILE would have been worse: it would also
+// hide a real session-value decode landing there, and `maps_sync.go` is where
+// this defect used to live.
+//
+// So the predicate is the actual #6816 shape: a Uint64 read (the width every
+// padded ABI field in the session value uses) out of a byte slice at a literal
+// offset.
+var rawSessionDecode6816 = regexp.MustCompile(`Uint64\(\s*\w+\[\d+\s*:`)
+
+// A package-wide sweep for hand-written offsets was tried and DELIBERATELY
+// DROPPED. The predicate cannot tell a padded C-ABI decode from a local
+// wire-format decode without knowing the type, and this package legitimately
+// contains two of the latter:
+//
+//   - maps_sync.go writes a cpumap value — a locally-declared, unpadded
+//     two-field 8-byte struct — as `PutUint32(val[0:4], …)` / `val[4:8]`;
+//   - eventstream.go reads its own 16-byte frame header as
+//     `Uint64(hdr[8:16])`, with the matching writer a few functions away.
+//
+// Both are correct: the offsets cannot drift from a layout the same file
+// declares, and there is no exported constant to reach for. A gate that fires on
+// correct code gets suppressed rather than obeyed, and exempting those FILES
+// would be worse still — it would also hide a real session-value decode landing
+// in them, and maps_sync.go is where this very defect used to live.
+//
+// So the binding is scoped to the file that decodes a session value, which is
+// the one the mutation matrix showed was unbound.
+
+// TestCleanupDecodesThroughTheExportedOffset6816 binds the consumer to the
+// derived constant.
+//
+// FAIL-ON-REVERT: change the decode in helper_status_apply.go back to
+// `val[16:end]` and this reds — which is exactly the mutation that escaped
+// before this cell existed.
+func TestCleanupDecodesThroughTheExportedOffset6816(t *testing.T) {
+	const file = "helper_status_apply.go"
+	src := lineComment6816.ReplaceAllString(readUserspaceSource6816(t, file), "")
+
+	want := "dataplane.SessionValue" + "CreatedOffset"
+	if !strings.Contains(src, want) {
+		t.Fatalf("%s does not decode Created through %s; a hand-written offset "+
+			"silently reads the wrong field — the pre-#6816 code read a SESSION ID "+
+			"and compared it against a seconds-since-boot cutoff", file, want)
+	}
+	if m := rawSessionDecode6816.FindString(src); m != "" {
+		t.Errorf("%s still slices a session value at a hand-written numeric "+
+			"offset (%q). Field offsets in this ABI move: Flags widened in #5460 "+
+			"and three padding gaps were made explicit in #6082, and the literal "+
+			"that survived both is what #6816 fixed. Use the exported "+
+			"dataplane.SessionValue*Offset constants.", file, m)
+	}
+}
+
+// TestTheOffsetSweepMatchesAHandWrittenDecode6816 is the sensitivity control.
+//
+// Without it, both cells passing means either "no hand-written offsets" or "the
+// pattern matches nothing" — the same green.
+func TestTheOffsetSweepMatchesAHandWrittenDecode6816(t *testing.T) {
+	for _, bad := range []string{
+		"created := binary.NativeEndian.Uint64(val[16:24])",
+		"x := binary.NativeEndian.Uint64(value[24 : 24+8])",
+		"n := binary.NativeEndian.Uint64(raw[8:16])",
+	} {
+		if !rawSessionDecode6816.MatchString(bad) {
+			t.Errorf("the sweep does not match %q; it would pass over the exact "+
+				"shape #6816 fixed", bad)
+		}
+	}
+	for _, good := range []string{
+		"created := binary.NativeEndian.Uint64(val[dataplane.SessionValueCreatedOffset:end])",
+		"z := other[i:j]",
+		"w := someSlice[start:stop]",
+		// A locally-declared, unpadded struct written on the spot: the offsets
+		// cannot drift from a layout the same function declares, and there is no
+		// exported constant to reach for. This is maps_sync.go's cpumap write,
+		// and the first cut of this sweep flagged it.
+		"binary.NativeEndian.PutUint32(val[0:4], 2048)",
+		"binary.NativeEndian.PutUint32(val[4:8], 0)",
+	} {
+		if rawSessionDecode6816.MatchString(good) {
+			t.Errorf("the sweep matches %q; a decode through the exported constant "+
+				"(or an unrelated slice) must not be flagged", good)
+		}
+	}
+}
+
+func readUserspaceSource6816(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
Closes #6816.

## Still live, and the issue's cite had rotted

The issue names `maps_sync.go:609`. That line is now an unrelated per-CPU stats
loop — the code moved in the #6429 split. Found by searching for the **decode**
rather than trusting the line number; it lives at
`pkg/dataplane/userspace/helper_status_apply.go:383`, and it reproduces.

## The defect

The initial-control session cleanup decoded `Created` from bytes `[16:24]` of the
raw BPF map value, justified by an in-comment sum:

```
State(1) + Flags(1) + TCPState(1) + IsReverse(1) + AppTimeout(4) + SessionID(8) = 16
```

**Wrong twice over.** `Flags` has been a `uint16` since #5460, and the struct
carries **three explicit padding gaps** (#6082) the sum omits entirely:

| field | real offset |
|---|---|
| `State` u8 | 0 |
| *pad* | 1 |
| `Flags` u16 | 2 |
| `TCPState` u8 / `IsReverse` u8 | 4, 5 |
| *pad* | 6 |
| `AppTimeout` u32 | 8 |
| *pad* | 12 |
| **`SessionID` u64** | **16** |
| **`Created` u64** | **24** |

So on every ctrl enable, the keep-or-delete decision for synced sessions compared
a **session ID** against a seconds-since-boot cutoff. It produced no error and no
log, because the read succeeds and returns a plausible integer.

## The fix: derive, don't re-type

`SessionValueCreatedOffset` / `SessionValueSessionIDOffset` are exported from
`bpf_session_value.go` via `unsafe.Offsetof`, and the consumer decodes through
them. The offset and the layout **must** agree, and a derived value cannot
disagree. A literal can — and this one did, for as long as it took two ABI
changes to move the field out from under it.

## On the tests

Asserting `SessionValueCreatedOffset == 24` would be a **tautology** against
`unsafe.Offsetof` — it can only fail if the compiler is wrong. The cells assert
the discriminator instead:

- Created and SessionID are **different** offsets, and 16 is not Created's;
- decoding at the exported offset returns what the struct **stored** there —
  **paired both ways**, so two constants both pointing at Created cannot satisfy
  it;
- bytes `[16:24]` decode to the **session ID**, which records the defect's
  mechanism as an executable fact and reds if a future layout change makes that
  narrative stale, forcing the comments citing it to be revisited together.

## Mutation matrix

| # | Mutation | Result | Cell |
|---|---|---|---|
| M1 | exported Created offset points at `SessionID` (the shipped defect) | **RED** | `TestCreatedIsNotWhereTheOldLiteralSaid_6816` +1 |
| M2b | consumer reverts to the hand-written literal `16` | **RED** | `TestCleanupDecodesThroughTheExportedOffset6816` |
| M3 | exported SessionID offset points at `Created` (roles swapped) | **RED** | `TestCreatedIsNotWhereTheOldLiteralSaid_6816` +1 |

**M2 escaped on the first pass, and it is the one that mattered.** Every offset
cell lives in `pkg/dataplane` and asserts what the constants resolve to; none of
them can see whether the *consumer* uses them. Reverting the decode to the literal
`16` left the whole suite **green** — the entire defect restored, with every cell
still passing. That is the recurring "bind the wiring, not the function it calls"
failure, and it took a `pkg/dataplane/userspace` cell to close.

M4 (remove a padding gap so `16` becomes correct for Created) **anchor-missed**:
the padding line is textually identical in the v4 and v6 structs, so the harness
refused to apply an ambiguous edit rather than guessing. Reported rather than
counted; it was a control for the narrative-staleness direction, which
`TestTheOldLiteralWouldHaveReadTheSessionID_6816` already asserts directly.

## A sweep I wrote, measured, and deliberately DROPPED

I generalised the consumer binding to a package-wide "no hand-written session
offsets" sweep. It fired twice on **correct** code:

- `maps_sync.go` writing a cpumap value — a locally-declared, unpadded two-field
  8-byte struct — as `PutUint32(val[0:4], …)` / `val[4:8]`;
- `eventstream.go` reading its own 16-byte frame header as `Uint64(hdr[8:16])`,
  with the matching writer a few functions away.

Narrowing from "any slice at a numeric offset" to "a `Uint64` read at a numeric
offset" removed the first and not the second. The predicate simply cannot tell a
padded C-ABI decode from a local wire-format decode without knowing the type.

So I dropped it and kept the file-scoped binding. A gate that fires on correct
code gets **suppressed rather than obeyed**, and exempting those two files would
have been worse still — it would also hide a real session-value decode landing in
them, and `maps_sync.go` is where this very defect used to live. The reasoning is
recorded next to the cell so the next person does not re-derive it.

## Validation

- `go build ./...` **rc=0**, `go vet ./...` **rc=0**, `go test -count=1 ./...`
  repo-wide **rc=0**, `UNMERGED=0`, at HEAD
  `b7d312590e3c326d5997f4da8019492d7600c3a3` (merges current `origin/master`).
- Rust touched: **0** — no cargo leg owed.
- Docs updated in the same change: `pkg/dataplane/README.md` gains a
  "never hand-compute a session-value byte offset" rule in the ABI section.

## Smoke

Not owed by the change class. Worth naming what a real one would be, since
throughput cannot see this: the cleanup only runs on **ctrl enable**, and its
visible effect is the `kept_synced` vs `deleted` counts in the
`userspace: flushed stale BPF conntrack on ctrl enable` log line. Before this
fix `kept_synced` was decided by a session ID; after it, a standby that has
synced sessions and then re-enables ctrl should report a non-zero `kept_synced`
rather than flushing them all.
