### PR TITLE
api: bound the BGP route stream against a connected non-reader (#6809)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,43 @@
+## 2026-08-26 — #6809: a connected non-reader no longer pins the BGP stream
+
+- **Timestamp**: 2026-08-26
+- **Action**: `/api/routing/bgp?type=routes` had bounds on PROGRESS only —
+  `maxBGPRoutes` caps bytes, `StreamBGPRoutes` caps memory, the #5232 check
+  aborts on DISCONNECT. None bound the handler while BLOCKED. A client that
+  stays connected and stops reading fills the socket buffers, `bw.Flush()`
+  parks in the kernel, the callback never returns, and the cancel/close/reap
+  that kills vtysh all sit AFTER the scan loop: handler goroutine, vtysh child,
+  pipe and connection pinned indefinitely. `WriteTimeout` is 0 process-wide for
+  SSE, so no global backstop either.
+  Added three bounds, deliberately not interchangeable: a per-write deadline
+  (the only thing that can unpin a goroutine already blocked in a write), an
+  elapsed backstop derived from `r.Context()` and handed to `StreamBGPRoutes`
+  so `exec.CommandContext` reaps vtysh, and a 2-slot non-blocking limiter so a
+  bounded stream cannot become an unbounded NUMBER of vtysh children.
+  MY FIRST FIX WAS WRONG AND THE TEST CAUGHT IT. I armed the deadline next to
+  the explicit 1024-route flushes; `bufio` auto-flushes when its 4 KiB buffer
+  fills, so ~17 real socket writes happen between two consecutive flush
+  boundaries and those block first. The slow-reader cell failed with the fix
+  in place. Restructured to a `deadlineArmingWriter` between `bufio` and the
+  `ResponseWriter`, which makes the coverage structural rather than a matter of
+  remembering every flush site — including the closing flush a sub-1024-route
+  table reaches without entering the periodic branch at all.
+  Corrected a false claim in `server.go` and `pkg/api/README.md`: "the response
+  side is bounded by per-handler context deadlines" does not hold as written —
+  a context deadline bounds a handler's WORK, not a write blocked in the
+  kernel. R70 flagged the same sentence.
+- **File(s)**: `pkg/api/routing.go`, `pkg/api/server.go`,
+  `pkg/api/bgp_slow_reader_pin_6809_test.go` (new), `pkg/api/README.md`,
+  `_Log.md`
+- **Validation**: the fixture models the hazard rather than approximating it —
+  a `net.Conn` that accepts a fixed prefix and then parks the writer until the
+  write deadline, forever if none is armed. Deterministic fail-on-revert, no
+  socket-buffer-size guessing. Includes a NEGATIVE CONTROL proving the fixture
+  can genuinely pin (deadlines unsupported + a distant backstop → the handler
+  must still be running), without which the passing cell proves nothing, and a
+  paired control proving a real reader still gets the whole table under tight
+  budgets.
+
 ## 2026-08-26 — #6790 r3: the timeout cell was reading the MACHINE, and found #7618
 
 - **Timestamp**: 2026-08-26

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -1111,8 +1111,15 @@ the drop fails loudly instead of going quietly vacuous.
   interface. `WriteTimeout` is deliberately left UNSET (0/unlimited): the SSE
   event/log streams (`/api/v1/events/stream`, `/api/v1/logs/stream`) are
   long-lived and a full metrics/session-table scrape is a large slow response —
-  a `WriteTimeout` would sever them; the response side is bounded by per-handler
-  context deadlines instead. Separately, every REST MUTATION handler decodes its
+  a `WriteTimeout` would sever them. **#6809 correction:** this used to add
+  "the response side is bounded by per-handler context deadlines instead",
+  which does not hold as written — a context deadline bounds a handler's WORK,
+  not a write already blocked in the kernel because the peer stopped reading.
+  Cancelling a context releases what the handler owns downstream (a child
+  process, a lock) while the goroutine stays parked in `Write`. Only
+  `http.ResponseController.SetWriteDeadline` ends that. A streaming endpoint
+  therefore has to arrange its own per-write deadline; see the BGP route stream
+  below. Separately, every REST MUTATION handler decodes its
   body through `decodeJSONBody`, which wraps `r.Body` in
   `http.MaxBytesReader(maxRequestBodyBytes)` (16 MiB) and returns **HTTP 413** on
   overflow instead of buffering a multi-gigabyte POST to an OOM-kill (config
@@ -1757,7 +1764,45 @@ the drop fails loudly instead of going quietly vacuous.
   the CLI for the complete table. Operators needing the full RIB use
   `show route protocol bgp`. The cap/truncation contract is pinned by
   `bgp_routes_cap_5056_test.go`; the streaming/non-buffering + wire-format
-  invariants by `bgp_routes_stream_4708_test.go`. The session
+  invariants by `bgp_routes_stream_4708_test.go`.
+
+  **A slow reader is a different hazard from a disconnected one (#6809).**
+  Every bound above is a bound on PROGRESS. A client that stays CONNECTED and
+  stops reading produces neither a disconnect nor a write error: the socket
+  buffers fill, `bw.Flush()` parks in the kernel, the stream callback never
+  returns, and the `cancel`/`Close`/reap that would kill vtysh all sit AFTER
+  the scan loop. Handler goroutine, vtysh child, pipe and connection stayed
+  pinned indefinitely. Three bounds now apply, and they are not
+  interchangeable:
+
+  - **`bgpStreamWriteDeadline` (30s, per write)** — the PROGRESS budget, and
+    the load-bearing one: it is the only thing that can unpin a goroutine
+    already blocked in a write. Armed by `deadlineArmingWriter`, which sits
+    between `bufio` and the `ResponseWriter` so *every* socket write is
+    covered. Arming at the handler's explicit flush points is not enough and
+    the regression cell catches it — `bufio` auto-flushes when its 4 KiB
+    buffer fills, so ~17 real writes happen between two consecutive 1024-route
+    flush boundaries, and those block first. Each write gets a FRESH window, so
+    a legitimately large table on a slow-but-progressing link still completes.
+  - **`bgpStreamTotalBudget` (10m, per request)** — the ELAPSED backstop,
+    derived from `r.Context()` and handed to `StreamBGPRoutes` so
+    `exec.CommandContext` kills and reaps vtysh. It catches a client that
+    dribbles just enough to reset the write window forever. On a
+    `ResponseWriter` that cannot carry a write deadline it frees the CHILD but
+    **not** this goroutine — a partial bound, stated as such.
+  - **`ribStreamLimiter` (2 concurrent)** — a bounded stream is still a vtysh
+    child, so an unbounded NUMBER of them still accumulates. Non-blocking
+    `Acquire`: over-cap requests get **429 + `Retry-After`** rather than
+    queueing, because a queued request holds the same connection it would hold
+    while streaming. Local to REST on purpose — the gRPC/CLI `show route
+    protocol bgp` paths call the BUFFERED `GetBGPRoutes`, which completes
+    before any client sees a byte and cannot be pinned by a reader, so there is
+    no second surface to share a budget with.
+
+  Pinned by `bgp_slow_reader_pin_6809_test.go`, whose fixture is a `net.Conn`
+  that accepts a fixed prefix and then parks the writer exactly as a full send
+  buffer does — including a negative-control cell proving the fixture can
+  genuinely pin, so the passing cell means something. The session
   handlers (`/sessions`, `/sessions/summary`, `/sessions/zone-pair`) share a
   per-batch sampler (`newRequestCancelSampler`, `sessionWalkCancelInterval`
   = 1024): each `IterateSessions`/`IterateSessionsV6` callback returns

--- a/pkg/api/bgp_slow_reader_pin_6809_test.go
+++ b/pkg/api/bgp_slow_reader_pin_6809_test.go
@@ -1,0 +1,353 @@
+package api
+
+// bgp_slow_reader_pin_6809_test.go — #6809.
+//
+// /api/routing/bgp?type=routes streams the RIB straight from a vtysh child to
+// the client. Every bound it had was a bound on PROGRESS — maxBGPRoutes caps
+// bytes, StreamBGPRoutes caps memory, the #5232 check aborts on DISCONNECT.
+// None of them bound the handler while it is BLOCKED.
+//
+// An authenticated client that opens the endpoint and then reads slowly, or
+// stops reading without disconnecting, fills the socket buffers; the periodic
+// bw.Flush() parks in the kernel; the callback never returns; the scan never
+// resumes; and the cancel/close/reap that would kill vtysh all sit AFTER the
+// scan loop. Handler goroutine, vtysh child, pipe and connection stay pinned
+// indefinitely. http.Server's WriteTimeout is deliberately 0 process-wide for
+// SSE, so there was no global backstop either.
+//
+// The fixture models the hazard rather than approximating it: a net.Conn that
+// accepts a fixed prefix of bytes and then behaves exactly as a real socket
+// with a full send buffer — it parks the writer until the write deadline
+// expires, and forever if none is set. That makes the fail-on-revert
+// DETERMINISTIC (no socket-buffer-size guessing, no sleeps calibrated against
+// a real slow client) and it is why the negative-control cell below can prove
+// the harness is genuinely capable of pinning.
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/diagcmd"
+)
+
+// --- a connection that stops accepting bytes, like a full send buffer -------
+
+type stalledConn6809 struct {
+	net.Conn
+	mu sync.Mutex
+	// budget is how many more bytes the "socket buffer" accepts before writes
+	// start blocking. The response header and the first chunk must get through
+	// or the test would be exercising a different (pre-stream) blocking point.
+	budget int
+	wdl    time.Time
+	// deadlineUnsupported models a ResponseWriter that cannot carry a write
+	// deadline: SetWriteDeadline fails, so nothing can interrupt a blocked
+	// write and only the elapsed backstop remains (which bounds the CHILD, not
+	// this goroutine — see the routing.go note).
+	deadlineUnsupported bool
+	closed              chan struct{}
+	closeOnce           sync.Once
+}
+
+func (c *stalledConn6809) SetWriteDeadline(t time.Time) error {
+	if c.deadlineUnsupported {
+		return http.ErrNotSupported
+	}
+	c.mu.Lock()
+	c.wdl = t
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *stalledConn6809) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	if c.budget > 0 {
+		c.budget -= len(p)
+		c.mu.Unlock()
+		return c.Conn.Write(p)
+	}
+	wdl := c.wdl
+	c.mu.Unlock()
+
+	// Buffers are "full". A real socket parks the writer here.
+	if wdl.IsZero() {
+		<-c.closed // no deadline armed: block until the test tears down
+		return 0, net.ErrClosed
+	}
+	t := time.NewTimer(time.Until(wdl))
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return 0, os.ErrDeadlineExceeded
+	case <-c.closed:
+		return 0, net.ErrClosed
+	}
+}
+
+func (c *stalledConn6809) Close() error {
+	c.closeOnce.Do(func() { close(c.closed) })
+	return c.Conn.Close()
+}
+
+// stalledListener6809 wraps every accepted conn so net/http writes the response
+// through it — which is also what routes http.ResponseController's
+// SetWriteDeadline into stalledConn6809 above.
+type stalledListener6809 struct {
+	net.Listener
+	budget              int
+	deadlineUnsupported bool
+	mu                  sync.Mutex
+	conns               []*stalledConn6809
+}
+
+func (l *stalledListener6809) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	sc := &stalledConn6809{
+		Conn:                c,
+		budget:              l.budget,
+		deadlineUnsupported: l.deadlineUnsupported,
+		closed:              make(chan struct{}),
+	}
+	l.mu.Lock()
+	l.conns = append(l.conns, sc)
+	l.mu.Unlock()
+	return sc, nil
+}
+
+func (l *stalledListener6809) releaseAll() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, c := range l.conns {
+		c.closeOnce.Do(func() { close(c.closed) })
+	}
+}
+
+// bigBGPTable6809 renders enough routes that the stream enters the periodic
+// 1024-route flush branch many times over.
+func bigBGPTable6809(n int) string {
+	rows := make([][3]string, n)
+	for i := range rows {
+		rows[i] = [3]string{
+			fmt.Sprintf("10.%d.%d.0/24", i/256%256, i%256),
+			"192.0.2.1",
+			"65001 i",
+		}
+	}
+	return makeFRRBGPOutput(rows)
+}
+
+// startStalledBGPServer6809 serves bgpHandler over a listener whose conns stop
+// accepting bytes after budget, and reports when the handler returns.
+func startStalledBGPServer6809(t *testing.T, budget int, deadlineUnsupported bool) (addr string, done <-chan struct{}, cleanup func()) {
+	t.Helper()
+	srv := newBGPServer(t, bigBGPTable6809(20000))
+
+	base, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	sl := &stalledListener6809{Listener: base, budget: budget, deadlineUnsupported: deadlineUnsupported}
+
+	handlerDone := make(chan struct{})
+	var once sync.Once
+	ts := &httptest.Server{
+		Listener: sl,
+		Config: &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer once.Do(func() { close(handlerDone) })
+			srv.bgpHandler(w, r)
+		})},
+	}
+	ts.Start()
+	return ts.Listener.Addr().String(), handlerDone, func() {
+		sl.releaseAll()
+		ts.Close()
+	}
+}
+
+// dialAndRequestWithoutReading6809 opens a raw connection, sends the request,
+// and NEVER reads the response — the exact shape of the hazard. The connection
+// stays OPEN, so nothing produces a disconnect or a write error on its own.
+func dialAndRequestWithoutReading6809(t *testing.T, addr string) net.Conn {
+	t.Helper()
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	if _, err := fmt.Fprintf(c, "GET /api/routing/bgp?type=routes HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n"); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	return c
+}
+
+// TestSlowReaderDoesNotPinTheHandler6809 is the issue. A connected non-reader
+// must not park the handler goroutine indefinitely.
+//
+// FAIL-ON-REVERT: remove either armWriteDeadline() call and no deadline is ever
+// set on the conn, so stalledConn6809.Write takes its wdl.IsZero() branch and
+// blocks until teardown — this cell then fails on the timeout, naming the pin.
+func TestSlowReaderDoesNotPinTheHandler6809(t *testing.T) {
+	restore := bgpStreamWriteDeadline
+	bgpStreamWriteDeadline = 250 * time.Millisecond
+	t.Cleanup(func() { bgpStreamWriteDeadline = restore })
+
+	// Budget lets the header and the first chunks through, so the stall lands
+	// inside the route stream rather than before it.
+	addr, done, cleanup := startStalledBGPServer6809(t, 32*1024, false)
+	defer cleanup()
+	dialAndRequestWithoutReading6809(t, addr)
+
+	select {
+	case <-done:
+		// Returned: the write deadline converted the blocked flush into an
+		// ordinary terminal write error, which the existing error path already
+		// turns into "stop the scan and cancel vtysh".
+	case <-time.After(15 * time.Second):
+		t.Fatal("the BGP route handler is still running ~60 write-deadline " +
+			"windows after a connected client stopped reading — the handler " +
+			"goroutine, the vtysh child, its pipe and the connection are all " +
+			"pinned, and nothing in the request bounds them (#6809)")
+	}
+}
+
+// TestStalledConnCanActuallyPinTheHandler6809 is the NEGATIVE CONTROL for the
+// cell above, and it is not optional: "the handler returned" proves the fix
+// only if this fixture is capable of NOT returning. Here the conn refuses write
+// deadlines and the elapsed backstop is set far away, so nothing can interrupt
+// the blocked write — the handler MUST still be running.
+//
+// It also pins the honest limit of the elapsed backstop: with write deadlines
+// unavailable it bounds the vtysh child, not this goroutine.
+func TestStalledConnCanActuallyPinTheHandler6809(t *testing.T) {
+	restoreW, restoreT := bgpStreamWriteDeadline, bgpStreamTotalBudget
+	bgpStreamWriteDeadline = 100 * time.Millisecond
+	bgpStreamTotalBudget = time.Hour // far away: not the thing under test
+	t.Cleanup(func() { bgpStreamWriteDeadline, bgpStreamTotalBudget = restoreW, restoreT })
+
+	addr, done, cleanup := startStalledBGPServer6809(t, 32*1024, true /* deadlines unsupported */)
+	defer cleanup()
+	dialAndRequestWithoutReading6809(t, addr)
+
+	select {
+	case <-done:
+		t.Fatal("the handler returned even though write deadlines are " +
+			"unsupported and the elapsed backstop is an hour away — the " +
+			"fixture cannot pin, so the sibling cell's pass proves nothing")
+	case <-time.After(2 * time.Second):
+		// Still blocked, as a real socket would be. Good.
+	}
+}
+
+// TestRIBStreamLimiterRefusesOverCap6809 covers the second half of the hazard:
+// even a bounded stream is a vtysh child, so an unbounded NUMBER of them is
+// still an accumulation. Over-cap requests are refused immediately (429), not
+// queued — a queued request holds the same connection it would hold while
+// streaming, which just moves the pin.
+func TestRIBStreamLimiterRefusesOverCap6809(t *testing.T) {
+	restore := ribStreamLimiter
+	ribStreamLimiter = diagcmd.NewLimiter(1)
+	t.Cleanup(func() { ribStreamLimiter = restore })
+
+	// Hold the only slot, exactly as an in-flight stream would.
+	release, err := ribStreamLimiter.Acquire()
+	if err != nil {
+		t.Fatalf("precondition: the fresh limiter must admit the first holder: %v", err)
+	}
+
+	srv := newBGPServer(t, makeFRRBGPOutput([][3]string{{"10.0.0.0/24", "192.0.2.1", "65001 i"}}))
+	rec := httptest.NewRecorder()
+	srv.bgpHandler(rec, httptest.NewRequest(http.MethodGet, "/api/routing/bgp?type=routes", nil))
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("over-cap RIB stream status = %d, want %d — an unbounded number "+
+			"of concurrent full-RIB streams can accumulate vtysh children (#6809)",
+			rec.Code, http.StatusTooManyRequests)
+	}
+	if ra := rec.Header().Get("Retry-After"); ra == "" {
+		t.Error("a 429 without Retry-After tells a client to back off but not for " +
+			"how long, so a poller retries immediately and the refusal costs more " +
+			"than it saves")
+	}
+
+	// PAIRED: once the slot is free the same request is admitted and streams.
+	release()
+	rec2 := httptest.NewRecorder()
+	srv.bgpHandler(rec2, httptest.NewRequest(http.MethodGet, "/api/routing/bgp?type=routes", nil))
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("status = %d after the slot was released, want 200 — the limiter "+
+			"refuses every request, not just over-cap ones", rec2.Code)
+	}
+	if !strings.Contains(rec2.Body.String(), "10.0.0.0/24") {
+		t.Fatalf("admitted stream did not carry the route: %s", rec2.Body.String())
+	}
+}
+
+// TestNormalReaderStillGetsTheWholeTable6809 is the PAIRED control for the
+// budgets. Every cell above asserts that something STOPS; without this one they
+// are all satisfied by a handler that stops on every request, which would break
+// the endpoint for the clients it exists to serve.
+func TestNormalReaderStillGetsTheWholeTable6809(t *testing.T) {
+	// Deliberately tight budgets: a reader that actually reads must still get
+	// the complete table, because each flush is granted a FRESH window.
+	restoreW, restoreT := bgpStreamWriteDeadline, bgpStreamTotalBudget
+	bgpStreamWriteDeadline = 2 * time.Second
+	bgpStreamTotalBudget = 30 * time.Second
+	t.Cleanup(func() { bgpStreamWriteDeadline, bgpStreamTotalBudget = restoreW, restoreT })
+
+	const routes = 5000
+	srv := newBGPServer(t, bigBGPTable6809(routes))
+	ts := httptest.NewServer(http.HandlerFunc(srv.bgpHandler))
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/routing/bgp?type=routes")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body := readAllString6809(t, resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	// The envelope closed properly — a stream cut short by a budget would not.
+	if !strings.HasSuffix(strings.TrimSpace(body), `"}}`) {
+		t.Fatalf("response envelope was not closed; the stream was cut short:\n%s",
+			tail6809(body, 200))
+	}
+	// Every route is present: count the emitted lines rather than spot-checking
+	// one, so a stream truncated in the middle fails.
+	if got := strings.Count(body, "192.0.2.1"); got != routes {
+		t.Fatalf("emitted %d routes, want %d — the #6809 budgets truncated a "+
+			"healthy stream", got, routes)
+	}
+}
+
+func readAllString6809(t *testing.T, r interface{ Read([]byte) (int, error) }) string {
+	t.Helper()
+	var b strings.Builder
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := r.Read(buf)
+		b.Write(buf[:n])
+		if err != nil {
+			return b.String()
+		}
+	}
+}
+
+func tail6809(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[len(s)-n:]
+}

--- a/pkg/api/bgp_slow_reader_pin_6809_test.go
+++ b/pkg/api/bgp_slow_reader_pin_6809_test.go
@@ -24,7 +24,9 @@ package api
 // the harness is genuinely capable of pinning.
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -35,6 +37,7 @@ import (
 	"time"
 
 	"github.com/psaab/xpf/pkg/diagcmd"
+	"github.com/psaab/xpf/pkg/frr"
 )
 
 // --- a connection that stops accepting bytes, like a full send buffer -------
@@ -350,4 +353,92 @@ func tail6809(s string, n int) string {
 		return s
 	}
 	return s[len(s)-n:]
+}
+
+// --- the elapsed backstop, bound by what it can actually be observed to do ---
+
+// ctxCapturingExecutor6809 records the context StreamBGPRoutes hands to
+// VtyshStream. That context is what exec.CommandContext binds the vtysh child
+// to, so its cancellation IS the child's death — the one observable the elapsed
+// backstop actually produces.
+type ctxCapturingExecutor6809 struct {
+	fakeBGPExecutor
+	got chan context.Context
+}
+
+func (e *ctxCapturingExecutor6809) VtyshStream(ctx context.Context, cmd string) (io.ReadCloser, func() error, error) {
+	select {
+	case e.got <- ctx:
+	default:
+	}
+	return e.fakeBGPExecutor.VtyshStream(ctx, cmd)
+}
+
+// TestElapsedBackstopReapsVtyshWhenWriteDeadlinesAreUnsupported6809 binds the
+// budget the write deadline cannot cover.
+//
+// This cell exists because the mutation matrix caught its absence: deleting the
+// elapsed backstop left the whole package GREEN. Every other cell here either
+// depends on the write deadline (which the backstop does not affect) or
+// deliberately parks the handler forever, so none of them could see it go.
+//
+// The property is deliberately NOT "the handler returns". With write deadlines
+// unsupported the handler genuinely cannot be unpinned — nothing short of a
+// socket deadline interrupts a blocked write — and a cell asserting otherwise
+// would be asserting something false. What the backstop does is cancel the
+// context the vtysh child is bound to, so the CHILD, its pipe and the RIB dump
+// are freed on a bounded schedule even while the goroutine stays parked. That
+// is a partial bound, and this asserts exactly the part that is real.
+//
+// FAIL-ON-REVERT: replace the context.WithTimeout with a bare WithCancel and
+// nothing cancels this context (the handler is blocked, so neither deferred
+// cancel runs) — the wait below times out.
+func TestElapsedBackstopReapsVtyshWhenWriteDeadlinesAreUnsupported6809(t *testing.T) {
+	restoreW, restoreT := bgpStreamWriteDeadline, bgpStreamTotalBudget
+	bgpStreamWriteDeadline = 100 * time.Millisecond
+	bgpStreamTotalBudget = 500 * time.Millisecond
+	t.Cleanup(func() { bgpStreamWriteDeadline, bgpStreamTotalBudget = restoreW, restoreT })
+
+	exec := &ctxCapturingExecutor6809{
+		fakeBGPExecutor: fakeBGPExecutor{vtyshOut: bigBGPTable6809(20000)},
+		got:             make(chan context.Context, 1),
+	}
+	srv := &Server{frr: frr.NewForTest(t.TempDir()+"/frr.conf", exec)}
+
+	base, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	// deadlineUnsupported: the write deadline is off the table, so the elapsed
+	// backstop is the ONLY bound left and this cell is measuring it alone.
+	sl := &stalledListener6809{Listener: base, budget: 32 * 1024, deadlineUnsupported: true}
+	ts := &httptest.Server{
+		Listener: sl,
+		Config:   &http.Server{Handler: http.HandlerFunc(srv.bgpHandler)},
+	}
+	ts.Start()
+	defer func() { sl.releaseAll(); ts.Close() }()
+
+	dialAndRequestWithoutReading6809(t, ts.Listener.Addr().String())
+
+	var streamCtx context.Context
+	select {
+	case streamCtx = <-exec.got:
+	case <-time.After(10 * time.Second):
+		t.Fatal("vtysh was never started, so this cell cannot observe the child's " +
+			"lifetime")
+	}
+
+	select {
+	case <-streamCtx.Done():
+		// The vtysh child's context was cancelled on schedule:
+		// exec.CommandContext kills and reaps it, freeing the process, its pipe
+		// and the RIB dump, even though this request's goroutine is still
+		// parked in a write nothing can interrupt.
+	case <-time.After(10 * time.Second):
+		t.Fatal("the vtysh child's context was never cancelled — with a connected " +
+			"non-reader and no usable write deadline, the child, its pipe and " +
+			"the full RIB dump stay live for as long as the client holds the " +
+			"connection open (#6809)")
+	}
 }

--- a/pkg/api/routing.go
+++ b/pkg/api/routing.go
@@ -2,13 +2,16 @@ package api
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/diagcmd"
 	"github.com/psaab/xpf/pkg/frr"
 )
 
@@ -25,6 +28,118 @@ import (
 // const) only so tests can drive the truncation path without synthesizing a
 // million-route fixture.
 var maxBGPRoutes = 100000
+
+// --- #6809: bounding a SLOW READER, not a large table ------------------------
+//
+// The route cap above bounds bytes and CPU *after progress*. It bounds nothing
+// while the handler is BLOCKED. An authenticated client that opens
+// /api/routing/bgp?type=routes and then reads slowly — or stops reading without
+// disconnecting — fills the socket buffers, and the periodic `bw.Flush()` in
+// the stream callback blocks in the kernel. That pins four things at once, none
+// of which any existing bound covers:
+//
+//   - the handler goroutine, parked in Flush;
+//   - the vtysh child, which blocks as soon as ITS stdout pipe fills;
+//   - that pipe and the client connection;
+//   - and, before this, an unbounded number of each, because there was no
+//     admission limit on the endpoint.
+//
+// r.Context() cancels on DISCONNECT, which the #5232 check already handles. A
+// still-connected non-reader produces neither a disconnect nor a write error,
+// so nothing fires. http.Server's WriteTimeout is deliberately 0 process-wide
+// (SSE event/log streams must be able to stay open indefinitely — see the const
+// block in server.go), so there is no global backstop either.
+//
+// THE TWO BUDGETS ARE NOT REDUNDANT, and this is the part that is easy to get
+// wrong. Cancelling a context does NOT interrupt a write already blocked in the
+// kernel: a finite context kills vtysh and frees the child + pipe, but the
+// handler goroutine stays parked in Flush forever. Only a socket write deadline
+// unblocks it. Conversely a write deadline alone does not bound a client that
+// dribbles just enough bytes to reset it every window. So:
+//
+//   - bgpStreamWriteDeadline is the PROGRESS budget — it bounds one flush, and
+//     is what actually unpins the goroutine;
+//   - bgpStreamTotalBudget is the ELAPSED backstop — it bounds the whole
+//     request, and catches the dribbling client that resets the write window
+//     forever.
+//
+// Be precise about what the backstop can and cannot do on a ResponseWriter
+// that does NOT support write deadlines: it still kills and reaps the vtysh
+// child, freeing the process, its pipe and the RIB dump, but it CANNOT unpin
+// this goroutine, because nothing short of a socket deadline interrupts a
+// write already blocked in the kernel. That configuration is therefore a
+// partial bound, not a full one, and the write deadline is the load-bearing
+// half. In production the writer is a real *http.response over a TCP conn,
+// which supports deadlines.
+//
+// A per-flush deadline is preferred over a pure elapsed cap as the primary
+// mechanism because it does not punish a LEGITIMATELY large table on a slow
+// but progressing link: each flush gets a fresh window, so a 1M-route dump to
+// a genuine slow consumer completes, while a non-reader fails on the first
+// window.
+
+// bgpStreamWriteDeadline bounds a SINGLE downstream flush. A client that
+// cannot accept one 1024-route chunk within this window is not reading. Vars,
+// not consts, so a test can compress them without a real slow reader.
+var bgpStreamWriteDeadline = 30 * time.Second
+
+// bgpStreamTotalBudget bounds the whole route stream end to end. Generous by
+// design: a full internet table capped at maxBGPRoutes streams out in seconds
+// on any real link, so this only trips on a client engineered to make minimal
+// progress, or where write deadlines are unavailable.
+var bgpStreamTotalBudget = 10 * time.Minute
+
+// maxConcurrentRIBStreams bounds how many full-RIB stream requests may be in
+// flight. Each holds a vtysh child dumping the routing table, which contends
+// with the control plane, so this is deliberately tighter than the diagnostic
+// limiters (#5057's 4). The endpoint is a diagnostic, not a hot path.
+const maxConcurrentRIBStreams = 2
+
+// ribStreamLimiter admits at most maxConcurrentRIBStreams concurrent full-RIB
+// streams, so a handful of slow readers cannot accumulate vtysh children
+// without bound. It reuses the diagcmd fixed-capacity counting semaphore — the
+// same fail-fast idiom the diagnostic and session-walk handlers use: Acquire is
+// non-blocking, so an over-cap request gets an immediate 429 instead of joining
+// an unbounded backlog (which would just move the pin).
+//
+// Unlike sessionWalkLimiter this instance is LOCAL to the REST surface rather
+// than a shared diagcmd process-wide one, and that is deliberate: the gRPC and
+// CLI `show route protocol bgp` paths call the BUFFERED GetBGPRoutes, which
+// runs vtysh to completion before any client sees a byte and therefore cannot
+// be pinned by a slow reader. There is no second surface to share a budget
+// with, so a shared instance would imply a cross-surface bound that does not
+// exist. A package var so a test can swap in a capacity-1 limiter.
+var ribStreamLimiter = diagcmd.NewLimiter(maxConcurrentRIBStreams)
+
+// deadlineArmingWriter arms a fresh write deadline immediately before each
+// underlying write, so no write to the socket can block longer than the
+// progress budget (#6809).
+//
+// It sits BETWEEN bufio and the ResponseWriter deliberately. Arming at the
+// handler's explicit flush points leaves bufio's own capacity-triggered
+// flushes — the majority of the real socket writes — uncovered, and those are
+// the ones that block first. Placing it here makes the property structural
+// rather than a matter of remembering every flush site, including the closing
+// one a sub-1024-route table reaches without ever entering the periodic branch.
+//
+// A writer that cannot carry a deadline (http.ErrNotSupported) is recorded
+// once and not retried per write; the elapsed backstop then bounds the vtysh
+// child, though not this goroutine — see the note above.
+type deadlineArmingWriter struct {
+	w           io.Writer
+	rc          *http.ResponseController
+	d           time.Duration
+	unsupported bool
+}
+
+func (a *deadlineArmingWriter) Write(p []byte) (int, error) {
+	if !a.unsupported {
+		if err := a.rc.SetWriteDeadline(time.Now().Add(a.d)); err != nil {
+			a.unsupported = true
+		}
+	}
+	return a.w.Write(p)
+}
 
 func (s *Server) routesHandler(w http.ResponseWriter, _ *http.Request) {
 	cfg := s.store.ActiveConfig()
@@ -164,7 +279,45 @@ func (s *Server) bgpHandler(w http.ResponseWriter, r *http.Request) {
 		// joined string. The output is capped at maxBGPRoutes with a trailing
 		// truncation notice so the response body stays bounded even for a
 		// pathologically large table.
-		bw := bufio.NewWriter(w)
+		// #6809 admission: one slot per in-flight full-RIB stream. Non-blocking
+		// — an over-cap request is refused immediately rather than queued,
+		// because a queued request holds the same connection it would have held
+		// while streaming.
+		release, err := ribStreamLimiter.Acquire()
+		if err != nil {
+			w.Header().Set("Retry-After", "5")
+			writeError(w, http.StatusTooManyRequests,
+				"BGP route-stream concurrency limit reached; retry shortly")
+			return
+		}
+		defer release()
+
+		// #6809 elapsed backstop. Derived from r.Context() so a real disconnect
+		// still cancels immediately (the #5232 path), and handed to
+		// StreamBGPRoutes so its exec.CommandContext kills and reaps vtysh when
+		// the budget expires. This bounds the CHILD; the write deadline below is
+		// what bounds this goroutine.
+		streamCtx, cancelStream := context.WithTimeout(r.Context(), bgpStreamTotalBudget)
+		defer cancelStream()
+
+		// #6809 progress budget, armed at the WRITE, not at the flush points.
+		//
+		// The obvious placement — arm it next to the periodic bw.Flush() — does
+		// not work, and the slow-reader cell catches it. bufio auto-flushes
+		// whenever its 4 KiB buffer fills, and 1024 routes is ~70 KiB, so the
+		// stream performs roughly seventeen real socket writes between two
+		// consecutive explicit flushes. Those are the writes that block first,
+		// and an arm that only runs at the explicit boundary never covers them.
+		//
+		// Wrapping the ResponseWriter instead makes the coverage structural:
+		// every byte that reaches the socket passes through one place that has
+		// just armed a deadline, whoever decided to flush. It costs one
+		// SetWriteDeadline per underlying write (~per 4 KiB), not per route.
+		bw := bufio.NewWriter(&deadlineArmingWriter{
+			w:  w,
+			rc: http.NewResponseController(w),
+			d:  bgpStreamWriteDeadline,
+		})
 		emitted := 0
 		started := false
 		// emitPrefix lazily writes the 200 status + envelope prefix on the
@@ -182,7 +335,7 @@ func (s *Server) bgpHandler(w http.ResponseWriter, r *http.Request) {
 			// empty (omitempty) — matches encoding/json field order.
 			io.WriteString(bw, `{"success":true,"data":{"output":"`)
 		}
-		truncated, err := s.frr.StreamBGPRoutes(r.Context(), maxBGPRoutes, func(route frr.BGPRoute) error {
+		truncated, err := s.frr.StreamBGPRoutes(streamCtx, maxBGPRoutes, func(route frr.BGPRoute) error {
 			emitPrefix()
 			writeJSONStringFragment(bw, fmt.Sprintf("%-24s %-20s %s\n",
 				route.Network, route.NextHop, route.Path))
@@ -196,12 +349,17 @@ func (s *Server) bgpHandler(w http.ResponseWriter, r *http.Request) {
 				// stops the scan and cancels vtysh upstream. The un-flushed
 				// bufio tail and closing envelope are intentionally dropped:
 				// the connection is gone.
-				if cerr := r.Context().Err(); cerr != nil {
+				// #6809: check the BUDGETED context, not r.Context(). It is
+				// derived from it, so a disconnect still lands here; the
+				// elapsed backstop now does too.
+				if cerr := streamCtx.Err(); cerr != nil {
 					return cerr
 				}
 				// A downstream write failure is also terminal: propagate it so
 				// the scan stops and vtysh is cancelled instead of dumping the
-				// rest of the table into a broken pipe.
+				// rest of the table into a broken pipe. Since #6809 that
+				// includes a write-deadline expiry, which is what converts a
+				// blocked handler into an ordinary terminal write error.
 				if ferr := bw.Flush(); ferr != nil {
 					return ferr
 				}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -449,9 +449,24 @@ type Server struct {
 // WriteTimeout is deliberately left UNSET (0 = unlimited): the SSE event/log
 // streams (GET /api/v1/events/stream, /api/v1/logs/stream) are long-lived, and
 // a full metrics or session-table scrape is a large, legitimately slow
-// response. A WriteTimeout would sever those. The response side is bounded by
-// per-handler context deadlines instead, so leaving it unlimited does not
-// reopen a slow-read DoS on the request side.
+// response. A WriteTimeout would sever those.
+//
+// #6809 CORRECTION. This block used to add "the response side is bounded by
+// per-handler context deadlines instead", and that is not true in the way it
+// reads. A context deadline bounds the handler's own WORK; it does not
+// interrupt a write already blocked in the kernel because the peer stopped
+// reading. Cancelling a context frees whatever the handler owns downstream — a
+// child process, a map lock — but the goroutine stays parked in Write until a
+// SOCKET write deadline fires. Only http.ResponseController.SetWriteDeadline
+// (or a global WriteTimeout, which is what SSE rules out) does that.
+//
+// So an endpoint that streams to a client which stays CONNECTED but stops
+// reading needs its own per-write deadline. /api/routing/bgp?type=routes
+// carries one (bgpStreamWriteDeadline, routing.go) because it also pins a
+// vtysh child behind the blocked write. Any future streaming endpoint has to
+// make the same arrangement explicitly; leaving WriteTimeout unset is a
+// deliberate trade that moves the bound to the handler, not a bound that
+// happens automatically.
 const (
 	// apiReadHeaderTimeout bounds the time to read the request headers — the
 	// slow-header slowloris defense, and the pre-auth guard since header read


### PR DESCRIPTION
Closes #6809

## Summary

- `/api/routing/bgp?type=routes` had bounds on **progress** only — `maxBGPRoutes` caps bytes, `StreamBGPRoutes` caps memory, the #5232 check aborts on **disconnect**. None of them bound the handler while it is **blocked**.
- A client that stays **connected** and stops reading fills the socket buffers; `bw.Flush()` parks in the kernel; the stream callback never returns; and the `cancel`/`Close`/reap that would kill vtysh all sit **after** the scan loop. Handler goroutine, vtysh child, its pipe and the connection stayed pinned indefinitely. `WriteTimeout` is 0 process-wide for SSE, so there was no global backstop either.
- Three bounds added, deliberately **not** interchangeable: a per-write deadline, an elapsed backstop, and a concurrency limiter.
- A false claim in `server.go` and `pkg/api/README.md` — "the response side is bounded by per-handler context deadlines instead" — is corrected. R70 flags the same sentence.

**Evidence source**: `docs/reviews/recovered/opus-review-001.md` root section **R70** (in-repo as of #7624), read including the Refutation attempt and Dedup note, then re-derived against current `origin/master`. All four cited sites reproduce.

## Why three bounds and not one

They cover different things, and collapsing them loses coverage:

| bound | value | what it actually does |
|---|---|---|
| `bgpStreamWriteDeadline` | 30s, **per write** | The **load-bearing** one. Cancelling a context does *not* interrupt a write already blocked in the kernel — only a socket write deadline does. Each write gets a **fresh** window, so a legitimately large table on a slow-but-progressing link still completes while a non-reader fails on the first window. |
| `bgpStreamTotalBudget` | 10m, per request | Elapsed backstop, derived from `r.Context()` and handed to `StreamBGPRoutes` so `exec.CommandContext` kills and reaps vtysh. Catches a client that dribbles just enough to reset the write window forever. |
| `ribStreamLimiter` | 2 concurrent | A bounded stream is still a vtysh child, so an unbounded **number** of them still accumulates. Non-blocking → **429 + `Retry-After`**, because a queued request holds the same connection it would hold while streaming. |

**Stated honestly:** on a `ResponseWriter` that cannot carry a write deadline, the elapsed backstop frees the **child**, its pipe and the RIB dump — but **not** this goroutine, because nothing short of a socket deadline interrupts a blocked write. That is a partial bound and the code says so rather than implying full coverage. In production the writer is a real `*http.response` over TCP, which supports deadlines.

The limiter is **local to REST** on purpose: the gRPC and CLI `show route protocol bgp` paths call the **buffered** `GetBGPRoutes`, which runs vtysh to completion before any client sees a byte and therefore cannot be pinned by a slow reader. There is no second surface to share a budget with, so a shared `diagcmd` instance would imply a cross-surface bound that does not exist.

## My first fix was wrong, and the test caught it

I armed the deadline next to the explicit 1024-route flushes. **The slow-reader cell failed with that fix in place.** `bufio` auto-flushes whenever its 4 KiB buffer fills, and 1024 routes is ~70 KiB — so roughly **seventeen real socket writes** happen between two consecutive explicit flush boundaries, and those are the ones that block first. An arm that only runs at the explicit boundary never covers them.

`deadlineArmingWriter` now sits between `bufio` and the `ResponseWriter`, which makes the coverage **structural** rather than a matter of remembering every flush site — including the closing flush that a sub-1024-route table reaches without ever entering the periodic branch. Cost is one `SetWriteDeadline` per underlying write (~per 4 KiB), not per route.

## Test plan

- [x] `pkg/api/bgp_slow_reader_pin_6809_test.go` — 5 cells. The fixture **models** the hazard rather than approximating it: a `net.Conn` that accepts a fixed prefix of bytes and then parks the writer exactly as a full send buffer does — until the write deadline, or forever if none is armed. That makes the fail-on-revert deterministic: no socket-buffer-size guessing, no sleeps calibrated against a real slow client.
  - `TestSlowReaderDoesNotPinTheHandler6809` — the issue. Handler must return; it does, in 0.27s.
  - `TestStalledConnCanActuallyPinTheHandler6809` — **negative control**, and not optional: "the handler returned" proves the fix only if the fixture is capable of *not* returning. Deadlines unsupported + backstop an hour away → the handler **must** still be running.
  - `TestElapsedBackstopReapsVtyshWhenWriteDeadlinesAreUnsupported6809` — binds the backstop to what it observably does: a capturing executor records the context handed to `VtyshStream` and the cell waits on its cancellation. Deliberately **not** "the handler returns", which would be asserting something false.
  - `TestRIBStreamLimiterRefusesOverCap6809` — 429 + `Retry-After` over cap, **paired** with an admitted request once the slot frees.
  - `TestNormalReaderStillGetsTheWholeTable6809` — **paired control**: every other cell asserts something *stops*; without this they are all satisfied by a handler that stops on every request. Tight budgets, 5000 routes, all present, envelope closed.
- [x] **Mutation matrix** at HEAD `538f7ae8b`, fix committed first, every cell a full-package `go test -count=1 ./pkg/api/` with **no** `-run` filter, `buildbreak=0` throughout:

  | mutation | cell that RED | verdict |
  |---|---|---|
  | deadline-arming writer removed (the shipped defect) | `TestSlowReaderDoesNotPinTheHandler6809` | RED |
  | arming reduced to the explicit flush points (my first, wrong fix) | `TestSlowReaderDoesNotPinTheHandler6809` | RED |
  | concurrency limiter removed | `TestRIBStreamLimiterRefusesOverCap6809` | RED |
  | 429 loses `Retry-After` | `TestRIBStreamLimiterRefusesOverCap6809` | RED |
  | elapsed backstop → bare `WithCancel` | `TestElapsedBackstopReapsVtyshWhenWriteDeadlinesAreUnsupported6809` | RED |

  **The matrix earned its keep again.** The elapsed-backstop mutation came back **GREEN** on the first run: every cell then present either depended on the write deadline (which the backstop does not affect) or deliberately parked the handler forever, so none could see it go. The cell that binds it is its own commit.
- [x] `go build ./... && go test -count=1 ./...` → **rc 0**, 67/67 packages, at HEAD `538f7ae8b89c88d2abd17726acd8310b6841ead0`, with `origin/master 6effbb826` merged in (MERGE, never rebase) and `merge-base --is-ancestor origin/master HEAD` verified.
- [ ] **No smoke owed.** `pkg/api` handler bounds only — no cluster, VRRP, session-sync, fabric or failover code, no `userspace-dp`/`userspace-xdp` (no cargo leg). The FRR **reload** path is untouched, so #1880's `frr-reload.py`-direct constraint is unaffected.

### `_Log.md` conflict, resolved structurally

#7626 merged while this was in flight, so `_Log.md` conflicted. Resolved as `theirs + ours_tail` and **verified on the result**, not on the method: our side is a clean prepend onto the merge base (asserted), master's side is deliberately **not** assumed to be — #7614/#7616 deleted lines mid-file — so `theirs` is taken whole. Post-checks: `disk == ours_new + theirs`, ends with `theirs` verbatim, heading count 1964 + 1 = 1965, **zero** master headings missing, and master's own `TestNoUnresolvedConflictMarkers` / `TestLogDuplicateDetectorFindsADuplicate` gates pass.

## Deferred

- SSE (`writeSSEEvent`, `pkg/api/sse.go`) writes with no deadline either, so a slow SSE reader can pin a goroutine on the same mechanism. Different profile — no child process, and there is already a subscriber cap (#4484) — so it is a sibling rather than part of this hazard, and R70's Dedup note does not cover it. Not fixed here; filed as **#7632**, which can reuse the `stalledConn6809` fixture directly.

## Refs

Closes #6809. Builds on #5056 (upstream streaming), #4708 (downstream streaming), #5232 (the disconnect abort this complements). Related: #5057 / #5708 (the `diagcmd.Limiter` idiom reused here), #4484 (the SSE subscriber cap), and the `WriteTimeout` rationale in `server.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1PvkJxs7KrzEdyC9u1LDu
