### PR TITLE
dataplane: record the filter binding a soft-skipped interface drops (#6893 part 1)

### DIFF
--- a/docs/log/6893.md
+++ b/docs/log/6893.md
@@ -1,0 +1,51 @@
+# #6893 — VLAN sub-interface fail-open: the filter binding that vanishes
+
+- **Timestamp**: 2026-08-27
+- **Action**: Part 1 — record the CONSEQUENCE of a soft-skipped interface
+  - **Re-measured the premise at master `8a12d2bc8`.** The harm is real and
+    reachable; one line of the issue has rotted, and the sharpest gap is one the
+    issue does not name.
+    - Both soft skips still `return nil` and `compileZones` still succeeds —
+      **true**.
+    - `compileFirewallFilters` still misses, warns and `continue`s — **true**.
+    - *"The only trace is two `slog.Warn` lines"* — **false**: #5275 records
+      both skips as `UnarmedSurface`.
+    - Net effect (clean commit, filter unapplied) — **true**, because nothing
+      outside `pkg/dataplane` consumes `UnarmedSurface` or `SurfaceCoverage`.
+      Grepped `pkg/daemon`, `pkg/api`, `pkg/cli`, `pkg/grpcapi`, `cmd`: no hits.
+      The records feed the internal arm-coverage proof, not the operator.
+  - **The gap the issue does not name**: the interface skips record their CAUSE;
+    the filter-assignment miss records **nothing at all**. So a binding that
+    could not be applied left no structured trace even internally, which is why
+    "the filter silently went missing" is undetectable except by reading logs.
+  - **`UnappliedFilterBinding` is deliberately a separate type.** A filter
+    binding is not an attach point, which is what `UnarmedSurface` documents
+    itself as — and `recordUnarmedSurface` dedups on `(Name, Ifindex)`, so in
+    the exact case this exists for (a VLAN child that could not be created,
+    whose filter then cannot be assigned) the consequence record would have
+    deduped onto the cause record and been lost. Measured before choosing, not
+    assumed.
+  - **The payload proof drives the real `compileFirewallFilters`** with the
+    post-soft-skip state — parent resolvable, VLAN child not — through the
+    `ifCache` seam, so no netlink and no privileges. It asserts today's
+    fail-open: the compile SUCCEEDS and the filter is not assigned. Its control
+    seeds the child and requires the filter IS assigned with nothing recorded,
+    so neither cell can pass against a build that never assigns filters, or one
+    that records unconditionally.
+  - **Mutation**: drop the recording at the VLAN miss site -> **RED**, 592
+    collected (full package, no `-run` filter), naming the payload cell alone;
+    the control stays green.
+  - **Scope decisions taken by the lead**: option (2) — plumbing unarmed
+    surfaces to commit output and `show` — was REJECTED as a four-package
+    operator contract that deserves its own issue. Option (3) — fail the apply
+    on a VLAN creation failure — is approved NARROWLY as a second PR, scoped to
+    creation failure only (`ensureVLANSubInterface`'s `"create VLAN
+    sub-interface %s: %w"`), leaving the absent-physical-interface skip alone
+    because the issue itself hedges on it as arguably legitimate.
+  - **This cell is part 3's done-signal.** When the apply starts failing, the
+    `err != nil` assertion here inverts rather than being deleted — which is
+    why part 1 lands first and separately.
+  - **Path rot corrected**: the files are `pkg/dataplane/`, not `pkg/config/`.
+  - **File(s)**: `pkg/dataplane/compiler_filter.go`,
+    `pkg/dataplane/compiler.go`, `pkg/dataplane/armproof.go`,
+    `pkg/dataplane/vlan_filter_failopen_6893_test.go`, `docs/log/6893.md`

--- a/pkg/dataplane/armproof.go
+++ b/pkg/dataplane/armproof.go
@@ -226,6 +226,40 @@ func attachModeName(generic bool) string {
 // parent is admin-DOWN and about to be torn down, and delegating to that would
 // report a covered child with nothing enforcing its traffic.
 
+// UnappliedFilterBinding records a firewall-filter binding the CONFIG declared
+// but the compiler could not assign, because the interface it names was not
+// resolvable at assignment time (#6893).
+//
+// WHY THIS IS SEPARATE FROM UnarmedSurface. The two soft skips in
+// compiler_iface.go already record the CAUSE — the physical interface was not
+// found, or the VLAN child could not be created — as an UnarmedSurface. Nothing
+// recorded the CONSEQUENCE: compileFirewallFilters resolves the same name,
+// misses, logs a warning and continues, so the binding vanishes with no
+// structured trace even internally. The cause was visible to the arm-coverage
+// proof and its consequence was not, which is why "the filter silently went
+// missing" is undetectable by anything except reading logs.
+//
+// It is not folded into UnarmedSurface for two reasons. A filter binding is not
+// an attach point, which is what that type documents itself as. And
+// recordUnarmedSurface dedups on (Name, Ifindex), so in the exact case this
+// exists for — a VLAN child that could not be created, whose filter then cannot
+// be assigned — the consequence record would dedup onto the cause record and be
+// lost.
+//
+// This is a record, not a gate: the compile still succeeds. Failing the apply on
+// a VLAN creation failure is the separate, narrower change (#6893 fix direction
+// 1), and this record is what its demonstration cell inverts.
+type UnappliedFilterBinding struct {
+	// Interface is the configured surface the binding names — "ge-0-0-2" for a
+	// physical miss, "ge-0-0-2.50" for a VLAN child.
+	Interface string
+	// Filters lists the declared bindings that were not applied, each rendered
+	// as "<direction> <family>:<name>".
+	Filters []string
+	// Reason is the resolution failure that prevented assignment.
+	Reason string
+}
+
 // UnarmedSurface records an attach point the CONFIG required but the compiler
 // DECLINED to arm, while the compile itself still SUCCEEDED (#5275).
 //

--- a/pkg/dataplane/compiler.go
+++ b/pkg/dataplane/compiler.go
@@ -94,6 +94,10 @@ type CompileResult struct {
 	// (armproof.go) cannot tell a declined surface from one armed
 	// successfully. Appended lazily; nil is a valid empty state.
 	unarmedSurfaces []UnarmedSurface
+	// unappliedFilterBindings records firewall-filter bindings the config
+	// declared but the compiler could not assign (#6893). The CAUSE of such a
+	// miss is already an unarmedSurfaces entry; this is its consequence.
+	unappliedFilterBindings []UnappliedFilterBinding
 
 	// ManagedInterfaces describes all interfaces managed by the firewall,
 	// used by the networkd manager to generate .link and .network files.
@@ -199,6 +203,33 @@ func (r *CompileResult) peekLinkByIndex(idx int) (netlink.Link, error) {
 // cosmetic wart. A repeat sighting never downgrades the classification: if
 // either one could not prove the netdev down, the surface keeps the
 // conservative reading.
+// recordUnappliedFilterBinding records a filter binding the compiler could not
+// assign (#6893). Deduped on (Interface, Reason) so one unresolvable interface
+// with several units does not fan out into near-identical rows.
+func (r *CompileResult) recordUnappliedFilterBinding(b UnappliedFilterBinding) {
+	if r == nil || len(b.Filters) == 0 {
+		return
+	}
+	for i := range r.unappliedFilterBindings {
+		if r.unappliedFilterBindings[i].Interface != b.Interface ||
+			r.unappliedFilterBindings[i].Reason != b.Reason {
+			continue
+		}
+		r.unappliedFilterBindings[i].Filters = append(r.unappliedFilterBindings[i].Filters, b.Filters...)
+		return
+	}
+	r.unappliedFilterBindings = append(r.unappliedFilterBindings, b)
+}
+
+// UnappliedFilterBindings reports the filter bindings this compile declined to
+// assign (#6893). See UnappliedFilterBinding for what a non-empty slice means.
+func (r *CompileResult) UnappliedFilterBindings() []UnappliedFilterBinding {
+	if r == nil {
+		return nil
+	}
+	return r.unappliedFilterBindings
+}
+
 func (r *CompileResult) recordUnarmedSurface(u UnarmedSurface) {
 	if r == nil {
 		return

--- a/pkg/dataplane/compiler_filter.go
+++ b/pkg/dataplane/compiler_filter.go
@@ -223,6 +223,16 @@ func compileFirewallFilters(dp DataPlane, cfg *config.Config, result *CompileRes
 			if err != nil {
 				slog.Warn("interface not found for filter assignment",
 					"interface", physName, "err", err)
+				// #6893: record the CONSEQUENCE. compiler_iface.go already
+				// records the cause (the interface was soft-skipped); without
+				// this the binding that could not be applied left no structured
+				// trace at all, so "the filter silently went missing" was
+				// undetectable except by reading logs.
+				result.recordUnappliedFilterBinding(UnappliedFilterBinding{
+					Interface: physName,
+					Filters:   unitFilterBindings(unit),
+					Reason:    fmt.Sprintf("interface not resolvable at filter assignment: %v", err),
+				})
 				continue
 			}
 
@@ -234,6 +244,15 @@ func compileFirewallFilters(dp DataPlane, cfg *config.Config, result *CompileRes
 				if err != nil {
 					slog.Warn("VLAN sub-interface not found for filter",
 						"name", subName, "err", err)
+					// #6893: the sharp case. compiler_iface.go's VLAN soft skip
+					// recorded the child as unarmed; this records the binding
+					// that therefore never reached the dataplane. A filter that
+					// is absent permits what it was configured to deny.
+					result.recordUnappliedFilterBinding(UnappliedFilterBinding{
+						Interface: subName,
+						Filters:   unitFilterBindings(unit),
+						Reason:    fmt.Sprintf("VLAN sub-interface not resolvable at filter assignment: %v", err),
+					})
 					continue
 				}
 				ifindex = uint32(subIface.Index)
@@ -824,4 +843,21 @@ func resolvePortName(name string) uint16 {
 		}
 		return 0
 	}
+}
+
+// unitFilterBindings renders the filter bindings a unit declares, for the
+// #6893 unapplied-binding record.
+func unitFilterBindings(unit *config.InterfaceUnit) []string {
+	var out []string
+	for _, b := range []struct{ dir, fam, name string }{
+		{"input", "inet", unit.FilterInputV4},
+		{"input", "inet6", unit.FilterInputV6},
+		{"output", "inet", unit.FilterOutputV4},
+		{"output", "inet6", unit.FilterOutputV6},
+	} {
+		if b.name != "" {
+			out = append(out, b.dir+" "+b.fam+":"+b.name)
+		}
+	}
+	return out
 }

--- a/pkg/dataplane/vlan_filter_failopen_6893_test.go
+++ b/pkg/dataplane/vlan_filter_failopen_6893_test.go
@@ -1,0 +1,162 @@
+package dataplane
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6893 — THE PAYLOAD PROOF for the VLAN-sub-interface fail-open.
+//
+// The filed harm: a VLAN sub-interface that fails to be created is soft-skipped
+// by compileZones, compileFirewallFilters then resolves the same name, misses,
+// and `continue`s — so the operator commits a config containing a filter
+// binding, the commit reports SUCCESS, and the filter is not applied. A filter
+// that is absent permits what it was configured to deny.
+//
+// This cell demonstrates that outcome rather than assuming it, which is what
+// makes the record it also asserts worth having: an absence claim is only as
+// good as the payload's ability to produce what it asserts is absent.
+//
+// The seam is `ifCache`. Seeding the PHYSICAL interface and leaving the VLAN
+// child absent reproduces exactly the post-soft-skip state — the parent
+// resolves, `ge-0-0-2.50` does not — with no netlink and no privileges.
+//
+// WHAT THIS CELL WILL BECOME. #6893's fix direction 1 makes a VLAN creation
+// failure fail the apply. When that lands, the `err != nil` assertion here
+// inverts, and that inversion is its done-signal. Until then this pins the
+// CURRENT behaviour honestly, including that it is a fail-open.
+func TestVLANSubInterfaceFilterSilentlyUnapplied_6893(t *testing.T) {
+	const physName = "ge-0-0-2"
+	const subName = "ge-0-0-2.50"
+
+	cfg := &config.Config{}
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"wan-in": {
+			Name:  "wan-in",
+			Terms: []*config.FirewallFilterTerm{{Name: "deny-all", Action: "discard"}},
+		},
+	}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		physName: {
+			Name: physName,
+			Units: map[int]*config.InterfaceUnit{
+				50: {Number: 50, VlanID: 50, FilterInputV4: "wan-in"},
+			},
+		},
+	}
+
+	dp := newIfaceFilterRecordingDP6893()
+	// The parent resolves; the VLAN child does not — the state compileZones
+	// leaves behind when ensureVLANSubInterface failed and it soft-skipped.
+	result := &CompileResult{
+		ifCache: map[string]*net.Interface{
+			physName: {Index: 42, Name: physName},
+		},
+	}
+
+	err := compileFirewallFilters(dp, cfg, result)
+
+	// THE FAIL-OPEN, demonstrated. The compile succeeds even though the filter
+	// the operator bound could not be assigned to anything.
+	if err != nil {
+		t.Fatalf("compileFirewallFilters returned %v — this cell pins the CURRENT "+
+			"fail-open, in which the compile SUCCEEDS. If #6893 fix direction 1 has "+
+			"landed, invert this assertion rather than deleting it: a failing apply "+
+			"is the intended end state", err)
+	}
+
+	// Guard the fixture: if the filter had actually been assigned, everything
+	// below would be asserting against a case that never arose.
+	if len(dp.ifaceFilters) != 0 {
+		t.Fatalf("fixture broken: the filter WAS assigned (%d bindings) — the VLAN "+
+			"child must be unresolvable for this cell to mean anything", len(dp.ifaceFilters))
+	}
+
+	// THE RECORD (#6893 part 1). The cause was already recorded by
+	// compiler_iface.go's soft skip; before this change the CONSEQUENCE — the
+	// binding that never reached the dataplane — left no structured trace.
+	bindings := result.UnappliedFilterBindings()
+	if len(bindings) != 1 {
+		t.Fatalf("want exactly 1 unapplied-binding record, got %d (%+v) — without it "+
+			"a filter that silently went missing is undetectable except by reading logs",
+			len(bindings), bindings)
+	}
+	b := bindings[0]
+	if b.Interface != subName {
+		t.Errorf("record names interface %q, want %q — the record must name the "+
+			"CONFIGURED surface, or a VLAN child folds onto its parent", b.Interface, subName)
+	}
+	if len(b.Filters) != 1 || !strings.Contains(b.Filters[0], "wan-in") {
+		t.Errorf("record filters = %v, want one naming wan-in — a record that does not "+
+			"say WHICH binding was dropped cannot tell an operator what is unenforced",
+			b.Filters)
+	}
+	if !strings.Contains(b.Reason, "VLAN sub-interface") {
+		t.Errorf("record reason = %q, want the VLAN resolution failure — the physical-miss "+
+			"and VLAN-miss paths must stay distinguishable", b.Reason)
+	}
+}
+
+// The CONTROL. With the VLAN child resolvable the filter IS assigned and
+// nothing is recorded — so the assertions above cannot pass against a build
+// that never assigns filters at all, or one that records unconditionally.
+func TestVLANSubInterfaceFilterAppliedWhenResolvable_6893(t *testing.T) {
+	const physName = "ge-0-0-2"
+	const subName = "ge-0-0-2.50"
+
+	cfg := &config.Config{}
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"wan-in": {
+			Name:  "wan-in",
+			Terms: []*config.FirewallFilterTerm{{Name: "deny-all", Action: "discard"}},
+		},
+	}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		physName: {
+			Name:  physName,
+			Units: map[int]*config.InterfaceUnit{50: {Number: 50, VlanID: 50, FilterInputV4: "wan-in"}},
+		},
+	}
+
+	dp := newIfaceFilterRecordingDP6893()
+	result := &CompileResult{
+		ifCache: map[string]*net.Interface{
+			physName: {Index: 42, Name: physName},
+			subName:  {Index: 43, Name: subName},
+		},
+	}
+
+	if err := compileFirewallFilters(dp, cfg, result); err != nil {
+		t.Fatalf("compileFirewallFilters: %v", err)
+	}
+	if len(dp.ifaceFilters) == 0 {
+		t.Error("the filter must be ASSIGNED when the VLAN child resolves — without this " +
+			"control the fail-open cell above proves nothing about the VLAN miss")
+	}
+	if got := result.UnappliedFilterBindings(); len(got) != 0 {
+		t.Errorf("nothing may be recorded when the binding APPLIED, got %+v", got)
+	}
+}
+
+// ifaceFilterRecordingDP6893 extends the package's recordingFilterDP with the
+// interface->filter assignment, which is the thing these cells are about: the
+// fail-open is precisely that SetIfaceFilter is never reached.
+type ifaceFilterRecordingDP6893 struct {
+	*recordingFilterDP
+	ifaceFilters map[IfaceFilterKey]uint32
+}
+
+func newIfaceFilterRecordingDP6893() *ifaceFilterRecordingDP6893 {
+	return &ifaceFilterRecordingDP6893{
+		recordingFilterDP: &recordingFilterDP{},
+		ifaceFilters:      map[IfaceFilterKey]uint32{},
+	}
+}
+
+func (d *ifaceFilterRecordingDP6893) SetIfaceFilter(key IfaceFilterKey, id uint32) error {
+	d.ifaceFilters[key] = id
+	return nil
+}


### PR DESCRIPTION
#6893 **part 1 of 2**. Records the filter binding that a soft-skipped interface
silently drops. **No behaviour change** — the compile still succeeds; part 2
(fail the apply on a VLAN creation failure) lands separately.

Refs #6893

> **Package note**, because the issue's cites have this wrong: these files are
> `pkg/dataplane/`, not `pkg/config/` — `compiler_filter.go`,
> `compiler_iface.go`, `compiler.go`, `armproof.go`.

## Re-measured first: the harm is real, one premise line has rotted

| issue claim | measured at `8a12d2bc8` |
|---|---|
| both soft skips `return nil`; `compileZones` succeeds | **true** |
| `compileFirewallFilters` misses, warns, `continue`s | **true** |
| *"the only trace is two `slog.Warn` lines"* | **false** — #5275 records both skips as `UnarmedSurface` |
| net effect: clean commit, filter unapplied | **true** |

The rotted line does not rescue the issue, because **nothing outside
`pkg/dataplane` consumes `UnarmedSurface` or `SurfaceCoverage`** — grepped
`pkg/daemon`, `pkg/api`, `pkg/cli`, `pkg/grpcapi`, `cmd`. Those records feed the
internal arm-coverage proof, not the operator. The trace is richer than the
issue says and equally invisible.

## The gap the issue does not name

The two *interface* skips record their **cause**. The filter-assignment miss
records **nothing at all** — a bare `slog.Warn` and `continue`. So the cause is
recorded and the consequence is not, which is exactly why "the filter silently
went missing" is undetectable by anything but reading logs.

`UnappliedFilterBinding` is a separate type, and that was measured rather than
assumed: a filter binding is not an attach point (what `UnarmedSurface`
documents itself as), and `recordUnarmedSurface` dedups on `(Name, Ifindex)` —
so in the exact case this exists for, a VLAN child that could not be created
whose filter then cannot be assigned, the consequence record would have deduped
onto the cause record and been **lost**.

## The payload proof

`TestVLANSubInterfaceFilterSilentlyUnapplied_6893` drives the real
`compileFirewallFilters` with the post-soft-skip state — parent resolvable, VLAN
child not — through the `ifCache` seam, so no netlink and no privileges. It
asserts today's fail-open honestly: **the compile SUCCEEDS and the filter is not
assigned.**

Its control seeds the child too and requires the filter **is** assigned with
nothing recorded, so neither cell can pass against a build that never assigns
filters, or one that records unconditionally.

| mutation | verdict |
|---|---|
| drop the recording at the VLAN miss site | **RED**, 592 collected (full package, no `-run` filter) — payload cell alone; control green |

## Why this is part 1 and not the whole fix

Scope was decided before building:

- **Rejected**: plumbing unarmed surfaces to commit output and `show`. That is a
  new operator-visible contract across four packages and deserves its own issue
  with that as the subject.
- **Approved, narrowly, as part 2**: fail the apply on a VLAN **creation**
  failure — `ensureVLANSubInterface`'s `"create VLAN sub-interface %s: %w"` —
  leaving the absent-physical-interface skip alone, because the issue itself
  hedges on that one as arguably legitimate.

**The demonstration cell here is part 2's done-signal**: when the apply starts
failing, its `err != nil` assertion inverts rather than being deleted. That is
why part 1 lands first and separately — folding them would mean writing the
cell twice, once asserting the silent success and then inverting it.

## Gates

Gated head **`e0b1f07c57a0c7661e6fa7bfbb72a6ccd2ffd6e4`**.

- `go test ./... -count=1` — **rc 0**, 68 packages ok.
- `gofmt` clean; `go build ./...` ok.
- `git merge-base --is-ancestor 8a12d2bc8 e0b1f07c5` succeeds.

No Rust gate: the diff is four Go files and a log, so a Rust run would measure
master rather than this change.
