### PR TITLE
dataplane: propagate the discarded map-write errors

### DIFF
--- a/docs/log/6959.md
+++ b/docs/log/6959.md
@@ -1,0 +1,64 @@
+# #6959 — blind-write clear loops swallowing every eBPF `Update` error
+
+- **Timestamp**: 2026-08-27
+- **Action**: Finished the sweep #6743 started for `clearPolicyCountersIn` /
+  `clearFilterCountersIn`. An AST census (bare `zm.Update(...)` expression
+  statements AND `_ = zm.Update(...)` blank assigns) over non-test
+  `pkg/dataplane` + `pkg/dataplane/userspace` found **32** discarded map
+  writes, splitting **17 / 15** on whether the enclosing function returns
+  `error`. The issue named 4; the population is 17.
+
+  **Fixed (15 of the 17).** Thirteen were blind-write clear loops; ten of
+  those now share one body, `clearArrayEntriesIn` (`maps_policy.go`), which
+  returns the first rejection naming the map and the index and takes the
+  same `counterMapUpdater` seam #6743 introduced. `ClearZonePairPolicies`
+  (iterator-driven, conditional) and `ClearNATPoolIPs` (two maps written in
+  one interleaved loop — kept interleaved so the visit order is unchanged)
+  are wrapped inline instead. Two more were NOT clear loops but were the
+  same defect: `SetNAT64Config`'s mirror write into `nat64_prefix_map` (the
+  array write beside it was already propagated, so a discarded mirror let
+  the two descriptions of one NAT64 prefix diverge while the caller was told
+  the whole write landed) and `programBootstrapMapsLocked`'s heartbeat
+  zero-init (a discarded rejection leaves the slot holding the previous
+  load's timestamp, which reads as FRESH and lets the shim redirect to a
+  worker that is not there — the exact hazard the #6702 bound fix closed;
+  the `userspace_ctrl` write in the same function already aborted bring-up
+  on the same class of failure).
+
+  **Declined (2 of the 17), documented at the site and allowlisted.**
+  `Compile`'s `redirect_capable` write is a per-interface optimisation HINT
+  whose unset default fails safe to `XDP_PASS` kernel forwarding, and it is
+  the config-commit path, not an operator clear — a hard error there aborts
+  a commit over a lost performance hint. `UpdatePolicyScheduleState` carries
+  an explicit #3780 contract in its own doc comment that it ALWAYS reports
+  success so the daemon's scheduler self-heal never spins on this retired,
+  runtime-shadowed eBPF path; propagating would break that contract, not fix
+  a defect.
+
+  **Not fixed, reported: the 15 with no error return** (`maps_stale.go`'s
+  nine stale-entry sweeps, `seedInterfaceCounter`, `clearNativeXDPFlags`,
+  `clearNativeXDPFlagsForIfindexes`, `SeedNATPortCounters`,
+  `clearAllBindingRowsLocked`, `reEnableUserspaceCtrlLocked`). A different
+  disposition — there is nothing to propagate to — so the scope was not
+  silently widened. The guard prints the census on every run so the
+  population stays visible.
+
+  **Guard.** `TestNoUndocumentedDiscardedMapUpdate` parses the package
+  WITHOUT `parser.ParseComments`, so a doc comment quoting the pattern
+  cannot satisfy it; it matches both discard spellings; it also flags a
+  discarded call to an error-returning clear helper, which would launder the
+  defect past a scan that only looks at `.Update`; and it asserts a NON-ZERO
+  match count (files scanned, total `Update` calls, total discards found)
+  before believing any clean result, so a broken walker fails loudly rather
+  than sweeping nothing. The allowlist is compared for EXACT equality, so
+  "fixing" a deliberate discard fails too.
+  `TestClearArrayEntriesInCallSitesKeepTheirBounds` pins every call site's
+  sweep bound to the expression its inline loop used at `origin/master`, so
+  the fold cannot have narrowed a sweep.
+- **File(s)**: `pkg/dataplane/maps_policy.go`, `pkg/dataplane/maps_counters.go`,
+  `pkg/dataplane/maps_filter.go`, `pkg/dataplane/maps_screen.go`,
+  `pkg/dataplane/maps_nat.go`, `pkg/dataplane/compiler.go`,
+  `pkg/dataplane/userspace/maps_sync.go`,
+  `pkg/dataplane/clear_array_entries_6959_test.go` (new),
+  `pkg/dataplane/discarded_map_update_6959_test.go` (new),
+  `pkg/dataplane/README.md`, `docs/log/6959.md` (new)

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -826,11 +826,56 @@ several test fakes), and widening that is a separable change with its own review
   the adapter is permanently non-nil, so the field cannot answer "does a
   dataplane exist?".
 
-### Counter-clear error propagation: what it does NOT cover
+### Map-write error propagation (#6743 r4-F2, #6959)
 
 `clearPolicyCountersIn` / `clearFilterCountersIn` propagate their
-`Map.Update` error (#6743 r4-F2), which fixes the discarded-error false
-success. It does NOT fix the DETACHED-backend false success: `Teardown()`
+`Map.Update` error (#6743 r4-F2). #6959 finished the sweep: an AST census
+of every DISCARDED `Update` in non-test `pkg/dataplane` found 32, split
+17 / 15 by whether the enclosing function returns `error`.
+
+- **The 15 in functions with NO error return** are a different
+  disposition — `maps_stale.go`'s stale-entry sweeps,
+  `seedInterfaceCounter`, `clearNativeXDPFlags*`, `SeedNATPortCounters`,
+  `clearAllBindingRowsLocked`, `reEnableUserspaceCtrlLocked`. There is
+  nothing to propagate to. Left alone by #6959.
+- **13 of the 17 were blind-write clear loops** and now share one body,
+  `clearArrayEntriesIn` (`maps_policy.go`), which returns the first
+  rejection naming the map and the index. It takes the same
+  `counterMapUpdater` seam #6743 introduced, because creating a real BPF
+  map returns EPERM in the unprivileged unit lane. Each call site's bound
+  is the map's declared `max_entries`, byte-identical to the inline loop
+  it replaced, so no working clear becomes an error and no sweep
+  narrowed.
+- **Two more were not clear loops but were the same defect.**
+  `SetNAT64Config`'s mirror write into `nat64_prefix_map` — the array
+  write beside it was already propagated, so a discarded mirror let the
+  two descriptions of one NAT64 prefix diverge while the caller was told
+  the whole write landed. `programBootstrapMapsLocked`'s heartbeat
+  zero-init (`userspace/maps_sync.go`) — a discarded rejection leaves the
+  slot holding the previous load's timestamp, which reads as FRESH and
+  lets the shim redirect to a worker that is not there; the
+  `userspace_ctrl` write in the same function already aborted bring-up on
+  the same class of failure.
+- **Two are DELIBERATE and stay discarded**, allowlisted with their
+  reasons in `discarded_map_update_6959_test.go`: `Compile`'s
+  `redirect_capable` write (an optimisation hint whose unset default
+  fails safe to `XDP_PASS`, on the config-commit path rather than an
+  operator clear) and `UpdatePolicyScheduleState` (the #3780 contract is
+  that it ALWAYS reports success so the scheduler self-heal never spins
+  on this retired, runtime-shadowed path).
+
+`TestNoUndocumentedDiscardedMapUpdate` gates the class. It parses the
+package WITHOUT `parser.ParseComments`, so a doc comment quoting the
+pattern cannot satisfy it; it matches both discard spellings (bare
+`zm.Update(...)` and `_ = zm.Update(...)`, four of the 32 used the
+second); it also flags a discarded call to an error-returning clear
+helper, which would otherwise launder the defect past a scan that only
+looks at `.Update`; and it asserts a NON-ZERO match count first, so a
+broken walker fails loudly instead of sweeping nothing and passing clean.
+The allowlist is compared for EXACT equality, so "fixing" a deliberate
+discard fails too.
+
+None of this fixes the DETACHED-backend false success: `Teardown()`
 closes only the link handles and `Cleanup` merely unpins, so a retained,
 torn-down `Manager` still holds live FD-backed map objects and an
 `Update` through them SUCCEEDS. A `clear` issued against a disowned

--- a/pkg/dataplane/clear_array_entries_6959_test.go
+++ b/pkg/dataplane/clear_array_entries_6959_test.go
@@ -1,0 +1,81 @@
+package dataplane
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6959: the blind-write clear loops #6743 left behind now share one body,
+// clearArrayEntriesIn, which PROPAGATES the first Update error instead of
+// discarding it. These bind that body through the same counterMapUpdater
+// seam #6743 introduced (a real *ebpf.Map cannot be created in the
+// unprivileged unit lane — map creation returns EPERM — and a test that
+// SKIPS leaves the mutation cell unknown rather than green).
+//
+// The fake is fakeCounterUpdater from counter_clear_error_2114_test.go:
+// one fake, so it cannot drift into two shapes, and
+// TestCounterMapUpdaterIsSatisfiedByEBPFMap there already pins that the
+// seam is exactly what *ebpf.Map provides.
+
+// TestClearArrayEntriesIn_PropagatesUpdateError is the binder.
+//
+// Fail-on-revert: drop the `if err := ...; err != nil { return ... }`
+// wrapper in clearArrayEntriesIn (pkg/dataplane/maps_policy.go) back to a
+// bare `zm.Update(i, zero, ebpf.UpdateAny)` and this reports a nil error
+// for a map that rejected the write.
+func TestClearArrayEntriesIn_PropagatesUpdateError(t *testing.T) {
+	t.Parallel()
+
+	up := &fakeCounterUpdater{failAt: 5, fail: true}
+	err := clearArrayEntriesIn(up, "test_map", 64, uint32(0))
+	if err == nil {
+		t.Fatal("clearArrayEntriesIn reported SUCCESS after the map rejected the write at index 5; " +
+			"the operator's clear silently did nothing")
+	}
+	if !strings.Contains(err.Error(), "test_map") {
+		t.Errorf("error %q does not name the map", err)
+	}
+	if !strings.Contains(err.Error(), "entry 5") {
+		t.Errorf("error %q does not name the rejected index", err)
+	}
+	// It must STOP at the rejection rather than blind-writing the rest:
+	// indices 0..5 inclusive, and nothing after.
+	if up.calls != 6 {
+		t.Errorf("clearArrayEntriesIn made %d writes after the index-5 rejection, want 6 (0..5); "+
+			"it kept blind-writing past a map that had already refused", up.calls)
+	}
+}
+
+// TestClearArrayEntriesIn_HealthyMapWritesEveryEntry is the OVER-REACH
+// guard: propagating an error must not change what a HEALTHY clear does.
+// A healthy map must still succeed AND still be swept end to end, so the
+// change cannot have narrowed the sweep, stopped it early, or turned a
+// working clear into an error. GREEN under the revert above.
+func TestClearArrayEntriesIn_HealthyMapWritesEveryEntry(t *testing.T) {
+	t.Parallel()
+
+	const entries = 4096
+	up := &fakeCounterUpdater{}
+	if err := clearArrayEntriesIn(up, "test_map", entries, uint32(0)); err != nil {
+		t.Fatalf("healthy clear returned %v, want nil", err)
+	}
+	if up.calls != entries || up.maxKey != entries-1 {
+		t.Fatalf("healthy clear wrote %d entries up to index %d, want %d up to %d",
+			up.calls, up.maxKey, entries, entries-1)
+	}
+}
+
+// TestClearArrayEntriesIn_ZeroEntriesIsNotAnError pins the degenerate
+// bound: an empty range is a completed clear, not a failure. Without this
+// a "fix" that returned an error on an empty sweep would look correct.
+func TestClearArrayEntriesIn_ZeroEntriesIsNotAnError(t *testing.T) {
+	t.Parallel()
+
+	up := &fakeCounterUpdater{failAt: 0, fail: true}
+	if err := clearArrayEntriesIn(up, "test_map", 0, uint32(0)); err != nil {
+		t.Fatalf("empty clear returned %v, want nil", err)
+	}
+	if up.calls != 0 {
+		t.Fatalf("empty clear made %d writes, want 0", up.calls)
+	}
+}

--- a/pkg/dataplane/compiler.go
+++ b/pkg/dataplane/compiler.go
@@ -528,6 +528,17 @@ func (m *Manager) Compile(cfg *config.Config) (*CompileResult, error) {
 				if result.tunnelIfindexes[ifidx] {
 					continue
 				}
+				// #6959 DELIBERATE DISCARD (allowlisted in
+				// discarded_map_update_6959_test.go). redirect_capable is
+				// a per-interface OPTIMISATION HINT, not policy: an unset
+				// flag makes xdp_forward take XDP_PASS and hand the packet
+				// to the kernel forwarding path instead of
+				// bpf_redirect_map, which is slower but forwards
+				// correctly. The default is unset, so a rejected write
+				// fails SAFE. This is also the config-commit path, not an
+				// operator clear — a hard error here aborts a commit over
+				// a lost performance hint. The absent-map skip above is
+				// the matching #2114 A3 optional-access contract.
 				rcMap.Update(uint32(ifidx), uint8(1), ebpf.UpdateAny)
 			}
 		}

--- a/pkg/dataplane/discarded_map_update_6959_test.go
+++ b/pkg/dataplane/discarded_map_update_6959_test.go
@@ -1,0 +1,347 @@
+package dataplane
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// #6959: an eBPF map Update whose error is DISCARDED inside a function that
+// RETURNS error is the defect this issue is about — the caller (an operator's
+// `clear ...`, a config commit) is told the write landed when the map
+// rejected it. #6743 fixed two such loops; the census behind #6959 found 15
+// more and fixed them. This guard exists so an 18th cannot appear silently.
+//
+// It is an AST scan, not a text grep, for two reasons:
+//
+//  1. A regex over the source can be satisfied by a DOC COMMENT that quotes
+//     the pattern it looks for. The Go parser is invoked without
+//     parser.ParseComments, so comments are not nodes here at all — a
+//     comment CANNOT satisfy this gate by construction.
+//  2. It must distinguish `zm.Update(...)` (discarded) from
+//     `return zm.Update(...)` and `if err := zm.Update(...)` (propagated),
+//     which is a statement-shape question a regex cannot answer.
+//
+// Both discard SPELLINGS are matched: the bare expression statement
+// `zm.Update(...)` and the explicit blank assign `_ = zm.Update(...)`. Four
+// of the 32 sites in the census used the second form, so a scan that only
+// looked for the first would have missed one member of the defect class.
+
+// discardedUpdateAllowlist is the exhaustive set of DELIBERATE discards
+// inside error-returning functions. Each entry is a claim with a reason,
+// and TestNoUndocumentedDiscardedMapUpdate asserts the reason is written at
+// the site.
+//
+// The set is checked for EXACT equality, not containment. Removing a site
+// from the source without removing it here also fails: "fixing" one of these
+// would silently change a documented best-effort contract, so it must be a
+// deliberate edit to this table.
+var discardedUpdateAllowlist = map[string]string{
+	"compiler.go:(*Manager).Compile": "redirect_capable is a per-interface optimisation HINT whose " +
+		"unset default fails safe (XDP_PASS to the kernel forwarding path), and this is the " +
+		"config-commit path, not an operator clear.",
+	"maps_policy.go:(*Manager).UpdatePolicyScheduleState": "#3780: the function's documented contract " +
+		"is that it ALWAYS reports success so the daemon's scheduler self-heal never spins on this " +
+		"retired eBPF path, which pkg/dataplane/userspace shadows at runtime.",
+}
+
+// clearArrayEntriesBounds pins the sweep bound at every clearArrayEntriesIn
+// call site. #6959 replaced ten hand-written `for i := 0; i < N; i++` loops
+// with calls to one shared body; each expression below is BYTE-IDENTICAL to
+// the bound its inline loop used at origin/master, so the conversion cannot
+// have narrowed a sweep or pointed one at the wrong map's max_entries.
+// Whitespace is normalised before comparison.
+var clearArrayEntriesBounds = map[string]string{
+	"app_ranges":        "MaxAppRanges",
+	"zone_counters":     "128",
+	"policer_configs":   "MaxPolicers",
+	"filter_configs":    "MaxFilterConfigs",
+	"screen_configs":    "64",
+	"snat_rules":        "MaxZones*MaxZones*MaxSNATRulesPerPair",
+	"snat_rules_v6":     "MaxZones*MaxZones*MaxSNATRulesPerPair",
+	"nat_pool_configs":  "32",
+	"nat64_configs":     "4",
+	"nat_rule_counters": "MaxNATRuleCounters",
+}
+
+// errorReturningClearHelpers are the same-package helpers that exist ONLY to
+// return a map-write error. Discarding one of THEM launders the defect right
+// past a scan that only looks at .Update, so they are matched too.
+var errorReturningClearHelpers = map[string]bool{
+	"clearArrayEntriesIn":      true,
+	"clearPolicyCountersIn":    true,
+	"clearFilterCountersIn":    true,
+	"clearInterfaceCountersIn": true,
+}
+
+type discardSite struct {
+	key      string // "<file>:<func>"
+	file     string
+	line     int
+	fn       string
+	callee   string
+	spelling string // "bare-expr" or "blank-assign"
+	inErrFn  bool
+}
+
+type updateScan struct {
+	totalUpdateCalls int // every .Update(...) call, discarded or not
+	filesScanned     int
+	discards         []discardSite
+	boundsSeen       map[string]string // clearArrayEntriesIn map name -> bound expr
+}
+
+// scanDirsForDiscardedUpdates parses every non-test .go file under the given
+// package directories and reports what it found. Comments are not parsed.
+func scanDirsForDiscardedUpdates(t *testing.T, dirs []string) *updateScan {
+	t.Helper()
+	sc := &updateScan{boundsSeen: map[string]string{}}
+	fset := token.NewFileSet()
+	for _, dir := range dirs {
+		ents, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read %s: %v", dir, err)
+		}
+		for _, e := range ents {
+			name := e.Name()
+			if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			path := filepath.Join(dir, name)
+			// NOTE: no parser.ParseComments — comments are not nodes, so a
+			// doc comment quoting `zm.Update(...)` cannot satisfy this gate.
+			f, err := parser.ParseFile(fset, path, nil, 0)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+			sc.filesScanned++
+			scanFile(sc, fset, f, filepath.Base(path))
+		}
+	}
+	return sc
+}
+
+func scanFile(sc *updateScan, fset *token.FileSet, f *ast.File, base string) {
+	for _, d := range f.Decls {
+		fd, ok := d.(*ast.FuncDecl)
+		if !ok || fd.Body == nil {
+			continue
+		}
+		name := fd.Name.Name
+		if fd.Recv != nil && len(fd.Recv.List) > 0 {
+			name = "(" + types.ExprString(fd.Recv.List[0].Type) + ")." + name
+		}
+		ast.Walk(&discardVisitor{sc: sc, fset: fset, base: base, fn: name, sig: fd.Type}, fd.Body)
+	}
+}
+
+type discardVisitor struct {
+	sc   *updateScan
+	fset *token.FileSet
+	base string
+	fn   string
+	sig  *ast.FuncType
+}
+
+func (v *discardVisitor) Visit(n ast.Node) ast.Visitor {
+	switch t := n.(type) {
+	case nil:
+		return nil
+	case *ast.FuncLit:
+		// A closure has its OWN return signature; walk it separately so a
+		// discard inside it is judged against the right one.
+		ast.Walk(&discardVisitor{sc: v.sc, fset: v.fset, base: v.base, fn: v.fn + ".func", sig: t.Type}, t.Body)
+		return nil
+	case *ast.CallExpr:
+		v.note(t)
+	case *ast.ExprStmt:
+		if ce, ok := t.X.(*ast.CallExpr); ok {
+			v.record(ce, t.Pos(), "bare-expr")
+		}
+	case *ast.AssignStmt:
+		if len(t.Rhs) != 1 || len(t.Lhs) == 0 {
+			return v
+		}
+		for _, l := range t.Lhs {
+			id, ok := l.(*ast.Ident)
+			if !ok || id.Name != "_" {
+				return v
+			}
+		}
+		if ce, ok := t.Rhs[0].(*ast.CallExpr); ok {
+			v.record(ce, t.Pos(), "blank-assign")
+		}
+	}
+	return v
+}
+
+// note counts every .Update call and every clearArrayEntriesIn bound,
+// independent of whether the result is discarded. The count is the
+// no-vacuous-sweep assertion: a walker that matched nothing would report
+// zero here and fail loudly instead of passing clean.
+func (v *discardVisitor) note(ce *ast.CallExpr) {
+	if se, ok := ce.Fun.(*ast.SelectorExpr); ok && se.Sel.Name == "Update" {
+		v.sc.totalUpdateCalls++
+		return
+	}
+	id, ok := ce.Fun.(*ast.Ident)
+	if !ok || id.Name != "clearArrayEntriesIn" || len(ce.Args) < 3 {
+		return
+	}
+	lit, ok := ce.Args[1].(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return
+	}
+	mapName := strings.Trim(lit.Value, `"`)
+	v.sc.boundsSeen[mapName] = strings.ReplaceAll(types.ExprString(ce.Args[2]), " ", "")
+}
+
+func (v *discardVisitor) record(ce *ast.CallExpr, pos token.Pos, spelling string) {
+	var callee string
+	switch fn := ce.Fun.(type) {
+	case *ast.SelectorExpr:
+		if fn.Sel.Name != "Update" {
+			return
+		}
+		callee = types.ExprString(fn.X) + ".Update"
+	case *ast.Ident:
+		if !errorReturningClearHelpers[fn.Name] {
+			return
+		}
+		callee = fn.Name
+	default:
+		return
+	}
+	retsErr := false
+	if v.sig != nil && v.sig.Results != nil {
+		for _, r := range v.sig.Results.List {
+			if types.ExprString(r.Type) == "error" {
+				retsErr = true
+			}
+		}
+	}
+	v.sc.discards = append(v.sc.discards, discardSite{
+		key:      v.base + ":" + v.fn,
+		file:     v.base,
+		line:     v.fset.Position(pos).Line,
+		fn:       v.fn,
+		callee:   callee,
+		spelling: spelling,
+		inErrFn:  retsErr,
+	})
+}
+
+// TestNoUndocumentedDiscardedMapUpdate is the #6959 guard.
+//
+// Fail-on-revert: restore any of the 15 fixed sites to its blind-write form
+// (for example put `zm.Update(i, empty, ebpf.UpdateAny)` back in
+// ClearScreenConfigs) and this names the file, line and function.
+//
+// Over-reach: "fix" either allowlisted site and this fails too, because the
+// allowlist is compared for EXACT equality — a documented best-effort
+// contract cannot be changed by accident.
+func TestNoUndocumentedDiscardedMapUpdate(t *testing.T) {
+	t.Parallel()
+
+	sc := scanDirsForDiscardedUpdates(t, []string{".", "userspace"})
+
+	// Anti-vacuity: a broken walker sweeps nothing and passes clean. Assert
+	// a NON-ZERO match count before believing any of the findings below.
+	if sc.filesScanned < 20 {
+		t.Fatalf("scanned only %d non-test .go files; the walker is not reaching the package", sc.filesScanned)
+	}
+	if sc.totalUpdateCalls == 0 {
+		t.Fatal("the scan matched ZERO .Update(...) calls in pkg/dataplane; the pattern is broken, " +
+			"so a clean result here means nothing was examined")
+	}
+	if len(sc.discards) == 0 {
+		t.Fatal("the scan matched ZERO discarded calls, but the two allowlisted deliberate discards " +
+			"must always be found; the discard-shape detection is broken")
+	}
+
+	got := map[string][]discardSite{}
+	var noErrReturn []discardSite
+	for _, d := range sc.discards {
+		if d.inErrFn {
+			got[d.key] = append(got[d.key], d)
+		} else {
+			noErrReturn = append(noErrReturn, d)
+		}
+	}
+
+	for key, sites := range got {
+		if _, ok := discardedUpdateAllowlist[key]; ok {
+			continue
+		}
+		for _, s := range sites {
+			t.Errorf("%s:%d %s discards the error from %s (%s) while RETURNING error.\n"+
+				"  The caller is told the map write landed when the map rejected it — the #6959 defect.\n"+
+				"  Propagate it (see clearArrayEntriesIn), or add %q to discardedUpdateAllowlist with a written reason.",
+				s.file, s.line, s.fn, s.callee, s.spelling, key)
+		}
+	}
+	for key := range discardedUpdateAllowlist {
+		if _, ok := got[key]; !ok {
+			t.Errorf("allowlisted deliberate discard %q is no longer present.\n"+
+				"  If that was intentional, the site's documented best-effort contract changed and this\n"+
+				"  entry must be removed deliberately: %s", key, discardedUpdateAllowlist[key])
+		}
+	}
+
+	// The no-error-return class is a DIFFERENT disposition (there is nothing
+	// to propagate to) and is deliberately not gated here. Reported so the
+	// population stays visible; tracked separately.
+	sort.Slice(noErrReturn, func(i, j int) bool {
+		if noErrReturn[i].file != noErrReturn[j].file {
+			return noErrReturn[i].file < noErrReturn[j].file
+		}
+		return noErrReturn[i].line < noErrReturn[j].line
+	})
+	var lines []string
+	for _, s := range noErrReturn {
+		lines = append(lines, fmt.Sprintf("  %s:%d %s (%s)", s.file, s.line, s.fn, s.spelling))
+	}
+	t.Logf("#6959 census: %d discarded map writes in functions with NO error return (not gated here):\n%s",
+		len(noErrReturn), strings.Join(lines, "\n"))
+}
+
+// TestClearArrayEntriesInCallSitesKeepTheirBounds is the second over-reach
+// guard: folding ten inline loops into one shared body must not have changed
+// how far any of them sweeps. Each bound expression must still be exactly
+// what its inline loop used at origin/master.
+func TestClearArrayEntriesInCallSitesKeepTheirBounds(t *testing.T) {
+	t.Parallel()
+
+	sc := scanDirsForDiscardedUpdates(t, []string{".", "userspace"})
+
+	if len(sc.boundsSeen) == 0 {
+		t.Fatal("found ZERO clearArrayEntriesIn call sites; the scan is broken, so a clean result " +
+			"here would certify nothing")
+	}
+	for name, want := range clearArrayEntriesBounds {
+		got, ok := sc.boundsSeen[name]
+		if !ok {
+			t.Errorf("no clearArrayEntriesIn call site clears %q; the clear loop for that map was "+
+				"removed or renamed, so its sweep is no longer bound", name)
+			continue
+		}
+		if got != want {
+			t.Errorf("clearArrayEntriesIn(%q) sweeps %s, want %s (the map's max_entries, byte-identical "+
+				"to the inline loop bound at origin/master); a narrowed sweep leaves stale entries behind",
+				name, got, want)
+		}
+	}
+	for name := range sc.boundsSeen {
+		if _, ok := clearArrayEntriesBounds[name]; !ok {
+			t.Errorf("clearArrayEntriesIn(%q) is a new call site with no pinned bound; add it to "+
+				"clearArrayEntriesBounds so its sweep cannot be narrowed silently", name)
+		}
+	}
+}

--- a/pkg/dataplane/maps_counters.go
+++ b/pkg/dataplane/maps_counters.go
@@ -341,10 +341,8 @@ func (m *Manager) ClearZoneCounters() error {
 	}
 	numCPUs := ebpf.MustPossibleCPU()
 	zero := make([]CounterValue, numCPUs)
-	for i := uint32(0); i < 128; i++ {
-		zm.Update(i, zero, ebpf.UpdateAny)
-	}
-	return nil
+	// #6959: PROPAGATE. 128 is zone_counters' max_entries.
+	return clearArrayEntriesIn(zm, "zone_counters", 128, zero)
 }
 
 // ClearAllCounters zeroes all counter maps (global, interface, zone, policy, filter).

--- a/pkg/dataplane/maps_filter.go
+++ b/pkg/dataplane/maps_filter.go
@@ -107,11 +107,8 @@ func (m *Manager) ClearPolicerConfigs() error {
 	if !present {
 		return fmt.Errorf("policer_configs map not found")
 	}
-	empty := PolicerConfig{}
-	for i := uint32(0); i < MaxPolicers; i++ {
-		zm.Update(i, empty, ebpf.UpdateAny)
-	}
-	return nil
+	// #6959: PROPAGATE. MaxPolicers is policer_configs' max_entries.
+	return clearArrayEntriesIn(zm, "policer_configs", MaxPolicers, PolicerConfig{})
 }
 
 // ClearFilterConfigs clears all filter config and rule entries.
@@ -123,11 +120,9 @@ func (m *Manager) ClearFilterConfigs() error {
 	if !present {
 		return fmt.Errorf("filter_configs not found")
 	}
+	// #6959: PROPAGATE. MaxFilterConfigs is filter_configs' max_entries.
 	var empty FilterConfig
-	for i := uint32(0); i < MaxFilterConfigs; i++ {
-		zm.Update(i, empty, ebpf.UpdateAny)
-	}
-	return nil
+	return clearArrayEntriesIn(zm, "filter_configs", MaxFilterConfigs, empty)
 }
 
 // ReadFilterCounters reads the per-CPU firewall filter counter values and sums them.

--- a/pkg/dataplane/maps_nat.go
+++ b/pkg/dataplane/maps_nat.go
@@ -87,11 +87,9 @@ func (m *Manager) ClearSNATRules() error {
 	if !present {
 		return fmt.Errorf("snat_rules map not found")
 	}
-	empty := SNATValue{}
-	for i := uint32(0); i < MaxZones*MaxZones*MaxSNATRulesPerPair; i++ {
-		zm.Update(i, empty, ebpf.UpdateAny)
-	}
-	return nil
+	// #6959: PROPAGATE. MaxZones*MaxZones*MaxSNATRulesPerPair is
+	// snat_rules' max_entries.
+	return clearArrayEntriesIn(zm, "snat_rules", MaxZones*MaxZones*MaxSNATRulesPerPair, SNATValue{})
 }
 
 // SetDNATEntryV6 writes a dnat_table_v6 entry.
@@ -166,11 +164,9 @@ func (m *Manager) ClearSNATRulesV6() error {
 	if !present {
 		return fmt.Errorf("snat_rules_v6 map not found")
 	}
-	empty := SNATValueV6{}
-	for i := uint32(0); i < MaxZones*MaxZones*MaxSNATRulesPerPair; i++ {
-		zm.Update(i, empty, ebpf.UpdateAny)
-	}
-	return nil
+	// #6959: PROPAGATE. MaxZones*MaxZones*MaxSNATRulesPerPair is
+	// snat_rules_v6' max_entries.
+	return clearArrayEntriesIn(zm, "snat_rules_v6", MaxZones*MaxZones*MaxSNATRulesPerPair, SNATValueV6{})
 }
 
 // SetNATPoolConfig writes a NAT pool configuration entry.
@@ -221,11 +217,8 @@ func (m *Manager) ClearNATPoolConfigs() error {
 	if !present {
 		return fmt.Errorf("nat_pool_configs map not found")
 	}
-	empty := NATPoolConfig{}
-	for i := uint32(0); i < 32; i++ {
-		zm.Update(i, empty, ebpf.UpdateAny)
-	}
-	return nil
+	// #6959: PROPAGATE. 32 is nat_pool_configs' max_entries.
+	return clearArrayEntriesIn(zm, "nat_pool_configs", 32, NATPoolConfig{})
 }
 
 // ClearNATPoolIPs zeroes all nat_pool_ips_v4 and nat_pool_ips_v6 entries.
@@ -247,9 +240,17 @@ func (m *Manager) ClearNATPoolIPs() error {
 	maxEntries := uint32(32 * MaxNATPoolIPsPerPool)
 	var zeroV4 uint32
 	zeroV6 := NATPoolIPV6{}
+	// #6959: PROPAGATE. Both writes stay in ONE interleaved loop rather
+	// than two clearArrayEntriesIn passes, so the visit order is byte for
+	// byte what it was before the error check was added. maxEntries is
+	// both maps' max_entries.
 	for i := uint32(0); i < maxEntries; i++ {
-		v4Map.Update(i, zeroV4, ebpf.UpdateAny)
-		v6Map.Update(i, zeroV6, ebpf.UpdateAny)
+		if err := v4Map.Update(i, zeroV4, ebpf.UpdateAny); err != nil {
+			return fmt.Errorf("clear nat_pool_ips_v4 entry %d: %w", i, err)
+		}
+		if err := v6Map.Update(i, zeroV6, ebpf.UpdateAny); err != nil {
+			return fmt.Errorf("clear nat_pool_ips_v6 entry %d: %w", i, err)
+		}
 	}
 	return nil
 }
@@ -364,7 +365,16 @@ func (m *Manager) SetNAT64Config(index uint32, cfg NAT64Config) error {
 	hm, present, _ := m.lookupMapLocked("nat64_prefix_map")
 	if present {
 		key := NAT64PrefixKey{Prefix: cfg.Prefix}
-		hm.Update(key, cfg, ebpf.UpdateAny)
+		// #6959: PROPAGATE. The array write above is already propagated;
+		// discarding this one let the two descriptions of the same NAT64
+		// prefix DIVERGE — the array holds the config, the hash map the
+		// BPF path actually looks up holds nothing — while the caller was
+		// told the whole write landed. The absent-map skip above stays
+		// deliberate (#2114 A3 optional access); only the rejected write
+		// on a map that IS present becomes an error.
+		if err := hm.Update(key, cfg, ebpf.UpdateAny); err != nil {
+			return fmt.Errorf("mirror nat64 prefix into nat64_prefix_map: %w", err)
+		}
 	}
 	return nil
 }
@@ -391,9 +401,11 @@ func (m *Manager) ClearNAT64Configs() error {
 	if !present {
 		return fmt.Errorf("nat64_configs not found")
 	}
+	// #6959: PROPAGATE. 4 == MAX_NAT64_PREFIXES is nat64_configs'
+	// max_entries.
 	var empty NAT64Config
-	for i := uint32(0); i < 4; i++ { // MAX_NAT64_PREFIXES
-		zm.Update(i, empty, ebpf.UpdateAny)
+	if err := clearArrayEntriesIn(zm, "nat64_configs", 4, empty); err != nil {
+		return err
 	}
 	// Clear the hash map
 	if hm, present, _ := m.lookupMapLocked("nat64_prefix_map"); present {
@@ -480,10 +492,9 @@ func (m *Manager) ClearNATRuleCounters() error {
 	}
 	numCPUs := ebpf.MustPossibleCPU()
 	zero := make([]CounterValue, numCPUs)
-	for i := uint32(0); i < MaxNATRuleCounters; i++ {
-		zm.Update(i, zero, ebpf.UpdateAny)
-	}
-	return nil
+	// #6959: PROPAGATE. MaxNATRuleCounters is nat_rule_counters'
+	// max_entries.
+	return clearArrayEntriesIn(zm, "nat_rule_counters", MaxNATRuleCounters, zero)
 }
 
 // ReadNATPortCounter reads the per-CPU NAT port allocation counter for a pool

--- a/pkg/dataplane/maps_policy.go
+++ b/pkg/dataplane/maps_policy.go
@@ -223,11 +223,8 @@ func (m *Manager) ClearAppRanges() error {
 	if !present {
 		return fmt.Errorf("app_ranges map not found")
 	}
-	zero := AppRangeEntry{}
-	for i := uint32(0); i < MaxAppRanges; i++ {
-		zm.Update(i, zero, ebpf.UpdateAny)
-	}
-	return nil
+	// #6959: PROPAGATE. MaxAppRanges is app_ranges' max_entries.
+	return clearArrayEntriesIn(zm, "app_ranges", MaxAppRanges, AppRangeEntry{})
 }
 
 // ClearZonePairPolicies zeros all zone-pair policy entries.
@@ -246,7 +243,12 @@ func (m *Manager) ClearZonePairPolicies() error {
 	iter := zm.Iterate()
 	for iter.Next(&key, &val) {
 		if val.NumRules > 0 {
-			zm.Update(key, zeroPS, ebpf.UpdateAny)
+			// #6959: PROPAGATE. The keys come from the map's own
+			// iterator, so every one is in range by construction and
+			// no working clear becomes an error.
+			if err := zm.Update(key, zeroPS, ebpf.UpdateAny); err != nil {
+				return fmt.Errorf("clear zone_pair_policies entry %d: %w", key, err)
+			}
 		}
 	}
 	return nil
@@ -324,6 +326,13 @@ func (m *Manager) UpdatePolicyScheduleState(_ *config.Config, activeState map[st
 		}
 		if rule.Active != newActive {
 			rule.Active = newActive
+			// #6959 DELIBERATE DISCARD (allowlisted in
+			// discarded_map_update_6959_test.go). The #3780 contract in
+			// this function's doc comment is that it ALWAYS reports
+			// success so the daemon's scheduler self-heal never spins on
+			// a dead path; this is the retired eBPF map, shadowed at
+			// runtime by pkg/dataplane/userspace. Propagating here would
+			// break that contract, not fix a defect.
 			zm.Update(idx, rule, ebpf.UpdateAny)
 			slog.Info("policy schedule state updated",
 				"policy", slot.PolicyName,
@@ -384,6 +393,30 @@ func (m *Manager) clearPolicyCountersRaw() error {
 // on a comment alone. *ebpf.Map satisfies it as declared.
 type counterMapUpdater interface {
 	Update(key, value any, flags ebpf.MapUpdateFlags) error
+}
+
+// clearArrayEntriesIn zeroes entries [0, entries) of a BPF ARRAY map and
+// PROPAGATES the first Update error, naming the map and the index.
+//
+// #6959: this is the shared body of the blind-write clear loops that #6743
+// left behind. Each of them ran `zm.Update(i, zero, ebpf.UpdateAny)` as a
+// bare statement, so an operator's `clear ...` reported success no matter
+// how many slots the map actually rejected — a detached map, a permissions
+// failure, or a size mismatch was indistinguishable from a completed clear.
+// It takes the same counterMapUpdater seam #6743 introduced because
+// creating a real BPF map returns EPERM in the unprivileged unit lane, so
+// the propagation contract is otherwise untestable.
+//
+// The bound is always the map's declared max_entries (see each call site),
+// so no index can be out of range on an armed map and no WORKING clear
+// becomes an error.
+func clearArrayEntriesIn(zm counterMapUpdater, mapName string, entries uint32, zero any) error {
+	for i := uint32(0); i < entries; i++ {
+		if err := zm.Update(i, zero, ebpf.UpdateAny); err != nil {
+			return fmt.Errorf("clear %s entry %d: %w", mapName, i, err)
+		}
+	}
+	return nil
 }
 
 // clearPolicyCountersIn zeroes every policy_counters slot.

--- a/pkg/dataplane/maps_screen.go
+++ b/pkg/dataplane/maps_screen.go
@@ -33,11 +33,8 @@ func (m *Manager) ClearScreenConfigs() error {
 	if !present {
 		return fmt.Errorf("screen_configs map not found")
 	}
-	empty := ScreenConfig{}
-	for i := uint32(0); i < 64; i++ {
-		zm.Update(i, empty, ebpf.UpdateAny)
-	}
-	return nil
+	// #6959: PROPAGATE. 64 is screen_configs' max_entries.
+	return clearArrayEntriesIn(zm, "screen_configs", 64, ScreenConfig{})
 }
 
 // UpdateSessionCountSrc writes a per-source-IP session count entry.

--- a/pkg/dataplane/userspace/maps_sync.go
+++ b/pkg/dataplane/userspace/maps_sync.go
@@ -217,8 +217,19 @@ func (m *Manager) programBootstrapMapsLocked(snapshot *ConfigSnapshot, cfg confi
 		// loss cluster. Every un-zeroed slot keeps whatever stale value it
 		// held. The bound the loop actually uses is the only thing worth
 		// pinning, so it is the only thing written.
+		//
+		// #6959: the Update error is PROPAGATED, matching the
+		// userspace_ctrl write above which already aborts bring-up on the
+		// same class of failure. A DISCARDED rejection here leaves the
+		// slot holding the previous load's timestamp, which reads as
+		// FRESH and lets the shim redirect to a worker that is not there
+		// — the exact hazard the #6702 bound fix above closed. The bound
+		// is the Array's own MaxEntries(), so no in-range write turns
+		// into a spurious bring-up failure.
 		for slot := uint32(0); slot < plan.HeartbeatSlots; slot++ {
-			_ = heartbeatMap.Update(slot, zeroHB, ebpf.UpdateAny)
+			if err := heartbeatMap.Update(slot, zeroHB, ebpf.UpdateAny); err != nil {
+				return fmt.Errorf("zero userspace heartbeat slot %d: %w", slot, err)
+			}
 		}
 	}
 	return m.syncUserspaceClassifierMapsLocked(snapshot)


### PR DESCRIPTION
Closes #6959. Advances #2114.

## Census first — the issue names 4, the population is 17

The issue lists four sibling clear loops. Before fixing them I ran an AST
census over every **discarded** `Update` in non-test `pkg/dataplane` +
`pkg/dataplane/userspace`, matching **both** discard spellings — the bare
expression statement `zm.Update(...)` and the explicit blank assign
`_ = zm.Update(...)`. Four of the sites use the second spelling, so a scan
that only looked for the first would have missed one member of the defect
class outright.

**32 discarded map writes, splitting 17 / 15** on whether the enclosing
function returns `error`.

## The 17 are NOT homogeneous

13 are blind-write clear loops. The other four are not, and they were read
individually:

| site | verdict | reason |
|---|---|---|
| `maps_nat.go:367` `SetNAT64Config` | **FIXED — same defect** | This is the *mirror* write into `nat64_prefix_map`, the map the BPF path actually looks up. The array write nine lines above is already propagated, so a discarded mirror let the two descriptions of one NAT64 prefix **diverge** — array holds the config, hash map holds nothing — while the caller was told the whole write landed. Strictly worse than a no-op clear: it is a *partial* write reported as complete. |
| `userspace/maps_sync.go:221` `programBootstrapMapsLocked` | **FIXED — same defect** | Zeroing a heartbeat slot is what makes the shim refuse to redirect until userspace starts updating it. A discarded rejection leaves the slot holding the **previous load's timestamp**, which reads as FRESH and lets the shim redirect to a worker that is not there — the exact hazard the #6702 bound fix in that same block closed. The `userspace_ctrl` write three lines above already aborts bring-up on the same class of failure, so this was an asymmetry, not a policy. |
| `compiler.go:531` `Compile` | **DECLINED — deliberate** | `redirect_capable` is a per-interface **optimisation hint**, not policy: unset means `xdp_forward` takes `XDP_PASS` to the kernel forwarding path — slower, still correct. The default is unset, so a rejected write **fails safe**. It is also the config-**commit** path, not an operator clear; hard-failing aborts a commit over a lost performance hint. |
| `maps_policy.go:327` `UpdatePolicyScheduleState` | **DECLINED — deliberate** | The function's own doc comment carries an explicit #3780 contract: *"It always reports success (nil) so the daemon's scheduler self-heal never spins on a dead path."* This is the retired eBPF map, shadowed at runtime by `pkg/dataplane/userspace`. Propagating here would **break** that contract, not fix a defect. |

Both declined sites now carry the reason inline and are allowlisted by name.

## What changed

Ten of the 13 clear loops now share one body, `clearArrayEntriesIn`, which
returns the first rejection naming the map and the index. It takes the same
`counterMapUpdater` seam #6743 introduced (creating a real BPF map returns
EPERM in the unprivileged unit lane, so the contract is otherwise
untestable). Two are wrapped inline instead because they are not the uniform
shape: `ClearZonePairPolicies` is iterator-driven and conditional, and
`ClearNATPoolIPs` writes two maps in one loop — kept **interleaved** rather
than split into two passes, so its visit order is byte for byte what it was.

Every bound is the map's declared `max_entries`, unchanged from the inline
loop it replaced, so no working clear becomes an error.

## The 15 with no error return — reported, not fixed

A different disposition: there is nothing to propagate to. Listed here so the
class is visible rather than silently widened, and printed by the guard on
every run.

```
loader.go:704             seedInterfaceCounter            (_ = )
loader.go:1061            clearNativeXDPFlags
loader.go:1091            clearNativeXDPFlagsForIfindexes
maps_nat.go:528           SeedNATPortCounters
maps_stale.go:82          DeleteStaleZonePairPolicies
maps_stale.go:136         DeleteStaleSNATRules
maps_stale.go:167         DeleteStaleSNATRulesV6
maps_stale.go:288         DeleteStaleNAT64
maps_stale.go:315         ZeroStaleScreenConfigs
maps_stale.go:325/333/341 ZeroStaleNATPoolConfigs (x3)
maps_stale.go:377         ZeroStaleFilterConfigs
userspace/maps_sync.go:557        clearAllBindingRowsLocked      (_ = )
userspace/process_linkcycle.go:117 reEnableUserspaceCtrlLocked   (_ = )
```

Whether the `maps_stale.go` sweeps are a real defect class is a separate
question — a stale entry that fails to zero stays live in the dataplane — and
wants its own issue rather than a silent widening here.

## The guard

`TestNoUndocumentedDiscardedMapUpdate` exists so an 18th cannot appear
silently. It is a **parser**, not a regex:

- Parsed **without** `parser.ParseComments`, so comments are not nodes at
  all — a doc comment quoting the pattern **cannot** satisfy this gate by
  construction. (A regex attempt is also what errored out during triage.)
- Matches **both** discard spellings, and distinguishes `zm.Update(...)`
  from `return zm.Update(...)` / `if err := zm.Update(...)` — a
  statement-shape question a regex cannot answer.
- Also flags a discarded call to an error-returning clear **helper**, which
  would otherwise launder the defect straight past a scan that only looks at
  `.Update` (bound by cell M10).
- Asserts a **NON-ZERO match count** in three places — files scanned, total
  `Update` calls seen, total discards found — before believing any clean
  result, so a broken walker fails loudly instead of sweeping nothing and
  passing green. Cell **M11** is the paired cell proving that assertion is
  load-bearing, not decoration.
- The allowlist is compared for **EXACT equality**, so *removing* a
  deliberate discard fails too (cell M9).

`TestClearArrayEntriesInCallSitesKeepTheirBounds` pins every call site's
sweep bound to the expression its inline loop used at `origin/master`, so
folding ten loops into one body cannot have narrowed a sweep.

## Mutation matrix

Per cell: **one** mutation, **full package** `./pkg/dataplane/`, `-count=1`,
**no `-run` filter**, worktree verified clean before and after each cell.
Control collected **387** tests, 0 failures. Every cell collected **387/387**
— matching the control, so no cell is a build break wearing a red's clothes.
Every verdict names the failing test, and the three subtlest were re-run to
confirm *which assertion* fired.

| cell | mutation | verdict | collected | named failing test(s) |
|---|---|---|---|---|
| M1 | `clearArrayEntriesIn` propagation → blind write | RED | 387/387 | `TestClearArrayEntriesIn_PropagatesUpdateError`, `TestNoUndocumentedDiscardedMapUpdate` |
| M2 | `ClearScreenConfigs` → inline blind-write loop | RED | 387/387 | `TestClearArrayEntriesInCallSitesKeepTheirBounds`, `TestNoUndocumentedDiscardedMapUpdate` |
| M3 | `ClearZonePairPolicies` wrap → blind write | RED | 387/387 | `TestNoUndocumentedDiscardedMapUpdate` |
| M4 | `SetNAT64Config` mirror wrap → blind write | RED | 387/387 | `TestNoUndocumentedDiscardedMapUpdate` |
| M5 | `ClearNATPoolIPs` **v6 leg only** → blind write | RED | 387/387 | `TestNoUndocumentedDiscardedMapUpdate` |
| M6 | `programBootstrapMapsLocked` → `_ =` | RED | 387/387 | `TestNoUndocumentedDiscardedMapUpdate` |
| M7 | **over-reach**: narrow `screen_configs` sweep 64→32 | RED | 387/387 | `TestClearArrayEntriesInCallSitesKeepTheirBounds` |
| M8 | **over-reach**: `clearArrayEntriesIn` stops halfway | RED | 387/387 | `TestClearArrayEntriesIn_HealthyMapWritesEveryEntry` |
| M9 | **over-reach**: propagate the *deliberate* `UpdatePolicyScheduleState` discard | RED | 387/387 | `TestNoUndocumentedDiscardedMapUpdate` |
| M10 | call site discards the **helper's** error | RED | 387/387 | `TestNoUndocumentedDiscardedMapUpdate` |
| M11 | **anti-vacuity**: blind the walker's `Update` matcher | RED | 387/387 | `TestNoUndocumentedDiscardedMapUpdate` |

M5 is deliberately **localised** to one of the two legs in `ClearNATPoolIPs`
— a compound mutation of both would have let the bound leg mask the other.

Assertion provenance for the three that matter:

```
M9  → :292 allowlisted deliberate discard "maps_policy.go:(*Manager).UpdatePolicyScheduleState"
          is no longer present.
M11 → :265 the scan matched ZERO discarded calls, but the two allowlisted deliberate
          discards must always be found; the discard-shape detection is broken
M6  → :284 maps_sync.go:230 (*Manager).programBootstrapMapsLocked discards the error from
          heartbeatMap.Update (blank-assign) while RETURNING error.
```

## Known bound of the guard

A new discarded `Update` placed in a **void** helper that an error-returning
function then calls would not be flagged — the guard reasons about the
immediately enclosing function's signature, not the call graph. Closing that
needs type/call-graph analysis; noted rather than silently assumed away.

## Validation

- `go build ./...` clean, `gofmt` clean, `go vet ./pkg/dataplane/` clean.
- `go test ./... -count=1` — **68 ok, 0 FAIL**, 6 packages with no test files.
  Re-run after merging `origin/master` (11 commits, no `pkg/dataplane`
  overlap): same result.
- Docs updated in the same change: `pkg/dataplane/README.md` §"Map-write
  error propagation" now carries the 17/15 split, the two declined sites with
  their reasons, and what the guard can and cannot see. Action log at
  `docs/log/6959.md`.

## Still out of scope

The DETACHED-backend false success remains untouched and #6741 remains open:
after `Teardown()` the map fds stay open, so an `Update` genuinely succeeds
against a map no loaded program reads. Error propagation cannot see that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jzDG7fbMYNJVKDMWDeuMg
