### PR TITLE
dataplane: prove a VLAN child before adopting it, and before reading its parent

### DIFF
--- a/docs/log/6916.md
+++ b/docs/log/6916.md
@@ -1,0 +1,150 @@
+# 6916 + 6917 — VLAN child provenance
+
+Two issues, handled as **one root cause with two sites**. The judgement came
+before the diff, from a measurement rather than a reading.
+
+## Re-derivation at `origin/master` (719a8d688)
+
+Both issues' claims hold; every line number had moved.
+
+| Issue cite | Current | Status |
+|---|---|---|
+| #6916 `compiler_iface.go:113` (adoption) | `compiler_iface.go:184` | holds |
+| #6916 `compiler_iface.go:548` (delegation write) | `compiler_iface.go:734` | holds |
+| #6916 `compiler_iface.go:1276` (sweep skip) | `compiler_iface.go:1500` | holds |
+| #6916 `compiler.go:469` (attach skip) | `compiler.go:541` | holds |
+| #6917 `compiler.go:474` (`ParentIndex` read) | `compiler.go:546` | holds |
+
+`ensureVLANSubInterface` had since grown a `created bool` (#4960) and
+`errVLANCreateFailed` (#6893 part 2), but the adoption branch itself was
+untouched: no kind, no `VlanId`, no parent, no `NetNsID`, and `LinkSetUp`'s
+error still discarded.
+
+## One defect or two — the measurement
+
+`genericXDPIfindexes` has **exactly one production writer** across `pkg/` and
+`cmd/`:
+
+```
+pkg/dataplane/compiler_iface.go:734:  result.genericXDPIfindexes[subIfindex] = true   <- only assignment
+pkg/dataplane/compiler_validate_4960.go:526:  genericXDPIfindexes: make(map[int]bool)  <- the make
+```
+
+no whole-map assignment anywhere, and `subIfindex` comes only from
+`ensureVLANSubInterfaceFn`. The guard at `compiler.go:541` means the
+`ParentIndex` read at `:546` is reached **only** for ifindexes that came through
+that adoption.
+
+So the causality runs **#6916 → #6917**: the missing check at adoption is what
+lets a wrong-kind or foreign device reach the read. Fixing adoption removes the
+population. #6917 is therefore shipped as an explicitly-labelled **second belt**,
+not as a claim of independent reachability — a branch on a condition that cannot
+vary is a revert wearing the shape of a fix. Its honest justification is the
+distance between check and use: adoption runs in compile phase 2 through
+`netlink.LinkByName`, the read runs in the attach loop after program load
+through `cachedLinkByIndex`, and the cache holds this child only when a unit MTU
+happens to be configured.
+
+### The third-read question, re-verified
+
+The issue asked whether a third `ParentIndex` read exists on a decision path.
+Swept `pkg/` and `cmd/`: the twin attach loop at `loader.go:348` **does not read
+`ParentIndex` at all** — it `continue`s on every VLAN child unconditionally — so
+on the attach path there are exactly the two sites named, one of which
+(`armproof.go`) #6864 already closed. Reads elsewhere
+(`daemon_ha_fabric.go:44/303/658`, `daemon_apply_dataplane.go:620`,
+`monitoriface/monitor.go:179`, `grpcapi/server_helpers.go:32`,
+`routing/xfrm.go`) are other subsystems and other decisions.
+`routing/xfrm.go:302` is the codebase's existing **good** precedent: it requires
+the concrete type *and* `ParentIndex == 0` before trusting the field.
+
+## What shipped
+
+**Commit 1 (#6916).** `vlanAdoptionRefusal` requires kind `vlan`, a local
+`real_dev`, the configured VLAN ID, and the configured parent ifindex before
+`ensureVLANSubInterface` will adopt a device found at `<phys>.<vid>`. A refusal
+takes the existing soft-skip path — WARN plus an `UnarmedSurface` record — and
+the squatter **never enters `genericXDPIfindexes` at all**, so it is neither
+adopted nor silently excluded from XDP attach.
+
+Deliberately **not** `errVLANCreateFailed`: refusing an entire commit because an
+unrelated device squats a name is a far larger blast radius than #6893 part 2
+took on, on a condition an operator may not be able to clear from the xpf side.
+
+The `UnarmedSurface` reason was hardcoded to `"create failed"`, which would be a
+**false statement** for a refusal — nothing failed to be created, a device is
+present and forwarding — and it is the statement that would send an operator
+looking for a creation error that never happened. A refusal now reads
+`"not adopted"`.
+
+`LinkSetUp`'s error is **logged, not returned**. A failed nudge leaves the child
+DOWN, so nothing forwards and the #6916 harm does not arise; turning a transient
+failure into a skip would instead drop a legitimate child out of the dataplane.
+Scoped by harm, not by the issue's wording.
+
+The kind and namespace rejections are **single-sourced** into
+`vlanDelegationDefect`, which `armproof.go` now calls too. A divergence between
+the two is always a bug: the proof decides whether a surface is covered and the
+adoption decides whether a device becomes that surface.
+
+**Commit 2 (#6917).** The decision is extracted into
+`skipGenericAttachForVLANChild`, which proves kind and namespace before reading
+`ParentIndex`. An unproven device **never skips** — falling through to the
+generic attach is the direction that cannot hide a surface — and a WARN names
+why. Extraction is also what makes it testable: left inline it was three lines
+in the middle of the attach loop that no unit test could reach, so the belt
+would have been unbound code.
+
+## Tests assert PROVENANCE, not presence
+
+Every assertion an existence check can make is answered identically by a device
+xpf created and a foreign device it merely found: the link is there, it has an
+ifindex, it is up, the compile succeeded. So every cell states **which of the two
+happened**.
+
+- `TestVLANAdoptionRefusesWhatItCannotProve_6916` — the predicate, over real
+  `vishvananda/netlink` types rather than fakes, because the production code
+  calls `Link.Type()` and the concrete type is the thing under test: a
+  cross-namespace `*netlink.Veth` (the issue's reproduction), a genuine
+  `*netlink.Vlan` with `NetNsID != -1`, wrong VID, wrong parent, and — the row
+  that stops a predicate that refuses everything — the child xpf would itself
+  have created.
+- `TestEnsureVLANSubInterfaceBindsTheAdoptionGate_6916` — binds the **wiring**.
+  Deleting the call to the predicate leaves the table test entirely green,
+  because the function it tests still works.
+- `TestRefusedVLANNeverEntersTheDelegatedChildSet_6916` — the **consequence**.
+  The refusal is only worth something if the withheld ifindex never reaches
+  `genericXDPIfindexes`, because being in that set is what makes the attach loop
+  skip an interface, and being skipped is the whole harm.
+- `TestGenericAttachSkipRequiresAProvenVLANParent_6917` — paired on the SAME
+  failed-parent input: a proven vlan child skips (or the EEXIST avoidance this
+  branch exists for is silently disabled), an unproven device attaches.
+
+The compile-level cells use a DP embedding `censusDP6903` rather than
+`recordingFilterDP`: the success path reaches `SetVlanIfaceInfo`, and
+`recordingFilterDP` embeds a nil `DataPlane` interface, so that cell would not
+have failed — it would have **panicked** and taken the package binary down,
+turning every other test in the package into a result nobody measured.
+
+## Mutations — six, one per assertion
+
+Full package, `-count=1`, no `-run` filter. Each cell restored before the next.
+
+| # | Mutation | Named RED | Collected |
+|---|---|---|---|
+| control | none | — (0 failed) | 617 |
+| 1 | adoption gate call deleted from `ensureVLANSubInterface` | `TestEnsureVLANSubInterfaceBindsTheAdoptionGate_6916` | 617 |
+| 2 | configured-parent check dropped from `vlanAdoptionRefusal` | `TestVLANAdoptionRefusesWhatItCannotProve_6916` | 617 |
+| 3 | `vlanDelegationDefect` check removed from `skipGenericAttachForVLANChild` | `TestGenericAttachSkipRequiresAProvenVLANParent_6917` | 617 |
+| 4 | refusal reported as `"create failed"` again | `…6916/refused` at the **reason** assertion (line 283) | 617 |
+| 5 | caller treats a refusal as success and delegates anyway | `…6916/refused` at the **delegated-child-set** assertion (line 270) | 617 |
+| 6 | `armproof.go` stops consulting the shared predicate | `TestArmProofNonVLANChildNeverInheritsItsParentIndex` | 617 |
+
+Every cell collected 617 = control, so none is a build break wearing a red's
+clothes. Cells 4 and 5 red the same test at **different lines**, which is why
+they are two mutations: a compound one could not have localised.
+
+**Cell 6 is the one that answers the standing hazard.** Single-sourcing
+decommissions the tests that were counting the old sites — #6903 hit exactly
+this. Here the pre-existing #6864 test still reds after the refactor, so the
+coverage followed the code rather than being quietly dropped.

--- a/pkg/dataplane/armproof.go
+++ b/pkg/dataplane/armproof.go
@@ -634,64 +634,21 @@ func coverDelegated(
 		s.Detail = "vlan child: parent unresolvable: no link"
 		return s
 	}
-	if kind := lnk.Type(); kind != vlanLinkKind {
-		// NOT AN 802.1Q DEVICE — so ParentIndex is not a delegation.
-		//
-		// vishvananda/netlink folds IFLA_LINK into LinkAttrs.ParentIndex in the
-		// COMMON attribute loop, for every link kind, not just vlan. What
-		// IFLA_LINK means is per-kind: a macvlan/ipvlan's lower device, a
-		// tunnel's bound device, and — the sharp one — a veth's PEER, which for
-		// a cross-namespace pair is an ifindex in the FOREIGN namespace and can
-		// numerically alias any local interface. Reading that as a parent lets
-		// an unrelated local interface answer for this surface: alias a
-		// proven-down one and the child inherits SKIPPED; alias a covered
-		// required one and it inherits DELEGATED. Both are UNDER-counts, and an
-		// under-count hides a live forwarding surface with no shim on it, which
-		// is worse for #5275 than the over-count this file already removed.
-		//
-		// Reachable because ensureVLANSubInterface adopts ANY existing device
-		// named "<phys>.<vid>" without checking its kind, and the unmanaged
-		// sweep skips any name whose prefix before '.' is managed — so a
-		// foreign or wrong-kind squatter at that name is recorded as a
-		// delegated child, skipped by the userspace attach loop, and never
-		// cleaned up. That adoption is a separate production defect; this
-		// belt only stops the PROOF from laundering it into a covered count.
-		//
-		// UNCOVERED is the honest reading: nothing here proves a shim covers
-		// this surface. Via is deliberately left ZERO — naming a bogus parent
-		// in the record would repeat the same confusion in the operator's log.
-		s.Detail = fmt.Sprintf(
-			"vlan child: ifindex %d is a %q link, not an 802.1Q vlan — its ParentIndex is not a "+
-				"vlan delegation and proves nothing about this surface", ifidx, kind)
-		return s
-	}
-	if nsid := lnk.Attrs().NetNsID; nsid != netnsIDLocal {
-		// A GENUINE 802.1Q device whose real_dev is in ANOTHER namespace.
-		//
-		// The kind belt above passes it — it really is a vlan — but its
-		// ParentIndex is an ifindex in that foreign namespace, so using it as a
-		// key into isRequired/unarmed/direct lets an unrelated LOCAL interface
-		// that happens to hold the same number answer for this surface: alias a
-		// proven-down one and the child inherits SKIPPED, alias a covered
-		// required one and it inherits DELEGATED. Both are UNDER-counts, which
-		// is the direction that hides a live forwarding surface with no shim.
-		//
-		// And it IS live: the orphan is refused only while its foreign real_dev
-		// is DOWN. Bring that real_dev up in its own namespace and the child
-		// comes up and forwards — measured, see netnsIDLocal. Reachable by the
-		// same route as the wrong-kind squatter: ensureVLANSubInterface adopts
-		// any existing "<phys>.<vid>" without checking where its real_dev
-		// lives, the userspace attach loop skips it as a delegated child, and
-		// the unmanaged sweep leaves it alone because the name's prefix before
-		// '.' is managed.
-		//
-		// Via stays ZERO for the same reason as the wrong-kind branch: printing
-		// a foreign ifindex as a covering parent repeats the confusion in the
-		// operator's log.
-		s.Detail = fmt.Sprintf(
-			"vlan child: ifindex %d is an 802.1Q vlan whose real_dev is in ANOTHER namespace "+
-				"(link-netnsid %d) — its ParentIndex names a foreign ifindex and proves nothing "+
-				"about this surface", ifidx, nsid)
+	// #6916 single-sourced the kind and namespace rejections into
+	// vlanDelegationDefect, which is also what ensureVLANSubInterface now
+	// consults before ADOPTING a device at "<phys>.<vid>". The two must agree:
+	// this proof decides whether a surface is covered, that adoption decides
+	// whether a device becomes the surface, and a device one trusts while the
+	// other refuses it is exactly the state #5275 exists to make impossible.
+	// The long-form reasoning for each rejection moved with the code.
+	//
+	// UNCOVERED is the honest reading of either rejection: nothing here proves
+	// a shim covers this surface. Via is deliberately left ZERO — naming a
+	// bogus parent in the record would repeat the same confusion in the
+	// operator's log, and an under-count that hides a live forwarding surface
+	// is worse for #5275 than the over-count this file already removed.
+	if why := vlanDelegationDefect(lnk); why != "" {
+		s.Detail = "vlan child: " + why + " and proves nothing about this surface"
 		return s
 	}
 	parent := lnk.Attrs().ParentIndex

--- a/pkg/dataplane/compiler.go
+++ b/pkg/dataplane/compiler.go
@@ -176,6 +176,49 @@ func (r *CompileResult) cachedLinkByIndex(idx int) (netlink.Link, error) {
 	return link, nil
 }
 
+// skipGenericAttachForVLANChild reports whether the generic-attach loop should
+// SKIP ifidx entirely because the VLAN parent it delegates to already fell back
+// to generic XDP. Attaching generic XDP to the child as well can raise EEXIST on
+// the parent, since the parent's generic hook already sees the tagged frames
+// (netif_receive_generic_xdp runs before kernel VLAN demuxing in
+// __netif_receive_skb_core).
+//
+// #6917: the parent is read from LinkAttrs.ParentIndex, which is only a VLAN
+// delegation once the KIND and the NAMESPACE are proven — see
+// vlanDelegationDefect. vishvananda/netlink folds IFLA_LINK into that field for
+// every link kind, so on an unproven device it can be a veth's peer or an
+// ifindex belonging to another namespace, free to alias a local interface
+// numerically. Read blind, an aliased value that happens to name a locally
+// failed interface returns true here and the interface gets NO XDP attach at
+// all: a live forwarding surface with no program on it.
+//
+// So an unproven device NEVER skips. Falling through to the generic attach is
+// the direction that cannot hide a surface, and the WARN names why.
+//
+// SECOND BELT, and labelled as one. The only production writer of
+// genericXDPIfindexes is the VLAN-child append in compiler_iface.go, whose
+// ifindex now comes from an adoption that refuses a wrong-kind or foreign
+// device (#6916) — so this is not independently reachable in first-order
+// production and is not claimed to be. What it covers is the distance between
+// check and use: the adoption runs in compile phase 2 through
+// netlink.LinkByName, this runs in the attach loop after program load through
+// cachedLinkByIndex, and the cache holds this child only when a unit MTU
+// happened to be configured. The two are not guaranteed to be looking at the
+// same device.
+func (r *CompileResult) skipGenericAttachForVLANChild(ifidx int, failedNativeXDP map[int]bool) bool {
+	link, err := r.cachedLinkByIndex(ifidx)
+	if err != nil {
+		return false
+	}
+	if why := vlanDelegationDefect(link); why != "" {
+		slog.Warn("VLAN child is not a local 802.1Q delegation; not skipping its "+
+			"XDP attach on an unverifiable parent", "ifindex", ifidx, "why", why)
+		return false
+	}
+	parentIfindex := link.Attrs().ParentIndex
+	return parentIfindex > 0 && failedNativeXDP[parentIfindex]
+}
+
 // peekLinkByIndex resolves idx WITHOUT writing to the result's link caches.
 //
 // cachedLinkByIndex memoises into linkIdxMap and linkCache. The observe-only
@@ -542,11 +585,8 @@ func (m *Manager) Compile(cfg *config.Config) (*CompileResult, error) {
 				if isUserspaceShim {
 					continue // skip VLAN sub-interfaces — parent handles VLAN traffic
 				}
-				if link, err := result.cachedLinkByIndex(ifidx); err == nil {
-					parentIfindex := link.Attrs().ParentIndex
-					if parentIfindex > 0 && failedNativeXDP[parentIfindex] {
-						continue
-					}
+				if result.skipGenericAttachForVLANChild(ifidx, failedNativeXDP) {
+					continue
 				}
 			}
 			if err := m.AttachXDP(ifidx, true); err != nil {

--- a/pkg/dataplane/compiler_iface.go
+++ b/pkg/dataplane/compiler_iface.go
@@ -162,6 +162,28 @@ var errVLANCreateFailed = errors.New("VLAN sub-interface creation failed")
 // CAP_NET_ADMIN. Production leaves it pointing at the real function.
 var ensureVLANSubInterfaceFn = ensureVLANSubInterface
 
+// errVLANAdoptRefused marks a device that already occupies "<phys>.<vid>" but
+// failed vlanAdoptionRefusal (#6916).
+//
+// It is deliberately NOT errVLANCreateFailed. #6893 part 2 fails the whole
+// apply when LinkAdd itself refused, because the device the config asked for
+// does not exist and a filter bound to it would be silently dropped. Here the
+// config's device does not exist EITHER, but the reason is a foreign object
+// squatting the name — refusing the entire commit for that would take a far
+// larger blast radius than #6893 chose, on a condition an operator may not be
+// able to clear from the xpf side. The surface takes the existing soft skip:
+// WARN, an UnarmedSurface record naming the check that refused, and — the
+// point of the fix — the squatter never enters genericXDPIfindexes at all, so
+// it is neither adopted nor silently excluded from XDP attach.
+var errVLANAdoptRefused = errors.New("VLAN sub-interface adoption refused")
+
+// vlanLinkByNameSeam is ensureVLANSubInterface's lookup seam, mirroring
+// linkByIndexSeam in proxyarp.go and linkLister in loader.go. The #6916 proof
+// needs an EXISTING device of the wrong kind at "<phys>.<vid>", which is not
+// reachable in a unit test without netlink and CAP_NET_ADMIN. Production
+// leaves it pointing at the real function.
+var vlanLinkByNameSeam = netlink.LinkByName
+
 // ensureVLANSubInterface creates a Linux VLAN sub-interface if it doesn't exist.
 // Returns the sub-interface's ifindex and whether this call CREATED it.
 //
@@ -173,7 +195,7 @@ var ensureVLANSubInterfaceFn = ensureVLANSubInterface
 // configured" would be true on every apply of a VLAN config and would report
 // nothing; it is true only when this call actually added a link.
 func ensureVLANSubInterface(parentName string, vlanID int) (int, bool, error) {
-	parent, err := netlink.LinkByName(parentName)
+	parent, err := vlanLinkByNameSeam(parentName)
 	if err != nil {
 		return 0, false, fmt.Errorf("parent interface %s: %w", parentName, err)
 	}
@@ -181,11 +203,33 @@ func ensureVLANSubInterface(parentName string, vlanID int) (int, bool, error) {
 	subName := fmt.Sprintf("%s.%d", parentName, vlanID)
 
 	// Check if sub-interface already exists
-	existing, err := netlink.LinkByName(subName)
+	existing, err := vlanLinkByNameSeam(subName)
 	if err == nil {
+		// #6916: PROVE it is ours before adopting it. A device merely NAMED
+		// "<phys>.<vid>" is not necessarily an 802.1Q child of <phys> — see
+		// vlanAdoptionRefusal for what each check stops. Adopting one that is
+		// not puts a live foreign link into the delegated-VLAN-child set, and
+		// the attach loop then skips it on the theory that its parent covers
+		// it, which for a device that is not that parent's child means nothing
+		// covers it.
+		if why := vlanAdoptionRefusal(existing, parent.Attrs().Index, vlanID); why != "" {
+			return 0, false, fmt.Errorf("%w: %s: %s",
+				errVLANAdoptRefused, subName, why)
+		}
 		// Already exists, ensure it's up
 		if existing.Attrs().OperState != netlink.OperUp {
-			netlink.LinkSetUp(existing)
+			// The error is LOGGED, not returned. A failed nudge leaves the
+			// child DOWN, so nothing forwards through it and the #6916 harm
+			// (a live surface with no shim) does not arise; turning a
+			// transient set-up failure into a skip would instead drop a
+			// legitimate child out of the dataplane. Discarding it entirely,
+			// which is what this line did before, left the operator with no
+			// way to see why a configured child never came up.
+			if err := netlink.LinkSetUp(existing); err != nil {
+				slog.Warn("could not bring existing VLAN sub-interface up",
+					"name", subName, "parent", parentName, "vlan_id", vlanID,
+					"err", err)
+			}
 		}
 		// Not counted as a creation: the link was already present. Bringing an
 		// existing link up is a state nudge the next apply repeats idempotently,
@@ -670,9 +714,21 @@ func (st *zoneMapState) mapZoneInterface(dp DataPlane, cfg *config.Config, resul
 			// #5275: same as above — the child was never created, so nothing
 			// forwards through it, but the config asked for it and the compile
 			// succeeds regardless.
+			//
+			// #6916: an ADOPTION REFUSAL reaches here too, and it is a
+			// different fact about the host — the name is occupied by
+			// something xpf will not touch, which is the one case where a
+			// device IS present and forwarding. Reporting it as "create
+			// failed" would be a false statement in the operator's own
+			// record, and it is the statement that would send them looking
+			// for a creation error that never happened.
+			what := "create failed"
+			if errors.Is(err, errVLANAdoptRefused) {
+				what = "not adopted"
+			}
 			result.recordUnarmedSurface(UnarmedSurface{
 				Name:   fmt.Sprintf("%s.%d", physName, vlanID),
-				Reason: fmt.Sprintf("VLAN sub-interface create failed in zone %s: %v", name, err),
+				Reason: fmt.Sprintf("VLAN sub-interface %s in zone %s: %v", what, name, err),
 			})
 			return nil
 		}

--- a/pkg/dataplane/vlan_adoption_provenance_6916_test.go
+++ b/pkg/dataplane/vlan_adoption_provenance_6916_test.go
@@ -1,0 +1,308 @@
+package dataplane
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6916 / #6917 — a device is adopted as xpf's VLAN child only if it can be
+// PROVEN to be one.
+//
+// The trap this file is written against: every assertion an existence check can
+// make is answered identically by a device xpf created and a foreign device it
+// merely found. "There is a link at ge-0-0-2.50" is true in both worlds; so is
+// "it has an ifindex", "it is up", and "the compile succeeded". The defect is
+// entirely about PROVENANCE, so every cell below asserts which of the two
+// happened — refused with a reason, or adopted — and never merely that a
+// device is there.
+//
+// Fixture shapes, all real vishvananda/netlink types rather than fakes, because
+// the production code calls Link.Type() and the concrete type IS the thing
+// under test:
+//
+//	*netlink.Veth  at "<phys>.<vid>"   -> the reproduction in #6916: a
+//	                                     cross-namespace veth whose
+//	                                     ParentIndex is its PEER's ifindex
+//	*netlink.Vlan  NetNsID != -1       -> a GENUINE 802.1Q child whose
+//	                                     real_dev moved to another namespace
+//	*netlink.Vlan  VlanId mismatch     -> right name, wrong tag
+//	*netlink.Vlan  ParentIndex mismatch-> right kind and tag, wrong parent
+//	*netlink.Vlan  all matching        -> the one that must be ADOPTED
+
+const (
+	provPhys6916   = "ge-0-0-2"
+	provVID6916    = 50
+	provParentIdx  = 4242
+	provSubIdx6916 = 4277
+)
+
+func provSubName6916() string { return fmt.Sprintf("%s.%d", provPhys6916, provVID6916) }
+
+// provDP6916 is the dataplane for the mapZoneInterface cells. It embeds
+// censusDP6903 rather than recordingFilterDP because the SUCCESS path reaches
+// SetVlanIfaceInfo, and recordingFilterDP embeds a nil DataPlane interface — so
+// the adopted-child cell would not fail, it would PANIC and take the whole
+// package binary down with it, turning every other test in the package into a
+// result nobody measured.
+type provDP6916 struct{ censusDP6903 }
+
+// goodVLAN6916 is the device xpf itself would have created: kind vlan, local
+// real_dev, the configured VID, delegating to the configured parent.
+func goodVLAN6916() *netlink.Vlan {
+	return &netlink.Vlan{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:        provSubName6916(),
+			Index:       provSubIdx6916,
+			ParentIndex: provParentIdx,
+			NetNsID:     netnsIDLocal,
+			OperState:   netlink.OperUp,
+		},
+		VlanId: provVID6916,
+	}
+}
+
+func TestVLANAdoptionRefusesWhatItCannotProve_6916(t *testing.T) {
+	mutate := func(f func(*netlink.Vlan)) *netlink.Vlan {
+		v := goodVLAN6916()
+		f(v)
+		return v
+	}
+
+	cases := []struct {
+		name string
+		link netlink.Link
+		// wantRefused is the whole point: an existence check cannot tell these
+		// apart, so each row states which side of the adoption decision it is.
+		wantRefused bool
+		wantReason  string
+	}{{
+		name:        "wrong kind: the #6916 cross-namespace veth squatting the name",
+		link:        &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: provSubName6916(), Index: 6, ParentIndex: provParentIdx, NetNsID: netnsIDLocal}},
+		wantRefused: true,
+		wantReason:  "not an 802.1Q vlan",
+	}, {
+		name:        "genuine vlan whose real_dev is in another namespace",
+		link:        mutate(func(v *netlink.Vlan) { v.NetNsID = 0 }),
+		wantRefused: true,
+		wantReason:  "ANOTHER namespace",
+	}, {
+		name:        "vlan carrying a different VID than configured",
+		link:        mutate(func(v *netlink.Vlan) { v.VlanId = provVID6916 + 1 }),
+		wantRefused: true,
+		wantReason:  "not the configured VID",
+	}, {
+		name:        "vlan delegating to a different parent than configured",
+		link:        mutate(func(v *netlink.Vlan) { v.ParentIndex = provParentIdx + 1 }),
+		wantRefused: true,
+		wantReason:  "not the configured parent",
+	}, {
+		name:        "the child xpf would itself have created",
+		link:        goodVLAN6916(),
+		wantRefused: false,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			why := vlanAdoptionRefusal(tc.link, provParentIdx, provVID6916)
+			if tc.wantRefused {
+				if why == "" {
+					t.Fatalf("ADOPTED a device it cannot prove is its VLAN child: %#v.\n"+
+						"That ifindex becomes a delegated VLAN child, and the attach loop "+
+						"skips delegated children because the parent handles their traffic "+
+						"— which for a device that is not that parent's child means NOTHING "+
+						"handles it. It forwards with no shim (#6916).", tc.link)
+				}
+				if !strings.Contains(why, tc.wantReason) {
+					t.Errorf("refused for the wrong reason: got %q, want it to name %q.\n"+
+						"The reason reaches the operator in the UnarmedSurface record; a "+
+						"refusal that does not say WHICH check refused leaves them nothing "+
+						"to act on.", why, tc.wantReason)
+				}
+				return
+			}
+			if why != "" {
+				t.Fatalf("REFUSED the device xpf would itself have created: %q.\n"+
+					"Without this row a predicate that refused unconditionally would "+
+					"satisfy every other row here and break every VLAN config on the box.", why)
+			}
+		})
+	}
+}
+
+// TestEnsureVLANSubInterfaceBindsTheAdoptionGate_6916 binds the WIRING, not the
+// predicate. TestVLANAdoptionRefusesWhatItCannotProve_6916 above proves
+// vlanAdoptionRefusal answers correctly; deleting the call to it from
+// ensureVLANSubInterface leaves that test entirely green, because the function
+// it tests still works. This is the cell that reds.
+func TestEnsureVLANSubInterfaceBindsTheAdoptionGate_6916(t *testing.T) {
+	parent := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: provPhys6916, Index: provParentIdx}}
+
+	withLinks := func(t *testing.T, sub netlink.Link) {
+		t.Helper()
+		orig := vlanLinkByNameSeam
+		t.Cleanup(func() { vlanLinkByNameSeam = orig })
+		vlanLinkByNameSeam = func(name string) (netlink.Link, error) {
+			switch name {
+			case provPhys6916:
+				return parent, nil
+			case provSubName6916():
+				return sub, nil
+			}
+			return nil, fmt.Errorf("no such link %q", name)
+		}
+	}
+
+	t.Run("a foreign device at the name is refused, not adopted", func(t *testing.T) {
+		withLinks(t, &netlink.Veth{LinkAttrs: netlink.LinkAttrs{
+			Name: provSubName6916(), Index: 6, ParentIndex: provParentIdx, NetNsID: netnsIDLocal,
+		}})
+
+		idx, created, err := ensureVLANSubInterface(provPhys6916, provVID6916)
+		if err == nil {
+			t.Fatalf("adopted the squatter: returned ifindex %d, created=%v, no error (#6916)",
+				idx, created)
+		}
+		if !errors.Is(err, errVLANAdoptRefused) {
+			t.Errorf("refusal must carry errVLANAdoptRefused so the caller can tell it "+
+				"apart from a create failure and report the right thing to the operator; "+
+				"got %v", err)
+		}
+		// The ifindex is the payload. Returning it alongside an error would
+		// still let a caller that ignores the error put the squatter into the
+		// delegated-child set.
+		if idx != 0 {
+			t.Errorf("returned ifindex %d with a refusal — a refused adoption must hand "+
+				"back NOTHING usable", idx)
+		}
+		if created {
+			t.Error("reported created=true for a device it did not create (#4960 host-mutation signal)")
+		}
+	})
+
+	t.Run("the child xpf would have created is still adopted", func(t *testing.T) {
+		withLinks(t, goodVLAN6916())
+
+		idx, created, err := ensureVLANSubInterface(provPhys6916, provVID6916)
+		if err != nil {
+			t.Fatalf("refused a legitimate existing VLAN child: %v.\n"+
+				"Without this row the gate could refuse everything and every cell above "+
+				"would still pass.", err)
+		}
+		if idx != provSubIdx6916 {
+			t.Errorf("adopted ifindex %d, want %d", idx, provSubIdx6916)
+		}
+		if created {
+			t.Error("created=true for a link that was already present — that flag is the " +
+				"#4960 signal that the host gained an object the operator must remove")
+		}
+	})
+}
+
+// TestRefusedVLANNeverEntersTheDelegatedChildSet_6916 is the consequence half.
+// The refusal above is only worth anything if the ifindex it withholds never
+// reaches genericXDPIfindexes — that set is what makes the attach loop skip an
+// interface, and being skipped is the whole harm.
+func TestRefusedVLANNeverEntersTheDelegatedChildSet_6916(t *testing.T) {
+	const physName = provPhys6916
+
+	newState := func() *zoneMapState {
+		return &zoneMapState{
+			writtenIfaceZone: map[IfaceZoneKey]bool{},
+			writtenVlanIface: map[uint32]bool{},
+			attached:         map[int]bool{},
+			attachedXDP:      map[int]bool{},
+			tunnelIfindexes:  map[int]bool{},
+		}
+	}
+	newCfg := func() *config.Config {
+		cfg := &config.Config{}
+		cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+			physName: {
+				Name:  physName,
+				Units: map[int]*config.InterfaceUnit{provVID6916: {Number: provVID6916, VlanID: provVID6916}},
+			},
+		}
+		return cfg
+	}
+	newResult := func() *CompileResult {
+		return &CompileResult{
+			ifCache:       map[string]*net.Interface{physName: {Index: provParentIdx, Name: physName}},
+			hostMutations: map[string]bool{},
+			// Pre-seeded so the #5268 fail-closed rx-vlan gate is already
+			// satisfied: this fixture is about adoption provenance, and a
+			// missing ethtool on the test host would otherwise abort the
+			// SUCCESS cell before it reaches the delegated-child append.
+			rxVlanOffCache: map[string]bool{physName: true},
+			ethtoolApplied: map[string]bool{},
+			// High, otherwise-unused ifindexes so the netlink fallbacks in
+			// cachedLinkByIndex MISS on the test host instead of resolving a
+			// real local interface into this fixture.
+			linkCache:           map[string]netlink.Link{},
+			linkIdxMap:          map[int]netlink.Link{},
+			genericXDPIfindexes: map[int]bool{},
+		}
+	}
+
+	orig := ensureVLANSubInterfaceFn
+	t.Cleanup(func() { ensureVLANSubInterfaceFn = orig })
+
+	t.Run("refused: not delegated, and recorded as unarmed", func(t *testing.T) {
+		ensureVLANSubInterfaceFn = func(string, int) (int, bool, error) {
+			return 0, false, fmt.Errorf("%w: %s: ifindex 6 is a %q link, not an 802.1Q vlan",
+				errVLANAdoptRefused, provSubName6916(), "veth")
+		}
+		st, result := newState(), newResult()
+		if err := st.mapZoneInterface(provDP6916{}, newCfg(), result,
+			"trust", &config.ZoneConfig{Name: "trust"}, 1, provSubName6916(),
+			map[string]uint32{}); err != nil {
+			t.Fatalf("an adoption refusal must SOFT-skip the surface, not fail the apply: %v.\n"+
+				"Refusing a whole commit because an unrelated device squats a name is a far "+
+				"larger blast radius than #6893 part 2 took on for a failed create.", err)
+		}
+		if len(result.genericXDPIfindexes) != 0 {
+			t.Fatalf("a refused device reached the delegated-VLAN-child set: %v.\n"+
+				"The attach loop SKIPS that set on the theory the parent covers it, so this "+
+				"is exactly the silent exclusion #6916 reported.", result.genericXDPIfindexes)
+		}
+		if len(result.unarmedSurfaces) != 1 {
+			t.Fatalf("refused surfaces recorded: %d, want 1 — a surface the config asked "+
+				"for and the compile declined to arm must be visible to the operator (#5275)",
+				len(result.unarmedSurfaces))
+		}
+		// The record must not tell the operator a creation failed. Nothing was
+		// created; a device is PRESENT and forwarding, which is the opposite
+		// state and sends them looking for the wrong thing.
+		if got := result.unarmedSurfaces[0].Reason; !strings.Contains(got, "not adopted") {
+			t.Errorf("unarmed record reads %q; a refusal must not be reported as a create "+
+				"failure — nothing failed to be created, a foreign device is present", got)
+		}
+	})
+
+	t.Run("adopted: delegated, exactly as before", func(t *testing.T) {
+		ensureVLANSubInterfaceFn = func(string, int) (int, bool, error) {
+			return provSubIdx6916, false, nil
+		}
+		st, result := newState(), newResult()
+		if err := st.mapZoneInterface(provDP6916{}, newCfg(), result,
+			"trust", &config.ZoneConfig{Name: "trust"}, 1, provSubName6916(),
+			map[string]uint32{}); err != nil {
+			t.Fatalf("a legitimate VLAN child must still compile: %v", err)
+		}
+		if !result.genericXDPIfindexes[provSubIdx6916] {
+			t.Fatalf("a legitimate VLAN child did NOT reach the delegated-child set: %v.\n"+
+				"Without this row the change could simply stop delegating every VLAN child "+
+				"and the refusal cell above would still pass.", result.genericXDPIfindexes)
+		}
+		if len(result.unarmedSurfaces) != 0 {
+			t.Errorf("recorded %d unarmed surfaces for a healthy child, want 0",
+				len(result.unarmedSurfaces))
+		}
+	})
+}

--- a/pkg/dataplane/vlan_attach_parent_proof_6917_test.go
+++ b/pkg/dataplane/vlan_attach_parent_proof_6917_test.go
@@ -1,0 +1,84 @@
+package dataplane
+
+import (
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+// #6917 — the generic-attach decision must not read ParentIndex off a device it
+// has not proven is a local 802.1Q child.
+//
+// PAIRED on the SAME failed-parent input, one axis:
+//
+//	proven vlan, parent in failedNativeXDP     -> SKIP   (the intended behaviour)
+//	unproven device, same parent ifindex       -> ATTACH (the aliasing belt)
+//
+// Without the first row a belt that returned false unconditionally would satisfy
+// the second and silently disable the EEXIST avoidance this loop exists for.
+// Without the second, an aliased ParentIndex sends a live interface down the
+// `continue` path and it gets NO XDP attach at all.
+func TestGenericAttachSkipRequiresAProvenVLANParent_6917(t *testing.T) {
+	const (
+		failedParent = 4310
+		childIdx     = 4311
+	)
+	failed := map[int]bool{failedParent: true}
+
+	newResult := func(child netlink.Link) *CompileResult {
+		return &CompileResult{
+			linkCache:  map[string]netlink.Link{},
+			linkIdxMap: map[int]netlink.Link{childIdx: child},
+		}
+	}
+
+	t.Run("proven vlan child of a failed parent is skipped", func(t *testing.T) {
+		child := &netlink.Vlan{
+			LinkAttrs: netlink.LinkAttrs{Name: "ge-0-0-9.50", Index: childIdx,
+				ParentIndex: failedParent, NetNsID: netnsIDLocal},
+			VlanId: 50,
+		}
+		if !newResult(child).skipGenericAttachForVLANChild(childIdx, failed) {
+			t.Fatal("a genuine local VLAN child whose parent fell back to generic XDP " +
+				"must still be SKIPPED — attaching generic XDP to both can raise EEXIST " +
+				"on the parent, which is what this branch exists to avoid")
+		}
+	})
+
+	// The aliasing rows. Each device carries a ParentIndex that IS in
+	// failedNativeXDP, so the ONLY thing standing between it and a silent
+	// `continue` is the kind/namespace proof.
+	for _, tc := range []struct {
+		name string
+		link netlink.Link
+	}{{
+		name: "veth whose ParentIndex is its cross-namespace PEER",
+		link: &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "ge-0-0-9.50", Index: childIdx,
+			ParentIndex: failedParent, NetNsID: netnsIDLocal}},
+	}, {
+		name: "genuine vlan whose real_dev is in another namespace",
+		link: &netlink.Vlan{LinkAttrs: netlink.LinkAttrs{Name: "ge-0-0-9.50", Index: childIdx,
+			ParentIndex: failedParent, NetNsID: 0}, VlanId: 50},
+	}} {
+		t.Run("unproven: "+tc.name+" is attached, not skipped", func(t *testing.T) {
+			if newResult(tc.link).skipGenericAttachForVLANChild(childIdx, failed) {
+				t.Fatalf("skipped the generic attach on an UNPROVEN device (%T).\n"+
+					"Its ParentIndex is not a VLAN delegation — netlink folds IFLA_LINK "+
+					"into that field for every link kind — so the number matching a "+
+					"locally-failed ifindex proves nothing. Skipping leaves the interface "+
+					"in pendingXDP with NO program attached: a live forwarding surface "+
+					"with no shim (#6917).", tc.link)
+			}
+		})
+	}
+
+	t.Run("unresolvable ifindex does not skip", func(t *testing.T) {
+		if (&CompileResult{
+			linkCache:  map[string]netlink.Link{},
+			linkIdxMap: map[int]netlink.Link{},
+		}).skipGenericAttachForVLANChild(999999, failed) {
+			t.Fatal("skipped on a link that could not be resolved at all — with no link " +
+				"there is no parent to prove, and skipping would hide the surface")
+		}
+	})
+}

--- a/pkg/dataplane/vlan_provenance_6916.go
+++ b/pkg/dataplane/vlan_provenance_6916.go
@@ -1,0 +1,107 @@
+package dataplane
+
+import (
+	"fmt"
+
+	"github.com/vishvananda/netlink"
+)
+
+// This file is the ONE definition of "may this link's ParentIndex be read as an
+// 802.1Q delegation, and may xpf adopt this device as its VLAN child".
+//
+// It exists because the two questions were answered in two places that could
+// drift, and a divergence between them is ALWAYS a bug: the arm-coverage proof
+// (#6864, armproof.go) decides whether a surface is covered, and
+// ensureVLANSubInterface decides whether a device becomes that surface. If the
+// proof trusts a device the compiler refuses — or worse, the compiler adopts a
+// device the proof knows it cannot vouch for — the two disagree about the same
+// physical link, which is precisely the state #5275 exists to make impossible.
+//
+// vishvananda/netlink folds IFLA_LINK into LinkAttrs.ParentIndex in the COMMON
+// attribute loop, for EVERY link kind. What IFLA_LINK means is per-kind: a
+// macvlan/ipvlan's lower device, a tunnel's bound device, and — the sharp one —
+// a veth's PEER, which for a cross-namespace pair is an ifindex in the FOREIGN
+// namespace and can numerically alias any local interface. So ParentIndex is
+// meaningless until the kind is proven, and still meaningless for a genuine
+// vlan whose real_dev lives in another namespace.
+
+// vlanDelegationDefect reports why lnk's ParentIndex may NOT be read as an
+// 802.1Q delegation, or "" when it may.
+//
+// The two rejections are the pair #6864 established, in the order that matters:
+// kind first, because a non-vlan's ParentIndex is not a parent at all, then
+// namespace, because a genuine vlan whose real_dev has moved keeps its kind and
+// keeps a ParentIndex that now names an ifindex in the FOREIGN namespace.
+//
+// That second case is not inert. A hostile review of #6864 reproduced it across
+// three namespaces: the orphan is un-`up`-able only while the foreign real_dev
+// is down, and once that device is up in its own namespace the local child
+// comes up (LinkSetUp rc=0, oper=up) and forwards.
+func vlanDelegationDefect(lnk netlink.Link) string {
+	if lnk == nil {
+		return "no link"
+	}
+	if kind := lnk.Type(); kind != vlanLinkKind {
+		return fmt.Sprintf("ifindex %d is a %q link, not an 802.1Q vlan — its "+
+			"ParentIndex is not a vlan delegation", lnk.Attrs().Index, kind)
+	}
+	if nsid := lnk.Attrs().NetNsID; nsid != netnsIDLocal {
+		return fmt.Sprintf("ifindex %d is an 802.1Q vlan whose real_dev is in "+
+			"ANOTHER namespace (link-netnsid %d) — its ParentIndex names a "+
+			"foreign ifindex", lnk.Attrs().Index, nsid)
+	}
+	return ""
+}
+
+// vlanAdoptionRefusal reports why the device already occupying "<phys>.<vid>"
+// must NOT be adopted as xpf's VLAN child for wantParent/wantVID, or "" when it
+// may be.
+//
+// #6916: the adoption used to be unconditional — LinkByName succeeded, so the
+// ifindex was taken. That ifindex then becomes a delegated VLAN child
+// (compiler_iface.go, the sole writer of genericXDPIfindexes), and the attach
+// loop SKIPS delegated children because "the parent handles VLAN traffic". For
+// a device that is not actually a child of that parent, nothing handles its
+// traffic: it forwards with no shim on it, and the unmanaged sweep will not
+// remove it either, because it deliberately skips any name whose prefix before
+// '.' is a managed interface.
+//
+// So the checks are not tidiness. Each one is a way for a live foreign device
+// to end up excluded from XDP attach:
+//
+//   - KIND and NAMESPACE, via vlanDelegationDefect above.
+//   - VLAN ID, because a vlan at "p0.100" carrying VID 200 is a different
+//     surface from the one the config asked for, and the vlan_iface_map entry
+//     written from it would demux the wrong tag.
+//   - PARENT, because a genuine local vlan of a DIFFERENT physical interface
+//     answers every other check while delegating to a parent that is not the
+//     one whose XDP program is supposed to cover it.
+//
+// The caller decides what to do with a refusal. It is deliberately a reason
+// string rather than a sentinel error: the reason reaches the operator in an
+// UnarmedSurface record, and "refused" without which check refused it would
+// leave them nothing to act on.
+func vlanAdoptionRefusal(existing netlink.Link, wantParent, wantVID int) string {
+	if why := vlanDelegationDefect(existing); why != "" {
+		return why
+	}
+	vlan, ok := existing.(*netlink.Vlan)
+	if !ok {
+		// Kind says "vlan" but the concrete type is not *netlink.Vlan. Nothing
+		// in vishvananda/netlink produces that today; refusing rather than
+		// falling through keeps the VlanId check below from being skipped by a
+		// shape this function cannot read.
+		return fmt.Sprintf("ifindex %d reports kind %q but did not decode as an "+
+			"802.1Q link, so its VLAN ID cannot be verified",
+			existing.Attrs().Index, vlanLinkKind)
+	}
+	if vlan.VlanId != wantVID {
+		return fmt.Sprintf("ifindex %d is an 802.1Q vlan carrying VID %d, not the "+
+			"configured VID %d", vlan.Attrs().Index, vlan.VlanId, wantVID)
+	}
+	if got := vlan.Attrs().ParentIndex; got != wantParent {
+		return fmt.Sprintf("ifindex %d is an 802.1Q vlan delegating to ifindex %d, "+
+			"not the configured parent ifindex %d", vlan.Attrs().Index, got, wantParent)
+	}
+	return ""
+}


### PR DESCRIPTION
Closes #6916
Closes #6917

## One root cause, two sites — established before the diff

`genericXDPIfindexes` has **exactly one production writer** across `pkg/` and `cmd/`:

```
pkg/dataplane/compiler_iface.go:734:  result.genericXDPIfindexes[subIfindex] = true   <- only assignment
pkg/dataplane/compiler_validate_4960.go:526:  genericXDPIfindexes: make(map[int]bool)  <- the make
```

no whole-map assignment anywhere, and `subIfindex` comes only from `ensureVLANSubInterfaceFn`. The guard at `compiler.go:541` means #6917's `ParentIndex` read at `:546` is reached **only** for ifindexes that came through #6916's adoption.

So the causality runs **#6916 → #6917**. Fixing adoption removes the population #6917 reads from. Two commits, because they are two decision surfaces — but the second is shipped as an explicitly-labelled **second belt**, not as a claim of independent reachability. A branch on a condition that cannot vary is a revert wearing the shape of a fix, and this one would not vary in first-order production once adoption is fixed. Its honest justification is the distance between check and use: adoption runs in compile phase 2 through `netlink.LinkByName`, the read runs in the attach loop after program load through `cachedLinkByIndex`, and the cache holds this child only when a unit MTU happens to be configured.

Both issues were **re-derived at `origin/master`** first. Every claim holds; every line number had moved (#6916's `:113`→`:184`, `:548`→`:734`, `:1276`→`:1500`; #6917's `:474`→`:546`). Posted on each issue.

**The third-read question, re-verified.** The twin attach loop at `loader.go:348` **does not read `ParentIndex` at all** — it `continue`s on every VLAN child unconditionally — so on the attach path there are exactly the two sites the issue names, one already closed by #6864. Reads elsewhere (`daemon_ha_fabric.go`, `daemon_apply_dataplane.go`, `monitoriface`, `grpcapi`, `routing/xfrm.go`) are other subsystems; `routing/xfrm.go:302` is the codebase's existing **good** precedent — concrete type *and* `ParentIndex == 0` before trusting the field.

## Commit 1 — prove a VLAN child before adopting it (#6916)

`vlanAdoptionRefusal` requires kind `vlan`, a local `real_dev`, the configured VLAN ID, and the configured parent ifindex. A refusal takes the existing soft-skip path — WARN plus an `UnarmedSurface` record — and the squatter **never enters `genericXDPIfindexes` at all**, so it is neither adopted nor silently excluded from XDP attach.

Deliberately **not** `errVLANCreateFailed`: refusing an entire commit because an unrelated device squats a name is a far larger blast radius than #6893 part 2 took on, on a condition an operator may not be able to clear from the xpf side.

Two things the issue did not ask for, both scoped by harm:

- The `UnarmedSurface` reason was hardcoded to `"create failed"`. For a refusal that is a **false statement in the operator's own record** — nothing failed to be created, a device is present and forwarding — and it is the statement that would send them looking for a creation error that never happened. A refusal now reads `"not adopted"`.
- `LinkSetUp`'s discarded error is now **logged, not returned**. A failed nudge leaves the child DOWN, so nothing forwards and the #6916 harm does not arise; turning a transient failure into a skip would instead drop a legitimate child out of the dataplane.

The kind and namespace rejections are **single-sourced** into `vlanDelegationDefect`, which `armproof.go` now calls too. A divergence between those two is always a bug: the proof decides whether a surface is covered, the adoption decides whether a device becomes that surface.

## Commit 2 — do not skip XDP attach on an unproven parent (#6917)

Both directions of the wrong branch, as the issue asked:

- aliased `ParentIndex` lands in `failedNativeXDP` → `continue` → the interface is in `pendingXDP` with **no XDP attach at all**: a live forwarding surface with no program on it;
- aliased `ParentIndex` absent → xpf attaches its generic program to a device that is not its VLAN child.

`skipGenericAttachForVLANChild` proves kind and namespace first; an unproven device **never skips**, because falling through to the generic attach is the direction that cannot hide a surface. Extracting it from the loop is also what makes it testable — left inline it was three lines no unit test could reach, so the belt would have been unbound code.

## Tests assert PROVENANCE, not presence

Every assertion an existence check can make is answered identically by a device xpf created and a foreign device it merely found: the link is there, it has an ifindex, it is up, the compile succeeded. So every cell states **which of the two happened**.

- `TestVLANAdoptionRefusesWhatItCannotProve_6916` — the predicate, over real `vishvananda/netlink` types rather than fakes, because production calls `Link.Type()` and the concrete type IS the thing under test: the issue's cross-namespace `*netlink.Veth`, a genuine `*netlink.Vlan` with `NetNsID != -1`, wrong VID, wrong parent, plus the row that stops a predicate that refuses everything.
- `TestEnsureVLANSubInterfaceBindsTheAdoptionGate_6916` — binds the **wiring**. Deleting the call to the predicate leaves the table test entirely green.
- `TestRefusedVLANNeverEntersTheDelegatedChildSet_6916` — the **consequence**: the withheld ifindex must never reach `genericXDPIfindexes`, because being in that set is what makes the attach loop skip an interface.
- `TestGenericAttachSkipRequiresAProvenVLANParent_6917` — paired on the SAME failed-parent input: proven vlan skips, unproven attaches.

The compile-level cells use a DP embedding `censusDP6903` rather than `recordingFilterDP`: the success path reaches `SetVlanIfaceInfo` and `recordingFilterDP` embeds a nil `DataPlane`, so that cell would not have failed — it would have **panicked** and taken the package binary down, turning every other test in the package into a result nobody measured.

## Mutations — six, one per assertion

Full package, `-count=1`, no `-run` filter, restored between cells.

| # | Mutation | Named RED | Collected |
|---|---|---|---|
| control | none | — (0 failed) | 617 |
| 1 | adoption gate call deleted from `ensureVLANSubInterface` | `TestEnsureVLANSubInterfaceBindsTheAdoptionGate_6916` | 617 |
| 2 | configured-parent check dropped from `vlanAdoptionRefusal` | `TestVLANAdoptionRefusesWhatItCannotProve_6916` | 617 |
| 3 | `vlanDelegationDefect` removed from `skipGenericAttachForVLANChild` | `TestGenericAttachSkipRequiresAProvenVLANParent_6917` | 617 |
| 4 | refusal reported as `"create failed"` again | `…6916/refused`, **reason** assertion (line 283) | 617 |
| 5 | caller treats a refusal as success and delegates anyway | `…6916/refused`, **delegated-child-set** assertion (line 270) | 617 |
| 6 | `armproof.go` stops consulting the shared predicate | `TestArmProofNonVLANChildNeverInheritsItsParentIndex` | 617 |

Every cell collected 617 = control, so none is a build break wearing a red's clothes. Cells 4 and 5 red the same test at **different lines** — that is why they are two mutations rather than one.

**Cell 6 is the one aimed at the standing hazard**: single-sourcing decommissions the tests that were counting the old sites. The pre-existing #6864 test still reds after the refactor, so its coverage followed the code rather than being quietly dropped.

## Gates

- `go test ./pkg/dataplane/ -count=1` — ok, 21.3s
- `go build ./...`, `go vet ./pkg/dataplane/`, `gofmt -l` — clean
- Gated head `e94bb1123`, `origin/master` verified as an ancestor.

## Docs

`docs/log/6916.md` carries the re-derivation, the single-writer measurement behind the one-vs-two judgement, the third-read sweep, and the mutation matrix.
