### PR TITLE
docs: correct two counts in the #6907 re-verification table, file the survivors

### DIFF
--- a/docs/log/6907.md
+++ b/docs/log/6907.md
@@ -20,7 +20,7 @@
 | 05 | mpsc_inbox single-consumer not type-enforced | **PRESENT** | `afxdp/mpsc_inbox.rs:59-60` `unsafe impl Send/Sync`, `:109` `get_unchecked`. The invariant is a doc comment (`:13`, "correctness needs only the weaker single-consumer invariant"), not a type. Claim accurate as written. |
 | 06 | shared_recycle unknown-slot drop leaks UMEM | **PRESENT, now instrumented** | `afxdp/tx/dispatch/shared_recycle.rs:38-42`: the drop still happens, but is counted and logged (`log_shared_recycle_unknown_slot_drops`, `record_shared_recycle_unknown_slot_drops`). Silent-leak half of the claim is refuted; the drop half stands. |
 | 07 | `slice_mut_unchecked` on shared `&MmapArea` | **PRESENT — cite rotted to the wrong FILE** | Not in `tx/transmit/rewrite.rs` as cited. Four sites in `afxdp/cos/queue_service/drain.rs` (`:97`, `:315`, `:384`, `:574`). |
-| 08 | ZoneCounterStore `expect` on poison | **PRESENT** | `afxdp/zone_counters.rs` — seven `expect("zone counter store poisoned")`, none at the cited `:189`; first at `:288`. Doc at `:283` scopes it to "Config-apply path only … NOT the hot path", which bounds the blast radius without removing the panic. |
+| 08 | ZoneCounterStore `expect` on poison | **PRESENT** | `afxdp/zone_counters.rs` — **six** `expect("zone counter store poisoned")` (`:288`, `:295`, `:333`, `:347`, `:393`, `:406`), none at the cited `:189`. (This said *seven* until #6907's own re-verification counted them; the enumerated line list is given so the number is checkable rather than re-asserted.) Doc at `:283` scopes it to "Config-apply path only … NOT the hot path", which bounds the blast radius without removing the panic. |
 | 09 | PrefixTrie `root.covers` ignores /0 → bypass | **REFUTED IN-TREE, direction inverted** | `prefix_set.rs:240-246` addresses this exact case and states the opposite outcome: a bypass-inserted /0 "would NOT match all … silently ineffective, not unsafe". The finding claims over-match; the code documents under-match. |
 | 10 | PrefixSet `Default` → `MatchAny` fail-open | **PRESENT — unambiguous** | `prefix_set.rs:198-208`: `impl Default for PrefixSetV4/V6 { fn default() -> Self { Self::MatchAny } }`. A defaulted prefix set matches every address. |
 | 11 | fairness_eval per_worker unchecked `u32 +=` | **PRESENT, low reach** | `fairness_eval/per_worker.rs:75`, `:121` — `.or_insert(0) += row.count`, unchecked. `fairness_eval` is an offline analysis module, not the packet path. |
@@ -36,10 +36,32 @@
 
 ## Totals
 
-**11 present** (04, 05, 06, 07, 08, 10, 11, 12, 14, 15, 16, 17 — twelve rows, of
-which 04 and 06 survive only in a narrowed form), **2 refuted in substance**
-(09, 13), **2 refuted in their tracking basis** (19, 20), **1 unverifiable**
-(18).
+**12 present** (04, 05, 06, 07, 08, 10, 11, 12, 14, 15, 16, 17 — of which 04 and
+06 survive only in a narrowed form), **2 refuted in substance** (09, 13),
+**2 refuted in their tracking basis** (19, 20), **1 unverifiable** (18).
+12 + 2 + 2 + 1 = 17, which is the whole set.
+
+> This line said **11 present** while listing twelve row numbers, and its own
+> parenthetical said "twelve rows". Corrected to 12, with the arithmetic shown
+> so the total is checkable against the row count rather than restated. Noting
+> it rather than quietly fixing it: a miscount in the summary of a
+> citation-quality audit is the same defect class the audit is about, and a
+> reader who trusted the headline would have under-counted the survivors by one.
+
+## Follow-ups filed
+
+Every **present** row is now tracked, so this document is a record rather than a
+worklist:
+
+| rows | issue | note |
+|---|---|---|
+| 10, 16 | **#7745** (closed, fixed by #7747) | the two fail-open defaults |
+| 05, 07 | **#7750** | unsafe-boundary rows |
+| 08, 12, 14, 17 | **#7751** | robustness rows |
+| 04 | **#7752** | adversarial shard targeting; the accidental case is mitigated |
+| 15 | **#7106** (pre-existing, open) | the io_uring teardown residual the in-tree comment already points at |
+| 11 | **#6898** (pre-existing, open) | fairness_eval is an offline module; carried in that cohort |
+| 06 | not filed | the silent-leak half is refuted — the drop is counted and logged; only the drop survives, and it is instrumented |
 
 ## What this pass says about the source document
 


### PR DESCRIPTION
Closes #6907

The 004/005 re-verification landed in #7744. This corrects **two numbers in it**, and files the follow-ups that #6907's step 4 asks for.

Both errors are the defect class the document is about — a claim restated rather than checked.

## The two corrections

**Row 08 said SEVEN `expect("zone counter store poisoned")`. There are SIX** — `:288`, `:295`, `:333`, `:347`, `:393`, `:406`. The enumerated line list is now given so the count is checkable rather than re-asserted; re-stating a number over an unverified population is how the original got there.

**The totals line said "11 present" while listing TWELVE row numbers**, and its own parenthetical said *"twelve rows"*. It is 12. The arithmetic `12 + 2 + 2 + 1 = 17` is now shown so the total reconciles against the row count. A reader trusting the headline would have under-counted the survivors by one — in the summary of an audit whose entire subject is citations that cannot be followed as written.

Both are noted **in place** rather than silently fixed: a quiet correction in this particular document would remove the evidence that the miscount happened.

## Verification method

Per the re-verification brief, every claim was checked against `git show origin/master:<path>` — **never** a working-tree `git grep`, which searches a possibly-stale checkout.

That mattered twice:

- **A false alarm I caught on myself.** My first probe for row 05's `unsafe impl Send/Sync` returned nothing, which read as "the table is wrong". It was my pattern: the code is `unsafe impl<T: Send> Send for MpscInbox<T>`, correctly at `:59-60`. The table was right and my grep was wrong — the same shape as three-simultaneous-zeros being a tree problem rather than a content problem.
- **A real one.** Row 08's count genuinely disagreed with master.

Rows re-verified at `origin/master` before filing: **04** (`sharded_neighbor.rs:162`), **05** (`mpsc_inbox.rs:59-60`, `:109`, `:152`), **06** (instrumentation present), **07** (four sites in `cos/queue_service/drain.rs`), **08** (six sites), **11** (`per_worker.rs:75`, `:121`), **12** (`io_uring_write.rs:375`), **14** (`filter/compiler.rs:405-412`), **17** (`csrc/xsk_bridge.c:171-173`).

## Follow-ups filed — every PRESENT row is now tracked

The document becomes a record rather than a worklist:

| rows | issue | note |
|---|---|---|
| 10, 16 | **#7745** (closed, fixed by #7747) | the two fail-open defaults |
| 05, 07 | **#7750** | unsafe-boundary rows |
| 08, 12, 14, 17 | **#7751** | robustness rows |
| 04 | **#7752** | adversarial shard targeting; the accidental case *is* mitigated |
| 15 | **#7106** (pre-existing, open) | the io_uring teardown residual the in-tree comment already points at |
| 11 | **#6898** (pre-existing, open) | `fairness_eval` is an offline module; carried in that cohort |
| 06 | not filed | silent-leak half **refuted** — the drop is counted and logged; only the instrumented drop survives |

Rows 15 and 11 were checked against the existing issues rather than duplicate-filed. Row 06 is deliberately not filed, with the reasoning recorded so "not filed" is distinguishable from "missed".

## Disposition summary — the three outcomes kept distinct

"No longer present" would hide which of two very different things happened, so the table separates them:

- **PRESENT (12)** — 04, 05, 06, 07, 08, 10, 11, 12, 14, 15, 16, 17 (04 and 06 in narrowed form)
- **REFUTED IN SUBSTANCE (2)** — 09 and 13, both refuted *by the file they cite*, and both tabled as majors
- **REFUTED IN TRACKING BASIS (2)** — 19 and 20 assert "#6755/#6754 still present"; **both issues are closed**. That refutes the row's basis, not necessarily the underlying defect — a distinction the table keeps
- **UNVERIFIABLE (1)** — 18 cites no file and no gauge matching its description was found. Recorded as unverifiable, **not** as fixed

## Gate

- `go test ./... -count=1 -p 4` → **rc 0, 68 packages, 0 failures**
- `merge-base --is-ancestor origin/master HEAD` verified
- Docs-only; no smoke, no cargo leg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ez9XCjM9mPjtocRjkousdB
