### PR TITLE
docs: name the instrument-blind-spot class in the testing guide

### DIFF
--- a/docs/log/instrument-blindspots.md
+++ b/docs/log/instrument-blindspots.md
@@ -1,0 +1,17 @@
+# docs: name the "instrument answers nothing when it means I cannot see" class
+
+- **Timestamp**: 2026-08-27
+  - **Action**: recorded as a class in `docs/testing.md`, beside the concrete
+    AF_XDP instance, after it bit five separate investigations. The shared
+    shape: an instrument that cannot observe something reports a well-formed,
+    plausible negative with no error and no unavailable marker, and it is most
+    dangerous on investigations where a negative is the expected finding,
+    because there it reads as confirmation. Table of all five, then the four
+    mitigations in order of strength — a positive control from OUTSIDE the
+    instrument, a marker check that GATES rather than annotates, making
+    "could not see" a distinct outcome from "saw nothing", and reporting
+    "not measured" rather than "no evidence found". Carries a hook line
+    leaving the `engineering-style.md` question to the repository owner,
+    since that file is an agent-behaviour contract rather than an operations
+    guide.
+  - **File(s)**: docs/testing.md

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -347,6 +347,53 @@ incus exec xpf-fw -- xpfd cleanup
 
 ## Debugging Techniques
 
+### When an instrument answers "nothing", ask whether it means "I cannot see"
+
+The failure below has now bitten five separate investigations in this repo, and
+it is worth naming as a class before the individual instances.
+
+**An instrument that cannot observe something usually reports a well-formed,
+plausible negative** — zero rows, zero packets, zero failures — with no error and
+no "unavailable" marker. That negative is indistinguishable from a real one. And
+it is most dangerous on exactly the investigations where a negative is the
+expected finding, because there it reads as confirmation.
+
+The instances so far:
+
+| instrument | reported | actually meant |
+|---|---|---|
+| `tcpdump` on `ge-*-0-1` / `ge-*-0-2` (#7770) | 4-14 frames of 15 sent | AF_XDP consumes packets before the `AF_PACKET` tap; it saw nothing |
+| `show security policies hit-count` (#7776) | `0 packets / 0 bytes` on every row | the surface is not fed on this path; policies were matching |
+| packet capture across an RG failover (#6934) | "zero unsolicited NAs reach the wire" | measured on a redundancy group that never transitioned |
+| a mutation harness (#6937 v1) | marker checked, then probed anyway | the lever had not applied; the probe measured the unchanged config |
+| the struct auditor's own Rust scanner (#6937) | no row for `ForwardingState` | an unhandled `pub(in path)` visibility prefix made it invisible |
+
+The last one is the most instructive: it was the blind spot of a tool built to
+find blind spots, and neither of its two defects was visible in its own output.
+What exposed them was a field count someone else had measured independently.
+
+**What actually helps, in order of strength:**
+
+1. **A positive control from OUTSIDE the instrument.** Prove the instrument can
+   see a thing you know is there before believing it when it sees nothing. The
+   `ForwardingState` bugs were caught only by an externally-stated count; the
+   #6934 capture was believed for two rounds because nothing external contradicted
+   it.
+2. **A marker check that GATES rather than annotates.** #6937's first harness
+   verified that its config lever had applied and then ran the probe regardless.
+   A check whose result does not stop the next step is decoration.
+3. **Make "could not see" a distinct outcome from "saw nothing".** Prefer an
+   instrument that errors, or that reports coverage alongside its result, over one
+   that renders a clean zero. Where the instrument cannot be changed, write the
+   blind spot down beside it — as the AF_XDP section below does.
+4. **State a negative as "not measured", not "no evidence found."** They license
+   different conclusions, and only the second is a finding.
+
+> Whether this belongs in `docs/engineering-style.md` — which is an
+> agent-behaviour contract rather than an operations guide — is a call for the
+> repository owner. It is recorded here, next to the concrete instances, so it is
+> usable either way.
+
 ### Packet capture is BLIND on the AF_XDP data interfaces (#7770)
 
 **`tcpdump` on `ge-*-0-1` / `ge-*-0-2` of the loss userspace cluster does not see


### PR DESCRIPTION
Docs only. Names a failure class that has now cost five separate investigations in this repo.

## The class

**An instrument that cannot observe something reports a well-formed, plausible negative** — zero rows, zero packets, zero failures — with no error and no "unavailable" marker. That negative is indistinguishable from a real one.

It is most dangerous on exactly the investigations where a negative *is* the expected finding, because there it reads as confirmation rather than as instrument failure.

| instrument | reported | actually meant |
|---|---|---|
| `tcpdump` on the AF_XDP data interfaces (#7770) | 4-14 frames of 15 sent | packets consumed in userspace before the `AF_PACKET` tap |
| `show security policies hit-count` (#7776) | `0 packets / 0 bytes` on every row | surface not fed on this path; policies were matching |
| capture across an RG failover (#6934) | "zero unsolicited NAs reach the wire" | measured on a redundancy group that never transitioned |
| a mutation harness (#6937) | marker checked, probe run anyway | the lever had not applied; the probe measured unchanged config |
| the struct auditor's own Rust scanner (#6937) | no row for `ForwardingState` | an unhandled `pub(in path)` prefix made it invisible |

**The last one is why this is written down.** It was the blind spot of a tool built to find blind spots, and neither of its two defects appeared in its own output. What exposed them was a field count measured independently, from outside the instrument.

## Mitigations, ordered by strength rather than listed

1. **A positive control from OUTSIDE the instrument** — first, because it is the only one that would have caught the scanner. Prove the instrument can see a thing you know is there before believing it when it sees nothing.
2. **A marker check that GATES rather than annotates** — #6937's first harness verified its config lever had applied and then probed regardless. A check whose result does not stop the next step is decoration.
3. **Make "could not see" a distinct outcome from "saw nothing"** — prefer an instrument that errors or reports coverage; where it cannot be changed, write the blind spot down beside it.
4. **State a negative as "not measured", not "no evidence found"** — they license different conclusions, and only the second is a finding.

## Placement

`docs/testing.md`, beside the concrete AF_XDP instance it generalises — an operations guide, and the file someone debugging a drop already opens.

**Deliberately not `docs/engineering-style.md`**, which is listed in `CLAUDE.md`'s Required Reading and is therefore an agent-behaviour contract rather than a technical guide. A one-line hook in the section leaves that placement decision to the repository owner rather than making it here.

## Test plan

- [x] Docs only — `git diff --stat` is `docs/testing.md` plus a log file. No code, no build surface.
- [x] Every row in the table is a measurement recorded in this session's issue comments and `docs/log/`, not a recollection.
- [x] `origin/master` folded; ancestry verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhHmVt536ZsY2RVEhc8WPV
