### PR TITLE
docs: a comment is a claim; an agreement test hides a shared defect

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -105663,3 +105663,35 @@ prose edit above them added. No diff falls in the new test body.
   output most needs to be readable, and a tripled list reads like three separate
   defects. Deduped by path.
 - **File(s)**: `pkg/refactoraudit/conflict_markers_test.go`, `_Log.md`
+
+## 2026-08-26 — engineering-style: a comment is a claim; an agreement test cannot see a shared defect
+
+- **Timestamp**: 2026-08-26
+- **Action**: Add three review-discipline rules to
+  `docs/engineering-style.md` ("Reviewing (adversarial by design)").
+- **Why now**: each rule is generalised from a defect that landed in ONE review
+  batch, not from principle.
+  1. **Three stale load-bearing comments**, all true when written and false at
+     head: `daemon_apply_tail.go`'s "every step below still RUNS (no early
+     return)"; `netlink_lo0.go`'s "a rejected table leaves NO host filter =
+     fail-OPEN" (true before #6476's cold-boot fence, false after — checking the
+     code rather than the comment is what unblocked #6806's correct direction);
+     and `daemon_nft.go`'s "mirroring the tcp-flags lowering", which was wrong
+     when written because tcp-flags does not drop its predicate. A comment that
+     justifies a DIRECTION is the dangerous kind: the reader takes the direction
+     and never re-derives the reason, which was verified once and never again.
+  2. **The #6806 lo0 parity gate was structurally blind.** Both mirrors dropped
+     an unresolvable token, so they AGREED perfectly while both were fail-open,
+     and the gate was green throughout. "Assert the agreement, never pin one to a
+     literal" is right for DRIFT — and drift is not the only defect. Each side
+     also owes a property independently.
+  3. **A tool-gated leg that SKIPs is a green that measured nothing** — report
+     tests-collected, not `ok`.
+- **Related, and the same shape at a larger scale**: #6807's review had DISPROVEN
+  the repo's FRR permit-all model while the repo's comments and tests still
+  asserted it, so a reader re-deriving from the title had a confidently wrong
+  prior with every local check agreeing. A stale comment and a refuted-but-still-
+  asserted consequence are one defect at two scales.
+- **Annotate stale comments as historical rather than deleting them** — the next
+  reader needs to know it WAS true, not merely that it is gone.
+- **File(s)**: `docs/engineering-style.md`, `_Log.md`

--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -425,6 +425,46 @@ Rules of thumb:
 - **Trust but verify.** An agent's commit summary describes what it
   intended. Read the diff. Re-run the tests on the updated head before
   approving.
+- **A comment is a CLAIM, not a check — verify it before you rely on
+  it.** A comment that justifies a direction ("we do X because Y") is
+  the most dangerous kind, because a reader takes the direction and
+  never re-derives Y. Y was verified once, at authorship, and never
+  again. Three landed in a single review batch, all true when written
+  and false at head:
+
+  - `daemon_apply_tail.go` asserted "every step below still RUNS (no
+    early return)". A lane whose teardown sits below it checked the
+    code rather than the comment, because if it *had* early-returned the
+    teardown would silently stop running on exactly the commits that
+    fail.
+  - `netlink_lo0.go` justified per-term fail-closed with "a rejected
+    table leaves NO host filter = fail-OPEN". True before #6476 added
+    the cold-boot fence; false after, which is what unblocked the
+    correct plan-failure direction in #6806.
+  - `daemon_nft.go` justified dropping a protocol predicate as
+    "mirroring the tcp-flags lowering" — and tcp-flags does not drop its
+    predicate. Wrong when written.
+
+  So: **when a comment is load-bearing for your change, read the code it
+  describes.** If it is stale, annotate it as historical rather than
+  deleting it — the next reader needs to know it *was* true, not merely
+  that it is gone. Note the failure mode this shares with a refuted
+  finding whose refutation never reached the code: in #6807 the review
+  had *disproven* the repo's FRR permit-all model, and the repo's own
+  comments and tests still asserted it — so a reader had not a neutral
+  prior but a confidently wrong one, with every local check agreeing.
+- **An agreement test cannot see a defect the two sides SHARE.** The
+  #6806 lo0 parity gate compares the netlink installer against the text
+  oracle. Both dropped an unresolvable token, so they agreed perfectly
+  while both were fail-open, and the gate was green the whole time. When
+  two implementations must match, "assert the agreement, never pin one
+  to a literal" is right for drift — but drift is not the only defect.
+  Add a cell asserting the PROPERTY each side owes independently (here:
+  neither mirror may lose the refusal evidence at its own boundary), or
+  the shared blind spot is invisible by construction.
+- **A tool-gated leg that SKIPs is a green that measured nothing.** Say
+  whether it ran. `nft`-dependent parity, cargo legs, cluster smoke:
+  report tests-collected, not just `ok`.
 - **Two independent review surfaces.** Codex (hostile, design-level)
   and Copilot (inline, mechanical-detail) catch different classes of
   bugs. Treat them as separate passes; do not skip either. Codex


### PR DESCRIPTION
Documentation only — `docs/engineering-style.md` plus a `_Log.md` entry.

Three review-discipline rules, each generalised from a defect that landed in
**one** review batch rather than from principle. All three came out of lanes
working #6790, #6801, #6806 and #6807 today.

## 1. A comment is a CLAIM, not a check

A comment that justifies a *direction* — "we do X because Y" — is the dangerous
kind: the reader takes the direction and never re-derives Y, which was verified
once at authorship and never again. Three landed together:

| comment | status |
|---|---|
| `daemon_apply_tail.go` — "every step below still RUNS (no early return)" | true, but only checked because a lane whose teardown sits below it read the code instead |
| `netlink_lo0.go` — "a rejected table leaves NO host filter = fail-OPEN" | **true when written, false after #6476** added the cold-boot fence; checking the code is what unblocked #6806's correct direction |
| `daemon_nft.go` — dropping a predicate as "mirroring the tcp-flags lowering" | **wrong when written** — tcp-flags does not drop its predicate |

So: when a comment is load-bearing for your change, read the code it describes.
And **annotate a stale comment as historical rather than deleting it** — the next
reader needs to know it *was* true, not merely that it is gone.

The rule also records the same failure at a larger scale: in #6807 the review had
**disproven** the repo's FRR permit-all model and the repo's own comments and
tests still asserted it. A lane re-deriving from the issue title therefore had not
a neutral prior but a **confidently wrong** one, with every local check agreeing.
A stale comment and a refuted-but-still-asserted consequence are one defect at two
scales.

## 2. An agreement test cannot see a defect the two sides SHARE

This is the one worth the PR on its own. The #6806 lo0 parity gate compares the
netlink installer against the text oracle. **Both dropped an unresolvable token**,
so they agreed perfectly while both were fail-open — the lo0 filter matched every
protocol in scope — and the gate was **green throughout**.

"Assert the agreement, never pin one side to a literal" is the right rule for
**drift**. Drift is not the only defect. Each side also owes a property
*independently* — here, that neither mirror may lose the refusal evidence at its
own boundary — or the shared blind spot is invisible by construction.

That is a refinement of the existing rule, not an application of it, and it came
from the lane that hit it rather than from me.

## 3. A tool-gated leg that SKIPs is a green that measured nothing

Say whether it ran. `nft`-dependent parity, cargo legs, cluster smoke: report
**tests-collected**, not `ok`.

## Placement and validation

All three go under "Review discipline → Reviewing (adversarial by design)",
next to the existing "Trust but verify" and "Test strength matters" bullets they
extend.

`go build ./...` **rc=0** and `go test -count=1 ./...` repo-wide **rc=0** at HEAD
`f19947de57adaabe1e4d9e7d03870423a9c51ad9` — run because `pkg/refactoraudit`
contains source-scanning gates that read docs, not because a prose change can
break a build. No Rust, no smoke owed.
