### PR TITLE
daemon: bind the recovered-rollback dispatch, not just its guard

### DIFF
--- a/docs/log/6739.md
+++ b/docs/log/6739.md
@@ -1,0 +1,25 @@
+# #6739 — commit-confirmed recovery integrity: the pre-manager dispatch window
+
+- **Timestamp**: 2026-08-27
+  - **Action**: bound the WIRING of the pre-manager recovered-rollback window,
+    not just the guard #7676 added at one site. #7676 fixed the nil `d.vrrpMgr`
+    dereference that panics the daemon at boot, and bound it with a cell that
+    calls `applyTailReconciles` DIRECTLY — which cannot see an unguarded
+    dereference in any of the ~10 reconcile helpers AHEAD of the tail. Added two
+    cells that drive the REAL dispatch (the store's own timer-expiry logic via
+    `InvokeRollbackTimerForTesting`, the registered executor, the apply body
+    UNSTUBBED) against a daemon in the exact pre-manager shape — store present,
+    every manager nil — over both branches of `executeConfirmedRollback`.
+    Measured: with the merged guard in place the dispatch survives across four
+    real configs including two cluster configs, and the only failure is the
+    guard firing fail-closed; the census is clean at master but nothing bound
+    it. Mutation cell M3 (delete the nil-`d.routing` guard at the head of
+    `applyInterfaceReconcile`, an unguarded dereference ahead of the tail) reds
+    the new dispatch cell and leaves BOTH of #7676's cells GREEN — the coverage
+    gap demonstrated rather than argued.
+  - **File(s)**: pkg/daemon/recovered_rollback_dispatch_6739_test.go,
+    pkg/daemon/README.md, pkg/configstore/README.md
+  - **Scope note**: NOT work item G. G releases recovery at end-of-phase-5 and
+    moves the dispatch point; this moves none. G + H + H2 remain in #7675 with
+    their unresolved 2-of-3 reviewer split (Codex NEEDS-REVISION r60-r67 against
+    AGY / Claude SMR PLAN-READY).

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -529,6 +529,22 @@ per-path:
   a crash in the microseconds between the `writeActive` syscall and the
   `confirm.json` write leaves no `confirm.json` — vastly smaller than
   the whole multi-minute window this closes.
+
+  **The re-armed timer dispatches into a HALF-BUILT daemon (#6739).**
+  `recoverPendingConfirmLocked` runs at the tail of `Load`, which the daemon
+  calls in startup **phase 1**; the daemon's managers are not constructed until
+  **phase 3**, and nothing holds the daemon's apply semaphore across the phases.
+  The remaining duration is strictly positive (an already-expired window takes
+  the synchronous branch above and never reaches this re-arm) but is bounded
+  below only by how close the boot is to the deadline, so a reboot shortly
+  before the deadline arms a timer with seconds on it. The store is not the
+  right layer to fix that — it owns the deadline, not the daemon's startup
+  ordering — but the re-arm is where the hazard originates, so it is recorded
+  here. The daemon side (the fail-closed `d.vrrpMgr` guard, and the
+  dispatch-level coverage that binds it) is documented in
+  `pkg/daemon/README.md`, "The recovered commit-confirmed rollback fires against
+  a HALF-BUILT daemon (#6739)". The startup-readiness gate that would move the
+  dispatch point is work item G, held in #7675 with H and H2.
 - **A degenerate `confirm.json` is rejected, never treated as a valid
   pending confirm (#5637, codex-review-181 M29).** `ReadConfirm` now
   validates the record's shape and fields, mirroring the #5474

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -216,6 +216,65 @@ and absent from the plain-commit entry points) and
 `pkg/config/lenient_dropped_locator_6707_test.go` (both policy shapes, compiled
 by the real tolerant compiler rather than asserted into a struct literal).
 
+### The recovered commit-confirmed rollback fires against a HALF-BUILT daemon (#6739)
+
+`Store.Load` restores a still-live `commit confirmed` window by re-arming
+`time.AfterFunc(time.Until(deadline))` (#4577). That happens in startup **phase
+1** (`loadAndBootstrapConfig`), and `d.store.SetRollbackExecutor(
+d.executeConfirmedRollback)` is registered before the phase list even starts —
+while every manager `initManagers` builds (`d.routing`, `d.frr`, `d.networkd`,
+`d.ipsec`, `d.ra`, `d.cluster`, `d.vrrpMgr`, the dataplane) is not constructed
+until **phase 3**. Nothing holds `applySem` across the phases, so the timer
+goroutine and the startup phases run concurrently.
+
+The remaining duration is strictly positive — an already-expired window is
+rolled back *synchronously* in an earlier branch of
+`recoverPendingConfirmLocked` and never reaches the re-arm — but it is bounded
+below only by how close the boot is to the deadline. A box that reboots shortly
+before its deadline (`commit confirmed 1` plus a ~55 s boot) arms a timer with
+seconds on it, against startup phases doing netlink and manager construction.
+**So the whole rollback transaction can run with every manager nil.**
+
+Both branches of `executeConfirmedRollback` are reachable in that window:
+
+- `prevCfg != nil` — the full `applyConfigLocked` pipeline re-applies the
+  rollback target. `applyTailReconciles` step 8 is the site that was NOT
+  nil-guarded: it dereferenced `d.vrrpMgr` and **panicked the daemon at boot**.
+  It now fails CLOSED, matching the gate one branch below it — reporting a
+  successful apply while the manager does not hold the requested instance set
+  claims HA coverage that is not running, and a nil manager holds no instance
+  set at all.
+- `prevCfg == nil` — the #1922 Item 1b first-commit branch runs
+  `enterBootstrapMode` + `reconcileManagementAfterPromotion` instead of an
+  apply. Its teardown steps are individually nil-guarded
+  (`relinquishClusterForBootstrap` on `d.cluster`, the FRR and dataplane steps
+  on theirs).
+
+**Coverage is at the DISPATCH, not just at the guarded function.** The cell that
+enters `applyTailReconciles` directly binds the guard but cannot see an
+unguarded dereference in any of the ~10 reconcile helpers *ahead* of the tail —
+that would panic the daemon at boot while the direct-entry cell stayed green.
+`recovered_rollback_dispatch_6739_test.go` therefore drives the real dispatch
+(the store's own timer-expiry logic → the registered executor → an **unstubbed**
+apply body) against a daemon in the exact pre-manager shape, over both branches,
+with a rollback target that declares a chassis cluster and RETH members so the
+cluster/VRRP/fabric reconciles actually run. It asserts the apply REACHED the
+guarded site rather than surviving by returning early, and a fixture assertion
+fails if the config ever stops compiling to that cluster shape — an
+empty-config apply survives for reasons that have nothing to do with the guard
+and would report a clean census anyway.
+
+The pre-existing rollback cells in `bootstrap_rollback_test.go` drive the same
+dispatch but set `applyBodyForTest`, which returns from `applyConfigLocked`
+before any reconcile helper runs. That seam is why this panic survived to be
+found by reading rather than by the suite.
+
+This is deliberately **not** work item G's startup-readiness gate. G releases
+recovery at end-of-phase-5, and #7675 (which carries G + H + H2, and their
+unresolved 2-of-3 reviewer split) records that landing G without H converts this
+short pre-manager window into a post-manager bootstrap-with-live-cluster hybrid.
+Guarding the dereference and binding the dispatch move **no dispatch point**.
+
 ### Config-apply file layout (#5661)
 
 The config-apply path was carved out of the former ~3095-line

--- a/pkg/daemon/recovered_rollback_dispatch_6739_test.go
+++ b/pkg/daemon/recovered_rollback_dispatch_6739_test.go
@@ -1,0 +1,278 @@
+package daemon
+
+// recovered_rollback_dispatch_6739_test.go — #6739, the WIRING of the
+// pre-manager recovered-rollback window.
+//
+// #7676 guarded ONE dereference — `d.vrrpMgr` inside applyTailReconciles — and
+// bound it with a cell that calls applyTailReconciles DIRECTLY. That binds the
+// guarded function. It does not bind the dispatch that has to reach it:
+//
+//	Store.Load (phase 1) re-arms time.AfterFunc(time.Until(deadline))
+//	    -> fireConfirmTimer(gen)
+//	        -> the executor registered before the phase list
+//	            -> executeConfirmedRollback
+//	                -> applyConfigLocked        <- ~10 reconcile helpers
+//	                    -> applyTailReconciles  <- the guarded site
+//
+// Every manager between phase 1 and phase 3 is still nil on that path. If any
+// helper AHEAD of the tail dereferences one without a guard, the daemon panics
+// at boot exactly as it did before #7676 — and #7676's cell stays GREEN,
+// because it enters at the tail and never runs the helpers that panicked.
+//
+// These cells drive the REAL dispatch (Store's own timer-expiry logic via
+// InvokeRollbackTimerForTesting, the registered executor, the apply body
+// UNSTUBBED) against a daemon in the exact pre-manager shape, over BOTH
+// branches of executeConfirmedRollback:
+//
+//   - prevCfg != nil -> the full applyConfigLocked pipeline
+//   - prevCfg == nil -> enterBootstrapMode (the #1922 Item 1b first-commit
+//     branch, which is also work item H's scenario when the abandoned config
+//     declares a cluster)
+//
+// The bootstrap_rollback_test.go cells already drive this dispatch, but they
+// set applyBodyForTest, which returns from applyConfigLocked before ANY
+// reconcile helper runs. That seam is why the #6739 panic survived to be found
+// by reading rather than by the suite.
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// clusterConfig6739 is the rollback TARGET for the dispatch cells: a config
+// that declares a chassis cluster with RETH members, so the reverted apply
+// walks the cluster/VRRP/fabric reconciles rather than the empty-config
+// no-op branches. assertRichFixture6739 keeps it from silently degenerating.
+const clusterConfig6739 = `
+system {
+    host-name rollback-target;
+}
+chassis {
+    cluster {
+        cluster-id 22;
+        authentication-key "test-psk-6739";
+        reth-count 2;
+        heartbeat-interval 200;
+        heartbeat-threshold 5;
+        control-interface em0;
+        redundancy-group 0 {
+            node 0 priority 200;
+            node 1 priority 100;
+        }
+        redundancy-group 1 {
+            node 0 priority 200;
+            node 1 priority 100;
+            interface-monitor ge-0/0/1 weight 255;
+        }
+    }
+}
+interfaces {
+    em0 {
+        unit 0 { family inet { address 10.99.12.1/30; } }
+    }
+    ge-0/0/1 {
+        gigether-options { redundant-parent reth1; }
+    }
+    ge-0/0/2 {
+        gigether-options { redundant-parent reth0; }
+    }
+    reth0 {
+        redundant-ether-options { redundancy-group 1; }
+        unit 0 { family inet { address 172.16.50.8/24; } }
+    }
+    reth1 {
+        redundant-ether-options { redundancy-group 1; }
+        unit 0 { family inet { address 10.0.61.1/24; } }
+    }
+}
+security {
+    zones {
+        security-zone trust {
+            interfaces reth1.0;
+        }
+        security-zone untrust {
+            interfaces reth0.0;
+        }
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy allow-all {
+                match {
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then { permit; }
+            }
+        }
+    }
+}
+`
+
+// daemonInPreManagerWindow6739 is the daemon EXACTLY as it is when a recovered
+// commit-confirmed timer can fire: startup phase 1 has run (the store exists —
+// it is the object that armed the timer, and applySem is built in New before
+// any phase), and every manager phase 3 constructs is still nil.
+//
+// The apply body is deliberately NOT stubbed. Stubbing it is what makes the
+// pre-existing rollback cells blind to this window.
+func daemonInPreManagerWindow6739(t *testing.T) (*Daemon, *configstore.Store) {
+	t.Helper()
+	s := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	d := &Daemon{applySem: semaphore.NewWeighted(1), store: s}
+	s.SetRollbackExecutor(d.executeConfirmedRollback)
+	return d, s
+}
+
+// assertRichFixture6739 fails if the committed fixture did not actually
+// compile to the cluster shape these cells claim to exercise. Without it a
+// parse/compile regression would quietly reduce every cell below to the
+// empty-config no-op path — which survives for reasons that have nothing to do
+// with the guard, and would report a clean census anyway.
+func assertRichFixture6739(t *testing.T, s *configstore.Store) {
+	t.Helper()
+	cfg := s.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("fixture did not compile: ActiveConfig is nil")
+	}
+	if cfg.Chassis.Cluster == nil {
+		t.Fatal("fixture degenerated: the rollback target declares no chassis cluster, so " +
+			"the reverted apply never walks the cluster/VRRP reconciles this cell exists for")
+	}
+	if len(cfg.Interfaces.Interfaces) == 0 {
+		t.Fatal("fixture degenerated: no interfaces, so the interface/networkd reconciles no-op")
+	}
+	var reths int
+	for name := range cfg.Interfaces.Interfaces {
+		if strings.HasPrefix(name, "reth") {
+			reths++
+		}
+	}
+	if reths == 0 {
+		t.Fatal("fixture degenerated: no reth interfaces, so the RETH/VRRP reconciles no-op")
+	}
+}
+
+// TestRecoveredRollbackDispatchSurvivesPreManagerWindow6739 is the wiring cell
+// for the non-nil rollback target: the whole applyConfigLocked pipeline runs
+// with every manager nil.
+//
+// FAIL-ON-REVERT: remove the `d.vrrpMgr == nil` arm in applyTailReconciles and
+// this panics — which is what the daemon does at boot. It also reds for an
+// unguarded dereference in ANY helper ahead of the tail, which is the case
+// #7676's direct-entry cell cannot see.
+func TestRecoveredRollbackDispatchSurvivesPreManagerWindow6739(t *testing.T) {
+	d, s := daemonInPreManagerWindow6739(t)
+
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.LoadOverride(clusterConfig6739); err != nil {
+		t.Fatalf("LoadOverride(rollback target): %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("Commit(rollback target): %v", err)
+	}
+	assertRichFixture6739(t, s)
+
+	// The abandoned config the operator armed with `commit confirmed` and never
+	// confirmed. The reboot lands inside its window; Store.Load re-arms.
+	if err := s.LoadOverride("system { host-name abandoned; }"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.CommitConfirmed(1); err != nil {
+		t.Fatalf("CommitConfirmed: %v", err)
+	}
+	s.ExitConfigure()
+
+	// Precondition: this is the pre-manager shape, not a fully-built daemon.
+	if d.vrrpMgr != nil || d.routing != nil || d.frr != nil || d.networkd != nil ||
+		d.cluster != nil || d.ipsec != nil {
+		t.Fatal("precondition: every manager initManagers builds must be nil — phase 3 has not run")
+	}
+	if d.applyBodyForTest != nil {
+		t.Fatal("precondition: the apply body must NOT be stubbed — the stub is what hides this window")
+	}
+
+	buf, restore := captureSlog(t)
+	defer restore()
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("the recovered commit-confirmed rollback PANICKED on the "+
+					"pre-manager window — this is a daemon panic AT BOOT (#6739): %v", r)
+			}
+		}()
+		// The exact dispatch Store's expired timer runs.
+		s.InvokeRollbackTimerForTesting(s.ConfirmGenForTesting())
+	}()
+
+	// The dispatch must REACH the guarded site, not survive by returning early.
+	// Without this the panic assertion above is satisfied by an apply that
+	// aborted in helper 1 and never ran the tail at all — a vacuous green that
+	// would look identical to a healthy one.
+	//
+	// Keyed on the guard's own fail-closed message, which is the same string
+	// TestRecoveredRollbackDoesNotPanicBeforeManagers6739 asserts on, so the two
+	// cells bind ONE contract rather than two independently-rotting ones.
+	if !strings.Contains(buf.String(), "VRRP manager not initialized") {
+		t.Fatalf("the rollback apply never reached the guarded VRRP reconcile — this cell "+
+			"would then prove nothing about the tail. Log was:\n%s", buf.String())
+	}
+
+	// And the transaction must have completed: the store is back on the target.
+	if got := s.ActiveConfig(); got == nil || got.System.HostName != "rollback-target" {
+		t.Fatalf("rollback did not promote the target config: %#v", got)
+	}
+}
+
+// TestRecoveredFirstCommitClusterRollbackDispatchSurvives6739 is the wiring
+// cell for the OTHER branch: prevCfg == nil, so executeConfirmedRollback runs
+// enterBootstrapMode instead of an apply.
+//
+// This is also work item H's exact scenario — a FirstCommit record whose
+// recovered active declares a cluster — so the cell records what master
+// actually does there today rather than leaving it to be re-derived.
+func TestRecoveredFirstCommitClusterRollbackDispatchSurvives6739(t *testing.T) {
+	d, s := daemonInPreManagerWindow6739(t)
+
+	// FIRST commit on a fresh store, and it declares a cluster.
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.LoadOverride(clusterConfig6739); err != nil {
+		t.Fatalf("LoadOverride: %v", err)
+	}
+	if _, err := s.CommitConfirmed(1); err != nil {
+		t.Fatalf("CommitConfirmed: %v", err)
+	}
+	assertRichFixture6739(t, s)
+	s.ExitConfigure()
+
+	if d.inBootstrap() {
+		t.Fatal("precondition: not in bootstrap before the timeout")
+	}
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("the recovered FIRST-COMMIT rollback PANICKED on the pre-manager "+
+					"window — a daemon panic AT BOOT (#6739): %v", r)
+			}
+		}()
+		s.InvokeRollbackTimerForTesting(s.ConfirmGenForTesting())
+	}()
+
+	if !d.inBootstrap() {
+		t.Fatal("a first-commit commit-confirmed timeout must leave the daemon in BOOTSTRAP mode")
+	}
+	if s.EverCommitted() {
+		t.Fatal("after a first-commit rollback the store must read never-committed")
+	}
+}


### PR DESCRIPTION
Closes #6739

> **This PR changes ZERO production lines.** `git diff --stat` is four files: one new test file and three markdown. It does **not** fix a live panic — the panic was fixed in #7676, and the census below confirms no second unguarded site is live on master today. What this adds is the **binding**: coverage at the dispatch, so the next helper someone adds ahead of the tail cannot re-open the window with the suite still green.

**Read the scope note first, because #6739's title no longer describes what is left in it.**

#6739 was **split on 2026-08-27**. Its comment *"Split done — #7675 carries G+H+H2"* moved work items **G + H + H2** — with their unresolved 2-of-3 reviewer split (Codex NEEDS-REVISION r60→r67 against AGY / Claude SMR PLAN-READY) and the re-anchored MAJOR 1–4 evidence table — into **#7675**, which is open and carries them in full. The stated purpose was *"so that issue can close on its provable half instead of standing as an unbounded blocker."*

What #6739 retained is the **pre-manager recovered-rollback window**. #7676 fixed the one dereference that was panicking there. What it did not do is bind the *path* to that dereference — this closes that, and with it the issue. **G, H and H2 stay in #7675 and are untouched here.**

## What #7676 left open (coverage, not a live defect)

#7676 guarded the dereference that *was* panicking the daemon at boot — `d.vrrpMgr` in `applyTailReconciles` — and bound it with a cell that calls `applyTailReconciles` **directly**.

That binds the guarded function. It does not bind the dispatch that has to reach it:

```
Store.Load (phase 1) re-arms time.AfterFunc(time.Until(deadline))
  -> fireConfirmTimer(gen)
    -> the executor registered before the phase list
      -> executeConfirmedRollback
        -> applyConfigLocked        (~10 reconcile helpers)
          -> applyTailReconciles    (the guarded site)
```

`Store.Load` runs in phase 1, `initManagers` in phase 3, and nothing holds `applySem` across them — so **every** manager is nil on that path, not just `vrrpMgr`. No such dereference is unguarded on master today (see the census below) — but if one is ever introduced, it panics the daemon at boot exactly as before, while the direct-entry cell stays **green**: it enters below the helpers that panicked and never runs them.

That is not hypothetical framing. It is cell **M3** in the matrix below.

## What this adds

Two cells that drive the **real dispatch** — the store's own timer-expiry logic via `InvokeRollbackTimerForTesting`, the registered executor, and the apply body **UNSTUBBED** — against a daemon in the exact pre-manager shape (store present, because it is the object that armed the timer; every manager nil), over **both** branches of `executeConfirmedRollback`:

- `prevCfg != nil` → the full `applyConfigLocked` pipeline.
- `prevCfg == nil` → `enterBootstrapMode`, the #1922 Item 1b first-commit branch, exercised with a config that **declares a cluster** — work item H's exact scenario, so what master does there today is recorded rather than left to be re-derived by whoever takes #7675.

The pre-existing cells in `bootstrap_rollback_test.go` drive this same dispatch but set `applyBodyForTest`, which returns from `applyConfigLocked` **before any reconcile helper runs**. That seam is why the panic survived to be found by reading rather than by the suite.

### Two guards against a vacuous green

**The fixture cannot silently degenerate.** The rollback target declares a chassis cluster with RETH members so the cluster/VRRP/fabric reconciles actually run, and `assertRichFixture6739` fails if it ever stops compiling to that shape. An empty-config apply survives for reasons that have nothing to do with the guard and would report a clean census anyway.

**The apply must REACH the guarded site.** Without that assertion, "it did not panic" is satisfied by an apply that aborted in helper 1 and never ran the tail — a vacuous green that looks identical to a healthy one. It is keyed on the same fail-closed string `TestRecoveredRollbackDoesNotPanicBeforeManagers6739` asserts on, so the two cells bind **one** contract rather than two independently-rotting ones. Mutating that expected string produces exactly 1 `^--- FAIL`, so the check is itself armed.

## Measured vs. inferred

**Measured.** Before writing anything I ran the real dispatch — unstubbed apply, every manager nil — over four real configs (`docs/ha-cluster-userspace.conf`, `test/incus/xpf-cluster-fw0.conf`, `xpf-test.conf`, `xpf-vlan-test.conf`), on both branches. All survive at master, and the **only** failure is the #7676 guard firing fail-closed. So there is no second unguarded site live on master today — the census is clean, but until this PR **nothing bound it**.

**Measured.** The M3 verdicts below, per cell, each with `RUN=1` so each actually ran.

**Inferred, and stated as such.** That "no second site today" is a census over the configs I drove, not a proof over all configs. That is precisely why the cells sit at the dispatch: the binding, not the census, is what survives the next helper someone adds.

## Mutation matrix

Full-package `go test ./pkg/daemon/ -count=1 -v`, **no `-run` filter**, one mutation per cell, fix committed **before** mutating, tree verified clean after each restore.

| cell | RUN | named `^--- FAIL` |
|---|---|---|
| control | 2138 | **0** |
| **M1** — remove the `d.vrrpMgr == nil` guard (restore the shipped panic) | 1492\* | **2** — `TestRecoveredRollbackDispatchSurvivesPreManagerWindow6739`, `TestRecoveredRollbackDoesNotPanicBeforeManagers6739` |
| **M2** — guard skips instead of failing closed | 2138 | **2** — same two cells |
| **M3** — delete the nil-`d.routing` guard at the head of `applyInterfaceReconcile` (an unguarded deref **ahead of** the tail) | 37\* | see below |

\* M1 and M3 panic-abort the test binary, so the run truncates. M3's truncation lands before either #6739 file, so its verdicts are disambiguated with a per-cell run — `-run` used **only** for that, never for the matrix itself, and every cell reports `RUN=1`:

| cell under M3 | verdict |
|---|---|
| `TestRecoveredRollbackDispatchSurvivesPreManagerWindow6739` (**new**) | **FAIL** |
| `TestRecoveredRollbackDoesNotPanicBeforeManagers6739` (#7676) | PASS |
| `TestVRRPGuardDoesNotFireWhenTheManagerExists6739` (#7676) | PASS |
| `TestRecoveredFirstCommitClusterRollbackDispatchSurvives6739` (**new**) | PASS — correct; that branch never enters `applyConfigLocked` |

**That table is the whole argument.** A boot panic, and every one of #7676's cells reports clean.

## Docs

#7676 shipped **no** doc update, and `pkg/daemon/README.md` had no mention of #6739 or the window. Both module READMEs now carry it, per the repo contract that docs land in the same change:

- `pkg/daemon/README.md` — the full phase-1-vs-phase-3 ordering, why the remaining duration can be seconds, both branches of `executeConfirmedRollback`, why coverage has to sit at the dispatch rather than the guarded function, and an explicit note that this is **not** work item G.
- `pkg/configstore/README.md` — a cross-reference from the #4577 re-arm, which is where the hazard originates. The store owns the deadline, not the daemon's startup ordering, so the fix does not belong there — but the re-arm is the origin and now says so.

`docs/log/6739.md` for the action log (`_Log.md` is closed since #6874).

## Gate

- `go build ./...` → rc 0.
- `go test ./... -count=1` → **rc 0, 68 packages ok, 0 failures**, at HEAD `44c65dbcf`.
- `git merge-base --is-ancestor origin/master HEAD` → **verified** at `origin/master` `2a5c7224b`.
- Brought up to date with `git merge` (not rebase).
- **No smoke owed.** Test + docs only; zero production lines changed (`git diff --stat` is 4 files, all tests/markdown). No forwarding-path, cluster, VRRP-runtime, session-sync or failover behaviour change. No `userspace-dp` / `userspace-xdp` change, so **no cargo leg**.

**One pre-existing red, not mine:** the gate at my base `40ced4503` reddened on `TestLogMdIsClosedToNewEntries6874` — another lane's #7688 entries had been appended below the LOG-CLOSED sentinel in `_Log.md`. Verified pre-existing at the base commit and already fixed on master; my merge pulled in the move to `docs/log/7688.md`. Recorded in case another lane hit the same red and mis-attributed it.

## Refs

Closes #6739 — its retained half is now complete and bound. **#7675 keeps G + H + H2**, their ordering constraint, and the unresolved reviewer split; nothing here reduces that scope or moves any dispatch point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ez9XCjM9mPjtocRjkousdB

