### PR TITLE
nat: correct #7717's done-signal — the pin will not invert

### DIFF
--- a/docs/log/7717.md
+++ b/docs/log/7717.md
@@ -1,58 +1,73 @@
-# #7717 — pool and interface SNAT mint one identity on a shared address
+# #7717 — recording what the fix's done-signal actually is
 
-## 2026-08-27 — the hazard was argued from prose twice before it was measured
+- **Timestamp**: 2026-08-27
+  - **Action**: recorded three measured findings about #7717's fix BEFORE
+    building it, because two of them are actively misleading while unwritten.
+    No behaviour change; this PR corrects a done-signal and bounds a design
+    space.
 
-- The rescued diff in `.claude/wt-a6751b` carried an articulate doc comment
-  claiming the hazard was "the previous allocator is DROPPED while live sessions
-  keep forwarding". **That mechanism is wrong**: `InterfaceNatAllocators::reclaim_absent`
-  retains on `live_egress.contains(addr) || alloc.live_flow_count() > 0`, and its
-  own doc names exactly that case as the reason both conditions are required.
-- A distilled plan brief then claimed "verified at current HEAD that the bug
-  shape is intact — port unset, no allocator touched". **Also wrong at
-  `e70b3c4ab`**: the interface branch calls `iface_allocs.allocator_for`, fails
-  closed on `InterfaceRegistryCap`, and PATs later colliders via
-  `allocate_interface_identity`. It had read the plan's base `ad9591177` and
-  reported it as HEAD.
-- Both artifacts were articulate, specific, and confirming. That is why neither
-  was doubted. **A verification performed by the same process that formed the
-  belief is not a verification.**
+  - **Finding 1 — the rescued PR-3b drain is INERT alone.** Measured, not
+    inferred: `origin/rescue/6751-pr3b-drain-unvalidated` (331 lines) applies
+    cleanly to current master, and with it applied whole the #7721
+    reproduction **still passes** — the collision still occurs. Its drain
+    engages only when `rule.pool_failure.is_some()`, and nothing in the
+    shipped tree sets that, because the Go snapshot-builder half is not
+    written. Adopting it as "the fix" would ship 331 lines of dataplane
+    change that alter nothing observable.
 
-## 2026-08-27 — the mechanism that survives, sourced from merged code
+  - **Finding 2 — the pin will NOT invert when #7717 is fixed**, contrary to
+    what #7721 wrote into the file in an authoritative voice ("that failure is
+    the SIGNAL THE FIX LANDED"). §5.7 forecloses at the snapshot builder by
+    quarantining the pool; that makes the colliding state unreachable FROM
+    CONFIG but cannot stop a unit test constructing it directly, and the pin
+    builds its rules via `parse_source_nat_rules` with a HEALTHY pool. So a
+    correct §5.7 lands and the pin keeps passing. A wrong done-signal is more
+    expensive than no done-signal: a lane would conclude the fix failed, or
+    chase the pin until it built something that inverts it and is not the
+    design.
+    The correct acceptance control drives the **snapshot builder** — configure
+    an interface-mode rule whose runtime-resolved egress overlaps a pool,
+    assert the builder quarantines the pool AND that live sessions drain
+    rather than strand.
 
-Pool mode and interface mode are SEPARATE occupancy structures keyed differently
-for one address — `rule.pool_allocator` keyed by `SourceNatPoolAllocatorKey`,
-versus `InterfaceNatAllocators` keyed by `IpAddr`. Neither consults the other.
+  - **Finding 3 — neither half is a fix alone**, so the work is a sequenced
+    pair. The Rust drain is inert without the Go quarantine (finding 1); the
+    Go quarantine cannot ship ENFORCING without the drain, because the merged
+    config gate says so itself — "marking a pool unusable with nothing
+    draining would strand live sessions"
+    (`pkg/config/compiler_nat_iface_egress.go`). It can ship DETECTING and
+    testable, which is why the Go half is sequenced first.
 
-The config gate that forecloses the overlap states its own scope
-(`pkg/config/compiler_nat_iface_egress.go`):
+  - **Design space, verified by symbol** (recorded so the next lane does not
+    re-derive it):
+    1. The two substrates are not unifiable without an apply-path refactor.
+       `resolve_pool_allocators` takes only snapshot inputs and cannot see the
+       node-lifetime registry; pool allocators are owned by value per
+       `SourceNatPoolAllocatorKey`, interface allocators are
+       `Arc<PortAllocator>` per `IpAddr` (`iface_registry.rs:115-116`).
+    2. Option (a)'s interface-side core already shipped — `allocator_for`,
+       fail-closed `InterfaceRegistryCap`, PAT via
+       `allocate_interface_identity` (`source.rs:2539-2588`). The gap is
+       purely cross-domain.
+    3. PATH A is out of scope. The plan's sourced sentence — the registry,
+       occupancy split, holders and drain "never read the mirror for their own
+       correctness" — says PATH A is ORTHOGONAL to the option-(a) core, not
+       that PRs may be split arbitrarily. Read narrowly, it is why the drain
+       does not need the sole-writer substrate.
 
-> "This is CONFIG-time derivation only. Runtime-resolved addresses (DHCP,
-> netlink) are deliberately out of scope here — foreclosing those is the
-> snapshot-builder half of §5.7 and needs the DRAIN discipline behind it."
+  - **§5.7 is deliberately NOT attempted whole.** Most of it addresses
+    collision classes that are not demonstrated — static-vs-interface, NAT64,
+    persistent/deterministic/sticky postures — argued from a plan whose two
+    prior distillations were both wrong about HEAD. #7721 established that a
+    demonstrated defect cannot be re-litigated from prose; the converse binds
+    equally, and a fix for an undemonstrated defect in NAT identity sourced
+    from a dead lane's reasoning is what that standard forbids.
 
-So a runtime-learned egress address overlapping a pool reaches the colliding
-state, and the merged gate says why that half was not shipped: it needs the
-drain first. That is a stated dependency, not an oversight.
+  - **Process note**: I ran the arming cell for the new assertion BEFORE
+    committing, and `git checkout --` took the uncommitted correction with it.
+    Caught by verifying the restore rather than trusting it. Re-applied and
+    committed first, then re-armed — the rule is commit-before-mutate and I
+    had just broken it.
 
-## 2026-08-27 — measured, through the real entry point
-
-```
-POOL  A : rewrite_src=Some(172.16.80.8)  rewrite_src_port=Some(1024)
-POOL  A2: rewrite_src_port=Some(1025)              <- CONTROL, known answer, PASSED
-IFACE B : rewrite_src=Some(172.16.80.8)  rewrite_src_port=None
-COLLISION: pool A wire=(172.16.80.8,1024) == iface B wire=(172.16.80.8,1024)
-```
-
-- **File(s)**: `userspace-dp/src/nat/tests_iface_pool_overlap_7717.rs`
-- This pins a DEFECT, not a guarantee. The name says `defect_pin_`, and the doc
-  says plainly that the assertion INVERTS when #7717 is fixed and that the
-  inversion is the signal the fix landed.
-- **The A2 control ships with it.** It is what makes this a cross-domain finding
-  rather than "the pool allocator is broken": if a future refactor broke the pool
-  allocator, the collision would still reproduce for a reason nobody intended and
-  the pin would be satisfiable by a second, unrelated defect.
-
-## Not done here
-
-The §5.7 drain fix is deliberately NOT attempted. It needs the Go snapshot-builder
-half alongside it, and #7717's acceptance orders the reproduction first.
+  - **File(s)**: userspace-dp/src/nat/tests_iface_pool_overlap_7717.rs,
+    docs/log/7717.md

--- a/userspace-dp/src/nat/tests_iface_pool_overlap_7717.rs
+++ b/userspace-dp/src/nat/tests_iface_pool_overlap_7717.rs
@@ -7,11 +7,57 @@
 // brief — and both were wrong in different directions. A demonstrated defect
 // cannot be re-litigated from prose.
 //
-// # WHEN #7717 IS FIXED, THIS TEST INVERTS
+// # CORRECTION: THIS TEST WILL *NOT* INVERT WHEN #7717 IS FIXED
 //
-// The collision assertion below will start failing. That failure is the SIGNAL
-// THE FIX LANDED, not a regression. Whoever lands the fix should flip this file
-// to assert non-collision and rename it off `defect_pin_`.
+// This block previously read "when #7717 is fixed, this test inverts... that
+// failure is the SIGNAL THE FIX LANDED". **That is wrong for the mechanism
+// §5.7 actually specifies, and a wrong done-signal is more expensive than no
+// done-signal.**
+//
+// §5.7 forecloses the overlap at the SNAPSHOT BUILDER: an interface-mode
+// egress address overlapping a pool marks that POOL unusable
+// (`pool_failure`/`PoolUnusable`), and the dataplane drains the quarantined
+// allocator. That prevents the colliding state from being reachable FROM
+// CONFIG. It does not — and cannot — stop this file constructing it directly:
+// the fixture below builds its rules with `parse_source_nat_rules` and a
+// HEALTHY pool, never passing through the builder that would quarantine it.
+// The assertion at the bottom of this file therefore keeps holding after a
+// correct §5.7 lands.
+//
+// MEASURED, not predicted. The rescued PR-3b drain
+// (`origin/rescue/6751-pr3b-drain-unvalidated`, 331 lines) applies cleanly to
+// current master; applied whole, **this test still passes** — the collision
+// still occurs. Its drain engages only when `rule.pool_failure.is_some()`, and
+// nothing in the shipped tree sets that, because the Go snapshot-builder half
+// is not written. So the Rust half is INERT ALONE, and adopting it as "the
+// fix" would ship 331 lines of dataplane change that alter nothing observable.
+//
+// # The done-signal that IS correct
+//
+// The pair's acceptance control must drive the **snapshot builder**, not this
+// unit-level pin: configure an interface-mode rule whose runtime-resolved
+// egress address overlaps a pool, and assert the builder quarantines the pool
+// AND that live sessions on it drain rather than strand. This file keeps its
+// job — it pins that the two occupancy domains are independent *at the
+// admission layer*, which stays true and stays worth guarding.
+//
+// # What bounds the design space (verified by symbol, for whoever builds it)
+//
+//   1. The substrates are NOT unifiable without an apply-path refactor.
+//      `resolve_pool_allocators` (source.rs) takes only snapshot inputs and has
+//      no access to the node-lifetime registry; pool allocators are owned BY
+//      VALUE per `SourceNatPoolAllocatorKey`, interface allocators are
+//      `Arc<PortAllocator>` per `IpAddr` (iface_registry.rs:115-116). Different
+//      owner, different granularity, different lifetime.
+//   2. Option (a)'s interface-side core ALREADY SHIPPED — the interface branch
+//      calls `allocator_for`, fails closed on `InterfaceRegistryCap`, and PATs
+//      later colliders via `allocate_interface_identity` (source.rs:2539-2588).
+//      The remaining gap is purely CROSS-DOMAIN.
+//   3. Neither half is a fix alone. The Rust drain is inert without the Go
+//      quarantine (measured, above); the Go quarantine cannot ship enforcing
+//      without the drain, because the merged config gate says so in its own
+//      words — "marking a pool unusable with nothing draining would strand
+//      live sessions" (pkg/config/compiler_nat_iface_egress.go).
 //
 // # The mechanism
 //
@@ -96,6 +142,19 @@ fn defect_pin_pool_and_interface_snat_mint_one_identity_7717() {
         interface_mode: true,
         ..SourceNATRuleSnapshot::default()
     }]);
+    // The pool is HEALTHY, and that is load-bearing for the correction in this
+    // file's header: §5.7 forecloses by QUARANTINING a pool
+    // (`pool_failure`/`PoolUnusable`), so a fixture whose pool is quarantined
+    // would be testing the post-fix state rather than the defect. Asserting it
+    // here makes the property explicit instead of incidental — and it reds if
+    // someone "fixes" this pin by quarantining the fixture, which is exactly
+    // the shape of chasing a done-signal that was never going to arrive.
+    assert!(
+        pool_rules[0].pool_failure.is_none(),
+        "#7717: the fixture's pool must be HEALTHY. A quarantined pool does not \
+         demonstrate the cross-domain collision — it demonstrates the foreclosure \
+         that §5.7 adds, which this unit-level pin cannot reach"
+    );
     let reg = InterfaceNatAllocators::default();
 
     // Flow A, POOL mode. Stays live for the rest of the test.


### PR DESCRIPTION
Follow-on to #7717 / PR #7721. **No behaviour change** — this PR corrects a
done-signal and bounds a design space, before either half of the fix is built.

## Why this ships before the fix

#7721 wrote into `tests_iface_pool_overlap_7717.rs`, in an authoritative voice:

> **WHEN #7717 IS FIXED, THIS TEST INVERTS** — "that failure is the SIGNAL THE
> FIX LANDED, not a regression."

**That is wrong for the mechanism §5.7 actually specifies**, and it is the most
expensive kind of wrong: a lane implementing §5.7 correctly will see the pin
still passing and conclude the fix failed — or chase the pin until it builds
something that inverts it and is not the design. A wrong done-signal is more
expensive than no done-signal.

§5.7 forecloses at the **snapshot builder**, quarantining a pool whose address
an interface-mode egress overlaps. That makes the colliding state unreachable
*from config*. It cannot stop this file constructing it directly — the fixture
builds its rules via `parse_source_nat_rules` with a **healthy** pool and never
passes through the builder that would quarantine it. So a correct §5.7 lands
and this test keeps passing.

## Measured, not predicted — and it also disposes of the rescued implementation

`origin/rescue/6751-pr3b-drain-unvalidated` (331 lines) applies cleanly to
current master. Applied **whole**:

```
defect_pin_pool_and_interface_snat_mint_one_identity_7717 ... ok
```

**The pin still passes. The collision still occurs.** The drain engages only
when `rule.pool_failure.is_some()`, and nothing in the shipped tree sets that,
because the Go snapshot-builder half is not written. **The Rust half is inert
alone** — adopting it as "the fix" would ship 331 lines of dataplane change
that alter nothing observable.

That is the **third** prose artifact around #7717 to be wrong in a confirming
direction — the rescued branch's own doc comment, a distilled brief's HEAD
claim, and now the inversion promise. All three articulate, all three
confirming, none measured until someone applied them and looked.

## The done-signal that IS correct

The pair's acceptance control must drive the **snapshot builder**, not this
unit-level pin: configure an interface-mode rule whose runtime-resolved egress
address overlaps a pool, and assert the builder quarantines the pool **and**
that live sessions on it drain rather than strand.

The pin keeps its job — it pins that the two occupancy domains are independent
*at the admission layer*, which stays true and stays worth guarding.

## The fixture's healthy pool is now asserted, not incidental

It is what makes the correction true: a fixture whose pool is quarantined would
be testing the post-fix state rather than the defect. The assertion reds on
exactly the "chase the done-signal" edit.

| Mutation | Collected | Named RED |
|---|---|---|
| `pool_rules[0].pool_failure = Some(OverBudget)` | 4726 | 1 — the pin, by name |

## Design space, verified by symbol

Recorded so the next lane does not re-derive it:

1. **The two substrates are not unifiable without an apply-path refactor.**
   `resolve_pool_allocators` takes only snapshot inputs and cannot see the
   node-lifetime registry; pool allocators are owned **by value** per
   `SourceNatPoolAllocatorKey`, interface allocators are `Arc<PortAllocator>`
   per `IpAddr` (`iface_registry.rs:115-116`). Different owner, granularity,
   lifetime.
2. **Option (a)'s interface-side core already shipped** — `allocator_for`,
   fail-closed `InterfaceRegistryCap`, PAT via `allocate_interface_identity`
   (`source.rs:2539-2588`). The remaining gap is purely cross-domain.
3. **Neither half is a fix alone**, so the work is a sequenced pair. The Rust
   drain is inert without the Go quarantine (measured above); the Go quarantine
   cannot ship *enforcing* without the drain, because the merged config gate
   says so itself — *"marking a pool unusable with nothing draining would
   strand live sessions"* (`pkg/config/compiler_nat_iface_egress.go`). It can
   ship *detecting* and testable, which is why the Go half is sequenced first.
4. **PATH A is out of scope.** The plan's sourced sentence — the registry,
   occupancy split, holders and drain *"never read the mirror for their own
   correctness"* — says PATH A is **orthogonal** to the option-(a) core, not
   that PRs may be split arbitrarily. Read narrowly, it is why the drain does
   not need the sole-writer substrate.

## §5.7 is deliberately not attempted whole

Most of it addresses collision classes that are **not demonstrated** —
static-vs-interface, NAT64, persistent/deterministic/sticky postures — argued
from a plan whose two prior distillations were both wrong about HEAD. #7721
established that a demonstrated defect cannot be re-litigated from prose; the
converse binds equally, and a fix for an *undemonstrated* defect in NAT
identity sourced from a dead lane's reasoning is exactly what that standard
forbids.

## Validation

Gated head `e216757e5` (`origin/master` merged in, not rebased; clean).

- `cargo test --release --bins --tests -- --test-threads=1`: **4796 collected, 0 failed**
- `go test ./... -count=1`: **rc=0**, 68 packages
