### PR TITLE
dataplane: guard the SNAT interface-mode to-zone against a nil map value (#6918)

### DIFF
--- a/pkg/dataplane/compiler_nat.go
+++ b/pkg/dataplane/compiler_nat.go
@@ -323,7 +323,15 @@ func compileNAT(dp DataPlane, cfg *config.Config, result *CompileResult) error {
 				// ANY of them resolves still decides whether this rule consumes
 				// a pool ID, so the resolution stays load-bearing.
 				toZoneCfg, ok := cfg.Security.Zones[rs.ToZone]
-				if !ok || len(toZoneCfg.Interfaces) == 0 {
+				// #6918: a map entry present with a NIL *ZoneConfig makes ok
+				// true, so testing ok alone falls through to the deref below and
+				// panics the compile. The sibling sweep in compiler_iface.go
+				// already treats a nil zone slot as reachable — its comment
+				// names the tolerant/programmatic and HA-peer-sync paths, which
+				// do not go through the parser that always allocates a zone.
+				// Treat nil exactly like a zone with no interfaces: this rule
+				// resolves nothing, so warn and skip.
+				if !ok || toZoneCfg == nil || len(toZoneCfg.Interfaces) == 0 {
 					compileWarn(dp, "to-zone has no interfaces",
 						"zone", rs.ToZone, "rule-set", rs.Name)
 					continue

--- a/pkg/dataplane/compiler_nat_nil_zone_6918_test.go
+++ b/pkg/dataplane/compiler_nat_nil_zone_6918_test.go
@@ -1,0 +1,125 @@
+package dataplane
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// capturingHandler records the message of every slog record emitted during a
+// compile, so a test can assert HOW FAR execution got rather than only that it
+// survived.
+type capturingHandler6918 struct{ msgs *[]string }
+
+func (h capturingHandler6918) Enabled(context.Context, slog.Level) bool { return true }
+func (h capturingHandler6918) Handle(_ context.Context, r slog.Record) error {
+	*h.msgs = append(*h.msgs, r.Message)
+	return nil
+}
+func (h capturingHandler6918) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h capturingHandler6918) WithGroup(string) slog.Handler      { return h }
+
+func captureCompileNAT6918(t *testing.T, cfg *config.Config) ([]string, error) {
+	t.Helper()
+	var msgs []string
+	prev := slog.Default()
+	slog.SetDefault(slog.New(capturingHandler6918{msgs: &msgs}))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	// assignZoneIDs is production's prelude to compileNAT (compiler.go runs it
+	// before the NAT phase); without it the from-zone lookup fails first and the
+	// to-zone path under test is never reached.
+	result := newValidationResult()
+	assignZoneIDs(result, cfg)
+	return msgs, compileNAT(idProbeDP{}, cfg, result)
+}
+
+// snatInterfaceModeCfg6918 builds the smallest config that reaches the
+// interface-mode to-zone resolution in compileNAT: one SNAT rule set whose rule
+// is `then source-nat interface`, with the named to-zone slot populated by the
+// caller.
+func snatInterfaceModeCfg6918(toZone string, zone *config.ZoneConfig) *config.Config {
+	cfg := &config.Config{}
+	// The from-zone is a REAL zone in both cases: only the to-zone slot varies
+	// between them, so nothing but the field under test can change the outcome.
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {Interfaces: []string{"ge-0-0-1"}},
+		toZone:  zone,
+	}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{{
+		Name:     "rs1",
+		FromZone: "trust",
+		ToZone:   toZone,
+		Rules: []*config.NATRule{{
+			Name: "r1",
+			Then: config.NATThen{Interface: true},
+		}},
+	}}
+	return cfg
+}
+
+// TestCompileNATSkipsANilToZone6918 is the #6918 guard.
+//
+// A map entry present with a NIL *ZoneConfig makes the two-value lookup's `ok`
+// true, so a guard testing `ok` alone falls through to `toZoneCfg.Interfaces`
+// and panics the compile. compiler_iface.go's sibling sweep already treats a nil
+// zone slot as reachable — its comment names the tolerant/programmatic and
+// HA-peer-sync paths, which do not go through the parser that always allocates a
+// zone. compileNAT did not, and this is the only site in the tree that did not:
+// every other `Security.Zones[...]` read either discards the value, checks it
+// inline, or routes through a `zone != nil` helper.
+//
+// RED-on-revert: dropping `toZoneCfg == nil` from the guard makes this PANIC,
+// which is a test failure naming this function.
+func TestCompileNATSkipsANilToZone6918(t *testing.T) {
+	cfg := snatInterfaceModeCfg6918("untrust", nil)
+
+	msgs, err := captureCompileNAT6918(t, cfg)
+	if err != nil {
+		t.Fatalf("compileNAT returned an error for a nil to-zone: %v", err)
+	}
+	if !containsMsg6918(msgs, "to-zone has no interfaces") {
+		t.Fatalf("nil to-zone did not take the skip branch; records = %v.\n"+
+			"A nil zone must be treated exactly like a zone with no interfaces — "+
+			"the rule resolves nothing either way.", msgs)
+	}
+}
+
+// TestCompileNATPopulatedToZoneReachesTheInterfaceLoop6918 is the paired
+// control, and it is what stops the test above from being vacuous.
+//
+// "Did not panic" is satisfied by a config that never reaches the deref at all,
+// so the nil case alone cannot distinguish "the guard works" from "the fixture
+// misses the code". This case differs from it in ONE field — the zone slot is
+// populated instead of nil — and must get PAST the guard into the interface
+// loop, which it proves by failing LATER with a different message. Two different
+// messages from one field change is what establishes the nil case is being
+// decided at the guard rather than never arriving.
+func TestCompileNATPopulatedToZoneReachesTheInterfaceLoop6918(t *testing.T) {
+	cfg := snatInterfaceModeCfg6918("untrust", &config.ZoneConfig{
+		Interfaces: []string{"ge-0-0-0"},
+	})
+
+	msgs, err := captureCompileNAT6918(t, cfg)
+	if err != nil {
+		t.Fatalf("compileNAT: %v", err)
+	}
+	if containsMsg6918(msgs, "to-zone has no interfaces") {
+		t.Fatalf("a zone WITH an interface took the no-interfaces skip; records = %v.\n"+
+			"If this branch is taken here too, the nil-zone test above proves nothing: "+
+			"both cases would stop at the guard and neither would reach the deref.", msgs)
+	}
+	if !containsMsg6918(msgs, "no IP addresses for interface SNAT") {
+		t.Fatalf("populated to-zone did not reach the interface loop; records = %v", msgs)
+	}
+}
+
+func containsMsg6918(msgs []string, want string) bool {
+	for _, m := range msgs {
+		if m == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
`compileNAT`'s interface-mode branch looked up the to-zone with the two-value
form and tested only `ok`. A map entry present with a **nil** `*ZoneConfig` makes
`ok` true, so the guard fell through to `toZoneCfg.Interfaces` and panicked the
compile.

Closes #6918

## Why a nil zone is reachable at all

`pkg/config` cannot produce one — `compiler_security_zones.go` always assigns
`&ZoneConfig{...}`. But `compiler_iface.go`'s sibling sweep already treats a nil
zone slot as reachable, and its comment names where one arrives: the tolerant /
programmatic and **HA-peer-sync** paths, which do not go through the parser. So
the interface compiler skips a nil zone while the NAT compiler panicked on it.
This makes the two agree.

## The population is 1, and that is measured rather than assumed

The issue reports one line. I swept the whole class before fixing it, because a
fix to one member of a set reported as the set is the failure I keep sending back.

Of the **50** `Security.Zones[...]` reads in `pkg/` outside tests: one is a write;
every remaining read either discards the value (`if _, ok := …`), checks it
inline (`ok && z != nil`), or routes through a helper. The three
`zones_host_inbound.go` sites that looked unguarded go through `configured`,
which is exactly `return zone != nil`.

**`compiler_nat.go` was the only unguarded read in the tree.** My first scan
flagged 16 candidates, but that was a floor with false positives, not a census —
the inline and helper forms are invisible to the pattern it used. Reading each
one is what produced the number.

## Mutation matrix

Fix committed before mutating. Full-package, no `-run` filter, scored on
collected count against control.

| # | Mutation | vet | collected | Named RED |
|---|---|---|---|---|
| — | control | 0 | 602 | — |
| N1 | drop `toZoneCfg == nil` (the shipped defect) | 0 | 175 † | `TestCompileNATSkipsANilToZone6918` |
| N2 | over-reach — guard skips every to-zone | 0 | 602 | `TestCompileNATPopulatedToZoneReachesTheInterfaceLoop6918`, `TestRealPassStillLogsItsSuccesses_4960` |

† **N1's low count is the defect firing, not a build break.** The nil deref
panics, which aborts the rest of the package. Confirmed by 0 vet errors and one
`panic: runtime error: invalid memory address`. My first attempt at N2 *was* a
build break — `if true` left `toZoneCfg` and `ok` unused, 0 collected — and the
row above is the compilable form.

**N2 is why the second test exists.** "Did not panic" is satisfied by a fixture
that never reaches the deref, so the nil case alone cannot distinguish a working
guard from a fixture that misses the code. The paired case differs in exactly one
field — the zone slot is populated instead of nil — and proves it gets *past* the
guard by failing later with a different message. Two different messages from one
field change is what makes the nil case a measurement.

The fixture also gives both cases a real from-zone, so only the field under test
can change the outcome; without it both failed at an earlier `from-zone not
found` and neither reached the branch.

## Docs

No documentation change. The contract this restores is already written down at
the sibling site in `compiler_iface.go`, which states the reachability and the
skip; this makes the NAT compiler match a rule the tree already documents rather
than introducing one.

## Gates

`go build ./...` clean. `go test ./... -count=1` → **68 ok / 0 FAIL**, with
`origin/master` folded and 0 unmerged paths.
