### PR TITLE
grpcapi: stop asserting skew as the only cause of an out-of-band fabric token

### DIFF
--- a/pkg/grpcapi/fabric_auth_skew_6708.go
+++ b/pkg/grpcapi/fabric_auth_skew_6708.go
@@ -34,10 +34,33 @@ import (
 // authenticated heartbeat) is a design change with its own HA gate, tracked
 // separately.
 //
-// WHY THE MEASUREMENT IS TRUSTWORTHY. The scan below only reports a skew when
-// the presented token matches a window under an ACCEPTED KEY. Only a key holder
-// can produce that, so the number is an authenticated statement, not something
-// an on-segment attacker can plant in an operator's status output.
+// WHAT THE MEASUREMENT PROVES, AND WHAT IT DOES NOT. The scan below reports an
+// offset only when the presented token matches a window under an ACCEPTED KEY.
+// That makes one thing certain and one thing merely likely, and the operator
+// message must not confuse them:
+//
+//   - CERTAIN: the PSK is correct. Only a key holder can produce a token that
+//     verifies at any window, so a forged token or a genuine key mismatch never
+//     reaches this clause. That is the diagnostic worth most — it is what stops
+//     an operator from re-provisioning a key that was never wrong.
+//
+//   - NOT CERTAIN: that the peer's clock is skewed. Producing the token needs
+//     the key; PRESENTING it does not. Tokens ride every fabric RPC on the
+//     control link, and this verifier has no nonce (replay-within-window is
+//     accepted Residual 1 in fabric_auth.go), so an on-segment attacker can
+//     CAPTURE a token and replay it later. Replayed from outside the accept
+//     band but inside the scan band, it fails verification — correctly — and
+//     lands here indistinguishable from a drifting clock.
+//
+// The truth condition for "the peer's clock is skewed" is therefore production
+// under the key AND arrival within that window's lifetime, and this scan can
+// only establish the first. An earlier version of this comment claimed the
+// number was "not something an on-segment attacker can plant in an operator's
+// status output"; that followed from produce-vs-present being conflated. The
+// clause below now states the certain half as fact and names both causes for
+// the rest, so the message stays true on every path that reaches it — a
+// confident wrong diagnosis being the same class of defect as the opaque one
+// #6708 exists to remove.
 
 const (
 	// fabricAuthSkewScanWindows bounds the diagnostic scan to ±2 hours
@@ -141,7 +164,7 @@ func (s *Server) noteFabricAuthSkew(keys [][]byte, tokenHex string, now time.Tim
 	s.fabricSkew.atNanos.Store(nowNanos)
 	if !s.fabricSkew.reported.Swap(true) {
 		slog.Warn(
-			"cluster: peer wall clock is skewed past the fabric auth window; every cross-node fabric RPC (session queries, aggregation, clear propagation, cross-node failover) will fail authentication until the clocks agree. Forwarding, VRRP and failover are NOT affected — the heartbeat authenticates independently. Synchronise NTP on both nodes.",
+			"cluster: a fabric auth token authenticated under an accepted key but at a window outside the accept band — the PSK is correct. Almost always a peer wall clock skewed past the fabric auth window; a stale or replayed token is indistinguishable here. Every cross-node fabric RPC (session queries, aggregation, clear propagation, cross-node failover) will fail authentication until the clocks agree. Forwarding, VRRP and failover are NOT affected — the heartbeat authenticates independently. Synchronise NTP on both nodes.",
 			"peer_skew_seconds", skew,
 			"auth_window_seconds", fabricAuthWindowSeconds,
 		)
@@ -157,8 +180,11 @@ func fabricSkewClause(skew int64) string {
 		dir = "behind"
 		mag = -mag
 	}
-	return " (peer wall clock is " + strconv.FormatInt(mag, 10) + "s " + dir +
-		" ours; the fabric token is time-windowed — synchronise NTP on both nodes)"
+	return " (the token authenticates under an accepted key at a window " +
+		strconv.FormatInt(mag, 10) + "s " + dir +
+		" ours, so the PSK is correct; the fabric token is time-windowed, so this " +
+		"is a peer wall clock skewed past the auth window — or a stale/replayed " +
+		"token, which this node cannot tell apart. Synchronise NTP on both nodes)"
 }
 
 // fabricSkewClause returns the clause for the LAST measurement, or "" when

--- a/pkg/grpcapi/fabric_auth_skew_6708_test.go
+++ b/pkg/grpcapi/fabric_auth_skew_6708_test.go
@@ -159,7 +159,7 @@ func TestRejectedSkewedTokenNamesTheClock6708(t *testing.T) {
 			if err == nil {
 				t.Fatal("checkFabricAuth admitted an out-of-band token")
 			}
-			named := strings.Contains(err.Error(), "peer wall clock is")
+			named := strings.Contains(err.Error(), "the PSK is correct")
 			if named != tc.wantClock {
 				if tc.wantClock {
 					t.Fatalf("rejection did not name the clock: %v\n"+
@@ -221,7 +221,7 @@ func TestSkewScanIsThrottled6708(t *testing.T) {
 	}
 	// ...and the throttled answer must still be the LAST GOOD one, so an
 	// operator's query does not depend on winning a race.
-	if !strings.Contains(first, "peer wall clock is") {
+	if !strings.Contains(first, "the PSK is correct") {
 		t.Fatalf("clause = %q, want it to name the clock", first)
 	}
 
@@ -293,5 +293,60 @@ func TestClusterStatusWarnsOnlyWhenSkewed6708(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("status warning missing %q:\n%s", want, out)
 		}
+	}
+}
+
+// The skew clause must stay TRUE on every path that reaches it.
+//
+// #6708's scan proves the token verified under an accepted key at some window.
+// That makes the PSK certainly correct, and the clock only PROBABLY skewed:
+// producing the token requires the key, but PRESENTING it does not. Tokens ride
+// every fabric RPC on the control link and this verifier has no nonce
+// (replay-within-window is accepted Residual 1), so a captured token replayed
+// from outside the accept band but inside the scan band fails verification —
+// correctly — and arrives here indistinguishable from a drifting clock.
+//
+// This test is the guard on the WORDING, because that is where the defect would
+// be: an unhedged "peer wall clock is Ns behind ours" is a confident wrong
+// diagnosis in the replay case, which is the same class of fault as the opaque
+// "invalid auth token" #6708 removed. It is deliberately paired: the certain
+// half must be asserted as fact, and the uncertain half must not be.
+func TestSkewClauseDoesNotAssertSkewAsTheOnlyCause_6708(t *testing.T) {
+	// A token from a window well outside the accept band — the shape both a
+	// drifting peer and a replayed capture produce. Nothing at this layer can
+	// distinguish them, which is the point.
+	clause := fabricSkewClause(-2400)
+
+	// CERTAIN half: this is the diagnostic that stops an operator
+	// re-provisioning a key that was never wrong. It must be stated plainly.
+	if !strings.Contains(clause, "the PSK is correct") {
+		t.Errorf("clause does not state the one thing the scan PROVES — that the "+
+			"key verified. That is the finding that ends the investigation: %q", clause)
+	}
+	// The measurement itself must survive; an operator needs the magnitude.
+	if !strings.Contains(clause, "2400s") {
+		t.Errorf("clause dropped the measured offset: %q", clause)
+	}
+	// UNCERTAIN half: the alternative cause must be named. Without this the
+	// message asserts a clock skew that may not exist.
+	if !strings.Contains(clause, "replayed") {
+		t.Errorf("clause asserts clock skew without naming the replay alternative: %q\n\n"+
+			"Producing this token needs the key; presenting it does not. A captured "+
+			"token replayed inside the scan band lands here too, and the scan cannot "+
+			"tell them apart — so an unhedged skew claim is a confident wrong "+
+			"diagnosis.", clause)
+	}
+	// The remedy for the overwhelmingly common cause must still be present, or
+	// hedging the diagnosis has cost the operator the action.
+	if !strings.Contains(clause, "NTP") {
+		t.Errorf("clause hedges the cause but drops the remedy: %q", clause)
+	}
+
+	// NON-VACUITY / direction: the sign must still be rendered, or the clause
+	// could satisfy every assertion above while telling an operator to look at
+	// the wrong node's clock.
+	ahead := fabricSkewClause(2400)
+	if !strings.Contains(ahead, "ahead of") || !strings.Contains(clause, "behind") {
+		t.Errorf("clause lost the skew DIRECTION: behind=%q ahead=%q", clause, ahead)
 	}
 }


### PR DESCRIPTION
Refs #6708, #6939

Surfaced while re-deriving #6939, which turned out to be a duplicate of #6708. Filed separately rather than smuggled into that duplicate's branch: this is a security-adjacent message change and deserves its own review.

## The claim that does not survive checking

#6708's skew scan reports an offset only when the presented token verifies under an **accepted key**. Its threat model concluded:

> Only a key holder can produce that, so the number is an authenticated statement, **not something an on-segment attacker can plant in an operator's status output.**

The premise is true. The conclusion does not follow, because **producing** a token requires the key but **presenting** one does not.

Tokens ride every fabric RPC on the control link, and this verifier has no nonce — replay-within-window is documented as accepted **Residual 1** in `fabric_auth.go`. So an on-segment attacker can *capture* a token and replay it. Replayed from outside the ±1 accept band but inside the ±2 h scan band, it fails verification (correctly) and then lands in the skew clause indistinguishable from a drifting clock, rendering as:

```
peer wall clock is 2400s behind ours; the fabric token is time-windowed — synchronise NTP on both nodes
```

in the rejection **and** in `show chassis cluster status`. A skew that does not exist.

The truth condition for *"the peer's clock is skewed"* is production under the key **AND** arrival within that window's lifetime. The scan establishes only the first.

## What changed

The clause now states the certain half as fact and names both causes for the rest.

**The certain half is the one that matters operationally — the PSK is correct.** That is what stops an operator re-provisioning a key that was never wrong, which is the investigation #6708 exists to end. The NTP remedy stays, because a skewed clock remains the overwhelmingly common cause: hedging the diagnosis must not cost the operator the action.

**Security posture is unchanged.** The token was rejected before and is rejected after. Only the explanation changes.

## Tests moved with the code, not deleted

Two pre-existing tests pinned the literal `"peer wall clock is"`. They were **moved to the new wording**, because the property they bind is untouched: a skew-explained rejection must name the cause and the remedy, and a wrong-PSK rejection must not. Deleting them to make the suite green would have decommissioned exactly the guard #6708 added.

The new guard is **paired on the two halves** — the certain claim must be present, the uncertain one must not be asserted alone — and additionally pins the measured magnitude and the direction, so a clause could not satisfy the hedging assertions while telling an operator to look at the wrong node's clock.

## Mutation

Reverting the clause to the original unhedged wording, full package, `-count=1`, no `-run` filter:

| | result |
|---|---|
| control | `ok`, 0 failed |
| clause reverted to `"peer wall clock is Ns behind ours…"` | **3 named REDs** |

```
--- FAIL: TestRejectedSkewedTokenNamesTheClock6708
--- FAIL: TestSkewScanIsThrottled6708
--- FAIL: TestSkewClauseDoesNotAssertSkewAsTheOnlyCause_6708
    clause asserts clock skew without naming the replay alternative:
    " (peer wall clock is 2400s behind ours; the fabric token is time-windowed — synchronise NTP on both nodes)"
```

The two moved tests redding alongside the new one is the evidence they still bind after the move rather than having been quietly retargeted at nothing.

## Gates

- `go test ./pkg/grpcapi/ -count=1` — ok, 15.7s
- `go vet`, `gofmt -l` — clean
- Gated head `d1aff0da9`, `origin/master` (`473d10176`) verified as an ancestor
