### PR TITLE
host-inbound: name both enforcement surfaces at the admit arm

### DIFF
--- a/docs/log/6873.md
+++ b/docs/log/6873.md
@@ -67,3 +67,36 @@
     survives" would guard a state nobody had shown was dangerous.
   - **File(s)**: `userspace-dp/src/afxdp/coordinator/tests.rs`,
     `docs/log/6873.md`
+
+- **Timestamp**: 2026-08-27
+- **Action**: Sweep for the CLAIM, not for the issue number — and find the half
+  of the answer I had missed
+  - Prompted by a #6846 follow-up: a doc claim about `transmit-rate percent`
+    being inert had been wrong since #4228, four months before #6846, so no
+    sweep scoped to "docs my change touched" could have found it. Applied the
+    same lens here rather than acknowledging it.
+  - **The sweep found something material to the open PR.**
+    `docs/host-inbound-service-matrix.md:939` says the lo0 fence fixed "the SAME
+    cold-boot fail-open the host-inbound table closed in **#5644**". I had
+    concluded "no cold-boot gate is needed" without ever finding #5644 — because
+    I searched `snapshot_installed` and the AF_XDP admit path, which is one
+    enforcement surface of two.
+  - **Both answers are correct, on different surfaces**, and that is the point:
+    - KERNEL nft chain: the window IS reachable (a boot apply can fail with no
+      prior table to retain), so it has a real fence —
+      `installHostInboundColdBootFence` (#5644, lo0 analogue #6476), guarded by
+      `TestColdBootHostInboundInstallFailureInstallsFence`.
+    - USERSPACE AF_XDP classifier: unreachable by worker-lifecycle ordering.
+      There is no failed-apply equivalent, because a worker exists only once a
+      state has been published.
+  - **This is very likely why the arm keeps being re-audited.** An auditor who
+    reads "#5644 closed the host-inbound cold-boot fail-open" and then finds no
+    fence at this admit site sees a contradiction and files it. The comment now
+    states both surfaces and why they answer differently, which is the actual
+    anti-re-open content — the previous version would have left the same trap.
+  - I had also swept only `docs/junos-cli-reference.md` when writing the
+    operator paragraph, and never opened `docs/host-inbound-service-matrix.md`
+    — the file whose entire subject is this feature. Same horizon, one directory
+    over.
+  - **File(s)**: `userspace-dp/src/afxdp/forwarding/host_inbound.rs`,
+    `docs/log/6873.md`

--- a/userspace-dp/src/afxdp/forwarding/host_inbound.rs
+++ b/userspace-dp/src/afxdp/forwarding/host_inbound.rs
@@ -740,6 +740,25 @@ pub(in crate::afxdp) fn host_inbound_admits(
         // _table_6873` (coordinator/tests.rs) — an ordering invariant with no
         // test is one refactor from being false.
         //
+        // TWO SURFACES, TWO DIFFERENT ANSWERS — and the difference is why this
+        // arm keeps getting re-audited. host-inbound is enforced BOTH here and
+        // by the kernel nft chain, and the cold-boot question resolves
+        // oppositely on each:
+        //
+        //   - KERNEL nft chain: the window IS reachable. A boot apply can fail
+        //     with no prior table to retain, leaving the host path with no
+        //     chain at all, so it needs a real gate — `installHostInboundCold
+        //     BootFence` (#5644, and its lo0 analogue #6476), guarded by
+        //     `TestColdBootHostInboundInstallFailureInstallsFence`.
+        //   - HERE (userspace AF_XDP classifier): unreachable, by the worker
+        //     lifecycle above. There is no failed-apply equivalent, because a
+        //     worker only exists once a state has been published.
+        //
+        // So "the host-inbound cold-boot fail-open was closed in #5644" is true
+        // of the kernel surface and says nothing about this one. Reading that
+        // sentence next to this arm is what makes an auditor expect a fence
+        // here and file the absence of one — twice so far.
+        //
         // So, precisely: this arm is settled for CONFIGURED zones (#3405) and
         // for addressed empty-zone interfaces (#5659); it deliberately keeps
         // admit for a legitimately zoneless NON-addressed control interface; and


### PR DESCRIPTION
Follow-up to #7703 (merged). One commit, stranded when the branch was deleted
after that merge — recovered from the surviving local ref rather than rewritten.

**Comment and action-log only. No executable change.**

## What it adds

#7703 answered #6873's question — the userspace host-inbound cold-boot window is
unreachable by worker-lifecycle ordering, so a `snapshot_installed` gate at the
admit site would be dead code. That answer is correct but was **one citation
short of preventing the next re-open.**

`docs/host-inbound-service-matrix.md` says the lo0 fence fixed *"the SAME
cold-boot fail-open the host-inbound table closed in #5644"*. I reached the "no
gate needed" conclusion without ever finding #5644, because I searched
`snapshot_installed` and the AF_XDP admit path — **one enforcement surface of
two.**

Both statements are true, on different surfaces, and the difference is the whole
reason this arm keeps being re-audited:

| surface | cold-boot window | why |
|---|---|---|
| kernel nft chain | **reachable** → real fence | a boot apply can fail with no prior table to retain, leaving the host path with no chain. `installHostInboundColdBootFence` (#5644; lo0 analogue #6476), guarded by `TestColdBootHostInboundInstallFailureInstallsFence` |
| userspace AF_XDP classifier | **unreachable** → no gate | no failed-apply equivalent: a worker exists only once a state has been published |

An auditor who reads "#5644 closed the host-inbound cold-boot fail-open" and then
finds no fence at this admit site sees a contradiction and files it — which has
now happened twice. The comment names both surfaces and why they answer
differently.

## How it was found

By sweeping for the **claim** rather than for the issue number, after the same
lens caught a four-month-old stale doc claim on #6846: a sweep scoped to "docs my
change touched" has a horizon, and the thing I needed was written under a
different issue's number.

Concretely, my own horizon: when writing #7703's operator paragraph I swept
`docs/junos-cli-reference.md` and never opened
`docs/host-inbound-service-matrix.md` — the file whose entire subject is this
feature.

## Gates

Gated head **`b9aa662569a8f97c636521c37d8788e59d1a972b`**.

- `go test ./... -count=1` — **rc 0**, 68 packages ok.
- `cargo test -- --test-threads=1` — **rc 0**, 4788 passed, 0 failed.

Master moved to `4328cee40` during the run, so ancestry is stated rather than
asserted: the delta is #7706, two commits touching `docs/cluster` prose only —
disjoint from this change's two files.

## Note on the prior run

The gate for the stranded commit was run in a worktree that was deleted mid-run
by the post-merge cleanup of #7703. It reported 5 Rust failures — all of them
tests that read source or fixtures from disk
(`wire_invariant_default_specimens`, `app_catalog_precedence_parity_fixture`,
`nat_pool_grammar_parity_fixture`,
`every_counter_accessor_is_wired_into_process_status`,
`shim_index_path_has_one_construction_and_one_lookup`). All 5 pass in a live
tree. That result was **void, not red** — the tree ceased to exist during the
measurement.
