### PR TITLE
config: gate the #2419 compact/block equivalence class (#6817, #6818, #6821, #6822)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -106098,3 +106098,58 @@ prose edit above them added. No diff falls in the new test body.
 - **Found by**: the lane driving #6808, caught in `git status` rather than at
   review.
 - **File(s)**: `docs/engineering-style.md`, `_Log.md`
+
+## 2026-08-26 — #2419 compact/block equivalence gate (cohort #6817/#6818/#6821/#6822)
+
+- **Timestamp**: 2026-08-26
+- **Action**: Add the generative gate that ENUMERATES the #2419 compact-leaf
+  class, plus a checked-in expected-failure inventory of the 194 sites that fail
+  it today. No production change — the normalizer that drives the inventory to
+  zero is a separate, deliberately unfolded change.
+- **The class**: a compiler stanza that iterates only `prop.Children` reads the
+  BLOCK spelling `stanza { leaf value; }` and silently drops the COMPACT
+  spelling `stanza leaf value;`, which puts the value on the stanza's own
+  `Keys[1:]`. `SchemaValidate` ACCEPTS the compact spelling, so this is the
+  normal commit path, not the tolerant-load path: the commit reports success and
+  the credential is gone.
+- **Why the instrument had to be generative**: two textual predicates were tried
+  on the issues. The first over-counted (80 readers, 68 "blind" — a `case`
+  handling the flat shape one line above the loop was flagged); the second
+  matched 11 candidates and NONE of the three known-true sites, because a
+  ±14-line lookback cannot scope itself to a `case` block. False positives AND
+  false negatives, with output indistinguishable from clean.
+- **THE PRESCRIBED INSTRUMENT WAS ALSO VACUOUS, and that is the main finding.**
+  The brief said to compare the flat-set spelling against the block spelling.
+  `ParseSetCommand` + `SetPath` produces the BLOCK tree — verified by dumping it
+  — so that comparison is block-against-block: equal for every leaf, green
+  everywhere, census of zero. The compact tree comes from the HIERARCHICAL
+  parser on hand-authored / `load merge`d text. Corrected before building.
+- **Three bugs in my own instrument, all found by the positive control**: it
+  found 2 of the 4 known-true sites on the first run. (a) args were rendered as
+  their own nesting level (`user { ops { } }` not `user ops { }`) — hid #6822;
+  (b) fixtures lacked REQUIRED SIBLINGS (`compiler_security_log.go` registers a
+  stream only when `Host != ""`) — hid #6821; (c) NAMED INSTANCES were being
+  compacted, which produces a node the compiler cannot recognise as that
+  instance — roughly 150 phantom divergences. 4/4 after the fixes; that control
+  is what makes the census believable.
+- **Census**: 792 sites enumerated, 326 checked under the vacuity guard, **194
+  divergent**. Skips: 346 under `groups` (schema re-host), 96 not observable, 15
+  parse/compile, 9 unsynthesizable. The honest count is ">= 194 divergent, 96
+  unruled" — the not-observable skips are candidates nobody has ruled out, not
+  clean sites. Hand-verified beyond the filed four: `protocols bgp export`
+  compiles an EMPTY export list, and a GRE tunnel loses BOTH source and
+  destination.
+- **Gate design**: the divergent set must EQUAL the inventory (a new
+  compact-blind reader reds; a fixed site left in the file also reds, so it
+  cannot rot into an allowlist); the checked-cell count is a RATCHET so sites
+  cannot drain into the skip buckets; the four filed instances are asserted
+  present by construction.
+- **Mutation matrix**: 9 cells. The ratchet is a PAIRED cell — the same
+  violation reds with the guard present and passes with it removed, which is
+  what proves the guard is what catches it. One cell (P1) initially "failed"
+  as a syntax break my build-break detector missed; detector widened and the
+  cell rewritten as a one-token change.
+- **File(s)**: `pkg/config/compact_block_equivalence_2419_test.go` (new),
+  `pkg/config/compact_block_inventory_regen_2419_test.go` (new),
+  `pkg/config/testdata/compact_block_divergences_2419.txt` (new),
+  `docs/config-schema.md`, `_Log.md`

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1264,6 +1264,81 @@ both config orderings, lenient-warn, deterministic-winner, namespace-aware
 absent-collision, non-colliding-commits), the strict-reject + lenient-warn cases
 RED on revert of the gate wiring.
 
+## Compact vs block stanza spellings (the #2419 sub-leaf contract)
+
+The bracketed-list contract below is about a **leaf** that carries several
+values. This section is about the neighbouring case that bit four security
+stanzas: a **container** whose sub-leaf is written on the container's own line.
+
+For a plain keyword stanza with `(name, value)` sub-leaves, the same operator
+intent has two legal spellings:
+
+```
+authentication { encrypted-password "$6$..."; }     # BLOCK
+authentication encrypted-password "$6$...";          # COMPACT
+```
+
+They produce different trees:
+
+```
+BLOCK    Keys=[authentication]                             children=1
+           └─ Keys=[encrypted-password $6$...]  IsLeaf
+COMPACT  Keys=[authentication encrypted-password $6$...]   children=0
+```
+
+So a compiler stanza that iterates only `prop.Children` and dispatches on child
+names reads the block spelling and **silently drops** the compact one. That is
+#2419 applied to sub-leaves rather than to list values, and it is where #6817
+(a login credential), #6818 (OSPF interface authentication), #6821 (a
+security-log TLS profile) and #6822 (an SNMPv3 password) all live. Each fails
+toward LESS security on a commit that reports success, and `SchemaValidate`
+accepts the compact spelling, so this is the normal commit path — not the
+tolerant-load path.
+
+Three things to know before working on this class:
+
+1. **The flat-set path is NOT the source of the compact shape.**
+   `ParseSetCommand` + `SetPath` produces the BLOCK tree — `authentication` as a
+   container with an `encrypted-password` child, bit-identical to the block
+   spelling. The compact tree comes from the HIERARCHICAL parser on
+   hand-authored or `load merge`d text, and from tools that render flat paths
+   into partial braces. A test that compares "flat-set vs block" is comparing
+   block against block: vacuously equal for every leaf and green everywhere.
+2. **Only a PLAIN KEYWORD stanza is compactable.** Collapsing a NAMED INSTANCE
+   (`interfaces ge-0/0/0`, `user ops`, `stream audit`) does not produce the
+   compact spelling of the same intent — the name is part of the node's identity
+   and the result is a node the compiler cannot recognise as that instance at
+   all. A census that compacts named instances over-reports by roughly a factor
+   of two.
+3. **Bracketed multi-value lists are schema LEAVES, not containers.**
+   `from protocol [ tcp udp ]` legitimately collapses onto `Keys` (see the next
+   section). Any fix for this class must key on the schema's container/leaf
+   distinction, or it will destroy every bracket list in the fleet.
+
+`pkg/config/compact_block_equivalence_2419_test.go` is the gate for the class:
+it walks `setSchema`, builds both spellings for every sub-leaf under a plain
+stanza, compiles both, and requires the typed configs to be equal. Sites that
+fail today are recorded in
+`pkg/config/testdata/compact_block_divergences_2419.txt` as an expected-failure
+inventory, so a NEW compact-blind reader reds the suite and a fixed site that
+is not removed from the file reds it too.
+
+Two properties of that gate are load-bearing and easy to lose:
+
+- **The vacuity guard.** A cell only counts once changing the VALUE is shown to
+  change the compiled config. Without it a site whose fixture observes nothing
+  reports a pass, and the census silently stops being a census.
+- **The positive control.** The four filed instances are asserted present by
+  construction. The first version of this instrument found two of them; an
+  instrument that quietly stops finding known-true sites reports "clean" for
+  exactly the reason the textual sweeps did.
+
+The inventory's `# checked:` header is a coverage RATCHET: sites must not drain
+out of the tested population into the skip buckets. The "not observable" skips
+are UNRULED, not clean — each is a site whose synthesized fixture was too thin
+to see the value (as #6821 was until a required-sibling `host` line was added),
+so the census is a floor.
+
 ## Multi-value leaves and bracketed lists (the dual-AST contract)
 
 A `multi: true` leaf with `children: nil` (e.g. `from protocol`,

--- a/pkg/config/compact_block_equivalence_2419_test.go
+++ b/pkg/config/compact_block_equivalence_2419_test.go
@@ -1,0 +1,331 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// ---- value synthesis ------------------------------------------------------
+
+// synthPair returns two DISTINCT plausible values for a valued leaf. Two are
+// needed for the vacuity guard: if the compiled config is identical for both,
+// this leaf's value is not observable in the typed config and the cell cannot
+// prove anything.
+func synthPair(n *schemaNode) (string, string, bool) {
+	if len(n.valueExamples) >= 2 {
+		return n.valueExamples[0], n.valueExamples[1], true
+	}
+	switch n.valueType {
+	case ValueInteger:
+		return "1", "2", true
+	case ValueIPAddress:
+		return "192.0.2.1", "192.0.2.2", true
+	case ValueCIDR:
+		return "192.0.2.0/24", "198.51.100.0/24", true
+	case ValueBool:
+		return "true", "false", true
+	case ValueIdentifier, ValueAny:
+		return "xpfaaa", "xpfbbb", true
+	case ValueCryptHash:
+		return `"$6$salt$aaa"`, `"$6$salt$bbb"`, true
+	case ValueMAC:
+		return "02:00:00:00:00:01", "02:00:00:00:00:02", true
+	case ValuePCIAddr:
+		return "0000:09:00.0", "0000:0a:00.0", true
+	}
+	if len(n.valueExamples) == 1 {
+		return "", "", false // one example, cannot vary
+	}
+	return "", "", false
+}
+
+// ---- required-sibling context ---------------------------------------------
+
+// contextFor returns statements that must accompany the stanza under test for
+// its enclosing object to be REGISTERED in the typed config at all.
+//
+// Without them the vacuity guard correctly reports "value not observable" and
+// the site is skipped — but for the wrong reason: the leaf IS observable, the
+// synthesized fixture was just incomplete. `security log stream <n>` is the
+// worked example: compiler_security_log.go records the stream only when
+// `stream.Host != ""`, so a transport-only fixture compiles to no stream at
+// all and BOTH spellings agree on nothing.
+//
+// This is the generative walk's structural limit: it cannot infer which
+// siblings an object requires. Entries are added here as the skip list is
+// worked through, and the remaining skip count is REPORTED so the census stays
+// an explicit floor rather than a silent one.
+func contextFor(parent []string) string {
+	switch strings.Join(parent, " ") {
+	case "security log stream xpfarg":
+		return "host 192.0.2.10; "
+	}
+	return ""
+}
+
+// ---- text construction ----------------------------------------------------
+
+// nest renders `a { b { c { <inner> } } }` for path [a b c].
+func nest(path []string, inner string) string {
+	if len(path) == 0 {
+		return inner
+	}
+	return path[0] + " { " + nest(path[1:], inner) + " }"
+}
+
+func compileText(t *testing.T, text string) *Config {
+	t.Helper()
+	p := NewParser(text)
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		return nil
+	}
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil || cfg == nil {
+		return nil
+	}
+	cfg.Warnings = nil
+	return cfg
+}
+
+func cfgEqual(a, b *Config) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+// ---- the walk -------------------------------------------------------------
+
+type compactSite struct {
+	container []string // token path of the enclosing container
+	leaf      string
+	node      *schemaNode
+}
+
+// A site is compactable ONLY when the innermost container is a PLAIN KEYWORD
+// stanza — args == 0 and not reached through a wildcard. A NAMED INSTANCE
+// (`interfaces ge-0/0/0`, `user ops`, `stream audit`) carries its name in the
+// node's own Keys, so collapsing the next level onto it does not produce the
+// compact spelling of the same intent; it produces a node the compiler cannot
+// recognise as that named instance at all. All four filed instances compact a
+// plain stanza (`authentication`, `transport`, `authentication-sha256`).
+
+func collectCompactSites() []compactSite {
+	var out []compactSite
+	seen := map[string]bool{}
+	var walk func(n *schemaNode, path []string, depth int, plainInner bool)
+	walk = func(n *schemaNode, path []string, depth int, plainInner bool) {
+		if n == nil || depth > 7 {
+			return
+		}
+		names := make([]string, 0, len(n.children))
+		for name := range n.children {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			ch := n.children[name]
+			if ch == nil {
+				continue
+			}
+			if ch.children == nil && ch.wildcard == nil && ch.args == 1 && len(path) >= 1 && plainInner {
+				key := strings.Join(path, "/") + "|" + name
+				if !seen[key] {
+					seen[key] = true
+					out = append(out, compactSite{
+						container: append([]string(nil), path...), leaf: name, node: ch,
+					})
+				}
+			}
+			elem := name
+			for i := 0; i < ch.args; i++ {
+				elem += " xpfarg"
+			}
+			np := append(append([]string(nil), path...), elem)
+			walk(ch, np, depth+1, ch.args == 0)
+		}
+		if n.wildcard != nil {
+			walk(n.wildcard, append(append([]string(nil), path...), "xpfname"), depth+1, false)
+		}
+	}
+	walk(setSchema, nil, 0, false)
+	return out
+}
+
+// ---- the gate --------------------------------------------------------------
+
+// inventoryPath records the sites that are KNOWN to drop the compact spelling
+// today. It is a checked-in expected-failure list, not a suppression: the gate
+// asserts the divergent set EQUALS it, so a NEW compact-blind reader reds the
+// suite, and a site that gets FIXED without updating the file reds it too.
+const inventoryPath = "testdata/compact_block_divergences_2419.txt"
+
+// filedInstances is the POSITIVE CONTROL. The first version of this instrument
+// found only 2 of these 4 — args rendered as their own nesting level hid one,
+// and a fixture missing a required sibling hid the other. An instrument that
+// silently stops finding known-true sites reports "clean" for the same reason
+// the textual sweeps did, so the four are asserted present by construction.
+var filedInstances = map[string]string{
+	"system login user xpfarg authentication encrypted-password":                         "#6817",
+	"protocols ospf area xpfarg interface xpfarg authentication simple-password":         "#6818",
+	"security log stream xpfarg transport tls-profile":                                   "#6821",
+	"snmp v3 usm local-engine user xpfarg authentication-sha256 authentication-password": "#6822",
+}
+
+type censusResult struct {
+	divergent []string
+	checked   int
+	skipped   map[string]int
+}
+
+func runCompactBlockCensus(t *testing.T) censusResult {
+	t.Helper()
+	res := censusResult{skipped: map[string]int{}}
+	for _, s := range collectCompactSites() {
+		if len(s.container) > 0 && strings.HasPrefix(s.container[0], "groups") {
+			res.skipped["under groups (schema re-host, duplicate coverage)"]++
+			continue
+		}
+		v1, v2, ok := synthPair(s.node)
+		if !ok {
+			res.skipped["no two distinct synthesizable values"]++
+			continue
+		}
+		parent := s.container[:len(s.container)-1]
+		stanza := s.container[len(s.container)-1]
+		ctx := contextFor(parent)
+		blockV1 := nest(parent, ctx+stanza+" { "+s.leaf+" "+v1+"; }")
+		blockV2 := nest(parent, ctx+stanza+" { "+s.leaf+" "+v2+"; }")
+		compact := nest(parent, ctx+stanza+" "+s.leaf+" "+v1+";")
+
+		cb1, cb2, cc := compileText(t, blockV1), compileText(t, blockV2), compileText(t, compact)
+		if cb1 == nil || cb2 == nil || cc == nil {
+			res.skipped["a spelling did not parse or compile"]++
+			continue
+		}
+		// VACUITY GUARD. If changing the VALUE does not change the compiled
+		// config, this cell cannot observe a dropped value and calling it a
+		// pass would be meaningless. #6821 sat in this bucket until its
+		// required-sibling context line was added — every entry here is an
+		// UNRULED candidate, not a clean site.
+		if cfgEqual(cb1, cb2) {
+			res.skipped["leaf value not observable in the typed config"]++
+			continue
+		}
+		res.checked++
+		if !cfgEqual(cb1, cc) {
+			res.divergent = append(res.divergent, strings.Join(s.container, " ")+" "+s.leaf)
+		}
+	}
+	sort.Strings(res.divergent)
+	return res
+}
+
+func readInventory(t *testing.T) (sites []string, wantChecked int) {
+	t.Helper()
+	raw, err := os.ReadFile(inventoryPath)
+	if err != nil {
+		t.Fatalf("read inventory: %v", err)
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "#") {
+			if _, err := fmt.Sscanf(line, "# checked: %d", &wantChecked); err == nil {
+				continue
+			}
+			continue
+		}
+		sites = append(sites, line)
+	}
+	sort.Strings(sites)
+	return sites, wantChecked
+}
+
+// TestCompactBlockEquivalenceInventory2419 is the #2419 class gate.
+//
+// The property: for every config leaf under a PLAIN KEYWORD stanza, the compact
+// spelling (`stanza leaf value;` — value on the stanza's own Keys) and the block
+// spelling (`stanza { leaf value; }`) must compile to the same typed config. A
+// compiler stanza that iterates only prop.Children reads one and silently drops
+// the other.
+//
+// Today 194 sites fail that property. They are recorded in the inventory file
+// rather than suppressed, so this gate does three things at once:
+//
+//   - a NEW compact-blind reader is an unexpected divergence -> RED;
+//   - a site FIXED without updating the inventory -> RED, so the file cannot
+//     rot into a stale allowlist;
+//   - the CHECKED count is a ratchet, so sites cannot silently drain out of the
+//     tested population into the skip buckets (which is how an instrument stops
+//     measuring while still reporting success).
+func TestCompactBlockEquivalenceInventory2419(t *testing.T) {
+	res := runCompactBlockCensus(t)
+	want, wantChecked := readInventory(t)
+
+	inWant := map[string]bool{}
+	for _, s := range want {
+		inWant[s] = true
+	}
+	inGot := map[string]bool{}
+	for _, s := range res.divergent {
+		inGot[s] = true
+	}
+	for _, s := range res.divergent {
+		if !inWant[s] {
+			t.Errorf("#2419: NEW compact-blind site (compact spelling drops the value): %s\n"+
+				"    A compiler stanza was added or changed to read only prop.Children.\n"+
+				"    Fix the reader, or add the site to %s with a reason.", s, inventoryPath)
+		}
+	}
+	for _, s := range want {
+		if !inGot[s] {
+			t.Errorf("#2419: %s lists %q as compact-blind, but it now compiles equivalently.\n"+
+				"    If you fixed it, REMOVE the line — a stale inventory is an allowlist "+
+				"that hides the next regression.", inventoryPath, s)
+		}
+	}
+	// Coverage ratchet.
+	if res.checked < wantChecked {
+		t.Errorf("#2419: checked-cell coverage DROPPED from %d to %d. Sites moved out of the "+
+			"tested population into the skip buckets; the census stops measuring them.",
+			wantChecked, res.checked)
+	}
+	// Positive control.
+	for site, issue := range filedInstances {
+		if !inGot[site] {
+			t.Errorf("#2419 POSITIVE CONTROL: the instrument no longer finds %s (%s). "+
+				"An instrument that stops finding known-true sites reports clean for the "+
+				"same reason a textual sweep does.", site, issue)
+		}
+	}
+}
+
+// TestCompactBlockCensusReport2419 prints the census. It asserts nothing the
+// gate above does not; it exists so the numbers — including the UNRULED skips —
+// are visible in `go test -v` output rather than only in a PR body.
+func TestCompactBlockCensusReport2419(t *testing.T) {
+	res := runCompactBlockCensus(t)
+	t.Logf("#2419 compact/block equivalence census")
+	t.Logf("  cells CHECKED (vacuity-guarded): %d", res.checked)
+	t.Logf("  cells DIVERGENT:                 %d", len(res.divergent))
+	keys := make([]string, 0, len(res.skipped))
+	for k := range res.skipped {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		t.Logf("  cells SKIPPED — %-52s %d", k, res.skipped[k])
+	}
+	t.Logf("  NOTE: the %d 'not observable' skips are UNRULED, not clean — each is a site "+
+		"whose synthesized fixture was too thin to observe the value (as #6821 was before "+
+		"its required-sibling context line). The census is a FLOOR.",
+		res.skipped["leaf value not observable in the typed config"])
+}

--- a/pkg/config/compact_block_inventory_regen_2419_test.go
+++ b/pkg/config/compact_block_inventory_regen_2419_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestRegenerateCompactBlockInventory2419 rewrites the checked-in inventory
+// from a live census. It is ENV-GATED and skipped by default: a golden that
+// regenerates itself on every run is not a gate, it is a transcript.
+//
+// Regenerate ONLY when you have classified the diff. Lines REMOVED mean sites
+// you fixed; lines ADDED mean compact-blind readers you introduced, and adding
+// them here instead of fixing them converts the gate into an allowlist. The
+// PR 2 normalizer should drive this file to zero data lines, and the diff is
+// the evidence for that claim.
+//
+//	XPF_GEN_2419=1 go test -run TestRegenerateCompactBlockInventory2419 ./pkg/config/
+func TestRegenerateCompactBlockInventory2419(t *testing.T) {
+	if os.Getenv("XPF_GEN_2419") != "1" {
+		t.Skip("env-gated: set XPF_GEN_2419=1 to regenerate the inventory (classify the diff first)")
+	}
+	res := runCompactBlockCensus(t)
+	var b strings.Builder
+	b.WriteString("# #2419 compact/block equivalence — KNOWN-FAILING INVENTORY\n")
+	b.WriteString("#\n")
+	b.WriteString("# Each line is a config site whose COMPACT spelling (`stanza leaf value;`)\n")
+	b.WriteString("# compiles to a different typed config than its BLOCK spelling\n")
+	b.WriteString("# (`stanza { leaf value; }`) — i.e. a compiler stanza that reads only\n")
+	b.WriteString("# prop.Children and silently drops the value.\n")
+	b.WriteString("#\n")
+	b.WriteString("# This is an EXPECTED-FAILURE list, not a suppression. The gate in\n")
+	b.WriteString("# compact_block_equivalence_2419_test.go asserts the divergent set EQUALS\n")
+	b.WriteString("# this file, so a new compact-blind reader reds the suite and a site fixed\n")
+	b.WriteString("# without removing its line reds it too.\n")
+	b.WriteString("#\n")
+	b.WriteString("# `xpfarg` / `xpfname` are synthesized instance names.\n")
+	b.WriteString("#\n")
+	b.WriteString("# checked: ")
+	b.WriteString(strconv.Itoa(res.checked))
+	b.WriteString("\n#\n")
+	for _, k := range []string{
+		"leaf value not observable in the typed config",
+		"a spelling did not parse or compile",
+		"no two distinct synthesizable values",
+		"under groups (schema re-host, duplicate coverage)",
+	} {
+		b.WriteString("# skipped (" + k + "): " + strconv.Itoa(res.skipped[k]) + "\n")
+	}
+	b.WriteString("#\n")
+	for _, s := range res.divergent {
+		b.WriteString(s + "\n")
+	}
+	if err := os.WriteFile(inventoryPath, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("wrote %d divergent sites, checked=%d", len(res.divergent), res.checked)
+}

--- a/pkg/config/testdata/compact_block_divergences_2419.txt
+++ b/pkg/config/testdata/compact_block_divergences_2419.txt
@@ -1,0 +1,215 @@
+# #2419 compact/block equivalence — KNOWN-FAILING INVENTORY
+#
+# Each line is a config site whose COMPACT spelling (`stanza leaf value;`)
+# compiles to a different typed config than its BLOCK spelling
+# (`stanza { leaf value; }`) — i.e. a compiler stanza that reads only
+# prop.Children and silently drops the value.
+#
+# This is an EXPECTED-FAILURE list, not a suppression. The gate in
+# compact_block_equivalence_2419_test.go asserts the divergent set EQUALS
+# this file, so a new compact-blind reader reds the suite and a site fixed
+# without removing its line reds it too.
+#
+# `xpfarg` / `xpfname` are synthesized instance names.
+#
+# checked: 326
+#
+# skipped (leaf value not observable in the typed config): 96
+# skipped (a spelling did not parse or compile): 15
+# skipped (no two distinct synthesizable values): 9
+# skipped (under groups (schema re-host, duplicate coverage)): 346
+#
+applications application-set
+chassis device-map unmapped-interface-policy
+class-of-service interfaces xpfarg classifiers dscp
+class-of-service interfaces xpfarg classifiers ieee-802.1
+class-of-service interfaces xpfarg rewrite-rules dscp
+class-of-service interfaces xpfarg rewrite-rules ieee-802.1
+firewall policer xpfarg if-exceeding bandwidth-limit
+firewall policer xpfarg if-exceeding burst-size-limit
+firewall policer xpfarg then loss-priority
+forwarding-options dhcp-relay server-group
+forwarding-options family inet6 mode
+forwarding-options sampling instance xpfarg family inet output source-address
+forwarding-options sampling instance xpfarg family inet6 output source-address
+forwarding-options sampling instance xpfarg input rate
+interfaces xpfname aggregated-ether-options lacp periodic
+interfaces xpfname aggregated-ether-options link-speed
+interfaces xpfname gigether-options 802.3ad
+interfaces xpfname gigether-options redundant-parent
+interfaces xpfname tunnel destination
+interfaces xpfname tunnel key
+interfaces xpfname tunnel mode
+interfaces xpfname tunnel routing-instance destination
+interfaces xpfname tunnel source
+interfaces xpfname tunnel ttl
+interfaces xpfname tunnel wireguard listen-port
+interfaces xpfname tunnel wireguard private-key
+policy-options policy-statement xpfarg term xpfarg from as-path
+policy-options policy-statement xpfarg term xpfarg from community
+policy-options policy-statement xpfarg term xpfarg from prefix-list
+policy-options policy-statement xpfarg term xpfarg from protocol
+policy-options policy-statement xpfarg term xpfarg then as-path-prepend
+policy-options policy-statement xpfarg term xpfarg then community
+policy-options policy-statement xpfarg term xpfarg then load-balance
+policy-options policy-statement xpfarg term xpfarg then local-preference
+policy-options policy-statement xpfarg term xpfarg then metric
+policy-options policy-statement xpfarg term xpfarg then metric-type
+policy-options policy-statement xpfarg term xpfarg then next-hop
+policy-options policy-statement xpfarg term xpfarg then origin
+policy-options prefix-list
+protocols bgp cluster-id
+protocols bgp export
+protocols bgp import
+protocols bgp local-as
+protocols bgp router-id
+protocols isis authentication-key
+protocols isis authentication-type
+protocols isis export
+protocols isis is-type
+protocols isis level
+protocols isis net
+protocols lldp hold-multiplier
+protocols lldp transmit-interval
+protocols ospf area xpfarg interface xpfarg authentication simple-password
+protocols ospf export
+protocols ospf router-id
+protocols ospf3 export
+protocols ospf3 router-id
+protocols rip authentication-key
+protocols rip authentication-type
+protocols rip neighbor
+protocols rip passive-interface
+protocols rip redistribute
+routing-instances xpfname protocols isis authentication-key
+routing-instances xpfname protocols isis authentication-type
+routing-instances xpfname protocols isis export
+routing-instances xpfname protocols isis is-type
+routing-instances xpfname protocols isis level
+routing-instances xpfname protocols isis net
+routing-instances xpfname protocols ospf area xpfarg interface xpfarg authentication simple-password
+routing-instances xpfname protocols ospf3 export
+routing-instances xpfname protocols ospf3 router-id
+routing-options autonomous-system
+routing-options forwarding-table export
+schedulers scheduler xpfarg daily start-time
+schedulers scheduler xpfarg daily stop-time
+schedulers scheduler xpfarg friday start-time
+schedulers scheduler xpfarg friday stop-time
+schedulers scheduler xpfarg monday start-time
+schedulers scheduler xpfarg monday stop-time
+schedulers scheduler xpfarg saturday start-time
+schedulers scheduler xpfarg saturday stop-time
+schedulers scheduler xpfarg sunday start-time
+schedulers scheduler xpfarg sunday stop-time
+schedulers scheduler xpfarg thursday start-time
+schedulers scheduler xpfarg thursday stop-time
+schedulers scheduler xpfarg tuesday start-time
+schedulers scheduler xpfarg tuesday stop-time
+schedulers scheduler xpfarg wednesday start-time
+schedulers scheduler xpfarg wednesday stop-time
+security dynamic-address address-name xpfarg profile feed-name
+security flow aging early-ageout
+security flow aging high-watermark
+security flow aging low-watermark
+security flow icmp-session timeout
+security flow multicast-session-lifetime
+security flow route-change-timeout
+security flow tcp-session closing-timeout
+security flow tcp-session established-timeout
+security flow tcp-session initial-timeout
+security flow tcp-session time-wait-timeout
+security flow traceoptions file
+security flow traceoptions flag
+security flow udp-session timeout
+security ipsec vpn xpfarg ike gateway
+security ipsec vpn xpfarg ike ipsec-policy
+security ipsec vpn xpfarg vpn-monitor destination-ip
+security ipsec vpn xpfarg vpn-monitor source-interface
+security log format
+security log mode
+security log source-interface
+security log stream xpfarg transport protocol
+security log stream xpfarg transport tls-profile
+security nat destination pool
+security nat destination rule-set xpfarg rule xpfarg match application
+security nat destination rule-set xpfarg rule xpfarg match destination-address
+security nat destination rule-set xpfarg rule xpfarg match destination-address-name
+security nat destination rule-set xpfarg rule xpfarg match destination-port
+security nat destination rule-set xpfarg rule xpfarg match protocol
+security nat destination rule-set xpfarg rule xpfarg match source-address
+security nat destination rule-set xpfarg rule xpfarg match source-address-name
+security nat source rule-set xpfarg rule xpfarg match application
+security nat source rule-set xpfarg rule xpfarg match destination-address
+security nat source rule-set xpfarg rule xpfarg match destination-address-name
+security nat source rule-set xpfarg rule xpfarg match destination-port
+security nat source rule-set xpfarg rule xpfarg match source-address
+security nat source rule-set xpfarg rule xpfarg match source-address-name
+security nat static rule-set xpfarg rule xpfarg match destination-address
+security nat static rule-set xpfarg rule xpfarg match destination-port
+security nat static rule-set xpfarg rule xpfarg match source-address
+security policies default-policy-log
+security policies from-zone xpfarg xpfarg xpfarg policy xpfarg match application
+security policies from-zone xpfarg xpfarg xpfarg policy xpfarg match destination-address
+security policies from-zone xpfarg xpfarg xpfarg policy xpfarg match source-address
+security policies from-zone xpfarg xpfarg xpfarg policy xpfarg then log
+security policies global policy xpfarg match application
+security policies global policy xpfarg match destination-address
+security policies global policy xpfarg match from-zone
+security policies global policy xpfarg match source-address
+security policies global policy xpfarg match to-zone
+security policies global policy xpfarg then log
+security pre-id-default-policy then log
+security screen ids-option xpfarg limit-session destination-ip-based
+security screen ids-option xpfarg limit-session source-ip-based
+security zones security-zone xpfarg host-inbound-traffic protocols
+security zones security-zone xpfarg host-inbound-traffic system-services
+security zones security-zone xpfarg interfaces xpfname host-inbound-traffic protocols
+security zones security-zone xpfarg interfaces xpfname host-inbound-traffic system-services
+services flow-monitoring version-ipfix template xpfarg template-refresh-rate seconds
+services flow-monitoring version9 template xpfarg template-refresh-rate seconds
+snmp v3 usm local-engine user xpfarg authentication-md5 authentication-password
+snmp v3 usm local-engine user xpfarg authentication-sha authentication-password
+snmp v3 usm local-engine user xpfarg authentication-sha256 authentication-password
+snmp v3 usm local-engine user xpfarg privacy-aes128 privacy-password
+snmp v3 usm local-engine user xpfarg privacy-des privacy-password
+system archival configuration archive-sites
+system archival configuration transfer-interval
+system dataplane binary
+system dataplane claim-host-tunables
+system dataplane coalescence adaptive
+system dataplane coalescence rx-usecs
+system dataplane coalescence tx-usecs
+system dataplane cpu-governor
+system dataplane netdev-budget
+system dataplane poll-mode
+system dataplane ring-entries
+system dataplane shared-umem artifact-file
+system dataplane shared-umem interface
+system dataplane shared-umem mode
+system dataplane shared-umem phase0-artifact-file
+system dataplane state-file
+system dataplane workers
+system domain-search
+system host-name
+system license autoupdate url
+system login user xpfarg authentication encrypted-password
+system login user xpfarg authentication ssh-dsa
+system login user xpfarg authentication ssh-ed25519
+system login user xpfarg authentication ssh-rsa
+system master-password pseudorandom-function
+system name-server
+system ntp server
+system root-authentication encrypted-password
+system root-authentication ssh-dsa
+system root-authentication ssh-ed25519
+system root-authentication ssh-rsa
+system services ssh client-alive-count-max
+system services ssh client-alive-interval
+system services ssh connection-limit
+system services ssh key-exchange
+system services ssh root-login
+system services web-management api-auth api-key
+system services web-management http interface
+system services web-management https interface
+system time-zone


### PR DESCRIPTION
Refs #6817, #6818, #6821, #6822 — **closes none of them.** This is PR 1 of 2: the gate and the census. The normalizer that drives the inventory to zero is PR 2, deliberately unfolded.

## Summary

- **#6817, #6818, #6821 and #6822 are four instances of one class.** A compiler stanza that iterates only `prop.Children` and dispatches on child names reads the BLOCK spelling `stanza { leaf value; }` and silently drops the COMPACT spelling `stanza leaf value;`, which puts the value on the stanza's own `Keys[1:]`.
- **These are silent security downgrades on the NORMAL commit path.** `SchemaValidate` accepts the compact spelling for all four, so the strict gate passes and the commit reports success: a login account with no credential, an **OSPF adjacency forming unauthenticated**, **audit logs shipping in clear**, and SNMPv3 with the protocol set and the password empty. Not tolerant-load-only.
- **Four was a floor and no textual instrument could say by how much.** So this PR adds a generative one and records what it finds. No production change.
- **The census is 194**, not 4 — and the honest number is **≥194 divergent, 96 unruled**.

## Why a textual sweep cannot enumerate this class

Two predicates were tried on the issues. The first found 80 readers with 68 "blind" — over-counted, because a `case` handling the flat shape one line above the loop was flagged. The second matched 11 candidates and **none of the three known-true sites**, because a ±14-line lookback cannot scope itself to a `case` block. False positives *and* false negatives, with output indistinguishable from a clean result.

## The prescribed instrument was also vacuous — this is the main finding

The plan of record was: build the **flat-set** spelling with `ParseSetCommand` + `SetPath`, build the block spelling, compile both, require equality.

`ParseSetCommand` + `SetPath` produces the **BLOCK** tree. Dumped:

```
set system login user ops authentication encrypted-password "$6$xyz"
  Keys=[system] → Keys=[login] → Keys=[user ops] → Keys=[authentication] children=1
                                                     └─ Keys=[encrypted-password $6$xyz] IsLeaf
```

That is bit-identical to what `authentication { encrypted-password "…"; }` produces, and exactly the shape the current reader already handles. So "flat vs block" compares block against block: **vacuously equal for every leaf, green everywhere, census of zero.**

The compact tree comes from the **hierarchical parser** on hand-authored / `load merge`d text:

```
Keys=[authentication encrypted-password $6$compact]  children=0
```

One leaf, value on the stanza's own Keys, no children — which is why a `prop.Children` loop sees nothing. Worth stating precisely because the issues imply otherwise: **the compact shape does not come from `| display set` round-tripping.** It comes from hand-authoring and from tools that render flat paths into partial braces. Real, but narrower than "any flattened config".

## Three bugs in my own instrument, all caught by the positive control

The check that mattered was: **does it find the four known-true sites?** First run: **2 of 4.**

| bug | effect |
|---|---|
| args rendered as their own nesting level (`user { ops { … } }` instead of `user ops { … }`) | different tree; hid #6822 |
| fixtures missing REQUIRED SIBLINGS — `compiler_security_log.go` registers a stream only when `Host != ""` | transport-only fixture produced no stream; both spellings agreed on nothing; hid #6821 |
| **NAMED INSTANCES** were being compacted | collapsing `interfaces ge-0/0/0` produces a node the compiler cannot recognise as that instance, not the compact spelling of the same intent — ~150 phantom divergences |

Each inflates divergences while hiding real sites, which is the worst error direction for a census. **4/4 after the fixes**, and that control is the only reason the rest is believable.

## Census at this head

| | count |
|---|---|
| sites enumerated | 792 |
| cells **CHECKED** (vacuity-guarded) | 326 |
| cells **DIVERGENT** | **194** |
| skipped — under `groups` (schema re-hosts the whole tree) | 346 |
| skipped — leaf value not observable in the typed config | **96 — UNRULED** |
| skipped — a spelling did not parse or compile | 15 |
| skipped — no two distinct synthesizable values | 9 |

By root: security 58, system 40, protocols 23, schedulers 16, policy-options 13, interfaces 12, routing-instances 9, snmp 5, forwarding-options 5, class-of-service 4, firewall 3, services 2, routing-options 2, chassis 1, applications 1.

**The 96 "not observable" skips are UNRULED, not clean** — each is a site whose synthesized fixture was too thin to observe the value, exactly as #6821 was before its required-sibling context line. The number to quote is **≥194 divergent, 96 unruled**; a census that rounds its unknowns into "clean" is the same failure as the instrument that found 2 of 4.

Hand-verified beyond the filed four (COUNT → VERIFY a sample):
- `protocols { bgp export my-policy; }` → the BGP export policy list compiles **empty**.
- `interfaces { gr-0/0/0 { tunnel source …; tunnel destination …; } }` → the GRE tunnel loses **both** endpoints.

## What the gate asserts

The 194 are recorded in `pkg/config/testdata/compact_block_divergences_2419.txt` as an **expected-failure inventory, not a suppression**:

- divergent set **must EQUAL** the inventory — a NEW compact-blind reader reds the suite;
- a site FIXED without removing its line also reds — a stale inventory is an allowlist that hides the next regression;
- the `# checked:` header is a **coverage RATCHET** — sites cannot drain out of the tested population into the skip buckets, which is how an instrument stops measuring while still reporting success;
- the **positive control** asserts the four filed instances are found, by construction.

The regenerator is env-gated (`XPF_GEN_2419=1`) and documented to require classifying the diff first: a golden that regenerates on every run is a transcript, not a gate.

## Test plan

- [x] `TestCompactBlockEquivalenceInventory2419` — the gate. `TestCompactBlockCensusReport2419` — prints the census including the unruled count.
- [x] **Mutation matrix, 9 cells**, full-package `go test -count=1 ./pkg/config/`, **no `-run` filter**, applied-check + restore-check per cell.
- [x] `go build ./...` rc 0 · **`go test -count=1 ./...` rc 0**, 67 packages ok.

Every cell reports **tests-collected**, and every cell collected **6601**. That is the verdict discriminator, not the absence of a build-failure string — see the note below the table.

| # | Mutation | Verdict | tests collected |
|---|---|---|---|
| I1 | remove a listed site from the inventory | RED | 6601 |
| I2 | add a bogus site to the inventory | RED | 6601 |
| G1 | render args as their own nesting level | RED | 6601 |
| G2 | drop the required-sibling context line | RED — and it reds the **positive control** naming #6821's site | 6601 |
| G3 | allow named-instance compaction | RED | 6601 |
| V1 | drop the vacuity guard | RED | 6601 |
| R1a | ratchet violation, guard PRESENT | RED | 6601 |
| R1b | same violation, guard REMOVED | **GREEN — the expected negative arm** | 6601 |
| P1 | point the positive control at a non-divergent site | RED | 6601 |

**R1a/R1b are a paired cell.** A lone "delete the guard" mutation showed nothing, because nothing currently violates the ratchet — that cell escaped green and would have certified a decorative guard. The pairing proves necessity *and* sufficiency: the same violation reds with the guard and passes without it.

**The harness discriminator was wrong and is now fixed at the source.** P1 initially reported a failure with **no named test**: a syntax break the detector missed because it grepped for `[build failed]` while Go emitted `[setup failed]` / `expected '(', found`. A cell that compiled nothing was being counted as RED coverage it never provided.

Enumerating Go's failure vocabulary is the wrong instrument — it is a denylist that is wrong the moment Go words something differently. The harness now gates on **tests-collected > 0** (`grep -c '^=== RUN'` under `-v`): a build break and an assertion failure both produce a non-zero rc, and only one of them ran anything. Every cell above is reported with its collected count, and all nine collected 6601. "Did it RED" and "did it RUN" are different questions, and the harness can now tell them apart.

Gated HEAD: **`a215f7c670ebb820e44bf221610dad8fe1fa310b`**, `git merge-base --is-ancestor origin/master HEAD` passes. Master moved three times under this branch and was **merged, not rebased** every time, with the full repo-wide `go build ./... && go test -count=1 ./...` re-run at each merged head (rc 0, 68 packages). `_Log.md` conflicted on the #6833 landing and was resolved `theirs + ours_tail` — 0 conflict markers, this PR's entry present exactly once, all 1971 of master's headings surviving, no line lost from master's side, `pkg/refactoraudit`'s marker and duplicate gates green. **The mutation matrix was re-run in full with the corrected detector** at `08844b76b`; the only delta since is a `_Log.md` merge, and disjointness is verified over that range — `git diff --name-only 574381933..b8aa08445` intersects the gate, the regenerator and the inventory in **0** places. No files under `userspace-dp/` or `userspace-xdp/`, so no cargo leg is owed.

## Validation not executed

`make test-deploy` / `make cluster-deploy` not run and not claimed — the loss cluster is shared and lock-protected and this lane does not take the lock. This PR adds no production code, so there is nothing on the dataplane for a smoke to exercise.

## Deferred — PR 2

The schema-driven normalizer: if a node's schema says it is a CONTAINER and its `Keys` tail begins with the name of one of that container's schema children, re-parent the tail as a child node. That turns every compact node into the block node existing readers already handle and closes the class in one place instead of 194.

Its correctness criterion is then measurable rather than argued — **the inventory goes 194 → 0 and nothing that passes today changes** — which is what makes the blast radius acceptable. Two properties it must assert beyond that: **identity on block-spelled input** (provably a no-op on a tree with no compact nodes) and **never touching a schema LEAF** (bracketed multi-value lists collapse onto `Keys` legitimately; a normalizer that re-parented those tails would destroy every bracket list in the fleet). Codex review is required on PR 2.

Kept separate on purpose: if the normalizer proves unsafe, the class stays visible here and per-site repair can proceed against the same inventory.

## Docs

`docs/config-schema.md` gains the compact/block sub-leaf contract beside the bracketed-list section that already documents the leaf half of the dual-AST contract — including the flat-set-is-block correction, the plain-stanza-only rule, and the bracket-list hazard any fix must respect.

## Reviews still owed

No Codex plan or code review on this branch. Copilot is dead repo-wide.
