### PR TITLE
config/api: make a leniently-admitted malformed NAT rule visible (#7640)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,56 @@
+## 2026-08-26 — #7640: a leniently-admitted malformed NAT rule is now visible
+
+- **Timestamp**: 2026-08-26
+- **Action**: The strict terminal-action cardinality gate (#5628) rejects a NAT
+  rule whose `then` carries other than exactly one action; the tolerant path
+  downgrades that to `cfg.Warnings` (#1960 no-brick). Traced where that warning
+  can actually go: the commit RESPONSE (`pkg/api/config.go`,
+  `pkg/grpcapi/server_config.go`) and an apply-time log line
+  (`pkg/daemon/daemon_apply.go`). A tolerant LOAD — boot, peer-sync, rollback —
+  has no commit response, and those are exactly the paths on which such a rule
+  survives. The node then ran indefinitely carrying a rule a commit would refuse
+  with one startup log line as the only trace.
+  Added `Config.LenientNATTerminalActionRules`, populated ONLY on the lenient
+  branch (so a non-empty slice means precisely "admitted leniently"), plus the
+  `xpf_nat_rules_lenient_terminal_action` gauge and a per-rule annotation in
+  `show security nat {source,destination} rule detail`. Both consumers read the
+  FIELD rather than re-deriving, so a count, an annotation and the warning can
+  never disagree about which rules are affected. Rebuilt per compile by
+  construction (each CompileConfig makes a fresh *Config), so fixing the config
+  clears it with no separate clear path.
+  The enumerator is separate from the gate on purpose — the gate reports the
+  FIRST offender and stops, which is right for a commit error, while the record
+  needs all of them — so they share `natThenTerminalActionCount` and a test
+  binds the agreement over 7 arity shapes rather than trusting it.
+  Found a display defect next to the annotation site and fixed it: the source
+  action string defaulted to `"interface"` whenever neither a pool nor `off` was
+  set, so an ACTIONLESS rule rendered `Action: interface` — an action it does
+  not carry, on exactly the rule shape an operator is trying to find. DNAT
+  defaulted to `"off"` with the same problem. Both now render `none`.
+  DECISION-NEUTRAL by design: this forecloses none of #6823's options A/B/C and
+  is what converts its crux question — how many real configs reach this state —
+  from an estimate into a measurement.
+- **File(s)**: `pkg/config/types.go`,
+  `pkg/config/compiler_validate_strict_nat.go`,
+  `pkg/config/compiler_uniformgates_firewall_nat2.go`,
+  `pkg/config/nat_lenient_terminal_visibility_7640_test.go` (new),
+  `pkg/config/testdata/golden_4406.json`, `pkg/natshow/natshow.go`,
+  `pkg/natshow/source.go`, `pkg/natshow/dest.go`,
+  `pkg/natshow/nat_lenient_terminal_annotation_7640_test.go` (new),
+  `pkg/api/metrics.go`, `pkg/api/server.go`,
+  `pkg/api/metrics_descriptors_controlplane.go`,
+  `pkg/api/metrics_nat_lenient_terminal_7640_test.go` (new),
+  `pkg/daemon/daemon_run_servers.go`, `_Log.md`
+- **Golden**: `golden_4406.json` regenerated only AFTER classifying the diff —
+  18 keys added, all `LenientNATTerminalActionRules`, all empty; 0 removed; 0
+  values changed. Benign by the add-only/no-value-change rule, so no behaviour
+  change is being laundered through the regen.
+- **Validation**: gauge bound on a pedantic registry across healthy/one/several
+  plus the unwired-is-absent cell; annotation bound with a paired
+  healthy-not-annotated control and a scoped-to-the-named-rule cell (a
+  tolerantly-loaded config carries good rules too, and annotating those is the
+  same noise as annotating everything).
+
 ## 2026-08-26 — #6810: a queue-full drop no longer consumes a threshold crossing
 
 - **Timestamp**: 2026-08-26

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -208,6 +208,11 @@ type xpfCollector struct {
 	// #1780: per-phase age of the Go periodic neighbor-maintenance loop.
 	neighborPeriodicAge *prometheus.Desc
 	frrReloadDegraded   *prometheus.Desc
+	// #7640: gauge — NAT rules the tolerant path admitted despite the strict
+	// terminal-action cardinality gate. Non-zero means the node is running a
+	// rule a commit would have refused, on a path with no commit response to
+	// report it.
+	natRulesLenientTerminalAction *prometheus.Desc
 	// #6807: gauge — how many route-maps the last rendered FRR managed
 	// section replaced with the bounded explicit deny because their
 	// expansion would overflow FRR's sequence ceiling. Non-zero is an
@@ -779,6 +784,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.neighborPeriodicAge
 	ch <- c.frrReloadDegraded
 	ch <- c.frrRouteMapsQuarantined
+	ch <- c.natRulesLenientTerminalAction
 	ch <- c.ipsecRebindPending
 	ch <- c.schedulerRepublishFailed
 	ch <- c.schedulerRepublishStale
@@ -1087,6 +1093,17 @@ func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 		ch <- prometheus.MustNewConstMetric(c.frrReloadDegraded,
 			prometheus.GaugeValue, v)
+	}
+
+	// #7640: NAT rules admitted by the tolerant path despite the strict
+	// terminal-action gate. Reported UNCONDITIONALLY when the hook is wired —
+	// an explicit 0 on a healthy node, so an alert on `> 0` can distinguish
+	// "none admitted" from "the exporter stopped reporting this series". ABSENT
+	// when unwired: a hardcoded 0 from a process that never consulted the
+	// active config is a false all-clear.
+	if c.srv.natLenientTerminalActionRulesFn != nil {
+		ch <- prometheus.MustNewConstMetric(c.natRulesLenientTerminalAction,
+			prometheus.GaugeValue, float64(len(c.srv.natLenientTerminalActionRulesFn())))
 	}
 
 	// #6807: quarantined route-maps. Reported UNCONDITIONALLY when the hook

--- a/pkg/api/metrics_descriptors_controlplane.go
+++ b/pkg/api/metrics_descriptors_controlplane.go
@@ -30,6 +30,23 @@ func (c *xpfCollector) initControlPlaneDescriptors() {
 			"or detached. Alert on > 0.",
 		nil, nil,
 	)
+	c.natRulesLenientTerminalAction = prometheus.NewDesc(
+		"xpf_nat_rules_lenient_terminal_action",
+		"Number of NAT rules in the ACTIVE config that the tolerant load / "+
+			"peer-sync / rollback path admitted despite the strict "+
+			"terminal-action cardinality gate rejecting them (#5628/#7640). "+
+			"Non-zero means this node is running a rule a commit would refuse: "+
+			"an ACTIONLESS rule installs no translation and (source NAT) does "+
+			"not stop rule evaluation, so matching traffic falls through to any "+
+			"later broader rule; a CONTRADICTORY rule has all but one action "+
+			"discarded by a fixed precedence the operator did not write. The "+
+			"warning that reports this at compile time reaches an operator only "+
+			"through a commit response, which a tolerant LOAD does not have — "+
+			"so before this gauge the surviving rules were invisible for the "+
+			"life of the node. Alert on > 0; `show security nat source rule "+
+			"detail` names them.",
+		nil, nil,
+	)
 	c.ipsecRebindPending = prometheus.NewDesc(
 		"xpf_ipsec_rebind_pending",
 		"1 while the last DHCP-lease-change IPsec rebind failed and has "+

--- a/pkg/api/metrics_nat_lenient_terminal_7640_test.go
+++ b/pkg/api/metrics_nat_lenient_terminal_7640_test.go
@@ -1,0 +1,74 @@
+package api
+
+import "testing"
+
+// metrics_nat_lenient_terminal_7640_test.go — #7640.
+//
+// A NAT rule admitted by the tolerant load / peer-sync / rollback path despite
+// the strict terminal-action gate had no live signal at all. The compile-time
+// warning reaches an operator through the commit RESPONSE and an apply-time log
+// line — and a tolerant LOAD has neither, which is precisely the path on which
+// such a rule survives. The node then runs indefinitely carrying a rule a
+// commit would refuse.
+//
+// This binds the WIRING: the record can be correct on the config and the
+// operator still sees nothing if the accessor never reaches a Desc.
+
+// TestNATLenientTerminalActionGauge7640 is PAIRED across three points.
+//
+// The healthy leg is load-bearing: the gauge must publish an explicit 0, not go
+// absent, on a clean node. An alert written `xpf_nat_rules_lenient_terminal_action > 0`
+// cannot distinguish "none admitted" from "this series stopped being reported",
+// so a gauge that vanishes when healthy is the same blindness the metric exists
+// to remove.
+//
+// The two-rule leg rejects a gauge hardwired to 1, which would look right
+// against a single-rule fixture and under-report every real config — one
+// tolerantly-loaded config commonly carries several such rules, since whatever
+// produced one (a pre-gate release, an older peer) produced them all.
+func TestNATLenientTerminalActionGauge7640(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		rules []string
+		want  float64
+	}{
+		{"healthy", nil, 0},
+		{"one-rule", []string{"source rule-set rs1 rule r (0 actions)"}, 1},
+		{"several-rules", []string{
+			"source rule-set rs1 rule r (0 actions)",
+			"destination rule-set drs rule d (2 actions)",
+		}, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{ // dp intentionally nil — config-only boot must still report
+				natLenientTerminalActionRulesFn: func() []string { return tc.rules },
+			}
+			got, ok := gatherSingleSample6802(t, s, "xpf_nat_rules_lenient_terminal_action")
+			if !ok {
+				t.Fatal("xpf_nat_rules_lenient_terminal_action was not emitted — a " +
+					"node running a NAT rule a commit would refuse looks identical " +
+					"to a clean one (#7640)")
+			}
+			if got != tc.want {
+				t.Errorf("gauge = %v, want %v — it does not track the wired fn, so "+
+					"it reports the same value whether or not the node is running "+
+					"rules the strict gate rejects", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNATLenientTerminalActionGaugeAbsentWhenUnwired7640 pins the other half of
+// the optional-hook contract. With no hook wired the series must not be
+// published at all rather than published as a constant 0: a hardcoded 0 from a
+// process that never consulted the active config asserts "no rule was admitted"
+// on something that has no idea, and an operator alerting on this series would
+// read that as an all-clear.
+func TestNATLenientTerminalActionGaugeAbsentWhenUnwired7640(t *testing.T) {
+	s := &Server{} // natLenientTerminalActionRulesFn deliberately nil
+	if _, ok := gatherSingleSample6802(t, s, "xpf_nat_rules_lenient_terminal_action"); ok {
+		t.Fatal("xpf_nat_rules_lenient_terminal_action was published with no hook " +
+			"wired — that reports a confident 'nothing admitted' from a process " +
+			"that never read the active config")
+	}
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -233,6 +233,13 @@ type Config struct {
 	// LENGTH feeds the xpf_frr_route_maps_quarantined gauge. Optional; if nil
 	// the gauge is not published.
 	FRRQuarantinedRouteMapsFn func() []string
+
+	// NATLenientTerminalActionRulesFn returns the identities of NAT rules in
+	// the ACTIVE config that the tolerant path admitted despite the strict
+	// terminal-action cardinality gate (#7640). Its LENGTH feeds the
+	// xpf_nat_rules_lenient_terminal_action gauge. Optional; if nil the gauge
+	// is not published.
+	NATLenientTerminalActionRulesFn func() []string
 	// IPsecRebindPendingFn reports whether the last DHCP-lease-change IPsec
 	// rebind failed and has not yet reconverged — swanctl local_addrs are
 	// bound to a stale lease address while set, so the tunnel cannot
@@ -422,6 +429,7 @@ type Server struct {
 	neighborPhaseAgeFn                   func() map[string]float64
 	frrReloadDegradedFn                  func() bool
 	frrQuarantinedRouteMapsFn            func() []string
+	natLenientTerminalActionRulesFn      func() []string
 	ipsecRebindPendingFn                 func() bool
 	hostInboundConntrackRevocationOwedFn func() bool
 	hostInboundConntrackFlushFailuresFn  func() uint64
@@ -526,6 +534,7 @@ func NewServer(cfg Config) *Server {
 		neighborPhaseAgeFn:                   cfg.NeighborPhaseAgeFn,
 		frrReloadDegradedFn:                  cfg.FRRReloadDegradedFn,
 		frrQuarantinedRouteMapsFn:            cfg.FRRQuarantinedRouteMapsFn,
+		natLenientTerminalActionRulesFn:      cfg.NATLenientTerminalActionRulesFn,
 		ipsecRebindPendingFn:                 cfg.IPsecRebindPendingFn,
 		hostInboundConntrackRevocationOwedFn: cfg.HostInboundConntrackRevocationOwedFn,
 		hostInboundConntrackFlushFailuresFn:  cfg.HostInboundConntrackFlushFailuresFn,

--- a/pkg/config/compiler_uniformgates_firewall_nat2.go
+++ b/pkg/config/compiler_uniformgates_firewall_nat2.go
@@ -270,6 +270,14 @@ func runUniformGatesFirewallNAT2(tree *ConfigTree, cfg *Config, opts compileOpts
 		if opts.lenientNATTerminalAction {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("NAT terminal-action cardinality (downgraded to warning on tolerant path): %v", err))
+			// #7640: record EVERY offender, not just the one the warning names.
+			// The warning goes to the commit response and an apply-time log
+			// line; a tolerant LOAD (boot, peer-sync, rollback) has neither a
+			// commit response nor anything that survives the log, so without
+			// this the surviving rules are invisible for the life of the node.
+			// Set only here, so a non-empty slice means precisely "admitted
+			// leniently" — the strict branch below returns instead.
+			cfg.LenientNATTerminalActionRules = natTerminalActionCardinalityOffenders(cfg)
 		} else {
 			return err
 		}

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -2958,6 +2958,55 @@ func validateStaticNATSingleTargetStrict(cfg *Config) error {
 // — never reaches two fields, because the packed branch of compileNATSource /
 // compileNATDestination reads `t.Keys[1]` alone and drops the rest. Those
 // spellings resolve to one field, count one, and commit. Tracked as #7033.
+// natTerminalActionCardinalityOffenders enumerates EVERY NAT rule the strict
+// cardinality gate objects to, in the same sorted-rule-set order
+// validateNATTerminalActionCardinalityStrict walks (#7640).
+//
+// It exists alongside that validator rather than inside it because the two
+// answer different questions. The validator reports the FIRST offender and
+// stops — deliberately, so a commit gets one deterministic, actionable error
+// rather than a wall. A gauge and an operator annotation need ALL of them.
+//
+// Both read the SAME per-rule predicate, natThenTerminalActionCount, which is
+// what keeps them from disagreeing about what "offending" means: a change to
+// the cardinality rule moves both, and TestLenientNATOffendersMatchTheGate_7640
+// binds that agreement rather than trusting it.
+func natTerminalActionCardinalityOffenders(cfg *Config) []LenientNATTerminalActionRule {
+	if cfg == nil {
+		return nil
+	}
+	var out []LenientNATTerminalActionRule
+	collect := func(kind string, rulesets []*NATRuleSet) {
+		sorted := append([]*NATRuleSet(nil), rulesets...)
+		sort.SliceStable(sorted, func(i, j int) bool {
+			if sorted[i] == nil || sorted[j] == nil {
+				return sorted[i] != nil
+			}
+			return sorted[i].Name < sorted[j].Name
+		})
+		for _, rs := range sorted {
+			if rs == nil {
+				continue
+			}
+			for _, rule := range rs.Rules {
+				if rule == nil {
+					continue
+				}
+				if n := natThenTerminalActionCount(rule.Then); n != 1 {
+					out = append(out, LenientNATTerminalActionRule{
+						Kind: kind, RuleSet: rs.Name, Rule: rule.Name, Actions: n,
+					})
+				}
+			}
+		}
+	}
+	collect("source", cfg.Security.NAT.Source)
+	if cfg.Security.NAT.Destination != nil {
+		collect("destination", cfg.Security.NAT.Destination.RuleSets)
+	}
+	return out
+}
+
 func natThenTerminalActionCount(then NATThen) int {
 	n := 0
 	if then.Interface {

--- a/pkg/config/nat_lenient_terminal_visibility_7640_test.go
+++ b/pkg/config/nat_lenient_terminal_visibility_7640_test.go
@@ -1,0 +1,180 @@
+package config
+
+// nat_lenient_terminal_visibility_7640_test.go — #7640.
+//
+// The strict terminal-action cardinality gate (#5628) rejects a NAT rule whose
+// `then` carries anything other than exactly one translation action. The
+// tolerant load / peer-sync / rollback path downgrades that to a cfg.Warnings
+// entry (#1960 no-brick) — correctly, since the alternative is a brick.
+//
+// But cfg.Warnings reaches an operator only through the commit RESPONSE
+// (pkg/api, pkg/grpcapi) and an apply-time log line (pkg/daemon), and a
+// tolerant LOAD has no commit response. Boot, peer-sync and rollback are
+// exactly the paths on which such a rule survives, so the node then runs
+// indefinitely carrying a rule a commit would refuse, with no live signal.
+//
+// These cells bind the record the gauge and the operator annotation read.
+
+import (
+	"strings"
+	"testing"
+)
+
+// actionlessSourceRuleSet builds a rule-set whose rule carries NO terminal
+// action — the shape a pre-#5628 config can still carry through a tolerant
+// load.
+func actionlessSourceRuleSet7640(rsName, ruleName string) *NATRuleSet {
+	return &NATRuleSet{
+		Name:  rsName,
+		Rules: []*NATRule{{Name: ruleName}}, // Then zero-valued: no action at all
+	}
+}
+
+// TestLenientPathRecordsTheAdmittedRule7640 is the core: a rule the strict gate
+// rejects, admitted by the tolerant path, must leave a durable record on the
+// compiled config — not only a warning string.
+//
+// FAIL-ON-REVERT: drop the LenientNATTerminalActionRules assignment in
+// compiler_uniformgates_firewall_nat2.go and the record is empty while the
+// warning still fires, which is precisely the pre-#7640 invisibility.
+func TestLenientPathRecordsTheAdmittedRule7640(t *testing.T) {
+	cfg := &Config{}
+	cfg.Security.NAT.Source = []*NATRuleSet{actionlessSourceRuleSet7640("rs1", "actionless")}
+
+	opts := compileOpts{lenientNATTerminalAction: true}
+	if err := runUniformGatesFirewallNAT2(nil, cfg, opts); err != nil {
+		t.Fatalf("the tolerant path must not reject: %v", err)
+	}
+
+	// Precondition: the warning fired, so this cell is about the RECORD being
+	// missing rather than about the gate not firing at all.
+	var warned bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "NAT terminal-action cardinality") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("the tolerant path did not warn, so the fixture never reached "+
+			"the downgrade this cell is about: %v", cfg.Warnings)
+	}
+
+	if len(cfg.LenientNATTerminalActionRules) != 1 {
+		t.Fatalf("LenientNATTerminalActionRules = %v, want exactly the one "+
+			"admitted rule — without the record the surviving rule is invisible "+
+			"to the gauge and to `show ... rule detail`, and a tolerant load has "+
+			"no commit response to carry the warning (#7640)",
+			cfg.LenientNATTerminalActionRules)
+	}
+	got := cfg.LenientNATTerminalActionRules[0]
+	if got.Kind != "source" || got.RuleSet != "rs1" || got.Rule != "actionless" || got.Actions != 0 {
+		t.Fatalf("recorded rule = %+v, want {source rs1 actionless 0} — the "+
+			"identity must be enough to find the stanza", got)
+	}
+	if s := got.String(); !strings.Contains(s, "rs1") || !strings.Contains(s, "actionless") {
+		t.Fatalf("String() = %q, must name the rule-set and rule", s)
+	}
+}
+
+// TestStrictPathRecordsNothing7640 is the PAIRED control. The record means
+// "admitted leniently"; on the strict path the config is REJECTED, so a
+// recorded rule there would make the gauge report a violation on a node that
+// refused to run one.
+func TestStrictPathRecordsNothing7640(t *testing.T) {
+	cfg := &Config{}
+	cfg.Security.NAT.Source = []*NATRuleSet{actionlessSourceRuleSet7640("rs1", "actionless")}
+
+	if err := runUniformGatesFirewallNAT2(nil, cfg, compileOpts{}); err == nil {
+		t.Fatal("the strict path must REJECT an actionless rule (#5628)")
+	}
+	if len(cfg.LenientNATTerminalActionRules) != 0 {
+		t.Fatalf("the strict path recorded %v — the record must mean "+
+			"'admitted leniently', and a rejected config admitted nothing",
+			cfg.LenientNATTerminalActionRules)
+	}
+}
+
+// TestHealthyConfigRecordsNothing7640 is the other half of the pairing: a
+// well-formed rule must leave the record empty, or the gauge reports a
+// violation on every node and the alert is worthless.
+func TestHealthyConfigRecordsNothing7640(t *testing.T) {
+	cfg := &Config{}
+	cfg.Security.NAT.Source = []*NATRuleSet{{
+		Name:  "rs1",
+		Rules: []*NATRule{{Name: "ok", Then: NATThen{Interface: true}}},
+	}}
+	if err := runUniformGatesFirewallNAT2(nil, cfg, compileOpts{lenientNATTerminalAction: true}); err != nil {
+		t.Fatalf("a well-formed rule must compile: %v", err)
+	}
+	if len(cfg.LenientNATTerminalActionRules) != 0 {
+		t.Fatalf("a healthy config recorded %v", cfg.LenientNATTerminalActionRules)
+	}
+}
+
+// TestLenientNATOffendersMatchTheGate_7640 binds the AGREEMENT between the
+// enumerator and the gate, which is the property that actually matters.
+//
+// They are separate functions on purpose — the gate reports the FIRST offender
+// and stops (one deterministic, actionable commit error), while the record needs
+// ALL of them. Separate walks are exactly how a count and a rejection drift
+// apart, so this asserts they cannot: for every shape, the gate rejects iff the
+// enumerator finds something.
+//
+// FAIL-ON-REVERT: change either side's predicate (e.g. make the enumerator
+// count `n == 0` only) and a row here reds.
+func TestLenientNATOffendersMatchTheGate_7640(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		then     NATThen
+		offender bool
+	}{
+		{"actionless", NATThen{}, true},
+		{"interface-only", NATThen{Interface: true}, false},
+		{"off-only", NATThen{Off: true}, false},
+		{"pool-only", NATThen{PoolName: "p"}, false},
+		{"interface+pool", NATThen{Interface: true, PoolName: "p"}, true},
+		{"off+interface", NATThen{Off: true, Interface: true}, true},
+		{"all-three", NATThen{Off: true, Interface: true, PoolName: "p"}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{}
+			cfg.Security.NAT.Source = []*NATRuleSet{{
+				Name:  "rs1",
+				Rules: []*NATRule{{Name: "r", Then: tc.then}},
+			}}
+			gateRejects := validateNATTerminalActionCardinalityStrict(cfg) != nil
+			found := len(natTerminalActionCardinalityOffenders(cfg)) > 0
+			if gateRejects != tc.offender {
+				t.Fatalf("gate rejects = %v, want %v", gateRejects, tc.offender)
+			}
+			if found != gateRejects {
+				t.Fatalf("the enumerator and the gate DISAGREE (enumerator found=%v, "+
+					"gate rejects=%v). They must share one predicate, or the gauge "+
+					"counts rules a commit would accept, or misses ones it would "+
+					"refuse", found, gateRejects)
+			}
+		})
+	}
+}
+
+// TestOffendersCoverBothKinds7640 pins that destination NAT is walked too. The
+// gate checks both kinds; an enumerator that walked only source would report a
+// healthy node for a config whose destination rules a commit would refuse.
+func TestOffendersCoverBothKinds7640(t *testing.T) {
+	cfg := &Config{}
+	cfg.Security.NAT.Source = []*NATRuleSet{actionlessSourceRuleSet7640("srs", "s-actionless")}
+	cfg.Security.NAT.Destination = &DestinationNATConfig{
+		RuleSets: []*NATRuleSet{actionlessSourceRuleSet7640("drs", "d-actionless")},
+	}
+	got := natTerminalActionCardinalityOffenders(cfg)
+	if len(got) != 2 {
+		t.Fatalf("offenders = %v, want one source and one destination", got)
+	}
+	kinds := map[string]bool{}
+	for _, r := range got {
+		kinds[r.Kind] = true
+	}
+	if !kinds["source"] || !kinds["destination"] {
+		t.Fatalf("offenders cover only %v; the gate checks BOTH kinds", kinds)
+	}
+}

--- a/pkg/config/testdata/golden_4406.json
+++ b/pkg/config/testdata/golden_4406.json
@@ -1260,7 +1260,8 @@
         "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "apply-groups \"${node}\" resolved using default node0 context during generic compile"
-      ]
+      ],
+      "LenientNATTerminalActionRules": null
     },
     "error": ""
   },
@@ -2524,7 +2525,8 @@
         "zone \"lan\" host-inbound-traffic: system-services dhcp is configured at the ZONE level, which Junos does not allow — DHCP and BOOTP are the host-inbound services Junos accepts only per interface, because the server must know the incoming interface to send replies. Here the zone-level token authorizes DHCP/BOOTP on reth1 (DHCP server), which Junos would require you to admit interface by interface. Move the token to `interfaces \u003cif\u003e host-inbound-traffic system-services ...` on the interfaces that need it — and note a per-interface stanza REPLACES the zone stanza (#6515), so restate the zone's other tokens there or they stop being admitted on that interface. (#6519 parity deviation; xpf still enforces the zone-level authorization today.)",
         "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model."
-      ]
+      ],
+      "LenientNATTerminalActionRules": null
     },
     "error": ""
   },
@@ -3788,7 +3790,8 @@
         "zone \"lan\" host-inbound-traffic: system-services dhcp is configured at the ZONE level, which Junos does not allow — DHCP and BOOTP are the host-inbound services Junos accepts only per interface, because the server must know the incoming interface to send replies. Here the zone-level token authorizes DHCP/BOOTP on reth1 (DHCP server), which Junos would require you to admit interface by interface. Move the token to `interfaces \u003cif\u003e host-inbound-traffic system-services ...` on the interfaces that need it — and note a per-interface stanza REPLACES the zone stanza (#6515), so restate the zone's other tokens there or they stop being admitted on that interface. (#6519 parity deviation; xpf still enforces the zone-level authorization today.)",
         "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model."
-      ]
+      ],
+      "LenientNATTerminalActionRules": null
     },
     "error": ""
   },
@@ -5053,7 +5056,8 @@
         "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "apply-groups \"${node}\" resolved using default node0 context during generic compile"
-      ]
+      ],
+      "LenientNATTerminalActionRules": null
     },
     "error": ""
   },
@@ -6317,7 +6321,8 @@
         "zone \"lan\" host-inbound-traffic: system-services dhcp is configured at the ZONE level, which Junos does not allow — DHCP and BOOTP are the host-inbound services Junos accepts only per interface, because the server must know the incoming interface to send replies. Here the zone-level token authorizes DHCP/BOOTP on reth1 (DHCP server), which Junos would require you to admit interface by interface. Move the token to `interfaces \u003cif\u003e host-inbound-traffic system-services ...` on the interfaces that need it — and note a per-interface stanza REPLACES the zone stanza (#6515), so restate the zone's other tokens there or they stop being admitted on that interface. (#6519 parity deviation; xpf still enforces the zone-level authorization today.)",
         "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model."
-      ]
+      ],
+      "LenientNATTerminalActionRules": null
     },
     "error": ""
   },
@@ -7581,7 +7586,8 @@
         "zone \"lan\" host-inbound-traffic: system-services dhcp is configured at the ZONE level, which Junos does not allow — DHCP and BOOTP are the host-inbound services Junos accepts only per interface, because the server must know the incoming interface to send replies. Here the zone-level token authorizes DHCP/BOOTP on reth1 (DHCP server), which Junos would require you to admit interface by interface. Move the token to `interfaces \u003cif\u003e host-inbound-traffic system-services ...` on the interfaces that need it — and note a per-interface stanza REPLACES the zone stanza (#6515), so restate the zone's other tokens there or they stop being admitted on that interface. (#6519 parity deviation; xpf still enforces the zone-level authorization today.)",
         "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model."
-      ]
+      ],
+      "LenientNATTerminalActionRules": null
     },
     "error": ""
   },
@@ -8556,7 +8562,8 @@
         "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "apply-groups \"${node}\" resolved using default node0 context during generic compile"
-      ]
+      ],
+      "LenientNATTerminalActionRules": null
     },
     "error": ""
   },
@@ -9530,7 +9537,8 @@
         "zone \"lan\" host-inbound-traffic: system-services dhcp is configured at the ZONE level, which Junos does not allow — DHCP and BOOTP are the host-inbound services Junos accepts only per interface, because the server must know the incoming interface to send replies. Here the zone-level token authorizes DHCP/BOOTP on reth1 (DHCP server), which Junos would require you to admit interface by interface. Move the token to `interfaces \u003cif\u003e host-inbound-traffic system-services ...` on the interfaces that need it — and note a per-interface stanza REPLACES the zone stanza (#6515), so restate the zone's other tokens there or they stop being admitted on that interface. (#6519 parity deviation; xpf still enforces the zone-level authorization today.)",
         "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model."
-      ]
+      ],
+      "LenientNATTerminalActionRules": null
     },
     "error": ""
   },
@@ -10504,7 +10512,8 @@
         "zone \"lan\" host-inbound-traffic: system-services dhcp is configured at the ZONE level, which Junos does not allow — DHCP and BOOTP are the host-inbound services Junos accepts only per interface, because the server must know the incoming interface to send replies. Here the zone-level token authorizes DHCP/BOOTP on reth1 (DHCP server), which Junos would require you to admit interface by interface. Move the token to `interfaces \u003cif\u003e host-inbound-traffic system-services ...` on the interfaces that need it — and note a per-interface stanza REPLACES the zone stanza (#6515), so restate the zone's other tokens there or they stop being admitted on that interface. (#6519 parity deviation; xpf still enforces the zone-level authorization today.)",
         "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model."
-      ]
+      ],
+      "LenientNATTerminalActionRules": null
     },
     "error": ""
   },
@@ -11479,7 +11488,8 @@
         "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "apply-groups \"${node}\" resolved using default node0 context during generic compile"
-      ]
+      ],
+      "LenientNATTerminalActionRules": null
     },
     "error": ""
   },
@@ -12453,7 +12463,8 @@
         "zone \"lan\" host-inbound-traffic: system-services dhcp is configured at the ZONE level, which Junos does not allow — DHCP and BOOTP are the host-inbound services Junos accepts only per interface, because the server must know the incoming interface to send replies. Here the zone-level token authorizes DHCP/BOOTP on reth1 (DHCP server), which Junos would require you to admit interface by interface. Move the token to `interfaces \u003cif\u003e host-inbound-traffic system-services ...` on the interfaces that need it — and note a per-interface stanza REPLACES the zone stanza (#6515), so restate the zone's other tokens there or they stop being admitted on that interface. (#6519 parity deviation; xpf still enforces the zone-level authorization today.)",
         "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model."
-      ]
+      ],
+      "LenientNATTerminalActionRules": null
     },
     "error": ""
   },
@@ -13427,7 +13438,8 @@
         "zone \"lan\" host-inbound-traffic: system-services dhcp is configured at the ZONE level, which Junos does not allow — DHCP and BOOTP are the host-inbound services Junos accepts only per interface, because the server must know the incoming interface to send replies. Here the zone-level token authorizes DHCP/BOOTP on reth1 (DHCP server), which Junos would require you to admit interface by interface. Move the token to `interfaces \u003cif\u003e host-inbound-traffic system-services ...` on the interfaces that need it — and note a per-interface stanza REPLACES the zone stanza (#6515), so restate the zone's other tokens there or they stop being admitted on that interface. (#6519 parity deviation; xpf still enforces the zone-level authorization today.)",
         "zone \"lan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model.",
         "zone \"wan\" host-inbound-traffic: host-bound routing multicast (router-discovery (IRDP) 224.0.0.1/224.0.0.2) is currently admitted PACKET-WIDE via the kernel input-chain accept fall-through, not scoped to this zone's ingress interface — a known Junos-parity gap (#4455), pending the per-zone iifname multicast admission model."
-      ]
+      ],
+      "LenientNATTerminalActionRules": null
     },
     "error": ""
   },
@@ -13706,7 +13718,8 @@
         "security flow tcp-mss all-tcp: invalid tcp-mss value: not an integer: \"mss\" (treated as unset/0 by the compiler — a strict commit would reject this)",
         "security flow traceoptions file: trace filename \"/etc/passwd\" must be a bare name, not a path (the file is written under /var/log) (ignored: tracing disabled, not written outside /var/log)",
         "application structure (downgraded to warning on tolerant path): application \"appA\": conflicting duplicate \"protocol\"; a single-valued application leaf (protocol / destination-port / source-port / inactivity-timeout / timeout / icmp-type / icmp-code / alg) may be set only once — a repeat with a different value is last-writer-wins and silently keeps only the LAST value by definition order, so a deny referencing this application covers fewer protocol/port combinations than authored and can fall through to a permit (split conflicting values into separate `term` sub-blocks or separate applications)"
-      ]
+      ],
+      "LenientNATTerminalActionRules": null
     },
     "error": ""
   },
@@ -13985,7 +13998,8 @@
         "security flow tcp-mss all-tcp: invalid tcp-mss value: not an integer: \"mss\" (treated as unset/0 by the compiler — a strict commit would reject this)",
         "security flow traceoptions file: trace filename \"/etc/passwd\" must be a bare name, not a path (the file is written under /var/log) (ignored: tracing disabled, not written outside /var/log)",
         "application structure (downgraded to warning on tolerant path): application \"appA\": conflicting duplicate \"protocol\"; a single-valued application leaf (protocol / destination-port / source-port / inactivity-timeout / timeout / icmp-type / icmp-code / alg) may be set only once — a repeat with a different value is last-writer-wins and silently keeps only the LAST value by definition order, so a deny referencing this application covers fewer protocol/port combinations than authored and can fall through to a permit (split conflicting values into separate `term` sub-blocks or separate applications)"
-      ]
+      ],
+      "LenientNATTerminalActionRules": null
     },
     "error": ""
   },
@@ -14264,7 +14278,8 @@
         "security flow tcp-mss all-tcp: invalid tcp-mss value: not an integer: \"mss\" (treated as unset/0 by the compiler — a strict commit would reject this)",
         "security flow traceoptions file: trace filename \"/etc/passwd\" must be a bare name, not a path (the file is written under /var/log) (ignored: tracing disabled, not written outside /var/log)",
         "application structure (downgraded to warning on tolerant path): application \"appA\": conflicting duplicate \"protocol\"; a single-valued application leaf (protocol / destination-port / source-port / inactivity-timeout / timeout / icmp-type / icmp-code / alg) may be set only once — a repeat with a different value is last-writer-wins and silently keeps only the LAST value by definition order, so a deny referencing this application covers fewer protocol/port combinations than authored and can fall through to a permit (split conflicting values into separate `term` sub-blocks or separate applications)"
-      ]
+      ],
+      "LenientNATTerminalActionRules": null
     },
     "error": ""
   },
@@ -14614,7 +14629,8 @@
         "policy zone reference (downgraded to warning on tolerant path): security policy from-zone \"trust\" to-zone \"untrust\" references undefined from-zone \"trust\"; define `set security zones security-zone trust` in the same commit or the rule is silently never matched (zone-pair falls through to the default policy)",
         "policy from-zone \"trust\": zone not defined",
         "policy to-zone \"untrust\": zone not defined"
-      ]
+      ],
+      "LenientNATTerminalActionRules": null
     },
     "error": ""
   },
@@ -14949,7 +14965,8 @@
         "policy zone reference (downgraded to warning on tolerant path): security policy from-zone \"trust\" to-zone \"untrust\" references undefined from-zone \"trust\"; define `set security zones security-zone trust` in the same commit or the rule is silently never matched (zone-pair falls through to the default policy)",
         "policy from-zone \"trust\": zone not defined",
         "policy to-zone \"untrust\": zone not defined"
-      ]
+      ],
+      "LenientNATTerminalActionRules": null
     },
     "error": ""
   },
@@ -15284,7 +15301,8 @@
         "policy zone reference (downgraded to warning on tolerant path): security policy from-zone \"trust\" to-zone \"untrust\" references undefined from-zone \"trust\"; define `set security zones security-zone trust` in the same commit or the rule is silently never matched (zone-pair falls through to the default policy)",
         "policy from-zone \"trust\": zone not defined",
         "policy to-zone \"untrust\": zone not defined"
-      ]
+      ],
+      "LenientNATTerminalActionRules": null
     },
     "error": ""
   },

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -333,6 +333,54 @@ type Config struct {
 	EventOptions      []*EventPolicy
 	BridgeDomains     []*BridgeDomainConfig
 	Warnings          []string // non-fatal validation warnings
+
+	// LenientNATTerminalActionRules records every NAT rule the TOLERANT path
+	// admitted despite validateNATTerminalActionCardinalityStrict rejecting it
+	// (#7640). It is populated ONLY on that path — the strict path returns the
+	// error instead, so a non-empty slice means exactly "this config carries a
+	// rule a commit would have refused".
+	//
+	// It exists because the warning alone has nowhere to go on the paths where
+	// such a rule survives. cfg.Warnings reaches an operator through the commit
+	// RESPONSE (pkg/api/config.go, pkg/grpcapi/server_config.go) and an
+	// apply-time log line (pkg/daemon/daemon_apply.go) — and a tolerant LOAD
+	// (boot, peer-sync, rollback) has no commit response. On exactly those
+	// paths the only trace was one startup log line that nothing alerts on.
+	//
+	// Rebuilt per compile by construction: every CompileConfig produces a fresh
+	// *Config, so fixing the config clears it without a separate clear path.
+	// That matters — an alert that keeps firing after the fix gets muted, and a
+	// muted alert is how the next real one is missed.
+	//
+	// Consumers: the xpf_nat_rules_lenient_terminal_action gauge (pkg/api) and
+	// the per-rule annotation in `show security nat {source,destination} rule
+	// detail` (pkg/natshow). Both read THIS field rather than re-deriving, so a
+	// count, an annotation and the warning can never disagree about which rules
+	// are affected.
+	LenientNATTerminalActionRules []LenientNATTerminalActionRule
+}
+
+// LenientNATTerminalActionRule identifies one NAT rule admitted by the tolerant
+// path despite carrying the wrong number of terminal actions (#7640).
+type LenientNATTerminalActionRule struct {
+	// Kind is "source" or "destination".
+	Kind string
+	// RuleSet and Rule are the authored names, so an operator can go straight
+	// to the offending stanza.
+	RuleSet string
+	Rule    string
+	// Actions is the terminal-action count the gate objected to: 0 (actionless
+	// — the rule installs no translation and, for source NAT, does not stop
+	// rule evaluation) or >= 2 (contradictory — all but one action is
+	// discarded by a fixed precedence the operator did not write).
+	Actions int
+}
+
+// String renders the rule identity for the gauge hook and the operator-facing
+// annotation. Stable and greppable: `source rule-set RS rule R (0 actions)`.
+func (r LenientNATTerminalActionRule) String() string {
+	return fmt.Sprintf("%s rule-set %s rule %s (%d actions)",
+		r.Kind, r.RuleSet, r.Rule, r.Actions)
 }
 
 // IRBToBridge returns a mapping of IRB interface reference (e.g. "irb.0") to

--- a/pkg/daemon/daemon_run_servers.go
+++ b/pkg/daemon/daemon_run_servers.go
@@ -347,6 +347,26 @@ func (d *Daemon) startHTTPServer(ctx context.Context, wg *sync.WaitGroup, eventB
 			}
 			return d.frr.QuarantinedRouteMaps()
 		},
+		// #7640: NAT rules the tolerant load / peer-sync / rollback path
+		// admitted despite the strict terminal-action cardinality gate. Read
+		// from the ACTIVE config, so it tracks what the node is actually
+		// running and clears the moment a fixed config is committed — an alert
+		// that keeps firing after the fix gets muted, and a muted alert is how
+		// the next real one is missed.
+		NATLenientTerminalActionRulesFn: func() []string {
+			if d.store == nil {
+				return nil
+			}
+			cfg := d.store.ActiveConfig()
+			if cfg == nil {
+				return nil
+			}
+			out := make([]string, 0, len(cfg.LenientNATTerminalActionRules))
+			for _, r := range cfg.LenientNATTerminalActionRules {
+				out = append(out, r.String())
+			}
+			return out
+		},
 		// #4899: 1 while the last DHCP-lease-change IPsec rebind
 		// failed and swanctl local_addrs are still bound to a stale
 		// lease address (the retry loop has not reconverged), so the

--- a/pkg/natshow/dest.go
+++ b/pkg/natshow/dest.go
@@ -63,9 +63,17 @@ func RenderDestRuleDetail(w io.Writer, cfg *config.Config, dp Reader, crFn func(
 	for _, rs := range dnat.RuleSets {
 		for _, rule := range rs.Rules {
 			ruleIdx++
-			action := "off"
-			if rule.Then.PoolName != "" {
+			// #7640: as in the source renderer, do not claim an action the
+			// rule does not carry. This defaulted to "off", so an ACTIONLESS
+			// destination rule displayed as an explicit exemption the operator
+			// never wrote. The observable disposition happens to match (the
+			// builder skips such a rule), but the display asserted intent.
+			action := "none"
+			switch {
+			case rule.Then.PoolName != "":
 				action = "pool " + rule.Then.PoolName
+			case rule.Then.Off:
+				action = "off"
 			}
 			dstMatch := "0.0.0.0/0"
 			if rule.Match.DestinationAddress != "" {

--- a/pkg/natshow/nat_lenient_terminal_annotation_7640_test.go
+++ b/pkg/natshow/nat_lenient_terminal_annotation_7640_test.go
@@ -1,0 +1,128 @@
+package natshow
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// nat_lenient_terminal_annotation_7640_test.go — #7640.
+//
+// The operator looking at the offending rule was the one person guaranteed not
+// to be told about it: the compile-time warning goes to the commit response,
+// which a tolerant LOAD does not have. These cells bind the annotation, and the
+// action-rendering defect it sits next to.
+
+func actionlessSourceCfg7640() *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{{
+		Name:     "rs1",
+		FromZone: "trust",
+		ToZone:   "untrust",
+		Rules:    []*config.NATRule{{Name: "actionless"}}, // no terminal action
+	}}
+	cfg.LenientNATTerminalActionRules = []config.LenientNATTerminalActionRule{
+		{Kind: "source", RuleSet: "rs1", Rule: "actionless", Actions: 0},
+	}
+	return cfg
+}
+
+// TestActionlessSourceRuleIsNotRenderedAsInterface7640 pins a display defect
+// the annotation work uncovered, and it is the worse half of the two.
+//
+// The action string defaulted to "interface" whenever neither a pool nor `off`
+// was set — so an ACTIONLESS rule displayed `Action: interface`, an action it
+// does not carry and will not perform. For the one rule shape an operator most
+// needs to find, the view actively asserted the wrong thing.
+//
+// FAIL-ON-REVERT: restore the `action := "interface"` default and the "none"
+// assertion reds.
+func TestActionlessSourceRuleIsNotRenderedAsInterface7640(t *testing.T) {
+	var b strings.Builder
+	RenderSourceRuleDetail(&b, actionlessSourceCfg7640(), nil, nil)
+	got := b.String()
+
+	if strings.Contains(got, "Action:                  interface") {
+		t.Fatalf("an ACTIONLESS rule rendered as `Action: interface` — the view "+
+			"claims an action the rule does not carry, on exactly the rule shape "+
+			"an operator is trying to find (#7640):\n%s", got)
+	}
+	if !strings.Contains(got, "Action:                  none") {
+		t.Fatalf("expected `Action: none` for a rule with no terminal action:\n%s", got)
+	}
+}
+
+// TestLenientlyAdmittedSourceRuleIsAnnotated7640 is the surface the issue is
+// about: the rule the tolerant path admitted says so, where the operator is
+// already looking.
+//
+// FAIL-ON-REVERT: drop the noteLenientTerminalAction call and the annotation
+// disappears while every other line still renders — the pre-#7640 silence.
+func TestLenientlyAdmittedSourceRuleIsAnnotated7640(t *testing.T) {
+	var b strings.Builder
+	RenderSourceRuleDetail(&b, actionlessSourceCfg7640(), nil, nil)
+	got := b.String()
+
+	if !strings.Contains(got, "ADMITTED BY TOLERANT LOAD") {
+		t.Fatalf("the rule the tolerant path admitted is not annotated — an "+
+			"operator inspecting it cannot tell a commit would refuse it "+
+			"(#7640):\n%s", got)
+	}
+	// The consequence, not just the fact: for source NAT the fall-through is
+	// what the operator has to reason about.
+	if !strings.Contains(got, "falls through") {
+		t.Fatalf("the annotation does not name the CONSEQUENCE (fall-through to a "+
+			"later broader rule), which is the part that decides whether this "+
+			"matters:\n%s", got)
+	}
+}
+
+// TestHealthyRuleIsNotAnnotated7640 is the PAIRED control. Without it, "the
+// annotation appears" is satisfied by a renderer that annotates every rule,
+// which would train an operator to ignore it.
+func TestHealthyRuleIsNotAnnotated7640(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{{
+		Name:  "rs1",
+		Rules: []*config.NATRule{{Name: "ok", Then: config.NATThen{Interface: true}}},
+	}}
+	var b strings.Builder
+	RenderSourceRuleDetail(&b, cfg, nil, nil)
+	got := b.String()
+
+	if strings.Contains(got, "ADMITTED BY TOLERANT LOAD") {
+		t.Fatalf("a well-formed rule was annotated:\n%s", got)
+	}
+	if !strings.Contains(got, "Action:                  interface") {
+		t.Fatalf("a genuine interface rule must still render as `interface`:\n%s", got)
+	}
+}
+
+// TestAnnotationIsScopedToTheNamedRule7640 pins that the record is matched on
+// identity rather than smeared across the rule-set. A tolerantly-loaded config
+// usually carries SOME good rules too, and annotating those would be the same
+// noise as annotating everything.
+func TestAnnotationIsScopedToTheNamedRule7640(t *testing.T) {
+	cfg := actionlessSourceCfg7640()
+	cfg.Security.NAT.Source[0].Rules = append(cfg.Security.NAT.Source[0].Rules,
+		&config.NATRule{Name: "healthy", Then: config.NATThen{Interface: true}})
+
+	var b strings.Builder
+	RenderSourceRuleDetail(&b, cfg, nil, nil)
+	got := b.String()
+
+	if n := strings.Count(got, "ADMITTED BY TOLERANT LOAD"); n != 1 {
+		t.Fatalf("annotation appeared %d times for one recorded rule in a "+
+			"two-rule rule-set; it must be scoped to the named rule:\n%s", n, got)
+	}
+	// And it is attached to the right one: the annotation must follow the
+	// actionless rule's header, not the healthy one's.
+	iActionless := strings.Index(got, "source NAT rule: actionless")
+	iHealthy := strings.Index(got, "source NAT rule: healthy")
+	iNote := strings.Index(got, "ADMITTED BY TOLERANT LOAD")
+	if !(iActionless < iNote && iNote < iHealthy) {
+		t.Fatalf("the annotation is not attached to the actionless rule "+
+			"(actionless@%d note@%d healthy@%d):\n%s", iActionless, iNote, iHealthy, got)
+	}
+}

--- a/pkg/natshow/natshow.go
+++ b/pkg/natshow/natshow.go
@@ -35,6 +35,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/psaab/xpf/pkg/config"
+
 	"github.com/psaab/xpf/pkg/dataplane"
 )
 
@@ -70,6 +72,52 @@ func noteNotInstalled(w io.Writer, reason string) {
 		return
 	}
 	fmt.Fprintf(w, "    Status:                  NOT INSTALLED — %s\n", reason)
+}
+
+// noteLenientTerminalAction annotates a rule that the TOLERANT config path
+// admitted despite the strict terminal-action cardinality gate rejecting it
+// (#7640).
+//
+// It reads config.Config.LenientNATTerminalActionRules rather than re-deriving
+// the predicate, so the annotation, the xpf_nat_rules_lenient_terminal_action
+// gauge and the compile-time warning can never disagree about which rules are
+// affected.
+//
+// This is the surface that was missing. The warning reaches an operator through
+// the commit RESPONSE and an apply-time log line — and a tolerant LOAD (boot,
+// peer-sync, rollback) has neither. Those are exactly the paths on which such a
+// rule survives, so an operator looking at the rule was the one person
+// guaranteed not to be told.
+//
+// The text names the consequence per arity rather than saying "invalid",
+// because the two arities fail differently and the difference is what an
+// operator has to act on.
+func noteLenientTerminalAction(w io.Writer, cfg *config.Config, kind, ruleSet, rule string) {
+	if cfg == nil {
+		return
+	}
+	for _, r := range cfg.LenientNATTerminalActionRules {
+		if r.Kind != kind || r.RuleSet != ruleSet || r.Rule != rule {
+			continue
+		}
+		var consequence string
+		switch {
+		case r.Actions == 0 && kind == "source":
+			consequence = "it installs no translation and does NOT stop rule " +
+				"evaluation, so matching traffic falls through to any later " +
+				"broader rule"
+		case r.Actions == 0:
+			consequence = "it installs no translation; the rule is not published " +
+				"to the dataplane at all"
+		default:
+			consequence = fmt.Sprintf("it carries %d mutually-exclusive actions; "+
+				"all but one are discarded by a fixed precedence, not by "+
+				"configuration order", r.Actions)
+		}
+		fmt.Fprintf(w, "    Status:                  ADMITTED BY TOLERANT LOAD — "+
+			"a commit would REJECT this rule: %s\n", consequence)
+		return
+	}
 }
 
 // noteNotInstalledStatic is noteNotInstalled at the static-NAT renderers' wider

--- a/pkg/natshow/source.go
+++ b/pkg/natshow/source.go
@@ -66,11 +66,20 @@ func RenderSourceRuleDetail(w io.Writer, cfg *config.Config, dp Reader, crFn fun
 	for _, rs := range cfg.Security.NAT.Source {
 		for _, rule := range rs.Rules {
 			ruleIdx++
-			action := "interface"
-			if rule.Then.PoolName != "" {
+			// #7640: render the action the rule ACTUALLY carries. This
+			// defaulted to "interface" whenever neither a pool nor `off` was
+			// set — so an ACTIONLESS rule (one the strict gate rejects, and
+			// which a tolerant load can still admit) displayed an action it
+			// does not have and will not perform. That is the worst possible
+			// output for the one rule shape an operator most needs to find.
+			action := "none"
+			switch {
+			case rule.Then.PoolName != "":
 				action = "pool " + rule.Then.PoolName
-			} else if rule.Then.Off {
+			case rule.Then.Off:
 				action = "off"
+			case rule.Then.Interface:
+				action = "interface"
 			}
 			srcMatch := "0.0.0.0/0"
 			if rule.Match.SourceAddress != "" {
@@ -101,6 +110,7 @@ func RenderSourceRuleDetail(w io.Writer, cfg *config.Config, dp Reader, crFn fun
 						cfg.Security.NAT.SourcePools[rule.Then.PoolName],
 						rule.Then.PoolName, overBudgetPools)))
 			}
+			noteLenientTerminalAction(w, cfg, "source", rs.Name, rule.Name)
 
 			if rule.Then.PoolName != "" && cfg.Security.NAT.SourcePools != nil {
 				if pool, ok := cfg.Security.NAT.SourcePools[rule.Then.PoolName]; ok {


### PR DESCRIPTION
Closes #7640

## Summary

- The strict terminal-action cardinality gate (#5628) rejects a NAT rule whose `then` carries other than exactly one translation action. The tolerant load / peer-sync / rollback path downgrades that to a `cfg.Warnings` entry (#1960 no-brick) — correctly, since the alternative is a brick.
- **But the warning has nowhere to go on those paths.** `cfg.Warnings` reaches an operator through the commit **response** (`pkg/api/config.go`, `pkg/grpcapi/server_config.go`) and an apply-time log line (`pkg/daemon/daemon_apply.go`). A tolerant **load** has no commit response — and boot, peer-sync and rollback are precisely the paths on which such a rule survives. The node then ran indefinitely carrying a rule a commit would refuse, with one startup log line as the only trace.
- `Config.LenientNATTerminalActionRules` records every offender; a gauge and a per-rule `show` annotation consume it.
- Fixed a display defect found at the annotation site: an **actionless** rule rendered `Action: interface`.

**Decision-neutral with respect to #6823, and that is the point.** It forecloses none of that issue's options A/B/C, fixes a real gap on its own merits, and converts its crux question — *how many real configurations actually reach this state* — from an estimate into a measurement.

## Design

**One record, two consumers, no re-derivation.** Both the gauge and the annotation read `Config.LenientNATTerminalActionRules` rather than re-running the predicate, so a count, an annotation and the compile-time warning can never disagree about which rules are affected.

**Populated only on the lenient branch**, so a non-empty slice means precisely *"admitted leniently"* — the strict branch returns the error instead. A rejected config admitted nothing, and a gauge that fired there would report a violation on a node that refused to run one.

**Rebuilt per compile by construction.** Every `CompileConfig` produces a fresh `*Config`, so fixing the config clears the record with no separate clear path. That matters: an alert that keeps firing after the fix gets muted, and a muted alert is how the next real one is missed.

**The enumerator is deliberately separate from the gate.** The gate reports the FIRST offender and stops — right for a commit error, which should be one deterministic actionable line rather than a wall. The record needs all of them. Separate walks are exactly how a count and a rejection drift apart, so both read `natThenTerminalActionCount` and `TestLenientNATOffendersMatchTheGate_7640` binds the agreement across seven arity shapes rather than trusting it.

**The gauge is a COUNT, not a boolean** — one tolerantly-loaded config commonly carries several such rules, since whatever produced one (a pre-gate release, an older peer) produced them all. It publishes an **explicit 0** when the hook is wired and is **ABSENT** when it is not: an alert on `> 0` cannot distinguish "none admitted" from "the series stopped reporting", and a hardcoded 0 from a process that never read the active config is a false all-clear.

**The annotation names the consequence per arity** rather than saying "invalid", because the two arities fail differently and the difference is what an operator has to act on:

```
source NAT rule: actionless
  Rule-set: rs1                        ID: 1
    ...
    Action:                  none
    Status:                  ADMITTED BY TOLERANT LOAD — a commit would REJECT
                             this rule: it installs no translation and does NOT
                             stop rule evaluation, so matching traffic falls
                             through to any later broader rule
```

### The display defect this uncovered

The source action string defaulted to `"interface"` whenever neither a pool nor `off` was set:

```go
action := "interface"
if rule.Then.PoolName != "" { ... } else if rule.Then.Off { ... }
```

`rule.Then.Interface` was never read. So an **actionless** rule displayed `Action: interface` — an action it does not carry and will not perform, on exactly the rule shape an operator is trying to find. Destination NAT defaulted to `"off"`, asserting an explicit exemption the operator never wrote. Both now render `none`.

## Test plan

- [x] `pkg/config/nat_lenient_terminal_visibility_7640_test.go` — the record. Core cell asserts the identity is enough to find the stanza, with a **precondition** that the warning actually fired (so the cell is about the record being missing, not about the gate not firing). Paired controls: the **strict** path records nothing, and a **healthy** config records nothing.
- [x] `TestLenientNATOffendersMatchTheGate_7640` — 7 arity shapes; for each, the gate rejects **iff** the enumerator finds something.
- [x] `TestOffendersCoverBothKinds7640` — destination NAT is walked too; a source-only enumerator would report a clean node for a config whose DNAT rules a commit would refuse.
- [x] `pkg/api/metrics_nat_lenient_terminal_7640_test.go` — gauge on a pedantic registry across healthy / one / several, plus the unwired-is-absent cell.
- [x] `pkg/natshow/nat_lenient_terminal_annotation_7640_test.go` — the annotation, with a **paired** healthy-not-annotated control (without it, "the annotation appears" is satisfied by a renderer that annotates everything, which trains an operator to ignore it) and a **scoped-to-the-named-rule** cell asserting both the count and its position, since a tolerantly-loaded config carries good rules too.
- [x] **Mutation matrix** at HEAD `723ab866f`, fix committed first, full-package `go test -count=1` per package with **no** `-run` filter, `buildbreak=0` throughout:

  | mutation | cell that RED | verdict |
  |---|---|---|
  | lenient branch stops recording (the shipped invisibility) | `TestLenientPathRecordsTheAdmittedRule7640` | RED |
  | enumerator counts only the actionless arity | `TestLenientNATOffendersMatchTheGate_7640` (3 subtests) | RED |
  | enumerator walks source only | `TestOffendersCoverBothKinds7640` | RED |
  | gauge published with no hook wired | `...GaugeAbsentWhenUnwired7640` | RED |
  | `show` annotation dropped | `...IsAnnotated7640` + `...ScopedToTheNamedRule7640` | RED |
  | actionless action reverts to `"interface"` | `...IsNotRenderedAsInterface7640` | RED |

- [x] `go build ./... && go test -count=1 ./...` → **rc 0**, 68/68 packages, at HEAD `723ab866f76368be18cb96bf9f72c915222ecec0`, with `origin/master b8aa08445` merged in (MERGE, never rebase) and `merge-base --is-ancestor origin/master HEAD` verified.
- [ ] **No smoke owed.** Compile-path record, a gauge and a `show` renderer — no forwarding-path code, no cluster / VRRP / session-sync / failover, no `userspace-dp` / `userspace-xdp` (no cargo leg).

### Golden regeneration — classified before regenerating

`golden_4406.json` changed because `Config` gained a field. Diff classified **before** regenerating rather than after:

| | |
|---|---|
| keys added | **18**, all `LenientNATTerminalActionRules` |
| added keys with a non-empty value | **0** |
| keys removed | **0** |
| values changed | **0** |

Add-only with no value change, so no behaviour change is being laundered through the regen. (Worth noting: none of the golden fixtures — including `lenient-downgrades` and `strict-violations` — carries a cardinality offender, so the field is empty in all 18. The new cells cover the non-empty case.)

## Refs

Closes #7640. Unblocks the decision on **#6823** by making its crux question measurable. Builds on #5628 (the gate), #1960 (the tolerant-path doctrine), #6820 / #7034 / #7035 (the gate's own claim corrections) and #6807 (the gauge shape reused here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1PvkJxs7KrzEdyC9u1LDu
