### PR TITLE
daemon: diagnose a host rename xpfd did not perform (#6863)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -107056,3 +107056,7 @@ prose edit above them added. No diff falls in the new test body.
   detector for that mutation rather than decoration.
 - **File(s)**: `pkg/config/compact_depth_census_7653_test.go`,
   `docs/config-schema.md`, `_Log.md`
+
+- **Timestamp**: 2026-08-27
+  - **Action**: #6863 — a watcher on the existing 30s management reassert tick records the stale-mgmt-cert debt when the kernel host name moves without xpfd renaming it. Baseline moves under the same lock as xpfd's own rename so one rename cannot produce two debts.
+  - **File(s)**: pkg/daemon/external_hostname_watch_6863.go, pkg/daemon/mgmt_listener_reassert.go, pkg/daemon/management.go, pkg/daemon/daemon.go

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -371,6 +371,21 @@ type Daemon struct {
 	//
 	// Guarded by staleCertMu.
 	staleCertPending bool
+	// lastSeenHostName is the kernel host name as of the last observation, used
+	// to detect a rename xpfd did NOT perform (#6863).
+	//
+	// Guarded by staleCertMu, and moved by renameHostNotingStaleMgmtCert under
+	// that same hold. That is what keeps the watcher from double-firing on the
+	// daemon's own renames: applyHostname already records the debt and delivers,
+	// so if the baseline did not move with it the next tick would see the new
+	// name as external and record a second debt for one rename — the duplicate
+	// WARN the #6827 generation fence exists to prevent, reintroduced from
+	// outside.
+	//
+	// Empty means "not yet observed": the first observation seeds the baseline
+	// and records nothing, because a daemon that has just started has no earlier
+	// name to have been renamed FROM.
+	lastSeenHostName string
 	// staleCertGen advances on every rename. A delivery claims a generation and
 	// clears the debt only if it is still current, so a rename landing while an
 	// in-flight delivery is unlocked is not settled by that older delivery

--- a/pkg/daemon/external_hostname_watch_6863.go
+++ b/pkg/daemon/external_hostname_watch_6863.go
@@ -1,0 +1,80 @@
+package daemon
+
+import "log/slog"
+
+// noteExternalHostRenameIfAny records a stale-management-certificate debt when
+// the kernel host name has changed WITHOUT xpfd performing the rename (#6863).
+//
+// # Why a watcher and not a hook
+//
+// The #6827 mechanism records the debt in `renameHostNotingStaleMgmtCert`,
+// which is an in-process fence around xpfd's own `sethostname`. Every other way
+// the kernel name can move — `hostnamectl set-hostname`, a direct
+// `sethostname(2)` by another process, a provisioning tool rewriting
+// /etc/hostname, a manual edit plus a reboot — never calls into xpfd, so there
+// is no event to hook and nothing ever sets the flag. Making that flag survive
+// longer or drain at more points cannot help.
+//
+// The boot path does not close it either: `applyHostname` returns early when
+// the kernel name already equals the configured one, which is exactly the state
+// an external rename leaves behind when it happens to match config.
+//
+// # Why it cannot double-fire on our own renames
+//
+// The baseline moves inside `renameHostNotingStaleMgmtCert`, under the same
+// single hold of staleCertMu that sets the flag. So a rename xpfd performs
+// advances the baseline atomically with the debt it already recorded, and this
+// watcher never sees it as external. Without that, one rename would produce two
+// debts and two WARNs — the duplicate the #6827 generation fence exists to
+// prevent, arriving from outside it.
+//
+// # Seeding
+//
+// An empty baseline means "not yet observed". The first call seeds it and
+// records NOTHING: a daemon that has just started has no earlier name to have
+// been renamed from, and treating boot as a rename would emit a diagnosis on
+// every restart of a box whose certificate is perfectly current.
+//
+// Returns true if a debt was recorded, for the tests. Delivery is the caller's
+// job and happens outside the lock, matching applyHostname.
+func (d *Daemon) noteExternalHostRenameIfAny() bool {
+	current, err := osHostname()
+	if err != nil || current == "" {
+		// An unreadable kernel name is not evidence of a rename. Say nothing
+		// and leave the baseline alone, so a transient read failure cannot
+		// manufacture a diagnosis on the next successful read.
+		return false
+	}
+
+	d.staleCertMu.Lock()
+	prior := d.lastSeenHostName
+	if prior == "" {
+		d.lastSeenHostName = current
+		d.staleCertMu.Unlock()
+		return false
+	}
+	if prior == current {
+		d.staleCertMu.Unlock()
+		return false
+	}
+	d.lastSeenHostName = current
+	d.staleCertPending = true
+	d.staleCertGen++
+	d.staleCertMu.Unlock()
+
+	slog.Info("kernel host name changed outside xpfd",
+		"from", prior, "to", current,
+		"note", "re-checking whether the durable management certificate still covers it")
+	return true
+}
+
+// watchExternalHostRenameOnce is the tick body: observe, and deliver if a debt
+// was recorded.
+//
+// Delivery runs OUTSIDE the lock because deliverStaleMgmtCertDiagnosis takes
+// staleCertMu itself, exactly as applyHostname does after a rename.
+func (d *Daemon) watchExternalHostRenameOnce() {
+	if d.noteExternalHostRenameIfAny() {
+		d.deliverStaleMgmtCertDiagnosis()
+	}
+}

--- a/pkg/daemon/external_hostname_watch_6863_test.go
+++ b/pkg/daemon/external_hostname_watch_6863_test.go
@@ -1,0 +1,202 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func withHostname6863(t *testing.T, name string, err error) {
+	t.Helper()
+	prior := osHostname
+	osHostname = func() (string, error) { return name, err }
+	t.Cleanup(func() { osHostname = prior })
+}
+
+// #6863: the FIRST observation must seed the baseline and record nothing.
+//
+// A daemon that has just started has no earlier name to have been renamed
+// from. Without this, every restart of a box whose certificate is perfectly
+// current would record a debt and emit the diagnosis — the diagnostic-muting
+// failure mode by volume rather than by silence.
+func TestFirstObservationSeedsAndRecordsNothing_6863(t *testing.T) {
+	withHostname6863(t, "fw0", nil)
+	d := &Daemon{}
+
+	if d.noteExternalHostRenameIfAny() {
+		t.Error("the first observation must NOT record a debt")
+	}
+	d.staleCertMu.Lock()
+	defer d.staleCertMu.Unlock()
+	if d.lastSeenHostName != "fw0" {
+		t.Errorf("baseline = %q, want fw0 — the first observation must seed it, or "+
+			"every later tick re-seeds and no rename is ever detected", d.lastSeenHostName)
+	}
+	if d.staleCertPending {
+		t.Error("staleCertPending set on the seeding observation")
+	}
+	if d.staleCertGen != 0 {
+		t.Errorf("staleCertGen = %d, want 0 on the seeding observation", d.staleCertGen)
+	}
+}
+
+// The property under test: a kernel name that moved without xpfd renaming it
+// must record the debt.
+func TestExternalRenameRecordsTheDebt_6863(t *testing.T) {
+	withHostname6863(t, "fw0", nil)
+	d := &Daemon{}
+	d.noteExternalHostRenameIfAny() // seed
+
+	withHostname6863(t, "renamed-by-hostnamectl", nil)
+	if !d.noteExternalHostRenameIfAny() {
+		t.Fatal("an external rename must record a debt — this is the whole gap " +
+			"(#6863): hostnamectl / sethostname(2) / a provisioning rewrite never " +
+			"call into xpfd, so nothing else ever sets the flag")
+	}
+	d.staleCertMu.Lock()
+	defer d.staleCertMu.Unlock()
+	if !d.staleCertPending {
+		t.Error("staleCertPending not set after an external rename")
+	}
+	if d.staleCertGen != 1 {
+		t.Errorf("staleCertGen = %d, want 1", d.staleCertGen)
+	}
+	if d.lastSeenHostName != "renamed-by-hostnamectl" {
+		t.Errorf("baseline = %q, want the new name — otherwise the SAME rename is "+
+			"re-recorded on every subsequent tick", d.lastSeenHostName)
+	}
+}
+
+// A steady name must record nothing, on every tick.
+//
+// Without this, a watcher that recorded unconditionally would satisfy the cell
+// above while emitting the diagnosis every 30 seconds forever.
+func TestUnchangedHostNameRecordsNothing_6863(t *testing.T) {
+	withHostname6863(t, "fw0", nil)
+	d := &Daemon{}
+	d.noteExternalHostRenameIfAny() // seed
+
+	for i := 0; i < 5; i++ {
+		if d.noteExternalHostRenameIfAny() {
+			t.Fatalf("tick %d recorded a debt for an UNCHANGED host name", i)
+		}
+	}
+	d.staleCertMu.Lock()
+	defer d.staleCertMu.Unlock()
+	if d.staleCertGen != 0 {
+		t.Errorf("staleCertGen = %d, want 0 — a steady box must not accumulate "+
+			"generations", d.staleCertGen)
+	}
+}
+
+// The rename xpfd performs ITSELF must not be seen as external.
+//
+// renameHostNotingStaleMgmtCert already records the debt and applyHostname
+// delivers it. If the baseline did not move under that same hold, the next tick
+// would find the new name differing from a stale baseline and record a SECOND
+// debt for one rename — a duplicate WARN arriving from outside the #6827
+// generation fence, which the fence cannot suppress because it is a genuinely
+// newer generation.
+//
+// This is the cell that makes the baseline update in management.go load-bearing
+// rather than incidental.
+func TestOwnRenameIsNotSeenAsExternal_6863(t *testing.T) {
+	priorSet := sethostname
+	sethostname = func([]byte) error { return nil }
+	t.Cleanup(func() { sethostname = priorSet })
+
+	withHostname6863(t, "fw0", nil)
+	d := &Daemon{}
+	d.noteExternalHostRenameIfAny() // seed at fw0
+
+	if err := d.renameHostNotingStaleMgmtCert("fw1"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	// The kernel now reports the new name, as it would after a real sethostname.
+	withHostname6863(t, "fw1", nil)
+
+	genAfterRename := func() uint64 {
+		d.staleCertMu.Lock()
+		defer d.staleCertMu.Unlock()
+		return d.staleCertGen
+	}()
+	if genAfterRename != 1 {
+		t.Fatalf("staleCertGen = %d after our own rename, want 1", genAfterRename)
+	}
+
+	if d.noteExternalHostRenameIfAny() {
+		t.Fatal("the daemon's OWN rename was recorded a second time as external — " +
+			"one rename, two debts, two WARNs (#6863)")
+	}
+	if got := genAfterRename; func() uint64 {
+		d.staleCertMu.Lock()
+		defer d.staleCertMu.Unlock()
+		return d.staleCertGen
+	}() != got {
+		t.Error("the generation advanced on a rename xpfd performed itself")
+	}
+}
+
+// An unreadable kernel name is not evidence of a rename.
+//
+// Without this, a transient read failure would leave the baseline untouched but
+// could otherwise be treated as a change to "", manufacturing a diagnosis on
+// the next successful read.
+func TestUnreadableHostNameRecordsNothing_6863(t *testing.T) {
+	withHostname6863(t, "fw0", nil)
+	d := &Daemon{}
+	d.noteExternalHostRenameIfAny() // seed
+
+	withHostname6863(t, "", errors.New("boom"))
+	if d.noteExternalHostRenameIfAny() {
+		t.Error("an unreadable kernel name must not record a debt")
+	}
+	d.staleCertMu.Lock()
+	defer d.staleCertMu.Unlock()
+	if d.lastSeenHostName != "fw0" {
+		t.Errorf("baseline = %q, want it left at fw0 — a failed read must not move "+
+			"the baseline, or the next successful read looks like a rename",
+			d.lastSeenHostName)
+	}
+}
+
+// #6863 WIRING: the management reassert loop must actually CALL the watcher.
+//
+// Every cell above drives `noteExternalHostRenameIfAny` directly, so all of
+// them pass just as well when nothing invokes it — which is the state this
+// issue reports about #6827's mechanism, one level up. A correct watcher that
+// no tick calls is exactly as useful as no watcher.
+//
+// The loop is driven with a tiny interval and cancelled as soon as the
+// observation lands, so this asserts the call rather than sleeping for one.
+func TestReassertLoopCallsTheHostWatcher_6863(t *testing.T) {
+	priorInterval := mgmtListenerReassertInterval
+	mgmtListenerReassertInterval = time.Millisecond
+	t.Cleanup(func() { mgmtListenerReassertInterval = priorInterval })
+
+	observed := make(chan struct{}, 1)
+	priorHost := osHostname
+	osHostname = func() (string, error) {
+		select {
+		case observed <- struct{}{}:
+		default:
+		}
+		return "fw0", nil
+	}
+	t.Cleanup(func() { osHostname = priorHost })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d := &Daemon{}
+	go d.mgmtListenerReassertLoop(ctx)
+
+	select {
+	case <-observed:
+		// The loop read the kernel host name. That is the wiring.
+	case <-time.After(5 * time.Second):
+		t.Fatal("the management reassert loop never read the kernel host name in 5s — " +
+			"the watcher is not wired into any tick, so an external rename is " +
+			"never observed no matter how correct the watcher itself is (#6863)")
+	}
+}

--- a/pkg/daemon/management.go
+++ b/pkg/daemon/management.go
@@ -657,6 +657,13 @@ func (d *Daemon) renameHostNotingStaleMgmtCert(name string) error {
 	}
 	d.staleCertPending = true
 	d.staleCertGen++
+	// #6863: move the external-rename watcher's baseline under this SAME hold.
+	// Without it the next watch tick reads the new kernel name, finds it differs
+	// from a baseline this rename never updated, and records a SECOND debt for
+	// one rename — a duplicate WARN arriving from outside the generation fence
+	// that the fence cannot suppress, because it is a genuinely newer
+	// generation.
+	d.lastSeenHostName = name
 	return nil
 }
 

--- a/pkg/daemon/mgmt_listener_reassert.go
+++ b/pkg/daemon/mgmt_listener_reassert.go
@@ -70,6 +70,22 @@ func (d *Daemon) mgmtListenerReassertLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
+			// #6863: observe the kernel host name on this tick.
+			//
+			// Deliberately OUTSIDE reassertMgmtListenersOnce and NOT behind its
+			// `mgmtListenerDown()` gate: an external rename can happen while
+			// every listener is healthy, which is the common case. Gating it on
+			// a down listener would mean the diagnostic only ever fired on a box
+			// that already had a second problem.
+			//
+			// This loop is the right host rather than a new one — it is
+			// always-on, mode-agnostic, low frequency (30s), and already in the
+			// management plane whose certificate is the thing at stake. A rename
+			// is a rare, operator-driven event, so the tick interval is the
+			// latency and that is acceptable for a LOW diagnostic. It reads
+			// os.Hostname through the seam and takes staleCertMu briefly; it
+			// runs on no per-packet or per-poll path.
+			d.watchExternalHostRenameOnce()
 			d.reassertMgmtListenersOnce(ctx)
 		}
 	}


### PR DESCRIPTION
Closes #6863

## The gap

`WarnStaleMgmtCertForHostName` was driven only by `applyHostname`, which runs on a committed `set system host-name`. Every other way the kernel name moves — `hostnamectl set-hostname`, a direct `sethostname(2)`, a provisioning tool rewriting `/etc/hostname`, a manual edit plus a reboot — never calls into xpfd. The durable management certificate (#1916 D6, never re-minted) could be left naming the old host with nothing said.

The issue is right that #6827's park/drain cannot reach it: **the problem is not that the flag drains too early, it is that nothing ever SETS it.** The boot path does not close it either — `applyHostname` returns early when the kernel name already equals the configured one, which is exactly what an external rename that happens to match config leaves behind.

## Design call: option 1, on an existing timer

Host is `mgmtListenerReassertLoop` — already always-on, mode-agnostic, 30 s, and **in the management plane whose certificate is the thing at stake**. No new subsystem for a LOW diagnostic. It reads `os.Hostname` through the existing seam and takes `staleCertMu` briefly; it runs on no per-packet or per-poll path.

Deliberately **outside** that loop's `mgmtListenerDown()` gate. An external rename can happen while every listener is healthy — the common case — so gating on a down listener would mean the diagnostic only ever fired on a box that already had a second problem.

## The subtle part: our own rename must not look external

The baseline moves inside `renameHostNotingStaleMgmtCert`, **under the same single hold of `staleCertMu`** that records the debt. Without that, a rename xpfd performs is seen as external on the next tick and records a **second** debt for one rename — a duplicate WARN arriving from *outside* the #6827 generation fence, which the fence cannot suppress because it is a genuinely newer generation.

`TestOwnRenameIsNotSeenAsExternal_6863` is what makes that one line load-bearing rather than incidental.

Two more deliberate behaviours: an empty baseline means *not yet observed*, so the first call seeds and records nothing (a daemon that just started has no earlier name to have been renamed from, and treating boot as a rename would fire on every restart of a healthy box); and an unreadable kernel name records nothing **and leaves the baseline alone**, so a transient read failure cannot manufacture a diagnosis on the next successful read.

## Mutation matrix — full package, `-count=1`, no `-run` filter, fix committed first

| cell | mutation | verdict | names |
|---|---|---|---|
| M1 | drop the baseline update in our own rename | **RED** | `TestOwnRenameIsNotSeenAsExternal_6863` |
| M2 | drop the seed guard (boot looks like a rename) | **RED** | 3 cells |
| M3 | drop the unchanged guard (fires every tick) | **RED** | 2 cells |
| M4 | drop the unreadable-read guard | **RED** | `TestUnreadableHostNameRecordsNothing_6863` |
| M5 | **drop the tick call — the WIRING** | **RED** | `TestReassertLoopCallsTheHostWatcher_6863` |

**M4 first came back a BUILD BREAK, not a red** — removing the guard orphaned `err`. A build break is not a mutation result, so it was rewritten to compile (`&& false`) and then reds properly.

**M5 is the one worth noting.** Every other cell drives `noteExternalHostRenameIfAny` directly and passes just as well when nothing invokes it — which is *this issue's own defect one level up*: a correct mechanism that no path calls. That cell was written before running the matrix precisely because this keeps happening, and it caught the wiring.

## Validation

- `go test ./... -count=1` — **rc=0, 68 packages, 0 FAIL**
- `go test ./pkg/daemon -race` — clean
- Go-only; **0 files under `userspace-dp/`**, so no cargo leg is owed
