### PR TITLE
test/incus: assert IPv6 transit across a failover (#6934)

### DIFF
--- a/docs/log/6934.md
+++ b/docs/log/6934.md
@@ -1,0 +1,67 @@
+# #6934 — IPv6 blackhole after manual RG failover: diagnosis refuted, gate gap closed
+
+- **Timestamp**: 2026-08-27
+  - **Action**: refuted the issue's central measured claim. It reported that no
+    unsolicited NA reaches the wire on a manual RG failover. Measured on **RG2**
+    — the RG that actually owns `reth1`, the interface carrying the blackholed
+    VIP — with simultaneous captures on sender (`fw1 ge-7-0-1`) and receiver
+    (LAN `eth0`): **96 unsolicited NAs sent, 96 received**, zero loss, plus
+    96/96 broadcast ARP. The frame is the exact one the issue says never
+    appears. The original capture was taken across an **RG0+RG1** failover;
+    `reth0`->RG1 (WAN), `reth1`->RG2 (LAN). RG2 never transitioned, so its VRRP
+    instance correctly emitted nothing. The absence was real; the population was
+    wrong.
+  - **File(s)**: none (measurement)
+
+- **Timestamp**: 2026-08-27
+  - **Action**: confirmed the burst's address coverage is complete, closing the
+    last mechanism that could produce a v6-only blackhole. The LAN host's v6
+    default route is `via fe80::bf72:16:2` (proto ra); the burst announces
+    exactly `2001:559:8585:ef00::1` (the VIP) and `fe80::bf72:16:2` (that
+    router). No announced-address gap.
+  - **File(s)**: none (measurement)
+
+- **Timestamp**: 2026-08-27
+  - **Action**: found a SEPARATE, previously unreported defect while testing the
+    reframed hypothesis. A LAN/WAN redundancy-group split — RG0+RG1 on one node
+    with RG2 on the other, which is exactly what the #6934 reporter did — costs
+    **one packet per new flow, symmetrically in v4 and v6, and does not
+    self-heal** (12.5% loss on a fresh probe 45s later). A full failover of all
+    three RGs costs nothing. Filed separately; it explains the reporter's v4
+    loss and explicitly does NOT explain the v6 blackhole (they measured v6 at
+    100%, this is 12.5% in both families).
+  - **File(s)**: none (measurement)
+
+- **Timestamp**: 2026-08-27
+  - **Action**: closed the IPv4-only gap in the failover gate, which is why this
+    reached a human as an ad-hoc observation rather than reddening a test.
+    `cluster-env.sh` has exported `IPERF_TARGET6` all along and
+    `test-failover.sh` never read it. Added `check_v6_transit`, asserted at
+    baseline and after the manual failover. Two design choices are measured
+    rather than assumed: it probes the **WAN-side target, not the LAN VIP**
+    (during a split the VIP answers 0% while transit is degraded, so a VIP probe
+    stays green through the failure it exists to catch), and the threshold is
+    **3 of 5 rather than 0% loss** (the split's one-packet loss is real and
+    persistent, so a strict cell would red on a condition this gate is not
+    scoped to, while `-c 1` would be flaky). 3-of-5 separates a blackhole
+    (0 received, the reported symptom) from first-packet loss (4 of 5).
+  - **File(s)**: test/incus/test-failover.sh
+
+- **Timestamp**: 2026-08-27
+  - **Action**: fixed the false RFC claim the issue found. `buildUnsolicitedNA`'s
+    doc said the NA is sent "with Override and Solicited flags cleared", while
+    the setter thirty lines below sets `0xA0` = Router+Override. Only Solicited
+    is cleared, and the difference is load-bearing: RFC 4861 §7.2.5 lets a
+    receiver KEEP its existing cache entry when Override=0, so an Override=0
+    burst could not correct a peer pointing at the old node — the exact
+    convergence this code exists to drive. #6934 spent a round ruling out an
+    Override=0 bug the code never had.
+  - **File(s)**: pkg/cluster/garp.go
+
+- **Timestamp**: 2026-08-27
+  - **Action**: the reported symptom (v6 100% loss for ~60s) is **not
+    reproduced** across four placements — baseline, RG2 failover, RG0+RG1 split,
+    and all-RGs failover. Recorded as unexplained rather than attached to the
+    split, whose numbers do not match it. The issue should be re-scoped, not
+    closed as works-as-intended.
+  - **File(s)**: none

--- a/docs/log/6934.md
+++ b/docs/log/6934.md
@@ -65,3 +65,14 @@
     split, whose numbers do not match it. The issue should be re-scoped, not
     closed as works-as-intended.
   - **File(s)**: none
+
+- **Timestamp**: 2026-08-27
+  - **Action**: documented the new threshold's COUPLING to #7770. 3-of-5 is not
+    a general tolerance — it is calibrated to absorb one known defect (the
+    LAN/WAN split's persistent one-packet loss). Once #7770 is fixed the
+    threshold is looser than it needs to be and would hide a one-packet
+    regression, so the comment says to raise `V6_PROBE_MIN` to
+    `V6_PROBE_COUNT` then. A tolerance whose reason is undocumented is
+    indistinguishable from one nobody thought about; only the documented kind
+    has an expiry.
+  - **File(s)**: test/incus/test-failover.sh

--- a/pkg/cluster/garp.go
+++ b/pkg/cluster/garp.go
@@ -567,9 +567,21 @@ func runNABurstFollowups(fd int, iface, ip string, pkt []byte, addr unix.Sockadd
 }
 
 // buildUnsolicitedNA constructs a raw Ethernet + IPv6 + ICMPv6 Neighbor
-// Advertisement packet. The NA is sent to the all-nodes multicast address
-// (ff02::1) with Override and Solicited flags cleared per RFC 4861 §7.2.6
-// (unsolicited NA). Includes Target Link-Layer Address option.
+// Advertisement packet, sent to the all-nodes multicast address (ff02::1) per
+// RFC 4861 §7.2.6 (unsolicited NA). Includes the Target Link-Layer Address
+// option.
+//
+// Flags are Router=1, Override=1, Solicited=0 — see the pkt[58] = 0xA0 setter
+// below, which states the same thing thirty lines further down.
+//
+// #6934: this comment used to say "with Override and Solicited flags cleared",
+// which contradicted that setter. Only Solicited is cleared. The distinction is
+// not cosmetic and it is the whole reason this builder works: RFC 4861 §7.2.5
+// lets a receiver keep its existing cache entry when an NA arrives with
+// Override=0, so an Override=0 burst could not correct a peer still pointing at
+// the old node — precisely the failover convergence this exists to drive. A
+// reader auditing RFC conformance hit the false sentence first, and #6934 spent
+// a round ruling out an Override=0 bug that the code never had.
 func buildUnsolicitedNA(mac net.HardwareAddr, ip net.IP) []byte {
 	// 14 Ethernet + 40 IPv6 + 24 ICMPv6 NA (8 hdr + 16 target) + 8 TLLA option = 86
 	pkt := make([]byte, 86)

--- a/test/incus/test-failover.sh
+++ b/test/incus/test-failover.sh
@@ -48,6 +48,22 @@ IPERF_TARGET="${IPERF_TARGET:-$IPERF_TARGET4}"
 IPERF_TARGET6="${IPERF_TARGET6:-2001:559:8585:80::200}"
 V6_PROBE_COUNT=5        # #6934: see check_v6_transit for why this is not 1
 V6_PROBE_MIN=3          # received replies required to call the path up
+# COUPLED TO #7770 — tighten this when that is fixed.
+#
+# 3-of-5 is not a general-purpose tolerance; it is calibrated to absorb one
+# specific KNOWN defect. #7770: a LAN/WAN redundancy-group split drops the first
+# packet of every new flow, symmetrically in v4 and v6, and does not self-heal
+# (measured 12.5% on 8 packets, still 12.5% on a fresh probe 45s later, against
+# 0% for a full failover). A 0%-loss assertion here would red on that rather
+# than on anything this gate is scoped to.
+#
+# So once #7770 lands, this threshold is LOOSER than it needs to be and would
+# hide a one-packet regression. Raise V6_PROBE_MIN to V6_PROBE_COUNT then.
+#
+# Written down because a tolerance whose reason is undocumented is
+# indistinguishable from a tolerance nobody thought about — the next reader
+# cannot tell "3 of 5 because a known defect costs exactly one packet" from
+# "3 of 5 because the author was not sure", and only the first has an expiry.
 IPERF_DURATION=120      # seconds — long enough to span retries + reboot + failback
 IPERF_STREAMS=8
 MIN_SESSIONS=4          # minimum established sessions (control + some data streams)

--- a/test/incus/test-failover.sh
+++ b/test/incus/test-failover.sh
@@ -41,6 +41,13 @@ source "${SCRIPT_DIR}/deploy-lib.sh"
 source "${SCRIPT_DIR}/iperf-throughput-lib.sh"
 
 IPERF_TARGET="${IPERF_TARGET:-$IPERF_TARGET4}"
+# #6934: the IPv6 transit target. cluster-env.sh has exported IPERF_TARGET6 all
+# along and this gate never read it — every assertion here was IPv4-only, which
+# is why an IPv6-specific failover regression reached a human as an ad-hoc
+# observation instead of reddening this gate.
+IPERF_TARGET6="${IPERF_TARGET6:-2001:559:8585:80::200}"
+V6_PROBE_COUNT=5        # #6934: see check_v6_transit for why this is not 1
+V6_PROBE_MIN=3          # received replies required to call the path up
 IPERF_DURATION=120      # seconds — long enough to span retries + reboot + failback
 IPERF_STREAMS=8
 MIN_SESSIONS=4          # minimum established sessions (control + some data streams)
@@ -57,6 +64,32 @@ pass()  { echo "  PASS  $*"; PASS=$((PASS + 1)); }
 fail()  { echo "  FAIL  $*"; FAIL=$((FAIL + 1)); ERRORS+=("$*"); }
 
 die() { echo "FATAL: $*" >&2; exit 2; }
+
+# check_v6_transit asserts IPv6 traffic still crosses the firewall (#6934).
+#
+# It probes the WAN-side target rather than the LAN VIP deliberately. Pinging
+# the VIP exercises L2 and local delivery on the same segment and never crosses
+# the fabric, so it stays green through exactly the failures this is here to
+# catch — measured: during a LAN/WAN redundancy-group split the VIP answers with
+# 0% loss while transit is degraded.
+#
+# It tolerates losing packets but not all of them, and that threshold is
+# measured rather than picked. A cross-node split costs the FIRST packet of a
+# new flow, reproducibly and without self-healing, so a `-c 1` probe would be
+# flaky on a healthy-enough cluster while a "0% loss" assertion would red on a
+# condition this gate is not scoped to. Requiring 3 of 5 separates a blackhole
+# (0 received — the #6934 report) from that first-packet loss (4 of 5).
+check_v6_transit() {
+	local label="$1" out recv
+	out=$(incus exec "$CLUSTER_LAN_HOST" -- ping6 -c "$V6_PROBE_COUNT" -W 1 "$IPERF_TARGET6" 2>&1 || true)
+	recv=$(printf '%s\n' "$out" | sed -n 's/.* \([0-9][0-9]*\) received.*/\1/p' | head -1)
+	[ -z "$recv" ] && recv=0
+	if [ "$recv" -ge "$V6_PROBE_MIN" ]; then
+		pass "IPv6 transit OK ${label} (${recv}/${V6_PROBE_COUNT} to ${IPERF_TARGET6})"
+	else
+		fail "IPv6 transit BLACKHOLED ${label}: only ${recv}/${V6_PROBE_COUNT} replies from ${IPERF_TARGET6}. IPv4 can stay healthy through this — ND holds a REACHABLE entry ~30s before probing, so a stale or unannounced neighbour entry blackholes v6 while ARP re-resolves in seconds (#6934)"
+	fi
+}
 # #7368: a PRECONDITION failure is not a failover regression, and neither is an
 # ownership/forwarding divergence. All three used to exit 2, so `FO_RC=2` was
 # read as "failover broke" when it meant "the cluster was not in a state to
@@ -122,6 +155,11 @@ if incus exec "$CLUSTER_LAN_HOST" -- ping -c 2 -W 2 "$IPERF_TARGET" &>/dev/null;
 else
 	die "Cannot reach iperf3 target $IPERF_TARGET from ${CLUSTER_LAN_HOST}"
 fi
+
+# #6934: the IPv6 baseline. Asserted BEFORE any failover so a later v6 failure
+# is attributable to the transition rather than to a cluster that never had v6
+# transit — without this the post-failover cells could red on a broken fixture.
+check_v6_transit "at baseline (before any failover)"
 
 # Kill any stale iperf3
 incus exec "$CLUSTER_LAN_HOST" -- pkill -9 iperf3 2>/dev/null || true
@@ -376,6 +414,13 @@ else
 		fail "iperf3 DIED during manual failover"
 	fi
 fi
+
+# #6934: the reported scenario. A manual RG failover moves the RETH virtual MAC,
+# so every peer holding a neighbour entry for a VIP or for the stable RETH
+# link-local must be corrected by the unsolicited-NA burst. The iperf3 check
+# above cannot see a failure here: it is one long-lived IPv4 flow, so it
+# survives on established state while a NEW IPv6 flow blackholes.
+check_v6_transit "after manual failover"
 
 # ── Phase 5: Wait for iperf3 to complete and validate results ───────
 


### PR DESCRIPTION
Refs #6934

**Does not close #6934.** The issue's diagnosis is refuted by measurement, but the operator's symptom is not reproduced, so this lands the two things that are settled and leaves the bug open and correctly characterised.

## What this changes

**1. `test-failover.sh` asserts IPv6 transit.** The gate asserted IPv4 iperf3 survival and nothing else, so an IPv6-only failover regression could not red it.

This is a NEW cell rather than a fix to an existing one, and the reason is worth stating: `cluster-env.sh` has exported `IPERF_TARGET6` since it was written, and this script never read it. **An unused export is a gate that looks like it covers something.** Anyone grepping for IPv6 coverage of the failover path finds the variable, finds it exported and populated per-cluster, and concludes the path is covered. That is why #6934 reached a human as an ad-hoc observation instead of reddening a test.

**2. A false RFC claim in `buildUnsolicitedNA`'s doc comment** (found by #6934) is corrected.

No behaviour change: one shell test gains assertions, one Go comment is fixed.

## Two design choices in the new cell, both measured

**It probes the WAN-side target, not the LAN VIP.** Pinging the VIP exercises L2 and local delivery on the same segment and never crosses the fabric. Measured: during a LAN/WAN redundancy-group split, the VIP answers with **0% loss** while transit through the box is degraded — so a VIP probe stays green through exactly the class of failure this cell exists to catch. I know because my first repro attempt did precisely that and produced a confidently wrong negative.

**The threshold is 3-of-5, not 0% loss — and it has an expiry.** A cross-node split costs the *first packet of every new flow*, reproducibly and without self-healing (12.5% still present on a fresh probe 45s later). A strict no-loss assertion would red on a condition this gate is not scoped to; a `-c 1` probe would be flaky on a healthy cluster. 3-of-5 separates a blackhole (0 received — the #6934 symptom) from first-packet loss (4 of 5).

**That tolerance is COUPLED to #7770 and the code says so.** 3-of-5 is not a general-purpose slack value; it is calibrated to absorb exactly one known defect. Once #7770 is fixed the threshold becomes looser than it needs to be and would hide a one-packet regression, so the comment next to it cites the issue and says to raise `V6_PROBE_MIN` to `V6_PROBE_COUNT` at that point. A tolerance whose reason is undocumented is indistinguishable from one nobody thought about — the next reader cannot tell "3 of 5 because a known defect costs exactly one packet" from "3 of 5 because the author was unsure", and only the first is safe to tighten later.

## Arming — parse and wiring, separately

The parse is the defect-prone half of a gate like this: a filter matching only the healthy shape goes silent exactly when the defect is present. Checked against six real `ping6` shapes:

| input | recv | verdict |
|---|---|---|
| `5 packets transmitted, 5 received, 0% packet loss` | 5 | PASS |
| `5 packets transmitted, 4 received, 20% packet loss` | 4 | **PASS** (the middle row) |
| `5 packets transmitted, 0 received, 100% packet loss` | 0 | FAIL |
| `5 packets transmitted, 0 received, +5 errors, 100% packet loss` | 0 | FAIL |
| `connect: Network is unreachable` (no summary) | 0 | FAIL |
| empty | 0 | FAIL |

The middle row is the one that distinguishes this threshold from a naive assertion; both malformed-input rows fail closed.

**Wiring armed separately from the parse**, using the cell's own commands against the live cluster:

```
target 2001:559:8585:80::200   recv=5/5 -> PASS
target 2001:db8:dead:beef::1   recv=0/5 -> FAIL (blackhole detected)
```

## The comment fix, and why it was not cosmetic

`buildUnsolicitedNA` said the NA is sent *"with Override and Solicited flags cleared per RFC 4861 §7.2.6"*, while the setter thirty lines below sets `pkt[58] = 0xA0` — Router + Override. Only Solicited is cleared.

That difference is load-bearing. RFC 4861 §7.2.5 permits a receiver to **keep** its existing cache entry when an NA arrives with Override=0, so an Override=0 burst could not correct a peer still pointing at the old node — which is the entire convergence this code drives. A reader auditing conformance hits the false sentence first, and #6934 spent a round ruling out an Override=0 bug the code never had.

## What the investigation established (context, not shipped here)

- **The NA burst works.** Manual failover of **RG2** — the RG that actually owns `reth1` — with simultaneous sender and receiver captures: **96 unsolicited NAs sent, 96 received**, plus 96/96 broadcast ARP. The issue's capture found zero because it was taken across an **RG0+RG1** failover, and `reth0`→RG1 (WAN) / `reth1`→RG2 (LAN). RG2 never transitioned, so its instance correctly emitted nothing.
- **Coverage is complete.** The LAN host's v6 default route is `via fe80::bf72:16:2`; the burst announces exactly that plus the VIP.
- **A separate, unreported defect**: the LAN/WAN split costs one packet per new flow, symmetrically in both families, persistently. Being filed on its own — it explains the reporter's v4 loss and explicitly not the v6 blackhole (100% vs 12.5%).
- **The reported symptom is unreproduced** across four placements. Left open rather than attached to the split, whose numbers do not match it.

## Test plan

- [x] `go build ./...` → rc 0
- [x] `go test ./... -count=1` → **68/68** at `ff557cc90` (head now `6dabb4735`, comment-only commit on top), `origin/master` folded, ancestry verified
- [x] `bash -n` and `shellcheck -S error` on `test-failover.sh` → clean
- [x] **`make test-failover` on the loss userspace cluster → 16 passed / 0 failed**, up from 14:
      `PASS IPv6 transit OK at baseline (5/5)` and `PASS IPv6 transit OK after manual failover (5/5)`.
      `passed + failed == 16`, so no cell went silent.
- [x] `docs/log/6934.md` records the measurements and the two unshipped findings

Note on the cluster run: the first attempt died in `cluster-deploy`'s post-deploy reassert, not in the gate. Realigning the RGs by hand fixed it and the rerun was clean. That failure looks like a race in `deploy-lib.sh` — it resets the manual pin immediately after driving the failover, with no wait for the transfer to land, and with `Preempt: no` the RG can fall straight back. Reported separately as a hypothesis; it is not caused by anything here and confirming it needs its own controlled comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhHmVt536ZsY2RVEhc8WPV
