### PR TITLE
docs: gofmt -w on a directory is a scope hazard in this repo

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -106039,3 +106039,20 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/daemon/daemon_apply_commit.go`, `pkg/daemon/daemon_run_servers.go`,
   `pkg/daemon/daemon_apply_tail.go`, `pkg/configstore/README.md`,
   plus mechanical test migrations, `_Log.md`
+
+## 2026-08-26 — engineering-style: gofmt -w on a directory is a scope hazard here
+
+- **Timestamp**: 2026-08-26
+- **Action**: Add "format the files you TOUCHED, never a directory" to
+  `docs/engineering-style.md`'s reviewing section.
+- **Why**: `gofmt -w pkg/daemon` reformatted 12 pre-existing unformatted files a
+  lane had never touched, silently widening its diff. The underlying fact is
+  repo-specific and worth stating: master CARRIES unformatted files, so
+  `gofmt -w <dir>` is not idempotent with respect to your change here, and a
+  widened diff is how an unrelated change rides in unreviewed.
+- **Includes the recovery**, since the lane worked it out under time pressure:
+  for each modified `.go`, if its diff adds none of your change's identifiers,
+  `git checkout HEAD -- <file>`.
+- **Found by**: the lane driving #6808, caught in `git status` rather than at
+  review.
+- **File(s)**: `docs/engineering-style.md`, `_Log.md`

--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -465,6 +465,15 @@ Rules of thumb:
 - **A tool-gated leg that SKIPs is a green that measured nothing.** Say
   whether it ran. `nft`-dependent parity, cargo legs, cluster smoke:
   report tests-collected, not just `ok`.
+- **Format the files you TOUCHED, never a directory.** `gofmt -w pkg/daemon`
+  reformatted **12 pre-existing unformatted files** a lane had never
+  touched, silently widening its diff. Master carries unformatted files,
+  so `gofmt -w` on a directory is not idempotent with respect to your
+  change in this repo specifically — and a widened diff is how an
+  unrelated change rides in unreviewed. Use `gofmt -w <file>...`. If it
+  has already happened, recover by filtering: for each modified `.go`,
+  if its diff adds none of your change's identifiers,
+  `git checkout HEAD -- <file>`.
 - **Two independent review surfaces.** Codex (hostile, design-level)
   and Copilot (inline, mechanical-detail) catch different classes of
   bugs. Treat them as separate passes; do not skip either. Codex


### PR DESCRIPTION
Documentation only — `docs/engineering-style.md` plus a `_Log.md` entry.

`gofmt -w pkg/daemon` reformatted **12 pre-existing unformatted files** a lane had
never touched, silently widening its diff.

The underlying fact is repo-specific and worth stating rather than leaving people
to rediscover: **master carries unformatted files**, so `gofmt -w` on a directory
is not idempotent with respect to *your* change here. And a widened diff is how an
unrelated change rides in unreviewed — the reviewer sees noise and stops reading
it.

So: **format the files you touched** — `gofmt -w <file>...`, never a directory.

The rule also carries the recovery, because the lane worked it out under time
pressure and it should not have to be re-derived: for each modified `.go`, if its
diff adds none of your change's identifiers, `git checkout HEAD -- <file>`.

Found by the lane driving #6808, caught in `git status` rather than at review.

## A note on this PR's own history

The first commit landed the `_Log.md` entry **without** the doc change — my
anchor missed on a line-wrap difference, the assertion fired, and the `&&`-chained
commit ran anyway on the `_Log.md` append alone. So for one commit this branch
carried a log entry describing a change that had not happened, which is the
claim-without-the-change defect the campaign has been sweeping.

Caught by checking `git show --stat` rather than trusting the edit script's exit,
fixed by amending with both files. Recording it because "the edit script said ok"
is not the same as "the file changed", and this is the second time today an
anchored edit has quietly no-op'd.

## Validation

`go build ./...` **rc=0**, `go test -count=1 ./...` repo-wide **rc=0** at HEAD
`5f7e7c6a0dd9368764d4d5198bf0009817b3d1f5`. Prose cannot break a build, but
`pkg/refactoraudit` carries source-scanning gates that read docs, so the run is
not ceremony. No Rust, no smoke owed.
