### PR TITLE
dataplane: route covered-phase logs through one validation-pass gate

### DIFF
--- a/docs/log/6903.md
+++ b/docs/log/6903.md
@@ -1,0 +1,119 @@
+# 6903 — isValidationPass gates only some duplicated INFO/WARN sites
+
+## What the issue reported
+
+The #4960 fallible-phase pre-pass runs every `validationPhases` row twice —
+once against `discardingDataPlane` to surface errors before any mutation, then
+again for real. Any record emitted inside those phases prints on BOTH passes
+unless its site gates on `isValidationPass(dp)`. The gating was per-site and
+partial, so an operator saw some compile records twice per apply.
+
+## Re-derivation (posted as issue comment 5447283280)
+
+The issue's inventory was read off a working tree, not `origin/master`. Against
+`git show origin/master:` the numbers are different in two ways that matter:
+
+- The **headline reproduction** — `compiler.go:1242` — was **already gated** by
+  #6894 r8 F6. The issue's own example no longer reproduces.
+- The real inventory is **19 ungated sites**, not the ~40 the issue implies. The
+  gap is mostly `compiler_nat.go`: 12 of the 19 are there against 4 in
+  `compiler.go`, because the NAT phases grew warn-on-bad-input branches after
+  the gating convention was established and never picked it up.
+
+## The decision: ONE GATE vs PER-SITE
+
+Reported to bpfrx-d9 before writing the diff, because it is the whole design
+question and per-site was the issue's implied shape.
+
+**One gate.** The failure mode here is an **omission** — a site that forgot to
+gate — and per-site gating is a convention that must be remembered 34 times.
+`compileInfo` / `compileWarn` in `compiler_validate_4960.go` carry the gate, and
+every covered-phase record routes through them. The 15 sites that already
+carried their own inline `if !isValidationPass(dp) { ... }` block were flattened
+onto the same helpers, so there is exactly one way to spell it and a reviewer
+can see a raw `slog.Info` in a covered phase as wrong on sight.
+
+**Scope, stated explicitly in the helpers' doc comment.** They are NOT for every
+log site in these files. A record emitted exactly once per apply —
+`compilePortMirroring`, `CompileConfig`'s own summary — would be **DELETED** by
+routing it here, not de-duplicated. Deleting an operator record is a worse
+outcome than printing it twice, which is why the acceptance gate below leads
+with the SET condition rather than the count condition.
+
+## Acceptance gate: a record census
+
+`TestValidationPassRecordCensus6903` captures every record of one full compile
+via a JSON `slog` handler, keyed on **message AND sorted fields** (a
+message-only key falsely reports two different NAT rules as a duplicate), and
+asserts:
+
+- **(a)** the pinned SET is still present — nothing dropped to zero. **This is
+  the load-bearing condition**: it is what catches a gate applied to a
+  single-copy site.
+- **(b)** no record appears more than once.
+
+A valid-only fixture measures nothing: every site it reaches was ALREADY gated,
+and the census showed 9 records with ZERO duplicates before the fix. The
+fixture therefore carries deliberately malformed input — NAT pool `p2`, rule
+`r-noaction`, static-NAT rules `s-missing` / `s-badmatch` / `s-badthen`, DNAT
+pool `dp2` and rules `d-nomatch` / `d-badmatch` / `d-badpool` / `d-badnames`,
+applications `app-badport` / `app-badsrcport`, and an interface-mode rule-set to
+the interface-less zone `dmz`. That reaches **22 distinct records**, 13 of them
+at sites this change converted.
+
+`TestCoveredPhasesUseTheLoggingChokePoint6903` derives the covered-phase list
+from `validationPhases` itself rather than a hand-kept allowlist, so a new
+fallible phase inherits the rule. It **strips comments** before scanning (a doc
+comment quoting `slog.Info` must neither satisfy nor trip it) and **fails
+loudly** if the derivation yields fewer than five phases or zero choke-point
+uses — either would make the scan vacuous.
+
+## The pre-existing over-reach arm had to follow the code
+
+`TestOverReachArmCoversEveryReachableGate_4960` proves every gate is *named*, so
+that a gate widened to suppress BOTH passes reds somewhere. Its instrument was a
+count of `isValidationPass` call sites. Moving the gate into the choke point
+dropped that count from 17 to **1**, and the test's own floor caught it:
+
+    found only 1 isValidationPass gate sites across the compiler sources —
+    the scan is not reaching them, so this test cannot bind the over-reach
+    arm's completeness
+
+That floor is why this change did not silently decommission the arm. The scan
+now counts `isValidationPass`, `compileInfo` and `compileWarn` call sites: 37.
+The 20 newly gated records are enrolled, not exempted:
+
+- **13 in `boundByCensus6903`** — driven to the real pass by the census fixture,
+  whose SET assertion reds if any of them stops being emitted.
+- **6 in `unboundGap6903`**, each with the reason no fixture reaches it. This is
+  the honest count of gates nothing can catch a widening on. One entry is a
+  measurement, not a guess: **`"DNAT application not found, ignoring"` is dead
+  code on the `CompileConfig` path** — `validate applications` rejects an
+  unresolvable DNAT rule application fatally before `compileNAT` runs. The
+  census fixture proved it by failing to compile with
+  `application "no-such-app" not found`.
+
+A new gate that nobody files in either table still reds the count, which is the
+property the arm exists for.
+
+## Mutations — two, one per assertion
+
+A compound mutation cannot localise: the bound half masks the unbound one.
+Both cells ran the FULL package, `-count=1`, no `-run` filter.
+
+| # | Mutation | Result | Collected |
+|---|---|---|---|
+| control | none | PASS, 0 failed | 600 |
+| 1 | one converted site (`"invalid pool address"`) reverted to raw `slog.Warn` | **RED**: `TestValidationPassRecordCensus6903` on condition **(b)** — `records emitted more than once: [... msg="invalid pool address"]` — plus `TestOverReachArmCoversEveryReachableGate_4960` and `TestCoveredPhasesUseTheLoggingChokePoint6903` | 600 |
+| 2 | `compileInfo`'s gate widened to `isValidationPass(dp) \|\| true`, suppressing on both passes | **RED**: `TestValidationPassRecordCensus6903` on condition **(a)** — 7 records `DISAPPEARED` — plus `TestFlowTimeoutRecordEmittedOnce6903` and `TestRealPassStillLogsItsSuccesses_4960` | 600 |
+
+Both cells collected 600 tests, equal to the control, so neither is a build
+break wearing a red's clothes.
+
+## Adjacent finding filed separately
+
+`recordingDP` (in `compiler_validate_4960_test.go`) embeds `discardingDataPlane`
+and therefore **inherits `xpfValidationPass() bool { return true }`** — a
+recording fixture that identifies itself as the discarded pre-pass. Filed as
+**#7754** rather than fixed here: it is a fixture-semantics bug with its own
+blast radius, and folding it into a logging change would hide it.

--- a/pkg/dataplane/compiler.go
+++ b/pkg/dataplane/compiler.go
@@ -708,7 +708,7 @@ func compileApplications(dp DataPlane, cfg *config.Config, result *CompileResult
 		// Parse destination port range boundaries.
 		dstLow, dstHigh, err := parsePortRange(app.DestinationPort)
 		if err != nil {
-			slog.Warn("bad port for application",
+			compileWarn(dp, "bad port for application",
 				"name", appName, "port", app.DestinationPort, "err", err)
 			continue
 		}
@@ -729,7 +729,7 @@ func compileApplications(dp DataPlane, cfg *config.Config, result *CompileResult
 			var srcErr error
 			srcLow, srcHigh, srcErr = parsePortRange(app.SourcePort)
 			if srcErr != nil {
-				slog.Warn("bad source-port for application",
+				compileWarn(dp, "bad source-port for application",
 					"name", appName, "port", app.SourcePort, "err", srcErr)
 				srcOK = false
 			} else {
@@ -787,7 +787,7 @@ func compileApplications(dp DataPlane, cfg *config.Config, result *CompileResult
 		if rangeSize > 256 && rangeIdx < MaxAppRanges {
 			for _, p := range protos {
 				if rangeIdx >= MaxAppRanges {
-					slog.Warn("app_ranges full, falling back to HASH expansion",
+					compileWarn(dp, "app_ranges full, falling back to HASH expansion",
 						"name", appName)
 					break
 				}
@@ -1200,13 +1200,9 @@ func compileDefaultPolicy(dp DataPlane, cfg *config.Config) error {
 		return fmt.Errorf("set default policy: %w", err)
 	}
 	if action == ActionPermit {
-		if !isValidationPass(dp) {
-			slog.Info("default policy compiled", "action", "permit-all")
-		}
+		compileInfo(dp, "default policy compiled", "action", "permit-all")
 	} else {
-		if !isValidationPass(dp) {
-			slog.Info("default policy compiled", "action", "deny-all")
-		}
+		compileInfo(dp, "default policy compiled", "action", "deny-all")
 	}
 	return nil
 }
@@ -1239,15 +1235,13 @@ func compileFlowTimeouts(dp DataPlane, cfg *config.Config) error {
 	// compile whose result was thrown away (#6894 r8 F6).
 	for _, v := range timeouts {
 		if v > 0 {
-			if !isValidationPass(dp) {
-				slog.Info("flow timeouts compiled",
-					"tcp_established", timeouts[FlowTimeoutTCPEstablished],
-					"tcp_initial", timeouts[FlowTimeoutTCPInitial],
-					"tcp_closing", timeouts[FlowTimeoutTCPClosing],
-					"tcp_time_wait", timeouts[FlowTimeoutTCPTimeWait],
-					"udp", timeouts[FlowTimeoutUDP],
-					"icmp", timeouts[FlowTimeoutICMP])
-			}
+			compileInfo(dp, "flow timeouts compiled",
+				"tcp_established", timeouts[FlowTimeoutTCPEstablished],
+				"tcp_initial", timeouts[FlowTimeoutTCPInitial],
+				"tcp_closing", timeouts[FlowTimeoutTCPClosing],
+				"tcp_time_wait", timeouts[FlowTimeoutTCPTimeWait],
+				"udp", timeouts[FlowTimeoutUDP],
+				"icmp", timeouts[FlowTimeoutICMP])
 			break
 		}
 	}
@@ -1327,17 +1321,15 @@ func compileFlowConfig(dp DataPlane, cfg *config.Config, result *CompileResult) 
 		return err
 	}
 
-	if !isValidationPass(dp) {
-		slog.Info("flow config compiled",
-			"tcp_mss_ipsec", fc.TCPMSSIPsec,
-			"tcp_mss_gre_in", fc.TCPMSSGreIn,
-			"tcp_mss_gre_out", fc.TCPMSSGreOut,
-			"allow_dns_reply", fc.AllowDNSReply,
-			"allow_embedded_icmp", fc.AllowEmbeddedICMP,
-			"app_flags", fc.AppFlags,
-			"lo0_filter_v4", fc.Lo0FilterV4,
-			"lo0_filter_v6", fc.Lo0FilterV6)
-	}
+	compileInfo(dp, "flow config compiled",
+		"tcp_mss_ipsec", fc.TCPMSSIPsec,
+		"tcp_mss_gre_in", fc.TCPMSSGreIn,
+		"tcp_mss_gre_out", fc.TCPMSSGreOut,
+		"allow_dns_reply", fc.AllowDNSReply,
+		"allow_embedded_icmp", fc.AllowEmbeddedICMP,
+		"app_flags", fc.AppFlags,
+		"lo0_filter_v4", fc.Lo0FilterV4,
+		"lo0_filter_v6", fc.Lo0FilterV6)
 
 	return nil
 }

--- a/pkg/dataplane/compiler_nat.go
+++ b/pkg/dataplane/compiler_nat.go
@@ -270,7 +270,7 @@ func compileNAT(dp DataPlane, cfg *config.Config, result *CompileResult) error {
 
 		for _, rule := range rs.Rules {
 			if !rule.Then.Interface && rule.Then.PoolName == "" && !rule.Then.Off {
-				slog.Warn("SNAT rule has no action",
+				compileWarn(dp, "SNAT rule has no action",
 					"rule", rule.Name, "rule-set", rs.Name)
 				continue
 			}
@@ -304,14 +304,12 @@ func compileNAT(dp DataPlane, cfg *config.Config, result *CompileResult) error {
 								rs.Name, rule.Name, dstAddr, err)
 						}
 
-						if !isValidationPass(dp) {
-							slog.Info("source NAT off rule compiled",
-								"rule-set", rs.Name, "rule", rule.Name,
-								"from", rs.FromZone, "to", rs.ToZone,
-								"counter_id", counterID,
-								"src_addr_id", srcAddrID, "dst_addr_id", dstAddrID,
-								"src_addr", srcAddr, "dst_addr", dstAddr)
-						}
+						compileInfo(dp, "source NAT off rule compiled",
+							"rule-set", rs.Name, "rule", rule.Name,
+							"from", rs.FromZone, "to", rs.ToZone,
+							"counter_id", counterID,
+							"src_addr_id", srcAddrID, "dst_addr_id", dstAddrID,
+							"src_addr", srcAddr, "dst_addr", dstAddr)
 					}
 				}
 				continue
@@ -326,7 +324,7 @@ func compileNAT(dp DataPlane, cfg *config.Config, result *CompileResult) error {
 				// a pool ID, so the resolution stays load-bearing.
 				toZoneCfg, ok := cfg.Security.Zones[rs.ToZone]
 				if !ok || len(toZoneCfg.Interfaces) == 0 {
-					slog.Warn("to-zone has no interfaces",
+					compileWarn(dp, "to-zone has no interfaces",
 						"zone", rs.ToZone, "rule-set", rs.Name)
 					continue
 				}
@@ -387,18 +385,14 @@ func compileNAT(dp DataPlane, cfg *config.Config, result *CompileResult) error {
 					if unitV6 != nil {
 						v6IPs = append(v6IPs, unitV6)
 					}
-					if !isValidationPass(dp) {
-						slog.Info("SNAT egress IP resolved",
-							"interface", ifaceRef, "ifindex", physIface.Index,
-							"vlan", vlanID, "v4", unitV4, "v6", unitV6)
-					}
+					compileInfo(dp, "SNAT egress IP resolved",
+						"interface", ifaceRef, "ifindex", physIface.Index,
+						"vlan", vlanID, "v4", unitV4, "v6", unitV6)
 				}
 
 				if len(v4IPs) == 0 && len(v6IPs) == 0 {
-					if !isValidationPass(dp) {
-						slog.Warn("no IP addresses for interface SNAT",
-							"zone", rs.ToZone)
-					}
+					compileWarn(dp, "no IP addresses for interface SNAT",
+						"zone", rs.ToZone)
 					continue
 				}
 
@@ -442,7 +436,7 @@ func compileNAT(dp DataPlane, cfg *config.Config, result *CompileResult) error {
 						}
 						ip, _, err := net.ParseCIDR(cidr)
 						if err != nil {
-							slog.Warn("invalid pool address", "addr", addr, "err", err)
+							compileWarn(dp, "invalid pool address", "addr", addr, "err", err)
 							continue
 						}
 						if ip.To4() != nil {
@@ -480,12 +474,10 @@ func compileNAT(dp DataPlane, cfg *config.Config, result *CompileResult) error {
 									pnat.RegisterNATIP(addr, pool.Name)
 								}
 							}
-							if !isValidationPass(dp) {
-								slog.Info("persistent NAT pool registered",
-									"pool", pool.Name,
-									"timeout", timeout,
-									"permit", string(pool.PersistentNAT.Permit))
-							}
+							compileInfo(dp, "persistent NAT pool registered",
+								"pool", pool.Name,
+								"timeout", timeout,
+								"permit", string(pool.PersistentNAT.Permit))
 						}
 					}
 
@@ -520,15 +512,13 @@ func compileNAT(dp DataPlane, cfg *config.Config, result *CompileResult) error {
 							rs.Name, rule.Name, dstAddr, err)
 					}
 
-					if !isValidationPass(dp) {
-						slog.Info("source NAT rule compiled",
-							"rule-set", rs.Name, "rule", rule.Name,
-							"from", rs.FromZone, "to", rs.ToZone,
-							"pool_id", curPoolID,
-							"counter_id", counterID,
-							"src_addr_id", srcAddrID, "dst_addr_id", dstAddrID,
-							"src_addr", srcAddr, "dst_addr", dstAddr)
-					}
+					compileInfo(dp, "source NAT rule compiled",
+						"rule-set", rs.Name, "rule", rule.Name,
+						"from", rs.FromZone, "to", rs.ToZone,
+						"pool_id", curPoolID,
+						"counter_id", counterID,
+						"src_addr_id", srcAddrID, "dst_addr_id", dstAddrID,
+						"src_addr", srcAddr, "dst_addr", dstAddr)
 				}
 			}
 		}
@@ -562,7 +552,7 @@ func compileNAT(dp DataPlane, cfg *config.Config, result *CompileResult) error {
 				// Validate source-address-name if present (config compatibility)
 				if rule.Match.SourceAddressName != "" {
 					if _, ok := result.AddrIDs[rule.Match.SourceAddressName]; !ok {
-						slog.Warn("DNAT source-address-name not found in address-book",
+						compileWarn(dp, "DNAT source-address-name not found in address-book",
 							"rule", rule.Name, "name", rule.Match.SourceAddressName)
 					}
 				}
@@ -570,14 +560,14 @@ func compileNAT(dp DataPlane, cfg *config.Config, result *CompileResult) error {
 				// #3229: validate destination-address-name (config compat)
 				if rule.Match.DestinationAddressName != "" {
 					if _, ok := result.AddrIDs[rule.Match.DestinationAddressName]; !ok {
-						slog.Warn("DNAT destination-address-name not found in address-book",
+						compileWarn(dp, "DNAT destination-address-name not found in address-book",
 							"rule", rule.Name, "name", rule.Match.DestinationAddressName)
 					}
 				}
 
 				// Parse match destination address
 				if rule.Match.DestinationAddress == "" {
-					slog.Warn("DNAT rule has no match destination-address",
+					compileWarn(dp, "DNAT rule has no match destination-address",
 						"rule", rule.Name)
 					continue
 				}
@@ -587,7 +577,7 @@ func compileNAT(dp DataPlane, cfg *config.Config, result *CompileResult) error {
 					// Try as plain IP
 					matchIP = net.ParseIP(rule.Match.DestinationAddress)
 					if matchIP == nil {
-						slog.Warn("invalid DNAT match address",
+						compileWarn(dp, "invalid DNAT match address",
 							"addr", rule.Match.DestinationAddress)
 						continue
 					}
@@ -605,7 +595,7 @@ func compileNAT(dp DataPlane, cfg *config.Config, result *CompileResult) error {
 				if err != nil {
 					poolIP = net.ParseIP(pool.Address)
 					if poolIP == nil {
-						slog.Warn("invalid DNAT pool address",
+						compileWarn(dp, "invalid DNAT pool address",
 							"addr", pool.Address)
 						continue
 					}
@@ -629,29 +619,27 @@ func compileNAT(dp DataPlane, cfg *config.Config, result *CompileResult) error {
 							// Expand application-set to individual terms
 							expanded, eerr := config.ExpandApplicationSet(rule.Match.Application, &cfg.Applications)
 							if eerr != nil {
-								slog.Warn("DNAT expand application-set failed",
+								compileWarn(dp, "DNAT expand application-set failed",
 									"rule", rule.Name, "application", rule.Match.Application, "err", eerr)
 							} else {
 								for _, termName := range expanded {
 									if _, ok := config.ResolveApplication(termName, userApps); !ok {
-										slog.Warn("DNAT application-set term not found",
+										compileWarn(dp, "DNAT application-set term not found",
 											"rule", rule.Name, "term", termName)
 									}
 								}
 							}
 						} else {
-							slog.Warn("DNAT application not found, ignoring",
+							compileWarn(dp, "DNAT application not found, ignoring",
 								"rule", rule.Name, "application", rule.Match.Application)
 						}
 					}
 				}
 
-				if !isValidationPass(dp) {
-					slog.Info("destination NAT rule compiled",
-						"rule-set", rs.Name, "rule", rule.Name,
-						"match_ip", matchIP,
-						"pool", pool.Name, "pool_ip", poolIP)
-				}
+				compileInfo(dp, "destination NAT rule compiled",
+					"rule-set", rs.Name, "rule", rule.Name,
+					"match_ip", matchIP,
+					"pool", pool.Name, "pool_ip", poolIP)
 			}
 		}
 	}
@@ -681,7 +669,7 @@ func compileStaticNAT(dp DataPlane, cfg *config.Config, result *CompileResult) e
 				continue // handled by compileNPTv6
 			}
 			if rule.Match == "" || rule.Then == "" {
-				slog.Warn("static NAT rule missing match or then",
+				compileWarn(dp, "static NAT rule missing match or then",
 					"rule-set", rs.Name, "rule", rule.Name)
 				continue
 			}
@@ -697,7 +685,7 @@ func compileStaticNAT(dp DataPlane, cfg *config.Config, result *CompileResult) e
 			}
 			extIP, _, err := net.ParseCIDR(matchCIDR)
 			if err != nil {
-				slog.Warn("invalid static NAT match address",
+				compileWarn(dp, "invalid static NAT match address",
 					"addr", rule.Match, "err", err)
 				continue
 			}
@@ -713,7 +701,7 @@ func compileStaticNAT(dp DataPlane, cfg *config.Config, result *CompileResult) e
 			}
 			intIP, _, err := net.ParseCIDR(thenCIDR)
 			if err != nil {
-				slog.Warn("invalid static NAT then address",
+				compileWarn(dp, "invalid static NAT then address",
 					"addr", rule.Then, "err", err)
 				continue
 			}
@@ -732,16 +720,14 @@ func compileStaticNAT(dp DataPlane, cfg *config.Config, result *CompileResult) e
 			_ = assignNATCounterID(result, NATCounterTypeStatic, rs.Name, rule.Name)
 
 			count++
-			if !isValidationPass(dp) {
-				slog.Info("static NAT rule compiled",
-					"rule-set", rs.Name, "rule", rule.Name,
-					"external", rule.Match, "internal", rule.Then)
-			}
+			compileInfo(dp, "static NAT rule compiled",
+				"rule-set", rs.Name, "rule", rule.Name,
+				"external", rule.Match, "internal", rule.Then)
 		}
 	}
 
-	if count > 0 && !isValidationPass(dp) {
-		slog.Info("static NAT compilation complete", "entries", count)
+	if count > 0 {
+		compileInfo(dp, "static NAT compilation complete", "entries", count)
 	}
 
 	return nil
@@ -823,7 +809,7 @@ func compileNPTv6(dp DataPlane, cfg *config.Config) error {
 			helperInstalls := nptv6HelperWouldInstall(rule.Match, rule.Then)
 			reject := func(reason string, attrs ...any) error {
 				if !installed || helperInstalls {
-					slog.Warn("nptv6: "+reason, attrs...)
+					compileWarn(dp, "nptv6: "+reason, attrs...)
 					return nil
 				}
 				return fmt.Errorf("rule-set %q rule %q: %s (match %q, nptv6-prefix %q); "+
@@ -907,17 +893,15 @@ func compileNPTv6(dp DataPlane, cfg *config.Config) error {
 			// retired map surface is removed.
 
 			count++
-			if !isValidationPass(dp) {
-				slog.Info("nptv6 rule compiled",
-					"rule-set", rs.Name, "rule", rule.Name,
-					"external", rule.Match, "internal", rule.Then,
-					"prefix_len", extOnes)
-			}
+			compileInfo(dp, "nptv6 rule compiled",
+				"rule-set", rs.Name, "rule", rule.Name,
+				"external", rule.Match, "internal", rule.Then,
+				"prefix_len", extOnes)
 		}
 	}
 
-	if count > 0 && !isValidationPass(dp) {
-		slog.Info("nptv6 compilation complete", "rules", count)
+	if count > 0 {
+		compileInfo(dp, "nptv6 compilation complete", "rules", count)
 	}
 
 	return nil
@@ -943,7 +927,7 @@ func compileNAT64(dp DataPlane, cfg *config.Config, result *CompileResult) error
 	count := uint32(0)
 	for _, rs := range ruleSets {
 		if count >= 4 { // MAX_NAT64_PREFIXES
-			slog.Warn("max NAT64 prefixes exceeded, skipping", "rule-set", rs.Name)
+			compileWarn(dp, "max NAT64 prefixes exceeded, skipping", "rule-set", rs.Name)
 			break
 		}
 
@@ -1001,22 +985,16 @@ func compileNAT64(dp DataPlane, cfg *config.Config, result *CompileResult) error
 				return fmt.Errorf("NAT64 rule-set %q: source pool %q has no valid addresses",
 					rs.Name, pool.Name)
 			}
-			if !isValidationPass(dp) {
-				slog.Info("auto-assigned NAT64 source pool",
-					"pool", pool.Name, "pool_id", newID, "v4_ips", numV4, "v6_ips", numV6)
-			}
+			compileInfo(dp, "auto-assigned NAT64 source pool",
+				"pool", pool.Name, "pool_id", newID, "v4_ips", numV4, "v6_ips", numV6)
 		}
 
-		if !isValidationPass(dp) {
-			slog.Info("compiled NAT64 prefix",
-				"rule-set", rs.Name, "prefix", rs.Prefix,
-				"pool", rs.SourcePool, "pool_id", poolID)
-		}
+		compileInfo(dp, "compiled NAT64 prefix",
+			"rule-set", rs.Name, "prefix", rs.Prefix,
+			"pool", rs.SourcePool, "pool_id", poolID)
 		count++
 	}
 
-	if !isValidationPass(dp) {
-		slog.Info("NAT64 compilation complete", "prefixes", count)
-	}
+	compileInfo(dp, "NAT64 compilation complete", "prefixes", count)
 	return nil
 }

--- a/pkg/dataplane/compiler_prepass_logging_4960_test.go
+++ b/pkg/dataplane/compiler_prepass_logging_4960_test.go
@@ -416,6 +416,54 @@ func TestOverReachArmCoversEveryReachableGate_4960(t *testing.T) {
 			"warnLogLines assertion in TestRealPassStillLogsItsSuccesses_4960",
 	}
 
+	// #6903 routed 20 previously-UNGATED covered-phase records through the
+	// compileInfo / compileWarn choke point. Each one is a new gate, and a gate
+	// this arm does not name can be widened to suppress both passes silently —
+	// which is the whole failure mode the test exists for. These are bound by
+	// TestValidationPassRecordCensus6903, whose fixture drives the malformed-
+	// input branches this file's valid-config fixture never reaches, and whose
+	// SET assertion reds if any of them stops being emitted on the REAL pass.
+	boundByCensus6903 := map[string]string{
+		"compiler.go:bad port for application":                       "app-badport",
+		"compiler.go:bad source-port for application":                "app-badsrcport",
+		"compiler_nat.go:to-zone has no interfaces":                  "rule-set rs2 -> zone dmz",
+		"compiler_nat.go:SNAT rule has no action":                    "rule r-noaction",
+		"compiler_nat.go:invalid pool address":                       "pool p2",
+		"compiler_nat.go:invalid static NAT match address":           "rule s-badmatch",
+		"compiler_nat.go:invalid static NAT then address":            "rule s-badthen",
+		"compiler_nat.go:static NAT rule missing match or then":      "rule s-missing",
+		"compiler_nat.go:invalid DNAT match address":                 "rule d-badmatch",
+		"compiler_nat.go:invalid DNAT pool address":                  "pool dp2",
+		"compiler_nat.go:DNAT rule has no match destination-address": "rule d-nomatch",
+		"compiler_nat.go:DNAT source-address-name not found":         "rule d-badnames",
+		"compiler_nat.go:DNAT destination-address-name not found":    "rule d-badnames",
+	}
+
+	// The residue: converted sites NEITHER fixture drives to the real pass, so
+	// widening one of these would not red anywhere. Recorded as a numbered gap
+	// rather than left out of the arithmetic — a NEW gate still reds the count
+	// below until someone deliberately files it here.
+	unboundGap6903 := map[string]string{
+		"compiler_nat.go:DNAT application not found, ignoring": "unreachable through " +
+			"a full compile: `validate applications` rejects an unresolvable DNAT " +
+			"rule application FATALLY before compileNAT runs, so this warn is dead " +
+			"on the CompileConfig path (measured — the census fixture failed to " +
+			"compile with `application \"no-such-app\" not found`)",
+		"compiler_nat.go:DNAT expand application-set failed": "needs a malformed " +
+			"application-SET; neither fixture defines one",
+		"compiler_nat.go:DNAT application-set term not found": "needs an " +
+			"application-set with a dangling term; neither fixture defines one",
+		"compiler.go:app_ranges full, falling back to HASH expansion": "needs " +
+			"MaxAppRanges large port ranges to overflow the array — a fixture cost " +
+			"out of proportion to one record",
+		"compiler_nat.go:max NAT64 prefixes exceeded, skipping": "needs more than " +
+			"the NAT64 prefix maximum; neither fixture configures NAT64",
+		"compiler_nat.go:nptv6: <reason>": "the message is BUILT at the call site " +
+			"(`\"nptv6: \"+reason`), so it cannot be a static want at all; the " +
+			"census keys on the rendered record and would see it only with an " +
+			"NPTv6 fixture",
+	}
+
 	sites := countValidationPassGates(t)
 	// FLOOR: a scan finding nothing would make the reconciliation vacuous.
 	if sites < 15 {
@@ -423,16 +471,22 @@ func TestOverReachArmCoversEveryReachableGate_4960(t *testing.T) {
 			"sources — the scan is not reaching them, so this test cannot bind "+
 			"the over-reach arm's completeness", sites)
 	}
-	if want := len(gatedRecordWants) + len(unbindable); sites != want {
-		t.Errorf("production carries %d `!isValidationPass(dp)` gate sites, but the "+
-			"over-reach arm accounts for %d (%d entries in gatedRecordWants + %d "+
-			"recorded as separately bound).\n\n"+
+	if want := len(gatedRecordWants) + len(unbindable) +
+		len(boundByCensus6903) + len(unboundGap6903); sites != want {
+		t.Errorf("production carries %d covered-phase gate sites (`isValidationPass` "+
+			"plus the #6903 compileInfo/compileWarn choke point), but the over-reach "+
+			"arm accounts for %d (%d gatedRecordWants + %d unbindable + %d "+
+			"boundByCensus6903 + %d unboundGap6903).\n\n"+
 			"A gate the over-reach arm does not name can be widened to suppress the "+
 			"record on the REAL pass too, and the whole package stays green — the "+
 			"operator loses a record and nothing notices (#6894 r9 F2). Add a want "+
 			"that this fixture actually reaches, or add the site to `unbindable` "+
-			"with the reason it cannot be driven here.",
-			sites, want, len(gatedRecordWants), len(unbindable))
+			"with the reason it cannot be driven here. A site the #6903 census "+
+			"fixture drives instead belongs in boundByCensus6903, and one NEITHER "+
+			"fixture reaches belongs in unboundGap6903 with the reason — that table "+
+			"is the honest count of gates nothing can catch a widening on.",
+			sites, want, len(gatedRecordWants), len(unbindable),
+			len(boundByCensus6903), len(unboundGap6903))
 	}
 }
 
@@ -453,7 +507,19 @@ func countValidationPassGates(t *testing.T) int {
 			if !ok {
 				return true
 			}
-			if id, ok := call.Fun.(*ast.Ident); ok && id.Name == "isValidationPass" {
+			id, ok := call.Fun.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			// #6903 moved the gate off the individual record and into the
+			// compileInfo / compileWarn choke point, so a covered-phase gate
+			// site is now a call to one of those helpers. Counting only
+			// `isValidationPass` after that change found ONE site (the
+			// ungated-by-choke-point screen record in compiler_iface.go) and
+			// the floor below caught it; the scan has to follow the mechanism
+			// or this test silently stops binding anything.
+			switch id.Name {
+			case "isValidationPass", "compileInfo", "compileWarn":
 				n++
 			}
 			return true

--- a/pkg/dataplane/compiler_validate_4960.go
+++ b/pkg/dataplane/compiler_validate_4960.go
@@ -137,6 +137,7 @@ package dataplane
 
 import (
 	"fmt"
+	"log/slog"
 	"net"
 
 	"github.com/vishvananda/netlink"
@@ -524,6 +525,41 @@ func newValidationResult() *CompileResult {
 		ethtoolApplied:      make(map[string]bool),
 		genericXDPIfindexes: make(map[int]bool),
 	}
+}
+
+// compileInfo / compileWarn are the CHOKE POINT for log records emitted inside
+// the validation pre-pass's phases (#6903).
+//
+// The pre-pass runs `validationPhases` against a discarding shim before the
+// real pass runs the same phases against the real dataplane, so any record a
+// covered phase emits unconditionally is printed TWICE for one apply — and the
+// two copies can disagree, which is the operator-facing harm #6894 fixed for
+// `lo0_filter_v4`.
+//
+// A helper rather than ~19 inline `if !isValidationPass(dp)` blocks, because
+// the failure this issue documents is an OMISSION: #6894's gate was correct
+// where wired and simply incomplete, and nothing detected the gap. Inline
+// blocks leave every future site equally forgettable; a helper plus the guard
+// in compiler_validation_gate_6903_test.go makes the omission a test failure.
+//
+// NOT for every log site in these files. A phase the pre-pass does NOT run —
+// `compilePortMirroring`, or `CompileConfig` itself — emits its record exactly
+// once, and routing it through here would DELETE that record rather than
+// de-duplicate it. The predicate is "reached by the pre-pass", which is the
+// `validationPhases` table, not "has dp in scope".
+func compileInfo(dp DataPlane, msg string, args ...any) {
+	if isValidationPass(dp) {
+		return
+	}
+	slog.Info(msg, args...)
+}
+
+// compileWarn is compileInfo for WARN records. See compileInfo.
+func compileWarn(dp DataPlane, msg string, args ...any) {
+	if isValidationPass(dp) {
+		return
+	}
+	slog.Warn(msg, args...)
 }
 
 // isValidationPass reports whether dp is the pre-pass's discarding shim.

--- a/pkg/dataplane/compiler_validation_gate_6903_test.go
+++ b/pkg/dataplane/compiler_validation_gate_6903_test.go
@@ -1,0 +1,442 @@
+package dataplane
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6903 — the validation pre-pass must not duplicate the records its phases
+// emit, AND must not delete records only one pass produces.
+//
+// `CompileConfig` runs `validationPhases` against a discarding shim before the
+// real pass runs the same phases for real. A covered-phase record emitted
+// unconditionally is therefore printed TWICE for one apply, and the copies can
+// disagree — the operator-facing harm #6894 fixed for `lo0_filter_v4`.
+//
+// WHY A CENSUS AND NOT A COUNT OF ONE RECORD. The dangerous mistake here is not
+// a missed duplicate, it is routing a record through the gate that only ONE
+// pass emits — `compilePortMirroring` is not a pre-pass phase, so gating it
+// would delete its record from operator output entirely. A count assertion on
+// one record watches one phase and stays green while another phase's records
+// vanish. So the census asserts the SET of distinct records, which is the
+// condition that catches a deletion.
+
+// censusDP6903 is a full no-op DataPlane that the compiler treats as the REAL
+// pass.
+//
+// Neither existing fixture works: `recordingDP` tripwires on `SetZoneConfig` by
+// design, and BOTH it and `discardingDataPlane` inherit
+// `xpfValidationPass() -> true`, so they present as the pre-pass — see #7754.
+// The explicit override below is what makes this a real-pass fixture, and the
+// zone-phase methods are needed because the pre-pass never reaches them.
+type censusDP6903 struct{ discardingDataPlane }
+
+func (censusDP6903) xpfValidationPass() bool { return false }
+
+func (censusDP6903) SetZoneConfig(uint16, ZoneConfig) error { return nil }
+func (censusDP6903) SetZone(int, uint16, uint16, uint32, uint8, uint8, uint32) error {
+	return nil
+}
+func (censusDP6903) AddTxPort(int) error                            { return nil }
+func (censusDP6903) SetVlanIfaceInfo(int, int, uint16) error        { return nil }
+func (censusDP6903) SetScreenConfig(uint32, ScreenConfig) error     { return nil }
+func (censusDP6903) DeleteStaleIfaceZone(map[IfaceZoneKey]bool)     {}
+func (censusDP6903) DeleteStaleVlanIface(map[uint32]bool)           {}
+func (censusDP6903) ZeroStaleScreenConfigs(uint32)                  {}
+func (censusDP6903) DeleteStaleIfaceFilter(map[IfaceFilterKey]bool) {}
+func (censusDP6903) ZeroStaleFilterConfigs(uint32)                  {}
+func (censusDP6903) SetIfaceFilter(IfaceFilterKey, uint32) error    { return nil }
+func (censusDP6903) SetFilterConfig(uint32, FilterConfig) error     { return nil }
+func (censusDP6903) SetFilterRule(uint32, FilterRule) error         { return nil }
+func (censusDP6903) SetPolicerConfig(uint32, PolicerConfig) error   { return nil }
+func (censusDP6903) SetMirrorConfig(int, int, uint32) error         { return nil }
+func (censusDP6903) ClearMirrorConfigs() error                      { return nil }
+func (censusDP6903) ClearIfaceFilterMap() error                     { return nil }
+func (censusDP6903) ClearFilterConfigs() error                      { return nil }
+func (censusDP6903) ClearPolicerConfigs() error                     { return nil }
+func (censusDP6903) ClearSNATRules() error                          { return nil }
+func (censusDP6903) ClearSNATRulesV6() error                        { return nil }
+func (censusDP6903) ClearNATPoolConfigs() error                     { return nil }
+func (censusDP6903) ClearNATPoolIPs() error                         { return nil }
+func (censusDP6903) ClearStaticNATEntries() error                   { return nil }
+func (censusDP6903) ClearNAT64Configs() error                       { return nil }
+func (censusDP6903) ClearScreenConfigs() error                      { return nil }
+func (censusDP6903) ClearDNATStatic() error                         { return nil }
+func (censusDP6903) ClearDNATStaticV6() error                       { return nil }
+func (censusDP6903) ClearAppRanges() error                          { return nil }
+func (censusDP6903) ClearApplications() error                       { return nil }
+func (censusDP6903) ClearIfaceZoneMap() error                       { return nil }
+func (censusDP6903) ClearVlanIfaceMap() error                       { return nil }
+func (censusDP6903) ClearZonePairPolicies() error                   { return nil }
+func (censusDP6903) ClearSessionCounts() error                      { return nil }
+
+// censusCfg6903 is the fixture, and it SHIPS WITH the assertions that read it —
+// the issue's body warns about the unreproducible `15 -> 22` claim that was
+// bound to a count measured on a fixture nobody recorded.
+//
+// The malformed entries are deliberate and load-bearing. The ungated sites this
+// change converts are warn-on-bad-input (`slog.Warn(...); continue`), so a
+// valid-only config reaches only the happy-path records — which were ALREADY
+// gated, and a census over them measures nothing. Verified: with valid-only NAT
+// this fixture produced 9 distinct records and ZERO duplicates before the fix.
+func censusCfg6903() *config.Config {
+	cfg := failLaterPhaseConfig()
+	// Make it valid: drop the unresolvable application reference.
+	// Two applications with malformed port ranges, referenced by the policy so
+	// compileApplications resolves and warns on them. The base fixture's own
+	// application reference is UNRESOLVABLE (that is what it exists to fail on),
+	// which aborts the phase before any record; these resolve and then warn.
+	cfg.Security.Policies[0].Policies[0].Match.Applications = []string{
+		"app-badport", "app-badsrcport",
+	}
+	cfg.Applications.Applications = map[string]*config.Application{
+		// Reaches "bad port for application".
+		"app-badport": {Name: "app-badport", Protocol: "tcp", DestinationPort: "not-a-port"},
+		// Reaches "bad source-port for application".
+		"app-badsrcport": {
+			Name: "app-badsrcport", Protocol: "tcp",
+			DestinationPort: "80", SourcePort: "not-a-port",
+		},
+	}
+	cfg.Security.Flow.UDPSessionTimeout = 30
+
+	cfg.Security.NAT.SourcePools = map[string]*config.NATPool{
+		"p1": {Name: "p1", Addresses: []string{"203.0.113.10"}},
+		// Reaches "invalid pool address".
+		"p2": {Name: "p2", Addresses: []string{"not-an-address"}},
+	}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{{
+		Name: "rs1", FromZone: "trust", ToZone: "untrust",
+		Rules: []*config.NATRule{
+			{
+				Name:  "r1",
+				Match: config.NATMatch{SourceAddress: "192.0.2.0/24"},
+				Then:  config.NATThen{Type: config.NATSource, PoolName: "p1"},
+			},
+			// Reaches "SNAT rule has no action".
+			{Name: "r-noaction", Match: config.NATMatch{SourceAddress: "192.0.2.0/24"}},
+			{
+				Name:  "r-badpool",
+				Match: config.NATMatch{SourceAddress: "192.0.2.0/24"},
+				Then:  config.NATThen{Type: config.NATSource, PoolName: "p2"},
+			},
+		},
+	}, {
+		// Interface-mode SNAT to a zone that carries no interfaces. Reaches
+		// "to-zone has no interfaces"; zone "dmz" is declared below.
+		Name: "rs2", FromZone: "trust", ToZone: "dmz",
+		Rules: []*config.NATRule{{
+			Name:  "r-noiface",
+			Match: config.NATMatch{SourceAddress: "192.0.2.0/24"},
+			Then:  config.NATThen{Type: config.NATSource, Interface: true},
+		}},
+	}}
+	cfg.Security.Zones["dmz"] = &config.ZoneConfig{Name: "dmz"}
+	cfg.Security.NAT.Static = []*config.StaticNATRuleSet{{
+		Name: "sr1", FromZone: "untrust",
+		Rules: []*config.StaticNATRule{
+			{Name: "s1", Match: "198.51.100.50/32", Then: "192.0.2.50/32"},
+			// Reaches "static NAT rule missing match or then".
+			{Name: "s-missing"},
+			// Reaches "invalid static NAT match address".
+			{Name: "s-badmatch", Match: "not-an-address", Then: "192.0.2.51/32"},
+			// Reaches "invalid static NAT then address".
+			{Name: "s-badthen", Match: "198.51.100.51/32", Then: "not-an-address"},
+		},
+	}}
+	// Destination NAT: one good rule plus one per warn-on-bad-input site. The
+	// DNAT arm is reached only through Destination.RuleSets, so without this
+	// block six converted sites in compileNAT are unreachable by the census and
+	// the over-reach arm has to carry them as unbound.
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		Pools: map[string]*config.NATPool{
+			"dp1": {Name: "dp1", Address: "198.51.100.60/32"},
+			// Reaches "invalid DNAT pool address".
+			"dp2": {Name: "dp2", Address: "not-an-address"},
+		},
+		RuleSets: []*config.NATRuleSet{{
+			Name: "drs1", FromZone: "untrust",
+			Rules: []*config.NATRule{
+				{
+					Name:  "d1",
+					Match: config.NATMatch{DestinationAddress: "198.51.100.80/32"},
+					Then:  config.NATThen{Type: config.NATDestination, PoolName: "dp1"},
+				},
+				// Reaches "DNAT rule has no match destination-address".
+				{
+					Name: "d-nomatch",
+					Then: config.NATThen{Type: config.NATDestination, PoolName: "dp1"},
+				},
+				// Reaches "invalid DNAT match address".
+				{
+					Name:  "d-badmatch",
+					Match: config.NATMatch{DestinationAddress: "not-an-address"},
+					Then:  config.NATThen{Type: config.NATDestination, PoolName: "dp1"},
+				},
+				// Reaches "invalid DNAT pool address".
+				{
+					Name:  "d-badpool",
+					Match: config.NATMatch{DestinationAddress: "198.51.100.70/32"},
+					Then:  config.NATThen{Type: config.NATDestination, PoolName: "dp2"},
+				},
+				// Reaches "DNAT destination-address-name not found in
+				// address-book" and "DNAT source-address-name not found ...".
+				{
+					Name: "d-badnames",
+					Match: config.NATMatch{
+						DestinationAddress:     "198.51.100.90/32",
+						DestinationAddressName: "no-such-addr",
+						SourceAddressName:      "no-such-src",
+					},
+					Then: config.NATThen{Type: config.NATDestination, PoolName: "dp1"},
+				},
+			},
+		}},
+	}
+	return cfg
+}
+
+// censusRecords6903 runs one full compile and returns message -> occurrences.
+func censusRecords6903(t *testing.T) map[string]int {
+	t.Helper()
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(old)
+
+	if _, err := CompileConfig(censusDP6903{}, censusCfg6903(), false); err != nil {
+		t.Fatalf("the census fixture must COMPILE — a failed compile stops early and "+
+			"the census then measures a truncated run: %v", err)
+	}
+	slog.SetDefault(old)
+
+	counts := map[string]int{}
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var m map[string]any
+		if json.Unmarshal([]byte(line), &m) != nil {
+			continue
+		}
+		if lvl, _ := m["level"].(string); lvl != "INFO" && lvl != "WARN" {
+			continue
+		}
+		// Keyed on message AND fields: two DIFFERENT rules legitimately emit
+		// the same message with different values, and a message-only key would
+		// score that as a duplicate. The defect is the SAME record twice.
+		delete(m, "time")
+		keys := make([]string, 0, len(m))
+		for k := range m {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var b strings.Builder
+		for _, k := range keys {
+			v, _ := json.Marshal(m[k])
+			b.WriteString(k)
+			b.WriteByte('=')
+			b.Write(v)
+			b.WriteByte(' ')
+		}
+		counts[b.String()]++
+	}
+	return counts
+}
+
+// TestValidationPassRecordCensus6903 is the acceptance gate: the SET of records
+// is preserved and no record is emitted twice.
+//
+// Both halves matter and they fail differently:
+//
+//   - a MISSING message means a site was gated that only one pass emits — the
+//     record vanished from operator output. That is the mistake this census
+//     exists to catch, and a per-record count assertion cannot see it.
+//   - a message with count > 1 means a covered-phase site is still ungated,
+//     which is the defect #6903 filed.
+func TestValidationPassRecordCensus6903(t *testing.T) {
+	// Pinned membership, produced by censusCfg6903 above. Recorded rather than
+	// derived so a record DISAPPEARING is a failure and not a silently smaller
+	// expected set.
+	want := []string{
+		"DNAT destination-address-name not found in address-book",
+		"DNAT rule has no match destination-address",
+		"DNAT source-address-name not found in address-book",
+		"SNAT rule has no action",
+		"bad port for application",
+		"bad source-port for application",
+		"config compiled to dataplane",
+		"default policy compiled",
+		"destination NAT rule compiled",
+		"flow config compiled",
+		"flow timeouts compiled",
+		"interface not found, skipping",
+		"invalid DNAT match address",
+		"invalid DNAT pool address",
+		"invalid pool address",
+		"invalid static NAT match address",
+		"invalid static NAT then address",
+		"source NAT rule compiled",
+		"static NAT compilation complete",
+		"static NAT rule compiled",
+		"static NAT rule missing match or then",
+		"to-zone has no interfaces",
+	}
+
+	got := censusRecords6903(t)
+
+	present := func(msg string) bool {
+		for rec, n := range got {
+			if n > 0 && strings.Contains(rec, `msg="`+msg+`"`) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, msg := range want {
+		if !present(msg) {
+			t.Errorf("record %q DISAPPEARED. A covered-phase gate was applied to a site "+
+				"only one pass reaches, so the record is gone from operator output "+
+				"entirely rather than de-duplicated (#6903)", msg)
+		}
+	}
+	var dup []string
+	for rec, n := range got {
+		if n > 1 {
+			dup = append(dup, rec)
+		}
+	}
+	sort.Strings(dup)
+	if len(dup) > 0 {
+		t.Errorf("records emitted more than once: %v — a covered phase still logs "+
+			"unconditionally, so one apply prints it on the discarded pre-pass AND "+
+			"the real pass (#6903)", dup)
+	}
+	// Non-vacuity: if the fixture stopped producing records the assertions above
+	// would both pass over an empty map.
+	if len(got) < len(want) {
+		t.Fatalf("census produced %d distinct records, want at least %d — the fixture "+
+			"no longer reaches the sites it exists to measure", len(got), len(want))
+	}
+}
+
+// TestFlowTimeoutRecordEmittedOnce6903 is the issue's own reproduction, kept as
+// a named cell because it is the one an operator would recognise.
+//
+// It asserts the COUNT, not the presence: presence is satisfied by both one
+// copy and two, which is the whole defect.
+func TestFlowTimeoutRecordEmittedOnce6903(t *testing.T) {
+	got := censusRecords6903(t)
+	n := 0
+	for rec, c := range got {
+		if strings.Contains(rec, `msg="flow timeouts compiled"`) {
+			n += c
+		}
+	}
+	if n != 1 {
+		t.Errorf("the flow-timeouts record was emitted %d times, want exactly 1", n)
+	}
+}
+
+// TestCoveredPhasesUseTheLoggingChokePoint6903 is the guard that makes the
+// omission a test failure rather than a silent gap.
+//
+// #6894's gate was correct where wired and simply INCOMPLETE, and nothing
+// detected the gap — which is why #6903 exists. Converting ~19 sites without
+// this leaves the 20th equally forgettable.
+//
+// The rule it encodes is "a function the pre-pass RUNS must not call
+// slog.Info/slog.Warn directly". It is NOT "any function with dp in scope":
+// `compilePortMirroring` has dp and is not a pre-pass phase, so it must keep
+// its raw calls.
+//
+// The covered set is DERIVED from validationPhases' own table rather than
+// hand-listed, so a phase added there is covered without anyone maintaining an
+// allowlist.
+func TestCoveredPhasesUseTheLoggingChokePoint6903(t *testing.T) {
+	gateSrc, err := os.ReadFile("compiler_validate_4960.go")
+	if err != nil {
+		t.Fatalf("read the phase table: %v", err)
+	}
+	// Each row is `{"name", func() error { return compileX(dp, ...) }}`.
+	phaseRe := regexp.MustCompile(`\{"[^"]+",\s*func\(\) error \{ return (\w+)\(`)
+	covered := map[string]bool{}
+	for _, m := range phaseRe.FindAllStringSubmatch(stripComments6903(string(gateSrc)), -1) {
+		covered[m[1]] = true
+	}
+	// FAIL LOUDLY on a derivation that finds nothing: a pattern that sweeps zero
+	// rows would otherwise pass by covering no functions at all.
+	if len(covered) < 5 {
+		t.Fatalf("derived only %d covered phases from validationPhases (%v) — the table's "+
+			"shape changed and this guard is now scanning almost nothing", len(covered), covered)
+	}
+
+	rawRe := regexp.MustCompile(`\bslog\.(Info|Warn)\(`)
+	chokeRe := regexp.MustCompile(`\bcompile(Info|Warn)\(dp,`)
+	funcRe := regexp.MustCompile(`^func (?:\([^)]*\) )?(\w+)`)
+
+	var offenders []string
+	chokeUses := 0
+	for _, path := range []string{"compiler.go", "compiler_nat.go"} {
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		fn := ""
+		for i, line := range strings.Split(stripComments6903(string(src)), "\n") {
+			if m := funcRe.FindStringSubmatch(line); m != nil {
+				fn = m[1]
+			}
+			if chokeRe.MatchString(line) {
+				chokeUses++
+			}
+			if covered[fn] && rawRe.MatchString(line) {
+				offenders = append(offenders, path+":"+itoa6903(i+1)+" in "+fn)
+			}
+		}
+	}
+	// Non-vacuity: a broken choke-point pattern must not pass by matching zero.
+	if chokeUses == 0 {
+		t.Fatal("found no compileInfo/compileWarn calls at all — the choke-point pattern " +
+			"matches nothing, so the offender scan above proves nothing")
+	}
+	if len(offenders) > 0 {
+		t.Errorf("covered phases calling slog directly instead of compileInfo/compileWarn "+
+			"(each is a record the pre-pass duplicates, #6903):\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}
+
+// stripComments6903 removes // and /* */ comments so this guard cannot be
+// satisfied by its own doc comment quoting the pattern it greps for.
+func stripComments6903(s string) string {
+	s = regexp.MustCompile(`(?s)/\*.*?\*/`).ReplaceAllString(s, "")
+	out := make([]string, 0, 512)
+	for _, l := range strings.Split(s, "\n") {
+		if i := strings.Index(l, "//"); i >= 0 {
+			l = l[:i]
+		}
+		out = append(out, l)
+	}
+	return strings.Join(out, "\n")
+}
+
+func itoa6903(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}


### PR DESCRIPTION
Closes #6903

## The decision, first: ONE GATE, not per-site

The #4960 fallible-phase pre-pass runs every `validationPhases` row twice — once
against `discardingDataPlane`, then again for real — so a record emitted inside
a covered phase prints on BOTH passes unless its site gates on
`isValidationPass(dp)`. The issue frames this as "gate the missing sites".

The failure mode is an **omission**, and per-site gating is a convention that
has to be remembered at every new log line. So this adds a choke point —
`compileInfo` / `compileWarn` in `compiler_validate_4960.go` — and routes every
covered-phase record through it: 19 sites that were ungated, plus the 15 that
carried their own inline `if !isValidationPass(dp) { ... }` block, flattened
onto the same helpers. One mechanism, so a raw `slog.Info` inside a covered
phase is wrong on sight.

**The helpers are deliberately not for every log site in these files**, and the
doc comment says so. A record emitted exactly once per apply —
`compilePortMirroring`, `CompileConfig`'s own summary — would be **DELETED** by
routing it here, not de-duplicated. Losing an operator record is worse than
printing one twice, which is why the acceptance gate below leads with the SET
condition.

## Re-derivation: the issue's inventory and its headline example

Re-derived from `git show origin/master:`, not a working tree. Two corrections,
posted on the issue as comment 5447283280:

- The **headline reproduction, `compiler.go:1242`, was already gated** by #6894
  r8 F6. The issue's own example no longer reproduces.
- The real inventory is **19 ungated sites, not the ~40 the issue implies**. The
  gap is lopsided: **12 in `compiler_nat.go` against 4 in `compiler.go`**,
  because the NAT phases grew warn-on-bad-input branches after the gating
  convention was set and never picked it up.

## Acceptance gate: a record census

`TestValidationPassRecordCensus6903` captures every record of one full compile,
keyed on **message AND sorted fields** — a message-only key falsely reports two
different NAT rules as a duplicate — and asserts:

- **(a) the pinned SET is still present, nothing dropped to zero.** The
  load-bearing condition: this is what catches a gate applied to a single-copy
  site.
- **(b) no record appears more than once.**

A valid-only fixture measures nothing here — every site it reaches was already
gated, and the census showed 9 records and ZERO duplicates before the fix. The
fixture therefore carries deliberately malformed input (bad NAT pool, actionless
SNAT rule, three broken static-NAT rules, four DNAT rules, two applications with
unparseable port ranges, an interface-mode rule-set to an interface-less zone),
reaching **22 distinct records, 13 of them at converted sites**.

`TestCoveredPhasesUseTheLoggingChokePoint6903` derives the covered-phase list
from `validationPhases` itself instead of a hand-kept allowlist, so a new
fallible phase inherits the rule. It **strips comments** before scanning — a doc
comment quoting `slog.Info` must neither satisfy nor trip it — and **fails
loudly** if the derivation yields fewer than five phases or zero choke-point
uses, since either makes the scan vacuous.

## The pre-existing over-reach arm caught this change

`TestOverReachArmCoversEveryReachableGate_4960` exists so that a gate widened to
suppress both passes reds somewhere. Its instrument counted `isValidationPass`
call sites; moving the gate into the choke point dropped that count from 17 to
**1**, and its own floor fired:

    found only 1 isValidationPass gate sites across the compiler sources — the
    scan is not reaching them, so this test cannot bind the over-reach arm's
    completeness

That is the arm working, and it is why this change did not silently decommission
it. The scan now follows the mechanism (37 sites), and the 20 newly gated
records are **enrolled, not exempted**:

- **13 in `boundByCensus6903`** — driven to the real pass by the census fixture,
  whose SET assertion reds if any stops being emitted.
- **6 in `unboundGap6903`**, each with the reason no fixture reaches it — the
  honest count of gates nothing can catch a widening on. One is a measurement,
  not a guess: **`"DNAT application not found, ignoring"` is dead on the
  `CompileConfig` path**, because `validate applications` rejects an
  unresolvable DNAT rule application fatally before `compileNAT` runs. The
  census fixture proved it by failing to compile with
  `application "no-such-app" not found`.

A new gate filed in neither table still reds the count.

## Mutations — two, one per assertion

A compound mutation cannot localise; the bound half masks the unbound one. Both
cells ran the FULL package, `-count=1`, no `-run` filter.

| # | Mutation | Result | Collected |
|---|---|---|---|
| control | none | PASS, 0 failed | 600 |
| 1 | one converted site (`"invalid pool address"`) reverted to raw `slog.Warn` | **RED** — census condition **(b)**: `records emitted more than once: [... msg="invalid pool address"]`, plus `TestOverReachArmCoversEveryReachableGate_4960` and `TestCoveredPhasesUseTheLoggingChokePoint6903` | 600 |
| 2 | `compileInfo`'s gate widened to `isValidationPass(dp) \|\| true` | **RED** — census condition **(a)**: 7 records `DISAPPEARED`, plus `TestFlowTimeoutRecordEmittedOnce6903` and `TestRealPassStillLogsItsSuccesses_4960` | 600 |

Both cells collected 600 tests, equal to the control, so neither is a build
break wearing a red's clothes.

## Gates

- `go test ./pkg/dataplane/ -count=1` — ok, 20.3s
- `go test ./pkg/config/ -count=1` — ok, 95.7s
- `go build ./...`, `go vet ./pkg/dataplane/`, `gofmt -l` — clean
- Gated head `4869941ed`, with `origin/master` verified as an ancestor.

## Adjacent finding, filed separately

`recordingDP` embeds `discardingDataPlane` and so **inherits
`xpfValidationPass() bool { return true }`** — a recording fixture that claims to
be the discarded pre-pass. Filed as **#7754** rather than folded in here.

## Docs

`docs/log/6903.md` carries the re-derivation, the one-gate-vs-per-site
reasoning, the census design, the over-reach reconciliation and the mutation
matrix. No operator-facing doc describes this gate — it is an internal
compile-path convention, and the behaviour change an operator sees is only that
duplicated records stop duplicating.
