### PR TITLE
docs: commit opus-review-001.md, which two open issues cite

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -107027,3 +107027,7 @@ prose edit above them added. No diff falls in the new test body.
   naturally in 80 attempts including 2x CPU oversubscription. The change is
   therefore a determinism + diagnosis improvement, not a proven fix.
 - **File(s)**: `pkg/api/listener_retiredauth_5561_test.go`, `_Log.md`
+
+- **Timestamp**: 2026-08-27
+  - **Action**: committed `opus-review-001.md` into `docs/reviews/recovered/`. Two OPEN issues (#6813, #6751) cite it and it existed only outside the repo, so their evidence was unreachable to anyone but the machine that produced it.
+  - **File(s)**: docs/reviews/recovered/opus-review-001.md


### PR DESCRIPTION
`opus-review-001.md` existed only at `/home/ps/git/opus-review-001.md` — **outside the repository** — while two OPEN issues cite it as their evidence base:

- **#6751** — live High-severity interface-SNAT forwarding work, currently in progress
- **#6813** — the audit cohort, whose annotation points readers at a repo path that does not exist

So the evidence behind an open High was reachable only from the machine that produced it.

`md5 d3de78f1fdaace39adc9fcfcfeca9c8d`, 2.4 MB, 20k+ lines, reviewed at base `ad959117` on 2026-08-02.

## On the size, since it is a real cost

A 2.4 MB markdown file in a repository is not free, and it is justified here only because live issues depend on it and **a review document that cannot be read is not evidence**. It joins `claude-opus-XC-show.md`, already in this directory for the same reason.

## A caveat that belongs with it

The review is anchored at `ad959117` and master is thousands of commits ahead, so **every file:line in it should be treated as a coordinate that has probably rotted**. The finding usually survives; the cite usually does not.

That failure mode is worth naming because it does not announce itself: a stale cite reads as *false reassurance*. Someone re-checking a finding at its recorded line sees unrelated code, concludes the finding is gone, and closes it. #6739 has a worked example — a finding whose two cites now point at a blank line and a boot-listener comment, where half had genuinely shipped 140 lines away in a different file and half was still open.

No code changes; docs only.
