### PR TITLE
test: close the method-value bypass in two source canaries (#7003, #7004)

### DIFF
--- a/docs/log/7003.md
+++ b/docs/log/7003.md
@@ -1,0 +1,109 @@
+# #7003 / #7004 — two canaries keyed on a NAME in a POSITION
+
+Both guards asked "does this function call X?" and answered it by looking for
+a *shape* — a direct callee identifier in one case, a rendered call string in
+the other. The property is about the name being **referenced at all**, so a
+method value walks past both while leaving them green.
+
+This family has already been compiled and measured in this tree. #6871 round 13
+found it live in `link_cycle_acquisition_site_6871_test.go`:
+`take := m.acquireLinkCycleLease` inside the allowlisted function, then
+identifier calls elsewhere, passed both static guards while creating a
+self-renewing lease outside the deferred-abandon extent.
+
+## #7003 — `call.Fun.(*ast.Ident)` only
+
+`TestProgramBootstrapWorkerCountDataFlow_5718` prohibited the clamp helpers by
+matching only the direct callee identifier of a call expression, so
+
+```go
+f := effectiveWorkers
+f(...)
+```
+
+invoked the helper with its only named reference on an assignment RHS the
+matcher never inspected.
+
+**The fix is not a longer list of call shapes.** The property is that
+`programBootstrapMapsLocked` does not reach around `planUserspaceWorkers`, and
+a reference in ANY position is a reach-around. Dropping the position condition
+also makes this guard match its own sibling in the same test — the `cfg.Workers`
+count, which has always been position-free, which is why *that* one has no
+bypass.
+
+### Half of the prohibition list is inert, and stays
+
+The list names `heartbeatZeroSlots` and `effectiveWorkers`. Only the second
+exists:
+
+```
+$ grep -rn "func heartbeatZeroSlots" pkg/     -> no match
+$ grep -rn "func effectiveWorkers" pkg/       -> maps_sync.go:1859
+```
+
+`heartbeatZeroSlots` survives only in comments (it was absorbed around #6702).
+A prohibition on a name nothing can reference is inert — it is not wrong, and it
+becomes live again if the name returns, so the entry is kept. Recorded here so
+the guard is not read as covering two helpers when it currently covers one. The
+mutation cell below therefore uses `effectiveWorkers`, the half that is live.
+
+## #7004 — `strings.Contains` over rendered call text
+
+`shim_loader_boundary_test.go` looked for `.Load()` and `.Compile(cfg)` in the
+printed function body. That has two holes, not one:
+
+1. **A method value.** `load := x.Load; load()` calls it; the literal never
+   appears.
+2. **Argument and receiver spelling.** `m.Compile(cfg)` is hard-coded, so
+   renaming a local or a parameter retires the guard — a *refactor* silently
+   turns a guard off, and it stays green either way.
+
+Every check now keys on the AST:
+
+- **Prohibitions are position-free**, for the same reason as #7003. That is
+  deliberately stronger than "is called here": a method value taken and stored
+  *is* the escape, so refusing the reference outright is the property, not an
+  approximation of it.
+- **The adapter requirements bind by binding, not by spelling.** The receiver
+  must be whatever `a.managerOrErr()` returned, and every argument must be one
+  of the enclosing function's own parameters. Binding the receiver to the
+  manager is also the stronger claim: routing through *some* `.Load` was never
+  the property.
+- **The legacy-token sweep moves from substring to identifier occurrence**,
+  which additionally removes its false-positive surface — a token could
+  previously match inside a longer identifier.
+
+#6647's printer round-trip is kept where a rendered form is still wanted, but
+only for the failure MESSAGE, never for a decision.
+
+## Paired cells
+
+The paired shape throughout: with the bad input, the guard **removed** must give
+the healthy verdict (the defect really was invisible) and the guard **restored**
+must give the unhealthy one. Every cell was confirmed to BUILD (`go build` rc=0)
+and to collect its tests, so no cell is a build break wearing the shape of a
+result.
+
+| cell | plant | guard | ran | failed |
+|---|---|---|---|---|
+| control | none | fixed | 3 | 0 |
+| **E1** (#7003) | `escape7003 := effectiveWorkers` in `programBootstrapMapsLocked` | fixed | 3 | **1** — `TestProgramBootstrapWorkerCountDataFlow_5718` |
+| E1 | same | **master's** | 1 | **0** |
+| **E2** (#7004) | `legacy7004 := m.bpfShim.Load` in `(*Manager).Load` | fixed | 1 | **1** — `references the legacy .Load method 1 time(s)` |
+| E2 | same | **master's** | 1 | **0** |
+| restored | none | fixed | 3 | 0 |
+
+### E3 — the fragility, in the other direction
+
+E1 and E2 show the guards missing a real escape. E3 shows the text guard
+*firing on something that is not one*: renaming the adapter's `Compile`
+parameter from `cfg` to `c`, a pure refactor with no behaviour change.
+
+| guard | failed | |
+|---|---|---|
+| fixed | **0** | correct — a rename is not a defect |
+| master's | **1** | `legacy adapter Compile must route through userspace Manager.Compile` |
+
+A guard that reds on a rename is the same defect as one that stays green on an
+escape: in both cases the verdict is not about the property. The first costs a
+cycle to disprove; the second costs the property.

--- a/pkg/dataplane/userspace/shim_loader_boundary_test.go
+++ b/pkg/dataplane/userspace/shim_loader_boundary_test.go
@@ -15,29 +15,68 @@ import (
 func TestUserspaceStartupUsesShimLoaderBoundary(t *testing.T) {
 	t.Parallel()
 
-	loadSrc := goFunctionSource(t, "manager.go", "Load")
-	if !strings.Contains(loadSrc, "LoadUserspaceShim") {
-		t.Fatalf("userspace Load must use LoadUserspaceShim, got:\n%s", loadSrc)
+	// #7004: every check below keys on the AST, not on rendered call text.
+	//
+	// A text match on `.Load()` cannot see a method value — `f := x.Load; f()`
+	// invokes it while the literal never appears — and a text match on
+	// `m.Compile(cfg)` additionally breaks on any respelling of the receiver or
+	// the argument, so ordinary refactoring silently retires the guard. Both
+	// failure modes leave the guard GREEN, which is the shape this project keeps
+	// paying for.
+	//
+	// The prohibitions are therefore POSITION-FREE: any reference to the banned
+	// method, in any position, is a violation. That is deliberately stronger than
+	// "is called here" — a method value taken and stored is exactly the escape,
+	// so refusing the reference outright is the property, not an approximation
+	// of it. The requirements bind the RECEIVER and ARGUMENT by what they are
+	// bound to rather than by how they are spelled.
+
+	loadFn, loadFset := funcDeclOf7004(t, "manager.go", "Load")
+	if selectorRefs7004(loadFn)["LoadUserspaceShim"] == 0 {
+		t.Errorf("userspace Load must use LoadUserspaceShim:\n%s", renderDecl7004(t, loadFset, loadFn))
 	}
-	if strings.Contains(loadSrc, ".Load()") {
-		t.Fatalf("userspace Load must not call legacy Manager.Load:\n%s", loadSrc)
+	if n := selectorRefs7004(loadFn)["Load"]; n != 0 {
+		t.Errorf("userspace Load references the legacy .Load method %d time(s); it must not, in any "+
+			"position — taking it as a method value calls it just as effectively as invoking it "+
+			"directly (#7004):\n%s", n, renderDecl7004(t, loadFset, loadFn))
 	}
 
-	compileSrc := goFunctionSource(t, "manager_compile.go", "Compile")
-	if !strings.Contains(compileSrc, "CompileUserspaceShim") {
-		t.Fatalf("userspace Compile must use CompileUserspaceShim, got:\n%s", compileSrc)
+	compileFn, compileFset := funcDeclOf7004(t, "manager_compile.go", "Compile")
+	if selectorRefs7004(compileFn)["CompileUserspaceShim"] == 0 {
+		t.Errorf("userspace Compile must use CompileUserspaceShim:\n%s", renderDecl7004(t, compileFset, compileFn))
 	}
-	if strings.Contains(compileSrc, ".Compile(cfg)") {
-		t.Fatalf("userspace Compile must not call legacy Manager.Compile:\n%s", compileSrc)
+	if n := selectorRefs7004(compileFn)["Compile"]; n != 0 {
+		t.Errorf("userspace Compile references the legacy .Compile method %d time(s); it must not, in "+
+			"any position (#7004):\n%s", n, renderDecl7004(t, compileFset, compileFn))
+	}
+	if n := allRefs7004(compileFn)["AttachTC"]; n != 0 {
+		t.Errorf("userspace Compile references AttachTC %d time(s); the userspace runtime must not "+
+			"attach TC programs (#7004):\n%s", n, renderDecl7004(t, compileFset, compileFn))
 	}
 
-	adapterLoadSrc := goFunctionSource(t, "legacy_dataplane.go", "Load")
-	if !strings.Contains(adapterLoadSrc, "m.Load()") || strings.Contains(adapterLoadSrc, "DataPlane.Load") {
-		t.Fatalf("legacy adapter Load must route through userspace Manager.Load:\n%s", adapterLoadSrc)
-	}
-	adapterCompileSrc := goFunctionSource(t, "legacy_dataplane.go", "Compile")
-	if !strings.Contains(adapterCompileSrc, "m.Compile(cfg)") || strings.Contains(adapterCompileSrc, "DataPlane.Compile") {
-		t.Fatalf("legacy adapter Compile must route through userspace Manager.Compile:\n%s", adapterCompileSrc)
+	// The adapter must route through the userspace Manager it obtained from
+	// managerOrErr. Binding "the receiver is whatever managerOrErr returned"
+	// instead of the literal `m` is what makes this survive a rename, and it is
+	// also the property that actually matters: routing through SOME `.Load` is
+	// not the claim, routing through THAT manager's is.
+	for _, tc := range []struct{ fn, method string }{{"Load", "Load"}, {"Compile", "Compile"}} {
+		adapterFn, adapterFset := funcDeclOf7004(t, "legacy_dataplane.go", tc.fn)
+		recv := managerOrErrBinding7004(adapterFn)
+		if recv == "" {
+			t.Errorf("legacy adapter %s does not bind the result of a.managerOrErr(); it cannot be "+
+				"routing through the userspace Manager:\n%s", tc.fn, renderDecl7004(t, adapterFset, adapterFn))
+			continue
+		}
+		if !callsMethodOn7004(adapterFn, recv, tc.method) {
+			t.Errorf("legacy adapter %s must call %s.%s() on the manager returned by managerOrErr "+
+				"(#7004 binds the receiver, not the spelling):\n%s",
+				tc.fn, recv, tc.method, renderDecl7004(t, adapterFset, adapterFn))
+		}
+		if n := qualifiedRefs7004(adapterFn)["DataPlane."+tc.method]; n != 0 {
+			t.Errorf("legacy adapter %s references DataPlane.%s %d time(s); it must route through the "+
+				"userspace Manager, not the legacy DataPlane (#7004):\n%s",
+				tc.fn, tc.method, n, renderDecl7004(t, adapterFset, adapterFn))
+		}
 	}
 }
 
@@ -48,25 +87,27 @@ func TestUserspaceShimLoaderDoesNotReferenceLegacyObjects(t *testing.T) {
 	// loader_userspace_shim.go. The pre-#1476 location at
 	// `../loader_ebpf.go` is deleted along with the legacy
 	// XDP/TC bpf2go batch it used to coexist with.
-	loaderSrc := goFunctionSource(t, filepath.Join("..", "loader_userspace_shim.go"), "loadUserspaceShimObjectsOnce")
-	if !strings.Contains(loaderSrc, "loadRustUserspaceXDP") {
-		t.Fatalf("userspace shim loader must load the retained Rust shim:\n%s", loaderSrc)
+	loaderFn, loaderFset := funcDeclOf7004(t, filepath.Join("..", "loader_userspace_shim.go"), "loadUserspaceShimObjectsOnce")
+	loaderRefs := allRefs7004(loaderFn)
+	if loaderRefs["loadRustUserspaceXDP"] == 0 {
+		t.Errorf("userspace shim loader must load the retained Rust shim:\n%s", renderDecl7004(t, loaderFset, loaderFn))
 	}
-	if !strings.Contains(loaderSrc, "userspaceShimEntryProg") {
-		t.Fatalf("userspace shim loader must register the explicit shim entry program:\n%s", loaderSrc)
+	if loaderRefs["userspaceShimEntryProg"] == 0 {
+		t.Errorf("userspace shim loader must register the explicit shim entry program:\n%s", renderDecl7004(t, loaderFset, loaderFn))
 	}
-	assertNoLegacyLoaderTokens(t, "loadUserspaceShimObjectsOnce", loaderSrc)
+	assertNoLegacyLoaderRefs7004(t, "loadUserspaceShimObjectsOnce", loaderRefs)
 
-	compileSrc := goFunctionSource(t, filepath.Join("..", "loader.go"), "CompileUserspaceShim")
-	assertNoLegacyLoaderTokens(t, "CompileUserspaceShim", compileSrc)
-	if strings.Contains(compileSrc, "AttachTC") {
-		t.Fatalf("CompileUserspaceShim must not attach TC programs:\n%s", compileSrc)
+	compileFn, _ := funcDeclOf7004(t, filepath.Join("..", "loader.go"), "CompileUserspaceShim")
+	compileRefs := allRefs7004(compileFn)
+	assertNoLegacyLoaderRefs7004(t, "CompileUserspaceShim", compileRefs)
+	if n := compileRefs["AttachTC"]; n != 0 {
+		t.Errorf("CompileUserspaceShim references AttachTC %d time(s); it must not attach TC programs (#7004)", n)
 	}
 }
 
-func assertNoLegacyLoaderTokens(t *testing.T, name, src string) {
+func assertNoLegacyLoaderRefs7004(t *testing.T, name string, refs map[string]int) {
 	t.Helper()
-	for _, token := range []string{
+	for _, tok := range []string{
 		"loadAllObjects",
 		"loadXpfXdp",
 		"loadXpfTc",
@@ -75,10 +116,162 @@ func assertNoLegacyLoaderTokens(t *testing.T, name, src string) {
 		"xdp_main_prog",
 		"tc_main_prog",
 	} {
-		if strings.Contains(src, token) {
-			t.Fatalf("%s must not reference legacy loader token %q:\n%s", name, token, src)
+		if n := refs[tok]; n != 0 {
+			t.Errorf("%s references legacy loader symbol %q %d time(s) (#7004: any position, not just "+
+				"as a direct callee)", name, tok, n)
 		}
 	}
+}
+
+// funcDeclOf7004 parses path and returns the named top-level declaration.
+//
+// Returning the DECLARATION rather than its rendered text is the #7004 change.
+// Comments were already excluded by #6647's printer round-trip; what a rendered
+// string still cannot express is the difference between a call and a method
+// value, or between an argument and its name.
+func funcDeclOf7004(t *testing.T, path, name string) (*ast.FuncDecl, *token.FileSet) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, data, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != name {
+			continue
+		}
+		return fn, fset
+	}
+	t.Fatalf("function %s not found in %s", name, path)
+	return nil, nil
+}
+
+func renderDecl7004(t *testing.T, fset *token.FileSet, fn *ast.FuncDecl) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := printer.Fprint(&buf, fset, fn); err != nil {
+		t.Fatalf("print %s: %v", fn.Name.Name, err)
+	}
+	return buf.String()
+}
+
+// selectorRefs7004 counts every X.Sel selector by its Sel name, in ANY position
+// — callee, method value, argument, assignment RHS. Position-free is the point:
+// a name-and-position matcher is defeated by `f := x.Load`.
+func selectorRefs7004(n ast.Node) map[string]int {
+	out := map[string]int{}
+	ast.Inspect(n, func(node ast.Node) bool {
+		if sel, ok := node.(*ast.SelectorExpr); ok {
+			out[sel.Sel.Name]++
+		}
+		return true
+	})
+	return out
+}
+
+// qualifiedRefs7004 counts selectors as "X.Sel" when the receiver is itself an
+// identifier or a selector, so a chain like a.legacy.DataPlane.Load registers as
+// "DataPlane.Load".
+func qualifiedRefs7004(n ast.Node) map[string]int {
+	out := map[string]int{}
+	ast.Inspect(n, func(node ast.Node) bool {
+		sel, ok := node.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		switch x := sel.X.(type) {
+		case *ast.Ident:
+			out[x.Name+"."+sel.Sel.Name]++
+		case *ast.SelectorExpr:
+			out[x.Sel.Name+"."+sel.Sel.Name]++
+		}
+		return true
+	})
+	return out
+}
+
+// allRefs7004 counts every identifier occurrence, bare or as a selector's Sel,
+// so a banned symbol cannot hide behind either spelling.
+func allRefs7004(n ast.Node) map[string]int {
+	out := map[string]int{}
+	ast.Inspect(n, func(node ast.Node) bool {
+		if id, ok := node.(*ast.Ident); ok {
+			out[id.Name]++
+		}
+		return true
+	})
+	return out
+}
+
+// managerOrErrBinding7004 returns the name the function binds the result of
+// a.managerOrErr() to, or "" if it never calls it.
+func managerOrErrBinding7004(fn *ast.FuncDecl) string {
+	name := ""
+	ast.Inspect(fn, func(node ast.Node) bool {
+		assign, ok := node.(*ast.AssignStmt)
+		if !ok || len(assign.Rhs) != 1 || len(assign.Lhs) == 0 {
+			return true
+		}
+		call, ok := assign.Rhs[0].(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "managerOrErr" {
+			return true
+		}
+		if id, ok := assign.Lhs[0].(*ast.Ident); ok && name == "" {
+			name = id.Name
+		}
+		return true
+	})
+	return name
+}
+
+// callsMethodOn7004 reports whether fn CALLS recv.method(...) — callee position
+// specifically, because here the claim is that the routing happens, and a method
+// value taken and never invoked would not route anything.
+//
+// For a method taking arguments it also requires every argument to be one of
+// fn's own parameters, so the check does not depend on what the argument is
+// NAMED — the respelling fragility #7004 is about.
+func callsMethodOn7004(fn *ast.FuncDecl, recv, method string) bool {
+	params := map[string]bool{}
+	if fn.Type.Params != nil {
+		for _, field := range fn.Type.Params.List {
+			for _, id := range field.Names {
+				params[id.Name] = true
+			}
+		}
+	}
+	found := false
+	ast.Inspect(fn, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != method {
+			return true
+		}
+		if id, ok := sel.X.(*ast.Ident); !ok || id.Name != recv {
+			return true
+		}
+		for _, arg := range call.Args {
+			id, ok := arg.(*ast.Ident)
+			if !ok || !params[id.Name] {
+				return true
+			}
+		}
+		found = true
+		return false
+	})
+	return found
 }
 
 func goFunctionSource(t *testing.T, path, name string) string {

--- a/pkg/dataplane/userspace/worker_count_single_source_5718_test.go
+++ b/pkg/dataplane/userspace/worker_count_single_source_5718_test.go
@@ -233,22 +233,40 @@ func TestProgramBootstrapWorkerCountDataFlow_5718(t *testing.T) {
 			"heartbeat loop came to describe the same quantity differently", rawReads, rawPos)
 	}
 
-	// (5) no direct clamp-helper call — every representation goes via the plan.
+	// (5) no clamp helper REFERENCED AT ALL — every representation goes via the
+	// plan.
+	//
+	// #7003: this used to match only call.Fun.(*ast.Ident), i.e. a prohibited
+	// helper recognised solely as the direct callee of a call expression. So
+	//
+	//	f := heartbeatZeroSlots
+	//	f(...)
+	//
+	// invoked the helper while the only reference to its name sat on an
+	// assignment RHS, which that matcher never inspected. The identical family
+	// was compiled and MEASURED as a live escape in
+	// link_cycle_acquisition_site_6871_test.go during #6871 round 13.
+	//
+	// The fix is not a longer list of call shapes to recognise. It is to drop
+	// the position condition: the property is "this function does not reach
+	// around the plan", and a reference in ANY position — callee, method value,
+	// argument, assignment RHS — is a reach-around. That also makes this guard
+	// match its own sibling above, the cfg.Workers count, which has always been
+	// position-free and is the reason that one has no bypass.
 	ast.Inspect(body, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
+		id, ok := n.(*ast.Ident)
 		if !ok {
 			return true
 		}
-		id, ok := call.Fun.(*ast.Ident)
-		if !ok {
+		if id.Name != "heartbeatZeroSlots" && id.Name != "effectiveWorkers" {
 			return true
 		}
-		if id.Name == "heartbeatZeroSlots" || id.Name == "effectiveWorkers" {
-			t.Fatalf("programBootstrapMapsLocked calls %s directly at %s. Reaching around the "+
-				"plan re-creates an independent derivation of the worker count — the exact "+
-				"drift planUserspaceWorkers exists to prevent — without reading cfg.Workers "+
-				"a second time", id.Name, fset.Position(call.Pos()))
-		}
+		t.Fatalf("programBootstrapMapsLocked references %s at %s. Reaching around the "+
+			"plan re-creates an independent derivation of the worker count — the exact "+
+			"drift planUserspaceWorkers exists to prevent — without reading cfg.Workers "+
+			"a second time. Any reference counts, not just a direct call: taking the "+
+			"helper as a value and invoking it later derives the same number by the same "+
+			"route (#7003)", id.Name, fset.Position(id.Pos()))
 		return true
 	})
 


### PR DESCRIPTION
Both guards asked *"does this function call X?"* and answered it by looking for a **shape** — a direct callee identifier in one case, a rendered call string in the other. The property is about the name being **referenced at all**, so a method value walks past both while leaving them green.

This family has already been compiled and measured in this tree: #6871 round 13 found it live in `link_cycle_acquisition_site_6871_test.go` — `take := m.acquireLinkCycleLease` inside the allowlisted function, then identifier calls elsewhere, passed both static guards while creating a self-renewing lease outside the deferred-abandon extent.

---

## #7003 — `call.Fun.(*ast.Ident)` only

The clamp-helper prohibition matched only the direct callee identifier of a call expression, so

```go
f := effectiveWorkers
f(...)
```

invoked the helper with its only named reference on an assignment RHS the matcher never inspected.

**The fix is not a longer list of call shapes.** The property is that `programBootstrapMapsLocked` does not reach around `planUserspaceWorkers`, and a reference in ANY position is a reach-around. Dropping the position condition also makes this guard match its own sibling in the same test — the `cfg.Workers` count, which has always been position-free, which is exactly why *that* one has no bypass.

### Half the prohibition list is inert, and stays

The list names `heartbeatZeroSlots` and `effectiveWorkers`. Only the second exists:

```
$ grep -rn "func heartbeatZeroSlots" pkg/   -> no match
$ grep -rn "func effectiveWorkers"   pkg/   -> maps_sync.go:1859
```

`heartbeatZeroSlots` survives only in comments (absorbed around #6702). A prohibition on a name nothing can reference is **inert** — not wrong, and live again if the name returns — so the entry is kept and the limit is recorded rather than the guard being read as covering two helpers when it currently covers one. The cell below therefore uses `effectiveWorkers`, the half that is live.

---

## #7004 — `strings.Contains` over rendered call text

Two holes, not one:

1. **A method value.** `load := x.Load; load()` calls it; the literal `.Load()` never appears.
2. **Argument and receiver spelling.** `m.Compile(cfg)` was hard-coded, so renaming a local or a parameter retires the guard — a *refactor* silently turns it off, and it is green either way.

Every check now keys on the AST:

- **Prohibitions are position-free**, same reason as #7003. Deliberately stronger than "is called here": a method value taken and stored *is* the escape, so refusing the reference outright is the property, not an approximation of it.
- **The adapter requirements bind by binding, not by spelling.** The receiver must be whatever `a.managerOrErr()` returned; every argument must be one of the enclosing function's own parameters. Binding the receiver to *that* manager is also the stronger claim — routing through *some* `.Load` was never the property.
- **The legacy-token sweep moves from substring to identifier occurrence**, which additionally removes its false-positive surface: a token could previously match inside a longer identifier.

#6647's printer round-trip is kept where a rendered form is still wanted, but only for the failure **message**, never for a decision.

---

## Paired cells

With the bad input, the guard **removed** must give the healthy verdict (the defect really was invisible) and the guard **restored** must give the unhealthy one. Every cell was confirmed to BUILD (`go build` rc=0) and to collect its tests, so no cell is a build break wearing the shape of a result.

| cell | plant | guard | ran | failed |
|---|---|---|---|---|
| control | none | fixed | 3 | 0 |
| **E1** (#7003) | `escape7003 := effectiveWorkers` in `programBootstrapMapsLocked` | fixed | 3 | **1** — `TestProgramBootstrapWorkerCountDataFlow_5718` |
| E1 | same | **master's** | 1 | **0** |
| **E2** (#7004) | `legacy7004 := m.bpfShim.Load` in `(*Manager).Load` | fixed | 1 | **1** — `references the legacy .Load method 1 time(s)` |
| E2 | same | **master's** | 1 | **0** |
| restored | none | fixed | 3 | 0 |

### E3 — the fragility, in the other direction

E1 and E2 show the guards missing a real escape. E3 shows the text guard **firing on something that is not one**: renaming the adapter's `Compile` parameter from `cfg` to `c`, a pure refactor with no behaviour change.

| guard | failed | |
|---|---|---|
| fixed | **0** | correct — a rename is not a defect |
| master's | **1** | `legacy adapter Compile must route through userspace Manager.Compile` |

A guard that reds on a rename is the same defect as one that stays green on an escape: in both cases the verdict is not about the property. The first costs a cycle to disprove; the second costs the property.

---

Repo-wide `go test -count=1 ./...` posted as a comment when it finishes. No Rust files touched.

Docs: `docs/log/7003.md`.

Closes #7003
Closes #7004