### PR TITLE
eventengine: roll back the edge latch when the action is not admitted (#6810)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,45 @@
+## 2026-08-26 — #6810: a queue-full drop no longer consumes a threshold crossing
+
+- **Timestamp**: 2026-08-26
+- **Action**: `evaluateEvent` arms the #3756 edge latch under `e.mu` and
+  returns; `HandleEvent` classifies and enqueues afterwards, OUTSIDE that lock,
+  and `enqueue` returned nothing — so a dropped action was indistinguishable
+  from an admitted one at the call site. Not a delayed remediation but a LOST
+  one: `withinMatches` suppresses every later at/above-threshold event while the
+  latch is armed and re-arms only when a clause drops BELOW threshold, which for
+  a sustained fault never happens. 64 distinct other policies saturating the
+  queue therefore permanently consumed the crossing.
+  `enqueue` now returns an admission verdict; `HandleEvent` calls
+  `releaseEdgeLatch` on false, carrying the same semantic-revision ABA guard
+  `armCooldown` uses (#5311) so a predecessor's failure cannot clear a
+  successor generation's latch. A SUPERSEDED placement counts as admitted — the
+  newer equivalent action is queued, which is exactly what the latch asserts.
+  Went past R71's enumeration: `HandleEvent` has THREE post-latch abandonment
+  paths, not one. Deliberately did NOT roll back the other two, and pinned that
+  as an executable decision — a `classifyPlan` rejection is DETERMINISTIC, so
+  re-arming would re-reject on every event (unbounded churn for a remediation
+  that can never run), and an empty op list had no remediation to lose. Only the
+  queue-full drop is transient, i.e. the only one where retrying succeeds.
+- **File(s)**: `pkg/eventengine/engine.go`,
+  `pkg/eventengine/engine_latch_before_admission_6810_test.go` (new),
+  `pkg/eventengine/README.md`, `docs/refactoring-audit-accepted.txt`, `_Log.md`
+- **Modularity**: the 63 LOC tipped `engine.go` 1477 -> 1540, crossing the soft
+  1500 `[WATCH]` floor. Recorded as a deliberate deferral with its reason rather
+  than split inline: the whole diff lives in `enqueue`/`HandleEvent`, so a
+  verbatim move would carry the fix inside it and make "new or moved?"
+  unanswerable on a change about a subtle ordering property. Under the 200-LOC
+  "split first" cue and the soft floor, not the hard 2000. None of the three
+  documented "When NOT to refactor" cases actually applies, so it is an ISSUE
+  (#7636) rather than a permanent acceptance.
+- **Validation**: cells drive the REAL `HandleEvent` — every pre-existing
+  edge-latch test calls `evaluateEvent` directly and is structurally blind to
+  the seam the defect lives in. Includes the 64-distinct-policy saturation test
+  R71 asks for, with a precondition asserting the drop actually happened; a
+  PAIRED control proving an ADMITTED sustained level still fires exactly once
+  (otherwise the rollback would degrade `trigger on` from edge- to
+  level-triggered, re-introducing what #3756 M1 removed); and a stale-revision
+  cell proving the ABA guard holds.
+
 ## 2026-08-26 — #6807 r2: make the quarantined withdrawal alertable
 
 - **Timestamp**: 2026-08-26

--- a/docs/refactoring-audit-accepted.txt
+++ b/docs/refactoring-audit-accepted.txt
@@ -21,3 +21,4 @@
 # has landed, every later branch measures the file as already over the
 # floor and no longer crosses it, so an entry may be pruned as soon as it
 # stops describing a live decision. It is a decision record, not state.
+[WATCH] pkg/eventengine/engine.go #6810 added 63 LOC (mostly the admission-verdict and latch-rollback rationale) and tipped it 1477 -> 1540. The file SHOULD be split — queue admission (enqueue/supersede/counters) and evaluation (evaluateEvent/withinMatches/pruneWindow) are two cohesive units — but not inside this PR: the change is a lost-remediation fix whose whole diff lives in enqueue and HandleEvent, so a verbatim code move would carry the fix with it and make "is this line new or moved?" unanswerable in review. Under the 200-LOC "split first" cue, and the soft 1500 floor rather than the hard 2000. Deferred as its own refactor, tracked in #7636.

--- a/pkg/eventengine/README.md
+++ b/pkg/eventengine/README.md
@@ -383,6 +383,42 @@ Junos reading in `withinMatches` (`engine.go`):
   `TestEdgeTriggerOn_*_3756`. Only a policy carrying a `trigger on` clause
   latches (`policyHasTriggerOn`); a no-within or `trigger until` policy is
   unaffected.
+- **The latch is rolled back when the action it authorized is never admitted
+  (#6810).** `evaluateEvent` arms the latch under `e.mu` and returns;
+  `HandleEvent` classifies and enqueues afterwards, OUTSIDE that lock. `enqueue`
+  used to return nothing, so a dropped action was indistinguishable from an
+  admitted one at the call site — and the consequence was not a delayed
+  remediation but a LOST one: `withinMatches` suppresses every later
+  at/above-threshold event while the latch is armed and re-arms only when a
+  clause's count drops BELOW its threshold, which for the sustained fault a
+  policy exists to remediate never happens. A transient saturation of the 64-slot
+  queue by 64 DISTINCT other policies therefore permanently consumed the
+  crossing.
+
+  `enqueue` now returns an admission verdict and `HandleEvent` calls
+  `releaseEdgeLatch` when it is false, restoring the invariant the latch
+  expresses — *this crossing already fired* — for a crossing that did not. A
+  **superseded** placement counts as admitted: the newer equivalent action is
+  queued, which is what the latch asserts. The rollback carries the same
+  semantic-revision ABA guard `armCooldown` uses (#5311): if a successor
+  generation was installed (or the policy removed) while the action was being
+  classified and rejected, its latch belongs to the successor and a
+  predecessor's failure must not clear it. A concurrent event landing between
+  the drop and the rollback is still suppressed, so the cost is a delay to the
+  next event rather than a consumed crossing.
+
+  **Two sibling paths deliberately do NOT roll back**, and the distinction is
+  transient-vs-deterministic. A `classifyPlan` rejection (malformed/unknown
+  command) fails identically every time, so re-arming would re-evaluate and
+  re-reject on every subsequent event — unbounded churn for a remediation that
+  can never run; it is counted (`rejected`) and logged once instead. An empty op
+  list had no remediation to lose. Only the queue-full drop is transient, i.e.
+  the only one where retrying succeeds. Pinned as an executable decision by
+  `TestClassifyRejectAndEmptyPlanKeepTheLatch6810` so the scope is not mistaken
+  for an oversight later. Regression-locked by
+  `engine_latch_before_admission_6810_test.go`, which drives the real
+  `HandleEvent` — every pre-existing edge-latch test calls `evaluateEvent`
+  directly and is structurally blind to this seam.
 - **`trigger until N` fires through the INCLUSIVE N-th event**, then stops
   (Junos "trigger UNTIL the event has been received N times" — the N-th
   occurrence is the last that fires). The current event is appended to the

--- a/pkg/eventengine/engine.go
+++ b/pkg/eventengine/engine.go
@@ -563,14 +563,22 @@ func (e *Engine) HandleEvent(ev rpm.Event) {
 		// evaluate (#3750) so the worker can revalidate it against live engine
 		// state before committing, plus the triggering-event context (#3754)
 		// for the remediation commit's audit description.
-		e.enqueue(plannedAction{
+		if !e.enqueue(plannedAction{
 			policyName: tp.pol.Name,
 			semRev:     tp.semRev,
 			event:      ev.Name,
 			testOwner:  ev.TestOwner,
 			testName:   ev.TestName,
 			ops:        ops,
-		})
+		}) {
+			// #6810: the action was NOT admitted, so this crossing did not
+			// fire. evaluateEvent already armed the edge latch for it; leaving
+			// it armed makes withinMatches suppress every later at/above-
+			// threshold event until some clause drops below its threshold —
+			// which, for the sustained fault the remediation exists to fix,
+			// never happens. Roll it back so the next event retries.
+			e.releaseEdgeLatch(tp.pol.Name, ev.Name, tp.semRev)
+		}
 	}
 }
 
@@ -646,7 +654,17 @@ func (e *Engine) Stats() Stats {
 // otherwise a second producer could take a slot supersede freed while draining
 // and force supersede to drop an already-accepted survivor. See the enqueueMu
 // field comment for the lock-ordering rationale.
-func (e *Engine) enqueue(a plannedAction) {
+// enqueue returns whether the action was ADMITTED — i.e. whether an equivalent
+// action for this policy is now queued for the worker. It returns false only
+// when nothing will run: a genuine capacity drop, or a shutdown fast-exit.
+//
+// #6810: the verdict exists because the caller has already armed the edge latch
+// for this crossing by the time it gets here. Before this, enqueue returned
+// nothing, so a dropped action was indistinguishable from an admitted one at
+// the call site and the latch stayed armed over a remediation that never ran.
+// A superseded placement still counts as admitted: the newer equivalent action
+// IS queued, which is exactly what the latch is asserting.
+func (e *Engine) enqueue(a plannedAction) bool {
 	e.enqueueMu.Lock()
 	defer e.enqueueMu.Unlock()
 	// Fast exit during shutdown: don't churn the queue for an action the worker
@@ -655,11 +673,11 @@ func (e *Engine) enqueue(a plannedAction) {
 	// consumer left to drain it.
 	select {
 	case <-e.stopCh:
-		return
+		return false
 	default:
 	}
 	if e.supersede(a) {
-		return
+		return true
 	}
 	// supersede could not place `a`: the queue is full of OTHER policies'
 	// actions and there was no same-policy entry to evict. This is the only
@@ -667,6 +685,51 @@ func (e *Engine) enqueue(a plannedAction) {
 	e.counters.droppedQueueFull.Add(1)
 	slog.Warn("event-options: action queue full, dropping remediation",
 		"policy", a.policyName)
+	return false
+}
+
+// releaseEdgeLatch clears the #3756 edge latch that evaluateEvent armed for one
+// crossing, when the action that crossing authorized was never admitted (#6810).
+//
+// evaluateEvent arms the latch under e.mu and returns; HandleEvent classifies
+// and enqueues afterwards, outside that lock. If the queue is full of OTHER
+// policies' actions the remediation is dropped — and because withinMatches
+// suppresses every later at/above-threshold event while the latch is armed, and
+// only re-arms when a clause's count falls BELOW its threshold, a transient
+// queue saturation permanently consumed the crossing. For a sustained fault the
+// level never drops, so the configured remediation simply never ran.
+//
+// Rolling the latch back restores the invariant the latch is supposed to
+// express: "this crossing already fired". A crossing whose action was dropped
+// did not fire.
+//
+// authRev is the policy's semantic revision as of the evaluate that armed the
+// latch, and the guard is the same ABA defence armCooldown uses (#5311): if a
+// successor generation was installed (or the policy removed) while this action
+// was being classified and rejected, its latch state belongs to the successor
+// and must not be cleared by a predecessor's failure. Identity check and clear
+// happen in ONE critical section under e.mu so a concurrent Apply cannot swap
+// the runtime between them.
+//
+// Lock order is safe by construction: the caller has already released
+// enqueueMu (enqueue returns before this runs), so e.mu is never taken while
+// enqueueMu is held.
+//
+// A concurrent event that lands between the drop and this rollback is still
+// suppressed by the armed latch — the window is one classify+enqueue — so the
+// crossing costs at most a delay to the next event rather than being consumed
+// outright, which is the whole of the defect.
+func (e *Engine) releaseEdgeLatch(name, eventName, authRev string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.semRev[name] != authRev {
+		// Successor generation installed, or the policy removed, while this
+		// action was rejected. Its latch is not ours to clear.
+		return
+	}
+	if rt := e.runtime[name]; rt != nil {
+		rt.onLatched[eventName] = false
+	}
 }
 
 // supersede non-blockingly rebuilds the queue, replacing any existing

--- a/pkg/eventengine/engine_latch_before_admission_6810_test.go
+++ b/pkg/eventengine/engine_latch_before_admission_6810_test.go
@@ -1,0 +1,264 @@
+package eventengine
+
+// engine_latch_before_admission_6810_test.go — #6810.
+//
+// evaluateEvent arms the #3756 edge latch under e.mu and returns the trigger.
+// HandleEvent classifies and enqueues AFTERWARDS, outside that lock — and
+// enqueue returned nothing, so a dropped action was indistinguishable from an
+// admitted one at the call site.
+//
+// The consequence is not a delayed remediation, it is a LOST one. withinMatches
+// suppresses every later at/above-threshold event while the latch is armed, and
+// re-arms only when a clause's count falls BELOW its threshold. For the
+// sustained fault an event-options policy exists to remediate, the level does
+// not fall — so a transient queue saturation permanently consumed the crossing
+// and the configured remediation simply never ran.
+//
+// These cells drive the REAL HandleEvent (classify + enqueue + rollback), not
+// evaluateEvent, because the whole defect lives in the seam BETWEEN them: every
+// pre-existing edge-latch test calls evaluateEvent directly and is structurally
+// incapable of seeing it.
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/rpm"
+)
+
+// newInertEngine6810 builds an engine on a deterministic clock whose action
+// worker never starts, so the queue is inert and a full queue STAYS full.
+// HandleEvent would normally start the worker via startOnce; consuming the
+// once here is the same seam the #5853/#5062 queue tests rely on.
+func newInertEngine6810(t *testing.T) (*Engine, func(int64)) {
+	t.Helper()
+	e := New(nil, nil)
+	t.Cleanup(e.Close)
+	e.startOnce.Do(func() {}) // the worker must never drain the queue
+	base := time.Unix(1_700_000_000, 0)
+	var cur int64
+	e.nowFn = func() time.Time { return base.Add(time.Duration(cur) * time.Second) }
+	return e, func(tick int64) { cur = tick }
+}
+
+// edgePolicy6810 is an edge-triggered policy with a real `then` command, so
+// classifyPlan yields a non-empty op list and the action actually reaches
+// enqueue.
+func edgePolicy6810(name, event string, triggerOn int) *config.EventPolicy {
+	return &config.EventPolicy{
+		Name:          name,
+		Events:        []string{event},
+		WithinClauses: []*config.EventWithin{{Seconds: 300, TriggerOn: triggerOn}},
+		ThenCommands:  []string{"set system host-name remediated-" + name},
+	}
+}
+
+// saturateWithOtherPolicies6810 fills all 64 slots with DISTINCT other-policy
+// actions — the exact shape R71 names. Distinct matters: supersede evicts a
+// same-policy entry, so a burst from one policy occupies a single slot (#5853)
+// and would never produce the capacity drop under test.
+func saturateWithOtherPolicies6810(t *testing.T, e *Engine) {
+	t.Helper()
+	for i := 0; i < actionQueueDepth; i++ {
+		if !e.enqueue(plannedAction{policyName: fmt.Sprintf("filler%03d", i)}) {
+			t.Fatalf("filler %d was not admitted; the queue could not be saturated, "+
+				"so this cell cannot reach the capacity drop it exists for", i)
+		}
+	}
+	if got := int(e.counters.queueDepth.Load()); got != actionQueueDepth {
+		t.Fatalf("queue depth = %d after saturation, want %d", got, actionQueueDepth)
+	}
+}
+
+// TestQueueFullDropDoesNotConsumeTheCrossing6810 is the issue, end to end.
+//
+// FAIL-ON-REVERT: drop the releaseEdgeLatch call in HandleEvent (or make
+// enqueue's verdict unconditional) and the latch stays armed over the dropped
+// action — the post-drain crossing is then suppressed as "already fired" and
+// the remediation never queues, so the final assertion goes RED.
+func TestQueueFullDropDoesNotConsumeTheCrossing6810(t *testing.T) {
+	e, at := newInertEngine6810(t)
+	const event = "ping_probe_failed"
+	pol := edgePolicy6810("remediate", event, 2)
+	e.Apply([]*config.EventPolicy{pol})
+
+	saturateWithOtherPolicies6810(t, e)
+
+	// Cross the threshold while the queue is full of OTHER policies. Event 1
+	// takes the count to 1 (below), event 2 is the crossing.
+	at(0)
+	e.HandleEvent(rpm.Event{Name: event, TestOwner: "o", TestName: "t"})
+	at(1)
+	e.HandleEvent(rpm.Event{Name: event, TestOwner: "o", TestName: "t"})
+
+	// Precondition: the crossing really did produce a capacity drop. Without
+	// this the cell would also pass on a run where nothing was ever dropped.
+	if got := e.Stats().DroppedQueueFull; got != 1 {
+		t.Fatalf("DroppedQueueFull = %d, want 1 — the crossing did not hit the "+
+			"capacity drop this cell is about", got)
+	}
+	if names := drainPolicyNames(e); len(names) != actionQueueDepth {
+		t.Fatalf("drained %d actions, want %d fillers and no remediation",
+			len(names), actionQueueDepth)
+	}
+
+	// The worker has now caught up (queue drained). The fault is SUSTAINED, so
+	// the next event keeps the count at/above the threshold — it does not
+	// re-cross. Before #6810 the latch was still armed from the consumed
+	// crossing, so withinMatches suppressed this and every later event, and the
+	// remediation never ran.
+	at(2)
+	e.HandleEvent(rpm.Event{Name: event, TestOwner: "o", TestName: "t"})
+
+	queued := drainPolicyNames(e)
+	if len(queued) != 1 || queued[0] != "remediate" {
+		t.Fatalf("after a queue-full drop the remediation never re-queued (got %v). "+
+			"The crossing was CONSUMED by the drop: withinMatches suppresses every "+
+			"later at/above-threshold event while the edge latch is armed, and "+
+			"re-arms only when the count falls BELOW the threshold — which, for "+
+			"the sustained fault this policy exists to remediate, never happens "+
+			"(#6810)", queued)
+	}
+}
+
+// TestSustainedLevelStillFiresOnlyOnceWhenAdmitted6810 is the PAIRED control,
+// and it is the cell that stops the fix from becoming a different bug.
+//
+// Rolling the latch back on a drop must not roll it back on a SUCCESS. If it
+// did, `trigger on N` would degrade from edge- to level-triggered and re-fire
+// on every above-threshold event — precisely the behaviour #3756 M1 removed.
+// The sibling cell above cannot see that: it only ever exercises the drop path.
+func TestSustainedLevelStillFiresOnlyOnceWhenAdmitted6810(t *testing.T) {
+	e, at := newInertEngine6810(t)
+	const event = "ping_probe_failed"
+	e.Apply([]*config.EventPolicy{edgePolicy6810("remediate", event, 2)})
+
+	// Empty queue: every action is admitted.
+	for tick := int64(0); tick < 10; tick++ {
+		at(tick)
+		e.HandleEvent(rpm.Event{Name: event, TestOwner: "o", TestName: "t"})
+	}
+
+	if got := e.Stats().DroppedQueueFull; got != 0 {
+		t.Fatalf("DroppedQueueFull = %d, want 0 — this control must exercise the "+
+			"ADMITTED path", got)
+	}
+	// One crossing, one queued action. Supersede collapses same-policy
+	// duplicates, so the queue depth alone cannot distinguish "fired once" from
+	// "fired ten times"; the superseded counter is what does.
+	if st := e.Stats(); st.Superseded != 0 {
+		t.Fatalf("Superseded = %d, want 0 — the sustained level re-fired %d extra "+
+			"times, so `trigger on` degraded from EDGE- to LEVEL-triggered and the "+
+			"#6810 rollback is clearing a latch that was legitimately armed (#3756 M1)",
+			st.Superseded, st.Superseded)
+	}
+	if queued := drainPolicyNames(e); len(queued) != 1 {
+		t.Fatalf("sustained above-threshold level queued %d actions, want exactly 1 "+
+			"(one crossing): %v", len(queued), queued)
+	}
+}
+
+// TestLatchRollbackIsRevisionGuarded6810 pins the ABA defence.
+//
+// A drop is reported by the goroutine that lost the race; by the time it rolls
+// the latch back, a commit may have REDEFINED the policy and Apply installed a
+// fresh, re-armed runtime for the successor. Clearing a latch then is a
+// name-based ABA: it would touch state belonging to a generation this failure
+// never authorized. The same guard armCooldown uses (#5311).
+//
+// Asserted through the observable contract rather than by reading onLatched: a
+// successor generation is re-armed by Apply anyway, so the check is that a
+// STALE revision's rollback does not disturb the live runtime's latch — the
+// successor still fires exactly once on its own crossing.
+func TestLatchRollbackIsRevisionGuarded6810(t *testing.T) {
+	e, at := newInertEngine6810(t)
+	const event = "ping_probe_failed"
+	e.Apply([]*config.EventPolicy{edgePolicy6810("remediate", event, 2)})
+
+	// Cross the threshold on an empty queue: admitted, latch legitimately armed.
+	at(0)
+	e.HandleEvent(rpm.Event{Name: event, TestOwner: "o", TestName: "t"})
+	at(1)
+	e.HandleEvent(rpm.Event{Name: event, TestOwner: "o", TestName: "t"})
+	if queued := drainPolicyNames(e); len(queued) != 1 {
+		t.Fatalf("precondition: the crossing must fire once, got %v", queued)
+	}
+
+	// A stale rollback arrives, quoting a revision that is no longer live.
+	e.releaseEdgeLatch("remediate", event, "stale-revision-that-never-existed")
+
+	// The live latch is untouched: the sustained level is still suppressed.
+	at(2)
+	e.HandleEvent(rpm.Event{Name: event, TestOwner: "o", TestName: "t"})
+	if queued := drainPolicyNames(e); len(queued) != 0 {
+		t.Fatalf("a rollback quoting a STALE semantic revision cleared the live "+
+			"policy's edge latch (got %v) — a predecessor's failure must not "+
+			"disturb a generation it never authorized (#5311 ABA guard)", queued)
+	}
+}
+
+// TestClassifyRejectAndEmptyPlanKeepTheLatch6810 documents, as an executable
+// decision, the two post-latch abandonment paths #6810 deliberately does NOT
+// roll back. R71 names only the queue-full one; HandleEvent has three.
+//
+//   - classifyPlan rejects (malformed/unknown command): DETERMINISTIC. The same
+//     policy fails identically every time, so rolling back would re-evaluate
+//     and re-reject on every subsequent event — unbounded log and counter churn
+//     for a remediation that can never run. It is already counted (rejected)
+//     and logged once, which is the better signal.
+//   - empty op list: there was no remediation to lose, so nothing was consumed.
+//
+// The queue-full drop is different in kind because it is TRANSIENT: retrying
+// succeeds once the worker catches up. That is the distinction the fix is
+// scoped to, and this cell is what stops the scope from being mistaken for an
+// oversight later.
+func TestClassifyRejectAndEmptyPlanKeepTheLatch6810(t *testing.T) {
+	t.Run("classify-reject", func(t *testing.T) {
+		e, at := newInertEngine6810(t)
+		const event = "ping_probe_failed"
+		bad := edgePolicy6810("broken", event, 2)
+		bad.ThenCommands = []string{"reboot the router"} // not set/delete → rejected
+		e.Apply([]*config.EventPolicy{bad})
+
+		at(0)
+		e.HandleEvent(rpm.Event{Name: event, TestOwner: "o", TestName: "t"})
+		at(1)
+		e.HandleEvent(rpm.Event{Name: event, TestOwner: "o", TestName: "t"})
+		if got := e.Stats().Rejected; got != 1 {
+			t.Fatalf("Rejected = %d, want 1 — the fixture did not reach the "+
+				"classify rejection it is about", got)
+		}
+		// Sustained level: still suppressed, and deliberately so.
+		at(2)
+		e.HandleEvent(rpm.Event{Name: event, TestOwner: "o", TestName: "t"})
+		if got := e.Stats().Rejected; got != 1 {
+			t.Fatalf("Rejected climbed to %d — a deterministic classify failure is "+
+				"being retried on every event, which is unbounded churn for a "+
+				"remediation that can never run", got)
+		}
+	})
+
+	t.Run("empty-plan", func(t *testing.T) {
+		e, at := newInertEngine6810(t)
+		const event = "ping_probe_failed"
+		empty := edgePolicy6810("noop", event, 2)
+		empty.ThenCommands = nil // classifies fine, yields zero ops
+		e.Apply([]*config.EventPolicy{empty})
+
+		at(0)
+		e.HandleEvent(rpm.Event{Name: event, TestOwner: "o", TestName: "t"})
+		at(1)
+		e.HandleEvent(rpm.Event{Name: event, TestOwner: "o", TestName: "t"})
+		at(2)
+		e.HandleEvent(rpm.Event{Name: event, TestOwner: "o", TestName: "t"})
+
+		if st := e.Stats(); st.DroppedQueueFull != 0 || st.Rejected != 0 {
+			t.Fatalf("an empty plan must neither drop nor reject: %+v", st)
+		}
+		if queued := drainPolicyNames(e); len(queued) != 0 {
+			t.Fatalf("an empty plan queued %v", queued)
+		}
+	})
+}


### PR DESCRIPTION
Closes #6810

## Summary

- `evaluateEvent` arms the #3756 edge latch under `e.mu` and returns the trigger. `HandleEvent` classifies and enqueues **afterwards, outside that lock** — and `enqueue` returned nothing, so a dropped action was indistinguishable from an admitted one at the call site.
- The consequence is not a delayed remediation but a **lost** one. `withinMatches` suppresses every later at/above-threshold event while the latch is armed and re-arms only when a clause's count falls **below** its threshold — which, for the sustained fault a policy exists to remediate, never happens. A transient saturation of the 64-slot queue by 64 **distinct** other policies permanently consumed the crossing.
- `enqueue` now returns an admission verdict; `HandleEvent` calls `releaseEdgeLatch` when it is false, restoring the invariant the latch expresses — *this crossing already fired* — for a crossing that did not.
- R71 names one abandonment path. `HandleEvent` has **three**; the other two are deliberately not rolled back, and that scope decision is pinned as an executable test rather than left implicit.

**Evidence source**: `docs/reviews/recovered/opus-review-001.md` root **R71**, read including the Refutation attempt and Dedup note, then re-derived against current `origin/master`. All four cited sites reproduce.

## Design

**A superseded placement counts as admitted.** The newer equivalent action *is* queued, which is exactly what the latch asserts — treating it as a drop would re-arm on a crossing that will in fact fire.

**The rollback carries the #5311 ABA guard.** `armCooldown` already solves the same problem for the cooldown stamp, so the rollback uses the same shape rather than inventing one: if a successor generation was installed (or the policy removed) while this action was being classified and rejected, its latch belongs to the successor and a predecessor's failure must not clear it. Identity check and clear happen in one critical section under `e.mu`, so a concurrent `Apply` cannot swap the runtime between them.

**Lock order is safe by construction.** `enqueue` returns — releasing `enqueueMu` — before `releaseEdgeLatch` takes `e.mu`, so `e.mu` is never held under `enqueueMu`. R71 calls this out as the deadlock risk to respect.

**Residual window, stated rather than papered over.** A concurrent event landing between the drop and the rollback is still suppressed by the armed latch. The window is one classify+enqueue, so the crossing costs a delay to the *next* event instead of being consumed outright — which is the whole of the defect.

### The two paths deliberately NOT rolled back

The discriminator is **transient vs deterministic**, not "the reviewer mentioned it":

| path | rolled back? | why |
|---|---|---|
| queue full (capacity drop) | **yes** | Transient. Retrying succeeds once the worker catches up. |
| `classifyPlan` rejects | no | **Deterministic** — the same policy fails identically every time, so re-arming would re-evaluate and re-reject on every subsequent event: unbounded log and counter churn for a remediation that can never run. Already counted (`rejected`) and logged once, which is the better signal. |
| empty op list | no | There was no remediation to lose, so nothing was consumed. |

`TestClassifyRejectAndEmptyPlanKeepTheLatch6810` pins this as an executable decision so the scope is not mistaken for an oversight later.

## Test plan

- [x] `pkg/eventengine/engine_latch_before_admission_6810_test.go` — 4 cells (5 with the subtest split). They drive the **real `HandleEvent`**, which is load-bearing: every pre-existing edge-latch test calls `evaluateEvent` directly and is structurally blind to the seam between arming and admission where the defect lives.
  - `TestQueueFullDropDoesNotConsumeTheCrossing6810` — the 64-**distinct**-policy saturation test R71 asks for. Distinct matters: `supersede` evicts a same-policy entry, so a single-policy burst occupies one slot (#5853) and would never produce the capacity drop under test. Carries a **precondition** asserting `DroppedQueueFull == 1`, so the cell cannot pass on a run where nothing was dropped.
  - `TestSustainedLevelStillFiresOnlyOnceWhenAdmitted6810` — **paired control**, and the cell that stops the fix becoming a different bug: rolling back on a drop must not roll back on success, or `trigger on N` degrades from edge- to level-triggered and re-fires on every above-threshold event, re-introducing exactly what #3756 M1 removed. Keyed on `Superseded == 0`, because `supersede` collapses same-policy duplicates and queue depth alone cannot distinguish "fired once" from "fired ten times".
  - `TestLatchRollbackIsRevisionGuarded6810` — a stale-revision rollback must not disturb the live runtime's latch.
  - `TestClassifyRejectAndEmptyPlanKeepTheLatch6810` — the scope decision above.
- [x] **Mutation matrix** at HEAD `e253c35af`, fix committed first, every cell a full-package `go test -count=1 ./pkg/eventengine/` with **no** `-run` filter:

  | mutation | cell that RED | verdict |
  |---|---|---|
  | `HandleEvent` discards the verdict (the shipped defect) | `TestQueueFullDropDoesNotConsumeTheCrossing6810` | RED (`buildbreak=0`) |
  | `enqueue` always reports admitted | `TestQueueFullDropDoesNotConsumeTheCrossing6810` | RED |
  | ABA guard removed from the rollback | `TestLatchRollbackIsRevisionGuarded6810` | RED |
  | roll back unconditionally, i.e. also on success | `TestSustainedLevelStillFiresOnlyOnceWhenAdmitted6810` + `...RevisionGuarded6810` | RED |

  The first mutation is written as `&& false` on the condition rather than deleting the branch, so the call still runs and the cell measures the discarded verdict rather than a build break.
- [x] `go build ./... && go test -count=1 ./...` → **rc 0**, 67/67 packages, at HEAD `e253c35af946d1c2d10cfbc286129d743e8fab79`, with `origin/master 32e0bfa8b` merged in (MERGE, never rebase) and `merge-base --is-ancestor origin/master HEAD` verified.
- [ ] **No smoke owed.** `pkg/eventengine` only — no cluster, VRRP, session-sync, fabric or failover code, no `userspace-dp`/`userspace-xdp` (no cargo leg).

### Modularity threshold — deferred, with an owner

The 63 LOC (mostly the admission-verdict and latch-rollback rationale) tipped `engine.go` 1477 → 1540, crossing the soft 1500 `[WATCH]` floor. Recorded in `docs/refactoring-audit-accepted.txt` as a deliberate deferral **with its reason**, not split inline: the entire diff lives in `enqueue` and `HandleEvent`, so a verbatim move would carry the fix inside it and make "is this line new, or moved?" unanswerable on a change whose whole point is a subtle ordering property. It is under the ~200 LOC "the PR splits the module first" cue and at the soft floor rather than the hard 2000.

None of the three documented "When NOT to refactor" cases actually applies, so this is **#7636** (an issue with a proposed split and its constraints) rather than a permanent acceptance — and that issue notes the `[WATCH]` entry should be pruned when the split lands.

### `_Log.md` conflict

#7631 merged while this was in flight. Resolved `theirs + ours_tail` and verified on the **result**: our side asserted a clean prepend onto the merge base, master's side deliberately not assumed to be one (mid-file deletions from #7614/#7616), so `theirs` taken whole. Post-checks: ends with `theirs` verbatim, headings 1967 + 1 = 1968, **zero** master headings missing, and master's own marker/duplicate gates pass.

## Refs

Closes #6810. Builds on #3756 M1 (the edge latch this protects), #5853/#5062/#2869 (the queue admission semantics `enqueue` returns a verdict for) and #5311 (the ABA guard reused here). Related: #7636 (the deferred `engine.go` split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1PvkJxs7KrzEdyC9u1LDu
