### PR TITLE
config: detect a `login` stanza packed behind another system statement (#6966)

### DIFF
--- a/docs/log/6966.md
+++ b/docs/log/6966.md
@@ -1,0 +1,88 @@
+# #6966 — a `login` stanza packed behind another system statement, dropped silently
+
+## The defect
+
+```
+system host-name fw login user alice class ops;    ACCEPTED  Login=nil  warnings=0
+system services ssh login user alice class ops;    ACCEPTED  Login=nil  warnings=0
+system login user alice class ops;      (control)  REJECTED
+```
+
+The first two commit **clean, with no diagnostic at all**. The stanza is
+dropped (`Config.System.Login == nil`), and because downstream reads nil as
+"no policy configured", `applyCLILoginClass` takes its early return and the
+shell runs with an **empty class** — allow-everything, secrets rendered in
+cleartext. The operator authored `user alice class ops` and got an
+unrestricted CLI.
+
+Worse than the shape #6706 closed, which at least failed a strict commit.
+
+Both detection arms tested `sys.Keys[1] == "login"`. In the two packed shapes
+`login` sits at index 3, so neither arm saw it.
+
+## The scan is schema-aware, and that is the whole design
+
+Searching for the literal `login` anywhere in the Keys tail would fix the
+reported cases and introduce a **worse** defect in the opposite direction.
+
+A firewall may legitimately be NAMED login:
+
+```
+system host-name login;
+```
+
+Marking that as packed sets `LoginDroppedByPacking`, which DENIES every
+non-root command — an outage produced by a legal config. A fail-open bug traded
+for a fail-closed one is not a fix.
+
+`packedLoginKeyIndex` therefore walks the packed tokens against `schemaSystem`
+and reports `login` only in a **keyword** position:
+
+- a **scalar** statement consumes its `args` value tokens, so `host-name login`
+  consumes `login` as the hostname and the scan returns -1;
+- a **container** statement descends, so following tokens are read at the child
+  level;
+- a token not consumable at the current level but which IS a `system` child
+  **re-opens** a system-level statement.
+
+That last rule is the same reasoning the `chassis cluster` packed-line splitter
+uses (`isClusterStatement`): an unrecognized token does not go inert, it opens
+the next statement. It is what makes `services ssh login …` report — `login` is
+no child of `ssh`, but is a child of `system` — while `host-name login` does
+not.
+
+## Mutation matrix
+
+`go test -count=1 -run 6966 -v ./pkg/config/`. **21 collected, 0 build errors in
+every cell.**
+
+| cell | mutation | failed | named failing test(s) |
+|---|---|---|---|
+| control | none | 0 | — |
+| M1 | both arms reverted to `Keys[1] == "login"` (master) | 4 | `TestPackedLoginBehindAnotherSystemStatementIsRejected_6966` |
+| M2 | schema consumption disabled — the naive `contains("login")` scan | 8 | `TestLoginAsAVALUEIsNotPacking_6966`, `TestPackedLoginKeyIndex_6966` |
+| M3 | index always returns 1 — right about WHETHER, wrong about WHERE | 4 | `TestPackedLoginKeyIndex_6966` |
+| restored | none | 0 | — |
+
+Each cell localises to exactly the table written for it, and **M2 is the one
+that matters most**: it is the fail-closed regression, and without the
+value-position table it would have passed. A test suite that only proved the
+reported shapes now reject would have accepted the naive scan.
+
+**M3 exists because a boolean assertion cannot see a wrong index.**
+`collectLoginPackedFindings` slices `sys.Keys[i:]` and reads the instance name
+at offset 2, so an index that is right about whether and wrong about where
+renders the wrong user name in the operator-facing diagnostic — a confident
+wrong name, which is worse than no name.
+
+## Scope
+
+Pre-existing on master; the issue records `git diff` on `compiler_system.go`
+against the #6706 head as empty, and `compiler_system_login_gates.go` not
+existing at the master it was measured against.
+
+The open question of what a **content-free** `system login` prefix should do —
+deny, permit, or reject at commit — is **#6972** and is deliberately untouched
+here. This change alters only WHERE the gate looks, not what it decides once it
+has looked, so the #6706 r11 divergence argument (`system { login; }` vs
+`system login;`) is unaffected.

--- a/pkg/config/compiler_system_login_gates.go
+++ b/pkg/config/compiler_system_login_gates.go
@@ -277,7 +277,9 @@ func loginPathPackedAnywhere(tree *ConfigTree) bool {
 	packed := false
 	forEachClusterNodeView(tree, func(view *ConfigTree) {
 		_ = forEachChild(view.Children, "system", func(sys *Node) error {
-			if len(sys.Keys) > 1 && sys.Keys[1] == "login" {
+			// #6966: `login` may sit BEHIND another system statement on the
+			// same packed line, not only at Keys[1].
+			if packedLoginKeyIndex(sys.Keys) > 0 {
 				packed = true
 				return nil
 			}
@@ -341,10 +343,14 @@ const (
 // and a second thing to wire wrong.
 func collectLoginPackedFindings(nodes []*Node, f *loginFindings) {
 	_ = forEachChild(nodes, "system", func(sys *Node) error {
-		if len(sys.Keys) > 1 && sys.Keys[1] == "login" {
+		// #6966: the same index scan. rest starts AT the `login` token, so the
+		// instance name is at index 2 exactly as it was when login was pinned
+		// to Keys[1] — the reporting shape is unchanged, only where the tail
+		// starts.
+		if i := packedLoginKeyIndex(sys.Keys); i > 0 {
 			// rest = [login, <keyword>, <name>, body...] — the instance name
 			// would sit at index 2.
-			reportLoginPathPacked(loginPathLevelSystem, sys.Keys[1:], 2, sys.Children, f)
+			reportLoginPathPacked(loginPathLevelSystem, sys.Keys[i:], 2, sys.Children, f)
 			return nil
 		}
 		return forEachChild(sys.Children, "login", func(login *Node) error {
@@ -681,4 +687,70 @@ func collectLoginClassShadowFindings(nodes []*Node, f *loginFindings) {
 			return nil
 		})
 	})
+}
+
+// packedLoginKeyIndex reports the index in keys at which a `login` statement
+// begins, when `login` is packed onto a `system` node's own Keys BEHIND another
+// system statement, or -1.
+//
+// #6966: both detection arms used to test `keys[1] == "login"` only, so
+//
+//	system host-name fw login user alice class ops;
+//	system services ssh login user alice class ops;
+//
+// were invisible — `login` sits at index 3 and 4. Both commit CLEAN with no
+// diagnostic, the stanza is dropped (`Config.System.Login == nil`), and because
+// downstream reads nil as "no policy configured" the shell runs with an empty
+// class: allow-everything, secrets in cleartext. That is worse than the shape
+// #6706 closed, which at least failed a strict commit.
+//
+// Scanning for the literal `login` anywhere would be wrong in the fail-CLOSED
+// direction, which is the worse mistake here. A firewall may legitimately be
+// NAMED login:
+//
+//	system host-name login;
+//
+// Marking that as packed sets LoginDroppedByPacking and DENIES every non-root
+// command — an outage produced by a legal config. So the scan walks the packed
+// tokens against the SCHEMA and only reports `login` in a KEYWORD position:
+//
+//   - a scalar statement consumes `args` value tokens, so `host-name login`
+//     consumes `login` as the hostname and this returns -1;
+//   - a container statement descends, so tokens after it are read at the child
+//     level;
+//   - a token that is not consumable at the current level but IS a `system`
+//     child re-opens a system-level statement — which is what makes
+//     `services ssh login …` report, since `login` is no child of `ssh`.
+//
+// That last rule is the same reasoning the packed-line splitter uses for
+// `chassis cluster` (isClusterStatement): an unrecognized token does not go
+// inert, it opens the next statement.
+func packedLoginKeyIndex(keys []string) int {
+	if len(keys) < 2 || schemaSystem == nil {
+		return -1
+	}
+	level := schemaSystem
+	for i := 1; i < len(keys); i++ {
+		tok := keys[i]
+		if tok == "login" {
+			// A keyword position: nothing above consumed it as a value.
+			return i
+		}
+		if node, ok := level.children[tok]; ok {
+			// Consume this statement's value tokens, then either descend into
+			// it or stay at the same level for the next statement.
+			i += node.args
+			if len(node.children) > 0 {
+				level = node
+			}
+			continue
+		}
+		// Not consumable here. If `system` knows it, the previous statement
+		// ended and this one opens at the system level; otherwise treat it as
+		// an opaque value and keep going.
+		if _, ok := schemaSystem.children[tok]; ok {
+			level = schemaSystem
+		}
+	}
+	return -1
 }

--- a/pkg/config/system_login_packed_behind_6966_test.go
+++ b/pkg/config/system_login_packed_behind_6966_test.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6966: a `system login` stanza packed BEHIND another system statement on the
+// same line committed CLEAN with no diagnostic, and the stanza was silently
+// dropped:
+//
+//	system host-name fw login user alice class ops;    ACCEPTED  Login=nil  warnings=0
+//	system services ssh login user alice class ops;    ACCEPTED  Login=nil  warnings=0
+//	system login user alice class ops;      (control)  REJECTED
+//
+// Because downstream reads `Config.System.Login == nil` as "no policy
+// configured", applyCLILoginClass takes its early return and the shell runs
+// with an EMPTY class — allow-everything, secrets rendered in cleartext. The
+// operator authored `user alice class ops` and got an unrestricted CLI.
+//
+// That is worse than the shape #6706 closed, which at least failed a strict
+// commit. Both detection arms tested `sys.Keys[1] == "login"`, so `login` at
+// index 3 or 4 was invisible to both.
+func TestPackedLoginBehindAnotherSystemStatementIsRejected_6966(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		src  string
+	}{
+		{"behind a scalar statement", "system host-name fw login user alice class ops;"},
+		{"behind a container statement", "system services ssh login user alice class ops;"},
+		{"behind two statements", "system host-name fw domain-name example.net login user alice class ops;"},
+		// The control that already worked. Kept here so a regression that
+		// re-narrows the scan to Keys[1] is distinguishable from one that
+		// breaks the gate outright.
+		{"login first (control, already rejected)", "system login user alice class ops;"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tree, errs := NewParser(tc.src).Parse()
+			if len(errs) > 0 {
+				t.Fatalf("parse: %v", errs)
+			}
+			cfg, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("strict CompileConfig ACCEPTED %q; the stanza is dropped "+
+					"(Login=%v) and the CLI then runs with an empty class (#6966)",
+					tc.src, cfg.System.Login)
+			}
+			if !strings.Contains(err.Error(), "login") {
+				t.Errorf("rejection does not name `login`, so it is not this gate firing: %v", err)
+			}
+		})
+	}
+}
+
+// The fail-CLOSED direction, which is the worse mistake here and the reason the
+// scan is schema-aware rather than a search for the literal `login`.
+//
+// A firewall may legitimately be NAMED login. Marking that as packed sets
+// LoginDroppedByPacking and DENIES every non-root command — an outage produced
+// by a legal config. A naive `slices.Contains(keys, "login")` reds this table.
+func TestLoginAsAVALUEIsNotPacking_6966(t *testing.T) {
+	for _, tc := range []struct{ name, src string }{
+		{"host named login", "system host-name login;"},
+		{"host named login-server", "system host-name login-server;"},
+		{"domain named login", "system domain-name login;"},
+		{"host named login, then another statement", "system host-name login domain-name example.net;"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tree, errs := NewParser(tc.src).Parse()
+			if len(errs) > 0 {
+				t.Fatalf("parse: %v", errs)
+			}
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("strict CompileConfig REJECTED a legal config %q: %v", tc.src, err)
+			}
+			if cfg.System.LoginDroppedByPacking {
+				t.Errorf("%q set LoginDroppedByPacking; the CLI would deny every non-root "+
+					"command for a config that packs no login stanza at all (#6966)", tc.src)
+			}
+		})
+	}
+}
+
+// The scanner's own contract, asserted directly so a failure localises to the
+// index rather than to a compile outcome three layers away.
+//
+// The index matters and is not just a boolean: collectLoginPackedFindings
+// slices `sys.Keys[i:]` and reads the instance name at offset 2, so an index
+// that is right about WHETHER and wrong about WHERE renders the wrong user
+// name in the diagnostic.
+func TestPackedLoginKeyIndex_6966(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		keys []string
+		want int
+	}{
+		{"login first", []string{"system", "login", "user", "alice"}, 1},
+		{"behind host-name", []string{"system", "host-name", "fw", "login", "user", "alice"}, 3},
+		{"behind services ssh", []string{"system", "services", "ssh", "login", "user", "alice"}, 3},
+		{"behind two statements", []string{"system", "host-name", "fw", "domain-name", "example.net", "login", "user", "alice"}, 5},
+		{"host NAMED login", []string{"system", "host-name", "login"}, -1},
+		{"domain NAMED login", []string{"system", "domain-name", "login"}, -1},
+		{"host named login then a real statement", []string{"system", "host-name", "login", "domain-name", "example.net"}, -1},
+		{"no login at all", []string{"system", "host-name", "fw"}, -1},
+		{"bare system", []string{"system"}, -1},
+		{"bare packed login", []string{"system", "login"}, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := packedLoginKeyIndex(tc.keys); got != tc.want {
+				t.Errorf("packedLoginKeyIndex(%v) = %d, want %d", tc.keys, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
```
system host-name fw login user alice class ops;    ACCEPTED  Login=nil  warnings=0
system services ssh login user alice class ops;    ACCEPTED  Login=nil  warnings=0
system login user alice class ops;      (control)  REJECTED
```

The first two commit **clean, with no diagnostic at all**. The stanza is dropped (`Config.System.Login == nil`), and because downstream reads nil as *"no policy configured"*, `applyCLILoginClass` takes its early return and the shell runs with an **empty class** — allow-everything, secrets rendered in cleartext.

The operator authored `user alice class ops` and got an unrestricted CLI. That is worse than the shape #6706 closed, which at least failed a strict commit.

Both detection arms tested `sys.Keys[1] == "login"`. In the packed shapes `login` sits at index 3, so neither arm saw it.

## The scan is schema-aware, and that is the whole design

Searching for the literal `login` anywhere in the Keys tail would fix the reported cases and introduce a **worse** defect in the opposite direction. A firewall may legitimately be NAMED login:

```
system host-name login;
```

Marking that as packed sets `LoginDroppedByPacking`, which DENIES every non-root command — an outage produced by a legal config. A fail-open bug traded for a fail-closed one is not a fix.

`packedLoginKeyIndex` walks the packed tokens against `schemaSystem` and reports `login` only in a **keyword** position:

- a **scalar** statement consumes its `args` value tokens, so `host-name login` consumes `login` as the hostname → -1;
- a **container** statement descends, so following tokens read at the child level;
- a token not consumable at the current level but which IS a `system` child **re-opens** a system-level statement.

That last rule is the same reasoning the `chassis cluster` packed-line splitter uses (`isClusterStatement`): an unrecognized token does not go inert, it opens the next statement. It is what makes `services ssh login …` report — `login` is no child of `ssh`, but is a child of `system` — while `host-name login` does not.

## Mutation matrix

`go test -count=1 -run 6966 -v ./pkg/config/`. **21 collected, 0 build errors in every cell.**

| cell | mutation | failed | named failing test(s) |
|---|---|---|---|
| control | none | 0 | — |
| M1 | both arms reverted to `Keys[1] == "login"` (master) | 4 | `TestPackedLoginBehindAnotherSystemStatementIsRejected_6966` |
| M2 | schema consumption disabled — the naive `contains("login")` scan | 8 | `TestLoginAsAVALUEIsNotPacking_6966`, `TestPackedLoginKeyIndex_6966` |
| M3 | index always returns 1 — right about WHETHER, wrong about WHERE | 4 | `TestPackedLoginKeyIndex_6966` |
| restored | none | 0 | — |

Each cell localises to exactly the table written for it.

**M2 is the one that matters most.** It is the fail-closed regression, and without the value-position table it would have passed — a test suite that only proved the reported shapes now reject would have accepted the naive scan.

**M3 exists because a boolean assertion cannot see a wrong index.** `collectLoginPackedFindings` slices `sys.Keys[i:]` and reads the instance name at offset 2, so an index right about *whether* and wrong about *where* renders the wrong user name in the operator-facing diagnostic — a confident wrong name, which is worse than no name.

## Scope

Pre-existing on master (the issue's `git diff` evidence stands). The open question of what a **content-free** `system login` prefix should do — deny, permit, or reject at commit — is **#6972** and is deliberately untouched: this changes only WHERE the gate looks, not what it decides once it has looked, so the #6706 r11 divergence argument (`system { login; }` vs `system login;`) is unaffected.

---

`./pkg/config/` green (rc=0, 0 FAIL). Repo-wide `go test -count=1 ./...` posted as a comment when it finishes. No Rust files touched.

Docs: `docs/log/6966.md`.

Closes #6966