### PR TITLE
daemon: report a RETH link cycle that happened but failed (#6915)

### DIFF
--- a/docs/log/6915.md
+++ b/docs/log/6915.md
@@ -1,0 +1,50 @@
+# #6915 — a failed cycled-MAC write dropped RETH VIPs with no reconcile
+
+- **Timestamp**: 2026-08-27
+  - **Action**: made `linkCycled` report what it names. `programRethMAC`'s
+    cycled `setHardwareAddr` failure path returned `false` even though `setDown`
+    had already succeeded, so step 2.6b's VIP reconcile — gated on that value
+    through `needLinkCycleRecovery` — was skipped for a cycle that genuinely
+    happened. The DOWN had flushed the VRRP VIPs and the stable RETH link-local,
+    and the member came back UP holding the VRRP role while answering for none
+    of its addresses. The link-up-failure path beside it has always returned
+    `true` after a DOWN, so `false` here was the outlier, not a contract.
+  - **File(s)**: pkg/daemon/daemon_reth.go
+
+- **Timestamp**: 2026-08-27
+  - **Action**: established the blast radius before fixing, rather than
+    inferring it. `ReconcileVIPs` has exactly ONE production caller (the gated
+    one). The 2s `reconcileRGState` tick re-adds only the stable link-local in
+    VRRP mode, and `sendAdvert` swallows its send error at `Debug`, so VRRP
+    never observes the flap and stays MASTER — nothing re-added the VIPs.
+    Direct (no-VRRP) mode was never exposed: the same tick calls
+    `reconcileDirectVIPOwnership` -> `addDirectVIPs` unconditionally, which is
+    idempotent and announces on `added > 0`. So the defect was VRRP-mode only,
+    and unbounded there. Also measured that `linkCycled` genuinely VARIES across
+    the three post-DOWN outcomes (true / false / true) before branching on it.
+  - **File(s)**: none (measurement)
+
+- **Timestamp**: 2026-08-27
+  - **Action**: relocated the rebind owner rather than deleting its guard.
+    With `linkCycled=true` the member leaves through the arm that delegates to
+    step 2.6b2, so the local rollback `NotifyLinkCycle` no longer fires for it —
+    firing both would be the double rebind that gets EBUSY on mlx5 zero-copy
+    queues. `TestCycledMACWriteFailureArmsTheRecoveryGate6915` binds the
+    handoff (the gate is armed) and
+    `TestSetDownFailureDoesNotArmTheRecoveryGate6915` is the paired control (a
+    failed `setDown` cycled nothing, so it must NOT arm and must keep its local
+    rollback). Without the first, dropping the local call count to zero would
+    look like the guard had been deleted.
+  - **File(s)**: pkg/daemon/reth_cycled_mac_vip_reconcile_6915_test.go,
+    pkg/daemon/reth_prepare_abort_recovery_5103_test.go
+
+- **Timestamp**: 2026-08-27
+  - **Action**: corrected every claim the change falsified. The in-tree
+    "AND THE ADDRESS GAP IS DELIBERATE (#6871 F4)" block asserted the carve-out
+    this closes; two passages in `docs/reth-mac.md` and one in
+    `daemon_apply_dataplane.go` said both post-`setDown` failures yield
+    `linkCycled=false`; the outcome table's row moved. Also recorded that the
+    two `true` rows differ in RECOVERABILITY — the link-up failure wrote the
+    MAC so later applies early-return on `bytes.Equal` and never retry `setUp`,
+    while this one did not and is retried.
+  - **File(s)**: docs/reth-mac.md, pkg/daemon/daemon_apply_dataplane.go

--- a/docs/reth-mac.md
+++ b/docs/reth-mac.md
@@ -124,7 +124,9 @@ retries; cycling out from under live workers is not recoverable.
 hook fails, `PrepareLinkCycle` has already disabled `ctrl` (and cleared every
 binding row if that disable could not be verified), and the helper may or may not
 have joined its workers. Nothing downstream re-arms that: the post-cycle rebind is
-gated on `linkCycled` (false — the cycle was aborted), and
+gated on `linkCycled`, false here because the cycle was aborted *before*
+`setDown` — a failed hook never reaches it (#6915: a failure AFTER a successful
+`setDown` does report true, and is re-armed by step 2.6b2), and
 `reapplyAfterDeferredMAC` is gated on `rethMACPending`, which is computed *before*
 `networkd.Apply` — so it is false for an apply whose only member needing a MAC was
 renamed into its config name by that same `networkd.Apply`. (`rethMACPending` is
@@ -160,11 +162,16 @@ failure path — a `stop_workers` that never reaches the helper joins nothing). 
 *successful* join therefore leaves the member just as un-forwarding as a failed
 one — and
 `setDown` and the cycled `setHardwareAddr` are both still fallible after it
-returns. Both of those yield `linkCycled=false`, i.e. exactly the state above:
-prepare applied, cycle not completed, and neither `linkCycled` nor
-`rethMACPending` able to re-arm it. Keying the rollback on the hook's own error
-let those two escape with a nil commit error and no rebind — `ctrl` off, transit
-dropped, commit green. So `programRethMACWithWorkerJoin` records that the hook
+returns. Keying the rollback on the hook's own error let both escape with a nil
+commit error and no rebind — `ctrl` off, transit dropped, commit green.
+
+Of those two, only a failed `setDown` still yields `linkCycled=false` and the
+state above (prepare applied, cycle not completed, neither `linkCycled` nor
+`rethMACPending` able to re-arm it). Since #6915 a failed *cycled* MAC write
+reports `linkCycled=true`, because by then `setDown` has succeeded and the link
+really has cycled; it is re-armed by step 2.6b2 rather than by the rollback here.
+Both still fail the commit, which is what this section is about — the rollback
+gate is "the hook RAN", and that is unchanged. So `programRethMACWithWorkerJoin` records that the hook
 ran (after its `d.dp == nil` guard, which keeps the rollback unreachable with no
 dataplane attached) and rolls back on any subsequent failure:
 
@@ -174,17 +181,44 @@ dataplane attached) and rolls back on any subsequent failure:
 | member lookup failed | false | no (hook never ran) | OK — warn-only |
 | join failed | false | `NotifyLinkCycle()` | FAIL |
 | join OK, `setDown` failed | false | `NotifyLinkCycle()` | FAIL |
-| join OK, cycled MAC write failed | false | `NotifyLinkCycle()` | FAIL |
+| join OK, cycled MAC write failed | **true** (#6915) | no — step 2.6b2 owns it | FAIL |
 | join OK, cycle ran, `link-up` failed | **true** | no — step 2.6b2 owns it | FAIL |
 | join OK, cycle completed | true | no — step 2.6b2 owns it | OK |
 
-The last-but-one row is the only failure in the class that does *not* roll back
-here: the cycle completed, so step 2.6b2 already rebinds off `linkCycled`, and
-firing `NotifyLinkCycle()` too would be the double rebind that gets `EBUSY` on
-mlx5 zero-copy queues. It still fails the commit — the member is left
-administratively DOWN after a deliberate teardown. Note that step 2.6b's VIP
-reconcile is likewise gated on `linkCycled`, so a cycled-MAC-write failure still
-skips it; that gap predates #5103 and is unchanged here.
+The last **three** rows are the failures in the class that do *not* roll back
+here: the link cycled, so step 2.6b2 already rebinds off `linkCycled`, and firing
+`NotifyLinkCycle()` too would be the double rebind that gets `EBUSY` on mlx5
+zero-copy queues. They still fail the commit.
+
+`linkCycled` reports whether the link **went DOWN and back UP**, not whether the
+MAC write succeeded (#6915). Those differ in exactly one row — "join OK, cycled
+MAC write failed" — which returned `false` until #6915 even though `setDown` had
+returned nil. A DOWN flushes every kernel address on the member, so that row lost
+the VRRP VIPs and the stable RETH link-local, and step 2.6b's reconcile is gated
+on this same value through `needLinkCycleRecovery`: it was **skipped for a cycle
+that genuinely happened**, and the member came back holding the VRRP role while
+answering for none of its addresses.
+
+Nothing else re-added them, which is why the gate was the whole fix:
+`ReconcileVIPs` has exactly **one** production caller (step 2.6b's), the 2s
+`reconcileRGState` tick re-adds only the *stable link-local* in VRRP mode, and
+`sendAdvert` swallows its send error at `Debug` so VRRP never observes the flap
+and stays MASTER. **Direct (no-VRRP) mode was never exposed**: the same tick calls
+`reconcileDirectVIPOwnership` → `addDirectVIPs` unconditionally, which is
+idempotent and re-adds what the DOWN removed, announcing on `added > 0`. So the
+defect was VRRP-mode only and unbounded there — the addresses returned on the
+next apply that cycled the member, not on any timer.
+
+The two rows that remain `false` are the ones where **no cycle happened at all**:
+a failed join, and a failed `setDown`. Those flushed nothing, so there is nothing
+for step 2.6b to reconcile and no torn-down sockets for step 2.6b2 to rebind —
+which is why the rollback below stays their only owner.
+
+Note the remaining `link-up failed` and `cycled MAC write failed` rows differ in
+recoverability even though both now report `true`: the first wrote the MAC, so
+every later apply early-returns on `bytes.Equal(current, mac)` and never retries
+`setUp` — the member stays administratively DOWN until a restart. The second did
+not, so the next apply retries the whole sequence.
 
 Suppression is per-MEMBER, while step 2.6b2's gate is a per-APPLY accumulator, so
 an apply that mixes an aborted member with a cycled one pays two rebinds. Which

--- a/pkg/daemon/daemon_apply_dataplane.go
+++ b/pkg/daemon/daemon_apply_dataplane.go
@@ -726,10 +726,17 @@ func (d *Daemon) reconcileAfterRethLinkCycle(cfg *config.Config, needLinkCycleRe
 // before it can fail on stop_workers, so a failed join leaves "the outcome is unknown" —
 // but a SUCCEEDED join leaves the workers deliberately stopped, which is the
 // same forwarding state. After it returns nil, setDown and the cycled
-// setHardwareAddr are both still fallible and both yield linkCycled=false. So
-// the gate is "did the hook RUN", not "did the hook FAIL": keying on the hook's
-// own error let those two escape with a nil commit error and no rebind, i.e. a
-// half-applied prepare under a green commit.
+// setHardwareAddr are both still fallible. So the gate is "did the hook RUN",
+// not "did the hook FAIL": keying on the hook's own error let those two escape
+// with a nil commit error and no rebind, i.e. a half-applied prepare under a
+// green commit.
+//
+// #6915: only the setDown failure still yields linkCycled=false. A failed CYCLED
+// MAC write now reports true — setDown has already succeeded by then, so the
+// link really did cycle — and is re-armed by step 2.6b2 rather than by the
+// rollback here. Both still fail the commit; the "did the hook RUN" gate is
+// unchanged, and the sentence above must not be read as a claim about the value
+// both paths return.
 //
 // A half-applied prepare has no other owner:
 //
@@ -798,13 +805,23 @@ func (d *Daemon) programRethMACWithWorkerJoin(ifName string, mac net.HardwareAdd
 		return linkCycled, nil
 	}
 	if linkCycled {
-		// The cycle completed and only link-up failed. Fail the commit — the
-		// member is administratively down, and NOTHING repairs it: the MAC
-		// write succeeded, so every later apply early-returns on
-		// bytes.Equal(current, mac) and never attempts setUp again, and the
-		// only other nlLinkSetUp on a RETH member runs at daemon start. It
-		// stays down until a restart while step 2.6b2 rebinds AF_XDP sockets
-		// onto it.
+		// The link went DOWN and back UP. Since #6915 that is TWO outcomes, not
+		// one, and they differ in whether anything repairs the member:
+		//
+		//   - link-up failed: the MAC write SUCCEEDED, so every later apply
+		//     early-returns on bytes.Equal(current, mac) and never attempts
+		//     setUp again, and the only other nlLinkSetUp on a RETH member runs
+		//     at daemon start. The member stays administratively down until a
+		//     restart while step 2.6b2 rebinds AF_XDP sockets onto it.
+		//   - the CYCLED MAC write failed: the member is back UP (programRethMAC
+		//     does a best-effort setUp on that path) and still carries its old
+		//     MAC, so the next apply does NOT early-return and retries the whole
+		//     sequence. Recoverable, unlike the row above — do not read the
+		//     "NOTHING repairs it" sentence as covering both.
+		//
+		// Both fail the commit, and both reach here rather than the rollback
+		// below for the same reason: the cycle happened, so step 2.6b2 owns the
+		// rebind and step 2.6b owns re-adding the addresses the DOWN flushed.
 		//
 		// Leave the rebind to step 2.6b2, which owns it for every cycled
 		// member. Note that suppression is per-MEMBER while 2.6b2's gate
@@ -856,24 +873,31 @@ func (d *Daemon) programRethMACWithWorkerJoin(ifName string, mac net.HardwareAdd
 	slog.Warn("userspace: RETH MAC link cycle did not complete after the worker join; "+
 		"rebinding AF_XDP sockets so the prepare is not left half-applied",
 		"iface", ifName, "err", err)
-	// AND THE ADDRESS GAP IS DELIBERATE (#6871 F4). One member of THIS class —
-	// join OK, setDown OK, the CYCLED MAC write refused — has already taken the
-	// link DOWN and back UP by the time it arrives here (programRethMAC's
-	// set-mac failure path does a best-effort setUp), and the kernel flushes an
-	// interface's addresses on the way down. It nonetheless returns
-	// linkCycled=false, so it contributes nothing to needLinkCycleRecovery, and
-	// step 2.6b's VIP reconcile is gated on exactly that: it is SKIPPED, and the
-	// member comes back without its VRRP VIPs until some later apply cycles it.
-	// Verified against origin/master: the pre-#5103 code returns false on that
-	// same path, so the gap predates this change and is unchanged by it.
+	// THE ADDRESS GAP IS CLOSED (#6915). This block used to record a deliberate
+	// carve-out: the "join OK, setDown OK, cycled MAC write refused" member had
+	// already taken the link DOWN and back UP by the time it arrived here, the
+	// kernel flushes an interface's addresses on the way down, and it
+	// nonetheless returned linkCycled=false — so it contributed nothing to
+	// needLinkCycleRecovery and step 2.6b's VIP reconcile was skipped for a
+	// cycle that genuinely happened. The member came back holding the VRRP role
+	// with none of the addresses that role answers for, and nothing re-added
+	// them: ReconcileVIPs has exactly ONE production caller (that gated one),
+	// the 2s reconcileRGState tick re-adds only the stable link-local in VRRP
+	// mode, and sendAdvert swallows its send error at Debug so VRRP never
+	// observes the flap and stays MASTER.
 	//
-	// It was attached to the WRONG BRANCH until round 11 — it sat in the
-	// linkCycled==true arm above, where needLinkCycleRecovery is necessarily
-	// true and the reconcile therefore DOES run, so the caveat contradicted the
-	// code it was written against. docs/reth-mac.md's outcome table has always
-	// had it on the right row ("join OK, cycled MAC write failed"), which is why
-	// that doc is the reference for the full table; the shipping artifact still
-	// has to carry the operative fact, which is why it is also here.
+	// programRethMAC now returns linkCycled=true on that path, because the value
+	// reports whether the link CYCLED and not whether the MAC write succeeded —
+	// which is what the link-up-failure row beside it has always meant. That
+	// member therefore leaves through the arm ABOVE, not this one: it arms step
+	// 2.6b (the VIP re-add) and step 2.6b2 (the rebind), and does NOT fire the
+	// local rollback, since doing both would be the double rebind this file
+	// warns gets EBUSY on mlx5 zero-copy queues.
+	//
+	// What still reaches HERE is the class where no cycle happened at all — the
+	// join failed, or setDown itself failed. Those flushed nothing, so there are
+	// no addresses to reconcile and no sockets a cycle tore down; the rollback
+	// below is the only owner of their rebind.
 
 	// NotifyLinkCycle opens with a 1s NIC-settle sleep before it takes the
 	// manager lock, and this call site is INSIDE the per-member RETH loop —

--- a/pkg/daemon/daemon_reth.go
+++ b/pkg/daemon/daemon_reth.go
@@ -389,7 +389,22 @@ func programRethMAC(ifName string, mac net.HardwareAddr, beforeCycle func() erro
 	}
 	if err := ops.setHardwareAddr(link, mac); err != nil {
 		ops.setUp(link) // best-effort restore
-		return false, fmt.Errorf("set mac %s: %w", ifName, err)
+		// #6915: linkCycled reports whether the link WENT DOWN AND BACK UP, not
+		// whether the MAC write succeeded. setDown returned nil on the line
+		// above, so it did — and a DOWN flushes every kernel address on the
+		// interface, including the VRRP VIPs and the stable RETH link-local.
+		// Returning false here told step 2.6b (the VIP reconcile, gated on this
+		// through needLinkCycleRecovery) that no cycle had happened, so the
+		// addresses the cycle had just removed were never re-added: the member
+		// came back UP holding the VRRP role and none of the addresses that role
+		// answers for.
+		//
+		// The two post-setDown failures now agree. The link-up failure below has
+		// always returned true for the same reason, so false here was the
+		// outlier rather than a contract — the value differed on the two sides
+		// of one `if` for outcomes that are identical in the only respect this
+		// return describes.
+		return true, fmt.Errorf("set mac %s: %w", ifName, err)
 	}
 	if err := ops.setUp(link); err != nil {
 		return true, fmt.Errorf("link up %s: %w", ifName, err)

--- a/pkg/daemon/reth_cycled_mac_vip_reconcile_6915_test.go
+++ b/pkg/daemon/reth_cycled_mac_vip_reconcile_6915_test.go
@@ -1,0 +1,117 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+)
+
+// #6915: a cycled-MAC-write failure must still arm the post-cycle recovery.
+//
+// programRethMAC's fallback is DOWN -> set MAC -> UP. When the CYCLED
+// setHardwareAddr fails, the link has already been taken down — and a DOWN
+// flushes every kernel address on the interface, including the VRRP VIPs and
+// the stable RETH link-local. The member then comes back UP holding the VRRP
+// role while answering for none of the addresses that role exists to serve.
+//
+// It used to return linkCycled=false on that path, which is the gate feeding
+// needLinkCycleRecovery, so step 2.6b's ReconcileVIPs / addStableRethLinkLocal
+// was SKIPPED for a cycle that had genuinely happened. Nothing else re-added
+// them: ReconcileVIPs has exactly ONE production caller (that gated one), the
+// 2s reconcileRGState tick re-adds only the stable link-local in VRRP mode, and
+// sendAdvert swallows its send error at Debug so VRRP never observes the flap
+// and stays MASTER. The node stayed VIP-less until some later apply cycled it.
+//
+// Direct (no-VRRP) mode was never exposed: the same 2s tick calls
+// reconcileDirectVIPOwnership -> addDirectVIPs unconditionally, which is
+// idempotent and re-adds what the DOWN removed, announcing on `added > 0`.
+// That asymmetry is why this is bound at the gate rather than at ReconcileVIPs.
+
+// TestCycledMACWriteFailureArmsTheRecoveryGate6915 binds the HANDOFF, which is
+// the part a unit test of programRethMACWithWorkerJoin alone cannot see.
+//
+// Making the cycle honest moves the rebind's owner: with linkCycled=true this
+// member no longer fires the local rollback NotifyLinkCycle (that would be the
+// double rebind the abort path's own comment warns gets EBUSY on mlx5
+// zero-copy queues) and instead arms needLinkCycleRecovery, which is the gate
+// on BOTH step 2.6b (the VIP reconcile this issue is about) and step 2.6b2 (the
+// rebind that used to happen locally).
+//
+// So the sibling test's `wantNotify: 0` is only safe if the gate is genuinely
+// armed. Without this cell, flipping the return would look like it had DELETED
+// the rebind guard rather than relocated it — the local call count drops to
+// zero and nothing observes that anything took it over.
+//
+// RED-on-revert: restore `return false` on programRethMAC's cycled-set-mac
+// failure path and this reds at "recovery gate = false".
+func TestCycledMACWriteFailureArmsTheRecoveryGate6915(t *testing.T) {
+	var events []string
+	withRethOps(t, newFailAfterJoinOps(t, &events, failSetMACCycled))
+	d, lc := newAbortRecoveryDaemon(nil /* the join SUCCEEDS */)
+
+	// needLinkCycleRecovery starts false, exactly as step 2.6 initialises it.
+	commitErr, gate := d.programRethMemberMAC("ge-0-0-1", virtMAC5103, nil, false)
+
+	if lc.prepareCalls != 1 {
+		t.Fatalf("PrepareLinkCycle calls = %d, want 1 — the fixture must reach the "+
+			"hook and have it SUCCEED, or this is a different failure class",
+			lc.prepareCalls)
+	}
+	if !gate {
+		t.Errorf("recovery gate = false, want true. The link went DOWN and back UP, " +
+			"so the kernel flushed the VRRP VIPs and the stable RETH link-local off " +
+			"this member. needLinkCycleRecovery is the ONLY gate on step 2.6b's " +
+			"ReconcileVIPs / addStableRethLinkLocal, and ReconcileVIPs has exactly one " +
+			"production caller — so with the gate down nothing re-adds them and the " +
+			"member holds the VRRP role carrying none of its addresses (#6915)")
+	}
+	// The commit must STILL fail — arming the recovery is not the same as
+	// pretending the MAC write landed. Without this, a change that armed the
+	// gate by swallowing the error would pass the assertion above.
+	if commitErr == nil {
+		t.Error("the commit must FAIL: the MAC write was refused after the dataplane " +
+			"was deliberately torn down. Arming the recovery gate must not launder " +
+			"that into a green commit")
+	}
+	if !errors.Is(commitErr, errRethPrepareLinkCycle) {
+		t.Errorf("commit error must carry errRethPrepareLinkCycle; got %v", commitErr)
+	}
+}
+
+// TestSetDownFailureDoesNotArmTheRecoveryGate6915 is the PAIRED control, and it
+// is what makes the cell above about the DOWN having happened rather than about
+// "any failure arms the gate".
+//
+// setDown FAILING means the link never went down: no addresses were flushed, so
+// there is nothing for step 2.6b to reconcile, and step 2.6b2 must not rebind
+// sockets that were never torn down by a cycle. That row keeps linkCycled=false
+// and keeps its LOCAL rollback rebind, since the join did run.
+//
+// Without this control, `return true` unconditionally from the fallback would
+// satisfy the measurement cell while arming recovery for a cycle that never
+// happened.
+func TestSetDownFailureDoesNotArmTheRecoveryGate6915(t *testing.T) {
+	var events []string
+	withRethOps(t, newFailAfterJoinOps(t, &events, failSetDown))
+	d, lc := newAbortRecoveryDaemon(nil /* the join SUCCEEDS */)
+
+	commitErr, gate := d.programRethMemberMAC("ge-0-0-1", virtMAC5103, nil, false)
+
+	if lc.prepareCalls != 1 {
+		t.Fatalf("PrepareLinkCycle calls = %d, want 1", lc.prepareCalls)
+	}
+	if gate {
+		t.Errorf("recovery gate = true, want false — setDown FAILED, so the link never " +
+			"went down and no address was flushed. Arming step 2.6b here would reconcile " +
+			"VIPs that were never removed, and arming step 2.6b2 would rebind AF_XDP " +
+			"sockets no cycle tore down")
+	}
+	if lc.notifyCalls != 1 {
+		t.Errorf("NotifyLinkCycle calls = %d, want 1 — with the gate correctly down, "+
+			"step 2.6b2 will not rebind, so this path must still own its local rollback "+
+			"or the join leaves every worker stopped with nothing to re-arm them",
+			lc.notifyCalls)
+	}
+	if commitErr == nil {
+		t.Error("the commit must FAIL on an aborted cycle after a successful join")
+	}
+}

--- a/pkg/daemon/reth_prepare_abort_recovery_5103_test.go
+++ b/pkg/daemon/reth_prepare_abort_recovery_5103_test.go
@@ -31,8 +31,13 @@ import (
 //
 // "the join RAN" is the gate, not "the join FAILED": PrepareLinkCycle disables
 // ctrl and stops the workers whether it goes on to succeed or fail, and setDown
-// and the cycled MAC write can then abort the cycle underneath a SUCCESSFUL
-// join. TestRethMACAbortRebindsWhenCycleFailsAfterJoin_5103 covers those two.
+// and the cycled MAC write can then fail underneath a SUCCESSFUL join.
+// TestRethMACAbortRebindsWhenCycleFailsAfterJoin_5103 covers those two — and
+// since #6915 they no longer share an outcome: only a failed setDown aborts the
+// CYCLE (the link never goes down, so this site owns the rollback). A failed
+// cycled MAC write leaves the link already cycled, so it reports
+// linkCycled=true and hands the rebind to step 2.6b2 along with step 2.6b's
+// re-add of the addresses the DOWN flushed.
 
 // abortRecoveryLinkController counts both halves of the link-cycle protocol so a
 // test can tell a rollback rebind from no rebind at all.
@@ -218,18 +223,32 @@ func TestRethMACAbortRebindsWhenCycleFailsAfterJoin_5103(t *testing.T) {
 		step      failStep
 		wantSeq   string
 		wantCause string
+		// #6915: the two rows diverge on whether the link actually CYCLED, and
+		// therefore on who owns the rebind. setDown FAILING means the link never
+		// went down — no cycle, no address loss, and this site must roll back.
+		// The cycled MAC write failing means it DID go down and come back up, so
+		// step 2.6b2 owns the rebind (firing it here too is the double rebind
+		// that gets EBUSY on mlx5 zero-copy queues) and step 2.6b owns the VIP
+		// re-add. Sharing one expectation across both rows is what let the
+		// second one keep a value that described the first.
+		wantLinkCycled bool
+		wantNotify     int
 	}{
 		{
-			name:      "set_down_fails",
-			step:      failSetDown,
-			wantSeq:   "set-mac-live,link-down-FAILED",
-			wantCause: "link down",
+			name:           "set_down_fails",
+			step:           failSetDown,
+			wantSeq:        "set-mac-live,link-down-FAILED",
+			wantCause:      "link down",
+			wantLinkCycled: false,
+			wantNotify:     1,
 		},
 		{
-			name:      "cycled_mac_write_fails",
-			step:      failSetMACCycled,
-			wantSeq:   "set-mac-live,link-down,set-mac-cycled-FAILED,link-up",
-			wantCause: "set mac",
+			name:           "cycled_mac_write_fails",
+			step:           failSetMACCycled,
+			wantSeq:        "set-mac-live,link-down,set-mac-cycled-FAILED,link-up",
+			wantCause:      "set mac",
+			wantLinkCycled: true,
+			wantNotify:     0,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -253,15 +272,23 @@ func TestRethMACAbortRebindsWhenCycleFailsAfterJoin_5103(t *testing.T) {
 				t.Errorf("link sequence = %q, want %q — the fixture must fail the step it "+
 					"claims to", got, tc.wantSeq)
 			}
-			if linkCycled {
-				t.Error("linkCycled must be false when the cycle did not complete")
+			if linkCycled != tc.wantLinkCycled {
+				t.Errorf("linkCycled = %v, want %v — this value reports whether the link "+
+					"WENT DOWN AND BACK UP, not whether the MAC write succeeded (#6915). "+
+					"setDown failing means no cycle; the cycled MAC write failing means the "+
+					"DOWN already flushed every address on the member",
+					linkCycled, tc.wantLinkCycled)
 			}
-			if lc.notifyCalls != 1 {
-				t.Errorf("NotifyLinkCycle calls = %d, want 1: the worker join SUCCEEDED and "+
-					"the cycle then aborted, so ctrl is off and every worker is stopped with "+
-					"nothing to re-arm them — linkCycled is false so step 2.6b2's rebind is "+
-					"skipped, and rethMACPending is false for a member renamed into existence "+
-					"by this apply. Forwarding stays down on this node", lc.notifyCalls)
+			if lc.notifyCalls != tc.wantNotify {
+				t.Errorf("NotifyLinkCycle calls = %d, want %d. The join SUCCEEDED, so ctrl is "+
+					"off and every worker is stopped with nothing to re-arm them unless "+
+					"something rebinds. WHO rebinds depends on whether the link cycled: with "+
+					"linkCycled=false this site owns the rollback (step 2.6b2 is gated off and "+
+					"rethMACPending is false for a member renamed into existence by this "+
+					"apply); with linkCycled=true step 2.6b2 owns it and firing here too is "+
+					"the double rebind that gets EBUSY on mlx5 zero-copy queues. "+
+					"TestCycledMACWriteFailureArmsTheRecoveryGate6915 binds the handoff",
+					lc.notifyCalls, tc.wantNotify)
 			}
 			if commitErr == nil {
 				t.Fatal("the commit must FAIL: the dataplane was deliberately torn down and " +


### PR DESCRIPTION
Closes #6915

## The defect

`programRethMAC`'s fallback is DOWN → set MAC → UP. When the **cycled** `setHardwareAddr` failed it returned `linkCycled=false` — even though `setDown` had returned nil on the line immediately above, so the link really had gone down. A DOWN flushes every kernel address on the interface, so the VRRP VIPs and the stable RETH link-local were already gone.

Step 2.6b's `ReconcileVIPs` / `addStableRethLinkLocal` is gated on exactly that value through `needLinkCycleRecovery`. So the reconcile was **skipped for a cycle that genuinely happened**: the member came back UP holding the VRRP role while answering for none of the addresses that role exists to serve. The MAC-write error is warn-only on this branch, so it was silent.

`linkCycled` reports whether the link **went down and back up**, not whether the MAC write succeeded. The link-up-failure path beside it has always returned `true` for that reason — so `false` here was the outlier, not a contract. The value differed on the two sides of one `if` for outcomes that are identical in the only respect it describes.

## Two things established before the fix

**1. What actually happens to the VIPs — nothing re-adds them, but only in VRRP mode.**

| | VIPs after the DOWN | stable link-local |
|---|---|---|
| **VRRP mode** | **never re-added** | re-added by the 2s tick |
| direct (no-VRRP) mode | re-added by the 2s tick, ≤2s | re-added by the 2s tick |

`ReconcileVIPs` has exactly **one** production caller — the gated one. The 2s `reconcileRGState` tick re-adds only the *stable link-local* in VRRP mode, and `sendAdvert` swallows its send error at `Debug`, so VRRP never observes the flap and stays MASTER. Direct mode was never exposed: the same tick calls `reconcileDirectVIPOwnership` → `addDirectVIPs` unconditionally, which is idempotent and announces on `added > 0`.

So the defect was **VRRP-mode only and unbounded there** — the addresses came back on the next apply that cycled the member, not on any timer. That asymmetry is why the fix is at the gate rather than at `ReconcileVIPs`.

**2. `linkCycled` genuinely varies — measured, not assumed.** A branch on a condition that never varies is a revert wearing the shape of a fix, so I measured all three post-DOWN outcomes through the fake link seam before touching anything:

| case | `linkCycled` | link went DOWN | |
|---|---|---|---|
| cycle succeeds | true | true | consistent |
| **cycled set-mac FAILS** | **false** | **true** | **mismatch — 2.6b skipped** |
| setUp FAILS | true | true | consistent |

Exactly one row disagrees. The condition varies, and the inconsistency is one line.

## The fix, and why it is not just a flipped bool

Returning `true` **relocates the rebind's owner**, and that is the part worth reviewing.

With `linkCycled=true` the member now leaves `programRethMACWithWorkerJoin` through the arm that delegates to step 2.6b2, so it no longer fires the local rollback `NotifyLinkCycle` — firing both would be the double rebind that this file warns gets `EBUSY` on mlx5 zero-copy queues. The rebind did not disappear; it moved to the site that already owns it for the sibling `link-up failed` row.

That is exactly how a guard gets quietly deleted, so it is bound explicitly:

- `TestCycledMACWriteFailureArmsTheRecoveryGate6915` — the **handoff**. Asserts `programRethMemberMAC` returns `needLinkCycleRecovery=true`, which is the gate on *both* 2.6b (the VIP re-add) and 2.6b2 (the rebind). Without this cell, the sibling test's call count dropping to zero would read as a deleted guard rather than a relocated one. It also asserts the commit still **fails**, so a change that armed the gate by swallowing the error cannot pass.
- `TestSetDownFailureDoesNotArmTheRecoveryGate6915` — the **paired control**. A failed `setDown` cycled nothing, so it must *not* arm the gate and must keep its local rollback. Without it, `return true` unconditionally would satisfy the measurement cell.

The sibling `TestRethMACAbortRebindsWhenCycleFailsAfterJoin_5103` had one shared expectation across two rows that now legitimately diverge; its table gained per-row `wantLinkCycled` / `wantNotify` rather than having the assertion loosened.

## Claims this falsified, all corrected

The change makes several in-tree statements false, and this repo treats those as defects rather than staleness:

- `daemon_apply_dataplane.go`'s **"AND THE ADDRESS GAP IS DELIBERATE (#6871 F4)"** block recorded the exact carve-out being closed here. Rewritten to say it is closed, what closed it, and what still reaches that arm.
- Three passages said both post-`setDown` failures yield `linkCycled=false` (one in `daemon_apply_dataplane.go`, two in `docs/reth-mac.md`). Only the `setDown` failure does now.
- `docs/reth-mac.md`'s outcome table row moved to **true / no rollback here**. The table's other rows were verified accurate at master first — my probe measured three of the seven and they matched.
- Recorded a distinction the old text did not need: the two `true` rows differ in **recoverability**. The link-up failure wrote the MAC, so later applies early-return on `bytes.Equal(current, mac)` and never retry `setUp` — the member stays administratively DOWN until a restart. This one did not write it, so the next apply retries the whole sequence. The old "NOTHING repairs it" sentence would have been false for the newly-routed case.

## Mutation matrix

Fix committed **before** mutating. Every cell full-package (`./pkg/daemon/`), `-count=1`, **no `-run` filter**, scored on tests-collected rather than FAIL count.

| # | mutation | cells that RED | collected | buildsig |
|---|---|---|---|---|
| D1 | revert the fix — `return false` on the cycled-set-mac path (**the shipped defect**) | `TestCycledMACWriteFailureArmsTheRecoveryGate6915`, `TestRethMACAbortRebindsWhenCycleFailsAfterJoin_5103` | 2164 | 0 |
| D2 | over-reach — arm on the `setDown` failure too (a cycle that never happened) | `TestSetDownFailureDoesNotArmTheRecoveryGate6915` (the paired control), + sibling | 2164 | 0 |
| D3 | break the gate **wiring** — drop `\|\| linkCycled` from `programRethMemberMAC` | 6 cells incl. `...ArmsTheRecoveryGate6915` | 2164 | 0 |
| D4 | delete the local rollback `NotifyLinkCycle` | 5 cells incl. `...DoesNotArmTheRecoveryGate6915`'s notify assertion | 2164 | 0 |

D2 is the one that matters most for review: it proves the fix is *"the link went down"* and not *"return true on failure"*. D3 binds the wiring rather than the function it calls. D4 confirms that making `wantNotify` per-row did not weaken the `setDown` row's rollback guard.

## Test plan

- [x] `go build ./...` → rc 0
- [x] `go test ./... -count=1` → **rc 0, 68/68 packages** at `33643c850`, `origin/master` folded (MERGE, never rebase), `merge-base --is-ancestor` verified
- [x] Mutation matrix above, full-package, no `-run` filter
- [x] `gofmt` — only my own new file needed formatting; the package is not gofmt-clean at baseline and `gofmt -w` on a directory is a documented scope hazard in this repo, so nothing else was touched
- [x] `docs/reth-mac.md` + `docs/log/6915.md` updated in the same change
- [x] The #6871 link-cycle lease guard (`TestLinkCycleLeaseHasExactlyOneAcquisitionSite_6871`) is green — no `PrepareLinkCycle` call site was added or moved

### `make test-failover` — GREEN, and what that does and does not prove

Run on the loss userspace cluster at this PR head, as a `with-cluster.sh` lock cell (`cluster-deploy && test-failover`), which queued and released cleanly:

```
PASS  fw0 is primary for every redundancy group
PASS  iperf3 target reachable (172.16.80.200)
PASS  fw0 has 10 established sessions / fw1 has 10 synced sessions
PASS  iperf3 survived fw0 reboot (failover to fw1)
PASS  fw0 rejoined as secondary (no auto-preempt)
PASS  fw1 remains primary after fw0 rejoin
PASS  iperf3 survived fw0 rejoin
PASS  fw0 became primary for all RGs after manual failover
PASS  iperf3 survived manual failover
PASS  iperf3 throughput: 22.7000 Gbps (>= 1.0 Gbps)
Failover test: 14 passed, 0 failed
```

`passed + failed == 14`, so no cell went silent — the #6897 class where a sub-Gbit run matches neither branch and the gate summarises "0 failed" having emitted nothing.

**Read this as the regression surface, not as coverage of the fix.** A green run here is evidence about the **unaffected** path only. Reaching the changed line needs a refused live MAC set *and* a refused cycled MAC write on the same member; the cluster's mlx5 VFs accept the live set, so every member on this run took the `linkCycled=false, no cycle` early return and never entered the fallback at all. What the run establishes is that the surrounding failover behaviour — including the manual-failover path whose readiness gate this issue is about — is unchanged. The fixed path itself is bound by the mutation matrix above, not by this.

Recording the distinction explicitly so a future reviewer does not mistake the green for exercise of the defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhHmVt536ZsY2RVEhc8WPV
