### PR TITLE
userspace-dp: observe bind_mode once in the binding snapshot

### DIFF
--- a/docs/log/6898.md
+++ b/docs/log/6898.md
@@ -1,0 +1,17 @@
+# #6898 item A1-b5-F1 — torn bind_mode pair in the binding snapshot
+
+- **Timestamp**: 2026-08-27
+  - **Action**: `BindingLiveSnapshot` read `self.bind_mode` TWICE — once for
+    `xsk_bind_mode` and once for `zero_copy` — so a concurrent rebind between
+    the two loads publishes a snapshot whose fields describe different modes.
+    Single load into a local, both fields derived from it.
+  - **Path had MOVED**, as the issue documents: filed as `umem/snapshot.rs`,
+    now `binding_state/snapshot.rs`.
+  - **Guards**: a comment-stripped source scan (exactly one `bind_mode.load(`
+    in code) plus an agreement test over every mode, because a torn read is a
+    race that no behavioural test can reliably observe.
+  - **Scope**: this is ONE of the five cohort items in #6898. The other four are
+    untouched and the issue stays open.
+  - **File(s)**: userspace-dp/src/afxdp/binding_state/snapshot.rs,
+    userspace-dp/src/afxdp/binding_state/torn_bindmode_6898_tests.rs (new),
+    userspace-dp/src/afxdp/binding_state/mod.rs

--- a/userspace-dp/src/afxdp/binding_state/mod.rs
+++ b/userspace-dp/src/afxdp/binding_state/mod.rs
@@ -1181,3 +1181,5 @@ impl BindingLiveState {
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod torn_bindmode_6898_tests;

--- a/userspace-dp/src/afxdp/binding_state/snapshot.rs
+++ b/userspace-dp/src/afxdp/binding_state/snapshot.rs
@@ -25,13 +25,24 @@ impl BindingLiveState {
             .lock()
             .map(|status| status.clone())
             .unwrap_or_default();
+        // #6898 (A1-b5-F1): ONE load, both fields derived from it. These two
+        // fields are two spellings of the same value -- the mode's name and
+        // whether that mode is zero-copy -- so reading the atomic twice lets a
+        // concurrent rebind land between them and publish a snapshot whose
+        // `xsk_bind_mode` and `zero_copy` describe DIFFERENT modes. That is a
+        // torn pair in an operator-facing status surface: `show` would report a
+        // copy-mode bind as zero-copy, or the reverse, and the disagreement is
+        // internal to one snapshot so nothing downstream can detect it.
+        //
+        // Relaxed remains correct -- the fields are independent status values,
+        // not a release/acquire handshake -- but they must come from a single
+        // observation of the atomic, not two.
+        let bind_mode = XskBindMode::from_u8(self.bind_mode.load(Ordering::Relaxed));
         BindingLiveSnapshot {
             bound: self.bound.load(Ordering::Relaxed),
             xsk_registered: self.xsk_registered.load(Ordering::Relaxed),
-            xsk_bind_mode: XskBindMode::from_u8(self.bind_mode.load(Ordering::Relaxed))
-                .as_str()
-                .to_string(),
-            zero_copy: XskBindMode::from_u8(self.bind_mode.load(Ordering::Relaxed)).is_zerocopy(),
+            xsk_bind_mode: bind_mode.as_str().to_string(),
+            zero_copy: bind_mode.is_zerocopy(),
             socket_fd: self.socket_fd.load(Ordering::Relaxed),
             socket_ifindex: self.socket_ifindex.load(Ordering::Relaxed),
             socket_queue_id: self.socket_queue_id.load(Ordering::Relaxed),

--- a/userspace-dp/src/afxdp/binding_state/torn_bindmode_6898_tests.rs
+++ b/userspace-dp/src/afxdp/binding_state/torn_bindmode_6898_tests.rs
@@ -1,0 +1,69 @@
+//! #6898 (A1-b5-F1): the binding snapshot must observe `bind_mode` ONCE.
+//!
+//! `xsk_bind_mode` and `zero_copy` are two spellings of one value — the mode's
+//! name, and whether that mode is zero-copy. Reading the atomic twice lets a
+//! concurrent rebind land between the reads and publish a snapshot whose two
+//! fields describe DIFFERENT modes.
+//!
+//! That is not merely a stale value: it is a snapshot that **disagrees with
+//! itself**, on an operator-facing status surface. `show` would report a
+//! copy-mode bind as zero-copy or the reverse, and because the inconsistency is
+//! internal to a single snapshot, nothing downstream can detect it — every
+//! consumer sees a well-formed record.
+//!
+//! A torn read is a race, so no behavioural test can reliably observe it. The
+//! two guards below cover the two ways it can come back:
+//!   * the SOURCE guard catches a reintroduced second load (the original bug);
+//!   * the AGREEMENT test catches a wrong derivation, where one field is
+//!     computed from something other than the single observation.
+
+/// The original defect, and the one a future edit is most likely to reintroduce
+/// by "inlining" the local back into both fields.
+///
+/// Comments are stripped BEFORE matching, so this file's own prose — which
+/// necessarily spells the banned expression — cannot satisfy the scan, and
+/// neither can the explanatory comment at the fix site.
+#[test]
+fn snapshot_observes_bind_mode_exactly_once_6898() {
+    let src = include_str!("snapshot.rs");
+    let code: String = src
+        .lines()
+        .map(|l| match l.find("//") {
+            Some(i) => &l[..i],
+            None => l,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let loads = code.matches("bind_mode.load(").count();
+    assert_eq!(
+        loads, 1,
+        "#6898: `snapshot.rs` performs {loads} `bind_mode.load(...)` calls in CODE \
+         (comments stripped); it must perform exactly ONE. Two observations let a \
+         concurrent rebind tear `xsk_bind_mode` against `zero_copy` within a single \
+         snapshot. Load once into a local and derive both fields from it."
+    );
+}
+
+/// Guards the derivation itself: for every mode, the rendered name and the
+/// zero-copy flag must describe the same mode. This is what a source guard
+/// cannot see — a single load whose two derivations disagree.
+#[test]
+fn bind_mode_name_and_zero_copy_flag_agree_6898() {
+    use crate::afxdp::binding_state::XskBindMode;
+
+    for raw in 0u8..=8 {
+        let mode = XskBindMode::from_u8(raw);
+        let name = mode.as_str();
+        let zc = mode.is_zerocopy();
+        // The two spellings must not disagree about zero-copy-ness. Keyed on the
+        // rendered name rather than on the enum, because the name is what the
+        // operator reads and what the snapshot actually carries.
+        let name_says_zc = name.contains("zerocopy") || name.contains("zero-copy");
+        assert_eq!(
+            name_says_zc, zc,
+            "#6898: mode {raw} renders as {name:?} but is_zerocopy()={zc}; the \
+             snapshot's two fields would describe different modes"
+        );
+    }
+}


### PR DESCRIPTION
Refs #6898 — item **A1-b5-F1** only. The other four cohort items are untouched
and the issue stays open.

## The defect

`BindingLiveSnapshot` read `self.bind_mode` **twice**:

```rust
xsk_bind_mode: XskBindMode::from_u8(self.bind_mode.load(Ordering::Relaxed)).as_str().to_string(),
zero_copy:     XskBindMode::from_u8(self.bind_mode.load(Ordering::Relaxed)).is_zerocopy(),
```

Two spellings of one value — the mode's name, and whether that mode is
zero-copy. A concurrent rebind landing between the reads publishes a snapshot
whose two fields describe **different modes**.

**That is not a stale value; it is a record that disagrees with itself**, on an
operator-facing status surface. `show` would report a copy-mode bind as
zero-copy or the reverse — and because the inconsistency is internal to a single
snapshot, no consumer downstream can detect it. Every reader sees a well-formed
record.

Relaxed ordering remains correct — these are independent status values, not a
release/acquire handshake — but both fields must come from **one** observation.

## Two guards, because a torn read is a race

No behavioural test can reliably observe the interleaving, so the guards cover
the two ways it comes back:

- **Source scan** — exactly one `bind_mode.load(` in code. This is the original
  bug and what an "inline the local back into both fields" edit reintroduces.
  **Comments are stripped before matching**, so neither this file's own prose nor
  the explanatory comment at the fix site can satisfy the scan.
- **Agreement test** — for every mode, the rendered name and the zero-copy flag
  must describe the same mode. This catches a single load whose two derivations
  disagree, which the source guard cannot see.

**Armed:** reintroducing the second load reds
`snapshot_observes_bind_mode_exactly_once_6898` by name, while the agreement
test correctly stays green — the two guards cover disjoint failures rather than
duplicating each other.

## Path had moved

The issue documents this: filed as `umem/snapshot.rs`, which no longer exists.
The code is `binding_state/snapshot.rs`. Two of the five cohort items sit at
paths that grep clean at their originally-filed location, and the issue records
the current loci — worth reading before starting any of the remaining four.

## Validation

`cargo test --bins --tests -- --test-threads=1` and `go test ./... -count=1`,
both clean. Fix committed before mutating; restore verified clean afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7PfivEWEESWuDihm6TgdT