### PR TITLE
process: close _Log.md and move action logs to docs/log/<issue>.md (#6874)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,18 @@ touches — a brief that says "read engineering-style.md" is followed; one
 that assumes the agent already did is not.
 
 ## Logging Rules
-- Maintain a log of all major actions in `_Log.md`.
+- Maintain a log of all major actions in **`docs/log/<issue>.md`** — one file per
+  issue or PR. Do **NOT** append to the repository-root `_Log.md`; it is the
+  historical record up to #6874 and is now closed to new entries.
+  - Why: `_Log.md` was an append-only file every lane wrote to, so every branch
+    touched the same trailing region. That made it an **O(n^2) serialization
+    point** — merging one PR flipped every other open PR to CONFLICTING, and
+    resolving one did not help the others. Measured on a 30-PR board: 19 of 30
+    flipped within seconds of one merge, with `_Log.md` the ONLY conflicting
+    path on every branch sampled.
+  - A `merge=union` driver is NOT the fix and must not be added for this file:
+    it fuses two same-minute entries into one malformed entry and exits 0. See
+    `docs/log/README.md` for the measurement.
 - Use YAML or Markdown bullet points for structure:
     - **Timestamp**: [Time]
     - **Action**: [Brief Description]

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,12 @@
+> **CLOSED to new entries as of #6874.** Write action logs to
+> `docs/log/<issue>.md` — one file per issue — not here.
+>
+> This file is the historical record. It stayed a single append-only file that
+> every lane wrote to, which made it an O(n^2) serialization point: every merge
+> conflicted every other open branch, on this file alone. See
+> `docs/log/README.md` for the measurement and for why a `merge=union` driver is
+> not a safe alternative.
+
 ## 2026-08-27 — #6821: security-log transport packed tail, gate and compiler together
 
 - **Timestamp**: 2026-08-27
@@ -107060,3 +107069,5 @@ prose edit above them added. No diff falls in the new test body.
 - **Timestamp**: 2026-08-27
   - **Action**: #6863 — a watcher on the existing 30s management reassert tick records the stale-mgmt-cert debt when the kernel host name moves without xpfd renaming it. Baseline moves under the same lock as xpfd's own rename so one rename cannot produce two debts.
   - **File(s)**: pkg/daemon/external_hostname_watch_6863.go, pkg/daemon/mgmt_listener_reassert.go, pkg/daemon/management.go, pkg/daemon/daemon.go
+
+<!-- LOG-CLOSED-SENTINEL-6874: nothing may be appended below this line. Write to docs/log/<issue>.md instead. -->

--- a/docs/log/6874.md
+++ b/docs/log/6874.md
@@ -1,0 +1,10 @@
+# #6874 — `_Log.md` O(n^2) serialization point
+
+- **Timestamp**: 2026-08-27
+  - **Action**: closed `_Log.md` to new entries and moved action logs to
+    `docs/log/<issue>.md`, one file per issue. Added a sentinel-based guard so
+    the append pattern cannot return silently, and recorded why a
+    `merge=union` driver is not a safe alternative (measured: it fuses
+    same-minute entries and exits 0).
+  - **File(s)**: CLAUDE.md, _Log.md, docs/log/README.md, docs/log/6874.md,
+    pkg/refactoraudit/log_closed_6874_test.go

--- a/docs/log/README.md
+++ b/docs/log/README.md
@@ -1,0 +1,61 @@
+# Per-change action logs
+
+Write your action log for a piece of work to **`docs/log/<issue>.md`** — one
+file per issue or PR — not to the repository-root `_Log.md`.
+
+`_Log.md` is retained as the historical record up to #6874. Do not append to it.
+
+## Why
+
+`_Log.md` was an append-only file that every lane wrote to, so every branch
+touched the same trailing region. That makes it an **O(n²) serialization
+point**: merging one PR flips every other open PR to CONFLICTING, resolving one
+does not help the others, and the next merge re-conflicts all of them. With N
+open PRs, merging all N costs on the order of N²/2 union-resolutions.
+
+Measured on a 30-PR board (#6874): after one merge, **19 of 30 open PRs flipped
+to CONFLICTING within seconds**, with `_Log.md` the *only* conflicting path on
+every branch sampled. A later session merged roughly fifteen PRs and hit the
+same conflict on every single one.
+
+Per-issue files remove the class outright: different files, no conflict, and
+each change's log lands atomically with its own merge.
+
+## Why NOT a union merge driver
+
+`merge=union` in `.gitattributes` is the obvious one-line alternative and it is
+**not safe for this file**. It resolves textually and line-based, so two entries
+written in the same minute are silently fused. Measured directly:
+
+    base:   - entry A / - entry B
+    lane1:  + - **Timestamp**: 10:00 / Action: lane1 did X / File(s): a.go
+    lane2:  + - **Timestamp**: 10:00 / Action: lane2 did Y / File(s): b.go
+
+    result with merge=union:
+        - **Timestamp**: 10:00
+          - **Action**: lane2 did Y
+          - **File(s)**: b.go
+          - **Action**: lane1 did X      <- lane1's Timestamp header is GONE
+          - **File(s)**: a.go
+
+The shared `- **Timestamp**: 10:00` line aligns, so the two entries collapse
+into one malformed entry with two Actions and one header. `git merge` reports
+success and exits 0. Nothing downstream notices.
+
+That is worse than the conflict it replaces: a conflict is loud and mechanical,
+this is silent and lossy. The union driver is not used here, and should not be
+added for this file.
+
+## Format
+
+Same as before — the `CLAUDE.md` logging rules are unchanged in content, only in
+destination:
+
+```markdown
+- **Timestamp**: 2026-08-27
+  - **Action**: what was done, briefly
+  - **File(s)**: the files changed
+```
+
+One file per issue means the file is short, self-contained, and reviewable in
+the same diff as the change it describes.

--- a/pkg/refactoraudit/log_closed_6874_test.go
+++ b/pkg/refactoraudit/log_closed_6874_test.go
@@ -1,0 +1,78 @@
+package refactoraudit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// logClosedSentinel6874 marks the end of the historical `_Log.md`. Nothing may
+// follow it.
+const logClosedSentinel6874 = "<!-- LOG-CLOSED-SENTINEL-6874:"
+
+// #6874: `_Log.md` was an append-only file every lane wrote to, which made it an
+// O(n^2) serialization point — merging one PR flipped every other open PR to
+// CONFLICTING, on that file alone, and resolving one did not help the others.
+// Logs now go to `docs/log/<issue>.md`, one file per issue.
+//
+// This guard exists because the old destination is the one habit reaches for,
+// and an append there is invisible until the next merge storm. A sentinel at
+// the END is the cheap mechanical check: an append lands after it, so "is the
+// sentinel the last content line" answers exactly the question.
+//
+// A sentinel at the end rather than a line count or a hash, deliberately —
+// those would also fire on a legitimate edit to the historical body (fixing a
+// typo, resolving an old marker), which is not what this is guarding against.
+func TestLogMdIsClosedToNewEntries6874(t *testing.T) {
+	root := repoRoot(t)
+	raw, err := os.ReadFile(filepath.Join(root, "_Log.md"))
+	if err != nil {
+		t.Fatalf("read _Log.md: %v", err)
+	}
+	lines := strings.Split(string(raw), "\n")
+
+	idx := -1
+	for i, l := range lines {
+		if strings.Contains(l, logClosedSentinel6874) {
+			idx = i
+		}
+	}
+	if idx < 0 {
+		t.Fatalf("_Log.md has lost its LOG-CLOSED sentinel. It marks the file as closed "+
+			"to new entries (#6874); without it nothing stops the O(n^2) append pattern "+
+			"returning. Restore the line, or if _Log.md is being retired entirely, delete "+
+			"this test in the same change. Expected to contain: %s", logClosedSentinel6874)
+	}
+
+	for i := idx + 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "" {
+			continue
+		}
+		t.Errorf("_Log.md line %d is AFTER the LOG-CLOSED sentinel:\n\n    %s\n\n"+
+			"`_Log.md` is closed to new entries (#6874). Write your action log to "+
+			"docs/log/<issue>.md — one file per issue — so your change does not conflict "+
+			"with every other open PR. See docs/log/README.md.",
+			i+1, strings.TrimSpace(lines[i]))
+	}
+}
+
+// The convention this redirects to must actually exist. Without this, deleting
+// docs/log/README.md would leave the guard above pointing at nothing and the
+// rule undiscoverable.
+func TestLogConventionIsDocumented6874(t *testing.T) {
+	root := repoRoot(t)
+	readme := filepath.Join(root, "docs", "log", "README.md")
+	raw, err := os.ReadFile(readme)
+	if err != nil {
+		t.Fatalf("docs/log/README.md is missing (%v) — the guard in this file redirects "+
+			"writers there, so it must exist", err)
+	}
+	for _, want := range []string{"docs/log/<issue>.md", "merge=union"} {
+		if !strings.Contains(string(raw), want) {
+			t.Errorf("docs/log/README.md no longer mentions %q. The union-driver warning "+
+				"in particular is load-bearing: it is the obvious one-line alternative and "+
+				"it silently fuses same-minute entries (measured in #6874).", want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #6874

## The cost, freshly confirmed

The issue measured **19 of 30 open PRs flipping to CONFLICTING within seconds** of one merge, with `_Log.md` the *only* conflicting path on every branch sampled.

This session merged roughly **fifteen PRs and hit that conflict on every single one** — each needing a fresh worktree, a union that preserved both blocks, and a structural check that no entry was orphaned. It is the dominant mechanical cost of merging right now.

**Option 1: per-issue files.** `docs/log/<issue>.md`. Different files, no conflict, and each change's log lands atomically with its own merge.

## Why NOT a union merge driver — measured, not argued

`merge=union` is the obvious one-line alternative and it is **not safe for this file**. It resolves line-based, so two entries written in the same minute share their `- **Timestamp**:` line, that line aligns, and the entries collapse:

```
- **Timestamp**: 10:00
  - **Action**: lane2 did Y
  - **File(s)**: b.go
  - **Action**: lane1 did X      <- lane1's Timestamp header is GONE
  - **File(s)**: a.go
```

Two entries become **one malformed entry** with two Actions and one header. `git merge` exits 0. Nothing downstream notices.

That is strictly worse than the conflict it replaces — a conflict is loud and mechanical; this is silent and lossy. The transcript is in `docs/log/README.md` so nobody adds it later as an "obvious" improvement.

## The transition cost was checked too

Closing `_Log.md` puts a header at the top of a file whose in-flight branches all append at the bottom. Measured whether that adds a second conflict region: **it does not** — a top-of-file edit merges cleanly with bottom appends, rc=0, both changes preserved.

Timed deliberately: **the board is at zero open PRs**, so no in-flight PR pays a transition cost at all.

## The guard

A sentinel at the end of `_Log.md` plus a test in `pkg/refactoraudit`. The old destination is the one habit reaches for, and an append there is invisible until the next merge storm.

A **sentinel** rather than a line count or a content hash, deliberately: those would also fire on a legitimate edit to the historical body — fixing a typo, resolving an old marker — which is not what this guards against. An append lands *after* the sentinel, so "is the sentinel the last content line" answers exactly the right question and nothing else.

Verified it reds on an append and names the offending line:

```
--- FAIL: TestLogMdIsClosedToNewEntries6874
    _Log.md line 107075 is AFTER the LOG-CLOSED sentinel:
```

A second test asserts `docs/log/README.md` still exists **and still carries the union-driver warning**, so the guard cannot end up redirecting writers to a file that is gone, or to one that has lost the reason it exists.

## Validation

- `go test ./... -count=1` — **rc=0, 68 packages, 0 FAIL**
- Guard verified in both directions: passes clean, reds on an append
- Dogfooded — this change's own log is at `docs/log/6874.md`, not `_Log.md`
