### PR TITLE
dataplane: resolve the xfrmi netdev from the authored bind string

### DIFF
--- a/docs/log/6955.md
+++ b/docs/log/6955.md
@@ -1,0 +1,59 @@
+# #6955 — a bare `bind-interface st0` never gets its authored address
+
+## 2026-08-27 — re-derived at origin/master before building
+
+- Cites had rotted twice over: the issue says `compiler_iface.go:757`, its own
+  comment says `:828`, and `buildInterfaceNetworkdModels` is actually at
+  `:1020` at `f0a1d3b25`. Symbols stable, line numbers useless.
+- The code had also CHANGED shape: it no longer builds `"<ifName>.<unit>"` and
+  uses it directly; it passes that constructed string to
+  `config.XFRMIfNameAndID`. That indirection does not help — the argument is
+  still the RECONSTRUCTED ref, not the authored bind string.
+- **The premise is confirmed by merged code's own documentation**
+  (`pkg/config/xfrmi.go`): "A secure tunnel is materialized by the xfrmi
+  reconciler under exactly `LinuxIfName(bindInterface)` — the AUTHORED string
+  ... The name therefore cannot be derived from the ref at all — see
+  SecureTunnelUnitNetdev, which reads it back from the config." It then names
+  the two unmigrated sites and states that `compiler_iface.go` "calls
+  SecureTunnelUnitNetdev zero times".
+
+### A search error worth recording
+
+I first grepped `func SecureTunnelUnitNetdev` in `pkg/config/*.go`, got nothing,
+and wrote "absent everywhere". It is a METHOD — `func (c *Config)
+SecureTunnelUnitNetdev` — and my filter encoded an assumption about its form.
+Caught only because `_Log.md` contradicted the conclusion. A filter built from
+one's own assumption cannot falsify that assumption.
+
+## 2026-08-27 — reproduced with the discriminator isolated
+
+Both cases use interface `st0`, unit 0, so the unit ref is `st0.0` in both.
+**Only the authored `BindInterface` differs.**
+
+| authored | netdev the reconciler creates | model emitted at master? |
+|---|---|---|
+| `st0.0` (dotted) | `st0.0` | YES — control, proves the fixture reaches the code |
+| `st0` (bare) | `st0` | **NO — `Models present: []`** |
+
+The dotted control passing is what makes the bare failure a defect rather than
+a fixture that never ran.
+
+## 2026-08-27 — the fix, and the sibling test it correctly reds
+
+- **File(s)**: `pkg/dataplane/compiler_iface.go`,
+  `pkg/dataplane/compiler_iface_bare_st_address_6955_test.go`,
+  `pkg/dataplane/compiler_iface_st_prefix_6729_6730_test.go`
+- Resolve the netdev via `cfg.SecureTunnelUnitNetdev(ref)` instead of
+  `XFRMIfNameAndID(reconstructed)`. `ok == false` means no configured VPN binds
+  the ref (or its if_id collides), so pkg/routing creates no device and there is
+  nothing to address.
+- **`TestNetworkdModelsStillSkipARealSecureTunnel_6730` red under the fix, and
+  it was pinning the defect.** Its stated intent is that a secure-tunnel name
+  must not reach the PHYSICAL-interface handling; its assertion was the broader
+  "no model named `st0` from any path", which the bug satisfied. The DOTTED
+  spelling emitted a model from this same branch even before the fix, so "a real
+  secure tunnel never gets a model" was never the contract.
+- Re-pointed that fixture from BOUND to **UNBOUND**, which tests the stated
+  intent: no VPN binds `st0`, pkg/routing creates no device, the branch emits
+  nothing — and if the predicate ever let the name reach the physical path a
+  model WOULD appear and the test fails. The seeded netdev gives it teeth.

--- a/pkg/dataplane/compiler_iface.go
+++ b/pkg/dataplane/compiler_iface.go
@@ -1054,8 +1054,21 @@ func buildInterfaceNetworkdModels(cfg *config.Config, result *CompileResult, see
 		if config.IsSecureTunnelIfName(ifName) {
 			mtu := ifCfg.MTU
 			for unitNum, unit := range ifCfg.Units {
-				unitName, _ := config.XFRMIfNameAndID(fmt.Sprintf("%s.%d", ifName, unitNum))
-				if unitName == "" {
+				// #6955: resolve the netdev through the AUTHORED
+				// `bind-interface` string, not by reconstructing it from the
+				// ref. pkg/routing/xfrm.go materialises the device under
+				// exactly `LinuxIfName(bindInterface)`, so `bind-interface
+				// st0` creates `st0` while the unit ref is `st0.0` — and the
+				// reconstruction answered `st0.0`, a device that does not
+				// exist. The lookup below then missed and `continue`d, so the
+				// authored `family inet address` was never applied and the
+				// tunnel came up with no IP and no connected prefix.
+				//
+				// `ok == false` means no configured VPN binds this ref (or its
+				// if_id collides), in which case pkg/routing creates NO device
+				// and there is nothing to address.
+				unitName, ok := cfg.SecureTunnelUnitNetdev(fmt.Sprintf("%s.%d", ifName, unitNum))
+				if !ok {
 					continue
 				}
 				if _, err := result.cachedInterfaceByName(unitName); err != nil {

--- a/pkg/dataplane/compiler_iface_bare_st_address_6955_test.go
+++ b/pkg/dataplane/compiler_iface_bare_st_address_6955_test.go
@@ -1,0 +1,69 @@
+package dataplane
+
+import (
+	"net"
+	"testing"
+)
+
+// #6955: `buildInterfaceNetworkdModels` derives the xfrmi netdev name from the
+// unit REF (`XFRMIfNameAndID("<ifName>.<unit>")`), but the reconciler
+// materialises the device under the AUTHORED `bind-interface` string. The two
+// agree only for the dotted spelling.
+//
+// The DISCRIMINATOR is the authored bind string, and nothing else: both cases
+// below use interface `st0` with unit 0, so the unit ref is `st0.0` in both.
+// Only `BindInterface` differs.
+func TestBareBindInterfaceGetsItsAuthoredAddress_6955(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		bind      string
+		netdev    string // what pkg/routing/xfrm.go actually creates
+		wantModel bool
+	}{
+		// Control: the DOTTED spelling, where reconstructing "<if>.<unit>"
+		// happens to equal the authored string. This is the shape every
+		// existing fixture uses, which is why the defect stayed green.
+		{name: "dotted spelling gets its address", bind: "st0.0", netdev: "st0.0", wantModel: true},
+		// The defect: the BARE spelling — the canonical form, the one
+		// ValidateSecureTunnelBindInterface advertises first.
+		{name: "bare spelling gets its address", bind: "st0", netdev: "st0", wantModel: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := stCfg6729("st0", []int{0}, tc.bind)
+			// Seed the netdev the reconciler would have created for THIS
+			// authored spelling. Without this the lookup fails for a second,
+			// unrelated reason and the cell cannot distinguish the defect.
+			result := &CompileResult{ifCache: map[string]*net.Interface{
+				tc.netdev: {Index: 98, Name: tc.netdev},
+			}}
+			buildInterfaceNetworkdModels(cfg, result, map[string]bool{})
+
+			var got *string
+			var addrs []string
+			for i := range result.ManagedInterfaces {
+				if result.ManagedInterfaces[i].Name == tc.netdev {
+					got = &result.ManagedInterfaces[i].Name
+					addrs = result.ManagedInterfaces[i].Addresses
+				}
+			}
+			if tc.wantModel && got == nil {
+				t.Fatalf("#6955: no networkd model for the netdev %q that the xfrmi "+
+					"reconciler creates from `bind-interface %s` — the authored "+
+					"`family inet address` is never applied, so the tunnel comes up "+
+					"with no IP and no connected prefix. Models present: %v",
+					tc.netdev, tc.bind, modelNames6955(result))
+			}
+			if tc.wantModel && len(addrs) == 0 {
+				t.Fatalf("#6955: model for %q carries no addresses", tc.netdev)
+			}
+		})
+	}
+}
+
+func modelNames6955(r *CompileResult) []string {
+	out := make([]string, 0, len(r.ManagedInterfaces))
+	for _, m := range r.ManagedInterfaces {
+		out = append(out, m.Name)
+	}
+	return out
+}

--- a/pkg/dataplane/compiler_iface_st_prefix_6729_6730_test.go
+++ b/pkg/dataplane/compiler_iface_st_prefix_6729_6730_test.go
@@ -184,7 +184,23 @@ func TestNetworkdModelsCoverAnStPrefixedNIC_6730(t *testing.T) {
 // that branch and must NOT be emitted as an ordinary physical interface — the
 // xfrmi is created by pkg/routing, not by networkd.
 func TestNetworkdModelsStillSkipARealSecureTunnel_6730(t *testing.T) {
-	cfg := stCfg6729("st0", []int{0}, "st0")
+	// #6955 re-pointed this fixture from BOUND to UNBOUND, and the reason is
+	// the point of the test rather than a detail.
+	//
+	// This cell exists to prove a secure-tunnel name does not fall through to
+	// the PHYSICAL-interface handling. It used to assert that with a VPN
+	// binding the bare `st0`, no model named `st0` was emitted — but that held
+	// only because of the #6955 defect: the branch reconstructed the netdev as
+	// `st0.0`, missed the lookup, and `continue`d. It was pinning the bug. The
+	// DOTTED spelling emitted a model from this same branch even then, so
+	// "a real secure tunnel never gets a model" was never the contract.
+	//
+	// UNBOUND is the shape that tests the stated intent. No VPN binds `st0`,
+	// so pkg/routing creates no device and the secure-tunnel branch correctly
+	// emits nothing — and if the predicate ever let the name reach the
+	// physical path, a model WOULD appear and this fails. The seeded netdev
+	// below is what gives that its teeth.
+	cfg := stCfg6729("st0", []int{0}, "")
 	// Seeded for the same reason, and here it is what gives the control its
 	// teeth: with the netdev present, a predicate that wrongly let `st0` reach
 	// the physical path WOULD emit a model, so this can actually fail.

--- a/pkg/dataplane/compiler_iface_st_prefix_6729_6730_test.go
+++ b/pkg/dataplane/compiler_iface_st_prefix_6729_6730_test.go
@@ -204,17 +204,28 @@ func TestNetworkdModelsStillSkipARealSecureTunnel_6730(t *testing.T) {
 	// Seeded for the same reason, and here it is what gives the control its
 	// teeth: with the netdev present, a predicate that wrongly let `st0` reach
 	// the physical path WOULD emit a model, so this can actually fail.
+	// BOTH candidate names are seeded. Found by the #6955 over-reach cell:
+	// with only `st0` present, a fix that fell back to `LinuxIfName(ref)` for
+	// an unbound ref resolved `st0.0`, missed the lookup, and continued — so
+	// the over-reach was masked by an unrelated lookup miss and this test
+	// stayed green. Seeding both means ANY path that emits a model finds a
+	// device, and the assertion can actually fire.
 	result := &CompileResult{ifCache: map[string]*net.Interface{
 		"st0": {
 			Index:        98,
 			Name:         "st0",
 			HardwareAddr: net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x02},
 		},
+		"st0.0": {
+			Index:        99,
+			Name:         "st0.0",
+			HardwareAddr: net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x03},
+		},
 	}}
 	buildInterfaceNetworkdModels(cfg, result, map[string]bool{})
 
 	for _, m := range result.ManagedInterfaces {
-		if m.Name == "st0" {
+		if m.Name == "st0" || m.Name == "st0.0" {
 			t.Fatalf("a real secure tunnel reached the physical-interface handling and was "+
 				"emitted as a networkd model (%q) — the xfrmi is created by pkg/routing, "+
 				"and the narrowed predicate must not widen this branch's escape hatch", m.Name)


### PR DESCRIPTION
Fixes #6955

## Re-derived first — cites had rotted twice over

The issue says `compiler_iface.go:757`; its own comment says `:828`; `buildInterfaceNetworkdModels` is actually at **`:1020`**. Symbols stable, line numbers useless.

The code had also **changed shape**: it no longer uses `"<ifName>.<unit>"` directly, it passes that constructed string to `config.XFRMIfNameAndID`. The indirection does not help — the argument is still the reconstructed ref, not the authored bind string.

**The premise is confirmed by merged code's own documentation** (`pkg/config/xfrmi.go`):

> "A secure tunnel is materialized by the xfrmi reconciler under exactly `LinuxIfName(bindInterface)` — the **AUTHORED** string ... The name therefore cannot be derived from the ref at all — see `SecureTunnelUnitNetdev`, which reads it back from the config."

That comment then names the two unmigrated sites and states `compiler_iface.go` "calls `SecureTunnelUnitNetdev` **zero times**".

## Reproduced with the discriminator isolated

Both cases use interface `st0`, unit `0` — so the unit ref is `st0.0` in **both**. Only the authored `BindInterface` differs.

| authored | netdev the reconciler creates | model emitted at master? |
|---|---|---|
| `st0.0` (dotted) | `st0.0` | **YES** — the control |
| `st0` (bare) | `st0` | **NO** — `Models present: []` |

The dotted control passing at master is what makes the bare failure a defect rather than a fixture that never reached the code.

## Who consumes the address — and the #6738 disagreement, resolved

The issue's comment records a contradiction between #6738 ("the connected prefix reaches the FIB regardless") and #6955 ("no tunnel IP, therefore no connected prefix") and asks the fixer to settle it.

**Both are right, about different consumers.** At `interfaces.go`:

```go
addresses = mergeInterfaceAddressSnapshots(addresses, buildConfiguredAddressSnapshots(unit.Addresses))
```

The configured addresses come **straight from `unit.Addresses`**, not from a netdev-name lookup. So:

- **#6738 is right about the dataplane snapshot** — the configured address reaches `InterfaceSnapshot.Addresses` even when no networkd model was emitted.
- **#6955 is right about the kernel** — `networkd.Apply` is the only applier of the authored address, so without a model the *kernel device* has no address and no connected route.

They were talking past each other. The severity statement is the kernel half: the device exists and is up, and anything requiring it to be genuinely addressable — connected route, next-hop resolution, source-address selection — is broken.

## The fix

Resolve through `cfg.SecureTunnelUnitNetdev(ref)`. `ok == false` means no configured VPN binds the ref (or its if_id collides), so `pkg/routing` creates no device and there is nothing to address.

## A sibling test was pinning the defect

`TestNetworkdModelsStillSkipARealSecureTunnel_6730` red under the fix. Its **stated intent** is that a secure-tunnel name must not reach the *physical-interface* handling; its **assertion** was the broader "no model named `st0` from any path" — which the bug satisfied. The dotted spelling emitted a model from this same branch even before the fix, so *"a real secure tunnel never gets a model"* was never the contract.

Re-pointed from **bound** to **unbound**, which tests the stated intent: no VPN binds `st0`, `pkg/routing` creates no device, the branch emits nothing — and if the predicate ever let the name reach the physical path a model *would* appear and it fails.

## Mutation matrix — measured

Fix committed **first** (`a04a9bc09`). One mutation per cell, **full package**, `-count=1`, **no `-run` filter**. Collected-test count reported against a control so a build break cannot read as a pass.

| # | Mutation | collected / control | Named FAILs | Result |
|---|---|---|---|---|
| M1 | revert to `XFRMIfNameAndID(reconstructed)` | 622 / 622 | 2 — `…6955` + its `bare_spelling` subtest; **`dotted` stayed green** | ✅ RED |
| M2 | **over-reach**: unbound refs fall back to `LinuxIfName(ref)` | 622 / 622 | **0** | ⚠️ **ESCAPED** |
| M2′ | same over-reach, after widening the fixture | 622 / 622 | 1 — `TestNetworkdModelsStillSkipARealSecureTunnel_6730` | ✅ RED |

**M2 is reported, not buried — it found a gap in my own guard.** The over-reach ran (collected matched control) and was simply not caught: the fixture seeded only `st0`, so an unbound ref falling back to `st0.0` missed the interface lookup, emitted nothing, and the assertion never fired. **The over-reach was masked by an unrelated lookup miss.** Fixture widened to seed both candidate names and assert on both (`f9be9a4`-class commit in this branch), after which M2′ reds by name.

M1 proves the fix is necessary and that the discriminator is the authored spelling. M2′ proves the fix is not applied too widely.

## Gate — measured

```
go test ./... -count=1   →   RC=0, 68 packages ok, 0 failures
```

- Gated head: `18927a02f1c1ebc40f5ad2b65e34a86963f52cfe`
- `git merge-base --is-ancestor origin/master HEAD` → **YES** against `dec5c6aa9`, verified immediately after the gate
- Master moved twice mid-gate (4 then 5 commits); this is the post-fold, ancestry-verified run

### One unrelated flake seen, and cleared

The first full-suite run showed `--- FAIL: TestDebounceCoalescing` in `pkg/ipmon`. Not attributable to this change, and measured rather than argued: **3/3 pass at clean `origin/master`**, **3/3 pass in this tree standalone**, and `go list -deps ./pkg/ipmon/` contains **zero** `pkg/dataplane` entries — there is no path by which this change could reach it. Load-induced under the full parallel run; it did not recur in either later gate.

## Measured vs inferred

**Measured:** the bare/dotted discriminator at master; all three mutation cells including the escaped one; the full gate; the ipmon flake's independence.

**Inferred:** that the kernel-side consequence (no connected route, no next-hop resolution) follows from the missing address — that is a reading of `networkd.Apply` being the sole applier, not something I drove on a live box.
