### PR TITLE
nat64: fence the fragment association on runtime RG ownership (#6857)

### DIFF
--- a/docs/log/6857.md
+++ b/docs/log/6857.md
@@ -1,0 +1,13 @@
+# #6857 — NAT64 fragment association outliving its owner-RG entitlement
+
+- **Timestamp**: 2026-08-27
+  - **Action**: added a runtime-ownership fence beside the #5624 config fence.
+    The association now carries the owner RG of the resolution its first
+    fragment was admitted under, and a consult refuses (and evicts) when that
+    RG is no longer forwarding-active locally. `owner_rg == 0` is deliberately
+    NOT fenced — a standalone box has no RGs, so fencing zero would disable
+    fragment association for every non-HA deployment.
+  - **File(s)**: userspace-dp/src/nat64.rs,
+    userspace-dp/src/afxdp/poll_descriptor/frag_assoc.rs,
+    userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+    userspace-dp/src/nat64_tests.rs

--- a/userspace-dp/src/afxdp/poll_descriptor/frag_assoc.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/frag_assoc.rs
@@ -109,10 +109,7 @@ pub(super) fn nat64_install_forward_fragment_assoc(
             // a later fragment can be refused once the RG stops forwarding
             // locally. The config generation beside it cannot see an RG
             // transition: that changes no config and bumps no snapshot.
-            crate::afxdp::forwarding::owner_rg_for_resolution(
-                forwarding,
-                decision.resolution,
-            ),
+            crate::afxdp::forwarding::owner_rg_for_resolution(forwarding, decision.resolution),
         );
     }
 }
@@ -145,20 +142,16 @@ pub(super) fn nat64_consult_forward_fragment_assoc(
     // changed deny/NAT64 rules) is treated as a miss + evicted here, so the
     // non-first fragment falls through to the #4617 fail-closed drop instead of
     // inheriting a stale verdict.
-    let (decision, _reverse) =
-        forwarding
-            .nat64
-            .frag_assoc
-            .lookup(
-                &key,
-                now_ns,
-                forwarding.nat64.build_generation,
-                |rg| {
-                    ha_state
-                        .get(&rg)
-                        .is_some_and(|group| group.is_forwarding_active(now_secs))
-                },
-            )?;
+    let (decision, _reverse) = forwarding.nat64.frag_assoc.lookup(
+        &key,
+        now_ns,
+        forwarding.nat64.build_generation,
+        |rg| {
+            ha_state
+                .get(&rg)
+                .is_some_and(|group| group.is_forwarding_active(now_secs))
+        },
+    )?;
     // Only a genuine NAT64 forward decision (nat64=true, rewrite_src/dst set)
     // routes to the NAT64 frame builder.
     if !decision.nat.nat64 {
@@ -218,10 +211,7 @@ pub(super) fn nat_install_forward_fragment_assoc(
             // a later fragment can be refused once the RG stops forwarding
             // locally. The config generation beside it cannot see an RG
             // transition: that changes no config and bumps no snapshot.
-            crate::afxdp::forwarding::owner_rg_for_resolution(
-                forwarding,
-                decision.resolution,
-            ),
+            crate::afxdp::forwarding::owner_rg_for_resolution(forwarding, decision.resolution),
         );
     }
 }
@@ -270,20 +260,16 @@ pub(super) fn nat_consult_forward_fragment_assoc(
     now_secs: u64,
 ) -> Option<SessionDecision> {
     let key = crate::nat64::nat64_nonfirst_fragment_key(l3_packet, addr_family, authority)?;
-    let (decision, _reverse) =
-        forwarding
-            .nat64
-            .frag_assoc
-            .lookup(
-                &key,
-                now_ns,
-                forwarding.nat64.build_generation,
-                |rg| {
-                    ha_state
-                        .get(&rg)
-                        .is_some_and(|group| group.is_forwarding_active(now_secs))
-                },
-            )?;
+    let (decision, _reverse) = forwarding.nat64.frag_assoc.lookup(
+        &key,
+        now_ns,
+        forwarding.nat64.build_generation,
+        |rg| {
+            ha_state
+                .get(&rg)
+                .is_some_and(|group| group.is_forwarding_active(now_secs))
+        },
+    )?;
     // Only an ordinary same-family NAT / NPT rewrite routes here; a NAT64
     // (cross-family) association is handled by `nat64_consult_forward_fragment_assoc`.
     if decision.nat.nat64

--- a/userspace-dp/src/afxdp/poll_descriptor/frag_assoc.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/frag_assoc.rs
@@ -105,6 +105,14 @@ pub(super) fn nat64_install_forward_fragment_assoc(
             None,
             now_ns,
             forwarding.nat64.build_generation,
+            // #6857: stamp the runtime entitlement this admission rested on, so
+            // a later fragment can be refused once the RG stops forwarding
+            // locally. The config generation beside it cannot see an RG
+            // transition: that changes no config and bumps no snapshot.
+            crate::afxdp::forwarding::owner_rg_for_resolution(
+                forwarding,
+                decision.resolution,
+            ),
         );
     }
 }
@@ -123,6 +131,10 @@ pub(super) fn nat64_consult_forward_fragment_assoc(
     addr_family: i32,
     authority: crate::nat64::FragAuthority,
     now_ns: u64,
+    // #6857: the runtime-ownership fence needs to ask whether the association's
+    // stamped owner RG is STILL forwarding-active locally.
+    ha_state: &std::collections::BTreeMap<i32, crate::afxdp::types::HAGroupRuntime>,
+    now_secs: u64,
 ) -> Option<SessionDecision> {
     if addr_family != libc::AF_INET6 {
         return None;
@@ -137,7 +149,16 @@ pub(super) fn nat64_consult_forward_fragment_assoc(
         forwarding
             .nat64
             .frag_assoc
-            .lookup(&key, now_ns, forwarding.nat64.build_generation)?;
+            .lookup(
+                &key,
+                now_ns,
+                forwarding.nat64.build_generation,
+                |rg| {
+                    ha_state
+                        .get(&rg)
+                        .is_some_and(|group| group.is_forwarding_active(now_secs))
+                },
+            )?;
     // Only a genuine NAT64 forward decision (nat64=true, rewrite_src/dst set)
     // routes to the NAT64 frame builder.
     if !decision.nat.nat64 {
@@ -193,6 +214,14 @@ pub(super) fn nat_install_forward_fragment_assoc(
             None,
             now_ns,
             forwarding.nat64.build_generation,
+            // #6857: stamp the runtime entitlement this admission rested on, so
+            // a later fragment can be refused once the RG stops forwarding
+            // locally. The config generation beside it cannot see an RG
+            // transition: that changes no config and bumps no snapshot.
+            crate::afxdp::forwarding::owner_rg_for_resolution(
+                forwarding,
+                decision.resolution,
+            ),
         );
     }
 }
@@ -235,13 +264,26 @@ pub(super) fn nat_consult_forward_fragment_assoc(
     addr_family: i32,
     authority: crate::nat64::FragAuthority,
     now_ns: u64,
+    // #6857: the runtime-ownership fence needs to ask whether the association's
+    // stamped owner RG is STILL forwarding-active locally.
+    ha_state: &std::collections::BTreeMap<i32, crate::afxdp::types::HAGroupRuntime>,
+    now_secs: u64,
 ) -> Option<SessionDecision> {
     let key = crate::nat64::nat64_nonfirst_fragment_key(l3_packet, addr_family, authority)?;
     let (decision, _reverse) =
         forwarding
             .nat64
             .frag_assoc
-            .lookup(&key, now_ns, forwarding.nat64.build_generation)?;
+            .lookup(
+                &key,
+                now_ns,
+                forwarding.nat64.build_generation,
+                |rg| {
+                    ha_state
+                        .get(&rg)
+                        .is_some_and(|group| group.is_forwarding_active(now_secs))
+                },
+            )?;
     // Only an ordinary same-family NAT / NPT rewrite routes here; a NAT64
     // (cross-family) association is handled by `nat64_consult_forward_fragment_assoc`.
     if decision.nat.nat64

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -3157,6 +3157,8 @@ pub(super) fn poll_binding_process_descriptor(
                             meta.addr_family as i32,
                             frag_authority,
                             now_ns,
+                            worker_ctx.ha_state,
+                            now_secs,
                         )
                         // #5689: fall back to the ORDINARY same-family NAT /
                         // NPTv6 fragment association so a non-first fragment of
@@ -3173,6 +3175,8 @@ pub(super) fn poll_binding_process_descriptor(
                                 meta.addr_family as i32,
                                 frag_authority,
                                 now_ns,
+                                worker_ctx.ha_state,
+                                now_secs,
                             )
                         })
                     })

--- a/userspace-dp/src/afxdp/tests_nat64_tunnel.rs
+++ b/userspace-dp/src/afxdp/tests_nat64_tunnel.rs
@@ -1577,7 +1577,7 @@ fn nat64_association_hit_still_runs_interface_input_filter_5798() {
             seed_fwd
                 .nat64
                 .frag_assoc
-                .lookup(&seed_key, 0, seed_fwd.nat64.build_generation)
+                .lookup(&seed_key, 0, seed_fwd.nat64.build_generation, |_| true)
                 .expect("the seed first fragment must have published an association")
                 .0
         };
@@ -1599,6 +1599,7 @@ fn nat64_association_hit_still_runs_interface_input_filter_5798() {
             None,
             crate::afxdp::neighbor::monotonic_nanos(),
             forwarding.nat64.build_generation,
+            0,
         );
         assert_eq!(
             forwarding.nat64.frag_assoc.len(),

--- a/userspace-dp/src/afxdp/tests_nat64_tunnel.rs
+++ b/userspace-dp/src/afxdp/tests_nat64_tunnel.rs
@@ -2785,18 +2785,20 @@ fn nat64_frag_assoc_install_site_derives_the_owner_rg_6857() {
         panic!("#6857: could not build the non-first fragment key");
     };
     let asked = std::cell::Cell::new(Vec::<i32>::new());
-    let hit = forwarding.nat64.frag_assoc.lookup(
-        &key,
-        1_000,
-        forwarding.nat64.build_generation,
-        |rg| {
-            let mut v = asked.take();
-            v.push(rg);
-            asked.set(v);
-            true
-        },
+    let hit =
+        forwarding
+            .nat64
+            .frag_assoc
+            .lookup(&key, 1_000, forwarding.nat64.build_generation, |rg| {
+                let mut v = asked.take();
+                v.push(rg);
+                asked.set(v);
+                true
+            });
+    assert!(
+        hit.is_some(),
+        "#6857 PREMISE: the association must be findable"
     );
-    assert!(hit.is_some(), "#6857 PREMISE: the association must be findable");
     assert_eq!(
         asked.take(),
         vec![3],

--- a/userspace-dp/src/afxdp/tests_nat64_tunnel.rs
+++ b/userspace-dp/src/afxdp/tests_nat64_tunnel.rs
@@ -2705,3 +2705,104 @@ fn t_run_6836(
          the packet on the wire is IPv4."
     );
 }
+
+/// #6857 WIRING: the install SITE must derive the owner RG, not stamp a
+/// constant.
+///
+/// The cells in nat64_tests.rs call `Nat64FragAssoc::install` directly with an
+/// explicit owner RG, so they pin the fence and say nothing about where the
+/// stamp comes from. The mutation matrix proved it: replacing the
+/// `owner_rg_for_resolution(...)` call at both install sites with a literal `0`
+/// left the ENTIRE suite green — the fence was correct and permanently unarmed,
+/// because owner RG 0 is deliberately never fenced.
+///
+/// This drives a real NAT64 first fragment through `txn_run_descriptor` with an
+/// RG-bound egress, then asks the published association which RG it carries.
+#[test]
+fn nat64_frag_assoc_install_site_derives_the_owner_rg_6857() {
+    let mut forwarding = build_forwarding_state(&nat64_frag_snapshot());
+    // Bind every egress to RG 3. The fixture binds none, so without this the
+    // derivation returns 0 legitimately and the cell could not tell a derived
+    // zero from a hardcoded one.
+    for iface in forwarding.egress.values_mut() {
+        iface.redundancy_group = 3;
+    }
+    // RG 3 must be forwarding-active for the first fragment to be admitted at
+    // all — the install is what publishes the association this cell reads.
+    // txn_ha_state() only carries RGs 1 and 2, and the PREMISE assertion below
+    // is what turned that omission into a named failure rather than an empty
+    // read.
+    let mut ha_state = txn_ha_state();
+    ha_state.insert(
+        3,
+        crate::afxdp::types::HAGroupRuntime {
+            active: true,
+            watchdog_timestamp: 123,
+            lease: crate::afxdp::types::HAGroupRuntime::active_lease_until(123, 123),
+        },
+    );
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 24, 0);
+    binding.interface = Arc::<str>::from("reth1.0");
+    let mut sessions = SessionTable::new();
+    sessions.set_max_sessions_for_test(16);
+
+    let src: Ipv6Addr = "2001:559:8585:ef00::102".parse().expect("src v6");
+    let dst: Ipv6Addr = "64:ff9b::808:808".parse().expect("nat64 dst");
+    let first = nat64_v6_frag_frame(0x0001, 0x1234_5678, src, dst, 12345, 443);
+    let (_b, dbg) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &first,
+        nat64_v6_frag_meta(first.len(), src, dst),
+    );
+    assert_eq!(
+        dbg.tx, 1,
+        "#6857 PREMISE: the first fragment must translate and forward, or no \
+         association is published and the assertion below reads nothing"
+    );
+    assert_eq!(
+        forwarding.nat64.frag_assoc.len(),
+        1,
+        "#6857 PREMISE: exactly one association must have been published"
+    );
+
+    // Ask the association which RG it carries, by recording what the fence
+    // predicate is asked about. A hardcoded 0 never reaches the predicate at
+    // all, because owner_rg 0 is deliberately not fenced.
+    let non_first = nat64_v6_frag_frame(0x0008, 0x1234_5678, src, dst, 0, 0);
+    let key = crate::nat64::nat64_nonfirst_fragment_key(
+        &non_first[14..],
+        libc::AF_INET6,
+        crate::afxdp::poll_descriptor::frag_assoc::frag_ingress_authority(
+            &forwarding,
+            nat64_v6_frag_meta(non_first.len(), src, dst),
+            None,
+        ),
+    );
+    let Some(key) = key else {
+        panic!("#6857: could not build the non-first fragment key");
+    };
+    let asked = std::cell::Cell::new(Vec::<i32>::new());
+    let hit = forwarding.nat64.frag_assoc.lookup(
+        &key,
+        1_000,
+        forwarding.nat64.build_generation,
+        |rg| {
+            let mut v = asked.take();
+            v.push(rg);
+            asked.set(v);
+            true
+        },
+    );
+    assert!(hit.is_some(), "#6857 PREMISE: the association must be findable");
+    assert_eq!(
+        asked.take(),
+        vec![3],
+        "#6857: the install site must DERIVE the owner RG from the resolution. \
+         An empty list means the entry carries 0, so the fence can never fire \
+         and the whole change is inert — which is exactly what the matrix saw \
+         when the derivation was replaced by a literal"
+    );
+}

--- a/userspace-dp/src/nat64.rs
+++ b/userspace-dp/src/nat64.rs
@@ -525,6 +525,22 @@ struct Nat64FragEntry {
     /// change (deny/NAT64 rules) invalidates associations minted under the old
     /// config instead of silently forwarding fragments the new config would drop.
     generation: u64,
+    /// #6857: the owner redundancy group of the resolution the FIRST fragment
+    /// was admitted under, or 0 when no RG-bound interface owns it.
+    ///
+    /// The config generation above is a CONFIG fence and does its job. An RG
+    /// transition is RUNTIME HA state: it changes no config and bumps no
+    /// snapshot generation, so a config-generation counter is structurally the
+    /// wrong instrument for invalidating state whose validity depends on
+    /// runtime ownership. This is the runtime fence beside it.
+    ///
+    /// ZERO MEANS NOT RG-DEPENDENT, and that distinction is load-bearing rather
+    /// than a convenience: on a standalone box (no chassis cluster) every
+    /// resolution has owner RG 0, so treating 0 as "not entitled" would evict
+    /// every association on every consult and disable fragment association
+    /// outright for the non-HA deployment. Only a POSITIVE owner RG is checked
+    /// against `is_forwarding_active`.
+    owner_rg: i32,
 }
 
 /// Cross-family fragment-association cache (#2562). Cheap to `Clone` (shares the
@@ -631,6 +647,9 @@ impl Nat64FragAssoc {
         reverse: Option<Nat64ReverseInfo>,
         now_ns: u64,
         generation: u64,
+        // #6857: owner RG of the resolution this fragment was admitted under;
+        // 0 when no RG-bound interface owns it.
+        owner_rg: i32,
     ) {
         let deadline_ns = now_ns.saturating_add(NAT64_FRAG_TTL_NS);
         let idx = nat64_frag_shard_index(&key);
@@ -647,6 +666,12 @@ impl Nat64FragAssoc {
             // generation. A stale-generation refresh would otherwise resurrect
             // a prior-config verdict.
             e.generation = generation;
+            // #6857: refresh the owner RG too. A refresh happens when a LATER
+            // first fragment of the same datagram re-admits under current
+            // state, so the entry must carry THAT admission's entitlement, not
+            // the original one — otherwise a refresh under a now-active RG
+            // would leave the entry stamped with the old value.
+            e.owner_rg = owner_rg;
             shard.push(e);
             return;
         }
@@ -672,6 +697,7 @@ impl Nat64FragAssoc {
             reverse,
             deadline_ns,
             generation,
+            owner_rg,
         });
     }
 
@@ -693,6 +719,15 @@ impl Nat64FragAssoc {
         key: &Nat64FragKey,
         now_ns: u64,
         generation: u64,
+        // #6857: "is this owner RG forwarding-active locally right now?".
+        //
+        // A predicate rather than the HA map, for two reasons. The RG to ask
+        // about is not known until the entry is found, so the caller cannot
+        // pre-compute a bool; and passing the map would drag
+        // `afxdp::HAGroupRuntime` (which is `pub(in crate::afxdp)`) into this
+        // module, widening a type's visibility to serve a fence. The closure
+        // keeps the HA vocabulary on the afxdp side of the boundary.
+        owner_rg_forwarding_active: impl Fn(i32) -> bool,
     ) -> Option<(SessionDecision, Option<Nat64ReverseInfo>)> {
         let idx = nat64_frag_shard_index(key);
         let mut shard = self.shards[idx]
@@ -705,6 +740,24 @@ impl Nat64FragAssoc {
         // changed deny/NAT64 rules invalidates the association instead of
         // letting stale fragments keep inheriting the old verdict.
         if shard[pos].generation != generation {
+            shard.remove(pos);
+            return None;
+        }
+        // #6857 RUNTIME-OWNERSHIP fence, beside the config one above.
+        //
+        // The association carries a permit this node granted while it was
+        // entitled to. An RG transition (failover, tracked-interface demotion)
+        // revokes that entitlement without touching config, so the generation
+        // guard above cannot see it: a later fragment would still HIT and
+        // inherit the earlier permit + egress + NAT on a node that is no longer
+        // forwarding-active for the owning RG. That is exactly what the #6458
+        // owner-RG gate exists to prevent on the enforcement path.
+        //
+        // owner_rg == 0 means NOT RG-dependent and is deliberately NOT checked:
+        // on a standalone box every resolution has owner RG 0, so checking it
+        // would evict every association on every consult and disable fragment
+        // association for the entire non-HA deployment.
+        if shard[pos].owner_rg > 0 && !owner_rg_forwarding_active(shard[pos].owner_rg) {
             shard.remove(pos);
             return None;
         }

--- a/userspace-dp/src/nat64_tests.rs
+++ b/userspace-dp/src/nat64_tests.rs
@@ -4809,9 +4809,9 @@ fn nat64_frag_assoc_v6_to_v4_nonfirst_inherits_and_translates() {
     // Install the first fragment's decision; the non-first fragment inherits it.
     let cache = Nat64FragAssoc::new();
     let decision = frag_test_decision(Nat64State::forward_decision(snat_v4, dst_v4, 5000));
-    cache.install(kf, decision, None, 1_000, 1);
+    cache.install(kf, decision, None, 1_000, 1, 0);
     let (hit, reverse) = cache
-        .lookup(&kn, 1_500, 1)
+        .lookup(&kn, 1_500, 1, |_| true)
         .expect("non-first inherits association");
     assert!(
         reverse.is_none(),
@@ -4888,9 +4888,9 @@ fn nat64_frag_assoc_v4_to_v6_nonfirst_inherits_and_translates() {
         orig_dst_v6,
     };
     let decision = frag_test_decision(Nat64State::forward_decision(snat_v4, server_v4, 5000));
-    cache.install(kf, decision, Some(reverse), 2_000, 1);
+    cache.install(kf, decision, Some(reverse), 2_000, 1, 0);
     let (_hit, rev) = cache
-        .lookup(&kn, 2_400, 1)
+        .lookup(&kn, 2_400, 1, |_| true)
         .expect("reverse non-first inherits");
     assert_eq!(
         rev,
@@ -4943,7 +4943,7 @@ fn nat64_frag_assoc_nonfirst_without_first_misses_and_drops() {
     let nonfirst = make_ipv6_frag_udp(src_v6, dst_v6, 0, 0, &[0u8; 16], 100, false, 0x9999);
     let kn = nat64_nonfirst_fragment_key(&nonfirst, libc::AF_INET6, frag_test_authority()).expect("key");
     assert!(
-        cache.lookup(&kn, 10, 1).is_none(),
+        cache.lookup(&kn, 10, 1, |_| true).is_none(),
         "orphan non-first fragment misses"
     );
     let snat = Ipv4Addr::new(198, 51, 100, 5);
@@ -4978,7 +4978,7 @@ fn nat64_frag_assoc_cache_is_bounded() {
             protocol: PROTO_UDP,
             authority: frag_test_authority(),
         };
-        cache.install(key, decision, None, 1_000, 1);
+        cache.install(key, decision, None, 1_000, 1, 0);
     }
     assert!(
         cache.len() <= ceiling,
@@ -5007,16 +5007,16 @@ fn nat64_frag_assoc_ttl_evicts() {
         Ipv4Addr::new(8, 8, 8, 8),
         5000,
     ));
-    cache.install(key, decision, None, 1_000, 1);
+    cache.install(key, decision, None, 1_000, 1, 0);
     assert_eq!(cache.len(), 1);
     // Still within the TTL window: hit.
     assert!(cache
-        .lookup(&key, 1_000 + NAT64_FRAG_TTL_NS - 1, 1)
+        .lookup(&key, 1_000 + NAT64_FRAG_TTL_NS - 1, 1, |_| true)
         .is_some());
     // Past the (refreshed) TTL with no intervening hit: pruned + miss.
-    cache.install(key, decision, None, 1_000, 1);
+    cache.install(key, decision, None, 1_000, 1, 0);
     assert!(
-        cache.lookup(&key, 1_000 + NAT64_FRAG_TTL_NS + 1, 1).is_none(),
+        cache.lookup(&key, 1_000 + NAT64_FRAG_TTL_NS + 1, 1, |_| true).is_none(),
         "expired association must miss",
     );
     assert_eq!(cache.len(), 0, "expired entry pruned");
@@ -5102,12 +5102,12 @@ fn nat64_frag_assoc_install_prunes_expired_before_evicting_live() {
     // insertion order). Its deadline is FAR in the future.
     let live_key = mk(idents[0]);
     let live_now = 2 * NAT64_FRAG_TTL_NS; // deadline = 4*TTL
-    cache.install(live_key, decision, None, live_now, 1);
+    cache.install(live_key, decision, None, live_now, 1, 0);
 
     // Fill the rest of the shard to cap with EXPIRED entries: installed at
     // now=0 so their deadline is TTL, which the flood/lookup times below exceed.
     for &ident in &idents[1..NAT64_FRAG_CAP_PER_SHARD] {
-        cache.install(mk(ident), decision, None, 0, 1);
+        cache.install(mk(ident), decision, None, 0, 1, 0);
     }
     assert_eq!(
         cache.len(),
@@ -5119,16 +5119,16 @@ fn nat64_frag_assoc_install_prunes_expired_before_evicting_live() {
     // deadlines but well within the LIVE entry's window.
     let flood_now = NAT64_FRAG_TTL_NS + 1; // > TTL (expired) but < 4*TTL (live alive)
     let new_key = mk(idents[NAT64_FRAG_CAP_PER_SHARD]);
-    cache.install(new_key, decision, None, flood_now, 1);
+    cache.install(new_key, decision, None, flood_now, 1, 0);
 
     // The LIVE association survived (expired slots were reclaimed first)...
     assert!(
-        cache.lookup(&live_key, flood_now + 1, 1).is_some(),
+        cache.lookup(&live_key, flood_now + 1, 1, |_| true).is_some(),
         "#5447: live association must survive a first-fragment flood",
     );
     // ...and the NEW association was installed into a reclaimed slot.
     assert!(
-        cache.lookup(&new_key, flood_now + 1, 1).is_some(),
+        cache.lookup(&new_key, flood_now + 1, 1, |_| true).is_some(),
         "new association installed into a reclaimed expired slot",
     );
 }
@@ -5161,22 +5161,22 @@ fn nat64_frag_assoc_install_all_live_still_evicts_oldest() {
     let cache = Nat64FragAssoc::new();
     // Fill the shard to cap with entries that are ALL live at the times below.
     for &ident in &idents[..NAT64_FRAG_CAP_PER_SHARD] {
-        cache.install(mk(ident), decision, None, 1_000, 1);
+        cache.install(mk(ident), decision, None, 1_000, 1, 0);
     }
     assert_eq!(cache.len(), NAT64_FRAG_CAP_PER_SHARD, "shard filled to cap");
 
     let oldest_key = mk(idents[0]);
     let new_key = mk(idents[NAT64_FRAG_CAP_PER_SHARD]);
     // Install a NEW key while every existing entry is still live.
-    cache.install(new_key, decision, None, 1_000, 1);
+    cache.install(new_key, decision, None, 1_000, 1, 0);
 
     // The oldest (front) live entry is evicted -- capacity bound preserved.
     assert!(
-        cache.lookup(&oldest_key, 1_000, 1).is_none(),
+        cache.lookup(&oldest_key, 1_000, 1, |_| true).is_none(),
         "capacity bound: oldest live entry evicted when the shard is all-live",
     );
     assert!(
-        cache.lookup(&new_key, 1_000, 1).is_some(),
+        cache.lookup(&new_key, 1_000, 1, |_| true).is_some(),
         "new entry installed",
     );
     assert!(
@@ -5216,12 +5216,12 @@ fn nat64_frag_assoc_generation_change_invalidates_stale_association() {
 
     // A first fragment installs the association under generation 7.
     let gen0: u64 = 7;
-    cache.install(key, decision, None, 1_000, gen0);
+    cache.install(key, decision, None, 1_000, gen0, 0);
 
     // A same-generation non-first fragment still inherits it (valid same-config
     // reassembly is NOT broken by the guard).
     assert!(
-        cache.lookup(&key, 1_100, gen0).is_some(),
+        cache.lookup(&key, 1_100, gen0, |_| true).is_some(),
         "same-generation replay must still hit",
     );
 
@@ -5229,7 +5229,7 @@ fn nat64_frag_assoc_generation_change_invalidates_stale_association() {
     // MISS under generation 8 -- the fix.
     let gen1: u64 = 8;
     assert!(
-        cache.lookup(&key, 1_200, gen1).is_none(),
+        cache.lookup(&key, 1_200, gen1, |_| true).is_none(),
         "#5624: association from a prior config generation must miss",
     );
     // ...and it was EVICTED, not merely skipped, so it cannot linger to be
@@ -5240,15 +5240,15 @@ fn nat64_frag_assoc_generation_change_invalidates_stale_association() {
         "stale association evicted on the mismatched lookup",
     );
     assert!(
-        cache.lookup(&key, 1_300, gen0).is_none(),
+        cache.lookup(&key, 1_300, gen0, |_| true).is_none(),
         "stale association was evicted, not merely skipped",
     );
 
     // A NEW first fragment re-admitted under the current config re-establishes
     // the association, and it hits again under the current generation.
-    cache.install(key, decision, None, 1_400, gen1);
+    cache.install(key, decision, None, 1_400, gen1, 0);
     assert!(
-        cache.lookup(&key, 1_500, gen1).is_some(),
+        cache.lookup(&key, 1_500, gen1, |_| true).is_some(),
         "re-established association under the new generation hits",
     );
 }
@@ -5770,7 +5770,7 @@ fn frag_assoc_cross_domain_nonfirst_fragment_does_not_inherit_permit() {
     // Domain A: the permitted first fragment installs its decision.
     let ka = nat64_first_fragment_key(&first, libc::AF_INET6, frag_test_authority())
         .expect("domain-A first-fragment key");
-    cache.install(ka, decision, None, 1_000, 1);
+    cache.install(ka, decision, None, 1_000, 1, 0);
 
     // Domain B: a non-first fragment with the SAME (family, src, dst, ident) —
     // an attacker only has to reproduce a 32-bit fragment ID, which is not an
@@ -5782,7 +5782,7 @@ fn frag_assoc_cross_domain_nonfirst_fragment_does_not_inherit_permit() {
         "a different ingress domain must build a DIFFERENT key (fail-closed by construction)"
     );
     assert!(
-        cache.lookup(&kb, 1_100, 1).is_none(),
+        cache.lookup(&kb, 1_100, 1, |_| true).is_none(),
         "a non-first fragment from another security domain must NOT inherit domain A's permit"
     );
 
@@ -5793,7 +5793,7 @@ fn frag_assoc_cross_domain_nonfirst_fragment_does_not_inherit_permit() {
         .expect("domain-A non-first-fragment key");
     assert_eq!(ka, ka_nonfirst, "same-domain first/non-first share one key");
     assert!(
-        cache.lookup(&ka_nonfirst, 1_100, 1).is_some(),
+        cache.lookup(&ka_nonfirst, 1_100, 1, |_| true).is_some(),
         "a same-domain non-first fragment must still inherit (no over-blocking)"
     );
 }
@@ -5856,7 +5856,7 @@ fn frag_assoc_every_authority_dimension_is_load_bearing() {
 
         let cache = Nat64FragAssoc::new();
         let kf = nat64_first_fragment_key(&first, libc::AF_INET6, base).expect("first key");
-        cache.install(kf, decision, None, 1_000, 1);
+        cache.install(kf, decision, None, 1_000, 1, 0);
 
         // POSITIVE CONTROL FIRST: the baseline non-first fragment HITS. Ordered
         // before the negative assertion so a lookup that never returns anything
@@ -5864,7 +5864,7 @@ fn frag_assoc_every_authority_dimension_is_load_bearing() {
         let kn_base =
             nat64_nonfirst_fragment_key(&nonfirst, libc::AF_INET6, base).expect("baseline key");
         assert!(
-            cache.lookup(&kn_base, 1_100, 1).is_some(),
+            cache.lookup(&kn_base, 1_100, 1, |_| true).is_some(),
             "{dimension} control: the SAME-authority non-first fragment must inherit — without \
              this the negative assertion below is also satisfied by a cache that never hits"
         );
@@ -5872,14 +5872,14 @@ fn frag_assoc_every_authority_dimension_is_load_bearing() {
         let kn =
             nat64_nonfirst_fragment_key(&nonfirst, libc::AF_INET6, other).expect("non-first key");
         assert!(
-            cache.lookup(&kn, 1_100, 1).is_none(),
+            cache.lookup(&kn, 1_100, 1, |_| true).is_none(),
             "{dimension} must be part of the association authority; a fragment differing only \
              in it inherited the permit"
         );
         // And the entry the perturbed fragment failed to match is still LIVE —
         // it MISSED, rather than the lookup above having consumed or expired it.
         assert!(
-            cache.lookup(&kn_base, 1_200, 1).is_some(),
+            cache.lookup(&kn_base, 1_200, 1, |_| true).is_some(),
             "{dimension}: the baseline association must survive the cross-authority miss"
         );
     }
@@ -5907,17 +5907,17 @@ fn frag_assoc_protocol_collision_does_not_alias() {
         kf.protocol, PROTO_UDP,
         "the key's protocol must be parsed from the IPv6 Fragment Header's Next Header"
     );
-    cache.install(kf, decision, None, 1_000, 1);
+    cache.install(kf, decision, None, 1_000, 1, 0);
 
     let kn = nat64_nonfirst_fragment_key(&nonfirst, libc::AF_INET6, frag_test_authority())
         .expect("non-first key");
     let collided = Nat64FragKey { protocol: PROTO_TCP, ..kn };
     assert!(
-        cache.lookup(&collided, 1_100, 1).is_none(),
+        cache.lookup(&collided, 1_100, 1, |_| true).is_none(),
         "a TCP fragment must not inherit a UDP datagram's decision on an ident collision"
     );
     assert!(
-        cache.lookup(&kn, 1_100, 1).is_some(),
+        cache.lookup(&kn, 1_100, 1, |_| true).is_some(),
         "the matching-protocol fragment must still inherit"
     );
 }
@@ -5966,17 +5966,132 @@ fn frag_assoc_v4_key_carries_protocol_and_authority() {
     // anything: same-domain HITS, other-domain MISSES, and the entry the
     // other-domain fragment failed to match is still live afterwards.
     let cache = Nat64FragAssoc::new();
-    cache.install(kf, frag_v6_decision(), None, 1_000, 1);
+    cache.install(kf, frag_v6_decision(), None, 1_000, 1, 0);
     assert!(
-        cache.lookup(&kn, 1_100, 1).is_some(),
+        cache.lookup(&kn, 1_100, 1, |_| true).is_some(),
         "control: the same-domain v4 non-first fragment must inherit"
     );
     assert!(
-        cache.lookup(&kn_other, 1_100, 1).is_none(),
+        cache.lookup(&kn_other, 1_100, 1, |_| true).is_none(),
         "a v4 non-first fragment from another domain must NOT inherit"
     );
     assert!(
-        cache.lookup(&kn, 1_200, 1).is_some(),
+        cache.lookup(&kn, 1_200, 1, |_| true).is_some(),
         "the v4 association must survive the cross-domain miss (it missed, it did not vanish)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #6857: the RUNTIME-ownership fence on the fragment association.
+//
+// The config-generation fence (#5624) invalidates an association when a commit
+// changes deny/NAT64 rules. An RG transition is runtime HA state: it changes no
+// config and bumps no snapshot generation, so that fence cannot see it. Without
+// a runtime fence a non-first fragment keeps HITTING an association minted while
+// this node was forwarding-active, inheriting the earlier permit + egress + NAT
+// on a node no longer entitled to grant it — exactly what the #6458 owner-RG
+// gate prevents on the enforcement path.
+// ---------------------------------------------------------------------------
+
+fn frag_rg_fixture() -> (Nat64FragAssoc, Nat64FragKey, Nat64FragKey, SessionDecision) {
+    let src_v6: Ipv6Addr = "2001:db8::1".parse().expect("src");
+    let dst_v6: Ipv6Addr = "64:ff9b::808:808".parse().expect("dst");
+    let snat_v4 = Ipv4Addr::new(172, 16, 80, 8);
+    let dst_v4 = Ipv4Addr::new(8, 8, 8, 8);
+    let ident: u32 = 0x0000_BEEF;
+    let first = make_ipv6_frag_udp(src_v6, dst_v6, 1000, 53, &[0xAAu8; 16], 0, true, ident);
+    let nonfirst = make_ipv6_frag_udp(src_v6, dst_v6, 0, 0, &[0xBBu8; 24], 185, false, ident);
+    let kf = nat64_first_fragment_key(&first, libc::AF_INET6, frag_test_authority())
+        .expect("first-fragment key");
+    let kn = nat64_nonfirst_fragment_key(&nonfirst, libc::AF_INET6, frag_test_authority())
+        .expect("non-first-fragment key");
+    assert_eq!(kf, kn, "#6857 premise: the two fragments must share one key");
+    let decision = frag_test_decision(Nat64State::forward_decision(snat_v4, dst_v4, 5000));
+    (Nat64FragAssoc::new(), kf, kn, decision)
+}
+
+/// The property: an association minted under owner RG 3 must MISS once RG 3 is
+/// no longer forwarding-active locally.
+#[test]
+fn frag_assoc_refuses_a_hit_once_the_owner_rg_stops_forwarding_6857() {
+    let (cache, kf, kn, decision) = frag_rg_fixture();
+    cache.install(kf, decision, None, 1_000, 1, 3);
+
+    assert!(
+        cache.lookup(&kn, 1_500, 1, |_| false).is_none(),
+        "#6857: a non-first fragment must NOT inherit a permit this node is no \
+         longer entitled to grant. The association was minted while owner RG 3 \
+         was forwarding-active; it is not any more, and the config-generation \
+         fence cannot see that because an RG transition bumps no generation"
+    );
+}
+
+/// The POSITIVE control, without which the cell above is satisfied by a lookup
+/// that refuses everything.
+#[test]
+fn frag_assoc_still_inherits_while_the_owner_rg_is_forwarding_6857() {
+    let (cache, kf, kn, decision) = frag_rg_fixture();
+    cache.install(kf, decision, None, 1_000, 1, 3);
+
+    assert!(
+        cache.lookup(&kn, 1_500, 1, |rg| rg == 3).is_some(),
+        "#6857 CONTROL: an unchanged RG must still inherit — over-blocking here \
+         is a fragment blackhole, not a safety improvement"
+    );
+}
+
+/// owner_rg == 0 means NOT RG-dependent and must NEVER be fenced.
+///
+/// This is the cell that stops the fix becoming a regression: on a STANDALONE
+/// box (no chassis cluster) every resolution has owner RG 0, so a fence that
+/// treated 0 as "not entitled" would evict every association on every consult
+/// and disable fragment association for the entire non-HA deployment. The
+/// predicate below refuses everything, exactly as it would on a box with no HA
+/// state at all.
+#[test]
+fn frag_assoc_with_no_owner_rg_is_not_fenced_6857() {
+    let (cache, kf, kn, decision) = frag_rg_fixture();
+    cache.install(kf, decision, None, 1_000, 1, 0);
+
+    assert!(
+        cache.lookup(&kn, 1_500, 1, |_| false).is_some(),
+        "#6857: owner RG 0 is NOT RG-dependent and must not be fenced. A \
+         standalone box has no redundancy groups, so fencing on 0 would disable \
+         fragment association entirely for every non-HA deployment"
+    );
+}
+
+/// A refused hit must also EVICT, so the fence is not re-evaluated on every
+/// later fragment of a datagram that can never be inherited again.
+#[test]
+fn frag_assoc_evicts_the_entry_it_refuses_6857() {
+    let (cache, kf, kn, decision) = frag_rg_fixture();
+    cache.install(kf, decision, None, 1_000, 1, 3);
+    assert_eq!(cache.len(), 1, "#6857 premise: the install must be present");
+
+    assert!(cache.lookup(&kn, 1_500, 1, |_| false).is_none());
+    assert_eq!(
+        cache.len(),
+        0,
+        "#6857: a refused association must be evicted, not left to be re-judged \
+         by every subsequent fragment"
+    );
+}
+
+/// The two fences are INDEPENDENT: a stale generation must still refuse even
+/// while the owner RG is perfectly healthy.
+///
+/// Without this, a fix that replaced the config fence with the runtime one —
+/// rather than adding beside it — would pass every cell above.
+#[test]
+fn frag_assoc_config_fence_survives_the_rg_fence_6857() {
+    let (cache, kf, kn, decision) = frag_rg_fixture();
+    cache.install(kf, decision, None, 1_000, 1, 3);
+
+    assert!(
+        cache.lookup(&kn, 1_500, 2, |rg| rg == 3).is_none(),
+        "#6857: the #5624 config-generation fence must still refuse a \
+         stale-generation entry even when the owner RG is forwarding-active. \
+         The runtime fence is added BESIDE the config one, not instead of it"
     );
 }

--- a/userspace-dp/src/nat64_tests.rs
+++ b/userspace-dp/src/nat64_tests.rs
@@ -5010,13 +5010,17 @@ fn nat64_frag_assoc_ttl_evicts() {
     cache.install(key, decision, None, 1_000, 1, 0);
     assert_eq!(cache.len(), 1);
     // Still within the TTL window: hit.
-    assert!(cache
-        .lookup(&key, 1_000 + NAT64_FRAG_TTL_NS - 1, 1, |_| true)
-        .is_some());
+    assert!(
+        cache
+            .lookup(&key, 1_000 + NAT64_FRAG_TTL_NS - 1, 1, |_| true)
+            .is_some()
+    );
     // Past the (refreshed) TTL with no intervening hit: pruned + miss.
     cache.install(key, decision, None, 1_000, 1, 0);
     assert!(
-        cache.lookup(&key, 1_000 + NAT64_FRAG_TTL_NS + 1, 1, |_| true).is_none(),
+        cache
+            .lookup(&key, 1_000 + NAT64_FRAG_TTL_NS + 1, 1, |_| true)
+            .is_none(),
         "expired association must miss",
     );
     assert_eq!(cache.len(), 0, "expired entry pruned");
@@ -6005,7 +6009,10 @@ fn frag_rg_fixture() -> (Nat64FragAssoc, Nat64FragKey, Nat64FragKey, SessionDeci
         .expect("first-fragment key");
     let kn = nat64_nonfirst_fragment_key(&nonfirst, libc::AF_INET6, frag_test_authority())
         .expect("non-first-fragment key");
-    assert_eq!(kf, kn, "#6857 premise: the two fragments must share one key");
+    assert_eq!(
+        kf, kn,
+        "#6857 premise: the two fragments must share one key"
+    );
     let decision = frag_test_decision(Nat64State::forward_decision(snat_v4, dst_v4, 5000));
     (Nat64FragAssoc::new(), kf, kn, decision)
 }


### PR DESCRIPTION
Closes #6857

## The gap

`Nat64FragEntry.generation` (#5624) is a **config** fence and does its job. An RG transition — failover, tracked-interface demotion — is **runtime HA state**: it changes no config and bumps no snapshot generation, so a config-generation counter is structurally the wrong instrument for invalidating state whose validity depends on runtime ownership.

So a first fragment admitted while the owner RG was forwarding-active installed an association; the RG then stopped forwarding locally; and a later fragment still **HIT**, inheriting the earlier permit, egress and NAT on a node no longer entitled to grant it. That is exactly what the #6458 owner-RG gate prevents on the enforcement path, and the association path had no equivalent.

The entry now carries the owner RG of the resolution its first fragment resolved under, and `lookup` refuses **and evicts** when that RG is not forwarding-active.

## `owner_rg == 0` is deliberately NOT fenced — this is what keeps it a fix

On a **standalone box** (no chassis cluster) every resolution has owner RG 0. A fence that treated 0 as "not entitled" would evict every association on every consult and **disable fragment association for the entire non-HA deployment**. Only a positive owner RG is checked, and a cell pins it with a predicate that refuses everything.

## `lookup` takes a predicate, not the HA map

The RG to ask about is not known until the entry is found, so a caller cannot pre-compute a bool; and passing the map would drag `afxdp::HAGroupRuntime` — which is `pub(in crate::afxdp)` — into `nat64.rs`, widening a type's visibility to serve a fence. The closure keeps the HA vocabulary on the afxdp side of the boundary.

The refresh path re-stamps the owner RG too: a refresh means a later first fragment re-admitted under current state, so the entry must carry *that* admission's entitlement.

## Mutation matrix — full suite, `--test-threads=1`, fix committed first

| cell | mutation | verdict |
|---|---|---|
| N1 | remove the RG fence | **RED** — refuse + evict cells |
| N2 | fence `owner_rg 0` too | **RED** — and it reds *pre-existing* SNAT fragment tests, which is the standalone regression made visible |
| N4 | remove the CONFIG fence (replace rather than add beside) | **RED** — the independence cell |
| **N3** | **install always stamps 0** | **GREEN → then RED** |

**N3 is the one worth reading.** Replacing `owner_rg_for_resolution(...)` at both install sites with a literal `0` left the **entire suite green** — the fence was correct and *permanently unarmed*, because owner RG 0 is deliberately never fenced. Every cell called `install` directly with an explicit RG, pinning the fence and saying nothing about where the stamp comes from. The change would have shipped inert.

Fixed by driving a real NAT64 first fragment through `txn_run_descriptor` with an RG-bound egress and asking the published association which RG it carries — the fence predicate **records** what it is asked about, and a hardcoded 0 never reaches it at all.

Two fixture facts the PREMISE assertions turned into named failures rather than empty reads: the egress must actually be RG-bound (the fixture binds none, so a *derived* zero would be indistinguishable from a hardcoded one), and RG 3 must be forwarding-active or HA enforcement drops the first fragment before anything is published.

## `make test-failover` — owed and RUN

This touches the forwarding path and now reads HA state, so the smoke is owed. Run on the loss userspace cluster after a fresh `cluster-deploy` + `apply-cos-config.sh` (both rc=0):

**13 passed, 1 failed.** All thirteen failover assertions pass — 10 established / 10 synced sessions, survives fw0 reboot, rejoin without auto-preempt, and manual failover.

The single failure is aggregate iperf3 throughput at **0.0920 Gbps**, which is **#7673** — it reproduces on master (0.0924) and on an unrelated branch (0.0939). Not attributable here.

## Validation

- `cargo test -- --test-threads=1` — **rc=0, 4633 passed, 0 failed**
- `go test ./... -count=1` — **rc=0, 68 packages**
- `make test-failover` — 13/13 failover assertions, throughput cell is #7673
- rustfmt: no new drift in any touched file (`nat64_tests.rs` 98 → **97**, `frag_assoc.rs` 3 → 3, `tests_nat64_tunnel.rs` 39 → 39). No crate-wide fmt.
