### PR TITLE
logging: bind the second PRI construction site

### DIFF
--- a/docs/log/6879.md
+++ b/docs/log/6879.md
@@ -61,3 +61,21 @@
   deliberately ABSENT from the table rather than invented — asserting a value
   for a constant that does not exist would be inventing a contract, not pinning
   one.
+
+## 2026-08-27 — a second PRI site, found by checking the "two spellings" hazard
+
+- **Action**: checked whether the wire numbers have a SECOND spelling anywhere
+  (Rust, docs, a second Go table), since binding one side to a literal is only
+  correct when there is one side.
+- **Result on the numbers**: there is exactly ONE spelling. No Rust or doc
+  table names them, and `junosRemoteFacility` references the constants
+  symbolically rather than repeating literals. So the RFC literal is the only
+  available anchor and pinning to it is right.
+- **But the ARITHMETIC is spelled twice.** `LocalLogWriter.Send`
+  (`locallog.go:139`) builds the same `<PRI>` independently of
+  `SyslogClient.Send` (`syslog.go:584`), for the sd-syslog format, into a file
+  operators and collectors read. The first revision of this test bound only the
+  network path — my own "bind the wiring" gap, one site of two.
+- Added `TestRFC3164PriorityInTheLocalFile6879`. Both sites are pinned to the
+  RFC's literals rather than to each other: a shared edit changing both copies
+  identically would satisfy an agreement check and still ship the wrong byte.

--- a/pkg/logging/syslog_rfc3164_wire_codes_6879_test.go
+++ b/pkg/logging/syslog_rfc3164_wire_codes_6879_test.go
@@ -2,6 +2,8 @@ package logging
 
 import (
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -190,5 +192,57 @@ func TestMinSeveritySentinelsAreNotWireCodes6879(t *testing.T) {
 	if SeverityNone == SeverityEmergency {
 		t.Error("SeverityNone and SeverityEmergency are equal — `none` and " +
 			"`emergency` would be indistinguishable to ShouldSend")
+	}
+}
+
+// TestRFC3164PriorityInTheLocalFile6879 binds the SECOND site that constructs a
+// PRI byte.
+//
+// `SyslogClient.Send` is not the only producer: `LocalLogWriter.Send` builds the
+// same `<PRI>` independently for the sd-syslog format
+// (`locallog.go`, `priority := lw.Facility*8 + severity`), into a file
+// operators and collectors read. Binding only the network path would leave the
+// duplicate unguarded — the arithmetic is spelled twice, and a change to one
+// copy is exactly the drift a single-site test cannot see.
+//
+// Both sites are pinned to the RFC's literals rather than to each other. That
+// is deliberately stronger than asserting the two agree: a shared edit that
+// changed both copies identically would satisfy an agreement check and still
+// ship the wrong byte to the collector.
+func TestRFC3164PriorityInTheLocalFile6879(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		facility int
+		severity int
+		wantPRI  string // quoted from RFC 3164 4.1.1
+	}{
+		{"kernel + emergency -> <0>", FacilityKern, SyslogEmergency, "<0>"},
+		{"local use 4 + notice -> <165>", FacilityLocal4, SyslogNotice, "<165>"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "security.log")
+			lw, err := NewLocalLogWriter(LocalLogConfig{Path: path})
+			if err != nil {
+				t.Fatal(err)
+			}
+			lw.Format = "sd-syslog"
+			lw.Facility = tc.facility
+			if err := lw.Send(tc.severity, "rfc3164 local priority probe"); err != nil {
+				t.Fatal(err)
+			}
+			if err := lw.Close(); err != nil {
+				t.Fatal(err)
+			}
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.HasPrefix(string(b), tc.wantPRI) {
+				t.Errorf("local-file PRI = %.12q..., want prefix %s — RFC 3164 4.1.1 "+
+					"states this exact priority, and the local writer must file "+
+					"records identically to the network path",
+					string(b), tc.wantPRI)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Follow-up to #7704 (which merged while this was being written). Same issue, #6879 — the wire-code contract — but a **second construction site** that #7704 left unbound.

## The gap

`SyslogClient.Send` is not the only producer of a syslog priority byte. `LocalLogWriter.Send` builds the same `<PRI>` independently for the `sd-syslog` format:

```go
// pkg/logging/locallog.go
priority := lw.Facility*8 + severity
```

versus

```go
// pkg/logging/syslog.go
priority := s.Facility*8 + severity
```

into a file operators and collectors read. #7704 bound only the network path, so the duplicate was unguarded — the arithmetic is spelled twice, and a change to one copy is exactly the drift a single-site test cannot see.

## How it was found

By checking whether the wire **numbers** have a second spelling, which is the precondition for "pin to a literal" being the right instrument at all:

- **No Rust table** names them.
- **No doc** names them.
- `junosRemoteFacility` references the constants **symbolically** rather than repeating literals.

So the numbers have exactly one spelling and the RFC literal is the only available anchor — pinning to it is correct. But the sweep turned up that the **arithmetic** is duplicated, which is a different quantity from the numbers and the one that was actually at risk.

## Why both sites are pinned to the RFC, not to each other

Deliberately stronger than an agreement assertion: a shared edit that changed **both** copies identically would satisfy "the two agree" and still ship the wrong byte to the collector. Each site is anchored to RFC 3164 §4.1.1's own worked examples — `<0>` for kernel+emergency, `<165>` for local-use-4+notice — so a common-mode change reds both rather than neither.

## Mutation — measured

| # | Mutation | Named FAILs | ran | build sigs | Result |
|---|---|---|---|---|---|
| M6 | `locallog.go`: `lw.Facility*8` → `lw.Facility*16` | **1** — `TestRFC3164PriorityInTheLocalFile6879` | 1 | 0 | ✅ RED |

**Exactly one named failure, and it is the new test** — nothing else in the package caught it, which is the measurement showing the gap was real rather than theoretical. (For contrast, the same mutation applied to `syslog.go` in #7704 red 4 tests, because that path already had incidental coverage. This one had none.)

## Gate — measured

```
go test ./... -count=1   →   RC=0, 68 packages ok, 0 failures
```

- Gated head: `de78821124b2d52b49f5cd40ff1892a77313b79b`
- `git merge-base --is-ancestor origin/master HEAD` → **YES** (re-gated after folding master)
- `TMPDIR=/var/tmp` (bare); 0 `no space left`, 0 `bind: invalid argument`

## Measured vs inferred

**Measured:** the M6 cell; the full-repo gate; that the wire numbers have exactly one spelling across Go, Rust and docs.

**Inferred:** that no third PRI construction site exists outside `pkg/logging` — the sweep covered `pkg/**/*.go` for `facility`/`severity`-adjacent `*8 +` expressions and found these two only.
