### PR TITLE
nat+docs: surface a swallowed DNAT prefix, restate a retired shim claim

### DIFF
--- a/docs/afxdp-packet-processing.md
+++ b/docs/afxdp-packet-processing.md
@@ -107,8 +107,28 @@ The shim checks several conditions before redirecting a packet to userspace:
    for local/control-plane delivery; the shim no longer tail-calls through
    `userspace_fallback_progs`.
 6. Local-destination traffic (matching `userspace_local_v4`/`userspace_local_v6`) passes to kernel.
-7. Non-SYN TCP without a live entry in `userspace_sessions` BPF map is dropped
-   (not fallen back -- legacy BPF would generate RSTs that kill the real connection).
+7. A session MISS is **not** decided by the shim. It redirects the packet to the
+   userspace dataplane, which evaluates policy and either creates a session or
+   drops (`lib.rs`: *"Let all session misses through to the userspace dataplane"*).
+   This item previously said non-SYN TCP without a live `userspace_sessions`
+   entry is **dropped by the shim**; that described the retired eBPF pipeline
+   (#6899 / C180-021) and would lead an operator to expect a drop where the
+   packet is in fact delivered.
+
+   The session-miss guard now lives in the userspace dataplane, and **the action
+   differs by disposition** — which is the part the old wording lost:
+   - **Transit** dispositions DROP a bare RST/FIN first packet (#4400), and a
+     single `has_syn` gate additionally declines the pure-PSH / null / URG
+     residual (#4539, subsuming #2151 and #4487).
+   - **Host-inbound `LocalDelivery` does NOT drop.** The same gate declines to
+     *cache* a session off a non-SYN first packet, but the packet still reaches
+     the local stack through the LocalDelivery reinject chokepoint — deliberately,
+     so a peer RST/FIN tearing down a firewall-ORIGINATED flow (BGP-active,
+     syslog-TCP/TLS, feed/RPM fetches, DNS-over-TCP), or a connection-refused RST
+     for the firewall's own outbound SYN, is not lost. Declining to cache never
+     skips policy: a later real SYN to a firewall IP is re-evaluated by the
+     `to-zone junos-host` mandatory-teardown gate that runs on every
+     LocalDelivery session hit.
 8. When helper/XSK state is degraded (`ctrl.enabled=0`, missing/not-ready
    binding, stale heartbeat, redirect failure), only the local/control cases
    above may reach the kernel. Transit drops and increments

--- a/docs/log/6899.md
+++ b/docs/log/6899.md
@@ -42,3 +42,28 @@
   - **File(s)**: docs/afxdp-packet-processing.md,
     userspace-dp/src/nat/destination.rs, userspace-dp/src/nat/tests_destination.rs,
     pkg/refactoraudit/afxdp_doc_shim_drop_6899_test.go
+
+- **Timestamp**: 2026-08-27 (validation)
+  - **The matrix caught my own cell passing for the wrong reason.** U3 turned
+    the #4718 both-unparseable `continue` into a fall-through and
+    `dnat_6899_both_unparseable_still_drops` stayed GREEN. The assertion was
+    `lookup(...).is_none()`, and a dropped rule and a rule installed under a
+    DIFFERENT key both answer None for whatever address the cell probes —
+    measured: the mutation installs keyed on 127.0.0.1 and a probe for
+    203.0.113.10 misses. Replaced with `installed_entry_count() == 0`, which is
+    mutation-independent: the cell no longer has to guess which key a broken
+    implementation would pick. Third instance of this class today (zero-value
+    fixture #6884, mirror cell #6892), and the first where I asked "which
+    mutation makes this red?" only AFTER writing the assertion.
+  - **Matrix** (Go + cargo in one cell, `--no-fail-fast`, 10/10 binaries
+    throughout, control 0/0): U1b removes the new `record_parse_error` → the
+    surfacing cell reds; U2 records unconditionally → the paired control reds
+    plus a pre-existing #6823 cell; U3b fall-through → the re-armed drop cell
+    reds; U4 reinstates the retired doc sentence → the doc guard reds; U5
+    DELETES the item instead of correcting it → the doc guard reds on its
+    second half.
+  - **Gate**: `go test ./... -count=1 -p 4` rc 0 / 68 packages / 0 failures;
+    `cargo test --no-fail-fast -- --test-threads=1` rc 0 / **4816 passed** /
+    10 binaries / 0 FAILED. **No smoke owed** — a doc restatement and one
+    diagnostic-only Rust arm on a path a normal commit cannot reach; no
+    forwarding, cluster or session-sync behaviour change.

--- a/docs/log/6899.md
+++ b/docs/log/6899.md
@@ -1,0 +1,44 @@
+# #6899 — two codex-180 survivors
+
+- **Timestamp**: 2026-08-27
+  - **Cohort triage first, as scoped.** Both items re-measured against master
+    before building either; **both survive**, and they are genuinely INDEPENDENT
+    (one doc claim about the shim, one Rust DNAT parse path). Neither is a dead
+    half, so both are fixed here.
+  - **Item 1 (C180-021) — cite had rotted, claim had not.** The issue cites
+    `docs/afxdp-packet-processing.md:48-49`; the claim now lives at **line 110**
+    (lines 48-49 are about #6784 restart adoption). The claim itself is real and
+    FALSE. Verified the true behaviour from source rather than from the issue:
+    `userspace-xdp/src/lib.rs` says *"Let all session misses through to the
+    userspace dataplane. The userspace DP will evaluate policy and either create
+    a session (new flow) or drop"* — the shim does not decide. The dataplane's
+    action then **differs by disposition**: transit drops a bare RST/FIN
+    (#4400/#4539), host-inbound LocalDelivery declines only to CACHE and still
+    delivers via the reinject chokepoint, so a peer teardown for a
+    firewall-originated flow is not lost.
+  - **The rewritten text is anchored to TESTED behaviour**, not to my reading:
+    `bare_rst_fin_session_miss_does_not_cache_local_delivery` and
+    `non_handshake_tcp_session_miss_does_not_cache_local_delivery` already cover
+    both halves, and the former's own comment states the packet "is still
+    DELIVERED to the host". A new guard asserts the retired sentence has not
+    come back (wrap-insensitive) AND that the corrected distinction is present —
+    the second half stops the guard being satisfied by deleting the item.
+  - **Item 2 (C180-023) — confirmed by constructing the input, not by grepping
+    the symbol**, exactly as the issue warns. A non-empty unparseable
+    `destination_prefix` with a VALID base address reaches
+    `Ok(ip) => DnatDest::Host(ip)` with nothing recorded; the
+    `record_parse_error` three lines below is the #4718 BOTH-unparseable drop and
+    never fires here.
+  - **The fallback is KEPT, only its silence is fixed.** The #4718 comment shows
+    the fallback is deliberate ("fall back to the host `destination_address` if
+    it parses") and that #4718 chose to surface the DROP, not to remove the
+    fallback. Dropping a rule that is currently forwarding would be a larger
+    behaviour change than the defect.
+  - **Reachability stated honestly**: the Go snapshot builder already SKIPS a
+    token that parses as neither IP nor CIDR (`nat_destination.go`), so a normal
+    commit cannot reach this arm. It is the last-line path for config drift
+    across a mixed-version pair or a direct control-socket write — the same
+    class #4718's own arms exist for. Not a live commit-reachable hazard.
+  - **File(s)**: docs/afxdp-packet-processing.md,
+    userspace-dp/src/nat/destination.rs, userspace-dp/src/nat/tests_destination.rs,
+    pkg/refactoraudit/afxdp_doc_shim_drop_6899_test.go

--- a/pkg/refactoraudit/afxdp_doc_shim_drop_6899_test.go
+++ b/pkg/refactoraudit/afxdp_doc_shim_drop_6899_test.go
@@ -1,0 +1,64 @@
+package refactoraudit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #6899 (C180-021): docs/afxdp-packet-processing.md asserted that the SHIM drops
+// non-SYN TCP without a live `userspace_sessions` entry. That described the
+// RETIRED eBPF pipeline. The shim redirects every session miss to the userspace
+// dataplane ("Let all session misses through to the userspace dataplane" —
+// userspace-xdp/src/lib.rs) and the guard now lives there, where the action
+// differs BY DISPOSITION: transit drops a bare RST/FIN (#4400/#4539), while
+// host-inbound LocalDelivery declines only to CACHE and still delivers the
+// packet to the local stack.
+//
+// An operator reading the old text would expect a drop where the packet is
+// delivered — a wrong answer, not a missing one.
+//
+// WHAT THIS GUARD CAN AND CANNOT DO, stated so nobody over-reads it. It catches
+// a LITERAL reintroduction of the retired sentence, which is what a revert or a
+// copy-paste from git history produces. It is defeated by a paraphrase, and no
+// string check can do better. The behavioural claims the rewritten text makes
+// are not guarded here at all — they are covered by their own cells in
+// userspace-dp (`bare_rst_fin_session_miss_does_not_cache_local_delivery`,
+// `non_handshake_tcp_session_miss_does_not_cache_local_delivery`), which is the
+// right place for them and the reason this file asserts only the negation.
+func TestAfxdpDocDoesNotClaimShimDropsNonSYN6899(t *testing.T) {
+	root := repoRoot(t)
+	path := filepath.Join(root, "docs", "afxdp-packet-processing.md")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	// Normalise whitespace so the check is WRAP-insensitive: the retired claim
+	// spanned two lines, and a `strings.Contains` against the raw bytes would
+	// miss it the moment someone re-flowed the paragraph.
+	flat := strings.Join(strings.Fields(string(raw)), " ")
+
+	const retired = "Non-SYN TCP without a live entry in `userspace_sessions` BPF map is dropped"
+	if strings.Contains(flat, retired) {
+		t.Fatalf("docs/afxdp-packet-processing.md has reacquired the retired #6899 claim "+
+			"%q. The shim does not decide a session miss — it redirects to the userspace "+
+			"dataplane, and host-inbound LocalDelivery DELIVERS the packet while declining "+
+			"to cache it. The old wording tells an operator to expect a drop that does not "+
+			"happen.", retired)
+	}
+
+	// And the replacement must actually carry the distinction the old text
+	// lost. Without this the guard is satisfied by DELETING the item entirely,
+	// which would remove a wrong answer by removing the answer.
+	for _, want := range []string{
+		"Let all session misses through to the userspace dataplane",
+		"differs by disposition",
+		"does NOT drop",
+	} {
+		if !strings.Contains(flat, want) {
+			t.Fatalf("the rewritten session-miss item is missing %q — the retired claim was "+
+				"removed without the corrected behaviour replacing it", want)
+		}
+	}
+}

--- a/userspace-dp/src/nat/destination.rs
+++ b/userspace-dp/src/nat/destination.rs
@@ -321,7 +321,40 @@ impl DnatTable {
                     // (fail-closed, like an unparseable host destination).
                     // #4718: surface the drop loudly instead of a silent skip.
                     Err(_) => match snap.destination_address.parse::<IpAddr>() {
-                        Ok(ip) => DnatDest::Host(ip),
+                        Ok(ip) => {
+                            // #6899 (C180-023): the FALLBACK was silent. #4718
+                            // surfaced the both-unparseable DROP three lines
+                            // below, and that neighbouring `record_parse_error`
+                            // is a decoy: it fires only when the prefix AND the
+                            // address both fail. With a VALID base address the
+                            // rule installed against it and the malformed prefix
+                            // vanished — DNAT quietly targeting one host where
+                            // the operator wrote a block, with nothing in the
+                            // counters to look at.
+                            //
+                            // The fallback itself is DELIBERATE and is kept: the
+                            // comment above states it, and #4718 chose to
+                            // surface the drop, not to remove the fallback. The
+                            // defect is the silence, so this records and
+                            // continues rather than dropping a rule that is
+                            // currently forwarding.
+                            //
+                            // Reachability, stated honestly: the Go snapshot
+                            // builder already SKIPS a token that parses as
+                            // neither IP nor CIDR (nat_destination.go), so a
+                            // normal commit cannot get here. This is the
+                            // last-line arm for config drift across a
+                            // mixed-version pair or a direct control-socket
+                            // write — the same class of caller #4718's own arms
+                            // exist for.
+                            nat_counters.record_parse_error(&format!(
+                                "DNAT rule {:?}: unparseable destination prefix {:?}; \
+                                 falling back to the host destination address {:?} — \
+                                 the configured block is NOT being translated",
+                                snap.name, snap.destination_prefix, snap.destination_address
+                            ));
+                            DnatDest::Host(ip)
+                        }
                         Err(_) => {
                             nat_counters.record_parse_error(&format!(
                                 "DNAT rule {:?}: unparseable destination prefix {:?} and address {:?}",

--- a/userspace-dp/src/nat/destination.rs
+++ b/userspace-dp/src/nat/destination.rs
@@ -282,6 +282,22 @@ enum DnatDest {
 }
 
 impl DnatTable {
+    /// #6899 test-only: total installed entries across BOTH the exact-host map
+    /// and the prefix map.
+    ///
+    /// It exists because "the rule was dropped" is NOT observable through
+    /// `lookup`: a dropped rule and a rule installed under a DIFFERENT key both
+    /// answer `None` for any address the test happens to probe. A cell asserting
+    /// the #4718 both-unparseable DROP therefore passes for the wrong reason
+    /// unless it can see that nothing was installed AT ALL — which is what this
+    /// reports, without the cell needing to guess which key a broken
+    /// implementation would have chosen.
+    #[cfg(test)]
+    pub(crate) fn installed_entry_count(&self) -> usize {
+        self.entries.values().map(|v| v.len()).sum::<usize>()
+            + self.prefix_entries.values().map(|v| v.len()).sum::<usize>()
+    }
+
     pub(crate) fn from_snapshots(
         snaps: &[DestinationNATRuleSnapshot],
         nat_counters: &NatCounterStore,

--- a/userspace-dp/src/nat/tests_destination.rs
+++ b/userspace-dp/src/nat/tests_destination.rs
@@ -2359,3 +2359,129 @@ fn actionless_dnat_entry_falls_through_6823() {
          pool address: {details:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #6899 (C180-023): the single-unparseable-prefix FALLBACK must be surfaced.
+// ---------------------------------------------------------------------------
+
+// FAIL-ON-REVERT: remove the #6899 `record_parse_error` from the
+// `Ok(ip) => DnatDest::Host(ip)` arm and `parse_errors()` stays 0 while the
+// rule still installs — the exact silence this item names.
+//
+// THE DECOY THIS CELL EXISTS TO DEFEAT: a `record_parse_error` already sits
+// three lines below, so grepping the symbol in this file returns a hit that
+// looks like the fix. It is the #4718 BOTH-unparseable drop and never fires
+// here. The fixture therefore uses a VALID base address, which is the only
+// input that separates the two arms — with an invalid one, the pre-existing
+// call fires and the cell would pass against unfixed code.
+#[test]
+fn dnat_6899_unparseable_prefix_with_valid_address_is_surfaced() {
+    let counters = crate::nat::NatCounterStore::default();
+    let table = DnatTable::from_snapshots(
+        &[DestinationNATRuleSnapshot {
+            name: "garbage-prefix".to_string(),
+            // Non-empty and unparseable...
+            destination_prefix: "not-a-cidr".to_string(),
+            // ...but the base address is VALID, so the both-unparseable
+            // #4718 arm below is NOT reached.
+            destination_address: "203.0.113.10".to_string(),
+            destination_port: 80,
+            protocol: "tcp".to_string(),
+            pool_address: "192.168.1.10".to_string(),
+            pool_port: 8080,
+            ..DestinationNATRuleSnapshot::default()
+        }],
+        &counters,
+    );
+
+    // The documented fallback is PRESERVED: the rule still translates the base
+    // address. This is not a fail-closed change; the defect was the silence.
+    assert!(
+        table
+            .lookup(
+                PROTO_TCP,
+                "198.51.100.1".parse().unwrap(),
+                "203.0.113.10".parse().unwrap(),
+                80,
+                "",
+            )
+            .is_some(),
+        "the deliberate fallback to the host destination address was dropped — \
+         #6899 surfaces the silence, it does not remove the fallback"
+    );
+
+    // ...and it is no longer SILENT.
+    assert!(
+        counters.parse_errors() > 0,
+        "an unparseable destination_prefix with a VALID base address installed \
+         with NO parse error recorded — DNAT quietly targets one host where the \
+         operator configured a block, and nothing in the counters says so (#6899)"
+    );
+}
+
+// PAIRED CONTROL. Without it, "record a parse error" is satisfied by recording
+// unconditionally, which would fire on every well-formed prefix rule and bury
+// the real ones.
+#[test]
+fn dnat_6899_valid_prefix_records_nothing() {
+    let counters = crate::nat::NatCounterStore::default();
+    let table = DnatTable::from_snapshots(
+        &[DestinationNATRuleSnapshot {
+            name: "good-prefix".to_string(),
+            destination_prefix: "203.0.113.0/24".to_string(),
+            destination_address: "203.0.113.0".to_string(),
+            destination_port: 80,
+            protocol: "tcp".to_string(),
+            pool_address: "192.168.1.10".to_string(),
+            pool_port: 8080,
+            ..DestinationNATRuleSnapshot::default()
+        }],
+        &counters,
+    );
+    assert!(
+        table
+            .lookup(
+                PROTO_TCP,
+                "198.51.100.1".parse().unwrap(),
+                "203.0.113.77".parse().unwrap(),
+                80,
+                "",
+            )
+            .is_some(),
+        "a well-formed prefix rule must still install and match inside the block"
+    );
+    assert_eq!(
+        counters.parse_errors(),
+        0,
+        "a well-formed prefix rule recorded a parse error — the #6899 surfacing \
+         fires unconditionally and would bury the genuine ones"
+    );
+}
+
+// The #4718 BOTH-unparseable arm must still DROP, not fall through. This is the
+// behaviour the decoy owns, pinned so the #6899 change cannot be mistaken for a
+// licence to install on any garbage.
+#[test]
+fn dnat_6899_both_unparseable_still_drops() {
+    let counters = crate::nat::NatCounterStore::default();
+    let table = DnatTable::from_snapshots(
+        &[DestinationNATRuleSnapshot {
+            name: "all-garbage".to_string(),
+            destination_prefix: "not-a-cidr".to_string(),
+            destination_address: "also-not-an-ip".to_string(),
+            destination_port: 80,
+            protocol: "tcp".to_string(),
+            pool_address: "192.168.1.10".to_string(),
+            pool_port: 8080,
+            ..DestinationNATRuleSnapshot::default()
+        }],
+        &counters,
+    );
+    assert!(
+        table
+            .lookup(PROTO_TCP, "198.51.100.1".parse().unwrap(), "203.0.113.10".parse().unwrap(), 80, "")
+            .is_none(),
+        "a rule with BOTH fields unparseable installed something (#4718 drop lost)"
+    );
+    assert!(counters.parse_errors() > 0, "#4718 drop stopped being surfaced");
+}

--- a/userspace-dp/src/nat/tests_destination.rs
+++ b/userspace-dp/src/nat/tests_destination.rs
@@ -2477,11 +2477,18 @@ fn dnat_6899_both_unparseable_still_drops() {
         }],
         &counters,
     );
-    assert!(
-        table
-            .lookup(PROTO_TCP, "198.51.100.1".parse().unwrap(), "203.0.113.10".parse().unwrap(), 80, "")
-            .is_none(),
-        "a rule with BOTH fields unparseable installed something (#4718 drop lost)"
+    // NOT a `lookup(...).is_none()` assertion. A dropped rule and a rule
+    // installed under a DIFFERENT key both answer None for whatever address the
+    // cell probes — measured: mutating the #4718 `continue` into a fall-through
+    // installs under 127.0.0.1 and a probe for 203.0.113.10 still returns None,
+    // so the cell passed against the mutation. Count what was installed instead;
+    // that cannot be satisfied by a wrong key.
+    assert_eq!(
+        table.installed_entry_count(),
+        0,
+        "a rule with BOTH destination fields unparseable installed an entry — the \
+         #4718 fail-closed drop is gone, and the entry is keyed on whatever the \
+         broken path chose (#6899)"
     );
     assert!(counters.parse_errors() > 0, "#4718 drop stopped being surfaced");
 }


### PR DESCRIPTION
Closes #6899

## Cohort triage first: both items survive, and they are independent

Per the #6898 lesson that a cohort's items can have independently rotted premises, both were re-measured against master before either was built. **Both are live**, and they are unrelated defects (one doc claim about the shim, one Rust DNAT parse arm) — so neither half is dead weight.

## Item 1 — C180-021: the cite rotted, the claim did not

The issue cites `docs/afxdp-packet-processing.md:48-49`; the claim is now at **line 110** (48-49 is #6784 restart adoption). The claim itself is real and **false**.

Verified the true behaviour from source, not from the issue. `userspace-xdp/src/lib.rs`:

> *"Let all session misses through to the userspace dataplane. The userspace DP will evaluate policy and either create a session (new flow) or drop (stale non-SYN TCP / policy deny)."*

**The shim does not decide a session miss.** The guard lives in the dataplane, and the action **differs by disposition** — which is exactly what the old wording lost:

- **Transit** drops a bare RST/FIN (#4400), with #4539's single `has_syn` gate additionally closing the pure-PSH / null / URG residual.
- **Host-inbound `LocalDelivery` does NOT drop.** It declines only to *cache*; the packet still reaches the local stack through the reinject chokepoint, so a peer RST/FIN tearing down a firewall-**originated** flow (BGP-active, syslog-TCP/TLS, feed/RPM, DNS-over-TCP) is not lost.

An operator reading the old text would expect a drop where the packet is delivered — a wrong answer, not a missing one.

**The rewrite is anchored to behaviour that is already tested**, not to my reading: `bare_rst_fin_session_miss_does_not_cache_local_delivery` and `non_handshake_tcp_session_miss_does_not_cache_local_delivery` cover both halves, and the former's own comment states the packet *"is still DELIVERED to the host"*. So the new guard asserts only the **negation** — that the retired sentence has not returned — plus that the corrected distinction is present, so it cannot be satisfied by deleting the item (cell U5).

The guard is wrap-insensitive (the retired claim spanned two lines; a raw `Contains` would miss a re-flow). It is defeated by a paraphrase, and the PR says so rather than implying a string check can do better.

## Item 2 — C180-023: confirmed by constructing the input, not by grepping the symbol

Exactly as the issue warns. A non-empty unparseable `destination_prefix` with a **valid** base address reaches `Ok(ip) => DnatDest::Host(ip)` with nothing recorded. The `record_parse_error` three lines below is the #4718 **both**-unparseable drop and never fires here — which is why the fixture uses a **valid** base address. With an invalid one the pre-existing call fires and the cell would pass against unfixed code.

**The fallback is kept; only its silence is fixed.** The #4718 comment shows the fallback is deliberate, and that #4718 chose to surface the *drop* rather than remove it. Dropping a rule that is currently forwarding would be a larger behaviour change than the defect.

**Reachability, stated honestly:** the Go snapshot builder already **skips** a token that parses as neither IP nor CIDR (`nat_destination.go`), so a normal commit cannot reach this arm. It is the last-line path for config drift across a mixed-version pair or a direct control-socket write — the same class #4718's own arms exist for. Not a live commit-reachable hazard.

## The matrix caught my own cell passing for the wrong reason

**U3 turned the #4718 `continue` into a fall-through and `dnat_6899_both_unparseable_still_drops` stayed GREEN.**

The assertion was `lookup(...).is_none()` — and a dropped rule and a rule installed under a **different key** both answer `None` for whatever address the cell probes. Measured: the mutation installs keyed on `127.0.0.1`, so a probe for `203.0.113.10` misses and the cell reports success.

Replaced with `installed_entry_count() == 0`, which is mutation-independent: the cell no longer has to guess which key a broken implementation would pick. **Third instance of this class today** (the zero-value fixture in #6884, the mirror cell in #6892) — and the first where I asked *"which mutation makes this red?"* only **after** writing the assertion rather than before.

## Mutation matrix

Go and cargo in one cell. `--no-fail-fast` with **10/10 binaries reporting** throughout — without it a red truncates later binaries and every count becomes a floor. Control **0 Go fails / 0 Rust fails**.

| cell | mutation | reds |
|---|---|---|
| control | — | **0** |
| U1b | remove the new `record_parse_error` (the shipped silence) | `unparseable_prefix_with_valid_address_is_surfaced` |
| U2 | record **unconditionally** | `valid_prefix_records_nothing` + pre-existing `actionless_dnat_entry_falls_through_6823` |
| U3 | #4718 drop → fall-through | **ESCAPED** — cell blind to the installed key |
| U3b | same, against the re-armed cell | `both_unparseable_still_drops` |
| U4 | reinstate the retired doc sentence | `AfxdpDocDoesNotClaimShimDropsNonSYN6899` |
| U5 | **delete** the item instead of correcting it | same guard, second half |

U5 is the row that keeps the doc guard from being satisfied by removing the answer along with the wrong answer.

## Gate

- `go build ./...` rc 0; `go test ./... -count=1 -p 4` → **rc 0, 68 packages, 0 failures**
- `cargo test --no-fail-fast -- --test-threads=1` → **rc 0, 4816 passed, 10/10 binaries, 0 FAILED**
- `merge-base --is-ancestor origin/master HEAD` verified; folded with `git merge`
- **No smoke owed** — a doc restatement plus one diagnostic-only Rust arm on a path a normal commit cannot reach. No forwarding, cluster, VRRP or session-sync behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ez9XCjM9mPjtocRjkousdB
