### PR TITLE
docs/cluster: retire the dual-accept prose #5078 left behind

### DIFF
--- a/docs/log/6881.md
+++ b/docs/log/6881.md
@@ -1,0 +1,19 @@
+# #6881 — stale dual-accept prose in sync_auth.go and the cluster README
+
+- **Timestamp**: 2026-08-27
+  - **Action**: Corrected two sites describing the dual-accept mechanism #5078
+    removed. (1) `wrapSyncConn`'s doc comment described a second return value
+    `pending`, "the legacy peer's first frame"; the function returns a bare
+    `*authConn` and no such frame exists. (2) The README "Rolling it onto a live
+    unkeyed cluster" section carried a step list marked STALE inline by #6865;
+    rewritten to point at the single recovery enumeration rather than restate a
+    procedure.
+  - **Re-located by SYMBOL, not line**: the issue's four cites had rotted, and
+    two of the four sites it names were already correct at master — the header
+    comment now states "A KEYED node does NOT dual-accept — #5078 removed that",
+    and the `:413` sticky-guard text is historical narration of what #5078
+    removed rather than a current claim.
+  - **Deliberately NOT touched**: README lines ~1657-1679 describe
+    `heartbeatAuthDecision` dual-accept, a DIFFERENT and still-live mechanism
+    (`heartbeat_epoch_admit.go:71`). #5078 removed session-sync dual-accept only.
+  - **File(s)**: pkg/cluster/sync_auth.go, pkg/cluster/README.md

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -2022,26 +2022,57 @@ constraint rather than recommended practice.
 
 ### Rolling it onto a live unkeyed cluster
 
-**STALE — dual-accept was removed by #5078; the sequence below no longer works
-as written.** It is kept for the shape of the problem, not as a procedure. Step 2
-asks the operator to commit the key on the *other* node: on an RG0 secondary
-whose read-only gate is armed that returns `ErrClusterReadOnly`, and if sync
-drops before step 2 the keyed side rejects the unkeyed reconnect outright. See
-the "Recovery" discussion above for what is actually available and under which
-preconditions. Rewriting this section is tracked as **#6881**.
+**There is no non-disruptive sequence. Keying a live unkeyed cluster costs a
+controlled outage on one node.** #5078 removed dual-accept, which was the only
+mechanism that made the forward direction seamless, so the operation is now a
+special case of the recovery problem rather than a rollout procedure of its own.
 
-Dual-accept made the forward direction non-disruptive:
+**Do not follow a step list from this section.** The preconditions are what
+decide whether a given node can be keyed at all, and they are enumerated once —
+with their failure modes and their tracking issues — under **"Recovery: no path
+is unconditional, and the one you can plan around costs a controlled outage"**
+above. Read that enumeration, establish which row your cluster is in, and act on
+that row.
 
-1. Set the key on one node and commit. It now signs; the unkeyed peer has no
-   key, so it accepts everything, and the keyed node has not armed
-   enforcement yet, so it still accepts the peer's unsigned frames.
-2. Set the SAME key on the other node and commit. Both sign, each observes
-   the other authenticate, and enforcement arms.
-3. **Restart `xpfd` on both nodes**, one at a time, waiting for the cluster
-   to re-form in between.
+Why this section does not restate them: three earlier revisions of the recovery
+discussion each replaced a hedge with an absolute, in three different
+directions, and each was refuted. A second summary here would be a fourth
+attempt at the same mistake, and it would drift from the enumeration the moment
+either changed.
 
-Step 3 is **no longer required for the legitimate peer** (#6628), and the
-reason it used to be is worth keeping in view.
+The shape of the constraint, so the enumeration reads in context:
+
+- **The keyed side stops accepting the unkeyed peer immediately.** Once one node
+  commits the key, `syncAuthDecision` rejects a local-key/peer-unkeyed
+  connection unconditionally. There is no first-contact grace — that grace was
+  an unauthenticated active bypass, not a compatibility affordance (#5078).
+- **So the second node must be keyed while it can still commit.** On an RG0
+  secondary whose read-only gate is ARMED, `EnterConfigureSession` returns
+  `ErrClusterReadOnly` from every entry point, and the commit that would key it
+  is refused. If sync has already dropped, it cannot be reached over the
+  fabric either.
+- **`configuration-synchronize` does not rescue this**, because the connection
+  that would carry the config to the secondary is the one the keyed side is now
+  rejecting.
+
+The path you can plan around is **controlled RG0 promotion** (row 3 of the
+recovery enumeration): stop `xpfd` on the keyed node so the secondary promotes,
+which clears its read-only gate and lets it accept a local commit of the same
+key. Every "if" in that row is a real precondition — election eligibility,
+event delivery — and they are stated there rather than duplicated here.
+
+For the historical record, dual-accept made the forward direction non-disruptive
+by having the keyed node accept the peer's unsigned frames until both sides had
+authenticated. **That mechanism no longer exists**; it is described here only so
+that a reader encountering the term in older commits or comments knows what it
+referred to and that it is gone.
+
+An in-place upgrade (#6628) now promotes an ESTABLISHED connection to
+authenticated without a reconnect, so a restart is **not** required for the
+legitimate peer once both sides are keyed. That is a separate mechanism from
+dual-accept and does not restore a non-disruptive rollout: it upgrades a
+connection that is already admitted, and the problem above is a connection that
+is being refused.
 
 Session sync fixed a connection's authentication state when the TCP connection
 was established (`performSyncHandshake` → `wrapSyncConn`), and committing the

--- a/pkg/cluster/sync_auth.go
+++ b/pkg/cluster/sync_auth.go
@@ -630,9 +630,16 @@ func (s *SessionSync) performSyncHandshake(conn net.Conn) (syncAuthMode, []byte,
 
 // wrapSyncConn applies the negotiated handshake result to a connection: it
 // wraps conn in an authConn (sealing frames when authenticated) and, when the
-// connection authenticated, arms the sticky downgrade-guard. pending is the
-// legacy peer's first frame (nil when none) and is returned for the caller to
-// process before starting the receive loop.
+// connection authenticated, arms the sticky downgrade-guard.
+//
+// #6881: an earlier revision of this comment described a second return value —
+// `pending`, "the legacy peer's first frame (nil when none) ... returned for
+// the caller to process before starting the receive loop". There is no such
+// value and there is no such frame. #5078 removed the dual-accept path that
+// produced one, and this function has returned a bare *authConn since. The
+// prose outlived the mechanism; see the `pendingFrame` note in
+// syncAuthDecision for why executing a peer frame before admission was the
+// bug rather than the feature.
 func (s *SessionSync) wrapSyncConn(fabricIdx int, conn net.Conn, mode syncAuthMode, frameKey []byte) *authConn {
 	ac := &authConn{Conn: conn}
 	if mode == syncAuthAuthenticated {


### PR DESCRIPTION
Closes #6881

Comment and documentation only; no executable change.

## Scope was established by measurement, and it is narrower than the issue

The issue names four sites by line. **Those cites had rotted, and two of the
four are already correct at master** — I re-located everything by symbol:

| issue's claim | measured at `c61019056` |
|---|---|
| file header labels the keyed case "Dual-accept" | **already fixed** — now reads *"A KEYED node does NOT dual-accept — #5078 removed that"* |
| `:413` describes a removed sticky guard | **not stale** — historical narration of what #5078 removed, in past tense |
| `performSyncHandshake` doc claims an optional legacy first frame | **real, but on a different function** — it is `wrapSyncConn` |
| README rollout section describes dual-accept | **real** |

So two sites, not four.

## What changed

**1. `wrapSyncConn`'s doc comment** described a second return value — `pending`,
*"the legacy peer's first frame (nil when none) ... returned for the caller to
process before starting the receive loop"*. The function returns a bare
`*authConn`. #5078 removed the dual-accept path that produced such a frame, and
executing a peer frame before admission was the bug rather than the feature.

**2. The README "Rolling it onto a live unkeyed cluster" section** still carried
a three-step procedure whose step 2 asks the operator to commit the key on the
*other* node — refused with `ErrClusterReadOnly` on an RG0 secondary whose gate
is armed, and unreachable at all if sync has already dropped. #6865 marked it
STALE inline and pointed at #6881; this rewrites it.

**It deliberately does not restate the preconditions.** The recovery discussion
above enumerates the three candidate paths with their failure modes and tracking
issues, and records that *"three earlier revisions of this section got this wrong
in three different directions ... Each replaced a hedge with an absolute and each
was refuted."* A second summary here would be a fourth attempt at that mistake,
and it would drift from the enumeration the moment either changed. So the section
states the shape of the constraint and routes the reader to the enumeration for
the rows.

## What is deliberately NOT touched

The README's `heartbeatAuthDecision` dual-accept passages (~1657-1679). **That is
a separate and still-live mechanism** — `heartbeat_epoch_admit.go:71` plus active
tests in `heartbeat_epoch_status_6169_test.go` and `heartbeat_auth_test.go`.
#5078 removed *session-sync* dual-accept only. Sweeping every occurrence of the
term would have deleted correct documentation for a live feature.

## Validation

`go test ./... -count=1` — rc=0, 68 packages, 0 failures. Cross-reference into
the rewritten section verified to still resolve. Bare `TMPDIR=/var/tmp`.

No mutation matrix: there is no executable change to mutate. The verification
that matters here is the scope check above — which claims are still true — and
it is stated per row rather than asserted in aggregate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7PfivEWEESWuDihm6TgdT