### PR TITLE
screen: bind the ext-header walk depth instead of restating a number

### DIFF
--- a/bpf/headers/xpf_common.h
+++ b/bpf/headers/xpf_common.h
@@ -34,7 +34,9 @@
 #define NEXTHDR_NONE    59
 /* RETIRED-eBPF (#1476): this bound belongs to the deleted XDP/TC pipeline's
  * walker in xpf_helpers.h, which no .c file compiles any more. It is NOT the
- * live AF_XDP shim's bound — that is MAX_EXT_HDRS in userspace-xdp/src/lib.rs,
+ * live AF_XDP shim's bound — that is MAX_EXT_HDRS in
+ * userspace-xdp/src/ipv6_ext_walk.rs (#6885: it lives there now; lib.rs only
+ * re-exports it),
  * which #4555 moved to 7 to reach parity with MAX_IPV6_EXT_HEADERS in
  * userspace-dp/src/afxdp/frame/inspect.rs. Editing THIS define changes nothing
  * at runtime; see pkg/dataplane/README.md "IPv6 extension-header walk". */

--- a/docs/log/6885.md
+++ b/docs/log/6885.md
@@ -1,0 +1,59 @@
+# #6885 — screen/extract.rs claimed MAX_EXT_HDRS=8 parity with the BPF parser
+
+- **Timestamp**: 2026-08-27
+  - **Action**: corrected the comment and, more usefully, bound the property it
+    was trying to state. `screen/extract.rs` claimed "We bound the walk to
+    MAX_EXT_HDRS=8 like the BPF parser". Both halves false — but the PARITY it
+    asserted is real, just not with that constant or that peer.
+  - **Measured at current master** (the issue's own figures had rotted):
+    | Walker | Bound | Location |
+    |---|---|---|
+    | screen extractor | bare literal `for _ in 0..8` | `screen/extract.rs` |
+    | forwarding walker | `MAX_IPV6_EXT_HEADERS = 8` | `afxdp/frame/inspect.rs:31` |
+    | AF_XDP shim | `MAX_EXT_HDRS = 7` | `userspace-xdp/src/ipv6_ext_walk.rs:48` |
+    | retired BPF | `MAX_EXT_HDRS = 6` | `bpf/headers/xpf_common.h:41` (dead) |
+
+    The issue says the shim is 6 in `lib.rs`. It is **7**, in
+    `ipv6_ext_walk.rs` — #4555 moved and changed it, and **#4555 is CLOSED**,
+    so the issue's "a reader would conclude #4555 was resolved" argument is
+    moot: it IS resolved. The comment was still wrong, for different reasons
+    than the issue gives.
+  - **The number the issue never states**: what the screen walk actually
+    resolves. Measured by driving chains of 0..=10 Destination-Options headers
+    through it — resolves 0..=7, refuses 8+. Identical to the forwarding
+    walker at every length. So all three walkers share one depth, reached by
+    three mechanisms with three different numbers, which is exactly why a
+    literal restated in a comment was wrong for two of them.
+  - **Bound as an agreement, not a literal**, per the rule that a doc comment
+    about cross-plane parity agrees with itself. The new test asserts the
+    screen extractor and the forwarding walker resolve the same depths at every
+    chain length, plus an anchor that the shared depth is 0..=7 so the
+    agreement cannot be satisfied by both regressing together (two all-false
+    vectors are equal).
+  - **Not single-sourced deliberately**: `MAX_IPV6_EXT_HEADERS` is reachable,
+    but `afxdp` depends on `screen` and screen production code is currently
+    afxdp-free, so importing it would invert the layering for a constant whose
+    agreement a test already holds.
+  - **Third edge of a triangle**: shim↔walker was already bound (#4555 emitted
+    facts, `tests_shim_ext_parity.rs`). screen↔walker was unguarded until now,
+    and a divergence there is an ext-header IDS evasion (#3120/#4517 class),
+    not a fast-path miss.
+  - **Also fixed**: `bpf/headers/xpf_common.h` pointed at
+    `userspace-xdp/src/lib.rs` for the live bound; the constant lives in
+    `ipv6_ext_walk.rs` now and lib.rs only re-exports it. Same staleness class,
+    same change.
+  - **No screen module README exists**, so the doc updated is the one that owns
+    this contract: `pkg/dataplane/README.md` "IPv6 extension-header walk".
+  - **Shim manifest**: `bpf/headers/xpf_common.h` is a hash-pinned BUILD INPUT
+    of the AF_XDP shim, so even a comment-only edit reds
+    `TestUserspaceXDPShimObjectMatchesSourceManifest`. Ran `make generate` and
+    classified the result rather than regenerating blind: verifier PASS
+    (784,175 insns, 21.58% headroom), **the object is byte-identical**
+    (md5 `8799db9dda59860db5c65ee8816be682` before and after — the edit moved no
+    code), and the manifest diff is exactly ONE value: the `xpf_common.h`
+    build-input hash, matching the value the failing test reported. 0 keys
+    added, 0 removed.
+  - **File(s)**: userspace-dp/src/screen/extract.rs,
+    userspace-dp/src/screen/tests.rs, bpf/headers/xpf_common.h,
+    pkg/dataplane/README.md, pkg/dataplane/userspace_xdp_manifest.json,
+    docs/log/6885.md

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -1109,6 +1109,29 @@ So the correct condition is `MAX_EXT_HDRS == MAX_IPV6_EXT_HEADERS - 1`
 (7 and 8): both walkers resolve 0..=7 extension headers and both refuse 8
 or more.
 
+**There is a THIRD walker, and it shares the same depth (#6885).** The screen
+extractor (`userspace-dp/src/screen/extract.rs`) walks the chain independently
+to find the Fragment header and the L4 for the TCP-flag screens and the
+SYN-cookie challenge. It is bounded by a bare `for _ in 0..8` — no named
+constant — and, like `walk_ipv6_ext_chain`, spends one iteration on the
+terminal, so it too resolves 0..=7 and refuses 8 or more. Measured, not
+assumed: `screen_ext_header_depth_agrees_with_the_forwarding_walker_6885`
+drives chains of 0..=10 headers through the extractor AND the walker and
+requires them to agree at every length.
+
+That test is the third edge of the parity triangle. The shim↔walker edge is
+held by the #4555 emitted-facts assertion in `tests_shim_ext_parity.rs`; the
+screen↔walker edge was unguarded until #6885, and a divergence there is a
+chain one plane screens and the other does not — an ext-header IDS evasion of
+the #3120/#4517 class rather than a fast-path miss.
+
+Note the three walkers carry three DIFFERENT numbers for one shared depth
+(`0..8` iterations, `MAX_IPV6_EXT_HEADERS = 8`, `MAX_EXT_HDRS = 7`), which is
+why the depth must be bound as an AGREEMENT and never restated as a literal in
+a comment. #6885 was exactly that failure: `extract.rs` claimed
+"MAX_EXT_HDRS=8 like the BPF parser", and no constant of that name has ever
+been 8 while the BPF parser bounded at 6.
+
 **The two mismatch directions are not symmetric.** Only shim-BELOW-userspace
 is fail-closed: the shim's unresolved chain leaves the extension-header type
 in `ParsedPacket::protocol` with `parse_l4`'s catch-all ports 0/0, so the

--- a/pkg/dataplane/userspace_xdp_manifest.json
+++ b/pkg/dataplane/userspace_xdp_manifest.json
@@ -16,7 +16,7 @@
     },
     {
       "path": "bpf/headers/xpf_common.h",
-      "sha256": "966135a80e3ff6ad25077f41e2c483700e1ddb65f9e41ba4f9074101cae1ca2e"
+      "sha256": "d2369219f7f7fa75aa702c6a3506a2ebb7613fe4255307d2f0ada224763ae22c"
     },
     {
       "path": "pkg/dataplane/build-userspace-xdp.sh",

--- a/userspace-dp/src/screen/extract.rs
+++ b/userspace-dp/src/screen/extract.rs
@@ -201,7 +201,37 @@ pub(crate) fn extract_screen_info(
     } else if addr_family == libc::AF_INET6 as u8 {
         // IPv6: walk the extension header chain looking for
         // NEXTHDR_FRAGMENT (44). Fixed IPv6 base header is 40 bytes.
-        // We bound the walk to MAX_EXT_HDRS=8 like the BPF parser.
+        //
+        // #6885: the bound below is `0..8` ITERATIONS, and one iteration is
+        // spent on the terminal (the arm that sets `tcp_offset` and breaks),
+        // so this walk resolves chains of **0..=7 extension headers** and
+        // refuses 8 or more. Measured, not asserted:
+        // `screen_ext_header_depth_agrees_with_the_forwarding_walker_6885`
+        // drives chains of 0..=10 headers through this extractor AND through
+        // `walk_ipv6_ext_chain` and requires the two to agree at every length.
+        //
+        // That depth is shared by all three IPv6 ext-header walkers in the
+        // tree, which reach it by DIFFERENT mechanisms and therefore carry
+        // three different numbers — which is why the number alone was never
+        // safe to state here:
+        //
+        //   this extractor            `0..8` iterations, terminal costs one
+        //   `walk_ipv6_ext_chain`     MAX_IPV6_EXT_HEADERS = 8, ditto, and
+        //                             folds exhaustion into `OverLimit`
+        //   the AF_XDP shim           MAX_EXT_HDRS = 7, exits by EXHAUSTION
+        //                             carrying the next-header, so it needs
+        //                             no terminal iteration
+        //
+        // The shim's parity condition is stated once, authoritatively, at
+        // `userspace-xdp/src/ipv6_ext_walk.rs` (`MAX_EXT_HDRS ==
+        // MAX_IPV6_EXT_HEADERS - 1`); #4555 moved it from 6 to 7 to reach it.
+        //
+        // The comment this replaces read "We bound the walk to
+        // MAX_EXT_HDRS=8 like the BPF parser", and both halves were false: no
+        // constant named `MAX_EXT_HDRS` has ever been 8 (it is 7 in the live
+        // shim and 6 in the retired BPF header), and the BPF parser bounded
+        // at 6 — so it was never in parity with this walk at all. The parity
+        // is real; the number and the peer named for it were not.
         //
         // FAIL-CLOSED (#2146): every place the walk runs out of bytes
         // (the base header is short, or an extension header's declared

--- a/userspace-dp/src/screen/tests.rs
+++ b/userspace-dp/src/screen/tests.rs
@@ -5856,3 +5856,85 @@ fn shared_fragment_route_helper_binds_full_path_6238() {
         ScreenVerdict::Drop("ip-source-route")
     );
 }
+
+/// #6885: the screen extractor's ext-header walk resolves the SAME chain
+/// depths as the forwarding walker — bound as an AGREEMENT, not as a number.
+///
+/// The comment this replaces asserted parity by stating a constant
+/// (`MAX_EXT_HDRS=8`) and a peer (`the BPF parser`), and both were false: no
+/// constant of that name has ever been 8, and the BPF parser bounded at 6.
+/// The parity itself was real. That is the failure mode a hand-written number
+/// has here — three walkers reach the same depth by different mechanisms and
+/// therefore carry three different numbers (this extractor's `0..8`
+/// iterations, `MAX_IPV6_EXT_HEADERS = 8`, the shim's `MAX_EXT_HDRS = 7`), so
+/// any single number copied into a comment is wrong for two of them.
+///
+/// Pinning either side's literal would just re-create that. This asserts the
+/// two walkers AGREE at every chain length, which stays true through a
+/// mechanism change on either side and reds the moment their coverage
+/// actually diverges.
+///
+/// The sweep spans the boundary deliberately: 0..=7 must resolve, 8..=10 must
+/// refuse. A sweep that stopped at 7 would pass against a walk with no bound
+/// at all.
+#[test]
+fn screen_ext_header_depth_agrees_with_the_forwarding_walker_6885() {
+    let mut screen_resolved = Vec::new();
+    let mut walker_resolved = Vec::new();
+
+    for n in 0usize..=10 {
+        // base -> n x Destination-Options(8B) -> TCP
+        let base = 14 + 40;
+        let mut frame = vec![0u8; base + n * 8 + 24];
+        frame[14] = 0x60; // version = 6
+        frame[14 + 6] = if n == 0 { 6 } else { 60 };
+        for i in 0..n {
+            let at = base + i * 8;
+            frame[at] = if i + 1 == n { 6 } else { 60 }; // last one points at TCP
+            frame[at + 1] = 0; // HdrExtLen = 0 -> 8 bytes
+        }
+        let tcp = base + n * 8;
+        frame[tcp + 4..tcp + 8].copy_from_slice(&0x1122_3344u32.to_be_bytes());
+        frame[tcp + 12] = 0x50; // data offset = 5 words
+
+        let screen = extract_screen_info(
+            &frame,
+            libc::AF_INET6 as u8,
+            6,
+            0x02,
+            frame.len() as u16,
+            IpAddr::V6("2001:db8::1".parse::<Ipv6Addr>().unwrap()),
+            IpAddr::V6("2001:db8::2".parse::<Ipv6Addr>().unwrap()),
+            12345,
+            80,
+            14,
+        );
+        // "Resolved" for the extractor means it actually REACHED the L4 and
+        // pulled the TCP header out — not merely that it returned Ok. A walk
+        // that gave up mid-chain still returns Ok with tcp_seq left at 0, and
+        // that is precisely the ext-header evasion #3120/#4517 are about.
+        screen_resolved.push(screen.map(|i| i.tcp_seq == 0x1122_3344).unwrap_or(false));
+
+        let walk = crate::afxdp::walk_ipv6_ext_chain(&frame, 14);
+        walker_resolved.push(matches!(
+            walk.outcome,
+            crate::afxdp::ExtChainOutcome::L4(_, _)
+        ));
+    }
+
+    assert_eq!(
+        screen_resolved, walker_resolved,
+        "#6885: the screen extractor and the forwarding walker must resolve the same IPv6 \
+         ext-header chain depths. Index n is a chain of n Destination-Options headers; a \
+         divergence means a chain one plane screens is invisible to the other, or vice versa"
+    );
+
+    // Anchor the shared depth so the agreement above cannot be satisfied by
+    // BOTH walkers regressing together (two all-false vectors are equal).
+    let expected: Vec<bool> = (0usize..=10).map(|n| n <= 7).collect();
+    assert_eq!(
+        screen_resolved, expected,
+        "#6885: both walkers must resolve 0..=7 extension headers and refuse 8 or more — the \
+         depth the shim's MAX_EXT_HDRS = MAX_IPV6_EXT_HEADERS - 1 parity note names"
+    );
+}


### PR DESCRIPTION
Closes #6885

## What the comment said, and what is actually true

`screen/extract.rs` claimed:

> `// We bound the walk to MAX_EXT_HDRS=8 like the BPF parser.`

Both halves are false — **but the parity it asserts is real**, which is what
makes this worth more than a number correction.

Measured at current master, all four walkers in the tree:

| Walker | Bound | Where |
|---|---|---|
| screen extractor | bare literal `for _ in 0..8` — **no named constant** | `userspace-dp/src/screen/extract.rs` |
| forwarding walker | `MAX_IPV6_EXT_HEADERS = 8` | `afxdp/frame/inspect.rs:31` |
| AF_XDP shim | `MAX_EXT_HDRS = 7` | `userspace-xdp/src/ipv6_ext_walk.rs:48` |
| retired BPF | `MAX_EXT_HDRS = 6` | `bpf/headers/xpf_common.h:41` (dead since #1476) |

No constant named `MAX_EXT_HDRS` has ever been 8, and the BPF parser bounded at
6 — so it was never in parity with this walk at all.

## The number the issue never states: what the screen walk actually resolves

Measured by driving chains of 0..=10 Destination-Options headers through the
extractor **and** through `walk_ipv6_ext_chain`:

| chain length | screen extractor | forwarding walker |
|---|---|---|
| 0–7 | resolves TCP | `L4(..)` |
| 8+ | refuses | `OverLimit` |

They agree at every length. The loop is `0..8` **iterations** and one iteration
is spent on the terminal, so it resolves 0..=7 headers — the same depth as the
other two, reached by a different mechanism.

**Three walkers, one depth, three different numbers.** That is precisely why a
literal restated in a comment is wrong for two of them, and how this one rotted.

## The fix: bind the agreement, don't restate a literal

`screen_ext_header_depth_agrees_with_the_forwarding_walker_6885` asserts the two
walkers resolve the same depths at every chain length. It survives a mechanism
change on either side and reds only when coverage actually diverges.

It carries a second assertion anchoring the shared depth at 0..=7, because an
agreement between two vectors is *also* satisfied by both regressing together —
two all-false vectors are equal.

**This is the third edge of a triangle.** The shim↔walker edge was already bound
(the #4555 emitted-facts assertion in `tests_shim_ext_parity.rs:360`). The
screen↔walker edge was **unguarded**, and the matrix shows what that meant:
changing the screen depth by ±1 red **exactly one test — the new one**. Nothing
else in the tree noticed.

A divergence on this edge is not a fast-path miss; it is a chain one plane
screens and the other does not — an ext-header IDS evasion of the #3120/#4517
class.

### Deliberately not single-sourced

`MAX_IPV6_EXT_HEADERS` is reachable, but `afxdp` depends on `screen` and screen
production code is currently afxdp-free. Importing it would invert the layering
for a constant whose agreement a test now holds.

## The issue's own figures had rotted

It reports the shim at **6**, in `userspace-xdp/src/lib.rs`. It is **7**, in
`userspace-xdp/src/ipv6_ext_walk.rs` — #4555 both moved and changed it. And
**#4555 is CLOSED**, so the issue's stated stakes ("it would have told someone
screening #4555 that the issue was already resolved") no longer apply: it *is*
resolved. The comment was still wrong, for different reasons than the issue
gives. Same class of staleness as the comment it reports — which is the point.

Also fixed, one file over and same class: `bpf/headers/xpf_common.h` pointed at
`userspace-xdp/src/lib.rs` for the live bound, which now only re-exports it.

## Mutation matrix

Fix committed before mutating. One mutation per cell, full suite, no `-run`
filter, `--test-threads=1`. The runner **refuses to score a cell whose mutation
did not change the file** (md5 before/after).

| # | Mutation | Collected | Named RED |
|---|---|---|---|
| M1 | screen walk one shallower (`0..8` → `0..7`) | 4723 | **1 — only the new test** |
| M2 | screen walk one deeper (`0..8` → `0..9`) | 4723 | **1 — only the new test** |
| M3 | forwarding walker shallower (`MAX_IPV6_EXT_HEADERS` 8 → 7) | 4716 | 8, incl. the new test, `shim_ipv6_ext_walk_matches_userspace_walker`, `nat64_v6_to_v4_seven_ext_headers_translates` |

M1/M2 landing on exactly one test each is the finding, not a weakness: it
measures how unguarded that edge was. M3's eight reds show the walker side was
already well covered — the asymmetry is the gap this PR closes.

## Shim manifest regeneration, classified rather than blind

`bpf/headers/xpf_common.h` is a hash-pinned **build input** of the AF_XDP shim,
so even a comment-only edit reds
`TestUserspaceXDPShimObjectMatchesSourceManifest`. Ran `make generate` and
classified:

- verifier **PASS** — 784,175 insns, **21.58% headroom**
- **the object is byte-identical** — `8799db9dda59860db5c65ee8816be682` before
  and after, confirming the edit moved no code
- manifest diff is exactly **one value**: the `xpf_common.h` build-input hash,
  matching the value the failing test reported. 0 keys added, 0 removed.

## Validation

Gated head `e372dacbb` (`origin/master` merged in, not rebased; clean, no
conflicting paths).

- `cargo test --release --bins --tests -- --test-threads=1`: **4793 collected, 0 failed**; `cargo check --benches` clean.
- `go test ./... -count=1`: **rc=0**, 68 packages.

Docs: there is no `screen` module README, so the doc updated is the one that
owns this contract — `pkg/dataplane/README.md` "IPv6 extension-header walk" —
which now names the third walker and the third edge.
