### PR TITLE
logging: pin the RFC 3164 wire codes to the RFC

### DIFF
--- a/docs/log/6879.md
+++ b/docs/log/6879.md
@@ -1,0 +1,63 @@
+# #6879 — RFC 3164 facility/severity numbers are a wire contract
+
+## 2026-08-27 — provenance of the expected numbers
+
+- **Action**: fetched RFC 3164 RAW rather than via a summarizing tool, because
+  the expected column of this test IS the contract and a transcription from a
+  non-authoritative source agrees with whatever it was copied from.
+- **Source**: `https://www.rfc-editor.org/rfc/rfc3164.txt` — 72951 bytes,
+  md5 `7f7aef1274f676b90bff677d477a18e6`.
+- **Read**: §4.1.1, "Table 1. syslog Message Facilities" and "Table 2. syslog
+  Message Severities", plus the priority derivation paragraph, which supplies
+  two worked examples used verbatim as fixtures:
+  > "a kernel message (Facility=0) with a Severity of Emergency (Severity=0)
+  > would have a Priority value of 0. Also, a "local use 4" message
+  > (Facility=20) with a Severity of Notice (Severity=5) would have a Priority
+  > value of 165."
+- **Compared against the tree**: every xpf constant matches the RFC. Facilities
+  kern 0, user 1, daemon 3, auth 4, syslog 5, FTP 11, NTP 12, local0-7 16-23;
+  severities emergency 0 through debug 7. **This issue is a missing-test issue,
+  not a bug** — nothing was mis-numbered.
+
+## 2026-08-27 — premise check, and a refinement of the issue
+
+- **Action**: measured the issue's claim rather than assuming it.
+- `FacilityAuth 4 -> 9`: package **GREEN**. Premise confirmed.
+- But the issue says "Every table-driven test references the constants
+  symbolically on both sides", i.e. nothing is pinned. That is slightly
+  overstated, and the shape of the real gap is more interesting:
+
+  | mutation | result | why |
+  |---|---|---|
+  | `FacilityAuth 4 -> 9` | GREEN | genuinely unpinned |
+  | `FacilityLocal0 16 -> 6` | 2 FAILs | accidentally pinned by the literal `<132>` in `TestSyslogSendReceive` |
+  | `FacilityDaemon 3 -> 13` | 1 FAIL | pinned somewhere |
+  | `SyslogWarning 4 -> 2` | 6 FAILs | looks pinned — but see below |
+  | `SyslogDebug 7 -> 8` (ORDER-PRESERVING) | **GREEN** | the severity VALUE is not pinned at all |
+
+- **The sharpest finding**: the severity codes are pinned only by ORDER, never
+  by VALUE. The `ShouldSend` tests look like value tests and are not — any
+  renumbering that preserves the comparison order leaves them green. So
+  `SyslogDebug = 8` ships a wrong wire byte on every debug record with a fully
+  green suite. `SyslogWarning 4 -> 2` reds only because it reorders.
+
+## 2026-08-27 — what was added
+
+- **File(s)**: `pkg/logging/syslog_rfc3164_wire_codes_6879_test.go`
+- Four guards:
+  1. **Facility codes** — every declared constant against its Table 1 literal,
+     AND `ParseFacility(name)` against the same literal, so a rewired mapping is
+     caught as well as a renumbered constant.
+  2. **Severity codes** — every constant against its Table 2 literal. This is
+     the one the ordering tests cannot provide.
+  3. **Priority on the wire** — the RFC's own two worked examples driven through
+     a real UDP `Send`, not by re-computing `facility*8 + severity` in the test.
+     Re-deriving the formula would pass even if `Send` stopped using it.
+  4. **Sentinel invariant** — `SeverityEmergency(-1)` / `SeverityNone(-2)` are
+     MinSeverity FILTER sentinels, not wire codes. Guarding that they stay
+     distinct from `SyslogEmergency(0)` is what makes it safe to pin the golden
+     severity table to 0..7; collapsing them is the #5314 over-forward bug.
+- Codes 2, 6-10, 13-15 exist in RFC Table 1 but have no xpf constant. They are
+  deliberately ABSENT from the table rather than invented — asserting a value
+  for a constant that does not exist would be inventing a contract, not pinning
+  one.

--- a/pkg/logging/syslog_rfc3164_wire_codes_6879_test.go
+++ b/pkg/logging/syslog_rfc3164_wire_codes_6879_test.go
@@ -1,0 +1,194 @@
+package logging
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+// #6879: the RFC 3164 facility and severity numbers are a WIRE CONTRACT. They
+// leave the appliance verbatim inside `<PRI>` and a third-party collector files,
+// routes, retains and alerts on them. Nothing in this package pinned them to
+// their RFC values, so a renumbering shipped silently.
+//
+// # Provenance of the expected numbers
+//
+// Every literal below is transcribed from the normative tables of RFC 3164,
+// fetched raw rather than summarized:
+//
+//	https://www.rfc-editor.org/rfc/rfc3164.txt
+//	72951 bytes, md5 7f7aef1274f676b90bff677d477a18e6
+//
+// §4.1.1 "Table 1. syslog Message Facilities" and "Table 2. syslog Message
+// Severities". The two priority examples are quoted from the same section:
+//
+//	"The Priority value is calculated by first multiplying the Facility
+//	 number by 8 and then adding the numerical value of the Severity. For
+//	 example, a kernel message (Facility=0) with a Severity of Emergency
+//	 (Severity=0) would have a Priority value of 0.  Also, a "local use 4"
+//	 message (Facility=20) with a Severity of Notice (Severity=5) would
+//	 have a Priority value of 165."
+//
+// The numbers are recorded here rather than derived, because a transcription
+// from memory or from a second implementation agrees with whatever it was
+// copied from. These agree with the RFC or they are wrong.
+//
+// # Why the expected column is a bare integer
+//
+// The pre-existing tables reference the constants on BOTH sides of the
+// assertion, so they compare a value to itself and bind only WHICH names map,
+// never WHAT they map to. Measured before writing this: `FacilityAuth = 9`
+// leaves the whole package green.
+
+// rfc3164Facilities is RFC 3164 §4.1.1 Table 1, for the codes xpf declares.
+// Codes 2, 6..10, 13..15 are in the RFC but have no xpf constant; they are
+// deliberately absent rather than invented.
+var rfc3164Facilities = []struct {
+	junosName string // name accepted by ParseFacility, "" if not parseable
+	constant  int
+	rfc       int // literal from Table 1
+	rfcLabel  string
+}{
+	{"kern", FacilityKern, 0, "kernel messages"},
+	{"user", FacilityUser, 1, "user-level messages"},
+	{"daemon", FacilityDaemon, 3, "system daemons"},
+	{"auth", FacilityAuth, 4, "security/authorization messages"},
+	{"syslog", FacilitySyslog, 5, "messages generated internally by syslogd"},
+	{"", FacilityFTP, 11, "FTP daemon"},
+	{"", FacilityNTP, 12, "NTP subsystem"},
+	{"local0", FacilityLocal0, 16, "local use 0"},
+	{"local1", FacilityLocal1, 17, "local use 1"},
+	{"local2", FacilityLocal2, 18, "local use 2"},
+	{"local3", FacilityLocal3, 19, "local use 3"},
+	{"local4", FacilityLocal4, 20, "local use 4"},
+	{"local5", FacilityLocal5, 21, "local use 5"},
+	{"local6", FacilityLocal6, 22, "local use 6"},
+	{"local7", FacilityLocal7, 23, "local use 7"},
+}
+
+// rfc3164Severities is RFC 3164 §4.1.1 Table 2 in full.
+var rfc3164Severities = []struct {
+	constant int
+	rfc      int // literal from Table 2
+	rfcLabel string
+}{
+	{SyslogEmergency, 0, "Emergency: system is unusable"},
+	{SyslogAlert, 1, "Alert: action must be taken immediately"},
+	{SyslogCritical, 2, "Critical: critical conditions"},
+	{SyslogError, 3, "Error: error conditions"},
+	{SyslogWarning, 4, "Warning: warning conditions"},
+	{SyslogNotice, 5, "Notice: normal but significant condition"},
+	{SyslogInfo, 6, "Informational: informational messages"},
+	{SyslogDebug, 7, "Debug: debug-level messages"},
+}
+
+func TestRFC3164FacilityCodesAreGolden6879(t *testing.T) {
+	for _, f := range rfc3164Facilities {
+		if f.constant != f.rfc {
+			t.Errorf("facility constant = %d, RFC 3164 Table 1 says %d (%s) — "+
+				"this integer goes out on the wire verbatim, so a collector would "+
+				"file every record under the wrong facility",
+				f.constant, f.rfc, f.rfcLabel)
+		}
+		if f.junosName == "" {
+			continue
+		}
+		// End-to-end: bind the NAME -> NUMBER mapping, not just the constant's
+		// value, so a rewired ParseFacility is caught as well as a renumbering.
+		if got := ParseFacility(f.junosName); got != f.rfc {
+			t.Errorf("ParseFacility(%q) = %d, RFC 3164 Table 1 says %d (%s)",
+				f.junosName, got, f.rfc, f.rfcLabel)
+		}
+	}
+}
+
+// TestRFC3164SeverityCodesAreGolden6879 pins severity VALUES.
+//
+// The pre-existing ShouldSend tests look like they cover this and do not: they
+// assert ORDERING, so they survive any renumbering that preserves the
+// comparison order. Measured before writing this: `SyslogDebug = 8` leaves the
+// whole package green while every debug record ships the wrong wire byte.
+func TestRFC3164SeverityCodesAreGolden6879(t *testing.T) {
+	for _, s := range rfc3164Severities {
+		if s.constant != s.rfc {
+			t.Errorf("severity constant = %d, RFC 3164 Table 2 says %d (%s)",
+				s.constant, s.rfc, s.rfcLabel)
+		}
+	}
+}
+
+// TestRFC3164PriorityOnTheWire6879 binds the PRI byte the collector actually
+// receives, using the RFC's own two worked examples.
+//
+// Deliberately driven through a real UDP send rather than re-computing
+// `facility*8 + severity` in the test: re-deriving the formula here would pass
+// even if Send stopped using it. The expected values are the RFC's, not this
+// test's arithmetic.
+func TestRFC3164PriorityOnTheWire6879(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		facility int
+		severity int
+		wantPRI  string // quoted from RFC 3164 §4.1.1
+	}{
+		{"kernel + emergency -> <0>", FacilityKern, SyslogEmergency, "<0>"},
+		{"local use 4 + notice -> <165>", FacilityLocal4, SyslogNotice, "<165>"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer pc.Close()
+			addr := pc.LocalAddr().(*net.UDPAddr)
+
+			client, err := NewSyslogClient("127.0.0.1", addr.Port)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer client.Close()
+			client.Facility = tc.facility
+
+			if err := client.Send(tc.severity, "rfc3164 priority probe"); err != nil {
+				t.Fatal(err)
+			}
+			buf := make([]byte, 4096)
+			n, _, err := pc.ReadFrom(buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(buf[:n])
+			if !strings.HasPrefix(got, tc.wantPRI) {
+				t.Errorf("wire PRI = %.12q…, want prefix %s — RFC 3164 §4.1.1 states "+
+					"this exact priority for this facility/severity pair",
+					got, tc.wantPRI)
+			}
+		})
+	}
+}
+
+// TestMinSeveritySentinelsAreNotWireCodes6879 guards the #5314 invariant that
+// makes the two tables above safe to read separately.
+//
+// SeverityEmergency(-1) and SeverityNone(-2) are MinSeverity FILTER sentinels,
+// not RFC severities — the file says so, and the golden table above therefore
+// pins SyslogEmergency to 0 rather than to them. If a future change collapsed
+// the sentinel onto the wire code, `emergency` would mean send-all again (the
+// #5314 over-forward bug) AND the golden table would start describing a
+// different thing than the wire.
+func TestMinSeveritySentinelsAreNotWireCodes6879(t *testing.T) {
+	if SeverityEmergency == SyslogEmergency {
+		t.Error("SeverityEmergency collapsed onto the wire code SyslogEmergency(0), " +
+			"which is the send-all sentinel — the #5314 over-forward bug")
+	}
+	if SeverityNone >= 0 {
+		t.Errorf("SeverityNone = %d, must stay negative so it cannot collide with "+
+			"an RFC 3164 severity code", SeverityNone)
+	}
+	// The sentinels must also not collide with each other or the filter cannot
+	// distinguish "send only emergency" from "send nothing".
+	if SeverityNone == SeverityEmergency {
+		t.Error("SeverityNone and SeverityEmergency are equal — `none` and " +
+			"`emergency` would be indistinguishable to ShouldSend")
+	}
+}


### PR DESCRIPTION
Closes #6879

## Provenance of the expected numbers — the part that decides whether this test is worth anything

The expected column of a golden test **is** the contract. A transcription from memory, or from a second implementation, agrees with whatever it was copied from and proves nothing.

So RFC 3164 was fetched **raw**, not through a summarizing tool:

```
https://www.rfc-editor.org/rfc/rfc3164.txt
72951 bytes, md5 7f7aef1274f676b90bff677d477a18e6
```

Read: §4.1.1 "Table 1. syslog Message Facilities", "Table 2. syslog Message Severities", and the priority derivation paragraph, which supplies both wire fixtures verbatim:

> "The Priority value is calculated by first multiplying the Facility number by 8 and then adding the numerical value of the Severity. For example, a kernel message (Facility=0) with a Severity of Emergency (Severity=0) would have a Priority value of 0. Also, a "local use 4" message (Facility=20) with a Severity of Notice (Severity=5) would have a Priority value of 165."

The URL, size, md5 and quoted paragraph are recorded in the test file header, so a future reader can re-derive the expectations from the same source rather than trusting this PR.

**Compared against the tree: every xpf constant already matches the RFC. No constant was wrong — this is a missing-test issue, not a bug.**

## Premise check — confirmed, and refined

`FacilityAuth 4 → 9` leaves `pkg/logging` fully green. Confirmed at `2cbb4f0c8`.

But the issue says *"Every table-driven test references the constants symbolically on both sides"*, i.e. nothing is pinned. That is slightly overstated, and the real shape is more interesting:

| mutation | result | why |
|---|---|---|
| `FacilityAuth 4 → 9` | **GREEN** | genuinely unpinned |
| `FacilityLocal0 16 → 6` | 2 FAILs | accidentally pinned by the literal `<132>` in `TestSyslogSendReceive` |
| `FacilityDaemon 3 → 13` | 1 FAIL | pinned somewhere |
| `SyslogWarning 4 → 2` | 6 FAILs | *looks* pinned — see below |
| `SyslogDebug 7 → 8` (**order-preserving**) | **GREEN** | the severity VALUE is not pinned at all |

**The sharpest finding: severity codes are pinned only by ORDER, never by VALUE.** The `ShouldSend` tests look like value tests and are not — any renumbering that preserves comparison order leaves them green. `SyslogDebug = 8` ships a wrong wire byte on every debug record with the package fully green; `SyslogWarning 4 → 2` reds only because it *reorders*.

## What was added

1. **Facility codes** — every declared constant against its Table 1 literal, **and** `ParseFacility(name)` against the same literal, so a rewired mapping is caught as well as a renumbered constant.
2. **Severity codes** — every constant against its Table 2 literal. This is the coverage the ordering tests cannot give.
3. **Priority on the wire** — the RFC's two worked examples driven through a **real UDP `Send`**, not by re-computing `facility*8 + severity` in the test. Re-deriving the formula would pass even if `Send` stopped using it.
4. **Sentinel invariant** — `SeverityEmergency(-1)` / `SeverityNone(-2)` are MinSeverity *filter* sentinels, not wire codes. The file says so, and the golden table therefore pins `SyslogEmergency` to 0 rather than to them. Collapsing a sentinel onto the wire code is the #5314 over-forward bug.

RFC codes 2, 6-10 and 13-15 have no xpf constant. They are **deliberately absent** rather than invented — asserting a value for a constant that does not exist would be inventing a contract, not pinning one.

## Mutation matrix — measured

Fix committed **first** (`e661586b9`), one mutation per cell, `go test ./pkg/logging/ -count=1`, full package, **no `-run` filter**, tree restored between cells. Gated on tests-collected > 0, with `named-FAILs == 0 && build-signals > 0` treated as **VOID**.

| # | Mutation | Named FAILs | ran | build sigs | Result |
|---|---|---|---|---|---|
| M1 | `FacilityAuth 4 → 9` — the issue's own measured escape | **1** — `TestRFC3164FacilityCodesAreGolden6879` | 1 | 0 | ✅ RED |
| M2 | `SyslogDebug 7 → 8` — order-preserving | **1** — `TestRFC3164SeverityCodesAreGolden6879` | 1 | 0 | ✅ RED |
| M3 | `ParseFacility("auth")` rewired to local0 | 5, incl. `…Golden6879` | 1 | 0 | ✅ RED (overlaps #6829/#6830) |
| M4 | `Send`: `Facility*8` → `Facility*16` | 4, incl. `TestRFC3164PriorityOnTheWire6879` | 1 | 0 | ✅ RED (overlaps existing) |
| M5 | `SeverityEmergency -1 → 0` | 0 | 1 | **1** | ⚠️ **VOID — build break** |
| M5′ | `SeverityNone -2 → 99` | **1** — `TestMinSeveritySentinelsAreNotWireCodes6879` | 1 | 0 | ✅ RED |

M1 and M2 are the load-bearing cells: each reds **exactly one** test, mine, and each was fully green before this PR.

**M5 is reported honestly rather than dropped.** Collapsing `SeverityEmergency` onto `SyslogEmergency` does not compile — `duplicate case SeverityEmergency … in expression switch` in `ShouldSend`. So **the compiler already enforces that half of the invariant**, and that assertion is documentation rather than a load-bearing guard. M5′ tests the half that *is* mutable and reds by name. A cell with zero named failures and a build signal is VOID, never an escape.

## Gate — measured

```
go test ./... -count=1   →   RC=0, 68 packages ok, 0 failures
```

- Gated head: `e661586b9f51088a9eedf375f8d7796afe11016e`
- `git merge-base --is-ancestor origin/master HEAD` → **YES**, 0 commits behind `2cbb4f0c8`
- `TMPDIR=/var/tmp` (bare); 0 `no space left`, 0 `bind: invalid argument`

## Measured vs inferred

**Measured:** all six mutation cells; the full-repo gate; the premise (`FacilityAuth = 9` green before, red after); the order-vs-value distinction for severities; that the RFC constants in the tree already match the fetched RFC text.

**Inferred, not measured:** that no collector-side behaviour depends on the codes beyond the PRI byte. No runtime behaviour changes in this PR — it adds tests only — so no cluster or syslog smoke was run.
