### PR TITLE
cos/waterfill: bind the Phase-2 wrap tail (#6958)

### DIFF
--- a/docs/log/6958.md
+++ b/docs/log/6958.md
@@ -1,0 +1,33 @@
+# #6958 — bind the cos/waterfill Phase-2 wrap tail
+
+- **Timestamp**: 2026-08-28
+  - **Action**: re-derived the issue's reachability claim at master rather than
+    trusting it, because "reached but never checked" is a claim in the
+    direction where a wrong answer means the new test exercises dead code.
+    Substituted `panic!("WRAP TAIL REACHED")` for the tail and ran the full bin
+    suite: **4705 passed, exactly 1 failed** —
+    `waterfill_guarantee_rate_skips_non_exact_queues`, which reaches the tail
+    incidentally and asserts nothing about its effects. Reached once, checked
+    never, confirmed.
+  - **File(s)**: none (measurement)
+
+- **Timestamp**: 2026-08-28
+  - **Action**: added the binding cell. It asserts the three writes
+    individually so a partial loss localizes, and then the CONSEQUENCE those
+    writes buy — that the call PAST the wrap resumes selection. Asserting only
+    the field values would pin plumbing; the resumption is what makes the tail
+    matter, since losing it leaves the honored bitset uncleared and every
+    Phase-1-honored class skipped by both phases.
+  - **File(s)**: userspace-dp/src/afxdp/cos/queue_service/tests/waterfill.rs
+
+- **Timestamp**: 2026-08-28
+  - **Action**: two fixture decisions that are load-bearing rather than
+    incidental. **Time is frozen** (`now_ns` constant): `epoch_boundary =
+    time_refresh || waterfill_epoch_wrap_pending` has TWO sources, so a clock
+    allowed past `COS_GUARANTEE_VISIT_NS` clears the honored bits on its own
+    and the cell would pass with the tail deleted — measuring the fallback
+    rather than the fix. And the **wrap is asserted as a measured
+    precondition** (drive until `None`, assert it happened) rather than assumed
+    from a loop count, since a fixture stopping one call short of the tail
+    exercises none of this.
+  - **File(s)**: userspace-dp/src/afxdp/cos/queue_service/tests/waterfill.rs

--- a/userspace-dp/src/afxdp/cos/queue_service/tests/waterfill.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests/waterfill.rs
@@ -912,3 +912,113 @@ fn waterfill_phase2_cursor_resumes_instead_of_restarting_at_the_largest() {
          re-serving it"
     );
 }
+
+/// #6958: the Phase-2 WRAP tail arms the epoch boundary, and the next call
+/// resumes selection.
+///
+/// The tail — three writes and a `None` at the end of
+/// `select_exact_cos_guarantee_queue_waterfill` — had ZERO binding coverage.
+/// Deleting all three left the whole bin suite green, and a `panic!` probe in
+/// its place fails exactly one test
+/// (`waterfill_guarantee_rate_skips_non_exact_queues`), which reaches the tail
+/// incidentally while asserting nothing about its effects. Reached once,
+/// checked never. Re-derived at master before writing this.
+///
+/// What the writes are FOR: `epoch_boundary = time_refresh ||
+/// waterfill_epoch_wrap_pending` in `refill_waterfill_epoch` is what clears
+/// `waterfill_honored_epoch_bits`. Lose the tail and `pass1_remaining` stays
+/// non-zero (so the `exhausted` trigger never fires), `epoch_wrap_pending`
+/// stays false, the honored bitset is never cleared, and every class honored
+/// in Phase 1 is skipped by BOTH phases — a `guarantee-rate` interface with
+/// fully backlogged queues goes idle for up to a whole epoch, silently, with
+/// no counter recording it.
+///
+/// TIME IS FROZEN, and that is the load-bearing fixture decision. `now_ns` is
+/// passed as a constant so `elapsed_since_refresh` stays 0 and `time_refresh`
+/// can never fire. `epoch_boundary` has two sources; if the clock is allowed
+/// to advance past `COS_GUARANTEE_VISIT_NS`, the time tick clears the honored
+/// bits on its own and this test passes whether or not the tail exists —
+/// measuring the fallback rather than the fix.
+#[test]
+fn waterfill_phase2_wrap_arms_epoch_boundary_and_resumes_6958() {
+    // Frozen: every call uses this same instant.
+    const NOW_NS: u64 = 1;
+    const TOKENS: u64 = 128 * 1024;
+
+    let mut root = test_mixed_class_root_with_primed_queues();
+    root.oversubscription_policy = CoSOversubscriptionPolicy::GuaranteeRate;
+    root.oversubscription_guarantee_fraction = 0.5;
+    root.exact_queues_by_rate_ascending = (0..root.queues.len())
+        .filter(|&idx| root.queues[idx].config.exact && root.queues[idx].config.guarantee_enabled)
+        .collect();
+    let prime = |root: &mut CoSInterfaceRuntime| {
+        for queue in &mut root.queues {
+            if queue.config.exact {
+                queue.hot.tokens = TOKENS;
+            }
+        }
+    };
+    prime(&mut root);
+
+    // Drive until the selector actually WRAPS. The wrap is asserted as a
+    // measured precondition rather than assumed from a loop count: a fixture
+    // that stops one call short of the tail exercises none of this and would
+    // pass with the tail deleted.
+    let mut wrapped = false;
+    for _ in 0..64 {
+        let mut tel = CoSQueueLeaseAcquireTelemetry::default();
+        if select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], NOW_NS, &mut tel)
+            .is_none()
+        {
+            wrapped = true;
+            break;
+        }
+    }
+    assert!(
+        wrapped,
+        "fixture never reached the Phase-2 wrap tail, so nothing below is being \
+         measured (#6958)"
+    );
+
+    // The three writes, individually, so a partial loss localizes.
+    assert_eq!(
+        root.waterfill_pass1_remaining_bytes, 0,
+        "the wrap must zero pass1_remaining; left non-zero, refill_waterfill_epoch's \
+         `exhausted` trigger never fires and the epoch never refills (#6958)"
+    );
+    assert_eq!(
+        root.waterfill_phase2_cursor, 0,
+        "the wrap must reset the Phase-2 cursor — it is the ONLY site that does, \
+         and neither refill path touches it (#1743 r2)"
+    );
+    assert!(
+        root.waterfill_epoch_wrap_pending,
+        "the wrap must arm epoch_wrap_pending; it is what makes the next refill a \
+         genuine epoch boundary and clears the honored bitset (#6958)"
+    );
+
+    // The CONSEQUENCE, which is why those three writes exist. Asserting the
+    // fields alone pins plumbing; this pins the behaviour they buy.
+    //
+    // Re-prime tokens first: after the drain the queues are empty, and a `None`
+    // from an out-of-tokens queue would look identical to a `None` from an
+    // unarmed epoch boundary. Without this the assertion could fail for a
+    // reason that has nothing to do with the tail.
+    prime(&mut root);
+    let mut tel = CoSQueueLeaseAcquireTelemetry::default();
+    let resumed =
+        select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], NOW_NS, &mut tel);
+    assert!(
+        resumed.is_some(),
+        "the selector stayed idle after the wrap. With the clock frozen, the ONLY \
+         thing that can clear waterfill_honored_epoch_bits is the epoch boundary the \
+         wrap tail arms — so every class honored in Phase 1 is now skipped by both \
+         phases and a fully backlogged guarantee-rate interface transmits nothing \
+         until the 200us tick (#6958)"
+    );
+    assert!(
+        !root.waterfill_epoch_wrap_pending,
+        "the refill must consume epoch_wrap_pending; leaving it armed would clear the \
+         honored bitset on every subsequent refill, not just at a genuine boundary"
+    );
+}

--- a/userspace-dp/src/afxdp/cos/queue_service/tests/waterfill.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests/waterfill.rs
@@ -960,6 +960,19 @@ fn waterfill_phase2_wrap_arms_epoch_boundary_and_resumes_6958() {
     };
     prime(&mut root);
 
+    // Seed the Phase-2 cursor NON-ZERO, and that is not decoration.
+    //
+    // The cursor legitimately persists across epochs — the wrap tail is its
+    // only reset, so the descending walk advances continuously (#1743 r2), and
+    // a non-zero cursor is ordinary steady state. Starting it at 0 makes the
+    // `phase2_cursor == 0` assertion below VACUOUS: a full descending cycle
+    // returns the cursor to where it began, so 0 holds whether or not the tail
+    // writes it. Measured — with the cursor seeded at 0 this cell PASSED with
+    // `root.waterfill_phase2_cursor = 0` deleted from the tail, and the
+    // mutation matrix is what exposed it. Seeded at 1, the walk arrives at the
+    // tail still holding 1, so only the write can produce 0.
+    root.waterfill_phase2_cursor = 1;
+
     // Drive until the selector actually WRAPS. The wrap is asserted as a
     // measured precondition rather than assumed from a loop count: a fixture
     // that stops one call short of the tail exercises none of this and would

--- a/userspace-dp/src/afxdp/cos/queue_service/tests/waterfill.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests/waterfill.rs
@@ -935,10 +935,20 @@ fn waterfill_phase2_cursor_resumes_instead_of_restarting_at_the_largest() {
 ///
 /// TIME IS FROZEN, and that is the load-bearing fixture decision. `now_ns` is
 /// passed as a constant so `elapsed_since_refresh` stays 0 and `time_refresh`
-/// can never fire. `epoch_boundary` has two sources; if the clock is allowed
-/// to advance past `COS_GUARANTEE_VISIT_NS`, the time tick clears the honored
-/// bits on its own and this test passes whether or not the tail exists —
-/// measuring the fallback rather than the fix.
+/// can never fire. `epoch_boundary` has TWO sources, and the wrap is only one
+/// of them.
+///
+/// Measured, not reasoned. With the tail deleted and the resumption assertion
+/// isolated:
+///
+///   frozen  `now_ns`                -> FAILS  (the assertion has teeth)
+///   thawed  `now_ns + 10_000_000`   -> PASSES (the time tick clears the
+///                                              honored bits by itself)
+///
+/// So a version of this cell written with a running clock would have been
+/// toothless in exactly the way it looks rigorous: it would exercise the wrap,
+/// reach the resumption, and pass on the fallback path with the code under
+/// test deleted.
 #[test]
 fn waterfill_phase2_wrap_arms_epoch_boundary_and_resumes_6958() {
     // Frozen: every call uses this same instant.


### PR DESCRIPTION
Closes #6958

Test-only. The wrap tail at the end of `select_exact_cos_guarantee_queue_waterfill` — three writes and a `None` — had **zero binding coverage**: deleting all three left the entire bin suite green.

## Reachability re-derived at master before writing anything

"Reached but never checked" is a claim in the direction where being wrong means the new test exercises dead code, so I re-measured rather than trusting the issue. Substituting `panic!("WRAP TAIL REACHED")` for the tail:

```
4705 passed; 1 failed
FAILED: waterfill_guarantee_rate_skips_non_exact_queues
WRAP TAIL REACHED
```

Exactly one test reaches it, incidentally, asserting nothing about its effects. Reached once, checked never — confirmed.

## What the cell binds

The three writes individually, so a partial loss localizes rather than producing one undifferentiated red — and then the **consequence** they buy: the call *past* the wrap resumes selection.

That second half is the load-bearing one. Asserting field values pins plumbing; the resumption pins what the tail is *for*. `epoch_boundary = time_refresh || waterfill_epoch_wrap_pending` is what clears `waterfill_honored_epoch_bits`. Lose the tail and `pass1_remaining` stays non-zero so the refill's `exhausted` trigger never fires, `epoch_wrap_pending` stays false, the bitset is never cleared, and every class honored in Phase 1 is skipped by **both** phases — a `guarantee-rate` interface with fully backlogged queues goes idle for up to a whole epoch, silently, with no counter recording it.

## Two fixture decisions, both measured rather than assumed

**Time is frozen**, and I proved that matters instead of asserting it. With the tail deleted and the resumption assertion isolated from the clock-independent field checks:

| clock | result |
|---|---|
| frozen `now_ns` | **FAILS** — the assertion has teeth |
| thawed `now_ns + 10_000_000` | **PASSES** — the time tick clears the bitset by itself |

A version written with a running clock would exercise the wrap, reach the resumption, and pass with the code under test deleted: rigorous in shape, empty in substance.

**The wrap is a measured precondition** — the cell drives until the selector returns `None` and asserts that it did, rather than assuming a loop count reaches the tail.

## The matrix caught a vacuous assertion of mine — second commit

Deleting `root.waterfill_phase2_cursor = 0` left the first version of the cell **green**.

The cursor persists across epochs by design (the wrap tail is its only reset, which is what lets the descending walk advance continuously, #1743 r2). A fresh root starts it at 0, and a full descending cycle returns it to where it began — so with the fixture at 0, `cursor == 0` at the tail holds whether or not the write happens. **The fixture was supplying the value the assertion checked for.**

Measured rather than reasoned: instrumenting the tail printed `cursor_at_wrap=0` for the original fixture and `cursor_at_wrap=1` when seeded at 1. Seeding non-zero is also the more representative state — a steady-state interface reaches the wrap mid-walk.

## Mutation matrix

Fix committed before mutating, and again before each mid-matrix correction.

| # | mutation | result |
|---|---|---|
| **W3** | delete all three writes (the issue's own cell) | **RED** — 1 named, `...wrap_arms_epoch_boundary_and_resumes_6958`. Left the suite **green** before this PR |
| **N1** | reorder the three writes (semantically null) | **GREEN** — negative control: the cell measures this code, not "any edit fails" |
| M-a | delete `pass1_remaining = 0` | **RED** by name |
| M-b | delete `phase2_cursor = 0` | **RED** by name *(escaped before the fixture fix — see above)* |
| M-c | delete `epoch_wrap_pending = true` | **RED** by name |
| fixture | tail deleted + clock thawed, resumption isolated | **PASSES** — which is why the clock is frozen |

## Test plan

- [x] `cargo test --bins --tests -- --test-threads=1` → **rc 0, 4837 passed, 0 failed**
- [x] `go test ./... -count=1` → **68/68**
- [x] `cargo fmt` — my two files carry **21** diffs, identical to the count at a detached `origin/master` baseline, so no new drift
- [x] `origin/master` folded; ancestry verified

**No documentation change.** The tail's behaviour is already described where it lives (the #1743 r2/r3 notes in `queue_service/mod.rs`); this adds coverage of it rather than changing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhHmVt536ZsY2RVEhc8WPV
