### PR TITLE
dataplane: fail the apply when a VLAN sub-interface cannot be created (#6893 part 2)

### DIFF
--- a/docs/log/6893.md
+++ b/docs/log/6893.md
@@ -49,3 +49,44 @@
   - **File(s)**: `pkg/dataplane/compiler_filter.go`,
     `pkg/dataplane/compiler.go`, `pkg/dataplane/armproof.go`,
     `pkg/dataplane/vlan_filter_failopen_6893_test.go`, `docs/log/6893.md`
+
+- **Timestamp**: 2026-08-27
+- **Action**: Part 2 — fail the apply on a VLAN CREATION failure, scoped
+  - **The guard**: `errVLANCreateFailed` marks `netlink.LinkAdd` refusing, and
+    `mapZoneInterface` returns an error on `errors.Is`. Everything else keeps
+    its soft skip.
+  - **Why the other three `ensureVLANSubInterface` errors are out of scope, by
+    harm rather than tidiness**:
+    - `"parent interface %s"` is the absent-PHYSICAL case, which #6893 itself
+      hedges on as arguably legitimate.
+    - `"find created ..."` and `"set ... up"` both report `created=true`, so the
+      link EXISTS — `compileFirewallFilters` resolves it and the filter IS
+      assigned. The #6893 harm does not arise there, so failing the apply would
+      refuse a config for a reason this issue is not about.
+  - **A correction to my own part-1 anticipation.** Part 1's cell doc predicted
+    its `err != nil` assertion would INVERT when part 2 landed. It does not, and
+    the anticipation named the wrong function: the guard is in
+    `mapZoneInterface`, and `compileZones` runs BEFORE `compileFirewallFilters`
+    (`compiler.go:304` and `:366`, both `if err != nil { return }`), so a
+    creation failure now aborts before that function is reached. The cell still
+    describes `compileFirewallFilters` truthfully and still guards a live path —
+    the absent-physical skip — but its framing was corrected in place rather
+    than left to mislead. **The done-signal idea was right; its location was
+    wrong.**
+  - **Paired proof, with an honest gap named**: creation failure -> apply fails
+    (drives the real `mapZoneInterface`); a NON-create failure -> soft skip
+    preserved AND still recorded (also drives the real function). The
+    creation-SUCCESS path is **not** unit-drivable — past the VLAN branch
+    `mapZoneInterface` does physical setup needing netlink and a real
+    DataPlane, and I chased two nil-map panics into a third nil-pointer before
+    stopping. Forcing it with stubs would have tested the stubs. The "not
+    refused" half is proven at the discriminator instead: a table asserting the
+    guard predicate is false for nil, absent-parent, not-findable and not-up,
+    and true only for the LinkAdd refusal.
+  - **Site A bound**, per review. Dropping the recording at the
+    interface-not-found miss left the package green — it read as covered only
+    because its VLAN sibling was. That is the #6893 asymmetry one level down,
+    in the tests rather than the code.
+  - **File(s)**: `pkg/dataplane/compiler_iface.go`,
+    `pkg/dataplane/vlan_create_failclosed_6893_test.go`,
+    `pkg/dataplane/vlan_filter_failopen_6893_test.go`, `docs/log/6893.md`

--- a/pkg/dataplane/compiler_iface.go
+++ b/pkg/dataplane/compiler_iface.go
@@ -1,6 +1,7 @@
 package dataplane
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -138,6 +139,29 @@ func resolveInterfaceRef(ref string, cfg *config.Config) (physName string, confi
 	return
 }
 
+// errVLANCreateFailed marks the ONE VLAN failure that must fail the apply
+// (#6893 part 2): netlink.LinkAdd itself refused, so the device the config
+// asked for does not exist and nothing downstream can be correct.
+//
+// It is deliberately NOT attached to the other three error returns of
+// ensureVLANSubInterface, and the reason is the harm rather than tidiness:
+//
+//   - "parent interface %s" is the absent-PHYSICAL case, which #6893 itself
+//     hedges on as arguably legitimate (an interface configured but not present
+//     on this chassis). Out of scope by decision, not oversight.
+//   - "find created ..." and "set ... up" both report created=true, so the link
+//     EXISTS. compileFirewallFilters then resolves it and the filter IS
+//     assigned — the #6893 harm (a binding silently dropped) does not arise, so
+//     failing the apply there would refuse a config for a reason this issue is
+//     not about.
+var errVLANCreateFailed = errors.New("VLAN sub-interface creation failed")
+
+// ensureVLANSubInterfaceFn is ensureVLANSubInterface's test seam, mirroring
+// teardownCleanupFn in loader.go: the paired proof for #6893 part 2 needs a
+// CREATION FAILURE, which is not reachable in a unit test without netlink and
+// CAP_NET_ADMIN. Production leaves it pointing at the real function.
+var ensureVLANSubInterfaceFn = ensureVLANSubInterface
+
 // ensureVLANSubInterface creates a Linux VLAN sub-interface if it doesn't exist.
 // Returns the sub-interface's ifindex and whether this call CREATED it.
 //
@@ -178,7 +202,8 @@ func ensureVLANSubInterface(parentName string, vlanID int) (int, bool, error) {
 		VlanId: vlanID,
 	}
 	if err := netlink.LinkAdd(vlan); err != nil {
-		return 0, false, fmt.Errorf("create VLAN sub-interface %s: %w", subName, err)
+		return 0, false, fmt.Errorf("create VLAN sub-interface %s: %w: %w",
+			subName, errVLANCreateFailed, err)
 	}
 
 	// Every return from here on reports created=true: the LinkAdd above
@@ -620,12 +645,24 @@ func (st *zoneMapState) mapZoneInterface(dp DataPlane, cfg *config.Config, resul
 
 	if vlanID > 0 {
 		// VLAN sub-interface: create it, populate vlan_iface_map
-		subIfindex, vlanCreated, err := ensureVLANSubInterface(physName, vlanID)
+		subIfindex, vlanCreated, err := ensureVLANSubInterfaceFn(physName, vlanID)
 		if vlanCreated {
 			// #4960: recorded BEFORE the error branch. LinkAdd succeeded even
 			// on the paths that fail afterwards, so the host carries the new
 			// link either way.
 			result.markHostMutated("created VLAN sub-interface")
+		}
+		if err != nil && errors.Is(err, errVLANCreateFailed) {
+			// #6893 part 2: FAIL THE APPLY. The config asked for a device, the
+			// create refused, and the device does not exist — so
+			// compileFirewallFilters will miss it and the filter bound to it is
+			// silently not assigned. A filter that is absent permits what it was
+			// configured to deny, and the commit used to report success.
+			//
+			// Scoped to the CREATE failure alone: the absent-parent and
+			// created-but-unusable cases keep the soft skip. See
+			// errVLANCreateFailed for why each.
+			return fmt.Errorf("zone %s interface %s.%d: %w", name, physName, vlanID, err)
 		}
 		if err != nil {
 			slog.Warn("VLAN sub-interface failed, skipping",

--- a/pkg/dataplane/vlan_create_failclosed_6893_test.go
+++ b/pkg/dataplane/vlan_create_failclosed_6893_test.go
@@ -1,0 +1,130 @@
+package dataplane
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6893 part 2 — a VLAN sub-interface that FAILS TO BE CREATED now fails the
+// apply, instead of being soft-skipped into a clean commit whose filter binding
+// silently went missing.
+//
+// PAIRED, because "the guard reds when deleted" shows only that it is
+// load-bearing, not that it was needed. The same input, one axis:
+//
+//	creation FAILS    -> mapZoneInterface returns an error (the apply fails)
+//	creation SUCCEEDS -> mapZoneInterface returns nil      (nothing refused)
+//
+// Without the second row a guard that refused unconditionally would satisfy the
+// first, and it would break every VLAN config on the box.
+//
+// SCOPE. The guard keys on errVLANCreateFailed, which marks netlink.LinkAdd
+// refusing — and nothing else. The absent-parent case keeps its soft skip
+// because #6893 itself hedges on it as arguably legitimate; the
+// created-but-unusable cases keep theirs because the link EXISTS, so
+// compileFirewallFilters resolves it and the filter IS assigned — the harm this
+// issue is about does not arise there. The third subtest pins that scope: a
+// non-create failure must still be soft-skipped, or this change has quietly
+// become "refuse every VLAN problem".
+func TestVLANCreateFailureFailsTheApply_6893(t *testing.T) {
+	const physName = "ge-0-0-2"
+
+	newState := func() *zoneMapState {
+		return &zoneMapState{
+			writtenIfaceZone: map[IfaceZoneKey]bool{},
+			writtenVlanIface: map[uint32]bool{},
+			attached:         map[int]bool{},
+			attachedXDP:      map[int]bool{},
+			tunnelIfindexes:  map[int]bool{},
+		}
+	}
+	newCfg := func() *config.Config {
+		cfg := &config.Config{}
+		cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+			physName: {
+				Name:  physName,
+				Units: map[int]*config.InterfaceUnit{50: {Number: 50, VlanID: 50}},
+			},
+		}
+		return cfg
+	}
+	newResult := func() *CompileResult {
+		return &CompileResult{
+			ifCache: map[string]*net.Interface{physName: {Index: 42, Name: physName}},
+			// markHostMutated writes here on the created=true path (#4960);
+			// the VLAN child is queued for generic XDP on the success path.
+			hostMutations:       map[string]bool{},
+			genericXDPIfindexes: map[int]bool{},
+		}
+	}
+
+	orig := ensureVLANSubInterfaceFn
+	t.Cleanup(func() { ensureVLANSubInterfaceFn = orig })
+
+	t.Run("creation failure fails the apply", func(t *testing.T) {
+		ensureVLANSubInterfaceFn = func(string, int) (int, bool, error) {
+			return 0, false, errors.Join(errVLANCreateFailed, errors.New("operation not permitted"))
+		}
+		st := newState()
+		err := st.mapZoneInterface(&recordingFilterDP{}, newCfg(), newResult(),
+			"trust", &config.ZoneConfig{Name: "trust"}, 1, physName+".50", map[string]uint32{})
+		if err == nil {
+			t.Fatal("a VLAN sub-interface that could not be CREATED must fail the apply — " +
+				"the device does not exist, compileFirewallFilters will miss it, and the " +
+				"filter bound to it is silently not assigned (#6893)")
+		}
+		if !strings.Contains(err.Error(), "50") {
+			t.Errorf("error %q does not name the surface — an operator needs to know WHICH "+
+				"interface refused", err)
+		}
+	})
+
+	t.Run("the guard's predicate selects ONLY the create failure", func(t *testing.T) {
+		// The success PATH is not unit-drivable: past the VLAN branch
+		// mapZoneInterface does physical-interface setup that needs netlink and
+		// a real DataPlane, and chasing that with stubs would test the stubs.
+		// So the "not refused" half is proven at the discriminator instead —
+		// which is the thing that could widen — plus the soft-skip row below,
+		// which drives the real function.
+		for _, tc := range []struct {
+			name string
+			err  error
+			want bool
+		}{
+			{"success", nil, false},
+			{"absent parent", errors.New("parent interface ge-0-0-2: no such device"), false},
+			{"created but not findable", errors.New("find created VLAN sub-interface ge-0-0-2.50: x"), false},
+			{"created but not up", errors.New("set VLAN sub-interface ge-0-0-2.50 up: x"), false},
+			{"LinkAdd refused", errors.Join(errVLANCreateFailed, errors.New("operation not permitted")), true},
+		} {
+			if got := tc.err != nil && errors.Is(tc.err, errVLANCreateFailed); got != tc.want {
+				t.Errorf("%s: guard fires = %v, want %v — the scope of this change is "+
+					"netlink.LinkAdd refusing and nothing else", tc.name, got, tc.want)
+			}
+		}
+	})
+
+	t.Run("a NON-create failure keeps its soft skip", func(t *testing.T) {
+		ensureVLANSubInterfaceFn = func(string, int) (int, bool, error) {
+			// The absent-parent shape: no errVLANCreateFailed marker.
+			return 0, false, errors.New("parent interface ge-0-0-2: no such device")
+		}
+		st := newState()
+		result := newResult()
+		err := st.mapZoneInterface(&recordingFilterDP{}, newCfg(), result,
+			"trust", &config.ZoneConfig{Name: "trust"}, 1, physName+".50", map[string]uint32{})
+		if err != nil {
+			t.Fatalf("a non-create VLAN failure must keep the soft skip, got %v — this change "+
+				"is scoped to netlink.LinkAdd refusing, and widening it silently would "+
+				"refuse configs #6893 deliberately does not take a position on", err)
+		}
+		if len(result.unarmedSurfaces) == 0 {
+			t.Error("the soft skip must still RECORD the unarmed surface — dropping the record " +
+				"while keeping the skip would lose the trace #5275 added")
+		}
+	})
+}

--- a/pkg/dataplane/vlan_filter_failopen_6893_test.go
+++ b/pkg/dataplane/vlan_filter_failopen_6893_test.go
@@ -24,10 +24,23 @@ import (
 // child absent reproduces exactly the post-soft-skip state — the parent
 // resolves, `ge-0-0-2.50` does not — with no netlink and no privileges.
 //
-// WHAT THIS CELL WILL BECOME. #6893's fix direction 1 makes a VLAN creation
-// failure fail the apply. When that lands, the `err != nil` assertion here
-// inverts, and that inversion is its done-signal. Until then this pins the
-// CURRENT behaviour honestly, including that it is a fail-open.
+// WHAT PART 2 CHANGED, and a correction to what this comment used to predict.
+// It said the `err != nil` assertion here would INVERT once a VLAN creation
+// failure failed the apply. It does not, and the anticipation named the wrong
+// function: part 2's guard is in `mapZoneInterface`, and `compileZones` runs
+// BEFORE `compileFirewallFilters` (compiler.go :304 and :366, both
+// `if err != nil { return }`). So a creation failure now aborts the apply
+// before this function is ever reached.
+//
+// This cell therefore still describes `compileFirewallFilters` in isolation
+// truthfully — that is exactly what it does when handed an unresolvable
+// sub-interface — but the route it models is no longer reachable through a
+// creation failure. It stays reachable through the ABSENT-PHYSICAL skip, which
+// part 2 deliberately leaves soft, so the cell is still guarding a live path.
+//
+// The done-signal idea was right and its location was wrong. Part 2's own
+// paired proof lives at the layer the guard is in
+// (vlan_create_failclosed_6893_test.go).
 func TestVLANSubInterfaceFilterSilentlyUnapplied_6893(t *testing.T) {
 	const physName = "ge-0-0-2"
 	const subName = "ge-0-0-2.50"
@@ -159,4 +172,59 @@ func newIfaceFilterRecordingDP6893() *ifaceFilterRecordingDP6893 {
 func (d *ifaceFilterRecordingDP6893) SetIfaceFilter(key IfaceFilterKey, id uint32) error {
 	d.ifaceFilters[key] = id
 	return nil
+}
+
+// Site A: the INTERFACE-NOT-FOUND miss, which is the sibling of the VLAN miss
+// above and was recording without anything binding it.
+//
+// Flagged during review of part 1: dropping the recording at that site left the
+// package fully green, so it read as covered only because its sibling was. That
+// asymmetry is the same shape #6893 is about — a thing that looks recorded
+// because something adjacent is — one level down, in the tests rather than the
+// code.
+//
+// Part 2 deliberately leaves this path a SOFT SKIP (#6893 hedges on an
+// interface configured but absent from this chassis as arguably legitimate), so
+// the record is the only trace it has, and it should be bound.
+func TestMissingInterfaceFilterBindingRecorded_6893(t *testing.T) {
+	const physName = "ge-0-0-9"
+
+	cfg := &config.Config{}
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"wan-in": {
+			Name:  "wan-in",
+			Terms: []*config.FirewallFilterTerm{{Name: "deny-all", Action: "discard"}},
+		},
+	}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		physName: {
+			Name:  physName,
+			Units: map[int]*config.InterfaceUnit{0: {Number: 0, FilterInputV4: "wan-in"}},
+		},
+	}
+
+	dp := newIfaceFilterRecordingDP6893()
+	// Nothing seeded: the physical interface itself does not resolve.
+	result := &CompileResult{}
+
+	if err := compileFirewallFilters(dp, cfg, result); err != nil {
+		t.Fatalf("compileFirewallFilters: %v", err)
+	}
+	if len(dp.ifaceFilters) != 0 {
+		t.Fatalf("fixture broken: the filter WAS assigned — the interface must be "+
+			"unresolvable for this cell to mean anything (%d bindings)", len(dp.ifaceFilters))
+	}
+
+	bindings := result.UnappliedFilterBindings()
+	if len(bindings) != 1 {
+		t.Fatalf("want 1 unapplied-binding record for the missing-interface miss, got %d (%+v)",
+			len(bindings), bindings)
+	}
+	if bindings[0].Interface != physName {
+		t.Errorf("record names %q, want %q", bindings[0].Interface, physName)
+	}
+	if !strings.Contains(bindings[0].Reason, "interface not resolvable") {
+		t.Errorf("reason = %q, want the interface-resolution failure — the physical-miss and "+
+			"VLAN-miss paths must stay distinguishable in the record", bindings[0].Reason)
+	}
 }


### PR DESCRIPTION
#6893 **part 2 of 2**. A VLAN sub-interface that cannot be **created** now fails
the apply, instead of being soft-skipped into a clean commit whose filter
binding silently went missing.

Closes #6893

## Scoped to one failure, chosen by harm

`ensureVLANSubInterface` has four error returns. `errVLANCreateFailed` marks
exactly one — `netlink.LinkAdd` refusing — and `mapZoneInterface` fails the
apply on `errors.Is`. The other three keep their soft skip:

| error | kept soft because |
|---|---|
| `parent interface %s` | the absent-PHYSICAL case, which #6893 itself hedges on as arguably legitimate |
| `find created ...` | reports `created=true`, so the link **exists** |
| `set ... up` | same — the link exists, `compileFirewallFilters` resolves it, **the filter IS assigned** |

For the last two the filed harm does not arise at all, so failing the apply
would refuse a config for a reason this issue is not about.

## Paired proof, with the gap named rather than faked

| row | drives | result |
|---|---|---|
| creation **fails** | the real `mapZoneInterface` | apply fails, error names the surface |
| a **non-create** failure | the real `mapZoneInterface` | soft skip preserved **and** still recorded |
| the guard's predicate | direct | true only for the LinkAdd refusal; false for nil, absent-parent, not-findable, not-up |

**The creation-SUCCESS row is not driven, and that is stated rather than
worked around.** Past the VLAN branch `mapZoneInterface` does physical-interface
setup needing netlink and a real `DataPlane` — I chased two nil-map panics into
a third nil-pointer before stopping. Forcing it with stubs would have tested the
stubs. The "not refused" half is carried by the discriminator row plus the
non-create row, which does drive the real function.

## A correction to part 1's own anticipation

Part 1's cell doc predicted its `err != nil` assertion would **invert** when this
landed. **It does not, and the anticipation named the wrong function.** The
guard is in `mapZoneInterface`, and `compileZones` runs *before*
`compileFirewallFilters` (`compiler.go:304` and `:366`, both
`if err != nil { return }`), so a creation failure now aborts the apply before
that function is reached.

That cell still describes `compileFirewallFilters` truthfully, and still guards
a live path — the absent-physical skip, which this PR deliberately leaves soft.
Its framing is corrected in place rather than left to mislead. The done-signal
idea was right; its location was wrong.

## Site A, bound

Review found that dropping the recording at the **interface-not-found** miss
left the package fully green — it read as covered only because its VLAN sibling
was. That is the #6893 asymmetry one level down, in the tests rather than the
code. `TestMissingInterfaceFilterBindingRecorded_6893` binds it, and asserts the
two paths stay distinguishable in the record.

## Gates

Gated head **`fe4dc0f267ea0bccade27bf40ca9d37b2b292960`**.

- `go test ./... -count=1` — **rc 0**, 68 packages ok.
- `gofmt` clean; `go build ./...` ok.
- `git merge-base --is-ancestor e26e61fbf fe4dc0f26` succeeds.

No Rust gate: the diff is Go and a log, so a Rust run would measure master.
