### PR TITLE
docs/log: re-verify the 004/005 finding set at master (#6907)

### DIFF
--- a/docs/log/6907.md
+++ b/docs/log/6907.md
@@ -1,0 +1,62 @@
+# #6907 — re-verification of the 004/005 "still present" set at master `ac1f4d134`
+
+- **Timestamp**: 2026-08-27
+- **Action**: Per-row disposition for all 17 `DUP still-major` rows. **No fixes
+  in this pass**, per the issue's scope.
+- **Method**: every row re-located by SYMBOL, never by the cited line. "Not
+  found at the cited path" was treated as *cite rotted*, never as *resolved* —
+  the trap #6898 hit.
+- **Source**: the issue cites `/tmp/result-claude-spark-review-007.md`, which
+  **does not exist**; the document is `/tmp/claude-spark-review-007.md`. The
+  evidence path for a citation-quality issue was itself a rotted citation.
+  Copied to `/home/ps/review-007-backup.md` before use, since `/tmp` is a
+  volatile tmpfs that hit 100% earlier in this campaign.
+
+## Disposition
+
+| # | claim | verdict | evidence at master |
+|---|---|---|---|
+| 04 | ShardedNeighborMap unkeyed FxHasher shard flood | **PRESENT, partly mitigated** | `afxdp/sharded_neighbor.rs:162` (cited `:176`). `FxHasher::default()` is there, but `shard_idx` post-multiplies by the Knuth constant and takes the HIGH bits, documented as producing "a uniform distribution for adversarial input patterns like `/24` LANs". That answers *structural* clustering; it adds no secret, so a chosen-input adversary can still target a shard. The finding survives in its strong form only. |
+| 05 | mpsc_inbox single-consumer not type-enforced | **PRESENT** | `afxdp/mpsc_inbox.rs:59-60` `unsafe impl Send/Sync`, `:109` `get_unchecked`. The invariant is a doc comment (`:13`, "correctness needs only the weaker single-consumer invariant"), not a type. Claim accurate as written. |
+| 06 | shared_recycle unknown-slot drop leaks UMEM | **PRESENT, now instrumented** | `afxdp/tx/dispatch/shared_recycle.rs:38-42`: the drop still happens, but is counted and logged (`log_shared_recycle_unknown_slot_drops`, `record_shared_recycle_unknown_slot_drops`). Silent-leak half of the claim is refuted; the drop half stands. |
+| 07 | `slice_mut_unchecked` on shared `&MmapArea` | **PRESENT — cite rotted to the wrong FILE** | Not in `tx/transmit/rewrite.rs` as cited. Four sites in `afxdp/cos/queue_service/drain.rs` (`:97`, `:315`, `:384`, `:574`). |
+| 08 | ZoneCounterStore `expect` on poison | **PRESENT** | `afxdp/zone_counters.rs` — seven `expect("zone counter store poisoned")`, none at the cited `:189`; first at `:288`. Doc at `:283` scopes it to "Config-apply path only … NOT the hot path", which bounds the blast radius without removing the panic. |
+| 09 | PrefixTrie `root.covers` ignores /0 → bypass | **REFUTED IN-TREE, direction inverted** | `prefix_set.rs:240-246` addresses this exact case and states the opposite outcome: a bypass-inserted /0 "would NOT match all … silently ineffective, not unsafe". The finding claims over-match; the code documents under-match. |
+| 10 | PrefixSet `Default` → `MatchAny` fail-open | **PRESENT — unambiguous** | `prefix_set.rs:198-208`: `impl Default for PrefixSetV4/V6 { fn default() -> Self { Self::MatchAny } }`. A defaulted prefix set matches every address. |
+| 11 | fairness_eval per_worker unchecked `u32 +=` | **PRESENT, low reach** | `fairness_eval/per_worker.rs:75`, `:121` — `.or_insert(0) += row.count`, unchecked. `fairness_eval` is an offline analysis module, not the packet path. |
+| 12 | io_uring Write SQE len truncation | **PRESENT** | `io_uring_write.rs:375` — `buf.len() as _` into the SQE length. |
+| 13 | ThreeColorPolicer Mutex per-packet | **NOT PRESENT** | No `Mutex<ThreeColorPolicer>` anywhere; the runtime is `Arc<ThreeColorPolicerRuntime>` (`filter/engine/cache_sensitive/rotation.rs:18`). The row contradicted itself ("now lock-free but prior path") and the code agrees with the parenthetical. **Fixing commit not identified — recorded as not-present, not as "fixed by X".** |
+| 14 | filter compiler `unique_runtime_id` exhaustion | **PRESENT** | `filter/compiler.rs:405-412` — `while !used_ids.insert(id) { id = id.wrapping_add(1); if id == 0 { id = 1 } }`. With the id space full this never terminates. Requires ~2^32 runtime ids to reach. |
+| 15 | RingWriter drop-order UAF | **PRESENT, and documented as open in-tree** | `io_uring_write.rs:466-477`. The Drop comment states the ordering "narrows the window **but is not a barrier** — the fd close only queues `io_ring_exit_work` (#6168)". The code itself says the window survives. |
+| 16 | PollMode wildcard → BusyPoll | **PRESENT — live** | `server/state.rs:19-21` — `match s { "interrupt" => Interrupt, _ => BusyPoll }`. Any unrecognised value, including a typo, silently selects the spinning mode. |
+| 17 | `bridge_xsk_ring_prod_cancel` direct `cached_prod` | **PRESENT — the one accurate citation** | `csrc/xsk_bridge.c:171-173`, exactly as cited: `ring->cached_prod -= nb;`. Note the asymmetry the finding is really about — the cons twin at `:219` delegates to `xsk_ring_cons__cancel`. |
+| 18 | workers `outstanding_tx` gauge fabricates `Workers=1` | **UNVERIFIABLE** | `outstanding_tx` exists (`afxdp/tx/rings.rs:24`, `:63`, `:308`), but I could not locate a gauge that fabricates a worker count from it. The row cites no file. Not "fixed" — I could not find what it refers to. |
+| 19 | Cross-surface DDNS co-ownership | **TRACKING CLAIM REFUTED** | The row's basis is "#6755 still present". **#6755 is CLOSED.** Whether the underlying defect persists is a separate question this row does not answer. |
+| 20 | HTTP DDNS cache ignores changed bind device | **TRACKING CLAIM REFUTED** | Basis "#6754 still present". **#6754 is CLOSED.** Same caveat. |
+
+## Totals
+
+**11 present** (04, 05, 06, 07, 08, 10, 11, 12, 14, 15, 16, 17 — twelve rows, of
+which 04 and 06 survive only in a narrowed form), **2 refuted in substance**
+(09, 13), **2 refuted in their tracking basis** (19, 20), **1 unverifiable**
+(18).
+
+## What this pass says about the source document
+
+- **Every line number I could check was wrong except one.** `:176` → `:162`,
+  `:189` → `:288`, `rewrite.rs` → `cos/queue_service/drain.rs`. The single
+  accurate citation is row 17's `xsk_bridge.c:171`.
+- **Two rows are refuted by the very file they cite** (09, 13), and the code
+  states the refutation in a comment. Both were tabled as majors.
+- **Two rows cite issues that are closed** (19, 20) while asserting "still
+  present tip".
+- The symbols are real everywhere, so these are drifted citations rather than
+  fabrications — but as filed, **16 of 17 could not be followed as written**.
+
+## Not done, deliberately
+
+No fixes. Rows 10 and 16 are the two I would file first if asked — both are
+unambiguous, both are fail-open-shaped, and neither depends on adjudicating a
+design rationale. Filing is out of scope for this pass per the issue.
+
+**File(s)**: `docs/log/6907.md`


### PR DESCRIPTION
Per-row disposition for all **17** `DUP still-major` rows from campaign 007,
verified at master `ac1f4d134`.

Refs #6907

**No fixes.** The issue scopes this pass to verification, and folding fixes in
would make both harder to review.

## Method

Every row re-located by **symbol**, never by the cited line. *"Not found at the
cited path"* was treated as **cite rotted**, never as **resolved** — the trap
#6898 hit, and the one that would have closed a third of this set without
reading any code.

## Result

**11 present** (two only in a narrowed form) · **2 refuted in substance** ·
**2 refuted in their tracking basis** · **1 unverifiable**

The two substantive refutations are both stated **by the very file the row
cites**:

- **Row 09** claims a `/0` bypass that over-matches. `prefix_set.rs:240-246`
  documents the opposite outcome — a bypass-inserted `/0` "would **NOT** match
  all … silently ineffective, not unsafe".
- **Row 13** claims a per-packet `ThreeColorPolicer` Mutex. No such Mutex
  exists; the runtime is `Arc<ThreeColorPolicerRuntime>`. The row contradicted
  itself in its own evidence column.

**Rows 19 and 20** assert "still present tip" on the basis of #6755 and #6754.
**Both issues are CLOSED.** That refutes the row's stated basis — not
necessarily the underlying defect, and the disposition keeps that distinction.

**Row 18 is unverifiable, not fixed.** `outstanding_tx` exists, but I could not
locate the gauge the row describes and the row cites no file. *"I could not find
it"* and *"it was fixed"* are different claims.

**Row 13 is recorded as NOT PRESENT rather than "fixed by X".** I did not
identify the commit that removed the mutex, and naming one I had not found would
inherit exactly the provenance problem this issue exists to fix.

## Citation quality, measured

- **Every line number checkable was wrong except one** — row 17's
  `xsk_bridge.c:171`. `:176` → `:162`; `:189` → `:288`; `rewrite.rs` →
  `cos/queue_service/drain.rs`.
- The symbols are real everywhere, so these are **drifted citations rather than
  fabrications** — but as filed, **16 of 17 could not be followed as written**.
- The issue's own evidence path, `/tmp/result-claude-spark-review-007.md`, does
  **not exist**; the document is `/tmp/claude-spark-review-007.md`. The evidence
  pointer for a citation-quality issue was itself a rotted citation. Copied to a
  non-volatile path before use, since `/tmp` is a tmpfs that hit 100% earlier in
  this campaign.

## If asked to file

Rows **10** (`impl Default for PrefixSetV4/V6 → MatchAny`, so a defaulted prefix
set matches every address) and **16** (`PollMode::from_str`'s `_ => BusyPoll`, so
a typo silently selects the spinning mode) are the two I would file first. Both
are unambiguous, both are fail-open-shaped, and neither needs a design rationale
adjudicated. Out of scope here.

The full table with per-row evidence is in `docs/log/6907.md` and posted as a
comment on #6907.

## Gates

Documentation only — one new file, no code touched.
`go test ./pkg/refactoraudit/ -count=1` ok (the modularity gate, since the diff
adds a file).
