### PR TITLE
daemon: bind the boot cluster-comms start in Run()

### DIFF
--- a/docs/log/7713.md
+++ b/docs/log/7713.md
@@ -1,0 +1,56 @@
+# #7713 — the boot cluster-comms start is unbound
+
+## 2026-08-27 — scoping the harness FIRST, as instructed
+
+- **Action**: before writing any assertion, established what binding this
+  behaviourally would cost.
+- `Daemon.Run` spans `daemon_run.go:64-853` — **~790 lines** — and **no test in
+  the package drives it**. (`grep` for `.Run(ctx` finds only the aggregator and
+  GC types, not `Daemon.Run`.)
+- Driving it needs a real config file, an initialised dataplane, the server
+  phase and the shutdown sequence. That harness does not exist, and #7713's
+  brief was explicit: do not reshape production code to make a test possible.
+
+## 2026-08-27 — the tempting fix that binds nothing
+
+The boot start is a self-contained three-line block:
+
+```go
+if d.cluster != nil {
+    d.startClusterComms(ctx)
+}
+```
+
+so the obvious move is to extract it into `startBootClusterComms` and unit-test
+that. **Rejected.** It would pass and bind nothing new: the unbound call simply
+moves up a level, from `Run() -> startClusterComms` to
+`Run() -> startBootClusterComms`. That is the same bind-the-wiring failure this
+issue exists to close, wearing the shape of a refactor. It would also have been
+a production change made solely to make a test possible — the thing the brief
+ruled out.
+
+So `Run()` is left byte-identical and its call site is bound where it lives.
+
+## 2026-08-27 — a call-shape canary, with precedent
+
+- **File(s)**: `pkg/daemon/boot_cluster_comms_wired_7713_test.go`
+- **Zero production change.**
+- AST call-site canaries are an established house technique here: **67 test
+  files** in `pkg/` use `go/ast` or `go/parser`. The closest precedent is
+  `reth_hook_wired_5103_test.go`, which binds a hook's call site the same way.
+- Mirrored that precedent's discipline of staying SMALL. Its doc records that an
+  early revision over-reached — matching an inline statement and its guard — and
+  a hostile reviewer escaped it three ways, each buying only another AST clause.
+- **Binds**: exactly one `d.startClusterComms` call in `Run()`, taking one
+  argument, not nested in a constant-false `if`.
+- **Does not bind, stated in the test**: a runtime-false guard, an earlier
+  `return`, or a `goto` over the call. Nothing structural can; those need `Run()`
+  executable. It also says nothing about what happens inside
+  `startClusterComms`.
+
+## Acceptance pairing
+
+#7713 asks for the paired proof explicitly: deleting the boot start must red the
+new cell **while #6878's step-20 cell stays GREEN** under that same mutation —
+which is what shows this binds a genuinely different site rather than widening
+existing coverage.

--- a/pkg/daemon/boot_cluster_comms_wired_7713_test.go
+++ b/pkg/daemon/boot_cluster_comms_wired_7713_test.go
@@ -1,0 +1,144 @@
+package daemon
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// #7713: Run() must actually START cluster comms at boot.
+//
+// Measured before this canary: deleting `d.startClusterComms(ctx)` from Run()
+// left pkg/daemon FULLY GREEN — 0 named failures. A daemon that never starts
+// cluster heartbeat or session sync at all passed the whole suite.
+//
+// # Why this is a call-shape canary and not a behavioural test
+//
+// Stated plainly rather than implied, because the choice is the interesting
+// part. Run() is ~790 lines and NOTHING drives it: no test in this package
+// calls Daemon.Run. Binding the boot start behaviourally needs a real config
+// file, an initialised dataplane, the server phase and the shutdown sequence —
+// a harness that does not exist and that #7713 explicitly declined to build by
+// reshaping production code.
+//
+// The tempting alternative is worse and was rejected: extracting the three-line
+// block into a `startBootClusterComms` method and unit-testing THAT. It would
+// pass, and it would bind nothing new — the unbound call simply moves up one
+// level, from `Run() -> startClusterComms` to `Run() -> startBootClusterComms`.
+// That is the same "bind the wiring, not the function it calls" failure this
+// issue exists to close, dressed as a refactor. So Run() is left exactly as it
+// is and its call site is bound where it lives.
+//
+// Mirrors the #5103 canary (reth_hook_wired_5103_test.go), including its
+// discipline of staying SMALL: that one over-reached in an early revision,
+// matching an inline statement and its guard, and a hostile reviewer escaped it
+// three ways that each only bought another AST clause.
+//
+// # What this binds
+//
+//  1. Run() contains EXACTLY ONE call to d.startClusterComms, taking one
+//     argument. Deleting it, or duplicating it, REDs.
+//  2. That call is not nested inside a constant-false `if` — the cheapest way
+//     to disable it while leaving the syntax in place.
+//
+// # What this does NOT bind, and cannot
+//
+// It cannot reject a RUNTIME-false guard, an earlier `return` under a
+// runtime-false condition, or a `goto` over the call. Nothing structural can;
+// those need Run() to be executable in a test. It also says nothing about
+// whether startClusterComms then works — pkg/daemon has separate coverage for
+// what happens inside it, and #6878 binds the step-20 restart pair.
+//
+// What it does buy: a silent drop of the boot start has to be a deliberate
+// control-flow edit rather than a plausible refactor or a bad merge.
+func TestRunStartsClusterCommsAtBoot_7713(t *testing.T) {
+	const file = "daemon_run.go"
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+
+	var runFn *ast.FuncDecl
+	ast.Inspect(f, func(n ast.Node) bool {
+		fd, ok := n.(*ast.FuncDecl)
+		if !ok || fd.Name == nil || fd.Name.Name != "Run" || fd.Recv == nil {
+			return true
+		}
+		runFn = fd
+		return false
+	})
+	if runFn == nil {
+		t.Fatalf("no method Run found in %s — this canary would count zero call "+
+			"sites and pass for the wrong reason", file)
+	}
+
+	// Collect calls to d.startClusterComms(...) inside Run, recording whether
+	// each sits under a constant-false `if`.
+	type site struct {
+		pos       token.Position
+		args      int
+		deadBlock bool
+	}
+	var sites []site
+
+	// Track constant-false `if` bodies so a disabled-but-present call is caught.
+	dead := map[ast.Node]bool{}
+	ast.Inspect(runFn, func(n ast.Node) bool {
+		if ifs, ok := n.(*ast.IfStmt); ok {
+			if lit, ok := ifs.Cond.(*ast.Ident); ok && lit.Name == "false" {
+				dead[ifs.Body] = true
+			}
+		}
+		return true
+	})
+
+	var stack []ast.Node
+	ast.Inspect(runFn, func(n ast.Node) bool {
+		if n == nil {
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+			return true
+		}
+		stack = append(stack, n)
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel == nil || sel.Sel.Name != "startClusterComms" {
+			return true
+		}
+		inDead := false
+		for _, anc := range stack {
+			if dead[anc] {
+				inDead = true
+				break
+			}
+		}
+		sites = append(sites, site{
+			pos:       fset.Position(call.Pos()),
+			args:      len(call.Args),
+			deadBlock: inDead,
+		})
+		return true
+	})
+
+	if len(sites) != 1 {
+		t.Fatalf("found %d call(s) to startClusterComms in Run(), want exactly 1 "+
+			"(%v) — deleting it leaves a daemon that never starts cluster heartbeat "+
+			"or session sync, and before this canary that passed the whole package",
+			len(sites), sites)
+	}
+	if got := sites[0].args; got != 1 {
+		t.Errorf("Run() calls startClusterComms with %d args at %s, want 1 (the "+
+			"context)", got, sites[0].pos)
+	}
+	if sites[0].deadBlock {
+		t.Errorf("Run()'s startClusterComms call at %s is nested inside a "+
+			"constant-false `if` — present in the source but never reached",
+			sites[0].pos)
+	}
+}


### PR DESCRIPTION
Closes #7713

## Scoping first, because the brief asked for it

Before writing an assertion: `Daemon.Run` spans `daemon_run.go:64-853` — **~790 lines** — and **no test in the package drives it**. (`grep` for `.Run(ctx` finds the aggregator and GC types, not `Daemon.Run`.) Binding the boot start behaviourally needs a real config file, an initialised dataplane, the server phase and the shutdown sequence. That harness does not exist, and #7713 was explicit about not reshaping production code to create one.

**So this PR changes no production code at all.**

## The tempting fix that binds nothing — rejected, and why

The boot start is a self-contained three-line block:

```go
if d.cluster != nil {
    d.startClusterComms(ctx)
}
```

The obvious move is to extract it into a `startBootClusterComms` method and unit-test that. It would pass. **It would also bind nothing new** — the unbound call simply moves up a level, from `Run() → startClusterComms` to `Run() → startBootClusterComms`. That is the same bind-the-wiring failure this issue exists to close, wearing the shape of a refactor, and it would be a production change made solely to make a test possible.

`Run()` is left byte-identical and its call site is bound where it lives.

## A call-shape canary, with precedent

AST call-site canaries are an established technique in this package — **67 test files** under `pkg/` use `go/ast` or `go/parser`, and `reth_hook_wired_5103_test.go` binds a hook's call site the same way.

This mirrors that precedent's discipline of staying **small**. The #5103 doc records that an early revision over-reached — matching an inline statement and its guard — and a hostile reviewer escaped it three ways, each buying only another AST clause.

**Binds:** exactly one `d.startClusterComms` call inside `Run()`, taking one argument, not nested in a constant-false `if`.

**Does not bind, and says so in the test:** a runtime-false guard, an earlier `return` under a runtime-false condition, or a `goto` over the call. Nothing structural can — those need `Run()` executable. It also says nothing about what happens *inside* `startClusterComms`; #6878 binds the step-20 restart pair separately.

What it buys: a silent drop of the boot start has to be a deliberate control-flow edit rather than a plausible refactor or a bad merge.

## Mutation matrix — measured, including the acceptance pairing

Fix committed **first** (`48108fa30`), one mutation per cell, `go test ./pkg/daemon/ -count=1`, full package, **no `-run` filter**, tree restored between cells. Gated on tests-collected > 0, `named-FAILs == 0 && build-signals > 0` treated as VOID.

| # | Mutation | Named FAILs | ran | build sigs | #6878 step-20 cell | Result |
|---|---|---|---|---|---|---|
| M1 | **boot start deleted** (the acceptance mutation) | **1** — `TestRunStartsClusterCommsAtBoot_7713` | 1 | 0 | **GREEN** | ✅ RED |
| M2 | call wrapped in a constant-false `if` (present but dead) | **1** — same | 1 | 0 | — | ✅ RED |
| M3 | call duplicated (double epoch bump at boot) | **1** — same | 1 | 0 | — | ✅ RED |

**M1 is the acceptance pairing the issue asked for explicitly**: deleting the boot start reds the new cell **by name**, while `TestStep20RestartsCommsToCompletion_6878` stays **GREEN** under the same mutation. That is the proof this binds a genuinely different site rather than widening existing coverage.

Every clause is load-bearing: M2 exercises the dead-block check, M3 the count check.

## Gate — measured

```
go test ./... -count=1   →   RC=0, 68 packages ok, 0 failures
```

- Gated head: `48108fa30e5ce301e24fcd351f45d9f3b62ae6d2`
- `git merge-base --is-ancestor origin/master HEAD` → **YES**, 0 commits behind `f923c5d6d`
- `TMPDIR` **unset** (default `/tmp`), per the retracted redirect guidance; 0 `no space left`, 0 `bind: invalid argument`

## Measured vs inferred

**Measured:** the original escape on the pre-fix tree; all three mutation cells; that the #6878 cell stays green under M1; the full-repo gate; that `Run()` has no existing test driver.

**Inferred:** that no other boot path starts cluster comms — the call-site enumeration by kind (restart pair in step 20, deliberate unpaired rollback teardown in `bootstrap.go`, boot start in `Run()`) covers every `startClusterComms` / `stopClusterComms` site in `pkg/`, but the classification of `bootstrap.go`'s as deliberate rests on reading its comment and surrounding rollback logic, not on a test.
