### PR TITLE
pkg/configstore: bind a commit to the holder that authorized it (#6808)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -105916,3 +105916,86 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/cli/cli_show_security_zones.go`,
   `pkg/api/metrics_zone_overflow_6845_test.go` (new), `pkg/api/README.md`,
   `_Log.md`
+
+## 2026-08-26 — #6808 bind the commit to the holder that authorized it
+
+- **Timestamp**: 2026-08-26
+- **Action**: Close the holder-turnover substitution (opus-review-001 root R69):
+  the commit paths verified the config-lock holder and then promoted through a
+  callback carrying NO identity, so the lock could turn over in between and the
+  in-flight commit would promote the NEW holder's candidate under the ORIGINAL
+  holder's authorization.
+- **Re-derivation widened the scope past the title.** R69 says "REST commit";
+  the identical gate-then-unscoped-callback shape is at FOUR sites — REST
+  commit/commit-confirmed (`pkg/api/config.go:233,500`) and gRPC
+  Commit/CommitConfirmed (`pkg/grpcapi/server_config.go:253,295`). Fixing only
+  REST would close two of four doors on one authorization defect, and the
+  threading is shared plumbing, so splitting would land an intermediate state
+  where two call sites pass a zero authority — the fail-open-by-omission the
+  explicit parameter exists to prevent.
+- **gRPC has a NON-ADVERSARIAL trigger**: `configLockStatsHandler.HandleConn`
+  auto-releases the lock on `ConnEnd` from a separate goroutine with no
+  coordination with an in-flight commit. Its comment claims the release is
+  "guarded ... by the store's holder check" — true of a DIFFERENT hazard
+  (releasing someone else's lock) and silent about releasing the committer's own
+  lock mid-commit. An ordinary disconnect reaches the substitution.
+- **Reading R69's Refutation, not just its Evidence, changed the fix.** The
+  natural read from the title is "generation binding is missing". Generation
+  binding is present AND correct; it answers a different question and takes no
+  session id. A turnover completing before `CompileCandidateGen` — during the
+  `applySem.Acquire` wait, where a busy daemon actually waits — yields a
+  perfectly consistent generation pair describing B's candidate. Worse, since
+  `commitWithGenBinding` RETRIES `ErrCandidateGenerationConflict` by design, a
+  turnover reported as a generation conflict would make the retry loop perform
+  the substitution automatically. Hence a DISTINCT `ErrConfigHolderTurnover`
+  sentinel, with a cell pinning the two apart.
+- **The zero value is invalid, not a bypass** (review strengthening, and the
+  part most likely to be got wrong). Letting `CommitAuthority{}` mean "internal
+  committer" would put the god-mode capability at exactly the value a forgotten
+  field produces: the explicit parameter would catch OMISSION (compile error)
+  while silently admitting a wrong-but-compiling zero that reads as deliberate.
+  Internal committers now state it with `InternalCommitter()`; the store rejects
+  the zero with `ErrCommitAuthorityMissing`.
+- **Explicit parameter, not a Context value**: an absent ctx value is
+  indistinguishable from a deliberate one and degrades silently to a bypass on
+  an authorization path. The signature change makes omission a compile error —
+  which is exactly how the four defect sites surfaced during the change.
+- **`EnsureConfigHolder` DELETED, its test MOVED.** Once all four commit paths
+  used `AuthorizeCommit` it had zero production callers, and its doc comment
+  ("the exported gate used by the commit-family gRPC RPCs") had become false.
+  Leaving a weaker twin beside the fixed gate is how this class regresses.
+  `TestEnsureConfigHolder` moved to `TestAuthorizeCommitHolderGate` — the #5059
+  property did not change, but the function enforcing it did, and a test left on
+  the old symbol would stay green while guarding nothing.
+- **Rejected alternative, recorded**: pin the holder for the commit's duration
+  so turnover cannot happen. Smaller, no signature change — but it breaks the
+  #5849 auto-release contract: a dropped connection whose commit is pinned finds
+  `sess.released.Do` already consumed and the lock wedged until the #4476 lease
+  TTL. Recovering that needs deferred-release machinery, which spends the
+  simplicity that made it attractive.
+- **Designed around a known asymmetry**: `ExitConfigure()` clears
+  `exclusiveHolder` but not `configHolder`, safe today only because
+  `ensureHolderLocked` short-circuits on `!s.configDir`. An epoch keyed off
+  `configHolder` alone would have inherited that. Bumping the epoch on that path
+  makes it safe without depending on the short-circuit. Filing separately.
+- **14 cells**: 6 enforcement (`pkg/configstore`), 4 REST wiring (`pkg/api`),
+  4 gRPC wiring (`pkg/grpcapi`). The wiring cells matter independently — a
+  handler passing `InternalCommitter()` still COMPILES and restores the defect
+  in full, so they assert the authority the handler PASSES, not the store's
+  reaction to it. Controls assert an unchanged holder still commits AND actually
+  promotes (a control checking only status/err would pass against a fixture that
+  never reached promotion), and that an explicit internal committer is still
+  accepted (else "refuse everything" passes every refusal cell — a configuration
+  outage strictly worse than the defect).
+- **File(s)**: `pkg/configstore/commit_authority.go` (new),
+  `pkg/configstore/commit_authority_6808_test.go` (new),
+  `pkg/configstore/store.go`, `pkg/configstore/store_lock.go`,
+  `pkg/configstore/store_commit.go`,
+  `pkg/configstore/config_lock_holder_5059_test.go`,
+  `pkg/api/config.go`, `pkg/api/server.go`,
+  `pkg/api/config_holder_turnover_6808_test.go` (new),
+  `pkg/grpcapi/server_config.go`, `pkg/grpcapi/server.go`,
+  `pkg/grpcapi/config_holder_turnover_6808_test.go` (new),
+  `pkg/daemon/daemon_apply_commit.go`, `pkg/daemon/daemon_run_servers.go`,
+  `pkg/daemon/daemon_apply_tail.go`, `pkg/configstore/README.md`,
+  plus mechanical test migrations, `_Log.md`

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -230,7 +230,16 @@ func (s *Server) configCommitHandler(w http.ResponseWriter, r *http.Request) {
 	// pending work — the empty-session commit path previously let a stateless
 	// REST caller smuggle another operator's staged edits into an applied
 	// commit. Mirrors the gRPC Commit gate (pkg/grpcapi/server_config.go).
-	if err := s.store.EnsureConfigHolder(sessionID); err != nil {
+	// #6808: mint the commit AUTHORITY under the same store-lock acquisition
+	// that verifies the holder, and carry it into the callback. The previous
+	// form verified the holder here and then invoked a callback carrying NO
+	// identity, so the lock could turn over in between — the holder exits,
+	// disconnects, or is reclaimed on its idle lease, another session enters and
+	// stages different edits — and this already-authorized commit would promote
+	// the NEW holder's candidate. The authority is re-verified against the live
+	// holder epoch at promotion, under the store lock.
+	authority, err := s.store.AuthorizeCommit(sessionID)
+	if err != nil {
 		writeConfigMutationError(w, err)
 		return
 	}
@@ -253,7 +262,7 @@ func (s *Server) configCommitHandler(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "commit handler not wired")
 		return
 	}
-	compiled, err := s.commitFn(r.Context(), "")
+	compiled, err := s.commitFn(r.Context(), authority, "")
 	if err != nil {
 		switch {
 		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
@@ -497,7 +506,16 @@ func (s *Server) configCommitConfirmedHandler(w http.ResponseWriter, r *http.Req
 	}
 	// #5870: only the config-lock holder may commit the shared candidate.
 	// Mirrors the gRPC CommitConfirmed gate.
-	if err := s.store.EnsureConfigHolder(sessionID); err != nil {
+	// #6808: mint the commit AUTHORITY under the same store-lock acquisition
+	// that verifies the holder, and carry it into the callback. The previous
+	// form verified the holder here and then invoked a callback carrying NO
+	// identity, so the lock could turn over in between — the holder exits,
+	// disconnects, or is reclaimed on its idle lease, another session enters and
+	// stages different edits — and this already-authorized commit would promote
+	// the NEW holder's candidate. The authority is re-verified against the live
+	// holder epoch at promotion, under the store lock.
+	authority, err := s.store.AuthorizeCommit(sessionID)
+	if err != nil {
 		writeConfigMutationError(w, err)
 		return
 	}
@@ -505,7 +523,7 @@ func (s *Server) configCommitConfirmedHandler(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusInternalServerError, "commit-confirmed handler not wired")
 		return
 	}
-	compiled, err := s.commitConfirmedFn(r.Context(), req.Minutes)
+	compiled, err := s.commitConfirmedFn(r.Context(), authority, req.Minutes)
 	if err != nil {
 		switch {
 		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):

--- a/pkg/api/config_commit_test.go
+++ b/pkg/api/config_commit_test.go
@@ -62,7 +62,7 @@ func TestConfigCommitHandlerRejectsRetiredEBPF(t *testing.T) {
 	store := newAPIEBPFRejectStore(t)
 	s := &Server{
 		store: store,
-		commitFn: func(context.Context, string) (*config.Config, error) {
+		commitFn: func(context.Context, configstore.CommitAuthority, string) (*config.Config, error) {
 			return store.Commit()
 		},
 	}
@@ -85,7 +85,7 @@ func TestConfigCommitConfirmedHandlerRejectsRetiredEBPF(t *testing.T) {
 	store := newAPIEBPFRejectStore(t)
 	s := &Server{
 		store: store,
-		commitConfirmedFn: func(context.Context, int) (*config.Config, error) {
+		commitConfirmedFn: func(context.Context, configstore.CommitAuthority, int) (*config.Config, error) {
 			return store.CommitConfirmed(10)
 		},
 	}

--- a/pkg/api/config_holder_turnover_6808_test.go
+++ b/pkg/api/config_holder_turnover_6808_test.go
@@ -1,0 +1,237 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// #6808 REST WIRING cells.
+//
+// pkg/configstore proves the store REFUSES a promotion whose authority has gone
+// stale. That proves nothing about these handlers unless they actually mint a
+// BOUND authority and hand it over: passing configstore.InternalCommitter()
+// instead still compiles, still type-checks, and restores the defect in full —
+// an internal authority satisfies every turnover check by design.
+//
+// So the assertion here is on the authority the handler PASSES, not on the
+// store's reaction to it. That is the difference between binding the wiring and
+// binding the function the wiring calls.
+
+// restHolderStore returns a store in config mode held by the REST session the
+// test helpers use, with one staged edit so a commit has something to promote.
+func restHolderStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigureSession(testRESTConfigSessionID); err != nil {
+		t.Fatalf("EnterConfigureSession: %v", err)
+	}
+	if err := store.SetFromInputAs(testRESTConfigSessionID, "system host-name staged-by-rest"); err != nil {
+		t.Fatalf("SetFromInputAs: %v", err)
+	}
+	return store
+}
+
+// TestRESTCommitPassesBoundAuthority_6808 pins that the plain-commit handler
+// hands the callback an authority BOUND to the REST session that passed the
+// gate.
+//
+// FAIL-ON-REVERT: change the handler to pass configstore.InternalCommitter()
+// (which compiles) and this REDS on IsInternal — the commit would then promote
+// whatever candidate exists at promotion time, which is the whole defect.
+func TestRESTCommitPassesBoundAuthority_6808(t *testing.T) {
+	store := restHolderStore(t)
+
+	var got configstore.CommitAuthority
+	var called bool
+	s := &Server{
+		store: store,
+		commitFn: func(_ context.Context, a configstore.CommitAuthority, _ string) (*config.Config, error) {
+			called, got = true, a
+			return store.Commit()
+		},
+	}
+
+	rr := httptest.NewRecorder()
+	req := withRESTConfigSession(
+		httptest.NewRequest("POST", "/api/v1/config/commit", nil), testRESTConfigSessionID)
+	s.configCommitHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("REST commit as the holder: status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	if !called {
+		t.Fatal("commitFn was never invoked, so this cell asserts nothing about the authority")
+	}
+	if got.IsInternal() {
+		t.Error("the REST commit handler passed an INTERNAL commit authority. An internal " +
+			"authority satisfies every holder-turnover check, so the commit would still " +
+			"promote whatever candidate exists at promotion time — the #6808 defect, intact")
+	}
+	if got.SessionID() != testRESTConfigSessionID {
+		t.Errorf("commit authority SessionID = %q, want %q — the authority must be bound to "+
+			"the session that passed the gate, or it binds nothing",
+			got.SessionID(), testRESTConfigSessionID)
+	}
+}
+
+// TestRESTCommitConfirmedPassesBoundAuthority_6808 is the commit-confirmed half.
+// It is a SEPARATE cell because the two handlers mint their authority
+// independently; one cell covering only the plain path would report the
+// confirmed path as guarded when it is not.
+//
+// FAIL-ON-REVERT: pass configstore.InternalCommitter() in
+// configCommitConfirmedHandler and this REDS.
+func TestRESTCommitConfirmedPassesBoundAuthority_6808(t *testing.T) {
+	store := restHolderStore(t)
+
+	var got configstore.CommitAuthority
+	var called bool
+	s := &Server{
+		store: store,
+		commitConfirmedFn: func(_ context.Context, a configstore.CommitAuthority, _ int) (*config.Config, error) {
+			called, got = true, a
+			return store.CommitConfirmed(5)
+		},
+	}
+
+	rr := httptest.NewRecorder()
+	req := withRESTConfigSession(
+		httptest.NewRequest("POST", "/api/v1/config/commit-confirmed",
+			strings.NewReader(`{"minutes":5}`)), testRESTConfigSessionID)
+	s.configCommitConfirmedHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("REST commit-confirmed as the holder: status = %d, want 200; body: %s",
+			rr.Code, rr.Body.String())
+	}
+	if !called {
+		t.Fatal("commitConfirmedFn was never invoked, so this cell asserts nothing")
+	}
+	if got.IsInternal() {
+		t.Error("the REST commit-CONFIRMED handler passed an INTERNAL authority; a substituted " +
+			"commit-confirmed also arms an auto-rollback timer against work its author never " +
+			"approved (#6808)")
+	}
+	if got.SessionID() != testRESTConfigSessionID {
+		t.Errorf("commit-confirmed authority SessionID = %q, want %q",
+			got.SessionID(), testRESTConfigSessionID)
+	}
+}
+
+// TestRESTCommitRefusedWhenHolderTurnsOverMidCommit_6808 is the end-to-end cell:
+// the substitution R69 describes, driven through the real handler with the
+// turnover performed INSIDE the commit callback — i.e. exactly in the window
+// between the holder gate returning nil and the promotion landing.
+//
+// The staged edits are distinguishable per session on purpose. Asserting only
+// "an error came back" would pass against a handler that refuses everything, and
+// asserting only "something was promoted" cannot tell A's work from B's.
+//
+// FAIL-ON-REVERT: pass InternalCommitter() from the handler, or drop
+// verifyCommitAuthorityLocked from CommitWithDescriptionGenAs, and this REDS with
+// the intruder's host-name active.
+func TestRESTCommitRefusedWhenHolderTurnsOverMidCommit_6808(t *testing.T) {
+	store := restHolderStore(t)
+
+	s := &Server{
+		store: store,
+		commitFn: func(_ context.Context, a configstore.CommitAuthority, comment string) (*config.Config, error) {
+			// The lock turns over while this commit is in flight. On REST this
+			// models an idle-lease reclaim or an explicit /config/exit; on gRPC
+			// an ordinary disconnect reaches the same state with no adversary.
+			if !store.ExitConfigureSession(testRESTConfigSessionID) {
+				t.Fatal("fixture: could not release the REST session's lock")
+			}
+			if err := store.EnterConfigureSession("intruder"); err != nil {
+				t.Fatalf("fixture: intruder could not enter: %v", err)
+			}
+			if err := store.SetFromInputAs("intruder", "system host-name staged-by-intruder"); err != nil {
+				t.Fatalf("fixture: intruder set: %v", err)
+			}
+			_, gen, cerr := store.CompileCandidateGen()
+			if cerr != nil {
+				t.Fatalf("fixture: CompileCandidateGen: %v", cerr)
+			}
+			return store.CommitWithDescriptionGenAs(a, comment, gen)
+		},
+	}
+
+	rr := httptest.NewRecorder()
+	req := withRESTConfigSession(
+		httptest.NewRequest("POST", "/api/v1/config/commit", nil), testRESTConfigSessionID)
+	s.configCommitHandler(rr, req)
+
+	if rr.Code == http.StatusOK {
+		t.Fatalf("REST commit SUCCEEDED after the config lock turned over mid-commit; "+
+			"the intruder's staged edits were applied under the original session's "+
+			"authorization (#6808). body: %s", rr.Body.String())
+	}
+	if active := store.ActiveConfig(); active != nil && active.System.HostName == "staged-by-intruder" {
+		t.Fatalf("the intruder's candidate was PROMOTED (host-name=%q) under the REST "+
+			"session's authority", active.System.HostName)
+	}
+}
+
+// TestRESTCommitStillWorksWithoutTurnover_6808 is the control for the two cells
+// above: with the holder unchanged, a REST commit must still succeed AND
+// actually promote.
+//
+// Without it, "refuse every commit" satisfies the refusal cells — and refusing
+// every commit is a configuration outage, strictly worse than the defect. The
+// host-name assertion is what makes it load-bearing: a control checking only the
+// status code would pass against a fixture that never reached promotion.
+func TestRESTCommitStillWorksWithoutTurnover_6808(t *testing.T) {
+	store := restHolderStore(t)
+
+	s := &Server{
+		store: store,
+		commitFn: func(_ context.Context, a configstore.CommitAuthority, comment string) (*config.Config, error) {
+			_, gen, cerr := store.CompileCandidateGen()
+			if cerr != nil {
+				t.Fatalf("CompileCandidateGen: %v", cerr)
+			}
+			return store.CommitWithDescriptionGenAs(a, comment, gen)
+		},
+	}
+
+	rr := httptest.NewRecorder()
+	req := withRESTConfigSession(
+		httptest.NewRequest("POST", "/api/v1/config/commit", nil), testRESTConfigSessionID)
+	s.configCommitHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("REST commit with an UNCHANGED holder: status = %d, want 200; body: %s",
+			rr.Code, rr.Body.String())
+	}
+	active := store.ActiveConfig()
+	if active == nil || active.System.HostName != "staged-by-rest" {
+		got := ""
+		if active != nil {
+			got = active.System.HostName
+		}
+		t.Fatalf("host-name after the control commit = %q, want %q — the control must reach "+
+			"promotion, or it cannot distinguish 'accepted' from 'never got there'",
+			got, "staged-by-rest")
+	}
+	// The turnover sentinel must never surface on the happy path.
+	if errors.Is(errFromBody(rr), configstore.ErrConfigHolderTurnover) {
+		t.Error("a turnover error surfaced on an unchanged-holder commit")
+	}
+}
+
+// errFromBody is a tiny helper so the control can assert the turnover sentinel
+// is absent without depending on the error-rendering shape.
+func errFromBody(rr *httptest.ResponseRecorder) error {
+	if rr.Code == http.StatusOK {
+		return nil
+	}
+	return errors.New(rr.Body.String())
+}

--- a/pkg/api/config_session_holder_5870_test.go
+++ b/pkg/api/config_session_holder_5870_test.go
@@ -98,7 +98,7 @@ func TestRESTConfigCommitRejectedWhenOtherSessionHoldsCandidate(t *testing.T) {
 	var commitCalled bool
 	s := &Server{
 		store: store,
-		commitFn: func(context.Context, string) (*config.Config, error) {
+		commitFn: func(context.Context, configstore.CommitAuthority, string) (*config.Config, error) {
 			commitCalled = true
 			return store.Commit()
 		},

--- a/pkg/api/config_session_holder_6197_test.go
+++ b/pkg/api/config_session_holder_6197_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
 )
 
 const testRESTConfigSessionID = "rest-00000000000000000000000000000001"
@@ -67,7 +68,7 @@ func TestRESTConfigSessionsAreMutuallyExcluded(t *testing.T) {
 	commitCalled := false
 	s := &Server{
 		store: store,
-		commitFn: func(context.Context, string) (*config.Config, error) {
+		commitFn: func(context.Context, configstore.CommitAuthority, string) (*config.Config, error) {
 			commitCalled = true
 			return store.Commit()
 		},

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -156,8 +156,8 @@ type Config struct {
 	// two concurrent committers can't interleave their commit→apply
 	// pairs. Returns ctx.Err() if the request is canceled before the
 	// semaphore is acquired (handlers translate to 408/503).
-	CommitFn          func(ctx context.Context, comment string) (*config.Config, error)
-	CommitConfirmedFn func(ctx context.Context, minutes int) (*config.Config, error)
+	CommitFn          func(ctx context.Context, authority configstore.CommitAuthority, comment string) (*config.Config, error)
+	CommitConfirmedFn func(ctx context.Context, authority configstore.CommitAuthority, minutes int) (*config.Config, error)
 	// CompileHealthFn surfaces dataplane compile state via /health (#758).
 	// Returning a snapshot with EverSucceeded=false and FailureCount>0
 	// makes /health return 503 so operators see the degraded state
@@ -413,8 +413,8 @@ type Server struct {
 	ipsec                                *ipsec.Manager
 	dhcp                                 *dhcp.Manager
 	vrrpMgr                              *vrrp.Manager
-	commitFn                             func(ctx context.Context, comment string) (*config.Config, error)
-	commitConfirmedFn                    func(ctx context.Context, minutes int) (*config.Config, error)
+	commitFn                             func(ctx context.Context, authority configstore.CommitAuthority, comment string) (*config.Config, error)
+	commitConfirmedFn                    func(ctx context.Context, authority configstore.CommitAuthority, minutes int) (*config.Config, error)
 	compileHealthFn                      func() CompileHealthSnapshot
 	bootstrapImportFn                    func() BootstrapImportSnapshot
 	configPersistDegradedFn              func() bool

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -344,6 +344,84 @@ identity that participates in the config-lock gate (#5870/#6197, see
 "Config-lock ownership gate"). Generation binding remains necessary for
 same-session/internal concurrent callers.
 
+## Authority-bound commit: holder turnover (#6808)
+
+Generation binding answers *"is the candidate CONTENT the one that was
+examined?"*. It does **not** answer *"is the SESSION that was authorized to
+commit still the one holding the lock?"* — `CommitWithDescriptionGen` /
+`CommitConfirmedGen` take no session id at all. Those are different questions
+and neither implies the other.
+
+The gap that opened: the REST and gRPC commit paths verified the config-lock
+holder and then invoked a daemon callback carrying **no identity**
+(`s.commitFn(ctx, comment)`). Between the two, the lock could turn over — the
+holder exits, disconnects, or is reclaimed on its idle lease (#4476), and
+another session enters and stages different edits — and the in-flight commit
+would snapshot and promote the **new** holder's candidate under the **original**
+holder's authorization.
+
+Generation binding does not close it, and the retry loop makes it worse. A
+turnover that completes *before* the daemon's `CompileCandidateGen` — i.e. while
+the commit waits on the apply semaphore, which is where a busy daemon actually
+waits — yields a perfectly *consistent* generation pair, describing the new
+holder's candidate. And because `commitWithGenBinding` retries
+`ErrCandidateGenerationConflict` by design, a turnover reported as a generation
+conflict would make the retry re-snapshot and promote the new holder's work
+automatically.
+
+The fix binds the **authority**, checked under the same `s.mu` acquisition as
+the generation:
+
+- **`holderEpoch`** — a counter advanced on every config-lock ACQUISITION and
+  RELEASE (`EnterConfigureSession`, `EnterConfigureExclusive`,
+  `ExitConfigureSession`, `ExitConfigure`, `ForceExitConfigure`,
+  `reclaimStaleLockLocked`). It is distinct from `candidateGen`, which tracks
+  candidate *content*, and from `configLockAt`, a wall-clock stamp that cannot
+  distinguish a still-held lock from a released-and-retaken one. A same-session
+  re-entry does **not** advance it: the lock never changed hands.
+- **`AuthorizeCommit(sessionID) (CommitAuthority, error)`** — verifies the
+  holder and mints the authority under **one** lock acquisition. Two calls would
+  leave a window in which the lock turns over between "you are the holder" and
+  "here is the epoch you hold it at" — the same defect one level down. It
+  replaces `EnsureConfigHolder`, which had no remaining callers once every
+  commit path was converted.
+- **`CommitWithDescriptionGenAs` / `CommitConfirmedGenAs`** — verify the
+  authority AND the generation under one `s.mu`, immediately before promotion.
+- **`ErrConfigHolderTurnover`** — a sentinel deliberately DISTINCT from
+  `ErrCandidateGenerationConflict`, because the correct reaction is opposite: a
+  generation conflict means "re-examine and retry"; a turnover means "the
+  authority that permitted this commit is gone", and retrying would perform the
+  substitution.
+
+### The zero value is invalid, not a bypass
+
+`CommitAuthority`'s zero value is **rejected** with `ErrCommitAuthorityMissing`.
+An internal/system committer (HA config-sync apply, event engine, in-process
+shell CLI, tests) must say so explicitly with `InternalCommitter()`.
+
+This is the point of the design, not an ornament. Letting the zero value mean
+"internal committer, skip the check" would put the god-mode capability at exactly
+the value a forgotten field or a `CommitAuthority{}` written in good faith
+already produces. The explicit parameter would then catch *omission* — it would
+not compile — while silently admitting a **wrong-but-compiling zero** that reads
+as deliberate in review. Splitting "this caller legitimately has no holder" from
+"nobody said" makes the first a written statement and the second an error.
+
+The authority travels as an explicit **parameter**, not on a `Context`, for the
+same reason: an absent context value is indistinguishable from a deliberate one
+and would degrade silently to a bypass on an authorization path.
+
+### Scope
+
+The identical gate-then-unscoped-callback shape existed at **four** sites, not
+the two the issue title names: REST commit and commit-confirmed
+(`pkg/api/config.go`) and gRPC `Commit`/`CommitConfirmed`
+(`pkg/grpcapi/server_config.go`). gRPC additionally has a **non-adversarial**
+trigger — `configLockStatsHandler.HandleConn` auto-releases the lock on
+`ConnEnd` from a separate goroutine with no coordination with an in-flight
+commit, so an ordinary disconnect reaches the substitution with no attacker
+timing.
+
 ## Persist-failure semantics (#1799)
 
 A `db.WriteActive` failure used to be non-fatal everywhere (one-shot

--- a/pkg/configstore/commit_authority.go
+++ b/pkg/configstore/commit_authority.go
@@ -1,0 +1,166 @@
+package configstore
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrCommitAuthorityMissing is returned by the authority-bound commit entry
+// points when the caller passes a ZERO CommitAuthority (#6808).
+//
+// It exists so the zero value fails CLOSED. The obvious design — let the zero
+// value mean "internal committer, skip the holder check" — would put the
+// god-mode capability at the exact value a forgotten struct field, a
+// zero-initialised slot, or a `CommitAuthority{}` written by someone who did
+// not know better already produces. The explicit parameter would then catch
+// OMISSION (it would not compile) while silently admitting a
+// wrong-but-compiling zero, which reads as deliberate in review. Internal
+// committers must say so with InternalCommitter().
+var ErrCommitAuthorityMissing = errors.New(
+	"commit authority missing: the caller did not state whose authority this commit runs under " +
+		"(use configstore.InternalCommitter() for a system/daemon commit, or AuthorizeCommit for a session)")
+
+// ErrConfigHolderTurnover is returned when a commit that was authorized for one
+// config-lock holder reaches promotion after the lock has turned over — the
+// holder released it (explicitly, by disconnect, or by idle-lease reclaim) and
+// possibly another session acquired it and staged different work (#6808).
+//
+// It is a distinct sentinel from ErrCandidateGenerationConflict because the
+// correct reaction is the OPPOSITE. A generation conflict means "the content
+// moved, re-examine and retry" — commitWithGenBinding retries it deliberately.
+// A holder turnover means "the authority that permitted this commit is gone";
+// retrying would re-snapshot and promote the NEW holder's candidate under the
+// OLD holder's authorization, which is the substitution this closes. So this
+// sentinel must never be fed to that retry loop.
+var ErrConfigHolderTurnover = errors.New(
+	"config lock changed hands during commit preparation; the commit was not applied " +
+		"(re-enter configuration mode and commit again)")
+
+// commitAuthorityKind distinguishes the three states a CommitAuthority can be
+// in. The zero value is deliberately the INVALID one — see
+// ErrCommitAuthorityMissing.
+type commitAuthorityKind uint8
+
+const (
+	// authorityUnset is the zero value: no authority was stated. Rejected.
+	authorityUnset commitAuthorityKind = iota
+	// authorityInternal is a system/daemon committer that legitimately carries
+	// no config-lock session (HA sync, event engine, in-process CLI, tests).
+	authorityInternal
+	// authorityHolder is a transport session that passed the holder gate, bound
+	// to the holder identity AND the epoch observed at that moment.
+	authorityHolder
+)
+
+// CommitAuthority states whose authority a commit transaction runs under, and
+// is verified again at promotion under the store lock (#6808).
+//
+// The defect it closes: the REST and gRPC commit paths verified the config-lock
+// holder, then invoked a daemon callback carrying NO identity. Between the two,
+// the lock could turn over — the holder exits, disconnects, or is reclaimed on
+// its idle lease, and another session enters and stages different edits — and
+// the in-flight commit would snapshot and promote the NEW holder's candidate
+// under the ORIGINAL holder's authorization.
+//
+// The #5848 candidate-generation binding does not close it. That binding proves
+// the candidate CONTENT did not move between the daemon's snapshot and the
+// promotion; it says nothing about WHO holds the lock, takes no session id, and
+// a turnover completing BEFORE the snapshot (i.e. while the commit waits on the
+// apply semaphore, which is where a busy daemon actually waits) yields a
+// perfectly consistent generation pair describing the new holder's candidate.
+//
+// It is passed as an explicit parameter rather than carried on a Context so a
+// caller cannot omit it: an absent context value is indistinguishable from a
+// deliberate one and would degrade silently to a bypass on an authorization
+// path.
+type CommitAuthority struct {
+	kind      commitAuthorityKind
+	sessionID string
+	// epoch is the holder epoch observed when this authority was minted. It
+	// distinguishes "the same session still holds the lock" from "the lock was
+	// released and re-acquired", which the session id alone cannot: the same
+	// session can legitimately re-enter, and a wall-clock stamp cannot tell a
+	// held lock from a re-taken one.
+	epoch uint64
+}
+
+// InternalCommitter returns the authority for a system/daemon commit that
+// legitimately carries no config-lock session — the HA config-sync apply, the
+// event engine, the in-process shell CLI, and tests. It mirrors the long
+// standing sessionID == "" bypass in ensureHolderLocked, but as a WRITTEN
+// STATEMENT rather than the absence of one, so "this caller has no holder" and
+// "somebody forgot to say" are different values (#6808).
+func InternalCommitter() CommitAuthority {
+	return CommitAuthority{kind: authorityInternal}
+}
+
+// IsInternal reports whether a is the system/daemon authority. Exported for the
+// daemon's logging and for tests asserting which authority a path used.
+func (a CommitAuthority) IsInternal() bool { return a.kind == authorityInternal }
+
+// SessionID returns the config session this authority is bound to, or "" for an
+// internal or unset authority.
+func (a CommitAuthority) SessionID() string { return a.sessionID }
+
+// verifyCommitAuthorityLocked re-checks at promotion time that the authority a
+// commit was granted still holds. Caller holds s.mu — the check and the
+// promotion it guards MUST be atomic, or the turnover simply moves into the gap
+// between them.
+func (s *Store) verifyCommitAuthorityLocked(a CommitAuthority) error {
+	switch a.kind {
+	case authorityInternal:
+		return nil
+	case authorityHolder:
+		holder := s.effectiveHolderLocked()
+		if holder != a.sessionID || s.holderEpoch != a.epoch {
+			return fmt.Errorf("%w (authorized for session %q at holder epoch %d; now %q at epoch %d)",
+				ErrConfigHolderTurnover, a.sessionID, a.epoch, holder, s.holderEpoch)
+		}
+		return nil
+	default:
+		return ErrCommitAuthorityMissing
+	}
+}
+
+// AuthorizeCommit verifies that sessionID may commit and mints the authority to
+// be re-verified at promotion, both under a SINGLE acquisition of s.mu (#6808).
+//
+// Doing the check and the mint under one lock acquisition is the point: two
+// calls would leave a window in which the lock turns over between "you are the
+// holder" and "here is the epoch you hold it at", which is the same defect one
+// level down.
+//
+// It is the authority-bearing replacement for EnsureConfigHolder on the
+// commit-family paths. sessionID == "" yields InternalCommitter(), matching the
+// documented internal/system bypass in ensureHolderLocked.
+func (s *Store) AuthorizeCommit(sessionID string) (CommitAuthority, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.ensureHolderLocked(sessionID); err != nil {
+		return CommitAuthority{}, err
+	}
+	if sessionID == "" {
+		return InternalCommitter(), nil
+	}
+	// A session that passed ensureHolderLocked while NOT in config mode, or
+	// against an unowned lock, holds nothing an epoch could bind — both are
+	// documented bypasses of the holder check, not ownership. Treat them as
+	// internal so behaviour is unchanged for those paths; the turnover this
+	// closes requires a real recorded holder.
+	if !s.configDir || s.effectiveHolderLocked() == "" {
+		return InternalCommitter(), nil
+	}
+	return CommitAuthority{
+		kind:      authorityHolder,
+		sessionID: sessionID,
+		epoch:     s.holderEpoch,
+	}, nil
+}
+
+// HolderEpoch returns the current holder epoch. Exported for tests asserting
+// that acquisition and release advance it.
+func (s *Store) HolderEpoch() uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.holderEpoch
+}

--- a/pkg/configstore/commit_authority_6808_test.go
+++ b/pkg/configstore/commit_authority_6808_test.go
@@ -1,0 +1,326 @@
+package configstore
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+// #6808: the commit paths verified the config-lock holder and then promoted
+// through a callback carrying NO identity, so the lock could turn over in
+// between and the in-flight commit would promote the NEW holder's candidate
+// under the ORIGINAL holder's authorization.
+//
+// These are the ENFORCEMENT cells — that the store refuses a promotion whose
+// authority no longer holds. The WIRING cells (that each transport actually
+// mints a bound authority and hands it over) live in pkg/api and pkg/grpcapi,
+// because a store that refuses correctly proves nothing if a handler passes
+// InternalCommitter() instead.
+
+// authTestStore returns a store in config mode held by sessionID, with one
+// staged edit so the candidate is non-empty and a promotion has something to do.
+func authTestStore(t *testing.T, sessionID string) *Store {
+	t.Helper()
+	s, err := New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := s.EnterConfigureSession(sessionID); err != nil {
+		t.Fatalf("EnterConfigureSession(%s): %v", sessionID, err)
+	}
+	if err := s.SetAs(sessionID, []string{"system", "host-name", sessionID + "-host"}); err != nil {
+		t.Fatalf("SetAs(%s): %v", sessionID, err)
+	}
+	return s
+}
+
+// hostName reads the committed host-name so a cell can assert WHOSE candidate
+// was promoted, not merely that some promotion happened.
+func hostName(t *testing.T, s *Store) string {
+	t.Helper()
+	active := s.ActiveConfig()
+	if active == nil {
+		return ""
+	}
+	return active.System.HostName
+}
+
+// TestCommitAuthorityZeroValueIsRejected_6808 pins the fail-CLOSED zero value.
+//
+// The tempting design is to let the zero CommitAuthority mean "internal
+// committer, skip the holder check". That puts the god-mode capability at
+// exactly the value a forgotten field, a zero-initialised slot, or a
+// `CommitAuthority{}` written in good faith already produces — so the explicit
+// parameter would catch OMISSION (it would not compile) while silently
+// admitting a wrong-but-compiling zero that reads as deliberate in review.
+//
+// FAIL-ON-REVERT: change verifyCommitAuthorityLocked's `default` arm to return
+// nil (i.e. treat an unset authority as a bypass) and this REDS.
+func TestCommitAuthorityZeroValueIsRejected_6808(t *testing.T) {
+	s := authTestStore(t, "owner")
+	_, gen, err := s.CompileCandidateGen()
+	if err != nil {
+		t.Fatalf("CompileCandidateGen: %v", err)
+	}
+
+	_, err = s.CommitWithDescriptionGenAs(CommitAuthority{}, "", gen)
+	if !errors.Is(err, ErrCommitAuthorityMissing) {
+		t.Errorf("CommitWithDescriptionGenAs(zero authority) = %v, want ErrCommitAuthorityMissing. "+
+			"A zero authority means the caller never stated whose authority the commit runs "+
+			"under; treating it as an internal committer hands it the bypass (#6808)", err)
+	}
+	if got := hostName(t, s); got != "" {
+		t.Errorf("a zero-authority commit PROMOTED (host-name=%q); it must not mutate store state", got)
+	}
+
+	_, err = s.CommitConfirmedGenAs(CommitAuthority{}, 5, gen)
+	if !errors.Is(err, ErrCommitAuthorityMissing) {
+		t.Errorf("CommitConfirmedGenAs(zero authority) = %v, want ErrCommitAuthorityMissing", err)
+	}
+
+	// Paired control: the EXPLICIT internal authority is accepted, on the same
+	// store and the same generation. Without it, "reject everything" passes the
+	// assertions above — and rejecting every internal commit would break the HA
+	// config-sync apply, the event engine, and the local shell.
+	if _, err := s.CommitWithDescriptionGenAs(InternalCommitter(), "", gen); err != nil {
+		t.Fatalf("CommitWithDescriptionGenAs(InternalCommitter) = %v, want nil — "+
+			"an explicit internal committer must still be able to commit", err)
+	}
+	if got := hostName(t, s); got != "owner-host" {
+		t.Errorf("host-name after internal commit = %q, want %q — the control must actually "+
+			"reach promotion, or it cannot distinguish 'accepted' from 'never got there'", got, "owner-host")
+	}
+}
+
+// TestHolderEpochAdvancesOnAcquireAndRelease_6808 pins the epoch itself.
+//
+// The epoch is what lets a stale authority be detected: the session id alone
+// cannot, because the same id can legitimately release and re-acquire, and
+// configLockAt is a wall-clock stamp that cannot tell a held lock from a
+// re-taken one.
+//
+// FAIL-ON-REVERT: delete any single `s.holderEpoch++` in store_lock.go and the
+// corresponding row REDS.
+func TestHolderEpochAdvancesOnAcquireAndRelease_6808(t *testing.T) {
+	s, err := New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	step := func(name string, fn func()) uint64 {
+		before := s.HolderEpoch()
+		fn()
+		after := s.HolderEpoch()
+		if after == before {
+			t.Errorf("%s did not advance the holder epoch (still %d); a commit authorized "+
+				"before it would still verify, and the lock changed hands (#6808)", name, before)
+		}
+		return after
+	}
+
+	step("EnterConfigureSession", func() {
+		if err := s.EnterConfigureSession("a"); err != nil {
+			t.Fatalf("enter: %v", err)
+		}
+	})
+	step("ExitConfigureSession", func() {
+		if !s.ExitConfigureSession("a") {
+			t.Fatal("exit returned false")
+		}
+	})
+	step("EnterConfigureExclusive", func() {
+		if err := s.EnterConfigureExclusive("x"); err != nil {
+			t.Fatalf("enter exclusive: %v", err)
+		}
+	})
+	step("ForceExitConfigure", func() { s.ForceExitConfigure() })
+	step("re-enter", func() {
+		if err := s.EnterConfigureSession("b"); err != nil {
+			t.Fatalf("re-enter: %v", err)
+		}
+	})
+	step("ExitConfigure", func() { s.ExitConfigure() })
+
+	// Control: a SAME-SESSION re-entry is not a turnover — the lock never left
+	// that session — so it must NOT advance the epoch and must not invalidate an
+	// authority already minted for it. Without this row, "bump on every call"
+	// passes every row above while needlessly failing a legitimate re-entrant
+	// commit.
+	if err := s.EnterConfigureSession("c"); err != nil {
+		t.Fatalf("enter c: %v", err)
+	}
+	before := s.HolderEpoch()
+	if err := s.EnterConfigureSession("c"); err != nil {
+		t.Fatalf("re-enter c: %v", err)
+	}
+	if got := s.HolderEpoch(); got != before {
+		t.Errorf("same-session re-entry advanced the holder epoch (%d -> %d); the lock did "+
+			"not change hands, so an authority minted for that session must stay valid", before, got)
+	}
+}
+
+// TestCommitRefusedAfterHolderTurnover_6808 is the core cell: the exact
+// substitution R69 describes, driven through the store.
+//
+// Session A is authorized to commit. Before the promotion lands, the lock turns
+// over — A releases (explicitly, or by disconnect, or by idle-lease reclaim) and
+// B enters and stages DIFFERENT work. A's promotion must be REFUSED, and B's
+// host-name must not become active under A's authorization.
+//
+// The fixture stages a distinguishable edit per session deliberately: asserting
+// only "an error came back" would pass against a store that refuses everything,
+// and asserting only "something was promoted" cannot tell A's work from B's.
+//
+// FAIL-ON-REVERT: delete the verifyCommitAuthorityLocked call from
+// CommitWithDescriptionGenAs and this REDS — the generation check alone accepts
+// the promotion, because after the turnover the generation is perfectly
+// consistent; it just describes B's candidate.
+func TestCommitRefusedAfterHolderTurnover_6808(t *testing.T) {
+	s := authTestStore(t, "sessionA")
+
+	authority, err := s.AuthorizeCommit("sessionA")
+	if err != nil {
+		t.Fatalf("AuthorizeCommit(sessionA): %v", err)
+	}
+
+	// --- the turnover, in the window between authorization and promotion ---
+	if !s.ExitConfigureSession("sessionA") {
+		t.Fatal("ExitConfigureSession(sessionA) returned false")
+	}
+	if err := s.EnterConfigureSession("sessionB"); err != nil {
+		t.Fatalf("EnterConfigureSession(sessionB): %v", err)
+	}
+	if err := s.SetAs("sessionB", []string{"system", "host-name", "sessionB-host"}); err != nil {
+		t.Fatalf("SetAs(sessionB): %v", err)
+	}
+
+	// A now snapshots and promotes, exactly as the daemon would.
+	_, gen, cerr := s.CompileCandidateGen()
+	if cerr != nil {
+		t.Fatalf("CompileCandidateGen: %v", cerr)
+	}
+	_, err = s.CommitWithDescriptionGenAs(authority, "", gen)
+
+	if !errors.Is(err, ErrConfigHolderTurnover) {
+		t.Fatalf("commit after holder turnover = %v, want ErrConfigHolderTurnover. "+
+			"Session A's authorization promoted session B's candidate — the substitution "+
+			"#6808 closes", err)
+	}
+	if got := hostName(t, s); got == "sessionB-host" {
+		t.Fatalf("session B's candidate was PROMOTED under session A's authority "+
+			"(host-name=%q)", got)
+	}
+	if got := hostName(t, s); got != "" {
+		t.Fatalf("host-name = %q, want empty: a refused commit must not promote anything", got)
+	}
+}
+
+// TestTurnoverSentinelIsNotGenerationConflict_6808 pins the two sentinels apart.
+//
+// This matters more than it looks. The daemon's commitWithGenBinding RETRIES on
+// ErrCandidateGenerationConflict by design — it re-snapshots and re-promotes
+// against the fresh generation. If a holder turnover were reported as a
+// generation conflict, that retry would re-snapshot the NEW holder's candidate
+// and promote it under the OLD holder's authority: the retry loop would perform
+// the substitution automatically, on every turnover, with no race needed.
+//
+// FAIL-ON-REVERT: make verifyCommitAuthorityLocked return a wrapped
+// ErrCandidateGenerationConflict and this REDS.
+func TestTurnoverSentinelIsNotGenerationConflict_6808(t *testing.T) {
+	s := authTestStore(t, "sessionA")
+	authority, err := s.AuthorizeCommit("sessionA")
+	if err != nil {
+		t.Fatalf("AuthorizeCommit: %v", err)
+	}
+	if !s.ExitConfigureSession("sessionA") {
+		t.Fatal("exit returned false")
+	}
+	if err := s.EnterConfigureSession("sessionB"); err != nil {
+		t.Fatalf("enter B: %v", err)
+	}
+	_, gen, _ := s.CompileCandidateGen()
+
+	_, err = s.CommitWithDescriptionGenAs(authority, "", gen)
+	if !errors.Is(err, ErrConfigHolderTurnover) {
+		t.Fatalf("want ErrConfigHolderTurnover, got %v", err)
+	}
+	if errors.Is(err, ErrCandidateGenerationConflict) {
+		t.Error("a holder turnover is reported as a candidate-GENERATION conflict. " +
+			"commitWithGenBinding retries that sentinel by design, so the retry would " +
+			"re-snapshot and promote the NEW holder's candidate under the OLD holder's " +
+			"authority — the retry loop would automate the substitution (#6808)")
+	}
+}
+
+// TestCommitConfirmedRefusedAfterHolderTurnover_6808 is the commit-confirmed
+// half. It is the higher-consequence one: a substituted commit-confirmed both
+// applies work its author never approved AND arms an auto-rollback timer against
+// it, so the authorized operator is left with a revert pending that they did not
+// schedule.
+//
+// FAIL-ON-REVERT: delete the verifyCommitAuthorityLocked call from
+// CommitConfirmedGenAs and this REDS. It is a SEPARATE cell from the plain-commit
+// one deliberately — the two entry points have independent checks, and a single
+// cell covering only one would report the other as guarded when it is not.
+func TestCommitConfirmedRefusedAfterHolderTurnover_6808(t *testing.T) {
+	s := authTestStore(t, "sessionA")
+	authority, err := s.AuthorizeCommit("sessionA")
+	if err != nil {
+		t.Fatalf("AuthorizeCommit: %v", err)
+	}
+	if !s.ExitConfigureSession("sessionA") {
+		t.Fatal("exit returned false")
+	}
+	if err := s.EnterConfigureSession("sessionB"); err != nil {
+		t.Fatalf("enter B: %v", err)
+	}
+	if err := s.SetAs("sessionB", []string{"system", "host-name", "sessionB-host"}); err != nil {
+		t.Fatalf("SetAs(B): %v", err)
+	}
+	_, gen, _ := s.CompileCandidateGen()
+
+	_, err = s.CommitConfirmedGenAs(authority, 5, gen)
+	if !errors.Is(err, ErrConfigHolderTurnover) {
+		t.Fatalf("commit-confirmed after turnover = %v, want ErrConfigHolderTurnover", err)
+	}
+	if s.IsConfirmPending() {
+		t.Error("a REFUSED commit-confirmed armed the auto-rollback timer; the operator " +
+			"now has a revert pending against a commit that never happened (#6808)")
+	}
+	if got := hostName(t, s); got == "sessionB-host" {
+		t.Fatalf("session B's candidate was promoted+armed under session A's authority")
+	}
+}
+
+// TestUnchangedHolderStillCommits_6808 is the control the whole set depends on:
+// a commit whose holder has NOT turned over must still succeed, through the
+// authority-bound entry points, and must actually PROMOTE.
+//
+// Without it, "refuse every authority" satisfies every refusal cell above — and
+// refusing every commit is a total configuration outage, a far worse failure
+// than the one being fixed. The host-name assertion is what makes it real: a
+// control that only checked `err == nil` would pass against a fixture that never
+// reached promotion at all.
+func TestUnchangedHolderStillCommits_6808(t *testing.T) {
+	s := authTestStore(t, "sessionA")
+	authority, err := s.AuthorizeCommit("sessionA")
+	if err != nil {
+		t.Fatalf("AuthorizeCommit: %v", err)
+	}
+	if authority.IsInternal() {
+		t.Fatal("the holder's authority came back INTERNAL; it would then satisfy every " +
+			"turnover check and this control would pass without testing anything")
+	}
+	_, gen, cerr := s.CompileCandidateGen()
+	if cerr != nil {
+		t.Fatalf("CompileCandidateGen: %v", cerr)
+	}
+	if _, err := s.CommitWithDescriptionGenAs(authority, "", gen); err != nil {
+		t.Fatalf("commit with an UNCHANGED holder = %v, want nil — the fix must not "+
+			"refuse legitimate commits", err)
+	}
+	if got := hostName(t, s); got != "sessionA-host" {
+		t.Fatalf("host-name after the control commit = %q, want %q — the control must reach "+
+			"promotion, or it cannot tell 'accepted' from 'never got there'", got, "sessionA-host")
+	}
+}

--- a/pkg/configstore/config_lock_holder_5059_test.go
+++ b/pkg/configstore/config_lock_holder_5059_test.go
@@ -66,8 +66,13 @@ func TestStoreMutatorHolderEnforcement(t *testing.T) {
 	}
 }
 
-// TestEnsureConfigHolder covers the exported gate the commit-family RPCs use.
-func TestEnsureConfigHolder(t *testing.T) {
+// TestAuthorizeCommitHolderGate covers the exported gate the commit-family RPCs
+// use. It MOVED here from TestEnsureConfigHolder when #6808 replaced
+// EnsureConfigHolder with AuthorizeCommit: the #5059 property (only the holder
+// may reach a commit; the internal caller bypasses) did not change, but the
+// function that enforces it did. Leaving the test on the old symbol would have
+// kept it green while guarding a function no commit path calls any more.
+func TestAuthorizeCommitHolderGate(t *testing.T) {
 	store, err := New(filepath.Join(t.TempDir(), "xpf.conf"))
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -75,13 +80,28 @@ func TestEnsureConfigHolder(t *testing.T) {
 	if err := store.EnterConfigureSession("owner"); err != nil {
 		t.Fatalf("EnterConfigureSession: %v", err)
 	}
-	if err := store.EnsureConfigHolder("intruder"); !errors.Is(err, ErrConfigLockedByOther) {
-		t.Errorf("EnsureConfigHolder(non-holder) = %v, want ErrConfigLockedByOther", err)
+	if _, err := store.AuthorizeCommit("intruder"); !errors.Is(err, ErrConfigLockedByOther) {
+		t.Errorf("AuthorizeCommit(non-holder) = %v, want ErrConfigLockedByOther", err)
 	}
-	if err := store.EnsureConfigHolder("owner"); err != nil {
-		t.Errorf("EnsureConfigHolder(holder) = %v, want nil", err)
+	auth, err := store.AuthorizeCommit("owner")
+	if err != nil {
+		t.Errorf("AuthorizeCommit(holder) = %v, want nil", err)
 	}
-	if err := store.EnsureConfigHolder(""); err != nil {
-		t.Errorf("EnsureConfigHolder(internal) = %v, want nil", err)
+	// #6808: the holder's authority must be BOUND, not internal — an authority
+	// that came back internal would satisfy every promotion check and silently
+	// restore the pre-#6808 behaviour.
+	if auth.IsInternal() {
+		t.Error("AuthorizeCommit(holder) returned an INTERNAL authority; the holder's " +
+			"commit would then bypass the turnover check entirely (#6808)")
+	}
+	if auth.SessionID() != "owner" {
+		t.Errorf("AuthorizeCommit(holder).SessionID() = %q, want \"owner\"", auth.SessionID())
+	}
+	internal, err := store.AuthorizeCommit("")
+	if err != nil {
+		t.Errorf("AuthorizeCommit(internal) = %v, want nil", err)
+	}
+	if !internal.IsInternal() {
+		t.Error("AuthorizeCommit(\"\") did not yield an internal authority")
 	}
 }

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -217,6 +217,16 @@ type Store struct {
 	configHolder string    // unique session ID of the config lock holder
 	configLockAt time.Time // when the lock was acquired
 
+	// holderEpoch advances on every config-lock ACQUISITION and RELEASE, so a
+	// commit authorized for one holder can detect that the lock turned over
+	// before it reached promotion (#6808). It is deliberately separate from
+	// candidateGen, which tracks candidate CONTENT: a turnover can leave
+	// content-consistent state (B enters and stages edits, bumping candidateGen
+	// in ways A's in-flight commit re-reads consistently), and configLockAt is a
+	// wall-clock stamp that cannot distinguish a still-held lock from a
+	// released-and-retaken one. Only a counter keyed to acquisition can.
+	holderEpoch uint64
+
 	// Cluster read-only mode: secondary nodes reject config mutations
 	clusterReadOnly bool
 

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -120,8 +120,37 @@ func (s *Store) CommitWithDescription(description string) (*config.Config, error
 // daemon pre-flighted against live hardware is exactly the one promoted, or the
 // commit conflicts — never a silent substitution.
 func (s *Store) CommitWithDescriptionGen(description string, expectedGen uint64) (*config.Config, error) {
+	return s.CommitWithDescriptionGenAs(InternalCommitter(), description, expectedGen)
+}
+
+// CommitWithDescriptionGenAs is CommitWithDescriptionGen additionally bound to
+// the AUTHORITY the commit was granted under (#6808).
+//
+// It verifies BOTH tokens under one acquisition of s.mu, immediately before
+// promotion, because they answer different questions and neither implies the
+// other:
+//
+//   - expectedGen answers "is the candidate CONTENT the one that was examined?"
+//   - authority answers "is the SESSION that was authorized to commit still the
+//     one holding the lock?"
+//
+// A holder turnover that completes before the caller's snapshot produces a
+// perfectly consistent generation pair — describing the NEW holder's candidate.
+// Only the authority check rejects that.
+//
+// On turnover it returns ErrConfigHolderTurnover, NOT
+// ErrCandidateGenerationConflict, so it can never be swept into the caller's
+// generation-conflict retry: retrying would re-snapshot the new holder's
+// candidate and promote it under the old holder's authorization, which is
+// precisely the substitution being closed.
+func (s *Store) CommitWithDescriptionGenAs(
+	authority CommitAuthority, description string, expectedGen uint64,
+) (*config.Config, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if err := s.verifyCommitAuthorityLocked(authority); err != nil {
+		return nil, err
+	}
 	if s.candidateGen != expectedGen {
 		return nil, fmt.Errorf("%w (examined generation %d, current %d)",
 			ErrCandidateGenerationConflict, expectedGen, s.candidateGen)
@@ -383,8 +412,26 @@ func (s *Store) CommitConfirmed(minutes int) (*config.Config, error) {
 // free) candidate generation is sufficient to keep both the promoted candidate
 // and the stashed rollback target bound to what was examined.
 func (s *Store) CommitConfirmedGen(minutes int, expectedGen uint64) (*config.Config, error) {
+	return s.CommitConfirmedGenAs(InternalCommitter(), minutes, expectedGen)
+}
+
+// CommitConfirmedGenAs is CommitConfirmedGen additionally bound to the commit
+// AUTHORITY (#6808) — the commit-confirmed analogue of
+// CommitWithDescriptionGenAs, with the same both-tokens-under-one-lock
+// discipline and the same distinct turnover sentinel.
+//
+// Commit-confirmed is the higher-consequence half: promoting another holder's
+// candidate ALSO arms an auto-rollback timer against it, so a substituted
+// commit-confirmed both applies work its author never approved and schedules a
+// revert the authorized operator does not know is pending.
+func (s *Store) CommitConfirmedGenAs(
+	authority CommitAuthority, minutes int, expectedGen uint64,
+) (*config.Config, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if err := s.verifyCommitAuthorityLocked(authority); err != nil {
+		return nil, err
+	}
 	if s.candidateGen != expectedGen {
 		return nil, fmt.Errorf("%w (examined generation %d, current %d)",
 			ErrCandidateGenerationConflict, expectedGen, s.candidateGen)

--- a/pkg/configstore/store_lock.go
+++ b/pkg/configstore/store_lock.go
@@ -60,18 +60,6 @@ func (s *Store) ensureHolderLocked(sessionID string) error {
 	return fmt.Errorf("%w", ErrConfigLockedByOther)
 }
 
-// EnsureConfigHolder atomically verifies that sessionID owns the config lock,
-// returning ErrConfigLockedByOther otherwise (#5059). It is the exported gate
-// used by the commit-family gRPC RPCs (Commit/CommitConfirmed) whose mutation
-// runs through a daemon callback rather than a single store method, so they
-// cannot thread the holder through an *As variant. sessionID == "" bypasses
-// (internal/system caller), matching ensureHolderLocked.
-func (s *Store) EnsureConfigHolder(sessionID string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.ensureHolderLocked(sessionID)
-}
-
 // configLockLeaseTTL bounds how long a config lock may sit idle — with no edit
 // activity — before a new entrant may reclaim it. #4476: the REST config-enter
 // path (POST /api/v1/config/enter) is stateless and has NO disconnect hook,
@@ -123,6 +111,9 @@ func (s *Store) reclaimStaleLockLocked() bool {
 	s.dirty = false
 	s.exclusiveHolder = ""
 	s.configHolder = ""
+	// #6808: the config lock changed hands — advance the holder epoch so a
+	// commit authorized under the previous holder cannot promote here.
+	s.holderEpoch++
 	s.editPath = nil
 	return true
 }
@@ -169,6 +160,9 @@ func (s *Store) EnterConfigureSession(sessionID string) error {
 	s.dirty = false
 	s.exclusiveHolder = ""
 	s.configHolder = sessionID
+	// #6808: the config lock changed hands — advance the holder epoch so a
+	// commit authorized under the previous holder cannot promote here.
+	s.holderEpoch++
 	s.configLockAt = time.Now()
 	s.editPath = nil
 	return nil
@@ -194,6 +188,9 @@ func (s *Store) EnterConfigureExclusive(holder string) error {
 	s.dirty = false
 	s.configHolder = ""
 	s.exclusiveHolder = holder
+	// #6808: the config lock changed hands — advance the holder epoch so a
+	// commit authorized under the previous holder cannot promote here.
+	s.holderEpoch++
 	s.configLockAt = time.Now()
 	s.editPath = nil
 	return nil
@@ -241,6 +238,9 @@ func (s *Store) ExitConfigureSession(sessionID string) bool {
 	s.dirty = false
 	s.exclusiveHolder = ""
 	s.configHolder = ""
+	// #6808: the config lock changed hands — advance the holder epoch so a
+	// commit authorized under the previous holder cannot promote here.
+	s.holderEpoch++
 	s.editPath = nil
 	return true
 }
@@ -261,6 +261,9 @@ func (s *Store) ForceExitConfigure() {
 	s.dirty = false
 	s.exclusiveHolder = ""
 	s.configHolder = ""
+	// #6808: the config lock changed hands — advance the holder epoch so a
+	// commit authorized under the previous holder cannot promote here.
+	s.holderEpoch++
 	s.editPath = nil
 }
 
@@ -283,6 +286,16 @@ func (s *Store) IsExclusiveLocked() bool {
 }
 
 // ExitConfigure exits configuration mode, discarding the candidate.
+//
+// NOTE (#6808): this clears exclusiveHolder but deliberately leaves
+// configHolder set — an asymmetry with ExitConfigureSession/ForceExitConfigure
+// that predates this change and is tracked separately. It is not exploitable
+// today only because ensureHolderLocked short-circuits on !s.configDir, i.e.
+// its safety rests on that short-circuit rather than on the field being clean.
+// The holder-epoch bump below is what makes this path safe for #6808 WITHOUT
+// depending on that: leaving config mode advances the epoch, so a commit
+// authorized before it fails verification regardless of the stale configHolder
+// string an epoch keyed off configHolder alone would have trusted.
 func (s *Store) ExitConfigure() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -291,6 +304,8 @@ func (s *Store) ExitConfigure() {
 	s.configDir = false
 	s.dirty = false
 	s.exclusiveHolder = ""
+	// #6808: the config lock was released — advance the holder epoch.
+	s.holderEpoch++
 	s.editPath = nil
 }
 

--- a/pkg/daemon/apply_serialize_test.go
+++ b/pkg/daemon/apply_serialize_test.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
 )
 
 // applyConfig must serialize concurrent callers via d.applySem.
@@ -84,13 +85,13 @@ func TestCommitAndApplyRespectsSemaphore(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
-	if _, err := d.commitAndApply(ctx, "", peerSyncNever); !errors.Is(err, context.DeadlineExceeded) {
+	if _, err := d.commitAndApply(ctx, configstore.InternalCommitter(), "", peerSyncNever); !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("commitAndApply must surface ctx err while semaphore is held; got %v", err)
 	}
 
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel2()
-	if _, err := d.commitConfirmedAndApply(ctx2, 1, peerSyncNever); !errors.Is(err, context.DeadlineExceeded) {
+	if _, err := d.commitConfirmedAndApply(ctx2, configstore.InternalCommitter(), 1, peerSyncNever); !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("commitConfirmedAndApply must surface ctx err while semaphore is held; got %v", err)
 	}
 }

--- a/pkg/daemon/cluster_identity_preflight_6192_test.go
+++ b/pkg/daemon/cluster_identity_preflight_6192_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/cluster"
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -118,7 +119,7 @@ func TestClusterIdentityDay2ChangeRejected(t *testing.T) {
 	}
 
 	d := &Daemon{store: store, applySem: semaphore.NewWeighted(1), cluster: running}
-	_, capErr := d.commitAndApply(context.Background(), "change cluster-id", peerSyncNever)
+	_, capErr := d.commitAndApply(context.Background(), configstore.InternalCommitter(), "change cluster-id", peerSyncNever)
 	if capErr == nil || !errors.Is(capErr, errClusterIdentityRequiresRestart) {
 		t.Fatalf("commitAndApply of a day-2 cluster-id change must be rejected with the "+
 			"identity-restart sentinel; got %v", capErr)

--- a/pkg/daemon/cluster_topology_preflight_5840_test.go
+++ b/pkg/daemon/cluster_topology_preflight_5840_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -116,7 +117,7 @@ func TestClusterTopologyDay2TransitionRejected(t *testing.T) {
 	}
 
 	d := &Daemon{store: store, applySem: semaphore.NewWeighted(1)}
-	_, cerr := d.commitAndApply(context.Background(), "add chassis cluster", peerSyncNever)
+	_, cerr := d.commitAndApply(context.Background(), configstore.InternalCommitter(), "add chassis cluster", peerSyncNever)
 	if cerr == nil || !errors.Is(cerr, errClusterTopologyRequiresRestart) {
 		t.Fatalf("commitAndApply of a standalone->cluster transition must be "+
 			"rejected with the restart-required sentinel; got %v", cerr)
@@ -160,7 +161,7 @@ func TestClusterTopologyDay2TransitionRejected(t *testing.T) {
 	}
 
 	dcl := &Daemon{store: cfgless, applySem: semaphore.NewWeighted(1)}
-	_, clErr := dcl.commitAndApply(context.Background(), "config-less add chassis cluster", peerSyncNever)
+	_, clErr := dcl.commitAndApply(context.Background(), configstore.InternalCommitter(), "config-less add chassis cluster", peerSyncNever)
 	if clErr == nil || !errors.Is(clErr, errClusterTopologyRequiresRestart) {
 		t.Fatalf("commitAndApply on a config-less node (nil active, nil runtime) adding "+
 			"chassis cluster must be rejected with the restart-required sentinel; got %v", clErr)

--- a/pkg/daemon/configsync_tail_error_test.go
+++ b/pkg/daemon/configsync_tail_error_test.go
@@ -82,7 +82,7 @@ func TestCommitAndApplySyncsPeerOnNonFatalApplyError(t *testing.T) {
 		syncedText = d.store.ShowActive()
 	}
 
-	compiled, err := d.commitAndApply(t.Context(), "", peerSyncAlways)
+	compiled, err := d.commitAndApply(t.Context(), configstore.InternalCommitter(), "", peerSyncAlways)
 
 	// The apply error must surface to the operator (fail-closed commit).
 	if !errors.Is(err, nonFatal) {
@@ -121,7 +121,7 @@ func TestCommitAndApplySyncsPeerOnCleanCommit(t *testing.T) {
 	var syncCalls int
 	d.syncPeerForTest = func() { syncCalls++ }
 
-	compiled, err := d.commitAndApply(t.Context(), "", peerSyncAlways)
+	compiled, err := d.commitAndApply(t.Context(), configstore.InternalCommitter(), "", peerSyncAlways)
 	if err != nil {
 		t.Fatalf("clean commit must succeed; got %v", err)
 	}
@@ -145,7 +145,7 @@ func TestCommitAndApplySkipsPeerSyncOnFatalApplyError(t *testing.T) {
 	var syncCalls int
 	d.syncPeerForTest = func() { syncCalls++ }
 
-	compiled, err := d.commitAndApply(t.Context(), "", peerSyncAlways)
+	compiled, err := d.commitAndApply(t.Context(), configstore.InternalCommitter(), "", peerSyncAlways)
 	if !errors.Is(err, dpuserspace.ErrPolicySchedulerProtocolIncompatible) {
 		t.Fatalf("fatal apply error must surface; got %v", err)
 	}
@@ -170,7 +170,7 @@ func TestCommitAndApplySkipsPeerSyncOnContextAbort(t *testing.T) {
 	var syncCalls int
 	d.syncPeerForTest = func() { syncCalls++ }
 
-	_, err := d.commitAndApply(t.Context(), "", peerSyncAlways)
+	_, err := d.commitAndApply(t.Context(), configstore.InternalCommitter(), "", peerSyncAlways)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("context abort must surface; got %v", err)
 	}
@@ -192,7 +192,7 @@ func TestCommitConfirmedAndApplySyncsPeerOnNonFatalApplyError(t *testing.T) {
 	var syncCalls int
 	d.syncPeerForTest = func() { syncCalls++ }
 
-	compiled, err := d.commitConfirmedAndApply(t.Context(), 1, peerSyncAlways)
+	compiled, err := d.commitConfirmedAndApply(t.Context(), configstore.InternalCommitter(), 1, peerSyncAlways)
 	if !errors.Is(err, nonFatal) {
 		t.Fatalf("commitConfirmedAndApply must surface the non-fatal apply error; got %v", err)
 	}

--- a/pkg/daemon/configsync_toctou_5962_test.go
+++ b/pkg/daemon/configsync_toctou_5962_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/cluster"
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
 )
 
 // setRG0Ownership drives a live cluster.Manager across the RG0-authority
@@ -64,7 +65,7 @@ func TestOperatorCommitResolvesPeerSyncAtPushTime(t *testing.T) {
 		d, calls := newSyncProbeDaemon(t, cl)
 		d.applyBodyForTest = func(_ *config.Config) { setRG0Ownership(t, cl, true) }
 
-		if _, err := d.commitAndApplyOperator(t.Context(), ""); err != nil {
+		if _, err := d.commitAndApplyOperator(t.Context(), configstore.InternalCommitter(), ""); err != nil {
 			t.Fatalf("commitAndApplyOperator: %v", err)
 		}
 		if *calls != 1 {
@@ -81,7 +82,7 @@ func TestOperatorCommitResolvesPeerSyncAtPushTime(t *testing.T) {
 		d, calls := newSyncProbeDaemon(t, cl)
 		d.applyBodyForTest = func(_ *config.Config) { setRG0Ownership(t, cl, false) }
 
-		if _, err := d.commitAndApplyOperator(t.Context(), ""); err != nil {
+		if _, err := d.commitAndApplyOperator(t.Context(), configstore.InternalCommitter(), ""); err != nil {
 			t.Fatalf("commitAndApplyOperator: %v", err)
 		}
 		if *calls != 0 {
@@ -96,7 +97,7 @@ func TestOperatorCommitResolvesPeerSyncAtPushTime(t *testing.T) {
 	// always pushed would pass the promotion case above.
 	t.Run("stable owner: pushes once (control)", func(t *testing.T) {
 		d, calls := newSyncProbeDaemon(t, clusterOwningRG0(t))
-		if _, err := d.commitAndApplyOperator(t.Context(), ""); err != nil {
+		if _, err := d.commitAndApplyOperator(t.Context(), configstore.InternalCommitter(), ""); err != nil {
 			t.Fatalf("commitAndApplyOperator: %v", err)
 		}
 		if *calls != 1 {
@@ -106,7 +107,7 @@ func TestOperatorCommitResolvesPeerSyncAtPushTime(t *testing.T) {
 
 	t.Run("stable non-owner: never pushes (control)", func(t *testing.T) {
 		d, calls := newSyncProbeDaemon(t, clusterNotOwningRG0(t))
-		if _, err := d.commitAndApplyOperator(t.Context(), ""); err != nil {
+		if _, err := d.commitAndApplyOperator(t.Context(), configstore.InternalCommitter(), ""); err != nil {
 			t.Fatalf("commitAndApplyOperator: %v", err)
 		}
 		if *calls != 0 {

--- a/pkg/daemon/configsync_transport_5054_test.go
+++ b/pkg/daemon/configsync_transport_5054_test.go
@@ -43,6 +43,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/cluster"
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
 )
 
 // clusterOwningRG0 builds a cluster.Manager whose local node (0) owns RG0. A
@@ -151,7 +152,7 @@ func newSyncProbeDaemon(t *testing.T, cl *cluster.Manager) (*Daemon, *int) {
 func TestOperatorCommitSyncsPeerWhenRG0Owner(t *testing.T) {
 	d, calls := newSyncProbeDaemon(t, clusterOwningRG0(t))
 
-	if _, err := d.commitAndApplyOperator(t.Context(), ""); err != nil {
+	if _, err := d.commitAndApplyOperator(t.Context(), configstore.InternalCommitter(), ""); err != nil {
 		t.Fatalf("commitAndApplyOperator: %v", err)
 	}
 	if *calls != 1 {
@@ -164,7 +165,7 @@ func TestOperatorCommitSyncsPeerWhenRG0Owner(t *testing.T) {
 func TestOperatorCommitDoesNotSyncWhenStandalone(t *testing.T) {
 	d, calls := newSyncProbeDaemon(t, nil)
 
-	if _, err := d.commitAndApplyOperator(t.Context(), ""); err != nil {
+	if _, err := d.commitAndApplyOperator(t.Context(), configstore.InternalCommitter(), ""); err != nil {
 		t.Fatalf("commitAndApplyOperator: %v", err)
 	}
 	if *calls != 0 {
@@ -177,7 +178,7 @@ func TestOperatorCommitDoesNotSyncWhenStandalone(t *testing.T) {
 func TestOperatorCommitDoesNotSyncWhenNonOwner(t *testing.T) {
 	d, calls := newSyncProbeDaemon(t, clusterNotOwningRG0(t))
 
-	if _, err := d.commitAndApplyOperator(t.Context(), ""); err != nil {
+	if _, err := d.commitAndApplyOperator(t.Context(), configstore.InternalCommitter(), ""); err != nil {
 		t.Fatalf("commitAndApplyOperator: %v", err)
 	}
 	if *calls != 0 {
@@ -195,7 +196,7 @@ func TestEventEngineCommitDoesNotSyncEvenWhenRG0Owner(t *testing.T) {
 	// #5962: peerSyncNever is a POLICY, not a resolved authority answer, so it
 	// stays false however ownership moves — which is the distinction the bool
 	// it replaced could not express.
-	if _, err := d.commitAndApply(t.Context(), "", peerSyncNever); err != nil {
+	if _, err := d.commitAndApply(t.Context(), configstore.InternalCommitter(), "", peerSyncNever); err != nil {
 		t.Fatalf("commitAndApply(false): %v", err)
 	}
 	if *calls != 0 {
@@ -208,7 +209,7 @@ func TestEventEngineCommitDoesNotSyncEvenWhenRG0Owner(t *testing.T) {
 func TestOperatorCommitConfirmedSyncsPeerWhenRG0Owner(t *testing.T) {
 	d, calls := newSyncProbeDaemon(t, clusterOwningRG0(t))
 
-	if _, err := d.commitConfirmedAndApplyOperator(t.Context(), 1); err != nil {
+	if _, err := d.commitConfirmedAndApplyOperator(t.Context(), configstore.InternalCommitter(), 1); err != nil {
 		t.Fatalf("commitConfirmedAndApplyOperator: %v", err)
 	}
 	if *calls != 1 {
@@ -241,8 +242,24 @@ func TestTransportCommitFnWiringSyncsPeerByRG0Ownership(t *testing.T) {
 		name string
 		fn   func(*Daemon) func(context.Context, string) (*config.Config, error)
 	}{
-		{"grpc", (*Daemon).grpcCommitFn},
-		{"rest", (*Daemon).restCommitFn},
+		// #6808: the gRPC/REST seams now take a CommitAuthority (the transport
+		// mints it from the config-lock holder); the local shell has no session
+		// and supplies InternalCommitter() itself. Adapt the two transport seams
+		// to the shell's shape so this table still drives the EXACT wired
+		// closures — the property under test is peer-sync-by-RG0-ownership, which
+		// the authority does not touch.
+		{"grpc", func(d *Daemon) func(context.Context, string) (*config.Config, error) {
+			inner := d.grpcCommitFn()
+			return func(ctx context.Context, comment string) (*config.Config, error) {
+				return inner(ctx, configstore.InternalCommitter(), comment)
+			}
+		}},
+		{"rest", func(d *Daemon) func(context.Context, string) (*config.Config, error) {
+			inner := d.restCommitFn()
+			return func(ctx context.Context, comment string) (*config.Config, error) {
+				return inner(ctx, configstore.InternalCommitter(), comment)
+			}
+		}},
 		{"shell", (*Daemon).shellCommitFn},
 	}
 	for _, tr := range transports {
@@ -270,8 +287,19 @@ func TestTransportCommitConfirmedFnWiringSyncsPeerByRG0Ownership(t *testing.T) {
 		name string
 		fn   func(*Daemon) func(context.Context, int) (*config.Config, error)
 	}{
-		{"grpc", (*Daemon).grpcCommitConfirmedFn},
-		{"rest", (*Daemon).restCommitConfirmedFn},
+		// #6808: same adaptation as the plain-commit table above.
+		{"grpc", func(d *Daemon) func(context.Context, int) (*config.Config, error) {
+			inner := d.grpcCommitConfirmedFn()
+			return func(ctx context.Context, minutes int) (*config.Config, error) {
+				return inner(ctx, configstore.InternalCommitter(), minutes)
+			}
+		}},
+		{"rest", func(d *Daemon) func(context.Context, int) (*config.Config, error) {
+			inner := d.restCommitConfirmedFn()
+			return func(ctx context.Context, minutes int) (*config.Config, error) {
+				return inner(ctx, configstore.InternalCommitter(), minutes)
+			}
+		}},
 		{"shell", (*Daemon).shellCommitConfirmedFn},
 	}
 	for _, tr := range transports {

--- a/pkg/daemon/daemon_apply_commit.go
+++ b/pkg/daemon/daemon_apply_commit.go
@@ -143,7 +143,7 @@ func (d *Daemon) commitWithGenBinding(
 // cancellation after store.Commit is deliberately ignored (aborting a
 // promoted commit on a still-running daemon would diverge the store from the
 // dataplane). See applyCancelCtx for the full rationale.
-func (d *Daemon) commitAndApply(ctx context.Context, comment string, syncPeer peerSyncPolicy) (*config.Config, error) {
+func (d *Daemon) commitAndApply(ctx context.Context, authority configstore.CommitAuthority, comment string, syncPeer peerSyncPolicy) (*config.Config, error) {
 	// #1922 Item 2 first-takeover gate (OQ-B, blunt resolution). In
 	// bootstrap mode a plain `commit` is refused: the first commit on a
 	// foreign/non-appliance host claims interfaces and can cut off
@@ -222,7 +222,9 @@ func (d *Daemon) commitAndApply(ctx context.Context, comment string, syncPeer pe
 			}
 			return d.deviceMapCommitPreflight(cand, nil)
 		},
-		func(gen uint64) (*config.Config, error) { return d.store.CommitWithDescriptionGen(comment, gen) },
+		func(gen uint64) (*config.Config, error) {
+			return d.store.CommitWithDescriptionGenAs(authority, comment, gen)
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -557,7 +559,7 @@ func (d *Daemon) deviceMapPassiveAdmissionAlarm(synced *config.Config) {
 
 // commitConfirmedAndApply is the commit-confirmed analogue of
 // commitAndApply. Same atomicity guarantees.
-func (d *Daemon) commitConfirmedAndApply(ctx context.Context, minutes int, syncPeer peerSyncPolicy) (*config.Config, error) {
+func (d *Daemon) commitConfirmedAndApply(ctx context.Context, authority configstore.CommitAuthority, minutes int, syncPeer peerSyncPolicy) (*config.Config, error) {
 	if err := d.applySem.Acquire(ctx, 1); err != nil {
 		return nil, err
 	}
@@ -611,7 +613,9 @@ func (d *Daemon) commitConfirmedAndApply(ctx context.Context, minutes int, syncP
 			}
 			return d.deviceMapCommitPreflight(cand, d.store.ActiveConfig())
 		},
-		func(gen uint64) (*config.Config, error) { return d.store.CommitConfirmedGen(minutes, gen) },
+		func(gen uint64) (*config.Config, error) {
+			return d.store.CommitConfirmedGenAs(authority, minutes, gen)
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -641,15 +645,15 @@ func (d *Daemon) commitConfirmedAndApply(ctx context.Context, minutes int, syncP
 // commits with peerSyncNever (commitAndApply directly, see initEventEngine)
 // because each node fires its remediation independently from that node's local
 // RPM events and must not push node-local state to the peer.
-func (d *Daemon) commitAndApplyOperator(ctx context.Context, comment string) (*config.Config, error) {
-	return d.commitAndApply(ctx, comment, peerSyncIfRG0Authority)
+func (d *Daemon) commitAndApplyOperator(ctx context.Context, authority configstore.CommitAuthority, comment string) (*config.Config, error) {
+	return d.commitAndApply(ctx, authority, comment, peerSyncIfRG0Authority)
 }
 
 // commitConfirmedAndApplyOperator is the commit-confirmed analogue of
 // commitAndApplyOperator: the same transport-independent RG0-ownership peer-sync
 // policy for an operator-initiated `commit confirmed` (#5054).
-func (d *Daemon) commitConfirmedAndApplyOperator(ctx context.Context, minutes int) (*config.Config, error) {
-	return d.commitConfirmedAndApply(ctx, minutes, peerSyncIfRG0Authority)
+func (d *Daemon) commitConfirmedAndApplyOperator(ctx context.Context, authority configstore.CommitAuthority, minutes int) (*config.Config, error) {
+	return d.commitConfirmedAndApply(ctx, authority, minutes, peerSyncIfRG0Authority)
 }
 
 // executeConfirmedRollback is the daemon-owned commit-confirmed timeout

--- a/pkg/daemon/daemon_apply_tail.go
+++ b/pkg/daemon/daemon_apply_tail.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/eventengine"
@@ -584,7 +585,10 @@ func (d *Daemon) initEventEngine() {
 		return
 	}
 	d.eventEngine = eventengine.New(d.store, func(ctx context.Context, comment string) (*config.Config, error) {
-		return d.commitAndApply(ctx, comment, peerSyncNever)
+		// #6808: the event engine is an autonomous system committer with no
+		// config-lock session, so it states that explicitly. It must never be
+		// the zero authority, which is rejected.
+		return d.commitAndApply(ctx, configstore.InternalCommitter(), comment, peerSyncNever)
 	})
 	if d.rpm != nil {
 		d.rpm.SetEventCallback(d.eventEngine.HandleEvent)

--- a/pkg/daemon/daemon_run_servers.go
+++ b/pkg/daemon/daemon_run_servers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/api"
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
 	"github.com/psaab/xpf/pkg/eventengine"
 	"github.com/psaab/xpf/pkg/feeds"
 	"github.com/psaab/xpf/pkg/fwdstatus"
@@ -67,39 +68,43 @@ func (d *Daemon) effectiveListeners() sysservices.Listeners {
 // transport is what lets a single-transport regression turn a single test case
 // RED instead of staying silent.
 
-func (d *Daemon) grpcCommitFn() func(context.Context, string) (*config.Config, error) {
-	return func(ctx context.Context, comment string) (*config.Config, error) {
-		return d.commitAndApplyOperator(ctx, comment)
+func (d *Daemon) grpcCommitFn() func(context.Context, configstore.CommitAuthority, string) (*config.Config, error) {
+	return func(ctx context.Context, authority configstore.CommitAuthority, comment string) (*config.Config, error) {
+		return d.commitAndApplyOperator(ctx, authority, comment)
 	}
 }
 
-func (d *Daemon) grpcCommitConfirmedFn() func(context.Context, int) (*config.Config, error) {
-	return func(ctx context.Context, minutes int) (*config.Config, error) {
-		return d.commitConfirmedAndApplyOperator(ctx, minutes)
+func (d *Daemon) grpcCommitConfirmedFn() func(context.Context, configstore.CommitAuthority, int) (*config.Config, error) {
+	return func(ctx context.Context, authority configstore.CommitAuthority, minutes int) (*config.Config, error) {
+		return d.commitConfirmedAndApplyOperator(ctx, authority, minutes)
 	}
 }
 
-func (d *Daemon) restCommitFn() func(context.Context, string) (*config.Config, error) {
-	return func(ctx context.Context, comment string) (*config.Config, error) {
-		return d.commitAndApplyOperator(ctx, comment)
+func (d *Daemon) restCommitFn() func(context.Context, configstore.CommitAuthority, string) (*config.Config, error) {
+	return func(ctx context.Context, authority configstore.CommitAuthority, comment string) (*config.Config, error) {
+		return d.commitAndApplyOperator(ctx, authority, comment)
 	}
 }
 
-func (d *Daemon) restCommitConfirmedFn() func(context.Context, int) (*config.Config, error) {
-	return func(ctx context.Context, minutes int) (*config.Config, error) {
-		return d.commitConfirmedAndApplyOperator(ctx, minutes)
+func (d *Daemon) restCommitConfirmedFn() func(context.Context, configstore.CommitAuthority, int) (*config.Config, error) {
+	return func(ctx context.Context, authority configstore.CommitAuthority, minutes int) (*config.Config, error) {
+		return d.commitConfirmedAndApplyOperator(ctx, authority, minutes)
 	}
 }
 
+// shellCommitFn is the in-process shell CLI's commit seam. The local shell
+// carries no config-lock session id, so it commits as an EXPLICIT internal
+// committer (#6808) rather than by omitting the authority — "this caller has no
+// holder" must be a written statement, not a zero value.
 func (d *Daemon) shellCommitFn() func(context.Context, string) (*config.Config, error) {
 	return func(ctx context.Context, comment string) (*config.Config, error) {
-		return d.commitAndApplyOperator(ctx, comment)
+		return d.commitAndApplyOperator(ctx, configstore.InternalCommitter(), comment)
 	}
 }
 
 func (d *Daemon) shellCommitConfirmedFn() func(context.Context, int) (*config.Config, error) {
 	return func(ctx context.Context, minutes int) (*config.Config, error) {
-		return d.commitConfirmedAndApplyOperator(ctx, minutes)
+		return d.commitConfirmedAndApplyOperator(ctx, configstore.InternalCommitter(), minutes)
 	}
 }
 

--- a/pkg/daemon/factory_reset_5281_test.go
+++ b/pkg/daemon/factory_reset_5281_test.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
 )
 
 // factoryReset must Acquire applySem BEFORE wiping, enter the terminal reset
@@ -63,10 +64,10 @@ func TestFactoryResetGatesAndEntersResetGeneration(t *testing.T) {
 	// (3) In the reset generation, a racing commit / HA-sync must be REJECTED
 	// before it persists (which would re-create the erased .configdb SSOT). The
 	// guard sits before any nil-store access, so these return cleanly.
-	if _, err := d.commitAndApply(context.Background(), "", peerSyncNever); !errors.Is(err, errDaemonResetting) {
+	if _, err := d.commitAndApply(context.Background(), configstore.InternalCommitter(), "", peerSyncNever); !errors.Is(err, errDaemonResetting) {
 		t.Fatalf("commitAndApply must be rejected during a factory reset; got %v", err)
 	}
-	if _, err := d.commitConfirmedAndApply(context.Background(), 1, peerSyncNever); !errors.Is(err, errDaemonResetting) {
+	if _, err := d.commitConfirmedAndApply(context.Background(), configstore.InternalCommitter(), 1, peerSyncNever); !errors.Is(err, errDaemonResetting) {
 		t.Fatalf("commitConfirmedAndApply must be rejected during a factory reset; got %v", err)
 	}
 	if _, err := d.syncAndApply(context.Background(), "", nil); !errors.Is(err, errDaemonResetting) {

--- a/pkg/daemon/rollback_serialize_test.go
+++ b/pkg/daemon/rollback_serialize_test.go
@@ -105,7 +105,7 @@ func TestExecuteConfirmedRollbackSerializesWithCommit(t *testing.T) {
 	}()
 	go func() {
 		defer wg.Done()
-		_, _ = d.commitAndApply(t.Context(), "", peerSyncNever)
+		_, _ = d.commitAndApply(t.Context(), configstore.InternalCommitter(), "", peerSyncNever)
 	}()
 	wg.Wait()
 
@@ -268,7 +268,7 @@ func TestExecuteConfirmedRollbackStoreApplyConsistency(t *testing.T) {
 		}()
 		go func() {
 			defer wg.Done()
-			_, _ = d.commitAndApply(t.Context(), "", peerSyncNever)
+			_, _ = d.commitAndApply(t.Context(), configstore.InternalCommitter(), "", peerSyncNever)
 		}()
 		wg.Wait()
 

--- a/pkg/grpcapi/commit_advisory_warnings_6515_test.go
+++ b/pkg/grpcapi/commit_advisory_warnings_6515_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 )
 
@@ -54,13 +55,13 @@ func hostInboundNarrowingStore(t *testing.T) *Server {
 	}
 	return &Server{
 		store: store,
-		commitFn: func(_ context.Context, comment string) (*config.Config, error) {
+		commitFn: func(_ context.Context, _ configstore.CommitAuthority, comment string) (*config.Config, error) {
 			if comment != "" {
 				return store.CommitWithDescription(comment)
 			}
 			return store.Commit()
 		},
-		commitConfirmedFn: func(_ context.Context, minutes int) (*config.Config, error) {
+		commitConfirmedFn: func(_ context.Context, _ configstore.CommitAuthority, minutes int) (*config.Config, error) {
 			return store.CommitConfirmed(minutes)
 		},
 	}

--- a/pkg/grpcapi/config_holder_turnover_6808_test.go
+++ b/pkg/grpcapi/config_holder_turnover_6808_test.go
@@ -1,0 +1,205 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #6808 gRPC WIRING cells.
+//
+// R69's title says "REST commit", but the identical gate-then-unscoped-callback
+// shape is in gRPC Commit / CommitConfirmed, and gRPC additionally has a
+// NON-ADVERSARIAL trigger REST lacks: configLockStatsHandler.HandleConn
+// auto-releases the config lock on ConnEnd from a separate goroutine, with no
+// coordination with an in-flight commit. Its comment says the release is
+// "guarded ... by the store's holder check" — true of a DIFFERENT hazard
+// (releasing someone else's lock), and silent about releasing the committer's
+// own lock mid-commit. So an ordinary disconnect while a commit waits on the
+// apply semaphore reaches the substitution with no attacker timing at all.
+//
+// These cells assert the authority the handler PASSES. Passing
+// configstore.InternalCommitter() instead compiles and restores the defect in
+// full, so asserting the store's behaviour alone would not catch it.
+
+// grpcHolderStore returns a store in config mode held by sessionID with one
+// staged edit, so a commit has something to promote.
+func grpcHolderStore(t *testing.T, sessionID string) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigureSession(sessionID); err != nil {
+		t.Fatalf("EnterConfigureSession(%s): %v", sessionID, err)
+	}
+	if err := store.SetFromInputAs(sessionID, "system host-name staged-by-holder"); err != nil {
+		t.Fatalf("SetFromInputAs: %v", err)
+	}
+	return store
+}
+
+// TestGRPCCommitPassesBoundAuthority_6808 pins that gRPC Commit hands the
+// callback an authority bound to the connection session that passed the gate.
+//
+// FAIL-ON-REVERT: pass configstore.InternalCommitter() in Commit (it compiles)
+// and this REDS on IsInternal.
+func TestGRPCCommitPassesBoundAuthority_6808(t *testing.T) {
+	ctx := clientCtx(4141)
+	sessionID := connSessionID(ctx)
+	store := grpcHolderStore(t, sessionID)
+
+	var got configstore.CommitAuthority
+	var called bool
+	s := &Server{
+		store: store,
+		commitFn: func(_ context.Context, a configstore.CommitAuthority, _ string) (*config.Config, error) {
+			called, got = true, a
+			return store.Commit()
+		},
+	}
+
+	if _, err := s.Commit(ctx, &pb.CommitRequest{}); err != nil {
+		t.Fatalf("Commit as the holder: %v", err)
+	}
+	if !called {
+		t.Fatal("commitFn was never invoked, so this cell asserts nothing about the authority")
+	}
+	if got.IsInternal() {
+		t.Error("gRPC Commit passed an INTERNAL commit authority. An internal authority " +
+			"satisfies every holder-turnover check, so a connection that drops mid-commit " +
+			"would still promote whichever candidate exists at promotion time (#6808)")
+	}
+	if got.SessionID() != sessionID {
+		t.Errorf("commit authority SessionID = %q, want %q — it must bind the session that "+
+			"passed the gate", got.SessionID(), sessionID)
+	}
+}
+
+// TestGRPCCommitConfirmedPassesBoundAuthority_6808 is the commit-confirmed half.
+// Separate cell: the two RPCs mint their authority independently.
+//
+// FAIL-ON-REVERT: pass configstore.InternalCommitter() in CommitConfirmed and
+// this REDS.
+func TestGRPCCommitConfirmedPassesBoundAuthority_6808(t *testing.T) {
+	ctx := clientCtx(4242)
+	sessionID := connSessionID(ctx)
+	store := grpcHolderStore(t, sessionID)
+
+	var got configstore.CommitAuthority
+	var called bool
+	s := &Server{
+		store: store,
+		commitConfirmedFn: func(_ context.Context, a configstore.CommitAuthority, _ int) (*config.Config, error) {
+			called, got = true, a
+			return store.CommitConfirmed(5)
+		},
+	}
+
+	if _, err := s.CommitConfirmed(ctx, &pb.CommitConfirmedRequest{Minutes: 5}); err != nil {
+		t.Fatalf("CommitConfirmed as the holder: %v", err)
+	}
+	if !called {
+		t.Fatal("commitConfirmedFn was never invoked, so this cell asserts nothing")
+	}
+	if got.IsInternal() {
+		t.Error("gRPC CommitConfirmed passed an INTERNAL authority; a substituted " +
+			"commit-confirmed also arms an auto-rollback timer against work its author " +
+			"never approved (#6808)")
+	}
+	if got.SessionID() != sessionID {
+		t.Errorf("commit-confirmed authority SessionID = %q, want %q", got.SessionID(), sessionID)
+	}
+}
+
+// TestGRPCCommitRefusedWhenConnectionDropsMidCommit_6808 models the
+// non-adversarial trigger end to end: the committing session's lock is released
+// the way HandleConn releases it on ConnEnd — by session id, from outside the
+// commit — while the commit is in flight, and another session then enters and
+// stages different work.
+//
+// It uses the same release entry point HandleConn uses (ExitConfigureSession by
+// session id) rather than reaching into the stats handler, so the cell exercises
+// the state transition that matters without depending on gRPC transport
+// plumbing to deliver a ConnEnd.
+//
+// FAIL-ON-REVERT: pass InternalCommitter() from Commit, or drop
+// verifyCommitAuthorityLocked from CommitWithDescriptionGenAs, and this REDS with
+// the intruder's host-name active.
+func TestGRPCCommitRefusedWhenConnectionDropsMidCommit_6808(t *testing.T) {
+	ctx := clientCtx(4343)
+	sessionID := connSessionID(ctx)
+	store := grpcHolderStore(t, sessionID)
+
+	s := &Server{
+		store: store,
+		commitFn: func(_ context.Context, a configstore.CommitAuthority, comment string) (*config.Config, error) {
+			// The committer's connection ends here — exactly what HandleConn
+			// does on ConnEnd, from its own goroutine, with no coordination
+			// with this in-flight commit.
+			if !store.ExitConfigureSession(sessionID) {
+				t.Fatal("fixture: could not release the committing session's lock")
+			}
+			if err := store.EnterConfigureSession("intruder"); err != nil {
+				t.Fatalf("fixture: intruder could not enter: %v", err)
+			}
+			if err := store.SetFromInputAs("intruder", "system host-name staged-by-intruder"); err != nil {
+				t.Fatalf("fixture: intruder set: %v", err)
+			}
+			_, gen, cerr := store.CompileCandidateGen()
+			if cerr != nil {
+				t.Fatalf("fixture: CompileCandidateGen: %v", cerr)
+			}
+			return store.CommitWithDescriptionGenAs(a, comment, gen)
+		},
+	}
+
+	if _, err := s.Commit(ctx, &pb.CommitRequest{}); err == nil {
+		t.Fatal("gRPC Commit SUCCEEDED after the committing connection's lock was released " +
+			"mid-commit; the intruder's staged edits were applied under the original " +
+			"session's authorization (#6808)")
+	}
+	if active := store.ActiveConfig(); active != nil && active.System.HostName == "staged-by-intruder" {
+		t.Fatalf("the intruder's candidate was PROMOTED (host-name=%q) under the dropped "+
+			"session's authority", active.System.HostName)
+	}
+}
+
+// TestGRPCCommitStillWorksWithoutTurnover_6808 is the control: an unchanged
+// holder must still commit AND actually promote.
+//
+// Without it, "refuse every commit" satisfies both refusal cells, and refusing
+// every commit is a configuration outage. The host-name assertion keeps the
+// control from being satisfiable by a fixture that never reaches promotion.
+func TestGRPCCommitStillWorksWithoutTurnover_6808(t *testing.T) {
+	ctx := clientCtx(4444)
+	sessionID := connSessionID(ctx)
+	store := grpcHolderStore(t, sessionID)
+
+	s := &Server{
+		store: store,
+		commitFn: func(_ context.Context, a configstore.CommitAuthority, comment string) (*config.Config, error) {
+			_, gen, cerr := store.CompileCandidateGen()
+			if cerr != nil {
+				t.Fatalf("CompileCandidateGen: %v", cerr)
+			}
+			return store.CommitWithDescriptionGenAs(a, comment, gen)
+		},
+	}
+
+	if _, err := s.Commit(ctx, &pb.CommitRequest{}); err != nil {
+		t.Fatalf("Commit with an UNCHANGED holder = %v, want nil — the fix must not refuse "+
+			"legitimate commits", err)
+	}
+	active := store.ActiveConfig()
+	if active == nil || active.System.HostName != "staged-by-holder" {
+		got := ""
+		if active != nil {
+			got = active.System.HostName
+		}
+		t.Fatalf("host-name after the control commit = %q, want %q — the control must reach "+
+			"promotion, or it cannot distinguish 'accepted' from 'never got there'",
+			got, "staged-by-holder")
+	}
+}

--- a/pkg/grpcapi/config_lock_holder_5059_test.go
+++ b/pkg/grpcapi/config_lock_holder_5059_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 )
 
@@ -47,7 +48,7 @@ func TestConfigLockHolderEnforced_TwoClients(t *testing.T) {
 	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
 	s := &Server{
 		store: store,
-		commitFn: func(context.Context, string) (*config.Config, error) {
+		commitFn: func(context.Context, configstore.CommitAuthority, string) (*config.Config, error) {
 			return store.Commit()
 		},
 	}

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -123,8 +123,8 @@ type Config struct {
 	// can't interleave their commit→apply pairs. Returns ctx.Err()
 	// if the request is canceled before the semaphore is acquired
 	// (handlers translate to DeadlineExceeded/Canceled).
-	CommitFn          func(ctx context.Context, comment string) (*config.Config, error)
-	CommitConfirmedFn func(ctx context.Context, minutes int) (*config.Config, error)
+	CommitFn          func(ctx context.Context, authority configstore.CommitAuthority, comment string) (*config.Config, error)
+	CommitConfirmedFn func(ctx context.Context, authority configstore.CommitAuthority, minutes int) (*config.Config, error)
 	// ZeroizeFn runs a factory-reset (zeroize) wipe under the daemon's apply
 	// gate (#5281). It acquires the same apply semaphore commit/sync serialize
 	// on, enters a TERMINAL reset generation so no concurrent or subsequent
@@ -198,8 +198,8 @@ type Server struct {
 	surfaceADDNSStatusFn  func() []ddnspkg.SurfaceAStatusView
 	surfaceADDNSForceFn   func(force bool) (bool, string)
 	flowCollectorHealthFn func() []flowexport.ExporterCollectorHealth
-	commitFn              func(ctx context.Context, comment string) (*config.Config, error)
-	commitConfirmedFn     func(ctx context.Context, minutes int) (*config.Config, error)
+	commitFn              func(ctx context.Context, authority configstore.CommitAuthority, comment string) (*config.Config, error)
+	commitConfirmedFn     func(ctx context.Context, authority configstore.CommitAuthority, minutes int) (*config.Config, error)
 	zeroizeFn             func(ctx context.Context, wipe func() error) error
 	vrrpMgr               *vrrp.Manager
 	raMgr                 *ra.Manager

--- a/pkg/grpcapi/server_config.go
+++ b/pkg/grpcapi/server_config.go
@@ -250,7 +250,16 @@ func (s *Server) Commit(ctx context.Context, req *pb.CommitRequest) (*pb.CommitR
 	// a commit from a non-holder session before it can confirm/apply another
 	// session's pending work. Empty session (unit tests / internal) bypasses.
 	sessionID := connSessionID(ctx)
-	if err := s.store.EnsureConfigHolder(sessionID); err != nil {
+	// #6808: mint the commit AUTHORITY under the same store-lock acquisition
+	// that verifies the holder, and carry it into the callback, so a lock
+	// turnover between this gate and promotion is detected instead of
+	// substituting the new holder's candidate. On gRPC the turnover needs no
+	// adversary: configLockStatsHandler.HandleConn auto-releases the lock on
+	// ConnEnd from a separate goroutine with no coordination with an in-flight
+	// commit, so an ordinary disconnect while this commit waits on the apply
+	// semaphore is enough.
+	authority, err := s.store.AuthorizeCommit(sessionID)
+	if err != nil {
 		return nil, configMutationStatus(err)
 	}
 
@@ -272,7 +281,7 @@ func (s *Server) Commit(ctx context.Context, req *pb.CommitRequest) (*pb.CommitR
 	if s.commitFn == nil {
 		return nil, status.Errorf(codes.Internal, "commit handler not wired")
 	}
-	compiled, err := s.commitFn(ctx, req.Comment)
+	compiled, err := s.commitFn(ctx, authority, req.Comment)
 	if err != nil {
 		// #5742: classify structurally — a non-fatal tail-reconcile / ordinary
 		// apply error (the daemon returns the committed config alongside it) is
@@ -292,13 +301,22 @@ func (s *Server) CommitCheck(_ context.Context, _ *pb.CommitCheckRequest) (*pb.C
 
 func (s *Server) CommitConfirmed(ctx context.Context, req *pb.CommitConfirmedRequest) (*pb.CommitConfirmedResponse, error) {
 	// #5059: only the config-lock holder may commit the shared candidate.
-	if err := s.store.EnsureConfigHolder(connSessionID(ctx)); err != nil {
+	// #6808: mint the commit AUTHORITY under the same store-lock acquisition
+	// that verifies the holder, and carry it into the callback, so a lock
+	// turnover between this gate and promotion is detected instead of
+	// substituting the new holder's candidate. On gRPC the turnover needs no
+	// adversary: configLockStatsHandler.HandleConn auto-releases the lock on
+	// ConnEnd from a separate goroutine with no coordination with an in-flight
+	// commit, so an ordinary disconnect while this commit waits on the apply
+	// semaphore is enough.
+	authority, err := s.store.AuthorizeCommit(connSessionID(ctx))
+	if err != nil {
 		return nil, configMutationStatus(err)
 	}
 	if s.commitConfirmedFn == nil {
 		return nil, status.Errorf(codes.Internal, "commit-confirmed handler not wired")
 	}
-	compiled, err := s.commitConfirmedFn(ctx, int(req.Minutes))
+	compiled, err := s.commitConfirmedFn(ctx, authority, int(req.Minutes))
 	if err != nil {
 		// #5742: same structural classification as Commit — commitConfirmedAndApply
 		// shares applyAndSyncCommitted, so a non-fatal tail error carries the

--- a/pkg/grpcapi/server_config_commit_errclass_5742_test.go
+++ b/pkg/grpcapi/server_config_commit_errclass_5742_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -35,10 +36,10 @@ func newCommitClassServer(t *testing.T, compiled *config.Config, injected error)
 	t.Helper()
 	return &Server{
 		store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")),
-		commitFn: func(context.Context, string) (*config.Config, error) {
+		commitFn: func(context.Context, configstore.CommitAuthority, string) (*config.Config, error) {
 			return compiled, injected
 		},
-		commitConfirmedFn: func(context.Context, int) (*config.Config, error) {
+		commitConfirmedFn: func(context.Context, configstore.CommitAuthority, int) (*config.Config, error) {
 			return compiled, injected
 		},
 	}

--- a/pkg/grpcapi/server_config_test.go
+++ b/pkg/grpcapi/server_config_test.go
@@ -61,7 +61,7 @@ func TestCommitRejectsRetiredEBPF(t *testing.T) {
 	store := newGRPCEBPFRejectStore(t)
 	s := &Server{
 		store: store,
-		commitFn: func(context.Context, string) (*config.Config, error) {
+		commitFn: func(context.Context, configstore.CommitAuthority, string) (*config.Config, error) {
 			return store.Commit()
 		},
 	}
@@ -89,7 +89,7 @@ func TestCommitConfirmedRejectsRetiredEBPF(t *testing.T) {
 	store := newGRPCEBPFRejectStore(t)
 	s := &Server{
 		store: store,
-		commitConfirmedFn: func(context.Context, int) (*config.Config, error) {
+		commitConfirmedFn: func(context.Context, configstore.CommitAuthority, int) (*config.Config, error) {
 			return store.CommitConfirmed(10)
 		},
 	}


### PR DESCRIPTION
## Problem

The REST **and gRPC** commit paths verified the config-lock holder, then invoked
a daemon callback carrying **no identity**:

```go
if err := s.store.EnsureConfigHolder(sessionID); err != nil { ... }   // gate
...
compiled, err := s.commitFn(r.Context(), "")                          // unscoped
```

Between those two steps the lock can turn over — the holder exits, disconnects,
or is reclaimed on its idle lease (#4476) — and another session enters and stages
different edits. The in-flight commit then snapshots and promotes the **new**
holder's candidate under the **original** holder's authorization.

Re-derived against current `origin/master`: present at all four sites.

## Why #5848's generation binding does not close it

This is the part the issue title would mislead you on, and R69's *Refutation
attempt* is what settles it. Generation binding is **present and correct** — it
just answers a different question, and `CommitWithDescriptionGen` /
`CommitConfirmedGen` take no session id at all.

A turnover completing *before* the daemon's `CompileCandidateGen` — i.e. while
the commit waits on `applySem`, which is where a busy daemon actually waits —
yields a **perfectly consistent** generation pair, describing the new holder's
candidate.

And the retry loop makes it worse: `commitWithGenBinding` retries
`ErrCandidateGenerationConflict` **by design**. A turnover reported as a
generation conflict would make that retry re-snapshot and promote the new
holder's work automatically, with no race needed. Hence a deliberately
**distinct** `ErrConfigHolderTurnover` sentinel, with a cell pinning the two
apart.

## Scope: four sites, not two

| Site | Gate | Unscoped callback |
|---|---|---|
| REST commit | `pkg/api/config.go:233` | `:256` |
| REST commit-confirmed | `pkg/api/config.go:500` | `:508` |
| gRPC `Commit` | `pkg/grpcapi/server_config.go:253` | `:275` |
| gRPC `CommitConfirmed` | `:295` | `:301` |

One mechanism over shared plumbing. Splitting would land an intermediate state
where two call sites pass a zero authority — precisely the fail-open-by-omission
the explicit parameter exists to prevent.

**gRPC additionally has a non-adversarial trigger.**
`configLockStatsHandler.HandleConn` auto-releases the lock on `ConnEnd` from a
separate goroutine with **no coordination with an in-flight commit**. Its comment
says the release is "guarded … by the store's holder check" — true of a
*different* hazard (releasing someone else's lock), and silent about releasing
the committer's own lock mid-commit. An ordinary disconnect reaches the
substitution with no attacker timing.

## Fix

- **`holderEpoch`** — advanced on every config-lock acquisition and release.
  Distinct from `candidateGen` (candidate *content*) and from `configLockAt` (a
  wall-clock stamp that cannot tell a held lock from a re-taken one). A
  same-session re-entry does **not** advance it.
- **`AuthorizeCommit`** — verifies the holder and mints the authority under
  **one** `s.mu` acquisition. Two calls would leave a window in which the lock
  turns over between "you are the holder" and "here is the epoch" — the same
  defect one level down.
- **`CommitWithDescriptionGenAs` / `CommitConfirmedGenAs`** — verify authority
  **and** generation together, immediately before promotion.

### The zero value is invalid, not a bypass

`CommitAuthority{}` is **rejected** with `ErrCommitAuthorityMissing`. Internal
committers (HA config-sync, event engine, in-process shell CLI) state it with
`InternalCommitter()`.

Letting the zero mean "internal, skip the check" would put the god-mode
capability at exactly the value a forgotten field already produces: the explicit
parameter would catch *omission* (a compile error) while silently admitting a
**wrong-but-compiling zero** that reads as deliberate in review. Explicit
parameter rather than a `Context` value for the same reason — an absent ctx value
is indistinguishable from a deliberate one.

The signature change is how the defect sites surfaced: **the compiler named all
four.**

### `EnsureConfigHolder` deleted, its test moved

Once all four paths used `AuthorizeCommit` it had zero production callers and its
doc comment ("the exported gate used by the commit-family gRPC RPCs") had become
false. `TestEnsureConfigHolder` → `TestAuthorizeCommitHolderGate`: the #5059
property did not change, but the function enforcing it did, and a test left on
the old symbol stays green while guarding nothing.

## Test plan

- [x] `go build ./...` — rc=0
- [x] `go test -count=1 ./...` repo-wide — **rc=0**, 67 packages, 0 FAIL, at
      `1207d312b9963fb5802f02eddafeeebda2bd792b` (parent `origin/master` `d427fb83f`,
      post-#6845; `merge-base --is-ancestor` rc=0). Full suite, not touched-packages —
      #6845 landed in `pkg/api`/`pkg/cli`, the same packages this changes.
- [x] **12-cell mutation matrix, re-run at the merged head** — 12/12 RED, full
      package per cell, no `-run` filter
- [x] `gofmt -l` clean on every touched file
- [ ] Deploy/cluster smoke — **NOT RUN**, see below
- [ ] Codex / AGY hostile review — not run; parent owns the review round

### Mutation matrix (12/12 RED)

| Cell | Expected RED | Verdict |
|---|---|---|
| M1 zero authority rejected | `TestCommitAuthorityZeroValueIsRejected_6808` | **RED** |
| M2 holder identity+epoch check | `TestCommitRefusedAfterHolderTurnover_6808` | **RED** |
| M3 epoch bump on `ExitConfigureSession` | `TestHolderEpochAdvancesOnAcquireAndRelease_6808` | **RED** |
| M4 epoch bump on `EnterConfigureSession` | `TestHolderEpochAdvancesOnAcquireAndRelease_6808` | **RED** |
| M5 `AuthorizeCommit` binds epoch (not internal) | `TestUnchangedHolderStillCommits_6808` | **RED** |
| M6 `CommitWithDescriptionGenAs` verifies authority | `TestCommitRefusedAfterHolderTurnover_6808` | **RED** |
| M7 `CommitConfirmedGenAs` verifies authority | `TestCommitConfirmedRefusedAfterHolderTurnover_6808` | **RED** |
| M8 turnover sentinel distinct from gen-conflict | `TestTurnoverSentinelIsNotGenerationConflict_6808` | **RED** |
| M9 REST commit passes bound authority | `TestRESTCommitPassesBoundAuthority_6808` | **RED** |
| M10 REST commit-confirmed passes bound authority | `TestRESTCommitConfirmedPassesBoundAuthority_6808` | **RED** |
| M11 gRPC `Commit` passes bound authority | `TestGRPCCommitPassesBoundAuthority_6808` | **RED** |
| M12 gRPC `CommitConfirmed` passes bound authority | `TestGRPCCommitConfirmedPassesBoundAuthority_6808` | **RED** |

**The wiring cells (M9–M12) are load-bearing and independent.** A handler passing
`configstore.InternalCommitter()` instead of the minted authority **still
compiles** and restores the defect in full — an internal authority satisfies
every turnover check by design. So those cells assert the authority the handler
*passes*, not the store's reaction to it. M9–M12 are exactly that mutation.

**Controls.** `TestUnchangedHolderStillCommits_6808` (and its REST/gRPC
equivalents) assert an unchanged holder still commits **and actually promotes** —
checked by reading back the committed `host-name`, so a fixture that never
reached promotion cannot satisfy it. `TestCommitAuthorityZeroValueIsRejected_6808`
also asserts an *explicit* `InternalCommitter()` is still accepted. Without those,
"refuse everything" passes every refusal cell — and refusing every commit is a
configuration outage strictly worse than the defect.

### Smoke not run — explicit disposition

No dataplane, forwarding, cluster, VRRP, or session-sync code is touched; this is
the config-lock/commit authorization path. Zone-to-zone ping and iperf3 cannot
observe it. The meaningful lane would be a two-session turnover against a live
daemon (session A commits while blocked on `applySem`, A's connection drops, B
enters and edits) — happy to run it on a VM if wanted.

## Rejected alternative, recorded

*Pin the holder for the commit's duration* so turnover cannot happen: smaller, no
signature change — but it breaks the #5849 auto-release contract. A dropped
connection whose commit is pinned finds `sess.released.Do` already consumed and
the lock wedged until the #4476 lease TTL. Recovering that needs deferred-release
machinery, which spends the simplicity that made it attractive.

## Adjacent finding — filed separately, designed around

`ExitConfigure()` clears `exclusiveHolder` but **not** `configHolder`, leaving a
stale holder string with `configDir=false`. Not exploitable today *only* because
`ensureHolderLocked` short-circuits on `!s.configDir` — a load-bearing accident.
An epoch keyed off `configHolder` alone would have inherited it; bumping the epoch
on that path makes this fix safe **without** depending on the short-circuit.

## Docs

`pkg/configstore/README.md` gains "Authority-bound commit: holder turnover
(#6808)" — why generation binding is insufficient, why the zero value is invalid,
the distinct sentinel, and the four-site scope. `_Log.md` appended.

Closes #6808
