### PR TITLE
nat64: select the synced reserve's prefix by the v6 destination

### DIFF
--- a/docs/log/6892.md
+++ b/docs/log/6892.md
@@ -31,3 +31,22 @@
     destination in the other prefix so hard-coding either index fails, and a
     third keeps the fallback bound.
   - **File(s)**: userspace-dp/src/nat64.rs, userspace-dp/src/nat64_tests.rs
+
+- **Timestamp**: 2026-08-27 (validation)
+  - **A harness trap found mid-matrix, in a Rust shape.** `cargo test` stops
+    after the first FAILING TEST BINARY unless `--no-fail-fast`, so the first
+    three cells were scored against a truncated run — 66 tests in later binaries
+    never executed, while my "collected > 0" gate passed. Same class as the
+    #6888 panic-abort: an incomplete run reading as a verdict. The harness now
+    passes `--no-fail-fast` AND compares the number of reporting test binaries
+    against the control's (10), voiding a short run. All cells re-run at full
+    collection; verdicts unchanged.
+  - **The mirror cell was unarmed** by the first three mutations: "remove the
+    narrowing" and "always prefix 0" both leave a prefix-A destination landing in
+    prefix 0, which is what that cell asserts. T4 ("always prefix 1") is the
+    mutation it exists to catch, and it reds there.
+  - **Validation**: Go `go test ./... -count=1 -p 4` rc 0 / 68 packages; cargo
+    `--no-fail-fast -- --test-threads=1` rc 0 / **4806 passed** / 10 binaries;
+    `make cluster-deploy` (sha256-verified both nodes) + `make test-failover` →
+    **14 passed, 0 failed**, 23.0 Gbps (passed+failed = 14, nothing silently
+    skipped).

--- a/docs/log/6892.md
+++ b/docs/log/6892.md
@@ -1,0 +1,33 @@
+# #6892 — NAT64 synced reserve selects the prefix on the wrong field
+
+- **Timestamp**: 2026-08-27
+  - **Measured the gating unknown FIRST**, as scoped: whether the synced
+    `SessionKey.dst_ip` holds the pre-translation IPv6 destination. **It does**,
+    confirmed from production code rather than inferred:
+    `build_nat64_reverse_rebuild` (server helpers) already extracts the RFC 6052
+    embedded v4 out of `key.dst_ip` and documents that "a NAT64 forward flow is
+    always keyed on the original IPv6 5-tuple"; `forward_wire_key`
+    (session/key.rs) exists precisely because the post-translation view is a
+    DIFFERENT key; and the function under repair already substitutes
+    `nat.rewrite_dst` for `key.dst_ip` when building its flow key. So
+    `match_ipv6_dest` is applicable and the fix shape holds.
+  - **The defect is matching on the WRONG FIELD, not matching too loosely.** The
+    active selects its prefix with `match_ipv6_dest` — `prefix_bytes` against the
+    IPv6 destination. The synced path scanned for the first prefix whose
+    `pool_v4` contains `snat_v4` and ignored `prefix_bytes` entirely. Each
+    `Nat64Prefix` owns its own `port_allocator`, so a divergent pick reserves in a
+    different allocator than the session occupies: the translated `(pool v4,
+    port)` stays free where it matters and a post-failover local flow can be
+    handed it.
+  - **Action**: narrow by `match_ipv6_dest` first, fall back to the existing pool
+    scan (#6211's narrow-then-fall-back shape). The fallback is retained, not
+    replaced, so a v4-keyed or prefix-less key (config drift, an old peer) keeps
+    today's behaviour instead of silently reserving nothing.
+  - **Fixture**: two prefixes sharing ONE `pool_v4` address with different
+    `prefix_bytes`. A single-prefix fixture cannot exercise this at all — with one
+    prefix the two selection rules give the same answer, so the defect is
+    invisible. The cells assert WHICH ALLOCATOR holds the reservation, because
+    "it reserved" is satisfied by the buggy path too. A mirror cell drives a
+    destination in the other prefix so hard-coding either index fails, and a
+    third keeps the fallback bound.
+  - **File(s)**: userspace-dp/src/nat64.rs, userspace-dp/src/nat64_tests.rs

--- a/userspace-dp/src/nat64.rs
+++ b/userspace-dp/src/nat64.rs
@@ -1896,6 +1896,49 @@ fn reserve_synced_nat64_allocation_with_holder(
         src_port: key.src_port,
         dst_port: key.dst_port,
     };
+    // #6892: narrow to the prefix the ACTIVE node would have used, by the SAME
+    // discriminator it uses, BEFORE falling back to the pool scan below.
+    //
+    // The scan alone takes the first prefix whose `pool_v4` contains `snat_v4`
+    // -- the #6211 shape. That is not merely too loose: each `Nat64Prefix` owns
+    // its OWN `port_allocator`, and the active selected its prefix with
+    // `match_ipv6_dest`, i.e. on `prefix_bytes` against the IPv6 destination.
+    // Two prefixes sharing one pool address therefore diverge because the
+    // standby is matching on the WRONG FIELD, and a divergent pick reserves in a
+    // different allocator than the one the session actually occupies -- so the
+    // port stays free in the allocator that matters and a post-failover local
+    // flow can be handed the same translated `(pool v4, port)`.
+    //
+    // `key.dst_ip` is the PRE-translation synthetic IPv6 destination, not the
+    // extracted v4: a NAT64 forward flow is always keyed on the original IPv6
+    // 5-tuple (`build_nat64_reverse_rebuild` in the server helpers already
+    // extracts the RFC 6052 embedded v4 out of this same field), and
+    // `forward_wire_key` exists precisely because the post-translation view is a
+    // DIFFERENT key. That is also why `flow.dst_ip` above substitutes
+    // `nat.rewrite_dst` for it.
+    //
+    // The scan is kept as a fallback rather than replaced: a v4-keyed or
+    // prefix-less key (config drift between nodes, an old peer) still gets
+    // today's behaviour instead of silently reserving nothing.
+    let narrowed = match key.dst_ip {
+        IpAddr::V6(dst_v6) => nat64.match_ipv6_dest(dst_v6).map(|(idx, _)| idx),
+        IpAddr::V4(_) => None,
+    };
+    if let Some(prefix) = narrowed.and_then(|idx| nat64.prefixes.get(idx)) {
+        if let Some(addr_index) = prefix.pool_v4.iter().position(|a| *a == snat_v4) {
+            return reserve_nat64_pool_port(
+                &prefix.port_allocator,
+                flow,
+                snat_v4,
+                port,
+                addr_index,
+                prefix.deterministic_v6.is_some(),
+                now_ns,
+                holder,
+            );
+        }
+    }
+
     for prefix in &nat64.prefixes {
         // The NAT64 allocator is sized to `pool_v4.len()` with
         // `family_offset == 0`, so the absolute allocator index equals the

--- a/userspace-dp/src/nat64_tests.rs
+++ b/userspace-dp/src/nat64_tests.rs
@@ -6102,3 +6102,212 @@ fn frag_assoc_config_fence_survives_the_rg_fence_6857() {
          The runtime fence is added BESIDE the config one, not instead of it"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #6892: the synced NAT64 reserve must pick the prefix by the SAME
+// discriminator the ACTIVE node used.
+// ---------------------------------------------------------------------------
+
+// TWO prefixes that SHARE one pool address and differ only in prefix_bytes.
+//
+// This shape is the whole test, and a single-prefix fixture cannot exercise it
+// at all: with one prefix, "first prefix whose pool_v4 contains snat_v4" and
+// "the prefix whose prefix_bytes match the v6 destination" are the same answer,
+// so the defect is invisible. Sharing the pool address is what makes the pool
+// scan ambiguous; differing prefix_bytes is what makes the v6 destination
+// decisive.
+fn shared_pool_prefixes_6892() -> Vec<NAT64RuleSnapshot> {
+    vec![
+        NAT64RuleSnapshot {
+            name: "nat64-a".to_string(),
+            prefix: "64:ff9b::/96".to_string(),
+            pool_addresses: vec!["198.51.100.1".to_string()],
+            no_v6_frag_header: false,
+            ..Default::default()
+        },
+        NAT64RuleSnapshot {
+            name: "nat64-b".to_string(),
+            // A DIFFERENT Pref64 with the SAME pool address.
+            prefix: "2001:db8:64::/96".to_string(),
+            pool_addresses: vec!["198.51.100.1".to_string()],
+            no_v6_frag_header: false,
+            ..Default::default()
+        },
+    ]
+}
+
+fn synced_key_for_dst_6892(client: &str, dst_v6: &str) -> crate::session::SessionKey {
+    crate::session::SessionKey {
+        addr_family: libc::AF_INET6 as u8,
+        protocol: crate::ip_proto::PROTO_TCP,
+        src_ip: IpAddr::V6(client.parse().unwrap()),
+        dst_ip: IpAddr::V6(dst_v6.parse().unwrap()),
+        src_port: 5000,
+        dst_port: 443,
+    }
+}
+
+// FAIL-ON-REVERT: drop the #6892 match_ipv6_dest narrowing and the reserve falls
+// back to "first prefix whose pool_v4 contains snat_v4", which is prefix 0 for
+// BOTH destinations. The prefix-1 assertion below then goes RED.
+//
+// This asserts WHICH ALLOCATOR holds the reservation, not merely that a
+// reservation happened — the defect is a reservation in the wrong allocator, so
+// "it reserved" is satisfied by the buggy path too.
+#[test]
+fn nat64_6892_synced_reserve_picks_the_prefix_the_active_used() {
+    let state = Nat64State::from_snapshots(&shared_pool_prefixes_6892());
+    assert_eq!(state.prefixes.len(), 2, "fixture must have two prefixes");
+    let snat = Ipv4Addr::new(198, 51, 100, 1);
+    let dst_v4 = Ipv4Addr::new(8, 8, 8, 8);
+
+    // The active translated a flow whose v6 destination lies in prefix B, so it
+    // selected prefix 1 via match_ipv6_dest and reserved in prefix 1's
+    // allocator. The standby must land in the SAME one.
+    let key = synced_key_for_dst_6892("2001:db8::1", "2001:db8:64::0808:0808");
+    let synced = Nat64State::forward_decision(snat, dst_v4, 1024);
+    assert!(
+        reserve_synced_nat64_allocation(&state, &key, synced, false, 0),
+        "the synced reserve must succeed"
+    );
+
+    // Prefix 1 (the one the ACTIVE used) must now refuse a DIFFERENT flow on the
+    // same (snat, port) — that is what "the reservation lives here" means.
+    let other_flow = SourceNatFlowKey {
+        protocol: crate::ip_proto::PROTO_TCP,
+        src_ip: "2001:db8::99".parse().unwrap(),
+        dst_ip: IpAddr::V4(dst_v4),
+        src_port: 6000,
+        dst_port: 443,
+    };
+    assert!(
+        !reserve_nat64_pool_port(
+            &state.prefixes[1].port_allocator,
+            other_flow,
+            snat,
+            1024,
+            0,
+            false,
+            0,
+            crate::nat::NatHolder::Untracked,
+        ),
+        "prefix 1's allocator does NOT hold the synced reservation — the standby \
+         reserved in a different allocator than the active used, so the translated \
+         (pool v4, port) is still free where it matters and a post-failover local \
+         flow can be handed it (#6892)"
+    );
+
+    // And prefix 0 must be UNTOUCHED: a reservation there is the bug's signature.
+    assert!(
+        reserve_nat64_pool_port(
+            &state.prefixes[0].port_allocator,
+            other_flow,
+            snat,
+            1024,
+            0,
+            false,
+            0,
+            crate::nat::NatHolder::Untracked,
+        ),
+        "prefix 0's allocator holds a reservation it should never have taken — the \
+         synced path selected by pool_v4 membership instead of the v6 destination (#6892)"
+    );
+}
+
+// The MIRROR case, and it is what stops the fix being "always pick prefix 1".
+// Same fixture, same pool address, destination in prefix A: the reservation must
+// land in prefix 0. Without this cell, hard-coding either index passes.
+#[test]
+fn nat64_6892_synced_reserve_follows_the_destination_prefix_both_ways() {
+    let state = Nat64State::from_snapshots(&shared_pool_prefixes_6892());
+    let snat = Ipv4Addr::new(198, 51, 100, 1);
+    let dst_v4 = Ipv4Addr::new(8, 8, 8, 8);
+
+    let key = synced_key_for_dst_6892("2001:db8::1", "64:ff9b::0808:0808");
+    let synced = Nat64State::forward_decision(snat, dst_v4, 2048);
+    assert!(reserve_synced_nat64_allocation(&state, &key, synced, false, 0));
+
+    let other_flow = SourceNatFlowKey {
+        protocol: crate::ip_proto::PROTO_TCP,
+        src_ip: "2001:db8::99".parse().unwrap(),
+        dst_ip: IpAddr::V4(dst_v4),
+        src_port: 6000,
+        dst_port: 443,
+    };
+    assert!(
+        !reserve_nat64_pool_port(
+            &state.prefixes[0].port_allocator,
+            other_flow,
+            snat,
+            2048,
+            0,
+            false,
+            0,
+            crate::nat::NatHolder::Untracked,
+        ),
+        "a destination in prefix A did not reserve in prefix 0's allocator (#6892)"
+    );
+    assert!(
+        reserve_nat64_pool_port(
+            &state.prefixes[1].port_allocator,
+            other_flow,
+            snat,
+            2048,
+            0,
+            false,
+            0,
+            crate::nat::NatHolder::Untracked,
+        ),
+        "prefix 1 took a reservation for a destination in prefix A (#6892)"
+    );
+}
+
+// The FALLBACK must survive. A key whose destination matches NO configured
+// prefix (config drift between nodes, or an old peer that synced a v4-keyed
+// tuple) must still reach the pool scan rather than silently reserving nothing —
+// narrowing is an added discriminator, not a replacement gate.
+#[test]
+fn nat64_6892_unmatched_destination_still_falls_back_to_the_pool_scan() {
+    let state = Nat64State::from_snapshots(&shared_pool_prefixes_6892());
+    let snat = Ipv4Addr::new(198, 51, 100, 1);
+    let dst_v4 = Ipv4Addr::new(8, 8, 8, 8);
+
+    // A destination in NEITHER Pref64.
+    let key = synced_key_for_dst_6892("2001:db8::1", "2001:dead:beef::0808:0808");
+    assert!(
+        state
+            .match_ipv6_dest("2001:dead:beef::0808:0808".parse().unwrap())
+            .is_none(),
+        "fixture precondition: this destination must match no prefix, or the cell \
+         is not exercising the fallback"
+    );
+
+    let synced = Nat64State::forward_decision(snat, dst_v4, 4096);
+    assert!(
+        reserve_synced_nat64_allocation(&state, &key, synced, false, 0),
+        "an unmatched destination must still reserve via the pool scan — dropping \
+         the fallback would leave the translated port free on the standby (#6892)"
+    );
+
+    // The scan takes the first pool owner, which is prefix 0.
+    let other_flow = SourceNatFlowKey {
+        protocol: crate::ip_proto::PROTO_TCP,
+        src_ip: "2001:db8::99".parse().unwrap(),
+        dst_ip: IpAddr::V4(dst_v4),
+        src_port: 6000,
+        dst_port: 443,
+    };
+    assert!(
+        !reserve_nat64_pool_port(
+            &state.prefixes[0].port_allocator,
+            other_flow,
+            snat,
+            4096,
+            0,
+            false,
+            0,
+            crate::nat::NatHolder::Untracked,
+        ),
+        "the fallback scan did not reserve anywhere (#6892)"
+    );
+}


### PR DESCRIPTION
Closes #6892

## The gating question, measured first

The fix depends entirely on whether the synced `SessionKey.dst_ip` holds the **pre-translation IPv6 destination**. If it carried the extracted v4, `match_ipv6_dest` could not be applied and this would be a different shape.

**It holds the v6 destination** — established from production code, not inferred from the forward path:

- `build_nat64_reverse_rebuild` (`server/helpers/session_sync.rs`) **already extracts the RFC 6052 embedded v4 out of this same field**, and documents that *"a NAT64 forward flow is always keyed on the original IPv6 5-tuple"*.
- `forward_wire_key` (`session/key.rs`) exists **precisely because** the post-translation view is a different key: `wire_dst = nat.rewrite_dst.unwrap_or(forward_key.dst_ip)`.
- The function under repair already substitutes `nat.rewrite_dst` for `key.dst_ip` when building its flow key — which is only meaningful if the two differ.

## The defect: matching on the wrong field, not too loosely

The **active** selects its prefix with `match_ipv6_dest` — `prefix_bytes` against the IPv6 destination. The **synced** path scanned for the first prefix whose `pool_v4` contains `snat_v4` and ignored `prefix_bytes` entirely.

Each `Nat64Prefix` owns its **own** `port_allocator`, so a divergent pick reserves in a different allocator than the session occupies: the translated `(pool v4, port)` stays free where it matters, and a post-failover local flow can be handed the same one. That is the RFC 6146 BIB violation #4381/#4512 closed for the single-prefix case, reappearing whenever two prefixes share a pool address.

## The fix

Narrow by `match_ipv6_dest` first, **fall back to the existing pool scan** — #6211's narrow-then-fall-back shape. The scan is kept rather than replaced: a v4-keyed or prefix-less key (config drift between nodes, an old peer) still gets today's behaviour instead of the narrowing becoming a gate that silently reserves nothing. Cell **T3** proves that matters — turning it into a gate reds both my fallback cell *and* a pre-existing #6600 rollback test.

## The fixture is the test

**Two prefixes sharing one `pool_v4` address with different `prefix_bytes`.** A single-prefix fixture cannot exercise this at all: with one prefix, "first pool owner" and "the prefix whose bytes match the destination" are the same answer and the defect is invisible.

The cells assert **which allocator holds the reservation**, not that a reservation happened — the buggy path reserves too, just in the wrong place. A mirror cell drives a destination in the *other* prefix, so hard-coding either index fails.

## Mutation matrix

`cargo test --no-fail-fast -- --test-threads=1`, one mutation per cell, committed before mutating, tree clean after each restore. Control **4802 collected / 0 failed / 10 binaries**.

| cell | mutation | reds |
|---|---|---|
| control | — | **0** |
| T1 | remove the narrowing (the shipped defect) | `synced_reserve_picks_the_prefix_the_active_used` |
| T2 | narrow but always take prefix 0 | `synced_reserve_picks_the_prefix_the_active_used` |
| T3 | narrowing becomes a **gate** (no fallback) | `unmatched_destination_still_falls_back_to_the_pool_scan` + **pre-existing** `upsert_synced_session_rolls_back_source_nat_when_nat64_refuses_6600` |
| **T4** | **always take prefix 1** | `synced_reserve_follows_the_destination_prefix_both_ways` |

**T4 exists because the mirror cell was unarmed by T1–T3**: "remove the narrowing" and "always prefix 0" both leave a prefix-A destination landing in prefix 0, which is exactly what that cell asserts. Only forcing prefix 1 can red it.

### A harness trap found mid-matrix

**`cargo test` stops after the first failing test BINARY unless `--no-fail-fast`.** The first three cells were scored against a truncated run — 66 tests in later binaries never executed — while my "collected > 0" gate passed. Same class as the #6888 panic-abort: an incomplete run reading as a verdict, arriving from a third direction.

The harness now passes `--no-fail-fast` **and** compares the number of reporting test binaries against the control's (10), voiding a short run. All cells were re-run at full collection; the verdicts are unchanged, but they are now measured rather than assumed.

## Gate

- `go build ./...` → rc 0; `go test ./... -count=1 -p 4` → **rc 0, 68 packages, 0 failures**
- `cargo test --no-fail-fast -- --test-threads=1` → **rc 0, 4806 passed, 10/10 binaries reporting**
- `make cluster-deploy` (sha256-verified both nodes) + `make test-failover` → **14 passed, 0 failed**, 23.0 Gbps (passed+failed = 14, so no gate silently skipped its verdict)
- `merge-base --is-ancestor origin/master HEAD` verified; folded with `git merge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ez9XCjM9mPjtocRjkousdB
