### PR TITLE
api/cli: surface the per-zone counter overflow flag nothing read (#6845)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -105777,3 +105777,50 @@ prose edit above them added. No diff falls in the new test body.
   this delta can move it.
 - **File(s)**: `pkg/daemon/login_inventory_read_failclosed_6798_test.go`,
   `docs/system-login.md`, `_Log.md`
+
+## 2026-08-26 — #6845: surface ZoneCounterOverflowActive, which nothing read
+
+- **Timestamp**: 2026-08-26
+- **Action**: Publish `xpf_zone_counters_overflow_active` and consume the flag in
+  `show security zones`.
+- **Why**: `ProcessStatus.ZoneCounterOverflowActive` was decoded by the Go
+  control plane and read by NOTHING — no CLI, no REST, no gRPC, no Prometheus.
+  The Rust helper has 63 assignable per-zone slots and sets the flag when it
+  exhausts them; zones past capacity are never registered, so their traffic is
+  silently uncounted.
+- **This is an observability gap, not a correctness bug, and the distinction
+  matters for how it was fixed**: an overflowed zone is never registered with
+  `ZoneCounterStore`, so it reads `ErrCounterNotPopulated` and every surface
+  renders an explicit "not available". Nothing publishes a false 0. What is
+  missing is the ability to tell WHY — `unpopulated` is three-way ambiguous by
+  construction (pre-#3651 helper / overflow / idle zone), and only the middle
+  case needs action.
+- **Absence semantics are the OPPOSITE of the sibling gauge's, deliberately.**
+  `xpf_zone_counters_unpopulated_zones` is config-derived and emitted ABOVE the
+  dataplane gate so it keeps reporting through a degraded boot. Overflow is a
+  property of the RUNNING helper's slot table: with no helper there is nothing to
+  overflow, so a 0 would be a false all-clear about a machine nothing asked.
+  Emitted from `collectUserspaceStatus`, which returns early on a nil status —
+  absent = "no helper to ask", 0 = "the helper said no overflow".
+- **The CLI fails to the AMBIGUOUS line on any status error.** It replaces a
+  truthful three-cause message with a specific one-cause message, so a wrong
+  `true` would send an operator to reduce their zone count when the real cause
+  might be an idle zone. "Cannot say" must fall back to honest ambiguity.
+- **REST deliberately not carried, and why**: `/security/zones` returns a bare
+  `[]ZoneInfo` with no envelope, so a response-level field means changing an
+  array response to an object — a breaking shape change that deserves its own
+  decision rather than riding in on an observability fix. Per-zone placement was
+  rejected too: the helper does not report WHICH zones lost slots, so a per-zone
+  flag would be an invention.
+- **Test note**: the cells drive `collectUserspaceStatus` (the real entry point,
+  including its nil-status early return that produces the absence contract),
+  not `emitZoneCounterOverflow` — driving the emitter directly would bind the
+  function and miss the gate, which is the wiring half. A PLAIN registry is used
+  because the pedantic one would demand declaring ~70 sibling descriptors by
+  hand; the Describe ⊇ Collect contract stays owned by
+  `metrics_descriptor_coverage_test.go`'s whole-collector canary (#1726),
+  verified still passing.
+- **File(s)**: `pkg/api/metrics.go`, `pkg/api/metrics_descriptors_zone.go`,
+  `pkg/api/metrics_userspace.go`, `pkg/cli/cli_show_security_zones.go`,
+  `pkg/api/metrics_zone_overflow_6845_test.go` (new), `pkg/api/README.md`,
+  `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -105820,7 +105820,22 @@ prose edit above them added. No diff falls in the new test body.
   hand; the Describe ⊇ Collect contract stays owned by
   `metrics_descriptor_coverage_test.go`'s whole-collector canary (#1726),
   verified still passing.
+- **The modularity gate caught me and I moved the code rather than accepting
+  it.** `pkg/api/metrics_userspace.go` sat at 1999 LOC; my emitter pushed it to
+  2023 and `TestTouchedFileCrossedModularityThreshold` redded. Moving the emitter
+  to its own file still left 2000 — the single CALL line was enough to cross —
+  so the call moved to `metrics.go` (1345 LOC, ample headroom), beside the other
+  top-level status-derived collectors. `metrics_userspace.go` is back at 1999
+  and no acceptance entry was spent on a one-line crossing.
+- **That relocation improved the design rather than dodging the gate**: the
+  emitter now takes `*ProcessStatus` and returns early on nil, so the
+  absence contract is STATED in the emitter and directly tested, instead of
+  being inherited from `collectUserspaceStatus`'s early return where a later
+  refactor could drop it silently. It also forced the wiring cell — a cell that
+  calls the emitter cannot see whether Collect does, and that is the
+  decoded-but-unread defect one layer up.
 - **File(s)**: `pkg/api/metrics.go`, `pkg/api/metrics_descriptors_zone.go`,
-  `pkg/api/metrics_userspace.go`, `pkg/cli/cli_show_security_zones.go`,
+  `pkg/api/metrics_userspace.go`, `pkg/api/metrics_zone_overflow.go` (new),
+  `pkg/cli/cli_show_security_zones.go`,
   `pkg/api/metrics_zone_overflow_6845_test.go` (new), `pkg/api/README.md`,
   `_Log.md`

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -1960,6 +1960,43 @@ the drop fails loudly instead of going quietly vacuous.
     `collectZoneCounters` runs before the `dp == nil || !dp.IsLoaded()` early
     return, alongside `collectPBRStatus` and the host-inbound families.
 
+    **`xpf_zone_counters_overflow_active` disambiguates it (#6845).** The
+    sentinel above is three-way ambiguous BY CONSTRUCTION — pre-#3651 helper,
+    slot-capacity overflow (traffic genuinely missed), or an idle zone — and only
+    the middle case needs action. The bit that separates it was already on the
+    wire (`ProcessStatus.ZoneCounterOverflowActive`, from
+    `userspace-dp/src/afxdp/zone_counters.rs`) and was read by **nothing**: no
+    CLI, no REST, no gRPC, no Prometheus. This 0/1 gauge publishes it.
+
+    **Its absence semantics are the OPPOSITE of the sibling gauge's, and that is
+    the design.** `xpf_zone_counters_unpopulated_zones` is config-derived, so it
+    is emitted above the dataplane gate and keeps reporting the full configured
+    zone count through a degraded boot. Overflow is a property of the RUNNING
+    helper's slot table: with no helper there is no slot table and nothing to
+    overflow, so a `0` would be a false all-clear about a machine nothing asked.
+    It is therefore emitted from `collectUserspaceStatus` — **only on a scrape
+    that actually read a status**. Absent means "no helper to ask"; `0` means
+    "the helper reported no overflow".
+
+    Not an error, and it must never touch `xpf_counter_read_errors_total`: an
+    overflowed zone degrades to "not known" on every read surface rather than
+    publishing a false zero, so no surface reports wrong numbers. What overflow
+    costs is the ability to tell **why**, which is what this restores.
+
+    `show security zones` consumes the same flag: on the unpopulated branch it
+    names capacity exhaustion specifically instead of listing three causes the
+    operator cannot choose between. It fails to the ambiguous line on any status
+    error — telling someone to reduce their zone count when the real cause was an
+    idle zone is worse than saying "cannot tell".
+
+    **REST deliberately does NOT carry it.** `/security/zones` returns a bare
+    `[]ZoneInfo` with no response envelope, so a response-level field would mean
+    changing the response from an array to an object — a breaking API shape change
+    that should be decided on its own merits, not ridden in on an observability
+    fix. Per-zone placement was rejected too: overflow is a property of the slot
+    TABLE, and the helper does not report which zones lost their slots, so a
+    per-zone flag would be an invention.
+
     Consequence: **the gauge's cause set is strictly wider than
     `ErrCounterNotPopulated`'s.** The sentinel has exactly three meanings; the
     gauge has those plus every pre-read membership branch. The authoritative

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -112,6 +112,11 @@ type xpfCollector struct {
 	zonePacketsTotal             *prometheus.Desc
 	zoneBytesTotal               *prometheus.Desc
 	zoneCountersUnpopulatedZones *prometheus.Desc
+	// #6845: 0/1 — 1 while the helper's per-zone hot-path slot table has
+	// OVERFLOWED, so some configured zones are not being counted at all.
+	// Emitted only when a helper status was actually read, so its ABSENCE means
+	// "no helper to ask" rather than "no overflow" — see the descriptor.
+	zoneCountersOverflowActive *prometheus.Desc
 
 	// Policy counters. policyCountersUnpublishedRules is the policy analogue of
 	// zoneCountersUnpopulatedZones: the explicit "no counter published for this
@@ -715,6 +720,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.zonePacketsTotal
 	ch <- c.zoneBytesTotal
 	ch <- c.zoneCountersUnpopulatedZones
+	ch <- c.zoneCountersOverflowActive
 	ch <- c.policyHitsTotal
 	ch <- c.policyCountersUnpublishedRules
 	ch <- c.filterHitsTotal

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -1306,6 +1306,10 @@ func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
 	c.collectSurfaceADDNSMetrics(ch)
 	c.collectSystemMetrics(ch)
 	c.collectUserspaceStatus(ch, userspaceStatus)
+	// #6845: a top-level status-derived signal, emitted only when a status was
+	// actually read — see emitZoneCounterOverflow for why its absence and its 0
+	// mean different things.
+	c.emitZoneCounterOverflow(ch, userspaceStatus)
 }
 
 // #709: emit per-bucket counter samples. Bucket index maps to a

--- a/pkg/api/metrics_descriptors_zone.go
+++ b/pkg/api/metrics_descriptors_zone.go
@@ -117,6 +117,46 @@ func (c *xpfCollector) initZoneDescriptors() {
 	// per_zone_counters_available:false for (pkg/api/security.go zonesHandler),
 	// so the two surfaces cannot drift apart silently; the coherence is pinned
 	// by TestZoneUnpopulatedGaugeMatchesRESTAvailability.
+	// #6845: the one bit that disambiguates xpf_zone_counters_unpopulated_zones.
+	//
+	// That gauge is three-way ambiguous BY CONSTRUCTION — a zone reads
+	// unpopulated when the helper predates the per-zone populate path (#3651),
+	// when the zone OVERFLOWED the helper's 63-slot capacity so its traffic is
+	// genuinely being missed, or when the zone is simply idle and nothing is
+	// wrong at all. The first and third need no action; the second is an
+	// operational problem, and the bit separating them was already on the wire
+	// (ProcessStatus.ZoneCounterOverflowActive, from
+	// userspace-dp/src/afxdp/zone_counters.rs) and thrown away by every Go
+	// surface.
+	//
+	// ABSENCE and 0 mean different things here, deliberately, and differently
+	// from the sibling gauge above. That one is CONFIG-derived and is emitted
+	// above the dataplane gate, so it reads the full configured zone count in a
+	// degraded boot. This one is a property of the RUNNING helper's slot table:
+	// with no helper there is no slot table and no overflow to report, so it is
+	// emitted only on a scrape that actually read a status. Absent = "no helper
+	// to ask"; 0 = "the helper reported no overflow". A hardcoded 0 in the
+	// no-helper case would be a false all-clear.
+	//
+	// Not an error, and it must never touch xpf_counter_read_errors_total: an
+	// overflowed zone degrades to "not known" on every read surface rather than
+	// publishing a false zero, so nothing is misreported. What overflow costs is
+	// the ABILITY TO TELL WHY, which is what this gauge restores.
+	c.zoneCountersOverflowActive = prometheus.NewDesc(
+		"xpf_zone_counters_overflow_active",
+		"1 while the userspace helper's per-zone hot-path counter slot table has "+
+			"overflowed, so some configured security zones are not counted at "+
+			"all and their traffic volume is silently missing. The helper has "+
+			"63 assignable slots (slot 0 reserved of 64) and assigns them in "+
+			"sorted zone-id order, so zones past that capacity are never "+
+			"registered and read as unpopulated. Use with "+
+			"xpf_zone_counters_unpopulated_zones: that gauge cannot say WHY a "+
+			"zone is unpopulated (pre-#3651 helper, overflow, or simply idle), "+
+			"and this one distinguishes the case that needs action. Emitted only "+
+			"when a helper status was read this scrape -- its absence means "+
+			"there was no helper to ask, not that there is no overflow.",
+		nil, nil,
+	)
 	c.zoneCountersUnpopulatedZones = prometheus.NewDesc(
 		"xpf_zone_counters_unpopulated_zones",
 		"Number of configured security zones whose per-zone traffic counters "+

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -58,7 +58,6 @@ func (c *xpfCollector) collectUserspaceStatus(ch chan<- prometheus.Metric, statu
 		return
 	}
 	status := *statusPtr
-	c.emitZoneCounterOverflow(ch, status)
 	c.emitCoSOwnerProfile(ch, status)
 	c.emitCoSDrainPhaseTelemetry(ch, status)
 	c.emitCoSParkReasonTelemetry(ch, status)
@@ -1997,27 +1996,4 @@ func (c *xpfCollector) emitCoSEqualFlowEnforcement(ch chan<- prometheus.Metric, 
 			)
 		}
 	}
-}
-
-// emitZoneCounterOverflow publishes xpf_zone_counters_overflow_active (#6845).
-//
-// It lives on the STATUS path rather than beside collectZoneCounters, and that
-// placement is the design rather than convenience. collectZoneCounters runs
-// ABOVE the dataplane gate on purpose: its gauge is config-derived and must keep
-// reporting the full configured zone count through a degraded / config-only boot.
-// This flag is the opposite — it is a property of the RUNNING helper's slot
-// table. With no helper there is no slot table and no overflow to report, so
-// emitting a 0 there would be a false all-clear about a machine that has not
-// been asked.
-//
-// Hence: emitted on every scrape that read a status, absent on every scrape that
-// did not. collectUserspaceStatus returns early on a nil status, which gives that
-// contract for free.
-func (c *xpfCollector) emitZoneCounterOverflow(ch chan<- prometheus.Metric, status dpuserspace.ProcessStatus) {
-	v := 0.0
-	if status.ZoneCounterOverflowActive {
-		v = 1
-	}
-	ch <- prometheus.MustNewConstMetric(c.zoneCountersOverflowActive,
-		prometheus.GaugeValue, v)
 }

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -58,6 +58,7 @@ func (c *xpfCollector) collectUserspaceStatus(ch chan<- prometheus.Metric, statu
 		return
 	}
 	status := *statusPtr
+	c.emitZoneCounterOverflow(ch, status)
 	c.emitCoSOwnerProfile(ch, status)
 	c.emitCoSDrainPhaseTelemetry(ch, status)
 	c.emitCoSParkReasonTelemetry(ch, status)
@@ -1996,4 +1997,27 @@ func (c *xpfCollector) emitCoSEqualFlowEnforcement(ch chan<- prometheus.Metric, 
 			)
 		}
 	}
+}
+
+// emitZoneCounterOverflow publishes xpf_zone_counters_overflow_active (#6845).
+//
+// It lives on the STATUS path rather than beside collectZoneCounters, and that
+// placement is the design rather than convenience. collectZoneCounters runs
+// ABOVE the dataplane gate on purpose: its gauge is config-derived and must keep
+// reporting the full configured zone count through a degraded / config-only boot.
+// This flag is the opposite — it is a property of the RUNNING helper's slot
+// table. With no helper there is no slot table and no overflow to report, so
+// emitting a 0 there would be a false all-clear about a machine that has not
+// been asked.
+//
+// Hence: emitted on every scrape that read a status, absent on every scrape that
+// did not. collectUserspaceStatus returns early on a nil status, which gives that
+// contract for free.
+func (c *xpfCollector) emitZoneCounterOverflow(ch chan<- prometheus.Metric, status dpuserspace.ProcessStatus) {
+	v := 0.0
+	if status.ZoneCounterOverflowActive {
+		v = 1
+	}
+	ch <- prometheus.MustNewConstMetric(c.zoneCountersOverflowActive,
+		prometheus.GaugeValue, v)
 }

--- a/pkg/api/metrics_zone_overflow.go
+++ b/pkg/api/metrics_zone_overflow.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// emitZoneCounterOverflow publishes xpf_zone_counters_overflow_active (#6845).
+//
+// It lives on the STATUS path rather than beside collectZoneCounters, and that
+// placement is the design rather than convenience. collectZoneCounters runs
+// ABOVE the dataplane gate on purpose: its gauge is config-derived and must keep
+// reporting the full configured zone count through a degraded / config-only boot.
+// This flag is the opposite — it is a property of the RUNNING helper's slot
+// table. With no helper there is no slot table and no overflow to report, so
+// emitting a 0 there would be a false all-clear about a machine that has not
+// been asked.
+//
+// Hence: emitted on every scrape that read a status, absent on every scrape that
+// did not. It takes the POINTER and returns early on nil, so that contract is
+// stated here and directly testable, rather than inherited from a sibling
+// collector's early return where a later refactor could drop it silently.
+func (c *xpfCollector) emitZoneCounterOverflow(ch chan<- prometheus.Metric, statusPtr *dpuserspace.ProcessStatus) {
+	if statusPtr == nil {
+		return
+	}
+	status := *statusPtr
+	v := 0.0
+	if status.ZoneCounterOverflowActive {
+		v = 1
+	}
+	ch <- prometheus.MustNewConstMetric(c.zoneCountersOverflowActive,
+		prometheus.GaugeValue, v)
+}

--- a/pkg/api/metrics_zone_overflow_6845_test.go
+++ b/pkg/api/metrics_zone_overflow_6845_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -78,11 +80,8 @@ func TestZoneCounterOverflowGaugeAbsentWithNoStatus6845(t *testing.T) {
 
 // gatherZoneOverflow6845 drives the real collector path.
 //
-// A PLAIN registry, not a pedantic one, and the reason is worth recording:
-// collectUserspaceStatus fans out to ~70 other metric families, so a pedantic
-// registry demands this cell declare every one of their descriptors just to ask
-// about one gauge — and a Describe list maintained by hand to satisfy a registry
-// is a second inventory that drifts.
+// A PLAIN registry, not a pedantic one: a hand-maintained Describe list written
+// to satisfy a registry is a second inventory that drifts.
 //
 // The Describe ⊇ Collect contract is NOT dropped, it is owned elsewhere:
 // metrics_descriptor_coverage_test.go runs the REAL Collect through a pedantic
@@ -111,10 +110,14 @@ func gatherZoneOverflow6845(t *testing.T, status *dpuserspace.ProcessStatus) (fl
 	return 0, false
 }
 
-// zoneOverflowOnlyCollector6845 exercises collectUserspaceStatus — the REAL
-// entry point, including its nil-status early return, which is what produces the
-// absence contract. Driving emitZoneCounterOverflow directly would bind the
-// emitter and miss the gate, which is the wiring half of the defect.
+// zoneOverflowOnlyCollector6845 drives emitZoneCounterOverflow with the same
+// *ProcessStatus the production Collect hands it, including nil — which is where
+// the absence contract lives, in the emitter itself rather than inherited from a
+// sibling's early return.
+//
+// The WIRING half — that Collect actually calls it — is bound separately by
+// TestCollectStillCallsTheOverflowEmitter6845 below, because a cell that calls
+// the emitter cannot see whether anything else does.
 type zoneOverflowOnlyCollector6845 struct {
 	c      *xpfCollector
 	status *dpuserspace.ProcessStatus
@@ -125,5 +128,57 @@ func (z *zoneOverflowOnlyCollector6845) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (z *zoneOverflowOnlyCollector6845) Collect(ch chan<- prometheus.Metric) {
-	z.c.collectUserspaceStatus(ch, z.status)
+	z.c.emitZoneCounterOverflow(ch, z.status)
+}
+
+// TestCollectStillCallsTheOverflowEmitter6845 is the WIRING cell.
+//
+// Every cell above calls emitZoneCounterOverflow directly, so a Collect that
+// stopped calling it would pass all of them while the series vanished from every
+// scrape — the decoded-but-unread state this issue exists to fix, one layer up.
+// Collect cannot be driven from a unit test without a loaded dataplane, so the
+// call is asserted at the source with comments stripped.
+//
+// FAIL-ON-REVERT: delete the c.emitZoneCounterOverflow(ch, userspaceStatus) line
+// from Collect and this reds.
+func TestCollectStillCallsTheOverflowEmitter6845(t *testing.T) {
+	src := stripComments6845(readAPISource6845(t, "metrics.go"))
+	const call = "c.emitZoneCounterOverflow(ch, userspaceStatus)"
+	if !strings.Contains(src, call) {
+		t.Fatalf("Collect does not call emitZoneCounterOverflow; " +
+			"xpf_zone_counters_overflow_active is emitted by nothing, which is " +
+			"exactly the decoded-but-unread state #6845 fixes")
+	}
+	// It must sit AFTER the status fetch, or it would be handed a nil status on
+	// every scrape and the gauge would be permanently absent — indistinguishable
+	// from "no helper", and wrong on a healthy box.
+	fetch := strings.Index(src, "userspaceStatus := fetchUserspaceStatus(dp)")
+	if fetch < 0 {
+		t.Fatal("could not find the status fetch to order against")
+	}
+	if strings.Index(src, call) < fetch {
+		t.Error("emitZoneCounterOverflow is called BEFORE the status is fetched, " +
+			"so it would always receive nil and the gauge would never be emitted")
+	}
+}
+
+func readAPISource6845(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}
+
+func stripComments6845(s string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(s, "\n") {
+		if i := strings.Index(line, "//"); i >= 0 {
+			line = line[:i]
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
 }

--- a/pkg/api/metrics_zone_overflow_6845_test.go
+++ b/pkg/api/metrics_zone_overflow_6845_test.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// metrics_zone_overflow_6845_test.go — #6845.
+//
+// `ProcessStatus.ZoneCounterOverflowActive` was decoded by the Go control plane
+// and consumed by NOTHING — no CLI, no REST, no gRPC, no Prometheus. When the
+// helper's 63-slot per-zone table overflows, zones past capacity are never
+// registered, read as `ErrCounterNotPopulated`, and render as "not available"
+// on every surface.
+//
+// Nothing is misreported by that: an overflowed zone degrades to "not known"
+// rather than publishing a false 0. What is missing is the ability to tell WHY,
+// because `unpopulated` is three-way ambiguous by construction — pre-#3651
+// helper, overflow (traffic genuinely missed), or an idle zone. Only the middle
+// one needs action, and the bit separating it was already on the wire.
+//
+// These cells bind the surfacing, since a decoded-but-unread field is exactly
+// what regressed here and a field that no test reads regresses again silently.
+
+// TestZoneCounterOverflowGaugeTracksTheStatus6845 is PAIRED. The overflow leg
+// alone is satisfied by a gauge hardwired to 1, which would tell every healthy
+// operator to go reduce their zone count; the healthy leg alone is satisfied by
+// one hardwired to 0, which is the pre-#6845 blindness with a series attached.
+func TestZoneCounterOverflowGaugeTracksTheStatus6845(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		overflow bool
+		want     float64
+	}{
+		{"overflowed", true, 1},
+		{"healthy", false, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := gatherZoneOverflow6845(t, &dpuserspace.ProcessStatus{
+				ZoneCounterOverflowActive: tc.overflow,
+			})
+			if !ok {
+				t.Fatalf("xpf_zone_counters_overflow_active was not emitted from a " +
+					"status that was successfully read; the operator cannot tell an " +
+					"overflowed zone from an idle one, which is #6845")
+			}
+			if got != tc.want {
+				t.Errorf("gauge = %v, want %v — it does not track "+
+					"ZoneCounterOverflowActive, so it reports the same value whether "+
+					"or not zones are going uncounted", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestZoneCounterOverflowGaugeAbsentWithNoStatus6845 pins the absence contract,
+// which differs deliberately from its sibling gauge.
+//
+// `xpf_zone_counters_unpopulated_zones` is CONFIG-derived and is emitted above
+// the dataplane gate, so it keeps reporting through a degraded boot. This one is
+// a property of the RUNNING helper's slot table: with no helper there is no slot
+// table, so a 0 would be a false all-clear about a machine that was never asked.
+// Absent must mean "no helper to ask"; 0 must mean "the helper said no overflow".
+//
+// FAIL-ON-REVERT: emit the gauge unconditionally (e.g. hoist it out of
+// collectUserspaceStatus, or default it to 0 when the status pointer is nil) and
+// this reds.
+func TestZoneCounterOverflowGaugeAbsentWithNoStatus6845(t *testing.T) {
+	if _, ok := gatherZoneOverflow6845(t, nil); ok {
+		t.Error("xpf_zone_counters_overflow_active was emitted with NO helper " +
+			"status read; a 0 there is a false all-clear — it asserts there is no " +
+			"overflow on a machine nothing asked")
+	}
+}
+
+// gatherZoneOverflow6845 drives the real collector path.
+//
+// A PLAIN registry, not a pedantic one, and the reason is worth recording:
+// collectUserspaceStatus fans out to ~70 other metric families, so a pedantic
+// registry demands this cell declare every one of their descriptors just to ask
+// about one gauge — and a Describe list maintained by hand to satisfy a registry
+// is a second inventory that drifts.
+//
+// The Describe ⊇ Collect contract is NOT dropped, it is owned elsewhere:
+// metrics_descriptor_coverage_test.go runs the REAL Collect through a pedantic
+// registry over the whole collector (#1726), so a descriptor emitted here and not
+// declared in Describe reds there. Splitting the two questions keeps each cell
+// able to fail for one reason.
+func gatherZoneOverflow6845(t *testing.T, status *dpuserspace.ProcessStatus) (float64, bool) {
+	t.Helper()
+	c := newCollector(&Server{})
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(&zoneOverflowOnlyCollector6845{c: c, status: status})
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != "xpf_zone_counters_overflow_active" {
+			continue
+		}
+		ms := mf.GetMetric()
+		if len(ms) != 1 {
+			t.Fatalf("metric count = %d, want 1", len(ms))
+		}
+		return ms[0].GetGauge().GetValue(), true
+	}
+	return 0, false
+}
+
+// zoneOverflowOnlyCollector6845 exercises collectUserspaceStatus — the REAL
+// entry point, including its nil-status early return, which is what produces the
+// absence contract. Driving emitZoneCounterOverflow directly would bind the
+// emitter and miss the gate, which is the wiring half of the defect.
+type zoneOverflowOnlyCollector6845 struct {
+	c      *xpfCollector
+	status *dpuserspace.ProcessStatus
+}
+
+func (z *zoneOverflowOnlyCollector6845) Describe(ch chan<- *prometheus.Desc) {
+	ch <- z.c.zoneCountersOverflowActive
+}
+
+func (z *zoneOverflowOnlyCollector6845) Collect(ch chan<- prometheus.Metric) {
+	z.c.collectUserspaceStatus(ch, z.status)
+}

--- a/pkg/cli/cli_show_security_zones.go
+++ b/pkg/cli/cli_show_security_zones.go
@@ -95,10 +95,27 @@ func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone strin
 				// security zones` prints real byte counts for slotted zones and
 				// "not implemented" for overflowed ones, pointing the operator
 				// at the wrong cause.
-				fmt.Println("  Traffic statistics: not available " +
-					"(no per-zone volume published for this zone: helper predates " +
-					"per-zone accounting, the zone exceeded the dataplane's " +
-					"hot-path slot capacity, or the zone is idle)")
+				// #6845: when the helper reports its slot table has OVERFLOWED,
+				// say so instead of listing three causes the operator has no way
+				// to choose between. Overflow is the only one of the three that
+				// needs action — traffic is genuinely being missed — and the bit
+				// that identifies it is already on the wire
+				// (ProcessStatus.ZoneCounterOverflowActive) and was read by
+				// nothing. The generic line stays for the other two causes,
+				// because with no overflow they remain genuinely ambiguous and
+				// naming one would be a guess.
+				if zoneCounterOverflowActive(c) {
+					fmt.Println("  Traffic statistics: not available " +
+						"(the dataplane's per-zone hot-path slot capacity is " +
+						"EXHAUSTED, so this zone's traffic is not being counted " +
+						"at all; reduce the number of configured zones or accept " +
+						"that zones past the capacity go uncounted)")
+				} else {
+					fmt.Println("  Traffic statistics: not available " +
+						"(no per-zone volume published for this zone: helper predates " +
+						"per-zone accounting, the zone exceeded the dataplane's " +
+						"hot-path slot capacity, or the zone is idle)")
+				}
 			case errIn == nil && errOut == nil:
 				fmt.Println("  Traffic statistics:")
 				fmt.Printf("    Input:  %d packets, %d bytes\n",
@@ -220,4 +237,27 @@ func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone strin
 		}
 	}
 	return nil
+}
+
+// zoneCounterOverflowActive reports whether the helper says its per-zone
+// hot-path slot table has overflowed (#6845).
+//
+// Fails to FALSE on any error, deliberately: the caller uses it to REPLACE a
+// truthful three-cause message with a specific one-cause message, so a wrong
+// true would tell the operator to go reduce their zone count when the real cause
+// might be an idle zone. An unreachable helper means "cannot say", and "cannot
+// say" must fall back to the honest ambiguous line rather than guess.
+//
+// The status read is per-invocation of `show security zones` and only on the
+// branch that has already decided the zone is unpopulated, so it costs nothing on
+// the healthy path.
+func zoneCounterOverflowActive(c *CLI) bool {
+	if c == nil {
+		return false
+	}
+	status, err := c.userspaceDataplaneStatus()
+	if err != nil {
+		return false
+	}
+	return status.ZoneCounterOverflowActive
 }


### PR DESCRIPTION
Closes #6845.

`ProcessStatus.ZoneCounterOverflowActive` was decoded by the Go control plane and
consumed by **nothing** — no CLI, no REST, no gRPC, no Prometheus. The Rust helper
has 63 assignable per-zone slots (slot 0 reserved of 64) and sets the flag on
exhausting them; zones past capacity are never registered, so their traffic is
silently uncounted.

## This is an observability gap, not a correctness bug — and that shapes the fix

An overflowed zone is never registered with `ZoneCounterStore`, so it reads
`ErrCounterNotPopulated` and every surface already renders an explicit "not
available". **Nothing publishes a false 0.** What is missing is the ability to tell
**why**, because `unpopulated` is three-way ambiguous by construction:

1. the helper predates the per-zone populate path (#3651),
2. the zone overflowed the 63-slot capacity — **traffic genuinely missed**,
3. the zone is simply idle — nothing is wrong.

Only (2) needs action. The bit separating it was already on the wire and thrown
away.

## Absence semantics are the OPPOSITE of the sibling gauge's, deliberately

`xpf_zone_counters_unpopulated_zones` is **config-derived** and emitted **above**
the dataplane gate, so it keeps reporting the full configured zone count through a
degraded boot — its absence must mean "the scrape did not run".

Overflow is a property of the **running helper's slot table**. With no helper
there is no slot table and nothing to overflow, so a `0` would be a false
all-clear about a machine nothing asked. So `xpf_zone_counters_overflow_active` is
emitted **only on a scrape that actually read a status**:

| | meaning |
|---|---|
| absent | no helper to ask |
| `0` | the helper reported no overflow |
| `1` | slots exhausted — zones going uncounted |

## `show security zones` fails to the AMBIGUOUS line

On the unpopulated branch the CLI now names capacity exhaustion specifically
instead of listing three causes the operator cannot choose between — but
`zoneCounterOverflowActive` returns **false on any status error**. It is replacing
a truthful three-cause message with a specific one-cause message, so a wrong
`true` would send someone to reduce their zone count when the real cause was an
idle zone. "Cannot say" must fall back to honest ambiguity.

## REST deliberately not carried

`/security/zones` returns a bare `[]ZoneInfo` with no envelope, so a
response-level field means changing an array response into an **object** — a
breaking API shape change that deserves its own decision rather than riding in on
an observability fix. Per-zone placement was rejected too: the helper does not
report **which** zones lost their slots, so a per-zone flag would be an invention.

## The modularity gate caught me, and I moved the code rather than accepting it

`TestTouchedFileCrossedModularityThreshold` redded:
`pkg/api/metrics_userspace.go` sat at **1999** LOC and the emitter pushed it to
**2023**. Moving the emitter to its own file still left it at **2000** — the
single *call* line was enough to cross — so the call moved to `metrics.go`
(1345 LOC, ample headroom), beside the other top-level status-derived collectors.
`metrics_userspace.go` is back at 1999 and **no acceptance entry was spent on a
one-line crossing**.

The relocation improved the design rather than dodging the gate: the emitter now
takes `*ProcessStatus` and returns early on nil, so the absence contract is
**stated where the emitter is** and directly tested, instead of inherited from
`collectUserspaceStatus`'s early return where a later refactor could drop it
silently. It also forced the wiring cell.

## Mutation matrix

Full-package `go test -count=1 ./pkg/api/`, no `-run` filter, control GREEN.

| # | Mutation | Result | Cell |
|---|---|---|---|
| M1 | `Collect` stops calling the emitter (**the decoded-but-unread state restored**) | **RED** | `TestCollectStillCallsTheOverflowEmitter6845` |
| M2 | gauge hardwired to **0** — pre-fix blindness with a series attached | **RED** | — |
| M3 | gauge hardwired to **1** — would tell every healthy operator to cut zones | **RED** | `TestZoneCounterOverflowGaugeTracksTheStatus6845` |
| M4 | nil status emits `0` instead of nothing — the false all-clear | **RED** | `TestZoneCounterOverflowGaugeAbsentWithNoStatus6845` |
| M5b | the call MOVED above the status fetch — always nil, series never emitted | **RED** | — |

**M5 was a bad mutation on the first cut and I re-cut it.** I *added* a
`c.emitZoneCounterOverflow(ch, nil)` call before the fetch rather than *moving*
the real one — a different string than the ordering cell searches for, so the cell
never saw it and returned GREEN. Re-cut as an actual move, it reds. A mutation
must restore what the defect would look like, not a paraphrase of it.

## Test note

The cells use a **plain** registry: a pedantic one would demand this cell declare
~70 sibling descriptors by hand, and a Describe list maintained to satisfy a
registry is a second inventory that drifts. The Describe ⊇ Collect contract stays
owned by `metrics_descriptor_coverage_test.go`'s whole-collector pedantic canary
(#1726) — verified still passing, so splitting the questions costs no coverage.

## Validation

- `go build ./...` **rc=0**, `go vet ./...` **rc=0**, `go test -count=1 ./...`
  repo-wide **rc=0**, `UNMERGED=0`, at HEAD
  `4ba0819acceb2371b933474badc7c87d214ddfcb` (merges current `origin/master`).
- Rust touched: **0** — no cargo leg owed.
- Docs: `pkg/api/README.md`, in the per-zone-counter section beside the sibling
  gauge, including why REST is excluded.

## Smoke

Not owed — a read-only observability addition. Worth naming what a real one
would be, since throughput cannot see it: configure **64+ zones** so the helper
exhausts its 63 slots, then confirm `xpf_zone_counters_overflow_active` reads 1
and `show security zones` names capacity exhaustion on the zones that lost slots.
