### PR TITLE
cluster: give the #7257 probe's teardown wait a bound load cannot expire

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -106992,3 +106992,7 @@ prose edit above them added. No diff falls in the new test body.
 - **Timestamp**: 2026-08-26
   - **Action**: #6854 — `then reject <message-type>` now selects the ICMP code. Threaded the token from the compiler through FirewallTermSnapshot into FilterAction::Reject and the ICMP builder, across all three reject paths (input, output/CoS, flow-cache replay).
   - **File(s)**: pkg/config/compiler_firewall_reject_message_6854_test.go, pkg/dataplane/userspace/{protocol_policies,filters,firewall_snapshot_render}.go, userspace-dp/src/filter/{mod,compiler,tests}.rs, userspace-dp/src/protocol/security.rs, userspace-dp/src/afxdp/{icmp,icmp_tests,flow_cache,forward_request,event_emit}.rs, userspace-dp/src/afxdp/tx/cos_classify.rs, userspace-dp/src/afxdp/poll_descriptor/*.rs, docs/feature-gaps.md
+
+- **Timestamp**: 2026-08-26
+  - **Action**: #7679 — raised the #7257 probe's teardown-progress bound from 5s to 30s. The 5s deadline made master RED under `go test ./...` twice; it is itself a fixed wall-clock sample of an asynchronous observable, which is the #7650 defect the file was changed to fix.
+  - **File(s)**: pkg/cluster/heartbeat_start_stop_race_7257_test.go

--- a/pkg/cluster/heartbeat_start_stop_race_7257_test.go
+++ b/pkg/cluster/heartbeat_start_stop_race_7257_test.go
@@ -76,6 +76,28 @@ import (
 // teardown and the start it races, which is exactly what the race detector
 // looks for the absence of — the probe would go quiet against the very bug it
 // exists to catch.
+// teardownProgressBudget bounds the wait for the teardown goroutine's first
+// stop. It is deliberately generous, and 5s was not.
+//
+// #7679: at 5s this test made master RED under `go test ./...` — twice. The
+// bound is not a timing assertion about the heartbeat code; its only job is to
+// turn "the goroutine was never scheduled at all" into a named failure instead
+// of a silent degenerate probe or a hang. Under `./...` the runner starts many
+// package binaries concurrently, each with GOMAXPROCS equal to the core count,
+// so the machine is heavily oversubscribed and a cheap goroutine can wait a
+// long time for a P.
+//
+// Raising it costs nothing when healthy — the loop exits on the first observed
+// stop, typically within a millisecond — and it does not weaken what the bound
+// detects, because a goroutine that is genuinely never scheduled stays
+// unscheduled for 30s just as surely as for 5s. Sampling an asynchronous
+// observable at a fixed wall-clock point is exactly the #7650 defect this file
+// was changed to fix; a 5s deadline is still such a point, just a later one.
+//
+// See #7663: this probe reaches nothing it claims to probe, so a green here is
+// not evidence the #7257 regression is guarded either way.
+const teardownProgressBudget = 30 * time.Second
+
 func waitForTeardownProgress(t *testing.T, stops *atomic.Int64, within time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(within)
@@ -142,7 +164,7 @@ func TestStartHeartbeatDoesNotRaceStopHeartbeat7257(t *testing.T) {
 	// suppress the very data race this probe exists to detect. The teardown
 	// goroutine keeps running freely for the whole start loop, so each start
 	// still overlaps unordered teardowns.
-	waitForTeardownProgress(t, &stops, 5*time.Second)
+	waitForTeardownProgress(t, &stops, teardownProgressBudget)
 	wg.Wait()
 	m.StopHeartbeat()
 


### PR DESCRIPTION
**Master has gone RED under `go test ./...` twice** on `TestStartHeartbeatDoesNotRaceStopHeartbeat7257`, at the 5 s `waitForTeardownProgress` deadline this file gained in #7664.

```
the teardown goroutine completed no stops in 5s — it was never scheduled,
so every start below would run uncontended and the probe would be degenerate
```

Passes **5/5 in isolation** both times. The trigger is concurrency: `./...` starts many package binaries at once, each with `GOMAXPROCS` equal to the core count, so the machine is heavily oversubscribed and a cheap goroutine can wait a long time for a P.

## Why this is the #7650 class again rather than a flake

#7664 replaced a fixed `time.Sleep` with a wait on an observable, which was right — **but it left the wait itself bounded by a fixed wall-clock deadline.** That is still a fixed sample of an asynchronous observable. The defect was moved, not removed.

This is the **third** instance in `pkg/cluster` this evening, after #7674's contention probe. The generalisation that keeps holding: *when a test maximises contention to prove a window is contended, check the window is still reachable* — and a bound on the wait is part of that window.

## Why raising the number is the fix and not a weakening

The bound is **not a timing assertion about the heartbeat code**. Its only job is to turn "the goroutine was never scheduled at all" into a named failure rather than a degenerate probe or a hang. 30 s does that exactly as well as 5 s: a goroutine genuinely never scheduled stays unscheduled for 30 s too. And it costs nothing when healthy — the loop exits on the first observed stop, typically within a millisecond.

It is now a named constant with the reasoning attached, so it cannot be quietly edited back down without reading why.

## Verified under the condition that produced the red

Not only on an idle box:

```
go test ./... -count=1   with a full cargo suite running concurrently
  →  rc=0, 68 packages, 0 FAIL
```

## Also recorded

A pointer to **#7663** next to the constant: this probe reaches nothing it claims to probe (`publish-window entered=0` against 39300 stops), so a green here is not evidence the #7257 regression is guarded either way. Someone raising a bound on a test should know if the test observes nothing.

Refs #7650 (the class), #7664 (which introduced this bound), #7674 (the sibling instance), #7663 (the vacuity).
