### PR TITLE
nat: pin the pool/interface SNAT identity collision

### DIFF
--- a/docs/log/7717.md
+++ b/docs/log/7717.md
@@ -1,0 +1,58 @@
+# #7717 — pool and interface SNAT mint one identity on a shared address
+
+## 2026-08-27 — the hazard was argued from prose twice before it was measured
+
+- The rescued diff in `.claude/wt-a6751b` carried an articulate doc comment
+  claiming the hazard was "the previous allocator is DROPPED while live sessions
+  keep forwarding". **That mechanism is wrong**: `InterfaceNatAllocators::reclaim_absent`
+  retains on `live_egress.contains(addr) || alloc.live_flow_count() > 0`, and its
+  own doc names exactly that case as the reason both conditions are required.
+- A distilled plan brief then claimed "verified at current HEAD that the bug
+  shape is intact — port unset, no allocator touched". **Also wrong at
+  `e70b3c4ab`**: the interface branch calls `iface_allocs.allocator_for`, fails
+  closed on `InterfaceRegistryCap`, and PATs later colliders via
+  `allocate_interface_identity`. It had read the plan's base `ad9591177` and
+  reported it as HEAD.
+- Both artifacts were articulate, specific, and confirming. That is why neither
+  was doubted. **A verification performed by the same process that formed the
+  belief is not a verification.**
+
+## 2026-08-27 — the mechanism that survives, sourced from merged code
+
+Pool mode and interface mode are SEPARATE occupancy structures keyed differently
+for one address — `rule.pool_allocator` keyed by `SourceNatPoolAllocatorKey`,
+versus `InterfaceNatAllocators` keyed by `IpAddr`. Neither consults the other.
+
+The config gate that forecloses the overlap states its own scope
+(`pkg/config/compiler_nat_iface_egress.go`):
+
+> "This is CONFIG-time derivation only. Runtime-resolved addresses (DHCP,
+> netlink) are deliberately out of scope here — foreclosing those is the
+> snapshot-builder half of §5.7 and needs the DRAIN discipline behind it."
+
+So a runtime-learned egress address overlapping a pool reaches the colliding
+state, and the merged gate says why that half was not shipped: it needs the
+drain first. That is a stated dependency, not an oversight.
+
+## 2026-08-27 — measured, through the real entry point
+
+```
+POOL  A : rewrite_src=Some(172.16.80.8)  rewrite_src_port=Some(1024)
+POOL  A2: rewrite_src_port=Some(1025)              <- CONTROL, known answer, PASSED
+IFACE B : rewrite_src=Some(172.16.80.8)  rewrite_src_port=None
+COLLISION: pool A wire=(172.16.80.8,1024) == iface B wire=(172.16.80.8,1024)
+```
+
+- **File(s)**: `userspace-dp/src/nat/tests_iface_pool_overlap_7717.rs`
+- This pins a DEFECT, not a guarantee. The name says `defect_pin_`, and the doc
+  says plainly that the assertion INVERTS when #7717 is fixed and that the
+  inversion is the signal the fix landed.
+- **The A2 control ships with it.** It is what makes this a cross-domain finding
+  rather than "the pool allocator is broken": if a future refactor broke the pool
+  allocator, the collision would still reproduce for a reason nobody intended and
+  the pin would be satisfiable by a second, unrelated defect.
+
+## Not done here
+
+The §5.7 drain fix is deliberately NOT attempted. It needs the Go snapshot-builder
+half alongside it, and #7717's acceptance orders the reproduction first.

--- a/userspace-dp/src/nat/mod.rs
+++ b/userspace-dp/src/nat/mod.rs
@@ -47,6 +47,9 @@ mod tests_pool;
 #[path = "tests_iface.rs"]
 mod tests_iface;
 #[cfg(test)]
+#[path = "tests_iface_pool_overlap_7717.rs"]
+mod tests_iface_pool_overlap_7717;
+#[cfg(test)]
 #[path = "tests_counter.rs"]
 mod tests_counter;
 #[cfg(test)]

--- a/userspace-dp/src/nat/tests_iface_pool_overlap_7717.rs
+++ b/userspace-dp/src/nat/tests_iface_pool_overlap_7717.rs
@@ -1,0 +1,132 @@
+// #7717 DEFECT PIN — this file asserts a BUG, not a guarantee.
+//
+// Read the test name before the assertions: `defect_pin_*`. It asserts that a
+// NAT pool and the interface-SNAT registry MINT THE SAME IDENTITY on one
+// address. That is the wrong behaviour. It is pinned because #7717 has already
+// been argued from prose twice — a dead lane's doc comment and a distilled plan
+// brief — and both were wrong in different directions. A demonstrated defect
+// cannot be re-litigated from prose.
+//
+// # WHEN #7717 IS FIXED, THIS TEST INVERTS
+//
+// The collision assertion below will start failing. That failure is the SIGNAL
+// THE FIX LANDED, not a regression. Whoever lands the fix should flip this file
+// to assert non-collision and rename it off `defect_pin_`.
+//
+// # The mechanism
+//
+// Pool mode and interface mode are SEPARATE occupancy structures keyed
+// differently for the same address:
+//
+//   pool mode      -> `rule.pool_allocator`, keyed by `SourceNatPoolAllocatorKey`
+//   interface mode -> `InterfaceNatAllocators`, keyed by `IpAddr`
+//
+// Neither consults the other, so the interface registry reports "uncontended"
+// for a port the pool is actively using and preserves it.
+//
+// The config gate that forecloses this overlap
+// (`pkg/config/compiler_nat_iface_egress.go`) states its own scope:
+//
+//   "This is CONFIG-time derivation only. Runtime-resolved addresses (DHCP,
+//    netlink) are deliberately out of scope here — foreclosing those is the
+//    snapshot-builder half of §5.7 and needs the DRAIN discipline behind it."
+//
+// So a runtime-learned egress address that overlaps a pool reaches this state.
+#![allow(unused_imports)]
+
+use super::allocator::NatHolder;
+use super::source::SourceNatFlowKey;
+use super::*;
+use crate::SourceNATRuleSnapshot;
+use std::net::IpAddr;
+
+const E: &str = "172.16.80.8";
+const SRV: &str = "172.16.80.200";
+const TCP: u8 = 6;
+
+fn admit(reg: &InterfaceNatAllocators, rules: &[SourceNatRule], src: &str, src_port: u16) -> SourceNatLookup {
+    let mut counter = None;
+    match_source_nat_result_for_tuple(
+        reg,
+        rules,
+        &NatScopeCtx::default(),
+        "lan",
+        "wan",
+        src.parse().expect("src"),
+        SRV.parse().expect("dst"),
+        Some(TCP),
+        src_port,
+        80,
+        Some(E.parse().expect("egress")),
+        None,
+        1_000,
+        false,
+        false,
+        NatHolder::Untracked,
+        &mut counter,
+    )
+}
+
+fn wire(l: &SourceNatLookup, sent_port: u16) -> (Option<IpAddr>, u16) {
+    match l {
+        // checksum.rs uses `rewrite_src_port.unwrap_or(key.src_port)`, so an
+        // unset port means the packet keeps its own — that is the wire tuple.
+        SourceNatLookup::Matched(d) => (d.rewrite_src, d.rewrite_src_port.unwrap_or(sent_port)),
+        other => panic!("admission did not match: {other:?}"),
+    }
+}
+
+#[test]
+fn defect_pin_pool_and_interface_snat_mint_one_identity_7717() {
+    let pool_rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "pool-snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "P".to_string(),
+        // The pool's ONLY address is also the interface-SNAT egress address.
+        pool_addresses: vec![E.to_string()],
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    let iface_rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "iface-snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        interface_mode: true,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    let reg = InterfaceNatAllocators::default();
+
+    // Flow A, POOL mode. Stays live for the rest of the test.
+    let (a_ip, a_port) = wire(&admit(&reg, &pool_rules, "10.0.0.1", 5555), 5555);
+
+    // CONTROL — KNOWN ANSWER, and it is load-bearing.
+    //
+    // A second POOL flow must NOT reuse A's identity. This is what makes the
+    // collision below a CROSS-DOMAIN finding rather than "the pool allocator is
+    // broken". Without it, a future refactor that broke the pool allocator
+    // would keep the collision assertion passing for a reason nobody intended,
+    // and the pin would be satisfiable by a second, unrelated defect.
+    let (_, a2_port) = wire(&admit(&reg, &pool_rules, "10.0.0.3", 5555), 5555);
+    assert_ne!(
+        a2_port, a_port,
+        "CONTROL FAILED: two pool-mode flows were handed the same port ({a_port}). \
+         The pool allocator is not correct within its own domain, so the collision \
+         asserted below would not be evidence of a CROSS-DOMAIN defect. Fix this \
+         before reading the assertion that follows."
+    );
+
+    // Flow B, INTERFACE mode, from a DIFFERENT internal host, sourcing exactly
+    // the port the pool handed A.
+    let (b_ip, b_port) = wire(&admit(&reg, &iface_rules, "10.0.0.2", a_port), a_port);
+
+    assert_eq!(
+        (b_ip, b_port),
+        (a_ip, a_port),
+        "#7717 appears FIXED — the interface mint no longer collides with the \
+         live pool identity. That is the desired behaviour and this defect pin \
+         has done its job: flip this file to assert NON-collision and rename it \
+         off `defect_pin_`."
+    );
+}


### PR DESCRIPTION
Closes #7717

Satisfies #7717's **acceptance item 1** — the reproduction. The §5.7 drain **fix is deliberately not attempted here**; the issue orders the reproduction first, and the fix needs the Go snapshot-builder half alongside it.

## This file pins a DEFECT, not a guarantee

The test is named `defect_pin_pool_and_interface_snat_mint_one_identity_7717` and its doc says outright: **when #7717 is fixed this assertion inverts, and that inversion is the signal the fix landed, not a regression.** Whoever lands the fix should flip the file to assert non-collision and rename it off `defect_pin_`.

## Why a pin, and not another prose argument

**#7717 was argued from prose twice, and both arguments were wrong in different directions.**

1. The rescued diff in a dead lane's worktree claimed the hazard was *"the previous allocator is DROPPED while live sessions keep forwarding."* **Wrong** — `InterfaceNatAllocators::reclaim_absent` retains on `live_egress.contains(addr) || alloc.live_flow_count() > 0`, and its own doc names exactly that case as why both conditions are required.
2. A distilled plan brief then claimed *"verified at current HEAD that the bug shape is intact — port unset, no allocator touched."* **Also wrong** at `e70b3c4ab`: the interface branch calls `iface_allocs.allocator_for`, fails closed on `InterfaceRegistryCap`, and PATs later colliders via `allocate_interface_identity`. It had read the plan's base `ad9591177` and reported it as HEAD.

Both artifacts were articulate, specific, and confirming — which is why neither was doubted. A demonstrated defect cannot be re-litigated from prose.

## The mechanism that survives, sourced from merged code

Pool mode and interface mode are **separate occupancy structures keyed differently for one address**: `rule.pool_allocator` keyed by `SourceNatPoolAllocatorKey`, versus `InterfaceNatAllocators` keyed by `IpAddr`. Neither consults the other.

The config gate that forecloses the overlap states its own scope (`pkg/config/compiler_nat_iface_egress.go`):

> "This is CONFIG-time derivation only. **Runtime-resolved addresses (DHCP, netlink) are deliberately out of scope here** — foreclosing those is the snapshot-builder half of §5.7 and **needs the DRAIN discipline behind it**."

So a runtime-learned egress address overlapping a pool reaches the colliding state — and the merged gate says why that half was not shipped. A stated dependency, not an oversight.

## Measured, through the real entry point

`match_source_nat_result_for_tuple`, one pool rule whose only address is the interface-SNAT egress, one interface rule, shared registry:

```
POOL  A : rewrite_src=Some(172.16.80.8)  rewrite_src_port=Some(1024)
POOL  A2: rewrite_src_port=Some(1025)              <- CONTROL, known answer, PASSED
IFACE B : rewrite_src=Some(172.16.80.8)  rewrite_src_port=None
COLLISION: pool A wire=(172.16.80.8,1024) == iface B wire=(172.16.80.8,1024)
```

## The A2 control ships with the test

It is what makes this a **cross-domain** finding rather than "the pool allocator is broken". A second pool-mode flow must not reuse the first's port. Without it, a future refactor that broke the pool allocator would keep the collision assertion passing for a reason nobody intended — the pin would be satisfiable by a second, unrelated defect.

## Mutation matrix — measured

Test committed **first** (`bf4ee6ba0`), one mutation per cell, full crate, `-- --test-threads=1`, no filter, tree restored between cells.

| # | Mutation | Named FAILs | Which assertion | Result |
|---|---|---|---|---|
| M1 | `rewrite_src_port: Some(identity.port)` (always PAT) | 0 | — | ⚠️ **NO-OP — cell void** |
| M1′ | `rewrite_src_port: Some(identity.port.wrapping_add(1))` | 1 | *"#7717 appears FIXED"* | ✅ RED |
| M2 | pool port pinned to a constant (allocator broken) | 1 | *"CONTROL FAILED: two pool-mode flows were handed the same port"* | ✅ RED |

**M1 is reported, not discarded.** Forcing `Some(identity.port)` changed nothing, because when the identity is *not* PAT'd `identity.port` **is** the preserved source port — so the "mutation" produced byte-identical behaviour. A cell whose discriminator does not vary proves nothing, and reporting it as a pass would have been the more comfortable error. M1′ is the same intent with a value that genuinely differs.

M1′ proves the collision assertion is load-bearing and that the pin will invert on the real fix. M2 proves the control is load-bearing.

## Gate — measured

```
go test ./... -count=1              →  RC=0, 68 packages ok, 0 failures
cargo test -- --test-threads=1      →  RC=0, 4794 collected, 0 FAILED
```

- Gated head: `7d39ea5235be2fc4d65750343a35402bf9516177`
- `git merge-base --is-ancestor origin/master HEAD` → **YES** (re-gated after folding master; the pre-fold head was green but 6 behind)
- `TMPDIR` unset (default `/tmp`)

## Measured vs inferred

**Measured:** the collision through the real entry point; the A2 control; both mutation cells including the void one; both full gates; that `reclaim_absent` is guarded and therefore refutes the originally-relayed mechanism.

**Inferred:** that a runtime-learned (DHCP/netlink) egress address is the practical route into this state. The gate's comment says such addresses are out of its scope, and the unit reproduction shows the collision once the overlap exists — but I did not drive a DHCP lease end-to-end to produce the overlap on a live box.
