### PR TITLE
config: make zone membership a set (#7031); record why the #6525 belt is inert (#7027)

### DIFF
--- a/docs/log/7031.md
+++ b/docs/log/7031.md
@@ -1,0 +1,92 @@
+# #7031 + #7027 — a duplicate zone member, and a belt that turned out to be inert
+
+## #7031 — zone membership was not a set
+
+Naming a member twice — once bare, once as the head of a
+`host-inbound-traffic` body — compiled to that member appearing **twice** in
+`zone.Interfaces`, committing clean with no warning:
+
+```
+zone Y Interfaces = [ge-0/0/2.0 ge-0/0/2.0]
+```
+
+This is not an exotic spelling. It is the ordinary way an operator adds a member
+and then gives it an override, and it is what `show configuration | display set`
+emits for a zone carrying both. Measured pre-existing on `master` and on the
+#6735 head, byte-identical, so no round introduced it.
+
+Deduped **first-seen at the append**, not at each consumer: the duplicate has no
+meaning to preserve — zone membership is a SET — and the per-interface override
+map is already keyed by name and merges (#4544/#4818), so the second mention only
+ever contributed a slice entry. First-seen order rather than sorted, because the
+slice order is what the operator authored and several renderers show it verbatim.
+
+### Fixture design
+
+Three things a naive fixture would miss, each given its own cell:
+
+- **Both authoring orders.** A dedupe written to skip the second of two identical
+  *consecutive* appends passes one order and fails the other.
+- **A positive control.** The override must SURVIVE. Without it, a dedupe that
+  "fixed" the count by dropping the override entirely would satisfy the
+  membership assertion.
+- **Distinct members.** A dedupe written as "keep only the first member of each
+  node" passes the whole membership table while reintroducing #5248 — a
+  zone-membership loss, and therefore a security-boundary loss.
+
+### Mutation matrix
+
+`go test -count=1 -run 7031 -v ./pkg/config/`. 5 collected, 0 build errors in
+every cell.
+
+| cell | mutation | failed | which |
+|---|---|---|---|
+| control | none | 0 | — |
+| M1 | dedupe reverted to master's plain append | 5 | all three `…NamedTwiceIsOneMember` subtests |
+| M2 | dedupe as "keep only the first member of each node" (#5248 shape) | 1 | `TestZoneDedupeKeepsDistinctMembers_7031` |
+| M3 | override dropped instead of deduped | 4 | the positive control in `…NamedTwiceIsOneMember` |
+| restored | none | 0 | — |
+
+Each mutation localises to a **different** assertion, so no cell masks another.
+
+## #7027 — the premise is superseded: the two expressions never differ
+
+The issue reports that reverting `zoneInterfaceMemberKeys(iface)` to
+`iface.Keys` leaves the whole `pkg/config` suite green, and reads that as a
+**missing assertion**. It is not missing. The two expressions never DIFFER.
+
+Instrumented the site to print whenever `len(truncated) != len(iface.Keys)` and
+ran the full package:
+
+```
+rc=0    build errors=0    failures=0    PROBE hits=0
+```
+
+Zero. No config in the corpus reaches a member node whose Keys carry a body
+keyword.
+
+The reason is that the spelling the truncation was written for is now rejected
+**earlier**: #6735's packed-tail gate refuses
+`interfaces a host-inbound-traffic <tail>` at commit
+(`validateZoneInterfacePackedTailStrict`). And the one remaining
+keyword-on-Keys spelling — the nested block
+`interfaces { a host-inbound-traffic { ... } }` — does not reach this branch at
+all; probed, it compiles to the member with an EMPTY override map, which is a
+separate question.
+
+So a regression test for the truncation would first need a config that both
+**differs** and **commits**, and the sweep found none. Writing one anyway would
+mean inventing a shape the compiler cannot produce, and the test would pass
+against both expressions — the exact defect the issue was filed about, in a new
+place.
+
+The truncation is kept, with the finding recorded at the site and the dependency
+stated in the direction it actually runs: **if #6735's gate is ever narrowed,
+this belt becomes live again.** That is the trigger for revisiting it.
+
+> Method note: the first two attempts at this sweep were BUILD BREAKS, not
+> measurements — the instrumentation used `fmt` and then `strings`, neither of
+> which that file imports. Both printed `PROBE hits: 0`, which is exactly what a
+> real zero looks like. The third attempt used only builtins and reported
+> `build errors=0` alongside the hit count, which is the pair that has to be read
+> together.

--- a/pkg/config/compiler_security_zones.go
+++ b/pkg/config/compiler_security_zones.go
@@ -170,7 +170,29 @@ func compileZones(node *Node, sec *SecurityConfig) error {
 					// zone-interface-defined gate. zoneInterfaceMembers flattens
 					// the nested chain so the hierarchical `{ a; b; }`, a single
 					// `a`, and the bracketed `[ a b c ]` all yield every member.
-					zone.Interfaces = append(zone.Interfaces, zoneInterfaceMembers(iface)...)
+					// #7031: FIRST-SEEN dedupe. Naming a member twice -- once
+					// bare for membership, once as the head of a
+					// host-inbound-traffic body -- is the ORDINARY way an
+					// operator adds a member and then gives it an override, and
+					// it is what `show configuration | display set` emits for a
+					// zone that has both. It compiled to the member appearing
+					// TWICE in zone.Interfaces, committing clean with no
+					// warning, on master and on every tree measured in the
+					// issue.
+					//
+					// Deduping here rather than at each consumer because the
+					// duplicate has no meaning to preserve: zone membership is
+					// a SET. The per-interface override map is already keyed by
+					// name and merges (#4544/#4818), so the second mention has
+					// always contributed nothing but the extra slice entry.
+					//
+					// First-seen order, not sorted: the slice order is what the
+					// operator authored and several renderers show it verbatim.
+					for _, member := range zoneInterfaceMembers(iface) {
+						if !zoneHasInterface(zone, member) {
+							zone.Interfaces = append(zone.Interfaces, member)
+						}
+					}
 					// #3362: per-interface host-inbound-traffic override
 					// (`interfaces <if> host-inbound-traffic { ... }`). Same
 					// token grammar as the zone-level stanza; parsed by the
@@ -256,6 +278,35 @@ func compileZones(node *Node, sec *SecurityConfig) error {
 						// stops the compact-leaf packed spelling
 						// `interfaces a host-inbound-traffic ...` from keying
 						// the override on its own body tokens.
+						//
+						// #7027, measured at b4ac34f10: this truncation is now a
+						// BELT IN FRONT OF A GATE, not a load-bearing read. The
+						// issue reports that reverting it to iface.Keys leaves
+						// the whole pkg/config suite green and reads that as a
+						// missing assertion. It is not missing — the two
+						// expressions never DIFFER. Instrumenting this site to
+						// print whenever len(truncated) != len(iface.Keys) and
+						// running the full package (rc=0, 0 build errors, 0
+						// failures) produced ZERO hits: no config in the corpus
+						// reaches a member node whose Keys carry a body keyword.
+						//
+						// The spelling the truncation was written for is now
+						// rejected earlier: #6735's packed-tail gate refuses
+						// `interfaces a host-inbound-traffic <tail>` at commit
+						// (validateZoneInterfacePackedTailStrict), and the one
+						// remaining keyword-on-Keys spelling, the nested block
+						// `interfaces { a host-inbound-traffic { ... } }`, does
+						// not reach this branch at all — it compiles to the
+						// member with NO override, which is a separate question
+						// and not this one.
+						//
+						// So a regression test for the truncation would first
+						// need a config that both differs AND commits, and the
+						// sweep found none. Kept rather than deleted, and kept
+						// with this note rather than dressed up as load-bearing:
+						// if #6735's gate is ever narrowed, this belt becomes
+						// live again, and the next reader should know the
+						// dependency runs in that direction.
 						for _, name := range zoneInterfaceMemberKeys(iface) {
 							zone.InterfaceHostInbound[name] = mergeHostInbound(zone.InterfaceHostInbound[name], cloneHostInbound(hib))
 						}
@@ -726,4 +777,19 @@ func zoneInterfaceStanzaPackedTail(prop *Node) (keyword string, tail []string, f
 		}
 	}
 	return "", nil, false
+}
+
+// zoneHasInterface reports whether the zone already lists this member.
+//
+// #7031: zone membership is a SET, but it is stored as a slice because the
+// authored order is operator-visible in several renderers. A linear scan is
+// right at this size -- a zone's member list is a handful of names, and a map
+// would have to be built and thrown away per zone per compile.
+func zoneHasInterface(zone *ZoneConfig, member string) bool {
+	for _, have := range zone.Interfaces {
+		if have == member {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/config/zone_member_dedupe_7031_test.go
+++ b/pkg/config/zone_member_dedupe_7031_test.go
@@ -1,0 +1,127 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// #7031: naming a zone member twice — once bare for membership, once as the
+// head of a host-inbound-traffic body — compiled to that member appearing TWICE
+// in zone.Interfaces, committing clean with no warning.
+//
+// This is not an exotic spelling. It is the ordinary way an operator adds a
+// member and then gives it an override, and it is what
+// `show configuration | display set` emits for a zone that has both. Measured
+// pre-existing on master and on the #6735 head, byte-identical, so no round
+// introduced it.
+//
+// The FIXTURE ORDER matters and both orders are exercised. A fixture that
+// authors the override line FIRST and the bare line second reaches the append
+// from the other side, and a dedupe written to skip only the second of two
+// identical CONSECUTIVE appends would pass one and fail the other.
+func TestZoneMemberNamedTwiceIsOneMember_7031(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		lines []string
+	}{
+		{
+			name: "bare membership first, override second",
+			lines: []string{
+				"set interfaces ge-0/0/2 unit 0 family inet address 10.0.3.1/24",
+				"set security zones security-zone Y interfaces ge-0/0/2.0",
+				"set security zones security-zone Y interfaces ge-0/0/2.0 host-inbound-traffic system-services ssh",
+			},
+		},
+		{
+			name: "override first, bare membership second",
+			lines: []string{
+				"set interfaces ge-0/0/2 unit 0 family inet address 10.0.3.1/24",
+				"set security zones security-zone Y interfaces ge-0/0/2.0 host-inbound-traffic system-services ssh",
+				"set security zones security-zone Y interfaces ge-0/0/2.0",
+			},
+		},
+		{
+			name: "named three times",
+			lines: []string{
+				"set interfaces ge-0/0/2 unit 0 family inet address 10.0.3.1/24",
+				"set security zones security-zone Y interfaces ge-0/0/2.0",
+				"set security zones security-zone Y interfaces ge-0/0/2.0 host-inbound-traffic system-services ssh",
+				"set security zones security-zone Y interfaces ge-0/0/2.0 host-inbound-traffic protocols all",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := &ConfigTree{}
+			for _, ln := range tc.lines {
+				path, err := ParseSetCommand(ln)
+				if err != nil {
+					t.Fatalf("ParseSetCommand(%q): %v", ln, err)
+				}
+				if err := tree.SetPath(path); err != nil {
+					t.Fatalf("SetPath(%q): %v", ln, err)
+				}
+			}
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("CompileConfig: %v", err)
+			}
+			zone := cfg.Security.Zones["Y"]
+			if zone == nil {
+				t.Fatal("zone Y did not compile")
+			}
+			if want := []string{"ge-0/0/2.0"}; !reflect.DeepEqual(zone.Interfaces, want) {
+				t.Errorf("zone Y Interfaces = %v, want %v — zone membership is a SET, and a "+
+					"member named on two set lines is one member (#7031)", zone.Interfaces, want)
+			}
+			// POSITIVE CONTROL. Without this the dedupe could be "correct" by
+			// dropping the override entirely, and the assertion above would
+			// still hold. The override must survive, and for the three-times
+			// case both of its blocks must have merged.
+			hib := zone.InterfaceHostInbound["ge-0/0/2.0"]
+			if hib == nil {
+				t.Fatalf("the per-interface override was lost: InterfaceHostInbound = %v",
+					zone.InterfaceHostInbound)
+			}
+			if len(hib.SystemServices) == 0 {
+				t.Errorf("the override lost its system-services: %+v", hib)
+			}
+		})
+	}
+}
+
+// Deduping must not merge two DIFFERENT members. Without this cell a dedupe
+// written as "keep only the first member of each node" would pass the table
+// above while silently dropping every member after the first — the #5248
+// regression, which is a zone-membership loss and therefore a security-boundary
+// loss.
+func TestZoneDedupeKeepsDistinctMembers_7031(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, ln := range []string{
+		"set interfaces ge-0/0/2 unit 0 family inet address 10.0.3.1/24",
+		"set interfaces ge-0/0/3 unit 0 family inet address 10.0.4.1/24",
+		"set security zones security-zone Y interfaces [ ge-0/0/2.0 ge-0/0/3.0 ]",
+		"set security zones security-zone Y interfaces ge-0/0/2.0",
+	} {
+		path, err := ParseSetCommand(ln)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", ln, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", ln, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	zone := cfg.Security.Zones["Y"]
+	if zone == nil {
+		t.Fatal("zone Y did not compile")
+	}
+	want := []string{"ge-0/0/2.0", "ge-0/0/3.0"}
+	if !reflect.DeepEqual(zone.Interfaces, want) {
+		t.Errorf("zone Y Interfaces = %v, want %v — the bracketed list must keep BOTH "+
+			"members (#5248) and the repeated name must not add a third entry (#7031)",
+			zone.Interfaces, want)
+	}
+}


### PR DESCRIPTION
## #7031 — zone membership was not a set

Naming a member twice — once bare, once as the head of a `host-inbound-traffic` body — compiled to that member appearing **twice** in `zone.Interfaces`, committing clean with no warning:

```
zone Y Interfaces = [ge-0/0/2.0 ge-0/0/2.0]
```

Not an exotic spelling: it is the ordinary way an operator adds a member and then gives it an override, and it is what `show configuration | display set` emits for a zone carrying both. Pre-existing on `master` and on the #6735 head, byte-identical — no round introduced it.

Deduped **first-seen at the append**, not at each consumer. The duplicate has no meaning to preserve (zone membership is a SET), and the per-interface override map is already keyed by name and merges (#4544/#4818), so the second mention only ever contributed a slice entry. First-seen order rather than sorted, because the slice order is what the operator authored and several renderers show it verbatim.

### Fixture design — three things a naive fixture would miss

- **Both authoring orders.** A dedupe written to skip the second of two identical *consecutive* appends passes one order and fails the other.
- **A positive control.** The override must SURVIVE — otherwise a dedupe that "fixed" the count by dropping the override entirely would satisfy the membership assertion.
- **Distinct members.** A dedupe written as "keep only the first member of each node" passes the whole membership table while reintroducing **#5248** — a zone-membership loss, and therefore a security-boundary loss.

### Mutation matrix

`go test -count=1 -run 7031 -v ./pkg/config/`. **5 collected, 0 build errors in every cell.**

| cell | mutation | failed | which |
|---|---|---|---|
| control | none | 0 | — |
| M1 | dedupe reverted to master's plain append | 5 | all three `…NamedTwiceIsOneMember` subtests |
| M2 | dedupe as "keep only the first member of each node" (#5248 shape) | 1 | `TestZoneDedupeKeepsDistinctMembers_7031` |
| M3 | override dropped instead of deduped | 4 | the positive control |
| restored | none | 0 | — |

Each mutation localises to a **different** assertion, so no cell masks another.

---

## #7027 — the premise is superseded: the two expressions never differ

The issue reports that reverting `zoneInterfaceMemberKeys(iface)` to `iface.Keys` leaves the whole `pkg/config` suite green, and reads that as a **missing assertion**. It is not missing. **The two expressions never DIFFER.**

Instrumented the site to print whenever `len(truncated) != len(iface.Keys)` and ran the full package:

```
rc=0    build errors=0    failures=0    PROBE hits=0
```

Zero. No config in the corpus reaches a member node whose Keys carry a body keyword.

The spelling the truncation was written for is now rejected **earlier**: #6735's packed-tail gate refuses `interfaces a host-inbound-traffic <tail>` at commit (`validateZoneInterfacePackedTailStrict`). And the one remaining keyword-on-Keys spelling — the nested block `interfaces { a host-inbound-traffic { ... } }` — does not reach this branch at all; probed, it compiles to the member with an **empty** override map, which is a separate question.

So a regression test would first need a config that both **differs** and **commits**, and the sweep found none. Writing one anyway would mean inventing a shape the compiler cannot produce, and it would pass against *both* expressions — the exact defect this issue was filed about, reappearing in a new place.

The truncation is **kept**, with the finding recorded at the site and the dependency stated in the direction it actually runs: **if #6735's gate is ever narrowed, this belt becomes live again.** That is the trigger for revisiting it.

> **Method note.** The first two attempts at this sweep were **build breaks, not measurements** — the instrumentation used `fmt` and then `strings`, neither of which that file imports. Both printed `PROBE hits: 0`, which is exactly what a real zero looks like. The third used only builtins and reported `build errors=0` alongside the hit count; that is the pair that has to be read together.

---

Repo-wide `go test -count=1 ./...` posted as a comment when it finishes. `./pkg/config/` alone is already green with the dedupe (rc=0, 0 FAIL). No Rust files touched.

Docs: `docs/log/7031.md`.

Closes #7031
Closes #7027