### PR TITLE
docs: correct a false claim about the upstream snapshot hop (#6961 follow-up)

### DIFF
--- a/userspace-dp/src/afxdp/coordinator/README.md
+++ b/userspace-dp/src/afxdp/coordinator/README.md
@@ -101,7 +101,13 @@ Differences that matter (#1881):
   value and drives the real `worker_runtime_snapshots`: distinctness is
   the whole mechanism, because an all-zeros or repeated-value fixture
   cannot tell `st.a = src.a` from `st.a = src.b`. It binds from the
-  ATOMICS, not from the counters snapshot, so a swap in EITHER hop reds.
+  ATOMICS, not from the counters snapshot, so a swap in EITHER hop reds —
+  though the upstream `WorkerRuntimeAtomics::snapshot()` hop was ALREADY
+  guarded by `worker_runtime::tests::snapshot_roundtrip`, a distinct-value
+  round-trip predating #6961 (matrix cell B1 confirms it still reds). The
+  hop that was genuinely unbound is the `worker_runtime_snapshots` literal;
+  covering the upstream one too is belt-and-braces, and `snapshot_roundtrip`
+  must not be deleted on the strength of the new file.
   A binding test over today's fields cannot see tomorrow's, so
   `every_runtime_atomic_is_bound_or_knowingly_off_wire_6961` parses the
   struct and requires each `AtomicU64` to be bound or listed in

--- a/userspace-dp/src/afxdp/coordinator/status_mapping_6961_tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/status_mapping_6961_tests.rs
@@ -29,11 +29,22 @@
 // IS the test. `distinct_seed` below is injective by construction and
 // `seeds_are_distinct_6961` asserts that rather than assuming it.
 //
-// WHY THE SOURCE IS THE ATOMICS AND NOT THE COUNTERS SNAPSHOT. There are TWO
-// unbound hops in this chain, not one: `WorkerRuntimeAtomics::snapshot()`
-// (atomics -> `WorkerRuntimeCounters`) has the identical arg-swap shape and
-// was equally unbound. Seeding the atomics and asserting on the wire status
-// binds BOTH, so a swap in either reds.
+// WHY THE SOURCE IS THE ATOMICS AND NOT THE COUNTERS SNAPSHOT. The chain has
+// TWO hops with the same arg-swap shape: `WorkerRuntimeAtomics::snapshot()`
+// (atomics -> `WorkerRuntimeCounters`) and then the literal above. Seeding the
+// ATOMICS and asserting on the wire status covers both end-to-end, so a swap in
+// either reds here.
+//
+// CORRECTION, measured. An earlier revision of this comment said the upstream
+// hop "was equally unbound". That is FALSE and the #6961 mutation matrix caught
+// it: cell B1 swaps a field inside `snapshot()` and reds the pre-existing
+// `worker_runtime::tests::snapshot_roundtrip` alongside this file's binding.
+// That test publishes a fixture whose values are all distinct and asserts each
+// field round-trips, which is a sound arg-swap guard for that hop and predates
+// #6961. The hop that was genuinely unbound is the ONE THIS FILE IS ABOUT —
+// the `worker_runtime_snapshots` literal. Covering the upstream hop too is
+// belt-and-braces, not a discovery, and `snapshot_roundtrip` must not be
+// deleted on the strength of this file.
 
 use super::*;
 use crate::afxdp::worker_runtime::WorkerRuntimeAtomics;


### PR DESCRIPTION
Follow-up to #7821, which merged while its mutation matrix was still running. The matrix then contradicted a sentence that is now **in master**.

## The false claim

`status_mapping_6961_tests.rs` and the coordinator `README.md` both said `WorkerRuntimeAtomics::snapshot()` "was equally unbound".

That is **false**. Matrix cell **B1** swaps a field inside `snapshot()`:

```
B1 | rc=101 | collected=4712 | named-failing=2 |
     worker_runtime_status_binds_every_shared_scalar_to_its_own_source_6961
     afxdp::worker_runtime::tests::snapshot_roundtrip
```

The second name is the point. `worker_runtime::tests::snapshot_roundtrip` (`worker_runtime_tests.rs:9`) publishes a fixture whose values are **all distinct** and asserts every field round-trips — a sound arg-swap guard for that hop, predating #6961 by a long way.

## What is actually true

The hop that was genuinely unbound is the one the issue is about: the `worker_runtime_snapshots` literal. Seeding from the atomics does cover the upstream hop as well, but that is **belt-and-braces, not a discovery**, and `snapshot_roundtrip` must not be deleted on the strength of the new file. The corrected comment says so explicitly, since "the new test covers this too" is exactly the argument that retires a load-bearing older guard.

Nothing about the fix's value changes — the 30-field `u64` group in the literal was unbound, and cells A1–A6 confirm each of those substitutions now reds. Only the sentence about the *upstream* hop was wrong.

## Why it was not caught before merge

The claim was written from what seemed obvious about a hop I had read but had not checked for existing coverage. What made it visible was running every matrix cell **FULL-SUITE** rather than under a `-run 6961` filter — that filter would have selected only the new tests and hidden `snapshot_roundtrip` entirely, and the cell would have looked like a clean single-test red confirming the claim.

Recorded in the commit message rather than quietly rewritten.

Refs #6961

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqdwwcwWUo7FyCQSCSUh9t