### PR TITLE
cluster: act on the peer's own reboot evidence, and correct a stale blocker

### DIFF
--- a/docs/log/6910.md
+++ b/docs/log/6910.md
@@ -43,3 +43,25 @@
     `peerEpochLatched` are documented "diagnostics and tests only") plus an
     unhandled latch race, and landing both together is how an invisible fallback
     ships looking correct. Re-filed as **#7762**.
+
+- **Timestamp**: 2026-08-28 (validation)
+  - **The matrix caught a fourth instance of the fixture-blindness class, in my
+    own cell.** V2b dropped the `priorInc.known()` guard — the exact regression
+    `TestFirstIncarnatedPrimeIsNotARebootEdge6910` was written for — and all 962
+    tests stayed GREEN. The cell called `notePeerBootIncarnation` directly, and
+    that function never evicts anything, so the assertion held whether or not the
+    guard existed. The guard lives in `handleMessage`'s BulkStart arm, so the
+    cell now arrives through that arm. Same tell as #6884/#6892/#6899: the cell
+    asserted a property of a HELPER rather than of the wired path the mutation
+    changes.
+  - **Matrix**: control 0/962. V1 (remove the wiring), V2 (drop the guard), V3
+    (act on every prime) all VOID as build breaks — correctly not scored as
+    escapes — then re-run compiling: V1b reds `BulkStartArmDrivesTheRemedy`;
+    V2b **ESCAPED**, fixed, V2c reds `FirstIncarnatedPrimeIsNotARebootEdge`;
+    V3b reds `BulkStartSameBootLeavesBothFabrics`; V4 (advance but do not evict —
+    the stamp-not-choice trap) reds both property cells.
+  - **Validation**: `go test ./... -count=1 -p 4` rc 0 / 68 packages;
+    `make cluster-deploy` (sha256-verified both nodes) + `make test-failover` →
+    **14 passed, 0 failed**, 22.9 Gbps. The reboot/rejoin cycle exercises the
+    incarnation path this changes, and the routine second-fabric case it must
+    not regress.

--- a/docs/log/6910.md
+++ b/docs/log/6910.md
@@ -1,0 +1,45 @@
+# #6910 — peer reboot through an EMPTY alternate fabric slot
+
+- **Timestamp**: 2026-08-28
+  - **The stated blocker had lifted, but the obstacle moved.** #6669 merged, yet
+    neither boot signal is reachable in `installConn`, and the issue conflates
+    two different mechanisms:
+    - `bootIncarnation` (#5084) — opaque `/proc` boot_id, **equality-only** by
+      its own doc, carried in the `syncMsgBulkStart` **payload**;
+    - the heartbeat boot epoch (#6669) — an **ordered** `uint64` floor latched
+      on `Manager.hbAuth`, on the independent UDP channel.
+  - **Root fact, one line**: `SessionSync`'s whole view of the outside world is
+    `clusterRuntime`, which exposes `Sessions()` and `Telemetry()` and nothing
+    else. There is no Manager handle, so the heartbeat epoch cannot be consulted
+    at all; and the config-sync incarnation arrives only on BulkStart, after the
+    install.
+  - **The "re-classify when the boot id arrives" alternative also fails for the
+    issue's exact case.** `connBootIncarnation` documents that a connection which
+    never received an incarnated prime — "including the second fabric, which may
+    carry config without having primed" — keeps the ZERO value, deliberately the
+    never-dropped fail-open class. So #5084's incarnation is structurally unable
+    to classify a replacement that never primes.
+  - **What landed here (the closable half)**: `notePeerBootIncarnation`'s
+    `switched` return already existed and reached only a log line.
+    `applyPeerIncarnationSwitchLocked` now hangs the real remedy off it —
+    advance the incarnation, drop the previous incarnation's ack capability,
+    evict connections still stamped with it, re-stamp the priming connection —
+    mirroring the supersession path exactly rather than inventing a second
+    notion of "retire the old peer".
+  - **A regression caught before it shipped**: `notePeerBootIncarnation` reports
+    `switched` for zero -> X as well as X -> Y. Only the second is a reboot; the
+    first is simply the first incarnated prime, and acting on it would evict the
+    peer's healthy same-boot second fabric — the routine case #5718 protects.
+    The remedy is therefore guarded on `priorInc.known()`, with its own cell.
+  - **Cells assert the CHOSEN FABRIC**, not the incarnation stamp: the stamp is
+    the mechanism, `preferredFabricLocked` choosing the dead fabric is the
+    property. The zero-incarnation case is asserted because it is the production
+    reality on that path, not a fixture convenience — and it documents the limit
+    rather than covering it.
+  - **File(s)**: pkg/cluster/sync_conn.go, pkg/cluster/sync_conn_read.go,
+    pkg/cluster/peer_reboot_prime_6910_test.go
+  - **Not done, deliberately**: plumbing the heartbeat epoch through
+    `clusterRuntime`. That is a contract change (`peerEpochFloor`/
+    `peerEpochLatched` are documented "diagnostics and tests only") plus an
+    unhandled latch race, and landing both together is how an invisible fallback
+    ships looking correct. Re-filed separately.

--- a/docs/log/6910.md
+++ b/docs/log/6910.md
@@ -42,4 +42,4 @@
     `clusterRuntime`. That is a contract change (`peerEpochFloor`/
     `peerEpochLatched` are documented "diagnostics and tests only") plus an
     unhandled latch race, and landing both together is how an invisible fallback
-    ships looking correct. Re-filed separately.
+    ships looking correct. Re-filed as **#7762**.

--- a/pkg/cluster/peer_reboot_prime_6910_test.go
+++ b/pkg/cluster/peer_reboot_prime_6910_test.go
@@ -178,8 +178,16 @@ func TestUnknownIncarnationPrimeChangesNothing6910(t *testing.T) {
 // notePeerBootIncarnation reports `switched` for zero -> X as well as X -> Y,
 // because both change the recorded value. Acting on the first would advance the
 // incarnation and evict the peer's OTHER fabric — a healthy same-boot
-// connection. FAIL-ON-REVERT: drop the `priorInc.known()` term in the BulkStart
-// arm and a first prime evicts a live sibling.
+// connection, the routine case #5718 protects.
+//
+// IT DRIVES handleMessage, NOT notePeerBootIncarnation. An earlier version of
+// this cell called the note function directly and the mutation matrix caught it:
+// that function never evicts anything by itself, so the cell passed whether or
+// not the guard was present. The guard lives in the BulkStart arm, so the cell
+// has to arrive through the BulkStart arm.
+//
+// FAIL-ON-REVERT: drop the `priorInc.known()` term and a first prime evicts a
+// live sibling.
 func TestFirstIncarnatedPrimeIsNotARebootEdge6910(t *testing.T) {
 	ss := newAckTestSync(t)
 	first := pipeConn(t)
@@ -187,29 +195,23 @@ func TestFirstIncarnatedPrimeIsNotARebootEdge6910(t *testing.T) {
 	second := pipeConn(t)
 	ss.installConn(1, second)
 
-	// Nothing has primed yet, so the recorded incarnation is zero.
+	// Nothing has primed yet, so the recorded incarnation is zero — this is a
+	// FIRST prime, not a reboot, even though it changes the recorded value.
 	if ss.PeerBootIncarnation().known() {
 		t.Fatal("precondition: no incarnation recorded yet")
 	}
-	prior := ss.PeerBootIncarnation()
-	inc := incarnation6910(0xC3)
-	switched := ss.notePeerBootIncarnation(inc)
 
-	if !switched {
-		t.Fatal("precondition: zero -> known must report switched; that is exactly why the " +
-			"remedy cannot key on `switched` alone")
-	}
-	if prior.known() {
-		t.Fatal("precondition: the PRIOR value must be unknown for this to be a first prime")
-	}
-	// The production guard is `switched && priorInc.known()`. With prior
-	// unknown, the remedy must not run — assert the state it would have changed.
+	// A real BulkStart carrying the first known boot id, on fabric 1.
+	ss.handleMessage(second, syncMsgBulkStart, bulkStartPayload6910(1, incarnation6910(0xC3)))
+
 	ss.mu.Lock()
 	c0, c1 := ss.conn0, ss.conn1
 	ss.mu.Unlock()
 	if c0 != first || c1 != second {
-		t.Fatal("a FIRST incarnated prime evicted a live sibling — zero -> X is a first " +
-			"prime, not a reboot (#6910)")
+		t.Fatal("a FIRST incarnated prime evicted a live sibling. zero -> X changes the " +
+			"recorded incarnation and so reports `switched`, but it is the first prime " +
+			"this SessionSync has seen, NOT a reboot — the remedy must additionally " +
+			"require that a DIFFERENT boot was known before (#6910)")
 	}
 }
 

--- a/pkg/cluster/peer_reboot_prime_6910_test.go
+++ b/pkg/cluster/peer_reboot_prime_6910_test.go
@@ -1,0 +1,287 @@
+package cluster
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+)
+
+// peer_reboot_prime_6910_test.go — #6910, the half that IS closable today.
+//
+// installConn classifies a new connection by LOCAL slot occupancy, so a peer
+// reboot whose replacement lands in the empty alternate slot — beside the dead
+// process's still-ESTABLISHED socket — is indistinguishable from the same peer
+// routinely bringing up its second fabric. The corpse keeps the current
+// incarnation stamp, and `preferredFabricLocked` then chooses DEAD fabric 0 over
+// LIVE fabric 1.
+//
+// When the replacement PRIMES, that ambiguity disappears: the boot id on the
+// wire changed, which only a new peer boot produces. These cells drive that
+// path.
+//
+// WHAT THEY DELIBERATELY DO NOT CLAIM: a replacement that never primes carries
+// NO boot id (connBootIncarnation is zero for it, fail-open by design), so this
+// cannot reach that case. That half needs the heartbeat epoch plumbed through
+// clusterRuntime and is tracked separately — see the LIMIT comment in
+// installConn. The zero case is asserted below precisely because it is the
+// PRODUCTION reality on that path, not a fixture convenience.
+
+func incarnation6910(b byte) bootIncarnation {
+	var inc bootIncarnation
+	for i := range inc {
+		inc[i] = b
+	}
+	return inc
+}
+
+// rebootFixture6910 models the issue's sequence: a corpse installed on
+// `corpseIdx` from the OLD peer boot, then the replacement connecting into the
+// empty alternate slot. Both are stamped current, which is the defect.
+func rebootFixture6910(t *testing.T, corpseIdx, replIdx int) (*SessionSync, net.Conn, net.Conn) {
+	t.Helper()
+	ss := newAckTestSync(t)
+	corpse := pipeConn(t)
+	ss.installConn(corpseIdx, corpse)
+	// The old peer primed on the corpse: that is what makes a LATER different
+	// boot id observable as a change rather than as a first prime.
+	ss.noteConnBootIncarnation(corpse, incarnation6910(0xA1))
+	ss.notePeerBootIncarnation(incarnation6910(0xA1))
+
+	repl := pipeConn(t)
+	ss.installConn(replIdx, repl)
+	return ss, corpse, repl
+}
+
+// TestRebootPrimeOnAlternateFabricEvictsTheCorpse6910 is the issue's step 5,
+// asserted on the CHOSEN FABRIC rather than on the incarnation stamp.
+//
+// The stamp is the mechanism; the choice is the property. A cell asserting only
+// that the incarnation advanced would pass for an implementation that advanced
+// it and still preferred the dead slot.
+//
+// FAIL-ON-REVERT: remove the applyPeerIncarnationSwitchLocked call from the
+// BulkStart arm and the preference stays on the corpse's fabric.
+func TestRebootPrimeOnAlternateFabricEvictsTheCorpse6910(t *testing.T) {
+	// Corpse on fabric 0 is the sharp case: fabric 0 WINS preference when both
+	// are stamped current, so a failure here is the blackhole the issue names.
+	ss, corpse, repl := rebootFixture6910(t, 0, 1)
+
+	ss.mu.Lock()
+	before := ss.preferredFabricLocked()
+	ss.mu.Unlock()
+	if before != 0 {
+		t.Fatalf("precondition: with both slots stamped current the corpse's fabric 0 must "+
+			"win preference, got %d — the fixture is not reproducing the defect", before)
+	}
+
+	// The replacement primes with a DIFFERENT, KNOWN boot id: positive evidence
+	// of a reboot. A zero/unknown id here would prove nothing (see the sibling
+	// cell) and is exactly the fixture mistake this comment exists to prevent.
+	newInc := incarnation6910(0xB2)
+	ss.noteConnBootIncarnation(repl, newInc)
+	switched := ss.notePeerBootIncarnation(newInc)
+	if !switched {
+		t.Fatal("precondition: a different known boot id must report switched")
+	}
+	ss.mu.Lock()
+	idx := ss.fabricIdxForConnLocked(repl)
+	ss.applyPeerIncarnationSwitchLocked(idx)
+	after := ss.preferredFabricLocked()
+	c0, c1 := ss.conn0, ss.conn1
+	ss.mu.Unlock()
+
+	if after != 1 {
+		t.Fatalf("after the peer's own boot id proved a reboot, preference is still fabric "+
+			"%d — the DEAD fabric. preferredFabricLocked chooses the corpse over the live "+
+			"replacement, which is how the next failover blackholes established "+
+			"sessions (#6910)", after)
+	}
+	if c0 != nil {
+		t.Error("the corpse on fabric 0 is still installed after the reboot was proven; " +
+			"slot occupancy is what several other readers consult")
+	}
+	if c1 != repl {
+		t.Error("the replacement was evicted or displaced")
+	}
+	_ = corpse
+}
+
+// PAIRED CONTROL — the routine second-fabric case #5718 exists to protect.
+// Without it, "evict the sibling on a prime" is satisfied by evicting
+// unconditionally, which breaks a healthy two-fabric peer.
+func TestRoutineSecondFabricPrimeDoesNotEvict6910(t *testing.T) {
+	ss := newAckTestSync(t)
+	first := pipeConn(t)
+	ss.installConn(0, first)
+	inc := incarnation6910(0xA1)
+	ss.noteConnBootIncarnation(first, inc)
+	ss.notePeerBootIncarnation(inc)
+
+	second := pipeConn(t)
+	ss.installConn(1, second)
+
+	// The SAME peer boot primes on its second fabric.
+	ss.noteConnBootIncarnation(second, inc)
+	if switched := ss.notePeerBootIncarnation(inc); switched {
+		t.Fatal("the same boot id reported a switch — rule 2 of the plan's §6 says a " +
+			"same-incarnation re-prime must not invalidate anything")
+	}
+
+	ss.mu.Lock()
+	c0, c1 := ss.conn0, ss.conn1
+	ss.mu.Unlock()
+	if c0 != first || c1 != second {
+		t.Fatal("a routine second-fabric prime from the SAME peer boot evicted a live " +
+			"connection (#6910 must not regress #5718)")
+	}
+}
+
+// THE ZERO CASE, asserted because it is the PRODUCTION reality on this path and
+// not a fixture convenience.
+//
+// connBootIncarnation returns zero for a connection that never received an
+// incarnated prime — "including the second fabric, which may carry config
+// without having primed" — and zero is deliberately the never-dropped fail-open
+// class. So the replacement in the issue's exact sequence may carry NO boot id
+// at all, and this path must then do nothing rather than guess.
+//
+// This cell documents the LIMIT: it is the reason #6910's empty-slot half stays
+// open, and it must not be read as coverage of it.
+func TestUnknownIncarnationPrimeChangesNothing6910(t *testing.T) {
+	ss, _, repl := rebootFixture6910(t, 0, 1)
+
+	// A prime with NO incarnation on the wire.
+	var unknown bootIncarnation
+	if unknown.known() {
+		t.Fatal("precondition: the zero value must be unknown")
+	}
+	ss.noteConnBootIncarnation(repl, unknown)
+	if switched := ss.notePeerBootIncarnation(unknown); switched {
+		t.Fatal("an un-incarnated prime reported a switch — absent means 'no information', " +
+			"not 'a different boot'")
+	}
+
+	ss.mu.Lock()
+	after := ss.preferredFabricLocked()
+	c0 := ss.conn0
+	ss.mu.Unlock()
+	if after != 0 || c0 == nil {
+		t.Fatal("an un-incarnated prime changed the classification — with no boot id there " +
+			"is no evidence of a reboot, and guessing here is exactly what installConn " +
+			"refuses to do (#6910 limit)")
+	}
+}
+
+// A FIRST incarnated prime is not a reboot, and this is the regression the
+// remedy's guard exists for.
+//
+// notePeerBootIncarnation reports `switched` for zero -> X as well as X -> Y,
+// because both change the recorded value. Acting on the first would advance the
+// incarnation and evict the peer's OTHER fabric — a healthy same-boot
+// connection. FAIL-ON-REVERT: drop the `priorInc.known()` term in the BulkStart
+// arm and a first prime evicts a live sibling.
+func TestFirstIncarnatedPrimeIsNotARebootEdge6910(t *testing.T) {
+	ss := newAckTestSync(t)
+	first := pipeConn(t)
+	ss.installConn(0, first)
+	second := pipeConn(t)
+	ss.installConn(1, second)
+
+	// Nothing has primed yet, so the recorded incarnation is zero.
+	if ss.PeerBootIncarnation().known() {
+		t.Fatal("precondition: no incarnation recorded yet")
+	}
+	prior := ss.PeerBootIncarnation()
+	inc := incarnation6910(0xC3)
+	switched := ss.notePeerBootIncarnation(inc)
+
+	if !switched {
+		t.Fatal("precondition: zero -> known must report switched; that is exactly why the " +
+			"remedy cannot key on `switched` alone")
+	}
+	if prior.known() {
+		t.Fatal("precondition: the PRIOR value must be unknown for this to be a first prime")
+	}
+	// The production guard is `switched && priorInc.known()`. With prior
+	// unknown, the remedy must not run — assert the state it would have changed.
+	ss.mu.Lock()
+	c0, c1 := ss.conn0, ss.conn1
+	ss.mu.Unlock()
+	if c0 != first || c1 != second {
+		t.Fatal("a FIRST incarnated prime evicted a live sibling — zero -> X is a first " +
+			"prime, not a reboot (#6910)")
+	}
+}
+
+// bulkStartPayload6910 builds a real syncMsgBulkStart payload: 8-byte epoch
+// followed by the boot incarnation, exactly the layout parseBootIncarnation
+// reads.
+func bulkStartPayload6910(epoch uint64, inc bootIncarnation) []byte {
+	p := make([]byte, 8+bootIncarnationLen)
+	binary.LittleEndian.PutUint64(p[:8], epoch)
+	copy(p[8:], inc[:])
+	return p
+}
+
+// TestBulkStartArmDrivesTheRemedy6910 binds the WIRING, and it is the cell
+// without which the others are inert.
+//
+// Every cell above calls applyPeerIncarnationSwitchLocked directly. Deleting the
+// call from handleMessage's syncMsgBulkStart arm — leaving the helper, the
+// guard and all four cells intact — restores exactly the shipped defect while
+// the suite stays green, because nothing else drives that arm.
+//
+// So this feeds a REAL BulkStart frame through handleMessage and asserts the
+// operator-visible property: the preference moves off the corpse.
+func TestBulkStartArmDrivesTheRemedy6910(t *testing.T) {
+	ss, _, repl := rebootFixture6910(t, 0, 1)
+
+	ss.mu.Lock()
+	before := ss.preferredFabricLocked()
+	ss.mu.Unlock()
+	if before != 0 {
+		t.Fatalf("precondition: preference must start on the corpse's fabric 0, got %d", before)
+	}
+
+	// A different, KNOWN boot id arriving on the replacement's connection.
+	ss.handleMessage(repl, syncMsgBulkStart, bulkStartPayload6910(7, incarnation6910(0xB2)))
+
+	ss.mu.Lock()
+	after := ss.preferredFabricLocked()
+	c0 := ss.conn0
+	ss.mu.Unlock()
+
+	if after != 1 {
+		t.Fatalf("a real BulkStart carrying a NEW peer boot id left preference on fabric %d "+
+			"(the corpse). The remedy is not wired into the BulkStart arm, so the peer's "+
+			"own reboot evidence reaches only a log line — which is the pre-#6910 "+
+			"behaviour", after)
+	}
+	if c0 != nil {
+		t.Error("the corpse is still installed after a real BulkStart proved the reboot")
+	}
+}
+
+// The wiring cell's PAIRED CONTROL: a real BulkStart from the SAME boot must
+// leave a healthy two-fabric peer alone. Without it, wiring an unconditional
+// eviction into the arm passes the cell above.
+func TestBulkStartSameBootLeavesBothFabrics6910(t *testing.T) {
+	ss := newAckTestSync(t)
+	first := pipeConn(t)
+	ss.installConn(0, first)
+	inc := incarnation6910(0xA1)
+	ss.handleMessage(first, syncMsgBulkStart, bulkStartPayload6910(1, inc))
+	second := pipeConn(t)
+	ss.installConn(1, second)
+
+	// Same boot re-primes on the second fabric.
+	ss.handleMessage(second, syncMsgBulkStart, bulkStartPayload6910(2, inc))
+
+	ss.mu.Lock()
+	c0, c1 := ss.conn0, ss.conn1
+	ss.mu.Unlock()
+	if c0 != first || c1 != second {
+		t.Fatal("a real BulkStart from the SAME peer boot evicted a live fabric — the " +
+			"remedy is firing on something other than a boot-id CHANGE (#6910/#5718)")
+	}
+}

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -232,6 +232,61 @@ func (s *SessionSync) connIsCurrentIncarnationLocked(conn net.Conn) bool {
 // case (the same process bringing up its second fabric), so it is not fixable
 // here: it needs the peer-supplied boot epoch #6669 signs into the heartbeat.
 // See pkg/cluster/README.md for the full sequence and which half self-heals.
+// applyPeerIncarnationSwitchLocked retires the previous peer incarnation when
+// the peer's own BOOT ID proves it rebooted (#6910, on #5084's signal).
+//
+// WHY THIS EXISTS SEPARATELY FROM installConn's supersededCurrent. That
+// classification is LOCAL: it infers a reboot from slot occupancy, and it is
+// blind whenever the replacement lands in the empty alternate slot beside a
+// corpse. This one is not an inference — `notePeerBootIncarnation` reports that
+// the boot id on the wire CHANGED, which only a genuinely new peer boot can
+// produce. So where the local classification must not guess, this may act.
+//
+// WHAT IT DOES NOT CLOSE, stated so the two are not confused: a replacement
+// connection that never PRIMES carries no boot id at all (connBootIncarnation
+// returns zero for it, deliberately fail-open), so this path never runs for it.
+// The empty-slot case in installConn's LIMIT comment is therefore still open and
+// still needs the heartbeat epoch — see #7754. This closes the reboot-that-primes
+// half only.
+//
+// The remedy mirrors the supersession path exactly rather than inventing one:
+// advance the incarnation, drop the previous incarnation's ack capability, evict
+// the connections still stamped with it, then re-stamp the priming connection so
+// it belongs to the incarnation it actually established. Keeping the two paths
+// identical is deliberate — a second, subtly different notion of "retire the old
+// peer" is how the readers listed on evictStaleIncarnationConnsLocked come to
+// disagree about which process is live.
+//
+// keepIdx names the priming connection's slot; it is re-stamped and never
+// evicted. Returns whether anything was evicted, for the caller's log.
+func (s *SessionSync) applyPeerIncarnationSwitchLocked(keepIdx int) bool {
+	s.peerIncarnation++
+	s.peerHeartbeatAckEver.Store(false)
+	evicted := s.evictStaleIncarnationConnsLocked(keepIdx)
+	// Stamp AFTER the advance, exactly as installConn does, so the priming
+	// connection belongs to the incarnation it established rather than to the
+	// one just retired.
+	switch keepIdx {
+	case 0:
+		s.conn0Gen = s.peerIncarnation
+	case 1:
+		s.conn1Gen = s.peerIncarnation
+	}
+	return evicted
+}
+
+// fabricIdxForConnLocked reports which slot holds conn, or -1.
+func (s *SessionSync) fabricIdxForConnLocked(conn net.Conn) int {
+	switch {
+	case conn != nil && s.conn0 == conn:
+		return 0
+	case conn != nil && s.conn1 == conn:
+		return 1
+	default:
+		return -1
+	}
+}
+
 func (s *SessionSync) evictStaleIncarnationConnsLocked(keepIdx int) bool {
 	// #5718 fold r6: "this can never empty the registry" is the ENTIRE
 	// justification for exempting this function from
@@ -519,18 +574,48 @@ func (s *SessionSync) installConn(fabricIdx int, conn net.Conn) connColdPrimeDec
 	// would strand the connection that legitimately proved the capability at a
 	// stale stamp, so it could never re-arm.
 	//
-	// LIMIT OF THIS CLASSIFICATION (#6910, blocked on #6669): wasDisconnected
-	// and supersededCurrent between them detect a reboot only when it lands on
-	// an OCCUPIED slot or an empty registry. A reboot whose replacement dials
-	// the EMPTY alternate slot, while the dead process's socket sits
-	// ESTABLISHED in the other one, satisfies NEITHER — so it advances no
-	// incarnation, evicts nothing, clears no capability and arms no cold prime,
-	// and the replacement is stamped current alongside the corpse (which then
-	// wins fab0 preference if it holds slot 0). Nothing observable locally
-	// separates that from the same peer bringing up its second fabric after a
-	// link flap, so do NOT add a heuristic here — it needs the peer-supplied
-	// boot epoch #6669 signs into the heartbeat. Full sequence, and which half
-	// self-heals, in pkg/cluster/README.md under "ACCEPTED RESIDUAL".
+	// LIMIT OF THIS CLASSIFICATION (#6910). wasDisconnected and
+	// supersededCurrent between them detect a reboot only when it lands on an
+	// OCCUPIED slot or an empty registry. A reboot whose replacement dials the
+	// EMPTY alternate slot, while the dead process's socket sits ESTABLISHED in
+	// the other one, satisfies NEITHER — so it advances no incarnation, evicts
+	// nothing, clears no capability and arms no cold prime, and the replacement
+	// is stamped current alongside the corpse (which then wins fab0 preference
+	// if it holds slot 0). Nothing observable LOCALLY separates that from the
+	// same peer bringing up its second fabric after a link flap, so do NOT add
+	// a heuristic here. Full sequence in pkg/cluster/README.md under
+	// "ACCEPTED RESIDUAL".
+	//
+	// THIS COMMENT USED TO SAY "blocked on #6669". THAT WAS WRONG IN A WAY THAT
+	// SENDS THE NEXT READER AT THE WRONG SIGNAL, so it is corrected here rather
+	// than deleted. #6669 MERGED (2026-08-12). Two distinct peer-boot signals
+	// now exist and they are NOT interchangeable:
+	//
+	//   - bootIncarnation (#5084) — an opaque /proc boot_id compared for
+	//     EQUALITY ONLY ("Never order two boot ids", sync_boot_incarnation.go),
+	//     carried in the syncMsgBulkStart PAYLOAD;
+	//   - the heartbeat boot epoch (#6669) — an ORDERED uint64 floor, latched
+	//     on Manager.hbAuth from the independent UDP heartbeat.
+	//
+	// NEITHER is reachable here, and the root fact is one line: SessionSync's
+	// whole view of the outside world is `clusterRuntime`, which exposes
+	// Sessions() and Telemetry() and nothing else — there is no Manager handle,
+	// so the heartbeat epoch cannot be consulted at all. And the config-sync
+	// incarnation arrives only on BulkStart, i.e. strictly AFTER this install.
+	//
+	// Nor can it simply be applied later for THIS case: connBootIncarnation
+	// documents that a connection which never received an incarnated prime —
+	// "including the second fabric, which may carry config without having
+	// primed" — keeps the ZERO value, and zero is deliberately the never-dropped
+	// fail-open class. The empty-slot connection this limit is about is exactly
+	// such a connection, so #5084's incarnation is structurally unable to
+	// classify it. Closing this needs the heartbeat epoch plumbed through
+	// clusterRuntime, which is a contract change plus a latch race (see #7754).
+	//
+	// What IS now actionable is the case where the replacement DOES prime:
+	// notePeerBootIncarnation's `switched` return is positive peer-supplied
+	// evidence of a reboot, and applyPeerIncarnationSwitchLocked below acts on
+	// it.
 	supersededCurrent := false
 	switch fabricIdx {
 	case 0:

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -246,7 +246,7 @@ func (s *SessionSync) connIsCurrentIncarnationLocked(conn net.Conn) bool {
 // connection that never PRIMES carries no boot id at all (connBootIncarnation
 // returns zero for it, deliberately fail-open), so this path never runs for it.
 // The empty-slot case in installConn's LIMIT comment is therefore still open and
-// still needs the heartbeat epoch — see #7754. This closes the reboot-that-primes
+// still needs the heartbeat epoch — see #7762. This closes the reboot-that-primes
 // half only.
 //
 // The remedy mirrors the supersession path exactly rather than inventing one:
@@ -610,7 +610,7 @@ func (s *SessionSync) installConn(fabricIdx int, conn net.Conn) connColdPrimeDec
 	// fail-open class. The empty-slot connection this limit is about is exactly
 	// such a connection, so #5084's incarnation is structurally unable to
 	// classify it. Closing this needs the heartbeat epoch plumbed through
-	// clusterRuntime, which is a contract change plus a latch race (see #7754).
+	// clusterRuntime, which is a contract change plus a latch race (see #7762).
 	//
 	// What IS now actionable is the case where the replacement DOES prime:
 	// notePeerBootIncarnation's `switched` return is positive peer-supplied

--- a/pkg/cluster/sync_conn_read.go
+++ b/pkg/cluster/sync_conn_read.go
@@ -240,7 +240,7 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 		// Scoped to the connection that PRIMED. A replacement that never primes
 		// carries no boot id (connBootIncarnation is zero for it, fail-open by
 		// design), so this cannot reach that case — see the LIMIT comment in
-		// installConn and #7754.
+		// installConn and #7762.
 		//
 		// GUARDED ON THE PRIOR VALUE BEING KNOWN, and this is not a nicety.
 		// notePeerBootIncarnation reports `switched` for zero -> X as well as

--- a/pkg/cluster/sync_conn_read.go
+++ b/pkg/cluster/sync_conn_read.go
@@ -204,6 +204,11 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 		// reset leaves the whole suite green.
 		inc := parseBootIncarnation(payload)
 		s.noteConnBootIncarnation(conn, inc)
+		// #6910: capture the PRIOR incarnation before the note overwrites it —
+		// distinguishing a first prime (zero -> X) from a reboot (X -> Y)
+		// requires the old value, and notePeerBootIncarnation's bool does not
+		// carry it.
+		priorInc := s.PeerBootIncarnation()
 		switched := s.notePeerBootIncarnation(inc)
 		s.stats.BulkSyncStartTime.Store(time.Now().UnixNano())
 		s.stats.BulkSyncEndTime.Store(0)
@@ -221,8 +226,42 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 		s.bulkRecvV6 = make(map[dataplane.SessionKeyV6]struct{})
 		s.bulkZoneSnapshot = zoneSnap
 		s.bulkMu.Unlock()
+		// #6910: ACT on the switch, do not merely report it. Until now
+		// `switched` reached only this log line, so a reboot whose replacement
+		// primed on the alternate fabric left the corpse installed, stamped
+		// current, and winning fab0 preference in preferredFabricLocked — the
+		// consequence the issue is actually about.
+		//
+		// This is peer-supplied evidence, not a local inference: the boot id on
+		// the wire changed, which only a new peer boot produces. installConn
+		// deliberately refuses to guess from slot occupancy; here there is
+		// nothing to guess.
+		//
+		// Scoped to the connection that PRIMED. A replacement that never primes
+		// carries no boot id (connBootIncarnation is zero for it, fail-open by
+		// design), so this cannot reach that case — see the LIMIT comment in
+		// installConn and #7754.
+		//
+		// GUARDED ON THE PRIOR VALUE BEING KNOWN, and this is not a nicety.
+		// notePeerBootIncarnation reports `switched` for zero -> X as well as
+		// for X -> Y, because both change the recorded incarnation. Only the
+		// second is a REBOOT; the first is simply the first incarnated prime
+		// this SessionSync has seen. Acting on it would advance the incarnation
+		// and evict the peer's OTHER fabric — a healthy connection from the same
+		// boot — which is the routine second-fabric case #5718's tests exist to
+		// protect. So the remedy needs "we knew a DIFFERENT boot before", which
+		// `switched` alone does not say.
+		var evictedStale bool
+		if switched && priorInc.known() {
+			s.mu.Lock()
+			if idx := s.fabricIdxForConnLocked(conn); idx >= 0 {
+				evictedStale = s.applyPeerIncarnationSwitchLocked(idx)
+			}
+			s.mu.Unlock()
+		}
 		slog.Info("cluster sync: bulk transfer starting", "epoch", epoch,
 			"peer_boot_incarnation", inc.String(), "incarnation_switched", switched,
+			"evicted_stale_incarnation_conn", evictedStale,
 			"local", connLocalAddrString(conn), "remote", connRemoteAddrString(conn))
 		// #5084: a peer that primes without an incarnation gets today's
 		// generation-only ordering (fail open). Warn ONCE per connection, not


### PR DESCRIPTION
Closes #6910

Lands the half of #6910 that is closable with the signals actually wired today, corrects an in-tree comment that sends readers at the wrong signal, and re-files the rest as **#7762** with the measurement attached.

## The stated blocker lifted; the obstacle moved

#6910 says it is *"blocked on #6669"*. **#6669 merged.** But two distinct peer-boot signals now exist and they are **not interchangeable** — the issue conflates them:

| signal | semantics | arrives | reachable in `installConn`? |
|---|---|---|---|
| `bootIncarnation` (**#5084**) | opaque `/proc` boot_id, **equality-only** — *"Never order two boot ids"* | `syncMsgBulkStart` **payload** | **No** — strictly after the install |
| heartbeat boot epoch (**#6669**) | **ordered** `uint64` floor | independent UDP heartbeat, on `Manager.hbAuth` | **No** |

**The root fact is one line.** `SessionSync`'s entire view of the outside world is `clusterRuntime`, which exposes `Sessions()` and `Telemetry()` and nothing else — **no Manager handle**, so the heartbeat epoch cannot be consulted from the classifier at all.

The old comment named a merged dependency as a blocker while the signal that *is* wired cannot answer the question. It now states both mechanisms and the `clusterRuntime` fact, so the next reader does not reach for #5084's incarnation and find it structurally unable to help.

## What this closes: the reboot that PRIMES

`notePeerBootIncarnation` already returned `switched` — and it reached **only a log line**. So a reboot whose replacement primed on the alternate fabric left the corpse installed, stamped current, and winning fab0 preference in `preferredFabricLocked`: the consequence the issue is actually about.

`applyPeerIncarnationSwitchLocked` now hangs the remedy off it — advance the incarnation, drop the previous incarnation's ack capability, evict connections still stamped with it, re-stamp the primer. It **mirrors the supersession path exactly** rather than inventing a second notion of "retire the old peer", because two notions is how the readers listed on `evictStaleIncarnationConnsLocked` come to disagree about which process is live.

This is peer-supplied evidence, not a local inference: the boot id on the wire changed, which only a new peer boot produces. `installConn` must not guess from slot occupancy; here there is nothing to guess.

## A regression caught before it shipped

`notePeerBootIncarnation` reports `switched` for **zero → X** as well as **X → Y**, because both change the recorded value. Only the second is a reboot; the first is simply the first incarnated prime this `SessionSync` has seen.

Acting on it would advance the incarnation and evict the peer's **other fabric** — a healthy same-boot connection, the routine second-fabric case #5718's tests exist to protect. The remedy is therefore guarded on `priorInc.known()`, which `switched` alone cannot express.

## What stays open, and why it is structural — #7762

A replacement that never primes carries **no boot id at all**. `connBootIncarnation` documents it: the zero value for a connection that never received an incarnated prime, *"including the second fabric, which may carry config without having primed"* — and zero is deliberately the never-dropped fail-open class.

So #5084's incarnation is structurally unable to classify exactly the connection the empty-slot case is about. `TestUnknownIncarnationPrimeChangesNothing6910` asserts that limit in-tree, so it is a recorded property rather than a gap to rediscover.

**#7762** carries the rest with the scope stated: extend `clusterRuntime` (a contract change — `peerEpochFloor`/`peerEpochLatched` are documented *"diagnostics and tests only"*), classify on the epoch, and handle the latch race **from the start** — on a peer reboot the heartbeat and the fabric connect race, an unlatched epoch reads as 0, and 0 falls back to today's classification **silently**. A fix that ignores that is indistinguishable from one that works, which is why it is filed rather than folded in here.

## Cells assert the CHOSEN FABRIC, not the stamp

The stamp is the mechanism; `preferredFabricLocked` picking the dead fabric is the property. A cell asserting only that the incarnation advanced would pass an implementation that advanced it and still preferred the corpse — which is exactly what mutation **V4** does.

The zero-incarnation case is asserted **because it is the production reality on that path**, not as a fixture convenience.

## Mutation matrix

Full-package `go test ./pkg/cluster/ -count=1 -v`, no `-run` filter, committed before mutating, tree clean after each restore. Control **962 collected / 0 failed**.

| cell | mutation | verdict |
|---|---|---|
| control | — | **0** |
| V1 / V2 / V3 | first attempts | **VOID — build breaks** (unused vars), correctly not scored as escapes |
| **V1b** | **remove the remedy call from the BulkStart arm (the WIRING)** | `BulkStartArmDrivesTheRemedy6910` |
| V2b | drop the `priorInc.known()` guard | **ESCAPED — 962 green** |
| **V2c** | same, against the re-armed cell | `FirstIncarnatedPrimeIsNotARebootEdge6910` |
| V3b | act on every incarnated prime | `BulkStartSameBootLeavesBothFabrics6910` |
| V4 | advance the incarnation but do **not** evict | `RebootPrimeOnAlternateFabricEvictsTheCorpse6910`, `BulkStartArmDrivesTheRemedy6910` |

**V2b is the row to read.** It dropped the exact guard `TestFirstIncarnatedPrimeIsNotARebootEdge6910` was written for, and all 962 tests stayed green — the cell called `notePeerBootIncarnation` **directly**, and that function never evicts anything, so its assertion held whether or not the guard existed. The guard lives in the BulkStart arm, so the cell now arrives through that arm. Fourth instance of this class in this campaign, same tell each time: **the cell asserted a property of a helper rather than of the wired path the mutation changes.**

## Gate

- `go build ./...` rc 0; `go test ./... -count=1 -p 4` → **rc 0, 68 packages, 0 failures**
- `make cluster-deploy` (sha256-verified both nodes) + `make test-failover` → **14 passed, 0 failed**, 22.9 Gbps (passed+failed = 14, nothing silently skipped). The reboot/rejoin cycle exercises the incarnation path this changes *and* the routine second-fabric case it must not regress
- `merge-base --is-ancestor origin/master HEAD` verified; folded with `git merge`
- No cargo leg — Go only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ez9XCjM9mPjtocRjkousdB
