### PR TITLE
cos: drop the dead `medium` priority arm, keep the rank numbering (#6849)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -106759,3 +106759,7 @@ prose edit above them added. No diff falls in the new test body.
 - **Timestamp**: 2026-08-26
   - **Action**: #6853 — carried the new field through the Rust test literals and the wire specimen; added a both-directions wire-compat test pinning the mixed-version HA claim.
   - **File(s)**: userspace-dp/src/filter/tests.rs, userspace-dp/src/protocol/tests.rs, userspace-dp/tests/fixtures/protocol_wire_v1.json
+
+- **Timestamp**: 2026-08-26
+  - **Action**: #6849 — settled the fork by measurement (no Go producer has ever emitted `medium`; the arm predates T-7 and was carried mechanically), removed the dead arm, kept the rank numbering, and documented why COS_PRIORITY_LEVELS=6 is correct rather than off by one.
+  - **File(s)**: userspace-dp/src/afxdp/forwarding_build/cos.rs, userspace-dp/src/afxdp/forwarding_build/tests.rs, userspace-dp/src/afxdp/types/cos.rs, userspace-dp/src/policy_snapshot_error.rs

--- a/userspace-dp/src/afxdp/forwarding_build/cos.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/cos.rs
@@ -404,12 +404,45 @@ fn cos_surplus_weight(rate_bytes: u64, root_rate_bytes: u64) -> u32 {
 /// non-empty string so the caller can fail the snapshot CLOSED (#hb166
 /// T-7) — mirroring the #2458 equal-flow-policy parse on the same queue
 /// rather than silently ranking an unknown priority lowest ("low").
+///
+/// # Rank 3 is deliberately vacant (#6849)
+///
+/// Junos has no bare `medium` scheduler priority. The five levels are
+/// `strict-high` / `high` / `medium-high` / `medium-low` / `low`, which is
+/// what the Go config schema's `priority` enum accepts and therefore the
+/// only set any committed config can produce (`pkg/config/schema_cos.go`,
+/// `ValidateEnum`).
+///
+/// A `"medium" => Some(3)` arm was here until #6849. It was not a
+/// deliberate tolerance for version drift: it predates the T-7 fail-closed
+/// work, where the original function was a six-level ladder ending in a
+/// catch-all `_ => 5`, and T-7 mechanically rewrote each arm to `Some(n)`
+/// while converting the signature. Checked before removing it: no version
+/// of the Go producer has ever emitted `medium` for this leaf, so the arm
+/// was unreachable from every path that can reach this function.
+///
+/// The remaining ranks KEEP their original numbers rather than closing up
+/// to 0..=4. Renumbering would move `low` from 5 to 4, and a large number
+/// of CoS tests construct queues with a literal `priority: 5` meaning
+/// "low" — they would still compile, still pass (the builder clamps with
+/// `.min(COS_PRIORITY_LEVELS - 1)`), and quietly mean something else. A
+/// vacant slot costs one unused `Vec` per interface; a silent
+/// reinterpretation of every hardcoded rank costs more.
+///
+/// Consequently `COS_PRIORITY_LEVELS` stays 6 and is CORRECT rather than
+/// off by one: it sizes arrays INDEXED BY RANK, and the highest live rank
+/// is still `low` = 5.
+#[cfg(test)]
+pub(in crate::afxdp::forwarding_build) fn cos_priority_rank_for_test(priority: &str) -> Option<u8> {
+    cos_priority_rank(priority)
+}
+
 fn cos_priority_rank(priority: &str) -> Option<u8> {
     match priority {
         "strict-high" => Some(0),
         "high" => Some(1),
         "medium-high" => Some(2),
-        "medium" => Some(3),
+        // rank 3 vacant — see the note above.
         "medium-low" => Some(4),
         "low" => Some(5),
         _ => None,

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -775,6 +775,18 @@ fn build_cos_state_fails_closed_on_unknown_equal_flow_target_policy() {
 
 #[test]
 fn build_cos_state_fails_closed_on_unknown_scheduler_priority() {
+    // #6849 added the `medium` case. `hgh` is an operator typo; `medium` is
+    // the more interesting one, because until #6849 removed its match arm it
+    // resolved to a REAL rank (3) and silently placed the class between
+    // medium-high and medium-low instead of failing. A unit test on
+    // cos_priority_rank alone would not catch that arm coming back: the
+    // caller has to actually consult it, which is what this drives.
+    for bad_priority in ["hgh", "medium"] {
+        build_cos_state_rejects_priority_6849(bad_priority);
+    }
+}
+
+fn build_cos_state_rejects_priority_6849(bad_priority: &str) {
     // #hb166 T-7: a scheduler carrying a NON-EMPTY `priority` string that
     // is not a known Junos scheduler priority fails the snapshot CLOSED
     // (the helper-boundary backstop for a typo / version-drifted snapshot)
@@ -800,7 +812,7 @@ fn build_cos_state_fails_closed_on_unknown_scheduler_priority() {
                 transmit_rate_bytes: 1_000_000_000 / 8,
                 transmit_rate_percent: 0.0,
                 transmit_rate_exact: true,
-                priority: "hgh".into(),
+                priority: bad_priority.into(),
                 buffer_size_bytes: 128 * 1024,
                 buffer_size_percent: 0.0,
                 surplus_sharing: false,
@@ -829,10 +841,13 @@ fn build_cos_state_fails_closed_on_unknown_scheduler_priority() {
             priority,
         }) => {
             assert_eq!(forwarding_class, "fc-bad");
-            assert_eq!(priority, "hgh");
+            assert_eq!(priority, bad_priority);
         }
         Err(other) => panic!("wrong integrity error: {other}"),
-        Ok(_) => panic!("unknown scheduler priority must fail the snapshot closed"),
+        Ok(_) => panic!(
+            "#6849: scheduler priority {bad_priority:?} must fail the snapshot CLOSED, not \
+             resolve to a rank"
+        ),
     }
 }
 
@@ -7305,4 +7320,61 @@ fn interface_snat_identity_registry_survives_apply_6751() {
         ),
         other => panic!("expected a matched interface SNAT decision, got {other:?}"),
     }
+}
+
+/// #6849: `medium` is not a Junos scheduler priority and must fail CLOSED.
+///
+/// The dead `"medium" => Some(3)` arm predated the T-7 fail-closed work —
+/// the original function was a six-level ladder ending in `_ => 5`, and T-7
+/// mechanically rewrote every arm to `Some(n)` while changing the signature,
+/// carrying `medium` along with it. No version of the Go producer has ever
+/// emitted it: the schema's `priority` enum accepts only the five below.
+///
+/// This is a fail-OPEN removal in the sense that matters — with the arm
+/// present, a `medium` string from a typo or a drifting snapshot resolved to
+/// a real rank and silently placed the class between `medium-high` and
+/// `medium-low`, rather than surfacing `CosUnknownSchedulerPriority`.
+#[test]
+fn cos_priority_rank_rejects_medium_and_pins_the_five_real_ranks_6849() {
+    assert_eq!(
+        super::cos::cos_priority_rank_for_test("medium"),
+        None,
+        "#6849: `medium` is not a Junos scheduler priority — it must fail CLOSED so the \
+         caller raises CosUnknownSchedulerPriority, not resolve to a rank between \
+         medium-high and medium-low"
+    );
+
+    // The five REAL priorities, with their ranks pinned to the exact values
+    // they have always had. This is the other half of #6849: the ranks were
+    // deliberately NOT renumbered when rank 3 became vacant, because a large
+    // number of CoS tests construct queues with a literal `priority: 5`
+    // meaning "low" and would silently mean something else. If a later change
+    // closes the gap to 0..=4, this cell reds and points at those literals.
+    for (name, want) in [
+        ("strict-high", 0u8),
+        ("high", 1),
+        ("medium-high", 2),
+        ("medium-low", 4),
+        ("low", 5),
+    ] {
+        assert_eq!(
+            super::cos::cos_priority_rank_for_test(name),
+            Some(want),
+            "#6849: rank of {name:?} must stay {want} — renumbering silently reinterprets \
+             every hardcoded `priority:` literal in the CoS tests"
+        );
+    }
+
+    // Rank 3 is vacant, and COS_PRIORITY_LEVELS is sized for the highest LIVE
+    // rank (low = 5), so six slots is correct rather than off by one. Without
+    // this the constant looks like a stale leftover and an unrelated tidy-up
+    // would shrink it to 5 and truncate `low`.
+    assert!(
+        crate::afxdp::types::COS_PRIORITY_LEVELS
+            > usize::from(
+                super::cos::cos_priority_rank_for_test("low").expect("low is a known priority")
+            ),
+        "#6849: COS_PRIORITY_LEVELS must exceed the highest live rank, or indexing by the \
+         rank of `low` is out of bounds"
+    );
 }

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -1733,6 +1733,16 @@ pub(in crate::afxdp) enum CoSPendingTxItem {
     Prepared(PreparedTxRequest),
 }
 
+/// Size of every per-priority array, INDEXED BY RANK.
+///
+/// Six, not five, and that is correct rather than off by one (#6849).
+/// Junos has five scheduler priorities, but `cos_priority_rank` assigns
+/// them ranks 0, 1, 2, 4, 5 — rank 3 is deliberately vacant since the dead
+/// `medium` arm was removed, and the ranks were not renumbered because a
+/// large number of CoS tests hardcode `priority: 5` meaning "low" and
+/// would silently mean something else. The highest live rank is therefore
+/// still 5, so these arrays need six slots; slot 3 is allocated and never
+/// populated. See `cos_priority_rank` for the full reasoning.
 pub(in crate::afxdp) const COS_PRIORITY_LEVELS: usize = 6;
 
 pub(in crate::afxdp) const COS_TIMER_WHEEL_L0_SLOTS: usize = 256;

--- a/userspace-dp/src/policy_snapshot_error.rs
+++ b/userspace-dp/src/policy_snapshot_error.rs
@@ -608,8 +608,11 @@ pub(crate) enum SnapshotIntegrityError {
     },
     /// #hb166 T-7: a CoS scheduler snapshot carried a NON-EMPTY `priority`
     /// wire string that is not one of the known Junos scheduler priorities
-    /// (`strict-high` / `high` / `medium-high` / `medium` / `medium-low` /
-    /// `low`). The pre-fix `cos_priority_rank` mapped any unrecognized
+    /// (`strict-high` / `high` / `medium-high` / `medium-low` / `low`).
+    /// There are FIVE, not six: this list named a bare `medium` until
+    /// #6849, which Junos does not have and the Go schema's `priority`
+    /// enum has never accepted. The pre-fix `cos_priority_rank` mapped any
+    /// unrecognized
     /// string to rank 5 (`low`, the strict-priority FLOOR) via a catch-all
     /// match arm — so a typo or a mixed-version snapshot silently demoted a
     /// class to lowest priority with no failure surfaced. Fail-closed here,


### PR DESCRIPTION
Closes #6849

The issue explicitly asked for a decision recorded in the code rather than a cleanup that quietly picks a reading. **Reading 1 wins — the arm is dead, not a deliberate tolerance — and it was settled by measurement.**

## Why reading 1

| evidence | result |
|---|---|
| Go schema `priority` enum | accepts only `low / medium-low / medium-high / high / strict-high` — no committed config can produce `medium` |
| `git log -S'"medium"'` over the CoS schema (checked for renames too) | **never present** |
| the three Go commits that do carry `"medium"` | router-advertisement preference (`low/medium/high`) — a different leaf |
| when the Rust arm appeared | it **predates** the fail-closed work. Pre-T-7 the function was a six-level ladder ending in `_ => 5`; T-7 mechanically rewrote each arm to `Some(n)` while changing the signature and carried `medium` along. Nothing chose to keep it. |

So `medium` now fails **closed** via `CosUnknownSchedulerPriority`. Until now it resolved to a real rank and silently placed the class between `medium-high` and `medium-low`.

## The ranks are deliberately NOT renumbered — and I measured this rather than asserting it

Closing the gap to `0..=4` is tidier but moves `low` from 5 to 4. I ran that mutation to see what it actually does:

- it **reds two** `forwarding_build` tests that assert ranks through `build_cos_state` — so it is **not** silent everywhere, and I do not want to overstate the case;
- but it leaves **91 `queue_service` / `queue_ops` tests green**, including the dozen that construct queues with a literal `priority: 5` meaning "low". Those keep passing while `5` no longer corresponds to any priority at all, because the builder clamps with `.min(COS_PRIORITY_LEVELS - 1)`.

A vacant slot costs one unused `Vec` per interface. A dozen tests still passing while asserting something they no longer mean costs more, and **that half is silent**. Rank 3 is left vacant and documented at both sites.

## This answers the constant question the issue raised

`COS_PRIORITY_LEVELS = 6` is **correct, not off by one**. It sizes arrays indexed *by rank*, and the highest live rank is still `low` = 5. It now carries a doc comment saying so — a bare `6` sitting next to five priorities reads like a stale leftover and invites exactly the shrink that would truncate `low`.

## Mutation matrix — full suite, `--test-threads=1`, fix committed BEFORE mutating

| cell | mutation | verdict | names |
|---|---|---|---|
| Z1 | restore the dead `medium` arm | **RED** | the unit cell **and** the end-to-end `build_cos_state` test |
| Z2 | renumber ranks to close the gap | **RED** | the rank-pinning cell (plus the two forwarding_build tests noted above) |

Z1 reddening *both* is the point: a unit test on `cos_priority_rank` alone would not notice the arm returning if the caller stopped consulting it, so the existing end-to-end fail-closed test was made table-driven and now drives `medium` through `build_cos_state` alongside the `hgh` typo case.

## Two shipped doc comments were inaccurate

Both corrected: the rank function's, and `CosUnknownSchedulerPriority`'s, which listed `medium` among "the known Junos scheduler priorities".

**No operator documentation changed**, and that is deliberate rather than an omission: no doc under `docs/` enumerates the scheduler priority set or mentions ranks, so nothing there was wrong. Both inaccurate statements were Rust doc comments.

## Out of scope

Gap 6b (unbounded `strict-high` semantics) is untouched, as the issue states — whether rank 0 should bypass its transmit-rate cap is a scheduler design question, not a rename.

## Validation

- `cargo test -- --test-threads=1` — **rc=0, 4622 passed, 0 failed**
- `go test ./... -count=1` — **rc=0, 68 packages, 0 FAIL**
- rustfmt drift unchanged in all four touched files (4→4, 14→14, 0→0, 20→20); no crate-wide fmt
