### PR TITLE
config: measure the #2419 class across packing depth

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -107027,3 +107027,19 @@ prose edit above them added. No diff falls in the new test body.
   naturally in 80 attempts including 2x CPU oversubscription. The change is
   therefore a determinism + diagnosis improvement, not a proven fix.
 - **File(s)**: `pkg/api/listener_retiredauth_5561_test.go`, `_Log.md`
+
+## 2026-08-27 — #7653: measure the #2419 class across PACKING DEPTH
+
+- **Timestamp**: 2026-08-27
+- **Action**: The #2419 census collapses exactly one container onto the leaf
+  line, so its 354-divergent figure was a floor in an unstated second dimension:
+  Junos compaction is recursive. Extended the SAME walker across depths.
+  Measured: divergence RATE rises with depth — 65% at depth 2, 87% at 3, 97% at
+  4, ~99% at 5+ — for >= 1793 divergent cells over >= 527 distinct sites, versus
+  the base census's 354. Only 2 cells in the whole sweep are REJECTED, which is
+  the measurement that this class is "accepted and dropped" rather than refused;
+  rejected cells are excluded from the divergent count per the #7653 policy call.
+  A depth-1 cross-check asserts the extension agrees with the base census cell
+  for cell, plus anti-vacuity on depth 3 and a rate-inversion guard.
+- **File(s)**: `pkg/config/compact_depth_census_7653_test.go`,
+  `docs/config-schema.md`, `_Log.md`

--- a/_Log.md
+++ b/_Log.md
@@ -107040,6 +107040,11 @@ prose edit above them added. No diff falls in the new test body.
   the measurement that this class is "accepted and dropped" rather than refused;
   rejected cells are excluded from the divergent count per the #7653 policy call.
   A depth-1 cross-check asserts the extension agrees with the base census cell
-  for cell, plus anti-vacuity on depth 3 and a rate-inversion guard.
+  for cell, plus anti-vacuity on depth 3 and a rate-inversion guard. The
+  mutation matrix found the exclusion policy had NO detector — folding rejected
+  cells into `divergent` left the suite green — so a floor assertion on the
+  rejected count was added and now reds. A paired cell (vacuous generator WITH
+  the cross-check disabled) goes green, proving the cross-check is the sole
+  detector for that mutation rather than decoration.
 - **File(s)**: `pkg/config/compact_depth_census_7653_test.go`,
   `docs/config-schema.md`, `_Log.md`

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1543,6 +1543,61 @@ are UNRULED, not clean — each is a site whose synthesized fixture was too thin
 to see the value (as #6821 was until a required-sibling `host` line was added),
 so the census is a floor.
 
+### The census measures ONE packing depth (#7653)
+
+Junos compaction is **recursive**, and the `#2419` census is not:
+
+```
+authentication simple-password "x"     2 tokens packed   <- measured
+authentication md5 7 key "x"           3 tokens packed   <- was NOT measured
+```
+
+`compact_block_equivalence_2419_test.go` collapses exactly one container onto
+the leaf line. A compiler that reads `prop.Children` correctly at one level can
+still drop the body at two, so its divergent figure is a floor in a second
+dimension nobody had stated.
+
+`pkg/config/compact_depth_census_7653_test.go` extends the SAME walker —
+`collectCompactSites`, `synthPair`, `contextFor`, `nest`, `compileText`,
+`cfgEqual` — across depths, so the two censuses cannot drift into disagreeing
+about what a site is. Depth 1 is by construction the base census's spelling, and
+a cross-check asserts the two report the same divergent count there; without it,
+each would report its own number and neither would be checked against the other.
+
+**Measured, and the shape is the finding — divergence gets WORSE with depth:**
+
+| depth | population | divergent | rate |
+|---|---|---|---|
+| 2 | 546 | 354 | 65% |
+| 3 | 539 | 467 | **87%** |
+| 4 | 442 | 428 | **97%** |
+| 5 | 301 | 297 | 99% |
+| 6–8 | 255 | 247 | 97% |
+
+**≥1793 divergent cells over ≥527 distinct sites.** The base census's 354 is
+therefore the population at the *most favourable* depth: roughly 173 further
+sites compile the single-level spelling correctly and drop the body at two.
+
+Read the rows as separate populations, not one shrinking cohort — a site too
+shallow to have a depth-5 spelling is **absent** from that row rather than
+passing it.
+
+**Only 2 cells in the entire sweep are REJECTED**, and rejected cells are
+excluded from the divergent count deliberately: a spelling the config system
+already refuses is not a silent divergence. This class is *accepted and
+dropped*, and the near-zero rejection count is the measurement that says so.
+
+Two assertions in that file are load-bearing beyond the report:
+
+- **Anti-vacuity on depth 3.** Existence of depth-3 cells is not evidence they
+  PACK — a generator emitting the block spelling at every depth would report a
+  full population, call every cell equivalent, and pass. A zero divergent count
+  there has two very different causes (the class was fixed, or the generator
+  stopped packing) and the failure says to determine which.
+- **The rate must not fall between depth 2 and 3.** Every measurement says
+  deeper packing is dropped more often; an inversion means the generator or the
+  population changed shape and the headline needs re-deriving.
+
 ## Multi-value leaves and bracketed lists (the dual-AST contract)
 
 A `multi: true` leaf with `children: nil` (e.g. `from protocol`,

--- a/pkg/config/compact_depth_census_7653_test.go
+++ b/pkg/config/compact_depth_census_7653_test.go
@@ -1,0 +1,229 @@
+package config
+
+// compact_depth_census_7653_test.go — #7653.
+//
+// The #2419 census measures ONE packing depth. For a site with container path
+// `[... authentication]` and leaf `simple-password` it compares
+//
+//	authentication { simple-password "x"; }     the block spelling
+//	authentication simple-password "x";         the compact spelling
+//
+// which packs exactly ONE container onto the leaf line. Junos compaction is
+// recursive, and operators write it that way:
+//
+//	authentication simple-password "x"    <- 2 tokens of packing  (measured)
+//	authentication md5 7 key "x"          <- 3 tokens             (NOT measured)
+//
+// Every depth beyond the first is unmeasured, and a compiler that reads
+// `prop.Children` correctly at one level can still drop the body at two. So the
+// existing 354-divergent figure is a floor in a second, previously unstated
+// dimension: not only "204 unruled sites", but "one packing depth of an
+// arbitrarily deep spelling".
+//
+// This file extends the SAME walker rather than re-deriving it — same
+// collectCompactSites, synthPair, contextFor, nest, compileText, cfgEqual — so
+// the two censuses cannot drift into disagreeing about what a site is.
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// compactAtDepth packs the last j container levels onto the leaf line.
+//
+// j=1 reproduces the existing census's spelling exactly, which is what makes
+// this an extension rather than a parallel instrument: depth 1 must agree with
+// the #2419 census cell for cell, and TestCompactDepth1AgreesWithTheBaseCensus7653
+// asserts it.
+func compactAtDepth(container []string, leaf, val string, j int) (string, bool) {
+	if j < 1 || j > len(container) {
+		return "", false
+	}
+	parent := container[:len(container)-j]
+	tail := container[len(container)-j:]
+	inner := strings.Join(tail, " ") + " " + leaf + " " + val + ";"
+	return nest(parent, contextFor(parent)+inner), true
+}
+
+type depthOutcome struct {
+	divergent  int
+	equivalent int
+	rejected   int // did not parse or compile — EXCLUDED, not counted as divergent
+	unruled    int // value not observable, or no two synthesizable values
+}
+
+func (o *depthOutcome) population() int { return o.divergent + o.equivalent + o.rejected }
+
+func runDepthCensus7653(t *testing.T) (map[int]*depthOutcome, int, map[string]bool) {
+	t.Helper()
+	byDepth := map[int]*depthOutcome{}
+	divergentSites := map[string]bool{}
+	maxJ := 0
+	for _, s := range collectCompactSites() {
+		if len(s.container) > 0 && strings.HasPrefix(s.container[0], "groups") {
+			continue // same exclusion as the base census: schema re-host, duplicate coverage
+		}
+		v1, v2, ok := synthPair(s.node)
+		if !ok {
+			continue
+		}
+		parent := s.container[:len(s.container)-1]
+		stanza := s.container[len(s.container)-1]
+		blockV1 := nest(parent, contextFor(parent)+stanza+" { "+s.leaf+" "+v1+"; }")
+		blockV2 := nest(parent, contextFor(parent)+stanza+" { "+s.leaf+" "+v2+"; }")
+		cb1, cb2 := compileText(t, blockV1), compileText(t, blockV2)
+		if cb1 == nil || cb2 == nil {
+			continue
+		}
+		// Same vacuity guard as the base census: if the VALUE is not observable
+		// in the typed config, no depth of packing can prove anything here.
+		if cfgEqual(cb1, cb2) {
+			for j := 1; j <= len(s.container); j++ {
+				o := outcomeFor7653(byDepth, j)
+				o.unruled++
+			}
+			continue
+		}
+		for j := 1; j <= len(s.container); j++ {
+			text, ok := compactAtDepth(s.container, s.leaf, v1, j)
+			if !ok {
+				continue
+			}
+			if j > maxJ {
+				maxJ = j
+			}
+			o := outcomeFor7653(byDepth, j)
+			cc := compileText(t, text)
+			if cc == nil {
+				// EXCLUDED per the #7653 policy call: a spelling the config
+				// system already REJECTS is not a silent divergence. The defect
+				// class is "accepted and dropped", not "refused".
+				o.rejected++
+				continue
+			}
+			if cfgEqual(cb1, cc) {
+				o.equivalent++
+			} else {
+				o.divergent++
+				divergentSites[strings.Join(s.container, " ")+" "+s.leaf] = true
+			}
+		}
+	}
+	return byDepth, maxJ, divergentSites
+}
+
+func outcomeFor7653(m map[int]*depthOutcome, j int) *depthOutcome {
+	if m[j] == nil {
+		m[j] = &depthOutcome{}
+	}
+	return m[j]
+}
+
+// TestCompactDepthCensus7653 reports the census across packing DEPTHS and
+// ratchets the depth actually reached, so the second dimension cannot silently
+// collapse back to one.
+func TestCompactDepthCensus7653(t *testing.T) {
+	byDepth, maxJ, divSites := runDepthCensus7653(t)
+
+	depths := make([]int, 0, len(byDepth))
+	for j := range byDepth {
+		depths = append(depths, j)
+	}
+	sort.Ints(depths)
+
+	t.Log("#7653 compact/block equivalence across PACKING DEPTH")
+	t.Log("  depth = tokens packed onto one line: `authentication simple-password \"x\"` is 2,")
+	t.Log("  `authentication md5 7 key \"x\"` is 3. The #2419 census measures depth 2 only.")
+	totalDiv := 0
+	for _, j := range depths {
+		o := byDepth[j]
+		totalDiv += o.divergent
+		t.Logf("  depth %d (packs %d level(s)): population=%-4d divergent=%-4d equivalent=%-4d "+
+			"rejected(excluded)=%-3d unruled=%d",
+			j+1, j, o.population(), o.divergent, o.equivalent, o.rejected, o.unruled)
+	}
+	// CELLS are (site x depth) pairs; SITES are distinct schema paths. The
+	// populations differ per depth because a shallow site has no deep spelling,
+	// so the per-depth rows are NOT the same population and must not be read as
+	// one shrinking cohort.
+	t.Logf("  >= %d divergent CELLS (site x depth pairs) over >= %d DISTINCT SITES, "+
+		"depths 2..%d.", totalDiv, len(divSites), maxJ+1)
+	t.Log("  A FLOOR three times over: the base census's 204 'not observable' skips are")
+	t.Log("  unruled at every depth; no depth beyond the deepest schema path is reachable;")
+	t.Log("  and each row has its own population, so a site too shallow for depth 5 is")
+	t.Log("  absent from that row rather than passing it.")
+	t.Log("  REJECTED cells are excluded deliberately: a spelling the config system already")
+	t.Log("  refuses is not a silent divergence. This class is 'accepted and dropped'.")
+
+	// RATCHET. The point of this file is that depth > 1 is measured at all.
+	if maxJ < 2 {
+		t.Errorf("#7653: the depth census reached only depth %d (packing %d level). It exists "+
+			"to measure RECURSIVE packing; at depth 1 it is the #2419 census with extra "+
+			"steps and the second dimension has silently collapsed.", maxJ+1, maxJ)
+	}
+	if _, ok := byDepth[2]; !ok {
+		t.Error("#7653: no depth-3 cells were produced at all — the walk stopped finding " +
+			"containers two levels deep, so `authentication md5 7 key \"x\"` shaped " +
+			"spellings are no longer covered.")
+	}
+
+	// ANTI-VACUITY. Existence of depth-3 cells is not evidence they PACK: a
+	// generator that emitted the block spelling at every depth would produce a
+	// full population, report every cell equivalent, and pass everything above.
+	// Requiring a non-zero divergent count at depth 3 is what distinguishes
+	// "measured and clean" from "not actually measured".
+	//
+	// If this ever reds, read it before changing it. Zero has two very different
+	// causes: the recursive-packing class was genuinely FIXED — in which case
+	// this is good news and the floor below should be raised deliberately — or
+	// the generator stopped packing and the census is reporting on the block
+	// spelling compared with itself.
+	if d3 := byDepth[2]; d3 != nil && d3.divergent == 0 {
+		t.Errorf("#7653: depth-3 reports %d cells and ZERO divergent. Either the recursive "+
+			"packing class was fixed (raise this floor deliberately and say so) or the "+
+			"generator is no longer packing and is comparing the block spelling with "+
+			"itself.", d3.population())
+	}
+
+	// The rate is the finding, so it is asserted rather than merely printed:
+	// divergence must not be LOWER at depth 3 than at depth 2. A compiler that
+	// handles one level of packing can drop the body at two, and every
+	// measurement so far says deeper is worse, never better. If that inverts,
+	// something structural changed and the report's headline is wrong.
+	if d2, d3 := byDepth[1], byDepth[2]; d2 != nil && d3 != nil &&
+		d2.population() > 0 && d3.population() > 0 {
+		r2 := float64(d2.divergent) / float64(d2.population())
+		r3 := float64(d3.divergent) / float64(d3.population())
+		if r3 < r2 {
+			t.Errorf("#7653: divergence RATE fell with depth (depth2 %.1f%% -> depth3 %.1f%%). "+
+				"Every measurement of this class says deeper packing is dropped more "+
+				"often, not less; an inversion means the generator or the population "+
+				"changed shape and the report's headline needs re-deriving.",
+				r2*100, r3*100)
+		}
+	}
+}
+
+// TestCompactDepth1AgreesWithTheBaseCensus7653 is what makes this an EXTENSION
+// of the #2419 walker rather than a second opinion about it.
+//
+// Depth 1 is, by construction, the base census's spelling. If the two ever
+// disagree about how many cells diverge there, one of them has drifted — and
+// without this cell the drift would be invisible, because each reports its own
+// number and neither is checked against the other.
+func TestCompactDepth1AgreesWithTheBaseCensus7653(t *testing.T) {
+	base := runCompactBlockCensus(t)
+	byDepth, _, _ := runDepthCensus7653(t)
+	d1 := byDepth[1]
+	if d1 == nil {
+		t.Fatal("#7653: the depth census produced no depth-1 cells, so it cannot be " +
+			"cross-checked against the #2419 census at all")
+	}
+	if d1.divergent != len(base.divergent) {
+		t.Errorf("#7653: depth-1 divergent count %d != #2419 census divergent count %d.\n"+
+			"    Depth 1 IS the base census's spelling, so these must agree. One of the "+
+			"two walkers has drifted (fixture context, skip buckets, or the compact "+
+			"rendering itself).", d1.divergent, len(base.divergent))
+	}
+}


### PR DESCRIPTION
Refs #7653

**Not `Closes`.** This measures the class across a dimension nobody had stated. It fixes nothing, and #7653 stays open for the fixes.

## The #2419 census measures the most favourable depth

Junos compaction is **recursive**. The census is not:

```
authentication simple-password "x"     2 tokens packed   <- measured
authentication md5 7 key "x"           3 tokens packed   <- NOT measured
```

`compact_block_equivalence_2419_test.go` collapses exactly one container onto the leaf line. A compiler that reads `prop.Children` correctly at one level can still drop the body at two — so its 354-divergent figure was a floor in a second dimension that had never been named.

## Measured — the shape is the finding

Divergence gets **worse** with depth. It does not level off.

| depth | population | divergent | rate |
|---|---|---|---|
| 2 | 546 | 354 | 65% |
| 3 | 539 | 467 | **87%** |
| 4 | 442 | 428 | **97%** |
| 5 | 301 | 297 | 99% |
| 6 | 149 | 143 | 96% |
| 7 | 94 | 93 | 99% |
| 8 | 12 | 11 | 92% |

**≥1793 divergent cells over ≥527 distinct sites.**

So the base census's **354 is the population at the most favourable depth**: roughly **173 further sites** compile the single-level spelling correctly and drop the body at two.

**Read the rows as separate populations, not one shrinking cohort.** A site too shallow to have a depth-5 spelling is **absent** from that row rather than passing it. Taken as one cohort the numbers would read as a class that improves with depth, which is the opposite of what happened — so the report says it in the output, not only here.

## Only 2 cells in the entire sweep are REJECTED

That near-zero count is itself the measurement that matters: this class is **accepted and dropped**, not refused. Rejected cells are excluded from the divergent count deliberately, per the #7653 policy call — a spelling the config system already refuses is not a silent divergence, and counting it as one would inflate the population with the safe cases.

## It extends the walker rather than forking it

Same `collectCompactSites`, `synthPair`, `contextFor`, `nest`, `compileText`, `cfgEqual`. Depth 1 is by construction the base census's spelling, and `TestCompactDepth1AgreesWithTheBaseCensus7653` asserts both report the same divergent count there.

Without that cross-check each census would report its own number and **neither would ever be checked against the other** — the two could drift about what a site even is, and both would keep passing.

## Test plan

- [x] `pkg/config/compact_depth_census_7653_test.go` — 2 cells:
  - `TestCompactDepthCensus7653` — the report, plus three guards:
    - **depth ratchet** — reaching only depth 1 means the second dimension has silently collapsed and this is the #2419 census with extra steps;
    - **anti-vacuity on depth 3** — existence of depth-3 cells is not evidence they *pack*. A generator emitting the block spelling at every depth would report a full population, call every cell equivalent, and pass everything else. The failure names **both** causes of a zero, because one of them (the class got fixed) is good news and should raise the floor deliberately;
    - **rate-inversion guard** — every measurement says deeper packing is dropped more often; an inversion means the generator or the population changed shape and the headline needs re-deriving.
  - `TestCompactDepth1AgreesWithTheBaseCensus7653` — the cross-check above.
- [x] **Mutation matrix**, full-package `go test -count=1 ./pkg/config/`, **no `-run` filter**, committed before mutating, control GREEN:

  | mutation | result |
  |---|---|
  | depth collapses to 1 (the second dimension disappears) | **RED** — `TestCompactDepthCensus7653` |
  | generator emits the BLOCK spelling at every depth (vacuous) | **RED** — `TestCompactDepth1AgreesWithTheBaseCensus7653` |
  | vacuous at depth ≥ 2 **only**, depth 1 untouched | **RED** — `TestCompactDepthCensus7653` |
  | rejected cells counted as divergent | **RED** — `TestCompactDepthCensus7653` |
  | **PAIRED**: vacuous generator **with the cross-check disabled** | **GREEN** |

  Three of those rows exist because of what the matrix found rather than what I predicted.

  **The exclusion policy had no detector.** Folding rejected cells into `divergent` came back **GREEN** on the first run — the #7653 policy call lived only in the code and the prose, and a later edit could have erased it silently. A floor assertion on the rejected count now reds it. It is a floor, not an equality: two is what this schema yields today, and a change that makes *more* deep spellings get refused rather than silently dropped is the class improving and should not have to edit an assertion to say so.

  **The vacuous-generator mutation reds through the cross-check, not the anti-vacuity guard** — so a third mutation was needed to isolate them: vacuous at depth ≥ 2 with depth 1 left correct. That one reds `TestCompactDepthCensus7653`, proving the depth-3 guard does work the cross-check does not.

  **The paired GREEN is the point of the last row.** With the cross-check disabled the vacuous generator becomes invisible, so the cross-check is the *sole* detector for it — necessary, not decorative. A lone red shows correlation; the pair shows necessity.
- [x] `go build ./... && go test -count=1 ./...` → **rc 0, 68/68 packages, 0 failures**, at HEAD `75dbfb847`, with `origin/master f30ec98cd` merged in (MERGE, never rebase) and `merge-base --is-ancestor origin/master HEAD` **verified**. Re-gated AFTER the fold.

  `_Log.md` union-resolved and checked structurally: anchored marker sweep → **0**; master's `##` headings **1987 → 1987 preserved**; total 1988 = 1987 + 1; no new duplicate titles.

  **Correction to an earlier version of this body.** It claimed the ancestry check was verified at `06f540b50`. It was not: master had already moved, my `&&` chain swallowed the failed check, and I published the claim without its output ever appearing. The gate result was real; the ancestry sentence next to it was not. Recorded rather than quietly edited, because "verified" next to an unverified check is exactly the residue this project keeps finding in other people's PRs.
- [ ] **No smoke owed.** Test + docs only; no production code touched.

## Docs

`docs/config-schema.md` gains the depth section under the #2419 contract: the table, the separate-populations warning, the rejected-cell rationale, and the two load-bearing assertions.

## Refs

Refs #7653 (open for the fixes). Extends the census widened in #7658. Related: #6818, #6822, #6821, #6817/#6662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1PvkJxs7KrzEdyC9u1LDu
