### PR TITLE
daemon: join AF_XDP workers before the RETH member rename link cycle (#6911)

### DIFF
--- a/docs/reth-mac.md
+++ b/docs/reth-mac.md
@@ -224,6 +224,33 @@ path where this node's forwarding is already down.
 | `pkg/dataplane/userspace/controllers.go` | `userspaceLinkController.PrepareLinkCycle()` — the live production adapter from the daemon hook to the manager |
 | `userspace-dp/src/server/handlers/stop_workers.rs` | helper side of the join; `rebind.rs` is its inverse |
 
+### The rename site cycles the link too (#6911)
+
+`programRethMAC` is not the only place that cycles a RETH member.
+`renameRethMember` performs its own `setDown` -> `setName` -> `setUp`
+(the rename requires the link DOWN, and #3920 makes it own the UP), and
+until #6911 it did so with **no worker join** — the identical hazard,
+one function up.
+
+It now takes the same `beforeCycle func() error`, invoked once a rename
+candidate is confirmed and strictly before `setDown`, and returns `""`
+**without touching the link** if the join fails. A nil hook means "no
+join needed", matching `programRethMAC`'s contract. The daemon wires a
+real hook at the apply site; the lease `PrepareLinkCycle` takes is
+released by the `abandonLinkCycleLease` already deferred over the whole
+apply, so this adds a join rather than a new lifecycle.
+
+**The hazard is latent, not live, and the hook is there because the
+argument for that is unasserted.** `renameRethMember` runs only when
+`LinkByName(targetName)` has already failed; it matches candidates by
+the *virtual* MAC; and the dataplane cannot have resolved a binding to a
+name that did not exist. So no live binding can be torn down today. That
+chain is correct, but it rests on three separate properties of unrelated
+code and none of them is checked anywhere — a future change to any one
+would reopen #5103 silently. Making the two cycle sites symmetric turns
+that into a loud failure for the price of one hook.
+
+
 ## The Link-Cycle Lease Holds the Join Across the Cycle (#6871)
 
 The join above is a **moment, not a barrier**. `PrepareLinkCycle` takes `m.mu`,
@@ -817,7 +844,7 @@ node never terminally publishes a workerless snapshot while reporting success.
 |------|----------|
 | `pkg/cluster/reth.go` | `RethMAC(clusterID, rgID)` -- returns deterministic MAC |
 | `pkg/cluster/reth.go` | `IsVirtualRethMAC(mac)` -- detects virtual RETH pattern |
-| `pkg/daemon/daemon_reth.go` | `renameRethMember()` -- renames a member found by virtual MAC (down → rename → **up**, #3920) |
+| `pkg/daemon/daemon_reth.go` | `renameRethMember()` -- renames a member found by virtual MAC (down → rename → **up**, #3920); takes the same `beforeCycle` AF_XDP worker-join hook as `programRethMAC` (#6911) |
 | `pkg/daemon/daemon_reth.go` | `programRethMAC()` -- sets MAC via netlink (step 2.6 in applyConfig); takes the mandatory `beforeCycle` AF_XDP worker-join hook (#5103) |
 | `pkg/dataplane/compiler.go` | Skips `.link` file when RETH member has virtual MAC |
 

--- a/pkg/daemon/daemon_apply_dataplane.go
+++ b/pkg/daemon/daemon_apply_dataplane.go
@@ -297,7 +297,22 @@ func (d *Daemon) applyDataplaneAndHACore(ctx context.Context, cfg *config.Config
 			// find it by RETH virtual MAC and rename it.
 			if _, err := netlink.LinkByName(linuxName); err != nil {
 				mac := cluster.RethMAC(cc.ClusterID, rethCfg.RedundancyGroup, cc.NodeID)
-				if oldName := renameRethMember(linuxName, mac); oldName != "" {
+				// #6911: renameRethMember cycles the link too, so it gets the
+				// same worker join programRethMAC has had since #5103. The
+				// lease PrepareLinkCycle takes is released by the
+				// abandonLinkCycleLease deferred over this whole apply, so the
+				// rebind is owned exactly as it is for the MAC-programming
+				// cycle — this hook adds a join, not a new lifecycle.
+				renameJoin := func() error {
+					rt := d.dataplane()
+					if rt == nil {
+						return nil
+					}
+					slog.Info("userspace: stopping workers before RETH member rename",
+						"iface", linuxName)
+					return rt.Link().PrepareLinkCycle()
+				}
+				if oldName := renameRethMember(linuxName, mac, renameJoin); oldName != "" {
 					slog.Info("renamed RETH member interface",
 						"from", oldName, "to", linuxName)
 					fixRethLinkFile(linuxName, oldName)

--- a/pkg/daemon/daemon_reth.go
+++ b/pkg/daemon/daemon_reth.go
@@ -244,7 +244,7 @@ var rethLinkOpsFn = rethLinkOps{
 // always no-ops on the just-renamed member. Without this UP the RETH data link
 // would be left administratively DOWN → the interface track detects link-down
 // → the redundancy group demotes → traffic blackhole (#3920).
-func renameRethMember(targetName string, expectedMAC net.HardwareAddr) string {
+func renameRethMember(targetName string, expectedMAC net.HardwareAddr, beforeCycle func() error) string {
 	ops := rethLinkOpsFn
 	ifaces, err := ops.interfaces()
 	if err != nil {
@@ -257,6 +257,28 @@ func renameRethMember(targetName string, expectedMAC net.HardwareAddr) string {
 		link, err := ops.byIndex(iface.Index)
 		if err != nil {
 			return ""
+		}
+		// #6911: the worker join belongs HERE — after a rename candidate is
+		// confirmed (so the hook cannot fire on a scan that cycles nothing) and
+		// strictly BEFORE setDown, the first mutation of the link. This mirrors
+		// programRethMAC's #5103 contract: worker threads live across the link
+		// DOWN, touching UMEM pages the NIC unmaps as it tears down its queues.
+		//
+		// The hazard is LATENT today, not live: renameRethMember runs only when
+		// LinkByName(targetName) already failed, it matches by the VIRTUAL MAC,
+		// and the dataplane cannot have resolved a binding to a name that did
+		// not exist — so there are no live bindings to tear down. That chain
+		// rests on three properties of unrelated code, none of them asserted.
+		// The hook makes the two cycle sites symmetric so a future change to
+		// any of them fails loudly here instead of silently reopening #5103.
+		if beforeCycle != nil {
+			if err := beforeCycle(); err != nil {
+				slog.Warn("skipping RETH member rename: worker join failed",
+					"from", iface.Name, "to", targetName, "err", err)
+				// Abort WITHOUT touching the link — the caller's workers are in
+				// an unknown state and a cycle now is exactly the #5103 hazard.
+				return ""
+			}
 		}
 		// Ensure interface is DOWN for rename.
 		ops.setDown(link)

--- a/pkg/daemon/daemon_reth_rename_up_test.go
+++ b/pkg/daemon/daemon_reth_rename_up_test.go
@@ -91,7 +91,7 @@ func TestRenameRethMemberBringsLinkUpWhenMACMatches(t *testing.T) {
 	var ops []string
 	installFakeRethLinkOps(t, link, &adminUp, &ops, false)
 
-	old := renameRethMember("ge-0-0-1", mac)
+	old := renameRethMember("ge-0-0-1", mac, nil)
 	if old != "enp8s0" {
 		t.Fatalf("renameRethMember returned old name %q, want enp8s0", old)
 	}
@@ -148,7 +148,7 @@ func TestRenameRethMemberUpOnFailedRename(t *testing.T) {
 		},
 	}
 
-	if old := renameRethMember("ge-0-0-1", mac); old != "" {
+	if old := renameRethMember("ge-0-0-1", mac, nil); old != "" {
 		t.Fatalf("expected empty old name on failed rename, got %q", old)
 	}
 	if !adminUp {

--- a/pkg/daemon/reth_rename_worker_join_6911_test.go
+++ b/pkg/daemon/reth_rename_worker_join_6911_test.go
@@ -179,3 +179,58 @@ func TestDaemonPassesRenameRethMemberBeforeCycleHook_6911(t *testing.T) {
 			"is watching a function the daemon no longer calls.", calls)
 	}
 }
+
+// TestRenameRethMemberHookRunsOnTheCallersGoroutine_6911 is the behavioural
+// proof that the #6871 acquisition-site allowlist requires for this call site.
+//
+// The daemon's renameJoin hook takes a link-cycle lease, and the ONLY thing
+// bounding that lease is applyDataplaneAndHACore's deferred
+// abandonLinkCycleLease. The hook is written as a func literal, so no AST fact
+// establishes that it runs inside that defer's extent — being inside it is a
+// property of renameRethMember invoking the callback SYNCHRONOUSLY. A hook that
+// outlived the renameRethMember call could take the lease after the defer has
+// run, and since #6871 round 8 the lease renews itself, so that would suppress
+// the 1 Hz reconcile for the life of the process rather than for one TTL.
+//
+// This is the same obligation, and the same proof, as
+// TestRethMACHookRunsOnTheCallersGoroutine_6871 carries for programRethMAC.
+func TestRenameRethMemberHookRunsOnTheCallersGoroutine_6911(t *testing.T) {
+	mac, err := net.ParseMAC("02:bf:72:01:01:00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := &fakeRethLink{attrs: netlink.LinkAttrs{Index: 7, Name: "enp8s0", HardwareAddr: mac}}
+	adminUp := true
+	var ops []string
+	installFakeRethLinkOps(t, link, &adminUp, &ops, false)
+
+	caller := goIDFromStack()
+	if caller == 0 {
+		t.Fatal("fixture: could not read the test goroutine's id from the runtime.Stack " +
+			"header, so the identity comparison below would compare 0 against 0")
+	}
+
+	ran := false
+	var hookGoID uint64
+	old := renameRethMember("ge-0-0-1", mac, func() error {
+		ran = true
+		hookGoID = goIDFromStack()
+		return nil
+	})
+	if old != "enp8s0" {
+		t.Fatalf("renameRethMember returned %q; on any other path the hook is not "+
+			"invoked at all and this test would assert nothing", old)
+	}
+	if !ran {
+		t.Fatal("the beforeCycle hook never ran on the rename path")
+	}
+	if hookGoID != caller {
+		t.Fatalf("beforeCycle ran on goroutine %d but renameRethMember was called from %d.\n"+
+			"The daemon takes its link-cycle lease inside this hook, and the only thing "+
+			"bounding that lease is applyDataplaneAndHACore's deferred "+
+			"abandonLinkCycleLease. A hook that does not complete within the "+
+			"renameRethMember call can take the lease after that defer has run, and "+
+			"since #6871 round 8 the lease renews itself — so it would suppress the "+
+			"1 Hz reconcile for the life of the process (#6911)", hookGoID, caller)
+	}
+}

--- a/pkg/daemon/reth_rename_worker_join_6911_test.go
+++ b/pkg/daemon/reth_rename_worker_join_6911_test.go
@@ -2,6 +2,9 @@ package daemon
 
 import (
 	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"net"
 	"testing"
 
@@ -119,5 +122,60 @@ func TestRenameRethMemberNilHookStillRenames(t *testing.T) {
 	}
 	if link.attrs.Name != "ge-0-0-1" {
 		t.Fatalf("link not renamed with a nil hook: %q", link.attrs.Name)
+	}
+}
+
+// TestDaemonPassesRenameRethMemberBeforeCycleHook_6911 binds the WIRING, not the
+// function.
+//
+// The behavioural cells above drive renameRethMember directly, so they bind what
+// happens INSIDE it. They do not bind the daemon's call TO it: replacing the
+// hook argument with a literal `nil` at the apply site compiles, keeps all three
+// of them green, and restores the #6911 defect exactly. I measured that — a
+// mutation passing nil at the call site produced ZERO failures across the whole
+// pkg/daemon suite before this test existed.
+//
+// Structured as an AST walk rather than a grep for the same reason as its #5103
+// sibling: a source scan keyed on text can be satisfied by a comment quoting the
+// pattern it looks for, and can silently sweep nothing. packageGoFiles fatals
+// when it finds no non-test files, so a broken sweep fails loudly instead of
+// counting zero call sites and passing.
+func TestDaemonPassesRenameRethMemberBeforeCycleHook_6911(t *testing.T) {
+	fset := token.NewFileSet()
+	calls := 0
+	for _, file := range packageGoFiles(t) {
+		f, err := parser.ParseFile(fset, file, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			id, ok := call.Fun.(*ast.Ident)
+			if !ok || id.Name != "renameRethMember" {
+				return true
+			}
+			calls++
+			if len(call.Args) != 3 {
+				t.Errorf("%s:%d: renameRethMember called with %d args, want 3 — the third "+
+					"is the beforeCycle worker-join hook (#6911)",
+					file, fset.Position(call.Pos()).Line, len(call.Args))
+				return true
+			}
+			if arg, ok := call.Args[2].(*ast.Ident); ok && arg.Name == "nil" {
+				t.Errorf("%s:%d: the daemon passes a nil beforeCycle hook to renameRethMember, "+
+					"so AF_XDP workers are never joined before the rename link cycle — the "+
+					"#6911 defect, restored with every producer-side test still green",
+					file, fset.Position(call.Pos()).Line)
+			}
+			return true
+		})
+	}
+	if calls != 1 {
+		t.Errorf("found %d production renameRethMember call sites, want exactly 1. "+
+			"A second call site would need its own hook, and zero means this canary "+
+			"is watching a function the daemon no longer calls.", calls)
 	}
 }

--- a/pkg/daemon/reth_rename_worker_join_6911_test.go
+++ b/pkg/daemon/reth_rename_worker_join_6911_test.go
@@ -1,0 +1,123 @@
+package daemon
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+// #6911: renameRethMember performs a setDown -> setName -> setUp cycle on a RETH
+// member. That is the same hazard #5103 fixed in programRethMAC — AF_XDP worker
+// threads live across the link DOWN and touch UMEM pages the NIC unmaps as it
+// tears down its queues — so this site needs the same beforeCycle join.
+//
+// The hazard is LATENT today (renameRethMember runs only when the target name
+// does not resolve, so no binding can exist), which is exactly why these guards
+// matter: the reachability argument rests on three properties of unrelated code
+// and none of them is asserted. These tests assert the ORDERING and the ABORT,
+// so a future change that makes the site reachable cannot silently reopen #5103.
+
+// TestRenameRethMemberJoinsWorkersBeforeLinkDown pins the ordering: the join
+// must run strictly BEFORE the first mutation of the link.
+//
+// RED-on-revert: moving the beforeCycle call below ops.setDown leaves
+// opsAtJoin == ["down"], because the fake records every netlink op in order.
+// A test that only asserted "the hook ran" would stay green under that move —
+// which is the whole defect, since a join after the DOWN is no join at all.
+func TestRenameRethMemberJoinsWorkersBeforeLinkDown(t *testing.T) {
+	mac, err := net.ParseMAC("02:bf:72:01:01:00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := &fakeRethLink{attrs: netlink.LinkAttrs{Index: 7, Name: "enp8s0", HardwareAddr: mac}}
+	adminUp := true
+	var ops []string
+	installFakeRethLinkOps(t, link, &adminUp, &ops, false)
+
+	joinRan := false
+	var opsAtJoin []string
+	join := func() error {
+		joinRan = true
+		opsAtJoin = append([]string(nil), ops...)
+		return nil
+	}
+
+	if old := renameRethMember("ge-0-0-1", mac, join); old != "enp8s0" {
+		t.Fatalf("renameRethMember returned %q, want enp8s0", old)
+	}
+	if !joinRan {
+		t.Fatal("the beforeCycle worker join never ran on the rename path (#6911)")
+	}
+	if len(opsAtJoin) != 0 {
+		t.Fatalf("worker join ran AFTER the link was already touched: ops at join = %v.\n"+
+			"The join must precede setDown — workers live across the link DOWN and touch\n"+
+			"UMEM pages the NIC unmaps during queue teardown (#5103, #6911).", opsAtJoin)
+	}
+	// The rename must still complete normally when the join succeeds.
+	if link.attrs.Name != "ge-0-0-1" {
+		t.Fatalf("link not renamed after a successful join: %q", link.attrs.Name)
+	}
+	if !adminUp {
+		t.Fatal("link left administratively DOWN after a successful rename (#3920)")
+	}
+}
+
+// TestRenameRethMemberAbortsWithoutTouchingLinkWhenJoinFails is the paired cell:
+// on a join error the link must be left EXACTLY as found.
+//
+// RED-on-revert: dropping the `return ""` in the error arm lets the rename
+// proceed, so ops becomes ["down", "name:ge-0-0-1", "up"] instead of empty.
+// Asserting the empty-op sequence rather than just the "" return value is what
+// makes this catch a fall-through — a fall-through that then failed for an
+// unrelated reason would also return "".
+func TestRenameRethMemberAbortsWithoutTouchingLinkWhenJoinFails(t *testing.T) {
+	mac, err := net.ParseMAC("02:bf:72:01:01:00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := &fakeRethLink{attrs: netlink.LinkAttrs{Index: 7, Name: "enp8s0", HardwareAddr: mac}}
+	adminUp := true
+	var ops []string
+	installFakeRethLinkOps(t, link, &adminUp, &ops, false)
+
+	join := func() error { return errors.New("worker join refused") }
+
+	if old := renameRethMember("ge-0-0-1", mac, join); old != "" {
+		t.Fatalf("renameRethMember returned %q on a failed join, want \"\"", old)
+	}
+	if len(ops) != 0 {
+		t.Fatalf("link was mutated after the worker join failed: ops = %v.\n"+
+			"A cycle with the workers in an unknown state is precisely the #5103\n"+
+			"hazard this hook exists to avoid — the abort must touch nothing.", ops)
+	}
+	if link.attrs.Name != "enp8s0" {
+		t.Fatalf("link renamed despite a failed join: %q", link.attrs.Name)
+	}
+	if !adminUp {
+		t.Fatal("link left DOWN after an aborted rename — the abort must not touch admin state")
+	}
+}
+
+// TestRenameRethMemberNilHookStillRenames keeps the nil-hook contract explicit,
+// matching programRethMAC's: a nil beforeCycle means "no join needed" and must
+// not change the rename behaviour. Without this, a fix that made the hook
+// mandatory would break every caller with no live dataplane.
+func TestRenameRethMemberNilHookStillRenames(t *testing.T) {
+	mac, err := net.ParseMAC("02:bf:72:01:01:00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := &fakeRethLink{attrs: netlink.LinkAttrs{Index: 7, Name: "enp8s0", HardwareAddr: mac}}
+	adminUp := true
+	var ops []string
+	installFakeRethLinkOps(t, link, &adminUp, &ops, false)
+
+	if old := renameRethMember("ge-0-0-1", mac, nil); old != "enp8s0" {
+		t.Fatalf("renameRethMember with a nil hook returned %q, want enp8s0", old)
+	}
+	if link.attrs.Name != "ge-0-0-1" {
+		t.Fatalf("link not renamed with a nil hook: %q", link.attrs.Name)
+	}
+}

--- a/pkg/dataplane/userspace/link_cycle_acquisition_site_6871_test.go
+++ b/pkg/dataplane/userspace/link_cycle_acquisition_site_6871_test.go
@@ -73,6 +73,15 @@ var linkCycleAcquisitionSites = map[string]acquisitionSite{
 		"defer is a property of programRethMAC invoking the callback synchronously, " +
 		"which no AST fact establishes. The proof is behavioural and lives in the " +
 		"test named by linkCycleUnprovenFormBindings"},
+	"pkg/daemon/daemon_apply_dataplane.go:(*Daemon).applyDataplaneAndHACore: " +
+		"rt.Link().PrepareLinkCycle [in a func literal renameJoin]": {occurrences: 1, reason: "" +
+		"#6911: renameRethMember cycles the member link too (setDown -> setName -> " +
+		"setUp), so it takes the same worker join. Like the site above it sits in " +
+		"step 2.6 of applyDataplaneAndHACore, inside the deferred " +
+		"abandonLinkCycleLease — but it is written in the renameJoin CALLBACK, so " +
+		"containment is a property of renameRethMember invoking it synchronously, " +
+		"which no AST fact establishes. The proof is behavioural and lives in the " +
+		"test named by linkCycleUnprovenFormBindings"},
 	"pkg/dataplane/userspace/controllers.go:(userspaceLinkController).PrepareLinkCycle: " +
 		"c.manager.PrepareLinkCycle": {occurrences: 1, reason: "" +
 		"adapter hop: userspaceLinkController forwards to Manager"},
@@ -121,6 +130,9 @@ var linkCycleUnprovenFormBindings = map[string]string{
 	"pkg/daemon/daemon_apply_dataplane.go:(*Daemon).programRethMACWithWorkerJoin: " +
 		"rt.Link().PrepareLinkCycle [in a func literal beforeCycle]": "" +
 		"TestRethMACHookRunsOnTheCallersGoroutine_6871",
+	"pkg/daemon/daemon_apply_dataplane.go:(*Daemon).applyDataplaneAndHACore: " +
+		"rt.Link().PrepareLinkCycle [in a func literal renameJoin]": "" +
+		"TestRenameRethMemberHookRunsOnTheCallersGoroutine_6911",
 }
 
 // repoRootFromPackage walks up from the test's working directory to the module


### PR DESCRIPTION
`renameRethMember` performs a `setDown` -> `setName` -> `setUp` cycle on a RETH
member link with **no AF_XDP worker join**. That is the identical hazard #5103
fixed in `programRethMAC`: worker threads live across the link DOWN and touch
UMEM pages the NIC unmaps as it tears down its queues. #6871 gave
`programRethMAC` a `beforeCycle` hook that joins workers before `setDown` and
aborts if the join fails; this site had none.

Closes #6911

## The hazard is latent, and that is *why* the hook rather than a comment

`renameRethMember` runs only when `LinkByName(targetName)` has already failed, it
matches candidates by the **virtual** MAC, and the dataplane cannot have resolved
a binding to a name that did not exist — so no live binding can be torn down
today. The reachability argument is correct.

It also rests on three separate properties of unrelated code, **none of them
asserted anywhere**. The issue offered two directions: enforce that argument, or
make the two cycle sites symmetric. Symmetry costs one hook and converts a silent
reopening of #5103 into a loud failure, so that is what this does. The PR does
not claim to fix a live defect.

## What the #6871 guard taught me, mid-change

The first version of this wiring **broke a green master**:
`TestLinkCycleLeaseHasExactlyOneAcquisitionSite_6871` failed, because the hook
takes a link-cycle lease and is therefore a *second* acquisition site.

That guard is right and its failure message is a specification. Since #6871 round
8 the lease renews itself, so a lease taken outside
`applyDataplaneAndHACore`'s deferred `abandonLinkCycleLease` suppresses the 1 Hz
reconcile *for the life of the process*. The new site **is** inside that defer —
but it is written in a callback, so containment is a property of
`renameRethMember` invoking it synchronously, which no AST fact establishes. Per
the guard's own contract, a key carrying `[in a func literal]` owes a
**behavioural proof**, not a prose reason. So this adds
`TestRenameRethMemberHookRunsOnTheCallersGoroutine_6911` and registers it in
`linkCycleUnprovenFormBindings`, mirroring the #5103 site exactly.

I verified that registration is load-bearing rather than decorative: removing the
binding entry while keeping the allowlist entry makes the guard fail.

## Mutation matrix

Fix committed before mutating. Every cell run **full-package** (no `-run`
filter — a filter hides the pre-existing test that may own the property), and
every cell's collected count is checked against control, because a build break
also produces zero failures.

| # | Mutation | vet | collected | Named RED |
|---|---|---|---|---|
| — | control | 0 | 2161 | — (0 failures) |
| M1 | join moved AFTER `setDown` | 0 | 2161 | `TestRenameRethMemberJoinsWorkersBeforeLinkDown`, `TestRenameRethMemberAbortsWithoutTouchingLinkWhenJoinFails` |
| M2 | abort dropped — fall through on join error | 0 | 2161 | `TestRenameRethMemberAbortsWithoutTouchingLinkWhenJoinFails` |
| M3 | production call site passes `nil` | 0 | 2161 | `TestDaemonPassesRenameRethMemberBeforeCycleHook_6911` |
| M4 | binding entry removed, allowlist entry kept | 0 | — | `TestLinkCycleLeaseHasExactlyOneAcquisitionSite_6871` |

**M3 is why the wiring test exists.** Run before that test was written, passing
`nil` at the call site produced **zero** failures across the whole `pkg/daemon`
suite — the hook was bound to the function but not to the wiring. Its first
run was also a **build break** (`declared and not used: renameJoin`, 0 tests
collected), which reads identically to a green if you only count failures; the
cell above is the compilable form.

## Docs

`docs/reth-mac.md` described the worker join as belonging to `programRethMAC`
alone, and its function table listed `renameRethMember` with no mention of a
join. Both corrected, with the latency of the hazard stated.

## Gates

`go build ./...` clean. `go test ./... -count=1` → **68 ok / 0 FAIL**, matching
`origin/master` measured in a separate worktree at `7b8bd5aa4`. `origin/master`
folded into the branch, 0 unmerged paths.

No `make test-failover`: the compiled change is a new callback parameter on a
daemon-local function and its call site. It touches no cluster, VRRP, session
sync or failover code. Say if you want it run anyway and I will queue behind the
cluster lock.
