### PR TITLE
daemon: bind step-20 restart completion, not teardown

### DIFF
--- a/docs/log/6878.md
+++ b/docs/log/6878.md
@@ -1,0 +1,45 @@
+# #6878 — step-20 subtests bind teardown, not restart completion
+
+## 2026-08-27 — both escapes measured against the pre-fix tree
+
+- **Escape 2, measured**: deleting `d.startClusterComms(d.daemonCtx)` from
+  `applyTailReconciles` step 20 left `pkg/daemon` **fully green** — 0 named
+  failures, package ran, no build signals. A build that tears comms down on
+  every endpoint change and never brings them back up passes the suite.
+- **Root, confirmed by reading**: `startClusterComms` early-returns on
+  `cfg == nil || cfg.Chassis.Cluster == nil` **before** `beginClusterCommsEpoch`,
+  so with no committed cluster config in the store it never bumps
+  `clusterCommsGen`. The three #5078 subtests observe that generation, and
+  `stopClusterComms` bumps it FIRST — so the generation cannot distinguish a
+  completed restart from a teardown that never came back.
+- **Escape 1, same root**: the #5078 fixture's store holds no committed cluster
+  config, so a suppression check reading the auth key from
+  `d.store.ActiveConfig()` sees nothing. In production the commit path promotes
+  the new config BEFORE apply, so that spelling would see the key and suppress
+  the restart — the same #5078 deadlock, no red.
+
+## 2026-08-27 — the fix is the fixture root, not more assertions
+
+- **File(s)**: `pkg/daemon/daemon.go`, `pkg/daemon/daemon_apply_tail.go`,
+  `pkg/daemon/cluster_step20_restart_completion_6878_test.go`
+- The #5078 subtests are correct as they stand and are **left untouched**, per
+  the issue's explicit "do not weaken them".
+- Added `startClusterCommsFn` — a call-site seam following the existing house
+  idiom (`raApplyFn`, `kernelRunnerFn`, `startupGoodbyeWithdrawFn`): nil selects
+  the real method, production never sets it. Placed at the CALL SITE rather than
+  inside `startClusterComms` so a test observes restart COMPLETION without
+  standing up heartbeat/sync sockets.
+- New harness commits a **keyed** cluster config into the store, which is what
+  makes Escape 1 observable at all, and counts start invocations rather than
+  watching `clusterCommsGen`, which is what makes Escape 2 observable.
+- Three cells: endpoint change starts exactly once; a key commit starts zero
+  times **with a keyed store**; an unchanged transport starts zero times. The
+  third is a negative control on the other axis — without it, a step 20 that
+  restarted on every apply would satisfy the completion cell.
+
+## Fixture note
+
+The commit gate rejects a cluster config with no PSK, and names the leaf:
+`chassis cluster authentication-key <key>`. My first draft used
+`control-link-authentication-key` (the Go field is `ControlLinkAuthKey`) and the
+commit failed — the Go field name and the config leaf are not the same spelling.

--- a/pkg/daemon/cluster_step20_restart_completion_6878_test.go
+++ b/pkg/daemon/cluster_step20_restart_completion_6878_test.go
@@ -1,0 +1,155 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/networkd"
+	"github.com/psaab/xpf/pkg/vrrp"
+)
+
+// #6878: the three #5078 subtests bind the step-20 DECISION correctly, but two
+// things beside them were unobservable in that harness. Both escapes below were
+// MEASURED against the pre-fix tree, not reasoned.
+//
+// Escape 1 — a store-derived keyed check is invisible. The #5078 fixture's
+// store deliberately holds NO committed cluster config, so a suppression check
+// reading the auth key from d.store.ActiveConfig() instead of the candidate cfg
+// sees nothing and the package stays green. A real commit promotes the new
+// config BEFORE apply (store_commit.go -> daemon_apply.go), so in production
+// that spelling would see the key and suppress the restart: the same #5078
+// deadlock, different spelling, no red.
+//
+// Escape 2 — the subtests prove teardown, not restart. All three observe
+// clusterCommsGen, which stopClusterComms bumps FIRST. Measured: deleting
+// d.startClusterComms(d.daemonCtx) from step 20 left the whole pkg/daemon
+// package green (0 named failures). A build that tears comms down on every
+// endpoint change and never brings them back up passes the suite, while every
+// endpoint move silently leaves the cluster with no session-sync.
+//
+// Both escapes share one root: the fixture had no committed cluster stanza.
+// This harness fixes that root rather than adding assertions to the #5078
+// subtests, which are correct as they stand and are deliberately left alone.
+//
+//   - The store holds a COMMITTED, KEYED cluster config. That is what makes a
+//     store-derived keyed check visible: it would now see the key.
+//   - The start is observed through startClusterCommsFn, so restart COMPLETION
+//     is bound without standing up heartbeat/sync sockets. Counting invocations
+//     rather than watching clusterCommsGen is the whole point — the generation
+//     cannot distinguish "restarted" from "torn down and abandoned".
+func TestStep20RestartsCommsToCompletion_6878(t *testing.T) {
+	installFakeNetworkctl(t)
+
+	// The transport the daemon believes is already live.
+	baseTransport := func() *config.Config {
+		cfg := &config.Config{}
+		cfg.Chassis.Cluster = &config.ClusterConfig{
+			ClusterID:         1,
+			NodeID:            0,
+			ControlInterface:  "em0",
+			PeerAddress:       "10.99.0.2",
+			FabricInterface:   "fab0",
+			FabricPeerAddress: "10.99.1.2",
+		}
+		return cfg
+	}
+
+	newDaemon := func(t *testing.T) (*Daemon, *int) {
+		t.Helper()
+		store := newConfigStore(t, filepath.Join(t.TempDir(), "config.db"))
+		if err := store.EnterConfigure(); err != nil {
+			t.Fatalf("EnterConfigure: %v", err)
+		}
+		// A committed cluster config that CARRIES AN AUTH KEY. Escape 1 is
+		// invisible without this: a store-derived keyed check needs a key in
+		// the store to read.
+		for _, line := range []string{
+			"chassis cluster cluster-id 1",
+			"chassis cluster node 0",
+			"chassis cluster authentication-key committed-psk-6878",
+		} {
+			if err := store.SetFromInput(line); err != nil {
+				t.Fatalf("SetFromInput(%q): %v", line, err)
+			}
+		}
+		if _, err := store.Commit(); err != nil {
+			t.Fatalf("commit keyed cluster config: %v", err)
+		}
+		active := store.ActiveConfig()
+		if active == nil || active.Chassis.Cluster == nil {
+			t.Fatal("fixture broken: the store must hold a committed cluster config, " +
+				"or a store-derived keyed check stays invisible exactly as it was " +
+				"before this test")
+		}
+		if active.Chassis.Cluster.ControlLinkAuthKey == "" {
+			t.Fatal("fixture broken: the committed cluster config must carry an auth " +
+				"key, or Escape 1 is not covered")
+		}
+
+		starts := 0
+		d := &Daemon{
+			store:     store,
+			networkd:  networkd.NewInDir(t.TempDir()),
+			vrrpMgr:   vrrp.NewManager(),
+			cluster:   cluster.NewManager(0, 1),
+			daemonCtx: context.Background(),
+			opts:      Options{NoDataplane: true},
+		}
+		d.startClusterCommsFn = func(context.Context) { starts++ }
+		d.activeClusterTransport = clusterTransportFromConfig(baseTransport())
+		return d, &starts
+	}
+
+	t.Run("endpoint_change_restarts_comms_to_COMPLETION", func(t *testing.T) {
+		// The load-bearing cell. clusterCommsGen cannot tell a completed
+		// restart from a teardown, so this counts the start itself.
+		d, starts := newDaemon(t)
+		moved := baseTransport()
+		moved.Chassis.Cluster.PeerAddress = "10.99.0.9"
+
+		_ = d.applyTailReconciles(moved, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+		if *starts != 1 {
+			t.Fatalf("step 20 started cluster comms %d times, want exactly 1 — a "+
+				"teardown that never comes back up leaves every endpoint move with "+
+				"no session-sync, and clusterCommsGen cannot see it because "+
+				"stopClusterComms bumps the generation first", *starts)
+		}
+	})
+
+	t.Run("key_commit_still_does_not_restart_with_a_KEYED_store", func(t *testing.T) {
+		// Escape 1. The #5078 subtest asserts this against a store holding no
+		// cluster config; here the store holds a KEYED one, so a suppression
+		// check derived from d.store.ActiveConfig() is now observable.
+		d, starts := newDaemon(t)
+		keyed := baseTransport()
+		keyed.Chassis.Cluster.ControlLinkAuthKey = config.Secret("a-real-cluster-psk-6878")
+
+		_ = d.applyTailReconciles(keyed, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+		if *starts != 0 {
+			t.Fatalf("committing an authentication key restarted cluster comms "+
+				"(%d starts): that drops the established session-sync connection at "+
+				"the moment the primary becomes keyed, and it is the ONLY path by "+
+				"which the key reaches a config read-only secondary (#5078)", *starts)
+		}
+	})
+
+	t.Run("no_transport_change_does_not_restart", func(t *testing.T) {
+		// Negative control on the other axis: step 20 must not fire when
+		// nothing moved. Without this, a step 20 that restarted on EVERY apply
+		// would satisfy the completion cell above.
+		d, starts := newDaemon(t)
+
+		_ = d.applyTailReconciles(baseTransport(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+		if *starts != 0 {
+			t.Fatalf("an unchanged transport restarted cluster comms (%d starts) — "+
+				"step 20 fires on every apply, which would make the completion "+
+				"assertion above pass for the wrong reason", *starts)
+		}
+	})
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -973,6 +973,22 @@ type Daemon struct {
 	// detect changes that require a comms restart (#87).
 	activeClusterTransport clusterTransportKey
 
+	// startClusterCommsFn is the startClusterComms entry point used by
+	// applyTailReconciles step 20; overridable in tests (#6878).
+	//
+	// The real startClusterComms early-returns when the store holds no committed
+	// cluster config, so in a unit harness its ABSENCE is unobservable: the three
+	// #5078 subtests watch clusterCommsGen, which stopClusterComms bumps first,
+	// and deleting the start call left the whole package green. A build that tore
+	// comms down on every endpoint change and never brought them back up passed
+	// the suite while every endpoint move silently left the cluster with no
+	// session-sync.
+	//
+	// The seam is at the CALL SITE rather than inside startClusterComms so a test
+	// can observe restart COMPLETION without standing up heartbeat/sync sockets.
+	// nil selects the real method; production never sets it.
+	startClusterCommsFn func(context.Context)
+
 	// clusterCommsMu guards the cluster-comms epoch state that is published
 	// asynchronously by the startClusterComms constructor goroutine and torn
 	// down by stopClusterComms: sessionSync, fabricRefreshCh/fabricRefreshCh1,

--- a/pkg/daemon/daemon_apply_tail.go
+++ b/pkg/daemon/daemon_apply_tail.go
@@ -341,7 +341,15 @@ func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, 
 				"old_fabric_peer", active.FabricPeerAddress,
 				"new_fabric_peer", newTransport.FabricPeerAddress)
 			d.stopClusterComms()
-			d.startClusterComms(d.daemonCtx)
+			// #6878: through the seam so a test can bind restart COMPLETION.
+			// stopClusterComms bumps clusterCommsGen first, so the generation
+			// alone cannot tell a completed restart from a teardown that never
+			// came back up.
+			start := d.startClusterCommsFn
+			if start == nil {
+				start = d.startClusterComms
+			}
+			start(d.daemonCtx)
 		}
 
 		// #4647 BUG-B: reconcile the #2239 DHCP lease-sync push loop against


### PR DESCRIPTION
Closes #6878

## Both escapes measured against the pre-fix tree, not reasoned

**Escape 2** — deleting `d.startClusterComms(d.daemonCtx)` from `applyTailReconciles` step 20 left `pkg/daemon` **fully green**: 0 named failures, package ran, no build signals. A build that tears comms down on every endpoint change and never brings them back up passes the suite, while every endpoint move silently leaves the cluster with no session-sync.

**The root, confirmed by reading**: `startClusterComms` early-returns on `cfg == nil || cfg.Chassis.Cluster == nil` **before** `beginClusterCommsEpoch`, so with no committed cluster config in the store it never bumps `clusterCommsGen`. The three #5078 subtests observe that generation — and `stopClusterComms` bumps it **first**. The generation therefore cannot distinguish a completed restart from a teardown that never came back.

**Escape 1** — same root. With no committed cluster config, a suppression check reading the auth key from `d.store.ActiveConfig()` instead of the candidate `cfg` sees nothing. In production the commit path promotes the new config **before** apply (`store_commit.go` → `daemon_apply.go`), so that spelling *would* see the key and suppress the restart: the same #5078 deadlock, different spelling, no red.

## The fix is the fixture root, not more assertions

The three #5078 subtests are correct as they stand and are **left untouched**, per the issue's explicit instruction.

- **`startClusterCommsFn`** — a call-site seam following the existing house idiom (`raApplyFn`, `kernelRunnerFn`, `startupGoodbyeWithdrawFn`): nil selects the real method, production never sets it. It sits at the **call site** rather than inside `startClusterComms` so a test observes restart *completion* without standing up heartbeat/sync sockets.
- **A committed, KEYED cluster config in the store** — this is what makes Escape 1 observable at all; a store-derived keyed check now has a key to read.
- **Counting start invocations** rather than watching `clusterCommsGen` — this is what makes Escape 2 observable.

Three cells, including a negative control on the other axis: without `no_transport_change_does_not_restart`, a step 20 that restarted on *every* apply would satisfy the completion cell.

## Mutation matrix — measured

Fix committed **first** (`ffe25817c`), one mutation per cell, `go test ./pkg/daemon/ -count=1`, full package, **no `-run` filter**, tree restored between cells. Gated on tests-collected > 0, `named-FAILs == 0 && build-signals > 0` treated as VOID.

| # | Mutation | Named FAILs | ran | build sigs | Result |
|---|---|---|---|---|---|
| M1 | **Escape 2** — start call deleted from step 20 | **1** — `…/endpoint_change_restarts_comms_to_COMPLETION` | 1 | 0 | ✅ RED |
| M2 | **Escape 1** — keyed check derived from `d.store.ActiveConfig()` | **1** — `…/endpoint_change_restarts_comms_to_COMPLETION` | 1 | 0 | ✅ RED |
| M3 | step 20 fires on every apply (change test dropped) | 3, incl. `…/no_transport_change_does_not_restart` and the pre-existing `…_5078/key_commit_must_not_restart` | 1 | 0 | ✅ RED |

**M1 and M2 are the load-bearing cells**: each reds **exactly one** test — the new one — and the pre-existing #5078 subtests stay **green** under both. That is the paired proof the issue asked for: the escapes were real (green before), and the new cell covers something nothing else does. M3 shows the negative control is load-bearing, and honestly overlaps the existing #5078 coverage.

## Gate — measured

```
go test ./... -count=1   →   RC=0, 68 packages ok, 0 failures
```

- Gated head: `d61bb880cb9cced9f11dd2d8583a83554be942b6`
- `git merge-base --is-ancestor origin/master HEAD` → **YES** (re-gated after folding master; the pre-fold head was also green, but 5 commits behind, so it is not the number reported here)
- `TMPDIR=/var/tmp` (bare); 0 `no space left`, 0 `bind: invalid argument`

## Measured vs inferred

**Measured:** both escapes on the pre-fix tree; all three mutation cells; that the #5078 subtests stay green under M1 and M2; the full-repo gate.

**Inferred:** that no other production path depends on step 20 calling `startClusterComms` directly rather than through the seam — the seam is a nil-check with an identical default, so behaviour is unchanged when unset, which is every production path.

## Fixture note for the next reader

The commit gate rejects a cluster config with no PSK and names the leaf: `chassis cluster authentication-key <key>`. The Go field is `ControlLinkAuthKey`; the config leaf is **not** the same spelling, and the first draft of this fixture failed its commit because of it.
