### PR TITLE
daemon: fail closed when the VRRP reconcile runs before its manager

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -106988,3 +106988,18 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: `pkg/eventengine/engine.go`, `pkg/eventengine/queue.go`,
   `pkg/eventengine/evaluate.go`, `pkg/eventengine/README.md`,
   `docs/refactoring-audit-accepted.txt`, `_Log.md`
+
+## 2026-08-26 — #6739: guard the pre-manager VRRP deref (work item G's provable half)
+
+- **Timestamp**: 2026-08-26
+- **Action**: A recovered commit-confirmed rollback can reach `applyTailReconciles`
+  before startup phase 3 constructs `d.vrrpMgr`, and the VRRP call site was the
+  only unguarded manager deref there — the daemon panics at boot. Guarded it and
+  failed CLOSED (a nil manager holds no instance set, which is the strongest form
+  of the condition the adjacent fail-closed gate already exists for). Deliberately
+  does NOT implement work item G's startup-readiness gate: #6739 records that
+  landing G without H converts this short pre-manager window into a post-manager
+  bootstrap-with-live-cluster hybrid, so no dispatch point is moved. G/H/H2 remain
+  unimplemented and unconverged.
+- **File(s)**: `pkg/daemon/daemon_apply_tail.go`,
+  `pkg/daemon/recovered_rollback_premanager_6739_test.go`, `_Log.md`

--- a/pkg/daemon/daemon_apply_tail.go
+++ b/pkg/daemon/daemon_apply_tail.go
@@ -50,7 +50,51 @@ func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, 
 		localPri := d.cluster.LocalPriorities()
 		vrrpInstances = append(vrrpInstances, vrrp.CollectRethInstances(cfg, localPri)...)
 	}
-	if err := d.vrrpMgr.UpdateInstances(vrrpInstances); err != nil {
+	if d.vrrpMgr == nil {
+		// #6739 (work item G, the half that is provable on master TODAY).
+		//
+		// Store.Load recovers a STILL-LIVE commit-confirmed window by re-arming
+		// time.AfterFunc(time.Until(deadline)). An ALREADY-EXPIRED window is
+		// handled synchronously in an earlier branch and never reaches that
+		// re-arm, so the remaining duration here is strictly positive — but it
+		// is bounded below only by how close the boot is to the deadline, and
+		// can be arbitrarily small. A box that reboots shortly before its
+		// deadline (`commit confirmed 1` and a ~55s boot) arms a timer with
+		// seconds on it.
+		//
+		// That timer is armed in startup PHASE 1 (loadAndBootstrapConfig); the
+		// rollback executor is registered before the phase list even starts;
+		// and vrrpMgr is not constructed until PHASE 3 (initManagers). Nothing
+		// holds applySem across the phases. So when the remaining duration
+		// elapses before phase 3 completes, the timer goroutine reaches this
+		// line with vrrpMgr still nil and the daemon panics AT BOOT.
+		//
+		// Measured, not argued — and the first mechanism I wrote here was
+		// WRONG: I recorded an unclamped negative duration firing immediately,
+		// then found the synchronous expired-window branch that makes that
+		// impossible. The panic is real (see
+		// TestRecoveredRollbackDoesNotPanicBeforeManagers6739); the route to it
+		// is a race against phases 2-3, not an instantaneous fire.
+		//
+		// Deliberately NOT "skip the update and carry on". This site is already
+		// a fail-closed gate one line below for exactly one reason: reporting a
+		// successful apply while the manager does not hold the requested
+		// instance set claims HA coverage for a family or segment that is not
+		// running. A nil manager holds NO instance set at all, which is the
+		// strongest form of that same condition, so it fails closed too.
+		//
+		// This is deliberately NOT work item G's startup-readiness gate. G
+		// releases recovery at end-of-phase-5, and #6739 records that landing
+		// that without work item H converts this short pre-manager window into
+		// a post-manager bootstrap-with-live-cluster hybrid — a worse state.
+		// Guarding the dereference moves no dispatch point and creates no such
+		// hybrid; it converts a boot panic into a reported apply failure and
+		// leaves G/H/H2 entirely to their unresolved convergence.
+		vrrpErr = errors.New("update VRRP instances: VRRP manager not initialized " +
+			"(apply reached the VRRP reconcile before daemon startup constructed it)")
+		slog.Error("VRRP reconcile ran before the VRRP manager exists; failing the apply "+
+			"closed rather than claiming HA coverage", "issue", "#6739")
+	} else if err := d.vrrpMgr.UpdateInstances(vrrpInstances); err != nil {
 		slog.Warn("failed to update VRRP instances", "err", err)
 		// Identity/family validation is a fail-closed runtime gate. Returning a
 		// successful commit while the manager retained the old instance set

--- a/pkg/daemon/recovered_rollback_premanager_6739_test.go
+++ b/pkg/daemon/recovered_rollback_premanager_6739_test.go
@@ -1,0 +1,135 @@
+package daemon
+
+// recovered_rollback_premanager_6739_test.go — #6739, work item G's provable half.
+//
+// A recovered commit-confirmed rollback can reach the apply tail BEFORE daemon
+// startup has constructed the managers that tail dereferences.
+//
+// THE ORDERING, all of it on master:
+//
+//	daemon_run.go     SetRollbackExecutor(d.executeConfirmedRollback)  <- before the phase list
+//	phase 1           loadAndBootstrapConfig -> Store.Load -> re-arms time.AfterFunc(remaining)
+//	phase 2           interface-naming
+//	phase 3           initManagers -> d.vrrpMgr = vrrp.NewManager()
+//
+// Nothing holds applySem across the phases, so the timer goroutine and the
+// startup phases run concurrently. When `remaining` elapses before phase 3, the
+// rollback dereferences a nil vrrpMgr and the daemon PANICS AT BOOT.
+//
+// `remaining` is strictly positive — an already-expired window is rolled back
+// synchronously in an earlier branch of recoverPendingConfirmLocked and never
+// reaches the re-arm — but it is bounded below only by how close the boot is to
+// the deadline. `commit confirmed 1` plus a ~55s reboot arms seconds.
+//
+// The fix guards the dereference and fails CLOSED. It deliberately does NOT
+// move the dispatch point: #6739 records that work item G's startup-readiness
+// gate (release at end-of-phase-5) is unsafe without work item H, because it
+// converts this short pre-manager window into a post-manager
+// bootstrap-with-live-cluster hybrid. G/H/H2 remain unimplemented and
+// unconverged.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/vrrp"
+)
+
+// daemonAtRecoveryWindow6739 models the daemon EXACTLY as it is when a
+// recovered timer can fire: phase 1 done, so the store exists — it is the very
+// object that armed the timer — and every manager initManagers builds is nil.
+//
+// A bare &Daemon{} would be the wrong fixture: it also has a nil store, which
+// panics later in the same function for a reason production never reaches, and
+// would make this cell pass for the wrong defect.
+func daemonAtRecoveryWindow6739(t *testing.T) *Daemon {
+	t.Helper()
+	return &Daemon{
+		store: newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+	}
+}
+
+// TestRecoveredRollbackDoesNotPanicBeforeManagers6739 is the issue.
+//
+// FAIL-ON-REVERT: remove the `d.vrrpMgr == nil` arm in applyTailReconciles and
+// this cell panics with a nil pointer dereference, which is what the daemon
+// does at boot.
+func TestRecoveredRollbackDoesNotPanicBeforeManagers6739(t *testing.T) {
+	d := daemonAtRecoveryWindow6739(t)
+
+	// Precondition: this is the state under test, not a bare struct.
+	if d.vrrpMgr != nil {
+		t.Fatal("precondition: vrrpMgr must be nil — phase 3 has not run")
+	}
+	if d.store == nil {
+		t.Fatal("precondition: the store must exist — phase 1 armed the timer from it")
+	}
+
+	err := d.applyTailReconciles(&config.Config{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	// FAIL CLOSED, not "skip and report success". This site is already
+	// fail-closed one branch below, because reporting a successful apply while
+	// the manager does not hold the requested instance set claims HA coverage
+	// that is not running. A nil manager holds no instance set at all.
+	if err == nil {
+		t.Fatal("a rollback that reached the VRRP reconcile with no VRRP manager reported " +
+			"SUCCESS — the apply claimed HA coverage from a manager that does not exist " +
+			"yet (#6739)")
+	}
+	if !strings.Contains(err.Error(), "VRRP manager not initialized") {
+		t.Fatalf("apply failed for a different reason than the missing manager: %v", err)
+	}
+}
+
+// TestVRRPGuardDoesNotFireWhenTheManagerExists6739 is the PAIRED control.
+//
+// Without it, "return an error when vrrpMgr is nil" is satisfied by a guard
+// that fires unconditionally — which would fail every normal apply on the box
+// while still passing the cell above.
+func TestVRRPGuardDoesNotFireWhenTheManagerExists6739(t *testing.T) {
+	d := daemonAtRecoveryWindow6739(t)
+	d.vrrpMgr = vrrp.NewManager()
+
+	err := d.applyTailReconciles(&config.Config{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	if err != nil && strings.Contains(err.Error(), "VRRP manager not initialized") {
+		t.Fatalf("the #6739 guard fired with a live VRRP manager present — it would fail "+
+			"every ordinary apply: %v", err)
+	}
+}
+
+// TestRecoveredWindowStillArmsATimerBeforeManagersExist6739 binds the ORDERING
+// premise the guard above exists for, rather than trusting the reading.
+//
+// If a future change made Store.Load resolve every recovered window
+// synchronously, or moved manager construction ahead of the config load, the
+// guard would become dead code and this cell is what would say so.
+func TestRecoveredWindowStillArmsATimerBeforeManagersExist6739(t *testing.T) {
+	// The executor is registered before the startup phase list, and
+	// loadAndBootstrapConfig (phase 1) runs before initManagers (phase 3).
+	// Assert the two source facts the hazard rests on, so a reordering reds.
+	runSrc := readSource6739(t, "daemon_run.go")
+	iLoad := strings.Index(runSrc, "d.loadAndBootstrapConfig()")
+	iInit := strings.Index(runSrc, "d.initManagers(")
+	iExec := strings.Index(runSrc, "d.store.SetRollbackExecutor(")
+	if iLoad < 0 || iInit < 0 || iExec < 0 {
+		t.Fatalf("anchors not found (load=%d init=%d exec=%d) — the startup shape changed; "+
+			"re-derive whether the #6739 window still exists", iLoad, iInit, iExec)
+	}
+	if !(iExec < iLoad && iLoad < iInit) {
+		t.Fatalf("startup order changed: SetRollbackExecutor@%d, loadAndBootstrapConfig@%d, "+
+			"initManagers@%d. The #6739 pre-manager window depends on executor-then-load-then-"+
+			"managers; re-check the guard is still needed", iExec, iLoad, iInit)
+	}
+}
+
+func readSource6739(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
Refs #6739

**Not `Closes`.** #6739 keeps its contested work items; this PR lands only the half that is provable on master today. G+H+H2 are split into #7675 and remain unimplemented and unconverged.

## The defect

A recovered commit-confirmed rollback can dereference a nil `d.vrrpMgr` and **panic the daemon at boot**.

The ordering, all of it on master:

```
daemon_run.go   SetRollbackExecutor(d.executeConfirmedRollback)   <- before the phase list
phase 1         loadAndBootstrapConfig -> Store.Load -> re-arms time.AfterFunc(time.Until(deadline))
phase 2         interface-naming
phase 3         initManagers -> d.vrrpMgr = vrrp.NewManager()
```

Nothing holds `applySem` across the phases, so the timer goroutine runs concurrently with startup. When the remaining duration elapses before phase 3, the rollback reaches `applyTailReconciles` and dereferences a nil `vrrpMgr`.

**How small can the remaining duration be?** It is strictly positive — an already-expired window is rolled back *synchronously* in an earlier branch of `recoverPendingConfirmLocked` and never reaches the re-arm — but it is bounded below only by how close the boot is to the deadline. A box that reboots shortly before its deadline (`commit confirmed 1` and a ~55 s boot) arms a timer with seconds on it, against startup phases that do netlink and manager construction.

## The fix

Guard the dereference and **fail closed**.

Not skip-and-continue. This site is already a fail-closed gate one branch below, for exactly one reason: reporting a successful apply while the manager does not hold the requested instance set claims HA coverage for a family or segment that is not running. **A nil manager holds no instance set at all**, which is the strongest form of that same condition.

## Scope — what this deliberately is NOT

This is **not** work item G's startup-readiness gate. G releases recovery at end-of-phase-5, and #6739 records that landing it without work item H converts this short pre-manager window into a **post-manager bootstrap-with-live-cluster hybrid** — a worse state than master, because H's revert-at-`Load` is only safe *before* `d.cluster` exists.

Guarding the dereference **moves no dispatch point** and so cannot create that hybrid. G/H/H2 stay in #7675 with their 2-of-3 reviewer split intact.

## Two corrections I made to myself, recorded because they are load-bearing

**The mechanism I first wrote into the code comment was false.** I recorded an unclamped *negative* remaining duration firing immediately, then found the synchronous expired-window branch that makes that impossible. The panic is real and measured; my stated route to it was not. **A fix whose justification is false is one edit from being reverted by whoever checks the justification**, so the comment now carries the real mechanism and says which one it replaced.

**My first census fixture was wrong in a way that manufactured a second finding.** A bare `&Daemon{}` panicked at a *second* site — `d.store` — which is nil only because the fixture was wrong; production always has a store there, since it is the object that armed the timer. A panic at a site production never reaches measures nothing. The fixture now models the daemon exactly as it is when the timer can fire: store present, managers nil.

## Test plan

- [x] `pkg/daemon/recovered_rollback_premanager_6739_test.go` — 3 cells:
  - `TestRecoveredRollbackDoesNotPanicBeforeManagers6739` — the issue. Panics with a nil pointer dereference on revert.
  - `TestVRRPGuardDoesNotFireWhenTheManagerExists6739` — **paired control**: without it, "return an error when `vrrpMgr` is nil" is satisfied by a guard that fires unconditionally and breaks every ordinary apply.
  - `TestRecoveredWindowStillArmsATimerBeforeManagersExist6739` — binds the **ordering premise** rather than trusting the reading. If a later change resolves every recovered window synchronously, or moves manager construction ahead of the config load, the guard becomes dead code and this cell says so instead of leaving it to rot.
- [x] **Mutation matrix**, full-package `go test -count=1 ./pkg/daemon/`, **no `-run` filter**, fix committed before mutating, control GREEN:

  | mutation | cells that RED |
  |---|---|
  | guard removed entirely (the shipped panic) | `TestRecoveredRollbackDoesNotPanicBeforeManagers6739` |
  | guard skips instead of failing closed | `TestRecoveredRollbackDoesNotPanicBeforeManagers6739` |
  | guard fires unconditionally | **19 cells** — the paired control plus 18 pre-existing apply tests |

  That last row is worth reading: the over-broad fix is caught by `TestVRRPGuardDoesNotFireWhenTheManagerExists6739` **and by eighteen tests that already existed**. Running every cell full-package rather than `-run`-filtered is what made that visible — a filtered matrix would have credited the new control alone for coverage the suite already had.

- [x] `go build ./... && go test -count=1 ./...` → **rc 0, 68/68 packages, 0 failures**, at HEAD `902704c45`, `merge-base --is-ancestor origin/master HEAD` verified.
- [ ] **No smoke owed.** One guarded dereference in the apply tail; no forwarding-path, cluster, VRRP-runtime, session-sync or failover behaviour changes, no `userspace-dp`/`userspace-xdp` (no cargo leg).

## Refs

Refs #6739 (keeps its contested items). G+H+H2 split to #7675. The re-anchored evidence table for the r67 findings is in #6739.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1PvkJxs7KrzEdyC9u1LDu
