### PR TITLE
daemon: derive the sshd drop-in directory from its own seam (#7609)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-08-26 — #7609: one var now relocates the whole sshd drop-in
+
+- **Timestamp**: 2026-08-26
+- **Action**: `sshdConfPath` is a package var precisely so a test can point the
+  xpf-managed sshd drop-in at a throwaway tree, but `applySSHConfig` created its
+  DIRECTORY from a hard-coded `/etc/ssh/sshd_config.d`. Relocating the var gave
+  a file path with no parent, the write failed ENOENT, and the failure surfaced
+  as whatever the test was actually asserting — so a cell checking only "an
+  error was returned" passed while observing the fixture's own broken seam
+  rather than the injected condition. Derived the directory from
+  `filepath.Dir(sshdConfPath)`; byte-identical in production.
+  DELETED the `os.MkdirAll(filepath.Dir(sshdConfPath))` workaround the #6790
+  credential cells were carrying. That deletion IS the regression signal: the
+  #6790 suite passes without it, which is the observable proof the derivation
+  works, and if the parent stops being derived the healthy-control cell goes red
+  instead of the failure being absorbed.
+  Added a PAIRED production-value cell, which is the one that keeps this from
+  being a behaviour change: every other cell relocates the path, so none of them
+  would notice if the derivation produced the wrong directory on a real box.
+- **File(s)**: `pkg/daemon/daemon_system.go`,
+  `pkg/daemon/sshd_dropin_dir_seam_7609_test.go` (new),
+  `pkg/daemon/apply_credential_failclosed_6790_test.go`,
+  `pkg/daemon/README.md`, `_Log.md`
+- **Validation**: 3 cells — the relocation property with a NESTED path (so a fix
+  that only works for an existing grandparent still fails) and no pre-created
+  parent, the production-value control, and a cell holding the pre-existing
+  #2062 property that the mkdir error is still surfaced by name rather than
+  swallowed into the opaque downstream write error.
+
 ## 2026-08-26 — #6830 round 2: `ntp` was an INVENTED row, and it was on the wire
 
 - **Timestamp**: 2026-08-26

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -2272,6 +2272,20 @@ never lock an operator out of a remote box it manages.
   inside-the-semaphore re-read; loop ticks + ctx cancel; a loop-START cell
   asserting `Run` launches it unconditionally; and the accessor + metric-wiring
   cells below).
+  **One var relocates the whole sshd drop-in (#7609).** `sshdConfPath` is a
+  package var so a test can point the drop-in at a throwaway tree, and
+  `applySSHConfig` used to create its DIRECTORY from a hard-coded
+  `/etc/ssh/sshd_config.d`. Relocating the var therefore produced a file path
+  with no parent, the write failed with `ENOENT`, and — the part that matters —
+  that failure surfaced as whatever the test was actually asserting. A cell
+  checking only "an error was returned" passed while observing the fixture's own
+  broken seam rather than the condition it injected. The directory is now
+  `filepath.Dir(sshdConfPath)`: byte-identical in production (pinned by
+  `TestProductionDropInDirIsUnchanged7609`, because every other cell relocates
+  the path and so none of them would notice a wrong production value), and one
+  seam relocates file and parent together — the property `provisionedUsersDir`
+  already has for the three #5841 marker roots.
+
   **sshd is the third instance, and the one the "already covered" reading
   misses.** `applySSHConfig`'s UPDATE path does have a retry owner: #2062's
   `revertDropIn` restores the prior content on a failed reload, so the file no

--- a/pkg/daemon/apply_credential_failclosed_6790_test.go
+++ b/pkg/daemon/apply_credential_failclosed_6790_test.go
@@ -79,12 +79,13 @@ func newCredentialTailFixture6790(t *testing.T) *credentialTailFixture6790 {
 	if err := os.MkdirAll(sudoersDir, 0o755); err != nil {
 		t.Fatalf("seed sudoers dir: %v", err)
 	}
-	// applySSHConfig's own mkdir targets the hard-coded production
-	// /etc/ssh/sshd_config.d, so the relocated drop-in's parent must exist
-	// here or the WRITE fails and masks whatever the cell injected.
-	if err := os.MkdirAll(filepath.Dir(sshdConfPath), 0o755); err != nil {
-		t.Fatalf("seed sshd drop-in dir: %v", err)
-	}
+	// #7609 REMOVED the MkdirAll that used to sit here. applySSHConfig derives
+	// its drop-in directory from sshdConfPath now, so relocating that one var
+	// relocates the parent with it and the fixture no longer has to create it.
+	// This deletion IS #7609's regression signal: if the parent stops being
+	// derived, the write fails with ENOENT and the healthy-control cell below
+	// goes red instead of the failure being absorbed into whatever a cell was
+	// actually asserting.
 
 	// A readable, valid identity pair holding only root, so no login user
 	// resolves and no credential is ever mutated by a cell that did not ask.

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -1981,6 +1981,12 @@ func (d *Daemon) reconcileUserPassword(user *config.LoginUser) (err error) {
 
 // sshdConfPath is the xpf-managed sshd drop-in. Overridable in tests so the
 // remove/revert side effects can be exercised against a temp dir.
+//
+// #7609: it is the SOLE seam for the drop-in's location. applySSHConfig
+// derives the directory it creates from this path (filepath.Dir) rather than
+// repeating the literal, so pointing this one var at a throwaway tree relocates
+// the file AND its parent together. Before that the parent was hard-coded, so a
+// relocated path had no directory to be written into.
 var sshdConfPath = "/etc/ssh/sshd_config.d/xpf.conf"
 
 // FS + reload seam (#2062). applySSHConfig owns three real-world side effects
@@ -2094,7 +2100,26 @@ func (d *Daemon) applySSHConfig(cfg *config.Config) (retErr error) {
 	// the write below will also fail, but the mkdir error is the real cause
 	// (e.g. a read-only /etc) so surface it rather than only the opaque write
 	// error.
-	if err := sshdMkdirAll("/etc/ssh/sshd_config.d", 0755); err != nil {
+	//
+	// #7609: derived from sshdConfPath rather than repeated as a literal.
+	// Byte-identical in production — filepath.Dir("/etc/ssh/sshd_config.d/
+	// xpf.conf") IS "/etc/ssh/sshd_config.d" — so this changes no behaviour on
+	// a real box. What it fixes is the SEAM: sshdConfPath is a package var
+	// precisely so a test can point the drop-in at a throwaway tree, and a
+	// hard-coded parent meant relocating it created the file path without its
+	// directory. The write then failed with ENOENT, and the failure surfaced
+	// as whatever the test was actually asserting — a cell that only checked
+	// "the tail returned an error" would pass for the wrong reason.
+	//
+	// That is not hypothetical: the #6790 credential cells hit it, and carried
+	// an os.MkdirAll(filepath.Dir(sshdConfPath)) workaround in their fixture
+	// until this landed. Deleting that workaround is this change's regression
+	// signal — if the control cell stays green without it, the derivation
+	// works.
+	//
+	// One var now relocates the whole drop-in, which is the property
+	// provisionedUsersDir already has for the three #5841 marker roots.
+	if err := sshdMkdirAll(filepath.Dir(sshdConfPath), 0755); err != nil {
 		slog.Warn("failed to create sshd config drop-in directory", "err", err)
 		fail(fmt.Errorf("create sshd config drop-in directory: %w", err))
 	}

--- a/pkg/daemon/sshd_dropin_dir_seam_7609_test.go
+++ b/pkg/daemon/sshd_dropin_dir_seam_7609_test.go
@@ -1,0 +1,136 @@
+package daemon
+
+// sshd_dropin_dir_seam_7609_test.go — #7609.
+//
+// sshdConfPath is a package var for one reason: so a test can point the
+// xpf-managed sshd drop-in at a throwaway tree instead of writing to the real
+// /etc/ssh/sshd_config.d. applySSHConfig then created its directory from a
+// HARD-CODED literal, so relocating the var produced a file path whose parent
+// did not exist and the write failed with ENOENT.
+//
+// The failure mode is worse than an inconvenient fixture. The write error
+// surfaces as whatever the test was actually asserting, so a cell checking only
+// "an error was returned" passes for the wrong reason — it observes the
+// fixture's own broken seam rather than the condition it injected. That is how
+// the #6790 credential cells first went green-then-red: their healthy control
+// caught it, but only because it asserted nil rather than "some error".
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// sshCfg7609 is the smallest config that makes applySSHConfig WRITE rather
+// than take its remove-or-no-op branches: one recognised ssh leaf, so
+// buildSSHDConfig returns a non-empty body.
+func sshCfg7609() *config.Config {
+	cfg := &config.Config{}
+	cfg.System.Services = &config.SystemServicesConfig{
+		SSH: &config.SSHServiceConfig{RootLogin: "deny"},
+	}
+	return cfg
+}
+
+// stubSSHDCmds7609 makes the validate/reload seams succeed so the only thing
+// that can fail is the filesystem work under test.
+func stubSSHDCmds7609(t *testing.T) {
+	t.Helper()
+	origV, origR := sshdValidateCmd, sshdReloadCmd
+	sshdValidateCmd = func() ([]byte, error) { return nil, nil }
+	sshdReloadCmd = func() ([]byte, error) { return nil, nil }
+	t.Cleanup(func() { sshdValidateCmd, sshdReloadCmd = origV, origR })
+}
+
+// TestRelocatingSSHDConfPathRelocatesItsDirectory7609 is the property: ONE var
+// moves the whole drop-in.
+//
+// The parent is deliberately NOT pre-created — creating it is exactly the
+// workaround this change removes, and a fixture that creates it cannot observe
+// the defect.
+//
+// FAIL-ON-REVERT: restore the hard-coded "/etc/ssh/sshd_config.d" and the
+// relocated write fails with ENOENT, so the drop-in is absent and this reds.
+func TestRelocatingSSHDConfPathRelocatesItsDirectory7609(t *testing.T) {
+	stubSSHDCmds7609(t)
+	orig := sshdConfPath
+	// Nested, so the derivation has to create more than a single component —
+	// a fix that only ever worked for an existing grandparent still fails.
+	sshdConfPath = filepath.Join(t.TempDir(), "etc", "ssh", "sshd_config.d", "xpf.conf")
+	t.Cleanup(func() { sshdConfPath = orig })
+
+	d := &Daemon{}
+	if err := d.applySSHConfig(sshCfg7609()); err != nil {
+		t.Fatalf("applySSHConfig returned %v — with sshdConfPath relocated and its "+
+			"parent NOT pre-created, the drop-in directory must be derived from "+
+			"the same var (#7609)", err)
+	}
+
+	got, err := os.ReadFile(sshdConfPath)
+	if err != nil {
+		t.Fatalf("the relocated drop-in was not written: %v", err)
+	}
+	if !strings.Contains(string(got), "PermitRootLogin no") {
+		t.Fatalf("the drop-in does not carry the configured setting:\n%s", got)
+	}
+}
+
+// TestProductionDropInDirIsUnchanged7609 is the PAIRED control, and it is the
+// one that keeps this from being a behaviour change.
+//
+// The whole justification is "byte-identical in production": filepath.Dir of
+// the production path IS the literal it replaced. Without this cell, the
+// derivation could be wrong in production and every relocated test would still
+// pass, because no test uses the production path.
+func TestProductionDropInDirIsUnchanged7609(t *testing.T) {
+	const wantPath = "/etc/ssh/sshd_config.d/xpf.conf"
+	const wantDir = "/etc/ssh/sshd_config.d"
+	if sshdConfPath != wantPath {
+		t.Fatalf("sshdConfPath = %q, want %q — the production location is part of "+
+			"the operator contract, not an implementation detail", sshdConfPath, wantPath)
+	}
+	if got := filepath.Dir(sshdConfPath); got != wantDir {
+		t.Fatalf("filepath.Dir(sshdConfPath) = %q, want %q — the derivation must "+
+			"reproduce the literal it replaced, or #7609 silently moved where a "+
+			"real box writes its sshd drop-in", got, wantDir)
+	}
+}
+
+// TestDropInDirectoryFailureIsStillReported7609 pins that deriving the path did
+// not swallow the error the mkdir already reported.
+//
+// The pre-existing comment at that site says the mkdir error is surfaced
+// because it is "the real cause (e.g. a read-only /etc)" and the write's error
+// would be opaque. That reasoning is unchanged by #7609 and is worth holding:
+// a derivation that quietly dropped the error would leave an operator with only
+// the downstream write failure.
+//
+// Induced with a parent that is a FILE, so MkdirAll fails with ENOTDIR — a
+// refusal no privilege level can bypass, so the cell behaves the same for a
+// root and a non-root runner.
+func TestDropInDirectoryFailureIsStillReported7609(t *testing.T) {
+	stubSSHDCmds7609(t)
+	root := t.TempDir()
+	blocked := filepath.Join(root, "blocked")
+	if err := os.WriteFile(blocked, []byte("not a directory\n"), 0o644); err != nil {
+		t.Fatalf("seed the blocking file: %v", err)
+	}
+	orig := sshdConfPath
+	sshdConfPath = filepath.Join(blocked, "sshd_config.d", "xpf.conf")
+	t.Cleanup(func() { sshdConfPath = orig })
+
+	d := &Daemon{}
+	err := d.applySSHConfig(sshCfg7609())
+	if err == nil {
+		t.Fatal("applySSHConfig returned nil although the drop-in directory could " +
+			"not be created — the commit reports success over an sshd posture that " +
+			"was never written (#6790 joins this error into the commit result)")
+	}
+	if !strings.Contains(err.Error(), "create sshd config drop-in directory") {
+		t.Fatalf("the error does not name the directory failure, so an operator sees "+
+			"only the opaque downstream write error: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #7609

## Summary

- `sshdConfPath` is a package var for exactly one reason: so a test can point the xpf-managed sshd drop-in at a throwaway tree instead of writing to the real `/etc/ssh/sshd_config.d`. `applySSHConfig` then created its **directory** from a hard-coded literal, so relocating the var produced a file path whose parent did not exist and the write failed with `ENOENT`.
- The directory is now `filepath.Dir(sshdConfPath)` — **byte-identical in production**, so nothing changes on a real box.
- The `os.MkdirAll` workaround the #6790 fixture was carrying is **deleted**, and that deletion is the regression signal rather than tidying.

## Why this is a defect and not a fixture inconvenience

The write error surfaces as **whatever the test was actually asserting**. A cell checking only *"an error was returned"* passes while observing the fixture's own broken seam rather than the condition it injected.

That is not hypothetical. The #6790 credential cells hit it — their healthy control caught it, but only because it asserted `nil` rather than "some error". A failure-injection cell in the same file would have passed for entirely the wrong reason.

One seam now relocates the file and its parent together, which is the property `provisionedUsersDir` already has for the three #5841 marker roots.

## The deleted workaround is the regression signal

```go
-	// applySSHConfig's own mkdir targets the hard-coded production
-	// /etc/ssh/sshd_config.d, so the relocated drop-in's parent must exist
-	// here or the WRITE fails and masks whatever the cell injected.
-	if err := os.MkdirAll(filepath.Dir(sshdConfPath), 0o755); err != nil {
-		t.Fatalf("seed sshd drop-in dir: %v", err)
-	}
```

The #6790 suite passes without it — that is the observable proof the derivation works. And it stays a live signal: restoring the hard-coded parent reds **`TestApplyTailIsCleanWithHealthyCredentialReconciles6790`** and **`TestApplyTailSurfacesSSHConfigFailure6790`** as well as this PR's own cells, so the property is now guarded from two files.

## Test plan

- [x] `pkg/daemon/sshd_dropin_dir_seam_7609_test.go` — 3 cells:
  - `TestRelocatingSSHDConfPathRelocatesItsDirectory7609` — the property. Uses a **nested** path (`.../etc/ssh/sshd_config.d/xpf.conf`) so a fix that only works when the grandparent already exists still fails, and deliberately does **not** pre-create the parent — creating it is precisely the workaround being removed, and a fixture that creates it cannot observe the defect.
  - `TestProductionDropInDirIsUnchanged7609` — the **paired control**, and the one that keeps this from being a behaviour change: every other cell relocates the path, so **none of them would notice a wrong production value**. It pins both the path and its derived directory against the literal that was replaced.
  - `TestDropInDirectoryFailureIsStillReported7609` — holds the pre-existing #2062 property that the mkdir error is surfaced **by name** rather than swallowed into the opaque downstream write error. Induced with a parent that is a FILE (`ENOTDIR`), a refusal no privilege level bypasses, so it behaves the same for a root and a non-root runner.
- [x] **Mutation matrix** at HEAD `2964a4fc4`, fix committed first, full-package `go test -count=1 ./pkg/daemon/` with **no** `-run` filter, `buildbreak=0` throughout:

  | mutation | cell that RED | verdict |
  |---|---|---|
  | restore the hard-coded parent (the shipped defect) | both #7609 relocation cells **+ 2 #6790 cells** | RED |
  | derive the WRONG directory (parent of the parent) | `...RelocatesItsDirectory7609` + 2 #6790 cells | RED |
  | swallow the mkdir error | `TestDropInDirectoryFailureIsStillReported7609` | RED |
  | move the production path | `TestProductionDropInDirIsUnchanged7609` | RED |

- [x] `go build ./... && go test -count=1 ./...` → **rc 0**, 68/68 packages, at HEAD `2964a4fc4035552d8bb637425bcfd4255beda1a1`, `origin/master 6b80a84f6` verified an ancestor.
- [ ] **No smoke owed.** One derived path plus tests; no forwarding-path, cluster, VRRP, session-sync or failover code, no `userspace-dp`/`userspace-xdp` (no cargo leg). The sshd reload path itself is untouched.

### A note on one gate run

The first full-tree run failed `pkg/ipmon`'s `TestGatewayChangeCoalescesWithProbeTransition` (`actuations = 0, want coalesced (1-2)`). Investigated rather than re-run-and-shrugged: my diff touches no `pkg/ipmon` file, the test passes **3/3 in isolation**, passes on `origin/master` alone, and the second full-tree run at this same head is **rc 0, 68/68**. It fails an **anti-degeneracy precondition** — 0 observed actuations, i.e. the test could not observe its property — which is the #7650 class exactly, and I have reported it there as a fourth instance rather than attaching it to this PR.

## Refs

Closes #7609. Found while writing the #6790 credential cells, whose fixture carried the workaround this removes. Related: #5841 (the `provisionedUsersDir` single-seam property this mirrors), #2062 (the drop-in lifecycle and the mkdir-error rationale preserved here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1PvkJxs7KrzEdyC9u1LDu
