### PR TITLE
config: make the syslog source resolver agree with its validator (#6942)

### DIFF
--- a/pkg/config/syslog_source.go
+++ b/pkg/config/syslog_source.go
@@ -21,15 +21,35 @@ import (
 // or a local-console commit (#5738). The split rule (first '.') mirrors
 // ValidateSyslogSourceInterface exactly.
 func ResolveSyslogSourceAddr(cfg *Config, srcIface string) string {
+	// #6942: normalise exactly as ValidateSyslogSourceInterface does. The
+	// validator trims before it parses, so on the strict path a value with
+	// surrounding whitespace is judged in its trimmed form and then handed here
+	// untrimmed — the two disagreed about the same string. The callers only
+	// guard `!= ""`, which a whitespace-only value passes.
+	srcIface = strings.TrimSpace(srcIface)
+
 	// Parse "iface.unit" — e.g. "reth1.100" → base="reth1", unit=100
 	base, unitStr, hasUnit := strings.Cut(srcIface, ".")
 	unitNum := 0
+	unitOK := true
 	if hasUnit {
-		if n, err := strconv.Atoi(unitStr); err == nil {
+		// #6942: the error was checked and then IGNORED — unitNum stayed 0, so
+		// "reth1.abc" resolved to reth1 unit 0 and syslog bound the wrong
+		// logical unit, silently and plausibly. ValidateSyslogSourceInterface
+		// rejects this and its message names this exact behaviour ("a
+		// non-numeric unit silently binds the syslog source to unit 0"), so the
+		// strict path masked it; the lenient path (Load / SyncApply) did not.
+		//
+		// A BARE name legitimately means unit 0 — that is why the skip is
+		// conditioned on hasUnit && parse-failed rather than on unitNum == 0.
+		n, err := strconv.Atoi(unitStr)
+		if err != nil {
+			unitOK = false
+		} else {
 			unitNum = n
 		}
 	}
-	if ifc, ok := cfg.Interfaces.Interfaces[base]; ok && ifc != nil {
+	if ifc, ok := cfg.Interfaces.Interfaces[base]; ok && ifc != nil && unitOK {
 		if unit, ok := ifc.Units[unitNum]; ok && unit.PrimaryAddress != "" {
 			// PrimaryAddress is CIDR — strip the prefix length
 			if ip, _, err := net.ParseCIDR(unit.PrimaryAddress); err == nil {

--- a/pkg/config/syslog_source_agreement_6942_test.go
+++ b/pkg/config/syslog_source_agreement_6942_test.go
@@ -1,0 +1,122 @@
+package config
+
+import "testing"
+
+// #6942: ResolveSyslogSourceAddr and ValidateSyslogSourceInterface judge the
+// SAME string and disagreed about it in two ways — the validator rejects where
+// the resolver silently substituted a default.
+//
+// The fixture gives unit 0 an address DIFFERENT from unit 100's, because that is
+// what makes the defect observable: if unit 0 had no address, or the same one,
+// a wrong-unit resolution would be indistinguishable from a correct one and
+// every cell below would pass against the unfixed code.
+func syslogFixture6942() *Config {
+	cfg := &Config{}
+	cfg.Interfaces.Interfaces = map[string]*InterfaceConfig{
+		"reth1": {
+			Name: "reth1",
+			Units: map[int]*InterfaceUnit{
+				0:   {PrimaryAddress: "10.0.0.1/24"},
+				100: {PrimaryAddress: "10.0.100.1/24"},
+			},
+		},
+	}
+	return cfg
+}
+
+// TestResolverRefusesAnUnparseableUnit6942 is the defect-1 guard.
+//
+// RED-on-revert: restore the `unitNum` fallback (drop `unitOK`) and "reth1.abc"
+// resolves to 10.0.0.1 — unit 0's address — instead of "". Asserting the
+// returned ADDRESS rather than merely "not unit 100" is what catches it: both
+// the fixed and unfixed code fail to return unit 100's address, and only the
+// unfixed one returns unit 0's.
+func TestResolverRefusesAnUnparseableUnit6942(t *testing.T) {
+	cfg := syslogFixture6942()
+	for _, bad := range []string{"reth1.abc", "reth1.", "reth1.99999999999999999999"} {
+		got := ResolveSyslogSourceAddr(cfg, bad)
+		if got == "10.0.0.1" {
+			t.Errorf("ResolveSyslogSourceAddr(%q) = %q — unit 0's address. An unparseable "+
+				"logical unit silently bound syslog to the WRONG unit, which is exactly what "+
+				"ValidateSyslogSourceInterface's own error message warns about (#6942).", bad, got)
+		}
+		if got != "" {
+			t.Errorf("ResolveSyslogSourceAddr(%q) = %q, want \"\" so the caller falls through "+
+				"to the global source rather than binding a guessed unit", bad, got)
+		}
+	}
+}
+
+// TestResolverStillHonoursValidInputs6942 is the paired control, and it is what
+// stops the guard above from being satisfied by a resolver that refuses
+// everything.
+//
+// It also pins the case the fix must NOT break: a BARE interface name
+// legitimately means unit 0. That is why the skip is conditioned on
+// `hasUnit && parse-failed` rather than on `unitNum == 0` — the latter would
+// have broken every bare-name caller while passing the defect-1 cell.
+func TestResolverStillHonoursValidInputs6942(t *testing.T) {
+	cfg := syslogFixture6942()
+	for in, want := range map[string]string{
+		"reth1":     "10.0.0.1",   // bare name -> unit 0, and it MUST still work
+		"reth1.0":   "10.0.0.1",   // explicit unit 0
+		"reth1.100": "10.0.100.1", // explicit non-zero unit
+	} {
+		if got := ResolveSyslogSourceAddr(cfg, in); got != want {
+			t.Errorf("ResolveSyslogSourceAddr(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestResolverTrimsLikeTheValidator6942 is the defect-2 guard.
+//
+// The validator trims before judging, so on the strict path a padded value is
+// approved in its trimmed form and then handed to the resolver untrimmed. The
+// callers only guard `!= ""`, which a whitespace-only value passes.
+//
+// RED-on-revert: drop the TrimSpace and " reth1.100 " resolves to "" (no such
+// interface) instead of unit 100's address.
+func TestResolverTrimsLikeTheValidator6942(t *testing.T) {
+	cfg := syslogFixture6942()
+	if got := ResolveSyslogSourceAddr(cfg, " reth1.100 "); got != "10.0.100.1" {
+		t.Errorf("ResolveSyslogSourceAddr(%q) = %q, want %q — the validator trims before it "+
+			"judges, so the resolver must trim before it resolves", " reth1.100 ", got, "10.0.100.1")
+	}
+}
+
+// TestResolverAndValidatorAgree6942 asserts the AGREEMENT rather than pinning
+// either side to a literal.
+//
+// Which side is authoritative is exactly the question a literal would silently
+// answer, so the property is stated as an implication instead: if the validator
+// REJECTS a value, the resolver must not return a config-derived address for it.
+// A resolver that answers from config for input the validator refuses is the
+// #6942 defect in its general form, whatever the specific string.
+func TestResolverAndValidatorAgree6942(t *testing.T) {
+	cfg := syslogFixture6942()
+	cases := []string{
+		"reth1", "reth1.0", "reth1.100", " reth1.100 ",
+		"reth1.abc", "reth1.", "reth1.-1", "reth1.99999999999999999999",
+		".100", "", "   ",
+	}
+	rejected := 0
+	for _, in := range cases {
+		verr := ValidateSyslogSourceInterface(in, cfg)
+		got := ResolveSyslogSourceAddr(cfg, in)
+		if verr == nil {
+			continue
+		}
+		rejected++
+		if got != "" {
+			t.Errorf("disagreement on %q: validator rejects (%v) but resolver returned %q. "+
+				"A value the validator refuses must not yield a config-derived address — "+
+				"the strict path masks this, the lenient path does not (#6942).", in, verr, got)
+		}
+	}
+	// Non-vacuity: if nothing in the corpus is rejected the loop above asserts
+	// nothing, and would pass against a validator that accepts everything.
+	if rejected < 4 {
+		t.Fatalf("only %d of %d inputs were rejected by the validator; this corpus must "+
+			"contain rejected values or the agreement assertion is vacuous", rejected, len(cases))
+	}
+}


### PR DESCRIPTION
`ResolveSyslogSourceAddr` and `ValidateSyslogSourceInterface` judge the same
string and disagreed about it in two ways. The validator rejects where the
resolver silently substituted a default — so the strict commit path masked both,
and the **lenient** path (`Load` / `SyncApply`) did not.

Closes #6942

## Defect 1 — an unparseable unit silently became unit 0

The `Atoi` error was **checked and then ignored**, leaving `unitNum` at its zero
value. So `reth1.abc` resolved to `reth1` unit 0, and syslog bound its source to
the wrong logical unit — silently, and plausibly, since unit 0 usually has an
address.

This is a different code shape from #6940's cohort, where the error is discarded
outright, so a sweep for `, _ = strconv.Atoi(` does not find it.

**The tree already knew.** `ValidateSyslogSourceInterface`'s own error message
reads *"a non-numeric unit silently binds the syslog source to unit 0"* — it was
written to describe this exact behaviour in the resolver it sits in front of.

### Why the skip is keyed on `hasUnit && parse-failed`, not on `unitNum == 0`

A **bare** interface name legitimately means unit 0. Keying on the value would
have broken every bare-name caller while still passing a defect-1 test — that is
mutation S3 below, and it reds four cells.

## Defect 2 — the resolver did not trim, the validator does

The validator normalises before it parses, so a padded value is judged in its
trimmed form and then handed to the resolver untrimmed. The callers only guard
`!= ""`, which a whitespace-only value passes.

## Why returning `""` is safe

Both call sites (`daemon_system.go`, `cli/apply.go`) fall through to the global
source, and the comment already there says an interface "merely not up yet must
not permanently strip a source the operator did configure globally." Falling
through to the global is strictly better than binding a guessed unit.

## Why this survived: it was recorded as fixed

`docs/reviews/archive/fable-review-175.md:4262` says:

> *ValidateSyslogSourceInterface: validates unit numeric — GOOD (closes silent
> fallback to unit 0 bug #3349)*

The validator **did** close it — on the strict path, which is the path a review
exercises. The resolver kept the fallback, and the lenient path kept reaching it.
A defect recorded as closed is harder to find than one nobody looked at.

## Mutation matrix

Fix committed before mutating. Full-package, no `-run` filter, collected count
checked against control.

| # | Mutation | collected | Named RED |
|---|---|---|---|
| — | control | 6780 | — (0 failed) |
| S1 | restore the `unitNum` fallback (the shipped defect) | 6780 | `TestResolverRefusesAnUnparseableUnit6942`, `TestResolverAndValidatorAgree6942` |
| S2 | drop the `TrimSpace` | 6780 | `TestResolverTrimsLikeTheValidator6942` |
| S3 | over-reach — skip whenever the unit is 0 | 6780 | `TestResolverStillHonoursValidInputs6942` **+ 3 pre-existing** (`TestResolveSyslogSourceAddr_Unit0`, `_IPv6Primary`, `TestStreamSourceInterfacePrecedence_6875`) |

**S3 is the cell that earns the fix's shape**, and its result is better than the
cell I wrote for it: three pre-existing tests already owned the bare-name
property, so the naive fix would have been caught regardless. My cell names the
property explicitly where they assert it incidentally.

The fixture gives unit 0 an address **different** from unit 100's — without that,
a wrong-unit resolution is indistinguishable from a correct one and every cell
passes against the unfixed code.

`TestResolverAndValidatorAgree6942` asserts the **agreement** rather than pinning
either side to a literal: if the validator rejects a value, the resolver must not
return a config-derived address for it. Which side is authoritative is exactly
the question a literal would silently answer. It carries a non-vacuity floor
(≥4 of the corpus must actually be rejected), since a validator that accepted
everything would make the loop assert nothing.

## Docs

No documentation change. `docs/config-schema.md` documents the *schema* contract
for `source-interface`, which the validator already enforced; this makes the
resolver match it, so that documentation becomes more accurate rather than
stale. The behavioural contract lives in the validator's error message and the
code comments, both updated here.

## Gates

`go build ./...` clean. `go test ./... -count=1` → **68 ok / 0 FAIL, rc=0**, with
`origin/master` folded and 0 unmerged paths.
