### PR TITLE
daemon: report a LinkList failure instead of silently skipping every VLAN MAC (#6980)

### DIFF
--- a/docs/log/6980.md
+++ b/docs/log/6980.md
@@ -1,0 +1,81 @@
+# #6980 — a discarded `netlink.LinkList()` error that silently skips every VLAN MAC
+
+```go
+links, _ := netlink.LinkList()
+```
+
+On failure `links` is nil, the propagation loop never executes, the RETH virtual
+MAC never reaches **any** VLAN sub-interface — and there was no log line and no
+commit error. **The apply reported success.**
+
+On the reference topology the VLAN units are what carry traffic (`reth0.50`
+transit, `reth0.80` the data path and iperf3 smoke target), so the silent skip
+leaves them on the **stale MAC** while the parent RETH has the new one. Peers
+ARP to an address this node no longer answers on, until the entry ages out. A
+blackhole whose only symptom is a successful commit.
+
+Pre-existing: the issue records it at `origin/master:daemon_apply_dataplane.go`
+and not in #6871's diff.
+
+## Why a warning would not have been enough
+
+The per-sub-interface failures in the same loop already `slog.Warn` and
+continue, and that is right — each is **one** child, and a best-effort repair
+that misses one netdev is a degraded outcome, not a wrong one.
+
+A `LinkList` failure skips **every** child. It is a different-sized event, so it
+goes to `networkdErr` — the "fail-closed but complete" accumulator this file
+already documents in `applyDataplaneAndHACore`'s header. The tail keeps running
+and the operator still sees the commit fail.
+
+The log line states what is lost rather than naming the syscall: an operator who
+reads *"failed to enumerate links"* learns nothing actionable; one who reads
+that every VLAN sub-interface kept a stale MAC knows both the blast radius and
+that it self-heals when the neighbour entry ages.
+
+## The sweep, because one instance is a floor
+
+Every `netlink.LinkList()` in `pkg/daemon` production code:
+
+```
+daemon_apply_dataplane.go:653   <- this one, was discarding
+daemon_flow.go:840              lister = netlink.LinkList     (named seam, error handled)
+daemon_snmp_reconcile.go:163    snmpLinkLister = netlink.LinkList (named seam, error handled)
+```
+
+This was the only discarded one.
+
+## Two seams, not one
+
+`rethParentLinkByName` and `rethLinkLister`, package-level function variables
+defaulting to netlink — the same shape `snmpLinkLister` already uses.
+
+Two rather than one because **the LinkList call is only reached when LinkByName
+succeeds**, and every pre-existing test in this area names an ABSENT interface
+(`xpf6871-absent0`), so `LinkByName` fails and the whole block is skipped. A
+test that stubbed only the lister would never reach the line under test and
+would pass against both the bug and the fix.
+
+That is also the explanation for the defect's lifetime: the path was not merely
+untested, it was **unreachable** from the existing fixtures.
+
+## Mutation matrix
+
+`go test -count=1 -run 6980 -v ./pkg/daemon/`. **2 collected, 0 build errors in
+every cell.**
+
+| cell | mutation | failed | named failing test |
+|---|---|---|---|
+| control | none | 0 | — |
+| M1 | error discarded again (master's shape) | 1 | `TestLinkListFailureIsReportedNotSwallowed_6980` |
+| M2 | bare error that neither wraps nor names the parent | 1 | `TestLinkListFailureIsReportedNotSwallowed_6980` |
+| M3 | return an error unconditionally | 1 | `TestLinkListSuccessWithNoChildrenIsNotAnError_6980` |
+| restored | none | 0 | — |
+
+**M2** is why the failure cell asserts `errors.Is` and the parent name rather
+than just non-nil: a commit failure reading only "netlink down" sends the
+operator to the wrong layer.
+
+**M3** is why the success cell exists. Without it, a fix that failed EVERY
+commit would satisfy the failure assertion perfectly — the two cells together
+are what distinguish "reports the failure" from "reports failure".

--- a/pkg/daemon/daemon_apply_dataplane.go
+++ b/pkg/daemon/daemon_apply_dataplane.go
@@ -341,7 +341,9 @@ func (d *Daemon) applyDataplaneAndHACore(ctx context.Context, cfg *config.Config
 			mac := cluster.RethMAC(cc.ClusterID, rethCfg.RedundancyGroup, cc.NodeID)
 			networkdErr, needLinkCycleRecovery = d.programRethMemberMAC(
 				linuxName, mac, networkdErr, needLinkCycleRecovery)
-			d.finishRethMemberLinkTail(linuxName, mac, rethCfg)
+			if err := d.finishRethMemberLinkTail(linuxName, mac, rethCfg); err != nil {
+				networkdErr = errors.Join(networkdErr, err)
+			}
 		}
 	}
 
@@ -602,7 +604,27 @@ func (d *Daemon) abandonLinkCycleLease() {
 // programRethMemberMAC's is: a member that needed no cycle still spends the
 // ethtool ceiling, and the lease it is burning down may have been taken by an
 // EARLIER member.
-func (d *Daemon) finishRethMemberLinkTail(linuxName string, mac net.HardwareAddr, rethCfg *config.InterfaceConfig) {
+// The returned error joins networkdErr, the "fail-closed but complete"
+// accumulator this file already uses (see applyDataplaneAndHACore's header):
+// the tail keeps going and the operator still sees the commit fail.
+//
+// #6980: it used to return nothing, and the VLAN propagation loop below read
+// `links, _ := netlink.LinkList()`. On a LinkList failure `links` is nil, the
+// loop body never runs, the RETH virtual MAC never reaches any VLAN
+// sub-interface -- and there was no log line and no commit error. The apply
+// reported success.
+//
+// On the reference topology the VLAN units are what carry traffic (reth0.50
+// transit, reth0.80 the data path), so the silent skip leaves them on the STALE
+// MAC while the parent RETH has the new one: peers ARP to an address the box no
+// longer answers on, until the entry ages out. A blackhole whose only symptom
+// is a successful commit.
+//
+// Warning alone would not be enough. The per-sub-interface failures below are
+// genuinely best-effort and warn, but those are ONE child each; a LinkList
+// failure skips EVERY child, so it is a different-sized event and belongs in
+// the channel that fails the commit.
+func (d *Daemon) finishRethMemberLinkTail(linuxName string, mac net.HardwareAddr, rethCfg *config.InterfaceConfig) error {
 	clearDadFailed(linuxName)
 	removeAutoLinkLocal(linuxName)
 	// Re-add link-local if this parent interface has IPv6 on unit 0.
@@ -626,9 +648,16 @@ func (d *Daemon) finishRethMemberLinkTail(linuxName string, mac net.HardwareAddr
 	// Propagate MAC change to VLAN sub-interfaces.
 	// Linux VLAN sub-interfaces don't always inherit the
 	// parent's MAC change after link down/up.
-	if parentLink, err := netlink.LinkByName(linuxName); err == nil {
+	if parentLink, err := rethParentLinkByName(linuxName); err == nil {
 		parentIdx := parentLink.Attrs().Index
-		links, _ := netlink.LinkList()
+		links, err := rethLinkLister()
+		if err != nil {
+			slog.Error("failed to enumerate links for RETH VLAN MAC propagation; "+
+				"every VLAN sub-interface keeps its STALE MAC while the parent has the new one, "+
+				"so peers ARP to an address this node no longer answers on until the entry ages out",
+				"parent", linuxName, "mac", mac, "err", err)
+			return fmt.Errorf("enumerate links to propagate RETH MAC from %s: %w", linuxName, err)
+		}
 		for _, l := range links {
 			if l.Attrs().ParentIndex != parentIdx {
 				continue
@@ -658,6 +687,7 @@ func (d *Daemon) finishRethMemberLinkTail(linuxName string, mac net.HardwareAddr
 		}
 	}
 	d.renewLinkCycleLease()
+	return nil
 }
 
 // reconcileAfterRethLinkCycle re-adds the VRRP VIPs and stable link-locals that
@@ -995,3 +1025,16 @@ func (d *Daemon) recordDataplaneWorkerArmDebt() {
 		r.RecordDeferredWorkerArmDebt()
 	}
 }
+
+// #6980 seams. Package-level function variables defaulting to netlink, the same
+// shape snmpLinkLister already uses, so the LinkList FAILURE path in
+// finishRethMemberLinkTail can be exercised without a privileged netdev.
+//
+// Two seams rather than one: the LinkList call is only reached when LinkByName
+// SUCCEEDS, so a test that stubs only the lister never gets there — every
+// existing test in this area names an absent interface, which is exactly why
+// this path stayed unbound long enough for the discarded error to survive.
+var (
+	rethParentLinkByName = netlink.LinkByName
+	rethLinkLister       = netlink.LinkList
+)

--- a/pkg/daemon/reth_vlan_mac_linklist_6980_test.go
+++ b/pkg/daemon/reth_vlan_mac_linklist_6980_test.go
@@ -1,0 +1,74 @@
+package daemon
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// stubRethLinkSeams6980 makes LinkByName succeed with a parent whose index is
+// parentIdx, and LinkList return listErr.
+//
+// Both seams are needed: the LinkList call is only reached when LinkByName
+// SUCCEEDS, and every pre-existing test in this area names an ABSENT interface
+// so LinkByName fails and the whole block is skipped. That is why this path
+// stayed unbound long enough for the discarded error to survive (#6980).
+func stubRethLinkSeams6980(t *testing.T, parentIdx int, listErr error) {
+	t.Helper()
+	origByName, origList := rethParentLinkByName, rethLinkLister
+	rethParentLinkByName = func(string) (netlink.Link, error) {
+		return &netlink.Device{LinkAttrs: netlink.LinkAttrs{Index: parentIdx, Name: "xpf6980-parent"}}, nil
+	}
+	rethLinkLister = func() ([]netlink.Link, error) { return nil, listErr }
+	t.Cleanup(func() { rethParentLinkByName, rethLinkLister = origByName, origList })
+}
+
+// #6980: `links, _ := netlink.LinkList()`. On failure `links` is nil, the
+// propagation loop never runs, the RETH virtual MAC never reaches ANY VLAN
+// sub-interface — and there was no log line and no commit error. The apply
+// reported success.
+//
+// On the reference topology the VLAN units carry the traffic (reth0.50
+// transit, reth0.80 the data path), so the silent skip leaves them on the STALE
+// MAC while the parent RETH has the new one: peers ARP to an address this node
+// no longer answers on until the entry ages out. A blackhole whose only symptom
+// is a successful commit.
+func TestLinkListFailureIsReportedNotSwallowed_6980(t *testing.T) {
+	d := &Daemon{}
+	want := errors.New("xpf6980 netlink down")
+	stubRethLinkSeams6980(t, 42, want)
+
+	err := d.finishRethMemberLinkTail("xpf6980-parent", net.HardwareAddr{2, 0xbf, 0x72, 1, 2, 3}, &config.InterfaceConfig{})
+	if err == nil {
+		t.Fatal("finishRethMemberLinkTail returned nil after LinkList failed; the RETH MAC " +
+			"reached no VLAN sub-interface and the apply reports success (#6980)")
+	}
+	if !errors.Is(err, want) {
+		t.Errorf("returned error does not wrap the netlink failure: %v", err)
+	}
+	// The message must name the PARENT, because an operator reading a commit
+	// failure needs to know which member did not propagate. An error that says
+	// only "netlink down" sends them to the wrong layer.
+	if !strings.Contains(err.Error(), "xpf6980-parent") {
+		t.Errorf("returned error does not name the parent interface: %v", err)
+	}
+}
+
+// The success path must NOT return an error — otherwise the fix would fail
+// every commit rather than only the broken one, and the assertion above could
+// not tell the two apart.
+//
+// Empty list, no error: the parent has no VLAN children, which is the ordinary
+// case for a member that carries no tagged units.
+func TestLinkListSuccessWithNoChildrenIsNotAnError_6980(t *testing.T) {
+	d := &Daemon{}
+	stubRethLinkSeams6980(t, 42, nil)
+	if err := d.finishRethMemberLinkTail("xpf6980-parent", net.HardwareAddr{2, 0xbf, 0x72, 1, 2, 3}, &config.InterfaceConfig{}); err != nil {
+		t.Fatalf("finishRethMemberLinkTail returned %v on a clean enumeration with no VLAN children", err)
+	}
+}


### PR DESCRIPTION
```go
links, _ := netlink.LinkList()
```

On failure `links` is nil, the propagation loop never executes, the RETH virtual MAC never reaches **any** VLAN sub-interface — and there was no log line and no commit error. **The apply reported success.**

On the reference topology the VLAN units are what carry traffic (`reth0.50` transit, `reth0.80` the data path and iperf3 smoke target), so the silent skip leaves them on the **stale MAC** while the parent RETH has the new one. Peers ARP to an address this node no longer answers on, until the entry ages out. A blackhole whose only symptom is a successful commit.

Pre-existing: the issue records it at `origin/master:daemon_apply_dataplane.go` and not in #6871's diff.

## Why a warning would not have been enough

The per-sub-interface failures in the same loop already `slog.Warn` and continue, and that is right — each is **one** child, and a best-effort repair that misses one netdev is a degraded outcome, not a wrong one.

A `LinkList` failure skips **every** child. Different-sized event, so it goes to `networkdErr` — the *"fail-closed but complete"* accumulator this file already documents in `applyDataplaneAndHACore`'s header. The tail keeps running and the operator still sees the commit fail.

The log line states what is lost rather than naming the syscall: an operator reading *"failed to enumerate links"* learns nothing actionable; one who reads that every VLAN sub-interface kept a stale MAC knows both the blast radius and that it self-heals when the neighbour entry ages.

## The sweep, because one instance is a floor

Every `netlink.LinkList()` in `pkg/daemon` production code:

```
daemon_apply_dataplane.go:653   <- this one, was discarding
daemon_flow.go:840              lister = netlink.LinkList          (named seam, error handled)
daemon_snmp_reconcile.go:163    snmpLinkLister = netlink.LinkList  (named seam, error handled)
```

This was the only discarded one.

## Two seams, not one — and that is also why the defect survived

`rethParentLinkByName` and `rethLinkLister`, package-level function variables defaulting to netlink, the same shape `snmpLinkLister` already uses.

Two rather than one because **the LinkList call is only reached when LinkByName succeeds**, and every pre-existing test in this area names an ABSENT interface (`xpf6871-absent0`), so `LinkByName` fails and the whole block is skipped. A test stubbing only the lister would never reach the line under test and would pass against both the bug and the fix.

That is the explanation for the defect's lifetime: the path was not merely untested, it was **unreachable from the existing fixtures**.

## Mutation matrix

`go test -count=1 -run 6980 -v ./pkg/daemon/`. **2 collected, 0 build errors in every cell.**

| cell | mutation | failed | named failing test |
|---|---|---|---|
| control | none | 0 | — |
| M1 | error discarded again (master's shape) | 1 | `TestLinkListFailureIsReportedNotSwallowed_6980` |
| M2 | bare error that neither wraps nor names the parent | 1 | `TestLinkListFailureIsReportedNotSwallowed_6980` |
| M3 | return an error unconditionally | 1 | `TestLinkListSuccessWithNoChildrenIsNotAnError_6980` |
| restored | none | 0 | — |

**M2** is why the failure cell asserts `errors.Is` and the parent name rather than just non-nil: a commit failure reading only *"netlink down"* sends the operator to the wrong layer.

**M3** is why the success cell exists. Without it, a fix that failed EVERY commit would satisfy the failure assertion perfectly — the two cells together are what distinguish "reports the failure" from "reports failure".

---

`./pkg/daemon/` green (rc=0, 0 FAIL). Repo-wide `go test -count=1 ./...` posted as a comment when it finishes. No Rust files touched.

Note on the `-race` leg: `pkg/daemon -race` currently reds at master on two unrelated tests, root-caused and filed as **#7825** (`installConntrackDeleteStub` guards its counter on the write side only). Not introduced here.

Docs: `docs/log/6980.md`.

Closes #6980
