### PR TITLE
xsk-repro: count only our own probes, not all queue traffic

### DIFF
--- a/docs/log/6898.md
+++ b/docs/log/6898.md
@@ -1,17 +1,46 @@
-# #6898 item A1-b5-F1 — torn bind_mode pair in the binding snapshot
+# #6898 — audit cohort survivors (item A10-b5-F1)
 
 - **Timestamp**: 2026-08-27
-  - **Action**: `BindingLiveSnapshot` read `self.bind_mode` TWICE — once for
-    `xsk_bind_mode` and once for `zero_copy` — so a concurrent rebind between
-    the two loads publishes a snapshot whose fields describe different modes.
-    Single load into a local, both fields derived from it.
-  - **Path had MOVED**, as the issue documents: filed as `umem/snapshot.rs`,
-    now `binding_state/snapshot.rs`.
-  - **Guards**: a comment-stripped source scan (exactly one `bind_mode.load(`
-    in code) plus an agreement test over every mode, because a torn read is a
-    race that no behavioural test can reliably observe.
-  - **Scope**: this is ONE of the five cohort items in #6898. The other four are
-    untouched and the issue stays open.
-  - **File(s)**: userspace-dp/src/afxdp/binding_state/snapshot.rs,
-    userspace-dp/src/afxdp/binding_state/torn_bindmode_6898_tests.rs (new),
-    userspace-dp/src/afxdp/binding_state/mod.rs
+  - **Item 5, `A10-b5-F1`** — the xsk reproducer's PASS criterion could not
+    detect the bug it exists to detect.
+  - **Shape, confirmed at master `02ca90f01`**: `main.rs` PASS is
+    `rx1 > 0 && rx2 > 0`, and the receive loop counted **every** descriptor.
+  - **The issue's stated mechanism is imprecise, and correcting it mattered.**
+    It says "`nonce` returns zero hits in the file, so the two receivers are not
+    distinguished". Two corrections:
+    1. The phases ARE distinguished from each other — `run_xsk_phase` does a
+       fresh `mmap` and a fresh `Umem` per call, so no phase-1 frame can be
+       counted in phase 2. The "stale descriptor" reading does not hold.
+    2. There IS a marker (`b"xsk-test-probe"`), it was simply never checked on
+       receive. So the item named the right property via the wrong token.
+  - **The real defect**: `xdp_pass_redirect.c` redirects EVERY packet on the
+    queue — it looks the queue up in the xskmap and redirects unconditionally,
+    with no filter. So the counters counted all interface traffic. `rx2 > 0` was
+    satisfiable by an ARP, an IPv6 RA or MLD report, or any stray broadcast,
+    while the tool's own probes never arrived — a completely broken rebind
+    reported as PASS.
+  - **Reachability: HIGH**, and measured rather than assumed. The redirect is
+    unconditional (verified in the `.c`), so any traffic on the queue counts. On
+    a live link IPv6 multicast alone is usually enough; the tool is documented
+    to run as root on a real interface.
+  - **Cost: none that matters.** A substring scan per received frame, in a
+    standalone repro tool with no dataplane role.
+  - **Why a substring scan and not a fixed offset**: the frame is
+    Ethernet + IP + UDP + payload and header sizes vary (VLAN tag, IPv4 options,
+    v4 vs v6). A fixed offset would silently stop matching on a tagged link and
+    reintroduce the same false verdict in the opposite direction — FAIL on a
+    healthy rebind.
+  - **Foreign frames are counted and reported separately**: "rx=0 but 5000
+    foreign frames seen" and "rx=0 and the link is silent" are different
+    diagnoses and the operator has to tell them apart.
+  - **Testability, which was not free.** `test/xsk-repro` is a standalone crate:
+    not a workspace member, not in the root Makefile, so `make test` never
+    builds it and a unit test alone would not run in any gate. Its three
+    existing selftests ARE wired into `scripts/run-selftests.sh`, so a fourth
+    was added there — a BEHAVIOURAL gate, unlike its siblings which are
+    strict-warning compiles, because the defect it guards compiles perfectly.
+    The script also refuses a vacuous pass: `cargo test` reports ok for zero
+    tests just as happily, so it requires `[1-9]+ passed`.
+  - **File(s)**: test/xsk-repro/main.rs,
+    test/xsk-repro/selftest-probe-filter_6898.sh,
+    scripts/run-selftests.sh, docs/log/6898.md

--- a/scripts/run-selftests.sh
+++ b/scripts/run-selftests.sh
@@ -158,6 +158,13 @@ run_shell test/xsk-repro/selftest-skipgate_6289.sh
 # through instead of false-SKIPping. Hermetic (fake cc via `env`); SKIPs without
 # make/xxd/env.
 run_shell test/xsk-repro/selftest-multitoken-cc_6355.sh
+# #6898 A10-b5-F1: BEHAVIOURAL gate (not a strict-warning compile) for the
+# reproducer's probe filter. The XDP program redirects every packet on the queue,
+# so the receive counters used to count all interface traffic and `rx > 0` was
+# satisfiable by an ARP or an IPv6 RA while the tool's own probes never arrived —
+# the exact failure the reproducer exists to detect, reported as PASS. SKIPs
+# without cargo or offline-buildable deps.
+run_shell test/xsk-repro/selftest-probe-filter_6898.sh
 
 # ── summary ──
 printf '\n\033[1m== selftest summary ==\033[0m\n'

--- a/test/xsk-repro/main.rs
+++ b/test/xsk-repro/main.rs
@@ -23,6 +23,38 @@ const FRAME_COUNT: u32 = 4096;
 const HEADROOM: u32 = 256;
 const XDP_OBJ: &[u8] = include_bytes!("xdp_pass_redirect.o");
 
+/// #6898 A10-b5-F1: the marker that identifies a frame as OUR generated probe.
+///
+/// ONE definition, used by both the generator and the receive filter. Two
+/// copies of a literal is how the two sides drift, and a drifted marker fails
+/// in the direction that matters here — every frame reads as foreign, rx goes
+/// to zero, and the tool reports FAIL on a healthy rebind.
+const PROBE_MARKER: &[u8] = b"xsk-test-probe";
+
+/// Does this received frame carry our probe marker?
+///
+/// WHY THIS EXISTS. The XDP program redirects EVERY packet on the queue to the
+/// XSK — `xdp_pass_redirect.c` looks the queue up in the xskmap and redirects
+/// unconditionally, with no filter. So the receive counters counted ALL traffic
+/// on the interface, not the traffic this tool generated.
+///
+/// That made the PASS criterion unable to detect the bug the tool exists to
+/// detect. `rx2 > 0` was satisfied by any background frame — an ARP, an IPv6
+/// RA or MLD report, a stray broadcast — so a rebind that was completely broken
+/// still reported PASS as long as the link carried any chatter at all. On a
+/// live interface IPv6 multicast alone is usually enough.
+///
+/// A substring scan rather than a parse at fixed offsets: the frame is
+/// Ethernet + IP + UDP + payload and the header sizes vary (VLAN tags, IPv4
+/// options, v4 vs v6), so a fixed offset would silently stop matching on a
+/// tagged or optioned link and reintroduce the false FAIL. Cost is irrelevant
+/// — this is a repro tool, not a dataplane.
+fn is_probe_frame(frame: &[u8]) -> bool {
+    frame
+        .windows(PROBE_MARKER.len())
+        .any(|w| w == PROBE_MARKER)
+}
+
 // UAPI XDP attach flags (linux/if_link.h).
 const XDP_FLAGS_UPDATE_IF_NOEXIST: u32 = 1 << 0;
 const XDP_FLAGS_REPLACE: u32 = 1 << 4;
@@ -286,6 +318,7 @@ fn run_xsk_phase(iface: &str, queue: u32, xsk_map_fd: i32, use_copy: bool, durat
         // Receive loop
         let start = Instant::now();
         let mut total_rx = 0u64;
+        let mut foreign_rx = 0u64;
         let mut poll_count = 0u64;
         while start.elapsed() < duration {
             let available = rx.available();
@@ -303,7 +336,30 @@ fn run_xsk_phase(iface: &str, queue: u32, xsk_map_fd: i32, use_copy: bool, durat
                 let mut recv = rx.receive(available);
                 let mut recycle: Vec<u64> = Vec::with_capacity(recv.capacity() as usize);
                 while let Some(desc) = recv.read() {
-                    total_rx += 1;
+                    // #6898 A10-b5-F1: count only OUR probes. Counting every
+                    // redirected frame made PASS satisfiable by unrelated
+                    // interface traffic, so the tool could not see the failure
+                    // it exists to find. Foreign frames are still counted, and
+                    // reported, because "rx=0 but 5000 foreign frames seen" and
+                    // "rx=0 and the link is silent" are different diagnoses and
+                    // the operator needs to tell them apart.
+                    let end = (desc.addr as usize).saturating_add(desc.len as usize);
+                    let is_ours = if end <= area_size {
+                        let bytes = unsafe {
+                            std::slice::from_raw_parts(
+                                area_ptr.cast::<u8>().add(desc.addr as usize),
+                                desc.len as usize,
+                            )
+                        };
+                        is_probe_frame(bytes)
+                    } else {
+                        false
+                    };
+                    if is_ours {
+                        total_rx += 1;
+                    } else {
+                        foreign_rx += 1;
+                    }
                     recycle.push(desc.addr & !((FRAME_SIZE as u64) - 1));
                 }
                 recv.release();
@@ -320,7 +376,10 @@ fn run_xsk_phase(iface: &str, queue: u32, xsk_map_fd: i32, use_copy: bool, durat
                 unsafe { libc::poll(&mut pfd, 1, 10) };
             }
         }
-        eprintln!("  rx={} empty_polls={}", total_rx, poll_count);
+        eprintln!(
+            "  rx={} (probe frames)  foreign_rx={} (other traffic on this queue)  empty_polls={}",
+            total_rx, foreign_rx, poll_count
+        );
 
         // Deregister before the sockets/umem drop at the end of this block.
         xskmap_delete(xsk_map_fd, queue);
@@ -346,7 +405,7 @@ fn generate_traffic(iface: &str, stop: std::sync::Arc<std::sync::atomic::AtomicB
     sa.sin_port = 9999u16.to_be();
     sa.sin_addr.s_addr = u32::from_ne_bytes(ip);
 
-    let payload = b"xsk-test-probe";
+    let payload = PROBE_MARKER;
     while !stop.load(std::sync::atomic::Ordering::Relaxed) {
         unsafe {
             libc::sendto(fd, payload.as_ptr() as _, payload.len(), libc::MSG_DONTWAIT,
@@ -443,4 +502,80 @@ fn xskmap_delete(map_fd: i32, key: u32) {
 fn if_nametoindex(name: &str) -> u32 {
     let cname = CString::new(name).unwrap();
     unsafe { libc::if_nametoindex(cname.as_ptr()) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A realistic redirected frame: Ethernet + IPv4 + UDP + payload. The
+    /// marker sits at an OFFSET, which is the whole reason the matcher scans
+    /// rather than reading a fixed position.
+    fn framed(payload: &[u8], vlan_tagged: bool) -> Vec<u8> {
+        let mut f = vec![0u8; 14];
+        if vlan_tagged {
+            // 802.1Q pushes every later header 4 bytes along — the case a
+            // fixed-offset parse silently stops matching on.
+            f.extend_from_slice(&[0x81, 0x00, 0x00, 0x64]);
+        }
+        f.extend_from_slice(&[0u8; 20]); // IPv4 header
+        f.extend_from_slice(&[0u8; 8]); // UDP header
+        f.extend_from_slice(payload);
+        f
+    }
+
+    #[test]
+    fn probe_frame_is_recognised_at_any_offset() {
+        assert!(is_probe_frame(&framed(PROBE_MARKER, false)));
+        assert!(
+            is_probe_frame(&framed(PROBE_MARKER, true)),
+            "a VLAN tag shifts every header; a fixed-offset match would stop seeing our own \
+             probes on a tagged link and report FAIL on a healthy rebind"
+        );
+    }
+
+    /// THE CELL THIS FIX EXISTS FOR.
+    ///
+    /// The XDP program redirects every packet on the queue with no filter, so
+    /// before #6898 the receive counters counted background traffic. `rx > 0`
+    /// was therefore satisfiable by an ARP or an IPv6 RA while the tool's own
+    /// probes were not arriving at all — which is the exact failure the
+    /// reproducer exists to detect, reported as PASS.
+    #[test]
+    fn foreign_traffic_is_not_counted_as_a_probe() {
+        // An IPv6 router advertisement is the realistic case: essentially every
+        // live link carries them, so this is not an exotic input.
+        let ra = framed(b"\x86\x00\x00\x00 router advertisement", false);
+        assert!(
+            !is_probe_frame(&ra),
+            "background interface traffic must not satisfy the PASS criterion — that is what \
+             made the reproducer unable to detect a broken rebind"
+        );
+        assert!(!is_probe_frame(&framed(b"", false)));
+        assert!(!is_probe_frame(b"arp who-has"));
+    }
+
+    #[test]
+    fn short_frames_do_not_panic() {
+        // `windows(n)` on a slice shorter than n yields nothing — but a runt
+        // frame reaching the matcher is a real possibility on a live queue, and
+        // a panic here would take down the tool mid-run.
+        for len in 0..PROBE_MARKER.len() {
+            assert!(!is_probe_frame(&vec![0u8; len]));
+        }
+    }
+
+    /// The generator and the matcher must use ONE marker definition.
+    ///
+    /// A duplicated literal drifts, and it drifts in the direction that hides
+    /// the fix: every frame reads as foreign, rx falls to zero, and the tool
+    /// reports FAIL on a healthy rebind — a false alarm that looks exactly like
+    /// the defect it is supposed to find.
+    #[test]
+    fn generator_and_matcher_share_one_marker() {
+        assert!(
+            is_probe_frame(&framed(PROBE_MARKER, false)),
+            "the marker the generator sends must be the marker the receiver matches"
+        );
+    }
 }

--- a/test/xsk-repro/selftest-probe-filter_6898.sh
+++ b/test/xsk-repro/selftest-probe-filter_6898.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# #6898 A10-b5-F1: behavioural gate for the reproducer's probe filter.
+#
+# The XDP program redirects EVERY packet on the queue to the XSK, so the receive
+# counters used to count all interface traffic. `rx > 0` was then satisfiable by
+# an ARP or an IPv6 RA while the tool's own probes never arrived — the exact
+# failure the reproducer exists to detect, reported as PASS.
+#
+# This runs the crate's unit tests for `is_probe_frame`. Reverting the filter
+# (counting every descriptor) or splitting the marker into two literals makes
+# them RED.
+#
+# Unlike its sibling selftests this is a BEHAVIOURAL gate, not a strict-warning
+# compile: the defect it guards compiles perfectly.
+#
+# SKIPs (77) on a host without cargo, or without the vendored deps to build
+# offline — matching the tool-gating convention of the other legs.
+set -e
+cd "$(dirname "$0")"
+
+if ! command -v cargo >/dev/null 2>&1; then
+	echo "SKIP: cargo not available"
+	exit 77
+fi
+
+if ! out=$(cargo test --offline --quiet 2>&1); then
+	case "$out" in
+	*"no matching package"*|*"failed to download"*|*"offline"*)
+		echo "SKIP: cargo cannot build offline (deps unavailable)"
+		exit 77
+		;;
+	esac
+	echo "FAIL: xsk-repro unit tests"
+	echo "$out"
+	exit 1
+fi
+
+# Guard against a vacuous pass: cargo reports ok for zero tests just as happily.
+if ! echo "$out" | grep -qE "test result: ok\. [1-9][0-9]* passed"; then
+	echo "FAIL: no tests ran (a filter matching nothing reports ok and exits 0)"
+	echo "$out"
+	exit 1
+fi
+echo "PASS: xsk-repro probe-filter tests"
+exit 0


### PR DESCRIPTION
Refs #6898 — item **A10-b5-F1** only. One of the four remaining survivors; the
other three are independently actionable and are **not** folded in here, with
measured reachability for each reported on the issue.

## The reproducer could not detect the bug it exists to detect

`xdp_pass_redirect.c` redirects **every** packet on the queue to the XSK — it
looks the queue up in the xskmap and redirects unconditionally, with no filter —
and the receive loop counted every descriptor. So `rx2 > 0` was satisfiable by an
ARP, an IPv6 RA or MLD report, or any stray broadcast, while the tool's own
probes were not arriving at all. **A completely broken zero-copy rebind reported
PASS.**

**Reachability: HIGH**, measured rather than assumed. The redirect is
unconditional, so any traffic on the queue counts, and the tool is documented to
run as root on a real interface — where IPv6 multicast alone is usually enough.

**Cost: none that matters.** A substring scan per received frame in a standalone
repro tool with no dataplane role.

## Two corrections to the issue's stated mechanism, both load-bearing

The item says the two receivers are not distinguished because `nonce` returns
zero hits.

1. **The phases ARE distinguished.** `run_xsk_phase` does a fresh `mmap` and a
   fresh `Umem` per call, so no phase-1 frame can be counted in phase 2 — the
   stale-descriptor reading does not hold.
2. **A marker already existed** (`b"xsk-test-probe"`) and was simply never
   checked on receive. The item named the right *property* through the wrong
   *token*, and chasing the token would have added a nonce duplicating a marker
   already there.

## The fix

The marker is now a single `const` used by both the generator and the matcher.
Two copies of a literal drift, and this one drifts in the direction that hides
the fix: every frame reads as foreign, rx falls to zero, and the tool reports
FAIL on a healthy rebind.

Matching is a **substring scan, not a fixed offset**: the frame is
Ethernet + IP + UDP + payload and header sizes vary (VLAN tag, IPv4 options, v4
vs v6), so a fixed offset would silently stop matching on a tagged link — the
same false verdict in the opposite direction.

Foreign frames are still counted and **reported separately**, because *"rx=0 but
5000 foreign frames seen"* and *"rx=0 and the link is silent"* are different
diagnoses.

## Testability was not free, and is the reason for the new selftest

`test/xsk-repro` is a **standalone crate** — not a workspace member, not in the
root Makefile — so `make test` never builds it and a unit test alone would run in
**no gate**. Its three existing selftests *are* wired into
`scripts/run-selftests.sh`, so this adds a fourth.

It is a **behavioural** gate, unlike its siblings which are strict-warning
compiles — the defect it guards compiles perfectly. The script also refuses a
vacuous pass: `cargo test` reports `ok` for zero tests just as happily, so it
requires a non-zero passed count.

## Mutation matrix

Run through the **real gate** (the selftest script as `run-selftests.sh` invokes
it), not just `cargo test`. Fix committed before mutating; runner refuses to
score a cell whose mutation did not change the file.

| # | Mutation | selftest rc | Named RED |
|---|---|---|---|
| M1 | revert the filter — count every descriptor | 1 | `foreign_traffic_is_not_counted_as_a_probe` |
| M2 | marker drift — matcher uses its own literal | 1 | `generator_and_matcher_share_one_marker` |
| M3 | fixed offset instead of a scan | 1 | `probe_frame_is_recognised_at_any_offset` |

## Validation

Gated head `d32e2be6b`, up to date with `origin/master` (`02ca90f01`).

- `scripts/run-selftests.sh`: **passed=65 skipped=0 failed=0**
- `go test ./... -count=1`: **rc=0**, 68 packages
- `cargo test --release --bins --tests -- --test-threads=1`: **4812 collected, 0 failed**
