### PR TITLE
fairness_eval: make --iface a required value like every other flag

### DIFF
--- a/docs/log/6898.md
+++ b/docs/log/6898.md
@@ -1,46 +1,43 @@
-# #6898 — audit cohort survivors (item A10-b5-F1)
+# #6898 — audit cohort survivors
 
-- **Timestamp**: 2026-08-27
-  - **Item 5, `A10-b5-F1`** — the xsk reproducer's PASS criterion could not
-    detect the bug it exists to detect.
-  - **Shape, confirmed at master `02ca90f01`**: `main.rs` PASS is
-    `rx1 > 0 && rx2 > 0`, and the receive loop counted **every** descriptor.
-  - **The issue's stated mechanism is imprecise, and correcting it mattered.**
-    It says "`nonce` returns zero hits in the file, so the two receivers are not
-    distinguished". Two corrections:
-    1. The phases ARE distinguished from each other — `run_xsk_phase` does a
-       fresh `mmap` and a fresh `Umem` per call, so no phase-1 frame can be
-       counted in phase 2. The "stale descriptor" reading does not hold.
-    2. There IS a marker (`b"xsk-test-probe"`), it was simply never checked on
-       receive. So the item named the right property via the wrong token.
-  - **The real defect**: `xdp_pass_redirect.c` redirects EVERY packet on the
-    queue — it looks the queue up in the xskmap and redirects unconditionally,
-    with no filter. So the counters counted all interface traffic. `rx2 > 0` was
-    satisfiable by an ARP, an IPv6 RA or MLD report, or any stray broadcast,
-    while the tool's own probes never arrived — a completely broken rebind
-    reported as PASS.
-  - **Reachability: HIGH**, and measured rather than assumed. The redirect is
-    unconditional (verified in the `.c`), so any traffic on the queue counts. On
-    a live link IPv6 multicast alone is usually enough; the tool is documented
-    to run as root on a real interface.
-  - **Cost: none that matters.** A substring scan per received frame, in a
-    standalone repro tool with no dataplane role.
-  - **Why a substring scan and not a fixed offset**: the frame is
-    Ethernet + IP + UDP + payload and header sizes vary (VLAN tag, IPv4 options,
-    v4 vs v6). A fixed offset would silently stop matching on a tagged link and
-    reintroduce the same false verdict in the opposite direction — FAIL on a
-    healthy rebind.
-  - **Foreign frames are counted and reported separately**: "rx=0 but 5000
-    foreign frames seen" and "rx=0 and the link is silent" are different
-    diagnoses and the operator has to tell them apart.
-  - **Testability, which was not free.** `test/xsk-repro` is a standalone crate:
-    not a workspace member, not in the root Makefile, so `make test` never
-    builds it and a unit test alone would not run in any gate. Its three
-    existing selftests ARE wired into `scripts/run-selftests.sh`, so a fourth
-    was added there — a BEHAVIOURAL gate, unlike its siblings which are
-    strict-warning compiles, because the defect it guards compiles perfectly.
-    The script also refuses a vacuous pass: `cargo test` reports ok for zero
-    tests just as happily, so it requires `[1-9]+ passed`.
-  - **File(s)**: test/xsk-repro/main.rs,
-    test/xsk-repro/selftest-probe-filter_6898.sh,
-    scripts/run-selftests.sh, docs/log/6898.md
+- **Timestamp**: 2026-08-27 (item `A10-b5-F1` — xsk repro probe filter; merged
+  as PR #7749)
+  - See PR #7749. The reproducer's PASS criterion counted all queue traffic
+    because the XDP program redirects unconditionally, so a broken rebind
+    reported PASS. Reachability HIGH. Two corrections to the filed mechanism:
+    the phases ARE distinguished (fresh mmap/Umem per phase), and a marker
+    already existed and was simply unchecked.
+
+- **Timestamp**: 2026-08-27 (item `A1-b6-F3` — `--iface` accepted a missing
+  value)
+  - **Action**: routed `--iface` through `parse_required_string_value`, the same
+    helper the other string-valued flags already use.
+  - **The inconsistency is the argument, and it is stronger than "a required arg
+    should be required".** `--iperf-json`, `--binding-flows` and `--cos-flows`
+    all go through `parse_required_string_value`; every numeric flag goes
+    through `parse_required_numeric_value`. `--iface` was the lone arm in the
+    match using `unwrap_or_default()`. There is no reading under which it should
+    be the one flag that accepts a missing value — which also tells the reviewer
+    which direction the fix goes.
+  - **The module documents the invariant this broke.** `parse_args_from`'s own
+    doc: *"A silent fallback here could seed a false PASS/FAIL from this
+    fairness merge gate (#1630/#1614), so the harness fails fast on an operator
+    CLI mistake."* This arm was the exception to a stated contract.
+  - **The defect is worse than the audit named.** `unwrap_or_default()` failed
+    silently in TWO ways: `--iface` as the final token left the interface `""`,
+    and **`--iface --warmup-secs 5` set the interface to the literal string
+    `"--warmup-secs"` and silently dropped the `5`** — two wrong values from one
+    typo, no diagnostic. `parse_required_string_value` already rejected both
+    (it refuses a missing value AND a value starting with `--`); the guard was
+    three lines away and unused.
+  - **Test placement was the load-bearing decision.** The existing tests
+    exercise `parse_required_string_value` DIRECTLY — and the helper was never
+    broken. The defect was that this arm did not CALL it, so a helper test would
+    have passed against the unfixed code. The new test drives `parse_args_from`.
+    Bind the wiring, not the function it calls.
+  - **The control caught a real fixture error.** `--iface ge-0-0-2` alone does
+    NOT parse — `--iperf-json` and `--binding-flows` are required after the
+    loop. Every case now carries them, so each fails for exactly one reason;
+    without that, a reverted build still errors (with "--iperf-json is
+    required") and the cell would red for a reason unrelated to this fix.
+  - **File(s)**: userspace-dp/src/fairness_eval/args.rs, docs/log/6898.md

--- a/userspace-dp/src/fairness_eval/args.rs
+++ b/userspace-dp/src/fairness_eval/args.rs
@@ -107,7 +107,22 @@ where
                 ))?);
             }
             "--iface" => {
-                iface = args.next().unwrap_or_default();
+                // #6898 A1-b6-F3: use the SAME helper the other string-valued
+                // flags use. This arm was the lone exception in the match —
+                // `--iperf-json`, `--binding-flows` and `--cos-flows` all go
+                // through `parse_required_string_value`, and every numeric flag
+                // through `parse_required_numeric_value`. The inconsistency is
+                // the argument: there is no reading under which `--iface`
+                // should be the one flag that accepts a missing value.
+                //
+                // `unwrap_or_default()` failed silently in TWO ways, and the
+                // second is worse than the empty string the audit named:
+                // `--iface` as the final token left the interface `""`, and
+                // `--iface --warmup-secs 5` set the interface to the STRING
+                // "--warmup-secs" and then dropped the 5. The helper rejects
+                // both — it refuses a missing value and refuses a value that
+                // starts with `--`.
+                iface = numeric_or_string(parse_required_string_value("--iface", args.next()))?;
             }
             "--warmup-secs" => {
                 warmup_secs =
@@ -284,6 +299,67 @@ mod tests {
             Err(ParseError::HelpRequested) => panic!("expected Usage error, got HelpRequested"),
             Ok(_) => panic!("expected Usage error, got Ok"),
         }
+    }
+
+    /// #6898 A1-b6-F3: `--iface` must fail fast like every other valued flag.
+    ///
+    /// Driven through `parse_args_from`, NOT through
+    /// `parse_required_string_value`. The helper was never broken — three other
+    /// string flags already used it correctly. The defect was that this arm did
+    /// not CALL it, so a test of the helper would have passed against the
+    /// unfixed code and bound nothing.
+    ///
+    /// The module's own contract is the argument: "A silent fallback here could
+    /// seed a false PASS/FAIL from this fairness merge gate (#1630/#1614), so
+    /// the harness fails fast on an operator CLI mistake." `--iface` was the
+    /// one arm violating it.
+    #[test]
+    fn iface_flag_requires_a_value_6898() {
+        // 1. Missing value — `--iface` as the final token. Pre-fix this left
+        //    the interface as "" and parsed successfully, so the harness ran
+        //    against no interface and reported a verdict anyway.
+        // Every case carries the two REQUIRED flags (`--iperf-json`,
+        // `--binding-flows`) so the only thing under test is the `--iface`
+        // handling. Without them a reverted build still errors — with
+        // "--iperf-json is required" — and the cell would red for a reason
+        // that has nothing to do with this fix.
+        const REQ: [&str; 4] = [
+            "--iperf-json",
+            "/tmp/iperf.json",
+            "--binding-flows",
+            "/tmp/bind.tsv",
+        ];
+        let with_req = |extra: &[&str]| -> Vec<String> {
+            REQ.iter().chain(extra.iter()).map(|s| s.to_string()).collect()
+        };
+
+        let Err(ParseError::Usage(msg)) = parse_args_from(with_req(&["--iface"])) else {
+            panic!(
+                "#6898: `--iface` with no value must be a usage error, not an empty interface"
+            );
+        };
+        assert!(
+            msg.contains("--iface") && msg.contains("requires a value"),
+            "the error must name the flag and the reason; got {msg:?}"
+        );
+
+        // 2. THE WORSE CASE, which the audit item did not name: the next FLAG
+        //    swallowed as the value. Pre-fix this set the interface to the
+        //    literal string "--warmup-secs" and silently dropped the 5, so the
+        //    run used a default warmup AND a nonsense interface — two wrong
+        //    values from one typo, with no diagnostic.
+        let Err(ParseError::Usage(msg)) = parse_args_from(with_req(&["--iface", "--warmup-secs", "5"]))
+        else {
+            panic!("#6898: a following flag must not be consumed as the interface name");
+        };
+        assert!(msg.contains("--iface"), "the error must name --iface; got {msg:?}");
+
+        // 3. CONTROL — the happy path still works. Without this, "reject
+        //    everything" satisfies both assertions above.
+        let Ok(args) = parse_args_from(with_req(&["--iface", "ge-0-0-2"])) else {
+            panic!("control: a valid --iface must still parse");
+        };
+        assert_eq!(args.iface, "ge-0-0-2");
     }
 
     #[test]


### PR DESCRIPTION
Refs #6898 — item **`A1-b6-F3`** only.

## The inconsistency is the argument

`--iface` was the lone arm in the argument match using
`args.next().unwrap_or_default()`:

| flag | handling |
|---|---|
| `--iperf-json`, `--binding-flows`, `--cos-flows` | `parse_required_string_value` — fails loudly |
| every numeric flag | `parse_required_numeric_value` — fails loudly |
| **`--iface`** | **`unwrap_or_default()` — fails silently** |

That is a stronger case than "a required arg should be required", because it also
says which direction the fix goes: there is no reading under which `--iface`
should be the one flag that accepts a missing value. The helper it now uses was
already there, three lines away.

**And the module documents the invariant this broke.** `parse_args_from`'s own
doc comment:

> "A silent fallback here could seed a false PASS/FAIL from this fairness merge
> gate (#1630/#1614), so the harness fails fast on an operator CLI mistake."

## The defect is worse than the audit named

`unwrap_or_default()` failed silently in **two** ways, and the second is the bad
one:

- `--iface` as the final token → interface `""`, parses successfully.
- **`--iface --warmup-secs 5` → interface set to the literal string
  `"--warmup-secs"`, and the `5` silently dropped.** Two wrong values from one
  typo, no diagnostic, in a harness whose verdict gates merges.

`parse_required_string_value` already rejected both — it refuses a missing value
*and* a value beginning with `--`.

## Test placement was the load-bearing decision

The existing tests exercise `parse_required_string_value` **directly**, and that
helper was never broken. The defect was that this arm did not **call** it, so a
helper test would have passed against the unfixed code and bound nothing. The new
test drives `parse_args_from`.

**The control caught a real fixture error before it shipped.** `--iface ge-0-0-2`
alone does **not** parse — `--iperf-json` and `--binding-flows` are required
after the loop. Every case now carries them so each fails for exactly one reason;
without that, a reverted build still errors (with *"--iperf-json is required"*)
and the cell would red for a reason unrelated to this fix.

## Mutation matrix

Site `userspace-dp/src/fairness_eval/args.rs:109`. Run with
`cargo test --release --bins --no-fail-fast -- --test-threads=1`.
**Control: 2 binaries reporting, 0 failures** — both cells report the same 2, so
neither is a build break.

| # | Mutation | Binaries | Named RED |
|---|---|---|---|
| M1 | revert to `args.next().unwrap_or_default()` | 2/2 | `fairness_eval::args::tests::iface_flag_requires_a_value_6898` |
| M2 | keep the required-value check, bypass the flag-swallow guard | 2/2 | same |

M2 is the one that distinguishes the two halves: a fix that only checked for a
missing value would still consume `--warmup-secs` as the interface name.

## Validation

Gated head `4aff549b0`, up to date with `origin/master` (`7b8bd5aa4`).

- `cargo test --release --bins --tests --no-fail-fast -- --test-threads=1`: **10 binaries, 4816 collected, 0 failed**
- `go test ./... -count=1`: **rc=0**, 68 packages
