### PR TITLE
dataplane: bind the README's verifier-floor figures to the constants

### DIFF
--- a/docs/log/6886.md
+++ b/docs/log/6886.md
@@ -28,8 +28,18 @@
        calls `ipv6_ext_walk::walk_ipv6_ext_headers` (`lib.rs:1307`), which is
        #4517-consistent. The divergence was confined to this shortcut.
   - **Verifier cost, measured** (the shim's budget is documented as tight):
-    784,175 -> 801,448 insns, headroom 21.58% -> 19.86%, 168,552 insns of slack
-    above the 3.0% floor. PASS.
+    784,175 -> 801,448 insns, headroom 21.58% -> 19.86%. PASS.
+  - **Correction (same day)**: the slack figure first recorded here — "168,552
+    insns above the 3.0% floor" — was stale on arrival. #7720 raised the floor
+    to 15% while this work was in flight and I merged master in without
+    re-reading my own sentence. Against the floor actually in force: the 15%
+    floor admits 850,000, so the slack is **48,552**.
+    The tripwire property still HOLDS at that figure — a structural change
+    (87,000 insns) would take the object to 888,448, past the ceiling, so the
+    floor fires. `noteFloorNoLongerTripwires` does NOT fire here; it returns
+    early when `slack < UserspaceShimStructuralChangeInsns`
+    (`cmd/shimverify/main.go`), which is the healthy direction. It fires on
+    slack being too LARGE.
   - **Self-inflicted, recorded**: the first `make generate` failed with "cargo
     build did not produce libxpf_userspace_xdp.so" because my exported
     `CARGO_TARGET_DIR` leaked into it and redirected the output away from the

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -1198,7 +1198,24 @@ It now gates on `eh_class(protocol) != EH_CLASS_TERMINAL` — the shim's own
 single classifier, the one the walk dispatches on and the emitted class table
 is generated from — so the site cannot drift from the walker again. Verifier
 cost of deferring to it, measured: 784,175 -> **801,448 insns**, headroom
-21.58% -> **19.86%**, still 168,552 insns of slack above the 3.0% floor.
+21.58% -> **19.86%**, comfortably above the floor.
+
+That measurement was reported against the **3.0%** floor, which is what the
+build printed at the time. #7720 raised the floor to **15%** in the same window,
+so the slack figure it carried (168,552 insns) was stale on arrival. Recomputed
+against the floor actually in force: the 15% floor admits 850,000 insns, so the
+slack is **48,552**.
+
+The distinction matters because the floor's stated property is that it fires
+BEFORE a structural change lands (`UserspaceShimStructuralChangeInsns` = 87,000,
+one IPv6 extension-header iteration). At 48,552 slack that property **HOLDS** —
+a structural change would take the object to 888,448, past the 850,000 ceiling,
+and the floor would fire. Correspondingly `noteFloorNoLongerTripwires`
+(`cmd/shimverify/main.go`) does **not** fire here: it returns early when
+`slack < UserspaceShimStructuralChangeInsns`, because that is the healthy
+direction. It fires on the opposite condition — slack so LARGE that a whole
+structural change could land unnoticed, which is how the shim previously reached
+0.92% headroom with every gate green.
 
 Whether such a mis-built key could ever HIT is now a bound property rather than
 an expectation: `shim_non_terminal_protocols_are_never_installable_by_userspace_6886`

--- a/pkg/dataplane/verify_userspace_shim_headroom_test.go
+++ b/pkg/dataplane/verify_userspace_shim_headroom_test.go
@@ -1,6 +1,7 @@
 package dataplane
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -446,5 +447,51 @@ func TestShimCarriesFragHdrSizeAssertion(t *testing.T) {
 			"a field added to FragHdr would make the shim advance 9 bytes past a Fragment "+
 			"header where userspace-dp advances 8, corrupting every fragmented-chain L4 "+
 			"offset (#4555)", root, itemPrefix, expr)
+	}
+}
+
+// TestReadmeFloorFigureMatchesTheConstants pins what pkg/dataplane/README.md
+// says about the verifier floor to the constants it is describing (#6886
+// follow-up).
+//
+// The sentence this guards rotted within hours of being written, and not by
+// anyone editing it: it was measured and reported against the 3.0% floor, and
+// #7720 raised the floor to 15% in the same window. Correct when written,
+// false once merged -- which no review of either change catches, because each
+// was right in isolation.
+//
+// So the README's figures are bound to the constants rather than restated. A
+// future floor change reds HERE, naming the doc that has to move with it,
+// instead of leaving a stale number in the file that explains the shim's
+// budget to the next person sizing a change against it.
+//
+// Only the two CONSTANT-backed figures are asserted. The admitted ceiling the
+// README also quotes is a pure function of the floor and the kernel's 1M
+// verifier limit, which is not a tracked constant -- asserting it here would
+// mean hardcoding 1,000,000 in the guard, i.e. inventing the third number the
+// guard exists to prevent.
+func TestReadmeFloorFigureMatchesTheConstants(t *testing.T) {
+	raw, err := os.ReadFile("README.md")
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	text := string(raw)
+
+	wantFloor := fmt.Sprintf("%.0f%% floor", UserspaceShimMinVerifierHeadroomPct)
+	if !strings.Contains(text, wantFloor) {
+		t.Errorf("pkg/dataplane/README.md does not mention %q. The floor in force is "+
+			"UserspaceShimMinVerifierHeadroomPct = %.1f, and the README is what explains the "+
+			"shim's budget to whoever sizes the next change against it, so it must name the "+
+			"floor actually applied", wantFloor, UserspaceShimMinVerifierHeadroomPct)
+	}
+
+	// The structural-change size is what makes the floor a TRIPWIRE rather than
+	// a bare threshold, and the README states which direction is healthy.
+	wantStructural := fmt.Sprintf("%d,000", UserspaceShimStructuralChangeInsns/1000)
+	if !strings.Contains(text, wantStructural) {
+		t.Errorf("pkg/dataplane/README.md does not mention the structural-change size %q "+
+			"(UserspaceShimStructuralChangeInsns = %d). The floor's stated property is that it "+
+			"fires BEFORE a change that large lands; the README cannot explain the budget "+
+			"without it", wantStructural, UserspaceShimStructuralChangeInsns)
 	}
 }


### PR DESCRIPTION
Follow-up to #6886 / PR #7724. Docs + test only; no dataplane change.

## What was wrong

#7724 recorded the shim's verifier cost as *"168,552 insns of slack above the
**3.0%** floor"*, in `pkg/dataplane/README.md` and `docs/log/6886.md`.

**That was stale on arrival, and not because anyone edited it.** It was measured
and reported against the 3.0% floor; **#7720 raised the floor to 15% in the same
window**, and merging master in did not re-read the sentence. Correct when
written, false once merged — and no review of either change catches it, because
each was right in isolation.

Recomputed against the floor actually in force:

| | |
|---|---|
| floor (`UserspaceShimMinVerifierHeadroomPct`) | **15.0** |
| admitted ceiling | 850,000 |
| object | 801,448 (headroom 19.86%) |
| **slack** | **48,552** |

## The smaller number reads like bad news and is not — so the prose now says which direction is healthy

The floor's stated property is that it fires **before** a structural change
lands (`UserspaceShimStructuralChangeInsns` = 87,000 — one IPv6
extension-header iteration).

At 48,552 slack that property **HOLDS**: a structural change takes the object to
888,448, past the 850,000 ceiling, so the floor fires. That is the tripwire
working.

Correspondingly `noteFloorNoLongerTripwires` (`cmd/shimverify/main.go`) does
**not** fire here — it returns early when
`slack < UserspaceShimStructuralChangeInsns`, because that is the healthy
direction:

```go
func noteFloorNoLongerTripwires(w io.Writer, slack int) {
	if slack < dataplane.UserspaceShimStructuralChangeInsns {
		return
	}
	...
```

It fires on the **opposite** condition — slack so *large* that a whole
structural change could land unnoticed, which is the state that let the shim
reach 0.92% headroom with every gate green.

## The fix binds the figures rather than restating them

Replacing one hand-written number with another invites the same rot, so
`TestReadmeFloorFigureMatchesTheConstants` ties the README's constant-backed
figures to the constants. A future floor change now reds in `pkg/dataplane`,
naming the doc that has to move with it.

**Only the two constant-backed figures are asserted.** The admitted ceiling the
README also quotes is a pure function of the floor and the kernel's 1M verifier
limit, which is *not* a tracked constant — asserting it would mean hardcoding
1,000,000 in the guard, i.e. inventing the third number the guard exists to
prevent.

### Arming

| Mutation | Result |
|---|---|
| `UserspaceShimMinVerifierHeadroomPct` 15.0 → 12.0 | **RED** by name |
| `UserspaceShimStructuralChangeInsns` 87,000 → 95,000 | **RED** by name |

## Validation

Gated head `ae7152185`, up to date with `origin/master` (`69a0a50c0`).

- `go test ./... -count=1`: **rc=0**, 68 packages
- `cargo test --release --bins --tests -- --test-threads=1`: **4796 collected, 0 failed**
