### PR TITLE
userspace-dp: redact the SYN-cookie master key in snapshot Debug (#6855)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -106306,3 +106306,9 @@ prose edit above them added. No diff falls in the new test body.
   `pkg/config/compact_block_inventory_regen_2419_test.go` (new),
   `pkg/config/testdata/compact_block_divergences_2419.txt` (new),
   `docs/config-schema.md`, `_Log.md`
+
+- **Timestamp**: 2026-08-26
+  - **Action**: #6855 — redact the SYN-cookie master key in ConfigSnapshot and
+    ControlRequest Debug via a newtype (the two carriers #4484 L-7 named)
+  - **File(s)**: userspace-dp/src/protocol/snapshot.rs,
+    userspace-dp/src/protocol/tests.rs

--- a/userspace-dp/src/protocol/snapshot.rs
+++ b/userspace-dp/src/protocol/snapshot.rs
@@ -312,6 +312,85 @@ pub(crate) struct NeighborSnapshot {
     pub link_local: bool,
 }
 
+/// SYN-cookie master key (hex) wrapped so its `Debug` never renders the secret
+/// (#6855).
+///
+/// `#4484` L-7 named `ConfigSnapshot` and `ControlRequest` as the carriers.
+/// `#4757` fixed a THIRD struct -- `ForwardingState` in
+/// `afxdp/types/forwarding.rs` -- with a `SynCookieMasterKey` newtype, which
+/// was correct and left the two named ones untouched. This is the same pattern
+/// applied where the item pointed.
+///
+/// A newtype rather than a hand-written `Debug` on `ConfigSnapshot`, and that
+/// choice is the point: the struct has 39 fields, so a manual impl would have
+/// to list all of them, and a field added later would silently stop being
+/// printed. Worse, a SECRET field added later would be printed, because nobody
+/// editing the struct would think to look at a `Debug` impl elsewhere in the
+/// file. Wrapping the secret keeps `#[derive(Debug)]` and makes the redaction a
+/// property of the VALUE, which no future field can undo.
+///
+/// `#[serde(transparent)]` keeps the wire format byte-identical: it serializes
+/// and deserializes exactly as the bare `String` did, so a peer running an older
+/// binary is unaffected. `Deref`/`AsRef` keep read sites unchanged.
+#[derive(Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(transparent)]
+pub(crate) struct SynCookieMasterKeyHex(pub(crate) String);
+
+impl std::fmt::Debug for SynCookieMasterKeyHex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Distinguish unset from set, as the sibling WG redactions do: "there
+        // is no key" and "there is a key I will not show you" are different
+        // facts, and the first is the one an operator debugging a control-socket
+        // problem actually needs.
+        if self.0.is_empty() {
+            f.write_str("<unset>")
+        } else {
+            f.write_str("<redacted>")
+        }
+    }
+}
+
+impl std::ops::Deref for SynCookieMasterKeyHex {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for SynCookieMasterKeyHex {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for SynCookieMasterKeyHex {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for SynCookieMasterKeyHex {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+/// Comparison against a bare `&str`, so an existing assertion reads unchanged.
+/// Without this the wrapper would force every call site to reach for `.0`, and
+/// a wrapper that makes every reader touch the raw secret is working against
+/// its own purpose.
+impl PartialEq<str> for SynCookieMasterKeyHex {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
+}
+
+impl PartialEq<&str> for SynCookieMasterKeyHex {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub(crate) struct ConfigSnapshot {
     pub version: i32,
@@ -407,7 +486,7 @@ pub(crate) struct ConfigSnapshot {
     /// HA: both chassis must derive the SAME key for cross-node SYN-cookie
     /// validation to survive failover.
     #[serde(rename = "syn_cookie_master_key", default, skip_serializing)]
-    pub syn_cookie_master_key: String,
+    pub syn_cookie_master_key: SynCookieMasterKeyHex,
     #[serde(default)]
     pub filters: Vec<FirewallFilterSnapshot>,
     #[serde(default)]

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -2620,3 +2620,99 @@ fn session_sync_request_policy_fields_roundtrip_3301() {
         "missing inactivity_timeout defaults to 0"
     );
 }
+
+// --- #6855: the SYN-cookie master key must never render in Debug ---------
+
+/// #4484 L-7 named `ConfigSnapshot` and `ControlRequest` as the carriers of a
+/// latent Debug leak. #4757 fixed a THIRD struct (`ForwardingState`) and the
+/// two named ones kept `#[derive(Debug)]` over the plaintext hex key.
+///
+/// Latent, not active: the only `{:?}` over these types was in a test. The
+/// exposure is that any future `slog`/`tracing`/`dbg!` line formatting a
+/// `ControlRequest` -- the obvious thing to add while debugging a control-socket
+/// problem, which is exactly when someone reaches for it -- writes the key to
+/// the journal. Journald is not a secret store, and this key is HA-WIDE: both
+/// chassis derive the same one from the root secret plus cluster-id.
+#[test]
+fn syn_cookie_master_key_is_redacted_in_config_snapshot_debug_6855() {
+    const KEY: &str = "0badc0ffee0badc0ffee0badc0ffee42";
+    let snap = ConfigSnapshot {
+        syn_cookie_master_key: KEY.to_string().into(),
+        ..Default::default()
+    };
+    let rendered = format!("{snap:?}");
+    assert!(
+        !rendered.contains(KEY),
+        "ConfigSnapshot Debug rendered the SYN-cookie master key: {rendered}"
+    );
+    assert!(
+        rendered.contains("<redacted>"),
+        "the key field must render as <redacted> so a reader can tell a key IS set; got: {rendered}"
+    );
+}
+
+/// The transitive half. `ControlRequest` embeds `Option<ConfigSnapshot>`, so it
+/// inherits the leak -- and it is the type someone actually formats when
+/// debugging the control socket.
+#[test]
+fn syn_cookie_master_key_is_redacted_in_control_request_debug_6855() {
+    const KEY: &str = "0badc0ffee0badc0ffee0badc0ffee42";
+    let req = ControlRequest {
+        snapshot: Some(ConfigSnapshot {
+            syn_cookie_master_key: KEY.to_string().into(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let rendered = format!("{req:?}");
+    assert!(
+        !rendered.contains(KEY),
+        "ControlRequest Debug rendered the SYN-cookie master key transitively: {rendered}"
+    );
+}
+
+/// PAIRED CONTROL, in two directions.
+///
+/// Without the first half, a `Debug` that printed "<redacted>" unconditionally
+/// -- or printed nothing at all -- would satisfy the assertions above while
+/// telling an operator nothing. Without the second, a wrapper whose `Debug`
+/// happened to be empty for every value would also pass.
+///
+/// "There is no key" and "there is a key I will not show you" are different
+/// facts, and the first is the one someone debugging a control-socket problem
+/// actually needs.
+#[test]
+fn syn_cookie_master_key_debug_distinguishes_unset_from_set_6855() {
+    let unset = SynCookieMasterKeyHex::default();
+    assert_eq!(
+        format!("{unset:?}"),
+        "<unset>",
+        "an empty key must render as <unset>, not as <redacted>: an operator \
+         chasing a missing key needs to know it is missing"
+    );
+
+    let set = SynCookieMasterKeyHex::from("deadbeef".to_string());
+    assert_eq!(format!("{set:?}"), "<redacted>");
+}
+
+/// The wrapper must not change the WIRE. `#[serde(transparent)]` means it
+/// serializes and deserializes exactly as the bare `String` did, so a peer
+/// running an older binary is unaffected -- a wire change at an unchanged
+/// version number is two readers at one version.
+#[test]
+fn syn_cookie_master_key_wire_format_is_unchanged_6855() {
+    const KEY: &str = "0badc0ffee0badc0ffee0badc0ffee42";
+
+    // The wrapper serializes as a bare JSON string, not as an object.
+    let wrapped = SynCookieMasterKeyHex::from(KEY.to_string());
+    let json = serde_json::to_string(&wrapped).expect("serialize");
+    assert_eq!(json, format!("\"{KEY}\""), "the wrapper must be transparent on the wire");
+
+    // And round-trips from that same bare string.
+    let back: SynCookieMasterKeyHex = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(&*back, KEY);
+
+    // Read sites see a plain &str through Deref, unchanged.
+    let as_str: &str = &wrapped;
+    assert_eq!(as_str, KEY);
+}


### PR DESCRIPTION
Closes #6855

## What this does

`#4484` L-7 named `ConfigSnapshot` and `ControlRequest` as the carriers of a latent `Debug` leak of the SYN-cookie master key. `#4757` fixed a **third** struct — `ForwardingState` in `afxdp/types/forwarding.rs` — with a redacting newtype. That was correct, and it left both named carriers deriving `Debug` over the plaintext hex key.

This applies the same pattern where the item actually pointed. I verified the claim before writing anything: `ConfigSnapshot` at `snapshot.rs:315` derives `Debug`, its `syn_cookie_master_key` field is a plain `String`, and there is no manual impl; `ControlRequest` embeds `Option<ConfigSnapshot>` and inherits it.

**Latent, not active.** The only `{:?}` over these types today is in a test, so nothing leaks now. The exposure is that any future `slog`/`tracing`/`dbg!` line formatting a `ControlRequest` — the obvious thing to add while debugging a control-socket problem, which is exactly when someone reaches for it — writes the key to the journal. Journald is not a secret store, and the key is **HA-wide**: both chassis derive the same one from the root secret plus cluster-id.

## Why a newtype and not a hand-written `Debug`

`ConfigSnapshot` has **39 fields**. A manual impl would have to list all of them, and:

- a field added later would silently stop being printed;
- worse, a **secret** field added later *would* be printed, because nobody editing the struct would think to look for a `Debug` impl elsewhere in the file.

Wrapping the secret keeps `#[derive(Debug)]` and makes redaction a property of the **value**, which no future field can undo. `ControlRequest` inherits it transitively — which is the whole reason the item named both.

## The wire is unchanged

`#[serde(transparent)]` means the wrapper serializes and deserializes exactly as the bare `String` did, so a peer running an older binary is unaffected. A wire change at an unchanged version number is two readers at one version, and that is not what this is.

`Deref`/`AsRef`/`From`/`PartialEq<str>` keep every existing call site reading unchanged. A wrapper that forced each reader to reach for `.0` would work against its own purpose by putting the raw secret back in front of everyone.

## Tests

Four cells:

1. `ConfigSnapshot` `Debug` does not contain the key, and does contain `<redacted>`.
2. `ControlRequest` `Debug` does not contain it **transitively** — the type someone actually formats.
3. **The paired control, in both directions:** an empty key renders `<unset>` and a set key renders `<redacted>`. Without it, a `Debug` printing a constant — or nothing at all — would satisfy cells 1 and 2 while telling an operator nothing. "There is no key" and "there is a key I will not show you" are different facts, and the first is the one someone debugging a control-socket problem needs.
4. The wire format, since the wrapper's whole safety argument is that it does not change it.

**Verified RED without the fix:** replacing the redacting `Debug` with `f.write_str(&self.0)` fails three of the four. The wire cell correctly still passes, since serialization is unaffected — which is itself a small check that the four cells are testing different things.

## Validation

- `cargo test -- --test-threads=1` (the parallel form deadlocks this crate): **4612 passed, 1 failed**.
- `go build ./...` clean.

### The one Rust failure is pre-existing on master, and I filed it

`afxdp::cold_path_hist::tests::snapshot_under_concurrent_writer_never_tears` fails on `origin/master` `de6b8c85d` itself — reproduced **3/3** in a detached worktree with no local changes. Filed as **#7650**.

It is worth knowing what it is before anyone triages it from the name: the assertion that fails is the **coherence precondition** (`only 5/1000 snapshots coherent`), an anti-vacuity floor. The actual tear detections — monotonicity and the cross-field `samples == bucket_sum` invariant — both pass. So the seqlock did not tear; the reader exhausted its retry budget on this machine. `make test` is red on master for that reason.
