### PR TITLE
prefix_set,server: record why two fail-open defaults are latent (#7745)

### DIFF
--- a/docs/log/7745.md
+++ b/docs/log/7745.md
@@ -1,0 +1,64 @@
+# #7745 — the two fail-open defaults from the #6907 re-verification
+
+- **Timestamp**: 2026-08-27
+- **Action**: Measure reachability FIRST. Both rows are **latent, not live** —
+  recorded in place, no behaviour changed.
+- The steer was right and it inverted the work: I had flagged both as "the two I
+  would file first, both unambiguous, both fail-open-shaped". They are
+  fail-open-shaped. Neither is reachable.
+
+## Row 10 — `PrefixSet::default() -> MatchAny`
+
+**Latent. Comment, not change.**
+
+- The only production references to `PrefixSetV4/V6::default()` are inside
+  `impl Default for PolicyRule` (`policy.rs:470-473`).
+- **`PolicyRule::default()` is never called on a production path.** Its two
+  production mentions are both COMMENTS. `policy.rs:2127` records why: the real
+  rule constructor deliberately dropped its `..PolicyRule::default()` tail so a
+  future field addition is a compile error, "eliminating the silent-zero-default
+  hazard" (#1632). The `impl Default` survives as a type-level convenience.
+- **`MatchAny` is load-bearing for internal consistency**, exactly as the steer
+  anticipated: the same `Default` impl sets `source_v4_match_any: true`,
+  `destination_v4_match_any: true` and siblings. A defaulted `PolicyRule` is
+  deliberately a match-anything rule. Flipping the sets to `MatchNone` would
+  leave it self-contradictory — booleans saying "any", sets saying "none" —
+  which is a worse hazard than the one removed.
+- Recorded at both `impl Default` sites with the reachability argument and the
+  condition that would make it live: a `..Default::default()` tail reintroduced
+  to a rule constructor. The fix would then belong at that call site, not here.
+
+## Row 16 — `PollMode::from_str`'s `_ => BusyPoll`
+
+**Latent. Comment, not change.**
+
+The wildcard does select the CPU-expensive direction. But from a committed
+config only `"busy-poll"` and `"interrupt"` can reach it, guarded **three**
+times before this point:
+
+1. `pkg/config/schema_system.go:365` — `ValidateEnum([]string{"busy-poll",
+   "interrupt"})`, so a typo is rejected at COMMIT.
+2. `pkg/config/compiler_system.go:922` — assigns only for those two literals;
+   anything else leaves `cfg.PollMode` empty.
+3. `pkg/dataplane/userspace/process.go:161` — an empty `cfg.PollMode` becomes
+   the explicit `"busy-poll"` before `--poll-mode` is passed.
+
+So the arm is reachable only by invoking the binary **by hand** with a bad
+`--poll-mode` — an operator/debug surface, not a configuration fail-open.
+Failing it closed would refuse a hand-run debug invocation for a typo while
+changing nothing a committed config can express.
+
+## What this pass is really about
+
+Both rows would have looked like clean one-line fixes. **Row 10's would have
+introduced a defect** — an internally inconsistent defaulted rule — to close a
+path nothing reaches. That is the shape the steer named: a fix that breaks a
+caller nobody enumerated.
+
+The reachability measurement is the deliverable, and it belongs at the sites so
+the next audit meets it where the question gets asked, rather than re-deriving
+it. Same reasoning as #7714's declined fence seam and #6873's two-surface
+comment.
+
+**File(s)**: `userspace-dp/src/prefix_set.rs`,
+`userspace-dp/src/server/state.rs`, `docs/log/7745.md`

--- a/userspace-dp/src/prefix_set.rs
+++ b/userspace-dp/src/prefix_set.rs
@@ -195,12 +195,40 @@ impl PrefixSetV6 {
     }
 }
 
+/// `MatchAny`, and that is FAIL-OPEN by construction — a defaulted prefix set
+/// matches every address (#7745, from the #6907 re-verification).
+///
+/// REACHABILITY, measured rather than assumed. No production path reaches
+/// `PrefixSetV4::default()`:
+///
+///   - the only production references are inside `impl Default for PolicyRule`
+///     (`policy.rs`), and the real rule constructor names EVERY field
+///     explicitly. `policy.rs:2127` records why: the `..PolicyRule::default()`
+///     tail was deliberately dropped so a future field addition is a compile
+///     error, "eliminating the silent-zero-default hazard" (#1632).
+///   - so `PolicyRule::default()` itself is never called on a packet path; the
+///     `impl` survives as a type-level convenience.
+///
+/// WHY IT IS NOT FLIPPED TO `MatchNone`. Inside that same `Default` impl the
+/// sibling fields are `source_v4_match_any: true`, `destination_v4_match_any:
+/// true`, and so on. A defaulted `PolicyRule` is deliberately a match-anything
+/// rule; making the prefix sets match NOTHING would leave it internally
+/// inconsistent — the booleans saying "any", the sets saying "none" — which is
+/// a worse hazard than the one being removed, and it would land on whichever
+/// caller relies on the current shape.
+///
+/// This is therefore a LATENT hazard recorded in place, not a defect to fix:
+/// the fail-open direction is real, and nothing can reach it today. If a
+/// `..Default::default()` tail is ever reintroduced to a rule constructor, this
+/// becomes live and the fix is at that call site, not here.
 impl Default for PrefixSetV4 {
     fn default() -> Self {
         Self::MatchAny
     }
 }
 
+/// See `impl Default for PrefixSetV4` for the reachability measurement and why
+/// this stays `MatchAny` (#7745).
 impl Default for PrefixSetV6 {
     fn default() -> Self {
         Self::MatchAny
@@ -319,4 +347,3 @@ impl PrefixTrieV6 {
 #[cfg(test)]
 #[path = "prefix_set_tests.rs"]
 mod tests;
-

--- a/userspace-dp/src/server/state.rs
+++ b/userspace-dp/src/server/state.rs
@@ -15,6 +15,31 @@ pub enum PollMode {
 }
 
 impl PollMode {
+    /// The `_` arm selects the SPINNING mode, which is the CPU-expensive
+    /// direction — so an unrecognised value burns a core rather than failing
+    /// visibly (#7745, from the #6907 re-verification).
+    ///
+    /// REACHABILITY, measured rather than assumed. From a committed config the
+    /// only strings that can arrive here are `"busy-poll"` and `"interrupt"`,
+    /// guarded three times before this point:
+    ///
+    ///   1. `pkg/config/schema_system.go` — `poll-mode` carries
+    ///      `ValidateEnum([]string{"busy-poll", "interrupt"})`, so a typo is
+    ///      rejected at COMMIT.
+    ///   2. `pkg/config/compiler_system.go` — the `poll-mode` case assigns only
+    ///      for those two literals; anything else leaves `cfg.PollMode` empty.
+    ///   3. `pkg/dataplane/userspace/process.go` — an empty `cfg.PollMode`
+    ///      becomes the explicit `"busy-poll"` before `--poll-mode` is passed.
+    ///
+    /// So the wildcard is reachable only by invoking this binary BY HAND with a
+    /// bad `--poll-mode`, which is an operator/debug surface rather than a
+    /// configuration fail-open.
+    ///
+    /// Left as a wildcard deliberately: making it fail closed would refuse a
+    /// hand-run debug invocation for a typo while changing nothing a committed
+    /// config can express, and the arm's real hazard is documented above where
+    /// a reader meets it. If the three guards upstream are ever relaxed, this
+    /// becomes live.
     pub(crate) fn from_str(s: &str) -> Self {
         match s {
             "interrupt" => PollMode::Interrupt,


### PR DESCRIPTION
The two fail-open defaults I flagged from the #6907 re-verification as *"the two
I would file first"*. Both are fail-open **shaped**. **Neither is reachable** —
and measuring that before touching either is what kept a clean-looking one-line
fix from introducing a defect.

Closes #7745

**No behaviour change.** Comments only.

## Row 10 — `PrefixSet::default() → MatchAny`

**Latent.**

- The only production references are inside `impl Default for PolicyRule`
  (`policy.rs:470-473`).
- **`PolicyRule::default()` is never called on a production path.** Both of its
  production mentions are *comments* — and `policy.rs:2127` records why: the
  real rule constructor deliberately dropped its `..PolicyRule::default()` tail
  so a future field addition is a compile error, *"eliminating the
  silent-zero-default hazard"* (#1632).
- **`MatchAny` is load-bearing.** The same `Default` impl sets
  `source_v4_match_any: true`, `destination_v4_match_any: true` and siblings — a
  defaulted `PolicyRule` is deliberately a match-anything rule. Flipping the sets
  to `MatchNone` would leave it **self-contradictory**: booleans saying *any*,
  sets saying *none*. That is a worse hazard than the one removed, and it lands
  on whichever caller relies on the current shape.

## Row 16 — the wildcard arm of `PollMode::from_str`

**Latent.**

The arm does select the CPU-expensive direction. But from a committed config
only `"busy-poll"` and `"interrupt"` can reach it, guarded **three** times:

1. `pkg/config/schema_system.go:365` — `ValidateEnum(["busy-poll",
   "interrupt"])`, so a typo is rejected **at commit**.
2. `pkg/config/compiler_system.go:922` — assigns only for those two literals;
   anything else leaves `cfg.PollMode` empty.
3. `pkg/dataplane/userspace/process.go:161` — an empty `cfg.PollMode` becomes
   the explicit `"busy-poll"` before `--poll-mode` is passed.

Reachable only by invoking the binary **by hand** with a bad `--poll-mode` — an
operator/debug surface, not a configuration fail-open. Failing it closed would
refuse a hand-run debug invocation for a typo while changing nothing a committed
config can express.

## Why this is comments and not fixes

Both rows would have looked like clean one-line changes. **Row 10's would have
introduced a defect** — an internally inconsistent defaulted rule — to close a
path nothing reaches.

The measurement is the deliverable, and it is recorded **at the sites**, each
with the condition that would make it live: a `..Default::default()` tail
reintroduced to a rule constructor, or the three poll-mode guards relaxed. Same
reasoning as #7714's declined fence seam and #6873's two-surface comment — the
next audit meets the answer where it asks the question, instead of re-deriving
it and re-filing.

## Gates

Gated head **`5ef262026fc4bf44c34dbf010a2cdb81071dbcee`**.

- `cargo test -- --test-threads=1` — **rc 0**, 4810 passed, 0 failed.
- `rustfmt --check` clean on both files; `cargo build` clean.
- `git merge-base --is-ancestor 44cfdb2be 5ef262026` succeeds.

No Go gate: the diff is two Rust files and a log.
