### PR TITLE
config: validate and compile the security-log transport packed tail (#6821)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,47 @@
+## 2026-08-27 — #6821: security-log transport packed tail, gate and compiler together
+
+- **Timestamp**: 2026-08-27
+- **Action**: `security log stream <s> transport` has two legal hierarchical
+  spellings and the compiler read only one. `transport protocol tls;` packs its
+  value onto the container's own `Keys` with NO children, so the
+  `prop.Children` loop ran zero times and left `Transport.Protocol` empty on a
+  config that committed cleanly. Not inert: `daemon_system.go` defaults an empty
+  protocol to `udp`, so the compact spelling of a TLS audit stream shipped over
+  PLAINTEXT UDP while the config on disk still read `protocol tls`. That answers
+  the question the issue left open, and it is the worst of the possibilities it
+  listed.
+  The issue prescribed "accumulate `Keys[1:]`", and that alone would have been
+  wrong — the arm carried a comment saying so, and measuring confirmed it: the
+  gate ignores a container's packed tail BY DESIGN (compiler-faithful), so
+  `transport { protocol tpc; }` was rejected by the enum while
+  `transport protocol tpc;` was ACCEPTED. Compiling the tail without the gate
+  turns "not compiled" into "compiled, unvalidated". Added `schemaNode.packedTail`
+  as the explicit pairing: it declares that a compiler reads this container's
+  packed tail, and `walkSchemaNode` then validates the same `packedBodyChildren`
+  expansion the compiler consumes. Three readers, one expansion, resolved through
+  `securityLogTransportSchema()` so a schema move cannot silently hand back the
+  unexpanded children and restore the defect.
+  The `tls-profile` half fails the other way and the issue framed both the same:
+  xpf resolves no TLS profile at all, so the BLOCK spelling is REJECTED at commit
+  (#3350). The compact spelling slipped past that rejection AND dropped the
+  value — a lost diagnostic, not lost protection.
+  The #2419 census tripwire fired, which is it working: the two leaves were
+  recorded as by-design divergent BECAUSE of the packed-tail blocker. They moved
+  to `filedFixed` rather than being deleted so the sites stay checked in both
+  directions, and the `filedByDesign` floor dropped 6 -> 4 with the reason at the
+  assertion.
+- **File(s)**: `pkg/config/schema.go`, `pkg/config/schema_security.go`,
+  `pkg/config/schema_walk.go`, `pkg/config/compiler_security_log.go`,
+  `pkg/config/security_log_transport_compact_6821_test.go` (new),
+  `pkg/config/compact_block_equivalence_2419_test.go`,
+  `pkg/config/testdata/compact_block_divergences_2419.txt`,
+  `docs/config-schema.md`
+- **Validation**: `go build ./...` + `go test -count=1 ./...` repo-wide, rc 0
+  (68 ok, 0 FAIL). 5-cell mutation matrix, 5/5 RED, full package, no `-run`
+  filter, fix committed before mutating. One cell initially reported ANCHOR x2
+  (both readers share the same call prefix) and was re-anchored — a cell that
+  cannot locate its line measures nothing.
+
 ## 2026-08-26 — #7609: one var now relocates the whole sshd drop-in
 
 - **Timestamp**: 2026-08-26

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -50,20 +50,44 @@ Returning the two as SIBLINGS is wrong in the silent direction: OSPF compiled
 `AuthType=md5` with an **empty key**. They spell one path, so the nested block is
 now attached UNDER the deepest packed node.
 
-**#6821 is deliberately NOT fixed here, and the reason generalises.** The strict
+**#6821 is now fixed, and the rule that blocked it is what fixed it.** The strict
 gate ignores leftover `Keys` on a container by design — compiler-faithful, since
 the compiler did not read them either. That equivalence breaks the moment a
-compiler starts reading them. Today `transport { protocol tpc; }` is rejected by
-the enum and `transport protocol tpc;` is **accepted**; compiling the compact
-form without teaching the gate to validate it turns "not compiled" into
-"compiled, unvalidated", and the daemon then silently omits the stream. For
-`tls-profile` it is worse: the block spelling is rejected at commit (#3350, no
-profile resolution exists) and the compact one would walk straight past that.
+compiler starts reading them, and measured on master before the fix it had:
+`transport { protocol tpc; }` was rejected by the enum while
+`transport protocol tpc;` was **accepted**.
 
-So the rule is: **a compiler may only start reading a packed tail at a site
+So the rule stands: **a compiler may only start reading a packed tail at a site
 where the gate validates the same expansion.** #6818's leaves have no enum to
 bypass (a bogus child is inert in both spellings today), which is why that one
-lands and #6821 does not.
+landed first.
+
+`schemaNode.packedTail` is how a site satisfies the rule instead of waiting for
+it. Setting it says *"a compiler reads this container's packed tail"*, and
+`walkSchemaNode` then validates the same `packedBodyChildren` expansion the
+compiler consumes — one schema fact rather than two files agreeing by comment.
+Default-off is deliberate: for every other container the tail is not compiled,
+so validating it would reject a configuration that behaves identically either
+way.
+
+`security log stream <s> transport` sets it, and all three readers now share one
+expansion resolved by `securityLogTransportSchema()`:
+
+| spelling | gate | compile |
+|---|---|---|
+| `transport { protocol tls; }` | accept | `Protocol="tls"` |
+| `transport protocol tls;` | accept | `Protocol="tls"` (was `""`) |
+| `transport { protocol tpc; }` | **reject** (enum) | — |
+| `transport protocol tpc;` | **reject** (enum) (was accept) | — |
+| `transport { tls-profile p; }` | accept | **reject** (#3350) |
+| `transport tls-profile p;` | accept | **reject** (#3350) (was accept-and-drop) |
+
+The empty-`Protocol` consequence is worth stating plainly because it is not
+inert: `daemon_system.go` defaults an empty protocol to `udp`, so the compact
+spelling of a TLS audit stream shipped over **plaintext UDP** while the config
+on disk still read `protocol tls`. The `tls-profile` half fails the other way —
+xpf resolves no TLS profile at all, so the block spelling is *rejected* at
+commit; the compact one lost that diagnostic as well as the value.
 
 #6822 is the one that does not use `packedBodyChildren`: its protocol comes from
 the reader's `case` label rather than from a value, so the reader needs the whole
@@ -78,8 +102,8 @@ path it warns and leaves the stanza inert so a peer-synced config behaves exactl
 as the binary that accepted it behaved (#1960). Compiling it there would change
 RBAC across an HA sync between nodes on different binaries. The #2419 inventory
 records this in a `filedByDesign` category so the entry is not mistaken for one
-awaiting a fix. #6821's two leaves sit in the same category with their own
-reason: filed and real, blocked on packed-tail validation.
+awaiting a fix. #6821's two leaves USED to sit in the same category; they moved
+to `filedFixed` once `packedTail` removed their blocker.
 
 A group applying a stanza in the compact spelling over an existing same-name
 peer drops the group's value (#7648). That is a property of the group merge
@@ -4389,8 +4413,10 @@ while adding a `host` sibling makes the value land. Recovering these means
 teaching the harness a per-parent prerequisite, which is why it is tracked
 separately rather than bundled here.
 
-**The #2419 cohort does NOT share this cause.** Measured against the eight open
-issues: only #6821 sits in the blind spot. `#6736`, `#6817`, `#6953`, `#6966`
+**The #2419 cohort does NOT share this cause.** Measured against the eight issues
+open at the time: only #6821 sat in the blind spot (it is fixed now — see the
+`packedTail` section above — but the measurement below is what it was when
+taken, and the blind spot itself is unchanged). `#6736`, `#6817`, `#6953`, `#6966`
 and `#7033` all have leaves the differential compares today, so their defects
 escaped for some other reason and closing them as one cohort would be wrong.
 

--- a/pkg/config/compact_block_equivalence_2419_test.go
+++ b/pkg/config/compact_block_equivalence_2419_test.go
@@ -197,6 +197,14 @@ const inventoryPath = "testdata/compact_block_divergences_2419.txt"
 var filedFixed = map[string]string{
 	"protocols ospf area xpfarg interface xpfarg authentication simple-password":         "#6818",
 	"snmp v3 usm local-engine user xpfarg authentication-sha256 authentication-password": "#6822",
+	// #6821 moved here from filedByDesign rather than being deleted. Its
+	// blocker -- the gate not validating a container's packed tail -- was
+	// removed by the `packedTail` opt-in, so the divergence is fixed rather
+	// than deliberate. Deleting the lines instead would stop the site being
+	// checked in EITHER direction, which is the stale-allowlist failure this
+	// file exists to prevent.
+	"security log stream xpfarg transport protocol":    "#6821",
+	"security log stream xpfarg transport tls-profile": "#6821",
 }
 
 // filedByDesign is the category the inventory did not previously distinguish:
@@ -219,15 +227,14 @@ var filedFixed = map[string]string{
 // longer exists: it is neither silent (commit names it, load warns) nor
 // accidental.
 var filedByDesign = map[string]string{
-	// #6821 is filed and REAL, but compiling the compact spelling is blocked on
-	// the strict gate learning to validate a container's packed tail. Today the
-	// block spelling `transport { protocol tpc; }` is rejected by the enum and
-	// the compact `transport protocol tpc;` is accepted, so compiling the
-	// compact form would turn "not compiled" into "compiled, unvalidated" --
-	// and for `tls-profile` it would walk past the deliberate #3350 commit
-	// rejection into a stream that silently ignores the named profile.
-	"security log stream xpfarg transport protocol":    "#6821 -> blocked on packed-tail validation",
-	"security log stream xpfarg transport tls-profile": "#6821 -> blocked on packed-tail validation",
+	// #6821's two transport leaves USED to sit here, blocked on the strict gate
+	// learning to validate a container's packed tail. That blocker is gone: the
+	// schema node now sets `packedTail: true`, walkSchemaNode validates the same
+	// expansion `packedBodyChildren` hands the compiler, and the #3350
+	// tls-profile check reads it too -- so the compact spelling is validated,
+	// compiled and rejected exactly as the block spelling is. This tripwire
+	// firing is what said the decision had been reversed; see
+	// security_log_transport_compact_6821_test.go.
 
 	"system login user xpfarg authentication encrypted-password": "#6817 -> resolved by #6662",
 	"system login user xpfarg authentication ssh-ed25519":        "#6817 -> resolved by #6662",
@@ -403,7 +410,7 @@ func TestCompactBlockEquivalenceInventory2419(t *testing.T) {
 	// adding an anchor never needs a second edit here -- but draining one out
 	// does.
 	if len(filedFixed) < 2 {
-		t.Errorf("filedFixed holds %d anchors, want at least 2 (#6818, #6822). "+
+		t.Errorf("filedFixed holds %d anchors, want at least 2 (#6818, #6822, #6821). "+
 			"An entry was removed, and the site it named is no longer checked in "+
 			"either direction.", len(filedFixed))
 	}
@@ -412,12 +419,17 @@ func TestCompactBlockEquivalenceInventory2419(t *testing.T) {
 			"compiler files. With fewer, a fault confined to one file can silence "+
 			"the whole known-true half of the control.", len(filedStillOpen))
 	}
-	if len(filedByDesign) < 6 {
-		t.Errorf("filedByDesign holds %d entries, want at least 6 (four `system login "+
-			"user ... authentication` leaves plus the two #6821 transport leaves). "+
-			"A dropped entry turns a deliberate "+
-			"divergence back into an ordinary inventory line, which is exactly the "+
-			"confusion this category exists to prevent.", len(filedByDesign))
+	if len(filedByDesign) < 4 {
+		t.Errorf("filedByDesign holds %d entries, want at least 4 (the four `system "+
+			"login user ... authentication` leaves). A dropped entry turns a "+
+			"deliberate divergence back into an ordinary inventory line, which is "+
+			"exactly the confusion this category exists to prevent.\n"+
+			"The floor was 6 until #6821: its two transport leaves were by-design "+
+			"divergent only because the gate could not validate a container's "+
+			"packed tail. `packedTail` removed that blocker, so they MOVED to "+
+			"filedFixed -- a count that falls because a population shrank is the "+
+			"fix working, and carrying the old number forward would demand entries "+
+			"that should no longer exist.", len(filedByDesign))
 	}
 
 	// Positive control, both directions.

--- a/pkg/config/compiler_security_log.go
+++ b/pkg/config/compiler_security_log.go
@@ -16,6 +16,38 @@ import (
 // syslog dial and silently lose audit records (#5250 A3-b2 F2).
 func validSyslogPort(n int) bool { return n >= 1 && n <= 65535 }
 
+// securityLogTransportSchema resolves the schema node for
+// `security log stream <s> transport` (#6821).
+//
+// Both readers of that container's packed tail — compileLog and the #3350
+// tls-profile strict check — expand it through `packedBodyChildren` with THIS
+// node, and `walkSchemaNode` validates the same expansion because the node sets
+// `packedTail: true`. Resolving it in one place is what stops the three from
+// drifting: a schema move that broke the lookup would make the expansion
+// silently return the unexpanded children again, which is the original defect.
+// TestSecurityLogTransportSchemaResolves6821 fails loudly if the path moves.
+func securityLogTransportSchema() *schemaNode {
+	n := setSchema
+	for _, k := range []string{"security", "log", "stream"} {
+		if n == nil {
+			return nil
+		}
+		n = n.children[k]
+	}
+	if n == nil {
+		return nil
+	}
+	// `stream` is a named instance: its per-instance body hangs off the
+	// wildcard when one is declared, otherwise off the node itself.
+	if n.wildcard != nil {
+		n = n.wildcard
+	}
+	if n == nil {
+		return nil
+	}
+	return n.children["transport"]
+}
+
 func compileLog(node *Node, sec *SecurityConfig) error {
 	if sec.Log.Streams == nil {
 		sec.Log.Streams = make(map[string]*SyslogStream)
@@ -80,26 +112,22 @@ func compileLog(node *Node, sec *SecurityConfig) error {
 			case "source-address":
 				stream.SourceAddress = nodeVal(prop)
 			case "transport":
-				// Children-only, deliberately, unlike the #6818 sibling.
+				// #6821: read BOTH spellings. `transport { protocol tls; }`
+				// arrives as children; `transport protocol tls;` packs the
+				// value onto this node's own Keys with NO children, so a
+				// Children-only loop ran zero times and left Protocol and
+				// TLSProfile empty on a config that committed cleanly.
 				//
-				// #6821 asks for the compact `transport protocol tls;` spelling
-				// to compile. It must NOT until the strict gate validates a
-				// container's packed tail, because today it does not: the block
-				// spelling `transport { protocol tpc; }` is rejected by the
-				// enum, and the compact `transport protocol tpc;` is ACCEPTED
-				// -- the walker ignores leftover Keys on a container by design
-				// (compiler-faithful: the compiler did not read them either).
-				// Compiling them here without teaching the gate to validate
-				// them turns "not compiled" into "compiled, unvalidated", and
-				// the daemon then silently omits the stream. For a compact
-				// `tls-profile` it is worse: the block spelling is REJECTED at
-				// commit (#3350, no profile resolution exists), and compiling
-				// the compact one walks straight past that rejection into a
-				// stream that ignores the named profile.
-				//
-				// The gate and the compiler have to move together here. Tracked
-				// separately; see the #6821 note in docs/config-schema.md.
-				for _, tc := range prop.Children {
+				// This arm used to be Children-only DELIBERATELY, because
+				// compiling a packed tail the gate does not validate turns
+				// "not compiled" into "compiled, unvalidated" — measured:
+				// `transport { protocol tpc; }` was rejected by the enum while
+				// `transport protocol tpc;` was ACCEPTED. That is why the
+				// schema's `transport` node now sets `packedTail: true`, which
+				// makes the walker validate this same expansion. The gate and
+				// the compiler move together, which is the rule
+				// docs/config-schema.md states; neither half is correct alone.
+				for _, tc := range packedBodyChildren(prop, securityLogTransportSchema()) {
 					switch tc.Name() {
 					case "protocol":
 						stream.Transport.Protocol = nodeVal(tc)
@@ -267,7 +295,13 @@ func validateSecurityLogStreamTLSProfileAST(nodes []*Node, prefix string, lenien
 					if prop.Name() != "transport" {
 						continue
 					}
-					for _, tc := range prop.Children {
+					// #6821: the SAME expansion the compiler reads. This check
+					// was Children-only too, so `transport tls-profile X;`
+					// slipped past the rejection that `transport { tls-profile
+					// X; }` gets — and then the compiler dropped the value, so
+					// the operator got neither the profile nor the error saying
+					// it is unimplemented.
+					for _, tc := range packedBodyChildren(prop, securityLogTransportSchema()) {
 						if tc.Name() != "tls-profile" {
 							continue
 						}

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -47,6 +47,30 @@ type schemaNode struct {
 	// sets it; every other multi+children node is unchanged.
 	valueList bool
 
+	// packedTail opts a CONTAINER into having its packed tail VALIDATED
+	// (#6821).
+	//
+	// The gate's default for a container is to IGNORE tokens packed past the
+	// identity, and that default is not laziness — it is a compiler-faithful
+	// contract (see the long note in schema_walk.go). The gate must not
+	// validate what no compiler reads, or a stray token becomes a commit
+	// error for a configuration that behaves identically with or without it.
+	//
+	// The contract is BIDIRECTIONAL, and that is the half #6821 turns on: the
+	// moment a compiler DOES read a container's packed tail, ignoring it here
+	// turns "not compiled" into "compiled, UNVALIDATED". Measured on
+	// `security log stream <s> transport` before this flag existed:
+	//
+	//	transport { protocol tpc; }   gate REJECTS (enum)
+	//	transport protocol tpc;       gate ACCEPTS  <- the hole
+	//
+	// So this flag is the explicit pairing. Setting it says "a compiler reads
+	// this container's packed tail", and the walker then validates the same
+	// expansion `packedBodyChildren` hands that compiler — one schema fact
+	// instead of two files agreeing by comment.
+	// TestPackedTailContainersValidateBothSpellings6821 holds the pairing.
+	packedTail bool
+
 	// blockValue opts a single-value typed leaf into the HIERARCHICAL BLOCK
 	// spelling `keyword { value; }`, in addition to the ordinary
 	// `keyword value` (#6774).

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -747,7 +747,11 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 			// mirrors the runtime switch (tcp/tls handled, everything else
 			// silently falls back to UDP), so a typo like `protocol tpc`
 			// committed and then quietly used UDP. Validate it.
-			"transport": {desc: "Stream transport (protocol + optional TLS profile)", children: map[string]*schemaNode{
+			// #6821: packedTail — the compiler reads this container's packed
+			// tail (`transport protocol tls;`), so the gate must validate the
+			// same expansion. Without the pairing the compact spelling of a
+			// bogus `protocol` slipped past the enum below.
+			"transport": {desc: "Stream transport (protocol + optional TLS profile)", packedTail: true, children: map[string]*schemaNode{
 				"protocol": {desc: "Transport protocol (udp|tcp|tls)", args: 1, placeholder: "<protocol>",
 					valueType: ValueEnumOf, valueDesc: "syslog transport protocol",
 					valueExamples: []string{"udp", "tcp", "tls"},

--- a/pkg/config/schema_walk.go
+++ b/pkg/config/schema_walk.go
@@ -607,7 +607,19 @@ func walkSchemaNode(node *Node, parent *schemaNode, path []string, vc *walkConte
 		return nil
 	}
 
-	return walkSchemaChildren(node.Children, descendSchema, newPath, vc, childClosed)
+	// #6821: a container that OPTS IN to packedTail has its packed tail
+	// validated, because a compiler reads it. The expansion is the SAME one
+	// `packedBodyChildren` hands that compiler, so the gate and the compiler
+	// cannot disagree about what the tokens mean.
+	//
+	// Default-off is deliberate and is the compiler-faithful contract above:
+	// for every other container the tail is not compiled, so validating it
+	// would reject a configuration that behaves identically either way.
+	walkChildren := node.Children
+	if childSchema.packedTail && len(node.Keys) > consumed {
+		walkChildren = packedBodyChildren(node, childSchema)
+	}
+	return walkSchemaChildren(walkChildren, descendSchema, newPath, vc, childClosed)
 }
 
 // walkInstanceChildren peels the missing instance-name level(s) off a

--- a/pkg/config/security_log_transport_compact_6821_test.go
+++ b/pkg/config/security_log_transport_compact_6821_test.go
@@ -1,0 +1,290 @@
+package config
+
+// security_log_transport_compact_6821_test.go — #6821.
+//
+// `security log stream <s> transport` has two legal hierarchical spellings, and
+// the compiler read only one of them:
+//
+//	transport { protocol tls; }   Keys=[transport]            children=2
+//	transport protocol tls;       Keys=[transport protocol tls] children=0
+//
+// The second packs its value onto the container's own Keys, so a
+// `prop.Children` loop ran ZERO times and left `Transport.Protocol` empty on a
+// config that committed cleanly. `daemon_system.go` defaults an empty protocol
+// to "udp", so the compact spelling of a TLS audit stream shipped over
+// PLAINTEXT UDP.
+//
+// The fix could not be "read Keys[1:] too" on its own, and that is the part
+// worth keeping straight. The gate ignores a container's packed tail BY DESIGN
+// — compiler-faithful, since no compiler read it — so compiling the tail
+// without teaching the gate turns "not compiled" into "compiled, UNVALIDATED".
+// Measured on master before the fix: `transport { protocol tpc; }` was rejected
+// by the enum while `transport protocol tpc;` was ACCEPTED. So the schema node
+// now sets `packedTail: true`, the walker validates the same expansion
+// `packedBodyChildren` hands the compiler, and the #3350 tls-profile check reads
+// it too. Three readers, one expansion.
+
+import (
+	"strings"
+	"testing"
+)
+
+// streamCfg6821 wraps a transport body in a complete security-log stream. The
+// `host` line is required: without it the stream is not installed at all and
+// every assertion below would be vacuous.
+func streamCfg6821(transportBody string) string {
+	return "security { log { stream audit { host 192.0.2.10; " + transportBody + " } } }"
+}
+
+// parseCfg6821 parses ONE braced configuration with NewParser.
+//
+// This is deliberate, and it is the corrected instrument from the issue thread.
+// The CLAUDE.md rule "never NewParser, use ParseSetCommand + SetPath" is about
+// feeding the parser MULTIPLE `set` lines, which it merges into one node.
+// Parsing a single braced config is the parser's ordinary job and is the ONLY
+// way to produce the compact-hierarchical shape under test — the flat-set path
+// lands `protocol` as a child, i.e. the block shape, so it cannot exercise the
+// defect at all.
+func parseCfg6821(t *testing.T, body string) *ConfigTree {
+	t.Helper()
+	tree, err := NewParser(streamCfg6821(body)).Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return tree
+}
+
+// transportNode6821 returns the `transport` node so a test can assert the SHAPE
+// it is actually exercising.
+func transportNode6821(t *testing.T, tree *ConfigTree) *Node {
+	t.Helper()
+	var found *Node
+	var walk func(n *Node)
+	walk = func(n *Node) {
+		if n == nil || found != nil {
+			return
+		}
+		if len(n.Keys) > 0 && n.Keys[0] == "transport" {
+			found = n
+			return
+		}
+		for _, c := range n.Children {
+			walk(c)
+		}
+	}
+	for _, top := range tree.Children {
+		walk(top)
+	}
+	if found == nil {
+		t.Fatal("no `transport` node in the parsed tree")
+	}
+	return found
+}
+
+// TestCompactAndBlockTransportAreDifferentShapes6821 is the PREMISE guard, and
+// it exists because of the trap #6853 hit: two spellings that were supposed to
+// exercise different arms landed on the SAME one, so a cell labelled "leaf
+// form" never touched the leaf arm.
+//
+// Assert the shapes are genuinely different before any behavioural cell below
+// is allowed to mean anything. If the parser ever normalises one into the
+// other, every other test in this file becomes a duplicate of its neighbour and
+// this says so instead of passing quietly.
+func TestCompactAndBlockTransportAreDifferentShapes6821(t *testing.T) {
+	block := transportNode6821(t, parseCfg6821(t, "transport { protocol tls; }"))
+	if len(block.Keys) != 1 || len(block.Children) != 2-1 {
+		// block form: Keys == ["transport"], value carried by a CHILD.
+		if len(block.Keys) != 1 {
+			t.Errorf("block: Keys = %v, want exactly [transport]", block.Keys)
+		}
+	}
+	if len(block.Children) == 0 {
+		t.Fatalf("block: expected the value as a CHILD, got Keys=%v children=0", block.Keys)
+	}
+
+	compact := transportNode6821(t, parseCfg6821(t, "transport protocol tls;"))
+	if len(compact.Keys) != 3 {
+		t.Fatalf("compact: Keys = %v, want [transport protocol tls] — if the parser "+
+			"now normalises this into the block shape, every cell in this file "+
+			"exercises one arm twice and none of them covers the packed tail (#6821)",
+			compact.Keys)
+	}
+	if len(compact.Children) != 0 {
+		t.Fatalf("compact: children = %d, want 0 — the whole defect is that a "+
+			"Children-only loop sees NOTHING here", len(compact.Children))
+	}
+}
+
+// TestCompactTransportProtocolCompiles6821 is the headline cell.
+//
+// An empty Protocol is the FAILURE default of this path and
+// `daemon_system.go` turns it into "udp", so asserting `""` would constrain
+// nothing and asserting "not empty" would pass on garbage. Assert the populated
+// value, and assert the two spellings agree.
+func TestCompactTransportProtocolCompiles6821(t *testing.T) {
+	for _, tc := range []struct{ name, body string }{
+		{"block", "transport { protocol tls; }"},
+		{"compact", "transport protocol tls;"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := CompileConfig(parseCfg6821(t, tc.body))
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			s := cfg.Security.Log.Streams["audit"]
+			if s == nil {
+				t.Fatal("premise: the stream must be installed, or nothing below means anything")
+			}
+			if s.Transport.Protocol != "tls" {
+				t.Fatalf("Transport.Protocol = %q, want \"tls\". An empty value is not "+
+					"inert: daemon_system.go defaults it to \"udp\", so the compact "+
+					"spelling of a TLS audit stream shipped over PLAINTEXT UDP while "+
+					"the config on disk still read `protocol tls` (#6821)",
+					s.Transport.Protocol)
+			}
+		})
+	}
+}
+
+// TestCompactTransportBogusProtocolIsRejected6821 is the half that makes the
+// fix safe rather than merely effective.
+//
+// Compiling a packed tail the gate does not validate turns "not compiled" into
+// "compiled, unvalidated". Before #6821 the block spelling of a bogus protocol
+// was rejected by the enum and the compact spelling was ACCEPTED — so reading
+// Keys[1:] in the compiler alone would have let `protocol tpc` through as a
+// compiled value. Both spellings must now be rejected by the same gate.
+func TestCompactTransportBogusProtocolIsRejected6821(t *testing.T) {
+	for _, tc := range []struct{ name, body string }{
+		{"block", "transport { protocol tpc; }"},
+		{"compact", "transport protocol tpc;"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := SchemaValidate(parseCfg6821(t, tc.body), nil)
+			if err == nil {
+				t.Fatalf("SchemaValidate accepted `%s`. A container's packed tail is "+
+					"ignored by the gate BY DESIGN (compiler-faithful), so a site "+
+					"whose compiler reads the tail must opt in via `packedTail` — "+
+					"otherwise the compact spelling compiles an unvalidated value "+
+					"the block spelling rejects (#6821)", tc.body)
+			}
+			if !strings.Contains(err.Error(), "tpc") {
+				t.Fatalf("reject must name the offending token, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestCompactTransportTLSProfileIsRejected6821 covers the second leaf, and its
+// consequence is the opposite of the protocol leaf's — worth stating because
+// the issue framed both the same way.
+//
+// xpf implements NO TLS profile resolution, so the BLOCK spelling is rejected
+// at commit by #3350 with a message telling the operator exactly that. The
+// compact spelling slipped past that rejection AND had its value dropped, so
+// the operator got neither the profile nor the diagnostic. The defect here is a
+// LOST DIAGNOSTIC, not lost protection — there was never any protection to lose.
+func TestCompactTransportTLSProfileIsRejected6821(t *testing.T) {
+	for _, tc := range []struct{ name, body string }{
+		{"block", "transport { protocol tls; tls-profile secure-logs; }"},
+		{"compact", "transport tls-profile secure-logs;"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := CompileConfig(parseCfg6821(t, tc.body))
+			if err == nil {
+				t.Fatalf("compile accepted `%s` — the #3350 reject is the only thing "+
+					"telling an operator that a named tls-profile is not resolved at "+
+					"runtime. Accepting the compact spelling loses that diagnostic "+
+					"AND drops the value (#6821)", tc.body)
+			}
+			if !strings.Contains(err.Error(), "secure-logs") ||
+				!strings.Contains(err.Error(), "not applied at runtime") {
+				t.Fatalf("reject must be the #3350 tls-profile message naming the "+
+					"profile, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestSecurityLogTransportSchemaResolves6821 guards the shared lookup.
+//
+// Three readers expand this container through `packedBodyChildren` with the
+// node this returns. A schema reshuffle that broke the lookup would return nil,
+// `packedBodyChildren` would hand back the unexpanded children, and all three
+// would silently revert to the ORIGINAL defect with every behavioural cell
+// above still green — because they would all fail together only in the compact
+// arm, which is exactly the arm a nil lookup makes invisible.
+func TestSecurityLogTransportSchemaResolves6821(t *testing.T) {
+	n := securityLogTransportSchema()
+	if n == nil {
+		t.Fatal("securityLogTransportSchema() = nil — the schema path moved. The " +
+			"compiler and the #3350 check both expand the packed tail with this " +
+			"node; nil silently restores the pre-#6821 Children-only behaviour")
+	}
+	if !n.packedTail {
+		t.Error("the transport schema node must set packedTail: the compiler reads " +
+			"its packed tail, so the gate has to validate the same expansion")
+	}
+	for _, want := range []string{"protocol", "tls-profile"} {
+		if n.children[want] == nil {
+			t.Errorf("transport schema is missing child %q — the expansion cannot "+
+				"resolve a leaf the compiler switches on", want)
+		}
+	}
+}
+
+// TestPackedTailContainersValidateBothSpellings6821 is the general invariant,
+// and it is what keeps `packedTail` from becoming a one-off.
+//
+// The flag is a CLAIM: "a compiler reads this container's packed tail, so the
+// gate validates it". The property that claim buys is that the two spellings
+// agree at the gate. Assert it directly for every opted-in container reachable
+// with a concrete fixture, so a future opt-in that forgets the walker change —
+// or a walker change that stops honouring the flag — reds here rather than in
+// whichever stanza happens to be exercised next.
+func TestPackedTailContainersValidateBothSpellings6821(t *testing.T) {
+	// One fixture per opted-in container. Kept explicit rather than generated:
+	// a synthesized value that both spellings reject for an unrelated reason
+	// would make the cell equal and vacuous, which is the failure mode this
+	// whole issue is about.
+	cases := []struct {
+		node           string
+		blockBody      string
+		compactBody    string
+		mustBeRejected bool
+	}{
+		{
+			node:           "security log stream <s> transport",
+			blockBody:      "transport { protocol tpc; }",
+			compactBody:    "transport protocol tpc;",
+			mustBeRejected: true,
+		},
+		{
+			node:           "security log stream <s> transport",
+			blockBody:      "transport { protocol tls; }",
+			compactBody:    "transport protocol tls;",
+			mustBeRejected: false,
+		},
+	}
+	for _, c := range cases {
+		blockErr := SchemaValidate(parseCfg6821(t, c.blockBody), nil)
+		compactErr := SchemaValidate(parseCfg6821(t, c.compactBody), nil)
+		if (blockErr != nil) != (compactErr != nil) {
+			t.Errorf("%s: the two spellings DISAGREE at the gate.\n  block   %q -> %v\n"+
+				"  compact %q -> %v\nA packedTail container must validate its tail the "+
+				"same way it validates the equivalent children, or one spelling "+
+				"compiles an unvalidated value (#6821)",
+				c.node, c.blockBody, blockErr, c.compactBody, compactErr)
+			continue
+		}
+		if c.mustBeRejected && blockErr == nil {
+			t.Errorf("%s: premise broken — %q was supposed to be REJECTED by the gate, "+
+				"but both spellings were accepted, so this row proves only that two "+
+				"accepted configs are both accepted", c.node, c.blockBody)
+		}
+		if !c.mustBeRejected && blockErr != nil {
+			t.Errorf("%s: premise broken — %q was supposed to be ACCEPTED, got %v",
+				c.node, c.blockBody, blockErr)
+		}
+	}
+}

--- a/pkg/config/testdata/compact_block_divergences_2419.txt
+++ b/pkg/config/testdata/compact_block_divergences_2419.txt
@@ -263,8 +263,6 @@ security log mode
 security log profile xpfarg stream-name
 security log source-interface
 security log stream xpfarg host
-security log stream xpfarg transport protocol
-security log stream xpfarg transport tls-profile
 security nat destination pool
 security nat destination rule-set xpfarg rule xpfarg match application
 security nat destination rule-set xpfarg rule xpfarg match destination-address


### PR DESCRIPTION
Closes #6821

## The defect, and what measuring it added

`security log stream <s> transport` has two legal hierarchical spellings. The
compiler read one:

| spelling | parsed shape |
|---|---|
| `transport { protocol tls; }` | `Keys=[transport]`, children=2 |
| `transport protocol tls;` | `Keys=[transport protocol tls]`, **children=0** |

The compact form packs its value onto the container's own `Keys`, so the
`prop.Children` loop ran **zero times** and left `Transport.Protocol` empty on a
config that committed cleanly.

**The issue left open what an empty `Protocol` resolves to. It is the worst of
the options it listed** — `daemon_system.go:113`:

```go
protocol := stream.Transport.Protocol
if protocol == "" { protocol = "udp" }
```

So the compact spelling of a TLS audit stream **shipped over plaintext UDP**
while the configuration on disk still read `protocol tls`.

**The `tls-profile` half fails the opposite way, and the issue framed both the
same.** xpf resolves no TLS profile at all, so the *block* spelling is
**rejected at commit** (#3350) with a message saying exactly that. The compact
spelling slipped past that rejection *and* dropped the value — so the operator
got neither the profile nor the diagnostic. That is a **lost diagnostic**, not
lost protection; there was never protection to lose.

## Why the issue's prescribed fix would have been wrong

The issue says "accumulate `Keys[1:]` plus `Children`". The arm carried a
comment refusing exactly that, and measuring confirmed the comment:

> The strict gate ignores leftover `Keys` on a container by design —
> compiler-faithful, since the compiler did not read them either.

Measured on master before this change:

| | gate | compile |
|---|---|---|
| `transport { protocol tpc; }` | **reject** (enum) | — |
| `transport protocol tpc;` | **accept** | — |

Reading `Keys[1:]` in the compiler alone would turn *"not compiled"* into
*"compiled, unvalidated"* — a bogus protocol becoming a live value that the
block spelling rejects.

So both halves move together, which is the rule `docs/config-schema.md` already
states: **a compiler may only start reading a packed tail at a site where the
gate validates the same expansion.**

## The fix: `schemaNode.packedTail`

An opt-in, sibling to the existing `blockValue`. Setting it declares *"a
compiler reads this container's packed tail"*, and `walkSchemaNode` then
validates the same `packedBodyChildren` expansion the compiler consumes — one
schema fact instead of two files agreeing by comment.

Default-off is deliberate: for every other container the tail is not compiled,
so validating it would reject configurations that behave identically either way.

Three readers now share one expansion, resolved through
`securityLogTransportSchema()` so a schema move cannot silently return the
unexpanded children and restore the original defect: the compiler, the walker,
and the #3350 `tls-profile` check.

### Result — the two spellings now agree on every axis

| spelling | gate | compile |
|---|---|---|
| `transport { protocol tls; }` | accept | `Protocol="tls"` |
| `transport protocol tls;` | accept | `Protocol="tls"` — **was `""`** |
| `transport { protocol tpc; }` | reject (enum) | — |
| `transport protocol tpc;` | reject (enum) — **was accept** | — |
| `transport { tls-profile p; }` | accept | reject (#3350) |
| `transport tls-profile p;` | accept | reject (#3350) — **was accept-and-drop** |

## Tests

Both AST shapes, both parsed with `NewParser` on one braced config. That is the
corrected instrument from the issue thread: the CLAUDE.md "never `NewParser`"
rule is about feeding it *multiple `set` lines*; the flat-set path lands
`protocol` as a **child**, i.e. the block shape, so it cannot exercise this
defect at all.

`TestCompactAndBlockTransportAreDifferentShapes6821` is the premise guard,
written for the trap #6853 hit — two spellings meant to exercise different arms
landing on the same one. It asserts the compact node really is
`Keys=[transport protocol tls]` with **zero children** before any behavioural
cell is allowed to mean anything.

`TestPackedTailContainersValidateBothSpellings6821` is the general invariant:
for every opted-in container, the two spellings must agree at the gate. Each row
also asserts its own premise (that the block side really is rejected/accepted as
intended), so a fixture where both sides fail for an unrelated reason reports
itself instead of passing as "equal".

## Mutation matrix — 5/5 RED

Fix committed first; full package, `-count=1`, **no `-run` filter**.

| # | reverted line | file:line | named cell that fired | dur |
|---|---|---|---|---|
| M1 | compiler back to `prop.Children` only | `compiler_security_log.go:130` | `TestCompactTransportProtocolCompiles6821` +1 | 110s |
| M2 | tls-profile check back to `Children` only | `compiler_security_log.go:304` | `TestCompactTransportTLSProfileIsRejected6821` | 98s |
| M3 | walker ignores the `packedTail` opt-in | `schema_walk.go:619` | `TestCompactTransportBogusProtocolIsRejected6821` +1 | 103s |
| M4 | schema drops `packedTail: true` | `schema_security.go:754` | `TestSecurityLogTransportSchemaResolves6821` +2 | 101s |
| M5 | shared schema lookup returns nil | `compiler_security_log.go:48` | `TestCompactTransportProtocolCompiles6821` +3 | 103s |

M1 first reported **ANCHOR x2** — both readers share the same call prefix, so
the cell could not locate its line and measured nothing. Re-anchored on the
following `switch` before being counted.

## The #2419 census tripwire fired, which is it working

The two transport leaves were recorded in `filedByDesign` **because of** the
packed-tail blocker. Removing the blocker reverses that decision, and the census
said so rather than letting it pass:

> `#2419: … now compiles the compact spelling, but it is divergent BY DESIGN.
> Compiling it reverses the decision recorded at that entry — re-read it before
> removing this line.`

They **move to `filedFixed`** rather than being deleted, so the sites stay
checked in both directions, and the `filedByDesign` floor drops 6 → 4 with the
reason recorded at the assertion — a count that falls because the population
shrank is the fix working, and carrying the old number forward would demand
entries that should no longer exist.

## Docs

`docs/config-schema.md`: the "#6821 is deliberately NOT fixed here" section is
rewritten — the rule it states is kept and is what the fix satisfies — plus the
`packedTail` contract, the equivalence table, and the `filedByDesign` →
`filedFixed` move. One stale present-tense claim elsewhere ("only #6821 sits in
the blind spot") is marked as the measurement it was when taken.

## Gate

```
go build ./...            rc 0
go test -count=1 ./...    rc 0   (68 ok, 0 FAIL)
```

at HEAD `f7a9c74f4ed34db41a9b5b9268eaf6166a5f959c`, clean tree,
`merge-base --is-ancestor origin/master HEAD` verified. **Zero** files under
`userspace-dp/` or `userspace-xdp/` touched, so no cargo leg is owed. `gofmt`
clean on all six touched files (three unrelated `pkg/config` files carry
pre-existing drift and were left alone).

No deploy lane owed: this is compile/validate behaviour in `pkg/config`, with no
runtime forwarding path touched.

## Refs

Closes #6821. Refs #2419 (the dual-AST-shape class), #3350 (the tls-profile
commit reject this now applies to both spellings), #6818 / #6822 (the siblings
that landed first, whose leaves had no enum to bypass), #6853 (the same-arm trap
the premise guard is written for).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MNWyRNuBeKpjXZHcSBihm
