### PR TITLE
config: implement per-stream syslog source-interface (#6875)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -107031,3 +107031,7 @@ prose edit above them added. No diff falls in the new test body.
 - **Timestamp**: 2026-08-27
   - **Action**: committed `opus-review-001.md` into `docs/reviews/recovered/`. Two OPEN issues (#6813, #6751) cite it and it existed only outside the repo, so their evidence was unreachable to anyone but the machine that produced it.
   - **File(s)**: docs/reviews/recovered/opus-review-001.md
+
+- **Timestamp**: 2026-08-27
+  - **Action**: #6875 — `security log stream <s> source-interface` is now modelled, validated, compiled and honoured at apply time, with precedence source-address > source-interface > global. The #3349 happy-path entry now asserts the compiled value instead of a clean commit.
+  - **File(s)**: pkg/config/types_security.go, pkg/config/schema_security.go, pkg/config/compiler_security_log.go, pkg/daemon/daemon_system.go, pkg/config/log_stream_config_3349_test.go, pkg/config/log_stream_source_interface_6875_test.go, docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -8123,8 +8123,29 @@ reserved for whole-dataplane selection where a rewrite shim
   (`error|warning|info`, matching `pkg/logging` `ParseSeverity`), `facility`
   (the `ParseFacility` set incl. `local0..7`/`change-log`), `category`
   (`all|session|policy|screen|firewall`, matching `ParseCategory`), and
-  `source-address` (`ValueIPAddress`). `source-interface` uses
-  `ValidateSyslogSourceInterface`, which rejects a non-numeric `.<unit>`
+  `source-address` (`ValueIPAddress`). **`source-interface` is modelled at BOTH
+  levels since #6875** — `security log source-interface` (global) and `security
+  log stream <s> source-interface` (per stream), sharing one validator. The
+  per-stream spelling previously parsed as an unmodelled keyword (the `stream`
+  subtree is open-world), compiled to nothing, and committed clean while the
+  stream sourced from the global setting or from nothing; a happy-path test
+  pinned that no-op as valid. Apply-time precedence is **`source-address` >
+  `source-interface` > global `source-interface`** (`daemon_system.go`): an
+  explicitly configured address beats one derived from an interface, and both
+  beat the global fallback. A per-stream `source-interface` that resolves to no
+  address falls through to the global rather than pinning the stream to "" —
+  resolution reads interface state, so an interface that is merely not up yet
+  must not permanently strip a source the operator did configure globally.
+
+  Worth knowing when reading either level: `ResolveSyslogSourceAddr` consults
+  only `unit.PrimaryAddress` from config, and a plain `address` line populates
+  `Addresses` while leaving `PrimaryAddress` empty. So a unit configured
+  without an explicit `primary` resolves to "" from config and depends on the
+  kernel-lookup fallback. That is pre-existing behaviour of the global feature,
+  not something #6875 introduced, and it is why the #6875 precedence tests set
+  `primary` explicitly.
+
+  `ValidateSyslogSourceInterface` rejects a non-numeric `.<unit>`
   suffix (`resolveSourceAddr` silently `Atoi`-fell-back to unit 0, binding the
   wrong source IP) AND, since #6218 item 7, a `.<unit>` above `MaxLogicalUnit`
   (16385) — e.g. `ge-0-0-0.50000` — which previously committed even though no

--- a/pkg/cli/apply.go
+++ b/pkg/cli/apply.go
@@ -119,7 +119,17 @@ func buildSyslogClients(cfg *config.Config) []*logging.SyslogClient {
 	}
 	var clients []*logging.SyslogClient
 	for name, stream := range cfg.Security.Log.Streams {
+		// #6875: MIRROR of daemon.applySyslogConfig. #5738 exists because these
+		// two paths must bind the same source — an in-process CLI commit and a
+		// daemon reconcile that disagree is the defect that issue closed — so
+		// the per-stream source-interface arm belongs at both sites or neither.
+		// TestSyslogSourcePrecedenceMatchesDaemon_6875 pins the agreement.
+		//
+		//	source-address  >  source-interface  >  global source-interface
 		srcAddr := stream.SourceAddress
+		if srcAddr == "" && stream.SourceInterface != "" {
+			srcAddr = config.ResolveSyslogSourceAddr(cfg, stream.SourceInterface)
+		}
 		if srcAddr == "" {
 			srcAddr = globalSourceAddr
 		}

--- a/pkg/cli/syslog_stream_source_iface_6875_test.go
+++ b/pkg/cli/syslog_stream_source_iface_6875_test.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6875 + #5738: the per-stream `source-interface` must bind the same source on
+// the CLI in-process commit path as on the daemon reconcile path.
+//
+// This exists because the precedence is implemented TWICE — daemon
+// applySyslogConfig and cli buildSyslogClients — and #5738 is the issue that
+// closed a divergence between exactly those two. A change to one and not the
+// other is invisible to any test that only drives one of them, and the symptom
+// is that an operator's audit stream sources differently depending on whether
+// the config arrived by CLI commit or by reconcile.
+func TestSyslogSourcePrecedenceMatchesDaemon_6875(t *testing.T) {
+	// `primary` is what ResolveSyslogSourceAddr actually reads; a unit with
+	// Addresses but no PrimaryAddress resolves to "" from config.
+	base := func() *config.Config {
+		cfg := &config.Config{}
+		cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+			"reth1": {Name: "reth1", Units: map[int]*config.InterfaceUnit{
+				100: {Number: 100, Addresses: []string{"10.0.1.20/24"}, PrimaryAddress: "10.0.1.20/24"},
+			}},
+			"reth2": {Name: "reth2", Units: map[int]*config.InterfaceUnit{
+				0: {Number: 0, Addresses: []string{"10.0.2.30/24"}, PrimaryAddress: "10.0.2.30/24"},
+			}},
+		}
+		return cfg
+	}
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*config.Config)
+		want   string
+	}{
+		{
+			// The new arm. Before #6875 this bound "" (or the global), because
+			// the leaf compiled to nothing.
+			name: "per-stream source-interface resolves",
+			mutate: func(c *config.Config) {
+				c.Security.Log.Streams["audit"].SourceInterface = "reth1.100"
+			},
+			want: "10.0.1.20",
+		},
+		{
+			// Precedence rung 1: an explicit address beats a derived one.
+			name: "source-address beats source-interface",
+			mutate: func(c *config.Config) {
+				c.Security.Log.Streams["audit"].SourceAddress = "192.0.2.7"
+				c.Security.Log.Streams["audit"].SourceInterface = "reth1.100"
+			},
+			want: "192.0.2.7",
+		},
+		{
+			// Precedence rung 3: the global still wins over nothing. Without
+			// this cell, an implementation that ignored the global entirely
+			// would pass the two above.
+			name: "global remains the fallback",
+			mutate: func(c *config.Config) {
+				c.Security.Log.SourceInterface = "reth2.0"
+			},
+			want: "10.0.2.30",
+		},
+		{
+			// Precedence rung 2 against rung 3 — the discriminating pair. Both
+			// are set, and only a correct ranking produces reth1's address.
+			name: "per-stream source-interface beats the global",
+			mutate: func(c *config.Config) {
+				c.Security.Log.SourceInterface = "reth2.0"
+				c.Security.Log.Streams["audit"].SourceInterface = "reth1.100"
+			},
+			want: "10.0.1.20",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base()
+			cfg.Security.Log.Streams = map[string]*config.SyslogStream{
+				"audit": {
+					Name:      "audit",
+					Host:      "127.0.0.1",
+					Port:      1,
+					Transport: config.SyslogTransport{Protocol: "tcp"},
+				},
+			}
+			tc.mutate(cfg)
+
+			clients := buildSyslogClients(cfg)
+			if len(clients) != 1 {
+				t.Fatalf("expected 1 syslog client, got %d — the assertion below "+
+					"would otherwise read a client that was never built", len(clients))
+			}
+			if got := clients[0].SourceAddr(); got != tc.want {
+				t.Errorf("CLI path bound source %q, want %q. The daemon path "+
+					"(daemon_system.go) implements the same precedence; a divergence "+
+					"here means an audit stream sources differently depending on "+
+					"whether the config arrived by CLI commit or by reconcile (#5738)",
+					got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/config/compiler_security_log.go
+++ b/pkg/config/compiler_security_log.go
@@ -111,6 +111,12 @@ func compileLog(node *Node, sec *SecurityConfig) error {
 				stream.Category = nodeVal(prop)
 			case "source-address":
 				stream.SourceAddress = nodeVal(prop)
+			case "source-interface":
+				// #6875: compiled so the per-stream spelling reaches the apply
+				// path. It is resolved to an address there, not here, because
+				// resolution reads interface addresses that the compiler does
+				// not own.
+				stream.SourceInterface = nodeVal(prop)
 			case "transport":
 				// #6821: read BOTH spellings. `transport { protocol tls; }`
 				// arrives as children; `transport protocol tls;` packs the

--- a/pkg/config/log_stream_config_3349_test.go
+++ b/pkg/config/log_stream_config_3349_test.go
@@ -97,8 +97,27 @@ func TestLogStream3349_SchemaFields_AcceptValid(t *testing.T) {
 		t.Fatalf("valid log config rejected: %v", err)
 	}
 	// And it must actually compile (strict).
-	if _, err := config.CompileConfig(buildTree3349(t, good...)); err != nil {
+	cfg, err := config.CompileConfig(buildTree3349(t, good...))
+	if err != nil {
 		t.Fatalf("valid log config failed strict compile: %v", err)
+	}
+	// #6875: this list contains `stream s2 source-interface reth1.100`, and
+	// until #6875 the only thing asserted about it was that it COMMITTED. It
+	// compiled to nothing — the stream subtree is open-world, so the leaf
+	// parsed as an unmodelled keyword and no field received it. A happy-path
+	// entry pinning "this commits clean" for a statement with no effect is
+	// worse than no coverage, because it makes the no-op look deliberate.
+	//
+	// Assert the COMPILED value, so this entry now witnesses the feature
+	// instead of witnessing its absence.
+	s2 := cfg.Security.Log.Streams["s2"]
+	if s2 == nil {
+		t.Fatalf("stream s2 did not compile; got streams %v", cfg.Security.Log.Streams)
+	}
+	if s2.SourceInterface != "reth1.100" {
+		t.Errorf("stream s2 SourceInterface = %q, want reth1.100 — the per-stream "+
+			"source-interface must reach the typed config, not be absorbed by the "+
+			"open-world stream subtree (#6875)", s2.SourceInterface)
 	}
 }
 

--- a/pkg/config/log_stream_source_interface_6875_test.go
+++ b/pkg/config/log_stream_source_interface_6875_test.go
@@ -1,0 +1,154 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6875: `security log stream <name> source-interface <x>` committed clean and
+// did nothing. `source-interface` was modelled only under `security log` (top
+// level); the `stream` subtree is OPEN-WORLD, so the per-stream spelling parsed
+// as an unmodelled keyword, `SyslogStream` had no field to receive it, and
+// nothing read it. The operator saw a clean commit and the stream sourced from
+// the global setting or from nothing.
+//
+// Disposition taken: ACCEPT AND IMPLEMENT (option 2 of the issue). The apply
+// path already resolved a per-stream `source-address` with a global fallback,
+// so this is a bounded thread rather than new machinery — which is what made
+// option 2 preferable to marking the leaf inert. Rejecting at commit was
+// declined because it is real Junos syntax and would break importing configs
+// that carry it.
+func TestStreamSourceInterfaceCompiles_6875(t *testing.T) {
+	cfg := compile6875(t,
+		"set security log mode stream",
+		"set security log stream s host 192.0.2.1",
+		"set security log stream s source-interface reth1.100",
+	)
+	s := cfg.Security.Log.Streams["s"]
+	if s == nil {
+		t.Fatalf("stream s did not compile")
+	}
+	if s.SourceInterface != "reth1.100" {
+		t.Errorf("SourceInterface = %q, want reth1.100", s.SourceInterface)
+	}
+}
+
+// The leaf must be VALIDATED now, not merely stored. Before #6875 it was
+// absorbed by the open-world subtree, so a malformed value could not be
+// rejected — there was nothing to reject it against. This is the half that
+// distinguishes "modelled" from "has a field": a struct field alone would
+// accept `reth1.abc` exactly as silently as the open-world path did.
+func TestStreamSourceInterfaceIsValidated_6875(t *testing.T) {
+	for _, bad := range []struct{ name, cmd string }{
+		{"non-numeric unit", "set security log stream s source-interface reth1.abc"},
+		{"unit out of range", "set security log stream s source-interface ge-0-0-0.99999"},
+	} {
+		t.Run(bad.name, func(t *testing.T) {
+			tree := setTree6875(t,
+				"set security log mode stream",
+				"set security log stream s host 192.0.2.1",
+				bad.cmd,
+			)
+			if err := config.SchemaValidate(tree, nil); err == nil {
+				t.Errorf("%q must be REJECTED at commit — the same validator the "+
+					"top-level source-interface uses now applies per stream (#6875)", bad.cmd)
+			}
+		})
+	}
+}
+
+// The precedence chain, which is the part a reviewer should argue with:
+//
+//	source-address  >  source-interface  >  global source-interface
+//
+// An explicitly configured address beats one derived from an interface, and
+// both beat the global fallback. Asserting only the middle rung would leave
+// either end free to change.
+func TestStreamSourceInterfacePrecedence_6875(t *testing.T) {
+	// An interface whose unit carries a primary address, so resolution has
+	// something real to return. Without this the "resolves" cases below would
+	// pass for the wrong reason — an empty resolution falls through to the
+	// global, which is indistinguishable from the global winning outright.
+	base := []string{
+		"set security log mode stream",
+		// `primary` is load-bearing and not decoration: ResolveSyslogSourceAddr
+		// reads ONLY unit.PrimaryAddress from config, and a plain `address`
+		// line populates Addresses while leaving PrimaryAddress empty. Measured
+		// — without it both resolutions below return "" and the cells would
+		// pass or fail for a reason unrelated to #6875. This is a property of
+		// the EXISTING top-level feature, not something #6875 introduces.
+		"set interfaces reth1 unit 100 family inet address 10.9.9.9/24 primary",
+		"set interfaces reth2 unit 0 family inet address 10.8.8.8/24 primary",
+		"set security log source-interface reth2.0",
+	}
+
+	t.Run("source-interface resolves when no source-address", func(t *testing.T) {
+		cfg := compile6875(t, append(append([]string{}, base...),
+			"set security log stream s host 192.0.2.1",
+			"set security log stream s source-interface reth1.100",
+		)...)
+		if got := config.ResolveSyslogSourceAddr(cfg, cfg.Security.Log.Streams["s"].SourceInterface); got != "10.9.9.9" {
+			t.Errorf("per-stream source-interface resolved to %q, want 10.9.9.9", got)
+		}
+	})
+
+	t.Run("source-address wins over source-interface", func(t *testing.T) {
+		cfg := compile6875(t, append(append([]string{}, base...),
+			"set security log stream s host 192.0.2.1",
+			"set security log stream s source-address 10.7.7.7",
+			"set security log stream s source-interface reth1.100",
+		)...)
+		s := cfg.Security.Log.Streams["s"]
+		if s.SourceAddress != "10.7.7.7" {
+			t.Errorf("SourceAddress = %q, want 10.7.7.7", s.SourceAddress)
+		}
+		// Both are present in the typed config; the apply path is what ranks
+		// them, and it consults SourceAddress first. Asserting both survive
+		// compilation is what makes that ranking meaningful — if the compiler
+		// dropped one, the apply-side precedence would be untestable.
+		if s.SourceInterface != "reth1.100" {
+			t.Errorf("SourceInterface = %q, want reth1.100 — both must survive "+
+				"compilation or the apply-path precedence has nothing to rank",
+				s.SourceInterface)
+		}
+	})
+
+	t.Run("global remains the fallback when the stream sets neither", func(t *testing.T) {
+		cfg := compile6875(t, append(append([]string{}, base...),
+			"set security log stream s host 192.0.2.1",
+		)...)
+		s := cfg.Security.Log.Streams["s"]
+		if s.SourceAddress != "" || s.SourceInterface != "" {
+			t.Fatalf("stream should carry neither; got addr=%q iface=%q",
+				s.SourceAddress, s.SourceInterface)
+		}
+		if got := config.ResolveSyslogSourceAddr(cfg, cfg.Security.Log.SourceInterface); got != "10.8.8.8" {
+			t.Errorf("global source-interface resolved to %q, want 10.8.8.8", got)
+		}
+	})
+}
+
+func setTree6875(t *testing.T, cmds ...string) *config.ConfigTree {
+	t.Helper()
+	tree := &config.ConfigTree{}
+	for _, c := range cmds {
+		path, err := config.ParseSetCommand(c)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", c, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", c, err)
+		}
+	}
+	return tree
+}
+
+func compile6875(t *testing.T, cmds ...string) *config.Config {
+	t.Helper()
+	cfg, err := config.CompileConfig(setTree6875(t, cmds...))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return cfg
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -739,6 +739,13 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 				valueType: ValueIPAddress, valueDesc: "source IP address for this stream",
 				valueExamples: []string{"10.0.1.10", "2001:db8::1"},
 				validator:     ValidateIPAddress, children: nil},
+			// #6875: modelled so the leaf is VALIDATED rather than absorbed by
+			// the open-world stream subtree. Before this it parsed as an
+			// unmodelled keyword, committed clean, and was compiled by nothing.
+			"source-interface": {desc: "Interface whose address is used as this stream's syslog source", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>",
+				valueType: ValueIdentifier, valueDesc: "interface name (optionally .<unit>)",
+				valueExamples: []string{"ge-0-0-0", "reth1.100"},
+				validator:     ValidateSyslogSourceInterface, children: nil},
 			// H8 (#2008): transport is fully compiled
 			// (compiler_security.go stream loop) and runtime-honored
 			// (pkg/logging/syslog.go dial), but the schema declared no

--- a/pkg/config/schema_spelling_gate_coverage_7484_test.go
+++ b/pkg/config/schema_spelling_gate_coverage_7484_test.go
@@ -159,7 +159,25 @@ var gateBlindCeiling = map[gateBlindClass]int{
 	// synthetic word. That is why the flag ceiling RISES here — the population
 	// changed, and a blind-spot count going up after a fix is the fix working,
 	// not a regression. Never carry a pre-fix number forward as a target.
-	gateBlindUnreachable: 143,
+	// #6875 raised this 143 -> 144, deliberately, for
+	// `security log stream <*> source-interface`.
+	//
+	// Measured before raising it rather than assumed: a stream with ONLY that
+	// leaf and no sibling `host` compiles to NOTHING —
+	// `cfg.Security.Log.Streams["s"]` is nil — so the differential, which
+	// probes one leaf at a time, sees no output change and can carry no
+	// verdict. That is a property of this stanza requiring a sibling to
+	// materialise, not of the leaf: EVERY existing `stream` leaf
+	// (`severity`, `facility`, `category`, `source-address`) is blind here for
+	// the same reason and is already inside the 143.
+	//
+	// So this cannot be made to compare without changing how the probe
+	// constructs the parent stanza — the #7492-style fix, which is a change to
+	// the gate and not to #6875. The leaf itself is covered behaviourally by
+	// TestStreamSourceInterfaceCompiles_6875, its validator by
+	// TestStreamSourceInterfaceIsValidated_6875, and both apply paths by the
+	// daemon and CLI cells; it is blind to THIS instrument only.
+	gateBlindUnreachable: 144,
 	gateBlindFlag:        175,
 	gateBlindErr:         43,
 	gateBlindValueMoves:  1,

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -339,7 +339,19 @@ type SyslogStream struct {
 	Format        string // per-stream format override
 	Category      string // "all", or specific category
 	SourceAddress string // source IP for this stream
-	Transport     SyslogTransport
+	// SourceInterface is the per-stream `source-interface` (#6875). It is
+	// RESOLVED to an address at apply time, so it is a lower-precedence way of
+	// saying the same thing as SourceAddress:
+	//
+	//	SourceAddress  >  SourceInterface  >  LogConfig.SourceInterface (global)
+	//
+	// An explicitly configured address beats one derived from an interface, and
+	// both beat the global fallback. Before #6875 this leaf parsed (the stream
+	// subtree is open-world) and was compiled by nothing, so a per-stream
+	// source-interface committed clean and the stream sourced from the global
+	// setting or from nothing.
+	SourceInterface string
+	Transport       SyslogTransport
 }
 
 // SSHKnownHostKey represents a known SSH host key.

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -106,7 +106,24 @@ func (d *Daemon) applySyslogConfig(er *logging.EventReader, cfg *config.Config) 
 
 	var clients []*logging.SyslogClient
 	for name, stream := range cfg.Security.Log.Streams {
+		// #6875 precedence: an explicitly configured address beats one derived
+		// from an interface, and both beat the global fallback.
+		//
+		//	source-address  >  source-interface  >  global source-interface
+		//
+		// The per-stream source-interface arm is the new one. Before #6875 the
+		// leaf parsed (the stream subtree is open-world), compiled to nothing,
+		// and the stream silently sourced from globalSourceAddr or from
+		// nothing at all.
+		//
+		// A source-interface that resolves to no address falls through to the
+		// global rather than pinning the stream to "": resolution reads
+		// interface state, so an interface that is merely not up yet must not
+		// permanently strip a source the operator did configure globally.
 		srcAddr := stream.SourceAddress
+		if srcAddr == "" && stream.SourceInterface != "" {
+			srcAddr = config.ResolveSyslogSourceAddr(cfg, stream.SourceInterface)
+		}
 		if srcAddr == "" {
 			srcAddr = globalSourceAddr
 		}

--- a/pkg/daemon/syslog_stream_source_iface_6875_test.go
+++ b/pkg/daemon/syslog_stream_source_iface_6875_test.go
@@ -1,0 +1,84 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/logging"
+)
+
+// #6875 WIRING, daemon side. The compiler storing a per-stream
+// `source-interface` is worth nothing if the apply path does not consult it —
+// which is precisely the defect this issue reports, a value carried to
+// somewhere nothing reads.
+//
+// This drives the real `applySyslogConfig` and reads the source the constructed
+// client actually bound. A mutation matrix showed the earlier cells, all of
+// which lived in pkg/config and asserted compilation, left this hop free: a
+// pre-existing spelling gate noticed the change incidentally, and no cell of
+// mine did.
+//
+// The CLI half is pinned separately by TestSyslogSourcePrecedenceMatchesDaemon_6875;
+// the two paths must agree (#5738) and each needs its own driver.
+func TestApplySyslogConfigHonoursStreamSourceInterface_6875(t *testing.T) {
+	ifaces := func() map[string]*config.InterfaceConfig {
+		return map[string]*config.InterfaceConfig{
+			"reth1": {Name: "reth1", Units: map[int]*config.InterfaceUnit{
+				100: {Number: 100, Addresses: []string{"10.0.1.20/24"}, PrimaryAddress: "10.0.1.20/24"},
+			}},
+			"reth2": {Name: "reth2", Units: map[int]*config.InterfaceUnit{
+				0: {Number: 0, Addresses: []string{"10.0.2.30/24"}, PrimaryAddress: "10.0.2.30/24"},
+			}},
+		}
+	}
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*config.Config)
+		want   string
+	}{
+		{"per-stream source-interface resolves", func(c *config.Config) {
+			c.Security.Log.Streams["audit"].SourceInterface = "reth1.100"
+		}, "10.0.1.20"},
+		{"source-address beats source-interface", func(c *config.Config) {
+			c.Security.Log.Streams["audit"].SourceAddress = "192.0.2.7"
+			c.Security.Log.Streams["audit"].SourceInterface = "reth1.100"
+		}, "192.0.2.7"},
+		{"per-stream source-interface beats the global", func(c *config.Config) {
+			c.Security.Log.SourceInterface = "reth2.0"
+			c.Security.Log.Streams["audit"].SourceInterface = "reth1.100"
+		}, "10.0.1.20"},
+		{"global remains the fallback", func(c *config.Config) {
+			c.Security.Log.SourceInterface = "reth2.0"
+		}, "10.0.2.30"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			er := logging.NewEventReader(nil, nil)
+			cfg := &config.Config{}
+			cfg.Interfaces.Interfaces = ifaces()
+			cfg.Security.Log.Mode = "stream"
+			cfg.Security.Log.Streams = map[string]*config.SyslogStream{
+				"audit": {
+					Name:      "audit",
+					Host:      "127.0.0.1",
+					Port:      1,
+					Transport: config.SyslogTransport{Protocol: "tcp"},
+				},
+			}
+			tc.mutate(cfg)
+
+			d := &Daemon{}
+			d.applySyslogConfig(er, cfg)
+
+			clients := er.SyslogClients()
+			if len(clients) != 1 {
+				t.Fatalf("expected 1 syslog client after apply, got %d — the assertion "+
+					"below would otherwise read a client that was never constructed",
+					len(clients))
+			}
+			if got := clients[0].SourceAddr(); got != tc.want {
+				t.Errorf("daemon apply bound source %q, want %q (#6875)", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #6875

## Disposition: option 2 (accept and implement), chosen from the runtime

`set security log stream <name> source-interface <x>` committed clean and did nothing. The leaf was modelled only under `security log` (top level); the `stream` subtree is **open-world**, so the per-stream spelling parsed as an unmodelled keyword, `SyslogStream` had no field to receive it, and nothing read it.

`daemon_system.go` already resolved a per-stream `source-address` with a global fallback, so this is a **bounded thread through an existing shape** rather than new machinery — which is what tipped it over option 3 (mark the leaf inert). Option 1 (reject at commit) was declined because this is real Junos syntax and rejecting it breaks importing configs that carry it.

## Precedence — the reviewable decision

```
source-address  >  source-interface  >  global source-interface
```

An explicitly configured address beats one derived from an interface, and both beat the global fallback. A per-stream `source-interface` that resolves to no address **falls through to the global** rather than pinning the stream to `""` — resolution reads interface state, so an interface merely not up yet must not permanently strip a source the operator did configure globally.

## The find that mattered most: the precedence is implemented TWICE

`daemon.applySyslogConfig` **and** `cli.buildSyslogClients` both carry it — and **#5738 is the issue that closed a divergence between exactly those two paths**. Changing one and not the other is invisible to any test driving only one, and the symptom is an audit stream sourcing differently depending on whether the config arrived by CLI commit or daemon reconcile. Both sites are changed, and `TestSyslogSourcePrecedenceMatchesDaemon_6875` pins the agreement.

## Mutation matrix — full package, `-count=1`, no `-run` filter, fix committed first

| cell | mutation | verdict |
|---|---|---|
| S1 | compiler: drop the `SourceInterface` assignment | **RED** |
| S2 | schema: remove the leaf (back to open-world) | **RED** |
| S3 | daemon apply: drop the per-stream resolution | **RED** |
| S4 | daemon apply: drop rung 1 (`source-address` first) | **RED** |
| W1 | CLI apply: drop the per-stream resolution | **RED** |
| W2 | CLI apply: drop rung 1 | **RED** |

**S3 initially reddened only a pre-existing spelling gate, not any cell of mine** — every test I had written lived in `pkg/config` and asserted compilation, so the hop from the typed field to the constructed client was free. That is the same "complete at both ends, connected by nothing" shape as the issue itself. Fixed by driving the real `applySyslogConfig` and reading the source the client actually bound.

## The #3349 test no longer pins the no-op

Its valid list contained `stream s2 source-interface reth1.100` and asserted only that the list **committed** — a happy-path entry pinning "this commits clean" for a statement with no effect, which is worse than no coverage because it makes the no-op look deliberate. It now asserts the **compiled value**.

**One correction to the issue:** it also cites `parser_security_test.go:3347` as carrying the same shape. That line is the **top-level** `source-interface`; a search for a per-stream spelling in that file finds none. Only the #3349 entry needed changing.

## The #7484 ceiling was raised by one, deliberately

The coverage ratchet reddened. Measured before raising it: a stream carrying only `source-interface` and no sibling `host` compiles to **nothing** (`Streams["s"]` is nil), so the one-leaf-at-a-time differential sees no output change and can carry no verdict. That is a property of the stanza needing a sibling to materialise — **every existing `stream` leaf is blind to that instrument for the same reason** and already sits inside the old 143. Making it compare means changing how the probe builds the parent stanza, which is a change to the gate, not to this issue. Blind to that instrument, covered by six mutation-bound cells.

## Two things found along the way

- A `SourceAddr()` accessor I nearly added **already existed**, added for #5738 with a doc comment describing this exact use. Grepping for the wrong receiver name is how it was missed; the duplicate is removed and `pkg/logging` is untouched in this diff.
- `ResolveSyslogSourceAddr` consults only `unit.PrimaryAddress`, while a plain `address` line populates `Addresses` and leaves `PrimaryAddress` empty — so a unit without an explicit `primary` resolves to `""` from config and depends on the kernel-lookup fallback. **Pre-existing behaviour of the global feature**, not introduced here, and the reason the precedence tests set `primary` explicitly. Recorded in `docs/config-schema.md`.

## Validation

- `go test ./... -count=1` — **rc=0, 68 packages, 0 FAIL**
- Go-only; **0 files under `userspace-dp/`**, so no cargo leg is owed
- `docs/config-schema.md` updated with both levels, the precedence, and the `PrimaryAddress` caveat
