### PR TITLE
userspace: collapse firstConfiguredUnit to a bool predicate (#7026); replace the #6735 SCOPE census (#7030)

### DIFF
--- a/docs/log/7026.md
+++ b/docs/log/7026.md
@@ -1,0 +1,86 @@
+# #7026 + #7030 — a dead selection and a census that rotted
+
+Two carried-forward findings from the #6722 / #6735 rounds. Both were
+recorded at the time with the note that fixing them would have been
+production movement in a claims-only round. This is the round that is
+allowed to move production.
+
+## #7026 — `firstConfiguredUnit`'s int had no consumer
+
+`pkg/dataplane/userspace/interfaces.go` returned `(int, bool)` and every
+one of its three call sites read only the bool:
+
+```go
+_, hasUnit := firstConfiguredUnit(ifc)   // egressMemberIsBarePort
+```
+
+So the `if !found || num < lowest` lowest-unit selection was **dead**, not
+merely unbound — the #6722 round-12 mutation table measured that reversing
+`num < lowest` to `num > lowest` left the whole Go suite green, and its own
+row said the fix was "worth collapsing to a bool predicate in a round that
+is allowed to move production."
+
+Collapsed to `hasConfiguredUnit(ifc) bool`.
+
+**The sibling is not dead and was not touched.** `firstUnitNumber`
+(`pkg/config/compiler_validate_strict_reth_member.go`) looks identical but
+its caller interpolates the int into the commit-check message — *"also
+configures `unit %d`"* — so its determinism requirement is real. The issue
+title named both functions; its body correctly excluded `firstUnitNumber`,
+and an independent read of the call site agrees with the body.
+
+### Collapsing must not decommission the guard's test
+
+The nil-slot skip (`#3494/#5068` tolerant load) survives the collapse in a
+different syntactic shape, so the #6722 table's cell **U** had to be
+re-run against the new shape rather than assumed to carry over:
+
+| cell | mutation | failed | named failing test |
+|---|---|---|---|
+| U (re-run) | `hasConfiguredUnit` drops its `unit != nil` skip | 1 | `TestNilUnitSlotOnARethMemberIsNotAnL3Identity_6722` |
+| restored | none | 0 | — |
+
+The table row that described the now-deleted selection is kept, marked
+RESOLVED, so the next reader sees the disposition instead of re-deriving
+it. The row describing the nil skip is reworded to the shape that now
+exists.
+
+## #7030 — the SCOPE census in the #6735 test
+
+The comment read:
+
+> That same empty-value edit reds 26 assertions that predate this branch
+> (#6391 ×9, #5248, #3362, #3703, #4544, #4818, #3226, #4455)
+
+Re-measured at `560544992` by applying the edit the comment itself names
+(`cloneHostInbound(hib)` -> `&HostInboundTraffic{}` in `compileZones`) and
+running `go test -count=1 -v ./pkg/config/`:
+
+```
+collected = 6819    top-level FAIL = 28    build errors = 0
+#6391 group = 11
+```
+
+Both halves had rotted:
+
+- The `#6391` parenthetical is **11**, not 9 — confirming the
+  re-measurement reported on PR #6735.
+- The enumeration was a **floor, not a census**. Four tags it never named
+  are now in the red set: `#6640` (×2), `#2419`
+  (`TestCompactBlockEquivalenceInventory2419`), `#7484`
+  (`TestSchemaSpellingGateCoverageIsGated_7484`), and the untagged
+  `TestSlotEscapeTable`.
+
+### Why the fix is not "write 11"
+
+Because the number is not the claim. #7030 says so itself: *"re-measure
+rather than adjust by hand — the population changes whenever a sibling
+round adds or removes an override assertion, so a hand-edited number goes
+stale the same way."* Correcting 9 to 11 resets the clock and reproduces
+the defect on the next sibling round.
+
+The comment now states the **predicate** — the override's content is
+pinned by assertions outside this table, so this row can be deleted
+without leaving the override unbound — and carries the measured figures as
+a dated observation at a named sha plus the exact command to re-derive
+them, rather than as a standing claim.

--- a/pkg/config/compiler_zone_interfaces_packed_tail_6735_test.go
+++ b/pkg/config/compiler_zone_interfaces_packed_tail_6735_test.go
@@ -158,11 +158,33 @@ func TestZoneInterfaces6735PackedTailRejectedAndPositiveControl(t *testing.T) {
 			//
 			// SCOPE, also measured, so nobody reads more into this than it
 			// carries: this assertion does NOT independently bind the override.
-			// That same empty-value edit reds 26 assertions that predate this
-			// branch (#6391 ×9, #5248, #3362, #3703, #4544, #4818, #3226,
-			// #4455), which already pin override CONTENT for these very shapes.
-			// It is here so the accept table states what it means; the binding
-			// is done elsewhere. See the mutation table in _Log.md.
+			// That same empty-value edit reds a large set of assertions that
+			// predate this branch and already pin override CONTENT for these
+			// very shapes. It is here so the accept table states what it means;
+			// the binding is done elsewhere.
+			//
+			// Deliberately not a census. This comment used to read "26
+			// assertions ... (#6391 ×9, #5248, #3362, #3703, #4544, #4818,
+			// #3226, #4455)" and both halves had gone stale: re-measured at
+			// 560544992 the #6391 group is ELEVEN, not nine, and the red set
+			// had grown four tags the enumeration never named (#6640 ×2, #2419,
+			// #7484, plus the untagged TestSlotEscapeTable). The population
+			// changes whenever any sibling round adds or removes an override
+			// assertion, so a hand-maintained number goes stale by construction
+			// and a corrected one would only reset the clock (#7030).
+			//
+			// The claim that matters is the PREDICATE, which does not rot: the
+			// override's content is pinned by assertions outside this table, so
+			// this row can be deleted without leaving the override unbound.
+			// Re-measure rather than trust a number — replace
+			// `cloneHostInbound(hib)` with `&HostInboundTraffic{}` at the
+			// per-interface override site in compileZones
+			// (pkg/config/compiler_security_zones.go) and run:
+			//
+			//	go test -count=1 -v ./pkg/config/ 2>&1 | grep -c '^--- FAIL'
+			//
+			// At 560544992 that is 28 top-level tests, 27 of them predating
+			// this branch. See the mutation table in _Log.md.
 			wantHIB map[string][]string
 		}{
 			{

--- a/pkg/dataplane/userspace/egress_zone_identity_6722_test.go
+++ b/pkg/dataplane/userspace/egress_zone_identity_6722_test.go
@@ -703,7 +703,7 @@ func TestTwoAuthoredZonesOnOneCoherentNetdevFailClosed_6722(t *testing.T) {
 // the conjunct is irrelevant to it.
 //
 // The clause only bites for a reth with NO configured unit. A member-named reth
-// that carries units is already refused by the `firstConfiguredUnit` conjunct,
+// that carries units is already refused by the `hasConfiguredUnit` conjunct,
 // which is why every fixture written before this one reached the answer through
 // a different clause and this one stayed unbound.
 //
@@ -735,13 +735,13 @@ func TestUnitlessRethNamedAsAMemberFailsClosedOnTheLenientPath_6722(t *testing.T
 	snaps := buildInterfaceSnapshots(cfg)
 
 	// The precondition that makes the clause the ONLY thing answering: reth1
-	// carries no configured unit, so `firstConfiguredUnit` does not refuse it
+	// carries no configured unit, so `hasConfiguredUnit` does not refuse it
 	// and `ifc.Tunnel` is nil.
 	if member := cfg.Interfaces.Interfaces["reth1"]; member == nil {
 		t.Fatalf("precondition: reth1 is absent from the compiled config")
-	} else if _, hasUnit := firstConfiguredUnit(member); hasUnit {
+	} else if hasConfiguredUnit(member) {
 		t.Fatalf("precondition: reth1 carries a configured unit, so the " +
-			"firstConfiguredUnit conjunct refuses it and the reth-prefix clause is " +
+			"hasConfiguredUnit conjunct refuses it and the reth-prefix clause is " +
 			"not what this cell measures")
 	}
 	base := snapByName6722(t, snaps, "reth0")
@@ -1278,7 +1278,7 @@ func truncate6722(s string, n int) string {
 //	authoredZoneRefs drops CanonicalInterfaceUnitRef              -> R (and P)
 //	unanimousUnitZone drops `if z == "" { continue }`             -> S
 //	unanimousUnitZone drops `if seen != "" && seen != z`          -> T
-//	firstConfiguredUnit drops `if unit == nil { continue }`       -> U
+//	hasConfiguredUnit drops its `unit != nil` skip                -> U
 //	unanimousUnitZone drops `if unit == nil { continue }`         -> V
 //	egressRethMemberOf drops `ifc.RedundantParent != reth`        -> W
 //	egressIdentitiesCohere drops `len(identities) > 2`            -> E/reth-as-member-plus-canonical-collision, but ONLY after the
@@ -1313,12 +1313,13 @@ func truncate6722(s string, n int) string {
 //	  cannot fire without the same edit that breaks the pairing, so no mutation
 //	  of the assert alone is observable. A construction invariant, not a guard.
 //
-//	`num < lowest` in firstConfiguredUnit. Reversing it to `num > lowest`
-//	  changes nothing because the int result has NO consumer: the sole
-//	  production call site is `_, hasUnit := firstConfiguredUnit(ifc)` in
-//	  egressMemberIsBarePort, and the only test call reads `hasUnit` too. The
-//	  selection is dead, not merely unbound — worth collapsing to a bool
-//	  predicate in a round that is allowed to move production.
+//	`num < lowest` in firstConfiguredUnit. RESOLVED in #7026, so this row no
+//	  longer describes the tree. The selection was dead rather than unbound —
+//	  the int had no consumer at any of its three call sites — and this row
+//	  said it was worth collapsing in a round allowed to move production.
+//	  #7026 was that round: the function is now `hasConfiguredUnit(ifc) bool`
+//	  and there is no selection left to mutate. Kept as a row so the next
+//	  reader of this table sees the disposition rather than re-deriving it.
 //
 //	`if rawIface == "" { continue }` in authoredZoneRefs. No `set` line produces
 //	  an empty zone-interface reference, so the clause is unreachable from the
@@ -1684,7 +1685,7 @@ func TestTrunkCarrierWithDisagreeingUnitsFailsClosed_6722(t *testing.T) {
 // U: a PRESENT-BUT-NIL unit slot on a reth member does not give it an L3
 // identity.
 //
-// `egressMemberIsBarePort` asks `firstConfiguredUnit`, which skips a nil unit
+// `egressMemberIsBarePort` asks `hasConfiguredUnit`, which skips a nil unit
 // slot — the tolerant load / HA config-sync shape of #3494/#5068, a key present
 // in `ifc.Units` with a nil value. That skip decides, in the PERMISSIVE
 // direction, whether such a member is still a bare port; it is the input to
@@ -1721,8 +1722,8 @@ func TestNilUnitSlotOnARethMemberIsNotAnL3Identity_6722(t *testing.T) {
 		t.Fatalf("precondition: ge-0/0/1 Units[7] present=%v nil=%v, want a "+
 			"PRESENT slot holding nil", ok, u == nil)
 	}
-	if _, hasUnit := firstConfiguredUnit(member); hasUnit {
-		t.Fatalf("firstConfiguredUnit reports a configured unit on a member whose " +
+	if hasConfiguredUnit(member) {
+		t.Fatalf("hasConfiguredUnit reports a configured unit on a member whose " +
 			"only unit slot is nil; a nil slot is an artefact of the tolerant " +
 			"load, not an operator statement, and treating it as one makes the " +
 			"member an L3 identity of its own")

--- a/pkg/dataplane/userspace/interfaces.go
+++ b/pkg/dataplane/userspace/interfaces.go
@@ -1258,24 +1258,31 @@ func egressMemberIsBarePort(name string, ifc *config.InterfaceConfig) bool {
 	if ifc.Tunnel != nil {
 		return false
 	}
-	_, hasUnit := firstConfiguredUnit(ifc)
-	return !hasUnit
+	return !hasConfiguredUnit(ifc)
 }
 
-// firstConfiguredUnit reports the lowest configured (non-nil) logical unit of
-// ifc. A present-but-nil unit slot (tolerant load / HA config-sync, #3494/#5068)
-// is not a configured unit.
-func firstConfiguredUnit(ifc *config.InterfaceConfig) (int, bool) {
-	lowest, found := 0, false
-	for num, unit := range ifc.Units {
-		if unit == nil {
-			continue
-		}
-		if !found || num < lowest {
-			lowest, found = num, true
+// hasConfiguredUnit reports whether ifc carries any configured (non-nil)
+// logical unit. A present-but-nil unit slot (tolerant load / HA config-sync,
+// #3494/#5068) is not a configured unit.
+//
+// This was firstConfiguredUnit, returning (int, bool). The int had no consumer
+// -- the sole production call site and both test call sites read only the bool
+// -- so the lowest-unit selection it performed was dead code, not merely
+// unbound: reversing `num < lowest` to `num > lowest` left the whole Go suite
+// green. The #6722 round-12 mutation table recorded that and deliberately left
+// it alone, being a claims-only round; #7026 carried it forward. Collapsed here.
+//
+// The sibling firstUnitNumber (pkg/config/compiler_validate_strict_reth_member.go)
+// keeps its int and its determinism requirement: it names the offending unit in
+// the commit-check message, so its selection is load-bearing. Only this copy
+// was dead.
+func hasConfiguredUnit(ifc *config.InterfaceConfig) bool {
+	for _, unit := range ifc.Units {
+		if unit != nil {
+			return true
 		}
 	}
-	return lowest, found
+	return false
 }
 
 // unanimousUnitZone implements rule 3 of stampEgressZones: the zone that every


### PR DESCRIPTION
Two findings carried forward from the #6722 / #6735 rounds, both recorded at the time with the note that fixing them would have been production movement in a claims-only round. This is a round that is allowed to move production.

## #7026 — `firstConfiguredUnit`'s int had no consumer

`pkg/dataplane/userspace/interfaces.go` returned `(int, bool)` and all three call sites — one production, two test — read only the bool:

```go
_, hasUnit := firstConfiguredUnit(ifc)   // egressMemberIsBarePort
```

So the `if !found || num < lowest` lowest-unit selection was **dead**, not merely unbound. The #6722 round-12 mutation table measured exactly that (reversing `num < lowest` to `num > lowest` left the whole Go suite green) and its own row said the fix was *"worth collapsing to a bool predicate in a round that is allowed to move production."*

Now `hasConfiguredUnit(ifc) bool`. There is no selection left to mutate.

### The look-alike sibling is NOT dead and is untouched

`firstUnitNumber` (`pkg/config/compiler_validate_strict_reth_member.go`) reads identically but its caller interpolates the int into the commit-check message that names the offending unit — *"also configures `unit %d`"* — so its determinism requirement is real. The issue **title** named both functions; its **body** correctly excluded the sibling, and an independent read of the call site agrees with the body.

### Collapsing must not decommission the guard's test

The nil-slot skip (`#3494`/`#5068` tolerant load) survives the collapse in a *different syntactic shape*, so the #6722 table's cell **U** was re-run against the new shape rather than assumed to carry over:

| cell | mutation | failed | named failing test |
|---|---|---|---|
| U (re-run) | `hasConfiguredUnit` drops its `unit != nil` skip | 1 | `TestNilUnitSlotOnARethMemberIsNotAnL3Identity_6722` |
| restored | none | 0 | — |

The table row describing the now-deleted selection is kept and marked RESOLVED so the next reader sees the disposition rather than re-deriving it; the row describing the nil skip is reworded to the shape that now exists.

## #7030 — the SCOPE census in the #6735 test had rotted in both halves

The comment read:

> That same empty-value edit reds 26 assertions that predate this branch (#6391 ×9, #5248, #3362, #3703, #4544, #4818, #3226, #4455)

Re-measured at `560544992` by applying the edit the comment itself names (`cloneHostInbound(hib)` → `&HostInboundTraffic{}` in `compileZones`) and running `go test -count=1 -v ./pkg/config/`:

```
collected = 6819    top-level FAIL = 28    build errors = 0
#6391 group = 11
```

- The `#6391` parenthetical is **11**, not 9 — confirming the re-measurement reported on PR #6735.
- The enumeration was a **floor, not a census**. Four tags it never named are in the red set today: `#6640` (×2), `#2419` (`TestCompactBlockEquivalenceInventory2419`), `#7484` (`TestSchemaSpellingGateCoverageIsGated_7484`), and the untagged `TestSlotEscapeTable`.

### Why the fix is not "write 11"

Because the number is not the claim, and #7030 says so itself: *"re-measure rather than adjust by hand — the population changes whenever a sibling round adds or removes an override assertion, so a hand-edited number goes stale the same way."* Correcting 9 → 11 resets the clock and reproduces the defect on the next sibling round.

The comment now states the **predicate**, which does not rot — the override's content is pinned by assertions outside this table, so this row can be deleted without leaving the override unbound — and carries the figures as a dated observation at a named sha plus the exact command to re-derive them.

## Validation

- Cell U above.
- `go test -count=1 -run 6735 -v ./pkg/config/` selects **50** tests (checked, because a `-run` filter that matches nothing exits 0 and prints `ok`).
- Repo-wide `go test -count=1 ./...` posted as a comment when it finishes.

Docs: `docs/log/7026.md`.

Closes #7026
Closes #7030