### PR TITLE
config: test the packed-tail guard at the helper, not through a compile

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -106649,3 +106649,9 @@ prose edit above them added. No diff falls in the new test body.
     terminal schema node permitting a body (Codex re-review finding 1)
   - **File(s)**: pkg/config/compact_tail.go,
     pkg/config/compact_leaf_credentials_test.go
+
+- **Timestamp**: 2026-08-26
+  - **Action**: #6818 — drive the packedBodyChildren guard test at the HELPER
+    instead of through a compile; one cell had a nil schema path and tested
+    nothing
+  - **File(s)**: pkg/config/compact_leaf_credentials_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -106717,3 +106717,7 @@ prose edit above them added. No diff falls in the new test body.
     instead of through a compile; one cell had a nil schema path and tested
     nothing
   - **File(s)**: pkg/config/compact_leaf_credentials_test.go
+
+- **Timestamp**: 2026-08-26
+  - **Action**: #6818 review round 2 — cells now assert VALUES and IDENTITY rather than node names, the schema paths are single-sourced so the resolution control cannot drift, and the end-to-end compile cells are restored alongside the helper cells instead of replaced by them.
+  - **File(s)**: pkg/config/compact_leaf_credentials_test.go

--- a/pkg/config/compact_leaf_credentials_test.go
+++ b/pkg/config/compact_leaf_credentials_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -218,7 +219,53 @@ func ospfIface6818(t *testing.T, cfg *Config, spelling string) *OSPFInterface {
 //
 // The guard is a property of packedBodyChildren. Test it there, and it holds
 // for every caller regardless of what runs upstream.
+// packedTailSchemaPaths is the SINGLE source of the schema paths the cells
+// below address.
+//
+// Every cell resolves its schema through packedTailSchema, which fails loudly
+// on a nil result, so a cell CANNOT run against a path that does not resolve.
+// The previous shape kept the paths as literals in each cell and re-spelled
+// them a second time in a "do these resolve?" control, which is two independent
+// copies of a fact that must agree: editing a cell's literal left the control
+// checking the OLD path and still passing. That is how
+// `firewall/family/filter/term/from` — missing the address family, therefore
+// nil — went unnoticed while the cell using it was green against a helper that
+// never ran.
+var packedTailSchemaPaths = map[string][]string{
+	"ospf-auth":     {"protocols", "ospf", "area", "interface", "authentication"},
+	"log-transport": {"security", "log", "stream", "transport"},
+	"filter-from":   {"firewall", "family", "inet", "filter", "term", "from"},
+}
+
+// packedTailSchema resolves one of the shared paths, failing the test if it is
+// nil. packedBodyChildren returns the node's children unchanged on a nil
+// schema, so an unresolved path turns its cell into a no-op that PASSES —
+// the failure has to happen here, not silently at the assertion.
+func packedTailSchema(t *testing.T, key string) *schemaNode {
+	t.Helper()
+	path, ok := packedTailSchemaPaths[key]
+	if !ok {
+		t.Fatalf("no packed-tail schema path registered under %q; add it to "+
+			"packedTailSchemaPaths so the resolution control covers it too", key)
+	}
+	s := schemaForPath(path...)
+	if s == nil {
+		t.Fatalf("schemaForPath(%v) is nil — packedBodyChildren short-circuits on a nil "+
+			"schema, so this cell would be a no-op that passes", path)
+	}
+	return s
+}
+
 func TestPackedTailAttachesOnlyWhereTheGrammarPermitsABody_6818(t *testing.T) {
+	// Every path resolves. packedTailSchema already fails a cell that uses a
+	// dead path, but a path can also go dead while the only cell using it is
+	// removed or skipped, so the registry is checked as a whole.
+	t.Run("every registered schema path resolves", func(t *testing.T) {
+		for key := range packedTailSchemaPaths {
+			packedTailSchema(t, key)
+		}
+	})
+
 	t.Run("terminal PERMITS a body: the block attaches UNDER it", func(t *testing.T) {
 		// `authentication md5 7 { key "k"; }` -- a packed tail AND a nested
 		// block on one node, which the parser does produce.
@@ -226,22 +273,31 @@ func TestPackedTailAttachesOnlyWhereTheGrammarPermitsABody_6818(t *testing.T) {
 			Keys:     []string{"authentication", "md5", "7"},
 			Children: []*Node{{Keys: []string{"key", "k"}}},
 		}
-		got := packedBodyChildren(node,
-			schemaForPath("protocols", "ospf", "area", "interface", "authentication"))
+		got := packedBodyChildren(node, packedTailSchema(t, "ospf-auth"))
 
 		if len(got) != 1 {
 			t.Fatalf("expected ONE synthesized child (the md5 chain head), got %d: %+v",
 				len(got), got)
 		}
 		md5 := got[0]
-		if md5.Name() != "md5" {
-			t.Fatalf("synthesized head = %q, want md5", md5.Name())
+		// KEYS, not Name(). The head carries the key-id `7` as its second key;
+		// a head that synthesized the name and dropped the value would satisfy
+		// Name() == "md5" while losing the thing the operator configured.
+		if !keysEqual6818(md5.Keys, "md5", "7") {
+			t.Fatalf("synthesized head Keys = %v, want [md5 7]", md5.Keys)
 		}
 		// The nested block must be UNDER md5, not beside it. Beside is what
-		// compiled an MD5 adjacency with an EMPTY key.
-		if len(md5.Children) != 1 || md5.Children[0].Name() != "key" {
-			t.Errorf("md5 children = %+v, want the `key` block attached BENEATH it. "+
-				"Returning it as a SIBLING is what dropped the key.", md5.Children)
+		// compiled an MD5 adjacency with an EMPTY key -- so the assertion is on
+		// the VALUE. `Name() == "key"` is equally true of a `key` node that
+		// arrived with its value stripped, which is precisely the defect.
+		if len(md5.Children) != 1 {
+			t.Fatalf("md5 children = %+v, want exactly the `key` block attached BENEATH "+
+				"it. Returning it as a SIBLING is what dropped the key.", md5.Children)
+		}
+		if !keysEqual6818(md5.Children[0].Keys, "key", "k") {
+			t.Errorf("md5 child Keys = %v, want [key k] — the defect this guards is an "+
+				"EMPTY key, so the VALUE is the property under test",
+				md5.Children[0].Keys)
 		}
 	})
 
@@ -249,40 +305,28 @@ func TestPackedTailAttachesOnlyWhereTheGrammarPermitsABody_6818(t *testing.T) {
 		// `protocol` is a scalar leaf under `transport`; it takes no body, so
 		// `transport protocol tcp { protocol tls; }` describes no nesting the
 		// schema has. The helper must decline rather than invent one.
+		orig := &Node{Keys: []string{"protocol", "tls"}}
 		node := &Node{
 			Keys:     []string{"transport", "protocol", "tcp"},
-			Children: []*Node{{Keys: []string{"protocol", "tls"}}},
+			Children: []*Node{orig},
 		}
-		got := packedBodyChildren(node,
-			schemaForPath("security", "log", "stream", "transport"))
+		got := packedBodyChildren(node, packedTailSchema(t, "log-transport"))
 
-		if len(got) != 1 || got[0].Name() != "protocol" {
+		if len(got) != 1 {
 			t.Fatalf("expected the node's own children returned unexpanded, got %+v", got)
 		}
-		// The real child, unexpanded -- NOT a synthesized `protocol tcp` with
-		// the block hung underneath it.
-		if len(got[0].Children) != 0 {
-			t.Errorf("the helper attached a body under a LEAF terminal: %+v. That invents "+
-				"a nesting level the schema does not have.", got[0].Children)
-		}
-	})
-
-	// A schema path that does not resolve makes packedBodyChildren a NO-OP --
-	// its first guard returns the node's children when the schema is nil. So a
-	// cell that passes a wrong path tests nothing and passes. This one nearly
-	// did: `schemaForPath("firewall","family","filter",...)` omits the address
-	// family and returns nil, and the cell below was green against it while the
-	// helper never ran. Assert the path RESOLVES before using it.
-	t.Run("the schema paths these cells use actually resolve", func(t *testing.T) {
-		for _, p := range [][]string{
-			{"protocols", "ospf", "area", "interface", "authentication"},
-			{"security", "log", "stream", "transport"},
-			{"firewall", "family", "inet", "filter", "term", "from"},
-		} {
-			if schemaForPath(p...) == nil {
-				t.Errorf("schemaForPath(%v) is nil — packedBodyChildren short-circuits on a "+
-					"nil schema, so every cell using this path is a no-op that passes", p)
-			}
+		// IDENTITY, not name. If the guard is deleted the helper returns a
+		// SYNTHESIZED `protocol tcp` node -- whose Name() is also "protocol",
+		// so no name-based assertion can tell the two apart. Requiring the
+		// caller's own child pointer back is what makes deleting the guard
+		// visible here, and it stays visible however the synthesized node is
+		// shaped.
+		if got[0] != orig {
+			t.Fatalf("the helper returned a SYNTHESIZED node (Keys=%v), not the node's own "+
+				"child. Under a LEAF terminal it must decline and hand back what it was "+
+				"given; inventing a nesting level the schema lacks is how the synthesized "+
+				"`tcp` overwrote a real `tls` child and downgraded an audit stream to "+
+				"plaintext", got[0].Keys)
 		}
 	})
 
@@ -293,8 +337,7 @@ func TestPackedTailAttachesOnlyWhereTheGrammarPermitsABody_6818(t *testing.T) {
 			Keys:     []string{"from", "flexible-match-range", "range", "r"},
 			Children: []*Node{{Keys: []string{"byte-offset", "9"}}},
 		}
-		got := packedBodyChildren(node,
-			schemaForPath("firewall", "family", "inet", "filter", "term", "from"))
+		got := packedBodyChildren(node, packedTailSchema(t, "filter-from"))
 		if len(got) != 1 {
 			t.Fatalf("expected one chain head, got %+v", got)
 		}
@@ -308,9 +351,19 @@ func TestPackedTailAttachesOnlyWhereTheGrammarPermitsABody_6818(t *testing.T) {
 		if depth < 2 {
 			t.Errorf("the tail expanded to depth %d; it should be a CHAIN, not one level", depth)
 		}
-		if len(deepest.Children) != 1 || deepest.Children[0].Name() != "byte-offset" {
-			t.Errorf("deepest node %q children = %+v, want the byte-offset block",
+		// The terminal is `range r`: the instance NAME is the value, and a
+		// chain that synthesized `range` without it addresses a different
+		// filter term while still walking to the right depth.
+		if !keysEqual6818(deepest.Keys, "range", "r") {
+			t.Errorf("deepest node Keys = %v, want [range r]", deepest.Keys)
+		}
+		if len(deepest.Children) != 1 {
+			t.Fatalf("deepest node %q children = %+v, want the byte-offset block",
 				deepest.Name(), deepest.Children)
+		}
+		if !keysEqual6818(deepest.Children[0].Keys, "byte-offset", "9") {
+			t.Errorf("deepest child Keys = %v, want [byte-offset 9]",
+				deepest.Children[0].Keys)
 		}
 	})
 
@@ -321,11 +374,75 @@ func TestPackedTailAttachesOnlyWhereTheGrammarPermitsABody_6818(t *testing.T) {
 		// above and corrupt every block-spelled config.
 		child := &Node{Keys: []string{"md5", "7"}}
 		node := &Node{Keys: []string{"authentication"}, Children: []*Node{child}}
-		got := packedBodyChildren(node,
-			schemaForPath("protocols", "ospf", "area", "interface", "authentication"))
+		got := packedBodyChildren(node, packedTailSchema(t, "ospf-auth"))
 		if len(got) != 1 || got[0] != child {
 			t.Errorf("a node with no packed tail must return its own children unchanged, "+
 				"got %+v", got)
 		}
 	})
+}
+
+// keysEqual6818 reports whether n.Keys is exactly want.
+func keysEqual6818(got []string, want ...string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestPackedTailCompilesLikeTheNestedSpelling_6818 is the END-TO-END half, and
+// it is a SUPPLEMENT to the helper cells above rather than a thing they
+// replace.
+//
+// The two answer different questions and neither subsumes the other:
+//
+//   - the helper cells pin the guard's contract at packedBodyChildren, so it
+//     holds for every caller including ones that do not exist yet, and they
+//     keep holding if something upstream (a #2419 whole-tree normalizer, say)
+//     stops the compiler from ever seeing a packed tail;
+//   - these cells pin that the guard is actually WIRED — that the compiler
+//     reaches it and the operator's key survives all the way into the compiled
+//     Config. A correct helper that no caller consults compiles an empty MD5
+//     key exactly like a broken one, and every cell above would still pass.
+//
+// The earlier revision of this file deleted these when it added the helper
+// cells. That traded the assertion on the compiled VALUE (AuthKey == "k") for
+// assertions on synthesized node NAMES, which is the wrong direction: the
+// defect being guarded is an EMPTY key.
+func TestPackedTailCompilesLikeTheNestedSpelling_6818(t *testing.T) {
+	t.Run("ospf md5: the packed spelling keeps the key", func(t *testing.T) {
+		compact, block := compileBothSpellings(t,
+			`protocols { ospf { area 0.0.0.0 { interface ge-0/0/0.0 { authentication md5 7 { key "k"; } } } } }`,
+			`protocols { ospf { area 0.0.0.0 { interface ge-0/0/0.0 { authentication { md5 7 { key "k"; } } } } } }`)
+		for name, cfg := range map[string]*Config{"packed": compact, "nested": block} {
+			iface := ospfIface6818(t, cfg, name)
+			if string(iface.AuthKey) != "k" {
+				t.Errorf("%s: AuthKey = %q, want \"k\" — the guard must not refuse an "+
+					"attachment the grammar allows, or the empty-MD5-key defect returns",
+					name, string(iface.AuthKey))
+			}
+		}
+	})
+
+	t.Run("three-level chain compiles identically", func(t *testing.T) {
+		compact, block := compileBothSpellings(t,
+			`firewall { family inet { filter f { term t { from flexible-match-range range r { byte-offset 9; } } } } }`,
+			`firewall { family inet { filter f { term t { from { flexible-match-range { range r { byte-offset 9; } } } } } } }`)
+		if !cfgEqualFirewall6818(compact, block) {
+			t.Error("the packed three-level chain compiled differently from the fully " +
+				"nested spelling; the guard is refusing an attachment the grammar allows")
+		}
+	})
+}
+
+// cfgEqualFirewall6818 compares the compiled firewall section of two configs.
+func cfgEqualFirewall6818(a, b *Config) bool {
+	ja, errA := json.Marshal(a.Firewall)
+	jb, errB := json.Marshal(b.Firewall)
+	return errA == nil && errB == nil && string(ja) == string(jb)
 }

--- a/pkg/config/compact_leaf_credentials_test.go
+++ b/pkg/config/compact_leaf_credentials_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"encoding/json"
 	"testing"
 )
 
@@ -196,7 +195,7 @@ func ospfIface6818(t *testing.T, cfg *Config, spelling string) *OSPFInterface {
 // secLogStream6821 resolves a security-log stream by name.
 
 // TestPackedTailAttachesOnlyWhereTheGrammarPermitsABody_6818 pins the guard on
-// packedBodyChildren's deep attachment.
+// packedBodyChildren's deep attachment, by calling the HELPER DIRECTLY.
 //
 // The helper attaches a node's real children UNDER the deepest node of the
 // expanded packed tail, which is what the grammar means for
@@ -204,43 +203,129 @@ func ospfIface6818(t *testing.T, cfg *Config, spelling string) *OSPFInterface {
 // the terminal is a LEAF: `stanza leaf value { body }` describes no nesting the
 // schema has, and attaching there would invent one.
 //
-// Both directions matter, so both are cells. Without the permits-a-body case,
-// a guard that refused every attachment would pass the refusal case and
-// silently reintroduce the empty-MD5-key defect; without the refusal case, the
-// guard could be deleted with nothing noticing.
+// # Why this drives the helper rather than a compile
+//
+// It used to go through CompileConfig on a packed source, which made it a test
+// of "does this packed config compile correctly" rather than of the helper's
+// contract. That is the wrong subject twice over:
+//
+//   - it tested the guard only via whichever callers happen to reach it today,
+//     so a new direct caller of packedBodyChildren was never covered;
+//   - and it is fragile to anything that rewrites the tree BEFORE the compiler
+//     runs. #2419's whole-tree normalizer does exactly that, and with it in
+//     place the compiler never sees a packed tail at all — the cell would pass
+//     while testing nothing, or fail for a reason unrelated to the guard.
+//
+// The guard is a property of packedBodyChildren. Test it there, and it holds
+// for every caller regardless of what runs upstream.
 func TestPackedTailAttachesOnlyWhereTheGrammarPermitsABody_6818(t *testing.T) {
-	t.Run("terminal PERMITS a body: the block attaches under it", func(t *testing.T) {
-		// `md5 7` takes a `key` child, so the nested block belongs under it.
-		compact, block := compileBothSpellings(t,
-			`protocols { ospf { area 0.0.0.0 { interface ge-0/0/0.0 { authentication md5 7 { key "k"; } } } } }`,
-			`protocols { ospf { area 0.0.0.0 { interface ge-0/0/0.0 { authentication { md5 7 { key "k"; } } } } } }`)
-		for name, cfg := range map[string]*Config{"packed": compact, "nested": block} {
-			iface := ospfIface6818(t, cfg, name)
-			if string(iface.AuthKey) != "k" {
-				t.Errorf("%s: AuthKey = %q, want \"k\" — the guard must not refuse an "+
-					"attachment the grammar allows, or the empty-MD5-key defect returns",
-					name, string(iface.AuthKey))
+	t.Run("terminal PERMITS a body: the block attaches UNDER it", func(t *testing.T) {
+		// `authentication md5 7 { key "k"; }` -- a packed tail AND a nested
+		// block on one node, which the parser does produce.
+		node := &Node{
+			Keys:     []string{"authentication", "md5", "7"},
+			Children: []*Node{{Keys: []string{"key", "k"}}},
+		}
+		got := packedBodyChildren(node,
+			schemaForPath("protocols", "ospf", "area", "interface", "authentication"))
+
+		if len(got) != 1 {
+			t.Fatalf("expected ONE synthesized child (the md5 chain head), got %d: %+v",
+				len(got), got)
+		}
+		md5 := got[0]
+		if md5.Name() != "md5" {
+			t.Fatalf("synthesized head = %q, want md5", md5.Name())
+		}
+		// The nested block must be UNDER md5, not beside it. Beside is what
+		// compiled an MD5 adjacency with an EMPTY key.
+		if len(md5.Children) != 1 || md5.Children[0].Name() != "key" {
+			t.Errorf("md5 children = %+v, want the `key` block attached BENEATH it. "+
+				"Returning it as a SIBLING is what dropped the key.", md5.Children)
+		}
+	})
+
+	t.Run("terminal is a LEAF: the body is NOT attached, tail unexpanded", func(t *testing.T) {
+		// `protocol` is a scalar leaf under `transport`; it takes no body, so
+		// `transport protocol tcp { protocol tls; }` describes no nesting the
+		// schema has. The helper must decline rather than invent one.
+		node := &Node{
+			Keys:     []string{"transport", "protocol", "tcp"},
+			Children: []*Node{{Keys: []string{"protocol", "tls"}}},
+		}
+		got := packedBodyChildren(node,
+			schemaForPath("security", "log", "stream", "transport"))
+
+		if len(got) != 1 || got[0].Name() != "protocol" {
+			t.Fatalf("expected the node's own children returned unexpanded, got %+v", got)
+		}
+		// The real child, unexpanded -- NOT a synthesized `protocol tcp` with
+		// the block hung underneath it.
+		if len(got[0].Children) != 0 {
+			t.Errorf("the helper attached a body under a LEAF terminal: %+v. That invents "+
+				"a nesting level the schema does not have.", got[0].Children)
+		}
+	})
+
+	// A schema path that does not resolve makes packedBodyChildren a NO-OP --
+	// its first guard returns the node's children when the schema is nil. So a
+	// cell that passes a wrong path tests nothing and passes. This one nearly
+	// did: `schemaForPath("firewall","family","filter",...)` omits the address
+	// family and returns nil, and the cell below was green against it while the
+	// helper never ran. Assert the path RESOLVES before using it.
+	t.Run("the schema paths these cells use actually resolve", func(t *testing.T) {
+		for _, p := range [][]string{
+			{"protocols", "ospf", "area", "interface", "authentication"},
+			{"security", "log", "stream", "transport"},
+			{"firewall", "family", "inet", "filter", "term", "from"},
+		} {
+			if schemaForPath(p...) == nil {
+				t.Errorf("schemaForPath(%v) is nil — packedBodyChildren short-circuits on a "+
+					"nil schema, so every cell using this path is a no-op that passes", p)
 			}
 		}
 	})
 
-	t.Run("three-level chain still attaches", func(t *testing.T) {
-		// `from flexible-match-range range r { byte-offset 9; }` expands through
-		// three levels and its terminal does take a body. Chain LENGTH was never
-		// the question; whether the terminal holds a body is.
-		compact, block := compileBothSpellings(t,
-			`firewall { family inet { filter f { term t { from flexible-match-range range r { byte-offset 9; } } } } }`,
-			`firewall { family inet { filter f { term t { from { flexible-match-range { range r { byte-offset 9; } } } } } } }`)
-		if !cfgEqualFirewall6818(compact, block) {
-			t.Error("the packed three-level chain compiled differently from the fully " +
-				"nested spelling; the guard is refusing an attachment the grammar allows")
+	t.Run("three-level chain: attaches at the DEEPEST node", func(t *testing.T) {
+		// Chain LENGTH was never the question; whether the terminal holds a
+		// body is. `range r` does, so the block belongs beneath it.
+		node := &Node{
+			Keys:     []string{"from", "flexible-match-range", "range", "r"},
+			Children: []*Node{{Keys: []string{"byte-offset", "9"}}},
+		}
+		got := packedBodyChildren(node,
+			schemaForPath("firewall", "family", "inet", "filter", "term", "from"))
+		if len(got) != 1 {
+			t.Fatalf("expected one chain head, got %+v", got)
+		}
+		// Walk to the deepest synthesized node and require the block there.
+		deepest := got[0]
+		depth := 1
+		for len(deepest.Children) == 1 && deepest.Children[0].Name() != "byte-offset" {
+			deepest = deepest.Children[0]
+			depth++
+		}
+		if depth < 2 {
+			t.Errorf("the tail expanded to depth %d; it should be a CHAIN, not one level", depth)
+		}
+		if len(deepest.Children) != 1 || deepest.Children[0].Name() != "byte-offset" {
+			t.Errorf("deepest node %q children = %+v, want the byte-offset block",
+				deepest.Name(), deepest.Children)
 		}
 	})
-}
 
-// cfgEqualFirewall6818 compares the compiled firewall section of two configs.
-func cfgEqualFirewall6818(a, b *Config) bool {
-	ja, errA := json.Marshal(a.Firewall)
-	jb, errB := json.Marshal(b.Firewall)
-	return errA == nil && errB == nil && string(ja) == string(jb)
+	t.Run("no packed tail: the children are returned untouched", func(t *testing.T) {
+		// The identity case, and the control for all three above: a node with
+		// no tail must come back exactly as it went in. Without this, a helper
+		// that synthesized something for EVERY node would satisfy the shapes
+		// above and corrupt every block-spelled config.
+		child := &Node{Keys: []string{"md5", "7"}}
+		node := &Node{Keys: []string{"authentication"}, Children: []*Node{child}}
+		got := packedBodyChildren(node,
+			schemaForPath("protocols", "ospf", "area", "interface", "authentication"))
+		if len(got) != 1 || got[0] != child {
+			t.Errorf("a node with no packed tail must return its own children unchanged, "+
+				"got %+v", got)
+		}
+	})
 }


### PR DESCRIPTION
Follows #7647. Corrects a guard test I wrote there — and a claim I made about it.

## The guard was tested through a compile; it should be tested at the helper

`TestPackedTailAttachesOnlyWhereTheGrammarPermitsABody_6818` compiled a packed config and compared it to the nested spelling. That is the wrong subject twice over:

- it exercised the guard only via whichever callers happen to reach it, so a new **direct** caller of `packedBodyChildren` was never covered;
- and it is fragile to anything that rewrites the tree **before** the compiler runs. #2419's whole-tree normalizer does exactly that, and with it in place the compiler never sees a packed tail — the cell would pass while testing nothing. close-6801 hit this on their branch, which is what prompted the look.

## One cell was already testing nothing, and the indirection hid it

```go
schemaForPath("firewall", "family", "filter", "term", "from")   // -> nil
```

It omits the address family. `packedBodyChildren`'s first guard returns the node's children unchanged on a **nil schema**, so the "three-level chain" cell was green against a helper that never ran.

**That also means a claim in #7647 was measuring the wrong thing.** I wrote:

> Verified rather than assumed: the three-level `from flexible-match-range range r { byte-offset 9; }` chain DOES permit a body at its terminal, and compiles byte-identically to the fully nested spelling.

The compile equivalence is real. It comes from the compiler's own `namedInstances`/`FindChildren` reading — **not** from the helper, which declined the entire tail. So it was evidence about the compiler offered as evidence about the guard. Driving the helper directly, the chain does expand and the block does attach at the deepest node; that is now asserted rather than inferred.

## Four cells, each on the helper

| cell | pins |
|---|---|
| terminal **permits** a body | the block attaches **beneath** the synthesized node — beside is what compiled an MD5 adjacency with an empty key |
| terminal is a **leaf** | the tail returns unexpanded rather than inventing a nesting the schema lacks |
| **three-level chain** | attaches at the deepest node, with the **depth asserted**, so a one-level expansion cannot pass |
| **no packed tail** | children returned untouched — the identity control |

The last is not decoration: without it, a helper that synthesized something for *every* node would satisfy the three shapes above and corrupt every block-spelled config.

Plus a cell asserting the schema paths the others use actually **resolve**, since a nil path silently turns each of them into a no-op that passes. That is the defect this commit found in its own predecessor, so the guard against it belongs here.

## Verified both directions

- Forcing the guard to refuse every attachment → reds the permits-a-body and chain cells.
- Returning the block as a **sibling** instead of a child → reds the permits-a-body cell.

## Validation

`go test -count=1 ./pkg/config/` green (98s full package, no `-run` filter); `go vet ./pkg/config/` clean.
