### PR TITLE
config: report malformed integer leaves instead of silently zeroing them

### DIFF
--- a/docs/log/6940.md
+++ b/docs/log/6940.md
@@ -1,0 +1,114 @@
+# 6940 — 13 typed integer leaves discard the `strconv.Atoi` error
+
+## Re-derivation: the count is RIGHT, the per-leaf claims are not
+
+First issue in this cohort whose headline number survives. The issue's own
+predicate `git grep -nE ', _ = strconv\.Atoi\(' -- pkg/config/` gives **13** at
+`b7096f4d1`.
+
+Confirmed with an **independent instrument** rather than by re-running the
+issue's: of **273** `strconv.(Atoi|ParseInt|ParseUint|ParseFloat)` calls in
+non-test `pkg/config`, exactly **13** discard the error. The `:=` form and every
+`Parse*` variant are zero, so the narrow predicate and the broad one agree. Two
+predicates agreeing is evidence; one predicate repeated is not.
+
+## The reachability column, and why it splits the cohort
+
+Measured, **with a path control on every row** — a valid value on the same path
+must be accepted, or an "accepted" verdict cannot be told apart from a path the
+schema walk never reached. That control immediately caught a bad probe value of
+mine: `ring-entries` with `7`, which is invalid because the validator requires a
+power of two, and would have read as "protected" for the wrong reason.
+
+**Bare leaves — silently zeroed AT COMMIT (5):** `minimum-links`, `lease-time`,
+`retransmission-attempt`, `retransmission-interval`, `ntp threshold`.
+Measured: `minimum-links banana` compiles clean with `MinimumLinks=0`, and the
+only warning emitted is the unrelated 802.3ad accepted-only advisory.
+
+**Already validator-protected (8):** `workers`, `ring-entries`,
+`netdev-budget`, `coalescence rx-usecs`, `coalescence tx-usecs`,
+`archival configuration transfer-interval`, `preferred-prefix-length`,
+`sub-prefix-length`. All rejected at commit-check. Their discarded `Atoi` is
+reachable **only** through `compileTreeLenient`. Measured there:
+`CompileConfigLenient` on `workers banana` gives `Workers=0`, **warnings=0** —
+accept-and-rewrite in silence, which is the posture the issue itself cites
+#1960 as forbidding.
+
+## The severity the issue understates
+
+The issue says a discarded error yields "a wrong number". For five leaves it
+yields something worse: **the documented sentinel for "not configured"**.
+
+| leaf | what 0 means |
+|---|---|
+| `LeaseTime` | "seconds (0 = default)" |
+| `NTPThreshold` | "0 = default" — consumers gate on `> 0` |
+| `TransferInterval` | **"0 = on commit only"** |
+| `PrefixDelegatingPrefixLen` | "0 = not set, send no length hint" |
+| `PrefixDelegatingSubPrefLen` | "0 = advertise the delegated prefix as-is" |
+
+So the malformed value lands exactly where "the operator never wrote this leaf"
+lands — the one place nothing can distinguish it from. `TransferInterval` is the
+sharpest: a typo silently switches archival from periodic to on-commit-only.
+
+This is the same structure as the fixture rule that a probe must never use the
+value the bug falls back to, except here it is **production** whose fallback
+equals the sentinel.
+
+## Two of the issue's per-leaf claims are wrong
+
+- *"`PrefixDelegatingPrefixLen`/`SubPrefLen` — a zero prefix length is a
+  distinct and wrong prefix, not an absent one."* The schema's own `valueDesc`
+  says the opposite: 0 is the documented absent-value sentinel. Both leaves are
+  validator-protected already.
+- *"`MinimumLinks` — a LAG minimum-links of 0 is not the same as an unset one."*
+  `MinimumLinks` has **zero readers** in `pkg/` or `cmd/`, and the compiler
+  emits a standing advisory that `aggregated-ether-options` is **accepted-only —
+  xpf does not implement 802.3ad**. The headline example is a wrong number in a
+  stanza nothing acts on. Fixed for consistency; the PR says so rather than
+  repeating the issue's framing.
+
+## Two mechanisms, not one applied thirteen times
+
+- **Validators** on the 5 bare leaves, bounded `>= 1`. For the three where 0 is
+  the sentinel that bound is deliberate: the sentinel should be reachable only
+  by OMITTING the leaf, which is what it means.
+- **`parseIntLeaf`** for all 13, warning instead of rewriting. It must not
+  reject — the lenient path exists to accept what the strict path refuses, and
+  rejecting would fail a boot or an HA sync, worse than the defect.
+
+`compileUserspaceDataplane` needed a warnings sink threaded through; the other
+eight sites already had one.
+
+## Does the warning reach anyone? Traced, not assumed
+
+A warning nobody reads is a counter nobody can see. `cfg.Warnings` has two
+consumers: the daemon's `applyConfigLocked` logs each as
+`slog.Warn("config validation", "warning", w)`, and `pkg/api/config.go` carries
+them into the commit response, which `cmd/cli/main.go` prints. The boot and
+peer-sync applies both run through `applyConfigLocked` — its own comment names
+"Boot / DHCP-callback / feed / config-poll applies". Same channel #4785's
+lenient ipip advisory uses.
+
+## The finding: #6940 was MASKING a #2419 divergence
+
+Adding the validator made `TestCompactBlockEquivalenceInventory2419` report a
+**NEW compact-blind site**, `interfaces xpfname aggregated-ether-options
+minimum-links`. Measured both ways rather than filed and forgotten:
+
+| leaf | census state | checked |
+|---|---|---|
+| bare (as it was) | `skipped: leaf value not observable` | 546 |
+| with validator + integer examples | `divergent` | **547** |
+
+The census synthesised the generic pair `xpfaaa`/`xpfbbb`; the discarded `Atoi`
+made **both** compile to 0; the value therefore did not change the compiled
+config, the vacuity guard fired, and the cell was skipped. Fixing the parse made
+the site observable — and the compact reader is genuinely blind. Pre-existing,
+and #2419's to fix, not #6940's.
+
+Note the direction: **checked went UP, 546 → 547.** The site moved *into* the
+tested population, so the coverage ratchet is satisfied. A blind-spot count that
+rises after a fix is the fix working — the opposite of the #6924 case, where the
+danger was a cell draining *out* of the population. The inventory entry records
+both measured states and the scope decision so nobody re-derives it.

--- a/pkg/config/compiler_interfaces.go
+++ b/pkg/config/compiler_interfaces.go
@@ -131,7 +131,9 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig, opts compileOpts, w
 			}
 			if mlNode := aeoNode.FindChild("minimum-links"); mlNode != nil {
 				if v := nodeVal(mlNode); v != "" {
-					opts.MinimumLinks, _ = strconv.Atoi(v)
+					if n, ok := parseIntLeaf(warnings, "interfaces "+ifName+" aggregated-ether-options minimum-links", v); ok {
+						opts.MinimumLinks = n
+					}
 				}
 			}
 			ifc.AggregatedEtherOpts = opts
@@ -437,15 +439,21 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig, opts compileOpts, w
 									switch prop.Name() {
 									case "lease-time":
 										if v := nodeVal(prop); v != "" {
-											opts.LeaseTime, _ = strconv.Atoi(v)
+											if n, ok := parseIntLeaf(warnings, "interfaces "+ifName+" dhcp lease-time", v); ok {
+												opts.LeaseTime = n
+											}
 										}
 									case "retransmission-attempt":
 										if v := nodeVal(prop); v != "" {
-											opts.RetransmissionAttempt, _ = strconv.Atoi(v)
+											if n, ok := parseIntLeaf(warnings, "interfaces "+ifName+" dhcp retransmission-attempt", v); ok {
+												opts.RetransmissionAttempt = n
+											}
 										}
 									case "retransmission-interval":
 										if v := nodeVal(prop); v != "" {
-											opts.RetransmissionInterval, _ = strconv.Atoi(v)
+											if n, ok := parseIntLeaf(warnings, "interfaces "+ifName+" dhcp retransmission-interval", v); ok {
+												opts.RetransmissionInterval = n
+											}
 										}
 									case "force-discover":
 										opts.ForceDiscover = true
@@ -566,12 +574,16 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig, opts compileOpts, w
 								case "prefix-delegating":
 									if plNode := prop.FindChild("preferred-prefix-length"); plNode != nil {
 										if v := nodeVal(plNode); v != "" {
-											dc.PrefixDelegatingPrefixLen, _ = strconv.Atoi(v)
+											if n, ok := parseIntLeaf(warnings, "interfaces "+ifName+" dhcpv6-client prefix-delegating preferred-prefix-length", v); ok {
+												dc.PrefixDelegatingPrefixLen = n
+											}
 										}
 									}
 									if slNode := prop.FindChild("sub-prefix-length"); slNode != nil {
 										if v := nodeVal(slNode); v != "" {
-											dc.PrefixDelegatingSubPrefLen, _ = strconv.Atoi(v)
+											if n, ok := parseIntLeaf(warnings, "interfaces "+ifName+" dhcpv6-client prefix-delegating sub-prefix-length", v); ok {
+												dc.PrefixDelegatingSubPrefLen = n
+											}
 										}
 									}
 								case "req-option":

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -84,7 +84,9 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 			}
 			if thNode := child.FindChild("threshold"); thNode != nil {
 				if v := nodeVal(thNode); v != "" {
-					sys.NTPThreshold, _ = strconv.Atoi(v)
+					if n, ok := parseIntLeaf(&cfg.Warnings, "system ntp threshold", v); ok {
+						sys.NTPThreshold = n
+					}
 				}
 				// Check for inline: threshold 400 action accept;
 				for i := 2; i < len(thNode.Keys)-1; i++ {
@@ -279,7 +281,9 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 				}
 				if tiNode := cfgNode.FindChild("transfer-interval"); tiNode != nil {
 					if v := nodeVal(tiNode); v != "" {
-						sys.Archival.TransferInterval, _ = strconv.Atoi(v)
+						if n, ok := parseIntLeaf(&cfg.Warnings, "system archival configuration transfer-interval", v); ok {
+							sys.Archival.TransferInterval = n
+						}
 					}
 				}
 				for _, asNode := range cfgNode.FindChildren("archive-sites") {
@@ -336,7 +340,7 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 				if sys.UserspaceDataplane == nil {
 					sys.UserspaceDataplane = &UserspaceConfig{}
 				}
-				if err := compileUserspaceDataplane(child, sys.UserspaceDataplane); err != nil {
+				if err := compileUserspaceDataplane(child, sys.UserspaceDataplane, &cfg.Warnings); err != nil {
 					return err
 				}
 			case dataplaneTypeEBPF:
@@ -873,7 +877,7 @@ func hasDNSProxyChild(node *Node) bool {
 	return false
 }
 
-func compileUserspaceDataplane(node *Node, cfg *UserspaceConfig) error {
+func compileUserspaceDataplane(node *Node, cfg *UserspaceConfig, warnings *[]string) error {
 	for _, child := range node.Children {
 		switch child.Name() {
 		case "userspace":
@@ -895,7 +899,7 @@ func compileUserspaceDataplane(node *Node, cfg *UserspaceConfig) error {
 					IsLeaf:   child.IsLeaf,
 				}
 				synthParent := &Node{Children: []*Node{synthetic}}
-				if err := compileUserspaceDataplane(synthParent, cfg); err != nil {
+				if err := compileUserspaceDataplane(synthParent, cfg, warnings); err != nil {
 					return err
 				}
 			}
@@ -913,11 +917,15 @@ func compileUserspaceDataplane(node *Node, cfg *UserspaceConfig) error {
 			cfg.StateFile = nodeVal(child)
 		case "workers":
 			if v := nodeVal(child); v != "" {
-				cfg.Workers, _ = strconv.Atoi(v)
+				if n, ok := parseIntLeaf(warnings, "system dataplane workers", v); ok {
+					cfg.Workers = n
+				}
 			}
 		case "ring-entries":
 			if v := nodeVal(child); v != "" {
-				cfg.RingEntries, _ = strconv.Atoi(v)
+				if n, ok := parseIntLeaf(warnings, "system dataplane ring-entries", v); ok {
+					cfg.RingEntries = n
+				}
 			}
 		case "poll-mode":
 			if v := nodeVal(child); v == "interrupt" || v == "busy-poll" {
@@ -949,7 +957,9 @@ func compileUserspaceDataplane(node *Node, cfg *UserspaceConfig) error {
 			cfg.CPUGovernor = nodeVal(child)
 		case "netdev-budget":
 			if v := nodeVal(child); v != "" {
-				cfg.NetdevBudget, _ = strconv.Atoi(v)
+				if n, ok := parseIntLeaf(warnings, "system dataplane netdev-budget", v); ok {
+					cfg.NetdevBudget = n
+				}
 			}
 		case "coalescence":
 			// `coalescence adaptive enable|disable`, `coalescence
@@ -975,11 +985,15 @@ func compileUserspaceDataplane(node *Node, cfg *UserspaceConfig) error {
 					}
 				case "rx-usecs":
 					if v := nodeVal(sub); v != "" {
-						cfg.CoalescenceRXUsecs, _ = strconv.Atoi(v)
+						if n, ok := parseIntLeaf(warnings, "system dataplane coalescence rx-usecs", v); ok {
+							cfg.CoalescenceRXUsecs = n
+						}
 					}
 				case "tx-usecs":
 					if v := nodeVal(sub); v != "" {
-						cfg.CoalescenceTXUsecs, _ = strconv.Atoi(v)
+						if n, ok := parseIntLeaf(warnings, "system dataplane coalescence tx-usecs", v); ok {
+							cfg.CoalescenceTXUsecs = n
+						}
 					}
 				}
 			}

--- a/pkg/config/int_leaf_parse_6940.go
+++ b/pkg/config/int_leaf_parse_6940.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// parseIntLeaf parses a typed integer leaf, reporting a malformed value instead
+// of silently yielding zero (#6940).
+//
+// THE DEFECT IT REPLACES. Thirteen leaves parsed as `x, _ = strconv.Atoi(v)`.
+// `Atoi` returns 0 alongside its error, so a typo, a unit suffix, or a `${var}`
+// that did not expand compiled to zero and the commit succeeded.
+//
+// "A wrong number" understates it. For five of the thirteen, ZERO IS THE
+// DOCUMENTED SENTINEL for "not configured":
+//
+//	LeaseTime                   "seconds (0 = default)"
+//	NTPThreshold                "0 = default"   (consumers gate on > 0)
+//	TransferInterval            "0 = on commit only"
+//	PrefixDelegatingPrefixLen   "0 = not set, send no length hint"
+//	PrefixDelegatingSubPrefLen  "0 = advertise the delegated prefix as-is"
+//
+// So the malformed value does not land somewhere visibly wrong — it lands
+// exactly where "the operator never wrote this leaf" lands, which is the one
+// place nothing can distinguish it from. `TransferInterval` is the sharpest: a
+// typo silently switches archival from periodic to on-commit-only.
+//
+// It is the same structure as the fixture rule that a probe must never use the
+// value the bug falls back to, except here it is PRODUCTION whose fallback
+// equals the sentinel.
+//
+// WHICH PATH THIS IS FOR. On the strict commit path the schema validator
+// rejects a malformed integer before the compiler runs — measured for all
+// thirteen leaves. So this warning is reachable only through
+// `compileTreeLenient`, which `Store.Load` (disk boot) and `Store.SyncApply`
+// (HA peer sync) use and which does not schema-validate at all.
+//
+// That is deliberate and it is why this WARNS rather than returning an error.
+// The lenient path exists to accept input the strict path would reject; making
+// it reject would refuse a persisted config on boot or fail an HA sync, which
+// is a worse failure than the one being fixed (#1960 no-brick). Warn, do not
+// rewrite silently, and do not reject.
+//
+// The warning reaches an operator: `cfg.Warnings` is logged by the daemon's
+// `applyConfigLocked` as `slog.Warn("config validation", ...)` on the boot and
+// sync applies, and is carried to the CLI in the commit response. It is not a
+// diagnostic into a void.
+func parseIntLeaf(warnings *[]string, path, raw string) (int, bool) {
+	n, err := strconv.Atoi(raw)
+	if err == nil {
+		return n, true
+	}
+	if warnings != nil {
+		*warnings = append(*warnings, fmt.Sprintf(
+			"%s: %q is not an integer — the leaf is IGNORED (a strict commit "+
+				"rejects this value; it survives here only because the tolerant "+
+				"load / peer-sync path does not schema-validate). Before #6940 it "+
+				"silently became 0, which for this leaf class is indistinguishable "+
+				"from never having configured it", path, raw))
+	}
+	return 0, false
+}

--- a/pkg/config/int_leaf_parse_6940_test.go
+++ b/pkg/config/int_leaf_parse_6940_test.go
@@ -1,0 +1,228 @@
+package config
+
+import (
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// #6940 — thirteen typed integer leaves discarded `strconv.Atoi`'s error, so a
+// malformed value silently compiled to 0.
+//
+// TWO MECHANISMS, because the reachability differs and so does the fix:
+//
+//   - FIVE leaves carried no schema validator at all, so a malformed value was
+//     accepted at COMMIT and silently zeroed. They get validators.
+//   - ALL THIRTEEN remain reachable through `compileTreeLenient` (Store.Load /
+//     Store.SyncApply), which does not schema-validate. There the value must
+//     WARN, not reject — rejecting would refuse a persisted config on boot or
+//     fail an HA sync (#1960) — and not silently rewrite either.
+//
+// "A wrong number" is the wrong severity. For five of these leaves ZERO IS THE
+// DOCUMENTED SENTINEL for "not configured" — `LeaseTime` "0 = default",
+// `NTPThreshold` "0 = default" (consumers gate on > 0), `TransferInterval`
+// "0 = on commit only", and the two prefix lengths — so the malformed value
+// landed exactly where "the operator never wrote this leaf" lands. Production
+// whose fallback equals the sentinel.
+
+// leafProbe is one leaf under test: a `set` path plus a VALID value for it.
+type leafProbe6940 struct {
+	name     string
+	path     string
+	okValue  string
+	badValue string
+}
+
+// The five leaves that had no validator before #6940. Each `okValue` is a
+// PATH CONTROL: if the valid value is rejected, the path is wrong and a
+// "rejected the bad value" verdict would be meaningless.
+var bareLeaves6940 = []leafProbe6940{
+	{"minimum-links", "set interfaces ae0 aggregated-ether-options minimum-links", "2", "banana"},
+	{"lease-time", "set interfaces ge-0/0/0 unit 0 family inet dhcp lease-time", "3600", "banana"},
+	{"retransmission-attempt", "set interfaces ge-0/0/0 unit 0 family inet dhcp retransmission-attempt", "4", "banana"},
+	{"retransmission-interval", "set interfaces ge-0/0/0 unit 0 family inet dhcp retransmission-interval", "2", "banana"},
+	{"ntp threshold", "set system ntp threshold", "128", "banana"},
+}
+
+func buildTree6940(t *testing.T, cmd string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	p, err := ParseSetCommand(cmd)
+	if err != nil {
+		t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+	}
+	if err := tree.SetPath(p); err != nil {
+		t.Fatalf("SetPath(%q): %v", cmd, err)
+	}
+	return tree
+}
+
+// TestBareIntegerLeavesRejectMalformedAtCommit_6940 is the strict half, paired
+// on the same path so only the VALUE differs.
+func TestBareIntegerLeavesRejectMalformedAtCommit_6940(t *testing.T) {
+	for _, tc := range bareLeaves6940 {
+		t.Run(tc.name, func(t *testing.T) {
+			// PATH CONTROL first. Without it, "the bad value was rejected"
+			// cannot be told apart from a path the schema walk never reached —
+			// which is exactly how a probe of mine read `ring-entries` as
+			// protected when the control value itself was invalid.
+			if err := SchemaValidate(buildTree6940(t, tc.path+" "+tc.okValue), nil); err != nil {
+				t.Fatalf("PATH CONTROL FAILED: the VALID value %q was rejected (%v). "+
+					"A rejection of the malformed value below would prove nothing.",
+					tc.okValue, err)
+			}
+			err := SchemaValidate(buildTree6940(t, tc.path+" "+tc.badValue), nil)
+			if err == nil {
+				t.Fatalf("`%s %s` was ACCEPTED at commit-check. `strconv.Atoi` "+
+					"discards its error, so this compiles to 0 — and for this leaf "+
+					"class 0 is the documented 'not configured' sentinel, making the "+
+					"typo indistinguishable from an absent leaf (#6940)",
+					tc.path, tc.badValue)
+			}
+			if !strings.Contains(err.Error(), tc.badValue) {
+				t.Errorf("rejected, but not for the value: %v", err)
+			}
+		})
+	}
+}
+
+// TestMalformedIntegerLeafWarnsOnTheLenientPath_6940 is the lenient half, and
+// it is the half that covers all thirteen: the tolerant ingress does not
+// schema-validate, so it is the ONLY path a malformed value can still reach.
+//
+// PAIRED on the same fixture, one axis:
+//
+//	lenient compile -> SUCCEEDS (no brick) AND warns (not silent)
+//	the field       -> left at its zero value, not a half-parsed number
+func TestMalformedIntegerLeafWarnsOnTheLenientPath_6940(t *testing.T) {
+	cases := []struct {
+		name, cmd, wantIn string
+	}{
+		{"bare leaf", "set interfaces ae0 aggregated-ether-options minimum-links banana", "minimum-links"},
+		{"validated leaf", "set system dataplane workers banana", "workers"},
+		{"validated leaf, archival mode change", "set system archival configuration transfer-interval banana", "transfer-interval"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := CompileConfigLenient(buildTree6940(t, tc.cmd))
+			if err != nil {
+				t.Fatalf("the tolerant path must NOT reject: a persisted config would "+
+					"fail to boot and an HA sync would fail (#1960): %v", err)
+			}
+			var found string
+			for _, w := range cfg.Warnings {
+				if strings.Contains(w, tc.wantIn) && strings.Contains(w, "not an integer") {
+					found = w
+				}
+			}
+			if found == "" {
+				t.Fatalf("no warning naming %q. Before #6940 this compiled to 0 in "+
+					"silence; a tolerant path that accepts AND rewrites without "+
+					"reporting is the accept-and-rewrite posture #1960 forbids.\n"+
+					"warnings: %v", tc.wantIn, cfg.Warnings)
+			}
+			// The warning must name the OFFENDING VALUE, or an operator cannot
+			// find it in a large config.
+			if !strings.Contains(found, "banana") {
+				t.Errorf("warning does not quote the offending value: %q", found)
+			}
+		})
+	}
+}
+
+// TestNoDiscardedAtoiRemainsInTheConfigCompiler_6940 is the cohort census: the
+// defect is a SHAPE, and a new site added later would reintroduce it silently.
+//
+// Comment-stripped, because the prose above and in int_leaf_parse_6940.go
+// quotes the very pattern it scans for — a gate its own doc comment can satisfy
+// is not a gate.
+func TestNoDiscardedAtoiRemainsInTheConfigCompiler_6940(t *testing.T) {
+	files := configPackageGoFiles6940(t)
+	// NON-VACUITY: a walk that found no files would report a clean census.
+	if len(files) < 20 {
+		t.Fatalf("scanned only %d non-test files in pkg/config — the walk is not "+
+			"reaching the package, so this census proves nothing", len(files))
+	}
+	var offenders []string
+	scanned := 0
+	for _, f := range files {
+		src := stripGoComments6940(readFile6940(t, f))
+		scanned += strings.Count(src, "strconv.")
+		for _, form := range []string{
+			", _ = strconv.Atoi(", ", _ := strconv.Atoi(",
+			", _ = strconv.ParseInt(", ", _ := strconv.ParseInt(",
+			", _ = strconv.ParseUint(", ", _ := strconv.ParseUint(",
+		} {
+			if strings.Contains(src, form) {
+				offenders = append(offenders, f+" -> "+form)
+			}
+		}
+	}
+	// NON-VACUITY: the stripper must not have eaten the code it scans.
+	if scanned == 0 {
+		t.Fatal("comment-stripped sources contain no `strconv.` at all — the " +
+			"stripper removed the code, so the scan above is vacuous")
+	}
+	if len(offenders) > 0 {
+		t.Errorf("a numeric leaf parse discards its error again (#6940): %v\n\n"+
+			"`Atoi` returns 0 with its error, and for several config leaves 0 is "+
+			"the documented 'not configured' sentinel — so the malformed value is "+
+			"indistinguishable from an absent leaf. Use parseIntLeaf.", offenders)
+	}
+}
+
+func configPackageGoFiles6940(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read pkg/config: %v", err)
+	}
+	var out []string
+	for _, e := range entries {
+		n := e.Name()
+		if e.IsDir() || !strings.HasSuffix(n, ".go") || strings.HasSuffix(n, "_test.go") {
+			continue
+		}
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func readFile6940(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}
+
+// stripGoComments6940 blanks // and /* */ comments so the census cannot be
+// satisfied — or tripped — by prose that quotes the pattern.
+func stripGoComments6940(src string) string {
+	var b strings.Builder
+	inBlock := false
+	for _, line := range strings.Split(src, "\n") {
+		l := line
+		if inBlock {
+			if i := strings.Index(l, "*/"); i >= 0 {
+				inBlock = false
+				l = l[i+2:]
+			} else {
+				continue
+			}
+		}
+		if i := strings.Index(l, "/*"); i >= 0 {
+			inBlock = true
+			l = l[:i]
+		}
+		if i := strings.Index(l, "//"); i >= 0 {
+			l = l[:i]
+		}
+		b.WriteString(l)
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/pkg/config/schema_interfaces.go
+++ b/pkg/config/schema_interfaces.go
@@ -87,8 +87,20 @@ var schemaInterfaces = &schemaNode{desc: "Interface configuration", wildcard: &s
 			"passive":  {desc: "Passive LACP mode", children: nil},
 			"periodic": {desc: "LACP timer period", args: 1, children: nil},
 		}},
-		"link-speed":    {desc: "Member link speed", args: 1, children: nil},
-		"minimum-links": {desc: "Minimum active member links", args: 1, children: nil},
+		"link-speed": {desc: "Member link speed", args: 1, children: nil},
+		"minimum-links": {
+			desc:          "Minimum active member links",
+			args:          1,
+			placeholder:   "<number>",
+			valueType:     ValueInteger,
+			valueDesc:     "Minimum active member links before the bundle goes down (>= 1)",
+			valueExamples: []string{"1", "2"},
+			// #6940: the leaf carried no validator, so a malformed value reached
+			// compileInterfaces and `Atoi`'s discarded error made it 0. Bounded at
+			// >= 1 because 0 members is not a floor an operator can mean.
+			validator: ValidateIntegerMin(1),
+			children:  nil,
+		},
 	}},
 	"redundant-ether-options": {desc: "Redundant Ethernet interface options", children: map[string]*schemaNode{
 		"redundancy-group": {desc: "Redundancy group for this RETH", args: 1, children: nil},
@@ -198,10 +210,21 @@ var schemaInterfaces = &schemaNode{desc: "Interface configuration", wildcard: &s
 					},
 				},
 				"dhcp": {desc: "DHCP client", children: map[string]*schemaNode{
-					"lease-time":              {desc: "Lease time", args: 1, placeholder: "<seconds>", children: nil},
-					"retransmission-attempt":  {desc: "Retransmission attempts", args: 1, placeholder: "<number>", children: nil},
-					"retransmission-interval": {desc: "Retransmission interval", args: 1, placeholder: "<seconds>", children: nil},
-					"force-discover":          {desc: "Force DHCP discover", children: nil},
+					"lease-time": {desc: "Lease time", args: 1, placeholder: "<seconds>",
+						valueType: ValueInteger, valueDesc: "DHCP lease time in seconds (>= 1; 0 means 'use the default' and cannot be requested)",
+						valueExamples: []string{"3600", "86400"},
+						// #6940: 0 is this leaf's DOCUMENTED sentinel for "default", so a
+						// silently-zeroed malformed value was indistinguishable from an
+						// unconfigured leaf. Bounded at >= 1 so the sentinel can only be
+						// reached by omitting the leaf, which is what it means.
+						validator: ValidateIntegerMin(1), children: nil},
+					"retransmission-attempt": {desc: "Retransmission attempts", args: 1, placeholder: "<number>",
+						valueType: ValueInteger, valueDesc: "DHCP retransmission attempts (>= 1)",
+						valueExamples: []string{"4"}, validator: ValidateIntegerMin(1), children: nil},
+					"retransmission-interval": {desc: "Retransmission interval", args: 1, placeholder: "<seconds>",
+						valueType: ValueInteger, valueDesc: "Seconds between DHCP retransmissions (>= 1)",
+						valueExamples: []string{"2"}, validator: ValidateIntegerMin(1), children: nil},
+					"force-discover": {desc: "Force DHCP discover", children: nil},
 				}},
 				"sampling": {desc: "Traffic sampling", children: map[string]*schemaNode{
 					"input":  {desc: "Sample input traffic", children: nil},

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -168,9 +168,16 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 		// space/control/malformed value cannot inject a second chrony directive
 		// token or fail the chrony reload.
 		"server": {desc: "NTP server", args: 1, multi: true, valueType: ValueHostname, valueDesc: "NTP server IP address or hostname", valueExamples: []string{"192.0.2.1", "pool.ntp.org"}, validator: ValidateNTPServer, placeholder: "<address>", children: nil},
-		"threshold": {desc: "Threshold", args: 1, placeholder: "<seconds>", children: map[string]*schemaNode{
-			"action": {desc: "Action on threshold", args: 1, placeholder: "<action>", children: nil},
-		}},
+		"threshold": {desc: "Threshold", args: 1, placeholder: "<seconds>",
+			valueType: ValueInteger, valueDesc: "NTP step threshold in seconds (>= 1; 0 means 'use the default')",
+			valueExamples: []string{"128", "600"},
+			// #6940: 0 is the documented default here and consumers gate on > 0,
+			// so a silently-zeroed malformed value disabled the threshold action
+			// with no diagnostic.
+			validator: ValidateIntegerMin(1),
+			children: map[string]*schemaNode{
+				"action": {desc: "Action on threshold", args: 1, placeholder: "<action>", children: nil},
+			}},
 	}},
 	"syslog": {desc: "Syslog configuration", children: map[string]*schemaNode{
 		// #2008 (syslog schema-only): a system syslog host/file/user

--- a/pkg/config/testdata/compact_block_divergences_2419.txt
+++ b/pkg/config/testdata/compact_block_divergences_2419.txt
@@ -12,7 +12,23 @@
 #
 # `xpfarg` / `xpfname` are synthesized instance names.
 #
-# checked: 546
+# checked: 547
+#
+# #6940 raised the checked count 546 -> 547 and added
+# `interfaces xpfname aggregated-ether-options minimum-links`. That site is NOT
+# a new compiler defect — it is a pre-existing compact-blind reader that this
+# census could not SEE until #6940 landed.
+#
+# Before #6940 the leaf carried no valueType or valueExamples, so the census
+# synthesised the generic pair "xpfaaa"/"xpfbbb"; the compiler parsed both with
+# `x, _ = strconv.Atoi(v)`, whose discarded error made BOTH compile to 0. The
+# value therefore did not change the compiled config, the vacuity guard fired,
+# and the cell was recorded "skipped: leaf value not observable" — measured
+# both ways. Giving the leaf a validator and integer examples made the two
+# probe values observable, and the compact spelling is genuinely blind.
+#
+# So one defect was masking another: a blind-spot count that RISES after a fix
+# is the fix working. Fixing the compact reader is #2419's job, not #6940's.
 #
 # skipped (leaf value not observable in the typed config): 204
 # skipped (a spelling did not parse or compile): 37
@@ -66,6 +82,7 @@ forwarding-options sampling instance xpfarg family inet6 output source-address
 forwarding-options sampling instance xpfarg input rate
 interfaces xpfname aggregated-ether-options lacp periodic
 interfaces xpfname aggregated-ether-options link-speed
+interfaces xpfname aggregated-ether-options minimum-links
 interfaces xpfname description
 interfaces xpfname duplex
 interfaces xpfname encapsulation


### PR DESCRIPTION
Closes #6940

## The severity, restated — this is not "a wrong number"

Thirteen typed integer leaves parsed as `x, _ = strconv.Atoi(v)`. `Atoi` returns 0 alongside its error, so a typo, a unit suffix, or a `${var}` that did not expand compiled to zero and the commit succeeded.

For **five** of the thirteen, zero is the **documented sentinel for "not configured"**:

| leaf | what 0 means |
|---|---|
| `LeaseTime` | `"seconds (0 = default)"` |
| `NTPThreshold` | `"0 = default"` — consumers gate on `> 0` |
| `TransferInterval` | **`"0 = on commit only"`** |
| `PrefixDelegatingPrefixLen` | `"0 = not set, send no length hint"` |
| `PrefixDelegatingSubPrefLen` | `"0 = advertise the delegated prefix as-is"` |

So the malformed value did not land somewhere visibly wrong. It landed exactly where *"the operator never wrote this leaf"* lands — the one place nothing can tell it apart from an absent leaf. `TransferInterval` is the sharpest: a typo silently switches archival from periodic to on-commit-only, and nothing reports it.

It is the same structure as the rule that a fixture must never use the value the bug falls back to, except here it is **production** whose fallback equals the sentinel.

## The count is right — verified with a second instrument

First issue in this cohort whose headline number survives re-derivation. The issue's predicate gives 13; an **independent** instrument agrees: of **273** `strconv.(Atoi|ParseInt|ParseUint|ParseFloat)` calls in non-test `pkg/config`, exactly **13** discard the error, with the `:=` form and every `Parse*` variant at zero. Two predicates agreeing is evidence; one predicate repeated is not.

## Two mechanisms, because the reachability differs

Measured **with a path control on every row** — a valid value on the same path must be accepted, or an "accepted" verdict cannot be told apart from a path the schema walk never reached. That control earned its place immediately, catching a bad probe value of mine on `ring-entries` (`7` is invalid there because the validator requires a power of two).

- **5 bare leaves** — no validator, so a malformed value was accepted at COMMIT and silently zeroed (`minimum-links`, `lease-time`, `retransmission-attempt`, `retransmission-interval`, `ntp threshold`). They get validators, bounded `>= 1`. For the three where 0 is the sentinel that bound is deliberate: the sentinel should be reachable only by **omitting** the leaf, which is what it means.
- **All 13** stay reachable through `compileTreeLenient` (`Store.Load` / `Store.SyncApply`), which does not schema-validate. Measured there: `workers banana` → `Workers=0`, **warnings=0**. Now they **warn**.

**Warn, not reject** — and this was your call to confirm, not mine to infer. The lenient path exists to accept input the strict path would refuse; rejecting would fail a boot or an HA sync, which is worse than the defect being fixed (#1960).

## Does the warning reach anyone? Traced, not assumed

A warning nobody reads is a counter nobody can see. `cfg.Warnings` has two consumers: the daemon's `applyConfigLocked` logs each as `slog.Warn("config validation", "warning", w)`, and `pkg/api/config.go` carries them into the commit response, which `cmd/cli/main.go` prints. Boot and peer-sync applies both run through `applyConfigLocked` — its own comment names *"Boot / DHCP-callback / feed / config-poll applies"*. Same channel #4785's lenient ipip advisory uses.

## Two of the issue's per-leaf claims are corrected

- *"`PrefixDelegatingPrefixLen`/`SubPrefLen` — a zero prefix length is a distinct and wrong prefix, not an absent one."* The schema's own `valueDesc` says the opposite — 0 **is** the documented absent-value sentinel — and both are validator-protected already.
- *"`MinimumLinks` — a LAG minimum-links of 0 is not the same as an unset one."* `MinimumLinks` has **zero readers** in `pkg/` or `cmd/`, and the compiler emits a standing advisory that `aggregated-ether-options` is **accepted-only — xpf does not implement 802.3ad**. The headline example is a wrong number in a stanza nothing acts on. Fixed for consistency; saying so, rather than repeating a framing that would make this PR's own severity claim false.

Both corrections are posted on the issue.

## Side finding: this defect was MASKING a #2419 divergence

Adding the `minimum-links` validator made `TestCompactBlockEquivalenceInventory2419` report a **new compact-blind site**. Measured both ways rather than filed and forgotten:

| leaf | census state | checked |
|---|---|---|
| bare (as it was) | `skipped: leaf value not observable` | 546 |
| with validator + integer examples | `divergent` | **547** |

The census synthesises the generic pair `xpfaaa`/`xpfbbb`; the discarded `Atoi` made **both** compile to 0, so the value did not change the compiled config, the vacuity guard fired, and the cell was skipped. Fixing the parse made the site observable — and the compact reader is genuinely blind. Pre-existing, and **#2419's to fix, not this PR's**.

Note the direction: **checked went UP, 546 → 547.** The site moved *into* the tested population, so the coverage ratchet is satisfied — a blind-spot count that rises after a fix is the fix working. That is the inverse of the #6924 case, where the hazard was a cell draining *out*. The inventory entry records both measured states and the scope decision.

## Tests

- `TestBareIntegerLeavesRejectMalformedAtCommit_6940` — the strict half, one subtest per bare leaf, each with its path control.
- `TestMalformedIntegerLeafWarnsOnTheLenientPath_6940` — the lenient half, paired: the compile must **succeed** (no brick) **and** warn, and the warning must quote the offending value or an operator cannot find it.
- `TestNoDiscardedAtoiRemainsInTheConfigCompiler_6940` — the cohort census, comment-stripped (the helper's own doc comment quotes the pattern it scans for), with non-vacuity floors on both the file walk and the `strconv.` count.

## Mutations — five cells, one per assertion

Full `./pkg/config/ ./pkg/configstore/`, `-count=1`, no `-run` filter, restored between cells, against a **committed** fix. Each cell voids itself if its anchor misses or its mutation does not apply, so an unapplied cell can never be scored as an escape.

| # | Mutation | Named RED | Collected |
|---|---|---|---|
| control | none | — (0 failed) | 7241 |
| 1 | the helper discards the error again | lenient-warn test + the cohort census | 7241 |
| 2 | the helper stops appending the warning | lenient-warn test | 7241 |
| 3 | `minimum-links` validator removed | strict-reject test | 7241 |
| 4 | `ntp threshold` validator removed | strict-reject test | 7241 |
| 5 | one site reverts to bare `Atoi` | lenient-warn test + the cohort census | 7241 |

Every cell collected 7241 = control, so none is a build break wearing a red's clothes. Cells 3 and 4 are separate because they are two different leaves' validators — one passing while the other reds would mean the strict test was binding only one member of the set.

## Gates

- `./pkg/config/ ./pkg/configstore/ ./pkg/daemon/` — all ok (97.2s / 6.3s / 43.3s)
- `go build ./...`, `go vet ./pkg/config/`, `gofmt -l` — clean
- Gated head `ef7c9d360`, `origin/master` (`104ef2567`) verified as an ancestor
- `git grep -cE ', _ = strconv\.Atoi\(' -- pkg/config/` → **0**
- `docs/log/6940.md` carries the re-derivation, the reachability table, the corrections and the masked-divergence measurement
