### PR TITLE
daemon/nft: bind disposition D directly, not via renderer parity

### DIFF
--- a/docs/log/7722.md
+++ b/docs/log/7722.md
@@ -1,0 +1,42 @@
+# #7722 — disposition D of the lo0 term-lowering contract
+
+- **Timestamp**: 2026-08-27
+- **Action**: Measure the premise; bind D directly; determine C's status
+  - **The filed premise is false as stated, and the reason is dominance.**
+    #7722 reports D unguarded because removing
+    `&& !lo0FlexMatchUnrepresentable(term)` at the flex-match RENDER site left
+    `pkg/daemon` green. Measured:
+    - `N1` delete the `lo0FlexMatchUnrepresentable` EARLY RETURN -> **RED**,
+      2146 collected, `TestNftNetlinkParity`.
+    - `N2` the filed mutation, at the render site -> **GREEN**, 2146 collected.
+    The early return dominates the render site — it leaves the function for
+    every unrepresentable term — so at the render site the predicate is always
+    false and deleting it cannot change behaviour. **A green there says nothing
+    about whether D is guarded.** Same category as the lead's own note that
+    their C mutation did not apply.
+  - **The smaller finding underneath is real**: D's only guard was INDIRECT.
+    `TestNftNetlinkParity` catches it because the two renderers disagree, not
+    because anything asserts D's disposition. Parity says "these two differ";
+    it does not say which is right, and it would not survive both renderers
+    drifting the same way.
+  - **D is now bound directly, and discriminated against C.** The cell asserts
+    the rule is EMPTY *and*, separately, that it is not a `drop` — flattening D
+    into C (#5512) would still return a non-empty rule. A control asserts a
+    REPRESENTABLE flex-match still renders, so the two match-nothing assertions
+    cannot pass against a build that never renders a flex-match at all.
+  - **Paired proof, as specified**: with the early return removed the new cell
+    REDs (alongside the parity test, 2147 collected); with it restored the
+    suite is green; and under the same mutation the A, B and C cells all still
+    PASS — so it binds a different disposition rather than widening coverage.
+  - **Disposition C, recorded by the issue as untested**: measured, and bound
+    directly by name. `tcpFlagsFailClosed = true -> false` REDs
+    `TestNftRuleFromTermTCPFlagsUnrepresentableFailsClosed`, 2146 collected.
+  - **All four dispositions are now bound**: A and B by the #7719 cells, C by a
+    pre-existing named test, D by the cell added here.
+  - **The dominated belt is documented in place rather than removed.** It is the
+    guard that would matter if the early return were moved or narrowed, but a
+    mutation deleting it cannot red — and this issue was filed on exactly that
+    green. The comment says so, so the next sweep reads it as dominated rather
+    than as an unguarded fail-open.
+  - **File(s)**: `pkg/daemon/daemon_nft_term_lower.go`,
+    `pkg/daemon/lo0_filter_test.go`, `docs/log/7722.md`

--- a/pkg/daemon/daemon_nft_term_lower.go
+++ b/pkg/daemon/daemon_nft_term_lower.go
@@ -351,6 +351,15 @@ func nftRulesFromTerm(term *config.FirewallFilterTerm, family string, prefixList
 	// nft's raw payload syntax takes BIT offset and BIT length from the base:
 	// `@nh,<off>,<len>`. match-start layer-3 — the only start point the compiler
 	// emits — is the network header base.
+	// The `!lo0FlexMatchUnrepresentable` conjunct is a BELT and is currently
+	// UNREACHABLE: the early return above already left the function for every
+	// unrepresentable term, so by here the predicate is always false. It is kept
+	// because it is the guard that would matter if the early return were ever
+	// moved or narrowed — but a mutation that deletes it CANNOT red, and #7722
+	// was filed on exactly that green. Recorded here so the next mutation sweep
+	// reads it as dominated rather than as an unguarded fail-open. The
+	// disposition itself is bound by
+	// TestNftRuleFromTermFlexMatchUnrepresentableMatchesNothing7722.
 	if fm := term.FlexMatch; fm != nil && !lo0FlexMatchUnrepresentable(term) {
 		parts = append(parts, nftFlexMatchExpr(*fm))
 	}

--- a/pkg/daemon/lo0_filter_test.go
+++ b/pkg/daemon/lo0_filter_test.go
@@ -1419,3 +1419,72 @@ func TestLo0PayloadSharedCounterDeclaredOnce(t *testing.T) {
 		t.Errorf("shared counter declared %d times, want exactly 1 (duplicate is an nft hard error):\n%s", n, payload)
 	}
 }
+
+// TestNftRuleFromTermFlexMatchUnrepresentableMatchesNothing7722 pins
+// DISPOSITION D of the lo0 term-lowering contract
+// (daemon_nft_term_lower.go): an unrepresentable flexible-match-range makes
+// the term match NOTHING — no rule at all — mirroring userspace, which poisons
+// it to FlexMatchStart::Unsupported so flex_matches() returns false and later
+// terms still run.
+//
+// WHY THIS EXISTS when the disposition was already caught. #7722 was filed
+// after a mutation that removed the belt at the flex-match RENDER site escaped
+// green. That mutation is a no-op: the early return dominates it, so at the
+// render site the predicate is already known false. Removing the EARLY RETURN
+// does red — but only `TestNftNetlinkParity`, which catches D incidentally,
+// because the two renderers disagree. Parity says "these two differ"; it does
+// not say WHICH disposition is right, and it would not survive both renderers
+// drifting the same way. This cell asserts the disposition itself.
+//
+// It is deliberately discriminated against DISPOSITION C (#5512 tcp-flags),
+// whose answer to an unrenderable narrowing is a scoped `drop` rather than no
+// rule. The code states why they differ: a tcp-flags constraint only ever
+// matches TCP so its drop can be scoped with `meta l4proto 6`, while a
+// flexible-match-range has no natural narrowing — a bare `drop` would deny ALL
+// host-inbound traffic, turning a fail-open into a lockout. So "empty" is
+// asserted, and "not a drop" is asserted separately: a future change that
+// flattened D into C would still return a non-empty rule and must be caught.
+//
+// Fail-on-revert: remove the `lo0FlexMatchUnrepresentable` early return from
+// nftRulesFromTerm and the first two subtests go RED.
+func TestNftRuleFromTermFlexMatchUnrepresentableMatchesNothing7722(t *testing.T) {
+	prefixLists := map[string]*config.PrefixList{}
+
+	// Route 1: a load width outside 1..4 bytes (40 bits -> 5).
+	wide := config.FlexMatchConfig{MatchStart: "layer-3", ByteOffset: 6, BitLength: 40, Value: 1, Mask: 0xff}
+	got := nftRule(t, &config.FirewallFilterTerm{
+		Name: "flex-too-wide", FlexMatch: &wide, Action: "accept",
+	}, "ip", prefixLists)
+	if got != "" {
+		t.Errorf("unrepresentable flex-match (5-byte load) rendered %q, want \"\" — "+
+			"disposition D is match-NOTHING, and rendering it anyway is the #6804 "+
+			"control-plane fail-open on the primary host-traffic chain", got)
+	}
+	if strings.Contains(got, "drop") {
+		t.Errorf("unrepresentable flex-match rendered a DROP (%q) — that is disposition C "+
+			"(#5512 tcp-flags), which is scoped to TCP. A flex-match has no natural "+
+			"narrowing, so a bare drop denies ALL host-inbound traffic", got)
+	}
+
+	// Route 2: an unparseable numeric token recorded by the compiler.
+	got = nftRule(t, &config.FirewallFilterTerm{
+		Name: "flex-unparseable", UnknownFlexMatch: []string{"byte-offset=not-a-number"},
+		Action: "discard",
+	}, "ip", prefixLists)
+	if got != "" {
+		t.Errorf("UnknownFlexMatch token rendered %q, want \"\" — a token the compiler "+
+			"could not parse must not be silently dropped from the narrowing", got)
+	}
+
+	// CONTROL. A REPRESENTABLE flex-match must still render, or the two
+	// assertions above would pass against a build that never renders a
+	// flex-match at all.
+	ok := config.FlexMatchConfig{MatchStart: "layer-3", ByteOffset: 6, BitLength: 8, Value: 1, Mask: 0xff}
+	got = nftRule(t, &config.FirewallFilterTerm{
+		Name: "flex-ok", FlexMatch: &ok, Action: "accept",
+	}, "ip", prefixLists)
+	if !strings.Contains(got, "@nh,") {
+		t.Errorf("representable flex-match did not render a payload match: %q — without "+
+			"this control the match-nothing assertions above prove nothing", got)
+	}
+}


### PR DESCRIPTION
#7722 reports disposition **D** (an unrepresentable flexible-match-range makes
the term match NOTHING, #6804) as unguarded, on a mutation that removed the belt
at the flex-match **render** site and left `pkg/daemon` green.

**Measured: that mutation is a no-op, and D was guarded — but only indirectly.**
Both halves matter, so both are here.

Closes #7722

## The filed mutation cannot red

| cell | mutation | verdict | collected |
|---|---|---|---|
| N1 | delete the `lo0FlexMatchUnrepresentable` **early return** | **RED** | 2146 — `TestNftNetlinkParity` |
| N2 | the filed mutation, at the **render** site | GREEN | 2146 |

The early return **dominates** the render site: it leaves the function for every
unrepresentable term, so by the render site the predicate is already known
false. Deleting it cannot change behaviour, and a green there says nothing about
whether D is guarded — the same category as the issue's own note that the C
mutation did not apply.

## The finding underneath is real: D's only guard was indirect

`TestNftNetlinkParity` catches D because the two renderers **disagree**, not
because anything asserts D's disposition. Parity says *"these two differ"*; it
does not say which is right, and it would not survive both renderers drifting
the same way.

So D is now bound **directly**, and discriminated against **C**:

- the rule must be **empty**, and
- separately, must **not be a `drop`** — flattening D into C (#5512 tcp-flags)
  would still return a non-empty rule. The code states why they must differ: a
  tcp-flags constraint only ever matches TCP so its drop can be scoped with
  `meta l4proto 6`, while a flexible-match-range has no natural narrowing, so a
  bare drop would deny **all** host-inbound traffic — a fail-open turned into a
  lockout.
- a **control** asserts a representable flex-match still renders, so the two
  match-nothing assertions cannot pass against a build that never renders a
  flex-match at all.

## Paired proof, as specified

| | new cell | A | B | C | parity |
|---|---|---|---|---|---|
| early return **removed** | **RED** | pass | pass | pass | RED |
| early return **restored** | pass | pass | pass | pass | pass |

2147 collected with the cell present. The A/B/C cells are unaffected by the
mutation that reds this one, which is what shows it binds a genuinely different
disposition rather than widening coverage.

## Disposition C — recorded by the issue as untested

Measured, and it is bound **directly by name**: `tcpFlagsFailClosed = true ->
false` REDs `TestNftRuleFromTermTCPFlagsUnrepresentableFailsClosed`, 2146
collected.

**All four dispositions are now bound**: A and B by the #7719 cells, C by a
pre-existing named test, D by the cell added here.

## The dominated belt is documented, not removed

It is the guard that would matter if the early return were ever moved or
narrowed — but a mutation deleting it **cannot** red, and this issue was filed
on exactly that green. The comment now says so, so the next sweep reads it as
dominated rather than as an unguarded fail-open.

## Gates

Gated head **`9b97c1cf3350f402058deb44ea4a54862cf723a9`**.

- `go test ./... -count=1` — **rc 0**, 68 packages ok.
- `cargo test -- --test-threads=1` — **rc 0**, 4795 passed, 0 failed.
- `gofmt` clean on both touched files.

Master moved to `69a0a50c0` during the run (#7724, GRE inner-v6 EH bailout);
ancestry stated rather than asserted — that delta does not touch these files.
