### PR TITLE
test: stop three guards from being satisfied by non-code text (#7028, #7061, #7449)

### DIFF
--- a/docs/log/7028.md
+++ b/docs/log/7028.md
@@ -1,0 +1,132 @@
+# #7028 / #7061 / #7449 — three assertions satisfied by text that is not the code they bind
+
+One family: a guard whose subject is "the program does X" implemented as a
+search over bytes that include text the program does not execute. Each fails
+to a value **indistinguishable from healthy**, so review cannot see them —
+only a paired mutation can.
+
+The paired shape is used throughout: with the bad input, the guard REMOVED
+must give the healthy verdict (proving the defect really was invisible) and
+the guard RESTORED must give the unhealthy one (proving the fix sees it). A
+lone "delete the guard and watch it red" cell shows correlation only.
+
+## #7028 — an assertion the reject template satisfies by itself
+
+`compiler_zone_interfaces_packed_tail_6735_test.go` asserted the reject
+message with:
+
+```go
+for _, want := range []string{`"Z"`, "host-inbound-traffic", tc.wantLost} {
+```
+
+`validateZoneInterfacePackedTailStrict`'s template embeds the literal
+`host-inbound-traffic` in its own "rewrite in the block spelling" clause:
+
+```
+`interfaces { a { host-inbound-traffic { ... } } }` for a per-interface body
+```
+
+so `strings.Contains(err, "host-inbound-traffic")` holds for **every** reject
+this gate can produce, whatever the detector put in `keyword`. The detector
+returns the matched keyword deliberately — `zoneInterfaceKeysBeforeBody`'s doc
+says *"adding a second entry to `zoneInterfaceBodyKeywords` cannot leave the
+reject naming the wrong token"* — and that is exactly the property the
+assertion looked like it bound and did not.
+
+Now asserted through the **rendered** fragment, `with %q followed by`.
+
+### Paired cell
+
+Mutation: the production `%q` keyword argument replaced by the constant
+`"BOGUS"`. Run `go test -count=1 -run TestZoneInterfaces6735Packed -v
+./pkg/config/` — 14 collected in every cell, 0 build errors.
+
+| cell | assertion | failed |
+|---|---|---|
+| control | fixed | 0 |
+| mutation | **fixed** | 7 |
+| mutation | **master's** | **0** |
+| restored | fixed | 0 |
+
+The third row is the finding: master's assertion could not see a reject
+naming the wrong token.
+
+> A note on method. The first attempt at that third row reported 7 failures
+> and appeared to refute the issue. The backup it restored had been taken
+> *after* the fix was applied, so the "master" row was re-running the fixed
+> assertion. Re-derived with `git show origin/master:<path>`, it is 0. A
+> restore-from-backup is only as good as when the backup was taken.
+
+## #7061 — a source scan that counted comments
+
+`TestScreenUnresolvedDispositionHasOneSource` requires the
+`ScreenUnresolvedDisposition` sentence to exist as a literal exactly once, so
+the metric HELP and the two status renderers share one source. It counted raw
+source bytes, so **prose quoting the sentence** reddened it — with a message
+asserting a duplicated literal that "lets the metric HELP and the status block
+drift", which a comment cannot cause. The test's own comment recorded this as
+a known false positive, and two production files already carry long comments
+*about* this sentence, so it was one reword from firing.
+
+Comments are now blanked (`blankGoComments`) before the count, preserving byte
+offsets so the `concatSplice` seam regex still lines up.
+
+**It also narrows escape 1** of the scan's documented limits — a `+` seam
+interrupted by a `//` comment defeated `concatSplice` because the comment sat
+between the two quotes; blanked to spaces, the seam splices. Measured, not
+assumed. Escapes 2, 3 and 4 are unchanged and remain deliberate limits.
+
+### Paired cell
+
+| plant | scanner | failed | message |
+|---|---|---|---|
+| none | fixed | 0 | — |
+| a **comment** quoting the sentence in `pkg/api/nat.go` | fixed | **0** | false positive gone |
+| the same comment | **master's** | **1** | `found 2 occurrence(s)` |
+| a real duplicate **literal** (`var _ = "…"`) | fixed | **1** | `found 2 occurrence(s)` |
+| none | fixed | 0 | — |
+
+Rows 3 and 4 are the pair that matters together: the fix removed the false
+positive **without** blinding the guard to the true one.
+
+## #7449 — a whitespace-flattened text search, comments included
+
+`sourceContainsFlat` flattened the raw file text, so every guard built on it
+was satisfiable by prose. The issue named one call site; the same helper backs
+**eight**, so the fix is in the helper and no call site changed.
+
+That failure mode is the *most likely* way a pinned call ever disappears:
+whoever removes it tends to leave a note saying so, and the note names the
+call. `sync_conn.go` already carries prose about `sendCapabilities` beside the
+call it pins.
+
+The helper now tokenises with `go/scanner` (no `ScanComments`) and searches the
+re-emitted token text, so comments are not searched. Whitespace insensitivity
+is unchanged.
+
+### Paired cell
+
+Mutation: delete `s.sendCapabilities(conn)` from `sync_conn.go` and leave
+`// removed s.sendCapabilities(conn) here, see #7449` in its place.
+
+| cell | helper | ran | failed |
+|---|---|---|---|
+| control | fixed | 1 | 0 |
+| mutation | **fixed** | 1 | **1** (`TestCapabilityAdvertisedOnConnectionInstall6650`) |
+| mutation | **master's** | 1 | **0** |
+| restored | fixed | 1 | 0 |
+
+### A claim in the helper's doc comment that is false, pinned rather than fixed
+
+The doc says the needle *"still matches when gofmt has wrapped the call across
+lines"*. For an **argument-list** wrap that is false, in both the old and the
+new helper: gofmt puts the closing paren on its own line and adds a trailing
+comma, so the flattened text is `s.sendCapabilities(conn,)` and the needle
+does not occur in it. Verified against master's helper directly, so it is not
+a regression from the tokenising change.
+
+Pinned with a test row rather than fixed. Making the search comma-insensitive
+would loosen all eight guards to buy tolerance for a shape none of the pinned
+calls has — they are all single-argument and fit on one line. The row exists so
+the next reader learns this from a test instead of from a guard that went quiet
+after an unrelated reformat.

--- a/pkg/cluster/sync_capabilities_6650_helper_test.go
+++ b/pkg/cluster/sync_capabilities_6650_helper_test.go
@@ -1,6 +1,8 @@
 package cluster
 
 import (
+	"go/scanner"
+	"go/token"
 	"os"
 	"strings"
 	"testing"
@@ -19,7 +21,132 @@ func mustReadClusterFile(t *testing.T, path string) string {
 // matches when gofmt has wrapped the call across lines. A line-oriented search
 // here would silently stop seeing the very statements these guards exist to
 // pin the moment the surrounding code grows an indent level.
+//
+// #7449: the source is tokenised first, so COMMENTS are not searched. Before
+// that, every guard built on this helper was satisfiable by prose. The failure
+// mode is not hypothetical and not rare — it is the single most likely way the
+// pinned call ever disappears, because whoever removes a call tends to leave a
+// note saying so ("removed the advertisement here, see X"), and that note names
+// the call. sync_conn.go already carries prose about sendCapabilities right
+// beside the call it pins.
+//
+// Tokenising also drops the search from "any byte sequence in the file" to
+// "the program text", which is what every caller of this helper meant. It
+// still tolerates gofmt wrapping: token text is re-emitted space-separated and
+// then flattened, so the result is whitespace-insensitive exactly as before.
 func sourceContainsFlat(src, needle string) bool {
-	flat := strings.Join(strings.Fields(src), "")
+	flat := flattenGoTokens(src)
 	return strings.Contains(flat, strings.Join(strings.Fields(needle), ""))
+}
+
+// flattenGoTokens re-emits src as its Go tokens with all whitespace removed.
+// Comments are not tokens (the scanner is initialised without ScanComments),
+// so they do not appear in the result.
+//
+// It does not require src to parse. These guards read production files that
+// always do, but a scanner-level walk keeps the helper usable on a fragment
+// and means a syntax error elsewhere in the file surfaces as the guard's own
+// mismatch rather than as an unrelated parse failure.
+func flattenGoTokens(src string) string {
+	var b strings.Builder
+	fset := token.NewFileSet()
+	f := fset.AddFile("", fset.Base(), len(src))
+	var sc scanner.Scanner
+	sc.Init(f, []byte(src), nil, 0) // mode 0: do NOT emit comments
+	for {
+		_, tok, lit := sc.Scan()
+		if tok == token.EOF {
+			break
+		}
+		if lit != "" {
+			b.WriteString(lit)
+			continue
+		}
+		b.WriteString(tok.String())
+	}
+	return strings.Join(strings.Fields(b.String()), "")
+}
+
+// #7449: the helper's own contract. Every source-identity guard in this package
+// is built on sourceContainsFlat, so a defect here is a defect in all of them at
+// once — the issue named one call site, but the same text search backed eight.
+//
+// The middle row is the one that matters, and it is the row the raw-text version
+// failed: a file where the statement has been DELETED and a comment naming it
+// left behind. That is not a contrived shape. It is what the file looks like
+// after someone removes the call and explains why.
+func TestSourceContainsFlatIgnoresComments_7449(t *testing.T) {
+	const needle = "s.sendCapabilities(conn)"
+	for _, tc := range []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{
+			name: "the call is present",
+			src:  "package p\nfunc f() {\n\ts.sendCapabilities(conn)\n}\n",
+			want: true,
+		},
+		{
+			// The whitespace tolerance the doc comment is really about: the
+			// statement gaining indent levels as the surrounding code grows.
+			name: "the call is present, more deeply indented",
+			src:  "package p\nfunc f() {\n\tif x {\n\t\tfor {\n\t\t\ts.sendCapabilities(conn)\n\t\t}\n\t}\n}\n",
+			want: true,
+		},
+		{
+			// Measured, and TRUE ON MASTER TOO -- not a regression from the
+			// #7449 tokenising change. The doc comment claims the needle "still
+			// matches when gofmt has wrapped the call across lines", and for an
+			// ARGUMENT-LIST wrap that is false in both versions: gofmt puts the
+			// closing paren on its own line and adds a trailing comma, so the
+			// flattened text is `s.sendCapabilities(conn,)` and the needle
+			// `s.sendCapabilities(conn)` does not occur in it.
+			//
+			// Pinned rather than fixed. Making the search comma-insensitive
+			// would loosen every guard in the package to buy tolerance for a
+			// shape none of the eight pinned calls has (they are all
+			// single-argument and fit on one line). Recorded here so the next
+			// reader learns it from a test instead of from a guard that went
+			// quiet after an unrelated reformat.
+			name: "argument-list wrap adds a trailing comma and does NOT match",
+			src:  "package p\nfunc f() {\n\ts.sendCapabilities(\n\t\tconn,\n\t)\n}\n",
+			want: false,
+		},
+		{
+			name: "DELETED, with a comment left behind that names it",
+			src:  "package p\nfunc f() {\n\t// removed s.sendCapabilities(conn) here, see X\n}\n",
+			want: false,
+		},
+		{
+			name: "DELETED, named in a block comment",
+			src:  "package p\n\n/* s.sendCapabilities(conn) used to live here */\nfunc f() {}\n",
+			want: false,
+		},
+		{
+			name: "DELETED, named in a doc comment on the function",
+			src:  "package p\n\n// f used to call s.sendCapabilities(conn).\nfunc f() {}\n",
+			want: false,
+		},
+		{
+			name: "absent entirely",
+			src:  "package p\nfunc f() {}\n",
+			want: false,
+		},
+		{
+			// A string literal IS program text, so this is a true match by the
+			// helper's contract. Recorded so the distinction is deliberate: the
+			// guard's subject is "the file says this", and only comments are
+			// excluded, not every non-statement occurrence.
+			name: "named inside a string literal",
+			src:  "package p\nvar s = \"s.sendCapabilities(conn)\"\n",
+			want: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sourceContainsFlat(tc.src, needle); got != tc.want {
+				t.Fatalf("sourceContainsFlat(%q) = %v, want %v", tc.src, got, tc.want)
+			}
+		})
+	}
 }

--- a/pkg/config/compiler_zone_interfaces_packed_tail_6735_test.go
+++ b/pkg/config/compiler_zone_interfaces_packed_tail_6735_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -122,7 +123,17 @@ func TestZoneInterfaces6735PackedTailRejectedAndPositiveControl(t *testing.T) {
 					t.Fatalf("CompileConfig ACCEPTED the ambiguous stanza %q; the truncator silently keeps only the names before `host-inbound-traffic`, so %q is dropped (#6735)",
 						tc.stanza, tc.wantLost)
 				}
-				for _, want := range []string{`"Z"`, "host-inbound-traffic", tc.wantLost} {
+				// #7028: the keyword is asserted through the RENDERED fragment,
+				// not as a bare substring. `host-inbound-traffic` also appears
+				// verbatim in the template's "rewrite in the block spelling"
+				// clause, so `strings.Contains(err, "host-inbound-traffic")`
+				// held for every reject this gate produced — including one whose
+				// %q argument was a constant. The detector returns the matched
+				// keyword precisely so the message cannot name the wrong token
+				// (see zoneInterfaceKeysBeforeBody's doc comment), and that is
+				// the property this row is here to bind.
+				wantKeyword := fmt.Sprintf("with %q followed by", "host-inbound-traffic")
+				for _, want := range []string{`"Z"`, wantKeyword, tc.wantLost} {
 					if !strings.Contains(err.Error(), want) {
 						t.Fatalf("reject error %q does not name %q — the message must identify the zone, the keyword, and the tokens that would have been dropped (#6735)",
 							err.Error(), want)

--- a/pkg/dataplane/userspace/screens_ssot_source_5806_test.go
+++ b/pkg/dataplane/userspace/screens_ssot_source_5806_test.go
@@ -3,6 +3,8 @@ package userspace
 import (
 	"encoding/json"
 	"fmt"
+	goscanner "go/scanner"
+	"go/token"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -97,15 +99,19 @@ func TestScreenUnresolvedDispositionHasOneSource(t *testing.T) {
 	// failure mode being defended against is an ordinary copy-paste of a
 	// sentence, not an adversary hand-obfuscating one.
 	//
-	// Known FALSE POSITIVE, pre-existing and deliberately not fixed here: the
-	// scan counts raw source bytes, so quoting this sentence inside a `//`
-	// comment in any non-test .go under pkg/ or cmd/ also reds the guard —
-	// measured — with a message asserting a duplicated literal that "lets the
-	// metric HELP and the status block drift". A comment cannot cause drift. It
-	// predates round 2 (round 1 counted raw bytes too) and is left alone, but
-	// screens.go and server_show_security_text.go now carry long comments ABOUT
-	// this sentence, so a near-miss is one reword away: if this guard reds on a
-	// file you only added prose to, that is this, not a duplicated literal.
+	// FIXED in #7061. The scan used to count raw source bytes, so quoting this
+	// sentence inside a `//` comment in any non-test .go under pkg/ or cmd/ red
+	// the guard — measured — with a message asserting a duplicated literal that
+	// "lets the metric HELP and the status block drift". A comment cannot cause
+	// drift, and the risk was not theoretical: screens.go and
+	// server_show_security_text.go carry long comments ABOUT this sentence, so
+	// the guard was one reword away from firing on prose.
+	//
+	// Comments are now blanked before the count (blankGoComments). That also
+	// narrows escape 1 above — a `+` seam interrupted by a comment is spliceable
+	// once the comment is whitespace — which is measured in
+	// TestBlankGoCommentsHidesProseAndExposesACommentInterruptedSeam_7061.
+	// Escapes 2, 3 and 4 are unchanged and remain deliberate limits.
 	total := 0
 	var hits []string
 	for _, sub := range []string{"pkg", "cmd"} {
@@ -118,7 +124,7 @@ func TestScreenUnresolvedDispositionHasOneSource(t *testing.T) {
 			if rerr != nil {
 				return nil
 			}
-			if n := strings.Count(concatSplice.ReplaceAllString(string(b), ""), fragment); n > 0 {
+			if n := strings.Count(concatSplice.ReplaceAllString(blankGoComments(string(b)), ""), fragment); n > 0 {
 				total += n
 				hits = append(hits, fmt.Sprintf("%s (x%d)", p, n))
 			}
@@ -161,7 +167,7 @@ func TestScreenUnresolvedDispositionHasOneSource(t *testing.T) {
 		// A split-concatenation copy: two adjacent quoted chunks that together
 		// reproduce the sentence. Normalising away Go string concatenation and
 		// re-counting catches it where the plain scan cannot.
-		normalised := concatSplice.ReplaceAllString(body, "")
+		normalised := concatSplice.ReplaceAllString(blankGoComments(body), "")
 		if n := strings.Count(normalised, fragment); n > 0 && consumer != filepath.Join(
 			root, "pkg", "dataplane", "userspace", "screens.go") {
 			t.Errorf("%s appears to inline the disposition via a split string "+
@@ -175,6 +181,42 @@ func TestScreenUnresolvedDispositionHasOneSource(t *testing.T) {
 // spacing — so a literal deliberately broken across chunks can be rejoined and
 // compared against the shared sentence.
 var concatSplice = regexp.MustCompile(`"\s*\+\s*\n?\s*"`)
+
+// blankGoComments replaces every Go comment in src with spaces, preserving the
+// byte offsets and the newlines of everything else so the concatSplice seam
+// regex and the offsets in any message still line up with the original file.
+//
+// #7061: without this the scan counted raw source bytes, so prose that merely
+// QUOTED the disposition sentence reddened a guard whose message asserts a
+// duplicated literal — a drift a comment cannot cause. The guard's subject is
+// what the program says, not what the file contains.
+//
+// The scanner tolerates a file that does not parse: it reports errors to the
+// handler and keeps going, and a malformed file would fail this package's own
+// build long before this test runs.
+func blankGoComments(src string) string {
+	out := []byte(src)
+	fset := token.NewFileSet()
+	f := fset.AddFile("", fset.Base(), len(src))
+	var sc goscanner.Scanner
+	sc.Init(f, []byte(src), func(token.Position, string) {}, goscanner.ScanComments)
+	for {
+		pos, tok, lit := sc.Scan()
+		if tok == token.EOF {
+			break
+		}
+		if tok != token.COMMENT {
+			continue
+		}
+		start := f.Offset(pos)
+		for i := start; i < start+len(lit) && i < len(out); i++ {
+			if out[i] != '\n' {
+				out[i] = ' '
+			}
+		}
+	}
+	return string(out)
+}
 
 // TestScreenMissingProfilesPublishedToSnapshot binds the publication path the
 // whole SSOT argument rests on (#5806): the metric and status block claim to
@@ -242,4 +284,61 @@ func TestScreenMissingProfilesPublishedToSnapshot(t *testing.T) {
 				i, wire.Refs[i].Zone, wire.Refs[i].Profile, want[i].Zone, want[i].Profile)
 		}
 	}
+}
+
+// #7061: blankGoComments' own contract, plus the one escape it narrows.
+//
+// The middle row is the point. TestScreenUnresolvedDispositionHasOneSource's
+// message asserts a duplicated LITERAL that "lets the metric HELP and the status
+// block drift"; a comment cannot cause that, so a guard that reds on prose is
+// asserting something it has not observed. Two production files already carry
+// long comments about this very sentence.
+func TestBlankGoCommentsHidesProseAndExposesACommentInterruptedSeam_7061(t *testing.T) {
+	const sentence = "no screen checks are applied"
+
+	t.Run("prose quoting the sentence is not counted", func(t *testing.T) {
+		src := "package p\n\n// Prose only: " + sentence + " to this zone.\nvar x = 1\n"
+		if strings.Count(src, sentence) != 1 {
+			t.Fatalf("fixture is wrong: the raw source must contain the sentence once")
+		}
+		if n := strings.Count(blankGoComments(src), sentence); n != 0 {
+			t.Fatalf("blankGoComments left %d occurrence(s) of a sentence that appears only in a comment", n)
+		}
+	})
+
+	t.Run("a real string literal is still counted", func(t *testing.T) {
+		src := "package p\n\nconst D = \"" + sentence + " to this zone\"\n"
+		if n := strings.Count(blankGoComments(src), sentence); n != 1 {
+			t.Fatalf("blankGoComments removed a real literal: %d occurrence(s), want 1", n)
+		}
+	})
+
+	t.Run("the sentence inside a block comment is not counted", func(t *testing.T) {
+		src := "package p\n\n/*\n" + sentence + " to this zone\n*/\nvar x = 1\n"
+		if n := strings.Count(blankGoComments(src), sentence); n != 0 {
+			t.Fatalf("blankGoComments left %d occurrence(s) of a sentence inside a block comment", n)
+		}
+	})
+
+	t.Run("byte offsets are preserved", func(t *testing.T) {
+		src := "package p\n\n// a comment\nconst D = \"x\"\n"
+		if got, want := len(blankGoComments(src)), len(src); got != want {
+			t.Fatalf("blankGoComments changed the length: %d, want %d — the concatSplice seam offsets depend on this", got, want)
+		}
+	})
+
+	t.Run("escape 1: a + seam interrupted by a comment becomes spliceable", func(t *testing.T) {
+		// Escape 1 in the scan's own list: a split-concatenation copy whose
+		// seam is interrupted by a `//` comment, which defeated concatSplice
+		// because the comment text sat between the two quotes. With the comment
+		// blanked to spaces the seam is whitespace again and splices.
+		src := "package p\n\nconst D = \"" + sentence + "\" + // seam\n\t\" to this zone\"\n"
+		if n := strings.Count(concatSplice.ReplaceAllString(src, ""), sentence+" to this zone"); n != 0 {
+			t.Fatalf("fixture is wrong: the RAW seam must not splice (that is what made it an escape); got %d", n)
+		}
+		spliced := concatSplice.ReplaceAllString(blankGoComments(src), "")
+		if n := strings.Count(spliced, sentence+" to this zone"); n != 1 {
+			t.Fatalf("blanking the comment did not make the seam spliceable: %d occurrence(s), want 1", n)
+		}
+	})
 }


### PR DESCRIPTION
One family, three instances: a guard whose subject is *"the program does X"*, implemented as a search over bytes that include text the program does not execute. Each fails to a value **indistinguishable from healthy**, so review cannot see them — only a paired mutation can.

**The paired shape is used throughout.** With the bad input, the guard *removed* must give the healthy verdict (proving the defect really was invisible) and the guard *restored* must give the unhealthy one (proving the fix sees it). A lone "delete the guard and watch it red" cell shows correlation only.

---

## #7028 — an assertion the reject template satisfies by itself

```go
for _, want := range []string{`"Z"`, "host-inbound-traffic", tc.wantLost} {
```

`validateZoneInterfacePackedTailStrict`'s template embeds that literal in its own *"rewrite in the block spelling"* clause, so `strings.Contains(err, "host-inbound-traffic")` held for **every** reject the gate can produce — whatever the detector put in `keyword`. The detector returns the matched keyword deliberately (`zoneInterfaceKeysBeforeBody`: *"adding a second entry to `zoneInterfaceBodyKeywords` cannot leave the reject naming the wrong token"*), which is precisely the property the assertion looked like it bound and did not.

Now asserted through the **rendered** fragment `with %q followed by`.

### Paired cell — production `%q` keyword argument → constant `"BOGUS"`

14 collected in every cell, 0 build errors.

| cell | assertion | failed |
|---|---|---|
| control | fixed | 0 |
| mutation | **fixed** | 7 |
| mutation | **master's** | **0** |
| restored | fixed | 0 |

> **Method note.** The first attempt at row 3 reported 7 failures and appeared to *refute* the issue. The backup it restored had been taken *after* the fix was applied, so the "master" row was re-running the fixed assertion. Re-derived with `git show origin/master:<path>`, it is 0. A restore-from-backup is only as good as when the backup was taken.

---

## #7061 — a source scan that counted comments

`TestScreenUnresolvedDispositionHasOneSource` counted raw source bytes, so **prose quoting the sentence** reddened it — with a message asserting a duplicated literal that *"lets the metric HELP and the status block drift"*, which a comment cannot cause. The test's own comment recorded this as a known false positive, and two production files already carry long comments *about* that sentence, so it was one reword from firing.

Comments are now blanked (`blankGoComments`) before the count, preserving byte offsets so the `concatSplice` seam regex still lines up.

**It also narrows escape 1** of the scan's documented limits: a `+` seam interrupted by a `//` comment defeated `concatSplice` because the comment sat between the two quotes; blanked to spaces, the seam splices. Measured in a test row, not assumed. Escapes 2–4 are unchanged and remain deliberate limits.

### Paired cell

| plant | scanner | failed | message |
|---|---|---|---|
| none | fixed | 0 | — |
| a **comment** quoting the sentence in `pkg/api/nat.go` | fixed | **0** | false positive gone |
| the same comment | **master's** | **1** | `found 2 occurrence(s)` |
| a real duplicate **literal** (`var _ = "…"`) | fixed | **1** | `found 2 occurrence(s)` |
| none | fixed | 0 | — |

Rows 3 and 4 matter *together*: the fix removed the false positive **without** blinding the guard to the true one. Both plants were confirmed to build (`go build ./pkg/api/` rc=0), so neither cell is a build break wearing the shape of a result.

---

## #7449 — a whitespace-flattened text search, comments included

`sourceContainsFlat` flattened the raw file text, so every guard built on it was satisfiable by prose — the *most likely* way a pinned call ever disappears, because whoever removes it leaves a note saying so and the note names the call. `sync_conn.go` already carries prose about `sendCapabilities` beside the call it pins.

**The issue named one call site; the helper backs eight.** The fix is therefore in the helper and no call site changed. It now tokenises with `go/scanner` (no `ScanComments`) and searches the re-emitted token text. Whitespace insensitivity is unchanged.

### Paired cell — delete `s.sendCapabilities(conn)`, leave a comment naming it

| cell | helper | ran | failed |
|---|---|---|---|
| control | fixed | 1 | 0 |
| mutation | **fixed** | 1 | **1** — `TestCapabilityAdvertisedOnConnectionInstall6650` |
| mutation | **master's** | 1 | **0** |
| restored | fixed | 1 | 0 |

### A claim in the helper's doc comment that is false — pinned, not fixed

The doc says the needle *"still matches when gofmt has wrapped the call across lines"*. For an **argument-list** wrap that is false in **both** the old and the new helper: gofmt puts the closing paren on its own line and adds a trailing comma, so the flattened text is `s.sendCapabilities(conn,)` and the needle does not occur in it. Verified directly against master's helper, so it is not a regression from the tokenising change.

Pinned with a test row rather than fixed: making the search comma-insensitive would loosen all eight guards to buy tolerance for a shape none of the pinned calls has (all single-argument, all one line). The row exists so the next reader learns this from a test rather than from a guard that went quiet after an unrelated reformat.

---

## Validation

- `-run` filters checked for selectivity, since a filter matching nothing exits 0 and prints `ok`: `TestZoneInterfaces6735Packed` → 14, `6650` → 8, `7449` → 1, `7061` → 1 (5 subtests).
- Repo-wide `go test -count=1 ./...` posted as a comment when it finishes.
- No Rust files touched.

Docs: `docs/log/7028.md`.

Closes #7028
Closes #7061
Closes #7449