### PR TITLE
userspace-dp: bound the per-zone accumulators and omit their empty wire blocks (#6946, #6947)

### DIFF
--- a/docs/log/6946.md
+++ b/docs/log/6946.md
@@ -1,0 +1,52 @@
+# #6946 / #6947 — per-zone counter accumulators and their wire block
+
+- **Timestamp**: 2026-08-27
+  - **Action**: judged the two issues INDEPENDENT before choosing a shape, and
+    verified it rather than assuming. They share a subject area and nothing
+    else: #6946 is per-worker thread-local reset/fold cost on the RX-batch
+    path, #6947 is a serde attribute on the wire struct. The empty array is
+    not a symptom of the accumulator — `server/helpers/status.rs:364/374`
+    populates the Vec from the folded totals, so it is empty only when there
+    genuinely are no counters. Two commits, one PR, no shared cause implied.
+  - **File(s)**: none (analysis)
+
+- **Timestamp**: 2026-08-27
+  - **Action**: #6947 — established that the defect really is hygiene and not
+    a masked correctness bug, which the "emits nothing" shape makes worth
+    checking. **No consumer distinguishes `[]` from absent**: nothing in `pkg/`
+    compares these fields to nil, and every read path uses `len()`/`range`,
+    which treat a nil slice and an empty one identically. So the cost is the
+    unconditional payload on the shared control socket, as filed.
+  - **File(s)**: none (measurement)
+
+- **Timestamp**: 2026-08-27
+  - **Action**: #6947 — added `skip_serializing_if = "Vec::is_empty"` to both
+    fields. The golden fixture regenerated, and the diff was **classified
+    rather than accepted**: 0 keys added, exactly 2 removed (the two fields),
+    0 values changed. The test failed before regen and passed after, so it
+    provably ran — an earlier attempt used a `-run` filter that matched zero
+    tests and reported a 0/0/0 diff that meant nothing.
+  - **File(s)**: userspace-dp/src/protocol/control.rs,
+    userspace-dp/tests/fixtures/protocol_wire_v1.json,
+    userspace-dp/src/protocol/tests.rs
+
+- **Timestamp**: 2026-08-27
+  - **Action**: #6946 — replaced `touched: bool` with a `touched_slots: u64`
+    bitmask in both `ZonePending` and `FloodPending`; reset and fold now walk
+    set bits instead of all 64 slots. Added `const _: () = assert!(SLOTS <=
+    64)` to both modules: past 64, `1u64 << slot` shifts out of range, which
+    is a panic in debug and a silently WRONG mask in release that would drop
+    whole zones with no error.
+  - **File(s)**: userspace-dp/src/afxdp/zone_counters.rs,
+    userspace-dp/src/afxdp/flood_counters.rs
+
+- **Timestamp**: 2026-08-27
+  - **Action**: tested the CEILING, not the floor. Filling slots and checking
+    the entries arrive passes identically with no bound at all, so the cells
+    assert the invariant the compile-time guard protects and exercise the
+    TOP slot, which is the one an off-by-one in the mask width loses. The
+    behavioural cell drives TWO batches touching different slots, because the
+    dangerous regression is not a lost delta but a delta folded and not
+    cleared — which re-folds next batch and silently double-counts, and a
+    single-batch test cannot see it.
+  - **File(s)**: userspace-dp/src/afxdp/zone_counters.rs

--- a/userspace-dp/src/afxdp/flood_counters.rs
+++ b/userspace-dp/src/afxdp/flood_counters.rs
@@ -57,6 +57,16 @@ use crate::protocol::ZoneFloodCounterStatus;
 /// [`ZONE_COUNTER_SLOTS`]: crate::afxdp::zone_counters::ZONE_COUNTER_SLOTS
 pub(in crate::afxdp) const FLOOD_COUNTER_SLOTS: usize = 64;
 
+/// #6946: `FloodPending::touched_slots` is a `u64` bitmask, one bit per slot.
+/// Raising the slot count past 64 would make `1u64 << slot` shift out of
+/// range — a panic in debug and a silently WRONG mask in release, dropping
+/// whole zones' flood counts with no error. Asserted at compile time so the
+/// capacity cannot be raised without widening the mask. (The sibling
+/// assertion below pins FLOOD == ZONE; this one pins the mask width, and
+/// both are needed: keeping the two counts equal does not keep either
+/// within 64.)
+const _: () = assert!(FLOOD_COUNTER_SLOTS <= 64);
+
 /// Number of assignable slots (slot 0 reserved).
 pub(in crate::afxdp) const FLOOD_COUNTER_ASSIGNABLE_SLOTS: usize = FLOOD_COUNTER_SLOTS - 1;
 
@@ -329,7 +339,12 @@ impl FloodCounterStore {
     /// atomics the slot map cached at build time. LOCK-FREE — a straight
     /// `Relaxed` `fetch_add` per touched slot; it does NOT lock `self.totals`.
     fn fold_pending(&self, pending: &FloodPending, slot_map: &FloodCounterSlotMap) {
-        for slot in 1..FLOOD_COUNTER_SLOTS {
+        // #6946: walk the touched bits rather than all 64 slots. Slot 0 is
+        // the unassigned sentinel and is never recorded into.
+        let mut mask = pending.touched_slots;
+        while mask != 0 {
+            let slot = mask.trailing_zeros() as usize;
+            mask &= mask - 1;
             let Some(totals) = &slot_map.slot_totals[slot] else {
                 continue;
             };
@@ -354,25 +369,35 @@ impl FloodCounterStore {
 /// worker thread on the drop path; folded into the shared store per RX batch.
 struct FloodPending {
     counts: [[u64; FLOOD_COUNTER_SLOTS]; FLOOD_KINDS],
-    touched: bool,
+    /// #6946: one bit per touched slot, replacing a single `touched: bool`.
+    /// See the ZonePending field of the same name; the flood case matters
+    /// more because this accumulator is fed from the screen DROP path, so it
+    /// is hot on every worker at once during precisely the flood the counter
+    /// exists to measure.
+    touched_slots: u64,
 }
 
 impl Default for FloodPending {
     fn default() -> Self {
         Self {
             counts: [[0; FLOOD_COUNTER_SLOTS]; FLOOD_KINDS],
-            touched: false,
+            touched_slots: 0,
         }
     }
 }
 
 impl FloodPending {
     fn reset(&mut self) {
-        if !self.touched {
-            return;
+        // #6946: clear only the slots that moved, across every kind.
+        let mut mask = self.touched_slots;
+        while mask != 0 {
+            let slot = mask.trailing_zeros() as usize;
+            mask &= mask - 1;
+            for counts in self.counts.iter_mut() {
+                counts[slot] = 0;
+            }
         }
-        self.counts = [[0; FLOOD_COUNTER_SLOTS]; FLOOD_KINDS];
-        self.touched = false;
+        self.touched_slots = 0;
     }
 }
 
@@ -406,7 +431,7 @@ pub(in crate::afxdp) fn record_zone_flood_drop(
         let mut p = pending.borrow_mut();
         let s = slot as usize;
         p.counts[kind][s] = p.counts[kind][s].saturating_add(1);
-        p.touched = true;
+        p.touched_slots |= 1u64 << s;
     });
 }
 
@@ -422,7 +447,7 @@ pub(in crate::afxdp) fn flush_recorded_flood_counters(
 ) {
     FLOOD_PENDING.with(|pending| {
         let mut p = pending.borrow_mut();
-        if !p.touched {
+        if p.touched_slots == 0 {
             return;
         }
         store.fold_pending(&p, slot_map);

--- a/userspace-dp/src/afxdp/zone_counters.rs
+++ b/userspace-dp/src/afxdp/zone_counters.rs
@@ -63,6 +63,14 @@ use crate::protocol::ZoneTrafficCounterStatus;
 /// accumulator small (64 × 4 × 8 = 2 KiB).
 pub(in crate::afxdp) const ZONE_COUNTER_SLOTS: usize = 64;
 
+/// #6946: `ZonePending::touched_slots` is a `u64` bitmask, one bit per slot.
+/// Raising the slot count past 64 would make `1u64 << slot` shift out of
+/// range — a panic in debug and a silently WRONG mask in release, which
+/// would drop whole zones' counters with no error. The bound is asserted at
+/// compile time so the capacity cannot be raised without also widening the
+/// mask.
+const _: () = assert!(ZONE_COUNTER_SLOTS <= 64);
+
 /// Number of assignable slots (slot 0 reserved).
 pub(in crate::afxdp) const ZONE_COUNTER_ASSIGNABLE_SLOTS: usize = ZONE_COUNTER_SLOTS - 1;
 
@@ -362,7 +370,12 @@ impl ZoneCounterStore {
     /// fold and the intervening `record_zone_traffic` calls always read the SAME
     /// slot map).
     fn fold_pending(&self, pending: &ZonePending, slot_map: &ZoneCounterSlotMap) {
-        for slot in 1..ZONE_COUNTER_SLOTS {
+        // #6946: walk the touched bits instead of all 64 slots. Slot 0 is the
+        // unassigned sentinel and is never recorded into, so it cannot be set.
+        let mut mask = pending.touched_slots;
+        while mask != 0 {
+            let slot = mask.trailing_zeros() as usize;
+            mask &= mask - 1;
             let Some(totals) = &slot_map.slot_totals[slot] else {
                 continue;
             };
@@ -414,7 +427,14 @@ struct ZonePending {
     ingress_bytes: [u64; ZONE_COUNTER_SLOTS],
     egress_packets: [u64; ZONE_COUNTER_SLOTS],
     egress_bytes: [u64; ZONE_COUNTER_SLOTS],
-    touched: bool,
+    /// #6946: one bit per touched slot, replacing a single `touched: bool`.
+    ///
+    /// The bool made both per-batch operations O(SLOTS) regardless of how
+    /// many slots actually moved: `reset` cleared 4 x [u64; 64] = 2048 B and
+    /// `fold_pending` scanned all 64 slots, to flush what is typically ONE
+    /// zone. The cost that matters is cache, not cycles — 32 dirtied lines
+    /// per flush per worker per RX batch.
+    touched_slots: u64,
 }
 
 impl Default for ZonePending {
@@ -424,21 +444,25 @@ impl Default for ZonePending {
             ingress_bytes: [0; ZONE_COUNTER_SLOTS],
             egress_packets: [0; ZONE_COUNTER_SLOTS],
             egress_bytes: [0; ZONE_COUNTER_SLOTS],
-            touched: false,
+            touched_slots: 0,
         }
     }
 }
 
 impl ZonePending {
     fn reset(&mut self) {
-        if !self.touched {
-            return;
+        // #6946: clear only the slots that moved. Whole-array assignment
+        // dirtied every line whether or not it held a delta.
+        let mut mask = self.touched_slots;
+        while mask != 0 {
+            let slot = mask.trailing_zeros() as usize;
+            mask &= mask - 1;
+            self.ingress_packets[slot] = 0;
+            self.ingress_bytes[slot] = 0;
+            self.egress_packets[slot] = 0;
+            self.egress_bytes[slot] = 0;
         }
-        self.ingress_packets = [0; ZONE_COUNTER_SLOTS];
-        self.ingress_bytes = [0; ZONE_COUNTER_SLOTS];
-        self.egress_packets = [0; ZONE_COUNTER_SLOTS];
-        self.egress_bytes = [0; ZONE_COUNTER_SLOTS];
-        self.touched = false;
+        self.touched_slots = 0;
     }
 }
 
@@ -469,13 +493,13 @@ pub(in crate::afxdp) fn record_zone_traffic(
             let s = ingress_slot as usize;
             p.ingress_packets[s] = p.ingress_packets[s].saturating_add(1);
             p.ingress_bytes[s] = p.ingress_bytes[s].saturating_add(packet_bytes);
-            p.touched = true;
+            p.touched_slots |= 1u64 << s;
         }
         if egress_slot != 0 {
             let s = egress_slot as usize;
             p.egress_packets[s] = p.egress_packets[s].saturating_add(1);
             p.egress_bytes[s] = p.egress_bytes[s].saturating_add(packet_bytes);
-            p.touched = true;
+            p.touched_slots |= 1u64 << s;
         }
     });
 }
@@ -498,7 +522,7 @@ pub(in crate::afxdp) fn flush_recorded_zone_counters(
 ) {
     ZONE_PENDING.with(|pending| {
         let mut p = pending.borrow_mut();
-        if !p.touched {
+        if p.touched_slots == 0 {
             return;
         }
         store.fold_pending(&p, slot_map);
@@ -512,6 +536,84 @@ mod tests {
     use std::sync::mpsc;
     use std::thread;
     use std::time::{Duration, Instant};
+
+    /// #6946: the touched-slot bitmask must clear every slot it folded, and
+    /// must reach the HIGHEST assignable slot.
+    ///
+    /// The dangerous regression is not "a delta is lost" — it is "a delta is
+    /// folded but not cleared", because the stale value then folds AGAIN on
+    /// the next batch and the counter silently double-counts. A test that
+    /// records once and checks the total arrives cannot see that; it needs a
+    /// SECOND batch that touches a different slot, so the first slot's
+    /// residue would be re-folded if reset missed it.
+    #[test]
+    fn touched_slot_mask_clears_what_it_folded_6946() {
+        let store = ZoneCounterStore::default();
+        let map = ZoneCounterSlotMap::build(&[11, 22], &store);
+
+        // Batch 1: traffic on zone 11 only.
+        record_zone_traffic(&map, 11, 0, 100);
+        flush_recorded_zone_counters(&store, &map);
+
+        // Batch 2: traffic on zone 22 only. If reset() failed to clear slot
+        // 11, its batch-1 delta folds a second time here.
+        record_zone_traffic(&map, 22, 0, 500);
+        flush_recorded_zone_counters(&store, &map);
+
+        let rows = store.snapshot();
+        let z11 = rows
+            .iter()
+            .find(|r| r.zone_id == 11)
+            .expect("zone 11 must be counted");
+        assert_eq!(
+            (z11.ingress_packets, z11.ingress_bytes),
+            (1, 100),
+            "zone 11 folded twice — reset() did not clear the slot it folded, so \
+             the stale delta was re-added on the next batch (#6946)"
+        );
+        let z22 = rows
+            .iter()
+            .find(|r| r.zone_id == 22)
+            .expect("zone 22 must be counted");
+        assert_eq!((z22.ingress_packets, z22.ingress_bytes), (1, 500));
+    }
+
+    /// #6946: the mask is a u64, so the capacity must never exceed 64 — a
+    /// larger slot count makes `1u64 << slot` shift out of range, which is a
+    /// panic in debug and a silently WRONG mask in release.
+    ///
+    /// This asserts the CEILING, not the floor. Filling slots and checking
+    /// they arrive passes identically with no bound at all; what would break
+    /// is a slot ABOVE the mask width, and the compile-time
+    /// `const _: () = assert!(ZONE_COUNTER_SLOTS <= 64)` is what prevents it.
+    /// This runtime cell fails loudly if that guard is ever deleted along
+    /// with the const it protects.
+    #[test]
+    fn slot_capacity_fits_the_touched_mask_6946() {
+        assert!(
+            ZONE_COUNTER_SLOTS <= 64,
+            "ZONE_COUNTER_SLOTS = {ZONE_COUNTER_SLOTS} exceeds the 64 bits of \
+             ZonePending::touched_slots; `1u64 << slot` would shift out of range \
+             and whole zones would stop being folded (#6946)"
+        );
+        assert!(
+            crate::afxdp::flood_counters::FLOOD_COUNTER_SLOTS <= 64,
+            "FLOOD_COUNTER_SLOTS exceeds the 64 bits of FloodPending::touched_slots"
+        );
+        // The top assignable slot must round-trip through the mask: bit 63 is
+        // the one an off-by-one in the shift would lose.
+        let mut p = ZonePending::default();
+        let top = ZONE_COUNTER_SLOTS - 1;
+        p.ingress_packets[top] = 7;
+        p.touched_slots |= 1u64 << top;
+        p.reset();
+        assert_eq!(
+            p.ingress_packets[top], 0,
+            "the highest slot was not cleared by reset(); an off-by-one in the \
+             mask width loses exactly this slot"
+        );
+        assert_eq!(p.touched_slots, 0, "reset() must clear the mask");
+    }
 
     #[test]
     fn build_assigns_slots_for_wide_stable_hash_zone_ids() {

--- a/userspace-dp/src/afxdp/zone_counters.rs
+++ b/userspace-dp/src/afxdp/zone_counters.rs
@@ -541,11 +541,15 @@ mod tests {
     /// must reach the HIGHEST assignable slot.
     ///
     /// The dangerous regression is not "a delta is lost" — it is "a delta is
-    /// folded but not cleared", because the stale value then folds AGAIN on
-    /// the next batch and the counter silently double-counts. A test that
-    /// records once and checks the total arrives cannot see that; it needs a
-    /// SECOND batch that touches a different slot, so the first slot's
-    /// residue would be re-folded if reset missed it.
+    /// folded but not cleared", because the stale value is then added AGAIN
+    /// the next time that same slot is touched, and the counter over-counts.
+    ///
+    /// The second batch must touch the SAME zone, and that is not obvious.
+    /// A second batch on a DIFFERENT zone cannot detect the bug: the fold
+    /// walks the mask, so with the stale slot's bit cleared its residue is
+    /// never revisited. The first version of this cell used a different zone
+    /// and stayed GREEN under its own killing mutation — it was measuring
+    /// nothing, and only the mutation matrix showed it.
     #[test]
     fn touched_slot_mask_clears_what_it_folded_6946() {
         let store = ZoneCounterStore::default();
@@ -555,8 +559,13 @@ mod tests {
         record_zone_traffic(&map, 11, 0, 100);
         flush_recorded_zone_counters(&store, &map);
 
-        // Batch 2: traffic on zone 22 only. If reset() failed to clear slot
-        // 11, its batch-1 delta folds a second time here.
+        // Batch 2: the SAME zone again. If reset() left slot 11's values in
+        // place, this folds 100 (residue) + 100 (new) = 200 bytes.
+        record_zone_traffic(&map, 11, 0, 100);
+        flush_recorded_zone_counters(&store, &map);
+
+        // Batch 3: a different zone, so the assertion above cannot pass by the
+        // mask having stopped recording zone 11 altogether.
         record_zone_traffic(&map, 22, 0, 500);
         flush_recorded_zone_counters(&store, &map);
 
@@ -567,7 +576,7 @@ mod tests {
             .expect("zone 11 must be counted");
         assert_eq!(
             (z11.ingress_packets, z11.ingress_bytes),
-            (1, 100),
+            (2, 200),
             "zone 11 folded twice — reset() did not clear the slot it folded, so \
              the stale delta was re-added on the next batch (#6946)"
         );

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -782,7 +782,16 @@ pub(crate) struct ProcessStatus {
         skip_serializing_if = "crate::protocol::bool_is_false"
     )]
     pub zone_counter_overflow_active: bool,
-    #[serde(rename = "zone_traffic_counters", default)]
+    // #6947: omit the block when empty, matching BOTH the Go mirror
+    // (`json:"zone_traffic_counters,omitempty"`) and the sibling scalars in
+    // this same struct, which already carry skip_serializing_if. Without
+    // it the helper puts an empty array on the shared control socket on
+    // every 1/s status poll, forever, on a firewall that never populated it.
+    #[serde(
+        rename = "zone_traffic_counters",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub zone_traffic_counters: Vec<ZoneTrafficCounterStatus>,
     /// #3651: per-zone SYN/ICMP/UDP flood-EVENT counts, summed across every
     /// worker by the helper (one `ProcessStatus`-level pre-summed sparse block,
@@ -810,7 +819,16 @@ pub(crate) struct ProcessStatus {
         skip_serializing_if = "crate::protocol::bool_is_false"
     )]
     pub flood_counter_overflow_active: bool,
-    #[serde(rename = "zone_flood_counters", default)]
+    // #6947: omit the block when empty, matching BOTH the Go mirror
+    // (`json:"zone_flood_counters,omitempty"`) and the sibling scalars in
+    // this same struct, which already carry skip_serializing_if. Without
+    // it the helper puts an empty array on the shared control socket on
+    // every 1/s status poll, forever, on a firewall that never populated it.
+    #[serde(
+        rename = "zone_flood_counters",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub zone_flood_counters: Vec<ZoneFloodCounterStatus>,
     #[serde(rename = "three_color_policer_counters", default)]
     pub three_color_policer_counters: Vec<ThreeColorPolicerStatus>,

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -1733,6 +1733,52 @@ fn app_catalog_entry_roundtrip() {
 // default (no per-zone data) ProcessStatus omits the layout-version /
 // overflow keys. The Go mirror lives in
 // pkg/dataplane/userspace/zone_counters_status_test.go.
+/// #6947: both per-zone blocks are OMITTED when empty and PRESENT when
+/// populated.
+///
+/// The two halves are load-bearing together. "The key is absent" alone is
+/// satisfied by a field that never serializes at all, so the populated half is
+/// what proves the omission is conditional rather than total — that is the
+/// difference between this fix and a silent wire regression that drops real
+/// counters.
+///
+/// Before this, both fields carried `default` but not
+/// `skip_serializing_if = "Vec::is_empty"`, so the helper put
+/// `"zone_traffic_counters":[]` and `"zone_flood_counters":[]` on the shared
+/// control socket on every 1/s status poll, forever, on a firewall that had
+/// never populated either — while their sibling scalars in the same struct,
+/// and both Go mirrors (`json:"...,omitempty"`), already omitted.
+#[test]
+fn zone_counter_blocks_omitted_when_empty_present_when_populated_6947() {
+    let empty = serde_json::to_string(&ProcessStatus::default()).expect("serialize default");
+    for key in ["zone_traffic_counters", "zone_flood_counters"] {
+        assert!(
+            !empty.contains(key),
+            "default ProcessStatus still emits {key} — an empty array on the shared \
+             control socket every poll, which the Go mirror already omits (#6947): {empty}"
+        );
+    }
+
+    let mut status = ProcessStatus::default();
+    status.zone_traffic_counters = vec![ZoneTrafficCounterStatus {
+        zone_id: 40000,
+        ingress_packets: 1,
+        ingress_bytes: 2,
+        egress_packets: 3,
+        egress_bytes: 4,
+    }];
+    status.zone_flood_counters = vec![ZoneFloodCounterStatus::default()];
+    let populated = serde_json::to_string(&status).expect("serialize populated");
+    for key in ["zone_traffic_counters", "zone_flood_counters"] {
+        assert!(
+            populated.contains(key),
+            "a POPULATED {key} was dropped from the wire. skip_serializing_if must be \
+             conditional on emptiness; if it omits a non-empty block the fix has \
+             become a counter-losing regression: {populated}"
+        );
+    }
+}
+
 #[test]
 fn zone_traffic_counters_wire_roundtrip_and_default_omits() {
     // Default helper: no zone data -> version/overflow omitted from the wire.

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -973,9 +973,7 @@
     "worker_command_queue_poison_recoveries": 0,
     "worker_heartbeats": [],
     "worker_runtime": [],
-    "workers": 0,
-    "zone_flood_counters": [],
-    "zone_traffic_counters": []
+    "workers": 0
   },
   "queue_control_request": {
     "armed": false,


### PR DESCRIPTION
Closes #6946
Closes #6947

**Two independent defects, verified independent rather than assumed.** They share a subject area and nothing else, so they are two commits and this PR says explicitly that there is no shared cause.

- **#6946** — per-worker thread-local reset/fold cost on the RX-batch path.
- **#6947** — a serde attribute on the wire struct.

The tempting story is "the unbounded accumulator is why the status block emits empties". **It is not.** `server/helpers/status.rs:364/374` populates both Vecs from the folded totals, so they are empty only when there genuinely are no counters. The accumulator's strategy affects *cost*, not *whether* the block populates.

---

## #6946 — bound the accumulators with a touched-slot mask

`ZonePending` and `FloodPending` had dense slot arrays and a single `touched: bool`, making both per-batch operations O(SLOTS) regardless of how many slots moved — `reset` cleared 2048 B / 1536 B and `fold_pending` scanned all 64 slots, to flush what is typically **one** zone. The cache cost is the real one: 24-32 dirtied lines per flush, per worker, per batch.

It matters more for flood: that accumulator is fed from the screen DROP path, and a SYN flood is the primary `screen_drops` trigger — so it is hot on every worker at once during precisely the event the counter exists to measure.

`touched_slots: u64` replaces the bool; reset and fold walk set bits. Both drop from O(64) to O(touched).

### The ceiling is asserted, not the floor

Past 64 slots, `1u64 << slot` shifts out of range — a panic in debug and a **silently wrong mask** in release, which would stop folding whole zones with no error. `const _: () = assert!(SLOTS <= 64)` is added to **both** modules. The existing sibling assertion pins `FLOOD == ZONE`, which is a different property: keeping the two counts equal does not keep either within 64.

Filling slots and checking the entries arrive would pass identically with no bound at all, so the test asserts the invariant the compile-time guard protects and exercises the **top** slot — the one an off-by-one in the mask width loses. Verified the guard actually fires:

```
error[E0080]: evaluation panicked: assertion failed: ZONE_COUNTER_SLOTS <= 64
   const _: () = assert!(ZONE_COUNTER_SLOTS <= 64);
```

### A cell that was measuring nothing — the third commit

**The mutation matrix caught a defect in my own test**, which is the point of running one.

The behavioural cell drove batch 1 on zone 11 and batch 2 on zone **22**, then asserted zone 11 had not double-counted. Under its own killing mutation — *reset clears the mask but not the slots* — **it stayed green**: the fold walks the mask, so with slot 11's bit cleared its stale residue is never revisited. Touching a different slot cannot detect the bug.

The second batch has to touch the **same** zone; that is when the residue is added on top of the new delta. A third batch keeps a different zone so the assertion cannot instead pass by the mask having stopped recording zone 11 altogether — a "correct" total for the wrong reason. Corrected, the matrix goes from **3 named failures to 4**, and the doc comment records why the obvious interleaving does not work.

---

## #6947 — omit the per-zone blocks when empty

Both fields carried `default` but not `skip_serializing_if = "Vec::is_empty"`, so the helper put `"zone_traffic_counters":[]` and `"zone_flood_counters":[]` on the wire **every 1/s poll, forever**, on a firewall that never populated either — while their sibling scalars in the same struct, and both Go mirrors, already omit.

The cost is not the bytes: the control socket is shared with HA sync, session installs, snapshot sync and forwarding sync, and this is unconditional payload nobody chose to send.

### Checked whether it was hiding something, because "emits an empty thing forever" usually is

**It is hygiene.** No consumer distinguishes `[]` from absent: nothing in `pkg/` compares these fields to nil, and every read path uses `len()`/`range`, which treat a nil slice and an empty one identically. Stating that as measured rather than assumed, because the alternative — a consumer that *does* distinguish — would have made this a correctness fix with a different shape.

### The golden diff is classified, not accepted

```
keys added    : 0
keys removed  : 2  ['/process_status/zone_flood_counters', '/process_status/zone_traffic_counters']
values changed: 0
```

Exactly the two fields, nothing else. **And the regeneration is verified to have run** — a first attempt used a filter matching zero tests (`0 passed; 61 filtered out`) and produced a 0/0/0 diff that meant nothing. The real test fails before regen and passes after.

The new cell asserts **both halves**: absent when empty, **present when populated**. "The key is absent" alone is satisfied by a field that never serializes at all, so the populated half is what separates this fix from a regression that silently drops real counters.

---

## Mutation matrix

Fix committed before mutating. Full `--bins`, `--test-threads=1`, no filter.

| # | mutation | outcome | ran |
|---|---|---|---|
| R1 | `reset()` clears the mask but not the slots | **RED** — 4 named, incl. both #6946 cells + 2 pre-existing | 4767 |
| R2 | raise `ZONE_COUNTER_SLOTS` to 65 | **compile-time REFUSAL**, assert named in the error | n/a |
| R3 | revert the `skip_serializing_if` | **RED** — `...6947` + the golden invariant | 4767 |

R2 is scored as a refusal, not a void cell: the build failure *is* the guard firing, and the error names the assertion.

## Test plan

- [x] `go test ./... -count=1` → **68/68**
- [x] `cargo test --bins --tests -- --test-threads=1` → **rc 0, 4834 passed, 0 failed**
- [x] `cargo fmt` — my four Rust files verified against a detached `origin/master` baseline: identical diff counts, offsets matching my insertions, so no new fmt drift
- [x] `origin/master` folded; ancestry verified

**One disclosed flake.** An intermediate full-Go run reported `67 ok / 3 FAIL` on `TestStartHeartbeatDoesNotRaceStopHeartbeat7257`, at exactly **30.00s** — a round-number timeout. My diff touches **zero Go files** (`git diff --name-only | grep -c '\.go$'` → 0), the test passes in **0.00s** in isolation, and load average was **16** with other lanes building. Re-ran clean: 68/0. Recording it rather than quietly reporting the good run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhHmVt536ZsY2RVEhc8WPV
