### PR TITLE
configstore: state the at-rest encryption threat model

### DIFF
--- a/docs/log/6856.md
+++ b/docs/log/6856.md
@@ -1,0 +1,70 @@
+# #6856 — at-rest config encryption threat model
+
+## 2026-08-27 — verify the premise before writing anything
+
+- **Action**: re-verified #6856's cites against current `origin/master`
+  (`2a5c7224b`). The issue was pinned at `ad9591177`; line numbers moved but
+  the mechanism is unchanged.
+- **Findings**:
+  - `crypto.go readOrCreateMasterKey` still generates 32 `crypto/rand` bytes
+    and persists them to `.configdb/master.key` (0600), inside the same 0700
+    directory as the ciphertext (`masterKeyPath` = `filepath.Join(db.dir,
+    "master.key")`). Confirmed.
+  - `deriveEncryptionKeyFromSalt` still runs HKDF over that file's bytes with
+    info `"xpf-configstore-master-password"`. No operator input reaches it.
+    Confirmed.
+  - `maybeEncryptTreeJSON` takes exactly one thing from the config:
+    `masterPasswordPRF(tree)`, the PRF selector NAME. Empty selector means no
+    encryption at all.
+- **Correction to the issue's framing**: the title says the encryption is keyed
+  by an on-box key "not the operator master-password", which implies an operator
+  master-password exists. It does not. `system master-password` is closed-world
+  and leaf-complete with exactly one leaf, `pseudorandom-function`
+  (`config/schema_system.go`), so `set system master-password
+  plain-text-password <secret>` is REJECTED at commit. Verified empirically:
+  `SchemaValidate` returns `system master-password: unknown configuration
+  keyword "plain-text-password" under closed-world subtree`. Binding the KDF to
+  an operator secret would therefore require first ADDING a leaf the schema
+  deliberately rejects — not re-pointing an existing input.
+- **Correction to the issue's scope**: item 1 ("document that at-rest encryption
+  does not protect a copied `.configdb`") was ALREADY largely done by #4056.
+  `pkg/configstore/README.md` "Threat model — what 0600 + 0700 defends, and what
+  it does not" already says `master.key` sits beside the ciphertext and that
+  "an attacker who can read `xpf.conf.N` can equally read `master.key` one
+  directory over and decrypt". The issue did not check this.
+
+## 2026-08-27 — what actually remained, and what was done
+
+- **Action**: scoped the change to the genuine residual rather than restating
+  #4056.
+- **File(s)**: `pkg/configstore/README.md`,
+  `pkg/configstore/crypto_at_rest_threat_model_6856_test.go`
+- **Residual 1 — the POSITIVE guarantee was never stated.** The existing
+  section is titled for file permissions and discusses `master.key` as an aside
+  explaining why the text copies are not encrypted. Nothing said what encrypting
+  the JSON body actually buys: protection against a reader who gets the body
+  WITHOUT the sibling key file. Added a "What `system master-password`
+  encryption does and does not protect" subsection with a three-row table
+  (body-only reader: protected; directory copy: not; root: not).
+- **Residual 2 — the no-secret fact was undocumented for operators.** Stated
+  outright, with the rejected Junos spelling named.
+- **Residual 3 — nothing bound any of it.** Added two tests.
+- **Deliberately NOT done**: the HKDF info string
+  `"xpf-configstore-master-password"` is misleading but changing it re-keys
+  every existing DB, so it must ride with the deferred migration (issue item 2).
+  No KMS/TPM key hierarchy — that is the maintainer decision the issue is
+  waiting on, and implementing it because the title gestures at one would be
+  exactly the wrong move.
+
+## Tests
+
+- `TestAtRestKeyTravelsWithTheConfigDirectory6856` — PAIRED cell. A copy of the
+  whole `.configdb` directory must DECRYPT (the non-guarantee); a copy of the
+  body alone must NOT (the guarantee). Either half alone proves only
+  correlation. Guarded by three vacuity preconditions: the PRF must resolve
+  non-empty, the body must actually be an envelope, and the plaintext canary
+  must not survive into the body — without those, a silently-plaintext body
+  would make both halves pass for the wrong reason.
+- `TestMasterPasswordCarriesNoSecret6856` — `plain-text-password` rejected,
+  `pseudorandom-function` accepted. The second is the positive control: without
+  it the reject would pass even if the whole subtree were broken.

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -93,6 +93,51 @@ The JSON DB body is the one copy that IS AES-GCM encrypted when
 `system master-password` is set; the text rollback slots, archives, and
 `rescue.conf` stay cleartext-at-rest (0600) by the reasoning above.
 
+### What `system master-password` encryption does and does not protect (#6856)
+
+The section above explains why the *text* copies are not encrypted. This one
+states what encrypting the JSON DB body actually buys, because "AES-GCM at-rest
+encryption" reads stronger than the guarantee it delivers.
+
+**`system master-password` carries no secret.** It is an encryption-*policy*
+knob. The subtree is closed-world and leaf-complete with exactly one leaf,
+`pseudorandom-function` (`config/schema_system.go`), so the Junos form an
+operator reaches for first — `set system master-password plain-text-password
+<secret>` — is **rejected at commit**, not accepted and ignored. Presence of the
+subtree is the on/off switch; the leaf's value selects only the HKDF hash.
+`SystemConfig.MasterPassword` holds that selector *name*, not key material, and
+is deliberately a plain string rather than a `config.Secret`
+(`config/types_system.go`).
+
+**The key is a random on-box file.** `readOrCreateMasterKey` generates 32 bytes
+from `crypto/rand` and persists them to `.configdb/master.key` (0600) — the same
+0700 directory as the ciphertext it protects. No operator input reaches the KDF.
+
+So the guarantee is narrow, and narrower than "encrypted at rest" suggests:
+
+| Threat | Protected? | Why |
+|---|---|---|
+| A reader who obtains the DB **body** but not `master.key` — a backup or file-disclosure scoped to `active.json` | **Yes** | the body is AES-GCM ciphertext and the key is a separate file |
+| A copy of the **`.configdb` directory** — stolen appliance, disk image, whole-directory backup | **No** | `master.key` travels with the ciphertext |
+| **Root** on a running box | **No** | unattended boot: the daemon must decrypt with no operator present |
+
+Both rows of that contract are pinned by
+`TestAtRestKeyTravelsWithTheConfigDirectory6856`
+(`crypto_at_rest_threat_model_6856_test.go`) as a **paired** cell — a
+directory copy must decrypt, and a body-only copy must not. If a future change
+binds the KDF to an operator secret, moves `master.key` out of the DB directory,
+or seals it to a TPM, that test REDS and this table must be rewritten in the
+same change.
+
+**Two things deliberately not done here.** Binding the KDF to an operator secret
+is not a hardening tweak: it would first require *adding* a secret leaf the
+schema currently rejects, and then answering unattended boot, HA key
+distribution, and a power-cut-safe re-key migration — a maintainer decision,
+deferred (#6856). And the HKDF info string `xpf-configstore-master-password`
+(`crypto.go deriveEncryptionKeyFromSalt`) names a secret that never enters the
+derivation: it is misleading, but changing it re-keys **every existing DB**, so
+it must ride with that migration rather than being corrected casually.
+
 **Off-box copy — `transfer-on-commit`:** the honest place to control the
 residual is the off-box transfer, not on-box encryption. When
 `system archival configuration transfer-on-commit` is set, the daemon

--- a/pkg/configstore/crypto_at_rest_threat_model_6856_test.go
+++ b/pkg/configstore/crypto_at_rest_threat_model_6856_test.go
@@ -1,0 +1,174 @@
+package configstore
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6856: pin the ACTUAL at-rest-encryption threat model, in both directions.
+//
+// `system master-password` is an encryption-POLICY knob, not a secret: the
+// subtree is closed-world and carries exactly one leaf
+// (`pseudorandom-function`), so no operator secret ever enters the config.
+// The AES-GCM key is 32 random bytes in `.configdb/master.key`, written
+// alongside the ciphertext it protects.
+//
+// That yields a guarantee much narrower than "the config is encrypted at
+// rest", and the narrowness is the whole point of pkg/configstore/README.md's
+// "What at-rest encryption does and does not protect" section. These cells
+// bind the two facts that section asserts, so the documentation cannot drift
+// away from the code silently:
+//
+//   - a COPY OF THE DIRECTORY decrypts, because the key travels with it; and
+//   - a copy of the BODY ALONE does not.
+//
+// Deliberately a PAIRED cell. Either half alone proves only correlation: the
+// body-only half would still pass if encryption were skipped entirely and the
+// body were rejected for some unrelated reason, and the directory-copy half
+// would still pass if nothing were ever encrypted. Together they show the key
+// file is necessary AND sufficient — which is exactly the documented claim.
+//
+// If a future change binds the KDF to an operator secret, moves master.key
+// outside the DB directory, or seals it to a TPM, the directory-copy half
+// REDS. That is correct and intended: the security claim in the README would
+// no longer be true, and it must be rewritten in the same change.
+func TestAtRestKeyTravelsWithTheConfigDirectory6856(t *testing.T) {
+	// A canary that no default, no empty tree, and no fallback path could
+	// produce. If encryption were silently skipped, this string would appear
+	// verbatim in the on-disk body and the ciphertext assertion below fires.
+	plaintext := []byte(`{"canary":"XPF-6856-PRESHARED-KEY-CANARY","system":{}}`)
+
+	originDir := t.TempDir()
+	origin := &DB{dir: originDir}
+
+	tree := &config.ConfigTree{}
+	if path, err := config.ParseSetCommand(
+		"set system master-password pseudorandom-function sha256",
+	); err != nil {
+		t.Fatalf("ParseSetCommand: %v", err)
+	} else if err := tree.SetPath(path); err != nil {
+		t.Fatalf("SetPath: %v", err)
+	}
+
+	// Precondition: encryption must actually have happened. Without this the
+	// two cells below are vacuous — a plaintext body "decrypts" in any
+	// directory and would make the directory-copy half pass for the wrong
+	// reason.
+	if prf := masterPasswordPRF(tree); prf == "" {
+		t.Fatalf("fixture broken: masterPasswordPRF resolved empty, so nothing " +
+			"would be encrypted and both cells below would prove nothing")
+	}
+	body, err := origin.maybeEncryptTreeJSON(plaintext, tree)
+	if err != nil {
+		t.Fatalf("maybeEncryptTreeJSON: %v", err)
+	}
+	if _, ok, err := unmarshalEnvelope(body); err != nil || !ok {
+		t.Fatalf("fixture broken: encrypted body is not an envelope (ok=%t err=%v) — "+
+			"the cells below would be asserting over plaintext", ok, err)
+	}
+	if bytes.Contains(body, []byte("XPF-6856-PRESHARED-KEY-CANARY")) {
+		t.Fatal("the canary survived into the on-disk body verbatim — the body is " +
+			"not actually encrypted, so neither cell below means anything")
+	}
+	keyMaterial, err := os.ReadFile(origin.masterKeyPath())
+	if err != nil {
+		t.Fatalf("read master.key: %v", err)
+	}
+	if got := filepath.Dir(origin.masterKeyPath()); got != originDir {
+		t.Fatalf("master.key path %q is not inside the DB directory %q — the "+
+			"README's claim that a directory copy carries the key is no longer true",
+			origin.masterKeyPath(), originDir)
+	}
+
+	t.Run("a copy of the whole .configdb directory DECRYPTS", func(t *testing.T) {
+		// The stolen-appliance / disk-image / full-directory-backup case.
+		// master.key rides along with the ciphertext, so the thief reads the
+		// config. This is the documented NON-guarantee.
+		stolenDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(stolenDir, "master.key"), keyMaterial, 0600); err != nil {
+			t.Fatalf("copy master.key: %v", err)
+		}
+		stolen := &DB{dir: stolenDir}
+
+		got, decrypted, err := stolen.maybeDecryptTreeJSON(body)
+		if err != nil {
+			t.Fatalf("a copied .configdb directory failed to decrypt (%v) — if this "+
+				"is an intentional hardening change, the README's threat-model "+
+				"section must be rewritten in the same commit", err)
+		}
+		if !decrypted {
+			t.Fatal("body was not treated as encrypted at all")
+		}
+		if !bytes.Equal(got, plaintext) {
+			t.Fatalf("decrypted body = %q, want %q", got, plaintext)
+		}
+	})
+
+	t.Run("the body WITHOUT master.key stays opaque", func(t *testing.T) {
+		// The documented guarantee: a reader who gets the DB body but not the
+		// sibling key file learns nothing. This is the only case at-rest
+		// encryption actually defends.
+		bodyOnly := &DB{dir: t.TempDir()} // no master.key written
+
+		got, decrypted, err := bodyOnly.maybeDecryptTreeJSON(body)
+		if err == nil {
+			t.Fatalf("body decrypted without master.key (decrypted=%t, got=%q) — "+
+				"at-rest encryption would then protect nothing at all", decrypted, got)
+		}
+		if bytes.Contains(got, []byte("XPF-6856-PRESHARED-KEY-CANARY")) {
+			t.Fatal("plaintext canary leaked out of the failed-decrypt path")
+		}
+	})
+}
+
+// TestMasterPasswordCarriesNoSecret6856 pins the most surprising half of the
+// #6856 threat model, which pkg/configstore/README.md now states outright: xpf's
+// `system master-password` is a POLICY knob that carries no secret at all.
+//
+// A Junos operator reaches for `set system master-password plain-text-password
+// <secret>` first. In xpf that is REJECTED at commit by the closed-world gate
+// on the subtree — it is not accepted-and-ignored, which is the failure mode
+// that would make the README's "no operator input reaches the KDF" sentence
+// read as an accident rather than a contract.
+//
+// Both directions matter. The accept case alone would still pass if the
+// subtree stopped being closed-world (everything would be accepted); the
+// reject case alone would still pass if the whole subtree were rejected.
+func TestMasterPasswordCarriesNoSecret6856(t *testing.T) {
+	validate := func(t *testing.T, cmd string) error {
+		t.Helper()
+		tree := &config.ConfigTree{}
+		path, err := config.ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+		return config.SchemaValidate(tree, nil)
+	}
+
+	t.Run("a secret-bearing leaf is rejected at commit", func(t *testing.T) {
+		// If this ever commits clean, an operator would believe they had set a
+		// master password that keys the config DB. Nothing would key it, and
+		// the README's threat-model table would be describing a different
+		// product than the one shipping.
+		if err := validate(t, "set system master-password plain-text-password hunter2"); err == nil {
+			t.Fatal("`master-password plain-text-password` committed clean — an operator " +
+				"would believe a secret keys the config DB when the KDF never sees it")
+		}
+	})
+
+	t.Run("the PRF selector still commits", func(t *testing.T) {
+		// The positive control: the reject above must come from the leaf being
+		// unmodeled, not from the subtree being unusable.
+		if err := validate(t, "set system master-password pseudorandom-function sha256"); err != nil {
+			t.Fatalf("the one modeled leaf must still commit, got %v — without this the "+
+				"reject above would pass even if the whole subtree were broken", err)
+		}
+	})
+}


### PR DESCRIPTION
Closes #6856

## What this is

A **docs + guard** change. No production behaviour changes; no key hierarchy, no re-key, no migration.

`system master-password` enables AES-GCM encryption of the JSON config DB body, and `pkg/configstore/README.md` described that as "AES-GCM at-rest encryption" without stating what it actually protects. The guarantee is much narrower than the phrase implies, and nothing bound the narrow part to the code.

## Verifying the premise first — the issue's scope was partly stale

Re-verified every cite against current `origin/master`. The mechanism is unchanged, but **two of the issue's claims needed correcting**, and both shrink the work rather than grow it:

**1. Item 1 was already largely done.** #6856 asks to "document that at-rest encryption does not protect a copied `.configdb`". #4056 already did: `pkg/configstore/README.md` has a "Threat model — what 0600 + 0700 defends, and what it does not" section which says `master.key` sits beside the ciphertext and that *"an attacker who can read `xpf.conf.N` can equally read `master.key` one directory over and decrypt"*. The issue (pinned at `ad9591177`) did not check this.

**2. There is no operator master-password to bind to.** The issue's title says encryption is keyed by an on-box key *"not the operator master-password"*, implying one exists. It does not. The subtree is closed-world and leaf-complete with exactly one leaf, `pseudorandom-function`, so the Junos spelling an operator reaches for first is **rejected at commit**. Verified empirically:

```
set system master-password plain-text-password hunter2
  -> system master-password: unknown configuration keyword
     "plain-text-password" under closed-world subtree
set system master-password pseudorandom-function sha256
  -> nil
```

So binding the KDF to an operator secret would require first **adding** a leaf the schema deliberately rejects — not re-pointing an existing input. That materially changes the cost of the deferred design and is worth having written down.

## What actually remained, and is done here

1. **The positive guarantee was never stated.** The existing section is titled for *file permissions* and treats `master.key` as an aside explaining why the text copies are not encrypted. Nothing said what encrypting the JSON body buys: protection against a reader who obtains the body **without** the sibling key file. Added a subsection with a three-row table.
2. **The no-secret fact was undocumented for operators.** Now stated outright, naming the rejected Junos spelling.
3. **Nothing bound any of it.** Two tests, so the prose cannot drift from the code.

Deliberately **not** done, per the issue and by design:
- The HKDF info string `"xpf-configstore-master-password"` names a secret that never enters the derivation. It is misleading, but changing it **re-keys every existing DB**, so it must ride with the deferred migration.
- No KMS/TPM key hierarchy. That is the maintainer decision the issue is waiting on.

## Mutation matrix — measured

All cells: fix committed **first** (`4d596ace2`), one mutation per cell, `go test ./pkg/config/ ./pkg/configstore/ -count=1`, **full package, no `-run` filter**, tree restored between cells.

| # | Mutation | Expected | Named FAILs | Result |
|---|---|---|---|---|
| M1 | `masterKeyPath()` → outside the DB dir | key no longer travels with a directory copy | 1 — `TestAtRestKeyTravelsWithTheConfigDirectory6856` | ✅ RED |
| M2 | decrypt fails **OPEN** on missing `master.key` | body-only copy stops being opaque | 1 — `TestAtRestKeyTravelsWithTheConfigDirectory6856` | ✅ RED |
| M3 | encryption becomes a no-op | vacuity preconditions fire | 8, incl. `TestAtRestKeyTravelsWithTheConfigDirectory6856` | ✅ RED |
| M4 | subtree stops being `closedWorld` | `plain-text-password` would commit | 2, incl. `TestMasterPasswordCarriesNoSecret6856` | ✅ RED |
| M5 | the one modeled leaf renamed | **positive control** must red | 6, incl. `TestMasterPasswordCarriesNoSecret6856/the_PRF_selector_still_commits` | ✅ RED |

M5 localizes exactly as intended — the control subtest FAILs while its sibling `a_secret-bearing_leaf_is_rejected_at_commit` PASSes, so the pair is necessary *and* sufficient rather than one assertion masking the other.

### Two cells were VOID on first run and were re-run, not trusted

M4 and M5 initially reported `named-FAILs=0`, which a harness gating only on `grep -c '^--- FAIL'` would score as **escapes**. They were not. `/tmp` is a 32G tmpfs that had reached 100%, and Go's build `$WORK` lives under `$TMPDIR`:

```
compile: writing output: write $WORK/b001/_pkg_.a: no space left on device
```

A build break is not a red. Both cells were re-run after redirecting `TMPDIR` and are the results in the table above.

**The first workaround then manufactured a different false signal**, which is worth recording because it looks exactly like a code regression: pointing `TMPDIR` at a long path (`/home/ps/.xpftmp-close6846`) pushed `t.TempDir()`-derived unix socket paths past the ~107-byte `sun_path` limit, and 20+ `pkg/daemon` tests failed with `bind: invalid argument`. Confirmed environmental by running `pkg/daemon` **at clean `origin/master`** both ways: FAIL with the long path, `ok ... 43.787s` with `TMPDIR=/var/tmp`.

## Gate — measured

```
go test ./... -count=1   →   RC=0, 68 packages ok, 0 failures
```

- Gated head: `80229d995f4ae3e277b779fa2c4f357639d2c65a`
- `git merge-base --is-ancestor origin/master HEAD` → **YES** (re-gated after folding master; the pre-merge head `4d596ace2` was also green at 68 packages)
- `TMPDIR=/var/tmp` (see above)

## Measured vs inferred

**Measured:** every mutation cell; the full-repo gate; the closed-world accept/reject behaviour; that `pkg/daemon` is green at clean master with a short `TMPDIR`; that the pre-existing `gofmt` complaint on `confirm_recovery_uncompilable_target_6538_test.go` exists at `origin/master` and is untouched here.

**Inferred, not measured:** that no *other* consumer depends on the README wording; and the operational claim that a stolen appliance yields a readable config — the test proves a copied directory decrypts in-process, which is the mechanism, not a field exercise. No cluster/CoS smoke is relevant to this change, and none was run.
