### PR TITLE
config: merge per-unit WireGuard peers into the interface endpoint

### DIFF
--- a/docs/log/7786.md
+++ b/docs/log/7786.md
@@ -69,6 +69,25 @@ map-iteration randomisation was not a live hazard on this path either.
 - **Wire fixture cannot move**: `protocol_wire_v1.json` is generated from Rust
   `::default()` specimens, and no Rust changed in this PR. Verified untouched.
 
+## Escape found in my own matrix, and what it was
+
+Cell **M3** (delete the pubkey sort) came back **GREEN** on the first run. The
+sort assertions could not see it, and the fault was the fixture rather than the
+code: the merge appends the interface-level peers before the per-unit ones, and
+both fixtures used pubkeys that ascend in exactly that order
+(`1111/2222/3333` then `aaaa/bbbb`), so the UNSORTED merge order already WAS
+the sorted order. The assertion was structurally incapable of failing.
+
+Fixed by making the interface-level peers sort AFTER the per-unit ones, so the
+two orders differ; M3 then reds by name. The same class as a fixture that uses
+the value the bug falls back to — the assertion looks right, the data makes it
+inert.
+
+Cell **M4** was also void on the first run: deleting the `!contributes`
+fast-path left `contributes` unused and broke the build, which is a VOID and
+not an escape. Re-expressed as returning a copy instead of the original
+pointer, which compiles and tests the actual claim; it then reds.
+
 ## Config-layer test bound at the endpoint
 
 `tunnel_perunit_deepcopy_test.go` asserted only compiled-config properties, and

--- a/docs/log/7786.md
+++ b/docs/log/7786.md
@@ -1,0 +1,85 @@
+# #7786 — per-unit WireGuard peers never reached the dataplane
+
+- **Timestamp**: 2026-08-28
+- **Action**: Merge per-unit peers into the interface's single endpoint; refuse
+  a unit that overrides the local WireGuard identity. Scope decided and
+  reported BEFORE writing code.
+
+## Framing that made this small
+
+The emitter's NON-WireGuard interface-level branch already emits the unit's own
+`TunnelConfig` and says why (#5635, `tunnelemit.go`): per-unit overrides must
+reach the snapshot builder "instead of the interface-level defaults". The
+WireGuard branch (#1910) short-circuits above it with the single-lowest-unit
+rule and never got that treatment. **#7786 is the WireGuard hole in #5635.**
+
+## Why merge, not reject, and not emit-per-unit
+
+Two sub-shapes, both measured at master:
+
+| | shape | meaning |
+|---|---|---|
+| (i) | unit ADDS peers, inherits port+key | same WireGuard interface |
+| (ii) | unit OVERRIDES listen-port and/or private-key | a different local identity |
+
+- **Merge is right for (i) and provably unambiguous.** I tried to construct a
+  merge conflict and could not: a unit re-declaring an inherited peer is
+  already rejected at commit (`duplicate peer public key`). So a unit's peer
+  set is always the inherited set plus disjoint pubkeys, de-dup by pubkey is
+  total, and no precedence rule is needed. This is a property of the validator,
+  not of the merge function, and is asserted as a precondition in the dedup
+  test so the test cannot pass because there was nothing to dedup.
+- **Emit-per-unit is wrong for (i).** It would place two endpoints on one
+  listen port and one private key. Measured: two interface-level WG tunnels
+  both on 51820 compile without complaint and `WireGuardListenPorts()` returns
+  `[51820]`, so nothing would report the collision.
+- **Merge is wrong for (ii)** — it folds a different identity's peers into the
+  parent, where they would be offered the parent's key. Refused at commit.
+- The split follows the codebase's own model, not taste: `types_routing.go`
+  states `WgListenPort`/`WgLocalPrivkeyHex` are TUNNEL-level, "one kernel UDP
+  socket, one local identity per WG interface", while `WgPeers` is the per-peer
+  set.
+- **Rejecting (ii) breaks nothing: zero in-tree uses.** The `tunnelid_test.go`
+  hits that resemble it are the canonical per-unit spelling with no
+  interface-level stanza, which still compiles (guarded by an over-rejection
+  test). And (ii) was half-wired badly: routing materialises the unit's TUN and
+  `WireGuardListenPorts()` already collects the unit's port, so the
+  host-inbound filter opened a port with nothing behind it.
+
+## Determinism
+
+Peers are sorted by pubkey in the merge. Stated precisely, because it is easy
+to overclaim: the snapshot builder ALREADY sorts by pubkey before serializing
+(`tunnels.go`), and that is what actually pins the #1434 §5.4
+byte-identical-across-HA-nodes property. Sorting in the emitter buys the same
+determinism for the emitter's OTHER consumers — the strict-tunnel validators
+and the endpoint-collision gate read `ep.Tunnel.WgPeers` directly and never see
+the builder's sort. Unit iteration is over the already-sorted `unitNums`, so
+map-iteration randomisation was not a live hazard on this path either.
+
+## Blast radius, checked rather than assumed
+
+- **Endpoint ref unchanged** (`wg0.<lowest unit>`), so `StableTunnelEndpointID`
+  — derived from that string — is identical for every existing config. Asserted.
+- **Device unchanged** (`tunnel.Name` still the interface device), so #6941's
+  open question is not perturbed. Asserted.
+- **No config without per-unit peers is copied at all**: the merge returns the
+  interface-level `*TunnelConfig` itself, same pointer. Asserted by pointer
+  identity, so the common path cannot start allocating or reordering silently.
+- **Wire fixture cannot move**: `protocol_wire_v1.json` is generated from Rust
+  `::default()` specimens, and no Rust changed in this PR. Verified untouched.
+
+## Config-layer test bound at the endpoint
+
+`tunnel_perunit_deepcopy_test.go` asserted only compiled-config properties, and
+every one of them passed throughout the period when per-unit peers reached
+nothing. It now also asserts the five distinct pubkeys arrive in the emitted
+endpoint, sorted. Put in that test rather than a new file deliberately: the
+property that makes the #3898 deep copy worth doing is that each unit's peer is
+installed, and if that lived elsewhere it could be deleted without this test
+noticing, and the shape would go back to being tested at the config layer and
+dead at the runtime layer.
+
+**File(s)**: pkg/config/tunnelemit.go, pkg/config/compiler_validate_wireguard.go,
+pkg/config/tunnel_perunit_deepcopy_test.go,
+pkg/config/wireguard_per_unit_peers_7786_test.go, docs/wireguard-interop.md

--- a/docs/wireguard-interop.md
+++ b/docs/wireguard-interop.md
@@ -21,6 +21,56 @@ therefore staged by capability, not by vendor.
 | S7 | Type-3 CookieReply + MAC2 generation/verification + IPv6 outer encap + DSCP/ECN | **DSCP/ECN encap DONE (#2303)** — inner DSCP+ECN copied onto the outer header (uniform DSCP + RFC 6040 ECN ingress copy). RFC 6040 §4.2 decap-side ECN *combine* shipped for GRE (#2315) AND WG (#2317) — WG captures the outer ECN via `recvmsg` + `IP_RECVTOS`/`IPV6_RECVTCLASS` cmsg and folds it into the decrypted inner via the shared `apply_decap_ecn_combine` (live ECN-propagation verification lab-deferred to #1703-class interop). **RESPONDER CookieReply + MAC2 under-load DoS mitigation DONE (#4094 PR-A)** — a per-tunnel rotating secret `Rm` (120 s, one-window previous-secret carry), an inbound-initiation fixed-window load gate, and MAC2 verification bind an initiation to the source that received the responder's type-3 CookieReply, so a valid-MAC1 flood (attacker knows our public key) no longer forces a Noise handshake per forged datagram. See "Responder cookie / MAC2 under-load DoS mitigation" below. **INITIATOR-side CookieReply *consume* DONE (#4094 PR-B)** — an inbound type-3 is decrypted (responder pubkey-derived key + our last-sent MAC1 as AAD), the cookie stored per-peer, and our NEXT initiation carries a real MAC2 (honoring the 120 s cookie TTL), so xpf-as-initiator now completes a handshake against a peer that is itself under load. IPv6 outer encap still pending |
 | S8 | HA RG WG-session migration | pending |
 
+## Config shape: interface-level tunnel with per-unit peers (#7786)
+
+A WireGuard interface can be written two ways, and they are not the same
+object.
+
+- **Per-unit** — `set interfaces wgN unit U tunnel mode wireguard ...` with no
+  interface-level `tunnel` stanza. This is the canonical spelling. Each unit
+  emits its own tunnel endpoint with its own device, listen port, private key
+  and peers.
+- **Interface-level** — `set interfaces wgN tunnel mode wireguard ...`. This is
+  **ONE persistent TUN and ONE local identity**: one kernel UDP socket, one
+  private key (`TunnelConfig.WgListenPort` / `WgLocalPrivkeyHex` are
+  tunnel-level; `WgPeers` is the per-peer set). The emitter produces exactly
+  one endpoint for the whole interface, keyed by the lowest configured unit ref
+  (#1910).
+
+Under the **interface-level** form a unit may still carry its own `tunnel`
+stanza, and what that means is now defined:
+
+- **`peer` entries are additive.** Every unit's peers are merged into the
+  interface's single endpoint, de-duplicated by public key and sorted by public
+  key. A unit re-declaring an inherited peer is already refused at commit
+  (`duplicate peer public key`), so a unit's peers are always the inherited set
+  plus keys no other unit declares — the merge cannot conflict and needs no
+  precedence rule.
+
+  Before #7786 those peers were discarded. `pkg/dataplane/userspace/tunnels.go`
+  builds the wire peer set from the emitted endpoint's `TunnelConfig`, and that
+  is the only path config peers have to the dataplane, so a peer authored under
+  a unit was parsed, deep-copied (#3898) and validated — and then silently
+  never installed. The tunnel came up carrying only the interface-level peers.
+
+- **`listen-port` and `private-key` overrides are refused at commit.** They ask
+  for a second local identity on one logical interface, which the one-socket /
+  one-identity model has no representation for. Merging such a unit would offer
+  a *different* identity's peers the parent's key; emitting it as its own
+  endpoint would put two endpoints on one listen port (two WireGuard tunnels
+  sharing a listen port compile without complaint, and
+  `WireGuardListenPorts()` de-duplicates them, so nothing would report it).
+  Configure the second identity on its own interface.
+
+  This shape was previously half-wired in a misleading direction: routing
+  materialised the unit's TUN and `WireGuardListenPorts()` already collected
+  the unit's port, so the host-inbound filter opened a port that no endpoint
+  ever listened on.
+
+Which Linux device that single endpoint binds to when the lowest configured
+unit carries its own `tunnel` stanza is a separate open question — see #6941.
+#7786 deliberately does not move the endpoint's ref or device.
+
 ## Tunnel MTU + MSS + DSCP/ECN model (#2299 / #2300 / #2303 / #2329)
 
 These correctness fixes share the encap sites and the tunnel-MTU

--- a/pkg/config/compiler_validate_wireguard.go
+++ b/pkg/config/compiler_validate_wireguard.go
@@ -98,9 +98,58 @@ func validateWireguardPeersStrict(cfg *Config, lenient bool) ([]string, error) {
 			if err := emit(label, validateOneWireguardTunnel(unit.Tunnel)); err != nil {
 				return warnings, err
 			}
+			if err := emit(label, unitWireguardIdentityOverride(ifc, unit.Tunnel)); err != nil {
+				return warnings, err
+			}
 		}
 	}
 	return warnings, nil
+}
+
+// unitWireguardIdentityOverride refuses a unit that changes the local
+// WireGuard IDENTITY of an interface-level tunnel (#7786).
+//
+// TunnelConfig states the model: WgListenPort and WgLocalPrivkeyHex are
+// TUNNEL-level -- "one kernel UDP socket, one local identity per WG interface"
+// -- while WgPeers is the per-peer set. A unit under an interface-level
+// `tunnel mode wireguard` therefore contributes PEERS, which are merged into
+// the interface's single emitted endpoint (EmitTunnelEndpointNames). A unit
+// that overrides the listen port or the private key is asking for a SECOND
+// local identity on one logical interface, which that model has no
+// representation for.
+//
+// It is refused rather than implemented because the shape is half-wired today
+// in a way that misleads: routing materialises the unit's TUN and
+// WireGuardListenPorts() already collects the unit's port, so the host-inbound
+// filter opens it -- and no endpoint is ever emitted for it, so nothing
+// listens on a port the firewall advertises as open. Merging it instead would
+// be worse than refusing: it would fold a DIFFERENT identity's peers into the
+// parent endpoint, where they would be offered the parent's key.
+//
+// Scope is deliberately narrow. This fires only under an interface-level
+// WireGuard tunnel. `interfaces wgN unit 0 tunnel mode wireguard` with no
+// interface-level stanza is the canonical per-unit spelling, it emits its own
+// endpoint through the per-unit branch, and it is untouched here.
+func unitWireguardIdentityOverride(ifc *InterfaceConfig, unitTunnel *TunnelConfig) error {
+	if ifc == nil || ifc.Tunnel == nil || ifc.Tunnel.Mode != "wireguard" || unitTunnel == nil {
+		return nil
+	}
+	if unitTunnel.WgListenPort != ifc.Tunnel.WgListenPort {
+		return fmt.Errorf("unit overrides the WireGuard listen-port of the interface-level "+
+			"tunnel (%d vs %d); listen-port and private-key are properties of the WireGuard "+
+			"interface, which is ONE UDP socket and ONE local identity, so a unit may add "+
+			"`peer` entries but cannot define a second identity. Configure the second "+
+			"identity on its own interface",
+			unitTunnel.WgListenPort, ifc.Tunnel.WgListenPort)
+	}
+	if unitTunnel.WgLocalPrivkeyHex != ifc.Tunnel.WgLocalPrivkeyHex {
+		return fmt.Errorf("unit overrides the WireGuard private-key of the interface-level " +
+			"tunnel; listen-port and private-key are properties of the WireGuard interface, " +
+			"which is ONE UDP socket and ONE local identity, so a unit may add `peer` " +
+			"entries but cannot define a second identity. Configure the second identity on " +
+			"its own interface")
+	}
+	return nil
 }
 
 // tunnelLabel renders an operator-facing identifier for a WG tunnel in

--- a/pkg/config/tunnel_perunit_deepcopy_test.go
+++ b/pkg/config/tunnel_perunit_deepcopy_test.go
@@ -184,6 +184,49 @@ func TestPerUnitTunnelWgPeersIndependent(t *testing.T) {
 		&u1.Tunnel.WgPeers[0] == &u2.Tunnel.WgPeers[0] {
 		t.Error("unit 1 and unit 2 tunnel WgPeers share the same backing array")
 	}
+
+	// #7786: every assertion above is about the COMPILED config, and all of
+	// them passed for the entire period in which per-unit peers never reached
+	// the dataplane at all. The interface-level WireGuard branch of
+	// EmitTunnelEndpointNames discarded every per-unit TunnelConfig, and
+	// buildTunnelEndpointSnapshots builds WgPeers from the emitted endpoint's
+	// TunnelConfig, which is the only config->dataplane path for them. So this
+	// test established the shape as SUPPORTED while nothing consumed it.
+	//
+	// Deliberately asserted here rather than in a separate file: the property
+	// that makes the deep copy worth doing is that each unit's peer is
+	// installed, and if that is guarded somewhere else it can be deleted
+	// without this test noticing and the shape goes back to being tested at
+	// the config layer and dead at the runtime layer.
+	eps := EmitTunnelEndpointNames(cfg)
+	if len(eps) != 1 {
+		t.Fatalf("interface-level WireGuard must emit exactly ONE endpoint (#1910); got %d", len(eps))
+	}
+	emitted := make([]string, 0, len(eps[0].Tunnel.WgPeers))
+	for _, p := range eps[0].Tunnel.WgPeers {
+		emitted = append(emitted, p.PublicKeyHex)
+	}
+	for _, want := range []string{peerX, peerY, peerZ, peerA, peerB} {
+		if !hasStr(emitted, want) {
+			t.Errorf("peer %s never reaches the dataplane: the emitted endpoint carries %v. "+
+				"Per-unit peers are merged into the interface's single endpoint (#7786); "+
+				"without that they are compiled, deep-copied and validated and then dropped",
+				want, emitted)
+		}
+	}
+	if len(emitted) != 5 {
+		t.Errorf("emitted endpoint carries %d peers %v, want the 5 distinct pubkeys "+
+			"(X/Y/Z inherited + A from unit 1 + B from unit 2) exactly once each",
+			len(emitted), emitted)
+	}
+	// Sorted by pubkey so every consumer of this emitter sees one order
+	// regardless of authoring or unit iteration (#1434 5.4).
+	for i := 1; i < len(emitted); i++ {
+		if emitted[i-1] >= emitted[i] {
+			t.Errorf("emitted peers are not sorted by pubkey: %v", emitted)
+			break
+		}
+	}
 }
 
 // TestPerUnitTunnelSingleUnitAndNoOverrideStillInherit guards the non-aliasing

--- a/pkg/config/tunnel_perunit_deepcopy_test.go
+++ b/pkg/config/tunnel_perunit_deepcopy_test.go
@@ -113,10 +113,15 @@ func TestPerUnitTunnelAddressesIndependent(t *testing.T) {
 // 2's peer instead of its own.
 func TestPerUnitTunnelWgPeersIndependent(t *testing.T) {
 	const (
-		priv  = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-		peerX = "1111111111111111111111111111111111111111111111111111111111111111"
-		peerY = "2222222222222222222222222222222222222222222222222222222222222222"
-		peerZ = "3333333333333333333333333333333333333333333333333333333333333333"
+		priv = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+		// X/Y/Z sort AFTER A/B on purpose (#7786). The merge appends the
+		// interface-level peers before the per-unit ones, so pubkeys that
+		// ascend in that order are already sorted by coincidence and the
+		// emitted-order assertion below could not detect the sort being
+		// dropped.
+		peerX = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+		peerY = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+		peerZ = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 		peerA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 		peerB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	)

--- a/pkg/config/tunnelemit.go
+++ b/pkg/config/tunnelemit.go
@@ -101,7 +101,22 @@ func EmitTunnelEndpointNames(cfg *Config) []TunnelEndpointName {
 				// Interface-level WireGuard is ONE persistent TUN; the
 				// builder emits exactly one endpoint keyed by the lowest
 				// configured unit ref (#1910). Mirror that here.
-				add(fmt.Sprintf("%s.%d", name, unitNums[0]), iface.Tunnel)
+				//
+				// #7786: that single endpoint carries the MERGED peer set,
+				// not the interface-level object's peers alone. A unit's own
+				// tunnel stanza under an interface-level WireGuard holds
+				// per-unit PEERS, and this branch used to discard every
+				// per-unit TunnelConfig — so a peer authored under a unit was
+				// compiled, deep-copied (#3898) and validated, and then never
+				// reached the dataplane, because tunnels.go builds WgPeers
+				// from the emitted endpoint's TunnelConfig and that is the
+				// only config->dataplane path for them. The non-WireGuard
+				// branch below already emits the unit's own TunnelConfig for
+				// exactly this reason (#5635); this is the same decision
+				// applied to the branch that skipped it, in the form the
+				// one-TUN model allows.
+				add(fmt.Sprintf("%s.%d", name, unitNums[0]),
+					mergeWireguardUnitPeers(iface, unitNums))
 				continue
 			}
 			for _, unitNum := range unitNums {
@@ -142,4 +157,83 @@ func EmitTunnelEndpointNames(cfg *Config) []TunnelEndpointName {
 		}
 	}
 	return out
+}
+
+// mergeWireguardUnitPeers returns the TunnelConfig for the single endpoint an
+// interface-level WireGuard interface emits: the interface-level object, with
+// every unit's peers merged in (#7786).
+//
+// WHY MERGE RATHER THAN EMIT PER UNIT. TunnelConfig documents the model this
+// follows (types_routing.go): WgListenPort and WgLocalPrivkeyHex are
+// TUNNEL-level -- "one kernel UDP socket, one local identity per WG interface"
+// -- while WgPeers is the per-peer set. So a unit's peers are additive to the
+// one interface, and emitting a second endpoint per unit would put two
+// endpoints on one listen port and one private key. Nothing would catch that:
+// two WireGuard tunnels sharing a listen port compile without complaint today
+// and WireGuardListenPorts() simply de-duplicates them. A unit that overrides
+// the port or the key is a different local identity and is refused at commit
+// instead (compiler_validate_wireguard.go), so it never reaches here.
+//
+// THE MERGE CANNOT CONFLICT, and that is a property of the validator rather
+// than of this function: a unit re-declaring an inherited peer is already
+// rejected at commit ("duplicate peer public key"), so a unit's peer set is
+// always the inherited set plus pubkeys no other unit declares. De-duplication
+// by pubkey is therefore total -- there is never a case where two different
+// values compete for one peer, so no precedence rule is needed or implied.
+//
+// The result is sorted by pubkey. Iteration here is already deterministic
+// (unitNums is sorted, and peers keep their authored order within a unit), and
+// the snapshot builder sorts by pubkey again before serializing, which is what
+// actually pins the #1434 5.4 byte-identical-across-HA-nodes property. Sorting
+// here buys the same determinism for the OTHER consumers of this emitter --
+// the strict-tunnel validators and the endpoint-collision gate read
+// ep.Tunnel.WgPeers directly and never see the builder's sort.
+//
+// Returns the interface-level object UNCHANGED, same pointer, when no unit
+// contributes a peer. That keeps the overwhelmingly common WireGuard config
+// allocation-free through this path and leaves every existing endpoint
+// byte-identical.
+func mergeWireguardUnitPeers(iface *InterfaceConfig, unitNums []int) *TunnelConfig {
+	contributes := false
+	for _, unitNum := range unitNums {
+		unit := iface.Units[unitNum]
+		if unit != nil && unit.Tunnel != nil && len(unit.Tunnel.WgPeers) > 0 {
+			contributes = true
+			break
+		}
+	}
+	if !contributes {
+		return iface.Tunnel
+	}
+
+	// cloneForUnit is the audited deep copy (#3898): a plain struct copy would
+	// share the parent's WgPeers backing array, so appending here would write
+	// into the interface-level tunnel every sibling also reads. The name is
+	// preserved -- this endpoint is still the interface-level device.
+	merged := iface.Tunnel.cloneForUnit(iface.Tunnel.Name)
+	seen := make(map[string]bool, len(merged.WgPeers))
+	for _, p := range merged.WgPeers {
+		seen[p.PublicKeyHex] = true
+	}
+	for _, unitNum := range unitNums {
+		unit := iface.Units[unitNum]
+		if unit == nil || unit.Tunnel == nil {
+			continue
+		}
+		for _, p := range unit.Tunnel.WgPeers {
+			if seen[p.PublicKeyHex] {
+				continue
+			}
+			seen[p.PublicKeyHex] = true
+			cp := p
+			if p.AllowedIPs != nil {
+				cp.AllowedIPs = append([]string(nil), p.AllowedIPs...)
+			}
+			merged.WgPeers = append(merged.WgPeers, cp)
+		}
+	}
+	sort.Slice(merged.WgPeers, func(i, j int) bool {
+		return merged.WgPeers[i].PublicKeyHex < merged.WgPeers[j].PublicKeyHex
+	})
+	return merged
 }

--- a/pkg/config/wireguard_per_unit_peers_7786_test.go
+++ b/pkg/config/wireguard_per_unit_peers_7786_test.go
@@ -8,7 +8,12 @@ import (
 const (
 	wg7786Priv  = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 	wg7786Priv2 = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
-	wg7786PeerX = "1111111111111111111111111111111111111111111111111111111111111111"
+	// PeerX sorts AFTER the unit peers on purpose. The merge appends the
+	// interface-level peers first, so a fixture whose pubkeys ascend in that
+	// same order is already sorted by coincidence and CANNOT detect the sort
+	// being removed. Measured: with X="1111..." deleting the sort left every
+	// assertion green.
+	wg7786PeerX = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 	wg7786PeerA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	wg7786PeerB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 )

--- a/pkg/config/wireguard_per_unit_peers_7786_test.go
+++ b/pkg/config/wireguard_per_unit_peers_7786_test.go
@@ -1,0 +1,248 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	wg7786Priv  = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	wg7786Priv2 = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	wg7786PeerX = "1111111111111111111111111111111111111111111111111111111111111111"
+	wg7786PeerA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	wg7786PeerB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+func wg7786Base() []string {
+	return []string{
+		"set interfaces wg0 tunnel mode wireguard",
+		"set interfaces wg0 tunnel wireguard listen-port 51820",
+		"set interfaces wg0 tunnel wireguard private-key " + wg7786Priv,
+		"set interfaces wg0 tunnel wireguard peer " + wg7786PeerX + " allowed-ips 10.100.0.0/24",
+	}
+}
+
+func wg7786Compile(t *testing.T, cmds []string) (*Config, error) {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, c := range cmds {
+		p, err := ParseSetCommand(c)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", c, err)
+		}
+		if err := tree.SetPath(p); err != nil {
+			t.Fatalf("SetPath(%q): %v", c, err)
+		}
+	}
+	return CompileConfig(tree)
+}
+
+func wg7786EmittedPeers(t *testing.T, cfg *Config) []string {
+	t.Helper()
+	eps := EmitTunnelEndpointNames(cfg)
+	if len(eps) != 1 {
+		t.Fatalf("interface-level WireGuard emits exactly one endpoint (#1910); got %d", len(eps))
+	}
+	out := make([]string, 0, len(eps[0].Tunnel.WgPeers))
+	for _, p := range eps[0].Tunnel.WgPeers {
+		out = append(out, p.PublicKeyHex)
+	}
+	return out
+}
+
+// TestPerUnitWireguardPeersReachTheEndpoint7786 is the fail-on-revert gate for
+// the merge. A peer authored under a unit must appear in the ONE endpoint an
+// interface-level WireGuard interface emits, because that endpoint's
+// TunnelConfig is the only path config peers have to the dataplane
+// (pkg/dataplane/userspace/tunnels.go builds WgPeers from it).
+func TestPerUnitWireguardPeersReachTheEndpoint7786(t *testing.T) {
+	cfg, err := wg7786Compile(t, append(wg7786Base(),
+		"set interfaces wg0 unit 1 tunnel wireguard peer "+wg7786PeerA+" allowed-ips 10.200.1.0/24",
+		"set interfaces wg0 unit 2 tunnel wireguard peer "+wg7786PeerB+" allowed-ips 10.200.2.0/24"))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	// The endpoint's REF is unchanged by the merge, which is what keeps
+	// StableTunnelEndpointID (derived from this string) identical for every
+	// existing config: only the peer set grows.
+	eps := EmitTunnelEndpointNames(cfg)
+	if eps[0].Name != "wg0.1" {
+		t.Errorf("emitted ref = %q, want %q — the merge must not move the ref, or "+
+			"StableTunnelEndpointID renumbers every existing WireGuard endpoint",
+			eps[0].Name, "wg0.1")
+	}
+	if eps[0].Tunnel.Name != "wg0" {
+		t.Errorf("emitted tunnel device = %q, want %q — the merge must not move the device "+
+			"either (#6941 is the open question about which device this binds to; this "+
+			"change must not perturb it)", eps[0].Tunnel.Name, "wg0")
+	}
+
+	got := wg7786EmittedPeers(t, cfg)
+	want := []string{wg7786PeerX, wg7786PeerA, wg7786PeerB}
+	for _, w := range want {
+		found := false
+		for _, g := range got {
+			if g == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("peer %s missing from the emitted endpoint %v — a per-unit peer that is "+
+				"compiled, deep-copied and validated but never emitted can never handshake, "+
+				"and nothing else reports it", w, got)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("emitted endpoint carries %d peers %v, want exactly %d", len(got), got, len(want))
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i-1] >= got[i] {
+			t.Errorf("emitted peers must be sorted by pubkey so every consumer of this "+
+				"emitter sees one order (#1434 5.4): %v", got)
+			break
+		}
+	}
+}
+
+// TestPerUnitWireguardPeerDedup7786 pins that a peer inherited by a unit is not
+// installed twice. Each unit's compiled tunnel carries the inherited peers as
+// well as its own, so a merge that simply concatenated would offer the
+// interface-level peer once per unit.
+func TestPerUnitWireguardPeerDedup7786(t *testing.T) {
+	cfg, err := wg7786Compile(t, append(wg7786Base(),
+		"set interfaces wg0 unit 1 tunnel wireguard peer "+wg7786PeerA+" allowed-ips 10.200.1.0/24",
+		"set interfaces wg0 unit 2 tunnel wireguard peer "+wg7786PeerB+" allowed-ips 10.200.2.0/24"))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	// Precondition, asserted rather than assumed: each unit really does carry
+	// the inherited peer, so concatenation really would duplicate it. Without
+	// this the dedup assertion below could pass because there was nothing to
+	// dedup.
+	ifc := cfg.Interfaces.Interfaces["wg0"]
+	for _, n := range []int{1, 2} {
+		unit := ifc.Units[n]
+		if unit == nil || unit.Tunnel == nil {
+			t.Fatalf("unit %d has no tunnel; fixture no longer exercises the merge", n)
+		}
+		inherited := false
+		for _, p := range unit.Tunnel.WgPeers {
+			if p.PublicKeyHex == wg7786PeerX {
+				inherited = true
+			}
+		}
+		if !inherited {
+			t.Fatalf("unit %d does not carry the inherited peer, so this fixture cannot "+
+				"detect a duplicate", n)
+		}
+	}
+
+	counts := map[string]int{}
+	for _, p := range wg7786EmittedPeers(t, cfg) {
+		counts[p]++
+	}
+	for pub, n := range counts {
+		if n != 1 {
+			t.Errorf("peer %s appears %d times in the emitted endpoint; each pubkey must be "+
+				"installed once", pub, n)
+		}
+	}
+}
+
+// TestInterfaceLevelWireguardUnchangedWithoutUnitPeers7786 pins that a config
+// with no per-unit peers is untouched by the merge — the emitter returns the
+// interface-level object itself, so no existing endpoint's bytes move.
+func TestInterfaceLevelWireguardUnchangedWithoutUnitPeers7786(t *testing.T) {
+	cfg, err := wg7786Compile(t, append(wg7786Base(),
+		"set interfaces wg0 unit 0 family inet address 10.66.0.1/24"))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	eps := EmitTunnelEndpointNames(cfg)
+	if len(eps) != 1 {
+		t.Fatalf("want one endpoint, got %d", len(eps))
+	}
+	if eps[0].Tunnel != cfg.Interfaces.Interfaces["wg0"].Tunnel {
+		t.Error("a WireGuard interface with no per-unit peers must emit the interface-level " +
+			"TunnelConfig itself, not a copy — copying it for every config would risk moving " +
+			"existing endpoints' serialized bytes for no reason")
+	}
+	if got := wg7786EmittedPeers(t, cfg); len(got) != 1 || got[0] != wg7786PeerX {
+		t.Errorf("emitted peers = %v, want just the interface-level peer", got)
+	}
+}
+
+// TestUnitWireguardIdentityOverrideRejected7786 pins the commit-time refusal of
+// a unit that changes the local WireGuard identity.
+//
+// The shape is refused rather than merged because merging would offer a
+// DIFFERENT identity's peers the parent's key, and rather than emitted because
+// the model is one UDP socket and one identity per WireGuard interface. It is
+// not academic: routing materialises the unit's TUN and WireGuardListenPorts()
+// already collects the unit's port, so before this the host-inbound filter
+// opened a port nothing listened on.
+func TestUnitWireguardIdentityOverrideRejected7786(t *testing.T) {
+	cases := []struct {
+		name    string
+		extra   []string
+		wantSub string
+	}{
+		{
+			name: "listen-port override",
+			extra: []string{
+				"set interfaces wg0 unit 1 tunnel wireguard listen-port 51999",
+				"set interfaces wg0 unit 1 tunnel wireguard peer " + wg7786PeerA + " allowed-ips 10.200.1.0/24",
+			},
+			wantSub: "listen-port",
+		},
+		{
+			name: "private-key override",
+			extra: []string{
+				"set interfaces wg0 unit 1 tunnel wireguard private-key " + wg7786Priv2,
+				"set interfaces wg0 unit 1 tunnel wireguard peer " + wg7786PeerA + " allowed-ips 10.200.1.0/24",
+			},
+			wantSub: "private-key",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := wg7786Compile(t, append(wg7786Base(), tc.extra...))
+			if err == nil {
+				t.Fatalf("a unit overriding the WireGuard %s of an interface-level tunnel must "+
+					"be refused at commit: the model is ONE UDP socket and ONE local identity "+
+					"per WireGuard interface, and this shape half-wires a device and an open "+
+					"port with no endpoint behind it", tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("rejection message does not name %q, so an operator cannot tell which "+
+					"leaf to remove: %v", tc.wantSub, err)
+			}
+		})
+	}
+}
+
+// TestUnitLevelWireguardWithoutInterfaceTunnelStillAccepted7786 is the
+// over-rejection guard. `interfaces wgN unit 0 tunnel mode wireguard` with NO
+// interface-level stanza is the canonical per-unit spelling; it emits its own
+// endpoint through the per-unit branch and must be untouched by the refusal
+// above, which is scoped to units UNDER an interface-level WireGuard tunnel.
+func TestUnitLevelWireguardWithoutInterfaceTunnelStillAccepted7786(t *testing.T) {
+	cfg, err := wg7786Compile(t, []string{
+		"set interfaces wg0 unit 0 tunnel mode wireguard",
+		"set interfaces wg0 unit 0 tunnel wireguard listen-port 51820",
+		"set interfaces wg0 unit 0 tunnel wireguard private-key " + wg7786Priv,
+		"set interfaces wg0 unit 0 tunnel wireguard peer " + wg7786PeerA + " allowed-ips 10.200.1.0/24",
+		"set interfaces wg1 unit 0 tunnel mode wireguard",
+		"set interfaces wg1 unit 0 tunnel wireguard listen-port 51999",
+		"set interfaces wg1 unit 0 tunnel wireguard private-key " + wg7786Priv2,
+		"set interfaces wg1 unit 0 tunnel wireguard peer " + wg7786PeerB + " allowed-ips 10.200.2.0/24",
+	})
+	if err != nil {
+		t.Fatalf("the canonical per-unit WireGuard spelling must still compile; the #7786 "+
+			"refusal is scoped to units under an INTERFACE-level WireGuard tunnel: %v", err)
+	}
+	if got := len(EmitTunnelEndpointNames(cfg)); got != 2 {
+		t.Errorf("two per-unit WireGuard interfaces must emit two endpoints; got %d", got)
+	}
+}


### PR DESCRIPTION
Closes #7786

## The defect

A peer authored under a unit of an interface-level `tunnel mode wireguard` was parsed, deep-copied (#3898) and validated — and then **never installed**. `EmitTunnelEndpointNames`' WireGuard branch emits one endpoint carrying the *interface-level* `TunnelConfig` and discarded every per-unit one; `pkg/dataplane/userspace/tunnels.go` builds the wire peer set from the emitted endpoint's `TunnelConfig`, and that is the **only** path config peers have to the dataplane.

It fails silently and asymmetrically: the tunnel comes up carrying the interface-level peers, so the operator sees a working WireGuard interface, and only the unit-scoped peers can never handshake. No log line, no counter, no commit warning.

## Framing: this is the WireGuard hole in #5635

The emitter's **non-WireGuard** interface-level branch already emits the unit's own `TunnelConfig`, and says why:

> *"a unit that carries its OWN tunnel stanza holds the per-unit overrides … Emit that per-unit TunnelConfig, NOT the interface-level object, so the dataplane snapshot builder sees the unit's real endpoint instead of the interface-level defaults."*

The #1910 WireGuard short-circuit lands *above* that loop and never got the treatment. So this is an existing, already-argued decision applied to the branch that skipped it — not a new design.

## Why merge, and not the two alternatives

Two sub-shapes, both measured at master:

| | shape | meaning | disposition |
|---|---|---|---|
| (i) | unit **adds peers**, inherits port+key | same WireGuard interface | **merge** |
| (ii) | unit **overrides** listen-port and/or private-key | a different local identity | **refuse at commit** |

**The merge cannot conflict, and that is a property of the validator rather than of the merge.** I tried to construct a conflict and could not: a unit re-declaring an inherited peer is *already* rejected at commit (`duplicate peer public key`). So a unit's peer set is always the inherited set plus pubkeys no other unit declares; de-dup by pubkey is total and **no precedence rule is needed or implied**. `TestPerUnitWireguardPeerDedup7786` asserts that precondition explicitly — that each unit really does carry the inherited peer — so it cannot pass because there was nothing to dedup.

**Emit-per-unit is wrong for (i).** It would put two endpoints on one listen port and one private key, and nothing would report it: two WireGuard tunnels sharing a listen port compile without complaint today, and `WireGuardListenPorts()` simply de-duplicates them (measured).

**Merge is wrong for (ii)** — it would fold a *different* identity's peers into the parent endpoint, where they would be offered the parent's key.

The split follows the codebase's own model rather than taste. `types_routing.go`: `WgListenPort` / `WgLocalPrivkeyHex` are **tunnel-level** — *"one kernel UDP socket, one local identity per WG interface"* — while `WgPeers` is the per-peer set.

**Refusing (ii) breaks nothing: it has zero in-tree uses.** The `tunnelid_test.go` hits that resemble it are the canonical per-unit spelling (`wgN unit 0 tunnel mode wireguard`) with no interface-level stanza, which still compiles — pinned by an over-rejection test. And (ii) was half-wired in a misleading direction: routing materialises the unit's TUN and `WireGuardListenPorts()` already collects the unit's port, so the host-inbound filter opened a port **no endpoint ever listened on**.

## Blast radius — checked, not assumed

- **Endpoint ref unchanged** (`wg0.<lowest unit>`), so `StableTunnelEndpointID` — derived from that string — does not renumber any existing endpoint. Asserted.
- **Device unchanged** (`tunnel.Name` is still the interface device), so #6941's open question is not perturbed. Asserted.
- **A config with no per-unit peers is not copied at all**: the merge returns the interface-level `*TunnelConfig` **itself, same pointer**. Asserted by pointer identity, so the common path cannot silently start allocating or reordering.
- **The wire fixture cannot move**: `protocol_wire_v1.json` is generated from Rust `::default()` specimens and no Rust changed here. Verified untouched.

## On determinism, stated precisely

Peers are sorted by pubkey in the merge — but it would be an overclaim to say that is what makes HA serialization safe. The snapshot builder **already** sorts by pubkey before serializing (`tunnels.go`), and *that* is what pins the #1434 §5.4 byte-identical-across-nodes property. Sorting in the emitter buys the same determinism for the emitter's **other** consumers — the strict-tunnel validators and the endpoint-collision gate read `ep.Tunnel.WgPeers` directly and never see the builder's sort. Unit iteration is over the already-sorted `unitNums`, so map-iteration randomisation was not a live hazard on this path either.

## The config-layer test that was lying

`tunnel_perunit_deepcopy_test.go` asserted only compiled-config properties, and **every one of them passed throughout the period when those peers reached nothing** — it established the shape as supported while nothing consumed it. It now also asserts the five distinct pubkeys arrive in the emitted endpoint, sorted.

That assertion is in *that* test rather than a new file on purpose: the property that makes the #3898 deep copy worth doing is that each unit's peer is installed, and if it lived elsewhere it could be deleted without that test noticing — and the shape would go back to being tested at the config layer and dead at the runtime layer.

## Mutation matrix

`go test ./pkg/config/ ./pkg/dataplane/userspace/ -count=1`, full packages, no `-run` filter. Control: 2 packages, 0 failures.

| cell | mutation | result | reds |
|---|---|---|---|
| M1 | revert the merge — emit `iface.Tunnel` (the shipped bug) | **RED** | `TestPerUnitWireguardPeersReachTheEndpoint7786`, `TestPerUnitTunnelWgPeersIndependent` |
| M2 | concatenate without de-dup | **RED** | + `TestPerUnitWireguardPeerDedup7786` |
| M3 | delete the pubkey sort | **RED** | the two emitted-order assertions |
| M4 | copy even when no unit contributes | **RED** | `TestInterfaceLevelWireguardUnchangedWithoutUnitPeers7786` |
| M5 | delete the identity-override refusal | **RED** | both `TestUnitWireguardIdentityOverrideRejected7786` subtests |
| M6 | drop the interface-level scoping (over-reject) | **RED** | `TestUnitLevelWireguardWithoutInterfaceTunnelStillAccepted7786` + 3 pre-existing tests |
| M7 | bypass the emitter in the deep-copy test | **RED** | `TestPerUnitTunnelWgPeersIndependent` — proves the new binding really goes through the emitter |

### An escape in my own matrix, and what it was

**M3 came back GREEN on the first run**, and the fault was my fixture, not the code. The merge appends the interface-level peers before the per-unit ones, and both fixtures used pubkeys that ascend in exactly that order (`1111/2222/3333` then `aaaa/bbbb`) — so the **unsorted** merge order already *was* the sorted order and the assertion was structurally incapable of failing. Fixed by making the interface-level peers sort *after* the per-unit ones; M3 then reds by name. Same class as a fixture that uses the value the bug falls back to: the assertion looks right, the data makes it inert.

**M4 was VOID on the first run**, not an escape — deleting the `!contributes` fast path left `contributes` unused and broke the build. Re-expressed as returning a copy instead of the original pointer, which compiles and tests the actual claim.

## Gates

Both legs at the merged head `7f59d2ffa` (master moved 14 commits during this work and was folded before gating):

- `go test ./... -count=1 -p 4` — **68 packages ok, 0 FAIL**
- `cargo test --no-fail-fast -- --test-threads=1` — **10 binaries, 4833 collected, 0 failed**
- `gofmt -l` clean on **every file this PR touches**. Stated that way deliberately: `gofmt -l pkg/config` is *not* clean — that package carries pre-existing formatting debt (`compiler_chassis.go`, `login_password_test.go` and others), verified unformatted at the merge-base too, so it is not this PR's and is left alone.

## Docs

`docs/wireguard-interop.md` gains a section defining the two config shapes and what a unit stanza means under each, including why the identity override is refused and the note that the endpoint's *device* question is separately open in #6941. `docs/log/7786.md` carries the scope decision, the measurements behind it, the blast-radius checks and the M3 escape.
