### PR TITLE
config: read a NAT terminal action packed onto the `then` node itself (#7014)

### DIFF
--- a/docs/log/7014.md
+++ b/docs/log/7014.md
@@ -1,0 +1,89 @@
+# #7014 — a legal Junos spelling that compiled to zero actions
+
+The fully-compact authoring packs every token onto the `then` node itself:
+
+```
+then source-nat off;              ->  0 actions  ->  REJECTED
+then { source-nat off; }          ->  1 action   ->  accepted
+```
+
+Both NAT compilers look for a `source-nat` / `destination-nat` **child** of
+`then`, so when the tokens pack onto `then` there is no child to find and the
+action set comes back empty. The zero-action arm then rejects with a message
+saying the rule *"carries no translation action"* — for a stanza that visibly
+carries one.
+
+Measured before changing anything, on the four shapes:
+
+```
+7014 fully-compact then               REJECTED: … `then` carries no translation action …
+7014 block form (control)             ACCEPTED src{pool= off=true}
+7013 repeated same-mode hierarchical  ACCEPTED dst{pool=PD off=false}
+7013 repeated same-mode packed        ACCEPTED dst{pool=PD off=false}
+```
+
+Flat-set is unaffected: `SetPath` builds the child, so `set … then source-nat
+off` produces the hierarchical shape.
+
+It **fails closed**, so no traffic was ever mishandled. The cost is a legal
+config that will not commit, refused with a diagnostic contradicting what the
+operator is looking at.
+
+## First-token-wins is deliberate, and is itself bound
+
+The packed reader takes the FIRST action token and yields ONE action, matching
+the packed **child** spelling `then { source-nat pool P off; }` one level down.
+
+That is not ideal semantics — a packed contradiction should be rejected — but
+the packed class is **#7033's** whole subject, and #7033 is named in the live
+gate message as the open case. Narrowing it in this one spelling would make that
+message half-false and leave two packed spellings resolving differently, so
+uniformity means #7033 can close the class in one move.
+
+`TestCompactThenPackedContradictionMatchesTheChildSpelling_7014` pins the two
+spellings to the same resolution, and says in its failure message what to update
+if #7033 lands, alongside `TestNATTerminalActionPackedContradictionCommits_7034`
+which carries the same instruction. Cell **M4** shows that pin is real: switching
+the reader to accumulate reds *only* that test.
+
+## Mutation matrix
+
+`go test -count=1 -run 7014 -v ./pkg/config/`. **13 collected, 0 build errors in
+every cell.**
+
+| cell | mutation | failed | named failing test(s) |
+|---|---|---|---|
+| control | none | 0 | — |
+| M1 | source-NAT packed call removed (master's shape) | 6 | `TestCompactThenCarriesItsAction_7014`, `TestCompactThenPackedContradictionMatchesTheChildSpelling_7014` |
+| M2 | destination-NAT packed call removed | 3 | `TestCompactThenCarriesItsAction_7014` |
+| M3 | pool-name read (`keys[3]`) dropped | 5 | both |
+| M4 | reader accumulates instead of first-wins | 2 | `TestCompactThenPackedContradictionMatchesTheChildSpelling_7014` **only** |
+| restored | none | 0 | — |
+
+M2 localising to the compact table alone — and not to the contradiction test,
+which is source-NAT — shows the two call sites are separately bound rather than
+one masking the other.
+
+## Fixture notes
+
+- Three **block-form controls** are asserted unchanged, so the fix cannot be
+  confused with one that also moved the block path.
+- Flat-set is asserted unaffected, so a later "simplification" that routes it
+  through the packed reader reds.
+- Every case checks `natThenTerminalActionCount` as well as the fields. A `Then`
+  carrying the right field but counting zero would still be rejected by the
+  zero-action arm, and a field assertion alone cannot see that — the count is
+  what the arm actually reads.
+
+## Not fixed here: #7013
+
+The sibling, repeated same-mode actions collapsing silently
+(`destination-nat { pool PD; pool PD2; }` → `PD`, ACCEPTED under strict), is
+left open. It needs authored-occurrence state the typed struct does not carry —
+`NATThen.PoolName` is a scalar, so by validation time the discarded value is
+already gone — which is a different change from this one.
+
+**One correction to #7013's account**, measured above: the collapse keeps the
+**FIRST** pool (`PD`), not the last. The issue reports `Pool:"PD2"`. The defect
+is the same — an authored pool silently discarded, committed under strict — but
+whoever takes it should not build a fixture around the wrong survivor.

--- a/pkg/config/compiler_nat_destination.go
+++ b/pkg/config/compiler_nat_destination.go
@@ -195,6 +195,12 @@ func compileNATDestination(node *Node, sec *SecurityConfig) error {
 			// translation-mode fields (#3850 review).
 			for _, thenNode := range ruleInst.node.FindChildren("then") {
 				rule.Then = NATThen{}
+				// #7014: the fully-compact `then destination-nat off;` packs
+				// every token onto the `then` node itself, leaving no
+				// `destination-nat` CHILD for the loop below and an EMPTY action
+				// set that the zero-action arm rejects. See the source-NAT call
+				// site for why this reads the same way as the packed child.
+				applyPackedNATThenTokens7014(&rule.Then, thenNode.Keys, "destination-nat", NATDestination)
 				for _, t := range thenNode.Children {
 					if t.Name() == "destination-nat" {
 						// #3844: `then destination-nat off` is a no-translate

--- a/pkg/config/compiler_nat_source.go
+++ b/pkg/config/compiler_nat_source.go
@@ -982,6 +982,28 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 			// review).
 			for _, thenNode := range ruleInst.node.FindChildren("then") {
 				rule.Then = NATThen{}
+				// #7014: the FULLY-COMPACT authoring `then source-nat off;`
+				// packs every token onto the `then` node itself, so there is no
+				// `source-nat` CHILD for the loop below to find and the action
+				// set came back EMPTY. The zero-action arm then rejected a
+				// stanza that visibly carries an action, with a message saying
+				// it "carries no translation action" — a legal Junos spelling
+				// refused with a diagnostic that contradicts the config in front
+				// of the operator.
+				//
+				// It failed CLOSED, so no traffic was ever mishandled; the cost
+				// was a correct config that would not commit.
+				//
+				// Read DELIBERATELY the same way as the packed CHILD spelling
+				// (`then { source-nat pool P off; }`) one level down: the first
+				// action token wins and the result counts as ONE action. That is
+				// not the ideal semantics -- a packed contradiction should be
+				// rejected -- but it is #7033's whole subject, and #7033's gate
+				// message names the packed class as the open case. Narrowing it
+				// in this ONE spelling would make that message half-false and
+				// leave two packed spellings behaving differently. Uniformity
+				// here means #7033 closes the class in one move.
+				applyPackedNATThenTokens7014(&rule.Then, thenNode.Keys, "source-nat", NATSource)
 				for _, t := range thenNode.Children {
 					if t.Name() == "source-nat" {
 						if len(t.Keys) >= 2 {
@@ -1045,4 +1067,38 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 		}
 	}
 	return nil
+}
+
+// applyPackedNATThenTokens7014 reads a terminal action packed onto the `then`
+// node's OWN Keys, as the fully-compact `then source-nat off;` spelling
+// produces (#7014).
+//
+// keys is thenNode.Keys, i.e. ["then", "<kind>", <action tokens...>]. It is a
+// no-op for every other shape: the hierarchical `then { ... }` and the flat-set
+// form both put <kind> in a CHILD, so keys is just ["then"] and this returns
+// before touching anything.
+//
+// First action token wins, matching the packed-child read one level down. See
+// the call site for why that uniformity is deliberate rather than an oversight.
+func applyPackedNATThenTokens7014(then *NATThen, keys []string, kind string, typ NATType) {
+	if len(keys) < 3 || keys[1] != kind {
+		return
+	}
+	switch keys[2] {
+	case "interface":
+		if typ != NATSource {
+			return
+		}
+		then.Type = typ
+		then.Interface = true
+	case "off":
+		then.Type = typ
+		then.Off = true
+	case "pool":
+		if len(keys) < 4 {
+			return
+		}
+		then.Type = typ
+		then.PoolName = keys[3]
+	}
 }

--- a/pkg/config/nat_compact_then_7014_test.go
+++ b/pkg/config/nat_compact_then_7014_test.go
@@ -1,0 +1,161 @@
+package config
+
+import "testing"
+
+// #7014: the fully-compact authoring `then source-nat off;` packs every token
+// onto the `then` node itself, so the compilers — which look for a
+// `source-nat` / `destination-nat` CHILD — found nothing and produced ZERO
+// actions. The zero-action arm then rejected the rule with a message saying it
+// "carries no translation action", for a stanza that visibly carries one.
+//
+// It failed CLOSED, so no traffic was mishandled; the cost was a legal Junos
+// spelling that would not commit, refused with a diagnostic contradicting the
+// config in front of the operator.
+//
+// Flat-set is unaffected and is asserted as such below: SetPath builds the
+// child, so `set … then source-nat off` produces the hierarchical shape.
+func TestCompactThenCarriesItsAction_7014(t *testing.T) {
+	snat := func(then string) string {
+		return `
+security { nat { source {
+  pool P { address 203.0.113.5; }
+  rule-set RS { from zone trust; to zone untrust;
+    rule R1 { match { source-address 10.0.0.0/24; } ` + then + ` } } } } }
+`
+	}
+	dnat := func(then string) string {
+		return `
+security { nat { destination {
+  pool PD { address 10.0.0.5; }
+  rule-set RD { from zone untrust;
+    rule R1 { match { destination-address 198.51.100.1/32; } ` + then + ` } } } } }
+`
+	}
+	for _, tc := range []struct {
+		name      string
+		src       string
+		dest      bool
+		wantOff   bool
+		wantPool  string
+		wantIface bool
+	}{
+		// The defect proper. Each of these compiled to zero actions and was
+		// REJECTED before this change.
+		{name: "compact source-nat off", src: snat("then source-nat off;"), wantOff: true},
+		{name: "compact source-nat pool", src: snat("then source-nat pool P;"), wantPool: "P"},
+		{name: "compact source-nat interface", src: snat("then source-nat interface;"), wantIface: true},
+		{name: "compact destination-nat off", src: dnat("then destination-nat off;"), dest: true, wantOff: true},
+		{name: "compact destination-nat pool", src: dnat("then destination-nat pool PD;"), dest: true, wantPool: "PD"},
+
+		// CONTROLS. These already worked and must be bit-identical, or the fix
+		// would be indistinguishable from one that changed the block form too.
+		{name: "block source-nat off (control)", src: snat("then { source-nat off; }"), wantOff: true},
+		{name: "block source-nat pool (control)", src: snat("then { source-nat pool P; }"), wantPool: "P"},
+		{name: "block destination-nat pool (control)", src: dnat("then { destination-nat pool PD; }"), dest: true, wantPool: "PD"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tree, errs := NewParser(tc.src).Parse()
+			if len(errs) > 0 {
+				t.Fatalf("parse: %v", errs)
+			}
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("CompileConfig REJECTED a rule that carries an action: %v", err)
+			}
+			var got NATThen
+			if tc.dest {
+				got = cfg.Security.NAT.Destination.RuleSets[0].Rules[0].Then
+			} else {
+				got = cfg.Security.NAT.Source[0].Rules[0].Then
+			}
+			if got.Off != tc.wantOff || got.PoolName != tc.wantPool || got.Interface != tc.wantIface {
+				t.Errorf("Then = {Off:%v Interface:%v PoolName:%q}, want {Off:%v Interface:%v PoolName:%q}",
+					got.Off, got.Interface, got.PoolName, tc.wantOff, tc.wantIface, tc.wantPool)
+			}
+			// The count is what the zero-action arm reads, so assert it
+			// directly: a Then that carries the right field but counts 0 would
+			// still be rejected, and the field assertion alone cannot see that.
+			if n := natThenTerminalActionCount(got); n != 1 {
+				t.Errorf("natThenTerminalActionCount = %d, want 1", n)
+			}
+		})
+	}
+}
+
+// The flat-set path builds the child, so it never had the defect. Asserted so
+// the fix cannot be "corrected" later by routing flat-set through the packed
+// reader, which would put two spellings on one code path for no reason.
+func TestFlatSetThenIsUnaffected_7014(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, ln := range []string{
+		"set security nat source pool P address 203.0.113.5",
+		"set security nat source rule-set RS from zone trust",
+		"set security nat source rule-set RS to zone untrust",
+		"set security nat source rule-set RS rule R1 match source-address 10.0.0.0/24",
+		"set security nat source rule-set RS rule R1 then source-nat off",
+	} {
+		path, err := ParseSetCommand(ln)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", ln, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", ln, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	got := cfg.Security.NAT.Source[0].Rules[0].Then
+	if !got.Off || got.PoolName != "" || got.Interface {
+		t.Errorf("flat-set Then = {Off:%v Interface:%v PoolName:%q}, want off only",
+			got.Off, got.Interface, got.PoolName)
+	}
+}
+
+// The packed CONTRADICTION in the compact spelling must behave exactly as it
+// does one level down in `then { source-nat pool P off; }` — first token wins,
+// counted as ONE action, committed. That uniformity is the reason the compact
+// reader takes the first token instead of accumulating: #7033 owns the packed
+// class, its gate message names it as the open case, and narrowing it in one
+// spelling only would make that message half-false.
+//
+// If #7033 is fixed, this expectation changes with it — update this case
+// together with TestNATTerminalActionPackedContradictionCommits_7034 and the
+// gate's message; do not delete it.
+func TestCompactThenPackedContradictionMatchesTheChildSpelling_7014(t *testing.T) {
+	src := func(then string) string {
+		return `
+security { nat { source {
+  pool P { address 203.0.113.5; }
+  rule-set RS { from zone trust; to zone untrust;
+    rule R1 { match { source-address 10.0.0.0/24; } ` + then + ` } } } } }
+`
+	}
+	for _, tc := range []struct{ name, then string }{
+		{"compact", "then source-nat pool P off;"},
+		{"child (the shape #7034 pins)", "then { source-nat pool P off; }"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tree, errs := NewParser(src(tc.then)).Parse()
+			if len(errs) > 0 {
+				t.Fatalf("parse: %v", errs)
+			}
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("strict CompileConfig REJECTED %q; if #7033 is fixed, update this "+
+					"case with TestNATTerminalActionPackedContradictionCommits_7034 and the "+
+					"gate message: %v", tc.then, err)
+			}
+			got := cfg.Security.NAT.Source[0].Rules[0].Then
+			if got.PoolName != "P" || got.Off {
+				t.Errorf("Then = {Off:%v PoolName:%q}, want {Off:false PoolName:\"P\"} — the "+
+					"two packed spellings must resolve identically (#7014/#7033)",
+					got.Off, got.PoolName)
+			}
+			if n := natThenTerminalActionCount(got); n != 1 {
+				t.Errorf("natThenTerminalActionCount = %d, want 1", n)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The fully-compact Junos authoring packs every token onto the `then` node:

```
then source-nat off;              ->  0 actions  ->  REJECTED
then { source-nat off; }          ->  1 action   ->  accepted
```

Both NAT compilers look for a `source-nat` / `destination-nat` **child** of `then`, so with the tokens packed onto `then` there is no child to find and the action set comes back empty. The zero-action arm then rejects with a message saying the rule *"carries no translation action"* — for a stanza that visibly carries one.

Measured before changing anything, on all four shapes:

```
7014 fully-compact then               REJECTED: … `then` carries no translation action …
7014 block form (control)             ACCEPTED src{pool= off=true}
7013 repeated same-mode hierarchical  ACCEPTED dst{pool=PD off=false}
7013 repeated same-mode packed        ACCEPTED dst{pool=PD off=false}
```

Flat-set is unaffected — `SetPath` builds the child.

It **fails closed**, so no traffic was ever mishandled. The cost is a legal config that will not commit, refused with a diagnostic contradicting what the operator is looking at.

## First-token-wins is deliberate, and is itself bound

The packed reader takes the FIRST action token and yields ONE action, matching the packed **child** spelling `then { source-nat pool P off; }` one level down.

That is not ideal semantics — a packed contradiction should be rejected — but the packed class is **#7033's** whole subject and #7033 is named in the live gate message as the open case. Narrowing it in this one spelling would make that message half-false and leave two packed spellings resolving differently. Uniformity means #7033 closes the class in one move.

`TestCompactThenPackedContradictionMatchesTheChildSpelling_7014` pins the two spellings together and says in its failure message what to update if #7033 lands, matching the instruction already carried by `TestNATTerminalActionPackedContradictionCommits_7034`. **Cell M4 shows that pin is real.**

## Mutation matrix

`go test -count=1 -run 7014 -v ./pkg/config/`. **13 collected, 0 build errors in every cell.**

| cell | mutation | failed | named failing test(s) |
|---|---|---|---|
| control | none | 0 | — |
| M1 | source-NAT packed call removed (master's shape) | 6 | `TestCompactThenCarriesItsAction_7014`, `TestCompactThenPackedContradictionMatchesTheChildSpelling_7014` |
| M2 | destination-NAT packed call removed | 3 | `TestCompactThenCarriesItsAction_7014` |
| M3 | pool-name read (`keys[3]`) dropped | 5 | both |
| M4 | reader accumulates instead of first-wins | 2 | `TestCompactThenPackedContradictionMatchesTheChildSpelling_7014` **only** |
| restored | none | 0 | — |

M2 localising to the compact table alone — and *not* to the contradiction test, which is source-NAT — shows the two call sites are separately bound rather than one masking the other.

## Fixture notes

- Three **block-form controls** asserted unchanged, so this cannot be confused with a fix that also moved the block path.
- Flat-set asserted unaffected, so a later "simplification" routing it through the packed reader reds.
- Every case checks `natThenTerminalActionCount` as well as the fields: a `Then` carrying the right field but counting zero would still be rejected, and a field assertion alone cannot see that. The count is what the arm actually reads.

## Not fixed here: #7013 — and a correction to it

The sibling (repeated same-mode actions collapsing silently and committing under strict) is left open. It needs authored-occurrence state the typed struct does not carry: `NATThen.PoolName` is a scalar, so by validation time the discarded value is already gone.

**One correction, measured above:** the collapse keeps the **FIRST** pool (`PD`), not the last. #7013 reports `Pool:"PD2"`. The defect is the same — an authored pool silently discarded, committed under strict — but a fixture built around the wrong survivor would not reproduce it. Recorded on the issue as well.

---

`./pkg/config/` is green (rc=0, 0 FAIL). Repo-wide `go test -count=1 ./...` posted as a comment when it finishes. No Rust files touched.

Docs: `docs/log/7014.md`.

Closes #7014