### PR TITLE
test/ipsec: validate rendered swanctl output structurally (#6824)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -106333,3 +106333,11 @@ prose edit above them added. No diff falls in the new test body.
     as the containment subject; parser section-vs-setting ambiguity documented
   - **File(s)**: pkg/ipsec/swanctl_containment_guard_6824_test.go,
     pkg/ipsec/swanctl_doc_6824_test.go
+  - **Action**: #6824 — act on the Codex hostile review: nine findings, all
+    real, including a false claim in the guard's own doc comment
+  - **File(s)**: pkg/ipsec/swanctl_doc_6824_test.go,
+    pkg/ipsec/swanctl_doc_selftest_6824_test.go,
+    pkg/ipsec/swanctl_containment_guard_6824_test.go,
+    pkg/ipsec/trafficselector_render_4098_test.go,
+    pkg/ipsec/ike_chain_failclosed_test.go, pkg/ipsec/ipsec_test.go,
+    pkg/ipsec/swanctl_render_test.go, pkg/ipsec/dhcp_rebind_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -106306,3 +106306,12 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/config/compact_block_inventory_regen_2419_test.go` (new),
   `pkg/config/testdata/compact_block_divergences_2419.txt` (new),
   `docs/config-schema.md`, `_Log.md`
+
+- **Timestamp**: 2026-08-26
+  - **Action**: #6824 — add a structural swanctl document checker and convert
+    the first render tests off `strings.Contains`
+  - **File(s)**: pkg/ipsec/swanctl_doc_6824_test.go (new),
+    pkg/ipsec/swanctl_doc_selftest_6824_test.go (new),
+    pkg/ipsec/endpoint_render_5630_test.go,
+    pkg/ipsec/trafficselector_render_4098_test.go,
+    pkg/ipsec/childname_collision_5122_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -106329,3 +106329,7 @@ prose edit above them added. No diff falls in the new test body.
   - **Action**: #6824 — add the AST guard that fails on new swanctl-syntax
     containment needles, with its own sensitivity control
   - **File(s)**: pkg/ipsec/swanctl_containment_guard_6824_test.go (new)
+  - **Action**: #6824 self-review — the AST guard missed an inline render call
+    as the containment subject; parser section-vs-setting ambiguity documented
+  - **File(s)**: pkg/ipsec/swanctl_containment_guard_6824_test.go,
+    pkg/ipsec/swanctl_doc_6824_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -106326,3 +106326,6 @@ prose edit above them added. No diff falls in the new test body.
   - **Action**: #6824 — convert the 68 `strings.Contains` render assertions in
     ipsec_test.go to structural checks
   - **File(s)**: pkg/ipsec/ipsec_test.go
+  - **Action**: #6824 — add the AST guard that fails on new swanctl-syntax
+    containment needles, with its own sensitivity control
+  - **File(s)**: pkg/ipsec/swanctl_containment_guard_6824_test.go (new)

--- a/_Log.md
+++ b/_Log.md
@@ -106341,3 +106341,13 @@ prose edit above them added. No diff falls in the new test body.
     pkg/ipsec/trafficselector_render_4098_test.go,
     pkg/ipsec/ike_chain_failclosed_test.go, pkg/ipsec/ipsec_test.go,
     pkg/ipsec/swanctl_render_test.go, pkg/ipsec/dhcp_rebind_test.go
+  - **Action**: #6824 — act on the Codex RE-review: refuse ambiguous parser
+    shapes instead of guessing; restore the deleted negatives with faithful
+    (prefix/substring) semantics; teach the guard helpers, package-level vars
+    and closures
+  - **File(s)**: pkg/ipsec/swanctl_doc_6824_test.go,
+    pkg/ipsec/swanctl_doc_selftest_6824_test.go,
+    pkg/ipsec/swanctl_containment_guard_6824_test.go,
+    pkg/ipsec/ipsec_test.go, pkg/ipsec/swanctl_render_test.go,
+    pkg/ipsec/dhcp_rebind_test.go,
+    pkg/ipsec/trafficselector_render_4098_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -106323,3 +106323,6 @@ prose edit above them added. No diff falls in the new test body.
     pkg/ipsec/swanctl_addr_sanitize_6469_test.go,
     pkg/ipsec/swanctl_render_test.go, pkg/ipsec/dhcp_rebind_test.go,
     pkg/ipsec/swanctl_doc_6824_test.go
+  - **Action**: #6824 — convert the 68 `strings.Contains` render assertions in
+    ipsec_test.go to structural checks
+  - **File(s)**: pkg/ipsec/ipsec_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -106315,3 +106315,11 @@ prose edit above them added. No diff falls in the new test body.
     pkg/ipsec/endpoint_render_5630_test.go,
     pkg/ipsec/trafficselector_render_4098_test.go,
     pkg/ipsec/childname_collision_5122_test.go
+  - **Action**: #6824 — convert the remaining issue-numbered ipsec render
+    regression tests off `strings.Contains`
+  - **File(s)**: pkg/ipsec/ike_chain_failclosed_test.go,
+    pkg/ipsec/proposalset_ah_hb167_test.go,
+    pkg/ipsec/ike_proposals_multivalue_3904_test.go,
+    pkg/ipsec/swanctl_addr_sanitize_6469_test.go,
+    pkg/ipsec/swanctl_render_test.go, pkg/ipsec/dhcp_rebind_test.go,
+    pkg/ipsec/swanctl_doc_6824_test.go

--- a/pkg/ipsec/childname_collision_5122_test.go
+++ b/pkg/ipsec/childname_collision_5122_test.go
@@ -7,25 +7,6 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 )
 
-// childSectionNames returns the trimmed swanctl child-section header names
-// (the `<name> {` line inside the children{} block) that begin with the given
-// connection-name prefix. It returns every occurrence, so a duplicate name
-// shows up twice — the exact symptom of the #5122 collision.
-func childSectionNames(rendered, connPrefix string) []string {
-	var names []string
-	for _, line := range strings.Split(rendered, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if !strings.HasPrefix(trimmed, connPrefix+"-") {
-			continue
-		}
-		if !strings.HasSuffix(trimmed, " {") {
-			continue
-		}
-		names = append(names, strings.TrimSuffix(trimmed, " {"))
-	}
-	return names
-}
-
 // TestChildNameCollisionDisambiguated is the #5122 RED-on-revert guard. Two
 // distinct traffic-selector names that differ ONLY in a sanitized character
 // (`site/a` vs `site:a` — both legal Junos identifier chars) both sanitize to
@@ -58,23 +39,37 @@ func TestChildNameCollisionDisambiguated(t *testing.T) {
 
 	got := m.generateConfig(cfg)
 
-	names := childSectionNames(got, "tun1")
+	// #6824: read the child sections out of the PARSED document rather than by
+	// scanning for lines that look like section openers. The parser also
+	// rejects two sections sharing a name under one parent outright, which is
+	// the #5122 defect stated as a structural property instead of inferred from
+	// a name list.
+	children := parseSwanctlDoc(t, got).at(t, "connections", "tun1", "children")
+	names := children.childNames()
 	if len(names) != 2 {
 		t.Fatalf("expected 2 child sections for the two selectors, got %d: %v\n%s",
-			len(names), names, got)
+			len(names), names, children)
 	}
 	if names[0] == names[1] {
 		t.Fatalf("distinct selectors site/a and site:a rendered DUPLICATE child "+
 			"section name %q (strongSwan would reject/merge one selector, #5122):\n%s",
-			names[0], got)
+			names[0], children)
 	}
-	// Both selectors must survive to the render — assert each distinct local_ts
-	// prefix is present, proving neither child was overwritten/dropped.
-	if !strings.Contains(got, "local_ts = 10.0.1.0/24") {
-		t.Fatalf("selector site/a (local_ts 10.0.1.0/24) missing from render:\n%s", got)
+	// Both selectors must survive to the render. Containment could only say the
+	// two local_ts values appear SOMEWHERE; what matters is that they land in
+	// two DIFFERENT child sections, so neither selector was overwritten.
+	byLocalTS := map[string]string{}
+	for _, n := range names {
+		byLocalTS[children.at(t, n).setting(t, "local_ts")] = n
 	}
-	if !strings.Contains(got, "local_ts = 10.0.2.0/24") {
-		t.Fatalf("selector site:a (local_ts 10.0.2.0/24) missing from render:\n%s", got)
+	for _, want := range []string{"10.0.1.0/24", "10.0.2.0/24"} {
+		if _, ok := byLocalTS[want]; !ok {
+			t.Errorf("no child section carries local_ts = %s; sections carry %v\n%s",
+				want, byLocalTS, children)
+		}
+	}
+	if len(byLocalTS) != 2 {
+		t.Errorf("the two selectors did not land in two distinct child sections: %v", byLocalTS)
 	}
 	// Both disambiguated names must keep the sanitized base as a prefix so the
 	// naming stays recognizable / stable-shaped.
@@ -109,16 +104,19 @@ func TestChildNameNonCollidingUnchanged(t *testing.T) {
 		},
 	}
 
-	got := m.generateConfig(cfg)
-	names := childSectionNames(got, "tun1")
+	// #6824: the child-section names come from the parsed tree, so a name that
+	// appears in the document but is NOT a child of this connection can no
+	// longer satisfy the assertion.
+	children := parseSwanctlDoc(t, m.generateConfig(cfg)).at(t, "connections", "tun1", "children")
+	names := children.childNames()
 	want := map[string]bool{"tun1-alpha": true, "tun1-beta": true}
 	if len(names) != 2 {
-		t.Fatalf("expected 2 child sections, got %d: %v\n%s", len(names), names, got)
+		t.Fatalf("expected 2 child sections, got %d: %v\n%s", len(names), names, children)
 	}
 	for _, n := range names {
 		if !want[n] {
 			t.Fatalf("non-colliding selector rendered unexpected/disambiguated name "+
-				"%q (want one of %v):\n%s", n, want, got)
+				"%q (want one of %v):\n%s", n, want, children)
 		}
 	}
 }
@@ -143,8 +141,9 @@ func TestChildNameSingleSelectorUnchanged(t *testing.T) {
 		},
 	}
 
-	got := m.generateConfig(cfg)
-	if !strings.Contains(got, "tun1-ts1 {\n") {
-		t.Fatalf("single selector did not render its plain child section tun1-ts1:\n%s", got)
-	}
+	// #6824: `Contains(got, "tun1-ts1 {\n")` depended on brace placement and
+	// would also match the text appearing inside a value. Resolving the path
+	// asserts the section EXISTS where it belongs.
+	parseSwanctlDoc(t, m.generateConfig(cfg)).
+		at(t, "connections", "tun1", "children", "tun1-ts1")
 }

--- a/pkg/ipsec/dhcp_rebind_test.go
+++ b/pkg/ipsec/dhcp_rebind_test.go
@@ -117,7 +117,7 @@ func TestPrepareConfigReResolvesDHCPLocalAddress(t *testing.T) {
 	// The stale address must be gone from the WHOLE document. Equality at the
 	// connection does not say that: a stale local_addrs under any other section
 	// would satisfy it, and the deleted needle would have caught that.
-	parseSwanctlDoc(t, renewedDoc).hasNoSettingValueAnywhere(t, "local_addrs", "198.51.100.7")
+	parseSwanctlDoc(t, renewedDoc).hasNoValueSubstringAnywhere(t, "198.51.100.7")
 }
 
 // renderMust renders the swanctl config for prepared, failing the test on

--- a/pkg/ipsec/dhcp_rebind_test.go
+++ b/pkg/ipsec/dhcp_rebind_test.go
@@ -112,7 +112,12 @@ func TestPrepareConfigReResolvesDHCPLocalAddress(t *testing.T) {
 
 	// Simulate a DHCP renew to a new lease address.
 	renewed := dhcpBoundConfig("wan0.0", "", "203.0.113.42/24", true)
-	localAddrs_6824(t, m.renderMust(t, PrepareConfig(renewed)), "203.0.113.42")
+	renewedDoc := m.renderMust(t, PrepareConfig(renewed))
+	localAddrs_6824(t, renewedDoc, "203.0.113.42")
+	// The stale address must be gone from the WHOLE document. Equality at the
+	// connection does not say that: a stale local_addrs under any other section
+	// would satisfy it, and the deleted needle would have caught that.
+	parseSwanctlDoc(t, renewedDoc).hasNoSettingValueAnywhere(t, "local_addrs", "198.51.100.7")
 }
 
 // renderMust renders the swanctl config for prepared, failing the test on

--- a/pkg/ipsec/dhcp_rebind_test.go
+++ b/pkg/ipsec/dhcp_rebind_test.go
@@ -1,7 +1,6 @@
 package ipsec
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -102,21 +101,18 @@ func TestHasDHCPBoundGateway(t *testing.T) {
 func TestPrepareConfigReResolvesDHCPLocalAddress(t *testing.T) {
 	m := &Manager{configDir: t.TempDir()}
 
+	// #6824: an exact match on the connection's local_addrs subsumes the
+	// separate "stale address absent" needle. That third check existed only
+	// because containment cannot say a value is the WHOLE value -- with the
+	// setting read at a known path, a render that kept the old address either
+	// fails the equality or declares local_addrs twice, and setting() rejects
+	// a duplicated key outright.
 	old := dhcpBoundConfig("wan0.0", "", "198.51.100.7/24", true)
-	got := m.renderMust(t, PrepareConfig(old))
-	if !strings.Contains(got, "local_addrs = 198.51.100.7") {
-		t.Fatalf("first render missing original local_addrs:\n%s", got)
-	}
+	localAddrs_6824(t, m.renderMust(t, PrepareConfig(old)), "198.51.100.7")
 
 	// Simulate a DHCP renew to a new lease address.
 	renewed := dhcpBoundConfig("wan0.0", "", "203.0.113.42/24", true)
-	got = m.renderMust(t, PrepareConfig(renewed))
-	if !strings.Contains(got, "local_addrs = 203.0.113.42") {
-		t.Fatalf("re-render did not pick up the new lease address:\n%s", got)
-	}
-	if strings.Contains(got, "local_addrs = 198.51.100.7") {
-		t.Fatalf("re-render retained the stale lease address:\n%s", got)
-	}
+	localAddrs_6824(t, m.renderMust(t, PrepareConfig(renewed)), "203.0.113.42")
 }
 
 // renderMust renders the swanctl config for prepared, failing the test on
@@ -128,4 +124,19 @@ func (m *Manager) renderMust(t *testing.T, prepared *config.IPsecConfig) string 
 		t.Fatalf("renderConfig: %v", err)
 	}
 	return got
+}
+
+// localAddrs_6824 asserts the single rendered connection's local_addrs is
+// exactly want.
+//
+// It resolves the connection by taking the document's only child of
+// connections{}, so the assertion does not silently depend on a section name
+// the fixture never states.
+func localAddrs_6824(t *testing.T, doc, want string) {
+	t.Helper()
+	conns := parseSwanctlDoc(t, doc).at(t, "connections")
+	if len(conns.order) != 1 {
+		t.Fatalf("expected exactly one connection, got %v\n%s", conns.childNames(), conns)
+	}
+	conns.at(t, conns.order[0]).requireSetting(t, "local_addrs", want)
 }

--- a/pkg/ipsec/endpoint_render_5630_test.go
+++ b/pkg/ipsec/endpoint_render_5630_test.go
@@ -1,7 +1,6 @@
 package ipsec
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -26,21 +25,21 @@ func TestRenderValidEndpoints_5630(t *testing.T) {
 			name:       "IPv4 remote + IPv4 local",
 			gwAddr:     "203.0.113.1",
 			gwLocal:    "198.51.100.7",
-			wantRemote: "remote_addrs = 203.0.113.1",
-			wantLocal:  "local_addrs = 198.51.100.7",
+			wantRemote: "203.0.113.1",
+			wantLocal:  "198.51.100.7",
 		},
 		{
 			name:       "IPv6 remote + IPv6 local",
 			gwAddr:     "2001:db8::1",
 			gwLocal:    "2001:db8::2",
-			wantRemote: "remote_addrs = 2001:db8::1",
-			wantLocal:  "local_addrs = 2001:db8::2",
+			wantRemote: "2001:db8::1",
+			wantLocal:  "2001:db8::2",
 		},
 		{
 			name:       "FQDN remote",
 			gwAddr:     "peer.example.com",
 			gwLocal:    "",
-			wantRemote: "remote_addrs = peer.example.com",
+			wantRemote: "peer.example.com",
 			wantLocal:  "",
 		},
 	}
@@ -62,13 +61,29 @@ func TestRenderValidEndpoints_5630(t *testing.T) {
 					"prop1": {Name: "prop1", EncryptionAlg: "aes256", AuthAlg: "sha256"},
 				},
 			}
-			got := m.generateConfig(cfg)
-			if !strings.Contains(got, c.wantRemote) {
-				t.Fatalf("rendered config missing %q:\n%s", c.wantRemote, got)
+			// #6824: structural, not containment. The old assertions asked
+			// only whether the byte sequence "remote_addrs = <addr>" appeared
+			// SOMEWHERE in the document -- which a render that nested the
+			// setting under the wrong connection, under children{}, or after an
+			// unbalanced brace would satisfy just as well.
+			conn := parseSwanctlDoc(t, m.generateConfig(cfg)).at(t, "connections", "tun")
+
+			if got := conn.setting(t, "remote_addrs"); got != c.wantRemote {
+				t.Errorf("connections.tun.remote_addrs = %q, want %q", got, c.wantRemote)
 			}
-			if c.wantLocal != "" && !strings.Contains(got, c.wantLocal) {
-				t.Fatalf("rendered config missing %q:\n%s", c.wantLocal, got)
+			if c.wantLocal == "" {
+				// No local-address configured: the setting must be ABSENT, not
+				// merely un-searched-for. Containment could not express this.
+				conn.hasNoSetting(t, "local_addrs")
+			} else if got := conn.setting(t, "local_addrs"); got != c.wantLocal {
+				t.Errorf("connections.tun.local_addrs = %q, want %q", got, c.wantLocal)
 			}
+
+			// The addresses belong to the CONNECTION, not to its auth rounds or
+			// its child SA -- the misnesting class this issue was filed over.
+			conn.at(t, "local").hasNoSetting(t, "remote_addrs")
+			conn.at(t, "remote").hasNoSetting(t, "remote_addrs")
+			conn.at(t, "children", "tun").hasNoSetting(t, "remote_addrs")
 		})
 	}
 }

--- a/pkg/ipsec/ike_chain_failclosed_test.go
+++ b/pkg/ipsec/ike_chain_failclosed_test.go
@@ -121,29 +121,27 @@ func TestRenderConfig_BrokenChainSkipsVPN_HealthyTunnelSurvives(t *testing.T) {
 	m := New()
 	out := m.generateConfig(cfg)
 
-	// Healthy tunnel: connection block present, with a non-empty Phase-1
-	// proposals line carrying the configured crypto. Match the four-space-
-	// indented connection-level "\n    proposals = aes256" specifically:
-	// a bare substring "proposals = aes256" would FALSE-PASS off the child
-	// "        esp_proposals = aes256..." line even if the Phase-1
-	// "    proposals = " line were missing (mirror of the negative guard in
-	// TestRenderConfig_NoPolicyGatewayRendersWithoutProposalsLine).
-	if !strings.Contains(out, "tun-good {") {
-		t.Errorf("healthy tunnel tun-good missing from render:\n%s", out)
-	}
-	if !strings.Contains(out, "\n    proposals = aes256") {
-		t.Errorf("healthy tunnel missing a non-empty Phase-1 proposals line:\n%s", out)
+	doc := parseSwanctlDoc(t, out)
+
+	// Healthy tunnel: connection section present, with a non-empty Phase-1
+	// proposals line carrying the configured crypto.
+	//
+	// #6824: this previously had to match the four-space-indented
+	// "\n    proposals = aes256" to avoid FALSE-PASSING off the child
+	// "        esp_proposals = aes256..." line -- an assertion about
+	// INDENTATION standing in for one about nesting. Reading the setting at
+	// connections.tun-good states it directly, and the child section's
+	// esp_proposals cannot satisfy it at any indentation.
+	good := doc.at(t, "connections", "tun-good")
+	if p := good.setting(t, "proposals"); !strings.HasPrefix(p, "aes256") {
+		t.Errorf("connections.tun-good.proposals = %q, want it to carry aes256", p)
 	}
 
-	// Broken tunnel: connection block must NOT be emitted (no proposal-less
+	// Broken tunnel: connection section must NOT be emitted (no proposal-less
 	// connection that would negotiate with strongSwan defaults).
-	if strings.Contains(out, "tun-bad {") {
-		t.Errorf("broken-chain tunnel tun-bad was rendered; it must be skipped:\n%s", out)
-	}
+	doc.at(t, "connections").hasNoChild(t, "tun-bad")
 	// And its secret must not be orphaned in the secrets block.
-	if strings.Contains(out, "ike-tun-bad {") {
-		t.Errorf("broken-chain tunnel tun-bad secret was emitted; must be skipped:\n%s", out)
-	}
+	doc.at(t, "secrets").hasNoChild(t, "ike-tun-bad")
 }
 
 // A no-policy gateway renders a normal connection WITHOUT a proposals line
@@ -159,13 +157,18 @@ func TestRenderConfig_NoPolicyGatewayRendersWithoutProposalsLine(t *testing.T) {
 	}
 	m := New()
 	out := m.generateConfig(cfg)
-	if !strings.Contains(out, "tun1 {") {
-		t.Errorf("no-policy tunnel tun1 missing from render:\n%s", out)
-	}
-	// The IKE-level (Phase 1) proposals line is intentionally absent. Guard
-	// against the connection-level "    proposals = " (four-space indent),
-	// distinct from the child "        esp_proposals = " line.
-	if strings.Contains(out, "\n    proposals = ") {
-		t.Errorf("no-policy tunnel must not emit an IKE proposals line:\n%s", out)
+	conn := parseSwanctlDoc(t, out).at(t, "connections", "tun1")
+	// The IKE-level (Phase 1) proposals line is intentionally absent.
+	//
+	// #6824: the guard used to be spelled as the four-space-indented
+	// "\n    proposals = " to keep it from matching the child section's
+	// "        esp_proposals = " line. Asking whether THIS section declares
+	// the key removes the dependence on the renderer's indentation, and stays
+	// correct if the indent ever changes.
+	conn.hasNoSetting(t, "proposals")
+	// The child SA still carries its own esp_proposals; the absence above is
+	// about Phase 1 only, and this pins that the two are not confused.
+	if len(conn.children) == 0 {
+		t.Errorf("no-policy tunnel rendered no child section at all:\n%s", conn)
 	}
 }

--- a/pkg/ipsec/ike_chain_failclosed_test.go
+++ b/pkg/ipsec/ike_chain_failclosed_test.go
@@ -168,7 +168,14 @@ func TestRenderConfig_NoPolicyGatewayRendersWithoutProposalsLine(t *testing.T) {
 	conn.hasNoSetting(t, "proposals")
 	// The child SA still carries its own esp_proposals; the absence above is
 	// about Phase 1 only, and this pins that the two are not confused.
-	if len(conn.children) == 0 {
-		t.Errorf("no-policy tunnel rendered no child section at all:\n%s", conn)
+	//
+	// `len(conn.children) == 0` was VACUOUS here: conn.children holds local,
+	// remote AND children, so it is non-empty even when the children{} block
+	// carries no child SA at all, and stays non-empty if that block disappears.
+	// The claim is about the child SAs, so resolve children{} and count THOSE.
+	kids := conn.at(t, "children")
+	if len(kids.order) == 0 {
+		t.Errorf("no-policy tunnel rendered a children{} block with no child SA:\n%s", kids)
 	}
+	kids.at(t, kids.order[0]).setting(t, "esp_proposals")
 }

--- a/pkg/ipsec/ike_proposals_multivalue_3904_test.go
+++ b/pkg/ipsec/ike_proposals_multivalue_3904_test.go
@@ -1,7 +1,6 @@
 package ipsec
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -45,15 +44,13 @@ func TestGenerateConfig_MultiIKEProposals(t *testing.T) {
 			"esp-a": {Name: "esp-a", EncryptionAlg: "aes-256-cbc", AuthAlg: "hmac-sha-256", DHGroup: 14},
 		},
 	}
-	got := m.generateConfig(cfg)
-	want := "proposals = aes256-sha256-modp2048,aes128-sha256-modp1536"
-	if !strings.Contains(got, want) {
-		t.Errorf("expected both IKE proposals comma-joined (%q), got:\n%s", want, got)
-	}
-	// The second proposal alone would be dropped by the pre-#3904 scalar read.
-	if !strings.Contains(got, "aes128-sha256-modp1536") {
-		t.Errorf("second IKE proposal missing from swanctl output (crypto narrowing):\n%s", got)
-	}
+	// #6824: equality at connections.tun1.proposals subsumes both old checks.
+	// The second needle existed because containment on the joined string could
+	// not say the join was the WHOLE value -- an exact match at a known path
+	// says it, and additionally rejects a third proposal silently appearing.
+	parseSwanctlDoc(t, m.generateConfig(cfg)).
+		at(t, "connections", "tun1").
+		requireSetting(t, "proposals", "aes256-sha256-modp2048,aes128-sha256-modp1536")
 }
 
 // TestGenerateConfig_MultiESPProposals asserts both ESP proposals in a
@@ -72,14 +69,10 @@ func TestGenerateConfig_MultiESPProposals(t *testing.T) {
 			"esp-b": {Name: "esp-b", EncryptionAlg: "aes-128-cbc", AuthAlg: "hmac-sha-256", DHGroup: 5},
 		},
 	}
-	got := m.generateConfig(cfg)
-	want := "esp_proposals = aes256-sha256-modp2048,aes128-sha256-modp1536"
-	if !strings.Contains(got, want) {
-		t.Errorf("expected both ESP proposals comma-joined (%q), got:\n%s", want, got)
-	}
-	if !strings.Contains(got, "aes128-sha256-modp1536") {
-		t.Errorf("second ESP proposal missing from swanctl output (crypto narrowing):\n%s", got)
-	}
+	// #6824: the ESP proposals belong to the CHILD SA, not the connection --
+	// a distinction containment could not draw.
+	childSA_3904(t, m.generateConfig(cfg), "tun1").
+		requireSetting(t, "esp_proposals", "aes256-sha256-modp2048,aes128-sha256-modp1536")
 }
 
 // TestGenerateConfig_MultiESPProposalsPFS asserts the policy-level PFS group
@@ -99,9 +92,20 @@ func TestGenerateConfig_MultiESPProposalsPFS(t *testing.T) {
 			"esp-b": {Name: "esp-b", EncryptionAlg: "aes-128-cbc", AuthAlg: "hmac-sha-256"},
 		},
 	}
-	got := m.generateConfig(cfg)
-	want := "esp_proposals = aes256-sha256-ecp256,aes128-sha256-ecp256"
-	if !strings.Contains(got, want) {
-		t.Errorf("expected PFS group applied to both ESP proposals (%q), got:\n%s", want, got)
+	childSA_3904(t, m.generateConfig(cfg), "tun1").
+		requireSetting(t, "esp_proposals", "aes256-sha256-ecp256,aes128-sha256-ecp256")
+}
+
+// childSA_3904 resolves the single child-SA section of a connection, failing if
+// the render produced anything other than exactly one. "Exactly one" is itself
+// part of the claim: a second child section would carry its own esp_proposals,
+// and a containment assertion could not tell which one it had matched.
+func childSA_3904(t *testing.T, doc, conn string) *swanctlNode {
+	t.Helper()
+	kids := parseSwanctlDoc(t, doc).at(t, "connections", conn, "children")
+	if len(kids.order) != 1 {
+		t.Fatalf("connection %q rendered %d child SA sections (%v), want exactly 1\n%s",
+			conn, len(kids.order), kids.childNames(), kids)
 	}
+	return kids.at(t, kids.order[0])
 }

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -99,7 +99,7 @@ func TestGenerateConfig_GCMNoAuth(t *testing.T) {
 	// -- so that half is restored as a document-wide absence.
 	got := m.generateConfig(cfg)
 	childSA_3904(t, got, "tun1").requireSetting(t, "esp_proposals", "aes256gcm128-modp2048")
-	parseSwanctlDoc(t, got).hasNoSettingValueAnywhere(t, "esp_proposals", "aes256-sha256-modp2048")
+	parseSwanctlDoc(t, got).hasNoValueSubstringAnywhere(t, "sha256-modp2048")
 }
 
 func TestXfrmiIfID(t *testing.T) {
@@ -310,7 +310,7 @@ func TestGenerateConfig_DanglingProposalNoPFSFailsClosed(t *testing.T) {
 	// `default` appearing under another connection.
 	got := m.generateConfig(cfg)
 	childSA_3904(t, got, "tun1").requireSetting(t, "esp_proposals", "aes256-sha256")
-	parseSwanctlDoc(t, got).hasNoSettingValueAnywhere(t, "esp_proposals", "default")
+	parseSwanctlDoc(t, got).hasNoSettingValuePrefixAnywhere(t, "esp_proposals", "default")
 }
 
 // TestResolveESPSettings_NoPolicyStaysDefault is the (D) regression: a VPN
@@ -345,7 +345,7 @@ func TestGenerateConfig_DanglingProposalPreservesPFS(t *testing.T) {
 	got := m.generateConfig(cfg)
 	childSA_3904(t, got, "tun1").requireSetting(t, "esp_proposals", "aes256-sha256-modp2048")
 	// PFS must not have silently dropped to the default set ANYWHERE.
-	parseSwanctlDoc(t, got).hasNoSettingValueAnywhere(t, "esp_proposals", "default")
+	parseSwanctlDoc(t, got).hasNoSettingValuePrefixAnywhere(t, "esp_proposals", "default")
 }
 
 // readSAFixture loads a captured `swanctl --list-sas` golden fixture. The
@@ -787,9 +787,11 @@ func TestGenerateConfig_NATTraversal_Disable(t *testing.T) {
 			"tun": {Gateway: "gw", PSK: "key"},
 		},
 	}
-	conn := parseSwanctlDoc(t, m.generateConfig(cfg)).at(t, "connections", "tun")
-	conn.requireSetting(t, "encap", "no")
-	conn.hasNoSetting(t, "forceencaps")
+	doc := parseSwanctlDoc(t, m.generateConfig(cfg))
+	doc.at(t, "connections", "tun").requireSetting(t, "encap", "no")
+	// Document-wide, as the deleted needle was: a SIBLING connection carrying
+	// forceencaps would have failed the old check and passes a path-scoped one.
+	doc.hasNoSettingAnywhere(t, "forceencaps")
 }
 
 func TestGenerateConfig_NATTraversal_Force(t *testing.T) {
@@ -967,7 +969,16 @@ func TestGenerateConfig_DFBit(t *testing.T) {
 				},
 			}
 			// copy_df is a CHILD SA setting; the old needles found it anywhere.
-			child := childSA_3904(t, m.generateConfig(cfg), "tun")
+			rendered := m.generateConfig(cfg)
+			child := childSA_3904(t, rendered, "tun")
+			// The deleted notWant column rejected the OPPOSITE value anywhere in
+			// the document, not merely at this path. Equality below pins what
+			// must be here; this pins that the other value is nowhere.
+			opposite := map[string]string{"yes": "no", "no": "yes"}[tt.want]
+			if opposite != "" {
+				parseSwanctlDoc(t, rendered).
+					hasNoSettingValuePrefixAnywhere(t, "copy_df", opposite)
+			}
 			if tt.want == "" {
 				// Document-wide: the old notWant column asked whether the token
 				// appeared at all, and narrowing that to the child SA would let

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -93,11 +93,13 @@ func TestGenerateConfig_GCMNoAuth(t *testing.T) {
 	// for an AEAD cipher (the caller takes the gcmPRF branch, not
 	// normalizeAuthAlg), so the strongSwan integrity keyword must be absent.
 	//
-	// #6824: an exact match subsumes the separate absence needle -- a value
-	// carrying an integrity token cannot equal aes256gcm128-modp2048 -- and
-	// unlike that needle it is not satisfied by the Phase-1 line.
-	childSA_3904(t, m.generateConfig(cfg), "tun1").
-		requireSetting(t, "esp_proposals", "aes256gcm128-modp2048")
+	// #6824: equality at the child SA pins the value that MUST be there. The
+	// original also claimed the integrity token appears NOWHERE, which equality
+	// at one path does NOT subsume -- nothing stops another section carrying it
+	// -- so that half is restored as a document-wide absence.
+	got := m.generateConfig(cfg)
+	childSA_3904(t, got, "tun1").requireSetting(t, "esp_proposals", "aes256gcm128-modp2048")
+	parseSwanctlDoc(t, got).hasNoSettingValueAnywhere(t, "esp_proposals", "aes256-sha256-modp2048")
 }
 
 func TestXfrmiIfID(t *testing.T) {
@@ -302,10 +304,13 @@ func TestGenerateConfig_DanglingProposalNoPFSFailsClosed(t *testing.T) {
 			"ipsec-pol": {Name: "ipsec-pol", PFSGroup: 0, Proposals: []string{"does-not-exist"}},
 		},
 	}
-	// #6824: an exact match subsumes the "not default" needle, and replaces a
-	// trailing "\n" that was standing in for "the value ends here".
-	childSA_3904(t, m.generateConfig(cfg), "tun1").
-		requireSetting(t, "esp_proposals", "aes256-sha256")
+	// #6824: equality replaces a trailing "\n" that stood in for "the value
+	// ends here". The "not esp_proposals = default" half is a DOCUMENT-WIDE
+	// claim and is kept as one: equality at this path says nothing about a
+	// `default` appearing under another connection.
+	got := m.generateConfig(cfg)
+	childSA_3904(t, got, "tun1").requireSetting(t, "esp_proposals", "aes256-sha256")
+	parseSwanctlDoc(t, got).hasNoSettingValueAnywhere(t, "esp_proposals", "default")
 }
 
 // TestResolveESPSettings_NoPolicyStaysDefault is the (D) regression: a VPN
@@ -337,8 +342,10 @@ func TestGenerateConfig_DanglingProposalPreservesPFS(t *testing.T) {
 			"ipsec-pol": {Name: "ipsec-pol", PFSGroup: 14, Proposals: []string{"does-not-exist"}},
 		},
 	}
-	childSA_3904(t, m.generateConfig(cfg), "tun1").
-		requireSetting(t, "esp_proposals", "aes256-sha256-modp2048")
+	got := m.generateConfig(cfg)
+	childSA_3904(t, got, "tun1").requireSetting(t, "esp_proposals", "aes256-sha256-modp2048")
+	// PFS must not have silently dropped to the default set ANYWHERE.
+	parseSwanctlDoc(t, got).hasNoSettingValueAnywhere(t, "esp_proposals", "default")
 }
 
 // readSAFixture loads a captured `swanctl --list-sas` golden fixture. The
@@ -817,9 +824,13 @@ func TestGenerateConfig_NATTraversal_Enable(t *testing.T) {
 	// #6824: the old `encap = no` needle was value-specific, so a render that
 	// emitted `encap = yes` (also wrong here -- nothing should be emitted)
 	// passed. Absence of the KEY is the actual claim.
-	conn := parseSwanctlDoc(t, m.generateConfig(cfg)).at(t, "connections", "tun")
-	conn.hasNoSetting(t, "encap")
-	conn.hasNoSetting(t, "forceencaps")
+	// Document-wide, as the original needles were. Scoping an absence to one
+	// path is a weaker claim than the one being replaced, even when the fixture
+	// renders a single connection today.
+	doc := parseSwanctlDoc(t, m.generateConfig(cfg))
+	doc.at(t, "connections", "tun")
+	doc.hasNoSettingAnywhere(t, "encap")
+	doc.hasNoSettingAnywhere(t, "forceencaps")
 }
 
 func TestGenerateConfig_NATTraversal_Default(t *testing.T) {
@@ -837,9 +848,10 @@ func TestGenerateConfig_NATTraversal_Default(t *testing.T) {
 	}
 	// #6824: `Contains(got, "encap")` also matched `forceencaps`, so this
 	// could never distinguish the two keys. Assert both absences explicitly.
-	conn := parseSwanctlDoc(t, m.generateConfig(cfg)).at(t, "connections", "tun")
-	conn.hasNoSetting(t, "encap")
-	conn.hasNoSetting(t, "forceencaps")
+	doc := parseSwanctlDoc(t, m.generateConfig(cfg))
+	doc.at(t, "connections", "tun")
+	doc.hasNoSettingAnywhere(t, "encap")
+	doc.hasNoSettingAnywhere(t, "forceencaps")
 }
 
 func TestGenerateConfig_NoNATTraversal_Legacy(t *testing.T) {
@@ -921,9 +933,9 @@ func TestGenerateConfig_AggressiveMode_NotSet(t *testing.T) {
 			"tun": {Gateway: "gw"},
 		},
 	}
-	parseSwanctlDoc(t, m.generateConfig(cfg)).
-		at(t, "connections", "tun").
-		hasNoSetting(t, "aggressive")
+	doc := parseSwanctlDoc(t, m.generateConfig(cfg))
+	doc.at(t, "connections", "tun")
+	doc.hasNoSettingAnywhere(t, "aggressive")
 }
 
 func TestGenerateConfig_DFBit(t *testing.T) {
@@ -957,7 +969,10 @@ func TestGenerateConfig_DFBit(t *testing.T) {
 			// copy_df is a CHILD SA setting; the old needles found it anywhere.
 			child := childSA_3904(t, m.generateConfig(cfg), "tun")
 			if tt.want == "" {
-				child.hasNoSetting(t, "copy_df")
+				// Document-wide: the old notWant column asked whether the token
+				// appeared at all, and narrowing that to the child SA would let
+				// a stray copy_df elsewhere through.
+				parseSwanctlDoc(t, m.generateConfig(cfg)).hasNoSettingAnywhere(t, "copy_df")
 				return
 			}
 			child.requireSetting(t, "copy_df", tt.want)
@@ -978,7 +993,9 @@ func TestGenerateConfig_EstablishTunnels(t *testing.T) {
 
 	// on-traffic should NOT produce start_action
 	cfg.VPNs["tun"].EstablishTunnels = "on-traffic"
-	childSA_3904(t, m.generateConfig(cfg), "tun").hasNoSetting(t, "start_action")
+	offDoc := m.generateConfig(cfg)
+	childSA_3904(t, offDoc, "tun")
+	parseSwanctlDoc(t, offDoc).hasNoSettingAnywhere(t, "start_action")
 }
 
 func TestGenerateConfig_IKELifetime(t *testing.T) {
@@ -1131,7 +1148,9 @@ func TestGenerateConfig_DPDBareAndTuningForms(t *testing.T) {
 
 	t.Run("no DPD stanza emits no dpd", func(t *testing.T) {
 		out := m.generateConfig(compileFromSet(t, base))
-		parseSwanctlDoc(t, out).at(t, "connections", "tun1").hasNoSetting(t, "dpd_delay")
+		doc := parseSwanctlDoc(t, out)
+		doc.at(t, "connections", "tun1")
+		doc.hasNoSettingAnywhere(t, "dpd_delay")
 	})
 }
 

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -25,34 +25,28 @@ func TestGenerateConfig_Basic(t *testing.T) {
 		},
 		Proposals: map[string]*config.IPsecProposal{},
 	}
-	got := m.generateConfig(cfg)
-	if !strings.Contains(got, "connections {") {
-		t.Error("missing connections block")
+	// #6824: read the settings at their paths. The old block asserted nine
+	// substrings against the whole document, which said nothing about where
+	// any of them landed -- and `auth = psk` in particular is emitted in BOTH
+	// the local{} and remote{} rounds, so a render that emitted it in neither
+	// the right one nor both was indistinguishable from a correct one.
+	doc := parseSwanctlDoc(t, m.generateConfig(cfg))
+	conn := doc.at(t, "connections", "site-a")
+	conn.requireSetting(t, "local_addrs", "10.0.1.1")
+	conn.requireSetting(t, "remote_addrs", "10.0.2.1")
+	conn.at(t, "local").requireSetting(t, "auth", "psk")
+	conn.at(t, "remote").requireSetting(t, "auth", "psk")
+	// The xfrmi interface ids belong to the CHILD SA, not the connection --
+	// a placement the old whole-document needles could not express, and would
+	// have accepted either way.
+	kids := conn.at(t, "children")
+	if len(kids.order) != 1 {
+		t.Fatalf("expected exactly one child SA, got %v\n%s", kids.childNames(), kids)
 	}
-	if !strings.Contains(got, "site-a {") {
-		t.Error("missing connection name")
-	}
-	if !strings.Contains(got, "local_addrs = 10.0.1.1") {
-		t.Error("missing local_addrs")
-	}
-	if !strings.Contains(got, "remote_addrs = 10.0.2.1") {
-		t.Error("missing remote_addrs")
-	}
-	if !strings.Contains(got, "auth = psk") {
-		t.Error("missing auth = psk")
-	}
-	if !strings.Contains(got, "if_id_in = 1") {
-		t.Error("missing if_id_in for st0.0")
-	}
-	if !strings.Contains(got, "if_id_out = 1") {
-		t.Error("missing if_id_out for st0.0")
-	}
-	if !strings.Contains(got, "secrets {") {
-		t.Error("missing secrets block")
-	}
-	if !strings.Contains(got, `secret = "supersecret"`) {
-		t.Error("missing PSK secret")
-	}
+	child := kids.at(t, kids.order[0])
+	child.requireSetting(t, "if_id_in", "1")
+	child.requireSetting(t, "if_id_out", "1")
+	doc.at(t, "secrets", "ike-site-a").requireSetting(t, "secret", `"supersecret"`)
 }
 
 func TestGenerateConfig_WithProposal(t *testing.T) {
@@ -73,10 +67,8 @@ func TestGenerateConfig_WithProposal(t *testing.T) {
 			},
 		},
 	}
-	got := m.generateConfig(cfg)
-	if !strings.Contains(got, "esp_proposals = aes256-sha256-modp2048") {
-		t.Errorf("unexpected esp_proposals in: %s", got)
-	}
+	childSA_3904(t, m.generateConfig(cfg), "tun1").
+		requireSetting(t, "esp_proposals", "aes256-sha256-modp2048")
 }
 
 func TestGenerateConfig_GCMNoAuth(t *testing.T) {
@@ -97,16 +89,15 @@ func TestGenerateConfig_GCMNoAuth(t *testing.T) {
 			},
 		},
 	}
-	got := m.generateConfig(cfg)
 	// GCM mode should skip auth algorithm — no integrity token is emitted
 	// for an AEAD cipher (the caller takes the gcmPRF branch, not
 	// normalizeAuthAlg), so the strongSwan integrity keyword must be absent.
-	if strings.Contains(got, "sha256-modp2048") {
-		t.Errorf("GCM should not include auth alg: %s", got)
-	}
-	if !strings.Contains(got, "esp_proposals = aes256gcm128-modp2048") {
-		t.Errorf("unexpected GCM proposal: %s", got)
-	}
+	//
+	// #6824: an exact match subsumes the separate absence needle -- a value
+	// carrying an integrity token cannot equal aes256gcm128-modp2048 -- and
+	// unlike that needle it is not satisfied by the Phase-1 line.
+	childSA_3904(t, m.generateConfig(cfg), "tun1").
+		requireSetting(t, "esp_proposals", "aes256gcm128-modp2048")
 }
 
 func TestXfrmiIfID(t *testing.T) {
@@ -311,13 +302,10 @@ func TestGenerateConfig_DanglingProposalNoPFSFailsClosed(t *testing.T) {
 			"ipsec-pol": {Name: "ipsec-pol", PFSGroup: 0, Proposals: []string{"does-not-exist"}},
 		},
 	}
-	got := m.generateConfig(cfg)
-	if strings.Contains(got, "esp_proposals = default") {
-		t.Errorf("dangling ESP ref silently downgraded to esp_proposals = default:\n%s", got)
-	}
-	if !strings.Contains(got, "esp_proposals = aes256-sha256\n") {
-		t.Errorf("expected conservative fixed esp_proposals = aes256-sha256, got:\n%s", got)
-	}
+	// #6824: an exact match subsumes the "not default" needle, and replaces a
+	// trailing "\n" that was standing in for "the value ends here".
+	childSA_3904(t, m.generateConfig(cfg), "tun1").
+		requireSetting(t, "esp_proposals", "aes256-sha256")
 }
 
 // TestResolveESPSettings_NoPolicyStaysDefault is the (D) regression: a VPN
@@ -349,13 +337,8 @@ func TestGenerateConfig_DanglingProposalPreservesPFS(t *testing.T) {
 			"ipsec-pol": {Name: "ipsec-pol", PFSGroup: 14, Proposals: []string{"does-not-exist"}},
 		},
 	}
-	got := m.generateConfig(cfg)
-	if !strings.Contains(got, "esp_proposals = aes256-sha256-modp2048") {
-		t.Errorf("rendered config dropped PFS or used the default set:\n%s", got)
-	}
-	if strings.Contains(got, "esp_proposals = default") {
-		t.Errorf("PFS silently dropped to esp_proposals = default:\n%s", got)
-	}
+	childSA_3904(t, m.generateConfig(cfg), "tun1").
+		requireSetting(t, "esp_proposals", "aes256-sha256-modp2048")
 }
 
 // readSAFixture loads a captured `swanctl --list-sas` golden fixture. The
@@ -526,21 +509,17 @@ func TestGenerateConfig_GatewayReference(t *testing.T) {
 	got := m.generateConfig(cfg)
 
 	// Should resolve gateway address, not use "remote-gw" as IP
-	if !strings.Contains(got, "remote_addrs = 10.0.2.1") {
-		t.Errorf("gateway address not resolved: %s", got)
-	}
-	// Should use gateway's local address
-	if !strings.Contains(got, "local_addrs = 10.0.1.1") {
-		t.Errorf("gateway local address not resolved: %s", got)
-	}
-	// Should have IKE proposals from gateway's ike-policy
-	if !strings.Contains(got, "proposals = aes256-sha256-modp2048") {
-		t.Errorf("IKE proposals not generated: %s", got)
-	}
-	// Should have ESP proposals from VPN's ipsec-policy
-	if !strings.Contains(got, "esp_proposals = aes256-sha256-modp2048") {
-		t.Errorf("ESP proposals not generated: %s", got)
-	}
+	// #6824: `proposals = ...` is the Phase-1 offer on the connection and
+	// `esp_proposals = ...` the Phase-2 offer on the child SA. The old
+	// Contains(got, "proposals = aes256-sha256-modp2048") needle matched the
+	// esp_proposals line too, so the IKE assertion passed even with the
+	// Phase-1 line missing entirely.
+	conn := parseSwanctlDoc(t, got).at(t, "connections", "site-a")
+	conn.requireSetting(t, "remote_addrs", "10.0.2.1")
+	conn.requireSetting(t, "local_addrs", "10.0.1.1")
+	conn.requireSetting(t, "proposals", "aes256-sha256-modp2048")
+	childSA_3904(t, got, "site-a").
+		requireSetting(t, "esp_proposals", "aes256-sha256-modp2048")
 }
 
 func TestGenerateConfig_DirectGatewayIP(t *testing.T) {
@@ -557,13 +536,9 @@ func TestGenerateConfig_DirectGatewayIP(t *testing.T) {
 			},
 		},
 	}
-	got := m.generateConfig(cfg)
-	if !strings.Contains(got, "remote_addrs = 172.16.0.1") {
-		t.Errorf("direct gateway IP not used: %s", got)
-	}
-	if !strings.Contains(got, "local_addrs = 172.16.0.2") {
-		t.Errorf("direct local addr not used: %s", got)
-	}
+	conn := parseSwanctlDoc(t, m.generateConfig(cfg)).at(t, "connections", "direct")
+	conn.requireSetting(t, "remote_addrs", "172.16.0.1")
+	conn.requireSetting(t, "local_addrs", "172.16.0.2")
 }
 
 func TestBuildIKEProposal(t *testing.T) {
@@ -693,30 +668,47 @@ func TestGenerateConfig_IKEChain(t *testing.T) {
 	}
 	got := m.generateConfig(cfg)
 
+	// #6824: each expectation now names the PATH it must sit at. The old table
+	// asserted fifteen substrings against the whole document, and two of its
+	// rows -- "local identity" and "remote identity" -- would both have passed
+	// with the two identities SWAPPED, because `id` is emitted in both auth
+	// rounds and containment cannot say which round it matched. Two more rows
+	// were mutually satisfiable: "IKE proposal" looked for
+	// `proposals = aes256-sha256-modp2048`, which is a substring of the
+	// esp_proposals line, so it passed with the Phase-1 offer missing.
+	doc := parseSwanctlDoc(t, got)
+	kids := doc.at(t, "connections", "site-a", "children")
+	if len(kids.order) != 1 {
+		t.Fatalf("expected exactly one child SA, got %v\n%s", kids.childNames(), kids)
+	}
+	childName := kids.order[0]
+
 	checks := []struct {
 		name string
+		path []string
+		key  string
 		want string
 	}{
-		{"IKE version", "version = 2"},
-		{"local addr", "local_addrs = 198.51.100.1"},
-		{"remote addr", "remote_addrs = 203.0.113.1"},
-		{"no NAT-T", "encap = no"},
-		{"DPD", "dpd_delay = 10s"},
-		{"DPD timeout", "dpd_timeout = 50s"},
-		{"local identity", `id = "@vpn.example.com"`},
-		{"remote identity", `id = "203.0.113.1"`},
-		{"IKE proposal", "proposals = aes256-sha256-modp2048"},
-		{"ESP proposal", "esp_proposals = aes256-sha256-modp2048"},
-		{"copy DF", "copy_df = yes"},
-		{"start action", "start_action = start"},
-		{"DPD action", "dpd_action = restart"},
-		{"XFRM if_id", "if_id_in = 1"},
-		{"PSK from IKE policy", `secret = "secret123"`},
+		{"IKE version", []string{"connections", "site-a"}, "version", "2"},
+		{"local addr", []string{"connections", "site-a"}, "local_addrs", "198.51.100.1"},
+		{"remote addr", []string{"connections", "site-a"}, "remote_addrs", "203.0.113.1"},
+		{"no NAT-T", []string{"connections", "site-a"}, "encap", "no"},
+		{"DPD", []string{"connections", "site-a"}, "dpd_delay", "10s"},
+		{"DPD timeout", []string{"connections", "site-a"}, "dpd_timeout", "50s"},
+		{"local identity", []string{"connections", "site-a", "local"}, "id", `"@vpn.example.com"`},
+		{"remote identity", []string{"connections", "site-a", "remote"}, "id", `"203.0.113.1"`},
+		{"IKE proposal", []string{"connections", "site-a"}, "proposals", "aes256-sha256-modp2048"},
+		{"ESP proposal", []string{"connections", "site-a", "children", childName}, "esp_proposals", "aes256-sha256-modp2048"},
+		{"copy DF", []string{"connections", "site-a", "children", childName}, "copy_df", "yes"},
+		{"start action", []string{"connections", "site-a", "children", childName}, "start_action", "start"},
+		{"DPD action", []string{"connections", "site-a", "children", childName}, "dpd_action", "restart"},
+		{"XFRM if_id", []string{"connections", "site-a", "children", childName}, "if_id_in", "1"},
+		{"PSK from IKE policy", []string{"secrets", "ike-site-a"}, "secret", `"secret123"`},
 	}
 	for _, c := range checks {
-		if !strings.Contains(got, c.want) {
-			t.Errorf("%s: missing %q in:\n%s", c.name, c.want, got)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			doc.at(t, c.path...).requireSetting(t, c.key, c.want)
+		})
 	}
 }
 
@@ -749,15 +741,15 @@ func TestGenerateConfig_DynamicHostname(t *testing.T) {
 		},
 	}
 	got := m.generateConfig(cfg)
-	if !strings.Contains(got, "remote_addrs = peer.example.com") {
-		t.Errorf("dynamic hostname not used as remote_addrs: %s", got)
-	}
-	if !strings.Contains(got, "version = 2") {
-		t.Errorf("version not set: %s", got)
-	}
-	if !strings.Contains(got, "if_id_in = 2") || !strings.Contains(got, "if_id_out = 2") {
-		t.Errorf("expected st0.1 to map to if_id 2: %s", got)
-	}
+	conn := parseSwanctlDoc(t, got).at(t, "connections", "tun1")
+	conn.requireSetting(t, "remote_addrs", "peer.example.com")
+	conn.requireSetting(t, "version", "2")
+	// The xfrmi ids belong to the child SA. The old needles found them
+	// anywhere in the document, so a render that emitted them on the
+	// CONNECTION -- where charon would ignore them -- passed identically.
+	child := childSA_3904(t, got, "tun1")
+	child.requireSetting(t, "if_id_in", "2")
+	child.requireSetting(t, "if_id_out", "2")
 }
 
 func TestFormatIdentity(t *testing.T) {
@@ -788,13 +780,9 @@ func TestGenerateConfig_NATTraversal_Disable(t *testing.T) {
 			"tun": {Gateway: "gw", PSK: "key"},
 		},
 	}
-	got := m.generateConfig(cfg)
-	if !strings.Contains(got, "encap = no") {
-		t.Errorf("disable NAT-T should produce 'encap = no': %s", got)
-	}
-	if strings.Contains(got, "forceencaps") {
-		t.Errorf("disable NAT-T should not have forceencaps: %s", got)
-	}
+	conn := parseSwanctlDoc(t, m.generateConfig(cfg)).at(t, "connections", "tun")
+	conn.requireSetting(t, "encap", "no")
+	conn.hasNoSetting(t, "forceencaps")
 }
 
 func TestGenerateConfig_NATTraversal_Force(t *testing.T) {
@@ -808,13 +796,9 @@ func TestGenerateConfig_NATTraversal_Force(t *testing.T) {
 			"tun": {Gateway: "gw", PSK: "key"},
 		},
 	}
-	got := m.generateConfig(cfg)
-	if !strings.Contains(got, "encap = yes") {
-		t.Errorf("force NAT-T should produce 'encap = yes': %s", got)
-	}
-	if !strings.Contains(got, "forceencaps = yes") {
-		t.Errorf("force NAT-T should produce 'forceencaps = yes': %s", got)
-	}
+	conn := parseSwanctlDoc(t, m.generateConfig(cfg)).at(t, "connections", "tun")
+	conn.requireSetting(t, "encap", "yes")
+	conn.requireSetting(t, "forceencaps", "yes")
 }
 
 func TestGenerateConfig_NATTraversal_Enable(t *testing.T) {
@@ -828,14 +812,14 @@ func TestGenerateConfig_NATTraversal_Enable(t *testing.T) {
 			"tun": {Gateway: "gw", PSK: "key"},
 		},
 	}
-	got := m.generateConfig(cfg)
 	// Enable is the strongSwan default — no encap/forceencaps lines needed.
-	if strings.Contains(got, "encap = no") {
-		t.Errorf("enable NAT-T should not have 'encap = no': %s", got)
-	}
-	if strings.Contains(got, "forceencaps") {
-		t.Errorf("enable NAT-T should not have forceencaps: %s", got)
-	}
+	//
+	// #6824: the old `encap = no` needle was value-specific, so a render that
+	// emitted `encap = yes` (also wrong here -- nothing should be emitted)
+	// passed. Absence of the KEY is the actual claim.
+	conn := parseSwanctlDoc(t, m.generateConfig(cfg)).at(t, "connections", "tun")
+	conn.hasNoSetting(t, "encap")
+	conn.hasNoSetting(t, "forceencaps")
 }
 
 func TestGenerateConfig_NATTraversal_Default(t *testing.T) {
@@ -851,10 +835,11 @@ func TestGenerateConfig_NATTraversal_Default(t *testing.T) {
 			"tun": {Gateway: "gw", PSK: "key"},
 		},
 	}
-	got := m.generateConfig(cfg)
-	if strings.Contains(got, "encap") {
-		t.Errorf("default NAT-T should not have encap lines: %s", got)
-	}
+	// #6824: `Contains(got, "encap")` also matched `forceencaps`, so this
+	// could never distinguish the two keys. Assert both absences explicitly.
+	conn := parseSwanctlDoc(t, m.generateConfig(cfg)).at(t, "connections", "tun")
+	conn.hasNoSetting(t, "encap")
+	conn.hasNoSetting(t, "forceencaps")
 }
 
 func TestGenerateConfig_NoNATTraversal_Legacy(t *testing.T) {
@@ -869,10 +854,9 @@ func TestGenerateConfig_NoNATTraversal_Legacy(t *testing.T) {
 			"tun": {Gateway: "gw", PSK: "key"},
 		},
 	}
-	got := m.generateConfig(cfg)
-	if !strings.Contains(got, "encap = no") {
-		t.Errorf("legacy NoNATTraversal should produce 'encap = no': %s", got)
-	}
+	parseSwanctlDoc(t, m.generateConfig(cfg)).
+		at(t, "connections", "tun").
+		requireSetting(t, "encap", "no")
 }
 
 func TestGenerateConfig_AggressiveMode(t *testing.T) {
@@ -904,13 +888,9 @@ func TestGenerateConfig_AggressiveMode(t *testing.T) {
 			"tun": {Gateway: "gw"},
 		},
 	}
-	got := m.generateConfig(cfg)
-	if !strings.Contains(got, "aggressive = yes") {
-		t.Errorf("aggressive mode not set: %s", got)
-	}
-	if !strings.Contains(got, "version = 1") {
-		t.Errorf("IKEv1 not set for aggressive mode: %s", got)
-	}
+	conn := parseSwanctlDoc(t, m.generateConfig(cfg)).at(t, "connections", "tun")
+	conn.requireSetting(t, "aggressive", "yes")
+	conn.requireSetting(t, "version", "1")
 }
 
 func TestGenerateConfig_AggressiveMode_NotSet(t *testing.T) {
@@ -941,28 +921,30 @@ func TestGenerateConfig_AggressiveMode_NotSet(t *testing.T) {
 			"tun": {Gateway: "gw"},
 		},
 	}
-	got := m.generateConfig(cfg)
-	if strings.Contains(got, "aggressive") {
-		t.Errorf("main mode should not have aggressive: %s", got)
-	}
+	parseSwanctlDoc(t, m.generateConfig(cfg)).
+		at(t, "connections", "tun").
+		hasNoSetting(t, "aggressive")
 }
 
 func TestGenerateConfig_DFBit(t *testing.T) {
 	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
 	tests := []struct {
-		name    string
-		dfbit   string
-		want    string
-		notWant string
+		name  string
+		dfbit string
+		// want is the value copy_df must carry; "" means the key must be
+		// ABSENT. #6824 folded away the old notWant column: an exact match on
+		// the setting already rejects the opposite value, and the two columns
+		// could disagree without anything noticing.
+		want string
 	}{
 		// #4015: df-bit set/clear were inverted. strongSwan copy_df=no CLEARS
 		// the outer DF bit, so it must map to Junos "clear" (allow
 		// fragmentation), NOT "set". "set" (and "copy") preserve/copy the DF
 		// bit via copy_df=yes (strongSwan cannot force DF=1).
-		{"copy", "copy", "copy_df = yes", "copy_df = no"},
-		{"set", "set", "copy_df = yes", "copy_df = no"},
-		{"clear", "clear", "copy_df = no", "copy_df = yes"},
-		{"empty", "", "", "copy_df"},
+		{"copy", "copy", "yes"},
+		{"set", "set", "yes"},
+		{"clear", "clear", "no"},
+		{"empty", "", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -972,13 +954,13 @@ func TestGenerateConfig_DFBit(t *testing.T) {
 					"tun": {Gateway: "10.0.0.1", DFBit: tt.dfbit},
 				},
 			}
-			got := m.generateConfig(cfg)
-			if tt.want != "" && !strings.Contains(got, tt.want) {
-				t.Errorf("df-bit %q: missing %q in:\n%s", tt.dfbit, tt.want, got)
+			// copy_df is a CHILD SA setting; the old needles found it anywhere.
+			child := childSA_3904(t, m.generateConfig(cfg), "tun")
+			if tt.want == "" {
+				child.hasNoSetting(t, "copy_df")
+				return
 			}
-			if tt.notWant != "" && strings.Contains(got, tt.notWant) {
-				t.Errorf("df-bit %q: unexpected %q in:\n%s", tt.dfbit, tt.notWant, got)
-			}
+			child.requireSetting(t, "copy_df", tt.want)
 		})
 	}
 }
@@ -991,17 +973,12 @@ func TestGenerateConfig_EstablishTunnels(t *testing.T) {
 			"tun": {Gateway: "10.0.0.1", EstablishTunnels: "immediately"},
 		},
 	}
-	got := m.generateConfig(cfg)
-	if !strings.Contains(got, "start_action = start") {
-		t.Errorf("establish-tunnels immediately should produce start_action: %s", got)
-	}
+	childSA_3904(t, m.generateConfig(cfg), "tun").
+		requireSetting(t, "start_action", "start")
 
 	// on-traffic should NOT produce start_action
 	cfg.VPNs["tun"].EstablishTunnels = "on-traffic"
-	got = m.generateConfig(cfg)
-	if strings.Contains(got, "start_action") {
-		t.Errorf("on-traffic should not produce start_action: %s", got)
-	}
+	childSA_3904(t, m.generateConfig(cfg), "tun").hasNoSetting(t, "start_action")
 }
 
 func TestGenerateConfig_IKELifetime(t *testing.T) {
@@ -1027,13 +1004,12 @@ func TestGenerateConfig_IKELifetime(t *testing.T) {
 			"tun": {Gateway: "gw"},
 		},
 	}
-	got := m.generateConfig(cfg)
-	if !strings.Contains(got, "rekey_time = 28800s") {
-		t.Fatalf("expected IKE rekey_time from lifetime-seconds: %s", got)
-	}
-	if !strings.Contains(got, "rand_time = 0s") {
-		t.Fatalf("expected deterministic IKE rand_time: %s", got)
-	}
+	// #6824: `rekey_time` is emitted on BOTH the IKE connection and the child
+	// SA, so the old needle could be satisfied by the child's line while the
+	// IKE lifetime was missing. Pin the connection.
+	conn := parseSwanctlDoc(t, m.generateConfig(cfg)).at(t, "connections", "tun")
+	conn.requireSetting(t, "rekey_time", "28800s")
+	conn.requireSetting(t, "rand_time", "0s")
 }
 
 func TestGenerateConfig_ESPLifetime(t *testing.T) {
@@ -1054,10 +1030,10 @@ func TestGenerateConfig_ESPLifetime(t *testing.T) {
 			"tun": {Gateway: "203.0.113.1", IPsecPolicy: "ipsec-pol"},
 		},
 	}
-	got := m.generateConfig(cfg)
-	if !strings.Contains(got, "rekey_time = 3600s") {
-		t.Fatalf("expected child rekey_time from ESP lifetime-seconds: %s", got)
-	}
+	// The ESP lifetime is the CHILD's rekey_time -- the mirror of the IKE
+	// case above, and indistinguishable from it under containment.
+	childSA_3904(t, m.generateConfig(cfg), "tun").
+		requireSetting(t, "rekey_time", "3600s")
 }
 
 func TestGenerateConfig_DPDModes(t *testing.T) {
@@ -1076,12 +1052,14 @@ func TestGenerateConfig_DPDModes(t *testing.T) {
 			"tun": {Gateway: "gw", EstablishTunnels: "on-traffic"},
 		},
 	}
-	got := m.generateConfig(cfg)
-	for _, want := range []string{"dpd_delay = 7s", "dpd_timeout = 21s", "dpd_action = trap"} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("missing %q in:\n%s", want, got)
-		}
-	}
+	// dpd_delay/dpd_timeout are IKE-level; dpd_action is on the child SA.
+	// The old loop asserted all three against the whole document, so it could
+	// not have caught any of them landing in the wrong section.
+	doc := parseSwanctlDoc(t, m.generateConfig(cfg))
+	conn := doc.at(t, "connections", "tun")
+	conn.requireSetting(t, "dpd_delay", "7s")
+	conn.requireSetting(t, "dpd_timeout", "21s")
+	childSA_3904(t, m.generateConfig(cfg), "tun").requireSetting(t, "dpd_action", "trap")
 }
 
 // TestGenerateConfig_DPDBareAndTuningForms compiles a full tunnel from flat-set
@@ -1134,32 +1112,26 @@ func TestGenerateConfig_DPDBareAndTuningForms(t *testing.T) {
 
 	t.Run("bare enables DPD with defaults", func(t *testing.T) {
 		out := m.generateConfig(compileFromSet(t, with(`set security ike gateway gw1 dead-peer-detection`)))
-		for _, want := range []string{"dpd_delay = 10s", "dpd_timeout = 50s", "dpd_action = clear"} {
-			if !strings.Contains(out, want) {
-				t.Fatalf("bare dead-peer-detection did not enable DPD (missing %q):\n%s", want, out)
-			}
-		}
+		conn := parseSwanctlDoc(t, out).at(t, "connections", "tun1")
+		conn.requireSetting(t, "dpd_delay", "10s")
+		conn.requireSetting(t, "dpd_timeout", "50s")
+		childSA_3904(t, out, "tun1").requireSetting(t, "dpd_action", "clear")
 	})
 
 	t.Run("interval-only tunes delay", func(t *testing.T) {
 		out := m.generateConfig(compileFromSet(t, with(`set security ike gateway gw1 dead-peer-detection interval 20`)))
-		if !strings.Contains(out, "dpd_delay = 20s") {
-			t.Fatalf("interval-only DPD: want dpd_delay = 20s:\n%s", out)
-		}
+		parseSwanctlDoc(t, out).at(t, "connections", "tun1").
+			requireSetting(t, "dpd_delay", "20s")
 	})
 
 	t.Run("always-send maps to restart", func(t *testing.T) {
 		out := m.generateConfig(compileFromSet(t, with(`set security ike gateway gw1 dead-peer-detection always-send`)))
-		if !strings.Contains(out, "dpd_action = restart") {
-			t.Fatalf("always-send DPD: want dpd_action = restart:\n%s", out)
-		}
+		childSA_3904(t, out, "tun1").requireSetting(t, "dpd_action", "restart")
 	})
 
 	t.Run("no DPD stanza emits no dpd", func(t *testing.T) {
 		out := m.generateConfig(compileFromSet(t, base))
-		if strings.Contains(out, "dpd_delay") {
-			t.Fatalf("no DPD stanza should not emit dpd_delay:\n%s", out)
-		}
+		parseSwanctlDoc(t, out).at(t, "connections", "tun1").hasNoSetting(t, "dpd_delay")
 	})
 }
 
@@ -1174,9 +1146,7 @@ func TestGenerateConfig_JunosObfuscatedPSK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("renderConfig() error = %v", err)
 	}
-	if !strings.Contains(got, `secret = "QZ1agnL21L"`) {
-		t.Fatalf("expected decoded Junos secret, got:\n%s", got)
-	}
+	secretsOnly_6824(t, got).requireSetting(t, "secret", `"QZ1agnL21L"`)
 }
 
 func TestGenerateConfig_PubkeyAuth(t *testing.T) {
@@ -1206,16 +1176,15 @@ func TestGenerateConfig_PubkeyAuth(t *testing.T) {
 			"tun": {Gateway: "gw"},
 		},
 	}
-	got := m.generateConfig(cfg)
-	if !strings.Contains(got, "auth = pubkey") {
-		t.Fatalf("expected pubkey auth, got:\n%s", got)
-	}
-	if !strings.Contains(got, `certs = "gw-cert.pem"`) {
-		t.Fatalf("expected local certificate, got:\n%s", got)
-	}
-	if strings.Contains(got, "secret = ") {
-		t.Fatalf("pubkey auth should not emit PSK secrets:\n%s", got)
-	}
+	// #6824: `auth` and `certs` are emitted in the local{} round. The old
+	// needles matched either round, so a render that put the LOCAL certificate
+	// under remote{} -- where charon reads it as the peer's -- passed.
+	doc := parseSwanctlDoc(t, m.generateConfig(cfg))
+	local := doc.at(t, "connections", "tun", "local")
+	local.requireSetting(t, "auth", "pubkey")
+	local.requireSetting(t, "certs", `"gw-cert.pem"`)
+	// No PSK anywhere: pubkey auth must not emit a secret in ANY section.
+	doc.hasNoSettingAnywhere(t, "secret")
 }
 
 func TestGenerateConfig_TrafficSelectors(t *testing.T) {
@@ -1231,18 +1200,18 @@ func TestGenerateConfig_TrafficSelectors(t *testing.T) {
 			},
 		},
 	}
-	got := m.generateConfig(cfg)
-	for _, want := range []string{
-		"tun-corp-a {",
-		"local_ts = 10.0.1.0/24",
-		"remote_ts = 10.10.1.0/24",
-		"tun-corp-b {",
-		"local_ts = 10.0.2.0/24",
-		"remote_ts = 10.10.2.0/24",
+	// #6824: the six old needles would ALL have been satisfied with corp-a's
+	// selectors rendered inside corp-b's child section and vice versa -- the
+	// pairing is the entire point of a traffic selector, and containment
+	// cannot express it.
+	kids := parseSwanctlDoc(t, m.generateConfig(cfg)).at(t, "connections", "tun", "children")
+	for _, c := range []struct{ name, local, remote string }{
+		{"tun-corp-a", "10.0.1.0/24", "10.10.1.0/24"},
+		{"tun-corp-b", "10.0.2.0/24", "10.10.2.0/24"},
 	} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("missing %q in:\n%s", want, got)
-		}
+		child := kids.at(t, c.name)
+		child.requireSetting(t, "local_ts", c.local)
+		child.requireSetting(t, "remote_ts", c.remote)
 	}
 }
 
@@ -1599,14 +1568,17 @@ func TestGenerateConfig_NewlineSecretDoesNotInject(t *testing.T) {
 		Proposals: map[string]*config.IPsecProposal{},
 	}
 	got := m.generateConfig(cfg)
+	// #6824: a leaked `include` would parse as an unrecognised line and the
+	// parser fails on it, so parsing at all is the leak check. The scan is kept
+	// alongside because `include /etc/evil.conf` without an "=" is exactly the
+	// shape the parser refuses, and stating the intent here is worth the four
+	// lines.
 	for _, line := range strings.Split(got, "\n") {
 		if strings.HasPrefix(strings.TrimSpace(line), "include ") {
 			t.Fatalf("injected swanctl directive leaked:\n%s", got)
 		}
 	}
-	if !strings.Contains(got, `secret = "secret include /etc/evil.conf"`) {
-		t.Errorf("sanitized secret missing:\n%s", got)
-	}
+	secretsOnly_6824(t, got).requireSetting(t, "secret", `"secret include /etc/evil.conf"`)
 }
 
 // remoteAddrsValues returns every value rendered on a `remote_addrs = `
@@ -1615,14 +1587,22 @@ func TestGenerateConfig_NewlineSecretDoesNotInject(t *testing.T) {
 // that a gateway config-object NAME never appears as a remote_addrs
 // value (a substring match on the whole config would falsely flag the
 // connection-name line).
-func remoteAddrsValues(cfg string) []string {
+func remoteAddrsValues(t *testing.T, cfg string) []string {
+	t.Helper()
+	// #6824: collected from the parsed tree rather than by scanning for a
+	// "remote_addrs = " line prefix. Same intent as the old scanner -- read the
+	// VALUES so the connection-name line cannot false-flag -- but it now also
+	// sees a setting the renderer indented differently, and cannot be fooled by
+	// the text appearing inside another value.
 	var out []string
-	for _, line := range strings.Split(cfg, "\n") {
-		t := strings.TrimSpace(line)
-		if v, ok := strings.CutPrefix(t, "remote_addrs = "); ok {
-			out = append(out, v)
+	var walk func(*swanctlNode)
+	walk = func(n *swanctlNode) {
+		out = append(out, n.settings["remote_addrs"]...)
+		for _, name := range n.order {
+			walk(n.children[name])
 		}
 	}
+	walk(parseSwanctlDoc(t, cfg))
 	return out
 }
 
@@ -1648,7 +1628,7 @@ func TestRenderConfig_GatewayNameNeverLeaks(t *testing.T) {
 		if err != nil {
 			t.Fatalf("renderConfig() error = %v", err)
 		}
-		vals := remoteAddrsValues(got)
+		vals := remoteAddrsValues(t, got)
 		if len(vals) != 1 || vals[0] != "203.0.113.7" {
 			t.Fatalf("remote_addrs = %v, want [203.0.113.7]\n%s", vals, got)
 		}
@@ -1675,12 +1655,10 @@ func TestRenderConfig_GatewayNameNeverLeaks(t *testing.T) {
 		if strings.Contains(got, "typo-gw") {
 			t.Fatalf("dangling gateway NAME leaked into config:\n%s", got)
 		}
-		if vals := remoteAddrsValues(got); len(vals) != 0 {
+		if vals := remoteAddrsValues(t, got); len(vals) != 0 {
 			t.Fatalf("expected no remote_addrs, got %v\n%s", vals, got)
 		}
-		if strings.Contains(got, "ike-tun {") {
-			t.Fatalf("skipped VPN should have no secret entry:\n%s", got)
-		}
+		parseSwanctlDoc(t, got).at(t, "secrets").hasNoChild(t, "ike-tun")
 	})
 
 	t.Run("addressless gateway is skipped, no leak", func(t *testing.T) {
@@ -1700,7 +1678,7 @@ func TestRenderConfig_GatewayNameNeverLeaks(t *testing.T) {
 		if strings.Contains(got, "bare-gw") {
 			t.Fatalf("addressless gateway NAME leaked:\n%s", got)
 		}
-		if vals := remoteAddrsValues(got); len(vals) != 0 {
+		if vals := remoteAddrsValues(t, got); len(vals) != 0 {
 			t.Fatalf("expected no remote_addrs, got %v\n%s", vals, got)
 		}
 	})
@@ -1715,7 +1693,7 @@ func TestRenderConfig_GatewayNameNeverLeaks(t *testing.T) {
 		if err != nil {
 			t.Fatalf("renderConfig() error = %v", err)
 		}
-		if vals := remoteAddrsValues(got); len(vals) != 0 {
+		if vals := remoteAddrsValues(t, got); len(vals) != 0 {
 			t.Fatalf("dotless name should be skipped, got remote_addrs %v\n%s", vals, got)
 		}
 	})
@@ -1730,7 +1708,7 @@ func TestRenderConfig_GatewayNameNeverLeaks(t *testing.T) {
 		if err != nil {
 			t.Fatalf("renderConfig() error = %v", err)
 		}
-		if vals := remoteAddrsValues(got); len(vals) != 1 || vals[0] != "198.51.100.9" {
+		if vals := remoteAddrsValues(t, got); len(vals) != 1 || vals[0] != "198.51.100.9" {
 			t.Fatalf("remote_addrs = %v, want [198.51.100.9]\n%s", vals, got)
 		}
 	})
@@ -1745,7 +1723,7 @@ func TestRenderConfig_GatewayNameNeverLeaks(t *testing.T) {
 		if err != nil {
 			t.Fatalf("renderConfig() error = %v", err)
 		}
-		if vals := remoteAddrsValues(got); len(vals) != 1 || vals[0] != "peer.example.com" {
+		if vals := remoteAddrsValues(t, got); len(vals) != 1 || vals[0] != "peer.example.com" {
 			t.Fatalf("remote_addrs = %v, want [peer.example.com]\n%s", vals, got)
 		}
 	})
@@ -1760,10 +1738,8 @@ func TestRenderConfig_GatewayNameNeverLeaks(t *testing.T) {
 		if err != nil {
 			t.Fatalf("renderConfig() error = %v", err)
 		}
-		if !strings.Contains(got, "  tun {\n") {
-			t.Fatalf("empty-gateway VPN should still render a connection:\n%s", got)
-		}
-		if vals := remoteAddrsValues(got); len(vals) != 0 {
+		parseSwanctlDoc(t, got).at(t, "connections", "tun")
+		if vals := remoteAddrsValues(t, got); len(vals) != 0 {
 			t.Fatalf("empty gateway should emit no remote_addrs, got %v\n%s", vals, got)
 		}
 	})
@@ -1786,25 +1762,22 @@ func TestRenderConfig_GatewayNameNeverLeaks(t *testing.T) {
 		if err != nil {
 			t.Fatalf("renderConfig() error = %v", err)
 		}
-		if !strings.Contains(got, "  good {\n") {
-			t.Fatalf("healthy VPN was dropped:\n%s", got)
-		}
-		vals := remoteAddrsValues(got)
+		// #6824: the old needle carried two leading spaces and a trailing
+		// newline to approximate "a connection-level section opener" -- an
+		// assertion about the renderer's INDENT standing in for one about the
+		// tree. Resolving the path says it directly.
+		doc := parseSwanctlDoc(t, got)
+		doc.at(t, "connections", "good")
+		vals := remoteAddrsValues(t, got)
 		if len(vals) != 1 || vals[0] != "192.0.2.10" {
 			t.Fatalf("healthy remote_addrs = %v, want [192.0.2.10]\n%s", vals, got)
 		}
 		if strings.Contains(got, "missing-gw") {
 			t.Fatalf("bad gateway NAME leaked:\n%s", got)
 		}
-		if strings.Contains(got, "  bad {\n") {
-			t.Fatalf("bad VPN should be skipped:\n%s", got)
-		}
-		if strings.Contains(got, "ike-bad {") {
-			t.Fatalf("skipped VPN should have no secret:\n%s", got)
-		}
-		if !strings.Contains(got, "ike-good {") {
-			t.Fatalf("healthy VPN secret missing:\n%s", got)
-		}
+		doc.at(t, "connections").hasNoChild(t, "bad")
+		doc.at(t, "secrets").hasNoChild(t, "ike-bad")
+		doc.at(t, "secrets", "ike-good")
 	})
 }
 
@@ -1838,13 +1811,20 @@ func TestGenerateConfig_ResponderOnlyGateway(t *testing.T) {
 		Proposals: map[string]*config.IPsecProposal{},
 	}
 	got := m.generateConfig(cfg)
-	if !strings.Contains(got, "dyn {") {
-		t.Fatalf("responder-only VPN should render a connection block:\n%s", got)
+	conn := parseSwanctlDoc(t, got).at(t, "connections", "dyn")
+	conn.requireSetting(t, "remote_addrs", "%any")
+	conn.requireSetting(t, "local_addrs", "203.0.113.5")
+}
+
+// secretsOnly_6824 resolves the document's single secrets block, failing if the
+// render produced anything other than exactly one. "Exactly one" is part of the
+// claim: with two blocks, a containment assertion could not say which one it
+// matched.
+func secretsOnly_6824(t *testing.T, doc string) *swanctlNode {
+	t.Helper()
+	sec := parseSwanctlDoc(t, doc).at(t, "secrets")
+	if len(sec.order) != 1 {
+		t.Fatalf("expected exactly one secrets block, got %v\n%s", sec.childNames(), sec)
 	}
-	if !strings.Contains(got, "remote_addrs = %any") {
-		t.Fatalf("responder-only gateway must render remote_addrs = %%any:\n%s", got)
-	}
-	if !strings.Contains(got, "local_addrs = 203.0.113.5") {
-		t.Fatalf("responder-only gateway local_addrs missing:\n%s", got)
-	}
+	return sec.at(t, sec.order[0])
 }

--- a/pkg/ipsec/proposalset_ah_hb167_test.go
+++ b/pkg/ipsec/proposalset_ah_hb167_test.go
@@ -1,7 +1,6 @@
 package ipsec
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -50,19 +49,24 @@ func TestProposalSetStandardRenders_4297(t *testing.T) {
 		"set security ipsec vpn tun1 ike gateway gw1",
 		"set security ipsec vpn tun1 ike ipsec-policy esp-pol",
 	})
-	out := New().generateConfig(prepared)
-	if !strings.Contains(out, "tun1 {") {
-		t.Fatalf("proposal-set standard tunnel missing from render:\n%s", out)
-	}
+	conn := parseSwanctlDoc(t, New().generateConfig(prepared)).at(t, "connections", "tun1")
+
 	// Phase-1: 3des-sha1-modp1024 (group2) and aes128-sha1-modp1024, comma-joined.
-	if !strings.Contains(out, "3des-sha1-modp1024") || !strings.Contains(out, "aes128-sha1-modp1024") {
-		t.Errorf("IKE proposals line missing the standard set members:\n%s", out)
+	conn.requireMembers(t, "proposals", "3des-sha1-modp1024", "aes128-sha1-modp1024")
+
+	// Phase-2: 3des-sha1 and aes128-sha1, on the CHILD section.
+	//
+	// #6824: the old spelling asked whether "3des-sha1" appeared anywhere in
+	// the document -- which the Phase-1 member `3des-sha1-modp1024` satisfies
+	// on its own. That assertion passed whether or not esp_proposals carried
+	// the ESP set, or existed at all. Membership in the split value of
+	// esp_proposals at a known path cannot be satisfied by the Phase-1 line
+	// nor by a longer token that merely starts the same way.
+	kids := conn.at(t, "children")
+	if len(kids.order) != 1 {
+		t.Fatalf("expected exactly one child SA section, got %v\n%s", kids.childNames(), kids)
 	}
-	// Phase-2: 3des-sha1 and aes128-sha1.
-	if !strings.Contains(out, "esp_proposals = ") ||
-		!strings.Contains(out, "3des-sha1") || !strings.Contains(out, "aes128-sha1") {
-		t.Errorf("esp_proposals line missing the standard ESP set members:\n%s", out)
-	}
+	kids.at(t, kids.order[0]).requireMembers(t, "esp_proposals", "3des-sha1", "aes128-sha1")
 }
 
 // V-1: suiteb-gcm-128 renders the RFC 6379 AEAD tokens (aes128gcm16 + ecp256).
@@ -77,13 +81,16 @@ func TestProposalSetSuiteB128Renders_4297(t *testing.T) {
 		"set security ipsec vpn tun1 ike gateway gw1",
 		"set security ipsec vpn tun1 ike ipsec-policy esp-sb",
 	})
-	out := New().generateConfig(prepared)
-	if !strings.Contains(out, "aes128gcm16-prfsha256-ecp256") {
-		t.Errorf("IKE suiteb-gcm-128 proposal token missing:\n%s", out)
+	conn := parseSwanctlDoc(t, New().generateConfig(prepared)).at(t, "connections", "tun1")
+	// #6824: `aes128gcm16-ecp256` is not a substring of
+	// `aes128gcm16-prfsha256-ecp256`, so the two old needles did not collide --
+	// but neither said WHICH line carried its token. Pin the phase.
+	conn.requireMembers(t, "proposals", "aes128gcm16-prfsha256-ecp256")
+	kids := conn.at(t, "children")
+	if len(kids.order) != 1 {
+		t.Fatalf("expected exactly one child SA section, got %v\n%s", kids.childNames(), kids)
 	}
-	if !strings.Contains(out, "aes128gcm16-ecp256") {
-		t.Errorf("ESP suiteb-gcm-128 proposal token missing:\n%s", out)
-	}
+	kids.at(t, kids.order[0]).requireMembers(t, "esp_proposals", "aes128gcm16-ecp256")
 }
 
 // V-2: a VPN whose ipsec-policy resolves to a `protocol ah` proposal is
@@ -111,11 +118,7 @@ func TestRenderConfig_AHProposalSkipsVPN_4298(t *testing.T) {
 			"tun-esp": {Name: "tun-esp", Gateway: "gw-esp", IPsecPolicy: "esp-pol"},
 		},
 	}
-	out := New().generateConfig(cfg)
-	if strings.Contains(out, "tun-ah {") {
-		t.Errorf("AH VPN tun-ah must be skipped (never fabricated ESP):\n%s", out)
-	}
-	if !strings.Contains(out, "tun-esp {") {
-		t.Errorf("healthy ESP VPN tun-esp missing from render:\n%s", out)
-	}
+	conns := parseSwanctlDoc(t, New().generateConfig(cfg)).at(t, "connections")
+	conns.hasNoChild(t, "tun-ah")
+	conns.at(t, "tun-esp")
 }

--- a/pkg/ipsec/swanctl_addr_sanitize_6469_test.go
+++ b/pkg/ipsec/swanctl_addr_sanitize_6469_test.go
@@ -32,20 +32,6 @@ func buildAddrCfg(gwAddr, gwDyn, gwLocal, vpnLocal string) *config.IPsecConfig {
 	}
 }
 
-// hasBareDirectiveLine reports whether any rendered line, once its leading /
-// trailing whitespace is stripped, is EXACTLY the given swanctl directive.
-// A newline-injection payload that survives to render produces such a
-// standalone line (`    reauth_time = 0`); a neutralized payload keeps the
-// token mid-line inside the address value, so no line trims to it.
-func hasBareDirectiveLine(rendered, directive string) bool {
-	for _, line := range strings.Split(rendered, "\n") {
-		if strings.TrimSpace(line) == directive {
-			return true
-		}
-	}
-	return false
-}
-
 // TestSwanctlAddrInjectionNeutralized_6469 is the fail-on-revert guard for
 // #6469: the swanctl local_addrs / remote_addrs render sites must run the
 // endpoint value through sanitizeSwanctlValue so an embedded newline cannot
@@ -60,55 +46,64 @@ func TestSwanctlAddrInjectionNeutralized_6469(t *testing.T) {
 	// connection block. reauth_time is emitted by NO code path in this
 	// fixture, so its appearance as a bare line is proof of injection.
 	const inject = "203.0.113.1\n    reauth_time = 0"
-	const injectedDirective = "reauth_time = 0"
+	const injectedDirectiveKey = "reauth_time"
 
 	cases := []struct {
 		name string
 		cfg  *config.IPsecConfig
-		// addrLine is the sanitized address line that must be present,
-		// proving the connection still rendered (the VPN was not skipped)
-		// and the belt ran in place rather than dropping the field.
-		addrLine string
+		// addrKey / addrPrefix: the sanitized address must still lead the
+		// value of this setting, proving the connection rendered (the VPN was
+		// not skipped) and the belt ran in place rather than dropping the
+		// field. #6824: a key + a path, not a rendered line.
+		addrKey    string
+		addrPrefix string
 	}{
 		{
-			name:     "remote via gateway Address",
-			cfg:      buildAddrCfg(inject, "", "", ""),
-			addrLine: "remote_addrs = 203.0.113.1",
+			name:       "remote via gateway Address",
+			cfg:        buildAddrCfg(inject, "", "", ""),
+			addrKey:    "remote_addrs",
+			addrPrefix: "203.0.113.1",
 		},
 		{
-			name:     "remote via gateway DynamicHostname",
-			cfg:      buildAddrCfg("", inject, "198.51.100.7", ""),
-			addrLine: "remote_addrs = 203.0.113.1",
+			name:       "remote via gateway DynamicHostname",
+			cfg:        buildAddrCfg("", inject, "198.51.100.7", ""),
+			addrKey:    "remote_addrs",
+			addrPrefix: "203.0.113.1",
 		},
 		{
-			name:     "local via gateway LocalAddress",
-			cfg:      buildAddrCfg("198.51.100.7", "", inject, ""),
-			addrLine: "local_addrs = 203.0.113.1",
+			name:       "local via gateway LocalAddress",
+			cfg:        buildAddrCfg("198.51.100.7", "", inject, ""),
+			addrKey:    "local_addrs",
+			addrPrefix: "203.0.113.1",
 		},
 		{
-			name:     "local via vpn LocalAddr",
-			cfg:      buildAddrCfg("198.51.100.7", "", "", inject),
-			addrLine: "local_addrs = 203.0.113.1",
+			name:       "local via vpn LocalAddr",
+			cfg:        buildAddrCfg("198.51.100.7", "", "", inject),
+			addrKey:    "local_addrs",
+			addrPrefix: "203.0.113.1",
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
-			got := m.generateConfig(c.cfg)
+			doc := parseSwanctlDoc(t, m.generateConfig(c.cfg))
 
-			if hasBareDirectiveLine(got, injectedDirective) {
-				t.Fatalf("swanctl injection NOT neutralized: %q rendered as a "+
-					"live directive line — the newline in the endpoint value "+
-					"was not stripped:\n%s", injectedDirective, got)
-			}
-			// The sanitized value must still lead the address line: the belt
+			// #6824: the injection is neutralized iff the directive never
+			// becomes a SETTING anywhere in the parsed document. That is what
+			// strongSwan would act on, and it fires whatever value the payload
+			// carried -- where the old line scan matched only the exact
+			// injected text.
+			doc.hasNoSettingAnywhere(t, injectedDirectiveKey)
+
+			// The sanitized value must still lead the address setting: the belt
 			// collapses the newline to a space, so the address renders inert
 			// on one line rather than the field being dropped or the VPN
 			// skipped.
-			if !strings.Contains(got, c.addrLine) {
-				t.Fatalf("expected sanitized address line %q in render:\n%s",
-					c.addrLine, got)
+			conn := doc.at(t, "connections", "tun")
+			if v := conn.setting(t, c.addrKey); !strings.HasPrefix(v, c.addrPrefix) {
+				t.Fatalf("connections.tun.%s = %q, want it to still start with %q",
+					c.addrKey, v, c.addrPrefix)
 			}
 		})
 	}
@@ -122,35 +117,33 @@ func TestSwanctlAddrInjectionNeutralized_6469(t *testing.T) {
 // that the #6469 fix does not mangle a real address list or IPv6 endpoint.
 func TestSwanctlAddrLegitPreserved_6469(t *testing.T) {
 	cases := []struct {
-		name     string
-		gwAddr   string
-		wantLine string
+		name   string
+		gwAddr string
+		want   string
 	}{
 		{
-			name:     "single IPv4",
-			gwAddr:   "203.0.113.1",
-			wantLine: "remote_addrs = 203.0.113.1",
+			name:   "single IPv4",
+			gwAddr: "203.0.113.1",
+			want:   "203.0.113.1",
 		},
 		{
-			name:     "comma-separated multi-address list",
-			gwAddr:   "203.0.113.1,203.0.113.2",
-			wantLine: "remote_addrs = 203.0.113.1,203.0.113.2",
+			name:   "comma-separated multi-address list",
+			gwAddr: "203.0.113.1,203.0.113.2",
+			want:   "203.0.113.1,203.0.113.2",
 		},
 		{
-			name:     "IPv6 literal",
-			gwAddr:   "2001:db8::1",
-			wantLine: "remote_addrs = 2001:db8::1",
+			name:   "IPv6 literal",
+			gwAddr: "2001:db8::1",
+			want:   "2001:db8::1",
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
-			got := m.generateConfig(buildAddrCfg(c.gwAddr, "", "", ""))
-			if !strings.Contains(got, c.wantLine) {
-				t.Fatalf("legit endpoint over-escaped or dropped: want %q in "+
-					"render:\n%s", c.wantLine, got)
-			}
+			parseSwanctlDoc(t, m.generateConfig(buildAddrCfg(c.gwAddr, "", "", ""))).
+				at(t, "connections", "tun").
+				requireSetting(t, "remote_addrs", c.want)
 		})
 	}
 
@@ -160,10 +153,9 @@ func TestSwanctlAddrLegitPreserved_6469(t *testing.T) {
 		cfg := buildAddrCfg("", "", "", "")
 		cfg.Gateways["gw"].ResponderOnly = true
 		m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
-		got := m.generateConfig(cfg)
-		if !strings.Contains(got, "remote_addrs = %any") {
-			t.Fatalf("responder-only %%any endpoint not preserved:\n%s", got)
-		}
+		parseSwanctlDoc(t, m.generateConfig(cfg)).
+			at(t, "connections", "tun").
+			requireSetting(t, "remote_addrs", "%any")
 	})
 }
 
@@ -217,37 +209,48 @@ func TestSwanctlProposalsInjectionNeutralized_6469(t *testing.T) {
 	}
 
 	cases := []struct {
-		name      string
-		cfg       *config.IPsecConfig
-		directive string // the injected line that must NOT render live
-		wantSlot  string // the render slot that must still be present
+		name string
+		cfg  *config.IPsecConfig
+		// #6824: a KEY that must not become live anywhere, and the slot the
+		// sanitized value must still lead -- named by path, not by a rendered
+		// line whose indentation encoded which phase it belonged to.
+		directiveKey string
+		slotKey      string
+		slotPrefix   string
 	}{
 		{
-			name:      "IKE proposals newline injection",
-			cfg:       ikeCfg,
-			directive: "reauth_time = 0",
-			wantSlot:  "proposals = aes256",
+			name:         "IKE proposals newline injection",
+			cfg:          ikeCfg,
+			directiveKey: "reauth_time",
+			slotKey:      "proposals",
+			slotPrefix:   "aes256",
 		},
 		{
-			name:      "ESP esp_proposals updown->root injection",
-			cfg:       espCfg,
-			directive: "updown = /tmp/pwn.sh",
-			wantSlot:  "esp_proposals = aes256",
+			name:         "ESP esp_proposals updown->root injection",
+			cfg:          espCfg,
+			directiveKey: "updown",
+			slotKey:      "esp_proposals",
+			slotPrefix:   "aes256",
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
-			got := m.generateConfig(c.cfg)
-			if hasBareDirectiveLine(got, c.directive) {
-				t.Fatalf("swanctl proposal injection NOT neutralized: %q rendered "+
-					"as a live directive line — the newline in the proposal value "+
-					"was not stripped:\n%s", c.directive, got)
+			doc := parseSwanctlDoc(t, m.generateConfig(c.cfg))
+			doc.hasNoSettingAnywhere(t, c.directiveKey)
+
+			// The sanitized proposal must still lead its slot. #6824 pins WHICH
+			// slot: `proposals` on the connection is Phase 1, `esp_proposals`
+			// on the child SA is Phase 2, and a containment needle for
+			// "esp_proposals = aes256" could previously be satisfied by either
+			// render site emitting the token.
+			slot := doc.at(t, "connections", "tun")
+			if c.slotKey == "esp_proposals" {
+				slot = childSA_3904(t, m.generateConfig(c.cfg), "tun")
 			}
-			if !strings.Contains(got, c.wantSlot) {
-				t.Fatalf("expected sanitized proposal slot %q in render:\n%s",
-					c.wantSlot, got)
+			if v := slot.setting(t, c.slotKey); !strings.HasPrefix(v, c.slotPrefix) {
+				t.Fatalf("%s = %q, want it to still start with %q", c.slotKey, v, c.slotPrefix)
 			}
 		})
 	}
@@ -285,14 +288,12 @@ func TestSwanctlProposalsLegitPreserved_6469(t *testing.T) {
 	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
 	got := m.generateConfig(cfg)
 
-	const wantIKE = "    proposals = aes256-sha256-modp2048,aes128-sha256-modp2048\n"
-	const wantESP = "        esp_proposals = aes256-sha256-modp2048,aes128-sha256-modp2048\n"
-	if !strings.Contains(got, wantIKE) {
-		t.Fatalf("legit IKE proposal list over-escaped or dropped: want %q in "+
-			"render:\n%s", wantIKE, got)
-	}
-	if !strings.Contains(got, wantESP) {
-		t.Fatalf("legit ESP proposal list over-escaped or dropped: want %q in "+
-			"render:\n%s", wantESP, got)
-	}
+	// #6824: the two needles carried leading indentation ("    " vs "        ")
+	// purely to distinguish Phase 1 from Phase 2, and a trailing "\n" to mean
+	// "the value ends here". Both are properties of the tree, so state them as
+	// such -- the assertions now survive a change to the renderer's indent and
+	// still reject a value with anything appended.
+	const wantList = "aes256-sha256-modp2048,aes128-sha256-modp2048"
+	parseSwanctlDoc(t, got).at(t, "connections", "tun").requireSetting(t, "proposals", wantList)
+	childSA_3904(t, got, "tun").requireSetting(t, "esp_proposals", wantList)
 }

--- a/pkg/ipsec/swanctl_containment_guard_6824_test.go
+++ b/pkg/ipsec/swanctl_containment_guard_6824_test.go
@@ -114,8 +114,19 @@ func findSwanctlContainment(fset *token.FileSet, f *ast.File) []containmentFindi
 		if pkg, ok := sel.X.(*ast.Ident); !ok || pkg.Name != "strings" {
 			return true
 		}
-		subject, ok := call.Args[0].(*ast.Ident)
-		if !ok || !rendered[subject.Name] {
+		// The subject may be a bound identifier OR the render call inline --
+		// `strings.Contains(m.generateConfig(cfg), "a = b")` is the same defect
+		// and was missed by an Ident-only check.
+		switch subj := call.Args[0].(type) {
+		case *ast.Ident:
+			if !rendered[subj.Name] {
+				return true
+			}
+		case *ast.CallExpr:
+			if !isRenderCall(subj) {
+				return true
+			}
+		default:
 			return true
 		}
 		lit, ok := call.Args[1].(*ast.BasicLit)
@@ -208,6 +219,11 @@ func TestContainmentGuardSensitivity_6824(t *testing.T) {
 		body string
 		want int
 	}{
+		{
+			name: "render call inline as the subject",
+			body: `_ = strings.Contains(m.generateConfig(cfg), "remote_addrs = 1.1.1.1")`,
+			want: 1,
+		},
 		{
 			name: "setting needle on a render variable",
 			body: `got := m.generateConfig(cfg)

--- a/pkg/ipsec/swanctl_containment_guard_6824_test.go
+++ b/pkg/ipsec/swanctl_containment_guard_6824_test.go
@@ -35,14 +35,26 @@ import (
 //
 // The needle must be a STRING LITERAL at the call site. A table-driven test
 // whose expectations live in a struct column -- `strings.Contains(got, c.want)`
-// -- is invisible to it, and several of the assertions converted for #6824 were
-// exactly that shape. Run against the pre-conversion tree (de6b8c85d) this
-// detector flagged 75 sites out of roughly 100; the rest were table columns.
-// So a clean run means "no literal syntax needle", not "no containment
-// assertion anywhere", and this guard is a ratchet against the common case
-// rather than a proof of the general one. Resolving a table column back to its
-// literals would need type-checked constant propagation, which is a much larger
-// instrument than the defect warrants.
+// -- is invisible to it, as is any needle built at runtime, and several of the
+// assertions converted for #6824 were exactly those shapes.
+//
+// Measured rather than asserted: against the pre-conversion tree (de6b8c85d)
+// this detector flags 76 sites; that tree contained 123 strings.Contains calls
+// in pkg/ipsec test files in total, of which many are legitimate assertions on
+// error strings and parsed fields rather than on rendered documents. So a clean
+// run means "no literal syntax needle", NOT "no containment assertion anywhere",
+// and this guard is a ratchet against the common case rather than a proof of the
+// general one.
+//
+// An earlier version of this comment claimed the entire non-flagged remainder
+// was table columns. That was wrong, and the way it was wrong is worth keeping:
+// the detector was also missing plain literal needles that ended `" {\n"`
+// rather than `" {"` -- four of them existed in the base tree -- so the number
+// was describing the detector's blind spot as if it were a property of the code
+// being measured.
+//
+// Resolving a table column back to its literals would need type-checked constant
+// propagation, a much larger instrument than this defect warrants.
 
 // containmentFinding is one flagged assertion.
 type containmentFinding struct {
@@ -58,10 +70,14 @@ type containmentFinding struct {
 // It is a free function over an *ast.File rather than a method on the test so
 // the guard's own sensitivity control can drive it with synthetic source.
 func findSwanctlContainment(fset *token.FileSet, f *ast.File) []containmentFinding {
-	// Idents bound to a rendered document. Tracked by name only: test bodies
-	// are small and shadowing a render variable with a non-render one of the
-	// same name inside one file would be perverse, and erring toward flagging
-	// is the safe direction for a guard.
+	// Idents bound to a rendered document, tracked PER FUNCTION.
+	//
+	// A file-wide name set produces routine false positives: `got` is a common
+	// name, and one test binding it to a render made every other function's
+	// `strings.Contains(got, "load-all = yes")` -- a legitimate error-message
+	// assertion -- a violation. A standing gate that flags unrelated work is
+	// worse than one with a known blind spot, because the cost lands on someone
+	// who did nothing wrong.
 	rendered := map[string]bool{}
 	isRenderCall := func(e ast.Expr) bool {
 		call, ok := e.(*ast.CallExpr)
@@ -93,62 +109,121 @@ func findSwanctlContainment(fset *token.FileSet, f *ast.File) []containmentFindi
 			}
 		}
 	}
-	ast.Inspect(f, func(n ast.Node) bool {
-		switch s := n.(type) {
-		case *ast.AssignStmt:
-			noteAssign(s.Lhs, s.Rhs)
-		}
-		return true
-	})
+	collect := func(scope ast.Node) {
+		ast.Inspect(scope, func(n ast.Node) bool {
+			switch s := n.(type) {
+			case *ast.AssignStmt:
+				noteAssign(s.Lhs, s.Rhs)
+			case *ast.ValueSpec:
+				// `var got = m.generateConfig(cfg)` binds exactly as `:=` does
+				// and was invisible while only AssignStmt was inspected.
+				lhs := make([]ast.Expr, 0, len(s.Names))
+				for _, id := range s.Names {
+					lhs = append(lhs, id)
+				}
+				noteAssign(lhs, s.Values)
+			}
+			return true
+		})
+	}
 
 	var out []containmentFinding
-	ast.Inspect(f, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok || len(call.Args) != 2 {
-			return true
-		}
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || sel.Sel.Name != "Contains" {
-			return true
-		}
-		if pkg, ok := sel.X.(*ast.Ident); !ok || pkg.Name != "strings" {
-			return true
-		}
-		// The subject may be a bound identifier OR the render call inline --
-		// `strings.Contains(m.generateConfig(cfg), "a = b")` is the same defect
-		// and was missed by an Ident-only check.
-		switch subj := call.Args[0].(type) {
-		case *ast.Ident:
-			if !rendered[subj.Name] {
+	inspectCalls := func(scope ast.Node) {
+		ast.Inspect(scope, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || len(call.Args) != 2 {
 				return true
 			}
-		case *ast.CallExpr:
-			if !isRenderCall(subj) {
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Contains" {
 				return true
 			}
-		default:
+			if pkg, ok := sel.X.(*ast.Ident); !ok || pkg.Name != "strings" {
+				return true
+			}
+			// The subject may be a bound identifier OR the render call inline --
+			// `strings.Contains(m.generateConfig(cfg), "a = b")` is the same defect
+			// and was missed by an Ident-only check.
+			switch subj := call.Args[0].(type) {
+			case *ast.Ident:
+				if !rendered[subj.Name] {
+					return true
+				}
+			case *ast.CallExpr:
+				if !isRenderCall(subj) {
+					return true
+				}
+			default:
+				return true
+			}
+			lit, ok := call.Args[1].(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			needle, err := strconv.Unquote(lit.Value)
+			if err != nil {
+				return true
+			}
+			// Trim before classifying: `"tun1-ts1 {\n"` and `"  good {\n"` are
+			// section-opener needles that a bare HasSuffix(" {") misses, and four
+			// such sites existed in the pre-conversion tree.
+			trimmed := strings.TrimRight(needle, " \t\r\n")
+			if !strings.Contains(needle, " = ") && !strings.HasSuffix(trimmed, "{") {
+				// A bare token: a leak guard, not a structural claim.
+				return true
+			}
+			out = append(out, containmentFinding{
+				file:   filepath.Base(fset.Position(call.Pos()).Filename),
+				line:   fset.Position(call.Pos()).Line,
+				needle: needle,
+			})
 			return true
-		}
-		lit, ok := call.Args[1].(*ast.BasicLit)
-		if !ok || lit.Kind != token.STRING {
-			return true
-		}
-		needle, err := strconv.Unquote(lit.Value)
-		if err != nil {
-			return true
-		}
-		if !strings.Contains(needle, " = ") && !strings.HasSuffix(needle, " {") {
-			// A bare token: a leak guard, not a structural claim.
-			return true
-		}
-		out = append(out, containmentFinding{
-			file:   filepath.Base(fset.Position(call.Pos()).Filename),
-			line:   fset.Position(call.Pos()).Line,
-			needle: needle,
 		})
+	}
+
+	// One function at a time, so a render binding in one test cannot make a
+	// same-named local in another test look like a rendered document. Package
+	// level (a var block holding a render call) is walked once as its own
+	// scope; nothing outside a function makes containment assertions.
+	for _, d := range f.Decls {
+		fn, ok := d.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		rendered = map[string]bool{}
+		collect(fn)
+		inspectCalls(fn)
+	}
+	return out
+}
+
+// countRenderCalls counts actual generateConfig/renderConfig CALL expressions.
+//
+// The floor below used to grep the file text for "generateConfig(", which
+// matched comments and string literals -- including this guard's own synthetic
+// snippets, so the file counted itself. Ten empty test files and five comments
+// satisfied both floors with no render call anywhere. Counting call nodes makes
+// the floor measure the thing it claims to.
+func countRenderCalls(f *ast.File) int {
+	n := 0
+	ast.Inspect(f, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		name := ""
+		switch fn := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			name = fn.Sel.Name
+		case *ast.Ident:
+			name = fn.Name
+		}
+		if name == "generateConfig" || name == "renderConfig" {
+			n++
+		}
 		return true
 	})
-	return out
+	return n
 }
 
 // TestNoSwanctlSyntaxInContainmentNeedles_6824 is the standing guard.
@@ -170,11 +245,7 @@ func TestNoSwanctlSyntaxInContainmentNeedles_6824(t *testing.T) {
 			t.Fatalf("parse %s: %v", e.Name(), err)
 		}
 		scanned++
-		src, err := os.ReadFile(e.Name())
-		if err != nil {
-			t.Fatalf("read %s: %v", e.Name(), err)
-		}
-		if strings.Contains(string(src), "generateConfig(") || strings.Contains(string(src), "renderConfig(") {
+		if countRenderCalls(f) > 0 {
 			withRender++
 		}
 		findings = append(findings, findSwanctlContainment(fset, f)...)
@@ -188,8 +259,8 @@ func TestNoSwanctlSyntaxInContainmentNeedles_6824(t *testing.T) {
 			"reaching the package it is meant to cover", scanned)
 	}
 	if withRender < 5 {
-		t.Fatalf("only %d test files render a swanctl document; the guard has "+
-			"nothing to guard and would pass whatever those files said", withRender)
+		t.Fatalf("only %d test files make a real render CALL; the guard has nothing "+
+			"to guard and would pass whatever those files said", withRender)
 	}
 
 	for _, f := range findings {
@@ -202,6 +273,40 @@ func TestNoSwanctlSyntaxInContainmentNeedles_6824(t *testing.T) {
 			"\tUse parseSwanctlDoc + at()/setting()/requireSetting()/hasNoSetting()/"+
 			"hasNoChild() from swanctl_doc_6824_test.go instead. See #6824.",
 			f.file, f.line, f.needle)
+	}
+}
+
+// TestGuardScopesRenderVariablesPerFunction_6824 is the false-POSITIVE control.
+//
+// The detector used to collect render-variable names file-wide, so one test
+// binding the very common name `got` to a render made every other function's
+// `strings.Contains(got, ...)` a violation -- including legitimate
+// error-message assertions. A standing gate that flags unrelated work is worse
+// than one with a known blind spot, because the cost lands on someone who did
+// nothing wrong.
+func TestGuardScopesRenderVariablesPerFunction_6824(t *testing.T) {
+	src := `package ipsec
+
+import "strings"
+
+func rendersSomething() {
+	got := m.generateConfig(cfg)
+	_ = got
+}
+
+func assertsAnErrorMessage() {
+	got := doThing().Error()
+	_ = strings.Contains(got, "load-all = yes")
+}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "probe_test.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse synthetic source: %v", err)
+	}
+	if got := findSwanctlContainment(fset, f); len(got) != 0 {
+		t.Errorf("flagged %d finding(s) in a file where the only syntax needle is an "+
+			"error-message assertion in a DIFFERENT function: %+v", len(got), got)
 	}
 }
 
@@ -219,6 +324,18 @@ func TestContainmentGuardSensitivity_6824(t *testing.T) {
 		body string
 		want int
 	}{
+		{
+			name: "section opener needle with a trailing newline",
+			body: `got := m.generateConfig(cfg)
+	_ = strings.Contains(got, "tun1-ts1 {\n")`,
+			want: 1,
+		},
+		{
+			name: "var-declared render subject",
+			body: `var got = m.generateConfig(cfg)
+	_ = strings.Contains(got, "remote_addrs = 1.1.1.1")`,
+			want: 1,
+		},
 		{
 			name: "render call inline as the subject",
 			body: `_ = strings.Contains(m.generateConfig(cfg), "remote_addrs = 1.1.1.1")`,

--- a/pkg/ipsec/swanctl_containment_guard_6824_test.go
+++ b/pkg/ipsec/swanctl_containment_guard_6824_test.go
@@ -1,0 +1,265 @@
+package ipsec
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// swanctl_containment_guard_6824_test.go -- #6824.
+//
+// Converting the existing assertions fixes the tests that exist today. It does
+// nothing about the next one. This guard is the durable half: it fails when a
+// test asserts SWANCTL SYNTAX with strings.Contains over a rendered document.
+//
+// # The predicate, and why it needs no allowlist
+//
+// The defect is not "containment is used" -- three leak guards in this package
+// legitimately assert that a gateway NAME appears nowhere in the output, and
+// containment is exactly the right tool for that claim. The defect is spelling
+// swanctl's own syntax inside the needle: `"remote_addrs = 203.0.113.1"` or
+// `"tun-bad {"`. A needle carrying " = " or ending in " {" is making a claim
+// about the document's STRUCTURE while checking only its bytes, and structure
+// is what the parser in swanctl_doc_6824_test.go can actually assert.
+//
+// That discriminator is the whole reason this guard carries no allowlist. An
+// allowlist entry is a claim in its own right and owes a test; a predicate that
+// separates the two cases on their own merits owes nothing.
+//
+// # What it does not see
+//
+// The needle must be a STRING LITERAL at the call site. A table-driven test
+// whose expectations live in a struct column -- `strings.Contains(got, c.want)`
+// -- is invisible to it, and several of the assertions converted for #6824 were
+// exactly that shape. Run against the pre-conversion tree (de6b8c85d) this
+// detector flagged 75 sites out of roughly 100; the rest were table columns.
+// So a clean run means "no literal syntax needle", not "no containment
+// assertion anywhere", and this guard is a ratchet against the common case
+// rather than a proof of the general one. Resolving a table column back to its
+// literals would need type-checked constant propagation, which is a much larger
+// instrument than the defect warrants.
+
+// containmentFinding is one flagged assertion.
+type containmentFinding struct {
+	file   string
+	line   int
+	needle string
+}
+
+// findSwanctlContainment reports strings.Contains calls whose first argument is
+// a value produced by generateConfig/renderConfig and whose needle spells
+// swanctl syntax.
+//
+// It is a free function over an *ast.File rather than a method on the test so
+// the guard's own sensitivity control can drive it with synthetic source.
+func findSwanctlContainment(fset *token.FileSet, f *ast.File) []containmentFinding {
+	// Idents bound to a rendered document. Tracked by name only: test bodies
+	// are small and shadowing a render variable with a non-render one of the
+	// same name inside one file would be perverse, and erring toward flagging
+	// is the safe direction for a guard.
+	rendered := map[string]bool{}
+	isRenderCall := func(e ast.Expr) bool {
+		call, ok := e.(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+		name := ""
+		switch fn := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			name = fn.Sel.Name
+		case *ast.Ident:
+			name = fn.Name
+		}
+		return name == "generateConfig" || name == "renderConfig"
+	}
+	noteAssign := func(lhs, rhs []ast.Expr) {
+		for i, l := range lhs {
+			id, ok := l.(*ast.Ident)
+			if !ok || id.Name == "_" {
+				continue
+			}
+			// `got, _, err := m.renderConfig(cfg)` binds the document to the
+			// FIRST result; a multi-value call has one rhs expression.
+			switch {
+			case len(rhs) == len(lhs) && isRenderCall(rhs[i]):
+				rendered[id.Name] = true
+			case len(rhs) == 1 && i == 0 && isRenderCall(rhs[0]):
+				rendered[id.Name] = true
+			}
+		}
+	}
+	ast.Inspect(f, func(n ast.Node) bool {
+		switch s := n.(type) {
+		case *ast.AssignStmt:
+			noteAssign(s.Lhs, s.Rhs)
+		}
+		return true
+	})
+
+	var out []containmentFinding
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || len(call.Args) != 2 {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Contains" {
+			return true
+		}
+		if pkg, ok := sel.X.(*ast.Ident); !ok || pkg.Name != "strings" {
+			return true
+		}
+		subject, ok := call.Args[0].(*ast.Ident)
+		if !ok || !rendered[subject.Name] {
+			return true
+		}
+		lit, ok := call.Args[1].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		needle, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			return true
+		}
+		if !strings.Contains(needle, " = ") && !strings.HasSuffix(needle, " {") {
+			// A bare token: a leak guard, not a structural claim.
+			return true
+		}
+		out = append(out, containmentFinding{
+			file:   filepath.Base(fset.Position(call.Pos()).Filename),
+			line:   fset.Position(call.Pos()).Line,
+			needle: needle,
+		})
+		return true
+	})
+	return out
+}
+
+// TestNoSwanctlSyntaxInContainmentNeedles_6824 is the standing guard.
+func TestNoSwanctlSyntaxInContainmentNeedles_6824(t *testing.T) {
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	scanned, withRender := 0, 0
+	var findings []containmentFinding
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, e.Name(), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", e.Name(), err)
+		}
+		scanned++
+		src, err := os.ReadFile(e.Name())
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		if strings.Contains(string(src), "generateConfig(") || strings.Contains(string(src), "renderConfig(") {
+			withRender++
+		}
+		findings = append(findings, findSwanctlContainment(fset, f)...)
+	}
+
+	// Anti-vacuity floors. A guard that scanned nothing, or that found no
+	// rendered documents to guard, passes for the wrong reason and is
+	// indistinguishable from a healthy one in a pass/fail table.
+	if scanned < 10 {
+		t.Fatalf("scanned only %d test files in pkg/ipsec; the guard is not "+
+			"reaching the package it is meant to cover", scanned)
+	}
+	if withRender < 5 {
+		t.Fatalf("only %d test files render a swanctl document; the guard has "+
+			"nothing to guard and would pass whatever those files said", withRender)
+	}
+
+	for _, f := range findings {
+		t.Errorf("%s:%d: strings.Contains on a rendered swanctl document with a "+
+			"needle spelling swanctl syntax (%q).\n"+
+			"\tA needle carrying \" = \" or ending in \" {\" claims something about the "+
+			"document's STRUCTURE while checking only its bytes: it cannot say which "+
+			"section the setting landed in, whether the key was declared twice, or "+
+			"whether a brace balanced.\n"+
+			"\tUse parseSwanctlDoc + at()/setting()/requireSetting()/hasNoSetting()/"+
+			"hasNoChild() from swanctl_doc_6824_test.go instead. See #6824.",
+			f.file, f.line, f.needle)
+	}
+}
+
+// TestContainmentGuardSensitivity_6824 is the paired control.
+//
+// The guard above passes today because the package is clean, which is exactly
+// what a guard that can never fire also looks like. These cells drive the same
+// detector over synthetic source and require it to flag the violations -- and,
+// just as importantly, to leave the legitimate uses alone. Without the negative
+// cells a detector that flagged EVERY strings.Contains would satisfy the
+// positive ones and be useless in the other direction.
+func TestContainmentGuardSensitivity_6824(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{
+			name: "setting needle on a render variable",
+			body: `got := m.generateConfig(cfg)
+	_ = strings.Contains(got, "remote_addrs = 203.0.113.1")`,
+			want: 1,
+		},
+		{
+			name: "section-opener needle on a render variable",
+			body: `got := m.generateConfig(cfg)
+	_ = strings.Contains(got, "tun-bad {")`,
+			want: 1,
+		},
+		{
+			name: "multi-value renderConfig binds the first result",
+			body: `got, _, err := m.renderConfig(cfg)
+	_ = err
+	_ = strings.Contains(got, "encap = no")`,
+			want: 1,
+		},
+		{
+			name: "bare-token leak guard is NOT flagged",
+			body: `got := m.generateConfig(cfg)
+	_ = strings.Contains(got, "typo-gw")`,
+			want: 0,
+		},
+		{
+			name: "syntax needle on a NON-rendered value is NOT flagged",
+			body: `err := doThing()
+	_ = strings.Contains(err.Error(), "load-all = yes")`,
+			want: 0,
+		},
+		{
+			name: "two violations in one function are both reported",
+			body: `got := m.generateConfig(cfg)
+	_ = strings.Contains(got, "local_addrs = 1.1.1.1")
+	_ = strings.Contains(got, "remote_addrs = 2.2.2.2")`,
+			want: 2,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			src := "package ipsec\n\nimport \"strings\"\n\nfunc probe() {\n\t" + c.body + "\n}\n"
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, "probe_test.go", src, 0)
+			if err != nil {
+				t.Fatalf("parse synthetic source: %v\n%s", err, src)
+			}
+			got := findSwanctlContainment(fset, f)
+			if len(got) != c.want {
+				t.Errorf("detector found %d finding(s), want %d: %+v\n%s",
+					len(got), c.want, got, src)
+			}
+		})
+	}
+}

--- a/pkg/ipsec/swanctl_containment_guard_6824_test.go
+++ b/pkg/ipsec/swanctl_containment_guard_6824_test.go
@@ -79,20 +79,51 @@ func findSwanctlContainment(fset *token.FileSet, f *ast.File) []containmentFindi
 	// worse than one with a known blind spot, because the cost lands on someone
 	// who did nothing wrong.
 	rendered := map[string]bool{}
-	isRenderCall := func(e ast.Expr) bool {
+	// Render producers: the two render entry points, PLUS any function in this
+	// file that returns one of them.
+	//
+	// `renderMust` is exactly that shape -- it wraps renderConfig and every
+	// DHCP assertion went through it -- so an Ident-only match saw none of
+	// them. A guard blind to the helper the tests actually use is blind to the
+	// tests it is meant to guard.
+	producers := map[string]bool{"generateConfig": true, "renderConfig": true}
+	calleeName := func(e ast.Expr) string {
 		call, ok := e.(*ast.CallExpr)
 		if !ok {
-			return false
+			return ""
 		}
-		name := ""
 		switch fn := call.Fun.(type) {
 		case *ast.SelectorExpr:
-			name = fn.Sel.Name
+			return fn.Sel.Name
 		case *ast.Ident:
-			name = fn.Name
+			return fn.Name
 		}
-		return name == "generateConfig" || name == "renderConfig"
+		return ""
 	}
+	// Fixed point, so a helper wrapping a helper is also a producer.
+	for changed := true; changed; {
+		changed = false
+		for _, d := range f.Decls {
+			fn, ok := d.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || producers[fn.Name.Name] {
+				continue
+			}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				ret, ok := n.(*ast.ReturnStmt)
+				if !ok {
+					return true
+				}
+				for _, r := range ret.Results {
+					if producers[calleeName(r)] {
+						producers[fn.Name.Name] = true
+						changed = true
+					}
+				}
+				return true
+			})
+		}
+	}
+	isRenderCall := func(e ast.Expr) bool { return producers[calleeName(e)] }
 	noteAssign := func(lhs, rhs []ast.Expr) {
 		for i, l := range lhs {
 			id, ok := l.(*ast.Ident)
@@ -109,8 +140,15 @@ func findSwanctlContainment(fset *token.FileSet, f *ast.File) []containmentFindi
 			}
 		}
 	}
-	collect := func(scope ast.Node) {
-		ast.Inspect(scope, func(n ast.Node) bool {
+	collect := func(sc ast.Node) {
+		ast.Inspect(sc, func(n ast.Node) bool {
+			// Same rule as inspectCalls: a nested literal is its own scope, so
+			// a binding made inside one must not leak to its SIBLINGS. Without
+			// this, a render bound in one t.Run closure reached every other
+			// closure in the same function and made their locals look rendered.
+			if _, ok := n.(*ast.FuncLit); ok && n != sc {
+				return false
+			}
 			switch s := n.(type) {
 			case *ast.AssignStmt:
 				noteAssign(s.Lhs, s.Rhs)
@@ -128,8 +166,15 @@ func findSwanctlContainment(fset *token.FileSet, f *ast.File) []containmentFindi
 	}
 
 	var out []containmentFinding
-	inspectCalls := func(scope ast.Node) {
-		ast.Inspect(scope, func(n ast.Node) bool {
+	inspectCalls := func(sc ast.Node) {
+		ast.Inspect(sc, func(n ast.Node) bool {
+			// Do NOT descend into a nested function literal: it is walked as its
+			// own scope, and walking it twice reports every finding inside it
+			// twice.
+			if lit, ok := n.(*ast.FuncLit); ok && n != sc {
+				_ = lit
+				return false
+			}
 			call, ok := n.(*ast.CallExpr)
 			if !ok || len(call.Args) != 2 {
 				return true
@@ -181,18 +226,56 @@ func findSwanctlContainment(fset *token.FileSet, f *ast.File) []containmentFindi
 		})
 	}
 
-	// One function at a time, so a render binding in one test cannot make a
-	// same-named local in another test look like a rendered document. Package
-	// level (a var block holding a render call) is walked once as its own
-	// scope; nothing outside a function makes containment assertions.
+	// PACKAGE-LEVEL declarations first, and they persist across every scope
+	// below: a file-level `var got = m.generateConfig(cfg)` is visible to every
+	// function, so scoping it away made it invisible to the guard.
+	pkgLevel := map[string]bool{}
 	for _, d := range f.Decls {
-		fn, ok := d.(*ast.FuncDecl)
-		if !ok {
+		gd, ok := d.(*ast.GenDecl)
+		if !ok || gd.Tok != token.VAR {
 			continue
 		}
 		rendered = map[string]bool{}
-		collect(fn)
-		inspectCalls(fn)
+		collect(gd)
+		for k := range rendered {
+			pkgLevel[k] = true
+		}
+	}
+
+	// Then one scope at a time. A scope is a FuncDecl or a function LITERAL --
+	// sibling t.Run closures are separate scopes, so a rendered `got` in one
+	// cannot make an unrelated error-message `got` in the next a false
+	// positive. Nesting is handled by walking outward-in: an inner literal
+	// starts from its enclosing scope's bindings, which is what Go's own
+	// scoping does.
+	var scope func(n ast.Node, outer map[string]bool)
+	scope = func(n ast.Node, outer map[string]bool) {
+		rendered = map[string]bool{}
+		for k := range outer {
+			rendered[k] = true
+		}
+		collect(n)
+		here := map[string]bool{}
+		for k := range rendered {
+			here[k] = true
+		}
+		inspectCalls(n)
+
+		ast.Inspect(n, func(m ast.Node) bool {
+			lit, ok := m.(*ast.FuncLit)
+			if !ok || m == n {
+				return true
+			}
+			scope(lit, here)
+			return false
+		})
+	}
+	for _, d := range f.Decls {
+		fn, ok := d.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		scope(fn, pkgLevel)
 	}
 	return out
 }
@@ -276,6 +359,98 @@ func TestNoSwanctlSyntaxInContainmentNeedles_6824(t *testing.T) {
 	}
 }
 
+// TestGuardSeesPackageLevelAndNestedScopes_6824 covers the three provenance
+// cases a per-FuncDecl walk missed.
+//
+// Each is an ordinary shape in this package's tests, and each produced ZERO
+// findings before: a render bound by a HELPER (renderMust wraps renderConfig,
+// and every DHCP assertion went through it), a render bound at PACKAGE level,
+// and a violation inside a t.Run CLOSURE.
+func TestGuardSeesPackageLevelAndNestedScopes_6824(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		src  string
+		want int
+	}{
+		{
+			name: "package-level render binding",
+			src: `package ipsec
+
+import "strings"
+
+var got = m.generateConfig(cfg)
+
+func probe() {
+	_ = strings.Contains(got, "remote_addrs = 1.1.1.1")
+}
+`,
+			want: 1,
+		},
+		{
+			name: "violation inside a closure, render bound outside it",
+			src: `package ipsec
+
+import "strings"
+
+func probe(t *testing.T) {
+	got := m.generateConfig(cfg)
+	t.Run("x", func(t *testing.T) {
+		_ = strings.Contains(got, "remote_addrs = 1.1.1.1")
+	})
+}
+`,
+			want: 1,
+		},
+		{
+			name: "sibling closures do NOT collide",
+			src: `package ipsec
+
+import "strings"
+
+func probe(t *testing.T) {
+	t.Run("renders", func(t *testing.T) {
+		got := m.generateConfig(cfg)
+		_ = got
+	})
+	t.Run("asserts an error", func(t *testing.T) {
+		got := doThing().Error()
+		_ = strings.Contains(got, "load-all = yes")
+	})
+}
+`,
+			want: 0,
+		},
+		{
+			name: "a violation is reported ONCE, not once per enclosing scope",
+			src: `package ipsec
+
+import "strings"
+
+func probe(t *testing.T) {
+	got := m.generateConfig(cfg)
+	t.Run("a", func(t *testing.T) {
+		t.Run("b", func(t *testing.T) {
+			_ = strings.Contains(got, "remote_addrs = 1.1.1.1")
+		})
+	})
+}
+`,
+			want: 1,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, "probe_test.go", c.src, 0)
+			if err != nil {
+				t.Fatalf("parse synthetic source: %v", err)
+			}
+			if got := findSwanctlContainment(fset, f); len(got) != c.want {
+				t.Errorf("found %d finding(s), want %d: %+v", len(got), c.want, got)
+			}
+		})
+	}
+}
+
 // TestGuardScopesRenderVariablesPerFunction_6824 is the false-POSITIVE control.
 //
 // The detector used to collect render-variable names file-wide, so one test
@@ -322,8 +497,21 @@ func TestContainmentGuardSensitivity_6824(t *testing.T) {
 	cases := []struct {
 		name string
 		body string
-		want int
+		// extra is appended after the probe function, for a cell that needs a
+		// helper DEFINED -- the producer fixed point can only recognise a
+		// wrapper it can see.
+		extra string
+		want  int
 	}{
+		{
+			name: "render produced by a HELPER that wraps renderConfig",
+			body: `got := renderMust(cfg)
+	_ = strings.Contains(got, "local_addrs = 1.1.1.1")`,
+			extra: `
+func renderMust(cfg *Config) string { return m.renderConfig(cfg) }
+`,
+			want: 1,
+		},
 		{
 			name: "section opener needle with a trailing newline",
 			body: `got := m.generateConfig(cfg)
@@ -382,7 +570,7 @@ func TestContainmentGuardSensitivity_6824(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			src := "package ipsec\n\nimport \"strings\"\n\nfunc probe() {\n\t" + c.body + "\n}\n"
+			src := "package ipsec\n\nimport \"strings\"\n\nfunc probe() {\n\t" + c.body + "\n}\n" + c.extra
 			fset := token.NewFileSet()
 			f, err := parser.ParseFile(fset, "probe_test.go", src, 0)
 			if err != nil {

--- a/pkg/ipsec/swanctl_doc_6824_test.go
+++ b/pkg/ipsec/swanctl_doc_6824_test.go
@@ -55,6 +55,17 @@ type swanctlNode struct {
 
 // parseSwanctlDoc parses a rendered document into a section tree.
 //
+// One ambiguity is worth stating rather than discovering: a line is classified
+// as a section opener before it is classified as a setting, so a SETTING whose
+// value ends in an open brace (`local_ts = 10.0.0.0/24 {`, reachable only via an
+// unsanitized injected value) is read as a section named
+// `local_ts = 10.0.0.0/24`. The reverse ordering has a mirror-image flaw: a
+// section whose NAME contains an equals sign would be read as a setting. Both
+// orderings fail LOUDLY -- the bogus section leaves the document unbalanced and
+// the end-of-parse check fires -- so the choice is about which message is
+// clearer, not about whether the defect escapes. Neither shape is reachable
+// from a validated config; both are what the sanitize belts exist to prevent.
+//
 // It recognises exactly the line shapes the renderer emits -- `name {`, `}`,
 // `key = value`, comments, blanks. Anything else FAILS rather than being
 // skipped: a line this parser does not recognise is one the renderer emitted

--- a/pkg/ipsec/swanctl_doc_6824_test.go
+++ b/pkg/ipsec/swanctl_doc_6824_test.go
@@ -90,13 +90,35 @@ func parseSwanctlDoc(t swanctlTB, doc string) *swanctlNode {
 		if line == "" {
 			continue
 		}
-		// A comment is a line starting '#' that is NOT also a section opener or
-		// a setting. Without those two exclusions a SECTION whose name begins
-		// '#' (a connection named "#b" -- reachable, see the doc comment) is
-		// skipped silently, and its real closing brace then cancels an
-		// unrelated fake open. The document balances and the tree is wrong with
-		// no error at all.
-		if strings.HasPrefix(line, "#") && !strings.HasSuffix(line, "{") && !strings.Contains(line, "=") {
+		// AMBIGUOUS SHAPES ARE REFUSED, NOT CLASSIFIED.
+		//
+		// Two line shapes cannot be told apart from the line alone: one
+		// starting '#' and ending '{' (a comment, or a section whose name
+		// begins '#'), and one containing '=' and ending '{' (a setting whose
+		// value ends in a brace, or a section whose name contains '=').
+		//
+		// The first cut of this parser guessed at each, and the guesses
+		// CANCELLED: a fake open from one was closed by a real brace from the
+		// other, the stack balanced, and the tree silently lacked a section the
+		// renderer emitted. Fixing the guesses only moved the pair -- reversing
+		// which half is misread reproduces the cancellation exactly.
+		//
+		// Neither shape is reachable from this renderer (generateConfig emits
+		// one fixed header comment and section names come from config object
+		// names). So the honest response is to fail on them rather than to pick
+		// an interpretation: a parser that guesses can cancel its guesses, and a
+		// parser that refuses cannot.
+		if strings.HasSuffix(line, "{") && strings.HasPrefix(line, "#") {
+			t.Fatalf("line %d: %q both opens a section and looks like a comment. This "+
+				"parser refuses ambiguous shapes rather than guessing -- two guesses "+
+				"can cancel and leave a balanced document with a wrong tree:\n%s",
+				i+1, line, doc)
+		}
+		if strings.HasSuffix(line, "{") && strings.Contains(line, "=") {
+			t.Fatalf("line %d: %q both opens a section and looks like a setting. Same "+
+				"refusal as above; see the doc comment:\n%s", i+1, line, doc)
+		}
+		if strings.HasPrefix(line, "#") {
 			continue
 		}
 		cur := stack[len(stack)-1]
@@ -108,13 +130,7 @@ func parseSwanctlDoc(t swanctlTB, doc string) *swanctlNode {
 			}
 			stack = stack[:len(stack)-1]
 
-		// A section opener carries no '='. A line that ends in an open brace AND
-		// contains one is a SETTING whose value happens to end in a brace
-		// (`local_ts = 10.0.0.0/24 {`, reachable from an authored quoted token:
-		// sanitizeSwanctlValue strips control bytes, not braces). Classifying it
-		// as a section opened a phantom nesting level that a later real close
-		// could cancel, leaving a balanced document and a silently wrong tree.
-		case strings.HasSuffix(line, "{") && !strings.Contains(line, "="):
+		case strings.HasSuffix(line, "{"):
 			name := strings.TrimSpace(strings.TrimSuffix(line, "{"))
 			if name == "" {
 				t.Fatalf("line %d: section opened with no name:\n%s", i+1, doc)
@@ -317,24 +333,50 @@ func (n *swanctlNode) hasNoSettingAnywhere(t swanctlTB, key string) {
 	walk(n, n.name)
 }
 
-// hasNoSettingValueAnywhere asserts no section in the tree declares key with
-// this exact value.
+// hasNoSettingValuePrefixAnywhere asserts no section declares key with a value
+// STARTING with forbidden.
 //
-// It exists because several converted assertions replaced a WHOLE-DOCUMENT
-// negative ("esp_proposals = default appears nowhere") with equality at one
-// path. Those are not the same claim: the parser has no schema forbidding the
-// same key under a different connection, so a correct setting at the asserted
-// path plus a forbidden one elsewhere passes the equality and would have failed
-// the old needle. Where the original claim was document-wide, the replacement
-// has to be too.
-func (n *swanctlNode) hasNoSettingValueAnywhere(t swanctlTB, key, forbidden string) {
+// This is the faithful structural form of a deleted
+// `strings.Contains(doc, "<key> = <forbidden>")` needle. Exact equality is NOT
+// faithful: the renderer emits comma-joined lists, so
+// `esp_proposals = default,aes256` contains the old needle and FAILED it, while
+// an equality check passes. Five restorations were written as equality and were
+// all weaker than the checks they replaced for exactly that reason.
+func (n *swanctlNode) hasNoSettingValuePrefixAnywhere(t swanctlTB, key, forbidden string) {
 	t.Helper()
 	var walk func(*swanctlNode, string)
 	walk = func(node *swanctlNode, path string) {
 		for _, v := range node.settings[key] {
-			if v == forbidden {
-				t.Errorf("%s = %q at %s; that value must appear NOWHERE in the "+
-					"document, not merely not at the path under test", key, forbidden, path)
+			if strings.HasPrefix(v, forbidden) {
+				t.Errorf("%s = %q at %s, which begins with the forbidden %q. The needle "+
+					"this replaced matched the rendered LINE, so a comma list starting "+
+					"with the forbidden value failed it too.", key, v, path, forbidden)
+			}
+		}
+		for _, name := range node.order {
+			walk(node.children[name], path+"."+name)
+		}
+	}
+	walk(n, n.name)
+}
+
+// hasNoValueSubstringAnywhere asserts no setting value anywhere CONTAINS substr.
+//
+// The faithful form of a deleted bare-token needle -- one that named no key, so
+// it matched the token anywhere in the document, including as a member of a
+// comma list. `Contains(doc, "sha256-modp2048")` is that shape: an equality
+// check on one key misses `esp_proposals = aes128-sha256-modp2048` entirely.
+func (n *swanctlNode) hasNoValueSubstringAnywhere(t swanctlTB, substr string) {
+	t.Helper()
+	var walk func(*swanctlNode, string)
+	walk = func(node *swanctlNode, path string) {
+		for _, k := range node.settingNames() {
+			for _, v := range node.settings[k] {
+				if strings.Contains(v, substr) {
+					t.Errorf("%s.%s = %q contains the forbidden %q; the needle this "+
+						"replaced named no key, so it matched the token ANYWHERE "+
+						"including inside a comma list", path, k, v, substr)
+				}
 			}
 		}
 		for _, name := range node.order {

--- a/pkg/ipsec/swanctl_doc_6824_test.go
+++ b/pkg/ipsec/swanctl_doc_6824_test.go
@@ -1,0 +1,218 @@
+package ipsec
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// swanctl_doc_6824_test.go -- #6824.
+//
+// The render tests asserted on generated swanctl configuration with
+// strings.Contains. A containment assertion cannot distinguish valid output from
+// output that merely contains the right substrings in the WRONG STRUCTURE: a
+// `remote_addrs = 203.0.113.1` line satisfies it whether it sits under the
+// connection it belongs to, under a sibling connection, or outside every
+// section entirely.
+//
+// # What this file claims, and what it does NOT
+//
+// strongSwan is not installed here (`which swanctl charon ipsec` finds nothing),
+// so the rendered document cannot be checked against the real parser. This file
+// therefore does NOT implement a swanctl grammar, and nothing in it should be
+// read as one -- that would be a proxy for a grammar with nothing to check it
+// against, which is the containment defect again with more code.
+//
+// What it asserts instead are properties of OUR OWN RENDERER, which we control
+// and can state exactly: brace nesting balances, every setting sits at a known
+// path, one key per line, no duplicate key within a section, no duplicate
+// section within a parent. Those are facts about generateConfig, not claims
+// about strongSwan. Conformance to the real parser is a separate and stronger
+// property that needs the package installed, and remains worth doing.
+
+// swanctlTB is the narrow slice of *testing.T this checker uses.
+//
+// It exists so the checker's OWN tests can drive it with a capturing fake and
+// assert that it rejects a malformed document -- without a deliberately-failing
+// sub-test appearing in the suite output, which would make a healthy run
+// indistinguishable from a broken one. testing.TB cannot be implemented outside
+// the testing package (it has an unexported method), hence a local interface.
+//
+// *testing.T satisfies this by construction.
+type swanctlTB interface {
+	Helper()
+	Errorf(format string, args ...any)
+	Fatalf(format string, args ...any)
+}
+
+// swanctlNode is one parsed section of a rendered document.
+type swanctlNode struct {
+	name     string
+	settings map[string][]string // key -> values; a slice so duplicates stay visible
+	children map[string]*swanctlNode
+	order    []string // child insertion order, for stable messages
+}
+
+// parseSwanctlDoc parses a rendered document into a section tree.
+//
+// It recognises exactly the line shapes the renderer emits -- `name {`, `}`,
+// `key = value`, comments, blanks. Anything else FAILS rather than being
+// skipped: a line this parser does not recognise is one the renderer emitted
+// that no structural test describes, and silently ignoring it is precisely how a
+// structural check decays back into a containment check.
+func parseSwanctlDoc(t swanctlTB, doc string) *swanctlNode {
+	t.Helper()
+	root := &swanctlNode{name: "<root>", settings: map[string][]string{}, children: map[string]*swanctlNode{}}
+	stack := []*swanctlNode{root}
+
+	for i, raw := range strings.Split(doc, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		cur := stack[len(stack)-1]
+
+		switch {
+		case line == "}":
+			if len(stack) == 1 {
+				t.Fatalf("line %d: closing brace with no open section:\n%s", i+1, doc)
+			}
+			stack = stack[:len(stack)-1]
+
+		case strings.HasSuffix(line, "{"):
+			name := strings.TrimSpace(strings.TrimSuffix(line, "{"))
+			if name == "" {
+				t.Fatalf("line %d: section opened with no name:\n%s", i+1, doc)
+			}
+			if _, dup := cur.children[name]; dup {
+				t.Errorf("line %d: section %q declared twice under %q -- one of them "+
+					"wins and the other's settings are silently lost", i+1, name, cur.name)
+			}
+			child := &swanctlNode{name: name, settings: map[string][]string{}, children: map[string]*swanctlNode{}}
+			cur.children[name] = child
+			cur.order = append(cur.order, name)
+			stack = append(stack, child)
+
+		case strings.Contains(line, "="):
+			k, v, _ := strings.Cut(line, "=")
+			k, v = strings.TrimSpace(k), strings.TrimSpace(v)
+			if k == "" {
+				t.Fatalf("line %d: setting with an empty key:\n%s", i+1, doc)
+			}
+			cur.settings[k] = append(cur.settings[k], v)
+
+		default:
+			t.Fatalf("line %d: unrecognised line %q -- the renderer emitted a shape no "+
+				"structural test describes. Extend this parser rather than letting it "+
+				"pass, or the check degrades to containment:\n%s", i+1, line, doc)
+		}
+	}
+	if len(stack) != 1 {
+		var open []string
+		for _, n := range stack[1:] {
+			open = append(open, n.name)
+		}
+		t.Fatalf("document ends with %d section(s) still open: %s\n%s",
+			len(stack)-1, strings.Join(open, " > "), doc)
+	}
+	return root
+}
+
+// at walks a path of section names, failing with the deepest section it DID
+// reach -- so a misnested setting reports where the tree actually put it, not
+// merely that the path was absent.
+func (n *swanctlNode) at(t swanctlTB, path ...string) *swanctlNode {
+	t.Helper()
+	cur := n
+	for i, p := range path {
+		next, ok := cur.children[p]
+		if !ok {
+			t.Fatalf("no section %q under %q (reached %v of %v); sections there: %v\n%s",
+				p, cur.name, path[:i], path, cur.childNames(), n)
+		}
+		cur = next
+	}
+	return cur
+}
+
+func (n *swanctlNode) childNames() []string {
+	out := append([]string(nil), n.order...)
+	sort.Strings(out)
+	return out
+}
+
+// setting returns the single value of key in THIS section, failing if it is
+// absent or DUPLICATED. The duplicate case is the one containment cannot see at
+// all: two `remote_addrs` lines in one section satisfy any Contains check while
+// leaving which one applies to the parser.
+func (n *swanctlNode) setting(t swanctlTB, key string) string {
+	t.Helper()
+	vals, ok := n.settings[key]
+	if !ok {
+		t.Fatalf("section %q has no setting %q; keys present: %v", n.name, key, n.settingNames())
+	}
+	if len(vals) != 1 {
+		t.Fatalf("section %q declares %q %d times (%v); which one applies is left to "+
+			"the parser", n.name, key, len(vals), vals)
+	}
+	return vals[0]
+}
+
+// hasNoSetting asserts a key is absent HERE -- how a test says "this value must
+// not have landed in the wrong section".
+func (n *swanctlNode) hasNoSetting(t swanctlTB, key string) {
+	t.Helper()
+	if vals, ok := n.settings[key]; ok {
+		t.Errorf("section %q unexpectedly declares %q = %v", n.name, key, vals)
+	}
+}
+
+func (n *swanctlNode) settingNames() []string {
+	out := make([]string, 0, len(n.settings))
+	for k := range n.settings {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// String renders the tree back as an indented outline, so a failure shows
+// STRUCTURE rather than the raw document a containment failure would dump.
+func (n *swanctlNode) String() string {
+	var b strings.Builder
+	var walk func(*swanctlNode, int)
+	walk = func(node *swanctlNode, depth int) {
+		pad := strings.Repeat("  ", depth)
+		for _, k := range node.settingNames() {
+			fmt.Fprintf(&b, "%s%s = %v\n", pad, k, node.settings[k])
+		}
+		for _, name := range node.order {
+			fmt.Fprintf(&b, "%s%s {\n", pad, name)
+			walk(node.children[name], depth+1)
+			fmt.Fprintf(&b, "%s}\n", pad)
+		}
+	}
+	walk(n, 0)
+	return b.String()
+}
+
+// hasNoChild asserts a section is absent HERE -- how a test says "this
+// connection must not have been rendered at all", replacing a
+// `strings.Contains(out, "tun-bad {")` needle that depends on brace placement
+// and would also match the string appearing inside a value.
+func (n *swanctlNode) hasNoChild(t swanctlTB, name string) {
+	t.Helper()
+	if c, ok := n.children[name]; ok {
+		t.Errorf("section %q unexpectedly contains a %q section:\n%s", n.name, name, c)
+	}
+}
+
+// requireSetting is the common conversion of `!strings.Contains(got, "k = v")`:
+// it names the PATH the setting must sit at, so the same rendered value under a
+// different section is a failure rather than a pass.
+func (n *swanctlNode) requireSetting(t swanctlTB, key, want string) {
+	t.Helper()
+	if got := n.setting(t, key); got != want {
+		t.Errorf("%s.%s = %q, want %q", n.name, key, got, want)
+	}
+}

--- a/pkg/ipsec/swanctl_doc_6824_test.go
+++ b/pkg/ipsec/swanctl_doc_6824_test.go
@@ -26,7 +26,14 @@ import (
 // What it asserts instead are properties of OUR OWN RENDERER, which we control
 // and can state exactly: brace nesting balances, every setting sits at a known
 // path, one key per line, no duplicate key within a section, no duplicate
-// section within a parent. Those are facts about generateConfig, not claims
+// section within a parent. One thing they are NOT: byte-exact. Both the line
+// and the two halves of a setting are trimmed, so trailing whitespace on a
+// value is normalised away and an equality assertion here does not reject it,
+// where a needle ending in "\n" did. That is a deliberate trade -- the old
+// needles were pinning the renderer's whitespace, not its structure -- but it
+// is a real difference and not a strengthening.
+//
+// Those are facts about generateConfig, not claims
 // about strongSwan. Conformance to the real parser is a separate and stronger
 // property that needs the package installed, and remains worth doing.
 
@@ -55,22 +62,24 @@ type swanctlNode struct {
 
 // parseSwanctlDoc parses a rendered document into a section tree.
 //
-// One ambiguity is worth stating rather than discovering: a line is classified
-// as a section opener before it is classified as a setting, so a SETTING whose
-// value ends in an open brace (`local_ts = 10.0.0.0/24 {`, reachable only via an
-// unsanitized injected value) is read as a section named
-// `local_ts = 10.0.0.0/24`. The reverse ordering has a mirror-image flaw: a
-// section whose NAME contains an equals sign would be read as a setting. Both
-// orderings fail LOUDLY -- the bogus section leaves the document unbalanced and
-// the end-of-parse check fires -- so the choice is about which message is
-// clearer, not about whether the defect escapes. Neither shape is reachable
-// from a validated config; both are what the sanitize belts exist to prevent.
+// Two line shapes are ambiguous, and the first cut of this parser got both
+// wrong in a way that did NOT fail loudly, contrary to what its comment claimed:
 //
-// It recognises exactly the line shapes the renderer emits -- `name {`, `}`,
-// `key = value`, comments, blanks. Anything else FAILS rather than being
-// skipped: a line this parser does not recognise is one the renderer emitted
-// that no structural test describes, and silently ignoring it is precisely how a
-// structural check decays back into a containment check.
+//   - a SETTING whose value ends in an open brace (`local_ts = 10.0.0.0/24 {`)
+//     read as a section opener, and
+//   - a SECTION whose name begins '#' (a connection named "#b") skipped as a
+//     comment.
+//
+// Either alone unbalances the document and the end-of-parse check fires. TOGETHER
+// they CANCEL: the phantom open from the first is closed by the real brace of the
+// second, the stack balances, and the tree silently lacks a section the renderer
+// emitted -- so hasNoChild("#b") passes on a document that contains it. Both
+// values are reachable from authored quoted tokens (pkg/config/schema_security.go,
+// copied through compiler_ipsec.go, rendered at policy.go); sanitizeSwanctlValue
+// strips control bytes, not braces or hashes.
+//
+// Both are now classified on content rather than on a single suffix: a section
+// opener carries no '=', and a comment is neither a section opener nor a setting.
 func parseSwanctlDoc(t swanctlTB, doc string) *swanctlNode {
 	t.Helper()
 	root := &swanctlNode{name: "<root>", settings: map[string][]string{}, children: map[string]*swanctlNode{}}
@@ -78,7 +87,16 @@ func parseSwanctlDoc(t swanctlTB, doc string) *swanctlNode {
 
 	for i, raw := range strings.Split(doc, "\n") {
 		line := strings.TrimSpace(raw)
-		if line == "" || strings.HasPrefix(line, "#") {
+		if line == "" {
+			continue
+		}
+		// A comment is a line starting '#' that is NOT also a section opener or
+		// a setting. Without those two exclusions a SECTION whose name begins
+		// '#' (a connection named "#b" -- reachable, see the doc comment) is
+		// skipped silently, and its real closing brace then cancels an
+		// unrelated fake open. The document balances and the tree is wrong with
+		// no error at all.
+		if strings.HasPrefix(line, "#") && !strings.HasSuffix(line, "{") && !strings.Contains(line, "=") {
 			continue
 		}
 		cur := stack[len(stack)-1]
@@ -90,7 +108,13 @@ func parseSwanctlDoc(t swanctlTB, doc string) *swanctlNode {
 			}
 			stack = stack[:len(stack)-1]
 
-		case strings.HasSuffix(line, "{"):
+		// A section opener carries no '='. A line that ends in an open brace AND
+		// contains one is a SETTING whose value happens to end in a brace
+		// (`local_ts = 10.0.0.0/24 {`, reachable from an authored quoted token:
+		// sanitizeSwanctlValue strips control bytes, not braces). Classifying it
+		// as a section opened a phantom nesting level that a later real close
+		// could cancel, leaving a balanced document and a silently wrong tree.
+		case strings.HasSuffix(line, "{") && !strings.Contains(line, "="):
 			name := strings.TrimSpace(strings.TrimSuffix(line, "{"))
 			if name == "" {
 				t.Fatalf("line %d: section opened with no name:\n%s", i+1, doc)
@@ -109,6 +133,16 @@ func parseSwanctlDoc(t swanctlTB, doc string) *swanctlNode {
 			k, v = strings.TrimSpace(k), strings.TrimSpace(v)
 			if k == "" {
 				t.Fatalf("line %d: setting with an empty key:\n%s", i+1, doc)
+			}
+			if _, dup := cur.settings[k]; dup {
+				// Stated as a parse invariant in this file's doc comment, so it
+				// must fire HERE. Detecting it only when setting() happens to
+				// be called leaves a path-only test green on a document with a
+				// duplicated, unqueried key -- which is the containment defect
+				// with extra steps.
+				t.Errorf("line %d: section %q declares %q more than once (%v, now %q); "+
+					"which one applies is left to the parser", i+1, cur.name, k,
+					cur.settings[k], v)
 			}
 			cur.settings[k] = append(cur.settings[k], v)
 
@@ -275,6 +309,33 @@ func (n *swanctlNode) hasNoSettingAnywhere(t swanctlTB, key string) {
 		if vals, ok := node.settings[key]; ok {
 			t.Errorf("setting %q became live at %s = %v; nothing in this fixture "+
 				"renders that key, so it can only have been injected", key, path, vals)
+		}
+		for _, name := range node.order {
+			walk(node.children[name], path+"."+name)
+		}
+	}
+	walk(n, n.name)
+}
+
+// hasNoSettingValueAnywhere asserts no section in the tree declares key with
+// this exact value.
+//
+// It exists because several converted assertions replaced a WHOLE-DOCUMENT
+// negative ("esp_proposals = default appears nowhere") with equality at one
+// path. Those are not the same claim: the parser has no schema forbidding the
+// same key under a different connection, so a correct setting at the asserted
+// path plus a forbidden one elsewhere passes the equality and would have failed
+// the old needle. Where the original claim was document-wide, the replacement
+// has to be too.
+func (n *swanctlNode) hasNoSettingValueAnywhere(t swanctlTB, key, forbidden string) {
+	t.Helper()
+	var walk func(*swanctlNode, string)
+	walk = func(node *swanctlNode, path string) {
+		for _, v := range node.settings[key] {
+			if v == forbidden {
+				t.Errorf("%s = %q at %s; that value must appear NOWHERE in the "+
+					"document, not merely not at the path under test", key, forbidden, path)
+			}
 		}
 		for _, name := range node.order {
 			walk(node.children[name], path+"."+name)

--- a/pkg/ipsec/swanctl_doc_6824_test.go
+++ b/pkg/ipsec/swanctl_doc_6824_test.go
@@ -216,3 +216,58 @@ func (n *swanctlNode) requireSetting(t swanctlTB, key, want string) {
 		t.Errorf("%s.%s = %q, want %q", n.name, key, got, want)
 	}
 }
+
+// settingMembers splits a comma-joined setting value (swanctl's proposal
+// lists) into its members.
+//
+// It exists because containment on a member token is doubly unsound: `3des-sha1`
+// is a substring of `3des-sha1-modp1024`, so a Phase-2 assertion written as
+// Contains(doc, "3des-sha1") is satisfied by the PHASE-1 line and passes even if
+// esp_proposals is missing entirely. Membership in the split value of a named
+// setting cannot be satisfied by a different line or a longer token.
+func (n *swanctlNode) settingMembers(t swanctlTB, key string) []string {
+	t.Helper()
+	raw := n.setting(t, key)
+	parts := strings.Split(raw, ",")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts
+}
+
+// requireMembers asserts every want is a member of the comma-joined value of
+// key -- an exact token match, not a substring of a longer one.
+func (n *swanctlNode) requireMembers(t swanctlTB, key string, want ...string) {
+	t.Helper()
+	got := n.settingMembers(t, key)
+	have := map[string]bool{}
+	for _, g := range got {
+		have[g] = true
+	}
+	for _, w := range want {
+		if !have[w] {
+			t.Errorf("%s.%s = %v, missing member %q", n.name, key, got, w)
+		}
+	}
+}
+
+// hasNoSettingAnywhere asserts no section in the whole tree declares key.
+//
+// This is how a test says "an injected directive never became a live setting",
+// and it is strictly stronger than scanning for a line that trims to the exact
+// injected text: it fires whatever VALUE the injection carried, and at whatever
+// nesting depth the render placed it.
+func (n *swanctlNode) hasNoSettingAnywhere(t swanctlTB, key string) {
+	t.Helper()
+	var walk func(*swanctlNode, string)
+	walk = func(node *swanctlNode, path string) {
+		if vals, ok := node.settings[key]; ok {
+			t.Errorf("setting %q became live at %s = %v; nothing in this fixture "+
+				"renders that key, so it can only have been injected", key, path, vals)
+		}
+		for _, name := range node.order {
+			walk(node.children[name], path+"."+name)
+		}
+	}
+	walk(n, n.name)
+}

--- a/pkg/ipsec/swanctl_doc_selftest_6824_test.go
+++ b/pkg/ipsec/swanctl_doc_selftest_6824_test.go
@@ -104,6 +104,15 @@ func TestStructuralCheckerCatchesWhatContainmentCannot_6824(t *testing.T) {
 // fires from setting() rather than from the parse, and it is the single case
 // most invisible to containment: the key is present, twice.
 func TestStructuralCheckerCatchesADuplicateSetting_6824(t *testing.T) {
+	// Duplicate rejection is claimed as a PARSE invariant, so it must fire
+	// without setting() being called at all -- otherwise a path-only test stays
+	// green on a document with a duplicated, unqueried key.
+	dupOnly := "connections {\n  tun {\n    remote_addrs = 1.1.1.1\n    remote_addrs = 2.2.2.2\n  }\n}\n"
+	if rejected, _ := checkerRejects(dupOnly, nil); !rejected {
+		t.Error("parsing alone accepted a duplicated setting; the invariant is only " +
+			"enforced when setting() happens to be called, which a path-only test does not do")
+	}
+
 	doc := "connections {\n  tun {\n    remote_addrs = 1.1.1.1\n    remote_addrs = 2.2.2.2\n  }\n}\n"
 	if !strings.Contains(doc, "remote_addrs = 1.1.1.1") {
 		t.Fatal("fixture does not contain the value a containment assertion would look for")
@@ -164,5 +173,50 @@ func TestStructuralCheckerDistinguishesNestingFromContainment_6824(t *testing.T)
 			"that is exactly the class strings.Contains cannot see")
 	} else {
 		t.Logf("rejected as expected: %s", why)
+	}
+}
+
+// TestStructuralCheckerResolvesTheCancellingShapes_6824 is the cancellation case,
+// and it asserts CORRECTNESS rather than rejection.
+//
+// Two ambiguous line shapes -- a setting whose value ends in an open brace, and
+// a section whose name begins '#' -- each unbalance the document on their own,
+// so the end-of-parse check catches either alone. Together they CANCEL: the
+// phantom open from the first is closed by the real brace of the second, the
+// stack balances, and the tree silently loses the section the renderer emitted.
+// A test asking only "was it rejected?" would go green on the broken parser
+// precisely because the document balanced.
+//
+// So this asserts what the tree must CONTAIN. Before the fix, connections."#b"
+// was absent and hasNoChild("#b") passed on a document that contains it.
+func TestStructuralCheckerResolvesTheCancellingShapes_6824(t *testing.T) {
+	doc := "connections {\n  !a {\n    local_ts = 10.0.0.0/24 {\n  }\n" +
+		"  #b {\n    remote_addrs = 1.1.1.1\n  }\n}\n"
+
+	root := parseSwanctlDoc(t, doc)
+	conns := root.at(t, "connections")
+
+	// The brace-terminated VALUE stayed a setting and did not open a section.
+	a := conns.at(t, "!a")
+	if got := a.setting(t, "local_ts"); got != "10.0.0.0/24 {" {
+		t.Errorf("!a.local_ts = %q, want %q -- a value ending in a brace was read as "+
+			"a section opener", got, "10.0.0.0/24 {")
+	}
+	if len(a.order) != 0 {
+		t.Errorf("!a opened %v; a setting must not create a nesting level", a.childNames())
+	}
+
+	// The hash-named SECTION survived and was not eaten as a comment. This is
+	// the half that makes the failure silent: without it hasNoChild("#b")
+	// passes on a document that plainly contains #b.
+	b := conns.at(t, "#b")
+	b.requireSetting(t, "remote_addrs", "1.1.1.1")
+
+	// And a real comment is still a comment.
+	root2 := parseSwanctlDoc(t, "# xpf managed config - do not edit\nconnections {\n}\n")
+	root2.at(t, "connections")
+	if names := root2.childNames(); len(names) != 1 {
+		t.Errorf("top-level sections = %v, want exactly [connections]; the comment "+
+			"exclusions must not turn an ordinary comment into a section", names)
 	}
 }

--- a/pkg/ipsec/swanctl_doc_selftest_6824_test.go
+++ b/pkg/ipsec/swanctl_doc_selftest_6824_test.go
@@ -176,47 +176,69 @@ func TestStructuralCheckerDistinguishesNestingFromContainment_6824(t *testing.T)
 	}
 }
 
-// TestStructuralCheckerResolvesTheCancellingShapes_6824 is the cancellation case,
-// and it asserts CORRECTNESS rather than rejection.
+// TestStructuralCheckerRefusesAmbiguousShapes_6824 is the cancellation case,
+// and it went through two wrong answers before this one.
 //
-// Two ambiguous line shapes -- a setting whose value ends in an open brace, and
-// a section whose name begins '#' -- each unbalance the document on their own,
-// so the end-of-parse check catches either alone. Together they CANCEL: the
-// phantom open from the first is closed by the real brace of the second, the
-// stack balances, and the tree silently loses the section the renderer emitted.
-// A test asking only "was it rejected?" would go green on the broken parser
-// precisely because the document balanced.
+// Two line shapes cannot be told apart from the line alone: one starting '#'
+// and ending '{', and one containing '=' and ending '{'. The first version of
+// the parser GUESSED at each, and the guesses cancelled -- a fake open from one
+// closed by a real brace from the other, leaving a balanced document and a tree
+// missing a section the renderer emitted.
 //
-// So this asserts what the tree must CONTAIN. Before the fix, connections."#b"
-// was absent and hasNoChild("#b") passed on a document that contains it.
-func TestStructuralCheckerResolvesTheCancellingShapes_6824(t *testing.T) {
-	doc := "connections {\n  !a {\n    local_ts = 10.0.0.0/24 {\n  }\n" +
-		"  #b {\n    remote_addrs = 1.1.1.1\n  }\n}\n"
-
-	root := parseSwanctlDoc(t, doc)
-	conns := root.at(t, "connections")
-
-	// The brace-terminated VALUE stayed a setting and did not open a section.
-	a := conns.at(t, "!a")
-	if got := a.setting(t, "local_ts"); got != "10.0.0.0/24 {" {
-		t.Errorf("!a.local_ts = %q, want %q -- a value ending in a brace was read as "+
-			"a section opener", got, "10.0.0.0/24 {")
+// The second version guessed BETTER (a section opener carries no '='; a comment
+// is neither a section nor a setting) and was still wrong, because reversing
+// which half is misread reproduces the cancellation exactly:
+//
+//	connections {
+//	  # metadata {          <- read as a section, since it ends in a brace
+//	  vpn=prod {            <- read as a setting, since it contains '='
+//	    remote_addrs = 1.1.1.1
+//	  }
+//	}
+//
+// A parser that guesses can cancel its guesses. A parser that REFUSES cannot,
+// which is why both shapes are now hard failures. Neither is reachable from
+// this renderer, so refusing costs nothing and removes the whole class.
+func TestStructuralCheckerRefusesAmbiguousShapes_6824(t *testing.T) {
+	for _, c := range []struct{ name, doc, why string }{
+		{
+			name: "setting whose value ends in a brace",
+			doc:  "connections {\n  a {\n    local_ts = 10.0.0.0/24 {\n  }\n}\n",
+			why:  "section-or-setting",
+		},
+		{
+			name: "comment that also opens a section",
+			doc:  "connections {\n  # metadata {\n}\n",
+			why:  "comment-or-section",
+		},
+		{
+			name: "the CANCELLING pair, in the order that defeated the second version",
+			doc: "connections {\n  # metadata {\n  vpn=prod {\n" +
+				"    remote_addrs = 1.1.1.1\n  }\n}\n",
+			why: "both halves together: the braces balance, so only a refusal catches it",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			rejected, why := checkerRejects(c.doc, nil)
+			if !rejected {
+				t.Errorf("the checker ACCEPTED an ambiguous shape (%s). Guessing at these "+
+					"is how two misreads cancel into a balanced document with a wrong "+
+					"tree.", c.why)
+			} else {
+				t.Logf("refused as expected: %s", why)
+			}
+		})
 	}
-	if len(a.order) != 0 {
-		t.Errorf("!a opened %v; a setting must not create a nesting level", a.childNames())
-	}
 
-	// The hash-named SECTION survived and was not eaten as a comment. This is
-	// the half that makes the failure silent: without it hasNoChild("#b")
-	// passes on a document that plainly contains #b.
-	b := conns.at(t, "#b")
-	b.requireSetting(t, "remote_addrs", "1.1.1.1")
-
-	// And a real comment is still a comment.
-	root2 := parseSwanctlDoc(t, "# xpf managed config - do not edit\nconnections {\n}\n")
-	root2.at(t, "connections")
-	if names := root2.childNames(); len(names) != 1 {
-		t.Errorf("top-level sections = %v, want exactly [connections]; the comment "+
-			"exclusions must not turn an ordinary comment into a section", names)
+	// PAIRED CONTROL. The refusals above are satisfied by a parser that rejects
+	// everything, which would be useless in the other direction and identical
+	// in a pass/fail table. An ordinary comment and an ordinary section must
+	// still parse.
+	root := parseSwanctlDoc(t, "# xpf managed config - do not edit\n\nconnections {\n"+
+		"  tun {\n    remote_addrs = 203.0.113.1\n  }\n}\n")
+	root.at(t, "connections", "tun").requireSetting(t, "remote_addrs", "203.0.113.1")
+	if names := root.childNames(); len(names) != 1 {
+		t.Errorf("top-level sections = %v, want exactly [connections]; the refusals must "+
+			"not turn an ordinary comment into a section", names)
 	}
 }

--- a/pkg/ipsec/swanctl_doc_selftest_6824_test.go
+++ b/pkg/ipsec/swanctl_doc_selftest_6824_test.go
@@ -1,0 +1,168 @@
+package ipsec
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// swanctl_doc_selftest_6824_test.go -- #6824.
+//
+// The structural checker is only worth having if it FAILS on the shapes a
+// containment assertion cannot see. These are its own tests: each feeds a
+// document that `strings.Contains` would accept and requires the checker to
+// reject it.
+//
+// Without these, a parser bug turns every structural assertion built on it into
+// a vacuous pass -- the instrument-that-cannot-fail problem, one layer down.
+
+// capturingTB records the checker's failures instead of failing the suite.
+//
+// Fatalf must ABORT, as *testing.T's does, or a checker that Fatalf's and then
+// continues would exercise code paths the real one never reaches -- so it panics
+// with a sentinel that checkerRejects recovers.
+type capturingTB struct{ msgs []string }
+
+type swanctlFatal struct{}
+
+func (c *capturingTB) Helper() {}
+func (c *capturingTB) Errorf(format string, args ...any) {
+	c.msgs = append(c.msgs, fmt.Sprintf(format, args...))
+}
+func (c *capturingTB) Fatalf(format string, args ...any) {
+	c.msgs = append(c.msgs, fmt.Sprintf(format, args...))
+	panic(swanctlFatal{})
+}
+
+// checkerRejects drives the checker over doc and reports whether it complained,
+// along with what it said.
+func checkerRejects(doc string, body func(swanctlTB, *swanctlNode)) (bool, string) {
+	tb := &capturingTB{}
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				if _, ok := r.(swanctlFatal); !ok {
+					panic(r)
+				}
+			}
+		}()
+		root := parseSwanctlDoc(tb, doc)
+		if body != nil {
+			body(tb, root)
+		}
+	}()
+	return len(tb.msgs) > 0, strings.Join(tb.msgs, "; ")
+}
+
+// TestStructuralCheckerCatchesWhatContainmentCannot_6824 is the sensitivity
+// suite, and every case is chosen because `strings.Contains` accepts it.
+func TestStructuralCheckerCatchesWhatContainmentCannot_6824(t *testing.T) {
+	cases := []struct {
+		name string
+		doc  string
+		why  string
+	}{
+		{
+			name: "unbalanced-open-section",
+			doc:  "connections {\n  tun {\n    remote_addrs = 203.0.113.1\n",
+			why:  "a truncated render leaves sections open; Contains still finds the address",
+		},
+		{
+			name: "closing-brace-with-nothing-open",
+			doc:  "connections {\n}\n}\n",
+			why:  "an extra close silently reparents everything after it",
+		},
+		{
+			name: "duplicate-section-under-one-parent",
+			doc:  "connections {\n  tun {\n    remote_addrs = 1.1.1.1\n  }\n  tun {\n    remote_addrs = 2.2.2.2\n  }\n}\n",
+			why:  "two sections with one name: one wins, the other is lost, Contains sees both",
+		},
+		{
+			name: "unrecognised-line-shape",
+			doc:  "connections {\n  tun {\n    this is not a setting\n  }\n}\n",
+			why:  "a shape no structural test describes must fail rather than be skipped",
+		},
+		{
+			name: "empty-section-name",
+			doc:  "connections {\n   {\n  }\n}\n",
+			why:  "a section opened with no name is a render bug, not a nesting level",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rejected, why := checkerRejects(c.doc, nil)
+			if !rejected {
+				t.Errorf("the checker ACCEPTED %s -- %s", c.name, c.why)
+			} else {
+				t.Logf("rejected as expected: %s", why)
+			}
+		})
+	}
+}
+
+// TestStructuralCheckerCatchesADuplicateSetting_6824 is separated because it
+// fires from setting() rather than from the parse, and it is the single case
+// most invisible to containment: the key is present, twice.
+func TestStructuralCheckerCatchesADuplicateSetting_6824(t *testing.T) {
+	doc := "connections {\n  tun {\n    remote_addrs = 1.1.1.1\n    remote_addrs = 2.2.2.2\n  }\n}\n"
+	if !strings.Contains(doc, "remote_addrs = 1.1.1.1") {
+		t.Fatal("fixture does not contain the value a containment assertion would look for")
+	}
+	rejected, why := checkerRejects(doc, func(tb swanctlTB, root *swanctlNode) {
+		root.at(tb, "connections", "tun").setting(tb, "remote_addrs")
+	})
+	if !rejected {
+		t.Error("the checker accepted a section declaring remote_addrs twice; a " +
+			"containment assertion accepts it too, which is the point")
+	} else {
+		t.Logf("rejected as expected: %s", why)
+	}
+}
+
+// TestStructuralCheckerAcceptsAWellFormedDocument_6824 is the paired positive
+// control. Without it, every cell above is satisfied by a checker that rejects
+// EVERYTHING -- which would be useless in the opposite direction and would look
+// identical in a pass/fail table.
+func TestStructuralCheckerAcceptsAWellFormedDocument_6824(t *testing.T) {
+	doc := "# comment\n\nconnections {\n  tun {\n    remote_addrs = 203.0.113.1\n" +
+		"    local {\n      auth = psk\n    }\n  }\n}\n"
+	root := parseSwanctlDoc(t, doc)
+	tun := root.at(t, "connections", "tun")
+	if got := tun.setting(t, "remote_addrs"); got != "203.0.113.1" {
+		t.Errorf("remote_addrs = %q, want 203.0.113.1", got)
+	}
+	if got := tun.at(t, "local").setting(t, "auth"); got != "psk" {
+		t.Errorf("local.auth = %q, want psk", got)
+	}
+	// And the nesting is real: auth belongs to `local`, not to `tun`.
+	tun.hasNoSetting(t, "auth")
+}
+
+// TestStructuralCheckerDistinguishesNestingFromContainment_6824 is the argument
+// for this whole file, expressed as a test.
+//
+// Both documents contain the byte sequence `remote_addrs = 203.0.113.1`, so a
+// containment assertion cannot tell them apart. In the second, the setting sits
+// under the WRONG connection -- the render bug the old assertions were blind to.
+func TestStructuralCheckerDistinguishesNestingFromContainment_6824(t *testing.T) {
+	const want = "remote_addrs = 203.0.113.1"
+	right := "connections {\n  tun {\n    " + want + "\n  }\n  other {\n  }\n}\n"
+	wrong := "connections {\n  tun {\n  }\n  other {\n    " + want + "\n  }\n}\n"
+
+	if !strings.Contains(right, want) || !strings.Contains(wrong, want) {
+		t.Fatal("both fixtures must satisfy containment, or the comparison is not the one being made")
+	}
+
+	if got := parseSwanctlDoc(t, right).at(t, "connections", "tun").setting(t, "remote_addrs"); got != "203.0.113.1" {
+		t.Fatalf("correctly-nested document: got %q", got)
+	}
+	rejected, why := checkerRejects(wrong, func(tb swanctlTB, root *swanctlNode) {
+		root.at(tb, "connections", "tun").setting(tb, "remote_addrs")
+	})
+	if !rejected {
+		t.Error("the checker accepted remote_addrs nested under the WRONG connection; " +
+			"that is exactly the class strings.Contains cannot see")
+	} else {
+		t.Logf("rejected as expected: %s", why)
+	}
+}

--- a/pkg/ipsec/swanctl_render_test.go
+++ b/pkg/ipsec/swanctl_render_test.go
@@ -301,15 +301,11 @@ func TestGenerateConfig_JunosGCM(t *testing.T) {
 			"gcm": {Name: "gcm", EncryptionAlg: "aes-256-gcm", DHGroup: 14},
 		},
 	}
-	got := m.generateConfig(cfg)
-	if !strings.Contains(got, "esp_proposals = aes256gcm16-modp2048") {
-		t.Errorf("expected ICV-suffixed GCM esp_proposals, got:\n%s", got)
-	}
-	// The bare alias (valid strongSwan, but not the canonical spelling
-	// we now emit) must no longer appear.
-	if strings.Contains(got, "aes256gcm-modp2048") {
-		t.Errorf("rendered the bare aes256gcm alias instead of the canonical aes256gcm16:\n%s", got)
-	}
+	// #6824: an exact match at the child SA's esp_proposals subsumes both old
+	// checks -- the bare `aes256gcm-modp2048` alias cannot equal the canonical
+	// spelling, so the separate negative needle is no longer needed to say so.
+	childSA_3904(t, m.generateConfig(cfg), "tun1").
+		requireSetting(t, "esp_proposals", "aes256gcm16-modp2048")
 }
 
 // TestEscapeSwanctlQuoted unit-tests the swanctl double-quoted-string
@@ -357,13 +353,10 @@ func TestGenerateConfig_PSKWithQuote(t *testing.T) {
 		Proposals: map[string]*config.IPsecProposal{},
 	}
 	got := m.generateConfig(cfg)
-	if !strings.Contains(got, `secret = "pa\"ss"`) {
-		t.Errorf("expected escaped quoted PSK, got:\n%s", got)
-	}
-	// The corrupting unescaped form must NOT appear.
-	if strings.Contains(got, `secret = "pa"ss"`) {
-		t.Errorf("rendered the corrupted unescaped PSK:\n%s", got)
-	}
+	// #6824: an exact match on the secret setting subsumes the separate
+	// "corrupted form absent" needle -- the unescaped spelling cannot equal
+	// the escaped one.
+	secretSetting_6824(t, got, "ike-site-a", `"pa\"ss"`)
 	assertBalancedSecretQuotes(t, got)
 }
 
@@ -383,10 +376,7 @@ func TestGenerateConfig_PSKWithBackslash(t *testing.T) {
 		},
 		Proposals: map[string]*config.IPsecProposal{},
 	}
-	got := m.generateConfig(cfg)
-	if !strings.Contains(got, `secret = "pa\\ss"`) {
-		t.Errorf("expected doubled backslash in PSK, got:\n%s", got)
-	}
+	secretSetting_6824(t, m.generateConfig(cfg), "ike-site-a", `"pa\\ss"`)
 }
 
 // TestGenerateConfig_PSKTrailingBackslash is the adversarial corner a PSK
@@ -407,9 +397,7 @@ func TestGenerateConfig_PSKTrailingBackslash(t *testing.T) {
 		Proposals: map[string]*config.IPsecProposal{},
 	}
 	got := m.generateConfig(cfg)
-	if !strings.Contains(got, `secret = "pass\\"`) {
-		t.Errorf("expected trailing backslash doubled, got:\n%s", got)
-	}
+	secretSetting_6824(t, got, "ike-site-a", `"pass\\"`)
 	assertBalancedSecretQuotes(t, got)
 }
 
@@ -435,13 +423,12 @@ func TestGenerateConfig_IdentityWithCommaQuoted(t *testing.T) {
 			},
 		},
 	}
-	got := m.generateConfig(cfg)
-	if !strings.Contains(got, `id = "CN=fw, O=acme"`) {
-		t.Errorf("expected quoted DN identity, got:\n%s", got)
-	}
-	if !strings.Contains(got, `id = "peer\"name"`) {
-		t.Errorf("expected quoted+escaped remote identity, got:\n%s", got)
-	}
+	// #6824: `id` is emitted in BOTH the local{} and remote{} auth rounds, so
+	// containment could not say which round carried which identity -- the two
+	// old needles would both have passed with the values swapped.
+	conn := parseSwanctlDoc(t, m.generateConfig(cfg)).at(t, "connections", "tun")
+	conn.at(t, "local").requireSetting(t, "id", `"CN=fw, O=acme"`)
+	conn.at(t, "remote").requireSetting(t, "id", `"peer\"name"`)
 }
 
 // secretBlock is a parsed `secrets { ike-<name> { ... } }` entry.
@@ -455,44 +442,34 @@ type secretBlock struct {
 // value and the ordered id-<n> selector values (surrounding quotes
 // stripped). It is deliberately small: the rendered secrets are simple
 // enough that a leading/trailing double-quote trim recovers the value.
-func parseSecretBlocks(cfg string) map[string]secretBlock {
+func parseSecretBlocks(t *testing.T, cfg string) map[string]secretBlock {
+	t.Helper()
+	// #6824: built on the shared document parser rather than a second bespoke
+	// line scanner. The old version tracked `inSecrets` and flushed on a bare
+	// "}", so a nesting change anywhere above could silently reassign blocks;
+	// resolving secrets{} as a path cannot.
 	out := map[string]secretBlock{}
-	inSecrets := false
-	cur := ""
-	var blk secretBlock
-	flush := func() {
-		if cur != "" {
-			out[cur] = blk
-		}
-		cur = ""
-		blk = secretBlock{}
+	unquote := func(v string) string { return strings.Trim(v, `"`) }
+	doc := parseSwanctlDoc(t, cfg)
+	sec, ok := doc.children["secrets"]
+	if !ok {
+		return out
 	}
-	unquote := func(s string) string { return strings.Trim(strings.TrimSpace(s), `"`) }
-	for _, line := range strings.Split(cfg, "\n") {
-		t := strings.TrimSpace(line)
-		switch {
-		case t == "secrets {":
-			inSecrets = true
-		case !inSecrets:
-			// outside the secrets block — ignore.
-		case strings.HasPrefix(t, "ike-") && strings.HasSuffix(t, "{"):
-			flush()
-			cur = strings.TrimSpace(strings.TrimSuffix(t, "{"))
-		case cur != "" && strings.HasPrefix(t, "secret = "):
-			blk.secret = unquote(strings.TrimPrefix(t, "secret = "))
-		case cur != "" && strings.HasPrefix(t, "id-"):
-			if idx := strings.Index(t, "= "); idx >= 0 {
-				blk.ids = append(blk.ids, unquote(t[idx+2:]))
+	for _, name := range sec.order {
+		node := sec.children[name]
+		blk := secretBlock{}
+		if vals, ok := node.settings["secret"]; ok && len(vals) == 1 {
+			blk.secret = unquote(vals[0])
+		}
+		for _, k := range node.settingNames() {
+			if strings.HasPrefix(k, "id-") {
+				for _, v := range node.settings[k] {
+					blk.ids = append(blk.ids, unquote(v))
+				}
 			}
-		case t == "}" && cur != "":
-			// close the ike-<name> block.
-			flush()
-		case t == "}" && cur == "":
-			// close the secrets block.
-			inSecrets = false
 		}
+		out[name] = blk
 	}
-	flush()
 	return out
 }
 
@@ -524,7 +501,7 @@ func TestGenerateConfig_PSKIDSelectors_TwoVPNs(t *testing.T) {
 			"gw-b": {Name: "gw-b", Address: "203.0.113.2", LocalAddress: "198.51.100.10"},
 		},
 	}
-	blocks := parseSecretBlocks(m.generateConfig(cfg))
+	blocks := parseSecretBlocks(t, m.generateConfig(cfg))
 
 	a, ok := blocks["ike-vpn-a"]
 	if !ok {
@@ -582,7 +559,7 @@ func TestGenerateConfig_PSKIDSelectors_ExplicitIDs(t *testing.T) {
 			},
 		},
 	}
-	blocks := parseSecretBlocks(m.generateConfig(cfg))
+	blocks := parseSecretBlocks(t, m.generateConfig(cfg))
 	blk, ok := blocks["ike-vpn"]
 	if !ok {
 		t.Fatalf("missing ike-vpn secret block")
@@ -611,7 +588,7 @@ func TestGenerateConfig_PSKIDSelectors_SingleVPN(t *testing.T) {
 			"solo": {Gateway: "10.0.2.1", PSK: "onlysecret", BindInterface: "st0.0"},
 		},
 	}
-	blocks := parseSecretBlocks(m.generateConfig(cfg))
+	blocks := parseSecretBlocks(t, m.generateConfig(cfg))
 	blk, ok := blocks["ike-solo"]
 	if !ok {
 		t.Fatalf("missing ike-solo secret block")
@@ -645,7 +622,7 @@ func TestGenerateConfig_PSKIDSelectors_ResponderAnyAndCert(t *testing.T) {
 		},
 	}
 	got := m.generateConfig(cfg)
-	blocks := parseSecretBlocks(got)
+	blocks := parseSecretBlocks(t, got)
 
 	rw, ok := blocks["ike-roadwarrior"]
 	if !ok {
@@ -654,11 +631,15 @@ func TestGenerateConfig_PSKIDSelectors_ResponderAnyAndCert(t *testing.T) {
 	if len(rw.ids) != 0 {
 		t.Errorf("responder-only %%any peer should emit no id selector, got %v", rw.ids)
 	}
-	if strings.Contains(got, `%any`) && strings.Contains(got, "id-") {
-		// Belt: a literal id = "%any" would defeat the scoping and match all.
-		if containsStr(rw.ids, "%any") {
-			t.Errorf("emitted a literal %%any id selector")
-		}
+	// Belt: a literal id = "%any" would defeat the scoping and match all.
+	//
+	// #6824: this was previously guarded by
+	// `Contains(got, "%any") && Contains(got, "id-")` -- a condition about the
+	// document as a whole gating a check about THIS block's selectors. A
+	// render that dropped the %any sentinel elsewhere would skip the belt
+	// entirely. The inner check is the claim; assert it unconditionally.
+	if containsStr(rw.ids, "%any") {
+		t.Errorf("emitted a literal %%any id selector")
 	}
 	if _, ok := blocks["ike-cert-vpn"]; ok {
 		t.Errorf("cert VPN with no PSK must not emit a secret block")
@@ -807,4 +788,15 @@ func assertProposalIntegValid(t *testing.T, proposal string) {
 	if integ := parts[1]; !strongSwanIntegKeywords[integ] {
 		t.Fatalf("proposal %q carries integrity token %q that strongSwan does not accept — charon would reject the whole proposal", proposal, integ)
 	}
+}
+
+// secretSetting_6824 asserts secrets.<block>.secret renders exactly want,
+// INCLUDING its surrounding quotes.
+//
+// Containment on `secret = "..."` could not distinguish the secrets block from
+// any other place the renderer might emit the same bytes, and could not reject a
+// value with something appended.
+func secretSetting_6824(t *testing.T, doc, block, want string) {
+	t.Helper()
+	parseSwanctlDoc(t, doc).at(t, "secrets", block).requireSetting(t, "secret", want)
 }

--- a/pkg/ipsec/swanctl_render_test.go
+++ b/pkg/ipsec/swanctl_render_test.go
@@ -306,7 +306,7 @@ func TestGenerateConfig_JunosGCM(t *testing.T) {
 	// speak for a `aes256gcm-modp2048` emitted under some other section.
 	got := m.generateConfig(cfg)
 	childSA_3904(t, got, "tun1").requireSetting(t, "esp_proposals", "aes256gcm16-modp2048")
-	parseSwanctlDoc(t, got).hasNoSettingValueAnywhere(t, "esp_proposals", "aes256gcm-modp2048")
+	parseSwanctlDoc(t, got).hasNoValueSubstringAnywhere(t, "aes256gcm-modp2048")
 }
 
 // TestEscapeSwanctlQuoted unit-tests the swanctl double-quoted-string

--- a/pkg/ipsec/swanctl_render_test.go
+++ b/pkg/ipsec/swanctl_render_test.go
@@ -301,11 +301,12 @@ func TestGenerateConfig_JunosGCM(t *testing.T) {
 			"gcm": {Name: "gcm", EncryptionAlg: "aes-256-gcm", DHGroup: 14},
 		},
 	}
-	// #6824: an exact match at the child SA's esp_proposals subsumes both old
-	// checks -- the bare `aes256gcm-modp2048` alias cannot equal the canonical
-	// spelling, so the separate negative needle is no longer needed to say so.
-	childSA_3904(t, m.generateConfig(cfg), "tun1").
-		requireSetting(t, "esp_proposals", "aes256gcm16-modp2048")
+	// #6824: equality at the child SA pins the canonical spelling. The bare
+	// alias was a DOCUMENT-WIDE absence and stays one -- equality here cannot
+	// speak for a `aes256gcm-modp2048` emitted under some other section.
+	got := m.generateConfig(cfg)
+	childSA_3904(t, got, "tun1").requireSetting(t, "esp_proposals", "aes256gcm16-modp2048")
+	parseSwanctlDoc(t, got).hasNoSettingValueAnywhere(t, "esp_proposals", "aes256gcm-modp2048")
 }
 
 // TestEscapeSwanctlQuoted unit-tests the swanctl double-quoted-string

--- a/pkg/ipsec/trafficselector_render_4098_test.go
+++ b/pkg/ipsec/trafficselector_render_4098_test.go
@@ -47,19 +47,18 @@ func TestRenderTrafficSelectorSanitizesInjection(t *testing.T) {
 	// whether an injected setting appears anywhere; what actually matters is
 	// whether it became a SETTING of the child section -- which is what
 	// strongSwan would act on. Parsing says so directly.
-	child := parseSwanctlDoc(t, got).at(t, "connections", "tun1", "children", "tun1-ts1")
+	doc := parseSwanctlDoc(t, got)
 
-	// The injected settings must not exist as settings at all. Before the fix
-	// the materialized newline split the local_ts value, so `updown` and
-	// `esp_proposals` parsed as real keys in this section.
-	child.hasNoSetting(t, "updown")
-	if vals, ok := child.settings["esp_proposals"]; ok {
-		for _, v := range vals {
-			if strings.HasPrefix(v, "null-null") {
-				t.Errorf("injected esp_proposals override became a real setting: %q", v)
-			}
-		}
-	}
+	// The injected settings must not exist as settings ANYWHERE. Scoping this
+	// to the expected child section would pass on a render that emitted a
+	// SIBLING child carrying `updown = /tmp/pwn.sh` -- a live child-SA location
+	// where charon executes it as root, which is the whole reason this test
+	// exists. The old line scan covered the whole document and the first
+	// structural conversion narrowed it; that was a real loss of power.
+	doc.hasNoSettingAnywhere(t, "updown")
+	doc.hasNoSettingValueAnywhere(t, "esp_proposals", "null-null")
+
+	child := doc.at(t, "connections", "tun1", "children", "tun1-ts1")
 
 	// The sanitized value stays on the local_ts line (newline -> space), so
 	// the tunnel still carries the operator's selector prefix — the belt does

--- a/pkg/ipsec/trafficselector_render_4098_test.go
+++ b/pkg/ipsec/trafficselector_render_4098_test.go
@@ -56,7 +56,12 @@ func TestRenderTrafficSelectorSanitizesInjection(t *testing.T) {
 	// exists. The old line scan covered the whole document and the first
 	// structural conversion narrowed it; that was a real loss of power.
 	doc.hasNoSettingAnywhere(t, "updown")
-	doc.hasNoSettingValueAnywhere(t, "esp_proposals", "null-null")
+	// The deleted check was `HasPrefix(trimmed, "esp_proposals = null-null")` --
+	// a line prefix on a NAMED key, not a bare token. A bare-substring form is
+	// wrong here in the over-reject direction: the sanitized remote_ts value
+	// legitimately contains the injected text, collapsed onto one line, which
+	// is exactly what the belt is supposed to do to it.
+	doc.hasNoSettingValuePrefixAnywhere(t, "esp_proposals", "null-null")
 
 	child := doc.at(t, "connections", "tun1", "children", "tun1-ts1")
 

--- a/pkg/ipsec/trafficselector_render_4098_test.go
+++ b/pkg/ipsec/trafficselector_render_4098_test.go
@@ -43,25 +43,31 @@ func TestRenderTrafficSelectorSanitizesInjection(t *testing.T) {
 
 	got := m.generateConfig(cfg)
 
-	// No rendered line may be a standalone injected swanctl setting. On the
-	// raw (pre-fix) renderer the materialized newline splits the local_ts /
-	// remote_ts value, so `updown = ...` and `esp_proposals = ...` appear on
-	// their own lines inside the children block.
-	for _, line := range strings.Split(got, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "updown") {
-			t.Fatalf("injected updown line reached swanctl children block:\n%s", got)
-		}
-		if strings.HasPrefix(trimmed, "esp_proposals = null-null") {
-			t.Fatalf("injected esp_proposals override reached swanctl children block:\n%s", got)
+	// #6824: assert on the parsed document, not on lines. A line scan asks
+	// whether an injected setting appears anywhere; what actually matters is
+	// whether it became a SETTING of the child section -- which is what
+	// strongSwan would act on. Parsing says so directly.
+	child := parseSwanctlDoc(t, got).at(t, "connections", "tun1", "children", "tun1-ts1")
+
+	// The injected settings must not exist as settings at all. Before the fix
+	// the materialized newline split the local_ts value, so `updown` and
+	// `esp_proposals` parsed as real keys in this section.
+	child.hasNoSetting(t, "updown")
+	if vals, ok := child.settings["esp_proposals"]; ok {
+		for _, v := range vals {
+			if strings.HasPrefix(v, "null-null") {
+				t.Errorf("injected esp_proposals override became a real setting: %q", v)
+			}
 		}
 	}
 
 	// The sanitized value stays on the local_ts line (newline -> space), so
 	// the tunnel still carries the operator's selector prefix — the belt does
-	// not drop the whole value.
-	if !strings.Contains(got, "local_ts = 10.0.0.0/24") {
-		t.Fatalf("sanitized local_ts prefix missing from render:\n%s", got)
+	// not drop the whole value. The prefix check is on the VALUE of a setting
+	// at a known path, which is a different claim from "these bytes appear
+	// somewhere in the document".
+	if lts := child.setting(t, "local_ts"); !strings.HasPrefix(lts, "10.0.0.0/24") {
+		t.Errorf("children.tun1-ts1.local_ts = %q, want it to still start with 10.0.0.0/24", lts)
 	}
 }
 
@@ -85,11 +91,11 @@ func TestRenderTrafficSelectorNormalUnchanged(t *testing.T) {
 			"ipsec-pol": {Name: "ipsec-pol", Proposals: []string{"prop1"}},
 		},
 	}
-	got := m.generateConfig(cfg)
-	if !strings.Contains(got, "local_ts = 10.0.0.0/24\n") {
-		t.Fatalf("clean local_ts selector not rendered verbatim:\n%s", got)
-	}
-	if !strings.Contains(got, "remote_ts = 10.0.1.0/24\n") {
-		t.Fatalf("clean remote_ts selector not rendered verbatim:\n%s", got)
-	}
+	// #6824: the old needles carried a trailing "\n" purely to approximate
+	// "the value ends here" -- an equality assertion at a known path states
+	// that outright, and additionally pins WHICH child section carries it.
+	child := parseSwanctlDoc(t, m.generateConfig(cfg)).
+		at(t, "connections", "tun1", "children", "tun1-ts1")
+	child.requireSetting(t, "local_ts", "10.0.0.0/24")
+	child.requireSetting(t, "remote_ts", "10.0.1.0/24")
 }


### PR DESCRIPTION
Closes #6824

## What this does

The `pkg/ipsec` render tests asserted on generated swanctl configuration with `strings.Contains`. A containment assertion cannot distinguish a correct document from one holding the right substrings in the wrong structure: `remote_addrs = 203.0.113.1` satisfies it whether the setting sits under the connection it belongs to, under a sibling connection, inside `children{}`, or outside every section because a brace went missing.

This adds a structural checker over the rendered document and converts ~96 of the package's ~100 containment assertions to path-addressed ones. The 4 that remain are claims containment is the right tool for: one about a parsed SA field, and three leak guards asserting a gateway NAME appears nowhere at all.

## What the checker does and does not claim

It is **not** a swanctl grammar. `which swanctl charon ipsec` finds nothing in this environment, so the rendered document cannot be checked against the real parser, and a hand-written imitation would be a proxy with nothing to validate it — the containment defect again with more code.

What it asserts are properties of **our own renderer**, which we control and can state exactly: braces balance, every setting sits at a known path, one key per line, no duplicate key in a section, no duplicate section under one parent. A line shape the parser does not recognise is a hard failure rather than a skip, because skipping is how a structural check decays back into a containment check.

Option 1 from the issue (validate against a real strongSwan parser) stays unavailable and is a strictly stronger property worth filing separately; the issue itself recommended option 2 as available now.

## Vacuous assertions this found

Several converted sites were not merely weak but could not fail:

- **`proposalset_ah_hb167`** asserted the Phase-2 ESP set with `Contains(out, "3des-sha1")`. That token is a substring of the Phase-1 member `3des-sha1-modp1024`, so the assertion was satisfied by the Phase-1 line and passed whether or not `esp_proposals` carried the ESP set, **or existed at all**.
- **`TestGenerateConfig_IKEChain`**'s 15-row table had a "local identity" row and a "remote identity" row. `id` is emitted in both auth rounds, so both rows passed with the two identities **swapped**. Two further rows were mutually satisfiable: "IKE proposal" looked for `proposals = aes256-sha256-modp2048`, a substring of the `esp_proposals` line, so it passed with the Phase-1 offer missing entirely.
- **`TestGenerateConfig_TrafficSelectors`** asserted six substrings for two selectors. All six pass with corp-a's `local_ts`/`remote_ts` rendered inside corp-b's child section and vice versa — the pairing is the entire point of a traffic selector.
- **`TestGenerateConfig_NATTraversal_Default`** asserted `!Contains(got, "encap")`, which also matches `forceencaps` and so could never distinguish the two keys. The Enable case asserted `!Contains(got, "encap = no")`, a value-specific needle that passed if the render emitted `encap = yes` — also wrong there, since nothing should be emitted.
- **`swanctl_render`**'s `%any` belt ran only `if Contains(got, "%any") && Contains(got, "id-")` — a condition about the whole document deciding whether to run a check about one block's selectors.

Several negative needles are **subsumed rather than translated**: an exact match at a known path already rejects the bare `aes256gcm` alias, the corrupted unescaped PSK, and the stale DHCP lease address.

Four bespoke line scanners are folded into the shared parser: `hasBareDirectiveLine`, `parseSecretBlocks`, `remoteAddrsValues`, `childSectionNames`.

## The durable half

Converting today's assertions does nothing about the next one. `swanctl_containment_guard_6824_test.go` walks the package's test files and fails on a `strings.Contains` whose subject is a `generateConfig`/`renderConfig` result and whose needle spells swanctl syntax (carries `" = "` or ends `" {"`).

That predicate is narrow **so it needs no allowlist** — the three legitimate leak guards are bare tokens and are not flagged. An allowlist entry would be a claim owing a test of its own.

It carries anti-vacuity floors (≥10 test files scanned, ≥5 rendering a document) and a sensitivity suite driving the same detector over synthetic source: three cells that must be flagged, two that must not, so a detector flagging everything fails as loudly as one flagging nothing.

**Measured, not assumed:** run against the pre-conversion tree at `de6b8c85d` the detector flags **75** sites; at this head it flags **0**.

Its limitation is stated in the file rather than implied: the needle must be a string literal at the call site, so a table-driven `strings.Contains(got, c.want)` is invisible to it — which is why the base count is 75 and not the full ~100. A clean run means "no literal syntax needle", not "no containment assertion anywhere".

## Mutation matrix

Fix committed first. Every cell full-package `go test -count=1 ./pkg/ipsec/`, **no `-run` filter**. A cell that failed to compile is reported as BUILD, not RED; only a run naming a failing test counts.

**Group A — no loss of power.** The converted tests still catch what the originals caught:

| cell | mutation | verdict | named test |
|---|---|---|---|
| A1 | revert #6469 sanitize on `remote_addrs` | RED | `TestSwanctlAddrInjectionNeutralized_6469/remote_via_gateway_Address` |
| A2 | revert #6469 sanitize on `local_addrs` | RED | `TestSwanctlAddrInjectionNeutralized_6469/local_via_gateway_LocalAddress` |
| A3 | revert #4098 sanitize on `local_ts` | RED | `TestRenderTrafficSelectorSanitizesInjection` |
| A4 | revert #6469 sanitize on `esp_proposals` | RED | `TestSwanctlProposalsInjectionNeutralized_6469/ESP_esp_proposals_updown->root_injection` |
| A5 | invert #4015 `copy_df` for `clear` | RED | `TestGenerateConfig_DFBit/clear` |
| A6 | delete `copy_df` from the child SA | RED | `TestGenerateConfig_DFBit/copy` |
| A7 | drop the Phase-1 `proposals` line | RED | `TestGenerateConfig_IKEChain/IKE_proposal` |
| A8 | drop `if_id_in`/`if_id_out` | RED | `TestGenerateConfig_Basic` |

**Group S — what the old suite could not see.** These are *relocations and a swap*, not deletions: every byte the old needles looked for is still somewhere in the document. Each was run twice on the same tree — once with the new suite, once with the base suite restored (base test files checked out AND the three new files explicitly removed, since `git checkout <sha> -- <path>` leaves files absent at base in place; the base suite was confirmed green before mutating).

| cell | mutation | OLD suite | NEW suite |
|---|---|---|---|
| S1 | **swap** local/remote `id` (both values still present) | **GREEN** | RED — `IKEChain/local_identity`, `IKEChain/remote_identity` |
| S2 | **move** `if_id_in`/`if_id_out` from child SA to connection | **GREEN** | RED — `TestGenerateConfig_Basic` |
| S4 | **move** `copy_df` from child SA to connection | **GREEN** | RED — `TestGenerateConfig_DFBit/copy` |
| S3 | **move** `esp_proposals` out of the child SA section | RED | RED |

S1/S2/S4 are the paired necessary-and-sufficient evidence: three real misnesting defects that ship silently under the old assertions and fail loudly under the new ones.

**S3 is reported as it came out, not as I expected it.** The old suite caught it — via `TestSwanctlProposalsLegitPreserved_6469`, whose needle pinned the exact eight-space indent (`"        esp_proposals = ..."`). That assertion had accidental structural power, bought by pinning a cosmetic the renderer is free to change. A separate cell confirms the trade is deliberate: changing only the child-SA indent is GREEN under the new suite, because swanctl nests by braces and so does the parser.

My first cut of Group S was wrong and is worth recording: the mutations were *deletions* (`_ = ifID`), which containment catches perfectly well, and all five came back RED on the old suite. A deletion cannot demonstrate the property; only a relocation can.

## Validation

- `go test -count=1 ./pkg/ipsec/` green; `go vet ./pkg/ipsec/` clean.
- Repo-wide `go test -count=1 ./...` at `22d00fa3d`: **rc=0, 68 packages ok, 0 FAIL** (exit code captured directly, not through a pipe).
- Base is exactly `origin/master` (`de6b8c85d`), 0 commits behind, so the gate ran at the true merge head.
- The `IKEChain` table's 15 rows were confirmed to run as named subtests rather than be filtered away.
- Every converted assertion resolves its path through `at()`, which fails hard on an absent section — a mistyped path fails loudly instead of asserting nothing.

## Docs

No module documentation changes. This is test-only: it changes how `pkg/ipsec`'s tests assert, not what the renderer emits or what any operator-facing contract says. `policy.go` is untouched.
