### PR TITLE
api: stop the retired-leg test racing the drain it depends on

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -106988,3 +106988,19 @@ prose edit above them added. No diff falls in the new test body.
 - **File(s)**: `pkg/eventengine/engine.go`, `pkg/eventengine/queue.go`,
   `pkg/eventengine/evaluate.go`, `pkg/eventengine/README.md`,
   `docs/refactoring-audit-accepted.txt`, `_Log.md`
+
+## 2026-08-26 — #7667: make the retired-leg fixture stop racing the drain
+
+- **Timestamp**: 2026-08-26
+- **Action**: `TestRetiredLegNeverGainsARotatedCredential_5561` samples an
+  asynchronous observable — whether the retired leg has finished draining — at a
+  fixed point. A leg that drains first is dropped by `pruneRetiredLocked`, so
+  `ReplaceAuth` never tightens it and the old credential survives, which the test
+  reports as "a revocation did not land". The fixture now holds a request IN
+  FLIGHT so the drain cannot complete (`http.Server.Shutdown` waits for active
+  requests), and asserts `!drained` by name before the revocation assertions.
+  **Root cause of the observed flake is NOT established**: forcing `drained=true`
+  reproduces the exact failure (sufficient), but the condition did not occur
+  naturally in 80 attempts including 2x CPU oversubscription. The change is
+  therefore a determinism + diagnosis improvement, not a proven fix.
+- **File(s)**: `pkg/api/listener_retiredauth_5561_test.go`, `_Log.md`

--- a/pkg/api/listener_retiredauth_5561_test.go
+++ b/pkg/api/listener_retiredauth_5561_test.go
@@ -2,11 +2,13 @@ package api
 
 import (
 	"context"
+	"encoding/base64"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 )
 
 // listener_retiredauth_5561_test.go is the fail-on-revert gate for the #5561
@@ -43,10 +45,30 @@ func legProbe(t *testing.T, leg *listenerLeg, user, pass string) bool {
 // retireTestServer builds a Server whose legs serve a trivial 200 handler over
 // the real per-leg auth middleware, with a listener factory that hands out
 // closed-on-cleanup local sockets.
+//
+// #7667: /hold blocks until the returned release func is called. A leg cannot
+// finish draining while a request is in flight — http.Server.Shutdown WAITS for
+// active requests — so a test that needs the leg to still be RETIRING at a
+// chosen moment can guarantee it instead of racing the drain.
 func retireTestServer(t *testing.T, boot *AuthConfig) *Server {
 	t.Helper()
+	s, _ := retireTestServerWithHold(t, boot)
+	return s
+}
+
+func retireTestServerWithHold(t *testing.T, boot *AuthConfig) (*Server, func()) {
+	t.Helper()
 	s := &Server{}
-	s.sharedBase = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	held := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(held) }) }
+	t.Cleanup(release)
+	s.sharedBase = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/hold" {
+			<-held
+		}
+		w.WriteHeader(http.StatusOK)
+	})
 	s.auth.Store(boot)
 	var mu sync.Mutex
 	var lns []net.Listener
@@ -70,7 +92,40 @@ func retireTestServer(t *testing.T, boot *AuthConfig) *Server {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	s.rootCtx = ctx
-	return s
+	return s, release
+}
+
+// startHeldRequest7667 puts a request IN FLIGHT on ln and returns once the
+// handler has certainly been entered. While it is in flight the leg's drain
+// cannot complete, so the leg stays on the retiring list deterministically.
+//
+// This is the #7563 ordering applied to a fixture that was sampling an
+// asynchronous observable: rather than hoping the drain has not finished, make
+// it UNABLE to finish. The test then measures the property it names — that a
+// leg which is still retiring honours a revocation — instead of measuring which
+// goroutine the scheduler picked.
+func startHeldRequest7667(t *testing.T, ln net.Listener) {
+	t.Helper()
+	entered := make(chan struct{})
+	go func() {
+		c, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			close(entered)
+			return
+		}
+		t.Cleanup(func() { _ = c.Close() })
+		req := "GET /hold HTTP/1.1\r\nHost: x\r\nAuthorization: Basic " +
+			base64.StdEncoding.EncodeToString([]byte("admin:secret-a")) + "\r\n\r\n"
+		_, _ = c.Write([]byte(req))
+		close(entered)
+	}()
+	<-entered
+	// The write has been issued; give the server goroutine the chance to accept
+	// and enter the handler. This sleep is NOT the synchronisation — the held
+	// channel is. It only narrows the window before the drain is requested; if
+	// it were too short the caller's explicit !drained precondition fails
+	// loudly by name rather than producing a confusing revocation failure.
+	time.Sleep(50 * time.Millisecond)
 }
 
 // A commit that MOVES the management bind and ROTATES the credential must not
@@ -100,6 +155,15 @@ func TestRetiredLegNeverGainsARotatedCredential_5561(t *testing.T) {
 		t.Fatal("the live listener rejects its own configured credential; the case starts wrong")
 	}
 
+	// #7667: hold a request IN FLIGHT so the retired leg cannot finish draining
+	// before ReplaceAuth runs. Without this the fixture races the drain: a leg
+	// that drains first is dropped by pruneRetiredLocked and ReplaceAuth never
+	// tightens it, so secret-a survives and this test fails intermittently
+	// under load — reporting "a revocation did not land" when nothing about
+	// revocation was broken. Measured: forcing drained=true before ReplaceAuth
+	// reproduces the exact failure, and leaving it false does not.
+	startHeldRequest7667(t, ln)
+
 	if err := s.ReconcileHTTP("10.0.0.2:8080"); err != nil {
 		t.Fatalf("ReconcileHTTP: %v", err)
 	}
@@ -110,6 +174,17 @@ func TestRetiredLegNeverGainsARotatedCredential_5561(t *testing.T) {
 
 	// This is exactly what managementReconciler does once every live leg sits at
 	// an address the committed config names.
+	// The subject of this test is a leg that is STILL RETIRING. If the drain
+	// finished anyway, say so by name — a leg the server has already reaped is
+	// a different case (its policy is deliberately no longer maintained; see
+	// the drainLeg commentary) and asserting revocation against it would be
+	// asserting something the design does not promise.
+	if retired.drained.Load() {
+		t.Fatal("precondition: the retired leg already finished draining, so it is no " +
+			"longer on the retiring list and ReplaceAuth will not tighten it. This " +
+			"test is about a leg that is still RETIRING (#7667)")
+	}
+
 	s.ReplaceAuth(&AuthConfig{Users: map[string]string{"admin": "secret-b"}})
 
 	if legProbe(t, retired, "admin", "secret-b") {


### PR DESCRIPTION
Refs #7667

**Not `Closes`.** This makes the fixture deterministic and the failure legible. It does **not** establish the root cause of the flake, and #7667 stays open for that.

## The test was racing an asynchronous fact it did not control

`TestRetiredLegNeverGainsARotatedCredential_5561` asserts that a leg which is **still retiring** honours a revocation. Whether it is still retiring at that moment was left to the scheduler.

`pruneRetiredLocked` keeps only legs whose drain has **not** finished, and `ReplaceAuth` tightens only those survivors. So a leg that finishes draining before `ReplaceAuth` runs is never tightened and keeps the old credential — which the test reports as:

```
secret-a still authenticates on the retired listener — a retiring leg must
still honour a revocation immediately (#5561 round 7)
```

i.e. **as a revocation failure, when nothing about revocation is broken.**

## The fix: make the fixture unable to observe the machine

The fixture now holds a request **in flight** across the retire. `http.Server.Shutdown` waits for active requests, so the leg **cannot** finish draining. That is the `docs/engineering-style.md` #7563 ordering — not a longer sleep, not a retry — and it models the case the test actually names: a leg still serving while it drains.

A precondition then asserts `!drained` **by name**. If the drain ever wins anyway, the failure says the leg was already reaped and this test is about a leg that is still retiring, instead of accusing the revocation path.

**That distinction is why this was worth doing even without the root cause.** The misleading message points at a security property, and the obvious way to quiet a flaky revocation assertion is to relax it — which leaves a test that passes forever while guarding nothing.

## What is measured, and what is NOT

Stated plainly, because the temptation is to present this as a fix.

**Measured — the mechanism is SUFFICIENT.** Paired probe, one variable:

| | secret-a still authenticates on the retired leg |
|---|---|
| drain NOT finished | **false** — revocation lands |
| drain FINISHED before `ReplaceAuth` | **true** — revocation lost |

Forcing the condition reproduces the observed message exactly; leaving it alone does not.

**NOT measured — that this is what actually happened.** `drained` was sampled at the `ReplaceAuth` point over **40 idle runs and 40 runs under 2× CPU oversubscription** (32 burners on 16 cores): **0/80.** The drain never won.

So the mechanism *can* produce the symptom; it is **not demonstrated to be the cause** of the failure seen under `./...`. Sufficiency is not causation. The next step for the root cause is reproduction under real `./...` contention rather than synthetic load, since 0/80 says synthetic burners are not the load that breaks it.

## A design question I raised on the issue, and withdraw

I asked whether a fully-drained leg *should* be exempt from tightening. **That is already decided, deliberately**, and `drainLeg`'s own commentary says so:

> a leg's policy stops being maintained the moment it drains (`listenerLeg.drained`, `Server.pruneRetiredLocked`), so a request admitted after that is judged by a snapshot no ReplaceAuth will ever tighten again

Tied to #6827. Asserting revocation against an already-reaped leg would be asserting something the design does not promise — I was reading a recorded decision as an open one.

## Test plan

- [x] `go build ./... && go test -count=1 ./...` → **rc 0, 68/68 packages, 0 failures**, at HEAD `cd72696ff`, `merge-base --is-ancestor origin/master HEAD` verified.
- [x] The hardened test green; `pkg/api` green.
- [x] No new test cells: this changes an existing fixture rather than adding behaviour. The existing assertions are the guard, and they now run against a state the fixture guarantees instead of one it hoped for.
- [ ] **No smoke owed.** Test-only change; no production code touched.

## Refs

Refs #7667 (root cause still open). Related: #7650 class (a test sampling an asynchronous observable at a fixed wall-clock point), #7674 (the same class in `pkg/cluster`), #6827 (the drained-leg policy decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1PvkJxs7KrzEdyC9u1LDu
