### PR TITLE
config: read the packed system host-name, and stop a second login block erasing the first

### DIFF
--- a/docs/log/6956.md
+++ b/docs/log/6956.md
@@ -1,0 +1,30 @@
+# #6956 + #6957 — two roots in one function
+
+- **Timestamp**: 2026-08-27
+- **Action**: Judged these as TWO defects with TWO roots before choosing the PR
+  shape, and the AST shapes are what settled it. #6956 is a packed tail
+  (`Keys=[system host-name fw1]`, zero children) the child walk never reads;
+  #6957 is two children the walk reads and then overwrites
+  (`Keys=[system]`, two `login` children, `sys.Login = &LoginConfig{}` per arm).
+  A packed tail never read is not the same defect as a child read and
+  discarded — one diff, two causes, said so explicitly.
+
+  #6956 is narrowed to the leaf the issue names rather than routed through
+  `packedBodyChildren` + a `packedTail` opt-in (the #6821 mechanism), because
+  measurement showed `host-name` has NO validator in either spelling —
+  `system host-name bad..name;` and the nested form are both accepted today —
+  so the "never compile a packed tail the gate does not validate" rule is
+  satisfied vacuously. Teaching the gate to validate every packed token on the
+  `system` line would newly reject configurations that commit cleanly now.
+
+  Fixing #6957 SURFACED a latent gap in #6992: its duplicate-user fold keyed off
+  a `userByName` map declared inside the per-block arm, so it could only fold
+  WITHIN one block. That was invisible while the reallocation discarded the
+  earlier block — the duplicate never coexisted, so #6992's own cross-block cell
+  passed for the wrong reason. Hoisted the index to function scope so the fold
+  spans blocks, which is what that cell always claimed.
+- **File(s)**: `pkg/config/compiler_system.go`,
+  `pkg/config/system_packed_and_duplicate_6956_6957_test.go` (new),
+  `pkg/config/testdata/compact_block_divergences_2419.txt`
+- **Validation**: `go build ./...` + `go test -count=1 ./...` repo-wide, rc 0.
+  Mutation matrix below, full package, no `-run` filter, fix committed first.

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -22,6 +22,34 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 	}
 	sys.DataplaneType = dpType
 
+	// #6956: `system host-name fw1;` packs the value onto the `system` node's
+	// OWN Keys — `Keys=["system","host-name","fw1"]` with ZERO children — so the
+	// child walk below never runs and the host name compiled to "" with no
+	// error and no warning. The nested spelling `system { host-name fw1; }`
+	// works, and the flattened one is what `display set` output and vSRX
+	// migration paths produce.
+	//
+	// Everything keyed on host name is affected: the management TLS
+	// certificate's subject, syslog's origin field, the CLI prompt.
+	//
+	// Read here rather than through `packedBodyChildren` + a `packedTail` opt-in
+	// (the #6821 mechanism) DELIBERATELY. That pairing exists because compiling
+	// a packed tail the gate does not validate turns "not compiled" into
+	// "compiled, unvalidated". It has nothing to bypass here: `host-name` is a
+	// scalar leaf with NO validator, measured in both spellings — `system
+	// host-name bad..name;` and `system { host-name bad..name; }` are both
+	// accepted by SchemaValidate today. So the rule is satisfied vacuously, and
+	// this stays narrowed to the leaf the issue names rather than teaching the
+	// gate to validate every packed token on the `system` line, which would
+	// newly reject configurations that commit cleanly now.
+	if len(node.Keys) >= 3 && node.Keys[1] == "host-name" {
+		sys.HostName = node.Keys[2]
+	}
+
+	// #6957/#6992: spans every `login` child of this `system` node. See the
+	// `case "login"` arm.
+	var loginUserByName map[string]*LoginUser
+
 	for _, child := range node.Children {
 		switch child.Name() {
 		case "host-name":
@@ -100,7 +128,41 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 				}
 			}
 		case "login":
-			sys.Login = &LoginConfig{}
+			// #6957: allocate ONCE. This arm runs per `login` child, and two
+			// sibling `login { … }` blocks under one `system` are legal Junos —
+			// a generated or concatenated config produces them routinely, and an
+			// operator appending a second stanza to add an account is the
+			// motivating case. Reallocating here discarded everything the
+			// EARLIER block had contributed, so the compiled set reduced to the
+			// last block and the first block's users vanished with no error.
+			//
+			// That is not merely absent-from-config: `reconcileAbsentLoginUsers`
+			// treats the compiled set as authoritative and DEPROVISIONS
+			// xpf-managed accounts missing from it, so the lost accounts were
+			// removed from the box by a commit that reported success.
+			//
+			// Everything below this line already appends (`sys.Login.Classes`,
+			// `sys.Login.Users`), so allocating once is the whole fix —
+			// subsequent blocks accumulate into the same struct.
+			//
+			// Distinct root from #6956, which is fixed in the same change: that
+			// one is a packed tail the walk never reads; this one is two
+			// children the walk reads and then overwrites.
+			if sys.Login == nil {
+				sys.Login = &LoginConfig{}
+			}
+			// #6957 + #6992: the name->entry index must span blocks too, for the
+			// same reason the allocation must. #6992 folds a user NAME authored
+			// twice into ONE entry, but its index was declared inside this arm,
+			// so it reset per block and could only ever fold WITHIN one. That
+			// was invisible while the reallocation above discarded the earlier
+			// block — the duplicate never coexisted, so the fold was never asked
+			// to span anything and #6992's own cross-block cell passed for the
+			// wrong reason. Fixing #6957 makes the duplicate real, which is what
+			// surfaced it.
+			if loginUserByName == nil {
+				loginUserByName = map[string]*LoginUser{}
+			}
 			// #4304 S-2: parse custom `login class <name>` RBAC definitions so
 			// a real vSRX config commits (the `user ... class` enum accepts
 			// the defined names) and maps its Junos permission set onto xpf's
@@ -176,7 +238,7 @@ func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts)
 			// Deliberately NOT applied to `class`: #6838 already made the class
 			// cohort reader-independent by folding permissions across it, and a
 			// merge here would fight that design.
-			userByName := map[string]*LoginUser{}
+			userByName := loginUserByName
 			for _, userInst := range namedInstances(child.FindChildren("user")) {
 				user := userByName[userInst.name]
 				if user == nil {

--- a/pkg/config/system_packed_and_duplicate_6956_6957_test.go
+++ b/pkg/config/system_packed_and_duplicate_6956_6957_test.go
@@ -1,0 +1,186 @@
+package config
+
+// system_packed_and_duplicate_6956_6957_test.go — #6956 and #6957.
+//
+// TWO DEFECTS, TWO ROOTS, fixed in one change because they sit in one function.
+// The shapes are what separate them, and each fixture asserts its own shape
+// first so a future parser change cannot silently turn one into the other:
+//
+//	#6956  system host-name fw1;   Keys=[system host-name fw1]  children=0
+//	       -> the value is on the ANCESTOR's own Keys; the child walk never runs.
+//
+//	#6957  system { login {…} login {…} }   Keys=[system]  children=2
+//	       -> both children ARE walked; the second reallocation discards the first.
+//
+// A packed tail never read is not the same defect as two children read and then
+// overwritten, and a shared diff must not imply a shared cause.
+
+import (
+	"strings"
+	"testing"
+)
+
+func compile6956(t *testing.T, cfg string) *Config {
+	t.Helper()
+	tree, perr := NewParser(cfg).Parse()
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	out, cerr := CompileConfig(tree)
+	if cerr != nil {
+		t.Fatalf("compile: %v", cerr)
+	}
+	return out
+}
+
+func systemNode6956(t *testing.T, cfg string) *Node {
+	t.Helper()
+	tree, perr := NewParser(cfg).Parse()
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	for _, top := range tree.Children {
+		if len(top.Keys) > 0 && top.Keys[0] == "system" {
+			return top
+		}
+	}
+	t.Fatal("no `system` node")
+	return nil
+}
+
+// TestPackedSystemHostNameCompiles6956 is the headline cell for #6956.
+//
+// An EMPTY host name is the failure default of this path, so a test expecting
+// "" would constrain nothing. Assert the populated value, and assert the two
+// spellings agree.
+func TestPackedSystemHostNameCompiles6956(t *testing.T) {
+	// Premise: the two spellings really do produce different shapes. If the
+	// parser ever normalises one into the other, the packed cell below becomes
+	// a duplicate of its control and this says so rather than passing quietly.
+	packed := systemNode6956(t, "system host-name fw1;")
+	if len(packed.Keys) != 3 || len(packed.Children) != 0 {
+		t.Fatalf("packed shape = Keys%v children=%d, want Keys[system host-name fw1] "+
+			"children=0 — the whole defect is that a child walk sees NOTHING here",
+			packed.Keys, len(packed.Children))
+	}
+	nested := systemNode6956(t, "system { host-name fw1; }")
+	if len(nested.Keys) != 1 || len(nested.Children) == 0 {
+		t.Fatalf("nested shape = Keys%v children=%d, want Keys[system] with the value "+
+			"as a CHILD", nested.Keys, len(nested.Children))
+	}
+
+	for _, tc := range []struct{ name, cfg string }{
+		{"packed", "system host-name fw1;"},
+		{"nested", "system { host-name fw1; }"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := compile6956(t, tc.cfg).System.HostName; got != "fw1" {
+				t.Fatalf("HostName = %q, want \"fw1\". An empty host name commits "+
+					"clean and silently: the management TLS certificate subject, "+
+					"syslog's origin field and the CLI prompt all key on it, and "+
+					"`display set` output plus vSRX migration paths produce exactly "+
+					"this spelling (#6956)", got)
+			}
+		})
+	}
+}
+
+// TestPackedSystemHostNameWithABody6956 is the case the two-shape split could
+// hide: a packed tail AND a nested block on the same node. The packed value
+// must survive the child walk that the block triggers.
+func TestPackedSystemHostNameWithABody6956(t *testing.T) {
+	cfg := compile6956(t, "system host-name fw1 {\n  login { user alice { class read-only; } }\n}")
+	if cfg.System.HostName != "fw1" {
+		t.Errorf("HostName = %q, want \"fw1\" — a packed tail must not be dropped "+
+			"just because the node also has children (#6956)", cfg.System.HostName)
+	}
+	if cfg.System.Login == nil || len(cfg.System.Login.Users) != 1 {
+		t.Errorf("the nested block must still compile alongside the packed tail")
+	}
+}
+
+// TestTwoSiblingLoginBlocksKeepBothUsers6957 is the headline cell for #6957.
+//
+// The two blocks carry DIFFERENT users deliberately. With the same user in
+// both, the count is 1 either way and the cell passes against unfixed code —
+// the defect is invisible unless the fixture can distinguish "merged" from
+// "last one won".
+func TestTwoSiblingLoginBlocksKeepBothUsers6957(t *testing.T) {
+	// Premise: the parser really does produce two sibling `login` children.
+	sys := systemNode6956(t, "system {\n  login { user alice { class read-only; } }\n  login { user bob { class operator; } }\n}")
+	logins := 0
+	for _, ch := range sys.Children {
+		if ch.Name() == "login" {
+			logins++
+		}
+	}
+	if logins != 2 {
+		t.Fatalf("fixture produced %d `login` children, want 2 — without two "+
+			"siblings there is no overwrite to detect", logins)
+	}
+
+	cfg := compile6956(t, "system {\n  login { user alice { class read-only; } }\n  login { user bob { class operator; } }\n}")
+	if cfg.System.Login == nil {
+		t.Fatal("System.Login is nil — no users compiled at all")
+	}
+	var names []string
+	for _, u := range cfg.System.Login.Users {
+		names = append(names, u.Name)
+	}
+	// Assert BOTH names, not the count. A count of 2 is also satisfied by the
+	// same user twice, and by the wrong user surviving alongside a duplicate.
+	joined := strings.Join(names, ",")
+	for _, want := range []string{"alice", "bob"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("user %q is missing (got %v). The FIRST block's users were "+
+				"discarded, and `reconcileAbsentLoginUsers` treats the compiled set "+
+				"as authoritative — so they are not merely absent from the running "+
+				"config, they are deprovisioned from the box by a commit that "+
+				"reported success (#6957)", want, names)
+		}
+	}
+}
+
+// TestTwoSiblingLoginBlocksMergeClasses6957 covers the other accumulating field
+// in the same arm. Users and classes are appended by different loops, so a fix
+// that repaired only one would leave the other reducing to the last block.
+func TestTwoSiblingLoginBlocksMergeClasses6957(t *testing.T) {
+	cfg := compile6956(t, "system {\n"+
+		"  login { class ops-a { permissions view; } }\n"+
+		"  login { class ops-b { permissions view; } }\n"+
+		"}")
+	if cfg.System.Login == nil {
+		t.Fatal("System.Login is nil")
+	}
+	var names []string
+	for _, c := range cfg.System.Login.Classes {
+		names = append(names, c.Name)
+	}
+	joined := strings.Join(names, ",")
+	for _, want := range []string{"ops-a", "ops-b"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("class %q is missing (got %v) — classes accumulate through a "+
+				"different loop than users, so the allocation fix has to cover "+
+				"both (#6957)", want, names)
+		}
+	}
+}
+
+// TestSingleLoginBlockUnchanged6957 is the over-reach control.
+//
+// Allocating once instead of per-block must not make a LATER block accumulate
+// onto a stale struct across separate compiles, and the ordinary single-block
+// config must be bit-identical to before. Without this, "allocate once" and
+// "never allocate" are not distinguished.
+func TestSingleLoginBlockUnchanged6957(t *testing.T) {
+	cfg := compile6956(t, "system {\n  login {\n    user alice { class read-only; }\n    user bob { class operator; }\n  }\n}")
+	if cfg.System.Login == nil || len(cfg.System.Login.Users) != 2 {
+		t.Fatalf("the ordinary single-block spelling must still compile both users")
+	}
+	// A SECOND, independent compile must not inherit the first's users.
+	again := compile6956(t, "system {\n  login { user carol { class operator; } }\n}")
+	if n := len(again.System.Login.Users); n != 1 {
+		t.Errorf("a fresh compile has %d users, want 1 — state leaked across "+
+			"compiles, which allocating once must not introduce", n)
+	}
+}

--- a/pkg/config/testdata/compact_block_divergences_2419.txt
+++ b/pkg/config/testdata/compact_block_divergences_2419.txt
@@ -354,7 +354,6 @@ system dataplane shared-umem phase0-artifact-file
 system dataplane state-file
 system dataplane workers
 system domain-search
-system host-name
 system license autoupdate url
 system login class xpfarg allow-commands
 system login class xpfarg allow-configuration


### PR DESCRIPTION
Fixes #6956 and #6957.

## Judged as TWO defects with TWO roots, before choosing the PR shape

Both reproduce at `origin/master`, and the AST shapes are what separate them — not a guess about the code:

| issue | parsed shape | compiled | root |
|---|---|---|---|
| **#6956** `system host-name fw1;` | `Keys=[system host-name fw1]` **children=0** | `host=""` | value on the **ancestor's own Keys**; the child walk never runs |
| control `system { host-name fw1; }` | `Keys=[system]` children=1 | `host="fw1"` | — |
| **#6957** two sibling `login` blocks | `Keys=[system]` **children=2** | `users=1` | both children **are** walked; the arm reallocates and discards the first |
| control, one block | `Keys=[system]` children=1 | `users=2` | — |

**A packed tail never read is not the same defect as a child read and then overwritten.** They share a function, not a cause. One diff, stated as two.

## #6956 — and why it is *not* routed through `packedTail`

`system host-name fw1;` compiled to an empty host name with no error and no warning. Everything keyed on host name is affected — the management TLS certificate subject, syslog's origin field, the CLI prompt — and this is the spelling `display set` output and vSRX migration paths produce.

The obvious fix is `packedBodyChildren` + a `packedTail: true` opt-in (the #6821 mechanism). **Deliberately not used here**, on measurement rather than preference: that pairing exists because compiling a packed tail the gate does not validate turns *"not compiled"* into *"compiled, unvalidated"*. Measured in both spellings:

```
system host-name bad..name;        SchemaValidate = <nil>   (accepted)
system { host-name bad..name; }    SchemaValidate = <nil>   (accepted)
```

`host-name` has **no validator at all**, so there is nothing to bypass and the rule is satisfied vacuously — the #6818 situation, not the #6821 one. Setting `packedTail` on `system` would teach the gate to validate every packed token on that line and could newly reject configurations that commit cleanly today, so the fix stays narrowed to the leaf the issue names.

## #6957 — a one-line allocation, with a real blast radius

The `case "login"` arm runs per child and did `sys.Login = &LoginConfig{}` each time. Everything below it already appends, so allocating once is the whole fix.

It matters beyond the config: `reconcileAbsentLoginUsers` treats the compiled set as authoritative and **deprovisions** xpf-managed accounts missing from it. The first block's users were not merely absent from the running config — they were removed from the box, by a commit that reported success.

## Fixing #6957 surfaced a latent gap in #6992

This is the part worth reading. #6992 folds a user name authored twice into one entry, and its own cross-block cell asserts the fold spans two `login` blocks. That cell **was passing for the wrong reason**: its `userByName` index was declared inside the per-block arm, so it could only fold *within* one block — but the reallocation above discarded the earlier block, so the duplicate never coexisted and the fold was never asked to span anything.

Making the duplicate real is what exposed it. `TestDuplicateUserAcrossTwoLoginBlocks_6992` failed with two live `alice` entries (uid 2001 and 2002). The index is now hoisted to function scope, so the fold spans blocks — which is what that cell always claimed.

## Tests

Every cell asserts its **shape** before its behaviour, so a future parser change cannot turn one defect's fixture into the other's and pass quietly. Per your convention 3, the #6957 fixtures carry **different** users (`alice` read-only / `bob` operator) and assert **both names**, not the count — a count of 2 is also satisfied by the same user twice, or by the wrong one surviving.

`TestTwoSiblingLoginBlocksMergeClasses6957` covers the other accumulating field: classes append through a different loop than users, so a fix repairing only one would leave the other reducing to the last block. `TestSingleLoginBlockUnchanged6957` is the over-reach control — without it, "allocate once" and "never allocate" are indistinguishable, and it also checks a fresh compile does not inherit the previous one's users.

## Mutation matrix — 4/4 RED

Fix committed first; full package, `-count=1`, **no `-run` filter**; classifier gates on a `pkg/config` result line so a build break cannot read as a pass.

| # | reverted line | file:line | verdict | first named cell |
|---|---|---|---|---|
| M1 | packed host-name not read | `compiler_system.go:45` | **RED** | `TestPackedSystemHostNameCompiles6956` +2 |
| M2 | packed read uses `Keys[1]` not `Keys[2]` | `compiler_system.go:46` | **RED** | `TestPackedSystemHostNameCompiles6956` +2 |
| M3 | login reallocates per block | `compiler_system.go:151` | **RED** | `TestTwoSiblingLoginBlocksKeepBothUsers6957` +2 |
| M4 | fold index resets per block | `compiler_system.go:241` | **RED** | `TestDuplicateUserAcrossTwoLoginBlocks_6992` |

M2 exists because M1 alone is satisfied by reading *any* index — an off-by-one would still be "read the packed tail".

M4 reds only #6992's own cell, which is the correct localisation: the hoist repairs that fold and nothing else.

## The #2419 census tripwire fired, which is it working

`system host-name` was listed as compact-blind. It now compiles equivalently, so the inventory line is retired rather than left as an allowlist entry that would hide the next regression.

## Gate

```
go build ./...            rc 0
go test -count=1 ./...    rc 0   (68 ok, 0 FAIL)
```

at HEAD `e0c93c6d4c8ae680cc7c59eabecddb8db57dfffc`, clean tree, `merge-base --is-ancestor origin/master HEAD` verified. **Zero** `userspace-dp/` or `userspace-xdp/` files touched, so no cargo leg is owed. Compile-time behaviour only, no runtime forwarding path, so no deploy lane is owed.

Log at `docs/log/6956.md` per the #6874 convention.

## Refs

Fixes #6956, #6957. Refs #6992 (the fold whose cross-block cell this repairs), #6706 (the `system login` packed-path fix these were split from), #2419 (the compact/block equivalence census), #6821 / #6818 (why `packedTail` applies to one and not the other).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MNWyRNuBeKpjXZHcSBihm
