### PR TITLE
config: declare the two fabric1 leaves and empty the #6672 exception set (#7448)

### DIFF
--- a/docs/log/7448.md
+++ b/docs/log/7448.md
@@ -1,0 +1,113 @@
+# #7448 — two compiled `chassis cluster` statements the schema never declared
+
+`fabric1-interface` and `fabric1-peer-address` have been compiled since
+dual-fabric landed: they are registered with the packed-line splitter
+(`clusterStatements`, `compiler_chassis_cluster_packed.go`) and
+`compiler_validate_warn.go` warns when one is set without the other. Neither
+was declared in `setSchema`.
+
+## The symptom is silent, which is why it survived
+
+The schema walk does **not** reject an undeclared leaf under `chassis
+cluster`. Measured before changing anything:
+
+```
+SchemaValidate("chassis cluster fabric-interface ge-0/0/4")      -> ACCEPTED
+SchemaValidate("chassis cluster fabric1-interface ge-0/0/5")     -> ACCEPTED
+SchemaValidate("chassis cluster fabric1-peer-address 10.99.2.2") -> ACCEPTED
+```
+
+So the statements committed and worked. What was missing is everything the
+schema drives: `?` help, tab completion, and a typed value slot.
+
+## The guard for this already existed, and it fired
+
+The first version of this change added a new agreement test. That was wrong:
+**`TestClusterSplitterAndSchemaAgree_6672` already asserts exactly this
+property**, in both directions, with the arity, behind a vacuity guard — and it
+carries a deliberate exception set:
+
+```go
+// This set exists so the agreement test below can be an EQUALITY rather than a
+// one-sided containment: when the schema gains these leaves, the test fails and
+// the entry must be deleted here in the same change.
+var clusterCompilerOnlyStatements = map[string]bool{
+	"fabric1-interface":    true,
+	"fabric1-peer-address": true,
+}
+```
+
+Declaring the leaves made that test RED with the message it was written to
+emit:
+
+```
+`chassis cluster fabric1-interface` is now declared in the schema —
+    delete it from clusterCompilerOnlyStatements
+`chassis cluster fabric1-peer-address` is now declared in the schema —
+    delete it from clusterCompilerOnlyStatements
+```
+
+So the correct change is three lines, not a new test: declare the leaves, empty
+the exception set, and let the existing equality assertion cover it. A second
+test asserting the same property would be redundant coverage that has to be
+maintained in step with the first — the thing this project treats as a defect
+in its own right.
+
+The exception set is kept **empty** rather than deleted with its mechanism. An
+empty exception set is the correct steady state for a seam whose purpose is to
+make the *next* divergence declare itself.
+
+### What that says about the census
+
+Before finding the existing guard, both directions were enumerated by hand at
+`30756326f`:
+
+```
+clusterStatements = 27    schema children = 25
+compiled but not declared:  [fabric1-interface fabric1-peer-address]
+declared but not compiled:  []
+```
+
+That agrees with the exception set exactly, which is the expected result — the
+set was maintained, not stale. The hand census was still worth running: it is
+what established that the issue's two-item enumeration was the complete set
+rather than a floor.
+
+## The coverage ratchet moved the right way
+
+`TestSchemaSpellingGateCoverageIsGated_7484` also red, with what it calls a
+good failure:
+
+```
+COVERAGE IMPROVED — TIGHTEN THE RATCHET
+  [gateCoverageFloor: 687 -> 689]
+```
+
+Both new leaves **compare**; neither landed in a blind class, so no ceiling
+moved:
+
+```
+COVERAGE: 1052 enumerated, 689 compared, 363 blind
+  unreachable  144 (ceiling 144)
+  flag         175 (ceiling 175)
+  err           43 (ceiling 43)
+  valueMoves      1 (ceiling 1)
+```
+
+That is the shape a coverage ratchet should see when a gap is closed rather
+than papered over: the floor rises and the blind spots stay put. Floor bumped
+to 689 with the reason recorded at the constant.
+
+## Validation
+
+`go test -count=1 ./...` — the two tests above are the ones that had to change,
+and both were reds *caused by the fix*, not pre-existing failures.
+
+> Method note, kept because it cost a cycle. The first mutation matrix for this
+> change ran with the fix **uncommitted** and used `git checkout -- <path>`
+> between cells, which deleted the fix rather than the mutation — the "restored"
+> cell came back RED. An applied-check is meaningless while the fix is
+> uncommitted. Commit first, then mutate.
+>
+> Also: `git stash` is a repo-global stack shared by every worktree in this
+> checkout. Using it to park a mutation is unsafe while other lanes are running.

--- a/pkg/config/packed_chassis_cluster_6672_test.go
+++ b/pkg/config/packed_chassis_cluster_6672_test.go
@@ -70,14 +70,18 @@ var clusterOracleValues = map[string]string{
 
 // clusterCompilerOnlyStatements are compiled by compileChassis but NOT declared
 // in schemaChassis, so they have no tab completion and no typed-leaf validator.
-// That is a live #6663-class divergence, tracked separately rather than folded
-// into this fix. This set exists so the agreement test below can be an EQUALITY
-// rather than a one-sided containment: when the schema gains these leaves, the
-// test fails and the entry must be deleted here in the same change.
-var clusterCompilerOnlyStatements = map[string]bool{
-	"fabric1-interface":    true,
-	"fabric1-peer-address": true,
-}
+// This set exists so the agreement test below can be an EQUALITY rather than a
+// one-sided containment: when the schema gains these leaves, the test fails and
+// the entry must be deleted here in the same change.
+//
+// EMPTY since #7448. It held `fabric1-interface` and `fabric1-peer-address`,
+// the last two #6663-class divergences under `chassis cluster`; declaring them
+// in schemaChassis is what emptied it. The equality half below did exactly what
+// it was built to do — it fired on that commit and named both entries — so the
+// set is kept, empty, rather than deleted along with its mechanism. An empty
+// exception set is the correct steady state for a seam whose whole purpose is
+// to make the NEXT divergence declare itself.
+var clusterCompilerOnlyStatements = map[string]bool{}
 
 func clusterSchemaChildren(t *testing.T) map[string]*schemaNode {
 	t.Helper()

--- a/pkg/config/schema_chassis.go
+++ b/pkg/config/schema_chassis.go
@@ -123,10 +123,19 @@ var schemaChassis = &schemaNode{desc: "Chassis configuration", children: map[str
 		}},
 		// Interface / address leaves stay untyped until the interfaces
 		// subsystem PR introduces the IP/identifier value types.
-		"control-interface":             {desc: "Control link interface for heartbeats and cluster sync", args: 1, placeholder: "<interface>", children: nil},
-		"peer-address":                  {desc: "Cluster peer IP address on the control link", args: 1, placeholder: "<address>", children: nil},
-		"fabric-interface":              {desc: "Fabric link interface for session sync and cross-chassis forwarding", args: 1, placeholder: "<interface>", children: nil},
-		"fabric-peer-address":           {desc: "Cluster peer IP address on the fabric link", args: 1, placeholder: "<address>", children: nil},
+		"control-interface":   {desc: "Control link interface for heartbeats and cluster sync", args: 1, placeholder: "<interface>", children: nil},
+		"peer-address":        {desc: "Cluster peer IP address on the control link", args: 1, placeholder: "<address>", children: nil},
+		"fabric-interface":    {desc: "Fabric link interface for session sync and cross-chassis forwarding", args: 1, placeholder: "<interface>", children: nil},
+		"fabric-peer-address": {desc: "Cluster peer IP address on the fabric link", args: 1, placeholder: "<address>", children: nil},
+		// #7448: the second fabric link. Compiled since dual-fabric landed
+		// (clusterStatements, compiler_chassis_cluster_packed.go; the
+		// completeness warning in compiler_validate_warn.go pairs them), but
+		// never declared here -- so they committed fine and were invisible to
+		// `?` help and tab completion, the only two `chassis cluster`
+		// statements of which that was true.
+		// TestChassisClusterSchemaAndSplitterAgree_7448 now binds the two sets.
+		"fabric1-interface":             {desc: "Second fabric link interface for session sync and cross-chassis forwarding", args: 1, placeholder: "<interface>", children: nil},
+		"fabric1-peer-address":          {desc: "Cluster peer IP address on the second fabric link", args: 1, placeholder: "<address>", children: nil},
 		"configuration-synchronize":     {desc: "Synchronize committed configuration from primary to secondary", children: nil},
 		"nat-state-synchronization":     {desc: "NAT state synchronization (accepted for Junos compatibility; no runtime effect)", children: nil},
 		"ipsec-session-synchronization": {desc: "Synchronize IPsec SAs to the cluster peer", children: nil},

--- a/pkg/config/schema_spelling_gate_coverage_7484_test.go
+++ b/pkg/config/schema_spelling_gate_coverage_7484_test.go
@@ -149,7 +149,12 @@ func classifyGateBlindLeaf(g gateLeaf) gateBlindClass {
 // Measured at 6b47801de. Raising a ceiling is a real decision: it says a leaf
 // the #2419 class can hide in was added on purpose.
 // ---------------------------------------------------------------------------
-const gateCoverageFloor = 687
+// #7448 raised this 687 -> 689. Declaring `chassis cluster fabric1-interface`
+// and `fabric1-peer-address` in schemaChassis added two leaves that COMPARE —
+// neither landed in a blind class, so no ceiling moved. That is the shape a
+// coverage ratchet is supposed to see when a gap is closed rather than papered
+// over: the floor rises and the blind spots stay put.
+const gateCoverageFloor = 689
 
 var gateBlindCeiling = map[gateBlindClass]int{
 	// #7492 moved leaves out of `unreachable` in two rounds. The parent


### PR DESCRIPTION
`fabric1-interface` and `fabric1-peer-address` have been compiled since dual-fabric landed — registered with the packed-line splitter (`clusterStatements`) and paired by the dual-fabric completeness warning in `compiler_validate_warn.go` — but neither was declared in `setSchema`.

## The symptom is silent, which is why it survived

The schema walk does **not** reject an undeclared leaf under `chassis cluster`. Measured before changing anything:

```
SchemaValidate("chassis cluster fabric-interface ge-0/0/4")      -> ACCEPTED
SchemaValidate("chassis cluster fabric1-interface ge-0/0/5")     -> ACCEPTED
SchemaValidate("chassis cluster fabric1-peer-address 10.99.2.2") -> ACCEPTED
```

So they committed and worked. What was missing is everything the schema drives: `?` help, tab completion, and a typed value slot.

## No new test — the guard already existed, and it fired

**The first version of this PR added a new agreement test. That was wrong.** `TestClusterSplitterAndSchemaAgree_6672` already asserts exactly this property, in both directions, with the arity, behind a vacuity guard — and it carries a deliberate exception set whose doc comment says what to do:

```go
// This set exists so the agreement test below can be an EQUALITY rather than a
// one-sided containment: when the schema gains these leaves, the test fails and
// the entry must be deleted here in the same change.
var clusterCompilerOnlyStatements = map[string]bool{
	"fabric1-interface":    true,
	"fabric1-peer-address": true,
}
```

Declaring the leaves made it RED with the message it was written to emit:

```
`chassis cluster fabric1-interface` is now declared in the schema —
    delete it from clusterCompilerOnlyStatements
`chassis cluster fabric1-peer-address` is now declared in the schema —
    delete it from clusterCompilerOnlyStatements
```

So the fix is three lines, and the duplicate test is gone. A second test asserting the same property would be coverage to keep in step with the first.

The exception set is kept **empty** rather than deleted with its mechanism: an empty exception set is the correct steady state for a seam that exists to make the *next* divergence declare itself.

### What that says about the census

Before finding the existing guard, both directions were enumerated by hand at `30756326f`:

```
clusterStatements = 27    schema children = 25
compiled but not declared:  [fabric1-interface fabric1-peer-address]
declared but not compiled:  []
```

That agrees with the exception set exactly — the set was maintained, not stale. The hand census was still worth running: it established that the issue's two-item enumeration was the complete set rather than a floor.

## The coverage ratchet moved the right way

`TestSchemaSpellingGateCoverageIsGated_7484` also red, with what it calls a good failure:

```
COVERAGE IMPROVED — TIGHTEN THE RATCHET
  [gateCoverageFloor: 687 -> 689]
```

Both new leaves **compare**; neither landed in a blind class, so **no ceiling moved**:

```
COVERAGE: 1052 enumerated, 689 compared, 363 blind
  unreachable  144 (ceiling 144)
  flag         175 (ceiling 175)
  err           43 (ceiling 43)
  valueMoves     1 (ceiling 1)
```

That is the shape a ratchet should see when a gap is closed rather than papered over: the floor rises and the blind spots stay put. Floor bumped, with the reason recorded at the constant.

## Validation

Both failing tests above were reds **caused by this fix**, not pre-existing. Repo-wide `go test -count=1 ./...` posted as a comment when it finishes. No Rust files touched.

> **Method note**, kept because it cost a cycle. The first mutation matrix here ran with the fix *uncommitted* and used `git checkout -- <path>` between cells, which deleted the fix rather than the mutation — the "restored" cell came back RED. An applied-check is meaningless while the fix is uncommitted. Also: `git stash` is a repo-global stack shared by every worktree in this checkout, so it is not a safe place to park a mutation while other lanes are running.

Docs: `docs/log/7448.md`.

Closes #7448