### PR TITLE
cluster: make the #6826 contention probe observe the contention it needs

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -106850,3 +106850,7 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: `pkg/cluster/heartbeat_epoch.go`,
   `pkg/cluster/heartbeat_epoch_stop_flock_6826_test.go` (new),
   `pkg/cluster/README.md`, `_Log.md`
+
+- **Timestamp**: 2026-08-26
+  - **Action**: #7674 — the #6826 contention probe was degenerate under `go test ./...`: the contender goroutine went unscheduled for the whole acquire loop, so the probe's own floor fired reporting it proved nothing. Master was RED. Wait on the observable before the loop, and measure overlap WITH the loop.
+  - **File(s)**: pkg/cluster/heartbeat_epoch_stop_flock_6826_test.go

--- a/pkg/cluster/heartbeat_epoch_stop_flock_6826_test.go
+++ b/pkg/cluster/heartbeat_epoch_stop_flock_6826_test.go
@@ -323,17 +323,54 @@ func TestContendedEpochLockAcquireIsRaceFree6826(t *testing.T) {
 		}
 	}()
 
+	// #7674: wait until the contender has PROVABLY taken the lock at least once
+	// before the acquire loop starts.
+	//
+	// The acquirer is fast — 40 acquisitions complete in ~300us on an idle box —
+	// and under `go test ./...` this package runs alongside dozens of others. The
+	// contender goroutine could therefore go unscheduled for the entire loop, and
+	// the `got == 0` check below then fired reporting that the probe proved
+	// nothing. That report was true, and it was a statement about the SCHEDULER
+	// rather than about the lock: the floor was reading the machine. Measured on
+	// master: "40 acquisitions in 283.121us, contender completed 0 lock cycles".
+	//
+	// ONE edge, and only BEFORE the contended region. A per-acquisition handshake
+	// would establish happens-before between the contender and the acquisition it
+	// races, which is precisely the absence `-race` looks for — the probe would go
+	// quiet against the very hazard it exists to detect. The contender keeps
+	// looping freely throughout the loop below.
+	waitForContenderProgress(t, &contentions, 5*time.Second)
+	before := atomic.LoadInt64(&contentions)
+
 	const acquires = 40
 	ran := 0
 	start := time.Now()
 	for i := 0; i < acquires; i++ {
 		withEpochFileLock(path, func() { ran++ })
 	}
+	// The contender is provably running by now, but a fixed 40 acquisitions can
+	// still fit inside a single scheduling quantum. Extend until the contender has
+	// demonstrably interleaved with THIS loop, so the overlap `-race` needs is
+	// measured rather than inferred from the pre-loop cycle.
+	overlapDeadline := time.Now().Add(5 * time.Second)
+	for atomic.LoadInt64(&contentions) == before {
+		if time.Now().After(overlapDeadline) {
+			close(done)
+			wg.Wait()
+			t.Fatalf("the contender took the lock %d times before the acquire loop but "+
+				"not once during it, over 5s — the two sides are not interleaving and "+
+				"-race observed nothing", before)
+		}
+		withEpochFileLock(path, func() { ran++ })
+	}
 	elapsed := time.Since(start)
 	close(done)
 	wg.Wait()
 
-	if ran != acquires {
+	// `ran` may exceed `acquires` when the overlap extension above ran; what must
+	// hold is that EVERY acquisition ran its callback, so a count short of the
+	// fixed floor means an uncontended lock was refused.
+	if ran < acquires {
 		t.Errorf("only %d/%d acquisitions ran their callback — an uncontended lock "+
 			"must always be takeable", ran, acquires)
 	}
@@ -341,8 +378,31 @@ func TestContendedEpochLockAcquireIsRaceFree6826(t *testing.T) {
 	rate := float64(got) / elapsed.Seconds()
 	t.Logf("contention probe: %d acquisitions in %v, contender completed %d "+
 		"lock cycles (%.0f/s)", acquires, elapsed, got, rate)
-	if got == 0 {
-		t.Error("the contender never took the lock once — the two sides did not " +
-			"overlap, so -race observed nothing and this probe proved nothing")
+	// Overlap is now guaranteed by the extension loop above, which fails loudly
+	// and names what never arrived rather than reaching here with zero. Keep the
+	// floor as a belt-and-braces invariant on the accounting itself.
+	if got <= before {
+		t.Errorf("contention count did not advance during the acquire loop "+
+			"(before=%d, after=%d) — the extension loop should have caught this",
+			before, got)
+	}
+}
+
+// waitForContenderProgress blocks until the contender goroutine has completed at
+// least one lock cycle, so the acquire loop is issued into a window that is
+// provably being contended rather than one the scheduler has not reached yet.
+//
+// Bounded, and fails naming what never arrived — a probe that silently proceeds
+// uncontended is the degenerate case this exists to prevent.
+func waitForContenderProgress(t *testing.T, contentions *int64, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for atomic.LoadInt64(contentions) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("the contender completed no lock cycles in %s — it was never "+
+				"scheduled, so the acquire loop would run uncontended and the probe "+
+				"would be degenerate", within)
+		}
+		time.Sleep(time.Millisecond)
 	}
 }


### PR DESCRIPTION
**Master is RED under `go test ./...`** on a test merged an hour ago in #7671. This fixes it.

## The failure, and why the message being true is the problem

```
contention probe: 40 acquisitions in 283.121µs, contender completed 0 lock cycles (0/s)
the contender never took the lock once — the two sides did not overlap,
so -race observed nothing and this probe proved nothing
```

Passes in isolation, fails under `./...`. The acquirer finishes 40 acquisitions in under 300 µs; under the full suite this package runs alongside dozens of others and the contender goroutine was **never scheduled at all** before the loop ended.

So the floor was reading the machine rather than the lock — the **#7650 class**, appearing this time in a probe written to guard #6826.

## The fix

- `waitForContenderProgress` blocks until the contender has provably completed **at least one lock cycle** before the acquire loop starts. Bounded at 5 s, fails loudly naming what never arrived.
- The loop then **extends until the contention count advances**, so the overlap `-race` depends on is measured against *this* loop rather than inferred from a cycle that happened before it. A fixed 40 acquisitions can fit inside one scheduling quantum even with the contender running.

**One edge, and only before the contended region.** A per-acquisition handshake would establish happens-before between the contender and the acquisition it races — precisely the absence `-race` looks for — and the probe would go quiet against the very hazard it exists to detect. The contender loops freely throughout.

`ran != acquires` became `ran < acquires`, since the extension loop can legitimately run more; the property is that no acquisition was refused. The old `got == 0` floor is now unreachable (the extension fails first, and says why), so it is kept only as an invariant on the accounting.

## Measured

| | contender cycles | verdict |
|---|---|---|
| master, under `./...` | **0** | FAIL |
| this branch | **274** (850k/s) | PASS |

- `go test ./pkg/cluster -run … -race` — ok
- `go test ./... -count=1` — **rc=0, 68 packages, 0 FAIL**, on the same box and the same concurrency that produced the red

## Why this is filed as a fix rather than a revert

The #6826 change itself is sound and its other six cells are load-bearing. Only the contention probe's precondition was degenerate. Reverting would give back a real fail-closed fix to repair a test.

Refs #7650 (the class), #6826 / #7671 (the change this guards).
