### PR TITLE
config: widen the #2419 census to named instances

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -106649,3 +106649,37 @@ prose edit above them added. No diff falls in the new test body.
     terminal schema node permitting a body (Codex re-review finding 1)
   - **File(s)**: pkg/config/compact_tail.go,
     pkg/config/compact_leaf_credentials_test.go
+
+## 2026-08-26 — #2419 widen the compact/block census to named instances
+
+- **Timestamp**: 2026-08-26
+- **Action**: Remove the named-instance exclusion from the #2419 census walker
+  and regenerate the inventory. No production change — this is a measurement
+  correction, and it makes the number the normalizer's criterion rests on
+  checkable by anyone.
+- **The exclusion was WRONG, and wrong in the direction that hides defects.**
+  It was generalized from ONE probe — `interfaces { ge-0/0/0 description
+  hello; }`, which genuinely compiles to zero interfaces — to every named
+  instance in the schema. Measured on the rest: `interface ge-0/0/0.0 cost 10;`
+  compiles the interface with `cost=0`. The instance IS recognised; only its
+  body is lost, which is strictly worse than not recognising it because the
+  half-built object reaches the renderer and the runtime. #7653 is the same
+  shape two levels deep, with OSPF authentication as the dropped body.
+- **Numbers, re-derived at `6b80a84f6`** (NOT the 363 measured before #6817/
+  #6818/#6822 merged — that number is now stale in a way that looks like
+  progress): **546 checked, 356 divergent, 204 unruled**. The honest quote is
+  ">= 356 divergent, 204 unruled": the unruled grew 96 -> 204 with the widening
+  and they are sites whose synthesized fixture was too thin to OBSERVE the
+  value, not clean sites.
+- **Golden diff classified before trusting it**: 0 data lines REMOVED (nothing
+  that was divergent silently stopped being divergent, so no behaviour change is
+  laundered in), +169 added, 5 header lines re-counted. Sample-verified one
+  added site by hand: `applications { application myapp description hello; }`
+  compiles the application with an EMPTY description while the block spelling
+  sets it.
+- **Not covered, and named as such**: the walker collapses exactly ONE level, so
+  it cannot generate #7653's two-level tail. Shape 3 is unmeasured here and its
+  number is owed separately, with the depth it reached stated.
+- **File(s)**: `pkg/config/compact_block_equivalence_2419_test.go`,
+  `pkg/config/testdata/compact_block_divergences_2419.txt`,
+  `docs/config-schema.md`, `_Log.md`

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1471,12 +1471,25 @@ Three things to know before working on this class:
    hand-authored or `load merge`d text, and from tools that render flat paths
    into partial braces. A test that compares "flat-set vs block" is comparing
    block against block: vacuously equal for every leaf and green everywhere.
-2. **Only a PLAIN KEYWORD stanza is compactable.** Collapsing a NAMED INSTANCE
-   (`interfaces ge-0/0/0`, `user ops`, `stream audit`) does not produce the
-   compact spelling of the same intent — the name is part of the node's identity
-   and the result is a node the compiler cannot recognise as that instance at
-   all. A census that compacts named instances over-reports by roughly a factor
-   of two.
+2. **A NAMED INSTANCE is compactable too, and that is where the dangerous
+   variant lives.** An earlier version of this section claimed collapsing a
+   named instance (`interfaces ge-0/0/0`, `user ops`, `stream audit`) produces
+   "a node the compiler cannot recognise as that instance at all". **That was
+   wrong**, generalized from a single probe, and wrong in the direction that
+   hides defects. There are two outcomes and they are not equally bad:
+
+   - **instance not created** — `interfaces { ge-0/0/0 description hello; }`
+     compiles to zero interfaces. A loud, total drop.
+   - **instance created, body dropped** — `interface ge-0/0/0.0 cost 10;`
+     compiles the interface with `cost=0`. This is the dangerous one: the
+     half-built object reaches the renderer and the runtime, so
+     `show configuration` displays what the operator wrote, the object binds
+     normally, and it enforces nothing. #7653 is this shape two levels deep,
+     where the dropped body is OSPF authentication.
+
+   `interfaces` gave the first outcome; everything else checked gives the
+   second. Excluding named instances hid ~169 sites of exactly the class the
+   census exists to count.
 3. **Bracketed multi-value lists are schema LEAVES, not containers.**
    `from protocol [ tcp udp ]` legitimately collapses onto `Keys` (see the next
    section). Any fix for this class must key on the schema's container/leaf

--- a/pkg/config/compact_block_equivalence_2419_test.go
+++ b/pkg/config/compact_block_equivalence_2419_test.go
@@ -107,19 +107,34 @@ type compactSite struct {
 	node      *schemaNode
 }
 
-// A site is compactable ONLY when the innermost container is a PLAIN KEYWORD
-// stanza — args == 0 and not reached through a wildcard. A NAMED INSTANCE
-// (`interfaces ge-0/0/0`, `user ops`, `stream audit`) carries its name in the
-// node's own Keys, so collapsing the next level onto it does not produce the
-// compact spelling of the same intent; it produces a node the compiler cannot
-// recognise as that named instance at all. All four filed instances compact a
-// plain stanza (`authentication`, `transport`, `authentication-sha256`).
+// A site is compactable when the innermost container is EITHER a plain keyword
+// stanza (`authentication`, `transport`) OR a NAMED INSTANCE
+// (`interface ge-0/0/0.0`, `user ops`, `stream audit`).
+//
+// This census previously excluded named instances, on the stated premise that
+// collapsing one "produces a node the compiler cannot recognise as that named
+// instance at all". That premise was WRONG, and wrong in the direction that
+// hides defects. It was generalized from a single probe — `interfaces {
+// ge-0/0/0 description hello; }`, which really does compile to zero interfaces
+// — to every named instance in the schema. Measured on the rest:
+//
+//	interface ge-0/0/0.0 { cost 10; }        -> ifaces=1 cost=10
+//	interface ge-0/0/0.0 cost 10;            -> ifaces=1 cost=0     <- recognised, body dropped
+//
+// The instance IS recognised; only its body is lost. That is strictly worse
+// than not recognising it, because the half-built object reaches the renderer
+// and the runtime: `show configuration` displays what the operator wrote, the
+// interface binds normally, and it enforces nothing. #7653 is the same shape
+// two levels deep, where the dropped body is OSPF authentication.
+//
+// So the exclusion was hiding ~169 sites of the same class the census exists to
+// count. Removing it is not a scope change; it is a correction.
 
 func collectCompactSites() []compactSite {
 	var out []compactSite
 	seen := map[string]bool{}
-	var walk func(n *schemaNode, path []string, depth int, plainInner bool)
-	walk = func(n *schemaNode, path []string, depth int, plainInner bool) {
+	var walk func(n *schemaNode, path []string, depth int)
+	walk = func(n *schemaNode, path []string, depth int) {
 		if n == nil || depth > 7 {
 			return
 		}
@@ -133,7 +148,7 @@ func collectCompactSites() []compactSite {
 			if ch == nil {
 				continue
 			}
-			if ch.children == nil && ch.wildcard == nil && ch.args == 1 && len(path) >= 1 && plainInner {
+			if ch.children == nil && ch.wildcard == nil && ch.args == 1 && len(path) >= 1 {
 				key := strings.Join(path, "/") + "|" + name
 				if !seen[key] {
 					seen[key] = true
@@ -147,13 +162,13 @@ func collectCompactSites() []compactSite {
 				elem += " xpfarg"
 			}
 			np := append(append([]string(nil), path...), elem)
-			walk(ch, np, depth+1, ch.args == 0)
+			walk(ch, np, depth+1)
 		}
 		if n.wildcard != nil {
-			walk(n.wildcard, append(append([]string(nil), path...), "xpfname"), depth+1, false)
+			walk(n.wildcard, append(append([]string(nil), path...), "xpfname"), depth+1)
 		}
 	}
-	walk(setSchema, nil, 0, false)
+	walk(setSchema, nil, 0)
 	return out
 }
 

--- a/pkg/config/testdata/compact_block_divergences_2419.txt
+++ b/pkg/config/testdata/compact_block_divergences_2419.txt
@@ -12,31 +12,68 @@
 #
 # `xpfarg` / `xpfname` are synthesized instance names.
 #
-# checked: 326
+# checked: 546
 #
-# skipped (leaf value not observable in the typed config): 96
-# skipped (a spelling did not parse or compile): 15
-# skipped (no two distinct synthesizable values): 9
-# skipped (under groups (schema re-host, duplicate coverage)): 346
+# skipped (leaf value not observable in the typed config): 204
+# skipped (a spelling did not parse or compile): 37
+# skipped (no two distinct synthesizable values): 12
+# skipped (under groups (schema re-host, duplicate coverage)): 642
 #
+applications application xpfarg alg
+applications application xpfarg description
+applications application xpfarg destination-port
+applications application xpfarg icmp-code
+applications application xpfarg icmp-type
+applications application xpfarg inactivity-timeout
+applications application xpfarg protocol
+applications application xpfarg source-port
+applications application xpfarg term
+applications application xpfarg timeout
 applications application-set
+bridge-domains xpfname domain-type
+bridge-domains xpfname routing-interface
 chassis device-map unmapped-interface-policy
 class-of-service interfaces xpfarg classifiers dscp
 class-of-service interfaces xpfarg classifiers ieee-802.1
+class-of-service interfaces xpfarg output-traffic-control-profile
+class-of-service interfaces xpfarg priority-low-min-share
 class-of-service interfaces xpfarg rewrite-rules dscp
 class-of-service interfaces xpfarg rewrite-rules ieee-802.1
+class-of-service interfaces xpfarg scheduler-map
+class-of-service interfaces xpfarg shaping-rate xpfarg burst-size
+class-of-service schedulers xpfarg codel-target
+class-of-service schedulers xpfarg equal-flow-target-policy
+class-of-service schedulers xpfarg priority
+class-of-service traffic-control-profiles xpfarg delay-buffer-rate
+class-of-service traffic-control-profiles xpfarg guaranteed-rate
+class-of-service traffic-control-profiles xpfarg scheduler-map
+class-of-service traffic-control-profiles xpfarg shaping-rate
 firewall policer xpfarg if-exceeding bandwidth-limit
 firewall policer xpfarg if-exceeding burst-size-limit
 firewall policer xpfarg then loss-priority
 forwarding-options dhcp-relay server-group
 forwarding-options family inet6 mode
+forwarding-options sampling instance xpfarg family inet output flow-server xpfarg port
+forwarding-options sampling instance xpfarg family inet output flow-server xpfarg source-address
+forwarding-options sampling instance xpfarg family inet output flow-server xpfarg version-ipfix-template
+forwarding-options sampling instance xpfarg family inet output flow-server xpfarg version9-template
 forwarding-options sampling instance xpfarg family inet output source-address
+forwarding-options sampling instance xpfarg family inet6 output flow-server xpfarg port
+forwarding-options sampling instance xpfarg family inet6 output flow-server xpfarg source-address
+forwarding-options sampling instance xpfarg family inet6 output flow-server xpfarg version-ipfix-template
+forwarding-options sampling instance xpfarg family inet6 output flow-server xpfarg version9-template
 forwarding-options sampling instance xpfarg family inet6 output source-address
 forwarding-options sampling instance xpfarg input rate
 interfaces xpfname aggregated-ether-options lacp periodic
 interfaces xpfname aggregated-ether-options link-speed
+interfaces xpfname description
+interfaces xpfname duplex
+interfaces xpfname encapsulation
 interfaces xpfname gigether-options 802.3ad
 interfaces xpfname gigether-options redundant-parent
+interfaces xpfname mtu
+interfaces xpfname native-vlan-id
+interfaces xpfname speed
 interfaces xpfname tunnel destination
 interfaces xpfname tunnel key
 interfaces xpfname tunnel mode
@@ -44,7 +81,12 @@ interfaces xpfname tunnel routing-instance destination
 interfaces xpfname tunnel source
 interfaces xpfname tunnel ttl
 interfaces xpfname tunnel wireguard listen-port
+interfaces xpfname tunnel wireguard peer xpfarg allowed-ips
+interfaces xpfname tunnel wireguard peer xpfarg endpoint
+interfaces xpfname tunnel wireguard peer xpfarg persistent-keepalive
+interfaces xpfname tunnel wireguard peer xpfarg preshared-key
 interfaces xpfname tunnel wireguard private-key
+policy-options community xpfarg members
 policy-options policy-statement xpfarg term xpfarg from as-path
 policy-options policy-statement xpfarg term xpfarg from community
 policy-options policy-statement xpfarg term xpfarg from prefix-list
@@ -60,19 +102,41 @@ policy-options policy-statement xpfarg term xpfarg then origin
 policy-options prefix-list
 protocols bgp cluster-id
 protocols bgp export
+protocols bgp group xpfarg neighbor xpfarg authentication-key
+protocols bgp group xpfarg neighbor xpfarg description
+protocols bgp group xpfarg neighbor xpfarg export
+protocols bgp group xpfarg neighbor xpfarg hold-time
+protocols bgp group xpfarg neighbor xpfarg import
+protocols bgp group xpfarg neighbor xpfarg local-address
+protocols bgp group xpfarg neighbor xpfarg local-as
+protocols bgp group xpfarg neighbor xpfarg peer-as
 protocols bgp import
 protocols bgp local-as
 protocols bgp router-id
 protocols isis authentication-key
 protocols isis authentication-type
 protocols isis export
+protocols isis interface xpfarg authentication-key
+protocols isis interface xpfarg authentication-type
+protocols isis interface xpfarg level
 protocols isis is-type
 protocols isis level
 protocols isis net
 protocols lldp hold-multiplier
 protocols lldp transmit-interval
+protocols ospf area xpfarg interface xpfarg authentication md5 xpfarg key
+protocols ospf area xpfarg interface xpfarg dead-interval
+protocols ospf area xpfarg interface xpfarg hello-interval
+protocols ospf area xpfarg interface xpfarg interface-type
+protocols ospf area xpfarg interface xpfarg priority
+protocols ospf area xpfarg interface xpfarg retransmit-interval
+protocols ospf area xpfarg virtual-link xpfarg transit-area
 protocols ospf export
 protocols ospf router-id
+protocols ospf3 area xpfarg interface xpfarg dead-interval
+protocols ospf3 area xpfarg interface xpfarg hello-interval
+protocols ospf3 area xpfarg interface xpfarg priority
+protocols ospf3 area xpfarg interface xpfarg retransmit-interval
 protocols ospf3 export
 protocols ospf3 router-id
 protocols rip authentication-key
@@ -80,12 +144,31 @@ protocols rip authentication-type
 protocols rip neighbor
 protocols rip passive-interface
 protocols rip redistribute
+protocols router-advertisement interface xpfarg default-lifetime
+protocols router-advertisement interface xpfarg dns-server-address
+protocols router-advertisement interface xpfarg link-mtu
+protocols router-advertisement interface xpfarg max-advertisement-interval
+protocols router-advertisement interface xpfarg min-advertisement-interval
+protocols router-advertisement interface xpfarg preference
 routing-instances xpfname protocols isis authentication-key
 routing-instances xpfname protocols isis authentication-type
 routing-instances xpfname protocols isis export
+routing-instances xpfname protocols isis interface xpfarg authentication-key
+routing-instances xpfname protocols isis interface xpfarg authentication-type
+routing-instances xpfname protocols isis interface xpfarg level
 routing-instances xpfname protocols isis is-type
 routing-instances xpfname protocols isis level
 routing-instances xpfname protocols isis net
+routing-instances xpfname protocols ospf area xpfarg interface xpfarg dead-interval
+routing-instances xpfname protocols ospf area xpfarg interface xpfarg hello-interval
+routing-instances xpfname protocols ospf area xpfarg interface xpfarg interface-type
+routing-instances xpfname protocols ospf area xpfarg interface xpfarg priority
+routing-instances xpfname protocols ospf area xpfarg interface xpfarg retransmit-interval
+routing-instances xpfname protocols ospf area xpfarg virtual-link xpfarg transit-area
+routing-instances xpfname protocols ospf3 area xpfarg interface xpfarg dead-interval
+routing-instances xpfname protocols ospf3 area xpfarg interface xpfarg hello-interval
+routing-instances xpfname protocols ospf3 area xpfarg interface xpfarg priority
+routing-instances xpfname protocols ospf3 area xpfarg interface xpfarg retransmit-interval
 routing-instances xpfname protocols ospf3 export
 routing-instances xpfname protocols ospf3 router-id
 routing-options autonomous-system
@@ -98,6 +181,8 @@ schedulers scheduler xpfarg monday start-time
 schedulers scheduler xpfarg monday stop-time
 schedulers scheduler xpfarg saturday start-time
 schedulers scheduler xpfarg saturday stop-time
+schedulers scheduler xpfarg start-time
+schedulers scheduler xpfarg stop-time
 schedulers scheduler xpfarg sunday start-time
 schedulers scheduler xpfarg sunday stop-time
 schedulers scheduler xpfarg thursday start-time
@@ -106,7 +191,14 @@ schedulers scheduler xpfarg tuesday start-time
 schedulers scheduler xpfarg tuesday stop-time
 schedulers scheduler xpfarg wednesday start-time
 schedulers scheduler xpfarg wednesday stop-time
+security address-book global address-set xpfarg address
+security address-book global address-set xpfarg address-set
 security dynamic-address address-name xpfarg profile feed-name
+security dynamic-address feed-server xpfarg feed-name xpfarg path
+security dynamic-address feed-server xpfarg hold-interval
+security dynamic-address feed-server xpfarg hostname
+security dynamic-address feed-server xpfarg update-interval
+security dynamic-address feed-server xpfarg url
 security flow aging early-ageout
 security flow aging high-watermark
 security flow aging low-watermark
@@ -119,14 +211,58 @@ security flow tcp-session initial-timeout
 security flow tcp-session time-wait-timeout
 security flow traceoptions file
 security flow traceoptions flag
+security flow traceoptions packet-filter xpfarg destination-prefix
+security flow traceoptions packet-filter xpfarg protocol
+security flow traceoptions packet-filter xpfarg source-prefix
 security flow udp-session timeout
+security ike gateway xpfarg address
+security ike gateway xpfarg external-interface
+security ike gateway xpfarg ike-policy
+security ike gateway xpfarg local-address
+security ike gateway xpfarg local-certificate
+security ike gateway xpfarg nat-traversal
+security ike gateway xpfarg version
+security ike policy xpfarg mode
+security ike policy xpfarg proposal-set
+security ike policy xpfarg proposals
+security ike proposal xpfarg authentication-algorithm
+security ike proposal xpfarg authentication-method
+security ike proposal xpfarg dh-group
+security ike proposal xpfarg encryption-algorithm
+security ike proposal xpfarg lifetime-seconds
+security ipsec gateway xpfarg address
+security ipsec gateway xpfarg external-interface
+security ipsec gateway xpfarg ike-policy
+security ipsec gateway xpfarg local-address
+security ipsec gateway xpfarg local-certificate
+security ipsec gateway xpfarg nat-traversal
+security ipsec gateway xpfarg version
+security ipsec policy xpfarg proposal-set
+security ipsec policy xpfarg proposals
+security ipsec proposal xpfarg authentication-algorithm
+security ipsec proposal xpfarg dh-group
+security ipsec proposal xpfarg encryption-algorithm
+security ipsec proposal xpfarg lifetime-kilobytes
+security ipsec proposal xpfarg lifetime-seconds
+security ipsec proposal xpfarg protocol
+security ipsec vpn xpfarg bind-interface
+security ipsec vpn xpfarg df-bit
+security ipsec vpn xpfarg establish-tunnels
 security ipsec vpn xpfarg ike gateway
 security ipsec vpn xpfarg ike ipsec-policy
+security ipsec vpn xpfarg local-address
+security ipsec vpn xpfarg local-identity
+security ipsec vpn xpfarg pre-shared-key
+security ipsec vpn xpfarg remote-identity
+security ipsec vpn xpfarg traffic-selector xpfarg local-ip
+security ipsec vpn xpfarg traffic-selector xpfarg remote-ip
 security ipsec vpn xpfarg vpn-monitor destination-ip
 security ipsec vpn xpfarg vpn-monitor source-interface
 security log format
 security log mode
+security log profile xpfarg stream-name
 security log source-interface
+security log stream xpfarg host
 security log stream xpfarg transport protocol
 security log stream xpfarg transport tls-profile
 security nat destination pool
@@ -137,6 +273,11 @@ security nat destination rule-set xpfarg rule xpfarg match destination-port
 security nat destination rule-set xpfarg rule xpfarg match protocol
 security nat destination rule-set xpfarg rule xpfarg match source-address
 security nat destination rule-set xpfarg rule xpfarg match source-address-name
+security nat nat64 rule-set xpfarg prefix
+security nat nat64 rule-set xpfarg source-pool
+security nat proxy-arp interface xpfarg address
+security nat source pool xpfarg port-overloading-factor
+security nat source pool xpfarg routing-instance
 security nat source rule-set xpfarg rule xpfarg match application
 security nat source rule-set xpfarg rule xpfarg match destination-address
 security nat source rule-set xpfarg rule xpfarg match destination-address-name
@@ -147,10 +288,12 @@ security nat static rule-set xpfarg rule xpfarg match destination-address
 security nat static rule-set xpfarg rule xpfarg match destination-port
 security nat static rule-set xpfarg rule xpfarg match source-address
 security policies default-policy-log
+security policies from-zone xpfarg xpfarg xpfarg policy xpfarg description
 security policies from-zone xpfarg xpfarg xpfarg policy xpfarg match application
 security policies from-zone xpfarg xpfarg xpfarg policy xpfarg match destination-address
 security policies from-zone xpfarg xpfarg xpfarg policy xpfarg match source-address
 security policies from-zone xpfarg xpfarg xpfarg policy xpfarg then log
+security policies global policy xpfarg description
 security policies global policy xpfarg match application
 security policies global policy xpfarg match destination-address
 security policies global policy xpfarg match from-zone
@@ -160,12 +303,24 @@ security policies global policy xpfarg then log
 security pre-id-default-policy then log
 security screen ids-option xpfarg limit-session destination-ip-based
 security screen ids-option xpfarg limit-session source-ip-based
+security zones security-zone xpfarg address-book address-set xpfarg address
+security zones security-zone xpfarg address-book address-set xpfarg address-set
+security zones security-zone xpfarg description
 security zones security-zone xpfarg host-inbound-traffic protocols
 security zones security-zone xpfarg host-inbound-traffic system-services
 security zones security-zone xpfarg interfaces xpfname host-inbound-traffic protocols
 security zones security-zone xpfarg interfaces xpfname host-inbound-traffic system-services
+security zones security-zone xpfarg screen
+services flow-monitoring version-ipfix template xpfarg flow-active-timeout
+services flow-monitoring version-ipfix template xpfarg flow-inactive-timeout
 services flow-monitoring version-ipfix template xpfarg template-refresh-rate seconds
+services flow-monitoring version9 template xpfarg flow-active-timeout
+services flow-monitoring version9 template xpfarg flow-inactive-timeout
 services flow-monitoring version9 template xpfarg template-refresh-rate seconds
+snmp community xpfarg clients
+snmp trap-group xpfarg categories
+snmp trap-group xpfarg targets
+snmp trap-group xpfarg version
 system archival configuration archive-sites
 system archival configuration transfer-interval
 system dataplane binary
@@ -186,10 +341,17 @@ system dataplane workers
 system domain-search
 system host-name
 system license autoupdate url
+system login class xpfarg allow-commands
+system login class xpfarg allow-configuration
+system login class xpfarg deny-commands
+system login class xpfarg deny-configuration
+system login class xpfarg idle-timeout
+system login class xpfarg permissions
 system login user xpfarg authentication encrypted-password
 system login user xpfarg authentication ssh-dsa
 system login user xpfarg authentication ssh-ed25519
 system login user xpfarg authentication ssh-rsa
+system login user xpfarg class
 system master-password pseudorandom-function
 system name-server
 system ntp server
@@ -197,12 +359,19 @@ system root-authentication encrypted-password
 system root-authentication ssh-dsa
 system root-authentication ssh-ed25519
 system root-authentication ssh-rsa
+system services dhcp-local-server group xpfarg pool xpfarg dns-server
+system services dhcp-local-server group xpfarg pool xpfarg static-binding xpfarg fixed-address
+system services dhcp-local-server group xpfarg pool xpfarg static-binding xpfarg host-name
+system services dhcpv6-local-server group xpfarg pool xpfarg dns-server
+system services dhcpv6-local-server group xpfarg pool xpfarg static-binding xpfarg fixed-address
+system services dhcpv6-local-server group xpfarg pool xpfarg static-binding xpfarg host-name
 system services ssh client-alive-count-max
 system services ssh client-alive-interval
 system services ssh connection-limit
 system services ssh key-exchange
 system services ssh root-login
 system services web-management api-auth api-key
+system services web-management api-auth user xpfname password
 system services web-management http interface
 system services web-management https interface
 system time-zone


### PR DESCRIPTION
Refs #2419, #6821, #7653 — **closes none.** No production change: this is a measurement correction that makes the number the normalizer's criterion rests on checkable by anyone, and gives the #7653 lane a committed base to extend rather than re-deriving the widening.

## Summary

- **The census excluded named instances on a premise that was wrong**, and wrong in the direction that hides defects.
- It was generalized from **one** probe — `interfaces { ge-0/0/0 description hello; }`, which genuinely compiles to zero interfaces — to every named instance in the schema.
- Measured on the rest, the instance **is** recognised and only its body is lost:

```
interface ge-0/0/0.0 { cost 10; }   ->  ifaces=1  cost=10
interface ge-0/0/0.0 cost 10;       ->  ifaces=1  cost=0
```

- **That is strictly worse than not recognising it.** The half-built object reaches the renderer and the runtime: `show configuration` displays what the operator wrote, the object binds normally, and it enforces nothing. #7653 is this shape two levels deep, where the dropped body is OSPF interface authentication and the result is an **unauthenticated adjacency**.
- The exclusion was hiding **~169 sites of exactly the class this census exists to count**. Removing it is a correction, not a scope change.

## Numbers, re-derived at this head

**Not** the 363 measured before #6817/#6818/#6822 landed — that number is now stale in a way that looks like progress, which is the trap worth naming.

| | |
|---|---|
| cells checked | **546** |
| cells divergent | **356** |
| cells unruled ("value not observable") | **204** |
| skipped — spelling did not parse/compile | 37 |
| skipped — no two distinct synthesizable values | 12 |
| skipped — under `groups` (schema re-host) | 642 |

**Quote it as "≥356 divergent, 204 unruled."** The unruled grew 96 → 204 with the widening, and they are sites whose synthesized fixture was too thin to **observe** the value — not sites that are clean. That is the same floor #6821 sat in until a required-sibling `host` line was added to its fixture. A census that rounds its unknowns into "clean" is the failure this category exists to prevent.

## The golden diff is classified, not assumed

Regenerating an inventory without classifying its diff launders a behaviour change, so:

| | |
|---|---|
| data lines **removed** | **0** — nothing that was divergent silently stopped being divergent |
| data lines added | 169 — the named-instance category, matching the measured delta exactly |
| header lines changed | 5 — the re-counted totals |

Zero removals is the load-bearing number: it proves this commit only *adds* to what the census sees.

**Sample-verified by hand** (COUNT → VERIFY): `applications { application myapp description hello; }` compiles the application with an **empty** description, while `applications { application myapp { description hello; } }` sets it.

## What this still does NOT measure

Stated so the number is not read as more than it is: **the walker collapses exactly one level**, so it cannot generate #7653's two-level tail (`interface ge-0/0/0.0 authentication simple-password "x"`). Shape 3 is unmeasured here and its number is owed separately, with the depth reached stated — otherwise it is a floor of a floor.

## Docs

`docs/config-schema.md` carried the same wrong claim and is corrected in place, with the discriminator that matters: **instance not created** versus **instance created with its body dropped**, and why the second is the dangerous one. `interfaces` gave the first outcome; everything else checked gives the second.

## Test plan

- [x] Gate passes at 356 with all existing controls intact — the positive control, `filedByDesign` (6 entries) and `filedStillOpen` all still assert observed states.
- [x] Inventory diff classified: 0 removed / 169 added / 5 header.
- [x] One added site hand-verified against the compiler.
- [x] `go build ./...` rc 0 · **`go test -count=1 ./...` rc 0**, 68 packages ok.

No mutation matrix: this commit changes no production code, and the gate's own matrix (9 cells, all RED with tests-collected > 0) landed with #7641 and is unchanged by the widening.

Gated HEAD is the branch head; `origin/master` is an ancestor. No files under `userspace-dp/` or `userspace-xdp/`, so no cargo leg is owed.

## Validation not executed

`make test-deploy` / `make cluster-deploy` not run and not claimed — shared lock, and this PR adds no production code for a smoke to exercise.
