### PR TITLE
cluster: document the incarnation fence's real coverage (#6908 not reproducible)

### DIFF
--- a/docs/log/6908.md
+++ b/docs/log/6908.md
@@ -1,0 +1,41 @@
+# #6908 — enqueue-side `lastRecvConfigGen` race: investigated, not reproducible
+
+- **Timestamp**: 2026-08-27
+  - **Action**: measured the narrowed mechanism rather than fixing it. The
+    ordering is real — `recordRecvConfigGen` can land after `resetRecvGen`, and
+    `configGenMu` serialises the writes but not their order — but it cannot
+    produce the claimed stuck readiness. `resetRecvGen` zeroes
+    `lastAppliedConfigGen` in the same transaction and `shouldApplyConfigGen` is
+    `last == 0 || gen > last`, so the late payload that raises `received` is the
+    one that then applies. Drove the whole ordering space through the real
+    handlers on the two-fabric `incEnv`: `applied == received` in all five.
+    Answered the gating question first — a bulk re-prime does NOT always change
+    the boot incarnation (`notePeerBootIncarnation` rule 2; three of four
+    `doBulkSync` call sites are reboot-independent) — so the #5084 fence is not
+    what closes this.
+  - **File(s)**: pkg/cluster/README.md, docs/log/6908.md
+
+- **Timestamp**: 2026-08-27
+  - **Action**: documented the #5084 fence's ACTUAL coverage, the useful half of
+    the investigation. `configItemIncarnationStale` stamps from
+    `connBootIncarnation(conn)`, so it covers config arriving on a connection
+    that itself primed under a replaced incarnation — not "any config from a
+    replaced boot". Measured: after a prime on fabric 0, `conn0` carries the
+    incarnation and `conn1` carries `none`, putting the second fabric's payloads
+    in the never-dropped class (rule 4). Deliberate and harmless — rule 4 is
+    symmetric across the receive and apply sites — but readable as stronger than
+    it is.
+  - **File(s)**: pkg/cluster/README.md
+
+- **Timestamp**: 2026-08-27
+  - **Action**: deliberately did NOT land the ordering probe as a regression
+    test. Measured the one mutation that breaks the structural argument —
+    deleting `s.lastAppliedConfigGen.Store(0)` from `resetRecvGen`, other two
+    clears intact, full package, no `-run` filter — and THREE existing cells red
+    on it: `TestResetRecvGenClearsReceivedConfigHighWater`,
+    `TestResetRecvGenResetsConfigGen`,
+    `TestConfigGenResetIsNotLostByAConcurrentAppliedAdvance`. The probe reds too,
+    but at its SETUP precondition, never reaching its own `ConfigStale`
+    assertion — it re-asserts what the existing cells own, through more
+    machinery. A test that cannot red on its own property guards nothing.
+  - **File(s)**: none (probe discarded)

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -3055,6 +3055,44 @@ outside the monitor loop:
   | `resetRecvGen` | all three, clear to 0 | receive loop (×2) | `configGenMu` |
   | `initGenState` | all three | `NewSessionSync` | none — pre-`Start`, no goroutines yet |
 
+  **What the #5084 incarnation fence actually covers, which is less than its
+  name suggests.** `configItemIncarnationStale` drops a payload whose stamped
+  incarnation differs from the current one, and the stamp comes from
+  `connBootIncarnation(conn)` — *the connection the payload arrived on*. A
+  connection that never received an incarnated `BulkStart` returns the ZERO
+  value, and zero is the never-dropped class (plan §6 rule 4, fail open). In a
+  two-fabric cluster only the fabric that primed carries a stamp; the other
+  routinely carries config with none — measured directly: after a prime on
+  fabric 0, `conn0` reports the incarnation and `conn1` reports `none`. So the
+  fence covers *config arriving on a connection that itself primed under a
+  now-replaced incarnation*, NOT "any config from a replaced boot". That is
+  deliberate and it strands nothing, because rule 4 is symmetric — an
+  un-incarnated payload passes at the receive site and at the apply site alike,
+  so it can never raise the received mark and then be refused at apply. Read as
+  the stronger claim it is not, this looks like a hole; it is a documented
+  fail-open with matching behaviour on both sides of the queue.
+
+  **The enqueue-side ordering cannot open the readiness gap (#6908, closed
+  not-reproducible).** `recordRecvConfigGen` runs on a receive loop and can
+  land *after* `resetRecvGen` has cleared the marks for a re-prime driven by
+  the other fabric — a real ordering, not prevented by `configGenMu`, which
+  serialises the writes but not their order. It was filed as leaving `received`
+  high while `applied` lands low, wedging the #5563 manual-failover gate. It
+  cannot: the reset that opens the window also removes the barrier that would
+  hold the marks apart. `resetRecvGen` zeroes `lastAppliedConfigGen` in the same
+  `configGenMu` transaction, and `shouldApplyConfigGen` is `last == 0 || gen >
+  last`, so with `applied == 0` the late payload that raises `received` is the
+  same payload that then applies and raises `applied`. Measured across the whole
+  ordering space (late-raise alone; live re-push before and after it; live
+  generation above and below the stale one) — `applied == received` in every
+  case. A same-incarnation re-prime is a first-class case, not an edge
+  (`notePeerBootIncarnation` rule 2, the #5450 forced resync), so the fence
+  above is not what closes this; the reset's own transaction is. The gap between
+  the marks CAN open, by the #6778 queue-full drop and by apply failure, both
+  deliberate and separately tracked, plus a genuine one-apply transient while a
+  queued newer generation is still in flight — which is the in-flight window
+  #5563 exists to represent.
+
   Readers stay lock-free (the marks are atomics and `configEpochStale` runs per
   synced session install); a reader racing a writer observes one side of a
   single monotone step, which is the tolerance the marks already had. **The guard is


### PR DESCRIPTION
Closes #6908

## Verdict: not reproducible. Docs-only.

#6908 asked whether the enqueue-side `lastRecvConfigGen` raise can wedge the #5563 manual-failover readiness gate at `applied < received`. **It cannot.** No production behaviour changes here — what lands is the reasoning, plus a documentation gap the investigation turned up that is worth more than the issue itself.

## The gating question, answered first

*Does a bulk re-prime always change the boot incarnation?* — because if it does, the #5084 fence already covers this.

**No, and the same-incarnation re-prime is a documented first-class case, not an edge.** `notePeerBootIncarnation` rule 2: *"the SAME incarnation is a mid-connection re-prime (the #5450 forced resync) and must NOT invalidate queued payloads."*

- **Four `doBulkSync()` call sites, and three are reboot-independent** — `sync_conn.go:453` (reconnect / both-fabric flap; its own comment says *"even for a peer that never rebooted"*), `sync_conn.go:1039` (survivor re-drive), `sync_conn_sweep.go:120` (#5450 delete-journal overflow — steady-state, driven by session churn), `sync_conn_sweep.go:155` (owed cold-prime re-drive).
- **The incarnation cannot change without an OS boot** — `localBootIncarnation` is `sync.Once`-cached from `/proc/sys/kernel/random/boot_id`; the design records that granularity as forced, not chosen.
- **`resetRecvGen` fires unconditionally** in the BulkStart arm, not gated on `switched`.

So the fence is *not* what closes this. Something else does.

## Why the ordering cannot open the gap

The ordering is **real**: `recordRecvConfigGen` runs on a receive loop and can land after `resetRecvGen` has cleared the marks for a re-prime driven by the other fabric. `configGenMu` serialises those writes but not their order — the existing code concedes it at `sync_conn_read.go:638`.

It still cannot produce the symptom, because **the reset that opens the window also removes the barrier that would hold the marks apart.** `resetRecvGen` zeroes `lastAppliedConfigGen` inside the same `configGenMu` transaction, and `shouldApplyConfigGen` is `last == 0 || gen > last`. With `applied == 0`, the late payload that raises `received` is the same payload that then applies and raises `applied`.

Measured across the **whole ordering space**, driven through the real handlers on the two-fabric `incEnv`:

| ordering | result |
|---|---|
| late raise alone, no live re-push | peer=5000 applied=5000 — not stale |
| live re-push first, live gen **below** stale | peer=5000 applied=5000 — not stale |
| live re-push first, live gen **above** stale | peer=9000 applied=9000 — not stale |
| late raise first, live gen **below** stale | peer=5000 applied=5000 — not stale |
| late raise first, live gen **above** stale | peer=9000 applied=9000 — not stale |

`ReadyForManualFailover()` true and `Reason()` empty in all five.

Two symbols the issue names **do not exist**: `configNamespaceMu` (it is `configGenMu`) and `configItemSuperseded` (the predicate is `shouldApplyConfigGen`). Corrections posted to the issue before this PR.

## Boundary of the refutation

Stated so it is not read as broader than it is. The gap between the marks **can** open:

- **#6778 queue-full drop** — the raise is deliberate there, so the node reads config-stale and #5563 refuses promotion. Known, tracked, has its own repair.
- **apply failure** — `ConfigsApplyFailed` plus the grace-timer health signal.
- **a genuine transient** — the late payload applies while a newer queued generation is still in flight, so the gate reads stale for one apply. That is the in-flight window #5563 exists to represent, and it clears.

The issue's impact sentence was also wrong independent of the above and is corrected on the issue: not *"no self-clearing path short of a process restart"* but **no self-clearing path short of a new config commit on the primary or a reconnect** — `reconcileConfigSyncToPeer` is keyed on (connection epoch × config-generation hash).

## What actually lands: the fence's real coverage

The useful half. `configItemIncarnationStale` stamps a payload from `connBootIncarnation(conn)` — **the connection it arrived on**. A connection that never received an incarnated `BulkStart` returns the zero value, which is the never-dropped class (plan §6 rule 4, fail open). In a two-fabric cluster only the fabric that primed carries a stamp; the other routinely carries config with none.

Measured directly: after a prime on fabric 0, `conn0` reports `0909…0e` and **`conn1` reports `none`**.

So the fence covers *config arriving on a connection that itself primed under a now-replaced incarnation*, **not** "any config from a replaced boot". That is deliberate and it strands nothing — rule 4 is symmetric, so an un-incarnated payload passes at the receive site and the apply site alike and can never raise the received mark only to be refused at apply. But it reads as the stronger claim, and someone reasoning about the fence from its name will over-trust it. That correction is what this PR is for.

## No regression test, deliberately — and this was measured, not assumed

My first pass said "I could not find a mutation it reds on", which is a search, not a result. The reviewer named the one candidate that breaks the structural argument, and I ran it: **delete `s.lastAppliedConfigGen.Store(0)` from `resetRecvGen`, other two clears intact**, full package, `-count=1`, **no `-run` filter**.

| | outcome |
|---|---|
| `TestResetRecvGenClearsReceivedConfigHighWater` | **RED** |
| `TestResetRecvGenResetsConfigGen` | **RED** |
| `TestConfigGenResetIsNotLostByAConcurrentAppliedAdvance` | **RED** |
| end-to-end ordering probe | RED — **but at its SETUP precondition** (`setup: re-prime must zero both, got peer=0 applied=5000`), never reaching its own `ConfigStale` assertion |

962 tests collected, `buildsig=0`. Three existing cells own the property. The probe re-asserts what they already own, through more machinery and 20s slower, and under the only mutation that matters it never evaluates the thing it purports to test. **A test that cannot red on its own property guards nothing**, so it was discarded rather than landed as coverage theatre.

## Test plan

- [x] `go build ./...` → rc 0
- [x] `go test ./... -count=1` → **rc 0, 68/68 packages** at `76bf57828`, `origin/master` folded (MERGE, never rebase) and `merge-base --is-ancestor` verified
- [x] Mutation above run full-package, no `-run` filter, 962 collected
- [x] `docs/log/6908.md` per the #6874 sentinel

No `make test-failover`: this is a documentation change to `pkg/cluster/README.md` plus a log file. No cluster/VRRP/session-sync/failover code is touched — `git diff --stat` is two files, neither compiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhHmVt536ZsY2RVEhc8WPV
