### PR TITLE
config/NAT: decide the actionless-rule contract as non-terminal (#6823)

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -5229,15 +5229,98 @@ there very differently, and the difference is load-bearing:
   first outcome ("and is translated by that"), which presumes a later rule
   exists (#6820 re-gate). Source NAT reaches the fall-through by emitting
   the actionless rule and letting the Rust matcher's `else` arm `continue`;
-  destination NAT reaches it by skipping the rule in the builder. Making an
-  actionless rule terminal would newly exempt traffic that already-deployed
-  configs translate, so that is a migration-contract decision tracked on #5717
-  rather than a mechanical fix.
+  destination NAT reaches it by skipping the rule in the builder. Whether to
+  make such a rule TERMINAL instead was a migration-contract question, decided
+  on #6823 — see "#6823 — an actionless NAT rule is NON-TERMINAL" below.
   `TestTolerantActionlessRuleIsNotInert_5717`,
-  `actionless_rule_falls_through_to_later_broader_rule_5717` and
-  `actionless_rule_with_no_later_rule_passes_untranslated_5717` pin BOTH
-  dispositions, so neither the "inert" framing nor the "always translated by a
-  later rule" framing can silently return.
+  `actionless_rule_falls_through_to_later_broader_rule_5717`,
+  `actionless_rule_with_no_later_rule_passes_untranslated_5717` and
+  `actionless_dnat_entry_falls_through_6823` pin BOTH dispositions on BOTH
+  kinds, so neither the "inert" framing nor the "always translated by a later
+  rule" framing can silently return.
+
+**#6823 — an actionless NAT rule is NON-TERMINAL (decided).** A NAT rule
+admitted by the TOLERANT path carrying ZERO terminal actions does not stop rule
+evaluation: matching traffic falls THROUGH to whatever rule follows. That is
+now the stated contract rather than merely the observed behaviour, and changing
+it is a deliberate migration decision, not a cleanup. Four options were on the
+table — **A** non-terminal fall-through (chosen), **B** terminal (matched =>
+exempt, evaluation stops), **C** refuse to install the rule at the builder,
+**D** terminal and fail-CLOSED (drop the flow).
+
+- **B is the only option that changes a packet's fate, and it changes it in the
+  leaking direction.** Take the pinned fixture: an actionless rule matching
+  `10.0.61.0/24` followed by a broad `10.0.0.0/8 interface` rule. Today
+  `10.0.61.102` falls through and is translated to the egress address; under B
+  it is exempt and **leaves on the WAN untranslated**. That is the same
+  disposition #5688 went out of its way to eliminate a few lines above this very
+  `continue`, in this very matcher ("forwarded the packet UNTRANSLATED — the
+  private/internal source leaked onto the egress. Fail CLOSED instead"). The two
+  error directions are not symmetric: when the operator meant "translate", A is
+  correct and B leaks a private source silently, on upgrade; when the operator
+  meant "exempt", B is correct and A breaks the intent in a way that is
+  functional, visible and leaks nothing.
+- **Only B needs the fleet count; A is correct at any count.** The rule survives
+  only on a tolerant load — a config persisted before #5628 added the gate, one
+  peer-synced from an older node, or a rollback target — and until #7643 that
+  population was not merely unmeasured but MISREPRESENTED, because the `show`
+  renderer displayed `Action: interface` for an actionless rule. A migration
+  cost cannot be estimated from a view that could not show the shape.
+- **Junos parity does not decide it.** Junos NAT matching IS terminal, but Junos
+  requires `then`, so a committed Junos config cannot express this input at all.
+  Parity argues for terminal MATCHING — which this matcher already does on every
+  other arm — and says nothing about what an actionless ACTION should mean.
+- **C is packet-identical to A and strictly weaker.** A rule that is not
+  installed is not matched, so evaluation proceeds to the next rule, which is
+  exactly what `continue` does; the same `else` arm already sets
+  `*matched_counter = None`, so the rule is counter-invisible either way. C buys
+  no packet behaviour and removes the information the dataplane would need to
+  implement B later.
+- **D is the option most faithful to #5688 and it is still wrong here.** It
+  would blackhole flows a deployed node forwards today. #1960's no-brick
+  doctrine governs the tolerant load path specifically: its job is to keep a
+  node forwarding on a config it cannot refuse. Turning a malformed rule into a
+  drop is the brick #1960 exists to prevent.
+- **The #3043 security-policy precedent does not carry over.** An actionless
+  POLICY defaults to `PolicyDeny` (`compiler_security_policy.go`) — actionless
+  => fail-closed. That works because a policy's action space `{permit, deny}` is
+  ORDERED by safety, so a safe default exists. A NAT rule's is
+  `{translate, exempt}`, which is not ordered: exempting leaks the private
+  source, translating overrides the operator's intent. With no safe default AT
+  the rule, the safe move is not to decide at the rule at all — which is what
+  falling through does.
+
+**B is not foreclosed, and the reopening criterion is explicit.**
+`xpf_nat_rules_lenient_terminal_action` (#7640, shipped in #7643) reading zero
+across the fleet makes B's migration cost zero, at which point terminal matching
+is the better parity answer. The information B needs is still on the wire — the
+SNAT builder publishes the actionless rule, so the dataplane can be taught to
+stop on it. Preserving that is precisely why C was rejected.
+
+**No upgrade note and no first-hit log**, because A is the status quo: there is
+no behaviour difference to announce or to log. The operator-facing surface for
+the shape is the #7640 gauge plus the per-rule `show security nat
+{source,destination} rule detail` annotation.
+
+**The SNAT/DNAT builder asymmetry is deliberate, and aligning it would be a
+regression.** Source NAT emits the actionless rule and lets Rust's `else` arm
+`continue`; destination NAT skips it in `buildDestinationNATSnapshots`. Both
+reach the same decided disposition, so the asymmetry costs no packet. Aligning
+DNAT to SNAT — installing the entry — is NOT free: measured, `from_snapshots`
+cannot parse the empty `pool_address`, so it drops the entry and records a #4718
+reconcile parse error for every such rule on every reconcile, turning a
+config-level malformation into a recurring wire-corruption diagnostic. Aligning
+SNAT to DNAT is option C. What the asymmetry did owe was a BINDING on the DNAT
+side: the Go builder's skip was pinned (`TestTolerantActionlessRuleIsNotInert_5717`
+asserts ZERO published entries) but the resulting Rust behaviour was not, and
+`DestinationNATRuleSnapshot` is the xpfd->helper wire form, so a hand-built
+snapshot or a mixed-version pair delivers the shape anyway.
+`actionless_dnat_entry_falls_through_6823` closes that: it discriminates
+three-ways between today's fall-through, B landing by accident (`None`), and the
+`snap.off` placeholder being widened to cover any pool-less entry — which reads
+like a harmless generalization but installs the rule with a `0.0.0.0` pool, and
+`DnatEntry::to_outcome` branches on `off` ALONE, so every matching flow is
+translated into a blackhole. That single `if snap.off` token is the whole guard.
 
   The no-later-rule test asserts on `SourceNatLookup`, via
   `match_source_nat_result_for_tuple`, and NOT on the `Option`-returning

--- a/docs/log/6823.md
+++ b/docs/log/6823.md
@@ -1,0 +1,48 @@
+# #6823 — the actionless NAT rule contract: DECIDED non-terminal
+
+- **Timestamp**: 2026-08-27
+  - **Action**: decided the migration-contract question #6823 was split out of
+    #5717 to own. A leniently-loaded NAT rule carrying ZERO terminal actions is
+    **NON-TERMINAL**: matching traffic falls THROUGH to whatever rule follows.
+    Recorded the argument, the three rejected alternatives (terminal;
+    refuse-to-install; terminal-and-fail-closed) and the explicit criterion that
+    would REOPEN the terminal option in `docs/config-schema.md`, and retired the
+    "tracked on #5717 / asserts today's behavior, not a desired one" hedges at
+    every site that carried them.
+  - **File(s)**: docs/config-schema.md,
+    pkg/config/compiler_validate_strict_nat.go,
+    userspace-dp/src/nat/tests_source.rs,
+    pkg/dataplane/userspace/nat_terminal_action_tolerant_5717_test.go
+
+- **Timestamp**: 2026-08-27
+  - **Action**: bound the DNAT half of the decision, which was pinned only on
+    the Go side (`TestTolerantActionlessRuleIsNotInert_5717` asserts the builder
+    publishes ZERO entries — a MECHANISM pin on one side of the language
+    boundary). `DestinationNATRuleSnapshot` is the xpfd->helper wire form, so a
+    hand-built snapshot or a mixed-version pair delivers the shape anyway.
+    `actionless_dnat_entry_falls_through_6823` discriminates three ways:
+    today's fall-through, the terminal option landing by accident (`None`), and
+    the `snap.off` placeholder being widened to cover any pool-less entry —
+    which reads like a harmless generalization but installs the rule with a
+    `0.0.0.0` pool, and `DnatEntry::to_outcome` branches on `off` ALONE, so
+    every matching flow is translated into a blackhole.
+  - **File(s)**: userspace-dp/src/nat/tests_destination.rs,
+    userspace-dp/src/nat/destination.rs, userspace-dp/src/nat/mod.rs
+
+- **Timestamp**: 2026-08-27
+  - **Action**: three operator-surface defects found while binding the above,
+    all on the exact rule shape this issue is about. (1) #7640's `show`
+    annotation was wired on the SOURCE renderer only, while its record and
+    gauge walk both kinds — so `show security nat destination rule detail`
+    never said a rule had been admitted by a tolerant load. (2) The destination
+    arm of that annotation named only the mechanism ("the rule is not published
+    to the dataplane at all"), which is true and reads as INERT — the framing
+    #5717/#6820 retired; both arms now name the consequence, which the decision
+    licenses because it is kind-independent. (3) An ACTIONLESS destination rule
+    was reported as `references undefined or address-less pool ""`, asserting a
+    reference it does not carry and mis-attributing the cause — the destination
+    twin of the `Action: interface` defect #7640 fixed on the source side. The
+    #6534 shared predicate is deliberately unchanged; only the string splits.
+  - **File(s)**: pkg/natshow/dest.go, pkg/natshow/natshow.go,
+    pkg/config/nat_exclusion_reason.go,
+    pkg/natshow/nat_actionless_dnat_annotation_6823_test.go

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -3156,13 +3156,25 @@ func natThenTerminalActionCount(then NATThen) int {
 //     revision of this comment asserted only the first outcome ("...and is
 //     translated by it"), which presumes a later rule exists.
 //     Making an actionless rule terminal instead would newly exempt traffic that
-//     already-deployed configs translate, so it is a migration-contract
-//     decision tracked on #5717, not a mechanical fix.
+//     already-deployed configs translate. That was a migration-contract
+//     question, not a mechanical fix, and it is DECIDED on #6823: an actionless
+//     rule is NON-TERMINAL. The short form is that making it terminal is the
+//     only option that changes a packet's fate, and it changes it in the
+//     leaking direction — the pinned 10.0.61.0/24-then-10.0.0.0/8 fixture would
+//     stop translating and put a private source on the WAN, which is the exact
+//     disposition #5688 eliminated a few lines above the `continue` in this
+//     same matcher. Junos parity does not decide it either way (Junos matching
+//     IS terminal, but Junos requires `then`, so a committed Junos config
+//     cannot express this input at all). The full argument, the two rejected
+//     alternatives, and the explicit criterion that would REOPEN the terminal
+//     option live in docs/config-schema.md, "#6823 — an actionless NAT rule is
+//     NON-TERMINAL".
 //     TestTolerantActionlessRuleIsNotInert_5717,
-//     actionless_rule_falls_through_to_later_broader_rule_5717 and
-//     actionless_rule_with_no_later_rule_passes_untranslated_5717 pin BOTH
-//     dispositions so neither the "inert" framing nor the "always translated by
-//     a later rule" framing can silently return.
+//     actionless_rule_falls_through_to_later_broader_rule_5717,
+//     actionless_rule_with_no_later_rule_passes_untranslated_5717 and
+//     actionless_dnat_entry_falls_through_6823 pin BOTH dispositions on BOTH
+//     kinds so neither the "inert" framing nor the "always translated by a
+//     later rule" framing can silently return.
 //
 // Rule-sets are walked in sorted name order for a deterministic first-reported
 // offender.

--- a/pkg/config/nat_exclusion_reason.go
+++ b/pkg/config/nat_exclusion_reason.go
@@ -108,6 +108,24 @@ func DestinationNATRuleExcludedReason(dnat *DestinationNATConfig, rule *NATRule)
 	}
 	pool, ok := dnat.Pools[rule.Then.PoolName]
 	if !ok || pool == nil || pool.Address == "" {
+		// #6823: an ACTIONLESS rule names no pool at all, and saying it
+		// "references undefined or address-less pool \"\"" asserts a
+		// reference it does not carry — the destination twin of the
+		// `Action: interface` defect #7640 fixed on the source side, on
+		// exactly the rule shape an operator is trying to find. Worse than
+		// cosmetic: it mis-attributes the CAUSE, sending someone off to
+		// define a pool when the rule carries no translation action for a
+		// pool to belong to.
+		//
+		// The PREDICATE is deliberately untouched — this is the same branch
+		// under the same condition, returning a different string. #6534
+		// shares this function with buildDestinationNATSnapshotsWithFeeds so
+		// the builder and the renderer cannot disagree about which rules are
+		// armed; moving the condition would be the #6534 defect with the
+		// polarity reversed.
+		if rule.Then.PoolName == "" {
+			return "names no translation action (neither `pool` nor `off`)"
+		}
 		return "references undefined or address-less pool " + quoteName(rule.Then.PoolName)
 	}
 	// #3450: a non-host pool address would be coerced to its network base, and

--- a/pkg/dataplane/userspace/nat_terminal_action_tolerant_5717_test.go
+++ b/pkg/dataplane/userspace/nat_terminal_action_tolerant_5717_test.go
@@ -444,9 +444,21 @@ security {
 // Destination NAT reaches the same fall-through by a different mechanism: the
 // builder skips the rule entirely.
 //
-// This test asserts today's behavior, not a desired one — see the #5717
-// scoping note for why changing it is a migration-contract decision. It exists
-// so the "inert" framing cannot silently return.
+// This test asserts the DECIDED contract, not merely today's behavior: #6823
+// settled that an actionless rule is NON-TERMINAL, so matching traffic falls
+// through. Making it terminal is the one option that changes a packet's fate,
+// and it does so in the leaking direction (contra #5688); the argument, the
+// rejected alternatives and the criterion that would REOPEN the terminal option
+// are in docs/config-schema.md, "#6823 — an actionless NAT rule is
+// NON-TERMINAL". This test exists so neither the "inert" framing nor a silent
+// reversal of that decision can return.
+//
+// The DNAT sub-test below pins the BUILDER (zero published entries), which is
+// only the Go half of the DNAT story. The resulting dataplane behaviour is
+// pinned by actionless_dnat_entry_falls_through_6823
+// (userspace-dp/src/nat/tests_destination.rs), because
+// DestinationNATRuleSnapshot is the xpfd->helper WIRE form and a hand-built
+// snapshot or a mixed-version pair delivers the shape this builder never emits.
 func TestTolerantActionlessRuleIsNotInert_5717(t *testing.T) {
 	t.Run("source NAT emits the actionless rule", func(t *testing.T) {
 		cfg := compileSetLenient5717(t, []string{

--- a/pkg/natshow/dest.go
+++ b/pkg/natshow/dest.go
@@ -98,6 +98,16 @@ func RenderDestRuleDetail(w io.Writer, cfg *config.Config, dp Reader, crFn func(
 			// for these rules, so the pool address/port printed below is config
 			// the dataplane never installed.
 			noteNotInstalled(w, config.DestinationNATRuleExcludedReason(dnat, rule))
+			// #6823: #7640 wired this annotation on the SOURCE renderer only,
+			// while its record and gauge both walk source AND destination
+			// (TestOffendersCoverBothKinds7640). So the operator-facing half
+			// covered one kind: `show security nat destination rule detail`
+			// never said a rule had been admitted by a tolerant load, on
+			// exactly the paths — boot, peer-sync, rollback — where such a
+			// rule is the only kind that can exist. An enumerator that finds
+			// both kinds and a view that shows one is a coverage gap that
+			// looks identical to healthy from the operator's side.
+			noteLenientTerminalAction(w, cfg, "destination", rs.Name, rule.Name)
 
 			if rule.Then.PoolName != "" && dnat.Pools != nil {
 				if pool, ok := dnat.Pools[rule.Then.PoolName]; ok {

--- a/pkg/natshow/nat_actionless_dnat_annotation_6823_test.go
+++ b/pkg/natshow/nat_actionless_dnat_annotation_6823_test.go
@@ -1,0 +1,175 @@
+package natshow
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// nat_actionless_dnat_annotation_6823_test.go — #6823.
+//
+// #6823 decided the contract for a leniently-admitted ACTIONLESS NAT rule: it
+// is NON-TERMINAL, so matching traffic falls THROUGH to whatever rule follows.
+// The decision is only as good as what the operator is told, and #7640's
+// annotation told the two kinds different things.
+//
+// The source arm named the consequence ("does NOT stop rule evaluation, so
+// matching traffic falls through to any later broader rule"). The destination
+// arm named only the mechanism — "the rule is not published to the dataplane
+// at all" — which is TRUE and reads as INERT. That is the precise framing the
+// #5717 / #6820 line of work exists to retire: the rule being absent is exactly
+// WHY evaluation continues, so an operator who wrote a DNAT rule believing it
+// exempts a host is told the reassuring half of a sentence whose other half is
+// that the host is translated by the next broader rule.
+//
+// TestLenientlyAdmittedSourceRuleIsAnnotated7640 cannot see this: it renders
+// the SOURCE detail only, so the destination arm of the same switch was
+// unbound.
+
+func actionlessDestCfg6823() *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		RuleSets: []*config.NATRuleSet{{
+			Name:     "rd1",
+			FromZone: "untrust",
+			Rules:    []*config.NATRule{{Name: "actionless"}}, // no terminal action
+		}},
+	}
+	cfg.LenientNATTerminalActionRules = []config.LenientNATTerminalActionRule{
+		{Kind: "destination", RuleSet: "rd1", Rule: "actionless", Actions: 0},
+	}
+	return cfg
+}
+
+// TestActionlessDestRuleAnnotationNamesTheFallThrough6823 binds the
+// destination arm to the same standard as the source arm.
+//
+// The "ADMITTED BY TOLERANT LOAD" half is asserted first as a PRECONDITION: it
+// proves the annotation fired for this rule at all, so a missing "falls
+// through" is a wording gap and not a renderer that annotated nothing.
+func TestActionlessDestRuleAnnotationNamesTheFallThrough6823(t *testing.T) {
+	var b strings.Builder
+	RenderDestRuleDetail(&b, actionlessDestCfg6823(), nil, nil)
+	got := b.String()
+
+	if !strings.Contains(got, "ADMITTED BY TOLERANT LOAD") {
+		t.Fatalf("precondition: the leniently-admitted DESTINATION rule is not "+
+			"annotated at all, so the wording assertion below would be vacuous "+
+			"(#7640/#6823):\n%s", got)
+	}
+	if !strings.Contains(got, "falls through") {
+		t.Fatalf("the destination annotation does not name the CONSEQUENCE. "+
+			"#6823 decided an actionless rule is NON-TERMINAL, so matching "+
+			"traffic is translated by the next broader rule; telling the "+
+			"operator only that the rule is 'not published to the dataplane' "+
+			"reads as INERT — the framing #5717/#6820 retired:\n%s", got)
+	}
+	if !strings.Contains(got, "does NOT stop rule evaluation") {
+		t.Fatalf("the destination annotation does not say the rule is "+
+			"NON-TERMINAL. That is the #6823 contract in one clause, and it is "+
+			"what distinguishes 'your exemption silently does nothing' from "+
+			"'your exemption works':\n%s", got)
+	}
+}
+
+// TestActionlessDestRuleIsNotBlamedOnAPool6823 pins the destination twin of
+// the `Action: interface` defect #7640 fixed on the source side.
+//
+// An ACTIONLESS rule names no pool, and the #6534 NOT INSTALLED line reported
+// it as `references undefined or address-less pool ""` — asserting a reference
+// the rule does not carry, on exactly the rule shape an operator is hunting.
+// It is worse than cosmetic because it mis-attributes the CAUSE: the reader
+// goes off to define a pool, when the rule carries no translation action for a
+// pool to belong to.
+//
+// The NOT-INSTALLED half is asserted as a PRECONDITION so this cannot pass by
+// the line disappearing altogether — which would be a different regression
+// (#6534: the renderer must say the dataplane installed nothing) wearing the
+// same green.
+func TestActionlessDestRuleIsNotBlamedOnAPool6823(t *testing.T) {
+	var b strings.Builder
+	RenderDestRuleDetail(&b, actionlessDestCfg6823(), nil, nil)
+	got := b.String()
+
+	if !strings.Contains(got, "NOT INSTALLED") {
+		t.Fatalf("precondition: the actionless rule no longer reports NOT "+
+			"INSTALLED at all, so the wording assertions below are vacuous "+
+			"(#6534 requires the renderer to say the dataplane installed "+
+			"nothing):\n%s", got)
+	}
+	if strings.Contains(got, "address-less pool") {
+		t.Fatalf("an ACTIONLESS destination rule is blamed on a pool it does "+
+			"not reference (#6823). The rule names no translation action; "+
+			"reporting an undefined pool sends the operator to define one:\n%s",
+			got)
+	}
+	if !strings.Contains(got, "names no translation action") {
+		t.Fatalf("the NOT INSTALLED reason does not name the actual cause — "+
+			"that the rule carries no translation action:\n%s", got)
+	}
+}
+
+// TestDestRuleWithADanglingPoolStillNamesThePool6823 is the paired control for
+// the cell above, and the reason the fix is a message split rather than a
+// message replacement. A rule that genuinely DOES reference a missing pool must
+// still be told so: collapsing both cases to "names no translation action"
+// would trade one misattribution for another, and this cell is what makes the
+// two distinguishable rather than merely different from the old text.
+func TestDestRuleWithADanglingPoolStillNamesThePool6823(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		RuleSets: []*config.NATRuleSet{{
+			Name:     "rd1",
+			FromZone: "untrust",
+			Rules: []*config.NATRule{{
+				Name: "dangling",
+				Then: config.NATThen{Type: config.NATDestination, PoolName: "nope"},
+			}},
+		}},
+	}
+	var b strings.Builder
+	RenderDestRuleDetail(&b, cfg, nil, nil)
+	got := b.String()
+
+	if !strings.Contains(got, `address-less pool "nope"`) {
+		t.Fatalf("a rule that DOES reference a missing pool must still name it "+
+			"— the #6823 split must not swallow the #6534 dangling-pool "+
+			"reason:\n%s", got)
+	}
+	if strings.Contains(got, "names no translation action") {
+		t.Fatalf("a rule naming pool \"nope\" was reported as carrying no "+
+			"translation action; it carries one, pointing at a pool that does "+
+			"not exist:\n%s", got)
+	}
+}
+
+// TestHealthyDestRuleIsNotAnnotated6823 is the PAIRED control. Without it,
+// "the annotation names the fall-through" is satisfied by a renderer that
+// prints the sentence on every destination rule — which is the same noise as
+// annotating everything, and trains an operator to skip the line.
+func TestHealthyDestRuleIsNotAnnotated6823(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		Pools: map[string]*config.NATPool{"dp1": {Name: "dp1", Address: "10.0.0.5"}},
+		RuleSets: []*config.NATRuleSet{{
+			Name:     "rd1",
+			FromZone: "untrust",
+			Rules: []*config.NATRule{{
+				Name: "ok",
+				Then: config.NATThen{Type: config.NATDestination, PoolName: "dp1"},
+			}},
+		}},
+	}
+	var b strings.Builder
+	RenderDestRuleDetail(&b, cfg, nil, nil)
+	got := b.String()
+
+	if strings.Contains(got, "ADMITTED BY TOLERANT LOAD") {
+		t.Fatalf("a well-formed destination rule was annotated:\n%s", got)
+	}
+	if strings.Contains(got, "falls through") {
+		t.Fatalf("a well-formed destination rule was told its traffic falls "+
+			"through:\n%s", got)
+	}
+}

--- a/pkg/natshow/natshow.go
+++ b/pkg/natshow/natshow.go
@@ -102,13 +102,22 @@ func noteLenientTerminalAction(w io.Writer, cfg *config.Config, kind, ruleSet, r
 		}
 		var consequence string
 		switch {
-		case r.Actions == 0 && kind == "source":
+		case r.Actions == 0:
+			// #6823: ONE arm for both kinds, because the decision is that the
+			// CONSEQUENCE is kind-independent — an actionless rule is
+			// NON-TERMINAL either way. Source NAT reaches that by publishing
+			// the rule and letting the Rust matcher's `else` arm continue;
+			// destination NAT by not publishing it at all. Naming the
+			// MECHANISM per kind is what went wrong before: the destination
+			// arm said only "the rule is not published to the dataplane at
+			// all", which is true and reads as INERT — the exact framing the
+			// #5717/#6820 work retired — so the operator whose DNAT exemption
+			// silently does nothing was told the reassuring half of the
+			// sentence. The mechanism is already covered on that side by the
+			// #6534 NOT INSTALLED line; the consequence is what this one owes.
 			consequence = "it installs no translation and does NOT stop rule " +
 				"evaluation, so matching traffic falls through to any later " +
 				"broader rule"
-		case r.Actions == 0:
-			consequence = "it installs no translation; the rule is not published " +
-				"to the dataplane at all"
 		default:
 			consequence = fmt.Sprintf("it carries %d mutually-exclusive actions; "+
 				"all but one are discarded by a fixed precedence, not by "+

--- a/userspace-dp/src/nat/destination.rs
+++ b/userspace-dp/src/nat/destination.rs
@@ -349,8 +349,39 @@ impl DnatTable {
             // a placeholder that is never read (the exemption short-circuits
             // before any translation), so a missing/empty pool_address must NOT
             // drop the entry the way it does for a translate rule.
+            //
+            // #6823: an ACTIONLESS entry (`off` clear AND no pool at all) is
+            // the third shape, and it lands here too — the empty string does
+            // not parse, so the entry is dropped and the traffic falls
+            // through, which IS the decided contract (see the ZERO-actions
+            // bullet in pkg/config/compiler_validate_strict_nat.go). Only the
+            // DIAGNOSTIC was wrong: "unparseable pool address" sends an
+            // operator hunting a serialization bug, when the cause is a
+            // malformed CONFIG rule that named no translation action —
+            // precisely the shape `xpf_nat_rules_lenient_terminal_action`
+            // (#7640) reports on the control-plane side. The Go builder never
+            // emits this entry (`nat_destination.go` skips it), so reaching it
+            // means a hand-built snapshot or a mixed-version xpfd/helper pair;
+            // the drop, the counter and the loud log are all unchanged, and
+            // the message now names the actual cause so the two surfaces can
+            // be connected.
+            //
+            // NOTE this branch is load-bearing beyond its wording: widening the
+            // `snap.off` placeholder above to cover any pool-less entry would
+            // install this rule with a 0.0.0.0 pool, and `to_outcome` — which
+            // branches on `off` alone — would then TRANSLATE every matching
+            // flow into a blackhole. actionless_dnat_entry_falls_through_6823
+            // pins that.
             let pool_ip: IpAddr = if snap.off {
                 IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED)
+            } else if snap.pool_address.is_empty() {
+                nat_counters.record_parse_error(&format!(
+                    "DNAT rule {:?}: no translation action (neither a pool nor \
+                     `off`) — a malformed rule admitted by a tolerant load; the \
+                     rule is dropped and matching traffic falls through",
+                    snap.name
+                ));
+                continue;
             } else {
                 match snap.pool_address.parse() {
                     Ok(ip) => ip,

--- a/userspace-dp/src/nat/mod.rs
+++ b/userspace-dp/src/nat/mod.rs
@@ -279,6 +279,17 @@ pub(crate) struct NatCounterStore {
     /// fail-on-revert test) reads. Monotonic error counter, not a gauge: it is
     /// only bumped, never reset by a reconcile.
     parse_errors: Arc<AtomicU64>,
+    /// #6823: the `record_parse_error` DETAILS, captured in test builds so a
+    /// test can bind what the operator is told and not merely how many drops
+    /// happened. Two drops with different causes are indistinguishable by
+    /// `parse_errors` alone, and the message is the whole operator-facing
+    /// half of #4718's loud-skip doctrine — an actionless DNAT rule reported
+    /// as an "unparseable pool address" sends someone hunting a
+    /// serialization bug instead of the malformed config rule that
+    /// `xpf_nat_rules_lenient_terminal_action` (#7640) is already flagging.
+    /// Compiled out of production builds entirely.
+    #[cfg(test)]
+    parse_error_details: Arc<Mutex<Vec<String>>>,
 }
 
 impl NatCounterStore {
@@ -375,7 +386,22 @@ impl NatCounterStore {
     /// the log adds no forwarding latency.
     pub(crate) fn record_parse_error(&self, detail: &str) {
         self.parse_errors.fetch_add(1, Ordering::Relaxed);
+        #[cfg(test)]
+        if let Ok(mut d) = self.parse_error_details.lock() {
+            d.push(detail.to_string());
+        }
         eprintln!("xpf nat reconcile: dropping rule (unparseable field): {detail}");
+    }
+
+    /// #6823: the details recorded by [`record_parse_error`](Self::record_parse_error),
+    /// in call order. The testable seam for the MESSAGE, alongside
+    /// [`parse_errors`](Self::parse_errors) for the count.
+    #[cfg(test)]
+    pub(crate) fn parse_error_details(&self) -> Vec<String> {
+        self.parse_error_details
+            .lock()
+            .map(|d| d.clone())
+            .unwrap_or_default()
     }
 
     /// #4718: cumulative NAT reconcile parse-failure count (see

--- a/userspace-dp/src/nat/tests_destination.rs
+++ b/userspace-dp/src/nat/tests_destination.rs
@@ -2218,3 +2218,144 @@ fn dnat_unparseable_source_constraint_surfaces_and_still_fails_closed_5190() {
          a NAT reconcile parse error, not silently dropped"
     );
 }
+
+/// #6823 DECIDED CONTRACT: an ACTIONLESS destination-NAT entry — `off` clear
+/// and no pool at all — is NON-TERMINAL. It installs nothing, so matching
+/// traffic falls THROUGH to whatever rule follows.
+///
+/// This is the DNAT half of the migration-contract decision taken on #6823
+/// (option A, fall-through, over option B, terminal-and-exempt). The SNAT half
+/// is `actionless_rule_falls_through_to_later_broader_rule_5717` /
+/// `actionless_rule_with_no_later_rule_passes_untranslated_5717` in
+/// tests_source.rs. Until now the DNAT half was bound only in Go
+/// (`TestTolerantActionlessRuleIsNotInert_5717` asserts the builder publishes
+/// ZERO entries) — which pins the MECHANISM on one side of the language
+/// boundary and leaves the resulting BEHAVIOUR unbound on the other.
+///
+/// That gap is reachable. `DestinationNATRuleSnapshot` IS the xpfd->helper wire
+/// form, so a hand-built snapshot or a mixed-version xpfd/helper pair delivers
+/// the shape the current Go builder never emits — and any future change that
+/// aligns the DNAT builder to the SNAT one (the asymmetry #6823 was asked to
+/// settle) makes xpfd itself emit it on the ordinary path.
+///
+/// THREE-WAY DISCRIMINATION, which is why the fixture pairs the actionless rule
+/// with a later broader TRANSLATING rule rather than asserting a bare `None`:
+///
+///   - today / decided: `Some(192.168.99.99:9999)` — the actionless entry was
+///     not installed and the LATER rule translated. Fall-through, observed.
+///   - option B landing by accident (the actionless entry installs and exempts):
+///     `None`. A bare-`None` assertion could not tell this from today.
+///   - the `snap.off` placeholder in `from_snapshots` widened to cover any
+///     pool-less entry — which reads like a harmless generalization:
+///     `Some(0.0.0.0:0)`. `DnatEntry::to_outcome` branches on `off` ALONE
+///     (#6820), so a pool-less entry that gets INSTALLED translates every
+///     matching flow into a blackhole, silently. That single `if snap.off`
+///     token is the whole guard.
+///
+/// The CONTROL is what makes the measurement mean anything: the same rule, same
+/// position, same match criteria, given a pool, must win over the later rule.
+/// Without it "the later rule translated" is equally satisfied by a fixture
+/// whose first rule never matched at all.
+#[test]
+fn actionless_dnat_entry_falls_through_6823() {
+    // The narrow /32 rule, differing ONLY in whether a translation action is
+    // present. An exact-host entry always beats the /24 prefix in the lookup,
+    // so position is fixed and only actionlessness varies.
+    let narrow_host = |pool: &str| DestinationNATRuleSnapshot {
+        name: "actionless-narrow".to_string(),
+        destination_address: "203.0.113.50".to_string(),
+        destination_port: 80,
+        protocol: "tcp".to_string(),
+        from_zone: "untrust".to_string(),
+        pool_address: pool.to_string(),
+        pool_port: if pool.is_empty() { 0 } else { 8080 },
+        // off stays false: this is the ACTIONLESS shape, not the exemption.
+        ..DestinationNATRuleSnapshot::default()
+    };
+    // The later, BROADER translating rule the narrow rule falls through to —
+    // the same shape as the SNAT fixture's 10.0.61.0/24 -> 10.0.0.0/8 pair.
+    let broader_prefix = DestinationNATRuleSnapshot {
+        name: "catch-all".to_string(),
+        destination_prefix: "203.0.113.0/24".to_string(),
+        destination_port: 80,
+        protocol: "tcp".to_string(),
+        from_zone: "untrust".to_string(),
+        pool_address: "192.168.99.99".to_string(),
+        pool_port: 9999,
+        ..DestinationNATRuleSnapshot::default()
+    };
+    let lookup = |rules: &[DestinationNATRuleSnapshot], counters: &crate::nat::NatCounterStore| {
+        DnatTable::from_snapshots(rules, counters).lookup(
+            PROTO_TCP,
+            "198.51.100.1".parse().unwrap(),
+            "203.0.113.50".parse().unwrap(),
+            80,
+            "untrust",
+        )
+    };
+
+    // CONTROL: give the narrow rule a pool and it wins — proving its match
+    // criteria and its PRECEDENCE over the /24 are live, so the measurement
+    // arm's fall-through is caused by the missing action and nothing else.
+    let control_counters = crate::nat::NatCounterStore::default();
+    assert_eq!(
+        lookup(
+            &[narrow_host("192.168.1.10"), broader_prefix.clone()],
+            &control_counters
+        ),
+        Some(NatDecision {
+            rewrite_dst: Some("192.168.1.10".parse().unwrap()),
+            rewrite_dst_port: Some(8080),
+            ..NatDecision::default()
+        }),
+        "control: with a pool, the narrow /32 rule must win over the /24 and \
+         translate to its OWN pool — if it does not, the measurement arm below \
+         proves nothing about actionlessness"
+    );
+    assert_eq!(
+        control_counters.parse_errors(),
+        0,
+        "control: a well-formed pair must record no reconcile parse error"
+    );
+
+    // MEASUREMENT: strip the action. The rule must not install, and the later
+    // broader /24 must translate.
+    let counters = crate::nat::NatCounterStore::default();
+    assert_eq!(
+        lookup(&[narrow_host(""), broader_prefix.clone()], &counters),
+        Some(NatDecision {
+            rewrite_dst: Some("192.168.99.99".parse().unwrap()),
+            rewrite_dst_port: Some(9999),
+            ..NatDecision::default()
+        }),
+        "an actionless DNAT entry must be NON-TERMINAL — the later broader rule \
+         translates (#6823, decided). `None` here means the actionless rule \
+         became terminal-and-exempt (option B, a migration-contract change that \
+         must not land silently); `Some(0.0.0.0)` means a pool-less entry was \
+         INSTALLED and `to_outcome`, which branches on `off` alone, translated \
+         the flow into a blackhole"
+    );
+
+    // #4718 + #6823: the drop must stay OBSERVABLE, and must say what actually
+    // happened. Reporting this rule as an "unparseable pool address" sends an
+    // operator after a serialization bug rather than the malformed config rule
+    // that `xpf_nat_rules_lenient_terminal_action` (#7640) already reports on
+    // the control-plane side; the two surfaces have to name the same thing.
+    assert_eq!(
+        counters.parse_errors(),
+        1,
+        "the actionless rule's drop must be COUNTED — a silent drop is how a \
+         translation vanishes with no trace at the helper boundary"
+    );
+    let details = counters.parse_error_details();
+    assert_eq!(
+        details.len(),
+        1,
+        "expected exactly one drop detail: {details:?}"
+    );
+    assert!(
+        details[0].contains("actionless-narrow") && details[0].contains("no translation action"),
+        "the drop must NAME the actionless cause, not report an unparseable \
+         pool address: {details:?}"
+    );
+}

--- a/userspace-dp/src/nat/tests_source.rs
+++ b/userspace-dp/src/nat/tests_source.rs
@@ -928,10 +928,13 @@ fn off_wins_over_contradictory_pool_action_5717() {
 /// the sibling `actionless_rule_with_no_later_rule_passes_untranslated_5717`
 /// covers the other half of that sentence (#6820).
 ///
-/// This test asserts today's behavior, not a desired one. Making an actionless
-/// rule TERMINAL would be a migration-contract change (it would newly exempt
-/// traffic that deployed configs currently translate) and is tracked on #5717,
-/// not made here. Any such change must consciously update this test.
+/// This test asserts the DECIDED contract (#6823: an actionless rule is
+/// NON-TERMINAL), not merely today's behavior. Making one TERMINAL would newly
+/// exempt traffic that deployed configs currently translate — the leaking
+/// direction, contra #5688 a few lines above the `continue` this exercises.
+/// The decision, the rejected alternatives and the criterion that would REOPEN
+/// the terminal option are in docs/config-schema.md; any such change must
+/// consciously update that section AND this test.
 #[test]
 fn actionless_rule_falls_through_to_later_broader_rule_5717() {
     let rules = parse_source_nat_rules(&[
@@ -974,8 +977,9 @@ fn actionless_rule_falls_through_to_later_broader_rule_5717() {
         }),
         "an actionless rule must fall THROUGH to the later broader rule (today's \
          behavior). If this now reports an exemption, the actionless disposition \
-         was changed to terminal — a migration-contract change that must be \
-         reviewed on #5717, not landed silently"
+         was changed to terminal — reversing the #6823 decision, a \
+         migration-contract change that must be argued in \
+         docs/config-schema.md, not landed silently"
     );
 }
 
@@ -1056,8 +1060,9 @@ fn actionless_rule_with_no_later_rule_passes_untranslated_5717() {
             "actionless rule with NO later rule reported Matched({d:?}) — a rewrite \
              means the actionless arm started translating on a rule that names no \
              terminal action; a default (no-rewrite) decision means the actionless \
-             disposition became TERMINAL, a migration-contract change tracked on #5717 \
-             that must be reviewed, not landed silently"
+             disposition became TERMINAL, reversing the #6823 decision — a \
+             migration-contract change that must be argued in \
+             docs/config-schema.md, not landed silently"
         ),
     }
 }


### PR DESCRIPTION
Closes #6823

## The decision

**A leniently-loaded actionless NAT rule is NON-TERMINAL.** Matching traffic
falls THROUGH to whatever rule follows. That is now the stated contract rather
than merely the observed behaviour, and reversing it is a deliberate migration
decision.

#6823 was split out of the #5717 cohort to own exactly one question, and it
asked for a decision rather than an implementation. Four options were on the
table:

| | operator meant "translate" | operator meant "exempt" |
|---|---|---|
| **A** non-terminal, fall through *(chosen)* | correct | intent broken — functional, visible, **no leak** |
| **B** terminal (matched ⇒ exempt) | **private source on the egress**, silent, on upgrade | correct |
| **C** refuse to install at the builder | packet-identical to A | packet-identical to A |
| **D** terminal + fail-CLOSED (drop) | flow blackholed | flow blackholed |

**B is the only option that changes a packet's fate, and it changes it in the
leaking direction.** Take the pinned fixture: an actionless rule matching
`10.0.61.0/24` followed by a broad `10.0.0.0/8 interface` rule. Today
`10.0.61.102` falls through and is translated to the egress address; under B it
is exempt and leaves on the WAN untranslated. That is the same disposition
#5688 went out of its way to eliminate *a few lines above this very `continue`,
in this very matcher* — "forwarded the packet UNTRANSLATED — the
private/internal source leaked onto the egress. Fail CLOSED instead." The two
error directions are not symmetric, and the asymmetry is what decides it.

**Only B needs the fleet count; A is correct at any count.** The rule survives
only on a tolerant load — a config persisted before #5628 added the gate, one
peer-synced from an older node, or a rollback target. Until #7643 that
population was not merely unmeasured but *misrepresented*: the `show` renderer
displayed `Action: interface` for an actionless rule. A migration cost cannot be
estimated from a view that could not show the shape.

**Junos parity does not decide it.** Junos NAT matching *is* terminal, but Junos
requires `then`, so a committed Junos config cannot express this input at all.
Parity argues for terminal *matching* — which this matcher already does on every
other arm — and says nothing about what an actionless *action* should mean.

**C is packet-identical to A and strictly weaker.** A rule that is not installed
is not matched, so evaluation proceeds to the next rule, which is exactly what
`continue` does; the same `else` arm already sets `*matched_counter = None`, so
the rule is counter-invisible either way. C buys no packet behaviour and removes
the information the dataplane would need to implement B later.

**D is the option most faithful to #5688 and it is still wrong here.** It would
blackhole flows a deployed node forwards today. #1960's no-brick doctrine
governs the tolerant load path specifically: its job is to keep a node
forwarding on a config it cannot refuse.

**The #3043 precedent does not carry over.** An actionless *policy* defaults to
`PolicyDeny` (`compiler_security_policy.go:332`) — actionless ⇒ fail-closed.
That works because a policy's action space `{permit, deny}` is **ordered by
safety**. A NAT rule's is `{translate, exempt}`, which is not: exempting leaks
the private source, translating overrides intent. With no safe default *at* the
rule, the safe move is not to decide at the rule — which is what falling through
does.

**B is not foreclosed, and the reopening criterion is explicit:** the #7640
gauge reading zero across the fleet makes B's migration cost zero. Preserving
that option is precisely why C was rejected. **No upgrade note and no first-hit
log**, because A is the status quo — there is no behaviour difference to
announce or to log.

## The SNAT/DNAT builder asymmetry, settled

The issue's named residual. Source NAT emits the actionless rule and lets Rust's
`else` arm `continue`; destination NAT skips it in the builder. Both reach the
same decided disposition, so the asymmetry costs no packet — and **aligning it
in either direction is a regression**:

- Aligning DNAT → SNAT (install the entry) is **not free**. Measured:
  `from_snapshots` cannot parse the empty `pool_address`, so it drops the entry
  and records a #4718 reconcile parse error *per such rule per reconcile*,
  turning a config-level malformation into a recurring wire-corruption
  diagnostic.
- Aligning SNAT → DNAT is option C.

What the asymmetry *did* owe was a **binding on the DNAT side**, which this PR
adds. See below.

## What this changes

**1. The decision, recorded where it is read.** `docs/config-schema.md` gains
the full argument, the three rejected options and the reopening criterion. Every
site carrying a "tracked on #5717 / asserts today's behavior, not a desired one"
hedge is updated to the decided contract — the gate comment, both Rust `_5717`
fixtures, and the Go tolerant-path test.

**2. The DNAT half of the decision is bound.** It was pinned only in Go
(`TestTolerantActionlessRuleIsNotInert_5717` asserts the builder publishes ZERO
entries) — a *mechanism* pin on one side of the language boundary.
`DestinationNATRuleSnapshot` is the xpfd→helper **wire form**, so a hand-built
snapshot or a mixed-version pair delivers the shape the current builder never
emits. `actionless_dnat_entry_falls_through_6823` discriminates **three ways**
rather than asserting a bare `None`:

| observed | means |
|---|---|
| `Some(192.168.99.99:9999)` | today / decided — fall-through |
| `None` | B landed by accident |
| `Some(0.0.0.0)` | **silent blackhole** |

That last one is the finding. Widening the `snap.off` placeholder to cover any
pool-less entry reads like a harmless generalization, but it *installs* the rule
with a `0.0.0.0` pool — and `DnatEntry::to_outcome` branches on `off` **alone**
(#6820), so every matching flow is translated into a blackhole. **That single
`if snap.off` token is the whole guard**, and nothing bound it.

**3. Three operator-surface defects**, all on the exact rule shape this issue is
about, found while binding the above:

- **#7640's `show` annotation was wired on the SOURCE renderer only**
  (`source.go:113`), while its record and gauge walk both kinds
  (`TestOffendersCoverBothKinds7640`). `show security nat destination rule
  detail` never said a rule had been admitted by a tolerant load — on the only
  paths where such a rule can exist. An enumerator that finds both kinds and a
  view that shows one is a coverage gap that looks identical to healthy.
- **Its destination arm named only the mechanism** — "the rule is not published
  to the dataplane at all" — which is true and reads as **INERT**, the exact
  framing #5717/#6820 retired. Both arms now name the consequence, which the
  decision licenses: the consequence is kind-independent.
- **An actionless destination rule was reported as `references undefined or
  address-less pool ""`**, asserting a reference it does not carry and sending
  the reader off to define a pool. The destination twin of the `Action:
  interface` defect #7640 fixed on the source side. The #6534 shared
  install/render predicate is **deliberately untouched** — same branch, same
  condition, different string — because moving the condition would be #6534
  with the polarity reversed.

## Measured vs inferred

**Measured.** The actionless DNAT wire entry drops with `decision=None` and
`parse_errors=1` (`unparseable pool address ""`) — probe-run before any edit.
The `0.0.0.0` blackhole under a widened `snap.off` — observed as `rewrite_dst:
Some(0.0.0.0)` in cell R2. Deleting the DNAT builder's actionless skip is a
**no-op** (cell M4): `DestinationNATRuleExcludedReason` independently skips the
rule, so the Go-side property needs both guards disabled to red (cell M5). Every
matrix cell below.

**Inferred.** That the fleet count of affected configurations is non-zero — the
*reachable set* is non-zero by construction (pre-#5628 persisted config,
peer-sync from an older node, rollback target), but the count itself is a fleet
question the #7640 gauge now answers and this PR does not. The decision is
deliberately built not to depend on it: only B does.

## Mutation matrix

Fix committed **before** mutating. Every cell full-package, `-count=1`, **no
`-run` filter**; Rust cells run the whole suite (`--bins --tests
--test-threads=1`). Head `f477d145f` (re-gated at `d6d9ece94` after a second
master merge; the merge touched only `pkg/daemon`, `pkg/configstore` and
`docs/log`, no NAT or Rust path).

| # | mutation | site | cell that RED | ran | buildbreak |
|---|---|---|---|---|---|
| M1 | drop the destination annotation wiring | `natshow/dest.go` | `TestActionlessDestRuleAnnotationNamesTheFallThrough6823` | — | 0 |
| M2 | restore the shipped two-arm switch (destination names only the mechanism) | `natshow/natshow.go` | `TestActionlessDestRuleAnnotationNamesTheFallThrough6823` *(source cell stays green — localises)* | — | 0 |
| M3 | drop the actionless-reason split | `config/nat_exclusion_reason.go` | `TestActionlessDestRuleIsNotBlamedOnAPool6823` *(dangling-pool control stays green)* | — | 0 |
| M4 | delete the DNAT builder's actionless skip | `userspace/nat_destination.go` | **none — genuine NO-OP**, `DestinationNATRuleExcludedReason` skips it independently | **1862 collected** | 0 |
| M5 | neutralize **both** Go guards (two-site, deliberately) | `nat_destination.go` + `nat_exclusion_reason.go` | `TestTolerantActionlessRuleIsNotInert_5717/destination_NAT_drops_the_actionless_rule` | — | 0 |
| R1 | revert the actionless diagnostic branch | `nat/destination.rs` | `actionless_dnat_entry_falls_through_6823` | 4697 | 0 |
| R2 | widen `snap.off` to any pool-less entry — **the blackhole** | `nat/destination.rs` | `actionless_dnat_entry_falls_through_6823` (`rewrite_dst: Some(0.0.0.0)`) | 4697 | 0 |
| R3 | silent drop (remove `record_parse_error`) | `nat/destination.rs` | `actionless_dnat_entry_falls_through_6823` | 4697 | 0 |
| R4 | make the SNAT actionless arm **terminal** — option B lands | `nat/source.rs` | `actionless_rule_falls_through_to_later_broader_rule_5717` + `actionless_rule_with_no_later_rule_passes_untranslated_5717` | 4697 | 0 |

**M4 is scored on tests-collected, not on FAIL count.** A cell reporting zero
named FAILs is ambiguous: a genuine no-op and a build that never compiled look
identical, and the second reads as *good news* in a matrix. `/tmp` on this box
is a 32G tmpfs that hit ENOSPC during this work, and Go puts its build `$WORK`
under `$TMPDIR`, so that failure mode was live. M4 was therefore re-run with an
explicit gate — **1862 tests collected, 0 named FAILs, no `no space left` and no
build signal** — which is what makes "no-op" a measurement rather than an
absence. The Rust cells were already gated this way (`tests_ran=4697` each), and
M1/M2/M3/M5 each produced a named FAIL, which is proof-positive they ran. **No
cell in this matrix was void.**

Two harness corrections worth recording, since both would have inverted a
verdict:

- The first M2 was a **compound** mutation — it applied the destination-only
  string to *both* arms, so it red the source cell too and could not localise.
  Re-run as an exact restoration of what shipped; it then reds only the
  destination cell.
- The first tightened failure grep was `^test [a-z_:]+ \.\.\. FAILED`, which
  **excludes digits** — so it silently dropped every test name containing an
  issue number and reported R2 as reddening only an unrelated flaky wg test.
  Corrected to `[A-Za-z0-9_:]+` and every Rust cell re-run.

## Test plan

- [x] `go build ./...` → rc 0
- [x] `go test ./... -count=1` → **rc 0, 68/68 packages**, at `d6d9ece94`
- [x] `cargo test --bins --tests -- --test-threads=1` → **rc 0, 4764 passed, 0 failed**
- [x] `cargo fmt` — my four Rust files are clean; every remaining diff in them
      was verified **pre-existing at `origin/master`** via a detached baseline
      worktree, not assumed
- [x] `merge-base --is-ancestor origin/master HEAD` verified at the gated head
- [x] Docs updated in the same change: `docs/config-schema.md`, `docs/log/6823.md`

No cluster smoke: this changes no packet behaviour. The one production-code
change on the forwarding side (`nat/destination.rs`) alters a **diagnostic
string** on a reconcile path the Go builder never reaches; R1 confirms the drop,
the counter and the fall-through are unchanged by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhHmVt536ZsY2RVEhc8WPV
