### PR TITLE
dataplane: refuse a Teardown-superseded registry generation (#6741 AC1)

### DIFF
--- a/docs/log/6741.md
+++ b/docs/log/6741.md
@@ -1,0 +1,52 @@
+# #6741 AC1 — refuse a Teardown-superseded registry generation
+
+- **Timestamp**: 2026-08-27
+- **Action**: Implement AC1's guard half, scoped to the Teardown boundary
+  - **Re-measured the scoping first** (it was written from a ~100-commit-stale
+    tree). Both cited facts hold at master: AC1's metric branch landed (#7548),
+    and `loader.go:43` still states the AC2 limit — the loaded bit "cannot drain
+    an operation that already observed true".
+  - **The third fact is what decided the shape.** AC1's acceptance offers
+    "mutation fails loudly OR is a verified no-op with a metric", and with the
+    counter landed the second branch looked nearly done. It is unavailable:
+    `Close()` closes ONLY the XDP/TC link handles, `Cleanup()` unpins without
+    closing, and no path closes `m.maps` / `m.programs`. An unpinned map with a
+    live FD stays alive and WRITABLE, so the retained-handle mutation succeeds
+    against an orphan. **The counter can say it happened; it cannot make it not
+    happen.** Checked by reading every `.Close()` in `loader.go`, not the two
+    obvious ones — the others are replacement-path closes.
+  - **The guard**: `lookupMapLocked` / `lookupProgramLocked` now return
+    `present=false` when `registryObsoleteLocked()` holds, so the caller takes
+    its not-present path instead of mutating an orphan.
+  - **Why this is safe to land despite revoking a rule documented as deliberate
+    in two places**: `registryObsoleteFrom` is set by `Teardown` and explicitly
+    NOT by `Close`. The #2114 A3 proceed-on-retained rule was argued for
+    hitless restart, which is Close's case — untouched **by construction**, not
+    by care. What is declined is only the Teardown window, where Cleanup has
+    already unpinned and the handles are orphans.
+  - **Two cells, and the second is the scope proof**:
+    - `TestObsoleteRegistryAccessCounted_6741` INVERTED — it used to require the
+      retained registry still SERVE the handle ("this change must not alter
+      it"); it now requires refusal. The old contract's test moved with the
+      behaviour rather than being deleted.
+    - `TestCloseRetainedRegistryStillProceeds_6741` NEW — a Close-then-reuse
+      sequence still serves, with a fixture guard asserting Close did not set
+      `registryObsoleteFrom` (or the cell would be testing the refusal path by
+      accident). Without it the change is indistinguishable from one that
+      revoked proceed-on-retained everywhere.
+  - **Two claim comments corrected, because they became false on landing** —
+    the exact class this campaign keeps fixing. `loader.go` called the counter
+    "an observability counter, not a guard"; `armed_gate.go` said "it changes no
+    behaviour. Every caller proceeds exactly as before". Both now describe a
+    refusal.
+  - **Stated honestly, not overclaimed**: the guard is LOOKUP-TIME. A handle
+    obtained BEFORE the Teardown and held across it is never re-checked, so it
+    is neither refused nor counted. AC1 is met for handles obtained after the
+    boundary, not for escaped ones — and a mutation-time check needs the
+    generation read at the syscall, which #6740 forbids (no m.mu across a BPF
+    syscall). That tension is precisely why AC2 is a design item.
+  - **Only one test broke** under the change — the one pinning the old
+    contract. 135 call sites, and no caller mishandled `absent`.
+  - **AC2 remains open**: #6741 should be re-scoped to it rather than closed.
+  - **File(s)**: `pkg/dataplane/armed_gate.go`, `pkg/dataplane/loader.go`,
+    `pkg/dataplane/registry_generation_6741_test.go`, `docs/log/6741.md`

--- a/pkg/dataplane/armed_gate.go
+++ b/pkg/dataplane/armed_gate.go
@@ -115,8 +115,10 @@ func (m *Manager) lookupMapLocked(name string) (h *ebpf.Map, present bool, st re
 		registryLookupHook()
 	}
 	h, present = m.maps[name]
-	if present {
+	if present && m.registryObsoleteLocked() {
+		// #6741 AC1: REFUSE rather than serve. See registryObsoleteLocked.
 		m.obsoleteRegistryLocked("map", name)
+		return nil, false, classifyRegistry(&m.loaded, len(m.maps))
 	}
 	return h, present, classifyRegistry(&m.loaded, len(m.maps))
 }
@@ -133,25 +135,52 @@ func (m *Manager) lookupMapLocked(name string) (h *ebpf.Map, present bool, st re
 // (bootstrap.go's enterBootstrapMode, and the standalone first-commit timeout in
 // daemon_apply_commit.go).
 //
-// WHAT THIS IS NOT — and the distinction is the whole reason it is a counter and
-// not a guard. It does NOT close the hazard, and it must not be read as
-// evidence that the hazard cannot happen:
+// WHAT CHANGED (#6741 AC1). This used to count SERVED handles and change no
+// behaviour. The lookup now REFUSES: it returns present=false so the caller
+// takes its not-present path instead of mutating an orphan. The counter is the
+// observability half of that guard, and counts refusals.
 //
-//   - it is a LOOKUP-TIME observation. lookupMapLocked returns the *ebpf.Map by
-//     reference and then RELEASES m.mu, so a republish that lands after the
-//     lookup returns is invisible here. A caller holding an escaped handle
-//     across a republish is counted zero times.
-//   - it changes no behaviour. Every caller proceeds exactly as before,
-//     deliberately: making retained mutations fail is a behaviour change at 135
-//     call sites and is the deferred half of #6741.
+// The acceptance criterion offered "fails loudly OR is a verified no-op with a
+// metric". The no-op branch was foreclosed by measurement: Close closes only
+// the XDP/TC link handles and Cleanup unpins WITHOUT closing, so m.maps /
+// m.programs FDs are never closed — the orphaned map stays alive and WRITABLE,
+// and the mutation succeeds against a generation nothing forwards through.
 //
-// A zero counter therefore means "no lookup OBSERVED a superseded generation",
-// never "no obsolete mutation occurred". The design tension that makes the
-// stronger guarantee expensive — #6740 forbids holding m.mu across a BPF
-// syscall, which is what a mutation-time check would require — is recorded on
-// #6741.
+// WHAT IT STILL DOES NOT COVER, and this must not be read as the hazard being
+// closed:
+//
+//   - it remains a LOOKUP-TIME check. lookupMapLocked returns the *ebpf.Map by
+//     reference and then RELEASES m.mu, so a handle obtained BEFORE the
+//     Teardown and held across it is never re-checked and is neither refused
+//     nor counted. AC1 is met for handles obtained after the boundary, not for
+//     escaped ones.
+//   - a mutation-time check, which would cover those, needs the generation read
+//     at the syscall — and #6740 forbids holding m.mu across a BPF syscall.
+//     That tension is why AC2 (a lease/refcount with drain discipline) is a
+//     design item rather than an extension of this.
+//
+// A zero counter means "no lookup was refused", never "no obsolete mutation
+// occurred".
+// registryObsoleteLocked reports whether the registry is currently serving a
+// generation that Teardown has superseded (#6741 AC1). The caller must hold
+// m.mu.
+//
+// SCOPE — this is the whole safety argument for refusing. `registryObsoleteFrom`
+// is set by `Teardown` and explicitly NOT by `Close`: Close keeps its pinned
+// handles live for hitless restart, and the #2114 A3 proceed-on-retained rule
+// is argued for exactly that case. So a Close-then-reuse sequence never sees
+// this predicate true and proceeds precisely as before. What is refused is only
+// the Teardown window, where `Cleanup` has already unpinned the objects and the
+// retained handles are ORPHANS of a generation nothing forwards through.
+//
+// The rule is not weakened; a generation Teardown already superseded is
+// declined.
+func (m *Manager) registryObsoleteLocked() bool {
+	return m.registryObsoleteFrom != 0 && m.registryGeneration <= m.registryObsoleteFrom
+}
+
 func (m *Manager) obsoleteRegistryLocked(kind, name string) {
-	if m.registryObsoleteFrom == 0 || m.registryGeneration > m.registryObsoleteFrom {
+	if !m.registryObsoleteLocked() {
 		return
 	}
 	m.obsoleteRegistryAccesses++
@@ -190,8 +219,10 @@ func (m *Manager) lookupProgramLocked(name string) (p *ebpf.Program, present boo
 		registryLookupHook()
 	}
 	p, present = m.programs[name]
-	if present {
+	if present && m.registryObsoleteLocked() {
+		// #6741 AC1: REFUSE rather than serve. See registryObsoleteLocked.
 		m.obsoleteRegistryLocked("program", name)
+		return nil, false, classifyRegistry(&m.loaded, len(m.maps))
 	}
 	return p, present, classifyRegistry(&m.loaded, len(m.maps))
 }

--- a/pkg/dataplane/loader.go
+++ b/pkg/dataplane/loader.go
@@ -66,8 +66,12 @@ type Manager struct {
 	// forwarding generation — Close does NOT set this, because Close
 	// deliberately keeps its pinned handles live for hitless-restart reuse.
 	//
-	// obsoleteRegistryAccesses counts lookups that SERVED such a handle. It is
-	// an observability counter, not a guard: see obsoleteRegistryLocked.
+	// obsoleteRegistryAccesses counts lookups REFUSED for that reason (#6741
+	// AC1). It used to count lookups that SERVED such a handle and was
+	// explicitly "not a guard"; the lookup now declines, so this is the
+	// observability half of a real guard. See obsoleteRegistryLocked for what
+	// it still does not cover — a handle obtained BEFORE the Teardown and held
+	// across it is never re-checked.
 	registryGeneration       uint64
 	registryObsoleteFrom     uint64
 	obsoleteRegistryAccesses uint64

--- a/pkg/dataplane/registry_generation_6741_test.go
+++ b/pkg/dataplane/registry_generation_6741_test.go
@@ -81,9 +81,23 @@ func TestObsoleteRegistryAccessCounted_6741(t *testing.T) {
 //
 // Without this cell the change is indistinguishable from one that revoked
 // proceed-on-retained everywhere, and the guard's scope would live only in
-// prose. Fail-on-revert: make Close set registryObsoleteFrom (or drop the
-// `registryObsoleteFrom != 0` conjunct from registryObsoleteLocked) and this
-// goes RED while the cell above stays green.
+// prose.
+//
+// FAIL-ON-REVERT, measured rather than asserted: make `Close` set
+// `registryObsoleteFrom` and this goes RED while
+// TestObsoleteRegistryAccessCounted_6741 stays green.
+//
+// What it does NOT bind, stated because an unverified fail-on-revert claim is
+// worse than none: dropping the `registryObsoleteFrom != 0` conjunct from
+// registryObsoleteLocked leaves this cell GREEN. Its fixture has
+// generation=1 and obsoleteFrom=0, so `1 <= 0` is false either way. (That
+// conjunct is not unguarded — removing it hangs the package suite, because
+// every lookup then refuses — but this cell is not what catches it.)
+//
+// And it is not the only guard for the Close boundary:
+// TestCloseDoesNotStartAnObsoleteEpoch_6741 pre-existed and reds on the same
+// mutation. That one pins the COUNTER not starting; this one pins the handle
+// still being SERVED, which is the half AC1 could have broken.
 func TestCloseRetainedRegistryStillProceeds_6741(t *testing.T) {
 	m := regTestManager6741()
 

--- a/pkg/dataplane/registry_generation_6741_test.go
+++ b/pkg/dataplane/registry_generation_6741_test.go
@@ -49,13 +49,73 @@ func TestObsoleteRegistryAccessCounted_6741(t *testing.T) {
 	m.registryObsoleteFrom = m.registryGeneration
 	m.mu.Unlock()
 
-	if _, present, _ := m.lookupMapLocked("sessions"); !present {
-		t.Fatalf("the retained registry must still SERVE the handle — proceed-on-retained is " +
-			"the deliberate #2114 A3 behaviour and this change must not alter it")
+	// #6741 AC1 INVERTS this assertion, deliberately. It used to require that
+	// the retained registry still SERVE the handle. It must now REFUSE: the
+	// handle is an orphan of a generation Cleanup already unpinned, and serving
+	// it lets a mutation succeed against an object nothing forwards through.
+	//
+	// The acceptance criterion offered "fails loudly OR is a verified no-op with
+	// a metric". The no-op branch is unavailable and that is measured, not
+	// assumed: `Close` closes only the XDP/TC link handles and `Cleanup` unpins
+	// without closing, so `m.maps` / `m.programs` FDs are never closed and the
+	// orphaned map stays alive and WRITABLE.
+	if h, present, _ := m.lookupMapLocked("sessions"); present || h != nil {
+		t.Errorf("a Teardown-superseded generation must be REFUSED, got present=%v handle=%v — "+
+			"serving it is the #6741 hazard: the mutation succeeds and reaches nothing",
+			present, h != nil)
 	}
 	if got := m.ObsoleteRegistryAccesses(); got != 1 {
-		t.Errorf("obsolete access count = %d, want 1 — a lookup served a handle whose kernel "+
-			"object Cleanup destroyed, and nothing measured that before #6741", got)
+		t.Errorf("obsolete access count = %d, want 1 — the counter is now the observability "+
+			"half of a real guard: it counts REFUSALS, not served-obsolete accesses", got)
+	}
+}
+
+// TestCloseRetainedRegistryStillProceeds_6741 is the SCOPE half of AC1, and the
+// reason the guard above is safe to add at all.
+//
+// #6741 AC1 refuses to serve a superseded generation. That revokes the #2114 A3
+// proceed-on-retained rule — but ONLY on the Teardown path, and by construction
+// rather than by care: `registryObsoleteFrom` is set by `Teardown` and
+// explicitly NOT by `Close`. Close keeps its pinned handles live for hitless
+// restart, which is the case A3 was argued for.
+//
+// Without this cell the change is indistinguishable from one that revoked
+// proceed-on-retained everywhere, and the guard's scope would live only in
+// prose. Fail-on-revert: make Close set registryObsoleteFrom (or drop the
+// `registryObsoleteFrom != 0` conjunct from registryObsoleteLocked) and this
+// goes RED while the cell above stays green.
+func TestCloseRetainedRegistryStillProceeds_6741(t *testing.T) {
+	m := regTestManager6741()
+
+	m.mu.Lock()
+	m.registryGeneration = 1
+	m.maps["sessions"] = &ebpf.Map{}
+	m.mu.Unlock()
+
+	// The hitless-restart shape: Close unarms and closes link handles, and
+	// deliberately leaves the pinned map registry intact for reuse. It does not
+	// mark the generation superseded.
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Guard the fixture: if Close ever DID mark the generation obsolete, the
+	// assertion below would be testing the refusal path by accident.
+	m.mu.Lock()
+	obsoleteFrom := m.registryObsoleteFrom
+	m.mu.Unlock()
+	if obsoleteFrom != 0 {
+		t.Fatalf("fixture broken: Close set registryObsoleteFrom=%d — Close must NOT mark a "+
+			"generation superseded, or hitless restart loses its retained handles", obsoleteFrom)
+	}
+
+	if _, present, _ := m.lookupMapLocked("sessions"); !present {
+		t.Error("a CLOSE-retained registry must still SERVE its handle — proceed-on-retained " +
+			"(#2114 A3) is preserved exactly where it was argued for. AC1 declines a " +
+			"generation TEARDOWN superseded; it does not weaken the rule")
+	}
+	if got := m.ObsoleteRegistryAccesses(); got != 0 {
+		t.Errorf("refusal count = %d, want 0 — nothing was superseded, so nothing is refused", got)
 	}
 }
 


### PR DESCRIPTION
#6741 AC1: **no retained handle can mutate a Teardown-superseded map
generation.** `lookupMapLocked` / `lookupProgramLocked` now refuse to serve such
a handle instead of counting the access and proceeding.

AC1 only. **AC2 remains open** — #6741 should be re-scoped to it rather than
closed.

## The acceptance criterion's own escape hatch is unavailable, and that is measured

AC1 reads *"mutation fails loudly **or is a verified no-op with a metric**"*.
With #7548's counter landed, the second branch looked nearly done. It is not
available:

- `Close()` closes **only** the XDP/TC link handles.
- `Cleanup()` unpins but does not close.
- **No path closes `m.maps` / `m.programs`** — checked by reading every
  `.Close()` in `loader.go`, not the two obvious ones; the rest are
  replacement-path closes.

An unpinned map with a live FD stays alive and **writable**, so the
retained-handle mutation *succeeds*, against an orphan of a generation nothing
forwards through. **The counter can say it happened; it cannot make it not
happen.** So AC1 can only be met by the fail-loudly branch.

## Why revoking a rule documented as deliberate is safe here

`Close()` says the registry is *"deliberately NOT cleared"* and `armed_gate.go`
says the #2114 A3 rule *deliberately* lets a retained method proceed. This
declines to serve — but the scope is **by construction, not by care**:

**`registryObsoleteFrom` is set by `Teardown` and explicitly NOT by `Close`.**

Close keeps its pinned handles live for hitless restart, which is the case A3
was argued for, and it never sets the predicate. Nothing about
proceed-on-retained is weakened; a generation Teardown already superseded is
declined.

## The scope claim is bound, not asserted

`TestCloseRetainedRegistryStillProceeds_6741` drives a real `Close()`-then-reuse
and requires the handle is **still served**, with a fixture guard asserting
`Close` did not set `registryObsoleteFrom` — otherwise the cell would be
exercising the refusal path by accident.

`TestObsoleteRegistryAccessCounted_6741` is **inverted, not deleted**. It used to
require the retained registry still SERVE the handle, in those words: *"this
change must not alter it"*. AC1 alters it, deliberately and narrowly, so the
test moved with the behaviour.

| mutation | result |
|---|---|
| remove the refusal at the map lookup site | **RED**, 590 collected — `TestObsoleteRegistryAccessCounted_6741` |
| make `Close` set `registryObsoleteFrom` | **RED** — `TestCloseRetainedRegistryStillProceeds_6741` **and** the pre-existing `TestCloseDoesNotStartAnObsoleteEpoch_6741` |

**A claim of mine that was wrong, and is corrected in the tree.** The scope
cell's doc originally stated two reverts that would red it. Only one does:
dropping the `registryObsoleteFrom != 0` conjunct leaves it **green**, because
its fixture has `generation=1, obsoleteFrom=0` and `1 <= 0` is false either way.
I wrote that clause without running it. An unverified fail-on-revert claim is
worse than none, because it reads as evidence — the comment now states only the
measured revert, and names what it does not bind.

(The conjunct is not unguarded: removing it hangs the package suite, since every
lookup then refuses. But this cell is not what catches that, and saying so is
the point.)

## Not overclaimed

The guard is **lookup-time**. A handle obtained *before* the Teardown and held
across it is never re-checked — neither refused nor counted. **AC1 is met for
handles obtained after the boundary, not for escaped ones.** Covering those
needs the generation read at the syscall, and #6740 forbids holding `m.mu`
across a BPF syscall — which is exactly why AC2 (lease/refcount with drain
discipline) is a design item rather than an extension of this.

Two comments are corrected because they became false on landing: `loader.go`
called the counter *"an observability counter, not a guard"*, and
`armed_gate.go` said *"it changes no behaviour. Every caller proceeds exactly as
before"*.

**Only one test broke** under the change — the one pinning the old contract. 135
call sites, and no caller mishandled `absent`.

## Gates

Gated head **`daa6d5da363df3fe7f6d02121d6daf548c61bfe0`**.

- `go test ./... -count=1` — **rc 0**, 68 packages ok.
- `gofmt` clean; `go build ./...` ok.
- `git merge-base --is-ancestor 7a86935a7 daa6d5da3` succeeds.

No Rust gate: the diff is three Go files and a log, so a Rust run would measure
master rather than this change.
