### PR TITLE
daemon: do not sweep sessions admitted after the policy set went live

### DIFF
--- a/docs/log/6948.md
+++ b/docs/log/6948.md
@@ -1,0 +1,29 @@
+# #6948 — commit-time deletion-clear over-clears a session on a reused policy id
+
+- **Timestamp**: 2026-08-27
+  - **Action**: Runtime policy ids are positional, so deleting a policy renumbers
+    every later one. The invalidation sweep computes its id set from the OLD
+    config's numbering but runs after `applyConfigLocked` returns, while the
+    dataplane admits under the NEW numbering from the moment the apply publishes
+    it — so a session admitted in that window by a policy that inherited a
+    deleted policy's id was swept although correctly permitted. Stamped
+    `d.policyActivationSecs` immediately before the dataplane publishes
+    (placement is the design: earlier would let genuinely-deleted-policy sessions
+    escape the sweep, the stale-authorization direction), and the shared
+    `clearSessionsForPolicyIDs` now skips rows `Created` strictly after it, for
+    both address families.
+  - **Correction to the issue**: it states the defect is "not fixable by refining
+    the sweep predicate" because the row carries no config epoch or stable rule
+    identity. True as far as it goes, but the row does carry `Created` — "seconds
+    since boot" on the BPF side, `CLOCK_MONOTONIC` seconds on the Go side, the
+    same clock — and the codebase already uses `Created >= threshold` as a
+    before/after discriminator for the incremental sync sweep.
+  - **Residual, not closed**: `Created` has one-second granularity, so a session
+    created in the same integer second as the stamp is ambiguous and is still
+    cleared (fail-safe: under-clear is a stale-authorization gap). This narrows
+    the over-clear from the entire post-activation apply — tail included, easily
+    seconds — to at most one second. Closing it fully still needs an admission
+    fence or a stable admitting-rule identity on the row.
+  - **File(s)**: `pkg/daemon/daemon.go`, `pkg/daemon/daemon_apply.go`,
+    `pkg/daemon/daemon_policy_invalidate.go`,
+    `pkg/daemon/policy_reused_id_overclear_6948_test.go`, `docs/log/6948.md`

--- a/docs/log/6948.md
+++ b/docs/log/6948.md
@@ -24,6 +24,11 @@
     the over-clear from the entire post-activation apply — tail included, easily
     seconds — to at most one second. Closing it fully still needs an admission
     fence or a stable admitting-rule identity on the row.
+  - **Found by the matrix**: the first four cells all set `policyActivationSecs`
+    directly, so deleting the production assignment in `applyConfigLocked` left
+    every one of them green — the guard would have gone permanently inert with
+    the whole file passing. Added a wiring cell that drives `applyConfigLocked`
+    and asserts the stamp advanced.
   - **File(s)**: `pkg/daemon/daemon.go`, `pkg/daemon/daemon_apply.go`,
     `pkg/daemon/daemon_policy_invalidate.go`,
     `pkg/daemon/policy_reused_id_overclear_6948_test.go`, `docs/log/6948.md`

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -440,6 +440,34 @@ type Daemon struct {
 	// unchanged-config reconcile should nevertheless re-apply. Mutated under
 	// applySem like the two fields above.
 	lldpUnresolved []string
+	// policyActivationSecs is CLOCK_MONOTONIC seconds captured immediately
+	// BEFORE the dataplane apply publishes a new policy set (#6948).
+	//
+	// Runtime policy ids are POSITIONAL (policySetID*MaxRulesPerPolicy +
+	// ruleIndex), so deleting a policy renumbers every later one. The
+	// commit-time invalidation sweep computes its id set from the OLD config's
+	// numbering but runs AFTER applyConfigLocked returns — and the dataplane
+	// admits sessions under the NEW numbering the moment the apply publishes it.
+	// A session admitted in that window by a policy that INHERITED a deleted
+	// policy's id matches the sweep set and is dropped although it is correctly
+	// permitted.
+	//
+	// The window is not a few instructions: the policy set goes live in
+	// applyDataplaneAndHACore, and the sweep does not run until the whole
+	// remainder of applyConfigLocked has finished, including applyTailReconciles
+	// (DNS, sudoers, sshd, IPsec, VRRP, FRR). That is easily seconds on a real
+	// box.
+	//
+	// Session rows carry no config epoch and no stable admitting-rule identity,
+	// but they DO carry Created — "seconds since boot" on the BPF side
+	// (bpf/headers/xpf_common.h) and CLOCK_MONOTONIC seconds on the Go side
+	// (daemonMonotonicSeconds), the SAME clock. So a session created strictly
+	// after this stamp was admitted under the new numbering and must not be
+	// swept by an old-numbering id set.
+	//
+	// Mutated under applySem like the fields above, and read by the sweep the
+	// same commit's caller runs while still holding it.
+	policyActivationSecs uint64
 	// scheduler is the live policy-window scheduler. It is an atomic.Pointer so
 	// the metrics collector can read it lock-free for the
 	// xpf_scheduler_republish_fail_closed SSOT gauge

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -424,6 +424,13 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// networkd write error for the routing rules + tail reconcile below; an
 	// error (a #2926 context abort or an ApplyConfig compile abort) bails
 	// before the tail.
+	// #6948: stamp the admission boundary IMMEDIATELY before the dataplane
+	// publishes the new policy set. Placement is the whole design: captured any
+	// earlier and sessions admitted under the OLD numbering by the policy being
+	// deleted would fall after the stamp and escape the sweep, which is the
+	// stale-authorization direction and strictly worse than the over-clear this
+	// closes. Captured here, that gap is the call itself.
+	d.policyActivationSecs = daemonMonotonicSeconds()
 	commitOverlay, networkdErr, applyErr, err := d.applyDataplaneAndHACore(ctx, cfg)
 	if err != nil {
 		// #5643 (M35): applyDataplaneAndHACore bailed at a #2926 ctx-cancellation

--- a/pkg/daemon/daemon_policy_invalidate.go
+++ b/pkg/daemon/daemon_policy_invalidate.go
@@ -322,9 +322,35 @@ func (d *Daemon) clearSessionsForPolicyIDs(ids map[uint32]struct{}, reason datap
 	// cleared sessions forwarding while logging an apparently-clean invalidation.
 	// Surface it loudly and suppress the success line so the partial clear is
 	// observable, not masked (Copilot #4320).
+	// #6948: the id set was computed from the OLD config's numbering, and
+	// runtime policy ids are POSITIONAL — deleting a policy renumbers every
+	// later one. The dataplane starts admitting under the NEW numbering as soon
+	// as the apply publishes it, which happens long before this sweep runs, so a
+	// session admitted in between by a policy that INHERITED a deleted policy's
+	// id matches `ids` and would be dropped while correctly permitted.
+	//
+	// admittedAfterActivation is the discriminator. It is STRICTLY greater on
+	// purpose: Created has one-second granularity, so a session created in the
+	// same integer second as the stamp is ambiguous, and an ambiguous session is
+	// still cleared — the direction this code already chose (over-clear is
+	// fail-safe for security; under-clear is a stale-authorization gap).
+	//
+	// That leaves a residual: this narrows the over-clear from the entire
+	// post-activation apply, tail included, to at most one second. It does not
+	// eliminate it, and nothing here should be read as claiming otherwise —
+	// closing it fully needs either an admission fence across
+	// activation->invalidation or a stable admitting-rule identity on the row.
+	activationSecs := d.policyActivationSecs
+	admittedAfterActivation := func(created uint64) bool {
+		return activationSecs != 0 && created > activationSecs
+	}
+
 	var v4Entries []dataplane.SessionEntryV4
 	v4EnumErr := store.ForEachV4(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
 		if val.IsReverse != 0 {
+			return true
+		}
+		if admittedAfterActivation(val.Created) {
 			return true
 		}
 		if _, hit := ids[val.PolicyID]; hit {
@@ -336,6 +362,11 @@ func (d *Daemon) clearSessionsForPolicyIDs(ids map[uint32]struct{}, reason datap
 	var v6Entries []dataplane.SessionEntryV6
 	v6EnumErr := store.ForEachV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
 		if val.IsReverse != 0 {
+			return true
+		}
+		// #6948: same boundary as v4. Both families must apply it or the defect
+		// simply moves to the other address family.
+		if admittedAfterActivation(val.Created) {
 			return true
 		}
 		if _, hit := ids[val.PolicyID]; hit {

--- a/pkg/daemon/policy_reused_id_overclear_6948_test.go
+++ b/pkg/daemon/policy_reused_id_overclear_6948_test.go
@@ -1,0 +1,207 @@
+package daemon
+
+// policy_reused_id_overclear_6948_test.go — #6948.
+//
+// Runtime policy ids are POSITIONAL (policySetID*MaxRulesPerPolicy +
+// ruleIndex), so deleting a policy renumbers every later one:
+//
+//	C1 = [A, B, C]  ->  A=0, B=1, C=2
+//	delete B
+//	C2 = [A, C]     ->  A=0, C=1        <- C INHERITED B's id
+//	deletion set     =  { B's old id } = { 1 }
+//
+// The commit path publishes the new policy set inside applyConfigLocked and
+// only runs the invalidation sweep after the WHOLE apply returns — tail
+// included. The dataplane admits under the new numbering from the moment of
+// publication, so a session admitted in that window under C carries policy_id 1
+// and is swept as though it were B: a correctly-permitted session dropped by an
+// unrelated policy's deletion.
+//
+// d.policyActivationSecs is stamped immediately before publication, and the
+// sweep skips rows Created strictly after it. Created is "seconds since boot"
+// on the BPF side and CLOCK_MONOTONIC seconds on the Go side — the same clock.
+//
+// RESIDUAL, asserted below rather than left to prose: Created has ONE-SECOND
+// granularity, so a session created in the same integer second as the stamp is
+// ambiguous and is still cleared. This narrows the over-clear from the entire
+// post-activation apply to at most one second; it does not eliminate it.
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// reusedIDFixture builds the worked example: p-web deleted, p-ssh inherits its
+// runtime id. It asserts the inheritance rather than assuming it — if the id
+// allocator ever stopped renumbering, every cell here would pass for the wrong
+// reason.
+func reusedIDFixture6948(t *testing.T) (oldCfg, newCfg *config.Config, deletedID uint32) {
+	t.Helper()
+	o := twoPolicyConfig([]string{"p-first", "p-web", "p-ssh"}, nil)
+	n := twoPolicyConfig([]string{"p-first", "p-ssh"}, nil)
+
+	oldIDs := dpuserspace.PolicyIDsByStableKey(o)
+	newIDs := dpuserspace.PolicyIDsByStableKey(n)
+	webOld := oldIDs["trust->untrust/p-web"]
+	sshNew := newIDs["trust->untrust/p-ssh"]
+
+	if webOld != sshNew {
+		t.Fatalf("precondition: this cell needs p-ssh to INHERIT deleted p-web's "+
+			"runtime id, which is what makes the over-clear possible. "+
+			"p-web(old)=%d p-ssh(new)=%d — ids are no longer positional, so "+
+			"re-derive #6948 before trusting these cells", webOld, sshNew)
+	}
+	return o, n, webOld
+}
+
+// TestFreshSessionOnInheritedIDIsNotSwept6948 is the defect.
+//
+// FAIL-ON-REVERT: drop the admittedAfterActivation guard from
+// clearSessionsForPolicyIDs and this reds — the post-activation session is
+// deleted although p-ssh, which admitted it, still exists.
+func TestFreshSessionOnInheritedIDIsNotSwept6948(t *testing.T) {
+	oldCfg, newCfg, reusedID := reusedIDFixture6948(t)
+
+	const activation = 1000
+	// Admitted AFTER the new policy set went live: this is a p-ssh session that
+	// merely inherited the id p-web used to hold.
+	fresh := dataplane.SessionKey{
+		SrcIP: [4]byte{10, 0, 0, 9}, DstIP: [4]byte{10, 0, 0, 2},
+		SrcPort: 41001, DstPort: 22, Protocol: 6,
+	}
+	dp := &policyInvalTestDP{
+		v4: map[dataplane.SessionKey]dataplane.SessionValue{
+			fresh: {State: dataplane.SessStateEstablished, PolicyID: reusedID, Created: activation + 5},
+		},
+	}
+	d := &Daemon{}
+	d.setDataplane(dp)
+	d.policyActivationSecs = activation
+
+	if err := d.clearSessionsForDeletedPolicies(oldCfg, newCfg); err != nil {
+		t.Fatalf("clearSessionsForDeletedPolicies: %v", err)
+	}
+
+	if _, ok := dp.v4[fresh]; !ok {
+		t.Fatal("a session admitted AFTER the new policy set went live was swept by an " +
+			"OLD-numbering deletion set: it carries the deleted policy's id only " +
+			"because a surviving policy inherited that id. A correctly-permitted " +
+			"session was dropped by an unrelated policy's deletion (#6948)")
+	}
+}
+
+// TestPreActivationSessionIsStillSwept6948 is the OVER-REACH cell, and the
+// reason it exists is that the previous cell alone is satisfied by a guard that
+// refuses to clear ANYTHING.
+//
+// A session admitted BEFORE activation under the genuinely-deleted policy must
+// still be cleared. Failing to clear it is a STALE-AUTHORIZATION gap — traffic
+// the new config no longer permits keeps forwarding — which is strictly worse
+// than the over-clear this change fixes.
+func TestPreActivationSessionIsStillSwept6948(t *testing.T) {
+	oldCfg, newCfg, deletedID := reusedIDFixture6948(t)
+
+	const activation = 1000
+	stale := dataplane.SessionKey{
+		SrcIP: [4]byte{10, 0, 0, 1}, DstIP: [4]byte{10, 0, 0, 2},
+		SrcPort: 40001, DstPort: 80, Protocol: 6,
+	}
+	dp := &policyInvalTestDP{
+		v4: map[dataplane.SessionKey]dataplane.SessionValue{
+			stale: {State: dataplane.SessStateEstablished, PolicyID: deletedID, Created: activation - 30},
+		},
+	}
+	d := &Daemon{}
+	d.setDataplane(dp)
+	d.policyActivationSecs = activation
+
+	if err := d.clearSessionsForDeletedPolicies(oldCfg, newCfg); err != nil {
+		t.Fatalf("clearSessionsForDeletedPolicies: %v", err)
+	}
+
+	if _, ok := dp.v4[stale]; ok {
+		t.Fatal("a session admitted BEFORE activation under the DELETED policy survived " +
+			"the sweep. The #6948 guard is over-broad: it is refusing to clear " +
+			"sessions the deletion-clear exists to remove, which is a stale-" +
+			"authorization gap and worse than the over-clear it was added to fix")
+	}
+}
+
+// TestSameSecondSessionIsStillSwept6948 pins the RESIDUAL rather than leaving it
+// to a comment that a later change could quietly invalidate.
+//
+// Created has one-second granularity, so a session created in the same integer
+// second as the activation stamp cannot be placed on either side of it. It is
+// still cleared — the direction this code already chose, since over-clear is
+// fail-safe for security and under-clear is a stale-authorization gap.
+//
+// If someone later switches the predicate to `>=`, this cell reds and tells
+// them they have traded a bounded availability bug for a security one.
+func TestSameSecondSessionIsStillSwept6948(t *testing.T) {
+	oldCfg, newCfg, deletedID := reusedIDFixture6948(t)
+
+	const activation = 1000
+	ambiguous := dataplane.SessionKey{
+		SrcIP: [4]byte{10, 0, 0, 7}, DstIP: [4]byte{10, 0, 0, 2},
+		SrcPort: 40007, DstPort: 80, Protocol: 6,
+	}
+	dp := &policyInvalTestDP{
+		v4: map[dataplane.SessionKey]dataplane.SessionValue{
+			ambiguous: {State: dataplane.SessStateEstablished, PolicyID: deletedID, Created: activation},
+		},
+	}
+	d := &Daemon{}
+	d.setDataplane(dp)
+	d.policyActivationSecs = activation
+
+	if err := d.clearSessionsForDeletedPolicies(oldCfg, newCfg); err != nil {
+		t.Fatalf("clearSessionsForDeletedPolicies: %v", err)
+	}
+
+	if _, ok := dp.v4[ambiguous]; ok {
+		t.Fatal("a session created in the SAME second as the activation stamp survived. " +
+			"Created has one-second granularity so that session is genuinely " +
+			"ambiguous, and the ambiguous case must fail SAFE (cleared): an " +
+			"under-clear is a stale-authorization gap. Switching the predicate to " +
+			">= trades a bounded availability bug for a security one (#6948)")
+	}
+}
+
+// TestUnstampedActivationClearsAsBefore6948 is the compatibility floor.
+//
+// policyActivationSecs is zero on any path that reaches the sweep without going
+// through applyConfigLocked (tests, and any future caller). Zero must mean "no
+// boundary known", falling back to the pre-#6948 behaviour of clearing every
+// matching id — NOT to skipping everything, which would silently disable the
+// deletion-clear wherever the stamp is missing.
+func TestUnstampedActivationClearsAsBefore6948(t *testing.T) {
+	oldCfg, newCfg, deletedID := reusedIDFixture6948(t)
+
+	sess := dataplane.SessionKey{
+		SrcIP: [4]byte{10, 0, 0, 1}, DstIP: [4]byte{10, 0, 0, 2},
+		SrcPort: 40001, DstPort: 80, Protocol: 6,
+	}
+	dp := &policyInvalTestDP{
+		v4: map[dataplane.SessionKey]dataplane.SessionValue{
+			// A Created far in the future: with no stamp it must be irrelevant.
+			sess: {State: dataplane.SessStateEstablished, PolicyID: deletedID, Created: 999999},
+		},
+	}
+	d := &Daemon{}
+	d.setDataplane(dp)
+	// policyActivationSecs deliberately left 0.
+
+	if err := d.clearSessionsForDeletedPolicies(oldCfg, newCfg); err != nil {
+		t.Fatalf("clearSessionsForDeletedPolicies: %v", err)
+	}
+
+	if _, ok := dp.v4[sess]; ok {
+		t.Fatal("with no activation stamp the deletion-clear skipped a matching session. " +
+			"An unstamped boundary must degrade to the pre-#6948 behaviour (clear " +
+			"everything matching), or the guard silently disables the deletion-clear " +
+			"on every path that does not set it (#6948)")
+	}
+}


### PR DESCRIPTION
Refs #6948

The race is **narrowed, not eliminated** — the residual is stated below and pinned by a test, so this stays open.

## Re-derived at current master first

The issue was verified at `b8b39a16a`; master has moved a long way. Every cite re-read with `git show origin/master:<path>`:

| claim | status |
|---|---|
| positional ids `policySetID*MaxRulesPerPolicy + ruleIndex` | **holds**, `policies.go` |
| apply publishes the policy set **before** the sweep runs | **holds** |
| deletion set computed from the OLD numbering | **holds** |
| `policy_id == 0` excluded, incidentally protecting the first slot | **holds** |
| `clearSessionsForPolicyChanges` is the sweep entry point | **renamed** — it is `reportSessionAuthorizationChanges` since #5858 |

## The window is not a few instructions

That matters, because it is the difference between a theoretical race and an ordinary one. The policy set goes live in `applyDataplaneAndHACore`; the sweep does not run until the **whole remainder of `applyConfigLocked`** has finished — including `applyTailReconciles` (DNS, sudoers, sshd, IPsec, VRRP, FRR). That is comfortably seconds on a real box, so a policy delete on a firewall carrying traffic is enough.

## Where the issue is too strong, and what it enables

The issue says this is *"not fixable by refining the sweep predicate"* because the row carries neither a config epoch nor a stable admitting-rule identity. **Both are true and the conclusion does not follow.** The row carries `Created`:

- `bpf/headers/xpf_common.h`: `__u32 created; /* session creation time (seconds since boot) */`
- `daemonMonotonicSeconds()`: `CLOCK_MONOTONIC`, `.Sec`

**The same clock** — and `docs/session-sync-architecture.md` already uses `Created >= threshold` as a before/after discriminator for the incremental sync sweep.

So: stamp `policyActivationSecs` immediately before publication, and skip rows `Created` **strictly after** it.

**Placement is the whole design.** Stamped any earlier, sessions admitted under the OLD numbering by the policy being deleted would fall after the stamp and escape the sweep — a stale-authorization gap, strictly worse than the over-clear being fixed. Stamped there, that gap is the call itself.

Applied in the shared `clearSessionsForPolicyIDs`, so deletion, policy-rematch and default-policy-change all get it, and to **both** address families — otherwise the defect just moves to the other one.

## Residual — why this does not close the issue

`Created` has **one-second granularity**, so a session created in the same integer second as the stamp cannot be placed on either side of it. It is still cleared: the ambiguous case fails **safe**, because an under-clear is a stale-authorization gap and an over-clear is not.

Net: the over-clear window shrinks from *the entire post-activation apply* to **at most one second**. Closing it fully still needs an admission fence across activation→invalidation, or stable admitting-rule identity on the row — the two directions the issue proposes.

`TestSameSecondSessionIsStillSwept6948` pins that residual, so switching the predicate to `>=` reds and tells the next author they have traded a bounded availability bug for a security one.

## Test plan

- [x] `pkg/daemon/policy_reused_id_overclear_6948_test.go` — 5 cells.
- [x] **Mutation matrix**, full package `go test ./pkg/daemon/ -count=1`, **no `-run` filter**, fix committed **before** mutating, gated on collected-test count so a build break cannot read as a pass (control **2161**):

  | mutation | result | collected |
  |---|---|---|
  | guard removed (the shipped over-clear) | **RED** — `TestFreshSessionOnInheritedIDIsNotSwept6948` | 2161 |
  | **over-reach**: clear nothing after activation | **RED** — `TestPreActivationSessionIsStillSwept6948`, `TestSameSecondSessionIsStillSwept6948` | 2161 |
  | boundary flipped to `>=` | **RED** — `TestSameSecondSessionIsStillSwept6948` | 2161 |
  | zero stamp skips everything | **RED** — `TestUnstampedActivationClearsAsBefore6948` | 2161 |
  | stamp never taken at activation | **RED** — `TestActivationStampIsWiredIntoTheApply6948` | 2162 |

  **The last row is the one the matrix earned.** It was **GREEN** at first: all four original cells set `policyActivationSecs` directly, so deleting the production assignment in `applyConfigLocked` left every one of them passing — the guard would have gone permanently inert with the whole file green. The wiring cell was added because of that, and the deletion now reds it at collected **2162**, one *above* control, so it is a real failure rather than a collection drop wearing one.

  The over-reach row is the second half of the pair: without it, "do not clear after activation" is satisfied by a guard that refuses to clear anything, which is the stale-authorization direction.

- [x] `go build ./... && go test -count=1 ./...` → **rc 0, 68/68 packages, 0 failures**, at HEAD `a81adc1b3`, with `origin/master ea7fef0a7` merged in and `merge-base --is-ancestor` **verified (rc 1)**. Re-gated AFTER the fold.

  **Both runs reported.** An earlier `./...` went red on `TestStartHeartbeatDoesNotRaceStopHeartbeat7257` (`pkg/cluster`) and `TestAutoArchiveCapturesCommittedTreeNoOverwrite` (`pkg/configstore`) — neither package is in this diff, the second passes 5/5 isolated, and the first is the known load-sensitive one. A separate earlier run hit `TestApplyWithoutOverlayChangeDoesNotActuate` (`pkg/ipmon`), whose fixture samples an asynchronous actuation at a **fixed `time.Sleep(60 * time.Millisecond)`** (`ipmon_test.go:894,904`) — the #7650 class, a different test in the same file as the one already known.

- [ ] **No smoke owed.** Go control-plane only; no Rust dataplane change, so the helper binary does not move.

## Refs

Refs #6948 — the residual above means this issue stays open. Related: #4626 (the id-0 overload whose exclusions incidentally protect the first slot), #4234, #5858, #7650 (the fixed-wall-clock-sample class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1PvkJxs7KrzEdyC9u1LDu
