### PR TITLE
test(config): pin which tunnel modes suppress a unit-level ipip endpoint (#6932)

### DIFF
--- a/pkg/config/ipip_anchor_mode_enumeration_6932_test.go
+++ b/pkg/config/ipip_anchor_mode_enumeration_6932_test.go
@@ -1,0 +1,141 @@
+package config
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// #6932: `ipipAnchorOnlyText`'s unit branch names `tunnel mode wireguard` as the
+// specific cause. That is correct today, but until now nothing MECHANICAL held
+// it: the only guard was a comment saying the wording needs revisiting if
+// another mode gains a short-circuit.
+//
+// WHAT THE RISK ACTUALLY IS, measured rather than restated. The issue frames it
+// as a future mode producing the WireGuard WORDING. That cannot happen: the call
+// site passes `iface.Tunnel != nil && iface.Tunnel.Mode == "wireguard"`, a
+// literal comparison, so any other short-circuiting mode yields false and takes
+// the `case isUnit:` arm — which says the cause "is not one this check
+// recognises". The failure mode is therefore an HONEST-BUT-USELESS advisory, not
+// a confidently wrong one.
+//
+// That is still worth guarding, and these two tests split the property:
+// this one pins WHICH modes suppress, and the one below pins what the
+// unrecognised-cause arm actually renders.
+
+// unitIpipSuppressedUnder reports whether an interface-level stanza in the named
+// mode suppresses a COMPLETE unit-level `ipip` endpoint.
+//
+// The discriminator is compile success, and it is exact rather than incidental.
+// A unit `ipip` endpoint that IS emitted reaches the #4785 rejection ("IPIP
+// (ip-in-ip) is NOT implemented"), so the compile fails. One that is SUPPRESSED
+// never reaches it, so the compile succeeds and the anchor advisory fires
+// instead. So "compiled" and "suppressed" are the same fact here.
+func unitIpipSuppressedUnder(t *testing.T, ifaceStanza []string, ifName string) bool {
+	t.Helper()
+	lines := append(append([]string{}, ifaceStanza...),
+		// unit 1 carries NO tunnel stanza, so it is the LOWEST unit and resolves
+		// to the interface's shared device. Without it the interface-level
+		// endpoint keys to unit 3 and resolves to unit 3's OWN device, so unit 3
+		// is not orphaned and nothing is suppressed — the shape #6861 F1b proved
+		// is not dead. Present in every row so the rows differ only in mode.
+		"set interfaces "+ifName+" unit 1 family inet address 10.9.9.1/30",
+		"set interfaces "+ifName+" unit 3 tunnel mode ipip",
+		"set interfaces "+ifName+" unit 3 tunnel source 10.0.0.5",
+		"set interfaces "+ifName+" unit 3 tunnel destination 10.0.0.6",
+	)
+	cfg, err := CompileConfig(ipipTree(t, lines...))
+	if err != nil {
+		// Emitted, and rejected by #4785. Assert that is WHY, so a compile
+		// failing for an unrelated reason cannot masquerade as "not suppressed".
+		if !strings.Contains(err.Error(), "is NOT implemented in the userspace dataplane") {
+			t.Fatalf("%s: compile failed for a reason unrelated to ipip emission, so this "+
+				"row measures nothing: %v", ifName, err)
+		}
+		return false
+	}
+	for _, w := range ipipAnchorOnlyWarnings(cfg) {
+		if strings.Contains(w, "unit 3") {
+			return true
+		}
+	}
+	t.Fatalf("%s: compiled without emitting the unit ipip endpoint AND without an anchor "+
+		"advisory naming it — the endpoint vanished with no diagnosis at all", ifName)
+	return false
+}
+
+// TestOnlyWireguardSuppressesACompleteUnitIpip_6932 is the mechanical guard the
+// comment asked for.
+//
+// RED-on-change: give any other interface-level mode a short-circuit and its row
+// flips to suppressed, the computed set stops equalling {wireguard}, and this
+// fails NAMING the new mode — so whoever adds it is told to revisit the advisory
+// wording instead of shipping a "cause not recognised" for a cause that is now
+// perfectly well known.
+func TestOnlyWireguardSuppressesACompleteUnitIpip_6932(t *testing.T) {
+	modes := map[string][]string{
+		"wireguard": ipipWgIfaceStanza(),
+		"gre": {
+			"set interfaces gr-0/0/0 tunnel mode gre",
+			"set interfaces gr-0/0/0 tunnel source 10.0.0.1",
+			"set interfaces gr-0/0/0 tunnel destination 10.0.0.2",
+		},
+		// An UNVALIDATED mode is a real input today, not a hypothetical: the
+		// `mode` schema leaf carries no ValueEnumOf (#6924), so `mode banana`
+		// commits. It is enumerated here because a mode nobody declared must not
+		// short-circuit either.
+		"unvalidated": {
+			"set interfaces gr-0/0/1 tunnel mode banana",
+			"set interfaces gr-0/0/1 tunnel source 10.0.0.1",
+			"set interfaces gr-0/0/1 tunnel destination 10.0.0.2",
+		},
+	}
+	ifNames := map[string]string{"wireguard": "wg0", "gre": "gr-0/0/0", "unvalidated": "gr-0/0/1"}
+
+	var suppressing []string
+	for mode, stanza := range modes {
+		if unitIpipSuppressedUnder(t, stanza, ifNames[mode]) {
+			suppressing = append(suppressing, mode)
+		}
+	}
+	sort.Strings(suppressing)
+
+	got := strings.Join(suppressing, ",")
+	if got != "wireguard" {
+		t.Fatalf("the set of interface-level modes that suppress a complete unit-level "+
+			"ipip endpoint is {%s}, want exactly {wireguard}.\n"+
+			"ipipAnchorOnlyText names `tunnel mode wireguard` as THE cause for the unit "+
+			"branch. If another mode suppresses too, units under it now get "+
+			"\"the reason is not one this check recognises\" for a reason that is in fact "+
+			"known — update the advisory alongside the new short-circuit.", got)
+	}
+}
+
+// TestIpipAnchorUnrecognisedCauseArmIsHonest_6932 pins what the fallback arm
+// renders. That arm is unreachable through config today — which is exactly why
+// it needs a direct test: an unreachable arm with no coverage is free to rot
+// into saying something wrong, and it only becomes reachable at the moment a new
+// short-circuit lands, which is the worst time to discover its wording is stale.
+//
+// It must NOT inherit WireGuard's explanation — that is the wrong-cause defect
+// #6861 was folded to fix, one layer in.
+func TestIpipAnchorUnrecognisedCauseArmIsHonest_6932(t *testing.T) {
+	// Both endpoint halves set, so ipipMissingEndpointHalves returns "" and the
+	// COMPLETE fallback renders rather than the missing-half wording.
+	tun := &TunnelConfig{Name: "x", Mode: "ipip", Source: "10.0.0.5", Destination: "10.0.0.6"}
+	got := ipipAnchorOnlyText(`interfaces "gr-0/0/0" unit 3`, tun, true, false)
+
+	if strings.Contains(got, "wireguard") {
+		t.Fatalf("the unrecognised-cause arm names WireGuard, which is the wrong cause by "+
+			"construction — this arm is reached precisely when the suppressor is NOT "+
+			"WireGuard: %q", got)
+	}
+	if !strings.Contains(got, "not one this check recognises") {
+		t.Fatalf("the unrecognised-cause arm must say the cause is unknown rather than "+
+			"guessing: %q", got)
+	}
+	if !strings.Contains(got, "Do not delete either before") {
+		t.Fatalf("the unrecognised-cause arm must not recommend deleting a stanza before "+
+			"the operator knows which one suppresses the other: %q", got)
+	}
+}


### PR DESCRIPTION
`ipipAnchorOnlyText`'s unit branch names `tunnel mode wireguard` as the cause. That
is correct today, but the only thing holding it was a comment: *"If another mode
ever gains a short-circuit, this wording needs revisiting with it."*

Closes #6932

## The issue's premise is half wrong, and that changes the fix

It frames the risk as a future short-circuiting mode producing the **WireGuard
wording** — "the same wrong-cause defect one layer in". Measured, that cannot
happen. The call site passes a **literal** comparison:

```go
iface.Tunnel != nil && iface.Tunnel.Mode == "wireguard"
```

so any other mode yields `false` and takes the `case isUnit:` arm, which already
says the cause "is not one this check recognises". The real failure mode is an
**honest-but-useless** advisory, not a confidently wrong one.

That also rules out the issue's **first** suggested fix — *"derive the suppressing
mode rather than hard-coding it"*. Only one mode short-circuits, so a derived
value always renders `wireguard`: a branch on a condition that cannot vary, whose
test could not distinguish it from the hard-coded version. This implements the
issue's **second** suggestion instead.

## Two tests, one property each

**`TestOnlyWireguardSuppressesACompleteUnitIpip_6932`** enumerates the mode space
and asserts the suppressing set is exactly `{wireguard}`.

The discriminator is compile success, and it is exact rather than incidental: an
emitted unit `ipip` endpoint reaches the #4785 rejection, a suppressed one never
does — so "compiled" and "suppressed" are the same fact. A compile failing for
any *other* reason fails the row rather than scoring it, so a fixture that breaks
for an unrelated reason cannot masquerade as "not suppressed".

**`TestIpipAnchorUnrecognisedCauseArmIsHonest_6932`** pins what the fallback arm
renders. That arm is unreachable through config today, which is exactly why it
needs direct coverage — an uncovered arm rots freely, and it becomes reachable at
the moment a new short-circuit lands, which is the worst time to find its wording
stale.

## An input the issue's 12-cell sweep did not include

The sweep reasons over "exactly three values". The mode space is **not** bounded:
`schema_interfaces.go`'s `"mode"` leaf has no `valueType: ValueEnumOf`, so
`tunnel mode banana` commits (#6924). Verified behaviourally — it commits, and
the compile then fails for an unrelated reason, never for the invalid mode. It is
enumerated as its own row; it does not short-circuit, so the conclusion is
unchanged, but that is now measured rather than assumed. **Landing #6924 removes
this input**, and its owner has been told the row will fail loudly rather than
pass silently.

## Fixture note

Every row carries a `unit 1` with no tunnel stanza. Without it the interface
endpoint keys to unit 3 and resolves to unit 3's *own* device, so nothing is
orphaned and nothing is suppressed — the shape #6861 F1b proved is not dead. My
first version omitted it and the WireGuard row failed, correctly, with "the
endpoint vanished with no diagnosis at all". Rows differ only in mode.

## Mutation matrix

Tests committed before mutating. Full-package, no `-run` filter, scored on
collected count against control.

| # | Mutation | collected | Named RED |
|---|---|---|---|
| — | control | 6767 | — (0 failed) |
| E1 | give `gre` a real short-circuit at `tunnelemit.go:100` | 6767 | `TestOnlyWireguardSuppressesACompleteUnitIpip_6932`, `TestEmitTunnelEndpointNamesPreservesPerUnitGREOverrides` |
| E2 | fallback arm inherits WireGuard's cause | 6767 | `TestIpipAnchorUnrecognisedCauseArmIsHonest_6932` (1 FAIL total) |

E1 is the mutation this PR exists for: it is not a paraphrase of the risk, it is
the risk — a second mode genuinely short-circuiting — and the test fails naming
it, which is what tells whoever adds one to revisit the wording.

## Docs

No documentation change. This adds no behaviour; it pins a property the code
already had and whose only previous guard was a comment. The comment stays, now
backed by a test.

## Gates

`go build ./...` clean. `go test ./... -count=1` → **68 ok / 0 FAIL**, with
`origin/master` folded and 0 unmerged paths.
