### PR TITLE
shimverify: report the floor's remaining slack, not just headroom

### DIFF
--- a/cmd/shimverify/main.go
+++ b/cmd/shimverify/main.go
@@ -113,8 +113,19 @@ func run(
 	}
 
 	decision := decide(stats, getenv(allowLowHeadroomEnv) == "1")
-	summary := fmt.Sprintf("processed %d insns (limit %d), headroom %.2f%%",
-		stats.ProcessedInsns, stats.InsnLimit, stats.HeadroomPct())
+	// #6884: the banner carries the floor's remaining SLACK, not just the
+	// headroom. Headroom answers "how close to the 1M wall"; slack answers the
+	// question this gate's sensitivity actually rests on — "how much can still
+	// land before the tripwire fires". The two diverge as the object improves,
+	// silently: the floor was chosen against a 5.3% object and went on reading
+	// 3% while the object reached 21.58%, at which point it admitted 1-2 whole
+	// extension-header iterations without a word. Printing slack on every build
+	// is what surfaces that drift when it happens instead of by archaeology.
+	summary := fmt.Sprintf("processed %d insns (limit %d), headroom %.2f%%, "+
+		"%d insns of slack before the %.1f%% floor",
+		stats.ProcessedInsns, stats.InsnLimit, stats.HeadroomPct(),
+		stats.SlackToFloorInsns(dataplane.UserspaceShimMinVerifierHeadroomPct),
+		dataplane.UserspaceShimMinVerifierHeadroomPct)
 
 	switch decision.refusal {
 	case refusalUnmeasured:

--- a/cmd/shimverify/main_test.go
+++ b/cmd/shimverify/main_test.go
@@ -33,7 +33,13 @@ import (
 // `<=` flips a 3.00%% object from install to refusal with every other fixture
 // unmoved.
 func TestShimverifyDecision(t *testing.T) {
-	// Above the floor: 947188/1000000 leaves 5.28%, the current object.
+	// Above the floor: 947188/1000000 leaves 5.28% — the object as it stood
+	// WHEN #4555 WAS WRITTEN, not now. #6884: master is at 784,175 (21.58%).
+	// The value stays because what it is chosen for is its RELATION to the
+	// floor (comfortably above), not its currency; the label is corrected
+	// because "the current object" is exactly the hand-maintained live number
+	// that #6884 removed from the constant's doc comment, and this copy of it
+	// misled a reader into a cross-kernel inference the data did not support.
 	above := dataplane.ShimVerifierStats{ProcessedInsns: 947188, InsnLimit: 1000000}
 	// Below it: 990796/1000000 leaves 0.92%, master before #4555.
 	below := dataplane.ShimVerifierStats{ProcessedInsns: 990796, InsnLimit: 1000000}

--- a/cmd/shimverify/slack_banner_6884_test.go
+++ b/cmd/shimverify/slack_banner_6884_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// slack_banner_6884_test.go — #6884.
+//
+// The #4555 tripwire reports HEADROOM (how close the object is to the 1M wall).
+// That is not the quantity its own sensitivity rests on. The floor was chosen
+// against a 5.3% object; #6676 then freed ~193k insns and the object reached
+// 21.58% — at which point the unchanged 3% constant admitted ~186k additional
+// insns, one to two whole IPv6 extension-header iterations (87k-106k each),
+// landing with the gate green and nothing said.
+//
+// Nothing detected that drift, and nothing could: headroom rising is
+// indistinguishable from a healthy object, which is precisely what it was.
+// SLACK is the discriminator, and printing it on every build is what turns a
+// silent recalibration into a visible one.
+
+// runBanner6884 drives the real run() with a stubbed verifier and returns
+// stdout, so these cells bind what the build actually prints rather than
+// re-deriving the string.
+func runBanner6884(t *testing.T, stats dataplane.ShimVerifierStats) string {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	run([]string{"shimverify", "/tmp/candidate.o"}, &stdout, &stderr,
+		func(string) string { return "" },
+		func(string) (dataplane.ShimVerifierStats, error) { return stats, nil })
+	return stdout.String()
+}
+
+func TestSlackToFloorInsnsArithmetic6884(t *testing.T) {
+	// The real master object, measured on kernel 7.0.13+deb14-amd64.
+	master := dataplane.ShimVerifierStats{ProcessedInsns: 784175, InsnLimit: 1000000}
+	if got := master.SlackToFloorInsns(3.0); got != 185825 {
+		t.Fatalf("SlackToFloorInsns(3.0) = %d, want 185825 (970000 admitted - 784175 used)", got)
+	}
+	// The fixture is chosen so slack and headroom cannot be confused: headroom
+	// is 21.58%, slack is 185825. A cell whose object sat exactly at the floor
+	// would make the two agree at zero and prove nothing.
+	if hp := master.HeadroomPct(); hp < 21.5 || hp > 21.6 {
+		t.Fatalf("fixture drifted: HeadroomPct() = %v, want ~21.58", hp)
+	}
+}
+
+// TestSlackGoesNegativePastTheFloor6884 pins the refusal-path magnitude. A
+// clamp at zero would make "just over" and "catastrophically over" look
+// identical at exactly the moment the number is being read to decide what to do.
+func TestSlackGoesNegativePastTheFloor6884(t *testing.T) {
+	// 990,796 — the object this issue was filed about.
+	past := dataplane.ShimVerifierStats{ProcessedInsns: 990796, InsnLimit: 1000000}
+	got := past.SlackToFloorInsns(3.0)
+	if got != -20796 {
+		t.Fatalf("SlackToFloorInsns(3.0) = %d, want -20796 (970000 admitted - 990796 used)", got)
+	}
+}
+
+// TestSlackIsZeroWhenUnmeasured6884 guards the documented caveat. Unmeasured
+// returns 0, which is NOT "no slack" — it is "no answer", and the gate refuses
+// an unmeasured object on its own.
+func TestSlackIsZeroWhenUnmeasured6884(t *testing.T) {
+	var none dataplane.ShimVerifierStats
+	if none.Measured() {
+		t.Fatal("precondition: the zero value must be unmeasured")
+	}
+	if got := none.SlackToFloorInsns(3.0); got != 0 {
+		t.Fatalf("SlackToFloorInsns on an unmeasured stat = %d, want 0", got)
+	}
+}
+
+// TestPassBannerReportsSlack6884 is the WIRING cell.
+//
+// SlackToFloorInsns is inert unless the banner prints it. Deleting the slack
+// operands from the summary leaves every arithmetic cell above green while the
+// build says exactly what it said before — which is the condition that let the
+// drift go unnoticed in the first place.
+func TestPassBannerReportsSlack6884(t *testing.T) {
+	stats := dataplane.ShimVerifierStats{ProcessedInsns: 784175, InsnLimit: 1000000}
+	out := runBanner6884(t, stats)
+
+	if !strings.HasPrefix(out, "PASS ") {
+		t.Fatalf("expected a PASS banner, got %q", out)
+	}
+	want := strconv.Itoa(stats.SlackToFloorInsns(dataplane.UserspaceShimMinVerifierHeadroomPct))
+	if !strings.Contains(out, want+" insns of slack") {
+		t.Fatalf("the PASS banner does not report the floor's remaining slack, so a build "+
+			"cannot see the tripwire's sensitivity drift (#6884).\nbanner: %s", out)
+	}
+}
+
+// TestBannerFloorAgreesWithTheGateConstant6884 binds the AGREEMENT rather than
+// pinning a literal.
+//
+// The banner names a floor and the gate enforces one. If the banner ever
+// hard-coded "3.0" it would keep printing 3.0 after the constant moved, and the
+// number a reader consults to judge sensitivity would describe a threshold that
+// is no longer in force — the same class of defect as the "~5.3%" comment this
+// issue is about, reintroduced one layer down. Asserting a literal here would
+// encode which side I trust; asserting agreement cannot.
+func TestBannerFloorAgreesWithTheGateConstant6884(t *testing.T) {
+	out := runBanner6884(t, dataplane.ShimVerifierStats{ProcessedInsns: 784175, InsnLimit: 1000000})
+
+	want := fmt.Sprintf("%.1f%% floor", dataplane.UserspaceShimMinVerifierHeadroomPct)
+	if !strings.Contains(out, want) {
+		t.Fatalf("the PASS banner does not name the floor the gate actually enforces "+
+			"(%q); banner and gate have diverged.\nbanner: %s", want, out)
+	}
+}
+
+// TestSlackTracksTheFloorConstant6884 proves the reported slack is DERIVED from
+// the enforced constant, not from a duplicate of its value.
+//
+// The two previous cells would both pass if the banner computed slack against a
+// hard-coded 3.0 while the gate enforced something else. This one varies the
+// floor and asserts the arithmetic moves with it, so the derivation is bound
+// without needing to mutate a const.
+func TestSlackTracksTheFloorConstant6884(t *testing.T) {
+	stats := dataplane.ShimVerifierStats{ProcessedInsns: 784175, InsnLimit: 1000000}
+	at3 := stats.SlackToFloorInsns(3.0)
+	at15 := stats.SlackToFloorInsns(15.0)
+	if at15 >= at3 {
+		t.Fatalf("a HIGHER floor must leave LESS slack: 3%%=%d, 15%%=%d", at3, at15)
+	}
+	if at15 != 850000-784175 {
+		t.Fatalf("SlackToFloorInsns(15.0) = %d, want %d", at15, 850000-784175)
+	}
+}

--- a/cmd/shimverify/slack_banner_6884_test.go
+++ b/cmd/shimverify/slack_banner_6884_test.go
@@ -65,13 +65,50 @@ func TestSlackGoesNegativePastTheFloor6884(t *testing.T) {
 // TestSlackIsZeroWhenUnmeasured6884 guards the documented caveat. Unmeasured
 // returns 0, which is NOT "no slack" — it is "no answer", and the gate refuses
 // an unmeasured object on its own.
+//
+// THE FIXTURES ARE THE POINT, and my first attempt at this cell was worthless.
+// It used the zero value, where the guarded and unguarded code return the SAME
+// answer: 0*(1-0.03) - 0 == 0 either way. Deleting the `!s.Measured()` guard
+// left the cell green — a real escape, caught by the mutation matrix and not by
+// review. The zero value is precisely the value the bug falls back to.
+//
+// Measured() requires BOTH fields positive, so the discriminating fixtures are
+// the half-populated ones. The first is the one that matters operationally: a
+// stat with a real limit and no count would report ~970,000 insns of slack —
+// "enormous room" — at exactly the moment headroom is UNKNOWN, which is the
+// #4555 blind spot reproduced inside the instrument built to close it.
 func TestSlackIsZeroWhenUnmeasured6884(t *testing.T) {
-	var none dataplane.ShimVerifierStats
-	if none.Measured() {
-		t.Fatal("precondition: the zero value must be unmeasured")
-	}
-	if got := none.SlackToFloorInsns(3.0); got != 0 {
-		t.Fatalf("SlackToFloorInsns on an unmeasured stat = %d, want 0", got)
+	for _, tc := range []struct {
+		name      string
+		stats     dataplane.ShimVerifierStats
+		unguarded int // what the arithmetic alone would produce
+	}{
+		{
+			name:      "limit but no processed count",
+			stats:     dataplane.ShimVerifierStats{ProcessedInsns: 0, InsnLimit: 1000000},
+			unguarded: 970000,
+		},
+		{
+			name:      "processed count but no limit",
+			stats:     dataplane.ShimVerifierStats{ProcessedInsns: 784175, InsnLimit: 0},
+			unguarded: -784175,
+		},
+		{
+			name:      "zero value",
+			stats:     dataplane.ShimVerifierStats{},
+			unguarded: 0, // NOT a discriminator — retained only as a boundary case
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.stats.Measured() {
+				t.Fatal("precondition: this fixture must be UNMEASURED")
+			}
+			if got := tc.stats.SlackToFloorInsns(3.0); got != 0 {
+				t.Fatalf("SlackToFloorInsns on an unmeasured stat = %d, want 0 "+
+					"(the bare arithmetic would give %d, which would read as a "+
+					"slack figure while headroom is unknown)", got, tc.unguarded)
+			}
+		})
 	}
 }
 

--- a/docs/log/6884.md
+++ b/docs/log/6884.md
@@ -29,10 +29,14 @@
   - **Deliberately NOT done**: raising the floor. That is a build gate — every
     lane whose change drops below it starts failing `make generate` — so it is
     a policy change, referred for a decision rather than taken unilaterally.
-    Also rejected: recording an absolute insn baseline. Processed-insn counts
-    are kernel-dependent (the #4555 fixture records 947,188 on a different
-    kernel than this 784,175), so an absolute tracked number would red on every
-    kernel bump. A ratio is the kernel-robust instrument.
+    Also rejected: recording an absolute insn baseline — the conclusion stands,
+    but the reasoning first written here was WITHDRAWN; see the follow-up entry
+    below. It cited kernel-dependence on the strength of the #4555 fixture
+    constants, which do not record that. The surviving argument is the drift
+    actually measured: 990,796 -> 947,188 -> 784,175 across three tree states,
+    so an absolute baseline would red on ordinary object change, which is
+    frequent and expected. A ratio is a proportion of a fixed 1M cap, which is
+    why it is the right instrument.
   - **Not bound by a test**: that the comment never re-acquires a
     hand-maintained percentage. A source-scanning prose guard is defeated by
     paraphrase and can be satisfied by its own doc comment, so the protection

--- a/docs/log/6884.md
+++ b/docs/log/6884.md
@@ -37,3 +37,27 @@
     hand-maintained percentage. A source-scanning prose guard is defeated by
     paraphrase and can be satisfied by its own doc comment, so the protection
     here is the explanation of WHY there is no number, not a grep.
+
+- **Timestamp**: 2026-08-27 (follow-up)
+  - **Action**: measured the kernel-dependence question instead of inferring
+    it, after review caught that my cited evidence did not support the claim.
+    The byte-identical tracked object (md5 `8799db9d…`, verified on both
+    sides) processes **784,175 insns on BOTH `7.0.13+deb14-amd64` and
+    `7.0.0-rc7+`** — zero variation. My earlier statement that "the #4555
+    fixture records 947,188 on a different kernel" was wrong twice over: those
+    are hand-written fixture constants, and the one carrying a kernel
+    annotation says "kernel 7.0", the same line as the host I measured on. The
+    three known counts (990,796 → 947,188 → 784,175) are a time series of the
+    object shrinking, not kernel spread.
+  - **Consequence**: the kernel-robustness argument I used to prefer a ratio
+    over a tracked absolute is not supported by evidence for this kernel pair.
+    A ratio is still the right instrument for other reasons (the floor is a
+    proportion of a fixed cap), but not for the reason I gave.
+  - **File(s)**: cmd/shimverify/main_test.go,
+    pkg/dataplane/verify_userspace_shim_headroom_test.go,
+    pkg/dataplane/README.md
+  - **Also corrected**: two more hand-maintained live numbers in test prose —
+    `main_test.go` called 947,188 "the current object" and the parser fixture's
+    kernel annotation was read as cross-kernel evidence. Same defect class as
+    the one this issue is fixing in the constant's comment, found because
+    review chased the citation.

--- a/docs/log/6884.md
+++ b/docs/log/6884.md
@@ -1,0 +1,39 @@
+# #6884 — userspace-xdp verifier instruction budget
+
+- **Timestamp**: 2026-08-27
+  - **Action**: re-measured the ceiling before proposing anything, per the
+    "a percentage in an issue body is stale by construction" rule. The issue's
+    990,796 / 0.92% headroom is stale: #6676 merged 2026-08-13 and the tracked
+    object now measures **784,175 / 1,000,000 = 21.58% headroom** (kernel
+    7.0.13+deb14-amd64, via `cmd/shimverify`). The guard the issue asks for
+    already exists too — #4555 shipped a 3% headroom floor that reports the
+    count and is enforced through `cmd/shimverify` from
+    `build-userspace-xdp.sh`, with a loud override banner. Verified the WIRING,
+    not just the constant.
+  - **Finding that was NOT stale**: the floor's calibration drifted invisibly.
+    Its doc comment claimed "the current object sits at ~5.3%", which is what
+    3% was chosen against. At 21.58% the same constant admits ~186k additional
+    insns — one to two IPv6 extension-header iterations (87k-106k each, the
+    issue's own figure) landing silently — so the tripwire no longer fires
+    "before the next change will not fit", which is its entire stated purpose.
+    A rising headroom is indistinguishable from a healthy object, so nothing
+    could have detected this.
+  - **Change**: removed the hand-maintained percentage from the constant's
+    comment (replaced with why there is no number, so it is not re-added), and
+    made every build report `SlackToFloorInsns` — how much can still land
+    before the tripwire fires — derived from the enforced constant rather than
+    a copy of its value. Slack is the quantity the floor's sensitivity rests
+    on; headroom is not.
+  - **File(s)**: pkg/dataplane/verify_userspace_shim.go, cmd/shimverify/main.go,
+    cmd/shimverify/slack_banner_6884_test.go, pkg/dataplane/README.md
+  - **Deliberately NOT done**: raising the floor. That is a build gate — every
+    lane whose change drops below it starts failing `make generate` — so it is
+    a policy change, referred for a decision rather than taken unilaterally.
+    Also rejected: recording an absolute insn baseline. Processed-insn counts
+    are kernel-dependent (the #4555 fixture records 947,188 on a different
+    kernel than this 784,175), so an absolute tracked number would red on every
+    kernel bump. A ratio is the kernel-robust instrument.
+  - **Not bound by a test**: that the comment never re-acquires a
+    hand-maintained percentage. A source-scanning prose guard is defeated by
+    paraphrase and can be satisfied by its own doc comment, so the protection
+    here is the explanation of WHY there is no number, not a grep.

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -490,6 +490,22 @@ Guard layers (`build-userspace-xdp.sh`):
      is `<`, so an object leaving EXACTLY 3.00% passes;
      `TestShimverifyDecision` carries a `970000/1000000` fixture, the only
      one that distinguishes `<` from `<=`.
+   - **The banner reports SLACK, not just headroom (#6884), and the two are
+     not the same question.** Headroom is "how close to the 1M wall". Slack
+     is "how much can still land before the tripwire fires" — the quantity
+     this floor's *sensitivity* rests on. They diverge as the object
+     improves, and the divergence is silent, because a rising headroom is
+     indistinguishable from a healthy object, which is exactly what it is.
+     The floor was chosen against a 5.3% object; #6676 then freed ~193k
+     insns and the object reached **21.58% (784,175/1,000,000)**, at which
+     point the unchanged 3% admitted ~186k more insns — one to two whole
+     extension-header iterations at 87k–106k each — with the gate green and
+     nothing said. `SlackToFloorInsns` is derived from the enforced constant
+     (never a copy of its value) and printed on every build, so a
+     recalibration this large is visible when it happens rather than found
+     by archaeology. **Whether 3% is still the right floor at 21.58% is an
+     open question — see #6884 — and the number to judge it on is the
+     slack, not the percentage.**
    - **The decision lives in ONE place.** `decide()` maps
      `(stats, override)` to the verdict, and `run()` only PRESENTS it —
      `main()` is `os.Exit(run(...))` and nothing else. Before that, `main`
@@ -1063,7 +1079,17 @@ authoritative list; quick recap:
 - xdp_zone fails the verifier on kernel 6.12 (NAT64 complexity); passes
   on 6.18+.
 
-### IPv6 extension-header walk: the shim's budget is nearly spent (#4555)
+### IPv6 extension-header walk: the shim's budget (#4555; re-measured #6884)
+
+> **Re-measured 2026-08-27 (#6884): the budget is no longer nearly spent.**
+> The tracked object is at **784,175 / 1,000,000 — 21.58% headroom** on
+> kernel 7.0.13, after #6676's runtime `binding_slot` extraction. The
+> table below is the #4555 measurement series and is retained because the
+> *couplings* it establishes still hold; its absolute counts are a
+> snapshot of a tree that has since moved by ~206k insns. Processed-insn
+> counts are also **kernel-dependent**, so treat any absolute figure here
+> as provenance-bearing, not as a current value — run `cmd/shimverify`
+> for that.
 
 The shim's `parse_ipv6` extension-header loop is fully unrolled, so every
 iteration duplicates each arm body and its `read_bytes` range

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -506,6 +506,18 @@ Guard layers (`build-userspace-xdp.sh`):
      by archaeology. **Whether 3% is still the right floor at 21.58% is an
      open question — see #6884 — and the number to judge it on is the
      slack, not the percentage.**
+   - **Processed-insn counts did NOT vary by kernel, measured (#6884).** The
+     byte-identical tracked object (md5 `8799db9d…`) verifies at **784,175 on
+     both `7.0.13+deb14-amd64` and `7.0.0-rc7+`** — zero difference. This is
+     recorded because the opposite was *assumed* during #6884 and used to
+     argue for a ratio over a tracked absolute: the 947,188 figure in
+     `verify_userspace_shim_headroom_test.go` is annotated "kernel 7.0" and
+     was read as a cross-kernel data point, but it is the same kernel line as
+     today's host and simply an older, larger object. **The three known counts
+     — 990,796 → 947,188 → 784,175 — are a time series of the object
+     shrinking, not kernel spread.** No evidence either way for a wider
+     version gap (6.x vs 7.x); the measurement above bounds only 7.0.0-rc7 →
+     7.0.13.
    - **The decision lives in ONE place.** `decide()` maps
      `(stats, override)` to the verdict, and `run()` only PRESENTS it —
      `main()` is `os.Exit(run(...))` and nothing else. Before that, `main`

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -1098,10 +1098,16 @@ authoritative list; quick recap:
 > kernel 7.0.13, after #6676's runtime `binding_slot` extraction. The
 > table below is the #4555 measurement series and is retained because the
 > *couplings* it establishes still hold; its absolute counts are a
-> snapshot of a tree that has since moved by ~206k insns. Processed-insn
-> counts are also **kernel-dependent**, so treat any absolute figure here
-> as provenance-bearing, not as a current value — run `cmd/shimverify`
-> for that.
+> snapshot of a tree that has since moved by ~206k insns. Treat any
+> absolute figure here as provenance-bearing, not as a current value — run
+> `cmd/shimverify` for that.
+>
+> Counts *may* also vary across kernel versions — verifier instruction
+> accounting is not a stable ABI — but that is a **caution, not a measured
+> property of this object**: the only cross-kernel measurement taken
+> (7.0.0-rc7+ vs 7.0.13, byte-identical object) found **zero** difference.
+> Nothing here should be read as evidence that a count moved because a
+> kernel did.
 
 The shim's `parse_ipv6` extension-header loop is fully unrolled, so every
 iteration duplicates each arm body and its `read_bytes` range

--- a/pkg/dataplane/verify_userspace_shim.go
+++ b/pkg/dataplane/verify_userspace_shim.go
@@ -50,7 +50,24 @@ import (
 //
 // 3% is deliberately loose. It is not a performance target; it is a
 // tripwire that says "the next change here will not fit" while there is
-// still room to plan. The current object sits at ~5.3%.
+// still room to plan.
+//
+// #6884: there is deliberately NO "the current object sits at X%" sentence
+// here any more. The one that used to be ("~5.3%") was written when the floor
+// was chosen and was FALSE within weeks — #6676 freed ~193k insns and the
+// object moved to 21.58% headroom. That matters more than a wrong number in a
+// comment, because the floor was CALIBRATED against 5.3%: at 21.58% the same
+// 3% admits ~186k additional insns, which is one to two IPv6 extension-header
+// iterations (87k-106k each) landing SILENTLY — so the tripwire no longer
+// fires "before the next change will not fit", which is the entire claim above
+// it. A hand-maintained number is exactly the wrong instrument for judging
+// whether a threshold is still calibrated, because it drifts in the same
+// silence the threshold is supposed to break.
+//
+// The live figures are reported by EVERY build instead: cmd/shimverify's PASS
+// banner prints the processed count, the headroom, and — the one to judge this
+// floor's sensitivity on — how many insns of slack the floor still admits.
+// Those are computed, so they cannot rot.
 const UserspaceShimMinVerifierHeadroomPct = 3.0
 
 // verifyShrinkHashMaxEntries is the verify-only ceiling applied to
@@ -206,6 +223,31 @@ func (s ShimVerifierStats) HeadroomPct() float64 {
 		return 0
 	}
 	return 100 * float64(s.InsnLimit-s.ProcessedInsns) / float64(s.InsnLimit)
+}
+
+// SlackToFloorInsns is how many additional processed instructions a change may
+// cost before this object would trip the given headroom floor (#6884).
+//
+// HeadroomPct answers "how close is this object to the 1M wall". This answers
+// the question the FLOOR's sensitivity actually depends on: "how much can still
+// land without the tripwire firing". They diverge as the object improves, and
+// that divergence is silent — the floor was chosen against a 5.3% object and
+// went on reading 3% while the object moved to 21.58%, at which point the same
+// constant admitted 1-2 whole extension-header iterations without a word.
+// Reporting this on every build is what makes that drift visible at the moment
+// it happens rather than by archaeology.
+//
+// Negative means the object is already past the floor, and the magnitude is how
+// far — useful in the refusal path, where "by how much" is the first thing
+// asked. Returns 0 when unmeasured, which callers must not read as "no slack":
+// stats.Measured() is the guard, and an unmeasured object is a refusal on its
+// own (see decide()).
+func (s ShimVerifierStats) SlackToFloorInsns(floorPct float64) int {
+	if !s.Measured() {
+		return 0
+	}
+	admitted := int(float64(s.InsnLimit) * (1 - floorPct/100))
+	return admitted - s.ProcessedInsns
 }
 
 // shimVerifierStatsRe matches the kernel's end-of-verification summary,

--- a/pkg/dataplane/verify_userspace_shim_headroom_test.go
+++ b/pkg/dataplane/verify_userspace_shim_headroom_test.go
@@ -16,7 +16,13 @@ import (
 // headroom arithmetic the floor is applied to.
 
 func TestParseShimVerifierStats_RealKernelLine(t *testing.T) {
-	// Verbatim from this repo's own `make generate` run (kernel 7.0).
+	// Verbatim from this repo's own `make generate` run (kernel 7.0), taken
+	// when #4555 was written. It is a PARSER fixture — what matters is that it
+	// is a real kernel stats line, not that its count is current. #6884: the
+	// object is now at 784,175; do not read 947,188 here as today's value, and
+	// do not read the kernel note as evidence that counts vary BY kernel (they
+	// were measured identical on 7.0.0-rc7+ and 7.0.13 — see pkg/dataplane
+	// README).
 	const log = "  1092: (bf) r5 = r8\n" +
 		"processed 947188 insns (limit 1000000) max_states_per_insn 34 " +
 		"total_states 54628 peak_states 4153 mark_read 0\n"


### PR DESCRIPTION
Closes #6884

## The issue's number is stale — re-measured first

| | insns | headroom |
|---|---:|---:|
| issue body (`86927d23c`) | 990,796 | 0.92% |
| **master today** | **784,175** | **21.58%** |

```
PASS pkg/dataplane/userspace_xdp_bpfel.o (processed 784175 insns (limit 1000000), headroom 21.58%, 185825 insns of slack before the 3.0% floor)
```
kernel `7.0.13+deb14-amd64`, via `cmd/shimverify` against the tracked object.

**#6676 merged on 2026-08-13** — the issue predicted it would land the object at 797,849; it is actually 784,175. The "one toolchain bump from unbuildable" ceiling is gone by a factor of 23.

**And the guard the issue asks for already exists.** #4555 (`4c56f9b92`) shipped exactly its "Suggested guard": a 3% headroom *threshold* rather than the 1M cliff, the processed count reported rather than pass/fail, enforced by `cmd/shimverify` and branched on by `build-userspace-xdp.sh` with a loud `XPF_SHIM_ALLOW_LOW_HEADROOM=1` override banner. I verified the **wiring**, not just that the constant exists.

So on its own terms the issue is resolved. This PR is about what the re-measurement exposed.

## The finding that is not stale: the floor's calibration drifted, invisibly

The constant's doc comment read:

> *"3% is deliberately loose… a tripwire that says 'the next change here will not fit' while there is still room to plan. **The current object sits at ~5.3%.**"*

True when written. The floor was **calibrated against that 5.3%**. At 21.58%:

```
3% floor admits up to 970,000 insns
=> a change may add 185,825 insns and still PASS
   one IPv6 extension-header iteration costs 87,000-106,000 (this issue's own figure)
   => 1-2 of them land SILENTLY
```

The comment promises a tripwire that fires *before* the next structural change will not fit. At today's headroom it fires only after roughly two have already landed.

**Nothing could have detected this**, and that is the interesting part. Headroom *rising* is indistinguishable from a healthy object — which is exactly what it was. The object genuinely improved; the threshold's sensitivity silently degraded as a side effect of the good news. This is the "a check that fails to a value indistinguishable from healthy" shape, with the twist that the value really was healthy.

## The fix: report the quantity the floor's sensitivity actually rests on

**Headroom** answers "how close to the 1M wall". **Slack** answers "how much can still land before the tripwire fires". They diverge precisely as the object improves, which is when nobody is looking.

Every build now prints slack, **derived from the enforced constant** rather than a copy of its value:

```
processed 784175 insns (limit 1000000), headroom 21.58%, 185825 insns of slack before the 3.0% floor
```

The hand-maintained percentage is **removed** from the comment, replaced by why there is no number there — a figure that must be updated by hand is the wrong instrument for judging whether a threshold is still calibrated, because it drifts in the same silence the threshold exists to break.

## A real escape my own matrix caught

Cell **N5** deleted the `!s.Measured()` guard and **all 617 tests stayed green.**

My fixture was the **zero value** — and for the zero value the guarded and unguarded paths return the same answer (`int(0*(1-0.03)) - 0 == 0` either way). The fixture was the value the bug falls back to, so the cell could not see the mutation it was written for. Dumped the fixture space to find one that discriminates:

| fixture | guarded | unguarded | |
|---|---:|---:|---|
| zero value (my original) | 0 | 0 | **identical — blind** |
| limit, no processed count | 0 | **970,000** | discriminates |
| processed count, no limit | 0 | **−784,175** | discriminates |

The first is the one that matters operationally: an unmeasured stat would report **~970,000 insns of slack — "enormous room" — at exactly the moment headroom is UNKNOWN.** That is the #4555 blind spot reproduced *inside the instrument built to close it*. The cell now carries both discriminating fixtures, and keeps the zero value labelled as **NOT a discriminator** so nobody mistakes it for coverage.

## Mutation matrix

Full-package `go test ./cmd/shimverify/ ./pkg/dataplane/ -count=1 -v`, no `-run` filter, one mutation per cell, fix committed before mutating, tree clean after each restore. No baseline subtraction — the control is 0. Bare `TMPDIR` (the #6859 lesson).

| cell | mutation | reds |
|---|---|---|
| control | — | **0** (620 collected) |
| **N1** | **banner drops the slack operands (the WIRING)** | `PassBannerReportsSlack`, `BannerFloorAgreesWithTheGateConstant` |
| N2 | banner hard-codes the floor instead of deriving it | `PassBannerReportsSlack`, `BannerFloorAgreesWithTheGateConstant` |
| N3 | slack clamped at zero (loses how-far-over) | `SlackGoesNegativePastTheFloor` |
| N4 | slack computed against the WALL — i.e. it just restates headroom, the exact confusion this change removes | `SlackToFloorInsnsArithmetic`, `SlackGoesNegativePastTheFloor`, `SlackTracksTheFloorConstant` |
| N5 | unmeasured guard dropped | **ESCAPED** — fixture was the fall-back value |
| N5b | same mutation, corrected fixture | `SlackIsZeroWhenUnmeasured` |

N1 is the wiring row: `SlackToFloorInsns` is inert unless the banner prints it, and deleting the operands leaves the arithmetic cells green while the build says exactly what it said before — the condition that let the drift go unnoticed.

## The floor: raised 3% → 15%

**Which inputs were measured and which were chosen** — the thing to know when revisiting this:

| input | kind | value |
|---|---|---|
| object headroom | **MEASURED** | 784,175 / 1,000,000 = 21.58%, on two kernels (`7.0.13+deb14-amd64` and `7.0.0-rc7+`, byte-identical object, md5 verified, **zero** difference) |
| structural-change cost | **JUDGED** | 87,000 insns — the conservative end of #4555's 87k–106k for one IPv6 extension-header iteration. **This is the number to revisit.** |

15% is deliberately **not** the mathematical minimum. 12.88% is where the admitted delta equals one structural change exactly — and a threshold placed on its own boundary is the failure this issue spent its time documenting: a path at exactly the `sun_path` budget failed only on wide random draws, and a floor at exactly 12.88% holds for an 87,000-insn change and fails for an 88,000 one. The 2.1 points above are margin, labelled as judgement rather than dressed as measurement.

Erring high is cheap and erring low is not: the gate carries a loud `XPF_SHIM_ALLOW_LOW_HEADROOM=1` override naming the object and reason, so too-high is an announced detour while too-low is the silent 1–2-iteration hole.

## The floor now self-checks its own calibration

The defect was that the floor's calibration drifted and **nothing could detect it** — "does it fire before the next structural change" is a fact about the *relationship* between the floor and the current object, and that relationship moves whenever the object does, silently, in the direction that looks like good news.

A test cannot own it: pinning the current object size reintroduces exactly the hand-maintained live number this PR removes. **The build can**, because it already computes slack from live inputs. Every PASSING build now compares slack against `UserspaceShimStructuralChangeInsns` and prints a NOTE — not a refusal, the object verified — when the property has broken. Silent while it holds; at 15% the slack is 65,825 against a cost of 87,000.

**General form: a threshold whose sensitivity is defined relative to a moving value needs a check on the relationship, not on the value.**

Second matrix (full-package, no `-run`, control 0 / 624 collected):

| cell | mutation | reds |
|---|---|---|
| **P1** | **delete the self-check's call from the PASS path (WIRING)** | `FloorSelfCheckIsWiredIntoThePassPath` |
| P2 | note fires unconditionally (tuned out in a week) | `FloorSelfCheckSilentWhenThePropertyHolds`, `FloorSelfCheckBoundary` |
| P3 | boundary `<` → `<=` (fires one change too late) | `FloorSelfCheckBoundary` |
| P4 | floor silently reverted to 3.0 | `TestShimverifyDecision` — the **pre-existing** fixture preconditions own the floor value, visible only because the matrix ran full-package |

### Fixtures the raise invalidated

Three, and **their own self-checking preconditions caught every one** — loudly, by name, rather than silently miscategorising. One of them, 947,188 labelled *"the current object"*, turned a correct raise into a phantom *"rejects the CURRENT object"* failure. That is the **third** instance of the hand-maintained-number defect inside this one issue. All are now synthetic and round, chosen purely for their relation to the floor, with the real measurement kept only as provenance.

## Deliberately NOT done, and why

**(the floor is now raised — this section is retained for the reasoning)**

**Raising the floor.** At 21.58% a 3% floor is arguably far too loose, and 15% would restore the designed sensitivity. But this is a **build gate**: any lane whose change drops below the new floor starts failing `make generate`. That is a policy change affecting every lane, so it is referred for a decision rather than taken unilaterally. The slack figure now makes the question answerable from any build log.

**Recording an absolute insn baseline.** An absolute would red on **ordinary object change** — 990,796 → 947,188 → 784,175 across three tree states, which is frequent and expected — whereas a ratio is a proportion of a fixed 1M cap.

> **Retracted from an earlier revision of this PR:** I first justified this by asserting counts are *kernel-dependent*, citing "the #4555 fixture records 947,188 on a different kernel". **It does not.** Those are hand-written fixture constants, and the one annotation naming a kernel says "kernel 7.0" — the same line as the host I measured on. The three counts are the object shrinking, not kernel spread. Review chased the citation and found the fixture.
>
> I then measured it rather than inferring: the byte-identical object (md5 verified both sides) processes **784,175 on both `7.0.13+deb14-amd64` and `7.0.0-rc7+` — zero difference**. Kernel variation survives in the README as a *caution* with no citation; the conclusion above never needed it.
>
> Worth naming: a PR that removes a stale hand-maintained claim from a comment had **added a cited-but-unsupported one to a comment**. That fixture label is a third instance of the very defect being fixed here, and it is what produced the bad inference.

**Guarding the comment against re-acquiring a number.** A source-scanning prose gate is defeated by paraphrase and can be satisfied by its own doc comment. The protection is the explanation of *why* there is no number, not a grep. Stated so the gap is visible rather than assumed covered.

## Docs

- `pkg/dataplane/README.md` — the slack-vs-headroom distinction beside the #4555 gate description, including the drift arithmetic and that whether 3% is still right is open.
- Same file — the extension-header section re-headed with the re-measurement and a warning that its absolute counts are a snapshot of a tree that has since moved ~206k insns, and that counts are kernel-dependent.
- `docs/log/6884.md`.

## Gate

- `go build ./...` → rc 0
- `go test ./... -count=1 -p 4` → **rc 0, 68 packages, 0 failures** at HEAD `706ac69d3`
- `merge-base --is-ancestor origin/master HEAD` verified against `origin/master` `e70b3c4ab`; folded with `git merge`
- **No `make generate`, no smoke, no cargo leg.** The shim source is untouched and the tracked `.o` is byte-identical — this changes only what the gate *reports*. The #1864 pinned-toolchain / kernel-verifier path is not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ez9XCjM9mPjtocRjkousdB


