### PR TITLE
api: bind the diagnostic arg bound across REST and gRPC (#6904)

### DIFF
--- a/docs/log/6904.md
+++ b/docs/log/6904.md
@@ -1,0 +1,61 @@
+# #6904 — REST/gRPC diagnostic argument bound divergence
+
+- **Timestamp**: 2026-08-27
+- **Action**: Bind the agreement; do not add a second literal
+  - **Is 512 chosen or derived?** CHOSEN. The gRPC comment states its own
+    reasoning: a DNS name is capped at 253 octets (RFC 1035), an IPv6 literal at
+    ~45, a VRF name is short — so 512 is largest-legitimate-plus-headroom, not a
+    protocol constant. There is no external authority to pin both surfaces to,
+    which is exactly why their AGREEMENT is the property and a shared constant
+    is the right shape. (The RFC 1035 253 is an INPUT to the choice, not the
+    bound.)
+  - **Enumerated both surfaces before assuming one bound was the whole gap**:
+
+    | check | gRPC | REST |
+    |---|---|---|
+    | target required | yes | yes |
+    | per-field length bound | yes | **no — the gap** |
+    | count clamp [1,100] | yes | yes |
+    | Size clamp to `diagcmd.MaxPingSize` | yes | yes |
+    | shared concurrency limiter | yes | yes |
+    | exec timeout | yes | yes |
+
+    One divergence, and the surrounding pattern is ALREADY single-sourced
+    through `pkg/diagcmd` — which is what told me where the shared checker
+    belongs (next to `MaxPingSize` / `DefaultLimiter`), rather than REST
+    importing `pkg/grpcapi`.
+  - **Severity: I agree with MEDIUM, with one bounding factor corrected.** Two
+    of the three hold — argv not shell (verified: `exec.CommandContext(argv[0],
+    argv[1:]...)`), and the limiter + per-request timeouts exist and are shared.
+    **The "localhost-bound" leg has rotted**: `pkg/api/server.go:1732` says the
+    API binds loopback "by default", and `pkg/daemon/daemon_cluster_bind.go`
+    resolves a web-management interface bind from config, with loopback only as
+    the FALLBACK when the configured interface is unusable. So the surface is
+    operator-configurable onto a real interface. Medium still stands on the
+    other two factors, but a reader should not conclude the surface is
+    unreachable remotely by construction.
+  - **Three mutation cells, all RED, all at the control count of 1862**:
+    - REST ping drops the bound -> the agreement test
+    - REST traceroute drops the bound -> the agreement test
+    - gRPC drops the bound -> the agreement test AND `TestDiagFieldLengthRejected`
+  - **The third cell caught a defect in my own test, via the collected count.**
+    It first reported RED at **613** against a control of **1862**. The
+    agreement driver passes a nil stream, which is safe only WHILE the bound
+    rejects before the stream is touched — remove the check and the call
+    proceeds into `streamDiag`, dereferences nil, and kills the package binary.
+    A future revert would have read as a mass crash rather than a named
+    failure. Made panic-safe (a panic there means validation did not reject,
+    which is the verdict the caller needs), and the count went 613 -> 1284 —
+    still short, because the PRE-EXISTING `TestDiagFieldLengthRejected` has the
+    same fragility and was killing `pkg/grpcapi`. Fixed there too: 1862, exactly
+    the control.
+  - **Scope stated rather than implied**: the agreement table drives gRPC only
+    on the REJECT rows. An ACCEPT row would proceed into `streamDiag` and spawn
+    a real ping child. The reject direction is the one that was asymmetric.
+  - **The pre-existing test that pinned the local `maxDiagArgLen` now reads
+    `diagcmd.MaxArgLen`** — a test pinned to its own literal would keep passing
+    while the surfaces drifted, which is the failure the move exists to prevent.
+  - **File(s)**: `pkg/diagcmd/diagcmd.go`, `pkg/api/system.go`,
+    `pkg/grpcapi/server_diag_ping.go`,
+    `pkg/grpcapi/server_diag_scanner_leak_5060_test.go`,
+    `pkg/api/diag_arg_bound_agreement_6904_test.go`, `docs/log/6904.md`

--- a/pkg/api/diag_arg_bound_agreement_6904_test.go
+++ b/pkg/api/diag_arg_bound_agreement_6904_test.go
@@ -1,0 +1,153 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/diagcmd"
+	"github.com/psaab/xpf/pkg/grpcapi"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #6904 — THE AGREEMENT between the two diagnostic surfaces.
+//
+// gRPC bounded target/source/routing-instance at 512 (#5060); REST bounded
+// nothing. One surface was hardened and the sibling was missed, so the
+// guarantee the gRPC check was supposed to give was not a system property.
+//
+// WHY THIS TEST IS SHAPED THIS WAY. Adding a second `512` to REST would fix
+// today and leave the two free to drift again — which is how this got here. So
+// the bound lives once, in pkg/diagcmd next to MaxPingSize, and this table
+// drives BOTH surfaces with the SAME inputs and requires the SAME verdict. A
+// REST-only test would leave the asymmetry re-introducible from the gRPC side,
+// and a test pinned to its own literal would keep passing while the surfaces
+// diverged.
+//
+// The bound is CHOSEN, not derived from an external authority — a DNS name is
+// capped at 253 (RFC 1035) and an IPv6 literal at ~45, so 512 is
+// largest-legitimate-plus-headroom. That is why the two surfaces AGREEING is
+// the whole property here: there is no third source of truth to pin them to.
+//
+// SCOPE, stated rather than implied: the gRPC surface is driven only on the
+// REJECT rows. Its length check runs before the stream is touched, so a nil
+// stream is safe there, but an ACCEPT row proceeds into streamDiag and would
+// spawn a real ping child. The reject direction is the one that was asymmetric
+// and is what this binds; the gRPC accept direction is covered by pkg/grpcapi's
+// own tests.
+//
+// Fail-on-revert: drop diagcmd.CheckArgs from either handler and the rows for
+// that surface go RED while the other surface's stay green — which is exactly
+// the asymmetry this issue is about.
+func TestDiagArgBoundAgreesAcrossSurfaces_6904(t *testing.T) {
+	oversized := strings.Repeat("a", diagcmd.MaxArgLen+1)
+	atLimit := strings.Repeat("a", diagcmd.MaxArgLen)
+
+	rows := []struct {
+		name            string
+		target          string
+		source          string
+		routingInstance string
+		wantReject      bool
+	}{
+		{"legitimate target", "192.0.2.1", "", "", false},
+		{"target at the limit", atLimit, "", "", false},
+		{"target one over", oversized, "", "", true},
+		{"source one over", "192.0.2.1", oversized, "", true},
+		{"routing-instance one over", "192.0.2.1", "", oversized, true},
+	}
+
+	for _, row := range rows {
+		t.Run(row.name, func(t *testing.T) {
+			ruleRejects := diagcmd.CheckArgs(row.target, row.source, row.routingInstance) != nil
+			restRejected := restPingRejects6904(t, row.target, row.source, row.routingInstance)
+
+			if ruleRejects != row.wantReject {
+				t.Fatalf("the SHARED rule rejected=%v, want %v — the table's premise is "+
+					"wrong before either surface is consulted", ruleRejects, row.wantReject)
+			}
+			if restRejected != row.wantReject {
+				t.Errorf("REST rejected=%v, want %v — the REST surface must enforce the "+
+					"same per-field bound as gRPC (#6904)", restRejected, row.wantReject)
+			}
+			if restRejected != ruleRejects {
+				t.Errorf("REST DISAGREES WITH THE SHARED RULE: rest=%v rule=%v. Two entry "+
+					"points to one operation must not differ about what input is "+
+					"acceptable — that asymmetry IS the defect (#6904)",
+					restRejected, ruleRejects)
+			}
+
+			// The gRPC surface is driven only on the REJECT rows. Its length
+			// check runs before the stream is touched, so a nil stream is safe
+			// there — but an ACCEPT row proceeds into streamDiag and would
+			// spawn a real ping child, which a unit test must not do. The
+			// accept direction on that surface is covered by pkg/grpcapi's own
+			// tests; what this table exists to bind is that the two surfaces
+			// REJECT the same inputs, which is the direction that was asymmetric.
+			// REST traceroute is the sibling handler and takes the same three
+			// fields; without this row a revert there would be invisible.
+			if got := restTracerouteRejects6904(t, row.target, row.source, row.routingInstance); got != row.wantReject {
+				t.Errorf("REST traceroute rejected=%v, want %v — both REST diagnostic "+
+					"handlers must enforce the bound, not just ping", got, row.wantReject)
+			}
+
+			if row.wantReject {
+				if !grpcPingRejects6904(row.target, row.source, row.routingInstance) {
+					t.Errorf("gRPC accepted an input the shared rule rejects — the surfaces " +
+						"have drifted apart again (#6904)")
+				}
+			}
+		})
+	}
+}
+
+// restPingRejects6904 drives the real REST ping handler and reports whether it
+// refused the request before reaching exec. diagRun is stubbed so a request
+// that PASSES validation cannot spawn a child in the test environment.
+func restPingRejects6904(t *testing.T, target, source, ri string) bool {
+	t.Helper()
+	orig := diagRun
+	t.Cleanup(func() { diagRun = orig })
+	diagRun = func(ctx context.Context, argv []string) (string, error) { return "stubbed", nil }
+
+	body, err := json.Marshal(PingRequest{Target: target, Source: source, RoutingInstance: ri})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest("POST", "/api/v1/diagnostics/ping", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	(&Server{}).pingHandler(w, req)
+	return w.Code >= 400
+}
+
+// grpcPingRejects6904 drives the real gRPC Ping validation. The length check
+// runs before the stream is touched, so a nil stream is safe — the same
+// property TestDiagFieldLengthRejected relies on.
+func grpcPingRejects6904(target, source, ri string) bool {
+	err := (&grpcapi.Server{}).Ping(&pb.PingRequest{
+		Target: target, Source: source, RoutingInstance: ri,
+	}, nil)
+	return err != nil
+}
+
+// restTracerouteRejects6904 is restPingRejects6904 for the sibling handler.
+func restTracerouteRejects6904(t *testing.T, target, source, ri string) bool {
+	t.Helper()
+	orig := diagRun
+	t.Cleanup(func() { diagRun = orig })
+	diagRun = func(ctx context.Context, argv []string) (string, error) { return "stubbed", nil }
+
+	body, err := json.Marshal(TracerouteRequest{Target: target, Source: source, RoutingInstance: ri})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest("POST", "/api/v1/diagnostics/traceroute", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	(&Server{}).tracerouteHandler(w, req)
+	return w.Code >= 400
+}

--- a/pkg/api/diag_arg_bound_agreement_6904_test.go
+++ b/pkg/api/diag_arg_bound_agreement_6904_test.go
@@ -127,7 +127,24 @@ func restPingRejects6904(t *testing.T, target, source, ri string) bool {
 // grpcPingRejects6904 drives the real gRPC Ping validation. The length check
 // runs before the stream is touched, so a nil stream is safe — the same
 // property TestDiagFieldLengthRejected relies on.
-func grpcPingRejects6904(target, source, ri string) bool {
+func grpcPingRejects6904(target, source, ri string) (rejected bool) {
+	// PANIC-SAFE, and the reason is a real property of the thing under test.
+	// The nil stream is safe only WHILE the length check rejects before the
+	// stream is touched. Remove that check — the exact revert this table
+	// exists to catch — and the call proceeds into streamDiag and dereferences
+	// the nil stream, killing the whole package binary and taking ~1200
+	// unrelated tests with it. A revert would then look like a mass failure
+	// instead of a named one, and the collected count would drop to a third of
+	// the control: the "did it RED or did it CRASH" tell.
+	//
+	// A panic here means validation did NOT reject, which is exactly the
+	// verdict the caller needs, so recovering and reporting false is truthful
+	// rather than a workaround.
+	defer func() {
+		if recover() != nil {
+			rejected = false
+		}
+	}()
 	err := (&grpcapi.Server{}).Ping(&pb.PingRequest{
 		Target: target, Source: source, RoutingInstance: ri,
 	}, nil)

--- a/pkg/api/system.go
+++ b/pkg/api/system.go
@@ -121,6 +121,14 @@ func (s *Server) pingHandler(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "target required")
 		return
 	}
+	// #6904: bound every operator-supplied string field before it reaches exec
+	// argv. The gRPC sibling has enforced this since #5060; REST did not, so
+	// the guarantee was not a system property. Both surfaces now call the same
+	// diagcmd.CheckArgs — sharing the RULE, not a second literal 512.
+	if err := diagcmd.CheckArgs(req.Target, req.Source, req.RoutingInstance); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
 	count := req.Count
 	if count <= 0 {
@@ -163,6 +171,11 @@ func (s *Server) tracerouteHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Target == "" {
 		writeError(w, http.StatusBadRequest, "target required")
+		return
+	}
+	// #6904: same bound as the ping handler and the gRPC surface.
+	if err := diagcmd.CheckArgs(req.Target, req.Source, req.RoutingInstance); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/pkg/diagcmd/diagcmd.go
+++ b/pkg/diagcmd/diagcmd.go
@@ -11,7 +11,10 @@
 // applied three times; it now lives here too.
 package diagcmd
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // vrfPrefix is the prefix the daemon uses for the kernel VRF master
 // device that backs a Junos routing-instance (a routing-instance named
@@ -49,6 +52,54 @@ func VRFDeviceName(name string) string {
 // contract, but the shared ceiling lives here so every surface stays in
 // lockstep (#5250 A8-b1 F4 for REST/gRPC; #6382 for the console CLI).
 const MaxPingSize = 65507
+
+// MaxArgLen bounds each operator-supplied diagnostic STRING argument
+// (target, source, routing-instance) at every control surface (#6904).
+//
+// It is a CHOSEN ceiling, not a protocol constant, and it lives here for the
+// same reason MaxPingSize does: two surfaces enforcing the same rule from two
+// literals is how they drift. #6904 is that drift — gRPC bounded these fields
+// and REST did not, so the guarantee the gRPC check was supposed to give was
+// not a system property.
+//
+// The value is derived from the largest LEGITIMATE input with headroom: a DNS
+// name is capped at 253 octets (RFC 1035), an IPv6 literal at ~45, and a VRF
+// name is short. 512 accepts every legitimate value while rejecting a
+// pathological field far below the streamDiagCmd line-scanner token cap. The
+// gRPC receive limit is 16 MiB, so without this bound a multi-kilobyte target
+// reaches exec and surfaces as a single combined-output line larger than the
+// scanner token size — the ErrTooLong leak vector fixed in streamDiagCmd
+// (#5060). REST has no equivalent receive cap of its own.
+const MaxArgLen = 512
+
+// CheckArg rejects an over-length diagnostic argument so an oversized field
+// never reaches exec or the combined-output line scanner (#6904).
+//
+// It returns a plain error naming the field and both lengths; each surface
+// wraps it in its own transport error — gRPC in codes.InvalidArgument, REST in
+// a 400 — so the surfaces share the RULE without sharing a status vocabulary.
+func CheckArg(name, v string) error {
+	if len(v) > MaxArgLen {
+		return fmt.Errorf("%s exceeds %d bytes (%d)", name, MaxArgLen, len(v))
+	}
+	return nil
+}
+
+// CheckArgs bounds the shared ping/traceroute string fields in one pass, in a
+// FIXED order so both surfaces report the same field first for a request that
+// violates more than one.
+func CheckArgs(target, source, routingInstance string) error {
+	for _, f := range []struct{ name, val string }{
+		{"target", target},
+		{"source", source},
+		{"routing-instance", routingInstance},
+	} {
+		if err := CheckArg(f.name, f.val); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 // PingOptions carries the already-validated, already-clamped ping
 // parameters the three control surfaces collect from their respective

--- a/pkg/grpcapi/server_diag_ping.go
+++ b/pkg/grpcapi/server_diag_ping.go
@@ -17,38 +17,16 @@ import (
 
 // --- Diagnostic RPCs ---
 
-// maxDiagArgLen bounds each operator-supplied diagnostic argument
-// (target, source, routing-instance) at the RPC boundary. A DNS name is
-// capped at 253 octets (RFC 1035), an IPv6 literal at ~45, and a VRF
-// name is short, so 512 accepts every legitimate value while rejecting a
-// pathological field far below the streamDiagCmd line-scanner token cap.
-// The gRPC receive limit is 16 MiB, so without this bound a multi-kilobyte
-// target reaches exec and surfaces as a single combined-output line larger
-// than the scanner token size — the ErrTooLong leak vector fixed in
-// streamDiagCmd (#5060).
-const maxDiagArgLen = 512
-
-// checkDiagArg rejects an over-length diagnostic argument with
-// InvalidArgument so an oversized field never reaches exec or the
-// combined-output line scanner.
-func checkDiagArg(name, v string) error {
-	if len(v) > maxDiagArgLen {
-		return status.Errorf(codes.InvalidArgument,
-			"%s exceeds %d bytes (%d)", name, maxDiagArgLen, len(v))
-	}
-	return nil
-}
-
-// checkDiagArgs bounds the shared ping/traceroute fields in one pass.
+// checkDiagArgs bounds the shared ping/traceroute string fields, delegating to
+// diagcmd.CheckArgs so this surface and the REST one cannot drift (#6904).
+//
+// The bound itself and its reasoning live in pkg/diagcmd next to MaxPingSize:
+// this used to hold its own `maxDiagArgLen = 512`, REST held nothing, and the
+// asymmetry is what #6904 filed. Only the transport error is local — the RULE
+// is shared.
 func checkDiagArgs(target, source, routingInstance string) error {
-	for _, f := range []struct{ name, val string }{
-		{"target", target},
-		{"source", source},
-		{"routing-instance", routingInstance},
-	} {
-		if err := checkDiagArg(f.name, f.val); err != nil {
-			return err
-		}
+	if err := diagcmd.CheckArgs(target, source, routingInstance); err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 	return nil
 }

--- a/pkg/grpcapi/server_diag_scanner_leak_5060_test.go
+++ b/pkg/grpcapi/server_diag_scanner_leak_5060_test.go
@@ -114,9 +114,31 @@ func TestDiagFieldLengthRejected(t *testing.T) {
 		{"source", &pb.PingRequest{Target: legit, Source: oversized}},
 		{"routing-instance", &pb.PingRequest{Target: legit, RoutingInstance: oversized}},
 	}
+	// #6904: the nil stream is safe only WHILE the bound rejects before the
+	// stream is touched. Remove the check — the revert this test exists to
+	// catch — and the call proceeds into streamDiag, dereferences nil, and
+	// kills the package binary, so the revert reads as a mass crash instead of
+	// a named failure and the collected count collapses. Recovering keeps the
+	// signal NAMED; a panic here means the bound did not reject, which is the
+	// failure this test reports either way.
+	callRejects := func(t *testing.T, call func() error) error {
+		t.Helper()
+		var err error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					err = status.Errorf(codes.Unknown,
+						"validation did not reject: reached the stream and panicked (%v)", r)
+				}
+			}()
+			err = call()
+		}()
+		return err
+	}
+
 	for _, c := range pingCases {
 		t.Run("ping/"+c.name, func(t *testing.T) {
-			err := s.Ping(c.req, nil)
+			err := callRejects(t, func() error { return s.Ping(c.req, nil) })
 			if status.Code(err) != codes.InvalidArgument {
 				t.Fatalf("Ping oversized %s = %v, want InvalidArgument", c.name, err)
 			}
@@ -133,7 +155,7 @@ func TestDiagFieldLengthRejected(t *testing.T) {
 	}
 	for _, c := range traceCases {
 		t.Run("traceroute/"+c.name, func(t *testing.T) {
-			err := s.Traceroute(c.req, nil)
+			err := callRejects(t, func() error { return s.Traceroute(c.req, nil) })
 			if status.Code(err) != codes.InvalidArgument {
 				t.Fatalf("Traceroute oversized %s = %v, want InvalidArgument", c.name, err)
 			}

--- a/pkg/grpcapi/server_diag_scanner_leak_5060_test.go
+++ b/pkg/grpcapi/server_diag_scanner_leak_5060_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/psaab/xpf/pkg/diagcmd"
 	"runtime"
 	"testing"
 	"time"
@@ -92,7 +93,11 @@ func assertGoroutinesSettle(t *testing.T, baseline int) {
 // scanner. Validation runs before the stream is touched, so a nil stream
 // is safe here. Revert the checkDiagArgs calls and this test fails.
 func TestDiagFieldLengthRejected(t *testing.T) {
-	huge := make([]byte, maxDiagArgLen+1)
+	// #6904: the bound moved to pkg/diagcmd so REST and gRPC share ONE rule.
+	// This reads the shared constant rather than a local literal — a test
+	// pinned to its own 512 would keep passing while the surfaces drifted,
+	// which is the failure this move exists to prevent.
+	huge := make([]byte, diagcmd.MaxArgLen+1)
 	for i := range huge {
 		huge[i] = 'a'
 	}


### PR DESCRIPTION
gRPC bounded `target`/`source`/`routing-instance` at 512 (#5060); REST bounded
nothing. One surface was hardened and the sibling was missed, so the guarantee
the gRPC check was supposed to give **was not a system property**.

Closes #6904

## Bind the agreement, not a second literal

Adding another `512` to REST would fix today and leave the two free to drift
again — which is how this got here. So the bound and its checker move to
`pkg/diagcmd`, next to `MaxPingSize` and `DefaultLimiter`, which both surfaces
**already** share. Each wraps the plain error in its own transport status
(gRPC `InvalidArgument`, REST 400), so they share the *rule* without sharing a
status vocabulary.

**Is 512 chosen or derived?** **Chosen** — the gRPC comment states its own
reasoning: a DNS name is capped at 253 octets (RFC 1035), an IPv6 literal at
~45, a VRF name is short, so 512 is largest-legitimate-plus-headroom. The RFC's
253 is an *input* to the choice, not the bound. There is no external authority
to pin both surfaces to, which is exactly why their **agreement** is the
property and a shared constant is the right shape.

## Enumerated both surfaces before assuming one bound was the whole gap

| check | gRPC | REST |
|---|---|---|
| target required | yes | yes |
| **per-field length bound** | **yes** | **no — the gap** |
| count clamp [1,100] | yes | yes |
| Size clamp to `diagcmd.MaxPingSize` | yes | yes |
| shared concurrency limiter | yes | yes |
| exec timeout | yes | yes |

One divergence — and the surrounding pattern is already single-sourced through
`pkg/diagcmd`, which is what told me where the shared checker belongs rather
than having REST import `pkg/grpcapi`.

## Severity: MEDIUM stands, with one bounding factor corrected

The issue downgrades its own source review from High to Medium. Two of its three
factors hold: **not command injection** (verified — `exec.CommandContext(argv[0],
argv[1:]...)`, no shell) and **adjacent limits exist** (limiter + per-request
timeouts, both shared).

**The "localhost-bound" factor has rotted.** `pkg/api/server.go:1732` says the
API binds loopback *"by default"*, and `pkg/daemon/daemon_cluster_bind.go`
resolves a **web-management interface** bind from config with loopback only as
the *fallback* when the configured interface is unusable. The surface is
operator-configurable onto a real interface. Medium still stands on the other
two factors, but a reader should not conclude the surface is unreachable
remotely by construction.

## Mutation matrix — all RED at the control count

Control: **1862** collected across `pkg/api` + `pkg/grpcapi`.

| cell | verdict | collected | named |
|---|---|---|---|
| REST ping drops the bound | RED | 1862 | the agreement test |
| REST traceroute drops the bound | RED | 1862 | the agreement test |
| gRPC drops the bound | RED | **1862** | the agreement test **and** `TestDiagFieldLengthRejected` |

**The third cell caught a defect in my own test, via the collected count.** It
first reported RED at **613** against a control of 1862. The agreement driver
passes a nil stream, which is safe only *while* the bound rejects before the
stream is touched — remove the check and the call proceeds into `streamDiag`,
dereferences nil, and kills the package binary. A future revert would have read
as a mass crash rather than a named failure.

Made panic-safe (a panic there means validation did **not** reject, which is the
verdict the caller needs, so recovering is truthful rather than a workaround).
613 → **1284** — still short, because the **pre-existing**
`TestDiagFieldLengthRejected` has the same fragility and was killing
`pkg/grpcapi`. Fixed there too: **1862**, exactly the control.

## Scope, stated rather than implied

The agreement table drives gRPC only on the **reject** rows. Its length check
runs before the stream is touched, so a nil stream is safe there, but an accept
row would proceed into `streamDiag` and spawn a real `ping` child. The reject
direction is the one that was asymmetric; the gRPC accept direction is covered
by `pkg/grpcapi`'s own tests.

The pre-existing test that pinned the local `maxDiagArgLen` now reads
`diagcmd.MaxArgLen` — a test pinned to its own literal would keep passing while
the surfaces drifted, which is the failure this move exists to prevent.

## Gates

Gated head **`f5cd1d2be27f046f042a7366aab2a177dc69ab23`**.

- `go test ./... -count=1` — **rc 0**, 68 packages ok.
- `gofmt` clean; `go build ./...` ok.
- `git merge-base --is-ancestor a028a673f f5cd1d2be` succeeds.

No Rust gate: the diff is Go and a log.
