### PR TITLE
worker: bind the GC-reap source-NAT release call site (#6901)

### DIFF
--- a/docs/log/6901.md
+++ b/docs/log/6901.md
@@ -1,0 +1,38 @@
+# #6901 — the GC-reap source-NAT release call site was unbound
+
+- **Timestamp**: 2026-08-27
+- **Action**: Re-measure the premise, then bind the call site
+  - **Premise re-measured at master `365e134ae` before building anything**, as
+    the issue's own table invites. Control: **4670 collected, 0 failed, rc 0**.
+    With `release_source_nat_allocation_for_worker` deleted from
+    `reap_expired_sessions`: **4670 collected, 0 failed, rc 0** — identical, and
+    the mutation RAN (same collection, not a build break). The call site is
+    genuinely unbound at master; the issue is not stale. Line drift only: the
+    issue cites `:1625`, it is now `:1598`.
+  - **Two cells, because the issue's acceptance has two halves**:
+    - `gc_reap_releases_the_source_nat_pool_port_6901` — drives the production
+      `reap_expired_sessions` with one expired translated session and requires
+      `used_ports` 1 -> 0, with a precondition assert so the zero cannot be read
+      off a pool that was never allocated from.
+    - `gc_reap_releases_only_the_reaped_flows_pool_6901` — TWO pools, reap one
+      flow, and the OTHER pool must be untouched. A single-pool fixture cannot
+      distinguish "released the right allocation" from "released something": a
+      release that freed by count would still drive one count to zero.
+  - Hosted in the sibling of `flow_cache_invalidation_tests`, which already
+    drives the production `reap_expired_sessions`, so the cells exercise the
+    real call path rather than a helper.
+  - **Mutation, at the control count**: deleting the release call -> **RED,
+    4672 collected, both new cells named**. Not a crash-truncated red — the
+    collected count matches the control exactly.
+  - **The issue's open question, answered: the NAT64 sibling is ALSO unbound.**
+    `release_nat64_allocation_for_worker` sits two lines below in the same reap
+    loop. Neutering it leaves the crate **GREEN at 4672 collected**. There ARE
+    existing NAT64 release tests (`nat64_tests.rs:3934`), but they call
+    `release_nat64_allocation` DIRECTLY — the function is bound, its reap call
+    site is not. That is the same shape as this issue, in a different allocator.
+  - **Not folded in, deliberately.** It needs its own NAT64 prefix/pool fixture,
+    and #6901's own provenance cites the "do not put a second unrelated
+    production claim under one title" rule. Reported as a measured finding for
+    its own item rather than carried here.
+  - **File(s)**: `userspace-dp/src/afxdp/worker/loop_body/mod.rs`,
+    `docs/log/6901.md`

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -2427,3 +2427,211 @@ mod snapshot_refresh_ordering_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod gc_reap_source_nat_release_tests_6901 {
+    //! #6901: the GC reap's `release_source_nat_allocation_for_worker` call was
+    //! UNBOUND — deleting it left the whole crate green (measured: 4670
+    //! collected, 0 failed, both with and without the call).
+    //!
+    //! `reap_expired_sessions` is the ordinary inactivity-timeout teardown, the
+    //! path that frees a source-NAT pool port for the overwhelming majority of
+    //! sessions — they age out rather than being explicitly deleted. Without the
+    //! call, every reaped translated session leaks a pool port until
+    //! `AllocatorExhausted`, and nothing in the suite noticed.
+    //!
+    //! TWO cells, because "the reap calls release" and "the reap releases the
+    //! port THIS session holds" are different claims and only the first is
+    //! bound by a count going to zero. A release that freed the wrong pool
+    //! would satisfy a single-pool fixture.
+    use super::*;
+    use crate::nat::NatDecision;
+    use crate::session::{
+        ExpiredSession, SessionDecision, SessionKey, SessionMetadata, SessionOrigin,
+    };
+    use std::net::{IpAddr, Ipv4Addr};
+
+    const POOL_A: Ipv4Addr = Ipv4Addr::new(172, 16, 80, 8);
+    const POOL_B: Ipv4Addr = Ipv4Addr::new(172, 16, 90, 9);
+
+    fn rule_snapshot(name: &str, from: &str, pool_addr: Ipv4Addr) -> crate::SourceNATRuleSnapshot {
+        crate::SourceNATRuleSnapshot {
+            name: name.to_string(),
+            from_zone: from.to_string(),
+            to_zone: "wan".to_string(),
+            source_addresses: vec!["0.0.0.0/0".to_string()],
+            pool_name: name.to_string(),
+            pool_addresses: vec![format!("{pool_addr}/32")],
+            port_low: 1024,
+            port_high: 65535,
+            ..crate::SourceNATRuleSnapshot::default()
+        }
+    }
+
+    fn key_for(src_port: u16) -> SessionKey {
+        SessionKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+            src_port,
+            dst_port: 443,
+        }
+    }
+
+    fn nat_for(pool_addr: Ipv4Addr, port: u16) -> NatDecision {
+        NatDecision {
+            rewrite_src: Some(IpAddr::V4(pool_addr)),
+            rewrite_src_port: Some(port),
+            ..NatDecision::default()
+        }
+    }
+
+    fn metadata() -> SessionMetadata {
+        SessionMetadata {
+            ingress_zone: 1,
+            egress_zone: 2,
+            ingress_ifindex: 0,
+            ingress_vlan_id: 0,
+            owner_rg_id: 1,
+            fabric_ingress: false,
+            is_reverse: false,
+            nat64_reverse: None,
+            log_session_init: false,
+            log_session_close: false,
+            policy_id: 0,
+            inactivity_timeout_ns: None,
+            policy_counter_idx: 0,
+            policy_counter: None,
+        }
+    }
+
+    fn expired_for(src_port: u16, pool_addr: Ipv4Addr, snat_port: u16) -> ExpiredSession {
+        ExpiredSession {
+            key: key_for(src_port),
+            decision: SessionDecision {
+                resolution: ForwardingResolution {
+                    disposition: ForwardingDisposition::ForwardCandidate,
+                    local_ifindex: 0,
+                    egress_ifindex: 12,
+                    tx_ifindex: 12,
+                    tunnel_endpoint_id: 0,
+                    next_hop: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 50, 1))),
+                    neighbor_mac: Some([0, 1, 2, 3, 4, 5]),
+                    src_mac: Some([6, 7, 8, 9, 10, 11]),
+                    tx_vlan_id: 0,
+                },
+                nat: nat_for(pool_addr, snat_port),
+            },
+            metadata: metadata(),
+            origin: SessionOrigin::ForwardFlow,
+        }
+    }
+
+    fn used(forwarding: &ForwardingState, pool: &str) -> u64 {
+        crate::nat::source_nat_pool_statuses(&forwarding.source_nat_rules)
+            .into_iter()
+            .find(|s| s.pool_name == pool)
+            .unwrap_or_else(|| panic!("no pool status for {pool}"))
+            .used_ports
+    }
+
+    /// The reap returns the pool port. Fail-on-revert: delete the
+    /// `release_source_nat_allocation_for_worker` call in `reap_expired_sessions`
+    /// and this goes RED — before #6901 that deletion left the crate green.
+    #[test]
+    fn gc_reap_releases_the_source_nat_pool_port_6901() {
+        let mut forwarding = ForwardingState::default();
+        forwarding.source_nat_rules =
+            crate::nat::parse_source_nat_rules(&[rule_snapshot("pool-a", "lan", POOL_A)]);
+
+        crate::nat::reserve_synced_source_nat_allocation(
+            &forwarding.iface_nat_allocators,
+            &forwarding.source_nat_rules,
+            &key_for(1111),
+            nat_for(POOL_A, 40000),
+            false,
+            None,
+            0,
+        );
+        assert_eq!(
+            used(&forwarding, "pool-a"),
+            1,
+            "precondition: the translated flow must hold one pool port, or the \
+             assertion below passes against a pool that was never allocated from",
+        );
+
+        reap_expired_sessions(
+            &mut [],
+            &[expired_for(1111, POOL_A, 40000)],
+            &forwarding,
+            -1,
+            -1,
+            -1,
+            1_000_000_000,
+            0,
+        );
+
+        assert_eq!(
+            used(&forwarding, "pool-a"),
+            0,
+            "the GC reap must return the pool port. Without this the ordinary \
+             inactivity teardown leaks one port per reaped translated session \
+             until AllocatorExhausted (#6901)",
+        );
+    }
+
+    /// It releases the port THIS session holds, not merely some port. A single
+    /// pool cannot tell those apart: a release that freed the wrong allocator
+    /// would still drive one count to zero.
+    #[test]
+    fn gc_reap_releases_only_the_reaped_flows_pool_6901() {
+        let mut forwarding = ForwardingState::default();
+        forwarding.source_nat_rules = crate::nat::parse_source_nat_rules(&[
+            rule_snapshot("pool-a", "lan", POOL_A),
+            rule_snapshot("pool-b", "dmz", POOL_B),
+        ]);
+
+        for (key_port, pool, snat_port) in [(1111u16, POOL_A, 40000u16), (2222, POOL_B, 40001)] {
+            crate::nat::reserve_synced_source_nat_allocation(
+                &forwarding.iface_nat_allocators,
+                &forwarding.source_nat_rules,
+                &key_for(key_port),
+                nat_for(pool, snat_port),
+                false,
+                None,
+                0,
+            );
+        }
+        assert_eq!(
+            (used(&forwarding, "pool-a"), used(&forwarding, "pool-b")),
+            (1, 1),
+            "precondition: both pools hold one port",
+        );
+
+        // Reap ONLY the pool-a flow.
+        reap_expired_sessions(
+            &mut [],
+            &[expired_for(1111, POOL_A, 40000)],
+            &forwarding,
+            -1,
+            -1,
+            -1,
+            1_000_000_000,
+            0,
+        );
+
+        assert_eq!(
+            used(&forwarding, "pool-a"),
+            0,
+            "the reaped flow's own pool must be released",
+        );
+        assert_eq!(
+            used(&forwarding, "pool-b"),
+            1,
+            "the OTHER pool must be untouched — a release that freed by count \
+             rather than by the reaped flow's own (pool, port) would free a \
+             port another live session is still forwarding through",
+        );
+    }
+}


### PR DESCRIPTION
`reap_expired_sessions`'s `release_source_nat_allocation_for_worker` call was
**unbound** — deleting it left the whole crate green.

Closes #6901

## Premise re-measured before building

| run | collected | failed | rc |
|---|---|---|---|
| control | 4670 | 0 | 0 |
| **release call deleted** | **4670** | **0** | **0** |

Identical, and the mutation **ran** — same collection, not a build break. The
issue is not stale. Only line drift: it cites `:1625`, the call is now at
`:1598`.

That call is the ordinary inactivity-timeout teardown — the path that frees a
source-NAT pool port for the overwhelming majority of sessions, which age out
rather than being explicitly deleted. Without it, every reaped translated
session leaks a port until `AllocatorExhausted`, and nothing noticed.

## Two cells, because the acceptance has two halves

*"The reap calls release"* and *"the reap releases the port THIS session holds"*
are different claims, and only the first is bound by a count reaching zero.

- **`gc_reap_releases_the_source_nat_pool_port_6901`** drives the production
  `reap_expired_sessions` with one expired translated session and requires
  `used_ports` 1 → 0 — with a precondition assert, so the zero cannot be read
  off a pool that was never allocated from.
- **`gc_reap_releases_only_the_reaped_flows_pool_6901`** uses **two** pools,
  reaps one flow, and requires the other pool is **untouched**. A single-pool
  fixture cannot distinguish *released the right allocation* from *released
  something*: a release that freed by count would still drive one count to zero.

Both live in the sibling of `flow_cache_invalidation_tests`, which already
drives the production `reap_expired_sessions` — so they exercise the real call
path rather than a helper.

## Mutation, at the control count

| mutation | verdict | collected | named |
|---|---|---|---|
| delete the release call | **RED** | **4672** | both new cells |

4672 is exactly the control with the cells present — a clean red, not a
crash-truncated one.

## The issue's open question, answered: the NAT64 sibling is also unbound

The issue notes *"same check is probably worth running for
`release_nat64_allocation`"*. Run:

| mutation | verdict | collected |
|---|---|---|
| neuter `release_nat64_allocation_for_worker` (two lines below, same loop) | **GREEN** | 4672 |

There **are** existing NAT64 release tests (`nat64_tests.rs:3934`), but they call
`release_nat64_allocation` **directly** — the function is bound, its reap call
site is not. Same shape as this issue, different allocator.

**Deliberately not folded in.** It needs its own NAT64 prefix/pool fixture, and
#6901's own provenance cites the *"do not put a second unrelated production
claim under one title"* rule. Reported for its own item rather than carried
here.

## Gates

Gated head **`83460cdd0bd554c199cbd9946e812bcd413a6ee4`**.

- `cargo test -- --test-threads=1` — **rc 0**, 4805 passed, 0 failed.
- `rustfmt --check` clean on the touched region.
- `git merge-base --is-ancestor 2bcd7a4d2 83460cdd0` succeeds.

No Go gate: the diff is one Rust file and a log, so a Go run would measure
master rather than this change.
