### PR TITLE
userspace-dp: serialise the GRE checksum-counter tests

### DIFF
--- a/docs/log/6891.md
+++ b/docs/log/6891.md
@@ -1,0 +1,21 @@
+# #6891 — GRE_DECAP_CHECKSUM_INVALID_DROPS cross-test race
+
+- **Timestamp**: 2026-08-27
+  - **Action**: Serialised the two tests that observe the process-global
+    `GRE_DECAP_CHECKSUM_INVALID_DROPS` counter, via a poison-tolerant test lock
+    placed NEXT TO THE COUNTER so a future test that can reach the `fetch_add`
+    inherits the requirement from the doc comment.
+  - **Why not `thread_local!`**: the counter is production state — read by
+    `coordinator/status.rs:432` and exported as
+    `xpf_userspace_gre_decap_checksum_invalid_drops_total`. Making it per-test
+    would have silenced the real counter while turning the suite green, i.e. a
+    fix matched to the symptom's shape that breaks the product.
+  - **Population checked, not assumed**: `try_native_gre_decap_from_frame` has
+    many callers, but only an INVALID checksum reaches the increment, and only
+    `native_gre_decap_checksum_invalid_drops_and_counts` deliberately corrupts
+    one ("corrupt a payload byte after sealing the checksum").
+  - **Paired proof**: `cargo test --bins native_gre_decap_checksum` x30 —
+    **29/30 RED at `021869e5f`**, **0/30 with the fix**. Full crate serialised:
+    4797 passed, 0 failed.
+  - **File(s)**: userspace-dp/src/afxdp/gre.rs,
+    userspace-dp/src/afxdp/tests_gre_local_delivery.rs

--- a/userspace-dp/src/afxdp/gre.rs
+++ b/userspace-dp/src/afxdp/gre.rs
@@ -219,6 +219,41 @@ pub(in crate::afxdp) static GRE_ENCAP_DF_OVERSIZE_DROPS: AtomicU64 = AtomicU64::
 /// corrupted (or a header truncated past the checksum field).
 pub(in crate::afxdp) static GRE_DECAP_CHECKSUM_INVALID_DROPS: AtomicU64 = AtomicU64::new(0);
 
+/// Serialises the tests that OBSERVE `GRE_DECAP_CHECKSUM_INVALID_DROPS`.
+///
+/// #6891: the counter above is PROCESS-GLOBAL production state — it is read by
+/// `coordinator::status` and exported as
+/// `xpf_userspace_gre_decap_checksum_invalid_drops_total`. So it cannot be made
+/// per-test (a `thread_local!` here would silently break the real counter);
+/// the tests must be serialised against each other instead.
+///
+/// Two tests observe it and they race under a parallel `cargo test`:
+/// `native_gre_decap_checksum_invalid_drops_and_counts` BUMPS it (it corrupts a
+/// payload byte after sealing the checksum), while
+/// `native_gre_decap_checksum_present_yields_inner_packet` asserts the counter
+/// is UNCHANGED across a valid-checksum decap. Interleaved, the second reads the
+/// first's increment and fails with `left: 1, right: 0`.
+///
+/// Measured at `021869e5f`: **29 of 30** parallel runs of
+/// `cargo test --bins native_gre_decap_checksum` failed before this lock.
+///
+/// It stayed hidden because `make test-rust` pins `-- --test-threads=1`
+/// (`Makefile`), adopted for the #6657 wedge — so the sanctioned gate is
+/// structurally blind to it, and it only surfaces on a plain parallel
+/// `cargo test`, which is exactly when a lane concludes "master is red".
+///
+/// **Any new test that can reach the `fetch_add` above must take this lock**,
+/// including one that merely corrupts a GRE checksum incidentally.
+///
+/// Poison-tolerant (`into_inner`) so one failing test does not cascade into
+/// every other holder reporting a lock error instead of its own assertion.
+#[cfg(test)]
+pub(in crate::afxdp) fn gre_checksum_counter_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::Mutex;
+    static LOCK: Mutex<()> = Mutex::new(());
+    LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 /// #6842: native-GRE frames REFUSED for decap because the GRE version
 /// field was non-zero while the outer tuple named a configured GRE
 /// tunnel endpoint.

--- a/userspace-dp/src/afxdp/tests_gre_local_delivery.rs
+++ b/userspace-dp/src/afxdp/tests_gre_local_delivery.rs
@@ -880,6 +880,9 @@ fn native_gre_decap_tagged_ingress_yields_self_consistent_frame_meta() {
 /// skip+validate makes this row drop and the assert fires.
 #[test]
 fn native_gre_decap_checksum_present_yields_inner_packet() {
+    // #6891: this test observes the process-global GRE_DECAP_CHECKSUM_INVALID_DROPS
+    // counter; hold the lock so the sibling that bumps it cannot interleave.
+    let _counter_guard = crate::afxdp::gre::gre_checksum_counter_test_lock();
     let forwarding = build_forwarding_state(&gre_to_self_snapshot());
     let inner = build_gre_inner_icmp_packet_v4();
     let frame = build_gre_checksum_present_outer_frame_v4(
@@ -944,6 +947,9 @@ fn native_gre_decap_checksum_key_sequence_present_yields_inner_packet() {
 /// and the decap must return `None`.
 #[test]
 fn native_gre_decap_checksum_invalid_drops_and_counts() {
+    // #6891: this test observes the process-global GRE_DECAP_CHECKSUM_INVALID_DROPS
+    // counter; hold the lock so the sibling that bumps it cannot interleave.
+    let _counter_guard = crate::afxdp::gre::gre_checksum_counter_test_lock();
     let forwarding = build_forwarding_state(&gre_to_self_snapshot());
     let inner = build_gre_inner_icmp_packet_v4();
     let frame = build_gre_checksum_present_outer_frame_v4(


### PR DESCRIPTION
Closes #6891

## Paired proof

`cargo test --bins native_gre_decap_checksum`, 30 runs each:

| tree | RED |
|---|---|
| master `021869e5f` | **29 / 30** |
| with the fix | **0 / 30** |

Full crate serialised: **4797 passed, 0 failed**.

## Why not `thread_local!`

The obvious fix is to make the counter per-test. **It would have turned the
suite green while silencing the production counter.**
`GRE_DECAP_CHECKSUM_INVALID_DROPS` is process-global production state — read by
`coordinator/status.rs:432` and exported as
`xpf_userspace_gre_decap_checksum_invalid_drops_total`. The same static the
tests observe is the one the status surface reads, so privatising it fixes the
symptom and breaks the product.

The tests are serialised against each other instead.

## Scope measured, not assumed

`try_native_gre_decap_from_frame` has many callers (18 in the GRE test file
alone), so "which tests can bump this?" is not answered by the two that name the
counter. But only an **invalid** checksum reaches the `fetch_add`, and only
`native_gre_decap_checksum_invalid_drops_and_counts` deliberately produces one
(*"corrupt a payload byte after sealing the checksum"*).

## The lock is next to the counter, not in the test file

So a future test inherits the requirement from the doc comment rather than from
this PR's memory. It states that any new test able to reach the `fetch_add` must
take it — including one that corrupts a GRE checksum incidentally. Poison-tolerant
(`into_inner`) so one failing holder does not cascade into every other test
reporting a lock error instead of its own assertion. Follows the existing
`global_bucket_test_lock` idiom in `icmp_ratelimit.rs`.

## Why it stayed hidden

`make test-rust` pins `-- --test-threads=1` for the #6657 wedge, so **the
sanctioned gate is structurally blind to this**. It surfaces only on a plain
parallel `cargo test` — exactly when a lane concludes "master is red" and loses
time attributing it. Two lanes hit unexplained parallel-run failures this
session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7PfivEWEESWuDihm6TgdT