### PR TITLE
test: correct two #6691 claims after re-measuring both (#7019, #7021)

### DIFF
--- a/docs/log/7019.md
+++ b/docs/log/7019.md
@@ -1,0 +1,106 @@
+# #7019 + #7021 — two claims on the #6691 netdev-verdict guards, re-measured
+
+Both are claim-accuracy defects, not runtime defects. Both were re-measured
+here at `fb6b0bc93` rather than transcribed, and the re-measurement changed the
+answer in one case and confirmed it exactly in the other.
+
+## #7019 — the FAIL-ON-REVERT clause is false in BOTH disjuncts, not one
+
+The clause on `TestFabricParentVerdictSurvivesACanonicalAlias` read:
+
+> FAIL-ON-REVERT: return the parent-config lookup to an exact map hit, or let a
+> fabric vote count while an interface row already owns the netdev, and this
+> reds.
+
+The issue reports the **second** disjunct false. Measured, each cell run against
+this test and its sibling:
+
+| revert | this test | `TestAFabricVoteCannotOverturnAnOwningRow` |
+|---|---|---|
+| R1 parent-config lookup → exact map hit | GREEN | GREEN |
+| R2 drop the `hasOwner -> netdevVoteAbstains` branch | GREEN | **RED** |
+| R1 + R2 together | GREEN | **RED** |
+
+So **both** disjuncts are false for the test that carries them.
+
+### R1 is DOMINATED here, which is the part worth knowing
+
+An initial reading of the R1 row was that the round-11 alias fix is unbound.
+**That was wrong**, and the discriminator probe is what caught it. Instrumenting
+both lookups for the only parent this fixture produces:
+
+```
+parentLinux=gr-0-0-3  exact=found+tunnel  tolerant=found+tunnel
+keys=[fab0,gr-0-0-3,ge-0/0/3,]
+```
+
+The alias in this fixture is authored the *other way round* from what the test's
+own paragraph describes: the fabric MEMBER is slash-spelled (`gr-0/0/3`, which
+`InterfaceSlot` requires) and the STANZA is dash-spelled (`gr-0-0-3`). So the
+stanza key already IS the netdev name, the exact hit finds it, and the tolerant
+lookup buys nothing on this config. R1 is a no-op mutation at this site — the
+test is not failing to catch a change; there is no change to catch.
+
+A mutation that does not vary the discriminator measures nothing, and reading
+its green as "unbound" would have produced a false coverage-hole issue.
+
+### The alias fix IS bound — by three other tests
+
+Reverting R1 and running the whole package:
+
+```
+--- FAIL: TestFabricParentVerdictReadsTheClassTable
+--- FAIL: TestFabricAndBaseRowNeverDisagree
+--- FAIL: TestProtocolGateDoesNotArmWhenARowOwnsTheFabricParent
+```
+
+Their fixtures put the alias on the parent. So the property is guarded; only the
+clause naming where it is guarded was wrong.
+
+### What the test actually binds
+
+Emptying the refused set reds it (see #7021 below). The corrected clause says
+that, and points at the sibling and the three class-table tests for the two
+reverts it used to claim.
+
+## #7021 — the empty-refused-set addendum, now written
+
+The addendum asked what the enumeration guard covers when the refused set is
+degenerate — the shape in which a coverage guard usually goes quietly vacuous.
+
+The issue's figure is confirmed **exactly**. Forcing
+`buildUserspaceRefusedNetdevs` to return `userspaceRefusedNetdevs{}` for any
+non-nil snapshot reds **ten** top-level tests:
+
+```
+TestAFabricVoteCannotOverturnAnOwningRow
+TestAliasTableRefusesOnAReachablePlainSibling
+TestFabricLoopCannotReadmitARefusedMember
+TestFabricParentVerdictSurvivesACanonicalAlias
+TestOwnerlessFabricParentIsRefused
+TestParentRedirectCannotReadmitTheExcludedXfrmi
+TestPlainUnitKeepsItsOwnIfindexUnderARefusedParent
+TestSkewedFabricSampleKeepsIngressAndAllowlistAgreed
+TestSkewedParentSampleKeepsTheChildOutOfAdjudication
+TestUserspaceBoundLinuxInterfaces_MatchesBindTargetSSOT
+```
+
+And `TestEveryNetdevProducerIsEnumerated` cannot go vacuous on a degenerate
+snapshot either, by three separate constructions rather than one:
+
+- `len(baseEmitted) < 2` is a `t.Fatalf` **premise**, not a skip, so a fixture
+  that stops emitting fails instead of passing quietly;
+- `excused == 0` fires if the fixture loses its redirect shape;
+- `fallbackOnly == 0` fires if it loses its ownerless-fabric shape.
+
+Written into the guard's doc, with the ten names, so the next reader does not
+re-derive it.
+
+## Not in this change
+
+**#7020** (the producer sweep is bounded to resettable slice fields with a
+differing cardinality) and **#7018** (the scope caveat names 2 of ≥5 predicates)
+are the other two residuals on this file. Both need their own enumeration work —
+#7018 in particular requires walking every predicate that decides a vote's
+contribution — and folding an unmeasured enumeration into a change whose whole
+subject is claim accuracy would be the same defect again.

--- a/pkg/dataplane/userspace/fabric_verdict_scope_6691_test.go
+++ b/pkg/dataplane/userspace/fabric_verdict_scope_6691_test.go
@@ -268,6 +268,39 @@ func TestProtocolGateDoesNotArmWhenARowOwnsTheFabricParent(t *testing.T) {
 // rebuilds its own snapshot), so it cannot be probed by mutating a snapshot;
 // both sets are fed by the same two loops per producer, so a producer that
 // reached only the allowlist would be a new shape, not a missed one.
+//
+// THE EMPTY-REFUSED-SET ADDENDUM (#7021), which had been left open. The question
+// was what this guard asserts when the refused set is DEGENERATE — the shape in
+// which a coverage guard usually goes quietly vacuous. It does not, and the
+// answer is measured rather than argued.
+//
+// Forcing buildUserspaceRefusedNetdevs to return an empty set reds TEN
+// top-level tests. Re-measured at fb6b0bc93 by making the function return
+// userspaceRefusedNetdevs{} for any non-nil snapshot:
+//
+//	TestAFabricVoteCannotOverturnAnOwningRow
+//	TestAliasTableRefusesOnAReachablePlainSibling
+//	TestFabricLoopCannotReadmitARefusedMember
+//	TestFabricParentVerdictSurvivesACanonicalAlias
+//	TestOwnerlessFabricParentIsRefused
+//	TestParentRedirectCannotReadmitTheExcludedXfrmi
+//	TestPlainUnitKeepsItsOwnIfindexUnderARefusedParent
+//	TestSkewedFabricSampleKeepsIngressAndAllowlistAgreed
+//	TestSkewedParentSampleKeepsTheChildOutOfAdjudication
+//	TestUserspaceBoundLinuxInterfaces_MatchesBindTargetSSOT
+//
+// And THIS guard cannot go vacuous on a degenerate snapshot either, by three
+// separate constructions rather than by one:
+//
+//	len(baseEmitted) < 2   is a t.Fatalf PREMISE, not a skip, so a fixture that
+//	                       stops emitting fails instead of passing quietly.
+//	excused == 0           fires if the fixture loses its redirect shape.
+//	fallbackOnly == 0      fires if it loses its ownerless-fabric shape.
+//
+// So the empty case is guarded, and what was missing was only the write-up.
+// Stated plainly: an empty refused set is not a state this guard tolerates
+// silently — it is a state ten other tests already refuse, and the two arms
+// below refuse a fixture that has drifted into it.
 func TestEveryNetdevProducerIsEnumerated(t *testing.T) {
 	defer stubLinkSnapshot5619(t, map[string]int{
 		"ge-0-0-0": 20, "ge-0-0-3": 21, "fab0": 22,
@@ -497,9 +530,37 @@ func TestEveryNetdevProducerIsEnumerated(t *testing.T) {
 //
 // Measured at 8c011681c: refusesName(gr-0-0-3) = false, ingress set contains 20.
 //
-// FAIL-ON-REVERT: return the parent-config lookup to an exact map hit, or let a
-// fabric vote count while an interface row already owns the netdev, and this
-// reds.
+// FAIL-ON-REVERT — CORRECTED IN #7019, because the clause that stood here named
+// two reverts and THIS test reds on neither. Re-measured at fb6b0bc93, each cell
+// run against both this test and its sibling:
+//
+//	revert                                      this test   TestAFabricVote-
+//	                                                        CannotOverturnAnOwningRow
+//	R1 parent-config lookup -> exact map hit     GREEN       GREEN
+//	R2 drop the hasOwner -> abstains branch      GREEN       RED
+//	R1 + R2 together                             GREEN       RED
+//
+// R1 is DOMINATED at this fixture, which is the part worth knowing. A probe on
+// the two lookups printed, for the only parent this test produces:
+//
+//	parentLinux=gr-0-0-3 exact=found+tunnel tolerant=found+tunnel
+//	keys=[fab0,gr-0-0-3,ge-0/0/3,]
+//
+// The alias here is authored the other way round from what the paragraph above
+// describes: the fabric MEMBER is slash-spelled and the STANZA is dash-spelled,
+// so the stanza key already IS the netdev name and the exact hit finds it. The
+// tolerant lookup buys nothing on this config. It is not unbound — reverting it
+// reds TestFabricParentVerdictReadsTheClassTable, TestFabricAndBaseRowNeverDisagree
+// and TestProtocolGateDoesNotArmWhenARowOwnsTheFabricParent, whose fixtures put
+// the alias on the parent — it is simply not bound HERE.
+//
+// What this test actually binds is the PRODUCER: forcing
+// buildUserspaceRefusedNetdevs to return an empty set reds it, along with nine
+// others (#7021). So the honest contract is:
+//
+//	FAIL-ON-REVERT: empty the refused set, and this reds. The two reverts the
+//	old clause named are covered by the sibling and by the three class-table
+//	tests, not here.
 func TestFabricParentVerdictSurvivesACanonicalAlias(t *testing.T) {
 	const (
 		greIfindex = 20


### PR DESCRIPTION
Both are claim-accuracy defects on the #6691 netdev-verdict guards, not runtime defects. Both were **re-measured at `fb6b0bc93` rather than transcribed** from the issues. One answer changed; the other was confirmed exactly.

---

## #7019 — the FAIL-ON-REVERT clause is false in BOTH disjuncts, not one

The clause on `TestFabricParentVerdictSurvivesACanonicalAlias` read:

> FAIL-ON-REVERT: return the parent-config lookup to an exact map hit, or let a fabric vote count while an interface row already owns the netdev, and this reds.

The issue reports the **second** disjunct false. Measured, each cell against this test *and* its sibling:

| revert | this test | `TestAFabricVoteCannotOverturnAnOwningRow` |
|---|---|---|
| R1 parent-config lookup → exact map hit | GREEN | GREEN |
| R2 drop the `hasOwner -> netdevVoteAbstains` branch | GREEN | **RED** |
| R1 + R2 together | GREEN | **RED** |

So **both** disjuncts are false for the test that carries them.

### R1 is DOMINATED here — and that is the part worth knowing

My first reading of the R1 row was *"the round-11 alias fix is unbound."* **That was wrong**, and a discriminator probe is what caught it. Instrumenting both lookups for the only parent this fixture produces:

```
parentLinux=gr-0-0-3  exact=found+tunnel  tolerant=found+tunnel
keys=[fab0,gr-0-0-3,ge-0/0/3,]
```

The alias in this fixture is authored **the other way round** from what the test's own paragraph describes: the fabric MEMBER is slash-spelled (`gr-0/0/3`, which `InterfaceSlot` requires) and the STANZA is dash-spelled (`gr-0-0-3`). So the stanza key already *is* the netdev name, the exact hit finds it, and the tolerant lookup buys nothing on this config.

R1 is a **no-op mutation at this site**. The test is not failing to catch a change; there is no change to catch. A mutation that does not vary the discriminator measures nothing — and reading its green as "unbound" would have filed a false coverage-hole issue.

### The alias fix IS bound — by three other tests

Reverting R1 and running the whole package:

```
--- FAIL: TestFabricParentVerdictReadsTheClassTable
--- FAIL: TestFabricAndBaseRowNeverDisagree
--- FAIL: TestProtocolGateDoesNotArmWhenARowOwnsTheFabricParent
```

Their fixtures put the alias **on the parent**. The property is guarded; only the clause naming *where* was wrong. The corrected clause states what this test does bind — the refused-set producer — and points at the four tests that bind the rest.

---

## #7021 — the empty-refused-set addendum, now written

The addendum asked what the enumeration guard covers when the refused set is **degenerate** — the shape in which a coverage guard usually goes quietly vacuous.

The issue's figure is confirmed **exactly**. Forcing `buildUserspaceRefusedNetdevs` to return `userspaceRefusedNetdevs{}` for any non-nil snapshot reds **ten** top-level tests, and the ten names are now recorded in the guard's doc:

```
TestAFabricVoteCannotOverturnAnOwningRow
TestAliasTableRefusesOnAReachablePlainSibling
TestFabricLoopCannotReadmitARefusedMember
TestFabricParentVerdictSurvivesACanonicalAlias
TestOwnerlessFabricParentIsRefused
TestParentRedirectCannotReadmitTheExcludedXfrmi
TestPlainUnitKeepsItsOwnIfindexUnderARefusedParent
TestSkewedFabricSampleKeepsIngressAndAllowlistAgreed
TestSkewedParentSampleKeepsTheChildOutOfAdjudication
TestUserspaceBoundLinuxInterfaces_MatchesBindTargetSSOT
```

And `TestEveryNetdevProducerIsEnumerated` cannot go vacuous on a degenerate snapshot either, by **three separate constructions** rather than one:

- `len(baseEmitted) < 2` is a `t.Fatalf` **premise**, not a skip, so a fixture that stops emitting fails instead of passing quietly;
- `excused == 0` fires if the fixture loses its redirect shape;
- `fallbackOnly == 0` fires if it loses its ownerless-fabric shape.

---

## Deliberately not in this change

**#7020** (the producer sweep is bounded to resettable slice fields with a differing cardinality) and **#7018** (the scope caveat names 2 of ≥5 predicates) are the other two residuals on this file. Both need their own enumeration work — #7018 in particular requires walking every predicate that decides a vote's contribution — and folding an **unmeasured enumeration** into a change whose whole subject is claim accuracy would be the same defect again.

Repo-wide `go test -count=1 ./...` posted as a comment when it finishes. No Rust files touched, no production code changed — the diff is comments plus `docs/log/7019.md`.

Closes #7019
Closes #7021