### PR TITLE
config: gate derived per-unit tunnel device names

### DIFF
--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -275,6 +275,58 @@ still boots but the overwrite is no longer silent. The fix is a GATE, not a
 remapping: `LinuxIfName`'s mapping is unchanged, so every existing
 single-name config compiles exactly as before.
 
+**The authored interface-name set is NOT the kernel device-name set (#6964).**
+The #5832 gate above compares AUTHORED names only, which is not the whole
+population of device names a config claims. A logical unit that carries its own
+`tunnel` stanza gets its OWN Linux device, named by `compileInterfaces` as the
+interface's canonical name plus `u<unit>` for unit > 0 and stored verbatim in
+`unit.Tunnel.Name`. So `gr-0/0/0 unit 1` needs the device `gr-0-0-0u1`, which is
+byte-identical to the canonical name of an interface an operator is free to
+author as `gr-0/0/0u1` — `u` and digits are ordinary allowed characters
+(`ValidateInterfaceName`, #6834). The two AUTHORED keys (`gr-0/0/0u1` and
+`gr-0/0/0`) are distinct, so the authored-only walk never saw them touch and the
+config compiled with `err == nil`.
+
+The consequence is at the routing layer. `pkg/routing` keys ALL of its
+per-device state by `TunnelConfig.Name` (`tunnel.go`): the desired/owned set
+(`desired[tc.Name]`), the applied-address set (`appliedAddrs[tc.Name]`), the
+VRF claim (`appliedRI[tc.Name]`), and the keepalive runner. The two records
+collapse to ONE entry in `desired` and then reconcile the SAME device TWICE
+within one `Apply`. The second pass runs `reconcileLinkAddrsLocked` against the
+first pass's applied set, which `AddrDel`s every non-link-local address on the
+device that is absent from the second record's `Addresses` — the two records
+delete each other's addresses off the shared device — and rewrites its VRF
+claim and keepalive runner on top. Which record is "second" is the
+`cfg.Interfaces.Interfaces` MAP order (`collectAppliedTunnels`, `pkg/daemon`),
+and BOTH orders were observed within a single process (measured 174/26 over 200
+calls), so there is no stable winner.
+
+Scope of that claim, checked rather than assumed: the endpoint-comparing
+delete+recreate in `applyKernelTunnelLocked` (`legacyTunnelMatches`) is NOT the
+production path — the daemon always sets `AnchorOnly`, so `applyAnchorLocked`
+runs and `anchorReusable` ignores tunnel endpoints, reusing the TUN in place.
+The name-keyed address / VRF / keepalive overwrite is common to both paths; the
+additional link flap belongs to the standalone-CLI path only.
+
+`validateInterfaceNameCollisionStrict` therefore compares the EFFECTIVE
+DEVICE-NAME SET: every authored canonical name PLUS every per-unit tunnel
+device name, with the same IFNAMSIZ length check applied to the derived name
+(a base that fits can have a `u<unit>` derivative that does not, and that
+device silently never materializes). Two rules keep it from over-rejecting:
+
+- a unit whose tunnel device name IS its interface's own canonical name is
+  SKIPPED — that is `unit 0`, which collapses onto the base device by design;
+  reporting it would refuse the ordinary single-tunnel config.
+- the walk reads the compiler-ASSIGNED `unit.Tunnel.Name` rather than
+  re-deriving `base + "u" + N`, so the gate cannot drift from the naming scheme
+  it polices.
+
+Same strict/lenient split as #5832 (`opts.lenientIfNameCollision`): the shape
+was reachable in an already-committed config, so the tolerant load / peer-sync
+path WARNS naming the collision rather than bricking a config that predates the
+gate (#1960). The tolerant path makes the collision visible; it does not repair
+it.
+
 **Present-but-nil interface/unit slots — walk via `RangeInterfaces` /
 `RangeUnits` (#5813).** The tolerant load / HA config-sync path admits a
 present-key/nil-value `InterfaceConfig` (`cfg.Interfaces.Interfaces["ge-0/0/0"]

--- a/pkg/config/compiler_validate_strict_ifname_collision.go
+++ b/pkg/config/compiler_validate_strict_ifname_collision.go
@@ -40,6 +40,50 @@ const maxLinuxIfNameLen = 15
 // The fix is a GATE, not a remapping: LinuxIfName's mapping is unchanged, so
 // every existing single-name config (the overwhelming common case, where an
 // authored name has no colliding sibling) compiles exactly as before.
+//
+// #6964 — THE AUTHORED SET IS NOT THE DEVICE SET. An authored interface name is
+// not the only way a kernel device name enters the config. A logical unit that
+// carries its own `tunnel` stanza gets its OWN Linux device, named by the
+// compiler as the interface's canonical name plus "u<unit>" for unit > 0
+// (compiler_interfaces.go, stored verbatim in unit.Tunnel.Name). So the DERIVED
+// device name of `gr-0/0/0 unit 1` is `gr-0-0-0u1`, which is byte-identical to
+// the canonical name of an interface an operator is free to author as
+// `gr-0/0/0u1` — `u` and digits are ordinary allowed characters
+// (ValidateInterfaceName, #6834), and the two AUTHORED keys (`gr-0/0/0u1` and
+// `gr-0/0/0`) are distinct, so the authored-only walk above never sees them
+// touch.
+//
+// Measured on origin/master before this gate was widened: that pair compiles
+// with err == nil and yields TWO *TunnelConfig records carrying the SAME
+// Name="gr-0-0-0u1" and DIFFERENT Source/Destination.
+//
+// The consequence is at the ROUTING layer. pkg/routing keys ALL of its
+// per-device state by TunnelConfig.Name: the desired/owned set
+// (`desired[tc.Name]`), the applied-address set (`appliedAddrs[tc.Name]`), the
+// VRF claim (`appliedRI[tc.Name]`), and the keepalive runner. So the two
+// records collapse to ONE entry in `desired` and then reconcile the SAME device
+// TWICE within one Apply. The second pass runs reconcileLinkAddrsLocked against
+// the first pass's applied set, which AddrDels every non-link-local address on
+// the device that is absent from the second record's Addresses — the two
+// records delete each other's addresses off the shared device — and rewrites
+// its VRF claim and keepalive runner on top.
+//
+// And which record is "second" is not fixed: collectAppliedTunnels (pkg/daemon)
+// walks the cfg.Interfaces.Interfaces MAP, and BOTH orders were observed within
+// a single process (174/26 over 200 calls). So this is not merely "one config
+// silently wins" — there is no stable winner.
+//
+// Scope of that claim, checked rather than assumed: the endpoint-comparing
+// delete+recreate in applyKernelTunnelLocked (legacyTunnelMatches) is NOT the
+// production path. The daemon always sets AnchorOnly, so applyAnchorLocked runs
+// instead, and anchorReusable ignores tunnel endpoints — the TUN is reused in
+// place. The name-keyed address / VRF / keepalive overwrite above is common to
+// both paths; the additional link flap belongs to the standalone-CLI path only.
+//
+// So the gate compares the EFFECTIVE DEVICE-NAME SET: every authored canonical
+// name PLUS every per-unit tunnel device name. Both halves share the strict /
+// lenient split, so a config already committed with this shape still boots with
+// a warning naming the collision rather than bricking (#1960).
 func validateInterfaceNameCollisionStrict(cfg *Config) error {
 	if cfg == nil {
 		return nil
@@ -82,6 +126,87 @@ func validateInterfaceNameCollisionStrict(cfg *Config) error {
 				earlier, name, linux, name)
 		}
 		firstByLinux[linux] = name
+	}
+
+	// Second pass: the DERIVED per-unit tunnel device names (#6964).
+	//
+	// The device name is read from unit.Tunnel.Name — the value the compiler
+	// actually assigned — rather than re-deriving base + "u" + N here. Binding
+	// to the assigned value means the gate cannot drift from the naming scheme
+	// it is policing: if compiler_interfaces.go ever changes how a per-unit
+	// tunnel device is named, this walk follows for free, where a re-derivation
+	// would silently start checking a name nothing creates.
+	//
+	// A unit whose tunnel device name IS the interface's own canonical name is
+	// SKIPPED, not reported. That is unit 0: `unit 0 { tunnel }` deliberately
+	// collapses onto the base device, which the authored pass above already
+	// claimed for this same interface. Reporting it would reject the ordinary
+	// single-tunnel config — every `gr-0/0/0 unit 0 tunnel` in the tree — which
+	// is the over-rejection this gate must not commit.
+	derivedOwner := make(map[string]string)
+	for _, name := range names {
+		ifc := cfg.Interfaces.Interfaces[name]
+		if ifc == nil {
+			continue
+		}
+		base := LinuxIfName(name)
+		unitNums := make([]int, 0, len(ifc.Units))
+		for unitNum := range ifc.Units {
+			unitNums = append(unitNums, unitNum)
+		}
+		sort.Ints(unitNums)
+		for _, unitNum := range unitNums {
+			unit := ifc.Units[unitNum]
+			if unit == nil || unit.Tunnel == nil || unit.Tunnel.Name == "" {
+				continue
+			}
+			dev := unit.Tunnel.Name
+			if dev == base {
+				// Unit 0: shares the interface's own device by design.
+				continue
+			}
+			ref := fmt.Sprintf("%s.%d", name, unitNum)
+			if len(dev) > maxLinuxIfNameLen {
+				return fmt.Errorf(
+					"per-unit tunnel %s needs Linux device name %q (%d bytes), over the "+
+						"kernel IFNAMSIZ limit of %d bytes; the device name is the "+
+						"interface's canonical name plus \"u<unit>\", so the kernel cannot "+
+						"create it and the tunnel endpoint would silently never "+
+						"materialize — shorten the interface name or renumber the unit",
+					ref, dev, len(dev), maxLinuxIfNameLen)
+			}
+			if owner, ok := firstByLinux[dev]; ok {
+				return fmt.Errorf(
+					"interface %q and per-unit tunnel %s both resolve to the same Linux "+
+						"device name %q (a unit>0 tunnel device is the interface's canonical "+
+						"name plus \"u<unit>\"); pkg/routing keys the device's addresses, "+
+						"VRF claim and keepalive by that name, so the two would reconcile ONE "+
+						"kernel device twice per commit and delete each other's addresses off "+
+						"it — and the order is the interface map's, so there is no stable "+
+						"winner — rename one of the two",
+					owner, ref, dev)
+			}
+			// REACHABILITY, stated honestly: this derived-vs-derived branch
+			// cannot fire today and therefore carries no test cell. A device
+			// name decomposes uniquely into base + "u" + <digits> (split at the
+			// last 'u' followed only by digits), so two per-unit tunnels can
+			// only collide when their BASES collide — and colliding bases are
+			// caught by the authored pass above, which returns first. It is
+			// retained rather than deleted because this walk reads the
+			// compiler-ASSIGNED unit.Tunnel.Name instead of re-deriving it: a
+			// future change to the per-unit device-naming scheme (a separator
+			// other than "u", a non-numeric suffix) would break the uniqueness
+			// argument, and the hole must not reopen silently.
+			if other, ok := derivedOwner[dev]; ok {
+				return fmt.Errorf(
+					"per-unit tunnels %s and %s both resolve to the same Linux device name "+
+						"%q (a unit>0 tunnel device is the interface's canonical name plus "+
+						"\"u<unit>\"); they would reconcile ONE kernel device twice per "+
+						"commit, with no stable winner — rename one of the two interfaces",
+					other, ref, dev)
+			}
+			derivedOwner[dev] = ref
+		}
 	}
 	return nil
 }

--- a/pkg/config/ifname_collision_derived_unit_6964_test.go
+++ b/pkg/config/ifname_collision_derived_unit_6964_test.go
@@ -1,0 +1,217 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6964: the authored interface-name set is NOT the kernel device-name set. A
+// logical unit carrying its own `tunnel` stanza gets its OWN Linux device, named
+// by the compiler as the interface's canonical name plus "u<unit>" for unit > 0.
+// So `gr-0/0/0 unit 1` needs the device `gr-0-0-0u1`, which is byte-identical to
+// the canonical name of an interface an operator may author as `gr-0/0/0u1`.
+// The two AUTHORED keys are distinct (`gr-0/0/0u1` vs `gr-0/0/0`), so the #5832
+// authored-only walk never sees them touch and the config compiled clean.
+//
+// These tests pin BOTH halves of the widened gate: it must REJECT the derived
+// collision, and it must not start rejecting the ordinary per-unit tunnel
+// configs that share a base device by design.
+
+// collidingDerivedUnitSets is the #6964 vector. The two colliding records are
+// given DIFFERENT tunnel endpoints deliberately: if both sides carried the same
+// source/destination the collapse onto one device would be invisible — the
+// single surviving device would be indistinguishable from the intended one and
+// a consequence assertion could not fail. The differing endpoints are what make
+// "one device, two intents" observable.
+func collidingDerivedUnitSets() []string {
+	return []string{
+		// Interface authored literally as the derived name of the unit below.
+		"set interfaces gr-0/0/0u1 tunnel source 10.0.0.1",
+		"set interfaces gr-0/0/0u1 tunnel destination 10.0.0.2",
+		// Distinct authored interface whose unit 1 tunnel DERIVES gr-0-0-0u1.
+		"set interfaces gr-0/0/0 unit 1 tunnel source 10.1.0.1",
+		"set interfaces gr-0/0/0 unit 1 tunnel destination 10.1.0.2",
+	}
+}
+
+// TestDerivedUnitDeviceCollisionStrictReject_6964 is the RED-on-revert guard:
+// a strict commit of the pair must HARD-REJECT, naming the authored interface,
+// the unit ref, and the shared Linux device.
+//
+// FAIL-ON-REVERT: dropping the derived-name pass from
+// validateInterfaceNameCollisionStrict makes CompileConfig return nil here, so
+// the reject assertion fires RED. The #5832 authored-only pass cannot cover
+// this — `gr-0/0/0u1` and `gr-0/0/0` canonicalize to DIFFERENT names.
+func TestDerivedUnitDeviceCollisionStrictReject_6964(t *testing.T) {
+	tree := flatTreeFromSets(t, collidingDerivedUnitSets()...)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("strict CompileConfig accepted an interface whose canonical name is the DERIVED per-unit tunnel device of another interface (#6964 silent shared device)")
+	}
+	for _, want := range []string{"gr-0/0/0u1", "gr-0/0/0.1", "gr-0-0-0u1"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("collision error %q does not name %q", err, want)
+		}
+	}
+}
+
+// TestDerivedUnitDeviceCollisionLenientWarns_6964 pins the compatibility
+// decision. The shape is reachable in an ALREADY-COMMITTED config (nothing ever
+// rejected it), so the widened gate inherits the #5832 strict/lenient split: the
+// tolerant load / peer-sync path WARNS instead of failing, and the warning names
+// the collision so the shared device is visible rather than silent.
+//
+// FAIL-ON-REVERT: hard-rejecting on the lenient path (dropping the
+// opts.lenientIfNameCollision downgrade, or gating outside it) makes the load
+// error → RED, which is the brick this project refuses (#1960).
+func TestDerivedUnitDeviceCollisionLenientWarns_6964(t *testing.T) {
+	tree := flatTreeFromSets(t, collidingDerivedUnitSets()...)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("tolerant load must NOT reject a grandfathered derived-device collision (brick-on-restart): %v", err)
+	}
+	for _, want := range []string{"gr-0/0/0u1", "gr-0/0/0.1", "gr-0-0-0u1"} {
+		if !hasWarningSubstr(cfg.Warnings, want) {
+			t.Errorf("tolerant load must warn naming %q, warnings=%v", want, cfg.Warnings)
+		}
+	}
+}
+
+// TestDerivedUnitDeviceCollisionConsequence_6964 is the SEVERITY statement, and
+// it is what makes the reject worth having. The tolerant path does not repair
+// the collision — it only makes it visible — so the compiled config still
+// carries the damage, and this reads it directly out of the typed config.
+//
+// Two config objects, one device name, two DIFFERENT tunnel endpoints. pkg/
+// routing keys its desired tunnel set by TunnelConfig.Name, so these are one
+// kernel device with two independent intents.
+func TestDerivedUnitDeviceCollisionConsequence_6964(t *testing.T) {
+	tree := flatTreeFromSets(t, collidingDerivedUnitSets()...)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("tolerant load: %v", err)
+	}
+	ifTun := cfg.Interfaces.Interfaces["gr-0/0/0u1"]
+	if ifTun == nil || ifTun.Tunnel == nil {
+		t.Fatalf("fixture did not build the interface-level tunnel: %+v", cfg.Interfaces.Interfaces["gr-0/0/0u1"])
+	}
+	base := cfg.Interfaces.Interfaces["gr-0/0/0"]
+	if base == nil || base.Units[1] == nil || base.Units[1].Tunnel == nil {
+		t.Fatalf("fixture did not build the per-unit tunnel: %+v", base)
+	}
+	unitTun := base.Units[1].Tunnel
+	if ifTun.Tunnel.Name != unitTun.Name {
+		t.Fatalf("fixture no longer collides: interface device %q vs unit device %q — the gate under test would be exercised on a non-colliding input",
+			ifTun.Tunnel.Name, unitTun.Name)
+	}
+	if ifTun.Tunnel.Name != "gr-0-0-0u1" {
+		t.Errorf("shared device name = %q, want %q", ifTun.Tunnel.Name, "gr-0-0-0u1")
+	}
+	// The endpoints MUST differ, or the collision would be unobservable and
+	// every assertion above would hold just as well on a correct config.
+	if ifTun.Tunnel.Source == unitTun.Source {
+		t.Fatalf("fixture is blind: both records carry source %q, so one device serving two intents is indistinguishable from one correct record", ifTun.Tunnel.Source)
+	}
+}
+
+// TestDerivedUnitDeviceOverlengthStrictReject_6964 covers the sibling hazard on
+// the same derived name: an authored name whose canonical form FITS IFNAMSIZ but
+// whose "u<unit>" derivative does not. The kernel cannot create that device, so
+// the tunnel endpoint silently never materializes — the same failure the #5832
+// authored-name length check exists to prevent, one derivation later.
+//
+// LinuxIfName("gr-0/0/1234567") == "gr-0-0-1234567" == 14 bytes (accepted), and
+// the unit-1 device "gr-0-0-1234567u1" == 16 bytes (over the 15-byte limit), so
+// ONLY the derived check can reject this config.
+func TestDerivedUnitDeviceOverlengthStrictReject_6964(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set interfaces gr-0/0/1234567 unit 1 tunnel source 10.2.0.1",
+		"set interfaces gr-0/0/1234567 unit 1 tunnel destination 10.2.0.2",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("strict CompileConfig accepted a per-unit tunnel whose derived device name is over IFNAMSIZ (#6964)")
+	}
+	if !strings.Contains(err.Error(), "gr-0-0-1234567u1") || !strings.Contains(err.Error(), "IFNAMSIZ") {
+		t.Errorf("over-length error %q must name the derived device and the IFNAMSIZ limit", err)
+	}
+}
+
+// --- OVER-REJECTION half ------------------------------------------------
+//
+// A gate that compares the effective device-name set must not start refusing
+// the configs that share a device BY DESIGN. These three cells are the ones a
+// too-broad implementation reddens.
+
+// TestUnitZeroTunnelSharesBaseDeviceAccepted_6964 is the cell a naive
+// implementation fails. `unit 0 { tunnel }` is assigned the interface's OWN base
+// device name — deliberately, unit 0 collapses onto the base interface — so a
+// derived-vs-authored comparison that does not exempt it would reject the single
+// most ordinary tunnel config in the tree.
+func TestUnitZeroTunnelSharesBaseDeviceAccepted_6964(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set interfaces gr-0/0/0 unit 0 tunnel source 10.0.0.1",
+		"set interfaces gr-0/0/0 unit 0 tunnel destination 10.0.0.2",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("strict CompileConfig must ACCEPT `unit 0 tunnel` — unit 0 shares the interface's own device by design: %v", err)
+	}
+	// Bind the premise the exemption rests on, so this cell cannot go vacuous
+	// if the compiler ever stops assigning unit 0 the base device name.
+	if got := cfg.Interfaces.Interfaces["gr-0/0/0"].Units[0].Tunnel.Name; got != "gr-0-0-0" {
+		t.Fatalf("unit 0 tunnel device = %q, want the interface base %q — the exemption this test guards no longer describes the compiler", got, "gr-0-0-0")
+	}
+}
+
+// TestOrdinaryPerUnitTunnelsAccepted_6964 is the broad over-rejection cell: a
+// realistic multi-unit, multi-interface tunnel config whose derived device names
+// are all distinct and none of which is authored anywhere must still compile.
+func TestOrdinaryPerUnitTunnelsAccepted_6964(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set interfaces gr-0/0/0 unit 0 tunnel source 10.0.0.1",
+		"set interfaces gr-0/0/0 unit 0 tunnel destination 10.0.0.2",
+		"set interfaces gr-0/0/0 unit 1 tunnel source 10.0.1.1",
+		"set interfaces gr-0/0/0 unit 1 tunnel destination 10.0.1.2",
+		"set interfaces gr-0/0/0 unit 2 tunnel source 10.0.2.1",
+		"set interfaces gr-0/0/0 unit 2 tunnel destination 10.0.2.2",
+		"set interfaces gr-0/0/1 unit 1 tunnel source 10.0.3.1",
+		"set interfaces gr-0/0/1 unit 1 tunnel destination 10.0.3.2",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("strict CompileConfig must ACCEPT ordinary per-unit tunnels with distinct derived devices: %v", err)
+	}
+	// The cell is only meaningful if the fixture actually produced the derived
+	// "uN" devices the gate walks; assert the population it was screened on.
+	for ref, want := range map[string]string{
+		"gr-0/0/0#1": "gr-0-0-0u1",
+		"gr-0/0/0#2": "gr-0-0-0u2",
+		"gr-0/0/1#1": "gr-0-0-1u1",
+	} {
+		name, unit := ref[:len(ref)-2], int(ref[len(ref)-1]-'0')
+		got := cfg.Interfaces.Interfaces[name].Units[unit].Tunnel.Name
+		if got != want {
+			t.Errorf("%s unit %d device = %q, want %q", name, unit, got, want)
+		}
+	}
+}
+
+// TestDerivedUnitDeviceAtIFNAMSIZBoundaryAccepted_6964 is the fencepost on the
+// derived length check. "gr-0-0-123456" (13) + "u1" == "gr-0-0-123456u1" == 15
+// bytes, EXACTLY the kernel limit, and must be accepted — a `>=` where the code
+// needs `>` turns a working config into a failed commit with no workaround.
+func TestDerivedUnitDeviceAtIFNAMSIZBoundaryAccepted_6964(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set interfaces gr-0/0/123456 unit 1 tunnel source 10.4.0.1",
+		"set interfaces gr-0/0/123456 unit 1 tunnel destination 10.4.0.2",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("strict CompileConfig must ACCEPT a derived device name of exactly %d bytes: %v", maxLinuxIfNameLen, err)
+	}
+	got := cfg.Interfaces.Interfaces["gr-0/0/123456"].Units[1].Tunnel.Name
+	if len(got) != maxLinuxIfNameLen {
+		t.Fatalf("boundary fixture drifted: derived device %q is %d bytes, want exactly %d", got, len(got), maxLinuxIfNameLen)
+	}
+}

--- a/pkg/daemon/tunnel_derived_unit_collision_6964_test.go
+++ b/pkg/daemon/tunnel_derived_unit_collision_6964_test.go
@@ -1,0 +1,91 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestCollectAppliedTunnelsCollapsesDerivedUnitDevice_6964 is the ROUTING-LAYER
+// consequence behind the #6964 commit gate, and it is why that gate rejects
+// rather than warns on the strict path.
+//
+// The fixture is built through the REAL config path (ParseSetCommand ->
+// SetPath -> CompileConfigLenient), never a *TunnelConfig struct literal, so
+// every Name asserted below is the one the compiler assigns — a literal fixture
+// would only prove that a literal round-trips.
+//
+// CompileConfigLenient rather than CompileConfig deliberately: the strict path
+// now REJECTS this shape, and the tolerant load / peer-sync path is exactly the
+// population that keeps producing it (an already-committed config that predates
+// the gate). The tolerant path WARNS; it does not repair. So the damage below is
+// what a grandfathered config still hands to the routing manager.
+//
+// pkg/routing keys ALL of its per-device state by TunnelConfig.Name
+// (pkg/routing/tunnel.go): the desired/owned set (`desired[tc.Name] = true`),
+// the applied-address set (appliedAddrs[tc.Name]), the VRF claim
+// (appliedRI[tc.Name]) and the keepalive runner. So two records with one Name
+// collapse to ONE entry in `desired` and then reconcile the SAME device TWICE
+// in one Apply: the second pass's reconcileLinkAddrsLocked AddrDels every
+// non-link-local address on the device that is absent from the second record's
+// Addresses, so the two records delete each other's addresses off the shared
+// device, and its VRF claim and keepalive are rewritten on top.
+//
+// Not the endpoint-comparing LinkDel+LinkAdd in applyKernelTunnelLocked —
+// that is the standalone-CLI path. The daemon always sets AnchorOnly, where
+// anchorReusable ignores tunnel endpoints and the TUN is reused in place.
+//
+// The ORDER is not stable: collectAppliedTunnels walks the
+// cfg.Interfaces.Interfaces MAP, and both orders were observed within a single
+// process (measured 174/26 over 200 calls). That ordering is deliberately NOT
+// asserted here — a randomized-order assertion is flaky by construction. What
+// is asserted is the deterministic defect it rests on: two records, one device
+// name, distinguishable intents.
+func TestCollectAppliedTunnelsCollapsesDerivedUnitDevice_6964(t *testing.T) {
+	tree := &config.ConfigTree{}
+	for _, s := range []string{
+		// Interface authored literally as the derived device name of the unit
+		// below. Endpoints differ from the unit's ON PURPOSE: identical
+		// endpoints would make the collapse onto one device invisible, and
+		// every assertion here would hold on a correct config too.
+		"set interfaces gr-0/0/0u1 tunnel source 10.0.0.1",
+		"set interfaces gr-0/0/0u1 tunnel destination 10.0.0.2",
+		"set interfaces gr-0/0/0 unit 1 tunnel source 10.1.0.1",
+		"set interfaces gr-0/0/0 unit 1 tunnel destination 10.1.0.2",
+	} {
+		path, err := config.ParseSetCommand(s)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", s, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", s, err)
+		}
+	}
+	cfg, err := config.CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("tolerant load must not reject a grandfathered config: %v", err)
+	}
+
+	tunnels := collectAppliedTunnels(cfg)
+	if len(tunnels) != 2 {
+		t.Fatalf("collectAppliedTunnels returned %d records, want 2 (the fixture must produce BOTH conflicting intents or the collapse is untested): %+v", len(tunnels), tunnels)
+	}
+	if tunnels[0].Name != tunnels[1].Name {
+		t.Fatalf("fixture no longer collides: device names %q and %q — the collapse this test documents is not being exercised", tunnels[0].Name, tunnels[1].Name)
+	}
+	if tunnels[0].Name != "gr-0-0-0u1" {
+		t.Errorf("shared device name = %q, want %q", tunnels[0].Name, "gr-0-0-0u1")
+	}
+	// The two intents must be DISTINGUISHABLE, or "one device, two intents"
+	// would be unobservable and this cell could not fail on a correct config.
+	if tunnels[0].Source == tunnels[1].Source || tunnels[0].Destination == tunnels[1].Destination {
+		t.Fatalf("fixture is blind: both records carry src=%q dst=%q, so one device serving two intents looks identical to one correct record",
+			tunnels[0].Source, tunnels[0].Destination)
+	}
+	got := map[string]string{tunnels[0].Source: tunnels[0].Destination, tunnels[1].Source: tunnels[1].Destination}
+	for src, dst := range map[string]string{"10.0.0.1": "10.0.0.2", "10.1.0.1": "10.1.0.2"} {
+		if got[src] != dst {
+			t.Errorf("device %q is missing the intent src=%s dst=%s; collected = %+v", tunnels[0].Name, src, dst, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #6964

## The defect

The #5832 interface-name collision gate compares **authored** interface names
only — and the authored set is not the set of kernel device names a config
claims.

A logical unit carrying its own `tunnel` stanza gets its **own** Linux device,
named by `compileInterfaces` as the interface's canonical name plus `u<unit>`
for unit > 0 and stored verbatim in `unit.Tunnel.Name`. So `gr-0/0/0 unit 1`
needs the device `gr-0-0-0u1` — byte-identical to the canonical name of an
interface an operator is free to author as `gr-0/0/0u1` (`u` and digits are
ordinary allowed characters, `ValidateInterfaceName` #6834). The two **authored**
keys are `gr-0/0/0u1` and `gr-0/0/0`, which canonicalize differently, so the
authored-only walk never sees them touch.

Measured on the unmodified tree:

```
STRICT CompileConfig err = <nil>
  iface gr-0/0/0u1     tunnel Name="gr-0-0-0u1" mode="gre" src="10.0.0.1"
  unit  gr-0/0/0.1     tunnel Name="gr-0-0-0u1" mode="gre" src="10.1.0.1"
```

## What actually breaks — and one correction to the issue

The issue says "last writer wins", and its neighbourhood implies the
endpoint-comparing `LinkDel` + `LinkAdd` in `applyKernelTunnelLocked`
(`legacyTunnelMatches`). **That is not the production path.** The daemon always
sets `AnchorOnly`, so `applyAnchorLocked` runs and `anchorReusable` ignores
tunnel endpoints — the TUN is reused in place, no link flap. I checked this
rather than inheriting it.

What does break is that `pkg/routing` keys **all** of its per-device state by
`TunnelConfig.Name`: `desired[tc.Name]`, `appliedAddrs[tc.Name]`,
`appliedRI[tc.Name]`, and the keepalive runner. The two records collapse to
**one** entry in `desired` and then reconcile the **same device twice in one
`Apply`**. The second pass runs `reconcileLinkAddrsLocked` against the first
pass's applied set, which `AddrDel`s every non-link-local address on the device
absent from the second record's `Addresses`. The two records **delete each
other's addresses off the shared device**, and its VRF claim and keepalive are
rewritten on top.

And there is no consistent "last" writer. `collectAppliedTunnels` walks the
`cfg.Interfaces.Interfaces` **map**; both orders were observed within a single
process — 174 / 26 over 200 calls. That is a stronger statement than the issue
makes: not "one config silently wins", but *no stable winner*.

Also: the issue's own posted reproduction no longer reproduces. It uses
`mode="ipip"`, which now trips the #4785 IPIP-not-implemented gate first and
returns an error, not `nil`. Nothing about the collision is fixed — the fixture
is shadowed. With `mode gre` it reproduces exactly as described. Recorded on the
issue.

## The fix

`validateInterfaceNameCollisionStrict` now compares the **effective device-name
set**: every authored canonical name **plus** every per-unit tunnel device name,
with the same IFNAMSIZ length check applied to the derived name (a base that
fits can have a `u<unit>` derivative that does not, and that device silently
never materializes).

Two rules keep it from over-rejecting:

- A unit whose tunnel device name **is** its interface's own canonical name is
  **skipped**. That is `unit 0`, which collapses onto the base device by design;
  reporting it would refuse the most ordinary tunnel config in the tree. This is
  the rule cell **C4** exists to prove load-bearing.
- The walk reads the compiler-**assigned** `unit.Tunnel.Name` rather than
  re-deriving `base + "u" + N`, so the gate cannot drift from the naming scheme
  it polices.

## Reject vs. rename — the compatibility decision

**Reject on the strict path only.** The shape was reachable in an
already-committed config (nothing ever rejected it), so a bare hard error would
brick a config on upgrade. This inherits the #5832 strict/lenient split via
`opts.lenientIfNameCollision`: interactive/gRPC commit and commit-check hard-
reject so the operator sees it before it takes effect, while the tolerant load /
peer-sync path **warns**, naming the collision, so a grandfathered or peer-synced
generation still boots (#1960 no-brick).

The tolerant path makes the collision *visible*; it does not repair it. That is
exactly what the `pkg/daemon` consequence cell reads back out of the compiled
config, so the "still broken, just no longer silent" property is pinned rather
than assumed.

## Known-unreachable branch, stated plainly

The derived-vs-derived arm cannot fire today and therefore carries **no test
cell**. A device name decomposes uniquely into `base + "u" + <digits>` (split at
the last `u` followed only by digits), so two per-unit tunnels can only collide
when their **bases** collide — and colliding bases are caught by the authored
pass, which returns first. It is retained rather than deleted precisely because
the walk binds to the assigned name instead of the derivation: a future change
to the naming scheme would break that uniqueness argument, and the hole must not
reopen silently. Flagging it here rather than letting a reviewer find untested
code.

## Filed while re-deriving

**#7795** — the same "authored set ≠ device set" hazard via a *second*
derivation: the VLAN sub-interface name. `ge-0/0/0 unit 100 vlan-id 100` resolves
to `ge-0-0-0.100`, and an interface authored `ge-0/0/0.100` canonicalizes to the
same string; `CompileConfig` returns `nil`. Different derivation and a different
consequence surface (`ResolveKernelIfName` consumers: RA, DDNS, proxy-arp,
cluster bind, VRRP, REST), so it is filed separately rather than widening this
PR. Its consequence half is explicitly marked unestablished there.

## Validation

`go test ./... -count=1` on the branch: clean. One flake surfaced on the first
pass — `pkg/cluster` `TestManualFailover_RetryablePreHookRetriesThenSucceeds`,
which budgets 100 ms for its retry loop and got one attempt in before the
deadline on a box at load average ~100. It is a wall-clock sample, not a
behaviour change: `-count=3` in isolation and a full `pkg/cluster -count=1`
re-run both pass, and this diff touches `pkg/config` validation plus two test
files, none of which `pkg/cluster` reaches.

### Mutation matrix

One mutation per cell, **full package**, `-count=1`, **no `-run` filter**.
Every cell reports its collected-test count against the control, because a
build break yields zero failures and reads exactly like a pass.

| # | Mutation | Collected | Named failures | Verdict |
|---|----------|-----------|----------------|---------|
| — | **control** `pkg/config` | 6805 | 0 | baseline |
| — | **control** `pkg/daemon` | 2165 | 0 | baseline |
| C1 | delete the whole derived-name pass | 6805 | 3 — `…CollisionStrictReject_6964`, `…CollisionLenientWarns_6964`, `…OverlengthStrictReject_6964` | RED |
| C2 | delete only the derived-vs-authored collision branch | 6805 | 2 — `…CollisionStrictReject_6964`, `…CollisionLenientWarns_6964` | RED |
| C3 | delete only the derived IFNAMSIZ branch | 6805 | 1 — `…OverlengthStrictReject_6964` | RED |
| C4 | *(void — see below)* delete the `unit 0` exemption | **0** | 0 | **BUILD BREAK, discarded** |
| C4b | mis-state the `unit 0` exemption as `base+"u0"` (over-reach) | 6805 | **45** — incl. `TestUnitZeroTunnelSharesBaseDeviceAccepted_6964`, `TestOrdinaryPerUnitTunnelsAccepted_6964` | RED |
| C5 | derived IFNAMSIZ check `>` → `>=` (over-reach) | 6805 | 1 — `TestDerivedUnitDeviceAtIFNAMSIZBoundaryAccepted_6964` | RED |
| C6 | dedupe collected tunnels by device name in `collectAppliedTunnels` | 2165 | 1 — `TestCollectAppliedTunnelsCollapsesDerivedUnitDevice_6964` | RED |
| — | restore + re-run `pkg/config` | 6805 | 0 | GREEN |

**C4 was void and is reported as void, not as a pass.** Deleting the `if dev ==
base { continue }` block leaves `base` declared-and-not-used, so the package did
not compile: `runs=0`, `nfail=0`, `rc=1`. Zero failures and a non-zero exit is
exactly what a passing-looking cell would print if you gated on failure count
alone — the collected-count column is what caught it. **C4b** replaces it with a
mutation that compiles: the exemption is mis-stated as `base+"u0"` (a plausible
wrong guess at how unit 0 is named), so it never fires for the real unit-0
device, whose name *is* `base`.

C4b's result is stronger than the cell was designed for. Removing the exemption
does not merely red my two over-rejection cells — it reds **45** tests across
the existing corpus (`TestPerUnitTunnelConfig`, `TestTunnelNameMap`, the #4785
and #6861 tunnel suites, the WireGuard plaintext-warning suite, …), every one of
them an existing config in the tree that uses `unit 0 tunnel`. That is the
over-rejection evidence: without the exemption this gate would refuse a large
fraction of the repo's own tunnel fixtures.


### What each cell proves

- **C1 / C2 / C3** are the fail-on-revert half: without the derived-name pass,
  the collision and the over-IFNAMSIZ derivative both compile clean. C2 and C3
  split the pass so a single surviving branch cannot cover for the other.
- **C4 and C5 are the over-rejection half**, and they are the reason this gate
  is safe to make a hard error. C4 deletes the `unit 0` exemption — a change
  that looks like *more* checking and is in fact a refusal of the most ordinary
  tunnel config in the tree. C5 turns the length check into `>=`, refusing a
  derived name of exactly 15 bytes, which the kernel accepts. Both must red,
  and both do.
- **C6** is aimed at the consequence cell rather than the gate: dedupe the
  collected tunnels by device name in `collectAppliedTunnels` and the
  `pkg/daemon` cell must red, proving it binds to "both conflicting intents
  reach the routing manager" and not merely to "a tunnel exists".

`TestDerivedUnitDeviceCollisionConsequence_6964` deliberately does **not** red
under C1–C3. It reads the damage off the *lenient* path, which those mutations
do not change — the gate is what stops the config being committed, not what
repairs an already-committed one. Listing it as an escape would be wrong; it is
measuring a different thing on purpose.
