### PR TITLE
userspace: bound the worker count before it narrows through uint32

### DIFF
--- a/docs/log/6930.md
+++ b/docs/log/6930.md
@@ -1,0 +1,37 @@
+# #6930 — heartbeat worker-count narrowing
+
+- **Timestamp**: 2026-08-28
+  - **The issue's stated defect is GONE, and its root survived one line away.**
+    `heartbeatZeroSlots` no longer exists: #6702 replaced it with
+    `heartbeatZeroSlotBound`, which returns the whole map and derives nothing
+    from the worker count, so the `workers * 32` multiply the issue describes
+    cannot overflow because it is not there.
+  - **The root reproduces at `planUserspaceWorkers`' cast.** `effectiveWorkers`
+    skips its clamp entirely when `maxW == 0` — i.e. a heartbeat Array holding
+    fewer than 32 entries — so `w` leaves unbounded and `uint32(w)` narrows it.
+    Measured at `heartbeatMapCap = 31` BEFORE fixing:
+    - `workers 1<<32` → `effectiveWorkers 4294967296` → **`plan.Workers 0`**
+    - `workers 1<<32+5` → `effectiveWorkers 4294967301` → **`plan.Workers 5`**
+    Those are the exact two values the code comment names as the A6-b01-C1
+    defect while claiming it is fixed because "the clamp runs entirely in INT
+    space, before any uint32 cast". True — but there is no clamp in the
+    degenerate case, so int space does not help.
+  - **Action**: an UNCONDITIONAL `MaxUint32` ceiling in `effectiveWorkers`, so
+    the cast is faithful for every input. Bounding the OPERAND rather than
+    checking the product is deliberate: a post-hoc check on an already-narrowed
+    value cannot tell 0-because-overflow from 0-because-zero, which is what made
+    it silent. No reachable answer changes — with `maxW >= 1` the far smaller
+    maxW clamp binds first.
+  - **Also corrected**: two stale references to the removed `heartbeatZeroSlots`
+    (the `effectiveWorkers` doc claim and a comment at :167).
+  - **Fixture values are COMPUTED, not guessed.** An arithmetic-order bug is
+    invisible to any input that does not cross the boundary, so the cells assert
+    `uint32(input) == the narrowed value` as a precondition before asserting the
+    fix, and the degenerate cap is derived as `heartbeatSlotsPerWorker - 1`
+    rather than picked.
+  - **File(s)**: pkg/dataplane/userspace/maps_sync.go,
+    pkg/dataplane/userspace/worker_count_narrowing_6930_test.go
+  - **Reachability, honestly**: unreachable today — the shim declares a
+    4096-entry Array so `maxW = 128` and the clamp always binds. The safety
+    still rests on a constant in another crate, which is the issue's own
+    argument for fixing it at the arithmetic site.

--- a/pkg/dataplane/userspace/maps_sync.go
+++ b/pkg/dataplane/userspace/maps_sync.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"net"
 	"net/netip"
 	"runtime"
@@ -163,7 +164,8 @@ func (m *Manager) programBootstrapMapsLocked(snapshot *ConfigSnapshot, cfg confi
 	// #5718 fold F3: ONE derivation feeds every representation of this
 	// quantity. cfg.Workers used to be consumed TWICE under different rules —
 	// `maxInt(cfg.Workers, 1)` cast to uint32 for ctrl.Workers/ctrl.QueueCount,
-	// and the RAW cfg.Workers passed to heartbeatZeroSlots below — so the two
+	// and the RAW cfg.Workers passed to the heartbeat zero-init bound below —
+	// so the two
 	// descriptions of "how many workers this dataplane has" could drift, and
 	// after the A6-b01-C1 narrowing fix they demonstrably DID: `workers
 	// 4294967296` clamps to the full heartbeat map for the zero-init loop
@@ -1816,14 +1818,43 @@ func planUserspaceWorkers(workers int, heartbeatMapCap uint32) userspaceWorkerPl
 // maxW is how many workers the fixed-size userspace_heartbeat Array can carry
 // slots for (4096 / 32 = 128 today), which is also the honest ceiling for the
 // ctrl fields: a worker with no zero-initialised heartbeat slot has none to
-// keep fresh, and the shim refuses to redirect on a stale slot. The floor
-// stays 1 even when the Array cannot hold a single worker's slots;
-// heartbeatZeroSlots caps the resulting SLOT count at mapCap for that
-// degenerate case instead of reporting zero workers.
+// keep fresh, and the shim refuses to redirect on a stale slot.
+//
+// #6930: THE INT-SPACE CLAIM ABOVE IS CONDITIONAL, AND THE CONDITION IS THE
+// DEGENERATE CASE. `maxW` is 0 whenever the Array holds fewer than
+// heartbeatSlotsPerWorker entries, and the clamp is then SKIPPED entirely — so
+// `w` leaves this function unbounded and `planUserspaceWorkers`' `uint32(w)`
+// narrows it. Measured before fixing, with heartbeatMapCap = 31:
+//
+//	workers 1<<32    -> effectiveWorkers 4294967296 -> plan.Workers 0
+//	workers 1<<32+5  -> effectiveWorkers 4294967301 -> plan.Workers 5
+//
+// Those are the exact two values the paragraph above names as the A6-b01-C1
+// defect — reporting ZERO workers and ZERO queues to the shim, or a
+// plausible-looking 5 — reproduced at the CAST rather than at the multiply that
+// #6702 removed. Running the clamp in int space does not help when there is no
+// clamp.
+//
+// The floor stays 1 even when the Array cannot hold a single worker's slots.
+// The CEILING is now unconditional: clamping to MaxUint32 makes the cast in
+// planUserspaceWorkers faithful for every input without changing any reachable
+// answer (with maxW >= 1 the maxW clamp binds first and is far smaller), so
+// this fixes the narrowing without altering the degenerate case's documented
+// intent of reporting a worker count rather than zero.
+//
+// Bounding the OPERAND rather than checking the product is deliberate: a
+// post-hoc check on a value that has already narrowed cannot tell 0-because-
+// overflow from 0-because-zero, which is what made the original silent.
 func effectiveWorkers(workers int, heartbeatMapCap uint32) int {
 	w := maxInt(workers, 1)
 	if maxW := int(heartbeatMapCap / heartbeatSlotsPerWorker); maxW >= 1 && w > maxW {
 		w = maxW
+	}
+	// #6930: unconditional, so it also binds when the maxW clamp above was
+	// skipped. int is 64-bit on every platform this builds for, so this cannot
+	// itself wrap.
+	if w > math.MaxUint32 {
+		w = math.MaxUint32
 	}
 	return w
 }

--- a/pkg/dataplane/userspace/worker_count_narrowing_6930_test.go
+++ b/pkg/dataplane/userspace/worker_count_narrowing_6930_test.go
@@ -1,0 +1,109 @@
+package userspace
+
+import (
+	"math"
+	"testing"
+)
+
+// worker_count_narrowing_6930_test.go — #6930.
+//
+// The issue names an overflow in `heartbeatZeroSlots`, a function #6702 has
+// since REMOVED — the zero-init bound no longer derives from the worker count
+// at all (`heartbeatZeroSlotBound` returns the whole map). That specific
+// multiply cannot overflow because it no longer exists.
+//
+// The ROOT survived one line away. `effectiveWorkers` skips its clamp entirely
+// when `maxW == 0` — i.e. whenever the heartbeat Array holds fewer than
+// heartbeatSlotsPerWorker entries — and `planUserspaceWorkers` then casts that
+// unbounded value with `uint32(w)`. The A6-b01-C1 failure the doc calls fixed
+// reproduces at the CAST instead of at the multiply.
+//
+// THE FIXTURE VALUES ARE COMPUTED, NOT GUESSED. An arithmetic-order bug is
+// invisible to any input that does not actually cross the boundary: a
+// large-looking worker count that still fits in uint32 passes against fixed and
+// unfixed code alike. 1<<32 and 1<<32+5 are the two the code comment itself
+// names, chosen because they narrow to 0 and to 5 — one obviously wrong, one
+// plausible enough to survive review.
+
+// degenerateHeartbeatCap is below heartbeatSlotsPerWorker (32), which is the
+// ONLY condition under which effectiveWorkers skips its clamp. With the shipped
+// shim's 4096-entry Array the clamp always binds, which is why this is
+// unreachable today — and why the fixture must set it explicitly rather than
+// hoping a big worker count is enough.
+const degenerateHeartbeatCap = heartbeatSlotsPerWorker - 1
+
+func TestWorkerCountDoesNotNarrowInTheDegenerateCase6930(t *testing.T) {
+	if degenerateHeartbeatCap/heartbeatSlotsPerWorker != 0 {
+		t.Fatalf("fixture precondition broken: cap %d must yield maxW == 0, or the "+
+			"clamp binds and this cell exercises nothing", degenerateHeartbeatCap)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		workers int
+		// narrowed is what uint32(w) produces WITHOUT the fix — recorded so the
+		// failure message can name the wrong answer rather than just the right one.
+		narrowed uint32
+	}{
+		{"exactly 2^32 narrows to zero", 1 << 32, 0},
+		{"2^32+5 narrows to a plausible 5", 1<<32 + 5, 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Confirm the input genuinely crosses the boundary — an arithmetic
+			// cell whose input does not overflow proves nothing.
+			if uint32(tc.workers) != tc.narrowed {
+				t.Fatalf("fixture is not exercising the narrowing: uint32(%d) = %d, "+
+					"expected %d", tc.workers, uint32(tc.workers), tc.narrowed)
+			}
+
+			plan := planUserspaceWorkers(tc.workers, degenerateHeartbeatCap)
+
+			if plan.Workers == tc.narrowed {
+				t.Fatalf("plan.Workers = %d — the unbounded worker count narrowed through "+
+					"uint32(). The shim is told there are %d workers and %d queues, which "+
+					"for 0 means it believes the dataplane has none, and for a small value "+
+					"looks like a legal count and sails through every bound (#6930)",
+					plan.Workers, plan.Workers, plan.Workers)
+			}
+			if plan.Workers != math.MaxUint32 {
+				t.Fatalf("plan.Workers = %d, want MaxUint32: with no maxW clamp the only "+
+					"honest ceiling is the widest value the cast can carry", plan.Workers)
+			}
+		})
+	}
+}
+
+// PAIRED CONTROL — the reachable configuration must be untouched. Without it,
+// "clamp the worker count" is satisfied by clamping to 1 (or to MaxUint32
+// unconditionally), which would misreport every real box.
+func TestReachableWorkerCountsAreUnchanged6930(t *testing.T) {
+	// The shipped shim declares 4096 entries, so maxW = 128.
+	const shippedCap = 4096
+	for _, tc := range []struct {
+		workers int
+		want    uint32
+	}{
+		{1, 1},         // the floor
+		{4, 4},         // a normal box
+		{128, 128},     // exactly maxW
+		{500, 128},     // above maxW: the existing clamp binds
+		{1 << 32, 128}, // huge, but the maxW clamp binds FIRST — no narrowing possible
+	} {
+		if got := planUserspaceWorkers(tc.workers, shippedCap).Workers; got != tc.want {
+			t.Errorf("planUserspaceWorkers(%d, %d).Workers = %d, want %d — the #6930 "+
+				"ceiling changed a reachable answer", tc.workers, shippedCap, got, tc.want)
+		}
+	}
+}
+
+// The degenerate case must still report a worker count rather than zero, which
+// is the documented intent the fix must not quietly discard.
+func TestDegenerateCapStillReportsAWorkerCount6930(t *testing.T) {
+	for _, w := range []int{1, 4, 64} {
+		if got := planUserspaceWorkers(w, degenerateHeartbeatCap).Workers; got != uint32(w) {
+			t.Errorf("with a sub-slot heartbeat Array, planUserspaceWorkers(%d).Workers = "+
+				"%d, want %d — the floor-stays-1 intent says report the count, not zero",
+				w, got, w)
+		}
+	}
+}


### PR DESCRIPTION
Closes #6930

## The issue's defect is gone; its root survived one line away

`heartbeatZeroSlots` **no longer exists**. #6702 replaced it with `heartbeatZeroSlotBound`, which returns the whole map and derives nothing from the worker count:

```go
func heartbeatZeroSlotBound(heartbeatMapCap uint32) uint32 { return heartbeatMapCap }
```

So the `workers * 32` multiply the issue describes cannot overflow, because it is not there. Re-derived at `origin/master` before writing anything.

**But the root reproduces at the cast.** `effectiveWorkers` skips its clamp *entirely* when `maxW == 0` — whenever the heartbeat Array holds fewer than `heartbeatSlotsPerWorker` entries — so `w` leaves unbounded and `planUserspaceWorkers` does `uint32(w)`.

Measured at `heartbeatMapCap = 31`, **before** fixing:

```
workers 1<<32    ->  effectiveWorkers 4294967296  ->  plan.Workers 0
workers 1<<32+5  ->  effectiveWorkers 4294967301  ->  plan.Workers 5
```

Those are the **exact two values the `effectiveWorkers` doc names** as the A6-b01-C1 defect — *"`1<<32` becomes 0 and `1<<32+5` becomes 5, both of which look like legal counts and sail through every bound"* — while claiming it is fixed because *"the clamp runs entirely in INT space, before any uint32 cast."*

That claim is true and does not help. **In the degenerate case there is no clamp at all**, so running it in int space protects nothing. `plan.Workers = 0` tells the shim the dataplane has zero workers and zero queues.

## The fix

An **unconditional** `MaxUint32` ceiling, so it also binds when the `maxW` clamp was skipped.

Bounding the **operand** rather than checking the product is deliberate: a post-hoc check on a value that has already narrowed cannot distinguish *0-because-overflow* from *0-because-zero* — which is exactly what made the original silent.

No reachable answer changes: with `maxW >= 1` the far smaller `maxW` clamp binds first, and a paired-control cell pins that.

Also corrects **two stale references** to the removed `heartbeatZeroSlots`, including the doc sentence the issue calls out as not literally true.

## Fixture values are computed, not guessed

An arithmetic-order bug is invisible to any input that does not actually cross the boundary — a large-looking worker count that still fits in `uint32` passes against fixed and unfixed code alike. So:

- the degenerate cap is derived as `heartbeatSlotsPerWorker - 1`, with a precondition asserting it yields `maxW == 0`, rather than picked for looking small;
- each case asserts `uint32(input) == the narrowed value` **as a precondition** before asserting the fix, so a fixture that stopped overflowing fails loudly instead of passing vacuously;
- the assertion is on `plan.Workers` — the resulting reported count — not on the ceiling having been applied.

## Mutation matrix

Full-package `go test ./pkg/dataplane/userspace/ -count=1 -v`, no `-run` filter, committed before mutating, tree clean after each restore. Control **1892 collected / 0 failed**.

| cell | mutation | reds |
|---|---|---|
| control | — | **0** |
| W1 | remove the unconditional ceiling (the shipped narrowing) | `WorkerCountDoesNotNarrowInTheDegenerateCase6930` |
| W2 | make the ceiling **conditional** again — present but skipped in the degenerate case | `WorkerCountDoesNotNarrowInTheDegenerateCase6930` |
| W3 | clamp to 1 instead | **VOID — build break** (`math` unused), correctly not scored as an escape |
| W3b | same, kept compiling | **5 cells**, incl. the paired control and **two pre-existing** `_5718` tests |

**W2 is the row that matters**: it is the fix present but not binding where it must, which is the failure a "did we add a clamp?" reading would miss. **W3b** shows the reachable-answers property is owned by prior coverage too — `TestHeartbeatZeroSlotsClampsBeforeNarrowing_5718` and `TestWorkerCountHasOneRepresentation_5718` both red, visible only because the matrix ran full-package.

## Reachability, stated honestly

**Unreachable today.** The shim declares a 4096-entry Array, so `maxW = 128` and the clamp always binds. The safety therefore rests on a constant in a *different crate* with nothing at the arithmetic site to notice if it changed — which is the issue's own argument for fixing it here rather than relying on that constant.

## Gate

- `go build ./...` rc 0; `go test ./... -count=1 -p 4` → **rc 0, 68 packages, 0 failures**
- `merge-base --is-ancestor origin/master HEAD` verified
- No smoke owed — a clamp on a bootstrap-time arithmetic helper, no forwarding or cluster behaviour change. No `userspace-dp` / `userspace-xdp` change, so no cargo leg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ez9XCjM9mPjtocRjkousdB
