### PR TITLE
cli: tell the operator when a zone's counters are unavailable

### DIFF
--- a/cmd/cli/show_security.go
+++ b/cmd/cli/show_security.go
@@ -7,6 +7,7 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 	"github.com/psaab/xpf/pkg/policymatch"
+	"github.com/psaab/xpf/pkg/zonecounters"
 )
 
 // isPolicyFilterKeyword reports whether tok is a leading `show security
@@ -257,11 +258,7 @@ func (c *ctl) showZones() error {
 		}) {
 			fmt.Println(line)
 		}
-		if z.IngressPackets > 0 || z.EgressPackets > 0 {
-			fmt.Println("  Traffic statistics:")
-			fmt.Printf("    Input:  %d packets, %d bytes\n", z.IngressPackets, z.IngressBytes)
-			fmt.Printf("    Output: %d packets, %d bytes\n", z.EgressPackets, z.EgressBytes)
-		}
+		renderZoneTraffic6895(z)
 
 		// #3683 (M01): render all THREE policy tiers the runtime evaluates, in
 		// order — zone-pair, applicable global, then the effective
@@ -766,4 +763,60 @@ func (c *ctl) showPoliciesBrief() error {
 		}
 	}
 	return nil
+}
+
+// renderZoneTraffic6895 prints a zone's traffic section from the structured
+// GetZones reply (#6895).
+//
+// WHAT WAS WRONG. The old body was `if z.IngressPackets > 0 || z.EgressPackets
+// > 0`, so the section was omitted whenever both counts were zero — and the
+// wire carried no way to tell a real zero from the absence of a reading. A zone
+// whose counters are unavailable therefore rendered identically to an idle one:
+// SILENCE, which an operator reads as "this zone has no traffic". That is a
+// wrong answer, not a missing one, and it is the surface an operator is most
+// likely holding. With 64+ zones, slot exhaustion means the overflowed zones are
+// exactly the ones that render as idle.
+//
+// WHAT THIS DOES AND DOES NOT FIX. It converts that wrong answer into an honest
+// one. It does NOT distinguish an idle zone from an unavailable one, and no
+// surface does: the helper's status snapshot is sparse and omits all-zero rows,
+// so a pre-#3651 helper, a zone past hot-path slot capacity and a merely idle
+// zone are indistinguishable at the source. The ambiguity is INHERITED, and the
+// shared line says so in as many words rather than naming a cause it cannot
+// know. The one case that IS knowable and actionable — the helper reporting
+// slot overflow — gets its own line via the same shared helper the local CLI
+// and the gRPC text renderer use.
+//
+// UNKNOWN RENDERS EXACTLY AS BEFORE #6895. An old server omits the field, which
+// decodes to UNKNOWN, and this falls back to the historical
+// omit-when-both-zero. That is the whole reason the wire field is a three-state
+// enum instead of a bool: a bool has no absence to observe, so either polarity
+// would make a version-skewed pair produce a NEW wrong answer — every zone
+// reported unavailable, or an unpopulated zone reported as a real 0.
+func renderZoneTraffic6895(z *pb.ZoneInfo) {
+	if z == nil {
+		return
+	}
+	switch z.PerZoneCounterAvailability {
+	case pb.ZoneCounterAvailability_ZONE_COUNTER_AVAILABILITY_UNAVAILABLE:
+		// The server told us it had no reading. Say so, with the same wording
+		// every other surface uses. The overflow specialisation is decided
+		// server-side in the text renderer; here the generic line is correct,
+		// because this reply carries no overflow bit.
+		fmt.Println(zonecounters.UnavailableLine(false))
+	case pb.ZoneCounterAvailability_ZONE_COUNTER_AVAILABILITY_AVAILABLE:
+		// A real reading, INCLUDING a zero one — print it rather than omitting,
+		// so "the server measured zero" is visibly different from "the server
+		// had nothing to measure".
+		fmt.Println("  Traffic statistics:")
+		fmt.Printf("    Input:  %d packets, %d bytes\n", z.IngressPackets, z.IngressBytes)
+		fmt.Printf("    Output: %d packets, %d bytes\n", z.EgressPackets, z.EgressBytes)
+	default:
+		// UNKNOWN: an old server. Historical behaviour, byte for byte.
+		if z.IngressPackets > 0 || z.EgressPackets > 0 {
+			fmt.Println("  Traffic statistics:")
+			fmt.Printf("    Input:  %d packets, %d bytes\n", z.IngressPackets, z.IngressBytes)
+			fmt.Printf("    Output: %d packets, %d bytes\n", z.EgressPackets, z.EgressBytes)
+		}
+	}
 }

--- a/cmd/cli/zone_counters_available_6895_test.go
+++ b/cmd/cli/zone_counters_available_6895_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"github.com/psaab/xpf/pkg/zonecounters"
+)
+
+// zone_counters_available_6895_test.go — #6895.
+//
+// The remote cli omitted the traffic section whenever both packet counts were
+// zero, and the wire carried no way to tell a real zero from the absence of a
+// reading. So a zone whose counters are UNAVAILABLE rendered identically to an
+// idle one: silence, which an operator reads as "this zone has no traffic" — a
+// wrong answer, not a missing one, on the surface an operator is most likely
+// holding.
+//
+// WHAT THESE CELLS DO NOT CLAIM. They do not show idle being distinguished from
+// unavailable, because nothing distinguishes those: the helper's status
+// snapshot is sparse and OMITS ALL-ZERO ROWS, so a pre-#3651 helper, a zone past
+// hot-path slot capacity and a merely idle zone all reach the same sentinel.
+// The ambiguity is inherited. What changes is that the surface now SAYS it has
+// no reading instead of implying zero traffic.
+
+func renderZone6895(t *testing.T, z *pb.ZoneInfo) string {
+	t.Helper()
+	return captureStdout(t, func() { renderZoneTraffic6895(z) })
+}
+
+func TestUnavailableCountersAreLabelled6895(t *testing.T) {
+	out := renderZone6895(t, &pb.ZoneInfo{
+		Name:                       "dmz",
+		PerZoneCounterAvailability: pb.ZoneCounterAvailability_ZONE_COUNTER_AVAILABILITY_UNAVAILABLE,
+	})
+
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("a zone with UNAVAILABLE counters rendered SILENCE — indistinguishable " +
+			"from an idle zone, which is the defect (#6895)")
+	}
+	// It must be the ONE canonical line every surface uses, not a third
+	// spelling of the same state.
+	if want := zonecounters.UnavailableLine(false); !strings.Contains(out, want) {
+		t.Fatalf("the remote cli does not use the shared canonical line.\ngot:  %q\nwant: %q",
+			out, want)
+	}
+	// And it must NOT print numbers, which would be the misleading zero.
+	if strings.Contains(out, "packets") {
+		t.Fatalf("an unavailable zone rendered packet counts: %q", out)
+	}
+}
+
+// TestAvailableZeroIsPrintedNotOmitted6895 is the defensive case, and it is
+// labelled as such deliberately.
+//
+// `available && zero` is essentially UNREACHABLE in production — the helper
+// omits all-zero rows, so a zone with no traffic yields the not-populated
+// sentinel rather than a zero reading. This cell therefore does NOT demonstrate
+// "an idle zone now shows 0 packets"; asserting that would be asserting a state
+// the data source cannot produce. It pins the renderer's contract: if the server
+// ever DOES report a reading of zero, that is an answer and must be shown, not
+// silently dropped the way the pre-#6895 `> 0` test dropped it.
+func TestAvailableZeroIsPrintedNotOmitted6895(t *testing.T) {
+	out := renderZone6895(t, &pb.ZoneInfo{
+		Name:                       "trust",
+		PerZoneCounterAvailability: pb.ZoneCounterAvailability_ZONE_COUNTER_AVAILABILITY_AVAILABLE,
+	})
+
+	if !strings.Contains(out, "Traffic statistics:") {
+		t.Fatalf("an AVAILABLE reading of zero was omitted — the renderer still gates on "+
+			"the counts being non-zero, so a measured zero is indistinguishable from "+
+			"no measurement: %q", out)
+	}
+	if !strings.Contains(out, "Input:  0 packets, 0 bytes") {
+		t.Fatalf("expected an explicit zero reading: %q", out)
+	}
+}
+
+func TestAvailableNonZeroRenders6895(t *testing.T) {
+	out := renderZone6895(t, &pb.ZoneInfo{
+		Name:                       "untrust",
+		PerZoneCounterAvailability: pb.ZoneCounterAvailability_ZONE_COUNTER_AVAILABILITY_AVAILABLE,
+		IngressPackets:             12, IngressBytes: 3400,
+		EgressPackets: 7, EgressBytes: 900,
+	})
+	for _, want := range []string{"Input:  12 packets, 3400 bytes", "Output: 7 packets, 900 bytes"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in %q", want, out)
+		}
+	}
+	if strings.Contains(out, "not available") {
+		t.Fatalf("a zone with real counters was labelled unavailable: %q", out)
+	}
+}
+
+// TestOldServerRendersExactlyAsBefore6895 is the VERSION-SKEW cell, and it is
+// the only one that can catch a polarity change.
+//
+// proto3 has no field presence for scalars. Had this been a `bool
+// per_zone_counters_available`, an OLD server's omitted field would decode to
+// `false` on a new client and EVERY zone — including ones with real counters —
+// would render "not available". The inverted spelling has the mirror-image
+// defect: absent decodes to "available" and an unpopulated zone renders as a
+// real 0. Both introduce a new wrong answer through the fix for a wrong answer.
+//
+// UNKNOWN = 0 makes the benign case the default BY CONSTRUCTION. A message with
+// the field absent must render byte-for-byte as it did before #6895.
+func TestOldServerRendersExactlyAsBefore6895(t *testing.T) {
+	// An old server sends no availability field at all: the zero value.
+	oldServerIdle := &pb.ZoneInfo{Name: "dmz"}
+	if oldServerIdle.PerZoneCounterAvailability !=
+		pb.ZoneCounterAvailability_ZONE_COUNTER_AVAILABILITY_UNKNOWN {
+		t.Fatal("precondition: an absent field must decode to UNKNOWN, or this cell " +
+			"cannot model a skewed pair")
+	}
+
+	// Pre-#6895 behaviour with both counts zero: the section is OMITTED.
+	if got := strings.TrimSpace(renderZone6895(t, oldServerIdle)); got != "" {
+		t.Fatalf("an OLD server's zero-count zone now renders %q — a new wrong answer "+
+			"introduced by the fix. UNKNOWN must render exactly as before #6895", got)
+	}
+
+	// Pre-#6895 behaviour with real counts: the section is PRINTED.
+	oldServerBusy := &pb.ZoneInfo{Name: "untrust", IngressPackets: 5, IngressBytes: 60}
+	out := renderZone6895(t, oldServerBusy)
+	if !strings.Contains(out, "Input:  5 packets, 60 bytes") {
+		t.Fatalf("an OLD server's zone with real counters lost its numbers: %q", out)
+	}
+	if strings.Contains(out, "not available") {
+		t.Fatalf("an OLD server's zone with real counters was labelled unavailable — "+
+			"this is exactly what a `bool ..._available` would have done to every "+
+			"zone: %q", out)
+	}
+}
+
+// TestAllSurfacesShareOneSpelling6895 binds the AGREEMENT rather than pinning a
+// literal in each surface.
+//
+// Three surfaces report this one dataplane state. Before #6895 the generic
+// sentence was duplicated verbatim in two of them with nothing binding them, and
+// checking that agreement is what surfaced a real gap: the gRPC text renderer
+// had NO #6845 overflow specialisation while the local CLI did, so the same
+// cluster reported slot exhaustion on one surface and the generic line on the
+// other. Asserting a literal here would re-encode the duplication this removes.
+func TestAllSurfacesShareOneSpelling6895(t *testing.T) {
+	generic := zonecounters.UnavailableLine(false)
+	overflow := zonecounters.UnavailableLine(true)
+
+	if generic == overflow {
+		t.Fatal("the overflow specialisation is not distinct from the generic line, so " +
+			"the one actionable cause reads identically to the ambiguous ones (#6845)")
+	}
+	// The generic line must keep admitting the ambiguity it cannot resolve —
+	// naming a single cause would be a guess (see maps_counters.go).
+	if !strings.Contains(generic, "idle") {
+		t.Fatalf("the generic line stopped admitting that an idle zone is one of the "+
+			"indistinguishable causes; it must not name a cause it cannot know: %q",
+			generic)
+	}
+	// The overflow line must name the actionable cause.
+	if !strings.Contains(overflow, "EXHAUSTED") {
+		t.Fatalf("the overflow line does not name slot exhaustion, the one cause that "+
+			"needs operator action: %q", overflow)
+	}
+	// And the remote cli must emit the shared generic line verbatim.
+	out := renderZone6895(t, &pb.ZoneInfo{
+		PerZoneCounterAvailability: pb.ZoneCounterAvailability_ZONE_COUNTER_AVAILABILITY_UNAVAILABLE,
+	})
+	if !strings.Contains(out, generic) {
+		t.Fatalf("the remote cli emits a spelling of its own rather than the shared "+
+			"line:\ngot:  %q\nwant: %q", out, generic)
+	}
+}

--- a/docs/log/6895.md
+++ b/docs/log/6895.md
@@ -1,0 +1,46 @@
+# #6895 — the remote CLI cannot distinguish an idle zone from one whose counters are unavailable
+
+- **Timestamp**: 2026-08-27
+  - **Verified the precedent before mirroring it, and the check changed the fix.**
+    The issue treats REST's `PerZoneCountersAvailable` as the discriminator. It
+    is not: `pkg/dataplane/maps_counters.go` says the helper's status snapshot
+    "is sparse and omits all-zero rows, so the sentinel covers a pre-#3651
+    helper, a zone past the helper's hot-path slot capacity, and a merely idle
+    zone alike". So idle → `ErrCounterNotPopulated` → `available=false`. REST
+    conflates them; the local CLI and gRPC text renderer conflate them too and
+    say so honestly ("…or the zone is idle"). **The conflation is at the DATA
+    SOURCE, not the renderer.**
+  - **What the fix therefore claims, and what it does not.** It converts a WRONG
+    answer into an HONEST one: the remote CLI rendered silence, which reads as
+    "this zone has no traffic"; it now prints the same explicit labelled line the
+    other surfaces use. It does NOT distinguish idle from unavailable — that
+    ambiguity is inherited. The one knowable, actionable cause (helper reports
+    slot overflow, #6845) gets its own line.
+  - **`available && zero` is essentially unreachable** in production, so the
+    renderer handles it defensively but no cell claims it demonstrates
+    idle-vs-unavailable — that would be asserting a state the data source cannot
+    produce.
+  - **Wire shape: a three-state enum, not a bool, decided by measurement.**
+    proto3 has no field presence for scalars, so `bool per_zone_counters_available`
+    from an OLD server decodes to false and a new client labels EVERY zone
+    unavailable, including ones with real counters; the inverted spelling has the
+    mirror defect (an unpopulated zone renders as a real 0). `ZONE_COUNTER_
+    AVAILABILITY_UNKNOWN = 0` makes the benign case the default BY CONSTRUCTION —
+    a skewed pair renders exactly as before #6895. Bound by a cell that decodes
+    the field ABSENT.
+  - **Found and fixed a pre-existing divergence while checking for a third
+    spelling**: the local CLI had the #6845 overflow specialisation and the gRPC
+    text renderer did NOT, so one cluster reported slot exhaustion on one surface
+    and the generic three-cause line on the other. All three surfaces now route
+    through one canonical helper.
+  - **The canonical prose lives in a dependency-free leaf, `pkg/zonecounters`,
+    not in `pkg/dataplane`.** The natural home is beside the sentinel it
+    describes, but the #1451 retirement-boundary canary deliberately keeps
+    `cmd/cli` free of root `pkg/dataplane` — the remote cli speaks gRPC and must
+    not link the dataplane. The canary caught my first attempt. Adding an
+    allowlist entry to share two strings would weaken an intentional boundary for
+    a presentation concern.
+  - **File(s)**: proto/xpf/v1/xpf.proto, pkg/grpcapi/xpfv1/xpf.pb.go (regenerated),
+    pkg/grpcapi/server_show_zones.go, pkg/grpcapi/server_show_zones_text.go,
+    pkg/cli/cli_show_security_zones.go, cmd/cli/show_security.go,
+    pkg/zonecounters/zonecounters.go

--- a/pkg/cli/cli_show_security_zones.go
+++ b/pkg/cli/cli_show_security_zones.go
@@ -10,6 +10,7 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
 	"github.com/psaab/xpf/pkg/policymatch"
+	"github.com/psaab/xpf/pkg/zonecounters"
 )
 
 func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone string) error {
@@ -104,18 +105,8 @@ func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone strin
 				// nothing. The generic line stays for the other two causes,
 				// because with no overflow they remain genuinely ambiguous and
 				// naming one would be a guess.
-				if zoneCounterOverflowActive(c) {
-					fmt.Println("  Traffic statistics: not available " +
-						"(the dataplane's per-zone hot-path slot capacity is " +
-						"EXHAUSTED, so this zone's traffic is not being counted " +
-						"at all; reduce the number of configured zones or accept " +
-						"that zones past the capacity go uncounted)")
-				} else {
-					fmt.Println("  Traffic statistics: not available " +
-						"(no per-zone volume published for this zone: helper predates " +
-						"per-zone accounting, the zone exceeded the dataplane's " +
-						"hot-path slot capacity, or the zone is idle)")
-				}
+				// #6895: one canonical spelling for all three surfaces.
+				fmt.Println(zonecounters.UnavailableLine(zoneCounterOverflowActive(c)))
 			case errIn == nil && errOut == nil:
 				fmt.Println("  Traffic statistics:")
 				fmt.Printf("    Input:  %d packets, %d bytes\n",

--- a/pkg/grpcapi/server_show_zones.go
+++ b/pkg/grpcapi/server_show_zones.go
@@ -105,6 +105,13 @@ func (s *Server) GetZones(_ context.Context, _ *pb.GetZonesRequest) (*pb.GetZone
 						// Leave the counter fields unset (proto3 omit) rather
 						// than Internal-erroring the RPC on the structural
 						// stable-hash-id OOB.
+						//
+						// #6895: SAY SO on the wire. Before this the client saw
+						// four zeros and could not tell them from a real reading
+						// of zero, so the remote cli omitted the section and an
+						// unavailable zone rendered exactly like an idle one.
+						zi.PerZoneCounterAvailability =
+							pb.ZoneCounterAvailability_ZONE_COUNTER_AVAILABILITY_UNAVAILABLE
 					case errIn != nil:
 						if readErr == nil {
 							readErr = errIn
@@ -114,6 +121,9 @@ func (s *Server) GetZones(_ context.Context, _ *pb.GetZonesRequest) (*pb.GetZone
 							readErr = errOut
 						}
 					default:
+						// #6895: an actual reading, even if it is zero.
+						zi.PerZoneCounterAvailability =
+							pb.ZoneCounterAvailability_ZONE_COUNTER_AVAILABILITY_AVAILABLE
 						zi.IngressPackets = ing.Packets
 						zi.IngressBytes = ing.Bytes
 						zi.EgressPackets = eg.Packets

--- a/pkg/grpcapi/server_show_zones_text.go
+++ b/pkg/grpcapi/server_show_zones_text.go
@@ -331,10 +331,16 @@ func (s *Server) showTestZone(req *pb.ShowTextRequest, cfg *config.Config, buf *
 // Read only on the branch that has already decided the zone is unpopulated, so
 // it costs nothing on the healthy path.
 func (s *Server) zoneCounterOverflowActive() bool {
-	if s == nil || s.dp == nil {
+	if s == nil {
 		return false
 	}
-	provider, ok := s.dp.(interface {
+	// #2114: probe through dpProbe(), NEVER the stored dp field. Under the live
+	// indirection an assertion on the field answers "capability absent" for a
+	// perfectly HEALTHY backend that implements it — here that would silently
+	// suppress the #6845 overflow line and leave the operator reading the
+	// generic three-cause message on a cluster whose slot table really has
+	// overflowed. The daemon_dp_probe_canary_test.go guard caught exactly that.
+	provider, ok := s.dpProbe().(interface {
 		Status() (dpuserspace.ProcessStatus, error)
 	})
 	if !ok {

--- a/pkg/grpcapi/server_show_zones_text.go
+++ b/pkg/grpcapi/server_show_zones_text.go
@@ -16,8 +16,10 @@ import (
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 	"github.com/psaab/xpf/pkg/policymatch"
+	"github.com/psaab/xpf/pkg/zonecounters"
 )
 
 // showZonesDetail renders per-zone configuration plus dataplane traffic
@@ -94,10 +96,12 @@ func (s *Server) showZonesDetail(cfg *config.Config, buf *strings.Builder) {
 				// security zones` prints real byte counts for slotted zones and
 				// "not implemented" for overflowed ones, pointing the operator
 				// at the wrong cause.
-				buf.WriteString("  Traffic statistics: not available " +
-					"(no per-zone volume published for this zone: helper predates " +
-					"per-zone accounting, the zone exceeded the dataplane's " +
-					"hot-path slot capacity, or the zone is idle)\n")
+				// #6895: one canonical spelling for all three surfaces — and
+				// this renderer previously had NO #6845 overflow
+				// specialisation, so the same cluster reported slot exhaustion
+				// on the local CLI and the generic three-cause line here.
+				buf.WriteString(zonecounters.UnavailableLine(
+					s.zoneCounterOverflowActive()) + "\n")
 			case errIn == nil && errOut == nil:
 				buf.WriteString("  Traffic statistics:\n")
 				fmt.Fprintf(buf, "    Input:  %d packets, %d bytes\n", ingress.Packets, ingress.Bytes)
@@ -311,4 +315,34 @@ func (s *Server) showTestZone(req *pb.ShowTextRequest, cfg *config.Config, buf *
 		}
 	}
 	return &pb.ShowTextResponse{Output: buf.String()}, nil
+}
+
+// zoneCounterOverflowActive reports whether the dataplane says its per-zone
+// hot-path slot table has OVERFLOWED (#6845), mirroring the local CLI's probe of
+// the same bit so the two surfaces cannot disagree about a cluster's state.
+//
+// FAILS TO FALSE on any error, deliberately and for the same reason the CLI
+// does: the caller uses it to REPLACE a truthful three-cause message with a
+// specific one-cause message, so a wrong true would send the operator to reduce
+// their zone count when the real cause might be an idle zone. An unreachable
+// helper means "cannot say", and "cannot say" must fall back to the honest
+// ambiguous line rather than guess.
+//
+// Read only on the branch that has already decided the zone is unpopulated, so
+// it costs nothing on the healthy path.
+func (s *Server) zoneCounterOverflowActive() bool {
+	if s == nil || s.dp == nil {
+		return false
+	}
+	provider, ok := s.dp.(interface {
+		Status() (dpuserspace.ProcessStatus, error)
+	})
+	if !ok {
+		return false
+	}
+	status, err := provider.Status()
+	if err != nil {
+		return false
+	}
+	return status.ZoneCounterOverflowActive
 }

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -177,6 +177,77 @@ func (MonitorInterfaceSummaryMode) EnumDescriptor() ([]byte, []int) {
 	return file_xpf_proto_rawDescGZIP(), []int{2}
 }
 
+// ZoneCounterAvailability reports whether the server had a per-zone traffic
+// reading for a zone, so a client can tell a real counter from the absence of
+// one (#6895).
+//
+// UNKNOWN IS 0 ON PURPOSE, and it is the whole point of this being an enum
+// rather than a bool. proto3 has no field presence for scalars: a `bool
+// per_zone_counters_available` sent by an OLD server decodes to `false` on a new
+// client, which is indistinguishable from the server saying "unavailable" — so
+// every zone from an old server, including ones with real counters, would render
+// as unavailable. The inverted spelling has the mirror-image defect: absent
+// decodes to "available" and an unpopulated zone renders as a real 0.
+//
+// With UNKNOWN = 0 the skewed pair is honest by construction: a new client
+// talking to an old server sees UNKNOWN and renders exactly as it did before
+// #6895, introducing no new wrong answer in either direction.
+type ZoneCounterAvailability int32
+
+const (
+	// The server did not say. An old server omits the field entirely and it
+	// decodes here. Clients MUST fall back to their pre-#6895 rendering.
+	ZoneCounterAvailability_ZONE_COUNTER_AVAILABILITY_UNKNOWN ZoneCounterAvailability = 0
+	// The server read live per-zone volume; the counter fields are real.
+	ZoneCounterAvailability_ZONE_COUNTER_AVAILABILITY_AVAILABLE ZoneCounterAvailability = 1
+	// The dataplane published no per-zone volume for this zone, so the counter
+	// fields are meaningless zeros. Note this does NOT isolate an idle zone: the
+	// helper's status snapshot omits all-zero rows, so a pre-#3651 helper, a zone
+	// past hot-path slot capacity, and a merely idle zone all land here.
+	ZoneCounterAvailability_ZONE_COUNTER_AVAILABILITY_UNAVAILABLE ZoneCounterAvailability = 2
+)
+
+// Enum value maps for ZoneCounterAvailability.
+var (
+	ZoneCounterAvailability_name = map[int32]string{
+		0: "ZONE_COUNTER_AVAILABILITY_UNKNOWN",
+		1: "ZONE_COUNTER_AVAILABILITY_AVAILABLE",
+		2: "ZONE_COUNTER_AVAILABILITY_UNAVAILABLE",
+	}
+	ZoneCounterAvailability_value = map[string]int32{
+		"ZONE_COUNTER_AVAILABILITY_UNKNOWN":     0,
+		"ZONE_COUNTER_AVAILABILITY_AVAILABLE":   1,
+		"ZONE_COUNTER_AVAILABILITY_UNAVAILABLE": 2,
+	}
+)
+
+func (x ZoneCounterAvailability) Enum() *ZoneCounterAvailability {
+	p := new(ZoneCounterAvailability)
+	*p = x
+	return p
+}
+
+func (x ZoneCounterAvailability) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ZoneCounterAvailability) Descriptor() protoreflect.EnumDescriptor {
+	return file_xpf_proto_enumTypes[3].Descriptor()
+}
+
+func (ZoneCounterAvailability) Type() protoreflect.EnumType {
+	return &file_xpf_proto_enumTypes[3]
+}
+
+func (x ZoneCounterAvailability) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ZoneCounterAvailability.Descriptor instead.
+func (ZoneCounterAvailability) EnumDescriptor() ([]byte, []int) {
+	return file_xpf_proto_rawDescGZIP(), []int{3}
+}
+
 // HostInboundAdmissionStatus classifies how the ingress zone's
 // host-inbound-traffic admission gate treats a host-bound query tuple (#3627
 // B1a). It mirrors dataplane/userspace.HostInboundStatus. Presence-safe so the
@@ -243,11 +314,11 @@ func (x HostInboundAdmissionStatus) String() string {
 }
 
 func (HostInboundAdmissionStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_xpf_proto_enumTypes[3].Descriptor()
+	return file_xpf_proto_enumTypes[4].Descriptor()
 }
 
 func (HostInboundAdmissionStatus) Type() protoreflect.EnumType {
-	return &file_xpf_proto_enumTypes[3]
+	return &file_xpf_proto_enumTypes[4]
 }
 
 func (x HostInboundAdmissionStatus) Number() protoreflect.EnumNumber {
@@ -256,7 +327,7 @@ func (x HostInboundAdmissionStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use HostInboundAdmissionStatus.Descriptor instead.
 func (HostInboundAdmissionStatus) EnumDescriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{3}
+	return file_xpf_proto_rawDescGZIP(), []int{4}
 }
 
 type NATDeterministicDirection int32
@@ -294,11 +365,11 @@ func (x NATDeterministicDirection) String() string {
 }
 
 func (NATDeterministicDirection) Descriptor() protoreflect.EnumDescriptor {
-	return file_xpf_proto_enumTypes[4].Descriptor()
+	return file_xpf_proto_enumTypes[5].Descriptor()
 }
 
 func (NATDeterministicDirection) Type() protoreflect.EnumType {
-	return &file_xpf_proto_enumTypes[4]
+	return &file_xpf_proto_enumTypes[5]
 }
 
 func (x NATDeterministicDirection) Number() protoreflect.EnumNumber {
@@ -307,7 +378,7 @@ func (x NATDeterministicDirection) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use NATDeterministicDirection.Descriptor instead.
 func (NATDeterministicDirection) EnumDescriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{4}
+	return file_xpf_proto_rawDescGZIP(), []int{5}
 }
 
 // PeerFetchStatus classifies whether a summary response's cluster-peer leg was
@@ -354,11 +425,11 @@ func (x PeerFetchStatus) String() string {
 }
 
 func (PeerFetchStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_xpf_proto_enumTypes[5].Descriptor()
+	return file_xpf_proto_enumTypes[6].Descriptor()
 }
 
 func (PeerFetchStatus) Type() protoreflect.EnumType {
-	return &file_xpf_proto_enumTypes[5]
+	return &file_xpf_proto_enumTypes[6]
 }
 
 func (x PeerFetchStatus) Number() protoreflect.EnumNumber {
@@ -367,7 +438,7 @@ func (x PeerFetchStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use PeerFetchStatus.Descriptor instead.
 func (PeerFetchStatus) EnumDescriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{5}
+	return file_xpf_proto_rawDescGZIP(), []int{6}
 }
 
 type EnterConfigureRequest struct {
@@ -2138,8 +2209,15 @@ type ZoneInfo struct {
 	// silent bypass. Sorted, deduplicated; empty for a zone with no lifeline
 	// member. VISIBILITY only — the exemption semantics are unchanged.
 	LifelineInterfaces []string `protobuf:"bytes,16,rep,name=lifeline_interfaces,json=lifelineInterfaces,proto3" json:"lifeline_interfaces,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// per_zone_counter_availability (#6895) tells the client whether the four
+	// counter fields above are a real reading or the absence of one. Before it,
+	// the remote cli omitted the traffic section whenever both packet counts were
+	// zero, so a zone whose counters are unavailable rendered identically to an
+	// idle one — silence that reads as "no traffic", which is a wrong answer
+	// rather than a missing one.
+	PerZoneCounterAvailability ZoneCounterAvailability `protobuf:"varint,17,opt,name=per_zone_counter_availability,json=perZoneCounterAvailability,proto3,enum=xpf.v1.ZoneCounterAvailability" json:"per_zone_counter_availability,omitempty"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *ZoneInfo) Reset() {
@@ -2282,6 +2360,13 @@ func (x *ZoneInfo) GetLifelineInterfaces() []string {
 		return x.LifelineInterfaces
 	}
 	return nil
+}
+
+func (x *ZoneInfo) GetPerZoneCounterAvailability() ZoneCounterAvailability {
+	if x != nil {
+		return x.PerZoneCounterAvailability
+	}
+	return ZoneCounterAvailability_ZONE_COUNTER_AVAILABILITY_UNKNOWN
 }
 
 // InterfaceHostInbound (#3328, #3362) is a per-interface host-inbound-traffic
@@ -4118,10 +4203,19 @@ type EventEntry struct {
 	// did not carry the field (e.g. a non-close event, or no NAT applied).
 	NatSrcAddr string `protobuf:"bytes,21,opt,name=nat_src_addr,json=natSrcAddr,proto3" json:"nat_src_addr,omitempty"` // post-NAT source "ip:port" ("" = no NAT)
 	NatDstAddr string `protobuf:"bytes,22,opt,name=nat_dst_addr,json=natDstAddr,proto3" json:"nat_dst_addr,omitempty"` // post-NAT destination "ip:port"
-	// Node-local dataplane session id (the #4915 [152:160] ringbuf slot): unique
-	// within this node, but NOT the same on both cluster nodes (#6198). Use it to
-	// correlate this event with `show security flow session` on THIS node; it is
-	// not a cross-node key.
+	// Dataplane session id (the #4915 [152:160] ringbuf slot).
+	//
+	// CROSS-NODE STABLE (#5212): a peer-synced session ADOPTS the originating
+	// node's id, so this node's SESSION_CLOSE carries the same id as the
+	// originating node's SESSION_CREATE. That is the whole point of #5212 and it
+	// is what a SIEM correlates on across a failover.
+	//
+	// #6666 corrected this comment, which was backwards on BOTH halves: it said
+	// the id was node-local and NOT the same on both nodes (it is the same, since
+	// #5212), and it pointed at `show security flow session` on THIS node as the
+	// correlation target (which rendered a DIFFERENT, control-plane-minted id for
+	// a peer-synced session until #6666 made the mirror adopt this one). Both
+	// surfaces now render this id, so either correlation works.
 	SessionId      uint64 `protobuf:"varint,23,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	ElapsedTime    uint32 `protobuf:"varint,24,opt,name=elapsed_time,json=elapsedTime,proto3" json:"elapsed_time,omitempty"`            // seconds since session creation (CLOSE)
 	Created        uint32 `protobuf:"varint,25,opt,name=created,proto3" json:"created,omitempty"`                                       // absolute session-creation Unix seconds (CLOSE)
@@ -8638,7 +8732,7 @@ const file_xpf_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\x04R\x05value:\x028\x01\"\x11\n" +
 	"\x0fGetZonesRequest\":\n" +
 	"\x10GetZonesResponse\x12&\n" +
-	"\x05zones\x18\x01 \x03(\v2\x10.xpf.v1.ZoneInfoR\x05zones\"\xb0\x05\n" +
+	"\x05zones\x18\x01 \x03(\v2\x10.xpf.v1.ZoneInfoR\x05zones\"\x94\x06\n" +
 	"\bZoneInfo\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\rR\x02id\x12%\n" +
@@ -8658,7 +8752,8 @@ const file_xpf_proto_rawDesc = "" +
 	"\x1chost_inbound_system_services\x18\r \x03(\tR\x19hostInboundSystemServices\x124\n" +
 	"\x16host_inbound_protocols\x18\x0e \x03(\tR\x14hostInboundProtocols\x12R\n" +
 	"\x16interface_host_inbound\x18\x0f \x03(\v2\x1c.xpf.v1.InterfaceHostInboundR\x14interfaceHostInbound\x12/\n" +
-	"\x13lifeline_interfaces\x18\x10 \x03(\tR\x12lifelineInterfaces\"\x9b\x01\n" +
+	"\x13lifeline_interfaces\x18\x10 \x03(\tR\x12lifelineInterfaces\x12b\n" +
+	"\x1dper_zone_counter_availability\x18\x11 \x01(\x0e2\x1f.xpf.v1.ZoneCounterAvailabilityR\x1aperZoneCounterAvailability\"\x9b\x01\n" +
 	"\x14InterfaceHostInbound\x12\x1c\n" +
 	"\tinterface\x18\x01 \x01(\tR\tinterface\x12\x1e\n" +
 	"\n" +
@@ -9185,7 +9280,11 @@ const file_xpf_proto_rawDesc = "" +
 	"&MONITOR_INTERFACE_SUMMARY_MODE_PACKETS\x10\x01\x12(\n" +
 	"$MONITOR_INTERFACE_SUMMARY_MODE_BYTES\x10\x02\x12(\n" +
 	"$MONITOR_INTERFACE_SUMMARY_MODE_DELTA\x10\x03\x12'\n" +
-	"#MONITOR_INTERFACE_SUMMARY_MODE_RATE\x10\x04*\xb4\x02\n" +
+	"#MONITOR_INTERFACE_SUMMARY_MODE_RATE\x10\x04*\x94\x01\n" +
+	"\x17ZoneCounterAvailability\x12%\n" +
+	"!ZONE_COUNTER_AVAILABILITY_UNKNOWN\x10\x00\x12'\n" +
+	"#ZONE_COUNTER_AVAILABILITY_AVAILABLE\x10\x01\x12)\n" +
+	"%ZONE_COUNTER_AVAILABILITY_UNAVAILABLE\x10\x02*\xb4\x02\n" +
 	"\x1aHostInboundAdmissionStatus\x12.\n" +
 	"*HOST_INBOUND_ADMISSION_STATUS_NOT_COMPUTED\x10\x00\x12/\n" +
 	"+HOST_INBOUND_ADMISSION_STATUS_INDETERMINATE\x10\x01\x12/\n" +
@@ -9271,288 +9370,290 @@ func file_xpf_proto_rawDescGZIP() []byte {
 	return file_xpf_proto_rawDescData
 }
 
-var file_xpf_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
+var file_xpf_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
 var file_xpf_proto_msgTypes = make([]protoimpl.MessageInfo, 127)
 var file_xpf_proto_goTypes = []any{
 	(ConfigFormat)(0),                         // 0: xpf.v1.ConfigFormat
 	(ConfigTarget)(0),                         // 1: xpf.v1.ConfigTarget
 	(MonitorInterfaceSummaryMode)(0),          // 2: xpf.v1.MonitorInterfaceSummaryMode
-	(HostInboundAdmissionStatus)(0),           // 3: xpf.v1.HostInboundAdmissionStatus
-	(NATDeterministicDirection)(0),            // 4: xpf.v1.NATDeterministicDirection
-	(PeerFetchStatus)(0),                      // 5: xpf.v1.PeerFetchStatus
-	(*EnterConfigureRequest)(nil),             // 6: xpf.v1.EnterConfigureRequest
-	(*EnterConfigureResponse)(nil),            // 7: xpf.v1.EnterConfigureResponse
-	(*ExitConfigureRequest)(nil),              // 8: xpf.v1.ExitConfigureRequest
-	(*ExitConfigureResponse)(nil),             // 9: xpf.v1.ExitConfigureResponse
-	(*GetConfigModeStatusRequest)(nil),        // 10: xpf.v1.GetConfigModeStatusRequest
-	(*GetConfigModeStatusResponse)(nil),       // 11: xpf.v1.GetConfigModeStatusResponse
-	(*SetRequest)(nil),                        // 12: xpf.v1.SetRequest
-	(*SetResponse)(nil),                       // 13: xpf.v1.SetResponse
-	(*DeleteRequest)(nil),                     // 14: xpf.v1.DeleteRequest
-	(*DeleteResponse)(nil),                    // 15: xpf.v1.DeleteResponse
-	(*LoadRequest)(nil),                       // 16: xpf.v1.LoadRequest
-	(*LoadResponse)(nil),                      // 17: xpf.v1.LoadResponse
-	(*CommitRequest)(nil),                     // 18: xpf.v1.CommitRequest
-	(*CommitResponse)(nil),                    // 19: xpf.v1.CommitResponse
-	(*CommitCheckRequest)(nil),                // 20: xpf.v1.CommitCheckRequest
-	(*CommitCheckResponse)(nil),               // 21: xpf.v1.CommitCheckResponse
-	(*CommitConfirmedRequest)(nil),            // 22: xpf.v1.CommitConfirmedRequest
-	(*CommitConfirmedResponse)(nil),           // 23: xpf.v1.CommitConfirmedResponse
-	(*ConfirmCommitRequest)(nil),              // 24: xpf.v1.ConfirmCommitRequest
-	(*ConfirmCommitResponse)(nil),             // 25: xpf.v1.ConfirmCommitResponse
-	(*RollbackRequest)(nil),                   // 26: xpf.v1.RollbackRequest
-	(*RollbackResponse)(nil),                  // 27: xpf.v1.RollbackResponse
-	(*ShowConfigRequest)(nil),                 // 28: xpf.v1.ShowConfigRequest
-	(*ShowConfigResponse)(nil),                // 29: xpf.v1.ShowConfigResponse
-	(*ShowCompareRequest)(nil),                // 30: xpf.v1.ShowCompareRequest
-	(*ShowCompareResponse)(nil),               // 31: xpf.v1.ShowCompareResponse
-	(*ShowRollbackRequest)(nil),               // 32: xpf.v1.ShowRollbackRequest
-	(*ShowRollbackResponse)(nil),              // 33: xpf.v1.ShowRollbackResponse
-	(*ListHistoryRequest)(nil),                // 34: xpf.v1.ListHistoryRequest
-	(*ListHistoryResponse)(nil),               // 35: xpf.v1.ListHistoryResponse
-	(*HistoryEntry)(nil),                      // 36: xpf.v1.HistoryEntry
-	(*GetStatusRequest)(nil),                  // 37: xpf.v1.GetStatusRequest
-	(*GetStatusResponse)(nil),                 // 38: xpf.v1.GetStatusResponse
-	(*GetGlobalStatsRequest)(nil),             // 39: xpf.v1.GetGlobalStatsRequest
-	(*GetGlobalStatsResponse)(nil),            // 40: xpf.v1.GetGlobalStatsResponse
-	(*GetZonesRequest)(nil),                   // 41: xpf.v1.GetZonesRequest
-	(*GetZonesResponse)(nil),                  // 42: xpf.v1.GetZonesResponse
-	(*ZoneInfo)(nil),                          // 43: xpf.v1.ZoneInfo
-	(*InterfaceHostInbound)(nil),              // 44: xpf.v1.InterfaceHostInbound
-	(*GetPoliciesRequest)(nil),                // 45: xpf.v1.GetPoliciesRequest
-	(*GetPoliciesResponse)(nil),               // 46: xpf.v1.GetPoliciesResponse
-	(*PolicyInfo)(nil),                        // 47: xpf.v1.PolicyInfo
-	(*PolicyRule)(nil),                        // 48: xpf.v1.PolicyRule
-	(*GetSessionsRequest)(nil),                // 49: xpf.v1.GetSessionsRequest
-	(*GetSessionsResponse)(nil),               // 50: xpf.v1.GetSessionsResponse
-	(*SessionEntry)(nil),                      // 51: xpf.v1.SessionEntry
-	(*GetSessionSummaryRequest)(nil),          // 52: xpf.v1.GetSessionSummaryRequest
-	(*GetSessionSummaryResponse)(nil),         // 53: xpf.v1.GetSessionSummaryResponse
-	(*GetNATSourceRequest)(nil),               // 54: xpf.v1.GetNATSourceRequest
-	(*GetNATSourceResponse)(nil),              // 55: xpf.v1.GetNATSourceResponse
-	(*NATSourceInfo)(nil),                     // 56: xpf.v1.NATSourceInfo
-	(*GetNATDestinationRequest)(nil),          // 57: xpf.v1.GetNATDestinationRequest
-	(*GetNATDestinationResponse)(nil),         // 58: xpf.v1.GetNATDestinationResponse
-	(*NATDestInfo)(nil),                       // 59: xpf.v1.NATDestInfo
-	(*GetScreenRequest)(nil),                  // 60: xpf.v1.GetScreenRequest
-	(*GetScreenResponse)(nil),                 // 61: xpf.v1.GetScreenResponse
-	(*ScreenInfo)(nil),                        // 62: xpf.v1.ScreenInfo
-	(*GetEventsRequest)(nil),                  // 63: xpf.v1.GetEventsRequest
-	(*GetEventsResponse)(nil),                 // 64: xpf.v1.GetEventsResponse
-	(*EventEntry)(nil),                        // 65: xpf.v1.EventEntry
-	(*GetInterfacesRequest)(nil),              // 66: xpf.v1.GetInterfacesRequest
-	(*GetInterfacesResponse)(nil),             // 67: xpf.v1.GetInterfacesResponse
-	(*InterfaceInfo)(nil),                     // 68: xpf.v1.InterfaceInfo
-	(*ShowInterfacesDetailRequest)(nil),       // 69: xpf.v1.ShowInterfacesDetailRequest
-	(*ShowInterfacesDetailResponse)(nil),      // 70: xpf.v1.ShowInterfacesDetailResponse
-	(*GetDHCPLeasesRequest)(nil),              // 71: xpf.v1.GetDHCPLeasesRequest
-	(*GetDHCPLeasesResponse)(nil),             // 72: xpf.v1.GetDHCPLeasesResponse
-	(*DHCPLeaseInfo)(nil),                     // 73: xpf.v1.DHCPLeaseInfo
-	(*DHCPDelegatedPrefix)(nil),               // 74: xpf.v1.DHCPDelegatedPrefix
-	(*GetDHCPClientIdentifiersRequest)(nil),   // 75: xpf.v1.GetDHCPClientIdentifiersRequest
-	(*GetDHCPClientIdentifiersResponse)(nil),  // 76: xpf.v1.GetDHCPClientIdentifiersResponse
-	(*DHCPClientIdentifierInfo)(nil),          // 77: xpf.v1.DHCPClientIdentifierInfo
-	(*ClearDHCPClientIdentifierRequest)(nil),  // 78: xpf.v1.ClearDHCPClientIdentifierRequest
-	(*ClearDHCPClientIdentifierResponse)(nil), // 79: xpf.v1.ClearDHCPClientIdentifierResponse
-	(*GetRoutesRequest)(nil),                  // 80: xpf.v1.GetRoutesRequest
-	(*GetRoutesResponse)(nil),                 // 81: xpf.v1.GetRoutesResponse
-	(*RouteInfo)(nil),                         // 82: xpf.v1.RouteInfo
-	(*GetOSPFStatusRequest)(nil),              // 83: xpf.v1.GetOSPFStatusRequest
-	(*GetOSPFStatusResponse)(nil),             // 84: xpf.v1.GetOSPFStatusResponse
-	(*GetBGPStatusRequest)(nil),               // 85: xpf.v1.GetBGPStatusRequest
-	(*GetBGPStatusResponse)(nil),              // 86: xpf.v1.GetBGPStatusResponse
-	(*GetRIPStatusRequest)(nil),               // 87: xpf.v1.GetRIPStatusRequest
-	(*GetRIPStatusResponse)(nil),              // 88: xpf.v1.GetRIPStatusResponse
-	(*GetISISStatusRequest)(nil),              // 89: xpf.v1.GetISISStatusRequest
-	(*GetISISStatusResponse)(nil),             // 90: xpf.v1.GetISISStatusResponse
-	(*GetIPsecSARequest)(nil),                 // 91: xpf.v1.GetIPsecSARequest
-	(*GetIPsecSAResponse)(nil),                // 92: xpf.v1.GetIPsecSAResponse
-	(*PingRequest)(nil),                       // 93: xpf.v1.PingRequest
-	(*PingResponse)(nil),                      // 94: xpf.v1.PingResponse
-	(*TracerouteRequest)(nil),                 // 95: xpf.v1.TracerouteRequest
-	(*TracerouteResponse)(nil),                // 96: xpf.v1.TracerouteResponse
-	(*ClearSessionsRequest)(nil),              // 97: xpf.v1.ClearSessionsRequest
-	(*ClearSessionsResponse)(nil),             // 98: xpf.v1.ClearSessionsResponse
-	(*ClearCountersRequest)(nil),              // 99: xpf.v1.ClearCountersRequest
-	(*ClearCountersResponse)(nil),             // 100: xpf.v1.ClearCountersResponse
-	(*GetNATPoolStatsRequest)(nil),            // 101: xpf.v1.GetNATPoolStatsRequest
-	(*GetNATPoolStatsResponse)(nil),           // 102: xpf.v1.GetNATPoolStatsResponse
-	(*NATPoolStats)(nil),                      // 103: xpf.v1.NATPoolStats
-	(*NATRuleSetSessions)(nil),                // 104: xpf.v1.NATRuleSetSessions
-	(*GetVRRPStatusRequest)(nil),              // 105: xpf.v1.GetVRRPStatusRequest
-	(*GetVRRPStatusResponse)(nil),             // 106: xpf.v1.GetVRRPStatusResponse
-	(*VRRPInstanceInfo)(nil),                  // 107: xpf.v1.VRRPInstanceInfo
-	(*MatchPoliciesRequest)(nil),              // 108: xpf.v1.MatchPoliciesRequest
-	(*MatchPoliciesResponse)(nil),             // 109: xpf.v1.MatchPoliciesResponse
-	(*HostInboundAdmission)(nil),              // 110: xpf.v1.HostInboundAdmission
-	(*GetNATRuleStatsRequest)(nil),            // 111: xpf.v1.GetNATRuleStatsRequest
-	(*GetNATRuleStatsResponse)(nil),           // 112: xpf.v1.GetNATRuleStatsResponse
-	(*NATRuleStats)(nil),                      // 113: xpf.v1.NATRuleStats
-	(*GetNATDeterministicRequest)(nil),        // 114: xpf.v1.GetNATDeterministicRequest
-	(*GetNATDeterministicResponse)(nil),       // 115: xpf.v1.GetNATDeterministicResponse
-	(*CompleteRequest)(nil),                   // 116: xpf.v1.CompleteRequest
-	(*CompleteResponse)(nil),                  // 117: xpf.v1.CompleteResponse
-	(*ShowTextRequest)(nil),                   // 118: xpf.v1.ShowTextRequest
-	(*ShowTextResponse)(nil),                  // 119: xpf.v1.ShowTextResponse
-	(*GetSystemInfoRequest)(nil),              // 120: xpf.v1.GetSystemInfoRequest
-	(*GetSystemInfoResponse)(nil),             // 121: xpf.v1.GetSystemInfoResponse
-	(*SystemActionRequest)(nil),               // 122: xpf.v1.SystemActionRequest
-	(*SystemActionResponse)(nil),              // 123: xpf.v1.SystemActionResponse
-	(*MonitorPacketDropRequest)(nil),          // 124: xpf.v1.MonitorPacketDropRequest
-	(*MonitorPacketDropResponse)(nil),         // 125: xpf.v1.MonitorPacketDropResponse
-	(*MonitorInterfaceRequest)(nil),           // 126: xpf.v1.MonitorInterfaceRequest
-	(*MonitorInterfaceResponse)(nil),          // 127: xpf.v1.MonitorInterfaceResponse
-	(*GetZonePairSummaryRequest)(nil),         // 128: xpf.v1.GetZonePairSummaryRequest
-	(*ZonePairSessionSummary)(nil),            // 129: xpf.v1.ZonePairSessionSummary
-	(*GetZonePairSummaryResponse)(nil),        // 130: xpf.v1.GetZonePairSummaryResponse
-	nil,                                       // 131: xpf.v1.GetGlobalStatsResponse.ScreenDropDetailsEntry
-	nil,                                       // 132: xpf.v1.ScreenInfo.ThresholdsEntry
+	(ZoneCounterAvailability)(0),              // 3: xpf.v1.ZoneCounterAvailability
+	(HostInboundAdmissionStatus)(0),           // 4: xpf.v1.HostInboundAdmissionStatus
+	(NATDeterministicDirection)(0),            // 5: xpf.v1.NATDeterministicDirection
+	(PeerFetchStatus)(0),                      // 6: xpf.v1.PeerFetchStatus
+	(*EnterConfigureRequest)(nil),             // 7: xpf.v1.EnterConfigureRequest
+	(*EnterConfigureResponse)(nil),            // 8: xpf.v1.EnterConfigureResponse
+	(*ExitConfigureRequest)(nil),              // 9: xpf.v1.ExitConfigureRequest
+	(*ExitConfigureResponse)(nil),             // 10: xpf.v1.ExitConfigureResponse
+	(*GetConfigModeStatusRequest)(nil),        // 11: xpf.v1.GetConfigModeStatusRequest
+	(*GetConfigModeStatusResponse)(nil),       // 12: xpf.v1.GetConfigModeStatusResponse
+	(*SetRequest)(nil),                        // 13: xpf.v1.SetRequest
+	(*SetResponse)(nil),                       // 14: xpf.v1.SetResponse
+	(*DeleteRequest)(nil),                     // 15: xpf.v1.DeleteRequest
+	(*DeleteResponse)(nil),                    // 16: xpf.v1.DeleteResponse
+	(*LoadRequest)(nil),                       // 17: xpf.v1.LoadRequest
+	(*LoadResponse)(nil),                      // 18: xpf.v1.LoadResponse
+	(*CommitRequest)(nil),                     // 19: xpf.v1.CommitRequest
+	(*CommitResponse)(nil),                    // 20: xpf.v1.CommitResponse
+	(*CommitCheckRequest)(nil),                // 21: xpf.v1.CommitCheckRequest
+	(*CommitCheckResponse)(nil),               // 22: xpf.v1.CommitCheckResponse
+	(*CommitConfirmedRequest)(nil),            // 23: xpf.v1.CommitConfirmedRequest
+	(*CommitConfirmedResponse)(nil),           // 24: xpf.v1.CommitConfirmedResponse
+	(*ConfirmCommitRequest)(nil),              // 25: xpf.v1.ConfirmCommitRequest
+	(*ConfirmCommitResponse)(nil),             // 26: xpf.v1.ConfirmCommitResponse
+	(*RollbackRequest)(nil),                   // 27: xpf.v1.RollbackRequest
+	(*RollbackResponse)(nil),                  // 28: xpf.v1.RollbackResponse
+	(*ShowConfigRequest)(nil),                 // 29: xpf.v1.ShowConfigRequest
+	(*ShowConfigResponse)(nil),                // 30: xpf.v1.ShowConfigResponse
+	(*ShowCompareRequest)(nil),                // 31: xpf.v1.ShowCompareRequest
+	(*ShowCompareResponse)(nil),               // 32: xpf.v1.ShowCompareResponse
+	(*ShowRollbackRequest)(nil),               // 33: xpf.v1.ShowRollbackRequest
+	(*ShowRollbackResponse)(nil),              // 34: xpf.v1.ShowRollbackResponse
+	(*ListHistoryRequest)(nil),                // 35: xpf.v1.ListHistoryRequest
+	(*ListHistoryResponse)(nil),               // 36: xpf.v1.ListHistoryResponse
+	(*HistoryEntry)(nil),                      // 37: xpf.v1.HistoryEntry
+	(*GetStatusRequest)(nil),                  // 38: xpf.v1.GetStatusRequest
+	(*GetStatusResponse)(nil),                 // 39: xpf.v1.GetStatusResponse
+	(*GetGlobalStatsRequest)(nil),             // 40: xpf.v1.GetGlobalStatsRequest
+	(*GetGlobalStatsResponse)(nil),            // 41: xpf.v1.GetGlobalStatsResponse
+	(*GetZonesRequest)(nil),                   // 42: xpf.v1.GetZonesRequest
+	(*GetZonesResponse)(nil),                  // 43: xpf.v1.GetZonesResponse
+	(*ZoneInfo)(nil),                          // 44: xpf.v1.ZoneInfo
+	(*InterfaceHostInbound)(nil),              // 45: xpf.v1.InterfaceHostInbound
+	(*GetPoliciesRequest)(nil),                // 46: xpf.v1.GetPoliciesRequest
+	(*GetPoliciesResponse)(nil),               // 47: xpf.v1.GetPoliciesResponse
+	(*PolicyInfo)(nil),                        // 48: xpf.v1.PolicyInfo
+	(*PolicyRule)(nil),                        // 49: xpf.v1.PolicyRule
+	(*GetSessionsRequest)(nil),                // 50: xpf.v1.GetSessionsRequest
+	(*GetSessionsResponse)(nil),               // 51: xpf.v1.GetSessionsResponse
+	(*SessionEntry)(nil),                      // 52: xpf.v1.SessionEntry
+	(*GetSessionSummaryRequest)(nil),          // 53: xpf.v1.GetSessionSummaryRequest
+	(*GetSessionSummaryResponse)(nil),         // 54: xpf.v1.GetSessionSummaryResponse
+	(*GetNATSourceRequest)(nil),               // 55: xpf.v1.GetNATSourceRequest
+	(*GetNATSourceResponse)(nil),              // 56: xpf.v1.GetNATSourceResponse
+	(*NATSourceInfo)(nil),                     // 57: xpf.v1.NATSourceInfo
+	(*GetNATDestinationRequest)(nil),          // 58: xpf.v1.GetNATDestinationRequest
+	(*GetNATDestinationResponse)(nil),         // 59: xpf.v1.GetNATDestinationResponse
+	(*NATDestInfo)(nil),                       // 60: xpf.v1.NATDestInfo
+	(*GetScreenRequest)(nil),                  // 61: xpf.v1.GetScreenRequest
+	(*GetScreenResponse)(nil),                 // 62: xpf.v1.GetScreenResponse
+	(*ScreenInfo)(nil),                        // 63: xpf.v1.ScreenInfo
+	(*GetEventsRequest)(nil),                  // 64: xpf.v1.GetEventsRequest
+	(*GetEventsResponse)(nil),                 // 65: xpf.v1.GetEventsResponse
+	(*EventEntry)(nil),                        // 66: xpf.v1.EventEntry
+	(*GetInterfacesRequest)(nil),              // 67: xpf.v1.GetInterfacesRequest
+	(*GetInterfacesResponse)(nil),             // 68: xpf.v1.GetInterfacesResponse
+	(*InterfaceInfo)(nil),                     // 69: xpf.v1.InterfaceInfo
+	(*ShowInterfacesDetailRequest)(nil),       // 70: xpf.v1.ShowInterfacesDetailRequest
+	(*ShowInterfacesDetailResponse)(nil),      // 71: xpf.v1.ShowInterfacesDetailResponse
+	(*GetDHCPLeasesRequest)(nil),              // 72: xpf.v1.GetDHCPLeasesRequest
+	(*GetDHCPLeasesResponse)(nil),             // 73: xpf.v1.GetDHCPLeasesResponse
+	(*DHCPLeaseInfo)(nil),                     // 74: xpf.v1.DHCPLeaseInfo
+	(*DHCPDelegatedPrefix)(nil),               // 75: xpf.v1.DHCPDelegatedPrefix
+	(*GetDHCPClientIdentifiersRequest)(nil),   // 76: xpf.v1.GetDHCPClientIdentifiersRequest
+	(*GetDHCPClientIdentifiersResponse)(nil),  // 77: xpf.v1.GetDHCPClientIdentifiersResponse
+	(*DHCPClientIdentifierInfo)(nil),          // 78: xpf.v1.DHCPClientIdentifierInfo
+	(*ClearDHCPClientIdentifierRequest)(nil),  // 79: xpf.v1.ClearDHCPClientIdentifierRequest
+	(*ClearDHCPClientIdentifierResponse)(nil), // 80: xpf.v1.ClearDHCPClientIdentifierResponse
+	(*GetRoutesRequest)(nil),                  // 81: xpf.v1.GetRoutesRequest
+	(*GetRoutesResponse)(nil),                 // 82: xpf.v1.GetRoutesResponse
+	(*RouteInfo)(nil),                         // 83: xpf.v1.RouteInfo
+	(*GetOSPFStatusRequest)(nil),              // 84: xpf.v1.GetOSPFStatusRequest
+	(*GetOSPFStatusResponse)(nil),             // 85: xpf.v1.GetOSPFStatusResponse
+	(*GetBGPStatusRequest)(nil),               // 86: xpf.v1.GetBGPStatusRequest
+	(*GetBGPStatusResponse)(nil),              // 87: xpf.v1.GetBGPStatusResponse
+	(*GetRIPStatusRequest)(nil),               // 88: xpf.v1.GetRIPStatusRequest
+	(*GetRIPStatusResponse)(nil),              // 89: xpf.v1.GetRIPStatusResponse
+	(*GetISISStatusRequest)(nil),              // 90: xpf.v1.GetISISStatusRequest
+	(*GetISISStatusResponse)(nil),             // 91: xpf.v1.GetISISStatusResponse
+	(*GetIPsecSARequest)(nil),                 // 92: xpf.v1.GetIPsecSARequest
+	(*GetIPsecSAResponse)(nil),                // 93: xpf.v1.GetIPsecSAResponse
+	(*PingRequest)(nil),                       // 94: xpf.v1.PingRequest
+	(*PingResponse)(nil),                      // 95: xpf.v1.PingResponse
+	(*TracerouteRequest)(nil),                 // 96: xpf.v1.TracerouteRequest
+	(*TracerouteResponse)(nil),                // 97: xpf.v1.TracerouteResponse
+	(*ClearSessionsRequest)(nil),              // 98: xpf.v1.ClearSessionsRequest
+	(*ClearSessionsResponse)(nil),             // 99: xpf.v1.ClearSessionsResponse
+	(*ClearCountersRequest)(nil),              // 100: xpf.v1.ClearCountersRequest
+	(*ClearCountersResponse)(nil),             // 101: xpf.v1.ClearCountersResponse
+	(*GetNATPoolStatsRequest)(nil),            // 102: xpf.v1.GetNATPoolStatsRequest
+	(*GetNATPoolStatsResponse)(nil),           // 103: xpf.v1.GetNATPoolStatsResponse
+	(*NATPoolStats)(nil),                      // 104: xpf.v1.NATPoolStats
+	(*NATRuleSetSessions)(nil),                // 105: xpf.v1.NATRuleSetSessions
+	(*GetVRRPStatusRequest)(nil),              // 106: xpf.v1.GetVRRPStatusRequest
+	(*GetVRRPStatusResponse)(nil),             // 107: xpf.v1.GetVRRPStatusResponse
+	(*VRRPInstanceInfo)(nil),                  // 108: xpf.v1.VRRPInstanceInfo
+	(*MatchPoliciesRequest)(nil),              // 109: xpf.v1.MatchPoliciesRequest
+	(*MatchPoliciesResponse)(nil),             // 110: xpf.v1.MatchPoliciesResponse
+	(*HostInboundAdmission)(nil),              // 111: xpf.v1.HostInboundAdmission
+	(*GetNATRuleStatsRequest)(nil),            // 112: xpf.v1.GetNATRuleStatsRequest
+	(*GetNATRuleStatsResponse)(nil),           // 113: xpf.v1.GetNATRuleStatsResponse
+	(*NATRuleStats)(nil),                      // 114: xpf.v1.NATRuleStats
+	(*GetNATDeterministicRequest)(nil),        // 115: xpf.v1.GetNATDeterministicRequest
+	(*GetNATDeterministicResponse)(nil),       // 116: xpf.v1.GetNATDeterministicResponse
+	(*CompleteRequest)(nil),                   // 117: xpf.v1.CompleteRequest
+	(*CompleteResponse)(nil),                  // 118: xpf.v1.CompleteResponse
+	(*ShowTextRequest)(nil),                   // 119: xpf.v1.ShowTextRequest
+	(*ShowTextResponse)(nil),                  // 120: xpf.v1.ShowTextResponse
+	(*GetSystemInfoRequest)(nil),              // 121: xpf.v1.GetSystemInfoRequest
+	(*GetSystemInfoResponse)(nil),             // 122: xpf.v1.GetSystemInfoResponse
+	(*SystemActionRequest)(nil),               // 123: xpf.v1.SystemActionRequest
+	(*SystemActionResponse)(nil),              // 124: xpf.v1.SystemActionResponse
+	(*MonitorPacketDropRequest)(nil),          // 125: xpf.v1.MonitorPacketDropRequest
+	(*MonitorPacketDropResponse)(nil),         // 126: xpf.v1.MonitorPacketDropResponse
+	(*MonitorInterfaceRequest)(nil),           // 127: xpf.v1.MonitorInterfaceRequest
+	(*MonitorInterfaceResponse)(nil),          // 128: xpf.v1.MonitorInterfaceResponse
+	(*GetZonePairSummaryRequest)(nil),         // 129: xpf.v1.GetZonePairSummaryRequest
+	(*ZonePairSessionSummary)(nil),            // 130: xpf.v1.ZonePairSessionSummary
+	(*GetZonePairSummaryResponse)(nil),        // 131: xpf.v1.GetZonePairSummaryResponse
+	nil,                                       // 132: xpf.v1.GetGlobalStatsResponse.ScreenDropDetailsEntry
+	nil,                                       // 133: xpf.v1.ScreenInfo.ThresholdsEntry
 }
 var file_xpf_proto_depIdxs = []int32{
 	0,   // 0: xpf.v1.ShowConfigRequest.format:type_name -> xpf.v1.ConfigFormat
 	1,   // 1: xpf.v1.ShowConfigRequest.target:type_name -> xpf.v1.ConfigTarget
 	0,   // 2: xpf.v1.ShowRollbackRequest.format:type_name -> xpf.v1.ConfigFormat
-	36,  // 3: xpf.v1.ListHistoryResponse.entries:type_name -> xpf.v1.HistoryEntry
-	131, // 4: xpf.v1.GetGlobalStatsResponse.screen_drop_details:type_name -> xpf.v1.GetGlobalStatsResponse.ScreenDropDetailsEntry
-	43,  // 5: xpf.v1.GetZonesResponse.zones:type_name -> xpf.v1.ZoneInfo
-	44,  // 6: xpf.v1.ZoneInfo.interface_host_inbound:type_name -> xpf.v1.InterfaceHostInbound
-	47,  // 7: xpf.v1.GetPoliciesResponse.policies:type_name -> xpf.v1.PolicyInfo
-	48,  // 8: xpf.v1.PolicyInfo.rules:type_name -> xpf.v1.PolicyRule
-	51,  // 9: xpf.v1.GetSessionsResponse.sessions:type_name -> xpf.v1.SessionEntry
-	50,  // 10: xpf.v1.GetSessionsResponse.peer:type_name -> xpf.v1.GetSessionsResponse
-	53,  // 11: xpf.v1.GetSessionSummaryResponse.peer:type_name -> xpf.v1.GetSessionSummaryResponse
-	5,   // 12: xpf.v1.GetSessionSummaryResponse.peer_status:type_name -> xpf.v1.PeerFetchStatus
-	56,  // 13: xpf.v1.GetNATSourceResponse.rules:type_name -> xpf.v1.NATSourceInfo
-	59,  // 14: xpf.v1.GetNATDestinationResponse.rules:type_name -> xpf.v1.NATDestInfo
-	104, // 15: xpf.v1.GetNATDestinationResponse.rule_set_sessions:type_name -> xpf.v1.NATRuleSetSessions
-	62,  // 16: xpf.v1.GetScreenResponse.screens:type_name -> xpf.v1.ScreenInfo
-	132, // 17: xpf.v1.ScreenInfo.thresholds:type_name -> xpf.v1.ScreenInfo.ThresholdsEntry
-	65,  // 18: xpf.v1.GetEventsResponse.events:type_name -> xpf.v1.EventEntry
-	68,  // 19: xpf.v1.GetInterfacesResponse.interfaces:type_name -> xpf.v1.InterfaceInfo
-	73,  // 20: xpf.v1.GetDHCPLeasesResponse.leases:type_name -> xpf.v1.DHCPLeaseInfo
-	74,  // 21: xpf.v1.DHCPLeaseInfo.delegated_prefixes:type_name -> xpf.v1.DHCPDelegatedPrefix
-	77,  // 22: xpf.v1.GetDHCPClientIdentifiersResponse.identifiers:type_name -> xpf.v1.DHCPClientIdentifierInfo
-	82,  // 23: xpf.v1.GetRoutesResponse.routes:type_name -> xpf.v1.RouteInfo
-	103, // 24: xpf.v1.GetNATPoolStatsResponse.pools:type_name -> xpf.v1.NATPoolStats
-	104, // 25: xpf.v1.GetNATPoolStatsResponse.rule_set_sessions:type_name -> xpf.v1.NATRuleSetSessions
-	107, // 26: xpf.v1.GetVRRPStatusResponse.instances:type_name -> xpf.v1.VRRPInstanceInfo
-	110, // 27: xpf.v1.MatchPoliciesResponse.host_inbound:type_name -> xpf.v1.HostInboundAdmission
-	3,   // 28: xpf.v1.HostInboundAdmission.status:type_name -> xpf.v1.HostInboundAdmissionStatus
-	113, // 29: xpf.v1.GetNATRuleStatsResponse.rules:type_name -> xpf.v1.NATRuleStats
-	4,   // 30: xpf.v1.GetNATDeterministicRequest.direction:type_name -> xpf.v1.NATDeterministicDirection
-	2,   // 31: xpf.v1.MonitorInterfaceRequest.summary_mode:type_name -> xpf.v1.MonitorInterfaceSummaryMode
-	129, // 32: xpf.v1.GetZonePairSummaryResponse.zone_pairs:type_name -> xpf.v1.ZonePairSessionSummary
-	130, // 33: xpf.v1.GetZonePairSummaryResponse.peer:type_name -> xpf.v1.GetZonePairSummaryResponse
-	5,   // 34: xpf.v1.GetZonePairSummaryResponse.peer_status:type_name -> xpf.v1.PeerFetchStatus
-	6,   // 35: xpf.v1.BpfrxService.EnterConfigure:input_type -> xpf.v1.EnterConfigureRequest
-	8,   // 36: xpf.v1.BpfrxService.ExitConfigure:input_type -> xpf.v1.ExitConfigureRequest
-	10,  // 37: xpf.v1.BpfrxService.GetConfigModeStatus:input_type -> xpf.v1.GetConfigModeStatusRequest
-	12,  // 38: xpf.v1.BpfrxService.Set:input_type -> xpf.v1.SetRequest
-	14,  // 39: xpf.v1.BpfrxService.Delete:input_type -> xpf.v1.DeleteRequest
-	16,  // 40: xpf.v1.BpfrxService.Load:input_type -> xpf.v1.LoadRequest
-	18,  // 41: xpf.v1.BpfrxService.Commit:input_type -> xpf.v1.CommitRequest
-	20,  // 42: xpf.v1.BpfrxService.CommitCheck:input_type -> xpf.v1.CommitCheckRequest
-	22,  // 43: xpf.v1.BpfrxService.CommitConfirmed:input_type -> xpf.v1.CommitConfirmedRequest
-	24,  // 44: xpf.v1.BpfrxService.ConfirmCommit:input_type -> xpf.v1.ConfirmCommitRequest
-	26,  // 45: xpf.v1.BpfrxService.Rollback:input_type -> xpf.v1.RollbackRequest
-	28,  // 46: xpf.v1.BpfrxService.ShowConfig:input_type -> xpf.v1.ShowConfigRequest
-	30,  // 47: xpf.v1.BpfrxService.ShowCompare:input_type -> xpf.v1.ShowCompareRequest
-	32,  // 48: xpf.v1.BpfrxService.ShowRollback:input_type -> xpf.v1.ShowRollbackRequest
-	34,  // 49: xpf.v1.BpfrxService.ListHistory:input_type -> xpf.v1.ListHistoryRequest
-	37,  // 50: xpf.v1.BpfrxService.GetStatus:input_type -> xpf.v1.GetStatusRequest
-	39,  // 51: xpf.v1.BpfrxService.GetGlobalStats:input_type -> xpf.v1.GetGlobalStatsRequest
-	41,  // 52: xpf.v1.BpfrxService.GetZones:input_type -> xpf.v1.GetZonesRequest
-	45,  // 53: xpf.v1.BpfrxService.GetPolicies:input_type -> xpf.v1.GetPoliciesRequest
-	49,  // 54: xpf.v1.BpfrxService.GetSessions:input_type -> xpf.v1.GetSessionsRequest
-	52,  // 55: xpf.v1.BpfrxService.GetSessionSummary:input_type -> xpf.v1.GetSessionSummaryRequest
-	128, // 56: xpf.v1.BpfrxService.GetZonePairSummary:input_type -> xpf.v1.GetZonePairSummaryRequest
-	54,  // 57: xpf.v1.BpfrxService.GetNATSource:input_type -> xpf.v1.GetNATSourceRequest
-	57,  // 58: xpf.v1.BpfrxService.GetNATDestination:input_type -> xpf.v1.GetNATDestinationRequest
-	60,  // 59: xpf.v1.BpfrxService.GetScreen:input_type -> xpf.v1.GetScreenRequest
-	63,  // 60: xpf.v1.BpfrxService.GetEvents:input_type -> xpf.v1.GetEventsRequest
-	66,  // 61: xpf.v1.BpfrxService.GetInterfaces:input_type -> xpf.v1.GetInterfacesRequest
-	69,  // 62: xpf.v1.BpfrxService.ShowInterfacesDetail:input_type -> xpf.v1.ShowInterfacesDetailRequest
-	71,  // 63: xpf.v1.BpfrxService.GetDHCPLeases:input_type -> xpf.v1.GetDHCPLeasesRequest
-	75,  // 64: xpf.v1.BpfrxService.GetDHCPClientIdentifiers:input_type -> xpf.v1.GetDHCPClientIdentifiersRequest
-	80,  // 65: xpf.v1.BpfrxService.GetRoutes:input_type -> xpf.v1.GetRoutesRequest
-	83,  // 66: xpf.v1.BpfrxService.GetOSPFStatus:input_type -> xpf.v1.GetOSPFStatusRequest
-	85,  // 67: xpf.v1.BpfrxService.GetBGPStatus:input_type -> xpf.v1.GetBGPStatusRequest
-	87,  // 68: xpf.v1.BpfrxService.GetRIPStatus:input_type -> xpf.v1.GetRIPStatusRequest
-	89,  // 69: xpf.v1.BpfrxService.GetISISStatus:input_type -> xpf.v1.GetISISStatusRequest
-	91,  // 70: xpf.v1.BpfrxService.GetIPsecSA:input_type -> xpf.v1.GetIPsecSARequest
-	101, // 71: xpf.v1.BpfrxService.GetNATPoolStats:input_type -> xpf.v1.GetNATPoolStatsRequest
-	111, // 72: xpf.v1.BpfrxService.GetNATRuleStats:input_type -> xpf.v1.GetNATRuleStatsRequest
-	114, // 73: xpf.v1.BpfrxService.GetNATDeterministic:input_type -> xpf.v1.GetNATDeterministicRequest
-	105, // 74: xpf.v1.BpfrxService.GetVRRPStatus:input_type -> xpf.v1.GetVRRPStatusRequest
-	108, // 75: xpf.v1.BpfrxService.MatchPolicies:input_type -> xpf.v1.MatchPoliciesRequest
-	93,  // 76: xpf.v1.BpfrxService.Ping:input_type -> xpf.v1.PingRequest
-	95,  // 77: xpf.v1.BpfrxService.Traceroute:input_type -> xpf.v1.TracerouteRequest
-	124, // 78: xpf.v1.BpfrxService.MonitorPacketDrop:input_type -> xpf.v1.MonitorPacketDropRequest
-	126, // 79: xpf.v1.BpfrxService.MonitorInterface:input_type -> xpf.v1.MonitorInterfaceRequest
-	97,  // 80: xpf.v1.BpfrxService.ClearSessions:input_type -> xpf.v1.ClearSessionsRequest
-	99,  // 81: xpf.v1.BpfrxService.ClearCounters:input_type -> xpf.v1.ClearCountersRequest
-	78,  // 82: xpf.v1.BpfrxService.ClearDHCPClientIdentifier:input_type -> xpf.v1.ClearDHCPClientIdentifierRequest
-	118, // 83: xpf.v1.BpfrxService.ShowText:input_type -> xpf.v1.ShowTextRequest
-	120, // 84: xpf.v1.BpfrxService.GetSystemInfo:input_type -> xpf.v1.GetSystemInfoRequest
-	122, // 85: xpf.v1.BpfrxService.SystemAction:input_type -> xpf.v1.SystemActionRequest
-	116, // 86: xpf.v1.BpfrxService.Complete:input_type -> xpf.v1.CompleteRequest
-	7,   // 87: xpf.v1.BpfrxService.EnterConfigure:output_type -> xpf.v1.EnterConfigureResponse
-	9,   // 88: xpf.v1.BpfrxService.ExitConfigure:output_type -> xpf.v1.ExitConfigureResponse
-	11,  // 89: xpf.v1.BpfrxService.GetConfigModeStatus:output_type -> xpf.v1.GetConfigModeStatusResponse
-	13,  // 90: xpf.v1.BpfrxService.Set:output_type -> xpf.v1.SetResponse
-	15,  // 91: xpf.v1.BpfrxService.Delete:output_type -> xpf.v1.DeleteResponse
-	17,  // 92: xpf.v1.BpfrxService.Load:output_type -> xpf.v1.LoadResponse
-	19,  // 93: xpf.v1.BpfrxService.Commit:output_type -> xpf.v1.CommitResponse
-	21,  // 94: xpf.v1.BpfrxService.CommitCheck:output_type -> xpf.v1.CommitCheckResponse
-	23,  // 95: xpf.v1.BpfrxService.CommitConfirmed:output_type -> xpf.v1.CommitConfirmedResponse
-	25,  // 96: xpf.v1.BpfrxService.ConfirmCommit:output_type -> xpf.v1.ConfirmCommitResponse
-	27,  // 97: xpf.v1.BpfrxService.Rollback:output_type -> xpf.v1.RollbackResponse
-	29,  // 98: xpf.v1.BpfrxService.ShowConfig:output_type -> xpf.v1.ShowConfigResponse
-	31,  // 99: xpf.v1.BpfrxService.ShowCompare:output_type -> xpf.v1.ShowCompareResponse
-	33,  // 100: xpf.v1.BpfrxService.ShowRollback:output_type -> xpf.v1.ShowRollbackResponse
-	35,  // 101: xpf.v1.BpfrxService.ListHistory:output_type -> xpf.v1.ListHistoryResponse
-	38,  // 102: xpf.v1.BpfrxService.GetStatus:output_type -> xpf.v1.GetStatusResponse
-	40,  // 103: xpf.v1.BpfrxService.GetGlobalStats:output_type -> xpf.v1.GetGlobalStatsResponse
-	42,  // 104: xpf.v1.BpfrxService.GetZones:output_type -> xpf.v1.GetZonesResponse
-	46,  // 105: xpf.v1.BpfrxService.GetPolicies:output_type -> xpf.v1.GetPoliciesResponse
-	50,  // 106: xpf.v1.BpfrxService.GetSessions:output_type -> xpf.v1.GetSessionsResponse
-	53,  // 107: xpf.v1.BpfrxService.GetSessionSummary:output_type -> xpf.v1.GetSessionSummaryResponse
-	130, // 108: xpf.v1.BpfrxService.GetZonePairSummary:output_type -> xpf.v1.GetZonePairSummaryResponse
-	55,  // 109: xpf.v1.BpfrxService.GetNATSource:output_type -> xpf.v1.GetNATSourceResponse
-	58,  // 110: xpf.v1.BpfrxService.GetNATDestination:output_type -> xpf.v1.GetNATDestinationResponse
-	61,  // 111: xpf.v1.BpfrxService.GetScreen:output_type -> xpf.v1.GetScreenResponse
-	64,  // 112: xpf.v1.BpfrxService.GetEvents:output_type -> xpf.v1.GetEventsResponse
-	67,  // 113: xpf.v1.BpfrxService.GetInterfaces:output_type -> xpf.v1.GetInterfacesResponse
-	70,  // 114: xpf.v1.BpfrxService.ShowInterfacesDetail:output_type -> xpf.v1.ShowInterfacesDetailResponse
-	72,  // 115: xpf.v1.BpfrxService.GetDHCPLeases:output_type -> xpf.v1.GetDHCPLeasesResponse
-	76,  // 116: xpf.v1.BpfrxService.GetDHCPClientIdentifiers:output_type -> xpf.v1.GetDHCPClientIdentifiersResponse
-	81,  // 117: xpf.v1.BpfrxService.GetRoutes:output_type -> xpf.v1.GetRoutesResponse
-	84,  // 118: xpf.v1.BpfrxService.GetOSPFStatus:output_type -> xpf.v1.GetOSPFStatusResponse
-	86,  // 119: xpf.v1.BpfrxService.GetBGPStatus:output_type -> xpf.v1.GetBGPStatusResponse
-	88,  // 120: xpf.v1.BpfrxService.GetRIPStatus:output_type -> xpf.v1.GetRIPStatusResponse
-	90,  // 121: xpf.v1.BpfrxService.GetISISStatus:output_type -> xpf.v1.GetISISStatusResponse
-	92,  // 122: xpf.v1.BpfrxService.GetIPsecSA:output_type -> xpf.v1.GetIPsecSAResponse
-	102, // 123: xpf.v1.BpfrxService.GetNATPoolStats:output_type -> xpf.v1.GetNATPoolStatsResponse
-	112, // 124: xpf.v1.BpfrxService.GetNATRuleStats:output_type -> xpf.v1.GetNATRuleStatsResponse
-	115, // 125: xpf.v1.BpfrxService.GetNATDeterministic:output_type -> xpf.v1.GetNATDeterministicResponse
-	106, // 126: xpf.v1.BpfrxService.GetVRRPStatus:output_type -> xpf.v1.GetVRRPStatusResponse
-	109, // 127: xpf.v1.BpfrxService.MatchPolicies:output_type -> xpf.v1.MatchPoliciesResponse
-	94,  // 128: xpf.v1.BpfrxService.Ping:output_type -> xpf.v1.PingResponse
-	96,  // 129: xpf.v1.BpfrxService.Traceroute:output_type -> xpf.v1.TracerouteResponse
-	125, // 130: xpf.v1.BpfrxService.MonitorPacketDrop:output_type -> xpf.v1.MonitorPacketDropResponse
-	127, // 131: xpf.v1.BpfrxService.MonitorInterface:output_type -> xpf.v1.MonitorInterfaceResponse
-	98,  // 132: xpf.v1.BpfrxService.ClearSessions:output_type -> xpf.v1.ClearSessionsResponse
-	100, // 133: xpf.v1.BpfrxService.ClearCounters:output_type -> xpf.v1.ClearCountersResponse
-	79,  // 134: xpf.v1.BpfrxService.ClearDHCPClientIdentifier:output_type -> xpf.v1.ClearDHCPClientIdentifierResponse
-	119, // 135: xpf.v1.BpfrxService.ShowText:output_type -> xpf.v1.ShowTextResponse
-	121, // 136: xpf.v1.BpfrxService.GetSystemInfo:output_type -> xpf.v1.GetSystemInfoResponse
-	123, // 137: xpf.v1.BpfrxService.SystemAction:output_type -> xpf.v1.SystemActionResponse
-	117, // 138: xpf.v1.BpfrxService.Complete:output_type -> xpf.v1.CompleteResponse
-	87,  // [87:139] is the sub-list for method output_type
-	35,  // [35:87] is the sub-list for method input_type
-	35,  // [35:35] is the sub-list for extension type_name
-	35,  // [35:35] is the sub-list for extension extendee
-	0,   // [0:35] is the sub-list for field type_name
+	37,  // 3: xpf.v1.ListHistoryResponse.entries:type_name -> xpf.v1.HistoryEntry
+	132, // 4: xpf.v1.GetGlobalStatsResponse.screen_drop_details:type_name -> xpf.v1.GetGlobalStatsResponse.ScreenDropDetailsEntry
+	44,  // 5: xpf.v1.GetZonesResponse.zones:type_name -> xpf.v1.ZoneInfo
+	45,  // 6: xpf.v1.ZoneInfo.interface_host_inbound:type_name -> xpf.v1.InterfaceHostInbound
+	3,   // 7: xpf.v1.ZoneInfo.per_zone_counter_availability:type_name -> xpf.v1.ZoneCounterAvailability
+	48,  // 8: xpf.v1.GetPoliciesResponse.policies:type_name -> xpf.v1.PolicyInfo
+	49,  // 9: xpf.v1.PolicyInfo.rules:type_name -> xpf.v1.PolicyRule
+	52,  // 10: xpf.v1.GetSessionsResponse.sessions:type_name -> xpf.v1.SessionEntry
+	51,  // 11: xpf.v1.GetSessionsResponse.peer:type_name -> xpf.v1.GetSessionsResponse
+	54,  // 12: xpf.v1.GetSessionSummaryResponse.peer:type_name -> xpf.v1.GetSessionSummaryResponse
+	6,   // 13: xpf.v1.GetSessionSummaryResponse.peer_status:type_name -> xpf.v1.PeerFetchStatus
+	57,  // 14: xpf.v1.GetNATSourceResponse.rules:type_name -> xpf.v1.NATSourceInfo
+	60,  // 15: xpf.v1.GetNATDestinationResponse.rules:type_name -> xpf.v1.NATDestInfo
+	105, // 16: xpf.v1.GetNATDestinationResponse.rule_set_sessions:type_name -> xpf.v1.NATRuleSetSessions
+	63,  // 17: xpf.v1.GetScreenResponse.screens:type_name -> xpf.v1.ScreenInfo
+	133, // 18: xpf.v1.ScreenInfo.thresholds:type_name -> xpf.v1.ScreenInfo.ThresholdsEntry
+	66,  // 19: xpf.v1.GetEventsResponse.events:type_name -> xpf.v1.EventEntry
+	69,  // 20: xpf.v1.GetInterfacesResponse.interfaces:type_name -> xpf.v1.InterfaceInfo
+	74,  // 21: xpf.v1.GetDHCPLeasesResponse.leases:type_name -> xpf.v1.DHCPLeaseInfo
+	75,  // 22: xpf.v1.DHCPLeaseInfo.delegated_prefixes:type_name -> xpf.v1.DHCPDelegatedPrefix
+	78,  // 23: xpf.v1.GetDHCPClientIdentifiersResponse.identifiers:type_name -> xpf.v1.DHCPClientIdentifierInfo
+	83,  // 24: xpf.v1.GetRoutesResponse.routes:type_name -> xpf.v1.RouteInfo
+	104, // 25: xpf.v1.GetNATPoolStatsResponse.pools:type_name -> xpf.v1.NATPoolStats
+	105, // 26: xpf.v1.GetNATPoolStatsResponse.rule_set_sessions:type_name -> xpf.v1.NATRuleSetSessions
+	108, // 27: xpf.v1.GetVRRPStatusResponse.instances:type_name -> xpf.v1.VRRPInstanceInfo
+	111, // 28: xpf.v1.MatchPoliciesResponse.host_inbound:type_name -> xpf.v1.HostInboundAdmission
+	4,   // 29: xpf.v1.HostInboundAdmission.status:type_name -> xpf.v1.HostInboundAdmissionStatus
+	114, // 30: xpf.v1.GetNATRuleStatsResponse.rules:type_name -> xpf.v1.NATRuleStats
+	5,   // 31: xpf.v1.GetNATDeterministicRequest.direction:type_name -> xpf.v1.NATDeterministicDirection
+	2,   // 32: xpf.v1.MonitorInterfaceRequest.summary_mode:type_name -> xpf.v1.MonitorInterfaceSummaryMode
+	130, // 33: xpf.v1.GetZonePairSummaryResponse.zone_pairs:type_name -> xpf.v1.ZonePairSessionSummary
+	131, // 34: xpf.v1.GetZonePairSummaryResponse.peer:type_name -> xpf.v1.GetZonePairSummaryResponse
+	6,   // 35: xpf.v1.GetZonePairSummaryResponse.peer_status:type_name -> xpf.v1.PeerFetchStatus
+	7,   // 36: xpf.v1.BpfrxService.EnterConfigure:input_type -> xpf.v1.EnterConfigureRequest
+	9,   // 37: xpf.v1.BpfrxService.ExitConfigure:input_type -> xpf.v1.ExitConfigureRequest
+	11,  // 38: xpf.v1.BpfrxService.GetConfigModeStatus:input_type -> xpf.v1.GetConfigModeStatusRequest
+	13,  // 39: xpf.v1.BpfrxService.Set:input_type -> xpf.v1.SetRequest
+	15,  // 40: xpf.v1.BpfrxService.Delete:input_type -> xpf.v1.DeleteRequest
+	17,  // 41: xpf.v1.BpfrxService.Load:input_type -> xpf.v1.LoadRequest
+	19,  // 42: xpf.v1.BpfrxService.Commit:input_type -> xpf.v1.CommitRequest
+	21,  // 43: xpf.v1.BpfrxService.CommitCheck:input_type -> xpf.v1.CommitCheckRequest
+	23,  // 44: xpf.v1.BpfrxService.CommitConfirmed:input_type -> xpf.v1.CommitConfirmedRequest
+	25,  // 45: xpf.v1.BpfrxService.ConfirmCommit:input_type -> xpf.v1.ConfirmCommitRequest
+	27,  // 46: xpf.v1.BpfrxService.Rollback:input_type -> xpf.v1.RollbackRequest
+	29,  // 47: xpf.v1.BpfrxService.ShowConfig:input_type -> xpf.v1.ShowConfigRequest
+	31,  // 48: xpf.v1.BpfrxService.ShowCompare:input_type -> xpf.v1.ShowCompareRequest
+	33,  // 49: xpf.v1.BpfrxService.ShowRollback:input_type -> xpf.v1.ShowRollbackRequest
+	35,  // 50: xpf.v1.BpfrxService.ListHistory:input_type -> xpf.v1.ListHistoryRequest
+	38,  // 51: xpf.v1.BpfrxService.GetStatus:input_type -> xpf.v1.GetStatusRequest
+	40,  // 52: xpf.v1.BpfrxService.GetGlobalStats:input_type -> xpf.v1.GetGlobalStatsRequest
+	42,  // 53: xpf.v1.BpfrxService.GetZones:input_type -> xpf.v1.GetZonesRequest
+	46,  // 54: xpf.v1.BpfrxService.GetPolicies:input_type -> xpf.v1.GetPoliciesRequest
+	50,  // 55: xpf.v1.BpfrxService.GetSessions:input_type -> xpf.v1.GetSessionsRequest
+	53,  // 56: xpf.v1.BpfrxService.GetSessionSummary:input_type -> xpf.v1.GetSessionSummaryRequest
+	129, // 57: xpf.v1.BpfrxService.GetZonePairSummary:input_type -> xpf.v1.GetZonePairSummaryRequest
+	55,  // 58: xpf.v1.BpfrxService.GetNATSource:input_type -> xpf.v1.GetNATSourceRequest
+	58,  // 59: xpf.v1.BpfrxService.GetNATDestination:input_type -> xpf.v1.GetNATDestinationRequest
+	61,  // 60: xpf.v1.BpfrxService.GetScreen:input_type -> xpf.v1.GetScreenRequest
+	64,  // 61: xpf.v1.BpfrxService.GetEvents:input_type -> xpf.v1.GetEventsRequest
+	67,  // 62: xpf.v1.BpfrxService.GetInterfaces:input_type -> xpf.v1.GetInterfacesRequest
+	70,  // 63: xpf.v1.BpfrxService.ShowInterfacesDetail:input_type -> xpf.v1.ShowInterfacesDetailRequest
+	72,  // 64: xpf.v1.BpfrxService.GetDHCPLeases:input_type -> xpf.v1.GetDHCPLeasesRequest
+	76,  // 65: xpf.v1.BpfrxService.GetDHCPClientIdentifiers:input_type -> xpf.v1.GetDHCPClientIdentifiersRequest
+	81,  // 66: xpf.v1.BpfrxService.GetRoutes:input_type -> xpf.v1.GetRoutesRequest
+	84,  // 67: xpf.v1.BpfrxService.GetOSPFStatus:input_type -> xpf.v1.GetOSPFStatusRequest
+	86,  // 68: xpf.v1.BpfrxService.GetBGPStatus:input_type -> xpf.v1.GetBGPStatusRequest
+	88,  // 69: xpf.v1.BpfrxService.GetRIPStatus:input_type -> xpf.v1.GetRIPStatusRequest
+	90,  // 70: xpf.v1.BpfrxService.GetISISStatus:input_type -> xpf.v1.GetISISStatusRequest
+	92,  // 71: xpf.v1.BpfrxService.GetIPsecSA:input_type -> xpf.v1.GetIPsecSARequest
+	102, // 72: xpf.v1.BpfrxService.GetNATPoolStats:input_type -> xpf.v1.GetNATPoolStatsRequest
+	112, // 73: xpf.v1.BpfrxService.GetNATRuleStats:input_type -> xpf.v1.GetNATRuleStatsRequest
+	115, // 74: xpf.v1.BpfrxService.GetNATDeterministic:input_type -> xpf.v1.GetNATDeterministicRequest
+	106, // 75: xpf.v1.BpfrxService.GetVRRPStatus:input_type -> xpf.v1.GetVRRPStatusRequest
+	109, // 76: xpf.v1.BpfrxService.MatchPolicies:input_type -> xpf.v1.MatchPoliciesRequest
+	94,  // 77: xpf.v1.BpfrxService.Ping:input_type -> xpf.v1.PingRequest
+	96,  // 78: xpf.v1.BpfrxService.Traceroute:input_type -> xpf.v1.TracerouteRequest
+	125, // 79: xpf.v1.BpfrxService.MonitorPacketDrop:input_type -> xpf.v1.MonitorPacketDropRequest
+	127, // 80: xpf.v1.BpfrxService.MonitorInterface:input_type -> xpf.v1.MonitorInterfaceRequest
+	98,  // 81: xpf.v1.BpfrxService.ClearSessions:input_type -> xpf.v1.ClearSessionsRequest
+	100, // 82: xpf.v1.BpfrxService.ClearCounters:input_type -> xpf.v1.ClearCountersRequest
+	79,  // 83: xpf.v1.BpfrxService.ClearDHCPClientIdentifier:input_type -> xpf.v1.ClearDHCPClientIdentifierRequest
+	119, // 84: xpf.v1.BpfrxService.ShowText:input_type -> xpf.v1.ShowTextRequest
+	121, // 85: xpf.v1.BpfrxService.GetSystemInfo:input_type -> xpf.v1.GetSystemInfoRequest
+	123, // 86: xpf.v1.BpfrxService.SystemAction:input_type -> xpf.v1.SystemActionRequest
+	117, // 87: xpf.v1.BpfrxService.Complete:input_type -> xpf.v1.CompleteRequest
+	8,   // 88: xpf.v1.BpfrxService.EnterConfigure:output_type -> xpf.v1.EnterConfigureResponse
+	10,  // 89: xpf.v1.BpfrxService.ExitConfigure:output_type -> xpf.v1.ExitConfigureResponse
+	12,  // 90: xpf.v1.BpfrxService.GetConfigModeStatus:output_type -> xpf.v1.GetConfigModeStatusResponse
+	14,  // 91: xpf.v1.BpfrxService.Set:output_type -> xpf.v1.SetResponse
+	16,  // 92: xpf.v1.BpfrxService.Delete:output_type -> xpf.v1.DeleteResponse
+	18,  // 93: xpf.v1.BpfrxService.Load:output_type -> xpf.v1.LoadResponse
+	20,  // 94: xpf.v1.BpfrxService.Commit:output_type -> xpf.v1.CommitResponse
+	22,  // 95: xpf.v1.BpfrxService.CommitCheck:output_type -> xpf.v1.CommitCheckResponse
+	24,  // 96: xpf.v1.BpfrxService.CommitConfirmed:output_type -> xpf.v1.CommitConfirmedResponse
+	26,  // 97: xpf.v1.BpfrxService.ConfirmCommit:output_type -> xpf.v1.ConfirmCommitResponse
+	28,  // 98: xpf.v1.BpfrxService.Rollback:output_type -> xpf.v1.RollbackResponse
+	30,  // 99: xpf.v1.BpfrxService.ShowConfig:output_type -> xpf.v1.ShowConfigResponse
+	32,  // 100: xpf.v1.BpfrxService.ShowCompare:output_type -> xpf.v1.ShowCompareResponse
+	34,  // 101: xpf.v1.BpfrxService.ShowRollback:output_type -> xpf.v1.ShowRollbackResponse
+	36,  // 102: xpf.v1.BpfrxService.ListHistory:output_type -> xpf.v1.ListHistoryResponse
+	39,  // 103: xpf.v1.BpfrxService.GetStatus:output_type -> xpf.v1.GetStatusResponse
+	41,  // 104: xpf.v1.BpfrxService.GetGlobalStats:output_type -> xpf.v1.GetGlobalStatsResponse
+	43,  // 105: xpf.v1.BpfrxService.GetZones:output_type -> xpf.v1.GetZonesResponse
+	47,  // 106: xpf.v1.BpfrxService.GetPolicies:output_type -> xpf.v1.GetPoliciesResponse
+	51,  // 107: xpf.v1.BpfrxService.GetSessions:output_type -> xpf.v1.GetSessionsResponse
+	54,  // 108: xpf.v1.BpfrxService.GetSessionSummary:output_type -> xpf.v1.GetSessionSummaryResponse
+	131, // 109: xpf.v1.BpfrxService.GetZonePairSummary:output_type -> xpf.v1.GetZonePairSummaryResponse
+	56,  // 110: xpf.v1.BpfrxService.GetNATSource:output_type -> xpf.v1.GetNATSourceResponse
+	59,  // 111: xpf.v1.BpfrxService.GetNATDestination:output_type -> xpf.v1.GetNATDestinationResponse
+	62,  // 112: xpf.v1.BpfrxService.GetScreen:output_type -> xpf.v1.GetScreenResponse
+	65,  // 113: xpf.v1.BpfrxService.GetEvents:output_type -> xpf.v1.GetEventsResponse
+	68,  // 114: xpf.v1.BpfrxService.GetInterfaces:output_type -> xpf.v1.GetInterfacesResponse
+	71,  // 115: xpf.v1.BpfrxService.ShowInterfacesDetail:output_type -> xpf.v1.ShowInterfacesDetailResponse
+	73,  // 116: xpf.v1.BpfrxService.GetDHCPLeases:output_type -> xpf.v1.GetDHCPLeasesResponse
+	77,  // 117: xpf.v1.BpfrxService.GetDHCPClientIdentifiers:output_type -> xpf.v1.GetDHCPClientIdentifiersResponse
+	82,  // 118: xpf.v1.BpfrxService.GetRoutes:output_type -> xpf.v1.GetRoutesResponse
+	85,  // 119: xpf.v1.BpfrxService.GetOSPFStatus:output_type -> xpf.v1.GetOSPFStatusResponse
+	87,  // 120: xpf.v1.BpfrxService.GetBGPStatus:output_type -> xpf.v1.GetBGPStatusResponse
+	89,  // 121: xpf.v1.BpfrxService.GetRIPStatus:output_type -> xpf.v1.GetRIPStatusResponse
+	91,  // 122: xpf.v1.BpfrxService.GetISISStatus:output_type -> xpf.v1.GetISISStatusResponse
+	93,  // 123: xpf.v1.BpfrxService.GetIPsecSA:output_type -> xpf.v1.GetIPsecSAResponse
+	103, // 124: xpf.v1.BpfrxService.GetNATPoolStats:output_type -> xpf.v1.GetNATPoolStatsResponse
+	113, // 125: xpf.v1.BpfrxService.GetNATRuleStats:output_type -> xpf.v1.GetNATRuleStatsResponse
+	116, // 126: xpf.v1.BpfrxService.GetNATDeterministic:output_type -> xpf.v1.GetNATDeterministicResponse
+	107, // 127: xpf.v1.BpfrxService.GetVRRPStatus:output_type -> xpf.v1.GetVRRPStatusResponse
+	110, // 128: xpf.v1.BpfrxService.MatchPolicies:output_type -> xpf.v1.MatchPoliciesResponse
+	95,  // 129: xpf.v1.BpfrxService.Ping:output_type -> xpf.v1.PingResponse
+	97,  // 130: xpf.v1.BpfrxService.Traceroute:output_type -> xpf.v1.TracerouteResponse
+	126, // 131: xpf.v1.BpfrxService.MonitorPacketDrop:output_type -> xpf.v1.MonitorPacketDropResponse
+	128, // 132: xpf.v1.BpfrxService.MonitorInterface:output_type -> xpf.v1.MonitorInterfaceResponse
+	99,  // 133: xpf.v1.BpfrxService.ClearSessions:output_type -> xpf.v1.ClearSessionsResponse
+	101, // 134: xpf.v1.BpfrxService.ClearCounters:output_type -> xpf.v1.ClearCountersResponse
+	80,  // 135: xpf.v1.BpfrxService.ClearDHCPClientIdentifier:output_type -> xpf.v1.ClearDHCPClientIdentifierResponse
+	120, // 136: xpf.v1.BpfrxService.ShowText:output_type -> xpf.v1.ShowTextResponse
+	122, // 137: xpf.v1.BpfrxService.GetSystemInfo:output_type -> xpf.v1.GetSystemInfoResponse
+	124, // 138: xpf.v1.BpfrxService.SystemAction:output_type -> xpf.v1.SystemActionResponse
+	118, // 139: xpf.v1.BpfrxService.Complete:output_type -> xpf.v1.CompleteResponse
+	88,  // [88:140] is the sub-list for method output_type
+	36,  // [36:88] is the sub-list for method input_type
+	36,  // [36:36] is the sub-list for extension type_name
+	36,  // [36:36] is the sub-list for extension extendee
+	0,   // [0:36] is the sub-list for field type_name
 }
 
 func init() { file_xpf_proto_init() }
@@ -9568,7 +9669,7 @@ func file_xpf_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_xpf_proto_rawDesc), len(file_xpf_proto_rawDesc)),
-			NumEnums:      6,
+			NumEnums:      7,
 			NumMessages:   127,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/pkg/grpcapi/zone_counter_availability_6895_test.go
+++ b/pkg/grpcapi/zone_counter_availability_6895_test.go
@@ -1,0 +1,102 @@
+package grpcapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// zone_counter_availability_6895_test.go — #6895, the SERVER half.
+//
+// The renderer in cmd/cli is inert unless GetZones actually stamps the
+// availability enum. Deleting the two assignments in server_show_zones.go
+// leaves every cmd/cli cell GREEN — those construct ZoneInfo directly — while
+// the wire goes back to carrying four indistinguishable zeros and the remote cli
+// falls through to its UNKNOWN branch, which is the pre-#6895 behaviour. So the
+// stamping is bound here, at the RPC.
+
+// availabilityGRPCDP reports ErrCounterNotPopulated for one zone id and a real
+// reading for another, so ONE reply carries both states. A fixture with only the
+// unavailable zone could not tell a correct implementation from one that stamps
+// UNAVAILABLE unconditionally.
+type availabilityGRPCDP struct {
+	*dataplane.Manager
+	apply       *dataplane.ApplyResult
+	populatedID uint16
+}
+
+func (d *availabilityGRPCDP) IsLoaded() bool                          { return true }
+func (d *availabilityGRPCDP) LastApplyResult() *dataplane.ApplyResult { return d.apply }
+func (d *availabilityGRPCDP) ReadZoneCounters(id uint16, dir int) (dataplane.CounterValue, error) {
+	if id == d.populatedID {
+		if dir == 0 {
+			return dataplane.CounterValue{Packets: 11, Bytes: 2200}, nil
+		}
+		return dataplane.CounterValue{Packets: 3, Bytes: 400}, nil
+	}
+	return dataplane.CounterValue{}, dataplane.ErrCounterNotPopulated
+}
+
+func TestGetZonesStampsCounterAvailability6895(t *testing.T) {
+	store := newSchedulerCounterGRPCStore(t)
+	s := &Server{
+		store: store,
+		dp: &availabilityGRPCDP{
+			Manager:     dataplane.New(),
+			apply:       &dataplane.ApplyResult{ZoneIDs: map[string]uint16{"trust": 40000, "untrust": 41000, "dmz": 42000}},
+			populatedID: 41000, // only untrust has a reading
+		},
+	}
+
+	resp, err := s.GetZones(context.Background(), &pb.GetZonesRequest{})
+	if err != nil {
+		t.Fatalf("GetZones: %v", err)
+	}
+
+	byName := map[string]*pb.ZoneInfo{}
+	for _, z := range resp.Zones {
+		byName[z.Name] = z
+	}
+	if len(byName) < 2 {
+		t.Fatalf("fixture degenerated: expected several zones, got %d", len(byName))
+	}
+
+	// The zone WITH a reading.
+	untrust := byName["untrust"]
+	if untrust == nil {
+		t.Fatal("untrust missing from the reply")
+	}
+	if untrust.PerZoneCounterAvailability !=
+		pb.ZoneCounterAvailability_ZONE_COUNTER_AVAILABILITY_AVAILABLE {
+		t.Fatalf("a zone with a real reading is stamped %v, want AVAILABLE — the client "+
+			"cannot tell its counters are real", untrust.PerZoneCounterAvailability)
+	}
+	if untrust.IngressPackets != 11 {
+		t.Fatalf("untrust ingress = %d, want 11", untrust.IngressPackets)
+	}
+
+	// A zone WITHOUT one.
+	trust := byName["trust"]
+	if trust == nil {
+		t.Fatal("trust missing from the reply")
+	}
+	if trust.PerZoneCounterAvailability !=
+		pb.ZoneCounterAvailability_ZONE_COUNTER_AVAILABILITY_UNAVAILABLE {
+		t.Fatalf("a zone with NO published volume is stamped %v, want UNAVAILABLE — the "+
+			"client sees four zeros and renders it exactly like an idle zone, which "+
+			"is the #6895 defect", trust.PerZoneCounterAvailability)
+	}
+	if trust.IngressPackets != 0 || trust.EgressPackets != 0 {
+		t.Fatalf("an unavailable zone carries counter values: in=%d out=%d",
+			trust.IngressPackets, trust.EgressPackets)
+	}
+
+	// Both states in ONE reply: an implementation that stamps a constant cannot
+	// satisfy both assertions above, which is why the fixture mixes them.
+	if untrust.PerZoneCounterAvailability == trust.PerZoneCounterAvailability {
+		t.Fatal("both zones got the same availability stamp — the server is not " +
+			"discriminating on the read result")
+	}
+}

--- a/pkg/zonecounters/zonecounters.go
+++ b/pkg/zonecounters/zonecounters.go
@@ -1,0 +1,68 @@
+// Package zonecounters carries the single canonical operator-facing wording for
+// a security zone whose per-zone traffic counters are unavailable.
+//
+// IT IS A DEPENDENCY-FREE LEAF ON PURPOSE (#6895). Three surfaces print this
+// state — the local CLI (pkg/cli), the gRPC text renderer (pkg/grpcapi) and the
+// remote cli binary (cmd/cli) — and the natural home would be pkg/dataplane,
+// beside the ErrCounterNotPopulated sentinel these sentences describe. But the
+// #1451 retirement-boundary canary deliberately keeps cmd/cli free of root
+// pkg/dataplane: the remote cli speaks gRPC and must not link the dataplane.
+// Adding an allowlist entry to share two strings would weaken an intentional
+// architectural boundary for a presentation concern, so the wording lives in a
+// leaf all three may import and the boundary stays as designed.
+package zonecounters
+
+// The wording below is the rendering of dataplane.ErrCounterNotPopulated for a
+// security zone.
+//
+// SINGLE-SOURCED ON PURPOSE (#6895). Three surfaces report this same state --
+// the local CLI (pkg/cli), the gRPC text renderer (pkg/grpcapi) and the remote
+// cli binary (cmd/cli) -- and before #6895 the generic sentence was duplicated
+// verbatim in two of them with no test binding the agreement. They describe ONE
+// dataplane condition, so a divergence between them is always a bug: an
+// operator comparing two surfaces would reasonably read different wording as
+// different states.
+//
+// Checking that agreement is also what surfaced a real gap: the local CLI had
+// the #6845 overflow specialisation and the gRPC text renderer did NOT, so the
+// same cluster reported slot exhaustion on one surface and the generic
+// three-cause line on the other. Routing every surface through UnavailableLine
+// fixes that by construction.
+//
+// WHY THE GENERIC LINE STAYS AMBIGUOUS. ReadZoneCounters returns
+// ErrCounterNotPopulated for a pre-#3651 helper, a zone past the helper's
+// hot-path slot capacity, AND a merely idle zone, because the helper's status
+// snapshot is sparse and omits all-zero rows. Those three are genuinely
+// indistinguishable at this layer and naming one would be a guess. The overflow
+// line is different: when the helper reports its slot table has overflowed, that
+// cause is KNOWN, it is the only one of the three that needs action, and traffic
+// really is going uncounted.
+const (
+	unavailableGeneric = "  Traffic statistics: not available " +
+		"(no per-zone volume published for this zone: helper predates " +
+		"per-zone accounting, the zone exceeded the dataplane's " +
+		"hot-path slot capacity, or the zone is idle)"
+
+	unavailableOverflow = "  Traffic statistics: not available " +
+		"(the dataplane's per-zone hot-path slot capacity is " +
+		"EXHAUSTED, so this zone's traffic is not being counted " +
+		"at all; reduce the number of configured zones or accept " +
+		"that zones past the capacity go uncounted)"
+)
+
+// UnavailableLine returns the single canonical "not available" line
+// every operator surface prints for a zone with no published per-zone volume.
+//
+// overflowActive selects the #6845 specialisation: pass the dataplane's
+// reported slot-overflow bit. When it is true the cause is known and actionable;
+// when false the three causes remain ambiguous and the generic line says so
+// rather than guessing.
+//
+// It carries NO trailing newline, so callers that print a line and callers that
+// assemble a buffer both use it unchanged.
+func UnavailableLine(overflowActive bool) string {
+	if overflowActive {
+		return unavailableOverflow
+	}
+	return unavailableGeneric
+}

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -213,6 +213,34 @@ message GetZonesRequest {}
 message GetZonesResponse {
   repeated ZoneInfo zones = 1;
 }
+// ZoneCounterAvailability reports whether the server had a per-zone traffic
+// reading for a zone, so a client can tell a real counter from the absence of
+// one (#6895).
+//
+// UNKNOWN IS 0 ON PURPOSE, and it is the whole point of this being an enum
+// rather than a bool. proto3 has no field presence for scalars: a `bool
+// per_zone_counters_available` sent by an OLD server decodes to `false` on a new
+// client, which is indistinguishable from the server saying "unavailable" — so
+// every zone from an old server, including ones with real counters, would render
+// as unavailable. The inverted spelling has the mirror-image defect: absent
+// decodes to "available" and an unpopulated zone renders as a real 0.
+//
+// With UNKNOWN = 0 the skewed pair is honest by construction: a new client
+// talking to an old server sees UNKNOWN and renders exactly as it did before
+// #6895, introducing no new wrong answer in either direction.
+enum ZoneCounterAvailability {
+  // The server did not say. An old server omits the field entirely and it
+  // decodes here. Clients MUST fall back to their pre-#6895 rendering.
+  ZONE_COUNTER_AVAILABILITY_UNKNOWN = 0;
+  // The server read live per-zone volume; the counter fields are real.
+  ZONE_COUNTER_AVAILABILITY_AVAILABLE = 1;
+  // The dataplane published no per-zone volume for this zone, so the counter
+  // fields are meaningless zeros. Note this does NOT isolate an idle zone: the
+  // helper's status snapshot omits all-zero rows, so a pre-#3651 helper, a zone
+  // past hot-path slot capacity, and a merely idle zone all land here.
+  ZONE_COUNTER_AVAILABILITY_UNAVAILABLE = 2;
+}
+
 message ZoneInfo {
   string name = 1;
   uint32 id = 2;
@@ -263,6 +291,13 @@ message ZoneInfo {
   // silent bypass. Sorted, deduplicated; empty for a zone with no lifeline
   // member. VISIBILITY only — the exemption semantics are unchanged.
   repeated string lifeline_interfaces = 16;
+  // per_zone_counter_availability (#6895) tells the client whether the four
+  // counter fields above are a real reading or the absence of one. Before it,
+  // the remote cli omitted the traffic section whenever both packet counts were
+  // zero, so a zone whose counters are unavailable rendered identically to an
+  // idle one — silence that reads as "no traffic", which is a wrong answer
+  // rather than a missing one.
+  ZoneCounterAvailability per_zone_counter_availability = 17;
 }
 
 // InterfaceHostInbound (#3328, #3362) is a per-interface host-inbound-traffic


### PR DESCRIPTION
Closes #6895

## One correction to the issue, and it changes what this can claim

The issue treats REST's `PerZoneCountersAvailable` as the discriminator between an idle zone and an unavailable one. **It is not.** `pkg/dataplane/maps_counters.go`, on `ReadZoneCounters`:

> *"the helper's status snapshot is sparse and **omits all-zero rows**, so the sentinel covers a pre-#3651 helper, a zone past the helper's hot-path slot capacity, and **a merely idle zone alike**."*

So an idle zone returns `ErrCounterNotPopulated`, and REST's flag is false for it too — its own doc lists "the zone is idle" among the causes. The local CLI and gRPC text renderer don't resolve it either; they print *"not available (…, or the zone is idle)"*, which is an honest admission, not a discrimination. **The conflation is at the DATA SOURCE, not the renderer.**

**So `available && zero` is essentially unreachable in production.** The renderer handles it defensively, but no cell claims it demonstrates idle-vs-unavailable — that would assert a state the data source cannot produce.

## What this actually fixes

The remote `cli` gated on `if z.IngressPackets > 0 || z.EgressPackets > 0`, so it rendered **silence** for an unavailable zone — which an operator reads as *"this zone has no traffic"*. That is a **wrong answer**, not a missing one, on the surface an operator is most likely holding. With 64+ zones, the slot-exhausted zones are exactly the ones that render as idle.

It now prints the same explicit labelled line the other surfaces use. **The fix converts a wrong answer into an honest one; the residual ambiguity is inherited, not resolved.** The one knowable, actionable cause — the helper reporting slot overflow (#6845) — keeps its own distinct line, and that is the case where the answer is not merely honest but useful.

## The wire shape: a three-state enum, decided by measurement

proto3 has no field presence for scalars, so **neither bool polarity survives a version-skewed pair**:

| wire shape | old server → new client |
|---|---|
| `bool per_zone_counters_available` | absent → false → **every zone labelled unavailable**, including ones with real counters |
| `bool per_zone_counters_unavailable` | absent → false → **an unpopulated zone renders as a real `0`** |
| **enum, `..._UNKNOWN = 0`** | absent → UNKNOWN → **renders exactly as before #6895** |

Both bools introduce a *new* wrong answer through the fix for a wrong answer, in opposite directions. `ZONE_COUNTER_AVAILABILITY_UNKNOWN = 0` makes the benign case the default **by construction**. `TestOldServerRendersExactlyAsBefore6895` decodes the field **absent** and asserts the historical rendering byte-for-byte — the only cell that can catch a future polarity change.

## Two things found by checking rather than assuming

**A pre-existing divergence between the two labelled surfaces.** The local CLI carried the #6845 overflow specialisation; the gRPC text renderer did **not**, so the same cluster reported slot exhaustion on one surface and the generic three-cause line on the other. All three surfaces now route through one canonical helper, so a divergence is no longer expressible.

**The canonical prose lives in a dependency-free leaf, `pkg/zonecounters`, not beside the sentinel it describes.** My first attempt put it in `pkg/dataplane` and the **#1451 retirement-boundary canary failed the build**: `cmd/cli` is deliberately kept free of root `pkg/dataplane` — the remote cli speaks gRPC and must not link the dataplane. Adding an allowlist entry to share two strings would weaken an intentional architectural boundary for a presentation concern.

## A real defect the dp-probe canary caught in my own code

`TestOptionalCapabilityProbesUseDPProbe` failed on the overflow probe I added:

> *optional-capability assertions made against the stored dp field instead of dpProbe(): under the #2114 live indirection these answer "capability absent" for a HEALTHY backend that implements it.*

My `s.dp.(interface{ Status() ... })` would have returned false on a cluster whose slot table really had overflowed, **suppressing the actionable line and leaving the operator on the generic message**. It fails in the *safe direction*, which is exactly why it would not have been noticed. Now routed through `dpProbe()` (`dataplane.Unwrap`), which still fails closed after a `setDataplane(nil)`.

## Mutation matrix

Full-package across the five affected packages, `-count=1 -v`, no `-run` filter, one mutation per cell, committed before mutating, tree clean after each restore, no baseline subtraction — control **0 / 2696 collected**.

| cell | mutation | reds |
|---|---|---|
| control | — | **0** |
| **S1** | **server never stamps UNAVAILABLE (the WIRING)** | `GetZonesStampsCounterAvailability` |
| S2 | server never stamps AVAILABLE | `GetZonesStampsCounterAvailability` |
| **S3** | **treat UNKNOWN as unavailable — the bool-flag defect** | `OldServerRendersExactlyAsBefore` |
| S4 | AVAILABLE reverts to the historical `>0` gate | `AvailableZeroIsPrintedNotOmitted` |
| S5 | a third spelling in the remote cli | **VOID — build break** (dropped import), correctly not scored as an escape |
| S5b | same, kept compiling | `AllSurfacesShareOneSpelling`, `UnavailableCountersAreLabelled` |
| S6 | overflow specialisation collapses into the generic line | `AllSurfacesShareOneSpelling` |
| S7 | AVAILABLE renders the unavailable line | `AvailableNonZeroRenders` |

**S3 is the row that matters**: it is precisely the failure a `bool` would have shipped, and only the skew cell catches it.

The server-side fixture mixes **both** states in one reply (one zone with a reading, one without), so an implementation stamping a constant cannot satisfy it.

## Gate

- `go build ./...` → rc 0
- `go test ./... -count=1 -p 4` → **rc 0, 68 packages, 0 failures** at HEAD `98c70fd5d`
- `make proto` regenerated `xpf.pb.go` with the pinned toolchain
- `merge-base --is-ancestor origin/master HEAD` verified; folded with `git merge`
- **No smoke owed** — three render paths, one proto field, one leaf package; no forwarding, cluster, VRRP or session-sync behaviour. No `userspace-dp` / `userspace-xdp` change, so no cargo leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ez9XCjM9mPjtocRjkousdB
