### PR TITLE
bpf_map: refuse to publish a v6 key whose protocol is an ext-header

### DIFF
--- a/docs/log/6923.md
+++ b/docs/log/6923.md
@@ -1,0 +1,54 @@
+# #6923 — the shim's over-limit refusal was held by an enumeration, not a gate
+
+- **Timestamp**: 2026-08-27
+  - **Action**: expressed the refusal ONCE, at the point where a v6 session key
+    becomes visible to the shim (`publish_v6_session`), so a third writer
+    inherits it instead of having to remember it.
+  - **The issue asked for "a single chokepoint that all session-key publication
+    goes through". It already existed** — the finding was establishing that,
+    not building it. Three sites write the v6 conntrack map:
+    | site | flag | can it create a key? |
+    |---|---|---|
+    | `publish_bpf_conntrack_entry` → `publish_v6_session` | `BPF_ANY` | **yes** — and `publish_v6_session` has exactly ONE caller |
+    | `refresh_bpf_conntrack_last_seen` | `BPF_EXIST` | **no** |
+    | `delete_bpf_conntrack_entry` | — | no, it deletes |
+  - **`BPF_EXIST` cannot create — demonstrated against a real map, not cited.**
+    "The flag is named EXIST" and "the kernel refuses creation under this flag"
+    are different claims and only the second is load-bearing. Measured:
+    `BPF_EXIST` on an absent key → **ENOENT**; `BPF_ANY` on the same key →
+    **rc=0**. Shipped as
+    `test/mutation/selftest-bpf-exist-cannot-create_6923.sh`, wired into
+    `scripts/run-selftests.sh`.
+    - The **`BPF_ANY` leg is the positive control**: without it an ENOENT is
+      equally consistent with "the flag refuses creation" and "the fixture is
+      broken and nothing would have worked".
+    - A **third leg** closes the remaining reading — `BPF_EXIST` on a key that
+      now EXISTS must succeed, so the ENOENT was about absence rather than
+      `BPF_EXIST` always failing.
+    - **SKIPs (77) rather than passing** when it cannot run: `BPF_MAP_CREATE`
+      needs `CAP_BPF`, and this host has `unprivileged_bpf_disabled=2`, so an
+      unprivileged create returns EPERM. A test that silently passes when it
+      could not run is worse than one that reports SKIP.
+  - **Deliberately unreachable today, and that is the intended state.** Both
+    existing writers already decline, so the refusal refuses nothing that
+    currently happens. It is a BACKSTOP whose value is staying true when a third
+    writer appears — and unlike the "ships and does nothing" shape, the guard IS
+    the deliverable and is directly testable at its own entry point.
+  - **The positive control is the one that matters most here.** A refusal that
+    is too WIDE is not a safe direction: refusing everything would be a total
+    outage of v6 session publication that, from the shim's side, looks exactly
+    like the fix working — every probe misses, every packet goes to userspace,
+    slower and correct-looking and catastrophic. So the sweep asserts BOTH
+    directions over all 256 values, and a named control pins TCP/UDP/ICMPv6/
+    ESP/SCTP/GRE as still publishable.
+  - **A wiring gap in my own change, caught by asking the question before the
+    matrix did.** Deleting the CALL from `publish_v6_session` would have red
+    nothing — every other test exercised the predicate directly, and the
+    predicate was never the part at risk. A behavioural test needs a real BPF
+    map fd and CAP_BPF, which unit tests lack, so the call site is bound
+    structurally instead, **including the ORDER**: the refusal must precede the
+    `BpfSessionKeyV6` construction, because a check after the map update leaves
+    the key visible for exactly the window that matters.
+  - **File(s)**: userspace-dp/src/afxdp/bpf_map/publish_conntrack.rs,
+    test/mutation/selftest-bpf-exist-cannot-create_6923.sh,
+    scripts/run-selftests.sh, docs/log/6923.md

--- a/scripts/run-selftests.sh
+++ b/scripts/run-selftests.sh
@@ -165,6 +165,13 @@ run_shell test/xsk-repro/selftest-multitoken-cc_6355.sh
 # the exact failure the reproducer exists to detect, reported as PASS. SKIPs
 # without cargo or offline-buildable deps.
 run_shell test/xsk-repro/selftest-probe-filter_6898.sh
+# #6923: the chokepoint argument for the v6 conntrack publish path rests on
+# `refresh_bpf_conntrack_last_seen` being unable to CREATE a key, because it
+# updates with BPF_EXIST. "The flag is named EXIST" and "the kernel refuses
+# creation under this flag" are different claims; this asks the kernel, with a
+# BPF_ANY positive control so an ENOENT cannot come from a broken fixture.
+# SKIPs without cc, passwordless sudo, or CAP_BPF.
+run_shell test/mutation/selftest-bpf-exist-cannot-create_6923.sh
 
 # ── summary ──
 printf '\n\033[1m== selftest summary ==\033[0m\n'

--- a/test/mutation/selftest-bpf-exist-cannot-create_6923.sh
+++ b/test/mutation/selftest-bpf-exist-cannot-create_6923.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# #6923: demonstrate that BPF_EXIST cannot CREATE a map entry.
+#
+# WHY THIS EXISTS AS A TEST RATHER THAN A CITATION. The #6923 chokepoint
+# argument is that `publish_v6_session` is the ONLY path by which a v6 session
+# key becomes visible to the shim, because the other two writers cannot mint a
+# key: `delete_bpf_conntrack_entry` deletes, and `refresh_bpf_conntrack_last_seen`
+# updates with BPF_EXIST.
+#
+# "The flag is named EXIST" and "the kernel refuses creation under this flag"
+# are DIFFERENT CLAIMS, and only the second is the one the argument needs. This
+# asks the kernel.
+#
+# The BPF_ANY leg is the positive control and it is what makes this a
+# measurement rather than a null result: without it, an ENOENT from the
+# BPF_EXIST leg is equally consistent with "the flag refuses creation" and "my
+# fixture is broken and nothing would have worked". The third leg (BPF_EXIST on
+# a key that now EXISTS) closes the remaining reading — that BPF_EXIST simply
+# always fails.
+#
+# SKIPs (77) rather than passing when it cannot run. Creating a BPF map needs
+# CAP_BPF, and on a host with kernel.unprivileged_bpf_disabled=2 an unprivileged
+# BPF_MAP_CREATE returns EPERM. A test that silently passes when it could not
+# run is worse than one that reports SKIP.
+set -e
+cd "$(dirname "$0")"
+
+command -v cc >/dev/null 2>&1 || { echo "SKIP: no C compiler"; exit 77; }
+sudo -n true >/dev/null 2>&1 || { echo "SKIP: no passwordless sudo (BPF_MAP_CREATE needs CAP_BPF)"; exit 77; }
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT INT TERM
+
+cat >"${tmp}/probe.c" <<'EOF'
+#include <linux/bpf.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+
+static int upd(int fd, unsigned *k, unsigned *v, unsigned long long flags) {
+    union bpf_attr a;
+    memset(&a, 0, sizeof(a));
+    a.map_fd = fd;
+    a.key = (unsigned long)k;
+    a.value = (unsigned long)v;
+    a.flags = flags;
+    return syscall(SYS_bpf, BPF_MAP_UPDATE_ELEM, &a, sizeof(a));
+}
+
+int main(void) {
+    union bpf_attr a;
+    memset(&a, 0, sizeof(a));
+    a.map_type = BPF_MAP_TYPE_HASH;
+    a.key_size = 4; a.value_size = 4; a.max_entries = 8;
+    int fd = syscall(SYS_bpf, BPF_MAP_CREATE, &a, sizeof(a));
+    if (fd < 0) { printf("SKIP_CREATE %s\n", strerror(errno)); return 77; }
+
+    unsigned k = 1, v = 7;
+
+    /* 1. BPF_EXIST on an ABSENT key MUST fail with ENOENT. */
+    if (upd(fd, &k, &v, BPF_EXIST) == 0) {
+        printf("FAIL BPF_EXIST created an absent key\n"); return 1;
+    }
+    if (errno != ENOENT) {
+        printf("FAIL BPF_EXIST failed with %s, expected ENOENT\n", strerror(errno)); return 1;
+    }
+
+    /* 2. POSITIVE CONTROL: BPF_ANY on the SAME absent key must succeed, or the
+     *    ENOENT above proves nothing about the flag. */
+    if (upd(fd, &k, &v, BPF_ANY) != 0) {
+        printf("FAIL control: BPF_ANY could not create (%s) — fixture broken\n", strerror(errno));
+        return 1;
+    }
+
+    /* 3. SECOND CONTROL: BPF_EXIST on the key that now EXISTS must succeed, so
+     *    the ENOENT was about ABSENCE and not about BPF_EXIST always failing. */
+    if (upd(fd, &k, &v, BPF_EXIST) != 0) {
+        printf("FAIL control: BPF_EXIST on a present key failed (%s)\n", strerror(errno));
+        return 1;
+    }
+
+    printf("OK BPF_EXIST refuses creation (ENOENT); BPF_ANY creates; BPF_EXIST updates\n");
+    return 0;
+}
+EOF
+
+cc -O1 -Wall -Wextra -o "${tmp}/probe" "${tmp}/probe.c" 2>"${tmp}/cc.err" || {
+    echo "SKIP: probe did not compile (missing linux/bpf.h?)"; sed 's/^/  /' "${tmp}/cc.err"; exit 77; }
+
+out="$(sudo -n "${tmp}/probe" 2>&1)" && rc=0 || rc=$?
+case "${out}" in
+  SKIP_CREATE*) echo "SKIP: BPF_MAP_CREATE refused (${out#SKIP_CREATE })"; exit 77 ;;
+esac
+if [ "${rc}" -ne 0 ]; then
+    echo "FAIL: ${out}"
+    exit 1
+fi
+echo "PASS: ${out}"
+exit 0

--- a/userspace-dp/src/afxdp/bpf_map/publish_conntrack.rs
+++ b/userspace-dp/src/afxdp/bpf_map/publish_conntrack.rs
@@ -256,6 +256,24 @@ pub(super) fn build_conntrack_value_v4(
 }
 
 #[allow(clippy::too_many_arguments)]
+/// #6923: may a v6 session key with this protocol become visible to the shim?
+///
+/// False for exactly the next-header values the shim's extension-header walk
+/// TRAVERSES. Those are the values the walk can emit by EXHAUSTING its loop —
+/// it returns the last declared next-header, so an over-limit chain surfaces as
+/// a key whose "protocol" is an extension header. Such a key must never exist
+/// in the map, because the shim probes it and a hit means the over-limit chain
+/// takes the fast path on an identity nothing parsed.
+///
+/// Derived from `ipv6_ext_header_is_traversable` rather than a second list of
+/// protocol numbers. A duplicated set drifts, and it drifts in the direction
+/// that reopens the hole: the walker learns a new traversable type, this copy
+/// does not, and the refusal silently stops covering it — which is exactly how
+/// the #4517 types came to be missing from the GRE-inner classify in #6886.
+fn v6_session_key_is_publishable(protocol: u8) -> bool {
+    !crate::afxdp::ipv6_ext_header_is_traversable(protocol)
+}
+
 pub(super) fn publish_v6_session(
     conntrack_v6_fd: c_int,
     key: &SessionKey,
@@ -272,6 +290,43 @@ pub(super) fn publish_v6_session(
     // #5213: stable dataplane session id — see publish_v4_session.
     session_id: u64,
 ) {
+    // #6923: THE CHOKEPOINT. Refuse to make a key the shim would probe visible
+    // when its protocol is an IPv6 extension-header type rather than an L4.
+    //
+    // The shim's over-limit refusal was never a property of the shim. Its walk
+    // exhausts and returns the LAST DECLARED next-header — an extension-header
+    // value, not a real protocol — and `parse_l4`'s catch-all then yields ports
+    // 0/0. The intended consequence is that the session lookup MISSES and the
+    // packet is redirected to userspace. But the lookup only misses while
+    // nothing has published `(AF_INET6, <a traversable next-header>, src, dst,
+    // 0, 0)`. Publish that tuple and the next packet of the same over-limit
+    // chain HITS and takes the fast path, silently, with no code change
+    // anywhere near the shim.
+    //
+    // That was previously held by an ENUMERATION — two writers that both
+    // declined the tuple (`metadata_tuple_complete` on the packet path,
+    // `build_synced_session_key` on the HA import path) and a doc comment
+    // asking that a third not be added. A comment is not a gate, and an
+    // enumeration is only as good as its completeness.
+    //
+    // Here it is expressed ONCE, at the point where a key becomes shim-visible,
+    // so a third writer inherits it instead of having to remember it. This is
+    // the sole path by which a v6 key can enter the map the shim probes:
+    //   - `publish_bpf_conntrack_entry` -> here, `BPF_ANY` (creates)
+    //   - `refresh_bpf_conntrack_last_seen`, `BPF_EXIST` — CANNOT create; that
+    //     is demonstrated against a real map, not inferred from the flag's
+    //     name, by `test/mutation/selftest-bpf-exist-cannot-create_6923.sh`
+    //   - `delete_bpf_conntrack_entry` — a delete, which cannot mint a key
+    //
+    // DELIBERATELY UNREACHABLE TODAY. Both existing writers already decline, so
+    // this refuses nothing that currently happens — it is a backstop, and its
+    // value is that it stays true when a third writer appears. It is exercised
+    // by its own tests rather than by production traffic, which is the intended
+    // state for a backstop and not the "ships and does nothing" shape: the
+    // guard IS the deliverable, and it is directly testable at its own entry.
+    if !v6_session_key_is_publishable(key.protocol) {
+        return;
+    }
     let bpf_key = BpfSessionKeyV6 {
         src_ip: src.octets(),
         dst_ip: dst.octets(),
@@ -538,5 +593,149 @@ mod alg_type_tests {
         );
         // Wrong protocol on an ALG port (e.g. TCP/53) is not the DNS ALG.
         assert_eq!(alg_type_for_session(PROTO_TCP, 41234, 53, 0), ALG_TYPE_NONE);
+    }
+}
+
+#[cfg(test)]
+mod publish_chokepoint_6923_tests {
+    use super::*;
+
+    /// #6923: the refusal covers exactly the traversable set — and no more.
+    ///
+    /// The second half is the part that needs saying. A refusal that is too
+    /// WIDE is not a safe direction here: it would stop publishing sessions
+    /// that are legitimate today, turning a backstop into an outage. So this
+    /// sweeps all 256 values and asserts both directions.
+    #[test]
+    fn refusal_covers_exactly_the_traversable_set_6923() {
+        let mut refused = Vec::new();
+        for protocol in 0u8..=255 {
+            let publishable = v6_session_key_is_publishable(protocol);
+            let traversable = crate::afxdp::ipv6_ext_header_is_traversable(protocol);
+            assert_eq!(
+                publishable, !traversable,
+                "#6923: protocol {protocol}: publishable={publishable} but traversable={traversable}. \
+                 The refusal must be exactly the set the shim's walk can emit by exhausting its \
+                 loop — narrower reopens the hole, wider drops legitimate sessions"
+            );
+            if !publishable {
+                refused.push(protocol);
+            }
+        }
+        assert_eq!(
+            refused,
+            vec![0, 43, 44, 51, 60, 135, 139, 140, 253, 254],
+            "#6923: the refused set changed. If the walker legitimately learned a new traversable \
+             type this is the expected red — update it deliberately. If it SHRANK, the refusal \
+             just stopped covering a value the shim can still emit"
+        );
+    }
+
+    /// THE POSITIVE CONTROL: the refusal must not reject a key that is
+    /// legitimate today.
+    ///
+    /// Without this the sweep above is satisfiable by refusing everything, and
+    /// "refuse everything" is a total outage of v6 session publication that
+    /// would look, from the shim's side, exactly like the fix working — every
+    /// probe misses and every packet goes to userspace. Slower, correct-looking,
+    /// and catastrophic.
+    #[test]
+    fn refusal_does_not_reject_a_currently_legitimate_key_6923() {
+        for (protocol, name) in [
+            (PROTO_TCP, "TCP"),
+            (PROTO_UDP, "UDP"),
+            (crate::ip_proto::PROTO_ICMPV6, "ICMPv6"),
+            (crate::ip_proto::PROTO_ESP, "ESP"),
+            (crate::ip_proto::PROTO_SCTP, "SCTP"),
+            (crate::ip_proto::PROTO_GRE, "GRE"),
+        ] {
+            assert!(
+                v6_session_key_is_publishable(protocol),
+                "#6923: {name} ({protocol}) is a real L4/terminal protocol whose v6 sessions must \
+                 still publish. Refusing it would take the fast path away from live traffic, and \
+                 from the shim's side that is indistinguishable from the backstop working"
+            );
+        }
+    }
+
+    /// #6923 WIRING: `publish_v6_session` must CALL the refusal, before it
+    /// builds the key.
+    ///
+    /// Added because deleting the call red nothing: every other test here
+    /// exercises the predicate directly, and the predicate was never the part
+    /// at risk. A refusal that is perfectly correct and never invoked is the
+    /// defect this whole change is about, one layer in — and this codebase has
+    /// hit that shape repeatedly (#6888, #7713, and #7734's own detector).
+    ///
+    /// A behavioural test would be better, but publishing needs a real BPF map
+    /// fd and CAP_BPF, which unit tests do not have. So this binds the call
+    /// site structurally, and the ORDER with it: the refusal must precede the
+    /// `BpfSessionKeyV6` construction, because a check after the map update
+    /// would let the key exist for the window that matters.
+    #[test]
+    fn publish_v6_session_calls_the_refusal_before_building_the_key_6923() {
+        let src = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("src/afxdp/bpf_map/publish_conntrack.rs"),
+        )
+        .expect("read publish_conntrack.rs");
+        let code: String = src
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let start = code
+            .find("pub(super) fn publish_v6_session(")
+            .expect("#6923: publish_v6_session is gone — fix this bind, do not delete it");
+        let body = &code[start..];
+        let end = body.find("\n}").expect("#6923: could not bound publish_v6_session");
+        let body = &body[..end];
+
+        let guard_at = body.find("v6_session_key_is_publishable").expect(
+            "#6923: publish_v6_session does not call the refusal. The predicate can be entirely \
+             correct and never invoked — that is the same defect this change exists to close, one \
+             layer in",
+        );
+        let key_at = body
+            .find("BpfSessionKeyV6 {")
+            .expect("#6923: publish_v6_session no longer builds a BpfSessionKeyV6");
+        assert!(
+            guard_at < key_at,
+            "#6923: the refusal must run BEFORE the key is built and published. A check placed \
+             after the map update leaves the key visible to the shim for exactly the window that \
+             matters"
+        );
+    }
+
+    /// #6923 anti-drift: the refusal must DERIVE from the walker's own set.
+    ///
+    /// Comments stripped first — this module's prose names both identifiers, so
+    /// an unstripped scan would be satisfied by the documentation rather than
+    /// the code (the #6885 lesson).
+    #[test]
+    fn refusal_derives_from_the_walker_set_not_a_second_list_6923() {
+        let src = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("src/afxdp/bpf_map/publish_conntrack.rs"),
+        )
+        .expect("read publish_conntrack.rs");
+        let code: String = src
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let start = code
+            .find("fn v6_session_key_is_publishable(")
+            .expect("#6923: the predicate is gone — this bind has rotted, fix it, do not delete it");
+        let body = &code[start..];
+        let end = body.find("\n}").expect("#6923: could not bound the predicate");
+        let body = &body[..end];
+        assert!(
+            body.contains("ipv6_ext_header_is_traversable"),
+            "#6923: the refusal must derive from `ipv6_ext_header_is_traversable`, not restate a \
+             list of protocol numbers. A second copy drifts, and it drifts toward reopening the \
+             hole: the walker learns a type, the copy does not, and the refusal silently stops \
+             covering it"
+        );
     }
 }


### PR DESCRIPTION
Closes #6923

The shim's over-limit extension-header refusal was never a property of the shim.
Its walk exhausts and returns the **last declared next-header** — an
extension-header value, not a real protocol — and `parse_l4`'s catch-all then
yields ports `0/0`. The intended consequence is that the session lookup misses
and the packet goes to userspace. But the lookup only misses while nothing has
published `(AF_INET6, <a traversable next-header>, src, dst, 0, 0)`. Publish that
tuple and the next packet of the same over-limit chain **hits** and takes the
fast path, silently, with no code change anywhere near the shim.

That was held by an **enumeration**: two writers that both decline the tuple, and
a doc comment asking that a third not be added. A comment is not a gate.

## The chokepoint already existed — establishing that was the finding

| site | flag | can it create a key? |
|---|---|---|
| `publish_bpf_conntrack_entry` → `publish_v6_session` | `BPF_ANY` | **yes** — and `publish_v6_session` has exactly **one** caller |
| `refresh_bpf_conntrack_last_seen` | `BPF_EXIST` | **no** |
| `delete_bpf_conntrack_entry` | — | no, it deletes |

So expressing the refusal in `publish_v6_session` covers every way a key becomes
shim-visible, and a third writer **inherits** it rather than having to remember
it.

## `BPF_EXIST` cannot create — demonstrated, not cited

*"The flag is named EXIST"* and *"the kernel refuses creation under this flag"*
are different claims, and only the second is load-bearing for the argument above.
Measured against a real map:

```
BPF_EXIST on an ABSENT key  -> rc=-1  ENOENT
BPF_ANY   on the same key   -> rc=0            (creates)
BPF_EXIST on the now-PRESENT key -> rc=0       (updates)
```

- The **`BPF_ANY` leg is the positive control**: without it, an ENOENT is equally
  consistent with *"the flag refuses creation"* and *"the fixture is broken and
  nothing would have worked"*.
- The **third leg** closes the last reading — that `BPF_EXIST` simply always
  fails.

Shipped as `test/mutation/selftest-bpf-exist-cannot-create_6923.sh` and wired
into `scripts/run-selftests.sh`. It **SKIPs (77) rather than passing** when it
cannot run: `BPF_MAP_CREATE` needs `CAP_BPF`, and a test that silently passes
when it could not run is worse than one that reports SKIP.

## Deliberately unreachable today

Both existing writers already decline, so this refuses nothing that currently
happens. It is a **backstop** whose value is staying true when a third writer
appears — and unlike code that ships and does nothing, the guard **is** the
deliverable and is directly testable at its own entry point.

## The positive control matters most here

A refusal that is too **wide** is not a safe direction. Refusing everything would
be a total outage of v6 session publication that, from the shim's side, looks
**exactly like the fix working** — every probe misses, every packet goes to
userspace. Slower, correct-looking, and catastrophic.

So the sweep asserts **both** directions over all 256 values, and a named control
pins TCP/UDP/ICMPv6/ESP/SCTP/GRE as still publishable.

## Mutation matrix

Fix committed before mutating. Control: **2 binaries, 4754 collected, 0 red**;
every cell reports the same 2, so none is a build break.

| # | Mutation | Named RED |
|---|---|---|
| M1 | delete the CALL (predicate intact, never invoked) | `publish_v6_session_calls_the_refusal_before_building_the_key_6923` |
| M2 | refusal restated as its own protocol list | the sweep + the anti-drift bind |
| M3 | refusal too **wide** (refuse everything) | the sweep, the anti-drift bind, **and the positive control** |
| M4 | check placed **after** the key is built | the order bind |

**M1 is a gap I closed in my own change before the matrix found it.** Deleting
the call would have red nothing — every other test exercised the predicate
directly, and the predicate was never the part at risk. A behavioural test needs
a real BPF map fd and `CAP_BPF`, which unit tests lack, so the call site is bound
structurally, **including its order** relative to the key construction: a check
placed after the map update leaves the key visible for exactly the window that
matters.

*(M4's second red, `v8_epoch_seqlock_snapshot_never_tears_tag_grace`, is a
pre-existing timing flake — it passes in every clean run and this PR touches no
`shared_cos_lease` file.)*

## Validation

Gated head `22d901154` (`origin/master` merged in, not rebased; clean).

- `cargo test --release --bins --tests --no-fail-fast -- --test-threads=1`: **10 binaries, 4830 collected, 0 failed**
- `go test ./... -count=1`: **rc=0**, 68 packages
- `scripts/run-selftests.sh`: **passed=66 skipped=0 failed=0**
