### PR TITLE
userspace: detect a NAT pool overlapping a runtime interface-SNAT egress

### DIFF
--- a/docs/log/7717.md
+++ b/docs/log/7717.md
@@ -1,73 +1,62 @@
-# #7717 — recording what the fix's done-signal actually is
+# #7717 — the Go snapshot-builder half: DETECTION only
 
-- **Timestamp**: 2026-08-27
-  - **Action**: recorded three measured findings about #7717's fix BEFORE
-    building it, because two of them are actively misleading while unwritten.
-    No behaviour change; this PR corrects a done-signal and bounds a design
-    space.
-
-  - **Finding 1 — the rescued PR-3b drain is INERT alone.** Measured, not
-    inferred: `origin/rescue/6751-pr3b-drain-unvalidated` (331 lines) applies
-    cleanly to current master, and with it applied whole the #7721
-    reproduction **still passes** — the collision still occurs. Its drain
-    engages only when `rule.pool_failure.is_some()`, and nothing in the
-    shipped tree sets that, because the Go snapshot-builder half is not
-    written. Adopting it as "the fix" would ship 331 lines of dataplane
-    change that alter nothing observable.
-
-  - **Finding 2 — the pin will NOT invert when #7717 is fixed**, contrary to
-    what #7721 wrote into the file in an authoritative voice ("that failure is
-    the SIGNAL THE FIX LANDED"). §5.7 forecloses at the snapshot builder by
-    quarantining the pool; that makes the colliding state unreachable FROM
-    CONFIG but cannot stop a unit test constructing it directly, and the pin
-    builds its rules via `parse_source_nat_rules` with a HEALTHY pool. So a
-    correct §5.7 lands and the pin keeps passing. A wrong done-signal is more
-    expensive than no done-signal: a lane would conclude the fix failed, or
-    chase the pin until it built something that inverts it and is not the
-    design.
-    The correct acceptance control drives the **snapshot builder** — configure
-    an interface-mode rule whose runtime-resolved egress overlaps a pool,
-    assert the builder quarantines the pool AND that live sessions drain
-    rather than strand.
-
-  - **Finding 3 — neither half is a fix alone**, so the work is a sequenced
-    pair. The Rust drain is inert without the Go quarantine (finding 1); the
-    Go quarantine cannot ship ENFORCING without the drain, because the merged
-    config gate says so itself — "marking a pool unusable with nothing
-    draining would strand live sessions"
-    (`pkg/config/compiler_nat_iface_egress.go`). It can ship DETECTING and
-    testable, which is why the Go half is sequenced first.
-
-  - **Design space, verified by symbol** (recorded so the next lane does not
-    re-derive it):
-    1. The two substrates are not unifiable without an apply-path refactor.
-       `resolve_pool_allocators` takes only snapshot inputs and cannot see the
-       node-lifetime registry; pool allocators are owned by value per
-       `SourceNatPoolAllocatorKey`, interface allocators are
-       `Arc<PortAllocator>` per `IpAddr` (`iface_registry.rs:115-116`).
-    2. Option (a)'s interface-side core already shipped — `allocator_for`,
-       fail-closed `InterfaceRegistryCap`, PAT via
-       `allocate_interface_identity` (`source.rs:2539-2588`). The gap is
-       purely cross-domain.
-    3. PATH A is out of scope. The plan's sourced sentence — the registry,
-       occupancy split, holders and drain "never read the mirror for their own
-       correctness" — says PATH A is ORTHOGONAL to the option-(a) core, not
-       that PRs may be split arbitrarily. Read narrowly, it is why the drain
-       does not need the sole-writer substrate.
-
-  - **§5.7 is deliberately NOT attempted whole.** Most of it addresses
-    collision classes that are not demonstrated — static-vs-interface, NAT64,
-    persistent/deterministic/sticky postures — argued from a plan whose two
-    prior distillations were both wrong about HEAD. #7721 established that a
-    demonstrated defect cannot be re-litigated from prose; the converse binds
-    equally, and a fix for an undemonstrated defect in NAT identity sourced
-    from a dead lane's reasoning is what that standard forbids.
-
-  - **Process note**: I ran the arming cell for the new assertion BEFORE
-    committing, and `git checkout --` took the uncommitted correction with it.
-    Caught by verifying the restore rather than trusting it. Re-applied and
-    committed first, then re-armed — the rule is commit-before-mutate and I
-    had just broken it.
-
-  - **File(s)**: userspace-dp/src/nat/tests_iface_pool_overlap_7717.rs,
-    docs/log/7717.md
+- **Timestamp**: 2026-08-27 (second entry; the first records the done-signal
+  correction that shipped as PR #7730)
+  - **Action**: added runtime-overlap DETECTION at snapshot build — the half the
+    merged config gate names as missing. It derives interface-mode SNAT egress
+    candidates from the snapshot's LIVE interface addresses, reports any NAT
+    pool address that coincides with one, and counts the scan.
+  - **Detection only, deliberately.** It does NOT set `pool_failure` and does
+    NOT quarantine. Two reasons, and the second decided the scope:
+    1. The merged gate says quarantining without a drain strands live sessions.
+    2. A wired-but-disabled quarantine cannot be mutation-tested, because
+       nothing makes it fire. It would ship as an unguarded path whose
+       correctness rests on review, and sit that way until the drain lands.
+       That is the same shape as #6850's five accepted-but-never-read knobs and
+       #6837's `_ => true`: code that exists and does nothing, where no test can
+       distinguish working from inert. The quarantine ships WITH the drain, in
+       one change, where a cell can make it fire.
+  - **Timing correction, worth stating because the framing was "commit-time"**:
+    this runs at SNAPSHOT BUILD, not at commit. A runtime-learned address is
+    unknown at commit time by definition — that is exactly the gap #7645 left,
+    so a commit-time check cannot close it. DHCP address changes trigger a full
+    recompile, so a lease that creates an overlap is detected on the rebuild it
+    causes.
+  - **The warning owes a three-row table and has one.** Fires on a real
+    overlap; silent when the addresses do not coincide; silent when there is no
+    interface-mode rule at all. The middle row is what a happy-path fixture
+    omits, and a detector that warns on every config is worse than none. The
+    third row separates two different reasons to stay silent.
+  - **The counter distinguishes "no overlap" from "detector never ran."** Two
+    values, not one gauge: `scans` and `addresses`. Zero addresses is the
+    healthy reading AND the not-wired reading, so a gauge alone cannot tell an
+    operator which they are looking at — the same ambiguity as an unguarded
+    headroom read reporting "enormous room" when headroom is unknown. A clean
+    scan still increments `scans`, which is what makes the distinction real, and
+    a test pins exactly that.
+  - **Scope matrix**: all four shapes, each tested BOTH matching and
+    non-matching, plus an AND-of-constraints row where one of two scopes
+    disagrees. The wildcard row is the one the old `maps_sync.go` precedent got
+    wrong by returning nothing — understating the candidate set exactly where it
+    is widest, so an overlap goes unreported.
+  - **Stated limitation, and it is tested**: pool members expressed as ranges or
+    prefixes are skipped, not approximated. Reporting a maybe-overlap as an
+    overlap makes the warning unactionable. The test pairs the skip with a
+    control on the same address as a host member, so the skip is demonstrably
+    about the member's SHAPE and not about the address.
+  - **A mutation cell found the WIRING unbound, and it is the same defect one
+    layer up.** M6 deleted `reportInterfaceSNATPoolOverlaps(snap)` from
+    `buildSnapshot` and **red nothing** — every test called the detector or the
+    reporter directly, so a detector that is entirely correct and never executes
+    would have shipped green. That is precisely "code that exists and does
+    nothing, where no test can distinguish working from inert" — the reason
+    detection-only was the right scope, arriving as a defect in my own change.
+    Closed with two binds: the scan counter must advance across a real
+    `buildSnapshot` (the builder called it), and a real config whose interface
+    address is also its pool address must produce a finding from the builder's
+    own snapshot (the builder populates the fields the detector reads). The
+    first alone would pass even if the builder handed the detector an empty
+    snapshot.
+  - **File(s)**: pkg/dataplane/userspace/nat_iface_pool_overlap.go,
+    pkg/dataplane/userspace/nat_iface_pool_overlap_7717_test.go,
+    pkg/dataplane/userspace/builder.go, docs/log/7717.md

--- a/pkg/dataplane/userspace/builder.go
+++ b/pkg/dataplane/userspace/builder.go
@@ -161,6 +161,14 @@ func buildSnapshotWithSchedulerStateAndNATCounters(cfg *config.Config, ucfg conf
 		snap.Summary.ZoneCount = len(snap.Zones)
 		snap.Summary.PolicyCount = len(snap.Policies)
 	}
+	// #7717: report (do NOT foreclose) a NAT pool overlapping an interface-mode
+	// SNAT egress address that is only knowable at snapshot build — a DHCP or
+	// netlink-learned address the commit-time gate cannot see. Quarantining the
+	// pool here is what §5.7 specifies, and it ships with the drain, in one
+	// change, because the merged config gate says marking a pool unusable with
+	// nothing draining strands live sessions.
+	reportInterfaceSNATPoolOverlaps(snap)
+
 	return snap, nil
 }
 

--- a/pkg/dataplane/userspace/nat_iface_pool_overlap.go
+++ b/pkg/dataplane/userspace/nat_iface_pool_overlap.go
@@ -1,0 +1,252 @@
+package userspace
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"sort"
+	"strings"
+	"sync/atomic"
+)
+
+// #7717 — DETECTION ONLY.
+//
+// The config-time gate (#7645, pkg/config/compiler_nat_iface_egress.go) forecloses
+// a NAT pool overlapping an interface-mode SNAT egress address when that address is
+// CONFIGURED. It says so itself, and says why the other half was not shipped:
+//
+//	"Runtime-resolved addresses (DHCP, netlink) are deliberately out of scope here
+//	 — foreclosing those is the snapshot-builder half of §5.7 and needs the DRAIN
+//	 discipline behind it, because marking a pool unusable with nothing draining
+//	 would strand live sessions."
+//
+// This is that snapshot-builder half, DETECTING and reporting only. It does NOT
+// mark the pool unusable and does not touch `pool_failure`: quarantining with
+// nothing draining is the stranding the merged gate names. The quarantine ships
+// with the drain, in one change, where a test can make it fire.
+//
+// Why detection is worth shipping alone: the overlap is silent today. Two
+// allocators mint the same (E, port) — demonstrated by
+// `defect_pin_pool_and_interface_snat_mint_one_identity_7717` — and an operator
+// has no signal that they are in that state. This gives them one, and gives the
+// drain PR a measurement to validate against.
+//
+// NOTE ON TIMING, and it is the reason this half exists at all: this runs at
+// SNAPSHOT BUILD, not at commit. A runtime-learned address is unknown at commit
+// time by definition, so a commit-time check cannot see it — that is precisely
+// the gap #7645 left. DHCP address changes trigger a full recompile, so a lease
+// that creates an overlap is detected on the rebuild it causes.
+
+// interfaceSNATPoolOverlap is one (address, pool rule, interface rule) finding.
+type interfaceSNATPoolOverlap struct {
+	// Address is the host form of the overlapping egress address.
+	Address string
+	// Interface is the snapshot interface whose live address it is.
+	Interface string
+	// InterfaceRule and PoolRule name the two rules whose domains collide.
+	InterfaceRule string
+	PoolRule      string
+}
+
+func (o interfaceSNATPoolOverlap) String() string {
+	return fmt.Sprintf("address %s on %s: interface-mode rule %q and pool rule %q",
+		o.Address, o.Interface, o.InterfaceRule, o.PoolRule)
+}
+
+// snatOverlapScans counts DETECTOR RUNS; snatOverlapAddresses is the count from
+// the most recent run.
+//
+// Two values, deliberately. A single "overlaps" gauge reads 0 both when there is
+// no overlap and when the detector never ran — the same ambiguity that let an
+// unguarded headroom read report "enormous room" at the moment headroom was
+// unknown. `scans_total == 0` means UNKNOWN, not healthy.
+var (
+	snatOverlapScans     atomic.Uint64
+	snatOverlapAddresses atomic.Uint64
+)
+
+// InterfaceSNATPoolOverlapStats reports (scans, overlapping addresses at the last
+// scan). A caller MUST read scans first: zero scans means the detector has not
+// run and the address count carries no information.
+func InterfaceSNATPoolOverlapStats() (scans uint64, addresses uint64) {
+	return snatOverlapScans.Load(), snatOverlapAddresses.Load()
+}
+
+// interfaceSNATEgressCandidatesFromSnapshot derives, from the SNAPSHOT's live
+// interface addresses, the set of addresses an interface-mode SNAT rule can
+// translate onto — the same matrix `interfaceSNATEgressAddresses` applies to
+// config, on runtime-resolved data.
+//
+// The scope semantics are AND-of-non-empty-constraints, mirroring the dataplane's
+// `scope_matches` and the config-time gate: each configured to-side scope must
+// agree, an unconfigured scope does not constrain, and a rule with NO to-side
+// scope is a wildcard over every interface. The wildcard row is the one the old
+// `maps_sync.go` precedent got wrong by returning nothing, which understates the
+// candidate set exactly where it is widest.
+//
+// Returns address -> label naming why it is a candidate.
+func interfaceSNATEgressCandidatesFromSnapshot(snap *ConfigSnapshot) map[string]string {
+	if snap == nil || len(snap.Interfaces) == 0 {
+		return nil
+	}
+	out := make(map[string]string)
+	rules := append([]SourceNATRuleSnapshot(nil), snap.SourceNAT...)
+	sort.SliceStable(rules, func(i, j int) bool { return rules[i].Name < rules[j].Name })
+	ifaces := append([]InterfaceSnapshot(nil), snap.Interfaces...)
+	sort.SliceStable(ifaces, func(i, j int) bool { return ifaces[i].Name < ifaces[j].Name })
+
+	for _, rule := range rules {
+		if !rule.InterfaceMode {
+			continue
+		}
+		for _, ifc := range ifaces {
+			if !interfaceInSnapshotEgressScope(rule, ifc) {
+				continue
+			}
+			for _, a := range ifc.Addresses {
+				host := hostOfSnapshotAddress(a.Address)
+				if host == "" {
+					continue
+				}
+				if _, seen := out[host]; !seen {
+					out[host] = fmt.Sprintf("interface-mode source-NAT rule %q egress %s",
+						rule.Name, ifc.Name)
+				}
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// interfaceInSnapshotEgressScope applies the derivation matrix for ONE snapshot
+// interface against ONE interface-mode rule's to-side scope.
+func interfaceInSnapshotEgressScope(rule SourceNATRuleSnapshot, ifc InterfaceSnapshot) bool {
+	if rule.ToInterface != "" && !snapshotInterfaceNameMatches(rule.ToInterface, ifc.Name) {
+		return false
+	}
+	if rule.ToRoutingInstance != "" && rule.ToRoutingInstance != ifc.RoutingInstance {
+		return false
+	}
+	if rule.ToZone != "" && rule.ToZone != ifc.Zone {
+		return false
+	}
+	return true
+}
+
+// snapshotInterfaceNameMatches accepts either the logical unit name ("ge-0/0/0.0")
+// or the bare physical name ("ge-0/0/0"), matching the config-time gate, which
+// compares a rule-set's ToInterface against BOTH forms.
+func snapshotInterfaceNameMatches(want, have string) bool {
+	if want == have {
+		return true
+	}
+	if base, _, ok := strings.Cut(have, "."); ok && want == base {
+		return true
+	}
+	return false
+}
+
+// hostOfSnapshotAddress strips any prefix length. Snapshot addresses are stored
+// as "A.B.C.D/len" or bare hosts depending on source, so both are accepted; a
+// value that does not parse as an IP contributes nothing rather than being
+// compared as a string.
+func hostOfSnapshotAddress(addr string) string {
+	s := strings.TrimSpace(addr)
+	if s == "" {
+		return ""
+	}
+	if host, _, ok := strings.Cut(s, "/"); ok {
+		s = host
+	}
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
+}
+
+// detectInterfaceSNATPoolOverlaps reports every (pool address, interface-mode
+// egress address) coincidence in the snapshot.
+//
+// Pool addresses are compared as HOSTS. A pool member expressed as a range or
+// prefix is out of scope for this detector and is skipped rather than
+// approximated — reporting a maybe-overlap as an overlap would make the warning
+// unactionable, and this half exists to give operators a signal they can act on.
+// That limitation is stated in the warning's own text.
+func detectInterfaceSNATPoolOverlaps(snap *ConfigSnapshot) []interfaceSNATPoolOverlap {
+	if snap == nil {
+		return nil
+	}
+	candidates := interfaceSNATEgressCandidatesFromSnapshot(snap)
+	if len(candidates) == 0 {
+		return nil
+	}
+	ifaceRuleFor := make(map[string]string, len(candidates))
+	ifaceNameFor := make(map[string]string, len(candidates))
+	for addr, label := range candidates {
+		ifaceRuleFor[addr] = label
+		ifaceNameFor[addr] = label
+	}
+
+	rules := append([]SourceNATRuleSnapshot(nil), snap.SourceNAT...)
+	sort.SliceStable(rules, func(i, j int) bool { return rules[i].Name < rules[j].Name })
+
+	var out []interfaceSNATPoolOverlap
+	seen := make(map[string]struct{})
+	for _, rule := range rules {
+		if rule.InterfaceMode || len(rule.PoolAddresses) == 0 {
+			continue
+		}
+		for _, member := range rule.PoolAddresses {
+			host := hostOfSnapshotAddress(member)
+			if host == "" {
+				continue
+			}
+			if _, isCandidate := candidates[host]; !isCandidate {
+				continue
+			}
+			key := host + "\x00" + rule.Name
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, interfaceSNATPoolOverlap{
+				Address:       host,
+				Interface:     ifaceNameFor[host],
+				InterfaceRule: ifaceRuleFor[host],
+				PoolRule:      rule.Name,
+			})
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Address != out[j].Address {
+			return out[i].Address < out[j].Address
+		}
+		return out[i].PoolRule < out[j].PoolRule
+	})
+	return out
+}
+
+// reportInterfaceSNATPoolOverlaps runs the detector over a freshly built
+// snapshot, logs one warning per finding, and records the counters.
+//
+// It ALWAYS bumps the scan counter, including when nothing overlaps — that is
+// what lets a reader tell "no overlap" from "detector never ran".
+func reportInterfaceSNATPoolOverlaps(snap *ConfigSnapshot) {
+	overlaps := detectInterfaceSNATPoolOverlaps(snap)
+	snatOverlapScans.Add(1)
+	snatOverlapAddresses.Store(uint64(len(overlaps)))
+	for _, o := range overlaps {
+		slog.Warn("source-NAT pool overlaps an interface-SNAT egress address; "+
+			"two allocators can mint the same (address, port) for different flows",
+			"address", o.Address,
+			"pool_rule", o.PoolRule,
+			"interface_rule", o.InterfaceRule,
+			"issue", "#7717",
+			"note", "detection only — the pool is NOT quarantined; pool members "+
+				"expressed as ranges or prefixes are not compared")
+	}
+}

--- a/pkg/dataplane/userspace/nat_iface_pool_overlap_7717_test.go
+++ b/pkg/dataplane/userspace/nat_iface_pool_overlap_7717_test.go
@@ -1,0 +1,257 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// The egress address every fixture shares. It is what a DHCP lease or a netlink
+// event would put on the WAN unit — knowable only at snapshot build.
+const overlapEgress = "172.16.80.8"
+
+func overlapSnapshot(ifaceRule, poolRule *SourceNATRuleSnapshot, ifc InterfaceSnapshot) *ConfigSnapshot {
+	snap := &ConfigSnapshot{Interfaces: []InterfaceSnapshot{ifc}}
+	if ifaceRule != nil {
+		snap.SourceNAT = append(snap.SourceNAT, *ifaceRule)
+	}
+	if poolRule != nil {
+		snap.SourceNAT = append(snap.SourceNAT, *poolRule)
+	}
+	return snap
+}
+
+func wanUnit() InterfaceSnapshot {
+	return InterfaceSnapshot{
+		Name:            "ge-0/0/2.0",
+		Zone:            "wan",
+		RoutingInstance: "vr-blue",
+		Addresses: []InterfaceAddressSnapshot{
+			{Family: "inet", Address: overlapEgress + "/24"},
+		},
+	}
+}
+
+func ifaceModeRule() *SourceNATRuleSnapshot {
+	return &SourceNATRuleSnapshot{Name: "iface-snat", InterfaceMode: true}
+}
+
+func poolRuleOn(addrs ...string) *SourceNATRuleSnapshot {
+	return &SourceNATRuleSnapshot{Name: "pool-snat", PoolName: "P", PoolAddresses: addrs}
+}
+
+// TestInterfaceSNATPoolOverlapDetection is the three-row table.
+//
+// The MIDDLE row is the one a happy-path fixture omits and the one that matters:
+// a detector that reports an overlap on every config is worse than none, because
+// an operator learns to ignore it. The THIRD row separates "the addresses do not
+// coincide" from "there is no interface-mode rule at all" — two different reasons
+// to stay silent, and a detector that only handled the first would still warn on
+// a pure-pool config that cannot collide with anything.
+func TestInterfaceSNATPoolOverlapDetection(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		ifaceRule *SourceNATRuleSnapshot
+		poolRule  *SourceNATRuleSnapshot
+		want      int
+	}{
+		{
+			name:      "pool address IS the interface egress address",
+			ifaceRule: ifaceModeRule(),
+			poolRule:  poolRuleOn(overlapEgress),
+			want:      1,
+		},
+		{
+			name:      "pool address does NOT coincide with the egress address",
+			ifaceRule: ifaceModeRule(),
+			poolRule:  poolRuleOn("198.51.100.7"),
+			want:      0,
+		},
+		{
+			name:     "no interface-mode rule at all — nothing can collide",
+			poolRule: poolRuleOn(overlapEgress),
+			want:     0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := detectInterfaceSNATPoolOverlaps(overlapSnapshot(tc.ifaceRule, tc.poolRule, wanUnit()))
+			if len(got) != tc.want {
+				t.Fatalf("detectInterfaceSNATPoolOverlaps = %d findings %v, want %d", len(got), got, tc.want)
+			}
+			if tc.want > 0 && got[0].Address != overlapEgress {
+				t.Errorf("finding names address %q, want %q", got[0].Address, overlapEgress)
+			}
+		})
+	}
+}
+
+// TestInterfaceSNATEgressScopeMatrix covers all FOUR shapes of the derivation
+// matrix, including the wildcard row the old maps_sync.go precedent got wrong by
+// returning nothing — which understates the candidate set exactly where it is
+// widest, so an overlap goes unreported.
+//
+// Each scope is exercised BOTH matching and non-matching. A row that only tests
+// the matching value cannot tell a working constraint from one that is ignored.
+func TestInterfaceSNATEgressScopeMatrix(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rule SourceNATRuleSnapshot
+		want bool
+	}{
+		{"unscoped is a WILDCARD", SourceNATRuleSnapshot{InterfaceMode: true}, true},
+
+		{"to-zone matches", SourceNATRuleSnapshot{InterfaceMode: true, ToZone: "wan"}, true},
+		{"to-zone does not match", SourceNATRuleSnapshot{InterfaceMode: true, ToZone: "dmz"}, false},
+
+		{"to-interface matches the logical unit", SourceNATRuleSnapshot{InterfaceMode: true, ToInterface: "ge-0/0/2.0"}, true},
+		{"to-interface matches the bare physical", SourceNATRuleSnapshot{InterfaceMode: true, ToInterface: "ge-0/0/2"}, true},
+		{"to-interface does not match", SourceNATRuleSnapshot{InterfaceMode: true, ToInterface: "ge-0/0/1.0"}, false},
+
+		{"to-routing-instance matches", SourceNATRuleSnapshot{InterfaceMode: true, ToRoutingInstance: "vr-blue"}, true},
+		{"to-routing-instance does not match", SourceNATRuleSnapshot{InterfaceMode: true, ToRoutingInstance: "vr-red"}, false},
+
+		// AND-of-non-empty-constraints: one disagreeing scope excludes the
+		// interface even when another agrees.
+		{"two scopes, one disagrees", SourceNATRuleSnapshot{InterfaceMode: true, ToZone: "wan", ToRoutingInstance: "vr-red"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.rule.Name = "iface-snat"
+			snap := overlapSnapshot(&tc.rule, poolRuleOn(overlapEgress), wanUnit())
+			got := len(detectInterfaceSNATPoolOverlaps(snap)) > 0
+			if got != tc.want {
+				t.Fatalf("interface in egress scope = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestInterfaceSNATPoolOverlapStatsDistinguishUnknownFromHealthy pins the reason
+// there are TWO values instead of one gauge.
+//
+// A single "overlaps" number reads 0 both when nothing overlaps and when the
+// detector never ran. Zero is the healthy reading AND the not-wired reading, so
+// a gauge alone cannot tell an operator which one they are looking at — the same
+// ambiguity as an unguarded headroom read reporting "enormous room" at the moment
+// headroom is unknown. `scans` is what disambiguates them.
+func TestInterfaceSNATPoolOverlapStatsDistinguishUnknownFromHealthy(t *testing.T) {
+	before, _ := InterfaceSNATPoolOverlapStats()
+
+	// A CLEAN snapshot: the detector ran and found nothing.
+	reportInterfaceSNATPoolOverlaps(overlapSnapshot(ifaceModeRule(), poolRuleOn("198.51.100.7"), wanUnit()))
+	afterClean, addrsClean := InterfaceSNATPoolOverlapStats()
+	if afterClean != before+1 {
+		t.Fatalf("scans = %d, want %d — a clean scan must still count, or 'no overlap' is "+
+			"indistinguishable from 'never ran'", afterClean, before+1)
+	}
+	if addrsClean != 0 {
+		t.Fatalf("addresses = %d on a non-overlapping snapshot, want 0", addrsClean)
+	}
+
+	// An OVERLAPPING snapshot: scan count advances again and the address count
+	// becomes non-zero.
+	reportInterfaceSNATPoolOverlaps(overlapSnapshot(ifaceModeRule(), poolRuleOn(overlapEgress), wanUnit()))
+	afterDirty, addrsDirty := InterfaceSNATPoolOverlapStats()
+	if afterDirty != afterClean+1 {
+		t.Fatalf("scans = %d, want %d", afterDirty, afterClean+1)
+	}
+	if addrsDirty != 1 {
+		t.Fatalf("addresses = %d on an overlapping snapshot, want 1", addrsDirty)
+	}
+}
+
+// TestInterfaceSNATPoolOverlapSkipsNonHostPoolMembers pins the stated limitation.
+//
+// A pool member expressed as a range or prefix is NOT compared. Reporting a
+// maybe-overlap as an overlap would make the warning unactionable, and this half
+// exists to give operators a signal they can act on. The limitation is in the
+// warning's own text; this is what keeps the code honest about it.
+func TestInterfaceSNATPoolOverlapSkipsNonHostPoolMembers(t *testing.T) {
+	snap := overlapSnapshot(ifaceModeRule(), poolRuleOn("172.16.80.0/24"), wanUnit())
+	if got := detectInterfaceSNATPoolOverlaps(snap); len(got) != 0 {
+		t.Fatalf("prefix pool member produced %d findings %v; ranges/prefixes are out of "+
+			"scope for this detector and must be skipped, not approximated", len(got), got)
+	}
+	// CONTROL: the same address as a HOST member is detected, so the skip above
+	// is about the member's SHAPE and not about the address being wrong.
+	snap = overlapSnapshot(ifaceModeRule(), poolRuleOn(overlapEgress), wanUnit())
+	if got := detectInterfaceSNATPoolOverlaps(snap); len(got) != 1 {
+		t.Fatalf("control: host pool member produced %d findings, want 1", len(got))
+	}
+}
+
+// TestBuilderRunsTheOverlapDetector binds the WIRING, not the detector.
+//
+// Added because a mutation cell found the wiring unbound: deleting the
+// `reportInterfaceSNATPoolOverlaps(snap)` call from buildSnapshot red NOTHING,
+// because every other test in this file calls the detector or the reporter
+// directly. A detector that is perfect and never runs in production is the
+// defect this whole PR is about, one layer up — code that exists and does
+// nothing, with no test able to tell working from inert.
+//
+// Asserting the SCAN counter advances is the minimal statement of "the builder
+// called it", and it holds regardless of whether the config overlaps.
+func TestBuilderRunsTheOverlapDetector(t *testing.T) {
+	before, _ := InterfaceSNATPoolOverlapStats()
+	_ = mustBuildSnapshot(t, &config.Config{}, config.UserspaceConfig{}, 1, 0)
+	after, _ := InterfaceSNATPoolOverlapStats()
+	if after == before {
+		t.Fatalf("buildSnapshot did not run the overlap detector (scans stayed %d). The "+
+			"detector can be entirely correct and never execute; this is the assertion that "+
+			"notices", before)
+	}
+}
+
+// TestBuilderDetectsOverlapEndToEnd drives the REAL builder with a config whose
+// interface address is also a pool address, and asserts the detector saw it.
+//
+// The counter test above proves the builder CALLS the detector; this proves the
+// snapshot the builder produces actually carries the shape the detector reads —
+// interface addresses and pool addresses in the fields it looks at. A wiring
+// bind that only counted calls would pass even if the builder handed the
+// detector a snapshot with no interfaces in it.
+func TestBuilderDetectsOverlapEndToEnd(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0/0/2": {Name: "ge-0/0/2", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{overlapEgress + "/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"wan": {Name: "wan", Interfaces: []string{"ge-0/0/2.0"}},
+	}
+	cfg.Security.NAT.SourcePools = map[string]*config.NATPool{
+		"P": {Name: "P", Addresses: []string{overlapEgress}},
+	}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{
+			Name: "rs-iface", FromZone: "lan", ToZone: "wan",
+			Rules: []*config.NATRule{{
+				Name: "iface-snat",
+				Then: config.NATThen{Type: config.NATSource, Interface: true},
+			}},
+		},
+		{
+			Name: "rs-pool", FromZone: "lan", ToZone: "wan",
+			Rules: []*config.NATRule{{
+				Name: "pool-snat",
+				Then: config.NATThen{Type: config.NATSource, PoolName: "P"},
+			}},
+		},
+	}
+
+	snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 1, 0)
+
+	// Read through the detector rather than the counter: the counter is global
+	// and other tests in this package build snapshots too, so a value read here
+	// could have come from anywhere.
+	got := detectInterfaceSNATPoolOverlaps(snap)
+	if len(got) == 0 {
+		t.Fatalf("the builder's own snapshot shows no overlap, but %s is both the interface "+
+			"address and the pool's only member. The detector reads snapshot fields; if the "+
+			"builder does not populate them the detection never fires in production, however "+
+			"green the unit tests are", overlapEgress)
+	}
+	if got[0].Address != overlapEgress {
+		t.Errorf("overlap names %q, want %q", got[0].Address, overlapEgress)
+	}
+}


### PR DESCRIPTION
Follow-on to #7717. **Detection only** — the Go snapshot-builder half. Second of
the sequenced pair; the drain (and the quarantine that depends on it) follows.

## The gap this closes

The merged config gate (#7645) forecloses a NAT pool overlapping an
interface-mode SNAT egress address **only when that address is configured**, and
states the rest of its own scope:

> "Runtime-resolved addresses (DHCP, netlink) are deliberately out of scope here
> — foreclosing those is the snapshot-builder half of §5.7 and needs the DRAIN
> discipline behind it, because marking a pool unusable with nothing draining
> would strand live sessions."

This is that half, detecting and reporting. It derives interface-mode egress
candidates from the snapshot's **live** interface addresses using the same
four-shape matrix the config gate applies to config, reports any pool address
that coincides, and counts the scan.

## Detection only is the scope decision, not a shortcut

It does **not** set `pool_failure` and does **not** quarantine:

1. The merged gate's own sentence — quarantining with nothing draining strands
   live sessions.
2. **A wired-but-disabled quarantine cannot be mutation-tested, because nothing
   makes it fire.** It would ship as an unguarded path whose correctness rests
   on review, and sit that way until the drain lands. That is the same shape as
   accepted-but-never-read config knobs: code that exists and does nothing,
   where no test can distinguish working from inert.

The quarantine ships **with** the drain, in one change, where a cell can make it
fire.

## Timing correction

The framing for this half had been "commit-time". It runs at **snapshot build**.
A runtime-learned address is unknown at commit time *by definition* — which is
exactly the gap #7645 left, so a commit-time check cannot close it. DHCP address
changes trigger a full recompile, so a lease that creates an overlap is detected
on the rebuild it causes.

## The warning owes a three-row table

| Row | Config | Warns? |
|---|---|---|
| 1 | pool address **is** the interface egress address | **yes** |
| 2 | pool address does **not** coincide | no |
| 3 | **no interface-mode rule at all** | no |

Row 2 is the one a happy-path fixture omits — a detector that warns on every
config is worse than none, because operators learn to ignore it. Row 3 separates
two different reasons to stay silent; without it a pure-pool config that cannot
collide with anything would still warn.

## The counter distinguishes "no overlap" from "detector never ran"

Two values, not one gauge. Zero overlaps is **both** the healthy reading and the
never-wired reading, so a gauge alone cannot tell an operator which they are
looking at — the same ambiguity as an unguarded headroom read reporting
"enormous room" at the moment headroom is unknown. A clean scan still increments
`scans`, and a test pins exactly that.

## Scope matrix — all four shapes, each tested both ways

Wildcard (no to-side scope), to-zone, to-interface (logical **and** bare
physical), to-routing-instance — each with a matching *and* a non-matching case,
plus an AND-of-constraints row where one of two scopes disagrees. A row that
only tests the matching value cannot tell a working constraint from an ignored
one.

The wildcard row is the one the old `maps_sync.go` precedent got wrong by
returning nothing, which understates the candidate set exactly where it is
widest — so an overlap goes unreported.

## Stated limitation, and it is tested

Pool members expressed as ranges or prefixes are **skipped, not approximated** —
a maybe-overlap reported as an overlap makes the warning unactionable. The test
pairs the skip with a **control** on the same address as a host member, so the
skip is demonstrably about the member's *shape* and not about the address.

## Mutation matrix

Fix committed before mutating. One mutation per cell, `go test ./pkg/...`, tree
restored between cells, runner refuses to score a cell whose mutation did not
change the file (md5 before/after).

| # | Mutation | Named RED |
|---|---|---|
| M1 | detector returns nil | 4 |
| M2 | clean scan does not count | 1 — the counter-disambiguation test |
| M3 | unscoped rule is not a wildcard (the `maps_sync.go` error) | 4 |
| M4 | to-routing-instance no longer constrains | 1 — the scope matrix |
| M5 | prefix members approximated instead of skipped | 4 |
| M6 | **builder never calls the detector** | **0 → then 1** (see below) |

### M6 found the wiring unbound, and it is this PR's own defect one layer up

Deleting `reportInterfaceSNATPoolOverlaps(snap)` from `buildSnapshot` **red
nothing** — every test called the detector or the reporter directly. A detector
that is entirely correct and never executes would have shipped green: *code that
exists and does nothing, where no test can distinguish working from inert*, which
is the exact reason detection-only was the right scope, arriving as a defect in
my own change.

Closed with two binds, because one is not enough:
- the scan counter must advance across a real `buildSnapshot` — **the builder
  called it**;
- a real config whose interface address is also its pool address must produce a
  finding from the builder's **own snapshot** — **the builder populates the
  fields the detector reads**.

The first alone would pass even if the builder handed the detector an empty
snapshot. M6 now reds `TestBuilderRunsTheOverlapDetector` by name.

## Validation

Gated head `88c013143` (`origin/master` merged in, not rebased; clean).

- `go test ./... -count=1`: **rc=0**, 68 packages
- `cargo test --release --bins --tests -- --test-threads=1`: **4796 collected, 0 failed**
