### PR TITLE
Gate the FBF smoke's apply phase; make its negative cells total (#6936)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,15 @@ make test-cos-apply-lib # Self-test the #6440 CoS-apply CLI-transcript gate:
                      #   and still exits 0, so apply-cos-config.sh verifies the
                      #   CLI's success markers, not the session exit status.
                      #   Hermetic (mocked incus) + the Go marker contract.
+make test-fbf-steering-lib # Self-test the #6936 FBF two-upstream steering
+                     #   verdicts. The defect it guards is a NEGATIVE CELL
+                     #   THAT FAILS TO A HEALTHY VALUE: the main-table
+                     #   pollution check counted matches, so "no leak" and
+                     #   "the probe returned nothing" both scored 0 = PASS.
+                     #   The verdict is now TOTAL and the selftest table
+                     #   carries the probe-blind middle row. Hermetic + the
+                     #   Go predicate that every config-committing smoke uses
+                     #   the #6440 marker gate.
 make test-cluster-env-lib # Self-test the cluster-env resolver (#5024): $FW0/
                      #   $FW1/$CLUSTER_LAN_HOST derive from each env's VM0/VM1/
                      #   LAN_HOST and get INCUS_REMOTE-qualified (no cluster)

--- a/Makefile
+++ b/Makefile
@@ -417,7 +417,7 @@ clean:
 # The standalone instance name defaults to xpf-fw; override it for an
 # ad-hoc/renamed VM with `XPF_INSTANCE=<name> make test-deploy` (#2162). The
 # env var flows through to setup.sh (INSTANCE_NAME=${XPF_INSTANCE:-xpf-fw}).
-.PHONY: test-env-init test-vm standalone-test-vm test-ct test-deploy test-deploy-lib test-cluster-lock-lib test-cluster-env-lib test-iperf-throughput-lib test-cos-apply-lib test-ssh test-destroy test-status test-start test-stop test-restart test-logs test-journal
+.PHONY: test-env-init test-vm standalone-test-vm test-ct test-deploy test-deploy-lib test-cluster-lock-lib test-cluster-env-lib test-iperf-throughput-lib test-cos-apply-lib test-fbf-steering-lib test-ssh test-destroy test-status test-start test-stop test-restart test-logs test-journal
 
 test-env-init:
 	./test/incus/setup.sh init
@@ -456,6 +456,19 @@ test-cluster-lock-lib:
 # of the marker contract lives in cmd/cli/cos_apply_markers_6440_test.go.
 test-cos-apply-lib:
 	bash ./test/incus/cos-apply-lib-selftest.sh
+	go test -count=1 -run 6440 ./cmd/cli/
+
+# Self-test the #6936 FBF two-upstream steering verdicts. The defect this
+# guards is a NEGATIVE CELL THAT FAILS TO A HEALTHY VALUE: the main-table
+# pollution check counted matches, so "no leak" and "the probe returned
+# nothing" both scored 0 = PASS, and the cell certified an absence it had
+# never looked for. The verdict is now TOTAL, and the selftest table carries
+# the middle (probe-blind) row that is the only way to see the difference.
+# Hermetic — no cluster. The Go half (every test/incus script that commits
+# config through the piped CLI must use the #6440 marker gate) is
+# cmd/cli/cos_apply_markers_6440_test.go.
+test-fbf-steering-lib:
+	bash ./test/incus/fbf-steering-selftest.sh
 	go test -count=1 -run 6440 ./cmd/cli/
 
 # Self-test the shared cluster-env resolver (#5024): the HA/failover

--- a/cmd/cli/cos_apply_markers_6440_test.go
+++ b/cmd/cli/cos_apply_markers_6440_test.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -247,4 +248,120 @@ func TestShellGateMarkersMatchCLI_6440(t *testing.T) {
 				assign, want.marker)
 		}
 	}
+}
+
+// shellCodeLines returns the script's lines with comment-only lines removed.
+//
+// A source-scanning gate that reads comments can be satisfied by prose ABOUT
+// the thing it greps for — including this test's own explanatory text once
+// someone pastes it into a script header. Strip them so the scan sees code.
+func shellCodeLines(src string) []string {
+	var out []string
+	for _, l := range strings.Split(src, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(l), "#") {
+			continue
+		}
+		out = append(out, l)
+	}
+	return out
+}
+
+// #6936: TestShellGateMarkersMatchCLI_6440 above binds exactly ONE script,
+// cos-apply-lib.sh. That is a floor, not a census: a second script can pipe a
+// config-mode session into this REPL and gate on the session's exit status —
+// which is always 0 — and nothing notices. test-fbf-steering.sh did exactly
+// that for its commit check, its commit, AND its rollback, so its whole apply
+// phase was ungated and every downstream cell could have been measuring the
+// pre-test config.
+//
+// State the rule as a PREDICATE over every smoke instead: a script that
+// commits configuration through the piped CLI must gate on the success
+// markers. Exemptions are explicit, carry a tracking issue, and are themselves
+// checked for staleness — an allowlist entry is a claim, so it expires the
+// moment the script it excuses starts passing.
+//
+// SCOPE, stated so this does not read as stronger than it is. The predicate is
+// FILE-level: "this script commits config, so it must reference the marker
+// gate". It catches a NEW ungated smoke and a stale exemption. It does NOT
+// catch removing one of several gates inside an already-gated script, because
+// the file still references the helpers elsewhere.
+//
+// A blanket ban on the `if ! incus exec ... cli <<EOF` shape was considered as
+// the finer-grained check and REJECTED on measurement: apply-cos-config.sh
+// uses that shape legitimately as a belt alongside the marker gate (its own
+// comment reads "the exit status above is NOT sufficient"), and the `cli -c`
+// form exits non-zero meaningfully. Banning the shape would fail correct code,
+// so the discriminator is marker PRESENCE, not the absence of an idiom.
+func TestEveryConfigCommittingSmokeUsesTheMarkerGate_6936(t *testing.T) {
+	const dir = "../../test/incus"
+	// name -> tracking issue for the known-ungated scripts.
+	exempt := map[string]string{
+		"wg-interop.sh": "#7792",
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	scanned := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sh") {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		lines := shellCodeLines(string(raw))
+
+		commits := false
+		for _, l := range lines {
+			// A bare `commit` / `commit check` line is heredoc content fed to
+			// the CLI, not a shell command — that is the config-mode session.
+			if t := strings.TrimSpace(l); t == "commit" || t == "commit check" {
+				commits = true
+				break
+			}
+		}
+		if !commits {
+			continue
+		}
+		scanned++
+
+		gated := false
+		for _, l := range lines {
+			if strings.Contains(l, "cos_require_markers") ||
+				strings.Contains(l, "cos_rollback_one") ||
+				strings.Contains(l, "COS_MARKER_") {
+				gated = true
+				break
+			}
+		}
+
+		issue, isExempt := exempt[e.Name()]
+		switch {
+		case gated && isExempt:
+			t.Errorf("%s is now marker-gated but is still listed as exempt (%s) — "+
+				"drop the exemption so the rule covers it; a stale allowlist entry "+
+				"silently re-opens the hole for the next script added under it",
+				e.Name(), issue)
+		case !gated && !isExempt:
+			t.Errorf("%s commits configuration through the piped-stdin CLI but never "+
+				"references the #6440 marker gate (cos_require_markers / "+
+				"cos_rollback_one / COS_MARKER_*). The piped CLI is a REPL: it prints "+
+				"'error: ...' for a failed command and still exits 0, so any gate on "+
+				"the session's exit status cannot fire. Source test/incus/cos-apply-lib.sh "+
+				"and assert the markers, or add an explicit exemption with a tracking issue.",
+				e.Name())
+		}
+	}
+
+	// The scan must actually reach scripts. If the heredoc shape changes and
+	// nothing matches, this test would pass having checked nothing — the same
+	// vacuity class it exists to catch.
+	if scanned == 0 {
+		t.Fatalf("scanned 0 config-committing scripts in %s — the detector matched "+
+			"nothing and this gate is vacuous", dir)
+	}
+	t.Logf("scanned %d config-committing smoke scripts", scanned)
 }

--- a/docs/log/6936.md
+++ b/docs/log/6936.md
@@ -103,3 +103,25 @@ the remaining actionable one (path-divergence) is scoped above.
 - `test/incus/fbf-steering-selftest.sh` — new, hermetic
 - `cmd/cli/cos_apply_markers_6440_test.go` — predicate guard
 - `Makefile`, `CLAUDE.md` — `make test-fbf-steering-lib`
+
+## Wiring the selftest into a gate that actually runs
+
+The sibling `*-lib` selftests (`test-cos-apply-lib`, `test-iperf-throughput-lib`,
+`test-cluster-lock-lib`) are standalone make targets — `make selftest` does not
+invoke them, so nothing runs them unless a human remembers to. A hermetic table
+nobody runs is not a gate (#6920).
+
+So `fbf-steering-selftest.sh` is ALSO wired into `scripts/run-selftests.sh`,
+which `make selftest` runs. That needed a new `run_bash` helper: the existing
+`run_shell` invokes every script with `sh` regardless of shebang, and under
+dash this selftest dies with "Bad substitution" on `${BASH_SOURCE[0]}` — a
+syntax error, not a result. Rewriting a bash library into POSIX so its own test
+can run would be backwards, so `run_bash` runs it with the interpreter it is
+written for and SKIPs when bash is absent. Additive: no existing entry changes
+interpreter.
+
+The three new/edited shell files were also added to the `SH_SCRIPTS` parse +
+shellcheck list.
+
+Measured: `make selftest` -> 73 passed, 0 failed, 0 skipped, and shellcheck
+(installed here) passes on all three.

--- a/docs/log/6936.md
+++ b/docs/log/6936.md
@@ -170,3 +170,31 @@ pre-existing GRE rule present on BOTH nodes, not residue.
 ## Follow-ups filed
 - **#7792** — `wg-interop.sh` has the same dead-gate defect in 4 sessions.
 - **#7796** — FBF DSCP steering installs no ip rule (FRA_TOS vs IPTOS_TOS_MASK).
+
+## Fourth defect: the PBR table discovery bound the wrong table
+
+Phase 2 found its table positionally:
+
+    ip rule show | awk -F'lookup ' '$1 ~ /^31[0-9][0-9][0-9]:/ {print $2; exit}'
+
+first match, then stop. But the 31000+ band is not private to FBF.
+Measured on `loss:xpf-userspace-fw0`, a PRE-EXISTING GRE rule sits at
+exactly priority 31000:
+
+    31000: from all to 10.255.192.40/30 iif ge-0-0-1 lookup 488570
+
+So the discovery binds a GRE table, and the divergence cell then reports
+"ISP-B kernel table 488570 lacks 'default via 172.16.80.1' — FRR table
+rendering broken". A false failure, naming the wrong subsystem, on a
+correctly-rendered config. Fail-CLOSED (a wasted investigation, not a
+silent pass), but it is the cell failing to identify its own subject.
+
+Now enumerates the whole band and selects by CONTENT
+(`fbf_table_holds_default`), with the same exact-token gateway match. The
+selftest carries the measured GRE table verbatim as a negative row, plus
+a row where the gateway appears on a NON-default route.
+
+Not validatable end-to-end right now: #7796 stops the FBF fixture
+committing at all, so no run can reach Phase 2. Hermetic rows are the
+best available evidence, which is equally true of every other cell in
+this file today.

--- a/docs/log/6936.md
+++ b/docs/log/6936.md
@@ -125,3 +125,48 @@ shellcheck list.
 
 Measured: `make selftest` -> 73 passed, 0 failed, 0 skipped, and shellcheck
 (installed here) passes on all three.
+
+## On-cluster validation — the gate caught a live failure on its first run
+
+Ran under the shared-cluster lock cell (lock was free; released cleanly):
+
+    ./test/incus/with-cluster.sh "6936 fbf steering gate validation" -- \
+        ./test/incus/test-fbf-steering.sh loss:xpf-userspace-fw0
+
+The new gate fired immediately:
+
+    load merge complete
+    error: commit failed: rpc error: code = Unavailable desc =
+      apply PBR rules: add PBR rule instance ISP-B table 236616: invalid argument
+
+`load merge complete` printed; `commit complete` did not. The OLD gate would
+have seen exit status 0, continued, and failed later at the PBR-table
+discovery with "no PBR ip rule in the 31000+ band (FBF kernel rule missing)"
+— blaming FRR table rendering for a commit that never landed. That is the
+same misdirection #6440 recorded for the CoS path.
+
+Root-caused and filed as **#7796**: `rules.go` emits the DSCP as a shifted
+TOS byte into `FRA_TOS`, which the kernel masks against `IPTOS_TOS_MASK`
+(0x1E). Measured boundary on kernel 7.0.13: dscp <= 7 accepted, dscp >= 8
+rejected "Invalid tos". Every DSCP name in `dscpToTOS`'s map is 0 or >= 8,
+and the two zero cases are separately dropped at rules.go:1148 — so NO
+`from dscp` value installs a rule. Not a regression from this change; this
+change only made it visible.
+
+A measurement error worth recording: my first boundary sweep passed decimal
+values to `ip rule add tos`, which parses a bare integer as HEX. That made
+dscp=7 look REJECTED and nearly produced a wrong boundary in the issue. Redone
+with explicit `0x` values.
+
+### Cluster hygiene
+
+The failed commit DID land in the config store even though the apply errored
+(commit-history entry 48, timestamped inside my run window) — so the active
+config was dirty. Reverted with a verified `cos_rollback_one`, then
+re-checked: 0 FBF/ISP-B lines in the active config, no FBF rule in the
+31000-band, `xpfd` active. The one remaining PBR rule (table 488570) is a
+pre-existing GRE rule present on BOTH nodes, not residue.
+
+## Follow-ups filed
+- **#7792** — `wg-interop.sh` has the same dead-gate defect in 4 sessions.
+- **#7796** — FBF DSCP steering installs no ip rule (FRA_TOS vs IPTOS_TOS_MASK).

--- a/docs/log/6936.md
+++ b/docs/log/6936.md
@@ -1,0 +1,105 @@
+# 6936 — lab-venue residuals from #4422
+
+## What the issue asked vs what the measurement found
+
+#6936 asked for two lab-bound smokes: PBR multi-WAN negative cells, and
+host-inbound VLAN/dup-address/HA-failover. Before writing cells INTO the
+named venue (`test/incus/test-fbf-steering.sh`), I checked the venue.
+
+**Its entire apply phase was ungated.** Three sites gated on the exit
+status of a piped-stdin CLI session:
+
+| site | form | can it fail? |
+|---|---|---|
+| commit check (L93) | `if ! incus exec .. "$CLI" <<EOF` | no |
+| commit (L107) | `if ! incus exec .. "$CLI" <<EOF` | no |
+| restore/rollback (L69) | `<<EOF \|\| echo "WARNING: rollback failed"` | no |
+
+Per #6440 — documented in `cos-apply-lib.sh`, pinned by
+`cmd/cli/cos_apply_markers_6440_test.go`, and re-verified at HEAD in
+`cmd/cli/main.go` — the piped CLI is a REPL: it prints `error: %v`,
+CONTINUES, and exits 0. So none of those three gates could fire.
+
+The consequence is exactly the failure mode #6936 wants cover for. A
+commit that silently did not land leaves every downstream cell measuring
+the PRE-TEST config, where the ISP-B default is legitimately absent: the
+smoke reports a clean main table having never applied the fixture that
+could dirty it. And a rollback that did not land leaves the SHARED
+cluster on the FBF test config for the next lane.
+
+Adding negative cells to a script whose apply phase cannot fail would
+have been building on sand, so the gates came first.
+
+## The second defect: a negative cell that fails to a healthy value
+
+The main-table pollution check was:
+
+    MAIN_DEFAULTS="$(... "ip route show default | grep -c 'via ${GW}'" || true)"
+    [[ "${MAIN_DEFAULTS:-0}" -eq 0 ]] || fail "ISP-B default leaked ..."
+
+Measured, three inputs collapse:
+
+| input | value | verdict |
+|---|---|---|
+| main table has an unrelated default | `0` | PASS (correct) |
+| **probe returned nothing at all** | `` | **PASS (wrong)** |
+| main table holds the ISP-B default | `1` | FAIL (correct) |
+
+`grep -c` prints 0 and exits 1 when it matches nothing, so `|| true` is
+load-bearing and correct — but an empty substitution then falls through
+`${MAIN_DEFAULTS:-0}` to the healthy value. The cell certifies an
+absence having looked at nothing.
+
+REACHABILITY, stated honestly: this is narrower than it first appears.
+Non-numeric output (an incus error string) makes bash's `[[ -eq ]]`
+comparison fail, so garbage reports FAIL, not PASS; and a total target
+outage is caught earlier by the PBR-table assertion at L131. The hole is
+specifically the empty case. It is worth closing because the cell is the
+template the next negative cell gets copied from, but it is not a live
+defect and is not claimed as one.
+
+Replaced with a TOTAL verdict (`fbf-steering-lib.sh`) whose positive
+control is intrinsic: non-empty output is itself the evidence the probe
+read the table, since this venue always carries the ISP-A default.
+
+## A third, found by my own selftest
+
+`grep 'via 172.16.80.1'` substring-matches `via 172.16.80.11`. The
+original had this too. Fail-CLOSED, so it costs a false alarm rather
+than a silent pass, but still wrong. Now an exact-token match on the
+field following `via` (awk, so the dots need no escaping). Pinned by the
+`NEAR_MISS_GW` row — which is the row that caught it.
+
+## Correcting the issue's own classification
+
+#6936 lists four PBR residuals as one class. The script's header
+separates them 3+1, and that distinction is load-bearing:
+
+- **Genuinely venue-blocked (3):** true dual-provider failure modes,
+  dual-public-IP SNAT, throughput under dual-path load. These need a
+  SECOND REAL UPLINK. No work in this repo reaches them.
+- **Not blocked (1):** path-divergence under uplink failure is already
+  documented as "the smoke-runner's MANUAL step" — blackhole the ISP-B
+  gateway and watch fbf-fallback repoint. That is automatable in the
+  existing venue; it is unwritten, not impossible.
+
+## Scope taken and not taken
+
+Taken: the three dead gates, the fail-to-healthy cell, the substring
+match, a hermetic selftest, and a Go predicate replacing an enumeration
+that bound exactly one script.
+
+Not taken: `wg-interop.sh` has the same dead-gate defect in 4 config
+sessions. Different venue, different subject — filed as **#7792** and
+carried as the single explicit exemption in the new guard, with a
+stale-exemption check so the guard fails once #7792 lands.
+
+Also not taken: the two lab smokes themselves. Both need the cluster;
+the remaining actionable one (path-divergence) is scoped above.
+
+## Files
+- `test/incus/test-fbf-steering.sh` — 3 gates + pollution cell
+- `test/incus/fbf-steering-lib.sh` — new, total verdict
+- `test/incus/fbf-steering-selftest.sh` — new, hermetic
+- `cmd/cli/cos_apply_markers_6440_test.go` — predicate guard
+- `Makefile`, `CLAUDE.md` — `make test-fbf-steering-lib`

--- a/scripts/run-selftests.sh
+++ b/scripts/run-selftests.sh
@@ -38,6 +38,37 @@ faill() { echo "  FAIL: $*" >&2; FAIL=$((FAIL + 1)); FAILED_LEGS="$FAILED_LEGS $
 
 # run_shell <script> [args...] — run a shell self-test. Exit 0 = PASS,
 # exit 77 = SKIP (a leg self-reported a missing tool), anything else = FAIL.
+# run_bash: like run_shell, but invokes the script with bash.
+#
+# run_shell forces `sh` regardless of the script's shebang, which is correct
+# for the POSIX self-tests it was written for. A self-test that legitimately
+# needs bash (arrays, [[ ]], <<< herestrings, ${var//pat/}) fails under dash
+# with "Bad substitution" — a syntax error, not a real result. Rather than
+# rewrite a bash library into POSIX so its own test can run, run it with the
+# interpreter it is written for, and SKIP rather than fail when bash is absent.
+run_bash() {
+	script=$1
+	shift
+	if [ ! -f "$script" ]; then
+		skipl "$script (not present)"
+		return
+	fi
+	if ! command -v bash >/dev/null 2>&1; then
+		skipl "$script (bash not installed)"
+		return
+	fi
+	out=$(bash "$script" "$@" 2>&1)
+	rc=$?
+	if [ "$rc" -eq 0 ]; then
+		passl "$script"
+	elif [ "$rc" -eq 77 ]; then
+		skipl "$script ($(echo "$out" | grep -m1 -i skip || echo 'tool unavailable'))"
+	else
+		faill "$script"
+		echo "$out" | sed 's/^/      /'
+	fi
+}
+
 run_shell() {
 	script=$1
 	shift
@@ -98,6 +129,9 @@ scripts/dist/selftest.sh
 scripts/dist/install.sh
 scripts/dist/build-apt-repo.sh
 scripts/run-selftests.sh
+test/incus/fbf-steering-lib.sh
+test/incus/fbf-steering-selftest.sh
+test/incus/test-fbf-steering.sh
 "
 for s in $SH_SCRIPTS; do
 	[ -f "$s" ] || continue
@@ -172,6 +206,10 @@ run_shell test/xsk-repro/selftest-probe-filter_6898.sh
 # BPF_ANY positive control so an ENOENT cannot come from a broken fixture.
 # SKIPs without cc, passwordless sudo, or CAP_BPF.
 run_shell test/mutation/selftest-bpf-exist-cannot-create_6923.sh
+# #6936: FBF two-upstream steering verdicts. Hermetic — no incus, no cluster,
+# no network. Guards a negative cell that used to fail to a HEALTHY value:
+# "no leak" and "the probe returned nothing" both scored PASS. Needs bash.
+run_bash test/incus/fbf-steering-selftest.sh
 
 # ── summary ──
 printf '\n\033[1m== selftest summary ==\033[0m\n'

--- a/test/incus/fbf-steering-lib.sh
+++ b/test/incus/fbf-steering-lib.sh
@@ -72,3 +72,36 @@ fbf_main_default_leak_verdict() {
 	fi
 	printf 'PASS %s\n' "main table holds $(grep -c . <<<"$routes") default route(s), none via ${gw}"
 }
+
+# fbf_table_holds_default <gw> <ip-route-show-table-output>
+#
+#   Exit 0 iff the table's routes contain a default via exactly <gw>.
+#
+#   Used to pick the RIGHT PBR table out of the priority band. The smoke used
+#   to take the FIRST rule in the 31000+ band and stop:
+#
+#       ip rule show | awk -F'lookup ' '$1 ~ /^31[0-9][0-9][0-9]:/ {print $2; exit}'
+#
+#   The band is not private to FBF. Measured on loss:xpf-userspace-fw0, a
+#   PRE-EXISTING GRE rule already sits at exactly priority 31000:
+#
+#       31000: from all to 10.255.192.40/30 iif ge-0-0-1 lookup 488570
+#
+#   so the discovery bound table 488570 — a GRE table — and the divergence cell
+#   then reported "ISP-B kernel table 488570 lacks 'default via ...' — FRR table
+#   rendering broken". A FALSE failure, pointing at the wrong subsystem, on a
+#   correctly-rendered config. Fail-CLOSED, so it costs a wasted investigation
+#   rather than a silent pass, but it is still the cell failing to identify its
+#   own subject.
+#
+#   Selecting by CONTENT instead of by position makes the cell name the table it
+#   actually means. Exact-token match, so `via 172.16.80.11` is not `via
+#   172.16.80.1` (the same near-miss the leak verdict fixes).
+fbf_table_holds_default() {
+	local gw="$1" routes="$2"
+	[[ -n "${gw//[[:space:]]/}" ]] || return 1
+	[[ -n "${routes//[[:space:]]/}" ]] || return 1
+	awk -v gw="$gw" '
+		/^default/ { for (i = 1; i < NF; i++) if ($i == "via" && $(i+1) == gw) found = 1 }
+		END { exit !found }' <<<"$routes"
+}

--- a/test/incus/fbf-steering-lib.sh
+++ b/test/incus/fbf-steering-lib.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Verdict helpers for the #1827 two-upstream FBF steering smoke (#6936).
+#
+# WHY THIS EXISTS
+#
+# `test-fbf-steering.sh` asserts, among other things, that the ISP-B default
+# route does NOT leak into the main routing table — the pre-PR-2 pollution
+# this smoke exists to catch. That cell was written as:
+#
+#     MAIN_DEFAULTS="$(incus exec "$TARGET" -- sh -c \
+#         "ip route show default | grep -c 'via ${ISP_B_GW4}'" || true)"
+#     [[ "${MAIN_DEFAULTS:-0}" -eq 0 ]] || fail "ISP-B default leaked ..."
+#
+# and it FAILS TO A VALUE INDISTINGUISHABLE FROM HEALTHY. Measured, three
+# inputs collapse onto the same verdict:
+#
+#     main table has an unrelated default   -> "0" -> PASS   (correct)
+#     probe produced NO OUTPUT AT ALL       -> ""  -> PASS   (WRONG)
+#     main table holds the ISP-B default    -> "1" -> FAIL   (correct)
+#
+# The middle row is the defect. `grep -c` prints "0" and exits 1 when it
+# matches nothing, so `|| true` is load-bearing and correct; but if the probe
+# never ran, or ran and emitted nothing, the substitution is EMPTY and
+# `${MAIN_DEFAULTS:-0}` silently supplies the healthy value. The cell then
+# certifies "no leak" on the strength of having looked at nothing.
+#
+# (One neighbouring input does NOT collapse: non-numeric output, e.g. an
+# incus error string, makes bash's `[[ -eq ]]` fail the comparison, so garbage
+# reports FAIL rather than PASS. The hole is specifically the empty case.)
+#
+# THE FIX: A TOTAL VERDICT WITH AN INTRINSIC POSITIVE CONTROL
+#
+# Take the route text rather than a count, and make every input class yield
+# exactly one verdict — including "the probe saw nothing", which becomes a
+# FAIL because an absence cannot be certified by an instrument that returned
+# no reading. The positive control is intrinsic rather than bolted on: the
+# main table in this venue always carries the ISP-A default (the smoke's own
+# PING_DST defaults to the ISP-A gateway and expects it to answer), so
+# non-empty output is itself the evidence that the probe could read the table
+# it is being asked to clear. A negative cell whose instrument cannot be shown
+# to work is not a negative result.
+#
+# Depends on nothing but bash, so fbf-steering-selftest.sh
+# (`make test-fbf-steering-lib`) is hermetic — no cluster.
+
+# fbf_main_default_leak_verdict <isp_b_gw> <ip-route-show-default-output>
+#
+#   Print exactly one line: "PASS <message>" or "FAIL <message>".
+#
+#   TOTAL BY CONSTRUCTION — every path prints, so this cell can never be the
+#   silent hole that the counting form was. Callers map the verdict onto their
+#   own pass/fail handling with a catch-all default.
+fbf_main_default_leak_verdict() {
+	local gw="$1" routes="$2"
+	if [[ -z "${gw//[[:space:]]/}" ]]; then
+		printf 'FAIL %s\n' "main-table leak check: no ISP-B gateway supplied — the cell has nothing to look for and cannot certify absence"
+		return 0
+	fi
+	if [[ -z "${routes//[[:space:]]/}" ]]; then
+		printf 'FAIL %s\n' "main-table leak check: 'ip route show default' returned NOTHING — the probe is blind, so the absence of the ISP-B default is unproven (this venue always carries the ISP-A default; empty means the probe failed, not that the table is clean)"
+		return 0
+	fi
+	# Exact-token match on the field FOLLOWING "via". A substring match
+	# (what the original `grep -c "via ${ISP_B_GW4}"` did) reports a leak for
+	# any longer address sharing the prefix — `via 172.16.80.11` reads as
+	# `via 172.16.80.1`. That direction is fail-CLOSED, so it costs a false
+	# alarm rather than a silent pass, but it is still wrong and the selftest
+	# pins it (NEAR_MISS_GW). awk avoids having to regex-escape the dots.
+	if awk -v gw="$gw" '{for (i = 1; i < NF; i++) if ($i == "via" && $(i+1) == gw) found = 1} END {exit !found}' <<<"$routes"; then
+		printf 'FAIL %s\n' "ISP-B default leaked into the MAIN table (pre-PR-2 pollution) — defaults seen: $(tr '\n' ';' <<<"$routes")"
+		return 0
+	fi
+	printf 'PASS %s\n' "main table holds $(grep -c . <<<"$routes") default route(s), none via ${gw}"
+}

--- a/test/incus/fbf-steering-selftest.sh
+++ b/test/incus/fbf-steering-selftest.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Hermetic self-test for test/incus/fbf-steering-lib.sh (#6936).
+#
+# No cluster, no incus, no network. Runs in `make test-fbf-steering-lib`.
+#
+# The row that matters is PROBE_BLIND. Under the counting form this smoke
+# shipped with, that input produced the same verdict as a healthy table, which
+# is why the defect was invisible to review: only a table that includes the
+# middle row can distinguish "there is no leak" from "I could not look".
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./fbf-steering-lib.sh
+. "${SCRIPT_DIR}/fbf-steering-lib.sh"
+
+pass=0
+fail=0
+GW="172.16.80.1"
+
+check() {
+	local name="$1" want="$2" gw="$3" routes="$4" got verdict
+	got="$(fbf_main_default_leak_verdict "$gw" "$routes")"
+	verdict="${got%% *}"
+	if [[ "$verdict" == "$want" ]]; then
+		pass=$((pass + 1))
+		printf 'ok   %-26s -> %s\n' "$name" "$verdict"
+	else
+		fail=$((fail + 1))
+		printf 'FAIL %-26s -> want %s got %s (%s)\n' "$name" "$want" "$verdict" "$got"
+	fi
+	# TOTALITY: exactly one verdict line, and it is one of the two known words.
+	if [[ "$(grep -c . <<<"$got")" -ne 1 ]]; then
+		fail=$((fail + 1))
+		printf 'FAIL %-26s -> verdict was not exactly one line: %q\n' "$name" "$got"
+	fi
+	if [[ "$verdict" != "PASS" && "$verdict" != "FAIL" ]]; then
+		fail=$((fail + 1))
+		printf 'FAIL %-26s -> verdict word %q is neither PASS nor FAIL\n' "$name" "$verdict"
+	fi
+}
+
+# --- the healthy case: a main table with an unrelated (ISP-A) default -------
+check CLEAN_ONE_DEFAULT   PASS "$GW" "default via 172.16.50.1 dev ge-0-0-2 proto static"
+check CLEAN_TWO_DEFAULTS  PASS "$GW" "default via 172.16.50.1 dev ge-0-0-2
+default via 10.0.61.254 dev ge-0-0-1 metric 100"
+
+# --- the defect the cell exists to catch -----------------------------------
+check LEAK_EXACT          FAIL "$GW" "default via 172.16.80.1 dev ge-0-0-2 proto static"
+check LEAK_AMONG_OTHERS   FAIL "$GW" "default via 172.16.50.1 dev ge-0-0-2
+default via 172.16.80.1 dev ge-0-0-2 metric 200"
+
+# --- THE MIDDLE ROW: the counting form scored every one of these as healthy -
+check PROBE_BLIND_EMPTY   FAIL "$GW" ""
+check PROBE_BLIND_WS      FAIL "$GW" "   "
+check PROBE_BLIND_NEWLINE FAIL "$GW" "
+"
+# A cell with no needle cannot certify absence either.
+check NO_GATEWAY_GIVEN    FAIL ""    "default via 172.16.50.1 dev ge-0-0-2"
+
+# --- the positive control must not be satisfiable by a near-miss -----------
+# A different gateway on the same /24 must NOT read as a leak.
+check NEAR_MISS_GW        PASS "$GW" "default via 172.16.80.11 dev ge-0-0-2"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/test/incus/fbf-steering-selftest.sh
+++ b/test/incus/fbf-steering-selftest.sh
@@ -61,5 +61,33 @@ check NO_GATEWAY_GIVEN    FAIL ""    "default via 172.16.50.1 dev ge-0-0-2"
 # A different gateway on the same /24 must NOT read as a leak.
 check NEAR_MISS_GW        PASS "$GW" "default via 172.16.80.11 dev ge-0-0-2"
 
+# --- fbf_table_holds_default: pick the PBR table by CONTENT, not position ---
+checkt() {
+	local name="$1" want="$2" gw="$3" routes="$4" got
+	if fbf_table_holds_default "$gw" "$routes"; then got=YES; else got=NO; fi
+	if [[ "$got" == "$want" ]]; then
+		pass=$((pass + 1)); printf 'ok   %-26s -> %s\n' "$name" "$got"
+	else
+		fail=$((fail + 1)); printf 'FAIL %-26s -> want %s got %s\n' "$name" "$want" "$got"
+	fi
+}
+
+# The real ISP-B table.
+checkt TBL_HAS_ISP_B_DEFAULT  YES "$GW" "default via 172.16.80.1 dev ge-0-0-2 proto static metric 20
+172.16.80.0/24 dev ge-0-0-2 proto kernel scope link"
+# The PRE-EXISTING GRE table that sits at priority 31000 on the loss cluster and
+# that the old first-match discovery bound instead. Verbatim shape.
+checkt TBL_GRE_NOT_ISP_B      NO  "$GW" "default nhid 101 via 10.255.192.41 dev gr-0-0-0 proto static metric 20
+10.255.192.40/30 dev gr-0-0-0 proto kernel scope link src 10.255.192.42
+local 10.255.192.42 dev gr-0-0-0 proto kernel scope host src 10.255.192.42"
+# A table with routes but no default at all.
+checkt TBL_NO_DEFAULT         NO  "$GW" "172.16.80.0/24 dev ge-0-0-2 proto kernel scope link"
+# Empty / unreadable table must not select.
+checkt TBL_EMPTY              NO  "$GW" ""
+# The gateway must match as a whole token here too.
+checkt TBL_NEAR_MISS_GW       NO  "$GW" "default via 172.16.80.11 dev ge-0-0-2"
+# The gateway may appear on a NON-default route without selecting the table.
+checkt TBL_GW_ONLY_NONDEFAULT NO  "$GW" "172.16.80.0/24 via 172.16.80.1 dev ge-0-0-2"
+
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [[ "$fail" -eq 0 ]]

--- a/test/incus/test-fbf-steering.sh
+++ b/test/incus/test-fbf-steering.sh
@@ -50,6 +50,16 @@ CONFIG_FILE="${SCRIPT_DIR}/fbf-two-upstream-config.set"
 REMOTE_SETS="/tmp/fbf-two-upstream.set"
 CLI=/usr/local/sbin/cli
 
+# #6936: the CLI-transcript marker gate (#6440) and the FBF verdict helpers.
+# The `cos_` prefix is historical — those helpers are CLI-generic, and reusing
+# them is deliberate: a second copy of the marker list could drift out of step
+# with cmd/cli, and only one copy is pinned by
+# cmd/cli/cos_apply_markers_6440_test.go.
+# shellcheck source=./cos-apply-lib.sh
+. "${SCRIPT_DIR}/cos-apply-lib.sh"
+# shellcheck source=./fbf-steering-lib.sh
+. "${SCRIPT_DIR}/fbf-steering-lib.sh"
+
 info() { echo "==> $*"; }
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
@@ -68,13 +78,14 @@ fi
 
 restore() {
     info "Restoring pre-test config (rollback 1 + commit)..."
-    incus exec "$TARGET" -- "$CLI" <<EOF || echo "WARNING: rollback failed — inspect $TARGET manually" >&2
-configure
-rollback 1
-commit
-exit
-quit
-EOF
+    # #6936: this gated on the session's exit status (`<<EOF || echo WARNING`).
+    # The piped-stdin CLI is a REPL that prints `error: ...` and still exits 0
+    # (#6440), so that warning could NEVER fire — a rollback that did not land
+    # announced nothing and left this SHARED cluster on the FBF test config for
+    # the next lane to measure against. cos_rollback_one verifies the CLI's own
+    # "configuration rolled back" + "commit complete" markers.
+    cos_rollback_one "$TARGET" \
+        || echo "WARNING: rollback did NOT land — inspect $TARGET manually" >&2
 }
 
 metric_value() {
@@ -90,31 +101,39 @@ incus file push --mode 0644 "$SETS_TMP" "${TARGET}/${REMOTE_SETS}" >/dev/null
 
 CHECK_OUT="$(mktemp)"; cleanup_files+=("$CHECK_OUT")
 info "commit check on $TARGET..."
-if ! incus exec "$TARGET" -- "$CLI" > "$CHECK_OUT" 2>&1 <<EOF
+incus exec "$TARGET" -- "$CLI" > "$CHECK_OUT" 2>&1 <<EOF || true
 configure
 load merge ${REMOTE_SETS}
 commit check
 exit
 quit
 EOF
-then
-    cat "$CHECK_OUT" >&2
-    fail "commit check failed (candidate invalid; live state unchanged)"
-fi
+# #6936/#6440: gate on the CLI's own success MARKERS, not the session exit
+# status, which is 0 even when a command inside the session failed. BOTH
+# markers are required: a failed `load merge` leaves an EMPTY candidate, and an
+# empty candidate checks clean — so `commit check` alone cannot tell "the
+# fixture is valid" from "the fixture never loaded".
+cos_require_markers "commit check on $TARGET" "$CHECK_OUT" \
+    "$COS_MARKER_LOAD_MERGE" "$COS_MARKER_COMMIT_CHECK" \
+    || fail "commit check failed (candidate invalid; live state unchanged)"
 
 APPLY_OUT="$(mktemp)"; cleanup_files+=("$APPLY_OUT")
 info "committing FBF two-upstream fixture..."
-if ! incus exec "$TARGET" -- "$CLI" > "$APPLY_OUT" 2>&1 <<EOF
+incus exec "$TARGET" -- "$CLI" > "$APPLY_OUT" 2>&1 <<EOF || true
 configure
 load merge ${REMOTE_SETS}
 commit
 exit
 quit
 EOF
-then
-    cat "$APPLY_OUT" >&2
-    fail "commit failed after commit-check passed"
-fi
+# #6936/#6440: as above — the exit status proves nothing. Without this gate a
+# commit that never landed let every cell below run against the PRE-TEST
+# config, where the ISP-B default is legitimately absent: the smoke would
+# report a clean main table having never applied the fixture that could dirty
+# it, which is the exact silent under-steer #6936 wants regression cover for.
+cos_require_markers "commit on $TARGET" "$APPLY_OUT" \
+    "$COS_MARKER_LOAD_MERGE" "$COS_MARKER_COMMIT" \
+    || fail "commit failed after commit-check passed"
 # From here on, always restore on exit.
 trap 'restore; rm -f "${cleanup_files[@]}"' EXIT
 sleep 3
@@ -131,9 +150,20 @@ echo "$ROUTES" | grep -q "default via ${ISP_B_GW4}" \
     || fail "ISP-B kernel table $PBR_TABLE lacks 'default via ${ISP_B_GW4}' — FRR table rendering broken (pre-PR-2 divergence): ${ROUTES:-<empty>}"
 info "ISP-B table $PBR_TABLE holds the instance default (divergence fix OK)"
 
-MAIN_DEFAULTS="$(incus exec "$TARGET" -- sh -c "ip route show default | grep -c 'via ${ISP_B_GW4}'" || true)"
-[[ "${MAIN_DEFAULTS:-0}" -eq 0 ]] \
-    || fail "ISP-B default leaked into the MAIN table (pre-PR-2 pollution)"
+# #6936: take the route TEXT, not a count. The counting form collapsed
+# "no leak" and "the probe returned nothing" onto the same healthy verdict
+# (`grep -c` prints 0 and exits 1, so `|| true` is load-bearing; an empty
+# substitution then fell through `${MAIN_DEFAULTS:-0}` to 0 = PASS). The
+# verdict below is TOTAL and treats a blind probe as a failure, because an
+# absence cannot be certified by an instrument that returned no reading.
+# Non-empty output doubles as the positive control: this venue always carries
+# the ISP-A default, so seeing defaults at all proves the probe read the table.
+MAIN_DEFAULTS="$(incus exec "$TARGET" -- ip route show default 2>/dev/null || true)"
+LEAK_VERDICT="$(fbf_main_default_leak_verdict "$ISP_B_GW4" "$MAIN_DEFAULTS")"
+case "$LEAK_VERDICT" in
+    PASS\ *) info "${LEAK_VERDICT#PASS }" ;;
+    *)       fail "${LEAK_VERDICT#FAIL }" ;;
+esac
 
 # ---- Phase 3: steering counter ----
 BEFORE="$(metric_value)"; BEFORE="${BEFORE:-0}"

--- a/test/incus/test-fbf-steering.sh
+++ b/test/incus/test-fbf-steering.sh
@@ -140,14 +140,29 @@ sleep 3
 
 # ---- Phase 2: kernel side of the divergence fix ----
 info "Discovering ISP-B kernel table from the PBR ip-rule band..."
-PBR_TABLE="$(incus exec "$TARGET" -- sh -c \
-    "ip rule show | awk -F'lookup ' '\$1 ~ /^31[0-9][0-9][0-9]:/ {print \$2; exit}'" | tr -d '[:space:]')"
-[[ -n "$PBR_TABLE" ]] || fail "no PBR ip rule in the 31000+ band (FBF kernel rule missing)"
-info "PBR rule -> table $PBR_TABLE"
+# #6936: enumerate ALL tables in the band and select by CONTENT, not by
+# position. The old form took the FIRST 31xxx rule and exited, but the band is
+# not private to FBF: this cluster already carries a GRE rule at exactly
+# priority 31000 (`from all to 10.255.192.40/30 iif ge-0-0-1 lookup 488570`),
+# so the discovery bound a GRE table and the cell below then blamed FRR for a
+# default it was never going to find there.
+PBR_CANDIDATES="$(incus exec "$TARGET" -- sh -c \
+    "ip rule show | awk -F'lookup ' '\$1 ~ /^31[0-9][0-9][0-9]:/ {print \$2}'" | tr -d '\r')"
+[[ -n "${PBR_CANDIDATES//[[:space:]]/}" ]] \
+    || fail "no PBR ip rule in the 31000+ band (FBF kernel rule missing)"
+info "PBR band candidates: $(echo $PBR_CANDIDATES)"
 
-ROUTES="$(incus exec "$TARGET" -- ip route show table "$PBR_TABLE")"
-echo "$ROUTES" | grep -q "default via ${ISP_B_GW4}" \
-    || fail "ISP-B kernel table $PBR_TABLE lacks 'default via ${ISP_B_GW4}' — FRR table rendering broken (pre-PR-2 divergence): ${ROUTES:-<empty>}"
+PBR_TABLE=""
+ROUTES=""
+for _cand in $PBR_CANDIDATES; do
+    _routes="$(incus exec "$TARGET" -- ip route show table "$_cand" 2>/dev/null || true)"
+    if fbf_table_holds_default "$ISP_B_GW4" "$_routes"; then
+        PBR_TABLE="$_cand"
+        ROUTES="$_routes"
+        break
+    fi
+done
+[[ -n "$PBR_TABLE" ]] || fail "no table in the 31000+ band ($(echo $PBR_CANDIDATES)) holds 'default via ${ISP_B_GW4}' — either FRR table rendering is broken (pre-PR-2 divergence) or the FBF rule never installed"
 info "ISP-B table $PBR_TABLE holds the instance default (divergence fix OK)"
 
 # #6936: take the route TEXT, not a count. The counting form collapsed

--- a/test/incus/test-fbf-steering.sh
+++ b/test/incus/test-fbf-steering.sh
@@ -163,7 +163,7 @@ for _cand in $PBR_CANDIDATES; do
     fi
 done
 [[ -n "$PBR_TABLE" ]] || fail "no table in the 31000+ band ($(echo $PBR_CANDIDATES)) holds 'default via ${ISP_B_GW4}' — either FRR table rendering is broken (pre-PR-2 divergence) or the FBF rule never installed"
-info "ISP-B table $PBR_TABLE holds the instance default (divergence fix OK)"
+info "ISP-B table $PBR_TABLE holds the instance default (divergence fix OK): $(grep -m1 '^default' <<<"$ROUTES")"
 
 # #6936: take the route TEXT, not a count. The counting form collapsed
 # "no leak" and "the probe returned nothing" onto the same healthy verdict


### PR DESCRIPTION
## #6936 asked for cells in a venue whose apply phase could not fail

The issue asks for PBR multi-WAN negative cells in
`test/incus/test-fbf-steering.sh`. Before writing cells INTO that venue I
checked the venue, and its **entire apply phase was ungated**.

| site | form | can it fail? |
|---|---|---|
| commit check (L93) | `if ! incus exec .. "$CLI" <<EOF` | **no** |
| commit (L107) | `if ! incus exec .. "$CLI" <<EOF` | **no** |
| restore / rollback (L69) | `<<EOF \|\| echo "WARNING: rollback failed"` | **no** |

Per #6440 — documented in `cos-apply-lib.sh`, pinned by
`cmd/cli/cos_apply_markers_6440_test.go`, and **re-verified at HEAD** in
`cmd/cli/main.go` — the piped-stdin CLI is a REPL:

```go
err = c.dispatch(line)
if err != nil {
    if err == errExit { break }
    if err == context.Canceled { continue }
    fmt.Fprintf(os.Stderr, "error: %v\n", err)   // print and CONTINUE
}
```

It prints `error:`, continues, and exits **0**. None of those three gates
could fire.

The consequence is the exact failure mode #6936 wants cover for. A commit
that silently did not land leaves every downstream cell measuring the
**pre-test** config, where the ISP-B default is legitimately absent — so
the smoke reports a clean main table having never applied the fixture that
could dirty it. And a rollback that did not land leaves the **shared**
cluster on the FBF test config for the next lane.

Adding negative cells to a script whose apply phase cannot fail would be
building on sand, so the gates came first. They now assert the CLI's own
success markers, reusing `cos-apply-lib.sh` rather than copying a marker
list that could drift from the one `cmd/cli` pins.

## Second defect: a negative cell that fails to a healthy value

```bash
MAIN_DEFAULTS="$(... "ip route show default | grep -c 'via ${GW}'" || true)"
[[ "${MAIN_DEFAULTS:-0}" -eq 0 ]] || fail "ISP-B default leaked ..."
```

| input | value | verdict |
|---|---|---|
| main table has an unrelated default | `0` | PASS (correct) |
| **probe returned nothing at all** | `` | **PASS (wrong)** |
| main table holds the ISP-B default | `1` | FAIL (correct) |

`grep -c` prints `0` and exits 1 when it matches nothing, so `|| true` is
load-bearing and correct — but an empty substitution then falls through
`${MAIN_DEFAULTS:-0}` to the healthy value. The cell certifies an absence
having looked at nothing.

**Reachability, stated honestly.** This is narrower than it first looks.
Non-numeric output (an incus error string) makes bash's `[[ -eq ]]`
comparison fail, so garbage reports FAIL, not PASS; and a total target
outage is caught earlier by the PBR-table assertion at L131. The hole is
specifically the empty case. It is worth closing because this cell is the
template the next negative cell gets copied from — **it is not claimed as a
live defect.**

Replaced with a TOTAL verdict whose positive control is intrinsic:
non-empty route output is itself the evidence that the probe read the table,
since this venue always carries the ISP-A default.

## Third defect, found by the selftest itself

`grep 'via 172.16.80.1'` substring-matches `via 172.16.80.11`. The original
had this too. Fail-**closed**, so it cost a false alarm rather than a silent
pass, but still wrong. Now an exact-token match on the field following
`via`. Pinned by `NEAR_MISS_GW` — the row that caught it.

## The guard was a floor of one

`TestShellGateMarkersMatchCLI_6440` binds exactly **one** script,
`cos-apply-lib.sh`. That is why this smoke could go ungated unnoticed.
Replaced with a predicate over every smoke that commits configuration, with
`wg-interop.sh` (the one remaining offender, 4 sessions) as an explicit
exemption tracking **#7792**, plus a **stale-exemption check** so the guard
fails the moment #7792 lands, and a `scanned == 0` fatal so the detector
cannot pass vacuously.

A blanket ban on the `if ! incus exec .. cli <<EOF` shape was considered as
the finer-grained check and **rejected on measurement**: `apply-cos-config.sh`
uses that shape legitimately as a belt alongside the marker gate, and the
`cli -c` form exits non-zero meaningfully. The discriminator is marker
PRESENCE, not the absence of an idiom. The guard's file-level granularity is
documented in the test rather than left to read as stronger than it is.

## Wired into a gate that actually runs

The sibling `*-lib` selftests are standalone make targets that nothing
invokes automatically. A hermetic table nobody runs is not a gate (#6920), so
this one is also wired into `scripts/run-selftests.sh` (`make selftest`).
That needed a new additive `run_bash` helper: `run_shell` forces `sh`
regardless of shebang, and under dash this selftest dies with
`Bad substitution` on `${BASH_SOURCE[0]}` — a syntax error reported as a
result. No existing entry changes interpreter.

## Fourth defect: the PBR table discovery bound the wrong table

Phase 2 found its table positionally — first rule in the 31000+ band, then
stop. That band is not private to FBF. **Measured** on `loss:xpf-userspace-fw0`,
a pre-existing GRE rule sits at exactly priority 31000:

```
31000:	from all to 10.255.192.40/30 iif ge-0-0-1 lookup 488570
```

So the discovery binds a GRE table, and the divergence cell then reports
*"ISP-B kernel table 488570 lacks 'default via 172.16.80.1' — FRR table
rendering broken"* on a correctly-rendered config: a false failure naming the
wrong subsystem. Fail-closed (a wasted investigation, not a silent pass), but a
cell that cannot identify its own subject is not a cell.

Now enumerates the band and selects by CONTENT, with the same exact-token
gateway match, and requires the match on a line starting with `default` so the
gateway appearing as a next hop on another prefix does not qualify. The
selftest carries the measured GRE table **verbatim** as a negative row.

## Correcting the issue's own classification

#6936 lists four PBR residuals as one class. The script's header separates
them 3 + 1, and the distinction is load-bearing:

- **Genuinely venue-blocked (3):** true dual-provider failure modes,
  dual-public-IP SNAT, throughput under dual-path load. These need a
  **second real uplink**; no work in this repo reaches them.
- **Not blocked (1):** path-divergence under uplink failure is already
  documented as *"the smoke-runner's MANUAL step"* — blackhole the ISP-B
  gateway and watch `fbf-fallback` repoint. That is automatable in the
  existing venue. It is unwritten, not impossible.

`Refs #6936` — the two lab smokes themselves are not written here.

## Mutation matrix

| Cell | Mutation | Expected | Result | Failing test |
|---|---|---|---|---|
| `CONTROL` | none | green | SURVIVE (9/9 rows; go 6440+6936 ok) | — |
| `L1_empty_probe_passes` | empty-probe verdict reverted to PASS (the original defect) | RED | **RED** (6 passed, 3 failed) | `PROBE_BLIND_EMPTY`, `_WS`, `_NEWLINE` |
| `L2_substring_match` | exact-token match reverted to `grep "via $gw"` | RED | **RED** (8 passed, 1 failed) | `NEAR_MISS_GW` |
| `N1_ungated_script` | strip marker refs from the smoke (simulates a new ungated script) | RED | **RED** | `...MarkerGate_6936`: "test-fbf-steering.sh commits configuration" |
| `N2_stale_exemption` | `wg-interop.sh` starts using the gate | RED | **RED** | `...MarkerGate_6936`: "wg-interop.sh is now marker-gated" |
| `N3_detector_vacuous` | detector matches no heredoc verb | RED | **RED** | `...MarkerGate_6936`: "scanned 0" |
| `L3_drop_default_anchor` | table selector loses its `/^default/` anchor | RED | **RED** (14 passed, 1 failed) | `TBL_GW_ONLY_NONDEFAULT` |
| `L4_table_substring_gw` | table selector reverts to a substring gateway match | RED | **RED** (14 passed, 1 failed) | `TBL_NEAR_MISS_GW` |
| `W1_selftest_is_gated` | L1 defect, run through **`make selftest`** | gate must fail | **RED** — `make selftest` rc=2, `failed=1` | `FAIL: test/incus/fbf-steering-selftest.sh` |

`W1` is the #6920 cell: it proves the harness is load-bearing rather than
merely present.

## Gates

- `make selftest` — **rc=0**, 73 passed / 0 skipped / 0 failed, shellcheck
  (installed here) clean on all three shell files
- `make test-go` — **rc=0**, 72 packages ok, 0 FAIL
- `make test-rust` — **not run, and not applicable**: this branch touches
  **0** `.rs` files (Go test, shell, Makefile, CLAUDE.md, docs only).

An earlier `make test-go` reported `TestLargeEventSurvivesASlowButProgressingReader7632`
(pkg/api) failing at 72s. That run overlapped the cluster smoke; the test passes
in 0.4s in isolation and this branch touches 0 files in `pkg/api`. The clean
re-run above is the reported one.

The full Go gate ran before the final two commits, which are shell-only. The
only Go test that reads those shell files is the #6936 predicate guard, re-run
directly (`go test -run "6440|6936" ./cmd/cli/` — ok), and `make selftest`
covers the shell side including shellcheck.

Adding the three shell files to the `SH_SCRIPTS` lint list earned its keep
immediately: shellcheck caught `ROUTES` going unread (SC2034) in the
content-based table selection, fixed by printing the default route the cell
actually matched.

## Measured vs inferred

**Measured**: the three dead gates and the REPL behaviour at HEAD; the
three-row collapse table and its narrow reachability; the substring
near-miss; the census of config-committing scripts; every matrix cell; the
`make selftest` results.

**Inferred**: that a silently-unapplied commit would have produced a
misleading clean run *in a real lab session*. The mechanism is measured; no
such historical run was found or attributed.

## On-cluster validation: the gate caught a live failure on its first run

Run under the shared-cluster lock cell (lock free; released cleanly):

```
load merge complete
error: commit failed: rpc error: code = Unavailable desc =
  apply PBR rules: add PBR rule instance ISP-B table 236616: invalid argument
```

`load merge complete` printed; `commit complete` did not. **The old gate would
have seen exit status 0 and continued**, failing later at the PBR-table
discovery with the misleading "no PBR ip rule in the 31000+ band (FBF kernel
rule missing)" — blaming FRR table rendering for a commit that never landed.
That is the same misdirection #6440 recorded for the CoS path.

Root-caused and filed as **#7796**: `rules.go` emits the DSCP as a shifted TOS
byte into `FRA_TOS`, which the kernel masks against `IPTOS_TOS_MASK` (0x1E).
Measured boundary on kernel 7.0.13: `dscp <= 7` accepted, `dscp >= 8` rejected
"Invalid tos". Every DSCP name in `dscpToTOS`'s map is 0 or >= 8, and both zero
cases are separately dropped at `rules.go:1148` — so **no `from dscp` value
installs a rule at all**. Not a regression from this change; this change only
made it visible.

**Cluster hygiene**: the failed commit DID land in the config store even though
the apply errored (commit-history entry 48, inside my run window), so the active
config was dirty. Reverted with a verified `cos_rollback_one` and re-checked: 0
FBF/ISP-B lines, no FBF rule in the 31000-band, `xpfd` active. The remaining PBR
rule (table 488570) is a pre-existing GRE rule present on both nodes.

A measurement error worth recording: my first boundary sweep passed DECIMAL
values to `ip rule add tos`, which parses a bare integer as HEX — making dscp=7
look rejected and nearly putting a wrong boundary in #7796. Redone with explicit
`0x` values.

## Follow-ups filed

- **#7792** — `wg-interop.sh` carries the same dead-gate defect in 4 sessions.
- **#7796** — FBF DSCP steering installs no ip rule.
