### PR TITLE
daemon: derive the transport-change log from clusterTransportKey (#7073) + #6290 comment residue

### DIFF
--- a/docs/log/7073.md
+++ b/docs/log/7073.md
@@ -1,0 +1,95 @@
+# #7073 / #7068 / #7069 / #7070 — the step-20 transport-change log and the #6290 comment residue
+
+Four findings from the hostile review of PR #6869 (#6290), fixed together
+because they are all in `pkg/daemon` and all describe the same code path.
+One of the four is operator-visible; three are documentation.
+
+## The operator-visible one (#7073)
+
+`clusterTransportKey` carries six fields, and step 20 compares the **whole
+struct**, so all six participate in the restart decision:
+
+```go
+if active != (clusterTransportKey{}) && newTransport != active {
+```
+
+The line that *reports* that decision was written out by hand and printed
+four pairs. `Fabric1Interface` and `Fabric1PeerAddress` were never logged.
+So a commit changing only fab1 restarted comms correctly and then emitted a
+line in which every `old`/`new` pair was identical — asserting a change and
+showing none. To an operator that reads as a spurious restart.
+
+Pre-existing on master; #6869 did not introduce it.
+
+### Shape of the fix
+
+Not "add the two missing pairs". The two had drifted apart once, and a
+second hand-written list can drift again. The pairs are now **derived from
+the struct** by reflection, one `old_`/`new_` pair per field, with the
+operator-facing key suffix carried on the field as a `log` tag:
+
+```go
+Fabric1Interface   string `log:"fabric1"`
+```
+
+A field added to `clusterTransportKey` therefore joins the comparison and
+the log line in the same edit. A field with **no** tag is still logged,
+under its Go name — the tag governs the key, not inclusion — so silent
+omission is not a reachable state. This is a commit-path call gated on an
+actual transport change, so reflection costs nothing that matters.
+
+## The three documentation ones
+
+- **#7068** — two comments named `setActiveTransport`, which does not
+  exist in the tree. One of the two *was* `setActiveTransportIfCurrent`'s
+  own godoc, so the block did not read as that function's documentation.
+- **#7069** — `daemon.go`'s `clusterCommsMu` enumeration is the in-file
+  SSOT for what the mutex covers, and still omitted
+  `activeClusterTransport` after #6290 folded it into the epoch. The
+  field's own comment named neither its guard nor its accessors.
+- **#7070** — two shipped sites (the godoc and `pkg/daemon/README.md`)
+  said the step-20 snapshot served "eight log fields". It served **four**;
+  the other four pairs came from the locally-computed `newTransport`,
+  which was never shared state.
+
+`clusterTransportKey`'s own doc also said "the four cluster transport
+fields" for a six-field struct.
+
+### Why #7070 is not fixed by writing "four"
+
+Because the count was wrong when it was written, and #7073 in this same
+change makes it wrong again (six `old_*` pairs now, eight snapshot uses).
+A number that has already rotted once and is being edited by the very
+change that would rot it again is the wrong shape. Both sites now state
+the invariant — "every `old_*` pair it logs" — which does not depend on
+how many fields the struct has.
+
+## Validation
+
+`pkg/daemon/cluster_transport_log_totality_7073_test.go`, two tests.
+
+**Fixture choice.** The totality test's fixture differs in
+`Fabric1Interface` **only**. A fixture differing in `ControlInterface`
+would have passed against the broken hand-written list too, because
+control was one of the four pairs it happened to print. fab1-only is the
+smallest shape in which the defect changes an outcome.
+
+**The wiring test walks the AST**, not the source text, so the comments
+this change adds — which quote the call — cannot satisfy it.
+
+### Mutation cells
+
+Run: `go test -count=1 -run 7073 -v ./pkg/daemon/`. Every cell collected
+**2** tests and reported **0** build errors, so no cell is a build break
+masquerading as a result.
+
+| cell | mutation | ran | failed | named failing test |
+|---|---|---|---|---|
+| control | none | 2 | 0 | — |
+| M1 | call site reverted to master's hand-written four-pair list | 2 | 1 | `TestStep20LogsTransportChangeThroughTheDerivedArgs_7073` |
+| M2 | helper loop bounded to `rt.NumField() - 2` (drops both fab1 fields) | 2 | 1 | `TestTransportChangeLogArgsCoverEveryTransportField_7073` |
+| restored | none | 2 | 0 | — |
+
+Each mutation localises to exactly one test: M1 leaves the totality test
+green (the helper is untouched) and M2 leaves the wiring test green (the
+call site is untouched). A compound mutation could not have shown that.

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -973,8 +973,21 @@ are read/written only under that lock; every reader goes through
   BEFORE the write. Goroutine creation therefore orders them the wrong way and
   supplies no happens-before, so a lease landing in that window was a real data
   race, the mirror of #5113 on `mgmtVRFInterfaces`. Step 20 now takes ONE
-  `activeTransport()` snapshot for both its comparison and its eight log
-  fields.
+  `activeTransport()` snapshot for both its comparison and every `old_*` pair it
+  logs. (Not a count: the earlier "eight log fields" here was wrong when it was
+  written — four of step 20's eight pairs came from the locally-computed
+  `newTransport`, which was never shared state — and #7073 has since changed the
+  number again, #7070.)
+- The line reporting the restart is derived from `clusterTransportKey` by
+  `transportChangeLogArgs`, one `old_`/`new_` pair per field, rather than
+  written out by hand. The hand-written list had drifted from the whole-struct
+  comparison that decides the restart: it printed four pairs where the
+  comparison used six, so a commit changing only `fabric1-interface` /
+  `fabric1-peer-address` restarted comms correctly and then logged four
+  identical `old`/`new` pairs — a line asserting a change and showing none
+  (#7073). Deriving the pairs from the struct makes that drift
+  unrepresentable; `cluster_transport_log_totality_7073_test.go` binds both the
+  totality and the call site.
 
 `make test-failover` is the required smoke for this path. The guard is covered
 by `daemon_ha_comms_race_test.go` (deterministic drop-of-stale-publish +

--- a/pkg/daemon/cluster_transport_log_totality_7073_test.go
+++ b/pkg/daemon/cluster_transport_log_totality_7073_test.go
@@ -1,0 +1,182 @@
+package daemon
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+// #7073: step 20 decides whether to restart cluster comms with a WHOLE-struct
+// comparison of clusterTransportKey (six fields), but the line that reported
+// the decision was written out by hand and printed only four pairs. A commit
+// that changed only fab1 therefore restarted comms correctly and then logged
+//
+//	cluster: transport config changed, restarting comms old_control=em0
+//	new_control=em0 old_peer=... new_peer=... old_fabric=... new_fabric=...
+//	old_fabric_peer=... new_fabric_peer=...
+//
+// with every pair identical — a line that asserts a change and then shows none,
+// which reads to an operator as a spurious restart.
+//
+// The fix derives the pairs from the struct. These tests bind that.
+
+// transportChangeLogArgs must yield one old_/new_ pair per field, carrying that
+// field's value, for EVERY field of clusterTransportKey.
+//
+// The fixture differs in Fabric1Interface ONLY. That is deliberate and is the
+// whole point: a fixture that differed in ControlInterface would have passed
+// against the broken hand-written list too, because control was one of the four
+// pairs it happened to print. fab1-only is the smallest shape in which the
+// defect changes an outcome.
+func TestTransportChangeLogArgsCoverEveryTransportField_7073(t *testing.T) {
+	active := clusterTransportKey{
+		ControlInterface:   "em0",
+		PeerAddress:        "10.99.0.2",
+		FabricInterface:    "fab0",
+		FabricPeerAddress:  "10.99.1.2",
+		Fabric1Interface:   "fab1-old",
+		Fabric1PeerAddress: "10.99.2.2",
+	}
+	next := active
+	next.Fabric1Interface = "fab1-new"
+
+	rt := reflect.TypeOf(clusterTransportKey{})
+	args := transportChangeLogArgs(active, next)
+
+	if want := 4 * rt.NumField(); len(args) != want {
+		t.Fatalf("transportChangeLogArgs returned %d args, want %d (one old_/new_ pair per field of %s)",
+			len(args), want, rt.Name())
+	}
+
+	pairs := map[string]string{}
+	for i := 0; i+1 < len(args); i += 2 {
+		k, ok := args[i].(string)
+		if !ok {
+			t.Fatalf("arg %d is not a string key: %#v", i, args[i])
+		}
+		v, ok := args[i+1].(string)
+		if !ok {
+			t.Fatalf("value for %q is not a string: %#v", k, args[i+1])
+		}
+		if _, dup := pairs[k]; dup {
+			t.Fatalf("duplicate log key %q", k)
+		}
+		pairs[k] = v
+	}
+
+	av := reflect.ValueOf(active)
+	nv := reflect.ValueOf(next)
+	differing := 0
+	for i := range rt.NumField() {
+		f := rt.Field(i)
+		// The tag is not what makes a field appear — a tagless field is still
+		// logged, under its Go name — but an untagged field means an unreadable
+		// operator-facing key, so require one.
+		tag := f.Tag.Get("log")
+		if tag == "" {
+			t.Errorf("clusterTransportKey.%s has no `log` tag; step 20 would log it as %q", f.Name, "old_"+f.Name)
+			tag = f.Name
+		}
+		gotOld, ok := pairs["old_"+tag]
+		if !ok {
+			t.Errorf("no old_%s pair for clusterTransportKey.%s", tag, f.Name)
+			continue
+		}
+		gotNew, ok := pairs["new_"+tag]
+		if !ok {
+			t.Errorf("no new_%s pair for clusterTransportKey.%s", tag, f.Name)
+			continue
+		}
+		if want := av.Field(i).String(); gotOld != want {
+			t.Errorf("old_%s = %q, want %q", tag, gotOld, want)
+		}
+		if want := nv.Field(i).String(); gotNew != want {
+			t.Errorf("new_%s = %q, want %q", tag, gotNew, want)
+		}
+		if gotOld != gotNew {
+			differing++
+		}
+	}
+
+	// The reported symptom, stated directly: a line announcing a change must
+	// show at least one. This is what reds if fab1 is dropped from the args.
+	if differing != 1 {
+		t.Errorf("fab1-only change produced %d differing old/new pairs, want exactly 1; "+
+			"0 means the line asserts a change and shows none (#7073)", differing)
+	}
+}
+
+// The helper is only worth anything if step 20 actually calls it. Bind the
+// WIRING, not just the function: parse daemon_apply_tail.go and require that
+// the "transport config changed" slog.Info call passes exactly one further
+// argument, a spread of transportChangeLogArgs.
+//
+// This walks the AST rather than grepping the source text, so a comment that
+// happens to quote the call — including the ones this change added — cannot
+// satisfy it.
+func TestStep20LogsTransportChangeThroughTheDerivedArgs_7073(t *testing.T) {
+	const (
+		file = "daemon_apply_tail.go"
+		msg  = "cluster: transport config changed, restarting comms"
+	)
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+
+	found := 0
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+		lit, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		if got, err := strconv.Unquote(lit.Value); err != nil || got != msg {
+			return true
+		}
+		found++
+		if len(call.Args) != 2 {
+			t.Errorf("%s: the %q call takes %d args; want 2 (the message and one spread of transportChangeLogArgs). "+
+				"A hand-written key/value list is what dropped the fab1 pairs (#7073).",
+				fset.Position(call.Pos()), msg, len(call.Args))
+			return true
+		}
+		if call.Ellipsis == token.NoPos {
+			t.Errorf("%s: the %q call's second argument is not spread with ...", fset.Position(call.Pos()), msg)
+		}
+		inner, ok := call.Args[1].(*ast.CallExpr)
+		if !ok {
+			t.Errorf("%s: second argument is %T, want a call to transportChangeLogArgs", fset.Position(call.Pos()), call.Args[1])
+			return true
+		}
+		id, ok := inner.Fun.(*ast.Ident)
+		if !ok || id.Name != "transportChangeLogArgs" {
+			t.Errorf("%s: second argument calls %s, want transportChangeLogArgs",
+				fset.Position(call.Pos()), exprName(inner.Fun))
+		}
+		return true
+	})
+
+	if found != 1 {
+		t.Fatalf("found %d %q log calls in %s, want exactly 1 — the test cannot bind a site it did not find",
+			found, msg, file)
+	}
+}
+
+func exprName(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.SelectorExpr:
+		return exprName(v.X) + "." + v.Sel.Name
+	default:
+		return "<expr>"
+	}
+}

--- a/pkg/daemon/cluster_transport_log_totality_7073_test.go
+++ b/pkg/daemon/cluster_transport_log_totality_7073_test.go
@@ -51,20 +51,16 @@ func TestTransportChangeLogArgsCoverEveryTransportField_7073(t *testing.T) {
 			len(args), want, rt.Name())
 	}
 
-	pairs := map[string]string{}
+	pairs := map[string]any{}
 	for i := 0; i+1 < len(args); i += 2 {
 		k, ok := args[i].(string)
 		if !ok {
 			t.Fatalf("arg %d is not a string key: %#v", i, args[i])
 		}
-		v, ok := args[i+1].(string)
-		if !ok {
-			t.Fatalf("value for %q is not a string: %#v", k, args[i+1])
-		}
 		if _, dup := pairs[k]; dup {
 			t.Fatalf("duplicate log key %q", k)
 		}
-		pairs[k] = v
+		pairs[k] = args[i+1]
 	}
 
 	av := reflect.ValueOf(active)
@@ -90,11 +86,11 @@ func TestTransportChangeLogArgsCoverEveryTransportField_7073(t *testing.T) {
 			t.Errorf("no new_%s pair for clusterTransportKey.%s", tag, f.Name)
 			continue
 		}
-		if want := av.Field(i).String(); gotOld != want {
-			t.Errorf("old_%s = %q, want %q", tag, gotOld, want)
+		if want := av.Field(i).Interface(); gotOld != want {
+			t.Errorf("old_%s = %v, want %v", tag, gotOld, want)
 		}
-		if want := nv.Field(i).String(); gotNew != want {
-			t.Errorf("new_%s = %q, want %q", tag, gotNew, want)
+		if want := nv.Field(i).Interface(); gotNew != want {
+			t.Errorf("new_%s = %v, want %v", tag, gotNew, want)
 		}
 		if gotOld != gotNew {
 			differing++

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -999,6 +999,12 @@ type Daemon struct {
 	// activeClusterTransport stores the transport config used by the
 	// currently running cluster comms. Compared on each applyConfig to
 	// detect changes that require a comms restart (#87).
+	//
+	// Guarded by clusterCommsMu since #6290; write only through
+	// setActiveTransportIfCurrent (epoch-gated) and read only through
+	// activeTransport, which returns one snapshot. Never touch this field
+	// directly — the boot writer holds neither applySem nor this mutex, so
+	// an unguarded access here is a real data race, not a theoretical one.
 	activeClusterTransport clusterTransportKey
 
 	// startClusterCommsFn is the startClusterComms entry point used by
@@ -1020,7 +1026,8 @@ type Daemon struct {
 	// clusterCommsMu guards the cluster-comms epoch state that is published
 	// asynchronously by the startClusterComms constructor goroutine and torn
 	// down by stopClusterComms: sessionSync, fabricRefreshCh/fabricRefreshCh1,
-	// clusterCommsCtx/clusterCommsCancel, and clusterCommsGen (#4958). Before
+	// clusterCommsCtx/clusterCommsCancel, clusterCommsGen (#4958), and
+	// activeClusterTransport, which joined the epoch in #6290. Before
 	// #4958 the constructor wrote sessionSync (and re-dereferenced it) and the
 	// fabric channels from an untracked goroutine with no lock, so a
 	// stop→start restart could nil-deref (stop nils sessionSync between the

--- a/pkg/daemon/daemon_apply_tail.go
+++ b/pkg/daemon/daemon_apply_tail.go
@@ -328,18 +328,16 @@ func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, 
 		// #6290: ONE guarded snapshot. The boot startClusterComms writes this
 		// field holding neither applySem nor clusterCommsMu, and a DHCP
 		// lease-change callback re-enters this step on a goroutine started
-		// before that write — see setActiveTransport for the full ordering.
+		// before that write — see setActiveTransportIfCurrent for the full
+		// ordering.
 		active := d.activeTransport()
 		if active != (clusterTransportKey{}) && newTransport != active {
+			// #7073: the pairs are derived from clusterTransportKey, the same
+			// struct the comparison above compares whole. Writing them out by
+			// hand had already dropped the two fab1 fields, so a fab1-only
+			// change logged four identical old/new pairs.
 			slog.Info("cluster: transport config changed, restarting comms",
-				"old_control", active.ControlInterface,
-				"new_control", newTransport.ControlInterface,
-				"old_peer", active.PeerAddress,
-				"new_peer", newTransport.PeerAddress,
-				"old_fabric", active.FabricInterface,
-				"new_fabric", newTransport.FabricInterface,
-				"old_fabric_peer", active.FabricPeerAddress,
-				"new_fabric_peer", newTransport.FabricPeerAddress)
+				transportChangeLogArgs(active, newTransport)...)
 			d.stopClusterComms()
 			// #6878: through the seam so a test can bind restart COMPLETION.
 			// stopClusterComms bumps clusterCommsGen first, so the generation

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -7,6 +7,7 @@ import (
 	"hash/fnv"
 	"log/slog"
 	"net"
+	"reflect"
 	"strings"
 	"time"
 
@@ -1226,16 +1227,55 @@ func (d *Daemon) stopClusterComms() {
 	}
 }
 
-// clusterTransportKey extracts the four cluster transport fields that
-// determine heartbeat and session sync endpoints. Used to detect config
-// changes that require restarting cluster comms.
+// clusterTransportKey extracts the cluster transport fields that determine
+// heartbeat and session sync endpoints. Used to detect config changes that
+// require restarting cluster comms: step 20 compares the WHOLE struct, so every
+// field here participates in the restart decision.
+//
+// The `log` tag is the key suffix step 20 uses when it reports that decision.
+// It exists so transportChangeLogArgs can derive the line from the struct
+// rather than from a hand-maintained argument list that has to be remembered
+// separately (#7073).
 type clusterTransportKey struct {
-	ControlInterface   string
-	PeerAddress        string
-	FabricInterface    string
-	FabricPeerAddress  string
-	Fabric1Interface   string
-	Fabric1PeerAddress string
+	ControlInterface   string `log:"control"`
+	PeerAddress        string `log:"peer"`
+	FabricInterface    string `log:"fabric"`
+	FabricPeerAddress  string `log:"fabric_peer"`
+	Fabric1Interface   string `log:"fabric1"`
+	Fabric1PeerAddress string `log:"fabric1_peer"`
+}
+
+// transportChangeLogArgs builds the key/value pairs for step 20's
+// "cluster: transport config changed, restarting comms" line: one old_/new_
+// pair per clusterTransportKey field, in declaration order.
+//
+// Derived from the struct by reflection rather than written out by hand,
+// because the two had already drifted: the comparison that decides the restart
+// used all six fields while the line that reported it printed four, so a commit
+// changing only fab1 correctly restarted comms and then logged four identical
+// old/new pairs — a line asserting a change and showing none, which reads as a
+// spurious restart (#7073). Deriving it makes that drift unrepresentable: a
+// field added to the struct joins the comparison and the line together.
+//
+// A field with no `log` tag still gets logged, under its Go name; the tag is
+// for a readable key, not for inclusion. Omission is not a reachable state.
+// Reflection is affordable here — this runs only on a commit that actually
+// changed the transport, never per packet or per session.
+func transportChangeLogArgs(active, next clusterTransportKey) []any {
+	rt := reflect.TypeOf(clusterTransportKey{})
+	av := reflect.ValueOf(active)
+	nv := reflect.ValueOf(next)
+	args := make([]any, 0, 4*rt.NumField())
+	for i := range rt.NumField() {
+		name := rt.Field(i).Tag.Get("log")
+		if name == "" {
+			name = rt.Field(i).Name
+		}
+		args = append(args,
+			"old_"+name, av.Field(i).String(),
+			"new_"+name, nv.Field(i).String())
+	}
+	return args
 }
 
 func clusterTransportFromConfig(cfg *config.Config) clusterTransportKey {
@@ -1253,9 +1293,9 @@ func clusterTransportFromConfig(cfg *config.Config) clusterTransportKey {
 	}
 }
 
-// setActiveTransport publishes the transport key of the comms epoch that
-// startClusterComms is bringing up, and activeTransport reads it back — both
-// under clusterCommsMu (#6290).
+// setActiveTransportIfCurrent publishes the transport key of the comms epoch
+// that startClusterComms is bringing up, and activeTransport reads it back —
+// both under clusterCommsMu (#6290).
 //
 // The lock is required, not decorative. The field is written by
 // startClusterComms, which runs on the boot path (daemon_run.go) holding
@@ -1277,9 +1317,13 @@ func clusterTransportFromConfig(cfg *config.Config) clusterTransportKey {
 // written under applySem, read by the same callback without it — and was fixed
 // the same way.
 //
-// activeTransport also returns ONE snapshot, so step 20's comparison and the
-// eight fields it logs all describe a single epoch rather than up to six
-// separate reads that a concurrent restart could interleave.
+// activeTransport also returns ONE snapshot, so step 20's comparison and every
+// old_* pair it logs all describe a single epoch rather than up to six separate
+// reads that a concurrent restart could interleave. Deliberately not a count:
+// the previous wording said "eight fields", which was wrong when written (four
+// of step 20's eight pairs came from the locally-computed newTransport, not
+// from the snapshot) and would have gone wrong again when #7073 added the two
+// fab1 pairs. The invariant is "every old_* pair", which does not rot (#7070).
 //
 // setActiveTransportIfCurrent is epoch-gated rather than a bare locked store,
 // mirroring publishSessionSyncIfCurrent. The same window that makes the race

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -1271,9 +1271,14 @@ func transportChangeLogArgs(active, next clusterTransportKey) []any {
 		if name == "" {
 			name = rt.Field(i).Name
 		}
+		// .Interface(), not .String(): reflect.Value.String() does not fail on a
+		// non-string field, it returns "<int Value>". Every field is a string
+		// today, so this is not a live bug — but the whole point of deriving
+		// the line is that a future field joins it automatically, and joining
+		// it as garbage would be worse than the omission this replaced.
 		args = append(args,
-			"old_"+name, av.Field(i).String(),
-			"new_"+name, nv.Field(i).String())
+			"old_"+name, av.Field(i).Interface(),
+			"new_"+name, nv.Field(i).Interface())
 	}
 	return args
 }


### PR DESCRIPTION
Four findings from the hostile review of PR #6869 (#6290), fixed together: they are all in `pkg/daemon` and all describe the same code path. One is operator-visible; three are documentation.

## The operator-visible one — #7073

`clusterTransportKey` carries **six** fields and step 20 compares the **whole struct**, so all six participate in the restart decision. The line that *reports* that decision was written by hand and printed **four** pairs — `Fabric1Interface` and `Fabric1PeerAddress` were never logged.

So a commit changing only fab1 restarted comms correctly and then emitted:

```
cluster: transport config changed, restarting comms old_control=em0 new_control=em0
  old_peer=... new_peer=... old_fabric=... new_fabric=... old_fabric_peer=... new_fabric_peer=...
```

— every old/new pair identical. A line that asserts a change and then shows none, which reads to an operator as a spurious restart. Pre-existing on master; #6869 did not introduce it.

**The fix is not "add the two missing pairs."** The two lists had already drifted apart once, and a second hand-written list can drift again. The pairs are now derived from the struct by reflection, one `old_`/`new_` pair per field, with the operator-facing key suffix carried on the field as a `log` tag:

```go
Fabric1Interface   string `log:"fabric1"`
```

A field added to `clusterTransportKey` now joins the comparison and the log line in the same edit. A field with **no** tag is still logged, under its Go name — the tag governs the key, not inclusion — so silent omission is not a reachable state. This is a commit-path call gated on an actual transport change; the reflection never runs per packet or per session.

## The three documentation ones

- **#7068** — two comments named `setActiveTransport`, which does not exist. One of them *was* `setActiveTransportIfCurrent`'s own godoc, so the block did not read as that function's documentation to a reader or to doc tooling.
- **#7069** — `daemon.go`'s `clusterCommsMu` enumeration is the in-file SSOT for what the mutex covers and still omitted `activeClusterTransport` after #6290 folded it into the epoch; the field's own comment named neither its guard nor its accessors.
- **#7070** — the godoc and `pkg/daemon/README.md` both said the step-20 snapshot served "eight log fields". It served **four**; the other four pairs came from the locally-computed `newTransport`, which was never shared state.

Also: `clusterTransportKey`'s own doc said "the four cluster transport fields" for a six-field struct.

### Why #7070 is not fixed by writing "four"

Because the count was wrong when written, and **#7073 in this same PR makes it wrong again** (six `old_*` pairs now; eight snapshot uses). A number that has already rotted once, being edited by the change that would rot it again, is the wrong shape. Both sites now state the invariant — *"every `old_*` pair it logs"* — which does not depend on the field count.

## Validation

`pkg/daemon/cluster_transport_log_totality_7073_test.go`, two tests.

**Fixture choice.** The totality test's fixture differs in `Fabric1Interface` **only**. A fixture differing in `ControlInterface` would have passed against the broken list too, because control was one of the four pairs it happened to print. fab1-only is the smallest shape in which the defect changes an outcome.

**The wiring test walks the AST**, not the source text — so the comments this PR adds, which quote the call, cannot satisfy it.

### Mutation cells

`go test -count=1 -run 7073 -v ./pkg/daemon/`. Every cell collected **2** tests and reported **0** build errors, so no cell is a build break wearing the shape of a result.

| cell | mutation | ran | failed | named failing test |
|---|---|---|---|---|
| control | none | 2 | 0 | — |
| M1 | call site reverted to master's hand-written four-pair list | 2 | 1 | `TestStep20LogsTransportChangeThroughTheDerivedArgs_7073` |
| M2 | helper loop bounded to `rt.NumField() - 2` (drops both fab1 fields) | 2 | 1 | `TestTransportChangeLogArgsCoverEveryTransportField_7073` |
| restored | none | 2 | 0 | — |

Each mutation **localises to exactly one test**: M1 leaves the totality test green (the helper is untouched), M2 leaves the wiring test green (the call site is untouched). A compound mutation could not have shown that.

Repo-wide `go test -count=1 ./...` result is posted as a comment once it finishes.

Docs: `pkg/daemon/README.md` updated in the same change (it carried two of the four defects), plus `docs/log/7073.md`.

Closes #7073
Closes #7068
Closes #7069
Closes #7070