### PR TITLE
daemon/nft: record why the fence surface is not a separate file

### DIFF
--- a/docs/log/7714.md
+++ b/docs/log/7714.md
@@ -58,3 +58,40 @@
     enough to act on, and inventing one is the failure mode.
   - **File(s)**: `pkg/daemon/daemon_nft.go`,
     `pkg/daemon/daemon_nft_term_lower.go`, `docs/log/7714.md`
+
+- **Timestamp**: 2026-08-27
+- **Action**: Seam A re-measured after the god-function landed — DECLINED, with
+  the measurement recorded in place
+  - **Re-measured at master `65bd392e3`** (`daemon_nft.go` now 2236 lines, 55
+    functions): the fence cluster is **9 functions / 333 lines**, unchanged.
+  - **My earlier "9 non-contiguous plucks" was wrong** — I counted functions
+    where I should have counted RUNS. In file order the fence functions sit at
+    positions 1, 3, 6-11 and 15 of 55: **4 contiguous runs**, one of which
+    carries six functions (198 of the 333 lines). The extraction would have
+    been 4 moves, not 9. Correcting it because the earlier number made the work
+    look harder than it is, and the decision below should not rest on a wrong
+    difficulty estimate.
+  - **Declined anyway, for a better reason: the file boundary would not carry
+    the property.** The seam's argument was "fences compute over a DIFFERENT
+    address scope than the real ruleset" (`daemon_nft.go:726`). Measured, that
+    is not what happens:
+    - the scope is **chosen by the callers**. `BuildFenceAddrSets` is invoked
+      at `:197` and `:607`, inside `applyLo0Filter` and `applyHostInboundFilter`
+      — the REAL-ruleset functions — and handed to the fences as a
+      `sets dpuserspace.FenceAddrSets` parameter. The fences RECEIVE the
+      divergent scope; they do not derive it.
+    - the two surfaces **share their address-set helpers**:
+      `hostInboundDesiredDropAddrs` is called from both `applyHostInboundFilter`
+      (`:575`) and `installHostInboundColdBootFence` (`:763`);
+      `hostInboundDropAddrKey` and `hostInboundUncoveredDropAddrs` straddle them
+      too.
+  - So a split would move the RECEIVERS away from the CHOOSERS and away from the
+    helpers they share with the real path — making the relationship less visible,
+    which is the opposite of what the seam was for. **An argument that does not
+    survive the file boundary is not a seam**, whatever its line count.
+  - The measurement is recorded **at the property's existing statement**
+    (`daemon_nft.go`, above the "Scope:" paragraph), not only in this log, so
+    the next sweep reads why the cluster stays rather than re-deriving it —
+    the same reasoning that kept the dominated flex-match belt in #7722.
+  - **`daemon_ha.go` (2254) remains "not yet argued"** and untouched.
+  - **File(s)**: `pkg/daemon/daemon_nft.go`, `docs/log/7714.md`

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -721,6 +721,26 @@ func (d *Daemon) installHostInboundGapFence(uncoveredV4, uncoveredV6 []string, w
 // with a successfully loaded zero-drop table shell; it does not prove table
 // absence.
 //
+// WHY THE FENCE SURFACE IS NOT A SEPARATE FILE (#7714 Seam A, measured and
+// declined). The fence functions look like a cluster — 9 of them, 333 lines,
+// in 4 runs — and their scope difference below reads like a seam. It is not one,
+// because the file boundary would not carry the property:
+//
+//   - the scope is CHOSEN BY THE CALLERS, not by the fences.
+//     `dpuserspace.BuildFenceAddrSets` is invoked inside `applyLo0Filter` and
+//     `applyHostInboundFilter` — the REAL-ruleset functions — and the result is
+//     passed in as `sets dpuserspace.FenceAddrSets`. The divergence is visible
+//     precisely because the choice sits next to the scope it diverges from.
+//   - the two surfaces SHARE their address-set helpers.
+//     `hostInboundDesiredDropAddrs` is called by both `applyHostInboundFilter`
+//     and `installHostInboundColdBootFence`; `hostInboundDropAddrKey` and
+//     `hostInboundUncoveredDropAddrs` likewise straddle them.
+//
+// So moving the fences out would separate the receivers from the choosers and
+// from the helpers they share with the real path — making the relationship this
+// comment exists to explain HARDER to see, not easier. The property is stated
+// here instead, which is where a reader asking the question already is.
+//
 // Scope: the fence is the real table with every service ACCEPT removed, so its
 // drop scope is NOT the real ruleset's scope — dpuserspace.BuildFenceAddrSets
 // (#6492) derives it. Lifeline INTERFACES are excluded by the view builders as


### PR DESCRIPTION
#7714's held half (Seam A — the fence surface in `daemon_nft.go`) re-measured now
that the god-function is gone, and **declined**. Comment-only: the measurement is
recorded where the question gets asked.

## The difficulty estimate I gave was wrong, and I am correcting it first

I described the cluster as **"9 non-contiguous plucks"**. I counted *functions*
where I should have counted *runs*. In file order the fence functions sit at
positions **1, 3, 6–11, 15 of 55** — **four contiguous runs**, one carrying six
functions and 198 of the 333 lines. The extraction would have been **4 moves**,
not 9.

That matters because the decision should not rest on an estimate that made the
work look harder than it is.

## Declined for a better reason: the boundary would not carry the property

The seam's argument was that fences compute over a **different address scope**
than the real ruleset (`daemon_nft.go:726`). Measured, that is not what happens:

- **The scope is chosen by the callers.** `dpuserspace.BuildFenceAddrSets` is
  invoked at `:197` and `:607` — inside `applyLo0Filter` and
  `applyHostInboundFilter`, the **real-ruleset** functions — and handed to the
  fences as a `sets dpuserspace.FenceAddrSets` parameter. The fences *receive*
  the divergent scope; they do not derive it. The divergence is visible
  precisely because the choice sits next to the scope it diverges from.
- **The two surfaces share their address-set helpers.**
  `hostInboundDesiredDropAddrs` is called from both `applyHostInboundFilter`
  (`:575`) and `installHostInboundColdBootFence` (`:763`);
  `hostInboundDropAddrKey` and `hostInboundUncoveredDropAddrs` straddle them too.

So a split would move the **receivers** away from the **choosers** and away from
the helpers they share with the real path — making the relationship the comment
exists to explain *harder* to see. **An argument that does not survive the file
boundary is not a seam**, whatever its line count.

## Why this is a comment and not just a closed issue

Recorded at the property's existing statement so the next sweep reads why the
cluster stays rather than re-deriving it — the same reasoning that kept the
dominated flex-match belt in #7722 instead of deleting a line that could not be
mutation-tested. A cluster that *looks* like a seam and is not will be re-filed
otherwise; this issue is the second time it came up.

`daemon_ha.go` (2254) remains **"not yet argued"** and untouched. Two
god-functions in a 65-function file with no property seam identified is not
enough to act on, and inventing one is the failure mode.

## Gates

Gated head **`e9cd747eb5ba351d5bf2bb48e797b1c1703395a7`**.

- `go test ./... -count=1` — **rc 0**, 68 packages ok.
- `gofmt` clean; `go build ./...` ok.

No Rust gate: the diff is `docs/log/7714.md` and one Go comment block, so a Rust
run would be measuring master rather than this change. Master moved to
`1d6038ab5` during the gate; ancestry stated rather than asserted.
