### PR TITLE
rendersafe: one control-byte primitive, two grammar justifications (#6833)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -106098,3 +106098,46 @@ prose edit above them added. No diff falls in the new test body.
 - **Found by**: the lane driving #6808, caught in `git status` rather than at
   review.
 - **File(s)**: `docs/engineering-style.md`, `_Log.md`
+
+## 2026-08-26 — #6833: one primitive, two justifications, and inventory guards
+
+- **Timestamp**: 2026-08-26
+- **Action**: Move the duplicated control-byte belt into `pkg/rendersafe`, and
+  give each consumer a wrapper that names ITS grammar plus an inventory guard.
+- **I diverged from the issue's fix direction #1, deliberately.** It says "one
+  shared helper, in one place", and direction #2 says each call site must name
+  "the specific byte class that is load-bearing for it". Those pull apart: a
+  single shared function cannot carry two justifications, and a function whose
+  doc names two grammars is exactly what invites the relaxation the issue warns
+  about. Resolved as ONE grammar-agnostic primitive
+  (`rendersafe.ReplaceControlBytes(s, repl)`, documented as NOT a security
+  boundary on its own) plus TWO thin per-consumer wrappers. The body exists once
+  — so the dangerous edit can only be made once — while the justification lives
+  at each call site, which is what direction #2 actually asks for.
+- **The substitute is now the caller's parameter**, not hardcoded. That is the
+  mechanical expression of "the safe substitute is a per-consumer fact"; a
+  primitive that hardcoded a space would pull the decision back inside.
+- **Checked, not assumed, that a space is safe at every CURRENT call site**:
+  `sanitizeUnitValue` is applied to `Description=` and only `Description=` (free
+  text); swanctl's unquoted interpolations are comma-separated list keys, not
+  whitespace-separated, and the quoted ones additionally pass through
+  `escapeSwanctlQuoted`. So both belts are correct as written — the issue's
+  `OriginalName=` hazard is real but NOT reachable through `sanitizeUnitValue`,
+  because it is not applied there.
+- **Which makes the real risk a FUTURE call site, so that is what is guarded.**
+  Each package gains an inventory cell asserting which keys the belt is applied
+  to. Adding `sanitizeUnitValue` to a whitespace-separated `[Match]` key, or
+  `sanitizeSwanctlValue` to an unrecorded swanctl key, REDS with a message saying
+  what to re-derive. Verified by probe: both fire on exactly that shape and pass
+  once reverted. The point is not to forbid new call sites but to make the
+  derivation unavoidable.
+- **The primitive's own test is exhaustive over 0x00-0xFF rather than sampled**,
+  because the failure it guards is a future edit NARROWING the class ("surely
+  0x0B is harmless") and a sampled test is what such an edit slips past. Plus a
+  cell asserting the UTF-8 claim the doc makes, which reds if the class were
+  widened to "any byte >= 0x7F".
+- **File(s)**: `pkg/rendersafe/rendersafe.go` (new),
+  `pkg/rendersafe/rendersafe_test.go` (new), `pkg/ipsec/policy.go`,
+  `pkg/ipsec/swanctl_value_grammar_6833_test.go` (new),
+  `pkg/networkd/networkd.go`,
+  `pkg/networkd/unit_value_grammar_6833_test.go` (new), `_Log.md`

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/rendersafe"
 )
 
 // childSelector is a resolved child SA traffic-selector pair for swanctl
@@ -527,32 +528,36 @@ func childNameDisambiguator(original string) string {
 	return fmt.Sprintf("%08x", uint32(h.Sum64()))
 }
 
-// sanitizeSwanctlValue strips ASCII control characters — the C0 set
-// (0x00-0x1F, including newline) and DEL (0x7F), each replaced by a
-// space — from a free-text config value (connection name, IKE
-// identity, certificate name, pre-shared key) before it is
-// interpolated into a generated swanctl.conf line. Render-side belt
-// for #1798: an embedded newline must not be able to inject extra
-// swanctl sections/keys even if the commit-time validation layer were
-// bypassed.
+// sanitizeSwanctlValue replaces every ASCII control byte (C0, 0x00-0x1F, which
+// includes newline, plus DEL 0x7F) with a SPACE before the value is interpolated
+// into a generated swanctl.conf line. Render-side belt for #1798.
+//
+// # The consuming grammar, and why a space is the right substitute here (#6833)
+//
+// swanctl.conf is `section { key = value }` with values running to end of line
+// and `#` starting a comment. The load-bearing byte for an interpolated value is
+// therefore the NEWLINE: it ends the current setting and lets the remainder be
+// read as a new key, or as a new section. That is the byte #1798 named and it is
+// genuinely the live one here.
+//
+// A space is safe at every current call site, and that is a checked claim rather
+// than an assumption:
+//
+//   - The UNQUOTED interpolations are `local_addrs`, `remote_addrs`, `proposals`,
+//     `esp_proposals`, `local_ts`, `remote_ts` and section names. The list-valued
+//     ones among these are COMMA-separated in swanctl, not whitespace-separated,
+//     so an injected space produces one malformed value rather than two entries.
+//   - The QUOTED interpolations (`certs`, `id`, `secret`) additionally pass
+//     through escapeSwanctlQuoted, so the quoting protects them independently.
+//
+// If a future call site interpolates into a key whose grammar makes whitespace
+// SIGNIFICANT, this substitution stops being safe and the caller must re-derive
+// it — a space would then manufacture the delimiter the belt exists to prevent
+// (the #6829 shape, where the space and not the newline was the live byte).
+// TestSwanctlSanitizerCallSitesAreUnquotedOrEscaped_6833 pins the current
+// inventory so such a site cannot be added silently.
 func sanitizeSwanctlValue(s string) string {
-	clean := true
-	for i := 0; i < len(s); i++ {
-		if s[i] < 0x20 || s[i] == 0x7f {
-			clean = false
-			break
-		}
-	}
-	if clean {
-		return s
-	}
-	b := []byte(s)
-	for i := range b {
-		if b[i] < 0x20 || b[i] == 0x7f {
-			b[i] = ' '
-		}
-	}
-	return string(b)
+	return rendersafe.ReplaceControlBytes(s, ' ')
 }
 
 // escapeSwanctlQuoted escapes a string for safe inclusion inside a

--- a/pkg/ipsec/swanctl_value_grammar_6833_test.go
+++ b/pkg/ipsec/swanctl_value_grammar_6833_test.go
@@ -1,0 +1,111 @@
+package ipsec
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// swanctl_value_grammar_6833_test.go -- #6833.
+//
+// sanitizeSwanctlValue replaces control bytes with a SPACE. Whether that is safe
+// is a fact about swanctl.conf's grammar, and it was not recorded anywhere until
+// now. These cells pin both halves: the byte the belt is actually for, and the
+// call-site inventory that makes the substitute correct.
+
+// TestSwanctlSanitizerReplacesTheNewline_6833 pins the live byte. swanctl.conf is
+// `section { key = value }` with values running to end of line, so a newline ends
+// the setting and lets the remainder be read as a new key or section.
+func TestSwanctlSanitizerReplacesTheNewline_6833(t *testing.T) {
+	got := sanitizeSwanctlValue("conn\n  rogue = 1")
+	if strings.ContainsRune(got, '\n') {
+		t.Fatalf("a newline survived sanitizeSwanctlValue (%q): values run to end "+
+			"of line, so the remainder is read as a NEW setting -- the #1798 "+
+			"injection this belt exists to stop", got)
+	}
+}
+
+// TestSwanctlSanitizerCallSitesAreUnquotedOrEscaped_6833 is the INVENTORY guard.
+//
+// A space is safe at every current call site for two different reasons, and the
+// distinction matters because only one of them survives a new call site:
+//
+//   - UNQUOTED keys (local_addrs, remote_addrs, proposals, esp_proposals,
+//     local_ts, remote_ts) and section names: swanctl's list-valued keys are
+//     COMMA-separated, not whitespace-separated, so an injected space yields one
+//     malformed value rather than two entries.
+//   - QUOTED keys (certs, id, secret): additionally wrapped by
+//     escapeSwanctlQuoted, so the quoting protects them independently of the
+//     substitute.
+//
+// If a future call site interpolates into a key whose grammar makes whitespace
+// SIGNIFICANT, the space stops being safe and manufactures the delimiter -- the
+// #6829 shape, where the space and not the newline was the live byte.
+//
+// This asserts the known-safe key inventory. A new key REDS, which forces
+// whoever adds it to state why a space is ordinary text there. The point is not
+// to forbid new call sites; it is to make the derivation unavoidable.
+func TestSwanctlSanitizerCallSitesAreUnquotedOrEscaped_6833(t *testing.T) {
+	src := stripLineComments6833(readIPsecSource6833(t, "policy.go"))
+
+	// Keys whose grammar has been checked and recorded in sanitizeSwanctlValue's
+	// doc comment. Section headers ("  %s {") and the quoted keys are handled
+	// separately below.
+	known := map[string]bool{
+		"local_addrs": true, "remote_addrs": true,
+		"proposals": true, "esp_proposals": true,
+		"local_ts": true, "remote_ts": true,
+	}
+
+	key := regexp.MustCompile(`"\s*([a-z_]+) = %s\\n", sanitizeSwanctlValue\(`)
+	found := key.FindAllStringSubmatch(src, -1)
+	if len(found) == 0 {
+		t.Fatal("found no unquoted key-equals-value sanitizeSwanctlValue call " +
+			"sites; the inventory guard is matching nothing and would pass over " +
+			"any change")
+	}
+	for _, m := range found {
+		if !known[m[1]] {
+			t.Errorf("sanitizeSwanctlValue is interpolated into the unquoted key %q, "+
+				"which is not in the checked inventory. A SPACE is only ordinary text "+
+				"where the key is not whitespace-list-valued; swanctl's list keys are "+
+				"comma-separated, but that was verified for the keys listed in the "+
+				"function's doc comment and not for %q. Re-derive it, then add %q "+
+				"here (#6833).", m[1], m[1], m[1])
+		}
+	}
+
+	// Every QUOTED interpolation must still pass through escapeSwanctlQuoted --
+	// the second, independent reason a space is safe there. A quoted site that
+	// dropped the escape would rely on the substitute alone.
+	quoted := regexp.MustCompile(`= \\"%s\\"\\n", ([A-Za-z]+)\(`)
+	for _, m := range quoted.FindAllStringSubmatch(src, -1) {
+		if m[1] != "escapeSwanctlQuoted" {
+			t.Errorf("a quoted swanctl value is rendered through %q rather than "+
+				"escapeSwanctlQuoted; the quoting is the independent protection for "+
+				"quoted keys and must not be dropped (#6833)", m[1])
+		}
+	}
+}
+
+func readIPsecSource6833(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}
+
+func stripLineComments6833(s string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(s, "\n") {
+		if i := strings.Index(line, "//"); i >= 0 {
+			line = line[:i]
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/pkg/networkd/networkd.go
+++ b/pkg/networkd/networkd.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/psaab/xpf/pkg/fsatomic"
+	"github.com/psaab/xpf/pkg/rendersafe"
 )
 
 // networkctlTimeout bounds every networkctl shell-out. Apply runs on
@@ -683,32 +684,35 @@ func (m *Manager) findExternallyManaged() map[string]bool {
 	return FindExternallyManaged(m.networkDir)
 }
 
-// sanitizeUnitValue strips ASCII control characters — the C0 set
-// (0x00-0x1F, including newline) and DEL (0x7F), each replaced by a
-// space — from a free-text config value before it is interpolated into
-// a generated systemd unit line. Render-side belt for #1798: a
-// description like "lan\nDHCP=ipv4" must not be able to inject extra
-// directives into a .network/.netdev/.link unit even if the
-// commit-time validation layer were bypassed (e.g. an old persisted
-// value reaching the renderer ahead of the load-time sanitizer).
+// sanitizeUnitValue replaces every ASCII control byte (C0, 0x00-0x1F, which
+// includes newline, plus DEL 0x7F) with a SPACE before the value is interpolated
+// into a generated systemd unit line. Render-side belt for #1798: a description
+// like "lan\nDHCP=ipv4" must not be able to inject extra directives into a
+// .network/.netdev/.link unit even if the commit-time validation layer were
+// bypassed (e.g. an old persisted value reaching the renderer ahead of the
+// load-time sanitizer).
+//
+// # The consuming grammar, and why a space is the right substitute here (#6833)
+//
+// A systemd unit file is `Key=Value` one per line. The load-bearing byte for an
+// interpolated value is therefore the NEWLINE, which ends the directive and lets
+// the remainder be read as a new one. That is the byte #1798 named and it is
+// genuinely the live one here.
+//
+// A space is safe because this belt is applied to `Description=` and ONLY to
+// `Description=`, which systemd treats as free text. That is not incidental — it
+// is what makes the substitution correct, and it is pinned by
+// TestUnitValueSanitizerIsAppliedOnlyToDescription_6833.
+//
+// It would NOT be safe on several `[Match]` keys, which are WHITESPACE-SEPARATED
+// LISTS: `OriginalName=` accepts a list of patterns, so a space inside one value
+// would make a single .link file match several kernel interfaces — the
+// substitution manufacturing the very delimiter the belt exists to prevent (the
+// #6829 shape, where the space and not the newline was the live byte). Any future
+// call site on such a key must re-derive the substitute rather than reuse this
+// function; the inventory test above is what forces that.
 func sanitizeUnitValue(s string) string {
-	clean := true
-	for i := 0; i < len(s); i++ {
-		if s[i] < 0x20 || s[i] == 0x7f {
-			clean = false
-			break
-		}
-	}
-	if clean {
-		return s
-	}
-	b := []byte(s)
-	for i := range b {
-		if b[i] < 0x20 || b[i] == 0x7f {
-			b[i] = ' '
-		}
-	}
-	return string(b)
+	return rendersafe.ReplaceControlBytes(s, ' ')
 }
 
 func (m *Manager) generateNetdev(ifc InterfaceConfig) string {

--- a/pkg/networkd/unit_value_grammar_6833_test.go
+++ b/pkg/networkd/unit_value_grammar_6833_test.go
@@ -1,0 +1,103 @@
+package networkd
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// unit_value_grammar_6833_test.go -- #6833.
+//
+// sanitizeUnitValue replaces control bytes with a SPACE. That is safe only
+// because it is applied to `Description=` and ONLY to `Description=`, which
+// systemd treats as free text. It would NOT be safe on several `[Match]` keys,
+// which are WHITESPACE-SEPARATED LISTS: `OriginalName=` takes a list of
+// patterns, so a space inside one value makes a single .link file match several
+// kernel interfaces -- the substitution manufacturing the very delimiter the
+// belt exists to prevent.
+//
+// So the risk is not today's call sites; it is a FUTURE one. These cells pin the
+// justification so it cannot be quietly invalidated.
+
+// TestUnitValueSanitizerReplacesTheNewline pins the byte the belt is actually
+// for. Its failure message says why, so a relaxation that keeps "no control
+// characters" while admitting the live byte cannot pass silently.
+func TestUnitValueSanitizerReplacesTheNewline_6833(t *testing.T) {
+	got := sanitizeUnitValue("lan\nDHCP=ipv4")
+	if strings.ContainsRune(got, '\n') {
+		t.Fatalf("a newline survived sanitizeUnitValue (%q): systemd units are "+
+			"one Key=Value per line, so the remainder is read as a NEW directive "+
+			"-- this is the #1798 injection the belt exists to stop", got)
+	}
+	if got != "lan DHCP=ipv4" {
+		t.Errorf("got %q, want %q", got, "lan DHCP=ipv4")
+	}
+}
+
+// TestUnitValueSanitizerIsAppliedOnlyToDescription_6833 is the INVENTORY guard,
+// and it is the load-bearing cell of the pair.
+//
+// The space substitution is correct only for a free-text key. Applying this
+// function to a whitespace-separated `[Match]` key would silently widen a .link
+// file to match interfaces it was never meant to -- and nothing about that change
+// would look wrong at the call site, because the function name does not say
+// "free text only".
+//
+// So this asserts the inventory: every call is to `Description=`. Adding a call
+// on any other key REDS, which forces whoever adds it to re-derive whether a
+// space is ordinary text for that key's grammar. That is the whole point -- not
+// to forbid new call sites, but to make the derivation unavoidable.
+//
+// FAIL-ON-REVERT: apply sanitizeUnitValue to any other Fprintf key and this reds.
+func TestUnitValueSanitizerIsAppliedOnlyToDescription_6833(t *testing.T) {
+	src := stripLineComments6833(readNetworkdSource6833(t, "networkd.go"))
+
+	// Every call, with the format string it is interpolated into.
+	call := regexp.MustCompile(`"([A-Za-z]+)=%s\\n", sanitizeUnitValue\(`)
+	calls := call.FindAllStringSubmatch(src, -1)
+	if len(calls) == 0 {
+		t.Fatal("found no sanitizeUnitValue call sites; the inventory guard is " +
+			"matching nothing and would pass over any change at all")
+	}
+	for _, m := range calls {
+		if m[1] != "Description" {
+			t.Errorf("sanitizeUnitValue is applied to %q=. A SPACE is only ordinary "+
+				"text for a free-text key; on a whitespace-separated [Match] key "+
+				"(OriginalName=, Path=, Driver=, Type=) the substitution splits one "+
+				"value into several and widens what the unit matches. Re-derive the "+
+				"safe substitute for %q's grammar before using this belt there "+
+				"(#6833).", m[1], m[1])
+		}
+	}
+
+	// And no bare sanitizeUnitValue call outside that shape, which would evade
+	// the check above entirely.
+	total := strings.Count(src, "sanitizeUnitValue(")
+	if total != len(calls)+1 { // +1 for the definition itself
+		t.Errorf("found %d sanitizeUnitValue( occurrences but only %d matched the "+
+			"Key=%%s call shape (+1 definition); an unrecognised call site is "+
+			"invisible to this guard", total, len(calls))
+	}
+}
+
+func readNetworkdSource6833(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}
+
+func stripLineComments6833(s string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(s, "\n") {
+		if i := strings.Index(line, "//"); i >= 0 {
+			line = line[:i]
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/pkg/rendersafe/rendersafe.go
+++ b/pkg/rendersafe/rendersafe.go
@@ -1,0 +1,65 @@
+// Package rendersafe holds render-side belts shared by the config generators
+// that interpolate operator-supplied text into a third-party daemon's
+// configuration file (#6833).
+//
+// # A function here is NOT a security boundary on its own
+//
+// Everything in this package is a PRIMITIVE: it performs a byte substitution
+// and knows nothing about the grammar it is protecting. Whether that
+// substitution is SAFE is a per-consumer fact, because the substituted byte has
+// to be ordinary text in the consuming parser. That fact belongs at the call
+// site, not here, and every caller is expected to state it.
+//
+// The failure this package exists to prevent is the one #6833 describes: two
+// packages carried byte-identical sanitizers whose doc comments justified them
+// by newline injection, while neither recorded whether the SPACE they substitute
+// in was safe for its own consumer. A sanitizer whose apparent purpose is "no
+// control characters" while the load-bearing constraint is something else invites
+// a future edit relaxing it to "printable ASCII" — an edit that looks like a
+// cleanup, still blocks the newline the comment names, and admits the byte that
+// actually matters. Duplicating the body means that edit can be made twice,
+// independently.
+//
+// So: the body lives here once, and the JUSTIFICATION lives at each call site.
+package rendersafe
+
+// ReplaceControlBytes returns s with every ASCII C0 control byte (0x00-0x1F,
+// which includes CR and LF) and DEL (0x7F) replaced by repl. All other bytes,
+// including every byte of a multi-byte UTF-8 sequence, are returned unchanged —
+// C0 and DEL cannot appear as a continuation byte, so this is safe on UTF-8
+// input and never splits a rune.
+//
+// It returns s itself when there is nothing to replace, so the common clean path
+// allocates nothing.
+//
+// # Choosing repl is the caller's decision, and it is the load-bearing one
+//
+// repl must be a byte the CONSUMING parser treats as ordinary text. A space is
+// the usual choice and is wrong wherever the consumer's grammar makes whitespace
+// significant — a whitespace-separated list key, or a
+// <selector><whitespace><action> line grammar, where substituting a space
+// manufactures the very delimiter the sanitizer was supposed to be protecting.
+// See #6829 for a case where the space, not the newline, was the live byte.
+//
+// This function cannot check that for you. State it where you call it.
+func ReplaceControlBytes(s string, repl byte) string {
+	isCtl := func(c byte) bool { return c < 0x20 || c == 0x7f }
+
+	clean := true
+	for i := 0; i < len(s); i++ {
+		if isCtl(s[i]) {
+			clean = false
+			break
+		}
+	}
+	if clean {
+		return s
+	}
+	b := []byte(s)
+	for i := range b {
+		if isCtl(b[i]) {
+			b[i] = repl
+		}
+	}
+	return string(b)
+}

--- a/pkg/rendersafe/rendersafe_test.go
+++ b/pkg/rendersafe/rendersafe_test.go
@@ -1,0 +1,69 @@
+package rendersafe
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestReplaceControlBytesReplacesTheWholeC0SetAndDEL is the primitive's own
+// contract. It is exhaustive over the byte range rather than sampling, because
+// the failure this guards is a future edit NARROWING the class -- "surely 0x0B
+// is harmless" -- and a sampled test is exactly what such an edit slips past.
+func TestReplaceControlBytesReplacesTheWholeC0SetAndDEL(t *testing.T) {
+	for b := 0; b < 0x100; b++ {
+		in := string([]byte{'a', byte(b), 'z'})
+		got := ReplaceControlBytes(in, '_')
+		ctl := b < 0x20 || b == 0x7f
+		want := in
+		if ctl {
+			want = "a_z"
+		}
+		if got != want {
+			t.Fatalf("byte %#02x: got %q, want %q (control=%v)", b, got, want, ctl)
+		}
+	}
+}
+
+// TestReplaceControlBytesLeavesCleanInputUnaltered pins the fast path's
+// OBSERVABLE half. A version that always rebuilt the string would still be
+// correct, so this asserts equality of contents rather than identity of the
+// backing array -- the property a caller can actually depend on.
+func TestReplaceControlBytesLeavesCleanInputUnaltered(t *testing.T) {
+	for _, s := range []string{"", "plain", "with spaces", "non-ascii: \u00fc\u00f1", "tabs?no"} {
+		if got := ReplaceControlBytes(s, '_'); got != s {
+			t.Errorf("clean input %q was altered to %q", s, got)
+		}
+	}
+}
+
+// TestReplaceControlBytesNeverSplitsARune asserts the UTF-8 safety claim the doc
+// comment makes, rather than leaving it as prose.
+//
+// It holds because C0 and DEL can never appear as a UTF-8 continuation byte, so
+// a byte-wise scan cannot land inside a multi-byte rune. If someone widened the
+// class to "any byte >= 0x7F", this reds -- and that widening is precisely the
+// plausible-looking edit the package doc warns about.
+func TestReplaceControlBytesNeverSplitsARune(t *testing.T) {
+	in := "a\u00e9\u65e5b\u00e7"
+	got := ReplaceControlBytes(in, ' ')
+	for _, r := range []rune{'\u00e9', '\u65e5', '\u00e7'} {
+		if !strings.ContainsRune(got, r) {
+			t.Fatalf("multi-byte rune %q did not survive: %q -> %q", r, in, got)
+		}
+	}
+}
+
+// TestReplaceControlBytesHonoursTheCallersSubstitute pins that the substitute is
+// the CALLER's choice.
+//
+// The whole point of #6833 is that the safe substitute is a per-consumer fact. A
+// primitive that hardcoded a space would pull that decision back inside, which is
+// the shape this package exists to undo.
+func TestReplaceControlBytesHonoursTheCallersSubstitute(t *testing.T) {
+	if got := ReplaceControlBytes("a\nb", '\t'); got != "a\tb" {
+		t.Errorf("got %q, want a<tab>b", got)
+	}
+	if got := ReplaceControlBytes("a\nb", '?'); got != "a?b" {
+		t.Errorf("got %q, want %q", got, "a?b")
+	}
+}


### PR DESCRIPTION
Closes #6833.

`pkg/ipsec` and `pkg/networkd` carried a **byte-identical** control-byte belt
whose doc comments both justified themselves by newline injection, while neither
recorded whether the **space they substitute in** was safe for its own consumer.

## I diverged from the issue's fix direction, and this is why

The issue asks for two things that pull apart:

1. *"One shared helper, in one place."*
2. *"At each call site, a comment naming the consuming grammar and the specific
   byte class that is load-bearing for it — not a generic 'strips control
   characters'."*

**A single shared function cannot carry two justifications.** Its doc would have
to name two grammars, which is precisely the vagueness the issue says invites the
dangerous relaxation. Resolved as:

- **one grammar-agnostic primitive** — `rendersafe.ReplaceControlBytes(s, repl)`,
  documented as **not a security boundary on its own**. The body exists once, so
  the dangerous edit can only be made once.
- **two thin per-consumer wrappers**, each naming its grammar and its
  load-bearing byte. That is what (2) actually asks for.

**The substitute is now the caller's parameter**, not hardcoded — the mechanical
expression of "the safe substitute is a per-consumer fact". A primitive that
hardcoded a space would pull the decision back inside, which is the shape being
undone.

## Checked, not assumed: a space is safe at every CURRENT call site

| consumer | interpolated into | why a space is ordinary text |
|---|---|---|
| networkd | `Description=` **and only** `Description=` | systemd treats it as free text |
| swanctl (unquoted) | `local_addrs`, `remote_addrs`, `proposals`, `esp_proposals`, `local_ts`, `remote_ts`, section names | swanctl's list keys are **comma**-separated, so a space yields one malformed value, not two entries |
| swanctl (quoted) | `certs`, `id`, `secret` | additionally pass through `escapeSwanctlQuoted` — independent protection |

So **both belts are correct as written**, and the newline the comments name really
is the live byte for both. Worth stating plainly, because the issue's framing
suggests the space might already be live somewhere: **the `OriginalName=` hazard
is real but is NOT reachable through `sanitizeUnitValue`**, because the belt is
not applied there.

## Which makes the real risk a FUTURE call site — so that is what is guarded

Each package gains an **inventory cell** asserting which keys the belt feeds:

- `TestUnitValueSanitizerIsAppliedOnlyToDescription_6833`
- `TestSwanctlSanitizerCallSitesAreUnquotedOrEscaped_6833`

Adding `sanitizeUnitValue` to a whitespace-separated `[Match]` key, or
`sanitizeSwanctlValue` to an unrecorded swanctl key, **reds** — with a message
saying what to re-derive rather than just "don't".

**Verified by probe rather than asserted.** Added `OriginalName=%s` and
`some_new_key = %s` call sites; both cells fired on exactly that shape and passed
again once reverted:

```
sanitizeUnitValue is applied to "OriginalName"=. A SPACE is only ordinary text
for a free-text key; on a whitespace-separated [Match] key ... the substitution
splits one value into several and widens what the unit matches.
```

The point is **not to forbid new call sites** — it is to make the derivation
unavoidable. That is the difference between a guard and a lock.

Each cell also asserts its own regex matched something, so "no bad call sites"
cannot mean "the pattern matched nothing", and the networkd cell cross-checks the
total `sanitizeUnitValue(` occurrence count against the call sites it recognised,
so an unrecognised call shape is visible rather than silently unguarded.

## The primitive's tests

**Exhaustive over `0x00`–`0xFF`, not sampled.** The failure being guarded is a
future edit **narrowing** the class — "surely `0x0B` is harmless" — and a sampled
test is exactly what such an edit slips past. Plus a cell asserting the UTF-8
claim the doc makes (C0/DEL cannot be a continuation byte, so a byte-wise scan
never splits a rune), which reds if someone widened the class to "any byte
>= 0x7F".

## Validation

- **No behaviour change**: both packages' existing suites pass unmodified, which
  is the claim a pure refactor owes.
- `go build ./...` **rc=0**, `go vet ./...` **rc=0**, `go test -count=1 ./...`
  repo-wide **rc=0** at HEAD `7025c9fac8383635b48c680e25cd3b081f31566e`
  (contains current `origin/master`).
- Rust touched: **0**. No smoke owed — render-side string handling with no
  behaviour delta.

## Explicitly out of scope, as the issue scopes it

The other sanitizers (`sanitizeFRRIdent` / `sanitizeFRRValue`, `sanitizeNftIdent`,
`sanitizeTLVString`, `sanitizeFQDN` / `sanitizeDomain` / `sanitizeLabel`,
`sanitizeEnvelopeToken`) were **not** assessed, and no claim is made about whether
each is applied at every interpolation site in its package. `rendersafe` is now
the place to consolidate them if that sweep is done later — but consolidating
without first deriving each consumer's grammar would reproduce the exact defect
this fixes.
