### PR TITLE
shimverify: raise the headroom floor to 15% and self-check its calibration

### DIFF
--- a/cmd/shimverify/main.go
+++ b/cmd/shimverify/main.go
@@ -184,6 +184,8 @@ func run(
 				allowLowHeadroomEnv, stats.HeadroomPct(), dataplane.UserspaceShimMinVerifierHeadroomPct)
 		}
 		fmt.Fprintf(stdout, "%s %s (%s)\n", decision.label, path, summary)
+		noteFloorNoLongerTripwires(stderr,
+			stats.SlackToFloorInsns(dataplane.UserspaceShimMinVerifierHeadroomPct))
 	}
 
 	return decision.exit
@@ -274,6 +276,50 @@ func decide(stats dataplane.ShimVerifierStats, overridden bool) shimverifyDecisi
 		return shimverifyDecision{refusal: refusalLowHeadroom, exit: 4, label: "LOW-HEADROOM"}
 	}
 	return shimverifyDecision{refusal: refusalNone, exit: 0, label: "PASS", staleOverrideNote: overridden}
+}
+
+// noteFloorNoLongerTripwires reports, on a PASSING build, that the floor has
+// stopped satisfying its own stated property (#6884).
+//
+// The floor promises to fire BEFORE the next structural change lands. Whether
+// it still does is a fact about the RELATIONSHIP between the floor and the
+// current object, and that relationship moves whenever the object does —
+// silently, and in the direction that looks like good news. 3% was chosen
+// against a 5.3% object and went on reading 3% while the object reached
+// 21.58%, at which point it admitted one to two whole extension-header
+// iterations with every gate green.
+//
+// A test cannot own this. The property depends on the current object size, and
+// pinning that in a test reintroduces exactly the hand-maintained live number
+// #6884 removed from the floor's doc comment. The BUILD can, because it already
+// computes slack from live inputs — so the check needs no maintained current
+// value, only the structural-change cost the property is defined against.
+//
+// This is the general form of the lesson: a threshold whose sensitivity is
+// defined relative to a moving value needs a check on the RELATIONSHIP, not on
+// the value.
+//
+// Silent when the property holds. It is a NOTE, not a refusal: the object
+// verified and the floor was satisfied, so the build is good — what has decayed
+// is the tripwire's usefulness, which is a thing to fix deliberately rather
+// than a reason to fail someone's build.
+func noteFloorNoLongerTripwires(w io.Writer, slack int) {
+	if slack < dataplane.UserspaceShimStructuralChangeInsns {
+		return
+	}
+	fmt.Fprintf(w,
+		"shimverify: NOTE (#6884): the %.1f%% floor now admits %d more insns before it "+
+			"fires, which is at least one STRUCTURAL change (%d insns — one IPv6 "+
+			"extension-header iteration).\n"+
+			"  The floor's stated property is that it fires BEFORE the next structural "+
+			"change lands. It no longer does: a change that large would be admitted "+
+			"silently, which is the exact condition that let the shim reach 0.92%% "+
+			"headroom with every gate green.\n"+
+			"  This is not a failure — the object verified and the floor was satisfied. "+
+			"It means the floor has drifted out of calibration because the object "+
+			"IMPROVED, and raising it is now a deliberate decision someone should make.\n",
+		dataplane.UserspaceShimMinVerifierHeadroomPct, slack,
+		dataplane.UserspaceShimStructuralChangeInsns)
 }
 
 // announceOverrideConsumed logs, loudly and unambiguously, that a build

--- a/cmd/shimverify/main_test.go
+++ b/cmd/shimverify/main_test.go
@@ -33,20 +33,23 @@ import (
 // `<=` flips a 3.00%% object from install to refusal with every other fixture
 // unmoved.
 func TestShimverifyDecision(t *testing.T) {
-	// Above the floor: 947188/1000000 leaves 5.28% — the object as it stood
-	// WHEN #4555 WAS WRITTEN, not now. #6884: master is at 784,175 (21.58%).
-	// The value stays because what it is chosen for is its RELATION to the
-	// floor (comfortably above), not its currency; the label is corrected
-	// because "the current object" is exactly the hand-maintained live number
-	// that #6884 removed from the constant's doc comment, and this copy of it
-	// misled a reader into a cross-kernel inference the data did not support.
-	above := dataplane.ShimVerifierStats{ProcessedInsns: 947188, InsnLimit: 1000000}
+	// Above the floor: 800000/1000000 leaves 20.00%. SYNTHETIC and round,
+	// chosen purely for its relation to the floor.
+	//
+	// #6884: this was 947,188 labelled "the current object" — a hand-maintained
+	// live number, the same defect this issue removed from the floor's doc
+	// comment, and the one that misled a reviewer into a cross-kernel inference
+	// the data did not support. When the floor moved 3% -> 15% it also turned a
+	// correct raise into a phantom "rejects the current object" failure. A
+	// fixture's job is to sit above or below the threshold; claiming to be the
+	// live object is a different job that goes stale by construction.
+	above := dataplane.ShimVerifierStats{ProcessedInsns: 800000, InsnLimit: 1000000}
 	// Below it: 990796/1000000 leaves 0.92%, master before #4555.
 	below := dataplane.ShimVerifierStats{ProcessedInsns: 990796, InsnLimit: 1000000}
-	// EXACTLY on it: 970000/1000000 leaves 3.00%, which in IEEE-754 is the
+	// EXACTLY on it: 850000/1000000 leaves 15.00%, which in IEEE-754 is the
 	// floor's value bit for bit (100*(10^6-97*10^4)/10^6 == 3.0 exactly, both
 	// operands being exactly representable), so this fixture straddles nothing.
-	atFloor := dataplane.ShimVerifierStats{ProcessedInsns: 970000, InsnLimit: 1000000}
+	atFloor := dataplane.ShimVerifierStats{ProcessedInsns: 850000, InsnLimit: 1000000}
 	// No recognisable stats line: Measured() is false.
 	unmeasured := dataplane.ShimVerifierStats{}
 
@@ -171,8 +174,8 @@ func TestShimverifyRun(t *testing.T) {
 		}
 	}
 
-	above := dataplane.ShimVerifierStats{ProcessedInsns: 947188, InsnLimit: 1000000}
-	atFloor := dataplane.ShimVerifierStats{ProcessedInsns: 970000, InsnLimit: 1000000}
+	above := dataplane.ShimVerifierStats{ProcessedInsns: 800000, InsnLimit: 1000000}
+	atFloor := dataplane.ShimVerifierStats{ProcessedInsns: 850000, InsnLimit: 1000000}
 	below := dataplane.ShimVerifierStats{ProcessedInsns: 990796, InsnLimit: 1000000}
 
 	for _, tc := range []struct {

--- a/cmd/shimverify/slack_banner_6884_test.go
+++ b/cmd/shimverify/slack_banner_6884_test.go
@@ -169,3 +169,112 @@ func TestSlackTracksTheFloorConstant6884(t *testing.T) {
 		t.Fatalf("SlackToFloorInsns(15.0) = %d, want %d", at15, 850000-784175)
 	}
 }
+
+// TestFloorSelfCheckFiresWhenThePropertyBreaks6884 is the self-check's reason
+// to exist: the floor's promise is to fire BEFORE the next structural change
+// lands, and whether it still does depends on the RELATIONSHIP between the
+// floor and the current object — which moves whenever the object does, in the
+// direction that looks like good news.
+//
+// The fixture is the historical condition: a 3%-era slack of 185,825, which is
+// more than two of the cheapest structural change. The note must say so.
+func TestFloorSelfCheckFiresWhenThePropertyBreaks6884(t *testing.T) {
+	var buf bytes.Buffer
+	noteFloorNoLongerTripwires(&buf, 185825)
+
+	out := buf.String()
+	if out == "" {
+		t.Fatal("the floor admitted 185,825 insns — more than two structural changes — and " +
+			"the build said nothing. That is the drift #6884 exists to make visible")
+	}
+	// It must name the structural-change cost, since that is the number the
+	// reader has to judge the floor against.
+	if !strings.Contains(out, strconv.Itoa(dataplane.UserspaceShimStructuralChangeInsns)) {
+		t.Fatalf("the note does not name the structural-change cost it compared against: %s", out)
+	}
+	// And it must not read as a build failure — the object verified.
+	if strings.Contains(strings.ToLower(out), "reject") {
+		t.Fatalf("the note reads as a refusal, but the object PASSED: %s", out)
+	}
+}
+
+// TestFloorSelfCheckSilentWhenThePropertyHolds6884 is the PAIRED control, and
+// it is the cell that makes the one above mean something: without it, "print a
+// note" is satisfied by a note that prints unconditionally, which would fire on
+// every healthy build and be tuned out within a week.
+//
+// 65,825 is the real slack at the 15% floor against master's measured 784,175.
+func TestFloorSelfCheckSilentWhenThePropertyHolds6884(t *testing.T) {
+	var buf bytes.Buffer
+	noteFloorNoLongerTripwires(&buf, 65825)
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("the floor still fires before one structural change (65,825 < %d) and the "+
+			"build emitted a drift note anyway: %s",
+			dataplane.UserspaceShimStructuralChangeInsns, got)
+	}
+}
+
+// TestFloorSelfCheckBoundary6884 pins the comparison at the exact edge.
+//
+// The check is `slack < cost -> silent`, so a slack of EXACTLY the
+// structural-change cost means one change fits precisely and the property has
+// broken. `<=` there would stay silent at the moment it first fails — the
+// off-by-one that makes a tripwire fire one change too late, which is the
+// entire defect this issue documents, reproduced in the detector for it.
+func TestFloorSelfCheckBoundary6884(t *testing.T) {
+	cost := dataplane.UserspaceShimStructuralChangeInsns
+
+	var atCost bytes.Buffer
+	noteFloorNoLongerTripwires(&atCost, cost)
+	if atCost.String() == "" {
+		t.Fatalf("slack of exactly %d insns fits one structural change precisely, so the "+
+			"property has broken — the note must fire", cost)
+	}
+
+	var justUnder bytes.Buffer
+	noteFloorNoLongerTripwires(&justUnder, cost-1)
+	if justUnder.String() != "" {
+		t.Fatalf("slack of %d is one insn short of a structural change, so the property "+
+			"still holds — the note must be silent: %s", cost-1, justUnder.String())
+	}
+}
+
+// TestFloorSelfCheckIsWiredIntoThePassPath6884 binds the WIRING.
+//
+// noteFloorNoLongerTripwires is inert unless run() calls it on the PASS path.
+// Deleting that one call leaves every cell above green while the build goes
+// back to saying nothing — which is precisely the silence this whole issue is
+// about.
+//
+// Driven with a stats value whose slack at the REAL floor exceeds the
+// structural-change cost, so the note is expected on stderr.
+func TestFloorSelfCheckIsWiredIntoThePassPath6884(t *testing.T) {
+	// Headroom well above the floor (so this PASSES), but slack large enough
+	// that the property has broken. At a 15% floor, 700,000 used leaves 150,000
+	// of slack — above the 87,000 cost.
+	stats := dataplane.ShimVerifierStats{ProcessedInsns: 700000, InsnLimit: 1000000}
+	if stats.HeadroomPct() < dataplane.UserspaceShimMinVerifierHeadroomPct {
+		t.Skipf("fixture no longer passes the floor (%.2f%% < %.1f%%); pick a smaller object",
+			stats.HeadroomPct(), dataplane.UserspaceShimMinVerifierHeadroomPct)
+	}
+	if stats.SlackToFloorInsns(dataplane.UserspaceShimMinVerifierHeadroomPct) <
+		dataplane.UserspaceShimStructuralChangeInsns {
+		t.Skipf("fixture no longer breaks the property; pick a smaller object")
+	}
+
+	var stdout, stderr bytes.Buffer
+	exit := run([]string{"shimverify", "/tmp/candidate.o"}, &stdout, &stderr,
+		func(string) string { return "" },
+		func(string) (dataplane.ShimVerifierStats, error) { return stats, nil })
+
+	if exit != 0 || !strings.HasPrefix(stdout.String(), "PASS ") {
+		t.Fatalf("expected a PASS; exit=%d stdout=%q", exit, stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "#6884") {
+		t.Fatalf("run() did not emit the floor drift note on a PASSING build whose floor "+
+			"admits %d insns — the check is not wired into the PASS path.\nstderr: %s",
+			stats.SlackToFloorInsns(dataplane.UserspaceShimMinVerifierHeadroomPct),
+			stderr.String())
+	}
+}

--- a/docs/log/6884.md
+++ b/docs/log/6884.md
@@ -65,3 +65,32 @@
     kernel annotation was read as cross-kernel evidence. Same defect class as
     the one this issue is fixing in the constant's comment, found because
     review chased the citation.
+
+- **Timestamp**: 2026-08-27 (floor decision)
+  - **Action**: raised `UserspaceShimMinVerifierHeadroomPct` 3.0 -> 15.0, and
+    added a build-time check that the floor still satisfies its own stated
+    property. 15% is not the minimum: 12.88% is where the admitted delta equals
+    one structural change exactly, and a threshold on its own boundary is the
+    failure mode this issue documents (a path at exactly the `sun_path` budget
+    failed only on wide random draws). The 2.1 points are margin and are
+    recorded as a JUDGEMENT — 21.58% headroom is measured, the 87,000-insn
+    structural-change cost is chosen, and the latter is the one to revisit.
+  - **The self-check is the part that stops recurrence.** Nothing asserted the
+    floor still fired before the next structural change, and nothing could: it
+    is a property of the RELATIONSHIP between floor and object, which moves
+    whenever the object does — silently, in the direction that looks like good
+    news. A test would have to pin the object size, reintroducing the
+    hand-maintained live number this issue removed. The build already computes
+    slack from live inputs, so it checks the relationship instead and needs no
+    maintained value.
+  - **File(s)**: pkg/dataplane/verify_userspace_shim.go, cmd/shimverify/main.go,
+    cmd/shimverify/slack_banner_6884_test.go, cmd/shimverify/main_test.go,
+    pkg/dataplane/verify_userspace_shim_headroom_test.go,
+    pkg/dataplane/README.md
+  - **Fixtures**: three were re-related to the new floor, caught by their own
+    self-checking preconditions rather than silently miscategorising. One
+    (947,188 labelled "the current object") turned a correct raise into a
+    phantom "rejects the CURRENT object" report — the third instance of the
+    hand-maintained-number defect in this issue. All now synthetic and round,
+    chosen for their relation to the floor; the real measurement is kept only
+    as provenance.

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -503,9 +503,24 @@ Guard layers (`build-userspace-xdp.sh`):
      nothing said. `SlackToFloorInsns` is derived from the enforced constant
      (never a copy of its value) and printed on every build, so a
      recalibration this large is visible when it happens rather than found
-     by archaeology. **Whether 3% is still the right floor at 21.58% is an
-     open question — see #6884 — and the number to judge it on is the
-     slack, not the percentage.**
+     by archaeology. **#6884 raised the floor 3% -> 15% on that basis**, and
+     15% is deliberately not the mathematical minimum: 12.88% is where the
+     admitted delta equals one structural change exactly, and a threshold on
+     its own boundary holds for an 87,000-insn change and fails for an 88,000
+     one. The 2.1 points above it are margin, and they are a JUDGEMENT — the
+     21.58% headroom is measured, the 87,000-insn structural-change cost is
+     chosen, and the second is the one to revisit.
+   - **The build now checks that the floor still satisfies its own property
+     (#6884).** Nothing did before, and nothing could: "does it fire before the
+     next structural change" is a fact about the RELATIONSHIP between the floor
+     and the current object, and that moves whenever the object does. A test
+     cannot own it without pinning the object size — the hand-maintained live
+     number this issue removed. `cmd/shimverify` compares slack against
+     `UserspaceShimStructuralChangeInsns` on every PASSING build and prints a
+     NOTE (not a refusal) when the property has broken. Silent while it holds:
+     at 15% the slack is 65,825 against a cost of 87,000. **General form: a
+     threshold whose sensitivity is defined relative to a moving value needs a
+     check on the relationship, not on the value.**
    - **Processed-insn counts did NOT vary by kernel, measured (#6884).** The
      byte-identical tracked object (md5 `8799db9d…`) verifies at **784,175 on
      both `7.0.13+deb14-amd64` and `7.0.0-rc7+`** — zero difference. This is

--- a/pkg/dataplane/verify_userspace_shim.go
+++ b/pkg/dataplane/verify_userspace_shim.go
@@ -68,7 +68,39 @@ import (
 // banner prints the processed count, the headroom, and — the one to judge this
 // floor's sensitivity on — how many insns of slack the floor still admits.
 // Those are computed, so they cannot rot.
-const UserspaceShimMinVerifierHeadroomPct = 3.0
+// #6884 raised this from 3.0 to 15.0. 3% was chosen against a 5.3% object; by
+// the time the object reached 21.58% the same constant admitted ~186k insns —
+// one to two whole extension-header iterations landing silently — so the
+// tripwire fired only after the thing it exists to prevent had happened twice.
+//
+// 15% is NOT the mathematical minimum. That is 12.88% (the floor at which the
+// admitted delta equals UserspaceShimStructuralChangeInsns exactly), and a
+// threshold placed on its own boundary satisfies the property for an 87,000
+// insn change and fails it for an 88,000 one. The extra 2.1 points are margin,
+// and they are a JUDGEMENT, not a measurement — recorded as such so whoever
+// revisits this knows which inputs were which:
+//
+//   - MEASURED: the object at 784,175/1,000,000, 21.58% headroom.
+//   - JUDGED:   the 87,000-insn structural-change cost the property is defined
+//     against. That is the number to revisit.
+//
+// Erring high is cheap and erring low is not: the gate carries a loud
+// XPF_SHIM_ALLOW_LOW_HEADROOM=1 override that names the object and the reason,
+// so a floor set too high is an announced detour, while one set too low is the
+// silent hole described above.
+const UserspaceShimMinVerifierHeadroomPct = 15.0
+
+// UserspaceShimStructuralChangeInsns is the measured cost of the shim's
+// cheapest known STRUCTURAL change — one additional IPv6 extension-header
+// iteration, which #4555 measured at 87,000-106,000 insns. The conservative
+// end is used deliberately: the floor's stated property is that it fires
+// BEFORE one of these lands, and the cheapest change is the one that tests it.
+//
+// This is the constant the floor is calibrated AGAINST, which is why it is
+// named rather than inlined: cmd/shimverify checks the relationship between
+// them on every build, so a future floor that stops satisfying the property
+// says so out loud instead of drifting quietly the way 3% did.
+const UserspaceShimStructuralChangeInsns = 87000
 
 // verifyShrinkHashMaxEntries is the verify-only ceiling applied to
 // hash-map MaxEntries before the anonymous load. The kernel allocates

--- a/pkg/dataplane/verify_userspace_shim_headroom_test.go
+++ b/pkg/dataplane/verify_userspace_shim_headroom_test.go
@@ -64,19 +64,38 @@ func TestParseShimVerifierStats_Unmeasurable(t *testing.T) {
 	}
 }
 
-// The floor must sit strictly between the pre-#4555 headroom (0.92%) and
-// the current one (5.28%), or it is either dead or an immediate blocker.
+// The floor must be a tripwire and not a blocker: strictly above the object it
+// was introduced to catch, and strictly below the one the build actually ships.
+//
+// #6884: the second fixture used to be 947,188 and was labelled "the current
+// object". That is the hand-maintained live number this issue removed from the
+// floor's doc comment, appearing here as a test constant — and when the floor
+// moved 3% -> 15% it made this cell fail with "rejects the CURRENT object",
+// which was FALSE: the real object is at 784,175/21.58% and passes 15%
+// comfortably. A stale fixture label turned a correct raise into a phantom
+// blocker report.
+//
+// Both fixtures are now SYNTHETIC and round, chosen purely for their relation
+// to the floor, with the real measurement quoted only as provenance. A fixture
+// value's job is to sit above or below a threshold; claiming to be the current
+// object is a different job, done badly, and one that goes stale by
+// construction.
 func TestUserspaceShimHeadroomFloorBracketsKnownValues(t *testing.T) {
-	preFix := ShimVerifierStats{ProcessedInsns: 990796, InsnLimit: 1000000}
-	current := ShimVerifierStats{ProcessedInsns: 947188, InsnLimit: 1000000}
+	// Well below the floor: the tripwire must catch this.
+	tooTight := ShimVerifierStats{ProcessedInsns: 990796, InsnLimit: 1000000} // 0.92%
+	// Well above it: a healthy object must not be blocked. 800,000 is 20.00%,
+	// chosen to bracket the floor without tracking any real object. For scale,
+	// master measured 784,175 (21.58%) on 2026-08-27.
+	healthy := ShimVerifierStats{ProcessedInsns: 800000, InsnLimit: 1000000}
 
-	if preFix.HeadroomPct() >= UserspaceShimMinVerifierHeadroomPct {
-		t.Errorf("floor %.1f%% does not catch the pre-#4555 object (%.2f%% headroom) — the tripwire is dead",
-			UserspaceShimMinVerifierHeadroomPct, preFix.HeadroomPct())
+	if tooTight.HeadroomPct() >= UserspaceShimMinVerifierHeadroomPct {
+		t.Errorf("floor %.1f%% does not catch a %.2f%%-headroom object — the tripwire is dead",
+			UserspaceShimMinVerifierHeadroomPct, tooTight.HeadroomPct())
 	}
-	if current.HeadroomPct() < UserspaceShimMinVerifierHeadroomPct {
-		t.Errorf("floor %.1f%% rejects the CURRENT object (%.2f%% headroom) — `make generate` would be blocked",
-			UserspaceShimMinVerifierHeadroomPct, current.HeadroomPct())
+	if healthy.HeadroomPct() < UserspaceShimMinVerifierHeadroomPct {
+		t.Errorf("floor %.1f%% rejects a %.2f%%-headroom object — it has stopped being a "+
+			"tripwire and become a blocker", UserspaceShimMinVerifierHeadroomPct,
+			healthy.HeadroomPct())
 	}
 }
 


### PR DESCRIPTION
Follow-up to #7716 (merged). Refs #6884.

#7716 landed the measurement, the slack banner and the retraction. It deliberately did **not** raise the floor — that was a build-gate policy change held for a decision. **The decision is 15%**; this lands it, plus the self-check that stops the same drift recurring.

## Which inputs were measured and which were chosen

The thing to know when revisiting this:

| input | kind | value |
|---|---|---|
| object headroom | **MEASURED** | 784,175 / 1,000,000 = 21.58%, on two kernels (`7.0.13+deb14-amd64` and `7.0.0-rc7+`, byte-identical object, md5 verified both sides, **zero** difference) |
| structural-change cost | **JUDGED** | 87,000 insns — the conservative end of #4555's 87k–106k for one IPv6 extension-header iteration. **This is the number to revisit.** |

## Why 15% and not 12.88%

12.88% is where the admitted delta equals one structural change *exactly*. A threshold placed on its own boundary is the failure this issue spent its time documenting: a `TMPDIR` at exactly the 11-character `sun_path` budget failed only on wide random draws, because `t.TempDir()` appends a variable-width suffix. A floor at exactly 12.88% holds for an 87,000-insn change and fails for an 88,000 one.

The 2.1 points above are margin, and they are labelled as **judgement** rather than dressed as measurement.

Erring high is cheap and erring low is not: the gate carries a loud `XPF_SHIM_ALLOW_LOW_HEADROOM=1` override naming the object and the reason, so a floor set too high is an announced detour, while one set too low is the silent 1–2-iteration hole that existed at 3%.

| floor | admitted | delta | verdict |
|---:|---:|---:|---|
| 3% (before) | 970,000 | 185,825 | 1–2 iterations fit silently |
| 12.88% | — | 87,000 | boundary — property holds by exactly zero |
| **15% (this PR)** | 850,000 | **65,825** | fires before even the cheapest |

## The half that stops recurrence

The original defect was that the floor's calibration drifted and **nothing could detect it.** "Does it fire before the next structural change" is a fact about the *relationship* between the floor and the current object — and that relationship moves whenever the object does, silently, in the direction that looks like good news.

A test cannot own it: pinning the current object size reintroduces exactly the hand-maintained live number #7716 removed. **The build can**, because it already computes slack from live inputs.

Every PASSING build now compares slack against `UserspaceShimStructuralChangeInsns` and prints a NOTE when the property has broken. It is a **note, not a refusal** — the object verified and the floor was satisfied; what decayed is the tripwire's usefulness, which is a thing to fix deliberately rather than a reason to fail someone's build. Silent while the property holds: at 15%, slack is 65,825 against a cost of 87,000.

**The general form of the lesson: a threshold whose sensitivity is defined relative to a moving value needs a check on the relationship, not on the value.**

Live banner at the new floor, against the real tracked object:

```
PASS pkg/dataplane/userspace_xdp_bpfel.o (processed 784175 insns (limit 1000000), headroom 21.58%, 65825 insns of slack before the 15.0% floor)
```

## Mutation matrix

Full-package `go test ./cmd/shimverify/ ./pkg/dataplane/ -count=1 -v`, no `-run` filter, one mutation per cell, committed before mutating, tree clean after each restore, no baseline subtraction — control **0 / 624 collected**.

| cell | mutation | reds |
|---|---|---|
| control | — | **0** |
| **P1** | **delete the self-check's call from the PASS path (the WIRING)** | `FloorSelfCheckIsWiredIntoThePassPath6884` |
| P2 | note fires unconditionally (the tuned-out-in-a-week failure) | `FloorSelfCheckSilentWhenThePropertyHolds6884`, `FloorSelfCheckBoundary6884` |
| P3 | boundary `<` → `<=` — fires one structural change too late | `FloorSelfCheckBoundary6884` |
| P4 | floor silently reverted to 3.0 | `TestShimverifyDecision` |

**P3 is why the boundary cell exists**: `<=` would stay silent at the exact moment the property first fails — the off-by-one that makes a tripwire fire one change too late, which is this issue's own defect reproduced inside the detector for it.

**P4 reds a *pre-existing* test**, not a new one: `TestShimverifyDecision`'s fixture preconditions already own the floor's value. Visible only because the matrix ran full-package rather than `-run`-filtered.

## Fixtures the raise invalidated

Three — and **their own self-checking preconditions caught every one**, loudly and by name, rather than silently miscategorising:

```
main_test.go:57: the above-floor fixture (5.28%) is below the floor 15.0%
verify_userspace_shim_headroom_test.go:78: floor 15.0% rejects the CURRENT object (5.28% headroom)
```

That second message is **false**, and instructively so: the real object is at 21.58% and passes 15% comfortably. The fixture was 947,188 labelled *"the current object"* — a hand-maintained live number that turned a correct raise into a phantom blocker report. **Third instance of that defect inside this one issue.**

All three are now synthetic and round (800,000 = 20%, 850,000 = 15% exactly), chosen purely for their relation to the floor, with the real measurement kept only as provenance. A fixture value's job is to sit above or below a threshold; claiming to be the live object is a different job that goes stale by construction.

## Gate

- `go build ./...` → rc 0
- `go test ./... -count=1 -p 4` → **rc 0, 68 packages, 0 failures** at HEAD `3f74b6c25`
- `merge-base --is-ancestor origin/master HEAD` verified against `origin/master` `c6fe87e9b`
- **No `make generate`, no smoke, no cargo leg** — the shim source is untouched and the tracked `.o` is byte-identical; this changes a constant and what the gate reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ez9XCjM9mPjtocRjkousdB
