### PR TITLE
test: the remaining three anti-degeneracy preconditions that read the machine (#7650)

### DIFF
--- a/pkg/cluster/heartbeat_start_stop_race_7257_test.go
+++ b/pkg/cluster/heartbeat_start_stop_race_7257_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // #7257 — StartHeartbeat published m.hbSender/m.hbReceiver under m.mu, RELEASED
@@ -31,6 +32,25 @@ import (
 
 // TestStartHeartbeatDoesNotRaceStopHeartbeat7257 is the race probe.
 //
+// WARNING (#7663): this probe currently observes NOTHING, and the change below
+// does not fix that — it only stops the degeneracy floor firing spuriously
+// under load (#7650). Measured at de6b8c85d on an idle machine, with the #7257
+// production fix reverted, `-race` reports ZERO data races, both with and
+// without the #7650 change. The fail-on-revert contract stated further down is
+// false as written.
+//
+// The cause is structural, not timing: StartHeartbeat re-checks its entry epoch
+// before publishing, StopHeartbeat bumps that epoch, and this probe runs an
+// UNBOUNDED teardown loop. Instrumenting the epoch check gives
+// `publish-window entered=0 superseded=60` against 39300 stops — every start is
+// superseded long before it reaches the derefs that carry the race. The
+// `stops >= starts` floor below is satisfied by exactly the condition that
+// guarantees the vacuity, so it cannot detect it.
+//
+// #7663 carries the fix (pace the teardown; assert the publish window was
+// entered). Do not read a green here as evidence the #7257 regression is
+// guarded.
+//
 // The BOUNDED side is the expensive one. StartHeartbeat creates two UDP
 // sockets; StopHeartbeat is nearly free. A first draft bounded the stops and
 // looped the starts "until done", and the logged rate gave it away immediately:
@@ -47,6 +67,28 @@ import (
 // RED on revert: restore the unlocked `m.hbReceiver.start()` / `m.hbSender.start()`
 // pair after the Unlock and `go test -race -run TestStartHeartbeatDoesNotRaceStopHeartbeat7257
 // ./pkg/cluster/` reports WARNING: DATA RACE naming StartHeartbeat and StopHeartbeat.
+// waitForTeardownProgress blocks until the teardown goroutine has completed at
+// least one stop, so the start loop is issued into a window that is provably
+// being contended (#7650).
+//
+// Only ONE edge, and only before the contended region. A per-start handshake
+// would be deterministic but would also establish happens-before between each
+// teardown and the start it races, which is exactly what the race detector
+// looks for the absence of — the probe would go quiet against the very bug it
+// exists to catch.
+func waitForTeardownProgress(t *testing.T, stops *atomic.Int64, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for stops.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("the teardown goroutine completed no stops in %s — it was "+
+				"never scheduled, so every start below would run uncontended and "+
+				"the probe would be degenerate (#7650)", within)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
 func TestStartHeartbeatDoesNotRaceStopHeartbeat7257(t *testing.T) {
 	m := NewManager(0, 1)
 
@@ -84,6 +126,23 @@ func TestStartHeartbeatDoesNotRaceStopHeartbeat7257(t *testing.T) {
 			stops.Add(1)
 		}
 	}()
+	// #7650: wait until the teardown side is provably RUNNING before the
+	// starts begin.
+	//
+	// The degeneracy floor below is `stops >= starts`, and it fired on a loaded
+	// machine with 0 stops against 60 starts — not because the window was
+	// uncontended by design, but because the cheap goroutine had not been
+	// scheduled at all while the expensive one ran to completion. The floor was
+	// reading the machine.
+	//
+	// This wait is deliberately placed BEFORE the start loop and creates a
+	// happens-before edge only with stops that precede every start. It must not
+	// become a per-start handshake: an edge between a stop and the start it
+	// contends would ORDER the unlocked publish against the teardown's read and
+	// suppress the very data race this probe exists to detect. The teardown
+	// goroutine keeps running freely for the whole start loop, so each start
+	// still overlaps unordered teardowns.
+	waitForTeardownProgress(t, &stops, 5*time.Second)
 	wg.Wait()
 	m.StopHeartbeat()
 
@@ -92,7 +151,12 @@ func TestStartHeartbeatDoesNotRaceStopHeartbeat7257(t *testing.T) {
 	}
 	if stops.Load() < starts.Load() {
 		t.Fatalf("#7257 probe is degenerate: %d stops against %d starts — the teardown side "+
-			"must out-run the start side or the window is barely contended",
+			"must out-run the start side or the window is barely contended. NOTE "+
+			"(#7650): this is an anti-degeneracy PRECONDITION, not the property. "+
+			"The property is the race detector, and it did not fire. A very low "+
+			"stop count means the teardown goroutine was starved, which is a "+
+			"statement about the machine; re-run on an idle box before suspecting "+
+			"the heartbeat code",
 			stops.Load(), starts.Load())
 	}
 	t.Logf("#7257 race probe: %d starts against %d stops (%.1f stops/start)",

--- a/pkg/ipmon/nexthop_test.go
+++ b/pkg/ipmon/nexthop_test.go
@@ -304,8 +304,61 @@ func TestGatewayChangeCoalescesWithProbeTransition(t *testing.T) {
 		r.set("ge-0-0-3", "198.51.100.1")
 		e.NotifyNextHopChange()
 	}
-	time.Sleep(40 * time.Millisecond)
-	if got := actuations.Load(); got < 1 || got > 2 {
-		t.Fatalf("actuations = %d, want coalesced (1-2) for transition + gateway churn", got)
+
+	// #7650: the two halves of this assertion have different natures and the
+	// old `time.Sleep(40ms)` conflated them.
+	//
+	// The UPPER bound is the property: six notifications must collapse into at
+	// most two actuations. The LOWER bound is an anti-vacuity floor — without
+	// it the test passes having observed nothing.
+	//
+	// A fixed sleep only ever tested the property when the machine happened to
+	// be fast enough. Under load the 40 ms expired before the actuator ran at
+	// all, and the FLOOR fired with `actuations = 0` — which reads as an
+	// over-coalescing failure but is the test failing to observe, not the
+	// coalescer failing to coalesce. That is a reading of the machine, not of
+	// the subject (docs/engineering-style.md #7563).
+	//
+	// So wait on the observable that IMPLIES the floor — the actuator having
+	// run — and fail loudly naming what never arrived. Then let the engine's
+	// OWN throttle window elapse from that observed point, so any further
+	// actuation it was going to emit has had its chance before the upper bound
+	// is checked. The settle is derived from e.throttle/e.debounce rather than
+	// a literal, so retuning either cannot silently make this vacuous.
+	waitForActuation(t, &actuations, 1, 5*time.Second)
+	time.Sleep(e.throttle + e.debounce)
+	if got := actuations.Load(); got > 2 {
+		t.Fatalf("actuations = %d, want coalesced (at most 2) for transition + "+
+			"gateway churn — the debounce/throttle did not collapse the six "+
+			"notifications", got)
+	}
+}
+
+// waitForActuation blocks until the counter reaches want, or fails the test
+// naming what never arrived (#7650).
+//
+// This is the anti-vacuity floor expressed as a WAIT rather than as a sample
+// taken at a fixed wall-clock point. The distinction is the whole fix: a
+// sample can only report what the machine happened to have done by then, so on
+// a loaded box it reports zero and the floor fires for a reason that has
+// nothing to do with the property under test.
+//
+// The deadline is deliberately generous. It is not a timing assertion — it
+// exists so a genuinely broken actuator fails in seconds with a clear message
+// instead of hanging the suite.
+func waitForActuation(t *testing.T, counter *atomic.Int32, want int32, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for {
+		if got := counter.Load(); got >= want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("actuator never reached %d actuations within %s (saw %d) — "+
+				"the engine never actuated at all, so nothing below can be "+
+				"interpreted as a coalescing result (#7650)",
+				want, within, counter.Load())
+		}
+		time.Sleep(time.Millisecond)
 	}
 }

--- a/userspace-dp/src/afxdp/wg/tests.rs
+++ b/userspace-dp/src/afxdp/wg/tests.rs
@@ -2425,9 +2425,33 @@ mod framed_handshake {
             let completed = completed.clone();
             let stop = stop.clone();
             thread::spawn(move || {
-                for _ in 0..400 {
+                // #7650: loop until enough handshakes have COMPLETED, not for a
+                // fixed iteration count.
+                //
+                // The floor below ("no handshake completed — the race path was
+                // not exercised") is an anti-vacuity precondition, and with a
+                // fixed 400 iterations it was a reading of the machine: the
+                // reconciler removes the peer for part of every cycle, so on a
+                // loaded box a run can spend all 400 attempts inside removal
+                // windows, take the `continue` every time, and fire the floor
+                // with zero completions — while soundness, the actual property,
+                // was never in question.
+                //
+                // Running until the observation is made removes that
+                // sensitivity without weakening anything: the reconciler churns
+                // throughout, so every completion counted here is still a
+                // CONTENDED one. The attempt cap only stops a genuinely broken
+                // engine from hanging the suite, and is far above what a healthy
+                // run needs (a healthy run reaches the target in well under 400).
+                const TARGET_COMPLETIONS: u32 = 8;
+                const MAX_ATTEMPTS: u32 = 200_000;
+                let mut attempts = 0u32;
+                while completed.load(AOrd::Relaxed) < TARGET_COMPLETIONS && attempts < MAX_ATTEMPTS
+                {
+                    attempts += 1;
                     let mut msg1 = [0u8; WG_MSG_INIT_LEN];
                     if init.create_initiation(&resp_pub, &mut msg1).is_err() {
+                        thread::yield_now();
                         continue;
                     }
                     let mut msg2 = [0u8; WG_MSG_RESPONSE_LEN];
@@ -2435,6 +2459,7 @@ mod framed_handshake {
                         .consume_initiation_create_response(&msg1, &mut msg2)
                         .is_err()
                     {
+                        thread::yield_now();
                         continue;
                     }
                     if init.consume_response(&msg2).is_ok() {
@@ -2482,10 +2507,17 @@ mod framed_handshake {
         driver.join().unwrap();
         reconciler.join().unwrap();
 
-        // The race must have exercised real completions.
+        // The race must have exercised real completions. The driver loops until
+        // it reaches this, so a failure here means the engine could not complete
+        // a handshake in 200k contended attempts — a real defect, not a slow
+        // machine (#7650).
+        let done = completed.load(AOrd::Relaxed);
         assert!(
-            completed.load(AOrd::Relaxed) > 0,
-            "no handshake completed — the race path was not exercised"
+            done >= 8,
+            "only {done} handshakes completed in up to 200k contended attempts — \
+             the race path was not exercised, so the soundness checks below \
+             cannot be interpreted. This is an anti-vacuity PRECONDITION, not \
+             the property: nothing here says the maps are corrupt (#7650)"
         );
 
         // Soundness: after the storm, drive ONE clean handshake and a


### PR DESCRIPTION
Closes #7650

PR #7662 landed the first of the four instances (`cold_path_hist`). This is the
remaining **three**, which were written while #7662 was in review and did not
make that merge.

| instance | package | precondition that fired | fix |
|---|---|---|---|
| `wg::…concurrent_consume_response…` | `userspace-dp` | `completed > 0` handshakes | driver loops until it observes, not 400 times |
| `TestStartHeartbeatDoesNotRaceStopHeartbeat7257` | `pkg/cluster` | `stops >= starts` | wait once for the teardown side to be running, before the start loop |
| `TestGatewayChangeCoalescesWithProbeTransition` | `pkg/ipmon` | `actuations >= 1` | wait on the actuator, then settle by the engine's own throttle |

Each fails an anti-degeneracy **precondition** rather than its property, and each
was reading the machine rather than the subject. The shape is one idea in three
places: **wait on the observable that implies the floor, failing loudly and
naming what never arrived** — never sample an asynchronous value at a fixed
wall-clock point, and never lengthen a sleep. Every floor keeps its value;
only the way the test reaches it moved.

## `pkg/ipmon` — a timing test, not a concurrency one

`time.Sleep(40ms)` then `1 <= actuations <= 2`. The upper bound is the
coalescing property; the lower is the anti-vacuity floor. Under load the sleep
expired before the actuator ran at all and the floor fired with `actuations = 0`
— which reads as an over-coalescing failure but is the test failing to observe.

Now: wait for the actuator to run, then let the engine's **own**
`throttle + debounce` elapse from that observed point before checking the upper
bound. The settle is derived from the engine's fields rather than a literal, so
retuning either cannot silently make it vacuous.

## `pkg/cluster` — and why the wait is placed where it is

The floor `stops >= starts` saw 0 stops against 60 starts on a loaded box: the
cheap teardown goroutine was never scheduled while the expensive start loop ran
to completion.

The wait is deliberately **before** the start loop, and there is exactly one of
them. A per-start handshake would be deterministic and would also establish
happens-before between each teardown and the start it contends — which is
precisely what the race detector looks for the absence of, so the probe would go
quiet against the very bug it exists to catch.

### ⚠ That probe is worse than reported — filed as #7663

Verifying the change had not suppressed detection, by measuring both the old and
new probe against a **reverted** #7257 fix, produced **zero** data races either
way. So the probe never detected the race, and that is pre-existing.

```
#7257 race probe: 60 starts against 39300 stops (655.0 stops/start)
REACH7650 publish-window entered=0 superseded=60
```

`StopHeartbeat` bumps the epoch `StartHeartbeat` re-checks before publishing, so
an unbounded teardown loop supersedes **every** start long before the derefs
that carry the race. `stops >= starts` is satisfied by exactly the condition
that guarantees the vacuity — the floor rewards what breaks the probe.

This PR does **not** fix that; it fixes the load-sensitivity. The test now
carries a loud comment saying so, so a green is not misread as coverage. #7663
carries the real fix.

## `userspace-dp/wg`

A fixed 400 handshake attempts against a thread churning the peer in and out,
then `completed > 0`. Both handshake steps take an `is_err() { continue }`
whenever an attempt lands in a removal window, so a loaded run can spend all 400
there and fire the floor with zero completions — while soundness, the actual
property, was never in question.

Loop until enough handshakes have **completed** instead. The reconciler churns
throughout, so every completion counted is still a contended one. The attempt
cap only stops a genuinely broken engine hanging the suite.

## Gate

Both legs of `make test`, at HEAD `2f1cb5acad80fc64f03cf6cdec5e3bf61a11bc63`,
clean tree, `merge-base --is-ancestor origin/master HEAD` verified:

```
go build ./...                                  rc 0
go test -count=1 ./...                          rc 0   (68 ok, 0 FAIL)
cargo check --benches                           rc 0
cargo test --release --bins --tests
      -- --test-threads=1                       rc 0   (0 FAILED across all binaries)
```

These are test-fixture changes with no production behaviour touched, so no
deploy lane is owed. The `pkg/cluster` one was additionally verified by the
reverted-production measurement above, which is what surfaced #7663.

## Refs

Closes #7650. Refs #7663 (the vacuity this surfaced), #7257, #7662 (instance 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MNWyRNuBeKpjXZHcSBihm
