### PR TITLE
test/incus: correct the v6-blackhole hint the gate hands its reader

### DIFF
--- a/docs/log/6934.md
+++ b/docs/log/6934.md
@@ -76,3 +76,245 @@
     indistinguishable from one nobody thought about; only the documented kind
     has an expiry.
   - **File(s)**: test/incus/test-failover.sh
+
+---
+
+- **Timestamp**: 2026-08-28
+  - **Action**: closed the issue as **NOT REPRODUCIBLE** after six instrumented
+    manual failover transitions plus a complete 8-of-8 redundancy-group
+    placement sweep, all probed at 4 Hz (established flows) and 1 Hz (new TCP +
+    new ICMP flows) across the full post-failover window. Zero IPv6 blackholes.
+    The reporter's IPv4 line reproduces character for character — `10 packets
+    transmitted, 9 received, 10% packet loss` — and is #7770; IPv6 in the same
+    split loses exactly the same one packet, never more. `iperf3 -6` started
+    1.6 s into the window connected and ran to completion at 96 Mbit/s rather
+    than hanging. Full evidence in the "2026-08-28 measurement pass" section
+    below.
+  - **File(s)**: docs/log/6934.md
+
+- **Timestamp**: 2026-08-28
+  - **Action**: corrected a **measurably false mechanism claim in shipped code**.
+    `check_v6_transit`'s failure message told the next reader that "IPv4 can stay
+    healthy through this — ND holds a REACHABLE entry ~30s before probing, so a
+    stale or unannounced neighbour entry blackholes v6 while ARP re-resolves in
+    seconds". Measured on the actual LAN host, every neighbour parameter is
+    byte-identical between the families (`base_reachable_time_ms` 30000/30000,
+    `gc_stale_time` 60/60, `delay_first_probe_time` 5/5, `retrans_time_ms`
+    1000/1000, `ucast_solicit` 3/3, `mcast_solicit` 3/3), and a deliberately
+    poisoned gateway entry repairs in **8.51 s for IPv6 and 8.71 s for IPv4** —
+    symmetric to 0.2 s, and 8.5 s rather than 30 or 60. The claim mattered
+    because it tells an investigator that a v4/v6 asymmetry is EXPECTED from
+    neighbour timers, which is the wrong hint and is the shape this issue
+    already chased for three rounds (the same failure mode as the `garp.go`
+    Override comment fixed in #7769).
+  - **File(s)**: test/incus/test-failover.sh
+
+- **Timestamp**: 2026-08-28
+  - **Action**: closed a real coverage gap the report itself names. The symptom
+    is described as self-healing after ~60 s, and `check_v6_transit` sampled
+    ONCE immediately after the manual failover — a single sample can land before
+    a transient window opens or after it closes, and would report a clean pass
+    either way. Added a second assertion ~30 s later so a self-healing window is
+    sampled at two points rather than one.
+  - **File(s)**: test/incus/test-failover.sh
+
+- **Timestamp**: 2026-08-28
+  - **Action**: recorded an environment defect found on the way, not
+    family-specific and not the cause here: both cluster nodes report
+    `NTPSynchronized=no` and their clocks are **12.0 s apart** (measured three
+    times with RTT compensation). 12 s is inside the ±60 s fabric-auth window so
+    failovers work today, but the drift is unbounded and this is the same
+    condition that invalidated the first capture run in this thread (200 s skew
+    → `fabric RPC authentication failed: invalid auth token`).
+  - **File(s)**: none (measurement)
+
+---
+
+## 2026-08-28 measurement pass — full evidence
+
+Cluster `loss:xpf-userspace-fw0/fw1`, build
+`userspace-forwarding-ok-20260402-bfb00432-12507-gda3c4e44c-dirty`. Every
+trial ran inside a `./test/incus/with-cluster.sh` lock cell. Raw data under
+`/var/tmp/xpf-6934/`.
+
+### The instruments, and the proof they can see the symptom
+
+Measured from `loss:cluster-userspace-host`, whose `eth0` is an ordinary
+kernel netdev — `tcpdump` there is NOT subject to the AF_XDP blindness that
+applies to the firewalls' data interfaces. Armed 10 s BEFORE each failover
+and left running through it:
+
+| instrument | cadence | what it answers |
+|---|---|---|
+| `ping -D -i 0.25 -W 1` to `172.16.80.200` / `2001:559:8585:80::200` | 4 Hz | established-flow transit; a blackhole shows as a gap |
+| new TCP connect + `ping -c 1`, per family | 1 Hz | NEW-flow transit (the reporter's shape) |
+| `tcpdump 'icmp6 and ip6[40] >= 133 and ip6[40] <= 137'` | continuous | NS/NA/RS/RA incl. the unsolicited-NA burst |
+| `tcpdump -vv 'ip6[40] == 134'` | continuous | RA source address + Router Lifetime |
+| `ip -6 route show default`, `ip -6/-4 neigh` | 1 Hz | did the default route or the gateway neighbour entry move |
+| `ip -ts monitor route` | event | any route add/del at all |
+
+**Positive control.** A zero is only evidence once the instrument is proven
+non-zero, so the symptom was manufactured deliberately: overwrite the LAN
+host's neighbour entry for the default gateway with a bogus MAC in state
+`STALE` — exactly what a failover leaves behind if the unsolicited-NA /
+gratuitous-ARP burst never arrives.
+
+```
+ip -6 neigh replace fe80::bf72:16:2 lladdr 02:bf:72:16:02:99 dev eth0 nud stale
+
+v4(control):  replies=230  span=59.6s  max_gap=0.29s
+  GAP   8.51s  from t=+0.11 to t=+8.62
+v6(POISONED): replies=197  span=59.7s  max_gap=8.51s
+```
+
+The NUD walk, sampled at 2 Hz, shows exactly where the 8.5 s goes:
+
+```
+  -0.2  fe80::bf72:16:2 lladdr 02:bf:72:16:02:00 router REACHABLE
+  +0.4  fe80::bf72:16:2 lladdr 02:bf:72:16:02:99 STALE
+  +0.9  fe80::bf72:16:2 lladdr 02:bf:72:16:02:99 DELAY      <- delay_first_probe_time = 5
+  +5.5  fe80::bf72:16:2 lladdr 02:bf:72:16:02:99 PROBE      <- ucast_solicit 3 x retrans 1000 ms
+  +8.5  fe80::bf72:16:2 FAILED
+  +9.0  fe80::bf72:16:2 lladdr 02:bf:72:16:02:00 router REACHABLE
+```
+
+The mirrored IPv4 control (`ip -4 neigh replace 10.0.61.1 …`) gives
+`v4(POISONED) max_gap=8.71s` with `v6(control) max_gap=0.29s`. So a
+family-isolated blackhole IS visible to this probe set, and a `max_gap` of
+0.3 s is a real negative rather than an instrument that cannot see.
+
+### Candidate-timer table — every value measured, none assumed
+
+`~60 s` is a real number in this path — `gc_stale_time = 60` — but it is 60
+in **both** families and it is not the timer the repair runs through.
+
+| candidate | where | measured value | can it produce a **v6-only** ~60 s blackhole? |
+|---|---|---|---|
+| `neigh.eth0.base_reachable_time_ms` | LAN host | **v4=30000  v6=30000** | No — identical |
+| `neigh.eth0.gc_stale_time` | LAN host | **v4=60  v6=60** | No — identical; GCs *unused* entries, this one is in continuous use |
+| `neigh.eth0.delay_first_probe_time` | LAN host | **v4=5  v6=5** | No — identical |
+| `neigh.eth0.retrans_time_ms` | LAN host | **v4=1000  v6=1000** | No — identical (the #1636 drop to 250 applies to the firewall nodes, measured 252 there) |
+| `neigh.eth0.ucast_solicit` / `mcast_solicit` | LAN host | **v4=3/3  v6=3/3** | No — identical |
+| **end-to-end neighbour repair, poisoned STALE** | measured | **v6 8.51 s / v4 8.71 s** | **No — 8.5 s, not 60 s, symmetric to 0.2 s** |
+| **end-to-end neighbour repair, poisoned REACHABLE** | measured | **9.86 s** (the periodic RA's SLLA repairs it early) | No |
+| RA `default-lifetime` | config + wire | **180 s** on every captured RA, from both nodes | No |
+| RA `max/min-advertisement-interval` | config + wire | 30 / 10; observed gaps 10–29 s | No |
+| RA **source address** | wire | **always `fe80::bf72:16:2`** (stable RETH LLA) — from node0's MAC and node1's MAC alike | No |
+| RA gap **across an RG2 transition** | wire | last old-master RA `16:20:54.18` → first new-master RA `16:21:05.20` = **0.58 s after the failover command**, then 3 frames at 100 ms | No |
+| host IPv6 default route | LAN host, 1 Hz | exactly **one**, `via fe80::bf72:16:2`, never changed; `ip -ts monitor route` logged **no events at all** | No |
+| `DEFAULT_ICMP_SESSION_TIMEOUT_NS` / `DEFAULT_UDP_SESSION_TIMEOUT_NS` | `userspace-dp/src/session/mod.rs:85-86` | 60 s | family-agnostic |
+| `WARM_GC_INTERVAL_NS` / `RESOLVER_GC_INTERVAL_NS` | `coordinator/neighbor_manager.rs:35`, `neighbor_resolver.rs:92` | 60 s | prunes rate-limit bookkeeping only; family-agnostic |
+| `nf_conntrack_icmpv6_timeout` | LAN host | 30 | not in the transit path |
+| inter-node clock skew | measured 3x | **12.0 s, `NTPSynchronized=no` on both** | not family-specific |
+
+Paired sysctl read, verbatim:
+
+```
+eth0 base_reachable_time_ms   v4=30000    v6=30000
+eth0 gc_stale_time            v4=60       v6=60
+eth0 delay_first_probe_time   v4=5        v6=5
+eth0 retrans_time_ms          v4=1000     v6=1000
+eth0 ucast_solicit            v4=3        v6=3
+eth0 mcast_solicit            v4=3        v6=3
+```
+
+### The six instrumented transitions
+
+`max_gap` = longest interval with no reply on a 4 Hz established flow.
+
+| # | transition | post-failover span | v4 max_gap | v6 max_gap | new-flow v4 | new-flow v6 |
+|---|---|---|---|---|---|---|
+| t1 | RG1+RG0 → node1 (the reporter's repro) | 67 s | **0.29 s** | **0.29 s** | — | — |
+| t2 | RG1+RG2+RG0 → node1 (full failover) | 137 s | **0.54 s** | **0.52 s** | ok | ok |
+| t3 | RG1 → node0 (mirrored split: LAN=node1, WAN=node0) | 96 s | **0.51 s** | **0.29 s** | 1 pkt | 1 pkt |
+| t4 | RG2+RG1+RG0 → node0 (RG2 transition) | 120 s | **0.52 s** | **0.52 s** | ok | ok |
+| t5 | RG1+RG0 → node1, reporter's instruments fired **in** the window | 100 s | **0.54 s** | **0.51 s** | 10 % | 10 % |
+| t6 | RG2 → node1, reporter's instruments fired **in** the window | 132 s | **0.52 s** | **0.54 s** | 10 % | 10 % |
+
+t6 independently reconfirmed the thread's 96/96 figure: **96 unsolicited NAs**
+to `33:33:00:00:00:01` observed on the LAN host, and 12 RAs, every one
+sourced from `fe80::bf72:16:2`.
+
+t5, the reporter's exact instruments fired 1.6 s into the window:
+
+```
+--- ping -c 10 v4 start=1787934256.397245439
+10 packets transmitted, 9 received, 10% packet loss, time 9097ms      <-- reporter: 10%   MATCH
+--- ping -c 10 v6 start=1787934266.497658047
+10 packets transmitted, 9 received, 10% packet loss, time 9139ms      <-- reporter: 100%  NO MATCH
+[  5]   0.00-10.00  sec  1.11 GBytes   955 Mbits/sec    1   sender   (iperf3 v4)
+[  5]   0.00-10.00  sec   115 MBytes  96.4 Mbits/sec   34   sender   (iperf3 v6)
+iperf6 rc=0 end=1787934268.463662934
+```
+
+Repeat v6 probes at t+20, t+40, t+60 and t+70 all returned 9/10. There is no
+window and nothing self-heals, because nothing broke.
+
+### Complete placement sweep — 8 of 8
+
+RG0 placement is irrelevant; the only axis that matters is whether RG1 (WAN,
+`reth0`) and RG2 (LAN, `reth1`) are co-located. `fast` counts TCP connects
+completing in <0.5 s; a 1.0 s connect is one SYN retransmit, i.e. the #7770
+first-packet drop.
+
+```
+want=000 actual=[0:node0 1:node0 2:node0] n=26  tcp4ok=26(fast 26) tcp6ok=26(fast 26)  icmp4ok=26 icmp6ok=26
+want=001 actual=[0:node0 1:node0 2:node1] n=6   tcp4ok=6(fast 0)   tcp6ok=6(fast 0)    icmp4ok=0  icmp6ok=0
+want=010 actual=[0:node0 1:node1 2:node0] n=6   tcp4ok=6(fast 0)   tcp6ok=6(fast 0)    icmp4ok=0  icmp6ok=0
+want=011 actual=[0:node0 1:node1 2:node1] n=26  tcp4ok=26(fast 26) tcp6ok=26(fast 26)  icmp4ok=26 icmp6ok=26
+want=100 actual=[0:node1 1:node0 2:node0] n=26  tcp4ok=26(fast 26) tcp6ok=26(fast 26)  icmp4ok=26 icmp6ok=26
+want=101 actual=[0:node1 1:node0 2:node1] n=6   tcp4ok=6(fast 1)   tcp6ok=6(fast 1)    icmp4ok=0  icmp6ok=0
+want=110 actual=[0:node1 1:node1 2:node0] n=6   tcp4ok=6(fast 0)   tcp6ok=6(fast 0)    icmp4ok=0  icmp6ok=0
+want=111 actual=[0:node1 1:node1 2:node1] n=26  tcp4ok=26(fast 26) tcp6ok=26(fast 26)  icmp4ok=26 icmp6ok=26
+```
+
+Every split row is symmetric between the families; every co-located row is
+clean in both. There is no placement in which IPv6 is worse than IPv4. (The
+`icmp*ok=0` rows are not a v6 finding: a `ping -c 1` new flow is a one-packet
+flow, so #7770 costs it its only packet, equally in both families. `n` differs
+per row because each split-state cycle spends 4 × 1 s in timeouts.)
+
+### Mechanisms positively excluded by measurement in this pass
+
+Each was a live candidate before the measurement, not a strawman.
+
+1. **The demoting node emits a goodbye RA (Router Lifetime 0) and the host
+   loses its v6 default route.** Refuted: every RA captured across an RG2
+   transition carries `router lifetime 180s`; no lifetime-0 RA appeared, and
+   `ip -ts monitor route` logged no route event of any kind.
+2. **The new master's RA is sourced from its own EUI-64 link-local, so the host
+   installs a SECOND default router and can select a node that is not
+   forwarding.** The strongest candidate — the LAN host does carry
+   `fe80::bf:72ff:fe16:200` and `:201` flagged `router` — and refuted on the
+   wire: the RA source is `fe80::bf72:16:2` from *both* nodes (pinned in
+   `pkg/daemon/daemon_ra.go` via `cluster.StableRethLinkLocal`), and the host
+   never held more than one default route. The `router` flag on the EUI-64
+   addresses comes from solicited NAs, not RAs.
+3. **The RA sender is down on the new master for tens of seconds.** Refuted:
+   0.58 s from failover command to first RA, then a 3-frame 100 ms burst.
+4. **The host's stale neighbour entry ages out over ~60 s.** Refuted by direct
+   poisoning: 8.51 s (v6) / 8.71 s (v4).
+5. **Neighbour-timer asymmetry between the families.** Refuted: every
+   `neigh.eth0.*` parameter is byte-identical for v4 and v6.
+6. **A placement-dependent v6 defect.** Refuted by the 8-of-8 sweep.
+7. **The v6 probe used the discredited `…:100::200` path.** Checked and
+   rejected: both `2001:559:8585:100::200` and `172.16.100.200` answer today at
+   0 % loss, so a mis-targeted probe would not have produced 100 %.
+
+### What would still move this forward
+
+Not more placement permutations — the space is now exhausted both statically
+(8 of 8) and dynamically (6 transitions, 4 Hz, full window). The remaining
+unexplored condition is a **degraded** cluster, which neither this pass nor the
+previous one held:
+
+- session sync DOWN across a split (the lead in the previous comment).
+  Predicted to blackhole *both* families totally, so it still does not explain
+  the reported asymmetry — but it has never been measured.
+- a large clock skew (see the NTP entry above) at the moment of failover.
+
+If the symptom recurs, the single most valuable artefact is the LAN host's
+`ip -6 neigh` and `ip -6 route` **during** the window alongside the same two
+for IPv4 — because the measurement above says the two families' repair paths
+are identical, so any asymmetry must be visible as a difference in those four
+outputs.

--- a/test/incus/test-failover.sh
+++ b/test/incus/test-failover.sh
@@ -48,6 +48,7 @@ IPERF_TARGET="${IPERF_TARGET:-$IPERF_TARGET4}"
 IPERF_TARGET6="${IPERF_TARGET6:-2001:559:8585:80::200}"
 V6_PROBE_COUNT=5        # #6934: see check_v6_transit for why this is not 1
 V6_PROBE_MIN=3          # received replies required to call the path up
+V6_RECHECK_DELAY=30     # #6934: seconds between the two post-failover samples
 # COUPLED TO #7770 — tighten this when that is fixed.
 #
 # 3-of-5 is not a general-purpose tolerance; it is calibrated to absorb one
@@ -89,6 +90,15 @@ die() { echo "FATAL: $*" >&2; exit 2; }
 # catch — measured: during a LAN/WAN redundancy-group split the VIP answers with
 # 0% loss while transit is degraded.
 #
+# The failure message deliberately does NOT blame the neighbour cache. That was
+# this issue's first instinct for three rounds and it is measurably wrong here:
+# on this LAN host the IPv4 and IPv6 neigh parameters are byte-identical, and
+# poisoning the default gateway's entry with a bogus MAC costs 8.51s in IPv6
+# against 8.71s in IPv4 — symmetric, and 8.5s rather than the ~30/~60s the old
+# message asserted. A stale neighbour entry can produce a blackhole; it cannot
+# produce a v4/v6 ASYMMETRY on this host, and it cannot produce a ~60s one.
+# Measurements in docs/log/6934.md.
+#
 # It tolerates losing packets but not all of them, and that threshold is
 # measured rather than picked. A cross-node split costs the FIRST packet of a
 # new flow, reproducibly and without self-healing, so a `-c 1` probe would be
@@ -103,7 +113,7 @@ check_v6_transit() {
 	if [ "$recv" -ge "$V6_PROBE_MIN" ]; then
 		pass "IPv6 transit OK ${label} (${recv}/${V6_PROBE_COUNT} to ${IPERF_TARGET6})"
 	else
-		fail "IPv6 transit BLACKHOLED ${label}: only ${recv}/${V6_PROBE_COUNT} replies from ${IPERF_TARGET6}. IPv4 can stay healthy through this — ND holds a REACHABLE entry ~30s before probing, so a stale or unannounced neighbour entry blackholes v6 while ARP re-resolves in seconds (#6934)"
+		fail "IPv6 transit BLACKHOLED ${label}: only ${recv}/${V6_PROBE_COUNT} replies from ${IPERF_TARGET6}. Do NOT reach for a neighbour-cache explanation first: on this LAN host every neigh parameter is byte-identical between the families (base_reachable_time_ms 30000/30000, gc_stale_time 60/60, delay_first_probe_time 5/5, retrans_time_ms 1000/1000, ucast_solicit 3/3), and a deliberately poisoned gateway entry repairs in 8.51s for v6 against 8.71s for v4 — symmetric, and 8.5s rather than 30 or 60. A v6-ONLY failure therefore has to be somewhere the families genuinely differ, and the one place they do here is the default route: v4 is proto static, v6 is proto ra with a 180s lifetime refreshed every 10-30s. Capture ip -6 route / ip -6 neigh AND their v4 twins DURING the window (#6934, docs/log/6934.md)"
 	fi
 }
 # #7368: a PRECONDITION failure is not a failover regression, and neither is an
@@ -437,6 +447,22 @@ fi
 # above cannot see a failure here: it is one long-lived IPv4 flow, so it
 # survives on established state while a NEW IPv6 flow blackholes.
 check_v6_transit "after manual failover"
+
+# #6934: sample the window TWICE, not once. The reported symptom self-heals
+# after ~60s with no intervention, and a single probe fired immediately after
+# the failover reports a clean pass whether it landed before such a window
+# opened or after it closed — a check that cannot distinguish "healthy" from
+# "I sampled the wrong instant".
+#
+# Cost, counted rather than asserted: the 120s iperf3 starts at line ~207 and by
+# the time control reaches here the script has already spent 8 + SYNC_WAIT + 3 +
+# (reboot wait) + 20 + 5 seconds plus a 5-packet probe. With a typical reboot
+# that leaves ~35-55s of iperf3 still to run, so the wait below overlaps it and
+# Phase 5 just waits out the remainder — free. Only when the reboot consumes the
+# full REBOOT_WAIT budget does any of it become extra wall clock, and then at
+# most V6_RECHECK_DELAY of it.
+sleep "$V6_RECHECK_DELAY"
+check_v6_transit "${V6_RECHECK_DELAY}s after manual failover"
 
 # ── Phase 5: Wait for iperf3 to complete and validate results ───────
 


### PR DESCRIPTION
Refs #6934. This does not resolve the underlying symptom; the issue itself is
being disposed of separately, with the measurement pass recorded there.

## What this changes

**1. `check_v6_transit`'s failure message told its reader something measurably
false.** It said:

> "IPv4 can stay healthy through this — ND holds a REACHABLE entry ~30s before
> probing, so a stale or unannounced neighbour entry blackholes v6 while ARP
> re-resolves in seconds"

Measured on the LAN host this gate actually probes from, every neighbour
parameter is byte-identical between the families:

```
eth0 base_reachable_time_ms   v4=30000    v6=30000
eth0 gc_stale_time            v4=60       v6=60
eth0 delay_first_probe_time   v4=5        v6=5
eth0 retrans_time_ms          v4=1000     v6=1000
eth0 ucast_solicit            v4=3        v6=3
eth0 mcast_solicit            v4=3        v6=3
```

and poisoning the default gateway's entry with a bogus MAC in state `STALE` —
exactly the state a failover leaves behind when the unsolicited-NA /
gratuitous-ARP burst never arrives — costs **8.51 s in IPv6 against 8.71 s in
IPv4**:

```
v4(control):  replies=230  span=59.6s  max_gap=0.29s
  GAP   8.51s  from t=+0.11 to t=+8.62
v6(POISONED): replies=197  span=59.7s  max_gap=8.51s
```

The 2 Hz NUD walk shows where the 8.5 s goes, and why it is not 30 or 60: a
STALE entry does not wait out `base_reachable_time`.

```
  -0.2  fe80::bf72:16:2 lladdr 02:bf:72:16:02:00 router REACHABLE
  +0.4  fe80::bf72:16:2 lladdr 02:bf:72:16:02:99 STALE
  +0.9  fe80::bf72:16:2 lladdr 02:bf:72:16:02:99 DELAY      <- delay_first_probe_time = 5
  +5.5  fe80::bf72:16:2 lladdr 02:bf:72:16:02:99 PROBE      <- ucast_solicit 3 x retrans 1000 ms
  +8.5  fe80::bf72:16:2 FAILED
  +9.0  fe80::bf72:16:2 lladdr 02:bf:72:16:02:00 router REACHABLE
```

The claim was load-bearing in the wrong direction: it tells an investigator
that a v4/v6 asymmetry is *expected* from neighbour timers, which is the exact
shape #6934 chased for three rounds. Same failure mode as the `garp.go`
Override comment fixed in #7769 — a false sentence in shipped code costing a
round of investigation.

**2. The post-failover window is now sampled twice, not once.** The reported
symptom self-heals after ~60 s with no intervention, so a single probe fired
immediately after the manual failover reports a clean pass whether it landed
before such a window opened or after it closed. That is a check that cannot
distinguish "healthy" from "I sampled the wrong instant". Cost is counted rather
than asserted in the comment: by the time control reaches that point the script
has already spent 8 + `SYNC_WAIT` + 3 + (reboot wait) + 20 + 5 s of the 120 s
iperf3 run, so with a typical reboot the wait overlaps ~35–55 s of remaining
iperf3 and Phase 5 just waits out the remainder. Only a reboot that consumes the
full `REBOOT_WAIT` budget makes any of it extra wall clock, and then at most
`V6_RECHECK_DELAY`.

**3. `docs/log/6934.md`** gains the full 2026-08-28 measurement pass: six
instrumented failover transitions, a complete 8-of-8 redundancy-group placement
sweep, three neighbour-poisoning positive controls, and a candidate-timer table
in which every value is measured on the live cluster rather than assumed.

## Validation

The **shipped text** of `check_v6_transit`, extracted verbatim by line range
rather than paraphrased, exercised against the live loss userspace cluster in
both directions:

```
== POSITIVE: healthy path, real target
  PASS  IPv6 transit OK verify-positive (4/5 to 2001:559:8585:80::200)
== NEGATIVE: unreachable target must red, with the new message
  FAIL  IPv6 transit BLACKHOLED verify-negative: only 0/5 replies from 2001:559:8585:80::dead. Do NOT reach for a neighbour-cache explanation first: ...
-- PASS=1 FAIL=1
VERDICT: gate discriminates correctly
```

(The `4/5` on the healthy path is the documented #7770 first-packet drop — the
threshold doing exactly the job its comment describes.)

`bash -n` clean. `shellcheck -S warning` reports only the pre-existing SC2034
at line 465, which this change does not touch. No dataplane or control-plane
behaviour changes: this is a test-gate message plus one extra assertion.

All cluster work ran inside `./test/incus/with-cluster.sh` lock cells, and the
cluster was restored to the all-node0 baseline afterwards (0% loss on both
families verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7KffmGU7ywXWkBk9gQs6y
