### PR TITLE
pkg/flowexport: make address family part of the group key (#6811)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -106141,3 +106141,60 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/ipsec/swanctl_value_grammar_6833_test.go` (new),
   `pkg/networkd/networkd.go`,
   `pkg/networkd/unit_value_grammar_6833_test.go` (new), `_Log.md`
+
+## 2026-08-26 — #6811 family is part of the flow-export group key
+
+- **Timestamp**: 2026-08-26
+- **Action**: Stop a single sampling instance carrying BOTH address families from
+  cross-fanning each family's flows to the other family's collectors
+  (opus-review-001 root R72).
+- **The collapse**: `SamplingInstance` keeps `FamilyInet`/`FamilyInet6` separate,
+  but `collectInstanceVersionCollectors` merged them into ONE slice and reduced
+  family to two per-INSTANCE booleans. `CollectorConfig` had no family field,
+  `groupCollectorsByTemplate` keyed on template alone, and `ServesFamily` was
+  evaluated per instance — so with both families configured both booleans were
+  true, the gate passed for either family, and `flowExportCallback` fanned the
+  record to EVERY group of that instance.
+- **Why nothing caught it**: the strict validator explicitly PERMITS one instance
+  holding both families, the #2462 isolation tests use family-DISJOINT instances
+  (where the instance-level gate IS sufficient), and the template tests use a
+  single family. No test configured the shape that breaks. R72's Refutation says
+  exactly this, which is why reading it first was worth more than the Evidence.
+- **Fix**: family becomes part of the identity at BUILD time — `CollectorConfig.IsV6`,
+  family in the dedup key, and `collectorGroupKey{Template, IsV6}` replacing the
+  template-only group key. Then one comparison at send time
+  (`GroupIsV6 != sd.IsIPv6`) inside the fan-out, at BOTH sites.
+- **Why family belongs in the KEY, not a per-record filter**: R72's HPC note says
+  family partitioning must not add a per-record collector search. Keying on
+  family makes every group single-family by construction, so the hot path is a
+  gate against a precomputed flag. Filtering conns per record would put a
+  collector scan on the export path for every flow.
+- **The subtlety that shaped the fix**: `ServesInet`/`ServesInet6` had to stay
+  per-INSTANCE. They gate the single sampling DECISION and must run BEFORE
+  `ShouldExport`, or a record of a family the instance does not serve would
+  consume a 1-in-N slot and change the sampling denominator. `GroupIsV6` gates
+  the fan-out only. Collapsing the two would either re-open the cross-fan or
+  silently alter the sample rate — a cell pins the distinction.
+- **Dedup key gained family**: the same address under both families is two
+  destinations-with-family, not one duplicate. Without it, a collector the
+  operator pointed at both families would silently stop receiving one.
+- **A pre-existing test went RED and was right to**: the #3745
+  distinct-source-address tests build their two collectors by putting one address
+  under BOTH families, then asserted on `BuildExportConfig(...).Collectors`, which
+  returns only the FIRST group. The #3745 property (both retained, distinct
+  sources) is unchanged — the assertion now counts across groups and additionally
+  pins two DISTINCT source addresses, so it tests the dedup rather than the
+  grouping. Also corrected `BuildExportConfig`/`BuildIPFIXExportConfig` doc
+  comments, which had become false ("the FIRST template group") — a comment is a
+  claim (#7629).
+- **6 cells**: 5 resolver (`pkg/flowexport`) + 1 send-path (`pkg/daemon`). The
+  daemon cell is independent and load-bearing: deleting the per-group gate leaves
+  every resolver cell green while the bug is fully restored. It also asserts the
+  inet group DID export, so the cell cannot pass against a build that exports
+  nothing. Controls: a single-family instance still produces exactly one group
+  with #2462 attribution intact.
+- **File(s)**: `pkg/flowexport/manager.go`,
+  `pkg/flowexport/family_fanout_6811_test.go` (new),
+  `pkg/flowexport/exporter_test.go`, `pkg/flowexport/README.md`,
+  `pkg/daemon/daemon_flowexport.go`,
+  `pkg/daemon/daemon_flowexport_family_fanout_6811_test.go` (new), `_Log.md`

--- a/pkg/daemon/daemon_flowexport.go
+++ b/pkg/daemon/daemon_flowexport.go
@@ -538,6 +538,22 @@ func (d *Daemon) flowExportCallback(rec logging.EventRecord, raw []byte) {
 			// template enabled `export-extension flow-dir` actually encode it.
 			sd.Direction = lead.FlowDirection(rec.InZone, rec.OutZone)
 			for k := i; k < j; k++ {
+				// #6811: fan out only to the groups of THIS address family.
+				// Groups are single-family by construction (the resolver keys
+				// them on template AND family), so this is one comparison
+				// against a precomputed flag — not a per-record collector
+				// search. Before it, the instance-level ServesFamily gate above
+				// was the ONLY family check, and an instance carrying both
+				// families passed it for either family and then fanned to EVERY
+				// group — IPv4 records to IPv6-only collectors and vice versa.
+				//
+				// The instance-level gate stays: it must run BEFORE
+				// ShouldExport so a record of a family this instance does not
+				// serve never consumes a 1-in-N sampling slot. Moving family
+				// entirely down here would change the sampling denominator.
+				if b.groups[k].ec.GroupIsV6 != sd.IsIPv6 {
+					continue
+				}
 				b.groups[k].exp.ExportSessionClose(rec, sd)
 			}
 		}
@@ -590,6 +606,22 @@ func (d *Daemon) ipfixExportCallback(rec logging.EventRecord, raw []byte) {
 			// #3270: see flowExportCallback.
 			sd.Direction = lead.FlowDirection(rec.InZone, rec.OutZone)
 			for k := i; k < j; k++ {
+				// #6811: fan out only to the groups of THIS address family.
+				// Groups are single-family by construction (the resolver keys
+				// them on template AND family), so this is one comparison
+				// against a precomputed flag — not a per-record collector
+				// search. Before it, the instance-level ServesFamily gate above
+				// was the ONLY family check, and an instance carrying both
+				// families passed it for either family and then fanned to EVERY
+				// group — IPv4 records to IPv6-only collectors and vice versa.
+				//
+				// The instance-level gate stays: it must run BEFORE
+				// ShouldExport so a record of a family this instance does not
+				// serve never consumes a 1-in-N sampling slot. Moving family
+				// entirely down here would change the sampling denominator.
+				if b.groups[k].ec.GroupIsV6 != sd.IsIPv6 {
+					continue
+				}
 				b.groups[k].exp.ExportSessionClose(rec, sd)
 			}
 		}

--- a/pkg/daemon/daemon_flowexport_family_fanout_6811_test.go
+++ b/pkg/daemon/daemon_flowexport_family_fanout_6811_test.go
@@ -1,0 +1,154 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6811: the SEND-PATH half of the multi-family cross-fan.
+//
+// pkg/flowexport proves the resolver now partitions collectors into one group
+// per (template, address family). That alone does not stop the cross-fan: the
+// fan-out lives here, in flowExportCallback, which gates the INSTANCE once via
+// ServesFamily and then sends the record to EVERY group of that instance.
+// Delete the per-group gate and every resolver cell stays green while the bug
+// is fully restored — so this cell exists to bind the gate, not the grouping.
+//
+// The existing #2462 isolation test looks like it covers this and does not: it
+// uses two family-DISJOINT instances, where the instance-level ServesFamily gate
+// is sufficient. The defect needs ONE instance holding BOTH families, which no
+// test configured. That is precisely why it went unnoticed, and the strict
+// validator explicitly permits the shape.
+
+// oneInstanceBothFamiliesV9Config is the shape the defect needs: a single
+// sampling instance with an inet flow-server AND an inet6 flow-server, each
+// pointed at its own collector port so a cross-fan is directly observable.
+func oneInstanceBothFamiliesV9Config(addr string, inetPort, inet6Port int) *config.Config {
+	cfg := &config.Config{}
+	cfg.ForwardingOptions.Sampling = &config.SamplingConfig{
+		Instances: map[string]*config.SamplingInstance{
+			"both": {
+				Name:      "both",
+				InputRate: 1,
+				FamilyInet: &config.SamplingFamily{
+					FlowServers: []*config.FlowServer{
+						{Address: addr, Port: inetPort, Version: config.FlowServerVersion9},
+					},
+				},
+				FamilyInet6: &config.SamplingFamily{
+					FlowServers: []*config.FlowServer{
+						{Address: addr, Port: inet6Port, Version: config.FlowServerVersion9},
+					},
+				},
+			},
+		},
+	}
+	cfg.Services.FlowMonitoring = &config.FlowMonitoringConfig{
+		Version9: &config.NetFlowV9Config{
+			Templates: map[string]*config.NetFlowV9Template{},
+		},
+	}
+	return cfg
+}
+
+// groupStatsForFamily totals exported flows across the groups of one instance
+// that serve the given address family. Keyed on GroupIsV6 rather than on the
+// instance name, because this defect lives BETWEEN the groups of a single
+// instance — an instance-keyed total (what the #2462 helper reports) sums both
+// families and cannot see a cross-fan at all.
+func groupStatsForFamily(b *exporterBundle, inst string, isV6 bool) uint64 {
+	var total uint64
+	for _, g := range b.groups {
+		if g.ec.InstanceName == inst && g.ec.GroupIsV6 == isV6 {
+			flows, _ := g.exp.Stats()
+			total += flows
+		}
+	}
+	return total
+}
+
+// TestSessionCloseSingleInstanceMultiFamilyDoesNotCrossFan_6811 is the
+// fail-on-revert cell for the send path.
+//
+// One instance, both families, two collector ports. An IPv4 SESSION_CLOSE is fed
+// through the REAL reconcile + callback path and must reach ONLY the inet group.
+// The inet6 group must export nothing: an IPv6-only collector receiving IPv4
+// records is the contamination R72 describes.
+//
+// FAIL-ON-REVERT: delete the `if b.groups[k].ec.GroupIsV6 != sd.IsIPv6 { continue }`
+// gate in flowExportCallback and the inet6 count goes from 0 to >= 1.
+func TestSessionCloseSingleInstanceMultiFamilyDoesNotCrossFan_6811(t *testing.T) {
+	inetColl, inetPort := listenUDP(t)
+	t.Cleanup(func() { inetColl.Close() })
+	inet6Coll, inet6Port := listenUDP(t)
+	t.Cleanup(func() { inet6Coll.Close() })
+
+	d := newFlowTestDaemon()
+	t.Cleanup(d.stopFlowExporter)
+	t.Cleanup(d.stopIPFIXExporter)
+
+	if !d.reconcileFlowExporters(oneInstanceBothFamiliesV9Config("127.0.0.1", inetPort, inet6Port)) {
+		t.Fatal("single-instance multi-family v9 reconcile must start exporters")
+	}
+	b := d.flowBundle.Load()
+	if b == nil {
+		t.Fatal("no v9 bundle")
+	}
+	if len(b.groups) != 2 {
+		t.Fatalf("expected 2 groups for one instance with two families, got %d. One group "+
+			"holding both families IS the cross-fan — every export to it reaches both "+
+			"collectors (#6811)", len(b.groups))
+	}
+
+	// The instance-level flags must still report BOTH families: they gate the
+	// single per-instance sampling decision, and narrowing them to the group
+	// would change the 1-in-N denominator rather than fix the fan-out.
+	for _, g := range b.groups {
+		if !g.ec.ServesFamily(false) || !g.ec.ServesFamily(true) {
+			t.Errorf("instance-level ServesFamily lost a family (v4=%v v6=%v); it must stay "+
+				"instance-wide (#2462) while GroupIsV6 does the per-group gating (#6811)",
+				g.ec.ServesFamily(false), g.ec.ServesFamily(true))
+		}
+	}
+
+	// Feed an IPv4 SESSION_CLOSE.
+	payload := buildSessionCloseRawEventV4(
+		6, // TCP
+		[4]byte{10, 0, 1, 102}, [4]byte{172, 16, 80, 200},
+		12345, 443,
+		[4]byte{172, 16, 80, 8}, 40000,
+		2, 3, // trust -> untrust
+	)
+	if !d.eventReader.ProcessRawEvent(payload) {
+		t.Fatal("ProcessRawEvent rejected a valid SESSION_CLOSE payload")
+	}
+
+	// The inet group MUST export it — without this the cell passes against a
+	// build that exports nothing at all, which is a silent loss of flow data
+	// rather than a fix.
+	deadline := time.Now().Add(2 * time.Second)
+	var v4 uint64
+	for time.Now().Before(deadline) {
+		if v4 = groupStatsForFamily(b, "both", false); v4 >= 1 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if v4 < 1 {
+		t.Fatalf("the inet group did not export the IPv4 SESSION_CLOSE (got %d flows); the "+
+			"family partition must not drop the record it is supposed to route", v4)
+	}
+
+	// The inet6 group must NEVER receive it. Give the 100ms flush ticker margin
+	// to (incorrectly) transmit before asserting zero — under the pre-#6811
+	// fan-out it would have exported by now.
+	time.Sleep(300 * time.Millisecond)
+	if v6 := groupStatsForFamily(b, "both", true); v6 != 0 {
+		t.Fatalf("the inet6 group exported %d IPv4 flows. A single instance carrying both "+
+			"families cross-fanned each family's records to the other family's collectors: "+
+			"IPv4 records reach IPv6-only collectors and vice versa, contaminating the "+
+			"dataset and violating the configured export routing (#6811)", v6)
+	}
+}

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -845,10 +845,11 @@ IPFIX:
 - `IPFIXExporter.ExportSessionClose(rec, evt)` — emit one record.
 
 Shared:
-- `ExportConfig` — `manager.go`. Resolved per-template-group config: the
-  collectors that referenced one template, that template's timeouts /
-  field options, plus the family-shared sampling state (#2461 — see
-  "Per-flow-server template binding" below).
+- `ExportConfig` — `manager.go`. Resolved per-group config: the collectors that
+  referenced one template **and share one address family** (#2461 + #6811), that
+  template's timeouts / field options, plus the instance-shared sampling state
+  (see "Per-flow-server template binding" below and "Family is part of the group
+  key (#6811)").
 - `ResolveV9TemplateGroups(...) []*ExportConfig` /
   `ResolveIPFIXTemplateGroups(...)` — `manager.go`. The per-template-group
   resolvers the daemon uses (#2461).
@@ -1081,3 +1082,58 @@ moment any caller sampled off the copy (#2224).
   `"%s:%d"` / `addr+":0"` left an IPv6 literal unbracketed and
   unparseable, so IPv6 collectors silently never dialed (#2183). IPv4
   addresses are unaffected.
+
+
+## Family is part of the group key (#6811)
+
+A sampling instance may legitimately carry BOTH address families —
+`family inet { flow-server A }` and `family inet6 { flow-server B }` under one
+instance — and the strict commit validator explicitly permits it (it rejects only
+two DIFFERENT instances claiming the same `(version, family)`).
+
+That shape used to cross-fan. `collectInstanceVersionCollectors` merged both
+families into ONE collector slice and collapsed family into two per-INSTANCE
+booleans (`servesInet` / `servesInet6`); `CollectorConfig` carried no family;
+grouping keyed on template alone; and `ServesFamily` was evaluated per instance.
+With both families configured both booleans were true, so the gate passed for
+either family and the daemon fanned the record to **every** group of the
+instance. IPv4 records reached the IPv6-only collector and IPv6 records reached
+the IPv4-only one.
+
+Nothing caught it because nothing configured the shape: the #2462 isolation tests
+use family-DISJOINT instances (where the instance-level gate IS sufficient) and
+the template tests use a single family.
+
+The fix partitions family at BUILD time and gates on it at send time:
+
+| Layer | Before | After |
+|---|---|---|
+| `CollectorConfig` | `Address`, `SourceAddress`, `Template` | + `IsV6` |
+| dedup key | address + source + template | + family |
+| group key | template | `collectorGroupKey{Template, IsV6}` |
+| `ExportConfig` | `ServesInet`/`ServesInet6` (per instance) | + `GroupIsV6` (per group) |
+| `flowExportCallback` | instance gate, then fan to every group | instance gate, then **per-group family gate** |
+
+**Family is in the group key so the hot path stays a gate, not a search.** Every
+group is single-family by construction, so the per-record cost is one comparison
+against a precomputed flag. Keeping template-only groups and filtering
+connections per record would put a collector scan on the export path for every
+flow.
+
+**`ServesInet`/`ServesInet6` deliberately stay per-INSTANCE.** They keep their
+#2462 meaning — *does this instance serve this family at all* — and gate the
+single sampling DECISION, which must run before `ShouldExport` so a record of an
+unserved family never consumes a 1-in-N slot. `GroupIsV6` gates which groups that
+decision then fans out to. Collapsing the two would either re-open the cross-fan
+or change the sampling denominator.
+
+**The same collector under both families is kept twice, not deduped.** Family is
+part of a collector's identity, so `10.0.0.1:2055` configured under both families
+is two destinations-with-family; collapsing them would silently stop exporting
+one family to a collector the operator explicitly configured for both.
+
+Note that `BuildExportConfig` / `BuildIPFIXExportConfig` return only the FIRST
+group, so for a multi-family instance they now return a single family's
+collectors. They have no production callers — the daemon uses the resolvers — but
+a test reaching for "the" ExportConfig of a multi-family instance must iterate
+`ResolveV9TemplateGroups` instead.

--- a/pkg/flowexport/exporter_test.go
+++ b/pkg/flowexport/exporter_test.go
@@ -398,12 +398,31 @@ func TestBuildExportConfig_DistinctSourceAddressesAreNotDeduped(t *testing.T) {
 		},
 	}
 
-	ec := BuildExportConfig(v9Svc(), fo)
-	if ec == nil {
-		t.Fatal("expected non-nil ExportConfig")
+	// #6811: this fixture creates its two collectors by putting the same
+	// address under BOTH families with different source-addresses, so they now
+	// land in two (template, family) groups rather than one. The #3745 property
+	// under test is unchanged — both collectors are RETAINED, neither deduped
+	// away — so the assertion counts across groups instead of pinning one
+	// group's length, which would have been asserting the grouping, not the
+	// dedup.
+	groups := ResolveV9TemplateGroups(v9Svc(), fo)
+	if len(groups) == 0 {
+		t.Fatal("expected at least one ExportConfig")
 	}
-	if len(ec.Collectors) != 2 {
-		t.Fatalf("expected 2 collectors, got %d", len(ec.Collectors))
+	total := 0
+	srcs := map[string]bool{}
+	for _, g := range groups {
+		total += len(g.Collectors)
+		for _, c := range g.Collectors {
+			srcs[c.SourceAddress] = true
+		}
+	}
+	if total != 2 {
+		t.Fatalf("expected 2 collectors across all groups, got %d", total)
+	}
+	if len(srcs) != 2 {
+		t.Fatalf("expected 2 DISTINCT source addresses, got %d (%v) — the per-collector "+
+			"source-address override was deduped away (#3745)", len(srcs), srcs)
 	}
 }
 
@@ -637,12 +656,31 @@ func TestBuildIPFIXExportConfig_DistinctSourceAddressesAreNotDeduped(t *testing.
 		},
 	}
 
-	ec := BuildIPFIXExportConfig(svc, fo)
-	if ec == nil {
-		t.Fatal("expected non-nil ExportConfig")
+	// #6811: this fixture creates its two collectors by putting the same
+	// address under BOTH families with different source-addresses, so they now
+	// land in two (template, family) groups rather than one. The #3745 property
+	// under test is unchanged — both collectors are RETAINED, neither deduped
+	// away — so the assertion counts across groups instead of pinning one
+	// group's length, which would have been asserting the grouping, not the
+	// dedup.
+	groups := ResolveIPFIXTemplateGroups(svc, fo)
+	if len(groups) == 0 {
+		t.Fatal("expected at least one ExportConfig")
 	}
-	if len(ec.Collectors) != 2 {
-		t.Fatalf("expected 2 collectors, got %d", len(ec.Collectors))
+	total := 0
+	srcs := map[string]bool{}
+	for _, g := range groups {
+		total += len(g.Collectors)
+		for _, c := range g.Collectors {
+			srcs[c.SourceAddress] = true
+		}
+	}
+	if total != 2 {
+		t.Fatalf("expected 2 collectors across all groups, got %d", total)
+	}
+	if len(srcs) != 2 {
+		t.Fatalf("expected 2 DISTINCT source addresses, got %d (%v) — the per-collector "+
+			"source-address override was deduped away (#3745)", len(srcs), srcs)
 	}
 }
 

--- a/pkg/flowexport/family_fanout_6811_test.go
+++ b/pkg/flowexport/family_fanout_6811_test.go
@@ -1,0 +1,220 @@
+package flowexport
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6811: a sampling instance carrying BOTH families cross-fanned each family's
+// flows to the other family's collectors.
+//
+// The families are separate in config (`SamplingInstance.FamilyInet` /
+// `FamilyInet6`, each with its own FlowServers), but
+// collectInstanceVersionCollectors merged them into ONE collector slice and
+// collapsed family to two per-INSTANCE booleans. `CollectorConfig` had no family
+// field, grouping keyed on template alone, and `ServesFamily` was evaluated per
+// instance — so with both families configured both booleans were true, the gate
+// passed for either family, and the daemon fanned the record to EVERY group of
+// that instance.
+//
+// Result: `family inet { flow-server A }` + `family inet6 { flow-server B }`
+// sent IPv4 flows to BOTH A and B.
+//
+// Why it went unnoticed is worth recording: the strict validator explicitly
+// PERMITS one instance holding both families, and the existing isolation tests
+// (#2462) use family-DISJOINT instances while the template tests use a single
+// family. No test configured the shape that breaks. These cells do.
+
+// bothFamiliesInstance builds the shape the defect needs: one instance, one
+// flow-server per family, distinct addresses so a cross-fan is visible.
+func bothFamiliesInstance(v4Addr, v6Addr, tmpl string) *config.ForwardingOptionsConfig {
+	return &config.ForwardingOptionsConfig{
+		Sampling: &config.SamplingConfig{
+			Instances: map[string]*config.SamplingInstance{
+				"both": {
+					Name: "both",
+					FamilyInet: &config.SamplingFamily{
+						FlowServers: []*config.FlowServer{
+							{Address: v4Addr, Port: 2055, Version9Template: tmpl, VersionIPFIXTemplate: tmpl},
+						},
+					},
+					FamilyInet6: &config.SamplingFamily{
+						FlowServers: []*config.FlowServer{
+							{Address: v6Addr, Port: 2055, Version9Template: tmpl, VersionIPFIXTemplate: tmpl},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// groupFor returns the single group serving isV6, failing if the collectors of
+// the two families were not partitioned.
+func groupFor(t *testing.T, groups []*ExportConfig, isV6 bool) *ExportConfig {
+	t.Helper()
+	var found *ExportConfig
+	for _, g := range groups {
+		if g.GroupIsV6 != isV6 {
+			continue
+		}
+		if found != nil {
+			t.Fatalf("more than one group for isV6=%v", isV6)
+		}
+		found = g
+	}
+	if found == nil {
+		t.Fatalf("no group serves isV6=%v; the families were not partitioned", isV6)
+	}
+	return found
+}
+
+// TestMultiFamilyInstanceDoesNotCrossFanV9_6811 is the core cell. A single
+// instance with one collector per family must produce one group per family, each
+// holding ONLY its own family's collector.
+//
+// The addresses are distinct on purpose: asserting only "two groups exist" would
+// pass against a split that put both collectors in both groups, and asserting
+// only a count would not catch A and B landing in the wrong ones.
+//
+// FAIL-ON-REVERT: drop IsV6 from collectorGroupKey (grouping by template alone)
+// and this REDS — one group holds both collectors, which is the cross-fan.
+func TestMultiFamilyInstanceDoesNotCrossFanV9_6811(t *testing.T) {
+	fo := bothFamiliesInstance("10.0.0.1", "2001:db8::9", "t")
+	groups := ResolveV9TemplateGroups(v9Svc(), fo)
+	if len(groups) != 2 {
+		t.Fatalf("got %d groups, want 2 (one per address family). A single group holding "+
+			"both families is the cross-fan: every export to it reaches both collectors (#6811)",
+			len(groups))
+	}
+
+	v4 := groupFor(t, groups, false)
+	if len(v4.Collectors) != 1 || v4.Collectors[0].Address != "10.0.0.1:2055" {
+		t.Fatalf("inet group collectors = %+v, want exactly the inet collector 10.0.0.1:2055 — "+
+			"an IPv6-only collector in the inet group receives IPv4 records", v4.Collectors)
+	}
+	v6 := groupFor(t, groups, true)
+	if len(v6.Collectors) != 1 || v6.Collectors[0].Address != "[2001:db8::9]:2055" {
+		t.Fatalf("inet6 group collectors = %+v, want exactly the inet6 collector "+
+			"[2001:db8::9]:2055", v6.Collectors)
+	}
+}
+
+// TestMultiFamilyInstanceDoesNotCrossFanIPFIX_6811 is the IPFIX half. Separate
+// cell because ResolveIPFIXTemplateGroups is an independent resolver with its
+// own grouping call — one cell covering only v9 would report IPFIX as guarded
+// when it is not.
+//
+// FAIL-ON-REVERT: same mutation; both resolvers must key on family.
+func TestMultiFamilyInstanceDoesNotCrossFanIPFIX_6811(t *testing.T) {
+	fo := bothFamiliesInstance("10.0.0.1", "2001:db8::9", "t")
+	groups := ResolveIPFIXTemplateGroups(ipfixSvc(), fo)
+	if len(groups) != 2 {
+		t.Fatalf("got %d IPFIX groups, want 2 (one per address family) (#6811)", len(groups))
+	}
+	v4 := groupFor(t, groups, false)
+	if len(v4.Collectors) != 1 || v4.Collectors[0].Address != "10.0.0.1:2055" {
+		t.Fatalf("IPFIX inet group collectors = %+v, want only the inet collector", v4.Collectors)
+	}
+	v6 := groupFor(t, groups, true)
+	if len(v6.Collectors) != 1 || v6.Collectors[0].Address != "[2001:db8::9]:2055" {
+		t.Fatalf("IPFIX inet6 group collectors = %+v, want only the inet6 collector", v6.Collectors)
+	}
+}
+
+// TestInstanceFamilyFlagsStayInstanceWide_6811 pins the distinction the fix
+// depends on and that a "simplification" would collapse.
+//
+// ServesInet/ServesInet6 stay per-INSTANCE (their #2462 meaning: does this
+// instance serve this family at all) and gate the single sampling DECISION;
+// GroupIsV6 is per-GROUP and gates which groups that decision fans out to.
+// Collapsing the two would either re-open the cross-fan (if the per-group gate
+// went away) or change the sampling denominator (if the instance-level gate
+// did): a record of a family the instance does not serve must not consume a
+// 1-in-N slot.
+//
+// FAIL-ON-REVERT: set ServesInet/ServesInet6 from the GROUP's collectors instead
+// of the instance aggregate and this REDS.
+func TestInstanceFamilyFlagsStayInstanceWide_6811(t *testing.T) {
+	fo := bothFamiliesInstance("10.0.0.1", "2001:db8::9", "t")
+	groups := ResolveV9TemplateGroups(v9Svc(), fo)
+	if len(groups) != 2 {
+		t.Fatalf("got %d groups, want 2", len(groups))
+	}
+	for _, g := range groups {
+		if !g.ServesInet || !g.ServesInet6 {
+			t.Errorf("group (template=%q isV6=%v) has ServesInet=%v ServesInet6=%v; both must "+
+				"stay TRUE because the INSTANCE serves both families. These flags gate the "+
+				"per-instance sampling decision, not the per-group fan-out — narrowing them "+
+				"to the group would make a record of the other family skip ShouldExport and "+
+				"change the 1-in-N denominator (#6811/#2462)",
+				g.TemplateName, g.GroupIsV6, g.ServesInet, g.ServesInet6)
+		}
+	}
+}
+
+// TestSingleFamilyInstanceUnchanged_6811 is the control: the family-disjoint
+// shape #2462 already covers must behave exactly as before — one group, one
+// collector, and the instance flags narrowed to the configured family.
+//
+// Without it, a "partition everything" change that split single-family groups or
+// broke the #2462 attribution would pass every cell above. A control that only
+// counted groups would not catch ServesInet6 wrongly becoming true.
+func TestSingleFamilyInstanceUnchanged_6811(t *testing.T) {
+	fo := &config.ForwardingOptionsConfig{
+		Sampling: &config.SamplingConfig{
+			Instances: map[string]*config.SamplingInstance{
+				"v4only": {
+					Name: "v4only",
+					FamilyInet: &config.SamplingFamily{
+						FlowServers: []*config.FlowServer{
+							{Address: "10.0.0.1", Port: 2055, Version9Template: "t"},
+						},
+					},
+				},
+			},
+		},
+	}
+	groups := ResolveV9TemplateGroups(v9Svc(), fo)
+	if len(groups) != 1 {
+		t.Fatalf("single-family instance produced %d groups, want 1 — the family partition "+
+			"must not split a group that only ever had one family", len(groups))
+	}
+	g := groups[0]
+	if g.GroupIsV6 {
+		t.Error("inet-only group reports GroupIsV6=true")
+	}
+	if !g.ServesInet || g.ServesInet6 {
+		t.Errorf("inet-only instance: ServesInet=%v ServesInet6=%v, want true/false — the "+
+			"#2462 attribution must still narrow an instance to its configured family",
+			g.ServesInet, g.ServesInet6)
+	}
+	if len(g.Collectors) != 1 {
+		t.Errorf("got %d collectors, want 1", len(g.Collectors))
+	}
+}
+
+// TestSameCollectorUnderBothFamiliesKeepsBoth_6811 pins the dedup-key change.
+//
+// An operator may point BOTH families at one collector address. Family is part
+// of a collector's identity, so those are two destinations-with-family, not one
+// duplicate — collapsing them would silently drop one family's export to a
+// collector explicitly configured for both.
+//
+// FAIL-ON-REVERT: remove the family component from collectorKey and this REDS —
+// dedupeCollectors keeps one entry and one family stops being exported.
+func TestSameCollectorUnderBothFamiliesKeepsBoth_6811(t *testing.T) {
+	fo := bothFamiliesInstance("10.0.0.1", "10.0.0.1", "t")
+	groups := ResolveV9TemplateGroups(v9Svc(), fo)
+	if len(groups) != 2 {
+		t.Fatalf("got %d groups, want 2: the same address under both families is two "+
+			"destinations-with-family, not one duplicate (#6811)", len(groups))
+	}
+	v4 := groupFor(t, groups, false)
+	v6 := groupFor(t, groups, true)
+	if len(v4.Collectors) != 1 || len(v6.Collectors) != 1 {
+		t.Fatalf("inet=%d inet6=%d collectors, want 1 each — a family was deduped away",
+			len(v4.Collectors), len(v6.Collectors))
+	}
+}

--- a/pkg/flowexport/manager.go
+++ b/pkg/flowexport/manager.go
@@ -81,8 +81,18 @@ type ExportConfig struct {
 	// collectors must not export an IPv6 flow. An instance that configured
 	// neither (no flow-servers for this version) produces no ExportConfig at
 	// all, so both true-everywhere defaults are never observed.
-	ServesInet     bool
-	ServesInet6    bool
+	ServesInet  bool
+	ServesInet6 bool
+	// GroupIsV6 is the address family of THIS group's collectors (#6811).
+	//
+	// It is deliberately NOT the same thing as ServesInet/ServesInet6, which
+	// stay per-INSTANCE and keep their #2462 meaning ("does this instance serve
+	// this family at all"). The instance-level flags gate the single sampling
+	// DECISION — a record of a family the instance does not serve must not
+	// consume a 1-in-N slot — while GroupIsV6 gates which groups that decision
+	// then fans out to. Collapsing the two would either re-open the cross-fan or
+	// change the sampling denominator.
+	GroupIsV6      bool
 	V9TemplateOpts V9TemplateOptions // optional v9 template field control
 	// IncludeFlowDir is the resolved `export-extension flow-dir` knob for THIS
 	// template group (#3270). When set, the NetFlow v9 / IPFIX template
@@ -110,10 +120,19 @@ type CollectorConfig struct {
 	Address       string // "host:port"
 	SourceAddress string // local bind address (empty = auto)
 	// Template is the per-flow-server template the collector referenced
-	// ("" = none → default group). It is the grouping key for #2461 and is
+	// ("" = none → default group). It is HALF the grouping key for #2461 and is
 	// NOT serialized into the dialed connection; it only steers which
 	// ExportConfig (template context) the collector is placed under.
 	Template string `json:"-"`
+	// IsV6 records the address family the flow-server was configured under
+	// (#6811). Before it, family was collapsed to two per-INSTANCE booleans the
+	// moment the two families were merged into one collector slice, so an
+	// instance carrying `family inet { flow-server A }` AND
+	// `family inet6 { flow-server B }` had both booleans true and exported IPv4
+	// flows to B and IPv6 flows to A. Carrying family per collector is what lets
+	// the grouping partition it back out at BUILD time, so the hot path stays a
+	// gate on a precomputed group rather than a per-record collector search.
+	IsV6 bool `json:"-"`
 }
 
 // resolveFlowServerVersion returns the export protocol a single
@@ -228,6 +247,7 @@ func collectInstanceVersionCollectors(inst *config.SamplingInstance, version str
 				Address:       addr,
 				SourceAddress: srcAddr,
 				Template:      tmpl,
+				IsV6:          fe.isV6,
 			})
 			if fe.isV6 {
 				servesInet6 = true
@@ -377,23 +397,51 @@ func sortedInstanceNames(fo *config.ForwardingOptionsConfig) []string {
 	return names
 }
 
-// groupCollectorsByTemplate partitions the deduplicated collector list into
-// one slice per referenced template name, returning the group keys sorted
-// deterministically. The empty-string key holds collectors that referenced
-// no template (the default group). Determinism (#2461): the group order and
-// the per-group collector order are stable across process restarts, killing
-// the Go-map-iteration nondeterminism that let a collector silently flip
-// between templates.
-func groupCollectorsByTemplate(collectors []CollectorConfig) ([]string, map[string][]CollectorConfig) {
-	groups := make(map[string][]CollectorConfig)
+// collectorGroupKey is the grouping identity of an ExportConfig: the template
+// a collector referenced AND the address family it was configured under
+// (#2461 + #6811).
+//
+// Family belongs in the key because it is what makes the hot path a GATE
+// rather than a SEARCH. With family in the key every group is single-family by
+// construction, so the per-record work is one comparison against a precomputed
+// group flag; keeping template-only groups and filtering conns per record
+// would put a collector scan on the export path for every flow.
+type collectorGroupKey struct {
+	Template string
+	IsV6     bool
+}
+
+// groupCollectorsByTemplateAndFamily partitions the deduplicated collector list
+// into one slice per (template, address-family) pair, returning the group keys
+// sorted deterministically. The empty Template holds collectors that referenced
+// no template (the default group).
+//
+// Determinism (#2461): the group order and the per-group collector order are
+// stable across process restarts, killing the Go-map-iteration nondeterminism
+// that let a collector silently flip between templates. IsV6 is the secondary
+// sort key so the ordering stays total.
+//
+// #6811: this used to key on template alone. Both families were merged into one
+// collector slice before grouping, so a single instance configured with
+// `family inet { flow-server A }` and `family inet6 { flow-server B }` produced
+// ONE group holding A and B, and every export to that group reached both — IPv4
+// records to the IPv6-only collector and vice versa.
+func groupCollectorsByTemplateAndFamily(collectors []CollectorConfig) ([]collectorGroupKey, map[collectorGroupKey][]CollectorConfig) {
+	groups := make(map[collectorGroupKey][]CollectorConfig)
 	for _, c := range collectors {
-		groups[c.Template] = append(groups[c.Template], c)
+		k := collectorGroupKey{Template: c.Template, IsV6: c.IsV6}
+		groups[k] = append(groups[k], c)
 	}
-	keys := make([]string, 0, len(groups))
+	keys := make([]collectorGroupKey, 0, len(groups))
 	for k := range groups {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Template != keys[j].Template {
+			return keys[i].Template < keys[j].Template
+		}
+		return !keys[i].IsV6 && keys[j].IsV6
+	})
 	for _, k := range keys {
 		cs := groups[k]
 		sort.Slice(cs, func(i, j int) bool {
@@ -458,8 +506,9 @@ func ResolveV9TemplateGroups(svc *config.ServicesConfig, fo *config.ForwardingOp
 		}
 		rate := inst.InputRate
 		shared := &atomic.Uint64{} // per-INSTANCE counter (#2462)
-		keys, groups := groupCollectorsByTemplate(collectors)
-		for _, name := range keys {
+		keys, groups := groupCollectorsByTemplateAndFamily(collectors)
+		for _, key := range keys {
+			name := key.Template
 			ctx := defaultCtx
 			if name != "" {
 				tmpl, ok := defined[name]
@@ -471,9 +520,10 @@ func ResolveV9TemplateGroups(svc *config.ServicesConfig, fo *config.ForwardingOp
 				ctx = v9TemplateContext(tmpl)
 			}
 			out = append(out, &ExportConfig{
-				Collectors:          groups[name],
+				Collectors:          groups[key],
 				InstanceName:        instName,
 				TemplateName:        name,
+				GroupIsV6:           key.IsV6,
 				FlowActiveTimeout:   ctx.activeTimeout,
 				FlowInactiveTimeout: ctx.inactiveTimeout,
 				TemplateRefreshRate: ctx.refreshRate,
@@ -521,8 +571,9 @@ func ResolveIPFIXTemplateGroups(svc *config.ServicesConfig, fo *config.Forwardin
 		}
 		rate := inst.InputRate
 		shared := &atomic.Uint64{} // per-INSTANCE counter (#2462)
-		keys, groups := groupCollectorsByTemplate(collectors)
-		for _, name := range keys {
+		keys, groups := groupCollectorsByTemplateAndFamily(collectors)
+		for _, key := range keys {
+			name := key.Template
 			ctx := defaultCtx
 			if name != "" {
 				tmpl, ok := defined[name]
@@ -532,9 +583,10 @@ func ResolveIPFIXTemplateGroups(svc *config.ServicesConfig, fo *config.Forwardin
 				ctx = ipfixTemplateContext(tmpl)
 			}
 			out = append(out, &ExportConfig{
-				Collectors:          groups[name],
+				Collectors:          groups[key],
 				InstanceName:        instName,
 				TemplateName:        name,
+				GroupIsV6:           key.IsV6,
 				FlowActiveTimeout:   ctx.activeTimeout,
 				FlowInactiveTimeout: ctx.inactiveTimeout,
 				TemplateRefreshRate: ctx.refreshRate,
@@ -550,11 +602,16 @@ func ResolveIPFIXTemplateGroups(svc *config.ServicesConfig, fo *config.Forwardin
 }
 
 // BuildExportConfig resolves config types into a single NetFlow v9
-// ExportConfig. It returns the FIRST template group (deterministically the
-// default/empty-template group, else the lowest template name) and is
-// retained for callers that want a single aggregate config; the daemon uses
+// ExportConfig. It returns the FIRST group (deterministically the
+// default/empty-template group, else the lowest template name; and within a
+// template, inet before inet6) and is retained for TESTS that want a single
+// aggregate config — it has no production callers. The daemon uses
 // ResolveV9TemplateGroups so each collector gets its referenced template
 // (#2461). Returns nil if no flow export is configured.
+//
+// #6811: groups are keyed on template AND address family, so for a
+// multi-family instance this returns only ONE family's collectors. A caller
+// that needs every collector must iterate ResolveV9TemplateGroups.
 func BuildExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOptionsConfig) *ExportConfig {
 	groups := ResolveV9TemplateGroups(svc, fo)
 	if len(groups) == 0 {
@@ -563,7 +620,8 @@ func BuildExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOptionsC
 	return groups[0]
 }
 
-// BuildIPFIXExportConfig is the IPFIX equivalent of BuildExportConfig.
+// BuildIPFIXExportConfig is the IPFIX equivalent of BuildExportConfig,
+// including the #6811 single-family caveat.
 func BuildIPFIXExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOptionsConfig) *ExportConfig {
 	groups := ResolveIPFIXTemplateGroups(svc, fo)
 	if len(groups) == 0 {
@@ -939,5 +997,13 @@ func estimateSessionDuration(pkts uint64, proto uint8) time.Duration {
 }
 
 func collectorKey(c CollectorConfig) string {
-	return c.Address + "\x00" + c.SourceAddress + "\x00" + c.Template
+	// #6811: family is part of the identity. The same address+source+template
+	// configured under BOTH families is two distinct destinations-with-family,
+	// not one duplicate: collapsing them would silently drop one family's
+	// export to a collector the operator explicitly configured for both.
+	fam := "4"
+	if c.IsV6 {
+		fam = "6"
+	}
+	return c.Address + "\x00" + c.SourceAddress + "\x00" + c.Template + "\x00" + fam
 }


### PR DESCRIPTION
## Problem

A sampling instance may legitimately carry **both** address families under one
instance:

```
forwarding-options sampling instance both {
    family inet  { flow-server 10.0.0.1 port 2055; }
    family inet6 { flow-server 2001:db8::9 port 2055; }
}
```

The strict commit validator **explicitly permits** this — it rejects only two
*different* instances claiming the same `(version, family)`.

That shape cross-fanned. `collectInstanceVersionCollectors` merged both families
into ONE collector slice and collapsed family into two **per-instance** booleans;
`CollectorConfig` carried no family; `groupCollectorsByTemplate` keyed on template
alone; and `ServesFamily` was evaluated per *instance*. With both families
configured both booleans were `true`, so the gate passed for either family and
`flowExportCallback` fanned the record to **every** group of that instance.

**IPv4 records reached the IPv6-only collector and IPv6 records reached the
IPv4-only one** — contaminating both datasets and violating the configured export
routing.

Re-derived against current `origin/master`: present at every point.

## Why nothing caught it

The #2462 isolation tests use family-**disjoint** instances, where the
instance-level gate genuinely *is* sufficient. The template tests use a single
family. **No test configured one instance with both families** — the only shape
that breaks. R72's *Refutation attempt* says exactly this, which is why reading it
before the Evidence was worth more than the line numbers.

## Fix

Family enters the identity at **build** time, and the send path gates on it:

| Layer | Before | After |
|---|---|---|
| `CollectorConfig` | `Address`, `SourceAddress`, `Template` | + `IsV6` |
| dedup key | address + source + template | **+ family** |
| group key | `Template` | `collectorGroupKey{Template, IsV6}` |
| `ExportConfig` | `ServesInet`/`ServesInet6` (per instance) | + `GroupIsV6` (per group) |
| `flowExportCallback` | instance gate → fan to **every** group | instance gate → **per-group family gate** |

**Family is in the key so the hot path stays a gate, not a search.** R72's
HPC note requires that family partitioning not add a per-record collector search.
Keying on family makes every group single-family by construction, so the
per-record cost is one comparison against a precomputed flag.

**`ServesInet`/`ServesInet6` deliberately stay per-INSTANCE.** They keep their
#2462 meaning — *does this instance serve this family at all* — and gate the
single sampling **decision**, which must run before `ShouldExport` so a record of
an unserved family never consumes a 1-in-N slot. `GroupIsV6` gates only which
groups that decision fans out to. Collapsing the two would either re-open the
cross-fan **or silently change the sampling denominator**. A cell pins the
distinction.

**The dedup key gains family** because the same address under both families is
two destinations-with-family, not one duplicate — collapsing them would silently
stop exporting one family to a collector the operator configured for both.

## A pre-existing test went RED, and was right to

The #3745 distinct-source-address tests build their two collectors by putting one
address under **both** families, then asserted on
`BuildExportConfig(...).Collectors` — which returns only the FIRST group. The
property they pin (both retained, neither deduped) is unchanged, so the
assertions now count across groups and additionally require two **distinct**
source addresses — testing the dedup rather than the grouping.

`BuildExportConfig` / `BuildIPFIXExportConfig` doc comments are corrected too:
they claimed "the FIRST template group", which is no longer what they return.
They have **no production callers** (the daemon uses the resolvers).

## Test plan

- [x] `go build ./...` — rc=0
- [x] `go test -count=1 ./...` repo-wide — **rc=0**, 67 packages, 0 FAIL, at
      `23d6502cb269af0069e4c2f667a8d33fff25501d` (parent `origin/master`
      `ec584dda2`; `merge-base --is-ancestor` rc=0, 0 commits behind)
- [x] 6-cell mutation matrix — **6/6 RED**, full package per cell, no `-run` filter
- [x] `gofmt -l` clean on every touched file (checked per-file, not per-directory)
- [ ] Deploy / cluster smoke — **NOT RUN**, see below
- [ ] Codex / AGY hostile review — not run; parent owns the review round

### Mutation matrix (6/6 RED)

| Cell | Expected RED | Verdict |
|---|---|---|
| M1 family in the group key | `TestMultiFamilyInstanceDoesNotCrossFanV9_6811` | **RED** |
| M2 family in the group key (IPFIX resolver) | `TestMultiFamilyInstanceDoesNotCrossFanIPFIX_6811` | **RED** |
| M3 family stamped on the collector | `TestMultiFamilyInstanceDoesNotCrossFanV9_6811` | **RED** |
| M4 family in the dedup key | `TestSameCollectorUnderBothFamiliesKeepsBoth_6811` | **RED** |
| M5 `GroupIsV6` stamped onto the `ExportConfig` | `TestMultiFamilyInstanceDoesNotCrossFanV9_6811` | **RED** |
| M6 send-path per-group family gate | `TestSessionCloseSingleInstanceMultiFamilyDoesNotCrossFan_6811` | **RED** (2072 collected) |

**M6 is independent and load-bearing.** The resolver cells prove partitioning;
the *fan-out* is what actually cross-fans. Delete the per-group gate in
`flowExportCallback` and **all five resolver cells stay green** while the bug is
fully restored — so M6 binds the gate, not the grouping. It drives the real
reconcile + callback path with two UDP collectors and asserts the inet6 group
exported **zero** IPv4 flows.

**Controls.** M6 also asserts the inet group **did** export, so it cannot pass
against a build that exports nothing — a silent loss of flow data rather than a
fix. `TestSingleFamilyInstanceUnchanged_6811` keeps a family-disjoint instance at
exactly one group with its #2462 attribution intact, so a "partition everything"
change fails. `TestInstanceFamilyFlagsStayInstanceWide_6811` fails if the
instance-level flags are narrowed to the group.

IPFIX gets its **own** cell because `ResolveIPFIXTemplateGroups` is an
independent resolver with its own grouping call — one cell covering only v9 would
report IPFIX as guarded when it is not.

### Smoke not run — explicit disposition

The change is in flow-export routing, not the forwarding path: no dataplane,
cluster, VRRP, or session-sync code is touched, so ping and iperf3 cannot observe
it. The meaningful lane is a live box with one instance configured for both
families and a packet capture on each collector, confirming each receives only its
own family. Happy to run it on a VM if wanted.

## Docs

`pkg/flowexport/README.md` gains "Family is part of the group key (#6811)" — the
before/after table, why family is in the key rather than a per-record filter, why
the instance flags stay instance-wide, and the dedup-key rationale. `_Log.md`
appended.

Closes #6811
