### PR TITLE
test: establish reader progress in the v8 seqlock contention test (#6945)

### DIFF
--- a/docs/log/6945.md
+++ b/docs/log/6945.md
@@ -1,0 +1,98 @@
+# 6945 — two concurrency tests flake under full-suite load
+
+## The prediction, recorded before the reproduction finished
+
+Stated up front and posted on the issue (comment 5449077614) so it could be
+**refuted** rather than fitted to whatever fired:
+
+> Neither test will fail on the property it exists to test. Both will fail on a
+> non-vacuity guard.
+
+That is deliberately not one of the three mechanisms the task named (a real
+race; a wall-clock deadline sampled under contention; a shared fixture path).
+It is a fourth: **a progress guard whose satisfaction depends on winning
+scheduler time.**
+
+## Reproduction
+
+**Step 1 — full suite at master (`22dcf4bbb`), no `-run` filter: 0 of 8 failed.**
+Ambient load average 9–13 on 16 cores, so the runs were genuinely contended
+rather than idle — but "did not reproduce at n=8" is a statement about
+conditions, not an absence.
+
+**Step 2 — amplify the stated trigger rather than only raise the trial count.**
+The mechanism requires threads *losing* a scheduler race, so the instrument
+confines the test's threads to two CPUs (`taskset -c 0,1`) instead of saturating
+a box that other lanes share. A global CPU hog would have created the contention
+by degrading everyone else's runs, which risks manufacturing flakes elsewhere
+rather than measuring this one.
+
+| test | full suite, ambient | 2-CPU confinement |
+|---|---|---|
+| `v8_epoch_seqlock_snapshot_never_tears_tag_grace` | 0/8 | **16/25 FAILED** |
+| `install_session_serializes_with_reconcile_removal` | 0/8 | 0/25 |
+
+## The prediction was confirmed for the seqlock test — by naming the assertion
+
+All 16 failures were the **same** assertion:
+
+```
+shared_cos_lease_tests.rs:2496
+readers must have validated at least one snapshot (test not vacuous)
+```
+
+The tag/grace tearing assertion inside the reader loop — the property the test
+exists for — **never fired once**. Contention starved the readers; it did not
+tear a snapshot.
+
+**Why.** Readers spin while `clock == 0`. The writer publishes `clock` only
+after its first rotation and sets `stop` after all 4 000, every one of them
+in-memory, so the window is short. On a contended box the writer could finish
+and stop the readers before any was scheduled past that spin. Every reader
+returned 0, `total_checked` was 0, and the guard tripped.
+
+## The fix establishes the precondition; it does not loosen a bound
+
+Readers publish an `observed` counter; the writer waits for the first
+observation before setting `stop`. Nothing about the tearing property changed,
+no timing assertion was relaxed, and the guard still fails if readers genuinely
+validate nothing.
+
+**This is finishing #6633's work, not inventing a fix.** That issue applied
+exactly this treatment to the *sibling* guard in the other flaky test, with a
+comment saying it "can no longer trip as a scheduler artifact on a loaded
+machine". It was applied to one guard and not to this one.
+
+**The wait is bounded, and the bound is a deadlock guard rather than a timing
+assertion.** Unbounded, a genuine regression — `test_snapshot_epoch_v8` ceasing
+to return snapshots — would become a HANG instead of a named RED, and a
+timed-out suite reports nothing about which assertion failed. On expiry the loop
+falls through and the original assert fires with its original message, so the
+failure mode is preserved exactly. `yield_now` rather than a spin, so the wait
+cannot itself starve the readers it is waiting on, which on two CPUs it
+otherwise would.
+
+**Paired verification on the identical instrument: 16/25 → 0/25.**
+
+## What is NOT claimed
+
+`install_session_serializes_with_reconcile_removal` did **not** reproduce under
+this instrument — 0/25 before and after — so its mechanism is uncharacterised
+and it is not addressed here. The prediction for it is neither confirmed nor
+refuted.
+
+A plausible reason the instrument does not reach it: 2-CPU confinement reduces
+the number of threads racing, which may *help* the installer get its turn rather
+than starve it. Its guard (`ok > 0`) fails when the reconciler wins the lock
+every time, which likely needs *more* parallelism, not less. That is a
+hypothesis for the next attempt, not a finding.
+
+## Third sighting, recorded on the issue
+
+`v8_epoch_seqlock_snapshot_never_tears_tag_grace` was seen failing once during
+the #6922 work, in a lane whose change (a NAT64 drop-attribution counter in the
+TX dispatcher) cannot reach a CoS seqlock. It did not recur across eleven
+further full-suite runs there and was recorded as a suspected flake rather than
+attributed. That made it the **third** independent sighting under three
+unrelated diffs — which is what the issue asked the next person to be able to
+say — and it is now explained.

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs
@@ -2448,6 +2448,9 @@ fn v8_epoch_seqlock_snapshot_never_tears_tag_grace() {
     // "no rotation yet".
     let clock = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
+    // #6945: reader progress, PUBLISHED so the writer can establish it
+    // instead of hoping for it. See the wait below `stop.store(true)`.
+    let observed = Arc::new(AtomicU64::new(0));
 
     // Reader threads: pure snapshots (no rotation) racing the writer's
     // payload publish. Each verifies the tag/grace invariant.
@@ -2456,6 +2459,7 @@ fn v8_epoch_seqlock_snapshot_never_tears_tag_grace() {
         let lease = Arc::clone(&lease);
         let clock = Arc::clone(&clock);
         let stop = Arc::clone(&stop);
+        let observed = Arc::clone(&observed);
         readers.push(std::thread::spawn(move || -> u64 {
             let mut checked: u64 = 0;
             while !stop.load(AtomicOrdering::Relaxed) {
@@ -2474,6 +2478,7 @@ fn v8_epoch_seqlock_snapshot_never_tears_tag_grace() {
                             tag, grace, expected,
                         );
                         checked += 1;
+                        observed.fetch_add(1, AtomicOrdering::Relaxed);
                     }
                 }
             }
@@ -2489,6 +2494,46 @@ fn v8_epoch_seqlock_snapshot_never_tears_tag_grace() {
         // acquire_v8 runs maybe_rotate_epoch_v8(now) then the snapshot.
         let _ = lease.acquire_v8(0, now, 1);
         clock.store(now, AtomicOrdering::Relaxed);
+    }
+    // #6945: WAIT for a reader to validate a snapshot before stopping them.
+    //
+    // The `total_checked > 0` guard below is a non-vacuity check, not the
+    // property under test — the property is the tag/grace equality asserted
+    // inside the reader loop. But the guard was HOPED for rather than
+    // established: readers spin while `clock == 0`, the writer publishes
+    // `clock` only after its first rotation, and all 4 000 rotations are
+    // in-memory, so on a contended box the writer could finish and set `stop`
+    // before any reader was scheduled past that spin. Every reader then
+    // returned 0, `total_checked` was 0, and the guard tripped while the
+    // tearing assertion had never been evaluated once.
+    //
+    // Measured, at master, on a 16-core box: 0/8 full-suite runs reproduced it
+    // under ambient load, but confining the test's threads to 2 CPUs
+    // (`taskset -c 0,1`) failed 16 of 25 runs — and EVERY failure was this
+    // guard, never the tag/grace assertion. Contention starved the readers; it
+    // did not tear a snapshot.
+    //
+    // So this is not a timing bound to relax. Waiting for the signal makes the
+    // precondition true by construction, which is the same treatment #6633
+    // gave the sibling guard in `install_session_serializes_with_reconcile_
+    // removal` ("can no longer trip as a scheduler artifact on a loaded
+    // machine"). `yield_now` rather than a spin so the wait cannot itself
+    // starve the readers it is waiting on, which on 2 CPUs it otherwise would.
+    // BOUNDED, and the bound is a deadlock guard rather than a timing
+    // assertion. An unbounded wait would convert a genuine regression -- one
+    // where `test_snapshot_epoch_v8` stopped returning snapshots at all -- from
+    // a named RED into a HANG, and a suite that times out reports nothing about
+    // which assertion failed. If the bound is ever reached the loop simply
+    // falls through and the `total_checked > 0` assert below fires with its
+    // original message, so the failure mode is preserved exactly. The cap is
+    // deliberately enormous relative to the work: readers need one scheduling
+    // slot, and the writer has already completed every rotation before this
+    // point.
+    for _ in 0..50_000_000u64 {
+        if observed.load(AtomicOrdering::Relaxed) > 0 {
+            break;
+        }
+        std::thread::yield_now();
     }
     stop.store(true, AtomicOrdering::Relaxed);
 


### PR DESCRIPTION
Refs #6945 — fixes **one** of the two tests. The other did not reproduce and is explicitly not addressed.

## The prediction was recorded BEFORE the reproduction finished

Posted on the issue (comment 5449077614) so it could be **refuted** rather than fitted to whatever fired:

> Neither test will fail on the property it exists to test. Both will fail on a non-vacuity guard.

That is none of the three mechanisms the task proposed (a real race; a wall-clock deadline under contention; a shared fixture path). It is a fourth: **a progress guard whose satisfaction depends on winning scheduler time.** A mechanism proposed *after* seeing which assertion fired would have fit by construction.

## Reproduction, in two steps

**Full suite at master (`22dcf4bbb`), no `-run` filter: 0 of 8 failed.** Ambient load average 9–13 on 16 cores, so the runs were contended rather than idle — but "did not reproduce at n=8" is a statement about conditions, not an absence.

**So amplify the stated trigger rather than only raise the trial count.** The mechanism requires threads *losing* a scheduler race, so the instrument confines the test's threads to two CPUs (`taskset -c 0,1`) rather than saturating a box other lanes share — a global CPU hog would create the contention by degrading everyone else's runs, manufacturing flakes elsewhere instead of measuring this one.

| test | full suite, ambient | 2-CPU confinement |
|---|---|---|
| `v8_epoch_seqlock_snapshot_never_tears_tag_grace` | 0/8 | **16/25 FAILED** |
| `install_session_serializes_with_reconcile_removal` | 0/8 | 0/25 |

## Confirmed — by naming the assertion, not by the test failing

All 16 failures were the **same** assertion:

```
shared_cos_lease_tests.rs:2496
readers must have validated at least one snapshot (test not vacuous)
```

The tag/grace tearing assertion inside the reader loop — the property the test exists for — **never fired once**. Contention starved the readers; it did not tear a snapshot.

**Why.** Readers spin while `clock == 0`. The writer publishes `clock` only after its first rotation and sets `stop` after all 4 000, every one in-memory, so the window is short. On a contended box the writer finishes and stops the readers before any is scheduled past that spin. Every reader returns 0, `total_checked` is 0, and the guard trips.

## This does not loosen anything

Readers publish an `observed` counter; the writer waits for the first observation before setting `stop`. The tearing property is untouched, no timing assertion was relaxed, and the guard still fails if readers genuinely validate nothing. **Saying this explicitly because "they loosened the test" is how a correct fix gets reverted later.**

**It is finishing #6633's work, not inventing a fix.** That issue applied exactly this treatment to the *sibling* guard in the other flaky test, with a comment saying it "can no longer trip as a scheduler artifact on a loaded machine". It was applied to one guard and not to this one.

**The wait is bounded, and the bound is a deadlock guard — not a timing assertion.** Unbounded, a genuine regression (`test_snapshot_epoch_v8` ceasing to return snapshots) would become a **hang** instead of a named RED, and a timed-out suite reports nothing about which assertion failed. On expiry the loop falls through and the original assert fires with its original message, so the failure mode is preserved exactly. `yield_now` rather than a spin, so the wait cannot itself starve the readers it waits on — which on two CPUs it otherwise would.

**Paired verification on the identical instrument: 16/25 → 0/25.**

## What is NOT claimed

`install_session_serializes_with_reconcile_removal` did **not** reproduce under this instrument (0/25 before and after) and is **not** addressed. Its mechanism is uncharacterised; the prediction for it is neither confirmed nor refuted, and #6945 should stay open for it.

A hypothesis for the next attempt, not a finding: 2-CPU confinement *reduces* the number of threads racing, which may help the installer get its turn rather than starve it. Its guard (`ok > 0`) fails when the reconciler wins the lock every time, which likely needs *more* parallelism, not less.

## Third sighting, now explained

The seqlock test was seen failing once during the #6922 work, in a lane whose change (a NAT64 drop-attribution counter in the TX dispatcher) cannot reach a CoS seqlock. It did not recur across eleven further full-suite runs there and was recorded as a suspected flake rather than attributed — making it the **third** independent sighting under three unrelated diffs, which is what the issue asked the next person to be able to say.

## Gates

- Full Rust suite at the pre-fold head (`4b36caa9f`): 10 binaries, **4830 passed, 0 failed**
- **First re-run after folding master to `d8965f149` went RED** — `slowpath::tests::enqueue_refuses_frame_above_live_mtu`, *"slow-path worker is not running"*. Investigated rather than re-run until green:
  - **0/40** in isolation, unconfined, at this head
  - **0/30** in isolation under the same 2-CPU confinement that reproduces the seqlock flake 16/25
  - the master fold brought **one docs-only commit** (`8463a7cdf`), and this diff is `docs/log/6945.md` plus one CoS-seqlock *test* file — neither touches `slowpath`
  - **2 further full-suite runs at the folded head: 10 binaries, 4830 passed, 0 failed, twice**
- Gated head `a74e96985`, `origin/master` (`d8965f149`) verified as an ancestor

**That red is a fourth sighting in the same family, not a regression from this diff — and it is reported on #6945 rather than buried here.** Its failure message is a *precondition* one ("worker is not running"), the same shape as the two tests the issue already names: something that must have started did not get scheduled before the assertion ran. It appeared only under the full suite and never in 70 isolated runs, which is exactly the pattern the issue documents. I am not claiming it is the same root cause — one sighting is a sighting.

