### PR TITLE
nat: drain a pool quarantined for an interface-SNAT egress overlap

### DIFF
--- a/docs/log/7717.md
+++ b/docs/log/7717.md
@@ -60,3 +60,68 @@
   - **File(s)**: pkg/dataplane/userspace/nat_iface_pool_overlap.go,
     pkg/dataplane/userspace/nat_iface_pool_overlap_7717_test.go,
     pkg/dataplane/userspace/builder.go, docs/log/7717.md
+
+- **Timestamp**: 2026-08-27 (third entry — the DRAIN, written fresh)
+  - **Action**: enabled the quarantine and shipped the drain that makes it safe,
+    in one change, so both can be made to fire by a test.
+  - **Written fresh, not adopted.** The rescued 331-line implementation was read
+    for shape only. It is inert alone (measured in the first entry), its doc
+    comment states the hazard incorrectly, and its author's lane died having
+    never validated it. Every line here is one I would have written; nothing was
+    carried across.
+  - **The mechanism, in three parts**:
+    1. **Go**: the overlap detector now sets `PoolUnusable` +
+       `PoolUnusableReason = "iface_snat_egress_overlap"` on the offending pool.
+       `PoolUnusable` is the SHIPPED transport — the Rust side already maps it
+       onto `pool_failure`, which already refuses new mints. An existing reason
+       is preserved rather than overwritten: a pool already unusable for its own
+       sake keeps its specific diagnosis.
+    2. **Rust retention**: `drain_allocator_key()` is a strict WIDENING of
+       `allocator_key()` that ignores `pool_failure`, used at the carry-over
+       site. `allocator_key()` refusing a failed pool is right for MINTING and
+       wrong for RETENTION — a quarantined pool's live flows still hold real
+       identities, and dropping the allocator is exactly the stranding the
+       merged config gate names. A new phase in `resolve_pool_allocators`
+       reuses (never creates) the previous allocator for a draining rule, and
+       charges it through the same `PendingPoolAllocator::charge` formula so
+       the aggregate budget does not admit new keys against capacity still in
+       use.
+    3. **Rust quarantine**: an interface-mode mint on an address a quarantined
+       pool is still draining fails CLOSED with a dedicated
+       `InterfaceOverlapDraining` reason. Fail closed rather than PAT: the
+       interface registry cannot enumerate the pool's held ports, so "PAT to
+       something else" would be a guess.
+  - **Scoped to the overlap variant deliberately.** `is_draining_pool()` tests
+    for `PoolIfaceEgressOverlap` specifically, not `pool_failure.is_some()`.
+    Retaining allocators for EVERY pool failure would be a wider behaviour
+    change than the demonstrated defect needs and would perturb the #6812 budget
+    walk for pools with nothing to drain.
+  - **The acceptance control is a PAIR, and the second half is the point.**
+    While the pool drains, the interface mint is refused; when the drain
+    COMPLETES — driven through the real `release_flow`, not a test backdoor —
+    the same mint succeeds. Without that second half the test cannot tell a
+    working drain from a permanent quarantine, which look identical on every
+    operator surface.
+  - **The pin does NOT invert, exactly as #7730 recorded**, and it still passes
+    here. It builds a healthy pool directly and never reaches the builder that
+    quarantines. The acceptance control drives the builder instead.
+  - **Wire-skew is fail-closed**: an older helper maps the new reason string to
+    the `InvalidPool` catch-all — still refused, just without drain retention.
+    A lockstep test pins the Go constant to the Rust arm (comment-stripped,
+    since both sides' prose names the string), because a typo there is silent:
+    the pool would be quarantined and its flows stranded with every test green.
+  - **A mutation cell found my SCOPING claim unbound.** R4 widened
+    `is_draining_pool` to `pool_failure.is_some()` and red nothing — so the
+    narrowing this change argues for (drain the overlap variant only) was a
+    claim in a commit message with no test behind it, which is the exact defect
+    class this campaign has been closing all day. Bound with
+    `only_the_overlap_quarantine_retains_its_allocator_7717`: a pool failed for
+    `aggregate_over_budget` must NOT retain, paired with a control on the same
+    generation shape showing the overlap reason DOES — without the control the
+    assertion is satisfied by retention being broken outright.
+  - **File(s)**: userspace-dp/src/nat/source.rs,
+    userspace-dp/src/nat/tests_iface_pool_drain_7717.rs,
+    userspace-dp/src/nat/mod.rs,
+    pkg/dataplane/userspace/nat_iface_pool_overlap.go,
+    pkg/dataplane/userspace/nat_iface_pool_overlap_7717_test.go,
+    docs/log/7717.md

--- a/pkg/dataplane/userspace/nat_iface_pool_overlap.go
+++ b/pkg/dataplane/userspace/nat_iface_pool_overlap.go
@@ -231,22 +231,60 @@ func detectInterfaceSNATPoolOverlaps(snap *ConfigSnapshot) []interfaceSNATPoolOv
 }
 
 // reportInterfaceSNATPoolOverlaps runs the detector over a freshly built
-// snapshot, logs one warning per finding, and records the counters.
+// snapshot, QUARANTINES each overlapping pool, logs one warning per finding,
+// and records the counters.
 //
 // It ALWAYS bumps the scan counter, including when nothing overlaps — that is
 // what lets a reader tell "no overlap" from "detector never ran".
+//
+// #7717 part 2: the quarantine is enabled HERE, in the same change as the
+// dataplane drain that makes it safe. Shipping it earlier would have marked
+// pools unusable with nothing draining, which the merged config gate names as
+// stranding live sessions — and a quarantine wired but disabled could not have
+// been mutation-tested, because nothing would make it fire.
+//
+// `PoolUnusable` is the SHIPPED transport for this: the Rust side already maps
+// it onto `pool_failure`, which already refuses new mints. What the drain adds
+// is that the quarantined pool's allocator is now RETAINED so its live flows
+// can still release, and that interface-mode mints on the address fail closed
+// until that drain completes.
 func reportInterfaceSNATPoolOverlaps(snap *ConfigSnapshot) {
 	overlaps := detectInterfaceSNATPoolOverlaps(snap)
 	snatOverlapScans.Add(1)
 	snatOverlapAddresses.Store(uint64(len(overlaps)))
+	if len(overlaps) == 0 {
+		return
+	}
+
+	quarantined := make(map[string]struct{}, len(overlaps))
 	for _, o := range overlaps {
-		slog.Warn("source-NAT pool overlaps an interface-SNAT egress address; "+
-			"two allocators can mint the same (address, port) for different flows",
+		quarantined[o.PoolRule] = struct{}{}
+	}
+	for i := range snap.SourceNAT {
+		if _, hit := quarantined[snap.SourceNAT[i].Name]; !hit {
+			continue
+		}
+		snap.SourceNAT[i].PoolUnusable = true
+		// Preserve an existing reason: a pool already unusable for its own
+		// sake (empty, invalid range) stays reported as that. Overwriting it
+		// would replace a specific diagnosis with a less specific one.
+		if snap.SourceNAT[i].PoolUnusableReason == "" {
+			snap.SourceNAT[i].PoolUnusableReason = poolUnusableReasonIfaceOverlap
+		}
+	}
+
+	for _, o := range overlaps {
+		slog.Warn("source-NAT pool overlaps an interface-SNAT egress address and has been "+
+			"QUARANTINED; its live flows drain and interface-mode mints on the address "+
+			"fail closed until they do",
 			"address", o.Address,
 			"pool_rule", o.PoolRule,
 			"interface_rule", o.InterfaceRule,
 			"issue", "#7717",
-			"note", "detection only — the pool is NOT quarantined; pool members "+
-				"expressed as ranges or prefixes are not compared")
+			"note", "pool members expressed as ranges or prefixes are not compared")
 	}
 }
+
+// poolUnusableReasonIfaceOverlap is the snapshot reason string for a pool
+// quarantined because its address is also an interface-SNAT egress address.
+const poolUnusableReasonIfaceOverlap = "iface_snat_egress_overlap"

--- a/pkg/dataplane/userspace/nat_iface_pool_overlap_7717_test.go
+++ b/pkg/dataplane/userspace/nat_iface_pool_overlap_7717_test.go
@@ -1,6 +1,9 @@
 package userspace
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -253,5 +256,106 @@ func TestBuilderDetectsOverlapEndToEnd(t *testing.T) {
 	}
 	if got[0].Address != overlapEgress {
 		t.Errorf("overlap names %q, want %q", got[0].Address, overlapEgress)
+	}
+}
+
+// TestBuilderQuarantinesTheOverlappingPool is the Go half of the acceptance
+// control, and it drives the SNAPSHOT BUILDER — not the unit-level pin, which
+// cannot invert because it constructs a healthy pool directly (#7730).
+//
+// Paired: the same builder, the same shapes, differing only in whether the pool
+// address coincides with the interface egress address. Without the second row a
+// builder that quarantined every pool would pass.
+func TestBuilderQuarantinesTheOverlappingPool(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		poolAddr string
+		wantQuar bool
+	}{
+		{"pool address IS the interface egress", overlapEgress, true},
+		{"pool address does NOT coincide", "198.51.100.7", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+				"ge-0/0/2": {Name: "ge-0/0/2", Units: map[int]*config.InterfaceUnit{
+					0: {Number: 0, Addresses: []string{overlapEgress + "/24"}},
+				}},
+			}
+			cfg.Security.Zones = map[string]*config.ZoneConfig{
+				"wan": {Name: "wan", Interfaces: []string{"ge-0/0/2.0"}},
+			}
+			cfg.Security.NAT.SourcePools = map[string]*config.NATPool{
+				"P": {Name: "P", Addresses: []string{tc.poolAddr}},
+			}
+			cfg.Security.NAT.Source = []*config.NATRuleSet{
+				{Name: "rs-iface", FromZone: "lan", ToZone: "wan", Rules: []*config.NATRule{{
+					Name: "iface-snat",
+					Then: config.NATThen{Type: config.NATSource, Interface: true},
+				}}},
+				{Name: "rs-pool", FromZone: "lan", ToZone: "wan", Rules: []*config.NATRule{{
+					Name: "pool-snat",
+					Then: config.NATThen{Type: config.NATSource, PoolName: "P"},
+				}}},
+			}
+
+			snap := mustBuildSnapshot(t, cfg, config.UserspaceConfig{}, 1, 0)
+
+			var poolRule *SourceNATRuleSnapshot
+			for i := range snap.SourceNAT {
+				if !snap.SourceNAT[i].InterfaceMode && snap.SourceNAT[i].PoolName == "P" {
+					poolRule = &snap.SourceNAT[i]
+				}
+			}
+			if poolRule == nil {
+				t.Fatal("the builder emitted no pool rule — fixture is not exercising the path")
+			}
+			if poolRule.PoolUnusable != tc.wantQuar {
+				t.Fatalf("PoolUnusable = %v, want %v. The builder is where the runtime overlap "+
+					"becomes a quarantine; the dataplane only honours what it is told",
+					poolRule.PoolUnusable, tc.wantQuar)
+			}
+			if tc.wantQuar && poolRule.PoolUnusableReason != poolUnusableReasonIfaceOverlap {
+				t.Fatalf("PoolUnusableReason = %q, want %q — the reason is what selects the "+
+					"DRAIN-retaining failure variant in the dataplane; any other string maps to "+
+					"the catch-all and the pool's allocator is dropped instead of drained",
+					poolRule.PoolUnusableReason, poolUnusableReasonIfaceOverlap)
+			}
+		})
+	}
+}
+
+// TestPoolUnusableReasonLockstepWithRust pins the reason STRING to the dataplane
+// arm that consumes it.
+//
+// Neither side is pinned to a literal by hand: the Go constant is read from the
+// package, and the Rust arm is read out of the source. A mismatch does not fail
+// anything loudly — `source_nat_failure_reason_from_snapshot` has a catch-all
+// that maps an unknown string to `InvalidPool`, which is still fail-closed but
+// does NOT retain the allocator. So the pool would be quarantined and its live
+// flows stranded: the exact outcome the drain exists to prevent, reached by a
+// typo, with every test green.
+func TestPoolUnusableReasonLockstepWithRust(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "userspace-dp", "src", "nat", "source.rs")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	// Strip comments first: this file's own prose names the reason string, and
+	// so does the Rust doc comment on the variant.
+	var code []string
+	for _, line := range strings.Split(string(raw), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue
+		}
+		code = append(code, line)
+	}
+	want := `"` + poolUnusableReasonIfaceOverlap + `" => SourceNatFailureReason::PoolIfaceEgressOverlap`
+	if !strings.Contains(strings.Join(code, "\n"), want) {
+		t.Fatalf("userspace-dp/src/nat/source.rs has no arm mapping %q to "+
+			"PoolIfaceEgressOverlap. Without it the reason falls to the catch-all "+
+			"(InvalidPool), which does NOT retain the allocator — the pool is quarantined and "+
+			"its live flows are stranded, which is what the drain exists to prevent",
+			poolUnusableReasonIfaceOverlap)
 	}
 }

--- a/userspace-dp/src/nat/mod.rs
+++ b/userspace-dp/src/nat/mod.rs
@@ -50,6 +50,9 @@ mod tests_iface;
 #[path = "tests_iface_pool_overlap_7717.rs"]
 mod tests_iface_pool_overlap_7717;
 #[cfg(test)]
+#[path = "tests_iface_pool_drain_7717.rs"]
+mod tests_iface_pool_drain_7717;
+#[cfg(test)]
 #[path = "tests_counter.rs"]
 mod tests_counter;
 #[cfg(test)]

--- a/userspace-dp/src/nat/source.rs
+++ b/userspace-dp/src/nat/source.rs
@@ -135,6 +135,32 @@ pub(crate) enum SourceNatFailureReason {
     /// `InterfaceIdentityExhausted` because the remedy differs: this says
     /// "no more bookkeeping capacity", not "this identity space is full".
     InterfaceRegistryCap,
+    /// #7717: the egress address this interface-mode admission would mint on
+    /// still carries LIVE allocations from a quarantined source-NAT pool that
+    /// is draining. The two domains keep independent occupancy, so minting
+    /// here can hand out an identity the draining pool still owns — the
+    /// collision `defect_pin_pool_and_interface_snat_mint_one_identity_7717`
+    /// demonstrates.
+    ///
+    /// Deliberately NOT folded into `InterfaceIdentityExhausted`: the remedy
+    /// differs and so does the expected duration. Exhaustion says "this
+    /// identity space is full"; this says "someone else is still holding part
+    /// of it and will let go". The quarantine lifts on its own when the last
+    /// draining flow closes, so an operator seeing this counter climb should
+    /// look at the overlap, not at pool sizing.
+    InterfaceOverlapDraining,
+    /// #7717: this POOL is quarantined because one of its addresses is also an
+    /// interface-mode SNAT egress address, which the snapshot builder can only
+    /// see for a runtime-resolved (DHCP/netlink) address. New pool mints are
+    /// refused; its existing allocator is RETAINED so live flows drain.
+    ///
+    /// A distinct variant rather than reusing an existing failure because it is
+    /// the ONLY one whose allocator is retained. Folding it into, say,
+    /// `EmptyPool` would silently extend drain retention to every pool failure
+    /// — a wider behaviour change than the demonstrated defect needs, and one
+    /// that perturbs the #6812 budget walk for pools that have nothing to
+    /// drain.
+    PoolIfaceEgressOverlap,
 }
 
 impl SourceNatFailureReason {
@@ -154,6 +180,8 @@ impl SourceNatFailureReason {
             Self::OverBudget => "source_nat_pool_over_budget",
             Self::InterfaceIdentityExhausted => "source_nat_interface_identity_exhausted",
             Self::InterfaceRegistryCap => "source_nat_interface_registry_cap",
+            Self::InterfaceOverlapDraining => "source_nat_interface_overlap_draining",
+            Self::PoolIfaceEgressOverlap => "source_nat_pool_iface_egress_overlap",
         }
     }
 }
@@ -172,6 +200,10 @@ fn source_nat_failure_reason_from_snapshot(reason: &str) -> SourceNatFailureReas
         // exclude the pool it knows builds no allocator.
         "invalid_pool" => SourceNatFailureReason::InvalidPool,
         "wrong_address_family" => SourceNatFailureReason::WrongAddressFamily,
+        // #7717: emitted by the Go snapshot builder when a pool address is also
+        // an interface-SNAT egress address. The ONLY reason whose allocator is
+        // retained for draining.
+        "iface_snat_egress_overlap" => SourceNatFailureReason::PoolIfaceEgressOverlap,
         "allocator_exhausted" => SourceNatFailureReason::AllocatorExhausted,
         // #6812: the Go tolerant snapshot poison for a pool that does not fit
         // the #5877 aggregate cardinality budget. Wire-skew safe: an older
@@ -392,6 +424,43 @@ impl SourceNatRule {
         })
     }
 
+    /// #7717: the carry-over key that IGNORES `pool_failure`.
+    ///
+    /// `allocator_key` refuses a failed pool, which is right for MINTING and
+    /// wrong for RETENTION. A pool quarantined because its address overlaps an
+    /// interface-SNAT egress still has live flows holding real identities; if
+    /// its allocator is not carried into the next generation those flows lose
+    /// the state that releases them, which is the stranding the merged config
+    /// gate names as the reason the quarantine could not ship alone.
+    ///
+    /// This is a strict WIDENING of `allocator_key`: for a healthy pool the two
+    /// return the same key, so retention is unchanged there. It must also
+    /// survive REPEATED quarantined snapshots — every rebuild while the overlap
+    /// persists re-derives the previous generation through this key, and a
+    /// key that dropped on the second one would strand exactly the flows the
+    /// first one preserved.
+    fn drain_allocator_key(&self) -> Option<SourceNatPoolAllocatorKey> {
+        let total_pool = self.pool_addresses_v4.len() + self.pool_addresses_v6.len();
+        (self.pool_mode && total_pool > 0)
+            .then(|| self.allocator_key_for(self.pool_port_low, self.pool_port_high))
+    }
+
+    /// #7717: is this rule a quarantined pool whose allocator is DRAINING —
+    /// refusing new mints while live flows still release into it?
+    fn is_draining_pool(&self) -> bool {
+        self.pool_failure == Some(SourceNatFailureReason::PoolIfaceEgressOverlap)
+            && self.pool_mode
+            && (self.pool_addresses_v4.len() + self.pool_addresses_v6.len()) > 0
+    }
+
+    /// Does this rule's pool contain `addr` as a member address?
+    fn pool_contains_address(&self, addr: IpAddr) -> bool {
+        match addr {
+            IpAddr::V4(v4) => self.pool_addresses_v4.contains(&v4),
+            IpAddr::V6(v6) => self.pool_addresses_v6.contains(&v6),
+        }
+    }
+
     /// Build the allocator key with an EXPLICIT port range. The resolve pass
     /// (#6812) keys a rule BEFORE its allocator exists, so it cannot read the
     /// range back off `pool_allocator` (still the empty default there); the
@@ -405,6 +474,24 @@ impl SourceNatRule {
             port_high,
         }
     }
+}
+
+/// #7717: does any QUARANTINED pool still hold live allocations on `addr`?
+///
+/// Scans the rule slice rather than consulting a precomputed set because the
+/// answer is time-varying: the same rule flips from draining to drained when
+/// its last flow closes, and a set computed at apply would pin the pre-drain
+/// answer forever — a permanent quarantine wearing the shape of a working
+/// drain. The scan is bounded by the rule count and runs only on the
+/// interface-mode mint path (new flows), and the `is_draining_pool` test is a
+/// cheap `Option::is_some` that is false for every rule in a healthy config, so
+/// the common case never reaches the address comparison.
+fn address_has_draining_pool_occupancy(rules: &[SourceNatRule], addr: IpAddr) -> bool {
+    rules.iter().any(|candidate| {
+        candidate.is_draining_pool()
+            && candidate.pool_contains_address(addr)
+            && candidate.pool_allocator.live_flow_count() > 0
+    })
 }
 
 /// #6812: source-NAT AGGREGATE allocator budget at the apply boundary — the
@@ -704,6 +791,59 @@ fn resolve_pool_allocators(
         }
         used = used.saturating_with(pending.charge());
         reserved.insert(key, ());
+    }
+
+    // PHASE 1b (#7717): DRAIN retention. A quarantined pool gets no pending, so
+    // phase 2 never assigns it an allocator and its previous one would be
+    // dropped — stranding the flows still holding identities from it. Reuse the
+    // previous allocator for such a rule, REUSE-ONLY: never create one, because
+    // a quarantined pool that never had live state has nothing to drain and
+    // fabricating an allocator for it would just be a new occupancy domain on
+    // an address we are quarantining precisely to stop that.
+    //
+    // Charged in phase 1 alongside the other reused keys: a draining allocator
+    // holds real ports for as long as its flows live, and omitting it would let
+    // the aggregate budget admit new keys against capacity that is still in use.
+    for rule in out.iter() {
+        if !rule.is_draining_pool() {
+            continue;
+        }
+        let Some(key) = rule.drain_allocator_key() else {
+            continue;
+        };
+        if !previous_allocators.contains_key(&key) || reserved.contains_key(&key) {
+            continue;
+        }
+        // Charged through the SAME `PendingPoolAllocator::charge` formula the
+        // healthy rules use, rather than a second copy of the arithmetic — a
+        // draining pool occupies exactly what it occupied before it was
+        // quarantined.
+        used = used.saturating_with(
+            PendingPoolAllocator {
+                port_low: rule.pool_port_low,
+                port_high: rule.pool_port_high,
+                total_pool: rule.pool_addresses_v4.len() + rule.pool_addresses_v6.len(),
+            }
+            .charge(),
+        );
+        reserved.insert(key, ());
+    }
+
+    // PHASE 1c (#7717): hand the retained allocator to the draining rule. It
+    // mints nothing — `pool_failure` is set, so the match path returns the
+    // exception before it reaches the allocator — but releases from live flows
+    // resolve through `rule.pool_allocator`, and the interface-side quarantine
+    // reads its live count to know when the drain is done.
+    for rule in out.iter_mut() {
+        if !rule.is_draining_pool() {
+            continue;
+        }
+        let Some(key) = rule.drain_allocator_key() else {
+            continue;
+        };
+        if let Some(existing) = previous_allocators.get(&key) {
+            rule.pool_allocator = existing.clone();
+        }
     }
 
     // PHASE 2: assign. Reused keys were charged in phase 1 and must NOT be
@@ -1195,7 +1335,11 @@ fn parse_source_nat_rules_inner(
     let mut previous_pools = FxHashMap::<String, Option<PreviousPool>>::default();
     if let Some(prev_rules) = previous {
         for prev in prev_rules {
-            if let Some(key) = prev.allocator_key() {
+            // #7717: keyed on `drain_allocator_key`, which ignores
+            // `pool_failure`. A QUARANTINED pool's allocator must survive into
+            // the next generation or its live flows lose the state that
+            // releases them. Widening only: a healthy pool keys identically.
+            if let Some(key) = prev.drain_allocator_key() {
                 previous_allocators
                     .entry(key)
                     .or_insert_with(|| prev.pool_allocator.clone());
@@ -2535,6 +2679,27 @@ pub(crate) fn match_source_nat_result_for_tuple(
                     rewrite_dst: None,
                     ..NatDecision::default()
                 });
+            }
+            // #7717: UNIFORM MINT QUARANTINE. While a quarantined pool is
+            // still DRAINING live allocations on this egress address, the two
+            // domains keep independent occupancy — the interface registry
+            // reports "uncontended" for a port the draining pool is actively
+            // using, preserves it, and both flows go out as one wire identity.
+            // That is the collision
+            // `defect_pin_pool_and_interface_snat_mint_one_identity_7717`
+            // demonstrates.
+            //
+            // Fail CLOSED rather than PAT around it. The interface registry
+            // cannot see which ports the pool holds, so "PAT to something else"
+            // would be a guess; and the plan's posture for a mint colliding
+            // with a domain it cannot enumerate is to refuse. The refusal is
+            // self-limiting: it lifts when the last draining flow closes, which
+            // is what makes this a drain rather than a permanent quarantine.
+            if address_has_draining_pool_occupancy(rules, rewrite_src) {
+                return SourceNatLookup::Unavailable(SourceNatFailure::for_rule(
+                    rule,
+                    SourceNatFailureReason::InterfaceOverlapDraining,
+                ));
             }
             let Some(alloc) = iface_allocs.allocator_for(rewrite_src) else {
                 // The registry cannot create state for this address and

--- a/userspace-dp/src/nat/tests_iface_pool_drain_7717.rs
+++ b/userspace-dp/src/nat/tests_iface_pool_drain_7717.rs
@@ -1,0 +1,290 @@
+// #7717 part 2 — the DRAIN, and the quarantine it makes safe.
+//
+// The companion pin (`tests_iface_pool_overlap_7717.rs`) demonstrates the
+// collision with a HEALTHY pool and, as its own header records, does NOT invert
+// when this lands: it constructs its rule sets directly and never passes through
+// the snapshot builder that quarantines. So the acceptance control lives here
+// and is driven by the QUARANTINE the builder emits — `pool_unusable` with the
+// `iface_snat_egress_overlap` reason — which is the state a runtime-learned
+// overlapping address actually produces.
+
+use super::allocator::{NatHolder, TranslatedTuple};
+use super::*;
+use super::source::SourceNatFlowKey;
+use crate::SourceNATRuleSnapshot;
+use std::net::IpAddr;
+
+const E: &str = "172.16.80.8";
+const SRV: &str = "172.16.80.200";
+const TCP: u8 = 6;
+
+fn pool_snapshot(quarantined: bool) -> SourceNATRuleSnapshot {
+    SourceNATRuleSnapshot {
+        name: "pool-snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "P".to_string(),
+        pool_addresses: vec![E.to_string()],
+        pool_unusable: quarantined,
+        pool_unusable_reason: if quarantined {
+            "iface_snat_egress_overlap".to_string()
+        } else {
+            String::new()
+        },
+        ..SourceNATRuleSnapshot::default()
+    }
+}
+
+fn iface_snapshot() -> SourceNATRuleSnapshot {
+    SourceNATRuleSnapshot {
+        name: "iface-snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        interface_mode: true,
+        ..SourceNATRuleSnapshot::default()
+    }
+}
+
+fn admit(reg: &InterfaceNatAllocators, rules: &[SourceNatRule], src: &str, src_port: u16) -> SourceNatLookup {
+    let mut counter = None;
+    match_source_nat_result_for_tuple(
+        reg,
+        rules,
+        &NatScopeCtx::default(),
+        "lan",
+        "wan",
+        src.parse().expect("src"),
+        SRV.parse().expect("dst"),
+        Some(TCP),
+        src_port,
+        80,
+        Some(E.parse().expect("egress")),
+        None,
+        1_000,
+        false,
+        false,
+        NatHolder::Untracked,
+        &mut counter,
+    )
+}
+
+/// The quarantined pool's allocator SURVIVES into the next generation.
+///
+/// This is the stranding the merged config gate names as the reason the
+/// quarantine could not ship alone: "marking a pool unusable with nothing
+/// draining would strand live sessions". Before the drain, `allocator_key`
+/// refused a failed pool and the carry-over dropped it, so the flows still
+/// holding identities from that allocator lost the state that releases them.
+#[test]
+fn quarantined_pool_retains_its_allocator_so_live_flows_drain_7717() {
+    // Generation 1: healthy pool, one live flow.
+    let gen1 = parse_source_nat_rules(&[pool_snapshot(false)]);
+    let reg = InterfaceNatAllocators::default();
+    assert!(matches!(
+        admit(&reg, &gen1, "10.0.0.1", 5555),
+        SourceNatLookup::Matched(_)
+    ));
+    let live_before = gen1[0].pool_allocator.live_flow_count();
+    assert_eq!(live_before, 1, "setup: the pool must hold one live flow");
+
+    // Generation 2: the SAME pool, now quarantined by the builder.
+    let gen2 = parse_source_nat_rules_with_previous(
+        &[pool_snapshot(true)],
+        Some(&gen1),
+        &NatCounterStore::default(),
+        0,
+    );
+    assert_eq!(
+        gen2[0].pool_allocator.live_flow_count(),
+        live_before,
+        "#7717: a quarantined pool must RETAIN its allocator — its live flows still hold \
+         identities and need the state that releases them. Dropping it is the stranding the \
+         merged config gate names as why the quarantine could not ship without this drain"
+    );
+
+    // And it must survive REPEATED quarantined snapshots. A carry-over key that
+    // dropped on the second rebuild would strand exactly the flows the first
+    // one preserved, and every rebuild while the overlap persists is one of
+    // these.
+    let gen3 = parse_source_nat_rules_with_previous(
+        &[pool_snapshot(true)],
+        Some(&gen2),
+        &NatCounterStore::default(),
+        0,
+    );
+    assert_eq!(
+        gen3[0].pool_allocator.live_flow_count(),
+        live_before,
+        "#7717: retention must survive repeated quarantined snapshots, not just the first"
+    );
+}
+
+/// A quarantined pool mints NOTHING new, which is what makes the drain finite.
+#[test]
+fn quarantined_pool_refuses_new_mints_7717() {
+    let gen1 = parse_source_nat_rules(&[pool_snapshot(false)]);
+    let reg = InterfaceNatAllocators::default();
+    assert!(matches!(
+        admit(&reg, &gen1, "10.0.0.1", 5555),
+        SourceNatLookup::Matched(_)
+    ));
+
+    let gen2 = parse_source_nat_rules_with_previous(
+        &[pool_snapshot(true)],
+        Some(&gen1),
+        &NatCounterStore::default(),
+        0,
+    );
+    match admit(&reg, &gen2, "10.0.0.9", 6666) {
+        SourceNatLookup::Unavailable(_) => {}
+        other => panic!(
+            "#7717: a quarantined pool must refuse NEW mints, or the drain never finishes \
+             because the pool keeps adding to what has to drain. Got {other:?}"
+        ),
+    }
+}
+
+/// THE ACCEPTANCE CONTROL, and it is a PAIR.
+///
+/// While the quarantined pool still holds a live allocation on E, an
+/// interface-mode mint on E fails CLOSED — that is the collision the pin
+/// demonstrates, refused. And when the drain COMPLETES the same mint succeeds:
+/// without that second half this would be indistinguishable from a permanent
+/// quarantine, which is a working drain's exact failure mode and reads
+/// identically on every operator surface.
+#[test]
+fn interface_mint_fails_closed_while_draining_then_recovers_7717() {
+    // Live pool flow on E, then quarantine.
+    // gen1 is POOL-ONLY so the pool is what admits and holds the live flow.
+    let gen1 = parse_source_nat_rules(&[pool_snapshot(false)]);
+    let reg = InterfaceNatAllocators::default();
+    let pool_port = match admit(&reg, &gen1, "10.0.0.1", 5555) {
+        SourceNatLookup::Matched(d) => d.rewrite_src_port.expect("pool mode PATs, so a port"),
+        other => panic!("setup: the healthy pool must admit: {other:?}"),
+    };
+    assert_eq!(gen1[0].pool_allocator.live_flow_count(), 1, "setup");
+
+    // The draining generation lists the INTERFACE rule first, so it is the rule
+    // that matches this flow. Order matters here and the ordering is the point:
+    // with the quarantined pool first it matches and refuses on its own
+    // account, which exercises the pool arm rather than the interface arm the
+    // collision actually lives on.
+    let draining = parse_source_nat_rules_with_previous(
+        &[iface_snapshot(), pool_snapshot(true)],
+        Some(&gen1),
+        &NatCounterStore::default(),
+        0,
+    );
+    let pool_idx = draining
+        .iter()
+        .position(|r| r.pool_mode)
+        .expect("the quarantined pool rule must be present — it is what the gate scans for");
+    assert_eq!(
+        draining[pool_idx].pool_allocator.live_flow_count(),
+        1,
+        "setup: still draining"
+    );
+
+    match admit(&reg, &draining, "10.0.0.2", 5555) {
+        SourceNatLookup::Unavailable(f) => assert_eq!(
+            f.reason,
+            SourceNatFailureReason::InterfaceOverlapDraining,
+            "#7717: the refusal must name the DRAIN, not exhaustion — the remedy and the \
+             expected duration differ, and an operator seeing this should look at the overlap"
+        ),
+        other => panic!(
+            "#7717: an interface-mode mint on an address a quarantined pool is still draining \
+             must fail CLOSED. Got {other:?} — that is the collision the pin demonstrates"
+        ),
+    }
+
+    // DRAIN COMPLETES — through the REAL release path, not a test backdoor, so
+    // this proves the production mechanism finishes the drain and not merely
+    // that a counter can be zeroed. The quarantine must then lift on its own:
+    // it is scoped to LIVE occupancy, not to the quarantine flag.
+    let flow = SourceNatFlowKey {
+        protocol: TCP,
+        src_ip: "10.0.0.1".parse().expect("src"),
+        dst_ip: SRV.parse().expect("dst"),
+        src_port: 5555,
+        dst_port: 80,
+    };
+    let translated = TranslatedTuple {
+        ip: E.parse::<IpAddr>().expect("egress"),
+        port: pool_port,
+    };
+    assert!(
+        draining[pool_idx]
+            .pool_allocator
+            .release_flow(flow, translated, 2_000, NatHolder::Untracked),
+        "the live pool flow must release through the RETAINED allocator — if the carry-over \
+         dropped it, this is exactly the stranding: the flow is live and nothing can free it"
+    );
+    assert_eq!(draining[pool_idx].pool_allocator.live_flow_count(), 0, "setup: drained");
+
+    match admit(&reg, &draining, "10.0.0.2", 5555) {
+        SourceNatLookup::Matched(_) => {}
+        other => panic!(
+            "#7717: once the drain completes the interface mint must SUCCEED. A refusal that \
+             never lifts is a permanent quarantine wearing the shape of a working drain, and \
+             it looks identical on every operator surface. Got {other:?}"
+        ),
+    }
+}
+
+/// The drain is scoped to the OVERLAP quarantine, and only to it.
+///
+/// Added because a mutation cell found the scope unbound: widening
+/// `is_draining_pool` to `pool_failure.is_some()` red nothing, so the narrowing
+/// this change argues for was a claim with no test behind it.
+///
+/// It matters because retention is not free. A pool failed for its own reasons —
+/// over budget, empty, invalid range — has nothing to drain: no interface-mode
+/// mint is being refused on its behalf, so holding its allocator only keeps
+/// aggregate-budget capacity (#6812) occupied by state nothing will release. The
+/// overlap case is different precisely because something IS being refused on its
+/// behalf, and that refusal must end.
+#[test]
+fn only_the_overlap_quarantine_retains_its_allocator_7717() {
+    let mut over_budget = pool_snapshot(true);
+    over_budget.pool_unusable_reason = "aggregate_over_budget".to_string();
+
+    let gen1 = parse_source_nat_rules(&[pool_snapshot(false)]);
+    let reg = InterfaceNatAllocators::default();
+    assert!(matches!(
+        admit(&reg, &gen1, "10.0.0.1", 5555),
+        SourceNatLookup::Matched(_)
+    ));
+    assert_eq!(gen1[0].pool_allocator.live_flow_count(), 1, "setup");
+
+    let gen2 = parse_source_nat_rules_with_previous(
+        &[over_budget],
+        Some(&gen1),
+        &NatCounterStore::default(),
+        0,
+    );
+    assert_eq!(
+        gen2[0].pool_allocator.live_flow_count(),
+        0,
+        "#7717: a pool failed for a reason OTHER than the interface-SNAT overlap must NOT \
+         retain its allocator — that is the pre-existing behaviour, and widening retention to \
+         every failure holds #6812 aggregate-budget capacity for state nothing is waiting on"
+    );
+
+    // CONTROL, same generation shape: the OVERLAP reason DOES retain. Without
+    // it this test passes against a build that retains nothing at all.
+    let gen2_overlap = parse_source_nat_rules_with_previous(
+        &[pool_snapshot(true)],
+        Some(&gen1),
+        &NatCounterStore::default(),
+        0,
+    );
+    assert_eq!(
+        gen2_overlap[0].pool_allocator.live_flow_count(),
+        1,
+        "control: the overlap quarantine must still retain, or the assertion above is \
+         satisfied by retention being broken outright"
+    );
+}


### PR DESCRIPTION
Closes #7717

The final half. The **quarantine and the drain ship together**, in one change,
because neither is safe alone — the merged config gate says why the quarantine
could not ship first (*"marking a pool unusable with nothing draining would
strand live sessions"*), and a quarantine wired-but-disabled could not have been
mutation-tested, because nothing would make it fire.

## Mechanism, in three parts

**Go** — the #7734 detector now sets `PoolUnusable` and the reason
`iface_snat_egress_overlap` on the offending pool. `PoolUnusable` is the
**shipped** transport: the dataplane already maps it onto `pool_failure`, which
already refuses new mints. An existing reason is preserved rather than
overwritten, so a pool already unusable for its own sake keeps its specific
diagnosis.

**Rust retention** — `drain_allocator_key` is a strict **widening** of
`allocator_key` that ignores `pool_failure`, used at the carry-over site.
Refusing a failed pool is right for *minting* and wrong for *retention*: a
quarantined pool's live flows still hold real identities, and dropping the
allocator **is** the stranding. A new phase in `resolve_pool_allocators`
**reuses — never creates** — the previous allocator for a draining rule, charged
through the same `PendingPoolAllocator::charge` formula the healthy rules use so
the aggregate budget cannot admit new keys against capacity still in use.
Retention also survives **repeated** quarantined snapshots; a key that dropped on
the second rebuild would strand exactly the flows the first preserved.

**Rust quarantine** — an interface-mode mint on an address a quarantined pool is
still draining fails **closed**, with a dedicated `InterfaceOverlapDraining`
reason rather than reusing exhaustion: the remedy and expected duration differ,
and an operator seeing it should look at the overlap, not at pool sizing. Fail
closed rather than PAT around it — the interface registry cannot enumerate the
ports the pool holds, so PATting would be a guess.

## The acceptance control is a pair, and the second half is the point

While the pool drains, the interface mint is **refused**; when the drain
**completes** — driven through the real `release_flow`, not a test backdoor — the
same mint **succeeds**.

Without that second half a test cannot tell a working drain from a **permanent
quarantine**, and those look identical on every operator surface.

Per #7730, the control drives the **snapshot builder**. The unit-level pin does
**not** invert and still passes here, because it builds a healthy pool directly
and never reaches the builder that quarantines.

## Written fresh

The rescued implementation was read for shape only. It is inert alone
(measured in #7730), its doc comment states the hazard incorrectly, and its
author's lane died having never validated it. Nothing was carried across.

## Mutation matrix

Fix committed before mutating. One mutation per cell, full suite,
`--test-threads=1`, runner refuses to score a cell whose mutation did not change
the file.

| # | Mutation | Collected | Named RED |
|---|---|---|---|
| R1 | carry-over reverts to `allocator_key` (the stranding) | 4731 | 1 — retention |
| R2 | interface quarantine gate removed (collision returns) | 4731 | 1 — the paired control |
| R3 | quarantine keyed on the flag, not live occupancy (**never lifts**) | 4731 | 1 — the paired control |
| R4 | drain widened to every pool failure | 4801 → **0**, then **1** | see below |
| R5 | reason-string typo (falls to the catch-all) | 4730 | 2 |
| G1 | builder no longer quarantines | 64 pkgs | 1 |

R3 is the one worth naming: it proves the quarantine actually **lifts**, which is
the failure mode a drain most easily hides.

### R4 found my own scoping claim unbound

Widening `is_draining_pool` to `pool_failure.is_some()` **red nothing** — so the
narrowing this PR argues for (drain the overlap variant *only*) was a claim in a
commit message with no test behind it.

It matters because retention is not free: a pool failed for its own reasons has
nothing to drain — no interface mint is being refused on its behalf — so holding
its allocator only keeps #6812 aggregate-budget capacity occupied by state
nothing will release. Bound with
`only_the_overlap_quarantine_retains_its_allocator_7717`, paired with a control
showing the overlap reason **does** retain; without the control the assertion is
satisfied by retention being broken outright. R4 now reds by name.

## Wire-skew is fail-closed

An older helper maps the new reason string to the `InvalidPool` catch-all —
still refused, just without drain retention. A lockstep test pins the Go constant
to the Rust arm (comment-stripped, since both sides' prose names the string),
because a typo there is otherwise **silent**: the pool is quarantined and its
flows stranded with every test green. R5 is that cell.

## Validation

Gated head `32300fa7b` (`origin/master` merged in, not rebased; clean).

- `cargo test --release --bins --tests -- --test-threads=1`: **4802 collected, 0 failed**
- `go test ./... -count=1`: **rc=0**, 68 packages
