### PR TITLE
pkg/daemon: correct two #6798 claims that #6790 falsified (#6798)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -105709,3 +105709,39 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/daemon/daemon_nft.go`, `pkg/daemon/daemon_nft_netlink.go`,
   `pkg/daemon/lo0_proto_icmp_failclosed_6806_test.go` (new),
   `pkg/nftables/README.md`, `pkg/daemon/README.md`, `_Log.md`
+
+## 2026-08-26 — #6798 follow-up: correct two claims #6790 falsified, now on master
+
+- **Timestamp**: 2026-08-26
+- **Action**: #7605 merged (`f8c1bb105`) at head `5705bdb99` while the re-derive
+  round was still in flight, so two corrections the re-derive found did NOT make
+  the merge and are live on master. This lands them.
+- **The escape**: this is the exact class being swept on master today — a
+  sentence true when written and false at merge — and it escaped INTO master
+  inside the #6798 change itself. The assertions were always correct; only the
+  prose explaining them rotted. Worth noting that re-deriving found it and the
+  merge race, not the analysis, is what let it through.
+- **(1) A now-false doc comment on the end-to-end cell.** It read: "on the normal
+  apply path every one of those returns is deliberately discarded ... The SINGLE
+  caller that CONSUMES them is the #5874/M35 daemon-stop cancel closeout." #6790
+  (#7604) made `applyTailReconciles` capture those returns, so there are TWO
+  consumers and both halves are false. Rewritten to name both, with an explicit
+  note that the sentence was falsified by #6790 — so the next reader sees the
+  dependency rather than re-deriving it.
+- **(2) An unqualified "is neither fatal class".** `exec.CommandContext` has TWO
+  deadline shapes: a context expiring BEFORE fork/exec makes `Start` return a
+  BARE `context.DeadlineExceeded`, which `applyErrSkipsPeerSync` cannot
+  distinguish from a #2926 daemon-stop abort and classes FATAL. Restated as
+  "neither class in these errors' ORDINARY failure shapes", with the
+  misclassified shape named and scoped: pre-existing and WIDER than #6798
+  (`nftApplyPayload` at 5s and the DNS `systemctl` calls already reach the same
+  classifier), reachable only with a short injected deadline under load and not
+  in production at 15s, tracked in #7618 and tripwired by
+  `TestACommandDeadlineIsMisclassifiedAsADaemonStopAbort6790`. What #6798 adds
+  cannot reach it: `os.ReadFile`/`os.ReadDir` yield EACCES/EIO/EISDIR/ENOTDIR,
+  never a context error.
+- **No production code changes** — comments and docs only. The 14/14 mutation
+  matrix measured at `b166d8229` (identical production files) stands; nothing in
+  this delta can move it.
+- **File(s)**: `pkg/daemon/login_inventory_read_failclosed_6798_test.go`,
+  `docs/system-login.md`, `_Log.md`

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -1786,15 +1786,31 @@ path (`syncAndApply`) the config stays **active and armed** and the failure is
 surfaced rather than swallowed. No `lenient*` option in
 `pkg/config/compiler_opts.go` is owed.
 
-One caveat, deliberately scoped: #7618 records that a **command** deadline (a
-short per-command context, e.g. `chpasswd` via `runCommandStdinTimeout`) is
-currently misclassified by that same classifier as a daemon-stop abort, and
-`TestACommandDeadlineIsMisclassifiedAsADaemonStopAbort6790` pins the current
-wrong behaviour. That does **not** extend to what #6798 adds: these errors
-originate in `os.ReadFile` / `os.ReadDir` and carry `EACCES`/`EIO`/`EISDIR`/
-`ENOTDIR`, never a `context.DeadlineExceeded`, so they cannot reach the
-misclassified branch. The credential reconcilers' *command* failures were
-already in that population before #6798.
+One caveat, and it must not be dropped when this paragraph is quoted: the
+"neither class" statement holds for these errors' **ordinary failure shapes**,
+not unconditionally. #7618 records that `exec.CommandContext` has **two**
+deadline shapes — if the context expires *before* fork/exec, `Start` returns a
+**bare `context.DeadlineExceeded`**, which `applyErrSkipsPeerSync` cannot
+distinguish from a #2926 daemon-stop abort and therefore classes FATAL, taking
+`syncAndApply`'s `return nil, applyErr` arm with `armedActive` false.
+
+That shape is **pre-existing and wider than #6798**: `runCommandStdinTimeout`
+(`pkg/daemon/exec_timeout.go`) builds a fresh `context.WithTimeout(
+context.Background(), externalCommandTimeout)` on the line immediately before
+`exec.CommandContext`, so reaching the bare-`ctx.Err()` arm needs the goroutine
+descheduled for the entire timeout between two adjacent statements — reachable
+in a loaded test with a short injected deadline, not in production at 15s. The
+same exposure already reaches the same classifier through `nftApplyPayload`
+(5s) and the DNS `systemctl` calls, which predate both #6790 and #6798. It is
+tripwired by `TestACommandDeadlineIsMisclassifiedAsADaemonStopAbort6790`, which
+asserts the CURRENT (wrong) classification so the fix must invert the test and
+that section together.
+
+What #6798 **adds** does not reach it at all: these errors originate in
+`os.ReadFile` / `os.ReadDir` and carry `EACCES`/`EIO`/`EISDIR`/`ENOTDIR`, never
+a `context.DeadlineExceeded`. The credential reconcilers' *command* failures
+(`chpasswd`) were already in that population before #6798 — this change neither
+widens nor narrows it.
 
 There is **no `show` surface** that renders credential-ownership state, so the
 #6534 "a fail-closed exclusion owes a show-surface annotation" rule does not

--- a/pkg/daemon/login_inventory_read_failclosed_6798_test.go
+++ b/pkg/daemon/login_inventory_read_failclosed_6798_test.go
@@ -547,13 +547,23 @@ func TestReconcileSudoersReportsUnreadableDir_6798(t *testing.T) {
 // state must retain debt and PREVENT A SUCCESSFUL CLOSEOUT".
 //
 // The nine cells above prove each reconciler RETURNS an error. That is only
-// half the property, because on the normal apply path every one of those
-// returns is deliberately discarded (`_ = d.reconcileAbsentLoginUsers(cfg)` in
-// applyTailReconciles — the #2926 next-boot convergence contract). The single
-// caller that CONSUMES them is the #5874/M35 daemon-stop cancel closeout, which
-// is precisely the moment next-boot convergence does NOT happen. If the error
-// did not reach it, the fix would report into a void at the one site that
-// matters.
+// half the property: a return is not a consequence until something consumes it.
+// There are TWO consumers, and this cell binds the second.
+//
+//   - The apply tail (`applyTailReconciles`, steps 11–13) captures these
+//     returns and joins them into the commit result. That is #6790's doing, not
+//     #6798's — before it, all five were `_ = d.<reconciler>(cfg)` on the #2926
+//     next-boot-convergence argument, and a commit over an unreadable inventory
+//     reported success.
+//   - The #5874/M35 daemon-stop cancel closeout collects them too, and that is
+//     the case where next-boot convergence does NOT happen, because the daemon
+//     is stopping and staying stopped. It is the site R58's invariant is
+//     literally about, and nothing else in this file reaches it.
+//
+// This comment previously said the returns went nowhere on the normal path and
+// that the closeout was the SINGLE consumer. Both were true when written and
+// were falsified by #6790 landing — recorded here because the sentence, not the
+// assertion, is what rots.
 //
 // Only "absent-login-users" is a real reconciler here; the other six owners are
 // clean no-ops, so a green cannot come from some unrelated owner failing — the
@@ -644,6 +654,17 @@ func TestHostAuthCloseoutSurfacesUnreadableInventory_6798(t *testing.T) {
 // applyErrSkipsPeerSync `return false` unconditionally would satisfy the main
 // assertion vacuously — and that mutation is precisely the one that WOULD
 // brick, by pushing a dataplane-disarming config to the standby.
+//
+// Scope, stated precisely rather than as a blanket "credential errors are never
+// fatal": what this pins is the ORDINARY failure shape of an inventory read.
+// #7618 records that exec.CommandContext returns a BARE
+// context.DeadlineExceeded when its context expires before fork/exec, which
+// this same classifier cannot tell from a #2926 daemon-stop abort. That shape
+// is pre-existing and wider than #6798 (nftApplyPayload at 5s and the DNS
+// systemctl calls already reach it), and it cannot arise from what #6798 adds:
+// os.ReadFile / os.ReadDir yield EACCES/EIO/EISDIR/ENOTDIR, never a context
+// error. So this cell deliberately asserts over the inventory-read class only,
+// and does NOT claim the reconcilers can never produce a misclassified error.
 //
 // FAIL-ON-REVERT: this cell reds if applyErrSkipsPeerSync is ever widened to
 // swallow a generic subsystem error (main assertion) or narrowed so a real


### PR DESCRIPTION
## Why this exists

#7605 merged (`f8c1bb105`) at head `5705bdb99` while its own re-derive pass was
still in flight. Two corrections that pass found did not make the merge, so they
are **live on master** right now.

Both are prose, not assertions. The mutation cells were correct when written and
are correct now — what rotted is the sentences explaining them. This is the exact
class being swept on master today ("true when written, false at merge"), and it
escaped *into* master inside the #6798 change itself.

**No production code changes.** Comments and documentation only.

## (1) A doc comment #6790 falsified

`TestHostAuthCloseoutSurfacesUnreadableInventory_6798`'s comment claimed the
reconcilers' returns:

> on the normal apply path every one of those returns is deliberately discarded
> (`_ = d.reconcileAbsentLoginUsers(cfg)` in applyTailReconciles …). The **SINGLE
> caller** that CONSUMES them is the #5874/M35 daemon-stop cancel closeout

#6790 (#7604) made `applyTailReconciles` capture those returns into its
`errors.Join`. There are now **two** consumers and both halves of that sentence
are false. Rewritten to name both, and to record explicitly that #6790 falsified
it — so the next reader sees the dependency rather than re-deriving it.

## (2) An unqualified "is neither fatal class"

`docs/system-login.md` stated flatly that an inventory-read failure "is neither"
class of `applyErrSkipsPeerSync`. That is **not true unconditionally**, and I
should not have propagated it in that form.

`exec.CommandContext` has **two** deadline shapes: a context that expires
*before* fork/exec makes `Start` return a **bare `context.DeadlineExceeded`**,
which the classifier cannot distinguish from a #2926 daemon-stop abort and
therefore classes FATAL — taking `syncAndApply`'s `return nil, applyErr` arm
with `armedActive` false.

The claim is now **scoped rather than dropped**:

- neither class in these errors' **ordinary failure shapes**, with the
  misclassified shape named;
- that shape is **pre-existing and wider than either PR** —
  `runCommandStdinTimeout` builds a fresh `context.WithTimeout` on the line
  immediately before `exec.CommandContext`, so reaching the bare-`ctx.Err()` arm
  needs the goroutine descheduled for the entire timeout between two adjacent
  statements (reachable in a loaded test with a short injected deadline, not in
  production at 15s), and `nftApplyPayload` (5s) plus the DNS `systemctl` calls
  already reach the same classifier;
- tracked in **#7618**, tripwired by
  `TestACommandDeadlineIsMisclassifiedAsADaemonStopAbort6790`, which asserts the
  CURRENT (wrong) classification so a fix must invert the test and the doc
  section together;
- **what #6798 adds cannot reach that branch at all**: these errors originate in
  `os.ReadFile` / `os.ReadDir` and carry `EACCES`/`EIO`/`EISDIR`/`ENOTDIR`, never
  a context error. The credential reconcilers' *command* failures were already in
  that population beforehand — #6798 neither widens nor narrows it.

The same scoping now appears in the composition test's comment, so the code
carries the qualification too and not just the doc.

## Test plan

- [x] `go build ./...` — rc=0
- [x] `go test -count=1 ./...` repo-wide — **rc=0**, 67 packages ok, 0 FAIL, at
      `49faa220e7c319259364a6d56b537472d85517db` (parent `origin/master`
      `0a396fb29`; `merge-base --is-ancestor` rc=0)
- [x] `gofmt -l` clean on both touched files
- [x] `_Log.md` four-check verification on the OUTPUT: 0 anchored markers; my
      entry present **exactly once**; all **1959** master `##` headings present;
      0 master lines short-counted; `theirs` is a prefix of the result
- [x] False-claim sweep over the working tree for "goes nowhere" / "SINGLE
      caller" / "deliberately discarded" — clean apart from the new sentence that
      explains the correction
- [x] Mutation matrix **not re-run, and not needed**: this delta touches no
      production line. The 14/14 result was measured over byte-identical
      `login_password.go` / `daemon_system.go`, and comments cannot move a cell.

## Refs

Follow-up to #7605 (#6798). Composition with #7604 (#6790). Scopes #7618.
